### PR TITLE
fix: #721 — Add missing database migration for decision capture tool

### DIFF
--- a/infra/database/lambda/db-init-handler.ts
+++ b/infra/database/lambda/db-init-handler.ts
@@ -52,7 +52,7 @@ const INITIAL_SETUP_FILES = migrationsConfig.initialSetupFiles;
 
 export async function handler(event: CustomResourceEvent): Promise<any> {
   console.log('Database initialization event:', JSON.stringify(event, null, 2));
-  console.log('Handler version: 2026-01-30-v13 - Add graph schema migration 050');
+  console.log('Handler version: 2026-02-03-v14 - Add decision capture tool migration 057');
   
   // SAFETY CHECK: Log what mode we're in
   console.log(`🔍 Checking database state for safety...`);

--- a/infra/database/migrations.json
+++ b/infra/database/migrations.json
@@ -51,6 +51,7 @@
     "053-oauth-provider-tables.sql",
     "054-oauth-consent-decisions.sql",
     "055-seed-decision-framework-prompt.sql",
-    "056-graph-nodes-search-indexes.sql"
+    "056-graph-nodes-search-indexes.sql",
+    "057-add-decision-capture-tool.sql"
   ]
 }

--- a/infra/database/schema/057-add-decision-capture-tool.sql
+++ b/infra/database/schema/057-add-decision-capture-tool.sql
@@ -1,0 +1,77 @@
+-- 057-add-decision-capture-tool.sql: Add Decision Capture tool, role grant, navigation, and model setting
+-- Migration file - only runs on existing databases (not fresh installs)
+-- Epic #675 (Context Graph Decision Capture Layer) - Issue #721
+--
+-- These records were only present in seed-local.sql, causing the tool to
+-- redirect to /dashboard on dev/prod due to hasToolAccess() returning false.
+
+-- 1. Insert the Decision Capture tool
+INSERT INTO tools (identifier, name, description, is_active, created_at, updated_at)
+SELECT
+    'decision-capture',
+    'Decision Capture',
+    'Extract and capture decisions from meeting transcripts into the context graph',
+    true,
+    NOW(),
+    NOW()
+WHERE NOT EXISTS (
+    SELECT 1 FROM tools WHERE identifier = 'decision-capture'
+);
+
+-- 2. Grant access to the Decision Capture tool for administrators
+INSERT INTO role_tools (role_id, tool_id, created_at)
+SELECT r.id, t.id, NOW()
+FROM roles r, tools t
+WHERE r.name = 'administrator'
+  AND t.identifier = 'decision-capture'
+  AND NOT EXISTS (
+    SELECT 1 FROM role_tools rt
+    WHERE rt.role_id = r.id AND rt.tool_id = t.id
+  );
+
+-- 3. Add navigation item for Decision Capture under Utilities section
+INSERT INTO navigation_items (
+    label,
+    icon,
+    link,
+    parent_id,
+    tool_id,
+    requires_role,
+    position,
+    is_active,
+    created_at,
+    description,
+    type
+)
+SELECT
+    'Decision Capture',
+    'IconGitBranch',
+    '/nexus/decision-capture',
+    (SELECT id FROM navigation_items WHERE label = 'Utilities' AND type = 'section' LIMIT 1),
+    t.id,
+    NULL,
+    40,
+    true,
+    NOW(),
+    'Extract decisions from meeting transcripts',
+    'link'
+FROM tools t
+WHERE t.identifier = 'decision-capture'
+  AND NOT EXISTS (
+    SELECT 1 FROM navigation_items ni
+    WHERE ni.link = '/nexus/decision-capture'
+  );
+
+-- 4. Add DECISION_CAPTURE_MODEL setting (required by decision-chat route)
+-- Uses gemini-3-flash-preview which matches the model_id in ai_models on dev/prod.
+-- Falls back gracefully: if this model_id doesn't exist in ai_models, the route
+-- returns a clear error message asking an administrator to update the setting.
+INSERT INTO settings (key, value, description, category, is_secret)
+VALUES (
+    'DECISION_CAPTURE_MODEL',
+    'gemini-3-flash-preview',
+    'AI model used for decision capture from meeting transcripts. Must match a model_id in ai_models table.',
+    'ai',
+    false
+)
+ON CONFLICT (key) DO NOTHING;


### PR DESCRIPTION
## Summary

- Decision capture tool redirected to `/dashboard` on dev/prod because `hasToolAccess('decision-capture')` returned `false`
- Root cause: tool registration, role grant, nav item, and model setting only existed in `seed-local.sql` (localhost), never as a deployed migration
- Adds migration `057-add-decision-capture-tool.sql` following the established pattern from `013`/`015`

## Changes

### New: `infra/database/schema/057-add-decision-capture-tool.sql`
Inserts 4 missing records (all idempotent with `NOT EXISTS`/`ON CONFLICT` guards):
1. **`tools`** — registers `decision-capture` tool identifier
2. **`role_tools`** — grants administrator role access
3. **`navigation_items`** — adds nav entry under Utilities section (parent looked up by label, not hardcoded ID)
4. **`settings`** — adds `DECISION_CAPTURE_MODEL = 'gemini-3-flash-preview'`

### Modified: `infra/database/migrations.json`
Registers `057-add-decision-capture-tool.sql` in the migration file list.

### Modified: `infra/database/lambda/db-init-handler.ts`
Updates handler version comment to `v14` for deployment tracking.

## Database verification (pre-migration state)

```sql
SELECT * FROM tools WHERE identifier = 'decision-capture';          -- 0 rows
SELECT * FROM navigation_items WHERE link = '/nexus/decision-capture'; -- 0 rows
SELECT * FROM settings WHERE key = 'DECISION_CAPTURE_MODEL';        -- 0 rows
```

## Test plan

- [ ] Migration runs without error on dev (via CDK deploy)
- [ ] Migration is idempotent (second run is a no-op)
- [ ] `hasToolAccess('decision-capture')` returns `true` for administrator
- [ ] `/nexus/decision-capture` loads without redirect
- [ ] Navigation item appears under Utilities
- [ ] Decision chat endpoint works (model setting resolves)
- [ ] `npm run lint` passes (0 errors)
- [ ] `npm run typecheck` passes

Closes #721