### PR TITLE
fix: URL validation and accessibility for web search citations

### DIFF
--- a/app/(protected)/nexus/_components/tools/web-search-ui.tsx
+++ b/app/(protected)/nexus/_components/tools/web-search-ui.tsx
@@ -4,6 +4,7 @@ import { makeAssistantToolUI } from '@assistant-ui/react'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
 import { ExternalLink, Globe, Clock } from 'lucide-react'
+import { isSafeUrl } from '@/lib/utils'
 
 interface WebSearchArgs {
   query: string
@@ -76,36 +77,43 @@ export const WebSearchUI = makeAssistantToolUI<WebSearchArgs, WebSearchResult>({
           </CardDescription>
         </CardHeader>
         <CardContent className="space-y-3">
-          {result.results.map((item, index) => (
-            <div key={index} className="space-y-1">
-              <div className="flex items-start justify-between gap-2">
-                <h4 className="text-sm font-medium text-blue-900 leading-tight">
-                  {item.title}
-                </h4>
-                <ExternalLink className="h-3 w-3 text-blue-600 flex-shrink-0 mt-0.5" />
+          {result.results.map((item, index) => {
+            // Security: Only render http/https URLs to prevent XSS
+            if (!isSafeUrl(item.url)) {
+              return null
+            }
+
+            return (
+              <div key={index} className="space-y-1">
+                <div className="flex items-start justify-between gap-2">
+                  <h4 className="text-sm font-medium text-blue-900 leading-tight">
+                    {item.title}
+                  </h4>
+                  <ExternalLink className="h-3 w-3 text-blue-600 flex-shrink-0 mt-0.5" />
+                </div>
+                <div className="flex items-center gap-2 text-xs text-blue-700">
+                  <span className="font-medium">{item.source}</span>
+                  {item.publishedDate && (
+                    <>
+                      <span>•</span>
+                      <span>{new Date(item.publishedDate).toLocaleDateString()}</span>
+                    </>
+                  )}
+                </div>
+                <p className="text-xs text-blue-800 leading-relaxed">
+                  {item.snippet}
+                </p>
+                <a
+                  href={item.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-xs text-blue-600 hover:text-blue-800 hover:underline break-all"
+                >
+                  {item.url}
+                </a>
               </div>
-              <div className="flex items-center gap-2 text-xs text-blue-700">
-                <span className="font-medium">{item.source}</span>
-                {item.publishedDate && (
-                  <>
-                    <span>•</span>
-                    <span>{new Date(item.publishedDate).toLocaleDateString()}</span>
-                  </>
-                )}
-              </div>
-              <p className="text-xs text-blue-800 leading-relaxed">
-                {item.snippet}
-              </p>
-              <a 
-                href={item.url} 
-                target="_blank" 
-                rel="noopener noreferrer"
-                className="text-xs text-blue-600 hover:text-blue-800 hover:underline break-all"
-              >
-                {item.url}
-              </a>
-            </div>
-          ))}
+            )
+          })}
         </CardContent>
       </Card>
     )

--- a/components/assistant-ui/web-search-sources.tsx
+++ b/components/assistant-ui/web-search-sources.tsx
@@ -2,8 +2,14 @@
 
 import type { SourceMessagePartComponent } from '@assistant-ui/react'
 import { ExternalLink, Globe } from 'lucide-react'
+import { isSafeUrl } from '@/lib/utils'
 
 export const WebSearchSource: SourceMessagePartComponent = ({ url, title }) => {
+  // Security: Only render http/https URLs to prevent XSS via javascript:, data:, etc.
+  if (!isSafeUrl(url)) {
+    return null
+  }
+
   let domain = url
   try {
     domain = new URL(url).hostname.replace('www.', '')
@@ -15,17 +21,18 @@ export const WebSearchSource: SourceMessagePartComponent = ({ url, title }) => {
       target="_blank"
       rel="noopener noreferrer"
       className="inline-flex items-center gap-2 rounded-lg border border-blue-200 bg-blue-50/50
-                 px-3 py-1.5 text-xs text-blue-800 hover:bg-blue-100 hover:border-blue-300
-                 transition-colors no-underline mr-2 mb-2"
+                 px-3 py-2 sm:py-1.5 text-xs text-blue-800 hover:bg-blue-100 hover:border-blue-300
+                 transition-colors no-underline mr-2 mb-2 min-h-[44px] sm:min-h-0"
     >
-      <Globe className="h-3.5 w-3.5 text-blue-600 flex-shrink-0" />
+      <Globe className="h-3.5 w-3.5 text-blue-600 flex-shrink-0" aria-hidden="true" />
       <span className="truncate max-w-[250px] font-medium">
         {title || domain}
       </span>
-      <span className="text-blue-500 text-[10px] hidden sm:inline">
+      <span className="text-blue-600 text-[10px] hidden sm:inline">
         {title ? domain : ''}
       </span>
-      <ExternalLink className="h-3 w-3 text-blue-400 flex-shrink-0" />
+      <ExternalLink className="h-3 w-3 text-blue-600 flex-shrink-0" aria-hidden="true" />
+      <span className="sr-only">Opens in new tab</span>
     </a>
   )
 }

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -6,6 +6,22 @@ export function cn(...inputs: ClassValue[]) {
 }
 
 /**
+ * Validate that a URL uses a safe protocol (http or https only).
+ * Prevents XSS attacks via javascript:, data:, file:, and other dangerous protocols.
+ *
+ * @param url - URL string to validate
+ * @returns true if URL uses http: or https: protocol, false otherwise
+ */
+export function isSafeUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url)
+    return parsed.protocol === 'http:' || parsed.protocol === 'https:'
+  } catch {
+    return false
+  }
+}
+
+/**
  * Generates a URL-friendly identifier from a tool name.
  * Used when creating tools in the base tools system.
  * 


### PR DESCRIPTION
## Summary
- Addresses security and accessibility review feedback from PR #729
- Fixes **2 critical XSS vulnerabilities** and **3 WCAG AA violations**
- Adds **12 new unit tests** for `isSourceUrlEvent()` type guard

## Security Fixes (P1 — Blocking)

### Open Redirect / XSS Vulnerability
- URLs from SSE events were rendered in `href` attributes without protocol validation
- `javascript:`, `data:`, `file://` protocols could execute XSS attacks
- **Fix:** Added `isSafeUrl()` utility (`lib/utils.ts`) that validates http/https only
- Applied at 3 layers (defense-in-depth):
  1. `WebSearchSource` component (render-time)
  2. `WebSearchUI` component (Nexus tool results)
  3. `isSourceUrlEvent()` type guard (event ingestion)

## Accessibility Fixes (P2 — WCAG AA)

| Issue | Before | After |
|-------|--------|-------|
| Color contrast (domain text) | blue-500 = 3.38:1 ❌ | blue-600 = 4.75:1 ✅ |
| Color contrast (icon) | blue-400 = 2.34:1 ❌ | blue-600 = 4.75:1 ✅ |
| Screen reader (external link) | No announcement | "Opens in new tab" via sr-only |
| Decorative icons | Read by SR | `aria-hidden="true"` |
| Touch target (mobile) | ~30-36px | min-h-[44px] ✅ |

## Test Plan
- [x] 12 new unit tests for `isSourceUrlEvent()` (valid, invalid, security protocols)
- [x] Integration test for mixed text + source-url stream sequence
- [x] All 67 tests passing
- [x] `npm run lint` — 0 errors
- [x] `npm run typecheck` — clean
- [ ] Manual: Verify web search citations render as styled cards
- [ ] Manual: Verify `javascript:alert(1)` URLs are blocked (return null)