### PR TITLE
fix: remove dead response_format json_object in OpenAI Responses API path

### DIFF
--- a/lib/streaming/provider-adapters/openai-adapter.ts
+++ b/lib/streaming/provider-adapters/openai-adapter.ts
@@ -305,16 +305,6 @@ export class OpenAIAdapter extends BaseProviderAdapter {
             stream_reasoning_summaries: true,
             preserve_reasoning_items: true,
 
-            // Response configuration
-            response_format: {
-              type: 'json_object' as const,
-              schema: {
-                reasoning_steps: 'array',
-                thinking_content: 'string',
-                final_answer: 'string'
-              }
-            },
-
             // Tool configuration for reasoning models
             parallel_tool_calls: true
           }


### PR DESCRIPTION
## Summary
Fixes #850 — removes a hard-coded `response_format: { type: 'json_object' }` from the dead `__responsesAPI` code path in the OpenAI adapter.

## Changes
- Removed `response_format` block (10 lines) from `openai-adapter.ts` Responses API config
- Preserved other Responses API scaffolding (reasoning effort, tool config)
- No behavioral change — the `__responsesAPI` flag is never set, so this path is unreachable

## Risk
Zero — removing dead code from an unreachable branch. Lint and typecheck pass clean.

## Test Plan
- [x] `bun run lint` — 0 errors
- [x] `bun run typecheck` — passes
- [x] Grep confirms `__responsesAPI` is not set anywhere in codebase

Closes #850