### PR TITLE
feat: Tool selection UI for Assistant Architect prompts (#252)

### DIFF
--- a/app/(protected)/utilities/assistant-architect/[id]/edit/prompts/_components/prompts-page-client.tsx
+++ b/app/(protected)/utilities/assistant-architect/[id]/edit/prompts/_components/prompts-page-client.tsx
@@ -4,7 +4,7 @@ import { useState, useCallback, useEffect, useRef } from "react"
 import { Button } from "@/components/ui/button"
 import { toast } from "sonner"
 import { addChainPromptAction, deletePromptAction, updatePromptAction, getAssistantArchitectByIdAction, setPromptPositionsAction } from "@/actions/db/assistant-architect-actions"
-import { PlusIcon, Pencil, Trash2, Play } from "lucide-react"
+import { PlusIcon, Pencil, Trash2, Play, Globe, Code2, Image as ImageIcon } from "lucide-react"
 import {
   ReactFlow,
   MiniMap,
@@ -63,6 +63,7 @@ import {
 } from "@mdxeditor/editor"
 import DocumentUploadButton from "@/components/ui/document-upload-button"
 import { RepositoryBrowser } from "@/components/features/assistant-architect/repository-browser"
+import { ToolSelectionSection } from "@/components/features/assistant-architect/tool-selection-section"
 const MDXEditor = dynamic(() => import("@mdxeditor/editor").then(mod => mod.MDXEditor), { ssr: false })
 
 
@@ -244,6 +245,7 @@ interface PromptNodeData {
   systemContext?: string;
   modelId: number;
   inputMapping?: unknown;
+  enabledTools?: string[];
   prompt: SelectChainPrompt;
   onEdit: (prompt: SelectChainPrompt) => void;
   onDelete: (id: string) => void;
@@ -294,6 +296,29 @@ function PromptNode({ data, id }: NodeProps) {
         <Badge variant="secondary" className="text-xs">
           {nodeData.modelName}
         </Badge>
+
+        {nodeData.enabledTools && nodeData.enabledTools.length > 0 && (
+          <div className="flex gap-1 mt-2 flex-wrap">
+            {nodeData.enabledTools.includes('webSearch') && (
+              <Badge variant="outline" className="text-xs px-1 py-0 h-5">
+                <Globe className="h-3 w-3 mr-1" />
+                Web
+              </Badge>
+            )}
+            {nodeData.enabledTools.includes('codeInterpreter') && (
+              <Badge variant="outline" className="text-xs px-1 py-0 h-5">
+                <Code2 className="h-3 w-3 mr-1" />
+                Code
+              </Badge>
+            )}
+            {nodeData.enabledTools.includes('generateImage') && (
+              <Badge variant="outline" className="text-xs px-1 py-0 h-5">
+                <ImageIcon className="h-3 w-3 mr-1" />
+                Image
+              </Badge>
+            )}
+          </div>
+        )}
       </div>
 
       <Handle type="target" position={Position.Top} className="w-2 h-2 !bg-primary" />
@@ -490,6 +515,7 @@ const Flow = React.forwardRef<FlowHandle, {
             systemContext: prompt.systemContext,
             modelId: prompt.modelId,
             inputMapping: prompt.inputMapping,
+            enabledTools: prompt.enabledTools,
             prompt,
             onEdit,
             onDelete
@@ -669,6 +695,7 @@ export function PromptsPageClient({ assistantId, prompts: initialPrompts, models
   const [isPdfContentCollapsed, setIsPdfContentCollapsed] = useState(true)
   const [promptTokens, setPromptTokens] = useState(0)
   const [flowKey, setFlowKey] = useState(0)
+  const [enabledTools, setEnabledTools] = useState<string[]>([])
   const mdxEditorRef = useRef<MDXEditorHandle>(null);
 
   // When initialPrompts changes (from server), update our local state
@@ -704,6 +731,7 @@ export function PromptsPageClient({ assistantId, prompts: initialPrompts, models
           modelId: parseInt(modelId as string),
           position: typeof prompts.length === 'number' ? prompts.length : 0,
           repositoryIds: useExternalKnowledge ? selectedRepositoryIds : [],
+          enabledTools: enabledTools,
         }
       )
 
@@ -717,6 +745,7 @@ export function PromptsPageClient({ assistantId, prompts: initialPrompts, models
         setUseExternalKnowledge(false)
         setSelectedRepositoryIds([])
         setIsPdfContentCollapsed(true)
+        setEnabledTools([])
         
         // Get the updated prompts
         const updatedResult = await getAssistantArchitectByIdAction(assistantId);
@@ -751,9 +780,10 @@ export function PromptsPageClient({ assistantId, prompts: initialPrompts, models
         content: promptContent,
         systemContext: systemContext || undefined,
         modelId: parseInt(modelId),
-        repositoryIds: useExternalKnowledge && selectedRepositoryIds.length > 0 
-          ? selectedRepositoryIds.filter(id => id !== undefined && id !== null) 
+        repositoryIds: useExternalKnowledge && selectedRepositoryIds.length > 0
+          ? selectedRepositoryIds.filter(id => id !== undefined && id !== null)
           : [], // Send empty array to clear repositories, not undefined
+        enabledTools: enabledTools,
       };
       
       const result = await updatePromptAction(editingPrompt.id.toString(), updateData)
@@ -841,6 +871,7 @@ export function PromptsPageClient({ assistantId, prompts: initialPrompts, models
       setModelId(latestPrompt.modelId ? latestPrompt.modelId.toString() : null)
       setUseExternalKnowledge(Boolean(latestPrompt.repositoryIds && latestPrompt.repositoryIds.length > 0))
       setSelectedRepositoryIds(latestPrompt.repositoryIds || [])
+      setEnabledTools(latestPrompt.enabledTools || [])
       setIsPdfContentCollapsed(true)
       setIsEditDialogOpen(true)
     } catch {
@@ -880,6 +911,10 @@ export function PromptsPageClient({ assistantId, prompts: initialPrompts, models
         setPromptContent("");
         setSystemContext("");
         setModelId(null);
+        setUseExternalKnowledge(false);
+        setSelectedRepositoryIds([]);
+        setEnabledTools([]);
+        setIsPdfContentCollapsed(true);
         setIsAddDialogOpen(true);
       }}>
         <PlusIcon className="h-4 w-4 mr-2" />
@@ -925,6 +960,13 @@ export function PromptsPageClient({ assistantId, prompts: initialPrompts, models
                   hideCapabilityMissing={true}
                 />
               </div>
+              <ToolSelectionSection
+                selectedModelId={modelId ? parseInt(modelId) : null}
+                enabledTools={enabledTools}
+                onToolsChange={setEnabledTools}
+                models={models}
+                disabled={isLoading}
+              />
               <KnowledgeSection
                 useExternalKnowledge={useExternalKnowledge}
                 setUseExternalKnowledge={setUseExternalKnowledge}
@@ -1063,6 +1105,13 @@ export function PromptsPageClient({ assistantId, prompts: initialPrompts, models
                     hideCapabilityMissing={true}
                   />
                 </div>
+                <ToolSelectionSection
+                  selectedModelId={modelId ? parseInt(modelId) : null}
+                  enabledTools={enabledTools}
+                  onToolsChange={setEnabledTools}
+                  models={models}
+                  disabled={isLoading}
+                />
                 <KnowledgeSection
                   useExternalKnowledge={useExternalKnowledge}
                   setUseExternalKnowledge={setUseExternalKnowledge}

--- a/app/(protected)/utilities/assistant-architect/[id]/edit/prompts/_components/prompts-page-client.tsx
+++ b/app/(protected)/utilities/assistant-architect/[id]/edit/prompts/_components/prompts-page-client.tsx
@@ -961,7 +961,7 @@ export function PromptsPageClient({ assistantId, prompts: initialPrompts, models
                 />
               </div>
               <ToolSelectionSection
-                selectedModelId={modelId ? parseInt(modelId) : null}
+                selectedModelId={modelId && !isNaN(parseInt(modelId)) ? parseInt(modelId) : null}
                 enabledTools={enabledTools}
                 onToolsChange={setEnabledTools}
                 models={models}
@@ -1106,7 +1106,7 @@ export function PromptsPageClient({ assistantId, prompts: initialPrompts, models
                   />
                 </div>
                 <ToolSelectionSection
-                  selectedModelId={modelId ? parseInt(modelId) : null}
+                  selectedModelId={modelId && !isNaN(parseInt(modelId)) ? parseInt(modelId) : null}
                   enabledTools={enabledTools}
                   onToolsChange={setEnabledTools}
                   models={models}

--- a/components/features/assistant-architect/tool-selection-section.tsx
+++ b/components/features/assistant-architect/tool-selection-section.tsx
@@ -1,0 +1,211 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import { Label } from '@/components/ui/label'
+import { Switch } from '@/components/ui/switch'
+import { Badge } from '@/components/ui/badge'
+import { Separator } from '@/components/ui/separator'
+import { Globe, Code2, Search, Brain, Info } from 'lucide-react'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip'
+import type { SelectAiModel } from '@/types'
+import { getAvailableToolsForModel, type ToolConfig } from '@/lib/tools'
+import { createLogger } from '@/lib/client-logger'
+
+const log = createLogger({ moduleName: 'tool-selection-section' })
+
+interface ToolSelectionSectionProps {
+  selectedModelId: number | null
+  enabledTools: string[]
+  onToolsChange: (tools: string[]) => void
+  models: SelectAiModel[]
+  disabled?: boolean
+}
+
+const TOOL_ICONS = {
+  search: Globe,
+  code: Code2,
+  analysis: Search,
+  creative: Brain,
+  media: Brain
+} as const
+
+export function ToolSelectionSection({
+  selectedModelId,
+  enabledTools,
+  onToolsChange,
+  models,
+  disabled = false
+}: ToolSelectionSectionProps) {
+  const [availableTools, setAvailableTools] = useState<ToolConfig[]>([])
+  const [isLoading, setIsLoading] = useState(false)
+
+  // Get selected model object
+  const selectedModel = selectedModelId
+    ? models.find(m => m.id === selectedModelId)
+    : null
+
+  // Load available tools when model changes
+  useEffect(() => {
+    if (!selectedModel?.modelId) {
+      setAvailableTools([])
+      return
+    }
+
+    setIsLoading(true)
+    log.debug('Loading tools for model', {
+      modelId: selectedModel.modelId,
+      modelName: selectedModel.name
+    })
+
+    getAvailableToolsForModel(selectedModel.modelId)
+      .then(tools => {
+        log.debug('Tools loaded', { tools: tools.map(t => t.name) })
+        setAvailableTools(tools)
+
+        // Auto-disable tools that are no longer available
+        const newEnabledTools = enabledTools.filter(toolName =>
+          tools.some(tool => tool.name === toolName)
+        )
+        if (newEnabledTools.length !== enabledTools.length) {
+          log.debug('Auto-disabling unavailable tools', {
+            before: enabledTools,
+            after: newEnabledTools
+          })
+          onToolsChange(newEnabledTools)
+        }
+      })
+      .catch(error => {
+        log.error('Failed to load tools', { error })
+        setAvailableTools([])
+      })
+      .finally(() => {
+        setIsLoading(false)
+      })
+  }, [selectedModel?.modelId, selectedModel?.name, enabledTools, onToolsChange])
+
+  const handleToolToggle = (toolName: string, enabled: boolean) => {
+    log.debug('Tool toggle', { toolName, enabled, currentEnabledTools: enabledTools })
+
+    if (enabled) {
+      const newTools = [...enabledTools, toolName]
+      log.debug('Enabling tool', { toolName, newTools })
+      onToolsChange(newTools)
+    } else {
+      const newTools = enabledTools.filter(name => name !== toolName)
+      log.debug('Disabling tool', { toolName, newTools })
+      onToolsChange(newTools)
+    }
+  }
+
+  // Don't render if no model is selected
+  if (!selectedModel) {
+    return null
+  }
+
+  // Group tools by category
+  const toolsByCategory = availableTools.reduce((acc, tool) => {
+    if (!acc[tool.category]) {
+      acc[tool.category] = []
+    }
+    acc[tool.category].push(tool)
+    return acc
+  }, {} as Record<string, ToolConfig[]>)
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center gap-2">
+        <Label className="text-sm font-medium">Available Tools</Label>
+        <TooltipProvider>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Info className="h-4 w-4 text-muted-foreground cursor-help" />
+            </TooltipTrigger>
+            <TooltipContent>
+              <p className="max-w-xs text-sm">
+                Enable AI tools for this prompt based on your selected model&apos;s capabilities.
+                Tools will be available during prompt execution.
+              </p>
+            </TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+        {enabledTools.length > 0 && (
+          <Badge variant="secondary" className="text-xs">
+            {enabledTools.length} enabled
+          </Badge>
+        )}
+      </div>
+
+      {isLoading ? (
+        <div className="flex items-center justify-center p-4 border rounded-lg bg-muted/50">
+          <div className="h-4 w-4 animate-spin rounded-full border-2 border-primary border-t-transparent" />
+          <span className="ml-2 text-sm text-muted-foreground">Loading tools...</span>
+        </div>
+      ) : availableTools.length === 0 ? (
+        <div className="p-4 border rounded-lg bg-muted/50">
+          <p className="text-sm text-muted-foreground text-center">
+            No tools available for {selectedModel.name}
+          </p>
+          <p className="text-xs text-muted-foreground text-center mt-1">
+            This model does not support any AI tools at this time.
+          </p>
+        </div>
+      ) : (
+        <div className="space-y-4 border rounded-lg p-4 bg-muted/20">
+          {Object.entries(toolsByCategory).map(([category, tools], categoryIndex) => {
+            const IconComponent = TOOL_ICONS[category as keyof typeof TOOL_ICONS] || Brain
+
+            return (
+              <div key={category}>
+                {categoryIndex > 0 && <Separator className="my-3" />}
+                <div className="space-y-3">
+                  <div className="flex items-center gap-2">
+                    <IconComponent className="h-3 w-3 text-muted-foreground" />
+                    <span className="text-xs font-medium capitalize text-muted-foreground">
+                      {category}
+                    </span>
+                  </div>
+                  <div className="space-y-3 pl-5">
+                    {tools.map(tool => {
+                      const isEnabled = enabledTools.includes(tool.name)
+
+                      return (
+                        <div
+                          key={tool.name}
+                          className="flex items-start justify-between space-x-3"
+                        >
+                          <div className="flex-1 space-y-1">
+                            <Label
+                              htmlFor={`tool-${tool.name}`}
+                              className="text-sm font-medium cursor-pointer"
+                            >
+                              {tool.displayName}
+                            </Label>
+                            <p className="text-xs text-muted-foreground leading-relaxed">
+                              {tool.description}
+                            </p>
+                          </div>
+                          <Switch
+                            id={`tool-${tool.name}`}
+                            checked={isEnabled}
+                            disabled={disabled || isLoading}
+                            onCheckedChange={(checked) => handleToolToggle(tool.name, checked)}
+                            className="mt-0.5"
+                          />
+                        </div>
+                      )
+                    })}
+                  </div>
+                </div>
+              </div>
+            )
+          })}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/lib/tools/client-tool-registry.ts
+++ b/lib/tools/client-tool-registry.ts
@@ -17,6 +17,7 @@ export interface ModelCapabilities {
   responsesAPI: boolean
   promptCaching: boolean
   contextCaching: boolean
+  imageGeneration: boolean
 }
 
 export interface ToolConfig {
@@ -25,7 +26,7 @@ export interface ToolConfig {
   requiredCapabilities: (keyof ModelCapabilities)[]
   displayName: string
   description: string
-  category: 'search' | 'code' | 'analysis' | 'creative'
+  category: 'search' | 'code' | 'analysis' | 'creative' | 'media'
 }
 
 /**
@@ -42,12 +43,20 @@ const TOOL_REGISTRY: Record<string, ToolConfig> = {
     category: 'search'
   },
   codeInterpreter: {
-    name: 'codeInterpreter', 
+    name: 'codeInterpreter',
     tool: {}, // Placeholder for client-side usage
     requiredCapabilities: ['codeInterpreter', 'codeExecution'],
     displayName: 'Code Interpreter',
     description: 'Execute code and perform data analysis',
     category: 'code'
+  },
+  generateImage: {
+    name: 'generateImage',
+    tool: {}, // Placeholder for client-side usage
+    requiredCapabilities: ['imageGeneration'],
+    displayName: 'Image Generation',
+    description: 'Generate images from text descriptions using AI models like GPT-Image-1, DALL-E 3, and Imagen 4',
+    category: 'media'
   }
 }
 


### PR DESCRIPTION
## Summary
Implements tool selection UI components for Assistant Architect prompt creation and editing, allowing users to enable web search and other tools based on model capabilities.

This addresses issue #252 and provides the frontend UI to complement the existing backend support for enabled_tools.

## Key Features

### ✅ Tool Selection Component
- **ToolSelectionSection**: Main component for tool selection with dynamic loading
- **Dynamic visibility**: Only shows tools supported by the selected model
- **Category grouping**: Tools grouped by type (search, code, media)
- **Real-time updates**: Tool list updates immediately when model changes
- **Auto-disable**: Incompatible tools automatically disabled on model change

### ✅ Integration Points
- **Prompt Creation Dialog**: Tool selection positioned after model selector
- **Prompt Edit Dialog**: Loads existing tool selections and allows modification
- **Form State Management**: Full enabledTools state integration
- **Database Persistence**: Tools saved/loaded with prompt configuration

### ✅ Visual Indicators
- **Flow View Badges**: Small badges on prompt nodes showing enabled tools
  - 🌐 Web (webSearch)
  - 💻 Code (codeInterpreter) 
  - 🖼️ Image (generateImage)
- **Tool Count Badges**: Shows number of enabled tools in selection UI
- **Loading States**: Proper loading indicators during tool fetching

### ✅ User Experience
- **Responsive Design**: Works on different screen sizes
- **Accessibility**: Proper labels, keyboard navigation, tooltips
- **Error Handling**: Graceful handling of API failures
- **Empty States**: Clear messaging when no tools available

## Technical Implementation

### Components Added
- `components/features/assistant-architect/tool-selection-section.tsx`
- Enhanced existing prompt editing components

### API Integration
- Uses existing `/api/models/[modelId]/capabilities` endpoint
- Client-side tool registry with capability matching
- Full TypeScript support with proper interfaces

### Database Support
- Leverages existing `enabled_tools` JSONB column in `chain_prompts` table
- Backend actions already support the field from issue #251

## Changes Made

### New Files
- `components/features/assistant-architect/tool-selection-section.tsx`

### Modified Files
- `app/(protected)/utilities/assistant-architect/[id]/edit/prompts/_components/prompts-page-client.tsx`
  - Added tool selection state management
  - Integrated ToolSelectionSection into both add/edit dialogs
  - Enhanced PromptNode with visual tool indicators
  - Updated form submission to include enabledTools
- `lib/tools/client-tool-registry.ts`
  - Added imageGeneration capability
  - Added generateImage tool definition
  - Updated category types to include 'media'

## Testing Done
- ✅ Lint checks pass
- ✅ TypeScript compilation successful
- ✅ Manual testing of tool selection flows
- ✅ Model compatibility checking
- ✅ Visual indicators in flow view

## Screenshots
[Tool selection UI will be visible in prompt creation/edit dialogs]
[Flow view will show tool badges on prompt nodes]

## Next Steps
The backend already supports enabled_tools from issue #251, so this frontend implementation should work end-to-end immediately.

Future enhancements could include:
- E2E tests for tool selection workflows
- Additional tool types as they become available
- Tool usage analytics and monitoring

Closes #252