### PR TITLE
fix: Remove ALB stickiness cookies — Qualys WAS scan remediation

### DIFF
--- a/docs/diagrams/09-streaming-architecture.md
+++ b/docs/diagrams/09-streaming-architecture.md
@@ -93,8 +93,7 @@ const httpsListener = alb.addListener('HttpsListener', {
   // Connection settings for streaming
   defaultActions: [{
     type: ListenerAction.forward({
-      targets: [ecsService],
-      stickinessCookieDuration: Duration.hours(1)
+      targets: [ecsService]
     })
   }]
 });
@@ -112,10 +111,7 @@ const targetGroup = new ApplicationTargetGroup(this, 'ECSTargetGroup', {
   },
   // Streaming-friendly settings
   deregistrationDelay: Duration.seconds(30),
-  slowStart: Duration.seconds(60),
-  // Keep connections alive for streaming
-  stickiness Enabled: true,
-  stickinessCookieDuration: Duration.hours(1)
+  slowStart: Duration.seconds(60)
 });
 ```
 

--- a/infra/lib/constructs/ecs-service.ts
+++ b/infra/lib/constructs/ecs-service.ts
@@ -656,7 +656,6 @@ export class EcsServiceConstruct extends Construct {
         healthyHttpCodes: '200',
       },
       deregistrationDelay: cdk.Duration.seconds(30),
-      stickinessCookieDuration: cdk.Duration.hours(1),
       targets: [this.service],
     });
 


### PR DESCRIPTION
## Summary

Resolves 3 Qualys WAS vulnerabilities (CVSS 4.3 each) flagged on 2026-04-08 by removing unnecessary ALB duration-based session stickiness.

Closes #878

## Qualys Findings Addressed

| QID | Cookie | Missing Attribute | CWE |
|-----|--------|-------------------|-----|
| 150122 | `AWSALB` | `Secure` | CWE-614 |
| 150123 | `AWSALBCORS` | `HttpOnly` | CWE-1004 |
| 150123 | `AWSALB` | `HttpOnly` | CWE-1004 |

## Changes

- Removed `stickinessCookieDuration: cdk.Duration.hours(1)` from `infra/lib/constructs/ecs-service.ts`

## Root Cause

AWS does not expose any API to set `Secure` or `HttpOnly` on ALB-managed duration-based stickiness cookies (`AWSALB`/`AWSALBCORS`). This is a hard vendor limitation. The fix is to remove stickiness entirely, which eliminates these cookies from responses.

**Application cookies** (`authjs.csrf-token`, `authjs.callback-url`) already have `Secure; HttpOnly; SameSite=Lax` — no changes needed there.

## Why This is Safe

- The application is **stateless** — NextAuth v5 JWT sessions + Aurora database
- No in-memory session state is tied to specific ECS containers
- Stickiness was added as a default in the initial ECS setup (#306) but was never functionally required
- SSE streaming connections persist within a single HTTP connection regardless of stickiness

## Test Plan

- [x] CDK synth passes (no compile errors)
- [x] TypeScript compilation clean
- [ ] Deploy to dev: `cd infra && bunx cdk deploy AIStudio-FrontendStack-ECS-Dev`
- [ ] Verify `AWSALB`/`AWSALBCORS` cookies absent: `curl -sI https://dev.aistudio.psd401.ai/ | grep -i set-cookie`
- [ ] SSE chat streaming works
- [ ] Login/logout flow works
- [ ] Request Qualys re-scan