### PR TITLE
fix: add JSONB cast for options column in tool input fields (#471)

### DIFF
--- a/actions/db/assistant-architect-actions.ts
+++ b/actions/db/assistant-architect-actions.ts
@@ -745,7 +745,7 @@ export async function addToolInputFieldAction(
     log.info("Action started: Adding tool input field", { architectId, fieldName: data.name })
     await executeSQL<never>(`
       INSERT INTO tool_input_fields (assistant_architect_id, name, label, field_type, position, options, created_at, updated_at)
-      VALUES (:toolId, :name, :label, :fieldType::field_type, :position, :options, NOW(), NOW())
+      VALUES (:toolId, :name, :label, :fieldType::field_type, :position, :options::jsonb, NOW(), NOW())
     `, [
       { name: 'toolId', value: { longValue: Number.parseInt(architectId, 10) } },
       { name: 'name', value: { stringValue: data.name } },
@@ -912,6 +912,9 @@ export async function updateInputFieldAction(
         const snakeKey = key === 'fieldType' ? 'field_type' : key === 'toolId' ? 'assistant_architect_id' : key;
         if (key === 'fieldType') {
           updateFields.push(`${snakeKey} = :param${paramIndex}::field_type`);
+        } else if (key === 'options') {
+          // Options is a JSONB column - must cast from text to jsonb
+          updateFields.push(`${snakeKey} = :param${paramIndex}::jsonb`);
         } else {
           updateFields.push(`${snakeKey} = :param${paramIndex}`);
         }


### PR DESCRIPTION
## Description

Fixes the database error preventing single select field options from being saved in the Assistant Architect tool:

```
ERROR: column "options" is of type jsonb but expression is of type text
Hint: You will need to rewrite or cast the expression.
```

## Root Cause

The `options` column in the `tool_input_fields` table is defined as `JSONB`, but the SQL queries in both `addToolInputFieldAction` and `updateInputFieldAction` were passing text values via the RDS Data API without explicit type casting. PostgreSQL requires an explicit `::jsonb` cast when inserting/updating text into JSONB columns via parameterized queries.

## Changes

1. **`addToolInputFieldAction`** (line 748): Added `::jsonb` cast to the INSERT query
2. **`updateInputFieldAction`** (line 915-917): Added conditional logic to append `::jsonb` cast when updating the `options` field

## Validation

- This fix follows the existing pattern used throughout the codebase for other JSONB columns:
  - `chain_prompts`: `input_mapping`, `repository_ids`, `enabled_tools` all use `::jsonb` cast
  - `knowledge_repositories`: `metadata` uses `::jsonb` cast
- Lint and typecheck pass

## Testing

- [ ] Create a single select field with options in Assistant Architect
- [ ] Save the field
- [ ] Refresh the page
- [ ] Verify options persist correctly
- [ ] Update an existing single select field's options
- [ ] Verify updates persist correctly

Closes #471