### PR TITLE
feat: #781 — reconnect signal for failed MCP connectors

### DIFF
--- a/app/(protected)/nexus/page.tsx
+++ b/app/(protected)/nexus/page.tsx
@@ -133,7 +133,7 @@ function ConversationRuntimeProvider({
         description: `${count} connector${count > 1 ? 's' : ''} could not be reached. Open the Connect menu to reconnect.`,
         duration: 8000
       })
-      log.warn('Connectors need reconnection', { reconnectIds })
+      log.warn('Connectors need reconnection', { failedCount: count })
     }
 
     return response

--- a/app/api/nexus/chat/route.ts
+++ b/app/api/nexus/chat/route.ts
@@ -167,7 +167,10 @@ async function executeStreaming(params: {
     }
 
     if (failedConnectorIds.length > 0) {
-      responseHeaders['X-Connector-Reconnect'] = failedConnectorIds.join(',');
+      const safeIds = failedConnectorIds.filter(id => /^[\da-f-]{36}$/i.test(id));
+      if (safeIds.length > 0) {
+        responseHeaders['X-Connector-Reconnect'] = safeIds.join(',');
+      }
     }
 
     return streamResponse.result.toUIMessageStreamResponse({ headers: responseHeaders });
@@ -191,7 +194,7 @@ const ChatRequestSchema = z.object({
   provider: z.string().optional(),
   conversationId: z.string().nullable().optional(),
   enabledTools: z.array(z.string()).optional(),
-  enabledConnectors: z.array(z.string().uuid()).optional(),
+  enabledConnectors: z.array(z.string().uuid()).max(10).optional(),
   reasoningEffort: z.enum(['minimal', 'low', 'medium', 'high']).optional(),
   responseMode: z.enum(['standard', 'priority', 'flex']).optional()
 });
@@ -498,8 +501,7 @@ export async function POST(req: Request) {
       const results = await Promise.allSettled(
         enabledConnectors.map(serverId => getConnectorTools(serverId, userId, userRoleNames))
       );
-      for (let i = 0; i < results.length; i++) {
-        const result = results[i];
+      for (const [i, result] of results.entries()) {
         if (result.status === 'fulfilled') {
           connectorToolResults.push(result.value);
         } else {


### PR DESCRIPTION
## Summary
Completes the final acceptance criterion from #781: **reconnect signal sent to client on auth failure**.

PR #793 implemented the core connector-tool integration (accepting `enabledConnectors`, resolving tools via `Promise.allSettled`, merging with adapter tools, MCP client cleanup). This PR adds the missing user-facing feedback when connectors fail.

## Changes
- **Route** (`app/api/nexus/chat/route.ts`): Track which connector server IDs fail during tool resolution. Send failed IDs via `X-Connector-Reconnect` response header.
- **Client** (`app/(protected)/nexus/page.tsx`): Read the header in `customFetch`, show a toast notification guiding the user to the Connect menu for reconnection.

## How It Works
1. User enables connectors and sends a message
2. Route resolves tools for each connector via `Promise.allSettled`
3. If any connector fails (expired token, missing auth, server down), its server ID is added to `failedConnectorIds`
4. Response includes `X-Connector-Reconnect: serverId1,serverId2` header
5. Client reads header, shows toast: "1 connector could not be reached. Open the Connect menu to reconnect."
6. Chat proceeds normally with remaining working tools (graceful degradation preserved)

## Test Plan
- [ ] `bun run typecheck` passes
- [ ] `bun run lint` passes (0 errors)
- [ ] When no connectors enabled — no `X-Connector-Reconnect` header sent
- [ ] When all connectors succeed — no header sent
- [ ] When connector auth fails — toast appears with reconnect guidance
- [ ] Chat stream works normally regardless of connector failures

Closes #781