### PR TITLE
fix: #860 — Asymmetric HATE filter, CONTENT_BLOCKED categories, and client error handling

### DIFF
--- a/app/(protected)/nexus/decision-capture/page.tsx
+++ b/app/(protected)/nexus/decision-capture/page.tsx
@@ -16,6 +16,7 @@ import { ChartVisualizationUI } from '../_components/tools/chart-visualization-u
 import { createEnhancedNexusAttachmentAdapter } from '@/lib/nexus/enhanced-attachment-adapters'
 import { validateConversationId, navigateToDecisionCaptureConversation, navigateToNewDecisionCapture } from '@/lib/nexus/conversation-navigation'
 import { createLogger } from '@/lib/client-logger'
+import { toast } from 'sonner'
 
 /**
  * Decision Capture Page
@@ -97,9 +98,42 @@ function DecisionRuntimeProvider({
     })
   }, [])
 
-  // Custom fetch to intercept conversation ID header
+  // Custom fetch to intercept conversation ID header and handle content safety blocks
   const customFetch = useCallback(async (input: RequestInfo | URL, init?: RequestInit) => {
     const response = await fetch(input, init)
+
+    // Handle content safety blocked errors (400 with CONTENT_BLOCKED code)
+    // Issue #860: Throw after showing the toast to prevent the AI SDK runtime
+    // from parsing the non-streaming 400 JSON response as a stream, which causes
+    // TypeError: Cannot read properties of undefined (reading 'id')
+    if (response.status === 400) {
+      try {
+        const clonedResponse = response.clone()
+        const errorData = await clonedResponse.json()
+        if (errorData.code === 'CONTENT_BLOCKED') {
+          const categories = errorData.categories?.length
+            ? ` (${errorData.categories.join(', ')})`
+            : ''
+          toast.error('Content Blocked', {
+            description: `Your message was flagged by the content safety filter${categories}. Try rephrasing your request.`,
+            duration: 6000
+          })
+          log.warn('Content blocked by safety guardrails', {
+            error: errorData.error,
+            categories: errorData.categories,
+            source: errorData.source,
+          })
+          const err = new Error(errorData.error || 'Content blocked by safety guardrails')
+          ;(err as Error & { isContentBlocked: boolean }).isContentBlocked = true
+          throw err
+        }
+      } catch (e) {
+        if (e instanceof Error && (e as Error & { isContentBlocked?: boolean }).isContentBlocked) {
+          throw e
+        }
+        log.debug('Could not parse error response as JSON')
+      }
+    }
 
     const newConversationId = response.headers.get('X-Conversation-Id')
     if (newConversationId && newConversationId !== conversationId) {

--- a/app/(protected)/nexus/decision-capture/page.tsx
+++ b/app/(protected)/nexus/decision-capture/page.tsx
@@ -16,7 +16,7 @@ import { ChartVisualizationUI } from '../_components/tools/chart-visualization-u
 import { createEnhancedNexusAttachmentAdapter } from '@/lib/nexus/enhanced-attachment-adapters'
 import { validateConversationId, navigateToDecisionCaptureConversation, navigateToNewDecisionCapture } from '@/lib/nexus/conversation-navigation'
 import { createLogger } from '@/lib/client-logger'
-import { toast } from 'sonner'
+import { handleContentBlockedResponse } from '@/lib/nexus/content-blocked-handler'
 
 /**
  * Decision Capture Page
@@ -102,38 +102,9 @@ function DecisionRuntimeProvider({
   const customFetch = useCallback(async (input: RequestInfo | URL, init?: RequestInit) => {
     const response = await fetch(input, init)
 
-    // Handle content safety blocked errors (400 with CONTENT_BLOCKED code)
-    // Issue #860: Throw after showing the toast to prevent the AI SDK runtime
-    // from parsing the non-streaming 400 JSON response as a stream, which causes
-    // TypeError: Cannot read properties of undefined (reading 'id')
-    if (response.status === 400) {
-      try {
-        const clonedResponse = response.clone()
-        const errorData = await clonedResponse.json()
-        if (errorData.code === 'CONTENT_BLOCKED') {
-          const categories = errorData.categories?.length
-            ? ` (${errorData.categories.join(', ')})`
-            : ''
-          toast.error('Content Blocked', {
-            description: `Your message was flagged by the content safety filter${categories}. Try rephrasing your request.`,
-            duration: 6000
-          })
-          log.warn('Content blocked by safety guardrails', {
-            error: errorData.error,
-            categories: errorData.categories,
-            source: errorData.source,
-          })
-          const err = new Error(errorData.error || 'Content blocked by safety guardrails')
-          ;(err as Error & { isContentBlocked: boolean }).isContentBlocked = true
-          throw err
-        }
-      } catch (e) {
-        if (e instanceof Error && (e as Error & { isContentBlocked?: boolean }).isContentBlocked) {
-          throw e
-        }
-        log.debug('Could not parse error response as JSON')
-      }
-    }
+    // Issue #860: Handle CONTENT_BLOCKED 400 responses — shows toast and throws
+    // to prevent AI SDK runtime from parsing non-streaming JSON as a stream
+    await handleContentBlockedResponse(response, log)
 
     const newConversationId = response.headers.get('X-Conversation-Id')
     if (newConversationId && newConversationId !== conversationId) {

--- a/app/(protected)/nexus/page.tsx
+++ b/app/(protected)/nexus/page.tsx
@@ -134,12 +134,16 @@ function ConversationRuntimeProvider({
             categories: errorData.categories,
             source: errorData.source,
           })
-          // Throw to stop the AI SDK runtime from processing this non-streaming response
-          throw new Error(errorData.error || 'Content blocked by safety guardrails')
+          // Throw to stop the AI SDK runtime from processing this non-streaming response.
+          // Use a sentinel property so the outer catch can reliably re-throw regardless
+          // of what Bedrock puts in the error message.
+          const err = new Error(errorData.error || 'Content blocked by safety guardrails')
+          ;(err as Error & { isContentBlocked: boolean }).isContentBlocked = true
+          throw err
         }
       } catch (e) {
         // Re-throw CONTENT_BLOCKED errors — only swallow JSON parse failures
-        if (e instanceof Error && e.message.includes('Content blocked')) {
+        if (e instanceof Error && (e as Error & { isContentBlocked?: boolean }).isContentBlocked) {
           throw e
         }
         log.debug('Could not parse error response as JSON')

--- a/app/(protected)/nexus/page.tsx
+++ b/app/(protected)/nexus/page.tsx
@@ -114,21 +114,34 @@ function ConversationRuntimeProvider({
     }
 
     // Handle content safety blocked errors (400 with CONTENT_BLOCKED code)
+    // Issue #860: Throw after showing the toast to prevent the AI SDK runtime
+    // from parsing the non-streaming 400 JSON response as a stream, which causes
+    // TypeError: Cannot read properties of undefined (reading 'id')
     if (response.status === 400) {
       try {
-        // Clone response to read body without consuming it
         const clonedResponse = response.clone()
         const errorData = await clonedResponse.json()
         if (errorData.code === 'CONTENT_BLOCKED') {
-          // Show user-friendly toast notification
+          const categories = errorData.categories?.length
+            ? ` (${errorData.categories.join(', ')})`
+            : ''
           toast.error('Content Blocked', {
-            description: errorData.error || 'This content is not appropriate for educational use.',
+            description: `Your message was flagged by the content safety filter${categories}. Try rephrasing your request.`,
             duration: 6000
           })
-          log.warn('Content blocked by safety guardrails', { error: errorData.error })
+          log.warn('Content blocked by safety guardrails', {
+            error: errorData.error,
+            categories: errorData.categories,
+            source: errorData.source,
+          })
+          // Throw to stop the AI SDK runtime from processing this non-streaming response
+          throw new Error(errorData.error || 'Content blocked by safety guardrails')
         }
-      } catch {
-        // If we can't parse the error, let the default error handling occur
+      } catch (e) {
+        // Re-throw CONTENT_BLOCKED errors — only swallow JSON parse failures
+        if (e instanceof Error && e.message.includes('Content blocked')) {
+          throw e
+        }
         log.debug('Could not parse error response as JSON')
       }
     }

--- a/app/(protected)/nexus/page.tsx
+++ b/app/(protected)/nexus/page.tsx
@@ -23,6 +23,7 @@ import { validateConversationId } from '@/lib/nexus/conversation-navigation'
 import type { SelectAiModel } from '@/types'
 import { createLogger } from '@/lib/client-logger'
 import { toast } from 'sonner'
+import { handleContentBlockedResponse } from '@/lib/nexus/content-blocked-handler'
 import { getPromptSettings } from '@/actions/prompt-library.actions'
 import { ModelFallbackBanner } from './_components/model-fallback-banner'
 
@@ -113,42 +114,9 @@ function ConversationRuntimeProvider({
       }
     }
 
-    // Handle content safety blocked errors (400 with CONTENT_BLOCKED code)
-    // Issue #860: Throw after showing the toast to prevent the AI SDK runtime
-    // from parsing the non-streaming 400 JSON response as a stream, which causes
-    // TypeError: Cannot read properties of undefined (reading 'id')
-    if (response.status === 400) {
-      try {
-        const clonedResponse = response.clone()
-        const errorData = await clonedResponse.json()
-        if (errorData.code === 'CONTENT_BLOCKED') {
-          const categories = errorData.categories?.length
-            ? ` (${errorData.categories.join(', ')})`
-            : ''
-          toast.error('Content Blocked', {
-            description: `Your message was flagged by the content safety filter${categories}. Try rephrasing your request.`,
-            duration: 6000
-          })
-          log.warn('Content blocked by safety guardrails', {
-            error: errorData.error,
-            categories: errorData.categories,
-            source: errorData.source,
-          })
-          // Throw to stop the AI SDK runtime from processing this non-streaming response.
-          // Use a sentinel property so the outer catch can reliably re-throw regardless
-          // of what Bedrock puts in the error message.
-          const err = new Error(errorData.error || 'Content blocked by safety guardrails')
-          ;(err as Error & { isContentBlocked: boolean }).isContentBlocked = true
-          throw err
-        }
-      } catch (e) {
-        // Re-throw CONTENT_BLOCKED errors — only swallow JSON parse failures
-        if (e instanceof Error && (e as Error & { isContentBlocked?: boolean }).isContentBlocked) {
-          throw e
-        }
-        log.debug('Could not parse error response as JSON')
-      }
-    }
+    // Issue #860: Handle CONTENT_BLOCKED 400 responses — shows toast and throws
+    // to prevent AI SDK runtime from parsing non-streaming JSON as a stream
+    await handleContentBlockedResponse(response, log)
 
     // Extract conversation ID from response header (new conversations only)
     const newConversationId = response.headers.get('X-Conversation-Id')

--- a/app/api/nexus/chat/route.ts
+++ b/app/api/nexus/chat/route.ts
@@ -609,7 +609,13 @@ export async function POST(req: Request) {
       });
       timer({ status: 'blocked' });
       return new Response(
-        JSON.stringify({ error: error.message, code: 'CONTENT_BLOCKED', requestId }),
+        JSON.stringify({
+          error: error.message,
+          code: 'CONTENT_BLOCKED',
+          categories: error.blockedCategories,
+          source: error.source,
+          requestId,
+        }),
         { status: 400, headers: { 'Content-Type': 'application/json', 'X-Request-Id': requestId } }
       );
     }

--- a/app/api/nexus/decision-chat/route.ts
+++ b/app/api/nexus/decision-chat/route.ts
@@ -475,7 +475,13 @@ export async function POST(req: Request) {
       });
       timer({ status: 'blocked' });
       return new Response(
-        JSON.stringify({ error: error.message, code: 'CONTENT_BLOCKED', requestId }),
+        JSON.stringify({
+          error: error.message,
+          code: 'CONTENT_BLOCKED',
+          categories: error.blockedCategories,
+          source: error.source,
+          requestId,
+        }),
         { status: 400, headers: { 'Content-Type': 'application/json', 'X-Request-Id': requestId } }
       );
     }

--- a/docs/features/k12-content-safety.md
+++ b/docs/features/k12-content-safety.md
@@ -37,7 +37,7 @@ The content filtering system evaluates all messages against configurable safety 
 
 | Category | Type | Description | Action |
 |----------|------|-------------|--------|
-| **Hate Speech** | Content Filter | Content targeting protected groups | **Blocked (LOW)** — Bedrock minimum requirement |
+| **Hate Speech** | Content Filter | Content targeting protected groups | **Input: Blocked (LOW), Output: Detect only** — Bedrock minimum req. Asymmetric since Issue #860 |
 | **Violence** | Content Filter | Graphic violence or threats | **Detect only (Issue #761)** |
 | **Self-Harm** | Topic Policy | Content encouraging self-injury | **Detect only (Issue #742)** |
 | **Sexual Content** | Content Filter | Inappropriate sexual material | **Detect only (Issue #761)** |
@@ -420,7 +420,7 @@ Content filters use strength levels (`NONE`, `LOW`, `MEDIUM`, `HIGH`) to balance
 
 | Filter | Current Setting | Purpose | Educational Considerations |
 |--------|----------------|---------|---------------------------|
-| **HATE** | **LOW** (blocking) | Blocks discrimination/prejudice | LOW is Bedrock minimum — required to maintain guardrail. Allows civil rights, Holocaust education at this threshold. |
+| **HATE** | **Input: LOW, Output: NONE** | Blocks discrimination/prejudice | Issue #860 — asymmetric config. Input at LOW (Bedrock minimum), output at NONE. 30-day analysis showed 100% FP rate on output (educational docs). |
 | **VIOLENCE** | NONE (detect only) | Graphic violence | Issue #761 — FPs on history (wars, civil rights), literature, biology |
 | **SEXUAL** | NONE (detect only) | Sexual content | Issue #761 — FPs on health education discussions |
 | **INSULTS** | NONE (detect only) | Personal attacks | Issue #761 — FPs on teacher observations, behavior discussions |

--- a/docs/operations/guardrail-tuning-analysis.md
+++ b/docs/operations/guardrail-tuning-analysis.md
@@ -10,8 +10,8 @@ Only two policies actively block content:
 
 | Policy | Type | Status | Notes |
 |--------|------|--------|-------|
-| **HATE** | Content Filter | `LOW` (blocking) | Bedrock requires at least one non-NONE filter |
-| **PROFANITY** | Managed Word List | ON (blocking) | Binary on/off — no strength tuning available |
+| **HATE** | Content Filter | Input: `LOW`, Output: `NONE` | Issue #860 — asymmetric. Bedrock requires at least one non-NONE filter; input LOW satisfies this. Output NONE eliminates AI response FPs. |
+| **PROFANITY** | Managed Word List | OFF (disabled) | Issue #763 — 97% of blocks, 24x rate spike. Binary on/off. |
 
 ### Detect-Only Policies (logging, not blocking)
 

--- a/infra/lib/guardrails-stack.ts
+++ b/infra/lib/guardrails-stack.ts
@@ -79,13 +79,20 @@ export class GuardrailsStack extends cdk.Stack {
       // - Issue #727: PROMPT_ATTACK disabled (75% false positive rate)
       // - Issue #761: All filters to NONE except HATE at LOW (Bedrock minimum requirement)
       // - Issue #763: PROFANITY word policy disabled (97% of all blocks, 24x rate spike)
+      // - Issue #860: HATE asymmetric (input LOW, output NONE) — 100% FP rate on output
       contentPolicyConfig: {
         filtersConfig: [
           {
-            // Kept at LOW — Bedrock requires at least one non-NONE filter
+            // Issue #860: Asymmetric — input at LOW (Bedrock minimum), output at NONE.
+            // 30-day analysis (#763) found HATE at LOW had 100% false positive rate
+            // (2/2 blocks were on large educational documents: 28KB, 52KB).
+            // Asymmetric config eliminates output false positives (the most disruptive —
+            // blocks AI responses users already waited for) while satisfying Bedrock's
+            // requirement of at least one non-NONE content filter.
+            // inputStrength: 'LOW' still catches genuinely hateful user input.
             type: 'HATE',
             inputStrength: 'LOW',
-            outputStrength: 'LOW',
+            outputStrength: 'NONE',
           },
           {
             type: 'VIOLENCE',

--- a/lib/nexus/content-blocked-handler.ts
+++ b/lib/nexus/content-blocked-handler.ts
@@ -43,7 +43,7 @@ export async function handleContentBlockedResponse(
     const clonedResponse = response.clone()
     const errorData: ContentBlockedResponse = await clonedResponse.json()
     if (errorData.code === 'CONTENT_BLOCKED') {
-      const categories = errorData.categories?.length
+      const categories = Array.isArray(errorData.categories) && errorData.categories.length
         ? ` (${errorData.categories.join(', ')})`
         : ''
       toast.error('Content Blocked', {

--- a/lib/nexus/content-blocked-handler.ts
+++ b/lib/nexus/content-blocked-handler.ts
@@ -1,0 +1,69 @@
+import { toast } from 'sonner'
+
+/**
+ * Client-side error for content safety blocks.
+ * Thrown from customFetch to prevent the AI SDK runtime from parsing
+ * the non-streaming 400 response as a stream (which causes TypeError).
+ *
+ * Issue #860: Replaces the inline `isContentBlocked` sentinel pattern
+ * with a proper typed class for `instanceof` checks.
+ */
+export class ContentBlockedFetchError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'ContentBlockedFetchError'
+  }
+}
+
+interface ContentBlockedResponse {
+  code: string
+  error?: string
+  categories?: string[]
+  source?: string
+}
+
+/**
+ * Handles CONTENT_BLOCKED responses in customFetch callbacks.
+ *
+ * Shows a user-friendly toast with the blocked categories, logs the event,
+ * and throws ContentBlockedFetchError to stop the AI SDK runtime from
+ * attempting to parse the non-streaming 400 JSON as a stream.
+ *
+ * @param response - The fetch Response to check
+ * @param log - Logger instance for structured logging
+ * @throws ContentBlockedFetchError if the response is a CONTENT_BLOCKED 400
+ */
+export async function handleContentBlockedResponse(
+  response: Response,
+  log: { warn: (msg: string, data?: Record<string, unknown>) => void; debug: (msg: string) => void }
+): Promise<void> {
+  if (response.status !== 400) return
+
+  try {
+    const clonedResponse = response.clone()
+    const errorData: ContentBlockedResponse = await clonedResponse.json()
+    if (errorData.code === 'CONTENT_BLOCKED') {
+      const categories = errorData.categories?.length
+        ? ` (${errorData.categories.join(', ')})`
+        : ''
+      toast.error('Content Blocked', {
+        description: `Your message was flagged by the content safety filter${categories}. Try rephrasing your request.`,
+        duration: 6000
+      })
+      log.warn('Content blocked by safety guardrails', {
+        error: errorData.error,
+        categories: errorData.categories,
+        source: errorData.source,
+      })
+      throw new ContentBlockedFetchError(
+        errorData.error || 'Content blocked by safety guardrails'
+      )
+    }
+  } catch (e) {
+    // Re-throw ContentBlockedFetchError — only swallow JSON parse failures
+    if (e instanceof ContentBlockedFetchError) {
+      throw e
+    }
+    log.debug('Could not parse error response as JSON')
+  }
+}


### PR DESCRIPTION
## Summary

Fixes #860 — Guardrail false positive blocking educational CollegeBoard content in Nanobanana2.

Three targeted changes based on 30-day production analysis (PR #858) and deep architecture research:

## Changes

### 1. Asymmetric HATE Content Filter (`infra/lib/guardrails-stack.ts`)
- Changed HATE from `inputStrength: LOW / outputStrength: LOW` → `inputStrength: LOW / outputStrength: NONE`
- **Evidence**: 30-day analysis showed HATE at LOW had **100% false positive rate** (2/2 blocks were on 28KB and 52KB educational documents)
- Eliminates AI output blocking (most disruptive — blocks responses users already waited for)
- `inputStrength: LOW` satisfies Bedrock's minimum non-NONE filter requirement
- CDK synth validated ✅

### 2. Include `blockedCategories` in API Error Responses
- Nexus chat and decision-chat routes now return `categories` and `source` in the 400 CONTENT_BLOCKED response
- Matches the existing pattern in v1 API routes and assistant-architect
- Client toast now shows which filter category triggered: "flagged by content safety filter (Hate speech)" instead of generic message

### 3. Fix Client TypeError on Guardrail Block (`page.tsx`)
- The `customFetch` callback showed a toast but still returned the non-streaming 400 response to the AI SDK runtime
- Runtime tried to parse it as a stream → `TypeError: Cannot read properties of undefined (reading 'id')`
- Now throws after showing the toast, preventing the runtime from processing the error response
- Re-throw logic preserves the throw while still catching JSON parse errors from non-CONTENT_BLOCKED 400s

## Guardrail State After This PR

| Policy | Input | Output | Status |
|--------|-------|--------|--------|
| HATE | LOW | **NONE** ← changed | Only active input filter |
| VIOLENCE | NONE | NONE | Detect only (#761) |
| SEXUAL | NONE | NONE | Detect only (#761) |
| INSULTS | NONE | NONE | Detect only (#761) |
| MISCONDUCT | NONE | NONE | Detect only (#761) |
| PROMPT_ATTACK | NONE | NONE | Disabled (#727) |
| PROFANITY | OFF | OFF | Disabled (#763) |
| Topics (4) | NONE | NONE | Detect only (#742) |

## Test Plan

- [x] TypeScript compiles (`bun run typecheck` — 0 errors)
- [x] Lint passes (`bun run lint` — 0 errors)
- [x] Guardrails unit tests pass (24/24)
- [x] CDK synth passes with asymmetric config
- [ ] Deploy to dev: `cd infra && bunx cdk deploy AIStudio-GuardrailsStack-Dev`
- [ ] Manual test: Paste CollegeBoard article content into Nanobanana2 → should NOT be blocked
- [ ] Manual test: Verify CONTENT_BLOCKED toast shows category when a block does occur
- [ ] Monitor block rate for 1 week — expect significant decrease

## Next Steps (Post-Merge)

1. **Deploy guardrails stack**: `cd infra && bunx cdk deploy AIStudio-GuardrailsStack-Dev`
2. **Monitor** detect-only data for 1 week via CloudWatch queries in `docs/operations/guardrail-tuning-analysis.md`
3. **Evaluate STANDARD tier** in dev (per issue #860 architecture comment) — AWS claims lower FP rates and 1000-char topic definitions
4. **90-day decision point**: If zero true positives detected that LLM providers missed → consider removing Bedrock content filtering entirely (keep PII tokenization)

Closes #860