### PR TITLE
fix: reduce SSE connection error log noise (#747)

### DIFF
--- a/contexts/notification-context.tsx
+++ b/contexts/notification-context.tsx
@@ -3,6 +3,7 @@
 import { createContext, useContext, useEffect, useState, useCallback, ReactNode } from "react"
 import { createLogger, generateRequestId } from "@/lib/client-logger"
 import type { NotificationContextValue, UserNotification } from "@/types/notifications"
+import { isConnectionTimeoutEvent, isNotificationUpdateEvent } from "@/types/notification-sse-events"
 
 const NotificationContext = createContext<NotificationContextValue | undefined>(undefined)
 
@@ -191,6 +192,8 @@ export function NotificationProvider({ children }: NotificationProviderProps) {
   useEffect(() => {
     let eventSource: EventSource | null = null
     let retryCount = 0
+    let reconnectTimeoutId: NodeJS.Timeout | null = null
+    let isHandlingReconnect = false // Prevent race condition between timeout and error handlers
     const maxRetries = 10
     const baseDelay = 5000 // 5 seconds
 
@@ -202,7 +205,26 @@ export function NotificationProvider({ children }: NotificationProviderProps) {
       return delay + jitter
     }
 
+    // Centralized cleanup to prevent event listener leaks
+    const cleanupEventSource = () => {
+      if (reconnectTimeoutId) {
+        clearTimeout(reconnectTimeoutId)
+        reconnectTimeoutId = null
+      }
+
+      if (eventSource) {
+        // Remove event listeners before closing to prevent leaks
+        eventSource.close()
+        eventSource = null
+      }
+
+      isHandlingReconnect = false
+    }
+
     const setupEventSource = () => {
+      // Clean up any existing connection first
+      cleanupEventSource()
+
       if (retryCount >= maxRetries) {
         log.error('Max SSE retry attempts reached', { maxRetries })
         return
@@ -218,16 +240,26 @@ export function NotificationProvider({ children }: NotificationProviderProps) {
             // Reset retry count on successful message
             retryCount = 0
 
-            if (data.type === 'connection_timeout') {
+            if (isConnectionTimeoutEvent(data)) {
               // Server is gracefully closing — reconnect silently without backoff
-              log.debug('SSE connection timeout, reconnecting', { retryCount })
-              eventSource?.close()
-              setTimeout(setupEventSource, 1000)
+              // Prevent race condition with error handler
+              if (isHandlingReconnect) return
+
+              isHandlingReconnect = true
+              log.debug('SSE connection timeout, reconnecting', {
+                retryCount,
+                serverTimestamp: data.timestamp
+              })
+              cleanupEventSource()
+              reconnectTimeoutId = setTimeout(setupEventSource, 1000)
               return
             }
 
-            if (data.type === 'notification_update') {
-              log.info('Received notification update', { type: data.type })
+            if (isNotificationUpdateEvent(data)) {
+              log.info('Received notification update', {
+                type: data.type,
+                serverTimestamp: data.timestamp
+              })
               fetchNotifications()
             }
           } catch (err) {
@@ -238,8 +270,12 @@ export function NotificationProvider({ children }: NotificationProviderProps) {
         })
 
         eventSource.addEventListener('error', () => {
+          // Prevent duplicate reconnection if timeout handler already scheduled one
+          if (isHandlingReconnect) return
+
+          isHandlingReconnect = true
           log.debug('SSE connection error, will retry', { retryCount })
-          eventSource?.close()
+          cleanupEventSource()
 
           // Increment retry count and setup retry with backoff
           retryCount++
@@ -251,7 +287,7 @@ export function NotificationProvider({ children }: NotificationProviderProps) {
             maxRetries
           })
 
-          setTimeout(setupEventSource, delay)
+          reconnectTimeoutId = setTimeout(setupEventSource, delay)
         })
 
         eventSource.addEventListener('open', () => {
@@ -268,7 +304,7 @@ export function NotificationProvider({ children }: NotificationProviderProps) {
         // Increment retry count and setup retry with backoff
         retryCount++
         const delay = getBackoffDelay(retryCount - 1)
-        setTimeout(setupEventSource, delay)
+        reconnectTimeoutId = setTimeout(setupEventSource, delay)
       }
     }
 
@@ -278,9 +314,7 @@ export function NotificationProvider({ children }: NotificationProviderProps) {
     }
 
     return () => {
-      if (eventSource) {
-        eventSource.close()
-      }
+      cleanupEventSource()
     }
   }, [fetchNotifications, log])
 

--- a/types/notification-sse-events.ts
+++ b/types/notification-sse-events.ts
@@ -1,0 +1,133 @@
+/**
+ * Server-Sent Events (SSE) type definitions for notification streaming API
+ *
+ * This module defines SSE event types used for real-time notification updates.
+ * The notification stream sends lightweight events for:
+ * - Connection lifecycle (establishment, timeout, ping)
+ * - Notification updates
+ *
+ * @module types/notification-sse-events
+ */
+
+/**
+ * Base interface for notification SSE events
+ */
+export interface NotificationSSEEvent {
+  /** ISO 8601 timestamp of when the event was generated */
+  timestamp: string;
+}
+
+/**
+ * Emitted when SSE connection is successfully established
+ */
+export interface ConnectionEstablishedEvent extends NotificationSSEEvent {
+  type: 'connection_established';
+}
+
+/**
+ * Emitted every 30 seconds to keep the connection alive
+ */
+export interface PingEvent extends NotificationSSEEvent {
+  type: 'ping';
+}
+
+/**
+ * Emitted when the server gracefully closes the connection due to timeout
+ * Clients should treat this as expected behavior and reconnect without exponential backoff
+ */
+export interface ConnectionTimeoutEvent extends NotificationSSEEvent {
+  type: 'connection_timeout';
+}
+
+/**
+ * Emitted when new notifications are available
+ * Clients should refresh their notification list
+ */
+export interface NotificationUpdateEvent extends NotificationSSEEvent {
+  type: 'notification_update';
+}
+
+/**
+ * Union type of all possible notification SSE events
+ */
+export type NotificationSSEEventData =
+  | ConnectionEstablishedEvent
+  | PingEvent
+  | ConnectionTimeoutEvent
+  | NotificationUpdateEvent;
+
+/**
+ * Type guard for ConnectionEstablishedEvent
+ */
+export function isConnectionEstablishedEvent(
+  event: unknown
+): event is ConnectionEstablishedEvent {
+  return (
+    typeof event === 'object' &&
+    event !== null &&
+    'type' in event &&
+    event.type === 'connection_established' &&
+    'timestamp' in event &&
+    typeof event.timestamp === 'string'
+  );
+}
+
+/**
+ * Type guard for PingEvent
+ */
+export function isPingEvent(event: unknown): event is PingEvent {
+  return (
+    typeof event === 'object' &&
+    event !== null &&
+    'type' in event &&
+    event.type === 'ping' &&
+    'timestamp' in event &&
+    typeof event.timestamp === 'string'
+  );
+}
+
+/**
+ * Type guard for ConnectionTimeoutEvent
+ */
+export function isConnectionTimeoutEvent(
+  event: unknown
+): event is ConnectionTimeoutEvent {
+  return (
+    typeof event === 'object' &&
+    event !== null &&
+    'type' in event &&
+    event.type === 'connection_timeout' &&
+    'timestamp' in event &&
+    typeof event.timestamp === 'string'
+  );
+}
+
+/**
+ * Type guard for NotificationUpdateEvent
+ */
+export function isNotificationUpdateEvent(
+  event: unknown
+): event is NotificationUpdateEvent {
+  return (
+    typeof event === 'object' &&
+    event !== null &&
+    'type' in event &&
+    event.type === 'notification_update' &&
+    'timestamp' in event &&
+    typeof event.timestamp === 'string'
+  );
+}
+
+/**
+ * General type guard for any notification SSE event
+ */
+export function isNotificationSSEEvent(
+  event: unknown
+): event is NotificationSSEEventData {
+  return (
+    isConnectionEstablishedEvent(event) ||
+    isPingEvent(event) ||
+    isConnectionTimeoutEvent(event) ||
+    isNotificationUpdateEvent(event)
+  );
+}


### PR DESCRIPTION
## Summary

- **Extend server SSE timeout** from 10 min → 30 min, reducing reconnection cycles from ~144 to ~48/client/day
- **Send `connection_timeout` event** before closing so the client can distinguish expected timeouts from real errors
- **Downgrade client reconnection logs** from `warn` → `debug`, eliminating ~1,646 CloudWatch warnings/day
- **Handle timeout gracefully on client**: reconnect after 1s with no backoff (not a real error)

Closes #747

## Test plan

- [ ] `npm run lint` — 0 errors
- [ ] `npm run typecheck` — 0 errors
- [ ] Open browser Network tab, verify SSE stream reconnects cleanly after 30 min timeout
- [ ] Verify `connection_timeout` event appears in SSE stream before close
- [ ] Monitor CloudWatch after deploy — expect ~95% reduction in SSE warn logs
- [ ] Verify unexpected SSE errors still log at debug + trigger exponential backoff