### PR TITLE
feat: #778 - MCP connector service for external server integration

### DIFF
--- a/lib/mcp/connector-service.ts
+++ b/lib/mcp/connector-service.ts
@@ -45,6 +45,9 @@ const MCP_CLIENT_TIMEOUT_MS = 30_000
 /** Token expiry buffer — proactively reject tokens expiring within 60 seconds */
 const TOKEN_EXPIRY_BUFFER_MS = 60_000
 
+/** Counter for audit log write failures — emitted in structured logs for CloudWatch alarming */
+let auditFailureCount = 0
+
 // ─── Connector Listing ───────────────────────────────────────────────────────
 
 /**
@@ -201,13 +204,9 @@ export async function getConnectorTools(
     throw error
   }
 
-  timer({ status: "success", toolCount: Object.keys(tools).length })
-  log.info("Connector tools fetched", {
-    requestId,
-    serverId,
-    serverName: server.name,
-    toolCount: Object.keys(tools).length,
-  })
+  const toolCount = Object.keys(tools).length
+  timer({ status: "success", toolCount })
+  log.info("Connector tools fetched", { requestId, serverId, serverName: server.name, toolCount })
 
   return {
     serverId,
@@ -235,12 +234,11 @@ export async function refreshUserToken(
 
   log.info("Attempting token refresh", { requestId, userId, serverId })
 
-  // Phase 1: Read — load token + server config (short transaction, no HTTP)
-  const { tokenRow, server, refreshToken } = await executeTransaction(
-    async (tx) => {
-      // Lock the token row to serialize concurrent refresh attempts.
-      // The lock is released when this transaction commits (before the HTTP call).
-      const rows = await tx
+  // Phase 1: Read token + server config (no transaction needed — just reads).
+  // Concurrency is handled by optimistic locking in Phase 3 (updatedAt check).
+  const tokenRows = await executeQuery(
+    (db) =>
+      db
         .select()
         .from(nexusMcpUserTokens)
         .where(
@@ -249,43 +247,51 @@ export async function refreshUserToken(
             eq(nexusMcpUserTokens.serverId, serverId)
           )
         )
-        .limit(1)
-        .for("update")
-
-      if (rows.length === 0 || !rows[0].encryptedRefreshToken) {
-        return { tokenRow: null, server: null, refreshToken: null }
-      }
-
-      const row = rows[0]
-
-      let decrypted: string
-      try {
-        decrypted = await decryptToken(row.encryptedRefreshToken!)
-      } catch (err) {
-        log.warn("Failed to decrypt refresh token", { requestId, error: String(err) })
-        return { tokenRow: null, server: null, refreshToken: null }
-      }
-
-      const servers = await tx
-        .select()
-        .from(nexusMcpServers)
-        .where(eq(nexusMcpServers.id, serverId))
-        .limit(1)
-
-      if (servers.length === 0) {
-        throw new Error(`MCP server not found: ${serverId}`)
-      }
-
-      return { tokenRow: row, server: servers[0], refreshToken: decrypted }
-    },
-    "refreshUserToken:read"
+        .limit(1),
+    "refreshUserToken:loadToken"
   )
 
-  if (!tokenRow || !server || !refreshToken) {
+  if (tokenRows.length === 0 || !tokenRows[0].encryptedRefreshToken) {
     log.warn("No refresh token available", { requestId, userId, serverId })
     timer({ status: "error" })
     return { success: false, reconnectRequired: true }
   }
+
+  const tokenRow = tokenRows[0]
+
+  let refreshToken: string
+  try {
+    refreshToken = await decryptToken(tokenRow.encryptedRefreshToken!)
+  } catch (err) {
+    log.warn("Failed to decrypt refresh token — deleting corrupted row", {
+      requestId, error: String(err),
+    })
+    // Delete the corrupted token so the user gets a clean "no_token" status
+    // and can re-authenticate via OAuth flow
+    await executeQuery(
+      (db) =>
+        db.delete(nexusMcpUserTokens).where(eq(nexusMcpUserTokens.id, tokenRow.id)),
+      "refreshUserToken:deleteCorrupt"
+    )
+    timer({ status: "error" })
+    return { success: false, reconnectRequired: true }
+  }
+
+  const serverRows = await executeQuery(
+    (db) =>
+      db
+        .select()
+        .from(nexusMcpServers)
+        .where(eq(nexusMcpServers.id, serverId))
+        .limit(1),
+    "refreshUserToken:loadServer"
+  )
+
+  if (serverRows.length === 0) {
+    throw new Error(`MCP server not found: ${serverId}`)
+  }
+
+  const server = serverRows[0]
 
   // Phase 2: Exchange — outbound HTTP call (no DB connection held)
   validateMcpServerUrl(server.url)
@@ -401,8 +407,15 @@ export async function logToolCall(entry: McpToolCallLogEntry): Promise<void> {
       "logToolCall"
     )
   } catch (err) {
-    // Audit log failure must not break the request
-    log.warn("Failed to write MCP audit log", { error: String(err) })
+    // Audit log failure must not break the request, but sustained failures
+    // silently dropping compliance records need to be alarmable.
+    auditFailureCount++
+    log.error("Failed to write MCP audit log", {
+      error: String(err),
+      auditFailureCount,
+      serverId: entry.serverId,
+      toolName: entry.toolName,
+    })
   }
 }
 
@@ -662,6 +675,7 @@ function truncateForAudit(
  * (where a public hostname resolves to a private IP after validation). For
  * defense-in-depth, deploy an egress proxy or DNS firewall at the infrastructure
  * level to block outbound connections to RFC 1918 / link-local addresses.
+ * Tracked as Issue #791 — must be resolved before production deployment.
  */
 function validateMcpServerUrl(rawUrl: string): void {
   let parsed: URL

--- a/lib/mcp/connector-types.ts
+++ b/lib/mcp/connector-types.ts
@@ -41,7 +41,7 @@ export interface McpConnector {
 
 // ─── Connection Status ───────────────────────────────────────────────────────
 
-export type McpConnectionStatus = "connected" | "token_expired" | "reconnect_required" | "no_token"
+export type McpConnectionStatus = "connected" | "token_expired" | "no_token"
 
 export interface McpUserConnectionStatus {
   serverId: string


### PR DESCRIPTION
## Summary
Implements #778 — backend core for connecting AI Studio to external MCP servers as a client.

## Changes
- **`lib/mcp/connector-types.ts`** — Type definitions for connector metadata, connection status, token refresh results, tool fetching results, and audit log entries
- **`lib/mcp/connector-service.ts`** — Stateless service with 5 core functions:
  - `getAvailableConnectors(userId, userRoles)` — queries `nexus_mcp_servers`, filters by `allowedUsers[]` whitelist or admin/staff role fallback
  - `getUserConnectionStatus(userId, serverId)` — checks token existence and expiry from `nexus_mcp_user_tokens`
  - `getConnectorTools(serverId, userId)` — creates ephemeral `MCPClient` via `@ai-sdk/mcp`, fetches tools as AI SDK-compatible tool set, caller must close()
  - `refreshUserToken(userId, serverId)` — decrypts refresh token, exchanges at OAuth endpoint, re-encrypts and stores atomically via `executeTransaction`
  - `logToolCall(entry)` — fire-and-forget audit insert to `nexus_mcp_audit_logs`

## Key Design Decisions
- **Ephemeral MCP clients** — create per-request, close in onFinish/onError to avoid stale connections
- **Auth resolution** — supports bearer, oauth2, api_key, and none auth types with exhaustive switch
- **Token encryption** — all token operations use `lib/crypto/token-encryption.ts` (Issue #777)
- **Non-blocking audit** — `logToolCall` catches errors internally, never propagates

## Validation Notes (PASS_WITH_WARNINGS)
- `bun run typecheck` passes (0 errors)
- `bun run lint` passes (0 errors in changed files; 303 pre-existing warnings)
- **Warning noted**: `getAvailableConnectors` does full table scan + app-side filtering — acceptable for current scale, DB-side filtering can be added later
- **Warning addressed**: exhaustive switch added to `resolveAuthHeaders` to prevent silent unauthenticated requests on unknown auth types

## Test Plan
- [ ] `bun run typecheck` passes
- [ ] `bun run lint` passes (no new errors)
- [ ] Manual review of type safety across DB schema alignment
- [ ] Unit tests to be added in follow-up (connector service is pure functions, easily testable with mocked DB + MCPClient)

## Dependencies
- #776 (DB migration — merged)
- #777 (Token encryption — merged)

Closes #778