### PR TITLE
Fix Nexus runtime remounting and implement URL-based conversation loading

### DIFF
--- a/app/(protected)/nexus/_components/conversation-panel.tsx
+++ b/app/(protected)/nexus/_components/conversation-panel.tsx
@@ -9,11 +9,10 @@ import { Button } from '@/components/ui/button'
 import { PanelRightOpen, PanelRightClose } from 'lucide-react'
 
 interface ConversationPanelProps {
-  onConversationSelect?: (conversationId: string | null) => void
   selectedConversationId?: string | null
 }
 
-export function ConversationPanel({ onConversationSelect, selectedConversationId }: ConversationPanelProps) {
+export function ConversationPanel({ selectedConversationId }: ConversationPanelProps) {
   const [isOpen, setIsOpen] = useState(false)
   const isMobile = useMediaQuery('(max-width: 640px)')
 
@@ -42,7 +41,6 @@ export function ConversationPanel({ onConversationSelect, selectedConversationId
             
             <div className="flex-1 overflow-y-auto px-4 pb-4 max-h-[calc(80vh-6rem)]">
               <ConversationList 
-                onConversationSelect={onConversationSelect}
                 selectedConversationId={selectedConversationId}
               />
             </div>
@@ -74,7 +72,6 @@ export function ConversationPanel({ onConversationSelect, selectedConversationId
           
           <div className="flex-1 overflow-y-auto mt-4 max-h-[calc(100vh-8rem)]">
             <ConversationList 
-              onConversationSelect={onConversationSelect}
               selectedConversationId={selectedConversationId}
             />
           </div>

--- a/app/(protected)/nexus/_components/layout/nexus-header.tsx
+++ b/app/(protected)/nexus/_components/layout/nexus-header.tsx
@@ -5,6 +5,7 @@ import { ModelSelector } from '@/components/features/model-selector'
 import { CompactToolSelector } from '../tools/compact-tool-selector'
 import { Button } from '@/components/ui/button'
 import { Plus } from 'lucide-react'
+import { navigateToNewConversation } from '@/lib/nexus/conversation-navigation'
 import type { SelectAiModel } from '@/types'
 
 interface NexusHeaderProps {
@@ -49,7 +50,7 @@ export function NexusHeader({
           <Button
             variant="outline"
             size="sm"
-            onClick={() => window.location.href = '/nexus'}
+            onClick={() => navigateToNewConversation()}
             className="flex items-center gap-1.5"
             title="Start new chat"
           >

--- a/app/(protected)/nexus/_components/layout/nexus-header.tsx
+++ b/app/(protected)/nexus/_components/layout/nexus-header.tsx
@@ -45,11 +45,11 @@ export function NexusHeader({
           </div>
         </div>
         <div className="flex items-center gap-2">
-          {/* New Chat Button - Not graceful but works like model selector */}
+          {/* New Chat Button - Full page reload to reset conversation */}
           <Button
             variant="outline"
             size="sm"
-            onClick={() => window.location.reload()}
+            onClick={() => window.location.href = '/nexus'}
             className="flex items-center gap-1.5"
             title="Start new chat"
           >

--- a/app/(protected)/nexus/page.tsx
+++ b/app/(protected)/nexus/page.tsx
@@ -1,9 +1,9 @@
 'use client'
 
-import { AssistantRuntimeProvider, useLocalRuntime } from '@assistant-ui/react'
+import { AssistantRuntimeProvider, useLocalRuntime, type ChatModelAdapter, type AttachmentAdapter } from '@assistant-ui/react'
 import { Thread } from '@/components/assistant-ui/thread'
 import { useSession } from 'next-auth/react'
-import { useRouter } from 'next/navigation'
+import { useRouter, useSearchParams } from 'next/navigation'
 import { useEffect, useMemo, useCallback, useState, useRef } from 'react'
 import { NexusShell } from './_components/layout/nexus-shell'
 import { ErrorBoundary } from './_components/error-boundary'
@@ -19,9 +19,51 @@ import { createLogger } from '@/lib/client-logger'
 
 const log = createLogger({ moduleName: 'nexus-page' })
 
+// Stable ConversationRuntime component - no remounting when conversationId changes
+interface ConversationRuntimeProviderProps {
+  children: React.ReactNode
+  conversationId: string | null
+  pollingAdapter: ChatModelAdapter | null
+  fallbackAdapter: ChatModelAdapter
+  attachmentAdapter: AttachmentAdapter
+}
+
+function ConversationRuntimeProvider({ 
+  children, 
+  conversationId,
+  pollingAdapter,
+  fallbackAdapter,
+  attachmentAdapter 
+}: ConversationRuntimeProviderProps) {
+  const historyAdapter = useMemo(
+    () => createNexusHistoryAdapter(conversationId),
+    [conversationId]
+  )
+  
+  const runtime = useLocalRuntime(
+    pollingAdapter || fallbackAdapter,
+    {
+      adapters: {
+        attachments: attachmentAdapter,
+        history: historyAdapter,
+      },
+    }
+  )
+  
+  return (
+    <AssistantRuntimeProvider runtime={runtime}>
+      {children}
+    </AssistantRuntimeProvider>
+  )
+}
+
 export default function NexusPage() {
   const router = useRouter()
+  const searchParams = useSearchParams()
   const { data: session, status: sessionStatus } = useSession()
+  
+  // Get conversation ID from URL parameter
+  const urlConversationId = searchParams.get('id')
   
   // Load models and manage model selection
   const { 
@@ -38,8 +80,8 @@ export default function NexusPage() {
   // Attachment processing state
   const [processingAttachments, setProcessingAttachments] = useState<Set<string>>(new Set())
   
-  // Conversation continuity state
-  const [conversationId, setConversationId] = useState<string | null>(null)
+  // Conversation continuity state - initialize from URL parameter
+  const [conversationId, setConversationId] = useState<string | null>(urlConversationId)
   
   
   // Conversation context for history adapter
@@ -92,20 +134,17 @@ export default function NexusPage() {
   const handleConversationIdChange = useCallback((newConversationId: string) => {
     setConversationId(newConversationId)
     conversationContext.setConversationId(newConversationId)
+    
+    // Update URL to reflect the current conversation
+    const newUrl = `/nexus?id=${newConversationId}`
+    router.push(newUrl, { scroll: false })
+    
     log.debug('Conversation ID updated', { 
       previousId: conversationId, 
-      newId: newConversationId 
+      newId: newConversationId,
+      newUrl
     })
-  }, [conversationId, conversationContext])
-  
-  // Handle conversation selection from conversation list
-  const handleConversationSelect = useCallback((selectedConversationId: string | null) => {
-    setConversationId(selectedConversationId)
-    conversationContext.setConversationId(selectedConversationId)
-    log.debug('Conversation selected from list', { 
-      conversationId: selectedConversationId 
-    })
-  }, [conversationContext])
+  }, [conversationId, conversationContext, router])
   
   // Authentication verification for defense in depth
   useEffect(() => {
@@ -155,29 +194,6 @@ export default function NexusPage() {
     })
   }, [handleAttachmentProcessingStart, handleAttachmentProcessingComplete])
 
-  // Create a component that remounts when conversation changes
-  const ConversationRuntime = useMemo(() => {
-    // This component will be recreated when conversationId changes
-    return function ConversationRuntimeComponent({ children }: { children: React.ReactNode }) {
-      const historyAdapter = createNexusHistoryAdapter(conversationId)
-      
-      const runtime = useLocalRuntime(
-        pollingAdapter || fallbackAdapter,
-        {
-          adapters: {
-            attachments: attachmentAdapter,
-            history: historyAdapter,
-          },
-        }
-      )
-      
-      return (
-        <AssistantRuntimeProvider runtime={runtime}>
-          {children}
-        </AssistantRuntimeProvider>
-      )
-    }
-  }, [conversationId, pollingAdapter, fallbackAdapter, attachmentAdapter])
 
   
   // Show loading state while checking authentication
@@ -209,19 +225,23 @@ export default function NexusPage() {
       >
         <div className="relative h-full">
           {selectedModel ? (
-            <ConversationRuntime>
+            <ConversationRuntimeProvider
+              conversationId={conversationId}
+              pollingAdapter={pollingAdapter}
+              fallbackAdapter={fallbackAdapter}
+              attachmentAdapter={attachmentAdapter}
+            >
               {/* Register tool UI components */}
               <WebSearchUI />
               <CodeInterpreterUI />
               
               <div className="flex h-full flex-col">
-                <Thread processingAttachments={processingAttachments} />
+                <Thread processingAttachments={processingAttachments} conversationId={conversationId} />
               </div>
               <ConversationPanel 
-                onConversationSelect={handleConversationSelect}
                 selectedConversationId={conversationId}
               />
-            </ConversationRuntime>
+            </ConversationRuntimeProvider>
           ) : (
             <div className="flex h-full items-center justify-center">
               <div className="text-center">

--- a/components/assistant-ui/thread.tsx
+++ b/components/assistant-ui/thread.tsx
@@ -34,9 +34,10 @@ import {
 
 interface ThreadProps {
   processingAttachments?: Set<string>;
+  conversationId?: string | null;
 }
 
-export const Thread: FC<ThreadProps> = ({ processingAttachments }) => {
+export const Thread: FC<ThreadProps> = ({ processingAttachments, conversationId }) => {
   return (
     <ThreadPrimitive.Root
       className="bg-white flex h-full flex-col"
@@ -46,7 +47,7 @@ export const Thread: FC<ThreadProps> = ({ processingAttachments }) => {
       }}
     >
       <ThreadPrimitive.Viewport className="relative flex min-w-0 flex-1 flex-col gap-6 overflow-y-scroll">
-        <ThreadWelcome />
+        <ThreadWelcome conversationId={conversationId} />
 
         <ThreadPrimitive.Messages
           components={{
@@ -80,8 +81,24 @@ const ThreadScrollToBottom: FC = () => {
   );
 };
 
-const ThreadWelcome: FC = () => {
+const ThreadWelcome: FC<{ conversationId?: string | null }> = ({ conversationId }) => {
   const { data: session } = useSession();
+  
+  // If we have a conversationId (loading existing conversation), show loading state
+  if (conversationId) {
+    return (
+      <ThreadPrimitive.Empty>
+        <div className="mx-auto flex w-full max-w-[var(--thread-max-width)] flex-grow flex-col px-[var(--thread-padding-x)]">
+          <div className="flex w-full flex-grow flex-col items-center justify-center">
+            <div className="flex items-center space-x-2">
+              <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-primary" />
+              <span className="text-muted-foreground">Loading conversation...</span>
+            </div>
+          </div>
+        </div>
+      </ThreadPrimitive.Empty>
+    );
+  }
   
   // Extract user name with fallback
   const getUserName = () => {

--- a/components/nexus/conversation-list.tsx
+++ b/components/nexus/conversation-list.tsx
@@ -67,12 +67,13 @@ export function ConversationList({ selectedConversationId }: ConversationListPro
       
       // Validate conversation data structure
       const validConversations = loadedConversations.filter((conv: unknown): conv is ConversationItem => {
-        return conv && 
+        return Boolean(conv) && 
                typeof conv === 'object' && 
+               conv !== null &&
                'id' in conv && 
                'title' in conv &&
-               typeof conv.id === 'string' && 
-               typeof conv.title === 'string'
+               typeof (conv as Record<string, unknown>).id === 'string' && 
+               typeof (conv as Record<string, unknown>).title === 'string'
       })
       
       if (validConversations.length !== loadedConversations.length) {

--- a/lib/nexus/conversation-navigation.ts
+++ b/lib/nexus/conversation-navigation.ts
@@ -1,0 +1,52 @@
+/**
+ * Utility functions for secure conversation navigation and validation
+ */
+
+import { createLogger } from '@/lib/client-logger'
+
+const log = createLogger({ moduleName: 'conversation-navigation' })
+
+/**
+ * Validates a conversation ID format
+ * @param conversationId - The conversation ID to validate
+ * @returns true if the conversation ID is valid, false otherwise
+ */
+export function validateConversationId(conversationId: string | null | undefined): conversationId is string {
+  if (!conversationId) return false
+  return /^[a-zA-Z0-9-_]{1,50}$/.test(conversationId)
+}
+
+/**
+ * Securely navigate to a conversation with validation
+ * @param conversationId - The conversation ID to navigate to (null for new conversation)
+ */
+export function navigateToConversation(conversationId: string | null) {
+  try {
+    if (conversationId && validateConversationId(conversationId)) {
+      const targetUrl = `/nexus?id=${conversationId}`
+      // Validate the constructed URL before navigation
+      if (targetUrl.startsWith('/nexus')) {
+        window.location.href = targetUrl
+      } else {
+        log.error('Invalid target URL constructed', { targetUrl })
+        window.location.href = '/nexus'
+      }
+    } else if (conversationId) {
+      log.warn('Invalid conversation ID for navigation', { conversationId })
+      window.location.href = '/nexus'
+    } else {
+      window.location.href = '/nexus'
+    }
+  } catch (error) {
+    log.error('Error during navigation', { error, conversationId })
+    // Fallback to safe navigation
+    window.location.href = '/nexus'
+  }
+}
+
+/**
+ * Securely navigate to a new conversation
+ */
+export function navigateToNewConversation() {
+  window.location.href = '/nexus'
+}


### PR DESCRIPTION
## Summary
This PR fixes Issue #230 where the Nexus runtime was remounting during conversation initialization, causing active streaming jobs to be cancelled. The solution implements URL-based conversation loading with improved UX and runtime stability.

## Key Improvements
- ✅ **Fixes runtime remounting**: Stable ConversationRuntimeProvider prevents unwanted remounts during conversation ID transitions
- ✅ **URL-based navigation**: Conversations now use `/nexus?id=xxx` URLs for direct linking and proper browser navigation
- ✅ **Eliminates welcome screen flash**: Shows loading spinner instead of jarring welcome screen when loading existing conversations
- ✅ **Full page reload navigation**: New Chat button and conversation links use proper page reloads for clean state reset
- ✅ **Industry standard patterns**: Follows URL patterns used by Slack, Discord, Gmail, etc.

## Technical Changes
- Extracted ConversationRuntimeProvider as stable component (removed component-in-useMemo anti-pattern)
- Added URL parameter handling with useSearchParams for conversation initialization
- Implemented URL syncing when conversation changes through routing
- Added conversationId prop to Thread component for loading state awareness
- Updated navigation to use window.location.href for full page reloads
- Simplified component interfaces by removing callback props

## Testing
- [x] TypeScript compilation passes
- [x] ESLint checks clean
- [x] Conversation loading from URL works correctly
- [x] New chat creation functions properly
- [x] Sidebar conversation switching works with full reload
- [x] Archive functionality properly navigates away from archived conversations
- [x] No runtime remounting during streaming jobs

## Test Plan
- [ ] Load existing conversation via direct URL
- [ ] Verify no welcome screen flash during conversation loading  
- [ ] Test New Chat button creates fresh conversation
- [ ] Test sidebar conversation switching with proper loading
- [ ] Verify streaming jobs aren't cancelled during initialization
- [ ] Test archiving current conversation navigates properly

Closes #230