### PR TITLE
feat(agent-image): add psd-redrover skill (read-only Red Rover absence data)

### DIFF
--- a/infra/agent-image/skills/psd-redrover/SKILL.md
+++ b/infra/agent-image/skills/psd-redrover/SKILL.md
@@ -1,0 +1,147 @@
+---
+name: psd-redrover
+summary: Read-only access to PSD Red Rover absence and vacancy data — daily and weekly staff-attendance reporting.
+description: Query Red Rover absence-management data for Peninsula School District. Supports raw vacancy listings for a date range, daily summaries (all staff or certificated-only), and weekly trend reports. Strictly read-only — never creates, modifies, or deletes data in Red Rover. Authenticates with a single district-wide credential set fetched from AWS Secrets Manager via psd-credentials (shared scope).
+allowed-tools: Bash(node:*)
+---
+
+# psd-redrover
+
+Read-only access to Red Rover absence/vacancy data for PSD. The skill never performs POST/PUT/DELETE/PATCH calls — every HTTP request goes through a single `rrGet()` chokepoint in `lib/api.js`. There is no companion write helper; adding one would violate the read-only contract.
+
+**Identity.** Every command requires `--user <caller-email>`. Pass the email verbatim from the `[caller: Name <email>]` header in the user turn. The email is used only as the `--user` argument to `psd-credentials/get.js`; the credential itself is district-wide (shared scope), not per-user.
+
+**Credentials.** A single shared secret at `psd-agent-creds/{env}/shared/redrover_credentials` with shape `{"username":"...","password":"...","apiKey":"..."}`. The skill uses Basic Auth (`username` + `password`) for the `/organization` endpoint, then uses the dynamic `apiKey` returned there for vacancy calls. The static `apiKey` field is a fallback if Red Rover ever stops minting a dynamic one.
+
+If the credential is missing the skill exits non-zero with `error: "redrover_credentials_missing"` — an administrator must provision it out of band; users cannot register Red Rover credentials themselves.
+
+## Configuration
+
+- **Base URL:** `https://connect.redroverk12.com`
+- **Org:** Peninsula School District
+- **Auth:** HTTP Basic Auth + `apiKey` header (dynamic, from `/organization`)
+- **Rate limit:** 100 requests/minute (Red Rover server-side)
+
+## Commands
+
+### `get_organization` — validate credentials, return orgId + dynamic apiKey
+
+```bash
+node /opt/psd-skills/psd-redrover/get_organization.js --user <email>
+```
+
+Returns `{"orgId":..., "name":"...", "apiKey":"..."}`. Useful as a connectivity smoke test. Never include the `apiKey` in chat output — it's returned for tooling only.
+
+### `get_absences` — raw vacancy data for a date range
+
+```bash
+node /opt/psd-skills/psd-redrover/get_absences.js \
+  --user <email> \
+  --start <YYYY-MM-DD> \
+  --end <YYYY-MM-DD> \
+  [--filter filled|unfilled|all]
+```
+
+Maximum range: 31 days. Returns `{ start, end, filter, total, data: [...] }` where `data` is the raw vacancy records.
+
+### `get_daily_summary` — all-staff daily summary
+
+```bash
+node /opt/psd-skills/psd-redrover/get_daily_summary.js --user <email> [--date <date>]
+```
+
+`<date>` accepts: `today` (default), `yesterday`, day names (`monday`, `tuesday`, ...), `last <day>` (`last friday`, etc.), or an explicit `YYYY-MM-DD`.
+
+Output: counts by school, reason, and position type; filled/unfilled split; fill rate; full unfilled-positions list; full absence detail list.
+
+### `get_certificated_summary` — certificated-staff-only daily summary
+
+```bash
+node /opt/psd-skills/psd-redrover/get_certificated_summary.js --user <email> [--date <date>]
+```
+
+Same date options. Filters to position types `Teacher`, `ESA - Certificated`, `CTE - Teacher`. This is the most-requested report — focuses on classroom coverage.
+
+### `get_weekly_summary` — weekly trends (Mon–Fri)
+
+```bash
+node /opt/psd-skills/psd-redrover/get_weekly_summary.js --user <email> [--weeks-ago <n>]
+```
+
+`--weeks-ago 0` (default) = this week, `1` = last week, etc. (max 52). Returns daily breakdown, peak/slow days, fill rate, and trend annotations.
+
+## Common workflows
+
+| Question | Command |
+|----------|---------|
+| "How many teachers were out yesterday?" | `get_certificated_summary.js --user <email> --date yesterday` |
+| "Show unfilled positions for today" | `get_daily_summary.js --user <email>` (look at `unfilled_positions`) |
+| "Weekly absence trends" | `get_weekly_summary.js --user <email>` |
+| "Last week's summary" | `get_weekly_summary.js --user <email> --weeks-ago 1` |
+| "Unfilled subs Mon–Fri this week" | `get_absences.js --user <email> --start <Mon> --end <Fri> --filter unfilled` |
+
+## Output schemas
+
+### Daily summary (all staff)
+
+```json
+{
+  "date": "yesterday",
+  "date_iso": "2026-01-26",
+  "day_of_week": "Monday",
+  "full_date": "Monday, January 26, 2026",
+  "total_absences": 110,
+  "filled": 75,
+  "unfilled": 35,
+  "fill_rate": 68,
+  "by_school": { "PENINSULA HIGH SCHOOL": 13, "...": "..." },
+  "by_reason": { "SICK LV > 1 SICK": 54, "...": "..." },
+  "by_position_type": { "Teacher": 55, "Paraprofessional": 36 },
+  "unfilled_positions": [{ "school": "...", "position": "...", "employee": "...", "start": "...", "end": "..." }],
+  "absences": [{ "...": "..." }]
+}
+```
+
+### Weekly summary
+
+```json
+{
+  "week": "Jan 20-24, 2026",
+  "week_label": "this week",
+  "date_range": { "start": "2026-01-20", "end": "2026-01-24" },
+  "total_absences": 450,
+  "daily_average": 90,
+  "filled": 380,
+  "unfilled": 70,
+  "fill_rate": 84,
+  "peak_day": { "day": "Monday", "count": 120 },
+  "slow_day": { "day": "Friday", "count": 65 },
+  "by_day": { "Monday": 120, "Tuesday": 95, "Wednesday": 90, "Thursday": 80, "Friday": 65 },
+  "trends": [{ "type": "info", "message": "Monday had 120 absences (50%+ above average)" }]
+}
+```
+
+## Data fields (vacancy records)
+
+| Field | Meaning |
+|-------|---------|
+| `absenceDetail.employee` | Employee who is absent |
+| `absenceDetail.reasons[0].name` | Reason category (SICK, PERSONAL, etc.) |
+| `location.name` | School name |
+| `position.title` | Position title |
+| `position.positionType.name` | Position category (Teacher, Paraprofessional, etc.) |
+| `substitute` | If present, position is filled |
+| `start` / `end` | Absence time range |
+| `needsReplacement` | Whether a sub is required |
+
+## Schools in PSD (common location names)
+
+PENINSULA HIGH SCHOOL, GIG HARBOR HIGH SCHOOL, HENDERSON BAY HIGH SCHOOL, GOODMAN MIDDLE SCHOOL, HARBOR RIDGE MIDDLE SCHOOL, KEY PENINSULA MIDDLE SCHOOL, KOPACHUCK MIDDLE SCHOOL, ARTONDALE ELEMENTARY SCHOOL, DISCOVERY ELEMENTARY SCHOOL, EVERGREEN ELEMENTARY SCHOOL, HARBOR HEIGHTS ELEMENTARY SCHOOL, MINTER CREEK ELEMENTARY SCHOOL, PIONEER ELEMENTARY SCHOOL, PURDY ELEMENTARY SCHOOL, SWIFT WATER ELEMENTARY SCHOOL, VAUGHN ELEMENTARY SCHOOL, VOYAGER ELEMENTARY SCHOOL.
+
+## Read-only enforcement
+
+- All HTTP traffic flows through `rrGet()` in `lib/api.js`. There is no `rrPost`/`rrPut`/`rrDelete`.
+- The skill performs **no** filesystem writes (no `fs.writeFile`, `fs.appendFile`, `fs.mkdir`, `fs.unlink`, etc.).
+- The only `child_process` invocation is `node psd-credentials/get.js` — never `put.js`.
+- `/opt/psd-skills` is `chmod a-w` at container build time; the agent process cannot modify the skill at runtime.
+- Credential values are kept in module-scope memory only — never logged, echoed, or persisted to workspace/S3.

--- a/infra/agent-image/skills/psd-redrover/SKILL.md
+++ b/infra/agent-image/skills/psd-redrover/SKILL.md
@@ -24,13 +24,13 @@ If the credential is missing the skill exits non-zero with `error: "redrover_cre
 
 ## Commands
 
-### `get_organization` — validate credentials, return orgId + dynamic apiKey
+### `get_organization` — validate credentials, return orgId
 
 ```bash
 node /opt/psd-skills/psd-redrover/get_organization.js --user <email>
 ```
 
-Returns `{"orgId":..., "name":"...", "apiKey":"..."}`. Useful as a connectivity smoke test. Never include the `apiKey` in chat output — it's returned for tooling only.
+Returns `{"orgId":..., "name":"..."}`. Useful as a connectivity smoke test. The apiKey is not included in output to prevent accidental credential exposure — downstream commands fetch it internally.
 
 ### `get_absences` — raw vacancy data for a date range
 

--- a/infra/agent-image/skills/psd-redrover/get_absences.js
+++ b/infra/agent-image/skills/psd-redrover/get_absences.js
@@ -31,8 +31,10 @@ const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
   const startMs = Date.parse(`${startDate}T00:00:00Z`);
   const endMs = Date.parse(`${endDate}T00:00:00Z`);
   if (!(startMs <= endMs)) fail('--end must be on or after --start', 'bad_args');
-  if ((endMs - startMs) / (1000 * 60 * 60 * 24) > 31) {
-    fail('Date range exceeds 31-day maximum', 'bad_args');
+  // Inclusive day count: end - start + 1 day. Allow up to 31 inclusive days.
+  // (endMs - startMs) / day gives the gap; 30 = 31 inclusive days (Jan 1..Jan 31).
+  if ((endMs - startMs) / (1000 * 60 * 60 * 24) >= 31) {
+    fail('Date range exceeds 31-day maximum (inclusive)', 'bad_args');
   }
 
   try {

--- a/infra/agent-image/skills/psd-redrover/get_absences.js
+++ b/infra/agent-image/skills/psd-redrover/get_absences.js
@@ -1,0 +1,47 @@
+#!/usr/bin/env node
+'use strict';
+
+// Fetch raw Red Rover vacancy/absence records for a date range.
+// Usage:
+//   node get_absences.js --user <email> --start <YYYY-MM-DD> --end <YYYY-MM-DD> [--filter filled|unfilled|all]
+// Max date range: 31 days. Read-only.
+
+const {
+  parseArgs, requireUser, getCredentials, getOrganization, getVacancyDetails, emit, fail,
+} = require('./lib/api.js');
+
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+(async () => {
+  const args = parseArgs(process.argv);
+  const user = requireUser(args);
+  const startDate = args.start;
+  const endDate = args.end;
+  const filledFilter = args.filter || 'all';
+
+  if (!startDate || startDate === true || !endDate || endDate === true) {
+    fail('--start and --end are required (YYYY-MM-DD)', 'bad_args');
+  }
+  if (!DATE_RE.test(startDate) || !DATE_RE.test(endDate)) {
+    fail('Dates must be in YYYY-MM-DD format', 'bad_args');
+  }
+  if (!['filled', 'unfilled', 'all'].includes(filledFilter)) {
+    fail('--filter must be one of: filled, unfilled, all', 'bad_args');
+  }
+  const startMs = Date.parse(`${startDate}T00:00:00Z`);
+  const endMs = Date.parse(`${endDate}T00:00:00Z`);
+  if (!(startMs <= endMs)) fail('--end must be on or after --start', 'bad_args');
+  if ((endMs - startMs) / (1000 * 60 * 60 * 24) > 31) {
+    fail('Date range exceeds 31-day maximum', 'bad_args');
+  }
+
+  try {
+    const creds = getCredentials(user);
+    const org = await getOrganization(creds);
+    const result = await getVacancyDetails(org.orgId, org.apiKey, creds, startDate, endDate, filledFilter);
+    if (result.error) fail(result.error, 'redrover_api_error');
+    emit({ start: startDate, end: endDate, filter: filledFilter, total: result.total, data: result.data });
+  } catch (err) {
+    fail(err.message, 'redrover_absences_failed');
+  }
+})();

--- a/infra/agent-image/skills/psd-redrover/get_certificated_summary.js
+++ b/infra/agent-image/skills/psd-redrover/get_certificated_summary.js
@@ -1,0 +1,81 @@
+#!/usr/bin/env node
+'use strict';
+
+// Daily Red Rover absence summary, certificated staff only (Teacher, ESA - Certificated, CTE - Teacher).
+// Usage: node get_certificated_summary.js --user <email> [--date today|yesterday|monday|"last friday"|YYYY-MM-DD]
+// Read-only.
+
+const {
+  parseArgs, requireUser, getCredentials, getOrganization, getVacancyDetails, parseDate, emit, fail,
+} = require('./lib/api.js');
+
+const CERTIFICATED_TYPES = new Set(['Teacher', 'ESA - Certificated', 'CTE - Teacher']);
+
+function buildSummary(vacancies, dateLabel, dateStr) {
+  const dateObj = new Date(`${dateStr}T12:00:00`);
+  const dayOfWeek = dateObj.toLocaleDateString('en-US', { weekday: 'long' });
+  const fullDate = dateObj.toLocaleDateString('en-US', {
+    weekday: 'long', year: 'numeric', month: 'long', day: 'numeric',
+  });
+
+  const cert = vacancies.filter(v => CERTIFICATED_TYPES.has(v.position?.positionType?.name));
+  const filled = cert.filter(v => v.substitute).length;
+  const unfilled = cert.length - filled;
+
+  const summary = {
+    date: dateLabel,
+    date_iso: dateStr,
+    day_of_week: dayOfWeek,
+    full_date: fullDate,
+    staff_type: 'Certificated Only',
+    total_absences: cert.length,
+    filled,
+    unfilled,
+    fill_rate: cert.length > 0 ? Math.round((filled / cert.length) * 100) : 100,
+    by_school: Object.create(null),
+    by_reason: Object.create(null),
+    by_position: Object.create(null),
+    unfilled_positions: [],
+  };
+
+  for (const v of cert) {
+    const school = v.location?.name || 'Unknown';
+    const reason = v.absenceDetail?.reasons?.[0]?.name || 'Unknown';
+    const position = v.position?.title || 'Unknown';
+    summary.by_school[school] = (summary.by_school[school] || 0) + 1;
+    summary.by_reason[reason] = (summary.by_reason[reason] || 0) + 1;
+    summary.by_position[position] = (summary.by_position[position] || 0) + 1;
+    if (!v.substitute) {
+      summary.unfilled_positions.push({
+        school,
+        position,
+        employee: `${v.absenceDetail?.employee?.firstName || ''} ${v.absenceDetail?.employee?.lastName || ''}`.trim(),
+        start: v.start,
+        end: v.end,
+      });
+    }
+  }
+
+  const sortDesc = obj => Object.fromEntries(Object.entries(obj).sort((a, b) => b[1] - a[1]));
+  summary.by_school = sortDesc(summary.by_school);
+  summary.by_reason = sortDesc(summary.by_reason);
+  summary.by_position = sortDesc(summary.by_position);
+
+  return summary;
+}
+
+(async () => {
+  const args = parseArgs(process.argv);
+  const user = requireUser(args);
+  const dateInfo = parseDate(args.date || args._positional[0]);
+
+  try {
+    const creds = getCredentials(user);
+    const org = await getOrganization(creds);
+    const result = await getVacancyDetails(org.orgId, org.apiKey, creds, dateInfo.date, dateInfo.date);
+    if (result.error) fail(result.error, 'redrover_api_error');
+    emit(buildSummary(result.data, dateInfo.label, dateInfo.date));
+  } catch (err) {
+    fail(err.message, 'redrover_certificated_failed');
+  }
+})();

--- a/infra/agent-image/skills/psd-redrover/get_daily_summary.js
+++ b/infra/agent-image/skills/psd-redrover/get_daily_summary.js
@@ -1,0 +1,94 @@
+#!/usr/bin/env node
+'use strict';
+
+// Daily Red Rover absence summary (all staff).
+// Usage: node get_daily_summary.js --user <email> [--date today|yesterday|monday|"last friday"|YYYY-MM-DD]
+// Read-only.
+
+const {
+  parseArgs, requireUser, getCredentials, getOrganization, getVacancyDetails, parseDate, emit, fail,
+} = require('./lib/api.js');
+
+function buildSummary(vacancies, dateLabel, dateStr) {
+  const dateObj = new Date(`${dateStr}T12:00:00`);
+  const dayOfWeek = dateObj.toLocaleDateString('en-US', { weekday: 'long' });
+  const fullDate = dateObj.toLocaleDateString('en-US', {
+    weekday: 'long', year: 'numeric', month: 'long', day: 'numeric',
+  });
+
+  const summary = {
+    date: dateLabel,
+    date_iso: dateStr,
+    day_of_week: dayOfWeek,
+    full_date: fullDate,
+    total_absences: vacancies.length,
+    filled: 0,
+    unfilled: 0,
+    by_school: Object.create(null),
+    by_reason: Object.create(null),
+    by_position_type: Object.create(null),
+    unfilled_positions: [],
+    absences: [],
+  };
+
+  for (const v of vacancies) {
+    const isFilled = !!v.substitute;
+    const school = v.location?.name || 'Unknown';
+    const reason = v.absenceDetail?.reasons?.[0]?.name || 'Unknown';
+    const posType = v.position?.positionType?.name || 'Unknown';
+    const employee = `${v.absenceDetail?.employee?.firstName || ''} ${v.absenceDetail?.employee?.lastName || ''}`.trim();
+
+    if (isFilled) summary.filled++;
+    else {
+      summary.unfilled++;
+      summary.unfilled_positions.push({
+        school,
+        position: v.position?.title || 'Unknown',
+        employee,
+        start: v.start,
+        end: v.end,
+      });
+    }
+
+    summary.by_school[school] = (summary.by_school[school] || 0) + 1;
+    summary.by_reason[reason] = (summary.by_reason[reason] || 0) + 1;
+    summary.by_position_type[posType] = (summary.by_position_type[posType] || 0) + 1;
+
+    summary.absences.push({
+      employee,
+      school,
+      position: v.position?.title || 'Unknown',
+      reason,
+      filled: isFilled,
+      substitute: isFilled ? `${v.substitute?.firstName || ''} ${v.substitute?.lastName || ''}`.trim() : null,
+      start: v.start,
+      end: v.end,
+    });
+  }
+
+  const sortDesc = obj => Object.fromEntries(Object.entries(obj).sort((a, b) => b[1] - a[1]));
+  summary.by_school = sortDesc(summary.by_school);
+  summary.by_reason = sortDesc(summary.by_reason);
+  summary.by_position_type = sortDesc(summary.by_position_type);
+  summary.fill_rate = summary.total_absences > 0
+    ? Math.round((summary.filled / summary.total_absences) * 100)
+    : 100;
+
+  return summary;
+}
+
+(async () => {
+  const args = parseArgs(process.argv);
+  const user = requireUser(args);
+  const dateInfo = parseDate(args.date || args._positional[0]);
+
+  try {
+    const creds = getCredentials(user);
+    const org = await getOrganization(creds);
+    const result = await getVacancyDetails(org.orgId, org.apiKey, creds, dateInfo.date, dateInfo.date);
+    if (result.error) fail(result.error, 'redrover_api_error');
+    emit(buildSummary(result.data, dateInfo.label, dateInfo.date));
+  } catch (err) {
+    fail(err.message, 'redrover_daily_failed');
+  }
+})();

--- a/infra/agent-image/skills/psd-redrover/get_organization.js
+++ b/infra/agent-image/skills/psd-redrover/get_organization.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 'use strict';
 
-// Validate Red Rover credentials and return organization info (orgId + dynamic apiKey).
+// Validate Red Rover credentials and return organization info (orgId + name).
 // Usage: node get_organization.js --user <email>
 // Read-only.
 
@@ -13,7 +13,9 @@ const { parseArgs, requireUser, getCredentials, getOrganization, emit, fail } = 
   try {
     const creds = getCredentials(user);
     const org = await getOrganization(creds);
-    emit({ orgId: org.orgId, name: org.raw?.name || null, apiKey: org.apiKey });
+    // Intentionally omit apiKey — downstream commands fetch it internally,
+    // and including it here risks accidental credential exposure in chat.
+    emit({ orgId: org.orgId, name: org.raw?.name || null });
   } catch (err) {
     fail(err.message, 'redrover_org_failed');
   }

--- a/infra/agent-image/skills/psd-redrover/get_organization.js
+++ b/infra/agent-image/skills/psd-redrover/get_organization.js
@@ -1,0 +1,20 @@
+#!/usr/bin/env node
+'use strict';
+
+// Validate Red Rover credentials and return organization info (orgId + dynamic apiKey).
+// Usage: node get_organization.js --user <email>
+// Read-only.
+
+const { parseArgs, requireUser, getCredentials, getOrganization, emit, fail } = require('./lib/api.js');
+
+(async () => {
+  const args = parseArgs(process.argv);
+  const user = requireUser(args);
+  try {
+    const creds = getCredentials(user);
+    const org = await getOrganization(creds);
+    emit({ orgId: org.orgId, name: org.raw?.name || null, apiKey: org.apiKey });
+  } catch (err) {
+    fail(err.message, 'redrover_org_failed');
+  }
+})();

--- a/infra/agent-image/skills/psd-redrover/get_weekly_summary.js
+++ b/infra/agent-image/skills/psd-redrover/get_weekly_summary.js
@@ -9,8 +9,14 @@ const {
   parseArgs, requireUser, getCredentials, getOrganization, getVacancyDetails, getWeekRange, emit, fail,
 } = require('./lib/api.js');
 
-const DAY_NAMES = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
 const SCHOOL_DAYS = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday'];
+
+// Use Intl.DateTimeFormat with explicit timezone to avoid UTC-shift bugs.
+// The container may run in UTC; PSD is always America/Los_Angeles.
+const DAY_FORMATTER = new Intl.DateTimeFormat('en-US', {
+  weekday: 'long',
+  timeZone: 'America/Los_Angeles',
+});
 
 function buildWeeklySummary(vacancies, weekRange) {
   const summary = {
@@ -38,8 +44,7 @@ function buildWeeklySummary(vacancies, weekRange) {
   }
 
   for (const v of vacancies) {
-    const start = new Date(v.start);
-    const dayOfWeek = DAY_NAMES[start.getDay()];
+    const dayOfWeek = DAY_FORMATTER.format(new Date(v.start));
     const isFilled = !!v.substitute;
 
     if (Object.prototype.hasOwnProperty.call(summary.by_day, dayOfWeek)) {
@@ -60,6 +65,8 @@ function buildWeeklySummary(vacancies, weekRange) {
     summary.by_position_type[posType] = (summary.by_position_type[posType] || 0) + 1;
   }
 
+  // Intentionally divide by 5 (full school week) even on partial weeks so
+  // cross-week trend comparisons use a consistent denominator.
   summary.daily_average = Math.round((summary.total_absences / SCHOOL_DAYS.length) * 10) / 10;
   summary.fill_rate = summary.total_absences > 0
     ? Math.round((summary.filled / summary.total_absences) * 100)

--- a/infra/agent-image/skills/psd-redrover/get_weekly_summary.js
+++ b/infra/agent-image/skills/psd-redrover/get_weekly_summary.js
@@ -1,0 +1,115 @@
+#!/usr/bin/env node
+'use strict';
+
+// Weekly Red Rover absence summary and trends (Mon–Fri).
+// Usage: node get_weekly_summary.js --user <email> [--weeks-ago 0|1|2|...]
+// Read-only.
+
+const {
+  parseArgs, requireUser, getCredentials, getOrganization, getVacancyDetails, getWeekRange, emit, fail,
+} = require('./lib/api.js');
+
+const DAY_NAMES = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
+const SCHOOL_DAYS = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday'];
+
+function buildWeeklySummary(vacancies, weekRange) {
+  const summary = {
+    week: weekRange.rangeLabel,
+    week_label: weekRange.label,
+    date_range: { start: weekRange.start, end: weekRange.end },
+    total_absences: vacancies.length,
+    daily_average: 0,
+    filled: 0,
+    unfilled: 0,
+    fill_rate: 0,
+    peak_day: null,
+    slow_day: null,
+    by_day: Object.create(null),
+    by_school: Object.create(null),
+    by_reason: Object.create(null),
+    by_position_type: Object.create(null),
+    daily_details: Object.create(null),
+    trends: [],
+  };
+
+  for (const day of SCHOOL_DAYS) {
+    summary.by_day[day] = 0;
+    summary.daily_details[day] = { total: 0, filled: 0, unfilled: 0 };
+  }
+
+  for (const v of vacancies) {
+    const start = new Date(v.start);
+    const dayOfWeek = DAY_NAMES[start.getDay()];
+    const isFilled = !!v.substitute;
+
+    if (Object.prototype.hasOwnProperty.call(summary.by_day, dayOfWeek)) {
+      summary.by_day[dayOfWeek]++;
+      summary.daily_details[dayOfWeek].total++;
+      if (isFilled) summary.daily_details[dayOfWeek].filled++;
+      else summary.daily_details[dayOfWeek].unfilled++;
+    }
+
+    if (isFilled) summary.filled++;
+    else summary.unfilled++;
+
+    const school = v.location?.name || 'Unknown';
+    const reason = v.absenceDetail?.reasons?.[0]?.name || 'Unknown';
+    const posType = v.position?.positionType?.name || 'Unknown';
+    summary.by_school[school] = (summary.by_school[school] || 0) + 1;
+    summary.by_reason[reason] = (summary.by_reason[reason] || 0) + 1;
+    summary.by_position_type[posType] = (summary.by_position_type[posType] || 0) + 1;
+  }
+
+  summary.daily_average = Math.round((summary.total_absences / SCHOOL_DAYS.length) * 10) / 10;
+  summary.fill_rate = summary.total_absences > 0
+    ? Math.round((summary.filled / summary.total_absences) * 100)
+    : 100;
+
+  const dayEntries = Object.entries(summary.by_day).filter(([, c]) => c > 0);
+  if (dayEntries.length > 0) {
+    const sorted = dayEntries.sort((a, b) => b[1] - a[1]);
+    summary.peak_day = { day: sorted[0][0], count: sorted[0][1] };
+    summary.slow_day = { day: sorted[sorted.length - 1][0], count: sorted[sorted.length - 1][1] };
+  }
+
+  const sortDesc = obj => Object.fromEntries(Object.entries(obj).sort((a, b) => b[1] - a[1]));
+  summary.by_school = sortDesc(summary.by_school);
+  summary.by_reason = sortDesc(summary.by_reason);
+  summary.by_position_type = sortDesc(summary.by_position_type);
+
+  if (summary.fill_rate < 80) {
+    summary.trends.push({
+      type: 'warning',
+      message: `Low fill rate (${summary.fill_rate}%) - ${summary.unfilled} unfilled positions`,
+    });
+  }
+  if (summary.peak_day && summary.peak_day.count > summary.daily_average * 1.5) {
+    summary.trends.push({
+      type: 'info',
+      message: `${summary.peak_day.day} had ${summary.peak_day.count} absences (50%+ above average)`,
+    });
+  }
+
+  return summary;
+}
+
+(async () => {
+  const args = parseArgs(process.argv);
+  const user = requireUser(args);
+  const weeksAgoRaw = args.weeks_ago ?? args._positional[0] ?? '0';
+  const weeksAgo = Number.parseInt(weeksAgoRaw, 10);
+  if (!Number.isFinite(weeksAgo) || weeksAgo < 0 || weeksAgo > 52) {
+    fail('--weeks-ago must be an integer between 0 and 52', 'bad_args');
+  }
+  const weekRange = getWeekRange(weeksAgo);
+
+  try {
+    const creds = getCredentials(user);
+    const org = await getOrganization(creds);
+    const result = await getVacancyDetails(org.orgId, org.apiKey, creds, weekRange.start, weekRange.end);
+    if (result.error) fail(result.error, 'redrover_api_error');
+    emit(buildWeeklySummary(result.data, weekRange));
+  } catch (err) {
+    fail(err.message, 'redrover_weekly_failed');
+  }
+})();

--- a/infra/agent-image/skills/psd-redrover/lib/api.js
+++ b/infra/agent-image/skills/psd-redrover/lib/api.js
@@ -89,6 +89,7 @@ function getCredentials(userEmail) {
     ], {
       encoding: 'utf8',
       stdio: ['ignore', 'pipe', 'inherit'],
+      timeout: 10_000,
     });
   } catch (err) {
     fail(
@@ -150,9 +151,10 @@ async function rrGet(urlOrPath, creds, extraHeaders = {}) {
   const url = urlOrPath.startsWith('http') ? urlOrPath : `${BASE_URL}${urlOrPath}`;
   const resp = await fetch(url, {
     method: 'GET',
+    signal: AbortSignal.timeout(30_000),
     headers: {
       Authorization: basicAuthHeader(creds.username, creds.password),
-      'Content-Type': 'application/json',
+      Accept: 'application/json',
       ...extraHeaders,
     },
   });
@@ -215,15 +217,26 @@ async function getVacancyDetails(orgId, apiKey, creds, startDate, endDate, fille
     if (!result.hasMoreData) break;
     page++;
     // Defensive ceiling to prevent runaway loops on a misbehaving API.
-    if (page > 200) break;
+    // Return an explicit error so callers know results are incomplete.
+    if (page > 200) {
+      return { error: 'Query exceeded maximum page limit (200). Please narrow the date range for complete results.', status: 400 };
+    }
   }
   return { data: allData, total: allData.length };
 }
 
 // ---------- Date helpers ----------
 
+/**
+ * Format a Date as YYYY-MM-DD using local time components.
+ * Previous implementation used toISOString() which converts to UTC first —
+ * after 5 PM Pacific (UTC-7/-8), "today" would format as tomorrow's date.
+ */
 function formatDate(date) {
-  return date.toISOString().split('T')[0];
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, '0');
+  const d = String(date.getDate()).padStart(2, '0');
+  return `${y}-${m}-${d}`;
 }
 
 const DAY_NAMES = ['sunday', 'monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday'];

--- a/infra/agent-image/skills/psd-redrover/lib/api.js
+++ b/infra/agent-image/skills/psd-redrover/lib/api.js
@@ -1,0 +1,321 @@
+/**
+ * Shared helpers for the psd-redrover OpenClaw skill.
+ *
+ * READ-ONLY contract:
+ *   - Every HTTP call goes through rrGet() — GET only, no method override.
+ *   - No fs.write*, no child_process other than psd-credentials/get.js.
+ *   - Credential values are held in module-scope memory only and never
+ *     written to disk, workspace, or chat.
+ *
+ * Authenticates with a single district-wide credential set fetched on
+ * demand from psd-credentials at:
+ *   psd-agent-creds/{env}/shared/redrover_credentials
+ * Secret value shape: {"username":"...","password":"...","apiKey":"..."}
+ *
+ * The static apiKey is currently unused at runtime — the Red Rover
+ * /api/v1/organization endpoint mints a dynamic apiKey on each call —
+ * but it's stored alongside username/password for parity with the
+ * upstream secrets.js and 1Password entry, and is wired through as a
+ * fallback if the org call ever stops returning one.
+ */
+
+'use strict';
+
+const { execFileSync } = require('node:child_process');
+const path = require('node:path');
+
+const BASE_URL = 'https://connect.redroverk12.com';
+const CREDENTIALS_GET = path.resolve(__dirname, '..', '..', 'psd-credentials', 'get.js');
+
+const EMAIL_RE = /^[^\s@/]+@[^\s@/]+\.[^\s@/]+$/;
+
+function fail(message, code = 'error') {
+  process.stderr.write(`Error: ${message}\n`);
+  process.stdout.write(JSON.stringify({ error: code, message }) + '\n');
+  process.exit(1);
+}
+
+function emit(obj) {
+  process.stdout.write(JSON.stringify(obj, null, 2) + '\n');
+}
+
+function parseArgs(argv) {
+  const args = { _positional: [] };
+  for (let i = 2; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === '--help' || arg === '-h') {
+      args.help = true;
+      continue;
+    }
+    if (!arg.startsWith('--')) {
+      args._positional.push(arg);
+      continue;
+    }
+    const key = arg.slice(2).replace(/-/g, '_');
+    const next = argv[i + 1];
+    if (!next || next.startsWith('--')) {
+      args[key] = true;
+    } else {
+      args[key] = next;
+      i++;
+    }
+  }
+  return args;
+}
+
+function requireUser(args) {
+  if (typeof args.user !== 'string' || !EMAIL_RE.test(args.user)) {
+    fail('--user is required and must be a valid email address', 'bad_args');
+  }
+  return args.user;
+}
+
+let _credentialsCache = null;
+
+/**
+ * Fetch the shared Red Rover credential bundle from psd-credentials.
+ * Cached for the process lifetime. Never logged, never echoed.
+ */
+function getCredentials(userEmail) {
+  if (_credentialsCache) return _credentialsCache;
+
+  let stdout = '';
+  try {
+    stdout = execFileSync('node', [
+      CREDENTIALS_GET,
+      '--user', userEmail,
+      '--name', 'redrover_credentials',
+      '--shared',
+    ], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'inherit'],
+    });
+  } catch (err) {
+    fail(
+      `redrover credentials not provisioned. Ask an administrator to create the shared secret at psd-agent-creds/<env>/shared/redrover_credentials with shape {"username","password","apiKey"}. (psd-credentials error: ${err.message})`,
+      'redrover_credentials_missing'
+    );
+  }
+
+  const lines = stdout.split('\n').filter((l) => l.trim().length > 0);
+  if (lines.length === 0) fail('psd-credentials returned no output', 'redrover_credentials_missing');
+
+  let parsed;
+  try {
+    parsed = JSON.parse(lines[lines.length - 1]);
+  } catch (err) {
+    fail(`psd-credentials returned non-JSON: ${err.message}`, 'redrover_credentials_missing');
+  }
+  if (parsed.error || !parsed.value) {
+    fail('psd-credentials returned no value', 'redrover_credentials_missing');
+  }
+
+  // Secret value is a JSON-encoded string; parse it once.
+  let creds;
+  try {
+    creds = JSON.parse(parsed.value);
+  } catch (err) {
+    fail(
+      'redrover_credentials secret value is not valid JSON. Expected shape: {"username","password","apiKey"}.',
+      'redrover_credentials_malformed'
+    );
+  }
+  if (!creds || typeof creds.username !== 'string' || typeof creds.password !== 'string') {
+    fail(
+      'redrover_credentials secret missing required fields. Expected shape: {"username","password","apiKey"}.',
+      'redrover_credentials_malformed'
+    );
+  }
+  _credentialsCache = {
+    username: creds.username,
+    password: creds.password,
+    apiKey: typeof creds.apiKey === 'string' ? creds.apiKey : null,
+  };
+  return _credentialsCache;
+}
+
+function basicAuthHeader(username, password) {
+  return 'Basic ' + Buffer.from(`${username}:${password}`).toString('base64');
+}
+
+/**
+ * Read-only HTTP chokepoint. All Red Rover API access in this skill
+ * goes through this function. There is no companion rrPost/rrPut —
+ * adding one would be a violation of the read-only contract.
+ *
+ * urlOrPath: absolute URL string OR a path beginning with '/'.
+ * headers: extra headers to merge in (Authorization is added here).
+ */
+async function rrGet(urlOrPath, creds, extraHeaders = {}) {
+  const url = urlOrPath.startsWith('http') ? urlOrPath : `${BASE_URL}${urlOrPath}`;
+  const resp = await fetch(url, {
+    method: 'GET',
+    headers: {
+      Authorization: basicAuthHeader(creds.username, creds.password),
+      'Content-Type': 'application/json',
+      ...extraHeaders,
+    },
+  });
+  if (!resp.ok) {
+    const body = await resp.text().catch(() => '');
+    return { __ok: false, status: resp.status, error: `Red Rover API error ${resp.status}: ${body.slice(0, 500)}` };
+  }
+  const json = await resp.json().catch(() => ({}));
+  return { __ok: true, status: resp.status, data: json };
+}
+
+let _orgCache = null;
+
+/**
+ * Get organization info (orgId + dynamic apiKey). Memoized per process.
+ * The dynamic apiKey is preferred; falls back to the static one stored
+ * in Secrets Manager if Red Rover ever stops returning it.
+ */
+async function getOrganization(creds) {
+  if (_orgCache) return _orgCache;
+  const resp = await rrGet('/api/v1/organization', creds);
+  if (!resp.__ok) {
+    throw new Error(resp.error);
+  }
+  const data = Array.isArray(resp.data) ? resp.data[0] : resp.data;
+  if (!data || !data.orgId) {
+    throw new Error('Red Rover /organization response missing orgId');
+  }
+  const apiKey = data.apiKey || creds.apiKey;
+  if (!apiKey) {
+    throw new Error('Red Rover did not return an apiKey and no static apiKey is provisioned in Secrets Manager');
+  }
+  _orgCache = { orgId: data.orgId, apiKey, raw: data };
+  return _orgCache;
+}
+
+/**
+ * Fetch all pages of /Vacancy/details for a date range, optionally
+ * filtered by filled/unfilled status. Read-only; uses rrGet under the
+ * hood. Returns { data: [...] } on success or { error } on API failure.
+ */
+async function getVacancyDetails(orgId, apiKey, creds, startDate, endDate, filledFilter) {
+  const url = new URL(`${BASE_URL}/api/v1/${orgId}/Vacancy/details`);
+  url.searchParams.set('fromDate', `${startDate}T00:00:00Z`);
+  url.searchParams.set('toDate', `${endDate}T23:59:59Z`);
+  url.searchParams.set('pageSize', '100');
+  if (filledFilter === 'filled') url.searchParams.set('filled', 'true');
+  else if (filledFilter === 'unfilled') url.searchParams.set('filled', 'false');
+
+  let allData = [];
+  let page = 1;
+  while (true) {
+    url.searchParams.set('page', String(page));
+    const resp = await rrGet(url.toString(), creds, { apiKey });
+    if (!resp.__ok) {
+      return { error: resp.error, status: resp.status };
+    }
+    const result = resp.data || {};
+    allData = allData.concat(result.data || []);
+    if (!result.hasMoreData) break;
+    page++;
+    // Defensive ceiling to prevent runaway loops on a misbehaving API.
+    if (page > 200) break;
+  }
+  return { data: allData, total: allData.length };
+}
+
+// ---------- Date helpers ----------
+
+function formatDate(date) {
+  return date.toISOString().split('T')[0];
+}
+
+const DAY_NAMES = ['sunday', 'monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday'];
+
+/**
+ * Parse a date argument into { date: 'YYYY-MM-DD', label: '...' }.
+ * Supports: undefined/today, yesterday, day names, "last <day>",
+ * and explicit YYYY-MM-DD.
+ */
+function parseDate(dateArg) {
+  const now = new Date();
+  if (!dateArg || dateArg === 'today') {
+    return { date: formatDate(now), label: 'today' };
+  }
+  if (dateArg === 'yesterday') {
+    const y = new Date(now);
+    y.setDate(y.getDate() - 1);
+    return { date: formatDate(y), label: 'yesterday' };
+  }
+  const lower = String(dateArg).toLowerCase();
+
+  if (lower.startsWith('last ')) {
+    const dayName = lower.slice(5).trim();
+    const targetDay = DAY_NAMES.indexOf(dayName);
+    if (targetDay !== -1) {
+      const currentDay = now.getDay();
+      let daysBack = currentDay - targetDay;
+      if (daysBack <= 0) daysBack += 7;
+      const t = new Date(now);
+      t.setDate(t.getDate() - daysBack);
+      return {
+        date: formatDate(t),
+        label: `last ${dayName.charAt(0).toUpperCase() + dayName.slice(1)}`,
+      };
+    }
+  }
+
+  const justDay = DAY_NAMES.indexOf(lower);
+  if (justDay !== -1) {
+    const currentDay = now.getDay();
+    let daysBack = currentDay - justDay;
+    if (daysBack < 0) daysBack += 7;
+    if (daysBack === 0) daysBack = 7;
+    const t = new Date(now);
+    t.setDate(t.getDate() - daysBack);
+    return {
+      date: formatDate(t),
+      label: t.toLocaleDateString('en-US', { weekday: 'long', month: 'short', day: 'numeric' }),
+    };
+  }
+
+  const d = new Date(dateArg);
+  if (isNaN(d.getTime())) {
+    fail(`Could not parse date: ${dateArg}`, 'bad_args');
+  }
+  return {
+    date: formatDate(d),
+    label: d.toLocaleDateString('en-US', { weekday: 'long', month: 'short', day: 'numeric' }),
+  };
+}
+
+/**
+ * Calculate a school-week range (Mon–Fri) offset by `weeksAgo`.
+ */
+function getWeekRange(weeksAgo = 0) {
+  const now = new Date();
+  const currentDay = now.getDay();
+  const monday = new Date(now);
+  const daysFromMonday = currentDay === 0 ? 6 : currentDay - 1;
+  monday.setDate(monday.getDate() - daysFromMonday - weeksAgo * 7);
+  const friday = new Date(monday);
+  friday.setDate(friday.getDate() + 4);
+  const fmtLabel = d => d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+  return {
+    start: formatDate(monday),
+    end: formatDate(friday),
+    label: weeksAgo === 0 ? 'this week' : weeksAgo === 1 ? 'last week' : `${weeksAgo} weeks ago`,
+    rangeLabel: `${fmtLabel(monday)}-${fmtLabel(friday)}, ${monday.getFullYear()}`,
+  };
+}
+
+module.exports = {
+  BASE_URL,
+  fail,
+  emit,
+  parseArgs,
+  requireUser,
+  getCredentials,
+  rrGet,
+  getOrganization,
+  getVacancyDetails,
+  formatDate,
+  parseDate,
+  getWeekRange,
+};

--- a/infra/agent-image/skills/psd-redrover/package.json
+++ b/infra/agent-image/skills/psd-redrover/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "psd-redrover",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Read-only Red Rover absence-management skill for PSD agent",
+  "dependencies": {}
+}


### PR DESCRIPTION
## Summary

- Ports the upstream `redrover-manager` skill (psd-claude-plugins) into the bundled-skill path at `infra/agent-image/skills/psd-redrover/` so the AgentCore container can query Red Rover absence/vacancy data without relying on the external plugin or hardcoded local secrets.
- Strictly read-only: every HTTP call flows through a single `rrGet()` chokepoint in `lib/api.js`; no companion write helper exists. No filesystem writes. Only `child_process` call is `node psd-credentials/get.js` (never `put.js`).
- Single district-wide credential bundle stored at `psd-agent-creds/{env}/shared/redrover_credentials` (shape `{username, password, apiKey}`), fetched via `psd-credentials/get.js --shared`, cached in module-scope memory only.

## Commands

All require `--user <caller-email>` (passed verbatim from the `[caller: …]` header):

| Script | Purpose |
|---|---|
| `get_organization.js` | Validate creds, return orgId + dynamic apiKey |
| `get_absences.js` | Raw vacancy records for a date range (max 31 days), with `filled / unfilled / all` filter |
| `get_daily_summary.js` | All-staff daily summary (counts by school, reason, position type; fill rate; unfilled-positions list) |
| `get_certificated_summary.js` | Daily summary filtered to `Teacher`, `ESA - Certificated`, `CTE - Teacher` |
| `get_weekly_summary.js` | Mon–Fri weekly trends with peak/slow days and trend annotations |

## Read-only enforcement

- All HTTP traffic via single GET-only `rrGet()` in `lib/api.js`. No `rrPost/rrPut/rrDelete`.
- Zero `fs.writeFile` / `fs.appendFile` / `fs.mkdir` / `fs.unlink` calls.
- Only `child_process` invocation is `psd-credentials/get.js` (never `put.js`).
- `/opt/psd-skills` is `chmod a-w` at container build time (existing Dockerfile line).
- Credential values held in module-scope memory only; never logged, echoed, or persisted.

## Out-of-scope (already handled)

- **Secret provisioning:** the dev shared secret `psd-agent-creds/dev/shared/redrover_credentials` was created outside this PR (sourced from `op://Geoffrey/RedRover`). Tags: `Environment=dev`, `ManagedBy=manual`, `Skill=psd-redrover`.
- **IAM:** existing `AgentCredentialsRead` policy on the AgentCore execution role already grants `GetSecretValue` on `psd-agent-creds/{env}/*`. No CDK change required.
- **Dockerfile:** zero npm deps (matches `psd-freshservice`); the existing `COPY skills /opt/psd-skills` line picks up the new directory automatically.

## Test plan

- [x] `node --check` passes on every `.js` file
- [x] Read-only audit: `grep -nE "fs\.(write|append|mkdir|unlink|rm)|method:\s*['\"](POST|PUT|DELETE|PATCH)|put\.js"` returns zero functional hits
- [x] Dev secret round-trip via `aws secretsmanager get-secret-value` (verified shape, not values)
- [ ] Build agent image: `cd infra/agent-image && ./build-and-push.sh`
- [ ] Deploy via canonical CDK command with `--context agentImageDigest=<digest>`
- [ ] In dev chat: smoke test `get_organization` (returns orgId + apiKey)
- [ ] In dev chat: "Show me yesterday's certificated absences" → routes to `get_certificated_summary.js`
- [ ] Verify `psd_agent_credentials_audit` records a `get` event for `redrover_credentials` (name only, no value)