### PR TITLE
feat: Implement S3 presigned URL uploads to bypass Amplify 1MB limit

### DIFF
--- a/app/api/documents/link/route.ts
+++ b/app/api/documents/link/route.ts
@@ -13,7 +13,7 @@ export async function POST(request: NextRequest) {
   }
   
   const currentUser = await getCurrentUserAction();
-  if (!currentUser.isSuccess) {
+  if (!currentUser.isSuccess || !currentUser.data?.user) {
     return unauthorized('User not found');
   }
   

--- a/app/api/documents/presigned-url/route.ts
+++ b/app/api/documents/presigned-url/route.ts
@@ -1,0 +1,137 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { z } from 'zod'
+import { getServerSession } from '@/lib/auth/server-session'
+import { getCurrentUserAction } from '@/actions/db/get-current-user-action'
+import { generateUploadPresignedUrl } from '@/lib/aws/s3-client'
+import { getSetting } from '@/lib/settings-manager'
+import logger from '@/lib/logger'
+
+// Get file size limit from settings or environment variable
+async function getMaxFileSize(): Promise<number> {
+  const maxSizeMB = await getSetting('MAX_FILE_SIZE_MB') || process.env.MAX_FILE_SIZE_MB || '25'
+  return parseInt(maxSizeMB, 10) * 1024 * 1024
+}
+
+// Supported file types
+const ALLOWED_FILE_EXTENSIONS = ['.pdf', '.docx', '.txt']
+const ALLOWED_MIME_TYPES = [
+  'application/pdf',
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+  'text/plain'
+]
+
+// Request validation schema (we'll validate file size dynamically in the handler)
+const PresignedUrlRequestSchema = z.object({
+  fileName: z.string().min(1).max(255),
+  fileType: z.string().refine(
+    (type) => ALLOWED_MIME_TYPES.includes(type),
+    { message: `Unsupported file type. Allowed types: ${ALLOWED_MIME_TYPES.join(', ')}` }
+  ),
+  fileSize: z.number().positive()
+})
+
+export async function POST(request: NextRequest) {
+  logger.info('[Presigned URL API] Handler entered')
+
+  const headers = {
+    'Content-Type': 'application/json',
+  }
+
+  try {
+    // Check authentication
+    const session = await getServerSession()
+    if (!session) {
+      logger.info('[Presigned URL API] Unauthorized - No session')
+      return NextResponse.json(
+        { error: 'Unauthorized' },
+        { status: 401, headers }
+      )
+    }
+
+    const currentUser = await getCurrentUserAction()
+    if (!currentUser.isSuccess) {
+      logger.info('[Presigned URL API] Unauthorized - User not found')
+      return NextResponse.json(
+        { error: 'User not found' },
+        { status: 401, headers }
+      )
+    }
+
+    const userId = currentUser.data.user.id
+    logger.info(`[Presigned URL API] User ID: ${userId}`)
+
+    // Parse and validate request body
+    const body = await request.json()
+    const validation = PresignedUrlRequestSchema.safeParse(body)
+
+    if (!validation.success) {
+      const errorMessage = validation.error.errors.map(e => e.message).join(', ')
+      logger.info('[Presigned URL API] Validation error:', errorMessage)
+      return NextResponse.json(
+        { error: errorMessage },
+        { status: 400, headers }
+      )
+    }
+
+    const { fileName, fileType, fileSize } = validation.data
+
+    // Get max file size and validate
+    const maxFileSize = await getMaxFileSize()
+    if (fileSize > maxFileSize) {
+      logger.info('[Presigned URL API] File size exceeds limit:', { fileSize, maxFileSize })
+      return NextResponse.json(
+        { error: `File size must be less than ${maxFileSize / (1024 * 1024)}MB` },
+        { status: 400, headers }
+      )
+    }
+
+    // Validate file extension matches content type
+    const fileExtension = `.${fileName.split('.').pop()?.toLowerCase()}`
+    if (!ALLOWED_FILE_EXTENSIONS.includes(fileExtension)) {
+      logger.info('[Presigned URL API] Invalid file extension:', fileExtension)
+      return NextResponse.json(
+        { error: `Unsupported file extension. Allowed types: ${ALLOWED_FILE_EXTENSIONS.join(', ')}` },
+        { status: 400, headers }
+      )
+    }
+
+    logger.info('[Presigned URL API] Generating presigned URL for:', {
+      fileName,
+      fileType,
+      fileSize,
+      userId: String(userId)
+    })
+
+    // Generate presigned URL
+    const presignedData = await generateUploadPresignedUrl({
+      userId: String(userId),
+      fileName,
+      contentType: fileType,
+      fileSize,
+      metadata: {
+        originalName: fileName,
+        uploadedBy: String(userId),
+      },
+      expiresIn: 3600 // 1 hour
+    })
+
+    logger.info('[Presigned URL API] Presigned URL generated successfully')
+
+    return NextResponse.json({
+      success: true,
+      url: presignedData.url,
+      key: presignedData.key,
+      fields: presignedData.fields,
+      expiresAt: new Date(Date.now() + 3600 * 1000).toISOString()
+    }, { status: 200, headers })
+
+  } catch (error) {
+    logger.error('[Presigned URL API] Error:', error)
+    return NextResponse.json(
+      { 
+        error: error instanceof Error ? error.message : 'Failed to generate upload URL'
+      },
+      { status: 500, headers }
+    )
+  }
+}

--- a/app/api/documents/process/route.ts
+++ b/app/api/documents/process/route.ts
@@ -1,0 +1,223 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { z } from 'zod'
+import { getServerSession } from '@/lib/auth/server-session'
+import { getCurrentUserAction } from '@/actions/db/get-current-user-action'
+import { getObjectStream, documentExists } from '@/lib/aws/s3-client'
+import { saveDocument, batchInsertDocumentChunks } from '@/lib/db/queries/documents'
+import { extractTextFromDocument, chunkText, getFileTypeFromFileName } from '@/lib/document-processing'
+import { getSetting } from '@/lib/settings-manager'
+import logger from '@/lib/logger'
+
+// Ensure this route is built for the Node.js runtime
+export const runtime = "nodejs"
+
+// Get file size limit from settings or environment variable
+async function getMaxFileSize(): Promise<number> {
+  const maxSizeMB = await getSetting('MAX_FILE_SIZE_MB') || process.env.MAX_FILE_SIZE_MB || '25'
+  return parseInt(maxSizeMB, 10) * 1024 * 1024
+}
+
+// Request validation schema
+const ProcessDocumentRequestSchema = z.object({
+  key: z.string().min(1),
+  fileName: z.string().min(1).max(255),
+  fileSize: z.number().positive(),
+  conversationId: z.number().nullable().optional()
+})
+
+export async function POST(request: NextRequest) {
+  logger.info('[Process Document API] Handler entered')
+
+  const headers = {
+    'Content-Type': 'application/json',
+  }
+
+  try {
+    // Check authentication
+    const session = await getServerSession()
+    if (!session) {
+      logger.info('[Process Document API] Unauthorized - No session')
+      return NextResponse.json(
+        { error: 'Unauthorized' },
+        { status: 401, headers }
+      )
+    }
+
+    const currentUser = await getCurrentUserAction()
+    if (!currentUser.isSuccess) {
+      logger.info('[Process Document API] Unauthorized - User not found')
+      return NextResponse.json(
+        { error: 'User not found' },
+        { status: 401, headers }
+      )
+    }
+
+    const userId = currentUser.data.user.id
+    logger.info(`[Process Document API] User ID: ${userId}`)
+
+    // Parse and validate request body
+    const body = await request.json()
+    const validation = ProcessDocumentRequestSchema.safeParse(body)
+
+    if (!validation.success) {
+      const errorMessage = validation.error.errors.map(e => e.message).join(', ')
+      logger.info('[Process Document API] Validation error:', errorMessage)
+      return NextResponse.json(
+        { error: errorMessage },
+        { status: 400, headers }
+      )
+    }
+
+    const { key, fileName, fileSize, conversationId } = validation.data
+
+    // Verify file size is within limits
+    const maxFileSize = await getMaxFileSize()
+    if (fileSize > maxFileSize) {
+      logger.info('[Process Document API] File size exceeds limit:', { fileSize, maxFileSize })
+      return NextResponse.json(
+        { error: `File size must be less than ${maxFileSize / (1024 * 1024)}MB` },
+        { status: 400, headers }
+      )
+    }
+
+    // Verify the S3 key belongs to this user
+    if (!key.startsWith(`${userId}/`)) {
+      logger.error('[Process Document API] Unauthorized access attempt to S3 key:', { key, userId })
+      return NextResponse.json(
+        { error: 'Unauthorized access to document' },
+        { status: 403, headers }
+      )
+    }
+
+    // Verify document exists in S3
+    const exists = await documentExists(key)
+    if (!exists) {
+      logger.error('[Process Document API] Document not found in S3:', key)
+      return NextResponse.json(
+        { error: 'Document not found' },
+        { status: 404, headers }
+      )
+    }
+
+    logger.info('[Process Document API] Retrieving document from S3:', key)
+
+    // Get document stream from S3
+    const { stream, metadata } = await getObjectStream(key)
+
+    // Extract file type
+    const fileType = getFileTypeFromFileName(fileName)
+    logger.info(`[Process Document API] File type: ${fileType}`)
+
+    // Convert stream to buffer for processing
+    const chunks: Buffer[] = []
+    for await (const chunk of stream) {
+      chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk))
+    }
+    const fileBuffer = Buffer.concat(chunks)
+    logger.info(`[Process Document API] File retrieved, size: ${fileBuffer.length}`)
+
+    // Process document content for text extraction
+    logger.info('[Process Document API] Extracting text from document...')
+    let text, extractedMetadata
+    try {
+      const extracted = await extractTextFromDocument(fileBuffer, fileType)
+      text = extracted.text
+      extractedMetadata = extracted.metadata
+      logger.info(`[Process Document API] Text extracted, length: ${text?.length ?? 0}`)
+    } catch (extractError) {
+      logger.error('[Process Document API] Error extracting text:', extractError)
+      return NextResponse.json(
+        { 
+          error: `Failed to extract text from document: ${extractError instanceof Error ? extractError.message : String(extractError)}` 
+        },
+        { status: 500, headers }
+      )
+    }
+
+    // Ensure text is not null or undefined
+    if (!text) {
+      logger.error('[Process Document API] No text content extracted from document')
+      return NextResponse.json(
+        { error: 'Failed to extract text content from document' },
+        { status: 500, headers }
+      )
+    }
+
+    // Save document metadata to database
+    logger.info('[Process Document API] Saving document to database...')
+    let document
+    try {
+      document = await saveDocument({
+        userId,
+        conversationId: conversationId || null,
+        name: fileName,
+        type: fileType,
+        size: fileSize,
+        url: key, // Store S3 key
+        metadata: {
+          ...extractedMetadata,
+          originalName: metadata?.originalName || fileName,
+          uploadedAt: metadata?.uploadedAt || new Date().toISOString()
+        }
+      })
+      logger.info(`[Process Document API] Document saved to database: ${document.id}`)
+    } catch (saveError) {
+      logger.error('[Process Document API] Error saving document:', saveError)
+      return NextResponse.json(
+        { 
+          error: `Failed to save document: ${saveError instanceof Error ? saveError.message : String(saveError)}` 
+        },
+        { status: 500, headers }
+      )
+    }
+
+    // Chunk text and save to database
+    logger.info('[Process Document API] Chunking text...')
+    let textChunks: string[] = []
+    try {
+      textChunks = chunkText(text)
+      logger.info(`[Process Document API] Created ${textChunks.length} chunks`)
+      
+      if (textChunks.length > 0) {
+        const documentChunks = textChunks.map((chunk, index) => ({
+          documentId: document.id,
+          content: chunk,
+          chunkIndex: index,
+          metadata: { position: index }
+        }))
+
+        logger.info('[Process Document API] Saving chunks to database...')
+        const savedChunks = await batchInsertDocumentChunks(documentChunks)
+        logger.info(`[Process Document API] Saved ${savedChunks.length} chunks`)
+      } else {
+        logger.warn('[Process Document API] No chunks created from document')
+      }
+    } catch (chunkError) {
+      logger.error('[Process Document API] Error processing chunks:', chunkError)
+      // Note: We don't fail the whole operation if chunking fails
+      // The document is already saved and can be re-processed later
+    }
+
+    // Return success response
+    return NextResponse.json({
+      success: true,
+      document: {
+        id: document.id,
+        name: document.name,
+        type: document.type,
+        size: document.size,
+        url: document.url,
+        totalChunks: textChunks.length
+      }
+    }, { status: 200, headers })
+
+  } catch (error) {
+    logger.error('[Process Document API] Unexpected error:', error)
+    return NextResponse.json(
+      { 
+        error: error instanceof Error ? error.message : 'Failed to process document'
+      },
+      { status: 500, headers }
+    )
+  }
+}

--- a/docs/file-upload-architecture.md
+++ b/docs/file-upload-architecture.md
@@ -1,0 +1,46 @@
+# File Upload Architecture
+
+## Overview
+The application now uses a hybrid approach for file uploads to work around AWS Amplify SSR's 1MB request body limitation.
+
+## Upload Flow
+
+### Small Files (≤ 1MB)
+1. Files are uploaded directly to `/api/documents/upload`
+2. The API processes the file in memory
+3. Text is extracted and chunked
+4. File is uploaded to S3
+5. Metadata is saved to the database
+
+### Large Files (> 1MB)
+1. Client requests a presigned URL from `/api/documents/presigned-url`
+2. Client uploads file directly to S3 using the presigned URL
+3. Client notifies `/api/documents/process` of successful upload
+4. Server downloads file from S3 for processing
+5. Text is extracted and chunked
+6. Metadata is saved to the database
+
+## Benefits
+- Bypasses Amplify's 1MB limit for production deployments
+- Provides real-time upload progress for large files
+- Reduces server memory usage for large uploads
+- Maintains backward compatibility for small files
+
+## Configuration
+- File size limit is controlled by `MAX_FILE_SIZE_MB` environment variable (default: 25MB)
+- The 1MB threshold for switching to presigned URLs is hardcoded but can be adjusted
+
+## Security
+- Presigned URLs expire after 1 hour
+- S3 keys include user ID for access isolation
+- Processing endpoint validates S3 object ownership
+- All endpoints require authentication
+
+## Related Files
+- `/app/api/documents/presigned-url/route.ts` - Generates presigned URLs
+- `/app/api/documents/process/route.ts` - Processes uploaded files
+- `/app/(protected)/chat/_components/document-upload.tsx` - Client upload component
+- `/lib/aws/s3-client.ts` - S3 utilities including presigned URL generation
+
+## GitHub Issue
+This implementation addresses issue #73: File uploads failing with HTTP 413 on production environment

--- a/lib/file-validation.ts
+++ b/lib/file-validation.ts
@@ -1,0 +1,122 @@
+import { getSetting } from '@/lib/settings-manager'
+
+// Supported file types
+export const ALLOWED_FILE_EXTENSIONS = ['.pdf', '.docx', '.txt'] as const
+export const ALLOWED_MIME_TYPES = [
+  'application/pdf',
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+  'text/plain'
+] as const
+
+// Type for allowed extensions
+export type AllowedFileExtension = typeof ALLOWED_FILE_EXTENSIONS[number]
+export type AllowedMimeType = typeof ALLOWED_MIME_TYPES[number]
+
+/**
+ * Get the maximum file size allowed for uploads
+ * @returns Maximum file size in bytes
+ */
+export async function getMaxFileSize(): Promise<number> {
+  const maxSizeMB = await getSetting('MAX_FILE_SIZE_MB') || process.env.MAX_FILE_SIZE_MB || '25'
+  return parseInt(maxSizeMB, 10) * 1024 * 1024
+}
+
+/**
+ * Get the threshold for using presigned URLs vs direct upload
+ * @returns Threshold in bytes
+ */
+export async function getPresignedUrlThreshold(): Promise<number> {
+  const thresholdMB = process.env.PRESIGNED_URL_THRESHOLD_MB || '1'
+  return parseInt(thresholdMB, 10) * 1024 * 1024
+}
+
+/**
+ * Validate file extension
+ * @param fileName - The name of the file to validate
+ * @returns True if valid, false otherwise
+ */
+export function isValidFileExtension(fileName: string): boolean {
+  const fileExtension = `.${fileName.split('.').pop()?.toLowerCase()}`
+  return ALLOWED_FILE_EXTENSIONS.includes(fileExtension as AllowedFileExtension)
+}
+
+/**
+ * Validate MIME type
+ * @param mimeType - The MIME type to validate
+ * @returns True if valid, false otherwise
+ */
+export function isValidMimeType(mimeType: string): boolean {
+  return ALLOWED_MIME_TYPES.includes(mimeType as AllowedMimeType)
+}
+
+/**
+ * Get file extension from filename
+ * @param fileName - The filename
+ * @returns The file extension with dot prefix
+ */
+export function getFileExtension(fileName: string): string {
+  return `.${fileName.split('.').pop()?.toLowerCase() || ''}`
+}
+
+/**
+ * Validate file size
+ * @param fileSize - Size in bytes
+ * @param maxSize - Maximum allowed size in bytes
+ * @returns True if within limits, false otherwise
+ */
+export function isValidFileSize(fileSize: number, maxSize: number): boolean {
+  return fileSize > 0 && fileSize <= maxSize
+}
+
+/**
+ * Get human-readable file size
+ * @param bytes - Size in bytes
+ * @returns Human-readable size string
+ */
+export function formatFileSize(bytes: number): string {
+  if (bytes === 0) return '0 Bytes'
+  
+  const k = 1024
+  const sizes = ['Bytes', 'KB', 'MB', 'GB']
+  const i = Math.floor(Math.log(bytes) / Math.log(k))
+  
+  return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + ' ' + sizes[i]
+}
+
+/**
+ * Comprehensive file validation
+ * @param file - File object or file metadata
+ * @returns Validation result with error message if invalid
+ */
+export async function validateFile(file: {
+  name: string
+  type: string
+  size: number
+}): Promise<{ isValid: boolean; error?: string }> {
+  // Check file extension
+  if (!isValidFileExtension(file.name)) {
+    return {
+      isValid: false,
+      error: `Unsupported file extension. Allowed types: ${ALLOWED_FILE_EXTENSIONS.join(', ')}`
+    }
+  }
+
+  // Check MIME type
+  if (!isValidMimeType(file.type)) {
+    return {
+      isValid: false,
+      error: `Unsupported file type. Allowed types: ${ALLOWED_MIME_TYPES.join(', ')}`
+    }
+  }
+
+  // Check file size
+  const maxSize = await getMaxFileSize()
+  if (!isValidFileSize(file.size, maxSize)) {
+    return {
+      isValid: false,
+      error: `File size must be less than ${formatFileSize(maxSize)}`
+    }
+  }
+
+  return { isValid: true }
+}

--- a/tests/integration/document-upload-flow.test.ts
+++ b/tests/integration/document-upload-flow.test.ts
@@ -2,6 +2,11 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 
+// Add TextEncoder/TextDecoder polyfills for Node.js test environment
+import { TextEncoder, TextDecoder } from 'util';
+global.TextEncoder = TextEncoder;
+global.TextDecoder = TextDecoder as any;
+
 // Mock Next.js server components first
 jest.mock('next/server', () => ({
   NextRequest: jest.fn(),
@@ -32,32 +37,75 @@ jest.mock('next/server', () => ({
   }
 }));
 
-import { POST as uploadAPI } from '@/app/api/documents/upload/route';
-import { POST as chatAPI } from '@/app/api/chat/route';
-import { POST as linkAPI } from '@/app/api/documents/link/route';
-import { NextRequest } from 'next/server';
-
-// Add TextEncoder/TextDecoder polyfills for Node.js test environment
-import { TextEncoder, TextDecoder } from 'util';
-global.TextEncoder = TextEncoder;
-global.TextDecoder = TextDecoder as any;
-
-// Mock all dependencies
+// Mock all dependencies BEFORE importing modules that use them
 jest.mock('@/lib/auth/server-session', () => ({
   getServerSession: jest.fn()
 }));
 jest.mock('@/actions/db/get-current-user-action');
 jest.mock('@/lib/aws/s3-client');
+jest.mock('@/lib/logger', () => ({
+  default: {
+    info: jest.fn(),
+    error: jest.fn(),
+    warn: jest.fn(),
+    debug: jest.fn()
+  }
+}));
+jest.mock('@/lib/file-validation', () => ({
+  ALLOWED_FILE_EXTENSIONS: ['.pdf', '.docx', '.txt'],
+  ALLOWED_MIME_TYPES: ['application/pdf', 'application/vnd.openxmlformats-officedocument.wordprocessingml.document', 'text/plain'],
+  getMaxFileSize: jest.fn().mockResolvedValue(25 * 1024 * 1024),
+  formatFileSize: jest.fn().mockImplementation((bytes) => `${Math.round(bytes / (1024 * 1024))}MB`)
+}));
 jest.mock('@/lib/db/queries/documents');
 jest.mock('@/lib/ai-helpers');
 jest.mock('@/lib/db/data-api-adapter');
+jest.mock('@/lib/settings-manager', () => ({
+  getSetting: jest.fn().mockResolvedValue('25')
+}));
+jest.mock('@/lib/document-processing', () => ({
+  extractTextFromDocument: jest.fn().mockResolvedValue({ text: 'Test PDF content about AI and machine learning', metadata: {} }),
+  chunkText: jest.fn().mockReturnValue(['Test PDF content about AI and machine learning']),
+  getFileTypeFromFileName: jest.fn().mockReturnValue('pdf')
+}));
+jest.mock('@/lib/error-utils', () => ({
+  createError: jest.fn((message, options) => {
+    const error = new Error(message);
+    Object.assign(error, options);
+    return error;
+  }),
+  handleError: jest.fn(),
+  ErrorLevel: { WARN: 'WARN', ERROR: 'ERROR', INFO: 'INFO' }
+}));
+jest.mock('@/lib/api-utils', () => ({
+  withErrorHandling: jest.fn((handler) => handler().then(
+    (data) => new (jest.requireActual('next/server').NextResponse)(
+      JSON.stringify({ success: true, data }),
+      { status: 200, headers: { 'Content-Type': 'application/json' } }
+    )
+  ).catch(
+    (error) => new (jest.requireActual('next/server').NextResponse)(
+      JSON.stringify({ success: false, message: error.message }),
+      { status: 500, headers: { 'Content-Type': 'application/json' } }
+    )
+  )),
+  unauthorized: jest.fn((msg) => new (jest.requireActual('next/server').NextResponse)(
+    JSON.stringify({ success: false, message: msg || 'Unauthorized' }),
+    { status: 401, headers: { 'Content-Type': 'application/json' } }
+  )),
+  forbidden: jest.fn((msg) => new (jest.requireActual('next/server').NextResponse)(
+    JSON.stringify({ success: false, message: msg || 'Forbidden' }),
+    { status: 403, headers: { 'Content-Type': 'application/json' } }
+  ))
+}));
 
 import { getServerSession } from '@/lib/auth/server-session';
 import { getCurrentUserAction } from '@/actions/db/get-current-user-action';
-import { uploadDocument } from '@/lib/aws/s3-client';
+import { uploadDocument, getObjectStream, documentExists } from '@/lib/aws/s3-client';
 import { 
   saveDocument, 
-  saveDocumentChunk, 
+  saveDocumentChunk,
+  batchInsertDocumentChunks,
   getDocumentsByConversationId,
   getDocumentById,
   getDocumentChunksByDocumentId,
@@ -66,12 +114,21 @@ import {
 import { generateCompletion } from '@/lib/ai-helpers';
 import { executeSQL } from '@/lib/db/data-api-adapter';
 
+// Import API routes AFTER all mocks are set up
+import { POST as uploadAPI } from '@/app/api/documents/upload/route';
+import { POST as chatAPI } from '@/app/api/chat/route';
+import { POST as linkAPI } from '@/app/api/documents/link/route';
+import { NextRequest } from 'next/server';
+
 describe('Document Upload End-to-End Flow', () => {
   const mockUserId = 'user-123';
   const mockSession = { sub: mockUserId, email: 'test@example.com' };
   const mockUser = {
     isSuccess: true,
-    data: { id: mockUserId, email: 'test@example.com' },
+    data: { 
+      user: { id: mockUserId, email: 'test@example.com' },
+      roles: []
+    },
   };
 
   beforeEach(() => {
@@ -117,6 +174,7 @@ describe('Document Upload End-to-End Flow', () => {
       (uploadDocument as jest.Mock).mockResolvedValue(mockUploadResult);
       (saveDocument as jest.Mock).mockResolvedValue(mockDocument);
       (saveDocumentChunk as jest.Mock).mockResolvedValue(mockChunks[0]);
+      (batchInsertDocumentChunks as jest.Mock).mockResolvedValue(mockChunks);
       
       // Create upload request
       const formData = new FormData();


### PR DESCRIPTION
## Summary
This PR implements a solution for issue #73 where file uploads larger than 1MB were failing with HTTP 413 errors in production due to AWS Amplify SSR's hardcoded request body size limit.

The solution uses AWS's recommended pattern of S3 presigned URLs for large file uploads, bypassing the Amplify limitation entirely.

## Changes
- **S3 Client Enhancement**: Added presigned URL generation and streaming capabilities
- **New API Endpoints**:
  - `/api/documents/presigned-url`: Generates secure upload URLs
  - `/api/documents/process`: Processes files after S3 upload
- **Upload Component Refactor**: Hybrid approach using direct upload for small files (≤1MB) and presigned URLs for large files
- **Progress Tracking**: Real-time upload progress using XMLHttpRequest
- **Documentation**: Comprehensive architecture documentation

## Technical Details
### Upload Flow
1. **Small files (≤ 1MB)**: Continue using existing direct upload to `/api/documents/upload`
2. **Large files (> 1MB)**:
   - Request presigned URL from new endpoint
   - Upload directly to S3 with progress tracking
   - Notify server to process the uploaded file

### Security
- Presigned URLs expire after 1 hour
- S3 keys include user ID for access isolation
- Processing endpoint validates object ownership
- All endpoints require authentication

### Configuration
- File size limit controlled by `MAX_FILE_SIZE_MB` environment variable (default: 25MB)
- 1MB threshold for presigned URL switch is hardcoded but adjustable

## Testing
- [x] Tested locally with various file sizes
- [x] Linting passes with no errors
- [x] TypeScript type checking passes
- [ ] To be tested in production environment after deployment

## Related Issue
Fixes #73

## Test Plan
1. Upload a file < 1MB - should use direct upload
2. Upload a file > 1MB - should use presigned URL flow
3. Upload a file > 25MB - should be rejected
4. Monitor upload progress for large files
5. Verify text extraction and chunking work correctly