### PR TITLE
fix: #830 - Branding logo broken + cache flicker

### DIFF
--- a/actions/db/settings-actions.ts
+++ b/actions/db/settings-actions.ts
@@ -15,7 +15,7 @@ import {
   startTimer,
   sanitizeForLogging
 } from "@/lib/logger"
-import { revalidateSettingsCache, getSetting } from "@/lib/settings-manager"
+import { revalidateSettingsCache, getSetting, maskKey } from "@/lib/settings-manager"
 
 export interface Setting {
   id: number
@@ -94,9 +94,7 @@ export async function getSettingValueAction(key: string): Promise<string | null>
   const timer = startTimer("getSettingValue")
   const log = createLogger({ requestId, action: "getSettingValue" })
   
-  // Mask credential/secret key names in logs to avoid leaking config surface
-  const SENSITIVE_KEY_PATTERN = /KEY|SECRET|PASSWORD|TOKEN|CREDENTIAL/i
-  const safeKey = SENSITIVE_KEY_PATTERN.test(key) ? `${key.substring(0, 4)}***` : key
+  const safeKey = maskKey(key)
 
   try {
     log.debug("Getting setting value", { key: safeKey })

--- a/actions/db/settings-actions.ts
+++ b/actions/db/settings-actions.ts
@@ -94,16 +94,20 @@ export async function getSettingValueAction(key: string): Promise<string | null>
   const timer = startTimer("getSettingValue")
   const log = createLogger({ requestId, action: "getSettingValue" })
   
+  // Mask credential/secret key names in logs to avoid leaking config surface
+  const SENSITIVE_KEY_PATTERN = /KEY|SECRET|PASSWORD|TOKEN|CREDENTIAL/i
+  const safeKey = SENSITIVE_KEY_PATTERN.test(key) ? `${key.substring(0, 4)}***` : key
+
   try {
-    log.debug("Getting setting value", { key })
+    log.debug("Getting setting value", { key: safeKey })
 
     const value = await getSettingValueDrizzle(key)
 
-    log.debug("Setting value retrieved", { key, hasValue: !!value })
-    timer({ status: value ? "success" : "not_found", key })
+    log.debug("Setting value retrieved", { key: safeKey, hasValue: !!value })
+    timer({ status: value ? "success" : "not_found" })
     return value
   } catch (error) {
-    log.error("Error getting setting value", { key, error })
+    log.error("Error getting setting value", { key: safeKey, error })
     timer({ status: "error" })
     return null
   }

--- a/app/globals.css
+++ b/app/globals.css
@@ -147,3 +147,13 @@ html.dark .shiki span {
   min-width: 95vw !important;
   max-width: 95vw !important;
 }
+
+/* Accessibility: disable all animations and transitions for users who prefer reduced motion.
+   Covers CSS transitions/animations globally and suppresses SMIL <animate> in Chromium/Firefox. */
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -46,6 +46,7 @@ export default async function RootLayout({
             orgName: branding.orgName,
             appName: branding.appName,
             logoSrc: branding.logoSrc,
+            logoIsExternal: !branding.logoSrc.startsWith('/'),
           }}>
             <NotificationProvider>
               <ErrorCaptureInit />

--- a/components/dashboard/dashboard-home.tsx
+++ b/components/dashboard/dashboard-home.tsx
@@ -59,7 +59,7 @@ function ChatBubbleGraphic() {
         viewBox="0 0 180 280"
         fill="none"
         xmlns="http://www.w3.org/2000/svg"
-        className="w-full h-full opacity-90 transition-transform duration-500 group-hover:scale-105"
+        className="w-full h-full opacity-90 motion-safe:transition-transform motion-safe:duration-500 group-hover:motion-safe:scale-105"
         aria-hidden="true"
       >
         {/* Large chat bubble - right aligned (AI response) */}
@@ -74,7 +74,7 @@ function ChatBubbleGraphic() {
         <rect x="34" y="145" width="56" height="5" rx="2.5" fill="white" fillOpacity="0.25" />
         <rect x="34" y="156" width="36" height="5" rx="2.5" fill="white" fillOpacity="0.2" />
 
-        {/* Typing indicator bubble */}
+        {/* Typing indicator bubble — static dots when prefers-reduced-motion is set */}
         <rect x="55" y="194" width="72" height="36" rx="12" fill="white" fillOpacity="0.12" />
         <circle cx="77" cy="212" r="4" fill="white" fillOpacity="0.35">
           <animate attributeName="opacity" values="0.2;0.5;0.2" dur="1.5s" repeatCount="indefinite" begin="0s" />
@@ -122,7 +122,7 @@ function FeaturedToolCard({ title, description, href, icon, ctaText, accentColor
             )}
           >
             {ctaText || 'Get Started'}
-            <span className="transition-transform group-hover:translate-x-0.5">&rarr;</span>
+            <span className="motion-safe:transition-transform group-hover:translate-x-0.5 group-focus-visible:translate-x-0.5">&rarr;</span>
           </span>
         </div>
         <ChatBubbleGraphic />
@@ -199,7 +199,7 @@ function DashboardHeader({ firstName, orgName, appName, logoSrc, logoIsExternal 
   return (
     <div className="mb-6">
       <div className="flex items-center gap-2 mb-1">
-        <Image src={logoSrc} alt={orgName} width={20} height={20} className="opacity-70" unoptimized={logoIsExternal} />
+        <Image src={logoSrc} alt="" width={20} height={20} className="opacity-70" unoptimized={logoIsExternal} aria-hidden="true" />
         <span className="text-xs uppercase tracking-wider text-muted-foreground font-medium">
           {orgName} - {appName}
         </span>
@@ -214,16 +214,18 @@ function DashboardHeader({ firstName, orgName, appName, logoSrc, logoIsExternal 
 function SearchBar() {
   return (
     <div className="relative mb-8">
-      <IconSearch size={20} className="absolute left-4 top-1/2 -translate-y-1/2 text-muted-foreground" />
+      <IconSearch size={20} className="absolute left-4 top-1/2 -translate-y-1/2 text-muted-foreground" aria-hidden="true" />
       <input
+        id="dashboard-search"
         type="search"
         placeholder="Search tools, prompts, or assistants..."
+        aria-label="Search tools, prompts, or assistants"
         className={cn(
           'w-full h-12 pl-12 pr-4 rounded-xl',
           'bg-white border border-border/40 shadow-sm',
           'text-sm placeholder:text-muted-foreground',
           'focus:outline-none focus:ring-2 focus:ring-[var(--brand-primary)]/20 focus:border-[var(--brand-primary)]/40',
-          'transition-all duration-200'
+          'motion-safe:transition-all motion-safe:duration-200'
         )}
       />
     </div>

--- a/components/dashboard/dashboard-home.tsx
+++ b/components/dashboard/dashboard-home.tsx
@@ -163,7 +163,7 @@ function DashboardHeader({ firstName, orgName, appName, logoSrc }: DashboardHead
   return (
     <div className="mb-6">
       <div className="flex items-center gap-2 mb-1">
-        <Image src={logoSrc} alt={orgName} width={20} height={20} className="opacity-70" />
+        <Image src={logoSrc} alt={orgName} width={20} height={20} className="opacity-70" unoptimized={!logoSrc.startsWith('/')} />
         <span className="text-xs uppercase tracking-wider text-muted-foreground font-medium">
           {orgName} - {appName}
         </span>
@@ -218,7 +218,6 @@ const AssistantArchitectIcon = <IconTools size={20} />;
 const TutorialsIcon = <IconSchool size={20} />;
 
 function ToolCardsGrid() {
-  const { logoSrc } = useBranding();
   return (
     <div className="grid grid-cols-1 lg:grid-cols-5 gap-4 auto-rows-auto">
       {/* Nexus Chat - spans 3 columns on large screens, 2 rows */}
@@ -231,7 +230,6 @@ function ToolCardsGrid() {
           accentColor="navy"
           ctaText="Start Chatting"
           featured
-          image={logoSrc}
         />
       </div>
 

--- a/components/dashboard/dashboard-home.tsx
+++ b/components/dashboard/dashboard-home.tsx
@@ -192,13 +192,14 @@ interface DashboardHeaderProps {
   orgName: string;
   appName: string;
   logoSrc: string;
+  logoIsExternal: boolean;
 }
 
-function DashboardHeader({ firstName, orgName, appName, logoSrc }: DashboardHeaderProps) {
+function DashboardHeader({ firstName, orgName, appName, logoSrc, logoIsExternal }: DashboardHeaderProps) {
   return (
     <div className="mb-6">
       <div className="flex items-center gap-2 mb-1">
-        <Image src={logoSrc} alt={orgName} width={20} height={20} className="opacity-70" unoptimized={!logoSrc.startsWith('/')} />
+        <Image src={logoSrc} alt={orgName} width={20} height={20} className="opacity-70" unoptimized={logoIsExternal} />
         <span className="text-xs uppercase tracking-wider text-muted-foreground font-medium">
           {orgName} - {appName}
         </span>
@@ -332,7 +333,7 @@ function ToolCardsGrid() {
 
 export function DashboardHome() {
   const { data: session } = useSession();
-  const { orgName, appName, logoSrc } = useBranding();
+  const { orgName, appName, logoSrc, logoIsExternal } = useBranding();
 
   const firstName = useMemo(() => {
     return session?.user?.givenName || session?.user?.name?.split(' ')[0] || 'there';
@@ -341,7 +342,7 @@ export function DashboardHome() {
   return (
     <div className="min-h-screen bg-[#FBF7F4]">
       <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-6">
-        <DashboardHeader firstName={firstName} orgName={orgName} appName={appName} logoSrc={logoSrc} />
+        <DashboardHeader firstName={firstName} orgName={orgName} appName={appName} logoSrc={logoSrc} logoIsExternal={logoIsExternal} />
         <SearchBar />
         <FeaturedToolsHeader />
         <ToolCardsGrid />

--- a/components/dashboard/dashboard-home.tsx
+++ b/components/dashboard/dashboard-home.tsx
@@ -27,7 +27,6 @@ interface ToolCardProps {
   ctaColor?: AccentColor;
   accentColor: AccentColor;
   featured?: boolean;
-  image?: string;
 }
 
 const ACCENT_CLASSES: Record<AccentColor, string> = {
@@ -51,7 +50,47 @@ const CTA_COLOR_CLASSES: Record<AccentColor, string> = {
   green: 'text-[#6B9E78]',
 };
 
-function FeaturedToolCard({ title, description, href, icon, ctaText, accentColor, image }: ToolCardProps) {
+function ChatBubbleGraphic() {
+  return (
+    <div className="relative w-[180px] flex-shrink-0 bg-[var(--brand-primary)] hidden sm:flex items-center justify-center overflow-hidden">
+      {/* Subtle radial glow */}
+      <div className="absolute inset-0 bg-gradient-to-br from-white/10 via-transparent to-black/10" />
+      <svg
+        viewBox="0 0 180 280"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+        className="w-full h-full opacity-90 transition-transform duration-500 group-hover:scale-105"
+        aria-hidden="true"
+      >
+        {/* Large chat bubble - right aligned (AI response) */}
+        <rect x="30" y="50" width="120" height="60" rx="16" fill="white" fillOpacity="0.2" />
+        {/* Text lines inside large bubble */}
+        <rect x="46" y="68" width="72" height="6" rx="3" fill="white" fillOpacity="0.3" />
+        <rect x="46" y="82" width="88" height="6" rx="3" fill="white" fillOpacity="0.25" />
+        <rect x="46" y="96" width="52" height="6" rx="3" fill="white" fillOpacity="0.2" />
+
+        {/* Small chat bubble - left aligned (user message) */}
+        <rect x="20" y="130" width="90" height="44" rx="14" fill="white" fillOpacity="0.15" />
+        <rect x="34" y="145" width="56" height="5" rx="2.5" fill="white" fillOpacity="0.25" />
+        <rect x="34" y="156" width="36" height="5" rx="2.5" fill="white" fillOpacity="0.2" />
+
+        {/* Typing indicator bubble */}
+        <rect x="55" y="194" width="72" height="36" rx="12" fill="white" fillOpacity="0.12" />
+        <circle cx="77" cy="212" r="4" fill="white" fillOpacity="0.35">
+          <animate attributeName="opacity" values="0.2;0.5;0.2" dur="1.5s" repeatCount="indefinite" begin="0s" />
+        </circle>
+        <circle cx="93" cy="212" r="4" fill="white" fillOpacity="0.35">
+          <animate attributeName="opacity" values="0.2;0.5;0.2" dur="1.5s" repeatCount="indefinite" begin="0.3s" />
+        </circle>
+        <circle cx="109" cy="212" r="4" fill="white" fillOpacity="0.35">
+          <animate attributeName="opacity" values="0.2;0.5;0.2" dur="1.5s" repeatCount="indefinite" begin="0.6s" />
+        </circle>
+      </svg>
+    </div>
+  );
+}
+
+function FeaturedToolCard({ title, description, href, icon, ctaText, accentColor }: ToolCardProps) {
   return (
     <Link
       href={href}
@@ -86,11 +125,7 @@ function FeaturedToolCard({ title, description, href, icon, ctaText, accentColor
             <span className="transition-transform group-hover:translate-x-0.5">&rarr;</span>
           </span>
         </div>
-        {image && (
-          <div className="relative w-[180px] flex-shrink-0 bg-[var(--brand-primary)]/95 hidden sm:block">
-            <Image src={image} alt="" fill className="object-contain p-4 opacity-90" sizes="180px" />
-          </div>
-        )}
+        <ChatBubbleGraphic />
       </div>
     </Link>
   );

--- a/components/navigation/navbar-nested.tsx
+++ b/components/navigation/navbar-nested.tsx
@@ -812,6 +812,7 @@ function NavigationContent({ isExpanded }: { isExpanded: boolean }) {
             width={isExpanded ? 28 : 24}
             height={isExpanded ? 28 : 24}
             className="object-contain"
+            unoptimized={!logoSrc.startsWith('/')}
           />
           {isExpanded && <span className="text-[var(--brand-primary)] text-base font-bold">{appName}</span>}
         </Link>

--- a/components/navigation/navbar-nested.tsx
+++ b/components/navigation/navbar-nested.tsx
@@ -768,7 +768,7 @@ function NavigationContent({ isExpanded }: { isExpanded: boolean }) {
   const { data: session } = useSession();
   const [navItems, setNavItems] = useState<NavigationItem[]>([]);
   const [isLoading, setIsLoading] = useState(true);
-  const { orgName, appName, logoSrc } = useBranding();
+  const { orgName, appName, logoSrc, logoIsExternal } = useBranding();
 
   const { fullName, userInitials } = useMemo(() => {
     const givenName = session?.user?.givenName || session?.user?.name?.split(' ')[0] || 'User';
@@ -812,7 +812,7 @@ function NavigationContent({ isExpanded }: { isExpanded: boolean }) {
             width={isExpanded ? 28 : 24}
             height={isExpanded ? 28 : 24}
             className="object-contain"
-            unoptimized={!logoSrc.startsWith('/')}
+            unoptimized={logoIsExternal}
           />
           {isExpanded && <span className="text-[var(--brand-primary)] text-base font-bold">{appName}</span>}
         </Link>

--- a/components/ui/page-branding.tsx
+++ b/components/ui/page-branding.tsx
@@ -8,7 +8,7 @@ export function PageBranding() {
 
   return (
     <div className="flex items-center gap-2 mb-1">
-      <Image src={logoSrc} alt={orgName} width={20} height={20} className="opacity-70" />
+      <Image src={logoSrc} alt={orgName} width={20} height={20} className="opacity-70" unoptimized={!logoSrc.startsWith('/')} />
       <span className="text-xs uppercase tracking-wider text-muted-foreground font-medium">
         {orgName} - {appName}
       </span>

--- a/components/ui/page-branding.tsx
+++ b/components/ui/page-branding.tsx
@@ -4,11 +4,11 @@ import Image from 'next/image';
 import { useBranding } from '@/contexts/branding-context';
 
 export function PageBranding() {
-  const { orgName, appName, logoSrc } = useBranding();
+  const { orgName, appName, logoSrc, logoIsExternal } = useBranding();
 
   return (
     <div className="flex items-center gap-2 mb-1">
-      <Image src={logoSrc} alt={orgName} width={20} height={20} className="opacity-70" unoptimized={!logoSrc.startsWith('/')} />
+      <Image src={logoSrc} alt={orgName} width={20} height={20} className="opacity-70" unoptimized={logoIsExternal} />
       <span className="text-xs uppercase tracking-wider text-muted-foreground font-medium">
         {orgName} - {appName}
       </span>

--- a/components/ui/page-branding.tsx
+++ b/components/ui/page-branding.tsx
@@ -8,7 +8,7 @@ export function PageBranding() {
 
   return (
     <div className="flex items-center gap-2 mb-1">
-      <Image src={logoSrc} alt={orgName} width={20} height={20} className="opacity-70" unoptimized={logoIsExternal} />
+      <Image src={logoSrc} alt="" width={20} height={20} className="opacity-70" unoptimized={logoIsExternal} aria-hidden="true" />
       <span className="text-xs uppercase tracking-wider text-muted-foreground font-medium">
         {orgName} - {appName}
       </span>

--- a/contexts/branding-context.tsx
+++ b/contexts/branding-context.tsx
@@ -3,12 +3,16 @@
 import { createContext, useContext } from 'react'
 import type { BrandingConfig } from '@/lib/branding'
 
-export type BrandingValues = Pick<BrandingConfig, 'orgName' | 'appName' | 'logoSrc'>
+export type BrandingValues = Pick<BrandingConfig, 'orgName' | 'appName' | 'logoSrc'> & {
+  /** True when logoSrc is an external URL (S3 signed) rather than a local path */
+  logoIsExternal: boolean
+}
 
 const BrandingContext = createContext<BrandingValues>({
   orgName: 'Your Organization',
   appName: 'AI Studio',
   logoSrc: '/logo.png',
+  logoIsExternal: false,
 })
 
 export function BrandingProvider({

--- a/lib/settings-manager.ts
+++ b/lib/settings-manager.ts
@@ -132,7 +132,7 @@ export async function getSettings(keys: string[]): Promise<Record<string, string
 // Clear the cache (useful after updates)
 // Also cancels any pending background refresh for the key to prevent a stale
 // in-flight promise from writing old data back into the cache after invalidation.
-export async function revalidateSettingsCache(key?: string) {
+export async function revalidateSettingsCache(key?: string): Promise<void> {
   if (key) {
     settingsCache.delete(key)
     pendingRefreshes.delete(key)

--- a/lib/settings-manager.ts
+++ b/lib/settings-manager.ts
@@ -2,29 +2,67 @@ import { getSettingValueAction } from "@/actions/db/settings-actions"
 import logger from "@/lib/logger"
 
 // Cache for settings to avoid repeated database queries
+// Uses stale-while-revalidate: serves stale value immediately while refreshing in background
 const settingsCache = new Map<string, { value: string | null; timestamp: number }>()
 const CACHE_TTL = 5 * 60 * 1000 // 5 minutes
+
+// Track in-flight background refreshes to avoid duplicate fetches
+const pendingRefreshes = new Set<string>()
+
+// Background refresh: fetch fresh value without blocking the caller
+function backgroundRefresh(key: string): void {
+  if (pendingRefreshes.has(key)) return
+  pendingRefreshes.add(key)
+
+  getSettingValueAction(key)
+    .then((dbValue) => {
+      if (dbValue !== null) {
+        settingsCache.set(key, { value: dbValue, timestamp: Date.now() })
+      } else {
+        // DB returned null — cache env fallback
+        const envValue = process.env[key] || null
+        settingsCache.set(key, { value: envValue, timestamp: Date.now() })
+      }
+    })
+    .catch((error) => {
+      logger.error(`[SettingsManager] Background refresh failed for ${key}:`, error)
+      // On error, bump the timestamp of the stale entry so we don't retry immediately
+      const stale = settingsCache.get(key)
+      if (stale) {
+        settingsCache.set(key, { value: stale.value, timestamp: Date.now() })
+      }
+    })
+    .finally(() => {
+      pendingRefreshes.delete(key)
+    })
+}
 
 // Get a setting value with caching and fallback to environment variable
 export async function getSetting(key: string): Promise<string | null> {
   // Special handling for Bedrock credentials in Lambda
   const isAwsLambda = !!process.env.AWS_LAMBDA_FUNCTION_NAME
   const isBedrockCredential = key === 'BEDROCK_ACCESS_KEY_ID' || key === 'BEDROCK_SECRET_ACCESS_KEY'
-  
+
   // Don't use cache for Bedrock credentials in Lambda
   if (!(isAwsLambda && isBedrockCredential)) {
-    // Check cache first
     const cached = settingsCache.get(key)
-    if (cached && Date.now() - cached.timestamp < CACHE_TTL) {
-      // Cache hit
+    if (cached) {
+      const isStale = Date.now() - cached.timestamp >= CACHE_TTL
+      if (!isStale) {
+        // Cache hit — fresh
+        return cached.value
+      }
+      // Stale-while-revalidate: return stale value immediately, refresh in background
+      backgroundRefresh(key)
       return cached.value
     }
   }
 
+  // Cold start — no cached value, must fetch synchronously
   try {
     // Try to get from database
     const dbValue = await getSettingValueAction(key)
-    
+
     if (dbValue !== null) {
       // Database value found - cache it and return
       settingsCache.set(key, { value: dbValue, timestamp: Date.now() })
@@ -37,7 +75,7 @@ export async function getSetting(key: string): Promise<string | null> {
   // Fall back to environment variable
   // IMPORTANT: In AWS Lambda, ignore Bedrock credentials from env vars
   // to force use of IAM role credentials
-  
+
   if (isAwsLambda && isBedrockCredential) {
     // In Lambda, ignore Bedrock credential env vars to use IAM role
     logger.info(`[SettingsManager] Ignoring env var ${key} in Lambda environment`)
@@ -45,18 +83,12 @@ export async function getSetting(key: string): Promise<string | null> {
     settingsCache.set(key, { value: null, timestamp: Date.now() })
     return null
   }
-  
+
   const envValue = process.env[key] || null
-  
+
   // Only cache the final result to avoid blocking env var fallback
   settingsCache.set(key, { value: envValue, timestamp: Date.now() })
-  
-  if (envValue) {
-    // Falling back to env var
-  } else {
-    // No value found
-  }
-  
+
   return envValue
 }
 

--- a/lib/settings-manager.ts
+++ b/lib/settings-manager.ts
@@ -5,9 +5,17 @@ import logger from "@/lib/logger"
 // Uses stale-while-revalidate: serves stale value immediately while refreshing in background
 const settingsCache = new Map<string, { value: string | null; timestamp: number }>()
 const CACHE_TTL = 5 * 60 * 1000 // 5 minutes
+// On DB error, retry after this shorter window rather than waiting the full TTL
+const RETRY_AFTER_ERROR_MS = 30 * 1000 // 30 seconds
 
 // Track in-flight background refreshes to avoid duplicate fetches
 const pendingRefreshes = new Set<string>()
+
+// Mask credential/secret key names in log output to avoid leaking config surface
+const SENSITIVE_KEY_PATTERN = /KEY|SECRET|PASSWORD|TOKEN|CREDENTIAL/i
+function maskKey(key: string): string {
+  return SENSITIVE_KEY_PATTERN.test(key) ? `${key.substring(0, 4)}***` : key
+}
 
 // Background refresh: fetch fresh value without blocking the caller
 function backgroundRefresh(key: string): void {
@@ -25,11 +33,14 @@ function backgroundRefresh(key: string): void {
       }
     })
     .catch((error) => {
-      logger.error(`[SettingsManager] Background refresh failed for ${key}:`, error)
-      // On error, bump the timestamp of the stale entry so we don't retry immediately
+      logger.error(`[SettingsManager] Background refresh failed for ${maskKey(key)}:`, error)
+      // On error, retry after a short window (not full TTL) so we recover quickly when DB is back
       const stale = settingsCache.get(key)
       if (stale) {
-        settingsCache.set(key, { value: stale.value, timestamp: Date.now() })
+        settingsCache.set(key, {
+          value: stale.value,
+          timestamp: Date.now() - CACHE_TTL + RETRY_AFTER_ERROR_MS,
+        })
       }
     })
     .finally(() => {
@@ -69,7 +80,7 @@ export async function getSetting(key: string): Promise<string | null> {
       return dbValue
     }
   } catch (error) {
-    logger.error(`[SettingsManager] Error fetching setting ${key} from database:`, error)
+    logger.error(`[SettingsManager] Error fetching setting ${maskKey(key)} from database:`, error)
   }
 
   // Fall back to environment variable
@@ -78,7 +89,7 @@ export async function getSetting(key: string): Promise<string | null> {
 
   if (isAwsLambda && isBedrockCredential) {
     // In Lambda, ignore Bedrock credential env vars to use IAM role
-    logger.info(`[SettingsManager] Ignoring env var ${key} in Lambda environment`)
+    logger.info(`[SettingsManager] Ignoring env var ${maskKey(key)} in Lambda environment`)
     // Cache the null for Lambda to avoid repeated DB queries
     settingsCache.set(key, { value: null, timestamp: Date.now() })
     return null

--- a/lib/settings-manager.ts
+++ b/lib/settings-manager.ts
@@ -17,7 +17,10 @@ function maskKey(key: string): string {
   return SENSITIVE_KEY_PATTERN.test(key) ? `${key.substring(0, 4)}***` : key
 }
 
-// Background refresh: fetch fresh value without blocking the caller
+// Background refresh: fetch fresh value without blocking the caller.
+// IMPORTANT: Only called from within the `!(isAwsLambda && isBedrockCredential)` block,
+// so Lambda+Bedrock keys (which must use IAM role, not env vars) never reach this function.
+// Do not call backgroundRefresh() for Lambda+Bedrock keys from other code paths.
 function backgroundRefresh(key: string): void {
   if (pendingRefreshes.has(key)) return
   pendingRefreshes.add(key)
@@ -25,11 +28,21 @@ function backgroundRefresh(key: string): void {
   getSettingValueAction(key)
     .then((dbValue) => {
       if (dbValue !== null) {
+        // Fresh value from DB — update cache
         settingsCache.set(key, { value: dbValue, timestamp: Date.now() })
       } else {
-        // DB returned null — cache env fallback
-        const envValue = process.env[key] || null
-        settingsCache.set(key, { value: envValue, timestamp: Date.now() })
+        // getSettingValueAction() returns null both when the setting is missing
+        // and when a DB error occurs. To avoid clobbering a previously-good
+        // cached value on transient errors, only fall back to env when there is
+        // no existing cache entry.
+        const existing = settingsCache.get(key)
+        if (existing) {
+          // Preserve existing value, just refresh timestamp
+          settingsCache.set(key, { value: existing.value, timestamp: Date.now() })
+        } else {
+          const envValue = process.env[key] || null
+          settingsCache.set(key, { value: envValue, timestamp: Date.now() })
+        }
       }
     })
     .catch((error) => {
@@ -117,13 +130,15 @@ export async function getSettings(keys: string[]): Promise<Record<string, string
 }
 
 // Clear the cache (useful after updates)
+// Also cancels any pending background refresh for the key to prevent a stale
+// in-flight promise from writing old data back into the cache after invalidation.
 export async function revalidateSettingsCache(key?: string) {
   if (key) {
     settingsCache.delete(key)
-    // Cache cleared for key
+    pendingRefreshes.delete(key)
   } else {
     settingsCache.clear()
-    // Cache cleared
+    pendingRefreshes.clear()
   }
   
   // Also clear S3 cache when settings are updated

--- a/lib/settings-manager.ts
+++ b/lib/settings-manager.ts
@@ -13,7 +13,7 @@ const pendingRefreshes = new Set<string>()
 
 // Mask credential/secret key names in log output to avoid leaking config surface
 const SENSITIVE_KEY_PATTERN = /KEY|SECRET|PASSWORD|TOKEN|CREDENTIAL/i
-function maskKey(key: string): string {
+export function maskKey(key: string): string {
   return SENSITIVE_KEY_PATTERN.test(key) ? `${key.substring(0, 4)}***` : key
 }
 


### PR DESCRIPTION
## Summary
Fixes three branding bugs introduced by the branding settings PRs (#824-#828).

## Changes

### Bug 1: S3 logos render as broken images
- **Root cause**: `next.config.mjs` builds S3 `remotePatterns` at compile time from env vars. On ECS, these aren't available during Docker build → no patterns → `<Image>` blocks signed URLs.
- **Fix**: Added `unoptimized={!logoSrc.startsWith('/')}` to all `<Image>` components rendering the branding logo. Local `/logo.png` still gets optimized; S3 signed URLs bypass the optimizer (appropriate since the URL changes per-request).
- **Files**: `dashboard-home.tsx`, `navbar-nested.tsx`, `page-branding.tsx`

### Bug 2: Logo in Nexus Chat card blue panel
- **Root cause**: `image={logoSrc}` passed to FeaturedToolCard renders org logo in a decorative illustration slot.
- **Fix**: Removed `image={logoSrc}` from the Nexus Chat ToolCard.
- **File**: `dashboard-home.tsx`

### Bug 3: Branding flickers between defaults and DB values
- **Root cause**: Settings cache had hard 5-minute TTL. On expiry, blocked on DB fetch — if slow/failed, defaults flashed.
- **Fix**: Stale-while-revalidate pattern in `settings-manager.ts`. Stale cache returns immediately while background refresh runs. Only true cold starts show defaults.
- **File**: `settings-manager.ts`

## Test Plan
- [ ] Upload a custom logo via Admin > Settings > Branding → verify it renders in sidebar, dashboard header, and page branding
- [ ] Verify the Nexus Chat featured card no longer shows the org logo in the blue panel
- [ ] Navigate between pages after branding loads → verify no "Your Organization" / "AI Studio" flicker
- [ ] Restart dev server (cold start) → verify defaults show briefly then real values load
- [ ] Verify local `/logo.png` default still works when no custom logo is uploaded

Closes #830