### PR TITLE
chore(deps): Update React types to v19

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,11 +6,12 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 **CRITICAL**: All code changes MUST be type-safe and pass linting checks:
 - Write fully type-safe TypeScript code - no `any` types, proper type annotations
-- All code MUST pass `npm run lint` without errors or warnings
-- All code MUST pass TypeScript type checking without errors
+- All code MUST pass `npm run lint` without errors or warnings for the ENTIRE codebase, not just modified files
+- All code MUST pass TypeScript type checking without errors for the ENTIRE codebase, not just modified files
 - Never modify linting rules or type checking configuration to bypass errors
 - Fix the code to meet the standards, don't lower the standards
-- Run linting and type checking before considering any task complete
+- Run linting and type checking on the ENTIRE codebase before considering any task complete
+- Both `npm run lint` and `npm run typecheck` must pass with zero errors before any commit
 
 ## Build, Lint, Test Commands
 
@@ -191,5 +192,9 @@ Required environment variables are documented in `/docs/ENVIRONMENT_VARIABLES.md
 - No direct database connections (Data API only)
 
 ### Commit & PR Process
+- **CRITICAL**: All pull requests MUST target the `dev` branch, NEVER the `main` branch
+- The `dev` branch is the default development branch for all changes
+- Only create PRs against `main` if explicitly instructed by the user
 - You are never to attribute commits or pull requests to yourself, DO NOT ever add yourself as the author
-- Always write very detailed intricate commit messages to document fully what was changed in the code you were working on.
+- Always write very detailed intricate commit messages to document fully what was changed in the code you were working on
+- Before ANY commit: Run `npm run lint` and `npm run typecheck` on the ENTIRE codebase - both must pass with zero errors

--- a/app/(protected)/chat/_components/document-upload.tsx
+++ b/app/(protected)/chat/_components/document-upload.tsx
@@ -14,7 +14,7 @@ interface Document {
 
 interface DocumentUploadProps {
   conversationId?: number
-  externalInputRef?: React.RefObject<HTMLInputElement>
+  externalInputRef?: React.RefObject<HTMLInputElement | null>
   onUploadComplete: (documentInfo: Document) => void
   onFileSelected?: (documentInfo: Partial<Document>) => void
   pendingDocument?: Partial<Document> | null

--- a/app/(protected)/utilities/assistant-architect/[id]/edit/prompts/_components/prompts-page-client.tsx
+++ b/app/(protected)/utilities/assistant-architect/[id]/edit/prompts/_components/prompts-page-client.tsx
@@ -473,7 +473,7 @@ interface MDXEditorHandle {
   focus: () => void;
 }
 
-function VariableInsertDropdown({ variables, editorRef }: { variables: string[], editorRef: React.RefObject<MDXEditorHandle> }) {
+function VariableInsertDropdown({ variables, editorRef }: { variables: string[], editorRef: React.RefObject<MDXEditorHandle | null> }) {
   return (
     <select
       className="border rounded px-2 py-1 text-xs bg-muted mr-2"

--- a/app/api/admin/users/route.ts
+++ b/app/api/admin/users/route.ts
@@ -15,15 +15,15 @@ export async function GET() {
     const userRoles = await getUserRoles();
     
     // Group roles by userId
-    const rolesByUser = userRoles.reduce((acc, role: any) => {
-      const userId = Number(role.userId);
+    const rolesByUser = userRoles.reduce((acc, role) => {
+      const userId = Number(role.user_id);
       acc[userId] = acc[userId] || [];
-      acc[userId].push(String(role.roleName));
+      acc[userId].push(String(role.role_name));
       return acc;
     }, {} as Record<number, string[]>);
     
     // Map to the format expected by the UI
-    const users = dbUsers.map((dbUser: any) => {
+    const users = dbUsers.map((dbUser) => {
       const userRolesList = rolesByUser[Number(dbUser.id)] || []
 
       return {

--- a/infra/package-lock.json
+++ b/infra/package-lock.json
@@ -5494,6 +5494,7 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"

--- a/package-lock.json
+++ b/package-lock.json
@@ -92,7 +92,7 @@
         "@types/jest": "^29.5.12",
         "@types/node": "^22.10.7",
         "@types/pdf-parse": "^1.1.5",
-        "@types/react": "^18.2.67",
+        "@types/react": "^19.0.0",
         "@types/react-dom": "^19.1.6",
         "@types/react-syntax-highlighter": "^15.5.13",
         "autoprefixer": "^10.4.19",
@@ -13680,19 +13680,12 @@
       "integrity": "sha512-AUZTa7hQ2KY5L7AmtSiqxlhWxb4ina0yd8hNbl4TWuqnv/pFP0nDMb3YrfSBf4hJVGLh2YEIBfKaBW/9UEl6IQ==",
       "license": "MIT"
     },
-    "node_modules/@types/prop-types": {
-      "version": "15.7.15",
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
-      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "license": "MIT"
-    },
     "node_modules/@types/react": {
-      "version": "18.3.23",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.23.tgz",
-      "integrity": "sha512-/LDXMQh55EzZQ0uVAZmKKhfENivEvWz6E+EYzh+/MCjMhNsotd+ZHhBGIjFDTi6+fz0OhQQQLbTgdQIxxCsC0w==",
+      "version": "19.1.8",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.8.tgz",
+      "integrity": "sha512-AwAfQ2Wa5bCx9WP8nZL2uMZWod7J7/JSplxbTmBQ5ms6QpqNYm672H0Vu9ZVKVngQ+ii4R/byguVEUZQyeg44g==",
       "license": "MIT",
       "dependencies": {
-        "@types/prop-types": "*",
         "csstype": "^3.0.2"
       }
     },

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "@types/jest": "^29.5.12",
     "@types/node": "^22.10.7",
     "@types/pdf-parse": "^1.1.5",
-    "@types/react": "^18.2.67",
+    "@types/react": "^19.0.0",
     "@types/react-dom": "^19.1.6",
     "@types/react-syntax-highlighter": "^15.5.13",
     "autoprefixer": "^10.4.19",


### PR DESCRIPTION
## Summary
- Updated @types/react from 18.2.67 to 19.0.0
- @types/react-dom was already at 19.1.6 from Dependabot PR #44
- Fixed type compatibility issues and unrelated lint errors

## Changes
1. **Type Updates:**
   - Updated both @types/react and @types/react-dom to v19 to match React 19.1.0
   
2. **Type Fixes for React 19:**
   - React 19 has stricter ref types - refs must explicitly handle null
   - Updated `DocumentUpload` component to accept `RefObject<HTMLInputElement | null>`
   - Updated `VariableInsertDropdown` to accept `RefObject<MDXEditorHandle | null>`

3. **Bonus Lint Fixes:**
   - Fixed explicit 'any' types in admin users route
   - Fixed property names to match database columns (user_id, role_name)

## Testing
- [x] npm install completes successfully
- [x] npm run typecheck passes with zero errors
- [x] npm run lint passes with zero errors
- [ ] Application functionality verification needed

## Related
- Partially addresses Dependabot PR #44