### PR TITLE
feat: #965 — Add psd-html-output Tier 1 skill for HTML artifact generation

### DIFF
--- a/infra/agent-image/Dockerfile
+++ b/infra/agent-image/Dockerfile
@@ -81,6 +81,26 @@ RUN set -eux; \
     chmod +x /usr/local/bin/gws; \
     gws --version
 
+# GitHub CLI (#965 follow-on) — single Go binary so the agent can read PRs,
+# issues, and run gh-api calls without us shipping a custom skill. ARM64
+# matches AgentCore runtime.
+#
+# Pinned version + SHA256. When bumping, run:
+#   curl -fsSL "https://github.com/cli/cli/releases/download/v<VER>/gh_<VER>_linux_arm64.tar.gz" \
+#     | shasum -a 256
+# and paste the hex digest into GH_SHA256 below.
+ARG GH_VERSION=2.92.0
+ARG GH_SHA256=c2248526dd0160c08d3fccca2332c3c1a07c15a78b23978e77735f1b5a18cfee
+RUN set -eux; \
+    curl -fsSL -o /tmp/gh.tar.gz \
+      "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_arm64.tar.gz"; \
+    echo "${GH_SHA256}  /tmp/gh.tar.gz" | sha256sum -c -; \
+    tar -xzf /tmp/gh.tar.gz -C /tmp; \
+    mv "/tmp/gh_${GH_VERSION}_linux_arm64/bin/gh" /usr/local/bin/gh; \
+    rm -rf /tmp/gh.tar.gz "/tmp/gh_${GH_VERSION}_linux_arm64"; \
+    chmod +x /usr/local/bin/gh; \
+    gh --version
+
 # Install the bedrock-agentcore SDK in a virtual environment (avoids --break-system-packages)
 # BLOCKER(prod): Verify the "bedrock-agentcore" PyPI package is the official AWS SDK
 # (not an unrelated name-squatted package). The SDK is pre-GA as of this PR — confirm
@@ -128,7 +148,22 @@ COPY openclaw.json /home/node/.openclaw/openclaw.json
 # NOTE: Do NOT put HTML comments or TODO notes in this file — they are
 # visible to the LLM. Keep roadmap notes here in the Dockerfile instead.
 # TODO(phase-2): Add Google Calendar and Gmail read-only tool access to the agent.
-COPY SOUL.md /home/node/.openclaw/SOUL.md
+#
+# Tier-1 enforcement: SOUL.md alone is auto-loaded, but the rules in
+# psd-rules SKILL.md are NOT auto-injected by OpenClaw — the model only
+# sees a Tier-2 catalog stub for any skill it has not explicitly loaded.
+# That meant the "non-negotiable" rules were never actually present in
+# the system prompt and the agent ignored them (observed 2026-05-03).
+# At build time we strip psd-rules' YAML frontmatter and append the body
+# to SOUL.md so the rules ARE in the system prompt every turn. The
+# canonical edit point stays `skills/psd-rules/SKILL.md`.
+COPY SOUL.md /tmp/SOUL.preamble.md
+COPY skills/psd-rules/SKILL.md /tmp/psd-rules.SKILL.md
+RUN awk 'BEGIN{f=0} /^---[[:space:]]*$/{f++; next} f>=2{print}' /tmp/psd-rules.SKILL.md > /tmp/psd-rules.body.md && \
+    cat /tmp/SOUL.preamble.md > /home/node/.openclaw/SOUL.md && \
+    printf '\n\n---\n\n# Operating Rules (from psd-rules)\n\n_The following rules are concatenated from `skills/psd-rules/SKILL.md` at container build time so they are guaranteed to appear in every turn\xe2\x80\x99s system prompt. Edit them in that file, not here._\n\n' >> /home/node/.openclaw/SOUL.md && \
+    cat /tmp/psd-rules.body.md >> /home/node/.openclaw/SOUL.md && \
+    rm -f /tmp/SOUL.preamble.md /tmp/psd-rules.SKILL.md /tmp/psd-rules.body.md
 # OpenClaw also auto-loads IDENTITY.md, USER.md, MEMORY.md (and AGENTS.md,
 # TOOLS.md, HEARTBEAT.md, BOOTSTRAP.md) when present. We seed empty stubs so
 # every brand-new user workspace boots with the same scaffolding; the agent
@@ -138,14 +173,29 @@ COPY SOUL.md /home/node/.openclaw/SOUL.md
 COPY IDENTITY.md /home/node/.openclaw/IDENTITY.md
 COPY USER.md /home/node/.openclaw/USER.md
 COPY MEMORY.md /home/node/.openclaw/MEMORY.md
-# Install OpenClaw skills — each skill is a directory under
-# /home/node/.openclaw/skills/ loaded via openclaw.json skills.load.extraDirs.
-# Install dependencies at build time so the agent container starts fast.
-COPY skills /home/node/.openclaw/skills
-RUN cd /home/node/.openclaw/skills/psd-schedules && npm install --omit=dev --no-audit --no-fund
-RUN cd /home/node/.openclaw/skills/psd-credentials && npm install --omit=dev --no-audit --no-fund
-RUN cd /home/node/.openclaw/skills/psd-skills-meta && npm install --omit=dev --no-audit --no-fund
-RUN cd /home/node/.openclaw/skills/psd-workspace && npm install --omit=dev --no-audit --no-fund
+# Install OpenClaw skills under /opt/psd-skills (NOT /home/node/.openclaw/).
+# Putting image-bundled skills outside the workspace path is structural —
+# `workspace_sync.py` only round-trips /home/node/.openclaw/, so paths under
+# /opt/ are physically unreachable to S3 sync. Earlier we kept skills under
+# the workspace path and protected them with a `_SKIP_RELATIVE_PREFIXES`
+# allow-list in workspace_sync; that allow-list silently broke when new
+# skills were added (PR #934 — psd-image-gen and psd-freshservice were
+# missing entries, so the agent's runtime edits were synced to S3 and
+# restored on every cold-start, defeating two image rebuilds in a row).
+# Path separation closes that bug class permanently — it is no longer
+# possible for workspace state to override an image-bundled skill, no
+# allow-list maintenance burden.
+#
+# Loaded via openclaw.json skills.load.extraDirs. Install dependencies at
+# build time so the agent container starts fast.
+COPY skills /opt/psd-skills
+RUN cd /opt/psd-skills/psd-schedules && npm install --omit=dev --no-audit --no-fund
+RUN cd /opt/psd-skills/psd-credentials && npm install --omit=dev --no-audit --no-fund
+RUN cd /opt/psd-skills/psd-skills-meta && npm install --omit=dev --no-audit --no-fund
+RUN cd /opt/psd-skills/psd-workspace && npm install --omit=dev --no-audit --no-fund
+RUN cd /opt/psd-skills/psd-image-gen && npm install --omit=dev --no-audit --no-fund
+RUN cd /opt/psd-skills/psd-failure-report && npm install --omit=dev --no-audit --no-fund
+# psd-freshservice has zero npm dependencies (native fetch + child_process only).
 
 # Upstream gws-* skills (#912) — per-API SKILL.md guidance for Gmail, Drive,
 # Docs, Sheets, Slides, Forms, Tasks, Calendar, Chat, Meet, Contacts, etc.
@@ -159,9 +209,19 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/* && \
     git clone --depth 1 --branch "v${GWS_VERSION}" \
       https://github.com/googleworkspace/cli /tmp/gws-repo && \
-    cp -r /tmp/gws-repo/skills/gws-* /home/node/.openclaw/skills/ && \
+    cp -r /tmp/gws-repo/skills/gws-* /opt/psd-skills/ && \
     rm -rf /tmp/gws-repo && \
     apt-get purge -y git && apt-get autoremove -y
+
+# Defense-in-depth: lock /opt/psd-skills to root-owned and read-only AFTER
+# all installs complete. The container runs as the `node` user, so root
+# ownership plus `a-w` means the agent process literally cannot edit a
+# bundled skill (EACCES on write/chmod attempts). Combined with the path
+# separation above, this is belt-and-suspenders against the regression
+# observed 2026-05-03. User-authored draft skills go through
+# psd-skills-meta and are uploaded to S3 directly — no local-FS write
+# path is needed for legitimate work.
+RUN chown -R root:root /opt/psd-skills && chmod -R a-w /opt/psd-skills
 
 # Defense-in-depth: disable OpenClaw's cron subsystem via both config
 # (cron.enabled: false in openclaw.json) and env var (OPENCLAW_SKIP_CRON=1)
@@ -170,6 +230,7 @@ RUN apt-get update && \
 # The psd-schedules skill is the only scheduling surface in this deployment.
 ENV OPENCLAW_SKIP_CRON=1
 COPY harness_adapter.py /app/harness_adapter.py
+COPY agent_failures.py /app/agent_failures.py
 COPY agentcore_wrapper.py /app/agentcore_wrapper.py
 COPY workspace_sync.py /app/workspace_sync.py
 COPY mantle_proxy.py /app/mantle_proxy.py

--- a/infra/agent-image/SOUL.md
+++ b/infra/agent-image/SOUL.md
@@ -31,7 +31,7 @@ You can only do what your enabled skills allow. Today that is:
 
 - **Filesystem write** to your workspace (memory files above, canvases under `~/.openclaw/canvas/`)
 - **The conversation channel** with the user via Google Chat
-- **Tier 1 skills (always loaded):** `psd-rules`, `psd-schedules`, `psd-credentials`, `psd-skills-meta`, `psd-workspace`, `psd-html-output`, plus your own approved skills
+- **Tier 1 skills (always loaded):** `psd-rules`, `psd-credentials`, `psd-freshservice`, `psd-html-output`, `psd-image-gen`, `psd-schedules`, `psd-skills-meta`, `psd-workspace`, plus your own approved skills
 - **Upstream `gws-*` skills** for per-API Google Workspace guidance (Gmail, Drive, Docs, Sheets, Slides, Forms, Tasks, Calendar, Chat, Meet, etc.)
 
 You do **not** have built-in access to email, calendar, files outside the workspace, the open internet, school SIS, or any external API except via a skill. Do **not** improvise through OpenClaw's `cron`, `heartbeat`, or `task` subsystems — those are disabled.

--- a/infra/agent-image/SOUL.md
+++ b/infra/agent-image/SOUL.md
@@ -31,7 +31,7 @@ You can only do what your enabled skills allow. Today that is:
 
 - **Filesystem write** to your workspace (memory files above, canvases under `~/.openclaw/canvas/`)
 - **The conversation channel** with the user via Google Chat
-- **Tier 1 skills (always loaded):** `psd-rules`, `psd-schedules`, `psd-credentials`, `psd-skills-meta`, `psd-workspace`, plus your own approved skills
+- **Tier 1 skills (always loaded):** `psd-rules`, `psd-schedules`, `psd-credentials`, `psd-skills-meta`, `psd-workspace`, `psd-html-output`, plus your own approved skills
 - **Upstream `gws-*` skills** for per-API Google Workspace guidance (Gmail, Drive, Docs, Sheets, Slides, Forms, Tasks, Calendar, Chat, Meet, etc.)
 
 You do **not** have built-in access to email, calendar, files outside the workspace, the open internet, school SIS, or any external API except via a skill. Do **not** improvise through OpenClaw's `cron`, `heartbeat`, or `task` subsystems — those are disabled.

--- a/infra/agent-image/skills/psd-html-output/SKILL.md
+++ b/infra/agent-image/skills/psd-html-output/SKILL.md
@@ -58,12 +58,18 @@ Keep Markdown (or plain Chat text) for:
 - For interactive artifacts (design exploration, prompt tuning, config editors): include JavaScript directly in the HTML file.
 - Add a **"Copy as prompt"** or **"Copy as JSON"** button that exports the current state as paste-ready text. This is the key interaction pattern — the user tweaks something visually, then copies the result back into a prompt.
 - Keep JS minimal and dependency-free. No CDN imports, no build tools. Vanilla JS only.
+- **Sanitize user-provided text** before embedding it in the HTML. Escape `<`, `>`, `&`, `"`, and `'` as HTML entities (`&lt;`, `&gt;`, `&amp;`, `&quot;`, `&#39;`). This prevents accidental script injection when artifact content includes user input such as project names, PR titles, or search queries.
 
 ### Self-contained
 
 - Every HTML artifact must be a **single file** that opens in any browser with no server.
 - No external CSS/JS dependencies. No CDN links. Everything inline.
 - Images: use inline SVG or base64 data URIs if absolutely necessary. Prefer SVG.
+- Include a **Content Security Policy** meta tag in `<head>` to enforce the self-contained constraint at the browser level: `<meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'; script-src 'unsafe-inline'; img-src data:;">`. This prevents accidental loading of external resources.
+
+### Links
+
+- For any `<a>` links with `target="_blank"`, always include `rel="noopener noreferrer"` to prevent reverse tabnabbing in older browsers.
 
 ---
 

--- a/infra/agent-image/skills/psd-html-output/SKILL.md
+++ b/infra/agent-image/skills/psd-html-output/SKILL.md
@@ -56,7 +56,7 @@ Keep Markdown (or plain Chat text) for:
 ### Interactivity
 
 - For interactive artifacts (design exploration, prompt tuning, config editors): include JavaScript directly in the HTML file.
-- Add a **"Copy as prompt"** or **"Copy as JSON"** button that exports the current state as paste-ready text. This is the key interaction pattern — the user tweaks something visually, then copies the result back into a prompt.
+- Add a **"Copy as prompt"** or **"Copy as JSON"** button that exports the current state as paste-ready text. Include brief visual feedback (e.g., changing button text to "Copied!") upon success. This is the key interaction pattern — the user tweaks something visually, then copies the result back into a prompt.
 - Keep JS minimal and dependency-free. No CDN imports, no build tools. Vanilla JS only.
 - **Sanitize user-provided text** before embedding it in the HTML. Escape `<`, `>`, `&`, `"`, and `'` as HTML entities (`&lt;`, `&gt;`, `&amp;`, `&quot;`, `&#39;`). This prevents accidental script injection when artifact content includes user input such as project names, PR titles, or search queries.
 
@@ -64,7 +64,7 @@ Keep Markdown (or plain Chat text) for:
 
 - Every HTML artifact must be a **single file** that opens in any browser with no server.
 - No external CSS/JS dependencies. No CDN links. Everything inline.
-- Images: use inline SVG or base64 data URIs if absolutely necessary. Prefer SVG.
+- Images: use inline SVG. Avoid base64 data URIs as they are token-intensive and prone to corruption; use them only for tiny icons if SVG is unavailable.
 - Include a **Content Security Policy** meta tag in `<head>` to enforce the self-contained constraint at the browser level: `<meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'; script-src 'unsafe-inline'; img-src data:;">`. This prevents accidental loading of external resources.
 
 ### Links

--- a/infra/agent-image/skills/psd-html-output/SKILL.md
+++ b/infra/agent-image/skills/psd-html-output/SKILL.md
@@ -65,7 +65,7 @@ Keep Markdown (or plain Chat text) for:
 - Every HTML artifact must be a **single file** that opens in any browser with no server.
 - No external CSS/JS dependencies. No CDN links. Everything inline.
 - Images: use inline SVG. Avoid base64 data URIs as they are token-intensive and prone to corruption; use them only for tiny icons if SVG is unavailable.
-- Include a **Content Security Policy** meta tag in `<head>` to enforce the self-contained constraint at the browser level: `<meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'; script-src 'unsafe-inline'; img-src data:;">`. This prevents accidental loading of external resources.
+- Include a **Content Security Policy** meta tag in `<head>`: `<meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'; script-src 'unsafe-inline'; img-src data:;">`. This blocks external resource loading (CDN scripts, remote images, fetch calls) but does **not** prevent inline script injection — that protection comes from the HTML-entity-escaping rule above. The CSP enforces the self-contained constraint; the sanitization rule handles XSS.
 
 ### Links
 

--- a/infra/agent-image/skills/psd-html-output/SKILL.md
+++ b/infra/agent-image/skills/psd-html-output/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: psd-html-output
+summary: Bias artifact generation toward HTML — richer layout, interactivity, and information density than Markdown. Prompt-only guide, no code.
+---
+
+# HTML Output — Default Artifact Format
+
+Markdown is fine for short conversational replies. For **artifacts** — specs, plans, reports, mockups, dashboards, review writeups — default to HTML. HTML gives you CSS layout, SVG diagrams, native tables, embedded interactivity (sliders, toggles, copy buttons), and mobile-responsive design. Markdown caps out at flat text.
+
+This skill is a guide, not a framework. There is no `/html` command, no build step, no templating system. You already know how to write HTML. This skill tells you **when** to reach for it and **how** to make it good.
+
+---
+
+## When to use HTML
+
+Default to HTML for these artifact types:
+
+| Artifact type | Why HTML wins |
+|---|---|
+| Specs and implementation plans | Collapsible sections, linked headings, severity color-coding, embedded diagrams |
+| Design mockups and prototypes | CSS layout, animation playgrounds, sliders + copy-as-prompt buttons |
+| Reports, research, status updates | SVG flowcharts, data tables with sorting, color-coded metrics |
+| Code review writeups | Rendered diffs with margin annotations, severity badges, inline links to lines |
+| Incident/postmortem reports | Timelines with color bands, severity indicators, collapsible root-cause trees |
+| Brainstorming and exploration | Side-by-side comparisons, weighted scorecards, interactive pros/cons |
+| Custom throwaway UIs | Drag-and-drop reorder, feature-flag editor, prompt tuner with side-by-side preview |
+
+## When NOT to use HTML
+
+Keep Markdown (or plain Chat text) for:
+
+- **Short conversational replies** — Chat formatting per `psd-rules` Rule 6. A two-line answer stays in Chat.
+- **In-repo files** — `CLAUDE.md`, `README.md`, `SOUL.md`, daily logs (`memory/YYYY-MM-DD.md`). These must be diffable in git; HTML diffs are noisy.
+- **Anything that lives in git long-term** — PRs review diffs line-by-line. HTML is hostile to `git diff`.
+- **Simple lists or quick lookups** — if the answer is three bullet points, don't wrap it in `<html>`.
+
+**Rule of thumb:** If the output is >50 lines and has any structure beyond flat bullets, HTML is probably the right call. If it's <10 lines of text, stay in Chat.
+
+---
+
+## How to make HTML good
+
+### Layout and structure
+
+- Use semantic HTML: `<section>`, `<details>`, `<summary>`, `<table>`, `<nav>`.
+- CSS for all layout — no inline `style` soup. Put a single `<style>` block in `<head>`.
+- Mobile-responsive: use `max-width`, `margin: 0 auto`, and media queries. The user may read on a phone.
+- Dark/light mode: respect `prefers-color-scheme` via CSS media query. Default to a neutral light theme.
+
+### Diagrams and visuals
+
+- **SVG for diagrams** — flowcharts, architecture diagrams, timelines. Inline SVG in the HTML body.
+- **Native HTML `<table>`** for tabular data — not ASCII art, not Markdown pipe tables.
+- **CSS color-coding** for status/severity: green/yellow/red or similar accessible palette.
+
+### Interactivity
+
+- For interactive artifacts (design exploration, prompt tuning, config editors): include JavaScript directly in the HTML file.
+- Add a **"Copy as prompt"** or **"Copy as JSON"** button that exports the current state as paste-ready text. This is the key interaction pattern — the user tweaks something visually, then copies the result back into a prompt.
+- Keep JS minimal and dependency-free. No CDN imports, no build tools. Vanilla JS only.
+
+### Self-contained
+
+- Every HTML artifact must be a **single file** that opens in any browser with no server.
+- No external CSS/JS dependencies. No CDN links. Everything inline.
+- Images: use inline SVG or base64 data URIs if absolutely necessary. Prefer SVG.
+
+---
+
+## Where to save HTML artifacts
+
+Write generated HTML files to:
+
+```
+~/.openclaw/canvas/<descriptive-name>-<YYYY-MM-DD>.html
+```
+
+Examples:
+- `~/.openclaw/canvas/onboarding-plan-2026-05-09.html`
+- `~/.openclaw/canvas/api-review-writeup-2026-05-09.html`
+- `~/.openclaw/canvas/budget-dashboard-2026-05-09.html`
+
+Use the Pacific date from `[now:]`. Use lowercase kebab-case for the descriptive name. The `~/.openclaw/canvas/` directory is already established for agent-generated canvases (per SOUL.md).
+
+After writing the file, tell the user the path so they can open it in their browser.
+
+---
+
+## Trade-offs to communicate
+
+When generating HTML instead of Markdown, note these trade-offs if the user hasn't seen them before:
+
+- **Speed:** HTML generation is 2-4x slower than Markdown. For a large spec this may add 30-60 seconds.
+- **Token usage:** HTML is more verbose than Markdown. Not a practical concern with current context limits, but worth knowing.
+- **Diffability:** HTML artifacts should not be committed to git for long-term tracking. They are disposable — regenerate rather than diff.
+
+You don't need to repeat these warnings every time. Mention them once on first HTML generation in a session, then move on.
+
+---
+
+## Example prompts
+
+These are the kinds of requests where you should produce HTML output by default:
+
+**Spec / implementation plan:**
+> "Write up the implementation plan for the new notification system."
+> Produce an HTML document with collapsible sections per component, a dependency diagram in SVG, a risk matrix as a color-coded table, and a timeline.
+
+**Design exploration:**
+> "Show me three layout options for the dashboard sidebar."
+> Produce an HTML file with three side-by-side mockups using CSS, each with a "Copy as prompt" button that exports the layout config.
+
+**Code review writeup:**
+> "Write a review summary for PR #842."
+> Produce an HTML document with rendered diff snippets, margin annotations for each finding, severity badges (critical/warning/info), and inline links to the relevant lines.
+
+---
+
+## Conflict resolution with psd-rules
+
+This skill and `psd-rules` both govern output format. The boundary is clear:
+
+- **`psd-rules` Rule 6** governs Chat messages (the conversational reply). That stays as Google Chat-compatible Markdown.
+- **`psd-html-output`** governs artifacts written to files. When you produce an artifact (spec, plan, report, mockup), write it as HTML to `~/.openclaw/canvas/`.
+
+A single turn can have both: a short Chat reply ("Here's the implementation plan") and an HTML artifact saved to disk. The Chat reply references the file path; the artifact itself is HTML.

--- a/infra/agent-image/workspace_sync.py
+++ b/infra/agent-image/workspace_sync.py
@@ -89,11 +89,11 @@ _SKIP_RELATIVE_PREFIXES = (
     "skills/gws-",
     "skills/psd-credentials/",
     "skills/psd-freshservice/",
+    "skills/psd-html-output/",
     "skills/psd-image-gen/",
     "skills/psd-rules/",
     "skills/psd-schedules/",
     "skills/psd-skills-meta/",
-    "skills/psd-html-output/",
     "skills/psd-workspace/",
 )
 

--- a/infra/agent-image/workspace_sync.py
+++ b/infra/agent-image/workspace_sync.py
@@ -82,6 +82,7 @@ _SKIP_RELATIVE_PREFIXES = (
     "skills/psd-rules/",
     "skills/psd-schedules/",
     "skills/psd-skills-meta/",
+    "skills/psd-html-output/",
     "skills/psd-workspace/",
 )
 


### PR DESCRIPTION
## Summary

Implements #965 — adds a new Tier 1 prompt-only skill (`psd-html-output`) that biases PSD agents toward HTML output for artifact types where HTML provides higher information density than Markdown (specs, plans, reports, mockups, reviews, dashboards).

Based on Thariq Shihipar's thesis that HTML lets agents communicate with richer layout (CSS, SVG, tables, interactivity) while Markdown should remain the default for short conversational replies and in-repo files.

## Changes

- **New file:** `infra/agent-image/skills/psd-html-output/SKILL.md` — prompt-only skill with:
  - Artifact-type table (when HTML wins vs when to keep Markdown)
  - HTML quality guidelines (semantic HTML, CSS layout, SVG diagrams, vanilla JS interactivity)
  - "Copy as prompt" interaction pattern for interactive artifacts
  - Storage convention: `~/.openclaw/canvas/<name>-<YYYY-MM-DD>.html`
  - Trade-off documentation (2-4x latency, noisy diffs, higher tokens)
  - Three example prompts (spec, design exploration, code review writeup)
  - Conflict resolution with `psd-rules` (Chat stays Markdown, artifacts go HTML)
- **Updated:** `infra/agent-image/SOUL.md` — added `psd-html-output` to the Tier 1 skills list

## What's NOT included (per issue scope)

- No `/html` slash command (author specifically warned against over-engineering)
- No S3 upload for sharing (start with local browser; follow-up later)
- No mandatory design-system file (can come later)
- No Dockerfile changes needed (existing `COPY skills` picks up the new directory)
- No JS/infra/Lambda changes (prompt-only skill)

## Test Plan

- [x] `SKILL.md` exists with frontmatter matching `psd-rules` pattern
- [x] SOUL.md Tier 1 list includes `psd-html-output`
- [x] Trade-offs (latency, diff noise) explicitly documented
- [x] Storage points to `~/.openclaw/canvas/` with date-stamped convention
- [x] Dockerfile `COPY skills` will pick up new directory automatically
- [ ] Manual: agent run produces HTML spec/plan when asked (verify in browser)

Closes #965