### PR TITLE
fix: resolve timestamp casting error in AI model updates

### DIFF
--- a/lib/db/data-api-adapter.ts
+++ b/lib/db/data-api-adapter.ts
@@ -845,6 +845,8 @@ export async function updateAIModel(id: number, updates: AIModelUpdateFields) {
   
   // Fields that need JSONB casting
   const jsonbFields = ['capabilities', 'allowed_roles', 'nexus_capabilities', 'provider_metadata'];
+  // Fields that need timestamp casting
+  const timestampFields = ['pricing_updated_at'];
   
   const updateFields = Object.keys(snakeCaseUpdates)
     .filter(key => key !== 'id')
@@ -852,6 +854,10 @@ export async function updateAIModel(id: number, updates: AIModelUpdateFields) {
       // Cast to JSONB for JSON fields
       if (jsonbFields.includes(key) && snakeCaseUpdates[key] !== null) {
         return `${key} = :param${index}::jsonb`;
+      }
+      // Cast to timestamp for timestamp fields
+      if (timestampFields.includes(key) && snakeCaseUpdates[key] !== null) {
+        return `${key} = :param${index}::timestamp`;
       }
       return `${key} = :param${index}`;
     });


### PR DESCRIPTION
## Summary
- Fixes PostgreSQL timestamp casting error when updating AI models in /admin/models
- Resolves 500 error: "column pricing_updated_at is of type timestamp without time zone but expression is of type text"

## Changes
- Added proper timestamp casting support to `updateAIModel` function in `data-api-adapter.ts`
- Defined `timestampFields` array to specify fields requiring `::timestamp` SQL casting
- Modified updateFields mapping to handle timestamp fields alongside existing JSONB casting

## Test Results
✅ **npm run lint**: No ESLint warnings or errors  
✅ **npm run typecheck**: TypeScript compilation successful  
✅ **npm run build**: Production build completed successfully

## Impact
- Model updates in admin interface now work correctly
- Proper type safety for timestamp fields in database operations
- Maintains backward compatibility with existing functionality

This is a critical bugfix for the AI model management system.