### PR TITLE
fix: #838 — JIT user provisioning for API routes missing DB records

### DIFF
--- a/actions/db/get-current-user-action.ts
+++ b/actions/db/get-current-user-action.ts
@@ -6,7 +6,7 @@ import {
   createUser,
   updateUser,
   getRoleByName,
-  assignRoleToUser,
+  addUserRole,
   getUserRolesByCognitoSub
 } from "@/lib/db/drizzle"
 import { getServerSession } from "@/lib/auth/server-session"
@@ -152,29 +152,20 @@ export async function getCurrentUserAction(): Promise<
         assignedRole: defaultRole
       })
 
-      const role = await getRoleByName(defaultRole)
-
-      if (role) {
-        const roleId = role.id
-        // UPSERT: If role already assigned by concurrent request, DO NOTHING
-        const assignmentResult = await assignRoleToUser(user!.id, roleId)
-
-        if (assignmentResult && assignmentResult.length > 0) {
-          log.info(`${defaultRole} role assigned to user`, {
-            userId: user.id,
-            roleId,
-            roleName: defaultRole
-          })
-        } else {
-          log.info(`${defaultRole} role already assigned (concurrent request)`, {
-            userId: user.id,
-            roleId,
-            roleName: defaultRole
-          })
-        }
-      } else {
-        log.warn("Default role not found in database - user has no default role", {
-          attemptedRole: defaultRole
+      // addUserRole runs in a transaction, handles role lookup, and increments
+      // role_version for session cache invalidation — consistent with resolveUserId
+      try {
+        await addUserRole(user!.id, defaultRole)
+        log.info(`${defaultRole} role assigned to user`, {
+          userId: user.id,
+          roleName: defaultRole
+        })
+      } catch (roleError) {
+        // Non-fatal: user is provisioned but may lack a role until next login
+        log.warn("Default role assignment failed", {
+          userId: user.id,
+          attemptedRole: defaultRole,
+          error: roleError instanceof Error ? roleError.message : "Unknown error"
         })
       }
     }

--- a/app/api/admin/assistants/import/route.ts
+++ b/app/api/admin/assistants/import/route.ts
@@ -2,11 +2,11 @@ import { NextRequest, NextResponse } from "next/server"
 import { requireAdmin } from "@/lib/auth/admin-check"
 import { getServerSession } from "@/lib/auth/server-session"
 import {
-  getUserIdByCognitoSubAsNumber,
   createAssistantArchitect,
   createChainPrompt,
   createToolInputField,
 } from "@/lib/db/drizzle"
+import { resolveUserId } from "@/lib/auth/resolve-user"
 import { validateImportFile, mapModelsForImport, type ExportFormat } from "@/lib/assistant-export-import"
 import { createLogger, generateRequestId, startTimer } from "@/lib/logger"
 
@@ -78,15 +78,8 @@ export async function POST(request: NextRequest) {
 
     log.info("Starting import", { assistantCount: importData.assistants.length })
 
-    // Get user ID from Cognito sub
-    const userId = await getUserIdByCognitoSubAsNumber(session.sub)
-
-    if (!userId) {
-      return NextResponse.json(
-        { isSuccess: false, message: "User not found" },
-        { status: 404 }
-      )
-    }
+    // Get user ID (provisions if missing)
+    const userId = await resolveUserId(session, requestId)
 
     // Collect all unique model names for mapping
     const modelNames = new Set<string>()

--- a/app/api/execution-results/[id]/download/handler.ts
+++ b/app/api/execution-results/[id]/download/handler.ts
@@ -90,7 +90,7 @@ export async function downloadHandler(
     }
 
     // Resolve user ID (auto-provisions if missing)
-    const userId = await resolveUserId(session)
+    const userId = await resolveUserId(session, requestId)
 
     // Get execution result with all related data - includes access control check
     const result = await getExecutionResultForDownload(resultId, userId)

--- a/app/api/execution-results/[id]/download/handler.ts
+++ b/app/api/execution-results/[id]/download/handler.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from "next/server"
 import { getServerSession } from "@/lib/auth/server-session"
 import { resolveUserId } from "@/lib/auth/resolve-user"
 import { createLogger, generateRequestId, startTimer, sanitizeForLogging } from "@/lib/logger"
-import { ErrorFactories } from "@/lib/error-utils"
+import { ErrorFactories, handleError } from "@/lib/error-utils"
 import { getExecutionResultForDownload } from "@/lib/db/drizzle"
 import { getBrandingConfig } from "@/lib/branding"
 
@@ -13,12 +13,9 @@ function sanitizeMarkdownContent(content: string): string {
   }
 
   return content
-    // Remove null bytes first
+    // Remove null bytes (\u0000 and \0 are the same character in JS)
     // eslint-disable-next-line no-control-regex
     .replace(/\u0000/g, '')
-    // eslint-disable-next-line no-control-regex
-    .replace(/\u0000/g, '')
-    .replace(/\0/g, '')
     // Remove dangerous HTML/XML elements
     .replace(/[<>]/g, '') // Remove angle brackets that could contain HTML/XML
     .replace(/javascript:/gi, '') // Remove javascript: URLs
@@ -155,44 +152,12 @@ export async function downloadHandler(
 
   } catch (error) {
     timer({ status: "error" })
-
-    // Log detailed error internally but return generic message to client
-    log.error("Failed to download execution result", {
-      error: error instanceof Error ? error.message : 'Unknown error',
-      resultId: sanitizeForLogging((await params).id),
-      stack: error instanceof Error ? error.stack : undefined
-    })
-
-    // Determine appropriate error status and message based on error type
-    if (error && typeof error === 'object' && 'name' in error) {
-      switch (error.name) {
-        case 'InvalidInputError':
-          return NextResponse.json(
-            { error: "Invalid execution result ID" },
-            { status: 400 }
-          )
-        case 'AuthNoSessionError':
-          return NextResponse.json(
-            { error: "Authentication required" },
-            { status: 401 }
-          )
-        case 'DbRecordNotFoundError':
-          return NextResponse.json(
-            { error: "Execution result not found" },
-            { status: 404 }
-          )
-        default:
-          // Return generic error message to client for server errors
-          return NextResponse.json(
-            { error: "Unable to download execution result" },
-            { status: 500 }
-          )
-      }
-    }
-
-    // Fallback for unknown error types
     return NextResponse.json(
-      { error: "Unable to download execution result" },
+      handleError(error, "Failed to download execution result", {
+        context: "GET /api/execution-results/[id]/download",
+        requestId,
+        operation: "downloadExecutionResult"
+      }),
       { status: 500 }
     )
   }
@@ -276,12 +241,9 @@ function generateSafeFilename(scheduleName: string): string {
 
   return scheduleName
     .toLowerCase()
-    // Remove null bytes (multiple representations)
+    // Remove null bytes (\u0000 and \0 are the same character in JS)
     // eslint-disable-next-line no-control-regex
-    .replace(/\u0000/g, '') // Actual null byte
-    // eslint-disable-next-line no-control-regex
-    .replace(/\u0000/g, '') // Unicode null
-    .replace(/\0/g, '') // Null character
+    .replace(/\u0000/g, '')
     // Remove path traversal patterns
     .replace(/\.\./g, '') // Remove dot-dot
     .replace(/\//g, '') // Remove forward slash

--- a/app/api/execution-results/[id]/download/handler.ts
+++ b/app/api/execution-results/[id]/download/handler.ts
@@ -153,6 +153,10 @@ export async function downloadHandler(
 
   } catch (error) {
     timer({ status: "error" })
+    log.error("Failed to download execution result", {
+      error: error instanceof Error ? error.message : String(error),
+      stack: error instanceof Error ? error.stack : undefined,
+    })
     return executionResultErrorResponse(error, "Unable to download execution result")
   }
 }

--- a/app/api/execution-results/[id]/download/handler.ts
+++ b/app/api/execution-results/[id]/download/handler.ts
@@ -1,8 +1,9 @@
 import { NextRequest, NextResponse } from "next/server"
 import { getServerSession } from "@/lib/auth/server-session"
+import { resolveUserId } from "@/lib/auth/resolve-user"
 import { createLogger, generateRequestId, startTimer, sanitizeForLogging } from "@/lib/logger"
 import { ErrorFactories } from "@/lib/error-utils"
-import { getExecutionResultForDownload, getUserIdByCognitoSub } from "@/lib/db/drizzle"
+import { getExecutionResultForDownload } from "@/lib/db/drizzle"
 import { getBrandingConfig } from "@/lib/branding"
 
 // Content sanitization for markdown to prevent XSS
@@ -88,14 +89,8 @@ export async function downloadHandler(
       throw ErrorFactories.authNoSession()
     }
 
-    // Get user ID from database using cognito sub
-    const userIdString = await getUserIdByCognitoSub(session.sub)
-
-    if (!userIdString) {
-      throw ErrorFactories.dbRecordNotFound("users", session.sub)
-    }
-
-    const userId = Number(userIdString)
+    // Resolve user ID (auto-provisions if missing)
+    const userId = await resolveUserId(session)
 
     // Get execution result with all related data - includes access control check
     const result = await getExecutionResultForDownload(resultId, userId)

--- a/app/api/execution-results/[id]/download/handler.ts
+++ b/app/api/execution-results/[id]/download/handler.ts
@@ -2,7 +2,8 @@ import { NextRequest, NextResponse } from "next/server"
 import { getServerSession } from "@/lib/auth/server-session"
 import { resolveUserId } from "@/lib/auth/resolve-user"
 import { createLogger, generateRequestId, startTimer, sanitizeForLogging } from "@/lib/logger"
-import { ErrorFactories, handleError } from "@/lib/error-utils"
+import { ErrorFactories } from "@/lib/error-utils"
+import { executionResultErrorResponse } from "@/lib/api/execution-result-error"
 import { getExecutionResultForDownload } from "@/lib/db/drizzle"
 import { getBrandingConfig } from "@/lib/branding"
 
@@ -152,14 +153,7 @@ export async function downloadHandler(
 
   } catch (error) {
     timer({ status: "error" })
-    return NextResponse.json(
-      handleError(error, "Failed to download execution result", {
-        context: "GET /api/execution-results/[id]/download",
-        requestId,
-        operation: "downloadExecutionResult"
-      }),
-      { status: 500 }
-    )
+    return executionResultErrorResponse(error, "Unable to download execution result")
   }
 }
 

--- a/app/api/execution-results/[id]/route.ts
+++ b/app/api/execution-results/[id]/route.ts
@@ -67,6 +67,10 @@ async function getHandler(
 
   } catch (error) {
     timer({ status: "error" })
+    log.error("Failed to fetch execution result", {
+      error: error instanceof Error ? error.message : String(error),
+      stack: error instanceof Error ? error.stack : undefined,
+    })
     return executionResultErrorResponse(error, "Unable to fetch execution result")
   }
 }
@@ -117,6 +121,10 @@ async function deleteHandler(
 
   } catch (error) {
     timer({ status: "error" })
+    log.error("Failed to delete execution result", {
+      error: error instanceof Error ? error.message : String(error),
+      stack: error instanceof Error ? error.stack : undefined,
+    })
     return executionResultErrorResponse(error, "Unable to delete execution result")
   }
 }

--- a/app/api/execution-results/[id]/route.ts
+++ b/app/api/execution-results/[id]/route.ts
@@ -2,9 +2,10 @@ import { NextRequest, NextResponse } from "next/server"
 import { getServerSession } from "@/lib/auth/server-session"
 import { resolveUserId } from "@/lib/auth/resolve-user"
 import { createLogger, generateRequestId, startTimer, sanitizeForLogging } from "@/lib/logger"
-import { ErrorFactories, handleError } from "@/lib/error-utils"
+import { ErrorFactories } from "@/lib/error-utils"
 import { getExecutionResultById, deleteExecutionResult } from "@/lib/db/drizzle"
 import type { ExecutionResult } from "@/types/notifications"
+import { executionResultErrorResponse } from "@/lib/api/execution-result-error"
 
 async function getHandler(
   request: NextRequest,
@@ -66,14 +67,7 @@ async function getHandler(
 
   } catch (error) {
     timer({ status: "error" })
-    return NextResponse.json(
-      handleError(error, "Failed to fetch execution result", {
-        context: "GET /api/execution-results/[id]",
-        requestId,
-        operation: "getExecutionResult"
-      }),
-      { status: 500 }
-    )
+    return executionResultErrorResponse(error, "Unable to fetch execution result")
   }
 }
 
@@ -123,14 +117,7 @@ async function deleteHandler(
 
   } catch (error) {
     timer({ status: "error" })
-    return NextResponse.json(
-      handleError(error, "Failed to delete execution result", {
-        context: "DELETE /api/execution-results/[id]",
-        requestId,
-        operation: "deleteExecutionResult"
-      }),
-      { status: 500 }
-    )
+    return executionResultErrorResponse(error, "Unable to delete execution result")
   }
 }
 

--- a/app/api/execution-results/[id]/route.ts
+++ b/app/api/execution-results/[id]/route.ts
@@ -2,21 +2,9 @@ import { NextRequest, NextResponse } from "next/server"
 import { getServerSession } from "@/lib/auth/server-session"
 import { resolveUserId } from "@/lib/auth/resolve-user"
 import { createLogger, generateRequestId, startTimer, sanitizeForLogging } from "@/lib/logger"
-import { ErrorFactories } from "@/lib/error-utils"
+import { ErrorFactories, handleError } from "@/lib/error-utils"
 import { getExecutionResultById, deleteExecutionResult } from "@/lib/db/drizzle"
-
-interface ExecutionResult {
-  id: number
-  scheduledExecutionId: number
-  resultData: Record<string, unknown>
-  status: 'success' | 'failed' | 'running'
-  executedAt: string
-  executionDurationMs: number
-  errorMessage: string | null
-  scheduleName: string
-  userId: number
-  assistantArchitectName: string
-}
+import type { ExecutionResult } from "@/types/notifications"
 
 async function getHandler(
   request: NextRequest,
@@ -78,41 +66,12 @@ async function getHandler(
 
   } catch (error) {
     timer({ status: "error" })
-
-    log.error("Failed to fetch execution result", {
-      error: error instanceof Error ? error.message : 'Unknown error',
-      resultId: sanitizeForLogging((await params).id),
-      stack: error instanceof Error ? error.stack : undefined
-    })
-
-    // Determine appropriate error status and message based on error type
-    if (error && typeof error === 'object' && 'name' in error) {
-      switch (error.name) {
-        case 'InvalidInputError':
-          return NextResponse.json(
-            { error: "Invalid execution result ID" },
-            { status: 400 }
-          )
-        case 'AuthNoSessionError':
-          return NextResponse.json(
-            { error: "Authentication required" },
-            { status: 401 }
-          )
-        case 'DbRecordNotFoundError':
-          return NextResponse.json(
-            { error: "Execution result not found" },
-            { status: 404 }
-          )
-        default:
-          return NextResponse.json(
-            { error: "Unable to fetch execution result" },
-            { status: 500 }
-          )
-      }
-    }
-
     return NextResponse.json(
-      { error: "Unable to fetch execution result" },
+      handleError(error, "Failed to fetch execution result", {
+        context: "GET /api/execution-results/[id]",
+        requestId,
+        operation: "getExecutionResult"
+      }),
       { status: 500 }
     )
   }
@@ -164,41 +123,12 @@ async function deleteHandler(
 
   } catch (error) {
     timer({ status: "error" })
-
-    log.error("Failed to delete execution result", {
-      error: error instanceof Error ? error.message : 'Unknown error',
-      resultId: sanitizeForLogging((await params).id),
-      stack: error instanceof Error ? error.stack : undefined
-    })
-
-    // Determine appropriate error status and message based on error type
-    if (error && typeof error === 'object' && 'name' in error) {
-      switch (error.name) {
-        case 'InvalidInputError':
-          return NextResponse.json(
-            { error: "Invalid execution result ID" },
-            { status: 400 }
-          )
-        case 'AuthNoSessionError':
-          return NextResponse.json(
-            { error: "Authentication required" },
-            { status: 401 }
-          )
-        case 'DbRecordNotFoundError':
-          return NextResponse.json(
-            { error: "Execution result not found" },
-            { status: 404 }
-          )
-        default:
-          return NextResponse.json(
-            { error: "Unable to delete execution result" },
-            { status: 500 }
-          )
-      }
-    }
-
     return NextResponse.json(
-      { error: "Unable to delete execution result" },
+      handleError(error, "Failed to delete execution result", {
+        context: "DELETE /api/execution-results/[id]",
+        requestId,
+        operation: "deleteExecutionResult"
+      }),
       { status: 500 }
     )
   }

--- a/app/api/execution-results/[id]/route.ts
+++ b/app/api/execution-results/[id]/route.ts
@@ -1,8 +1,9 @@
 import { NextRequest, NextResponse } from "next/server"
 import { getServerSession } from "@/lib/auth/server-session"
+import { resolveUserId } from "@/lib/auth/resolve-user"
 import { createLogger, generateRequestId, startTimer, sanitizeForLogging } from "@/lib/logger"
 import { ErrorFactories } from "@/lib/error-utils"
-import { getExecutionResultById, getUserIdByCognitoSub, deleteExecutionResult } from "@/lib/db/drizzle"
+import { getExecutionResultById, deleteExecutionResult } from "@/lib/db/drizzle"
 
 interface ExecutionResult {
   id: number
@@ -42,17 +43,8 @@ async function getHandler(
       throw ErrorFactories.authNoSession()
     }
 
-    // Get user ID from database using cognito sub
-    const userIdString = await getUserIdByCognitoSub(session.sub)
-
-    if (!userIdString) {
-      throw ErrorFactories.dbRecordNotFound("users", session.sub)
-    }
-
-    const userId = Number(userIdString)
-    if (!Number.isInteger(userId) || userId <= 0) {
-      throw ErrorFactories.invalidInput("userId", userIdString, "must be a positive integer")
-    }
+    // Resolve user ID (auto-provisions if missing)
+    const userId = await resolveUserId(session)
 
     // Get execution result with all related data - includes access control check
     const result = await getExecutionResultById(resultId, userId)
@@ -151,17 +143,8 @@ async function deleteHandler(
       throw ErrorFactories.authNoSession()
     }
 
-    // Get user ID from database using cognito sub
-    const userIdString = await getUserIdByCognitoSub(session.sub)
-
-    if (!userIdString) {
-      throw ErrorFactories.dbRecordNotFound("users", session.sub)
-    }
-
-    const userId = Number(userIdString)
-    if (!Number.isInteger(userId) || userId <= 0) {
-      throw ErrorFactories.invalidInput("userId", userIdString, "must be a positive integer")
-    }
+    // Resolve user ID (auto-provisions if missing)
+    const userId = await resolveUserId(session)
 
     // Delete the execution result with access control check
     const deleted = await deleteExecutionResult(resultId, userId)

--- a/app/api/execution-results/[id]/route.ts
+++ b/app/api/execution-results/[id]/route.ts
@@ -44,7 +44,7 @@ async function getHandler(
     }
 
     // Resolve user ID (auto-provisions if missing)
-    const userId = await resolveUserId(session)
+    const userId = await resolveUserId(session, requestId)
 
     // Get execution result with all related data - includes access control check
     const result = await getExecutionResultById(resultId, userId)
@@ -144,7 +144,7 @@ async function deleteHandler(
     }
 
     // Resolve user ID (auto-provisions if missing)
-    const userId = await resolveUserId(session)
+    const userId = await resolveUserId(session, requestId)
 
     // Delete the execution result with access control check
     const deleted = await deleteExecutionResult(resultId, userId)

--- a/app/api/execution-results/recent/route.ts
+++ b/app/api/execution-results/recent/route.ts
@@ -1,8 +1,9 @@
 import { NextRequest, NextResponse } from "next/server"
 import { getServerSession } from "@/lib/auth/server-session"
+import { resolveUserId } from "@/lib/auth/resolve-user"
 import { createLogger, generateRequestId, startTimer, sanitizeForLogging } from "@/lib/logger"
 import { handleError, ErrorFactories, createSuccess } from "@/lib/error-utils"
-import { getRecentExecutionResults, getUserIdByCognitoSub } from "@/lib/db/drizzle"
+import { getRecentExecutionResults } from "@/lib/db/drizzle"
 import type { ExecutionResult } from "@/types/notifications"
 
 export async function GET(request: NextRequest) {
@@ -20,14 +21,8 @@ export async function GET(request: NextRequest) {
       throw ErrorFactories.authNoSession()
     }
 
-    // Get user ID from database using cognito sub
-    const userIdString = await getUserIdByCognitoSub(session.sub)
-
-    if (!userIdString) {
-      throw ErrorFactories.dbRecordNotFound("users", session.sub)
-    }
-
-    const userId = Number(userIdString)
+    // Resolve user ID (auto-provisions if missing)
+    const userId = await resolveUserId(session)
     log.info("Fetching recent execution results for user", { userId: sanitizeForLogging(userId) })
 
     // Get query parameters

--- a/app/api/execution-results/recent/route.ts
+++ b/app/api/execution-results/recent/route.ts
@@ -22,7 +22,7 @@ export async function GET(request: NextRequest) {
     }
 
     // Resolve user ID (auto-provisions if missing)
-    const userId = await resolveUserId(session)
+    const userId = await resolveUserId(session, requestId)
     log.info("Fetching recent execution results for user", { userId: sanitizeForLogging(userId) })
 
     // Get query parameters

--- a/app/api/ideas/[id]/notes/route.ts
+++ b/app/api/ideas/[id]/notes/route.ts
@@ -1,6 +1,7 @@
 import { getServerSession } from '@/lib/auth/server-session';
 import { NextResponse } from 'next/server';
-import { getIdeaNotes, addNote, getUserIdByCognitoSub } from '@/lib/db/drizzle';
+import { getIdeaNotes, addNote } from '@/lib/db/drizzle';
+import { resolveUserId } from '@/lib/auth/resolve-user';
 import { hasRole } from '@/utils/roles';
 import { createLogger, generateRequestId, startTimer } from '@/lib/logger';
 export async function GET(request: Request, { params }: { params: Promise<{ id: string }> }) {
@@ -81,14 +82,8 @@ export async function POST(request: Request, context: { params: Promise<{ id: st
       return new NextResponse('Missing content', { status: 400 });
     }
 
-    // Get the user's numeric ID from their cognito_sub
-    const userIdString = await getUserIdByCognitoSub(session.sub);
-
-    if (!userIdString) {
-      return new NextResponse('User not found', { status: 404 });
-    }
-
-    const userId = Number(userIdString);
+    // Get the user's numeric ID (provisions if missing)
+    const userId = await resolveUserId(session, requestId);
 
     // Add the note
     const newNote = await addNote(ideaId, userId, content);

--- a/app/api/ideas/[id]/route.ts
+++ b/app/api/ideas/[id]/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse, NextRequest } from 'next/server';
 import { getServerSession } from '@/lib/auth/server-session';
-import { getUserIdByCognitoSub, updateIdea } from '@/lib/db/drizzle';
+import { updateIdea } from '@/lib/db/drizzle';
+import { resolveUserId } from '@/lib/auth/resolve-user';
 import { executeTransaction as drizzleTransaction, ideas, ideaVotes, ideaNotes } from '@/lib/db/drizzle-client';
 import { hasRole } from '@/utils/roles';
 import { createLogger, generateRequestId, startTimer } from '@/lib/logger';
@@ -50,14 +51,8 @@ export async function PATCH(
     if (body.status) {
       updates.status = body.status;
       if (body.status === 'completed') {
-        // Get the user's numeric ID from their cognito_sub
-        const userIdString = await getUserIdByCognitoSub(session.sub);
-
-        if (!userIdString) {
-          return NextResponse.json({ error: 'User not found' }, { status: 404 });
-        }
-
-        updates.completedBy = userIdString;
+        const userId = await resolveUserId(session, requestId);
+        updates.completedBy = String(userId);
       }
     }
 

--- a/app/api/ideas/[id]/status/route.ts
+++ b/app/api/ideas/[id]/status/route.ts
@@ -1,6 +1,7 @@
 import { getServerSession } from '@/lib/auth/server-session';
 import { NextResponse } from 'next/server';
-import { getUserIdByCognitoSub, updateIdeaStatus } from '@/lib/db/drizzle';
+import { updateIdeaStatus } from '@/lib/db/drizzle';
+import { resolveUserId } from '@/lib/auth/resolve-user';
 import { hasRole } from '@/utils/roles';
 import { createLogger, generateRequestId, startTimer } from '@/lib/logger';
 export async function PATCH(request: Request, context: { params: Promise<{ id: string }> }) {
@@ -37,14 +38,8 @@ export async function PATCH(request: Request, context: { params: Promise<{ id: s
 
     let completedBy: string | undefined;
     if (status === 'completed') {
-      // Get the user's numeric ID from their cognito_sub
-      const userIdString = await getUserIdByCognitoSub(session.sub);
-
-      if (!userIdString) {
-        return new NextResponse('User not found', { status: 404 });
-      }
-
-      completedBy = userIdString;
+      const userId = await resolveUserId(session, requestId);
+      completedBy = String(userId);
     }
 
     const result = await updateIdeaStatus(ideaId, status, completedBy);

--- a/app/api/ideas/[id]/vote/route.ts
+++ b/app/api/ideas/[id]/vote/route.ts
@@ -1,6 +1,7 @@
 import { getServerSession } from '@/lib/auth/server-session';
 import { NextResponse } from 'next/server';
-import { getUserIdByCognitoSub, hasUserVoted, addVote, removeVote } from '@/lib/db/drizzle';
+import { hasUserVoted, addVote, removeVote } from '@/lib/db/drizzle';
+import { resolveUserId } from '@/lib/auth/resolve-user';
 import { hasRole } from '@/utils/roles';
 import { createLogger, generateRequestId, startTimer } from '@/lib/logger';
 
@@ -42,16 +43,8 @@ export async function POST(request: Request, { params }: { params: Promise<{ id:
 
     log.debug("Processing vote for idea", { ideaId });
 
-    // Get the user's numeric ID from their cognito_sub
-    const userIdString = await getUserIdByCognitoSub(session.sub);
-
-    if (!userIdString) {
-      log.warn("User not found", { cognitoSub: session.sub });
-      timer({ status: "error", reason: "user_not_found" });
-      return new NextResponse('User not found', { status: 404, headers: { "X-Request-Id": requestId } });
-    }
-
-    const userId = Number(userIdString);
+    // Get the user's numeric ID (provisions if missing)
+    const userId = await resolveUserId(session, requestId);
 
     // Check if the user has already voted
     const alreadyVoted = await hasUserVoted(ideaId, userId);

--- a/app/api/ideas/route.ts
+++ b/app/api/ideas/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { getServerSession } from '@/lib/auth/server-session';
-import { getIdeas, getUserVotedIdeaIds, createIdea } from '@/lib/db/drizzle';
+import { getIdeas, getUserVotedIdeaIds, createIdea, getUserIdByCognitoSubAsNumber } from '@/lib/db/drizzle';
 import { resolveUserId } from '@/lib/auth/resolve-user';
 import { hasRole } from '@/utils/roles';
 import { createLogger, generateRequestId, startTimer } from '@/lib/logger';
@@ -28,13 +28,17 @@ export async function GET() {
     // Get all ideas with creator names and counts
     const allIdeas = await getIdeas();
 
-    // Get the user's numeric ID for vote checking
-    const currentUserId = await resolveUserId(session, requestId);
-    const userVotedIdeaIds = await getUserVotedIdeaIds(currentUserId);
+    // Look up existing user ID without provisioning — GET should not create users.
+    // If the user has no DB record yet, return ideas with hasVoted: false as a
+    // graceful fallback; provisioning happens on the next write action.
+    const currentUserId = await getUserIdByCognitoSubAsNumber(session.sub);
+    const votedIds = currentUserId !== null
+      ? await getUserVotedIdeaIds(currentUserId)
+      : new Set<number>();
 
     const ideasWithVotes = allIdeas.map((idea) => ({
       ...idea,
-      hasVoted: userVotedIdeaIds.has(idea.id)
+      hasVoted: votedIds.has(idea.id)
     }));
 
     log.info("Ideas retrieved successfully", { count: ideasWithVotes.length });

--- a/app/api/ideas/route.ts
+++ b/app/api/ideas/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { getServerSession } from '@/lib/auth/server-session';
-import { getIdeas, getUserVotedIdeaIds, getUserIdByCognitoSub, createIdea } from '@/lib/db/drizzle';
+import { getIdeas, getUserVotedIdeaIds, createIdea } from '@/lib/db/drizzle';
+import { resolveUserId } from '@/lib/auth/resolve-user';
 import { hasRole } from '@/utils/roles';
 import { createLogger, generateRequestId, startTimer } from '@/lib/logger';
 
@@ -28,13 +29,8 @@ export async function GET() {
     const allIdeas = await getIdeas();
 
     // Get the user's numeric ID for vote checking
-    const currentUserIdString = await getUserIdByCognitoSub(session.sub);
-    const currentUserId = currentUserIdString ? Number(currentUserIdString) : null;
-
-    let userVotedIdeaIds = new Set<number>();
-    if (currentUserId) {
-      userVotedIdeaIds = await getUserVotedIdeaIds(currentUserId);
-    }
+    const currentUserId = await resolveUserId(session, requestId);
+    const userVotedIdeaIds = await getUserVotedIdeaIds(currentUserId);
 
     const ideasWithVotes = allIdeas.map((idea) => ({
       ...idea,
@@ -103,19 +99,8 @@ export async function POST(request: Request) {
       });
     }
 
-    // Get the user's numeric ID from their cognito_sub
-    const userIdString = await getUserIdByCognitoSub(session.sub);
-
-    if (!userIdString) {
-      log.error("User not found in database", { cognitoSub: session.sub });
-      timer({ status: "error", reason: "user_not_found" });
-      return new NextResponse('User not found', {
-        status: 404,
-        headers: { "X-Request-Id": requestId }
-      });
-    }
-
-    const userId = Number(userIdString);
+    // Get the user's numeric ID (provisions if missing)
+    const userId = await resolveUserId(session, requestId);
 
     const newIdea = await createIdea({
       title,

--- a/app/api/nexus/conversations/[id]/fork/route.ts
+++ b/app/api/nexus/conversations/[id]/fork/route.ts
@@ -4,8 +4,8 @@ import {
   getConversationById,
   recordConversationEvent,
   updateConversation,
-  getUserIdByCognitoSubAsNumber,
 } from '@/lib/db/drizzle';
+import { resolveUserId } from '@/lib/auth/resolve-user';
 import { executeQuery } from '@/lib/db/drizzle-client';
 import { nexusConversations } from '@/lib/db/schema';
 
@@ -43,15 +43,8 @@ export async function POST(
       return new Response('Unauthorized', { status: 401 });
     }
     
-    const userCognitoSub = session.sub;
-
-    // Get numeric user ID
-    const userId = await getUserIdByCognitoSubAsNumber(userCognitoSub);
-    if (!userId) {
-      log.warn('User not found', { cognitoSub: userCognitoSub });
-      timer({ status: 'error', reason: 'user_not_found' });
-      return new Response('User not found', { status: 404 });
-    }
+    // Get numeric user ID (provisions if missing)
+    const userId = await resolveUserId(session, requestId);
 
     // Parse request body
     const body: ForkRequest = await req.json();

--- a/app/api/notifications/[id]/read/route.ts
+++ b/app/api/notifications/[id]/read/route.ts
@@ -1,8 +1,9 @@
 import { NextRequest, NextResponse } from "next/server"
 import { getServerSession } from "@/lib/auth/server-session"
+import { resolveUserId } from "@/lib/auth/resolve-user"
 import { createLogger, generateRequestId, startTimer, sanitizeForLogging } from "@/lib/logger"
 import { handleError, ErrorFactories, createSuccess } from "@/lib/error-utils"
-import { markNotificationAsRead, getUserIdByCognitoSub } from "@/lib/db/drizzle"
+import { markNotificationAsRead } from "@/lib/db/drizzle"
 
 
 export async function PUT(request: NextRequest, context: { params: Promise<{ id: string }> }) {
@@ -26,14 +27,8 @@ export async function PUT(request: NextRequest, context: { params: Promise<{ id:
       throw ErrorFactories.authNoSession()
     }
 
-    // Get user ID from database using cognito sub
-    const userIdString = await getUserIdByCognitoSub(session.sub)
-
-    if (!userIdString) {
-      throw ErrorFactories.dbRecordNotFound("users", session.sub)
-    }
-
-    const userId = Number(userIdString)
+    // Resolve user ID (auto-provisions if missing)
+    const userId = await resolveUserId(session)
 
     // Verify notification belongs to user and update status
     const result = await markNotificationAsRead(notificationId, userId)

--- a/app/api/notifications/[id]/read/route.ts
+++ b/app/api/notifications/[id]/read/route.ts
@@ -28,7 +28,7 @@ export async function PUT(request: NextRequest, context: { params: Promise<{ id:
     }
 
     // Resolve user ID (auto-provisions if missing)
-    const userId = await resolveUserId(session)
+    const userId = await resolveUserId(session, requestId)
 
     // Verify notification belongs to user and update status
     const result = await markNotificationAsRead(notificationId, userId)

--- a/app/api/notifications/read-all/route.ts
+++ b/app/api/notifications/read-all/route.ts
@@ -21,7 +21,7 @@ export async function PUT() {
     }
 
     // Resolve user ID (auto-provisions if missing)
-    const userId = await resolveUserId(session)
+    const userId = await resolveUserId(session, requestId)
     log.info("Marking all notifications as read for user", { userId: sanitizeForLogging(userId) })
 
     // Update all unread notifications for the user

--- a/app/api/notifications/read-all/route.ts
+++ b/app/api/notifications/read-all/route.ts
@@ -1,8 +1,9 @@
 import { NextResponse } from "next/server"
 import { getServerSession } from "@/lib/auth/server-session"
+import { resolveUserId } from "@/lib/auth/resolve-user"
 import { createLogger, generateRequestId, startTimer, sanitizeForLogging } from "@/lib/logger"
 import { handleError, ErrorFactories, createSuccess } from "@/lib/error-utils"
-import { markAllNotificationsAsRead, getUserIdByCognitoSub } from "@/lib/db/drizzle"
+import { markAllNotificationsAsRead } from "@/lib/db/drizzle"
 
 export async function PUT() {
   const requestId = generateRequestId()
@@ -19,14 +20,8 @@ export async function PUT() {
       throw ErrorFactories.authNoSession()
     }
 
-    // Get user ID from database using cognito sub
-    const userIdString = await getUserIdByCognitoSub(session.sub)
-
-    if (!userIdString) {
-      throw ErrorFactories.dbRecordNotFound("users", session.sub)
-    }
-
-    const userId = Number(userIdString)
+    // Resolve user ID (auto-provisions if missing)
+    const userId = await resolveUserId(session)
     log.info("Marking all notifications as read for user", { userId: sanitizeForLogging(userId) })
 
     // Update all unread notifications for the user

--- a/app/api/notifications/route.ts
+++ b/app/api/notifications/route.ts
@@ -1,8 +1,9 @@
 import { NextRequest, NextResponse } from "next/server"
 import { getServerSession } from "@/lib/auth/server-session"
+import { resolveUserId } from "@/lib/auth/resolve-user"
 import { createLogger, generateRequestId, startTimer, sanitizeForLogging } from "@/lib/logger"
 import { handleError, ErrorFactories, createSuccess } from "@/lib/error-utils"
-import { getUserNotifications, getUserIdByCognitoSub } from "@/lib/db/drizzle"
+import { getUserNotifications } from "@/lib/db/drizzle"
 import type { UserNotification } from "@/types/notifications"
 
 export async function GET(request: NextRequest) {
@@ -20,14 +21,8 @@ export async function GET(request: NextRequest) {
       throw ErrorFactories.authNoSession()
     }
 
-    // Get user ID from database using cognito sub
-    const userIdString = await getUserIdByCognitoSub(session.sub)
-
-    if (!userIdString) {
-      throw ErrorFactories.dbRecordNotFound("users", session.sub)
-    }
-
-    const userId = Number(userIdString)
+    // Resolve user ID (auto-provisions if missing)
+    const userId = await resolveUserId(session)
     log.info("Fetching notifications for user", { userId: sanitizeForLogging(userId) })
 
     // Get query parameters

--- a/app/api/notifications/route.ts
+++ b/app/api/notifications/route.ts
@@ -22,7 +22,7 @@ export async function GET(request: NextRequest) {
     }
 
     // Resolve user ID (auto-provisions if missing)
-    const userId = await resolveUserId(session)
+    const userId = await resolveUserId(session, requestId)
     log.info("Fetching notifications for user", { userId: sanitizeForLogging(userId) })
 
     // Get query parameters

--- a/lib/api/execution-result-error.ts
+++ b/lib/api/execution-result-error.ts
@@ -1,0 +1,28 @@
+import { NextResponse } from "next/server"
+import { ErrorCode } from "@/types/error-types"
+
+/**
+ * Map a typed error to an appropriate HTTP response for execution-result API routes.
+ *
+ * Uses ErrorCode (set by ErrorFactories) to determine status code — not error.name
+ * string matching, which breaks on refactoring, and not handleError(), which returns
+ * ActionState shape (designed for Server Actions, not API routes).
+ */
+export function executionResultErrorResponse(
+  error: unknown,
+  fallbackMessage: string
+): NextResponse {
+  if (error !== null && typeof error === "object" && "code" in error) {
+    const code = (error as { code: unknown }).code
+    if (code === ErrorCode.INVALID_INPUT || code === ErrorCode.MISSING_REQUIRED_FIELD) {
+      return NextResponse.json({ error: "Invalid execution result ID" }, { status: 400 })
+    }
+    if (code === ErrorCode.AUTH_NO_SESSION || code === ErrorCode.AUTH_INVALID_TOKEN) {
+      return NextResponse.json({ error: "Authentication required" }, { status: 401 })
+    }
+    if (code === ErrorCode.DB_RECORD_NOT_FOUND) {
+      return NextResponse.json({ error: "Execution result not found" }, { status: 404 })
+    }
+  }
+  return NextResponse.json({ error: fallbackMessage }, { status: 500 })
+}

--- a/lib/auth/resolve-user.ts
+++ b/lib/auth/resolve-user.ts
@@ -31,8 +31,13 @@ import type { CognitoSession } from "./server-session"
  * 2. If not found, look up by email and link cognito_sub (migration path)
  * 3. If still not found, create user via UPSERT and assign default role (new user path)
  *
+ * **Write side-effect**: On the first call for a new Cognito user, this function
+ * creates a users row and assigns a default role. Callers on read-only (GET) routes
+ * accept this one-time write — it is intentional for JIT provisioning.
+ *
  * @returns Numeric user ID (never null — provisions if missing)
- * @throws If database operations fail or session has no email for a new user
+ * @throws ErrorFactories.missingRequiredField if session has no email (new user only)
+ * @throws If database operations fail
  */
 export async function resolveUserId(
   session: CognitoSession,
@@ -42,7 +47,7 @@ export async function resolveUserId(
 
   // Fast path: user exists (returns null on miss, throws TypeError on malformed ID)
   const existingId = await getUserIdByCognitoSubAsNumber(session.sub)
-  if (existingId) {
+  if (existingId !== null) {
     return existingId
   }
 
@@ -119,7 +124,7 @@ export async function resolveUserId(
   // Numeric username prefix → student (K-12 district convention: student IDs
   // are all-digit numbers, e.g. 123456@psd401.net). Non-numeric → staff.
   // Defaults to least-privilege (student) when username cannot be determined.
-  const isNumeric = username.length > 0 && /^\d+$/.test(username)
+  const isNumeric = /^\d+$/.test(username) // already false for empty strings
   const defaultRole = isNumeric ? "student" : "staff"
 
   try {
@@ -131,11 +136,25 @@ export async function resolveUserId(
   } catch (error) {
     // Role assignment failure is non-fatal — user can still access the app,
     // and getCurrentUserAction will handle role assignment on next full login.
-    log.warn("Default role assignment failed — user provisioned without role", {
-      userId,
-      attemptedRole: defaultRole,
-      error: error instanceof Error ? error.message : "Unknown error",
-    })
+    // Distinguish a missing role record (expected in misconfigured envs) from
+    // infrastructure failures (DB connectivity, deadlock) which warrant error-level.
+    const isRoleNotFound =
+      error !== null &&
+      typeof error === "object" &&
+      "code" in error &&
+      (error as { code: unknown }).code === ErrorCode.DB_RECORD_NOT_FOUND
+    if (isRoleNotFound) {
+      log.warn("Default role not found in database — user provisioned without role", {
+        userId,
+        attemptedRole: defaultRole,
+      })
+    } else {
+      log.error("Role assignment failed — infrastructure error; user provisioned without role", {
+        userId,
+        attemptedRole: defaultRole,
+        error: error instanceof Error ? error.message : "Unknown error",
+      })
+    }
   }
 
   return userId

--- a/lib/auth/resolve-user.ts
+++ b/lib/auth/resolve-user.ts
@@ -14,26 +14,29 @@
 import {
   getUserIdByCognitoSub,
   getUserByEmail,
+  updateUser,
   createUser,
-  getRoleByName,
-  assignRoleToUser,
+  addUserRole,
 } from "@/lib/db/drizzle"
-import { createLogger } from "@/lib/logger"
+import { createLogger, sanitizeForLogging } from "@/lib/logger"
 import type { CognitoSession } from "./server-session"
 
 /**
  * Resolve a Cognito session to a numeric database user ID.
  *
  * Flow:
- * 1. Look up user by cognito_sub
- * 2. If not found, look up by email and link cognito_sub
- * 3. If still not found, create user via UPSERT and assign default role
+ * 1. Look up user by cognito_sub (fast path)
+ * 2. If not found, look up by email and link cognito_sub (migration path)
+ * 3. If still not found, create user via UPSERT and assign default role (new user path)
  *
  * @returns Numeric user ID (never null — provisions if missing)
- * @throws If database operations fail
+ * @throws If database operations fail or session has no email for a new user
  */
-export async function resolveUserId(session: CognitoSession): Promise<number> {
-  const log = createLogger({ module: "resolveUserId" })
+export async function resolveUserId(
+  session: CognitoSession,
+  requestId?: string
+): Promise<number> {
+  const log = createLogger({ module: "resolveUserId", requestId })
 
   // Fast path: user exists
   const existingId = await getUserIdByCognitoSub(session.sub)
@@ -43,11 +46,12 @@ export async function resolveUserId(session: CognitoSession): Promise<number> {
 
   // Slow path: provision the user
   log.info("User not found by Cognito sub — provisioning", {
-    cognitoSub: session.sub,
+    cognitoSub: sanitizeForLogging(session.sub),
     hasEmail: !!session.email,
   })
 
-  // Check by email (migration from old auth)
+  // Check by email (migration from old auth — link the new cognitoSub to
+  // the existing record rather than creating a duplicate row)
   if (session.email) {
     try {
       const byEmail = await getUserByEmail(session.email)
@@ -55,42 +59,75 @@ export async function resolveUserId(session: CognitoSession): Promise<number> {
         log.info("User found by email, linking Cognito sub", {
           userId: byEmail.id,
         })
-        // updateUser is not needed here — createUser UPSERT will handle it
-        // Just fall through to the UPSERT below
+        // MUST explicitly update cognitoSub — createUser UPSERT conflicts on
+        // cognitoSub, not email. Without this call a duplicate row is inserted.
+        // Mirrors getCurrentUserAction.ts:100
+        await updateUser(byEmail.id, { cognitoSub: session.sub })
+        return byEmail.id
       }
-    } catch {
-      // Not found by email — continue to create
+    } catch (error) {
+      // getUserByEmail throws dbRecordNotFound when not found — only catch that.
+      // Re-throw real DB errors (connection failures, timeouts, etc.)
+      const isNotFound =
+        error instanceof Error && error.message.toLowerCase().includes("not found")
+      if (!isNotFound) {
+        throw error
+      }
+      // User not found by email — fall through to create
     }
   }
 
-  // Create via UPSERT (safe for concurrent requests)
-  const username = session.email?.split("@")[0] || ""
+  // New user: create via UPSERT (safe for concurrent requests)
+  const username = session.email?.split("@")[0] ?? ""
+
+  // Require a real email for new users — synthetic addresses create permanent
+  // bad data in the users table and break downstream notification delivery.
+  if (!session.email) {
+    log.warn("Cannot provision user: session has no email address", {
+      cognitoSub: sanitizeForLogging(session.sub),
+    })
+    throw new Error("Cannot provision user: session contains no email address")
+  }
+
   const firstName = session.givenName || username || "User"
   const lastName = session.familyName || undefined
 
   const newUser = await createUser({
     cognitoSub: session.sub,
-    email: session.email || `${session.sub}@cognito.local`,
+    email: session.email,
     firstName,
     lastName,
   })
 
-  const userId = newUser.id as number
+  // Guard against UPSERT returning no rows (DB trigger, RLS, permission error)
+  const userId = newUser?.id
+  if (!userId || typeof userId !== "number" || userId <= 0) {
+    throw new Error(
+      `createUser UPSERT returned no valid ID for cognitoSub: ${sanitizeForLogging(session.sub)}`
+    )
+  }
 
-  // Assign default role (student for numeric usernames, staff otherwise)
-  const isNumeric = /^\d+$/.test(username)
+  // Assign default role using addUserRole, which runs in a transaction and
+  // increments role_version for session cache invalidation.
+  // Numeric username prefix → student (K-12 district convention: student IDs
+  // are all-digit numbers, e.g. 123456@psd401.net). Non-numeric → staff.
+  // Defaults to least-privilege (student) when username cannot be determined.
+  const isNumeric = username.length > 0 && /^\d+$/.test(username)
   const defaultRole = isNumeric ? "student" : "staff"
-  const role = await getRoleByName(defaultRole)
-  if (role) {
-    await assignRoleToUser(userId, role.id)
+
+  try {
+    await addUserRole(userId, defaultRole)
     log.info("User provisioned with default role", {
       userId,
       role: defaultRole,
     })
-  } else {
-    log.warn("Default role not found — user created without role", {
+  } catch (error) {
+    // Role assignment failure is non-fatal — user can still access the app,
+    // and getCurrentUserAction will handle role assignment on next full login.
+    log.warn("Default role assignment failed — user provisioned without role", {
       userId,
       attemptedRole: defaultRole,
+      error: error instanceof Error ? error.message : "Unknown error",
     })
   }
 

--- a/lib/auth/resolve-user.ts
+++ b/lib/auth/resolve-user.ts
@@ -12,13 +12,15 @@
  */
 
 import {
-  getUserIdByCognitoSub,
+  getUserIdByCognitoSubAsNumber,
   getUserByEmail,
   updateUser,
   createUser,
   addUserRole,
 } from "@/lib/db/drizzle"
 import { createLogger, sanitizeForLogging } from "@/lib/logger"
+import { ErrorFactories } from "@/lib/error-utils"
+import { ErrorCode } from "@/types/error-types"
 import type { CognitoSession } from "./server-session"
 
 /**
@@ -38,10 +40,10 @@ export async function resolveUserId(
 ): Promise<number> {
   const log = createLogger({ module: "resolveUserId", requestId })
 
-  // Fast path: user exists
-  const existingId = await getUserIdByCognitoSub(session.sub)
+  // Fast path: user exists (returns null on miss, throws TypeError on malformed ID)
+  const existingId = await getUserIdByCognitoSubAsNumber(session.sub)
   if (existingId) {
-    return Number(existingId)
+    return existingId
   }
 
   // Slow path: provision the user
@@ -66,10 +68,14 @@ export async function resolveUserId(
         return byEmail.id
       }
     } catch (error) {
-      // getUserByEmail throws dbRecordNotFound when not found — only catch that.
-      // Re-throw real DB errors (connection failures, timeouts, etc.)
+      // getUserByEmail throws ErrorFactories.dbRecordNotFound when not found.
+      // Check the typed error code — string-match is too broad and risks swallowing
+      // real DB errors whose message happens to contain "not found".
       const isNotFound =
-        error instanceof Error && error.message.toLowerCase().includes("not found")
+        error !== null &&
+        typeof error === "object" &&
+        "code" in error &&
+        (error as { code: unknown }).code === ErrorCode.DB_RECORD_NOT_FOUND
       if (!isNotFound) {
         throw error
       }
@@ -86,7 +92,7 @@ export async function resolveUserId(
     log.warn("Cannot provision user: session has no email address", {
       cognitoSub: sanitizeForLogging(session.sub),
     })
-    throw new Error("Cannot provision user: session contains no email address")
+    throw ErrorFactories.missingRequiredField("email")
   }
 
   const firstName = session.givenName || username || "User"

--- a/lib/auth/resolve-user.ts
+++ b/lib/auth/resolve-user.ts
@@ -83,9 +83,6 @@ export async function resolveUserId(
     }
   }
 
-  // New user: create via UPSERT (safe for concurrent requests)
-  const username = session.email?.split("@")[0] ?? ""
-
   // Require a real email for new users — synthetic addresses create permanent
   // bad data in the users table and break downstream notification delivery.
   if (!session.email) {
@@ -95,6 +92,9 @@ export async function resolveUserId(
     throw ErrorFactories.missingRequiredField("email")
   }
 
+  // New user: create via UPSERT (safe for concurrent requests)
+  // session.email is guaranteed non-null after the guard above
+  const username = session.email.split("@")[0]
   const firstName = session.givenName || username || "User"
   const lastName = session.familyName || undefined
 
@@ -108,8 +108,9 @@ export async function resolveUserId(
   // Guard against UPSERT returning no rows (DB trigger, RLS, permission error)
   const userId = newUser?.id
   if (!userId || typeof userId !== "number" || userId <= 0) {
-    throw new Error(
-      `createUser UPSERT returned no valid ID for cognitoSub: ${sanitizeForLogging(session.sub)}`
+    throw ErrorFactories.dbQueryFailed(
+      "createUser UPSERT",
+      new Error(`Returned no valid ID for cognitoSub: ${sanitizeForLogging(session.sub)}`)
     )
   }
 

--- a/lib/auth/resolve-user.ts
+++ b/lib/auth/resolve-user.ts
@@ -1,0 +1,98 @@
+/**
+ * Resolve a Cognito session to a database user ID.
+ *
+ * Performs JIT (just-in-time) user provisioning if the user
+ * doesn't exist in the database yet. This handles the case where
+ * a valid Cognito session has no corresponding users table record
+ * (e.g., first login, deleted user re-authenticating).
+ *
+ * @see actions/db/get-current-user-action.ts for the full provisioning
+ *      flow (role assignment, name updates, last sign-in tracking).
+ *      This utility performs a lightweight version — lookup + create only.
+ */
+
+import {
+  getUserIdByCognitoSub,
+  getUserByEmail,
+  createUser,
+  getRoleByName,
+  assignRoleToUser,
+} from "@/lib/db/drizzle"
+import { createLogger } from "@/lib/logger"
+import type { CognitoSession } from "./server-session"
+
+/**
+ * Resolve a Cognito session to a numeric database user ID.
+ *
+ * Flow:
+ * 1. Look up user by cognito_sub
+ * 2. If not found, look up by email and link cognito_sub
+ * 3. If still not found, create user via UPSERT and assign default role
+ *
+ * @returns Numeric user ID (never null — provisions if missing)
+ * @throws If database operations fail
+ */
+export async function resolveUserId(session: CognitoSession): Promise<number> {
+  const log = createLogger({ module: "resolveUserId" })
+
+  // Fast path: user exists
+  const existingId = await getUserIdByCognitoSub(session.sub)
+  if (existingId) {
+    return Number(existingId)
+  }
+
+  // Slow path: provision the user
+  log.info("User not found by Cognito sub — provisioning", {
+    cognitoSub: session.sub,
+    hasEmail: !!session.email,
+  })
+
+  // Check by email (migration from old auth)
+  if (session.email) {
+    try {
+      const byEmail = await getUserByEmail(session.email)
+      if (byEmail) {
+        log.info("User found by email, linking Cognito sub", {
+          userId: byEmail.id,
+        })
+        // updateUser is not needed here — createUser UPSERT will handle it
+        // Just fall through to the UPSERT below
+      }
+    } catch {
+      // Not found by email — continue to create
+    }
+  }
+
+  // Create via UPSERT (safe for concurrent requests)
+  const username = session.email?.split("@")[0] || ""
+  const firstName = session.givenName || username || "User"
+  const lastName = session.familyName || undefined
+
+  const newUser = await createUser({
+    cognitoSub: session.sub,
+    email: session.email || `${session.sub}@cognito.local`,
+    firstName,
+    lastName,
+  })
+
+  const userId = newUser.id as number
+
+  // Assign default role (student for numeric usernames, staff otherwise)
+  const isNumeric = /^\d+$/.test(username)
+  const defaultRole = isNumeric ? "student" : "staff"
+  const role = await getRoleByName(defaultRole)
+  if (role) {
+    await assignRoleToUser(userId, role.id)
+    log.info("User provisioned with default role", {
+      userId,
+      role: defaultRole,
+    })
+  } else {
+    log.warn("Default role not found — user created without role", {
+      userId,
+      attemptedRole: defaultRole,
+    })
+  }
+
+  return userId
+}


### PR DESCRIPTION
## Summary

Fixes #838 — Users with valid Cognito sessions but no corresponding database record were getting 404 errors on polling APIs.

## Root Cause

API routes (`/api/notifications`, `/api/execution-results/*`) look up users by `cognitoSub` but throw `dbRecordNotFound` (HTTP 404) if no record exists. This fails for:
- First-time users before `getCurrentUserAction()` runs
- Users whose DB records were manually deleted
- Race conditions between client polling and JIT provisioning

## Changes

### New: `lib/auth/resolve-user.ts`
Shared utility that resolves a Cognito session to a numeric user ID with automatic JIT provisioning:
1. **Fast path:** Lookup by `cognito_sub` (existing users)
2. **Migration path:** Lookup by email + link `cognito_sub`
3. **Provisioning path:** Create user via UPSERT + assign default role (student/staff)

Uses the same UPSERT pattern as `getCurrentUserAction()` for concurrency safety.

### Updated: 6 API routes
Replaced the `getUserIdByCognitoSub` + `dbRecordNotFound` pattern with `resolveUserId(session)`:
- `GET /api/notifications`
- `PUT /api/notifications/[id]/read`
- `PUT /api/notifications/read-all`
- `GET /api/execution-results/recent`
- `GET|DELETE /api/execution-results/[id]`
- `GET /api/execution-results/[id]/download`

## Test Plan
- [ ] Build passes (`bun run build`)
- [ ] Lint clean (0 errors)
- [ ] Existing users: fast path lookup works (no provisioning triggered)
- [ ] New users: auto-provisioned on first API call
- [ ] Concurrent requests: UPSERT handles race conditions safely
- [ ] Verify `dbRecordNotFound("users")` errors stop appearing in prod logs

Closes #838