### PR TITLE
fix: #565 - Migration 042 CONCURRENTLY incompatibility with RDS Data API

### DIFF
--- a/docs/guides/database-migrations.md
+++ b/docs/guides/database-migrations.md
@@ -1,0 +1,141 @@
+# Database Migrations Guide
+
+This guide covers best practices for writing database migrations that work with the Lambda migration handler and RDS Data API.
+
+## Migration System Overview
+
+Database migrations are managed through:
+- **SQL files**: Located in `infra/database/schema/`
+- **Lambda handler**: `infra/database/lambda/db-init-handler.ts`
+- **Tracking table**: `migration_log` in the database
+
+Migrations run automatically during CDK deployment via a custom resource.
+
+## File Naming Convention
+
+```
+XXX-descriptive-name.sql
+```
+
+Where `XXX` is a three-digit number (e.g., `042`, `043`). Numbers 001-009 are reserved for initial setup.
+
+## Adding a New Migration
+
+1. Create SQL file in `infra/database/schema/`
+2. Add filename to `MIGRATION_FILES` array in `db-init-handler.ts`
+3. Deploy with `npx cdk deploy`
+
+## RDS Data API Limitations
+
+The migration system uses AWS RDS Data API, which has specific limitations:
+
+### ❌ CONCURRENTLY Operations Are NOT Supported
+
+**DO NOT USE** these patterns in migrations:
+
+```sql
+-- WILL FAIL - CONCURRENTLY is incompatible with RDS Data API
+CREATE INDEX CONCURRENTLY idx_name ON table (column);
+DROP INDEX CONCURRENTLY idx_name;
+REINDEX CONCURRENTLY table_name;
+```
+
+**Reason**: `CONCURRENTLY` requires autocommit mode and uses multiple internal transactions, which is incompatible with how RDS Data API executes statements.
+
+**USE INSTEAD**:
+
+```sql
+-- WORKS - Standard index creation (briefly blocks writes)
+CREATE INDEX IF NOT EXISTS idx_name ON table (column);
+DROP INDEX IF EXISTS idx_name;
+```
+
+### When You Need Zero-Downtime Index Creation
+
+For large production tables where blocking writes is unacceptable:
+
+1. **Use psql directly** during a maintenance window:
+   ```bash
+   psql -h <rds-endpoint> -U <username> -d aistudio
+   CREATE INDEX CONCURRENTLY idx_name ON large_table (column);
+   ```
+
+2. **Create a maintenance script** separate from the Lambda system
+
+3. **Consider partial indexes** to reduce index size and creation time
+
+### Other Considerations
+
+#### Dollar-Quoted Blocks (DO $$ ... $$)
+
+These work but with caveats:
+- Cannot contain `CONCURRENTLY`
+- Should be simple verification, not complex logic
+- The `splitSqlStatements()` function handles them specially
+
+#### IF NOT EXISTS / IF EXISTS
+
+Always use these for idempotency:
+```sql
+CREATE TABLE IF NOT EXISTS ...
+CREATE INDEX IF NOT EXISTS ...
+ALTER TABLE ... ADD COLUMN IF NOT EXISTS ...
+DROP TABLE IF EXISTS ...
+```
+
+## Migration Template
+
+```sql
+-- Migration XXX: Brief description
+-- Part of Issue #NNN - Related issue title
+--
+-- Purpose:
+-- What this migration does and why
+--
+-- Notes:
+-- Any important considerations
+--
+-- Rollback:
+-- How to undo if needed
+
+-- The actual migration SQL
+CREATE TABLE IF NOT EXISTS new_table (
+  id SERIAL PRIMARY KEY,
+  name VARCHAR(255) NOT NULL,
+  created_at TIMESTAMP DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_new_table_name ON new_table (name);
+```
+
+## Troubleshooting
+
+### Migration Marked as Failed But Actually Succeeded
+
+This can happen when:
+- An error occurs after the DDL succeeds
+- Verification blocks (DO $$ ... $$) throw exceptions
+- Network issues during status recording
+
+**To fix**: Create a new migration to update `migration_log`:
+
+```sql
+-- Migration XXX: Fix migration_log status for migration YYY
+UPDATE migration_log
+SET status = 'completed', error_message = NULL
+WHERE description = 'YYY-original-migration.sql'
+  AND status = 'failed';
+```
+
+### Handler Version
+
+The handler logs its version on each run. Check CloudWatch Logs:
+```
+Handler version: 2025-12-24-v12 - Add CONCURRENTLY detection, fix migration 042
+```
+
+## References
+
+- [PostgreSQL CREATE INDEX](https://www.postgresql.org/docs/current/sql-createindex.html)
+- [RDS Data API Documentation](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/data-api.html)
+- [Issue #565 - Migration 042 CONCURRENTLY incompatibility](https://github.com/psd401/aistudio/issues/565)

--- a/infra/database/schema/042-ai-streaming-jobs-pending-index.sql
+++ b/infra/database/schema/042-ai-streaming-jobs-pending-index.sql
@@ -11,34 +11,24 @@
 -- - Keep index size small by only indexing pending jobs
 -- - Support efficient FIFO processing (ORDER BY created_at ASC)
 --
+-- NOTE: CONCURRENTLY removed - incompatible with RDS Data API / Lambda migration system
+-- For zero-downtime index creation on large production tables, use direct psql connection
+-- The IF NOT EXISTS clause provides idempotency for safe re-runs
+--
 -- ROLLBACK PROCEDURE (if migration fails):
 -- If the index creation fails or needs to be removed:
 --   1. Connect to database: psql -h <rds-endpoint> -U <username> -d aistudio
 --   2. Check index state:
 --      SELECT indexname, indexdef FROM pg_indexes
 --      WHERE indexname = 'idx_ai_streaming_jobs_pending_created';
---   3. Drop invalid index:
---      DROP INDEX CONCURRENTLY IF EXISTS idx_ai_streaming_jobs_pending_created;
+--   3. Drop index if needed:
+--      DROP INDEX IF EXISTS idx_ai_streaming_jobs_pending_created;
 --   4. Remove from migration_log:
---      DELETE FROM migration_log WHERE migration_name = '042-ai-streaming-jobs-pending-index.sql';
+--      DELETE FROM migration_log WHERE description = '042-ai-streaming-jobs-pending-index.sql';
 --   5. Re-run migration via CDK deploy
 
 -- Create composite partial index for pending jobs
--- CONCURRENTLY allows creation without blocking writes
-CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_ai_streaming_jobs_pending_created
+-- IF NOT EXISTS ensures idempotency (index already created successfully)
+CREATE INDEX IF NOT EXISTS idx_ai_streaming_jobs_pending_created
   ON ai_streaming_jobs (status, created_at)
   WHERE status = 'pending';
-
--- Verify index was created
-DO $$
-BEGIN
-  IF EXISTS (
-    SELECT 1
-    FROM pg_indexes
-    WHERE indexname = 'idx_ai_streaming_jobs_pending_created'
-  ) THEN
-    RAISE NOTICE 'Index idx_ai_streaming_jobs_pending_created created successfully';
-  ELSE
-    RAISE EXCEPTION 'Failed to create index idx_ai_streaming_jobs_pending_created';
-  END IF;
-END $$;


### PR DESCRIPTION
## Summary

Fixes migration 042 which failed due to `CREATE INDEX CONCURRENTLY` being incompatible with RDS Data API / Lambda migration system.

Closes #565

## Root Cause

PostgreSQL `CONCURRENTLY` operations:
- Require autocommit mode
- Use multiple internal transactions
- Cannot run in a transaction block

RDS Data API cannot support this execution model, causing migrations with CONCURRENTLY to fail.

## Changes

### 1. Fixed Migration 042
- Removed `CONCURRENTLY` keyword
- Changed to `CREATE INDEX IF NOT EXISTS` (standard, works with Data API)
- Added documentation explaining the limitation
- `IF NOT EXISTS` ensures idempotency (index already exists from partial run)

### 2. Added CONCURRENTLY Detection Guard
- New `validateStatements()` function in handler
- Runs before execution, fails fast with clear error
- Prevents future migrations from using this anti-pattern

### 3. Added Migration Documentation
- New `docs/guides/database-migrations.md`
- Documents RDS Data API limitations
- Provides alternative approaches for zero-downtime indexing

## How the Fix Works

```
1. Handler detects 042 not completed (status = 'failed')
2. Re-runs fixed 042 (no CONCURRENTLY)
3. CREATE INDEX IF NOT EXISTS succeeds (no-op, index exists)
4. Handler records 042 as 'completed'
```

## Testing

- [x] TypeScript: 0 errors
- [x] ESLint: 0 errors
- [x] No other CONCURRENTLY usage in migrations
- [ ] Deploy to dev and verify migration completes

## Checklist

- [x] Code follows project conventions
- [x] No TypeScript errors
- [x] Documentation added
- [x] Addresses all acceptance criteria from issue