### PR TITLE
fix: remove client-logger import from shared sse-event-types module

### DIFF
--- a/lib/streaming/__tests__/sse-event-types.test.ts
+++ b/lib/streaming/__tests__/sse-event-types.test.ts
@@ -84,7 +84,7 @@ describe('SSE Event Parsing', () => {
       const data = '{"type":"unknown-type","data":"test"}';
 
       // parseSSEEvent should not throw — unknown types are gracefully forwarded
-      // with a structured log.warn via @/lib/client-logger (no console.warn)
+      // with a console.warn (can't use client-logger or server logger in this shared module)
       expect(() => parseSSEEvent(data)).not.toThrow();
       const event = parseSSEEvent(data);
       expect(event.type).toBe('unknown-type');

--- a/lib/streaming/sse-event-types.ts
+++ b/lib/streaming/sse-event-types.ts
@@ -665,7 +665,7 @@ export function parseSSEEvent(data: string): SSEEvent {
     // Warn about unrecognized event types (but don't throw - allow extensibility)
     if (!VALID_SSE_EVENT_TYPES.has(parsed.type)) {
       // eslint-disable-next-line no-console -- shared client/server file, can't use either logger
-      console.warn('[sse-event-types] Unrecognized SSE event type:', parsed.type);
+      console.warn('[sse-event-types] Unrecognized SSE event type', { type: parsed.type, hint: 'This may indicate a new event type from the SDK or a malformed event' });
     }
 
     return parsed as unknown as SSEEvent;

--- a/lib/streaming/sse-event-types.ts
+++ b/lib/streaming/sse-event-types.ts
@@ -13,9 +13,9 @@
  * @see https://github.com/psd401/aistudio/issues/366
  */
 
-import { createLogger } from '@/lib/client-logger'
-
-const log = createLogger({ moduleName: 'sse-event-types' })
+// Note: This file is imported by both server routes (API) and client components.
+// Do NOT import from @/lib/client-logger (has 'use client') or @/lib/logger (uses winston).
+// Either would poison the opposite bundle. Use console.warn for the single diagnostic call.
 
 /**
  * Base interface for all SSE events
@@ -664,10 +664,8 @@ export function parseSSEEvent(data: string): SSEEvent {
 
     // Warn about unrecognized event types (but don't throw - allow extensibility)
     if (!VALID_SSE_EVENT_TYPES.has(parsed.type)) {
-      log.warn('Unrecognized SSE event type', {
-        type: parsed.type,
-        hint: 'This may indicate a new event type from the SDK or a malformed event'
-      });
+      // eslint-disable-next-line no-console -- shared client/server file, can't use either logger
+      console.warn('[sse-event-types] Unrecognized SSE event type:', parsed.type);
     }
 
     return parsed as unknown as SSEEvent;


### PR DESCRIPTION
## Summary

Fixes production build failure introduced in PR #841 (merged 2026-03-11).

**Error:**
```
Error: Attempted to call createLogger() from the server but createLogger is on the client.
Failed to collect page data for /api/assistant-architect/execute/scheduled
```

**Root cause:** `lib/streaming/sse-event-types.ts` imported `createLogger` from `@/lib/client-logger` (which has `'use client'`). This file is also imported by server-side API routes via `lib/streaming/` imports. Next.js 16 classifies the module as client code due to the transitive `'use client'` dependency, then fails when server routes try to call `createLogger()`.

**Fix:** Removed the `client-logger` import. Replaced the single `log.warn` call with `console.warn`. This file is shared between client and server contexts — it cannot import from either logger.

**Bisection evidence:**
- Build passes at `e05267e6` (before PR #841)
- Build fails at `03cc45e6` (after PR #841)

## Test Plan
- [x] `bun run build` passes (was failing)
- [x] `bun run typecheck` clean
- [x] No functionality lost — the removed log was a single diagnostic `warn` for unrecognized SSE event types, now `console.warn`