### PR TITLE
fix: prevent nexus conversation remount on browser tab switch

### DIFF
--- a/app/(protected)/nexus/_components/conversation-initializer.tsx
+++ b/app/(protected)/nexus/_components/conversation-initializer.tsx
@@ -176,8 +176,8 @@ export function ConversationInitializer({
       return
     }
 
-    // Note: NextAuth guarantees session.user exists when status === 'authenticated'.
-    // No additional guard needed — status check above is sufficient.
+    // In this project, our NextAuth configuration ensures session.user is set when status === 'authenticated'.
+    // Given that setup (see auth.ts and Session type augmentation), no additional session guard is needed here.
 
     if (!conversationId) {
       startTransition(() => {

--- a/app/(protected)/nexus/_components/conversation-initializer.tsx
+++ b/app/(protected)/nexus/_components/conversation-initializer.tsx
@@ -158,7 +158,7 @@ export function ConversationInitializer({
 }) {
   const [messages, setMessages] = useState<UIMessage[]>([])
   const [loading, setLoading] = useState(true)
-  const { status, data: session } = useSession()
+  const { status } = useSession()
 
   useEffect(() => {
     // Verify authentication before making API call
@@ -176,15 +176,8 @@ export function ConversationInitializer({
       return
     }
 
-    // Guard against authenticated status with missing user data
-    if (status === 'authenticated' && !session?.user) {
-      log.warn('Authenticated but no user data, skipping conversation load')
-      startTransition(() => {
-        setMessages([])
-        setLoading(false)
-      })
-      return
-    }
+    // Note: NextAuth guarantees session.user exists when status === 'authenticated'.
+    // No additional guard needed — status check above is sufficient.
 
     if (!conversationId) {
       startTransition(() => {
@@ -236,7 +229,7 @@ export function ConversationInitializer({
     return () => {
       abortController.abort()
     }
-  }, [conversationId, status, session])
+  }, [conversationId, status])
 
   if (loading) {
     return (

--- a/components/utilities/session-provider.tsx
+++ b/components/utilities/session-provider.tsx
@@ -7,9 +7,14 @@ export default function AuthSessionProvider({
 }: {
   children: React.ReactNode;
 }) {
-  // refetchOnWindowFocus disabled to prevent unnecessary session object churn on tab switch
-  // (which would trigger useEffect deps that include `status`). A 5-minute background interval
-  // preserves session expiry detection without requiring window focus events.
+  // NOTE: This affects the entire app (wraps RootLayout). The trade-off is accepted because:
+  // 1. API routes enforce auth independently (JWT validation on each request)
+  // 2. Stale session objects were causing Nexus useEffect dep instability (see #811)
+  // 3. The 5-minute poll provides a reasonable expiry detection fallback
+  //
+  // refetchInterval added to compensate: polls every 5 min to detect session expiry
+  // (previously no background polling existed; refetchOnWindowFocus covered this).
+  // Note: each open tab generates one /api/auth/session request per interval.
   return (
     <SessionProvider refetchOnWindowFocus={false} refetchInterval={5 * 60}>
       {children}

--- a/components/utilities/session-provider.tsx
+++ b/components/utilities/session-provider.tsx
@@ -7,5 +7,5 @@ export default function AuthSessionProvider({
 }: {
   children: React.ReactNode;
 }) {
-  return <SessionProvider>{children}</SessionProvider>;
+  return <SessionProvider refetchOnWindowFocus={false}>{children}</SessionProvider>;
 }

--- a/components/utilities/session-provider.tsx
+++ b/components/utilities/session-provider.tsx
@@ -7,5 +7,12 @@ export default function AuthSessionProvider({
 }: {
   children: React.ReactNode;
 }) {
-  return <SessionProvider refetchOnWindowFocus={false}>{children}</SessionProvider>;
+  // refetchOnWindowFocus disabled to prevent unnecessary session object churn on tab switch
+  // (which would trigger useEffect deps that include `status`). A 5-minute background interval
+  // preserves session expiry detection without requiring window focus events.
+  return (
+    <SessionProvider refetchOnWindowFocus={false} refetchInterval={5 * 60}>
+      {children}
+    </SessionProvider>
+  );
 }

--- a/docs/features/nexus-conversation-architecture.md
+++ b/docs/features/nexus-conversation-architecture.md
@@ -495,6 +495,27 @@ useEffect(() => {
 // The component doesn't remount, so useEffect only runs once
 ```
 
+### ❌ Pitfall 6: Session object reference in useEffect deps
+
+```typescript
+// WRONG - new session object on every refetch triggers re-mount
+const { status, data: session } = useSession()
+useEffect(() => { ... }, [conversationId, status, session])
+// ← session is a new object reference on every SessionProvider refetch,
+//    even if auth state hasn't changed. This causes the effect to re-run,
+//    setting loading=true and unmounting the conversation tree (losing draft text).
+```
+
+```typescript
+// CORRECT - use only the stable `status` string
+const { status } = useSession()
+useEffect(() => { ... }, [conversationId, status])
+// ← status is a primitive string ('loading' | 'authenticated' | 'unauthenticated')
+//    that only changes on actual auth state transitions.
+```
+
+See #811 for the full root cause analysis.
+
 ---
 
 ## Troubleshooting Guide


### PR DESCRIPTION
## Summary

Fixes #811 — Nexus conversations remount when switching browser tabs, causing draft text loss in the composer input.

## Root Cause

NextAuth's `SessionProvider` refetches the session on window focus by default (`refetchOnWindowFocus={true}`). The new session object reference triggered `ConversationInitializer`'s `useEffect` (which had `session` in its dependency array), setting `loading=true` and unmounting the entire conversation component tree — destroying any draft text in the composer.

## Changes

- **`components/utilities/session-provider.tsx`**: Add `refetchOnWindowFocus={false}` to `SessionProvider` — eliminates the unnecessary session refetch on every tab switch
- **`app/(protected)/nexus/_components/conversation-initializer.tsx`**: Remove `session` object from `useEffect` dependency array, keeping only `status` (a stable primitive string). Removed the redundant `session?.user` guard since NextAuth guarantees user data exists when `status === 'authenticated'`

## Test Plan

- [ ] Open existing Nexus conversation, type draft text, switch tabs, return — text preserved
- [ ] Session expiry still redirects to login correctly
- [ ] No loading spinner flash on tab return
- [ ] Conversation streaming/history still works
- [ ] Lint and typecheck pass (verified)

Closes #811