### PR TITLE
Fix Amplify build: use Node.js 20 and update package-lock.json

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -4,6 +4,8 @@ applications:
       phases:
         preBuild:
           commands:
+            # Use Node.js 20
+            - nvm use 20
             # Install dependencies
             - npm ci --legacy-peer-deps
         build:

--- a/package-lock.json
+++ b/package-lock.json
@@ -59,6 +59,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "date-fns": "^4.1.0",
+        "escape-html": "^1.0.3",
         "framer-motion": "^12.6.3",
         "js-tiktoken": "^1.0.19",
         "jsonwebtoken": "^9.0.2",
@@ -18416,6 +18417,12 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/escape-carriage/-/escape-carriage-1.3.1.tgz",
       "integrity": "sha512-GwBr6yViW3ttx1kb7/Oh+gKQ1/TrhYwxKqVmg5gS+BK+Qe2KrOa/Vh7w3HPBvgGf0LfcDGoY9I6NHKoA5Hozhw==",
+      "license": "MIT"
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
       "license": "MIT"
     },
     "node_modules/escape-string-regexp": {


### PR DESCRIPTION
## Description

<!-- What does this PR do? Summarize the change and why it is needed. -->

## Checklist

- [ ] No `console.*` calls in production/shared code; all server-side logging uses Winston logger (`@/lib/logger`)
- [ ] **No imports or usage of `@/lib/logger` in client components or client hooks**
- [ ] Client code uses `console.error` only for actionable errors in development (never for routine info)
- [ ] Lint passes (`npm run lint`)
- [ ] All tests pass (`npm test`)
- [ ] Types/interfaces follow project conventions
- [ ] Environment variables handled securely and `.env.example` updated if needed
- [ ] Documentation updated (if needed)
- [ ] Code reviewed and approved
- [ ] App builds and runs without module errors (e.g., no 'fs' errors in browser)

## Related Issues

<!-- Link to any related issues or tickets --> 