### PR TITLE
fix: #735 - Shorten Bedrock guardrail Self-Harm topic definition to ≤200 chars

### DIFF
--- a/infra/lib/guardrails-stack.ts
+++ b/infra/lib/guardrails-stack.ts
@@ -145,7 +145,7 @@ export class GuardrailsStack extends cdk.Stack {
             // cover distinct categories: general self-harm, suicide, eating disorders,
             // and instructional content.
             name: 'Self-Harm',
-            definition: 'Content that actively promotes, provides instructions for, or glorifies self-harm, suicide, or eating disorders. Focus on instructional or promotional content, not educational discussions or behavioral documentation.',
+            definition: 'Content that promotes, instructs, or glorifies self-harm, suicide, or eating disorders. Targets instructional or promotional content, not educational discussions or behavioral documentation.',
             type: 'DENY',
             examples: [
               'Methods of self-harm',


### PR DESCRIPTION
## Description
Fixes GuardrailsStack deployment failure caused by the Self-Harm topic definition exceeding Bedrock's 200-character limit for `GuardrailTopicConfig.definition`.

Closes #735

## Changes
- Shortened Self-Harm topic definition from **216 → 190 characters**
- Condensed wording: removed "actively", replaced "provides instructions for" → "instructs", "Focus on" → "Targets"
- Meaning and filtering intent preserved

## Verification
All 4 topic definitions confirmed under 200 chars:

| Topic | Characters | Limit |
|-------|-----------|-------|
| Weapons | 67 | 200 |
| Drugs | 74 | 200 |
| **Self-Harm** | **190** (was 216) | 200 |
| Bullying | 69 | 200 |

- `npx cdk synth AIStudio-GuardrailsStack-Dev` succeeds
- `npm run lint` — 0 errors
- `npm run typecheck` — passes

## Test Plan
- [ ] `cdk synth` succeeds (verified locally)
- [ ] GuardrailsStack deploys without "definition exceeds maximum length" error
- [ ] Guardrail still blocks self-harm content appropriately