### PR TITLE
feat: #875 — Voice transcript persistence with Bedrock guardrails

### DIFF
--- a/lib/constants/conversation.ts
+++ b/lib/constants/conversation.ts
@@ -1,0 +1,16 @@
+/**
+ * Conversation Constants
+ *
+ * Shared sentinel values used across conversation creation, title detection,
+ * and voice transcript persistence. Centralizing these prevents silent
+ * coupling failures if a default value changes in one location.
+ */
+
+/**
+ * Default title assigned to new conversations when no title is provided.
+ *
+ * Used by:
+ * - nexus-conversations.ts (conversation creation default)
+ * - transcript-service.ts (detect untitled conversations for auto-titling)
+ */
+export const DEFAULT_CONVERSATION_TITLE = "New Conversation"

--- a/lib/db/drizzle/nexus-conversations.ts
+++ b/lib/db/drizzle/nexus-conversations.ts
@@ -25,6 +25,7 @@ import {
   nexusConversationEvents,
 } from "@/lib/db/schema";
 import { countAsInt } from "@/lib/db/drizzle/helpers/pagination";
+import { DEFAULT_CONVERSATION_TITLE } from "@/lib/constants/conversation";
 import type {
   NexusConversationMetadata,
   NexusFolderSettings,
@@ -280,7 +281,7 @@ export async function createConversation(data: CreateConversationData) {
   }
 
   // Use provided title or default (handles undefined, null, empty, or whitespace-only strings)
-  const title = data.title?.trim() || "New Conversation";
+  const title = data.title?.trim() || DEFAULT_CONVERSATION_TITLE;
 
   const result = await executeQuery(
     (db) =>

--- a/lib/voice/__tests__/transcript-service.test.ts
+++ b/lib/voice/__tests__/transcript-service.test.ts
@@ -1,0 +1,437 @@
+/**
+ * Tests for Voice Transcript Persistence Service
+ *
+ * Tests transcript preparation (merge, filter), guardrail integration (mocked),
+ * title generation, and the full save flow with mocked DB operations.
+ *
+ * Issue #875
+ */
+
+import { saveVoiceTranscript, prepareTranscriptEntries } from "../transcript-service"
+import type { TranscriptEntry } from "../types"
+
+// ============================================
+// Mocks
+// ============================================
+
+const mockExecuteTransaction = jest.fn()
+const mockGetConversationById = jest.fn()
+
+jest.mock("@/lib/db/drizzle-client", () => ({
+  executeTransaction: (...args: unknown[]) => mockExecuteTransaction(...args),
+}))
+
+jest.mock("@/lib/db/drizzle/nexus-conversations", () => ({
+  getConversationById: (...args: unknown[]) => mockGetConversationById(...args),
+}))
+
+jest.mock("@/lib/db/schema", () => ({
+  nexusMessages: { id: "id", conversationId: "conversation_id", role: "role" },
+  nexusConversations: { id: "id", messageCount: "message_count" },
+}))
+
+jest.mock("@/lib/db/json-utils", () => ({
+  safeJsonbStringify: (val: unknown) => JSON.stringify(val),
+}))
+
+// Mock drizzle-orm's sql template tag and eq function
+jest.mock("drizzle-orm", () => ({
+  sql: Object.assign(
+    (strings: TemplateStringsArray, ...values: unknown[]) => ({ strings, values, _tag: "sql" }),
+    { raw: (s: string) => ({ raw: s, _tag: "sql" }) },
+  ),
+  eq: (a: unknown, b: unknown) => ({ a, b, _tag: "eq" }),
+}))
+
+const mockCheckInputSafety = jest.fn()
+const mockCheckOutputSafety = jest.fn()
+const mockIsGuardrailsEnabled = jest.fn()
+
+jest.mock("@/lib/safety", () => ({
+  getContentSafetyService: () => ({
+    isGuardrailsEnabled: mockIsGuardrailsEnabled,
+    checkInputSafety: mockCheckInputSafety,
+    checkOutputSafety: mockCheckOutputSafety,
+  }),
+}))
+
+jest.mock("@/lib/logger", () => ({
+  createLogger: () => ({
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  }),
+  generateRequestId: () => "test-request-id",
+  startTimer: () => jest.fn().mockReturnValue(42),
+}))
+
+// ============================================
+// Test Helpers
+// ============================================
+
+function makeEntry(
+  role: "user" | "assistant",
+  text: string,
+  opts?: { isFinal?: boolean; timestamp?: Date },
+): TranscriptEntry {
+  return {
+    role,
+    text,
+    isFinal: opts?.isFinal ?? true,
+    timestamp: opts?.timestamp ?? new Date("2026-04-11T10:00:00Z"),
+  }
+}
+
+// ============================================
+// Tests: prepareTranscriptEntries
+// ============================================
+
+describe("prepareTranscriptEntries", () => {
+  it("should filter out non-final entries", () => {
+    const entries = [
+      makeEntry("user", "hello", { isFinal: false }),
+      makeEntry("user", "hello world", { isFinal: true }),
+      makeEntry("assistant", "partial", { isFinal: false }),
+      makeEntry("assistant", "hi there", { isFinal: true }),
+    ]
+
+    const result = prepareTranscriptEntries(entries)
+    expect(result).toHaveLength(2)
+    expect(result[0].text).toBe("hello world")
+    expect(result[1].text).toBe("hi there")
+  })
+
+  it("should filter out empty text entries", () => {
+    const entries = [
+      makeEntry("user", "", { isFinal: true }),
+      makeEntry("user", "  ", { isFinal: true }),
+      makeEntry("user", "actual content", { isFinal: true }),
+    ]
+
+    const result = prepareTranscriptEntries(entries)
+    expect(result).toHaveLength(1)
+    expect(result[0].text).toBe("actual content")
+  })
+
+  it("should merge consecutive same-role entries", () => {
+    const t1 = new Date("2026-04-11T10:00:00Z")
+    const t2 = new Date("2026-04-11T10:00:01Z")
+    const t3 = new Date("2026-04-11T10:00:02Z")
+
+    const entries = [
+      makeEntry("user", "hello", { timestamp: t1 }),
+      makeEntry("user", "how are you?", { timestamp: t2 }),
+      makeEntry("assistant", "I'm good", { timestamp: t3 }),
+    ]
+
+    const result = prepareTranscriptEntries(entries)
+    expect(result).toHaveLength(2)
+    expect(result[0].role).toBe("user")
+    expect(result[0].text).toBe("hello how are you?")
+    // Keeps the earlier timestamp
+    expect(result[0].timestamp).toBe(t1)
+    expect(result[1].role).toBe("assistant")
+    expect(result[1].text).toBe("I'm good")
+  })
+
+  it("should not merge entries with different roles", () => {
+    const entries = [
+      makeEntry("user", "hello"),
+      makeEntry("assistant", "hi"),
+      makeEntry("user", "another question"),
+    ]
+
+    const result = prepareTranscriptEntries(entries)
+    expect(result).toHaveLength(3)
+  })
+
+  it("should return empty array for empty input", () => {
+    expect(prepareTranscriptEntries([])).toHaveLength(0)
+  })
+
+  it("should return empty array when all entries are non-final", () => {
+    const entries = [
+      makeEntry("user", "partial", { isFinal: false }),
+      makeEntry("assistant", "also partial", { isFinal: false }),
+    ]
+    expect(prepareTranscriptEntries(entries)).toHaveLength(0)
+  })
+
+  it("should cap at 500 entries", () => {
+    const entries: TranscriptEntry[] = []
+    for (let i = 0; i < 600; i++) {
+      entries.push(
+        makeEntry(i % 2 === 0 ? "user" : "assistant", `message ${i}`),
+      )
+    }
+
+    const result = prepareTranscriptEntries(entries)
+    expect(result.length).toBeLessThanOrEqual(500)
+  })
+
+  it("should trim whitespace from entry text", () => {
+    const entries = [
+      makeEntry("user", "  hello world  "),
+    ]
+
+    const result = prepareTranscriptEntries(entries)
+    expect(result[0].text).toBe("hello world")
+  })
+})
+
+// ============================================
+// Tests: saveVoiceTranscript
+// ============================================
+
+describe("saveVoiceTranscript", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockIsGuardrailsEnabled.mockReturnValue(false)
+    mockCheckInputSafety.mockResolvedValue({ allowed: true, processedContent: "test" })
+    mockCheckOutputSafety.mockResolvedValue({ allowed: true, processedContent: "test" })
+  })
+
+  it("should throw if conversation not found", async () => {
+    mockGetConversationById.mockResolvedValue(null)
+
+    const entries = [makeEntry("user", "hello")]
+    await expect(
+      saveVoiceTranscript("conv-123", 1, entries),
+    ).rejects.toThrow("Conversation conv-123 not found")
+  })
+
+  it("should return early with zero counts for empty transcript", async () => {
+    mockGetConversationById.mockResolvedValue({ id: "conv-123", title: "Test" })
+
+    const result = await saveVoiceTranscript("conv-123", 1, [])
+    expect(result.messageCount).toBe(0)
+    expect(result.filteredCount).toBe(0)
+    expect(result.titleGenerated).toBe(false)
+    expect(mockExecuteTransaction).not.toHaveBeenCalled()
+  })
+
+  it("should return early for transcript with only non-final entries", async () => {
+    mockGetConversationById.mockResolvedValue({ id: "conv-123", title: "Test" })
+
+    const entries = [
+      makeEntry("user", "partial", { isFinal: false }),
+    ]
+    const result = await saveVoiceTranscript("conv-123", 1, entries)
+    expect(result.messageCount).toBe(0)
+    expect(mockExecuteTransaction).not.toHaveBeenCalled()
+  })
+
+  it("should save transcript without guardrails when disabled", async () => {
+    mockGetConversationById.mockResolvedValue({ id: "conv-123", title: "Existing Title" })
+    mockIsGuardrailsEnabled.mockReturnValue(false)
+    mockExecuteTransaction.mockImplementation(async (fn: (tx: unknown) => Promise<void>) => {
+      const mockTx = {
+        insert: jest.fn().mockReturnValue({ values: jest.fn() }),
+        update: jest.fn().mockReturnValue({ set: jest.fn().mockReturnValue({ where: jest.fn() }) }),
+      }
+      await fn(mockTx)
+    })
+
+    const entries = [
+      makeEntry("user", "hello"),
+      makeEntry("assistant", "hi there"),
+    ]
+
+    const result = await saveVoiceTranscript("conv-123", 1, entries, "gemini-2.0-flash-live-001")
+    expect(result.messageCount).toBe(2)
+    expect(result.filteredCount).toBe(0)
+    expect(result.titleGenerated).toBe(false)
+    expect(mockExecuteTransaction).toHaveBeenCalledTimes(1)
+    // Guardrail checks should not have been called
+    expect(mockCheckInputSafety).not.toHaveBeenCalled()
+    expect(mockCheckOutputSafety).not.toHaveBeenCalled()
+  })
+
+  it("should generate title for new conversations", async () => {
+    mockGetConversationById.mockResolvedValue({ id: "conv-123", title: "New Conversation" })
+    mockIsGuardrailsEnabled.mockReturnValue(false)
+
+    let capturedTx: Record<string, jest.Mock> | null = null
+    mockExecuteTransaction.mockImplementation(async (fn: (tx: unknown) => Promise<void>) => {
+      capturedTx = {
+        insert: jest.fn().mockReturnValue({ values: jest.fn() }),
+        update: jest.fn().mockReturnValue({
+          set: jest.fn().mockReturnValue({ where: jest.fn() }),
+        }),
+      }
+      await fn(capturedTx)
+    })
+
+    const entries = [
+      makeEntry("user", "Tell me about the solar system"),
+      makeEntry("assistant", "The solar system consists of..."),
+    ]
+
+    const result = await saveVoiceTranscript("conv-123", 1, entries)
+    expect(result.titleGenerated).toBe(true)
+
+    // Verify the update was called with a title
+    expect(capturedTx).not.toBeNull()
+    const setCall = capturedTx!.update.mock.results[0]?.value?.set
+    expect(setCall).toBeDefined()
+  })
+
+  it("should not generate title when conversation already has one", async () => {
+    mockGetConversationById.mockResolvedValue({ id: "conv-123", title: "My Existing Chat" })
+    mockIsGuardrailsEnabled.mockReturnValue(false)
+    mockExecuteTransaction.mockImplementation(async (fn: (tx: unknown) => Promise<void>) => {
+      await fn({
+        insert: jest.fn().mockReturnValue({ values: jest.fn() }),
+        update: jest.fn().mockReturnValue({ set: jest.fn().mockReturnValue({ where: jest.fn() }) }),
+      })
+    })
+
+    const entries = [makeEntry("user", "hello")]
+    const result = await saveVoiceTranscript("conv-123", 1, entries)
+    expect(result.titleGenerated).toBe(false)
+  })
+
+  it("should apply guardrails and filter blocked content", async () => {
+    mockGetConversationById.mockResolvedValue({ id: "conv-123", title: "Test" })
+    mockIsGuardrailsEnabled.mockReturnValue(true)
+
+    // First user message is blocked, second passes
+    mockCheckInputSafety
+      .mockResolvedValueOnce({
+        allowed: false,
+        processedContent: "blocked",
+        blockedReason: "Violence",
+        blockedCategories: ["Violence"],
+      })
+      .mockResolvedValueOnce({ allowed: true, processedContent: "good content" })
+
+    mockCheckOutputSafety.mockResolvedValue({ allowed: true, processedContent: "response" })
+
+    mockExecuteTransaction.mockImplementation(async (fn: (tx: unknown) => Promise<void>) => {
+      await fn({
+        insert: jest.fn().mockReturnValue({ values: jest.fn() }),
+        update: jest.fn().mockReturnValue({ set: jest.fn().mockReturnValue({ where: jest.fn() }) }),
+      })
+    })
+
+    const entries = [
+      makeEntry("user", "blocked content"),
+      makeEntry("assistant", "response"),
+      makeEntry("user", "good content"),
+    ]
+
+    const result = await saveVoiceTranscript("conv-123", 1, entries)
+    expect(result.messageCount).toBe(3)
+    expect(result.filteredCount).toBe(1)
+    expect(mockCheckInputSafety).toHaveBeenCalledTimes(2)
+    expect(mockCheckOutputSafety).toHaveBeenCalledTimes(1)
+  })
+
+  it("should gracefully handle guardrail API errors", async () => {
+    mockGetConversationById.mockResolvedValue({ id: "conv-123", title: "Test" })
+    mockIsGuardrailsEnabled.mockReturnValue(true)
+    mockCheckInputSafety.mockRejectedValue(new Error("Bedrock unavailable"))
+    mockCheckOutputSafety.mockResolvedValue({ allowed: true, processedContent: "ok" })
+
+    mockExecuteTransaction.mockImplementation(async (fn: (tx: unknown) => Promise<void>) => {
+      await fn({
+        insert: jest.fn().mockReturnValue({ values: jest.fn() }),
+        update: jest.fn().mockReturnValue({ set: jest.fn().mockReturnValue({ where: jest.fn() }) }),
+      })
+    })
+
+    const entries = [
+      makeEntry("user", "hello"),
+      makeEntry("assistant", "hi"),
+    ]
+
+    // Should not throw — graceful degradation
+    const result = await saveVoiceTranscript("conv-123", 1, entries)
+    expect(result.messageCount).toBe(2)
+    expect(result.filteredCount).toBe(0)
+  })
+
+  it("should propagate transaction errors", async () => {
+    mockGetConversationById.mockResolvedValue({ id: "conv-123", title: "Test" })
+    mockIsGuardrailsEnabled.mockReturnValue(false)
+    mockExecuteTransaction.mockRejectedValue(new Error("DB connection lost"))
+
+    const entries = [makeEntry("user", "hello")]
+    await expect(
+      saveVoiceTranscript("conv-123", 1, entries),
+    ).rejects.toThrow("DB connection lost")
+  })
+})
+
+// ============================================
+// Tests: Title Generation (via saveVoiceTranscript)
+// ============================================
+
+describe("voice title generation", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockIsGuardrailsEnabled.mockReturnValue(false)
+  })
+
+  it("should truncate long titles with ellipsis", async () => {
+    const longMessage = "This is a very long message that should be truncated because it exceeds the maximum title length"
+    mockGetConversationById.mockResolvedValue({ id: "conv-123", title: "New Conversation" })
+
+    let updateArgs: Record<string, unknown> = {}
+    mockExecuteTransaction.mockImplementation(async (fn: (tx: unknown) => Promise<void>) => {
+      await fn({
+        insert: jest.fn().mockReturnValue({ values: jest.fn() }),
+        update: jest.fn().mockReturnValue({
+          set: jest.fn().mockImplementation((args: Record<string, unknown>) => {
+            updateArgs = args
+            return { where: jest.fn() }
+          }),
+        }),
+      })
+    })
+
+    const entries = [makeEntry("user", longMessage)]
+    const result = await saveVoiceTranscript("conv-123", 1, entries)
+    expect(result.titleGenerated).toBe(true)
+    // Title should be 40 chars + "..."
+    expect(updateArgs.title).toBeDefined()
+    const title = updateArgs.title as string
+    expect(title.length).toBeLessThanOrEqual(43)
+    expect(title.endsWith("...")).toBe(true)
+  })
+
+  it("should skip title generation if first user message was filtered", async () => {
+    mockGetConversationById.mockResolvedValue({ id: "conv-123", title: "New Conversation" })
+    mockIsGuardrailsEnabled.mockReturnValue(true)
+    // Block the only user message
+    mockCheckInputSafety.mockResolvedValue({
+      allowed: false,
+      processedContent: "blocked",
+      blockedReason: "Violence",
+    })
+    mockCheckOutputSafety.mockResolvedValue({ allowed: true, processedContent: "ok" })
+
+    let updateArgs: Record<string, unknown> = {}
+    mockExecuteTransaction.mockImplementation(async (fn: (tx: unknown) => Promise<void>) => {
+      await fn({
+        insert: jest.fn().mockReturnValue({ values: jest.fn() }),
+        update: jest.fn().mockReturnValue({
+          set: jest.fn().mockImplementation((args: Record<string, unknown>) => {
+            updateArgs = args
+            return { where: jest.fn() }
+          }),
+        }),
+      })
+    })
+
+    const entries = [
+      makeEntry("user", "violent content"),
+      makeEntry("assistant", "ok"),
+    ]
+    const result = await saveVoiceTranscript("conv-123", 1, entries)
+    // Title should NOT be generated because the user entry was filtered
+    expect(result.titleGenerated).toBe(false)
+    expect(updateArgs.title).toBeUndefined()
+  })
+})

--- a/lib/voice/__tests__/transcript-service.test.ts
+++ b/lib/voice/__tests__/transcript-service.test.ts
@@ -483,6 +483,80 @@ describe("saveVoiceTranscript", () => {
       saveVoiceTranscript("conv-123", 1, entries),
     ).rejects.toThrow("DB connection lost")
   })
+
+  it("should propagate getConversationById errors (DB failure vs returning null)", async () => {
+    mockGetConversationById.mockRejectedValue(new Error("Connection refused"))
+
+    const entries = [makeEntry("user", "hello")]
+    await expect(
+      saveVoiceTranscript("conv-123", 1, entries),
+    ).rejects.toThrow("Connection refused")
+  })
+
+  it("should fall back to original text when processedContent is null or undefined", async () => {
+    mockGetConversationById.mockResolvedValue({ id: "conv-123", title: "Test" })
+    mockIsGuardrailsEnabled.mockReturnValue(true)
+    // Return null/undefined processedContent — should fall back to original entry text
+    mockCheckInputSafety.mockResolvedValue({ allowed: true, processedContent: null })
+    mockCheckOutputSafety.mockResolvedValue({ allowed: true, processedContent: undefined })
+
+    let capturedValues: unknown[] = []
+    mockExecuteTransaction.mockImplementation(async (fn: (tx: unknown) => Promise<void>) => {
+      await fn({
+        insert: jest.fn().mockImplementation((_table: unknown) => ({
+          values: jest.fn().mockImplementation((vals: unknown[]) => {
+            capturedValues = vals
+          }),
+        })),
+        update: jest.fn().mockReturnValue({ set: jest.fn().mockReturnValue({ where: jest.fn() }) }),
+      })
+    })
+
+    const entries = [
+      makeEntry("user", "original user text"),
+      makeEntry("assistant", "original assistant text"),
+    ]
+
+    await saveVoiceTranscript("conv-123", 1, entries)
+
+    // With null/undefined processedContent, the original text should be used
+    expect(capturedValues).toHaveLength(2)
+    expect((capturedValues[0] as { content: string }).content).toBe("original user text")
+    expect((capturedValues[1] as { content: string }).content).toBe("original assistant text")
+  })
+
+  it("should process entries correctly across guardrail batch boundaries", async () => {
+    mockGetConversationById.mockResolvedValue({ id: "conv-123", title: "Existing" })
+    mockIsGuardrailsEnabled.mockReturnValue(true)
+    mockCheckInputSafety.mockResolvedValue({ allowed: true, processedContent: "user msg" })
+    mockCheckOutputSafety.mockResolvedValue({ allowed: true, processedContent: "assistant msg" })
+
+    let capturedValues: unknown[] = []
+    mockExecuteTransaction.mockImplementation(async (fn: (tx: unknown) => Promise<void>) => {
+      await fn({
+        insert: jest.fn().mockImplementation((_table: unknown) => ({
+          values: jest.fn().mockImplementation((vals: unknown[]) => {
+            capturedValues = vals
+          }),
+        })),
+        update: jest.fn().mockReturnValue({ set: jest.fn().mockReturnValue({ where: jest.fn() }) }),
+      })
+    })
+
+    // 25 entries — crosses the GUARDRAIL_CONCURRENCY_LIMIT (20) boundary
+    const entries: TranscriptEntry[] = []
+    for (let i = 0; i < 25; i++) {
+      entries.push(makeEntry(i % 2 === 0 ? "user" : "assistant", `message ${i}`))
+    }
+
+    const result = await saveVoiceTranscript("conv-123", 1, entries)
+
+    // All 25 entries should be saved — no entries dropped at batch boundary
+    expect(result.messageCount).toBe(25)
+    expect(capturedValues).toHaveLength(25)
+    // Verify guardrail checks were called for all entries
+    expect(mockCheckInputSafety.mock.calls.length + mockCheckOutputSafety.mock.calls.length).toBe(25)
+  })
 })
 
 // ============================================
@@ -515,7 +589,7 @@ describe("voice title generation", () => {
     const entries = [makeEntry("user", longMessage)]
     const result = await saveVoiceTranscript("conv-123", 1, entries)
     expect(result.titleGenerated).toBe(true)
-    // Title should be 40 chars + "..."
+    // Title is at most 40 chars + "..." (43 total); trim() may make it shorter
     expect(updateArgs.title).toBeDefined()
     const title = updateArgs.title as string
     expect(title.length).toBeLessThanOrEqual(43)

--- a/lib/voice/__tests__/transcript-service.test.ts
+++ b/lib/voice/__tests__/transcript-service.test.ts
@@ -455,6 +455,50 @@ describe("saveVoiceTranscript", () => {
     expect((capturedValues[1] as { content: string }).content).toBe("transformed response")
   })
 
+  it("should log error when all entries are filtered by guardrails", async () => {
+    mockLogger.error.mockClear()
+    mockGetConversationById.mockResolvedValue({ id: "conv-123", title: "Test" })
+    mockIsGuardrailsEnabled.mockReturnValue(true)
+    // Block every entry
+    mockCheckInputSafety.mockResolvedValue({
+      allowed: false,
+      processedContent: "blocked",
+      blockedReason: "Violence",
+      blockedCategories: ["Violence"],
+    })
+    mockCheckOutputSafety.mockResolvedValue({
+      allowed: false,
+      processedContent: "blocked",
+      blockedReason: "Violence",
+      blockedCategories: ["Violence"],
+    })
+
+    mockExecuteTransaction.mockImplementation(async (fn: (tx: unknown) => Promise<void>) => {
+      await fn({
+        insert: jest.fn().mockReturnValue({ values: jest.fn() }),
+        update: jest.fn().mockReturnValue({ set: jest.fn().mockReturnValue({ where: jest.fn() }) }),
+      })
+    })
+
+    const entries = [
+      makeEntry("user", "bad content"),
+      makeEntry("assistant", "bad response"),
+    ]
+
+    const result = await saveVoiceTranscript("conv-123", 1, entries)
+    expect(result.filteredCount).toBe(2)
+    expect(result.messageCount).toBe(2)
+    // When 100% of entries are filtered, an error-level log should be emitted
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      "Voice transcript entries filtered by guardrails",
+      expect.objectContaining({
+        filteredCount: 2,
+        totalCount: 2,
+        allFiltered: true,
+      }),
+    )
+  })
+
   it("should gracefully handle guardrail API errors", async () => {
     mockGetConversationById.mockResolvedValue({ id: "conv-123", title: "Test" })
     mockIsGuardrailsEnabled.mockReturnValue(true)
@@ -543,6 +587,27 @@ describe("saveVoiceTranscript", () => {
     ).rejects.toThrow("DB connection lost")
   })
 
+  it("should propagate errors when transaction callback throws (rollback path)", async () => {
+    mockGetConversationById.mockResolvedValue({ id: "conv-123", title: "Test" })
+    mockIsGuardrailsEnabled.mockReturnValue(false)
+    // Simulate executeTransaction throwing because the callback itself failed —
+    // in production, Drizzle rolls back automatically on callback throw.
+    mockExecuteTransaction.mockImplementation(async (fn: (tx: unknown) => Promise<void>) => {
+      const mockTx = {
+        insert: jest.fn().mockReturnValue({
+          values: jest.fn().mockRejectedValue(new Error("unique constraint violation")),
+        }),
+        update: jest.fn().mockReturnValue({ set: jest.fn().mockReturnValue({ where: jest.fn() }) }),
+      }
+      await fn(mockTx)
+    })
+
+    const entries = [makeEntry("user", "hello")]
+    await expect(
+      saveVoiceTranscript("conv-123", 1, entries),
+    ).rejects.toThrow("unique constraint violation")
+  })
+
   it("should propagate getConversationById errors (DB failure vs returning null)", async () => {
     mockGetConversationById.mockRejectedValue(new Error("Connection refused"))
 
@@ -550,6 +615,34 @@ describe("saveVoiceTranscript", () => {
     await expect(
       saveVoiceTranscript("conv-123", 1, entries),
     ).rejects.toThrow("Connection refused")
+  })
+
+  it("should warn when processedContent is null or undefined from safety service", async () => {
+    mockLogger.warn.mockClear()
+    mockGetConversationById.mockResolvedValue({ id: "conv-123", title: "Test" })
+    mockIsGuardrailsEnabled.mockReturnValue(true)
+    mockCheckInputSafety.mockResolvedValue({ allowed: true, processedContent: null })
+    mockCheckOutputSafety.mockResolvedValue({ allowed: true, processedContent: undefined })
+
+    mockExecuteTransaction.mockImplementation(async (fn: (tx: unknown) => Promise<void>) => {
+      await fn({
+        insert: jest.fn().mockReturnValue({ values: jest.fn() }),
+        update: jest.fn().mockReturnValue({ set: jest.fn().mockReturnValue({ where: jest.fn() }) }),
+      })
+    })
+
+    const entries = [
+      makeEntry("user", "hello"),
+      makeEntry("assistant", "hi"),
+    ]
+
+    await saveVoiceTranscript("conv-123", 1, entries)
+
+    // Should warn for each entry with null/undefined processedContent
+    const processedContentWarns = mockLogger.warn.mock.calls.filter(
+      (call: unknown[]) => call[0] === "Safety service returned no processedContent, using original text",
+    )
+    expect(processedContentWarns).toHaveLength(2)
   })
 
   it("should fall back to original text when processedContent is null or undefined", async () => {
@@ -648,10 +741,10 @@ describe("voice title generation", () => {
     const entries = [makeEntry("user", longMessage)]
     const result = await saveVoiceTranscript("conv-123", 1, entries)
     expect(result.titleGenerated).toBe(true)
-    // Title is at most 40 chars + "..." (43 total); trim() may make it shorter
+    // Title is at most MAX_TITLE_LENGTH (40) including the "..." suffix
     expect(updateArgs.title).toBeDefined()
     const title = updateArgs.title as string
-    expect(title.length).toBeLessThanOrEqual(43)
+    expect(title.length).toBeLessThanOrEqual(40)
     expect(title.endsWith("...")).toBe(true)
   })
 

--- a/lib/voice/__tests__/transcript-service.test.ts
+++ b/lib/voice/__tests__/transcript-service.test.ts
@@ -8,6 +8,7 @@
  */
 
 import { saveVoiceTranscript, prepareTranscriptEntries } from "../transcript-service"
+import { DEFAULT_CONVERSATION_TITLE } from "@/lib/constants/conversation"
 import type { TranscriptEntry } from "../types"
 
 // ============================================
@@ -55,16 +56,27 @@ jest.mock("@/lib/safety", () => ({
   }),
 }))
 
-jest.mock("@/lib/logger", () => ({
-  createLogger: () => ({
+// Logger mock — the factory creates a singleton logger object with jest.fn() methods.
+// We retrieve it after jest.mock via the mocked module's createLogger().
+jest.mock("@/lib/logger", () => {
+  const logger = {
     info: jest.fn(),
     warn: jest.fn(),
     error: jest.fn(),
     debug: jest.fn(),
-  }),
-  generateRequestId: () => "test-request-id",
-  startTimer: () => jest.fn().mockReturnValue(42),
-}))
+  }
+  return {
+    __mockLogger: logger,
+    createLogger: () => logger,
+    generateRequestId: () => "test-request-id",
+    startTimer: () => jest.fn().mockReturnValue(42),
+  }
+})
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
+const { __mockLogger: mockLogger } = require("@/lib/logger") as { __mockLogger: {
+  info: jest.Mock; warn: jest.Mock; error: jest.Mock; debug: jest.Mock
+}}
 
 // ============================================
 // Test Helpers
@@ -170,6 +182,25 @@ describe("prepareTranscriptEntries", () => {
     expect(result.length).toBeLessThanOrEqual(500)
   })
 
+  it("should warn when transcript is truncated beyond MAX_TRANSCRIPT_ENTRIES", () => {
+    mockLogger.warn.mockClear()
+    const entries: TranscriptEntry[] = []
+    for (let i = 0; i < 600; i++) {
+      entries.push(
+        makeEntry(i % 2 === 0 ? "user" : "assistant", `message ${i}`),
+      )
+    }
+
+    prepareTranscriptEntries(entries)
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      "Transcript truncated to maximum entry limit",
+      expect.objectContaining({
+        maxEntries: 500,
+        droppedCount: expect.any(Number),
+      }),
+    )
+  })
+
   it("should trim whitespace from entry text", () => {
     const entries = [
       makeEntry("user", "  hello world  "),
@@ -249,7 +280,7 @@ describe("saveVoiceTranscript", () => {
   })
 
   it("should generate title for new conversations", async () => {
-    mockGetConversationById.mockResolvedValue({ id: "conv-123", title: "New Conversation" })
+    mockGetConversationById.mockResolvedValue({ id: "conv-123", title: DEFAULT_CONVERSATION_TITLE })
     mockIsGuardrailsEnabled.mockReturnValue(false)
 
     let capturedTx: Record<string, jest.Mock> | null = null
@@ -386,6 +417,38 @@ describe("saveVoiceTranscript", () => {
     )
   })
 
+  it("should use processedContent from guardrails when content is transformed", async () => {
+    mockGetConversationById.mockResolvedValue({ id: "conv-123", title: "Test" })
+    mockIsGuardrailsEnabled.mockReturnValue(true)
+    // Simulate safety service returning transformed content (e.g., PII redaction)
+    mockCheckInputSafety.mockResolvedValue({ allowed: true, processedContent: "hello [REDACTED]" })
+    mockCheckOutputSafety.mockResolvedValue({ allowed: true, processedContent: "transformed response" })
+
+    let capturedValues: unknown[] = []
+    mockExecuteTransaction.mockImplementation(async (fn: (tx: unknown) => Promise<void>) => {
+      await fn({
+        insert: jest.fn().mockImplementation((_table: unknown) => ({
+          values: jest.fn().mockImplementation((vals: unknown[]) => {
+            capturedValues = vals
+          }),
+        })),
+        update: jest.fn().mockReturnValue({ set: jest.fn().mockReturnValue({ where: jest.fn() }) }),
+      })
+    })
+
+    const entries = [
+      makeEntry("user", "hello original"),
+      makeEntry("assistant", "original response"),
+    ]
+
+    await saveVoiceTranscript("conv-123", 1, entries)
+
+    // Verify the persisted content uses processedContent, not original text
+    expect(capturedValues).toHaveLength(2)
+    expect((capturedValues[0] as { content: string }).content).toBe("hello [REDACTED]")
+    expect((capturedValues[1] as { content: string }).content).toBe("transformed response")
+  })
+
   it("should gracefully handle guardrail API errors", async () => {
     mockGetConversationById.mockResolvedValue({ id: "conv-123", title: "Test" })
     mockIsGuardrailsEnabled.mockReturnValue(true)
@@ -434,7 +497,7 @@ describe("voice title generation", () => {
 
   it("should truncate long titles with ellipsis", async () => {
     const longMessage = "This is a very long message that should be truncated because it exceeds the maximum title length"
-    mockGetConversationById.mockResolvedValue({ id: "conv-123", title: "New Conversation" })
+    mockGetConversationById.mockResolvedValue({ id: "conv-123", title: DEFAULT_CONVERSATION_TITLE })
 
     let updateArgs: Record<string, unknown> = {}
     mockExecuteTransaction.mockImplementation(async (fn: (tx: unknown) => Promise<void>) => {
@@ -460,7 +523,7 @@ describe("voice title generation", () => {
   })
 
   it("should skip title generation if first user message was filtered", async () => {
-    mockGetConversationById.mockResolvedValue({ id: "conv-123", title: "New Conversation" })
+    mockGetConversationById.mockResolvedValue({ id: "conv-123", title: DEFAULT_CONVERSATION_TITLE })
     mockIsGuardrailsEnabled.mockReturnValue(true)
     // Block the only user message
     mockCheckInputSafety.mockResolvedValue({

--- a/lib/voice/__tests__/transcript-service.test.ts
+++ b/lib/voice/__tests__/transcript-service.test.ts
@@ -170,7 +170,7 @@ describe("prepareTranscriptEntries", () => {
     expect(prepareTranscriptEntries(entries)).toHaveLength(0)
   })
 
-  it("should cap at 500 entries", () => {
+  it("should cap at 500 entries, keeping the most recent (tail)", () => {
     const entries: TranscriptEntry[] = []
     for (let i = 0; i < 600; i++) {
       entries.push(
@@ -180,6 +180,9 @@ describe("prepareTranscriptEntries", () => {
 
     const result = prepareTranscriptEntries(entries)
     expect(result.length).toBeLessThanOrEqual(500)
+    // Verify tail entries are kept (most recent), not head entries
+    const lastEntry = result[result.length - 1]
+    expect(lastEntry.text).toBe("message 599")
   })
 
   it("should warn when transcript is truncated beyond MAX_TRANSCRIPT_ENTRIES", () => {

--- a/lib/voice/__tests__/transcript-service.test.ts
+++ b/lib/voice/__tests__/transcript-service.test.ts
@@ -198,7 +198,7 @@ describe("saveVoiceTranscript", () => {
     const entries = [makeEntry("user", "hello")]
     await expect(
       saveVoiceTranscript("conv-123", 1, entries),
-    ).rejects.toThrow("Conversation conv-123 not found")
+    ).rejects.toThrow("Conversation not found or access denied")
   })
 
   it("should return early with zero counts for empty transcript", async () => {
@@ -326,6 +326,64 @@ describe("saveVoiceTranscript", () => {
     expect(result.filteredCount).toBe(1)
     expect(mockCheckInputSafety).toHaveBeenCalledTimes(2)
     expect(mockCheckOutputSafety).toHaveBeenCalledTimes(1)
+  })
+
+  it("should pass voiceModel and voiceProvider to checkOutputSafety", async () => {
+    mockGetConversationById.mockResolvedValue({ id: "conv-123", title: "Test" })
+    mockIsGuardrailsEnabled.mockReturnValue(true)
+    mockCheckInputSafety.mockResolvedValue({ allowed: true, processedContent: "hello" })
+    mockCheckOutputSafety.mockResolvedValue({ allowed: true, processedContent: "hi" })
+
+    mockExecuteTransaction.mockImplementation(async (fn: (tx: unknown) => Promise<void>) => {
+      await fn({
+        insert: jest.fn().mockReturnValue({ values: jest.fn() }),
+        update: jest.fn().mockReturnValue({ set: jest.fn().mockReturnValue({ where: jest.fn() }) }),
+      })
+    })
+
+    const entries = [
+      makeEntry("user", "hello"),
+      makeEntry("assistant", "hi there"),
+    ]
+
+    await saveVoiceTranscript("conv-123", 1, entries, "gemini-2.0-flash-live-001", "gemini-live")
+
+    // Verify checkOutputSafety received the actual model and provider, not hardcoded values
+    expect(mockCheckOutputSafety).toHaveBeenCalledWith(
+      "hi there",
+      "gemini-2.0-flash-live-001",
+      "gemini-live",
+      "voice-conv-123",
+    )
+  })
+
+  it("should use fallback strings when voiceModel/voiceProvider are undefined", async () => {
+    mockGetConversationById.mockResolvedValue({ id: "conv-123", title: "Test" })
+    mockIsGuardrailsEnabled.mockReturnValue(true)
+    mockCheckInputSafety.mockResolvedValue({ allowed: true, processedContent: "hello" })
+    mockCheckOutputSafety.mockResolvedValue({ allowed: true, processedContent: "hi" })
+
+    mockExecuteTransaction.mockImplementation(async (fn: (tx: unknown) => Promise<void>) => {
+      await fn({
+        insert: jest.fn().mockReturnValue({ values: jest.fn() }),
+        update: jest.fn().mockReturnValue({ set: jest.fn().mockReturnValue({ where: jest.fn() }) }),
+      })
+    })
+
+    const entries = [
+      makeEntry("user", "hello"),
+      makeEntry("assistant", "hi there"),
+    ]
+
+    // Call without voiceModel and voiceProvider
+    await saveVoiceTranscript("conv-123", 1, entries)
+
+    expect(mockCheckOutputSafety).toHaveBeenCalledWith(
+      "hi there",
+      "unknown-voice-model",
+      "unknown-voice-provider",
+      "voice-conv-123",
+    )
   })
 
   it("should gracefully handle guardrail API errors", async () => {

--- a/lib/voice/__tests__/transcript-service.test.ts
+++ b/lib/voice/__tests__/transcript-service.test.ts
@@ -242,6 +242,7 @@ describe("saveVoiceTranscript", () => {
     expect(result.messageCount).toBe(0)
     expect(result.filteredCount).toBe(0)
     expect(result.titleGenerated).toBe(false)
+    expect(result.guardrailsBypassed).toBe(false)
     expect(mockExecuteTransaction).not.toHaveBeenCalled()
   })
 
@@ -276,6 +277,7 @@ describe("saveVoiceTranscript", () => {
     expect(result.messageCount).toBe(2)
     expect(result.filteredCount).toBe(0)
     expect(result.titleGenerated).toBe(false)
+    expect(result.guardrailsBypassed).toBe(true)
     expect(mockExecuteTransaction).toHaveBeenCalledTimes(1)
     // Guardrail checks should not have been called
     expect(mockCheckInputSafety).not.toHaveBeenCalled()
@@ -358,6 +360,7 @@ describe("saveVoiceTranscript", () => {
     const result = await saveVoiceTranscript("conv-123", 1, entries)
     expect(result.messageCount).toBe(3)
     expect(result.filteredCount).toBe(1)
+    expect(result.guardrailsBypassed).toBe(false)
     expect(mockCheckInputSafety).toHaveBeenCalledTimes(2)
     expect(mockCheckOutputSafety).toHaveBeenCalledTimes(1)
   })
@@ -474,6 +477,59 @@ describe("saveVoiceTranscript", () => {
     const result = await saveVoiceTranscript("conv-123", 1, entries)
     expect(result.messageCount).toBe(2)
     expect(result.filteredCount).toBe(0)
+    // Individual entry errors are handled gracefully within the batch — the guardrail
+    // pipeline itself completed, so bypassed is false. bypassed=true only when the
+    // entire pipeline was skipped (disabled or timed out).
+    expect(result.guardrailsBypassed).toBe(false)
+  })
+
+  it("should write modelUsed to conversation metadata when voiceModel is provided", async () => {
+    mockGetConversationById.mockResolvedValue({ id: "conv-123", title: "Existing" })
+    mockIsGuardrailsEnabled.mockReturnValue(false)
+
+    let updateArgs: Record<string, unknown> = {}
+    mockExecuteTransaction.mockImplementation(async (fn: (tx: unknown) => Promise<void>) => {
+      await fn({
+        insert: jest.fn().mockReturnValue({ values: jest.fn() }),
+        update: jest.fn().mockReturnValue({
+          set: jest.fn().mockImplementation((args: Record<string, unknown>) => {
+            updateArgs = args
+            return { where: jest.fn() }
+          }),
+        }),
+      })
+    })
+
+    const entries = [makeEntry("user", "hello")]
+    await saveVoiceTranscript("conv-123", 1, entries, "gemini-2.0-flash-live-001")
+
+    // Verify modelUsed is passed in the .set() call — confirms the column name
+    // matches the schema (nexusConversations.modelUsed → model_used varchar(100))
+    expect(updateArgs.modelUsed).toBe("gemini-2.0-flash-live-001")
+  })
+
+  it("should not write modelUsed when voiceModel is not provided", async () => {
+    mockGetConversationById.mockResolvedValue({ id: "conv-123", title: "Existing" })
+    mockIsGuardrailsEnabled.mockReturnValue(false)
+
+    let updateArgs: Record<string, unknown> = {}
+    mockExecuteTransaction.mockImplementation(async (fn: (tx: unknown) => Promise<void>) => {
+      await fn({
+        insert: jest.fn().mockReturnValue({ values: jest.fn() }),
+        update: jest.fn().mockReturnValue({
+          set: jest.fn().mockImplementation((args: Record<string, unknown>) => {
+            updateArgs = args
+            return { where: jest.fn() }
+          }),
+        }),
+      })
+    })
+
+    const entries = [makeEntry("user", "hello")]
+    await saveVoiceTranscript("conv-123", 1, entries)
+
+    // When voiceModel is undefined, modelUsed should NOT be in the update
+    expect(updateArgs.modelUsed).toBeUndefined()
   })
 
   it("should propagate transaction errors", async () => {

--- a/lib/voice/constants.ts
+++ b/lib/voice/constants.ts
@@ -46,3 +46,11 @@ export const MAX_SESSION_INSTRUCTION_LENGTH = 10_000
 
 /** Max length for conversationId in session_config (UUID = 36 chars) */
 export const MAX_CONVERSATION_ID_LENGTH = 36
+
+/**
+ * Timeout for resolveTranscriptContext DB lookup during session setup (ms).
+ * If the DB is slow, this prevents the in-flight promise from blocking
+ * cleanup resource release indefinitely. On timeout, transcript persistence
+ * is silently skipped (non-fatal).
+ */
+export const TRANSCRIPT_CONTEXT_TIMEOUT_MS = 5_000

--- a/lib/voice/index.ts
+++ b/lib/voice/index.ts
@@ -18,5 +18,5 @@ export type {
 
 export { GeminiLiveProvider } from "./gemini-live-provider"
 export { createVoiceProvider } from "./provider-factory"
-export { saveVoiceTranscript, prepareTranscriptEntries } from "./transcript-service"
+export { saveVoiceTranscript } from "./transcript-service"
 export type { TranscriptSaveResult } from "./transcript-service"

--- a/lib/voice/index.ts
+++ b/lib/voice/index.ts
@@ -18,3 +18,5 @@ export type {
 
 export { GeminiLiveProvider } from "./gemini-live-provider"
 export { createVoiceProvider } from "./provider-factory"
+export { saveVoiceTranscript, prepareTranscriptEntries } from "./transcript-service"
+export type { TranscriptSaveResult } from "./transcript-service"

--- a/lib/voice/transcript-service.ts
+++ b/lib/voice/transcript-service.ts
@@ -261,7 +261,9 @@ export function prepareTranscriptEntries(
     }
   }
 
-  // Step 3: Cap at maximum — log if truncation occurs so data loss is visible
+  // Step 3: Cap at maximum — keep the MOST RECENT entries (tail) so late-session
+  // context is preserved. In long voice sessions, the tail typically contains the
+  // user's most recent intent. Log if truncation occurs so data loss is visible.
   if (merged.length > MAX_TRANSCRIPT_ENTRIES) {
     log.warn("Transcript truncated to maximum entry limit", {
       originalCount: merged.length,
@@ -269,7 +271,7 @@ export function prepareTranscriptEntries(
       droppedCount: merged.length - MAX_TRANSCRIPT_ENTRIES,
     })
   }
-  return merged.slice(0, MAX_TRANSCRIPT_ENTRIES)
+  return merged.slice(-MAX_TRANSCRIPT_ENTRIES)
 }
 
 /**
@@ -299,12 +301,13 @@ async function applyGuardrails(
 
   // Wrap the entire guardrail processing with a timeout to prevent hanging
   // during Bedrock brownouts. On timeout, fall back to saving unfiltered.
+  let timeoutHandle: ReturnType<typeof setTimeout> | undefined
   try {
     return await Promise.race([
       applyGuardrailsBatched(entries, safetySvc, { conversationId, requestId, voiceModel, voiceProvider }),
-      new Promise<never>((_, reject) =>
-        setTimeout(() => reject(new Error("Guardrail processing timeout")), GUARDRAIL_TOTAL_TIMEOUT_MS),
-      ),
+      new Promise<never>((_, reject) => {
+        timeoutHandle = setTimeout(() => reject(new Error("Guardrail processing timeout")), GUARDRAIL_TOTAL_TIMEOUT_MS)
+      }),
     ])
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error)
@@ -314,6 +317,9 @@ async function applyGuardrails(
       error: message,
     })
     return entries.map((e) => ({ ...e, wasFiltered: false }))
+  } finally {
+    // Clear the timeout to prevent resource leak when batched processing resolves first
+    if (timeoutHandle) clearTimeout(timeoutHandle)
   }
 }
 

--- a/lib/voice/transcript-service.ts
+++ b/lib/voice/transcript-service.ts
@@ -67,6 +67,9 @@ const MAX_TITLE_LENGTH = 40
 /** Max concurrent guardrail checks — entries are processed in sequential batches of this size */
 const GUARDRAIL_CONCURRENCY_LIMIT = 20
 
+/** Maximum wall-clock time for all guardrail processing before falling back to unfiltered save */
+const GUARDRAIL_TOTAL_TIMEOUT_MS = 30_000
+
 const log = createLogger({ module: "TranscriptService" })
 
 // ============================================
@@ -101,6 +104,7 @@ export async function saveVoiceTranscript(
 ): Promise<TranscriptSaveResult> {
   const requestId = generateRequestId()
   const timer = startTimer("saveVoiceTranscript")
+  const startTime = Date.now()
 
   log.info("Saving voice transcript", {
     requestId,
@@ -124,8 +128,8 @@ export async function saveVoiceTranscript(
 
     if (mergedEntries.length === 0) {
       log.info("No transcript entries to save after preparation", { requestId })
-      const elapsed = timer({ status: "empty" })
-      return { messageCount: 0, filteredCount: 0, titleGenerated: false, processingTimeMs: typeof elapsed === "number" ? elapsed : 0 }
+      timer({ status: "empty" })
+      return { messageCount: 0, filteredCount: 0, titleGenerated: false, processingTimeMs: Date.now() - startTime }
     }
 
     log.info("Transcript entries prepared", {
@@ -186,21 +190,22 @@ export async function saveVoiceTranscript(
       "saveVoiceTranscript",
     )
 
-    const elapsed = timer({ status: "success" })
+    timer({ status: "success" })
+    const processingTimeMs = Date.now() - startTime
     log.info("Voice transcript saved", {
       requestId,
       conversationId,
       messageCount: processedEntries.length,
       filteredCount,
       titleGenerated: !!autoTitle,
-      processingTimeMs: elapsed,
+      processingTimeMs,
     })
 
     return {
       messageCount: processedEntries.length,
       filteredCount,
       titleGenerated: !!autoTitle,
-      processingTimeMs: typeof elapsed === "number" ? elapsed : 0,
+      processingTimeMs,
     }
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error)
@@ -284,6 +289,7 @@ async function applyGuardrails(
   voiceModel?: string,
   voiceProvider?: string,
 ): Promise<ProcessedEntry[]> {
+  // getContentSafetyService is a singleton — no heavy init on repeated calls
   const safetySvc = getContentSafetyService()
 
   if (!safetySvc.isGuardrailsEnabled()) {
@@ -291,6 +297,33 @@ async function applyGuardrails(
     return entries.map((e) => ({ ...e, wasFiltered: false }))
   }
 
+  // Wrap the entire guardrail processing with a timeout to prevent hanging
+  // during Bedrock brownouts. On timeout, fall back to saving unfiltered.
+  try {
+    return await Promise.race([
+      applyGuardrailsBatched(entries, safetySvc, { conversationId, requestId, voiceModel, voiceProvider }),
+      new Promise<never>((_, reject) =>
+        setTimeout(() => reject(new Error("Guardrail processing timeout")), GUARDRAIL_TOTAL_TIMEOUT_MS),
+      ),
+    ])
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    log.warn("Guardrail processing timed out or failed, saving unfiltered", {
+      requestId,
+      entryCount: entries.length,
+      error: message,
+    })
+    return entries.map((e) => ({ ...e, wasFiltered: false }))
+  }
+}
+
+/** Process entries through guardrails in sequential batches of GUARDRAIL_CONCURRENCY_LIMIT. */
+async function applyGuardrailsBatched(
+  entries: Array<{ role: "user" | "assistant"; text: string; timestamp: Date }>,
+  safetySvc: ReturnType<typeof getContentSafetyService>,
+  opts: { conversationId: string; requestId: string; voiceModel?: string; voiceProvider?: string },
+): Promise<ProcessedEntry[]> {
+  const { conversationId, requestId, voiceModel, voiceProvider } = opts
   const processed: ProcessedEntry[] = []
 
   // Process in batches

--- a/lib/voice/transcript-service.ts
+++ b/lib/voice/transcript-service.ts
@@ -25,6 +25,12 @@ import { getContentSafetyService } from "@/lib/safety"
 import { getConversationById } from "@/lib/db/drizzle/nexus-conversations"
 import type { TranscriptEntry } from "./types"
 
+/**
+ * Default conversation title — shared sentinel used by conversation creation
+ * (nexus-conversations.ts, chat-helpers.ts, route.ts) to detect untitled conversations.
+ */
+const DEFAULT_CONVERSATION_TITLE = "New Conversation"
+
 // ============================================
 // Types
 // ============================================
@@ -87,6 +93,7 @@ const log = createLogger({ module: "TranscriptService" })
  * @param userId - Numeric user ID (for ownership verification)
  * @param transcript - Ordered array of transcript entries from the voice session
  * @param voiceModel - The voice model identifier (e.g. "gemini-2.0-flash-live-001")
+ * @param voiceProvider - The voice provider identifier (e.g. "gemini-live") for guardrail audit trails
  * @returns Result with message count, filtered count, and processing time
  * @throws Error if conversation not found/not owned, or transaction fails
  */
@@ -95,6 +102,7 @@ export async function saveVoiceTranscript(
   userId: number,
   transcript: TranscriptEntry[],
   voiceModel?: string,
+  voiceProvider?: string,
 ): Promise<TranscriptSaveResult> {
   const requestId = generateRequestId()
   const timer = startTimer("saveVoiceTranscript")
@@ -109,9 +117,10 @@ export async function saveVoiceTranscript(
 
   try {
     // Step 1: Verify conversation exists and is owned by user
+    // getConversationById checks both id AND userId (ownership) — returns null for either mismatch
     const conversation = await getConversationById(conversationId, userId)
     if (!conversation) {
-      throw new Error(`Conversation ${conversationId} not found`)
+      throw new Error("Conversation not found or access denied")
     }
 
     // Step 2: Prepare entries — filter non-final, merge consecutive same-role
@@ -119,8 +128,8 @@ export async function saveVoiceTranscript(
 
     if (mergedEntries.length === 0) {
       log.info("No transcript entries to save after preparation", { requestId })
-      timer({ status: "empty" })
-      return { messageCount: 0, filteredCount: 0, titleGenerated: false, processingTimeMs: 0 }
+      const elapsed = timer({ status: "empty" })
+      return { messageCount: 0, filteredCount: 0, titleGenerated: false, processingTimeMs: typeof elapsed === "number" ? elapsed : 0 }
     }
 
     log.info("Transcript entries prepared", {
@@ -130,7 +139,7 @@ export async function saveVoiceTranscript(
     })
 
     // Step 3: Run content through Bedrock guardrails
-    const processedEntries = await applyGuardrails(mergedEntries, conversationId, requestId, voiceModel)
+    const processedEntries = await applyGuardrails(mergedEntries, conversationId, requestId, voiceModel, voiceProvider)
     const filteredCount = processedEntries.filter((e) => e.wasFiltered).length
 
     if (filteredCount > 0) {
@@ -143,7 +152,7 @@ export async function saveVoiceTranscript(
     }
 
     // Step 4: Determine if title needs to be auto-generated
-    const needsTitle = !conversation.title || conversation.title === "New Conversation"
+    const needsTitle = !conversation.title || conversation.title === DEFAULT_CONVERSATION_TITLE
     const autoTitle = needsTitle ? generateVoiceTitle(processedEntries) : null
 
     // Step 5: Atomic save — all messages + conversation metadata in one transaction
@@ -162,28 +171,20 @@ export async function saveVoiceTranscript(
           createdAt: entry.timestamp,
         }))
 
-        if (messageValues.length > 0) {
-          await tx.insert(nexusMessages).values(messageValues)
-        }
+        // processedEntries is guaranteed non-empty (early return above for empty case)
+        await tx.insert(nexusMessages).values(messageValues)
 
-        // Update conversation metadata
-        const updateFields: Record<string, unknown> = {
-          messageCount: sql`COALESCE(${nexusConversations.messageCount}, 0) + ${processedEntries.length}`,
-          lastMessageAt: processedEntries[processedEntries.length - 1].timestamp,
-          updatedAt: new Date(),
-        }
-
-        if (voiceModel) {
-          updateFields.modelUsed = voiceModel
-        }
-
-        if (autoTitle) {
-          updateFields.title = autoTitle
-        }
-
+        // Update conversation metadata — use explicit typed fields to prevent
+        // silent no-ops from misspelled column names (CLAUDE.md silent failure pattern)
         await tx
           .update(nexusConversations)
-          .set(updateFields)
+          .set({
+            messageCount: sql`COALESCE(${nexusConversations.messageCount}, 0) + ${processedEntries.length}`,
+            lastMessageAt: processedEntries[processedEntries.length - 1].timestamp,
+            updatedAt: new Date(),
+            ...(voiceModel ? { modelUsed: voiceModel } : {}),
+            ...(autoTitle ? { title: autoTitle } : {}),
+          })
           .where(eq(nexusConversations.id, conversationId))
       },
       "saveVoiceTranscript",
@@ -259,7 +260,14 @@ export function prepareTranscriptEntries(
     }
   }
 
-  // Step 3: Cap at maximum
+  // Step 3: Cap at maximum — log if truncation occurs so data loss is visible
+  if (merged.length > MAX_TRANSCRIPT_ENTRIES) {
+    log.warn("Transcript truncated to maximum entry limit", {
+      originalCount: merged.length,
+      maxEntries: MAX_TRANSCRIPT_ENTRIES,
+      droppedCount: merged.length - MAX_TRANSCRIPT_ENTRIES,
+    })
+  }
   return merged.slice(0, MAX_TRANSCRIPT_ENTRIES)
 }
 
@@ -278,6 +286,7 @@ async function applyGuardrails(
   conversationId: string,
   requestId: string,
   voiceModel?: string,
+  voiceProvider?: string,
 ): Promise<ProcessedEntry[]> {
   const safetySvc = getContentSafetyService()
 
@@ -301,7 +310,7 @@ async function applyGuardrails(
           // Use the appropriate check based on role
           const result = entry.role === "user"
             ? await safetySvc.checkInputSafety(entry.text, sessionId)
-            : await safetySvc.checkOutputSafety(entry.text, voiceModel ?? "unknown", "gemini-live", sessionId)
+            : await safetySvc.checkOutputSafety(entry.text, voiceModel ?? "unknown-voice-model", voiceProvider ?? "unknown-voice-provider", sessionId)
 
           if (!result.allowed) {
             log.warn("Voice transcript entry filtered by guardrails", {

--- a/lib/voice/transcript-service.ts
+++ b/lib/voice/transcript-service.ts
@@ -70,7 +70,11 @@ const MAX_TRANSCRIPT_ENTRIES = 500
 /** Placeholder text for content blocked by safety guardrails */
 const FILTERED_CONTENT_NOTICE = "[Content filtered by safety policy]"
 
-/** Maximum title length (matches DB constraint of 500, but we target 40 for consistency) */
+/**
+ * Maximum title length INCLUDING the "..." suffix.
+ * Titles longer than this are truncated to (MAX_TITLE_LENGTH - 3) + "...".
+ * Matches the DB constraint of 500, but we target 40 total for UI consistency.
+ */
 const MAX_TITLE_LENGTH = 40
 
 /** Max concurrent guardrail checks — entries are processed in sequential batches of this size */
@@ -126,9 +130,15 @@ export async function saveVoiceTranscript(
 
   try {
     // Step 1: Verify conversation exists and is owned by user
-    // getConversationById checks both id AND userId (ownership) — returns null for either mismatch
+    // getConversationById checks both id AND userId (ownership) — returns null for either mismatch.
+    // A null result can mean the conversation was deleted mid-session or userId doesn't match.
     const conversation = await getConversationById(conversationId, userId)
     if (!conversation) {
+      log.warn("Conversation not found or not owned — transcript will not be saved", {
+        requestId,
+        conversationId,
+        userId,
+      })
       throw new Error("Conversation not found or access denied")
     }
 
@@ -154,11 +164,16 @@ export async function saveVoiceTranscript(
     const filteredCount = processedEntries.filter((e) => e.wasFiltered).length
 
     if (filteredCount > 0) {
-      log.warn("Voice transcript entries filtered by guardrails", {
+      const allFiltered = filteredCount === processedEntries.length
+      // Elevated to error when 100% of entries are filtered — may indicate guardrail
+      // misconfiguration or systematic abuse. Operators should investigate.
+      const logLevel = allFiltered ? "error" : "warn"
+      log[logLevel]("Voice transcript entries filtered by guardrails", {
         requestId,
         conversationId,
         filteredCount,
         totalCount: processedEntries.length,
+        allFiltered,
       })
     }
 
@@ -384,6 +399,12 @@ async function applyGuardrailsBatched(
           // Use processedContent if the safety service transformed the text (e.g., PII redaction).
           // Currently the quick check methods don't modify content, but this is defensive
           // against future safety service changes that may introduce content transformations.
+          if (result.processedContent == null) {
+            log.warn("Safety service returned no processedContent, using original text", {
+              requestId,
+              role: entry.role,
+            })
+          }
           return { ...entry, text: result.processedContent ?? entry.text, wasFiltered: false }
         } catch (error) {
           // Graceful degradation — allow entry through on error
@@ -422,5 +443,6 @@ function generateVoiceTitle(entries: ProcessedEntry[]): string | null {
   if (!cleaned) return null
 
   if (cleaned.length <= MAX_TITLE_LENGTH) return cleaned
-  return `${cleaned.slice(0, MAX_TITLE_LENGTH).trim()}...`
+  // Truncate to (MAX_TITLE_LENGTH - 3) so total with "..." never exceeds MAX_TITLE_LENGTH
+  return `${cleaned.slice(0, MAX_TITLE_LENGTH - 3).trim()}...`
 }

--- a/lib/voice/transcript-service.ts
+++ b/lib/voice/transcript-service.ts
@@ -63,8 +63,8 @@ const FILTERED_CONTENT_NOTICE = "[Content filtered by safety policy]"
 /** Maximum title length (matches DB constraint of 500, but we target 40 for consistency) */
 const MAX_TITLE_LENGTH = 40
 
-/** Batch size for guardrail checks — process this many entries per API call */
-const GUARDRAIL_BATCH_SIZE = 20
+/** Max concurrent guardrail checks — entries are processed in sequential batches of this size */
+const GUARDRAIL_CONCURRENCY_LIMIT = 20
 
 const log = createLogger({ module: "TranscriptService" })
 
@@ -111,7 +111,7 @@ export async function saveVoiceTranscript(
     // Step 1: Verify conversation exists and is owned by user
     const conversation = await getConversationById(conversationId, userId)
     if (!conversation) {
-      throw new Error(`Conversation ${conversationId} not found or not owned by user ${userId}`)
+      throw new Error(`Conversation ${conversationId} not found`)
     }
 
     // Step 2: Prepare entries — filter non-final, merge consecutive same-role
@@ -130,7 +130,7 @@ export async function saveVoiceTranscript(
     })
 
     // Step 3: Run content through Bedrock guardrails
-    const processedEntries = await applyGuardrails(mergedEntries, conversationId, requestId)
+    const processedEntries = await applyGuardrails(mergedEntries, conversationId, requestId, voiceModel)
     const filteredCount = processedEntries.filter((e) => e.wasFiltered).length
 
     if (filteredCount > 0) {
@@ -277,6 +277,7 @@ async function applyGuardrails(
   entries: Array<{ role: "user" | "assistant"; text: string; timestamp: Date }>,
   conversationId: string,
   requestId: string,
+  voiceModel?: string,
 ): Promise<ProcessedEntry[]> {
   const safetySvc = getContentSafetyService()
 
@@ -288,8 +289,8 @@ async function applyGuardrails(
   const processed: ProcessedEntry[] = []
 
   // Process in batches
-  for (let i = 0; i < entries.length; i += GUARDRAIL_BATCH_SIZE) {
-    const batch = entries.slice(i, i + GUARDRAIL_BATCH_SIZE)
+  for (let i = 0; i < entries.length; i += GUARDRAIL_CONCURRENCY_LIMIT) {
+    const batch = entries.slice(i, i + GUARDRAIL_CONCURRENCY_LIMIT)
 
     // Process each entry in the batch concurrently
     const batchResults = await Promise.all(
@@ -300,7 +301,7 @@ async function applyGuardrails(
           // Use the appropriate check based on role
           const result = entry.role === "user"
             ? await safetySvc.checkInputSafety(entry.text, sessionId)
-            : await safetySvc.checkOutputSafety(entry.text, "voice-model", "gemini-live", sessionId)
+            : await safetySvc.checkOutputSafety(entry.text, voiceModel ?? "unknown", "gemini-live", sessionId)
 
           if (!result.allowed) {
             log.warn("Voice transcript entry filtered by guardrails", {

--- a/lib/voice/transcript-service.ts
+++ b/lib/voice/transcript-service.ts
@@ -1,0 +1,359 @@
+/**
+ * Voice Transcript Persistence Service
+ *
+ * Converts voice conversation transcripts into standard Nexus messages,
+ * runs them through Bedrock content safety guardrails, and saves to the
+ * existing conversation infrastructure so users can continue in text mode.
+ *
+ * Flow:
+ *   1. Receive ordered TranscriptEntry[] from voice session
+ *   2. Filter to final entries only, merge consecutive same-role entries
+ *   3. Run each message through Bedrock guardrails (content safety)
+ *   4. Replace flagged content with "[Content filtered by safety policy]"
+ *   5. Save all messages + update conversation metadata in a single transaction
+ *   6. Generate title from first user message if conversation is new
+ *
+ * Issue #875
+ */
+
+import { createLogger, generateRequestId, startTimer } from "@/lib/logger"
+import { sql, eq } from "drizzle-orm"
+import { executeTransaction } from "@/lib/db/drizzle-client"
+import { nexusMessages, nexusConversations } from "@/lib/db/schema"
+import { safeJsonbStringify } from "@/lib/db/json-utils"
+import { getContentSafetyService } from "@/lib/safety"
+import { getConversationById } from "@/lib/db/drizzle/nexus-conversations"
+import type { TranscriptEntry } from "./types"
+
+// ============================================
+// Types
+// ============================================
+
+/** Result of saving a voice transcript */
+export interface TranscriptSaveResult {
+  /** Number of messages saved */
+  messageCount: number
+  /** Number of messages that had content filtered by guardrails */
+  filteredCount: number
+  /** Whether a title was auto-generated for the conversation */
+  titleGenerated: boolean
+  /** Processing time in milliseconds */
+  processingTimeMs: number
+}
+
+/** A transcript entry after guardrail processing */
+interface ProcessedEntry {
+  role: "user" | "assistant"
+  text: string
+  timestamp: Date
+  /** Whether guardrails modified this entry's content */
+  wasFiltered: boolean
+}
+
+// ============================================
+// Constants
+// ============================================
+
+/** Maximum number of transcript entries to process in one save operation */
+const MAX_TRANSCRIPT_ENTRIES = 500
+
+/** Placeholder text for content blocked by safety guardrails */
+const FILTERED_CONTENT_NOTICE = "[Content filtered by safety policy]"
+
+/** Maximum title length (matches DB constraint of 500, but we target 40 for consistency) */
+const MAX_TITLE_LENGTH = 40
+
+/** Batch size for guardrail checks — process this many entries per API call */
+const GUARDRAIL_BATCH_SIZE = 20
+
+const log = createLogger({ module: "TranscriptService" })
+
+// ============================================
+// Public API
+// ============================================
+
+/**
+ * Save a voice transcript to the conversation as standard Nexus messages.
+ *
+ * This is the main entry point called by the voice session lifecycle when
+ * a session ends. It handles:
+ * - Filtering to final transcript entries only
+ * - Merging consecutive same-role entries
+ * - Running content through Bedrock guardrails
+ * - Atomic save of all messages + conversation metadata update
+ * - Auto-generating a title for new conversations
+ *
+ * @param conversationId - UUID of the existing conversation
+ * @param userId - Numeric user ID (for ownership verification)
+ * @param transcript - Ordered array of transcript entries from the voice session
+ * @param voiceModel - The voice model identifier (e.g. "gemini-2.0-flash-live-001")
+ * @returns Result with message count, filtered count, and processing time
+ * @throws Error if conversation not found/not owned, or transaction fails
+ */
+export async function saveVoiceTranscript(
+  conversationId: string,
+  userId: number,
+  transcript: TranscriptEntry[],
+  voiceModel?: string,
+): Promise<TranscriptSaveResult> {
+  const requestId = generateRequestId()
+  const timer = startTimer("saveVoiceTranscript")
+
+  log.info("Saving voice transcript", {
+    requestId,
+    conversationId,
+    userId,
+    rawEntryCount: transcript.length,
+    voiceModel,
+  })
+
+  try {
+    // Step 1: Verify conversation exists and is owned by user
+    const conversation = await getConversationById(conversationId, userId)
+    if (!conversation) {
+      throw new Error(`Conversation ${conversationId} not found or not owned by user ${userId}`)
+    }
+
+    // Step 2: Prepare entries — filter non-final, merge consecutive same-role
+    const mergedEntries = prepareTranscriptEntries(transcript)
+
+    if (mergedEntries.length === 0) {
+      log.info("No transcript entries to save after preparation", { requestId })
+      timer({ status: "empty" })
+      return { messageCount: 0, filteredCount: 0, titleGenerated: false, processingTimeMs: 0 }
+    }
+
+    log.info("Transcript entries prepared", {
+      requestId,
+      rawCount: transcript.length,
+      mergedCount: mergedEntries.length,
+    })
+
+    // Step 3: Run content through Bedrock guardrails
+    const processedEntries = await applyGuardrails(mergedEntries, conversationId, requestId)
+    const filteredCount = processedEntries.filter((e) => e.wasFiltered).length
+
+    if (filteredCount > 0) {
+      log.warn("Voice transcript entries filtered by guardrails", {
+        requestId,
+        conversationId,
+        filteredCount,
+        totalCount: processedEntries.length,
+      })
+    }
+
+    // Step 4: Determine if title needs to be auto-generated
+    const needsTitle = !conversation.title || conversation.title === "New Conversation"
+    const autoTitle = needsTitle ? generateVoiceTitle(processedEntries) : null
+
+    // Step 5: Atomic save — all messages + conversation metadata in one transaction
+    await executeTransaction(
+      async (tx) => {
+        // Insert all messages
+        const messageValues = processedEntries.map((entry) => ({
+          conversationId,
+          role: entry.role,
+          content: entry.text,
+          parts: sql`${safeJsonbStringify([{ type: "text", text: entry.text }])}::jsonb`,
+          metadata: sql`${safeJsonbStringify({
+            source: "voice",
+            ...(entry.wasFiltered ? { filtered: true } : {}),
+          })}::jsonb`,
+          createdAt: entry.timestamp,
+        }))
+
+        if (messageValues.length > 0) {
+          await tx.insert(nexusMessages).values(messageValues)
+        }
+
+        // Update conversation metadata
+        const updateFields: Record<string, unknown> = {
+          messageCount: sql`COALESCE(${nexusConversations.messageCount}, 0) + ${processedEntries.length}`,
+          lastMessageAt: processedEntries[processedEntries.length - 1].timestamp,
+          updatedAt: new Date(),
+        }
+
+        if (voiceModel) {
+          updateFields.modelUsed = voiceModel
+        }
+
+        if (autoTitle) {
+          updateFields.title = autoTitle
+        }
+
+        await tx
+          .update(nexusConversations)
+          .set(updateFields)
+          .where(eq(nexusConversations.id, conversationId))
+      },
+      "saveVoiceTranscript",
+    )
+
+    const elapsed = timer({ status: "success" })
+    log.info("Voice transcript saved", {
+      requestId,
+      conversationId,
+      messageCount: processedEntries.length,
+      filteredCount,
+      titleGenerated: !!autoTitle,
+      processingTimeMs: elapsed,
+    })
+
+    return {
+      messageCount: processedEntries.length,
+      filteredCount,
+      titleGenerated: !!autoTitle,
+      processingTimeMs: typeof elapsed === "number" ? elapsed : 0,
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    log.error("Failed to save voice transcript", {
+      requestId,
+      conversationId,
+      error: message,
+    })
+    timer({ status: "error" })
+    throw error
+  }
+}
+
+// ============================================
+// Internal Functions
+// ============================================
+
+/**
+ * Prepare transcript entries for persistence:
+ * 1. Filter to final entries only (isFinal === true)
+ * 2. Skip entries with empty text
+ * 3. Merge consecutive entries from the same role
+ * 4. Cap at MAX_TRANSCRIPT_ENTRIES
+ *
+ * Merging is important because Gemini Live can emit multiple transcript
+ * fragments for a single "turn" (e.g., partial sentences). Merging them
+ * produces cleaner messages that read naturally in the text UI.
+ */
+export function prepareTranscriptEntries(
+  entries: TranscriptEntry[],
+): Array<{ role: "user" | "assistant"; text: string; timestamp: Date }> {
+  // Step 1: Filter to final, non-empty entries
+  const finalEntries = entries.filter(
+    (e) => e.isFinal && e.text.trim().length > 0,
+  )
+
+  if (finalEntries.length === 0) return []
+
+  // Step 2: Merge consecutive same-role entries
+  const merged: Array<{ role: "user" | "assistant"; text: string; timestamp: Date }> = []
+
+  for (const entry of finalEntries) {
+    const last = merged[merged.length - 1]
+    if (last && last.role === entry.role) {
+      // Append text with a space separator, keep the earlier timestamp
+      last.text = `${last.text} ${entry.text.trim()}`
+    } else {
+      merged.push({
+        role: entry.role,
+        text: entry.text.trim(),
+        timestamp: entry.timestamp,
+      })
+    }
+  }
+
+  // Step 3: Cap at maximum
+  return merged.slice(0, MAX_TRANSCRIPT_ENTRIES)
+}
+
+/**
+ * Apply Bedrock content safety guardrails to transcript entries.
+ *
+ * Processes entries in batches to avoid overwhelming the guardrails API.
+ * If an individual entry is flagged, its content is replaced with the
+ * filtered notice — the entry is NOT removed from the transcript.
+ *
+ * On guardrail service error (disabled, unavailable), entries pass through
+ * unmodified (graceful degradation — consistent with existing pattern).
+ */
+async function applyGuardrails(
+  entries: Array<{ role: "user" | "assistant"; text: string; timestamp: Date }>,
+  conversationId: string,
+  requestId: string,
+): Promise<ProcessedEntry[]> {
+  const safetySvc = getContentSafetyService()
+
+  if (!safetySvc.isGuardrailsEnabled()) {
+    log.info("Guardrails disabled, skipping transcript safety check", { requestId })
+    return entries.map((e) => ({ ...e, wasFiltered: false }))
+  }
+
+  const processed: ProcessedEntry[] = []
+
+  // Process in batches
+  for (let i = 0; i < entries.length; i += GUARDRAIL_BATCH_SIZE) {
+    const batch = entries.slice(i, i + GUARDRAIL_BATCH_SIZE)
+
+    // Process each entry in the batch concurrently
+    const batchResults = await Promise.all(
+      batch.map(async (entry) => {
+        try {
+          const sessionId = `voice-${conversationId}`
+
+          // Use the appropriate check based on role
+          const result = entry.role === "user"
+            ? await safetySvc.checkInputSafety(entry.text, sessionId)
+            : await safetySvc.checkOutputSafety(entry.text, "voice-model", "gemini-live", sessionId)
+
+          if (!result.allowed) {
+            log.warn("Voice transcript entry filtered by guardrails", {
+              requestId,
+              role: entry.role,
+              blockedReason: result.blockedReason,
+              blockedCategories: result.blockedCategories,
+            })
+            return {
+              role: entry.role,
+              text: FILTERED_CONTENT_NOTICE,
+              timestamp: entry.timestamp,
+              wasFiltered: true,
+            }
+          }
+
+          return { ...entry, wasFiltered: false }
+        } catch (error) {
+          // Graceful degradation — allow entry through on error
+          const message = error instanceof Error ? error.message : String(error)
+          log.warn("Guardrail check failed for transcript entry, allowing through", {
+            requestId,
+            role: entry.role,
+            error: message,
+          })
+          return { ...entry, wasFiltered: false }
+        }
+      }),
+    )
+
+    processed.push(...batchResults)
+  }
+
+  return processed
+}
+
+/**
+ * Generate a conversation title from the first user message in the transcript.
+ * Follows the same pattern as generateConversationTitle in chat-helpers.ts:
+ * - Extract first user text
+ * - Clean whitespace
+ * - Truncate to MAX_TITLE_LENGTH chars with ellipsis
+ */
+function generateVoiceTitle(entries: ProcessedEntry[]): string | null {
+  const firstUserEntry = entries.find(
+    (e) => e.role === "user" && e.text !== FILTERED_CONTENT_NOTICE,
+  )
+
+  if (!firstUserEntry) return null
+
+  const cleaned = firstUserEntry.text.replace(/\s+/g, " ").trim()
+  if (!cleaned) return null
+
+  if (cleaned.length <= MAX_TITLE_LENGTH) return cleaned
+  return `${cleaned.slice(0, MAX_TITLE_LENGTH).trim()}...`
+}

--- a/lib/voice/transcript-service.ts
+++ b/lib/voice/transcript-service.ts
@@ -23,13 +23,8 @@ import { nexusMessages, nexusConversations } from "@/lib/db/schema"
 import { safeJsonbStringify } from "@/lib/db/json-utils"
 import { getContentSafetyService } from "@/lib/safety"
 import { getConversationById } from "@/lib/db/drizzle/nexus-conversations"
+import { DEFAULT_CONVERSATION_TITLE } from "@/lib/constants/conversation"
 import type { TranscriptEntry } from "./types"
-
-/**
- * Default conversation title — shared sentinel used by conversation creation
- * (nexus-conversations.ts, chat-helpers.ts, route.ts) to detect untitled conversations.
- */
-const DEFAULT_CONVERSATION_TITLE = "New Conversation"
 
 // ============================================
 // Types
@@ -113,6 +108,7 @@ export async function saveVoiceTranscript(
     userId,
     rawEntryCount: transcript.length,
     voiceModel,
+    voiceProvider,
   })
 
   try {
@@ -327,7 +323,10 @@ async function applyGuardrails(
             }
           }
 
-          return { ...entry, wasFiltered: false }
+          // Use processedContent if the safety service transformed the text (e.g., PII redaction).
+          // Currently the quick check methods don't modify content, but this is defensive
+          // against future safety service changes that may introduce content transformations.
+          return { ...entry, text: result.processedContent ?? entry.text, wasFiltered: false }
         } catch (error) {
           // Graceful degradation — allow entry through on error
           const message = error instanceof Error ? error.message : String(error)

--- a/lib/voice/transcript-service.ts
+++ b/lib/voice/transcript-service.ts
@@ -40,6 +40,8 @@ export interface TranscriptSaveResult {
   titleGenerated: boolean
   /** Processing time in milliseconds */
   processingTimeMs: number
+  /** Whether guardrails were bypassed due to timeout, error, or being disabled */
+  guardrailsBypassed: boolean
 }
 
 /** A transcript entry after guardrail processing */
@@ -49,6 +51,13 @@ interface ProcessedEntry {
   timestamp: Date
   /** Whether guardrails modified this entry's content */
   wasFiltered: boolean
+}
+
+/** Result from guardrail processing, including bypass status */
+interface GuardrailResult {
+  entries: ProcessedEntry[]
+  /** True if guardrails were bypassed (disabled, timed out, or errored) */
+  bypassed: boolean
 }
 
 // ============================================
@@ -124,12 +133,12 @@ export async function saveVoiceTranscript(
     }
 
     // Step 2: Prepare entries — filter non-final, merge consecutive same-role
-    const mergedEntries = prepareTranscriptEntries(transcript)
+    const mergedEntries = prepareTranscriptEntries(transcript, requestId)
 
     if (mergedEntries.length === 0) {
       log.info("No transcript entries to save after preparation", { requestId })
       timer({ status: "empty" })
-      return { messageCount: 0, filteredCount: 0, titleGenerated: false, processingTimeMs: Date.now() - startTime }
+      return { messageCount: 0, filteredCount: 0, titleGenerated: false, processingTimeMs: Date.now() - startTime, guardrailsBypassed: false }
     }
 
     log.info("Transcript entries prepared", {
@@ -139,7 +148,9 @@ export async function saveVoiceTranscript(
     })
 
     // Step 3: Run content through Bedrock guardrails
-    const processedEntries = await applyGuardrails(mergedEntries, conversationId, requestId, voiceModel, voiceProvider)
+    const guardrailResult = await applyGuardrails(mergedEntries, conversationId, requestId, voiceModel, voiceProvider)
+    const processedEntries = guardrailResult.entries
+    const guardrailsBypassed = guardrailResult.bypassed
     const filteredCount = processedEntries.filter((e) => e.wasFiltered).length
 
     if (filteredCount > 0) {
@@ -198,6 +209,7 @@ export async function saveVoiceTranscript(
       messageCount: processedEntries.length,
       filteredCount,
       titleGenerated: !!autoTitle,
+      guardrailsBypassed,
       processingTimeMs,
     })
 
@@ -206,6 +218,7 @@ export async function saveVoiceTranscript(
       filteredCount,
       titleGenerated: !!autoTitle,
       processingTimeMs,
+      guardrailsBypassed,
     }
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error)
@@ -236,6 +249,7 @@ export async function saveVoiceTranscript(
  */
 export function prepareTranscriptEntries(
   entries: TranscriptEntry[],
+  requestId?: string,
 ): Array<{ role: "user" | "assistant"; text: string; timestamp: Date }> {
   // Step 1: Filter to final, non-empty entries
   const finalEntries = entries.filter(
@@ -266,6 +280,7 @@ export function prepareTranscriptEntries(
   // user's most recent intent. Log if truncation occurs so data loss is visible.
   if (merged.length > MAX_TRANSCRIPT_ENTRIES) {
     log.warn("Transcript truncated to maximum entry limit", {
+      requestId,
       originalCount: merged.length,
       maxEntries: MAX_TRANSCRIPT_ENTRIES,
       droppedCount: merged.length - MAX_TRANSCRIPT_ENTRIES,
@@ -290,33 +305,37 @@ async function applyGuardrails(
   requestId: string,
   voiceModel?: string,
   voiceProvider?: string,
-): Promise<ProcessedEntry[]> {
+): Promise<GuardrailResult> {
   // getContentSafetyService is a singleton — no heavy init on repeated calls
   const safetySvc = getContentSafetyService()
 
   if (!safetySvc.isGuardrailsEnabled()) {
     log.info("Guardrails disabled, skipping transcript safety check", { requestId })
-    return entries.map((e) => ({ ...e, wasFiltered: false }))
+    return { entries: entries.map((e) => ({ ...e, wasFiltered: false })), bypassed: true }
   }
 
   // Wrap the entire guardrail processing with a timeout to prevent hanging
   // during Bedrock brownouts. On timeout, fall back to saving unfiltered.
   let timeoutHandle: ReturnType<typeof setTimeout> | undefined
   try {
-    return await Promise.race([
+    const processed = await Promise.race([
       applyGuardrailsBatched(entries, safetySvc, { conversationId, requestId, voiceModel, voiceProvider }),
       new Promise<never>((_, reject) => {
         timeoutHandle = setTimeout(() => reject(new Error("Guardrail processing timeout")), GUARDRAIL_TOTAL_TIMEOUT_MS)
       }),
     ])
+    return { entries: processed, bypassed: false }
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error)
-    log.warn("Guardrail processing timed out or failed, saving unfiltered", {
+    // Elevated to error level — content is being saved without safety filtering,
+    // which callers should audit. guardrailsBypassed in the result enables alerting.
+    log.error("Guardrail processing failed, saving unfiltered content", {
       requestId,
+      conversationId,
       entryCount: entries.length,
       error: message,
     })
-    return entries.map((e) => ({ ...e, wasFiltered: false }))
+    return { entries: entries.map((e) => ({ ...e, wasFiltered: false })), bypassed: true }
   } finally {
     // Clear the timeout to prevent resource leak when batched processing resolves first
     if (timeoutHandle) clearTimeout(timeoutHandle)

--- a/lib/voice/ws-handler.ts
+++ b/lib/voice/ws-handler.ts
@@ -226,6 +226,88 @@ function registerMessageHandler(
   })
 }
 
+/** Mutable session state shared between handleVoiceConnection and its helpers. */
+interface VoiceSessionState {
+  providerRef: { current: VoiceProvider | null }
+  pingInterval: ReturnType<typeof setInterval> | null
+  sessionEnded: boolean
+  capturedTranscript: TranscriptEntry[]
+  transcriptContext: { conversationId: string; userId: number; voiceModel: string; voiceProvider: string } | null
+}
+
+/** Create a fresh session state object. */
+function createSessionState(): VoiceSessionState {
+  return {
+    providerRef: { current: null },
+    pingInterval: null,
+    sessionEnded: false,
+    capturedTranscript: [],
+    transcriptContext: null,
+  }
+}
+
+/**
+ * Idempotent session cleanup. Captures transcript, disconnects provider,
+ * fires async persistence, and records timing.
+ */
+function cleanupSession(
+  state: VoiceSessionState,
+  status: string,
+  logFn: ReturnType<typeof createLogger>,
+  timer: ReturnType<typeof startTimer>,
+): void {
+  if (state.sessionEnded) return
+  state.sessionEnded = true
+  if (state.pingInterval) { clearInterval(state.pingInterval); state.pingInterval = null }
+
+  // Capture transcript BEFORE disconnect clears it from provider memory.
+  // Shallow copy the array — disconnect() may mutate/clear the original.
+  if (state.providerRef.current) {
+    try {
+      const providerState = state.providerRef.current.getSessionState()
+      if (providerState.transcript.length > 0) {
+        state.capturedTranscript = [...providerState.transcript]
+      }
+    } catch {
+      logFn.warn("Failed to capture transcript before disconnect")
+    }
+
+    state.providerRef.current.disconnect().catch((e: Error) =>
+      logFn.warn("Provider disconnect failed during cleanup", { error: e.message })
+    )
+    state.providerRef.current = null
+  }
+
+  // Fire-and-forget transcript persistence — non-blocking, non-fatal
+  if (state.transcriptContext && state.capturedTranscript.length > 0) {
+    const { conversationId, userId, voiceModel, voiceProvider } = state.transcriptContext
+    logFn.info("Persisting voice transcript", {
+      conversationId,
+      entryCount: state.capturedTranscript.length,
+    })
+    saveVoiceTranscript(conversationId, userId, state.capturedTranscript, voiceModel, voiceProvider)
+      .then((result) => {
+        const logMethod = result.processingTimeMs > 5000 ? "warn" : "info"
+        logFn[logMethod]("Voice transcript persisted", {
+          conversationId,
+          messageCount: result.messageCount,
+          filteredCount: result.filteredCount,
+          titleGenerated: result.titleGenerated,
+          processingTimeMs: result.processingTimeMs,
+          ...(result.processingTimeMs > 5000 ? { slow: true } : {}),
+        })
+      })
+      .catch((error: Error) => {
+        logFn.error("Failed to persist voice transcript", {
+          conversationId,
+          error: error.message,
+        })
+      })
+  }
+
+  timer({ status })
+}
+
 /** Forward a provider event to the client WebSocket. */
 function forwardProviderEvent(ws: WebSocket, event: VoiceProviderEvent): void {
   switch (event.type) {
@@ -336,6 +418,44 @@ function waitForSessionConfig(
   })
 }
 
+/**
+ * Authenticate and authorize a WebSocket connection for voice.
+ * Returns auth info on success, or sends the appropriate error/close and returns null.
+ */
+async function authenticateAndAuthorize(
+  ws: WebSocket,
+  req: IncomingMessage,
+  logFn: ReturnType<typeof createLogger>,
+  timer: ReturnType<typeof startTimer>,
+): Promise<{ userId: string; sub: string } | null> {
+  const auth = await authenticateWebSocket(req)
+  if (!auth) {
+    logFn.warn("Unauthorized voice connection attempt")
+    sendToClient(ws, { type: "error", message: "Unauthorized" })
+    ws.close(4001, "Unauthorized")
+    timer({ status: "unauthorized" })
+    return null
+  }
+
+  logFn.info("Voice connection authenticated", { userId: sanitizeForLogging(auth.userId) })
+
+  let hasAccess = false
+  try {
+    hasAccess = await hasToolAccess(auth.sub, "voice-mode")
+  } catch {
+    hasAccess = false
+  }
+  if (!hasAccess) {
+    logFn.warn("User lacks voice-mode access", { userId: sanitizeForLogging(auth.userId) })
+    sendToClient(ws, { type: "error", message: "Voice mode not enabled for this user" })
+    ws.close(4003, "Forbidden")
+    timer({ status: "forbidden" })
+    return null
+  }
+
+  return auth
+}
+
 /** Returns a reason string if voice config is invalid, or null if OK. */
 function validateVoiceConfig(
   settings: { provider: string | null; model: string | null },
@@ -384,97 +504,14 @@ export async function handleVoiceConnection(ws: WebSocket, req: IncomingMessage)
   const log = createLogger({ requestId, context: "voice-ws" })
   const timer = startTimer("voice-session")
 
-  /** Mutable ref so both cleanup() and registerMessageHandler() share the same provider pointer */
-  const providerRef: { current: VoiceProvider | null } = { current: null }
-  let pingInterval: ReturnType<typeof setInterval> | null = null
-  let sessionEnded = false
-  /** Captured transcript for persistence — snapshot taken before provider.disconnect() clears it */
-  let capturedTranscript: TranscriptEntry[] = []
-  /** Session context for transcript persistence — set after auth + config */
-  let transcriptContext: { conversationId: string; userId: number; voiceModel: string; voiceProvider: string } | null = null
-
-  /** Idempotent cleanup — synchronous to avoid swallowed errors in event handlers */
-  function cleanup(status: string) {
-    if (sessionEnded) return
-    sessionEnded = true
-    if (pingInterval) { clearInterval(pingInterval); pingInterval = null }
-
-    // Capture transcript BEFORE disconnect clears it from provider memory.
-    // Shallow copy the array — disconnect() may mutate/clear the original.
-    if (providerRef.current) {
-      try {
-        const state = providerRef.current.getSessionState()
-        if (state.transcript.length > 0) {
-          capturedTranscript = [...state.transcript]
-        }
-      } catch {
-        log.warn("Failed to capture transcript before disconnect")
-      }
-
-      providerRef.current.disconnect().catch((e: Error) =>
-        log.warn("Provider disconnect failed during cleanup", { error: e.message })
-      )
-      providerRef.current = null
-    }
-
-    // Fire-and-forget transcript persistence — non-blocking, non-fatal
-    if (transcriptContext && capturedTranscript.length > 0) {
-      const { conversationId, userId, voiceModel, voiceProvider } = transcriptContext
-      log.info("Persisting voice transcript", {
-        conversationId,
-        entryCount: capturedTranscript.length,
-      })
-      saveVoiceTranscript(conversationId, userId, capturedTranscript, voiceModel, voiceProvider)
-        .then((result) => {
-          const logMethod = result.processingTimeMs > 5000 ? "warn" : "info"
-          log[logMethod]("Voice transcript persisted", {
-            conversationId,
-            messageCount: result.messageCount,
-            filteredCount: result.filteredCount,
-            titleGenerated: result.titleGenerated,
-            processingTimeMs: result.processingTimeMs,
-            ...(result.processingTimeMs > 5000 ? { slow: true } : {}),
-          })
-        })
-        .catch((error: Error) => {
-          log.error("Failed to persist voice transcript", {
-            conversationId,
-            error: error.message,
-          })
-        })
-    }
-
-    timer({ status })
-  }
+  const session = createSessionState()
+  const cleanup = (status: string) => cleanupSession(session, status, log, timer)
 
   try {
-    // Step 1: Authenticate
+    // Steps 1-2: Authenticate and check voice-mode access
     log.info("New voice WebSocket connection")
-    const auth = await authenticateWebSocket(req)
-    if (!auth) {
-      log.warn("Unauthorized voice connection attempt")
-      sendToClient(ws, { type: "error", message: "Unauthorized" })
-      ws.close(4001, "Unauthorized")
-      timer({ status: "unauthorized" })
-      return
-    }
-
-    log.info("Voice connection authenticated", { userId: sanitizeForLogging(auth.userId) })
-
-    // Step 2: Check voice access (fail-closed on error)
-    let hasAccess = false
-    try {
-      hasAccess = await hasToolAccess(auth.sub, "voice-mode")
-    } catch {
-      hasAccess = false
-    }
-    if (!hasAccess) {
-      log.warn("User lacks voice-mode access", { userId: sanitizeForLogging(auth.userId) })
-      sendToClient(ws, { type: "error", message: "Voice mode not enabled for this user" })
-      ws.close(4003, "Forbidden")
-      timer({ status: "forbidden" })
-      return
-    }
+    const auth = await authenticateAndAuthorize(ws, req, log, timer)
+    if (!auth) return
 
     // Step 3: Get voice settings and API key (cached 5-min TTL; changes take effect on new sessions)
     const [voiceSettings, googleApiKey] = await Promise.all([
@@ -492,7 +529,7 @@ export async function handleVoiceConnection(ws: WebSocket, req: IncomingMessage)
       return
     }
     // Non-null safe: validateVoiceConfig returned null, so provider is valid
-    providerRef.current = createVoiceProvider(voiceSettings.provider!)
+    session.providerRef.current = createVoiceProvider(voiceSettings.provider!)
 
     // Step 4: Register close/error handlers BEFORE provider.connect()
     ws.on("close", (code, reason) => { log.info("Voice WS closed", { code, reason: reason.toString() }); cleanup("success") })
@@ -504,7 +541,7 @@ export async function handleVoiceConnection(ws: WebSocket, req: IncomingMessage)
     const sessionConfig = await waitForSessionConfig(ws, log)
 
     // Abort if socket closed during wait — prevents leaking a provider connection with no client
-    if (sessionEnded || ws.readyState !== WS_OPEN) {
+    if (session.sessionEnded || ws.readyState !== WS_OPEN) {
       log.info("Socket closed during config wait")
       return
     }
@@ -527,7 +564,7 @@ export async function handleVoiceConnection(ws: WebSocket, req: IncomingMessage)
     const connectTimer = setTimeout(() => connectAbort.abort(), PROVIDER_CONNECT_TIMEOUT_MS)
 
     try {
-      await providerRef.current.connect(
+      await session.providerRef.current.connect(
         providerConfig,
         (event) => forwardProviderEvent(ws, event),
         connectAbort.signal,
@@ -538,7 +575,7 @@ export async function handleVoiceConnection(ws: WebSocket, req: IncomingMessage)
 
     // Step 7: Register message handler BEFORE signaling ready — prevents
     // dropping early audio frames if the client sends immediately after "ready".
-    registerMessageHandler(ws, providerRef, log)
+    registerMessageHandler(ws, session.providerRef, log)
 
     // Signal session is fully ready for audio
     sendToClient(ws, { type: "ready" })
@@ -553,10 +590,10 @@ export async function handleVoiceConnection(ws: WebSocket, req: IncomingMessage)
     // affects very short sessions or poor-connectivity scenarios. Acceptable
     // because the persistence is a best-effort fire-and-forget operation.
     if (sessionConfig?.conversationId && voiceSettings.model && voiceSettings.provider) {
-      transcriptContext = await resolveTranscriptContext(
+      session.transcriptContext = await resolveTranscriptContext(
         sessionConfig.conversationId, auth.sub, voiceSettings.model, voiceSettings.provider, log,
       )
-      if (transcriptContext) {
+      if (session.transcriptContext) {
         log.info("Transcript persistence enabled", {
           conversationId: sessionConfig.conversationId,
         })
@@ -564,7 +601,7 @@ export async function handleVoiceConnection(ws: WebSocket, req: IncomingMessage)
     }
 
     // Step 8: Keepalive ping — cleanup() handles clearInterval on close/error
-    pingInterval = setInterval(() => {
+    session.pingInterval = setInterval(() => {
       if (ws.readyState === WS_OPEN) ws.ping()
     }, PING_INTERVAL_MS)
   } catch (error) {

--- a/lib/voice/ws-handler.ts
+++ b/lib/voice/ws-handler.ts
@@ -26,6 +26,7 @@ import {
   PING_INTERVAL_MS,
   WS_OPEN,
   MAX_CONVERSATION_ID_LENGTH,
+  TRANSCRIPT_CONTEXT_TIMEOUT_MS,
 } from "./constants"
 import { buildInstructionFromConversation } from "./voice-instruction-builder"
 import { getUserIdByCognitoSubAsNumber } from "@/lib/db/drizzle/utils"
@@ -147,7 +148,8 @@ function isValidClientMessage(msg: unknown): msg is VoiceClientMessage {
 
 /**
  * Resolve the numeric userId from a Cognito sub and build the transcript context.
- * Non-fatal: returns null if userId cannot be resolved.
+ * Non-fatal: returns null if userId cannot be resolved or if the DB lookup
+ * exceeds TRANSCRIPT_CONTEXT_TIMEOUT_MS (prevents hanging cleanup on slow DB).
  *
  * Uses the canonical `getUserIdByCognitoSubAsNumber` utility (lib/db/drizzle/utils)
  * which handles string→number conversion and NaN validation internally.
@@ -159,8 +161,17 @@ async function resolveTranscriptContext(
   voiceProvider: string,
   logFn: ReturnType<typeof createLogger>,
 ): Promise<{ conversationId: string; userId: number; voiceModel: string; voiceProvider: string } | null> {
+  let timeoutHandle: ReturnType<typeof setTimeout> | undefined
   try {
-    const userId = await getUserIdByCognitoSubAsNumber(cognitoSub)
+    const userId = await Promise.race([
+      getUserIdByCognitoSubAsNumber(cognitoSub),
+      new Promise<never>((_, reject) => {
+        timeoutHandle = setTimeout(
+          () => reject(new Error("Transcript context resolution timed out")),
+          TRANSCRIPT_CONTEXT_TIMEOUT_MS,
+        )
+      }),
+    ])
     if (!userId) {
       logFn.warn("Could not resolve userId for transcript persistence")
       return null
@@ -175,6 +186,8 @@ async function resolveTranscriptContext(
     const msg = error instanceof Error ? error.message : String(error)
     logFn.warn("Failed to set up transcript persistence context", { error: msg })
     return null
+  } finally {
+    if (timeoutHandle) clearTimeout(timeoutHandle)
   }
 }
 
@@ -294,7 +307,12 @@ async function cleanupSession(
   }
 
   // If transcriptContext hasn't resolved yet (early disconnect), await the in-flight promise
-  // so we don't silently lose the transcript. This is bounded by the DB query timeout.
+  // so we don't silently lose the transcript. This is bounded by TRANSCRIPT_CONTEXT_TIMEOUT_MS.
+  //
+  // Double-await safety: handleVoiceConnection also awaits this same promise. Since JS
+  // promises settle exactly once, both awaits resolve to the same value. The sessionEnded
+  // flag (set synchronously above) prevents handleVoiceConnection from mutating state
+  // after cleanup has run — it checks sessionEnded before starting the ping interval.
   if (!state.transcriptContext && state.transcriptContextPromise) {
     try {
       state.transcriptContext = await state.transcriptContextPromise

--- a/lib/voice/ws-handler.ts
+++ b/lib/voice/ws-handler.ts
@@ -145,6 +145,82 @@ function isValidClientMessage(msg: unknown): msg is VoiceClientMessage {
   return true
 }
 
+/**
+ * Resolve the numeric userId from a Cognito sub and build the transcript context.
+ * Non-fatal: returns null if userId cannot be resolved.
+ */
+async function resolveTranscriptContext(
+  conversationId: string,
+  cognitoSub: string,
+  voiceModel: string,
+  logFn: ReturnType<typeof createLogger>,
+): Promise<{ conversationId: string; userId: number; voiceModel: string } | null> {
+  try {
+    const userIdStr = await getUserIdByCognitoSub(cognitoSub)
+    if (!userIdStr) {
+      logFn.warn("Could not resolve userId for transcript persistence")
+      return null
+    }
+    return {
+      conversationId,
+      userId: Number.parseInt(userIdStr, 10),
+      voiceModel,
+    }
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : String(error)
+    logFn.warn("Failed to set up transcript persistence context", { error: msg })
+    return null
+  }
+}
+
+/** Register the client message handler on the WebSocket. */
+function registerMessageHandler(
+  ws: WebSocket,
+  providerRef: { current: VoiceProvider | null },
+  logFn: ReturnType<typeof createLogger>,
+): void {
+  let lastAudioTime = 0
+  ws.on("message", (data) => {
+    try {
+      const parsed: unknown = JSON.parse(data.toString())
+      if (!isValidClientMessage(parsed)) {
+        logFn.warn("Invalid client message format")
+        return
+      }
+
+      switch (parsed.type) {
+        case "audio": {
+          if (!providerRef.current?.isConnected()) break
+          if (parsed.data.length > MAX_AUDIO_DATA_LENGTH) {
+            logFn.warn("Audio data too large", { length: parsed.data.length })
+            break
+          }
+          const now = Date.now()
+          if (now - lastAudioTime < MIN_AUDIO_INTERVAL_MS) break
+          lastAudioTime = now
+          providerRef.current.sendAudio(Buffer.from(parsed.data, "base64"))
+          break
+        }
+
+        case "session_config":
+          logFn.debug("Ignoring late session_config (provider already connected)")
+          break
+
+        case "disconnect": {
+          logFn.info("Client requested disconnect")
+          providerRef.current?.disconnect().catch((e: Error) =>
+            logFn.warn("Error during client-requested disconnect", { error: e.message })
+          )
+          break
+        }
+      }
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error)
+      logFn.error("Error processing client message", { error: errorMessage })
+    }
+  })
+}
+
 /** Forward a provider event to the client WebSocket. */
 function forwardProviderEvent(ws: WebSocket, event: VoiceProviderEvent): void {
   switch (event.type) {
@@ -303,7 +379,8 @@ export async function handleVoiceConnection(ws: WebSocket, req: IncomingMessage)
   const log = createLogger({ requestId, context: "voice-ws" })
   const timer = startTimer("voice-session")
 
-  let provider: VoiceProvider | null = null
+  /** Mutable ref so both cleanup() and registerMessageHandler() share the same provider pointer */
+  const providerRef: { current: VoiceProvider | null } = { current: null }
   let pingInterval: ReturnType<typeof setInterval> | null = null
   let sessionEnded = false
   /** Captured transcript for persistence — snapshot taken before provider.disconnect() clears it */
@@ -318,9 +395,9 @@ export async function handleVoiceConnection(ws: WebSocket, req: IncomingMessage)
     if (pingInterval) { clearInterval(pingInterval); pingInterval = null }
 
     // Capture transcript BEFORE disconnect clears it from provider memory
-    if (provider) {
+    if (providerRef.current) {
       try {
-        const state = provider.getSessionState()
+        const state = providerRef.current.getSessionState()
         if (state.transcript.length > 0) {
           capturedTranscript = state.transcript
         }
@@ -328,10 +405,10 @@ export async function handleVoiceConnection(ws: WebSocket, req: IncomingMessage)
         log.warn("Failed to capture transcript before disconnect")
       }
 
-      provider.disconnect().catch((e: Error) =>
+      providerRef.current.disconnect().catch((e: Error) =>
         log.warn("Provider disconnect failed during cleanup", { error: e.message })
       )
-      provider = null
+      providerRef.current = null
     }
 
     // Fire-and-forget transcript persistence — non-blocking, non-fatal
@@ -407,7 +484,7 @@ export async function handleVoiceConnection(ws: WebSocket, req: IncomingMessage)
       return
     }
     // Non-null safe: validateVoiceConfig returned null, so provider is valid
-    provider = createVoiceProvider(voiceSettings.provider!)
+    providerRef.current = createVoiceProvider(voiceSettings.provider!)
 
     // Step 4: Register close/error handlers BEFORE provider.connect()
     ws.on("close", (code, reason) => { log.info("Voice WS closed", { code, reason: reason.toString() }); cleanup("success") })
@@ -442,7 +519,7 @@ export async function handleVoiceConnection(ws: WebSocket, req: IncomingMessage)
     const connectTimer = setTimeout(() => connectAbort.abort(), PROVIDER_CONNECT_TIMEOUT_MS)
 
     try {
-      await provider.connect(
+      await providerRef.current.connect(
         providerConfig,
         (event) => forwardProviderEvent(ws, event),
         connectAbort.signal,
@@ -457,68 +534,18 @@ export async function handleVoiceConnection(ws: WebSocket, req: IncomingMessage)
 
     // Set up transcript persistence context (requires conversationId + resolved userId)
     if (sessionConfig?.conversationId) {
-      try {
-        const userIdStr = await getUserIdByCognitoSub(auth.sub)
-        if (userIdStr) {
-          transcriptContext = {
-            conversationId: sessionConfig.conversationId,
-            userId: Number.parseInt(userIdStr, 10),
-            voiceModel: voiceSettings.model!,
-          }
-          log.info("Transcript persistence enabled", {
-            conversationId: sessionConfig.conversationId,
-          })
-        } else {
-          log.warn("Could not resolve userId for transcript persistence")
-        }
-      } catch (error) {
-        const msg = error instanceof Error ? error.message : String(error)
-        log.warn("Failed to set up transcript persistence context", { error: msg })
+      transcriptContext = await resolveTranscriptContext(
+        sessionConfig.conversationId, auth.sub, voiceSettings.model!, log,
+      )
+      if (transcriptContext) {
+        log.info("Transcript persistence enabled", {
+          conversationId: sessionConfig.conversationId,
+        })
       }
     }
 
     // Step 7: Register message handler AFTER connect (clients must wait for second "ready")
-    let lastAudioTime = 0
-    ws.on("message", (data) => {
-      try {
-        const parsed: unknown = JSON.parse(data.toString())
-        if (!isValidClientMessage(parsed)) {
-          log.warn("Invalid client message format")
-          return
-        }
-
-        switch (parsed.type) {
-          case "audio": {
-            if (!provider?.isConnected()) break
-            // Validate base64 string length (aligned with WS_MAX_PAYLOAD via 4:3 ratio)
-            if (parsed.data.length > MAX_AUDIO_DATA_LENGTH) {
-              log.warn("Audio data too large", { length: parsed.data.length })
-              break
-            }
-            const now = Date.now()
-            if (now - lastAudioTime < MIN_AUDIO_INTERVAL_MS) break
-            lastAudioTime = now
-            provider.sendAudio(Buffer.from(parsed.data, "base64"))
-            break
-          }
-
-          case "session_config":
-            log.debug("Ignoring late session_config (provider already connected)")
-            break
-
-          case "disconnect": {
-            log.info("Client requested disconnect")
-            provider?.disconnect().catch((e: Error) =>
-              log.warn("Error during client-requested disconnect", { error: e.message })
-            )
-            break
-          }
-        }
-      } catch (error) {
-        const errorMessage = error instanceof Error ? error.message : String(error)
-        log.error("Error processing client message", { error: errorMessage })
-      }
-    })
+    registerMessageHandler(ws, providerRef, log)
 
     // Step 8: Keepalive ping — cleanup() handles clearInterval on close/error
     pingInterval = setInterval(() => {

--- a/lib/voice/ws-handler.ts
+++ b/lib/voice/ws-handler.ts
@@ -161,9 +161,14 @@ async function resolveTranscriptContext(
       logFn.warn("Could not resolve userId for transcript persistence")
       return null
     }
+    const userId = Number.parseInt(userIdStr, 10)
+    if (Number.isNaN(userId) || userId <= 0) {
+      logFn.warn("Resolved userId is not a valid positive integer", { rawValue: userIdStr })
+      return null
+    }
     return {
       conversationId,
-      userId: Number.parseInt(userIdStr, 10),
+      userId,
       voiceModel,
     }
   } catch (error) {
@@ -420,12 +425,14 @@ export async function handleVoiceConnection(ws: WebSocket, req: IncomingMessage)
       })
       saveVoiceTranscript(conversationId, userId, capturedTranscript, voiceModel)
         .then((result) => {
-          log.info("Voice transcript persisted", {
+          const logMethod = result.processingTimeMs > 5000 ? "warn" : "info"
+          log[logMethod]("Voice transcript persisted", {
             conversationId,
             messageCount: result.messageCount,
             filteredCount: result.filteredCount,
             titleGenerated: result.titleGenerated,
             processingTimeMs: result.processingTimeMs,
+            ...(result.processingTimeMs > 5000 ? { slow: true } : {}),
           })
         })
         .catch((error: Error) => {

--- a/lib/voice/ws-handler.ts
+++ b/lib/voice/ws-handler.ts
@@ -285,6 +285,14 @@ async function cleanupSession(
     state.providerRef.current = null
   }
 
+  // Early exit: if there's no transcript context (and no in-flight promise) and no captured
+  // transcript, there's nothing to save. Avoids unnecessary DB round-trips for sessions that
+  // closed during setup (auth failure, config timeout, etc.).
+  if (!state.transcriptContext && !state.transcriptContextPromise && state.capturedTranscript.length === 0) {
+    timer({ status })
+    return
+  }
+
   // If transcriptContext hasn't resolved yet (early disconnect), await the in-flight promise
   // so we don't silently lose the transcript. This is bounded by the DB query timeout.
   if (!state.transcriptContext && state.transcriptContextPromise) {
@@ -309,6 +317,7 @@ async function cleanupSession(
           messageCount: result.messageCount,
           filteredCount: result.filteredCount,
           titleGenerated: result.titleGenerated,
+          guardrailsBypassed: result.guardrailsBypassed,
           processingTimeMs: result.processingTimeMs,
         })
       })
@@ -634,6 +643,9 @@ export async function handleVoiceConnection(ws: WebSocket, req: IncomingMessage)
     // Guard against the session ending during the transcriptContextPromise await above:
     // if cleanup already ran, starting a new interval would leak because cleanup
     // already cleared pingInterval and won't run again (idempotent guard).
+    // NOTE: This guard and the double-await race in cleanupSession are tested
+    // indirectly via the ws-handler integration tests (26 tests). The sessionEnded
+    // check prevents interval leak — see issue #875 for E2E coverage tracking.
     if (session.sessionEnded) {
       log.info("Session ended during context resolution, skipping ping setup")
       return

--- a/lib/voice/ws-handler.ts
+++ b/lib/voice/ws-handler.ts
@@ -547,8 +547,20 @@ export async function handleVoiceConnection(ws: WebSocket, req: IncomingMessage)
     session.providerRef.current = createVoiceProvider(voiceSettings.provider!)
 
     // Step 4: Register close/error handlers BEFORE provider.connect()
-    ws.on("close", (code, reason) => { log.info("Voice WS closed", { code, reason: reason.toString() }); cleanup("success") })
-    ws.on("error", (error) => { log.error("Voice WS error", { error: error.message }); cleanup("error") })
+    // cleanup() is async — attach .catch() to prevent unhandled rejections
+    // from unexpected throws inside cleanupSession.
+    ws.on("close", (code, reason) => {
+      log.info("Voice WS closed", { code, reason: reason.toString() })
+      cleanup("success").catch((e: Error) =>
+        log.error("Unexpected cleanup failure on close", { error: e.message })
+      )
+    })
+    ws.on("error", (error) => {
+      log.error("Voice WS error", { error: error.message })
+      cleanup("error").catch((e: Error) =>
+        log.error("Unexpected cleanup failure on error", { error: e.message })
+      )
+    })
 
     // Step 5a: Signal auth OK and wait for client session_config (conversationId only)
     sendToClient(ws, { type: "ready" })
@@ -600,9 +612,12 @@ export async function handleVoiceConnection(ws: WebSocket, req: IncomingMessage)
     // The message handler is already registered above, so no audio frames are lost
     // during this async DB lookup.
     //
-    // The promise is stored on session state so cleanupSession can await it if the
-    // client disconnects before resolution completes — preventing silent transcript loss
-    // on very short sessions or poor-connectivity scenarios.
+    // The promise is stored on session state separately from the awaited result
+    // because cleanupSession needs it as a fallback: if the client disconnects
+    // during THIS await, cleanup fires (setting sessionEnded=true and clearing
+    // the ping interval), then awaits transcriptContextPromise to capture the
+    // in-flight result. Without storing the promise, early disconnects would
+    // silently lose the transcript context.
     if (sessionConfig?.conversationId && voiceSettings.model && voiceSettings.provider) {
       session.transcriptContextPromise = resolveTranscriptContext(
         sessionConfig.conversationId, auth.sub, voiceSettings.model, voiceSettings.provider, log,
@@ -615,7 +630,14 @@ export async function handleVoiceConnection(ws: WebSocket, req: IncomingMessage)
       }
     }
 
-    // Step 8: Keepalive ping — cleanup() handles clearInterval on close/error
+    // Step 8: Keepalive ping — cleanup() handles clearInterval on close/error.
+    // Guard against the session ending during the transcriptContextPromise await above:
+    // if cleanup already ran, starting a new interval would leak because cleanup
+    // already cleared pingInterval and won't run again (idempotent guard).
+    if (session.sessionEnded) {
+      log.info("Session ended during context resolution, skipping ping setup")
+      return
+    }
     session.pingInterval = setInterval(() => {
       if (ws.readyState === WS_OPEN) ws.ping()
     }, PING_INTERVAL_MS)

--- a/lib/voice/ws-handler.ts
+++ b/lib/voice/ws-handler.ts
@@ -28,12 +28,15 @@ import {
   MAX_CONVERSATION_ID_LENGTH,
 } from "./constants"
 import { buildInstructionFromConversation } from "./voice-instruction-builder"
+import { getUserIdByCognitoSub } from "@/lib/db/drizzle/users"
+import { saveVoiceTranscript } from "./transcript-service"
 import type {
   VoiceProvider,
   VoiceProviderConfig,
   VoiceClientMessage,
   VoiceServerMessage,
   VoiceProviderEvent,
+  TranscriptEntry,
 } from "./types"
 
 /**
@@ -303,18 +306,59 @@ export async function handleVoiceConnection(ws: WebSocket, req: IncomingMessage)
   let provider: VoiceProvider | null = null
   let pingInterval: ReturnType<typeof setInterval> | null = null
   let sessionEnded = false
+  /** Captured transcript for persistence — snapshot taken before provider.disconnect() clears it */
+  let capturedTranscript: TranscriptEntry[] = []
+  /** Session context for transcript persistence — set after auth + config */
+  let transcriptContext: { conversationId: string; userId: number; voiceModel: string } | null = null
 
   /** Idempotent cleanup — synchronous to avoid swallowed errors in event handlers */
   function cleanup(status: string) {
     if (sessionEnded) return
     sessionEnded = true
     if (pingInterval) { clearInterval(pingInterval); pingInterval = null }
+
+    // Capture transcript BEFORE disconnect clears it from provider memory
     if (provider) {
+      try {
+        const state = provider.getSessionState()
+        if (state.transcript.length > 0) {
+          capturedTranscript = state.transcript
+        }
+      } catch {
+        log.warn("Failed to capture transcript before disconnect")
+      }
+
       provider.disconnect().catch((e: Error) =>
         log.warn("Provider disconnect failed during cleanup", { error: e.message })
       )
       provider = null
     }
+
+    // Fire-and-forget transcript persistence — non-blocking, non-fatal
+    if (transcriptContext && capturedTranscript.length > 0) {
+      const { conversationId, userId, voiceModel } = transcriptContext
+      log.info("Persisting voice transcript", {
+        conversationId,
+        entryCount: capturedTranscript.length,
+      })
+      saveVoiceTranscript(conversationId, userId, capturedTranscript, voiceModel)
+        .then((result) => {
+          log.info("Voice transcript persisted", {
+            conversationId,
+            messageCount: result.messageCount,
+            filteredCount: result.filteredCount,
+            titleGenerated: result.titleGenerated,
+            processingTimeMs: result.processingTimeMs,
+          })
+        })
+        .catch((error: Error) => {
+          log.error("Failed to persist voice transcript", {
+            conversationId,
+            error: error.message,
+          })
+        })
+    }
+
     timer({ status })
   }
 
@@ -410,6 +454,28 @@ export async function handleVoiceConnection(ws: WebSocket, req: IncomingMessage)
     // Signal session is fully ready for audio
     sendToClient(ws, { type: "ready" })
     log.info("Voice session ready")
+
+    // Set up transcript persistence context (requires conversationId + resolved userId)
+    if (sessionConfig?.conversationId) {
+      try {
+        const userIdStr = await getUserIdByCognitoSub(auth.sub)
+        if (userIdStr) {
+          transcriptContext = {
+            conversationId: sessionConfig.conversationId,
+            userId: Number.parseInt(userIdStr, 10),
+            voiceModel: voiceSettings.model!,
+          }
+          log.info("Transcript persistence enabled", {
+            conversationId: sessionConfig.conversationId,
+          })
+        } else {
+          log.warn("Could not resolve userId for transcript persistence")
+        }
+      } catch (error) {
+        const msg = error instanceof Error ? error.message : String(error)
+        log.warn("Failed to set up transcript persistence context", { error: msg })
+      }
+    }
 
     // Step 7: Register message handler AFTER connect (clients must wait for second "ready")
     let lastAudioTime = 0

--- a/lib/voice/ws-handler.ts
+++ b/lib/voice/ws-handler.ts
@@ -228,11 +228,14 @@ function registerMessageHandler(
 
 /** Mutable session state shared between handleVoiceConnection and its helpers. */
 interface VoiceSessionState {
+  /** Ref-wrapper so registerMessageHandler can read the provider after it's assigned post-connect */
   providerRef: { current: VoiceProvider | null }
   pingInterval: ReturnType<typeof setInterval> | null
   sessionEnded: boolean
   capturedTranscript: TranscriptEntry[]
   transcriptContext: { conversationId: string; userId: number; voiceModel: string; voiceProvider: string } | null
+  /** In-flight promise from resolveTranscriptContext — awaited by cleanup so early disconnects don't lose transcripts */
+  transcriptContextPromise: Promise<{ conversationId: string; userId: number; voiceModel: string; voiceProvider: string } | null> | null
 }
 
 /** Create a fresh session state object. */
@@ -243,19 +246,23 @@ function createSessionState(): VoiceSessionState {
     sessionEnded: false,
     capturedTranscript: [],
     transcriptContext: null,
+    transcriptContextPromise: null,
   }
 }
 
 /**
  * Idempotent session cleanup. Captures transcript, disconnects provider,
  * fires async persistence, and records timing.
+ *
+ * Awaits transcriptContextPromise if the context resolution is still in-flight,
+ * ensuring transcripts are not silently lost on early client disconnects.
  */
-function cleanupSession(
+async function cleanupSession(
   state: VoiceSessionState,
   status: string,
   logFn: ReturnType<typeof createLogger>,
   timer: ReturnType<typeof startTimer>,
-): void {
+): Promise<void> {
   if (state.sessionEnded) return
   state.sessionEnded = true
   if (state.pingInterval) { clearInterval(state.pingInterval); state.pingInterval = null }
@@ -278,6 +285,16 @@ function cleanupSession(
     state.providerRef.current = null
   }
 
+  // If transcriptContext hasn't resolved yet (early disconnect), await the in-flight promise
+  // so we don't silently lose the transcript. This is bounded by the DB query timeout.
+  if (!state.transcriptContext && state.transcriptContextPromise) {
+    try {
+      state.transcriptContext = await state.transcriptContextPromise
+    } catch {
+      logFn.warn("Transcript context resolution failed during cleanup")
+    }
+  }
+
   // Fire-and-forget transcript persistence — non-blocking, non-fatal
   if (state.transcriptContext && state.capturedTranscript.length > 0) {
     const { conversationId, userId, voiceModel, voiceProvider } = state.transcriptContext
@@ -287,14 +304,12 @@ function cleanupSession(
     })
     saveVoiceTranscript(conversationId, userId, state.capturedTranscript, voiceModel, voiceProvider)
       .then((result) => {
-        const logMethod = result.processingTimeMs > 5000 ? "warn" : "info"
-        logFn[logMethod]("Voice transcript persisted", {
+        logFn.info("Voice transcript persisted", {
           conversationId,
           messageCount: result.messageCount,
           filteredCount: result.filteredCount,
           titleGenerated: result.titleGenerated,
           processingTimeMs: result.processingTimeMs,
-          ...(result.processingTimeMs > 5000 ? { slow: true } : {}),
         })
       })
       .catch((error: Error) => {
@@ -585,14 +600,14 @@ export async function handleVoiceConnection(ws: WebSocket, req: IncomingMessage)
     // The message handler is already registered above, so no audio frames are lost
     // during this async DB lookup.
     //
-    // Known limitation: if the client disconnects before this await completes,
-    // transcriptContext remains null and the transcript is not persisted. This
-    // affects very short sessions or poor-connectivity scenarios. Acceptable
-    // because the persistence is a best-effort fire-and-forget operation.
+    // The promise is stored on session state so cleanupSession can await it if the
+    // client disconnects before resolution completes — preventing silent transcript loss
+    // on very short sessions or poor-connectivity scenarios.
     if (sessionConfig?.conversationId && voiceSettings.model && voiceSettings.provider) {
-      session.transcriptContext = await resolveTranscriptContext(
+      session.transcriptContextPromise = resolveTranscriptContext(
         sessionConfig.conversationId, auth.sub, voiceSettings.model, voiceSettings.provider, log,
       )
+      session.transcriptContext = await session.transcriptContextPromise
       if (session.transcriptContext) {
         log.info("Transcript persistence enabled", {
           conversationId: sessionConfig.conversationId,

--- a/lib/voice/ws-handler.ts
+++ b/lib/voice/ws-handler.ts
@@ -28,7 +28,7 @@ import {
   MAX_CONVERSATION_ID_LENGTH,
 } from "./constants"
 import { buildInstructionFromConversation } from "./voice-instruction-builder"
-import { getUserIdByCognitoSub } from "@/lib/db/drizzle/users"
+import { getUserIdByCognitoSubAsNumber } from "@/lib/db/drizzle/utils"
 import { saveVoiceTranscript } from "./transcript-service"
 import type {
   VoiceProvider,
@@ -148,28 +148,28 @@ function isValidClientMessage(msg: unknown): msg is VoiceClientMessage {
 /**
  * Resolve the numeric userId from a Cognito sub and build the transcript context.
  * Non-fatal: returns null if userId cannot be resolved.
+ *
+ * Uses the canonical `getUserIdByCognitoSubAsNumber` utility (lib/db/drizzle/utils)
+ * which handles string→number conversion and NaN validation internally.
  */
 async function resolveTranscriptContext(
   conversationId: string,
   cognitoSub: string,
   voiceModel: string,
+  voiceProvider: string,
   logFn: ReturnType<typeof createLogger>,
-): Promise<{ conversationId: string; userId: number; voiceModel: string } | null> {
+): Promise<{ conversationId: string; userId: number; voiceModel: string; voiceProvider: string } | null> {
   try {
-    const userIdStr = await getUserIdByCognitoSub(cognitoSub)
-    if (!userIdStr) {
+    const userId = await getUserIdByCognitoSubAsNumber(cognitoSub)
+    if (!userId) {
       logFn.warn("Could not resolve userId for transcript persistence")
-      return null
-    }
-    const userId = Number.parseInt(userIdStr, 10)
-    if (Number.isNaN(userId) || userId <= 0) {
-      logFn.warn("Resolved userId is not a valid positive integer", { rawValue: userIdStr })
       return null
     }
     return {
       conversationId,
       userId,
       voiceModel,
+      voiceProvider,
     }
   } catch (error) {
     const msg = error instanceof Error ? error.message : String(error)
@@ -391,7 +391,7 @@ export async function handleVoiceConnection(ws: WebSocket, req: IncomingMessage)
   /** Captured transcript for persistence — snapshot taken before provider.disconnect() clears it */
   let capturedTranscript: TranscriptEntry[] = []
   /** Session context for transcript persistence — set after auth + config */
-  let transcriptContext: { conversationId: string; userId: number; voiceModel: string } | null = null
+  let transcriptContext: { conversationId: string; userId: number; voiceModel: string; voiceProvider: string } | null = null
 
   /** Idempotent cleanup — synchronous to avoid swallowed errors in event handlers */
   function cleanup(status: string) {
@@ -399,12 +399,13 @@ export async function handleVoiceConnection(ws: WebSocket, req: IncomingMessage)
     sessionEnded = true
     if (pingInterval) { clearInterval(pingInterval); pingInterval = null }
 
-    // Capture transcript BEFORE disconnect clears it from provider memory
+    // Capture transcript BEFORE disconnect clears it from provider memory.
+    // Shallow copy the array — disconnect() may mutate/clear the original.
     if (providerRef.current) {
       try {
         const state = providerRef.current.getSessionState()
         if (state.transcript.length > 0) {
-          capturedTranscript = state.transcript
+          capturedTranscript = [...state.transcript]
         }
       } catch {
         log.warn("Failed to capture transcript before disconnect")
@@ -418,12 +419,12 @@ export async function handleVoiceConnection(ws: WebSocket, req: IncomingMessage)
 
     // Fire-and-forget transcript persistence — non-blocking, non-fatal
     if (transcriptContext && capturedTranscript.length > 0) {
-      const { conversationId, userId, voiceModel } = transcriptContext
+      const { conversationId, userId, voiceModel, voiceProvider } = transcriptContext
       log.info("Persisting voice transcript", {
         conversationId,
         entryCount: capturedTranscript.length,
       })
-      saveVoiceTranscript(conversationId, userId, capturedTranscript, voiceModel)
+      saveVoiceTranscript(conversationId, userId, capturedTranscript, voiceModel, voiceProvider)
         .then((result) => {
           const logMethod = result.processingTimeMs > 5000 ? "warn" : "info"
           log[logMethod]("Voice transcript persisted", {
@@ -535,14 +536,20 @@ export async function handleVoiceConnection(ws: WebSocket, req: IncomingMessage)
       clearTimeout(connectTimer)
     }
 
+    // Step 7: Register message handler BEFORE signaling ready — prevents
+    // dropping early audio frames if the client sends immediately after "ready".
+    registerMessageHandler(ws, providerRef, log)
+
     // Signal session is fully ready for audio
     sendToClient(ws, { type: "ready" })
     log.info("Voice session ready")
 
-    // Set up transcript persistence context (requires conversationId + resolved userId)
-    if (sessionConfig?.conversationId) {
+    // Set up transcript persistence context in the background (non-blocking).
+    // The message handler is already registered above, so no audio frames are lost
+    // during this async DB lookup.
+    if (sessionConfig?.conversationId && voiceSettings.model && voiceSettings.provider) {
       transcriptContext = await resolveTranscriptContext(
-        sessionConfig.conversationId, auth.sub, voiceSettings.model!, log,
+        sessionConfig.conversationId, auth.sub, voiceSettings.model, voiceSettings.provider, log,
       )
       if (transcriptContext) {
         log.info("Transcript persistence enabled", {
@@ -550,9 +557,6 @@ export async function handleVoiceConnection(ws: WebSocket, req: IncomingMessage)
         })
       }
     }
-
-    // Step 7: Register message handler AFTER connect (clients must wait for second "ready")
-    registerMessageHandler(ws, providerRef, log)
 
     // Step 8: Keepalive ping — cleanup() handles clearInterval on close/error
     pingInterval = setInterval(() => {

--- a/lib/voice/ws-handler.ts
+++ b/lib/voice/ws-handler.ts
@@ -547,6 +547,11 @@ export async function handleVoiceConnection(ws: WebSocket, req: IncomingMessage)
     // Set up transcript persistence context in the background (non-blocking).
     // The message handler is already registered above, so no audio frames are lost
     // during this async DB lookup.
+    //
+    // Known limitation: if the client disconnects before this await completes,
+    // transcriptContext remains null and the transcript is not persisted. This
+    // affects very short sessions or poor-connectivity scenarios. Acceptable
+    // because the persistence is a best-effort fire-and-forget operation.
     if (sessionConfig?.conversationId && voiceSettings.model && voiceSettings.provider) {
       transcriptContext = await resolveTranscriptContext(
         sessionConfig.conversationId, auth.sub, voiceSettings.model, voiceSettings.provider, log,


### PR DESCRIPTION
## Summary

Implements voice transcript persistence (Issue #875, part 4 of the Nexus Voice Mode epic). When a voice session ends, the full transcript is converted to standard Nexus messages, run through Bedrock content safety guardrails, and saved atomically to the database.

- **Transcript Service** (`lib/voice/transcript-service.ts`): Prepares entries (filter non-final, merge consecutive same-role), applies guardrails per-entry with graceful degradation, saves all messages + conversation metadata in a single transaction
- **WS Handler Integration**: Captures transcript from provider state before disconnect, resolves userId, triggers async save during cleanup (non-blocking, non-fatal)
- **Guardrails**: Blocked content replaced with "[Content filtered by safety policy]" — entries are never silently dropped. User entries checked via `checkInputSafety`, assistant entries via `checkOutputSafety`
- **Title Generation**: Auto-generates from first (non-filtered) user message for new conversations

## Changes
- `lib/voice/transcript-service.ts` — New: core persistence service
- `lib/voice/__tests__/transcript-service.test.ts` — New: 19 unit tests
- `lib/voice/ws-handler.ts` — Modified: integrated transcript save into session lifecycle
- `lib/voice/index.ts` — Modified: added exports

## Test Plan
- [x] 19 unit tests pass (entry preparation, guardrail integration, title generation, error handling, graceful degradation)
- [x] `bun run typecheck` passes (zero errors)
- [x] `bun run lint` passes (zero errors, existing warnings only)
- [ ] Manual testing: complete voice session → verify messages appear in conversation
- [ ] Manual testing: verify text continuation after voice transcript save
- [ ] Manual testing: verify guardrail filtering with test content

Closes #875