### PR TITLE
fix(safety): Lower INSULTS/MISCONDUCT guardrail thresholds for educational content

### DIFF
--- a/infra/lib/guardrails-stack.ts
+++ b/infra/lib/guardrails-stack.ts
@@ -49,8 +49,15 @@ export class GuardrailsStack extends cdk.Stack {
       blockedOutputsMessaging: 'The AI response contained inappropriate content and has been blocked for your safety.',
 
       // Content filtering policies - Balanced for K-12 educational use
-      // MEDIUM allows legitimate educational discussions (history, literature, health)
-      // HIGH reserved for sexual content and prompt attacks
+      //
+      // Filter strength rationale (Issue #639):
+      // - LOW: Allows professional educational discussions including behavior management,
+      //   teacher observations, and student incident documentation
+      // - MEDIUM: Allows civil rights, Holocaust, history, literature discussions
+      // - HIGH: Reserved for truly inappropriate K-12 content
+      //
+      // Note: Topic-based filtering (weapons, drugs, self-harm, bullying) and profanity
+      // word lists provide additional protection independent of these content filters.
       contentPolicyConfig: {
         filtersConfig: [
           {
@@ -69,14 +76,20 @@ export class GuardrailsStack extends cdk.Stack {
             outputStrength: 'HIGH',
           },
           {
+            // Issue #639: Lowered from MEDIUM to LOW
+            // MEDIUM was blocking legitimate teacher observation content discussing
+            // student behavioral challenges (e.g., "argued", classroom management)
             type: 'INSULTS',
-            inputStrength: 'MEDIUM', // Allows character analysis in literature
-            outputStrength: 'MEDIUM',
+            inputStrength: 'LOW', // Allows behavior discussions, character analysis
+            outputStrength: 'LOW',
           },
           {
+            // Issue #639: Lowered from MEDIUM to LOW
+            // MEDIUM was blocking legitimate educational content about behavior
+            // management, student consequences, and disciplinary discussions
             type: 'MISCONDUCT',
-            inputStrength: 'MEDIUM', // Allows legal system, drug education discussions
-            outputStrength: 'MEDIUM',
+            inputStrength: 'LOW', // Allows behavior management, legal/drug education
+            outputStrength: 'LOW',
           },
           {
             type: 'PROMPT_ATTACK',


### PR DESCRIPTION
## Summary

Fixes false positive where Bedrock Guardrails blocked legitimate teacher observation content for Principal Brett Bradshaw.

**Problem**: The MEDIUM strength for INSULTS and MISCONDUCT filters was too aggressive for standard educational administrator use cases like coding teacher observations using the Danielson Framework.

**Solution**: Lower INSULTS and MISCONDUCT filters from MEDIUM to LOW.

## Changes

### `infra/lib/guardrails-stack.ts`
- Changed INSULTS filter: `MEDIUM` → `LOW`
- Changed MISCONDUCT filter: `MEDIUM` → `LOW`
- Added detailed comments explaining the rationale and referencing Issue #639

### `lib/safety/__tests__/bedrock-guardrails-service.test.ts`
Added 5 new test cases documenting legitimate educational content that should be allowed:
1. Teacher observation content (sample from blocked conversation)
2. Danielson Framework evaluation requests
3. Behavior management discussions
4. Special education SEL lesson observations
5. Classroom management discussions

## Safety Guarantees Maintained

Despite lowering INSULTS and MISCONDUCT thresholds, strong safety protections remain:

| Protection | Status |
|------------|--------|
| HATE filter | MEDIUM (unchanged) |
| VIOLENCE filter | MEDIUM (unchanged) |
| SEXUAL filter | HIGH (unchanged) |
| PROMPT_ATTACK filter | HIGH (unchanged) |
| Topic: Weapons | DENY (unchanged) |
| Topic: Drugs | DENY (unchanged) |
| Topic: Self-Harm | DENY (unchanged) |
| Topic: Bullying | DENY (unchanged) |
| Profanity word list | Active (unchanged) |

## Testing

- [x] All existing unit tests pass
- [x] New educational content tests pass (5 tests)
- [x] TypeScript compilation passes
- [x] ESLint passes (no new errors)
- [x] CDK synth validates

## Deployment Instructions

After merge, redeploy the GuardrailsStack to apply the new filter configuration:

```bash
cd infra && npx cdk deploy AIStudio-GuardrailsStack-Dev
```

## Verification

After deployment, have Brett Bradshaw retry his original Danielson Framework observation coding task to confirm the false positive is resolved.

Closes #639