### PR TITLE
fix: #836 — deduplicate PII token keys before DynamoDB BatchGetItem

### DIFF
--- a/lib/safety/__tests__/pii-tokenization-service.test.ts
+++ b/lib/safety/__tests__/pii-tokenization-service.test.ts
@@ -12,6 +12,14 @@ jest.mock('@aws-sdk/client-dynamodb');
 
 import { DynamoDBClient, BatchGetItemCommand } from '@aws-sdk/client-dynamodb';
 
+interface BatchGetInput {
+  RequestItems: {
+    [tableName: string]: {
+      Keys: Array<{ token: { S: string }; sessionId: { S: string } }>;
+    };
+  };
+}
+
 describe('PIITokenizationService', () => {
   let service: PIITokenizationService;
   const TEST_REGION = 'us-west-2';
@@ -163,14 +171,14 @@ describe('PIITokenizationService', () => {
     const PLACEHOLDER = `[PII:${TOKEN_UUID}]`;
 
     // Capture BatchGetItemCommand constructor args since auto-mock doesn't preserve input
-    let capturedBatchInputs: unknown[];
+    let capturedBatchInputs: BatchGetInput[];
     let mockSend: jest.Mock;
 
     function setupMockDynamo(responses: Record<string, unknown[]>) {
       capturedBatchInputs = [];
       const MockedBatchGetItemCommand = BatchGetItemCommand as jest.MockedClass<typeof BatchGetItemCommand>;
       MockedBatchGetItemCommand.mockImplementation((input) => {
-        capturedBatchInputs.push(input);
+        capturedBatchInputs.push(input as unknown as BatchGetInput);
         return Object.assign(Object.create(BatchGetItemCommand.prototype), { input });
       });
 
@@ -193,8 +201,7 @@ describe('PIITokenizationService', () => {
       // BatchGetItem should be called once with only 1 unique key (not 3)
       expect(mockSend).toHaveBeenCalledTimes(1);
       expect(capturedBatchInputs).toHaveLength(1);
-      const keys = (capturedBatchInputs[0] as Record<string, Record<string, { Keys: unknown[] }>>)
-        .RequestItems['test-table'].Keys;
+      const keys = capturedBatchInputs[0].RequestItems['test-table'].Keys;
       expect(keys).toHaveLength(1);
 
       // All 3 occurrences should still be replaced
@@ -212,8 +219,7 @@ describe('PIITokenizationService', () => {
 
       const result = await service.detokenize(text, 'session-123');
 
-      const keys = (capturedBatchInputs[0] as Record<string, Record<string, { Keys: unknown[] }>>)
-        .RequestItems['test-table'].Keys;
+      const keys = capturedBatchInputs[0].RequestItems['test-table'].Keys;
       expect(keys).toHaveLength(1);
       expect(result).toBe('Jane Jane');
     });
@@ -233,8 +239,7 @@ describe('PIITokenizationService', () => {
 
       const result = await service.detokenize(text, 'session-123');
 
-      const keys = (capturedBatchInputs[0] as Record<string, Record<string, { Keys: unknown[] }>>)
-        .RequestItems['test-table'].Keys;
+      const keys = capturedBatchInputs[0].RequestItems['test-table'].Keys;
       expect(keys).toHaveLength(2);
       expect(result).toBe('Alice and Bob met Alice');
     });

--- a/lib/safety/__tests__/pii-tokenization-service.test.ts
+++ b/lib/safety/__tests__/pii-tokenization-service.test.ts
@@ -229,6 +229,7 @@ describe('PIITokenizationService', () => {
 
       const result = await service.detokenize(text, 'session-123');
 
+      expect(capturedBatchInputs).toHaveLength(1);
       const keys = capturedBatchInputs[0].RequestItems['test-table'].Keys;
       expect(keys).toHaveLength(1);
       expect(result).toBe('Jane Jane');
@@ -249,6 +250,7 @@ describe('PIITokenizationService', () => {
 
       const result = await service.detokenize(text, 'session-123');
 
+      expect(capturedBatchInputs).toHaveLength(1);
       const keys = capturedBatchInputs[0].RequestItems['test-table'].Keys;
       expect(keys).toHaveLength(2);
       expect(result).toBe('Alice and Bob met Alice');

--- a/lib/safety/__tests__/pii-tokenization-service.test.ts
+++ b/lib/safety/__tests__/pii-tokenization-service.test.ts
@@ -172,9 +172,10 @@ describe('PIITokenizationService', () => {
 
     // Capture BatchGetItemCommand constructor args since auto-mock doesn't preserve input
     let capturedBatchInputs: MockBatchGetItemInput[];
-    let mockSend: jest.Mock;
 
     afterEach(() => {
+      // restoreAllMocks() only restores jest.spyOn spies — not direct prototype assignments.
+      // Using jest.spyOn below ensures this cleanup is actually effective.
       jest.restoreAllMocks();
     });
 
@@ -186,8 +187,14 @@ describe('PIITokenizationService', () => {
         return Object.assign(Object.create(BatchGetItemCommand.prototype), { input });
       });
 
-      mockSend = jest.fn().mockResolvedValue({ Responses: responses });
-      (DynamoDBClient as jest.MockedClass<typeof DynamoDBClient>).prototype.send = mockSend;
+      // Use jest.spyOn (not direct assignment) so afterEach restoreAllMocks() cleans up.
+      // Direct assignment (prototype.send = mockFn) is NOT restored by restoreAllMocks()
+      // and would leak mock state to subsequent tests in the same worker.
+      // Cast prototype to any: DynamoDBClient.send is overloaded and TypeScript
+      // resolves the intersection to `never`, blocking mockResolvedValue without the cast.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      jest.spyOn(DynamoDBClient.prototype as any, 'send')
+        .mockResolvedValue({ Responses: responses });
     }
 
     it('should deduplicate token IDs before BatchGetItem call', async () => {
@@ -203,7 +210,6 @@ describe('PIITokenizationService', () => {
       const result = await service.detokenize(text, 'session-123');
 
       // BatchGetItem should be called once with only 1 unique key (not 3)
-      expect(mockSend).toHaveBeenCalledTimes(1);
       expect(capturedBatchInputs).toHaveLength(1);
       const keys = capturedBatchInputs[0].RequestItems['test-table'].Keys;
       expect(keys).toHaveLength(1);

--- a/lib/safety/__tests__/pii-tokenization-service.test.ts
+++ b/lib/safety/__tests__/pii-tokenization-service.test.ts
@@ -12,7 +12,7 @@ jest.mock('@aws-sdk/client-dynamodb');
 
 import { DynamoDBClient, BatchGetItemCommand } from '@aws-sdk/client-dynamodb';
 
-interface BatchGetInput {
+interface MockBatchGetItemInput {
   RequestItems: {
     [tableName: string]: {
       Keys: Array<{ token: { S: string }; sessionId: { S: string } }>;
@@ -171,14 +171,18 @@ describe('PIITokenizationService', () => {
     const PLACEHOLDER = `[PII:${TOKEN_UUID}]`;
 
     // Capture BatchGetItemCommand constructor args since auto-mock doesn't preserve input
-    let capturedBatchInputs: BatchGetInput[];
+    let capturedBatchInputs: MockBatchGetItemInput[];
     let mockSend: jest.Mock;
+
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
 
     function setupMockDynamo(responses: Record<string, unknown[]>) {
       capturedBatchInputs = [];
       const MockedBatchGetItemCommand = BatchGetItemCommand as jest.MockedClass<typeof BatchGetItemCommand>;
       MockedBatchGetItemCommand.mockImplementation((input) => {
-        capturedBatchInputs.push(input as unknown as BatchGetInput);
+        capturedBatchInputs.push(input as unknown as MockBatchGetItemInput);
         return Object.assign(Object.create(BatchGetItemCommand.prototype), { input });
       });
 

--- a/lib/safety/__tests__/pii-tokenization-service.test.ts
+++ b/lib/safety/__tests__/pii-tokenization-service.test.ts
@@ -10,6 +10,8 @@ import { PIITokenizationService } from '../pii-tokenization-service';
 jest.mock('@aws-sdk/client-comprehend');
 jest.mock('@aws-sdk/client-dynamodb');
 
+import { DynamoDBClient, BatchGetItemCommand } from '@aws-sdk/client-dynamodb';
+
 describe('PIITokenizationService', () => {
   let service: PIITokenizationService;
   const TEST_REGION = 'us-west-2';
@@ -153,6 +155,88 @@ describe('PIITokenizationService', () => {
       // Not a valid UUID format - should be left as-is
       const result = await service.detokenize('[PII:invalid]', 'session-123');
       expect(result).toBe('[PII:invalid]');
+    });
+  });
+
+  describe('duplicate token deduplication (Issue #836)', () => {
+    const TOKEN_UUID = '12345678-1234-1234-1234-123456789012';
+    const PLACEHOLDER = `[PII:${TOKEN_UUID}]`;
+
+    // Capture BatchGetItemCommand constructor args since auto-mock doesn't preserve input
+    let capturedBatchInputs: unknown[];
+    let mockSend: jest.Mock;
+
+    function setupMockDynamo(responses: Record<string, unknown[]>) {
+      capturedBatchInputs = [];
+      const MockedBatchGetItemCommand = BatchGetItemCommand as jest.MockedClass<typeof BatchGetItemCommand>;
+      MockedBatchGetItemCommand.mockImplementation((input) => {
+        capturedBatchInputs.push(input);
+        return Object.assign(Object.create(BatchGetItemCommand.prototype), { input });
+      });
+
+      mockSend = jest.fn().mockResolvedValue({ Responses: responses });
+      (DynamoDBClient as jest.MockedClass<typeof DynamoDBClient>).prototype.send = mockSend;
+    }
+
+    it('should deduplicate token IDs before BatchGetItem call', async () => {
+      // Text with the same PII token appearing 3 times
+      const text = `Hello ${PLACEHOLDER}, as ${PLACEHOLDER} mentioned, ${PLACEHOLDER} is correct.`;
+
+      setupMockDynamo({
+        'test-table': [
+          { token: { S: TOKEN_UUID }, original: { S: 'John' }, sessionId: { S: 'session-123' }, type: { S: 'NAME' } },
+        ],
+      });
+
+      const result = await service.detokenize(text, 'session-123');
+
+      // BatchGetItem should be called once with only 1 unique key (not 3)
+      expect(mockSend).toHaveBeenCalledTimes(1);
+      expect(capturedBatchInputs).toHaveLength(1);
+      const keys = (capturedBatchInputs[0] as Record<string, Record<string, { Keys: unknown[] }>>)
+        .RequestItems['test-table'].Keys;
+      expect(keys).toHaveLength(1);
+
+      // All 3 occurrences should still be replaced
+      expect(result).toBe('Hello John, as John mentioned, John is correct.');
+    });
+
+    it('should handle all-duplicate tokens as a single batch key', async () => {
+      const text = `${PLACEHOLDER} ${PLACEHOLDER}`;
+
+      setupMockDynamo({
+        'test-table': [
+          { token: { S: TOKEN_UUID }, original: { S: 'Jane' }, sessionId: { S: 'session-123' }, type: { S: 'NAME' } },
+        ],
+      });
+
+      const result = await service.detokenize(text, 'session-123');
+
+      const keys = (capturedBatchInputs[0] as Record<string, Record<string, { Keys: unknown[] }>>)
+        .RequestItems['test-table'].Keys;
+      expect(keys).toHaveLength(1);
+      expect(result).toBe('Jane Jane');
+    });
+
+    it('should preserve unique tokens while deduplicating repeats', async () => {
+      const TOKEN_A = '11111111-1111-1111-1111-111111111111';
+      const TOKEN_B = '22222222-2222-2222-2222-222222222222';
+      // A appears twice, B appears once → batch should have 2 keys
+      const text = `[PII:${TOKEN_A}] and [PII:${TOKEN_B}] met [PII:${TOKEN_A}]`;
+
+      setupMockDynamo({
+        'test-table': [
+          { token: { S: TOKEN_A }, original: { S: 'Alice' }, sessionId: { S: 'session-123' }, type: { S: 'NAME' } },
+          { token: { S: TOKEN_B }, original: { S: 'Bob' }, sessionId: { S: 'session-123' }, type: { S: 'NAME' } },
+        ],
+      });
+
+      const result = await service.detokenize(text, 'session-123');
+
+      const keys = (capturedBatchInputs[0] as Record<string, Record<string, { Keys: unknown[] }>>)
+        .RequestItems['test-table'].Keys;
+      expect(keys).toHaveLength(2);
+      expect(result).toBe('Alice and Bob met Alice');
     });
   });
 });

--- a/lib/safety/pii-tokenization-service.ts
+++ b/lib/safety/pii-tokenization-service.ts
@@ -322,6 +322,7 @@ export class PIITokenizationService {
       const tokenIds = matches.map((m) => m[1]);
       const tokenMappings = await this.batchGetTokenMappings(tokenIds, sessionId);
 
+      let replacementsApplied = 0;
       for (const match of matches) {
         const [placeholder, token] = match;
 
@@ -330,6 +331,7 @@ export class PIITokenizationService {
 
         if (tokenMapping) {
           detokenizedText = detokenizedText.replace(placeholder, tokenMapping.original);
+          replacementsApplied++;
         } else {
           this.log.warn('Token mapping not found', {
             requestId,
@@ -342,7 +344,8 @@ export class PIITokenizationService {
 
       this.log.info('PII detokenization complete', {
         requestId,
-        tokensRestored: tokenMappings.length,
+        uniqueTokensFetched: tokenMappings.length,
+        textReplacementsApplied: replacementsApplied,
       });
 
       return detokenizedText;

--- a/lib/safety/pii-tokenization-service.ts
+++ b/lib/safety/pii-tokenization-service.ts
@@ -323,6 +323,10 @@ export class PIITokenizationService {
       const tokenMappings = await this.batchGetTokenMappings(tokenIds, sessionId);
 
       let replacementsApplied = 0;
+      // NOTE: matchAll returns every occurrence of a token placeholder as a separate entry.
+      // String.replace(string, string) replaces only the FIRST occurrence, which is correct
+      // here because each iteration handles exactly one site. If matches were deduplicated
+      // before this loop, subsequent occurrences would go unreplaced — intentionally not done.
       for (const match of matches) {
         const [placeholder, token] = match;
 
@@ -330,8 +334,14 @@ export class PIITokenizationService {
         const tokenMapping = tokenMappings.find((t) => t.token === token);
 
         if (tokenMapping) {
+          const before = detokenizedText;
           detokenizedText = detokenizedText.replace(placeholder, tokenMapping.original);
-          replacementsApplied++;
+          // Only increment when the substitution actually changed the string.
+          // In the pathological case where original itself contains a [PII:UUID] pattern,
+          // a prior iteration may have already consumed this placeholder.
+          if (detokenizedText !== before) {
+            replacementsApplied++;
+          }
         } else {
           this.log.warn('Token mapping not found', {
             requestId,
@@ -482,7 +492,10 @@ export class PIITokenizationService {
       return [];
     }
 
-    // BatchGetItem supports up to 100 items per request
+    // BatchGetItem supports up to 100 items per request.
+    // Deduplication is applied BEFORE batching so that batch boundaries always
+    // contain only unique keys. This means 101 tokens that deduplicate to 51
+    // unique IDs split into batches of 51 and 0, not 100 and 1.
     const BATCH_SIZE = 100;
     const batches: string[][] = [];
     for (let i = 0; i < uniqueTokens.length; i += BATCH_SIZE) {

--- a/lib/safety/pii-tokenization-service.ts
+++ b/lib/safety/pii-tokenization-service.ts
@@ -469,6 +469,11 @@ export class PIITokenizationService {
       return [];
     }
 
+    // Deduplicate token IDs — DynamoDB BatchGetItem rejects requests with
+    // duplicate composite keys (token + sessionId). The same PII token UUID
+    // can appear multiple times in text (e.g., same name repeated).
+    const uniqueTokens = [...new Set(tokens)];
+
     const tableName = this.config.piiTokenTableName;
     if (!tableName) {
       return [];
@@ -477,8 +482,8 @@ export class PIITokenizationService {
     // BatchGetItem supports up to 100 items per request
     const BATCH_SIZE = 100;
     const batches: string[][] = [];
-    for (let i = 0; i < tokens.length; i += BATCH_SIZE) {
-      batches.push(tokens.slice(i, i + BATCH_SIZE));
+    for (let i = 0; i < uniqueTokens.length; i += BATCH_SIZE) {
+      batches.push(uniqueTokens.slice(i, i + BATCH_SIZE));
     }
 
     // Process batches concurrently with resilience - use allSettled to avoid losing

--- a/lib/safety/pii-tokenization-service.ts
+++ b/lib/safety/pii-tokenization-service.ts
@@ -354,7 +354,7 @@ export class PIITokenizationService {
 
       this.log.info('PII detokenization complete', {
         requestId,
-        uniqueTokensFetched: tokenMappings.length,
+        uniqueTokensResolved: tokenMappings.length,
         textReplacementsApplied: replacementsApplied,
       });
 
@@ -495,7 +495,7 @@ export class PIITokenizationService {
     // BatchGetItem supports up to 100 items per request.
     // Deduplication is applied BEFORE batching so that batch boundaries always
     // contain only unique keys. This means 101 tokens that deduplicate to 51
-    // unique IDs split into batches of 51 and 0, not 100 and 1.
+    // unique IDs produce a single batch of [51], not two batches of [100, 1].
     const BATCH_SIZE = 100;
     const batches: string[][] = [];
     for (let i = 0; i < uniqueTokens.length; i += BATCH_SIZE) {


### PR DESCRIPTION
## Summary
Fixes #836 — PIITokenizationService sends duplicate composite keys in DynamoDB `BatchGetItem` requests when the same PII token UUID appears multiple times in AI response text.

## Root Cause
`text.matchAll(tokenPattern)` returns all occurrences including duplicates. The token ID array was passed directly to `batchGetTokenMappings()` without deduplication. DynamoDB rejects `BatchGetItem` with duplicate keys (`ValidationException: Provided list of item keys contains duplicates`), triggering a fallback to N individual `GetItem` calls — adding latency and producing 26 error log entries over 2 weeks.

## Changes
- **`lib/safety/pii-tokenization-service.ts`**: Added `[...new Set(tokens)]` deduplication inside `batchGetTokenMappings()` before batch construction. Defensive placement — the method enforces the AWS invariant regardless of caller.
- **`lib/safety/__tests__/pii-tokenization-service.test.ts`**: Added 3 test cases covering:
  - Same token 3x in text → 1 unique batch key, all 3 replacements still applied
  - All-duplicate tokens → single batch key
  - Mixed unique/duplicate tokens → preserves uniques, deduplicates repeats

## Test Plan
- [x] 16 tests passing (13 existing + 3 new)
- [x] Typecheck clean
- [x] Lint clean (no new warnings)
- [x] Validated `detokenize()` loop still replaces all N text occurrences despite deduplicated lookup

Closes #836