### PR TITLE
Fix Assistant Architect execution failures (#241)

### DIFF
--- a/actions/db/assistant-architect-actions.ts
+++ b/actions/db/assistant-architect-actions.ts
@@ -1935,34 +1935,17 @@ export async function executeAssistantArchitectAction({
         {
           id: `assistant-architect-start-${Date.now()}`,
           role: 'system' as const,
-          parts: [{ 
-            type: 'text' as const, 
-            text: 'Assistant Architect execution initiated' 
+          parts: [{
+            type: 'text' as const,
+            text: 'Assistant Architect execution initiated'
           }]
         },
         {
           id: `assistant-architect-user-${Date.now()}`,
           role: 'user' as const,
-          parts: [{ 
-            type: 'text' as const, 
-            text: JSON.stringify({
-              action: 'execute_assistant_architect',
-              toolId: String(toolId),
-              executionId,
-              inputs: validatedInputs,
-              toolName: tool.name,
-              prompts: tool.prompts?.map(p => ({
-                id: p.id,
-                name: p.name,
-                content: p.content,
-                systemContext: p.systemContext,
-                modelId: p.modelId,
-                position: p.position,
-                inputMapping: p.inputMapping,
-                repositoryIds: p.repositoryIds ? parseRepositoryIds(p.repositoryIds) : undefined
-              })) || [],
-              repositoryIds
-            })
+          parts: [{
+            type: 'text' as const,
+            text: `Execute Assistant Architect tool: ${tool.name}`
           }]
         }
       ],
@@ -1974,7 +1957,22 @@ export async function executeAssistantArchitectAction({
         reasoningEffort: 'medium' as const
       },
       source: 'assistant-architect',
-      sessionId: session.sub
+      sessionId: session.sub,
+      toolMetadata: {
+        toolId: parseInt(String(toolId), 10),
+        executionId,
+        prompts: tool.prompts?.map(p => ({
+          id: p.id,
+          name: p.name,
+          content: p.content,
+          systemContext: p.systemContext || undefined,
+          modelId: p.modelId || modelId, // Use the tool's model if prompt modelId is null
+          position: p.position,
+          inputMapping: p.inputMapping as Record<string, unknown> || undefined,
+          repositoryIds: p.repositoryIds ? parseRepositoryIds(p.repositoryIds) : undefined
+        })) || [],
+        inputMapping: validatedInputs
+      }
     };
 
     // Create the streaming job

--- a/actions/db/assistant-architect-actions.ts
+++ b/actions/db/assistant-architect-actions.ts
@@ -1965,13 +1965,13 @@ export async function executeAssistantArchitectAction({
           id: p.id,
           name: p.name,
           content: p.content,
-          systemContext: p.systemContext || undefined,
+          systemContext: p.systemContext || null,
           modelId: p.modelId || modelId, // Use the tool's model if prompt modelId is null
           position: p.position,
-          inputMapping: p.inputMapping as Record<string, unknown> || undefined,
-          repositoryIds: p.repositoryIds ? parseRepositoryIds(p.repositoryIds) : undefined
+          inputMapping: p.inputMapping as Record<string, unknown> || {},
+          repositoryIds: p.repositoryIds ? parseRepositoryIds(p.repositoryIds) : []
         })) || [],
-        inputMapping: validatedInputs
+        inputMapping: validatedInputs || {}
       }
     };
 

--- a/app/api/nexus/chat/jobs/[jobId]/route.ts
+++ b/app/api/nexus/chat/jobs/[jobId]/route.ts
@@ -117,9 +117,9 @@ export async function GET(
         
         // Check if we already saved the assistant response (prevent duplicates)
         const existingAssistantMessages = await executeSQL(
-          `SELECT id FROM nexus_messages 
-           WHERE conversation_id = :conversationId 
-           AND role = 'assistant' 
+          `SELECT id FROM nexus_messages
+           WHERE conversation_id = :conversationId::uuid
+           AND role = 'assistant'
            AND created_at >= :jobCreatedAt
            LIMIT 1`,
           [
@@ -155,11 +155,11 @@ export async function GET(
           
           await executeSQL(
             `INSERT INTO nexus_messages (
-              conversation_id, role, content, parts, 
-              model_id, token_usage, finish_reason, 
+              conversation_id, role, content, parts,
+              model_id, token_usage, finish_reason,
               metadata, created_at
             ) VALUES (
-              :conversationId, 'assistant', :content, :parts,
+              :conversationId::uuid, 'assistant', :content, :parts,
               :modelId, :tokenUsage, :finishReason,
               :metadata, NOW()
             )`,
@@ -178,12 +178,12 @@ export async function GET(
 
           // Update conversation message count
           await executeSQL(
-            `UPDATE nexus_conversations 
-             SET 
+            `UPDATE nexus_conversations
+             SET
                message_count = message_count + 1,
                last_message_at = NOW(),
                updated_at = NOW()
-             WHERE id = :conversationId`,
+             WHERE id = :conversationId::uuid`,
             [{ name: 'conversationId', value: { stringValue: job.nexusConversationId } }]
           );
 

--- a/infra/lambdas/streaming-jobs-worker/index.js
+++ b/infra/lambdas/streaming-jobs-worker/index.js
@@ -1092,24 +1092,41 @@ async function processStreamingJob(job) {
     // DEBUG: Comprehensive message format logging for debugging circular conversion issue
     console.log('=== MESSAGE FORMAT DEBUG BEFORE STREAMING SERVICE ===');
     messages.forEach((msg, idx) => {
-      if (msg.parts?.some(p => p.type === 'image') || (Array.isArray(msg.content) && msg.content.some(p => p.type === 'image'))) {
-        console.log(`Message ${idx} (${msg.role}) format analysis:`, {
-          hasContent: !!msg.content,
-          hasParts: !!msg.parts,
-          contentType: Array.isArray(msg.content) ? 'array' : typeof msg.content,
-          partsType: Array.isArray(msg.parts) ? 'array' : typeof msg.parts,
-          contentLength: Array.isArray(msg.content) ? msg.content.length : 0,
-          partsLength: Array.isArray(msg.parts) ? msg.parts.length : 0,
-          imageInParts: msg.parts?.filter(p => p.type === 'image').map(p => ({
-            hasImage: !!p.image,
-            imageStartsWithData: p.image?.startsWith('data:'),
-            imageLength: p.image?.length || 0
-          })) || [],
-          imageInContent: Array.isArray(msg.content) ? msg.content.filter(p => p.type === 'image').map(p => ({
-            hasImage: !!p.image,
-            imageStartsWithData: p.image?.startsWith('data:'),
-            imageLength: p.image?.length || 0
-          })) : []
+      try {
+        // Only log messages that might have images
+        const hasImageParts = msg.parts && Array.isArray(msg.parts) && msg.parts.some(p => p.type === 'image');
+        const hasImageContent = msg.content && Array.isArray(msg.content) && msg.content.some(p => p.type === 'image');
+
+        if (hasImageParts || hasImageContent) {
+          console.log(`Message ${idx} (${msg.role}) format analysis:`, {
+            hasContent: !!msg.content,
+            hasParts: !!msg.parts,
+            contentType: Array.isArray(msg.content) ? 'array' : typeof msg.content,
+            partsType: Array.isArray(msg.parts) ? 'array' : typeof msg.parts,
+            contentLength: Array.isArray(msg.content) ? msg.content.length : 0,
+            partsLength: Array.isArray(msg.parts) ? msg.parts.length : 0,
+            imageInParts: Array.isArray(msg.parts) ? msg.parts.filter(p => p.type === 'image').map(p => ({
+              hasImage: !!p.image,
+              imageStartsWithData: p.image?.startsWith('data:'),
+              imageLength: p.image?.length || 0
+            })) : [],
+            imageInContent: Array.isArray(msg.content) ? msg.content.filter(p => p.type === 'image').map(p => ({
+              hasImage: !!p.image,
+              imageStartsWithData: p.image?.startsWith('data:'),
+              imageLength: p.image?.length || 0
+            })) : []
+          });
+        }
+      } catch (error) {
+        console.log(`Debug logging error for message ${idx}:`, {
+          error: error.message,
+          messageStructure: {
+            role: msg.role,
+            hasContent: !!msg.content,
+            hasParts: !!msg.parts,
+            contentType: typeof msg.content,
+            partsType: typeof msg.parts
+          }
         });
       }
     });

--- a/infra/lambdas/streaming-jobs-worker/index.js
+++ b/infra/lambdas/streaming-jobs-worker/index.js
@@ -905,11 +905,11 @@ async function processAssistantArchitectJob(job) {
         // Substitute variables in prompt content
         const processedContent = substituteVariables(prompt.content, chainContext);
         
-        // Build messages for this specific prompt
+        // Build messages for this specific prompt in UIMessage format
         const promptMessages = [
           {
             role: 'user',
-            content: processedContent
+            parts: [{ type: 'text', text: processedContent }]
           }
         ];
 
@@ -970,7 +970,8 @@ async function processAssistantArchitectJob(job) {
         if (isLastPrompt) {
           const responseData = {
             type: 'assistant_architect_chain',
-            finalOutput: finalText,
+            text: finalText,
+            finalOutput: finalText, // Keep for backward compatibility
             chainContext: chainContext,
             totalPrompts: sortedPrompts.length,
             toolId: toolId,

--- a/lib/streaming/job-management-service.ts
+++ b/lib/streaming/job-management-service.ts
@@ -141,7 +141,7 @@ export interface CreateJobRequest {
       id: number;
       name: string;
       content: string;
-      systemContext?: string;
+      systemContext?: string | null;
       modelId: number;
       position: number;
       inputMapping?: Record<string, unknown>;

--- a/lib/streaming/job-management-service.ts
+++ b/lib/streaming/job-management-service.ts
@@ -134,6 +134,21 @@ export interface CreateJobRequest {
   tools?: unknown;
   source?: string;
   sessionId?: string;
+  toolMetadata?: {
+    toolId: number;
+    executionId: number;
+    prompts: Array<{
+      id: number;
+      name: string;
+      content: string;
+      systemContext?: string;
+      modelId: number;
+      position: number;
+      inputMapping?: Record<string, unknown>;
+      repositoryIds?: number[];
+    }>;
+    inputMapping: Record<string, unknown>;
+  };
 }
 
 /**
@@ -186,7 +201,8 @@ export class JobManagementService {
         maxTokens: request.maxTokens,
         temperature: request.temperature,
         tools: request.tools,
-        source: request.source || 'chat' // CRITICAL: Include source for Nexus message persistence
+        source: request.source || 'chat', // CRITICAL: Include source for Nexus message persistence
+        toolMetadata: request.toolMetadata // Include toolMetadata for Assistant Architect jobs
       };
 
       // Generate job ID first


### PR DESCRIPTION
## Summary
Fixes Assistant Architect execution failures that were preventing tools from running and displaying responses properly.

## Root Cause Analysis
The issue had multiple layers:
1. **PostgreSQL UUID type casting**: Missing `::uuid` type casting in SQL queries
2. **Missing toolMetadata**: Lambda expected toolMetadata but it wasn't being passed  
3. **Message format incompatibility**: Lambda passed simple `{role, content}` format but AI SDK v5 expects `{role, parts}` format
4. **Response field mismatch**: Lambda saved response as `finalOutput` but frontend expected `text`

## Changes Made

### Database Layer (`app/api/nexus/chat/jobs/[jobId]/route.ts`)
- Added explicit `::uuid` type casting to all UUID parameters in SQL queries
- Fixed 3 queries: conversation lookup, message insert, and conversation update

### Job Management (`lib/streaming/job-management-service.ts`) 
- Added `toolMetadata` field to `CreateJobRequest` interface
- Updated request data structure to include toolMetadata for Lambda processing

### Assistant Architect Actions (`actions/db/assistant-architect-actions.ts`)
- Added comprehensive toolMetadata to job requests including:
  - Tool ID and execution ID
  - Prompt chain with proper structure
  - Input mapping and repository IDs
- Replaced undefined values with safe defaults (null, {}, [])

### Lambda Worker (`infra/lambdas/streaming-jobs-worker/index.js`)
- **Message Format Fix**: Changed from simple `{role, content}` to UIMessage format `{role, parts: [{type: 'text', text}]}`
- **Response Field Fix**: Added `text` field to responseData (keeping `finalOutput` for backward compatibility)
- **Debug Logging Fix**: Added proper array checks before filtering to prevent undefined errors

## Test Plan
- [x] Assistant Architect executions complete without errors
- [x] Response content displays correctly in UI  
- [x] All database operations succeed
- [x] Linting and type checking pass
- [x] No breaking changes to existing functionality

## Fixes
Closes #241

## Breaking Changes
None - all changes are backward compatible