### PR TITLE
fix: resolve AWS build errors for static generation

### DIFF
--- a/app/(protected)/nexus/page.tsx
+++ b/app/(protected)/nexus/page.tsx
@@ -4,7 +4,7 @@ import { AssistantRuntimeProvider, useLocalRuntime, type ChatModelAdapter, type 
 import { Thread } from '@/components/assistant-ui/thread'
 import { useSession } from 'next-auth/react'
 import { useRouter, useSearchParams } from 'next/navigation'
-import { useEffect, useMemo, useCallback, useState, useRef } from 'react'
+import { useEffect, useMemo, useCallback, useState, useRef, Suspense } from 'react'
 import { NexusShell } from './_components/layout/nexus-shell'
 import { ErrorBoundary } from './_components/error-boundary'
 import { ConversationPanel } from './_components/conversation-panel'
@@ -58,7 +58,8 @@ function ConversationRuntimeProvider({
   )
 }
 
-export default function NexusPage() {
+// Component that uses useSearchParams - must be wrapped in Suspense
+function NexusPageContent() {
   const router = useRouter()
   const searchParams = useSearchParams()
   const { data: session, status: sessionStatus } = useSession()
@@ -274,5 +275,21 @@ export default function NexusPage() {
         </div>
       </NexusShell>
     </ErrorBoundary>
+  )
+}
+
+// Main component with Suspense boundary for useSearchParams
+export default function NexusPage() {
+  return (
+    <Suspense fallback={
+      <div className="flex h-screen items-center justify-center">
+        <div className="text-center">
+          <div className="h-8 w-8 animate-spin rounded-full border-2 border-primary border-t-transparent mx-auto mb-4" />
+          <div className="text-lg text-muted-foreground">Loading Nexus...</div>
+        </div>
+      </div>
+    }>
+      <NexusPageContent />
+    </Suspense>
   )
 }

--- a/app/(protected)/unauthorized/page.tsx
+++ b/app/(protected)/unauthorized/page.tsx
@@ -4,6 +4,9 @@ import { AlertCircle, Home, LogIn, Mail } from "lucide-react"
 import Link from "next/link"
 import { getCurrentUserAction } from "@/actions/db/get-current-user-action"
 
+// Force dynamic rendering to allow headers() usage in server actions
+export const dynamic = 'force-dynamic'
+
 export default async function UnauthorizedPage() {
   const userResult = await getCurrentUserAction()
   const userRoles = userResult.isSuccess && userResult.data 


### PR DESCRIPTION
Critical fixes for Next.js 15 static generation issues:

**Unauthorized Page Dynamic Server Usage:**
- Added 'export const dynamic = force-dynamic' to /unauthorized page
- Allows headers() usage in server actions during static generation
- Resolves DYNAMIC_SERVER_USAGE error for route that uses authentication

**Nexus Page useSearchParams Suspense Boundary:**
- Wrapped useSearchParams() usage in proper Suspense boundary
- Created NexusPageContent component for search params handling
- Added loading fallback with spinner for better UX
- Resolves missing-suspense-with-csr-bailout warning

**Build Quality Verification:**
- TypeScript type checking passes cleanly
- ESLint linting passes without errors
- Addresses AWS Amplify SSR deployment requirements

These fixes ensure static generation works properly while maintaining all authentication and URL parameter functionality.

## Description

<!-- What does this PR do? Summarize the change and why it is needed. -->

## Checklist

- [ ] No `console.*` calls in production/shared code; all server-side logging uses Winston logger (`@/lib/logger`)
- [ ] **No imports or usage of `@/lib/logger` in client components or client hooks**
- [ ] Client code uses `console.error` only for actionable errors in development (never for routine info)
- [ ] Lint passes (`npm run lint`)
- [ ] All tests pass (`npm test`)
- [ ] Types/interfaces follow project conventions
- [ ] No type assertions (`as any`) without justification
- [ ] Database field names use snake_case (automatic camelCase transformation handled by data API adapter)
- [ ] TypeScript strict mode errors resolved
- [ ] Environment variables handled securely and `.env.example` updated if needed
- [ ] Documentation updated (if needed)
- [ ] Code reviewed and approved
- [ ] App builds and runs without module errors (e.g., no 'fs' errors in browser)

## Related Issues

<!-- Link to any related issues or tickets --> 