### PR TITLE
feat: #172 - Fix Nexus ThreadList to show conversation titles

### DIFF
--- a/app/(protected)/nexus/_components/conversation-panel.tsx
+++ b/app/(protected)/nexus/_components/conversation-panel.tsx
@@ -3,7 +3,7 @@
 import { useState } from 'react'
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@/components/ui/sheet'
 import { Drawer, DrawerContent, DrawerHeader, DrawerTitle } from '@/components/ui/drawer'
-import { ThreadList } from '@/components/assistant-ui/thread-list'
+import { NexusThreadList } from '@/components/assistant-ui/nexus-thread-list'
 import { useMediaQuery } from '@/lib/hooks/use-media-query'
 import { Button } from '@/components/ui/button'
 import { PanelRightOpen, PanelRightClose } from 'lucide-react'
@@ -36,7 +36,7 @@ export function ConversationPanel() {
             </DrawerHeader>
             
             <div className="flex-1 overflow-auto px-4 pb-4">
-              <ThreadList />
+              <NexusThreadList />
             </div>
           </DrawerContent>
         </Drawer>
@@ -65,7 +65,7 @@ export function ConversationPanel() {
           </SheetHeader>
           
           <div className="flex-1 overflow-auto mt-4">
-            <ThreadList />
+            <NexusThreadList />
           </div>
         </SheetContent>
       </Sheet>

--- a/components/assistant-ui/nexus-thread-list.tsx
+++ b/components/assistant-ui/nexus-thread-list.tsx
@@ -1,0 +1,74 @@
+import type { FC } from "react";
+import {
+  ThreadListItemPrimitive,
+  ThreadListPrimitive,
+  useThreadListItem
+} from "@assistant-ui/react";
+import { ArchiveIcon, PlusIcon } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { TooltipIconButton } from "@/components/assistant-ui/tooltip-icon-button";
+import { useThreadTitles } from "@/lib/nexus/use-thread-titles";
+
+export const NexusThreadList: FC = () => {
+  return (
+    <ThreadListPrimitive.Root className="text-foreground flex flex-col items-stretch gap-1.5">
+      <ThreadListNew />
+      <ThreadListItems />
+    </ThreadListPrimitive.Root>
+  );
+};
+
+const ThreadListNew: FC = () => {
+  return (
+    <ThreadListPrimitive.New asChild>
+      <Button className="data-active:bg-muted hover:bg-muted flex items-center justify-start gap-1 rounded-lg px-2.5 py-2 text-start" variant="ghost">
+        <PlusIcon />
+        New Thread
+      </Button>
+    </ThreadListPrimitive.New>
+  );
+};
+
+const ThreadListItems: FC = () => {
+  return <ThreadListPrimitive.Items components={{ ThreadListItem: NexusThreadListItem }} />;
+};
+
+const NexusThreadListItem: FC = () => {
+  return (
+    <ThreadListItemPrimitive.Root className="data-active:bg-muted hover:bg-muted focus-visible:bg-muted focus-visible:ring-ring flex items-center gap-2 rounded-lg transition-all focus-visible:outline-none focus-visible:ring-2">
+      <ThreadListItemPrimitive.Trigger className="flex-grow px-3 py-2 text-start">
+        <NexusThreadListItemTitle />
+      </ThreadListItemPrimitive.Trigger>
+      <ThreadListItemArchive />
+    </ThreadListItemPrimitive.Root>
+  );
+};
+
+const NexusThreadListItemTitle: FC = () => {
+  const threadItem = useThreadListItem();
+  const { getThreadTitle } = useThreadTitles();
+  
+  // Get the actual title from database, fallback to default
+  const title = getThreadTitle(threadItem.id);
+  
+  return (
+    <p className="text-sm">
+      {title}
+    </p>
+  );
+};
+
+const ThreadListItemArchive: FC = () => {
+  return (
+    <ThreadListItemPrimitive.Archive asChild>
+      <TooltipIconButton
+        className="hover:text-foreground/60 text-foreground ml-auto mr-1 size-4 p-4"
+        variant="ghost"
+        tooltip="Archive thread"
+      >
+        <ArchiveIcon />
+      </TooltipIconButton>
+    </ThreadListItemPrimitive.Archive>
+  );
+};

--- a/components/assistant-ui/nexus-thread-list.tsx
+++ b/components/assistant-ui/nexus-thread-list.tsx
@@ -11,10 +11,13 @@ import { TooltipIconButton } from "@/components/assistant-ui/tooltip-icon-button
 import { useThreadTitles } from "@/lib/nexus/use-thread-titles";
 
 export const NexusThreadList: FC = () => {
+  // Initialize the hook at the top level to ensure it always runs
+  const { getThreadTitle } = useThreadTitles();
+  
   return (
     <ThreadListPrimitive.Root className="text-foreground flex flex-col items-stretch gap-1.5">
       <ThreadListNew />
-      <ThreadListItems />
+      <ThreadListItems getThreadTitle={getThreadTitle} />
     </ThreadListPrimitive.Root>
   );
 };
@@ -30,24 +33,23 @@ const ThreadListNew: FC = () => {
   );
 };
 
-const ThreadListItems: FC = () => {
-  return <ThreadListPrimitive.Items components={{ ThreadListItem: NexusThreadListItem }} />;
+const ThreadListItems: FC<{ getThreadTitle: (id: string) => string }> = ({ getThreadTitle }) => {
+  return <ThreadListPrimitive.Items components={{ ThreadListItem: (props) => <NexusThreadListItem {...props} getThreadTitle={getThreadTitle} /> }} />;
 };
 
-const NexusThreadListItem: FC = () => {
+const NexusThreadListItem: FC<{ getThreadTitle: (id: string) => string }> = ({ getThreadTitle }) => {
   return (
     <ThreadListItemPrimitive.Root className="data-active:bg-muted hover:bg-muted focus-visible:bg-muted focus-visible:ring-ring flex items-center gap-2 rounded-lg transition-all focus-visible:outline-none focus-visible:ring-2">
       <ThreadListItemPrimitive.Trigger className="flex-grow px-3 py-2 text-start">
-        <NexusThreadListItemTitle />
+        <NexusThreadListItemTitle getThreadTitle={getThreadTitle} />
       </ThreadListItemPrimitive.Trigger>
       <ThreadListItemArchive />
     </ThreadListItemPrimitive.Root>
   );
 };
 
-const NexusThreadListItemTitle: FC = () => {
+const NexusThreadListItemTitle: FC<{ getThreadTitle: (id: string) => string }> = ({ getThreadTitle }) => {
   const threadItem = useThreadListItem();
-  const { getThreadTitle } = useThreadTitles();
   
   // Get the actual title from database, fallback to default
   const title = getThreadTitle(threadItem.id);

--- a/lib/nexus/use-thread-titles.ts
+++ b/lib/nexus/use-thread-titles.ts
@@ -1,0 +1,69 @@
+'use client'
+
+import { useState, useEffect, useCallback } from 'react';
+import { useThreadList } from '@assistant-ui/react';
+import { createLogger } from '@/lib/client-logger';
+
+const log = createLogger({ moduleName: 'use-thread-titles' });
+
+interface ThreadTitles {
+  [threadId: string]: string;
+}
+
+/**
+ * Hook to sync thread titles from database with runtime threads
+ */
+export function useThreadTitles() {
+  const threadList = useThreadList();
+  const [titles, setTitles] = useState<ThreadTitles>({});
+  const [isLoading, setIsLoading] = useState(false);
+  
+  // Fetch titles from database
+  const fetchTitles = useCallback(async () => {
+    if (!threadList?.threads?.length) return;
+    
+    try {
+      setIsLoading(true);
+      const response = await fetch('/api/nexus/conversations');
+      
+      if (!response.ok) {
+        throw new Error(`Failed to fetch conversations: ${response.statusText}`);
+      }
+      
+      const data = await response.json();
+      const newTitles: ThreadTitles = {};
+      
+      // Map conversation IDs to titles
+      data.conversations?.forEach((conv: { id: string; title: string }) => {
+        newTitles[conv.id] = conv.title;
+      });
+      
+      setTitles(newTitles);
+      log.info('Thread titles synced', { count: Object.keys(newTitles).length });
+      
+    } catch (error) {
+      log.error('Failed to fetch thread titles', { 
+        error: error instanceof Error ? error.message : String(error) 
+      });
+    } finally {
+      setIsLoading(false);
+    }
+  }, [threadList?.threads?.length]);
+  
+  // Sync titles when threads change
+  useEffect(() => {
+    fetchTitles();
+  }, [fetchTitles]);
+  
+  // Get title for a specific thread
+  const getThreadTitle = useCallback((threadId: string) => {
+    return titles[threadId] || 'New Chat';
+  }, [titles]);
+  
+  return {
+    titles,
+    isLoading,
+    getThreadTitle,
+    refreshTitles: fetchTitles
+  };
+}

--- a/lib/nexus/use-thread-titles.ts
+++ b/lib/nexus/use-thread-titles.ts
@@ -20,10 +20,10 @@ export function useThreadTitles() {
   
   // Fetch titles from database
   const fetchTitles = useCallback(async () => {
-    if (!threadList?.threads?.length) return;
-    
     try {
       setIsLoading(true);
+      log.info('Fetching conversation titles from API');
+      
       const response = await fetch('/api/nexus/conversations');
       
       if (!response.ok) {
@@ -31,6 +31,12 @@ export function useThreadTitles() {
       }
       
       const data = await response.json();
+      log.info('API response received', { 
+        hasConversations: !!data.conversations, 
+        conversationCount: data.conversations?.length || 0,
+        sampleData: data.conversations?.slice(0, 2)
+      });
+      
       const newTitles: ThreadTitles = {};
       
       // Map conversation IDs to titles
@@ -48,7 +54,7 @@ export function useThreadTitles() {
     } finally {
       setIsLoading(false);
     }
-  }, [threadList?.threads?.length]);
+  }, []);
   
   // Sync titles when threads change
   useEffect(() => {


### PR DESCRIPTION
## Description
Implements solution for #172 - Nexus ThreadList now shows actual conversation titles instead of generic "New Chat" for all conversations.

## Changes
- **Created `useThreadTitles` hook**: Syncs conversation titles from database with runtime threads
- **Implemented `NexusThreadList` component**: Enhanced ThreadList that displays actual conversation titles
- **Updated ConversationPanel**: Replaced generic ThreadList with NexusThreadList
- **Preserved existing architecture**: Kept original transport and runtime intact for minimal disruption

## Technical Implementation
- Uses existing `/api/nexus/conversations` endpoint to fetch conversation titles
- Titles are synced from `nexus_conversations` table where they're generated from first user message
- Fallback to "New Chat" when titles are unavailable or loading
- No changes to core runtime or transport logic

## Testing
- [x] TypeScript compilation passes
- [x] ESLint passes
- [x] Component renders without errors
- [x] Titles load from database correctly
- [x] Fallback behavior works as expected

## Impact
- **User Experience**: Users now see meaningful conversation titles instead of generic "New Chat"
- **Performance**: Minimal - single API call to load titles on mount
- **Compatibility**: Full backward compatibility maintained

## Type of Change
- [x] New feature (non-breaking change that adds functionality)
- [x] Bug fix (non-breaking change that fixes an issue)

Closes #172