### PR TITLE
fix: #758 — new users cannot use Nexus Chat (auto-select regression)

### DIFF
--- a/lib/hooks/use-models.ts
+++ b/lib/hooks/use-models.ts
@@ -141,7 +141,7 @@ export function useModelsWithPersistence(storageKey: string, requiredCapabilitie
   // Tracks the last model ID this effect validated to prevent redundant runs.
   // This allows selectedModel in the dependency array (no stale closure)
   // while preventing infinite loops from setSelectedModel triggering re-runs.
-  const lastValidatedModelId = useRef<string | null>(null)
+  const lastValidatedModelId = useRef<string | null | undefined>(undefined)
 
   // Auto-select a valid model if none selected or if persisted model is no longer available
   useEffect(() => {


### PR DESCRIPTION
## Summary

- Fixes regression from PR #750 where new users see "Please select a model" with no chat UI
- Root cause: `lastValidatedModelId` ref initialized to `null` matched new user's `null` model state, causing early return before auto-select logic
- Fix: Initialize ref to `undefined` so `null === undefined` → `false`, allowing auto-select to proceed

## Changes

- `lib/hooks/use-models.ts` — Changed `useRef<string | null>(null)` to `useRef<string | null | undefined>(undefined)`

## Verification

| Scenario | Before | After |
|----------|--------|-------|
| New user (empty localStorage) | Stuck on "Please select a model" | Auto-selects first chat-capable model |
| Existing user (valid localStorage) | Works | Works (unaffected) |
| Stale model (deleted from DB) | Auto-selects new model | Auto-selects new model (unaffected) |
| Re-render loop prevention | No loops | No loops (guard still works after first validation) |

## Test Plan

- [ ] Clear `nexus-modelData` and `nexus-modelId` from localStorage → navigate to `/nexus` → model auto-selects, chat UI renders
- [ ] Verify DevTools console shows "Auto-selected model" log from `use-models`
- [ ] Existing user with valid model in localStorage → chat loads normally
- [ ] Set localStorage to a non-existent model ID → stale detection triggers, auto-selects valid model
- [ ] No infinite re-render loops (check React DevTools profiler)

Closes #758