### PR TITLE
fix: #835 — SSE streaming validation failures, credential errors, and log noise

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,9 @@ next-env.d.ts
 /tests/e2e/videos/
 /.playwright-mcp/
 
+# Python
+__pycache__/
+
 # Claude agent internal state
 .claude/agent-memory/
 docs/learnings/.evolve-state.json

--- a/app/api/assistant-architect/execute/route.ts
+++ b/app/api/assistant-architect/execute/route.ts
@@ -492,19 +492,14 @@ export async function POST(req: Request) {
     }
 
   } catch (error) {
-    log.error('Assistant architect execution error', {
-      error: error instanceof Error ? {
-        message: error.message,
-        name: error.name,
-        stack: error.stack
-      } : String(error)
-    });
-
-    timer({ status: 'error' });
-
-    // Issue #657: Handle ContentSafetyBlockedError with proper 400 response
-    // This provides a user-friendly error message when guardrails block content
+    // Issue #657/#835: Handle ContentSafetyBlockedError at warn level (expected behavior)
     if (error instanceof ContentSafetyBlockedError) {
+      log.warn('Content blocked by safety guardrails', {
+        error: { message: error.message, name: error.name },
+        categories: error.blockedCategories,
+        source: error.source
+      });
+      timer({ status: 'blocked' });
       return new Response(
         JSON.stringify({
           error: error.message,
@@ -522,6 +517,16 @@ export async function POST(req: Request) {
         }
       );
     }
+
+    log.error('Assistant architect execution error', {
+      error: error instanceof Error ? {
+        message: error.message,
+        name: error.name,
+        stack: error.stack
+      } : String(error)
+    });
+
+    timer({ status: 'error' });
 
     return new Response(
       JSON.stringify({

--- a/app/api/assistant-architect/execute/route.ts
+++ b/app/api/assistant-architect/execute/route.ts
@@ -504,8 +504,6 @@ export async function POST(req: Request) {
         JSON.stringify({
           error: error.message,
           code: 'CONTENT_BLOCKED',
-          categories: error.blockedCategories,
-          source: error.source,
           requestId
         }),
         {

--- a/app/api/assistant-architect/execute/route.ts
+++ b/app/api/assistant-architect/execute/route.ts
@@ -504,6 +504,8 @@ export async function POST(req: Request) {
         JSON.stringify({
           error: error.message,
           code: 'CONTENT_BLOCKED',
+          categories: error.blockedCategories,
+          source: error.source,
           requestId
         }),
         {

--- a/app/api/nexus/chat/chat-helpers.ts
+++ b/app/api/nexus/chat/chat-helpers.ts
@@ -439,35 +439,3 @@ export async function getAndValidateModel(
   return { modelConfig, isImageGenerationModel };
 }
 
-/**
- * Handle chat API errors
- */
-export function handleChatError(
-  error: unknown,
-  requestId: string,
-  timer: (data: Record<string, unknown>) => void,
-  log: { warn: (msg: string, data?: unknown) => void; error: (msg: string, data?: unknown) => void },
-  ContentSafetyBlockedError: new (msg: string) => Error
-): Response {
-  if (error instanceof ContentSafetyBlockedError) {
-    log.warn('Content blocked by safety guardrails', {
-      error: error instanceof Error ? { message: error.message, name: error.name } : String(error)
-    });
-    timer({ status: 'blocked' });
-    return new Response(
-      JSON.stringify({ error: (error as Error).message, code: 'CONTENT_BLOCKED', requestId }),
-      { status: 400, headers: { 'Content-Type': 'application/json', 'X-Request-Id': requestId } }
-    );
-  }
-
-  log.error('Nexus chat API error', {
-    error: error instanceof Error ? { message: error.message, name: error.name } : String(error)
-  });
-
-  timer({ status: 'error' });
-
-  return new Response(
-    JSON.stringify({ error: 'Failed to process chat request', requestId }),
-    { status: 500, headers: { 'Content-Type': 'application/json', 'X-Request-Id': requestId } }
-  );
-}

--- a/app/api/nexus/chat/chat-helpers.ts
+++ b/app/api/nexus/chat/chat-helpers.ts
@@ -446,21 +446,25 @@ export function handleChatError(
   error: unknown,
   requestId: string,
   timer: (data: Record<string, unknown>) => void,
-  log: { error: (msg: string, data?: unknown) => void },
+  log: { warn: (msg: string, data?: unknown) => void; error: (msg: string, data?: unknown) => void },
   ContentSafetyBlockedError: new (msg: string) => Error
 ): Response {
-  log.error('Nexus chat API error', {
-    error: error instanceof Error ? { message: error.message, name: error.name } : String(error)
-  });
-
-  timer({ status: 'error' });
-
   if (error instanceof ContentSafetyBlockedError) {
+    log.warn('Content blocked by safety guardrails', {
+      error: error instanceof Error ? { message: error.message, name: error.name } : String(error)
+    });
+    timer({ status: 'blocked' });
     return new Response(
       JSON.stringify({ error: (error as Error).message, code: 'CONTENT_BLOCKED', requestId }),
       { status: 400, headers: { 'Content-Type': 'application/json', 'X-Request-Id': requestId } }
     );
   }
+
+  log.error('Nexus chat API error', {
+    error: error instanceof Error ? { message: error.message, name: error.name } : String(error)
+  });
+
+  timer({ status: 'error' });
 
   return new Response(
     JSON.stringify({ error: 'Failed to process chat request', requestId }),

--- a/app/api/nexus/chat/route.ts
+++ b/app/api/nexus/chat/route.ts
@@ -603,7 +603,9 @@ export async function POST(req: Request) {
 
     if (error instanceof ContentSafetyBlockedError) {
       log.warn('Content blocked by safety guardrails', {
-        error: { message: error.message, name: error.name }
+        error: { message: error.message, name: error.name },
+        categories: error.blockedCategories,
+        source: error.source
       });
       timer({ status: 'blocked' });
       return new Response(

--- a/app/api/nexus/chat/route.ts
+++ b/app/api/nexus/chat/route.ts
@@ -601,18 +601,22 @@ export async function POST(req: Request) {
     // for all terminal states including errors (verified against ai@6.x).
     await closeMcpClients(connectorToolResults, log, 'catch');
 
-    log.error('Nexus chat API error', {
-      error: error instanceof Error ? { message: error.message, name: error.name } : String(error)
-    });
-
-    timer({ status: 'error' });
-
     if (error instanceof ContentSafetyBlockedError) {
+      log.warn('Content blocked by safety guardrails', {
+        error: { message: error.message, name: error.name }
+      });
+      timer({ status: 'blocked' });
       return new Response(
         JSON.stringify({ error: error.message, code: 'CONTENT_BLOCKED', requestId }),
         { status: 400, headers: { 'Content-Type': 'application/json', 'X-Request-Id': requestId } }
       );
     }
+
+    log.error('Nexus chat API error', {
+      error: error instanceof Error ? { message: error.message, name: error.name } : String(error)
+    });
+
+    timer({ status: 'error' });
 
     return new Response(
       JSON.stringify({ error: 'Failed to process chat request', requestId }),

--- a/app/api/nexus/decision-chat/route.ts
+++ b/app/api/nexus/decision-chat/route.ts
@@ -467,18 +467,22 @@ export async function POST(req: Request) {
     });
 
   } catch (error) {
-    log.error('Decision chat API error', {
-      error: error instanceof Error ? { message: error.message, name: error.name } : String(error),
-    });
-
-    timer({ status: 'error' });
-
     if (error instanceof ContentSafetyBlockedError) {
+      log.warn('Content blocked by safety guardrails', {
+        error: { message: error.message, name: error.name }
+      });
+      timer({ status: 'blocked' });
       return new Response(
         JSON.stringify({ error: error.message, code: 'CONTENT_BLOCKED', requestId }),
         { status: 400, headers: { 'Content-Type': 'application/json', 'X-Request-Id': requestId } }
       );
     }
+
+    log.error('Decision chat API error', {
+      error: error instanceof Error ? { message: error.message, name: error.name } : String(error),
+    });
+
+    timer({ status: 'error' });
 
     // Handle missing setting gracefully
     if (error instanceof Error && error.message.includes('Required setting')) {

--- a/app/api/nexus/decision-chat/route.ts
+++ b/app/api/nexus/decision-chat/route.ts
@@ -469,7 +469,9 @@ export async function POST(req: Request) {
   } catch (error) {
     if (error instanceof ContentSafetyBlockedError) {
       log.warn('Content blocked by safety guardrails', {
-        error: { message: error.message, name: error.name }
+        error: { message: error.message, name: error.name },
+        categories: error.blockedCategories,
+        source: error.source
       });
       timer({ status: 'blocked' });
       return new Response(

--- a/components/features/assistant-architect/assistant-architect-streaming.tsx
+++ b/components/features/assistant-architect/assistant-architect-streaming.tsx
@@ -493,7 +493,7 @@ function createAssistantArchitectAdapter(options: AssistantArchitectAdapterOptio
             }
           }
 
-          // Complete monitoring and publish metrics
+          // Complete monitoring and log metrics locally
           const metrics = monitor.complete()
 
           log.info('Streaming completed successfully', {

--- a/components/features/assistant-architect/assistant-architect-streaming.tsx
+++ b/components/features/assistant-architect/assistant-architect-streaming.tsx
@@ -44,6 +44,8 @@ import {
   isToolCallEvent,
   isToolCallDeltaEvent,
   isToolInputStartEvent,
+  isToolInputDeltaEvent,
+  isToolInputAvailableEvent,
   isToolInputErrorEvent,
   isToolOutputErrorEvent,
   isToolOutputAvailableEvent,
@@ -346,6 +348,12 @@ function createAssistantArchitectAdapter(options: AssistantArchitectAdapterOptio
                   // Handle tool input events (from web_search_preview, etc.)
                   else if (isToolInputStartEvent(event)) {
                     log.debug('Tool input started', { toolCallId: event.toolCallId, toolName: event.toolName })
+                  }
+                  else if (isToolInputDeltaEvent(event)) {
+                    log.debug('Tool input delta', { toolCallId: event.toolCallId })
+                  }
+                  else if (isToolInputAvailableEvent(event)) {
+                    log.debug('Tool input available', { toolCallId: event.toolCallId })
                   }
                   else if (isToolInputErrorEvent(event)) {
                     log.debug('Tool input error', { toolCallId: event.toolCallId, toolName: event.toolName })

--- a/components/features/assistant-architect/assistant-architect-streaming.tsx
+++ b/components/features/assistant-architect/assistant-architect-streaming.tsx
@@ -56,7 +56,6 @@ import {
 import { createSSEMonitor } from '@/lib/streaming/sse-monitoring'
 import { validateSSEEvent } from '@/lib/streaming/sse-event-schemas'
 import { processUnknownEvent } from '@/lib/streaming/graceful-degradation'
-import { publishSSEMonitorMetrics } from '@/lib/streaming/cloudwatch-metrics'
 
 const log = createLogger({ moduleName: 'assistant-architect-streaming' })
 
@@ -488,16 +487,6 @@ function createAssistantArchitectAdapter(options: AssistantArchitectAdapterOptio
 
           // Complete monitoring and publish metrics
           const metrics = monitor.complete()
-
-          // Publish metrics to CloudWatch (non-blocking)
-          publishSSEMonitorMetrics(metrics, {
-            executionId: executionIdRef.current || undefined,
-            toolId
-          }).catch(err => {
-            log.warn('Failed to publish SSE metrics to CloudWatch', {
-              error: err instanceof Error ? err.message : String(err)
-            })
-          })
 
           log.info('Streaming completed successfully', {
             totalLength: accumulatedText.length,

--- a/components/features/assistant-architect/assistant-architect-streaming.tsx
+++ b/components/features/assistant-architect/assistant-architect-streaming.tsx
@@ -37,6 +37,7 @@ import {
   isTextStartEvent,
   isTextEndEvent,
   isReasoningStartEvent,
+  isReasoningDeltaEvent,
   isReasoningEndEvent,
   isStartStepEvent,
   isStartEvent,
@@ -327,6 +328,9 @@ function createAssistantArchitectAdapter(options: AssistantArchitectAdapterOptio
                   else if (isReasoningStartEvent(event)) {
                     log.debug('Reasoning started', { id: event.id })
                   }
+                  else if (isReasoningDeltaEvent(event)) {
+                    log.debug('Reasoning delta received', { delta: event.delta?.slice(0, 50) })
+                  }
                   else if (isReasoningEndEvent(event)) {
                     log.debug('Reasoning completed', { id: event.id })
                   }
@@ -410,32 +414,14 @@ function createAssistantArchitectAdapter(options: AssistantArchitectAdapterOptio
                     sources.push({ id: event.sourceId, url: event.url, title: event.title })
                     log.debug('Source URL collected', { sourceId: event.sourceId })
                   }
-                  // Handle complete assistant messages (direct format - legacy support)
-                  else if ('role' in event && event.role === 'assistant' && 'parts' in event) {
-                    log.info('Received complete assistant message (legacy format)')
-                    const parts = (event as { parts: unknown }).parts
-                    if (Array.isArray(parts)) {
-                      const text = parts.find((p: { type: string; text?: string }) => p.type === 'text')?.text
-                      if (text) {
-                        accumulatedText = text
-                        yield {
-                          content: [{
-                            type: 'text' as const,
-                            text: accumulatedText
-                          }]
-                        }
-                        log.debug('✅ YIELDED content from assistant message', {
-                          textLength: accumulatedText.length
-                        })
-                      }
-                    }
-                  }
                   // Graceful degradation for unknown event types
+                  // event is `never` here (all SSEEvent union members handled above)
                   else {
+                    const unknownEvent = event as unknown as Record<string, unknown>
                     log.warn('⚠️ UNHANDLED SSE EVENT TYPE', {
-                      type: event.type,
-                      keys: Object.keys(event),
-                      sample: JSON.stringify(event).substring(0, 200)
+                      type: unknownEvent['type'],
+                      keys: Object.keys(unknownEvent),
+                      sample: JSON.stringify(unknownEvent).substring(0, 200)
                     })
 
                     // Attempt to extract text content from unknown event
@@ -454,7 +440,7 @@ function createAssistantArchitectAdapter(options: AssistantArchitectAdapterOptio
                         }]
                       }
                       log.debug('✅ YIELDED content from unknown event', {
-                        type: event.type,
+                        type: unknownEvent['type'],
                         textLength: accumulatedText.length
                       })
                     }

--- a/docs/learnings/api-patterns/2026-03-11-api-error-helper-must-preserve-logging.md
+++ b/docs/learnings/api-patterns/2026-03-11-api-error-helper-must-preserve-logging.md
@@ -1,0 +1,44 @@
+---
+title: API error helpers handle response shape only — logging stays in catch block
+category: api-patterns
+tags:
+  - error-handling
+  - logging
+  - api-routes
+  - cloudwatch
+  - jit-provisioning
+  - read-vs-write
+severity: high
+date: 2026-03-11
+source: auto — /review-pr
+applicable_to: project
+---
+
+## What Happened
+
+PR #840 introduced `lib/api/execution-result-error.ts` to map `ErrorCode` to correct HTTP status codes (fixing `handleError()` misuse in API routes — it returns `ActionState` shape, not `NextResponse`, so always produced HTTP 500). When callers were refactored to use `executionResultErrorResponse()`, all `log.error()` calls in the catch blocks were silently dropped.
+
+## Root Cause
+
+Two separate concerns were conflated during extraction: (1) HTTP status code mapping and (2) error logging. The helper correctly owns HTTP mapping but has no access to the route's logger context (`requestId`, `action`). Moving the entire catch body into the helper stripped CloudWatch visibility.
+
+## Solution
+
+Keep `log.error(error, "message", { requestId })` in the route handler's catch block. Call the helper only for building the response:
+
+```typescript
+} catch (error) {
+  log.error(error, "Action failed", { requestId })   // stays here
+  return executionResultErrorResponse(error)          // only this goes to helper
+}
+```
+
+## Prevention
+
+- When extracting a response-shaping helper, treat `log.error()` as non-movable — it requires the caller's logger instance and request context.
+- Audit every catch block after refactoring: confirm a `log.error()` or equivalent is still present.
+- Separate concerns explicitly: logging = route handler, HTTP status mapping = helper.
+
+## Bonus: GET routes must not provision users
+
+`resolveUserId()` provisions a new user on first call — correct for write routes, wrong for read-only GET routes. A GET that calls `resolveUserId()` creates accounts on every unauthenticated or first-time read. Use a fast-path lookup (`getUserIdByCognitoSub`) with a graceful `null` fallback (e.g., `hasVoted: false`) instead.

--- a/docs/learnings/code-quality/2026-03-04-verify-exports-have-production-consumers.md
+++ b/docs/learnings/code-quality/2026-03-04-verify-exports-have-production-consumers.md
@@ -1,0 +1,37 @@
+---
+title: Verify every new export has a production consumer before opening a PR
+category: code-quality
+tags:
+  - dead-code
+  - exports
+  - pre-pr-checklist
+  - streaming
+  - error-boundary
+  - react
+severity: medium
+date: 2026-03-04
+source: auto — /review-pr
+applicable_to: project
+---
+
+## What Happened
+
+PR #822 added `isSafePlotData` and `SAFE_PLOT_MIME_TYPES` as named exports from a shared utility module. Neither was imported anywhere in production code. The dead exports were discovered during review (round 3+), causing friction and requiring a cleanup commit.
+
+## Root Cause
+
+New helpers were written and exported speculatively — useful in tests or anticipated for future use — but no production call site was wired up before the PR was opened.
+
+## Solution
+
+Before opening a PR, run a grep check for every new export name:
+
+```bash
+grep -rn "isSafePlotData\|SAFE_PLOT_MIME_TYPES" app/ components/ actions/ lib/
+```
+
+If the only hits are the definition file and test files, the export is untethered. Either wire it up or remove the `export` keyword until it is needed.
+
+## Prevention
+
+Add to pre-PR checklist: for each newly exported symbol, confirm at least one non-test import exists. A single grep per symbol takes seconds and eliminates reviewer friction around dead-code questions.

--- a/docs/learnings/code-quality/2026-03-10-typed-error-code-over-string-match.md
+++ b/docs/learnings/code-quality/2026-03-10-typed-error-code-over-string-match.md
@@ -1,0 +1,33 @@
+---
+title: Typed ErrorCode check always beats error.message string matching
+category: code-quality
+tags:
+  - error-handling
+  - type-safety
+  - typed-errors
+  - ErrorFactories
+severity: high
+date: 2026-03-10
+source: auto — /review-pr
+applicable_to: project
+---
+
+## What Happened
+
+PR #840 review found `error.message` string-match guards used to detect specific error conditions in API routes, despite the codebase having a typed `ErrorCode` enum and `ErrorFactories` infrastructure.
+
+## Root Cause
+
+Developers fell back to `error.message.includes("some phrase")` pattern because it is immediately readable. When typed error infrastructure exists but is not enforced by lint or convention, ad-hoc string matching silently competes with it.
+
+## Solution
+
+Check the typed property instead: `error.code === ErrorCode.SomeCode` (or equivalent typed discriminant).
+Replace `new Number()` / `Number()` raw conversions with the project helper `getUserIdByCognitoSubAsNumber`, which includes a NaN guard.
+Consolidate duplicated error-switch blocks across routes into `handleError()`.
+
+## Prevention
+
+- When reviewing any `catch` block that inspects `error.message`, flag it as wrong — always use the typed `code` property.
+- String-match on error messages has two failure modes: (1) swallows real errors whose message coincidentally matches; (2) silently breaks when the message template changes.
+- Enforce via code review checklist: "Does this project have a typed error enum? Then no `error.message` string matching."

--- a/docs/learnings/code-quality/2026-03-11-feature-removal-artifacts-dead-helpers-stale-comments.md
+++ b/docs/learnings/code-quality/2026-03-11-feature-removal-artifacts-dead-helpers-stale-comments.md
@@ -1,0 +1,40 @@
+---
+title: Feature removal leaves dead helpers, stale comments, and log field inconsistencies
+category: code-quality
+tags:
+  - dead-code
+  - feature-removal
+  - consistency
+  - review-patterns
+  - logging
+severity: medium
+date: 2026-03-11
+source: auto — /review-pr
+applicable_to: project
+---
+
+## What Happened
+
+PR #841 removed CloudWatch publishing from a chat route. After removal, a helper (`handleChatError`) remained exported but was never called outside its own file. A stale comment referencing the removed feature persisted. Log fields (`blockedCategories`, `source`) were present in two routes but missing from parallel routes handling the same error type.
+
+## Root Cause
+
+Feature removal focuses on the primary deletion path. Secondary artifacts — exported helpers that existed to support the removed feature, inline comments explaining the old behavior, and log fields added alongside the feature — are easy to miss because they don't cause build or runtime errors.
+
+## Solution
+
+After any feature removal, run three checks before opening a PR:
+
+1. **Dead helpers**: grep for every function/constant defined in the affected file to confirm each has at least one external caller:
+   ```bash
+   grep -rn "handleChatError" app/ actions/ lib/ components/
+   ```
+   If the only hits are the definition file, remove the export (or the function entirely).
+
+2. **Stale comments**: scan the diff for comments that reference the removed feature by name — they are documentation lies once the code they describe is gone.
+
+3. **Log field parity**: when a log field is added to one route handler, grep for sibling routes handling the same error type and confirm the field is present in all of them.
+
+## Prevention
+
+Add to the feature-removal PR checklist: grep all exported symbols in touched files; scan for comments mentioning the removed feature name; compare log fields across all parallel route handlers.

--- a/docs/learnings/frontend/2026-03-04-assistant-ui-upgrade-type-compat-and-stable-stringify.md
+++ b/docs/learnings/frontend/2026-03-04-assistant-ui-upgrade-type-compat-and-stable-stringify.md
@@ -1,0 +1,43 @@
+---
+title: "@assistant-ui upgrade type breaks — exhaustive switch and generic constraint tightening"
+category: frontend
+tags:
+  - assistant-ui
+  - streaming
+  - argsText
+  - tool-ui
+  - dependency-upgrade
+  - error-boundary
+  - typescript
+severity: medium
+date: 2026-03-04
+source: auto — /work
+applicable_to: project
+---
+
+## What Happened
+
+Upgraded `@assistant-ui/react-ai-sdk` from 1.3.3 to 1.3.11. The package ships `stableStringifyToolArgs` (v1.3.11) which fixes key-order instability in tool args serialization during streaming — the root fix for `argsText` invariant violations. Two TypeScript breakages appeared on upgrade:
+
+1. Attachment type union was widened (no longer a closed union) — an exhaustive `never` check on the attachment type switch statement broke at compile time.
+2. `MessageFormatAdapter` generic constraint was tightened — `TStorageFormat` now requires `Record<string, unknown>`, breaking usages that passed a narrower or unrelated type.
+
+`ToolArgsRecoveryBoundary` was also added as a defense-in-depth error boundary around all tool UI rendering paths.
+
+## Root Cause
+
+- **Exhaustive switch break**: Library widened a discriminated union to be string-extensible. Exhaustive switches that fell through to a `never` check became invalid once the union is open-ended.
+- **Generic constraint tightening**: `MessageFormatAdapter<TStorageFormat>` added `Record<string, unknown>` as a constraint on `TStorageFormat`. Any adapter with a storage type that didn't satisfy that constraint (e.g., a plain string or narrower interface) failed.
+
+## Solution
+
+- Replace `never` exhaustive checks on assistant-ui type unions with a `default` case (log/throw a runtime error instead of relying on compile-time exhaustion).
+- Add `Record<string, unknown>` (or `& Record<string, unknown>`) to adapter storage format types to satisfy the tightened constraint.
+- Wrap all tool UI rendering paths with `ToolArgsRecoveryBoundary` so streaming parse errors degrade gracefully rather than crashing the chat view.
+
+## Prevention
+
+- When upgrading `@assistant-ui/*`, audit all exhaustive switches on library-owned union types — use `default` cases instead of `never` checks.
+- Check `MessageFormatAdapter` generic constraints after any upgrade; the storage format type must satisfy `Record<string, unknown>`.
+- Pin `stableStringifyToolArgs` usage to v1.3.11+ as the canonical fix for argsText key-order drift during streaming.
+- Always add `ToolArgsRecoveryBoundary` around tool UI rendering as a standard pattern.

--- a/docs/learnings/frontend/2026-03-09-branding-migration-image-paths-and-color-literals.md
+++ b/docs/learnings/frontend/2026-03-09-branding-migration-image-paths-and-color-literals.md
@@ -1,0 +1,45 @@
+---
+title: Branding migration must audit image paths and color literals, not just text strings
+category: frontend
+tags:
+  - branding
+  - accessibility
+  - review-patterns
+severity: medium
+date: 2026-03-09
+source: auto — /review-pr
+applicable_to: project
+---
+
+## What Happened
+
+PR #828 replaced hardcoded branding with settings-driven values. Initial implementation
+missed `/psd-ai-logo.png` (a district-specific image path) and `bg-sky-600` / `sky-600`
+color literals on the landing page. These were not near the text-string branding changes
+so they were not caught in the first pass.
+
+## Root Cause
+
+Branding is mentally modeled as text (names, titles, taglines). Image `src` attributes
+and Tailwind color classes don't read as "branding" during implementation, so they survive
+initial replacement sweeps.
+
+## Solution
+
+Add explicit grep passes during branding migration:
+```bash
+# Image paths
+rg "/psd-|/district-|/logo\." --type tsx --type ts
+
+# Hardcoded color classes tied to brand palette
+rg "sky-600|brand-blue|#005" --type tsx
+```
+
+Replace with dynamic values from the branding config (`logoUrl`, `primaryColor`).
+
+## Prevention
+
+- Before opening a branding PR, run the above greps and resolve all hits
+- Treat image `src` strings and palette-specific Tailwind classes as branding references
+- Also audit `alt=""` on logo `<img>` tags — empty alt on a meaningful image is a WCAG violation;
+  use the brand name as alt text (e.g., `alt={branding.organizationName}`)

--- a/docs/learnings/frontend/2026-03-09-dynamic-settings-trace-child-component-props.md
+++ b/docs/learnings/frontend/2026-03-09-dynamic-settings-trace-child-component-props.md
@@ -1,0 +1,34 @@
+---
+title: Dynamic settings migration must trace ALL usage sites including child component props
+category: frontend
+tags:
+  - branding
+  - react-context
+  - review-patterns
+  - testing
+severity: medium
+date: 2026-03-09
+source: auto — /review-pr
+applicable_to: project
+---
+
+## What Happened
+
+PR #828 replaced hardcoded branding values with dynamic settings. A reviewer caught that the featured card image was updated from `/psd-ai-logo.png` to `/logo.png` but was not wired to the dynamic `logoSrc` from the branding context. The parent component (`ToolCardsGrid`) called `useBranding()` but never passed the value down as a prop, so the child component kept a static path.
+
+## Root Cause
+
+The audit checked which components called the hook, not which components consumed branding values via props. A child component can use a hardcoded value even when its parent correctly calls `useBranding()` — the value simply never gets passed down.
+
+## Solution
+
+When replacing hardcoded branding values:
+1. Grep for the old literal strings (e.g., `/psd-ai-logo.png`, `sky-600`) across the full component tree, not just files that call the hook
+2. For each hit, check whether the parent component supplies that value dynamically or still passes a static string
+3. Confirm the dynamic value flows all the way from the hook call to the rendered attribute
+
+## Prevention
+
+- After any settings-driven replacement, run: `grep -rn "psd-ai-logo\|sky-600\|old-brand-token" app/ components/` to catch survivors
+- Review PR diffs for child components that receive image/color props — verify prop is dynamic, not a newly-renamed static string
+- Add E2E tests that assert the rendered value changes when the setting changes (not just that the UI renders)

--- a/docs/learnings/frontend/2026-03-10-nextjs-image-remote-patterns-build-time.md
+++ b/docs/learnings/frontend/2026-03-10-nextjs-image-remote-patterns-build-time.md
@@ -1,0 +1,36 @@
+---
+title: Next.js Image remotePatterns evaluated at build time — S3 signed URLs blocked when env vars absent from Docker build context
+category: frontend
+tags:
+  - nextjs
+  - image-optimization
+  - s3
+  - caching
+  - stale-while-revalidate
+severity: high
+date: 2026-03-10
+source: auto — /work
+applicable_to: project
+---
+
+## What Happened
+
+S3 presigned URLs served via `next/image` were blocked in the containerized app. `remotePatterns` in `next.config.ts` referenced env vars for the S3 hostname, but those vars were not present in the Docker build context, so the pattern compiled to an empty or wrong value.
+
+## Root Cause
+
+`next/image` `remotePatterns` are evaluated at **build time** (when `next build` runs), not at runtime. If the env var supplying the S3 hostname is missing during `docker build`, the pattern is never registered and all matching URLs are blocked with a 400.
+
+## Solution
+
+Add the `unoptimized` prop to `<Image>` components that render dynamic S3 presigned URLs. This bypasses the Next.js image optimizer entirely, which is appropriate for short-lived signed URLs that cannot be cached anyway.
+
+```tsx
+<Image src={presignedUrl} unoptimized ... />
+```
+
+## Prevention
+
+- For any `<Image>` that renders a signed or dynamic S3 URL, default to `unoptimized`.
+- `remotePatterns` is only viable for stable, non-signed hostnames whose value is known at build time and injected into the Docker build via `--build-arg` / `ARG` / `ENV`.
+- If the hostname is dynamic or env var is runtime-only, `unoptimized` is the correct approach.

--- a/docs/learnings/frontend/2026-03-11-client-side-aws-calls-and-log-level-hygiene.md
+++ b/docs/learnings/frontend/2026-03-11-client-side-aws-calls-and-log-level-hygiene.md
@@ -1,0 +1,33 @@
+---
+title: Client-side AWS calls always fail — route through server; expected errors belong at warn
+category: frontend
+tags:
+  - sse
+  - streaming
+  - cloudwatch
+  - error-handling
+  - logging
+severity: high
+date: 2026-03-11
+source: auto — /work
+applicable_to: project
+---
+
+## What Happened
+
+Client-side code was publishing metrics directly to CloudWatch. Every call silently failed because browser JS has no AWS credentials. Separately, `ContentSafetyBlockedError` was logged at `error` level in route handlers, inflating error counts in monitoring for expected application behavior.
+
+## Root Cause
+
+- CloudWatch SDK calls from browser context: no IAM credentials available in the browser; calls always reject silently or throw.
+- Log level mismatch: content safety blocks are expected outcomes of guardrail policy, not unexpected failures. Logging them at `error` treats normal behavior as incidents.
+
+## Solution
+
+- Removed client-side CloudWatch publishing entirely. Route any client-initiated metrics through a server-side API endpoint that has IAM access.
+- Downgraded `ContentSafetyBlockedError` from `log.error` to `log.warn` in all affected route handlers.
+
+## Prevention
+
+- Any AWS SDK import in a `components/` or client-boundary file is a red flag — AWS SDK clients require credentials unavailable in the browser.
+- When adding `catch` blocks, ask: "Is this a genuinely unexpected failure, or an expected application state?" Expected states (rate limits, content blocks, not-found) → `warn`. Unexpected failures → `error`.

--- a/docs/learnings/infrastructure/2026-03-09-lambda-branding-via-cdk-context-env-vars.md
+++ b/docs/learnings/infrastructure/2026-03-09-lambda-branding-via-cdk-context-env-vars.md
@@ -1,0 +1,39 @@
+---
+title: Pass branding to Lambda via CDK context env vars, not DB access
+category: infrastructure
+tags:
+  - cdk
+  - lambda
+  - branding
+  - env-vars
+severity: medium
+date: 2026-03-09
+source: auto — /work
+applicable_to: project
+---
+
+## What Happened
+
+Hardcoded PSD branding strings existed across 4 infra files. Replacing them required a pattern for Lambda functions that need branding values but have no database access.
+
+## Root Cause
+
+Lambda functions (e.g., email notification handlers) are deployed independently from the app and cannot call the settings database. Attempting to add DB access purely for branding would be over-engineered.
+
+## Solution
+
+Pass branding as environment variables injected from CDK context at deploy time:
+
+```typescript
+// In CDK stack
+environment: {
+  BRANDING_ORG_NAME: this.node.tryGetContext("brandingOrgName") ?? "AI Studio",
+  BRANDING_EMAIL_FROM: this.node.tryGetContext("brandingEmailFrom") ?? "noreply@example.com",
+}
+```
+
+Lambda reads `process.env.BRANDING_ORG_NAME` with a sensible fallback default. CDK context values are set per-environment in `cdk.json` or passed via `--context` flags.
+
+## Prevention
+
+When a Lambda needs a settings-type value: prefer CDK context env vars over adding DB connectivity. Reserve DB access for Lambda functions that already need it for business logic.

--- a/docs/learnings/infrastructure/2026-03-10-rds-proxy-removal-implicit-security-audit.md
+++ b/docs/learnings/infrastructure/2026-03-10-rds-proxy-removal-implicit-security-audit.md
@@ -1,0 +1,36 @@
+---
+title: Removing infrastructure components requires auditing their implicit security responsibilities
+category: infrastructure
+tags:
+  - aws
+  - aurora
+  - rds
+  - cost-optimization
+  - security
+  - lambda
+  - cdk
+severity: high
+date: 2026-03-10
+source: auto — /work
+applicable_to: project
+---
+
+## What Happened
+
+During Aurora/RDS cost optimization (removed RDS Proxy, fixed auto-pause Lambda, right-sized ACU config from 2-8 to 1-4), a security audit revealed a dev security group with `0.0.0.0/0` ingress on port 5432 that was previously masked by the RDS Proxy — the Proxy had been the actual network entry point, so the open SG was never directly reachable. Removing the Proxy made the group directly exposed.
+
+## Root Cause
+
+RDS Proxy was implicitly enforcing TLS termination and acting as the sole network ingress to Aurora. The open security group rule predated the Proxy and was never cleaned up because the Proxy masked it. Additional findings: Lambda error responses leaking boto3 exception details (ARNs, cluster IDs), a misleading CloudFormation export for a removed reader endpoint, missing RETAIN policy on prod log groups, a Python function shadowing bug, and deprecated `datetime.utcnow()` usage.
+
+## Solution
+
+Audit all security controls that a removed component was providing before finalizing removal:
+- Network ingress rules that the component was absorbing
+- TLS termination responsibilities
+- Exported CloudFormation values that referenced the component
+- Error response sanitization (ensure exceptions don't leak infra details)
+
+## Prevention
+
+Before removing any infrastructure component, explicitly document what security responsibilities it holds — network filtering, TLS, auth, error masking. Treat the removal as a security change, not just a cost change, and run a full audit of dependent security groups, exports, and error paths.

--- a/docs/learnings/infrastructure/2026-03-10-swr-cache-null-return-ambiguity.md
+++ b/docs/learnings/infrastructure/2026-03-10-swr-cache-null-return-ambiguity.md
@@ -1,0 +1,34 @@
+---
+title: Stale-while-revalidate cache breaks when DB accessor returns null for both not-found and error
+category: infrastructure
+tags:
+  - cache
+  - stale-while-revalidate
+  - database
+  - null-safety
+  - settings
+severity: high
+date: 2026-03-10
+source: auto — /review-pr
+applicable_to: project
+---
+
+## What Happened
+
+PR #831 implemented a stale-while-revalidate (SWR) cache for settings. Review caught two bugs: (1) the DB accessor returned `null` for both "row not found" and "DB error", making the SWR refresh logic unable to distinguish them. (2) `revalidateSettingsCache` had a race condition where an in-flight background refresh could write stale data back to the cache after an explicit invalidation.
+
+## Root Cause
+
+The DB accessor's null return type conflated two distinct conditions. SWR refresh logic that writes `null` back to cache (or falls back to defaults) will silently overwrite valid cached state when the DB is temporarily unavailable or the row doesn't exist yet.
+
+## Solution
+
+- DB accessor must distinguish not-found from error: throw on error, return `null` only for not-found, or use a discriminated union `{ found: false } | { found: true; data: T }`.
+- SWR refresh: on null/error from DB, preserve existing cache entry rather than overwriting it.
+- Cache invalidation must cancel or ignore in-flight background refreshes (e.g., generation counter or `AbortController`).
+
+## Prevention
+
+- Before implementing SWR, audit the DB accessor's null semantics. If it returns null for errors, fix the accessor first.
+- Background refresh callbacks must check whether the cache has been invalidated since the refresh was triggered before writing.
+- Use a generation/version counter on the cache entry: only write if `generation === currentGeneration`.

--- a/docs/learnings/react-patterns/2026-03-04-error-boundary-getderivedstatefromerror-partial-state.md
+++ b/docs/learnings/react-patterns/2026-03-04-error-boundary-getderivedstatefromerror-partial-state.md
@@ -1,0 +1,38 @@
+---
+title: getDerivedStateFromError must return Partial<State> to preserve accumulating counters
+category: react-patterns
+tags:
+  - error-boundary
+  - getDerivedStateFromError
+  - react
+  - streaming
+  - assistant-ui
+severity: high
+date: 2026-03-04
+source: auto — /review-pr
+applicable_to: project
+---
+
+## What Happened
+
+PR #822 added a `ToolArgsRecoveryBoundary` for assistant-ui streaming errors. `getDerivedStateFromError` returned the full state object with `recoveryAttempt: 0`, silently resetting the counter on every error. The `MAX_RECOVERY_ATTEMPTS` cap never triggered because the counter always restarted from 0.
+
+## Root Cause
+
+`getDerivedStateFromError` is a static method with no access to `this.state`. Returning the full state shape with reset values (e.g., `{ hasArgsTextError: true, recoveryAttempt: 0 }`) overwrites the accumulated counter instead of merging only the changed field.
+
+## Solution
+
+Return only the fields you want to change — React merges the partial return into the existing state:
+
+```typescript
+static getDerivedStateFromError(): Partial<State> {
+  return { hasArgsTextError: true };
+  // recoveryAttempt is incremented separately in componentDidCatch or a handler
+}
+```
+
+## Prevention
+
+- Treat `getDerivedStateFromError` return type as `Partial<State>` whenever your error boundary state has accumulating counters or fields that must survive across errors.
+- Always verify cap/limit logic in error boundaries with a test that triggers the error more times than the cap allows.

--- a/docs/learnings/react-patterns/2026-03-09-context-over-server-component-for-wide-usage.md
+++ b/docs/learnings/react-patterns/2026-03-09-context-over-server-component-for-wide-usage.md
@@ -1,0 +1,32 @@
+---
+title: Use React Context (not async server components) when a data source is consumed by 30+ files
+category: react-patterns
+tags:
+  - branding
+  - context
+  - css-variables
+  - next.js
+  - server-components
+severity: medium
+date: 2026-03-09
+source: auto — /work
+applicable_to: project
+---
+
+## What Happened
+
+Replacing hardcoded branding across 30+ UI references. Initial plan: make `PageBranding` an async server component that fetches settings. Abandoned because the component was already imported in 30+ client components, which cannot directly consume async server components.
+
+## Root Cause
+
+Async server components can only be composed by other server components or passed as children. When the consumer count is high and includes client components, wrapping each usage site is impractical.
+
+## Solution
+
+- `BrandingProvider` (server component) fetches branding data once at the root layout and passes it via React Context
+- `useBranding()` hook consumed in any client component without prop drilling
+- Brand color exposed as a CSS custom property set on the `<html>` element in root layout, so it cascades globally without JS
+
+## Prevention
+
+Before making a shared component async, grep its import count. If it appears in many client component files, use a root-level Provider + context hook instead. Reserve async server components for components with a small, server-side-only usage surface.

--- a/docs/learnings/react-patterns/2026-03-09-hook-wired-but-template-literals-not-updated.md
+++ b/docs/learnings/react-patterns/2026-03-09-hook-wired-but-template-literals-not-updated.md
@@ -1,0 +1,30 @@
+---
+title: Hook import and call added without updating template literals in same component
+category: react-patterns
+tags:
+  - branding
+  - context
+  - hardcoded-strings
+  - migration
+  - tutorials
+severity: low
+date: 2026-03-09
+source: auto — /review-pr
+applicable_to: project
+---
+
+## What Happened
+
+PR #828 migrated branding to dynamic settings. In `tutorials/page.tsx`, the `useBranding()` hook was imported and called (likely in a prior commit), but the heading and description text still contained hardcoded `'AI Studio'` string literals. The hook result (`appName`) was never substituted into the template literals.
+
+## Root Cause
+
+Multi-commit migrations can split the hook wiring step from the consumption step. When a reviewer or author verifies that a hook is "already imported and called", they may not re-audit every JSX text node and template literal in the same file for remaining hardcoded values.
+
+## Solution
+
+After confirming the hook is imported and the variable is bound, grep the same file for every hardcoded brand name occurrence and replace with the variable. In this case: replace `'AI Studio'` string literals with `${appName}` or `{appName}`.
+
+## Prevention
+
+After any branding migration commit, run a targeted grep for the literal brand name inside each modified file — not just across the repo. A file can import and call the hook and still have unresolved literals lower in the JSX tree.

--- a/docs/learnings/refactoring/2026-03-04-security-comments-must-migrate-with-extracted-code.md
+++ b/docs/learnings/refactoring/2026-03-04-security-comments-must-migrate-with-extracted-code.md
@@ -1,0 +1,35 @@
+---
+title: Security and doc comments must migrate with extracted code to shared utilities
+category: refactoring
+tags:
+  - extraction
+  - shared-utilities
+  - security-comments
+  - documentation-migration
+severity: high
+date: 2026-03-04
+source: auto — /review-pr
+applicable_to: project
+---
+
+## What Happened
+
+During PR #822 review (argsText error boundary fix), a constant and a utility function were extracted from an inline component into a shared module. The original file contained a safety warning about SVG injection risk in plot data validation (`isSafePlotData`). That comment was dropped during the extraction — leaving the shared utility with no indication of the security assumption it encodes (self-reported MIME type, no binary inspection).
+
+A second issue: the constant `MAX_RECOVERY_ATTEMPTS` was misleading because `getDerivedStateFromError` (which has no access to current state) resets it on error, causing the effective cap to be threshold+1 due to async setState stale-state reads. Renamed to `RECOVERY_ATTEMPT_THRESHOLD` to reflect actual behavior.
+
+## Root Cause
+
+Refactoring focus is on code structure, not comment preservation. Safety/doc comments in source files are not automatically flagged as "must migrate" during extraction — they are silently left behind.
+
+## Solution
+
+- Audited original file after extraction; carried the SVG injection warning forward into the shared utility's JSDoc
+- Renamed `MAX_RECOVERY_ATTEMPTS` → `RECOVERY_ATTEMPT_THRESHOLD` to match effective semantics
+- Added 12 edge-case unit tests for `isSafePlotData` covering null, malformed, unexpected MIME types, and boundary values
+
+## Prevention
+
+- After any extraction to a shared utility, re-read the original source for security comments, `// SAFETY:`, `// IMPORTANT:`, or `// NOTE:` annotations and carry them forward
+- When naming a constant that controls a threshold (not a hard limit), prefer `*_THRESHOLD` over `*_MAX` or `*_LIMIT` if the actual cap is derived (e.g., +1 from framework behavior)
+- Treat security utility functions as requiring unit tests at extraction time, not as a follow-up

--- a/docs/learnings/security/2026-03-09-webp-riff-magic-byte-secondary-check.md
+++ b/docs/learnings/security/2026-03-09-webp-riff-magic-byte-secondary-check.md
@@ -1,0 +1,41 @@
+---
+title: WebP magic-byte validation requires secondary RIFF marker check at bytes 8-11
+category: security
+tags:
+  - magic-bytes
+  - file-upload
+  - webp
+  - validation
+  - s3
+  - server-actions
+severity: high
+date: 2026-03-09
+source: auto — /review-pr
+applicable_to: project
+---
+
+## What Happened
+
+PR #827 (branding settings) added server-side file type validation for logo uploads. The initial check validated only bytes 0-3 for the RIFF signature (`52 49 46 46`). This is insufficient: WAV and AVI files share the same RIFF container header. A malicious actor could upload a WAV file that passes validation as a WebP.
+
+## Root Cause
+
+WebP is a RIFF container format — it begins with the generic RIFF header, not a unique WebP-specific signature. Checking only `bytes[0..3] === "RIFF"` is a single-container-format pitfall that incorrectly trusts a shared header as proof of image type.
+
+## Solution
+
+Add a secondary check at bytes 8-11 for the `WEBP` marker:
+
+```typescript
+const riff = header.slice(0, 4).toString("ascii") === "RIFF";
+const webp = header.slice(8, 12).toString("ascii") === "WEBP";
+if (!riff || !webp) throw new Error("Invalid WebP file");
+```
+
+Both checks are required together to confirm a WebP file.
+
+## Prevention
+
+- Any RIFF-container format (WebP, WAV, AVI, WEBM) requires a secondary chunk-type check beyond the leading RIFF signature.
+- When adding magic-byte validation, consult the format spec for the secondary identifier, not just the container signature.
+- Apply the same two-check pattern to other container-wrapped formats (e.g., MP4/QuickTime share `ftyp` at byte 4 — still verify the brand at bytes 8-11).

--- a/docs/learnings/security/2026-03-10-sanitization-must-cover-all-output-paths.md
+++ b/docs/learnings/security/2026-03-10-sanitization-must-cover-all-output-paths.md
@@ -1,0 +1,31 @@
+---
+title: Sanitization must cover all output paths — missing one creates a false sense of security
+category: security
+tags:
+  - sanitization
+  - consistency
+  - xss
+  - branding
+severity: high
+date: 2026-03-10
+source: auto — /review-pr
+applicable_to: project
+---
+
+## What Happened
+
+A PR sanitized operator-provided branding values in the HTML and plain-text output paths of an attachment generator, but left the markdown output path (`generateMarkdownAttachment()`) unsanitized. A reviewer caught this in Round 1 of PR #829.
+
+## Root Cause
+
+When adding sanitization incrementally across multiple output formats (HTML, text, markdown), it is easy to treat the first two as "done" and overlook the third. The omission was not caught before review because each path looked correct in isolation.
+
+## Solution
+
+Apply the same sanitization call to every output path that renders operator- or user-controlled values. In this case, the same `sanitizeBrandingValue()` call used in the HTML and text paths was added to `generateMarkdownAttachment()`.
+
+## Prevention
+
+- When a function has N output paths, treat sanitization as an N-of-N requirement, not a per-path checkbox.
+- During PR self-review, grep for the sanitization function name and count call sites against the number of output paths.
+- Sanitize at the point of value capture (top of function, once) rather than at each render site to eliminate per-path omission risk.

--- a/lib/streaming/__tests__/sse-event-types.test.ts
+++ b/lib/streaming/__tests__/sse-event-types.test.ts
@@ -80,17 +80,14 @@ describe('SSE Event Parsing', () => {
       expect(() => parseSSEEvent(data)).toThrow('SSE event missing required "type" field');
     });
 
-    it('should warn for unrecognized event type', () => {
-      const consoleSpy = jest.spyOn(console, 'warn').mockImplementation();
+    it('should not throw for unrecognized event type (logs a warning instead)', () => {
       const data = '{"type":"unknown-type","data":"test"}';
 
-      parseSSEEvent(data);
-
-      expect(consoleSpy).toHaveBeenCalledWith(
-        expect.stringContaining('Unrecognized event type: "unknown-type"')
-      );
-
-      consoleSpy.mockRestore();
+      // parseSSEEvent should not throw — unknown types are gracefully forwarded
+      // with a structured log.warn via @/lib/client-logger (no console.warn)
+      expect(() => parseSSEEvent(data)).not.toThrow();
+      const event = parseSSEEvent(data);
+      expect(event.type).toBe('unknown-type');
     });
   });
 
@@ -318,6 +315,15 @@ describe('Tool Event Type Guards', () => {
         type: 'tool-input-delta',
         toolCallId: 'call-123',
         delta: '{"key":'
+      };
+
+      expect(isToolInputDeltaEvent(event)).toBe(true);
+    });
+
+    it('should return true for tool-input-delta without optional delta field', () => {
+      const event: SSEEvent = {
+        type: 'tool-input-delta',
+        toolCallId: 'call-123'
       };
 
       expect(isToolInputDeltaEvent(event)).toBe(true);

--- a/lib/streaming/__tests__/sse-event-types.test.ts
+++ b/lib/streaming/__tests__/sse-event-types.test.ts
@@ -334,6 +334,12 @@ describe('Tool Event Type Guards', () => {
 
       expect(isToolInputDeltaEvent(event)).toBe(false);
     });
+
+    it('should return false for tool-input-delta with non-string delta', () => {
+      const event = { type: 'tool-input-delta', toolCallId: 'call-123', delta: 123 } as unknown as SSEEvent;
+
+      expect(isToolInputDeltaEvent(event)).toBe(false);
+    });
   });
 
   describe('isToolInputAvailableEvent', () => {
@@ -359,6 +365,24 @@ describe('Tool Event Type Guards', () => {
 
     it('should return false for tool-input-available with missing toolCallId', () => {
       const event = { type: 'tool-input-available' } as unknown as SSEEvent;
+
+      expect(isToolInputAvailableEvent(event)).toBe(false);
+    });
+
+    it('should return false for tool-input-available with non-string toolName', () => {
+      const event = { type: 'tool-input-available', toolCallId: 'call-123', toolName: 42 } as unknown as SSEEvent;
+
+      expect(isToolInputAvailableEvent(event)).toBe(false);
+    });
+
+    it('should return false for tool-input-available with null args', () => {
+      const event = { type: 'tool-input-available', toolCallId: 'call-123', args: null } as unknown as SSEEvent;
+
+      expect(isToolInputAvailableEvent(event)).toBe(false);
+    });
+
+    it('should return false for tool-input-available with array args', () => {
+      const event = { type: 'tool-input-available', toolCallId: 'call-123', args: [] } as unknown as SSEEvent;
 
       expect(isToolInputAvailableEvent(event)).toBe(false);
     });

--- a/lib/streaming/__tests__/sse-event-types.test.ts
+++ b/lib/streaming/__tests__/sse-event-types.test.ts
@@ -17,6 +17,8 @@ import {
   isToolCallEvent,
   isToolCallDeltaEvent,
   isToolInputStartEvent,
+  isToolInputDeltaEvent,
+  isToolInputAvailableEvent,
   isToolInputErrorEvent,
   isToolOutputErrorEvent,
   isToolOutputAvailableEvent,
@@ -307,6 +309,52 @@ describe('Tool Event Type Guards', () => {
       };
 
       expect(isToolInputStartEvent(event)).toBe(true);
+    });
+  });
+
+  describe('isToolInputDeltaEvent', () => {
+    it('should return true for valid tool-input-delta event', () => {
+      const event: SSEEvent = {
+        type: 'tool-input-delta',
+        toolCallId: 'call-123',
+        delta: '{"key":'
+      };
+
+      expect(isToolInputDeltaEvent(event)).toBe(true);
+    });
+
+    it('should return false for tool-input-delta with missing toolCallId', () => {
+      const event = { type: 'tool-input-delta' } as unknown as SSEEvent;
+
+      expect(isToolInputDeltaEvent(event)).toBe(false);
+    });
+  });
+
+  describe('isToolInputAvailableEvent', () => {
+    it('should return true for valid tool-input-available event', () => {
+      const event: SSEEvent = {
+        type: 'tool-input-available',
+        toolCallId: 'call-123'
+      };
+
+      expect(isToolInputAvailableEvent(event)).toBe(true);
+    });
+
+    it('should return true for tool-input-available with optional fields', () => {
+      const event: SSEEvent = {
+        type: 'tool-input-available',
+        toolCallId: 'call-123',
+        toolName: 'web_search',
+        args: { query: 'test' }
+      };
+
+      expect(isToolInputAvailableEvent(event)).toBe(true);
+    });
+
+    it('should return false for tool-input-available with missing toolCallId', () => {
+      const event = { type: 'tool-input-available' } as unknown as SSEEvent;
+
+      expect(isToolInputAvailableEvent(event)).toBe(false);
     });
   });
 

--- a/lib/streaming/cloudwatch-metrics.ts
+++ b/lib/streaming/cloudwatch-metrics.ts
@@ -261,6 +261,7 @@ export function convertSSEMetricsToCloudWatch(
  *
  * @param sseMetrics - Metrics from SSEMonitor.complete()
  * @param context - Additional context
+ * @deprecated No active callers. Tracked for removal in issue #842.
  */
 export async function publishSSEMonitorMetrics(
   sseMetrics: SSEMetrics,

--- a/lib/streaming/sse-event-schemas.ts
+++ b/lib/streaming/sse-event-schemas.ts
@@ -172,6 +172,32 @@ export const ToolOutputAvailableSchema = BaseEventSchema.extend({
 })
 
 // ============================================================================
+// SOURCE SCHEMAS
+// ============================================================================
+
+/**
+ * Source URL event schema
+ * Includes URL protocol validation (http/https only) as defense-in-depth against XSS.
+ * Mirrors the runtime check in the isSourceUrlEvent type guard.
+ */
+export const SourceUrlSchema = BaseEventSchema.extend({
+  type: z.literal('source-url'),
+  sourceId: z.string(),
+  url: z.string().refine(
+    (u) => {
+      try {
+        const p = new URL(u);
+        return p.protocol === 'http:' || p.protocol === 'https:';
+      } catch {
+        return false;
+      }
+    },
+    { message: 'URL must use http or https protocol' }
+  ),
+  title: z.string().optional()
+})
+
+// ============================================================================
 // LIFECYCLE SCHEMAS
 // ============================================================================
 
@@ -288,6 +314,7 @@ export const SSEEventSchema = z.discriminatedUnion('type', [
   ToolInputErrorSchema,
   ToolOutputErrorSchema,
   ToolOutputAvailableSchema,
+  SourceUrlSchema,
   StartEventSchema,
   StartStepSchema,
   FinishStepSchema,
@@ -423,6 +450,7 @@ export function validateEventType(event: unknown, eventType: string): Validation
     'tool-input-error': ToolInputErrorSchema,
     'tool-output-error': ToolOutputErrorSchema,
     'tool-output-available': ToolOutputAvailableSchema,
+    'source-url': SourceUrlSchema,
     'start': StartEventSchema,
     'start-step': StartStepSchema,
     'finish-step': FinishStepSchema,

--- a/lib/streaming/sse-event-schemas.ts
+++ b/lib/streaming/sse-event-schemas.ts
@@ -399,7 +399,7 @@ export function validateSSEEvent(event: unknown): ValidationResult {
   )
 
   if (fieldNameIssues.length > 0) {
-    hint = 'Field name mismatch detected. This may indicate an AI SDK compatibility issue or version mismatch. Check that field names match the Vercel AI SDK v5 specification.'
+    hint = 'Field name mismatch detected. This may indicate an AI SDK compatibility issue or version mismatch. Check that field names match the Vercel AI SDK v6 specification.'
   }
 
   // Check for type mismatches

--- a/lib/streaming/sse-event-schemas.ts
+++ b/lib/streaming/sse-event-schemas.ts
@@ -123,6 +123,27 @@ export const ToolInputStartSchema = BaseEventSchema.extend({
 })
 
 /**
+ * Tool input delta event schema
+ * Incremental tool input updates from AI SDK v6
+ */
+export const ToolInputDeltaSchema = BaseEventSchema.extend({
+  type: z.literal('tool-input-delta'),
+  toolCallId: z.string(),
+  delta: z.string().optional()
+})
+
+/**
+ * Tool input available event schema
+ * Complete tool input is available for processing
+ */
+export const ToolInputAvailableSchema = BaseEventSchema.extend({
+  type: z.literal('tool-input-available'),
+  toolCallId: z.string(),
+  toolName: z.string().optional(),
+  args: z.record(z.string(), z.unknown()).optional()
+})
+
+/**
  * Tool input error event schema
  */
 export const ToolInputErrorSchema = BaseEventSchema.extend({
@@ -262,6 +283,8 @@ export const SSEEventSchema = z.discriminatedUnion('type', [
   ToolCallSchema,
   ToolCallDeltaSchema,
   ToolInputStartSchema,
+  ToolInputDeltaSchema,
+  ToolInputAvailableSchema,
   ToolInputErrorSchema,
   ToolOutputErrorSchema,
   ToolOutputAvailableSchema,
@@ -395,6 +418,8 @@ export function validateEventType(event: unknown, eventType: string): Validation
     'tool-call': ToolCallSchema,
     'tool-call-delta': ToolCallDeltaSchema,
     'tool-input-start': ToolInputStartSchema,
+    'tool-input-delta': ToolInputDeltaSchema,
+    'tool-input-available': ToolInputAvailableSchema,
     'tool-input-error': ToolInputErrorSchema,
     'tool-output-error': ToolOutputErrorSchema,
     'tool-output-available': ToolOutputAvailableSchema,

--- a/lib/streaming/sse-event-schemas.ts
+++ b/lib/streaming/sse-event-schemas.ts
@@ -14,7 +14,7 @@
  * @see /lib/streaming/sse-event-types.ts
  */
 
-import { z } from 'zod'
+import { z, ZodIssueCode } from 'zod'
 import type { SSEEvent } from './sse-event-types'
 
 // ============================================================================
@@ -378,35 +378,38 @@ export function validateSSEEvent(event: unknown): ValidationResult {
     }
   }
 
-  // Generate helpful error messages
-  const issues = result.error.issues.map(issue => ({
-    path: issue.path.map(String),
-    message: issue.message,
-    expected: 'expected' in issue ? String(issue.expected) : undefined,
-    received: 'received' in issue ? String(issue.received) : undefined
-  }))
-
-  // Generate helpful hints based on error patterns
+  // Generate hints from raw Zod issues (before mapping) to access ZodIssueCode
   let hint: string | undefined
 
   // Check for field name mismatches (like textDelta vs delta)
-  // Zod v4 may say "expected string, received undefined" for missing required fields
-  const fieldNameIssues = issues.filter(i =>
-    i.message.includes('Unrecognized key') ||
-    i.message.includes('Required') ||
-    i.message.includes('received undefined') ||
-    (i.message.includes('Invalid input') && i.path.includes('delta'))
+  // In Zod v4, invalid_type issues have `input` (not `received`):
+  //   - input === undefined → required field is missing (likely wrong field name)
+  //   - input !== undefined → field is present but has wrong type
+  const fieldNameIssues = result.error.issues.filter(i =>
+    i.code === ZodIssueCode.unrecognized_keys ||
+    i.code === ZodIssueCode.invalid_union ||
+    (i.code === ZodIssueCode.invalid_type && i.input === undefined)
   )
 
   if (fieldNameIssues.length > 0) {
     hint = 'Field name mismatch detected. This may indicate an AI SDK compatibility issue or version mismatch. Check that field names match the Vercel AI SDK v6 specification.'
   }
 
-  // Check for type mismatches
-  const typeIssues = issues.filter(i => i.message.includes('Expected') || i.message.includes('invalid_type'))
+  // Check for type mismatches (wrong type provided, not a missing field)
+  const typeIssues = result.error.issues.filter(i =>
+    i.code === ZodIssueCode.invalid_type && i.input !== undefined
+  )
   if (typeIssues.length > 0 && !hint) {
     hint = 'Type mismatch detected. Verify that the event fields have the correct data types.'
   }
+
+  // Map issues for structured output
+  const issues = result.error.issues.map(issue => ({
+    path: issue.path.map(String),
+    message: issue.message,
+    expected: 'expected' in issue ? String(issue.expected) : undefined,
+    received: 'received' in issue ? String(issue.received) : undefined
+  }))
 
   return {
     success: false,
@@ -534,7 +537,7 @@ export function generateValidationErrorMessage(result: ValidationResult): string
   }
 
   if (result.error.hint) {
-    message += `\n\n💡 Hint: ${result.error.hint}`
+    message += `\n\nHint: ${result.error.hint}`
   }
 
   return message

--- a/lib/streaming/sse-event-schemas.ts
+++ b/lib/streaming/sse-event-schemas.ts
@@ -388,7 +388,10 @@ export function validateSSEEvent(event: unknown): ValidationResult {
   const fieldNameIssues = result.error.issues.filter(i =>
     i.code === ZodIssueCode.unrecognized_keys ||
     i.code === ZodIssueCode.invalid_union ||
-    (i.code === ZodIssueCode.invalid_type && i.input === undefined)
+    // Zod v4 $ZodIssueInvalidType has optional `input` — omitted entirely (not just undefined)
+    // when the field is missing from the object, so `'input' in i` would be false.
+    // Cast to access the optional property safely.
+    (i.code === ZodIssueCode.invalid_type && (i as { input?: unknown }).input === undefined)
   )
 
   if (fieldNameIssues.length > 0) {
@@ -397,7 +400,7 @@ export function validateSSEEvent(event: unknown): ValidationResult {
 
   // Check for type mismatches (wrong type provided, not a missing field)
   const typeIssues = result.error.issues.filter(i =>
-    i.code === ZodIssueCode.invalid_type && i.input !== undefined
+    i.code === ZodIssueCode.invalid_type && (i as { input?: unknown }).input !== undefined
   )
   if (typeIssues.length > 0 && !hint) {
     hint = 'Type mismatch detected. Verify that the event fields have the correct data types.'

--- a/lib/streaming/sse-event-types.ts
+++ b/lib/streaming/sse-event-types.ts
@@ -612,7 +612,8 @@ export function isErrorEvent(event: SSEEvent): event is ErrorEvent {
 // ============================================================================
 
 // Valid SSE event types for runtime validation
-const VALID_SSE_EVENT_TYPES = new Set([
+// Exported for sync tests — must match SSEEventSchema discriminated union options
+export const VALID_SSE_EVENT_TYPES = new Set([
   'text-start',
   'text-delta',
   'text-end',

--- a/lib/streaming/sse-event-types.ts
+++ b/lib/streaming/sse-event-types.ts
@@ -13,6 +13,10 @@
  * @see https://github.com/psd401/aistudio/issues/366
  */
 
+import { createLogger } from '@/lib/client-logger'
+
+const log = createLogger({ moduleName: 'sse-event-types' })
+
 /**
  * Base interface for all SSE events
  * Every event must have a type discriminator for runtime type checking
@@ -653,12 +657,10 @@ export function parseSSEEvent(data: string): SSEEvent {
 
     // Warn about unrecognized event types (but don't throw - allow extensibility)
     if (!VALID_SSE_EVENT_TYPES.has(parsed.type)) {
-      // In development, log a warning. In production, this could be sent to monitoring.
-      // eslint-disable-next-line no-console
-      if (typeof console !== 'undefined' && console.warn) {
-        // eslint-disable-next-line no-console
-        console.warn(`[SSE] Unrecognized event type: "${parsed.type}". This may indicate a new event type from the SDK or a malformed event.`);
-      }
+      log.warn('Unrecognized SSE event type', {
+        type: parsed.type,
+        hint: 'This may indicate a new event type from the SDK or a malformed event'
+      });
     }
 
     return parsed as unknown as SSEEvent;

--- a/lib/streaming/sse-event-types.ts
+++ b/lib/streaming/sse-event-types.ts
@@ -477,7 +477,8 @@ export function isToolInputStartEvent(event: SSEEvent): event is ToolInputStartE
 export function isToolInputDeltaEvent(event: SSEEvent): event is ToolInputDeltaEvent {
   return event.type === 'tool-input-delta' &&
          'toolCallId' in event &&
-         typeof event.toolCallId === 'string';
+         typeof event.toolCallId === 'string' &&
+         (!('delta' in event) || typeof event.delta === 'string');
 }
 
 /**
@@ -487,7 +488,12 @@ export function isToolInputDeltaEvent(event: SSEEvent): event is ToolInputDeltaE
 export function isToolInputAvailableEvent(event: SSEEvent): event is ToolInputAvailableEvent {
   return event.type === 'tool-input-available' &&
          'toolCallId' in event &&
-         typeof event.toolCallId === 'string';
+         typeof event.toolCallId === 'string' &&
+         (!('toolName' in event) || typeof event.toolName === 'string') &&
+         (!('args' in event) ||
+           (event.args !== null &&
+            typeof event.args === 'object' &&
+            !Array.isArray(event.args)));
 }
 
 /**

--- a/lib/streaming/sse-event-types.ts
+++ b/lib/streaming/sse-event-types.ts
@@ -142,6 +142,32 @@ export interface ToolInputStartEvent extends BaseSSEEvent {
 }
 
 /**
+ * Tool input delta event - incremental tool input updates
+ * Emitted by AI SDK v6 during streaming tool argument construction
+ */
+export interface ToolInputDeltaEvent extends BaseSSEEvent {
+  type: 'tool-input-delta';
+  /** Unique identifier for this tool call */
+  toolCallId: string;
+  /** Incremental input data */
+  delta?: string;
+}
+
+/**
+ * Tool input available event
+ * Indicates complete tool input is available for processing
+ */
+export interface ToolInputAvailableEvent extends BaseSSEEvent {
+  type: 'tool-input-available';
+  /** Unique identifier for this tool call */
+  toolCallId: string;
+  /** Tool name */
+  toolName?: string;
+  /** Complete tool input arguments */
+  args?: Record<string, unknown>;
+}
+
+/**
  * Tool input error event
  * Indicates validation or parsing error in tool inputs
  */
@@ -330,6 +356,8 @@ export type SSEEvent =
   | ToolCallEvent
   | ToolCallDeltaEvent
   | ToolInputStartEvent
+  | ToolInputDeltaEvent
+  | ToolInputAvailableEvent
   | ToolInputErrorEvent
   | ToolOutputErrorEvent
   | ToolOutputAvailableEvent
@@ -436,6 +464,26 @@ export function isToolInputStartEvent(event: SSEEvent): event is ToolInputStartE
          typeof event.toolCallId === 'string' &&
          'toolName' in event &&
          typeof event.toolName === 'string';
+}
+
+/**
+ * Type guard for tool-input-delta events
+ * Validates both type and required fields with strict runtime checks
+ */
+export function isToolInputDeltaEvent(event: SSEEvent): event is ToolInputDeltaEvent {
+  return event.type === 'tool-input-delta' &&
+         'toolCallId' in event &&
+         typeof event.toolCallId === 'string';
+}
+
+/**
+ * Type guard for tool-input-available events
+ * Validates both type and required fields with strict runtime checks
+ */
+export function isToolInputAvailableEvent(event: SSEEvent): event is ToolInputAvailableEvent {
+  return event.type === 'tool-input-available' &&
+         'toolCallId' in event &&
+         typeof event.toolCallId === 'string';
 }
 
 /**
@@ -564,6 +612,8 @@ const VALID_SSE_EVENT_TYPES = new Set([
   'tool-call',
   'tool-call-delta',
   'tool-input-start',
+  'tool-input-delta',
+  'tool-input-available',
   'tool-input-error',
   'tool-output-error',
   'tool-output-available',

--- a/tests/unit/lib/sse-event-schemas.test.ts
+++ b/tests/unit/lib/sse-event-schemas.test.ts
@@ -13,8 +13,10 @@ import {
   validateSSEEvent,
   validateEventType,
   extractEventFields,
-  generateValidationErrorMessage
+  generateValidationErrorMessage,
+  SSEEventSchema
 } from '@/lib/streaming/sse-event-schemas'
+import { VALID_SSE_EVENT_TYPES } from '@/lib/streaming/sse-event-types'
 
 describe('SSE Event Schemas', () => {
   describe('TextDeltaSchema', () => {
@@ -497,6 +499,28 @@ describe('SSE Event Schemas', () => {
       const event = { type: 'source-url', url: 'https://example.com' }
       const result = validateSSEEvent(event)
       expect(result.success).toBe(false)
+    })
+  })
+
+  describe('Schema Sync', () => {
+    it('SSEEventSchema and VALID_SSE_EVENT_TYPES must contain identical event types', () => {
+      // Extract type literals from discriminated union options
+      const schemaTypes = new Set(
+        SSEEventSchema.options.map((schema) => schema.shape.type.value as string)
+      )
+
+      // Every type in SSEEventSchema must be in VALID_SSE_EVENT_TYPES
+      for (const type of schemaTypes) {
+        expect(VALID_SSE_EVENT_TYPES).toContain(type)
+      }
+
+      // Every type in VALID_SSE_EVENT_TYPES must be in SSEEventSchema
+      for (const type of VALID_SSE_EVENT_TYPES) {
+        expect(schemaTypes).toContain(type)
+      }
+
+      // Sets must be the same size
+      expect(schemaTypes.size).toBe(VALID_SSE_EVENT_TYPES.size)
     })
   })
 })

--- a/tests/unit/lib/sse-event-schemas.test.ts
+++ b/tests/unit/lib/sse-event-schemas.test.ts
@@ -422,4 +422,81 @@ describe('SSE Event Schemas', () => {
       expect(duration).toBeLessThan(100)
     })
   })
+
+  describe('ToolInputDeltaSchema', () => {
+    it('should validate tool-input-delta with toolCallId and delta', () => {
+      const event = { type: 'tool-input-delta', toolCallId: 'call-123', delta: '{"key":' }
+      const result = validateSSEEvent(event)
+      expect(result.success).toBe(true)
+    })
+
+    it('should validate tool-input-delta without optional delta', () => {
+      const event = { type: 'tool-input-delta', toolCallId: 'call-123' }
+      const result = validateSSEEvent(event)
+      expect(result.success).toBe(true)
+    })
+
+    it('should reject tool-input-delta missing toolCallId', () => {
+      const event = { type: 'tool-input-delta', delta: '{"key":' }
+      const result = validateSSEEvent(event)
+      expect(result.success).toBe(false)
+    })
+  })
+
+  describe('ToolInputAvailableSchema', () => {
+    it('should validate tool-input-available with toolCallId only', () => {
+      const event = { type: 'tool-input-available', toolCallId: 'call-123' }
+      const result = validateSSEEvent(event)
+      expect(result.success).toBe(true)
+    })
+
+    it('should validate tool-input-available with all optional fields', () => {
+      const event = {
+        type: 'tool-input-available',
+        toolCallId: 'call-123',
+        toolName: 'web_search',
+        args: { query: 'test' }
+      }
+      const result = validateSSEEvent(event)
+      expect(result.success).toBe(true)
+    })
+
+    it('should reject tool-input-available missing toolCallId', () => {
+      const event = { type: 'tool-input-available', toolName: 'web_search' }
+      const result = validateSSEEvent(event)
+      expect(result.success).toBe(false)
+    })
+  })
+
+  describe('SourceUrlSchema', () => {
+    it('should validate source-url with valid https URL', () => {
+      const event = { type: 'source-url', sourceId: 'ws_1', url: 'https://example.com' }
+      const result = validateSSEEvent(event)
+      expect(result.success).toBe(true)
+    })
+
+    it('should validate source-url with optional title', () => {
+      const event = { type: 'source-url', sourceId: 'ws_1', url: 'https://example.com', title: 'Example' }
+      const result = validateSSEEvent(event)
+      expect(result.success).toBe(true)
+    })
+
+    it('should reject source-url with javascript: protocol', () => {
+      const event = { type: 'source-url', sourceId: 'ws_evil', url: 'javascript:alert(1)' }
+      const result = validateSSEEvent(event)
+      expect(result.success).toBe(false)
+    })
+
+    it('should reject source-url with data: protocol', () => {
+      const event = { type: 'source-url', sourceId: 'ws_evil', url: 'data:text/html,<script>alert(1)</script>' }
+      const result = validateSSEEvent(event)
+      expect(result.success).toBe(false)
+    })
+
+    it('should reject source-url missing sourceId', () => {
+      const event = { type: 'source-url', url: 'https://example.com' }
+      const result = validateSSEEvent(event)
+      expect(result.success).toBe(false)
+    })
+  })
 })


### PR DESCRIPTION
## Summary
Fixes three related issues in the Assistant Architect streaming pipeline causing 1,800+ log entries over 2 weeks.

### Changes

**1. Add missing SSE event types** (tool-input-delta, tool-input-available)
- Added TypeScript interfaces, Zod validation schemas, type guards
- Added to discriminated union, valid event type set, and schema validation map
- Added unit tests for new type guards (72 tests passing)
- Eliminates ~1,776 SSE validation warnings/day

**2. Remove client-side CloudWatch publishing**
- Removed publishSSEMonitorMetrics import and call from assistant-architect-streaming.tsx
- Client-side JS has no AWS credentials — these calls always fail
- Server-side ADOT/CloudWatch metrics remain unaffected
- Eliminates 52 "Credential is missing" warnings

**3. Downgrade ContentSafetyBlockedError to warn level**
- Moved ContentSafetyBlockedError check before generic log.error() in all 4 route handlers
- Content safety blocks are expected behavior, not application errors
- Prevents inflating error counts in CloudWatch dashboards
- Updated: nexus/chat, assistant-architect/execute, nexus/decision-chat, chat-helpers

## Test Plan
- [x] TypeScript typecheck passes (0 errors)
- [x] ESLint passes (0 errors, only pre-existing warnings)
- [x] SSE event type unit tests pass (72/72)
- [ ] Deploy to dev and verify SSE validation warnings drop to near-zero
- [ ] Verify CloudWatch credential warnings stop
- [ ] Verify ContentSafetyBlockedError appears at warn level, not error

Closes #835