### PR TITLE
feat: #699 — Save prompt chain results as conversation messages

### DIFF
--- a/lib/db/types/jsonb/index.ts
+++ b/lib/db/types/jsonb/index.ts
@@ -94,6 +94,22 @@ export interface NexusConversationMetadata {
 }
 
 /**
+ * Metadata for Assistant Architect prompt execution messages
+ * Stored in nexus_messages.metadata for assistant architect chain executions.
+ * Part of PR #715 - Save prompt chain results as conversation messages
+ */
+export interface AssistantArchitectMessageMetadata extends NexusConversationMetadata {
+  source: 'assistant-architect-execution';
+  executionId: number;
+  promptId: number;
+  promptName: string;
+  position: number;
+  executionTimeMs?: number;
+  failed?: boolean;
+  error?: string;
+}
+
+/**
  * Metadata for Decision Capture conversations (provider: "decision-capture")
  * Stored in nexus_conversations.metadata for decision capture sessions.
  * Part of Epic #675 (Context Graph Decision Capture Layer) - Issue #681


### PR DESCRIPTION
## Summary
- Each completed prompt result is now saved as an assistant message in the Nexus conversation (not just the final prompt)
- Failed prompt results are saved with error indication so the conversation shows what happened
- Existing `prompt_results` table is still populated (dual storage preserved)
- Message metadata includes promptId, promptName, position, and executionTimeMs for UI rendering

## Changes
- **`app/api/assistant-architect/execute/route.ts`**: Added `createMessageWithStats` call in the `onFinish` callback for every prompt (success and failure paths), removed duplicate save that only handled the last prompt

## Design Decisions
- **One message per prompt** — preserves chain structure, allows UI to render with headers
- **Dual storage is intentional** — `prompt_results` serves execution auditing, `nexus_messages` serves conversation UX
- **Non-fatal** — message save failures are logged but don't interrupt execution
- **`metadata.source: 'assistant-architect-execution'`** — distinguishes from regular chat messages

## Testing
- [ ] Execute a multi-prompt assistant architect chain and verify all prompt results appear as messages in the Nexus conversation
- [ ] Execute a single-prompt assistant and verify the result appears as a conversation message
- [ ] Trigger a prompt failure and verify the error message appears in the conversation
- [ ] Verify `prompt_results` table is still populated (dual storage)
- [ ] Verify SSE streaming performance is not impacted
- [ ] Verify conversation stats (message_count, last_message_at) are correct

## Dependencies
- Task 1: Create Nexus conversation on execution start (PR #714 — merged)

Closes #699