### PR TITLE
fix: Remove old follow-up UI from assistant architect - keep Thread visible after completion

### DIFF
--- a/app/(protected)/utilities/assistant-architect/[id]/edit/preview/_components/preview-page-client.tsx
+++ b/app/(protected)/utilities/assistant-architect/[id]/edit/preview/_components/preview-page-client.tsx
@@ -14,7 +14,7 @@ export function PreviewPageClient({
   return (
     <div className="space-y-4">
       <div className="border rounded-lg p-4 space-y-4">
-        <AssistantArchitectStreaming tool={tool} isPreview={true} />
+        <AssistantArchitectStreaming tool={tool} />
       </div>
     </div>
   )


### PR DESCRIPTION
## 🐛 Problem
After PR #326 migrated Assistant Architect to assistant-ui, the Thread component disappears after execution completes and is replaced by the old follow-up UI (AssistantArchitectChat), preventing users from testing follow-up conversations.

## 🔧 Solution
This PR removes the old follow-up UI and keeps the assistant-ui Thread component visible throughout the entire execution lifecycle, enabling seamless follow-up conversations.

## 📝 Changes Made

### Components Modified
1. **`assistant-architect-streaming.tsx`**
   - Removed conditional rendering of `AssistantArchitectChat` (lines 625-639)
   - Changed Thread visibility: `isExecuting` → `isExecuting || hasResults`
   - Removed unused imports: `AssistantArchitectChat`, `ChatErrorBoundary`, `ExecutionResultDetails`
   - Removed unused state: `conversationId`, `executionId`, `executionStartTime`, `executionEndTime`
   - Removed `isPreview` prop (only used by old chat component)
   - Updated progress indicator to show only during execution

2. **`preview-page-client.tsx`**
   - Removed `isPreview={true}` prop from AssistantArchitectStreaming call

### Behavior Changes
**Before**: Thread → (execution completes) → AssistantArchitectChat ❌  
**After**: Thread → (execution completes) → Thread (continues) ✅

The Thread component now handles:
1. Initial execution with streaming output
2. Follow-up conversations after completion

## ✅ Testing
- [x] TypeScript type checking passes (`npm run typecheck`)
- [x] ESLint checks pass (`npm run lint`)
- [x] No console errors in browser
- [x] Thread remains visible after execution
- [x] Progress indicator shows correctly during multi-prompt execution
- [x] Error handling still works

## 📊 Code Quality
- **Lines Changed**: -58 deletions, +6 insertions
- **Files Modified**: 2
- **Type Safety**: All TypeScript checks pass
- **Linting**: Zero ESLint warnings or errors

## 🧪 Manual Testing Steps
1. Navigate to `/utilities/assistant-architect`
2. Select or create an assistant
3. Go to Preview & Test step
4. Fill in input fields and click Generate
5. ✅ Verify streaming output displays in Thread
6. ✅ Verify Thread remains visible after completion (no UI switch)
7. ✅ Test follow-up questions work in same Thread
8. ✅ Verify execution history is preserved

## 🔗 Related
Closes #351  
Follows pattern from: Nexus Chat (`/app/(protected)/nexus/page.tsx`)  
Part of: PR #326 (assistant-ui migration)

## ⚠️ Breaking Changes
None - this is a bug fix that restores expected behavior

## 📚 Additional Notes
The old `AssistantArchitectChat` and `ChatErrorBoundary` components are now unused but remain in the codebase. A future cleanup PR could remove these files entirely if they're not needed for rollback purposes.