### PR TITLE
fix: #761 — Switch ALL guardrail policies to detect-only mode

### DIFF
--- a/infra/lib/guardrails-stack.ts
+++ b/infra/lib/guardrails-stack.ts
@@ -48,58 +48,57 @@ export class GuardrailsStack extends cdk.Stack {
       blockedInputMessaging: 'This content is not appropriate for educational use. Please rephrase your question.',
       blockedOutputsMessaging: 'The AI response contained inappropriate content and has been blocked for your safety.',
 
-      // Content filtering policies - Balanced for K-12 educational use
+      // Content filtering policies
       //
-      // Filter strength rationale (Issue #639):
-      // - LOW: Allows professional educational discussions including behavior management,
-      //   teacher observations, and student incident documentation
-      // - MEDIUM: Allows civil rights, Holocaust, history, literature discussions
-      // - HIGH: Reserved for truly inappropriate K-12 content
+      // Issue #761: ALL content filters switched to detect-only mode (NONE).
+      // Following the same strategy as topic policies (Issue #742), content filters
+      // were blocking legitimate K-12 educational content:
+      // - SEXUAL: Blocking health education discussions
+      // - INSULTS: Blocking teacher observations about student behavior
+      // - VIOLENCE: Blocking history lessons (wars, civil rights struggles)
+      // - HATE: Blocking Holocaust education, civil rights content
       //
-      // Note: Topic-based filtering (weapons, drugs, self-harm, bullying) and profanity
-      // word lists provide additional protection independent of these content filters.
+      // Strategy: Log all detections without blocking to collect data on what triggers
+      // each filter. Once we understand false positive patterns, we can selectively
+      // re-enable blocking on filters that don't affect educational use cases.
+      //
+      // Safety net: LLM providers (OpenAI, Anthropic, Google) have built-in safety
+      // training that provides baseline content filtering even without Bedrock.
+      //
+      // History:
+      // - Issue #639: INSULTS/MISCONDUCT lowered from MEDIUM to LOW
+      // - Issue #727: PROMPT_ATTACK disabled (75% false positive rate)
+      // - Issue #761: ALL filters switched to NONE (detect-only mode)
       contentPolicyConfig: {
         filtersConfig: [
           {
             type: 'HATE',
-            inputStrength: 'MEDIUM', // Allows civil rights, Holocaust education
-            outputStrength: 'MEDIUM',
+            inputStrength: 'NONE',  // Issue #761: Detect only, don't block
+            outputStrength: 'NONE',
           },
           {
             type: 'VIOLENCE',
-            inputStrength: 'MEDIUM', // Allows history (wars), literature, biology
-            outputStrength: 'MEDIUM',
+            inputStrength: 'NONE',  // Issue #761: Detect only, don't block
+            outputStrength: 'NONE',
           },
           {
             type: 'SEXUAL',
-            inputStrength: 'HIGH', // Keep HIGH for K-12
-            outputStrength: 'HIGH',
+            inputStrength: 'NONE',  // Issue #761: Detect only, don't block
+            outputStrength: 'NONE',
           },
           {
-            // Issue #639: Lowered from MEDIUM to LOW
-            // MEDIUM was blocking legitimate teacher observation content discussing
-            // student behavioral challenges (e.g., "argued", classroom management)
             type: 'INSULTS',
-            inputStrength: 'LOW', // Allows behavior discussions, character analysis
-            outputStrength: 'LOW',
+            inputStrength: 'NONE',  // Issue #761: Detect only, don't block
+            outputStrength: 'NONE',
           },
           {
-            // Issue #639: Lowered from MEDIUM to LOW
-            // MEDIUM was blocking legitimate educational content about behavior
-            // management, student consequences, and disciplinary discussions
             type: 'MISCONDUCT',
-            inputStrength: 'LOW', // Allows behavior management, legal/drug education
-            outputStrength: 'LOW',
+            inputStrength: 'NONE',  // Issue #761: Detect only, don't block
+            outputStrength: 'NONE',
           },
           {
-            // Issue #657: Lowered HIGH→MEDIUM→LOW. Issue #727: Lowered LOW→NONE.
-            // 3 of 4 first-day prompt attack detections were false positives:
-            // role-based prompting ("as an expert, veteran principal"), Assistant
-            // Architect system prompts with detailed instructions, and Danielson
-            // Framework evaluation requests. Legitimate injection attempts are still
-            // caught by LLM safety training. Other filters remain active.
             type: 'PROMPT_ATTACK',
-            inputStrength: 'NONE', // Disabled - too many false positives on educational content
+            inputStrength: 'NONE',  // Issue #727: Already disabled
             outputStrength: 'NONE',
           },
         ],

--- a/lib/safety/types.ts
+++ b/lib/safety/types.ts
@@ -38,6 +38,8 @@ export interface GuardrailCheckResult {
   blockedCategories?: string[];
   /** Issue #742: Topics detected in detect-only mode (not blocked) */
   detectedTopics?: string[];
+  /** Issue #761: Content filters detected in detect-only mode (not blocked) */
+  detectedFilters?: string[];
 }
 
 /**
@@ -177,7 +179,8 @@ export interface GuardrailAssessment {
     filters?: Array<{
       type: ContentFilterType;
       confidence: string;
-      action: 'BLOCKED' | 'ALLOWED';
+      /** BLOCKED = filter triggered and blocked, NONE = filter triggered but detect-only, other = not triggered */
+      action: 'BLOCKED' | 'NONE' | string;
     }>;
   };
   topicPolicy?: {


### PR DESCRIPTION
## Summary

- PR #743 changed **topic policies** to detect-only — but users are still seeing blocks
- Root cause: **content filters** (SEXUAL, INSULTS, etc.) were still actively blocking
- This PR sets ALL content filter strengths to `NONE` (detect-only)

## What Was Blocking

| Filter | Before | After |
|--------|--------|-------|
| HATE | MEDIUM | NONE |
| VIOLENCE | MEDIUM | NONE |
| SEXUAL | HIGH | NONE |
| INSULTS | LOW | NONE |
| MISCONDUCT | LOW | NONE |
| PROMPT_ATTACK | NONE | NONE |

## Changes

### `infra/lib/guardrails-stack.ts`
- Set all content filter `inputStrength`/`outputStrength` to `'NONE'`
- Updated comments documenting the detect-only strategy
- References Issue #761 on each filter

### `lib/safety/bedrock-guardrails-service.ts`
- Added `extractDetectedFilters()` method (mirrors `extractDetectedTopics()`)
- Added CloudWatch logging for detected content filters
- Added SNS notifications with `action: 'detected'` for filter detections
- Updated log entries to include `detectedFilters`

### `lib/safety/types.ts`
- Added `detectedFilters?: string[]` to `GuardrailCheckResult`
- Updated filter action type to include `'NONE'` for detect-only mode

## Safety Net

LLM providers (OpenAI, Anthropic, Google) have built-in safety training that provides baseline content filtering even without Bedrock guardrails blocking.

## Deployment

After merge:
```bash
cd infra && npx cdk deploy AIStudio-GuardrailsStack-Dev
```

## Verification

Post-deployment CloudWatch query to confirm no blocking:
```
fields @timestamp, action, blockedCategories, detectedFilters
| filter module = "BedrockGuardrailsService"
| filter action = "blocked" OR detectedFilters is not empty
| stats count() by action
| sort count desc
```

Should see:
- `action: "detected"` — content filters still evaluate but don't block
- NO `action: "blocked"` from content filters

## Test Plan

- [ ] Deploy to dev
- [ ] Send content that previously triggered "Sexual content" block → should pass (detect only)
- [ ] Send content that previously triggered "INSULTS" block → should pass (detect only)
- [ ] Check CloudWatch logs show `detectedFilters` in INFO logs
- [ ] Check SNS notifications show `action: "detected"` (not `"blocked"`)

Closes #761