### PR TITLE
feat: Nexus URL config, prompt library settings & model fallback

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ cd infra && bunx cdk deploy AIStudio-FrontendStack-Dev     # Deploy single stack
 ## 🎯 Critical Rules
 
 1. **Type Safety**: NO `any` types. Full TypeScript. Run `bun run lint` and `bun run typecheck` on ENTIRE codebase before commits.
-2. **Database Migrations**: Files 001-005 are IMMUTABLE. Only add migrations 010+. Add filename to `MIGRATION_FILES` array in `/infra/database/lambda/db-init-handler.ts`.
+2. **Database Migrations**: Files 001-005 are IMMUTABLE. Only add migrations 010+. Add filename to `migrationFiles` array in `/infra/database/migrations.json`.
 3. **Logging**: NEVER use `console.log/error`. Always use `@/lib/logger`. See patterns below.
 4. **Git Flow**: PRs target `dev` branch, never `main`. Write detailed commit messages.
 5. **Testing**: Add E2E tests for new features. Use Playwright MCP during development.
@@ -156,7 +156,7 @@ user.settings.theme;  // "light" | "dark" | "system"
 bun run drizzle:generate        # Generate from schema changes
 bun run migration:prepare       # Format for Lambda
 bun run migration:list          # List all migrations
-# Then add to MIGRATION_FILES in db-init-handler.ts
+# Then add to migrationFiles array in /infra/database/migrations.json
 ```
 
 **MCP tools for schema verification**:

--- a/actions/prompt-library.actions.ts
+++ b/actions/prompt-library.actions.ts
@@ -13,6 +13,9 @@ import {
   deletePrompt as drizzleDeletePrompt,
   trackUsageEvent
 } from "@/lib/db/drizzle"
+import { executeQuery } from "@/lib/db/drizzle-client"
+import { promptLibrary } from "@/lib/db/schema"
+import { eq, and, isNull } from "drizzle-orm"
 import { type ActionState } from "@/types/actions-types"
 import {
   handleError,
@@ -239,6 +242,7 @@ export async function getPrompt(id: string): Promise<ActionState<Prompt>> {
 
 /**
  * Get only the settings for a prompt without incrementing view count.
+ * Uses a targeted query (settings column only) to avoid fetching full content.
  * Used for pre-loading URL-driven configuration without skewing analytics.
  */
 export async function getPromptSettings(
@@ -249,6 +253,8 @@ export async function getPromptSettings(
   const log = createLogger({ requestId, action: "getPromptSettings" })
 
   try {
+    log.info("Action started", { params: sanitizeForLogging({ id }) })
+
     const session = await getServerSession()
     if (!session) {
       throw ErrorFactories.authNoSession()
@@ -260,14 +266,22 @@ export async function getPromptSettings(
       throw ErrorFactories.authzResourceNotFound("Prompt", id)
     }
 
-    const result = await getPromptById(id)
-    if (!result) {
+    // Targeted query: only fetch settings column, not full prompt content
+    const [row] = await executeQuery(
+      (db) => db.select({ settings: promptLibrary.settings })
+        .from(promptLibrary)
+        .where(and(eq(promptLibrary.id, id), isNull(promptLibrary.deletedAt)))
+        .limit(1),
+      "getPromptSettings"
+    )
+
+    if (!row) {
       throw ErrorFactories.dbRecordNotFound("prompt_library", id)
     }
 
     log.info("Prompt settings retrieved", { promptId: id })
     timer({ status: "success" })
-    return createSuccess(result.settings ?? null)
+    return createSuccess(row.settings ?? null)
   } catch (error) {
     timer({ status: "error" })
     return handleError(error, "Failed to retrieve prompt settings", {

--- a/actions/prompt-library.actions.ts
+++ b/actions/prompt-library.actions.ts
@@ -98,7 +98,8 @@ export async function createPrompt(
       description: validated.description,
       visibility: validated.visibility,
       sourceMessageId: validated.sourceMessageId,
-      sourceConversationId: validated.sourceConversationId
+      sourceConversationId: validated.sourceConversationId,
+      settings: validated.settings ?? null
     })
 
     // Build prompt object with type conversion
@@ -110,6 +111,7 @@ export async function createPrompt(
       sourceMessageId: string | null
       sourceConversationId: string | null
       deletedAt: Date | null
+      settings: import("@/lib/db/types/jsonb").PromptLibrarySettings | null
     }
 
     const prompt: Prompt = {
@@ -130,6 +132,7 @@ export async function createPrompt(
       createdAt: resultWithAllFields.createdAt.toISOString(),
       updatedAt: resultWithAllFields.updatedAt.toISOString(),
       deletedAt: resultWithAllFields.deletedAt?.toISOString() ?? null,
+      settings: resultWithAllFields.settings ?? null,
       tags: []
     }
 
@@ -214,6 +217,7 @@ export async function getPrompt(id: string): Promise<ActionState<Prompt>> {
       createdAt: result.createdAt.toISOString(),
       updatedAt: result.updatedAt.toISOString(),
       deletedAt: result.deletedAt?.toISOString() ?? null,
+      settings: result.settings ?? null,
       tags: result.tags,
       ownerName: result.ownerName ?? undefined
     }
@@ -362,7 +366,8 @@ export async function updatePrompt(
     const hasFieldUpdates = validated.title !== undefined ||
                            validated.content !== undefined ||
                            validated.description !== undefined ||
-                           validated.visibility !== undefined
+                           validated.visibility !== undefined ||
+                           validated.settings !== undefined
 
     if (!hasFieldUpdates && !validated.tags) {
       // No changes requested, fetch and return current prompt
@@ -379,7 +384,8 @@ export async function updatePrompt(
         title: validated.title,
         content: validated.content,
         description: validated.description,
-        visibility: validated.visibility
+        visibility: validated.visibility,
+        settings: validated.settings
       })
 
       if (!result) {

--- a/actions/prompt-library.actions.ts
+++ b/actions/prompt-library.actions.ts
@@ -6,6 +6,7 @@ import {
   setPromptTags,
   getTagsForPrompt,
   getPromptById,
+  getPromptSettingsById,
   incrementViewCount,
   incrementUseCount,
   listPrompts as drizzleListPrompts,
@@ -13,9 +14,6 @@ import {
   deletePrompt as drizzleDeletePrompt,
   trackUsageEvent
 } from "@/lib/db/drizzle"
-import { executeQuery } from "@/lib/db/drizzle-client"
-import { promptLibrary } from "@/lib/db/schema"
-import { eq, and, isNull } from "drizzle-orm"
 import { type ActionState } from "@/types/actions-types"
 import {
   handleError,
@@ -266,22 +264,11 @@ export async function getPromptSettings(
       throw ErrorFactories.authzResourceNotFound("Prompt", id)
     }
 
-    // Targeted query: only fetch settings column, not full prompt content
-    const [row] = await executeQuery(
-      (db) => db.select({ settings: promptLibrary.settings })
-        .from(promptLibrary)
-        .where(and(eq(promptLibrary.id, id), isNull(promptLibrary.deletedAt)))
-        .limit(1),
-      "getPromptSettings"
-    )
-
-    if (!row) {
-      throw ErrorFactories.dbRecordNotFound("prompt_library", id)
-    }
+    const settings = await getPromptSettingsById(id)
 
     log.info("Prompt settings retrieved", { promptId: id })
     timer({ status: "success" })
-    return createSuccess(row.settings ?? null)
+    return createSuccess(settings)
   } catch (error) {
     timer({ status: "error" })
     return handleError(error, "Failed to retrieve prompt settings", {

--- a/actions/prompt-library.actions.ts
+++ b/actions/prompt-library.actions.ts
@@ -46,6 +46,7 @@ import type {
   PromptListItem,
   PromptListResult
 } from "@/lib/prompt-library/types"
+import type { PromptLibrarySettings } from "@/lib/db/types/jsonb"
 
 /**
  * Create a new prompt
@@ -232,6 +233,47 @@ export async function getPrompt(id: string): Promise<ActionState<Prompt>> {
       context: "getPrompt",
       requestId,
       operation: "getPrompt"
+    })
+  }
+}
+
+/**
+ * Get only the settings for a prompt without incrementing view count.
+ * Used for pre-loading URL-driven configuration without skewing analytics.
+ */
+export async function getPromptSettings(
+  id: string
+): Promise<ActionState<PromptLibrarySettings | null>> {
+  const requestId = generateRequestId()
+  const timer = startTimer("getPromptSettings")
+  const log = createLogger({ requestId, action: "getPromptSettings" })
+
+  try {
+    const session = await getServerSession()
+    if (!session) {
+      throw ErrorFactories.authNoSession()
+    }
+
+    const userId = await getUserIdFromSession(session.sub)
+    const canRead = await canReadPrompt(id, userId)
+    if (!canRead) {
+      throw ErrorFactories.authzResourceNotFound("Prompt", id)
+    }
+
+    const result = await getPromptById(id)
+    if (!result) {
+      throw ErrorFactories.dbRecordNotFound("prompt_library", id)
+    }
+
+    timer({ status: "success" })
+    log.info("Prompt settings retrieved", { promptId: id })
+    return createSuccess(result.settings ?? null)
+  } catch (error) {
+    timer({ status: "error" })
+    return handleError(error, "Failed to retrieve prompt settings", {
+      context: "getPromptSettings",
+      requestId,
+      operation: "getPromptSettings"
     })
   }
 }

--- a/actions/prompt-library.actions.ts
+++ b/actions/prompt-library.actions.ts
@@ -112,7 +112,7 @@ export async function createPrompt(
       sourceMessageId: string | null
       sourceConversationId: string | null
       deletedAt: Date | null
-      settings: import("@/lib/db/types/jsonb").PromptLibrarySettings | null
+      settings: PromptLibrarySettings | null
     }
 
     const prompt: Prompt = {
@@ -265,8 +265,8 @@ export async function getPromptSettings(
       throw ErrorFactories.dbRecordNotFound("prompt_library", id)
     }
 
-    timer({ status: "success" })
     log.info("Prompt settings retrieved", { promptId: id })
+    timer({ status: "success" })
     return createSuccess(result.settings ?? null)
   } catch (error) {
     timer({ status: "error" })

--- a/app/(protected)/admin/models/_components/models-page-client.tsx
+++ b/app/(protected)/admin/models/_components/models-page-client.tsx
@@ -61,11 +61,12 @@ export function ModelsPageClient({ initialModels }: ModelsPageClientProps) {
       chainPrompts: number
       conversations: number
       modelComparisons: number
+      promptLibrary: number
     }
   }>({
     isOpen: false,
     model: null,
-    referenceCounts: { chainPrompts: 0, conversations: 0, modelComparisons: 0 },
+    referenceCounts: { chainPrompts: 0, conversations: 0, modelComparisons: 0, promptLibrary: 0 },
   })
 
   // Calculate stats from models
@@ -439,10 +440,16 @@ export function ModelsPageClient({ initialModels }: ModelsPageClientProps) {
           // Model has references, show replacement dialog
           const fullModel = models.find((m) => m.id === model.id)
           if (fullModel) {
+            const apiCounts = referenceData.data.counts
             setReplacementDialog({
               isOpen: true,
               model: fullModel,
-              referenceCounts: referenceData.data.counts,
+              referenceCounts: {
+                chainPrompts: apiCounts.chainPrompts ?? 0,
+                conversations: (apiCounts.nexusMessages ?? 0) + (apiCounts.nexusConversations ?? 0),
+                modelComparisons: apiCounts.modelComparisons ?? 0,
+                promptLibrary: apiCounts.promptLibrary ?? 0,
+              },
             })
           }
         } else {
@@ -502,7 +509,7 @@ export function ModelsPageClient({ initialModels }: ModelsPageClientProps) {
         setReplacementDialog({
           isOpen: false,
           model: null,
-          referenceCounts: { chainPrompts: 0, conversations: 0, modelComparisons: 0 },
+          referenceCounts: { chainPrompts: 0, conversations: 0, modelComparisons: 0, promptLibrary: 0 },
         })
 
         toast({
@@ -708,7 +715,7 @@ export function ModelsPageClient({ initialModels }: ModelsPageClientProps) {
             setReplacementDialog({
               isOpen: false,
               model: null,
-              referenceCounts: { chainPrompts: 0, conversations: 0, modelComparisons: 0 },
+              referenceCounts: { chainPrompts: 0, conversations: 0, modelComparisons: 0, promptLibrary: 0 },
             })
           }
           modelToDelete={replacementDialog.model}

--- a/app/(protected)/nexus/_components/chat/prompt-save-button.tsx
+++ b/app/(protected)/nexus/_components/chat/prompt-save-button.tsx
@@ -13,6 +13,9 @@ interface PromptSaveButtonProps {
   content: string
   conversationId: string | null
   className?: string
+  currentModelId?: string
+  currentTools?: string[]
+  currentConnectors?: string[]
 }
 
 /**
@@ -22,7 +25,10 @@ interface PromptSaveButtonProps {
 export function PromptSaveButton({
   content,
   conversationId,
-  className = ""
+  className = "",
+  currentModelId,
+  currentTools,
+  currentConnectors
 }: PromptSaveButtonProps) {
   const [showDialog, setShowDialog] = useState(false)
   const { savePrompt, isSaving } = usePromptSave()
@@ -69,6 +75,9 @@ export function PromptSaveButton({
         onOpenChange={setShowDialog}
         content={content}
         conversationId={conversationId}
+        currentModelId={currentModelId}
+        currentTools={currentTools}
+        currentConnectors={currentConnectors}
       />
     </>
   )

--- a/app/(protected)/nexus/_components/chat/prompt-save-dialog.tsx
+++ b/app/(protected)/nexus/_components/chat/prompt-save-dialog.tsx
@@ -24,12 +24,16 @@ import { TagInput } from "@/components/ui/tag-input"
 import { usePromptSave } from "../hooks/use-prompt-save"
 import { ScrollArea } from "@/components/ui/scroll-area"
 import type { PromptVisibility } from "@/lib/prompt-library/types"
+import type { PromptLibrarySettings } from "@/lib/db/types/jsonb"
 
 interface PromptSaveDialogProps {
   open: boolean
   onOpenChange: (open: boolean) => void
   content: string
   conversationId: string | null
+  currentModelId?: string
+  currentTools?: string[]
+  currentConnectors?: string[]
 }
 
 /**
@@ -39,7 +43,10 @@ export function PromptSaveDialog({
   open,
   onOpenChange,
   content,
-  conversationId
+  conversationId,
+  currentModelId,
+  currentTools,
+  currentConnectors
 }: PromptSaveDialogProps) {
   // Generate default title from content (first 100 chars)
   const defaultTitle = content.slice(0, 100).trim() || "Untitled Prompt"
@@ -62,6 +69,15 @@ export function PromptSaveDialog({
     }
   }, [open, defaultTitle])
 
+  // Build settings from current chat configuration
+  const settings: PromptLibrarySettings | undefined = (() => {
+    const s: PromptLibrarySettings = {}
+    if (currentModelId) s.modelId = currentModelId
+    if (currentTools && currentTools.length > 0) s.tools = currentTools
+    if (currentConnectors && currentConnectors.length > 0) s.connectors = currentConnectors
+    return Object.keys(s).length > 0 ? s : undefined
+  })()
+
   const handleSave = async () => {
     const result = await savePrompt({
       title: title.trim() || defaultTitle,
@@ -69,7 +85,8 @@ export function PromptSaveDialog({
       description: description.trim() || undefined,
       visibility,
       tags: tags.length > 0 ? tags : undefined,
-      sourceConversationId: conversationId || undefined
+      sourceConversationId: conversationId || undefined,
+      settings
     })
 
     if (result.success) {
@@ -169,6 +186,23 @@ export function PromptSaveDialog({
                 Add up to 10 tags to help organize and find this prompt
               </div>
             </div>
+
+            {settings && (
+              <div className="grid gap-2">
+                <Label className="text-xs text-muted-foreground">
+                  Saved Configuration
+                </Label>
+                <div className="rounded-md bg-muted p-3 text-sm text-muted-foreground space-y-1">
+                  {settings.modelId && <div>Model: {settings.modelId}</div>}
+                  {settings.tools && settings.tools.length > 0 && (
+                    <div>Tools: {settings.tools.join(", ")}</div>
+                  )}
+                  {settings.connectors && settings.connectors.length > 0 && (
+                    <div>Connectors: {settings.connectors.length} connected</div>
+                  )}
+                </div>
+              </div>
+            )}
 
             <div className="grid gap-2">
               <Label className="text-xs text-muted-foreground">

--- a/app/(protected)/nexus/_components/chat/prompt-save-dialog.tsx
+++ b/app/(protected)/nexus/_components/chat/prompt-save-dialog.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState, useEffect, startTransition } from "react"
+import { useState, useEffect, startTransition, useMemo } from "react"
 import {
   Dialog,
   DialogContent,
@@ -69,14 +69,14 @@ export function PromptSaveDialog({
     }
   }, [open, defaultTitle])
 
-  // Build settings from current chat configuration
-  const settings: PromptLibrarySettings | undefined = (() => {
+  // Build settings from current chat configuration (memoized to avoid recalculation on every render)
+  const settings = useMemo((): PromptLibrarySettings | undefined => {
     const s: PromptLibrarySettings = {}
     if (currentModelId) s.modelId = currentModelId
     if (currentTools && currentTools.length > 0) s.tools = currentTools
     if (currentConnectors && currentConnectors.length > 0) s.connectors = currentConnectors
     return Object.keys(s).length > 0 ? s : undefined
-  })()
+  }, [currentModelId, currentTools, currentConnectors])
 
   const handleSave = async () => {
     const result = await savePrompt({

--- a/app/(protected)/nexus/_components/conversation-initializer.tsx
+++ b/app/(protected)/nexus/_components/conversation-initializer.tsx
@@ -151,10 +151,12 @@ interface ApiMessage {
  */
 export function ConversationInitializer({
   conversationId,
-  children
+  children,
+  onModelUsed
 }: {
   conversationId: string | null
   children: (messages: UIMessage[]) => React.ReactNode
+  onModelUsed?: (modelId: string | null) => void
 }) {
   const [messages, setMessages] = useState<UIMessage[]>([])
   const [loading, setLoading] = useState(true)
@@ -198,11 +200,19 @@ export function ConversationInitializer({
         if (!res.ok) {
           throw new Error(`Failed to load messages: ${res.status}`)
         }
-        return res.json() as Promise<{ messages: ApiMessage[] }>
+        return res.json() as Promise<{
+          messages: ApiMessage[]
+          conversation?: { modelUsed?: string | null }
+        }>
       })
       .then(data => {
         const loadedMessages = data.messages || []
         log.debug('Messages loaded from API', { count: loadedMessages.length })
+
+        // Pass conversation model info up to parent
+        if (onModelUsed && data.conversation?.modelUsed) {
+          onModelUsed(data.conversation.modelUsed)
+        }
 
         // Convert to UIMessage format (required by useChatRuntime)
         const threadMessages: UIMessage[] = loadedMessages.map((msg) => ({

--- a/app/(protected)/nexus/_components/model-fallback-banner.tsx
+++ b/app/(protected)/nexus/_components/model-fallback-banner.tsx
@@ -19,7 +19,7 @@ export function ModelFallbackBanner({
     <Alert className="mx-auto w-full max-w-[48rem] relative">
       <Info className="h-4 w-4" />
       <AlertDescription className="pr-8">
-        This conversation was created with <strong>{originalModel}</strong>, which is no longer available.
+        This conversation was created with model <strong>{originalModel}</strong>, which is no longer available.
         Using <strong>{fallbackModel}</strong> instead.
       </AlertDescription>
       <Button

--- a/app/(protected)/nexus/_components/model-fallback-banner.tsx
+++ b/app/(protected)/nexus/_components/model-fallback-banner.tsx
@@ -15,12 +15,15 @@ export function ModelFallbackBanner({
   fallbackModel,
   onDismiss
 }: ModelFallbackBannerProps) {
+  const displayOriginal = originalModel || 'an unknown model'
+  const displayFallback = fallbackModel || 'the default model'
+
   return (
     <Alert className="mx-auto w-full max-w-[48rem] relative">
       <Info className="h-4 w-4" />
       <AlertDescription className="pr-8">
-        This conversation was created with model <strong>{originalModel}</strong>, which is no longer available.
-        Using <strong>{fallbackModel}</strong> instead.
+        This conversation was created with model <strong>{displayOriginal}</strong>, which is no longer available.
+        Using <strong>{displayFallback}</strong> instead.
       </AlertDescription>
       <Button
         variant="ghost"

--- a/app/(protected)/nexus/_components/model-fallback-banner.tsx
+++ b/app/(protected)/nexus/_components/model-fallback-banner.tsx
@@ -1,0 +1,36 @@
+"use client"
+
+import { Alert, AlertDescription } from "@/components/ui/alert"
+import { Button } from "@/components/ui/button"
+import { Info, X } from "lucide-react"
+
+interface ModelFallbackBannerProps {
+  originalModel: string
+  fallbackModel: string
+  onDismiss: () => void
+}
+
+export function ModelFallbackBanner({
+  originalModel,
+  fallbackModel,
+  onDismiss
+}: ModelFallbackBannerProps) {
+  return (
+    <Alert className="mx-auto w-full max-w-[48rem] relative">
+      <Info className="h-4 w-4" />
+      <AlertDescription className="pr-8">
+        This conversation was created with <strong>{originalModel}</strong>, which is no longer available.
+        Using <strong>{fallbackModel}</strong> instead.
+      </AlertDescription>
+      <Button
+        variant="ghost"
+        size="icon"
+        className="absolute right-2 top-2 h-6 w-6"
+        onClick={onDismiss}
+      >
+        <X className="h-3 w-3" />
+        <span className="sr-only">Dismiss</span>
+      </Button>
+    </Alert>
+  )
+}

--- a/app/(protected)/nexus/page.tsx
+++ b/app/(protected)/nexus/page.tsx
@@ -348,10 +348,13 @@ function NexusPageContent() {
     return null
   }, [urlConversationId])
 
-  // Parse URL configuration params — slice arrays to prevent unbounded input
+  // Parse URL configuration params — slice arrays and validate formats
   const urlModelId = searchParams.get('model')
   const urlTools = useMemo(() => searchParams.getAll('tool').slice(0, 50), [searchParams])
-  const urlConnectors = useMemo(() => searchParams.getAll('connector').slice(0, 50), [searchParams])
+  const urlConnectors = useMemo(
+    () => searchParams.getAll('connector').slice(0, 50).filter(c => uuidSchema.safeParse(c).success),
+    [searchParams]
+  )
 
   // Load models and manage model selection
   const [preferredModelId, setPreferredModelId] = useState<string | null>(urlModelId)
@@ -371,15 +374,18 @@ function NexusPageContent() {
   // Load prompt settings when promptId is present (lower priority than URL params)
   // Uses getPromptSettings to avoid incrementing view count (PromptAutoLoader handles the full view)
   const urlPromptId = searchParams.get('promptId')
-  // Tracks which promptId we've already applied settings for. Prevents re-applying
-  // settings on subsequent renders, which would override any tool/connector changes
-  // the user has made since the initial prompt load.
-  const promptSettingsLoadedRef = useRef<string | null>(null)
+  // Tracks which promptId settings were last requested. Used both to prevent
+  // re-applying settings (which would override user changes after initial load)
+  // and to discard stale responses when the user rapidly switches prompts.
+  const promptSettingsRequestedRef = useRef<string | null>(null)
   useEffect(() => {
     if (!urlPromptId || !uuidSchema.safeParse(urlPromptId).success) return
-    if (promptSettingsLoadedRef.current === urlPromptId) return
-    promptSettingsLoadedRef.current = urlPromptId
-    getPromptSettings(urlPromptId).then(result => {
+    if (promptSettingsRequestedRef.current === urlPromptId) return
+    promptSettingsRequestedRef.current = urlPromptId
+    const requestedId = urlPromptId
+    getPromptSettings(requestedId).then(result => {
+      // Discard stale response if user has already navigated to a different prompt
+      if (promptSettingsRequestedRef.current !== requestedId) return
       if (!result.isSuccess || !result.data) return
       const settings = result.data
 
@@ -395,7 +401,7 @@ function NexusPageContent() {
       }
     }).catch(err => {
       log.warn('Failed to load prompt settings', {
-        promptId: urlPromptId,
+        promptId: requestedId,
         error: err instanceof Error ? err.message : String(err)
       })
     })

--- a/app/(protected)/nexus/page.tsx
+++ b/app/(protected)/nexus/page.tsx
@@ -23,6 +23,9 @@ import { validateConversationId } from '@/lib/nexus/conversation-navigation'
 import type { SelectAiModel } from '@/types'
 import { createLogger } from '@/lib/client-logger'
 import { toast } from 'sonner'
+import { getPrompt } from '@/actions/prompt-library.actions'
+import type { PromptLibrarySettings } from '@/lib/db/types/jsonb'
+import { ModelFallbackBanner } from './_components/model-fallback-banner'
 
 const log = createLogger({ moduleName: 'nexus-page' })
 
@@ -337,27 +340,66 @@ function NexusPageContent() {
     if (validateConversationId(urlConversationId)) {
       return urlConversationId
     }
-    
+
     if (urlConversationId) {
       log.warn('Invalid conversation ID in URL parameter', { urlConversationId })
     }
-    
+
     return null
   }, [urlConversationId])
-  
-  // Load models and manage model selection
-  const { 
-    models, 
-    selectedModel, 
-    setSelectedModel: originalSetSelectedModel, 
-    isLoading: isLoadingModels 
-  } = useModelsWithPersistence('nexus-model', ['chat'])
-  
-  // Tool management state
-  const [enabledTools, setEnabledTools] = useState<string[]>([])
 
-  // Connector management state (per-conversation)
-  const [enabledConnectors, setEnabledConnectors] = useState<string[]>([])
+  // Parse URL configuration params (lazy — stable from initial searchParams)
+  const urlModelId = searchParams.get('model')
+  const urlTools = useMemo(() => searchParams.getAll('tool'), [searchParams])
+  const urlConnectors = useMemo(() => searchParams.getAll('connector'), [searchParams])
+
+  // Load models and manage model selection
+  // preferredModelId will be resolved in Task 5 to include prompt settings
+  const [preferredModelId, setPreferredModelId] = useState<string | null>(urlModelId)
+  const {
+    models,
+    selectedModel,
+    setSelectedModel: originalSetSelectedModel,
+    isLoading: isLoadingModels
+  } = useModelsWithPersistence('nexus-model', ['chat'], preferredModelId)
+
+  // Tool management state — initialize from URL params
+  const [enabledTools, setEnabledTools] = useState<string[]>(() => urlTools)
+
+  // Connector management state — initialize from URL params
+  const [enabledConnectors, setEnabledConnectors] = useState<string[]>(() => urlConnectors)
+
+  // Load prompt settings when promptId is present (lower priority than URL params)
+  const urlPromptId = searchParams.get('promptId')
+  useEffect(() => {
+    if (!urlPromptId) return
+    getPrompt(urlPromptId).then(result => {
+      if (!result.isSuccess || !result.data?.settings) return
+      const settings = result.data.settings as PromptLibrarySettings
+
+      // URL params take priority over prompt settings
+      if (!urlModelId && settings.modelId) {
+        setPreferredModelId(settings.modelId)
+      }
+      if (urlTools.length === 0 && settings.tools?.length) {
+        setEnabledTools(settings.tools)
+      }
+      if (urlConnectors.length === 0 && settings.connectors?.length) {
+        setEnabledConnectors(settings.connectors)
+      }
+    }).catch(err => {
+      log.warn('Failed to load prompt settings', {
+        promptId: urlPromptId,
+        error: err instanceof Error ? err.message : String(err)
+      })
+    })
+  }, [urlPromptId, urlModelId, urlTools.length, urlConnectors.length])
+
+  // Model fallback state for archived conversations
+  const [modelFallbackInfo, setModelFallbackInfo] = useState<{
+    originalModel: string
+    fallbackModel: string
+  } | null>(null)
 
   // Attachment processing state
   const [processingAttachments, setProcessingAttachments] = useState<Set<string>>(new Set())
@@ -390,6 +432,23 @@ function NexusPageContent() {
       window.location.reload();
     }
   }, [originalSetSelectedModel, selectedModel])
+
+  // Handle model info from loaded conversation
+  const handleModelUsed = useCallback((conversationModelId: string | null) => {
+    if (!conversationModelId || models.length === 0) return
+    const modelExists = models.some(m => m.modelId === conversationModelId)
+    if (!modelExists) {
+      const fallback = selectedModel?.name || 'default model'
+      setModelFallbackInfo({
+        originalModel: conversationModelId,
+        fallbackModel: fallback
+      })
+      log.info('Conversation model not available, showing fallback banner', {
+        originalModel: conversationModelId,
+        fallbackModel: fallback
+      })
+    }
+  }, [models, selectedModel?.name])
 
   // Memoized callback for tool changes to prevent unnecessary re-renders
   const onToolsChange = useCallback((tools: string[]) => {
@@ -487,25 +546,39 @@ function NexusPageContent() {
           <NexusShell>
             <div className="relative h-full">
               {selectedModel ? (
-                <ConversationInitializer conversationId={stableConversationId}>
-                  {(initialMessages) => (
-                    <NexusRuntimeWrapper
-                      conversationId={conversationId}
-                      selectedModel={selectedModel}
-                      enabledTools={enabledTools}
-                      enabledConnectors={enabledConnectors}
-                      attachmentAdapter={attachmentAdapter}
-                      initialMessages={initialMessages}
-                      onConversationIdChange={handleConversationIdChange}
-                      processingAttachments={processingAttachments}
-                      models={models}
-                      onModelChange={setSelectedModel}
-                      isLoadingModels={isLoadingModels}
-                      onToolsChange={onToolsChange}
-                      onConnectorsChange={onConnectorsChange}
-                    />
+                <>
+                  {modelFallbackInfo && (
+                    <div className="px-4 pt-2">
+                      <ModelFallbackBanner
+                        originalModel={modelFallbackInfo.originalModel}
+                        fallbackModel={modelFallbackInfo.fallbackModel}
+                        onDismiss={() => setModelFallbackInfo(null)}
+                      />
+                    </div>
                   )}
-                </ConversationInitializer>
+                  <ConversationInitializer
+                    conversationId={stableConversationId}
+                    onModelUsed={handleModelUsed}
+                  >
+                    {(initialMessages) => (
+                      <NexusRuntimeWrapper
+                        conversationId={conversationId}
+                        selectedModel={selectedModel}
+                        enabledTools={enabledTools}
+                        enabledConnectors={enabledConnectors}
+                        attachmentAdapter={attachmentAdapter}
+                        initialMessages={initialMessages}
+                        onConversationIdChange={handleConversationIdChange}
+                        processingAttachments={processingAttachments}
+                        models={models}
+                        onModelChange={setSelectedModel}
+                        isLoadingModels={isLoadingModels}
+                        onToolsChange={onToolsChange}
+                        onConnectorsChange={onConnectorsChange}
+                      />
+                    )}
+                  </ConversationInitializer>
+                </>
               ) : (
                 <div className="flex h-full items-center justify-center">
                   <div className="text-center">

--- a/app/(protected)/nexus/page.tsx
+++ b/app/(protected)/nexus/page.tsx
@@ -363,11 +363,11 @@ function NexusPageContent() {
     isLoading: isLoadingModels
   } = useModelsWithPersistence('nexus-model', ['chat'], preferredModelId)
 
-  // Tool management state — initialize from URL params
-  const [enabledTools, setEnabledTools] = useState<string[]>(() => searchParams.getAll('tool').slice(0, 50))
+  // Tool management state — single source of truth from urlTools
+  const [enabledTools, setEnabledTools] = useState<string[]>(() => urlTools)
 
-  // Connector management state — initialize from URL params
-  const [enabledConnectors, setEnabledConnectors] = useState<string[]>(() => searchParams.getAll('connector').slice(0, 50))
+  // Connector management state — single source of truth from urlConnectors
+  const [enabledConnectors, setEnabledConnectors] = useState<string[]>(() => urlConnectors)
 
   // Load prompt settings when promptId is present (lower priority than URL params)
   // Uses getPromptSettings to avoid incrementing view count (PromptAutoLoader handles the full view)
@@ -400,11 +400,20 @@ function NexusPageContent() {
     })
   }, [urlPromptId, urlModelId, urlTools.length, urlConnectors.length])
 
-  // Model fallback state for archived conversations
-  const [modelFallbackInfo, setModelFallbackInfo] = useState<{
-    originalModel: string
-    fallbackModel: string
-  } | null>(null)
+  // Model fallback for archived conversations — derived from conversationModelId + available models.
+  // Setting conversationModelId to null (on dismiss or navigation) hides the banner.
+  const [conversationModelId, setConversationModelId] = useState<string | null>(null)
+  const modelFallbackInfo = useMemo(() => {
+    if (!conversationModelId || models.length === 0) return null
+    const modelExists = models.some(m => m.modelId === conversationModelId)
+    if (!modelExists) {
+      return {
+        originalModel: conversationModelId,
+        fallbackModel: selectedModel?.name || 'default model'
+      }
+    }
+    return null
+  }, [conversationModelId, models, selectedModel?.name])
 
   // Attachment processing state
   const [processingAttachments, setProcessingAttachments] = useState<Set<string>>(new Set())
@@ -430,31 +439,19 @@ function NexusPageContent() {
     // Clear enabled tools and connectors when switching models
     setEnabledTools([]);
     setEnabledConnectors([]);
-    // Clear conversation ID and fallback banner when switching models
+    // Clear conversation ID and fallback state when switching models
     setConversationId(null);
-    setModelFallbackInfo(null);
+    setConversationModelId(null);
     // Force page reload to ensure clean state
     if (model && selectedModel && model.modelId !== selectedModel.modelId) {
       window.location.reload();
     }
   }, [originalSetSelectedModel, selectedModel])
 
-  // Handle model info from loaded conversation
-  const handleModelUsed = useCallback((conversationModelId: string | null) => {
-    if (!conversationModelId || models.length === 0) return
-    const modelExists = models.some(m => m.modelId === conversationModelId)
-    if (!modelExists) {
-      const fallback = selectedModel?.name || 'default model'
-      setModelFallbackInfo({
-        originalModel: conversationModelId,
-        fallbackModel: fallback
-      })
-      log.info('Conversation model not available, showing fallback banner', {
-        originalModel: conversationModelId,
-        fallbackModel: fallback
-      })
-    }
-  }, [models, selectedModel?.name])
+  // Store the conversation's model ID when received — availability check is derived via useMemo above
+  const handleModelUsed = useCallback((modelId: string | null) => {
+    setConversationModelId(modelId)
+  }, [])
 
   // Memoized callback for tool changes to prevent unnecessary re-renders
   const onToolsChange = useCallback((tools: string[]) => {
@@ -484,8 +481,8 @@ function NexusPageContent() {
   // Conversation ID callback for maintaining conversation continuity
   const handleConversationIdChange = useCallback((newConversationId: string) => {
     setConversationId(newConversationId)
-    // Clear fallback banner — it's only relevant to the previously loaded conversation
-    setModelFallbackInfo(null)
+    // Clear fallback state — it's only relevant to the previously loaded conversation
+    setConversationModelId(null)
     conversationContext.setConversationId(newConversationId)
 
     // Update URL to reflect the current conversation
@@ -560,7 +557,7 @@ function NexusPageContent() {
                       <ModelFallbackBanner
                         originalModel={modelFallbackInfo.originalModel}
                         fallbackModel={modelFallbackInfo.fallbackModel}
-                        onDismiss={() => setModelFallbackInfo(null)}
+                        onDismiss={() => setConversationModelId(null)}
                       />
                     </div>
                   )}

--- a/app/(protected)/nexus/page.tsx
+++ b/app/(protected)/nexus/page.tsx
@@ -349,16 +349,24 @@ function NexusPageContent() {
     return null
   }, [urlConversationId])
 
-  // Parse URL configuration params — slice arrays and validate formats
+  // Parse URL configuration params — validate formats, cap at 50 entries
   const urlModelId = searchParams.get('model')
-  const urlTools = useMemo(
-    () => searchParams.getAll('tool').slice(0, 50).filter(t => toolNameSchema.safeParse(t).success),
-    [searchParams]
-  )
-  const urlConnectors = useMemo(
-    () => searchParams.getAll('connector').slice(0, 50).filter(c => uuidSchema.safeParse(c).success),
-    [searchParams]
-  )
+  const urlTools = useMemo(() => {
+    const raw = searchParams.getAll('tool')
+    const validated = raw.filter(t => toolNameSchema.safeParse(t).success).slice(0, 50)
+    if (raw.length > validated.length) {
+      log.warn('URL tool params truncated or filtered', { rawCount: raw.length, validCount: validated.length })
+    }
+    return validated
+  }, [searchParams])
+  const urlConnectors = useMemo(() => {
+    const raw = searchParams.getAll('connector')
+    const validated = raw.filter(c => uuidSchema.safeParse(c).success).slice(0, 50)
+    if (raw.length > validated.length) {
+      log.warn('URL connector params truncated or filtered', { rawCount: raw.length, validCount: validated.length })
+    }
+    return validated
+  }, [searchParams])
 
   // Load models and manage model selection
   const [preferredModelId, setPreferredModelId] = useState<string | null>(urlModelId)

--- a/app/(protected)/nexus/page.tsx
+++ b/app/(protected)/nexus/page.tsx
@@ -24,7 +24,6 @@ import type { SelectAiModel } from '@/types'
 import { createLogger } from '@/lib/client-logger'
 import { toast } from 'sonner'
 import { getPromptSettings } from '@/actions/prompt-library.actions'
-import type { PromptLibrarySettings } from '@/lib/db/types/jsonb'
 import { ModelFallbackBanner } from './_components/model-fallback-banner'
 
 const log = createLogger({ moduleName: 'nexus-page' })
@@ -372,15 +371,17 @@ function NexusPageContent() {
   // Load prompt settings when promptId is present (lower priority than URL params)
   // Uses getPromptSettings to avoid incrementing view count (PromptAutoLoader handles the full view)
   const urlPromptId = searchParams.get('promptId')
+  // Tracks which promptId we've already applied settings for. Prevents re-applying
+  // settings on subsequent renders, which would override any tool/connector changes
+  // the user has made since the initial prompt load.
   const promptSettingsLoadedRef = useRef<string | null>(null)
   useEffect(() => {
     if (!urlPromptId || !uuidSchema.safeParse(urlPromptId).success) return
-    // Guard: only load settings once per promptId
     if (promptSettingsLoadedRef.current === urlPromptId) return
     promptSettingsLoadedRef.current = urlPromptId
     getPromptSettings(urlPromptId).then(result => {
       if (!result.isSuccess || !result.data) return
-      const settings = result.data as PromptLibrarySettings
+      const settings = result.data
 
       // URL params take priority over prompt settings
       if (!urlModelId && settings.modelId) {
@@ -398,7 +399,7 @@ function NexusPageContent() {
         error: err instanceof Error ? err.message : String(err)
       })
     })
-  }, [urlPromptId, urlModelId, urlTools.length, urlConnectors.length])
+  }, [urlPromptId, urlModelId, urlTools, urlConnectors])
 
   // Model fallback for archived conversations — derived from conversationModelId + available models.
   // Setting conversationModelId to null (on dismiss or navigation) hides the banner.

--- a/app/(protected)/nexus/page.tsx
+++ b/app/(protected)/nexus/page.tsx
@@ -6,7 +6,7 @@ import { type UIMessage } from '@ai-sdk/react'
 import { Thread } from '@/components/assistant-ui/thread'
 import { useSession } from 'next-auth/react'
 import { useRouter, useSearchParams } from 'next/navigation'
-import { useEffect, useMemo, useCallback, useState, Suspense } from 'react'
+import { useEffect, useMemo, useCallback, useState, useRef, Suspense } from 'react'
 import { NexusShell } from './_components/layout/nexus-shell'
 import { NexusLayout } from './_components/layout/nexus-layout'
 import { ErrorBoundary } from './_components/error-boundary'
@@ -23,11 +23,12 @@ import { validateConversationId } from '@/lib/nexus/conversation-navigation'
 import type { SelectAiModel } from '@/types'
 import { createLogger } from '@/lib/client-logger'
 import { toast } from 'sonner'
-import { getPrompt } from '@/actions/prompt-library.actions'
+import { getPromptSettings } from '@/actions/prompt-library.actions'
 import type { PromptLibrarySettings } from '@/lib/db/types/jsonb'
 import { ModelFallbackBanner } from './_components/model-fallback-banner'
 
 const log = createLogger({ moduleName: 'nexus-page' })
+const uuidSchema = z.string().uuid()
 
 /** Zod schema for X-Connector-Tools response header — validates server-sent tool mapping */
 const ConnectorToolsSchema = z.record(z.string(), z.object({
@@ -348,13 +349,12 @@ function NexusPageContent() {
     return null
   }, [urlConversationId])
 
-  // Parse URL configuration params (lazy — stable from initial searchParams)
+  // Parse URL configuration params — slice arrays to prevent unbounded input
   const urlModelId = searchParams.get('model')
-  const urlTools = useMemo(() => searchParams.getAll('tool'), [searchParams])
-  const urlConnectors = useMemo(() => searchParams.getAll('connector'), [searchParams])
+  const urlTools = useMemo(() => searchParams.getAll('tool').slice(0, 50), [searchParams])
+  const urlConnectors = useMemo(() => searchParams.getAll('connector').slice(0, 50), [searchParams])
 
   // Load models and manage model selection
-  // preferredModelId will be resolved in Task 5 to include prompt settings
   const [preferredModelId, setPreferredModelId] = useState<string | null>(urlModelId)
   const {
     models,
@@ -364,18 +364,23 @@ function NexusPageContent() {
   } = useModelsWithPersistence('nexus-model', ['chat'], preferredModelId)
 
   // Tool management state — initialize from URL params
-  const [enabledTools, setEnabledTools] = useState<string[]>(() => urlTools)
+  const [enabledTools, setEnabledTools] = useState<string[]>(() => searchParams.getAll('tool').slice(0, 50))
 
   // Connector management state — initialize from URL params
-  const [enabledConnectors, setEnabledConnectors] = useState<string[]>(() => urlConnectors)
+  const [enabledConnectors, setEnabledConnectors] = useState<string[]>(() => searchParams.getAll('connector').slice(0, 50))
 
   // Load prompt settings when promptId is present (lower priority than URL params)
+  // Uses getPromptSettings to avoid incrementing view count (PromptAutoLoader handles the full view)
   const urlPromptId = searchParams.get('promptId')
+  const promptSettingsLoadedRef = useRef<string | null>(null)
   useEffect(() => {
-    if (!urlPromptId) return
-    getPrompt(urlPromptId).then(result => {
-      if (!result.isSuccess || !result.data?.settings) return
-      const settings = result.data.settings as PromptLibrarySettings
+    if (!urlPromptId || !uuidSchema.safeParse(urlPromptId).success) return
+    // Guard: only load settings once per promptId
+    if (promptSettingsLoadedRef.current === urlPromptId) return
+    promptSettingsLoadedRef.current = urlPromptId
+    getPromptSettings(urlPromptId).then(result => {
+      if (!result.isSuccess || !result.data) return
+      const settings = result.data as PromptLibrarySettings
 
       // URL params take priority over prompt settings
       if (!urlModelId && settings.modelId) {
@@ -425,8 +430,9 @@ function NexusPageContent() {
     // Clear enabled tools and connectors when switching models
     setEnabledTools([]);
     setEnabledConnectors([]);
-    // Clear conversation ID when switching models for fresh conversation
+    // Clear conversation ID and fallback banner when switching models
     setConversationId(null);
+    setModelFallbackInfo(null);
     // Force page reload to ensure clean state
     if (model && selectedModel && model.modelId !== selectedModel.modelId) {
       window.location.reload();
@@ -478,6 +484,8 @@ function NexusPageContent() {
   // Conversation ID callback for maintaining conversation continuity
   const handleConversationIdChange = useCallback((newConversationId: string) => {
     setConversationId(newConversationId)
+    // Clear fallback banner — it's only relevant to the previously loaded conversation
+    setModelFallbackInfo(null)
     conversationContext.setConversationId(newConversationId)
 
     // Update URL to reflect the current conversation

--- a/app/(protected)/nexus/page.tsx
+++ b/app/(protected)/nexus/page.tsx
@@ -28,6 +28,7 @@ import { ModelFallbackBanner } from './_components/model-fallback-banner'
 
 const log = createLogger({ moduleName: 'nexus-page' })
 const uuidSchema = z.string().uuid()
+const toolNameSchema = z.string().max(100).regex(/^[\w:-]+$/)
 
 /** Zod schema for X-Connector-Tools response header — validates server-sent tool mapping */
 const ConnectorToolsSchema = z.record(z.string(), z.object({
@@ -350,7 +351,10 @@ function NexusPageContent() {
 
   // Parse URL configuration params — slice arrays and validate formats
   const urlModelId = searchParams.get('model')
-  const urlTools = useMemo(() => searchParams.getAll('tool').slice(0, 50), [searchParams])
+  const urlTools = useMemo(
+    () => searchParams.getAll('tool').slice(0, 50).filter(t => toolNameSchema.safeParse(t).success),
+    [searchParams]
+  )
   const urlConnectors = useMemo(
     () => searchParams.getAll('connector').slice(0, 50).filter(c => uuidSchema.safeParse(c).success),
     [searchParams]

--- a/app/api/admin/models/[id]/references/route.ts
+++ b/app/api/admin/models/[id]/references/route.ts
@@ -40,7 +40,8 @@ export async function GET(
       counts.chainPromptsCount +
       counts.nexusMessagesCount +
       counts.nexusConversationsCount +
-      counts.modelComparisonsCount;
+      counts.modelComparisonsCount +
+      counts.promptLibraryCount;
 
     log.info("Reference counts retrieved successfully", {
       modelId,
@@ -62,7 +63,8 @@ export async function GET(
             nexusMessages: counts.nexusMessagesCount,
             nexusConversations: counts.nexusConversationsCount,
             toolExecutions: 0, // toolExecutions tracking removed in Drizzle migration
-            modelComparisons: counts.modelComparisonsCount
+            modelComparisons: counts.modelComparisonsCount,
+            promptLibrary: counts.promptLibraryCount
           }
         }
       },

--- a/app/api/nexus/conversations/[id]/messages/route.ts
+++ b/app/api/nexus/conversations/[id]/messages/route.ts
@@ -260,7 +260,11 @@ export async function GET(
 
     return Response.json({
       messages: aiSdkMessages,
-      conversation: { id: conversation.id, title: conversation.title },
+      conversation: {
+        id: conversation.id,
+        title: conversation.title,
+        modelUsed: conversation.modelUsed ?? null
+      },
       pagination: { limit: pagination.limit, offset: pagination.offset, total: totalCount }
     })
 

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "aistudio",
@@ -7,7 +8,7 @@
         "@ai-sdk/amazon-bedrock": "~4.0.61",
         "@ai-sdk/azure": "~3.0.31",
         "@ai-sdk/google": "~3.0.29",
-        "@ai-sdk/mcp": "~1.0.21",
+        "@ai-sdk/mcp": "1.0.21",
         "@ai-sdk/openai": "~3.0.30",
         "@ai-sdk/react": "~3.0.93",
         "@assistant-ui/react": "^0.12.3",

--- a/components/assistant-ui/thread.tsx
+++ b/components/assistant-ui/thread.tsx
@@ -10,6 +10,8 @@ import {
 } from "@assistant-ui/react";
 import type { FC } from "react";
 import { createContext, useContext, useMemo } from "react";
+import { ChatConfigContext, useChatConfig } from "@/lib/contexts/chat-config-context";
+import type { ChatConfig } from "@/lib/contexts/chat-config-context";
 import {
   ArrowDownIcon,
   ArrowUpIcon,
@@ -46,14 +48,7 @@ const ConversationIdContext = createContext<string | null>(null);
 
 export const useConversationId = () => useContext(ConversationIdContext);
 
-// Context for passing current chat configuration to message components (prompt save)
-interface ChatConfig {
-  modelId?: string;
-  tools: string[];
-  connectors: string[];
-}
-const ChatConfigContext = createContext<ChatConfig>({ tools: [], connectors: [] });
-const useChatConfig = () => useContext(ChatConfigContext);
+// ChatConfigContext and useChatConfig imported from @/lib/contexts/chat-config-context
 
 // Pre-defined constants to avoid creating new objects/arrays on every render
 const EMPTY_MODELS_ARRAY: SelectAiModel[] = [];

--- a/components/assistant-ui/thread.tsx
+++ b/components/assistant-ui/thread.tsx
@@ -46,6 +46,15 @@ const ConversationIdContext = createContext<string | null>(null);
 
 export const useConversationId = () => useContext(ConversationIdContext);
 
+// Context for passing current chat configuration to message components (prompt save)
+interface ChatConfig {
+  modelId?: string;
+  tools: string[];
+  connectors: string[];
+}
+const ChatConfigContext = createContext<ChatConfig>({ tools: [], connectors: [] });
+const useChatConfig = () => useContext(ChatConfigContext);
+
 // Pre-defined constants to avoid creating new objects/arrays on every render
 const EMPTY_MODELS_ARRAY: SelectAiModel[] = [];
 const EMPTY_TOOLS_ARRAY: string[] = [];
@@ -157,8 +166,16 @@ export const Thread: FC<ThreadProps> = ({
     AssistantMessage,
   }), []);
 
+  // Memoize chat config for prompt save context
+  const chatConfig = useMemo<ChatConfig>(() => ({
+    modelId: selectedModel?.modelId,
+    tools: enabledTools,
+    connectors: enabledConnectors,
+  }), [selectedModel?.modelId, enabledTools, enabledConnectors]);
+
   return (
     <AssistantContentComponentsContext.Provider value={contentComponents}>
+      <ChatConfigContext.Provider value={chatConfig}>
       <ConversationIdContext.Provider value={conversationId || null}>
         <ThreadPrimitive.Root
           className="bg-white flex h-full flex-col"
@@ -191,6 +208,7 @@ export const Thread: FC<ThreadProps> = ({
           />
         </ThreadPrimitive.Root>
       </ConversationIdContext.Provider>
+      </ChatConfigContext.Provider>
     </AssistantContentComponentsContext.Provider>
   );
 };
@@ -499,6 +517,7 @@ const UserMessage: FC = () => {
 const UserActionBar: FC = () => {
   const message = useMessage();
   const conversationId = useConversationId();
+  const chatConfig = useChatConfig();
 
   // Extract text content from message
   const messageContent = message.content
@@ -522,6 +541,9 @@ const UserActionBar: FC = () => {
         <PromptSaveButton
           content={messageContent}
           conversationId={conversationId}
+          currentModelId={chatConfig.modelId}
+          currentTools={chatConfig.tools}
+          currentConnectors={chatConfig.connectors}
         />
       )}
     </ActionBarPrimitive.Root>

--- a/components/features/ai-models-client.tsx
+++ b/components/features/ai-models-client.tsx
@@ -103,10 +103,16 @@ export const AiModelsClient = memo(function AiModelsClient({ initialModels = [] 
         // Model has references, show replacement dialog
         const modelToDelete = models.find(m => m.id === modelId);
         if (modelToDelete) {
+          const apiCounts = referenceData.data.counts;
           setReplacementDialog({
             isOpen: true,
             model: modelToDelete,
-            referenceCounts: referenceData.data.counts
+            referenceCounts: {
+              chainPrompts: apiCounts.chainPrompts ?? 0,
+              conversations: (apiCounts.nexusMessages ?? 0) + (apiCounts.nexusConversations ?? 0),
+              modelComparisons: apiCounts.modelComparisons ?? 0,
+              promptLibrary: apiCounts.promptLibrary ?? 0,
+            }
           });
         }
       } else {

--- a/components/features/ai-models-client.tsx
+++ b/components/features/ai-models-client.tsx
@@ -19,11 +19,12 @@ export const AiModelsClient = memo(function AiModelsClient({ initialModels = [] 
       chainPrompts: number;
       conversations: number;
       modelComparisons: number;
+      promptLibrary: number;
     };
   }>({
     isOpen: false,
     model: null,
-    referenceCounts: { chainPrompts: 0, conversations: 0, modelComparisons: 0 }
+    referenceCounts: { chainPrompts: 0, conversations: 0, modelComparisons: 0, promptLibrary: 0 }
   });
   const { toast } = useToast();
 
@@ -159,7 +160,7 @@ export const AiModelsClient = memo(function AiModelsClient({ initialModels = [] 
       setReplacementDialog({
         isOpen: false,
         model: null,
-        referenceCounts: { chainPrompts: 0, conversations: 0, modelComparisons: 0 }
+        referenceCounts: { chainPrompts: 0, conversations: 0, modelComparisons: 0, promptLibrary: 0 }
       });
       
       toast({
@@ -191,7 +192,7 @@ export const AiModelsClient = memo(function AiModelsClient({ initialModels = [] 
           onClose={() => setReplacementDialog({
             isOpen: false,
             model: null,
-            referenceCounts: { chainPrompts: 0, conversations: 0, modelComparisons: 0 }
+            referenceCounts: { chainPrompts: 0, conversations: 0, modelComparisons: 0, promptLibrary: 0 }
           })}
           modelToDelete={replacementDialog.model}
           availableModels={models}

--- a/components/features/model-replacement-dialog.tsx
+++ b/components/features/model-replacement-dialog.tsx
@@ -30,6 +30,7 @@ interface ModelReplacementDialogProps {
     chainPrompts: number;
     conversations: number;
     modelComparisons: number;
+    promptLibrary: number;
   };
   onConfirm: (replacementModelId: number) => Promise<void>;
 }
@@ -46,10 +47,11 @@ export function ModelReplacementDialog({
   const [isReplacing, setIsReplacing] = useState(false);
   const [validationWarnings, setValidationWarnings] = useState<string[]>([]);
   
-  const totalReferences = 
-    referenceCounts.chainPrompts + 
-    referenceCounts.conversations + 
-    referenceCounts.modelComparisons;
+  const totalReferences =
+    referenceCounts.chainPrompts +
+    referenceCounts.conversations +
+    referenceCounts.modelComparisons +
+    referenceCounts.promptLibrary;
   
   // Filter out the model being deleted and inactive models
   const replacementOptions = useMemo(() => {
@@ -129,6 +131,9 @@ export function ModelReplacementDialog({
               )}
               {referenceCounts.modelComparisons > 0 && (
                 <div>• {referenceCounts.modelComparisons} Model Comparison{referenceCounts.modelComparisons !== 1 ? 's' : ''}</div>
+              )}
+              {referenceCounts.promptLibrary > 0 && (
+                <div>• {referenceCounts.promptLibrary} Prompt Library {referenceCounts.promptLibrary !== 1 ? 'entries' : 'entry'}</div>
               )}
               <div className="font-medium pt-1">
                 Total: {totalReferences} record{totalReferences !== 1 ? 's' : ''} will be updated

--- a/infra/database/migrations.json
+++ b/infra/database/migrations.json
@@ -57,6 +57,7 @@
     "059-mcp-oauth-registration.sql",
     "060-mcp-cognito-passthrough-auth.sql",
     "061-mcp-oauth-credentials.sql",
-    "062-mcp-tool-source.sql"
+    "062-mcp-tool-source.sql",
+    "063-prompt-library-settings.sql"
   ]
 }

--- a/infra/database/schema/063-prompt-library-settings.sql
+++ b/infra/database/schema/063-prompt-library-settings.sql
@@ -1,0 +1,11 @@
+-- Migration 063: Add settings JSONB column to prompt_library
+-- Stores model, tools, and connector configuration for prompts
+-- Also adds prompt_library_updated column to model_replacement_audit
+
+ALTER TABLE prompt_library ADD COLUMN IF NOT EXISTS settings JSONB;
+
+CREATE INDEX IF NOT EXISTS idx_prompt_library_settings_model
+ON prompt_library ((settings->>'modelId'))
+WHERE settings IS NOT NULL AND settings->>'modelId' IS NOT NULL;
+
+ALTER TABLE model_replacement_audit ADD COLUMN IF NOT EXISTS prompt_library_updated INTEGER DEFAULT 0;

--- a/lib/contexts/chat-config-context.ts
+++ b/lib/contexts/chat-config-context.ts
@@ -1,0 +1,17 @@
+"use client"
+
+import { createContext, useContext } from "react"
+
+/**
+ * Configuration context for passing current chat settings (model, tools, connectors)
+ * to descendant components like PromptSaveButton.
+ */
+export interface ChatConfig {
+  modelId?: string
+  tools: string[]
+  connectors: string[]
+}
+
+export const ChatConfigContext = createContext<ChatConfig>({ tools: [], connectors: [] })
+
+export const useChatConfig = () => useContext(ChatConfigContext)

--- a/lib/db/drizzle/ai-models.ts
+++ b/lib/db/drizzle/ai-models.ts
@@ -44,6 +44,7 @@ import {
   nexusConversations,
   modelComparisons,
   modelReplacementAudit,
+  promptLibrary,
 } from "@/lib/db/schema";
 import { createLogger, generateRequestId } from "@/lib/logger";
 import { ErrorFactories } from "@/lib/error-utils";
@@ -426,10 +427,23 @@ export async function getModelReferenceCounts(modelId: number) {
           ),
       "countModelComparisons"
     ),
+    executeQuery(
+      (db) =>
+        db
+          .select({ count: countAsInt })
+          .from(promptLibrary)
+          .where(
+            and(
+              sql`${promptLibrary.settings}->>'modelId' = (SELECT model_id FROM ai_models WHERE id = ${modelId})`,
+              sql`${promptLibrary.deletedAt} IS NULL`
+            )
+          ),
+      "countPromptLibrarySettings"
+    ),
   ]);
 
   // Check for failures and provide detailed error context
-  const labels = ["chainPrompts", "nexusMessages", "nexusConversations", "modelComparisons"];
+  const labels = ["chainPrompts", "nexusMessages", "nexusConversations", "modelComparisons", "promptLibrary"];
   const failedQueries = results
     .map((result, index) => (result.status === "rejected" ? labels[index] : null))
     .filter(Boolean);
@@ -440,7 +454,7 @@ export async function getModelReferenceCounts(modelId: number) {
   }
 
   // Extract successful results
-  const [chainPromptsResult, nexusMessagesResult, nexusConversationsResult, modelComparisonsResult] =
+  const [chainPromptsResult, nexusMessagesResult, nexusConversationsResult, modelComparisonsResult, promptLibraryResult] =
     results.map((r) => (r.status === "fulfilled" ? r.value : []));
 
   return {
@@ -448,6 +462,7 @@ export async function getModelReferenceCounts(modelId: number) {
     nexusMessagesCount: nexusMessagesResult[0]?.count ?? 0,
     nexusConversationsCount: nexusConversationsResult[0]?.count ?? 0,
     modelComparisonsCount: modelComparisonsResult[0]?.count ?? 0,
+    promptLibraryCount: promptLibraryResult[0]?.count ?? 0,
   };
 }
 
@@ -564,12 +579,14 @@ export async function replaceModelReferences(
         const nexusMessagesResult = await tx.select({ count: countAsInt }).from(nexusMessages).where(eq(nexusMessages.modelId, targetModelId));
         const nexusConversationsResult = await tx.select({ count: countAsInt }).from(nexusConversations).where(sql`${nexusConversations.modelUsed} = ${targetModel.modelId}`);
         const modelComparisonsResult = await tx.select({ count: countAsInt }).from(modelComparisons).where(or(eq(modelComparisons.model1Id, targetModelId), eq(modelComparisons.model2Id, targetModelId)));
+        const promptLibraryResult = await tx.select({ count: countAsInt }).from(promptLibrary).where(and(sql`${promptLibrary.settings}->>'modelId' = ${targetModel.modelId}`, sql`${promptLibrary.deletedAt} IS NULL`));
 
         const counts = {
           chainPromptsCount: chainPromptsResult[0]?.count ?? 0,
           nexusMessagesCount: nexusMessagesResult[0]?.count ?? 0,
           nexusConversationsCount: nexusConversationsResult[0]?.count ?? 0,
           modelComparisonsCount: modelComparisonsResult[0]?.count ?? 0,
+          promptLibraryCount: promptLibraryResult[0]?.count ?? 0,
         };
         // Update chain_prompts
         if (counts.chainPromptsCount > 0) {
@@ -611,6 +628,17 @@ export async function replaceModelReferences(
             .where(eq(modelComparisons.model2Id, targetModelId));
         }
 
+        // Update prompt_library settings
+        if (counts.promptLibraryCount > 0) {
+          await tx.execute(sql`
+            UPDATE prompt_library
+            SET settings = jsonb_set(settings, '{modelId}', to_jsonb(${replacementModel.modelId}::text)),
+                updated_at = NOW()
+            WHERE settings->>'modelId' = ${targetModel.modelId}
+            AND deleted_at IS NULL
+          `);
+        }
+
         // Record in audit table with generated ID
         // FIXME: COLLISION RISK - Epoch-based ID generation is dangerous
         //
@@ -639,6 +667,7 @@ export async function replaceModelReferences(
           nexusMessagesUpdated: counts.nexusMessagesCount,
           nexusConversationsUpdated: counts.nexusConversationsCount,
           modelComparisonsUpdated: counts.modelComparisonsCount,
+          promptLibraryUpdated: counts.promptLibraryCount,
         });
 
         // Delete the original model
@@ -656,12 +685,14 @@ export async function replaceModelReferences(
             nexusMessages: counts.nexusMessagesCount,
             nexusConversations: counts.nexusConversationsCount,
             modelComparisons: counts.modelComparisonsCount,
+            promptLibrary: counts.promptLibraryCount,
           },
           totalUpdated:
             counts.chainPromptsCount +
             counts.nexusMessagesCount +
             counts.nexusConversationsCount +
-            counts.modelComparisonsCount,
+            counts.modelComparisonsCount +
+            counts.promptLibraryCount,
         };
       },
       "replaceModelReferencesTransaction"

--- a/lib/db/drizzle/ai-models.ts
+++ b/lib/db/drizzle/ai-models.ts
@@ -628,7 +628,8 @@ export async function replaceModelReferences(
             .where(eq(modelComparisons.model2Id, targetModelId));
         }
 
-        // Update prompt_library settings
+        // Update prompt_library settings — raw SQL required because Drizzle ORM
+        // doesn't support jsonb_set() for partial JSONB field updates
         if (counts.promptLibraryCount > 0) {
           await tx.execute(sql`
             UPDATE prompt_library

--- a/lib/db/drizzle/index.ts
+++ b/lib/db/drizzle/index.ts
@@ -562,6 +562,7 @@ export {
   type PromptSearchOptions,
   // Prompt query operations
   getPromptById,
+  getPromptSettingsById,
   listPrompts,
   getPendingPrompts,
   // Prompt CRUD operations

--- a/lib/db/drizzle/prompt-library.ts
+++ b/lib/db/drizzle/prompt-library.ts
@@ -20,7 +20,7 @@
  * @see https://orm.drizzle.team/docs/select
  */
 
-import { eq, and, desc, or, ilike, sql, inArray } from "drizzle-orm";
+import { eq, and, desc, or, ilike, sql, inArray, isNull } from "drizzle-orm";
 import { executeQuery } from "@/lib/db/drizzle-client";
 import {
   promptLibrary,
@@ -193,6 +193,26 @@ export async function getPromptById(id: string): Promise<{
     ownerName: firstName && lastName ? `${firstName} ${lastName}` : null,
     tags: tagResult.map((t) => t.name),
   };
+}
+
+/**
+ * Get only the settings JSONB field for a prompt by ID.
+ * Targeted query that avoids fetching full content — used for
+ * URL-driven configuration preloading without view count tracking.
+ */
+export async function getPromptSettingsById(
+  promptId: string
+): Promise<PromptLibrarySettings | null> {
+  const [row] = await executeQuery(
+    (db) =>
+      db
+        .select({ settings: promptLibrary.settings })
+        .from(promptLibrary)
+        .where(and(eq(promptLibrary.id, promptId), isNull(promptLibrary.deletedAt)))
+        .limit(1),
+    "getPromptSettingsById"
+  );
+  return row?.settings ?? null;
 }
 
 /**

--- a/lib/db/drizzle/prompt-library.ts
+++ b/lib/db/drizzle/prompt-library.ts
@@ -31,6 +31,7 @@ import {
   nexusConversations,
 } from "@/lib/db/schema";
 import { createLogger, sanitizeForLogging } from "@/lib/logger";
+import type { PromptLibrarySettings } from "@/lib/db/types/jsonb";
 
 // ============================================
 // Types
@@ -62,6 +63,7 @@ export interface CreatePromptData {
   visibility?: PromptVisibility;
   sourceMessageId?: string | null;
   sourceConversationId?: string | null;
+  settings?: PromptLibrarySettings | null;
 }
 
 /**
@@ -72,6 +74,7 @@ export interface UpdatePromptData {
   content?: string;
   description?: string | null;
   visibility?: PromptVisibility;
+  settings?: PromptLibrarySettings | null;
 }
 
 /**
@@ -132,6 +135,7 @@ export async function getPromptById(id: string): Promise<{
   createdAt: Date;
   updatedAt: Date;
   deletedAt: Date | null;
+  settings: PromptLibrarySettings | null;
   ownerName: string | null;
   tags: string[];
 } | null> {
@@ -156,6 +160,7 @@ export async function getPromptById(id: string): Promise<{
           createdAt: promptLibrary.createdAt,
           updatedAt: promptLibrary.updatedAt,
           deletedAt: promptLibrary.deletedAt,
+          settings: promptLibrary.settings,
           firstName: users.firstName,
           lastName: users.lastName,
         })
@@ -184,6 +189,7 @@ export async function getPromptById(id: string): Promise<{
   const { firstName, lastName, ...prompt } = result[0];
   return {
     ...prompt,
+    settings: prompt.settings ?? null,
     ownerName: firstName && lastName ? `${firstName} ${lastName}` : null,
     tags: tagResult.map((t) => t.name),
   };
@@ -435,6 +441,7 @@ export async function createPrompt(data: CreatePromptData): Promise<{
           moderationStatus,
           sourceMessageId: data.sourceMessageId ?? null,
           sourceConversationId: data.sourceConversationId ?? null,
+          settings: data.settings ?? null,
         })
         .returning(),
     "createPrompt"
@@ -479,6 +486,9 @@ export async function updatePrompt(
   }
   if (data.description !== undefined) {
     updateData.description = data.description;
+  }
+  if (data.settings !== undefined) {
+    updateData.settings = data.settings;
   }
   if (data.visibility !== undefined) {
     updateData.visibility = data.visibility;

--- a/lib/db/schema/tables/model-replacement-audit.ts
+++ b/lib/db/schema/tables/model-replacement-audit.ts
@@ -31,4 +31,5 @@ export const modelReplacementAudit = pgTable("model_replacement_audit", {
   nexusMessagesUpdated: integer("nexus_messages_updated").default(0),
   nexusConversationsUpdated: integer("nexus_conversations_updated").default(0),
   toolExecutionsUpdated: integer("tool_executions_updated").default(0),
+  promptLibraryUpdated: integer("prompt_library_updated").default(0),
 });

--- a/lib/db/schema/tables/prompt-library.ts
+++ b/lib/db/schema/tables/prompt-library.ts
@@ -5,12 +5,14 @@
 
 import {
   integer,
+  jsonb,
   pgTable,
   text,
   timestamp,
   uuid,
   varchar,
 } from "drizzle-orm/pg-core";
+import type { PromptLibrarySettings } from "@/lib/db/types/jsonb";
 import { users } from "./users";
 import { nexusConversations } from "./nexus-conversations";
 import { nexusMessages } from "./nexus-messages";
@@ -39,4 +41,5 @@ export const promptLibrary = pgTable("prompt_library", {
   createdAt: timestamp("created_at").defaultNow().notNull(),
   updatedAt: timestamp("updated_at").defaultNow().notNull(),
   deletedAt: timestamp("deleted_at"),
+  settings: jsonb("settings").$type<PromptLibrarySettings>(),
 });

--- a/lib/db/types/jsonb/index.ts
+++ b/lib/db/types/jsonb/index.ts
@@ -253,6 +253,20 @@ export interface UserProfile {
 }
 
 // ============================================
+// Prompt Library JSONB Types
+// ============================================
+
+/**
+ * Settings for prompt library entries
+ * Stores model, tools, and connector configuration
+ */
+export interface PromptLibrarySettings {
+  modelId?: string;
+  tools?: string[];
+  connectors?: string[];
+}
+
+// ============================================
 // Context Graph JSONB Types
 // ============================================
 

--- a/lib/hooks/use-models.ts
+++ b/lib/hooks/use-models.ts
@@ -8,6 +8,18 @@ import { createLogger } from "@/lib/client-logger"
 
 const log = createLogger({ module: 'use-models' })
 
+/** Check if a model meets all required capabilities */
+function meetsRequiredCapabilities(model: SelectAiModel, required: string[]): boolean {
+  try {
+    const caps = typeof model.capabilities === 'string'
+      ? JSON.parse(model.capabilities)
+      : model.capabilities
+    return Array.isArray(caps) && required.every(cap => caps.includes(cap))
+  } catch {
+    return false
+  }
+}
+
 // Validation schema for localStorage model data
 // This is a partial schema - we only validate the fields we actually use
 const StoredModelSchema = z.object({
@@ -164,19 +176,9 @@ export function useModelsWithPersistence(
       const preferredModel = models.find(m => m.modelId === preferredModelId)
       if (preferredModel) {
         // Verify the preferred model meets required capabilities before selecting
-        let meetsCapabilities = true
-        if (requiredCapabilities && requiredCapabilities.length > 0) {
-          try {
-            const caps = typeof preferredModel.capabilities === 'string'
-              ? JSON.parse(preferredModel.capabilities)
-              : preferredModel.capabilities
-            meetsCapabilities = Array.isArray(caps) && requiredCapabilities.every(cap => caps.includes(cap))
-          } catch {
-            meetsCapabilities = false
-          }
-        }
+        const capsSatisfied = !requiredCapabilities?.length || meetsRequiredCapabilities(preferredModel, requiredCapabilities)
 
-        if (meetsCapabilities) {
+        if (capsSatisfied) {
           if (currentModelId !== preferredModelId) {
             setSelectedModel(preferredModel)
             lastValidatedModelId.current = preferredModel.modelId
@@ -217,29 +219,7 @@ export function useModelsWithPersistence(
       let candidateModel: SelectAiModel | null = null
 
       if (requiredCapabilities && requiredCapabilities.length > 0) {
-        candidateModel = models.find(model => {
-          try {
-            const capabilities = typeof model.capabilities === 'string'
-              ? JSON.parse(model.capabilities)
-              : model.capabilities
-
-            if (!Array.isArray(capabilities)) {
-              log.warn('Model has invalid capabilities format', {
-                modelId: model.modelId,
-                capabilitiesType: typeof capabilities
-              })
-              return false
-            }
-
-            return requiredCapabilities.every(cap => capabilities.includes(cap))
-          } catch (error) {
-            log.warn('Failed to parse model capabilities', {
-              modelId: model.modelId,
-              error: error instanceof Error ? error.message : String(error)
-            })
-            return false
-          }
-        }) ?? null
+        candidateModel = models.find(model => meetsRequiredCapabilities(model, requiredCapabilities)) ?? null
 
         // If no model matches required capabilities, don't fall back to models[0]
         // Instead, leave it null to prompt user selection

--- a/lib/hooks/use-models.ts
+++ b/lib/hooks/use-models.ts
@@ -15,7 +15,11 @@ function meetsRequiredCapabilities(model: SelectAiModel, required: string[]): bo
       ? JSON.parse(model.capabilities)
       : model.capabilities
     return Array.isArray(caps) && required.every(cap => caps.includes(cap))
-  } catch {
+  } catch (error) {
+    log.warn('Failed to parse model capabilities', {
+      modelId: model.modelId,
+      error: error instanceof Error ? error.message : String(error)
+    })
     return false
   }
 }

--- a/lib/hooks/use-models.ts
+++ b/lib/hooks/use-models.ts
@@ -163,24 +163,45 @@ export function useModelsWithPersistence(
     if (preferredModelId) {
       const preferredModel = models.find(m => m.modelId === preferredModelId)
       if (preferredModel) {
-        if (currentModelId !== preferredModelId) {
-          setSelectedModel(preferredModel)
-          lastValidatedModelId.current = preferredModel.modelId
-          log.info('Selected preferred model', {
-            modelId: preferredModel.modelId,
-            name: preferredModel.name
-          })
+        // Verify the preferred model meets required capabilities before selecting
+        let meetsCapabilities = true
+        if (requiredCapabilities && requiredCapabilities.length > 0) {
+          try {
+            const caps = typeof preferredModel.capabilities === 'string'
+              ? JSON.parse(preferredModel.capabilities)
+              : preferredModel.capabilities
+            meetsCapabilities = Array.isArray(caps) && requiredCapabilities.every(cap => caps.includes(cap))
+          } catch {
+            meetsCapabilities = false
+          }
+        }
+
+        if (meetsCapabilities) {
+          if (currentModelId !== preferredModelId) {
+            setSelectedModel(preferredModel)
+            lastValidatedModelId.current = preferredModel.modelId
+            log.info('Selected preferred model', {
+              modelId: preferredModel.modelId,
+              name: preferredModel.name
+            })
+            return
+          }
+          // Already selected — just record validation
+          lastValidatedModelId.current = currentModelId
           return
         }
-        // Already selected — just record validation
-        lastValidatedModelId.current = currentModelId
-        return
+
+        log.warn('Preferred model does not meet required capabilities, falling back', {
+          preferredModelId,
+          requiredCapabilities
+        })
+      } else {
+        // Preferred model not available — warn and fall through to default selection
+        log.warn('Preferred model not available, falling back', {
+          preferredModelId,
+          availableModelCount: models.length
+        })
       }
-      // Preferred model not available — warn and fall through to default selection
-      log.warn('Preferred model not available, falling back', {
-        preferredModelId,
-        availableModels: models.map(m => m.modelId)
-      })
     }
 
     if (!currentModelId || isStale) {
@@ -225,7 +246,7 @@ export function useModelsWithPersistence(
         if (!candidateModel) {
           log.warn('No models match required capabilities', {
             requiredCapabilities,
-            availableModels: models.map(m => m.modelId)
+            availableModelCount: models.length
           })
         }
       } else {

--- a/lib/hooks/use-models.ts
+++ b/lib/hooks/use-models.ts
@@ -135,7 +135,11 @@ export function useModelPersistence(storageKey: string) {
  * Combined hook for models with persistence
  * Convenience wrapper that combines fetching and persistence
  */
-export function useModelsWithPersistence(storageKey: string, requiredCapabilities?: string[]) {
+export function useModelsWithPersistence(
+  storageKey: string,
+  requiredCapabilities?: string[],
+  preferredModelId?: string | null
+) {
   const { models, isLoading, error, refetch } = useModels()
   const [selectedModel, setSelectedModel] = useModelPersistence(storageKey)
   // Tracks the last model ID this effect validated to prevent redundant runs.
@@ -144,6 +148,7 @@ export function useModelsWithPersistence(storageKey: string, requiredCapabilitie
   const lastValidatedModelId = useRef<string | null | undefined>(undefined)
 
   // Auto-select a valid model if none selected or if persisted model is no longer available
+  // Priority: preferredModelId > localStorage > first available
   useEffect(() => {
     if (models.length === 0 || isLoading) return
 
@@ -153,6 +158,30 @@ export function useModelsWithPersistence(storageKey: string, requiredCapabilitie
     if (currentModelId === lastValidatedModelId.current) return
 
     const isStale = currentModelId && !models.some(m => m.modelId === currentModelId)
+
+    // If a preferred model ID is specified (e.g. from URL), try to use it first
+    if (preferredModelId) {
+      const preferredModel = models.find(m => m.modelId === preferredModelId)
+      if (preferredModel) {
+        if (currentModelId !== preferredModelId) {
+          setSelectedModel(preferredModel)
+          lastValidatedModelId.current = preferredModel.modelId
+          log.info('Selected preferred model', {
+            modelId: preferredModel.modelId,
+            name: preferredModel.name
+          })
+          return
+        }
+        // Already selected — just record validation
+        lastValidatedModelId.current = currentModelId
+        return
+      }
+      // Preferred model not available — warn and fall through to default selection
+      log.warn('Preferred model not available, falling back', {
+        preferredModelId,
+        availableModels: models.map(m => m.modelId)
+      })
+    }
 
     if (!currentModelId || isStale) {
       if (isStale && selectedModel) {
@@ -216,7 +245,7 @@ export function useModelsWithPersistence(storageKey: string, requiredCapabilitie
       // Current model is valid — record it so we don't re-validate
       lastValidatedModelId.current = currentModelId
     }
-  }, [models, isLoading, requiredCapabilities, setSelectedModel, selectedModel])
+  }, [models, isLoading, requiredCapabilities, setSelectedModel, selectedModel, preferredModelId])
 
   return {
     models,

--- a/lib/hooks/use-models.ts
+++ b/lib/hooks/use-models.ts
@@ -144,7 +144,14 @@ export function useModelPersistence(storageKey: string) {
     }
   }, [storageKey])
   
-  return [selectedModel, setSelectedModel] as const
+  // setTransientModel updates in-memory state without persisting to localStorage.
+  // Used for URL-driven or prompt-settings-driven model selections that should not
+  // overwrite the user's stored preference.
+  const setTransientModel = useCallback((model: SelectAiModel | null) => {
+    setSelectedModelState(model)
+  }, [])
+
+  return [selectedModel, setSelectedModel, setTransientModel] as const
 }
 
 /**
@@ -157,7 +164,7 @@ export function useModelsWithPersistence(
   preferredModelId?: string | null
 ) {
   const { models, isLoading, error, refetch } = useModels()
-  const [selectedModel, setSelectedModel] = useModelPersistence(storageKey)
+  const [selectedModel, setSelectedModel, setTransientModel] = useModelPersistence(storageKey)
   // Tracks the last model ID this effect validated to prevent redundant runs.
   // This allows selectedModel in the dependency array (no stale closure)
   // while preventing infinite loops from setSelectedModel triggering re-runs.
@@ -184,7 +191,9 @@ export function useModelsWithPersistence(
 
         if (capsSatisfied) {
           if (currentModelId !== preferredModelId) {
-            setSelectedModel(preferredModel)
+            // Use transient setter — URL/prompt-driven selection should not overwrite
+            // the user's persisted localStorage preference
+            setTransientModel(preferredModel)
             lastValidatedModelId.current = preferredModel.modelId
             log.info('Selected preferred model', {
               modelId: preferredModel.modelId,
@@ -250,7 +259,7 @@ export function useModelsWithPersistence(
       // Current model is valid — record it so we don't re-validate
       lastValidatedModelId.current = currentModelId
     }
-  }, [models, isLoading, requiredCapabilities, setSelectedModel, selectedModel, preferredModelId])
+  }, [models, isLoading, requiredCapabilities, setSelectedModel, setTransientModel, selectedModel, preferredModelId])
 
   return {
     models,

--- a/lib/prompt-library/types.ts
+++ b/lib/prompt-library/types.ts
@@ -3,6 +3,8 @@
  * Based on schema: 039-prompt-library-schema.sql
  */
 
+import type { PromptLibrarySettings } from "@/lib/db/types/jsonb"
+
 export type PromptVisibility = 'private' | 'public'
 export type ModerationStatus = 'pending' | 'approved' | 'rejected'
 export type EventType = 'view' | 'use' | 'share'
@@ -25,6 +27,7 @@ export interface Prompt {
   createdAt: string
   updatedAt: string
   deletedAt: string | null
+  settings?: PromptLibrarySettings | null
   // Joined fields
   tags?: string[]
   ownerName?: string

--- a/lib/prompt-library/validation.ts
+++ b/lib/prompt-library/validation.ts
@@ -13,6 +13,12 @@ export const eventTypeSchema = z.enum(['view', 'use', 'share'])
 
 export const sortOptionsSchema = z.enum(['created', 'usage', 'views']).default('created')
 
+export const promptSettingsSchema = z.object({
+  modelId: z.string().max(100).optional(),
+  tools: z.array(z.string().max(100)).max(50).optional(),
+  connectors: z.array(z.string().uuid()).max(50).optional(),
+}).optional().nullable()
+
 // Create Prompt Schema
 export const createPromptSchema = z.object({
   title: z.string()
@@ -31,6 +37,7 @@ export const createPromptSchema = z.object({
     .optional(),
   sourceMessageId: z.string().uuid().optional().nullable(),
   sourceConversationId: z.string().uuid().optional().nullable(),
+  settings: promptSettingsSchema,
 })
 
 export type CreatePromptInput = z.infer<typeof createPromptSchema>
@@ -53,6 +60,7 @@ export const updatePromptSchema = z.object({
   tags: z.array(z.string().min(1).max(50))
     .max(10, 'Maximum 10 tags allowed')
     .optional(),
+  settings: promptSettingsSchema,
 })
 
 export type UpdatePromptInput = z.infer<typeof updatePromptSchema>

--- a/scripts/db/seed-local.sql
+++ b/scripts/db/seed-local.sql
@@ -216,6 +216,36 @@ INSERT INTO ai_models (
     0.120000,
     NULL
 ),
+(
+    'Gemini 3.1 Pro',
+    'gemini-3.1-pro-preview',
+    'google',
+    'Google''s most advanced reasoning model with a massive context window, ideal for complex research projects, detailed essay feedback, and multi-step problem solving',
+    '["chat", "function_calling", "json_mode", "image_analysis", "streaming", "thinking", "code_execution", "web_search"]',
+    1048576,
+    true,
+    true,
+    true,
+    NULL,
+    0.002000,
+    0.012000,
+    0.000200
+),
+(
+    'Nano Banana 2',
+    'gemini-3.1-flash-image-preview',
+    'google',
+    'Fast and affordable image generation model that creates high-quality images up to 4K resolution, perfect for art projects, presentations, and visual learning activities',
+    '["chat", "image_generation", "image_analysis", "streaming"]',
+    1048576,
+    true,
+    true,
+    false,
+    NULL,
+    0.000250,
+    0.001500,
+    NULL
+),
 
 -- OpenAI GPT-5.2 Models
 (
@@ -410,6 +440,7 @@ BEGIN
     RAISE NOTICE '';
     RAISE NOTICE 'AI Models seeded:';
     RAISE NOTICE '  - Gemini 3 Pro, Gemini 3 Flash, Gemini 3 Pro Image';
+    RAISE NOTICE '  - Gemini 3.1 Pro, Nano Banana 2';
     RAISE NOTICE '  - GPT-5.2, GPT-5.2 Pro, GPT Image 1.5';
     RAISE NOTICE '  - Claude Opus 4.5, Claude Sonnet 4.5 (Bedrock)';
     RAISE NOTICE '==========================================';


### PR DESCRIPTION
## Summary

- **URL-driven Nexus configuration**: Parse `?model=`, `?tool=`, `?connector=` URL params to pre-configure Nexus chat sessions
- **Prompt library settings**: Save model/tools/connector configuration with prompt library entries; auto-apply when loading prompts via `?promptId=`
- **Model fallback banner**: Show dismissible info banner when loading conversations whose model is no longer available
- **Model deletion safety**: Extend reference counting and replacement to cover prompt library settings JSONB

Priority chain: URL params > prompt settings > localStorage > system default.

### Files changed (22 files)

**Database**: New migration `063-prompt-library-settings.sql` adds `settings JSONB` to `prompt_library` and `prompt_library_updated` to `model_replacement_audit`

**Data layer**: Updated Drizzle schema, types, validation, CRUD operations, and server actions to support `settings` field

**UI**: Updated prompt save dialog to auto-capture configuration, added `ChatConfigContext` in thread, created `ModelFallbackBanner` component

**Model management**: Added prompt library to reference counting, replacement logic, API response, and replacement dialog UI

## Test plan

- [ ] Run `bun run db:reset && bun run db:seed` to apply migration 063
- [ ] Navigate to `/nexus?model=gpt-4o` — verify model pre-selected
- [ ] Navigate to `/nexus?tool=web-search&tool=code-interpreter` — verify tools enabled
- [ ] Navigate to `/nexus?model=nonexistent-model` — verify fallback to default model
- [ ] Save a prompt with model+tools configured — verify settings captured in "Saved Configuration" section
- [ ] Load prompt via `?promptId={id}` — verify model/tools pre-selected
- [ ] Load with URL override: `?promptId={id}&model=different-model` — verify URL model wins
- [ ] Load conversation with deleted model — verify fallback banner appears
- [ ] Delete a model referenced by prompt library settings — verify count appears in replacement dialog
- [ ] `bun run typecheck` passes (verified)
- [ ] `bun run lint` passes (verified, 0 errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)