### PR TITLE
fix(guardrails): include account ID in cross-region guardrail profile ARN

### DIFF
--- a/infra/lib/guardrails-stack.ts
+++ b/infra/lib/guardrails-stack.ts
@@ -122,12 +122,13 @@ export class GuardrailsStack extends cdk.Stack {
 
       // Cross-region inference — mandatory when STANDARD tier is enabled.
       // System-defined US guardrail profile routes inference across US regions
-      // for resilience. Account-less ARN (system profile, not user-owned).
+      // for resilience. ARN must include the deploying account ID per the
+      // CFN regex: arn:aws:bedrock:<region>:<account>:guardrail-profile/us.guardrail.v1:0
       // NOTE: The `us.` prefix is intentional — all deployments target US regions.
       // If deploying to a non-US region, this ARN must be updated to the appropriate
       // regional guardrail profile (e.g., `eu.guardrail.v1:0`).
       crossRegionConfig: {
-        guardrailProfileArn: `arn:aws:bedrock:${cdk.Stack.of(this).region}::guardrail-profile/us.guardrail.v1:0`,
+        guardrailProfileArn: `arn:aws:bedrock:${cdk.Stack.of(this).region}:${cdk.Stack.of(this).account}:guardrail-profile/us.guardrail.v1:0`,
       },
 
       // Word policy - PROFANITY managed word list (DISABLED — Issue #763)


### PR DESCRIPTION
## Summary

Follow-up to PR #930. The cross-region guardrail profile ARN added in #930 was account-less (`arn:aws:bedrock:us-east-1::guardrail-profile/us.guardrail.v1:0`), which CloudFormation rejected during deploy:

> Property value does not match pattern: `^arn:aws(-[^:]+)?:bedrock:[a-z0-9-]{1,20}:[0-9]{12}:guardrail-profile/...`

The regex requires a 12-digit account ID. AWS system-defined profiles are usable by any account, but each principal references them with their own account ID prefix.

## Fix

Build the ARN via `cdk.Stack.of(this).account` so it works for both dev and prod accounts without hardcoding.

## Verification

`cdk synth AIStudio-GuardrailsStack-Dev` now emits:
```
GuardrailProfileArn: arn:aws:bedrock:us-east-1:390844780692:guardrail-profile/us.guardrail.v1:0
```
which matches the required CFN pattern.

## Touched files
- `infra/lib/guardrails-stack.ts`

## Test plan
- [x] cdk synth produces ARN matching the regex
- [x] typecheck clean
- [ ] cdk deploy AIStudio-GuardrailsStack-Dev succeeds (post-merge)

Refs #929, follow-up to #930.