### PR TITLE
fix: #408 - Fix prompt ownership permission checks

### DIFF
--- a/actions/prompt-library.actions.ts
+++ b/actions/prompt-library.actions.ts
@@ -535,7 +535,7 @@ export async function updatePrompt(
       const updateQuery = `
         UPDATE prompt_library
         SET ${fields.join(", ")}
-        WHERE id = :id AND deleted_at IS NULL
+        WHERE id = :id::uuid AND deleted_at IS NULL
         RETURNING *
       `
 
@@ -605,7 +605,7 @@ export async function deletePrompt(id: string): Promise<ActionState<void>> {
     await executeSQL(
       `UPDATE prompt_library
        SET deleted_at = CURRENT_TIMESTAMP
-       WHERE id = :id AND deleted_at IS NULL`,
+       WHERE id = :id::uuid AND deleted_at IS NULL`,
       [{ name: "id", value: { stringValue: id } }]
     )
 
@@ -692,7 +692,7 @@ async function updateTagsForPrompt(
 ): Promise<void> {
   // Remove existing tags
   await executeSQL(
-    `DELETE FROM prompt_library_tags WHERE prompt_id = :promptId`,
+    `DELETE FROM prompt_library_tags WHERE prompt_id = :promptId::uuid`,
     [{ name: "promptId", value: { stringValue: promptId } }]
   )
 

--- a/lib/prompt-library/access-control.ts
+++ b/lib/prompt-library/access-control.ts
@@ -34,10 +34,10 @@ export async function canReadPrompt(
   userId: number
 ): Promise<boolean> {
   const results = await executeSQL<{
-    user_id: number
+    userId: number
     visibility: string
-    moderation_status: string
-    deleted_at: string | null
+    moderationStatus: string
+    deletedAt: string | null
   }>(
     `SELECT user_id, visibility, moderation_status, deleted_at
      FROM prompt_library
@@ -45,19 +45,19 @@ export async function canReadPrompt(
     [{ name: "promptId", value: { stringValue: promptId } }]
   )
 
-  if (results.length === 0 || results[0].deleted_at) {
+  if (results.length === 0 || results[0].deletedAt) {
     return false
   }
 
   const prompt = results[0]
 
   // Owner can always read their own prompts - ensure numeric comparison
-  if (Number(prompt.user_id) === Number(userId)) {
+  if (Number(prompt.userId) === Number(userId)) {
     return true
   }
 
   // Public prompts must be approved to be visible to others
-  if (prompt.visibility === 'public' && prompt.moderation_status === 'approved') {
+  if (prompt.visibility === 'public' && prompt.moderationStatus === 'approved') {
     return true
   }
 
@@ -82,7 +82,7 @@ export async function canUpdatePrompt(
 
   log.info("Permission check started", { promptId, userId })
 
-  const results = await executeSQL<{ user_id: number; deleted_at: string | null }>(
+  const results = await executeSQL<{ userId: number; deletedAt: string | null }>(
     `SELECT user_id, deleted_at FROM prompt_library WHERE id = :promptId::uuid`,
     [{ name: "promptId", value: { stringValue: promptId } }]
   )
@@ -92,13 +92,13 @@ export async function canUpdatePrompt(
     return false
   }
 
-  if (results[0].deleted_at) {
-    log.warn("Prompt is deleted", { promptId, deletedAt: results[0].deleted_at })
+  if (results[0].deletedAt) {
+    log.warn("Prompt is deleted", { promptId, deletedAt: results[0].deletedAt })
     return false
   }
 
-  // Get the raw database value
-  const dbUserId = results[0].user_id
+  // Get the raw database value (field is transformed from user_id to userId by data-api-adapter)
+  const dbUserId = results[0].userId
   const dbUserIdType = typeof dbUserId
 
   // Convert both to numbers with validation
@@ -168,19 +168,19 @@ export async function canDeletePrompt(
   promptId: string,
   userId: number
 ): Promise<boolean> {
-  const results = await executeSQL<{ user_id: number; deleted_at: string | null }>(
+  const results = await executeSQL<{ userId: number; deletedAt: string | null }>(
     `SELECT user_id, deleted_at FROM prompt_library WHERE id = :promptId::uuid`,
     [{ name: "promptId", value: { stringValue: promptId } }]
   )
 
-  if (results.length === 0 || results[0].deleted_at) {
+  if (results.length === 0 || results[0].deletedAt) {
     return false
   }
 
   const prompt = results[0]
 
   // Owner can delete their own prompts - ensure numeric comparison
-  if (Number(prompt.user_id) === Number(userId)) {
+  if (Number(prompt.userId) === Number(userId)) {
     return true
   }
 


### PR DESCRIPTION
## Summary
Fixes issue #408 by resolving two bugs that prevented users from editing their own prompts.

## Root Causes

### Bug 1: Field Name Mismatch
The RDS Data API adapter transforms snake_case database columns to camelCase, but TypeScript interfaces used snake_case, causing `results[0].user_id` to return `undefined`.

**Production logs showed:**
```json
{"dbUserIdType": "undefined", "promptUserId": null}
```

### Bug 2: Missing UUID Type Casts  
SQL WHERE clauses comparing UUID columns with string parameters needed explicit `::uuid` casts.

**Error:**
```
ERROR: operator does not exist: uuid = text
```

## Changes

### lib/prompt-library/access-control.ts
- ✅ Fixed TypeScript interfaces: `user_id` → `userId`, `deleted_at` → `deletedAt`
- ✅ Updated all property access to use camelCase
- ✅ Added inline documentation explaining transformation

### actions/prompt-library.actions.ts
- ✅ Added `::uuid` casts to WHERE clauses in updatePrompt (line 538)
- ✅ Added `::uuid` cast in deletePrompt (line 608)  
- ✅ Added `::uuid` cast in updateTagsForPrompt (line 695)

## Testing
- ✅ TypeScript compilation passes
- ✅ ESLint passes with no warnings
- ✅ Production logs confirm permission check succeeds:
  - `dbUserIdType: "number"` (was "undefined")
  - `promptUserIdIsValid: true` (was false)
  - `"Permission granted - owner match"`

## Expected Outcome
- Owners can edit their own prompts
- SQL queries execute without type errors
- Non-owners correctly denied
- Comprehensive audit logging works

## Type of Change
- [x] Bug fix (non-breaking)
- [x] Critical issue blocking users

Closes #408