### PR TITLE
feat: #523 - Persist parallel prompt connections in Assistant Architect

### DIFF
--- a/tests/e2e/assistant-architect-parallel-persistence.spec.ts
+++ b/tests/e2e/assistant-architect-parallel-persistence.spec.ts
@@ -12,6 +12,10 @@ import { test, expect } from '@playwright/test'
  * Related: Epic #523
  */
 
+// Test configuration constants
+const MIN_NODE_SPACING = 50; // px - minimum horizontal spacing between parallel nodes
+const Y_POSITION_TOLERANCE = 10; // px - tolerance for grouping nodes at same vertical position
+
 test.describe('Assistant Architect - Parallel Execution Persistence', () => {
   test.describe('Edge Persistence', () => {
     test('should persist edge connections when navigating away and back', async ({ page }) => {
@@ -330,14 +334,13 @@ test.describe('Assistant Architect - Parallel Execution Persistence', () => {
       expect(nodePositions.length).toBeGreaterThan(0)
 
       // Group nodes by Y coordinate (vertical position) with tolerance
-      const yTolerance = 10 // pixels
       const nodesByYPosition = new Map<number, { x: number; y: number }[]>()
 
       for (const pos of nodePositions) {
         // Find existing Y group or create new one
         let foundGroup = false
         for (const [yKey, group] of nodesByYPosition.entries()) {
-          if (Math.abs(yKey - pos.y) < yTolerance) {
+          if (Math.abs(yKey - pos.y) < Y_POSITION_TOLERANCE) {
             group.push(pos)
             foundGroup = true
             break
@@ -355,7 +358,7 @@ test.describe('Assistant Architect - Parallel Execution Persistence', () => {
           const xCoords = nodesAtSameY.map(n => n.x).sort((a, b) => a - b)
           for (let i = 1; i < xCoords.length; i++) {
             // Each node should have a different X coordinate
-            expect(Math.abs(xCoords[i] - xCoords[i-1])).toBeGreaterThan(50) // At least 50px apart
+            expect(Math.abs(xCoords[i] - xCoords[i-1])).toBeGreaterThan(MIN_NODE_SPACING)
           }
         }
       }


### PR DESCRIPTION
## Summary

Fixes the parallel prompt execution persistence issue where users could draw parallel connections in the ReactFlow editor but edge/connection data was lost on page reload.

This epic consolidates and resolves:
- #335 - Original parallel execution feature request
- #504 - Test coverage requirements
- #516 - UI persistence bug

## Problem

Users can visually create parallel execution flows in Step 3 of Assistant Architect, but when they leave and return:
1. Custom edge connections are lost
2. System auto-regenerates edges from position numbers only
3. Parallel execution intent is silently discarded

## Root Cause

The `parallel_group` column existed in the database but was never used:
- `setPromptPositionsAction()` only saved `position`, discarding edge data
- `getAssistantArchitectByIdAction()` didn't SELECT `parallel_group`
- Edge reconstruction used only position-based heuristics

## Solution

**Backend Changes:**
- Add `parallel_group` to SELECT query in `getAssistantArchitectByIdAction()`
- Update `setPromptPositionsAction()` to accept and persist `parallelGroup`
- Modified UPDATE SQL to save `parallel_group` alongside `position`

**Frontend Changes:**
- Update `calculateExecutionOrder()` to compute `parallelGroup` from graph topology
- Nodes at same position receive unique parallel group IDs
- Edge reconstruction now uses `parallelGroup` for precise connection matching
- Handles multiple-to-multiple edge connections correctly

**Testing:**
- Added E2E tests for edge persistence across navigation
- Added tests for parallel group calculation
- Added backward compatibility tests

## Implementation Approach

Used **Option A** from the epic: leverage existing `parallel_group` column (no migration needed).

## Changes

| File | Change |
|------|--------|
| `actions/db/assistant-architect-actions.ts` | Added `parallel_group` to SELECT, updated `setPromptPositionsAction` signature and UPDATE query |
| `prompts-page-client.tsx` | Updated `calculateExecutionOrder()` to compute parallel groups, improved edge reconstruction logic |
| `tests/e2e/assistant-architect-parallel-persistence.spec.ts` | New E2E test file |

## Testing

- [x] Lint passes
- [x] TypeScript compilation passes
- [x] E2E tests added for:
  - Edge persistence across page navigation
  - Edge structure after page reload
  - Parallel group calculation
  - Backward compatibility with existing assistants
  - Visual layout of parallel nodes

## Acceptance Criteria

- [x] Parallel prompt connections persist across page navigation
- [x] Custom edge configurations restored on reload
- [x] `parallel_group` field populated and retrieved correctly
- [x] Backward compatible with existing assistants (null `parallel_group` handled gracefully)

Closes #523