### PR TITLE
fix: remove @aws-sdk/lib-storage to resolve Turbopack MODULE_NOT_FOUND

### DIFF
--- a/lib/aws/document-upload.ts
+++ b/lib/aws/document-upload.ts
@@ -1,8 +1,6 @@
 import { S3Client, PutObjectCommand, CreateMultipartUploadCommand, UploadPartCommand, CompleteMultipartUploadCommand } from '@aws-sdk/client-s3';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 import { createLogger } from '@/lib/logger';
-import { Readable } from 'node:stream';
-import type { ReadableStream as WebReadableStream } from 'node:stream/web';
 
 const s3Client = new S3Client({});
 const log = createLogger({ service: 'document-upload' });
@@ -260,12 +258,38 @@ export interface DirectUploadResult {
 }
 
 /**
+ * Convert a Web ReadableStream to a Buffer.
+ * Used for S3 uploads since @aws-sdk/lib-storage has Turbopack compatibility issues.
+ */
+async function streamToBuffer(stream: ReadableStream<Uint8Array>): Promise<Buffer> {
+  const chunks: Uint8Array[] = [];
+  const reader = stream.getReader();
+
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    if (value) chunks.push(value);
+  }
+
+  return Buffer.concat(chunks);
+}
+
+/**
  * Upload a file directly to S3 using the SDK (server-side).
  * This bypasses presigned URLs which can be blocked by school network proxies.
  *
- * Supports both streaming and buffered uploads:
- * - For streaming (memory-efficient): Use fileStream
- * - For buffered (legacy): Use fileBuffer
+ * ## Memory Model
+ * Both fileStream and fileBuffer result in the entire file being loaded into memory.
+ * This is acceptable because:
+ * - Next.js formData() already loads the file into memory before we receive it
+ * - Rate limiting (5 uploads/min/user) controls concurrent memory usage
+ * - File size limits (50MB assistant, 500MB chat) bound maximum memory per upload
+ *
+ * ## Why not @aws-sdk/lib-storage?
+ * That package has Turbopack compatibility issues (MODULE_NOT_FOUND at runtime)
+ * due to missing proper `exports` field in package.json. Using PutObjectCommand
+ * from @aws-sdk/client-s3 works reliably with Turbopack.
  *
  * @see https://github.com/psd401/aistudio/issues/632
  */
@@ -276,58 +300,34 @@ export async function uploadToS3(config: DirectUploadConfig): Promise<DirectUplo
   const bucket = getDocumentsBucket();
 
   try {
-    let body: Buffer | Readable;
+    let body: Buffer;
 
     if (fileStream) {
-      // Convert Web ReadableStream to Node.js Readable stream for streaming upload
-      // This is memory-efficient for large files
-      body = Readable.fromWeb(fileStream as WebReadableStream<Uint8Array>);
-
-      // Dynamic import to avoid Turbopack resolution issues with @aws-sdk/lib-storage
-      // (package lacks proper exports field, causing static import failures)
-      const { Upload } = await import('@aws-sdk/lib-storage');
-
-      // Use Upload class for streaming (handles multipart automatically)
-      const upload = new Upload({
-        client: s3Client,
-        params: {
-          Bucket: bucket,
-          Key: s3Key,
-          Body: body,
-          ContentType: contentType,
-          Metadata: {
-            jobId,
-            originalFileName: fileName,
-            uploadTimestamp: Date.now().toString(),
-          },
-        },
-        queueSize: 4, // Concurrent parts
-        partSize: 5 * 1024 * 1024, // 5MB chunks
-      });
-
-      await upload.done();
-
-      log.info('Direct S3 streaming upload completed', { jobId, fileName, s3Key, method: 'streaming' });
+      // Convert ReadableStream to Buffer for S3 upload
+      // Note: This loads the file into memory, but formData() already did that
+      body = await streamToBuffer(fileStream);
+      log.info('Converted stream to buffer', { jobId, fileName, size: body.length });
     } else if (fileBuffer) {
-      // Legacy buffered upload (loads entire file in memory)
-      const command = new PutObjectCommand({
-        Bucket: bucket,
-        Key: s3Key,
-        Body: fileBuffer,
-        ContentType: contentType,
-        Metadata: {
-          jobId,
-          originalFileName: fileName,
-          uploadTimestamp: Date.now().toString(),
-        },
-      });
-
-      await s3Client.send(command);
-
-      log.info('Direct S3 buffered upload completed', { jobId, fileName, s3Key, size: fileBuffer.length, method: 'buffered' });
+      body = fileBuffer;
     } else {
       throw new Error('Either fileBuffer or fileStream must be provided');
     }
+
+    const command = new PutObjectCommand({
+      Bucket: bucket,
+      Key: s3Key,
+      Body: body,
+      ContentType: contentType,
+      Metadata: {
+        jobId,
+        originalFileName: fileName,
+        uploadTimestamp: Date.now().toString(),
+      },
+    });
+
+    await s3Client.send(command);
+
+    log.info('Direct S3 upload completed', { jobId, fileName, s3Key, size: body.length });
 
     return {
       s3Key,

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -18,7 +18,7 @@ const nextConfig = {
     ]
   },
   experimental: {
-    serverComponentsExternalPackages: ['mammoth', 'pdf-parse', '@aws-sdk/lib-storage', 'oidc-provider', 'argon2'], // Server-only packages with Node.js dependencies
+    serverComponentsExternalPackages: ['mammoth', 'pdf-parse', 'oidc-provider', 'argon2'], // Server-only packages with Node.js dependencies
     serverActions: {
       bodySizeLimit: '100mb', // Match the file upload limit from settings
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,6 @@
         "@aws-sdk/client-sqs": "^3.982.0",
         "@aws-sdk/client-ssm": "^3.982.0",
         "@aws-sdk/credential-providers": "^3.982.0",
-        "@aws-sdk/lib-storage": "^3.982.0",
         "@aws-sdk/s3-request-presigner": "^3.982.0",
         "@aws-sdk/util-dynamodb": "^3.982.0",
         "@dnd-kit/core": "^6.3.1",
@@ -4743,37 +4742,6 @@
       },
       "engines": {
         "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/lib-storage": {
-      "version": "3.982.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/lib-storage/-/lib-storage-3.982.0.tgz",
-      "integrity": "sha512-N3FeXRwWxkRq5/WSNqgg4PNaT6mFG8eZyKs1AsS7n3PvoLTa17qTvtKUlxYvyf4AC5qNRF8Vp1OCMQycV013SQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/abort-controller": "^4.2.8",
-        "@smithy/middleware-endpoint": "^4.4.12",
-        "@smithy/smithy-client": "^4.11.1",
-        "buffer": "5.6.0",
-        "events": "3.3.0",
-        "stream-browserify": "3.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "peerDependencies": {
-        "@aws-sdk/client-s3": "3.982.0"
-      }
-    },
-    "node_modules/@aws-sdk/lib-storage/node_modules/buffer": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
-      "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.0.2",
-        "ieee754": "^1.1.4"
       }
     },
     "node_modules/@aws-sdk/middleware-bucket-endpoint": {
@@ -19672,7 +19640,9 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
       "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.8.x"
       }
@@ -26516,6 +26486,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -28439,30 +28410,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/stream-browserify": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-3.0.0.tgz",
-      "integrity": "sha512-H73RAHsVBapbim0tU2JwwOiXUj+fikfiaoYAKHF3VJfA0pe2BCzkhAHBlLG6REzE+2WNZcxOXjK7lkso+9euLA==",
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "~2.0.4",
-        "readable-stream": "^3.5.0"
-      }
-    },
-    "node_modules/stream-browserify/node_modules/readable-stream": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/strict-event-emitter": {

--- a/package.json
+++ b/package.json
@@ -66,7 +66,6 @@
     "@aws-sdk/client-sqs": "^3.982.0",
     "@aws-sdk/client-ssm": "^3.982.0",
     "@aws-sdk/credential-providers": "^3.982.0",
-    "@aws-sdk/lib-storage": "^3.982.0",
     "@aws-sdk/s3-request-presigner": "^3.982.0",
     "@aws-sdk/util-dynamodb": "^3.982.0",
     "@dnd-kit/core": "^6.3.1",


### PR DESCRIPTION
## Summary

Follow-up to PR #633. Removes `@aws-sdk/lib-storage` dependency that causes MODULE_NOT_FOUND runtime errors in Turbopack.

## Problem

After merging #633, document uploads fail at runtime with:
```
Failed to upload to S3: Cannot find module '@aws-sdk/lib-storage'
```

Even with dynamic import and `serverComponentsExternalPackages`, Turbopack cannot resolve this package due to missing proper `exports` field in its package.json.

## Solution

Remove `@aws-sdk/lib-storage` entirely and use `PutObjectCommand` from `@aws-sdk/client-s3` (which works).

## Changes

- **lib/aws/document-upload.ts**
  - Add `streamToBuffer()` helper to convert ReadableStream → Buffer
  - Replace Upload class with PutObjectCommand
  - Update JSDoc explaining memory model and Turbopack compatibility

- **next.config.mjs**
  - Remove from serverComponentsExternalPackages

- **package.json**
  - Remove @aws-sdk/lib-storage (4 packages removed)

## Memory Impact

Acceptable because:
- Next.js formData() already loads entire file into memory
- Rate limiting (5 uploads/min/user) controls concurrent memory
- File size limits bound max memory (50MB assistant, 500MB chat)

## Testing

- [x] TypeScript type checking passes
- [x] ESLint passes
- [x] npm install removes 4 packages cleanly
- [ ] Manual upload test (requires deployment)

## Checklist

- [x] Code follows project conventions
- [x] No TypeScript errors
- [x] Detailed commit message