### PR TITLE
fix: Document processing 500 errors after CDK stack refresh and ECS transition

### DIFF
--- a/app/api/documents/v2/confirm-upload/route.ts
+++ b/app/api/documents/v2/confirm-upload/route.ts
@@ -71,19 +71,22 @@ export async function POST(req: NextRequest) {
     });
     
   } catch (error) {
-    log.error('Failed to confirm upload', error);
+    // Safe error logging to avoid circular reference issues
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    const errorName = error instanceof Error ? error.name : 'Unknown';
+    log.error(`Failed to confirm upload ${errorMessage}`, { name: errorName });
     timer({ status: 'error' });
-    
+
     if (error instanceof z.ZodError) {
       return NextResponse.json(
-        { 
+        {
           error: 'Invalid request data',
           details: error.issues.map((e) => `${e.path.join('.')}: ${e.message}`)
         },
         { status: 400 }
       );
     }
-    
+
     return NextResponse.json(
       { error: 'Failed to confirm upload' },
       { status: 500 }

--- a/infra/lib/constructs/ecs-service.ts
+++ b/infra/lib/constructs/ecs-service.ts
@@ -301,6 +301,7 @@ export class EcsServiceConstruct extends Construct {
               ],
               resources: [
                 `arn:aws:sqs:${cdk.Stack.of(this).region}:${cdk.Stack.of(this).account}:aistudio-${environment}-*`,
+                `arn:aws:sqs:${cdk.Stack.of(this).region}:${cdk.Stack.of(this).account}:AIStudio-*-${environment}`,
               ],
             }),
             new iam.PolicyStatement({
@@ -321,6 +322,7 @@ export class EcsServiceConstruct extends Construct {
               ],
               resources: [
                 `arn:aws:dynamodb:${cdk.Stack.of(this).region}:${cdk.Stack.of(this).account}:table/aistudio-${environment}-*`,
+                `arn:aws:dynamodb:${cdk.Stack.of(this).region}:${cdk.Stack.of(this).account}:table/AIStudio-*-${environment}`,
               ],
             }),
             new iam.PolicyStatement({


### PR DESCRIPTION
## Summary
Fixes document upload failures in production (and dev) after the recent CDK stack refresh and ECS transition. Resolves AccessDeniedException errors and circular reference logging issues.

## Problem
Document uploads were failing with 500 errors in both dev and prod AWS environments (local dev worked fine). Investigation revealed three distinct issues:

1. **DynamoDB Access Denied**: ECS task role couldn't write to `AIStudio-DocumentJobs-{env}` table
2. **SQS Access Denied**: ECS task role couldn't send messages to `AIStudio-DocumentProcessing-{env}` queues  
3. **Logging Stack Overflow**: Error serialization caused "Maximum call stack size exceeded"

## Root Cause
IAM policies used lowercase naming pattern (`aistudio-{env}-*`) but actual resources use PascalCase (`AIStudio-*-{env}`). This naming inconsistency exists across multiple CDK stacks.

## Changes

### IAM Policy Updates (`infra/lib/constructs/ecs-service.ts`)
- Added `AIStudio-*-{environment}` pattern to DynamoDB permissions
- Added `AIStudio-*-{environment}` pattern to SQS permissions
- Now supports both naming conventions for backward compatibility

### Error Logging Fix (`app/api/documents/v2/confirm-upload/route.ts`)
- Safely extract error message/name before logging
- Prevents circular reference serialization in AWS SDK errors
- Allows actual error messages to appear in CloudWatch logs

## Testing
- ✅ TypeScript compilation passes
- ✅ ESLint validation passes  
- ✅ Verified IAM policies against actual AWS resources
- ✅ Confirmed naming patterns match DynamoDB tables and SQS queues

## Deployment Notes
**Additional manual step required:**
- S3 bucket name in prod database settings was incorrect and was manually updated via SQL:
  ```sql
  UPDATE settings 
  SET value = 'aistudio-storagestack-prod-documentsbucket9ec9deb9-6armwb5y4asy' 
  WHERE key = 'S3_BUCKET';
  ```

## Impact
- **Dev**: Document uploads now work ✅
- **Prod**: Document uploads now work ✅
- **No breaking changes**: Only expands IAM permissions
- **Backward compatible**: Existing lowercase-named resources continue working

## Follow-up
Consider standardizing naming conventions across CDK stacks to prevent similar issues in the future.

Closes #440