### PR TITLE
fix: remove 50-row truncation from XLSX markdown conversion

### DIFF
--- a/infra/lambdas/document-processor-v2/processors/office-processor.ts
+++ b/infra/lambdas/document-processor-v2/processors/office-processor.ts
@@ -376,10 +376,9 @@ export class OfficeProcessor implements DocumentProcessor {
             markdown += '| ' + headers.map(() => '---').join(' | ') + ' |\n';
             
             // Include all data rows for complete AI context
+            // Use array.map().join() for better performance with large datasets
             const dataRows = rows.slice(1);
-            dataRows.forEach((row: any[]) => {
-              markdown += '| ' + row.join(' | ') + ' |\n';
-            });
+            markdown += dataRows.map((row: any[]) => '| ' + row.join(' | ') + ' |\n').join('');
           }
         }
         


### PR DESCRIPTION
## Summary

Fixes the document-processor-v2's XLSX to markdown conversion that was truncating spreadsheet data to only 50 rows. This prevented AI assistants from receiving complete file content.

## Changes

- Remove hardcoded 50-row limit in `convertXlsxToMarkdown()`
- Remove truncation message that appeared after row 51  
- Include all data rows for complete AI context

## Root Cause

The `processXlsx()` method already extracts ALL rows via `XLSX.utils.sheet_to_csv()` for text content - only the markdown conversion had this artificial limit. This fix ensures consistency between text and markdown outputs.

## Test Plan

- [ ] Upload XLSX file with 100+ rows through Nexus attachment
- [ ] Upload XLSX file with 100+ rows through Assistant Architect
- [ ] Verify no "... and N more rows" truncation message appears
- [ ] Verify all rows are present in AI context

## Checklist

- [x] Code follows project conventions
- [x] No TypeScript errors (`npm run typecheck` passes)
- [x] No lint errors (`npm run lint` passes)

Closes #515