### PR TITLE
feat: prompt library settings UI and model selection fix

### DIFF
--- a/app/(protected)/admin/connectors/_components/connectors-page-client.tsx
+++ b/app/(protected)/admin/connectors/_components/connectors-page-client.tsx
@@ -167,6 +167,7 @@ export function ConnectorsPageClient({ initialServers, fetchError: initialFetchE
               <TableHeader>
                 <TableRow>
                   <TableHead>Name</TableHead>
+                  <TableHead>ID</TableHead>
                   <TableHead>URL</TableHead>
                   <TableHead>Transport</TableHead>
                   <TableHead>Auth</TableHead>
@@ -179,6 +180,11 @@ export function ConnectorsPageClient({ initialServers, fetchError: initialFetchE
                 {servers.map((server) => (
                   <TableRow key={server.id}>
                     <TableCell className="font-medium">{server.name}</TableCell>
+                    <TableCell>
+                      <code className="text-xs bg-muted px-1 py-0.5 rounded font-mono select-all">
+                        {server.id}
+                      </code>
+                    </TableCell>
                     <TableCell>
                       <code className="text-xs bg-muted px-1 py-0.5 rounded max-w-[200px] truncate block">
                         {server.url}

--- a/app/(protected)/prompt-library/[id]/page.tsx
+++ b/app/(protected)/prompt-library/[id]/page.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState, useEffect, useCallback, useRef, startTransition } from "react"
+import { useState, useEffect, useRef, startTransition } from "react"
 import { useParams, useRouter } from "next/navigation"
 import { useAction } from "@/lib/hooks/use-action"
 import { getPrompt, updatePrompt, deletePrompt } from "@/actions/prompt-library.actions"
@@ -52,7 +52,7 @@ export default function PromptEditPage() {
       setLoading(false)
     }
     if (promptId) loadPrompt()
-  }, [promptId]) // eslint-disable-line react-hooks/exhaustive-deps
+  }, [promptId]) // eslint-disable-line react-hooks/exhaustive-deps -- executeGet is stable (useAction returns stable ref)
 
   const modelInitialized = useRef(false)
   useEffect(() => {
@@ -64,28 +64,31 @@ export default function PromptEditPage() {
     }
   }, [models, promptData])
 
-  const handleModelChange = useCallback((model: SelectAiModel) => { setSelectedModel(model) }, [])
-
   const handleSave = async () => {
     if (!formData.title || !formData.content) { toast.error("Title and content are required"); return }
-    const settings: PromptLibrarySettings = {}
-    if (selectedModel) settings.modelId = selectedModel.modelId
-    if (enabledTools.length > 0) settings.tools = enabledTools
-    if (enabledConnectors.length > 0) settings.connectors = enabledConnectors
+    const hasSettings = selectedModel || enabledTools.length > 0 || enabledConnectors.length > 0
+    const settings: PromptLibrarySettings | null = hasSettings ? {
+      ...(selectedModel ? { modelId: selectedModel.modelId } : {}),
+      ...(enabledTools.length > 0 ? { tools: enabledTools } : {}),
+      ...(enabledConnectors.length > 0 ? { connectors: enabledConnectors } : {}),
+    } : null
 
     setIsUpdating(true)
-    const result = await updatePrompt(promptId, {
-      title: formData.title, content: formData.content,
-      description: formData.description || undefined, visibility: formData.visibility,
-      tags: formData.tags, settings: Object.keys(settings).length > 0 ? settings : undefined
-    })
-    if (result?.isSuccess) {
-      toast.success("Prompt updated successfully")
-      if (result.data) setPromptData(result.data)
-    } else {
-      toast.error(result?.message || "Failed to update prompt")
+    try {
+      const result = await updatePrompt(promptId, {
+        title: formData.title, content: formData.content,
+        description: formData.description || undefined, visibility: formData.visibility,
+        tags: formData.tags, settings
+      })
+      if (result?.isSuccess) {
+        toast.success("Prompt updated successfully")
+        if (result.data) setPromptData(result.data)
+      } else {
+        toast.error(result?.message || "Failed to update prompt")
+      }
+    } finally {
+      setIsUpdating(false)
     }
-    setIsUpdating(false)
   }
 
   const handleDelete = async () => {
@@ -140,7 +143,7 @@ export default function PromptEditPage() {
       <PromptEditForm
         formData={formData} onFormDataChange={setFormData} promptData={promptData}
         models={models} modelsLoading={modelsLoading}
-        selectedModel={selectedModel} onModelChange={handleModelChange}
+        selectedModel={selectedModel} onModelChange={setSelectedModel}
         enabledTools={enabledTools} onToolsChange={setEnabledTools}
         enabledConnectors={enabledConnectors} onConnectorsChange={setEnabledConnectors}
       />

--- a/app/(protected)/prompt-library/[id]/page.tsx
+++ b/app/(protected)/prompt-library/[id]/page.tsx
@@ -1,26 +1,18 @@
 "use client"
 
-import { useState, useEffect } from "react"
+import { useState, useEffect, useCallback, useRef, startTransition } from "react"
 import { useParams, useRouter } from "next/navigation"
 import { useAction } from "@/lib/hooks/use-action"
 import { getPrompt, updatePrompt, deletePrompt } from "@/actions/prompt-library.actions"
 import { Button } from "@/components/ui/button"
-import { Input } from "@/components/ui/input"
-import { Textarea } from "@/components/ui/textarea"
-import { Label } from "@/components/ui/label"
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue
-} from "@/components/ui/select"
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { toast } from "sonner"
 import { ArrowLeft, Save, Trash2 } from "lucide-react"
-import { TagInput } from "../_components/tag-input"
 import { PageBranding } from "@/components/ui/page-branding"
-import type { Prompt, PromptVisibility } from "@/lib/prompt-library/types"
+import { useModels } from "@/lib/hooks/use-models"
+import { PromptEditForm } from "./prompt-edit-form"
+import type { SelectAiModel } from "@/types"
+import type { Prompt } from "@/lib/prompt-library/types"
+import type { PromptLibrarySettings } from "@/lib/db/types/jsonb"
 
 export default function PromptEditPage() {
   const params = useParams()
@@ -28,63 +20,68 @@ export default function PromptEditPage() {
   const promptId = params.id as string
 
   const [formData, setFormData] = useState<Partial<Prompt>>({
-    title: '',
-    content: '',
-    description: '',
-    visibility: 'private',
-    tags: []
+    title: '', content: '', description: '', visibility: 'private', tags: []
   })
   const [loading, setLoading] = useState(true)
   const [promptData, setPromptData] = useState<Prompt | null>(null)
-
-  const { execute: executeGet } = useAction(getPrompt, {
-    showSuccessToast: false,
-    showErrorToast: false
-  })
-  const { execute: executeDelete, isPending: isDeleting } = useAction(deletePrompt)
+  const [selectedModel, setSelectedModel] = useState<SelectAiModel | null>(null)
+  const [enabledTools, setEnabledTools] = useState<string[]>([])
+  const [enabledConnectors, setEnabledConnectors] = useState<string[]>([])
   const [isUpdating, setIsUpdating] = useState(false)
 
-  // Load prompt
+  const { models, isLoading: modelsLoading } = useModels()
+  const { execute: executeGet } = useAction(getPrompt, { showSuccessToast: false, showErrorToast: false })
+  const { execute: executeDelete, isPending: isDeleting } = useAction(deletePrompt)
+
   useEffect(() => {
     async function loadPrompt() {
       setLoading(true)
       const result = await executeGet(promptId)
-
       if (result?.isSuccess && result.data) {
         setPromptData(result.data)
         setFormData({
-          title: result.data.title,
-          content: result.data.content,
-          description: result.data.description || '',
-          visibility: result.data.visibility,
+          title: result.data.title, content: result.data.content,
+          description: result.data.description || '', visibility: result.data.visibility,
           tags: result.data.tags || []
         })
+        if (result.data.settings) {
+          setEnabledTools(result.data.settings.tools || [])
+          setEnabledConnectors(result.data.settings.connectors || [])
+        }
       }
       setLoading(false)
     }
-
-    if (promptId) {
-      loadPrompt()
-    }
+    if (promptId) loadPrompt()
   }, [promptId]) // eslint-disable-line react-hooks/exhaustive-deps
 
-  const handleSave = async () => {
-    if (!formData.title || !formData.content) {
-      toast.error("Title and content are required")
-      return
+  const modelInitialized = useRef(false)
+  useEffect(() => {
+    if (models.length === 0 || !promptData?.settings?.modelId || modelInitialized.current) return
+    const match = models.find(m => m.modelId === promptData.settings?.modelId)
+    if (match) {
+      modelInitialized.current = true
+      startTransition(() => { setSelectedModel(match) })
     }
+  }, [models, promptData])
+
+  const handleModelChange = useCallback((model: SelectAiModel) => { setSelectedModel(model) }, [])
+
+  const handleSave = async () => {
+    if (!formData.title || !formData.content) { toast.error("Title and content are required"); return }
+    const settings: PromptLibrarySettings = {}
+    if (selectedModel) settings.modelId = selectedModel.modelId
+    if (enabledTools.length > 0) settings.tools = enabledTools
+    if (enabledConnectors.length > 0) settings.connectors = enabledConnectors
 
     setIsUpdating(true)
     const result = await updatePrompt(promptId, {
-      title: formData.title,
-      content: formData.content,
-      description: formData.description || undefined,
-      visibility: formData.visibility,
-      tags: formData.tags
+      title: formData.title, content: formData.content,
+      description: formData.description || undefined, visibility: formData.visibility,
+      tags: formData.tags, settings: Object.keys(settings).length > 0 ? settings : undefined
     })
-
     if (result?.isSuccess) {
       toast.success("Prompt updated successfully")
+      if (result.data) setPromptData(result.data)
     } else {
       toast.error(result?.message || "Failed to update prompt")
     }
@@ -94,13 +91,8 @@ export default function PromptEditPage() {
   const handleDelete = async () => {
     if (confirm("Are you sure you want to delete this prompt?")) {
       const result = await executeDelete(promptId)
-
-      if (result?.isSuccess) {
-        toast.success("Prompt deleted successfully")
-        router.push('/prompt-library')
-      } else {
-        toast.error(result?.message || "Failed to delete prompt")
-      }
+      if (result?.isSuccess) { toast.success("Prompt deleted successfully"); router.push('/prompt-library') }
+      else { toast.error(result?.message || "Failed to delete prompt") }
     }
   }
 
@@ -122,157 +114,36 @@ export default function PromptEditPage() {
 
   return (
     <div className="mx-auto max-w-4xl p-6">
-      {/* Header */}
       <div className="mb-6">
         <PageBranding />
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-4">
-            <Button
-              variant="ghost"
-              size="icon"
-              onClick={() => router.push('/prompt-library')}
-            >
+            <Button variant="ghost" size="icon" onClick={() => router.push('/prompt-library')}>
               <ArrowLeft className="h-4 w-4" />
             </Button>
             <div>
               <h1 className="text-2xl font-semibold text-gray-900">Edit Prompt</h1>
-              <p className="text-sm text-muted-foreground">
-                Modify your prompt details and settings
-              </p>
+              <p className="text-sm text-muted-foreground">Modify your prompt details and settings</p>
             </div>
           </div>
-
           <div className="flex gap-2">
-          <Button
-            variant="outline"
-            onClick={handleDelete}
-            disabled={isDeleting}
-          >
-            <Trash2 className="mr-2 h-4 w-4" />
-            Delete
-          </Button>
-          <Button
-            onClick={handleSave}
-            disabled={isUpdating}
-          >
-            <Save className="mr-2 h-4 w-4" />
-            {isUpdating ? 'Saving...' : 'Save Changes'}
-          </Button>
+            <Button variant="outline" onClick={handleDelete} disabled={isDeleting}>
+              <Trash2 className="mr-2 h-4 w-4" /> Delete
+            </Button>
+            <Button onClick={handleSave} disabled={isUpdating}>
+              <Save className="mr-2 h-4 w-4" /> {isUpdating ? 'Saving...' : 'Save Changes'}
+            </Button>
           </div>
         </div>
       </div>
 
-      {/* Form */}
-      <Card>
-        <CardHeader>
-          <CardTitle>Prompt Details</CardTitle>
-        </CardHeader>
-        <CardContent className="space-y-6">
-          {/* Title */}
-          <div className="space-y-2">
-            <Label htmlFor="title">Title *</Label>
-            <Input
-              id="title"
-              value={formData.title}
-              onChange={(e) =>
-                setFormData({ ...formData, title: e.target.value })
-              }
-              placeholder="Enter prompt title"
-            />
-          </div>
-
-          {/* Description */}
-          <div className="space-y-2">
-            <Label htmlFor="description">Description</Label>
-            <Textarea
-              id="description"
-              value={formData.description || ''}
-              onChange={(e) =>
-                setFormData({ ...formData, description: e.target.value })
-              }
-              placeholder="Enter a brief description"
-              rows={3}
-            />
-          </div>
-
-          {/* Content */}
-          <div className="space-y-2">
-            <Label htmlFor="content">Prompt Content *</Label>
-            <Textarea
-              id="content"
-              value={formData.content}
-              onChange={(e) =>
-                setFormData({ ...formData, content: e.target.value })
-              }
-              placeholder="Enter your prompt content"
-              rows={10}
-              className="font-mono"
-            />
-            <p className="text-xs text-muted-foreground">
-              Use variables like {`{{variable_name}}`} for dynamic content
-            </p>
-          </div>
-
-          {/* Tags */}
-          <div className="space-y-2">
-            <Label htmlFor="tags">Tags</Label>
-            <TagInput
-              value={formData.tags || []}
-              onChange={(tags) => setFormData({ ...formData, tags })}
-            />
-          </div>
-
-          {/* Visibility */}
-          <div className="space-y-2">
-            <Label htmlFor="visibility">Visibility</Label>
-            <Select
-              value={formData.visibility}
-              onValueChange={(value: PromptVisibility) =>
-                setFormData({ ...formData, visibility: value })
-              }
-            >
-              <SelectTrigger className="w-48">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="private">Private</SelectItem>
-                <SelectItem value="public">Public</SelectItem>
-              </SelectContent>
-            </Select>
-            <p className="text-xs text-muted-foreground">
-              Public prompts will be visible to all users after moderation
-            </p>
-          </div>
-
-          {/* Stats */}
-          <div className="grid grid-cols-3 gap-4 rounded-lg border p-4">
-            <div>
-              <div className="text-sm font-medium text-muted-foreground">
-                Views
-              </div>
-              <div className="text-2xl font-semibold">
-                {promptData.viewCount}
-              </div>
-            </div>
-            <div>
-              <div className="text-sm font-medium text-muted-foreground">
-                Uses
-              </div>
-              <div className="text-2xl font-semibold">
-                {promptData.useCount}
-              </div>
-            </div>
-            <div>
-              <div className="text-sm font-medium text-muted-foreground">
-                Status
-              </div>
-              <div className="text-sm font-semibold capitalize">
-                {promptData.moderationStatus}
-              </div>
-            </div>
-          </div>
-        </CardContent>
-      </Card>
+      <PromptEditForm
+        formData={formData} onFormDataChange={setFormData} promptData={promptData}
+        models={models} modelsLoading={modelsLoading}
+        selectedModel={selectedModel} onModelChange={handleModelChange}
+        enabledTools={enabledTools} onToolsChange={setEnabledTools}
+        enabledConnectors={enabledConnectors} onConnectorsChange={setEnabledConnectors}
+      />
     </div>
   )
 }

--- a/app/(protected)/prompt-library/[id]/page.tsx
+++ b/app/(protected)/prompt-library/[id]/page.tsx
@@ -34,6 +34,7 @@ export default function PromptEditPage() {
     title: '', content: '', description: '', visibility: 'private', tags: []
   })
   const [loading, setLoading] = useState(true)
+  const [loadError, setLoadError] = useState<string | null>(null)
   const [promptData, setPromptData] = useState<Prompt | null>(null)
   const [selectedModel, setSelectedModel] = useState<SelectAiModel | null>(null)
   const [enabledTools, setEnabledTools] = useState<string[]>([])
@@ -47,6 +48,7 @@ export default function PromptEditPage() {
   useEffect(() => {
     async function loadPrompt() {
       setLoading(true)
+      setLoadError(null)
       const result = await executeGet(promptId)
       if (result?.isSuccess && result.data) {
         setPromptData(result.data)
@@ -59,27 +61,27 @@ export default function PromptEditPage() {
           setEnabledTools(result.data.settings.tools || [])
           setEnabledConnectors(result.data.settings.connectors || [])
         }
+      } else {
+        setLoadError(result?.message || "Failed to load prompt")
       }
       setLoading(false)
     }
     if (promptId) loadPrompt()
   }, [promptId]) // eslint-disable-line react-hooks/exhaustive-deps -- executeGet is stable (useAction returns stable ref)
 
-  // Reset model initialization flag when navigating between prompts
-  // (Next.js App Router may reuse the component instance across route changes)
-  const modelInitialized = useRef(false)
+  // Track which promptId we've already initialized the model for.
+  // Using promptId (not a boolean) handles Next.js App Router reusing the
+  // component instance across route changes without needing a separate reset effect.
+  const modelInitializedForId = useRef<string | null>(null)
   useEffect(() => {
-    modelInitialized.current = false
-  }, [promptId])
-
-  useEffect(() => {
-    if (models.length === 0 || !promptData?.settings?.modelId || modelInitialized.current) return
-    const match = models.find(m => m.modelId === promptData?.settings?.modelId)
+    if (models.length === 0 || !promptData?.settings?.modelId) return
+    if (modelInitializedForId.current === promptId) return
+    const match = models.find(m => m.modelId === promptData.settings!.modelId)
     if (match) {
-      modelInitialized.current = true
+      modelInitializedForId.current = promptId
       setSelectedModel(match)
     }
-  }, [models, promptData])
+  }, [models, promptData, promptId])
 
   const handleSave = async () => {
     if (!formData.title || !formData.content) { toast.error("Title and content are required"); return }
@@ -128,8 +130,11 @@ export default function PromptEditPage() {
 
   if (!promptData) {
     return (
-      <div className="flex h-screen items-center justify-center">
-        <p className="text-destructive">Prompt not found</p>
+      <div className="flex h-screen flex-col items-center justify-center gap-2">
+        <p className="text-destructive">{loadError ?? "Prompt not found"}</p>
+        <Button variant="ghost" onClick={() => router.push('/prompt-library')}>
+          <ArrowLeft className="mr-2 h-4 w-4" /> Back to library
+        </Button>
       </div>
     )
   }

--- a/app/(protected)/prompt-library/[id]/page.tsx
+++ b/app/(protected)/prompt-library/[id]/page.tsx
@@ -1,10 +1,21 @@
 "use client"
 
-import { useState, useEffect, useRef, startTransition } from "react"
+import { useState, useEffect, useRef } from "react"
 import { useParams, useRouter } from "next/navigation"
 import { useAction } from "@/lib/hooks/use-action"
 import { getPrompt, updatePrompt, deletePrompt } from "@/actions/prompt-library.actions"
 import { Button } from "@/components/ui/button"
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog"
 import { toast } from "sonner"
 import { ArrowLeft, Save, Trash2 } from "lucide-react"
 import { PageBranding } from "@/components/ui/page-branding"
@@ -41,7 +52,7 @@ export default function PromptEditPage() {
         setPromptData(result.data)
         setFormData({
           title: result.data.title, content: result.data.content,
-          description: result.data.description || '', visibility: result.data.visibility,
+          description: result.data.description ?? '', visibility: result.data.visibility,
           tags: result.data.tags || []
         })
         if (result.data.settings) {
@@ -54,13 +65,19 @@ export default function PromptEditPage() {
     if (promptId) loadPrompt()
   }, [promptId]) // eslint-disable-line react-hooks/exhaustive-deps -- executeGet is stable (useAction returns stable ref)
 
+  // Reset model initialization flag when navigating between prompts
+  // (Next.js App Router may reuse the component instance across route changes)
   const modelInitialized = useRef(false)
   useEffect(() => {
+    modelInitialized.current = false
+  }, [promptId])
+
+  useEffect(() => {
     if (models.length === 0 || !promptData?.settings?.modelId || modelInitialized.current) return
-    const match = models.find(m => m.modelId === promptData.settings?.modelId)
+    const match = models.find(m => m.modelId === promptData?.settings?.modelId)
     if (match) {
       modelInitialized.current = true
-      startTransition(() => { setSelectedModel(match) })
+      setSelectedModel(match)
     }
   }, [models, promptData])
 
@@ -68,9 +85,9 @@ export default function PromptEditPage() {
     if (!formData.title || !formData.content) { toast.error("Title and content are required"); return }
     const hasSettings = selectedModel || enabledTools.length > 0 || enabledConnectors.length > 0
     const settings: PromptLibrarySettings | null = hasSettings ? {
-      ...(selectedModel ? { modelId: selectedModel.modelId } : {}),
-      ...(enabledTools.length > 0 ? { tools: enabledTools } : {}),
-      ...(enabledConnectors.length > 0 ? { connectors: enabledConnectors } : {}),
+      ...(selectedModel && { modelId: selectedModel.modelId }),
+      ...(enabledTools.length > 0 && { tools: enabledTools }),
+      ...(enabledConnectors.length > 0 && { connectors: enabledConnectors }),
     } : null
 
     setIsUpdating(true)
@@ -92,10 +109,12 @@ export default function PromptEditPage() {
   }
 
   const handleDelete = async () => {
-    if (confirm("Are you sure you want to delete this prompt?")) {
-      const result = await executeDelete(promptId)
-      if (result?.isSuccess) { toast.success("Prompt deleted successfully"); router.push('/prompt-library') }
-      else { toast.error(result?.message || "Failed to delete prompt") }
+    const result = await executeDelete(promptId)
+    if (result?.isSuccess) {
+      toast.success("Prompt deleted successfully")
+      router.push('/prompt-library')
+    } else {
+      toast.error(result?.message || "Failed to delete prompt")
     }
   }
 
@@ -121,7 +140,7 @@ export default function PromptEditPage() {
         <PageBranding />
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-4">
-            <Button variant="ghost" size="icon" onClick={() => router.push('/prompt-library')}>
+            <Button variant="ghost" size="icon" aria-label="Back to prompt library" onClick={() => router.push('/prompt-library')}>
               <ArrowLeft className="h-4 w-4" />
             </Button>
             <div>
@@ -130,9 +149,27 @@ export default function PromptEditPage() {
             </div>
           </div>
           <div className="flex gap-2">
-            <Button variant="outline" onClick={handleDelete} disabled={isDeleting}>
-              <Trash2 className="mr-2 h-4 w-4" /> Delete
-            </Button>
+            <AlertDialog>
+              <AlertDialogTrigger asChild>
+                <Button variant="outline" disabled={isDeleting}>
+                  <Trash2 className="mr-2 h-4 w-4" /> Delete
+                </Button>
+              </AlertDialogTrigger>
+              <AlertDialogContent>
+                <AlertDialogHeader>
+                  <AlertDialogTitle>Delete Prompt</AlertDialogTitle>
+                  <AlertDialogDescription>
+                    This will permanently delete this prompt. This action cannot be undone.
+                  </AlertDialogDescription>
+                </AlertDialogHeader>
+                <AlertDialogFooter>
+                  <AlertDialogCancel>Cancel</AlertDialogCancel>
+                  <AlertDialogAction onClick={handleDelete} disabled={isDeleting}>
+                    {isDeleting ? "Deleting…" : "Delete"}
+                  </AlertDialogAction>
+                </AlertDialogFooter>
+              </AlertDialogContent>
+            </AlertDialog>
             <Button onClick={handleSave} disabled={isUpdating}>
               <Save className="mr-2 h-4 w-4" /> {isUpdating ? 'Saving...' : 'Save Changes'}
             </Button>

--- a/app/(protected)/prompt-library/[id]/prompt-edit-form.tsx
+++ b/app/(protected)/prompt-library/[id]/prompt-edit-form.tsx
@@ -70,7 +70,7 @@ export function PromptEditForm({
           <Label htmlFor="description">Description ({(formData.description ?? '').length}/1000)</Label>
           <Textarea
             id="description"
-            value={formData.description || ''}
+            value={formData.description ?? ''}
             onChange={(e) => onFormDataChange({ ...formData, description: e.target.value })}
             placeholder="Enter a brief description"
             rows={3}

--- a/app/(protected)/prompt-library/[id]/prompt-edit-form.tsx
+++ b/app/(protected)/prompt-library/[id]/prompt-edit-form.tsx
@@ -53,37 +53,44 @@ export function PromptEditForm({
       <CardContent className="space-y-6">
         {/* Title */}
         <div className="space-y-2">
-          <Label htmlFor="title">Title *</Label>
+          <Label htmlFor="title">Title * ({(formData.title ?? '').length}/255)</Label>
           <Input
             id="title"
-            value={formData.title}
+            value={formData.title ?? ''}
             onChange={(e) => onFormDataChange({ ...formData, title: e.target.value })}
             placeholder="Enter prompt title"
+            maxLength={255}
+            aria-required="true"
+            aria-invalid={!formData.title}
           />
         </div>
 
         {/* Description */}
         <div className="space-y-2">
-          <Label htmlFor="description">Description</Label>
+          <Label htmlFor="description">Description ({(formData.description ?? '').length}/1000)</Label>
           <Textarea
             id="description"
             value={formData.description || ''}
             onChange={(e) => onFormDataChange({ ...formData, description: e.target.value })}
             placeholder="Enter a brief description"
             rows={3}
+            maxLength={1000}
           />
         </div>
 
         {/* Content */}
         <div className="space-y-2">
-          <Label htmlFor="content">Prompt Content *</Label>
+          <Label htmlFor="content">Prompt Content * ({(formData.content ?? '').length}/50000)</Label>
           <Textarea
             id="content"
-            value={formData.content}
+            value={formData.content ?? ''}
             onChange={(e) => onFormDataChange({ ...formData, content: e.target.value })}
             placeholder="Enter your prompt content"
             rows={10}
             className="font-mono"
+            maxLength={50000}
+            aria-required="true"
+            aria-invalid={!formData.content}
           />
           <p className="text-xs text-muted-foreground">
             Use variables like {`{{variable_name}}`} for dynamic content
@@ -125,7 +132,7 @@ export function PromptEditForm({
         <div className="space-y-3">
           <Label>Chat Configuration</Label>
           <p className="text-xs text-muted-foreground">
-            Configure the model, tools, and connectors that will be pre-selected when this prompt is used in Nexus.
+            Optionally configure a model, tools, and connectors that will be pre-selected when this prompt is used in Nexus.
           </p>
           <div className="rounded-lg border p-4">
             <div className="flex flex-wrap items-center gap-2">

--- a/app/(protected)/prompt-library/[id]/prompt-edit-form.tsx
+++ b/app/(protected)/prompt-library/[id]/prompt-edit-form.tsx
@@ -1,0 +1,169 @@
+"use client"
+
+import { Input } from "@/components/ui/input"
+import { Textarea } from "@/components/ui/textarea"
+import { Label } from "@/components/ui/label"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue
+} from "@/components/ui/select"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { ModelSelectorCompact } from "@/app/(protected)/nexus/_components/chat/model-selector-compact"
+import { ToolsPopover } from "@/app/(protected)/nexus/_components/chat/tools-popover"
+import { MCPPopover } from "@/app/(protected)/nexus/_components/chat/mcp-popover"
+import { TagInput } from "../_components/tag-input"
+import type { SelectAiModel } from "@/types"
+import type { Prompt, PromptVisibility } from "@/lib/prompt-library/types"
+
+interface PromptEditFormProps {
+  formData: Partial<Prompt>
+  onFormDataChange: (data: Partial<Prompt>) => void
+  promptData: Prompt
+  models: SelectAiModel[]
+  modelsLoading: boolean
+  selectedModel: SelectAiModel | null
+  onModelChange: (model: SelectAiModel) => void
+  enabledTools: string[]
+  onToolsChange: (tools: string[]) => void
+  enabledConnectors: string[]
+  onConnectorsChange: (connectors: string[]) => void
+}
+
+export function PromptEditForm({
+  formData,
+  onFormDataChange,
+  promptData,
+  models,
+  modelsLoading,
+  selectedModel,
+  onModelChange,
+  enabledTools,
+  onToolsChange,
+  enabledConnectors,
+  onConnectorsChange,
+}: PromptEditFormProps) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Prompt Details</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        {/* Title */}
+        <div className="space-y-2">
+          <Label htmlFor="title">Title *</Label>
+          <Input
+            id="title"
+            value={formData.title}
+            onChange={(e) => onFormDataChange({ ...formData, title: e.target.value })}
+            placeholder="Enter prompt title"
+          />
+        </div>
+
+        {/* Description */}
+        <div className="space-y-2">
+          <Label htmlFor="description">Description</Label>
+          <Textarea
+            id="description"
+            value={formData.description || ''}
+            onChange={(e) => onFormDataChange({ ...formData, description: e.target.value })}
+            placeholder="Enter a brief description"
+            rows={3}
+          />
+        </div>
+
+        {/* Content */}
+        <div className="space-y-2">
+          <Label htmlFor="content">Prompt Content *</Label>
+          <Textarea
+            id="content"
+            value={formData.content}
+            onChange={(e) => onFormDataChange({ ...formData, content: e.target.value })}
+            placeholder="Enter your prompt content"
+            rows={10}
+            className="font-mono"
+          />
+          <p className="text-xs text-muted-foreground">
+            Use variables like {`{{variable_name}}`} for dynamic content
+          </p>
+        </div>
+
+        {/* Tags */}
+        <div className="space-y-2">
+          <Label htmlFor="tags">Tags</Label>
+          <TagInput
+            value={formData.tags || []}
+            onChange={(tags) => onFormDataChange({ ...formData, tags })}
+          />
+        </div>
+
+        {/* Visibility */}
+        <div className="space-y-2">
+          <Label htmlFor="visibility">Visibility</Label>
+          <Select
+            value={formData.visibility}
+            onValueChange={(value: PromptVisibility) =>
+              onFormDataChange({ ...formData, visibility: value })
+            }
+          >
+            <SelectTrigger className="w-48">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="private">Private</SelectItem>
+              <SelectItem value="public">Public</SelectItem>
+            </SelectContent>
+          </Select>
+          <p className="text-xs text-muted-foreground">
+            Public prompts will be visible to all users after moderation
+          </p>
+        </div>
+
+        {/* Chat Configuration */}
+        <div className="space-y-3">
+          <Label>Chat Configuration</Label>
+          <p className="text-xs text-muted-foreground">
+            Configure the model, tools, and connectors that will be pre-selected when this prompt is used in Nexus.
+          </p>
+          <div className="rounded-lg border p-4">
+            <div className="flex flex-wrap items-center gap-2">
+              <ModelSelectorCompact
+                models={models}
+                selectedModel={selectedModel}
+                onModelChange={onModelChange}
+                isLoading={modelsLoading}
+              />
+              <ToolsPopover
+                selectedModel={selectedModel}
+                enabledTools={enabledTools}
+                onToolsChange={onToolsChange}
+              />
+              <MCPPopover
+                enabledConnectors={enabledConnectors}
+                onConnectorsChange={onConnectorsChange}
+              />
+            </div>
+          </div>
+        </div>
+
+        {/* Stats */}
+        <div className="grid grid-cols-3 gap-4 rounded-lg border p-4">
+          <div>
+            <div className="text-sm font-medium text-muted-foreground">Views</div>
+            <div className="text-2xl font-semibold">{promptData.viewCount}</div>
+          </div>
+          <div>
+            <div className="text-sm font-medium text-muted-foreground">Uses</div>
+            <div className="text-2xl font-semibold">{promptData.useCount}</div>
+          </div>
+          <div>
+            <div className="text-sm font-medium text-muted-foreground">Status</div>
+            <div className="text-sm font-semibold capitalize">{promptData.moderationStatus}</div>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/app/(protected)/prompt-library/[id]/prompt-edit-form.tsx
+++ b/app/(protected)/prompt-library/[id]/prompt-edit-form.tsx
@@ -61,7 +61,6 @@ export function PromptEditForm({
             placeholder="Enter prompt title"
             maxLength={255}
             aria-required="true"
-            aria-invalid={!formData.title}
           />
         </div>
 
@@ -90,7 +89,6 @@ export function PromptEditForm({
             className="font-mono"
             maxLength={50000}
             aria-required="true"
-            aria-invalid={!formData.content}
           />
           <p className="text-xs text-muted-foreground">
             Use variables like {`{{variable_name}}`} for dynamic content

--- a/app/(protected)/prompt-library/new/page.tsx
+++ b/app/(protected)/prompt-library/new/page.tsx
@@ -87,6 +87,7 @@ export default function NewPromptPage() {
             <Button
               variant="ghost"
               size="icon"
+              aria-label="Back to prompt library"
               onClick={() => router.push('/prompt-library')}
             >
               <ArrowLeft className="h-4 w-4" />

--- a/app/(protected)/prompt-library/new/page.tsx
+++ b/app/(protected)/prompt-library/new/page.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState, useCallback } from "react"
+import { useState } from "react"
 import { useRouter } from "next/navigation"
 import { createPrompt } from "@/actions/prompt-library.actions"
 import { useAction } from "@/lib/hooks/use-action"
@@ -50,10 +50,6 @@ export default function NewPromptPage() {
     }
   })
 
-  const handleModelChange = useCallback((model: SelectAiModel) => {
-    setSelectedModel(model)
-  }, [])
-
   const handleCreate = async () => {
     // Validate using Zod schema for consistency with server-side validation
     const validation = createPromptSchema.safeParse(formData)
@@ -63,11 +59,13 @@ export default function NewPromptPage() {
       return
     }
 
-    // Build settings from current selections
-    const settings: PromptLibrarySettings = {}
-    if (selectedModel) settings.modelId = selectedModel.modelId
-    if (enabledTools.length > 0) settings.tools = enabledTools
-    if (enabledConnectors.length > 0) settings.connectors = enabledConnectors
+    // Build settings from current selections; null means explicitly no settings
+    const hasSettings = selectedModel || enabledTools.length > 0 || enabledConnectors.length > 0
+    const settings: PromptLibrarySettings | null = hasSettings ? {
+      ...(selectedModel ? { modelId: selectedModel.modelId } : {}),
+      ...(enabledTools.length > 0 ? { tools: enabledTools } : {}),
+      ...(enabledConnectors.length > 0 ? { connectors: enabledConnectors } : {}),
+    } : null
 
     await executeCreate({
       title: formData.title,
@@ -75,7 +73,7 @@ export default function NewPromptPage() {
       description: formData.description || undefined,
       visibility: formData.visibility,
       tags: formData.tags,
-      settings: Object.keys(settings).length > 0 ? settings : undefined
+      settings: settings ?? undefined
     })
   }
 
@@ -117,7 +115,7 @@ export default function NewPromptPage() {
         models={models}
         modelsLoading={modelsLoading}
         selectedModel={selectedModel}
-        onModelChange={handleModelChange}
+        onModelChange={setSelectedModel}
         enabledTools={enabledTools}
         onToolsChange={setEnabledTools}
         enabledConnectors={enabledConnectors}

--- a/app/(protected)/prompt-library/new/page.tsx
+++ b/app/(protected)/prompt-library/new/page.tsx
@@ -62,9 +62,9 @@ export default function NewPromptPage() {
     // Build settings from current selections; null means explicitly no settings
     const hasSettings = selectedModel || enabledTools.length > 0 || enabledConnectors.length > 0
     const settings: PromptLibrarySettings | null = hasSettings ? {
-      ...(selectedModel ? { modelId: selectedModel.modelId } : {}),
-      ...(enabledTools.length > 0 ? { tools: enabledTools } : {}),
-      ...(enabledConnectors.length > 0 ? { connectors: enabledConnectors } : {}),
+      ...(selectedModel && { modelId: selectedModel.modelId }),
+      ...(enabledTools.length > 0 && { tools: enabledTools }),
+      ...(enabledConnectors.length > 0 && { connectors: enabledConnectors }),
     } : null
 
     await executeCreate({

--- a/app/(protected)/prompt-library/new/page.tsx
+++ b/app/(protected)/prompt-library/new/page.tsx
@@ -1,26 +1,18 @@
 "use client"
 
-import { useState } from "react"
+import { useState, useCallback } from "react"
 import { useRouter } from "next/navigation"
 import { createPrompt } from "@/actions/prompt-library.actions"
 import { useAction } from "@/lib/hooks/use-action"
 import { Button } from "@/components/ui/button"
-import { Input } from "@/components/ui/input"
-import { Textarea } from "@/components/ui/textarea"
-import { Label } from "@/components/ui/label"
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue
-} from "@/components/ui/select"
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { toast } from "sonner"
 import { ArrowLeft, Save } from "lucide-react"
-import { TagInput } from "../_components/tag-input"
 import { PageBranding } from "@/components/ui/page-branding"
+import { useModels } from "@/lib/hooks/use-models"
+import { PromptCreateForm } from "./prompt-create-form"
+import type { SelectAiModel } from "@/types"
 import type { PromptVisibility } from "@/lib/prompt-library/types"
+import type { PromptLibrarySettings } from "@/lib/db/types/jsonb"
 import { createPromptSchema } from "@/lib/prompt-library/validation"
 
 interface NewPromptFormData {
@@ -41,16 +33,26 @@ export default function NewPromptPage() {
     tags: []
   })
 
+  // Settings state
+  const [selectedModel, setSelectedModel] = useState<SelectAiModel | null>(null)
+  const [enabledTools, setEnabledTools] = useState<string[]>([])
+  const [enabledConnectors, setEnabledConnectors] = useState<string[]>([])
+
+  const { models, isLoading: modelsLoading } = useModels()
+
   const { execute: executeCreate, isPending: isCreating } = useAction(createPrompt, {
     onSuccess: (data) => {
       toast.success("Prompt created successfully")
-      // Redirect to view the newly created prompt
       router.push(`/prompt-library/${data.id}`)
     },
     onError: (error) => {
       toast.error(error)
     }
   })
+
+  const handleModelChange = useCallback((model: SelectAiModel) => {
+    setSelectedModel(model)
+  }, [])
 
   const handleCreate = async () => {
     // Validate using Zod schema for consistency with server-side validation
@@ -61,12 +63,19 @@ export default function NewPromptPage() {
       return
     }
 
+    // Build settings from current selections
+    const settings: PromptLibrarySettings = {}
+    if (selectedModel) settings.modelId = selectedModel.modelId
+    if (enabledTools.length > 0) settings.tools = enabledTools
+    if (enabledConnectors.length > 0) settings.connectors = enabledConnectors
+
     await executeCreate({
       title: formData.title,
       content: formData.content,
       description: formData.description || undefined,
       visibility: formData.visibility,
-      tags: formData.tags
+      tags: formData.tags,
+      settings: Object.keys(settings).length > 0 ? settings : undefined
     })
   }
 
@@ -93,111 +102,27 @@ export default function NewPromptPage() {
           </div>
 
           <Button
-          onClick={handleCreate}
-          disabled={isCreating}
-        >
-          <Save className="mr-2 h-4 w-4" />
-          {isCreating ? 'Creating...' : 'Create Prompt'}
-        </Button>
+            onClick={handleCreate}
+            disabled={isCreating}
+          >
+            <Save className="mr-2 h-4 w-4" />
+            {isCreating ? 'Creating...' : 'Create Prompt'}
+          </Button>
         </div>
       </div>
 
-      {/* Form */}
-      <Card>
-        <CardHeader>
-          <CardTitle>Prompt Details</CardTitle>
-        </CardHeader>
-        <CardContent className="space-y-6">
-          {/* Title */}
-          <div className="space-y-2">
-            <Label htmlFor="title">
-              Title * ({formData.title.length}/255)
-            </Label>
-            <Input
-              id="title"
-              value={formData.title}
-              onChange={(e) =>
-                setFormData({ ...formData, title: e.target.value })
-              }
-              placeholder="Enter prompt title"
-              maxLength={255}
-              aria-required="true"
-              aria-invalid={!formData.title}
-            />
-          </div>
-
-          {/* Description */}
-          <div className="space-y-2">
-            <Label htmlFor="description">
-              Description ({formData.description.length}/1000)
-            </Label>
-            <Textarea
-              id="description"
-              value={formData.description}
-              onChange={(e) =>
-                setFormData({ ...formData, description: e.target.value })
-              }
-              placeholder="Enter a brief description"
-              rows={3}
-              maxLength={1000}
-            />
-          </div>
-
-          {/* Content */}
-          <div className="space-y-2">
-            <Label htmlFor="content">
-              Prompt Content * ({formData.content.length}/50000)
-            </Label>
-            <Textarea
-              id="content"
-              value={formData.content}
-              onChange={(e) =>
-                setFormData({ ...formData, content: e.target.value })
-              }
-              placeholder="Enter your prompt content"
-              rows={10}
-              className="font-mono"
-              maxLength={50000}
-              aria-required="true"
-              aria-invalid={!formData.content}
-            />
-            <p className="text-xs text-muted-foreground">
-              Use variables like {`{{variable_name}}`} for dynamic content
-            </p>
-          </div>
-
-          {/* Tags */}
-          <div className="space-y-2">
-            <Label htmlFor="tags">Tags</Label>
-            <TagInput
-              value={formData.tags}
-              onChange={(tags) => setFormData({ ...formData, tags })}
-            />
-          </div>
-
-          {/* Visibility */}
-          <div className="space-y-2">
-            <Label htmlFor="visibility">Visibility</Label>
-            <Select
-              value={formData.visibility}
-              onValueChange={(value: PromptVisibility) =>
-                setFormData({ ...formData, visibility: value })
-              }
-            >
-              <SelectTrigger className="w-48">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="private">Private</SelectItem>
-                <SelectItem value="public">Public</SelectItem>
-              </SelectContent>
-            </Select>
-            <p className="text-xs text-muted-foreground">
-              Public prompts will be visible to all users after moderation
-            </p>
-          </div>
-        </CardContent>
-      </Card>
+      <PromptCreateForm
+        formData={formData}
+        onFormDataChange={setFormData}
+        models={models}
+        modelsLoading={modelsLoading}
+        selectedModel={selectedModel}
+        onModelChange={handleModelChange}
+        enabledTools={enabledTools}
+        onToolsChange={setEnabledTools}
+        enabledConnectors={enabledConnectors}
+        onConnectorsChange={setEnabledConnectors}
+      />
     </div>
   )
 }

--- a/app/(protected)/prompt-library/new/prompt-create-form.tsx
+++ b/app/(protected)/prompt-library/new/prompt-create-form.tsx
@@ -59,24 +59,23 @@ export function PromptCreateForm({
       <CardContent className="space-y-6">
         {/* Title */}
         <div className="space-y-2">
-          <Label htmlFor="title">Title * ({formData.title.length}/255)</Label>
+          <Label htmlFor="title">Title * ({(formData.title ?? '').length}/255)</Label>
           <Input
             id="title"
-            value={formData.title}
+            value={formData.title ?? ''}
             onChange={(e) => onFormDataChange({ ...formData, title: e.target.value })}
             placeholder="Enter prompt title"
             maxLength={255}
             aria-required="true"
-            aria-invalid={!formData.title}
           />
         </div>
 
         {/* Description */}
         <div className="space-y-2">
-          <Label htmlFor="description">Description ({formData.description.length}/1000)</Label>
+          <Label htmlFor="description">Description ({(formData.description ?? '').length}/1000)</Label>
           <Textarea
             id="description"
-            value={formData.description}
+            value={formData.description ?? ''}
             onChange={(e) => onFormDataChange({ ...formData, description: e.target.value })}
             placeholder="Enter a brief description"
             rows={3}
@@ -86,17 +85,16 @@ export function PromptCreateForm({
 
         {/* Content */}
         <div className="space-y-2">
-          <Label htmlFor="content">Prompt Content * ({formData.content.length}/50000)</Label>
+          <Label htmlFor="content">Prompt Content * ({(formData.content ?? '').length}/50000)</Label>
           <Textarea
             id="content"
-            value={formData.content}
+            value={formData.content ?? ''}
             onChange={(e) => onFormDataChange({ ...formData, content: e.target.value })}
             placeholder="Enter your prompt content"
             rows={10}
             className="font-mono"
             maxLength={50000}
             aria-required="true"
-            aria-invalid={!formData.content}
           />
           <p className="text-xs text-muted-foreground">
             Use variables like {`{{variable_name}}`} for dynamic content

--- a/app/(protected)/prompt-library/new/prompt-create-form.tsx
+++ b/app/(protected)/prompt-library/new/prompt-create-form.tsx
@@ -1,0 +1,166 @@
+"use client"
+
+import { Input } from "@/components/ui/input"
+import { Textarea } from "@/components/ui/textarea"
+import { Label } from "@/components/ui/label"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue
+} from "@/components/ui/select"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { ModelSelectorCompact } from "@/app/(protected)/nexus/_components/chat/model-selector-compact"
+import { ToolsPopover } from "@/app/(protected)/nexus/_components/chat/tools-popover"
+import { MCPPopover } from "@/app/(protected)/nexus/_components/chat/mcp-popover"
+import { TagInput } from "../_components/tag-input"
+import type { SelectAiModel } from "@/types"
+import type { PromptVisibility } from "@/lib/prompt-library/types"
+
+interface FormData {
+  title: string
+  content: string
+  description: string
+  visibility: PromptVisibility
+  tags: string[]
+}
+
+interface PromptCreateFormProps {
+  formData: FormData
+  onFormDataChange: (data: FormData) => void
+  models: SelectAiModel[]
+  modelsLoading: boolean
+  selectedModel: SelectAiModel | null
+  onModelChange: (model: SelectAiModel) => void
+  enabledTools: string[]
+  onToolsChange: (tools: string[]) => void
+  enabledConnectors: string[]
+  onConnectorsChange: (connectors: string[]) => void
+}
+
+export function PromptCreateForm({
+  formData,
+  onFormDataChange,
+  models,
+  modelsLoading,
+  selectedModel,
+  onModelChange,
+  enabledTools,
+  onToolsChange,
+  enabledConnectors,
+  onConnectorsChange,
+}: PromptCreateFormProps) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Prompt Details</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        {/* Title */}
+        <div className="space-y-2">
+          <Label htmlFor="title">Title * ({formData.title.length}/255)</Label>
+          <Input
+            id="title"
+            value={formData.title}
+            onChange={(e) => onFormDataChange({ ...formData, title: e.target.value })}
+            placeholder="Enter prompt title"
+            maxLength={255}
+            aria-required="true"
+            aria-invalid={!formData.title}
+          />
+        </div>
+
+        {/* Description */}
+        <div className="space-y-2">
+          <Label htmlFor="description">Description ({formData.description.length}/1000)</Label>
+          <Textarea
+            id="description"
+            value={formData.description}
+            onChange={(e) => onFormDataChange({ ...formData, description: e.target.value })}
+            placeholder="Enter a brief description"
+            rows={3}
+            maxLength={1000}
+          />
+        </div>
+
+        {/* Content */}
+        <div className="space-y-2">
+          <Label htmlFor="content">Prompt Content * ({formData.content.length}/50000)</Label>
+          <Textarea
+            id="content"
+            value={formData.content}
+            onChange={(e) => onFormDataChange({ ...formData, content: e.target.value })}
+            placeholder="Enter your prompt content"
+            rows={10}
+            className="font-mono"
+            maxLength={50000}
+            aria-required="true"
+            aria-invalid={!formData.content}
+          />
+          <p className="text-xs text-muted-foreground">
+            Use variables like {`{{variable_name}}`} for dynamic content
+          </p>
+        </div>
+
+        {/* Tags */}
+        <div className="space-y-2">
+          <Label htmlFor="tags">Tags</Label>
+          <TagInput
+            value={formData.tags}
+            onChange={(tags) => onFormDataChange({ ...formData, tags })}
+          />
+        </div>
+
+        {/* Visibility */}
+        <div className="space-y-2">
+          <Label htmlFor="visibility">Visibility</Label>
+          <Select
+            value={formData.visibility}
+            onValueChange={(value: PromptVisibility) =>
+              onFormDataChange({ ...formData, visibility: value })
+            }
+          >
+            <SelectTrigger className="w-48">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="private">Private</SelectItem>
+              <SelectItem value="public">Public</SelectItem>
+            </SelectContent>
+          </Select>
+          <p className="text-xs text-muted-foreground">
+            Public prompts will be visible to all users after moderation
+          </p>
+        </div>
+
+        {/* Chat Configuration */}
+        <div className="space-y-3">
+          <Label>Chat Configuration</Label>
+          <p className="text-xs text-muted-foreground">
+            Optionally configure a model, tools, and connectors that will be pre-selected when this prompt is used in Nexus.
+          </p>
+          <div className="rounded-lg border p-4">
+            <div className="flex flex-wrap items-center gap-2">
+              <ModelSelectorCompact
+                models={models}
+                selectedModel={selectedModel}
+                onModelChange={onModelChange}
+                isLoading={modelsLoading}
+              />
+              <ToolsPopover
+                selectedModel={selectedModel}
+                enabledTools={enabledTools}
+                onToolsChange={onToolsChange}
+              />
+              <MCPPopover
+                enabledConnectors={enabledConnectors}
+                onConnectorsChange={onConnectorsChange}
+              />
+            </div>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/docs/learnings/database/2026-02-26-drizzle-undefined-vs-null-column-update.md
+++ b/docs/learnings/database/2026-02-26-drizzle-undefined-vs-null-column-update.md
@@ -1,0 +1,50 @@
+---
+title: Drizzle ORM — undefined skips column updates, null explicitly clears
+category: database
+tags:
+  - drizzle
+  - orm
+  - null-semantics
+  - jsonb
+severity: high
+date: 2026-02-26
+source: auto — /review-pr
+applicable_to: project
+---
+
+## What Happened
+
+A PR for prompt library settings used conditional column updates (`if (data.field !== undefined)`). When a user cleared an optional field, the value was passed as `undefined`, causing Drizzle to silently skip the DB update — the old value persisted.
+
+## Root Cause
+
+Drizzle ORM treats `undefined` as "omit this column from the SET clause entirely". It only includes columns explicitly set to a value, including `null`. This differs from SQL's explicit NULL semantics.
+
+## Solution
+
+Always pass `null` (not `undefined`) when the intent is to clear a column:
+
+```typescript
+// Wrong — skips update when user clears field
+await db.update(table).set({
+  optionalField: data.optionalField, // undefined silently skips
+})
+
+// Correct — explicitly clears the column
+await db.update(table).set({
+  optionalField: data.optionalField ?? null,
+})
+```
+
+For conditional update patterns, prefer explicit nulling:
+
+```typescript
+const updates: Partial<typeof table.$inferInsert> = {}
+if (data.field !== undefined) updates.field = data.field ?? null
+```
+
+## Prevention
+
+- In any update action handling optional/clearable fields, default to `?? null` at the assignment site.
+- Applies especially to JSONB columns and nullable text fields where clearing is a valid user action.
+- Code review checklist: search for `data.field` in `.set({})` calls and verify null handling.

--- a/docs/learnings/frontend/2026-02-23-nextauth-refetchinterval-required-with-refetchonwindowfocus-false.md
+++ b/docs/learnings/frontend/2026-02-23-nextauth-refetchinterval-required-with-refetchonwindowfocus-false.md
@@ -1,0 +1,43 @@
+---
+title: NextAuth refetchInterval required when disabling refetchOnWindowFocus
+category: frontend
+tags:
+  - nextauth
+  - session
+  - refetchInterval
+  - pr-review
+  - session-expiry
+  - side-effects
+severity: high
+date: 2026-02-23
+source: review-pr
+applicable_to: project
+---
+
+## What Happened
+
+PR #812 review caught that disabling `refetchOnWindowFocus` globally (to prevent component remounts on tab switch) created a session expiry blind spot for long-lived sessions. Sessions were no longer being re-validated, so an expired token would not be detected until the next explicit API call. Fix: added `refetchInterval={5*60}` to compensate.
+
+## Root Cause
+
+Disabling `refetchOnWindowFocus` stops NextAuth from checking session validity on every tab focus. For users who keep the app open in the background for hours, the session can expire silently. Without periodic refetch, the first sign of expiry is a failed API call — not ideal for UX or security.
+
+## Solution
+
+Pair `refetchOnWindowFocus={false}` with a periodic `refetchInterval`:
+
+```typescript
+// app/layout.tsx
+<SessionProvider refetchOnWindowFocus={false} refetchInterval={5 * 60}>
+  {children}
+</SessionProvider>
+```
+
+This ensures session validity is checked every 5 minutes, catching expiry without causing remounts on window focus.
+
+## Prevention
+
+1. When disabling a NextAuth default behavior, **audit what safety mechanism you're removing**
+2. **Compensate** with an alternative (e.g., interval-based polling, explicit refresh on auth-protected routes)
+3. Test long-lived sessions (leave app open for 30+ min after token expiry time)
+4. Code review: always question "why disable this?" and verify the replacement strategy

--- a/docs/learnings/frontend/2026-02-23-nextauth-sessionprovider-refetch-causes-remount.md
+++ b/docs/learnings/frontend/2026-02-23-nextauth-sessionprovider-refetch-causes-remount.md
@@ -1,0 +1,65 @@
+---
+title: NextAuth SessionProvider refetchOnWindowFocus=true causes component remounts on tab switch
+category: frontend
+tags:
+  - nextauth
+  - react
+  - useEffect
+  - session
+  - tab-switch
+  - remount
+  - dependencies
+severity: high
+date: 2026-02-23
+source: work
+applicable_to: project
+---
+
+## What Happened
+
+Nexus conversation was remounting on every tab switch, causing loss of draft text and UI state. Root cause: `SessionProvider` has `refetchOnWindowFocus=true` by default, which triggers a session refetch on tab focus. This refetch returns a new object reference, which was included in the `useEffect` dependency array of `ConversationInitializer`, causing the effect to re-run, setting `loading=true`, and unmounting the entire component tree.
+
+## Root Cause
+
+NextAuth `SessionProvider` refetches the session on window focus by default. Each refetch creates a **new object reference** even if the session data is unchanged. When `session` object is added to a `useEffect` dependency array, any tab switch will:
+
+1. Trigger refetch → new session object reference
+2. Dependency check fails → effect re-runs
+3. Loading state reset → component tree unmounts
+4. User loses any unsaved work
+
+## Solution
+
+**Always use `status` (primitive string) instead of `session` (object) in dependency arrays:**
+
+```typescript
+// WRONG: session is an object, new reference on every refetch
+useEffect(() => {
+  if (session?.user?.id) {
+    initializeConversation()
+  }
+}, [session, conversationId])  // ❌ Remounts on tab switch
+
+// RIGHT: status is a primitive string, stable across refetches
+useEffect(() => {
+  if (status === 'authenticated') {
+    initializeConversation()
+  }
+}, [status, conversationId])  // ✅ No remount
+```
+
+**Disable refetchOnWindowFocus in SessionProvider:**
+
+```typescript
+// app/layout.tsx
+<SessionProvider refetchOnWindowFocus={false}>
+  {children}
+</SessionProvider>
+```
+
+## Prevention
+
+1. Add `refetchOnWindowFocus={false}` to NextAuth `SessionProvider` at app startup
+2. When reading session state in effects: always use `status` (primitive) instead of `session` (object)
+3. If you need the actual session data, store it in state/ref instead of dependency array
+4. Code review: grep for `useEffect.*session` and replace with `useEffect.*status`

--- a/docs/learnings/react-patterns/2026-02-26-form-extraction-validation-attrs-and-usecallback.md
+++ b/docs/learnings/react-patterns/2026-02-26-form-extraction-validation-attrs-and-usecallback.md
@@ -1,0 +1,42 @@
+---
+title: Form component extraction — carry validation attrs explicitly; don't wrap useState setters in useCallback
+category: react-patterns
+tags:
+  - react-forms
+  - form-extraction-refactor
+  - useCallback
+  - accessibility
+severity: medium
+date: 2026-02-26
+source: auto — /review-pr
+applicable_to: project
+---
+
+## What Happened
+
+During a PR refactoring form fields into extracted components, two issues appeared: (1) `maxLength`, `aria-required`, and `aria-invalid` attributes were dropped — they didn't transfer from the inline JSX to the new component's props. (2) A `useCallback` wrapping a `useState` setter was flagged as unnecessary.
+
+## Root Cause
+
+1. Validation attributes are easy to overlook in refactors because they sit alongside unrelated props; there's no compiler error when they're missing.
+2. `useState` setters are already referentially stable — React guarantees this. Wrapping them in `useCallback` adds noise with no benefit.
+
+## Solution
+
+When extracting form fields into components:
+- Explicitly audit and carry over: `maxLength`, `minLength`, `required`, `aria-required`, `aria-invalid`, `aria-describedby`, character counters, and any `onBlur` validation triggers.
+- Remove `useCallback` wrappers around raw `useState` setters:
+
+```tsx
+// Unnecessary
+const handleChange = useCallback((val: string) => setValue(val), [])
+
+// Correct — setValue is already stable
+<Input onChange={setValue} />
+```
+
+## Prevention
+
+- During form extraction PRs, explicitly check each removed JSX attribute against the new component's prop interface.
+- Treat accessibility attributes (`aria-*`) and HTML validation attributes as a required audit step, not optional cleanup.
+- Lint rule candidate: no `useCallback` wrapping a single-expression `setState` call with no additional logic.

--- a/docs/learnings/security/2026-02-23-tool-execute-sanitization-dead-code-and-prototype-pollution.md
+++ b/docs/learnings/security/2026-02-23-tool-execute-sanitization-dead-code-and-prototype-pollution.md
@@ -1,0 +1,55 @@
+---
+title: Tool execute() sanitization is dead code when return value is {id,success}; use Object.create(null) for model-controlled key accumulators
+category: security
+tags:
+  - prototype-pollution
+  - tool-execute
+  - sanitization
+  - ai-sdk
+  - dead-code
+  - xss
+severity: high
+date: 2026-02-23
+source: auto — /review-pr
+applicable_to: project
+---
+
+## What Happened
+
+PR #810 review found two security issues in a chart tool:
+
+1. `sanitizeChartArgs()` inside `execute()` built and returned a sanitized copy of args, but `execute()` itself only returns `{ id, success }`. The sanitized object was never used — the frontend reads args directly from the AI SDK tool invocation stream, bypassing `execute()` output entirely.
+
+2. A data-reduction loop used a plain object (`{}`) as an accumulator while iterating model-controlled keys. Keys like `__proto__` or `constructor` could pollute the object prototype chain.
+
+## Root Cause
+
+1. Misunderstanding of AI SDK data flow: `execute()` is for side effects and returning a result to the model. The frontend UI reads args from the streaming tool invocation object, not from the `execute()` return value. Sanitizing args inside `execute()` has no effect on what the render layer sees.
+
+2. Using `{}` as an accumulator when keys originate from model output. Plain object literals inherit from `Object.prototype`, so a key of `__proto__` becomes a prototype mutation rather than an own property.
+
+## Solution
+
+1. Moved XSS sanitization to the render component (the only place that actually uses args for HTML output).
+
+2. Changed accumulator initialization from `{}` to `Object.create(null)` to produce a prototype-free object immune to `__proto__` pollution.
+
+```typescript
+// Before — prototype pollution risk
+const result = data.reduce((acc, item) => {
+  acc[item.modelKey] = item.value;  // __proto__ pollutes here
+  return acc;
+}, {});
+
+// After — safe accumulator
+const result = data.reduce((acc, item) => {
+  acc[item.modelKey] = item.value;
+  return acc;
+}, Object.create(null));
+```
+
+## Prevention
+
+- If `execute()` returns only an ID or status, any arg sanitization inside it is dead code. Sanitize at the render layer instead.
+- Always use `Object.create(null)` (not `{}`) as an accumulator when iterating keys that originate from model/user-controlled data.
+- Audit tool `execute()` return types: if the return shape doesn't include sanitized args, in-execute sanitization achieves nothing for XSS defense.

--- a/lib/hooks/use-models.ts
+++ b/lib/hooks/use-models.ts
@@ -177,12 +177,11 @@ export function useModelsWithPersistence(
 
     const currentModelId = selectedModel?.modelId ?? null
 
-    // Skip if we've already validated this model ID against this models list
-    // BUT don't skip if a preferred model arrived async and differs from current
-    // (e.g. prompt settings loaded after initial model selection from localStorage)
-    if (currentModelId === lastValidatedModelId.current) {
-      if (!preferredModelId || preferredModelId === currentModelId) return
-    }
+    // Skip if we've already validated this model ID against this models list.
+    // Exception: if a preferredModelId arrived async (e.g. prompt settings loaded after
+    // localStorage model was already selected), allow re-validation so it gets applied.
+    const preferredPending = preferredModelId && preferredModelId !== currentModelId
+    if (currentModelId === lastValidatedModelId.current && !preferredPending) return
 
     const isStale = currentModelId && !models.some(m => m.modelId === currentModelId)
 

--- a/lib/hooks/use-models.ts
+++ b/lib/hooks/use-models.ts
@@ -178,7 +178,11 @@ export function useModelsWithPersistence(
     const currentModelId = selectedModel?.modelId ?? null
 
     // Skip if we've already validated this model ID against this models list
-    if (currentModelId === lastValidatedModelId.current) return
+    // BUT don't skip if a preferred model arrived async and differs from current
+    // (e.g. prompt settings loaded after initial model selection from localStorage)
+    if (currentModelId === lastValidatedModelId.current) {
+      if (!preferredModelId || preferredModelId === currentModelId) return
+    }
 
     const isStale = currentModelId && !models.some(m => m.modelId === currentModelId)
 


### PR DESCRIPTION
## Summary
- Add editable chat configuration (model, tools, connectors) to prompt library edit and create pages, reusing existing Nexus components (ModelSelectorCompact, ToolsPopover, MCPPopover)
- Fix race condition in `useModelsWithPersistence` where async `preferredModelId` from prompt settings was ignored because the `lastValidatedModelId` guard caused an early return after localStorage model was already validated
- Display connector ID column in admin connectors table for use in Nexus URL configuration

## Test plan
- [ ] Create a new prompt with model, tools, and connectors configured — verify settings persist after save
- [ ] Edit an existing prompt — verify saved model/tools/connectors load correctly
- [ ] Use "Use Prompt" from prompt library — verify Nexus selects the correct model, tools, and connectors
- [ ] Verify admin connectors page shows ID column with copyable text
- [ ] Run `bun run lint` and `bun run typecheck` — both pass