### PR TITLE
fix: #970 — Scrolling issue — chat viewport collapses when composer textarea expands

### DIFF
--- a/components/assistant-ui/thread.tsx
+++ b/components/assistant-ui/thread.tsx
@@ -335,7 +335,7 @@ const Composer: FC<ComposerProps> = ({
   composerExtraActions,
 }) => {
   return (
-    <div className="bg-white relative mx-auto flex w-full max-w-[var(--thread-max-width)] flex-col gap-4 px-[var(--thread-padding-x)] pb-4 md:pb-6">
+    <div className="bg-white relative mx-auto flex w-full max-w-[var(--thread-max-width)] flex-col gap-4 px-[var(--thread-padding-x)] pb-4 md:pb-6 shrink-0">
       <ThreadScrollToBottom />
       <ThreadPrimitive.Empty>
         <ThreadWelcomeSuggestions actions={suggestedActions} />


### PR DESCRIPTION
## Summary

Fixes #970 — the chat scroll area collapses as the user types multi-line messages, preventing them from scrolling back to see earlier messages.

## Root Cause

`ThreadPrimitive.Root` is a `flex h-full flex-col` container. Its two children are:
1. `ThreadPrimitive.Viewport` — `flex-1 h-0 overflow-y-auto` (takes remaining space)
2. `Composer` wrapper div — **missing `shrink-0`**

When the `ComposerPrimitive.Input` textarea grew (bounded by `max-h-[calc(50dvh)]`), the outer Composer div had no `shrink-0` constraint, so it could steal the `flex-1` budget from the Viewport, physically collapsing the scroll area.

## Changes

- `components/assistant-ui/thread.tsx` line 338: added `shrink-0` to the Composer's outer wrapper `<div>`

This is a single-class CSS fix. No logic changes, no new dependencies.

## Test Plan

- [x] Inline typecheck passes (no new errors in thread.tsx)
- [x] work-validator passed
- [x] Security audit — PASSED (zero findings, all INFO)
- [ ] Human review — verify manually: open a Nexus chat, type a multi-line message filling ~50% of the viewport, then scroll up; the scroll area should remain stable

Closes #970

---
*Opened by the lfg routine.*