### PR TITLE
Fix: Critical repository security vulnerability and admin interface (#79)

### DIFF
--- a/actions/admin/repositories.actions.ts
+++ b/actions/admin/repositories.actions.ts
@@ -1,0 +1,261 @@
+"use server"
+
+import { getServerSession } from "@/lib/auth/server-session"
+import { executeSQL } from "@/lib/db/data-api-adapter"
+import { type ActionState } from "@/types/actions-types"
+import { hasRole } from "@/utils/roles"
+import { handleError } from "@/lib/error-utils"
+import { revalidatePath } from "next/cache"
+import { transformSnakeToCamel } from "@/lib/db/field-mapper"
+import type { Repository } from "@/actions/repositories/repository.actions"
+
+export interface RepositoryWithOwner extends Repository {
+  ownerEmail: string
+}
+
+/**
+ * Admin function to list all repositories with owner information
+ */
+export async function listAllRepositories(): Promise<ActionState<RepositoryWithOwner[]>> {
+  try {
+    const session = await getServerSession()
+    if (!session) {
+      return { isSuccess: false, message: "Unauthorized" }
+    }
+
+    // Check if user is administrator
+    const isAdmin = await hasRole("administrator")
+    if (!isAdmin) {
+      return { isSuccess: false, message: "Access denied. Administrator privileges required." }
+    }
+
+    const repositories = await executeSQL<RepositoryWithOwner>(
+      `SELECT 
+        kr.*,
+        u.email as owner_email,
+        (SELECT COUNT(*) FROM repository_items WHERE repository_id = kr.id) as item_count
+       FROM knowledge_repositories kr
+       LEFT JOIN users u ON kr.owner_id = u.id
+       ORDER BY kr.created_at DESC`
+    )
+
+    const transformed = repositories.map(repo => transformSnakeToCamel<RepositoryWithOwner>(repo))
+    return { isSuccess: true, message: "Repositories loaded successfully", data: transformed }
+  } catch (error) {
+    return handleError(error, "Failed to list repositories")
+  }
+}
+
+/**
+ * Admin function to update any repository
+ */
+export async function adminUpdateRepository(
+  input: {
+    id: number
+    name?: string
+    description?: string
+    isPublic?: boolean
+    metadata?: Record<string, any>
+  }
+): Promise<ActionState<Repository>> {
+  try {
+    const session = await getServerSession()
+    if (!session) {
+      return { isSuccess: false, message: "Unauthorized" }
+    }
+
+    // Check if user is administrator
+    const isAdmin = await hasRole("administrator")
+    if (!isAdmin) {
+      return { isSuccess: false, message: "Access denied. Administrator privileges required." }
+    }
+
+    const updates: string[] = []
+    const params: any[] = [
+      { name: "id", value: { longValue: input.id } }
+    ]
+
+    if (input.name !== undefined) {
+      updates.push("name = :name")
+      params.push({ name: "name", value: { stringValue: input.name } })
+    }
+
+    if (input.description !== undefined) {
+      updates.push("description = :description")
+      params.push({ name: "description", value: input.description ? { stringValue: input.description } : { isNull: true } })
+    }
+
+    if (input.isPublic !== undefined) {
+      updates.push("is_public = :is_public")
+      params.push({ name: "is_public", value: { booleanValue: input.isPublic } })
+    }
+
+    if (input.metadata !== undefined) {
+      updates.push("metadata = :metadata::jsonb")
+      params.push({ name: "metadata", value: { stringValue: JSON.stringify(input.metadata) } })
+    }
+
+    if (updates.length === 0) {
+      return { isSuccess: false, message: "No fields to update" }
+    }
+
+    updates.push("updated_at = CURRENT_TIMESTAMP")
+
+    const result = await executeSQL<Repository>(
+      `UPDATE knowledge_repositories 
+       SET ${updates.join(", ")}
+       WHERE id = :id
+       RETURNING *`,
+      params
+    )
+
+    if (result.length === 0) {
+      return { isSuccess: false, message: "Repository not found" }
+    }
+
+    revalidatePath("/admin/repositories")
+    revalidatePath(`/repositories/${input.id}`)
+    return { isSuccess: true, message: "Repository updated successfully (admin)", data: result[0] }
+  } catch (error) {
+    return handleError(error, "Failed to update repository")
+  }
+}
+
+/**
+ * Admin function to delete any repository
+ */
+export async function adminDeleteRepository(
+  id: number
+): Promise<ActionState<void>> {
+  try {
+    const session = await getServerSession()
+    if (!session) {
+      return { isSuccess: false, message: "Unauthorized" }
+    }
+
+    // Check if user is administrator
+    const isAdmin = await hasRole("administrator")
+    if (!isAdmin) {
+      return { isSuccess: false, message: "Access denied. Administrator privileges required." }
+    }
+
+    // First, get all document items to delete from S3
+    const items = await executeSQL<{ id: number; type: string; source: string }>(
+      `SELECT id, type, source FROM repository_items 
+       WHERE repository_id = :repository_id AND type = 'document'`,
+      [{ name: "repository_id", value: { longValue: id } }]
+    )
+
+    // Delete all documents from S3
+    if (items.length > 0) {
+      const { deleteDocument } = await import("@/lib/aws/s3-client")
+      
+      for (const item of items) {
+        try {
+          await deleteDocument(item.source)
+        } catch (error) {
+          // Log error but continue with deletion
+          console.error(`Failed to delete S3 file ${item.source}:`, error)
+        }
+      }
+    }
+
+    // Now delete the repository (this will cascade delete all items and chunks)
+    await executeSQL(
+      `DELETE FROM knowledge_repositories WHERE id = :id`,
+      [{ name: "id", value: { longValue: id } }]
+    )
+
+    revalidatePath("/admin/repositories")
+    revalidatePath("/repositories")
+    return { isSuccess: true, message: "Repository deleted successfully (admin)", data: undefined as any }
+  } catch (error) {
+    return handleError(error, "Failed to delete repository")
+  }
+}
+
+/**
+ * Admin function to get repository items
+ */
+export async function adminGetRepositoryItems(
+  repositoryId: number
+): Promise<ActionState<any[]>> {
+  try {
+    const session = await getServerSession()
+    if (!session) {
+      return { isSuccess: false, message: "Unauthorized" }
+    }
+
+    // Check if user is administrator
+    const isAdmin = await hasRole("administrator")
+    if (!isAdmin) {
+      return { isSuccess: false, message: "Access denied. Administrator privileges required." }
+    }
+
+    const items = await executeSQL(
+      `SELECT * FROM repository_items 
+       WHERE repository_id = :repository_id
+       ORDER BY created_at DESC`,
+      [{ name: "repository_id", value: { longValue: repositoryId } }]
+    )
+
+    return { isSuccess: true, message: "Items loaded successfully", data: items }
+  } catch (error) {
+    return handleError(error, "Failed to list repository items")
+  }
+}
+
+/**
+ * Admin function to remove an item from any repository
+ */
+export async function adminRemoveRepositoryItem(
+  itemId: number
+): Promise<ActionState<void>> {
+  try {
+    const session = await getServerSession()
+    if (!session) {
+      return { isSuccess: false, message: "Unauthorized" }
+    }
+
+    // Check if user is administrator
+    const isAdmin = await hasRole("administrator")
+    if (!isAdmin) {
+      return { isSuccess: false, message: "Access denied. Administrator privileges required." }
+    }
+
+    // Get the item to check if it's a document (need to delete from S3)
+    const items = await executeSQL<{ id: number; type: string; source: string; repositoryId: number }>(
+      `SELECT * FROM repository_items WHERE id = :id`,
+      [{ name: "id", value: { longValue: itemId } }]
+    )
+
+    if (items.length === 0) {
+      return { isSuccess: false, message: "Item not found" }
+    }
+
+    const item = items[0]
+
+    // Delete from S3 if it's a document
+    if (item.type === 'document') {
+      try {
+        const { deleteDocument } = await import("@/lib/aws/s3-client")
+        await deleteDocument(item.source)
+      } catch (error) {
+        // Log error but continue with database deletion
+        console.error("Failed to delete from S3:", error)
+      }
+    }
+
+    // Delete from database (cascades to chunks)
+    await executeSQL(
+      `DELETE FROM repository_items WHERE id = :id`,
+      [{ name: "id", value: { longValue: itemId } }]
+    )
+
+    revalidatePath(`/admin/repositories`)
+    revalidatePath(`/repositories/${item.repositoryId}`)
+    return { isSuccess: true, message: "Item removed successfully (admin)", data: undefined as any }
+  } catch (error) {
+    return handleError(error, "Failed to remove item")
+  }
+}

--- a/actions/repositories/repository-permissions.ts
+++ b/actions/repositories/repository-permissions.ts
@@ -1,0 +1,47 @@
+"use server"
+
+import { executeSQL } from "@/lib/db/data-api-adapter"
+import { hasRole } from "@/utils/roles"
+import { createError } from "@/lib/error-utils"
+import { ErrorLevel } from "@/types/actions-types"
+
+/**
+ * Check if a user can modify a repository
+ * Returns true if the user is the owner or an administrator
+ */
+export async function canModifyRepository(
+  repositoryId: number,
+  userId: number
+): Promise<boolean> {
+  // Check if user owns the repository
+  const ownerCheck = await executeSQL<{ id: number }>(
+    `SELECT 1 as id FROM knowledge_repositories 
+     WHERE id = :repositoryId AND owner_id = :userId`,
+    [
+      { name: "repositoryId", value: { longValue: repositoryId } },
+      { name: "userId", value: { longValue: userId } }
+    ]
+  )
+  
+  if (ownerCheck.length > 0) return true
+  
+  // Check if user is administrator
+  return await hasRole("administrator")
+}
+
+/**
+ * Get user ID from cognito_sub
+ * Returns the user's database ID or throws error if not found
+ */
+export async function getUserIdFromSession(cognitoSub: string): Promise<number> {
+  const userResult = await executeSQL<{ id: number }>(
+    `SELECT id FROM users WHERE cognito_sub = :cognito_sub`,
+    [{ name: "cognito_sub", value: { stringValue: cognitoSub } }]
+  )
+
+  if (userResult.length === 0) {
+    throw createError("User not found", { level: ErrorLevel.ERROR })
+  }
+
+  return userResult[0].id
+}

--- a/app/(protected)/admin/repositories/_components/repositories-admin-client.tsx
+++ b/app/(protected)/admin/repositories/_components/repositories-admin-client.tsx
@@ -1,0 +1,236 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { useRouter } from "next/navigation"
+import { useAction } from "@/lib/hooks/use-action"
+import { 
+  listAllRepositories, 
+  adminDeleteRepository,
+  type RepositoryWithOwner 
+} from "@/actions/admin/repositories.actions"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
+import { Badge } from "@/components/ui/badge"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
+import { 
+  Loader2, 
+  MoreHorizontal, 
+  Eye, 
+  Edit, 
+  Trash2,
+  Package
+} from "lucide-react"
+import { useToast } from "@/components/ui/use-toast"
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog"
+
+export function RepositoriesAdminClient() {
+  const router = useRouter()
+  const { toast } = useToast()
+  const [repositories, setRepositories] = useState<RepositoryWithOwner[]>([])
+  const [deleteRepoId, setDeleteRepoId] = useState<number | null>(null)
+  const [isLoading, setIsLoading] = useState(true)
+
+  const { execute: executeList } = useAction(listAllRepositories)
+  const { execute: executeDelete, isPending: isDeleting } = useAction(adminDeleteRepository)
+
+  useEffect(() => {
+    loadRepositories()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  async function loadRepositories() {
+    setIsLoading(true)
+    const result = await executeList({})
+    if (result.isSuccess && result.data) {
+      setRepositories(result.data)
+    } else {
+      toast({
+        title: "Error",
+        description: result.message || "Failed to load repositories",
+        variant: "destructive",
+      })
+    }
+    setIsLoading(false)
+  }
+
+  async function handleDelete() {
+    if (!deleteRepoId) return
+
+    const result = await executeDelete(deleteRepoId)
+    if (result.isSuccess) {
+      toast({
+        title: "Repository deleted",
+        description: "The repository has been deleted successfully.",
+      })
+      setDeleteRepoId(null)
+      loadRepositories()
+    } else {
+      toast({
+        title: "Error",
+        description: result.message || "Failed to delete repository",
+        variant: "destructive",
+      })
+    }
+  }
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center min-h-[400px]">
+        <Loader2 className="h-8 w-8 animate-spin" />
+      </div>
+    )
+  }
+
+  return (
+    <>
+      <Card>
+        <CardHeader>
+          <CardTitle>Repository Management</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="rounded-md border">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Name</TableHead>
+                  <TableHead>Owner</TableHead>
+                  <TableHead>Visibility</TableHead>
+                  <TableHead>Items</TableHead>
+                  <TableHead>Created</TableHead>
+                  <TableHead className="text-right">Actions</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {repositories.length === 0 ? (
+                  <TableRow>
+                    <TableCell colSpan={6} className="text-center text-muted-foreground py-8">
+                      No repositories found
+                    </TableCell>
+                  </TableRow>
+                ) : (
+                  repositories.map((repo) => (
+                    <TableRow key={repo.id}>
+                      <TableCell className="font-medium">
+                        <div>
+                          <div>{repo.name}</div>
+                          {repo.description && (
+                            <div className="text-sm text-muted-foreground">
+                              {repo.description}
+                            </div>
+                          )}
+                        </div>
+                      </TableCell>
+                      <TableCell>
+                        <div className="text-sm">{repo.ownerEmail}</div>
+                      </TableCell>
+                      <TableCell>
+                        <Badge variant={repo.isPublic ? 'default' : 'secondary'}>
+                          {repo.isPublic ? 'Public' : 'Private'}
+                        </Badge>
+                      </TableCell>
+                      <TableCell>
+                        <div className="flex items-center gap-1">
+                          <Package className="h-4 w-4 text-muted-foreground" />
+                          <span>{repo.itemCount || 0}</span>
+                        </div>
+                      </TableCell>
+                      <TableCell>
+                        {new Date(repo.createdAt).toLocaleDateString()}
+                      </TableCell>
+                      <TableCell className="text-right">
+                        <DropdownMenu>
+                          <DropdownMenuTrigger asChild>
+                            <Button variant="ghost" className="h-8 w-8 p-0">
+                              <span className="sr-only">Open menu</span>
+                              <MoreHorizontal className="h-4 w-4" />
+                            </Button>
+                          </DropdownMenuTrigger>
+                          <DropdownMenuContent align="end">
+                            <DropdownMenuLabel>Actions</DropdownMenuLabel>
+                            <DropdownMenuItem
+                              onClick={() => router.push(`/repositories/${repo.id}`)}
+                            >
+                              <Eye className="mr-2 h-4 w-4" />
+                              View
+                            </DropdownMenuItem>
+                            <DropdownMenuItem
+                              onClick={() => router.push(`/repositories/${repo.id}/edit`)}
+                            >
+                              <Edit className="mr-2 h-4 w-4" />
+                              Edit
+                            </DropdownMenuItem>
+                            <DropdownMenuItem
+                              onClick={() => router.push(`/repositories/${repo.id}/items`)}
+                            >
+                              <Package className="mr-2 h-4 w-4" />
+                              Manage Items
+                            </DropdownMenuItem>
+                            <DropdownMenuSeparator />
+                            <DropdownMenuItem
+                              onClick={() => setDeleteRepoId(repo.id)}
+                              className="text-destructive"
+                            >
+                              <Trash2 className="mr-2 h-4 w-4" />
+                              Delete
+                            </DropdownMenuItem>
+                          </DropdownMenuContent>
+                        </DropdownMenu>
+                      </TableCell>
+                    </TableRow>
+                  ))
+                )}
+              </TableBody>
+            </Table>
+          </div>
+        </CardContent>
+      </Card>
+
+      <AlertDialog open={!!deleteRepoId} onOpenChange={() => setDeleteRepoId(null)}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Are you sure?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This action cannot be undone. This will permanently delete the repository
+              and all its items.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleDelete}
+              disabled={isDeleting}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            >
+              {isDeleting && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+              Delete
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  )
+}

--- a/app/(protected)/admin/repositories/page.tsx
+++ b/app/(protected)/admin/repositories/page.tsx
@@ -1,0 +1,9 @@
+import { requireRole } from "@/lib/auth/role-helpers"
+import { RepositoriesAdminClient } from "./_components/repositories-admin-client"
+
+export default async function AdminRepositoriesPage() {
+  // Check admin permissions
+  await requireRole("administrator")
+
+  return <RepositoriesAdminClient />
+}

--- a/app/api/assistant-architect/stream/route.ts
+++ b/app/api/assistant-architect/stream/route.ts
@@ -269,10 +269,25 @@ export async function POST(req: NextRequest) {
                     })}\n\n`
                   ));
 
+                  // Get assistant owner's cognito_sub
+                  let assistantOwnerSub: string | undefined;
+                  if (tool.userId) {
+                    const assistantOwnerQuery = `
+                      SELECT u.cognito_sub 
+                      FROM users u 
+                      WHERE u.id = :userId
+                    `;
+                    const ownerResult = await executeSQL<{ cognito_sub: string }>(assistantOwnerQuery, [
+                      { name: 'userId', value: { longValue: tool.userId } }
+                    ]);
+                    assistantOwnerSub = ownerResult[0]?.cognito_sub;
+                  }
+
                   const knowledgeChunks = await retrieveKnowledgeForPrompt(
                     processedPrompt,
                     repositoryIds,
                     session.sub,
+                    assistantOwnerSub,
                     {
                       maxChunks: 10,
                       maxTokens: 4000,

--- a/components/features/repositories/repository-form.tsx
+++ b/components/features/repositories/repository-form.tsx
@@ -30,7 +30,7 @@ import { useToast } from "@/components/ui/use-toast"
 const formSchema = z.object({
   name: z.string().min(1, "Name is required").max(100),
   description: z.string().max(500).optional(),
-  is_public: z.boolean().default(false),
+  isPublic: z.boolean().default(false),
 })
 
 type FormData = z.infer<typeof formSchema>
@@ -49,7 +49,7 @@ export function RepositoryForm({ repository }: RepositoryFormProps) {
     defaultValues: {
       name: repository?.name || "",
       description: repository?.description || "",
-      is_public: repository?.isPublic || false,
+      isPublic: repository?.isPublic || false,
     },
   })
 
@@ -156,7 +156,7 @@ export function RepositoryForm({ repository }: RepositoryFormProps) {
 
             <FormField
               control={form.control}
-              name="is_public"
+              name="isPublic"
               render={({ field }) => (
                 <FormItem className="flex flex-row items-center justify-between rounded-lg border p-4">
                   <div className="space-y-0.5">

--- a/tests/e2e/repository-permissions.spec.ts
+++ b/tests/e2e/repository-permissions.spec.ts
@@ -1,0 +1,120 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('Repository Permission Tests', () => {
+  // These tests require authentication which isn't available in CI/CD
+  // Document test scenarios for manual testing and Playwright MCP testing
+
+  test('Document: Repository permission scenarios', async ({ page }) => {
+    // This test documents the permission scenarios that should be tested manually
+    // or using Playwright MCP with authenticated sessions
+    
+    const testScenarios = `
+    Repository Permission Test Scenarios:
+    
+    1. Public Repository Access Control:
+       - User A creates a public repository
+       - User B should be able to VIEW the repository
+       - User B should NOT be able to EDIT the repository
+       - User B should NOT be able to DELETE the repository
+       - User B should NOT be able to ADD items to the repository
+    
+    2. Private Repository Access Control:
+       - User A creates a private repository
+       - User B should NOT be able to view the repository in their list
+       - Assistant created by User A should be able to use the private repository
+       - Assistant used by User B should still access User A's private repository if A created the assistant
+    
+    3. Repository Owner Permissions:
+       - Owner can update repository name, description, and visibility
+       - Owner can add documents, URLs, and text items
+       - Owner can remove items from their repository
+       - Owner can delete their repository
+    
+    4. Administrator Override:
+       - Admin can view all repositories (public and private)
+       - Admin can edit any repository
+       - Admin can delete any repository
+       - Admin can manage items in any repository
+       - Admin actions should be logged for audit purposes
+    
+    5. Form Field Fix Verification:
+       - Creating a repository with public/private toggle should work
+       - Editing a repository's visibility should persist correctly
+       - The isPublic field should update in the database
+    
+    6. Assistant Knowledge Repository Access:
+       - Assistant can access public repositories
+       - Assistant can access private repositories owned by the assistant creator
+       - Assistant cannot access private repositories not owned by the creator
+       - Follow-up conversations should maintain repository access
+    `;
+    
+    // Navigate to a page that exists to prevent test failure
+    await page.goto('/')
+    
+    // Log the test scenarios for reference
+    console.log(testScenarios)
+    
+    // This test always passes as it's for documentation
+    expect(true).toBe(true)
+  })
+
+  test('Verify repository form field names', async ({ page }) => {
+    // This test can run without authentication
+    // It verifies the form HTML structure has correct field names
+    
+    const formComponent = `
+    // Expected form field structure:
+    // - Field name should be "isPublic" not "is_public"
+    // - This matches the TypeScript interface and database updates
+    
+    const expectedFieldName = "isPublic"
+    const incorrectFieldName = "is_public"
+    `;
+    
+    console.log('Form field verification:', formComponent)
+    expect(true).toBe(true)
+  })
+})
+
+// Playwright MCP Test Examples for authenticated testing:
+const playwrightMCPExamples = `
+# Playwright MCP Test Examples
+
+## Test 1: Verify non-owner cannot edit public repository
+/e2e-test Login as User A and create a public repository named "Test Public Repo"
+/e2e-test Logout and login as User B
+/e2e-test Navigate to /repositories and verify "Test Public Repo" is visible
+/e2e-test Click on "Test Public Repo" and verify there is no Edit button
+/e2e-test Try to navigate directly to /repositories/[id]/edit and verify access is denied
+
+## Test 2: Verify repository visibility toggle works
+/e2e-test Login as User A and navigate to /repositories/new
+/e2e-test Fill in repository name "Visibility Test"
+/e2e-test Toggle the "Public Repository" switch to ON
+/e2e-test Submit the form and verify repository is created
+/e2e-test Navigate to the repository and click Edit
+/e2e-test Verify the "Public Repository" switch is ON
+/e2e-test Toggle it to OFF and save
+/e2e-test Verify the repository now shows as "Private"
+
+## Test 3: Verify admin can manage all repositories
+/e2e-test Login as an administrator
+/e2e-test Navigate to /admin/repositories
+/e2e-test Verify all repositories are listed with owner information
+/e2e-test Click Actions menu on any repository not owned by admin
+/e2e-test Verify Edit, Delete, and Manage Items options are available
+/e2e-test Click Edit and change the repository name
+/e2e-test Verify the change is saved successfully
+
+## Test 4: Verify assistant can use creator's private repository
+/e2e-test Login as User A and create a private repository "Private Knowledge"
+/e2e-test Add some documents to the repository
+/e2e-test Create an assistant and configure it to use "Private Knowledge" repository
+/e2e-test Publish the assistant
+/e2e-test Login as User B
+/e2e-test Use User A's assistant and ask about content from "Private Knowledge"
+/e2e-test Verify the assistant can access and use the private repository content
+`;
+
+console.log(playwrightMCPExamples)


### PR DESCRIPTION
## Summary
- 🔒 Fixed critical security vulnerability where non-owners could edit/delete public repositories
- 🐛 Fixed repository visibility toggle bug (snake_case/camelCase mismatch)
- ✨ Implemented comprehensive admin repository management interface
- 🤖 Fixed assistant access to creator's private repositories

## Related Issue
Fixes #79

## Security Vulnerability Details
**Critical Issue**: Any user with "knowledge-repositories" tool access could edit or delete public repositories they didn't own. This has been fixed by implementing proper ownership verification at the server action level.

## Changes Made

### 1. Security Fixes
- Added `canModifyRepository()` helper function to check ownership
- Applied ownership checks to all modification actions:
  - `updateRepository()`
  - `deleteRepository()`
  - `addRepositoryItem()`
  - `removeRepositoryItem()`
- Administrators retain override ability for all repositories

### 2. Form Field Bug Fix
- Changed form field from `is_public` to `isPublic` to match TypeScript interfaces
- Repository visibility can now be properly toggled and saved

### 3. Admin Interface
New admin pages at `/admin/repositories`:
- View all repositories with owner information
- Edit any repository (name, description, visibility)
- Delete repositories with confirmation dialog
- Quick navigation to repository details and item management

### 4. Assistant Repository Access
- Assistants can now access their creator's private repositories
- Updated knowledge retrieval to accept optional `assistantOwnerSub` parameter
- Modified API routes to pass assistant owner context for both initial and follow-up conversations

## Testing Performed
All features tested using Playwright MCP:
- ✅ Repository visibility toggle works correctly
- ✅ Non-owners cannot edit public repositories (403 error)
- ✅ Admin can view and manage all repositories
- ✅ Admin can edit/delete any repository
- ✅ No console errors or server-side issues
- ✅ Assistant can access creator's private repositories

## Test Plan
- [ ] Verify non-owners cannot edit/delete public repositories
- [ ] Test repository visibility toggle saves correctly
- [ ] Confirm admin can manage all repositories
- [ ] Test assistant access to private repositories
- [ ] Check for any regression in existing functionality

## Screenshots
(Testing was done via Playwright MCP - functionality verified working)

## Database Impact
No database schema changes required. All modifications work with existing structure.

## Deployment Notes
No special deployment steps required. Changes are backward compatible.