### PR TITLE
Fix authentication flow issues: double sign-in, nonce validation, and redundant UI elements

### DIFF
--- a/app/(public)/page.tsx
+++ b/app/(public)/page.tsx
@@ -3,10 +3,9 @@
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import Image from "next/image";
-import { useSession } from "next-auth/react";
+import { useSession, signIn } from "next-auth/react";
 import { useEffect, Suspense } from "react";
 import { useRouter } from "next/navigation";
-import Link from "next/link";
 
 function LandingPageContent() {
   const router = useRouter();
@@ -15,7 +14,11 @@ function LandingPageContent() {
   // Get callbackUrl from query params if present
   const searchParams = new URLSearchParams(typeof window !== 'undefined' ? window.location.search : '');
   const callbackUrl = searchParams.get('callbackUrl') || '/dashboard';
-  const signInUrl = `/api/auth/signin?callbackUrl=${encodeURIComponent(callbackUrl)}`;
+  
+  const handleSignIn = () => {
+    // Use signIn function to skip the intermediate page
+    signIn('cognito', { callbackUrl });
+  };
 
   useEffect(() => {
     // Only redirect to dashboard if truly authenticated
@@ -59,17 +62,13 @@ function LandingPageContent() {
             <p className="text-center mb-6 text-muted-foreground">
               Your creative space for building, exploring, and innovating with AI in education.
             </p>
-            <Link 
-              href={signInUrl}
-              className="w-full"
+            <Button
+              className="w-full bg-sky-600 hover:bg-sky-700 text-white shadow-lg"
+              size="lg"
+              onClick={handleSignIn}
             >
-              <Button
-                className="w-full bg-sky-600 hover:bg-sky-700 text-white shadow-lg"
-                size="lg"
-              >
-                Sign In with Cognito
-              </Button>
-            </Link>
+              Sign In
+            </Button>
           </CardContent>
         </Card>
       </div>

--- a/auth.ts
+++ b/auth.ts
@@ -5,6 +5,7 @@ import type { NextAuthConfig } from "next-auth"
 export const authConfig: NextAuthConfig = {
   providers: [
     Cognito({
+      name: "AI Studio",
       clientId: process.env.AUTH_COGNITO_CLIENT_ID!,
       clientSecret: process.env.AUTH_COGNITO_CLIENT_SECRET || "",
       issuer: process.env.AUTH_COGNITO_ISSUER!,
@@ -20,7 +21,7 @@ export const authConfig: NextAuthConfig = {
       client: {
         token_endpoint_auth_method: "none",
       },
-      checks: ["pkce", "state"], // Enable PKCE and state checks (CSRF protection)
+      checks: ["pkce", "state", "nonce"], // Enable PKCE, state and nonce checks (CSRF protection)
       profile(profile) {
         return {
           id: profile.sub,

--- a/components/user/user-button.tsx
+++ b/components/user/user-button.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useSession, signIn } from 'next-auth/react';
+import { useSession } from 'next-auth/react';
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
 import { useRouter } from "next/navigation";
@@ -19,11 +19,7 @@ export function UserButton() {
   }
 
   if (!session) {
-    return (
-      <Button size="sm" variant="outline" onClick={() => signIn('cognito')}>
-        Sign in
-      </Button>
-    );
+    return null;
   }
 
   // Extract first name from user info

--- a/tests/e2e/working-tests.spec.ts
+++ b/tests/e2e/working-tests.spec.ts
@@ -26,6 +26,18 @@ describeOrSkip('Public Pages', () => {
     await expect(welcomeHeading.or(loadingText)).toBeVisible();
   });
 
+  test('should display only one sign-in button when not authenticated', async ({ page }) => {
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+    
+    // Check that there's only one "Sign In" button on the page
+    const signInButtons = page.getByRole('button', { name: /Sign In/i });
+    await expect(signInButtons).toHaveCount(1);
+    
+    // Verify the button text is "Sign In" (not "Sign In with Cognito")
+    await expect(signInButtons).toHaveText('Sign In');
+  });
+
   test('should protect routes from unauthenticated access', async ({ page }) => {
     const protectedRoutes = ['/dashboard', '/chat', '/admin/users', '/compare', '/repositories'];
     
@@ -35,9 +47,23 @@ describeOrSkip('Public Pages', () => {
     }
   });
 
-  test('should show sign in page', async ({ page }) => {
-    await page.goto('/api/auth/signin');
-    await expect(page.getByRole('button', { name: 'Sign in with Cognito' })).toBeVisible();
+  test('should trigger sign in when clicking the button', async ({ page }) => {
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+    
+    // Click the sign in button
+    const signInButton = page.getByRole('button', { name: 'Sign In' });
+    
+    // Verify the button exists and is clickable
+    await expect(signInButton).toBeVisible();
+    await expect(signInButton).toBeEnabled();
+    
+    // Click will trigger signIn('cognito') function
+    await signInButton.click();
+    
+    // Should navigate away from home page (to Cognito)
+    await page.waitForTimeout(1000);
+    expect(page.url()).not.toBe('http://localhost:3000/');
   });
 });
 


### PR DESCRIPTION
## Summary
This PR fixes three critical authentication flow issues that were degrading user experience:
- ✅ Eliminates double sign-in requirement 
- ✅ Fixes nonce validation error
- ✅ Removes redundant sign-in buttons

## Problem
Users experienced a frustrating authentication flow where they had to:
1. Click "Sign In with Cognito" on the landing page
2. Click "Sign In with Cognito" again on NextAuth's default page
3. Often encounter a "Configuration" error due to nonce validation issues
4. See confusing duplicate sign-in buttons in header and main content

## Solution
- **Direct Authentication**: Modified landing page to use `signIn('cognito')` function, bypassing NextAuth's intermediate page
- **Nonce Fix**: Added 'nonce' to checks array in Cognito provider configuration
- **UI Cleanup**: UserButton returns null when not authenticated, showing only one sign-in button
- **Better Branding**: Customized provider name to show "AI Studio" instead of "Cognito"

## Testing
- [x] Fresh session authentication works on first attempt
- [x] Existing session re-authentication works without nonce errors  
- [x] Sign-out and immediate sign-in works correctly
- [x] Protected routes properly redirect to authentication
- [x] Only one sign-in button visible when not authenticated
- [x] ESLint and TypeScript checks pass

## Screenshots
Before: Users saw "Sign in with Cognito" and had to click twice
After: Users see "Sign In" and authenticate with a single click

Fixes #95

## References
- Related NextAuth issue: https://github.com/nextauthjs/next-auth/discussions/3551
- Original request: User feedback via Claude Code /issue command