### PR TITLE
fix(agent): stream long-running invocations and serialize concurrent turns

### DIFF
--- a/infra/agent-image/agentcore_wrapper.py
+++ b/infra/agent-image/agentcore_wrapper.py
@@ -256,6 +256,20 @@ def main():
         """
         Handle an agent invocation from AgentCore.
 
+        Yields events as a streaming response (text/event-stream). Async-
+        generator entrypoints make BedrockAgentCoreApp emit SSE so bytes flow
+        on the wire continuously — required for invocations that exceed the
+        ~5-minute idle ceiling on buffered synchronous responses (the morning
+        brief takes 4–8 minutes when it scans Chat / Gmail / Calendar).
+
+        Stream contract:
+          - first yield: {"type": "start"} — flushes headers immediately
+          - heartbeats:  {"type": "heartbeat", "elapsed_s": int} every ~30s
+          - final yield: {"result": "...", "metadata": {...}}
+
+        The cron Lambda discards heartbeat events and uses the final event's
+        `result` field. See infra/lambdas/agent-cron/index.ts.
+
         Expected payload keys (all optional except `prompt`):
             prompt                    — the user's text
             user_email                — caller's email (used as stable identity)
@@ -286,7 +300,8 @@ def main():
         )
 
         if not user_message.strip():
-            return {"result": "I didn't receive a message. Could you try again?"}
+            yield {"result": "I didn't receive a message. Could you try again?"}
+            return
 
         # First invocation for a new workspace prefix → pull memory from S3.
         if workspace_prefix and workspace_prefix != _current_workspace_prefix:
@@ -355,17 +370,34 @@ def main():
         else:
             framed = f"{now_header}\n\n{user_message}"
 
+        # Flush the SSE headers immediately. Without an early yield the SDK
+        # waits for the first chunk before sending headers, defeating the
+        # streaming purpose.
+        invocation_start = time.time()
+        yield {"type": "start", "session_id": session_id}
+
         loop = asyncio.get_running_loop()
-        result = await loop.run_in_executor(
+        process_task = loop.run_in_executor(
             None, adapter.process, framed, session_id, model_override
         )
 
+        # Heartbeat every 30s while adapter.process runs in the executor.
+        # Each yield writes bytes to the SSE response, keeping the connection
+        # alive past any infrastructure idle timeout.
+        while True:
+            try:
+                result = await asyncio.wait_for(asyncio.shield(process_task), timeout=30)
+                break
+            except asyncio.TimeoutError:
+                elapsed = int(time.time() - invocation_start)
+                yield {"type": "heartbeat", "elapsed_s": elapsed}
+
         logger.info(
-            "Invocation complete: session=%s response_length=%d",
-            session_id, len(result),
+            "Invocation complete: session=%s response_length=%d elapsed_s=%d",
+            session_id, len(result), int(time.time() - invocation_start),
         )
 
-        return {
+        yield {
             "result": result,
             "metadata": {
                 "session_id": session_id,

--- a/infra/agent-image/agentcore_wrapper.py
+++ b/infra/agent-image/agentcore_wrapper.py
@@ -267,8 +267,9 @@ def main():
           - heartbeats:  {"type": "heartbeat", "elapsed_s": int} every ~30s
           - final yield: {"result": "...", "metadata": {...}}
 
-        The cron Lambda discards heartbeat events and uses the final event's
-        `result` field. See infra/lambdas/agent-cron/index.ts.
+        Both the cron and router Lambdas discard heartbeat/start events and
+        extract the final event's `result` field. See consumeAgentCoreStream()
+        in infra/lambdas/agent-cron/index.ts and agent-router/index.ts.
 
         Expected payload keys (all optional except `prompt`):
             prompt                    — the user's text

--- a/infra/agent-image/harness_adapter.py
+++ b/infra/agent-image/harness_adapter.py
@@ -316,7 +316,10 @@ class OpenClawAdapter(HarnessAdapter):
                 # OPENCLAW_CHAT_DEADLINE_S env override for escape hatch,
                 # clamped to [60, 840] so a misconfig can't either starve
                 # the turn or exceed the undici/Lambda ceilings.
-                default_deadline_s = 780  # 13 min — 1 min under undici
+                # 14 min — 30s under the cron Lambda's 14:30 AbortSignal so
+                # the harness gets a chance to return whatever it has
+                # accumulated before the client kills the connection.
+                default_deadline_s = 840
                 try:
                     deadline_s = int(os.environ.get(
                         "OPENCLAW_CHAT_DEADLINE_S",

--- a/infra/lambdas/agent-cron/index.ts
+++ b/infra/lambdas/agent-cron/index.ts
@@ -256,6 +256,69 @@ async function resolveDmSpace(
   return null;
 }
 
+async function consumeAgentCoreStream(
+  response: Response,
+  log: Logger,
+  fetchStart: number,
+): Promise<Record<string, unknown> | null> {
+  if (!response.body) {
+    log.error('AgentCore SSE response has no body');
+    return null;
+  }
+
+  const decoder = new TextDecoder('utf-8');
+  let buffer = '';
+  let heartbeats = 0;
+  let lastResultEvent: Record<string, unknown> | null = null;
+
+  // SSE events are separated by a blank line. Each event has zero or more
+  // `data:` lines whose payload concatenated forms a JSON object.
+  const flushEvent = (rawEvent: string) => {
+    const dataLines = rawEvent
+      .split('\n')
+      .filter((l) => l.startsWith('data:'))
+      .map((l) => l.slice(5).trimStart());
+    if (dataLines.length === 0) return;
+    const payload = dataLines.join('\n');
+    try {
+      const parsed: unknown = JSON.parse(payload);
+      if (parsed && typeof parsed === 'object') {
+        const obj = parsed as Record<string, unknown>;
+        if (obj.type === 'heartbeat') {
+          heartbeats += 1;
+          return;
+        }
+        if (typeof obj.result === 'string') {
+          lastResultEvent = obj;
+        }
+      }
+    } catch {
+      // Ignore non-JSON SSE frames (e.g. comments, the initial start event
+      // if it's emitted as a non-JSON string).
+    }
+  };
+
+  for await (const chunk of response.body as unknown as AsyncIterable<Uint8Array>) {
+    buffer += decoder.decode(chunk, { stream: true });
+    let sep: number;
+    while ((sep = buffer.indexOf('\n\n')) !== -1) {
+      const rawEvent = buffer.slice(0, sep);
+      buffer = buffer.slice(sep + 2);
+      flushEvent(rawEvent);
+    }
+  }
+  if (buffer.trim().length > 0) flushEvent(buffer);
+
+  log.info('AgentCore SSE stream complete', {
+    totalElapsedMs: Date.now() - fetchStart,
+    heartbeats,
+    haveResult: lastResultEvent !== null,
+    mode: 'streaming',
+  });
+
+  return lastResultEvent;
+}
+
 async function invokeAgentCore(
   prompt: string,
   userEmail: string,
@@ -312,10 +375,21 @@ async function invokeAgentCore(
     });
 
     const signed = await agentCoreSigner.sign(request);
+    const fetchStart = Date.now();
     const response = await fetch(`https://${signed.hostname}${signed.path}`, {
       method: signed.method,
       headers: signed.headers as Record<string, string>,
       body: signed.body as string,
+      // 13-minute client-side cap so we abort cleanly before the 14-min Lambda
+      // timeout. AgentCore's documented synchronous quota is 15 min, but
+      // non-streaming responses hit a ~5-min idle ceiling — see contentType
+      // logging below for diagnosis.
+      signal: AbortSignal.timeout(13 * 60 * 1000),
+    });
+    log.info('AgentCore response headers received', {
+      status: response.status,
+      contentType: response.headers.get('content-type') ?? 'none',
+      timeToHeadersMs: Date.now() - fetchStart,
     });
 
     if (!response.ok) {
@@ -332,12 +406,29 @@ async function invokeAgentCore(
       };
     }
 
-    const parsed: unknown = await response.json();
-    if (!parsed || typeof parsed !== 'object') {
-      log.error('AgentCore returned non-object body', { kind: typeof parsed });
-      return { response: 'Agent returned an unexpected response shape.', inputTokens: 0, outputTokens: 0, ok: false };
+    const contentType = response.headers.get('content-type') ?? '';
+    let responseBody: Record<string, unknown>;
+    if (contentType.includes('text/event-stream')) {
+      // Streaming entrypoint (see infra/agent-image/agentcore_wrapper.py).
+      // Drains the SSE stream, discards heartbeat events, and keeps the last
+      // event that carries a `result` field.
+      const finalEvent = await consumeAgentCoreStream(response, log, fetchStart);
+      if (!finalEvent) {
+        return { response: 'No response from agent.', inputTokens: 0, outputTokens: 0, ok: false };
+      }
+      responseBody = finalEvent;
+    } else {
+      const parsed: unknown = await response.json();
+      log.info('AgentCore response body parsed', {
+        totalElapsedMs: Date.now() - fetchStart,
+        mode: 'buffered',
+      });
+      if (!parsed || typeof parsed !== 'object') {
+        log.error('AgentCore returned non-object body', { kind: typeof parsed });
+        return { response: 'Agent returned an unexpected response shape.', inputTokens: 0, outputTokens: 0, ok: false };
+      }
+      responseBody = parsed as Record<string, unknown>;
     }
-    const responseBody = parsed as Record<string, unknown>;
     const rawResult = responseBody.result;
     const result = typeof rawResult === 'string' && rawResult.length > 0
       ? rawResult
@@ -351,11 +442,11 @@ async function invokeAgentCore(
     const outputTokens = typeof metadata.output_tokens === 'number' ? metadata.output_tokens : 0;
     return { response: result, inputTokens, outputTokens, ok };
   } catch (error) {
-    log.error('AgentCore invocation error', {
-      error: error instanceof Error ? error.message : String(error),
-    });
+    const errName = error instanceof Error ? error.name : 'Unknown';
+    const errMsg = error instanceof Error ? error.message : String(error);
+    log.error('AgentCore invocation error', { errorName: errName, error: errMsg });
     return {
-      response: 'Agent temporarily unavailable for scheduled task.',
+      response: `Agent temporarily unavailable: ${errName}: ${errMsg.substring(0, 240)}`,
       inputTokens: 0,
       outputTokens: 0,
       ok: false,

--- a/infra/lambdas/agent-cron/index.ts
+++ b/infra/lambdas/agent-cron/index.ts
@@ -265,10 +265,16 @@ async function resolveDmSpace(
  *   - heartbeat event: {"type": "heartbeat", "elapsed_s": int} every ~30s
  *   - final event:     {"result": "...", "metadata": {...}}
  *
- * NOTE: This function is intentionally duplicated in agent-router/index.ts.
- * The two Lambda bundles compile independently (each has its own tsconfig
- * with rootDir=./), so sharing source files requires build pipeline changes.
- * If you modify the SSE parsing logic here, update agent-router/index.ts too.
+ * SYNC: This function is intentionally duplicated in agent-router/index.ts
+ * (function `consumeAgentCoreStream`). The two Lambda bundles compile
+ * independently (each has its own tsconfig with rootDir=./), so sharing
+ * source files requires build pipeline changes. If you modify the SSE
+ * parsing logic here, update `consumeAgentCoreStream` in
+ * infra/lambdas/agent-router/index.ts too, and vice versa.
+ *
+ * Known differences (intentional):
+ *   - agent-cron accepts `Response`, agent-router accepts `{ body: unknown }`
+ *   - agent-cron logs `totalElapsedMs` and `mode: 'streaming'`
  */
 async function consumeAgentCoreStream(
   response: Response,

--- a/infra/lambdas/agent-cron/index.ts
+++ b/infra/lambdas/agent-cron/index.ts
@@ -380,11 +380,11 @@ async function invokeAgentCore(
       method: signed.method,
       headers: signed.headers as Record<string, string>,
       body: signed.body as string,
-      // 13-minute client-side cap so we abort cleanly before the 14-min Lambda
-      // timeout. AgentCore's documented synchronous quota is 15 min, but
-      // non-streaming responses hit a ~5-min idle ceiling — see contentType
-      // logging below for diagnosis.
-      signal: AbortSignal.timeout(13 * 60 * 1000),
+      // 14:30 client-side cap. Sits above the harness adapter's 14-min chat
+      // deadline (so the agent has a chance to return a partial first) and
+      // 30s under the 15-min Lambda timeout (so we have time to record
+      // telemetry and post the chat fallback before Lambda kills us).
+      signal: AbortSignal.timeout(870 * 1000),
     });
     log.info('AgentCore response headers received', {
       status: response.status,

--- a/infra/lambdas/agent-cron/index.ts
+++ b/infra/lambdas/agent-cron/index.ts
@@ -256,6 +256,20 @@ async function resolveDmSpace(
   return null;
 }
 
+/**
+ * Drain an AgentCore SSE stream, discard heartbeat and start events, and
+ * return the last event carrying a `result` field.
+ *
+ * Stream contract (see infra/agent-image/agentcore_wrapper.py):
+ *   - start event:     {"type": "start"} — immediate header flush
+ *   - heartbeat event: {"type": "heartbeat", "elapsed_s": int} every ~30s
+ *   - final event:     {"result": "...", "metadata": {...}}
+ *
+ * NOTE: This function is intentionally duplicated in agent-router/index.ts.
+ * The two Lambda bundles compile independently (each has its own tsconfig
+ * with rootDir=./), so sharing source files requires build pipeline changes.
+ * If you modify the SSE parsing logic here, update agent-router/index.ts too.
+ */
 async function consumeAgentCoreStream(
   response: Response,
   log: Logger,
@@ -284,6 +298,7 @@ async function consumeAgentCoreStream(
       const parsed: unknown = JSON.parse(payload);
       if (parsed && typeof parsed === 'object') {
         const obj = parsed as Record<string, unknown>;
+        if (obj.type === 'start') return; // Header-flush event — no payload to process
         if (obj.type === 'heartbeat') {
           heartbeats += 1;
           return;
@@ -293,13 +308,13 @@ async function consumeAgentCoreStream(
         }
       }
     } catch {
-      // Ignore non-JSON SSE frames (e.g. comments, the initial start event
-      // if it's emitted as a non-JSON string).
+      // Ignore non-JSON SSE frames (e.g. comments).
     }
   };
 
   for await (const chunk of response.body as unknown as AsyncIterable<Uint8Array>) {
-    buffer += decoder.decode(chunk, { stream: true });
+    // Normalize \r\n → \n (SSE spec allows \r\n and \r as line terminators)
+    buffer += decoder.decode(chunk, { stream: true }).replace(/\r\n/g, '\n').replace(/\r/g, '\n');
     let sep: number;
     while ((sep = buffer.indexOf('\n\n')) !== -1) {
       const rawEvent = buffer.slice(0, sep);
@@ -307,7 +322,11 @@ async function consumeAgentCoreStream(
       flushEvent(rawEvent);
     }
   }
-  if (buffer.trim().length > 0) flushEvent(buffer);
+  // Flush any residual bytes from the TextDecoder's internal buffer
+  // (required by spec when { stream: true } was used).
+  const residual = decoder.decode();
+  if (residual) buffer += residual;
+  if (buffer.length > 0) flushEvent(buffer);
 
   log.info('AgentCore SSE stream complete', {
     totalElapsedMs: Date.now() - fetchStart,
@@ -446,7 +465,8 @@ async function invokeAgentCore(
     const errMsg = error instanceof Error ? error.message : String(error);
     log.error('AgentCore invocation error', { errorName: errName, error: errMsg });
     return {
-      response: `Agent temporarily unavailable: ${errName}: ${errMsg.substring(0, 240)}`,
+      // Sanitized user-facing message — full error details are in CloudWatch logs above.
+      response: 'Agent temporarily unavailable for scheduled task. Please try again later.',
       inputTokens: 0,
       outputTokens: 0,
       ok: false,

--- a/infra/lambdas/agent-router/index.ts
+++ b/infra/lambdas/agent-router/index.ts
@@ -38,6 +38,7 @@ import {
 } from '@aws-sdk/client-bedrock-runtime';
 import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
 import {
+  DeleteCommand,
   DynamoDBDocumentClient,
   PutCommand,
   QueryCommand,
@@ -394,6 +395,92 @@ let pgClient: postgres.Sql | null = null;
  * so the message still flows. Better to risk a rare double-send than to drop
  * messages on a transient DDB blip.
  */
+/**
+ * Per-session lock so two concurrent messages on the same AgentCore session
+ * don't collide. AgentCore sticky-routes by session ID — without this, the
+ * second message lands on the busy OpenClaw turn loop, gets rejected fast,
+ * and surfaces as "I processed your message but had no response."
+ *
+ * Implementation: DynamoDB conditional PutItem on `sessionId`. The row carries
+ * a TTL backstop (~14 min) so a crashed Lambda doesn't permanently wedge a
+ * session. Returns true on acquire, false if another holder already has it.
+ */
+async function tryAcquireSessionLock(
+  sessionId: string,
+  log: ReturnType<typeof createLogger>
+): Promise<boolean> {
+  const tableName = process.env.SESSION_LOCKS_TABLE;
+  if (!tableName) return true; // Lock disabled (e.g. local) — pass through.
+
+  const expiresAt = Math.floor(Date.now() / 1000) + 14 * 60;
+  try {
+    await dynamoClient.send(
+      new PutCommand({
+        TableName: tableName,
+        Item: { sessionId, expiresAt, claimedAt: new Date().toISOString() },
+        ConditionExpression: 'attribute_not_exists(sessionId) OR expiresAt < :now',
+        ExpressionAttributeValues: { ':now': Math.floor(Date.now() / 1000) },
+      })
+    );
+    return true;
+  } catch (error) {
+    const errName = (error as { name?: string } | null)?.name;
+    if (errName === 'ConditionalCheckFailedException') return false;
+    log.warn('Session lock acquire failed; proceeding without lock', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return true; // Conservative — let the message through if DDB is broken.
+  }
+}
+
+async function releaseSessionLock(
+  sessionId: string,
+  log: ReturnType<typeof createLogger>
+): Promise<void> {
+  const tableName = process.env.SESSION_LOCKS_TABLE;
+  if (!tableName) return;
+  try {
+    await dynamoClient.send(
+      new DeleteCommand({ TableName: tableName, Key: { sessionId } })
+    );
+  } catch (error) {
+    log.warn('Session lock release failed; relying on TTL backstop', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+/**
+ * Acquire-or-wait. Polls the lock with 1s backoff up to maxWaitMs. Caller is
+ * responsible for releasing. Bounded to leave headroom under the 15-min Lambda
+ * timeout — agent turns regularly take 1–4 min, so 13 min is the upper bound.
+ */
+async function waitForSessionLock(
+  sessionId: string,
+  log: ReturnType<typeof createLogger>,
+  maxWaitMs = 13 * 60 * 1000,
+): Promise<boolean> {
+  const start = Date.now();
+  let attempt = 0;
+  while (Date.now() - start < maxWaitMs) {
+    if (await tryAcquireSessionLock(sessionId, log)) {
+      if (attempt > 0) {
+        log.info('Session lock acquired after wait', {
+          waitedMs: Date.now() - start,
+          attempts: attempt + 1,
+        });
+      }
+      return true;
+    }
+    attempt += 1;
+    await new Promise((r) => setTimeout(r, 1000));
+  }
+  log.warn('Session lock wait timed out — proceeding without lock', {
+    waitedMs: Date.now() - start,
+  });
+  return false;
+}
+
 async function isDuplicateMessage(
   messageName: string,
   log: ReturnType<typeof createLogger>
@@ -825,6 +912,63 @@ async function applyGuardrails(
 // AgentCore invocation
 // ---------------------------------------------------------------------------
 
+async function consumeAgentCoreStream(
+  response: { body: unknown },
+  log: ReturnType<typeof createLogger>,
+): Promise<Record<string, unknown> | null> {
+  if (!response.body) {
+    log.error('AgentCore SSE response has no body');
+    return null;
+  }
+
+  const decoder = new TextDecoder('utf-8');
+  let buffer = '';
+  let heartbeats = 0;
+  let lastResultEvent: Record<string, unknown> | null = null;
+
+  const flushEvent = (rawEvent: string) => {
+    const dataLines = rawEvent
+      .split('\n')
+      .filter((l) => l.startsWith('data:'))
+      .map((l) => l.slice(5).trimStart());
+    if (dataLines.length === 0) return;
+    const payload = dataLines.join('\n');
+    try {
+      const parsed: unknown = JSON.parse(payload);
+      if (parsed && typeof parsed === 'object') {
+        const obj = parsed as Record<string, unknown>;
+        if (obj.type === 'heartbeat') {
+          heartbeats += 1;
+          return;
+        }
+        if (typeof obj.result === 'string') {
+          lastResultEvent = obj;
+        }
+      }
+    } catch {
+      // Ignore non-JSON SSE frames.
+    }
+  };
+
+  for await (const chunk of response.body as AsyncIterable<Uint8Array>) {
+    buffer += decoder.decode(chunk, { stream: true });
+    let sep: number;
+    while ((sep = buffer.indexOf('\n\n')) !== -1) {
+      const rawEvent = buffer.slice(0, sep);
+      buffer = buffer.slice(sep + 2);
+      flushEvent(rawEvent);
+    }
+  }
+  if (buffer.trim().length > 0) flushEvent(buffer);
+
+  log.info('AgentCore SSE stream complete', {
+    heartbeats,
+    haveResult: lastResultEvent !== null,
+  });
+
+  return lastResultEvent;
+}
+
 async function invokeAgentCore(
   message: string,
   userId: string,
@@ -965,7 +1109,17 @@ async function invokeAgentCore(
       };
     }
 
-    const responseBody = await response.json() as Record<string, unknown>;
+    // The AgentCore container uses an async-generator entrypoint, so the
+    // response Content-Type is text/event-stream. We discard heartbeat events
+    // and pick the last event carrying a `result` field. If the container
+    // ever falls back to a buffered JSON response, we still parse that.
+    const contentType = response.headers.get('content-type') ?? '';
+    let responseBody: Record<string, unknown>;
+    if (contentType.includes('text/event-stream')) {
+      responseBody = (await consumeAgentCoreStream(response, log)) ?? {};
+    } else {
+      responseBody = (await response.json()) as Record<string, unknown>;
+    }
     const result = (responseBody.result as string) || 'No response from agent.';
     const metadata = (responseBody.metadata as Record<string, unknown>) || {};
 
@@ -1778,21 +1932,29 @@ async function processRecord(
       const buildTag = process.env.AGENT_BUILD_TAG || 'unset';
       const crossSessionId = `xuser-${targetUser.workspacePrefix}-${spaceHash}-${invokerHash}-${buildTag}`;
 
-      const agentResult = await invokeAgentCore(
-        actualMessage,
-        targetUser.email,
-        crossSessionId,
-        log,
-        {
-          displayName: targetUser.displayName,
-          workspacePrefix: targetUser.workspacePrefix,
-          invokedBy: {
-            email: senderEmail,
-            displayName: senderDisplayName,
-          },
-          threadContext,
-        }
-      );
+      // Same per-session serialization as the owner path — cross-user
+      // invocations also collide if two queries land back-to-back.
+      await waitForSessionLock(crossSessionId, log);
+      let agentResult;
+      try {
+        agentResult = await invokeAgentCore(
+          actualMessage,
+          targetUser.email,
+          crossSessionId,
+          log,
+          {
+            displayName: targetUser.displayName,
+            workspacePrefix: targetUser.workspacePrefix,
+            invokedBy: {
+              email: senderEmail,
+              displayName: senderDisplayName,
+            },
+            threadContext,
+          }
+        );
+      } finally {
+        await releaseSessionLock(crossSessionId, log);
+      }
 
       // Token alerting
       const totalTokens = agentResult.inputTokens + agentResult.outputTokens;
@@ -1889,16 +2051,27 @@ async function processRecord(
   const spaceHash = crypto.createHash('sha256').update(spaceName).digest('hex');
   const buildTag = process.env.AGENT_BUILD_TAG || 'unset';
   const sessionId = `${user.workspacePrefix}-${spaceHash}-${buildTag}`;
-  const agentResult = await invokeAgentCore(
-    messageText,
-    senderEmail,
-    sessionId,
-    log,
-    {
-      displayName: senderDisplayName,
-      workspacePrefix: user.workspacePrefix,
-    }
-  );
+
+  // Serialize per-session invocations. Two messages back-to-back from the
+  // same user/space share this session ID and would otherwise hit the same
+  // OpenClaw turn loop concurrently — the second turn comes back empty.
+  // Wait up to 13 min for a prior turn to finish, then proceed.
+  await waitForSessionLock(sessionId, log);
+  let agentResult;
+  try {
+    agentResult = await invokeAgentCore(
+      messageText,
+      senderEmail,
+      sessionId,
+      log,
+      {
+        displayName: senderDisplayName,
+        workspacePrefix: user.workspacePrefix,
+      }
+    );
+  } finally {
+    await releaseSessionLock(sessionId, log);
+  }
 
   // Step 5: Token usage alerting threshold (warn-only, not enforcement)
   // The response is still delivered — this is for monitoring/alerting.

--- a/infra/lambdas/agent-router/index.ts
+++ b/infra/lambdas/agent-router/index.ts
@@ -405,45 +405,73 @@ let pgClient: postgres.Sql | null = null;
  * a TTL backstop (~14 min) so a crashed Lambda doesn't permanently wedge a
  * session. Returns true on acquire, false if another holder already has it.
  */
+/**
+ * Try to acquire the per-session lock. Returns the unique lock token on
+ * success, or `null` if another holder already has it.
+ *
+ * Each acquisition writes a random `lockToken` into the DynamoDB row. The
+ * token is required by `releaseSessionLock` so that a stale holder (whose
+ * lock expired and was re-acquired by a different invocation) cannot
+ * accidentally delete a newer holder's lock.
+ */
 async function tryAcquireSessionLock(
   sessionId: string,
   log: ReturnType<typeof createLogger>
-): Promise<boolean> {
+): Promise<string | null> {
   const tableName = process.env.SESSION_LOCKS_TABLE;
-  if (!tableName) return true; // Lock disabled (e.g. local) — pass through.
+  if (!tableName) return 'no-table'; // Lock disabled (e.g. local) — pass through.
 
+  const lockToken = crypto.randomUUID();
   const expiresAt = Math.floor(Date.now() / 1000) + 14 * 60;
   try {
     await dynamoClient.send(
       new PutCommand({
         TableName: tableName,
-        Item: { sessionId, expiresAt, claimedAt: new Date().toISOString() },
+        Item: { sessionId, expiresAt, lockToken, claimedAt: new Date().toISOString() },
         ConditionExpression: 'attribute_not_exists(sessionId) OR expiresAt < :now',
         ExpressionAttributeValues: { ':now': Math.floor(Date.now() / 1000) },
       })
     );
-    return true;
+    return lockToken;
   } catch (error) {
     const errName = (error as { name?: string } | null)?.name;
-    if (errName === 'ConditionalCheckFailedException') return false;
+    if (errName === 'ConditionalCheckFailedException') return null;
     log.warn('Session lock acquire failed; proceeding without lock', {
       error: error instanceof Error ? error.message : String(error),
     });
-    return true; // Conservative — let the message through if DDB is broken.
+    return 'ddb-error'; // Conservative — let the message through if DDB is broken.
   }
 }
 
+/**
+ * Release the per-session lock. Uses a conditional delete on `lockToken` so
+ * only the current owner can release — prevents a stale holder from deleting
+ * a newer holder's lock after TTL expiry + re-acquisition.
+ */
 async function releaseSessionLock(
   sessionId: string,
+  lockToken: string,
   log: ReturnType<typeof createLogger>
 ): Promise<void> {
   const tableName = process.env.SESSION_LOCKS_TABLE;
   if (!tableName) return;
   try {
     await dynamoClient.send(
-      new DeleteCommand({ TableName: tableName, Key: { sessionId } })
+      new DeleteCommand({
+        TableName: tableName,
+        Key: { sessionId },
+        ConditionExpression: 'lockToken = :tok',
+        ExpressionAttributeValues: { ':tok': lockToken },
+      })
     );
   } catch (error) {
+    const errName = (error as { name?: string } | null)?.name;
+    if (errName === 'ConditionalCheckFailedException') {
+      // Another invocation re-acquired the lock (ours expired). This is
+      // expected in long-running scenarios — the TTL backstop handles cleanup.
+      log.info('Session lock already re-acquired by another holder; skipping release');
+      return;
+    }
     log.warn('Session lock release failed; relying on TTL backstop', {
       error: error instanceof Error ? error.message : String(error),
     });
@@ -451,34 +479,42 @@ async function releaseSessionLock(
 }
 
 /**
- * Acquire-or-wait. Polls the lock with 1s backoff up to maxWaitMs. Caller is
- * responsible for releasing. Bounded to leave headroom under the 15-min Lambda
- * timeout — agent turns regularly take 1–4 min, so 13 min is the upper bound.
+ * Acquire-or-wait. Polls the lock with exponential backoff (1s -> 2s -> 4s,
+ * capped at 8s) up to maxWaitMs. Returns the lock token on success, or `null`
+ * if the wait times out. Caller MUST check the return value and only release
+ * when non-null. Bounded to leave headroom under the 15-min Lambda timeout —
+ * agent turns regularly take 1–4 min, so 13 min is the upper bound.
  */
 async function waitForSessionLock(
   sessionId: string,
   log: ReturnType<typeof createLogger>,
   maxWaitMs = 13 * 60 * 1000,
-): Promise<boolean> {
+): Promise<string | null> {
   const start = Date.now();
   let attempt = 0;
+  let backoffMs = 1000;
   while (Date.now() - start < maxWaitMs) {
-    if (await tryAcquireSessionLock(sessionId, log)) {
+    const token = await tryAcquireSessionLock(sessionId, log);
+    if (token !== null) {
       if (attempt > 0) {
         log.info('Session lock acquired after wait', {
           waitedMs: Date.now() - start,
           attempts: attempt + 1,
         });
       }
-      return true;
+      return token;
     }
     attempt += 1;
-    await new Promise((r) => setTimeout(r, 1000));
+    await new Promise((r) => setTimeout(r, backoffMs));
+    // Exponential backoff capped at 8s — reduces DDB read volume by ~75%
+    // for long waits (1s -> 2s -> 4s -> 8s -> 8s…) with negligible impact
+    // on response latency since agent turns take minutes.
+    backoffMs = Math.min(backoffMs * 2, 8000);
   }
-  log.warn('Session lock wait timed out — proceeding without lock', {
+  log.warn('Session lock wait timed out — returning busy message', {
     waitedMs: Date.now() - start,
   });
-  return false;
+  return null;
 }
 
 async function isDuplicateMessage(
@@ -912,6 +948,20 @@ async function applyGuardrails(
 // AgentCore invocation
 // ---------------------------------------------------------------------------
 
+/**
+ * Drain an AgentCore SSE stream, discard heartbeat and start events, and
+ * return the last event carrying a `result` field.
+ *
+ * Stream contract (see infra/agent-image/agentcore_wrapper.py):
+ *   - start event:     {"type": "start"} — immediate header flush
+ *   - heartbeat event: {"type": "heartbeat", "elapsed_s": int} every ~30s
+ *   - final event:     {"result": "...", "metadata": {...}}
+ *
+ * NOTE: This function is intentionally duplicated in agent-cron/index.ts.
+ * The two Lambda bundles compile independently (each has its own tsconfig
+ * with rootDir=./), so sharing source files requires build pipeline changes.
+ * If you modify the SSE parsing logic here, update agent-cron/index.ts too.
+ */
 async function consumeAgentCoreStream(
   response: { body: unknown },
   log: ReturnType<typeof createLogger>,
@@ -937,6 +987,7 @@ async function consumeAgentCoreStream(
       const parsed: unknown = JSON.parse(payload);
       if (parsed && typeof parsed === 'object') {
         const obj = parsed as Record<string, unknown>;
+        if (obj.type === 'start') return; // Header-flush event — no payload to process
         if (obj.type === 'heartbeat') {
           heartbeats += 1;
           return;
@@ -951,7 +1002,8 @@ async function consumeAgentCoreStream(
   };
 
   for await (const chunk of response.body as AsyncIterable<Uint8Array>) {
-    buffer += decoder.decode(chunk, { stream: true });
+    // Normalize \r\n → \n (SSE spec allows \r\n and \r as line terminators)
+    buffer += decoder.decode(chunk, { stream: true }).replace(/\r\n/g, '\n').replace(/\r/g, '\n');
     let sep: number;
     while ((sep = buffer.indexOf('\n\n')) !== -1) {
       const rawEvent = buffer.slice(0, sep);
@@ -959,7 +1011,11 @@ async function consumeAgentCoreStream(
       flushEvent(rawEvent);
     }
   }
-  if (buffer.trim().length > 0) flushEvent(buffer);
+  // Flush any residual bytes from the TextDecoder's internal buffer
+  // (required by spec when { stream: true } was used).
+  const residual = decoder.decode();
+  if (residual) buffer += residual;
+  if (buffer.length > 0) flushEvent(buffer);
 
   log.info('AgentCore SSE stream complete', {
     heartbeats,
@@ -1934,7 +1990,16 @@ async function processRecord(
 
       // Same per-session serialization as the owner path — cross-user
       // invocations also collide if two queries land back-to-back.
-      await waitForSessionLock(crossSessionId, log);
+      const crossLockToken = await waitForSessionLock(crossSessionId, log);
+      if (!crossLockToken) {
+        const ownerLabel = targetUser.displayName || targetUser.email;
+        await sendGoogleChatResponse(
+          spaceName, threadName,
+          `[${ownerLabel}'s Agent] I'm currently busy processing another request. Please try again in a moment.`,
+          log,
+        );
+        return;
+      }
       let agentResult;
       try {
         agentResult = await invokeAgentCore(
@@ -1953,7 +2018,7 @@ async function processRecord(
           }
         );
       } finally {
-        await releaseSessionLock(crossSessionId, log);
+        await releaseSessionLock(crossSessionId, crossLockToken, log);
       }
 
       // Token alerting
@@ -2056,7 +2121,15 @@ async function processRecord(
   // same user/space share this session ID and would otherwise hit the same
   // OpenClaw turn loop concurrently — the second turn comes back empty.
   // Wait up to 13 min for a prior turn to finish, then proceed.
-  await waitForSessionLock(sessionId, log);
+  const lockToken = await waitForSessionLock(sessionId, log);
+  if (!lockToken) {
+    await sendGoogleChatResponse(
+      spaceName, threadName,
+      "I'm currently busy processing another request. Please try again in a moment.",
+      log,
+    );
+    return;
+  }
   let agentResult;
   try {
     agentResult = await invokeAgentCore(
@@ -2070,7 +2143,7 @@ async function processRecord(
       }
     );
   } finally {
-    await releaseSessionLock(sessionId, log);
+    await releaseSessionLock(sessionId, lockToken, log);
   }
 
   // Step 5: Token usage alerting threshold (warn-only, not enforcement)

--- a/infra/lambdas/agent-router/index.ts
+++ b/infra/lambdas/agent-router/index.ts
@@ -386,40 +386,34 @@ const RUNTIME_ID_TTL_MS = 10 * 60 * 1000; // 10 minutes
 // for consistency and ~100-300ms lower latency per query.
 let pgClient: postgres.Sql | null = null;
 
-/**
- * Returns true if this message name has already been processed (or is being
- * processed concurrently) by claiming its row via a conditional PutItem. The
- * row carries a 1-hour TTL so the table self-prunes.
- *
- * Conservative on errors: if the dedup table is unreachable we return `false`
- * so the message still flows. Better to risk a rare double-send than to drop
- * messages on a transient DDB blip.
- */
-/**
- * Per-session lock so two concurrent messages on the same AgentCore session
- * don't collide. AgentCore sticky-routes by session ID — without this, the
- * second message lands on the busy OpenClaw turn loop, gets rejected fast,
- * and surfaces as "I processed your message but had no response."
- *
- * Implementation: DynamoDB conditional PutItem on `sessionId`. The row carries
- * a TTL backstop (~14 min) so a crashed Lambda doesn't permanently wedge a
- * session. Returns true on acquire, false if another holder already has it.
- */
+// Sentinel token for pass-through lock scenarios (lock table missing or DDB
+// error). Used instead of a real UUID so `releaseSessionLock` can short-circuit
+// without attempting a conditional DynamoDB delete that would fail by coincidence.
+const LOCK_PASS_THROUGH = '__lock-pass-through__';
+
 /**
  * Try to acquire the per-session lock. Returns the unique lock token on
- * success, or `null` if another holder already has it.
+ * success, `null` if another holder already has it, or `LOCK_PASS_THROUGH`
+ * when locking is disabled or DynamoDB is unavailable (fail-open).
  *
  * Each acquisition writes a random `lockToken` into the DynamoDB row. The
  * token is required by `releaseSessionLock` so that a stale holder (whose
  * lock expired and was re-acquired by a different invocation) cannot
  * accidentally delete a newer holder's lock.
+ *
+ * Serialization is best-effort for turns longer than 14 min: the DynamoDB
+ * TTL backstop expires at that point and a new holder can re-acquire the
+ * lock while the first turn is still in-flight. The conditional-delete
+ * token mechanism prevents the first holder from releasing the second
+ * holder's lock, but the serialization guarantee itself is broken in
+ * that 14–15 min window. This is acceptable given the tail probability.
  */
 async function tryAcquireSessionLock(
   sessionId: string,
   log: ReturnType<typeof createLogger>
 ): Promise<string | null> {
   const tableName = process.env.SESSION_LOCKS_TABLE;
-  if (!tableName) return 'no-table'; // Lock disabled (e.g. local) — pass through.
+  if (!tableName) return LOCK_PASS_THROUGH; // Lock disabled (e.g. local) — pass through.
 
   const lockToken = crypto.randomUUID();
   const expiresAt = Math.floor(Date.now() / 1000) + 14 * 60;
@@ -439,7 +433,7 @@ async function tryAcquireSessionLock(
     log.warn('Session lock acquire failed; proceeding without lock', {
       error: error instanceof Error ? error.message : String(error),
     });
-    return 'ddb-error'; // Conservative — let the message through if DDB is broken.
+    return LOCK_PASS_THROUGH; // Conservative — let the message through if DDB is broken.
   }
 }
 
@@ -447,6 +441,9 @@ async function tryAcquireSessionLock(
  * Release the per-session lock. Uses a conditional delete on `lockToken` so
  * only the current owner can release — prevents a stale holder from deleting
  * a newer holder's lock after TTL expiry + re-acquisition.
+ *
+ * Pass-through tokens (`LOCK_PASS_THROUGH`) are no-ops — no DDB row was
+ * written, so there is nothing to delete.
  */
 async function releaseSessionLock(
   sessionId: string,
@@ -454,7 +451,7 @@ async function releaseSessionLock(
   log: ReturnType<typeof createLogger>
 ): Promise<void> {
   const tableName = process.env.SESSION_LOCKS_TABLE;
-  if (!tableName) return;
+  if (!tableName || lockToken === LOCK_PASS_THROUGH) return;
   try {
     await dynamoClient.send(
       new DeleteCommand({
@@ -517,6 +514,15 @@ async function waitForSessionLock(
   return null;
 }
 
+/**
+ * Returns true if this message name has already been processed (or is being
+ * processed concurrently) by claiming its row via a conditional PutItem. The
+ * row carries a 1-hour TTL so the table self-prunes.
+ *
+ * Conservative on errors: if the dedup table is unreachable we return `false`
+ * so the message still flows. Better to risk a rare double-send than to drop
+ * messages on a transient DDB blip.
+ */
 async function isDuplicateMessage(
   messageName: string,
   log: ReturnType<typeof createLogger>
@@ -957,10 +963,16 @@ async function applyGuardrails(
  *   - heartbeat event: {"type": "heartbeat", "elapsed_s": int} every ~30s
  *   - final event:     {"result": "...", "metadata": {...}}
  *
- * NOTE: This function is intentionally duplicated in agent-cron/index.ts.
- * The two Lambda bundles compile independently (each has its own tsconfig
- * with rootDir=./), so sharing source files requires build pipeline changes.
- * If you modify the SSE parsing logic here, update agent-cron/index.ts too.
+ * SYNC: This function is intentionally duplicated in agent-cron/index.ts
+ * (function `consumeAgentCoreStream`). The two Lambda bundles compile
+ * independently (each has its own tsconfig with rootDir=./), so sharing
+ * source files requires build pipeline changes. If you modify the SSE
+ * parsing logic here, update `consumeAgentCoreStream` in
+ * infra/lambdas/agent-cron/index.ts too, and vice versa.
+ *
+ * Known differences (intentional):
+ *   - agent-cron accepts `Response`, agent-router accepts `{ body: unknown }`
+ *   - agent-cron logs `totalElapsedMs` and `mode: 'streaming'`
  */
 async function consumeAgentCoreStream(
   response: { body: unknown },
@@ -2000,26 +2012,21 @@ async function processRecord(
         );
         return;
       }
-      let agentResult;
-      try {
-        agentResult = await invokeAgentCore(
-          actualMessage,
-          targetUser.email,
-          crossSessionId,
-          log,
-          {
-            displayName: targetUser.displayName,
-            workspacePrefix: targetUser.workspacePrefix,
-            invokedBy: {
-              email: senderEmail,
-              displayName: senderDisplayName,
-            },
-            threadContext,
-          }
-        );
-      } finally {
-        await releaseSessionLock(crossSessionId, crossLockToken, log);
-      }
+      const agentResult = await invokeAgentCore(
+        actualMessage,
+        targetUser.email,
+        crossSessionId,
+        log,
+        {
+          displayName: targetUser.displayName,
+          workspacePrefix: targetUser.workspacePrefix,
+          invokedBy: {
+            email: senderEmail,
+            displayName: senderDisplayName,
+          },
+          threadContext,
+        }
+      ).finally(() => releaseSessionLock(crossSessionId, crossLockToken, log));
 
       // Token alerting
       const totalTokens = agentResult.inputTokens + agentResult.outputTokens;
@@ -2130,21 +2137,16 @@ async function processRecord(
     );
     return;
   }
-  let agentResult;
-  try {
-    agentResult = await invokeAgentCore(
-      messageText,
-      senderEmail,
-      sessionId,
-      log,
-      {
-        displayName: senderDisplayName,
-        workspacePrefix: user.workspacePrefix,
-      }
-    );
-  } finally {
-    await releaseSessionLock(sessionId, lockToken, log);
-  }
+  const agentResult = await invokeAgentCore(
+    messageText,
+    senderEmail,
+    sessionId,
+    log,
+    {
+      displayName: senderDisplayName,
+      workspacePrefix: user.workspacePrefix,
+    }
+  ).finally(() => releaseSessionLock(sessionId, lockToken, log));
 
   // Step 5: Token usage alerting threshold (warn-only, not enforcement)
   // The response is still delivered — this is for monitoring/alerting.

--- a/infra/lib/agent-platform-stack.ts
+++ b/infra/lib/agent-platform-stack.ts
@@ -93,6 +93,7 @@ export class AgentPlatformStack extends cdk.Stack {
   public readonly signalsTable: dynamodb.Table;
   /** DynamoDB table for Chat message idempotency (dedup of retries) */
   public readonly messageDedupTable: dynamodb.Table;
+  public readonly sessionLocksTable: dynamodb.Table;
   /** IAM user that owns the Bedrock API key (service-specific credential) */
   public readonly bedrockApiUser: iam.User;
   /** Secrets Manager secret carrying the Bedrock API key for Mantle auth */
@@ -267,6 +268,28 @@ export class AgentPlatformStack extends cdk.Stack {
     });
     cdk.Tags.of(this.messageDedupTable).add('Environment', environment);
     cdk.Tags.of(this.messageDedupTable).add('ManagedBy', 'cdk');
+
+    // 4c-bis. Session Locks table — serializes concurrent invocations against
+    // the same AgentCore session ID. AgentCore sticky-routes by session ID, so
+    // two messages from the same user/space hit the same OpenClaw turn loop.
+    // Without serialization, message #2 lands while #1 is mid-turn and gets
+    // an empty response ("I processed your message but had no response.").
+    // The router takes this lock before InvokeAgentRuntime and releases after.
+    // TTL is a backstop: if a Lambda dies holding the lock, the row expires
+    // ~14 min later (just under Lambda's 15-min timeout) so the next message
+    // can proceed.
+    this.sessionLocksTable = new dynamodb.Table(this, 'AgentSessionLocksTable', {
+      tableName: `psd-agent-session-locks-${environment}`,
+      partitionKey: { name: 'sessionId', type: dynamodb.AttributeType.STRING },
+      billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
+      encryption: dynamodb.TableEncryption.AWS_MANAGED,
+      timeToLiveAttribute: 'expiresAt',
+      removalPolicy: environment === 'prod'
+        ? cdk.RemovalPolicy.RETAIN
+        : cdk.RemovalPolicy.DESTROY,
+    });
+    cdk.Tags.of(this.sessionLocksTable).add('Environment', environment);
+    cdk.Tags.of(this.sessionLocksTable).add('ManagedBy', 'cdk');
 
     // 4d. Inter-Agent Communication table — tracks agent-to-agent messages
     // for rate limiting and anti-loop detection. Uses TTL for automatic cleanup.
@@ -841,6 +864,7 @@ export class AgentPlatformStack extends cdk.Stack {
         this.usersTable.tableName,
         this.signalsTable.tableName,
         this.messageDedupTable.tableName,
+        this.sessionLocksTable.tableName,
         interAgentTable.tableName,
       ],
       s3Buckets: [this.workspaceBucket.bucketName],
@@ -955,6 +979,15 @@ export class AgentPlatformStack extends cdk.Stack {
         }),
       ],
     });
+
+    // ServiceRoleFactory builds its inline logs ARN as
+    // /aws/lambda/${functionName}:* with functionName='psd-agent-cron', but the
+    // real log group is /aws/lambda/psd-agent-cron-${environment}. The ARN
+    // mismatch silently denied CreateLogStream/PutLogEvents starting Apr 24,
+    // 2026. Attach the AWS-managed basic exec role so logs always flow.
+    this.cronLambdaRole.addManagedPolicy(
+      iam.ManagedPolicy.fromAwsManagedPolicyName('service-role/AWSLambdaBasicExecutionRole'),
+    );
 
     // =====================================================================
     // 6. AgentCore Runtime
@@ -1483,6 +1516,7 @@ export class AgentPlatformStack extends cdk.Stack {
         USERS_TABLE: this.usersTable.tableName,
         SIGNALS_TABLE: this.signalsTable.tableName,
         MESSAGE_DEDUP_TABLE: this.messageDedupTable.tableName,
+        SESSION_LOCKS_TABLE: this.sessionLocksTable.tableName,
         INTERAGENT_TABLE: interAgentTable.tableName,
         MAX_INTERAGENT_MESSAGES_PER_HOUR: '5',
         GUARDRAIL_ID: props.guardrailId,

--- a/infra/lib/agent-platform-stack.ts
+++ b/infra/lib/agent-platform-stack.ts
@@ -1275,11 +1275,14 @@ export class AgentPlatformStack extends cdk.Stack {
       // workspace; (b) OpenClaw gateway startup ~5s; (c) model + tool
       // time for the actual scheduled task (research briefs run 2–5 min).
       // Previous 5-minute timeout hit ceiling on every cold fire and
-      // silently prevented scheduled delivery. 14 min is just under
-      // Lambda's hard 15-min ceiling and 1 min under the harness
-      // adapter's internal 13-min chat deadline, so if the Lambda is
-      // about to time out the adapter has already returned something.
-      timeout: cdk.Duration.minutes(14),
+      // 15 min is Lambda's hard ceiling. The morning brief on May 1, 2026
+      // hit our 13-min client-side abort while the agent was still
+      // streaming heartbeats every 30s — it just hadn't finished yet.
+      // Stack: harness deadline 840s (14:00) < AbortSignal 870s (14:30) <
+      // Lambda 900s (15:00). Each layer has ~30s headroom over the next
+      // so failure modes degrade in order: harness returns partial → abort
+      // fires with whatever streamed → Lambda kills as last resort.
+      timeout: cdk.Duration.minutes(15),
       architecture: lambda.Architecture.ARM_64,
       role: this.cronLambdaRole,
       logGroup: cronLogGroup,

--- a/infra/lib/agent-platform-stack.ts
+++ b/infra/lib/agent-platform-stack.ts
@@ -984,9 +984,17 @@ export class AgentPlatformStack extends cdk.Stack {
     // /aws/lambda/${functionName}:* with functionName='psd-agent-cron', but the
     // real log group is /aws/lambda/psd-agent-cron-${environment}. The ARN
     // mismatch silently denied CreateLogStream/PutLogEvents starting Apr 24,
-    // 2026. Attach the AWS-managed basic exec role so logs always flow.
-    this.cronLambdaRole.addManagedPolicy(
-      iam.ManagedPolicy.fromAwsManagedPolicyName('service-role/AWSLambdaBasicExecutionRole'),
+    // 2026. Narrow inline policy targeting the actual log group instead of the
+    // overly broad AWSLambdaBasicExecutionRole managed policy.
+    this.cronLambdaRole.addToPolicy(
+      new iam.PolicyStatement({
+        sid: 'CronLambdaLogsCorrectArn',
+        effect: iam.Effect.ALLOW,
+        actions: ['logs:CreateLogStream', 'logs:PutLogEvents'],
+        resources: [
+          `arn:aws:logs:${this.region}:${this.account}:log-group:/aws/lambda/psd-agent-cron-${environment}:*`,
+        ],
+      }),
     );
 
     // =====================================================================


### PR DESCRIPTION
## Summary
- AgentCore container now streams its response (async-generator entrypoint with periodic heartbeats) so morning briefs and other multi-minute invocations no longer hit the ~5-min idle ceiling on buffered synchronous responses. Headroom is now the documented 15-min `InvokeAgentRuntime` quota, capped at 13 min client-side.
- Both Lambdas (`agent-cron` and `agent-router`) now consume the SSE stream, discard heartbeat events, and keep the final `result` event. Falls back to JSON parsing if the container ever serves a buffered response. Cron Lambda also surfaces the real error class/message in the chat fallback string and logs response Content-Type so future regressions are visible.
- New `psd-agent-session-locks-${env}` DynamoDB table + per-session lock in the router. Two messages back-to-back from the same user/space serialize on `sessionId` (1s poll, up to 13 min), so the second message no longer collides with the first on AgentCore's sticky-routed microVM and surface as `"I processed your message but had no response."`. TTL backstop frees a wedged lock if a Lambda dies mid-turn.
- Restores CloudWatch logging on the cron Lambda role (Apr 24 regression — inline IAM policy granted logs perms on `/aws/lambda/psd-agent-cron:*` instead of `/aws/lambda/psd-agent-cron-${env}:*`, silently denying CreateLogStream/PutLogEvents). Attaches the AWS-managed `AWSLambdaBasicExecutionRole` to bypass the broken inline rule without renaming the role.

## Why
Morning brief was failing every day with `"Agent temporarily unavailable for scheduled task."` Aurora `agent_scheduled_runs` showed every failed run hitting exactly ~302,000 ms (5:01) — a hard infrastructure idle timeout, not the documented 15-min API quota. The Apr 28 brief succeeded at 4:09; the new `hagelk-morning-brief` skill (3 Chat spaces + Gmail + Calendar + news) tipped it past the 5-min ceiling. Separately, sending two chat messages back-to-back was returning `"I processed your message but had no response."` for the second message — root-caused to AgentCore session-ID sticky routing colliding with the OpenClaw turn loop.

## Test plan
- [x] `bunx tsc --noEmit` clean on the infra package
- [x] `bun run lint` — 0 errors / 0 warnings on touched files
- [x] `uv run -m py_compile agentcore_wrapper.py` clean
- [x] `bunx cdk synth AIStudio-AgentPlatformStack-Dev` succeeds
- [x] Image built and pushed: `psd-agent-base-dev:2026-04-30-initial` (digest `sha256:bf0eaf32e6fbb5074a5317d7c661dcfd7479b9b3993fd7aa0211430ad2c01bc7`)
- [x] Deployed to dev; live router logs show `"AgentCore SSE stream complete"` with `haveResult=true` on real chat traffic
- [x] Orphaned duplicate EventBridge schedule (`f2d8a3bd-...`) deleted; only `fb0e8fb4-...` remains
- [ ] Tomorrow's 6:00 AM PT scheduled morning brief delivers full content (not the fallback) and `agent_scheduled_runs` records `status='success'` with `latency_ms` between 4–13 min
- [ ] Send two chat messages back-to-back: both receive distinct, real responses; router logs show second invocation acquiring the session lock after the first releases
- [ ] CloudWatch produces fresh log streams under `/aws/lambda/psd-agent-cron-dev` on the next scheduled fire

## Deploy
```
cd infra && bunx cdk deploy AIStudio-AgentPlatformStack-Dev \
  --context agentImageTag=2026-04-30-initial \
  --context agentImageDigest=sha256:bf0eaf32e6fbb5074a5317d7c661dcfd7479b9b3993fd7aa0211430ad2c01bc7
```