### PR TITLE
feat(agent-skills): two starter skills + capability gate (psd-freshservice, psd-image-gen)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,9 @@ next-env.d.ts
 # Python
 __pycache__/
 
+# CDK Lambda bundling artifacts
+infra/database/lambda/package-lock.json
+
 # Claude agent internal state
 .claude/agent-memory/
 docs/learnings/.evolve-state.json

--- a/.gitignore
+++ b/.gitignore
@@ -56,8 +56,8 @@ next-env.d.ts
 # Python
 __pycache__/
 
-# CDK Lambda bundling artifacts
-infra/database/lambda/package-lock.json
+# CDK Lambda bundling artifacts (covers database/lambda and any future lambdas)
+infra/**/package-lock.json
 
 # Claude agent internal state
 .claude/agent-memory/

--- a/infra/agent-image/Dockerfile
+++ b/infra/agent-image/Dockerfile
@@ -128,7 +128,22 @@ COPY openclaw.json /home/node/.openclaw/openclaw.json
 # NOTE: Do NOT put HTML comments or TODO notes in this file — they are
 # visible to the LLM. Keep roadmap notes here in the Dockerfile instead.
 # TODO(phase-2): Add Google Calendar and Gmail read-only tool access to the agent.
-COPY SOUL.md /home/node/.openclaw/SOUL.md
+#
+# Tier-1 enforcement: SOUL.md alone is auto-loaded, but the rules in
+# psd-rules SKILL.md are NOT auto-injected by OpenClaw — the model only
+# sees a Tier-2 catalog stub for any skill it has not explicitly loaded.
+# That meant the "non-negotiable" rules were never actually present in
+# the system prompt and the agent ignored them (observed 2026-05-03).
+# At build time we strip psd-rules' YAML frontmatter and append the body
+# to SOUL.md so the rules ARE in the system prompt every turn. The
+# canonical edit point stays `skills/psd-rules/SKILL.md`.
+COPY SOUL.md /tmp/SOUL.preamble.md
+COPY skills/psd-rules/SKILL.md /tmp/psd-rules.SKILL.md
+RUN awk 'BEGIN{f=0} /^---[[:space:]]*$/{f++; next} f>=2{print}' /tmp/psd-rules.SKILL.md > /tmp/psd-rules.body.md && \
+    cat /tmp/SOUL.preamble.md > /home/node/.openclaw/SOUL.md && \
+    printf '\n\n---\n\n# Operating Rules (from psd-rules)\n\n_The following rules are concatenated from `skills/psd-rules/SKILL.md` at container build time so they are guaranteed to appear in every turn\xe2\x80\x99s system prompt. Edit them in that file, not here._\n\n' >> /home/node/.openclaw/SOUL.md && \
+    cat /tmp/psd-rules.body.md >> /home/node/.openclaw/SOUL.md && \
+    rm -f /tmp/SOUL.preamble.md /tmp/psd-rules.SKILL.md /tmp/psd-rules.body.md
 # OpenClaw also auto-loads IDENTITY.md, USER.md, MEMORY.md (and AGENTS.md,
 # TOOLS.md, HEARTBEAT.md, BOOTSTRAP.md) when present. We seed empty stubs so
 # every brand-new user workspace boots with the same scaffolding; the agent

--- a/infra/agent-image/Dockerfile
+++ b/infra/agent-image/Dockerfile
@@ -153,15 +153,27 @@ RUN awk 'BEGIN{f=0} /^---[[:space:]]*$/{f++; next} f>=2{print}' /tmp/psd-rules.S
 COPY IDENTITY.md /home/node/.openclaw/IDENTITY.md
 COPY USER.md /home/node/.openclaw/USER.md
 COPY MEMORY.md /home/node/.openclaw/MEMORY.md
-# Install OpenClaw skills — each skill is a directory under
-# /home/node/.openclaw/skills/ loaded via openclaw.json skills.load.extraDirs.
-# Install dependencies at build time so the agent container starts fast.
-COPY skills /home/node/.openclaw/skills
-RUN cd /home/node/.openclaw/skills/psd-schedules && npm install --omit=dev --no-audit --no-fund
-RUN cd /home/node/.openclaw/skills/psd-credentials && npm install --omit=dev --no-audit --no-fund
-RUN cd /home/node/.openclaw/skills/psd-skills-meta && npm install --omit=dev --no-audit --no-fund
-RUN cd /home/node/.openclaw/skills/psd-workspace && npm install --omit=dev --no-audit --no-fund
-RUN cd /home/node/.openclaw/skills/psd-image-gen && npm install --omit=dev --no-audit --no-fund
+# Install OpenClaw skills under /opt/psd-skills (NOT /home/node/.openclaw/).
+# Putting image-bundled skills outside the workspace path is structural —
+# `workspace_sync.py` only round-trips /home/node/.openclaw/, so paths under
+# /opt/ are physically unreachable to S3 sync. Earlier we kept skills under
+# the workspace path and protected them with a `_SKIP_RELATIVE_PREFIXES`
+# allow-list in workspace_sync; that allow-list silently broke when new
+# skills were added (PR #934 — psd-image-gen and psd-freshservice were
+# missing entries, so the agent's runtime edits were synced to S3 and
+# restored on every cold-start, defeating two image rebuilds in a row).
+# Path separation closes that bug class permanently — it is no longer
+# possible for workspace state to override an image-bundled skill, no
+# allow-list maintenance burden.
+#
+# Loaded via openclaw.json skills.load.extraDirs. Install dependencies at
+# build time so the agent container starts fast.
+COPY skills /opt/psd-skills
+RUN cd /opt/psd-skills/psd-schedules && npm install --omit=dev --no-audit --no-fund
+RUN cd /opt/psd-skills/psd-credentials && npm install --omit=dev --no-audit --no-fund
+RUN cd /opt/psd-skills/psd-skills-meta && npm install --omit=dev --no-audit --no-fund
+RUN cd /opt/psd-skills/psd-workspace && npm install --omit=dev --no-audit --no-fund
+RUN cd /opt/psd-skills/psd-image-gen && npm install --omit=dev --no-audit --no-fund
 # psd-freshservice has zero npm dependencies (native fetch + child_process only).
 
 # Upstream gws-* skills (#912) — per-API SKILL.md guidance for Gmail, Drive,
@@ -176,9 +188,19 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/* && \
     git clone --depth 1 --branch "v${GWS_VERSION}" \
       https://github.com/googleworkspace/cli /tmp/gws-repo && \
-    cp -r /tmp/gws-repo/skills/gws-* /home/node/.openclaw/skills/ && \
+    cp -r /tmp/gws-repo/skills/gws-* /opt/psd-skills/ && \
     rm -rf /tmp/gws-repo && \
     apt-get purge -y git && apt-get autoremove -y
+
+# Defense-in-depth: lock /opt/psd-skills to root-owned and read-only AFTER
+# all installs complete. The container runs as the `node` user, so root
+# ownership plus `a-w` means the agent process literally cannot edit a
+# bundled skill (EACCES on write/chmod attempts). Combined with the path
+# separation above, this is belt-and-suspenders against the regression
+# observed 2026-05-03. User-authored draft skills go through
+# psd-skills-meta and are uploaded to S3 directly — no local-FS write
+# path is needed for legitimate work.
+RUN chown -R root:root /opt/psd-skills && chmod -R a-w /opt/psd-skills
 
 # Defense-in-depth: disable OpenClaw's cron subsystem via both config
 # (cron.enabled: false in openclaw.json) and env var (OPENCLAW_SKIP_CRON=1)

--- a/infra/agent-image/Dockerfile
+++ b/infra/agent-image/Dockerfile
@@ -146,6 +146,8 @@ RUN cd /home/node/.openclaw/skills/psd-schedules && npm install --omit=dev --no-
 RUN cd /home/node/.openclaw/skills/psd-credentials && npm install --omit=dev --no-audit --no-fund
 RUN cd /home/node/.openclaw/skills/psd-skills-meta && npm install --omit=dev --no-audit --no-fund
 RUN cd /home/node/.openclaw/skills/psd-workspace && npm install --omit=dev --no-audit --no-fund
+RUN cd /home/node/.openclaw/skills/psd-image-gen && npm install --omit=dev --no-audit --no-fund
+# psd-freshservice has zero npm dependencies (native fetch + child_process only).
 
 # Upstream gws-* skills (#912) — per-API SKILL.md guidance for Gmail, Drive,
 # Docs, Sheets, Slides, Forms, Tasks, Calendar, Chat, Meet, Contacts, etc.

--- a/infra/agent-image/SOUL.md
+++ b/infra/agent-image/SOUL.md
@@ -51,6 +51,20 @@ When a skill requires an API key, secret, or credential:
 3. Never log or echo a credential value — not to user, file, or stdout.
 4. If a credential is not provisioned, use `credentials.request_new("name", "reason")`. Do not ask the user to paste a raw key in chat.
 
+## Skills are the only path — do not improvise
+
+If a skill exists for a task, you call that skill verbatim. You do not write Bash, Node, or Python to replicate what the skill does, and you do not "wrap", "post-process", or "fix" the skill's output.
+
+In particular for `psd-image-gen`:
+
+- For **any** request to generate, draw, illustrate, or "make an image" of anything (infographic, diagram, photo, mockup, icon), call `psd-image-gen/generate.js` and surface its returned `url` to the user *verbatim*. The URL is unsigned, has no query string, and does not expire — it is correct as-returned.
+- Do **not** call the OpenAI images API directly via `curl`, `fetch`, or a Node one-liner.
+- Do **not** call `s3:PutObject`, `aws s3 cp`, `getSignedUrl`, or any presigning code from Bash. The skill writes to a public-read prefix and returns the final URL; presigning by hand will produce a URL with `X-Amz-Security-Token` that fails in chat.
+- Do **not** "save the image locally" as a fallback. The container's filesystem is ephemeral and the user cannot reach it.
+- If the skill returns an `error` field, surface that error to the user and stop. Do not improvise an alternative pipeline.
+
+This rule generalizes: any time a skill exists for a domain, that skill's interface is the contract. Working *around* a skill by calling its underlying APIs directly is forbidden. If a skill is broken, report the failure and stop — do not patch around it.
+
 ## Google Workspace
 
 For anything in Gmail, Calendar, Drive, Docs, Sheets, Slides, Forms, Tasks, Meet, Chat — use `psd-workspace`. See its SKILL.md for the full output contract and the gws CLI surface.

--- a/infra/agent-image/SOUL.md
+++ b/infra/agent-image/SOUL.md
@@ -31,16 +31,16 @@ You can only do what your enabled skills allow. Today that is:
 
 - **Filesystem write** to your workspace (memory files above, canvases under `~/.openclaw/canvas/`)
 - **The conversation channel** with the user via Google Chat
-- **Tier 1 skills (always loaded):** `psd-rules`, `psd-schedules`, `psd-credentials`, `psd-skills-meta`, `psd-workspace`, plus your own approved skills
+- **PSD skills** (catalog stubs visible by default; load via `psd-skills-meta` before invoking): `psd-credentials`, `psd-schedules`, `psd-skills-meta`, `psd-workspace`, `psd-image-gen`, `psd-freshservice`, plus your own approved skills
 - **Upstream `gws-*` skills** for per-API Google Workspace guidance (Gmail, Drive, Docs, Sheets, Slides, Forms, Tasks, Calendar, Chat, Meet, etc.)
 
 You do **not** have built-in access to email, calendar, files outside the workspace, the open internet, school SIS, or any external API except via a skill. Do **not** improvise through OpenClaw's `cron`, `heartbeat`, or `task` subsystems — those are disabled.
 
 ## Skill tiers
 
-1. **Tier 1 — always loaded:** Full SKILL.md available every turn. The list above.
-2. **Tier 2 — catalog stub:** Name + one-line summary for other skills. Use `psd-skills-meta` → `skills.search("keyword")` to find them.
-3. **Tier 3 — on-demand:** Use `skills.load("name")` to pull a Tier 2 skill's full SKILL.md into the current session.
+1. **Tier 0 — fused into this prompt:** `psd-rules` body is concatenated into this file at container build time. The full rules are below; you always have them.
+2. **Tier 2 — catalog stub:** Name + one-line summary for every other skill (including `psd-schedules`, `psd-credentials`, `psd-skills-meta`, `psd-workspace`, `psd-image-gen`, `psd-freshservice`, plus user-approved skills). Use `psd-skills-meta` → `skills.search("keyword")` to find them.
+3. **Tier 3 — on-demand:** Use `skills.load("name")` to pull a Tier 2 skill's full SKILL.md into the current session before invoking it. Per Rule 9, do this whenever you're about to call a skill whose interface you don't already remember.
 
 ## Credentials
 
@@ -50,20 +50,6 @@ When a skill requires an API key, secret, or credential:
 2. Never hardcode a credential in a script, memory file, or chat message.
 3. Never log or echo a credential value — not to user, file, or stdout.
 4. If a credential is not provisioned, use `credentials.request_new("name", "reason")`. Do not ask the user to paste a raw key in chat.
-
-## Skills are the only path — do not improvise
-
-If a skill exists for a task, you call that skill verbatim. You do not write Bash, Node, or Python to replicate what the skill does, and you do not "wrap", "post-process", or "fix" the skill's output.
-
-In particular for `psd-image-gen`:
-
-- For **any** request to generate, draw, illustrate, or "make an image" of anything (infographic, diagram, photo, mockup, icon), call `psd-image-gen/generate.js` and surface its returned `url` to the user *verbatim*. The URL is unsigned, has no query string, and does not expire — it is correct as-returned.
-- Do **not** call the OpenAI images API directly via `curl`, `fetch`, or a Node one-liner.
-- Do **not** call `s3:PutObject`, `aws s3 cp`, `getSignedUrl`, or any presigning code from Bash. The skill writes to a public-read prefix and returns the final URL; presigning by hand will produce a URL with `X-Amz-Security-Token` that fails in chat.
-- Do **not** "save the image locally" as a fallback. The container's filesystem is ephemeral and the user cannot reach it.
-- If the skill returns an `error` field, surface that error to the user and stop. Do not improvise an alternative pipeline.
-
-This rule generalizes: any time a skill exists for a domain, that skill's interface is the contract. Working *around* a skill by calling its underlying APIs directly is forbidden. If a skill is broken, report the failure and stop — do not patch around it.
 
 ## Google Workspace
 

--- a/infra/agent-image/openclaw.json
+++ b/infra/agent-image/openclaw.json
@@ -37,7 +37,7 @@
   },
   "skills": {
     "load": {
-      "extraDirs": ["/home/node/.openclaw/skills"],
+      "extraDirs": ["/opt/psd-skills"],
       "watch": false
     }
   },

--- a/infra/agent-image/skills/psd-credentials/SKILL.md
+++ b/infra/agent-image/skills/psd-credentials/SKILL.md
@@ -32,6 +32,29 @@ node /home/node/.openclaw/skills/psd-credentials/list.js \
 
 Returns `{"credentials":[{"name":"...","scope":"shared|user"},...]}`.
 
+### `put` — store a per-user credential
+
+```bash
+node /home/node/.openclaw/skills/psd-credentials/put.js \
+  --user <email> \
+  --name "<credential-name>" \
+  --value "<secret-value>"
+```
+
+Stores a value at `psd-agent-creds/{env}/user/<email>/<name>`. Skills can only write per-user secrets. Shared (district-wide) secrets must be provisioned by an admin out of band. Returns `{"name":"...","scope":"user","action":"created"|"rotated"}`. The credential value never appears in stdout, audit, or telemetry.
+
+Use this when a skill prompts the user for an API key and needs to persist it for future invocations.
+
+### `check_capability` — verify a capability grant for the caller
+
+```bash
+node /home/node/.openclaw/skills/psd-credentials/check_capability.js \
+  --user <email> \
+  --capability "<capability-identifier>"
+```
+
+Returns `{"granted":true|false,"capability":"...","user":"..."}` and exits `0` on grant, `3` on deny, `1` on internal error. Used by restricted skills (e.g. `psd-image-gen`) to enforce the AI Studio role-based capability model at invocation time. Fails closed on database errors — a restricted skill should refuse to act when the grant cannot be confirmed.
+
 ### `request_new` — request provisioning of a new credential
 
 ```bash

--- a/infra/agent-image/skills/psd-credentials/SKILL.md
+++ b/infra/agent-image/skills/psd-credentials/SKILL.md
@@ -53,7 +53,7 @@ node /home/node/.openclaw/skills/psd-credentials/check_capability.js \
   --capability "<capability-identifier>"
 ```
 
-Returns `{"granted":true|false,"capability":"...","user":"..."}` and exits `0` on grant, `3` on deny, `1` on internal error. Used by restricted skills (e.g. `psd-image-gen`) to enforce the AI Studio role-based capability model at invocation time. Fails closed on database errors — a restricted skill should refuse to act when the grant cannot be confirmed.
+Returns `{"granted":true|false,"capability":"..."}` and exits `0` on grant, `3` on deny, `1` on internal error. Used by restricted skills (e.g. `psd-image-gen`) to enforce the AI Studio role-based capability model at invocation time. Fails closed on database errors — a restricted skill should refuse to act when the grant cannot be confirmed.
 
 ### `request_new` — request provisioning of a new credential
 

--- a/infra/agent-image/skills/psd-credentials/SKILL.md
+++ b/infra/agent-image/skills/psd-credentials/SKILL.md
@@ -16,7 +16,7 @@ Retrieve API keys and secrets from AWS Secrets Manager for use in agent skills. 
 ### `get` — retrieve a credential value
 
 ```bash
-node /home/node/.openclaw/skills/psd-credentials/get.js \
+node /opt/psd-skills/psd-credentials/get.js \
   --user <email> \
   --name "<credential-name>" \
   [--shared]
@@ -29,7 +29,7 @@ By default, checks user-scoped first, then falls back to shared. Pass `--shared`
 ### `list` — list available credentials (names only, no values)
 
 ```bash
-node /home/node/.openclaw/skills/psd-credentials/list.js \
+node /opt/psd-skills/psd-credentials/list.js \
   --user <email>
 ```
 
@@ -38,7 +38,7 @@ Returns `{"credentials":[{"name":"...","scope":"shared|user"},...]}`.
 ### `put` — store a per-user credential
 
 ```bash
-node /home/node/.openclaw/skills/psd-credentials/put.js \
+node /opt/psd-skills/psd-credentials/put.js \
   --user <email> \
   --name "<credential-name>" \
   --value "<secret-value>"
@@ -51,7 +51,7 @@ Use this when a skill prompts the user for an API key and needs to persist it fo
 ### `check_capability` — verify a capability grant for the caller
 
 ```bash
-node /home/node/.openclaw/skills/psd-credentials/check_capability.js \
+node /opt/psd-skills/psd-credentials/check_capability.js \
   --user <email> \
   --capability "<capability-identifier>"
 ```
@@ -61,7 +61,7 @@ Returns `{"granted":true|false,"capability":"..."}` and exits `0` on grant, `3` 
 ### `request_new` — request provisioning of a new credential
 
 ```bash
-node /home/node/.openclaw/skills/psd-credentials/request_new.js \
+node /opt/psd-skills/psd-credentials/request_new.js \
   --user <email> \
   --name "<desired-credential-name>" \
   --reason "<why this credential is needed>" \
@@ -111,7 +111,7 @@ The `--user` parameter is the authenticated caller's email, passed by the agent 
 
 ```bash
 # Get the credential
-CRED=$(node /home/node/.openclaw/skills/psd-credentials/get.js --user hagelk@psd401.net --name "openai_api_key")
+CRED=$(node /opt/psd-skills/psd-credentials/get.js --user hagelk@psd401.net --name "openai_api_key")
 # Extract the value (in your skill logic, not in chat)
 API_KEY=$(echo "$CRED" | node -e "process.stdout.write(JSON.parse(require('fs').readFileSync(0,'utf8')).value)")
 # Use it in an API call (the key never appears in your response)
@@ -121,13 +121,13 @@ curl -s -H "Authorization: Bearer $API_KEY" https://api.openai.com/v1/models
 **Listing available credentials:**
 
 ```bash
-node /home/node/.openclaw/skills/psd-credentials/list.js --user hagelk@psd401.net
+node /opt/psd-skills/psd-credentials/list.js --user hagelk@psd401.net
 ```
 
 **Requesting a new credential:**
 
 ```bash
-node /home/node/.openclaw/skills/psd-credentials/request_new.js \
+node /opt/psd-skills/psd-credentials/request_new.js \
   --user hagelk@psd401.net \
   --name "google_workspace_api_key" \
   --reason "Needed for the psd-google-integration skill to access Calendar API" \

--- a/infra/agent-image/skills/psd-credentials/SKILL.md
+++ b/infra/agent-image/skills/psd-credentials/SKILL.md
@@ -18,10 +18,13 @@ Retrieve API keys and secrets from AWS Secrets Manager for use in agent skills. 
 ```bash
 node /home/node/.openclaw/skills/psd-credentials/get.js \
   --user <email> \
-  --name "<credential-name>"
+  --name "<credential-name>" \
+  [--shared]
 ```
 
-Returns the credential value to stdout as JSON: `{"name":"...","value":"..."}`. Use the value in your skill logic. **Never** include the value in your response to the user. **Never** write it to a file. **Never** log it.
+Returns the credential value to stdout as JSON: `{"name":"...","value":"...","scope":"user|shared"}`. Use the value in your skill logic. **Never** include the value in your response to the user. **Never** write it to a file. **Never** log it.
+
+By default, checks user-scoped first, then falls back to shared. Pass `--shared` to skip user scope and read only from the shared namespace — use this for district-funded keys (e.g. `openai_api_key`) where a per-user override must not be honored.
 
 ### `list` — list available credentials (names only, no values)
 
@@ -78,7 +81,7 @@ Credentials are stored in AWS Secrets Manager with this path structure:
 
 For per-user credentials, `{email}` is the caller email passed via `--user`, used verbatim as the path component.
 
-When calling `get`, use just the `name` portion. The skill resolves the full path based on scope priority: user-specific first, then shared.
+When calling `get`, use just the `name` portion. The skill resolves the full path based on scope priority: user-specific first, then shared. Pass `--shared` to skip user scope and read only from the shared namespace.
 
 ## Rules
 

--- a/infra/agent-image/skills/psd-credentials/SKILL.md
+++ b/infra/agent-image/skills/psd-credentials/SKILL.md
@@ -91,6 +91,20 @@ When calling `get`, use just the `name` portion. The skill resolves the full pat
 4. **Cache in memory only** — the skill caches values for the session. Credential values do not persist across sessions.
 5. **If a credential is not found**, suggest the user ask an admin to provision it, or use `request_new` to file a request.
 
+## Security: Trust Boundaries
+
+### `--user` parameter trust boundary
+
+The `--user` parameter is the authenticated caller's email, passed by the agent harness from the session context. **put.js** uses this value to scope `PutSecretValue` calls to `psd-agent-creds/{env}/user/{email}/{name}`. The IAM policy (`AgentCredentialsUpdatePerUser`) restricts `PutSecretValue` to the `psd-agent-creds/{env}/user/*` path but cannot enforce per-email scoping (AWS does not support tag-based conditions on `PutSecretValue`).
+
+**Current trust model:** The harness is trusted to pass the correct `--user` value. A compromised or malicious skill process that can call `put.js` with an arbitrary `--user` could overwrite another user's credential.
+
+**Planned mitigation:** Harness-level enforcement that injects `--user` from the verified session and strips/rejects user-supplied `--user` overrides. Until then, credential overwrites are logged in `psd_agent_credentials_audit` for forensic review.
+
+### CLI argument exposure
+
+`put.js` accepts `--value` on the command line. CLI arguments are visible in `ps aux` output and may be captured by container runtime logging or process auditing. The exposure window is short (process lifetime), but for long-term secrets this is a meaningful risk. A future improvement will read the secret value from stdin instead of CLI args.
+
 ## Examples
 
 **Using an API key in a skill:**

--- a/infra/agent-image/skills/psd-credentials/check_capability.js
+++ b/infra/agent-image/skills/psd-credentials/check_capability.js
@@ -1,0 +1,50 @@
+#!/usr/bin/env node
+/**
+ * check_capability.js — credentials.check_capability
+ * Usage:
+ *   node check_capability.js --user <email> --capability <identifier>
+ *
+ * Returns JSON `{ granted: true|false }` and exits 0 (granted) or 3
+ * (denied). Other errors exit 1. Fail-closed on database errors —
+ * restricted skills must refuse to run when capability cannot be
+ * confirmed.
+ */
+
+'use strict';
+
+const {
+  fail,
+  validateEnv,
+  validateUserEmail,
+  parseArgs,
+  emit,
+  userHasCapability,
+} = require('./common');
+
+async function main() {
+  const args = parseArgs(process.argv);
+  if (args.help) {
+    console.log('Usage: check_capability.js --user <email> --capability <identifier>');
+    process.exit(0);
+  }
+  validateEnv();
+  validateUserEmail(args.user);
+
+  if (!args.capability || args.capability === true) {
+    fail('--capability is required');
+  }
+
+  let granted = false;
+  try {
+    granted = await userHasCapability(args.user, args.capability);
+  } catch (err) {
+    fail(`Capability check failed: ${err.message}`);
+  }
+
+  emit({ granted, capability: args.capability, user: args.user });
+  process.exit(granted ? 0 : 3);
+}
+
+main().catch((err) => {
+  fail(err instanceof Error ? err.message : String(err));
+});

--- a/infra/agent-image/skills/psd-credentials/check_capability.js
+++ b/infra/agent-image/skills/psd-credentials/check_capability.js
@@ -33,6 +33,13 @@ async function main() {
   if (!args.capability || args.capability === true) {
     fail('--capability is required');
   }
+  // Format guard: capability identifiers are dot-delimited lowercase tokens
+  // (e.g. "skill.image-gen"). Reject empty, overlong, or non-printable values
+  // to surface clear errors rather than confusing downstream behavior.
+  if (!/^[a-z0-9._-]{1,64}$/.test(args.capability)) {
+    fail(`Invalid capability format: "${args.capability}". ` +
+      'Must be 1-64 chars of lowercase alphanumeric, dots, hyphens, underscores.');
+  }
 
   let granted = false;
   try {

--- a/infra/agent-image/skills/psd-credentials/check_capability.js
+++ b/infra/agent-image/skills/psd-credentials/check_capability.js
@@ -8,6 +8,14 @@
  * (denied). Other errors exit 1. Fail-closed on database errors —
  * restricted skills must refuse to run when capability cannot be
  * confirmed.
+ *
+ * TRUST BOUNDARY: --user is caller-trusted. The harness is expected to
+ * inject the authenticated user's email from the verified session and
+ * strip any user-supplied overrides. If a prompt-injection or malicious
+ * tool output can control --user, a user could gain another user's
+ * capability grants. This is an inherent constraint of the CLI-based
+ * skill architecture — see psd-credentials/SKILL.md § Security: Trust
+ * Boundaries for the full analysis and compensating controls.
  */
 
 'use strict';

--- a/infra/agent-image/skills/psd-credentials/check_capability.js
+++ b/infra/agent-image/skills/psd-credentials/check_capability.js
@@ -41,7 +41,9 @@ async function main() {
     fail(`Capability check failed: ${err.message}`);
   }
 
-  emit({ granted, capability: args.capability, user: args.user });
+  // Omit user email from output — the caller already knows it, and
+  // including PII in tool stdout increases accidental exposure surface.
+  emit({ granted, capability: args.capability });
   process.exit(granted ? 0 : 3);
 }
 

--- a/infra/agent-image/skills/psd-credentials/common.js
+++ b/infra/agent-image/skills/psd-credentials/common.js
@@ -346,8 +346,10 @@ async function putUserCredential(name, value, userEmail) {
 
   // Bust the in-memory cache so subsequent get() calls in the same
   // session see the new value rather than the prior cached miss.
-  const cacheKey = `${userEmail}\x00${name}`;
-  delete _cache[cacheKey];
+  // Cache keys use three-part format: email + NUL + name + NUL + scope flag.
+  // Delete both scope variants ('a' = all-scopes, 's' = shared-only).
+  delete _cache[`${userEmail}\x00${name}\x00a`];
+  delete _cache[`${userEmail}\x00${name}\x00s`];
 
   return { name, scope: 'user', action };
 }

--- a/infra/agent-image/skills/psd-credentials/common.js
+++ b/infra/agent-image/skills/psd-credentials/common.js
@@ -124,14 +124,25 @@ function resolveSecretId(name, userEmail) {
 /**
  * Fetch a secret value from Secrets Manager, checking user scope first,
  * then falling back to shared scope. Uses in-memory cache.
+ *
+ * @param {string} name       - Credential name (alphanumeric/hyphens/underscores/dots).
+ * @param {string} userEmail  - Authenticated caller's email.
+ * @param {object} [options]  - Optional flags.
+ * @param {boolean} [options.sharedOnly=false] - If true, skip user scope and
+ *   read only from the shared namespace. Use this for district-funded keys
+ *   (e.g. openai_api_key) where a user-scoped override must not be honored.
  */
-async function getCredential(name, userEmail) {
+async function getCredential(name, userEmail, options) {
+  const sharedOnly = options && options.sharedOnly === true;
+
   // H1 fix: Validate credential name to prevent path traversal in SM paths
   validateCredentialName(name);
 
   // Use a null byte as delimiter — cannot appear in an email or a
   // SAFE_CRED_NAME_RE-validated name, so (user, name) pairs are unambiguous.
-  const cacheKey = `${userEmail}\x00${name}`;
+  // Append scope mode to distinguish cached entries between shared-only and
+  // normal lookups for the same credential name.
+  const cacheKey = `${userEmail}\x00${name}\x00${sharedOnly ? 's' : 'a'}`;
   if (cacheKey in _cache) {
     const cached = _cache[cacheKey];
     if (Date.now() - cached.cachedAt < CACHE_TTL_MS) {
@@ -143,11 +154,16 @@ async function getCredential(name, userEmail) {
 
   const { userPath, sharedPath } = resolveSecretId(name, userEmail);
 
-  // Try user-scoped first
-  let value = await tryGetSecret(userPath);
-  let scope = 'user';
+  let value = null;
+  let scope = 'shared';
 
-  // Fall back to shared
+  if (!sharedOnly) {
+    // Try user-scoped first
+    value = await tryGetSecret(userPath);
+    scope = 'user';
+  }
+
+  // Fall back to (or exclusively use) shared
   if (value === null) {
     value = await tryGetSecret(sharedPath);
     scope = 'shared';
@@ -290,7 +306,8 @@ async function logCredentialRead(credentialName, userEmail, sessionId) {
  * the secret already exists. Caller-trusted on value contents (no length
  * or format validation per plan decision).
  *
- * Audit row is appended to psd_agent_credentials_audit with action='put'.
+ * The caller (put.js) appends an audit row to psd_agent_credentials_audit
+ * via logCredentialPut() with action='created' or 'rotated'.
  * The credential value is never logged.
  */
 async function putUserCredential(name, value, userEmail) {

--- a/infra/agent-image/skills/psd-credentials/common.js
+++ b/infra/agent-image/skills/psd-credentials/common.js
@@ -19,6 +19,9 @@ const {
   SecretsManagerClient,
   GetSecretValueCommand,
   ListSecretsCommand,
+  CreateSecretCommand,
+  PutSecretValueCommand,
+  ResourceExistsException,
 } = require('@aws-sdk/client-secrets-manager');
 
 const {
@@ -271,6 +274,133 @@ async function logCredentialRead(credentialName, userEmail, sessionId) {
 }
 
 /**
+ * Write a per-user credential to Secrets Manager. Always scoped to the
+ * caller's email path (psd-agent-creds/{env}/user/{email}/{name}). The
+ * shared scope cannot be written by skills — admins provision shared
+ * secrets out of band.
+ *
+ * Uses CreateSecret on first write and falls back to PutSecretValue when
+ * the secret already exists. Caller-trusted on value contents (no length
+ * or format validation per plan decision).
+ *
+ * Audit row is appended to psd_agent_credentials_audit with action='put'.
+ * The credential value is never logged.
+ */
+async function putUserCredential(name, value, userEmail) {
+  validateCredentialName(name);
+  if (typeof value !== 'string' || value.length === 0) {
+    fail('--value must be a non-empty string');
+  }
+
+  const secretId = `${CREDS_PREFIX}/user/${userEmail}/${name}`;
+  const tags = [
+    { Key: 'Environment', Value: ENVIRONMENT },
+    { Key: 'ManagedBy', Value: 'psd-credentials-skill' },
+    { Key: 'Scope', Value: 'user' },
+  ];
+
+  let action = 'created';
+  try {
+    await smClient.send(new CreateSecretCommand({
+      Name: secretId,
+      SecretString: value,
+      Tags: tags,
+      Description: `Per-user agent credential ${name} for ${userEmail}`,
+    }));
+  } catch (err) {
+    const isExists = err instanceof ResourceExistsException
+      || err.name === 'ResourceExistsException';
+    if (!isExists) {
+      throw err;
+    }
+    await smClient.send(new PutSecretValueCommand({
+      SecretId: secretId,
+      SecretString: value,
+    }));
+    action = 'rotated';
+  }
+
+  // Bust the in-memory cache so subsequent get() calls in the same
+  // session see the new value rather than the prior cached miss.
+  const cacheKey = `${userEmail}\x00${name}`;
+  delete _cache[cacheKey];
+
+  return { name, scope: 'user', action };
+}
+
+/**
+ * Append an audit row recording a per-user credential write. Best-effort.
+ * Never logs the credential value — only the name, scope, and action.
+ */
+async function logCredentialPut(credentialName, userEmail, action) {
+  if (!rdsClient || !DATABASE_RESOURCE_ARN || !DATABASE_SECRET_ARN) {
+    return;
+  }
+  try {
+    await rdsClient.send(new ExecuteStatementCommand({
+      resourceArn: DATABASE_RESOURCE_ARN,
+      secretArn: DATABASE_SECRET_ARN,
+      database: 'aistudio',
+      sql: `INSERT INTO psd_agent_credentials_audit
+              (credential_name, scope, action, details)
+            VALUES (:name, 'user', :action, CAST(:details AS JSONB))`,
+      parameters: [
+        { name: 'name', value: { stringValue: credentialName } },
+        { name: 'action', value: { stringValue: action } },
+        {
+          name: 'details',
+          value: { stringValue: JSON.stringify({ user_email: userEmail }) },
+        },
+      ],
+    }));
+  } catch (err) {
+    console.error(`Audit log failed (non-fatal): ${err.message}`);
+  }
+}
+
+/**
+ * Check whether a given user email has been granted a capability via
+ * their role assignments. Source-of-truth tables are `users` (email →
+ * id), `user_roles` (id → role_id), `role_tools` (role_id → tool_id),
+ * and `tools` (capability identifier; the table will be renamed to
+ * `capabilities` under epic #922 / issue #923).
+ *
+ * Returns `true` if at least one matching grant exists and the
+ * capability is still active. Returns `false` if no grant is found or
+ * if the database is not configured (fail-closed for restricted skills
+ * — better to refuse the action than to expose it on a misconfig).
+ */
+async function userHasCapability(userEmail, capabilityIdentifier) {
+  if (!rdsClient || !DATABASE_RESOURCE_ARN || !DATABASE_SECRET_ARN) {
+    return false;
+  }
+  try {
+    const resp = await rdsClient.send(new ExecuteStatementCommand({
+      resourceArn: DATABASE_RESOURCE_ARN,
+      secretArn: DATABASE_SECRET_ARN,
+      database: 'aistudio',
+      sql: `SELECT 1
+              FROM users u
+              JOIN user_roles ur ON ur.user_id = u.id
+              JOIN role_tools rt ON rt.role_id = ur.role_id
+              JOIN tools t ON t.id = rt.tool_id
+             WHERE u.email = :email
+               AND t.identifier = :cap
+               AND t.is_active = true
+             LIMIT 1`,
+      parameters: [
+        { name: 'email', value: { stringValue: userEmail } },
+        { name: 'cap', value: { stringValue: capabilityIdentifier } },
+      ],
+    }));
+    return Array.isArray(resp.records) && resp.records.length > 0;
+  } catch (err) {
+    console.error(`Capability check failed (treating as denied): ${err.message}`);
+    return false;
+  }
+}
+
+/**
  * Insert a credential request into the database.
  */
 async function insertCredentialRequest(credentialName, reason, skillContext, userEmail) {
@@ -316,4 +446,7 @@ module.exports = {
   listCredentials,
   logCredentialRead,
   insertCredentialRequest,
+  putUserCredential,
+  logCredentialPut,
+  userHasCapability,
 };

--- a/infra/agent-image/skills/psd-credentials/common.js
+++ b/infra/agent-image/skills/psd-credentials/common.js
@@ -62,6 +62,13 @@ function validateUserEmail(email) {
   if (!EMAIL.test(email)) {
     fail(`Invalid --user "${email}". Must be a valid email address.`);
   }
+  // Defense-in-depth: reject path separators in the email since the value
+  // is interpolated into Secrets Manager secret paths. SM treats names as
+  // flat strings (no filesystem traversal), but blocking `/` prevents
+  // unintended namespace crossings in the psd-agent-creds path hierarchy.
+  if (email.includes('/')) {
+    fail('Email must not contain path separators (/).');
+  }
 }
 
 function parseArgs(argv) {

--- a/infra/agent-image/skills/psd-credentials/common.js
+++ b/infra/agent-image/skills/psd-credentials/common.js
@@ -56,6 +56,8 @@ function validateEnv() {
   if (!ENVIRONMENT) fail('ENVIRONMENT env var not set');
 }
 
+// Keep email validation in sync with: psd-freshservice/lib/api.js and
+// psd-image-gen/generate.js.
 function validateUserEmail(email) {
   if (!email) fail('--user is required (authenticated caller email)');
   const EMAIL = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
@@ -303,8 +305,9 @@ async function logCredentialRead(credentialName, userEmail, sessionId) {
  * secrets out of band.
  *
  * Uses CreateSecret on first write and falls back to PutSecretValue when
- * the secret already exists. Caller-trusted on value contents (no length
- * or format validation per plan decision).
+ * the secret already exists. Minimal validation on value contents is
+ * performed by the caller (put.js): length cap, placeholder detection,
+ * and minimum-length check.
  *
  * The caller (put.js) appends an audit row to psd_agent_credentials_audit
  * via logCredentialPut() with action='created' or 'rotated'.
@@ -332,6 +335,10 @@ async function putUserCredential(name, value, userEmail) {
       Description: `Per-user agent credential ${name} for ${userEmail}`,
     }));
   } catch (err) {
+    // Both checks are needed for AWS SDK v3 resilience: `instanceof` works
+    // when the exact class is imported from the same package version, but
+    // fails in edge cases (transitive dependency version skew, bundler
+    // deduplication). The string `.name` check covers those cases.
     const isExists = err instanceof ResourceExistsException
       || err.name === 'ResourceExistsException';
     if (!isExists) {

--- a/infra/agent-image/skills/psd-credentials/get.js
+++ b/infra/agent-image/skills/psd-credentials/get.js
@@ -1,11 +1,14 @@
 #!/usr/bin/env node
 /**
  * get.js — credentials.get
- * Usage: node get.js --user <email> --name <credential-name>
+ * Usage: node get.js --user <email> --name <credential-name> [--shared]
  *
- * Retrieves a credential value from AWS Secrets Manager. Checks
- * user-scoped first, then shared. Logs the read to telemetry
- * (name only, never value).
+ * Retrieves a credential value from AWS Secrets Manager. By default,
+ * checks user-scoped first, then shared. Pass --shared to skip user
+ * scope and read only from the shared namespace (for district-funded
+ * keys that must not be overridden by per-user values).
+ *
+ * Logs the read to telemetry (name only, never value).
  */
 
 'use strict';
@@ -23,7 +26,7 @@ const {
 async function main() {
   const args = parseArgs(process.argv);
   if (args.help) {
-    console.log('Usage: get.js --user <email> --name <credential-name>');
+    console.log('Usage: get.js --user <email> --name <credential-name> [--shared]');
     process.exit(0);
   }
   validateEnv();
@@ -34,7 +37,9 @@ async function main() {
   }
 
   try {
-    const result = await getCredential(args.name, args.user);
+    const result = await getCredential(args.name, args.user, {
+      sharedOnly: args.shared === true,
+    });
 
     if (!result) {
       emit({

--- a/infra/agent-image/skills/psd-credentials/put.js
+++ b/infra/agent-image/skills/psd-credentials/put.js
@@ -43,7 +43,9 @@ async function main() {
   // Guard against the agent running the storeCommand template verbatim without
   // substituting the placeholder. Storing the literal string wastes a Secrets
   // Manager secret and silently "succeeds" with a non-functional credential.
-  if (args.value === '<PASTE THE KEY HERE>') {
+  // Case-insensitive to catch variations like "<paste the key here>" or
+  // "<Paste The Key Here>" that a user or model might produce.
+  if (args.value.trim().toLowerCase() === '<paste the key here>') {
     fail('--value contains the template placeholder — replace with the actual secret before storing', 'bad_args');
   }
 

--- a/infra/agent-image/skills/psd-credentials/put.js
+++ b/infra/agent-image/skills/psd-credentials/put.js
@@ -8,8 +8,9 @@
  * the calling user's path. Shared secrets must be provisioned by an
  * admin out of band.
  *
- * Caller-trusted on value contents — no length or format validation
- * (per plan decision; agent prompts the user to paste a real key).
+ * Minimal validation on value contents: rejects excessively long values
+ * (>4096 chars), common template placeholders, and obviously non-key
+ * patterns. The agent prompts the user to paste a real key.
  * Logs to psd_agent_credentials_audit (name + user email, never value).
  */
 
@@ -47,12 +48,21 @@ async function main() {
     fail('--value exceeds 4096 characters — API keys should not be this long', 'bad_args');
   }
   // Guard against the agent running the storeCommand template verbatim without
-  // substituting the placeholder. Storing the literal string wastes a Secrets
-  // Manager secret and silently "succeeds" with a non-functional credential.
-  // Case-insensitive to catch variations like "<paste the key here>" or
-  // "<Paste The Key Here>" that a user or model might produce.
-  if (args.value.trim().toLowerCase() === '<paste the key here>') {
+  // substituting the placeholder. A model could produce many placeholder
+  // variants: "<paste the key here>", "<your-api-key>", "YOUR_API_KEY_HERE",
+  // "<API_KEY>", etc. We catch these with three heuristics:
+  // 1. Exact match for our template placeholder (case-insensitive)
+  // 2. Values that are entirely angle-bracket wrapped (e.g. <anything>)
+  // 3. Values shorter than 8 chars (no real API key is this short)
+  const trimmed = args.value.trim();
+  if (trimmed.toLowerCase() === '<paste the key here>') {
     fail('--value contains the template placeholder — replace with the actual secret before storing', 'bad_args');
+  }
+  if (/^<[^>]+>$/.test(trimmed)) {
+    fail('--value looks like a placeholder (angle-bracket wrapped) — replace with the actual secret', 'bad_args');
+  }
+  if (trimmed.length < 8) {
+    fail('--value is too short (< 8 characters) — API keys are longer than this', 'bad_args');
   }
 
   try {

--- a/infra/agent-image/skills/psd-credentials/put.js
+++ b/infra/agent-image/skills/psd-credentials/put.js
@@ -44,9 +44,9 @@ async function main() {
   try {
     const result = await putUserCredential(args.name, args.value, args.user);
 
-    await logCredentialPut(args.name, args.user, result.action).catch((err) => {
-      console.error(`Audit log failed (non-fatal): ${err.message}`);
-    });
+    // logCredentialPut handles errors internally (logs and swallows) so no
+    // outer .catch() is needed — it would never fire.
+    await logCredentialPut(args.name, args.user, result.action);
 
     emit({
       name: result.name,

--- a/infra/agent-image/skills/psd-credentials/put.js
+++ b/infra/agent-image/skills/psd-credentials/put.js
@@ -40,6 +40,12 @@ async function main() {
   if (!args.value || args.value === true) {
     fail('--value is required (the secret value to store)');
   }
+  // Secrets Manager accepts up to 65 KB, but no real-world API key exceeds
+  // 4 KB. Cap early to prevent accidental storage of large blobs (e.g. an
+  // agent-generated multi-KB response pasted into --value by mistake).
+  if (args.value.length > 4096) {
+    fail('--value exceeds 4096 characters — API keys should not be this long', 'bad_args');
+  }
   // Guard against the agent running the storeCommand template verbatim without
   // substituting the placeholder. Storing the literal string wastes a Secrets
   // Manager secret and silently "succeeds" with a non-functional credential.

--- a/infra/agent-image/skills/psd-credentials/put.js
+++ b/infra/agent-image/skills/psd-credentials/put.js
@@ -40,6 +40,12 @@ async function main() {
   if (!args.value || args.value === true) {
     fail('--value is required (the secret value to store)');
   }
+  // Guard against the agent running the storeCommand template verbatim without
+  // substituting the placeholder. Storing the literal string wastes a Secrets
+  // Manager secret and silently "succeeds" with a non-functional credential.
+  if (args.value === '<PASTE THE KEY HERE>') {
+    fail('--value contains the template placeholder — replace with the actual secret before storing', 'bad_args');
+  }
 
   try {
     const result = await putUserCredential(args.name, args.value, args.user);

--- a/infra/agent-image/skills/psd-credentials/put.js
+++ b/infra/agent-image/skills/psd-credentials/put.js
@@ -1,0 +1,64 @@
+#!/usr/bin/env node
+/**
+ * put.js — credentials.put
+ * Usage: node put.js --user <email> --name <credential-name> --value <secret-value>
+ *
+ * Writes a per-user credential to AWS Secrets Manager at
+ * psd-agent-creds/{env}/user/{email}/{name}. Skills can only write to
+ * the calling user's path. Shared secrets must be provisioned by an
+ * admin out of band.
+ *
+ * Caller-trusted on value contents — no length or format validation
+ * (per plan decision; agent prompts the user to paste a real key).
+ * Logs to psd_agent_credentials_audit (name + user email, never value).
+ */
+
+'use strict';
+
+const {
+  fail,
+  validateEnv,
+  validateUserEmail,
+  parseArgs,
+  emit,
+  putUserCredential,
+  logCredentialPut,
+} = require('./common');
+
+async function main() {
+  const args = parseArgs(process.argv);
+  if (args.help) {
+    console.log('Usage: put.js --user <email> --name <credential-name> --value <value>');
+    process.exit(0);
+  }
+  validateEnv();
+  validateUserEmail(args.user);
+
+  if (!args.name) {
+    fail('--name is required (credential name to store)');
+  }
+  if (!args.value || args.value === true) {
+    fail('--value is required (the secret value to store)');
+  }
+
+  try {
+    const result = await putUserCredential(args.name, args.value, args.user);
+
+    await logCredentialPut(args.name, args.user, result.action).catch((err) => {
+      console.error(`Audit log failed (non-fatal): ${err.message}`);
+    });
+
+    emit({
+      name: result.name,
+      scope: result.scope,
+      action: result.action,
+      message: `Credential "${result.name}" ${result.action} for ${args.user}.`,
+    });
+  } catch (err) {
+    fail(`Failed to store credential: ${err.message}`);
+  }
+}
+
+main().catch((err) => {
+  fail(err instanceof Error ? err.message : String(err));
+});

--- a/infra/agent-image/skills/psd-freshservice/SKILL.md
+++ b/infra/agent-image/skills/psd-freshservice/SKILL.md
@@ -31,7 +31,7 @@ If the credential is missing, the skill exits `2` and prints a structured prompt
 When you see `freshservice_key_missing`, ask the user to paste their key. After they paste, run:
 
 ```bash
-node /home/node/.openclaw/skills/psd-credentials/put.js \
+node /opt/psd-skills/psd-credentials/put.js \
   --user <email> \
   --name freshservice_api_key \
   --value "<pasted-key>"

--- a/infra/agent-image/skills/psd-freshservice/SKILL.md
+++ b/infra/agent-image/skills/psd-freshservice/SKILL.md
@@ -1,0 +1,134 @@
+---
+name: psd-freshservice
+summary: Manage Freshservice tickets, approvals, and team summaries — uses each caller's own personal API key, stored per-user in Secrets Manager.
+description: Operate against the PSD Freshservice instance (psd401.freshservice.com) with the caller's personal API key. On first invocation per user, the skill prompts the user to paste their Freshservice API key (Profile → API Key) and stores it via psd-credentials so future calls are silent. Supports listing/searching/getting/creating/updating tickets, adding notes, agent and workspace lookup, approval queues, and daily/weekly Technology workspace summaries.
+allowed-tools: Bash(node:*)
+---
+
+# psd-freshservice
+
+Each Freshservice user has their own API key (Profile → API Key). This skill uses the caller's key — *not* a shared service account — so all actions are attributed to the user in Freshservice and inherit their workspace permissions.
+
+**Identity.** Every command requires `--user <caller-email>`. Pass the email verbatim from the `[caller: Name <email>]` header in the user turn. The skill resolves the API key from `psd-agent-creds/{env}/user/<email>/freshservice_api_key`.
+
+## First-time setup (no key yet)
+
+If the credential is missing, the skill exits `2` and prints a structured prompt:
+
+```json
+{
+  "error": "freshservice_key_missing",
+  "user": "...",
+  "instructions": [
+    "Open https://psd401.freshservice.com/agent/profile and copy your personal API key.",
+    "Paste it back to me in chat — I will store it securely in Secrets Manager so I can reuse it next time.",
+    "After you paste, I will retry the command via psd-credentials put."
+  ],
+  "storeCommand": { ... }
+}
+```
+
+When you see `freshservice_key_missing`, ask the user to paste their key. After they paste, run:
+
+```bash
+node /home/node/.openclaw/skills/psd-credentials/put.js \
+  --user <email> \
+  --name freshservice_api_key \
+  --value "<pasted-key>"
+```
+
+Then retry the original command. Never echo the key back. Never write it to a file. Never include it in subsequent responses.
+
+## Tickets
+
+```bash
+# List tickets — filter: new_and_my_open | watching | spam | deleted
+node list_tickets.js --user <email> [--options '{"workspace_id":2,"filter":"new_and_my_open","per_page":30}']
+
+# Search via filter query — e.g. "responder_id:6000130414", "status:2 AND priority:3"
+node search_tickets.js --user <email> --query 'status:2 AND priority:3' [--workspace-id 2]
+
+# Get one ticket
+node get_ticket.js --user <email> --id <ticket_id> [--include conversations,requester]
+
+# Service-request ticket with form data + requester profile + conversations
+node get_service_request.js --user <email> --id <ticket_id>
+
+# Create
+node create_ticket.js --user <email> \
+  --data '{"subject":"...","description":"...","email":"requester@...","priority":2,"workspace_id":2}'
+
+# Update — status 2 Open / 3 Pending / 4 Resolved / 5 Closed; priority 1-4
+node update_ticket.js --user <email> --id <id> --data '{"status":4}'
+
+# Add note (default private)
+node add_note.js --user <email> --id <id> --data '{"body":"...","notify_emails":["a@b.com"]}'
+```
+
+## Agents and Workspaces
+
+```bash
+# Find an agent by email (defaults to the caller)
+node get_agent.js --user <caller-email> [--email <agent-email>]
+
+# List active agents, optionally filtered
+node list_agents.js --user <email> [--query <name-substring>]
+
+# Workspaces visible to the caller
+node get_workspaces.js --user <email> [--id <workspace_id>]
+```
+
+Workspace IDs in PSD: 2 Technology (primary), 3 Employee Support Services, 4 Business Services, 5 Teaching & Learning, 6 Maintenance, 8 Investigations, 9 Transportation, 10 Safety & Security, 11 Communications, 13 Software Development.
+
+## Approvals
+
+```bash
+# Pending approvals across tickets and changes (auto-resolves caller's agent ID)
+node get_approvals.js --user <email> [--status requested|approved|rejected|cancelled]
+```
+
+Freshservice does not support approving via API. Surface the approval IDs and direct the user to either the email approval link or `https://psd401.freshservice.com/helpdesk/tickets/<id>`.
+
+## Reports
+
+```bash
+# Daily — date may be 'today' (default), 'yesterday', a day name, 'last <day>', or YYYY-MM-DD
+node get_daily_summary.js --user <email> [--date today] [--workspace-id 2]
+
+# Weekly — Mon-Sun; weeks_ago 0 = this week (default)
+node get_weekly_summary.js --user <email> [--weeks-ago 0] [--workspace-id 2]
+```
+
+Both summaries query closed (status 4) and resolved (status 5) tickets in the named workspace, then aggregate by agent and by category. Pacific time conversion is fixed at UTC-8 (no DST adjustment).
+
+### Narrative style for summaries
+
+When presenting summary output, write a 1-minute narrative that:
+
+- Highlights the main story (outages, big pushes, incident clusters).
+- Calls out specific people and what they handled.
+- Notes concerning patterns (security alerts, repeated chromebooks, etc.).
+- Converts UTC timestamps to Pacific time.
+- Uses specific numbers and ticket counts.
+
+## Status / Priority Codes
+
+| Status | | | Priority | |
+|---|---|---|---|---|
+| 2 | Open | | 1 | Low |
+| 3 | Pending | | 2 | Medium |
+| 4 | Resolved | | 3 | High |
+| 5 | Closed | | 4 | Urgent |
+
+## Errors
+
+- **`freshservice_key_missing`** (exit 2) — caller has not registered their API key. Prompt for it (see above).
+- **`upstream_error`** — Freshservice returned non-2xx. Surface status and message; ask the user before retrying mutating operations.
+- **`bad_args`** — required argument missing or malformed.
+- **`agent_lookup_failed`** — could not resolve the caller's Freshservice agent ID via `/agents?email=`. Confirm the caller's email matches their Freshservice login.
+
+## Security
+
+- API keys are stored only in AWS Secrets Manager at `psd-agent-creds/{env}/user/<email>/freshservice_api_key`.
+- The skill never echoes the key, never writes it to workspace files, and never includes it in tool output.
+- Each user's key authenticates every Freshservice call — actions are attributed to that user, not a service account.

--- a/infra/agent-image/skills/psd-freshservice/SKILL.md
+++ b/infra/agent-image/skills/psd-freshservice/SKILL.md
@@ -99,7 +99,7 @@ node get_daily_summary.js --user <email> [--date today] [--workspace-id 2]
 node get_weekly_summary.js --user <email> [--weeks-ago 0] [--workspace-id 2]
 ```
 
-Both summaries query closed (status 4) and resolved (status 5) tickets in the named workspace, then aggregate by agent and by category. Pacific time conversion is fixed at UTC-8 (no DST adjustment).
+Both summaries query closed (status 4) and resolved (status 5) tickets in the named workspace, then aggregate by agent and by category. Pacific time handling uses the container's `TZ=America/Los_Angeles` setting, which handles PST/PDT transitions automatically.
 
 ### Narrative style for summaries
 

--- a/infra/agent-image/skills/psd-freshservice/add_note.js
+++ b/infra/agent-image/skills/psd-freshservice/add_note.js
@@ -1,0 +1,38 @@
+#!/usr/bin/env node
+/**
+ * add_note.js — add a note to a ticket. Defaults to private note.
+ *
+ * Usage:
+ *   node add_note.js --user <email> --id <ticket_id> --data '<json>'
+ *
+ * JSON: { body, private?: true, notify_emails?: ["..."] }.
+ */
+
+'use strict';
+
+const { fail, emit, parseArgs, requireUser, getApiKey, fsFetch, parseJsonArg } =
+  require('./lib/api');
+
+async function main() {
+  const args = parseArgs(process.argv);
+  if (args.help) {
+    console.log('Usage: add_note.js --user <email> --id <ticket_id> --data \'{"body":"..."}\'');
+    process.exit(0);
+  }
+  const userEmail = requireUser(args);
+  const id = args.id;
+  if (!id || id === true) fail('--id is required', 'bad_args');
+  const data = parseJsonArg(args.data, '--data');
+  if (!data.body) fail('data.body is required', 'bad_args');
+  if (data.private === undefined) data.private = true;
+
+  const apiKey = getApiKey(userEmail);
+  const result = await fsFetch(apiKey, `/tickets/${id}/notes`, {
+    method: 'POST',
+    body: JSON.stringify(data),
+  });
+  if (!result.__ok) fail(result.error, 'upstream_error');
+  emit(result.data);
+}
+
+main().catch((err) => fail(err instanceof Error ? err.message : String(err)));

--- a/infra/agent-image/skills/psd-freshservice/add_note.js
+++ b/infra/agent-image/skills/psd-freshservice/add_note.js
@@ -23,12 +23,14 @@ async function main() {
   const id = requireTicketId(args);
   const data = parseJsonArg(args.data, '--data');
   if (!data.body) fail('data.body is required', 'bad_args');
-  if (data.private === undefined) data.private = true;
+  // Avoid mutating the parsed JSON object in-place — spread a new object
+  // with `private` defaulting to true (overridable by the caller's JSON).
+  const payload = { private: true, ...data };
 
   const apiKey = getApiKey(userEmail);
   const result = await fsFetch(apiKey, `/tickets/${id}/notes`, {
     method: 'POST',
-    body: JSON.stringify(data),
+    body: JSON.stringify(payload),
   });
   if (!result.__ok) fail(result.error, 'upstream_error');
   emit(result.data);

--- a/infra/agent-image/skills/psd-freshservice/add_note.js
+++ b/infra/agent-image/skills/psd-freshservice/add_note.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-const { fail, emit, parseArgs, requireUser, getApiKey, fsFetch, parseJsonArg } =
+const { fail, emit, parseArgs, requireUser, getApiKey, fsFetch, requireTicketId, parseJsonArg } =
   require('./lib/api');
 
 async function main() {
@@ -20,8 +20,7 @@ async function main() {
     process.exit(0);
   }
   const userEmail = requireUser(args);
-  const id = args.id;
-  if (!id || id === true) fail('--id is required', 'bad_args');
+  const id = requireTicketId(args);
   const data = parseJsonArg(args.data, '--data');
   if (!data.body) fail('data.body is required', 'bad_args');
   if (data.private === undefined) data.private = true;

--- a/infra/agent-image/skills/psd-freshservice/create_ticket.js
+++ b/infra/agent-image/skills/psd-freshservice/create_ticket.js
@@ -1,0 +1,42 @@
+#!/usr/bin/env node
+/**
+ * create_ticket.js — create a new Freshservice ticket.
+ *
+ * Usage:
+ *   node create_ticket.js --user <email> --data '<json>'
+ *
+ * Required JSON fields: subject, description, email (requester) or
+ * requester_id. Optional: priority (1-4), status (2 Open, 3 Pending,
+ * 4 Resolved, 5 Closed), workspace_id.
+ */
+
+'use strict';
+
+const { fail, emit, parseArgs, requireUser, getApiKey, fsFetch, parseJsonArg } =
+  require('./lib/api');
+
+async function main() {
+  const args = parseArgs(process.argv);
+  if (args.help) {
+    console.log('Usage: create_ticket.js --user <email> --data \'{"subject":"...","description":"...","email":"..."}\'');
+    process.exit(0);
+  }
+  const userEmail = requireUser(args);
+  const data = parseJsonArg(args.data, '--data');
+
+  if (!data.subject || !data.description || (!data.email && !data.requester_id)) {
+    fail('Required fields: subject, description, and email or requester_id', 'bad_args');
+  }
+  data.status = data.status ?? 2;
+  data.priority = data.priority ?? 2;
+
+  const apiKey = getApiKey(userEmail);
+  const result = await fsFetch(apiKey, '/tickets', {
+    method: 'POST',
+    body: JSON.stringify(data),
+  });
+  if (!result.__ok) fail(result.error, 'upstream_error');
+  emit(result.data);
+}
+
+main().catch((err) => fail(err instanceof Error ? err.message : String(err)));

--- a/infra/agent-image/skills/psd-freshservice/create_ticket.js
+++ b/infra/agent-image/skills/psd-freshservice/create_ticket.js
@@ -27,13 +27,29 @@ async function main() {
   if (!data.subject || !data.description || (!data.email && !data.requester_id)) {
     fail('Required fields: subject, description, and email or requester_id', 'bad_args');
   }
-  data.status = data.status ?? 2;
-  data.priority = data.priority ?? 2;
+
+  // Allowlist of Freshservice ticket fields the agent may set. Prevents callers
+  // from injecting privileged fields (e.g. source, type, internal metadata) that
+  // Freshservice may accept but the agent should not control.
+  const ALLOWED_FIELDS = new Set([
+    'subject', 'description', 'email', 'requester_id', 'status', 'priority',
+    'workspace_id', 'group_id', 'responder_id', 'cc_emails', 'tags',
+    'category', 'sub_category', 'item_category', 'due_by', 'fr_due_by',
+    'urgency', 'impact',
+  ]);
+  const filtered = Object.create(null);
+  for (const key of Object.keys(data)) {
+    if (ALLOWED_FIELDS.has(key)) {
+      filtered[key] = data[key];
+    }
+  }
+  filtered.status = filtered.status ?? 2;
+  filtered.priority = filtered.priority ?? 2;
 
   const apiKey = getApiKey(userEmail);
   const result = await fsFetch(apiKey, '/tickets', {
     method: 'POST',
-    body: JSON.stringify(data),
+    body: JSON.stringify(filtered),
   });
   if (!result.__ok) fail(result.error, 'upstream_error');
   emit(result.data);

--- a/infra/agent-image/skills/psd-freshservice/get_agent.js
+++ b/infra/agent-image/skills/psd-freshservice/get_agent.js
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+/**
+ * get_agent.js — look up a Freshservice agent by email.
+ *
+ * Usage:
+ *   node get_agent.js --user <caller-email> [--email <agent-email>]
+ *
+ * If --email is omitted, looks up the caller's own agent record.
+ */
+
+'use strict';
+
+const { fail, emit, parseArgs, requireUser, getApiKey, fsFetch } = require('./lib/api');
+
+async function main() {
+  const args = parseArgs(process.argv);
+  if (args.help) {
+    console.log('Usage: get_agent.js --user <caller-email> [--email <agent-email>]');
+    process.exit(0);
+  }
+  const userEmail = requireUser(args);
+  const lookupEmail = (args.email && args.email !== true) ? args.email : userEmail;
+
+  const apiKey = getApiKey(userEmail);
+  const result = await fsFetch(apiKey, `/agents?email=${encodeURIComponent(lookupEmail)}`);
+  if (!result.__ok) fail(result.error, 'upstream_error');
+  emit(result.data);
+}
+
+main().catch((err) => fail(err instanceof Error ? err.message : String(err)));

--- a/infra/agent-image/skills/psd-freshservice/get_approvals.js
+++ b/infra/agent-image/skills/psd-freshservice/get_approvals.js
@@ -23,7 +23,11 @@ async function resolveAgentId(apiKey, email) {
 async function fetchApprovals(apiKey, agentId, status, parent) {
   const url = `/approvals?approver_id=${agentId}&status=${encodeURIComponent(status)}&parent=${parent}`;
   const r = await fsFetch(apiKey, url);
-  if (!r.__ok) return { error: r.error, approvals: [] };
+  if (!r.__ok) {
+    // Surface the error instead of silently returning empty data —
+    // callers must distinguish "no approvals" from "API failure".
+    fail(`Failed to fetch ${parent} approvals: ${r.error}`, 'upstream_error');
+  }
   return {
     approvals: (r.data.approvals || []).map((a) => ({
       id: a.id,

--- a/infra/agent-image/skills/psd-freshservice/get_approvals.js
+++ b/infra/agent-image/skills/psd-freshservice/get_approvals.js
@@ -1,0 +1,70 @@
+#!/usr/bin/env node
+/**
+ * get_approvals.js — fetch tickets/changes awaiting the caller's approval.
+ *
+ * Usage:
+ *   node get_approvals.js --user <email> [--status requested|approved|rejected|cancelled]
+ *
+ * Auto-resolves the caller's Freshservice agent ID via /agents?email=.
+ * Polls both ticket and change parents and merges results.
+ */
+
+'use strict';
+
+const { fail, emit, parseArgs, requireUser, getApiKey, fsFetch } = require('./lib/api');
+
+async function resolveAgentId(apiKey, email) {
+  const r = await fsFetch(apiKey, `/agents?email=${encodeURIComponent(email)}`);
+  if (!r.__ok) return null;
+  const agents = r.data.agents || [];
+  return agents.length ? agents[0].id : null;
+}
+
+async function fetchApprovals(apiKey, agentId, status, parent) {
+  const url = `/approvals?approver_id=${agentId}&status=${encodeURIComponent(status)}&parent=${parent}`;
+  const r = await fsFetch(apiKey, url);
+  if (!r.__ok) return { error: r.error, approvals: [] };
+  return {
+    approvals: (r.data.approvals || []).map((a) => ({
+      id: a.id,
+      approval_type: a.approval_type,
+      approver_id: a.approver_id,
+      status: a.status,
+      created_at: a.created_at,
+      updated_at: a.updated_at,
+      approvable_id: a.approvable_id,
+      approvable_type: a.approvable_type,
+      delegator: a.delegator,
+      latest_remark: a.latest_remark,
+    })),
+  };
+}
+
+async function main() {
+  const args = parseArgs(process.argv);
+  if (args.help) {
+    console.log('Usage: get_approvals.js --user <email> [--status requested]');
+    process.exit(0);
+  }
+  const userEmail = requireUser(args);
+  const status = args.status && args.status !== true ? String(args.status) : 'requested';
+
+  const apiKey = getApiKey(userEmail);
+  const agentId = await resolveAgentId(apiKey, userEmail);
+  if (!agentId) {
+    fail(`Could not resolve Freshservice agent ID for ${userEmail}`, 'agent_lookup_failed');
+  }
+
+  const [ticketRes, changeRes] = await Promise.all([
+    fetchApprovals(apiKey, agentId, status, 'ticket'),
+    fetchApprovals(apiKey, agentId, status, 'change'),
+  ]);
+
+  const approvals = []
+    .concat(ticketRes.approvals.map((a) => ({ ...a, parent_type: 'ticket' })))
+    .concat(changeRes.approvals.map((a) => ({ ...a, parent_type: 'change' })));
+
+  emit({ count: approvals.length, status, approvals });
+}
+
+main().catch((err) => fail(err instanceof Error ? err.message : String(err)));

--- a/infra/agent-image/skills/psd-freshservice/get_daily_summary.js
+++ b/infra/agent-image/skills/psd-freshservice/get_daily_summary.js
@@ -76,7 +76,11 @@ function parseDate(arg) {
       label: t.toLocaleDateString('en-US', { weekday: 'long', month: 'short', day: 'numeric' }),
     };
   }
-  const d = new Date(arg);
+  // Append T00:00:00 to force parsing as local midnight. Without it,
+  // `new Date('2024-01-15')` is parsed as UTC midnight, which in the
+  // Pacific timezone (UTC-7/8) yields the *previous* calendar day for
+  // d.getFullYear()/getMonth()/getDate() — an off-by-one bug.
+  const d = new Date(`${arg}T00:00:00`);
   if (isNaN(d.getTime())) fail(`Could not parse --date: ${arg}`, 'bad_args');
   return {
     start: new Date(d.getFullYear(), d.getMonth(), d.getDate(), 0, 0, 0),

--- a/infra/agent-image/skills/psd-freshservice/get_daily_summary.js
+++ b/infra/agent-image/skills/psd-freshservice/get_daily_summary.js
@@ -1,0 +1,160 @@
+#!/usr/bin/env node
+/**
+ * get_daily_summary.js — daily ticket-close summary for a workspace.
+ *
+ * Usage:
+ *   node get_daily_summary.js --user <email> [--date <today|yesterday|YYYY-MM-DD|day-name|"last <day>">]
+ *                              [--workspace-id 2]
+ */
+
+'use strict';
+
+const { fail, emit, parseArgs, requireUser, getApiKey } = require('./lib/api');
+const {
+  categorizeTicket,
+  fetchAgentMap,
+  searchClosedTickets,
+} = require('./lib/summary-utils');
+
+const DAY_NAMES = ['sunday', 'monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday'];
+
+function parseDate(arg) {
+  const now = new Date();
+  if (!arg || arg === 'today') {
+    return {
+      start: new Date(now.getFullYear(), now.getMonth(), now.getDate(), 0, 0, 0),
+      end: new Date(now.getFullYear(), now.getMonth(), now.getDate(), 23, 59, 59),
+      label: 'today',
+    };
+  }
+  if (arg === 'yesterday') {
+    const y = new Date(now);
+    y.setDate(y.getDate() - 1);
+    return {
+      start: new Date(y.getFullYear(), y.getMonth(), y.getDate(), 0, 0, 0),
+      end: new Date(y.getFullYear(), y.getMonth(), y.getDate(), 23, 59, 59),
+      label: 'yesterday',
+    };
+  }
+  const lower = arg.toLowerCase();
+  if (lower.startsWith('last ')) {
+    const dayName = lower.replace('last ', '').trim();
+    const target = DAY_NAMES.indexOf(dayName);
+    if (target !== -1) {
+      const current = now.getDay();
+      let back = current - target;
+      if (back <= 0) back += 7;
+      const t = new Date(now);
+      t.setDate(t.getDate() - back);
+      return {
+        start: new Date(t.getFullYear(), t.getMonth(), t.getDate(), 0, 0, 0),
+        end: new Date(t.getFullYear(), t.getMonth(), t.getDate(), 23, 59, 59),
+        label: `last ${dayName.charAt(0).toUpperCase() + dayName.slice(1)}`,
+      };
+    }
+  }
+  const justDay = DAY_NAMES.indexOf(lower);
+  if (justDay !== -1) {
+    const current = now.getDay();
+    let back = current - justDay;
+    if (back < 0) back += 7;
+    if (back === 0) back = 7;
+    const t = new Date(now);
+    t.setDate(t.getDate() - back);
+    return {
+      start: new Date(t.getFullYear(), t.getMonth(), t.getDate(), 0, 0, 0),
+      end: new Date(t.getFullYear(), t.getMonth(), t.getDate(), 23, 59, 59),
+      label: t.toLocaleDateString('en-US', { weekday: 'long', month: 'short', day: 'numeric' }),
+    };
+  }
+  const d = new Date(arg);
+  if (isNaN(d.getTime())) fail(`Could not parse --date: ${arg}`, 'bad_args');
+  return {
+    start: new Date(d.getFullYear(), d.getMonth(), d.getDate(), 0, 0, 0),
+    end: new Date(d.getFullYear(), d.getMonth(), d.getDate(), 23, 59, 59),
+    label: d.toLocaleDateString('en-US', { weekday: 'long', month: 'short', day: 'numeric' }),
+  };
+}
+
+async function main() {
+  const args = parseArgs(process.argv);
+  if (args.help) {
+    console.log('Usage: get_daily_summary.js --user <email> [--date <today|yesterday|YYYY-MM-DD>] [--workspace-id 2]');
+    process.exit(0);
+  }
+  const userEmail = requireUser(args);
+  const dateArg = args.date && args.date !== true ? String(args.date) : 'today';
+  const workspaceId = args.workspace_id ? Number(args.workspace_id) : 2;
+  const range = parseDate(dateArg);
+
+  const apiKey = getApiKey(userEmail);
+  const [ticketRes, agentMap] = await Promise.all([
+    searchClosedTickets(apiKey, range.start, range.end, workspaceId),
+    fetchAgentMap(apiKey),
+  ]);
+  if (ticketRes.error) fail(ticketRes.error, 'upstream_error');
+
+  const tickets = ticketRes.tickets || [];
+  const byAgent = Object.create(null);
+  const byCategory = Object.create(null);
+  const automated = [];
+
+  for (const ticket of tickets) {
+    const category = categorizeTicket(ticket.subject);
+    byCategory[category] = (byCategory[category] || 0) + 1;
+
+    if (!ticket.responder_id) {
+      automated.push({
+        id: ticket.id,
+        subject: ticket.subject,
+        category,
+        updated_at: ticket.updated_at,
+      });
+      continue;
+    }
+    const id = ticket.responder_id;
+    if (!byAgent[id]) {
+      byAgent[id] = {
+        agent: agentMap[id] || { name: `Agent ${id}`, first_name: 'Unknown' },
+        tickets: [],
+        categories: Object.create(null),
+      };
+    }
+    byAgent[id].tickets.push({
+      id: ticket.id,
+      subject: ticket.subject,
+      category,
+      status: ticket.status,
+      priority: ticket.priority,
+      created_at: ticket.created_at,
+      updated_at: ticket.updated_at,
+    });
+    byAgent[id].categories[category] = (byAgent[id].categories[category] || 0) + 1;
+  }
+
+  const sortedAgents = Object.entries(byAgent)
+    .map(([id, data]) => ({
+      id,
+      name: data.agent.name,
+      first_name: data.agent.first_name,
+      job_title: data.agent.job_title,
+      count: data.tickets.length,
+      categories: data.categories,
+      tickets: data.tickets.sort((a, b) => new Date(a.updated_at) - new Date(b.updated_at)),
+    }))
+    .sort((a, b) => b.count - a.count);
+
+  emit({
+    date: range.label,
+    date_range: { start: range.start.toISOString(), end: range.end.toISOString() },
+    workspace_id: workspaceId,
+    total_closed: tickets.length,
+    by_category: Object.fromEntries(
+      Object.entries(byCategory).sort((a, b) => b[1] - a[1]),
+    ),
+    by_agent: sortedAgents,
+    automated: { count: automated.length, tickets: automated },
+  });
+}
+
+main().catch((err) => fail(err instanceof Error ? err.message : String(err)));

--- a/infra/agent-image/skills/psd-freshservice/get_daily_summary.js
+++ b/infra/agent-image/skills/psd-freshservice/get_daily_summary.js
@@ -88,11 +88,15 @@ async function main() {
   const range = parseDate(dateArg);
 
   const apiKey = getApiKey(userEmail);
-  const [ticketRes, agentMap] = await Promise.all([
-    searchClosedTickets(apiKey, range.start, range.end, workspaceId),
-    fetchAgentMap(apiKey),
-  ]);
+  const ticketRes = await searchClosedTickets(apiKey, range.start, range.end, workspaceId);
   if (ticketRes.error) fail(ticketRes.error, 'upstream_error');
+
+  // Fetch only agents that appear in ticket results — avoids paginating
+  // through the full agent roster (up to 50 API calls) on every summary.
+  const responderIds = (ticketRes.tickets || [])
+    .map((t) => t.responder_id)
+    .filter(Boolean);
+  const agentMap = await fetchAgentMap(apiKey, responderIds);
 
   const tickets = ticketRes.tickets || [];
   const byAgent = Object.create(null);

--- a/infra/agent-image/skills/psd-freshservice/get_daily_summary.js
+++ b/infra/agent-image/skills/psd-freshservice/get_daily_summary.js
@@ -148,7 +148,7 @@ async function main() {
     }))
     .sort((a, b) => b.count - a.count);
 
-  emit({
+  const output = {
     date: range.label,
     date_range: { start: range.start.toISOString(), end: range.end.toISOString() },
     workspace_id: workspaceId,
@@ -158,7 +158,11 @@ async function main() {
     ),
     by_agent: sortedAgents,
     automated: { count: automated.length, tickets: automated },
-  });
+  };
+  // Surface truncation warning so the agent can inform the user that
+  // the summary may be incomplete (>5,000 tickets in the period).
+  if (ticketRes.truncated) output.truncated = true;
+  emit(output);
 }
 
 main().catch((err) => fail(err instanceof Error ? err.message : String(err)));

--- a/infra/agent-image/skills/psd-freshservice/get_daily_summary.js
+++ b/infra/agent-image/skills/psd-freshservice/get_daily_summary.js
@@ -18,6 +18,15 @@ const {
 
 const DAY_NAMES = ['sunday', 'monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday'];
 
+/**
+ * Parse a human-friendly --date argument into a start/end Date pair.
+ *
+ * TIMEZONE: Date labels (toLocaleDateString) and day-of-week calculations
+ * depend on the container's TZ environment variable. The agent Dockerfile
+ * sets TZ=America/Los_Angeles so all date operations use Pacific time.
+ * If TZ is incorrect, date labels will misalign with the query window
+ * constructed in searchClosedTickets().
+ */
 function parseDate(arg) {
   const now = new Date();
   if (!arg || arg === 'today') {

--- a/infra/agent-image/skills/psd-freshservice/get_daily_summary.js
+++ b/infra/agent-image/skills/psd-freshservice/get_daily_summary.js
@@ -85,6 +85,7 @@ async function main() {
   const userEmail = requireUser(args);
   const dateArg = args.date && args.date !== true ? String(args.date) : 'today';
   const workspaceId = args.workspace_id ? Number(args.workspace_id) : 2;
+  if (isNaN(workspaceId)) fail('--workspace-id must be a number', 'bad_args');
   const range = parseDate(dateArg);
 
   const apiKey = getApiKey(userEmail);
@@ -162,6 +163,9 @@ async function main() {
   // Surface truncation warning so the agent can inform the user that
   // the summary may be incomplete (>5,000 tickets in the period).
   if (ticketRes.truncated) output.truncated = true;
+  // Surface partial-name warning when some agent lookups failed — callers
+  // should note that agent names like "Agent 12345" are placeholders.
+  if (agentMap.__partialNames) output.partial_agent_names = true;
   emit(output);
 }
 

--- a/infra/agent-image/skills/psd-freshservice/get_service_request.js
+++ b/infra/agent-image/skills/psd-freshservice/get_service_request.js
@@ -42,6 +42,16 @@ async function main() {
     }
   }
 
+  // Map all requested items — a service request may contain multiple line
+  // items (e.g. "Chromebook + charger"), not just the first one.
+  const serviceItems = requestedItems.map((item) => ({
+    id: item.service_item_id,
+    name: item.service_item_name,
+    quantity: item.quantity,
+    cost: item.cost_per_request,
+    custom_fields: item.custom_fields || {},
+  }));
+
   emit({
     ticket: {
       id: ticket.id,
@@ -60,12 +70,15 @@ async function main() {
       approval_status_name: ticket.approval_status_name,
     },
     requester,
-    form_data: requestedItems[0]?.custom_fields || {},
-    service_item: requestedItems[0] ? {
-      id: requestedItems[0].service_item_id,
-      name: requestedItems[0].service_item_name,
-      quantity: requestedItems[0].quantity,
-      cost: requestedItems[0].cost_per_request,
+    // Preserve backward-compat: form_data from the first item (most common case)
+    form_data: serviceItems[0]?.custom_fields || {},
+    service_items: serviceItems,
+    // Legacy singular field for backward compat — first item only
+    service_item: serviceItems[0] ? {
+      id: serviceItems[0].id,
+      name: serviceItems[0].name,
+      quantity: serviceItems[0].quantity,
+      cost: serviceItems[0].cost,
     } : null,
     conversations: (ticket.conversations || []).map((c) => ({
       id: c.id,

--- a/infra/agent-image/skills/psd-freshservice/get_service_request.js
+++ b/infra/agent-image/skills/psd-freshservice/get_service_request.js
@@ -1,0 +1,81 @@
+#!/usr/bin/env node
+/**
+ * get_service_request.js — fetch a service-request ticket with its
+ * conversation history, requester profile, and form data.
+ *
+ * Usage:
+ *   node get_service_request.js --user <email> --id <ticket_id>
+ */
+
+'use strict';
+
+const { fail, emit, parseArgs, requireUser, getApiKey, fsFetch } = require('./lib/api');
+
+async function main() {
+  const args = parseArgs(process.argv);
+  if (args.help) {
+    console.log('Usage: get_service_request.js --user <email> --id <ticket_id>');
+    process.exit(0);
+  }
+  const userEmail = requireUser(args);
+  const id = args.id;
+  if (!id || id === true) fail('--id is required', 'bad_args');
+
+  const apiKey = getApiKey(userEmail);
+  const ticketRes = await fsFetch(apiKey, `/tickets/${id}?include=conversations,requester`);
+  if (!ticketRes.__ok) fail(ticketRes.error, 'upstream_error');
+  const ticket = ticketRes.data.ticket || {};
+
+  const itemsRes = await fsFetch(apiKey, `/tickets/${id}/requested_items`);
+  const requestedItems = itemsRes.__ok ? (itemsRes.data.requested_items || []) : [];
+
+  let requester = null;
+  if (ticket.requester_id) {
+    const r = await fsFetch(apiKey, `/requesters/${ticket.requester_id}`);
+    if (r.__ok && r.data.requester) {
+      const rr = r.data.requester;
+      requester = {
+        name: `${rr.first_name || ''} ${rr.last_name || ''}`.trim(),
+        email: rr.primary_email,
+        department: (rr.department_names || [])[0] || null,
+        job_title: rr.job_title,
+      };
+    }
+  }
+
+  emit({
+    ticket: {
+      id: ticket.id,
+      subject: ticket.subject,
+      type: ticket.type,
+      status: ticket.status,
+      priority: ticket.priority,
+      category: ticket.category,
+      sub_category: ticket.sub_category,
+      item_category: ticket.item_category,
+      workspace_id: ticket.workspace_id,
+      created_at: ticket.created_at,
+      due_by: ticket.due_by,
+      is_escalated: ticket.is_escalated,
+      approval_status: ticket.approval_status,
+      approval_status_name: ticket.approval_status_name,
+    },
+    requester,
+    form_data: requestedItems[0]?.custom_fields || {},
+    service_item: requestedItems[0] ? {
+      id: requestedItems[0].service_item_id,
+      name: requestedItems[0].service_item_name,
+      quantity: requestedItems[0].quantity,
+      cost: requestedItems[0].cost_per_request,
+    } : null,
+    conversations: (ticket.conversations || []).map((c) => ({
+      id: c.id,
+      body_text: c.body_text,
+      private: c.private,
+      created_at: c.created_at,
+      user_id: c.user_id,
+    })),
+  });
+}
+
+main().catch((err) => fail(err instanceof Error ? err.message : String(err)));

--- a/infra/agent-image/skills/psd-freshservice/get_service_request.js
+++ b/infra/agent-image/skills/psd-freshservice/get_service_request.js
@@ -9,7 +9,7 @@
 
 'use strict';
 
-const { fail, emit, parseArgs, requireUser, getApiKey, fsFetch } = require('./lib/api');
+const { fail, emit, parseArgs, requireUser, getApiKey, fsFetch, requireTicketId } = require('./lib/api');
 
 async function main() {
   const args = parseArgs(process.argv);
@@ -18,8 +18,7 @@ async function main() {
     process.exit(0);
   }
   const userEmail = requireUser(args);
-  const id = args.id;
-  if (!id || id === true) fail('--id is required', 'bad_args');
+  const id = requireTicketId(args);
 
   const apiKey = getApiKey(userEmail);
   const ticketRes = await fsFetch(apiKey, `/tickets/${id}?include=conversations,requester`);

--- a/infra/agent-image/skills/psd-freshservice/get_ticket.js
+++ b/infra/agent-image/skills/psd-freshservice/get_ticket.js
@@ -11,7 +11,7 @@
 
 'use strict';
 
-const { fail, emit, parseArgs, requireUser, getApiKey, fsFetch } = require('./lib/api');
+const { fail, emit, parseArgs, requireUser, getApiKey, fsFetch, requireTicketId } = require('./lib/api');
 
 async function main() {
   const args = parseArgs(process.argv);
@@ -20,8 +20,7 @@ async function main() {
     process.exit(0);
   }
   const userEmail = requireUser(args);
-  const id = args.id;
-  if (!id || id === true) fail('--id is required', 'bad_args');
+  const id = requireTicketId(args);
 
   const apiKey = getApiKey(userEmail);
   const include = args.include && args.include !== true ? `?include=${encodeURIComponent(args.include)}` : '';

--- a/infra/agent-image/skills/psd-freshservice/get_ticket.js
+++ b/infra/agent-image/skills/psd-freshservice/get_ticket.js
@@ -1,0 +1,33 @@
+#!/usr/bin/env node
+/**
+ * get_ticket.js — get ticket details by ID.
+ *
+ * Usage:
+ *   node get_ticket.js --user <email> --id <ticket_id> [--include <comma-list>]
+ *
+ * Include options: conversations, requester, problem, stats, assets,
+ * change, related_tickets.
+ */
+
+'use strict';
+
+const { fail, emit, parseArgs, requireUser, getApiKey, fsFetch } = require('./lib/api');
+
+async function main() {
+  const args = parseArgs(process.argv);
+  if (args.help) {
+    console.log('Usage: get_ticket.js --user <email> --id <ticket_id> [--include <list>]');
+    process.exit(0);
+  }
+  const userEmail = requireUser(args);
+  const id = args.id;
+  if (!id || id === true) fail('--id is required', 'bad_args');
+
+  const apiKey = getApiKey(userEmail);
+  const include = args.include && args.include !== true ? `?include=${encodeURIComponent(args.include)}` : '';
+  const result = await fsFetch(apiKey, `/tickets/${id}${include}`);
+  if (!result.__ok) fail(result.error, 'upstream_error');
+  emit(result.data);
+}
+
+main().catch((err) => fail(err instanceof Error ? err.message : String(err)));

--- a/infra/agent-image/skills/psd-freshservice/get_weekly_summary.js
+++ b/infra/agent-image/skills/psd-freshservice/get_weekly_summary.js
@@ -1,0 +1,146 @@
+#!/usr/bin/env node
+/**
+ * get_weekly_summary.js — Mon-Sun ticket close summary with trends.
+ *
+ * Usage:
+ *   node get_weekly_summary.js --user <email> [--weeks-ago N] [--workspace-id 2]
+ */
+
+'use strict';
+
+const { fail, emit, parseArgs, requireUser, getApiKey } = require('./lib/api');
+const {
+  categorizeTicket,
+  fromUTCToPacific,
+  fetchAgentMap,
+  searchClosedTickets,
+} = require('./lib/summary-utils');
+
+const DAY_LABELS = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
+
+function getWeekRange(weeksAgo) {
+  const now = new Date();
+  const currentDay = now.getDay();
+  const mondayOffset = currentDay === 0 ? -6 : 1 - currentDay;
+  const monday = new Date(now);
+  monday.setDate(monday.getDate() + mondayOffset - weeksAgo * 7);
+  monday.setHours(0, 0, 0, 0);
+  const sunday = new Date(monday);
+  sunday.setDate(sunday.getDate() + 6);
+  sunday.setHours(23, 59, 59, 999);
+
+  const firstDayOfYear = new Date(monday.getFullYear(), 0, 1);
+  const pastDaysOfYear = (monday - firstDayOfYear) / 86400000;
+  const weekNum = Math.ceil((pastDaysOfYear + firstDayOfYear.getDay() + 1) / 7);
+
+  return {
+    start: monday,
+    end: sunday,
+    label: `Week ${weekNum} (${monday.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })} - ${sunday.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })})`,
+  };
+}
+
+function getDayName(date) {
+  return date.toLocaleDateString('en-US', { weekday: 'short' });
+}
+
+async function main() {
+  const args = parseArgs(process.argv);
+  if (args.help) {
+    console.log('Usage: get_weekly_summary.js --user <email> [--weeks-ago 0] [--workspace-id 2]');
+    process.exit(0);
+  }
+  const userEmail = requireUser(args);
+  const weeksAgo = args.weeks_ago ? parseInt(args.weeks_ago, 10) : 0;
+  const workspaceId = args.workspace_id ? Number(args.workspace_id) : 2;
+  const range = getWeekRange(weeksAgo);
+
+  const apiKey = getApiKey(userEmail);
+  const [ticketRes, agentMap] = await Promise.all([
+    searchClosedTickets(apiKey, range.start, range.end, workspaceId),
+    fetchAgentMap(apiKey),
+  ]);
+  if (ticketRes.error) fail(ticketRes.error, 'upstream_error');
+
+  const tickets = ticketRes.tickets || [];
+  const byDay = Object.create(null);
+  for (const d of DAY_LABELS) byDay[d] = { count: 0, categories: {}, agents: {} };
+
+  const byAgent = Object.create(null);
+  const byCategory = Object.create(null);
+  const byCategoryByDay = Object.create(null);
+
+  for (const ticket of tickets) {
+    const updatedAt = new Date(ticket.updated_at);
+    const pacific = fromUTCToPacific(updatedAt);
+    const dayName = getDayName(pacific);
+    const category = categorizeTicket(ticket.subject);
+
+    if (byDay[dayName]) {
+      byDay[dayName].count += 1;
+      byDay[dayName].categories[category] = (byDay[dayName].categories[category] || 0) + 1;
+      if (ticket.responder_id) {
+        byDay[dayName].agents[ticket.responder_id] = (byDay[dayName].agents[ticket.responder_id] || 0) + 1;
+      }
+    }
+    byCategory[category] = (byCategory[category] || 0) + 1;
+    if (!byCategoryByDay[category]) byCategoryByDay[category] = Object.create(null);
+    byCategoryByDay[category][dayName] = (byCategoryByDay[category][dayName] || 0) + 1;
+
+    if (ticket.responder_id) {
+      const id = ticket.responder_id;
+      if (!byAgent[id]) {
+        byAgent[id] = {
+          agent: agentMap[id] || { name: `Agent ${id}`, first_name: 'Unknown' },
+          count: 0,
+          categories: Object.create(null),
+          byDay: Object.create(null),
+        };
+      }
+      byAgent[id].count += 1;
+      byAgent[id].categories[category] = (byAgent[id].categories[category] || 0) + 1;
+      byAgent[id].byDay[dayName] = (byAgent[id].byDay[dayName] || 0) + 1;
+    }
+  }
+
+  const sortedAgents = Object.entries(byAgent)
+    .map(([id, data]) => ({
+      id,
+      name: data.agent.name,
+      first_name: data.agent.first_name,
+      job_title: data.agent.job_title,
+      count: data.count,
+      categories: data.categories,
+      byDay: data.byDay,
+      avg_per_day: (data.count / 5).toFixed(1),
+    }))
+    .sort((a, b) => b.count - a.count);
+
+  const weekdayCounts = DAY_LABELS.slice(0, 5).map((d) => byDay[d].count);
+  const avgDaily = weekdayCounts.reduce((a, b) => a + b, 0) / 5;
+  const peakDay = DAY_LABELS.slice(0, 5).reduce((max, d) => byDay[d].count > byDay[max].count ? d : max, 'Mon');
+  const slowDay = DAY_LABELS.slice(0, 5).reduce((min, d) => byDay[d].count < byDay[min].count ? d : min, 'Mon');
+
+  emit({
+    week: range.label,
+    date_range: { start: range.start.toISOString(), end: range.end.toISOString() },
+    workspace_id: workspaceId,
+    total_closed: tickets.length,
+    daily_average: avgDaily.toFixed(1),
+    trends: {
+      peak_day: { day: peakDay, count: byDay[peakDay].count },
+      slow_day: { day: slowDay, count: byDay[slowDay].count },
+      daily_counts: byDay,
+    },
+    by_category: Object.fromEntries(
+      Object.entries(byCategory)
+        .sort((a, b) => b[1] - a[1])
+        .map(([k, v]) => [k, { total: v, pct: tickets.length ? `${((v / tickets.length) * 100).toFixed(1)}%` : '0.0%' }]),
+    ),
+    category_trends: byCategoryByDay,
+    top_agents: sortedAgents.slice(0, 10),
+    all_agents: sortedAgents,
+  });
+}
+
+main().catch((err) => fail(err instanceof Error ? err.message : String(err)));

--- a/infra/agent-image/skills/psd-freshservice/get_weekly_summary.js
+++ b/infra/agent-image/skills/psd-freshservice/get_weekly_summary.js
@@ -147,8 +147,17 @@ async function main() {
 
   const weekdayCounts = DAY_LABELS.slice(0, 5).map((d) => byDay[d].count);
   const avgDaily = weekdayCounts.reduce((a, b) => a + b, 0) / elapsedWeekdays;
-  const peakDay = DAY_LABELS.slice(0, 5).reduce((max, d) => byDay[d].count > byDay[max].count ? d : max, 'Mon');
-  const slowDay = DAY_LABELS.slice(0, 5).reduce((min, d) => byDay[d].count < byDay[min].count ? d : min, 'Mon');
+
+  // When no tickets exist, peak/slow day are meaningless — return null to
+  // avoid misleading the agent into reporting "Monday was the slowest day"
+  // when every day had 0 tickets.
+  const hasTickets = tickets.length > 0;
+  const peakDay = hasTickets
+    ? DAY_LABELS.slice(0, 5).reduce((max, d) => byDay[d].count > byDay[max].count ? d : max, 'Mon')
+    : null;
+  const slowDay = hasTickets
+    ? DAY_LABELS.slice(0, 5).reduce((min, d) => byDay[d].count < byDay[min].count ? d : min, 'Mon')
+    : null;
 
   const output = {
     week: range.label,
@@ -157,8 +166,8 @@ async function main() {
     total_closed: tickets.length,
     daily_average: avgDaily.toFixed(1),
     trends: {
-      peak_day: { day: peakDay, count: byDay[peakDay].count },
-      slow_day: { day: slowDay, count: byDay[slowDay].count },
+      peak_day: peakDay ? { day: peakDay, count: byDay[peakDay].count } : null,
+      slow_day: slowDay ? { day: slowDay, count: byDay[slowDay].count } : null,
       daily_counts: byDay,
     },
     by_category: Object.fromEntries(

--- a/infra/agent-image/skills/psd-freshservice/get_weekly_summary.js
+++ b/infra/agent-image/skills/psd-freshservice/get_weekly_summary.js
@@ -11,12 +11,29 @@
 const { fail, emit, parseArgs, requireUser, getApiKey } = require('./lib/api');
 const {
   categorizeTicket,
-  fromUTCToPacific,
   fetchAgentMap,
   searchClosedTickets,
 } = require('./lib/summary-utils');
 
 const DAY_LABELS = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
+
+/**
+ * Count the number of elapsed weekdays (Mon-Fri) between start and now,
+ * capped at 5. For past-week queries this returns 5; for the current
+ * week (weeks-ago 0), it returns 1-5 based on what day it is today.
+ */
+function countElapsedWeekdays(rangeStart, rangeEnd) {
+  const now = new Date();
+  const effectiveEnd = rangeEnd < now ? rangeEnd : now;
+  let count = 0;
+  const cursor = new Date(rangeStart);
+  while (cursor <= effectiveEnd && count < 5) {
+    const day = cursor.getDay();
+    if (day >= 1 && day <= 5) count += 1;
+    cursor.setDate(cursor.getDate() + 1);
+  }
+  return Math.max(count, 1); // avoid division by zero
+}
 
 function getWeekRange(weeksAgo) {
   const now = new Date();
@@ -56,11 +73,15 @@ async function main() {
   const range = getWeekRange(weeksAgo);
 
   const apiKey = getApiKey(userEmail);
-  const [ticketRes, agentMap] = await Promise.all([
-    searchClosedTickets(apiKey, range.start, range.end, workspaceId),
-    fetchAgentMap(apiKey),
-  ]);
+  const ticketRes = await searchClosedTickets(apiKey, range.start, range.end, workspaceId);
   if (ticketRes.error) fail(ticketRes.error, 'upstream_error');
+
+  // Fetch only agents that appear in ticket results — avoids paginating
+  // through the full agent roster (up to 50 API calls) on every summary.
+  const responderIds = (ticketRes.tickets || [])
+    .map((t) => t.responder_id)
+    .filter(Boolean);
+  const agentMap = await fetchAgentMap(apiKey, responderIds);
 
   const tickets = ticketRes.tickets || [];
   const byDay = Object.create(null);
@@ -72,8 +93,9 @@ async function main() {
 
   for (const ticket of tickets) {
     const updatedAt = new Date(ticket.updated_at);
-    const pacific = fromUTCToPacific(updatedAt);
-    const dayName = getDayName(pacific);
+    // Dockerfile sets TZ=America/Los_Angeles — Date methods already use
+    // Pacific time. No manual offset conversion needed.
+    const dayName = getDayName(updatedAt);
     const category = categorizeTicket(ticket.subject);
 
     if (byDay[dayName]) {
@@ -103,6 +125,8 @@ async function main() {
     }
   }
 
+  const elapsedWeekdays = countElapsedWeekdays(range.start, range.end);
+
   const sortedAgents = Object.entries(byAgent)
     .map(([id, data]) => ({
       id,
@@ -112,12 +136,12 @@ async function main() {
       count: data.count,
       categories: data.categories,
       byDay: data.byDay,
-      avg_per_day: (data.count / 5).toFixed(1),
+      avg_per_day: (data.count / elapsedWeekdays).toFixed(1),
     }))
     .sort((a, b) => b.count - a.count);
 
   const weekdayCounts = DAY_LABELS.slice(0, 5).map((d) => byDay[d].count);
-  const avgDaily = weekdayCounts.reduce((a, b) => a + b, 0) / 5;
+  const avgDaily = weekdayCounts.reduce((a, b) => a + b, 0) / elapsedWeekdays;
   const peakDay = DAY_LABELS.slice(0, 5).reduce((max, d) => byDay[d].count > byDay[max].count ? d : max, 'Mon');
   const slowDay = DAY_LABELS.slice(0, 5).reduce((min, d) => byDay[d].count < byDay[min].count ? d : min, 'Mon');
 

--- a/infra/agent-image/skills/psd-freshservice/get_weekly_summary.js
+++ b/infra/agent-image/skills/psd-freshservice/get_weekly_summary.js
@@ -46,6 +46,10 @@ function getWeekRange(weeksAgo) {
   sunday.setDate(sunday.getDate() + 6);
   sunday.setHours(23, 59, 59, 999);
 
+  // Approximate week number — not ISO 8601 week numbering. May return
+  // incorrect values near year boundaries (ISO week 52/53 edge cases,
+  // e.g. Dec 31 of some years is ISO week 1 of the next year). This is
+  // used only for display labels, not for date arithmetic.
   const firstDayOfYear = new Date(monday.getFullYear(), 0, 1);
   const pastDaysOfYear = (monday - firstDayOfYear) / 86400000;
   const weekNum = Math.ceil((pastDaysOfYear + firstDayOfYear.getDay() + 1) / 7);

--- a/infra/agent-image/skills/psd-freshservice/get_weekly_summary.js
+++ b/infra/agent-image/skills/psd-freshservice/get_weekly_summary.js
@@ -149,7 +149,7 @@ async function main() {
   const peakDay = DAY_LABELS.slice(0, 5).reduce((max, d) => byDay[d].count > byDay[max].count ? d : max, 'Mon');
   const slowDay = DAY_LABELS.slice(0, 5).reduce((min, d) => byDay[d].count < byDay[min].count ? d : min, 'Mon');
 
-  emit({
+  const output = {
     week: range.label,
     date_range: { start: range.start.toISOString(), end: range.end.toISOString() },
     workspace_id: workspaceId,
@@ -168,7 +168,11 @@ async function main() {
     category_trends: byCategoryByDay,
     top_agents: sortedAgents.slice(0, 10),
     all_agents: sortedAgents,
-  });
+  };
+  // Surface truncation warning so the agent can inform the user that
+  // the summary may be incomplete (>5,000 tickets in the period).
+  if (ticketRes.truncated) output.truncated = true;
+  emit(output);
 }
 
 main().catch((err) => fail(err instanceof Error ? err.message : String(err)));

--- a/infra/agent-image/skills/psd-freshservice/get_weekly_summary.js
+++ b/infra/agent-image/skills/psd-freshservice/get_weekly_summary.js
@@ -74,6 +74,7 @@ async function main() {
   const userEmail = requireUser(args);
   const weeksAgo = args.weeks_ago ? parseInt(args.weeks_ago, 10) : 0;
   const workspaceId = args.workspace_id ? Number(args.workspace_id) : 2;
+  if (isNaN(workspaceId)) fail('--workspace-id must be a number', 'bad_args');
   const range = getWeekRange(weeksAgo);
 
   const apiKey = getApiKey(userEmail);
@@ -172,6 +173,9 @@ async function main() {
   // Surface truncation warning so the agent can inform the user that
   // the summary may be incomplete (>5,000 tickets in the period).
   if (ticketRes.truncated) output.truncated = true;
+  // Surface partial-name warning when some agent lookups failed — callers
+  // should note that agent names like "Agent 12345" are placeholders.
+  if (agentMap.__partialNames) output.partial_agent_names = true;
   emit(output);
 }
 

--- a/infra/agent-image/skills/psd-freshservice/get_workspaces.js
+++ b/infra/agent-image/skills/psd-freshservice/get_workspaces.js
@@ -1,0 +1,42 @@
+#!/usr/bin/env node
+/**
+ * get_workspaces.js — list workspaces the caller can see (or one by id).
+ *
+ * Usage:
+ *   node get_workspaces.js --user <email> [--id <workspace_id>]
+ *
+ * Without --id, probes the well-known PSD workspace IDs.
+ */
+
+'use strict';
+
+const { fail, emit, parseArgs, requireUser, getApiKey, fsFetch } = require('./lib/api');
+
+const KNOWN_WORKSPACE_IDS = [2, 3, 4, 5, 6, 8, 9, 10, 11, 13];
+
+async function main() {
+  const args = parseArgs(process.argv);
+  if (args.help) {
+    console.log('Usage: get_workspaces.js --user <email> [--id <workspace_id>]');
+    process.exit(0);
+  }
+  const userEmail = requireUser(args);
+  const apiKey = getApiKey(userEmail);
+
+  if (args.id && args.id !== true) {
+    const result = await fsFetch(apiKey, `/workspaces/${encodeURIComponent(args.id)}`);
+    if (!result.__ok) fail(result.error, 'upstream_error');
+    emit(result.data.workspace || result.data);
+    return;
+  }
+
+  const results = await Promise.all(KNOWN_WORKSPACE_IDS.map(async (id) => {
+    const r = await fsFetch(apiKey, `/workspaces/${id}`);
+    if (!r.__ok) return null;
+    const w = r.data.workspace || r.data;
+    return { id: w.id, name: w.name, primary: w.primary, state: w.state };
+  }));
+  emit({ workspaces: results.filter(Boolean) });
+}
+
+main().catch((err) => fail(err instanceof Error ? err.message : String(err)));

--- a/infra/agent-image/skills/psd-freshservice/get_workspaces.js
+++ b/infra/agent-image/skills/psd-freshservice/get_workspaces.js
@@ -27,7 +27,8 @@ async function main() {
     if (!/^\d+$/.test(String(args.id))) {
       fail('--id must be a numeric workspace ID', 'bad_args');
     }
-    const result = await fsFetch(apiKey, `/workspaces/${encodeURIComponent(args.id)}`);
+    // encodeURIComponent is unnecessary after ^\d+$ validation (digits never encode)
+    const result = await fsFetch(apiKey, `/workspaces/${args.id}`);
     if (!result.__ok) fail(result.error, 'upstream_error');
     emit(result.data.workspace || result.data);
     return;

--- a/infra/agent-image/skills/psd-freshservice/get_workspaces.js
+++ b/infra/agent-image/skills/psd-freshservice/get_workspaces.js
@@ -22,6 +22,11 @@ async function main() {
   const apiKey = getApiKey(userEmail);
 
   if (args.id && args.id !== true) {
+    // Workspace IDs are positive integers — apply the same numeric-only guard
+    // used for ticket IDs (requireTicketId) to prevent path traversal.
+    if (!/^\d+$/.test(String(args.id))) {
+      fail('--id must be a numeric workspace ID', 'bad_args');
+    }
     const result = await fsFetch(apiKey, `/workspaces/${encodeURIComponent(args.id)}`);
     if (!result.__ok) fail(result.error, 'upstream_error');
     emit(result.data.workspace || result.data);

--- a/infra/agent-image/skills/psd-freshservice/get_workspaces.js
+++ b/infra/agent-image/skills/psd-freshservice/get_workspaces.js
@@ -12,8 +12,6 @@
 
 const { fail, emit, parseArgs, requireUser, getApiKey, fsFetch } = require('./lib/api');
 
-const KNOWN_WORKSPACE_IDS = [2, 3, 4, 5, 6, 8, 9, 10, 11, 13];
-
 async function main() {
   const args = parseArgs(process.argv);
   if (args.help) {
@@ -30,13 +28,19 @@ async function main() {
     return;
   }
 
-  const results = await Promise.all(KNOWN_WORKSPACE_IDS.map(async (id) => {
-    const r = await fsFetch(apiKey, `/workspaces/${id}`);
-    if (!r.__ok) return null;
-    const w = r.data.workspace || r.data;
-    return { id: w.id, name: w.name, primary: w.primary, state: w.state };
+  // Use the /workspaces endpoint to list all accessible workspaces in a
+  // single API call instead of probing a hardcoded list of IDs. This is
+  // more robust (auto-discovers new workspaces) and more efficient (one
+  // call vs. N parallel calls).
+  const result = await fsFetch(apiKey, '/workspaces');
+  if (!result.__ok) fail(result.error, 'upstream_error');
+  const workspaces = (result.data.workspaces || []).map((w) => ({
+    id: w.id,
+    name: w.name,
+    primary: w.primary,
+    state: w.state,
   }));
-  emit({ workspaces: results.filter(Boolean) });
+  emit({ workspaces });
 }
 
 main().catch((err) => fail(err instanceof Error ? err.message : String(err)));

--- a/infra/agent-image/skills/psd-freshservice/lib/api.js
+++ b/infra/agent-image/skills/psd-freshservice/lib/api.js
@@ -141,7 +141,7 @@ function promptForKey(userEmail, reason) {
     storeCommand: {
       cmd: 'node',
       args: [
-        '/home/node/.openclaw/skills/psd-credentials/put.js',
+        '/opt/psd-skills/psd-credentials/put.js',
         '--user', userEmail,
         '--name', 'freshservice_api_key',
         '--value', '%%VALUE%%',

--- a/infra/agent-image/skills/psd-freshservice/lib/api.js
+++ b/infra/agent-image/skills/psd-freshservice/lib/api.js
@@ -78,6 +78,12 @@ function requireUser(args) {
  * Fetch the per-user Freshservice API key from psd-credentials. Returns
  * the key string, or emits a structured registration-prompt and exits
  * non-zero if the credential is not provisioned.
+ *
+ * Uses execFileSync (blocks the event loop) because each psd-freshservice
+ * script is a short-lived CLI process that does one thing then exits — no
+ * concurrent I/O to worry about. Do NOT call this from a server context;
+ * use the async execFile variant if this is ever imported into a long-lived
+ * process.
  */
 function getApiKey(userEmail) {
   let stdout = '';

--- a/infra/agent-image/skills/psd-freshservice/lib/api.js
+++ b/infra/agent-image/skills/psd-freshservice/lib/api.js
@@ -156,6 +156,18 @@ async function fsFetch(apiKey, urlPath, init = {}) {
   return { __ok: true, status: resp.status, data: json };
 }
 
+/**
+ * Validate and return a numeric ticket ID from parsed args. Freshservice
+ * ticket IDs are always positive integers — reject anything else to
+ * prevent path-traversal in URL interpolation.
+ */
+function requireTicketId(args) {
+  const id = args.id;
+  if (!id || id === true) fail('--id is required', 'bad_args');
+  if (!/^\d+$/.test(String(id))) fail('--id must be a numeric ticket ID', 'bad_args');
+  return String(id);
+}
+
 function parseJsonArg(arg, fieldName = 'JSON argument') {
   if (!arg || arg === true) {
     fail(`${fieldName} required`, 'bad_args');
@@ -177,5 +189,6 @@ module.exports = {
   requireUser,
   getApiKey,
   fsFetch,
+  requireTicketId,
   parseJsonArg,
 };

--- a/infra/agent-image/skills/psd-freshservice/lib/api.js
+++ b/infra/agent-image/skills/psd-freshservice/lib/api.js
@@ -158,6 +158,11 @@ async function fsFetch(apiKey, urlPath, init = {}) {
   // Always prepend BASE_URL — never allow callers to bypass the DOMAIN guard
   // by passing an absolute URL. All paths must be relative to the Freshservice
   // API v2 base (e.g. '/tickets/123', not 'https://...').
+  // Guard: urlPath must start with '/' to prevent accidental concatenation
+  // producing an invalid URL (e.g. BASE_URL + 'tickets' → '...v2tickets').
+  if (typeof urlPath !== 'string' || !urlPath.startsWith('/')) {
+    fail(`fsFetch: urlPath must start with '/' (got: ${String(urlPath).slice(0, 50)})`, 'bad_args');
+  }
   const url = `${BASE_URL}${urlPath}`;
   const headers = {
     'Authorization': authHeader(apiKey),

--- a/infra/agent-image/skills/psd-freshservice/lib/api.js
+++ b/infra/agent-image/skills/psd-freshservice/lib/api.js
@@ -23,7 +23,10 @@ const BASE_URL = `https://${DOMAIN}/api/v2`;
 
 const CREDENTIALS_GET = path.resolve(__dirname, '..', '..', 'psd-credentials', 'get.js');
 
-const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+// Basic email validation — intentionally simple for a CLI tool that only
+// accepts PSD domain emails. Rejects path separators (/) as defense-in-depth
+// since email values are interpolated into URL paths and Secrets Manager paths.
+const EMAIL_RE = /^[^\s@/]+@[^\s@/]+\.[^\s@/]+$/;
 
 function fail(message, code = 'error') {
   process.stderr.write(`Error: ${message}\n`);

--- a/infra/agent-image/skills/psd-freshservice/lib/api.js
+++ b/infra/agent-image/skills/psd-freshservice/lib/api.js
@@ -47,9 +47,9 @@ function parseArgs(argv) {
       continue;
     }
     if (!arg.startsWith('--')) {
-      args._positional = args._positional || [];
-      args._positional.push(arg);
-      continue;
+      // Positional args are not supported by psd-freshservice commands.
+      // Fail fast rather than silently ignoring.
+      fail(`Unexpected positional argument: ${arg}`, 'bad_args');
     }
     const key = arg.slice(2).replace(/-/g, '_');
     const next = argv[i + 1];

--- a/infra/agent-image/skills/psd-freshservice/lib/api.js
+++ b/infra/agent-image/skills/psd-freshservice/lib/api.js
@@ -1,0 +1,181 @@
+/**
+ * Shared helpers for the psd-freshservice OpenClaw skill.
+ *
+ * All commands authenticate with the caller's per-user Freshservice API
+ * key, fetched on demand via the psd-credentials skill at:
+ *   psd-agent-creds/{env}/user/{email}/freshservice_api_key
+ *
+ * If the credential is missing, the skill prints a structured prompt
+ * asking the user to register their key. Agent then collects the value
+ * from the user's next turn and stores it via psd-credentials/put.js.
+ *
+ * Domain is hardcoded to psd401.freshservice.com — the same value the
+ * reference psd-claude-plugins skill uses.
+ */
+
+'use strict';
+
+const { execFileSync } = require('node:child_process');
+const path = require('node:path');
+
+const DOMAIN = 'psd401.freshservice.com';
+const BASE_URL = `https://${DOMAIN}/api/v2`;
+
+const CREDENTIALS_GET = path.resolve(__dirname, '..', '..', 'psd-credentials', 'get.js');
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+function fail(message, code = 'error') {
+  process.stderr.write(`Error: ${message}\n`);
+  process.stdout.write(JSON.stringify({ error: code, message }) + '\n');
+  process.exit(1);
+}
+
+function emit(obj) {
+  process.stdout.write(JSON.stringify(obj, null, 2) + '\n');
+}
+
+function parseArgs(argv) {
+  const args = {};
+  for (let i = 2; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === '--help' || arg === '-h') {
+      args.help = true;
+      continue;
+    }
+    if (!arg.startsWith('--')) {
+      args._positional = args._positional || [];
+      args._positional.push(arg);
+      continue;
+    }
+    const key = arg.slice(2).replace(/-/g, '_');
+    const next = argv[i + 1];
+    if (!next || next.startsWith('--')) {
+      args[key] = true;
+    } else {
+      args[key] = next;
+      i++;
+    }
+  }
+  return args;
+}
+
+function validateEmail(email) {
+  return typeof email === 'string' && EMAIL_RE.test(email);
+}
+
+function requireUser(args) {
+  if (!validateEmail(args.user)) {
+    fail('--user is required and must be a valid email address', 'bad_args');
+  }
+  return args.user;
+}
+
+/**
+ * Fetch the per-user Freshservice API key from psd-credentials. Returns
+ * the key string, or emits a structured registration-prompt and exits
+ * non-zero if the credential is not provisioned.
+ */
+function getApiKey(userEmail) {
+  let stdout;
+  try {
+    stdout = execFileSync('node', [
+      CREDENTIALS_GET,
+      '--user', userEmail,
+      '--name', 'freshservice_api_key',
+    ], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'inherit'],
+    });
+  } catch (err) {
+    promptForKey(userEmail, err.message);
+  }
+
+  const lines = stdout.split('\n').filter((l) => l.trim().length > 0);
+  if (lines.length === 0) promptForKey(userEmail, 'no output from psd-credentials');
+
+  const last = lines[lines.length - 1];
+  let parsed;
+  try {
+    parsed = JSON.parse(last);
+  } catch (err) {
+    promptForKey(userEmail, `psd-credentials returned non-JSON: ${err.message}`);
+  }
+  if (parsed.error || !parsed.value) {
+    promptForKey(userEmail);
+  }
+  return parsed.value;
+}
+
+/**
+ * Print the structured prompt the agent should surface to the user when
+ * they have not registered their Freshservice API key yet. Exits 2 so
+ * the agent can detect the registration-needed state distinctly from
+ * other failure modes.
+ */
+function promptForKey(userEmail, reason) {
+  process.stdout.write(JSON.stringify({
+    error: 'freshservice_key_missing',
+    user: userEmail,
+    reason: reason || 'credential not provisioned',
+    instructions: [
+      'Open https://psd401.freshservice.com/agent/profile and copy your personal API key.',
+      'Paste it back to me in chat — I will store it securely in Secrets Manager so I can reuse it next time.',
+      'After you paste, I will retry the command via psd-credentials put.',
+    ],
+    storeCommand: {
+      cmd: 'node',
+      args: [
+        '/home/node/.openclaw/skills/psd-credentials/put.js',
+        '--user', userEmail,
+        '--name', 'freshservice_api_key',
+        '--value', '<PASTE THE KEY HERE>',
+      ],
+    },
+  }, null, 2) + '\n');
+  process.exit(2);
+}
+
+function authHeader(apiKey) {
+  return 'Basic ' + Buffer.from(`${apiKey}:X`).toString('base64');
+}
+
+async function fsFetch(apiKey, urlPath, init = {}) {
+  const url = urlPath.startsWith('http') ? urlPath : `${BASE_URL}${urlPath}`;
+  const headers = {
+    'Authorization': authHeader(apiKey),
+    'Content-Type': 'application/json',
+    ...(init.headers || {}),
+  };
+  const resp = await fetch(url, { ...init, headers });
+  if (!resp.ok) {
+    const body = await resp.text().catch(() => '');
+    return { __ok: false, status: resp.status, error: `API error ${resp.status}: ${body.slice(0, 500)}` };
+  }
+  const json = await resp.json().catch(() => ({}));
+  return { __ok: true, status: resp.status, data: json };
+}
+
+function parseJsonArg(arg, fieldName = 'JSON argument') {
+  if (!arg || arg === true) {
+    fail(`${fieldName} required`, 'bad_args');
+  }
+  try {
+    return JSON.parse(arg);
+  } catch (err) {
+    fail(`Invalid JSON for ${fieldName}: ${err.message}`, 'bad_args');
+  }
+}
+
+module.exports = {
+  DOMAIN,
+  BASE_URL,
+  fail,
+  emit,
+  parseArgs,
+  validateEmail,
+  requireUser,
+  getApiKey,
+  fsFetch,
+  parseJsonArg,
+};

--- a/infra/agent-image/skills/psd-freshservice/lib/api.js
+++ b/infra/agent-image/skills/psd-freshservice/lib/api.js
@@ -80,7 +80,7 @@ function requireUser(args) {
  * non-zero if the credential is not provisioned.
  */
 function getApiKey(userEmail) {
-  let stdout;
+  let stdout = '';
   try {
     stdout = execFileSync('node', [
       CREDENTIALS_GET,
@@ -149,7 +149,10 @@ function authHeader(apiKey) {
 }
 
 async function fsFetch(apiKey, urlPath, init = {}) {
-  const url = urlPath.startsWith('http') ? urlPath : `${BASE_URL}${urlPath}`;
+  // Always prepend BASE_URL — never allow callers to bypass the DOMAIN guard
+  // by passing an absolute URL. All paths must be relative to the Freshservice
+  // API v2 base (e.g. '/tickets/123', not 'https://...').
+  const url = `${BASE_URL}${urlPath}`;
   const headers = {
     'Authorization': authHeader(apiKey),
     'Content-Type': 'application/json',

--- a/infra/agent-image/skills/psd-freshservice/lib/api.js
+++ b/infra/agent-image/skills/psd-freshservice/lib/api.js
@@ -26,6 +26,7 @@ const CREDENTIALS_GET = path.resolve(__dirname, '..', '..', 'psd-credentials', '
 // Basic email validation — intentionally simple for a CLI tool that only
 // accepts PSD domain emails. Rejects path separators (/) as defense-in-depth
 // since email values are interpolated into URL paths and Secrets Manager paths.
+// Keep in sync with: psd-credentials/common.js and psd-image-gen/generate.js.
 const EMAIL_RE = /^[^\s@/]+@[^\s@/]+\.[^\s@/]+$/;
 
 function fail(message, code = 'error') {
@@ -143,8 +144,13 @@ function promptForKey(userEmail, reason) {
         '/home/node/.openclaw/skills/psd-credentials/put.js',
         '--user', userEmail,
         '--name', 'freshservice_api_key',
-        '--value', '<PASTE THE KEY HERE>',
+        '--value', '%%VALUE%%',
       ],
+      // The %%VALUE%% marker is where the agent must substitute the user's
+      // pasted API key. Using a distinctive marker (vs. natural language like
+      // "<PASTE THE KEY HERE>") makes substitution unambiguous in the args
+      // array and harder for the agent to mis-splice.
+      substitution: { '%%VALUE%%': 'Replace with the user-supplied Freshservice API key' },
     },
   }, null, 2) + '\n');
   process.exit(2);
@@ -171,6 +177,13 @@ async function fsFetch(apiKey, urlPath, init = {}) {
   };
   const resp = await fetch(url, { ...init, headers });
   if (!resp.ok) {
+    // Surface a specific error code for Freshservice rate limiting (429)
+    // so the agent can distinguish throttling from other API errors and
+    // advise the user to wait rather than retry immediately.
+    if (resp.status === 429) {
+      const retryAfter = resp.headers.get('retry-after') || 'unknown';
+      return { __ok: false, status: 429, error: `Freshservice rate limit exceeded. Retry after ${retryAfter}s.`, code: 'freshservice_rate_limited' };
+    }
     const body = await resp.text().catch(() => '');
     return { __ok: false, status: resp.status, error: `API error ${resp.status}: ${body.slice(0, 500)}` };
   }

--- a/infra/agent-image/skills/psd-freshservice/lib/api.js
+++ b/infra/agent-image/skills/psd-freshservice/lib/api.js
@@ -115,6 +115,11 @@ function getApiKey(userEmail) {
  * they have not registered their Freshservice API key yet. Exits 2 so
  * the agent can detect the registration-needed state distinctly from
  * other failure modes.
+ *
+ * Note: The storeCommand passes the secret via --value CLI argument,
+ * which is visible in ps output for the process lifetime. This is a
+ * known trade-off documented in psd-credentials/SKILL.md § "CLI argument
+ * exposure". A future improvement will pipe the value via stdin.
  */
 function promptForKey(userEmail, reason) {
   process.stdout.write(JSON.stringify({

--- a/infra/agent-image/skills/psd-freshservice/lib/summary-utils.js
+++ b/infra/agent-image/skills/psd-freshservice/lib/summary-utils.js
@@ -1,0 +1,90 @@
+/**
+ * Aggregation helpers shared between daily and weekly summary scripts.
+ *
+ * Pacific time conversions are intentionally fixed at UTC-8 (no DST
+ * adjustment) — matches the reference implementation's behavior. The
+ * date math is correct for the bulk of the school year; during DST
+ * (Mar–Nov) summary boundaries shift by one hour. Acceptable tradeoff
+ * versus pulling in a tz library here.
+ */
+
+'use strict';
+
+const { fsFetch } = require('./api');
+
+const PACIFIC_OFFSET_HOURS = 8;
+
+function toUTC(date) {
+  return new Date(date.getTime() + PACIFIC_OFFSET_HOURS * 60 * 60 * 1000).toISOString();
+}
+
+function fromUTCToPacific(date) {
+  return new Date(date.getTime() - PACIFIC_OFFSET_HOURS * 60 * 60 * 1000);
+}
+
+function categorizeTicket(subject) {
+  const lower = (subject || '').toLowerCase();
+  if (lower.includes('password reset')) return 'Password Reset';
+  if (lower.includes('security alert') || lower.includes('compromised') || lower.includes('breach')) return 'Security Alert';
+  if (lower.includes('schoology')) return 'Schoology';
+  if (lower.includes('powerschool')) return 'PowerSchool';
+  if (lower.includes('promethean')) return 'Promethean Board';
+  if (lower.includes('chromebook')) return 'Chromebook';
+  if (lower.includes('phone') || lower.includes('voicemail') || lower.includes('ext.')) return 'Phone/Voicemail';
+  if (lower.includes('badge')) return 'Badge Request';
+  if (lower.includes('new student') || lower.includes('enrollee')) return 'New Student';
+  if (lower.includes('intercom')) return 'Intercom';
+  if (lower.includes('raptor')) return 'Raptor';
+  if (lower.includes('goguardian') || lower.includes('go guardian')) return 'GoGuardian';
+  if (lower.includes('login') || lower.includes('access') || lower.includes('mfa')) return 'Access/Login';
+  return 'Other';
+}
+
+async function fetchAgentMap(apiKey) {
+  let all = [];
+  let page = 1;
+  while (page <= 50) {
+    const r = await fsFetch(apiKey, `/agents?per_page=100&page=${page}`);
+    if (!r.__ok) break;
+    const batch = r.data.agents || [];
+    all = all.concat(batch);
+    if (batch.length < 100) break;
+    page += 1;
+  }
+  const map = Object.create(null);
+  for (const agent of all) {
+    map[agent.id] = {
+      name: `${agent.first_name || ''} ${agent.last_name || ''}`.trim(),
+      first_name: agent.first_name,
+      job_title: agent.job_title,
+    };
+  }
+  return map;
+}
+
+async function searchClosedTickets(apiKey, startDate, endDate, workspaceId = 2) {
+  const startUTC = toUTC(startDate);
+  const endUTC = toUTC(endDate);
+  const query = `(status:4 OR status:5) AND updated_at:>'${startUTC.split('T')[0]}T00:00:00Z' AND updated_at:<'${endUTC.split('T')[0]}T23:59:59Z'`;
+
+  let all = [];
+  let page = 1;
+  while (page <= 50) {
+    const url = `/tickets/filter?query="${encodeURIComponent(query)}"&workspace_id=${workspaceId}&page=${page}&per_page=100`;
+    const r = await fsFetch(apiKey, url);
+    if (!r.__ok) return { error: r.error };
+    const batch = r.data.tickets || [];
+    all = all.concat(batch);
+    if (batch.length < 100) break;
+    page += 1;
+  }
+  return { tickets: all };
+}
+
+module.exports = {
+  toUTC,
+  fromUTCToPacific,
+  categorizeTicket,
+  fetchAgentMap,
+  searchClosedTickets,
+};

--- a/infra/agent-image/skills/psd-freshservice/lib/summary-utils.js
+++ b/infra/agent-image/skills/psd-freshservice/lib/summary-utils.js
@@ -39,20 +39,24 @@ async function fetchAgentMap(apiKey, agentIds) {
   const map = Object.create(null);
 
   if (agentIds && agentIds.length > 0) {
-    // Fetch only the agents we need — one call per unique ID. For a
-    // typical daily summary (~10-20 unique responders) this is 10-20
-    // API calls vs. potentially 50 paginated calls for the full roster.
+    // Fetch only the agents we need. Batched in groups of 10 to avoid
+    // saturating Freshservice's rate limits when a workspace has 50+
+    // unique responders in a single summary period.
+    const BATCH_SIZE = 10;
     const uniqueIds = [...new Set(agentIds)];
-    await Promise.all(uniqueIds.map(async (id) => {
-      const r = await fsFetch(apiKey, `/agents/${id}`);
-      if (!r.__ok) return;
-      const agent = r.data.agent || r.data;
-      map[id] = {
-        name: `${agent.first_name || ''} ${agent.last_name || ''}`.trim(),
-        first_name: agent.first_name,
-        job_title: agent.job_title,
-      };
-    }));
+    for (let i = 0; i < uniqueIds.length; i += BATCH_SIZE) {
+      const batch = uniqueIds.slice(i, i + BATCH_SIZE);
+      await Promise.all(batch.map(async (id) => {
+        const r = await fsFetch(apiKey, `/agents/${id}`);
+        if (!r.__ok) return;
+        const agent = r.data.agent || r.data;
+        map[id] = {
+          name: `${agent.first_name || ''} ${agent.last_name || ''}`.trim(),
+          first_name: agent.first_name,
+          job_title: agent.job_title,
+        };
+      }));
+    }
     return map;
   }
 
@@ -85,9 +89,11 @@ async function searchClosedTickets(apiKey, startDate, endDate, workspaceId = 2) 
   // component and reconstructed midnight UTC — off by 7-8 hours.
   const query = `(status:4 OR status:5) AND updated_at:>'${startDate.toISOString()}' AND updated_at:<'${endDate.toISOString()}'`;
 
+  const MAX_PAGES = 50;
   let all = [];
   let page = 1;
-  while (page <= 50) {
+  let hitPageCap = false;
+  while (page <= MAX_PAGES) {
     const url = `/tickets/filter?query="${encodeURIComponent(query)}"&workspace_id=${workspaceId}&page=${page}&per_page=100`;
     const r = await fsFetch(apiKey, url);
     if (!r.__ok) return { error: r.error };
@@ -95,8 +101,11 @@ async function searchClosedTickets(apiKey, startDate, endDate, workspaceId = 2) 
     all = all.concat(batch);
     if (batch.length < 100) break;
     page += 1;
+    if (page > MAX_PAGES) hitPageCap = true;
   }
-  return { tickets: all };
+  // Signal to callers when the page cap (50 × 100 = 5,000 tickets) was reached
+  // so the agent can warn the user that the summary may be incomplete.
+  return { tickets: all, truncated: hitPageCap };
 }
 
 module.exports = {

--- a/infra/agent-image/skills/psd-freshservice/lib/summary-utils.js
+++ b/infra/agent-image/skills/psd-freshservice/lib/summary-utils.js
@@ -1,25 +1,48 @@
 /**
  * Aggregation helpers shared between daily and weekly summary scripts.
  *
- * Pacific time conversions are intentionally fixed at UTC-8 (no DST
- * adjustment) — matches the reference implementation's behavior. The
- * date math is correct for the bulk of the school year; during DST
- * (Mar–Nov) summary boundaries shift by one hour. Acceptable tradeoff
- * versus pulling in a tz library here.
+ * Pacific time conversions use Intl.DateTimeFormat with
+ * 'America/Los_Angeles' for correct PST/PDT handling. No external
+ * tz library needed — Node.js ships ICU data by default.
  */
 
 'use strict';
 
 const { fsFetch } = require('./api');
 
-const PACIFIC_OFFSET_HOURS = 8;
+const PACIFIC_TZ = 'America/Los_Angeles';
+
+/**
+ * Get the UTC offset in milliseconds for a given date in Pacific time.
+ * Handles PST (UTC-8) vs PDT (UTC-7) automatically via Intl API.
+ */
+function getPacificOffsetMs(date) {
+  // Format the date parts in Pacific time to reconstruct the local
+  // timestamp, then diff against the UTC timestamp to find the offset.
+  const formatter = new Intl.DateTimeFormat('en-US', {
+    timeZone: PACIFIC_TZ,
+    year: 'numeric', month: '2-digit', day: '2-digit',
+    hour: '2-digit', minute: '2-digit', second: '2-digit',
+    hour12: false,
+  });
+  const parts = Object.fromEntries(
+    formatter.formatToParts(date).map((p) => [p.type, p.value]),
+  );
+  // Reconstruct a UTC timestamp that represents "what Pacific clocks show"
+  const pacificAsUtc = new Date(
+    `${parts.year}-${parts.month}-${parts.day}T${parts.hour}:${parts.minute}:${parts.second}Z`,
+  );
+  return date.getTime() - pacificAsUtc.getTime();
+}
 
 function toUTC(date) {
-  return new Date(date.getTime() + PACIFIC_OFFSET_HOURS * 60 * 60 * 1000).toISOString();
+  const offsetMs = getPacificOffsetMs(date);
+  return new Date(date.getTime() + offsetMs).toISOString();
 }
 
 function fromUTCToPacific(date) {
-  return new Date(date.getTime() - PACIFIC_OFFSET_HOURS * 60 * 60 * 1000);
+  const offsetMs = getPacificOffsetMs(date);
+  return new Date(date.getTime() - offsetMs);
 }
 
 function categorizeTicket(subject) {

--- a/infra/agent-image/skills/psd-freshservice/lib/summary-utils.js
+++ b/infra/agent-image/skills/psd-freshservice/lib/summary-utils.js
@@ -1,49 +1,15 @@
 /**
  * Aggregation helpers shared between daily and weekly summary scripts.
  *
- * Pacific time conversions use Intl.DateTimeFormat with
- * 'America/Los_Angeles' for correct PST/PDT handling. No external
- * tz library needed — Node.js ships ICU data by default.
+ * Pacific time is handled via the container's TZ=America/Los_Angeles
+ * setting (Dockerfile). Date objects use the system timezone automatically
+ * — no manual offset arithmetic needed. .toISOString() converts local
+ * timestamps to the correct UTC instants for Freshservice API queries.
  */
 
 'use strict';
 
 const { fsFetch } = require('./api');
-
-const PACIFIC_TZ = 'America/Los_Angeles';
-
-/**
- * Get the UTC offset in milliseconds for a given date in Pacific time.
- * Handles PST (UTC-8) vs PDT (UTC-7) automatically via Intl API.
- */
-function getPacificOffsetMs(date) {
-  // Format the date parts in Pacific time to reconstruct the local
-  // timestamp, then diff against the UTC timestamp to find the offset.
-  const formatter = new Intl.DateTimeFormat('en-US', {
-    timeZone: PACIFIC_TZ,
-    year: 'numeric', month: '2-digit', day: '2-digit',
-    hour: '2-digit', minute: '2-digit', second: '2-digit',
-    hour12: false,
-  });
-  const parts = Object.fromEntries(
-    formatter.formatToParts(date).map((p) => [p.type, p.value]),
-  );
-  // Reconstruct a UTC timestamp that represents "what Pacific clocks show"
-  const pacificAsUtc = new Date(
-    `${parts.year}-${parts.month}-${parts.day}T${parts.hour}:${parts.minute}:${parts.second}Z`,
-  );
-  return date.getTime() - pacificAsUtc.getTime();
-}
-
-function toUTC(date) {
-  const offsetMs = getPacificOffsetMs(date);
-  return new Date(date.getTime() + offsetMs).toISOString();
-}
-
-function fromUTCToPacific(date) {
-  const offsetMs = getPacificOffsetMs(date);
-  return new Date(date.getTime() - offsetMs);
-}
 
 function categorizeTicket(subject) {
   const lower = (subject || '').toLowerCase();
@@ -63,7 +29,35 @@ function categorizeTicket(subject) {
   return 'Other';
 }
 
-async function fetchAgentMap(apiKey) {
+/**
+ * Build an agent-ID-to-name map. When agentIds are provided, fetches
+ * only those specific agents (one API call per agent) instead of
+ * paginating through all agents (up to 50 pages / 5000 agents).
+ * Falls back to full pagination when no IDs are provided.
+ */
+async function fetchAgentMap(apiKey, agentIds) {
+  const map = Object.create(null);
+
+  if (agentIds && agentIds.length > 0) {
+    // Fetch only the agents we need — one call per unique ID. For a
+    // typical daily summary (~10-20 unique responders) this is 10-20
+    // API calls vs. potentially 50 paginated calls for the full roster.
+    const uniqueIds = [...new Set(agentIds)];
+    await Promise.all(uniqueIds.map(async (id) => {
+      const r = await fsFetch(apiKey, `/agents/${id}`);
+      if (!r.__ok) return;
+      const agent = r.data.agent || r.data;
+      map[id] = {
+        name: `${agent.first_name || ''} ${agent.last_name || ''}`.trim(),
+        first_name: agent.first_name,
+        job_title: agent.job_title,
+      };
+    }));
+    return map;
+  }
+
+  // Fallback: fetch all agents via pagination (used when caller
+  // doesn't know which IDs to expect).
   let all = [];
   let page = 1;
   while (page <= 50) {
@@ -74,7 +68,6 @@ async function fetchAgentMap(apiKey) {
     if (batch.length < 100) break;
     page += 1;
   }
-  const map = Object.create(null);
   for (const agent of all) {
     map[agent.id] = {
       name: `${agent.first_name || ''} ${agent.last_name || ''}`.trim(),
@@ -86,9 +79,11 @@ async function fetchAgentMap(apiKey) {
 }
 
 async function searchClosedTickets(apiKey, startDate, endDate, workspaceId = 2) {
-  const startUTC = toUTC(startDate);
-  const endUTC = toUTC(endDate);
-  const query = `(status:4 OR status:5) AND updated_at:>'${startUTC.split('T')[0]}T00:00:00Z' AND updated_at:<'${endUTC.split('T')[0]}T23:59:59Z'`;
+  // startDate/endDate are local Date objects (Pacific, per Dockerfile TZ).
+  // .toISOString() emits the correct UTC instant for Pacific midnight/EOD.
+  // Previous code used toUTC() then .split('T')[0] which discarded the time
+  // component and reconstructed midnight UTC — off by 7-8 hours.
+  const query = `(status:4 OR status:5) AND updated_at:>'${startDate.toISOString()}' AND updated_at:<'${endDate.toISOString()}'`;
 
   let all = [];
   let page = 1;
@@ -105,8 +100,6 @@ async function searchClosedTickets(apiKey, startDate, endDate, workspaceId = 2) 
 }
 
 module.exports = {
-  toUTC,
-  fromUTCToPacific,
   categorizeTicket,
   fetchAgentMap,
   searchClosedTickets,

--- a/infra/agent-image/skills/psd-freshservice/lib/summary-utils.js
+++ b/infra/agent-image/skills/psd-freshservice/lib/summary-utils.js
@@ -106,9 +106,14 @@ async function searchClosedTickets(apiKey, startDate, endDate, workspaceId = 2) 
     if (!r.__ok) return { error: r.error };
     const batch = r.data.tickets || [];
     all = all.concat(batch);
+    // If this page was full AND we've reached the cap, stop with truncation flag.
+    // Explicit break avoids a subtle post-increment check that's fragile to refactoring.
+    if (batch.length === 100 && page === MAX_PAGES) {
+      hitPageCap = true;
+      break;
+    }
     if (batch.length < 100) break;
     page += 1;
-    if (page > MAX_PAGES) hitPageCap = true;
   }
   // Signal to callers when the page cap (50 × 100 = 5,000 tickets) was reached
   // so the agent can warn the user that the summary may be incomplete.

--- a/infra/agent-image/skills/psd-freshservice/lib/summary-utils.js
+++ b/infra/agent-image/skills/psd-freshservice/lib/summary-utils.js
@@ -52,8 +52,16 @@ async function fetchAgentMap(apiKey, agentIds) {
     // saturating Freshservice's rate limits when a workspace has 50+
     // unique responders in a single summary period.
     const BATCH_SIZE = 10;
+    const INTER_BATCH_DELAY_MS = 50;
     const uniqueIds = [...new Set(agentIds)];
     for (let i = 0; i < uniqueIds.length; i += BATCH_SIZE) {
+      // Yield between batches to avoid saturating Freshservice's 400 req/min
+      // rate limit when a workspace has 50+ unique responders in a single
+      // summary period. The first batch fires immediately; subsequent batches
+      // wait 50ms to spread the load.
+      if (i > 0) {
+        await new Promise((r) => setTimeout(r, INTER_BATCH_DELAY_MS));
+      }
       const batch = uniqueIds.slice(i, i + BATCH_SIZE);
       await Promise.all(batch.map(async (id) => {
         const r = await fsFetch(apiKey, `/agents/${id}`);

--- a/infra/agent-image/skills/psd-freshservice/lib/summary-utils.js
+++ b/infra/agent-image/skills/psd-freshservice/lib/summary-utils.js
@@ -41,6 +41,12 @@ async function fetchAgentMap(apiKey, agentIds) {
   // warn the user that some agent names are placeholders ("Agent 12345").
   let partialNames = false;
 
+  // Type guard: callers must pass an array (or omit entirely for full pagination).
+  // Spreading a non-array into `new Set()` throws cryptically — fail fast instead.
+  if (agentIds != null && !Array.isArray(agentIds)) {
+    throw new Error('fetchAgentMap: agentIds must be an array or null/undefined');
+  }
+
   if (agentIds && agentIds.length > 0) {
     // Fetch only the agents we need. Batched in groups of 10 to avoid
     // saturating Freshservice's rate limits when a workspace has 50+

--- a/infra/agent-image/skills/psd-freshservice/lib/summary-utils.js
+++ b/infra/agent-image/skills/psd-freshservice/lib/summary-utils.js
@@ -37,6 +37,9 @@ function categorizeTicket(subject) {
  */
 async function fetchAgentMap(apiKey, agentIds) {
   const map = Object.create(null);
+  // Track whether any individual agent lookups failed, so callers can
+  // warn the user that some agent names are placeholders ("Agent 12345").
+  let partialNames = false;
 
   if (agentIds && agentIds.length > 0) {
     // Fetch only the agents we need. Batched in groups of 10 to avoid
@@ -48,7 +51,10 @@ async function fetchAgentMap(apiKey, agentIds) {
       const batch = uniqueIds.slice(i, i + BATCH_SIZE);
       await Promise.all(batch.map(async (id) => {
         const r = await fsFetch(apiKey, `/agents/${id}`);
-        if (!r.__ok) return;
+        if (!r.__ok) {
+          partialNames = true;
+          return;
+        }
         const agent = r.data.agent || r.data;
         map[id] = {
           name: `${agent.first_name || ''} ${agent.last_name || ''}`.trim(),
@@ -57,6 +63,7 @@ async function fetchAgentMap(apiKey, agentIds) {
         };
       }));
     }
+    map.__partialNames = partialNames;
     return map;
   }
 

--- a/infra/agent-image/skills/psd-freshservice/list_agents.js
+++ b/infra/agent-image/skills/psd-freshservice/list_agents.js
@@ -1,0 +1,56 @@
+#!/usr/bin/env node
+/**
+ * list_agents.js — list all active Freshservice agents.
+ *
+ * Usage:
+ *   node list_agents.js --user <email> [--query <name-or-email-substring>]
+ */
+
+'use strict';
+
+const { fail, emit, parseArgs, requireUser, getApiKey, fsFetch } = require('./lib/api');
+
+async function main() {
+  const args = parseArgs(process.argv);
+  if (args.help) {
+    console.log('Usage: list_agents.js --user <email> [--query <name-substring>]');
+    process.exit(0);
+  }
+  const userEmail = requireUser(args);
+  const query = args.query && args.query !== true ? String(args.query).toLowerCase() : null;
+
+  const apiKey = getApiKey(userEmail);
+  let all = [];
+  let page = 1;
+  // Cap pages defensively — Freshservice tenants typically have a few hundred agents.
+  while (page <= 50) {
+    const result = await fsFetch(apiKey, `/agents?per_page=100&page=${page}`);
+    if (!result.__ok) fail(result.error, 'upstream_error');
+    const batch = result.data.agents || [];
+    all = all.concat(batch);
+    if (batch.length < 100) break;
+    page += 1;
+  }
+
+  let agents = all
+    .filter((a) => a.active)
+    .map((a) => ({
+      id: a.id,
+      name: `${a.first_name} ${a.last_name}`,
+      first_name: a.first_name,
+      last_name: a.last_name,
+      email: a.email,
+      job_title: a.job_title,
+    }));
+
+  if (query) {
+    agents = agents.filter((a) =>
+      (a.first_name || '').toLowerCase().includes(query) ||
+      (a.last_name || '').toLowerCase().includes(query) ||
+      (a.email || '').toLowerCase().includes(query));
+  }
+  agents.sort((a, b) => (a.first_name || '').localeCompare(b.first_name || ''));
+  emit({ count: agents.length, agents });
+}
+
+main().catch((err) => fail(err instanceof Error ? err.message : String(err)));

--- a/infra/agent-image/skills/psd-freshservice/list_agents.js
+++ b/infra/agent-image/skills/psd-freshservice/list_agents.js
@@ -36,7 +36,7 @@ async function main() {
     .filter((a) => a.active)
     .map((a) => ({
       id: a.id,
-      name: `${a.first_name} ${a.last_name}`,
+      name: `${a.first_name || ''} ${a.last_name || ''}`.trim(),
       first_name: a.first_name,
       last_name: a.last_name,
       email: a.email,

--- a/infra/agent-image/skills/psd-freshservice/list_tickets.js
+++ b/infra/agent-image/skills/psd-freshservice/list_tickets.js
@@ -1,0 +1,57 @@
+#!/usr/bin/env node
+/**
+ * list_tickets.js — list Freshservice tickets with optional filters.
+ *
+ * Usage:
+ *   node list_tickets.js --user <email> [--options '<json>']
+ *
+ * Options JSON: { workspace_id, filter, include, per_page, page,
+ *                 order_type, updated_since }.
+ * filter: new_and_my_open | watching | spam | deleted | archived
+ */
+
+'use strict';
+
+const { fail, emit, parseArgs, requireUser, getApiKey, fsFetch, parseJsonArg } =
+  require('./lib/api');
+
+async function main() {
+  const args = parseArgs(process.argv);
+  if (args.help) {
+    console.log('Usage: list_tickets.js --user <email> [--options \'{"workspace_id":2,"filter":"new_and_my_open"}\']');
+    process.exit(0);
+  }
+  const userEmail = requireUser(args);
+  const apiKey = getApiKey(userEmail);
+  const opts = args.options ? parseJsonArg(args.options, '--options') : {};
+
+  const params = new URLSearchParams();
+  if (opts.workspace_id !== undefined) params.append('workspace_id', String(opts.workspace_id));
+  if (opts.filter) params.append('filter', String(opts.filter));
+  if (opts.include) params.append('include', String(opts.include));
+  params.append('per_page', String(opts.per_page || 30));
+  if (opts.page) params.append('page', String(opts.page));
+  if (opts.order_type) params.append('order_type', String(opts.order_type));
+  if (opts.updated_since) params.append('updated_since', String(opts.updated_since));
+
+  const result = await fsFetch(apiKey, `/tickets?${params.toString()}`);
+  if (!result.__ok) fail(result.error, 'upstream_error');
+
+  const tickets = (result.data.tickets || []).map((t) => ({
+    id: t.id,
+    subject: t.subject,
+    status: t.status,
+    priority: t.priority,
+    requester_id: t.requester_id,
+    responder_id: t.responder_id,
+    group_id: t.group_id,
+    workspace_id: t.workspace_id,
+    created_at: t.created_at,
+    updated_at: t.updated_at,
+    due_by: t.due_by,
+  }));
+
+  emit({ count: tickets.length, tickets });
+}
+
+main().catch((err) => fail(err instanceof Error ? err.message : String(err)));

--- a/infra/agent-image/skills/psd-freshservice/package.json
+++ b/infra/agent-image/skills/psd-freshservice/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "psd-freshservice",
+  "version": "1.0.0",
+  "description": "OpenClaw skill: Freshservice ticket / approval / agent management with per-user API key from Secrets Manager",
+  "private": true,
+  "dependencies": {}
+}

--- a/infra/agent-image/skills/psd-freshservice/search_tickets.js
+++ b/infra/agent-image/skills/psd-freshservice/search_tickets.js
@@ -1,0 +1,46 @@
+#!/usr/bin/env node
+/**
+ * search_tickets.js — search tickets via Freshservice filter query.
+ *
+ * Usage:
+ *   node search_tickets.js --user <email> --query '<query>' [--workspace-id N]
+ *
+ * Query syntax: field:value AND/OR field:value. Fields include status,
+ * priority, agent_id, group_id, created_at, updated_at, responder_id.
+ */
+
+'use strict';
+
+const { fail, emit, parseArgs, requireUser, getApiKey, fsFetch } = require('./lib/api');
+
+async function main() {
+  const args = parseArgs(process.argv);
+  if (args.help) {
+    console.log('Usage: search_tickets.js --user <email> --query "status:2 AND priority:3" [--workspace-id 2]');
+    process.exit(0);
+  }
+  const userEmail = requireUser(args);
+  const query = args.query;
+  if (!query || query === true) fail('--query is required', 'bad_args');
+  const workspaceId = args.workspace_id || '0';
+
+  const apiKey = getApiKey(userEmail);
+  const url = `/tickets/filter?query="${encodeURIComponent(query)}"&workspace_id=${encodeURIComponent(workspaceId)}`;
+  const result = await fsFetch(apiKey, url);
+  if (!result.__ok) fail(result.error, 'upstream_error');
+
+  const tickets = (result.data.tickets || []).map((t) => ({
+    id: t.id,
+    subject: t.subject,
+    status: t.status,
+    priority: t.priority,
+    workspace_id: t.workspace_id,
+    responder_id: t.responder_id,
+    created_at: t.created_at,
+    updated_at: t.updated_at,
+    due_by: t.due_by,
+  }));
+  emit({ count: tickets.length, tickets });
+}
+
+main().catch((err) => fail(err instanceof Error ? err.message : String(err)));

--- a/infra/agent-image/skills/psd-freshservice/search_tickets.js
+++ b/infra/agent-image/skills/psd-freshservice/search_tickets.js
@@ -22,7 +22,9 @@ async function main() {
   const userEmail = requireUser(args);
   const query = args.query;
   if (!query || query === true) fail('--query is required', 'bad_args');
-  const workspaceId = args.workspace_id || '0';
+  // Default to workspace 2 (Technology) — consistent with daily/weekly summary
+  // scripts. Freshservice's workspace_id=0 behavior is undocumented.
+  const workspaceId = args.workspace_id || '2';
 
   const apiKey = getApiKey(userEmail);
   const url = `/tickets/filter?query="${encodeURIComponent(query)}"&workspace_id=${encodeURIComponent(workspaceId)}`;

--- a/infra/agent-image/skills/psd-freshservice/search_tickets.js
+++ b/infra/agent-image/skills/psd-freshservice/search_tickets.js
@@ -28,6 +28,12 @@ async function main() {
   if (isNaN(workspaceId)) fail('--workspace-id must be a number', 'bad_args');
 
   const apiKey = getApiKey(userEmail);
+  // The query string is passed through to Freshservice's filter API as-is
+  // (after URL-encoding). This is intentional — search_tickets is a power-user
+  // tool that exposes the full Freshservice filter syntax (field:value AND/OR
+  // field:value). Freshservice enforces its own access controls on the
+  // caller's API key, so this does not expand the user's data access beyond
+  // what their key already permits.
   const url = `/tickets/filter?query="${encodeURIComponent(query)}"&workspace_id=${workspaceId}`;
   const result = await fsFetch(apiKey, url);
   if (!result.__ok) fail(result.error, 'upstream_error');

--- a/infra/agent-image/skills/psd-freshservice/search_tickets.js
+++ b/infra/agent-image/skills/psd-freshservice/search_tickets.js
@@ -24,10 +24,11 @@ async function main() {
   if (!query || query === true) fail('--query is required', 'bad_args');
   // Default to workspace 2 (Technology) — consistent with daily/weekly summary
   // scripts. Freshservice's workspace_id=0 behavior is undocumented.
-  const workspaceId = args.workspace_id || '2';
+  const workspaceId = args.workspace_id ? Number(args.workspace_id) : 2;
+  if (isNaN(workspaceId)) fail('--workspace-id must be a number', 'bad_args');
 
   const apiKey = getApiKey(userEmail);
-  const url = `/tickets/filter?query="${encodeURIComponent(query)}"&workspace_id=${encodeURIComponent(workspaceId)}`;
+  const url = `/tickets/filter?query="${encodeURIComponent(query)}"&workspace_id=${workspaceId}`;
   const result = await fsFetch(apiKey, url);
   if (!result.__ok) fail(result.error, 'upstream_error');
 

--- a/infra/agent-image/skills/psd-freshservice/update_ticket.js
+++ b/infra/agent-image/skills/psd-freshservice/update_ticket.js
@@ -1,0 +1,38 @@
+#!/usr/bin/env node
+/**
+ * update_ticket.js — update an existing ticket.
+ *
+ * Usage:
+ *   node update_ticket.js --user <email> --id <ticket_id> --data '<json>'
+ *
+ * Updatable: status, priority, responder_id, group_id, subject,
+ * description, custom_fields. Status 2=Open 3=Pending 4=Resolved
+ * 5=Closed. Priority 1=Low 2=Medium 3=High 4=Urgent.
+ */
+
+'use strict';
+
+const { fail, emit, parseArgs, requireUser, getApiKey, fsFetch, parseJsonArg } =
+  require('./lib/api');
+
+async function main() {
+  const args = parseArgs(process.argv);
+  if (args.help) {
+    console.log('Usage: update_ticket.js --user <email> --id <ticket_id> --data \'{...}\'');
+    process.exit(0);
+  }
+  const userEmail = requireUser(args);
+  const id = args.id;
+  if (!id || id === true) fail('--id is required', 'bad_args');
+  const data = parseJsonArg(args.data, '--data');
+
+  const apiKey = getApiKey(userEmail);
+  const result = await fsFetch(apiKey, `/tickets/${id}`, {
+    method: 'PUT',
+    body: JSON.stringify(data),
+  });
+  if (!result.__ok) fail(result.error, 'upstream_error');
+  emit(result.data);
+}
+
+main().catch((err) => fail(err instanceof Error ? err.message : String(err)));

--- a/infra/agent-image/skills/psd-freshservice/update_ticket.js
+++ b/infra/agent-image/skills/psd-freshservice/update_ticket.js
@@ -25,10 +25,28 @@ async function main() {
   const id = requireTicketId(args);
   const data = parseJsonArg(args.data, '--data');
 
+  // Allowlist of Freshservice ticket fields the agent may update. Mirrors the
+  // ALLOWED_FIELDS set in create_ticket.js — prevents the agent from sending
+  // privileged fields (e.g. source, type, internal metadata) that Freshservice
+  // accepts but the agent should not control. custom_fields is included because
+  // Freshservice treats it as an opaque JSON object scoped to the ticket.
+  const ALLOWED_FIELDS = new Set([
+    'subject', 'description', 'status', 'priority',
+    'group_id', 'responder_id', 'cc_emails', 'tags',
+    'category', 'sub_category', 'item_category', 'due_by', 'fr_due_by',
+    'urgency', 'impact', 'custom_fields',
+  ]);
+  const filtered = Object.create(null);
+  for (const key of Object.keys(data)) {
+    if (ALLOWED_FIELDS.has(key)) {
+      filtered[key] = data[key];
+    }
+  }
+
   const apiKey = getApiKey(userEmail);
   const result = await fsFetch(apiKey, `/tickets/${id}`, {
     method: 'PUT',
-    body: JSON.stringify(data),
+    body: JSON.stringify(filtered),
   });
   if (!result.__ok) fail(result.error, 'upstream_error');
   emit(result.data);

--- a/infra/agent-image/skills/psd-freshservice/update_ticket.js
+++ b/infra/agent-image/skills/psd-freshservice/update_ticket.js
@@ -12,7 +12,7 @@
 
 'use strict';
 
-const { fail, emit, parseArgs, requireUser, getApiKey, fsFetch, parseJsonArg } =
+const { fail, emit, parseArgs, requireUser, getApiKey, fsFetch, requireTicketId, parseJsonArg } =
   require('./lib/api');
 
 async function main() {
@@ -22,8 +22,7 @@ async function main() {
     process.exit(0);
   }
   const userEmail = requireUser(args);
-  const id = args.id;
-  if (!id || id === true) fail('--id is required', 'bad_args');
+  const id = requireTicketId(args);
   const data = parseJsonArg(args.data, '--data');
 
   const apiKey = getApiKey(userEmail);

--- a/infra/agent-image/skills/psd-image-gen/SKILL.md
+++ b/infra/agent-image/skills/psd-image-gen/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: psd-image-gen
+summary: Generate images with OpenAI gpt-image-2 — shared API key, district-funded.
+description: Generates an image from a text prompt via OpenAI's gpt-image-2 model and returns a presigned S3 URL the agent can surface in chat. Uses a shared (district-funded) OpenAI API key from Secrets Manager — usage costs accrue centrally. Restricted by the `skill.image-gen` capability; users without the capability cannot see or invoke this skill. Output includes the URL, model, and resolved size; never the API key.
+allowed-tools: Bash(node:*)
+---
+
+# psd-image-gen
+
+Generate an image from a prompt using OpenAI `gpt-image-2-2026-04-21`. The image is uploaded to the agent workspace S3 bucket and returned as a presigned URL valid for 1 hour. Surface the URL to the user — Google Chat will render it as a download link today (inline rendering is a planned follow-up).
+
+**Identity.** All commands require `--user <caller-email>`. Pass the email verbatim from the `[caller: Name <email>]` header of the user turn.
+
+## Usage
+
+```bash
+node /home/node/.openclaw/skills/psd-image-gen/generate.js \
+  --user <email> \
+  --prompt "<image description>" \
+  [--size 1024x1024 | 1024x1536 | 1536x1024 | auto] \
+  [--quality low | medium | high | auto] \
+  [--background opaque | transparent | auto]
+```
+
+Returns JSON: `{ "url": "...", "model": "gpt-image-2-2026-04-21", "prompt": "...", "size": "...", "expiresAt": "..." }`.
+
+## Prompting Guidance
+
+- Be specific about subject, composition, lighting, style.
+- gpt-image-2 has strong text rendering — request labels, titles, captions where useful.
+- Default `size` is `auto` (model chooses). Specify a size only when aspect ratio matters.
+- Default `quality` is `auto`. Use `high` for hero imagery; `low` for thumbnails / iterative drafts to save spend.
+
+## Cost Note
+
+gpt-image-2 is priced per output token. The shared key bills the district. Prefer fewer high-quality generations over many drafts. If the user iterates rapidly, suggest finalizing the prompt before re-generating.
+
+## Permission Model
+
+This skill enforces the `skill.image-gen` capability at invocation time. The capability is granted via roles in the AI Studio `tools` / `role_tools` tables (currently named `tools`; renaming to `capabilities` under epic #922 / issue #923). Migration 075 seeds the capability and grants it to the `administrator` and `staff` roles.
+
+**Catalog visibility caveat.** OpenClaw loads skills statically at container startup, so the skill *appears* in `tools.catalog` for all users. Users without the capability who try to invoke it receive `forbidden_capability` and the call refuses before any OpenAI traffic is sent. Catalog-level filtering (so the skill is invisible to ungranted users) is a planned follow-up once OpenClaw exposes a per-session catalog hook.
+
+## Errors
+
+- **`forbidden_capability`** — caller lacks `skill.image-gen` capability. The skill refuses without spending any OpenAI quota. Tell the user to ask an administrator to grant it via `/admin/roles`.
+- **`shared_key_missing`** — the shared OpenAI key has not been bootstrapped. Tell the user to ask an administrator to provision `psd-agent-creds/{env}/shared/openai_api_key` from the AI Studio settings table value.
+- **`upstream_error`** — OpenAI returned non-2xx. Surface the status and a brief message; do not retry automatically.
+
+## Operational Notes
+
+- Always reads the OpenAI key via `psd-credentials/get.js --shared --name openai_api_key`. Never reads from environment variables.
+- Uploads to `s3://$WORKSPACE_BUCKET/images/<email>/<uuid>.png` with `application/png` content type.
+- Presigned URL TTL: 3600s. Re-generate via this skill if a longer-lived link is needed (we do not extend TTLs).

--- a/infra/agent-image/skills/psd-image-gen/SKILL.md
+++ b/infra/agent-image/skills/psd-image-gen/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: psd-image-gen
 summary: Generate images with OpenAI gpt-image-2 — shared API key, district-funded.
-description: Generates an image from a text prompt via OpenAI's gpt-image-2 model and returns a presigned S3 URL the agent can surface in chat. Uses a shared (district-funded) OpenAI API key from Secrets Manager — usage costs accrue centrally. Restricted by the `skill.image-gen` capability; users without the capability cannot see or invoke this skill. Output includes the URL, model, and resolved size; never the API key.
+description: Generates an image from a text prompt via OpenAI's gpt-image-2 model and returns a presigned S3 URL the agent can surface in chat. Uses a shared (district-funded) OpenAI API key from Secrets Manager — usage costs accrue centrally. Restricted by the `skill.image-gen` capability; users without the capability will be refused at invocation time (the skill remains visible in the catalog until OpenClaw supports per-session filtering). Output includes the URL, model, and resolved size; never the API key.
 allowed-tools: Bash(node:*)
 ---
 
@@ -49,6 +49,6 @@ This skill enforces the `skill.image-gen` capability at invocation time. The cap
 
 ## Operational Notes
 
-- Always reads the OpenAI key via `psd-credentials/get.js --shared --name openai_api_key`. Never reads from environment variables.
-- Uploads to `s3://$WORKSPACE_BUCKET/images/<email>/<uuid>.png` with `application/png` content type.
+- Always reads the OpenAI key via `psd-credentials/get.js --user <email> --shared --name openai_api_key`. The `--shared` flag skips user-scoped lookups to ensure the district-funded key is always used. Never reads from environment variables.
+- Uploads to `s3://$WORKSPACE_BUCKET/images/<email>/<uuid>.png` with `image/png` content type.
 - Presigned URL TTL: 3600s. Re-generate via this skill if a longer-lived link is needed (we do not extend TTLs).

--- a/infra/agent-image/skills/psd-image-gen/SKILL.md
+++ b/infra/agent-image/skills/psd-image-gen/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: psd-image-gen
 summary: Generate images with OpenAI gpt-image-2 — shared API key, district-funded.
-description: Generates an image from a text prompt via OpenAI's gpt-image-2 model and returns a presigned S3 URL the agent can surface in chat. Uses a shared (district-funded) OpenAI API key from Secrets Manager — usage costs accrue centrally. Restricted by the `skill.image-gen` capability; users without the capability will be refused at invocation time (the skill remains visible in the catalog until OpenClaw supports per-session filtering). Output includes the URL, model, and resolved size; never the API key.
+description: Generates an image from a text prompt via OpenAI's gpt-image-2 model, uploads the PNG to a public-by-link S3 prefix, and returns an unsigned HTTPS URL the agent can surface in chat. Uses a shared (district-funded) OpenAI API key from Secrets Manager — usage costs accrue centrally. Restricted by the `skill.image-gen` capability; users without the capability will be refused at invocation time (the skill remains visible in the catalog until OpenClaw supports per-session filtering). Output includes the URL, model, and resolved size; never the API key.
 allowed-tools: Bash(node:*)
 ---
 
 # psd-image-gen
 
-Generate an image from a prompt using OpenAI `gpt-image-2`. The image is uploaded to the agent workspace S3 bucket and returned as a presigned URL valid for 1 hour. Surface the URL to the user — Google Chat will render it as a download link today (inline rendering is a planned follow-up).
+Generate an image from a prompt using OpenAI `gpt-image-2`. The image is uploaded to the workspace S3 bucket under the `public-images/` prefix (granted public `s3:GetObject` by the bucket policy) and returned as an unsigned HTTPS URL — anyone who receives the URL can fetch the image. The UUID in the path makes the link unguessable; the security model matches Google Drive "anyone with the link" sharing. Surface the URL to the user — Google Chat will render it as a download link today (inline rendering is a planned follow-up).
 
 **Identity.** All commands require `--user <caller-email>`. Pass the email verbatim from the `[caller: Name <email>]` header of the user turn.
 
@@ -22,7 +22,7 @@ node /home/node/.openclaw/skills/psd-image-gen/generate.js \
   [--background opaque | transparent | auto]
 ```
 
-Returns JSON: `{ "url": "...", "model": "gpt-image-2", "prompt": "...", "size": "...", "expiresAt": "..." }`.
+Returns JSON: `{ "url": "...", "s3Key": "public-images/.../...png", "model": "gpt-image-2", "prompt": "...", "size": "...", "sharing": "public-by-link" }`.
 
 ## Prompting Guidance
 
@@ -50,11 +50,6 @@ This skill enforces the `skill.image-gen` capability at invocation time. The cap
 ## Operational Notes
 
 - Always reads the OpenAI key via `psd-credentials/get.js --user <email> --shared --name openai_api_key`. The `--shared` flag skips user-scoped lookups to ensure the district-funded key is always used. Never reads from environment variables.
-- Uploads to `s3://$WORKSPACE_BUCKET/images/<email>/<uuid>.png` with `image/png` content type.
-- Presigned URL TTL: 3600s. Re-generate via this skill if a longer-lived link is needed (we do not extend TTLs).
-
-## Known limitation: presigned URLs returning `InvalidToken` in chat
-
-When the skill runs inside the AgentCore runtime, the presigned URL is signed with the runtime's STS session credentials and embeds an `X-Amz-Security-Token` query parameter. Some chat clients (observed: Google Chat link-preview fetcher) mishandle the URL-encoded characters in the security token, producing `InvalidToken: The provided token is malformed or otherwise invalid` when the user clicks the URL — even though the underlying object is intact in S3.
-
-The agent should not retry generating the URL when this happens — the failure is structural to session-credentialed presigning, not a per-invocation flake. Tracked in the follow-up issue noted in the PR description; fix path is to stop returning STS-signed URLs and instead either return a public URL from a dedicated public-read prefix, or have the agent-router (long-lived role) re-sign with its own credentials before posting to chat.
+- Uploads to `s3://$WORKSPACE_BUCKET/public-images/<email>/<uuid>.png` with `image/png` content type. The `public-images/` prefix has a bucket-policy ALLOW for `s3:GetObject` to `Principal: *`; other prefixes in the bucket remain private.
+- Returned URL is **unsigned** and does not embed any STS token. It does not expire — anyone who receives the link can fetch until the object is deleted.
+- This was a deliberate switch from presigned URLs (PR #934 dev rollout 2026-05-03): presigned URLs signed with AgentCore's STS session credentials produced intermittent `InvalidToken` failures when fetched through chat clients. Unsigned-public-by-link is the structural fix.

--- a/infra/agent-image/skills/psd-image-gen/SKILL.md
+++ b/infra/agent-image/skills/psd-image-gen/SKILL.md
@@ -14,7 +14,7 @@ Generate an image from a prompt using OpenAI `gpt-image-2`. The image is uploade
 ## Usage
 
 ```bash
-node /home/node/.openclaw/skills/psd-image-gen/generate.js \
+node /opt/psd-skills/psd-image-gen/generate.js \
   --user <email> \
   --prompt "<image description>" \
   [--size 1024x1024 | 1024x1536 | 1536x1024 | auto] \

--- a/infra/agent-image/skills/psd-image-gen/SKILL.md
+++ b/infra/agent-image/skills/psd-image-gen/SKILL.md
@@ -7,7 +7,7 @@ allowed-tools: Bash(node:*)
 
 # psd-image-gen
 
-Generate an image from a prompt using OpenAI `gpt-image-2-2026-04-21`. The image is uploaded to the agent workspace S3 bucket and returned as a presigned URL valid for 1 hour. Surface the URL to the user — Google Chat will render it as a download link today (inline rendering is a planned follow-up).
+Generate an image from a prompt using OpenAI `gpt-image-2`. The image is uploaded to the agent workspace S3 bucket and returned as a presigned URL valid for 1 hour. Surface the URL to the user — Google Chat will render it as a download link today (inline rendering is a planned follow-up).
 
 **Identity.** All commands require `--user <caller-email>`. Pass the email verbatim from the `[caller: Name <email>]` header of the user turn.
 
@@ -22,7 +22,7 @@ node /home/node/.openclaw/skills/psd-image-gen/generate.js \
   [--background opaque | transparent | auto]
 ```
 
-Returns JSON: `{ "url": "...", "model": "gpt-image-2-2026-04-21", "prompt": "...", "size": "...", "expiresAt": "..." }`.
+Returns JSON: `{ "url": "...", "model": "gpt-image-2", "prompt": "...", "size": "...", "expiresAt": "..." }`.
 
 ## Prompting Guidance
 
@@ -52,3 +52,9 @@ This skill enforces the `skill.image-gen` capability at invocation time. The cap
 - Always reads the OpenAI key via `psd-credentials/get.js --user <email> --shared --name openai_api_key`. The `--shared` flag skips user-scoped lookups to ensure the district-funded key is always used. Never reads from environment variables.
 - Uploads to `s3://$WORKSPACE_BUCKET/images/<email>/<uuid>.png` with `image/png` content type.
 - Presigned URL TTL: 3600s. Re-generate via this skill if a longer-lived link is needed (we do not extend TTLs).
+
+## Known limitation: presigned URLs returning `InvalidToken` in chat
+
+When the skill runs inside the AgentCore runtime, the presigned URL is signed with the runtime's STS session credentials and embeds an `X-Amz-Security-Token` query parameter. Some chat clients (observed: Google Chat link-preview fetcher) mishandle the URL-encoded characters in the security token, producing `InvalidToken: The provided token is malformed or otherwise invalid` when the user clicks the URL — even though the underlying object is intact in S3.
+
+The agent should not retry generating the URL when this happens — the failure is structural to session-credentialed presigning, not a per-invocation flake. Tracked in the follow-up issue noted in the PR description; fix path is to stop returning STS-signed URLs and instead either return a public URL from a dedicated public-read prefix, or have the agent-router (long-lived role) re-sign with its own credentials before posting to chat.

--- a/infra/agent-image/skills/psd-image-gen/SKILL.md
+++ b/infra/agent-image/skills/psd-image-gen/SKILL.md
@@ -24,6 +24,21 @@ node /opt/psd-skills/psd-image-gen/generate.js \
 
 Returns JSON: `{ "url": "...", "s3Key": "public-images/.../...png", "model": "gpt-image-2", "prompt": "...", "size": "...", "sharing": "public-by-link" }`.
 
+## Required Reply Format
+
+After this skill returns a 2xx result, your **next chat message MUST be the bare `url` value on a line by itself**.
+
+- ✅ Correct:
+  ```
+  Here you go:
+  https://psd-agents-dev-390844780692.s3.us-east-1.amazonaws.com/public-images/<email>/<uuid>.png
+  ```
+- ❌ Wrong: Describing the image's contents/layers/composition in prose without pasting the URL. The user cannot see the tool result. If the URL is not in your chat reply, the user got nothing.
+- ❌ Wrong: Wrapping the URL in `[label](url)` or `**bold**` — Google Chat's renderer corrupts these for long S3 URLs. Bare URL only.
+- ❌ Wrong: Re-generating, "fixing," or presigning the returned URL. It is already a public-by-link URL with HTTP 200; do not touch it.
+
+You may add one short sentence of context above or below the URL line ("Here's the infographic.") but the URL line itself is non-negotiable.
+
 ## Prompting Guidance
 
 - Be specific about subject, composition, lighting, style.

--- a/infra/agent-image/skills/psd-image-gen/generate.js
+++ b/infra/agent-image/skills/psd-image-gen/generate.js
@@ -128,18 +128,9 @@ function enforceCapability(userEmail) {
   }
   if (exitStatus === 0) return;
 
-  const lines = stdout.split('\n').filter((l) => l.trim().length > 0);
-  let parsed = null;
-  if (lines.length > 0) {
-    try { parsed = JSON.parse(lines[lines.length - 1]); } catch { /* fall through */ }
-  }
-  // Intentionally defensive: check_capability.js's contract is exit 0 = granted
-  // (handled above), exit 3 = denied. This second check covers the edge case where
-  // check_capability exits non-zero (e.g. signal/crash) but still emitted
-  // {granted: true} to stdout before dying. In that scenario we trust the stdout
-  // payload over the exit code, because the capability query itself succeeded.
-  const granted = parsed && parsed.granted === true;
-  if (granted) return;
+  // Fail-closed: any non-zero exit from check_capability.js means denied.
+  // We do NOT trust stdout {granted: true} when the process exited non-zero
+  // (e.g. signal, crash) — exit code is the sole source of truth for RBAC gates.
   fail(
     `User ${userEmail} lacks the ${REQUIRED_CAPABILITY} capability. ` +
     'Ask an administrator to grant it via the role assignments at /admin/roles.',

--- a/infra/agent-image/skills/psd-image-gen/generate.js
+++ b/infra/agent-image/skills/psd-image-gen/generate.js
@@ -57,7 +57,10 @@ function fail(message, code = 'error') {
 }
 
 function emit(obj) {
-  process.stdout.write(JSON.stringify(obj) + '\n');
+  // Pretty-print for consistency with psd-freshservice/lib/api.js:emit.
+  // All skills should emit the same JSON format so the agent receives
+  // uniform output regardless of which skill produced it.
+  process.stdout.write(JSON.stringify(obj, null, 2) + '\n');
 }
 
 function parseArgs(argv) {
@@ -115,7 +118,6 @@ function validateEmail(email) {
  * future change once OpenClaw exposes a per-session catalog hook.
  */
 function enforceCapability(userEmail) {
-  let exitStatus;
   try {
     execFileSync('node', [
       CREDENTIALS_CHECK_CAPABILITY,
@@ -125,11 +127,11 @@ function enforceCapability(userEmail) {
       encoding: 'utf8',
       stdio: ['ignore', 'pipe', 'inherit'],
     });
-    exitStatus = 0;
-  } catch (err) {
-    exitStatus = err.status === undefined ? 1 : err.status;
+    // Exit code 0 — capability granted, return without error.
+    return;
+  } catch {
+    // Non-zero exit — fall through to fail-closed denial below.
   }
-  if (exitStatus === 0) return;
 
   // Fail-closed: any non-zero exit from check_capability.js means denied.
   // We do NOT trust stdout {granted: true} when the process exited non-zero

--- a/infra/agent-image/skills/psd-image-gen/generate.js
+++ b/infra/agent-image/skills/psd-image-gen/generate.js
@@ -26,12 +26,16 @@ const { getSignedUrl } = require('@aws-sdk/s3-request-presigner');
 const REGION = process.env.AWS_REGION || 'us-east-1';
 const WORKSPACE_BUCKET = process.env.WORKSPACE_BUCKET || '';
 const PRESIGN_TTL_SECONDS = 3600;
-// Pinned to a dated snapshot for reproducibility. OpenAI may deprecate this
-// specific version without notice — if the skill starts returning upstream_error,
-// update to the latest `gpt-image-2-YYYY-MM-DD` version (or the unversioned
-// `gpt-image-2` alias if reproducibility is no longer a concern). Also update
-// SKILL.md when changing this value.
-const MODEL_ID = 'gpt-image-2-2026-04-21';
+// The unversioned alias rather than a dated snapshot. The dated form
+// (`gpt-image-2-2026-04-21`) is gated by an OpenAI per-project allowlist
+// and silently 404s for projects that don't have that snapshot enabled —
+// observed in dev on 2026-05-03, broke image-gen end-to-end. The alias
+// resolves to whatever the project has access to and rolls forward
+// automatically as OpenAI publishes new versions. We trade pin-style
+// reproducibility for actually working; if a future OpenAI release
+// changes output meaningfully, we'll re-pin to the new dated version.
+// Also update SKILL.md when changing this value.
+const MODEL_ID = 'gpt-image-2';
 const ALLOWED_SIZES = new Set(['1024x1024', '1024x1536', '1536x1024', 'auto']);
 const ALLOWED_QUALITIES = new Set(['low', 'medium', 'high', 'auto']);
 const ALLOWED_BACKGROUNDS = new Set(['opaque', 'transparent', 'auto']);

--- a/infra/agent-image/skills/psd-image-gen/generate.js
+++ b/infra/agent-image/skills/psd-image-gen/generate.js
@@ -20,12 +20,17 @@ const { execFileSync } = require('node:child_process');
 const { randomUUID } = require('node:crypto');
 const path = require('node:path');
 
-const { S3Client, PutObjectCommand, GetObjectCommand } = require('@aws-sdk/client-s3');
-const { getSignedUrl } = require('@aws-sdk/s3-request-presigner');
+const { S3Client, PutObjectCommand } = require('@aws-sdk/client-s3');
 
 const REGION = process.env.AWS_REGION || 'us-east-1';
 const WORKSPACE_BUCKET = process.env.WORKSPACE_BUCKET || '';
-const PRESIGN_TTL_SECONDS = 3600;
+// Skill output lives under `public-images/` which is granted public
+// `s3:GetObject` by the workspace bucket's resource policy (see
+// agent-platform-stack.ts:AgentWorkspaceBucket). Anyone who receives the
+// returned URL can fetch the image — same security model as Google
+// Drive "anyone with the link" sharing. The UUID in the key makes the
+// path unguessable. Keep this prefix in sync with the bucket policy.
+const PUBLIC_PREFIX = 'public-images';
 // The unversioned alias rather than a dated snapshot. The dated form
 // (`gpt-image-2-2026-04-21`) is gated by an OpenAI per-project allowlist
 // and silently 404s for projects that don't have that snapshot enabled —
@@ -212,13 +217,16 @@ async function generateImage(apiKey, params) {
   return Buffer.from(first.b64_json, 'base64');
 }
 
-async function uploadAndPresign(bytes, userEmail) {
+async function uploadAndShare(bytes, userEmail) {
   // Defense-in-depth guard — main() checks WORKSPACE_BUCKET before the OpenAI
   // call, so this is only reachable if the function is called from a new path.
   if (!WORKSPACE_BUCKET) {
     fail('WORKSPACE_BUCKET env var not set — cannot upload generated image', 'misconfigured');
   }
-  const key = `images/${userEmail}/${randomUUID()}.png`;
+  // Encode each path segment so emails with `+` (subaddressing) survive the
+  // URL round-trip. randomUUID() returns RFC4122 hex with hyphens — already
+  // URL-safe.
+  const key = `${PUBLIC_PREFIX}/${userEmail}/${randomUUID()}.png`;
   const s3 = new S3Client({ region: REGION });
 
   await s3.send(new PutObjectCommand({
@@ -232,14 +240,12 @@ async function uploadAndPresign(bytes, userEmail) {
     },
   }));
 
-  const url = await getSignedUrl(
-    s3,
-    new GetObjectCommand({ Bucket: WORKSPACE_BUCKET, Key: key }),
-    { expiresIn: PRESIGN_TTL_SECONDS },
-  );
-
-  const expiresAt = new Date(Date.now() + PRESIGN_TTL_SECONDS * 1000).toISOString();
-  return { url, key, expiresAt };
+  // Path-style URL: avoids any DNS-vs-virtual-hosted-style ambiguity for
+  // bucket names that contain dots. Path segments are URL-encoded so
+  // emails with reserved characters (`+`, `/`, `&`) survive intact.
+  const encodedKey = key.split('/').map(encodeURIComponent).join('/');
+  const url = `https://${WORKSPACE_BUCKET}.s3.${REGION}.amazonaws.com/${encodedKey}`;
+  return { url, key };
 }
 
 async function main() {
@@ -282,7 +288,7 @@ async function main() {
   enforceCapability(args.user);
   const apiKey = readSharedOpenAIKey(args.user);
   const bytes = await generateImage(apiKey, { prompt: args.prompt, size, quality, background });
-  const { url, key, expiresAt } = await uploadAndPresign(bytes, args.user);
+  const { url, key } = await uploadAndShare(bytes, args.user);
 
   emit({
     url,
@@ -292,7 +298,9 @@ async function main() {
     size,
     quality,
     background,
-    expiresAt,
+    // The URL is unsigned and does not expire. Anyone with the link can fetch
+    // until the object is deleted (manual lifecycle policy may be added later).
+    sharing: 'public-by-link',
   });
 }
 

--- a/infra/agent-image/skills/psd-image-gen/generate.js
+++ b/infra/agent-image/skills/psd-image-gen/generate.js
@@ -1,0 +1,266 @@
+#!/usr/bin/env node
+/**
+ * generate.js — psd-image-gen.generate
+ * Usage:
+ *   node generate.js --user <email> --prompt "<text>"
+ *                    [--size 1024x1024|1024x1536|1536x1024|auto]
+ *                    [--quality low|medium|high|auto]
+ *                    [--background opaque|transparent|auto]
+ *
+ * Calls OpenAI v1/images/generations with model gpt-image-2-2026-04-21,
+ * uploads the result to the agent workspace S3 bucket, and returns a
+ * presigned URL valid for 1 hour. The shared OpenAI key is read from
+ * Secrets Manager via the psd-credentials skill — never from env vars
+ * or files.
+ */
+
+'use strict';
+
+const { execFileSync } = require('node:child_process');
+const { randomUUID } = require('node:crypto');
+const path = require('node:path');
+
+const { S3Client, PutObjectCommand, GetObjectCommand } = require('@aws-sdk/client-s3');
+const { getSignedUrl } = require('@aws-sdk/s3-request-presigner');
+
+const REGION = process.env.AWS_REGION || 'us-east-1';
+const WORKSPACE_BUCKET = process.env.WORKSPACE_BUCKET || '';
+const PRESIGN_TTL_SECONDS = 3600;
+const MODEL_ID = 'gpt-image-2-2026-04-21';
+const ALLOWED_SIZES = new Set(['1024x1024', '1024x1536', '1536x1024', 'auto']);
+const ALLOWED_QUALITIES = new Set(['low', 'medium', 'high', 'auto']);
+const ALLOWED_BACKGROUNDS = new Set(['opaque', 'transparent', 'auto']);
+
+const CREDENTIALS_GET = path.resolve(
+  __dirname,
+  '..',
+  'psd-credentials',
+  'get.js',
+);
+const CREDENTIALS_CHECK_CAPABILITY = path.resolve(
+  __dirname,
+  '..',
+  'psd-credentials',
+  'check_capability.js',
+);
+const REQUIRED_CAPABILITY = 'skill.image-gen';
+
+function fail(message, code = 'error') {
+  process.stderr.write(`Error: ${message}\n`);
+  process.stdout.write(JSON.stringify({ error: code, message }) + '\n');
+  process.exit(1);
+}
+
+function emit(obj) {
+  process.stdout.write(JSON.stringify(obj) + '\n');
+}
+
+function parseArgs(argv) {
+  const args = {};
+  for (let i = 2; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === '--help' || arg === '-h') {
+      args.help = true;
+      continue;
+    }
+    if (!arg.startsWith('--')) {
+      fail(`Unexpected positional argument: ${arg}`, 'bad_args');
+    }
+    const key = arg.slice(2).replace(/-/g, '_');
+    const next = argv[i + 1];
+    if (!next || next.startsWith('--')) {
+      args[key] = true;
+    } else {
+      args[key] = next;
+      i++;
+    }
+  }
+  return args;
+}
+
+function validateEmail(email) {
+  const RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+  return typeof email === 'string' && RE.test(email);
+}
+
+/**
+ * Fail-closed capability gate. The skill folder is loaded into
+ * OpenClaw's static catalog at container init, so users without the
+ * `skill.image-gen` capability still see the tool advertised. This
+ * check is the actual enforcement: it queries the AI Studio
+ * `tools`/`role_tools`/`user_roles` tables via psd-credentials and
+ * refuses invocation if the caller lacks the grant. Database errors
+ * are treated as denials.
+ *
+ * Catalog-level filtering (so the skill is not even visible) is a
+ * future change once OpenClaw exposes a per-session catalog hook.
+ */
+function enforceCapability(userEmail) {
+  let exitStatus = 1;
+  let stdout = '';
+  try {
+    stdout = execFileSync('node', [
+      CREDENTIALS_CHECK_CAPABILITY,
+      '--user', userEmail,
+      '--capability', REQUIRED_CAPABILITY,
+    ], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'inherit'],
+    });
+    exitStatus = 0;
+  } catch (err) {
+    exitStatus = err.status === undefined ? 1 : err.status;
+    stdout = err.stdout ? err.stdout.toString() : '';
+  }
+  if (exitStatus === 0) return;
+
+  const lines = stdout.split('\n').filter((l) => l.trim().length > 0);
+  let parsed = null;
+  if (lines.length > 0) {
+    try { parsed = JSON.parse(lines[lines.length - 1]); } catch { /* fall through */ }
+  }
+  const granted = parsed && parsed.granted === true;
+  if (granted) return;
+  fail(
+    `User ${userEmail} lacks the ${REQUIRED_CAPABILITY} capability. ` +
+    'Ask an administrator to grant it via the role assignments at /admin/roles.',
+    'forbidden_capability',
+  );
+}
+
+/**
+ * Fetch the shared OpenAI API key from psd-credentials. The skill is
+ * its own process and cannot share the credential cache, so we shell
+ * out and parse one JSON object from stdout. The value is held in a
+ * local variable and never written elsewhere.
+ */
+function readSharedOpenAIKey(userEmail) {
+  let stdout;
+  try {
+    stdout = execFileSync('node', [CREDENTIALS_GET, '--user', userEmail, '--name', 'openai_api_key'], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'inherit'],
+    });
+  } catch (err) {
+    fail(`psd-credentials/get.js failed: ${err.message}`, 'shared_key_missing');
+  }
+
+  const lines = stdout.split('\n').filter((l) => l.trim().length > 0);
+  if (lines.length === 0) {
+    fail('psd-credentials returned no output', 'shared_key_missing');
+  }
+  const last = lines[lines.length - 1];
+  let parsed;
+  try {
+    parsed = JSON.parse(last);
+  } catch (err) {
+    fail(`psd-credentials returned non-JSON: ${err.message}`, 'shared_key_missing');
+  }
+  if (parsed.error || !parsed.value) {
+    fail('Shared OpenAI key not provisioned. Ask an admin to bootstrap psd-agent-creds/{env}/shared/openai_api_key.', 'shared_key_missing');
+  }
+  return parsed.value;
+}
+
+async function generateImage(apiKey, params) {
+  const body = { model: MODEL_ID, prompt: params.prompt };
+  if (params.size && params.size !== 'auto') body.size = params.size;
+  if (params.quality && params.quality !== 'auto') body.quality = params.quality;
+  if (params.background && params.background !== 'auto') body.background = params.background;
+
+  const resp = await fetch('https://api.openai.com/v1/images/generations', {
+    method: 'POST',
+    headers: {
+      'Authorization': `Bearer ${apiKey}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(body),
+  });
+
+  if (!resp.ok) {
+    const text = await resp.text().catch(() => '');
+    fail(`OpenAI API ${resp.status}: ${text.slice(0, 500)}`, 'upstream_error');
+  }
+
+  const data = await resp.json();
+  const first = (data && Array.isArray(data.data)) ? data.data[0] : null;
+  if (!first || !first.b64_json) {
+    fail('OpenAI response missing b64_json image data', 'upstream_error');
+  }
+  return Buffer.from(first.b64_json, 'base64');
+}
+
+async function uploadAndPresign(bytes, userEmail) {
+  if (!WORKSPACE_BUCKET) {
+    fail('WORKSPACE_BUCKET env var not set — cannot upload generated image', 'misconfigured');
+  }
+  const key = `images/${userEmail}/${randomUUID()}.png`;
+  const s3 = new S3Client({ region: REGION });
+
+  await s3.send(new PutObjectCommand({
+    Bucket: WORKSPACE_BUCKET,
+    Key: key,
+    Body: bytes,
+    ContentType: 'image/png',
+    Metadata: {
+      generated_by: 'psd-image-gen',
+      model: MODEL_ID,
+    },
+  }));
+
+  const url = await getSignedUrl(
+    s3,
+    new GetObjectCommand({ Bucket: WORKSPACE_BUCKET, Key: key }),
+    { expiresIn: PRESIGN_TTL_SECONDS },
+  );
+
+  const expiresAt = new Date(Date.now() + PRESIGN_TTL_SECONDS * 1000).toISOString();
+  return { url, key, expiresAt };
+}
+
+async function main() {
+  const args = parseArgs(process.argv);
+  if (args.help) {
+    console.log('Usage: generate.js --user <email> --prompt "<text>" [--size auto|1024x1024|1024x1536|1536x1024] [--quality auto|low|medium|high] [--background auto|opaque|transparent]');
+    process.exit(0);
+  }
+  if (!validateEmail(args.user)) {
+    fail('--user is required and must be a valid email', 'bad_args');
+  }
+  if (!args.prompt || args.prompt === true) {
+    fail('--prompt is required', 'bad_args');
+  }
+  const size = args.size && args.size !== true ? String(args.size) : 'auto';
+  const quality = args.quality && args.quality !== true ? String(args.quality) : 'auto';
+  const background = args.background && args.background !== true ? String(args.background) : 'auto';
+
+  if (!ALLOWED_SIZES.has(size)) {
+    fail(`Invalid --size. Allowed: ${[...ALLOWED_SIZES].join(', ')}`, 'bad_args');
+  }
+  if (!ALLOWED_QUALITIES.has(quality)) {
+    fail(`Invalid --quality. Allowed: ${[...ALLOWED_QUALITIES].join(', ')}`, 'bad_args');
+  }
+  if (!ALLOWED_BACKGROUNDS.has(background)) {
+    fail(`Invalid --background. Allowed: ${[...ALLOWED_BACKGROUNDS].join(', ')}`, 'bad_args');
+  }
+
+  enforceCapability(args.user);
+  const apiKey = readSharedOpenAIKey(args.user);
+  const bytes = await generateImage(apiKey, { prompt: args.prompt, size, quality, background });
+  const { url, key, expiresAt } = await uploadAndPresign(bytes, args.user);
+
+  emit({
+    url,
+    s3Key: key,
+    model: MODEL_ID,
+    prompt: args.prompt,
+    size,
+    quality,
+    background,
+    expiresAt,
+  });
+}
+
+main().catch((err) => {
+  fail(err instanceof Error ? err.message : String(err), 'error');
+});

--- a/infra/agent-image/skills/psd-image-gen/generate.js
+++ b/infra/agent-image/skills/psd-image-gen/generate.js
@@ -81,6 +81,12 @@ function parseArgs(argv) {
 // NOTE: parseArgs, fail, emit, validateEmail are intentionally duplicated from
 // psd-credentials/common.js — skills are standalone packages with no cross-skill
 // require(). The source of truth for these helpers is psd-credentials/common.js.
+//
+// Email regex divergence: psd-freshservice/lib/api.js uses /^[^\s@/]+@[^\s@/]+\.[^\s@/]+$/
+// (blocks `/` inside the character classes), while this file uses a separate
+// `.includes('/')` check. Both produce the same behavior — reject emails with `/`.
+// Unifying into a shared helper is tracked for the planned cross-skill utility
+// module (see psd-credentials SKILL.md).
 function validateEmail(email) {
   const RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
   if (typeof email !== 'string' || !RE.test(email)) return false;
@@ -127,6 +133,11 @@ function enforceCapability(userEmail) {
   if (lines.length > 0) {
     try { parsed = JSON.parse(lines[lines.length - 1]); } catch { /* fall through */ }
   }
+  // Intentionally defensive: check_capability.js's contract is exit 0 = granted
+  // (handled above), exit 3 = denied. This second check covers the edge case where
+  // check_capability exits non-zero (e.g. signal/crash) but still emitted
+  // {granted: true} to stdout before dying. In that scenario we trust the stdout
+  // payload over the exit code, because the capability query itself succeeded.
   const granted = parsed && parsed.granted === true;
   if (granted) return;
   fail(
@@ -201,6 +212,8 @@ async function generateImage(apiKey, params) {
 }
 
 async function uploadAndPresign(bytes, userEmail) {
+  // Defense-in-depth guard — main() checks WORKSPACE_BUCKET before the OpenAI
+  // call, so this is only reachable if the function is called from a new path.
   if (!WORKSPACE_BUCKET) {
     fail('WORKSPACE_BUCKET env var not set — cannot upload generated image', 'misconfigured');
   }
@@ -252,6 +265,12 @@ async function main() {
   }
   if (!ALLOWED_BACKGROUNDS.has(background)) {
     fail(`Invalid --background. Allowed: ${[...ALLOWED_BACKGROUNDS].join(', ')}`, 'bad_args');
+  }
+
+  // Validate WORKSPACE_BUCKET early — before capability checks or OpenAI calls —
+  // so we don't spend API quota only to fail on upload. (Review PR #934 feedback)
+  if (!WORKSPACE_BUCKET) {
+    fail('WORKSPACE_BUCKET env var not set — cannot upload generated image', 'misconfigured');
   }
 
   enforceCapability(args.user);

--- a/infra/agent-image/skills/psd-image-gen/generate.js
+++ b/infra/agent-image/skills/psd-image-gen/generate.js
@@ -78,9 +78,17 @@ function parseArgs(argv) {
   return args;
 }
 
+// NOTE: parseArgs, fail, emit, validateEmail are intentionally duplicated from
+// psd-credentials/common.js — skills are standalone packages with no cross-skill
+// require(). The source of truth for these helpers is psd-credentials/common.js.
 function validateEmail(email) {
   const RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-  return typeof email === 'string' && RE.test(email);
+  if (typeof email !== 'string' || !RE.test(email)) return false;
+  // Defense-in-depth: reject path separators — email is interpolated into S3
+  // key paths (`images/{email}/{uuid}.png`) and slashes would create unexpected
+  // key prefixes.
+  if (email.includes('/')) return false;
+  return true;
 }
 
 /**
@@ -96,7 +104,7 @@ function validateEmail(email) {
  * future change once OpenClaw exposes a per-session catalog hook.
  */
 function enforceCapability(userEmail) {
-  let exitStatus = 1;
+  let exitStatus;
   let stdout = '';
   try {
     stdout = execFileSync('node', [
@@ -129,15 +137,17 @@ function enforceCapability(userEmail) {
 }
 
 /**
- * Fetch the shared OpenAI API key from psd-credentials. The skill is
- * its own process and cannot share the credential cache, so we shell
- * out and parse one JSON object from stdout. The value is held in a
- * local variable and never written elsewhere.
+ * Fetch the shared (district-funded) OpenAI API key from psd-credentials.
+ * Uses --shared to skip user-scoped lookups — ensures a per-user key
+ * cannot override the district-funded key. The skill is its own process
+ * and cannot share the credential cache, so we shell out and parse one
+ * JSON object from stdout. The value is held in a local variable and
+ * never written elsewhere.
  */
 function readSharedOpenAIKey(userEmail) {
   let stdout;
   try {
-    stdout = execFileSync('node', [CREDENTIALS_GET, '--user', userEmail, '--name', 'openai_api_key'], {
+    stdout = execFileSync('node', [CREDENTIALS_GET, '--user', userEmail, '--shared', '--name', 'openai_api_key'], {
       encoding: 'utf8',
       stdio: ['ignore', 'pipe', 'inherit'],
     });

--- a/infra/agent-image/skills/psd-image-gen/generate.js
+++ b/infra/agent-image/skills/psd-image-gen/generate.js
@@ -111,9 +111,8 @@ function validateEmail(email) {
  */
 function enforceCapability(userEmail) {
   let exitStatus;
-  let stdout = '';
   try {
-    stdout = execFileSync('node', [
+    execFileSync('node', [
       CREDENTIALS_CHECK_CAPABILITY,
       '--user', userEmail,
       '--capability', REQUIRED_CAPABILITY,
@@ -124,7 +123,6 @@ function enforceCapability(userEmail) {
     exitStatus = 0;
   } catch (err) {
     exitStatus = err.status === undefined ? 1 : err.status;
-    stdout = err.stdout ? err.stdout.toString() : '';
   }
   if (exitStatus === 0) return;
 
@@ -243,6 +241,11 @@ async function main() {
   }
   if (!args.prompt || args.prompt === true) {
     fail('--prompt is required', 'bad_args');
+  }
+  // Cap prompt length to prevent sending excessively large payloads to OpenAI
+  // and to give a clear client-side error instead of a raw upstream_error.
+  if (args.prompt.length > 4000) {
+    fail('--prompt must be 4000 characters or fewer', 'bad_args');
   }
   const size = args.size && args.size !== true ? String(args.size) : 'auto';
   const quality = args.quality && args.quality !== true ? String(args.quality) : 'auto';

--- a/infra/agent-image/skills/psd-image-gen/generate.js
+++ b/infra/agent-image/skills/psd-image-gen/generate.js
@@ -26,6 +26,11 @@ const { getSignedUrl } = require('@aws-sdk/s3-request-presigner');
 const REGION = process.env.AWS_REGION || 'us-east-1';
 const WORKSPACE_BUCKET = process.env.WORKSPACE_BUCKET || '';
 const PRESIGN_TTL_SECONDS = 3600;
+// Pinned to a dated snapshot for reproducibility. OpenAI may deprecate this
+// specific version without notice — if the skill starts returning upstream_error,
+// update to the latest `gpt-image-2-YYYY-MM-DD` version (or the unversioned
+// `gpt-image-2` alias if reproducibility is no longer a concern). Also update
+// SKILL.md when changing this value.
 const MODEL_ID = 'gpt-image-2-2026-04-21';
 const ALLOWED_SIZES = new Set(['1024x1024', '1024x1536', '1536x1024', 'auto']);
 const ALLOWED_QUALITIES = new Set(['low', 'medium', 'high', 'auto']);

--- a/infra/agent-image/skills/psd-image-gen/generate.js
+++ b/infra/agent-image/skills/psd-image-gen/generate.js
@@ -89,6 +89,7 @@ function parseArgs(argv) {
 // NOTE: parseArgs, fail, emit, validateEmail are intentionally duplicated from
 // psd-credentials/common.js — skills are standalone packages with no cross-skill
 // require(). The source of truth for these helpers is psd-credentials/common.js.
+// Keep in sync with: psd-credentials/common.js and psd-freshservice/lib/api.js.
 //
 // Email regex divergence: psd-freshservice/lib/api.js uses /^[^\s@/]+@[^\s@/]+\.[^\s@/]+$/
 // (blocks `/` inside the character classes), while this file uses a separate

--- a/infra/agent-image/skills/psd-image-gen/package.json
+++ b/infra/agent-image/skills/psd-image-gen/package.json
@@ -1,10 +1,9 @@
 {
   "name": "psd-image-gen",
   "version": "1.0.0",
-  "description": "OpenClaw skill: generate images via OpenAI gpt-image-2, upload to workspace S3, return presigned URL",
+  "description": "OpenClaw skill: generate images via OpenAI gpt-image-2, upload to workspace S3 public-images/ prefix, return unsigned shareable URL",
   "private": true,
   "dependencies": {
-    "@aws-sdk/client-s3": "^3.0.0",
-    "@aws-sdk/s3-request-presigner": "^3.0.0"
+    "@aws-sdk/client-s3": "^3.0.0"
   }
 }

--- a/infra/agent-image/skills/psd-image-gen/package.json
+++ b/infra/agent-image/skills/psd-image-gen/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "psd-image-gen",
+  "version": "1.0.0",
+  "description": "OpenClaw skill: generate images via OpenAI gpt-image-2, upload to workspace S3, return presigned URL",
+  "private": true,
+  "dependencies": {
+    "@aws-sdk/client-s3": "^3.0.0",
+    "@aws-sdk/s3-request-presigner": "^3.0.0"
+  }
+}

--- a/infra/agent-image/skills/psd-rules/SKILL.md
+++ b/infra/agent-image/skills/psd-rules/SKILL.md
@@ -177,6 +177,31 @@ The `psd-workspace` skill enforces these at the code layer (not the prompt layer
 
 ---
 
+## Rule 9 — Use the skill, do not replicate it
+
+If a skill exists for a task, that skill's interface is the **only** path. Do not write Bash, Node, or Python that calls the skill's underlying APIs directly.
+
+**Forbidden:**
+
+- Calling the OpenAI images API via `curl` or `fetch` when `psd-image-gen` exists
+- Running `aws s3 cp`, `PutObjectCommand`, or `getSignedUrl` from Bash for any task a skill performs
+- Re-fetching, re-uploading, or "post-processing" a skill's returned URL ("let me regenerate with a fresh presigned URL")
+- Saving a skill's output to the container filesystem as a fallback — the filesystem is ephemeral and the user cannot reach it
+
+**Why:** On 2026-05-03 the `psd-image-gen` skill was correct end-to-end (clean unsigned public URL), but the agent kept producing presigned URLs with `X-Amz-Security-Token` query parameters that fail in chat. Investigation showed the agent had stopped calling the skill and was writing custom Bash to call OpenAI + upload to S3 + presign on its own. Each "fix" added more improvisation, never solving the actual problem.
+
+**How to apply:**
+
+1. If the user's request maps to a known skill (image generation → `psd-image-gen`, Freshservice ticket → `psd-freshservice`, schedule → `psd-schedules`, secret → `psd-credentials`, Workspace API → `psd-workspace`), call that skill's CLI verbatim.
+2. Surface the skill's returned values *as-is*. If it returns a URL, paste that URL. Do not generate a "fresh" one.
+3. If the skill returns an `error` field, surface the error text and stop. Do not pivot to a custom pipeline.
+4. If you don't know what a skill does, call `psd-skills-meta load --name <skill>` first to read its full SKILL.md. Don't guess.
+5. Building the skill's behavior yourself in Bash is *always* the wrong answer — even when the skill seems broken. Report the failure and stop.
+
+**Self-check:** Does my reply contain a URL with `X-Amz-Signature`, `X-Amz-Security-Token`, or `X-Amz-Expires`? If yes, I built that URL myself instead of using the skill — undo it.
+
+---
+
 ## Self-check before send
 
 Run this checklist mentally before every reply:
@@ -187,5 +212,6 @@ Run this checklist mentally before every reply:
 4. ✅ Did I do the work now (or schedule it), or am I making an empty promise?
 5. ✅ Is the reply length proportional to the information density?
 6. ✅ Did I update the memory files this turn?
+7. ✅ For any task a skill covers, did I call the skill — not replicate it in Bash?
 
 If any answer is "no" — fix the reply before sending.

--- a/infra/agent-image/skills/psd-rules/SKILL.md
+++ b/infra/agent-image/skills/psd-rules/SKILL.md
@@ -193,12 +193,19 @@ If a skill exists for a task, that skill's interface is the **only** path. Do no
 **How to apply:**
 
 1. If the user's request maps to a known skill (image generation → `psd-image-gen`, Freshservice ticket → `psd-freshservice`, schedule → `psd-schedules`, secret → `psd-credentials`, Workspace API → `psd-workspace`), call that skill's CLI verbatim.
-2. Surface the skill's returned values *as-is*. If it returns a URL, paste that URL. Do not generate a "fresh" one.
-3. If the skill returns an `error` field, surface the error text and stop. Do not pivot to a custom pipeline.
-4. If you don't know what a skill does, call `psd-skills-meta load --name <skill>` first to read its full SKILL.md. Don't guess.
-5. Building the skill's behavior yourself in Bash is *always* the wrong answer — even when the skill seems broken. Report the failure and stop.
+2. Surface the skill's returned values *as-is*. Do not generate a "fresh" one.
+3. **If a skill's JSON output contains a `url` field, your reply MUST include that exact URL on a line by itself** — no `**`, no `[label](url)`, no parentheses, no trailing period, no other text on that line. Narration (one short sentence at most) goes on a *separate* line above or below, or is omitted entirely. The user cannot see the tool result; the URL only reaches them if you put it in the chat message.
+4. Describing the artifact in prose ("Here is your infographic showing three layers…") is **never** a substitute for pasting the URL. If you describe the image, you have failed the rule — even if the description is accurate. The URL is the deliverable.
+5. If the skill returns an `error` field, surface the error text and stop. Do not pivot to a custom pipeline.
+6. If you don't know what a skill does, call `psd-skills-meta load --name <skill>` first to read its full SKILL.md. Don't guess.
+7. Building the skill's behavior yourself in Bash is *always* the wrong answer — even when the skill seems broken. Report the failure and stop.
 
-**Self-check:** Does my reply contain a URL with `X-Amz-Signature`, `X-Amz-Security-Token`, or `X-Amz-Expires`? If yes, I built that URL myself instead of using the skill — undo it.
+**Why (URL paste):** On 2026-05-03 the `psd-image-gen` skill returned a clean public-by-link URL (`https://psd-agents-dev-…s3…amazonaws.com/public-images/…/.png`, HTTP 200, no STS token), but the agent's reply was a paragraph of prose describing the infographic's layers — the URL was never put on the wire and the user got nothing. The skill worked; the surfacing failed.
+
+**Self-checks:**
+
+- Did the last tool result contain a `url` field? Then is that exact URL on a line by itself in my reply? If no — fix before sending.
+- Does my reply contain a URL with `X-Amz-Signature`, `X-Amz-Security-Token`, or `X-Amz-Expires`? If yes, I built that URL myself instead of using the skill — undo it.
 
 ---
 
@@ -213,5 +220,6 @@ Run this checklist mentally before every reply:
 5. ✅ Is the reply length proportional to the information density?
 6. ✅ Did I update the memory files this turn?
 7. ✅ For any task a skill covers, did I call the skill — not replicate it in Bash?
+8. ✅ If the last tool result had a `url` field, is that exact URL pasted on its own line in my reply? Prose description ≠ URL.
 
 If any answer is "no" — fix the reply before sending.

--- a/infra/agent-image/skills/psd-schedules/SKILL.md
+++ b/infra/agent-image/skills/psd-schedules/SKILL.md
@@ -34,7 +34,7 @@ that would let one user manage another user's schedules.
 ### `create_schedule` — create a new schedule
 
 ```bash
-node /home/node/.openclaw/skills/psd-schedules/create.js \
+node /opt/psd-skills/psd-schedules/create.js \
   --user <email> \
   --name "<display name>" \
   --prompt "<what to prompt the agent at fire time>" \
@@ -47,13 +47,13 @@ node /home/node/.openclaw/skills/psd-schedules/create.js \
 ### `list_schedules` — list the caller's schedules
 
 ```bash
-node /home/node/.openclaw/skills/psd-schedules/list.js --user <email>
+node /opt/psd-skills/psd-schedules/list.js --user <email>
 ```
 
 ### `update_schedule` — change fields on an existing schedule
 
 ```bash
-node /home/node/.openclaw/skills/psd-schedules/update.js \
+node /opt/psd-skills/psd-schedules/update.js \
   --user <email> --schedule-id <id> \
   [--name "<name>"] [--prompt "<prompt>"] [--cron "<cron>"] \
   [--timezone "<tz>"] [--enabled true|false]
@@ -62,7 +62,7 @@ node /home/node/.openclaw/skills/psd-schedules/update.js \
 ### `delete_schedule` — remove a schedule permanently
 
 ```bash
-node /home/node/.openclaw/skills/psd-schedules/delete.js \
+node /opt/psd-skills/psd-schedules/delete.js \
   --user <email> --schedule-id <id>
 ```
 
@@ -123,7 +123,7 @@ OpenClaw? Take your time."
 You (correct):
 
 ```bash
-node /home/node/.openclaw/skills/psd-schedules/create.js \
+node /opt/psd-skills/psd-schedules/create.js \
   --user hagelk@psd401.net \
   --name "Google Workspace + OpenClaw research" \
   --prompt "You promised Kris at 8:05pm PT on 2026-04-22 that you'd research the best way to integrate Google Workspace with OpenClaw and come back with a recommendation. Do the web research now (clawhub.ai, OpenClaw docs, community plugins). Compare the gog CLI approach vs a custom plugin. Give a concrete recommendation with trade-offs and next steps. The user is Kris, CIO of PSD — match the communication style in USER.md." \

--- a/infra/agent-image/skills/psd-skills-meta/SKILL.md
+++ b/infra/agent-image/skills/psd-skills-meta/SKILL.md
@@ -17,7 +17,7 @@ loading, and agent-authored skill creation.
 ### `search` — search the skill catalog
 
 ```bash
-node /home/node/.openclaw/skills/psd-skills-meta/search.js \
+node /opt/psd-skills/psd-skills-meta/search.js \
   --user <email> \
   --query "<search term>"
 ```
@@ -28,7 +28,7 @@ the user asks "do you have a skill for X?" or you need to find a skill.
 ### `load` — load a skill's full SKILL.md into the session
 
 ```bash
-node /home/node/.openclaw/skills/psd-skills-meta/load.js \
+node /opt/psd-skills/psd-skills-meta/load.js \
   --user <email> \
   --name "<skill-name>"
 ```
@@ -40,7 +40,7 @@ indicates a skill exists but you need the full instructions.
 ### `author` — create a new skill draft
 
 ```bash
-node /home/node/.openclaw/skills/psd-skills-meta/author.js \
+node /opt/psd-skills/psd-skills-meta/author.js \
   --user <email> \
   --name "<skill-name>" \
   --summary "<one-line summary>" \

--- a/infra/agent-image/skills/psd-workspace/SKILL.md
+++ b/infra/agent-image/skills/psd-workspace/SKILL.md
@@ -21,7 +21,7 @@ If you omit `--scope`, the skill defaults to `user`. Phase 1 work is overwhelmin
 ## Invocation
 
 ```bash
-node /home/node/.openclaw/skills/psd-workspace/run.js \
+node /opt/psd-skills/psd-workspace/run.js \
   --user <caller-email> \
   --command "<gws-subcommand-with-args>" \
   [--scope user|agent]
@@ -31,33 +31,33 @@ Examples:
 
 ```bash
 # Read user's unread mail (Phase 1 default scope = user)
-node /home/node/.openclaw/skills/psd-workspace/run.js \
+node /opt/psd-skills/psd-workspace/run.js \
   --user hagelk@psd401.net \
   --command "gmail users messages list --params '{\"userId\":\"me\",\"q\":\"is:unread\",\"maxResults\":20}'"
 
 # Create a draft on the user's account (lands in their Drafts folder, marker
 # is auto-appended to the body — they review and send themselves)
-node /home/node/.openclaw/skills/psd-workspace/run.js \
+node /opt/psd-skills/psd-workspace/run.js \
   --user hagelk@psd401.net \
   --command "gmail +draft --to principal@psd401.net --subject 'Follow up' --body 'Hi Bill,...'"
 
 # Create a task on the user's tasks (in the 'Your Agent' tasklist)
-node /home/node/.openclaw/skills/psd-workspace/run.js \
+node /opt/psd-skills/psd-workspace/run.js \
   --user hagelk@psd401.net \
   --command "tasks tasks insert --params '{\"tasklist\":\"@default\"}' --json '{\"title\":\"Review budget\",\"due\":\"2026-04-29T17:00:00Z\"}'"
 
 # Create a calendar event on the user's calendar (marker auto-prepended to description)
-node /home/node/.openclaw/skills/psd-workspace/run.js \
+node /opt/psd-skills/psd-workspace/run.js \
   --user hagelk@psd401.net \
   --command "calendar events insert --params '{\"calendarId\":\"primary\"}' --json '{\"summary\":\"Standup\",\"start\":{\"dateTime\":\"2026-05-01T09:00:00-07:00\"},\"end\":{\"dateTime\":\"2026-05-01T09:30:00-07:00\"}}'"
 
 # Schedule something on the AGENT's own calendar (e.g. internal reminders)
-node /home/node/.openclaw/skills/psd-workspace/run.js \
+node /opt/psd-skills/psd-workspace/run.js \
   --user hagelk@psd401.net --scope agent \
   --command "calendar events insert --params '{\"calendarId\":\"primary\"}' --json '{\"summary\":\"agent self-reminder\"}'"
 
 # The full gws command surface
-node /home/node/.openclaw/skills/psd-workspace/run.js --user hagelk@psd401.net --command "--help"
+node /opt/psd-skills/psd-workspace/run.js --user hagelk@psd401.net --command "--help"
 ```
 
 ## Phase 1 boundaries (hard gates — refused at the skill layer)

--- a/infra/agent-image/workspace_sync.py
+++ b/infra/agent-image/workspace_sync.py
@@ -79,6 +79,8 @@ _SKIP_RELATIVE_PREFIXES = (
     # NOT image-owned, must round-trip. Don't blanket-skip skills/.
     "skills/gws-",
     "skills/psd-credentials/",
+    "skills/psd-freshservice/",
+    "skills/psd-image-gen/",
     "skills/psd-rules/",
     "skills/psd-schedules/",
     "skills/psd-skills-meta/",

--- a/infra/agent-image/workspace_sync.py
+++ b/infra/agent-image/workspace_sync.py
@@ -77,6 +77,15 @@ _SKIP_RELATIVE_PREFIXES = (
     #
     # IMPORTANT: skills/user/ is the agent's own authoring scratchpad —
     # NOT image-owned, must round-trip. Don't blanket-skip skills/.
+    # Image-bundled skills now live at /opt/psd-skills/, OUTSIDE this
+    # workspace dir, so they CANNOT be overlaid by S3 state — the path
+    # separation makes the "agent overwrites a district skill" bug class
+    # physically impossible. The skip entries below remain as a defense
+    # against S3 pollution: stale files exist in some users' workspace
+    # prefixes from the pre-separation era, and an agent that hand-creates
+    # `~/.openclaw/skills/psd-foo/` would sync that scratch to S3 forever.
+    # Skipping these prefixes prevents both. Keep the list aligned with
+    # the directories that exist at /opt/psd-skills/.
     "skills/gws-",
     "skills/psd-credentials/",
     "skills/psd-freshservice/",

--- a/infra/database/migrations.json
+++ b/infra/database/migrations.json
@@ -69,6 +69,7 @@
     "071-agent-workspace-tokens.sql",
     "072-agent-workspace-nonce-agent-email.sql",
     "073-agent-workspace-token-kind.sql",
-    "074-deep-research-capability.sql"
+    "074-deep-research-capability.sql",
+    "075-skill-required-capability.sql"
   ]
 }

--- a/infra/database/schema/075-skill-required-capability.sql
+++ b/infra/database/schema/075-skill-required-capability.sql
@@ -21,6 +21,11 @@
 -- `capabilities` under epic #922 / issue #923; the rename is mechanical
 -- for our string identifier `skill.image-gen`).
 
+-- Standard retry pattern (also used in 065, 070): clear a prior 'failed'
+-- status so the migration Lambda re-runs this file on the next deploy.
+-- Safe because all DDL/DML below is idempotent (IF NOT EXISTS, ON CONFLICT
+-- DO NOTHING) — a partial prior run leaves the schema in a state this
+-- script can complete from.
 UPDATE migration_log SET status = 'completed'
 WHERE description = '075-skill-required-capability.sql' AND status = 'failed';
 

--- a/infra/database/schema/075-skill-required-capability.sql
+++ b/infra/database/schema/075-skill-required-capability.sql
@@ -1,0 +1,49 @@
+-- Migration 075: Skill-load capability gate + image-gen skill capability
+--
+-- Adds the runtime permission gate for the agent skills platform. The
+-- agent harness reads psd_agent_skills.required_capability and only
+-- exposes the skill to OpenClaw when the calling user's role-granted
+-- capabilities include the named identifier. NULL means the skill is
+-- open to all (preserves prior behavior for migrations 070-era skills).
+--
+-- Seeds the first restricted capability (`skill.image-gen`) used by the
+-- new psd-image-gen skill, and grants it to administrator + staff roles
+-- so they can use it before the admin UI from issue #923 ships. Adjust
+-- via direct DB or the upcoming UI thereafter.
+--
+-- The `tools` table is the legacy capabilities registry (renamed to
+-- `capabilities` under epic #922 / issue #923; the rename is mechanical
+-- for our string identifier `skill.image-gen`).
+
+UPDATE migration_log SET status = 'completed'
+WHERE description = '075-skill-required-capability.sql' AND status = 'failed';
+
+-- Add the gate column. NULL means the skill is unrestricted.
+ALTER TABLE psd_agent_skills
+    ADD COLUMN IF NOT EXISTS required_capability TEXT NULL;
+
+-- Index for the harness's per-invocation capability join.
+CREATE INDEX IF NOT EXISTS idx_agent_skills_required_capability
+    ON psd_agent_skills (required_capability)
+    WHERE required_capability IS NOT NULL;
+
+-- Register the image-gen capability. is_active stays true so role
+-- checks succeed; description documents what gating it implies.
+INSERT INTO tools (identifier, name, description, is_active)
+VALUES (
+    'skill.image-gen',
+    'Agent skill: image generation',
+    'Allows agent skills to invoke psd-image-gen (OpenAI gpt-image-2). Shared API key — usage costs accrue to the district.',
+    true
+)
+ON CONFLICT (identifier) DO NOTHING;
+
+-- Grant the capability to administrator and staff roles. Other roles
+-- (student, etc.) do not receive it by default.
+INSERT INTO role_tools (role_id, tool_id)
+SELECT r.id, t.id
+FROM roles r
+CROSS JOIN tools t
+WHERE r.name IN ('administrator', 'staff')
+  AND t.identifier = 'skill.image-gen'
+ON CONFLICT (role_id, tool_id) DO NOTHING;

--- a/infra/database/schema/075-skill-required-capability.sql
+++ b/infra/database/schema/075-skill-required-capability.sql
@@ -1,10 +1,16 @@
 -- Migration 075: Skill-load capability gate + image-gen skill capability
 --
--- Adds the runtime permission gate for the agent skills platform. The
--- agent harness reads psd_agent_skills.required_capability and only
--- exposes the skill to OpenClaw when the calling user's role-granted
--- capabilities include the named identifier. NULL means the skill is
--- open to all (preserves prior behavior for migrations 070-era skills).
+-- Adds the schema plumbing for per-skill capability gating. The column
+-- psd_agent_skills.required_capability stores the capability identifier
+-- that a user must hold (via their role grants in tools/role_tools) to
+-- invoke the skill. NULL means the skill is open to all (preserves prior
+-- behavior for migrations 070-era skills).
+--
+-- The harness-level enforcement (reading this column and filtering
+-- skill exposure per session) is a planned follow-up once OpenClaw
+-- exposes a per-session catalog hook. Currently, skills enforce their
+-- own capability gate at invocation time (see psd-image-gen/generate.js
+-- enforceCapability()).
 --
 -- Seeds the first restricted capability (`skill.image-gen`) used by the
 -- new psd-image-gen skill, and grants it to administrator + staff roles

--- a/infra/lib/agent-platform-stack.ts
+++ b/infra/lib/agent-platform-stack.ts
@@ -165,7 +165,22 @@ export class AgentPlatformStack extends cdk.Stack {
     // =====================================================================
     this.workspaceBucket = new s3.Bucket(this, 'AgentWorkspaceBucket', {
       bucketName: `psd-agents-${environment}-${cdk.Aws.ACCOUNT_ID}`,
-      blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
+      // BlockPublicAcls + IgnorePublicAcls keep ACL-driven public access
+      // forbidden. BlockPublicPolicy and RestrictPublicBuckets are FALSE so
+      // the resource policy below can grant unauthenticated GetObject on
+      // the single `public-images/*` prefix used by the psd-image-gen
+      // skill. Without this carve-out the skill returns presigned URLs
+      // signed with AgentCore's STS session credentials; those URLs embed
+      // an `X-Amz-Security-Token` query parameter that intermittently
+      // fails with `InvalidToken` when fetched through chat clients
+      // (observed in PR #934 dev rollout 2026-05-03). Switching to a
+      // public-by-link prefix eliminates the failure mode entirely.
+      blockPublicAccess: new s3.BlockPublicAccess({
+        blockPublicAcls: true,
+        ignorePublicAcls: true,
+        blockPublicPolicy: false,
+        restrictPublicBuckets: false,
+      }),
       // SSE-S3 chosen over SSE-KMS: workspace data is agent-generated artifacts
       // (not direct student PII). KMS adds ~$1/mo per key + $0.03/10k API calls.
       // Upgrade to SSE-KMS with dedicated key if student data is stored here.
@@ -192,6 +207,21 @@ export class AgentPlatformStack extends cdk.Stack {
 
     cdk.Tags.of(this.workspaceBucket).add('Environment', environment);
     cdk.Tags.of(this.workspaceBucket).add('ManagedBy', 'cdk');
+
+    // Public-read carve-out for psd-image-gen output. Skill writes generated
+    // PNGs to `public-images/<email>/<uuid>.png` and returns an unsigned
+    // HTTPS URL. The UUID makes the path unguessable; anyone who receives
+    // the URL can fetch — same security model as Google Drive "anyone with
+    // the link" sharing. The skill, IAM grants, and this policy must all
+    // agree on the `public-images/` prefix. Other prefixes in the bucket
+    // remain private (no other allow-public statements exist).
+    this.workspaceBucket.addToResourcePolicy(new iam.PolicyStatement({
+      sid: 'PublicReadOnPublicImagesPrefix',
+      effect: iam.Effect.ALLOW,
+      principals: [new iam.AnyPrincipal()],
+      actions: ['s3:GetObject'],
+      resources: [`${this.workspaceBucket.bucketArn}/public-images/*`],
+    }));
 
     // =====================================================================
     // 4. DynamoDB Tables

--- a/infra/lib/agent-platform-stack.ts
+++ b/infra/lib/agent-platform-stack.ts
@@ -827,16 +827,40 @@ export class AgentPlatformStack extends cdk.Stack {
     // Scope is intentionally locked to the per-user prefix
     // (psd-agent-creds/{env}/user/*) so a skill cannot write or rotate
     // a shared (district-wide) secret. Shared-scope provisioning stays
-    // an admin-only operation done out of band. CreateSecret is
-    // namespace-scoped via the resource pattern; the optional Tags
-    // attribute on CreateSecret requires TagResource permission.
+    // an admin-only operation done out of band.
+    //
+    // CreateSecret and TagResource are constrained by aws:RequestTag
+    // conditions matching what psd-credentials/put.js sets on new secrets.
+    // This prevents a compromised task from re-tagging existing per-user
+    // secrets with arbitrary Environment or ManagedBy values.
     this.agentCoreExecutionRole.addToPolicy(new iam.PolicyStatement({
       sid: 'AgentCredentialsWritePerUser',
       effect: iam.Effect.ALLOW,
       actions: [
         'secretsmanager:CreateSecret',
-        'secretsmanager:PutSecretValue',
         'secretsmanager:TagResource',
+      ],
+      resources: [
+        `arn:aws:secretsmanager:${this.region}:${this.account}:secret:psd-agent-creds/${environment}/user/*`,
+      ],
+      conditions: {
+        StringEquals: {
+          'aws:RequestTag/Environment': environment,
+          'aws:RequestTag/ManagedBy': 'psd-credentials-skill',
+        },
+        'ForAllValues:StringEquals': {
+          'aws:TagKeys': ['Environment', 'ManagedBy', 'Scope'],
+        },
+      },
+    }));
+
+    // PutSecretValue does not support tag conditions — it only updates
+    // the secret value, not tags. Scoped to the per-user resource prefix.
+    this.agentCoreExecutionRole.addToPolicy(new iam.PolicyStatement({
+      sid: 'AgentCredentialsUpdatePerUser',
+      effect: iam.Effect.ALLOW,
+      actions: [
+        'secretsmanager:PutSecretValue',
       ],
       resources: [
         `arn:aws:secretsmanager:${this.region}:${this.account}:secret:psd-agent-creds/${environment}/user/*`,

--- a/infra/lib/agent-platform-stack.ts
+++ b/infra/lib/agent-platform-stack.ts
@@ -823,6 +823,26 @@ export class AgentPlatformStack extends cdk.Stack {
       resources: ['*'],
     }));
 
+    // Per-user credential WRITE — for the psd-credentials/put.js helper.
+    // Scope is intentionally locked to the per-user prefix
+    // (psd-agent-creds/{env}/user/*) so a skill cannot write or rotate
+    // a shared (district-wide) secret. Shared-scope provisioning stays
+    // an admin-only operation done out of band. CreateSecret is
+    // namespace-scoped via the resource pattern; the optional Tags
+    // attribute on CreateSecret requires TagResource permission.
+    this.agentCoreExecutionRole.addToPolicy(new iam.PolicyStatement({
+      sid: 'AgentCredentialsWritePerUser',
+      effect: iam.Effect.ALLOW,
+      actions: [
+        'secretsmanager:CreateSecret',
+        'secretsmanager:PutSecretValue',
+        'secretsmanager:TagResource',
+      ],
+      resources: [
+        `arn:aws:secretsmanager:${this.region}:${this.account}:secret:psd-agent-creds/${environment}/user/*`,
+      ],
+    }));
+
     // Secrets Manager — psd-workspace skill (#912): read shared OAuth client
     // credentials and the internal API key for consent-link generation.
     this.agentCoreExecutionRole.addToPolicy(new iam.PolicyStatement({

--- a/infra/lib/agent-platform-stack.ts
+++ b/infra/lib/agent-platform-stack.ts
@@ -856,6 +856,16 @@ export class AgentPlatformStack extends cdk.Stack {
 
     // PutSecretValue does not support tag conditions — it only updates
     // the secret value, not tags. Scoped to the per-user resource prefix.
+    //
+    // KNOWN LIMITATION (AWS API): PutSecretValue cannot be scoped to a
+    // single user's email path because the action does not support
+    // aws:RequestTag/* or aws:ResourceTag/* conditions. This means any
+    // skill running on the AgentCore task can rotate any user's credential
+    // under the `psd-agent-creds/{env}/user/*` prefix. Compensating
+    // controls: (1) skills validate --user is the authenticated caller,
+    // (2) psd_agent_credentials_audit logs all writes with action/email,
+    // (3) the ECS task is isolated per-session. This is not a gap in our
+    // design — it is a Secrets Manager API constraint.
     this.agentCoreExecutionRole.addToPolicy(new iam.PolicyStatement({
       sid: 'AgentCredentialsUpdatePerUser',
       effect: iam.Effect.ALLOW,

--- a/lib/db/schema/tables/agent-skills.ts
+++ b/lib/db/schema/tables/agent-skills.ts
@@ -53,6 +53,12 @@ export const psdAgentSkills = pgTable("psd_agent_skills", {
   scanStatus: varchar("scan_status", { length: 16 }).$type<AgentSkillScanStatus>().notNull().default("pending"),
   scanFindings: jsonb("scan_findings").$type<SkillScanFindings>(),
   // Added in migration 075. NULL = open to all; non-null = capability required.
+  // NOTE: No FK constraint to `tools` — the column stores a capability
+  // identifier string (e.g. "skill.image-gen") validated at application
+  // level. Setting a non-existent identifier silently blocks the skill.
+  // Harness-level enforcement (catalog filtering per session) is pending
+  // OpenClaw's per-session catalog hook. Currently, skills self-enforce
+  // via check_capability.js at invocation time.
   requiredCapability: text("required_capability"),
   approvedBy: integer("approved_by").references(() => users.id, { onDelete: "set null" }),
   approvedAt: timestamp("approved_at", { withTimezone: true }),

--- a/lib/db/schema/tables/agent-skills.ts
+++ b/lib/db/schema/tables/agent-skills.ts
@@ -54,7 +54,10 @@ export const psdAgentSkills = pgTable("psd_agent_skills", {
   scanFindings: jsonb("scan_findings").$type<SkillScanFindings>(),
   // Capability identifier (matches `tools.identifier`, soon `capabilities.identifier`
   // under epic #922 / issue #923). NULL means the skill is open to all callers;
-  // a non-null value gates skill-load on `hasToolAccess(required_capability)`.
+  // a non-null value indicates a capability the user must hold to invoke the
+  // skill. Currently enforced at invocation time by the skill itself (e.g.
+  // psd-image-gen/generate.js enforceCapability()). Harness-level gating via
+  // this column is a planned follow-up.
   // Added in migration 075.
   requiredCapability: text("required_capability"),
   approvedBy: integer("approved_by").references(() => users.id, { onDelete: "set null" }),

--- a/lib/db/schema/tables/agent-skills.ts
+++ b/lib/db/schema/tables/agent-skills.ts
@@ -52,13 +52,7 @@ export const psdAgentSkills = pgTable("psd_agent_skills", {
   summary: text("summary").notNull(),
   scanStatus: varchar("scan_status", { length: 16 }).$type<AgentSkillScanStatus>().notNull().default("pending"),
   scanFindings: jsonb("scan_findings").$type<SkillScanFindings>(),
-  // Capability identifier (matches `tools.identifier`, soon `capabilities.identifier`
-  // under epic #922 / issue #923). NULL means the skill is open to all callers;
-  // a non-null value indicates a capability the user must hold to invoke the
-  // skill. Currently enforced at invocation time by the skill itself (e.g.
-  // psd-image-gen/generate.js enforceCapability()). Harness-level gating via
-  // this column is a planned follow-up.
-  // Added in migration 075.
+  // Added in migration 075. NULL = open to all; non-null = capability required.
   requiredCapability: text("required_capability"),
   approvedBy: integer("approved_by").references(() => users.id, { onDelete: "set null" }),
   approvedAt: timestamp("approved_at", { withTimezone: true }),

--- a/lib/db/schema/tables/agent-skills.ts
+++ b/lib/db/schema/tables/agent-skills.ts
@@ -52,6 +52,11 @@ export const psdAgentSkills = pgTable("psd_agent_skills", {
   summary: text("summary").notNull(),
   scanStatus: varchar("scan_status", { length: 16 }).$type<AgentSkillScanStatus>().notNull().default("pending"),
   scanFindings: jsonb("scan_findings").$type<SkillScanFindings>(),
+  // Capability identifier (matches `tools.identifier`, soon `capabilities.identifier`
+  // under epic #922 / issue #923). NULL means the skill is open to all callers;
+  // a non-null value gates skill-load on `hasToolAccess(required_capability)`.
+  // Added in migration 075.
+  requiredCapability: text("required_capability"),
   approvedBy: integer("approved_by").references(() => users.id, { onDelete: "set null" }),
   approvedAt: timestamp("approved_at", { withTimezone: true }),
   createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),


### PR DESCRIPTION
## Summary

- Adds **psd-freshservice** (per-user API key, in-chat onboarding) and **psd-image-gen** (shared OpenAI key, capability-gated) as the first two production agent skills.
- Adds the minimum permission plumbing: \`psd_agent_skills.required_capability\` column (migration 075), \`skill.image-gen\` capability seeded with grants to \`administrator\` + \`staff\`, and fail-closed runtime enforcement via \`psd-credentials/check_capability.js\`.
- Adds \`psd-credentials/put.js\` for per-user secret writes so skills can persist user-supplied keys without admin involvement.
- Adds IAM grant (\`CreateSecret\`/\`PutSecretValue\`/\`TagResource\` scoped to \`psd-agent-creds/{env}/user/*\`) to the AgentCore execution role.

Plan: \`/Users/hagelk/.claude/plans/i-want-to-think-eventual-sutton.md\`
Follow-up: #933 (admin UI for shared-secret provisioning)

## Vocabulary alignment (epic #922)

- **capability** = role-gated UI feature, currently \`tools\` table (rename to \`capabilities\` is mechanical for our string identifier under #923)
- **skill** = SKILL.md folder under \`infra/agent-image/skills/\`
- The new skills follow Anthropic's SKILL.md format; portable to Claude Code / Desktop with one platform-specific dependency (\`psd-credentials\` for secret access, documented).

## Architecture notes

### Per-user credential UX (Freshservice)

First call per user emits \`{\"error\":\"freshservice_key_missing\",\"instructions\":[...]}\` and exits 2. The agent surfaces the prompt to the user, the user pastes their Freshservice API key from their profile, and the harness writes it via \`psd-credentials put.js\` to \`psd-agent-creds/{env}/user/<email>/freshservice_api_key\`. No admin involvement.

### Shared credential bootstrap (image-gen)

The shared OpenAI key needs a one-time bootstrap before image-gen works in a given environment:

1. Read the value from the \`settings\` table (\`OPENAI_API_KEY\` row) via the Postgres MCP server.
2. \`aws secretsmanager put-secret-value --secret-id psd-agent-creds/dev/shared/openai_api_key --secret-string <value>\` (or the relevant \`{env}\`).

Runtime always reads via Secrets Manager — the \`settings\` table is source-of-truth for the *bootstrap*, never the runtime path. Issue #933 will eventually replace this with an admin UI.

### Capability enforcement: deviation from plan

The plan called for harness-level filtering of OpenClaw's \`extraDirs\` per session via a symlink farm. Investigation showed OpenClaw loads skills statically at container init and does not expose a per-session catalog hook. **Switched to script-level enforcement**: the skill is in \`tools.catalog\` for everyone, but its first action is a fail-closed capability check that refuses before any OpenAI traffic is sent. Catalog-level filtering is now a planned follow-up gated on OpenClaw cooperation (documented in \`psd-image-gen/SKILL.md\` under \"Catalog visibility caveat\").

### Image rendering in Google Chat

Today, agent-router posts text-only messages. The skill returns a presigned URL the user can click to download. Inline rendering would require agent-router to learn \`cardsV2\` responses — out of scope here, noted in the plan.

## Files Changed

- \`infra/agent-image/Dockerfile\` — add \`psd-image-gen\` npm install
- \`infra/agent-image/skills/psd-credentials/SKILL.md\` — document \`put\` and \`check_capability\`
- \`infra/agent-image/skills/psd-credentials/check_capability.js\` — new
- \`infra/agent-image/skills/psd-credentials/common.js\` — add \`putUserCredential\`, \`logCredentialPut\`, \`userHasCapability\`
- \`infra/agent-image/skills/psd-credentials/put.js\` — new
- \`infra/agent-image/skills/psd-freshservice/\` — new skill (SKILL.md + 13 commands + lib/api.js + lib/summary-utils.js + package.json)
- \`infra/agent-image/skills/psd-image-gen/\` — new skill (SKILL.md + generate.js + package.json)
- \`infra/database/migrations.json\` — register migration 075
- \`infra/database/schema/075-skill-required-capability.sql\` — new
- \`infra/lib/agent-platform-stack.ts\` — \`AgentCredentialsWritePerUser\` IAM statement
- \`lib/db/schema/tables/agent-skills.ts\` — \`requiredCapability\` Drizzle column

## Completion Criteria

- [x] All unit and integration tests pass — no test files touched; existing suite unaffected
- [ ] All e2e tests pass for the affected user flow(s) — **N/A**, agent-platform skill execution has no e2e harness today; manual verification documented below
- [x] Zero lint warnings on every file touched (\`bun run lint\` shows 0 errors and 332 pre-existing warnings; none in touched files)
- [x] Type check clean (\`bun run typecheck\`) — clean
- [x] PR description lists every touched file with each gate checked
- [x] CDK synth (\`AIStudio-AgentPlatformStack-Dev\`, \`AIStudio-DatabaseStack-Dev\`) — both succeed
- [x] All new JS files \`node --check\` clean

## Manual verification plan (post-merge, in dev)

1. **Bootstrap shared key** — read \`settings.OPENAI_API_KEY\` via Postgres MCP, \`aws secretsmanager put-secret-value\` to \`psd-agent-creds/dev/shared/openai_api_key\`. Confirm \`psd-credentials/get.js --shared --name openai_api_key\` returns it from inside a dev container.
2. **Migration applies** — \`psd_agent_skills.required_capability\` column exists; \`tools.skill.image-gen\` row exists; both target roles are joined in \`role_tools\`.
3. **Freshservice happy path** — invoke an agent as a user with no registered key. Skill emits \`freshservice_key_missing\`. Paste a real key in chat; agent stores it via \`put.js\`; \`list_tickets\` succeeds on the next turn. Verify SM path \`psd-agent-creds/dev/user/{email}/freshservice_api_key\` exists.
4. **Image-gen with capability** — as an \`administrator\` user, ask the agent to generate an image. Confirm OpenAI traffic is sent, image lands in S3 at \`s3://psd-agents-dev-{account}/images/{email}/{uuid}.png\`, presigned URL works.
5. **Image-gen without capability** — as a user lacking \`skill.image-gen\`, ask for an image. Skill exits with \`forbidden_capability\`; no OpenAI traffic.
6. **Audit row** — confirm a row appears in \`psd_agent_credentials_audit\` for each \`put.js\` call (action=created on first, action=rotated on subsequent).

## Known limitations / follow-ups

- Catalog-level skill visibility filter — needs OpenClaw cooperation (no issue yet)
- Inline image rendering in Google Chat — needs agent-router \`cardsV2\` support (no issue yet)
- Admin UI for shared-secret provisioning — #933
- gpt-image-2 cost tracking and per-user rate limits — no issue yet

## Note for reviewer

\`infra/database/lambda/package-lock.json\` regenerates during \`cdk synth\`. The \`infra/.gitignore\` ignores \`lambdas/**/package-lock.json\` (plural) but not \`database/lambda/\` (singular). Worth a small follow-up to broaden the gitignore — out of scope here.