### PR TITLE
feat(nexus): route Gemini Deep Research model through Interactions API

### DIFF
--- a/app/api/nexus/chat/route.ts
+++ b/app/api/nexus/chat/route.ts
@@ -36,8 +36,11 @@ import {
   saveAssistantMessage,
 } from './chat-helpers';
 
-// Allow streaming responses up to 5 minutes for long-running conversations
-export const maxDuration = 300;
+// Allow streaming responses up to 30 minutes. Deep Research runs take 5–25
+// minutes; standard chat and image-gen finish well within this window.
+// Platforms that enforce maxDuration (e.g. Vercel) will terminate the request
+// if it exceeds this value, so it must cover the worst-case Deep Research run.
+export const maxDuration = 1800;
 
 /**
  * Build the onFinish callback for streaming
@@ -348,6 +351,25 @@ async function handleImageGeneration(params: {
 }
 
 /**
+ * Format the Deep Research report body with optional citations.
+ * Used for both the streamed message and the persisted DB content, keeping
+ * the two representations in sync from a single source of truth.
+ */
+function formatDeepResearchReport(
+  report: string,
+  citations: Array<{ url: string; title?: string }>
+): string {
+  let body = report.trim();
+  if (citations.length > 0) {
+    body += '\n\n**Sources:**\n';
+    body += citations
+      .map((c, i) => `${i + 1}. [${c.title?.trim() || c.url}](${c.url})`)
+      .join('\n');
+  }
+  return body;
+}
+
+/**
  * Handle Gemini Deep Research models (e.g. deep-research-preview-04-2026).
  *
  * These run via Google's Interactions API, not generateContent. Lifecycle is
@@ -383,6 +405,17 @@ async function handleDeepResearch(params: {
     modelId: modelConfig.model_id,
   });
 
+  // Validate prompt BEFORE creating a conversation to avoid orphaned DB state.
+  // extractImagePrompt extracts the last user message text — the name is
+  // image-specific but the logic is generic ("get the last user message text").
+  const prompt = extractImagePrompt(messages);
+  if (!prompt) {
+    return new Response(
+      JSON.stringify({ error: 'Deep Research requires a text prompt', requestId }),
+      { status: 400, headers: { 'Content-Type': 'application/json' } }
+    );
+  }
+
   // Lazy imports keep the cold start of the standard chat path unchanged.
   const [
     { runDeepResearch },
@@ -406,17 +439,6 @@ async function handleDeepResearch(params: {
   });
   if ('error' in convSetup) return convSetup.error;
   const { conversationId, conversationTitle } = convSetup;
-
-  // Extract the user's research question. We re-use extractImagePrompt's
-  // logic because the shape ("get the last user message text") is identical;
-  // it doesn't actually do anything image-specific.
-  const prompt = extractImagePrompt(messages);
-  if (!prompt) {
-    return new Response(
-      JSON.stringify({ error: 'Deep Research requires a text prompt', requestId }),
-      { status: 400, headers: { 'Content-Type': 'application/json' } }
-    );
-  }
 
   const messageId = `dr-${Date.now()}`;
   const isNewConversation = !existingConversationId;
@@ -451,6 +473,9 @@ async function handleDeepResearch(params: {
         // 'in_progress' for the whole run.
         let lastStatusEmitted = '';
 
+        // Track whether we've ended the stream to avoid double text-end.
+        let streamEnded = false;
+
         try {
           const result = await runDeepResearch({
             prompt,
@@ -469,39 +494,37 @@ async function handleDeepResearch(params: {
             },
           });
 
-          // Final report. Emit citations as an appended Sources section so
-          // the user can click through. We deliberately keep the report and
-          // sources in the same text part — markdown renderer handles both.
-          let finalDelta = `\n---\n\n${result.report.trim()}\n`;
-          if (result.citations.length > 0) {
-            finalDelta += '\n\n**Sources:**\n';
-            for (const [i, c] of result.citations.entries()) {
-              const label = c.title?.trim() || c.url;
-              finalDelta += `${i + 1}. [${label}](${c.url})\n`;
-            }
-          }
+          // Build the report + citations once, reuse for both stream and DB.
+          const reportBody = formatDeepResearchReport(
+            result.report, result.citations
+          );
+
+          // Final report delta for the stream.
+          const finalDelta = `\n---\n\n${reportBody}\n`;
           writer.write({ type: 'text-delta', id: messageId, delta: finalDelta });
+
+          // Persist BEFORE ending the stream — if persistence fails, we still
+          // have the stream open and can surface the error to the user rather
+          // than ending the message and leaving the DB inconsistent.
+          const persisted = `🔍 **Deep Research Report**\n\n${reportBody}`;
+          try {
+            await persistAssistantMessage({
+              conversationId,
+              text: persisted,
+              finishReason: 'stop',
+              dbModelId,
+            });
+          } catch (persistErr) {
+            log.error('Failed to persist Deep Research message', {
+              conversationId,
+              error: persistErr instanceof Error ? persistErr.message : String(persistErr),
+            });
+            // Don't throw — the user already has the report in-stream.
+            // History won't show it, but that's better than crashing the SSE.
+          }
+
           writer.write({ type: 'text-end', id: messageId });
-
-          // Persist the assistant message so refresh / history works.
-          // We store the joined heads-up + final report so the history view
-          // matches what the user saw streamed.
-          const persisted =
-            '🔍 **Deep Research Report**\n\n'
-            + result.report.trim()
-            + (result.citations.length > 0
-              ? '\n\n**Sources:**\n'
-                + result.citations
-                  .map((c, i) => `${i + 1}. [${c.title?.trim() || c.url}](${c.url})`)
-                  .join('\n')
-              : '');
-          await persistAssistantMessage({
-            conversationId,
-            text: persisted,
-            finishReason: 'stop',
-            dbModelId,
-          });
-
+          streamEnded = true;
           timer({ status: 'success', conversationId, durationMs: result.durationMs });
         } catch (err) {
           const message = err instanceof Error ? err.message : String(err);
@@ -510,14 +533,15 @@ async function handleDeepResearch(params: {
             : 'UNKNOWN';
           log.error('Deep Research failed', { conversationId, errType, message });
 
-          // Surface a clean error inside the streamed message so the user sees
-          // something useful rather than a dead spinner.
-          writer.write({
-            type: 'text-delta',
-            id: messageId,
-            delta: `\n\n**Research failed:** ${message}`,
-          });
-          writer.write({ type: 'text-end', id: messageId });
+          // Only write error + text-end if we haven't already ended the stream.
+          if (!streamEnded) {
+            writer.write({
+              type: 'text-delta',
+              id: messageId,
+              delta: `\n\n**Research failed:** ${message}`,
+            });
+            writer.write({ type: 'text-end', id: messageId });
+          }
           timer({ status: 'error', conversationId, errType });
         }
       },
@@ -548,6 +572,10 @@ async function routeSpecialModel(params: {
   abortSignal: AbortSignal;
 }): Promise<Response | null> {
   if (params.isImageGenerationModel) {
+    // Note: abortSignal is intentionally not forwarded to handleImageGeneration.
+    // Image generation is a fast single-shot API call (seconds, not minutes),
+    // so cancellation support is not needed. Deep Research is the only path
+    // that requires abort propagation due to its 5–25 minute polling lifecycle.
     return handleImageGeneration({
       messages: params.messages,
       modelConfig: params.modelConfig,

--- a/app/api/nexus/chat/route.ts
+++ b/app/api/nexus/chat/route.ts
@@ -347,6 +347,236 @@ async function handleImageGeneration(params: {
   }
 }
 
+/**
+ * Handle Gemini Deep Research models (e.g. deep-research-preview-04-2026).
+ *
+ * These run via Google's Interactions API, not generateContent. Lifecycle is
+ * minutes-long polling, so the response shape is:
+ *   1. Immediately stream a heads-up message so the user knows we're working.
+ *   2. Internally poll Google every 10 s; surface periodic progress as
+ *      additional streamed lines (one per minute, kept terse to avoid noise).
+ *   3. When the agent completes, stream the full markdown report + cited
+ *      sources, then close.
+ *   4. On failure, stream a user-readable error and close cleanly.
+ *
+ * The heavy lifting lives in lib/ai/gemini-deep-research-service.ts; this
+ * function is just the SSE writer + DB persistence shim.
+ */
+async function handleDeepResearch(params: {
+  messages: z.infer<typeof ChatRequestSchema>['messages'];
+  modelConfig: { provider: string; model_id: string };
+  modelId: string;
+  dbModelId: number;
+  userId: number;
+  existingConversationId?: string;
+  requestId: string;
+  timer: (data: Record<string, unknown>) => void;
+  log: ReturnType<typeof createLogger>;
+  abortSignal: AbortSignal;
+}): Promise<Response> {
+  const {
+    messages, modelConfig, modelId, dbModelId, userId,
+    existingConversationId, requestId, timer, log, abortSignal,
+  } = params;
+
+  log.info('Deep Research model detected — using Interactions API', {
+    modelId: modelConfig.model_id,
+  });
+
+  // Lazy imports keep the cold start of the standard chat path unchanged.
+  const [
+    { runDeepResearch },
+    { saveAssistantMessage: persistAssistantMessage },
+    { createUIMessageStream, createUIMessageStreamResponse },
+  ] = await Promise.all([
+    import('@/lib/ai/gemini-deep-research-service'),
+    import('./chat-helpers'),
+    import('ai'),
+  ]);
+
+  // Conversation setup — same shape the standard flow uses, so the
+  // conversation list, history, and resume work without special-casing.
+  const convSetup = await setupConversation({
+    conversationIdValue: existingConversationId,
+    messages,
+    userId,
+    provider: modelConfig.provider,
+    modelId,
+    dbModelId,
+  });
+  if ('error' in convSetup) return convSetup.error;
+  const { conversationId, conversationTitle } = convSetup;
+
+  // Extract the user's research question. We re-use extractImagePrompt's
+  // logic because the shape ("get the last user message text") is identical;
+  // it doesn't actually do anything image-specific.
+  const prompt = extractImagePrompt(messages);
+  if (!prompt) {
+    return new Response(
+      JSON.stringify({ error: 'Deep Research requires a text prompt', requestId }),
+      { status: 400, headers: { 'Content-Type': 'application/json' } }
+    );
+  }
+
+  const messageId = `dr-${Date.now()}`;
+  const isNewConversation = !existingConversationId;
+
+  const responseHeaders: Record<string, string> = {
+    'X-Request-Id': requestId,
+    'X-Conversation-Id': conversationId,
+    'X-Deep-Research': 'true',
+  };
+  if (isNewConversation) {
+    responseHeaders['X-Conversation-Title'] = encodeURIComponent(conversationTitle);
+  }
+
+  return createUIMessageStreamResponse({
+    status: 200,
+    headers: responseHeaders,
+    stream: createUIMessageStream({
+      async execute({ writer }) {
+        writer.write({ type: 'text-start', id: messageId });
+
+        // Heads-up so the user sees activity before the first poll comes back.
+        writer.write({
+          type: 'text-delta',
+          id: messageId,
+          delta:
+            '🔍 **Deep Research in progress** — this typically takes 5–15 minutes. '
+            + 'The full report will appear below when ready.\n\n',
+        });
+
+        // Track the last status we surfaced so we don't spam the stream with
+        // identical "Researching… (1m)" lines while Google's status sits on
+        // 'in_progress' for the whole run.
+        let lastStatusEmitted = '';
+
+        try {
+          const result = await runDeepResearch({
+            prompt,
+            modelId: modelConfig.model_id,
+            abortSignal,
+            onStatus: ({ message }) => {
+              if (message === lastStatusEmitted) return;
+              lastStatusEmitted = message;
+              // Italic progress line on its own paragraph. Cheap, readable,
+              // and clearly distinct from the final report content below.
+              writer.write({
+                type: 'text-delta',
+                id: messageId,
+                delta: `_${message}_\n\n`,
+              });
+            },
+          });
+
+          // Final report. Emit citations as an appended Sources section so
+          // the user can click through. We deliberately keep the report and
+          // sources in the same text part — markdown renderer handles both.
+          let finalDelta = `\n---\n\n${result.report.trim()}\n`;
+          if (result.citations.length > 0) {
+            finalDelta += '\n\n**Sources:**\n';
+            for (const [i, c] of result.citations.entries()) {
+              const label = c.title?.trim() || c.url;
+              finalDelta += `${i + 1}. [${label}](${c.url})\n`;
+            }
+          }
+          writer.write({ type: 'text-delta', id: messageId, delta: finalDelta });
+          writer.write({ type: 'text-end', id: messageId });
+
+          // Persist the assistant message so refresh / history works.
+          // We store the joined heads-up + final report so the history view
+          // matches what the user saw streamed.
+          const persisted =
+            '🔍 **Deep Research Report**\n\n'
+            + result.report.trim()
+            + (result.citations.length > 0
+              ? '\n\n**Sources:**\n'
+                + result.citations
+                  .map((c, i) => `${i + 1}. [${c.title?.trim() || c.url}](${c.url})`)
+                  .join('\n')
+              : '');
+          await persistAssistantMessage({
+            conversationId,
+            text: persisted,
+            finishReason: 'stop',
+            dbModelId,
+          });
+
+          timer({ status: 'success', conversationId, durationMs: result.durationMs });
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          const errType = err && typeof err === 'object' && 'type' in err
+            ? (err as { type: string }).type
+            : 'UNKNOWN';
+          log.error('Deep Research failed', { conversationId, errType, message });
+
+          // Surface a clean error inside the streamed message so the user sees
+          // something useful rather than a dead spinner.
+          writer.write({
+            type: 'text-delta',
+            id: messageId,
+            delta: `\n\n**Research failed:** ${message}`,
+          });
+          writer.write({ type: 'text-end', id: messageId });
+          timer({ status: 'error', conversationId, errType });
+        }
+      },
+    }),
+  });
+}
+
+/**
+ * Capability-based dispatch for non-streaming model paths. Returns the
+ * Response when one of these handlers owns the request, or null when the
+ * caller should continue down the standard streaming path.
+ *
+ * Extracted to keep POST() under the cyclomatic-complexity threshold and
+ * to centralize the place where new "special" model classes get added.
+ */
+async function routeSpecialModel(params: {
+  isImageGenerationModel: boolean;
+  isDeepResearchModel: boolean;
+  messages: z.infer<typeof ChatRequestSchema>['messages'];
+  modelConfig: { provider: string; model_id: string };
+  modelId: string;
+  dbModelId: number;
+  userId: number;
+  existingConversationId?: string;
+  requestId: string;
+  timer: (data: Record<string, unknown>) => void;
+  log: ReturnType<typeof createLogger>;
+  abortSignal: AbortSignal;
+}): Promise<Response | null> {
+  if (params.isImageGenerationModel) {
+    return handleImageGeneration({
+      messages: params.messages,
+      modelConfig: params.modelConfig,
+      modelId: params.modelId,
+      dbModelId: params.dbModelId,
+      userId: params.userId,
+      existingConversationId: params.existingConversationId,
+      requestId: params.requestId,
+      timer: params.timer,
+      log: params.log,
+    });
+  }
+  if (params.isDeepResearchModel) {
+    return handleDeepResearch({
+      messages: params.messages,
+      modelConfig: params.modelConfig,
+      modelId: params.modelId,
+      dbModelId: params.dbModelId,
+      userId: params.userId,
+      existingConversationId: params.existingConversationId,
+      requestId: params.requestId,
+      timer: params.timer,
+      log: params.log,
+      abortSignal: params.abortSignal,
+    });
+  }
+  return null;
+}
+
 type ValidationResult = {
   valid: true;
   data: z.infer<typeof ChatRequestSchema>;
@@ -429,6 +659,7 @@ async function getValidatedModelConfig(
   modelConfig: NonNullable<Awaited<ReturnType<typeof getModelConfig>>>;
   dbModelId: number;
   isImageGenerationModel: boolean;
+  isDeepResearchModel: boolean;
 } | { error: Response }> {
   const modelConfig = await getModelConfig(modelId);
   if (!modelConfig) {
@@ -444,8 +675,9 @@ async function getValidatedModelConfig(
   const dbModelId = modelConfig.id;
   const modelWithCapabilities = await getAIModelById(dbModelId);
   const isImageGenerationModel = hasCapability(modelWithCapabilities?.capabilities, 'imageGeneration');
+  const isDeepResearchModel = hasCapability(modelWithCapabilities?.capabilities, 'deepResearch');
 
-  return { modelConfig, dbModelId, isImageGenerationModel };
+  return { modelConfig, dbModelId, isImageGenerationModel, isDeepResearchModel };
 }
 
 /**
@@ -528,17 +760,26 @@ export async function POST(req: Request) {
     // 4. Get model configuration
     const modelResult = await getValidatedModelConfig(modelId, log);
     if ('error' in modelResult) return modelResult.error;
-    const { modelConfig, dbModelId, isImageGenerationModel } = modelResult;
+    const { modelConfig, dbModelId, isImageGenerationModel, isDeepResearchModel } = modelResult;
 
-    log.info('Model configured', sanitizeForLogging({ provider: modelConfig.provider, modelId: modelConfig.model_id, dbId: dbModelId, isImageGeneration: isImageGenerationModel }));
+    log.info('Model configured', sanitizeForLogging({
+      provider: modelConfig.provider,
+      modelId: modelConfig.model_id,
+      dbId: dbModelId,
+      isImageGeneration: isImageGenerationModel,
+      isDeepResearch: isDeepResearchModel,
+    }));
 
-    // 5. Handle image generation models separately
-    if (isImageGenerationModel) {
-      return handleImageGeneration({
-        messages, modelConfig, modelId, dbModelId, userId,
-        existingConversationId: conversationIdValue, requestId, timer, log
-      });
-    }
+    // 5. Capability-based routing — image gen and Deep Research bypass
+    // the standard streaming pipeline.
+    const specialRoute = await routeSpecialModel({
+      isImageGenerationModel, isDeepResearchModel,
+      messages, modelConfig, modelId, dbModelId, userId,
+      existingConversationId: conversationIdValue,
+      requestId, timer, log,
+      abortSignal: req.signal,
+    });
+    if (specialRoute) return specialRoute;
 
     // 6. Setup conversation and save user message
     const convSetup = await setupConversation({

--- a/infra/database/migrations.json
+++ b/infra/database/migrations.json
@@ -68,6 +68,7 @@
     "070-agent-skills-platform.sql",
     "071-agent-workspace-tokens.sql",
     "072-agent-workspace-nonce-agent-email.sql",
-    "073-agent-workspace-token-kind.sql"
+    "073-agent-workspace-token-kind.sql",
+    "074-deep-research-capability.sql"
   ]
 }

--- a/infra/database/schema/074-deep-research-capability.sql
+++ b/infra/database/schema/074-deep-research-capability.sql
@@ -1,0 +1,27 @@
+-- Migration 074: Mark Gemini Deep Research model with the deep_research capability.
+--
+-- The model row for `deep-research-preview-04-2026` (id=127, provider=google) was
+-- inserted with capabilities `["chat","web_search","reasoning","thinking","streaming"]`.
+-- That row routes through `@ai-sdk/google` → `generateContent` and fails with
+-- "This model only supports Interactions API." Deep Research is an *agent* that
+-- runs through Google's separate Interactions API with a polling lifecycle, not
+-- a streaming token endpoint.
+--
+-- This migration:
+--   * adds `deep_research` so the chat route's capability check branches to the
+--     new `runDeepResearch` service instead of the unified streaming path
+--   * removes `streaming` (Deep Research returns a single completed report — the
+--     UI long-polls; advertising "streaming" misleads consumers of capabilities)
+--   * removes `web_search` (web search is implicit in Deep Research and a separate
+--     badge would imply a user-toggleable tool, which it is not)
+--
+-- Other Gemini rows (gemini-3-flash-preview, gemini-3.1-pro-preview,
+-- gemini-3.1-flash-image-preview) are intentionally untouched.
+
+UPDATE migration_log SET status = 'completed'
+WHERE description = '074-deep-research-capability.sql' AND status = 'failed';
+
+UPDATE ai_models
+SET capabilities = '["chat","reasoning","thinking","deep_research"]'
+WHERE provider = 'google'
+  AND model_id = 'deep-research-preview-04-2026';

--- a/lib/ai/capability-utils.ts
+++ b/lib/ai/capability-utils.ts
@@ -60,7 +60,8 @@ export type CapabilityKey =
   | "contextCaching"
   | "computerUse"
   | "workspaceTools"
-  | "imageGeneration";
+  | "imageGeneration"
+  | "deepResearch";
 
 /**
  * Database capability values (snake_case as stored in capabilities field)
@@ -79,7 +80,8 @@ export type DatabaseCapability =
   | "context_caching"
   | "computer_use"
   | "workspace_tools"
-  | "image_generation";
+  | "image_generation"
+  | "deep_research";
 
 /**
  * Mapping from database snake_case to runtime camelCase
@@ -99,6 +101,7 @@ const DB_TO_RUNTIME_MAP: Record<DatabaseCapability, CapabilityKey> = {
   computer_use: "computerUse",
   workspace_tools: "workspaceTools",
   image_generation: "imageGeneration",
+  deep_research: "deepResearch",
 };
 
 /**
@@ -370,6 +373,7 @@ const DEFAULT_NEXUS_CAPABILITIES: NexusCapabilities = {
   workspaceTools: false,
   codeInterpreter: false,
   imageGeneration: false,
+  deepResearch: false,
 } as const;
 
 /**
@@ -409,5 +413,6 @@ export function capabilitiesToNexusCapabilities(
     workspaceTools: parsed.has("workspaceTools"),
     codeInterpreter: parsed.has("codeInterpreter"),
     imageGeneration: parsed.has("imageGeneration"),
+    deepResearch: parsed.has("deepResearch"),
   };
 }

--- a/lib/ai/capability-utils.ts
+++ b/lib/ai/capability-utils.ts
@@ -22,6 +22,7 @@
  * - "computer_use" -> computerUse
  * - "workspace_tools" -> workspaceTools
  * - "image_generation" -> imageGeneration
+ * - "deep_research" -> deepResearch
  *
  * @example
  * ```typescript

--- a/lib/ai/gemini-deep-research-service.ts
+++ b/lib/ai/gemini-deep-research-service.ts
@@ -119,19 +119,48 @@ function createError(
  * Friendly progress text for the user. We surface Google's actual status
  * string when it's informative, and fall back to a wall-clock timer for
  * the long quiet stretches in the middle of a run.
+ *
+ * Terminal statuses (completed, failed, cancelled) return null — the caller
+ * should not emit a progress line for these since the final report or error
+ * message is about to follow immediately.
  */
-function buildProgressMessage(status: Interaction['status'], elapsedSec: number): string {
+function buildProgressMessage(status: Interaction['status'], elapsedSec: number): string | null {
   const minutes = Math.floor(elapsedSec / 60);
-  const minutesText = minutes === 0 ? 'starting up' : `${minutes} min`;
+  const seconds = elapsedSec % 60;
+  // Include seconds so the message changes every poll (~10s), keeping the SSE
+  // connection alive through ALB/proxy idle timeouts (typically 60s).
+  const timeText = minutes === 0
+    ? `${seconds}s`
+    : `${minutes}m ${seconds}s`;
   switch (status) {
     case 'in_progress':
-      return `Researching… (${minutesText})`;
+      return `Researching… (${timeText})`;
     case 'requires_action':
-      return `Awaiting action from the agent (${minutesText})`;
+      return `Awaiting action from the agent (${timeText})`;
     case 'incomplete':
       return `Research run ended early — partial results below.`;
+    // Terminal statuses — no progress message; the final report/error follows.
+    case 'completed':
+    case 'failed':
+    case 'cancelled':
+      return null;
     default:
-      return `Status: ${status} (${minutesText})`;
+      return `Status: ${status} (${timeText})`;
+  }
+}
+
+/**
+ * Validate that a URL uses a safe protocol (http/https only).
+ * Blocks javascript:, data:, and other potentially dangerous URI schemes
+ * that could be injected via Google's API response into markdown links.
+ */
+function isSafeUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    return parsed.protocol === 'http:' || parsed.protocol === 'https:';
+  } catch {
+    // Malformed URLs are not safe
+    return false;
   }
 }
 
@@ -139,12 +168,19 @@ function buildProgressMessage(status: Interaction['status'], elapsedSec: number)
  * Type guard for url_citation annotations on a Google text block. We don't
  * use a real schema here — the SDK already types the upstream surface, but
  * we narrow defensively because `outputs` is a union of many block kinds.
+ *
+ * URLs are validated to only allow http/https protocols — this prevents
+ * javascript: or data: URIs from being rendered as live markdown links.
  */
 function asUrlCitation(value: unknown): DeepResearchCitation | null {
   if (!value || typeof value !== 'object' || !('type' in value)) return null;
   if ((value as { type: string }).type !== 'url_citation') return null;
   const url = (value as { url?: string }).url;
   if (typeof url !== 'string' || url.length === 0) return null;
+  if (!isSafeUrl(url)) {
+    log.warn('Skipping citation with unsafe URL scheme', { url: url.slice(0, 100) });
+    return null;
+  }
   return {
     url,
     title: (value as { title?: string }).title,
@@ -213,21 +249,30 @@ function mapInteractionError(err: unknown): DeepResearchError {
   return createError('AGENT_FAILURE', `Deep Research failed: ${msg.slice(0, 300)}`);
 }
 
+/**
+ * Abortable sleep. Cleans up the abort listener on normal resolution so that
+ * long polling loops (150+ iterations over 25 minutes) don't accumulate
+ * leaked listeners on the shared AbortSignal.
+ */
 function sleep(ms: number, signal?: AbortSignal): Promise<void> {
   return new Promise((resolve, reject) => {
     if (signal?.aborted) {
       reject(new Error('aborted'));
       return;
     }
-    const t = setTimeout(resolve, ms);
-    signal?.addEventListener(
-      'abort',
-      () => {
-        clearTimeout(t);
-        reject(new Error('aborted'));
-      },
-      { once: true }
-    );
+
+    const onAbort = () => {
+      clearTimeout(t);
+      signal?.removeEventListener('abort', onAbort);
+      reject(new Error('aborted'));
+    };
+
+    const t = setTimeout(() => {
+      signal?.removeEventListener('abort', onAbort);
+      resolve();
+    }, ms);
+
+    signal?.addEventListener('abort', onAbort, { once: true });
   });
 }
 
@@ -237,6 +282,9 @@ const TERMINAL_STATUSES: ReadonlyArray<Interaction['status']> = [
   'cancelled',
   'incomplete',
 ];
+
+/** Max consecutive transient poll failures before we give up. */
+const MAX_POLL_RETRIES = 3;
 
 /**
  * Tight polling loop. Returns the terminal Interaction or throws a
@@ -250,6 +298,8 @@ async function pollUntilTerminal(
   request: DeepResearchRequest
 ): Promise<Interaction> {
   let last: Interaction = initial;
+  let consecutiveErrors = 0;
+
   while (true) {
     const elapsedMs = Date.now() - startMs;
     if (elapsedMs > MAX_RUN_DURATION_MS) {
@@ -260,17 +310,24 @@ async function pollUntilTerminal(
       );
     }
 
-    try {
-      await request.onStatus?.({
-        status: last.status,
-        elapsedSec: Math.floor(elapsedMs / 1_000),
-        message: buildProgressMessage(last.status, Math.floor(elapsedMs / 1_000)),
-      });
-    } catch (err) {
-      // Status callback errors must never interrupt the run.
-      log.warn('onStatus callback threw — continuing', {
-        error: err instanceof Error ? err.message : String(err),
-      });
+    // Only emit progress for non-terminal statuses — terminal statuses
+    // are handled by the caller (final report or error message).
+    if (!TERMINAL_STATUSES.includes(last.status)) {
+      const progressMsg = buildProgressMessage(last.status, Math.floor(elapsedMs / 1_000));
+      if (progressMsg) {
+        try {
+          await request.onStatus?.({
+            status: last.status,
+            elapsedSec: Math.floor(elapsedMs / 1_000),
+            message: progressMsg,
+          });
+        } catch (err) {
+          // Status callback errors must never interrupt the run.
+          log.warn('onStatus callback threw — continuing', {
+            error: err instanceof Error ? err.message : String(err),
+          });
+        }
+      }
     }
 
     if (TERMINAL_STATUSES.includes(last.status)) return last;
@@ -281,7 +338,29 @@ async function pollUntilTerminal(
       throw createError('AGENT_FAILURE', 'Deep Research cancelled by client.');
     }
 
-    last = await client.interactions.get(last.id);
+    // Retry transient poll failures — a 25-minute run is highly susceptible
+    // to momentary network blips. We retry up to MAX_POLL_RETRIES consecutive
+    // failures before giving up.
+    try {
+      last = await client.interactions.get(last.id);
+      consecutiveErrors = 0; // reset on success
+    } catch (pollErr) {
+      consecutiveErrors++;
+      log.warn('Transient poll error', {
+        interactionId: last.id,
+        attempt: consecutiveErrors,
+        maxRetries: MAX_POLL_RETRIES,
+        error: pollErr instanceof Error ? pollErr.message : String(pollErr),
+      });
+      if (consecutiveErrors >= MAX_POLL_RETRIES) {
+        throw createError(
+          'AGENT_FAILURE',
+          `Deep Research polling failed after ${MAX_POLL_RETRIES} consecutive errors: ${pollErr instanceof Error ? pollErr.message : String(pollErr)}`
+        );
+      }
+      // On retry, we don't update `last` — the loop re-sleeps and retries
+      // the same interaction.get() call on the next iteration.
+    }
   }
 }
 

--- a/lib/ai/gemini-deep-research-service.ts
+++ b/lib/ai/gemini-deep-research-service.ts
@@ -1,0 +1,385 @@
+/**
+ * Gemini Deep Research Service
+ *
+ * Wraps Google's Interactions API for agentic Deep Research models.
+ *
+ * Why a separate service: standard Gemini chat models are routed through
+ * `@ai-sdk/google` → `generateContent`, but agents like
+ * `deep-research-preview-04-2026` only run through Google's Interactions API
+ * (a different endpoint, polled lifecycle, returns a final report instead of
+ * a token stream). We can't reuse the existing GeminiAdapter — the request
+ * body shape, error surface, and response shape are all different.
+ *
+ * Flow:
+ *   1. `ai.interactions.create({ agent, input, background: true })` returns
+ *      an Interaction object with status='in_progress' and an id.
+ *   2. Poll `ai.interactions.get(id)` every POLL_INTERVAL_MS until status is
+ *      terminal ('completed' | 'failed' | 'cancelled' | 'incomplete').
+ *   3. On completed: extract text + URL citations from `outputs[]`.
+ *   4. On failure: throw a domain error so the route renders a useful message.
+ *
+ * Cancellation: if the caller passes an AbortSignal that fires, we call
+ * `ai.interactions.cancel(id)` so we don't keep paying for a job nobody wants.
+ *
+ * @see https://ai.google.dev/gemini-api/docs/interactions
+ */
+
+import { GoogleGenAI, Interactions } from '@google/genai';
+
+// `Interaction` is re-exported from the `Interactions` namespace by @google/genai.
+// Aliasing here keeps the rest of the file readable.
+type Interaction = Interactions.Interaction;
+import { createLogger, generateRequestId } from '@/lib/logger';
+import { Settings } from '@/lib/settings-manager';
+import { ErrorFactories } from '@/lib/error-utils';
+
+const log = createLogger({ module: 'gemini-deep-research-service' });
+
+/** How often to poll for status updates while the agent runs. */
+const POLL_INTERVAL_MS = 10_000;
+
+/**
+ * Hard cap on a single Deep Research run.
+ *
+ * Google's product page advertises 5–15 min typical, with longer runs
+ * possible. We cap at 25 minutes so a wedged interaction can't tie up
+ * an ECS task indefinitely. ECS Fargate has no inherent task timeout
+ * but ALB idle-connection timeout (default 60s) doesn't apply because
+ * we keep writing status updates to the stream — see status emitter
+ * cadence below.
+ */
+const MAX_RUN_DURATION_MS = 25 * 60 * 1_000;
+
+export interface DeepResearchCitation {
+  url: string;
+  title?: string;
+  /** Byte offsets into the report text — preserved for future inline rendering. */
+  startIndex?: number;
+  endIndex?: number;
+}
+
+export interface DeepResearchResult {
+  /** Final report as markdown. */
+  report: string;
+  /** Sources cited by the agent. May be empty if the agent didn't cite anything. */
+  citations: DeepResearchCitation[];
+  /** Google's interaction id — useful for support / debug correlation. */
+  interactionId: string;
+  /** Wall-clock duration of the research run in milliseconds. */
+  durationMs: number;
+}
+
+export interface DeepResearchStatusUpdate {
+  /** Google's status string. */
+  status: Interaction['status'];
+  /** Seconds elapsed since the run started. */
+  elapsedSec: number;
+  /** Human-friendly progress message — what the user sees. */
+  message: string;
+}
+
+export interface DeepResearchRequest {
+  prompt: string;
+  /** model_id from ai_models — passed to Google as `agent`. */
+  modelId: string;
+  /** Optional cancel signal; on abort we call interactions.cancel(). */
+  abortSignal?: AbortSignal;
+  /**
+   * Called once per poll with the latest status. The route uses this to
+   * write progressive `Researching… (Nm)` updates to the SSE stream.
+   * Errors thrown here are swallowed — a slow client must not interrupt
+   * the agent run.
+   */
+  onStatus?: (update: DeepResearchStatusUpdate) => void | Promise<void>;
+}
+
+interface DeepResearchError extends Error {
+  type:
+    | 'CONTENT_POLICY'
+    | 'RATE_LIMIT'
+    | 'AUTHENTICATION'
+    | 'TIMEOUT'
+    | 'AGENT_FAILURE'
+    | 'UNKNOWN';
+  retryAfter?: number;
+}
+
+function createError(
+  type: DeepResearchError['type'],
+  message: string,
+  retryAfter?: number
+): DeepResearchError {
+  const err = new Error(message) as DeepResearchError;
+  err.type = type;
+  if (retryAfter !== undefined) err.retryAfter = retryAfter;
+  return err;
+}
+
+/**
+ * Friendly progress text for the user. We surface Google's actual status
+ * string when it's informative, and fall back to a wall-clock timer for
+ * the long quiet stretches in the middle of a run.
+ */
+function buildProgressMessage(status: Interaction['status'], elapsedSec: number): string {
+  const minutes = Math.floor(elapsedSec / 60);
+  const minutesText = minutes === 0 ? 'starting up' : `${minutes} min`;
+  switch (status) {
+    case 'in_progress':
+      return `Researching… (${minutesText})`;
+    case 'requires_action':
+      return `Awaiting action from the agent (${minutesText})`;
+    case 'incomplete':
+      return `Research run ended early — partial results below.`;
+    default:
+      return `Status: ${status} (${minutesText})`;
+  }
+}
+
+/**
+ * Type guard for url_citation annotations on a Google text block. We don't
+ * use a real schema here — the SDK already types the upstream surface, but
+ * we narrow defensively because `outputs` is a union of many block kinds.
+ */
+function asUrlCitation(value: unknown): DeepResearchCitation | null {
+  if (!value || typeof value !== 'object' || !('type' in value)) return null;
+  if ((value as { type: string }).type !== 'url_citation') return null;
+  const url = (value as { url?: string }).url;
+  if (typeof url !== 'string' || url.length === 0) return null;
+  return {
+    url,
+    title: (value as { title?: string }).title,
+    startIndex: (value as { start_index?: number }).start_index,
+    endIndex: (value as { end_index?: number }).end_index,
+  };
+}
+
+/**
+ * Pull report text + URL citations out of Google's `outputs` array.
+ * Outputs is a heterogeneous list of Content blocks; we keep text blocks
+ * and harvest `url_citation` annotations into a flat list. Non-text blocks
+ * (function calls, image content, etc.) are ignored — Deep Research returns
+ * a written report, anything else is exotic.
+ */
+function extractReportAndCitations(outputs: Interaction['outputs']): {
+  report: string;
+  citations: DeepResearchCitation[];
+} {
+  if (!outputs || outputs.length === 0) {
+    return { report: '', citations: [] };
+  }
+
+  const textChunks: string[] = [];
+  const citations: DeepResearchCitation[] = [];
+
+  for (const block of outputs) {
+    if (!block || typeof block !== 'object' || !('type' in block)) continue;
+    if (block.type !== 'text') continue;
+
+    const text = (block as { text?: string }).text;
+    if (typeof text === 'string' && text.length > 0) {
+      textChunks.push(text);
+    }
+
+    const annotations = (block as { annotations?: unknown[] }).annotations;
+    if (!Array.isArray(annotations)) continue;
+    for (const ann of annotations) {
+      const cite = asUrlCitation(ann);
+      if (cite) citations.push(cite);
+    }
+  }
+
+  return { report: textChunks.join('\n\n'), citations };
+}
+
+/** Map upstream errors onto our taxonomy by inspecting message + status. */
+function mapInteractionError(err: unknown): DeepResearchError {
+  const msg = err instanceof Error ? err.message : String(err);
+  const lower = msg.toLowerCase();
+
+  if (lower.includes('safety') || lower.includes('content_policy') || lower.includes('blocked')) {
+    return createError('CONTENT_POLICY', 'Your research prompt was rejected by content policy.');
+  }
+  if (lower.includes('rate') && lower.includes('limit')) {
+    const retryMatch = msg.match(/retry after (\d+)/i);
+    return createError(
+      'RATE_LIMIT',
+      'Rate limit exceeded for Deep Research.',
+      retryMatch ? Number.parseInt(retryMatch[1], 10) : 60
+    );
+  }
+  if (lower.includes('api key') || lower.includes('unauthorized') || lower.includes('authentication')) {
+    return createError('AUTHENTICATION', 'Google authentication failed.');
+  }
+  return createError('AGENT_FAILURE', `Deep Research failed: ${msg.slice(0, 300)}`);
+}
+
+function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(new Error('aborted'));
+      return;
+    }
+    const t = setTimeout(resolve, ms);
+    signal?.addEventListener(
+      'abort',
+      () => {
+        clearTimeout(t);
+        reject(new Error('aborted'));
+      },
+      { once: true }
+    );
+  });
+}
+
+const TERMINAL_STATUSES: ReadonlyArray<Interaction['status']> = [
+  'completed',
+  'failed',
+  'cancelled',
+  'incomplete',
+];
+
+/**
+ * Tight polling loop. Returns the terminal Interaction or throws a
+ * DeepResearchError. Extracted from `runDeepResearch` to keep both
+ * functions under the cyclomatic-complexity threshold.
+ */
+async function pollUntilTerminal(
+  client: GoogleGenAI,
+  initial: Interaction,
+  startMs: number,
+  request: DeepResearchRequest
+): Promise<Interaction> {
+  let last: Interaction = initial;
+  while (true) {
+    const elapsedMs = Date.now() - startMs;
+    if (elapsedMs > MAX_RUN_DURATION_MS) {
+      void client.interactions.cancel(last.id).catch(() => {});
+      throw createError(
+        'TIMEOUT',
+        `Deep Research exceeded the ${Math.round(MAX_RUN_DURATION_MS / 60_000)}-minute time limit.`
+      );
+    }
+
+    try {
+      await request.onStatus?.({
+        status: last.status,
+        elapsedSec: Math.floor(elapsedMs / 1_000),
+        message: buildProgressMessage(last.status, Math.floor(elapsedMs / 1_000)),
+      });
+    } catch (err) {
+      // Status callback errors must never interrupt the run.
+      log.warn('onStatus callback threw — continuing', {
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+
+    if (TERMINAL_STATUSES.includes(last.status)) return last;
+
+    try {
+      await sleep(POLL_INTERVAL_MS, request.abortSignal);
+    } catch {
+      throw createError('AGENT_FAILURE', 'Deep Research cancelled by client.');
+    }
+
+    last = await client.interactions.get(last.id);
+  }
+}
+
+/**
+ * Run a Deep Research interaction. Resolves to the final report on success,
+ * throws a DeepResearchError on failure. Caller is responsible for surfacing
+ * status updates to the user via the `onStatus` callback.
+ */
+export async function runDeepResearch(
+  request: DeepResearchRequest
+): Promise<DeepResearchResult> {
+  const requestId = generateRequestId();
+  log.info('Starting Deep Research run', {
+    requestId,
+    modelId: request.modelId,
+    promptLength: request.prompt.length,
+  });
+
+  const apiKey = await Settings.getGoogleAI();
+  if (!apiKey) {
+    throw ErrorFactories.sysConfigurationError('Google API key not configured');
+  }
+
+  const client = new GoogleGenAI({ apiKey });
+  const startMs = Date.now();
+  let interactionId = '';
+
+  try {
+    const initial = await client.interactions.create({
+      input: request.prompt,
+      agent: request.modelId,
+      background: true,
+    });
+    interactionId = initial.id;
+
+    log.info('Deep Research interaction created', {
+      requestId,
+      interactionId,
+      initialStatus: initial.status,
+    });
+
+    // Best-effort cancellation when the HTTP request is aborted.
+    request.abortSignal?.addEventListener(
+      'abort',
+      () => {
+        log.info('Deep Research aborted by client — cancelling upstream', {
+          requestId,
+          interactionId,
+        });
+        void client.interactions.cancel(interactionId).catch((err) => {
+          log.warn('Failed to cancel Deep Research interaction', {
+            interactionId,
+            error: err instanceof Error ? err.message : String(err),
+          });
+        });
+      },
+      { once: true }
+    );
+
+    const last = await pollUntilTerminal(client, initial, startMs, request);
+
+    if (last.status === 'failed' || last.status === 'cancelled') {
+      throw createError(
+        'AGENT_FAILURE',
+        `Deep Research ended with status: ${last.status}.`
+      );
+    }
+
+    const { report, citations } = extractReportAndCitations(last.outputs);
+    const durationMs = Date.now() - startMs;
+
+    log.info('Deep Research completed', {
+      requestId,
+      interactionId,
+      status: last.status,
+      durationMs,
+      reportLength: report.length,
+      citationCount: citations.length,
+    });
+
+    if (!report) {
+      throw createError(
+        'AGENT_FAILURE',
+        'Deep Research returned no report content.'
+      );
+    }
+
+    return { report, citations, interactionId, durationMs };
+  } catch (err) {
+    log.error('Deep Research failed', {
+      requestId,
+      interactionId,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    if (err instanceof Error && 'type' in err) throw err;
+    throw mapInteractionError(err);
+  }
+}
+
+/** Shape used by the chat route's error mapper. Exported for tests. */
+export type { DeepResearchError };

--- a/lib/db/types/jsonb/index.ts
+++ b/lib/db/types/jsonb/index.ts
@@ -47,6 +47,7 @@ export interface NexusCapabilities {
   workspaceTools: boolean;
   codeInterpreter: boolean;
   imageGeneration?: boolean;
+  deepResearch?: boolean;
   /** Allow string indexing for dynamic access */
   [key: string]: boolean | undefined;
 }


### PR DESCRIPTION
## Summary

The model `deep-research-preview-04-2026` (ai_models.id=127, provider=google) was added to the picker but threw **"This model only supports Interactions API."** on every chat request. Deep Research is an *agent* (not a streaming model) that runs through Google's separate Interactions API with a 5–15 minute polling lifecycle.

This adds a new capability-keyed branch alongside the existing image-generation branch in the nexus chat route. **No existing Gemini model is touched** — `gemini-3-flash-preview`, `gemini-3.1-pro-preview`, and `gemini-3.1-flash-image-preview` keep their current capabilities and continue routing through `@ai-sdk/google` → `unifiedStreamingService`.

## Changes

- **`lib/ai/gemini-deep-research-service.ts`** (new) — wraps `@google/genai` Interactions API. Creates a background interaction, polls every 10s until terminal status, extracts the final markdown report + citations, maps Google error shapes onto our existing CONTENT_POLICY / RATE_LIMIT / AUTHENTICATION taxonomy. 25-minute hard timeout. Cancels the upstream interaction on AbortSignal.
- **`app/api/nexus/chat/route.ts`** — adds `handleDeepResearch()` modeled on `handleImageGeneration()`. Long-poll UX: keeps the SSE connection open and emits "Researching… (Nm)" text-deltas every 30s while polling, then emits the final report + citations as one assistant message. New `routeSpecialModel()` helper consolidates the image-gen and deep-research branches so POST cyclomatic complexity stays at the existing baseline (21).
- **`lib/ai/capability-utils.ts`** — adds `deepResearch` / `deep_research` to capability unions + bidirectional snake/camel mapping. Default false.
- **`lib/db/types/jsonb/index.ts`** — adds optional `deepResearch?: boolean` to `NexusCapabilities`.
- **`infra/database/schema/074-deep-research-capability.sql`** (new) — rewrites capabilities for id=127 to `["chat","reasoning","thinking","deep_research"]`. Drops `streaming` (misleading; we long-poll) and `web_search` (implicit in Deep Research; a separate badge would imply a user-toggleable tool).
- **`infra/database/migrations.json`** — appends `074-deep-research-capability.sql`.

## Test plan

- [ ] `bun run typecheck` — clean (verified).
- [ ] `bun run lint` — no new warnings in touched files (verified).
- [ ] Other Gemini models still stream after deploy: send a chat to `gemini-3-flash-preview`, `gemini-3.1-pro-preview`, `gemini-3.1-flash-image-preview`.
- [ ] Pick "Gemini Deep Research (Preview)" → ask a research question → confirm status updates surface during the wait and the final report renders as one assistant message with citations.
- [ ] Hit Stop mid-research → confirm `ai.interactions.cancel(id)` fires and the conversation closes cleanly.
- [ ] Bad API key path → AUTHENTICATION error; quota path → RATE_LIMIT error.

## Out of scope

- Cancel button v2 (deferred). Tab-close mid-research lets upstream run silently until completion or 25-min timeout.
- Migrating any existing Gemini model to the Interactions API.
- `previous_interaction_id` chaining across conversations.