### PR TITLE
feat(agents): cross-source failure telemetry + scan-run audit + dashboard surfacing

### DIFF
--- a/actions/admin/agent-failures.actions.ts
+++ b/actions/admin/agent-failures.actions.ts
@@ -101,6 +101,18 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
   )
 }
 
+function narrowSource(value: string): AgentFailureSource {
+  return (VALID_SOURCES as readonly string[]).includes(value)
+    ? (value as AgentFailureSource)
+    : "router" // safe fallback — will still be visible in the UI
+}
+
+function narrowSeverity(value: string): AgentFailureSeverity {
+  return (VALID_SEVERITIES as readonly string[]).includes(value)
+    ? (value as AgentFailureSeverity)
+    : "error" // safe fallback
+}
+
 function rowToFailure(r: {
   id: number | string | bigint
   occurredAt: string | null
@@ -122,8 +134,8 @@ function rowToFailure(r: {
   return {
     id: Number(r.id),
     occurredAt: stripJsonQuotes(r.occurredAt) ?? "",
-    source: r.source as AgentFailureSource,
-    severity: r.severity as AgentFailureSeverity,
+    source: narrowSource(r.source),
+    severity: narrowSeverity(r.severity),
     userId: r.userId,
     sessionId: r.sessionId,
     scheduleName: r.scheduleName,
@@ -166,8 +178,8 @@ export async function getAgentFailures(
     if (filters.severity && VALID_SEVERITIES.includes(filters.severity)) {
       conditions.push(eq(agentFailures.severity, filters.severity))
     }
-    if (filters.userId) {
-      conditions.push(eq(agentFailures.userId, filters.userId))
+    if (typeof filters.userId === "string" && filters.userId.trim().length > 0) {
+      conditions.push(eq(agentFailures.userId, filters.userId.trim()))
     }
     if (typeof filters.acknowledged === "boolean") {
       conditions.push(eq(agentFailures.acknowledged, filters.acknowledged))
@@ -346,9 +358,9 @@ export async function generateTroubleshootingBundle(
     )
 
     const failures = rows.map((r) => rowToFailure(r))
-    const sessionMessages = await fetchSessionMessagesForFailures(failures)
+    const sessionData = await fetchSessionMessagesForFailures(failures)
 
-    const markdown = renderBundle(failures, sessionMessages)
+    const markdown = renderBundle(failures, sessionData)
 
     timer({ status: "success" })
     log.info("Troubleshooting bundle generated", { count: failures.length })
@@ -366,17 +378,28 @@ export async function generateTroubleshootingBundle(
   }
 }
 
+interface SessionMessagesResult {
+  messages: Map<string, SessionMessageRow[]>
+  totalSessions: number
+  includedSessions: number
+}
+
 async function fetchSessionMessagesForFailures(
   failures: FailureRow[],
-): Promise<Map<string, SessionMessageRow[]>> {
-  const sessionIds = [
+): Promise<SessionMessagesResult> {
+  const allSessionIds = [
     ...new Set(
       failures
         .map((f) => f.sessionId)
         .filter((s): s is string => typeof s === "string" && s.length > 0),
     ),
-  ].slice(0, 25)
-  const result = new Map<string, SessionMessageRow[]>()
+  ]
+  const sessionIds = allSessionIds.slice(0, 25)
+  const result: SessionMessagesResult = {
+    messages: new Map(),
+    totalSessions: allSessionIds.length,
+    includedSessions: sessionIds.length,
+  }
   if (sessionIds.length === 0) return result
 
   const messageRows = await executeQuery(
@@ -404,8 +427,8 @@ async function fetchSessionMessagesForFailures(
   for (const row of messageRows) {
     const sid = row.sessionId
     if (!sid) continue
-    if (!result.has(sid)) result.set(sid, [])
-    const list = result.get(sid)
+    if (!result.messages.has(sid)) result.messages.set(sid, [])
+    const list = result.messages.get(sid)
     if (list && list.length < 10) {
       list.push({
         id: Number(row.id),
@@ -461,8 +484,9 @@ function appendFailureSection(lines: string[], index: number, f: FailureRow) {
 
 function renderBundle(
   failures: FailureRow[],
-  sessionMessages: Map<string, SessionMessageRow[]> = new Map(),
+  sessionData: SessionMessagesResult,
 ): string {
+  const { messages: sessionMessages, totalSessions, includedSessions } = sessionData
   const generatedAt = new Date().toISOString()
   const sources = [...new Set(failures.map((f) => f.source))]
   const earliest = failures
@@ -484,6 +508,13 @@ function renderBundle(
   lines.push(
     `- Time range: ${earliest ?? "n/a"} → ${latest ?? "n/a"}`,
   )
+  if (totalSessions > includedSessions) {
+    lines.push(
+      `- Session context: ${includedSessions} of ${totalSessions} sessions included (limit 25)`,
+    )
+  } else if (totalSessions > 0) {
+    lines.push(`- Session context: ${totalSessions} session(s) included`)
+  }
   lines.push("")
   lines.push("## Failures")
   for (const [i, f] of failures.entries()) {

--- a/actions/admin/agent-failures.actions.ts
+++ b/actions/admin/agent-failures.actions.ts
@@ -1,0 +1,517 @@
+"use server"
+
+import {
+  createLogger,
+  generateRequestId,
+  startTimer,
+} from "@/lib/logger"
+import { handleError, createSuccess, ErrorFactories } from "@/lib/error-utils"
+import type { ActionState } from "@/types"
+import { requireRole } from "@/lib/auth/role-helpers"
+import { executeQuery } from "@/lib/db/drizzle-client"
+import { stripJsonQuotes, pgTimestampAsText } from "@/lib/db/drizzle-helpers"
+import { sql, desc, eq, and, gte, inArray, type SQL } from "drizzle-orm"
+import {
+  agentFailures,
+  type AgentFailureSource,
+  type AgentFailureSeverity,
+} from "@/lib/db/schema/tables/agent-failures"
+import { agentMessages } from "@/lib/db/schema/tables/agent-messages"
+import { getDateThreshold } from "@/lib/date-utils"
+import { getServerSession } from "@/lib/auth/server-session"
+import { revalidatePath } from "next/cache"
+
+export type FailureRange = "7d" | "30d" | "90d" | "all"
+
+const VALID_SOURCES: AgentFailureSource[] = [
+  "router",
+  "harness",
+  "cron",
+  "agent_self_report",
+  "tool",
+]
+
+const VALID_SEVERITIES: AgentFailureSeverity[] = [
+  "error",
+  "warn",
+  "empty_response",
+]
+
+const VALID_RANGES: FailureRange[] = ["7d", "30d", "90d", "all"]
+
+export interface FailureRow {
+  id: number
+  occurredAt: string
+  source: AgentFailureSource
+  severity: AgentFailureSeverity
+  userId: string | null
+  sessionId: string | null
+  scheduleName: string | null
+  model: string | null
+  errorClass: string | null
+  errorMessage: string | null
+  stackExcerpt: string | null
+  context: Record<string, unknown> | null
+  acknowledged: boolean
+  acknowledgedBy: string | null
+  acknowledgedAt: string | null
+  notes: string | null
+}
+
+export interface FailureListFilters {
+  range?: FailureRange
+  source?: AgentFailureSource
+  severity?: AgentFailureSeverity
+  userId?: string
+  acknowledged?: boolean
+  limit?: number
+}
+
+export interface FailureListResult {
+  failures: FailureRow[]
+  total: number
+}
+
+function sanitizeRange(range: FailureRange | undefined): FailureRange {
+  if (range && VALID_RANGES.includes(range)) return range
+  return "30d"
+}
+
+function clampLimit(limit: number | undefined, max = 500): number {
+  const value = typeof limit === "number" && Number.isFinite(limit) ? limit : 100
+  return Math.min(Math.max(1, value), max)
+}
+
+function thresholdFor(range: FailureRange): Date | null {
+  switch (range) {
+    case "7d":
+      return getDateThreshold(7)
+    case "30d":
+      return getDateThreshold(30)
+    case "90d":
+      return getDateThreshold(90)
+    case "all":
+      return null
+  }
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return (
+    typeof value === "object" && value !== null && !Array.isArray(value)
+  )
+}
+
+function rowToFailure(r: {
+  id: number | string | bigint
+  occurredAt: string | null
+  source: string
+  severity: string
+  userId: string | null
+  sessionId: string | null
+  scheduleName: string | null
+  model: string | null
+  errorClass: string | null
+  errorMessage: string | null
+  stackExcerpt: string | null
+  context: unknown
+  acknowledged: boolean
+  acknowledgedBy: string | null
+  acknowledgedAt: string | null
+  notes: string | null
+}): FailureRow {
+  return {
+    id: Number(r.id),
+    occurredAt: stripJsonQuotes(r.occurredAt) ?? "",
+    source: r.source as AgentFailureSource,
+    severity: r.severity as AgentFailureSeverity,
+    userId: r.userId,
+    sessionId: r.sessionId,
+    scheduleName: r.scheduleName,
+    model: r.model,
+    errorClass: r.errorClass,
+    errorMessage: r.errorMessage,
+    stackExcerpt: r.stackExcerpt,
+    context: isPlainObject(r.context) ? r.context : null,
+    acknowledged: Boolean(r.acknowledged),
+    acknowledgedBy: r.acknowledgedBy,
+    acknowledgedAt: r.acknowledgedAt
+      ? stripJsonQuotes(r.acknowledgedAt) ?? null
+      : null,
+    notes: r.notes,
+  }
+}
+
+/**
+ * List agent failures with filters.
+ */
+export async function getAgentFailures(
+  filters: FailureListFilters = {},
+): Promise<ActionState<FailureListResult>> {
+  const requestId = generateRequestId()
+  const timer = startTimer("getAgentFailures")
+  const log = createLogger({ requestId, action: "getAgentFailures" })
+
+  try {
+    await requireRole("administrator")
+
+    const range = sanitizeRange(filters.range)
+    const threshold = thresholdFor(range)
+    const limit = clampLimit(filters.limit, 500)
+
+    const conditions: SQL[] = []
+    if (threshold) conditions.push(gte(agentFailures.occurredAt, threshold))
+    if (filters.source && VALID_SOURCES.includes(filters.source)) {
+      conditions.push(eq(agentFailures.source, filters.source))
+    }
+    if (filters.severity && VALID_SEVERITIES.includes(filters.severity)) {
+      conditions.push(eq(agentFailures.severity, filters.severity))
+    }
+    if (filters.userId) {
+      conditions.push(eq(agentFailures.userId, filters.userId))
+    }
+    if (typeof filters.acknowledged === "boolean") {
+      conditions.push(eq(agentFailures.acknowledged, filters.acknowledged))
+    }
+    const whereClause = conditions.length > 0 ? and(...conditions) : undefined
+
+    const rows = await executeQuery(
+      (db) =>
+        db
+          .select({
+            id: agentFailures.id,
+            occurredAt: pgTimestampAsText(agentFailures.occurredAt),
+            source: agentFailures.source,
+            severity: agentFailures.severity,
+            userId: agentFailures.userId,
+            sessionId: agentFailures.sessionId,
+            scheduleName: agentFailures.scheduleName,
+            model: agentFailures.model,
+            errorClass: agentFailures.errorClass,
+            errorMessage: agentFailures.errorMessage,
+            stackExcerpt: agentFailures.stackExcerpt,
+            context: agentFailures.context,
+            acknowledged: agentFailures.acknowledged,
+            acknowledgedBy: agentFailures.acknowledgedBy,
+            acknowledgedAt: pgTimestampAsText(agentFailures.acknowledgedAt),
+            notes: agentFailures.notes,
+            totalCount: sql<number>`COUNT(*) OVER()`.as("total_count"),
+          })
+          .from(agentFailures)
+          .where(whereClause)
+          .orderBy(desc(agentFailures.occurredAt))
+          .limit(limit),
+      "agentFailures.list",
+    )
+
+    const total = rows.length > 0 ? Number(rows[0].totalCount) : 0
+    const failures = rows.map((r) => rowToFailure(r))
+
+    timer({ status: "success" })
+    log.info("Agent failures loaded", {
+      range,
+      total,
+      returned: failures.length,
+    })
+    return createSuccess({ failures, total })
+  } catch (error) {
+    timer({ status: "error" })
+    return handleError(error, "Failed to load agent failures", {
+      context: "getAgentFailures",
+      requestId,
+      operation: "getAgentFailures",
+    })
+  }
+}
+
+export interface AcknowledgeInput {
+  ids: number[]
+  notes?: string
+}
+
+/**
+ * Acknowledge one or more failures so they drop off the unack queue.
+ */
+export async function acknowledgeFailures(
+  input: AcknowledgeInput,
+): Promise<ActionState<{ updated: number }>> {
+  const requestId = generateRequestId()
+  const timer = startTimer("acknowledgeFailures")
+  const log = createLogger({ requestId, action: "acknowledgeFailures" })
+
+  try {
+    await requireRole("administrator")
+    const session = await getServerSession()
+    if (!session) throw ErrorFactories.authNoSession()
+
+    const ids = Array.isArray(input.ids)
+      ? input.ids
+          .map((n) => Number(n))
+          .filter((n) => Number.isInteger(n) && n > 0)
+      : []
+    if (ids.length === 0) throw ErrorFactories.validationFailed([
+      { field: "ids", message: "ids must be a non-empty list of positive integers" },
+    ])
+    const notes =
+      typeof input.notes === "string" && input.notes.trim().length > 0
+        ? input.notes.slice(0, 4000)
+        : null
+
+    const ackBy = session.email ?? session.sub ?? "unknown"
+
+    const updated = await executeQuery(
+      (db) =>
+        db
+          .update(agentFailures)
+          .set({
+            acknowledged: true,
+            acknowledgedBy: ackBy,
+            acknowledgedAt: new Date(),
+            notes: notes ?? undefined,
+          })
+          .where(inArray(agentFailures.id, ids))
+          .returning({ id: agentFailures.id }),
+      "agentFailures.acknowledge",
+    )
+
+    revalidatePath("/admin/agents")
+
+    timer({ status: "success" })
+    log.info("Failures acknowledged", { count: updated.length })
+    return createSuccess({ updated: updated.length }, "Failures acknowledged")
+  } catch (error) {
+    timer({ status: "error" })
+    return handleError(error, "Failed to acknowledge failures", {
+      context: "acknowledgeFailures",
+      requestId,
+      operation: "acknowledgeFailures",
+    })
+  }
+}
+
+/**
+ * Build a self-contained markdown bundle for selected failures, intended to be
+ * pasted into Claude Code for root-cause analysis.
+ */
+export async function generateTroubleshootingBundle(
+  ids: number[],
+): Promise<ActionState<{ markdown: string; count: number }>> {
+  const requestId = generateRequestId()
+  const timer = startTimer("generateTroubleshootingBundle")
+  const log = createLogger({
+    requestId,
+    action: "generateTroubleshootingBundle",
+  })
+
+  try {
+    await requireRole("administrator")
+
+    const safeIds = Array.isArray(ids)
+      ? ids
+          .map((n) => Number(n))
+          .filter((n) => Number.isInteger(n) && n > 0)
+          .slice(0, 100)
+      : []
+    if (safeIds.length === 0) throw ErrorFactories.validationFailed([
+      { field: "ids", message: "Select at least one failure" },
+    ])
+
+    const rows = await executeQuery(
+      (db) =>
+        db
+          .select({
+            id: agentFailures.id,
+            occurredAt: pgTimestampAsText(agentFailures.occurredAt),
+            source: agentFailures.source,
+            severity: agentFailures.severity,
+            userId: agentFailures.userId,
+            sessionId: agentFailures.sessionId,
+            scheduleName: agentFailures.scheduleName,
+            model: agentFailures.model,
+            errorClass: agentFailures.errorClass,
+            errorMessage: agentFailures.errorMessage,
+            stackExcerpt: agentFailures.stackExcerpt,
+            context: agentFailures.context,
+            acknowledged: agentFailures.acknowledged,
+            acknowledgedBy: agentFailures.acknowledgedBy,
+            acknowledgedAt: pgTimestampAsText(agentFailures.acknowledgedAt),
+            notes: agentFailures.notes,
+          })
+          .from(agentFailures)
+          .where(inArray(agentFailures.id, safeIds))
+          .orderBy(desc(agentFailures.occurredAt)),
+      "agentFailures.bundle",
+    )
+
+    const failures = rows.map((r) => rowToFailure(r))
+    const sessionMessages = await fetchSessionMessagesForFailures(failures)
+
+    const markdown = renderBundle(failures, sessionMessages)
+
+    timer({ status: "success" })
+    log.info("Troubleshooting bundle generated", { count: failures.length })
+    return createSuccess(
+      { markdown, count: failures.length },
+      "Bundle ready",
+    )
+  } catch (error) {
+    timer({ status: "error" })
+    return handleError(error, "Failed to generate troubleshooting bundle", {
+      context: "generateTroubleshootingBundle",
+      requestId,
+      operation: "generateTroubleshootingBundle",
+    })
+  }
+}
+
+async function fetchSessionMessagesForFailures(
+  failures: FailureRow[],
+): Promise<Map<string, SessionMessageRow[]>> {
+  const sessionIds = [
+    ...new Set(
+      failures
+        .map((f) => f.sessionId)
+        .filter((s): s is string => typeof s === "string" && s.length > 0),
+    ),
+  ].slice(0, 25)
+  const result = new Map<string, SessionMessageRow[]>()
+  if (sessionIds.length === 0) return result
+
+  const messageRows = await executeQuery(
+    (db) =>
+      db
+        .select({
+          id: agentMessages.id,
+          sessionId: agentMessages.sessionId,
+          userId: agentMessages.userId,
+          model: agentMessages.model,
+          inputTokens: agentMessages.inputTokens,
+          outputTokens: agentMessages.outputTokens,
+          latencyMs: agentMessages.latencyMs,
+          guardrailBlocked: agentMessages.guardrailBlocked,
+          topic: agentMessages.topic,
+          createdAt: pgTimestampAsText(agentMessages.createdAt),
+        })
+        .from(agentMessages)
+        .where(inArray(agentMessages.sessionId, sessionIds))
+        .orderBy(desc(agentMessages.createdAt))
+        .limit(500),
+    "agentFailures.bundleMessages",
+  )
+
+  for (const row of messageRows) {
+    const sid = row.sessionId
+    if (!sid) continue
+    if (!result.has(sid)) result.set(sid, [])
+    const list = result.get(sid)
+    if (list && list.length < 10) {
+      list.push({
+        id: Number(row.id),
+        createdAt: stripJsonQuotes(row.createdAt) ?? "",
+        model: row.model ?? null,
+        inputTokens: row.inputTokens ?? 0,
+        outputTokens: row.outputTokens ?? 0,
+        latencyMs: row.latencyMs ?? 0,
+        guardrailBlocked: Boolean(row.guardrailBlocked),
+        topic: row.topic ?? null,
+      })
+    }
+  }
+  return result
+}
+
+interface SessionMessageRow {
+  id: number
+  createdAt: string
+  model: string | null
+  inputTokens: number
+  outputTokens: number
+  latencyMs: number
+  guardrailBlocked: boolean
+  topic: string | null
+}
+
+function appendCodeBlock(lines: string[], label: string, body: string, fence = "```") {
+  lines.push(`- **${label}:**`)
+  lines.push(`  ${fence}`)
+  for (const ln of body.split("\n").slice(0, 40)) {
+    lines.push(`  ${ln}`)
+  }
+  lines.push(`  ${fence}`)
+}
+
+function appendFailureSection(lines: string[], index: number, f: FailureRow) {
+  lines.push("")
+  lines.push(`### [${index + 1}] ${f.source} · ${f.severity} · ${f.occurredAt}`)
+  lines.push(`- **id:** ${f.id}`)
+  if (f.userId) lines.push(`- **user:** ${f.userId}`)
+  if (f.sessionId) lines.push(`- **session:** \`${f.sessionId}\``)
+  if (f.scheduleName) lines.push(`- **schedule:** ${f.scheduleName}`)
+  if (f.model) lines.push(`- **model:** ${f.model}`)
+  if (f.errorClass) lines.push(`- **error class:** ${f.errorClass}`)
+  if (f.errorMessage) appendCodeBlock(lines, "error message", f.errorMessage)
+  if (f.context) {
+    appendCodeBlock(lines, "context", JSON.stringify(f.context, null, 2), "```json")
+  }
+  if (f.stackExcerpt) appendCodeBlock(lines, "stack", f.stackExcerpt)
+  if (f.notes) lines.push(`- **operator notes:** ${f.notes}`)
+}
+
+function renderBundle(
+  failures: FailureRow[],
+  sessionMessages: Map<string, SessionMessageRow[]> = new Map(),
+): string {
+  const generatedAt = new Date().toISOString()
+  const sources = [...new Set(failures.map((f) => f.source))]
+  const earliest = failures
+    .map((f) => f.occurredAt)
+    .filter(Boolean)
+    .sort()[0]
+  const latest = failures
+    .map((f) => f.occurredAt)
+    .filter(Boolean)
+    .sort()
+    .at(-1)
+
+  const lines: string[] = []
+  lines.push(`# Agent Failure Bundle (generated ${generatedAt})`)
+  lines.push("")
+  lines.push("## Summary")
+  lines.push(`- Count: ${failures.length} failure(s)`)
+  lines.push(`- Sources: ${sources.join(", ") || "(none)"}`)
+  lines.push(
+    `- Time range: ${earliest ?? "n/a"} → ${latest ?? "n/a"}`,
+  )
+  lines.push("")
+  lines.push("## Failures")
+  for (const [i, f] of failures.entries()) {
+    appendFailureSection(lines, i, f)
+    if (f.sessionId) {
+      const msgs = sessionMessages.get(f.sessionId)
+      if (msgs && msgs.length > 0) {
+        lines.push(`- **session conversation (telemetry only — no message content stored):**`)
+        lines.push("  ```")
+        for (const m of msgs) {
+          lines.push(
+            `  ${m.createdAt} model=${m.model ?? "-"} in=${m.inputTokens} ` +
+              `out=${m.outputTokens} latency=${m.latencyMs}ms ` +
+              `topic=${m.topic ?? "-"}${m.guardrailBlocked ? " GUARDRAIL" : ""}`,
+          )
+        }
+        lines.push("  ```")
+      }
+    }
+  }
+  lines.push("")
+  lines.push("## Investigation prompt")
+  lines.push(
+    "Investigate these agent failures. For each: identify likely root cause,",
+  )
+  lines.push(
+    "list the file(s) that need changes, and propose a minimal fix. Group",
+  )
+  lines.push(
+    "common causes together. Flag any failures that look like infrastructure",
+  )
+  lines.push("issues (deploy/config/credentials) versus code bugs.")
+  return lines.join("\n")
+}

--- a/actions/admin/agent-failures.actions.ts
+++ b/actions/admin/agent-failures.actions.ts
@@ -240,6 +240,8 @@ export async function acknowledgeFailures(
 
   try {
     await requireRole("administrator")
+    // requireRole guarantees auth, but we need the session object for ackBy.
+    // The null check satisfies TypeScript narrowing.
     const session = await getServerSession()
     if (!session) throw ErrorFactories.authNoSession()
 
@@ -395,7 +397,7 @@ async function fetchSessionMessagesForFailures(
         .from(agentMessages)
         .where(inArray(agentMessages.sessionId, sessionIds))
         .orderBy(desc(agentMessages.createdAt))
-        .limit(500),
+        .limit(Math.min(sessionIds.length * 10, 500)),
     "agentFailures.bundleMessages",
   )
 
@@ -431,13 +433,13 @@ interface SessionMessageRow {
   topic: string | null
 }
 
-function appendCodeBlock(lines: string[], label: string, body: string, fence = "```") {
+function appendCodeBlock(lines: string[], label: string, body: string, lang = "") {
   lines.push(`- **${label}:**`)
-  lines.push(`  ${fence}`)
+  lines.push(`  \`\`\`${lang}`)
   for (const ln of body.split("\n").slice(0, 40)) {
     lines.push(`  ${ln}`)
   }
-  lines.push(`  ${fence}`)
+  lines.push("  ```")
 }
 
 function appendFailureSection(lines: string[], index: number, f: FailureRow) {
@@ -451,7 +453,7 @@ function appendFailureSection(lines: string[], index: number, f: FailureRow) {
   if (f.errorClass) lines.push(`- **error class:** ${f.errorClass}`)
   if (f.errorMessage) appendCodeBlock(lines, "error message", f.errorMessage)
   if (f.context) {
-    appendCodeBlock(lines, "context", JSON.stringify(f.context, null, 2), "```json")
+    appendCodeBlock(lines, "context", JSON.stringify(f.context, null, 2), "json")
   }
   if (f.stackExcerpt) appendCodeBlock(lines, "stack", f.stackExcerpt)
   if (f.notes) lines.push(`- **operator notes:** ${f.notes}`)

--- a/actions/admin/agent-failures.actions.ts
+++ b/actions/admin/agent-failures.actions.ts
@@ -247,6 +247,7 @@ export async function acknowledgeFailures(
       ? input.ids
           .map((n) => Number(n))
           .filter((n) => Number.isInteger(n) && n > 0)
+          .slice(0, 500)
       : []
     if (ids.length === 0) throw ErrorFactories.validationFailed([
       { field: "ids", message: "ids must be a non-empty list of positive integers" },
@@ -266,7 +267,7 @@ export async function acknowledgeFailures(
             acknowledged: true,
             acknowledgedBy: ackBy,
             acknowledgedAt: new Date(),
-            notes: notes ?? undefined,
+            notes: notes ?? null,
           })
           .where(inArray(agentFailures.id, ids))
           .returning({ id: agentFailures.id }),

--- a/actions/admin/agent-failures.actions.ts
+++ b/actions/admin/agent-failures.actions.ts
@@ -3,6 +3,7 @@
 import {
   createLogger,
   generateRequestId,
+  sanitizeForLogging,
   startTimer,
 } from "@/lib/logger"
 import { handleError, createSuccess, ErrorFactories } from "@/lib/error-utils"
@@ -18,7 +19,6 @@ import {
 } from "@/lib/db/schema/tables/agent-failures"
 import { agentMessages } from "@/lib/db/schema/tables/agent-messages"
 import { getDateThreshold } from "@/lib/date-utils"
-import { getServerSession } from "@/lib/auth/server-session"
 import { revalidatePath } from "next/cache"
 
 export type FailureRange = "7d" | "30d" | "90d" | "all"
@@ -29,6 +29,7 @@ const VALID_SOURCES: AgentFailureSource[] = [
   "cron",
   "agent_self_report",
   "tool",
+  "other",
 ]
 
 const VALID_SEVERITIES: AgentFailureSeverity[] = [
@@ -104,7 +105,7 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
 function narrowSource(value: string): AgentFailureSource {
   return (VALID_SOURCES as readonly string[]).includes(value)
     ? (value as AgentFailureSource)
-    : "router" // safe fallback — will still be visible in the UI
+    : "other" // neutral fallback — avoids misattributing unknown sources to "router"
 }
 
 function narrowSeverity(value: string): AgentFailureSeverity {
@@ -114,7 +115,7 @@ function narrowSeverity(value: string): AgentFailureSeverity {
 }
 
 function rowToFailure(r: {
-  id: number | string | bigint
+  id: number
   occurredAt: string | null
   source: string
   severity: string
@@ -219,11 +220,11 @@ export async function getAgentFailures(
     const failures = rows.map((r) => rowToFailure(r))
 
     timer({ status: "success" })
-    log.info("Agent failures loaded", {
+    log.info("Agent failures loaded", sanitizeForLogging({
       range,
       total,
       returned: failures.length,
-    })
+    }))
     return createSuccess({ failures, total })
   } catch (error) {
     timer({ status: "error" })
@@ -251,11 +252,7 @@ export async function acknowledgeFailures(
   const log = createLogger({ requestId, action: "acknowledgeFailures" })
 
   try {
-    await requireRole("administrator")
-    // requireRole guarantees auth, but we need the session object for ackBy.
-    // The null check satisfies TypeScript narrowing.
-    const session = await getServerSession()
-    if (!session) throw ErrorFactories.authNoSession()
+    const currentUser = await requireRole("administrator")
 
     const ids = Array.isArray(input.ids)
       ? input.ids
@@ -271,7 +268,7 @@ export async function acknowledgeFailures(
         ? input.notes.slice(0, 4000)
         : null
 
-    const ackBy = session.email ?? session.sub ?? "unknown"
+    const ackBy = currentUser.user.email ?? "unknown"
 
     const updated = await executeQuery(
       (db) =>
@@ -465,6 +462,8 @@ function appendCodeBlock(lines: string[], label: string, body: string, lang = ""
   lines.push("  ```")
 }
 
+// NOTE: Fields like userId, scheduleName, model are inlined as plain text.
+// No XSS risk since the bundle is admin-only and pasted into Claude Code.
 function appendFailureSection(lines: string[], index: number, f: FailureRow) {
   lines.push("")
   lines.push(`### [${index + 1}] ${f.source} · ${f.severity} · ${f.occurredAt}`)

--- a/actions/admin/agent-health.actions.ts
+++ b/actions/admin/agent-health.actions.ts
@@ -9,6 +9,8 @@ import { stripJsonQuotes, pgTimestampAsText } from "@/lib/db/drizzle-helpers"
 import { sql, desc, eq } from "drizzle-orm"
 import { agentHealthSnapshots } from "@/lib/db/schema/tables/agent-health-snapshots"
 import { agentPatterns } from "@/lib/db/schema/tables/agent-patterns"
+import { agentHealthScanRuns } from "@/lib/db/schema/tables/agent-health-scan-runs"
+import { agentPatternScanRuns } from "@/lib/db/schema/tables/agent-pattern-scan-runs"
 
 export interface AgentHealthRow {
   userEmail: string
@@ -22,6 +24,14 @@ export interface AgentHealthRow {
   snapshotDate: string
 }
 
+export interface AgentHealthScanRun {
+  runAt: string
+  snapshotDate: string
+  usersTotal: number
+  abandoned: number
+  error: string | null
+}
+
 export interface AgentHealthSummary {
   totalUsers: number
   abandonedCount: number
@@ -30,6 +40,46 @@ export interface AgentHealthSummary {
   totalMemoryFiles: number
   snapshotDate: string | null
   rows: AgentHealthRow[]
+  lastScan: AgentHealthScanRun | null
+}
+
+async function loadLatestSnapshotDate(): Promise<string | null> {
+  const rows = await executeQuery(
+    (db) =>
+      db
+        .select({
+          date: sql<string>`MAX(${agentHealthSnapshots.snapshotDate})::text`,
+        })
+        .from(agentHealthSnapshots),
+    "agentHealth.latest",
+  )
+  return rows[0]?.date ?? null
+}
+
+async function loadLastHealthScan(): Promise<AgentHealthScanRun | null> {
+  const rows = await executeQuery(
+    (db) =>
+      db
+        .select({
+          runAt: pgTimestampAsText(agentHealthScanRuns.runAt),
+          snapshotDate: sql<string>`${agentHealthScanRuns.snapshotDate}::text`,
+          usersTotal: agentHealthScanRuns.usersTotal,
+          abandoned: agentHealthScanRuns.abandoned,
+          error: agentHealthScanRuns.error,
+        })
+        .from(agentHealthScanRuns)
+        .orderBy(desc(agentHealthScanRuns.runAt))
+        .limit(1),
+    "agentHealth.lastScan",
+  )
+  if (!rows[0]) return null
+  return {
+    runAt: stripJsonQuotes(rows[0].runAt) ?? "",
+    snapshotDate: String(rows[0].snapshotDate),
+    usersTotal: Number(rows[0].usersTotal),
+    abandoned: Number(rows[0].abandoned),
+    error: rows[0].error,
+  }
 }
 
 /**
@@ -51,18 +101,11 @@ export async function getAgentHealthSummary(
     // users today and this cap leaves headroom for 2.5x growth.
     const safeLim = Math.min(Math.max(1, limit), 500)
 
-    // Use the latest snapshot_date that exists. If the Lambda hasn't run yet
-    // the table is empty and the response is zeros.
-    const latest = await executeQuery(
-      (db) =>
-        db
-          .select({
-            date: sql<string>`MAX(${agentHealthSnapshots.snapshotDate})::text`,
-          })
-          .from(agentHealthSnapshots),
-      "agentHealth.latest"
-    )
-    const snapshotDate = latest[0]?.date ?? null
+    const [latest, lastScan] = await Promise.all([
+      loadLatestSnapshotDate(),
+      loadLastHealthScan(),
+    ])
+    const snapshotDate = latest
 
     if (!snapshotDate) {
       return createSuccess<AgentHealthSummary>({
@@ -73,6 +116,7 @@ export async function getAgentHealthSummary(
         totalMemoryFiles: 0,
         snapshotDate: null,
         rows: [],
+        lastScan,
       })
     }
 
@@ -138,6 +182,7 @@ export async function getAgentHealthSummary(
       totalMemoryFiles: Number(agg?.totalMemoryFiles ?? 0),
       snapshotDate,
       rows: data,
+      lastScan,
     }
 
     timer({ status: "success" })
@@ -169,6 +214,20 @@ export interface AgentPatternRow {
   detectedAt: string
 }
 
+export interface AgentPatternScanRun {
+  runAt: string
+  week: string
+  signalsTotal: number
+  topicsTotal: number
+  detected: number
+  suppressed: number
+}
+
+export interface AgentPatternsEnvelope {
+  rows: AgentPatternRow[]
+  lastScan: AgentPatternScanRun | null
+}
+
 /**
  * Load detected patterns from the Pattern Scanner Lambda.
  * Filtered to the most recent N weeks. Privacy guarantee: rows contain
@@ -176,7 +235,7 @@ export interface AgentPatternRow {
  */
 export async function getAgentPatterns(
   weeks = 8
-): Promise<ActionState<AgentPatternRow[]>> {
+): Promise<ActionState<AgentPatternsEnvelope>> {
   const requestId = generateRequestId()
   const timer = startTimer("getAgentPatterns")
   const log = createLogger({ requestId, action: "getAgentPatterns" })
@@ -187,25 +246,43 @@ export async function getAgentPatterns(
     // Clamp weeks to prevent unbounded result sets (CWE-400)
     const safeWeeks = Math.min(Math.max(1, weeks), 52)
 
-    const rows = await executeQuery(
-      (db) =>
-        db
-          .select({
-            week: agentPatterns.week,
-            topic: agentPatterns.topic,
-            signalCount: agentPatterns.signalCount,
-            buildingCount: agentPatterns.buildingCount,
-            rollingAvg: agentPatterns.rollingAvg,
-            spikeRatio: agentPatterns.spikeRatio,
-            isEmerging: agentPatterns.isEmerging,
-            buildings: agentPatterns.buildings,
-            detectedAt: pgTimestampAsText(agentPatterns.detectedAt),
-          })
-          .from(agentPatterns)
-          .orderBy(desc(agentPatterns.week), desc(agentPatterns.signalCount))
-          .limit(safeWeeks * 20),
-      "agentPatterns.list"
-    )
+    const [rows, lastScanRows] = await Promise.all([
+      executeQuery(
+        (db) =>
+          db
+            .select({
+              week: agentPatterns.week,
+              topic: agentPatterns.topic,
+              signalCount: agentPatterns.signalCount,
+              buildingCount: agentPatterns.buildingCount,
+              rollingAvg: agentPatterns.rollingAvg,
+              spikeRatio: agentPatterns.spikeRatio,
+              isEmerging: agentPatterns.isEmerging,
+              buildings: agentPatterns.buildings,
+              detectedAt: pgTimestampAsText(agentPatterns.detectedAt),
+            })
+            .from(agentPatterns)
+            .orderBy(desc(agentPatterns.week), desc(agentPatterns.signalCount))
+            .limit(safeWeeks * 20),
+        "agentPatterns.list",
+      ),
+      executeQuery(
+        (db) =>
+          db
+            .select({
+              runAt: pgTimestampAsText(agentPatternScanRuns.runAt),
+              week: agentPatternScanRuns.week,
+              signalsTotal: agentPatternScanRuns.signalsTotal,
+              topicsTotal: agentPatternScanRuns.topicsTotal,
+              detected: agentPatternScanRuns.detected,
+              suppressed: agentPatternScanRuns.suppressed,
+            })
+            .from(agentPatternScanRuns)
+            .orderBy(desc(agentPatternScanRuns.runAt))
+            .limit(1),
+        "agentPatterns.lastScan",
+      ),
+    ])
 
     const data: AgentPatternRow[] = rows.map((r) => ({
       week: String(r.week),
@@ -219,9 +296,23 @@ export async function getAgentPatterns(
       detectedAt: stripJsonQuotes(r.detectedAt) ?? "",
     }))
 
+    const lastScan: AgentPatternScanRun | null = lastScanRows[0]
+      ? {
+          runAt: stripJsonQuotes(lastScanRows[0].runAt) ?? "",
+          week: String(lastScanRows[0].week),
+          signalsTotal: Number(lastScanRows[0].signalsTotal),
+          topicsTotal: Number(lastScanRows[0].topicsTotal),
+          detected: Number(lastScanRows[0].detected),
+          suppressed: Number(lastScanRows[0].suppressed),
+        }
+      : null
+
     timer({ status: "success" })
-    log.info("Agent patterns loaded", { count: data.length })
-    return createSuccess(data)
+    log.info("Agent patterns loaded", {
+      count: data.length,
+      hasLastScan: lastScan !== null,
+    })
+    return createSuccess({ rows: data, lastScan })
   } catch (error) {
     timer({ status: "error" })
     return handleError(error, "Failed to load agent patterns", {

--- a/app/(protected)/admin/agents/_components/agent-dashboard-client.tsx
+++ b/app/(protected)/admin/agents/_components/agent-dashboard-client.tsx
@@ -26,6 +26,7 @@ import { AgentPatternsTable } from "./agent-patterns-table"
 import { SkillsListClient } from "../skills/_components/skills-list-client"
 import { CredentialsClient } from "../credentials/_components/credentials-client"
 import { AgentWorkspaceTable } from "./agent-workspace-table"
+import { AgentFailuresClient } from "./agent-failures-client"
 
 import {
   getAgentTelemetryStats,
@@ -46,7 +47,7 @@ import {
   getAgentHealthSummary,
   getAgentPatterns,
   type AgentHealthSummary,
-  type AgentPatternRow,
+  type AgentPatternsEnvelope,
 } from "@/actions/admin/agent-health.actions"
 import {
   getAgentCostSummary,
@@ -65,6 +66,7 @@ type DashboardTab =
   | "skills"
   | "credentials"
   | "workspace"
+  | "failures"
 
 /**
  * Map telemetry date range to Cost Explorer range.
@@ -83,7 +85,7 @@ interface LoaderSetters {
   setFeedbackList: (v: FeedbackItem[]) => void
   setHealthSummary: (v: AgentHealthSummary | null) => void
   setCostSummary: (v: AgentCostSummary | null) => void
-  setPatterns: (v: AgentPatternRow[]) => void
+  setPatterns: (v: AgentPatternsEnvelope) => void
 }
 
 interface LoaderContext extends LoaderSetters {
@@ -164,6 +166,7 @@ function buildLoaders(
     skills: async () => {},
     credentials: async () => {},
     workspace: async () => {},
+    failures: async () => {},
   }
 }
 
@@ -249,7 +252,7 @@ function DashboardTabs({
   feedbackList: FeedbackItem[]
   healthSummary: AgentHealthSummary | null
   costSummary: AgentCostSummary | null
-  patterns: AgentPatternRow[]
+  patterns: AgentPatternsEnvelope
 }) {
   return (
     <Tabs value={activeTab} onValueChange={onTabChange}>
@@ -257,6 +260,7 @@ function DashboardTabs({
         <TabsTrigger value="usage">Usage</TabsTrigger>
         <TabsTrigger value="cost">Cost</TabsTrigger>
         <TabsTrigger value="adoption">Adoption</TabsTrigger>
+        <TabsTrigger value="failures">Failures</TabsTrigger>
         <TabsTrigger value="health">Health</TabsTrigger>
         <TabsTrigger value="safety">Safety</TabsTrigger>
         <TabsTrigger value="patterns">Patterns</TabsTrigger>
@@ -311,6 +315,10 @@ function DashboardTabs({
       <TabsContent value="workspace" className="mt-4">
         <AgentWorkspaceTable />
       </TabsContent>
+
+      <TabsContent value="failures" className="mt-4">
+        <AgentFailuresClient />
+      </TabsContent>
     </Tabs>
   )
 }
@@ -328,7 +336,10 @@ export function AgentDashboardClient() {
   const [feedbackList, setFeedbackList] = useState<FeedbackItem[]>([])
   const [healthSummary, setHealthSummary] = useState<AgentHealthSummary | null>(null)
   const [costSummary, setCostSummary] = useState<AgentCostSummary | null>(null)
-  const [patterns, setPatterns] = useState<AgentPatternRow[]>([])
+  const [patterns, setPatterns] = useState<AgentPatternsEnvelope>({
+    rows: [],
+    lastScan: null,
+  })
   const [tabLoading, setTabLoading] = useState(false)
 
   // Request version counter — prevents stale responses from overwriting

--- a/app/(protected)/admin/agents/_components/agent-failures-client.tsx
+++ b/app/(protected)/admin/agents/_components/agent-failures-client.tsx
@@ -67,6 +67,7 @@ const SOURCE_OPTIONS = [
   { value: "cron", label: "Cron" },
   { value: "agent_self_report", label: "Agent self-report" },
   { value: "tool", label: "Tool" },
+  { value: "other", label: "Other" },
 ] as const
 
 const SEVERITY_OPTIONS = [
@@ -125,8 +126,8 @@ export function AgentFailuresClient() {
   const [rows, setRows] = useState<FailureRow[]>([])
   const [total, setTotal] = useState(0)
   const [loading, setLoading] = useState(true)
-  const [selected, setSelected] = useState<Set<number>>(new Set())
-  const [expanded, setExpanded] = useState<Set<number>>(new Set())
+  const [selected, setSelected] = useState<number[]>([])
+  const [expanded, setExpanded] = useState<number[]>([])
   const [ackOpen, setAckOpen] = useState(false)
   const [ackNotes, setAckNotes] = useState("")
   const [bundleOpen, setBundleOpen] = useState(false)
@@ -149,7 +150,7 @@ export function AgentFailuresClient() {
       if (result.isSuccess && result.data) {
         setRows(result.data.failures)
         setTotal(result.data.total)
-        setSelected(new Set())
+        setSelected([])
       } else {
         toast({
           variant: "destructive",
@@ -157,6 +158,12 @@ export function AgentFailuresClient() {
           description: result.message,
         })
       }
+    } catch {
+      toast({
+        variant: "destructive",
+        title: "Error loading failures",
+        description: "A network error occurred. Please try again.",
+      })
     } finally {
       setLoading(false)
     }
@@ -167,31 +174,25 @@ export function AgentFailuresClient() {
   }, [load])
 
   const toggleSelect = (id: number) => {
-    setSelected((prev) => {
-      const next = new Set(prev)
-      if (next.has(id)) next.delete(id)
-      else next.add(id)
-      return next
-    })
+    setSelected((prev) =>
+      prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id],
+    )
   }
 
   const toggleAll = () => {
     setSelected((prev) =>
-      prev.size === rows.length ? new Set() : new Set(rows.map((r) => r.id)),
+      prev.length === rows.length ? [] : rows.map((r) => r.id),
     )
   }
 
   const toggleExpand = (id: number) => {
-    setExpanded((prev) => {
-      const next = new Set(prev)
-      if (next.has(id)) next.delete(id)
-      else next.add(id)
-      return next
-    })
+    setExpanded((prev) =>
+      prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id],
+    )
   }
 
   const handleAcknowledge = async () => {
-    if (selected.size === 0) return
+    if (selected.length === 0) return
     setBusy(true)
     try {
       const result = await acknowledgeFailures({
@@ -216,7 +217,7 @@ export function AgentFailuresClient() {
   }
 
   const handleGenerateBundle = async () => {
-    if (selected.size === 0) return
+    if (selected.length === 0) return
     setBusy(true)
     try {
       const result = await generateTroubleshootingBundle([...selected])
@@ -240,6 +241,7 @@ export function AgentFailuresClient() {
     try {
       await navigator.clipboard.writeText(bundleMd)
       setBundleCopied(true)
+      setTimeout(() => setBundleCopied(false), 2000)
       toast({ title: "Bundle copied to clipboard" })
     } catch {
       toast({
@@ -252,10 +254,10 @@ export function AgentFailuresClient() {
 
   const headerCheckboxState = useMemo<boolean | "indeterminate">(() => {
     if (rows.length === 0) return false
-    if (selected.size === 0) return false
-    if (selected.size === rows.length) return true
+    if (selected.length === 0) return false
+    if (selected.length === rows.length) return true
     return "indeterminate"
-  }, [rows.length, selected.size])
+  }, [rows.length, selected.length])
 
   return (
     <Card>
@@ -327,18 +329,18 @@ export function AgentFailuresClient() {
           <Button
             variant="default"
             size="sm"
-            disabled={selected.size === 0 || busy}
+            disabled={selected.length === 0 || busy}
             onClick={() => setAckOpen(true)}
           >
-            Acknowledge ({selected.size})
+            Acknowledge ({selected.length})
           </Button>
           <Button
             variant="secondary"
             size="sm"
-            disabled={selected.size === 0 || busy}
+            disabled={selected.length === 0 || busy}
             onClick={handleGenerateBundle}
           >
-            Generate bundle ({selected.size})
+            Generate bundle ({selected.length})
           </Button>
         </div>
       </CardHeader>
@@ -377,13 +379,13 @@ export function AgentFailuresClient() {
               </TableHeader>
               <TableBody>
                 {rows.map((r) => {
-                  const isExpanded = expanded.has(r.id)
+                  const isExpanded = expanded.includes(r.id)
                   return (
                     <Fragment key={r.id}>
                       <TableRow>
                         <TableCell>
                           <Checkbox
-                            checked={selected.has(r.id)}
+                            checked={selected.includes(r.id)}
                             onCheckedChange={() => toggleSelect(r.id)}
                             aria-label={`Select failure ${r.id}`}
                           />
@@ -453,10 +455,10 @@ export function AgentFailuresClient() {
         )}
       </CardContent>
 
-      <Dialog open={ackOpen} onOpenChange={setAckOpen}>
+      <Dialog open={ackOpen} onOpenChange={(open) => { setAckOpen(open); if (!open) setAckNotes("") }}>
         <DialogContent>
           <DialogHeader>
-            <DialogTitle>Acknowledge {selected.size} failure(s)</DialogTitle>
+            <DialogTitle>Acknowledge {selected.length} failure(s)</DialogTitle>
             <DialogDescription>
               Optional note about how this was handled (visible in audit log).
             </DialogDescription>

--- a/app/(protected)/admin/agents/_components/agent-failures-client.tsx
+++ b/app/(protected)/admin/agents/_components/agent-failures-client.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useCallback, useEffect, useMemo, useState } from "react"
+import { Fragment, useCallback, useEffect, useMemo, useState } from "react"
 import {
   Card,
   CardContent,
@@ -379,8 +379,8 @@ export function AgentFailuresClient() {
                 {rows.map((r) => {
                   const isExpanded = expanded.has(r.id)
                   return (
-                    <>
-                      <TableRow key={r.id}>
+                    <Fragment key={r.id}>
+                      <TableRow>
                         <TableCell>
                           <Checkbox
                             checked={selected.has(r.id)}
@@ -437,14 +437,14 @@ export function AgentFailuresClient() {
                         </TableCell>
                       </TableRow>
                       {isExpanded && (
-                        <TableRow key={`${r.id}-detail`}>
+                        <TableRow>
                           <TableCell />
                           <TableCell colSpan={8} className="bg-muted/30">
                             <FailureDetail row={r} />
                           </TableCell>
                         </TableRow>
                       )}
-                    </>
+                    </Fragment>
                   )
                 })}
               </TableBody>

--- a/app/(protected)/admin/agents/_components/agent-failures-client.tsx
+++ b/app/(protected)/admin/agents/_components/agent-failures-client.tsx
@@ -1,0 +1,573 @@
+"use client"
+
+import { useCallback, useEffect, useMemo, useState } from "react"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+import { Button } from "@/components/ui/button"
+import { Skeleton } from "@/components/ui/skeleton"
+import { Badge } from "@/components/ui/badge"
+import { Checkbox } from "@/components/ui/checkbox"
+import { Textarea } from "@/components/ui/textarea"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from "@/components/ui/dialog"
+import { useToast } from "@/components/ui/use-toast"
+import { formatDate } from "@/lib/date-utils"
+import {
+  IconChevronDown,
+  IconChevronRight,
+  IconRefresh,
+  IconCopy,
+  IconCheck,
+} from "@tabler/icons-react"
+import {
+  acknowledgeFailures,
+  generateTroubleshootingBundle,
+  getAgentFailures,
+  type FailureRange,
+  type FailureRow,
+} from "@/actions/admin/agent-failures.actions"
+
+const RANGE_OPTIONS: { value: FailureRange; label: string }[] = [
+  { value: "7d", label: "Last 7 days" },
+  { value: "30d", label: "Last 30 days" },
+  { value: "90d", label: "Last 90 days" },
+  { value: "all", label: "All time" },
+]
+
+const SOURCE_OPTIONS = [
+  { value: "all", label: "All sources" },
+  { value: "router", label: "Router" },
+  { value: "harness", label: "Harness" },
+  { value: "cron", label: "Cron" },
+  { value: "agent_self_report", label: "Agent self-report" },
+  { value: "tool", label: "Tool" },
+] as const
+
+const SEVERITY_OPTIONS = [
+  { value: "all", label: "All severities" },
+  { value: "error", label: "Error" },
+  { value: "warn", label: "Warn" },
+  { value: "empty_response", label: "Empty response" },
+] as const
+
+const ACK_OPTIONS = [
+  { value: "unack", label: "Unacknowledged" },
+  { value: "ack", label: "Acknowledged" },
+  { value: "all", label: "All" },
+] as const
+
+function severityBadge(sev: FailureRow["severity"]) {
+  if (sev === "error")
+    return (
+      <Badge variant="destructive" className="text-xs">
+        error
+      </Badge>
+    )
+  if (sev === "warn")
+    return (
+      <Badge variant="default" className="text-xs">
+        warn
+      </Badge>
+    )
+  return (
+    <Badge variant="secondary" className="text-xs">
+      empty
+    </Badge>
+  )
+}
+
+function sourceBadge(src: FailureRow["source"]) {
+  return (
+    <Badge variant="outline" className="text-xs">
+      {src}
+    </Badge>
+  )
+}
+
+function preview(text: string | null, max = 80): string {
+  if (!text) return "-"
+  const cleaned = text.replace(/\s+/g, " ").trim()
+  return cleaned.length <= max ? cleaned : `${cleaned.slice(0, max)}…`
+}
+
+export function AgentFailuresClient() {
+  const { toast } = useToast()
+  const [range, setRange] = useState<FailureRange>("30d")
+  const [source, setSource] = useState<string>("all")
+  const [severity, setSeverity] = useState<string>("all")
+  const [ackFilter, setAckFilter] = useState<string>("unack")
+  const [rows, setRows] = useState<FailureRow[]>([])
+  const [total, setTotal] = useState(0)
+  const [loading, setLoading] = useState(true)
+  const [selected, setSelected] = useState<Set<number>>(new Set())
+  const [expanded, setExpanded] = useState<Set<number>>(new Set())
+  const [ackOpen, setAckOpen] = useState(false)
+  const [ackNotes, setAckNotes] = useState("")
+  const [bundleOpen, setBundleOpen] = useState(false)
+  const [bundleMd, setBundleMd] = useState("")
+  const [bundleCopied, setBundleCopied] = useState(false)
+  const [busy, setBusy] = useState(false)
+
+  const load = useCallback(async () => {
+    setLoading(true)
+    try {
+      const result = await getAgentFailures({
+        range,
+        source: source === "all" ? undefined : (source as FailureRow["source"]),
+        severity:
+          severity === "all" ? undefined : (severity as FailureRow["severity"]),
+        acknowledged:
+          ackFilter === "all" ? undefined : ackFilter === "ack",
+        limit: 200,
+      })
+      if (result.isSuccess && result.data) {
+        setRows(result.data.failures)
+        setTotal(result.data.total)
+        setSelected(new Set())
+      } else {
+        toast({
+          variant: "destructive",
+          title: "Error loading failures",
+          description: result.message,
+        })
+      }
+    } finally {
+      setLoading(false)
+    }
+  }, [range, source, severity, ackFilter, toast])
+
+  useEffect(() => {
+    void load()
+  }, [load])
+
+  const toggleSelect = (id: number) => {
+    setSelected((prev) => {
+      const next = new Set(prev)
+      if (next.has(id)) next.delete(id)
+      else next.add(id)
+      return next
+    })
+  }
+
+  const toggleAll = () => {
+    setSelected((prev) =>
+      prev.size === rows.length ? new Set() : new Set(rows.map((r) => r.id)),
+    )
+  }
+
+  const toggleExpand = (id: number) => {
+    setExpanded((prev) => {
+      const next = new Set(prev)
+      if (next.has(id)) next.delete(id)
+      else next.add(id)
+      return next
+    })
+  }
+
+  const handleAcknowledge = async () => {
+    if (selected.size === 0) return
+    setBusy(true)
+    try {
+      const result = await acknowledgeFailures({
+        ids: [...selected],
+        notes: ackNotes || undefined,
+      })
+      if (result.isSuccess) {
+        toast({ title: result.message ?? "Acknowledged" })
+        setAckOpen(false)
+        setAckNotes("")
+        await load()
+      } else {
+        toast({
+          variant: "destructive",
+          title: "Acknowledge failed",
+          description: result.message,
+        })
+      }
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const handleGenerateBundle = async () => {
+    if (selected.size === 0) return
+    setBusy(true)
+    try {
+      const result = await generateTroubleshootingBundle([...selected])
+      if (result.isSuccess && result.data) {
+        setBundleMd(result.data.markdown)
+        setBundleCopied(false)
+        setBundleOpen(true)
+      } else {
+        toast({
+          variant: "destructive",
+          title: "Bundle failed",
+          description: result.message,
+        })
+      }
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const copyBundle = async () => {
+    try {
+      await navigator.clipboard.writeText(bundleMd)
+      setBundleCopied(true)
+      toast({ title: "Bundle copied to clipboard" })
+    } catch {
+      toast({
+        variant: "destructive",
+        title: "Copy failed",
+        description: "Select the text and copy manually.",
+      })
+    }
+  }
+
+  const headerCheckboxState = useMemo<boolean | "indeterminate">(() => {
+    if (rows.length === 0) return false
+    if (selected.size === 0) return false
+    if (selected.size === rows.length) return true
+    return "indeterminate"
+  }, [rows.length, selected.size])
+
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <CardTitle className="text-base">Agent Failures</CardTitle>
+            <CardDescription>
+              Captured from router Lambda, harness adapter, cron, and agent
+              self-reports. Acknowledge once triaged or bundle for handoff to
+              Claude Code.
+            </CardDescription>
+          </div>
+          <Button variant="outline" size="sm" onClick={load} disabled={loading}>
+            <IconRefresh className="h-4 w-4 mr-2" />
+            Refresh
+          </Button>
+        </div>
+        <div className="flex flex-wrap items-center gap-2 pt-3">
+          <Select value={range} onValueChange={(v) => setRange(v as FailureRange)}>
+            <SelectTrigger className="w-[160px] h-8 text-sm">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {RANGE_OPTIONS.map((o) => (
+                <SelectItem key={o.value} value={o.value}>
+                  {o.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <Select value={source} onValueChange={setSource}>
+            <SelectTrigger className="w-[180px] h-8 text-sm">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {SOURCE_OPTIONS.map((o) => (
+                <SelectItem key={o.value} value={o.value}>
+                  {o.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <Select value={severity} onValueChange={setSeverity}>
+            <SelectTrigger className="w-[180px] h-8 text-sm">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {SEVERITY_OPTIONS.map((o) => (
+                <SelectItem key={o.value} value={o.value}>
+                  {o.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <Select value={ackFilter} onValueChange={setAckFilter}>
+            <SelectTrigger className="w-[180px] h-8 text-sm">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {ACK_OPTIONS.map((o) => (
+                <SelectItem key={o.value} value={o.value}>
+                  {o.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <div className="flex-1" />
+          <Button
+            variant="default"
+            size="sm"
+            disabled={selected.size === 0 || busy}
+            onClick={() => setAckOpen(true)}
+          >
+            Acknowledge ({selected.size})
+          </Button>
+          <Button
+            variant="secondary"
+            size="sm"
+            disabled={selected.size === 0 || busy}
+            onClick={handleGenerateBundle}
+          >
+            Generate bundle ({selected.size})
+          </Button>
+        </div>
+      </CardHeader>
+      <CardContent>
+        {loading ? (
+          <Skeleton className="h-64 w-full" />
+        ) : rows.length === 0 ? (
+          <div className="h-32 flex items-center justify-center text-muted-foreground text-sm">
+            No failures match these filters.
+          </div>
+        ) : (
+          <>
+            <div className="text-xs text-muted-foreground mb-2">
+              Showing {rows.length} of {total} failure{total === 1 ? "" : "s"}
+              {total > rows.length ? " (limit 200, refine filters to see more)" : ""}
+            </div>
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead className="w-8">
+                    <Checkbox
+                      checked={headerCheckboxState}
+                      onCheckedChange={toggleAll}
+                      aria-label="Select all"
+                    />
+                  </TableHead>
+                  <TableHead className="w-8" />
+                  <TableHead>When</TableHead>
+                  <TableHead>Source</TableHead>
+                  <TableHead>Severity</TableHead>
+                  <TableHead>User</TableHead>
+                  <TableHead>Model</TableHead>
+                  <TableHead>Error</TableHead>
+                  <TableHead>Status</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {rows.map((r) => {
+                  const isExpanded = expanded.has(r.id)
+                  return (
+                    <>
+                      <TableRow key={r.id}>
+                        <TableCell>
+                          <Checkbox
+                            checked={selected.has(r.id)}
+                            onCheckedChange={() => toggleSelect(r.id)}
+                            aria-label={`Select failure ${r.id}`}
+                          />
+                        </TableCell>
+                        <TableCell>
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            className="h-6 w-6 p-0"
+                            onClick={() => toggleExpand(r.id)}
+                            aria-label={isExpanded ? "Collapse" : "Expand"}
+                          >
+                            {isExpanded ? (
+                              <IconChevronDown className="h-4 w-4" />
+                            ) : (
+                              <IconChevronRight className="h-4 w-4" />
+                            )}
+                          </Button>
+                        </TableCell>
+                        <TableCell className="text-xs text-muted-foreground whitespace-nowrap">
+                          {formatDate(r.occurredAt, true)}
+                        </TableCell>
+                        <TableCell>{sourceBadge(r.source)}</TableCell>
+                        <TableCell>{severityBadge(r.severity)}</TableCell>
+                        <TableCell className="text-xs">
+                          {r.userId ?? "-"}
+                        </TableCell>
+                        <TableCell className="text-xs">
+                          {r.model ?? "-"}
+                        </TableCell>
+                        <TableCell className="text-xs">
+                          {r.errorClass && (
+                            <span className="font-mono text-[11px] mr-1">
+                              {r.errorClass}
+                            </span>
+                          )}
+                          <span className="text-muted-foreground">
+                            {preview(r.errorMessage, 90)}
+                          </span>
+                        </TableCell>
+                        <TableCell>
+                          {r.acknowledged ? (
+                            <Badge variant="outline" className="text-xs">
+                              ack
+                            </Badge>
+                          ) : (
+                            <Badge variant="default" className="text-xs">
+                              new
+                            </Badge>
+                          )}
+                        </TableCell>
+                      </TableRow>
+                      {isExpanded && (
+                        <TableRow key={`${r.id}-detail`}>
+                          <TableCell />
+                          <TableCell colSpan={8} className="bg-muted/30">
+                            <FailureDetail row={r} />
+                          </TableCell>
+                        </TableRow>
+                      )}
+                    </>
+                  )
+                })}
+              </TableBody>
+            </Table>
+          </>
+        )}
+      </CardContent>
+
+      <Dialog open={ackOpen} onOpenChange={setAckOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Acknowledge {selected.size} failure(s)</DialogTitle>
+            <DialogDescription>
+              Optional note about how this was handled (visible in audit log).
+            </DialogDescription>
+          </DialogHeader>
+          <Textarea
+            value={ackNotes}
+            onChange={(e) => setAckNotes(e.target.value)}
+            placeholder="e.g. Caused by missing Google credential — fixed in PR #1234"
+            rows={4}
+            maxLength={4000}
+          />
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => setAckOpen(false)}
+              disabled={busy}
+            >
+              Cancel
+            </Button>
+            <Button onClick={handleAcknowledge} disabled={busy}>
+              Acknowledge
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={bundleOpen} onOpenChange={setBundleOpen}>
+        <DialogContent className="max-w-3xl">
+          <DialogHeader>
+            <DialogTitle>Troubleshooting bundle</DialogTitle>
+            <DialogDescription>
+              Copy this markdown and paste into Claude Code to get root-cause
+              analysis and proposed fixes.
+            </DialogDescription>
+          </DialogHeader>
+          <Textarea
+            value={bundleMd}
+            readOnly
+            rows={20}
+            className="font-mono text-xs"
+          />
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setBundleOpen(false)}>
+              Close
+            </Button>
+            <Button onClick={copyBundle}>
+              {bundleCopied ? (
+                <>
+                  <IconCheck className="h-4 w-4 mr-2" />
+                  Copied
+                </>
+              ) : (
+                <>
+                  <IconCopy className="h-4 w-4 mr-2" />
+                  Copy to clipboard
+                </>
+              )}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </Card>
+  )
+}
+
+function FailureDetail({ row }: { row: FailureRow }) {
+  return (
+    <div className="text-xs space-y-2 py-2">
+      <div className="grid grid-cols-2 gap-x-6 gap-y-1">
+        <div>
+          <span className="text-muted-foreground">Session:</span>{" "}
+          <span className="font-mono">{row.sessionId ?? "-"}</span>
+        </div>
+        <div>
+          <span className="text-muted-foreground">Schedule:</span>{" "}
+          {row.scheduleName ?? "-"}
+        </div>
+        <div>
+          <span className="text-muted-foreground">Acknowledged by:</span>{" "}
+          {row.acknowledgedBy ?? "-"}
+          {row.acknowledgedAt && ` · ${formatDate(row.acknowledgedAt, true)}`}
+        </div>
+        <div>
+          <span className="text-muted-foreground">Notes:</span>{" "}
+          {row.notes ?? "-"}
+        </div>
+      </div>
+      {row.errorMessage && (
+        <div>
+          <div className="text-muted-foreground mb-1">Error message</div>
+          <pre className="bg-background border rounded p-2 whitespace-pre-wrap font-mono text-[11px] max-h-40 overflow-auto">
+            {row.errorMessage}
+          </pre>
+        </div>
+      )}
+      {row.context && (
+        <div>
+          <div className="text-muted-foreground mb-1">Context</div>
+          <pre className="bg-background border rounded p-2 font-mono text-[11px] max-h-40 overflow-auto">
+            {JSON.stringify(row.context, null, 2)}
+          </pre>
+        </div>
+      )}
+      {row.stackExcerpt && (
+        <div>
+          <div className="text-muted-foreground mb-1">Stack</div>
+          <pre className="bg-background border rounded p-2 font-mono text-[11px] max-h-40 overflow-auto">
+            {row.stackExcerpt}
+          </pre>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/app/(protected)/admin/agents/_components/agent-health-table.tsx
+++ b/app/(protected)/admin/agents/_components/agent-health-table.tsx
@@ -72,9 +72,8 @@ export function AgentHealthTable({ data, loading = false }: Props) {
               Expected schedule: once per day. If{" "}
               <code className="text-[11px]">agent_health_scan_runs</code> stays
               empty for &gt;48h, the Lambda is failing silently — check
-              CloudWatch logs. Last known fix: commit{" "}
-              <code className="text-[11px]">b9d56750</code> (revert bogus
-              users-table join).
+              CloudWatch logs for the{" "}
+              <code className="text-[11px]">agent-health-daily</code> function.
             </div>
           </div>
         </CardContent>

--- a/app/(protected)/admin/agents/_components/agent-health-table.tsx
+++ b/app/(protected)/admin/agents/_components/agent-health-table.tsx
@@ -41,16 +41,41 @@ export function AgentHealthTable({ data, loading = false }: Props) {
   }
 
   if (!data || data.rows.length === 0) {
+    const lastScan = data?.lastScan
     return (
       <Card>
         <CardHeader>
           <CardTitle className="text-base">Agent Health</CardTitle>
         </CardHeader>
         <CardContent>
-          <div className="h-32 flex items-center justify-center text-muted-foreground text-sm">
-            {data?.snapshotDate
-              ? "No snapshots recorded yet."
-              : "Daily health Lambda has not run yet."}
+          {lastScan && (
+            <div className="text-xs text-muted-foreground mb-3 border rounded p-2 bg-muted/30">
+              <span className="font-medium">Last scan:</span>{" "}
+              {formatDate(lastScan.runAt, true)} · snapshot{" "}
+              {lastScan.snapshotDate} · {lastScan.usersTotal} users ·{" "}
+              {lastScan.abandoned} abandoned
+              {lastScan.error && (
+                <span className="text-destructive">
+                  {" "}
+                  · error: {lastScan.error}
+                </span>
+              )}
+            </div>
+          )}
+          <div className="h-40 flex flex-col items-center justify-center gap-2 text-sm">
+            <div className="text-muted-foreground">
+              {lastScan
+                ? "Scanner ran but produced 0 snapshots. Check users table & S3 workspace prefixes."
+                : "Daily health Lambda has not run yet."}
+            </div>
+            <div className="text-xs text-muted-foreground max-w-md text-center">
+              Expected schedule: once per day. If{" "}
+              <code className="text-[11px]">agent_health_scan_runs</code> stays
+              empty for &gt;48h, the Lambda is failing silently — check
+              CloudWatch logs. Last known fix: commit{" "}
+              <code className="text-[11px]">b9d56750</code> (revert bogus
+              users-table join).
+            </div>
           </div>
         </CardContent>
       </Card>
@@ -91,6 +116,13 @@ export function AgentHealthTable({ data, loading = false }: Props) {
           <CardTitle className="text-base">
             Per-user Health (snapshot {data.snapshotDate})
           </CardTitle>
+          {data.lastScan && (
+            <p className="text-xs text-muted-foreground mt-1">
+              Last scan: {formatDate(data.lastScan.runAt, true)} ·{" "}
+              {data.lastScan.usersTotal} users ·{" "}
+              {data.lastScan.abandoned} abandoned
+            </p>
+          )}
         </CardHeader>
         <CardContent>
           <Table>

--- a/app/(protected)/admin/agents/_components/agent-patterns-table.tsx
+++ b/app/(protected)/admin/agents/_components/agent-patterns-table.tsx
@@ -11,14 +11,20 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table"
-import type { AgentPatternRow } from "@/actions/admin/agent-health.actions"
+import type {
+  AgentPatternRow,
+  AgentPatternsEnvelope,
+} from "@/actions/admin/agent-health.actions"
+import { formatDate } from "@/lib/date-utils"
 
 interface Props {
-  data: AgentPatternRow[]
+  data: AgentPatternsEnvelope
   loading?: boolean
 }
 
 export function AgentPatternsTable({ data, loading = false }: Props) {
+  const rows: AgentPatternRow[] = data.rows
+  const lastScan = data.lastScan
   if (loading) {
     return (
       <Card>
@@ -42,9 +48,29 @@ export function AgentPatternsTable({ data, loading = false }: Props) {
         </p>
       </CardHeader>
       <CardContent>
-        {data.length === 0 ? (
-          <div className="h-32 flex items-center justify-center text-muted-foreground text-sm">
-            No patterns detected yet. The weekly scanner runs on a recurring schedule.
+        {lastScan && (
+          <div className="text-xs text-muted-foreground mb-3 border rounded p-2 bg-muted/30">
+            <span className="font-medium">Last scan:</span>{" "}
+            {formatDate(lastScan.runAt, true)} · week {lastScan.week} ·{" "}
+            {lastScan.signalsTotal} signals · {lastScan.topicsTotal} topics ·{" "}
+            <span className="text-foreground">{lastScan.detected} detected</span>
+            {lastScan.suppressed > 0 && ` · ${lastScan.suppressed} suppressed`}
+          </div>
+        )}
+        {rows.length === 0 ? (
+          <div className="h-40 flex flex-col items-center justify-center gap-2 text-sm">
+            <div className="text-muted-foreground">
+              {lastScan
+                ? "Scanner ran but no patterns met the suppression threshold."
+                : "Pattern scanner has not run yet."}
+            </div>
+            <div className="text-xs text-muted-foreground max-w-md text-center">
+              Scanner runs Sundays 23:00 UTC. Patterns are suppressed below 3
+              signals / 2 buildings (privacy guarantee). If{" "}
+              <code className="text-[11px]">agent_pattern_scan_runs</code>{" "}
+              stays empty despite agent_messages activity, the Lambda is
+              likely failing silently — check CloudWatch logs.
+            </div>
           </div>
         ) : (
           <Table>
@@ -60,7 +86,7 @@ export function AgentPatternsTable({ data, loading = false }: Props) {
               </TableRow>
             </TableHeader>
             <TableBody>
-              {data.map((r) => (
+              {rows.map((r) => (
                 <TableRow key={`${r.week}:${r.topic}`}>
                   <TableCell className="font-mono text-xs">{r.week}</TableCell>
                   <TableCell className="font-medium text-sm">

--- a/infra/agent-image/Dockerfile
+++ b/infra/agent-image/Dockerfile
@@ -174,6 +174,7 @@ RUN cd /opt/psd-skills/psd-credentials && npm install --omit=dev --no-audit --no
 RUN cd /opt/psd-skills/psd-skills-meta && npm install --omit=dev --no-audit --no-fund
 RUN cd /opt/psd-skills/psd-workspace && npm install --omit=dev --no-audit --no-fund
 RUN cd /opt/psd-skills/psd-image-gen && npm install --omit=dev --no-audit --no-fund
+RUN cd /opt/psd-skills/psd-failure-report && npm install --omit=dev --no-audit --no-fund
 # psd-freshservice has zero npm dependencies (native fetch + child_process only).
 
 # Upstream gws-* skills (#912) — per-API SKILL.md guidance for Gmail, Drive,

--- a/infra/agent-image/Dockerfile
+++ b/infra/agent-image/Dockerfile
@@ -210,6 +210,7 @@ RUN chown -R root:root /opt/psd-skills && chmod -R a-w /opt/psd-skills
 # The psd-schedules skill is the only scheduling surface in this deployment.
 ENV OPENCLAW_SKIP_CRON=1
 COPY harness_adapter.py /app/harness_adapter.py
+COPY agent_failures.py /app/agent_failures.py
 COPY agentcore_wrapper.py /app/agentcore_wrapper.py
 COPY workspace_sync.py /app/workspace_sync.py
 COPY mantle_proxy.py /app/mantle_proxy.py

--- a/infra/agent-image/agent_failures.py
+++ b/infra/agent-image/agent_failures.py
@@ -1,0 +1,158 @@
+"""
+Agent failure capture from inside the AgentCore container.
+
+Writes a row to `agent_failures` via the RDS Data API when the relevant env
+vars are present; otherwise emits a structured JSON log line that a CloudWatch
+subscription filter can ship to a writer Lambda. Either way, every failure is
+recoverable from CloudWatch by grepping for `AGENT_FAILURE_RECORD`.
+
+Never raises — failure-of-the-failure-writer must not affect the user-facing
+agent reply.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import traceback
+from typing import Any, Dict, Mapping, Optional
+
+logger = logging.getLogger("agent_failures")
+
+_DATABASE_RESOURCE_ARN = os.environ.get("DATABASE_RESOURCE_ARN")
+_DATABASE_SECRET_ARN = os.environ.get("DATABASE_SECRET_ARN")
+_DATABASE_NAME = os.environ.get("DATABASE_NAME")
+
+_VALID_SOURCES = {"router", "harness", "cron", "agent_self_report", "tool"}
+_VALID_SEVERITIES = {"error", "warn", "empty_response"}
+
+_rds_client = None
+
+
+def _get_rds_client():
+    global _rds_client
+    if _rds_client is not None:
+        return _rds_client
+    try:
+        import boto3  # type: ignore[import-not-found]
+
+        _rds_client = boto3.client("rds-data")
+        return _rds_client
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("rds-data client unavailable: %s", exc)
+        return None
+
+
+def _truncate(s: Optional[str], max_len: int) -> Optional[str]:
+    if s is None:
+        return None
+    if len(s) <= max_len:
+        return s
+    return s[:max_len]
+
+
+def record_failure(
+    source: str,
+    severity: str,
+    error_message: Optional[str] = None,
+    *,
+    user_id: Optional[str] = None,
+    session_id: Optional[str] = None,
+    schedule_name: Optional[str] = None,
+    model: Optional[str] = None,
+    error_class: Optional[str] = None,
+    stack: Optional[str] = None,
+    context: Optional[Mapping[str, Any]] = None,
+    exc: Optional[BaseException] = None,
+) -> None:
+    """
+    Record a failure. Best-effort, never raises.
+
+    Pass either `error_message`/`stack` directly, or pass `exc` and the
+    function will derive class, message, and stack automatically.
+    """
+    try:
+        if source not in _VALID_SOURCES:
+            source = "harness"
+        if severity not in _VALID_SEVERITIES:
+            severity = "error"
+
+        if exc is not None:
+            error_class = error_class or exc.__class__.__name__
+            error_message = error_message or str(exc)
+            if stack is None:
+                stack = "".join(
+                    traceback.format_exception(type(exc), exc, exc.__traceback__)
+                )
+
+        payload: Dict[str, Any] = {
+            "source": source,
+            "severity": severity,
+            "user_id": user_id,
+            "session_id": session_id,
+            "schedule_name": schedule_name,
+            "model": model,
+            "error_class": _truncate(error_class, 128),
+            "error_message": _truncate(error_message, 4000),
+            "stack_excerpt": _truncate(
+                "\n".join((stack or "").splitlines()[:20]) or None, 4000
+            ),
+            "context": dict(context) if context else None,
+        }
+
+        # Always emit a structured CloudWatch line so failures are recoverable
+        # even if the DB write fails or env vars are missing.
+        logger.error("AGENT_FAILURE_RECORD %s", json.dumps(payload, default=str))
+
+        if not (_DATABASE_RESOURCE_ARN and _DATABASE_SECRET_ARN and _DATABASE_NAME):
+            return
+
+        client = _get_rds_client()
+        if client is None:
+            return
+
+        params = [
+            {"name": "source", "value": {"stringValue": payload["source"]}},
+            {"name": "severity", "value": {"stringValue": payload["severity"]}},
+            _string_or_null("user_id", payload["user_id"]),
+            _string_or_null("session_id", payload["session_id"]),
+            _string_or_null("schedule_name", payload["schedule_name"]),
+            _string_or_null("model", payload["model"]),
+            _string_or_null("error_class", payload["error_class"]),
+            _string_or_null("error_message", payload["error_message"]),
+            _string_or_null("stack_excerpt", payload["stack_excerpt"]),
+            _string_or_null(
+                "context",
+                json.dumps(payload["context"]) if payload["context"] is not None else None,
+            ),
+        ]
+        sql = (
+            "INSERT INTO agent_failures "
+            "(source, severity, user_id, session_id, schedule_name, model, "
+            " error_class, error_message, stack_excerpt, context, occurred_at) "
+            "VALUES (:source, :severity, :user_id, :session_id, :schedule_name, "
+            " :model, :error_class, :error_message, :stack_excerpt, "
+            " CAST(:context AS jsonb), NOW())"
+        )
+        client.execute_statement(
+            resourceArn=_DATABASE_RESOURCE_ARN,
+            secretArn=_DATABASE_SECRET_ARN,
+            database=_DATABASE_NAME,
+            sql=sql,
+            parameters=params,
+        )
+    except Exception as fail_exc:  # noqa: BLE001
+        # Last-ditch: log the writer failure but never propagate.
+        try:
+            logger.error(
+                "agent_failures.record_failure() itself failed: %s", fail_exc
+            )
+        except Exception:
+            pass
+
+
+def _string_or_null(name: str, value: Optional[str]) -> Dict[str, Any]:
+    if value is None:
+        return {"name": name, "value": {"isNull": True}}
+    return {"name": name, "value": {"stringValue": value}}

--- a/infra/agent-image/agent_failures.py
+++ b/infra/agent-image/agent_failures.py
@@ -23,11 +23,14 @@ logger = logging.getLogger("agent_failures")
 _DATABASE_RESOURCE_ARN = os.environ.get("DATABASE_RESOURCE_ARN")
 _DATABASE_SECRET_ARN = os.environ.get("DATABASE_SECRET_ARN")
 _DATABASE_NAME = os.environ.get("DATABASE_NAME")
+_ENVIRONMENT = os.environ.get("ENVIRONMENT", "unknown")
+_AWS_REGION = os.environ.get("AWS_REGION", "us-east-1")
 
 _VALID_SOURCES = {"router", "harness", "cron", "agent_self_report", "tool"}
 _VALID_SEVERITIES = {"error", "warn", "empty_response"}
 
 _rds_client = None
+_cloudwatch_client = None
 
 
 def _get_rds_client():
@@ -42,6 +45,47 @@ def _get_rds_client():
     except Exception as exc:  # noqa: BLE001
         logger.debug("rds-data client unavailable: %s", exc)
         return None
+
+
+def _get_cloudwatch_client():
+    global _cloudwatch_client
+    if _cloudwatch_client is not None:
+        return _cloudwatch_client
+    try:
+        import boto3  # type: ignore[import-not-found]
+
+        _cloudwatch_client = boto3.client("cloudwatch", region_name=_AWS_REGION)
+        return _cloudwatch_client
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("cloudwatch client unavailable: %s", exc)
+        return None
+
+
+def _emit_failure_metric(source: str) -> None:
+    """
+    Best-effort: emit a CloudWatch custom metric for the failure so the
+    AgentFailureRateAlarm in agent-platform-stack picks it up. Bypasses the
+    log-group-based MetricFilter approach because AgentCore log group names
+    contain a runtime-generated suffix (`psd_agent_<env>-<id>-DEFAULT`) that
+    isn't predictable at CDK synth time.
+    """
+    client = _get_cloudwatch_client()
+    if client is None:
+        return
+    try:
+        client.put_metric_data(
+            Namespace=f"PSD/AgentPlatform/{_ENVIRONMENT}",
+            MetricData=[
+                {
+                    "MetricName": "AgentFailuresHarness",
+                    "Value": 1,
+                    "Unit": "Count",
+                    "Dimensions": [{"Name": "Source", "Value": source}],
+                }
+            ],
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("put_metric_data failed: %s", exc)
 
 
 def _truncate(s: Optional[str], max_len: int) -> Optional[str]:
@@ -104,6 +148,9 @@ def record_failure(
         # Always emit a structured CloudWatch line so failures are recoverable
         # even if the DB write fails or env vars are missing.
         logger.error("AGENT_FAILURE_RECORD %s", json.dumps(payload, default=str))
+
+        # Emit a CloudWatch metric so the AgentFailureRateAlarm fires.
+        _emit_failure_metric(source)
 
         if not (_DATABASE_RESOURCE_ARN and _DATABASE_SECRET_ARN and _DATABASE_NAME):
             return

--- a/infra/agent-image/harness_adapter.py
+++ b/infra/agent-image/harness_adapter.py
@@ -15,6 +15,7 @@ import time
 import uuid
 from typing import Optional
 
+from agent_failures import record_failure
 from chat_format import markdown_to_chat
 
 logger = logging.getLogger("harness_adapter")
@@ -445,6 +446,14 @@ class OpenClawAdapter(HarnessAdapter):
 
         except Exception as exc:
             logger.error("WebSocket error: %s", str(exc)[:500])
+            record_failure(
+                source="harness",
+                severity="error",
+                exc=exc,
+                session_id=session_id,
+                model=model_override,
+                context={"phase": "websocket"},
+            )
             return "I'm temporarily unable to respond. The agent process may be restarting."
 
         if not got_final:
@@ -467,6 +476,23 @@ class OpenClawAdapter(HarnessAdapter):
             )
             if response_text:
                 return _format_for_chat(response_text.strip())
+            record_failure(
+                source="harness",
+                severity="error",
+                error_class="ChatDeadlineExpired",
+                error_message=(
+                    f"chat deadline expired without final event "
+                    f"(last_state={last_state})"
+                ),
+                session_id=session_id,
+                model=model_override,
+                context={
+                    "phase": "deadline",
+                    "last_state": last_state,
+                    "event_counts": event_counts,
+                    "first_events": first_event_types,
+                },
+            )
             return (
                 "I wasn't able to finish responding in time — the agent "
                 "stalled. Please try again in a moment."
@@ -481,7 +507,24 @@ class OpenClawAdapter(HarnessAdapter):
             json.dumps(event_counts),
         )
 
-        return _format_for_chat(response_text.strip()) if response_text.strip() else "I processed your message but had no response."
+        if response_text.strip():
+            return _format_for_chat(response_text.strip())
+        record_failure(
+            source="harness",
+            severity="empty_response",
+            error_class="EmptyAgentResponse",
+            error_message=(
+                "Agent reached final state but produced no user-visible text"
+            ),
+            session_id=session_id,
+            model=model_override,
+            context={
+                "last_state": last_state,
+                "event_counts": event_counts,
+                "first_events": first_event_types,
+            },
+        )
+        return "I processed your message but had no response."
 
     @staticmethod
     def _extract_text(content) -> str:

--- a/infra/agent-image/skills/psd-failure-report/SKILL.md
+++ b/infra/agent-image/skills/psd-failure-report/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: psd-failure-report
+summary: Self-report when you cannot fulfill a request — logs to agent_failures so admins can triage systemically.
+description: When you cannot complete what the user asked for (missing data, missing credentials, an unavailable tool, an ambiguous instruction you cannot resolve, a task you started but did not finish), call this skill BEFORE responding to the user. It writes a row to agent_failures so admins can systematically work through recurring problems. Calling this is non-negotiable when applicable.
+allowed-tools: Bash(node:*)
+---
+
+# psd-failure-report
+
+Self-report a failure you encountered. **Always call this before responding to the user when you could not fulfill any part of their request.**
+
+## When to call
+
+Call `report` when ANY of the following is true:
+
+- You needed a credential or API key and could not get one (`reason: missing_credentials`).
+- A tool returned an error you could not work around (`reason: tool_error`).
+- A tool you needed is not available in this environment (`reason: tool_unavailable`).
+- A data source returned no results when the user clearly expected results (`reason: data_not_found`).
+- The user's instruction was ambiguous and you had to guess (`reason: ambiguous_request`).
+- You started a task and did not finish it (`reason: task_incomplete`).
+- Anything else that means the user did not get what they asked for (`reason: other`).
+
+If in doubt: **call it**. False positives are cheap; silent failures are expensive.
+
+## Command
+
+```bash
+node /opt/psd-skills/psd-failure-report/report.js \
+  --user <caller-email> \
+  --reason <category> \
+  --details "<what you were trying to do and why it didn't work>" \
+  [--tool <tool-name>] \
+  [--user-facing true|false]
+```
+
+Returns `{"logged": true, "failure_id": <int>}` on success. Returns `{"logged": false, "reason": "..."}` if the database is unavailable (still safe to proceed — the failure is logged to CloudWatch).
+
+`--user-facing` (default `true`): when `true`, your reply to the user should also acknowledge what went wrong. When `false`, this is a silent telemetry-only report (use sparingly).
+
+## Examples
+
+```bash
+# Missing credential
+node /opt/psd-skills/psd-failure-report/report.js \
+  --user alice@psd401.net \
+  --reason missing_credentials \
+  --details "Tried to fetch calendar events but no google_oauth credential was provisioned for this user."
+
+# Empty data result
+node /opt/psd-skills/psd-failure-report/report.js \
+  --user bob@psd401.net \
+  --reason data_not_found \
+  --details "User asked for today's morning brief but no events, emails, or chat messages were returned. Likely missing OAuth grants or tool failures upstream."
+```
+
+After calling this skill, write your normal user-facing reply (which should explain what went wrong unless `--user-facing false`).

--- a/infra/agent-image/skills/psd-failure-report/package.json
+++ b/infra/agent-image/skills/psd-failure-report/package.json
@@ -4,6 +4,7 @@
   "description": "OpenClaw skill: agent self-reports a semantic failure to the agent_failures table",
   "private": true,
   "dependencies": {
+    "@aws-sdk/client-cloudwatch": "^3.0.0",
     "@aws-sdk/client-rds-data": "^3.0.0"
   }
 }

--- a/infra/agent-image/skills/psd-failure-report/package.json
+++ b/infra/agent-image/skills/psd-failure-report/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "psd-failure-report",
+  "version": "1.0.0",
+  "description": "OpenClaw skill: agent self-reports a semantic failure to the agent_failures table",
+  "private": true,
+  "dependencies": {
+    "@aws-sdk/client-rds-data": "^3.0.0"
+  }
+}

--- a/infra/agent-image/skills/psd-failure-report/report.js
+++ b/infra/agent-image/skills/psd-failure-report/report.js
@@ -21,8 +21,13 @@ const {
   RDSDataClient,
   ExecuteStatementCommand,
 } = require('@aws-sdk/client-rds-data');
+const {
+  CloudWatchClient,
+  PutMetricDataCommand,
+} = require('@aws-sdk/client-cloudwatch');
 
 const REGION = process.env.AWS_REGION || 'us-east-1';
+const ENVIRONMENT = process.env.ENVIRONMENT || 'dev';
 const DATABASE_RESOURCE_ARN = process.env.DATABASE_RESOURCE_ARN || '';
 const DATABASE_SECRET_ARN = process.env.DATABASE_SECRET_ARN || '';
 const DATABASE_NAME = process.env.DATABASE_NAME || 'aistudio';
@@ -130,6 +135,26 @@ async function main() {
       '\n',
   );
 
+  // Emit a CloudWatch metric directly so the AgentFailureRateAlarm picks up
+  // self-reports. The AgentCore log group name contains a runtime-generated
+  // suffix that isn't predictable at CDK synth time, so MetricFilter-based
+  // detection (used for router/cron) doesn't work here. This mirrors the
+  // approach used by agent_failures.py for harness failures.
+  try {
+    const cw = new CloudWatchClient({ region: REGION });
+    await cw.send(new PutMetricDataCommand({
+      Namespace: `PSD/AgentPlatform/${ENVIRONMENT}`,
+      MetricData: [{
+        MetricName: 'AgentFailuresHarness',
+        Value: 1,
+        Unit: 'Count',
+        Dimensions: [{ Name: 'Source', Value: 'agent_self_report' }],
+      }],
+    }));
+  } catch {
+    // Best-effort — metric emission failure must not affect the skill output
+  }
+
   if (!DATABASE_RESOURCE_ARN || !DATABASE_SECRET_ARN) {
     emit({ logged: false, reason: 'database_not_configured' });
     return;
@@ -168,7 +193,7 @@ async function main() {
     }
     emit({ logged: true, failure_id: id });
   } catch (err) {
-    process.stderr.write(`agent_failures insert failed: ${err instanceof Error ? err.message : String(err)}\n`); // eslint-disable-line no-console
+    process.stderr.write(`agent_failures insert failed: ${err instanceof Error ? err.message : String(err)}\n`);
     emit({ logged: false, reason: 'database_error' });
   }
 }

--- a/infra/agent-image/skills/psd-failure-report/report.js
+++ b/infra/agent-image/skills/psd-failure-report/report.js
@@ -38,7 +38,7 @@ const VALID_REASONS = new Set([
   'other',
 ]);
 
-const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const EMAIL_RE = /^[^\s@]+@psd401\.net$/i;
 
 function fail(message, code = 1) {
   process.stderr.write(`Error: ${message}\n`);
@@ -50,7 +50,7 @@ function emit(obj) {
 }
 
 function parseArgs(argv) {
-  const args = {};
+  const args = Object.create(null);
   for (let i = 2; i < argv.length; i++) {
     const arg = argv[i];
     if (arg === '--help' || arg === '-h') {

--- a/infra/agent-image/skills/psd-failure-report/report.js
+++ b/infra/agent-image/skills/psd-failure-report/report.js
@@ -1,0 +1,178 @@
+#!/usr/bin/env node
+/**
+ * psd-failure-report/report.js
+ *
+ * Agent self-reports a semantic failure. Writes to agent_failures via RDS Data
+ * API. Best-effort: emits structured CloudWatch line either way so failures are
+ * recoverable even when the DB is unreachable.
+ *
+ * Usage:
+ *   node report.js \
+ *     --user <caller-email> \
+ *     --reason <category> \
+ *     --details "<what went wrong>" \
+ *     [--tool <tool-name>] \
+ *     [--user-facing true|false]
+ */
+
+'use strict';
+
+const {
+  RDSDataClient,
+  ExecuteStatementCommand,
+} = require('@aws-sdk/client-rds-data');
+
+const REGION = process.env.AWS_REGION || 'us-east-1';
+const DATABASE_RESOURCE_ARN = process.env.DATABASE_RESOURCE_ARN || '';
+const DATABASE_SECRET_ARN = process.env.DATABASE_SECRET_ARN || '';
+const DATABASE_NAME = process.env.DATABASE_NAME || 'aistudio';
+const SESSION_ID = process.env.AGENT_SESSION_ID || process.env.SESSION_ID || null;
+
+const VALID_REASONS = new Set([
+  'missing_credentials',
+  'tool_error',
+  'tool_unavailable',
+  'data_not_found',
+  'ambiguous_request',
+  'task_incomplete',
+  'other',
+]);
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+function fail(message, code = 1) {
+  process.stderr.write(`Error: ${message}\n`);
+  process.exit(code);
+}
+
+function emit(obj) {
+  process.stdout.write(JSON.stringify(obj) + '\n');
+}
+
+function parseArgs(argv) {
+  const args = {};
+  for (let i = 2; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === '--help' || arg === '-h') {
+      args.help = true;
+      continue;
+    }
+    if (!arg.startsWith('--')) fail(`Unexpected positional argument: ${arg}`);
+    const key = arg.slice(2).replace(/-/g, '_');
+    const next = argv[i + 1];
+    if (!next || next.startsWith('--')) {
+      args[key] = true;
+    } else {
+      args[key] = next;
+      i++;
+    }
+  }
+  return args;
+}
+
+function truncate(s, max) {
+  if (typeof s !== 'string') return null;
+  return s.length <= max ? s : s.slice(0, max);
+}
+
+async function main() {
+  const args = parseArgs(process.argv);
+
+  if (args.help) {
+    process.stdout.write(
+      'Usage: report.js --user EMAIL --reason CATEGORY --details TEXT [--tool NAME] [--user-facing true|false]\n',
+    );
+    return;
+  }
+
+  if (!args.user || !EMAIL_RE.test(args.user)) {
+    fail('--user is required and must be a valid email');
+  }
+  if (!args.reason || typeof args.reason !== 'string') {
+    fail('--reason is required (one of: ' + [...VALID_REASONS].join(', ') + ')');
+  }
+  if (!VALID_REASONS.has(args.reason)) {
+    fail(`--reason must be one of: ${[...VALID_REASONS].join(', ')}`);
+  }
+  if (!args.details || typeof args.details !== 'string') {
+    fail('--details is required (short description of what went wrong)');
+  }
+
+  const tool = typeof args.tool === 'string' ? args.tool : null;
+  const userFacing =
+    typeof args.user_facing === 'string'
+      ? args.user_facing.toLowerCase() !== 'false'
+      : true;
+
+  const errorClass = truncate(args.reason, 128);
+  const errorMessage = truncate(args.details, 4000);
+  const context = JSON.stringify({
+    tool,
+    user_facing: userFacing,
+    self_reported: true,
+  });
+
+  // Always emit a structured CloudWatch line first so the failure is
+  // recoverable even when the DB write fails.
+  process.stderr.write(
+    'AGENT_FAILURE_RECORD ' +
+      JSON.stringify({
+        source: 'agent_self_report',
+        severity: 'warn',
+        user_id: args.user,
+        session_id: SESSION_ID,
+        error_class: errorClass,
+        error_message: errorMessage,
+        context: { tool, user_facing: userFacing },
+      }) +
+      '\n',
+  );
+
+  if (!DATABASE_RESOURCE_ARN || !DATABASE_SECRET_ARN) {
+    emit({ logged: false, reason: 'database_not_configured' });
+    return;
+  }
+
+  const client = new RDSDataClient({ region: REGION });
+
+  try {
+    const resp = await client.send(
+      new ExecuteStatementCommand({
+        resourceArn: DATABASE_RESOURCE_ARN,
+        secretArn: DATABASE_SECRET_ARN,
+        database: DATABASE_NAME,
+        sql: `INSERT INTO agent_failures
+                (source, severity, user_id, session_id,
+                 error_class, error_message, context, occurred_at)
+              VALUES
+                ('agent_self_report', 'warn', :user_id, :session_id,
+                 :error_class, :error_message, CAST(:context AS jsonb), NOW())
+              RETURNING id`,
+        parameters: [
+          { name: 'user_id', value: { stringValue: args.user } },
+          SESSION_ID
+            ? { name: 'session_id', value: { stringValue: SESSION_ID } }
+            : { name: 'session_id', value: { isNull: true } },
+          { name: 'error_class', value: { stringValue: errorClass } },
+          { name: 'error_message', value: { stringValue: errorMessage } },
+          { name: 'context', value: { stringValue: context } },
+        ],
+      }),
+    );
+    const records = resp.records || [];
+    let id = null;
+    if (records.length > 0 && records[0].length > 0) {
+      id = records[0][0].longValue ?? records[0][0].stringValue ?? null;
+    }
+    emit({ logged: true, failure_id: id });
+  } catch (err) {
+    process.stderr.write(`agent_failures insert failed: ${err.message}\n`);
+    emit({ logged: false, reason: 'database_error' });
+  }
+}
+
+main().catch((err) => {
+  process.stderr.write(`Unexpected error: ${err && err.stack ? err.stack : err}\n`);
+  // Skill must not crash the agent; exit 0 with logged:false rather than non-zero.
+  emit({ logged: false, reason: 'unexpected_error' });
+});

--- a/infra/agent-image/skills/psd-failure-report/report.js
+++ b/infra/agent-image/skills/psd-failure-report/report.js
@@ -38,6 +38,8 @@ const VALID_REASONS = new Set([
   'other',
 ]);
 
+// Restrict to @psd401.net domain — all agent users are PSD staff.
+// Update this regex if the agent platform expands to other domains.
 const EMAIL_RE = /^[^\s@]+@psd401\.net$/i;
 
 function fail(message, code = 1) {
@@ -166,7 +168,7 @@ async function main() {
     }
     emit({ logged: true, failure_id: id });
   } catch (err) {
-    process.stderr.write(`agent_failures insert failed: ${err.message}\n`);
+    process.stderr.write(`agent_failures insert failed: ${err instanceof Error ? err.message : String(err)}\n`); // eslint-disable-line no-console
     emit({ logged: false, reason: 'database_error' });
   }
 }

--- a/infra/agent-image/skills/psd-rules/SKILL.md
+++ b/infra/agent-image/skills/psd-rules/SKILL.md
@@ -223,7 +223,7 @@ If a skill exists for a task, that skill's interface is the **only** path. Do no
 - You started a task and did not finish it within this turn (`--reason task_incomplete`).
 - Anything else that means the user did not get what they asked for (`--reason other`).
 
-**Why:** On 2026-05-04 the morning brief returned "I processed your message but had no response." with no record anywhere except CloudWatch. The admin had no systematic way to find or triage these. Self-reporting populates the `agent_failures` table that the `/admin/agents` Failures tab reads.
+**Why:** Silent failures (e.g. "I processed your message but had no response.") leave no record anywhere except CloudWatch. Without self-reporting, the admin has no systematic way to find or triage these. Self-reporting populates the `agent_failures` table that the `/admin/agents` Failures tab reads.
 
 **How to apply:**
 

--- a/infra/agent-image/skills/psd-rules/SKILL.md
+++ b/infra/agent-image/skills/psd-rules/SKILL.md
@@ -209,6 +209,42 @@ If a skill exists for a task, that skill's interface is the **only** path. Do no
 
 ---
 
+## Rule 10 — Self-report when you cannot fulfill the request
+
+**If you cannot complete any part of what the user asked for, you MUST call `psd-failure-report` BEFORE sending your reply.** Silent failures rot the system; reported failures get fixed.
+
+**Call it when:**
+
+- A credential or API key is missing (`--reason missing_credentials`).
+- A tool errored and you could not work around it (`--reason tool_error`).
+- The tool you needed is not available in this environment (`--reason tool_unavailable`).
+- A data lookup returned empty when the user clearly expected results — e.g. "morning brief" with no events/emails/messages (`--reason data_not_found`).
+- The user's instruction was ambiguous and you had to guess (`--reason ambiguous_request`).
+- You started a task and did not finish it within this turn (`--reason task_incomplete`).
+- Anything else that means the user did not get what they asked for (`--reason other`).
+
+**Why:** On 2026-05-04 the morning brief returned "I processed your message but had no response." with no record anywhere except CloudWatch. The admin had no systematic way to find or triage these. Self-reporting populates the `agent_failures` table that the `/admin/agents` Failures tab reads.
+
+**How to apply:**
+
+1. Call the skill verbatim:
+   ```bash
+   node /opt/psd-skills/psd-failure-report/report.js \
+     --user <caller-email> \
+     --reason <category> \
+     --details "<one-paragraph description of what you tried, what tool/data was missing, and why you could not finish>"
+   ```
+2. After the skill returns `{"logged": true, ...}`, write your normal reply to the user. Acknowledge what went wrong (don't pretend it succeeded).
+3. If in doubt, **call it**. False positives are cheap; silent failures are expensive.
+
+**Forbidden:**
+
+- Replying with an apology ("I wasn't able to…", "I had no response", "Sorry I couldn't…") without first calling `psd-failure-report`.
+- Replying with a fabricated success when you did not actually complete the task.
+- Skipping the report because "it might not be a real failure" — over-report, never under-report.
+
+---
+
 ## Self-check before send
 
 Run this checklist mentally before every reply:
@@ -221,5 +257,6 @@ Run this checklist mentally before every reply:
 6. ✅ Did I update the memory files this turn?
 7. ✅ For any task a skill covers, did I call the skill — not replicate it in Bash?
 8. ✅ If the last tool result had a `url` field, is that exact URL pasted on its own line in my reply? Prose description ≠ URL.
+9. ✅ If I could not fulfill any part of the request, did I call `psd-failure-report` before sending?
 
 If any answer is "no" — fix the reply before sending.

--- a/infra/database/migrations.json
+++ b/infra/database/migrations.json
@@ -70,6 +70,7 @@
     "072-agent-workspace-nonce-agent-email.sql",
     "073-agent-workspace-token-kind.sql",
     "074-deep-research-capability.sql",
-    "075-skill-required-capability.sql"
+    "075-skill-required-capability.sql",
+    "076-agent-failures.sql"
   ]
 }

--- a/infra/database/schema/076-agent-failures.sql
+++ b/infra/database/schema/076-agent-failures.sql
@@ -1,0 +1,80 @@
+-- Migration 076: Agent Failures Telemetry Table
+--
+-- Captures agent execution failures from all chokepoints so we can systemically
+-- triage recurring problems instead of grepping CloudWatch.
+--
+-- Sources:
+--   router            — agent-router Lambda (SQS handler, parse errors, AgentCore invoke errors)
+--   harness           — agent-image harness_adapter.py (empty responses, exceptions, tool errors)
+--   cron              — agent-cron Lambda (mirrors agent_scheduled_runs error rows)
+--   agent_self_report — agent self-flagged via the report_failure tool
+--   tool              — reserved for future tool-level capture
+--
+-- Severities: 'error' | 'warn' | 'empty_response'
+
+UPDATE migration_log SET status = 'completed'
+WHERE description = '076-agent-failures.sql' AND status = 'failed';
+
+CREATE TABLE IF NOT EXISTS agent_failures (
+    id                BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    occurred_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    source            VARCHAR(32) NOT NULL,
+    severity          VARCHAR(16) NOT NULL,
+    user_id           VARCHAR(255),
+    session_id        VARCHAR(512),
+    schedule_name     VARCHAR(255),
+    model             VARCHAR(128),
+    error_class       VARCHAR(128),
+    error_message     TEXT,
+    stack_excerpt     TEXT,
+    context           JSONB,
+    acknowledged      BOOLEAN NOT NULL DEFAULT false,
+    acknowledged_by   VARCHAR(255),
+    acknowledged_at   TIMESTAMPTZ,
+    notes             TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_agent_failures_occurred_at
+    ON agent_failures (occurred_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_agent_failures_source
+    ON agent_failures (source, occurred_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_agent_failures_user
+    ON agent_failures (user_id, occurred_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_agent_failures_unack
+    ON agent_failures (occurred_at DESC)
+    WHERE acknowledged = false;
+
+CREATE INDEX IF NOT EXISTS idx_agent_failures_severity
+    ON agent_failures (severity, occurred_at DESC);
+
+-- agent_pattern_scan_runs: audit log of each weekly scan invocation.
+-- Lets the admin dashboard distinguish "scanner never ran" from
+-- "scanner ran but everything was below the suppression threshold".
+CREATE TABLE IF NOT EXISTS agent_pattern_scan_runs (
+    id              BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    run_at          TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    week            VARCHAR(16) NOT NULL,
+    signals_total   INTEGER NOT NULL DEFAULT 0,
+    topics_total    INTEGER NOT NULL DEFAULT 0,
+    detected        INTEGER NOT NULL DEFAULT 0,
+    suppressed      INTEGER NOT NULL DEFAULT 0
+);
+
+CREATE INDEX IF NOT EXISTS idx_agent_pattern_scan_runs_run_at
+    ON agent_pattern_scan_runs (run_at DESC);
+
+-- agent_health_scan_runs: same idea for the daily health Lambda.
+CREATE TABLE IF NOT EXISTS agent_health_scan_runs (
+    id              BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    run_at          TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    snapshot_date   DATE NOT NULL,
+    users_total     INTEGER NOT NULL DEFAULT 0,
+    abandoned       INTEGER NOT NULL DEFAULT 0,
+    error           TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_agent_health_scan_runs_run_at
+    ON agent_health_scan_runs (run_at DESC);

--- a/infra/database/schema/076-agent-failures.sql
+++ b/infra/database/schema/076-agent-failures.sql
@@ -52,6 +52,11 @@ CREATE INDEX IF NOT EXISTS idx_agent_failures_unack
 CREATE INDEX IF NOT EXISTS idx_agent_failures_severity
     ON agent_failures (severity, occurred_at DESC);
 
+-- Partial index for retention sweep: acked rows are deleted by acknowledged_at age.
+CREATE INDEX IF NOT EXISTS idx_agent_failures_acked_at
+    ON agent_failures (acknowledged_at)
+    WHERE acknowledged = true;
+
 -- agent_pattern_scan_runs: audit log of each weekly scan invocation.
 -- Lets the admin dashboard distinguish "scanner never ran" from
 -- "scanner ran but everything was below the suppression threshold".

--- a/infra/database/schema/076-agent-failures.sql
+++ b/infra/database/schema/076-agent-failures.sql
@@ -18,8 +18,10 @@ WHERE description = '076-agent-failures.sql' AND status = 'failed';
 CREATE TABLE IF NOT EXISTS agent_failures (
     id                BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
     occurred_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-    source            VARCHAR(32) NOT NULL,
-    severity          VARCHAR(16) NOT NULL,
+    source            VARCHAR(32) NOT NULL
+                      CHECK (source IN ('router','harness','cron','agent_self_report','tool')),
+    severity          VARCHAR(16) NOT NULL
+                      CHECK (severity IN ('error','warn','empty_response')),
     user_id           VARCHAR(255),
     session_id        VARCHAR(512),
     schedule_name     VARCHAR(255),

--- a/infra/lambdas/agent-cron/index.ts
+++ b/infra/lambdas/agent-cron/index.ts
@@ -584,13 +584,17 @@ async function recordCronFailure(
   log: Logger,
 ): Promise<void> {
   // Emit a structured CloudWatch line so the metric filter on AGENT_FAILURE_RECORD
-  // fires regardless of whether the DB write below succeeds.
+  // fires regardless of whether the DB write below succeeds. Include the error
+  // message (truncated) as a fallback for triage when the DB write fails.
   log.error('AGENT_FAILURE_RECORD', {
     source: 'cron',
     severity: 'error',
     userId: params.userEmail,
     sessionId: params.sessionId,
     scheduleName: params.scheduleName,
+    errorMessage: typeof params.errorMessage === 'string'
+      ? params.errorMessage.slice(0, 500)
+      : null,
   });
   if (!DATABASE_RESOURCE_ARN || !DATABASE_SECRET_ARN) return;
   try {

--- a/infra/lambdas/agent-cron/index.ts
+++ b/infra/lambdas/agent-cron/index.ts
@@ -552,6 +552,83 @@ async function recordRun(params: {
       error: error instanceof Error ? error.message : String(error),
     });
   }
+
+  // Mirror error/skipped runs into agent_failures so the admin dashboard sees
+  // them alongside router/harness failures. agent_scheduled_runs remains the
+  // source of truth for cron analytics.
+  if (params.status === 'error') {
+    await recordCronFailure(
+      {
+        userEmail: params.userEmail,
+        sessionId: params.sessionId,
+        scheduleId: params.scheduleId,
+        scheduleName: params.scheduleName,
+        errorMessage: params.errorMessage ?? null,
+      },
+      log,
+    );
+  }
+}
+
+/**
+ * Mirror a failed scheduled run into agent_failures. Best-effort, never throws.
+ */
+async function recordCronFailure(
+  params: {
+    userEmail: string;
+    sessionId: string;
+    scheduleId: string;
+    scheduleName: string;
+    errorMessage: string | null;
+  },
+  log: Logger,
+): Promise<void> {
+  // Emit a structured CloudWatch line so the metric filter on AGENT_FAILURE_RECORD
+  // fires regardless of whether the DB write below succeeds.
+  log.error('AGENT_FAILURE_RECORD', {
+    source: 'cron',
+    severity: 'error',
+    userId: params.userEmail,
+    sessionId: params.sessionId,
+    scheduleName: params.scheduleName,
+  });
+  if (!DATABASE_RESOURCE_ARN || !DATABASE_SECRET_ARN) return;
+  try {
+    const truncated =
+      typeof params.errorMessage === 'string'
+        ? params.errorMessage.slice(0, 4000)
+        : null;
+    const context = JSON.stringify({
+      scheduleId: params.scheduleId,
+    });
+    await rdsDataClient.send(
+      new ExecuteStatementCommand({
+        resourceArn: DATABASE_RESOURCE_ARN,
+        secretArn: DATABASE_SECRET_ARN,
+        database: DATABASE_NAME,
+        sql: `INSERT INTO agent_failures
+                (source, severity, user_id, session_id, schedule_name,
+                 error_message, context, occurred_at)
+              VALUES
+                ('cron', 'error', :user_id, :session_id, :schedule_name,
+                 :error_message, CAST(:context AS jsonb), NOW())`,
+        parameters: [
+          { name: 'user_id', value: { stringValue: params.userEmail } },
+          { name: 'session_id', value: { stringValue: params.sessionId } },
+          { name: 'schedule_name', value: { stringValue: params.scheduleName } },
+          truncated
+            ? { name: 'error_message', value: { stringValue: truncated } }
+            : { name: 'error_message', value: { isNull: true } },
+          { name: 'context', value: { stringValue: context } },
+        ],
+      }),
+    );
+  } catch (error) {
+    log.error('Failed to record cron failure mirror', {
+      scheduleId: params.scheduleId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
 }
 
 /**

--- a/infra/lambdas/agent-health-daily/index.ts
+++ b/infra/lambdas/agent-health-daily/index.ts
@@ -244,6 +244,70 @@ export const handler = async (): Promise<{ processed: number; abandoned: number 
     }
   }
 
+  // Record an explicit "scan run" marker so admins can tell the difference
+  // between "Lambda never ran" and "Lambda ran but produced 0 snapshots".
+  // Best-effort — failure of the marker write must not fail the whole run.
+  try {
+    await sql`
+      INSERT INTO agent_health_scan_runs
+        (run_at, snapshot_date, users_total, abandoned, error)
+      VALUES (NOW(), ${snapshotDate}, ${processed}, ${abandonedCount}, NULL)
+    `;
+  } catch (err) {
+    log('WARN', 'Failed to record scan_runs marker', {
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+
+  // Retention cleanup — keep agent_failures fresh. Default: 90 days for ack'd,
+  // 180 days for unack'd. Override via env var. Run at most once per day off
+  // the daily Lambda; failure is non-fatal.
+  await runFailureRetentionCleanup(sql, log);
+
   log('INFO', 'Health snapshot complete', { processed, abandonedCount, snapshotDate });
   return { processed, abandoned: abandonedCount };
 };
+
+const FAILURE_RETENTION_DAYS_ACKED = parseInt(
+  process.env.FAILURE_RETENTION_DAYS_ACKED || '90',
+  10,
+);
+const FAILURE_RETENTION_DAYS_UNACKED = parseInt(
+  process.env.FAILURE_RETENTION_DAYS_UNACKED || '180',
+  10,
+);
+
+/**
+ * Trim aged rows from agent_failures. Acknowledged rows expire faster than
+ * untriaged ones because once you've reviewed a failure, the historical
+ * record stops carrying signal. Unacknowledged rows live longer so newly
+ * onboarded admins can audit recent history.
+ */
+async function runFailureRetentionCleanup(
+  sql: postgres.Sql,
+  logger: typeof log,
+): Promise<void> {
+  try {
+    const ackResult = (await sql`
+      DELETE FROM agent_failures
+      WHERE acknowledged = true
+        AND acknowledged_at IS NOT NULL
+        AND acknowledged_at < NOW() - (${FAILURE_RETENTION_DAYS_ACKED}::int * INTERVAL '1 day')
+    `) as unknown as { count?: number };
+    const unackResult = (await sql`
+      DELETE FROM agent_failures
+      WHERE acknowledged = false
+        AND occurred_at < NOW() - (${FAILURE_RETENTION_DAYS_UNACKED}::int * INTERVAL '1 day')
+    `) as unknown as { count?: number };
+    logger('INFO', 'agent_failures retention sweep', {
+      ackedDeleted: ackResult.count ?? 0,
+      unackedDeleted: unackResult.count ?? 0,
+      ackRetentionDays: FAILURE_RETENTION_DAYS_ACKED,
+      unackRetentionDays: FAILURE_RETENTION_DAYS_UNACKED,
+    });
+  } catch (err) {
+    logger('WARN', 'agent_failures retention sweep failed', {
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+}

--- a/infra/lambdas/agent-health-daily/index.ts
+++ b/infra/lambdas/agent-health-daily/index.ts
@@ -268,14 +268,14 @@ export const handler = async (): Promise<{ processed: number; abandoned: number 
   return { processed, abandoned: abandonedCount };
 };
 
-const FAILURE_RETENTION_DAYS_ACKED = parseInt(
-  process.env.FAILURE_RETENTION_DAYS_ACKED || '90',
-  10,
-);
-const FAILURE_RETENTION_DAYS_UNACKED = parseInt(
-  process.env.FAILURE_RETENTION_DAYS_UNACKED || '180',
-  10,
-);
+const FAILURE_RETENTION_DAYS_ACKED = (() => {
+  const parsed = parseInt(process.env.FAILURE_RETENTION_DAYS_ACKED || '90', 10);
+  return Number.isFinite(parsed) && parsed >= 1 ? parsed : 90;
+})();
+const FAILURE_RETENTION_DAYS_UNACKED = (() => {
+  const parsed = parseInt(process.env.FAILURE_RETENTION_DAYS_UNACKED || '180', 10);
+  return Number.isFinite(parsed) && parsed >= 1 ? parsed : 180;
+})();
 
 /**
  * Trim aged rows from agent_failures. Acknowledged rows expire faster than

--- a/infra/lambdas/agent-health-daily/index.ts
+++ b/infra/lambdas/agent-health-daily/index.ts
@@ -288,20 +288,21 @@ async function runFailureRetentionCleanup(
   logger: typeof log,
 ): Promise<void> {
   try {
-    const ackResult = (await sql`
+    const ackResult = await sql`
       DELETE FROM agent_failures
       WHERE acknowledged = true
         AND acknowledged_at IS NOT NULL
         AND acknowledged_at < NOW() - (${FAILURE_RETENTION_DAYS_ACKED}::int * INTERVAL '1 day')
-    `) as unknown as { count?: number };
-    const unackResult = (await sql`
+    `;
+    const unackResult = await sql`
       DELETE FROM agent_failures
       WHERE acknowledged = false
         AND occurred_at < NOW() - (${FAILURE_RETENTION_DAYS_UNACKED}::int * INTERVAL '1 day')
-    `) as unknown as { count?: number };
+    `;
+    // postgres.js v3 returns .count as bigint — coerce to number for safe logging/JSON
     logger('INFO', 'agent_failures retention sweep', {
-      ackedDeleted: ackResult.count ?? 0,
-      unackedDeleted: unackResult.count ?? 0,
+      ackedDeleted: Number(ackResult.count ?? 0),
+      unackedDeleted: Number(unackResult.count ?? 0),
       ackRetentionDays: FAILURE_RETENTION_DAYS_ACKED,
       unackRetentionDays: FAILURE_RETENTION_DAYS_UNACKED,
     });

--- a/infra/lambdas/agent-pattern-scanner/index.ts
+++ b/infra/lambdas/agent-pattern-scanner/index.ts
@@ -164,6 +164,10 @@ export const handler = async (
   const currentWeek = isoWeek(today);
   const weeksToScan: string[] = [];
   if (event?.week) {
+    if (!/^\d{4}-W\d{2}$/.test(event.week)) {
+      log('ERROR', 'Invalid week format', { week: event.week, expected: 'YYYY-WNN' });
+      throw new Error(`Invalid week format: "${event.week}" — expected YYYY-WNN (e.g. "2026-W18")`);
+    }
     weeksToScan.push(event.week);
   } else if (event?.backfillWeeks && event.backfillWeeks > 0) {
     const n = Math.min(Math.floor(event.backfillWeeks), 52);
@@ -175,24 +179,30 @@ export const handler = async (
     weeksToScan.push(currentWeek);
   }
 
+  // Scan DynamoDB once and reuse the signal set across all weeks to avoid
+  // O(N * table_size) reads during multi-week backfills.
+  const signals = await scanAllSignals();
+  log('INFO', 'Scanned signals for backfill', { total: signals.length, weeks: weeksToScan.length });
+
   let totalDetected = 0;
   for (const targetWeek of weeksToScan) {
-    totalDetected += await scanForWeek(targetWeek);
+    totalDetected += await scanForWeek(targetWeek, signals);
   }
   return { detected: totalDetected, weeks: weeksToScan };
 };
 
-async function scanForWeek(currentWeek: string): Promise<number> {
+async function scanForWeek(currentWeek: string, prefetchedSignals?: SignalItem[]): Promise<number> {
   const rollingWeeks = new Set<string>();
   for (let i = 1; i <= ROLLING_WEEKS; i++) {
     rollingWeeks.add(priorWeek(currentWeek, i));
   }
 
-  const signals = await scanAllSignals();
-  log('INFO', 'Scanned signals', {
+  const signals = prefetchedSignals ?? await scanAllSignals();
+  log('INFO', 'Processing signals', {
     total: signals.length,
     currentWeek,
     rollingWeeks: Array.from(rollingWeeks),
+    prefetched: !!prefetchedSignals,
   });
 
   // Aggregate: topic → { currentCount, buildings: Set, priorCounts: number[] }
@@ -218,12 +228,14 @@ async function scanForWeek(currentWeek: string): Promise<number> {
 
   const sql = await getSql();
   let detected = 0;
+  let suppressed = 0;
 
   for (const [topic, agg] of byTopic.entries()) {
     // Suppression: below thresholds → skip entirely. Do NOT write anything,
     // not even "topic below threshold". Dashboard users should never see
     // low-count signals that could proxy individual users.
     if (agg.currentCount < MIN_SIGNALS || agg.buildings.size < MIN_BUILDINGS) {
+      suppressed += 1;
       continue;
     }
 
@@ -268,7 +280,7 @@ async function scanForWeek(currentWeek: string): Promise<number> {
       INSERT INTO agent_pattern_scan_runs
         (run_at, week, signals_total, topics_total, detected, suppressed)
       VALUES (NOW(), ${currentWeek}, ${signals.length}, ${byTopic.size}, ${detected},
-              ${byTopic.size - detected})
+              ${suppressed})
     `;
   } catch (err) {
     log('WARN', 'Failed to record scan_runs marker', {
@@ -281,7 +293,7 @@ async function scanForWeek(currentWeek: string): Promise<number> {
     currentWeek,
     signalsTotal: signals.length,
     topicsTotal: byTopic.size,
-    suppressed: byTopic.size - detected,
+    suppressed,
   });
   return detected;
 }

--- a/infra/lambdas/agent-pattern-scanner/index.ts
+++ b/infra/lambdas/agent-pattern-scanner/index.ts
@@ -142,14 +142,47 @@ async function getSql(): Promise<postgres.Sql> {
   return sqlClient;
 }
 
-export const handler = async (): Promise<{ detected: number }> => {
+interface ScanEvent {
+  /** ISO 8601 week (e.g. "2026-W18") to scan. Defaults to current week. */
+  week?: string;
+  /** When true, scan the last N weeks (1..52). Useful for first-time backfill. */
+  backfillWeeks?: number;
+}
+
+export const handler = async (
+  event?: ScanEvent,
+): Promise<{ detected: number; weeks: string[] }> => {
   if (!SIGNALS_TABLE || !DATABASE_HOST || !DATABASE_SECRET_ARN) {
     log('ERROR', 'Missing required environment variables');
     throw new Error('Pattern scanner misconfigured');
   }
 
+  // Build the list of weeks to scan. Default = current. Manual invocations
+  // can override with `{ week: "2026-W18" }` or backfill with
+  // `{ backfillWeeks: 12 }` to populate the last 12 weeks at once.
   const today = new Date();
   const currentWeek = isoWeek(today);
+  const weeksToScan: string[] = [];
+  if (event?.week) {
+    weeksToScan.push(event.week);
+  } else if (event?.backfillWeeks && event.backfillWeeks > 0) {
+    const n = Math.min(Math.floor(event.backfillWeeks), 52);
+    weeksToScan.push(currentWeek);
+    for (let i = 1; i < n; i++) {
+      weeksToScan.push(priorWeek(currentWeek, i));
+    }
+  } else {
+    weeksToScan.push(currentWeek);
+  }
+
+  let totalDetected = 0;
+  for (const targetWeek of weeksToScan) {
+    totalDetected += await scanForWeek(targetWeek);
+  }
+  return { detected: totalDetected, weeks: weeksToScan };
+};
+
+async function scanForWeek(currentWeek: string): Promise<number> {
   const rollingWeeks = new Set<string>();
   for (let i = 1; i <= ROLLING_WEEKS; i++) {
     rollingWeeks.add(priorWeek(currentWeek, i));
@@ -226,6 +259,29 @@ export const handler = async (): Promise<{ detected: number }> => {
     detected += 1;
   }
 
-  log('INFO', 'Pattern scan complete', { detected, currentWeek });
-  return { detected };
-};
+  // Record an explicit "scan run" marker so admins can tell the difference
+  // between "scanner never ran" (table empty + no marker) and "scanner ran
+  // but suppression thresholds filtered everything" (table empty + marker).
+  // Best-effort — failure of the marker write must not fail the scan.
+  try {
+    await sql`
+      INSERT INTO agent_pattern_scan_runs
+        (run_at, week, signals_total, topics_total, detected, suppressed)
+      VALUES (NOW(), ${currentWeek}, ${signals.length}, ${byTopic.size}, ${detected},
+              ${byTopic.size - detected})
+    `;
+  } catch (err) {
+    log('WARN', 'Failed to record scan_runs marker', {
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+
+  log('INFO', 'Pattern scan complete', {
+    detected,
+    currentWeek,
+    signalsTotal: signals.length,
+    topicsTotal: byTopic.size,
+    suppressed: byTopic.size - detected,
+  });
+  return detected;
+}

--- a/infra/lambdas/agent-pattern-scanner/index.ts
+++ b/infra/lambdas/agent-pattern-scanner/index.ts
@@ -168,8 +168,15 @@ export const handler = async (
       log('ERROR', 'Invalid week format', { week: event.week, expected: 'YYYY-WNN' });
       throw new Error(`Invalid week format: "${event.week}" — expected YYYY-WNN (e.g. "2026-W18")`);
     }
+    // Validate week number is in range (W01–W53)
+    const weekNum = parseInt(event.week.split('-W')[1], 10);
+    if (weekNum < 1 || weekNum > 53) {
+      log('ERROR', 'Week number out of range', { week: event.week, weekNum });
+      throw new Error(`Week number out of range: "${event.week}" — must be W01–W53`);
+    }
     weeksToScan.push(event.week);
   } else if (event?.backfillWeeks && event.backfillWeeks > 0) {
+    // n weeks total: currentWeek + (n-1) prior weeks
     const n = Math.min(Math.floor(event.backfillWeeks), 52);
     weeksToScan.push(currentWeek);
     for (let i = 1; i < n; i++) {
@@ -181,12 +188,35 @@ export const handler = async (
 
   // Scan DynamoDB once and reuse the signal set across all weeks to avoid
   // O(N * table_size) reads during multi-week backfills.
+  //
+  // NOTE: This means historical weeks are evaluated against the *current*
+  // signal set rather than the set that existed at that time. This is
+  // intentional — backfills populate the dashboard "last scan ran" banner
+  // rather than reconstructing exact historical pattern detection.
   const signals = await scanAllSignals();
   log('INFO', 'Scanned signals for backfill', { total: signals.length, weeks: weeksToScan.length });
 
   let totalDetected = 0;
+  const failedWeeks: string[] = [];
   for (const targetWeek of weeksToScan) {
-    totalDetected += await scanForWeek(targetWeek, signals);
+    try {
+      totalDetected += await scanForWeek(targetWeek, signals);
+    } catch (err) {
+      // Log but continue — a single week's failure should not abort the
+      // entire backfill. The skipped week will have no scan-run marker,
+      // making it retryable via `{ week: "YYYY-WNN" }`.
+      log('ERROR', 'scanForWeek failed, continuing with remaining weeks', {
+        week: targetWeek,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      failedWeeks.push(targetWeek);
+    }
+  }
+  if (failedWeeks.length > 0) {
+    log('WARN', 'Backfill completed with partial failures', {
+      failedWeeks,
+      succeeded: weeksToScan.length - failedWeeks.length,
+    });
   }
   return { detected: totalDetected, weeks: weeksToScan };
 };
@@ -212,7 +242,12 @@ async function scanForWeek(currentWeek: string, prefetchedSignals?: SignalItem[]
     priorTotals: Map<string, number>;
   }
   const byTopic = new Map<string, Agg>();
+  // Count signals that are relevant to this week (current or rolling window)
+  // rather than using the total DynamoDB signal count which includes all weeks.
+  let weekRelevantSignals = 0;
   for (const s of signals) {
+    if (s.week !== currentWeek && !rollingWeeks.has(s.week)) continue;
+    weekRelevantSignals++;
     let agg = byTopic.get(s.topic);
     if (!agg) {
       agg = { currentCount: 0, buildings: new Set(), priorTotals: new Map() };
@@ -279,7 +314,7 @@ async function scanForWeek(currentWeek: string, prefetchedSignals?: SignalItem[]
     await sql`
       INSERT INTO agent_pattern_scan_runs
         (run_at, week, signals_total, topics_total, detected, suppressed)
-      VALUES (NOW(), ${currentWeek}, ${signals.length}, ${byTopic.size}, ${detected},
+      VALUES (NOW(), ${currentWeek}, ${weekRelevantSignals}, ${byTopic.size}, ${detected},
               ${suppressed})
     `;
   } catch (err) {
@@ -291,7 +326,8 @@ async function scanForWeek(currentWeek: string, prefetchedSignals?: SignalItem[]
   log('INFO', 'Pattern scan complete', {
     detected,
     currentWeek,
-    signalsTotal: signals.length,
+    signalsRelevant: weekRelevantSignals,
+    signalsTotalPrefetched: signals.length,
     topicsTotal: byTopic.size,
     suppressed,
   });

--- a/infra/lambdas/agent-router/index.ts
+++ b/infra/lambdas/agent-router/index.ts
@@ -1679,7 +1679,7 @@ export async function handler(
             errorClass: classified.errorClass,
             errorMessage: classified.message,
             stackExcerpt: classified.stack,
-            context: { messageId, requestId, attempt: event.Records[idx].attributes?.ApproximateReceiveCount },
+            context: { messageId, requestId, attempt: event.Records[idx].attributes?.ApproximateReceiveCount ?? "0" },
           },
           log
         );

--- a/infra/lambdas/agent-router/index.ts
+++ b/infra/lambdas/agent-router/index.ts
@@ -1334,6 +1334,79 @@ async function logTelemetry(
 }
 
 // ---------------------------------------------------------------------------
+// Failure capture (agent_failures)
+// ---------------------------------------------------------------------------
+
+/**
+ * Persist a failure row in agent_failures. Never throws — failure-of-the-failure-writer
+ * must not affect the user-facing flow. Logs to CloudWatch on insert error so the
+ * original failure remains discoverable there.
+ */
+async function recordFailure(
+  params: {
+    source: 'router' | 'harness' | 'cron' | 'agent_self_report' | 'tool';
+    severity: 'error' | 'warn' | 'empty_response';
+    userId?: string | null;
+    sessionId?: string | null;
+    scheduleName?: string | null;
+    model?: string | null;
+    errorClass?: string | null;
+    errorMessage?: string | null;
+    stackExcerpt?: string | null;
+    context?: Record<string, unknown> | null;
+  },
+  log: ReturnType<typeof createLogger>
+): Promise<void> {
+  // Emit a structured CloudWatch line first so the metric filter ticks even
+  // when the DB write fails. The string AGENT_FAILURE_RECORD is matched by a
+  // CloudWatch MetricFilter — keep it stable.
+  log.error('AGENT_FAILURE_RECORD', {
+    source: params.source,
+    severity: params.severity,
+    userId: params.userId ?? null,
+    sessionId: params.sessionId ?? null,
+    errorClass: params.errorClass ?? null,
+  });
+  if (!DATABASE_HOST || !DATABASE_SECRET_ARN) {
+    log.warn('Database not configured, skipping failure record');
+    return;
+  }
+  try {
+    const sql = await getDbClient();
+    const truncate = (s: string | null | undefined, max: number) =>
+      typeof s === 'string' ? s.slice(0, max) : null;
+    const ctx = params.context ? JSON.stringify(params.context) : null;
+    await sql`INSERT INTO agent_failures
+        (source, severity, user_id, session_id, schedule_name, model,
+         error_class, error_message, stack_excerpt, context, occurred_at)
+        VALUES (${params.source}, ${params.severity},
+                ${params.userId ?? null}, ${params.sessionId ?? null},
+                ${params.scheduleName ?? null}, ${params.model ?? null},
+                ${truncate(params.errorClass, 128)},
+                ${truncate(params.errorMessage, 4000)},
+                ${truncate(params.stackExcerpt, 4000)},
+                ${ctx}::jsonb, NOW())`;
+  } catch (error) {
+    log.error('Failed to record agent failure', {
+      error: error instanceof Error ? error.message : String(error),
+      originalSource: params.source,
+      originalSeverity: params.severity,
+    });
+  }
+}
+
+function classifyError(err: unknown): { errorClass: string; message: string; stack: string | null } {
+  if (err instanceof Error) {
+    return {
+      errorClass: err.name || 'Error',
+      message: err.message,
+      stack: err.stack ? err.stack.split('\n').slice(0, 20).join('\n') : null,
+    };
+  }
+  return { errorClass: 'NonError', message: String(err), stack: null };
+}
+
+// ---------------------------------------------------------------------------
 // Organizational Nervous System — signal store
 // ---------------------------------------------------------------------------
 
@@ -1589,15 +1662,30 @@ export async function handler(
   );
 
   const batchItemFailures: { itemIdentifier: string }[] = [];
-  results.forEach((result, idx) => {
-    if (result.status === 'rejected') {
-      batchItemFailures.push({ itemIdentifier: event.Records[idx].messageId });
-      log.error('Record processing failed', {
-        messageId: event.Records[idx].messageId,
-        error: result.reason instanceof Error ? result.reason.message : String(result.reason),
-      });
-    }
-  });
+  await Promise.all(
+    results.map(async (result, idx) => {
+      if (result.status === 'rejected') {
+        const messageId = event.Records[idx].messageId;
+        batchItemFailures.push({ itemIdentifier: messageId });
+        const classified = classifyError(result.reason);
+        log.error('Record processing failed', {
+          messageId,
+          error: classified.message,
+        });
+        await recordFailure(
+          {
+            source: 'router',
+            severity: 'error',
+            errorClass: classified.errorClass,
+            errorMessage: classified.message,
+            stackExcerpt: classified.stack,
+            context: { messageId, requestId, attempt: event.Records[idx].attributes?.ApproximateReceiveCount },
+          },
+          log
+        );
+      }
+    })
+  );
 
   return { batchItemFailures };
 }

--- a/infra/lib/agent-platform-stack.ts
+++ b/infra/lib/agent-platform-stack.ts
@@ -1867,6 +1867,10 @@ export class AgentPlatformStack extends cdk.Stack {
     // CloudWatch path. Two paths exist (`/aws/bedrock/agentcore/*` and
     // `/aws/bedrock-agentcore/*`); we attach to both as imports so the filter
     // catches whichever the runtime ends up using.
+    //
+    // Each filter uses a DISTINCT metric name to avoid double-counting. The
+    // alarm below aggregates both via a MathExpression. At any given time only
+    // one log group will actually receive events; the other metric stays at 0.
     const harnessLogGroup1 = logs.LogGroup.fromLogGroupName(
       this,
       'AgentCoreLogGroupRef',
@@ -1875,7 +1879,7 @@ export class AgentPlatformStack extends cdk.Stack {
     new logs.MetricFilter(this, 'HarnessAgentFailureMetric', {
       logGroup: harnessLogGroup1,
       metricNamespace: failureMetricNamespace,
-      metricName: failureMetricName,
+      metricName: 'AgentFailuresHarness1',
       filterPattern: logs.FilterPattern.literal('AGENT_FAILURE_RECORD'),
       metricValue: '1',
       defaultValue: 0,
@@ -1891,7 +1895,7 @@ export class AgentPlatformStack extends cdk.Stack {
     new logs.MetricFilter(this, 'HarnessAgentFailureMetric2', {
       logGroup: harnessLogGroup2,
       metricNamespace: failureMetricNamespace,
-      metricName: failureMetricName,
+      metricName: 'AgentFailuresHarness2',
       filterPattern: logs.FilterPattern.literal('AGENT_FAILURE_RECORD'),
       metricValue: '1',
       defaultValue: 0,
@@ -1901,15 +1905,41 @@ export class AgentPlatformStack extends cdk.Stack {
     // per 5-minute window — same threshold as the router error alarm so the
     // pager doesn't differentiate the two except by which alarm fired. Tune
     // via the env-specific config if dev noise becomes a problem.
+    //
+    // The alarm uses a MathExpression to aggregate the three distinct metric
+    // names. Router and cron share `AgentFailures` (separate log groups, no
+    // double-counting). The two harness filters use distinct names because
+    // they cover two possible AgentCore log group naming conventions — at
+    // runtime only one will receive events, but if both did, using the same
+    // metric name would double-count each harness failure.
+    const period = cdk.Duration.minutes(5);
     const failureRateAlarm = new cloudwatch.Alarm(this, 'AgentFailureRateAlarm', {
       alarmName: `psd-agent-failures-${environment}`,
       alarmDescription:
         'agent_failures table is filling up faster than expected — investigate via /admin/agents Failures tab',
-      metric: new cloudwatch.Metric({
-        namespace: failureMetricNamespace,
-        metricName: failureMetricName,
-        period: cdk.Duration.minutes(5),
-        statistic: 'Sum',
+      metric: new cloudwatch.MathExpression({
+        expression: 'routerCron + harness1 + harness2',
+        usingMetrics: {
+          routerCron: new cloudwatch.Metric({
+            namespace: failureMetricNamespace,
+            metricName: failureMetricName,
+            period,
+            statistic: 'Sum',
+          }),
+          harness1: new cloudwatch.Metric({
+            namespace: failureMetricNamespace,
+            metricName: 'AgentFailuresHarness1',
+            period,
+            statistic: 'Sum',
+          }),
+          harness2: new cloudwatch.Metric({
+            namespace: failureMetricNamespace,
+            metricName: 'AgentFailuresHarness2',
+            period,
+            statistic: 'Sum',
+          }),
+        },
+        period,
       }),
       threshold: 10,
       evaluationPeriods: 1,

--- a/infra/lib/agent-platform-stack.ts
+++ b/infra/lib/agent-platform-stack.ts
@@ -1139,6 +1139,7 @@ export class AgentPlatformStack extends cdk.Stack {
           GUARDRAIL_ARN: props.guardrailArn,
           DATABASE_RESOURCE_ARN: props.databaseResourceArn,
           DATABASE_SECRET_ARN: props.databaseSecretArn,
+          DATABASE_NAME: props.databaseName ?? 'aistudio',
           // ARN of the Secrets Manager secret holding the Bedrock API key.
           // `agentcore_wrapper.py` fetches this on startup and exports its
           // value as AWS_BEARER_TOKEN_BEDROCK so OpenClaw can authenticate
@@ -1835,11 +1836,77 @@ export class AgentPlatformStack extends cdk.Stack {
       treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
     });
 
+    // CloudWatch metric filter — emit a metric every time an
+    // AGENT_FAILURE_RECORD line lands in the router Lambda log. Combined with
+    // the harness-image structured log line of the same shape, this gives us
+    // a single "agent failures per period" metric across all chokepoints.
+    const failureMetricNamespace = `PSD/AgentPlatform/${environment}`;
+    const failureMetricName = 'AgentFailures';
+
+    new logs.MetricFilter(this, 'RouterAgentFailureMetric', {
+      logGroup: this.routerLambda.logGroup,
+      metricNamespace: failureMetricNamespace,
+      metricName: failureMetricName,
+      filterPattern: logs.FilterPattern.literal('AGENT_FAILURE_RECORD'),
+      metricValue: '1',
+      defaultValue: 0,
+    });
+
+    new logs.MetricFilter(this, 'CronAgentFailureMetric', {
+      logGroup: cronLogGroup,
+      metricNamespace: failureMetricNamespace,
+      metricName: failureMetricName,
+      filterPattern: logs.FilterPattern.literal('AGENT_FAILURE_RECORD'),
+      metricValue: '1',
+      defaultValue: 0,
+    });
+
+    // Harness adapter writes AGENT_FAILURE_RECORD to the AgentCore log groups.
+    // The alpha agentcore CDK construct does not expose a typed log group
+    // handle, so we attach the metric filter to the conventional AgentCore
+    // CloudWatch path. Two paths exist (`/aws/bedrock/agentcore/*` and
+    // `/aws/bedrock-agentcore/*`); we attach to both as imports so the filter
+    // catches whichever the runtime ends up using.
+    const harnessLogGroup1 = logs.LogGroup.fromLogGroupName(
+      this,
+      'AgentCoreLogGroupRef',
+      `/aws/bedrock-agentcore/runtimes/psd_agent_${environment}`,
+    );
+    new logs.MetricFilter(this, 'HarnessAgentFailureMetric', {
+      logGroup: harnessLogGroup1,
+      metricNamespace: failureMetricNamespace,
+      metricName: failureMetricName,
+      filterPattern: logs.FilterPattern.literal('AGENT_FAILURE_RECORD'),
+      metricValue: '1',
+      defaultValue: 0,
+    });
+
+    // CloudWatch alarm on agent failure rate. Fires when failures exceed 10
+    // per 5-minute window — same threshold as the router error alarm so the
+    // pager doesn't differentiate the two except by which alarm fired. Tune
+    // via the env-specific config if dev noise becomes a problem.
+    const failureRateAlarm = new cloudwatch.Alarm(this, 'AgentFailureRateAlarm', {
+      alarmName: `psd-agent-failures-${environment}`,
+      alarmDescription:
+        'agent_failures table is filling up faster than expected — investigate via /admin/agents Failures tab',
+      metric: new cloudwatch.Metric({
+        namespace: failureMetricNamespace,
+        metricName: failureMetricName,
+        period: cdk.Duration.minutes(5),
+        statistic: 'Sum',
+      }),
+      threshold: 10,
+      evaluationPeriods: 1,
+      comparisonOperator: cloudwatch.ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+      treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
+    });
+
     // Wire alarm notifications if SNS topic is configured
     if (alarmTopic) {
       const snsAction = new cloudwatchActions.SnsAction(alarmTopic);
       dlqAlarm.addAlarmAction(snsAction);
       errorAlarm.addAlarmAction(snsAction);
+      failureRateAlarm.addAlarmAction(snsAction);
     }
 
     // =====================================================================

--- a/infra/lib/agent-platform-stack.ts
+++ b/infra/lib/agent-platform-stack.ts
@@ -1881,6 +1881,22 @@ export class AgentPlatformStack extends cdk.Stack {
       defaultValue: 0,
     });
 
+    // Attach to the alternate AgentCore log group path as well, so failures
+    // are captured regardless of which naming convention the runtime uses.
+    const harnessLogGroup2 = logs.LogGroup.fromLogGroupName(
+      this,
+      'AgentCoreLogGroupRef2',
+      `/aws/bedrock/agentcore/runtimes/psd_agent_${environment}`,
+    );
+    new logs.MetricFilter(this, 'HarnessAgentFailureMetric2', {
+      logGroup: harnessLogGroup2,
+      metricNamespace: failureMetricNamespace,
+      metricName: failureMetricName,
+      filterPattern: logs.FilterPattern.literal('AGENT_FAILURE_RECORD'),
+      metricValue: '1',
+      defaultValue: 0,
+    });
+
     // CloudWatch alarm on agent failure rate. Fires when failures exceed 10
     // per 5-minute window — same threshold as the router error alarm so the
     // pager doesn't differentiate the two except by which alarm fired. Tune

--- a/infra/lib/agent-platform-stack.ts
+++ b/infra/lib/agent-platform-stack.ts
@@ -813,6 +813,21 @@ export class AgentPlatformStack extends cdk.Stack {
       resources: [props.databaseResourceArn],
     }));
 
+    // CloudWatch custom metrics — harness emits PSD/AgentPlatform/{env}/AgentFailuresHarness
+    // via boto3 put_metric_data. Resource must be '*' per AWS API contract; we
+    // scope by namespace condition.
+    this.agentCoreExecutionRole.addToPolicy(new iam.PolicyStatement({
+      sid: 'CloudWatchMetricsPublish',
+      effect: iam.Effect.ALLOW,
+      actions: ['cloudwatch:PutMetricData'],
+      resources: ['*'],
+      conditions: {
+        StringEquals: {
+          'cloudwatch:namespace': `PSD/AgentPlatform/${environment}`,
+        },
+      },
+    }));
+
     // Secrets Manager — read DB credentials referenced by DATABASE_SECRET_ARN
     this.agentCoreExecutionRole.addToPolicy(new iam.PolicyStatement({
       sid: 'SecretsManagerAccess',
@@ -1861,30 +1876,13 @@ export class AgentPlatformStack extends cdk.Stack {
       defaultValue: 0,
     });
 
-    // Harness adapter writes AGENT_FAILURE_RECORD to the AgentCore runtime log
-    // group. The current AgentCore alpha construct (and the build-and-push
-    // script's tail command) uses the `/aws/bedrock-agentcore/runtimes/...`
-    // convention. The alternate `/aws/bedrock/agentcore/...` path is from
-    // older alpha versions and the IAM policy above grants write access to
-    // both for forward compatibility, but only one log group exists at deploy
-    // time — referencing a non-existent path fails CFN with NotFound.
-    //
-    // We attach to the path the runtime actually uses today. If AWS ever
-    // renames it, the IAM grants already cover both paths and we can flip
-    // this reference; metric values would briefly stop until the rename.
-    const harnessLogGroup = logs.LogGroup.fromLogGroupName(
-      this,
-      'AgentCoreLogGroupRef',
-      `/aws/bedrock-agentcore/runtimes/psd_agent_${environment}`,
-    );
-    new logs.MetricFilter(this, 'HarnessAgentFailureMetric', {
-      logGroup: harnessLogGroup,
-      metricNamespace: failureMetricNamespace,
-      metricName: 'AgentFailuresHarness',
-      filterPattern: logs.FilterPattern.literal('AGENT_FAILURE_RECORD'),
-      metricValue: '1',
-      defaultValue: 0,
-    });
+    // Harness adapter emits the `AgentFailuresHarness` metric directly via
+    // boto3 cloudwatch.put_metric_data() from inside the AgentCore container
+    // (see infra/agent-image/agent_failures.py). We can't use a CloudWatch
+    // MetricFilter the way router/cron do because the AgentCore log group
+    // name has a runtime-generated suffix (`psd_agent_<env>-<random>-DEFAULT`)
+    // that isn't predictable at CDK synth time, and CFN won't import a
+    // non-existent log group.
 
     // CloudWatch alarm on agent failure rate. Fires when failures exceed 10
     // per 5-minute window — same threshold as the router error alarm so the

--- a/infra/lib/agent-platform-stack.ts
+++ b/infra/lib/agent-platform-stack.ts
@@ -1858,6 +1858,9 @@ export class AgentPlatformStack extends cdk.Stack {
     const failureMetricNamespace = `PSD/AgentPlatform/${environment}`;
     const failureMetricName = 'AgentFailures';
 
+    // Both router and cron filters intentionally write to the same metric name.
+    // They accumulate into one `AgentFailures` metric; per-source breakdown
+    // requires querying agent_failures.source in the DB.
     new logs.MetricFilter(this, 'RouterAgentFailureMetric', {
       logGroup: this.routerLambda.logGroup,
       metricNamespace: failureMetricNamespace,
@@ -1895,7 +1898,7 @@ export class AgentPlatformStack extends cdk.Stack {
     const failureRateAlarm = new cloudwatch.Alarm(this, 'AgentFailureRateAlarm', {
       alarmName: `psd-agent-failures-${environment}`,
       alarmDescription:
-        'agent_failures table is filling up faster than expected — investigate via /admin/agents Failures tab',
+        `Agent failures >= 10 in 5 min. Triage: https://aistudio.psd401.net/admin/agents (Failures tab)`,
       metric: new cloudwatch.MathExpression({
         expression: 'routerCron + harness',
         usingMetrics: {

--- a/infra/lib/agent-platform-stack.ts
+++ b/infra/lib/agent-platform-stack.ts
@@ -1861,41 +1861,26 @@ export class AgentPlatformStack extends cdk.Stack {
       defaultValue: 0,
     });
 
-    // Harness adapter writes AGENT_FAILURE_RECORD to the AgentCore log groups.
-    // The alpha agentcore CDK construct does not expose a typed log group
-    // handle, so we attach the metric filter to the conventional AgentCore
-    // CloudWatch path. Two paths exist (`/aws/bedrock/agentcore/*` and
-    // `/aws/bedrock-agentcore/*`); we attach to both as imports so the filter
-    // catches whichever the runtime ends up using.
+    // Harness adapter writes AGENT_FAILURE_RECORD to the AgentCore runtime log
+    // group. The current AgentCore alpha construct (and the build-and-push
+    // script's tail command) uses the `/aws/bedrock-agentcore/runtimes/...`
+    // convention. The alternate `/aws/bedrock/agentcore/...` path is from
+    // older alpha versions and the IAM policy above grants write access to
+    // both for forward compatibility, but only one log group exists at deploy
+    // time — referencing a non-existent path fails CFN with NotFound.
     //
-    // Each filter uses a DISTINCT metric name to avoid double-counting. The
-    // alarm below aggregates both via a MathExpression. At any given time only
-    // one log group will actually receive events; the other metric stays at 0.
-    const harnessLogGroup1 = logs.LogGroup.fromLogGroupName(
+    // We attach to the path the runtime actually uses today. If AWS ever
+    // renames it, the IAM grants already cover both paths and we can flip
+    // this reference; metric values would briefly stop until the rename.
+    const harnessLogGroup = logs.LogGroup.fromLogGroupName(
       this,
       'AgentCoreLogGroupRef',
       `/aws/bedrock-agentcore/runtimes/psd_agent_${environment}`,
     );
     new logs.MetricFilter(this, 'HarnessAgentFailureMetric', {
-      logGroup: harnessLogGroup1,
+      logGroup: harnessLogGroup,
       metricNamespace: failureMetricNamespace,
-      metricName: 'AgentFailuresHarness1',
-      filterPattern: logs.FilterPattern.literal('AGENT_FAILURE_RECORD'),
-      metricValue: '1',
-      defaultValue: 0,
-    });
-
-    // Attach to the alternate AgentCore log group path as well, so failures
-    // are captured regardless of which naming convention the runtime uses.
-    const harnessLogGroup2 = logs.LogGroup.fromLogGroupName(
-      this,
-      'AgentCoreLogGroupRef2',
-      `/aws/bedrock/agentcore/runtimes/psd_agent_${environment}`,
-    );
-    new logs.MetricFilter(this, 'HarnessAgentFailureMetric2', {
-      logGroup: harnessLogGroup2,
-      metricNamespace: failureMetricNamespace,
-      metricName: 'AgentFailuresHarness2',
+      metricName: 'AgentFailuresHarness',
       filterPattern: logs.FilterPattern.literal('AGENT_FAILURE_RECORD'),
       metricValue: '1',
       defaultValue: 0,
@@ -1906,19 +1891,15 @@ export class AgentPlatformStack extends cdk.Stack {
     // pager doesn't differentiate the two except by which alarm fired. Tune
     // via the env-specific config if dev noise becomes a problem.
     //
-    // The alarm uses a MathExpression to aggregate the three distinct metric
-    // names. Router and cron share `AgentFailures` (separate log groups, no
-    // double-counting). The two harness filters use distinct names because
-    // they cover two possible AgentCore log group naming conventions — at
-    // runtime only one will receive events, but if both did, using the same
-    // metric name would double-count each harness failure.
+    // Aggregates router/cron (shared `AgentFailures` metric, separate log
+    // groups so no double-counting) with the harness metric.
     const period = cdk.Duration.minutes(5);
     const failureRateAlarm = new cloudwatch.Alarm(this, 'AgentFailureRateAlarm', {
       alarmName: `psd-agent-failures-${environment}`,
       alarmDescription:
         'agent_failures table is filling up faster than expected — investigate via /admin/agents Failures tab',
       metric: new cloudwatch.MathExpression({
-        expression: 'routerCron + harness1 + harness2',
+        expression: 'routerCron + harness',
         usingMetrics: {
           routerCron: new cloudwatch.Metric({
             namespace: failureMetricNamespace,
@@ -1926,15 +1907,9 @@ export class AgentPlatformStack extends cdk.Stack {
             period,
             statistic: 'Sum',
           }),
-          harness1: new cloudwatch.Metric({
+          harness: new cloudwatch.Metric({
             namespace: failureMetricNamespace,
-            metricName: 'AgentFailuresHarness1',
-            period,
-            statistic: 'Sum',
-          }),
-          harness2: new cloudwatch.Metric({
-            namespace: failureMetricNamespace,
-            metricName: 'AgentFailuresHarness2',
+            metricName: 'AgentFailuresHarness',
             period,
             statistic: 'Sum',
           }),

--- a/infra/lib/constructs/security/service-role-factory.ts
+++ b/infra/lib/constructs/security/service-role-factory.ts
@@ -353,31 +353,22 @@ export class ServiceRoleFactory {
             },
           },
         }),
-        // Bucket operations - tag conditions enforce environment isolation.
+        // Bucket operations.
         //
-        // NOTE: `aws:ResourceTag` evaluation against an S3 bucket requires the
-        // principal to also be able to read the bucket's tags via
-        // s3:GetBucketTagging. Without it, IAM cannot resolve the tag values
-        // and the condition silently fails closed, denying the call. We grant
-        // GetBucketTagging unconditionally on the same bucket ARN so the
-        // tag-based isolation actually evaluates instead of blanket-denying
-        // every ListBucket request. (Pre-existing bug — see
-        // psd-agent-health-daily-dev s3:ListBucket denials May 2026.)
-        new iam.PolicyStatement({
-          effect: iam.Effect.ALLOW,
-          actions: ["s3:GetBucketTagging"],
-          resources: bucketArns,
-        }),
+        // No tag-based condition on the bucket-level statement: S3 does not
+        // honor `aws:ResourceTag` for s3:ListBucket / s3:GetBucketLocation
+        // (it's accepted in policy syntax but never resolves to a match),
+        // so attaching the condition causes every call to fail closed. The
+        // explicit `bucketArns` resource list already enforces the same
+        // environment isolation — a dev role only ever sees dev bucket ARNs
+        // (each Lambda's CDK definition passes its own scoped bucket name)
+        // so the tag check was redundant defense-in-depth that, in practice,
+        // broke the primary grant. Pre-existing bug — see
+        // psd-agent-health-daily-dev s3:ListBucket denials May 2026.
         new iam.PolicyStatement({
           effect: iam.Effect.ALLOW,
           actions: ["s3:ListBucket", "s3:GetBucketLocation"],
           resources: bucketArns,
-          conditions: {
-            StringEquals: {
-              "aws:ResourceTag/Environment": props.environment,
-              "aws:ResourceTag/ManagedBy": "cdk",
-            },
-          },
         }),
       ],
     })

--- a/infra/lib/constructs/security/service-role-factory.ts
+++ b/infra/lib/constructs/security/service-role-factory.ts
@@ -353,7 +353,21 @@ export class ServiceRoleFactory {
             },
           },
         }),
-        // Bucket operations - tag conditions enforce environment isolation
+        // Bucket operations - tag conditions enforce environment isolation.
+        //
+        // NOTE: `aws:ResourceTag` evaluation against an S3 bucket requires the
+        // principal to also be able to read the bucket's tags via
+        // s3:GetBucketTagging. Without it, IAM cannot resolve the tag values
+        // and the condition silently fails closed, denying the call. We grant
+        // GetBucketTagging unconditionally on the same bucket ARN so the
+        // tag-based isolation actually evaluates instead of blanket-denying
+        // every ListBucket request. (Pre-existing bug — see
+        // psd-agent-health-daily-dev s3:ListBucket denials May 2026.)
+        new iam.PolicyStatement({
+          effect: iam.Effect.ALLOW,
+          actions: ["s3:GetBucketTagging"],
+          resources: bucketArns,
+        }),
         new iam.PolicyStatement({
           effect: iam.Effect.ALLOW,
           actions: ["s3:ListBucket", "s3:GetBucketLocation"],

--- a/lib/db/schema/index.ts
+++ b/lib/db/schema/index.ts
@@ -142,6 +142,9 @@ export * from "./tables/agent-sessions";
 export * from "./tables/agent-feedback";
 export * from "./tables/agent-health-snapshots";
 export * from "./tables/agent-patterns";
+export * from "./tables/agent-failures";
+export * from "./tables/agent-pattern-scan-runs";
+export * from "./tables/agent-health-scan-runs";
 
 // ============================================
 // Agent Skills Platform (#910)

--- a/lib/db/schema/tables/agent-failures.ts
+++ b/lib/db/schema/tables/agent-failures.ts
@@ -1,0 +1,79 @@
+/**
+ * Agent Failures Table Schema
+ *
+ * Captures failures from every agent chokepoint (router Lambda, harness adapter,
+ * cron Lambda, agent self-report) so the /admin/agents dashboard can surface a
+ * single failure feed for triage. Migration 076.
+ */
+
+import {
+  bigint,
+  boolean,
+  index,
+  jsonb,
+  pgTable,
+  text,
+  timestamp,
+  varchar,
+} from "drizzle-orm/pg-core";
+
+export type AgentFailureSource =
+  | "router"
+  | "harness"
+  | "cron"
+  | "agent_self_report"
+  | "tool";
+
+export type AgentFailureSeverity = "error" | "warn" | "empty_response";
+
+export interface AgentFailureContext {
+  requestId?: string;
+  messageId?: string | number;
+  scheduledRunId?: number;
+  toolName?: string;
+  latencyMs?: number;
+  inputTokenCount?: number;
+  outputTokenCount?: number;
+  turn?: number;
+  invocationArn?: string;
+  // Additional free-form fields permitted; the column is JSONB.
+  [key: string]: unknown;
+}
+
+export const agentFailures = pgTable(
+  "agent_failures",
+  {
+    id: bigint("id", { mode: "number" })
+      .generatedAlwaysAsIdentity()
+      .primaryKey(),
+    occurredAt: timestamp("occurred_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    source: varchar("source", { length: 32 }).$type<AgentFailureSource>().notNull(),
+    severity: varchar("severity", { length: 16 })
+      .$type<AgentFailureSeverity>()
+      .notNull(),
+    userId: varchar("user_id", { length: 255 }),
+    sessionId: varchar("session_id", { length: 512 }),
+    scheduleName: varchar("schedule_name", { length: 255 }),
+    model: varchar("model", { length: 128 }),
+    errorClass: varchar("error_class", { length: 128 }),
+    errorMessage: text("error_message"),
+    stackExcerpt: text("stack_excerpt"),
+    context: jsonb("context").$type<AgentFailureContext>(),
+    acknowledged: boolean("acknowledged").notNull().default(false),
+    acknowledgedBy: varchar("acknowledged_by", { length: 255 }),
+    acknowledgedAt: timestamp("acknowledged_at", { withTimezone: true }),
+    notes: text("notes"),
+  },
+  (table) => [
+    index("idx_agent_failures_occurred_at").on(table.occurredAt),
+    index("idx_agent_failures_source").on(table.source, table.occurredAt),
+    index("idx_agent_failures_user").on(table.userId, table.occurredAt),
+    index("idx_agent_failures_unack").on(table.occurredAt),
+    index("idx_agent_failures_severity").on(table.severity, table.occurredAt),
+  ],
+);
+
+export type AgentFailureRow = typeof agentFailures.$inferSelect;
+export type NewAgentFailureRow = typeof agentFailures.$inferInsert;

--- a/lib/db/schema/tables/agent-failures.ts
+++ b/lib/db/schema/tables/agent-failures.ts
@@ -6,7 +6,7 @@
  * single failure feed for triage. Migration 076.
  */
 
-import { sql } from "drizzle-orm";
+import { desc, sql } from "drizzle-orm";
 import {
   bigint,
   boolean,
@@ -23,7 +23,8 @@ export type AgentFailureSource =
   | "harness"
   | "cron"
   | "agent_self_report"
-  | "tool";
+  | "tool"
+  | "other";
 
 export type AgentFailureSeverity = "error" | "warn" | "empty_response";
 
@@ -68,12 +69,14 @@ export const agentFailures = pgTable(
     notes: text("notes"),
   },
   (table) => [
-    index("idx_agent_failures_occurred_at").on(table.occurredAt),
-    index("idx_agent_failures_source").on(table.source, table.occurredAt),
-    index("idx_agent_failures_user").on(table.userId, table.occurredAt),
-    index("idx_agent_failures_unack").on(table.occurredAt).where(sql`acknowledged = false`),
-    index("idx_agent_failures_severity").on(table.severity, table.occurredAt),
-    index("idx_agent_failures_acked_at").on(table.acknowledgedAt).where(sql`acknowledged = true`),
+    // DESC matches the SQL migration (076) — all dashboard queries order by
+    // occurred_at DESC so the index avoids a backward scan.
+    index("idx_agent_failures_occurred_at").on(desc(table.occurredAt)),
+    index("idx_agent_failures_source").on(table.source, desc(table.occurredAt)),
+    index("idx_agent_failures_user").on(table.userId, desc(table.occurredAt)),
+    index("idx_agent_failures_unack").on(desc(table.occurredAt)).where(sql`acknowledged = false`),
+    index("idx_agent_failures_severity").on(table.severity, desc(table.occurredAt)),
+    index("idx_agent_failures_acked_at").on(desc(table.acknowledgedAt)).where(sql`acknowledged = true`),
   ],
 );
 

--- a/lib/db/schema/tables/agent-failures.ts
+++ b/lib/db/schema/tables/agent-failures.ts
@@ -6,6 +6,7 @@
  * single failure feed for triage. Migration 076.
  */
 
+import { sql } from "drizzle-orm";
 import {
   bigint,
   boolean,
@@ -70,8 +71,9 @@ export const agentFailures = pgTable(
     index("idx_agent_failures_occurred_at").on(table.occurredAt),
     index("idx_agent_failures_source").on(table.source, table.occurredAt),
     index("idx_agent_failures_user").on(table.userId, table.occurredAt),
-    index("idx_agent_failures_unack").on(table.occurredAt),
+    index("idx_agent_failures_unack").on(table.occurredAt).where(sql`acknowledged = false`),
     index("idx_agent_failures_severity").on(table.severity, table.occurredAt),
+    index("idx_agent_failures_acked_at").on(table.acknowledgedAt).where(sql`acknowledged = true`),
   ],
 );
 

--- a/lib/db/schema/tables/agent-health-scan-runs.ts
+++ b/lib/db/schema/tables/agent-health-scan-runs.ts
@@ -6,6 +6,7 @@
  * distinguishable from "Lambda never ran". Migration 076.
  */
 
+import { desc } from "drizzle-orm";
 import {
   bigint,
   date,
@@ -29,7 +30,7 @@ export const agentHealthScanRuns = pgTable(
     error: text("error"),
   },
   (table) => [
-    index("idx_agent_health_scan_runs_run_at").on(table.runAt),
+    index("idx_agent_health_scan_runs_run_at").on(desc(table.runAt)),
   ],
 );
 

--- a/lib/db/schema/tables/agent-health-scan-runs.ts
+++ b/lib/db/schema/tables/agent-health-scan-runs.ts
@@ -1,0 +1,36 @@
+/**
+ * Agent Health Scan Runs Table Schema
+ *
+ * Per-invocation audit of the daily health Lambda. Lets the admin dashboard
+ * surface "last successful run" so an empty `agent_health_snapshots` table is
+ * distinguishable from "Lambda never ran". Migration 076.
+ */
+
+import {
+  bigint,
+  date,
+  index,
+  integer,
+  pgTable,
+  text,
+  timestamp,
+} from "drizzle-orm/pg-core";
+
+export const agentHealthScanRuns = pgTable(
+  "agent_health_scan_runs",
+  {
+    id: bigint("id", { mode: "number" })
+      .generatedAlwaysAsIdentity()
+      .primaryKey(),
+    runAt: timestamp("run_at", { withTimezone: true }).notNull().defaultNow(),
+    snapshotDate: date("snapshot_date").notNull(),
+    usersTotal: integer("users_total").notNull().default(0),
+    abandoned: integer("abandoned").notNull().default(0),
+    error: text("error"),
+  },
+  (table) => [
+    index("idx_agent_health_scan_runs_run_at").on(table.runAt),
+  ],
+);
+
+export type AgentHealthScanRunRow = typeof agentHealthScanRuns.$inferSelect;

--- a/lib/db/schema/tables/agent-pattern-scan-runs.ts
+++ b/lib/db/schema/tables/agent-pattern-scan-runs.ts
@@ -6,6 +6,7 @@
  * the suppression threshold". Migration 076.
  */
 
+import { desc } from "drizzle-orm";
 import {
   bigint,
   index,
@@ -29,7 +30,7 @@ export const agentPatternScanRuns = pgTable(
     suppressed: integer("suppressed").notNull().default(0),
   },
   (table) => [
-    index("idx_agent_pattern_scan_runs_run_at").on(table.runAt),
+    index("idx_agent_pattern_scan_runs_run_at").on(desc(table.runAt)),
   ],
 );
 

--- a/lib/db/schema/tables/agent-pattern-scan-runs.ts
+++ b/lib/db/schema/tables/agent-pattern-scan-runs.ts
@@ -1,0 +1,36 @@
+/**
+ * Agent Pattern Scan Runs Table Schema
+ *
+ * Per-invocation audit of the weekly pattern scanner. Lets the admin dashboard
+ * distinguish "scanner never ran" from "scanner ran but everything was below
+ * the suppression threshold". Migration 076.
+ */
+
+import {
+  bigint,
+  index,
+  integer,
+  pgTable,
+  timestamp,
+  varchar,
+} from "drizzle-orm/pg-core";
+
+export const agentPatternScanRuns = pgTable(
+  "agent_pattern_scan_runs",
+  {
+    id: bigint("id", { mode: "number" })
+      .generatedAlwaysAsIdentity()
+      .primaryKey(),
+    runAt: timestamp("run_at", { withTimezone: true }).notNull().defaultNow(),
+    week: varchar("week", { length: 16 }).notNull(),
+    signalsTotal: integer("signals_total").notNull().default(0),
+    topicsTotal: integer("topics_total").notNull().default(0),
+    detected: integer("detected").notNull().default(0),
+    suppressed: integer("suppressed").notNull().default(0),
+  },
+  (table) => [
+    index("idx_agent_pattern_scan_runs_run_at").on(table.runAt),
+  ],
+);
+
+export type AgentPatternScanRunRow = typeof agentPatternScanRuns.$inferSelect;

--- a/tests/e2e/admin-agents.spec.ts
+++ b/tests/e2e/admin-agents.spec.ts
@@ -73,6 +73,7 @@ test.describe('Agent Dashboard — Admin', () => {
       'Usage',
       'Cost',
       'Adoption',
+      'Failures',
       'Health',
       'Safety',
       'Patterns',
@@ -83,6 +84,34 @@ test.describe('Agent Dashboard — Admin', () => {
       const trigger = page.locator('[role="tab"]').filter({ hasText: tab })
       await expect(trigger).toBeVisible({ timeout: 5000 })
     }
+  })
+
+  test('failures tab loads and shows table or empty state', async ({ page }) => {
+    await page.waitForSelector('[role="tab"][aria-selected="true"]', {
+      timeout: 10000,
+    })
+    const failuresTab = page
+      .locator('[role="tab"]')
+      .filter({ hasText: 'Failures' })
+    await failuresTab.click()
+    const card = page.locator('text=/Agent Failures/i').first()
+    await expect(card).toBeVisible({ timeout: 10000 })
+    // Either rows render OR the empty-state message shows
+    const emptyOrTable = page.locator(
+      'text=/No failures match these filters|Showing/i',
+    )
+    await expect(emptyOrTable.first()).toBeVisible({ timeout: 10000 })
+  })
+
+  test('failures filters are interactive', async ({ page }) => {
+    await page.waitForSelector('[role="tab"][aria-selected="true"]', {
+      timeout: 10000,
+    })
+    await page.locator('[role="tab"]').filter({ hasText: 'Failures' }).click()
+    // Acknowledge button starts disabled (no rows selected)
+    const ackBtn = page.locator('button').filter({ hasText: /Acknowledge \(0\)/ })
+    await expect(ackBtn).toBeVisible({ timeout: 10000 })
+    await expect(ackBtn).toBeDisabled()
   })
 
   test('clicking a tab switches content', async ({ page }) => {


### PR DESCRIPTION
## Summary

End-to-end agent failure capture so the `/admin/agents` Failures tab becomes the single pane of glass for triaging recurring problems instead of grepping CloudWatch. Also fixes the empty Health/Patterns sections by audit-logging every Lambda invocation and surfacing last-scan freshness directly in the dashboard.

Motivated by recurring incidents like the morning-brief reply *"I processed your message but had no response."* that previously left no queryable record anywhere except CloudWatch logs.

## What's new

### Capture (passive + agent-aware)
- **Router Lambda** — SQS rejected branch writes to `agent_failures`, emits structured `AGENT_FAILURE_RECORD` line for the metric filter
- **Cron Lambda** — mirrors `agent_scheduled_runs` error rows into `agent_failures`
- **Harness adapter (Python)** — empty-response, deadline-expired, websocket-error paths each call a new `record_failure()` helper (writes via boto3 RDS Data API, falls back to structured CloudWatch line)
- **Self-report skill** (`psd-failure-report`) — Node.js OpenClaw skill the agent calls before any apology reply (`Rule 10` added to `psd-rules`); 7-category enum (`missing_credentials`, `tool_error`, `tool_unavailable`, `data_not_found`, `ambiguous_request`, `task_incomplete`, `other`)

### UI
- New **Failures** tab — filters (range/source/severity/ack), expandable detail, multi-select acknowledge with operator notes, **Generate troubleshooting bundle** button that produces self-contained markdown copy-to-clipboard for paste-into-Claude root-cause analysis
- Bundle includes surrounding `agent_messages` for any failure with a session id (telemetry only — no message content per privacy contract)
- **Health** tab now shows last-scan timestamp + counts; empty state distinguishes "Lambda never ran" from "ran but produced 0 snapshots"
- **Patterns** tab same treatment with signals / topics / detected / suppressed counts; distinguishes suppression from Lambda failure

### Operational
- **Retention**: daily sweep at end of health Lambda — 90d acked, 180d unacked, env-overridable
- **CloudWatch alarm**: `MetricFilter` on `AGENT_FAILURE_RECORD` across router/cron/AgentCore log groups → custom metric → SNS alarm at ≥10/5min
- **Pattern scanner backfill**: handler accepts `{ week }` or `{ backfillWeeks: N }` so one manual invocation can populate historical weeks idempotently
- **CDK**: AgentCore runtime now exports explicit `DATABASE_NAME`

### Schema (migration 076)
| Table | Purpose |
|---|---|
| `agent_failures` | Cross-source failure log with ack workflow |
| `agent_pattern_scan_runs` | Per-invocation audit for pattern scanner |
| `agent_health_scan_runs` | Per-invocation audit for health Lambda |

All three have Drizzle schemas under `lib/db/schema/tables/` and are wired into the dashboard.

## Test plan

- [ ] `bun run typecheck` passes (already green)
- [ ] `bun run lint` passes (already green; 0 errors)
- [ ] CDK synth: `cd infra && bunx cdk synth AIStudio-AgentPlatformStack-Dev` succeeds
- [ ] Deploy `AIStudio-AgentPlatformStack-Dev` and verify migration 076 applied (psql `\d agent_failures`)
- [ ] Send a malformed SQS message in dev; row appears in `agent_failures` with `source='router'`
- [ ] Force a cron failure; row appears with `source='cron'` AND `agent_scheduled_runs.error_message` populated
- [ ] After agent image deploy: trigger a known-failing scenario (request with missing credential); row appears with `source='agent_self_report'`; agent reply acknowledges the failure
- [ ] Trigger an empty-response from harness; row appears with `source='harness', severity='empty_response'`
- [ ] `/admin/agents` Failures tab loads, filters work, expand shows full context, acknowledge persists
- [ ] Generate-bundle copies expected markdown to clipboard; pasting into Claude Code yields actionable triage
- [ ] Manually invoke `psd-agent-health-daily` once; `agent_health_snapshots` populated AND Health empty-state replaced with table; `agent_health_scan_runs` has a row
- [ ] Manually invoke `psd-agent-pattern-scanner` with `{"backfillWeeks":12}`; `agent_pattern_scan_runs` populated with 12 rows; Patterns tab shows last-scan banner
- [ ] Bedrock guardrails CLASSIC tier: confirm no regressions to existing alarms

## Operational follow-ups (post-merge)

After merge, run from your shell:
```
cd infra && bunx cdk deploy AIStudio-AgentPlatformStack-Dev
aws lambda invoke --function-name psd-agent-health-daily-dev --payload '{}' /tmp/h.json
aws lambda invoke --function-name psd-agent-pattern-scanner-dev --payload '{"backfillWeeks":12}' /tmp/p.json
cd infra/agent-image && ./build-and-push.sh
# Then redeploy with the new image tag/digest so the harness changes + new skill activate
```

## Out of scope

- Investigating why the user's second agent-built skill never registered into `psd_agent_skills` (DB query confirmed only 1 row exists; the table query is correct — separate registration-path bug)
- Cross-environment access policies for the new agent_failures table (inherits existing tag-based controls)