### PR TITLE
chore(deps): Upgrade react-markdown to v10

### DIFF
--- a/app/(protected)/chat/_components/message.tsx
+++ b/app/(protected)/chat/_components/message.tsx
@@ -82,9 +82,9 @@ export function Message({ message, messageId }: MessageProps) {
           >
             {isAssistant ? "Assistant" : "You"}
           </span>
-          <ReactMarkdown
-            className="prose prose-sm dark:prose-invert max-w-none prose-p:leading-relaxed prose-pre:p-0"
-            components={{
+          <div className="prose prose-sm dark:prose-invert max-w-none prose-p:leading-relaxed prose-pre:p-0">
+            <ReactMarkdown
+              components={{
               p: ({ children }) => <p className="mb-2 last:mb-0">{children}</p>,
               // Use default pre/code handling from prose for consistency?
               // Or keep custom highlighter if preferred.
@@ -138,7 +138,8 @@ export function Message({ message, messageId }: MessageProps) {
             }}
           >
             {message.content}
-          </ReactMarkdown>
+            </ReactMarkdown>
+          </div>
         </div>
 
         {/* Action Buttons (Show on Hover, ONLY for Assistant) */}

--- a/app/api/admin/users/route.ts
+++ b/app/api/admin/users/route.ts
@@ -15,15 +15,15 @@ export async function GET() {
     const userRoles = await getUserRoles();
     
     // Group roles by userId
-    const rolesByUser = userRoles.reduce((acc, role: any) => {
-      const userId = Number(role.userId);
+    const rolesByUser = userRoles.reduce((acc, role) => {
+      const userId = Number(role.user_id);
       acc[userId] = acc[userId] || [];
-      acc[userId].push(String(role.roleName));
+      acc[userId].push(String(role.role_name));
       return acc;
     }, {} as Record<number, string[]>);
     
     // Map to the format expected by the UI
-    const users = dbUsers.map((dbUser: any) => {
+    const users = dbUsers.map((dbUser) => {
       const userRolesList = rolesByUser[Number(dbUser.id)] || []
 
       return {

--- a/components/features/assistant-architect/assistant-architect-execution.tsx
+++ b/components/features/assistant-architect/assistant-architect-execution.tsx
@@ -1076,16 +1076,17 @@ export const AssistantArchitectExecution = memo(function AssistantArchitectExecu
                                       font-size: 0.9em;
                                     }
                                   `}</style>
-                                  <ReactMarkdown
-                                    className="markdown-output"
-                                    components={{
+                                  <div className="markdown-output">
+                                    <ReactMarkdown
+                                      components={{
                                       h1: (props) => <h2 {...props} />,
                                       h2: (props) => <h3 {...props} />,
                                       h3: (props) => <h4 {...props} />,
                                     }}
                                   >
                                     {promptTexts[index] || promptResult.outputData || ""}
-                                  </ReactMarkdown>
+                                    </ReactMarkdown>
+                                  </div>
                                 </div>
                                 <div className="flex items-center gap-2 justify-end mt-4">
                                   <Button

--- a/package-lock.json
+++ b/package-lock.json
@@ -74,7 +74,7 @@
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-hook-form": "^7.54.2",
-        "react-markdown": "^9.0.3",
+        "react-markdown": "^10.1.0",
         "react-syntax-highlighter": "^15.6.1",
         "rehype-sanitize": "^6.0.0",
         "sonner": "^2.0.1",
@@ -23733,9 +23733,9 @@
       "license": "MIT"
     },
     "node_modules/react-markdown": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-9.1.0.tgz",
-      "integrity": "sha512-xaijuJB0kzGiUdG7nc2MOMDUDBWPyGAjZtUrow9XxUeua8IqeP+VlIfAZ3bphpcLTnSZXz6z9jcVC/TCwbfgdw==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-10.1.0.tgz",
+      "integrity": "sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==",
       "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-hook-form": "^7.54.2",
-    "react-markdown": "^9.0.3",
+    "react-markdown": "^10.1.0",
     "react-syntax-highlighter": "^15.6.1",
     "rehype-sanitize": "^6.0.0",
     "sonner": "^2.0.1",


### PR DESCRIPTION
## Summary
- Upgraded react-markdown from 9.1.0 to 10.1.0
- Fixed breaking changes in v10
- Fixed unrelated lint errors discovered during update

## Changes
1. **react-markdown v10 Breaking Change:**
   - The `className` prop was removed in v10
   - Solution: Wrapped ReactMarkdown components in divs to apply className
   - Files updated:
     - `app/(protected)/chat/_components/message.tsx`
     - `components/features/assistant-architect/assistant-architect-execution.tsx`

2. **Bonus Lint Fixes:**
   - Fixed explicit 'any' types in admin users route
   - Fixed property names to match database columns (user_id, role_name)

## Testing
- [x] npm install completes successfully
- [x] npm run typecheck passes with zero errors
- [x] npm run lint passes with zero errors
- [ ] UI rendering verification needed for markdown content

## Related
- Closes Dependabot PR #43 when merged