### PR TITLE
feat(agent-router): replace @agent:username with /ask slash commands

### DIFF
--- a/infra/lambdas/agent-router/index.ts
+++ b/infra/lambdas/agent-router/index.ts
@@ -228,26 +228,12 @@ interface GoogleChatEvent {
     };
     /**
      * Populated when the user invokes a registered slash command (e.g., /ask).
-     * Contains only the commandId. The full metadata (commandName, triggersDialog)
-     * lives in message.annotations[].slashCommand.
+     * Contains only the commandId — the command name is mapped locally via
+     * SLASH_COMMAND_NAMES for usage help text.
      */
     slashCommand?: {
       commandId: string;
     };
-    /**
-     * Annotations on the message, including SLASH_COMMAND entries. Used to
-     * identify which slash command was invoked when multiple are registered.
-     */
-    annotations?: Array<{
-      type: 'SLASH_COMMAND' | 'USER_MENTION' | 'RICH_LINK';
-      startIndex?: number;
-      length?: number;
-      slashCommand?: {
-        commandName: string;
-        commandId: string;
-        triggersDialog?: boolean;
-      };
-    }>;
     createTime: string;
   };
 }
@@ -349,6 +335,8 @@ interface CrossUserInvocation {
   strippedMessage: string;
   /** Which invocation method was used — drives deprecation notices */
   source: 'slash-command' | 'text-prefix';
+  /** The slash command name that was invoked (e.g., "/ask", "/consult"). Only set for slash-command source. */
+  commandName?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -356,19 +344,22 @@ interface CrossUserInvocation {
 // ---------------------------------------------------------------------------
 
 /**
- * Registered slash command IDs from Google Chat API configuration.
- * These must match the command IDs configured in the Google Cloud Console
- * under Chat API → Configuration → Slash commands.
+ * Recognized slash command IDs for cross-user invocation. These must match
+ * the command IDs configured in the Google Cloud Console under
+ * Chat API -> Configuration -> Slash commands.
  *
  * Command registration (manual in Cloud Console):
- *   /ask     → commandId "1"  → "Ask another PSD staff member's agent a question"
- *   /consult → commandId "2"  → "Consult another PSD staff member's agent"
+ *   /ask     -> commandId "1"  -> "Ask another PSD staff member's agent a question"
+ *   /consult -> commandId "2"  -> "Consult another PSD staff member's agent"
  *
  * Both commands behave identically — /consult is a synonym for /ask.
  */
-const SLASH_COMMAND_IDS: Record<string, 'ask'> = {
-  '1': 'ask',
-  '2': 'ask', // /consult is a synonym
+const CROSS_USER_SLASH_COMMAND_IDS = new Set(['1', '2']);
+
+/** Maps commandId to the human-readable command name for usage help text. */
+const SLASH_COMMAND_NAMES: Record<string, string> = {
+  '1': '/ask',
+  '2': '/consult',
 };
 
 // ---------------------------------------------------------------------------
@@ -590,8 +581,8 @@ async function getOrCreateUser(
 /**
  * Validate that a string is a plausible email local part (username).
  * Allows alphanumeric characters, dots, hyphens, and underscores.
- * Must start and end with alphanumeric, minimum 2 chars to reject edge cases
- * like "." or "---" which are not valid email local parts.
+ * Must start and end with alphanumeric (single-char usernames like "a" are
+ * accepted; punctuation-only inputs like "." or "---" are rejected).
  *
  * Shared between parseCrossUserInvocation() and parseSlashCommandInvocation()
  * to ensure consistent input validation regardless of invocation method.
@@ -616,8 +607,8 @@ function isValidUsername(value: string): boolean {
 function parseCrossUserInvocation(text: string): CrossUserInvocation | null {
   // Trim leading whitespace — Google Chat formatting may add spaces.
   // Match @agent: followed by a username (alphanumeric, dots, hyphens, underscores).
-  // Must start and end with alphanumeric, minimum 2 chars to reject edge cases
-  // like @agent:. or @agent:--- which are not valid email local parts.
+  // Must start and end with alphanumeric; rejects punctuation-only inputs like
+  // @agent:. or @agent:--- which are not valid email local parts.
   const match = text.trim().match(/^@agent:([a-zA-Z0-9](?:[a-zA-Z0-9._-]*[a-zA-Z0-9])?)\s*([\s\S]*)/);
   if (!match) return null;
 
@@ -638,45 +629,54 @@ function parseCrossUserInvocation(text: string): CrossUserInvocation | null {
  *
  * The first token of argumentText is the target username; the remainder is the
  * question. Returns null if the message doesn't contain a recognized slash command.
+ *
+ * Fallback: if `argumentText` is absent (older API versions / edge cases),
+ * derives arguments from `message.text` by stripping the leading slash command
+ * token (e.g., "/ask reese question" -> "reese question").
  */
 function parseSlashCommandInvocation(
   message: NonNullable<GoogleChatEvent['message']>,
 ): CrossUserInvocation | null {
   const commandId = message.slashCommand?.commandId;
-  if (!commandId || !SLASH_COMMAND_IDS[commandId]) {
+  if (!commandId || !CROSS_USER_SLASH_COMMAND_IDS.has(commandId)) {
     return null;
   }
 
+  const cmdName = SLASH_COMMAND_NAMES[commandId] ?? '/ask';
+
   // argumentText contains everything after the slash command itself.
-  // For "/ask reese what's up?" → argumentText = "reese what's up?"
+  // For "/ask reese what's up?" -> argumentText = "reese what's up?"
   // Google Chat strips bot @mentions from argumentText, so we don't need
   // to worry about mention chips polluting the parse.
-  const argText = (message.argumentText ?? '').trim();
+  //
+  // Fallback: when argumentText is absent (older API versions or edge cases
+  // where only message.text is populated), derive arguments from message.text
+  // by stripping the leading slash command token.
+  let argText = (message.argumentText ?? '').trim();
+  if (!argText && message.text) {
+    // message.text includes the slash command: "/ask reese question"
+    // Strip the first whitespace-delimited token (the command itself).
+    const textTrimmed = message.text.trim();
+    const firstSpace = textTrimmed.search(/\s/);
+    argText = firstSpace === -1 ? '' : textTrimmed.substring(firstSpace).trim();
+  }
+
   if (!argText) {
     // No arguments — caller should prompt with usage help or a dialog
     return {
       targetUsername: '',
       strippedMessage: '',
       source: 'slash-command',
+      commandName: cmdName,
     };
   }
 
-  // First token = target username, remainder = question
-  const spaceIdx = argText.search(/\s/);
-  if (spaceIdx === -1) {
-    // Only a username, no question — validate before accepting
-    if (!isValidUsername(argText)) {
-      return null; // Invalid username format; caller treats as non-slash-command
-    }
-    return {
-      targetUsername: argText.toLowerCase(),
-      strippedMessage: '',
-      source: 'slash-command',
-    };
-  }
-
-  const username = argText.substring(0, spaceIdx);
-  const question = argText.substring(spaceIdx).trim();
+  // Split on whitespace: first token = target username, remainder = question.
+  // Using split(/\s+/) handles multiple spaces between username and question
+  // without leaving residual whitespace in the question text.
+  const parts = argText.split(/\s+/);
+  const username = parts[0];
+  const question = parts.slice(1).join(' ');
 
   // Validate the extracted username against the same rules used by the
   // @agent:username parser — prevents arbitrary input reaching DynamoDB queries.
@@ -688,6 +688,7 @@ function parseSlashCommandInvocation(
     targetUsername: username.toLowerCase(),
     strippedMessage: question,
     source: 'slash-command',
+    commandName: cmdName,
   };
 }
 
@@ -1456,9 +1457,18 @@ async function processRecord(
   const rawText = (message?.argumentText ?? message?.text ?? '').trim();
   // Slash commands with no arguments (e.g., bare "/ask") have empty argumentText
   // but are still valid — the handler will show usage help. Only bail on truly
-  // empty messages when there's no slash command present.
-  const hasSlashCommand = !!message?.slashCommand?.commandId;
-  if (!message || (!rawText && !hasSlashCommand) || !message.sender) {
+  // empty messages when there's no recognized slash command present.
+  //
+  // Unrecognized slash commands (commandId not in CROSS_USER_SLASH_COMMAND_IDS)
+  // are rejected early to prevent them from falling through to the normal
+  // AgentCore path with an empty prompt.
+  const slashCommandId = message?.slashCommand?.commandId;
+  const hasRecognizedSlashCommand = !!slashCommandId && CROSS_USER_SLASH_COMMAND_IDS.has(slashCommandId);
+  if (slashCommandId && !hasRecognizedSlashCommand) {
+    log.warn('Ignoring unrecognized slash command', { commandId: slashCommandId });
+    return;
+  }
+  if (!message || (!rawText && !hasRecognizedSlashCommand) || !message.sender) {
     log.warn('Message event missing required fields');
     return;
   }
@@ -1676,23 +1686,30 @@ async function processRecord(
   const crossUserInvocation = slashInvocation ?? textInvocation;
 
   if (crossUserInvocation) {
-    log.info('Cross-user invocation detected', {
-      sender: senderEmail,
-      targetUsername: crossUserInvocation.targetUsername,
-      source: crossUserInvocation.source,
-      space: spaceName,
-    });
+    // The command name used in the invocation ("/ask", "/consult", or "@agent:").
+    // Used to generate context-appropriate usage help text.
+    const cmdLabel = crossUserInvocation.commandName ?? '/ask';
 
     // Handle empty invocation — user typed just "/ask" with no arguments.
     // Respond with usage help. A future Phase 2 enhancement could open a
     // dialog card with a dropdown of agent owners (issue #907 open question).
     if (!crossUserInvocation.targetUsername) {
       const usageHelp = crossUserInvocation.source === 'slash-command'
-        ? 'Usage: `/ask <username> <question>`\n\nExample: `/ask reese what\'s on the calendar for today?`'
+        ? `Usage: \`${cmdLabel} <username> <question>\`\n\nExample: \`${cmdLabel} reese what's on the calendar for today?\``
         : 'Usage: `@agent:<username> <question>`\n\nExample: `@agent:reese what\'s on the calendar for today?`';
       await sendGoogleChatResponse(spaceName, threadName, usageHelp, log);
       return;
     }
+
+    // Log after the empty-username fast path but with a validated username
+    // (isValidUsername already ran inside the parser; only validated usernames
+    // reach here). Avoids logging arbitrary raw input at INFO level.
+    log.info('Cross-user invocation detected', {
+      sender: senderEmail,
+      targetUsername: crossUserInvocation.targetUsername,
+      source: crossUserInvocation.source,
+      space: spaceName,
+    });
 
     // Resolve the target user
     const targetUser = await resolveUserByEmailPrefix(
@@ -1723,7 +1740,7 @@ async function processRecord(
       // sending an empty string to AgentCore.
       if (!crossUserInvocation.strippedMessage) {
         const selfHelp = crossUserInvocation.source === 'slash-command'
-          ? 'You can talk to your own agent by sending a message directly — no need for `/ask`.'
+          ? `You can talk to your own agent by sending a message directly -- no need for \`${cmdLabel}\`.`
           : 'Please include a message. You can talk to your agent normally without the @agent: prefix.';
         await sendGoogleChatResponse(spaceName, threadName, selfHelp, log);
         return;
@@ -1734,7 +1751,7 @@ async function processRecord(
       const actualMessage = crossUserInvocation.strippedMessage;
       if (!actualMessage) {
         const emptyHelp = crossUserInvocation.source === 'slash-command'
-          ? `Please include a question. Example: \`/ask ${crossUserInvocation.targetUsername} what's the budget status?\``
+          ? `Please include a question. Example: \`${cmdLabel} ${crossUserInvocation.targetUsername} what's the budget status?\``
           : `Please include a question after @agent:${crossUserInvocation.targetUsername}. ` +
             `Example: @agent:${crossUserInvocation.targetUsername} what's the budget status?`;
         await sendGoogleChatResponse(spaceName, threadName, emptyHelp, log);
@@ -1788,14 +1805,15 @@ async function processRecord(
         });
       }
 
-      // Response — always prefixed with the target user's name in shared spaces.
+      // Response — cross-user replies are always prefixed with the target user's
+      // agent label (in both shared spaces and DMs via slash commands).
       // When invoked via the deprecated @agent: prefix, append a deprecation
       // notice nudging users toward the /ask slash command (issue #907).
       const deprecationNotice = crossUserInvocation.source === 'text-prefix'
-        ? `\n\n_💡 Tip: \`/ask ${crossUserInvocation.targetUsername} …\` works too (and is faster)_`
+        ? `\n\n_Tip: \`/ask ${crossUserInvocation.targetUsername} ...\` works too (and is faster)_`
         : '';
       const maxLength = 4096;
-      const truncationSuffix = '\n\n_(Response truncated — ask me to continue)_';
+      const truncationSuffix = '\n\n_(Response truncated -- ask me to continue)_';
       const ownerLabel = targetUser.displayName || targetUser.email;
       const crossPrefix = `[${ownerLabel}'s Agent] `;
       const reservedLength = crossPrefix.length + deprecationNotice.length;
@@ -1803,6 +1821,13 @@ async function processRecord(
       // the prefix + deprecation notice are unusually long (e.g., very long
       // display name). In that edge case the response body is fully truncated.
       const availableLength = Math.max(maxLength - reservedLength, 0);
+      if (availableLength === 0) {
+        log.warn('Cross-user response body fully truncated due to long prefix/notice', {
+          reservedLength,
+          maxLength,
+          ownerLabel,
+        });
+      }
       const truncatedResponse =
         agentResult.response.length > availableLength
           ? agentResult.response.substring(0, Math.max(availableLength - truncationSuffix.length, 0)) +

--- a/infra/lambdas/agent-router/index.ts
+++ b/infra/lambdas/agent-router/index.ts
@@ -226,6 +226,28 @@ interface GoogleChatEvent {
     thread?: {
       name: string;
     };
+    /**
+     * Populated when the user invokes a registered slash command (e.g., /ask).
+     * Contains only the commandId. The full metadata (commandName, triggersDialog)
+     * lives in message.annotations[].slashCommand.
+     */
+    slashCommand?: {
+      commandId: string;
+    };
+    /**
+     * Annotations on the message, including SLASH_COMMAND entries. Used to
+     * identify which slash command was invoked when multiple are registered.
+     */
+    annotations?: Array<{
+      type: 'SLASH_COMMAND' | 'USER_MENTION' | 'RICH_LINK';
+      startIndex?: number;
+      length?: number;
+      slashCommand?: {
+        commandName: string;
+        commandId: string;
+        triggersDialog?: boolean;
+      };
+    }>;
     createTime: string;
   };
 }
@@ -317,15 +339,37 @@ interface AgentUser {
 }
 
 /**
- * Result of parsing an @agent:username invocation from the message text.
- * Returns null if no cross-user invocation is detected.
+ * Result of parsing a cross-user invocation — either from @agent:username
+ * (deprecated text prefix) or from a /ask slash command.
  */
 interface CrossUserInvocation {
-  /** The username portion from @agent:username (email local part) */
+  /** The username portion (email local part) of the target agent owner */
   targetUsername: string;
-  /** The message text with the @agent:username prefix stripped */
+  /** The message text with the invocation syntax stripped */
   strippedMessage: string;
+  /** Which invocation method was used — drives deprecation notices */
+  source: 'slash-command' | 'text-prefix';
 }
+
+// ---------------------------------------------------------------------------
+// Slash command configuration
+// ---------------------------------------------------------------------------
+
+/**
+ * Registered slash command IDs from Google Chat API configuration.
+ * These must match the command IDs configured in the Google Cloud Console
+ * under Chat API → Configuration → Slash commands.
+ *
+ * Command registration (manual in Cloud Console):
+ *   /ask     → commandId "1"  → "Ask another PSD staff member's agent a question"
+ *   /consult → commandId "2"  → "Consult another PSD staff member's agent"
+ *
+ * Both commands behave identically — /consult is a synonym for /ask.
+ */
+const SLASH_COMMAND_IDS: Record<string, 'ask'> = {
+  '1': 'ask',
+  '2': 'ask', // /consult is a synonym
+};
 
 // ---------------------------------------------------------------------------
 // Cached secrets
@@ -544,13 +588,17 @@ async function getOrCreateUser(
 // ---------------------------------------------------------------------------
 
 /**
- * Parse @agent:username from the beginning of a message.
+ * Parse @agent:username from the beginning of a message (DEPRECATED).
  * Supports formats:
  *   @agent:ashley what's the budget?
  *   @agent:ashley.jones what's the budget?
  *
  * The username is matched against the email local part (before @) of users in
  * DynamoDB. Returns null if no @agent: prefix is found.
+ *
+ * Deprecated in favor of /ask slash commands (issue #907). Kept for backward
+ * compatibility during the sunset window — the caller appends a deprecation
+ * notice to responses triggered via this parser.
  */
 function parseCrossUserInvocation(text: string): CrossUserInvocation | null {
   // Trim leading whitespace — Google Chat formatting may add spaces.
@@ -563,6 +611,61 @@ function parseCrossUserInvocation(text: string): CrossUserInvocation | null {
   return {
     targetUsername: match[1].toLowerCase(),
     strippedMessage: match[2].trim(),
+    source: 'text-prefix',
+  };
+}
+
+/**
+ * Parse a /ask (or /consult) slash command invocation from a Google Chat message.
+ *
+ * Slash commands are the preferred invocation method (issue #907). When a user
+ * types `/ask reese what's on the calendar?`, Google Chat delivers:
+ *   - message.slashCommand.commandId = "1"
+ *   - message.argumentText = "reese what's on the calendar?"
+ *
+ * The first token of argumentText is the target username; the remainder is the
+ * question. Returns null if the message doesn't contain a recognized slash command.
+ */
+function parseSlashCommandInvocation(
+  message: NonNullable<GoogleChatEvent['message']>,
+): CrossUserInvocation | null {
+  const commandId = message.slashCommand?.commandId;
+  if (!commandId || !SLASH_COMMAND_IDS[commandId]) {
+    return null;
+  }
+
+  // argumentText contains everything after the slash command itself.
+  // For "/ask reese what's up?" → argumentText = "reese what's up?"
+  // Google Chat strips bot @mentions from argumentText, so we don't need
+  // to worry about mention chips polluting the parse.
+  const argText = (message.argumentText ?? '').trim();
+  if (!argText) {
+    // No arguments — caller should prompt with usage help or a dialog
+    return {
+      targetUsername: '',
+      strippedMessage: '',
+      source: 'slash-command',
+    };
+  }
+
+  // First token = target username, remainder = question
+  const spaceIdx = argText.search(/\s/);
+  if (spaceIdx === -1) {
+    // Only a username, no question
+    return {
+      targetUsername: argText.toLowerCase(),
+      strippedMessage: '',
+      source: 'slash-command',
+    };
+  }
+
+  const username = argText.substring(0, spaceIdx);
+  const question = argText.substring(spaceIdx).trim();
+
+  return {
+    targetUsername: username.toLowerCase(),
+    strippedMessage: question,
+    source: 'slash-command',
   };
 }
 
@@ -1329,7 +1432,11 @@ async function processRecord(
   // Prefer argumentText; fall back to text when absent (older API versions,
   // edge cases where only one field is populated).
   const rawText = (message?.argumentText ?? message?.text ?? '').trim();
-  if (!message || !rawText || !message.sender) {
+  // Slash commands with no arguments (e.g., bare "/ask") have empty argumentText
+  // but are still valid — the handler will show usage help. Only bail on truly
+  // empty messages when there's no slash command present.
+  const hasSlashCommand = !!message?.slashCommand?.commandId;
+  if (!message || (!rawText && !hasSlashCommand) || !message.sender) {
     log.warn('Message event missing required fields');
     return;
   }
@@ -1529,18 +1636,41 @@ async function processRecord(
     void recordSignal({ building: user.department, topic }, log);
   }
 
-  // Step 3: Check for cross-user agent invocation (@agent:username)
-  // Only supported in shared spaces (ROOM) — in DMs the sender's own agent
-  // always responds. The cross-user path invokes the target user's AgentCore
-  // session with the sender's identity passed as `invokedBy`.
-  const crossUserInvocation = isSharedSpace ? parseCrossUserInvocation(messageText) : null;
+  // Step 3: Check for cross-user agent invocation.
+  // Supports two invocation methods:
+  //   1. /ask slash command (preferred) — `/ask reese what's on the calendar?`
+  //   2. @agent:username text prefix (deprecated) — `@agent:reese what's on the calendar?`
+  //
+  // Slash commands are checked first because Google Chat sets message.slashCommand
+  // on the event, making them unambiguous. The @agent: text parser is kept for
+  // backward compatibility during the sunset window (issue #907).
+  //
+  // In DMs, slash commands are still recognized (the /ask command routes to
+  // another agent even from a private DM), but @agent: text prefix is only
+  // recognized in shared spaces (historical behavior preserved).
+  const slashInvocation = message ? parseSlashCommandInvocation(message) : null;
+  const textInvocation = isSharedSpace ? parseCrossUserInvocation(messageText) : null;
+  // Slash command takes priority; fall back to @agent: text prefix
+  const crossUserInvocation = slashInvocation ?? textInvocation;
 
   if (crossUserInvocation) {
     log.info('Cross-user invocation detected', {
       sender: senderEmail,
       targetUsername: crossUserInvocation.targetUsername,
+      source: crossUserInvocation.source,
       space: spaceName,
     });
+
+    // Handle empty invocation — user typed just "/ask" with no arguments.
+    // Respond with usage help. A future Phase 2 enhancement could open a
+    // dialog card with a dropdown of agent owners (issue #907 open question).
+    if (!crossUserInvocation.targetUsername) {
+      const usageHelp = crossUserInvocation.source === 'slash-command'
+        ? 'Usage: `/ask <username> <question>`\n\nExample: `/ask reese what\'s on the calendar for today?`'
+        : 'Usage: `@agent:<username> <question>`\n\nExample: `@agent:reese what\'s on the calendar for today?`';
+      await sendGoogleChatResponse(spaceName, threadName, usageHelp, log);
+      return;
+    }
 
     // Resolve the target user
     const targetUser = await resolveUserByEmailPrefix(
@@ -1560,23 +1690,20 @@ async function processRecord(
       return;
     }
 
-    // Don't allow invoking your own agent via @agent: — use normal messaging.
-    // H3 fix: Use the stripped message (without @agent:prefix) for normal processing.
+    // Don't allow invoking your own agent — use normal messaging.
+    // H3 fix: Use the stripped message (without invocation prefix) for normal processing.
     if (targetUser.email.toLowerCase() === senderEmail.toLowerCase()) {
       log.info('Self-invocation detected, treating as normal message', {
         sender: senderEmail,
       });
       // Fall through to normal processing with the stripped message.
-      // Overwrite messageText so the @agent:username prefix isn't sent to AgentCore.
-      // If the stripped message is empty (user typed just "@agent:self"), return
-      // a prompt rather than sending the raw prefix to AgentCore.
+      // If the stripped message is empty, return a prompt rather than
+      // sending an empty string to AgentCore.
       if (!crossUserInvocation.strippedMessage) {
-        await sendGoogleChatResponse(
-          spaceName,
-          threadName,
-          'Please include a message. You can talk to your agent normally without the @agent: prefix.',
-          log
-        );
+        const selfHelp = crossUserInvocation.source === 'slash-command'
+          ? 'You can talk to your own agent by sending a message directly — no need for `/ask`.'
+          : 'Please include a message. You can talk to your agent normally without the @agent: prefix.';
+        await sendGoogleChatResponse(spaceName, threadName, selfHelp, log);
         return;
       }
       messageText = crossUserInvocation.strippedMessage;
@@ -1584,18 +1711,16 @@ async function processRecord(
       // Cross-user path: invoke the TARGET user's agent with sender context
       const actualMessage = crossUserInvocation.strippedMessage;
       if (!actualMessage) {
-        await sendGoogleChatResponse(
-          spaceName,
-          threadName,
-          `Please include a question after @agent:${crossUserInvocation.targetUsername}. ` +
-            `Example: @agent:${crossUserInvocation.targetUsername} what's the budget status?`,
-          log
-        );
+        const emptyHelp = crossUserInvocation.source === 'slash-command'
+          ? `Please include a question. Example: \`/ask ${crossUserInvocation.targetUsername} what's the budget status?\``
+          : `Please include a question after @agent:${crossUserInvocation.targetUsername}. ` +
+            `Example: @agent:${crossUserInvocation.targetUsername} what's the budget status?`;
+        await sendGoogleChatResponse(spaceName, threadName, emptyHelp, log);
         return;
       }
 
       // H1 fix: Run guardrails on the stripped message (what AgentCore actually
-      // receives), not the original text with the @agent:username prefix.
+      // receives), not the original text with the invocation prefix.
       // Telemetry-only per policy: record the assessment but never refuse the
       // message — cross-user invocations pass through just like direct DMs.
       await applyGuardrails(actualMessage, log);
@@ -1641,18 +1766,24 @@ async function processRecord(
         });
       }
 
-      // Response — always prefixed with the target user's name in shared spaces
+      // Response — always prefixed with the target user's name in shared spaces.
+      // When invoked via the deprecated @agent: prefix, append a deprecation
+      // notice nudging users toward the /ask slash command (issue #907).
+      const deprecationNotice = crossUserInvocation.source === 'text-prefix'
+        ? `\n\n_💡 Tip: \`/ask ${crossUserInvocation.targetUsername} …\` works too (and is faster)_`
+        : '';
       const maxLength = 4096;
       const truncationSuffix = '\n\n_(Response truncated — ask me to continue)_';
       const ownerLabel = targetUser.displayName || targetUser.email;
       const crossPrefix = `[${ownerLabel}'s Agent] `;
-      const availableLength = maxLength - crossPrefix.length;
+      const reservedLength = crossPrefix.length + deprecationNotice.length;
+      const availableLength = maxLength - reservedLength;
       const truncatedResponse =
         agentResult.response.length > availableLength
           ? agentResult.response.substring(0, availableLength - truncationSuffix.length) +
             truncationSuffix
           : agentResult.response;
-      const finalResponse = `${crossPrefix}${truncatedResponse}`;
+      const finalResponse = `${crossPrefix}${truncatedResponse}${deprecationNotice}`;
 
       await sendGoogleChatResponse(spaceName, threadName, finalResponse, log);
 
@@ -1685,6 +1816,7 @@ async function processRecord(
         invoker: senderEmail,
         agentOwner: targetUser.email,
         model: agentResult.model,
+        source: crossUserInvocation.source,
         latencyMs,
       });
       return;

--- a/infra/lambdas/agent-router/index.ts
+++ b/infra/lambdas/agent-router/index.ts
@@ -588,6 +588,19 @@ async function getOrCreateUser(
 // ---------------------------------------------------------------------------
 
 /**
+ * Validate that a string is a plausible email local part (username).
+ * Allows alphanumeric characters, dots, hyphens, and underscores.
+ * Must start and end with alphanumeric, minimum 2 chars to reject edge cases
+ * like "." or "---" which are not valid email local parts.
+ *
+ * Shared between parseCrossUserInvocation() and parseSlashCommandInvocation()
+ * to ensure consistent input validation regardless of invocation method.
+ */
+function isValidUsername(value: string): boolean {
+  return /^[a-zA-Z0-9](?:[a-zA-Z0-9._-]*[a-zA-Z0-9])?$/.test(value);
+}
+
+/**
  * Parse @agent:username from the beginning of a message (DEPRECATED).
  * Supports formats:
  *   @agent:ashley what's the budget?
@@ -651,7 +664,10 @@ function parseSlashCommandInvocation(
   // First token = target username, remainder = question
   const spaceIdx = argText.search(/\s/);
   if (spaceIdx === -1) {
-    // Only a username, no question
+    // Only a username, no question — validate before accepting
+    if (!isValidUsername(argText)) {
+      return null; // Invalid username format; caller treats as non-slash-command
+    }
     return {
       targetUsername: argText.toLowerCase(),
       strippedMessage: '',
@@ -661,6 +677,12 @@ function parseSlashCommandInvocation(
 
   const username = argText.substring(0, spaceIdx);
   const question = argText.substring(spaceIdx).trim();
+
+  // Validate the extracted username against the same rules used by the
+  // @agent:username parser — prevents arbitrary input reaching DynamoDB queries.
+  if (!isValidUsername(username)) {
+    return null;
+  }
 
   return {
     targetUsername: username.toLowerCase(),
@@ -1777,10 +1799,13 @@ async function processRecord(
       const ownerLabel = targetUser.displayName || targetUser.email;
       const crossPrefix = `[${ownerLabel}'s Agent] `;
       const reservedLength = crossPrefix.length + deprecationNotice.length;
-      const availableLength = maxLength - reservedLength;
+      // Clamp to a minimum of 0 to prevent negative substring lengths when
+      // the prefix + deprecation notice are unusually long (e.g., very long
+      // display name). In that edge case the response body is fully truncated.
+      const availableLength = Math.max(maxLength - reservedLength, 0);
       const truncatedResponse =
         agentResult.response.length > availableLength
-          ? agentResult.response.substring(0, availableLength - truncationSuffix.length) +
+          ? agentResult.response.substring(0, Math.max(availableLength - truncationSuffix.length, 0)) +
             truncationSuffix
           : agentResult.response;
       const finalResponse = `${crossPrefix}${truncatedResponse}${deprecationNotice}`;


### PR DESCRIPTION
## Summary

Implements #907 — replaces the `@agent:username` text-prefix cross-user invocation syntax with Google Chat `/ask` slash commands as the preferred invocation method.

- Add `/ask` (commandId 1) and `/consult` (commandId 2) slash command handling in the agent-router Lambda
- Parse `message.slashCommand.commandId` + `message.argumentText` to extract target username and question
- Slash commands work in both DMs and shared spaces; `@agent:` text prefix remains limited to shared spaces for backward compatibility
- Add deprecation notice footer to responses triggered via `@agent:` prefix: _"Tip: `/ask <username> …` works too (and is faster)"_
- Handle edge cases: bare `/ask` (usage help), username-only (prompt for question), self-invocation (redirect to normal messaging)
- Existing cross-user session isolation, `invokedBy` framing, SOUL.md consultation rules, and telemetry columns are reused unchanged

## Manual Setup Required

Register these commands in **Google Cloud Console → Chat API → Configuration → Slash commands**:

| Command | ID | Description |
|---|---|---|
| `/ask` | 1 | Ask another PSD staff member's agent a question |
| `/consult` | 2 | Consult another PSD staff member's agent |

## Test Plan

- [ ] Register `/ask` and `/consult` in Cloud Console
- [ ] Deploy to dev: `cd infra && bunx cdk deploy AIStudio-AgentPlatformStack-Dev`
- [ ] Verify `/ask reese <question>` in a shared space invokes Reese's agent and shows `[Reese's Agent]` prefix
- [ ] Verify `/consult reese <question>` works identically
- [ ] Verify bare `/ask` (no args) returns usage help
- [ ] Verify `/ask reese` (no question) prompts for a question
- [ ] Verify `/ask self` redirects to normal agent messaging
- [ ] Verify `@agent:reese <question>` still works but now includes deprecation notice
- [ ] Verify `/ask` works in a DM (routes to another user's agent from a private conversation)
- [ ] Verify normal messages (no slash command, no @agent:) still go through the owner's agent
- [ ] TypeScript compiles cleanly (`bunx tsc --noEmit` in agent-router)
- [ ] Full project lint and typecheck pass

Closes #907