### PR TITLE
fix: include argon2 native module in standalone output

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -10,6 +10,16 @@ const nextConfig = {
     ignoreBuildErrors: true,
   },
   output: 'standalone',
+  // argon2 is loaded dynamically via createRequire in argon2-loader.ts,
+  // which prevents Next.js standalone file tracing from detecting it.
+  // Explicitly include argon2 and its runtime dependencies.
+  outputFileTracingIncludes: {
+    '/**': [
+      './node_modules/argon2/**/*',
+      './node_modules/@phc/format/**/*',
+      './node_modules/node-gyp-build/**/*',
+    ],
+  },
   images: {
     remotePatterns: [],
   },


### PR DESCRIPTION
## Summary

- API key creation fails on AWS ECS (dev + prod) with `TypeError: (void 0) is not a function`
- `argon2-loader.ts` uses `createRequire()` with a variable module name to bypass Turbopack, which also bypasses Next.js standalone file tracing (`@vercel/nft`)
- `argon2`, `@phc/format`, and `node-gyp-build` were never copied to `.next/standalone/node_modules/`
- Added `outputFileTracingIncludes` in `next.config.js` to explicitly include these packages

## Test plan

- [x] `npm run lint` passes (0 errors)
- [x] `npm run build` succeeds
- [x] Verified `.next/standalone/node_modules/argon2/` contains full package with prebuilds
- [x] Verified `linux-arm64/argon2.armv8.musl.node` present (needed for Graviton2 Alpine)
- [x] Verified `@phc/format` and `node-gyp-build` present in standalone output
- [ ] Deploy to dev and test API key creation
- [ ] Deploy to prod and test API key creation