### PR TITLE
fix: #731 - Reduce Self-Harm topic examples to meet Bedrock quota limit

### DIFF
--- a/infra/lib/guardrails-stack.ts
+++ b/infra/lib/guardrails-stack.ts
@@ -140,17 +140,18 @@ export class GuardrailsStack extends cdk.Stack {
             // showing what TO block, rather than long exclusion lists. K-12 behavioral
             // management language (PBIS, SEL self-regulation) is not harmful and should
             // not match these explicit self-harm examples.
+            //
+            // Issue #731: Bedrock enforces max 5 examples per topic. Selected examples
+            // cover distinct categories: general self-harm, suicide, eating disorders,
+            // and instructional content.
             name: 'Self-Harm',
             definition: 'Content that actively promotes, provides instructions for, or glorifies self-harm, suicide, or eating disorders. Focus on instructional or promotional content, not educational discussions or behavioral documentation.',
             type: 'DENY',
             examples: [
               'Methods of self-harm',
-              'How to hurt yourself',
-              'Pro-eating disorder content',
               'Ways to commit suicide',
-              'I want to end my life',
+              'Pro-eating disorder content',
               'Step by step guide to self-injury',
-              'Best ways to hide self-harm',
               'How to restrict food intake severely',
             ],
           },


### PR DESCRIPTION
## Summary
- Reduces Self-Harm topic examples from 8 to 5 (Bedrock max is 5 per topic)
- Unblocks `AIStudio-GuardrailsStack-Dev` deployment that failed after PR #728

## Root Cause
PR #728 added 3 examples to improve Self-Harm true-positive matching, exceeding AWS Bedrock's 5-example-per-topic quota.

## Changes
- Removed 3 overlapping examples from Self-Harm topic in `infra/lib/guardrails-stack.ts`
- Retained 5 examples covering distinct harm categories (general self-harm, suicide, eating disorders, instructional content)
- Added comment documenting the 5-example Bedrock quota

## Verification
- All 4 topics within quota: Weapons (3), Drugs (3), Self-Harm (5), Bullying (3)
- 19/19 guardrail tests pass (including #727 regression tests)
- Lint: 0 errors
- Typecheck: clean

## Test plan
- [ ] `npx cdk synth AIStudio-GuardrailsStack-Dev` succeeds
- [ ] `cd infra && npx cdk deploy AIStudio-GuardrailsStack-Dev` deploys without error
- [ ] Guardrail regression tests pass

Fixes #731