### PR TITLE
fix: #604 - Restore padding to dialog components

### DIFF
--- a/components/ui/dialog.tsx
+++ b/components/ui/dialog.tsx
@@ -82,7 +82,7 @@ function DialogContent({
         {...props}
         className={cn(
           "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 rounded-lg border shadow-lg duration-200",
-          !wide && "fixed top-[50%] left-[50%] z-50 w-full translate-x-[-50%] translate-y-[-50%]",
+          !wide && "fixed top-[50%] left-[50%] z-50 grid w-full translate-x-[-50%] translate-y-[-50%] gap-4 p-6",
           className
         )}
         style={inlineStyles}


### PR DESCRIPTION
## Summary
- Restores `p-6` padding and `gap-4` spacing to non-wide DialogContent
- Fixes schedule edit modal (and all other dialogs) displaying content without proper edge spacing

## Changes
- Added `grid`, `gap-4`, and `p-6` classes to non-wide DialogContent in `components/ui/dialog.tsx`
- These classes were removed during wide modal refactoring (commits a37abca, d556a04, 5595c96)

## Testing
- [ ] Schedule edit modal has proper padding around content
- [ ] AI models add/edit modal renders correctly
- [ ] User add/edit modal renders correctly
- [ ] Wide modals (if any) still function at 95vw
- [ ] Dialogs with explicit `p-0` (navigation-item-form, user-detail-sheet) still work

## Root Cause
The base `DialogContent` component had `p-6` padding and `gap-4` spacing removed to support wide modals. This was correct for wide modals but inadvertently removed defaults for all standard dialogs.

Closes #604

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated dialog layout on smaller screens to use a more flexible grid-based positioning with improved spacing, replacing the previous fixed-position centering approach.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->