### PR TITLE
feat(agent): integrate psd-data MCP server with Cognito-based auth

### DIFF
--- a/actions/agent-workspace.actions.ts
+++ b/actions/agent-workspace.actions.ts
@@ -185,7 +185,21 @@ export async function verifyConsentAndGetOAuthUrl(
     // Scopes and login_hint are kind-dependent:
     //   agent_account → log in as agnt_<uniqname>, broad agent scopes
     //   user_account  → log in as the user themself, narrow Phase 1 scopes
-    const kind = payload.kind ?? "agent_account"
+    //
+    // cognito_data tokens belong to a different consent flow
+    // (/agent-connect-data) and must not flow through this Workspace path —
+    // reject them here so a misrouted token doesn't accidentally trigger
+    // a Google OAuth redirect.
+    const payloadKind = payload.kind ?? "agent_account"
+    if (payloadKind !== "agent_account" && payloadKind !== "user_account") {
+      timer({ status: "error" })
+      log.warn("Consent token has non-Workspace kind", { kind: payloadKind })
+      return createSuccess({
+        valid: false,
+        error: "This consent link is for a different flow.",
+      })
+    }
+    const kind: "agent_account" | "user_account" = payloadKind
     const scopes = SCOPES_BY_KIND[kind]
     const loginHint = kind === "user_account" ? payload.sub : payload.agent
     const params = new URLSearchParams({
@@ -597,6 +611,20 @@ export async function handleOAuthCallback(
       return createSuccess({
         success: false,
         error: "This consent link has already been used or has expired. Ask your agent for a new one.",
+      })
+    }
+
+    // cognito_data nonces belong to the /agent-connect-data flow and must
+    // never enter the Google OAuth callback — the page consumes them
+    // directly. Reject here as defence-in-depth.
+    if (nonceRow.tokenKind !== "agent_account" && nonceRow.tokenKind !== "user_account") {
+      timer({ status: "error" })
+      log.warn("Consent nonce has non-Workspace kind in OAuth callback", {
+        kind: nonceRow.tokenKind,
+      })
+      return createSuccess({
+        success: false,
+        error: "This consent link is for a different flow.",
       })
     }
 

--- a/actions/agent-workspace.actions.ts
+++ b/actions/agent-workspace.actions.ts
@@ -20,12 +20,14 @@ import { addUserRole } from "@/lib/db/drizzle/user-roles"
  * because the agent owns its own Calendar/Drive/Chat presence and may need
  * write access to shared resources.
  *
- * user_account: the human's own identity. NARROW Phase 1 scopes only —
- * read mail + create drafts, manage tasks, scoped Drive files. No send,
- * no destructive operations. Calendar scope included so the agent can
- * write events directly to the user's calendar (Calendar via sharing
- * already worked, but the user wants the agent to be able to make
- * changes from the user-account side as well).
+ * user_account: the human's own identity. Mail is gmail.modify so the
+ * agent can read, draft, send, archive, and label on the user's behalf
+ * (no permanent delete — gmail.modify cannot bypass Trash). This is a
+ * single scope because Google does not split "modify metadata" from
+ * "send" — once you go beyond gmail.compose, archiving requires
+ * gmail.modify and that scope includes send. The agent's behavioral
+ * rules (psd-rules) still gate sending on explicit user confirmation.
+ * Calendar / Tasks / Drive.file remain narrow.
  */
 const SCOPES_BY_KIND: Record<"agent_account" | "user_account", string[]> = {
   agent_account: [
@@ -41,9 +43,11 @@ const SCOPES_BY_KIND: Record<"agent_account" | "user_account", string[]> = {
     "profile",
   ],
   user_account: [
-    // Phase 1: read mail and create drafts only. No send.
-    "https://www.googleapis.com/auth/gmail.readonly",
-    "https://www.googleapis.com/auth/gmail.compose",
+    // gmail.modify supersedes readonly + compose and adds archive/label/
+    // mark-read/trash + send. No permanent-delete bypass. Granting this
+    // requires a fresh consent click — existing refresh tokens retain
+    // only the original scope set until re-issued.
+    "https://www.googleapis.com/auth/gmail.modify",
     // Full calendar so the agent can write events with markers (per user
     // direction 2026-04-26: "the way it is working right now is fine").
     "https://www.googleapis.com/auth/calendar",
@@ -420,7 +424,7 @@ async function exchangeAndStore(
       "https://www.googleapis.com/auth/drive",
     ],
     user_account: [
-      "https://www.googleapis.com/auth/gmail.readonly",
+      "https://www.googleapis.com/auth/gmail.modify",
       "https://www.googleapis.com/auth/calendar",
       "https://www.googleapis.com/auth/tasks",
     ],

--- a/app/agent-connect-data/page.tsx
+++ b/app/agent-connect-data/page.tsx
@@ -82,9 +82,21 @@ async function processConsent(token: string | undefined, selfPath: string): Prom
     return { status: "no-refresh-token", ownerEmail: payload.sub }
   }
 
-  // Atomic burn-then-write: try to mark the nonce consumed first. If the
-  // update affects zero rows, the nonce was already consumed (replay) — we
-  // treat that as success because the secret is already populated.
+  // Write the refresh token to Secrets Manager first (idempotent: put-or-
+  // create). This way, if the write fails the nonce is still unconsumed and
+  // the user can click the same link again to retry.
+  const arn = await syncCognitoRefreshForAgent(payload.sub, refreshToken)
+  if (!arn) {
+    log.error(
+      "Cognito-data consent: refresh-token sync returned null — IAM or env missing",
+      sanitizeForLogging({ ownerEmail: payload.sub }),
+    )
+    return { status: "write-failed", ownerEmail: payload.sub }
+  }
+
+  // Burn the nonce only after a successful write. If the update affects zero
+  // rows, the nonce was already consumed (replay or duplicate click) — treat
+  // as success because the secret is already populated.
   const burn = await executeQuery(
     (db) =>
       db
@@ -106,16 +118,6 @@ async function processConsent(token: string | undefined, selfPath: string): Prom
       sanitizeForLogging({ ownerEmail: payload.sub }),
     )
     return { status: "already-consumed", ownerEmail: payload.sub }
-  }
-
-  // Write the refresh token to Secrets Manager.
-  const arn = await syncCognitoRefreshForAgent(payload.sub, refreshToken)
-  if (!arn) {
-    log.error(
-      "Cognito-data consent: refresh-token sync returned null — IAM or env missing",
-      sanitizeForLogging({ ownerEmail: payload.sub }),
-    )
-    return { status: "write-failed", ownerEmail: payload.sub }
   }
 
   log.info(
@@ -235,6 +237,7 @@ export default async function AgentConnectDataPage({ searchParams }: PageProps) 
             usually means the deployment is missing IAM or environment
             configuration. Please ping the AI Studio team.
           </p>
+          <p>Your consent link is still valid — you can try clicking it again once the issue is resolved.</p>
         </CardContent>
       </Layout>
     )

--- a/app/agent-connect-data/page.tsx
+++ b/app/agent-connect-data/page.tsx
@@ -1,0 +1,265 @@
+/**
+ * Agent Connect — Cognito data-MCP consent page
+ *
+ * Public route (NOT under (protected), NOT in nav).
+ * Accepts `?token=<signed-jwt>` issued by `/api/agent/consent-link` with
+ * `kind: "cognito_data"`. The user clicks this link from Google Chat when
+ * the agent needs to authenticate to the data MCP server on their behalf.
+ *
+ * Flow:
+ *   1. Verify the consent JWT.
+ *   2. Require an active AI Studio session whose email matches the JWT's `sub`.
+ *      If not signed in, surface a sign-in link with this page as `callbackUrl`.
+ *   3. Capture the session's Cognito refresh token and write it to Secrets
+ *      Manager at `psd-agent-creds/{env}/user/{email}/cognito-refresh`.
+ *   4. Burn the nonce (one-time use).
+ *   5. Render confirmation. The user goes back to Chat and re-asks.
+ *
+ * This is a Server Component — no client-side JS required.
+ */
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Button } from "@/components/ui/button"
+import Link from "next/link"
+import { createAuth } from "@/auth"
+import { verifyConsentToken } from "@/lib/agent-workspace/consent-token"
+import { executeQuery } from "@/lib/db/drizzle-client"
+import { psdAgentWorkspaceConsentNonces } from "@/lib/db/schema/tables/agent-workspace-consent-nonces"
+import { and, eq, isNull } from "drizzle-orm"
+import { syncCognitoRefreshForAgent } from "@/lib/auth/agent-token-sync"
+import { createLogger, sanitizeForLogging } from "@/lib/logger"
+
+export const dynamic = "force-dynamic"
+
+const log = createLogger({ module: "agent-connect-data" })
+
+interface PageProps {
+  searchParams: Promise<{ token?: string }>
+}
+
+type Outcome =
+  | { status: "missing-token" }
+  | { status: "invalid-token"; reason: string }
+  | { status: "needs-signin"; ownerEmail: string; selfHref: string }
+  | { status: "wrong-user"; expected: string; actual: string }
+  | { status: "no-refresh-token"; ownerEmail: string }
+  | { status: "already-consumed"; ownerEmail: string }
+  | { status: "stored"; ownerEmail: string }
+  | { status: "write-failed"; ownerEmail: string }
+
+async function processConsent(token: string | undefined, selfPath: string): Promise<Outcome> {
+  if (!token) return { status: "missing-token" }
+
+  const payload = await verifyConsentToken(token)
+  if (!payload) return { status: "invalid-token", reason: "Token is invalid or expired." }
+  if (payload.kind !== "cognito_data") {
+    return {
+      status: "invalid-token",
+      reason: "This link is for a different consent flow. Ask the agent for a fresh link.",
+    }
+  }
+
+  const { auth } = createAuth()
+  const session = await auth()
+  if (!session?.user?.email) {
+    return {
+      status: "needs-signin",
+      ownerEmail: payload.sub,
+      selfHref: selfPath,
+    }
+  }
+
+  const sessionEmail = session.user.email.toLowerCase()
+  const targetEmail = payload.sub.toLowerCase()
+  if (sessionEmail !== targetEmail) {
+    return { status: "wrong-user", expected: payload.sub, actual: session.user.email }
+  }
+
+  // The session callback exposes the Cognito refresh token (auth.ts:323).
+  const sessionWithToken = session as typeof session & { refreshToken?: string }
+  const refreshToken = sessionWithToken.refreshToken
+  if (!refreshToken || typeof refreshToken !== "string") {
+    return { status: "no-refresh-token", ownerEmail: payload.sub }
+  }
+
+  // Atomic burn-then-write: try to mark the nonce consumed first. If the
+  // update affects zero rows, the nonce was already consumed (replay) — we
+  // treat that as success because the secret is already populated.
+  const burn = await executeQuery(
+    (db) =>
+      db
+        .update(psdAgentWorkspaceConsentNonces)
+        .set({ consumedAt: new Date() })
+        .where(
+          and(
+            eq(psdAgentWorkspaceConsentNonces.nonce, payload.nonce),
+            isNull(psdAgentWorkspaceConsentNonces.consumedAt),
+          ),
+        )
+        .returning({ nonce: psdAgentWorkspaceConsentNonces.nonce }),
+    "consumeCognitoDataConsentNonce",
+  )
+
+  if (burn.length === 0) {
+    log.info(
+      "Cognito-data consent nonce already consumed (replay or duplicate click)",
+      sanitizeForLogging({ ownerEmail: payload.sub }),
+    )
+    return { status: "already-consumed", ownerEmail: payload.sub }
+  }
+
+  // Write the refresh token to Secrets Manager.
+  const arn = await syncCognitoRefreshForAgent(payload.sub, refreshToken)
+  if (!arn) {
+    log.error(
+      "Cognito-data consent: refresh-token sync returned null — IAM or env missing",
+      sanitizeForLogging({ ownerEmail: payload.sub }),
+    )
+    return { status: "write-failed", ownerEmail: payload.sub }
+  }
+
+  log.info(
+    "Cognito-data consent captured",
+    sanitizeForLogging({ ownerEmail: payload.sub, secretArn: arn }),
+  )
+  return { status: "stored", ownerEmail: payload.sub }
+}
+
+function Layout({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-gray-50 p-4">
+      <Card className="w-full max-w-md">{children}</Card>
+    </div>
+  )
+}
+
+export default async function AgentConnectDataPage({ searchParams }: PageProps) {
+  const { token } = await searchParams
+  const selfPath =
+    `/agent-connect-data?token=${encodeURIComponent(token ?? "")}`
+  const outcome = await processConsent(token, selfPath)
+
+  if (outcome.status === "missing-token") {
+    return (
+      <Layout>
+        <CardHeader>
+          <CardTitle className="text-center text-red-600">No consent token</CardTitle>
+        </CardHeader>
+        <CardContent className="text-sm text-muted-foreground text-center">
+          This page expects a one-time link from your agent. Ask the agent in
+          Google Chat to send you a fresh consent link.
+        </CardContent>
+      </Layout>
+    )
+  }
+
+  if (outcome.status === "invalid-token") {
+    return (
+      <Layout>
+        <CardHeader>
+          <CardTitle className="text-center text-red-600">Invalid consent link</CardTitle>
+        </CardHeader>
+        <CardContent className="text-sm text-muted-foreground text-center space-y-2">
+          <p>{outcome.reason}</p>
+          <p>Ask the agent for a fresh link.</p>
+        </CardContent>
+      </Layout>
+    )
+  }
+
+  if (outcome.status === "needs-signin") {
+    const signinHref = `/api/auth/signin?callbackUrl=${encodeURIComponent(outcome.selfHref)}`
+    return (
+      <Layout>
+        <CardHeader>
+          <CardTitle className="text-center">Sign in to connect your data access</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <p className="text-sm text-muted-foreground">
+            You&apos;re about to grant your agent permission to query the PSD
+            data warehouse on your behalf, using your own row-level access.
+            Sign in as <strong>{outcome.ownerEmail}</strong> to continue.
+          </p>
+          <div className="flex justify-center">
+            <Button asChild>
+              <Link href={signinHref}>Sign in to AI Studio</Link>
+            </Button>
+          </div>
+        </CardContent>
+      </Layout>
+    )
+  }
+
+  if (outcome.status === "wrong-user") {
+    return (
+      <Layout>
+        <CardHeader>
+          <CardTitle className="text-center text-red-600">Wrong account</CardTitle>
+        </CardHeader>
+        <CardContent className="text-sm text-muted-foreground text-center space-y-2">
+          <p>
+            This link was issued for <strong>{outcome.expected}</strong>, but
+            you&apos;re signed in as <strong>{outcome.actual}</strong>.
+          </p>
+          <p>Sign out and sign back in with the right account, then click the link again.</p>
+        </CardContent>
+      </Layout>
+    )
+  }
+
+  if (outcome.status === "no-refresh-token") {
+    return (
+      <Layout>
+        <CardHeader>
+          <CardTitle className="text-center text-red-600">No refresh token on session</CardTitle>
+        </CardHeader>
+        <CardContent className="text-sm text-muted-foreground text-center space-y-2">
+          <p>
+            Your AI Studio session is missing the Cognito refresh token we need.
+            Sign out, sign back in, and click the agent&apos;s consent link again.
+          </p>
+        </CardContent>
+      </Layout>
+    )
+  }
+
+  if (outcome.status === "write-failed") {
+    return (
+      <Layout>
+        <CardHeader>
+          <CardTitle className="text-center text-red-600">Could not save credential</CardTitle>
+        </CardHeader>
+        <CardContent className="text-sm text-muted-foreground text-center space-y-2">
+          <p>
+            We verified your identity but failed to store the credential. This
+            usually means the deployment is missing IAM or environment
+            configuration. Please ping the AI Studio team.
+          </p>
+        </CardContent>
+      </Layout>
+    )
+  }
+
+  // stored OR already-consumed → both render success
+  return (
+    <Layout>
+      <CardHeader>
+        <CardTitle className="text-center">You&apos;re connected</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-3 text-sm text-muted-foreground">
+        <p>
+          Your agent can now query PSD data warehouse on your behalf as{" "}
+          <strong>{outcome.ownerEmail}</strong>. Row-level security still
+          applies — the agent sees only what you can see.
+        </p>
+        <p>
+          Head back to your Google Chat and re-ask your question.
+        </p>
+        <p className="text-xs">
+          Revoke at any time by signing out of AI Studio; the stored token
+          rotates on every login.
+        </p>
+      </CardContent>
+    </Layout>
+  )
+}

--- a/app/api/agent/consent-link/route.ts
+++ b/app/api/agent/consent-link/route.ts
@@ -142,14 +142,16 @@ export async function POST(request: NextRequest) {
 
   // Validate kind. Default to 'agent_account' for backwards compatibility
   // with skills that haven't been updated to pass kind explicitly.
-  const kind: "agent_account" | "user_account" = body.kind === "user_account"
-    ? "user_account"
-    : body.kind === "agent_account" || body.kind === undefined
-      ? "agent_account"
-      : (() => { return "invalid" as never })()
-  if (body.kind !== undefined && body.kind !== "agent_account" && body.kind !== "user_account") {
+  type Kind = "agent_account" | "user_account" | "cognito_data"
+  const allowedKinds: Kind[] = ["agent_account", "user_account", "cognito_data"]
+  const kind: Kind = body.kind === undefined
+    ? "agent_account"
+    : (allowedKinds as readonly string[]).includes(body.kind)
+      ? (body.kind as Kind)
+      : "agent_account"
+  if (body.kind !== undefined && !(allowedKinds as readonly string[]).includes(body.kind)) {
     return NextResponse.json(
-      { error: "kind must be 'agent_account' or 'user_account' if provided" },
+      { error: "kind must be 'agent_account', 'user_account', or 'cognito_data' if provided" },
       { status: 400 }
     )
   }
@@ -198,9 +200,12 @@ export async function POST(request: NextRequest) {
     kind,
   })
 
-  // Build the consent URL
+  // Build the consent URL. cognito_data has its own dedicated page that
+  // captures a NextAuth session's Cognito refresh token; the other kinds
+  // route to the Google Workspace OAuth start page.
   const baseUrl = getIssuerUrl()
-  const url = `${baseUrl}/agent-connect?token=${encodeURIComponent(token)}`
+  const path = kind === "cognito_data" ? "/agent-connect-data" : "/agent-connect"
+  const url = `${baseUrl}${path}?token=${encodeURIComponent(token)}`
 
   log.info("Consent link generated", sanitizeForLogging({ ownerEmail, agentEmail, kind, requestId }))
 

--- a/auth.ts
+++ b/auth.ts
@@ -23,10 +23,11 @@ function syncCognitoRefreshForAgentBackground(
     try {
       const mod = await import("@/lib/auth/agent-token-sync")
       await mod.syncCognitoRefreshForAgent(email, refreshToken)
-    } catch {
+    } catch (err) {
       // edge runtime, missing IAM, etc. — swallow. The on-demand consent
       // flow is the fallback for users whose token never makes it here.
-      // No logger access in edge contexts is acceptable.
+      // eslint-disable-next-line no-console
+      console.error("[agent-token-sync] background sync failed:", err)
     }
   })()
 }

--- a/auth.ts
+++ b/auth.ts
@@ -5,6 +5,32 @@ import type { JWT } from "next-auth/jwt"
 import { refreshAccessToken, shouldRefreshToken } from "@/lib/auth/token-refresh-client"
 import { createLogger } from "@/lib/auth/edge-logger"
 
+/**
+ * Fire-and-forget mirror of the user's Cognito refresh token to Secrets
+ * Manager so the AgentCore agent (running in a different environment) can
+ * authenticate to the data MCP server on their behalf.
+ *
+ * Dynamic import so this never loads on edge runtime, and any failure
+ * (missing env vars, IAM, AWS unavailable) is logged but does NOT break
+ * the auth flow.
+ */
+function syncCognitoRefreshForAgentBackground(
+  email: string | undefined,
+  refreshToken: string | undefined,
+): void {
+  if (!email || !refreshToken) return
+  ;(async () => {
+    try {
+      const mod = await import("@/lib/auth/agent-token-sync")
+      await mod.syncCognitoRefreshForAgent(email, refreshToken)
+    } catch {
+      // edge runtime, missing IAM, etc. — swallow. The on-demand consent
+      // flow is the fallback for users whose token never makes it here.
+      // No logger access in edge contexts is acceptable.
+    }
+  })()
+}
+
 export const authConfig: NextAuthConfig = {
   providers: [
     Cognito({
@@ -104,6 +130,15 @@ export const authConfig: NextAuthConfig = {
             expiresAt: newToken.expiresAt ? new Date(newToken.expiresAt).toISOString() : 'unknown'
           })
 
+          // Mirror the freshly-issued Cognito refresh token into Secrets
+          // Manager so the AgentCore agent (different environment) can
+          // authenticate as this user against the data MCP server. Best
+          // effort — see syncCognitoRefreshForAgentBackground above.
+          syncCognitoRefreshForAgentBackground(
+            typeof newToken.email === "string" ? newToken.email : undefined,
+            typeof newToken.refreshToken === "string" ? newToken.refreshToken : undefined,
+          )
+
           return newToken
         } catch (error) {
           // Log error but don't fail authentication
@@ -184,6 +219,14 @@ export const authConfig: NextAuthConfig = {
             log.info("Token refresh successful", {
               newExpiresAt: new Date(refreshedTokens.expiresAt).toISOString()
             })
+
+            // Re-mirror the rotated refresh token to Secrets Manager so the
+            // agent's stored copy stays current. Best effort — see
+            // syncCognitoRefreshForAgentBackground above.
+            syncCognitoRefreshForAgentBackground(
+              typeof token.email === "string" ? token.email : undefined,
+              refreshedTokens.refreshToken,
+            )
 
             // Return refreshed token with existing user data and preserve lifetime info
             const tokenWithLifetime = token as JWT & { tokenLifetimeMs?: number }

--- a/infra/agent-image/Dockerfile
+++ b/infra/agent-image/Dockerfile
@@ -195,7 +195,13 @@ RUN cd /opt/psd-skills/psd-skills-meta && npm install --omit=dev --no-audit --no
 RUN cd /opt/psd-skills/psd-workspace && npm install --omit=dev --no-audit --no-fund
 RUN cd /opt/psd-skills/psd-image-gen && npm install --omit=dev --no-audit --no-fund
 RUN cd /opt/psd-skills/psd-failure-report && npm install --omit=dev --no-audit --no-fund
-RUN cd /opt/psd-skills/psd-data && npm install --omit=dev --no-audit --no-fund
+# psd-data depends on @aws-sdk/client-secrets-manager — the SAME package
+# psd-workspace already installed. Rather than duplicate the entire SDK tree
+# (~2,900 files, ~7 MB), symlink to psd-workspace's node_modules. Node's
+# resolver walks up looking for node_modules, so requires from psd-data
+# resolve through the symlink into the shared tree. Both skills pin the
+# same major version (^3.0.0) so the shared install is API-compatible.
+RUN ln -s ../psd-workspace/node_modules /opt/psd-skills/psd-data/node_modules
 # psd-freshservice has zero npm dependencies (native fetch + child_process only).
 # psd-brand-guidelines has zero npm dependencies (config + static assets only).
 # psd-github has zero npm dependencies (wraps /usr/local/bin/gh).

--- a/infra/agent-image/Dockerfile
+++ b/infra/agent-image/Dockerfile
@@ -195,7 +195,10 @@ RUN cd /opt/psd-skills/psd-skills-meta && npm install --omit=dev --no-audit --no
 RUN cd /opt/psd-skills/psd-workspace && npm install --omit=dev --no-audit --no-fund
 RUN cd /opt/psd-skills/psd-image-gen && npm install --omit=dev --no-audit --no-fund
 RUN cd /opt/psd-skills/psd-failure-report && npm install --omit=dev --no-audit --no-fund
+RUN cd /opt/psd-skills/psd-data && npm install --omit=dev --no-audit --no-fund
 # psd-freshservice has zero npm dependencies (native fetch + child_process only).
+# psd-brand-guidelines has zero npm dependencies (config + static assets only).
+# psd-github has zero npm dependencies (wraps /usr/local/bin/gh).
 
 # Upstream gws-* skills (#912) — per-API SKILL.md guidance for Gmail, Drive,
 # Docs, Sheets, Slides, Forms, Tasks, Calendar, Chat, Meet, Contacts, etc.

--- a/infra/agent-image/Dockerfile
+++ b/infra/agent-image/Dockerfile
@@ -195,13 +195,10 @@ RUN cd /opt/psd-skills/psd-skills-meta && npm install --omit=dev --no-audit --no
 RUN cd /opt/psd-skills/psd-workspace && npm install --omit=dev --no-audit --no-fund
 RUN cd /opt/psd-skills/psd-image-gen && npm install --omit=dev --no-audit --no-fund
 RUN cd /opt/psd-skills/psd-failure-report && npm install --omit=dev --no-audit --no-fund
-# psd-data depends on @aws-sdk/client-secrets-manager — the SAME package
-# psd-workspace already installed. Rather than duplicate the entire SDK tree
-# (~2,900 files, ~7 MB), symlink to psd-workspace's node_modules. Node's
-# resolver walks up looking for node_modules, so requires from psd-data
-# resolve through the symlink into the shared tree. Both skills pin the
-# same major version (^3.0.0) so the shared install is API-compatible.
-RUN ln -s ../psd-workspace/node_modules /opt/psd-skills/psd-data/node_modules
+# psd-data has zero npm install of its own. Its common.js require()s
+# `@aws-sdk/client-secrets-manager` from psd-workspace's already-installed
+# tree via an absolute path. No symlink, no duplicate install — keeps the
+# image file-count identical to a no-psd-data build.
 # psd-freshservice has zero npm dependencies (native fetch + child_process only).
 # psd-brand-guidelines has zero npm dependencies (config + static assets only).
 # psd-github has zero npm dependencies (wraps /usr/local/bin/gh).

--- a/infra/agent-image/skills/psd-data/SKILL.md
+++ b/infra/agent-image/skills/psd-data/SKILL.md
@@ -46,6 +46,38 @@ verbatim instead of inventing your own explanation.
 
 ## Subcommands
 
+The 8 typed subcommands below cover the tools the MCP server exposes today
+and validate their arguments before sending. For **anything not listed
+here** — including new tools the server may add after this skill was
+shipped — use the **`list` + `call` discovery pair** at the bottom.
+Hardcoded subcommands are a convenience, not a fence; the agent is never
+limited to them.
+
+### `list` — discover available MCP tools
+
+```bash
+node /opt/psd-skills/psd-data/run.js list --user <caller-email>
+```
+
+Returns the MCP server's current `tools/list` response: every tool name,
+description, and JSON-Schema `inputSchema`. **Use this first** if:
+
+- You're not sure whether a typed subcommand below covers what you need
+- The server might have added new tools since this skill was built
+- A typed subcommand returns a `MethodNotFound` or schema-mismatch error
+
+### `call` — generic passthrough to any MCP tool
+
+```bash
+node /opt/psd-skills/psd-data/run.js call --user <caller-email> \
+  --tool <tool-name> \
+  --args '{"arg1": "value", "arg2": 42}'
+```
+
+`--args` is a JSON object matching the tool's `inputSchema`. Always run
+`list` first so you can craft a correct args object. Use this when a
+typed subcommand doesn't exist for the tool you need.
+
 ### `tables` — list every table the user can see
 
 ```bash

--- a/infra/agent-image/skills/psd-data/SKILL.md
+++ b/infra/agent-image/skills/psd-data/SKILL.md
@@ -1,0 +1,182 @@
+---
+name: psd-data
+summary: Query the PSD data warehouse via the psd-data-mcp server. Authenticates as the calling user, enforces row-level security, exposes 8 tools (tables, schema, permissions, query, lessons).
+description: Read-only access to PSD's Redshift data warehouse, authenticated with the caller's Cognito identity. Lists tables, inspects schemas, runs RLS-rewritten SELECT queries, and manages cross-session "lessons" learned about the data. The MCP server enforces all access control — the skill simply forwards JSON-RPC calls with the right bearer token.
+allowed-tools: Bash(node:*)
+---
+
+# psd-data
+
+Access to the PSD data warehouse (Redshift) via the `psd-data-mcp` server.
+
+**Every command requires `--user <caller-email>`** (the email from the
+`[caller: Name <email>]` header at the top of each user turn). The skill
+uses that email to look up the caller's stored Cognito refresh token,
+mint a fresh id_token, and authenticate to the MCP server as the user.
+
+## Authentication
+
+You do not handle authentication directly. The skill:
+
+1. Reads the caller's refresh token from Secrets Manager at
+   `psd-agent-creds/${ENVIRONMENT}/user/${email}/cognito-refresh`.
+2. If the secret is missing or revoked, the skill **emits a `needs-auth`
+   payload and exits 10** — same shape as `psd-workspace`. Follow the rule-9
+   convention: paste `consent_chat_hyperlink` on its own line, no surrounding
+   markdown, then on a *separate* line explain that the user needs to
+   authorize data access. Do not retry the command after a `needs-auth`.
+3. On success, exchanges the refresh token for a fresh Cognito id_token
+   and sends it to the MCP server as `Authorization: Bearer …`.
+4. Row-level security applies server-side — the user sees only the data
+   the warehouse says they may see.
+
+## Exit codes
+
+| Code | Meaning | Agent response |
+|------|---------|----------------|
+| 0 | Success — JSON-RPC result on stdout | Use the result |
+| 1 | Config / usage error | Surface the error, do not retry |
+| 10 | needs-auth: no token, or token revoked | Paste `consent_chat_hyperlink` on its own line |
+| 12 | Upstream MCP error (JSON-RPC error or unexpected HTTP) | Surface the error verbatim |
+| 13 | Forbidden: user not in `userpermissions` table | Tell the user to ping the data team |
+| 14 | Rate-limited: 60 req/min/user | Wait a minute, retry once |
+
+The MCP server itself returns useful error messages — surface them
+verbatim instead of inventing your own explanation.
+
+## Subcommands
+
+### `tables` — list every table the user can see
+
+```bash
+node /opt/psd-skills/psd-data/run.js tables --user <caller-email> [--detailed]
+```
+
+`--detailed` adds the table descriptions to the listing. Use this first
+when the user asks "do we have data on X?".
+
+### `schema` — inspect one or more tables' columns
+
+```bash
+node /opt/psd-skills/psd-data/run.js schema --user <caller-email> \
+  --table students
+
+# multiple tables in one call:
+node /opt/psd-skills/psd-data/run.js schema --user <caller-email> \
+  --table '["students","enrollments"]'
+```
+
+### `permissions` — show the user's row-level filters on a table
+
+```bash
+node /opt/psd-skills/psd-data/run.js permissions --user <caller-email> \
+  --table students
+```
+
+Use this when a query unexpectedly returns no rows — the user may not
+have access to the rows they expect.
+
+### `query` — run a SELECT query
+
+```bash
+node /opt/psd-skills/psd-data/run.js query --user <caller-email> \
+  --reason "Headcount sanity check before report" \
+  --sql "SELECT COUNT(*) FROM students WHERE active = true"
+```
+
+Optional flags:
+- `--export` — return a 5-minute presigned S3 download URL for CSV (use
+  this when the user asks for the data as a file). If you get a `url` field
+  back in the result, paste it on its own line per rule 9.
+- `--view-results` — include the result rows inline (default true; pass
+  `--view-results false` for export-only).
+- `--limit <N>` `--offset <N>` — paging.
+
+`--reason` is **required** by the MCP server for audit. State the user's
+intent in plain English; do not pad with fluff.
+
+**Hard rules from the MCP server (do not try to bypass):**
+- Only `SELECT` queries are accepted; DDL / DML are rejected
+- Row-level security rewrites your query — do not write your own access
+  filters; let the server do it
+- Casts to `NUMERIC` / `DECIMAL` without precision are rejected
+
+### Lessons
+
+The MCP server has a persistent "lessons" store — cross-session knowledge
+about the data ("this column is null for graduated students", "this table
+joins on `student_id`, not `id`"). Use lessons when you learn something
+non-obvious that future invocations should know.
+
+**Save a lesson** (only after you've actually learned it):
+
+```bash
+node /opt/psd-skills/psd-data/run.js lesson-save --user <caller-email> \
+  --lesson "When querying student enrollments, filter exit_date IS NULL for active students. Otherwise counts double on re-enrollees." \
+  --tables '["students","enrollments"]' \
+  --task "headcount queries" \
+  --category "filter_behavior" \
+  --significance 7
+```
+
+Categories: `data_quality`, `schema`, `query_pattern`, `domain_knowledge`,
+`filter_behavior`. Significance is 1–10 (10 = critical correctness rule).
+
+**Check for relevant lessons** before running a query you're unsure about:
+
+```bash
+node /opt/psd-skills/psd-data/run.js lesson-check --user <caller-email> \
+  --task "headcount of active students" \
+  --tables '["students"]'
+```
+
+**Rate a lesson** that came back from `lesson-check`:
+
+```bash
+node /opt/psd-skills/psd-data/run.js lesson-rate --user <caller-email> \
+  --id 42 --rating helpful
+
+node /opt/psd-skills/psd-data/run.js lesson-rate --user <caller-email> \
+  --id 42 --rating unhelpful --feedback "The lesson was about a different table"
+```
+
+**Delete a lesson** you saved within the last 24 hours:
+
+```bash
+node /opt/psd-skills/psd-data/run.js lesson-delete --user <caller-email> \
+  --uuid <uuid-from-save-response>
+```
+
+## Rules
+
+1. **Pass the caller's email verbatim.** Do not substitute your own agent
+   email. Row-level security depends on it.
+2. **Always supply `--reason`** for `query`. Lying or padding will land in
+   the audit log; the data team reviews these.
+3. **No mutations.** The server rejects them; do not try.
+4. **On `needs-auth`, paste the consent link on its own line.** Do not
+   retry, do not improvise an alternative auth flow.
+5. **On `forbidden`, surface the data-team contact pointer.** The skill
+   already includes a helpful message — use it.
+
+## Example end-to-end
+
+User: "How many students were enrolled in PSD as of last Tuesday?"
+
+```bash
+# First, check what's known about this kind of query
+node /opt/psd-skills/psd-data/run.js lesson-check --user hagelk@psd401.net \
+  --task "active student headcount on a specific date" \
+  --tables '["students","enrollments"]'
+
+# Then inspect the schema
+node /opt/psd-skills/psd-data/run.js schema --user hagelk@psd401.net \
+  --table '["students","enrollments"]'
+
+# Run the query
+node /opt/psd-skills/psd-data/run.js query --user hagelk@psd401.net \
+  --reason "Active enrollment count as of 2026-05-06 per user request" \
+  --sql "SELECT COUNT(DISTINCT student_id) FROM enrollments
+         WHERE enroll_date <= '2026-05-06'
+           AND (exit_date IS NULL OR exit_date > '2026-05-06')"
+```

--- a/infra/agent-image/skills/psd-data/SKILL.md
+++ b/infra/agent-image/skills/psd-data/SKILL.md
@@ -164,6 +164,8 @@ node /opt/psd-skills/psd-data/run.js lesson-check --user <caller-email> \
 
 **Rate a lesson** that came back from `lesson-check`:
 
+`--feedback` is **required** when `--rating unhelpful`; optional (but encouraged) for `helpful`.
+
 ```bash
 node /opt/psd-skills/psd-data/run.js lesson-rate --user <caller-email> \
   --id 42 --rating helpful

--- a/infra/agent-image/skills/psd-data/common.js
+++ b/infra/agent-image/skills/psd-data/common.js
@@ -1,0 +1,366 @@
+/**
+ * Shared helpers for the psd-data OpenClaw skill.
+ *
+ * Authenticates the caller against the PSD data MCP server using a Cognito
+ * id_token derived from the user's stored refresh token. On missing or
+ * expired refresh token, mints a consent URL via AI Studio's
+ * /api/agent/consent-link endpoint (kind: cognito_data) so the agent can
+ * post the link in chat and have the user authorize.
+ *
+ * Environment contract (set by infra/lib/agent-platform-stack.ts):
+ *   AWS_REGION                          — e.g. us-east-1 (Cognito region)
+ *   ENVIRONMENT                         — dev/staging/prod
+ *   APP_BASE_URL                        — Base URL of the AI Studio web app
+ *   AGENT_INTERNAL_API_KEY_SECRET_ID    — Secrets Manager ID for shared secret
+ *   AUTH_COGNITO_USER_POOL_ID           — Cognito user pool (info only)
+ *   AUTH_COGNITO_CLIENT_ID              — Cognito app client (used for refresh)
+ *   AUTH_COGNITO_REGION                 — Cognito region (defaults to AWS_REGION)
+ *   PSD_DATA_MCP_URL                    — MCP server JSON-RPC endpoint
+ */
+
+'use strict';
+
+const {
+  SecretsManagerClient,
+  GetSecretValueCommand,
+} = require('@aws-sdk/client-secrets-manager');
+
+const REGION = process.env.AWS_REGION || 'us-east-1';
+const ENVIRONMENT = process.env.ENVIRONMENT || 'dev';
+const APP_BASE_URL = process.env.APP_BASE_URL || '';
+const AGENT_INTERNAL_API_KEY_SECRET_ID =
+  process.env.AGENT_INTERNAL_API_KEY_SECRET_ID ||
+  `psd-agent/${ENVIRONMENT}/internal-api-key`;
+const COGNITO_REGION =
+  process.env.AUTH_COGNITO_REGION || REGION;
+const COGNITO_CLIENT_ID = process.env.AUTH_COGNITO_CLIENT_ID || '';
+const PSD_DATA_MCP_URL = process.env.PSD_DATA_MCP_URL || '';
+
+const SAFE_EMAIL_RE = /^[\w%+.-]+@[\d.A-Za-z-]+\.[A-Za-z]{2,}$/;
+
+const smClient = new SecretsManagerClient({ region: REGION });
+
+function fail(message, code = 1) {
+  process.stderr.write(`psd-data: ${message}\n`);
+  process.exit(code);
+}
+
+function emit(obj) {
+  process.stdout.write(JSON.stringify(obj) + '\n');
+}
+
+/**
+ * Minimal long-form argv parser. Same conventions as psd-workspace's
+ * parseArgs — `--foo bar` and `--foo` (boolean) both supported, dashes in
+ * key names become underscores so callers can use `args.user_email` etc.
+ */
+function parseArgs(argv) {
+  const args = {};
+  for (let i = 2; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === '--help' || arg === '-h') {
+      args.help = true;
+      continue;
+    }
+    if (!arg.startsWith('--')) {
+      fail(`Unexpected positional argument: ${arg}`);
+    }
+    const key = arg.slice(2).replace(/-/g, '_');
+    const next = argv[i + 1];
+    if (next === undefined || next.startsWith('--')) {
+      args[key] = true;
+    } else {
+      args[key] = next;
+      i++;
+    }
+  }
+  return args;
+}
+
+function validateUserEmail(email) {
+  if (!email) fail('--user is required (authenticated caller email)');
+  if (typeof email !== 'string' || !SAFE_EMAIL_RE.test(email)) {
+    fail(`Invalid --user "${email}". Must be a valid email address.`);
+  }
+}
+
+function cognitoRefreshSecretId(email) {
+  return `psd-agent-creds/${ENVIRONMENT}/user/${email}/cognito-refresh`;
+}
+
+async function getSecretJson(secretId) {
+  const resp = await smClient.send(
+    new GetSecretValueCommand({ SecretId: secretId })
+  );
+  if (!resp.SecretString) {
+    throw new Error(`Secret ${secretId} has no SecretString value`);
+  }
+  try {
+    return JSON.parse(resp.SecretString);
+  } catch (err) {
+    throw new Error(`Secret ${secretId} is not valid JSON: ${err.message}`);
+  }
+}
+
+async function getSecretString(secretId) {
+  const resp = await smClient.send(
+    new GetSecretValueCommand({ SecretId: secretId })
+  );
+  return resp.SecretString || null;
+}
+
+/**
+ * Read the user's stored Cognito refresh-token record. Returns null when
+ * the secret does not yet exist (user hasn't completed the consent flow).
+ *
+ * Record shape (written by `lib/auth/agent-token-sync.ts`):
+ *   { refresh_token, obtained_at, user_pool_id, client_id, region }
+ */
+async function getUserCognitoRefreshRecord(email) {
+  const secretId = cognitoRefreshSecretId(email);
+  try {
+    return await getSecretJson(secretId);
+  } catch (err) {
+    if (err && err.name === 'ResourceNotFoundException') return null;
+    throw err;
+  }
+}
+
+/**
+ * Exchange the user's Cognito refresh token for a fresh id_token by POSTing
+ * directly to the Cognito Identity Provider service endpoint. No AWS
+ * credentials required — InitiateAuth with REFRESH_TOKEN_AUTH is a public
+ * endpoint that authenticates with the refresh token itself.
+ *
+ * Returns { id_token, access_token, expires_in } on success.
+ * Throws an Error with `code === 'NotAuthorizedException'` when the
+ * refresh token has been revoked or expired (caller should mint a fresh
+ * consent URL).
+ */
+async function refreshCognitoIdToken(refreshToken, clientId, region) {
+  const endpoint = `https://cognito-idp.${region}.amazonaws.com/`;
+  const body = JSON.stringify({
+    AuthFlow: 'REFRESH_TOKEN_AUTH',
+    ClientId: clientId,
+    AuthParameters: { REFRESH_TOKEN: refreshToken },
+  });
+
+  const resp = await fetch(endpoint, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-amz-json-1.1',
+      'X-Amz-Target': 'AWSCognitoIdentityProviderService.InitiateAuth',
+    },
+    body,
+  });
+
+  const data = await resp.json().catch(() => ({}));
+  if (!resp.ok) {
+    const err = new Error(
+      `Cognito InitiateAuth failed: ${resp.status} ${data.__type || data.message || ''}`
+    );
+    // Cognito returns errors as { __type: "NotAuthorizedException", message: "..." }
+    err.code = data.__type || `http_${resp.status}`;
+    err.cognito = data;
+    throw err;
+  }
+
+  const result = data.AuthenticationResult || {};
+  if (!result.IdToken) {
+    throw new Error('Cognito InitiateAuth returned no IdToken');
+  }
+  return {
+    id_token: result.IdToken,
+    access_token: result.AccessToken || null,
+    expires_in: result.ExpiresIn || null,
+  };
+}
+
+/**
+ * Ask AI Studio for a fresh signed consent URL the agent can give the user
+ * in chat. Uses the same internal-API-key auth as psd-workspace.
+ */
+async function mintConsentUrl(ownerEmail) {
+  if (!APP_BASE_URL) {
+    throw new Error('APP_BASE_URL env var not set — cannot mint consent URL');
+  }
+  const apiKey = await getSecretString(AGENT_INTERNAL_API_KEY_SECRET_ID);
+  if (!apiKey) {
+    throw new Error(
+      `Internal API key secret ${AGENT_INTERNAL_API_KEY_SECRET_ID} is empty`
+    );
+  }
+  const resp = await fetch(
+    `${APP_BASE_URL.replace(/\/$/, '')}/api/agent/consent-link`,
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({ ownerEmail, kind: 'cognito_data' }),
+    }
+  );
+  const data = await resp.json().catch(() => ({}));
+  if (!resp.ok || !data.url) {
+    throw new Error(
+      `Consent-link API failed: ${resp.status} ${data.error || ''}`
+    );
+  }
+  return data.url;
+}
+
+/**
+ * Emit a needs-auth payload and exit 10. Encapsulates the chat-format
+ * conventions (psd-rules rule 9) so callers don't have to duplicate them.
+ */
+async function emitNeedsAuthAndExit(ownerEmail, reason) {
+  let consentUrl;
+  try {
+    consentUrl = await mintConsentUrl(ownerEmail);
+  } catch (err) {
+    fail(`Unable to mint consent URL: ${err.message}`);
+  }
+  emit({
+    status: 'needs-auth',
+    kind: 'cognito_data',
+    reason,
+    consent_url: consentUrl,
+    consent_chat_hyperlink: `<${consentUrl}|Authorize PSD data access>`,
+    message:
+      'Paste consent_chat_hyperlink on its own line, no surrounding markdown. ' +
+      'Then on a separate line: "Click the link to let me query the PSD data warehouse on your behalf."',
+  });
+  process.exit(10);
+}
+
+/**
+ * Single entry point for every MCP call. Handles auth (refresh-or-mint),
+ * the JSON-RPC envelope, and uniform error surfacing.
+ *
+ *   - method: MCP method name ('tools/call', 'tools/list', etc.)
+ *   - params: object — the JSON-RPC params field
+ *   - ownerEmail: caller identity (used for the SM secret lookup)
+ *
+ * Side effects: writes the JSON-RPC result to stdout on success; emits a
+ * needs-auth payload + exits 10 if no token; emits a structured error and
+ * exits non-zero otherwise. Callers do not need to handle errors.
+ */
+async function callMcp(method, params, ownerEmail) {
+  if (!PSD_DATA_MCP_URL) {
+    fail('PSD_DATA_MCP_URL is not set');
+  }
+  if (!COGNITO_CLIENT_ID) {
+    fail('AUTH_COGNITO_CLIENT_ID is not set');
+  }
+
+  const record = await getUserCognitoRefreshRecord(ownerEmail);
+  if (!record || !record.refresh_token) {
+    await emitNeedsAuthAndExit(
+      ownerEmail,
+      'no refresh token stored for this user yet'
+    );
+  }
+
+  // Prefer the client_id captured at consent time; fall back to env var.
+  const clientId = record.client_id || COGNITO_CLIENT_ID;
+  const region = record.region || COGNITO_REGION;
+
+  let auth;
+  try {
+    auth = await refreshCognitoIdToken(record.refresh_token, clientId, region);
+  } catch (err) {
+    if (
+      err.code === 'NotAuthorizedException' ||
+      err.code === 'invalid_grant' ||
+      err.code === 'UserNotFoundException'
+    ) {
+      await emitNeedsAuthAndExit(
+        ownerEmail,
+        `stored refresh token rejected: ${err.code}`
+      );
+    }
+    fail(`Cognito token refresh failed: ${err.message}`);
+  }
+
+  const requestId = Math.floor(Math.random() * 1e9);
+  const rpcBody = {
+    jsonrpc: '2.0',
+    id: requestId,
+    method,
+    params: params || {},
+  };
+
+  const resp = await fetch(PSD_DATA_MCP_URL, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${auth.id_token}`,
+      'X-Client-Model': process.env.BUILD_MARKER || 'agentcore',
+      'mcp-protocol-version': '2025-11-25',
+    },
+    body: JSON.stringify(rpcBody),
+  });
+
+  // psd-data-mcp uses HTTP status codes for auth/permission errors and the
+  // JSON-RPC error field for tool errors. Handle both.
+  if (resp.status === 401) {
+    await emitNeedsAuthAndExit(ownerEmail, 'MCP server rejected token (401)');
+  }
+  if (resp.status === 403) {
+    const text = await resp.text().catch(() => '');
+    emit({
+      status: 'forbidden',
+      kind: 'data-permission',
+      message:
+        'The data MCP server denied access. Most likely the user is not yet ' +
+        'registered in the PSD data warehouse userpermissions table. Contact ' +
+        'the data team to be added.',
+      detail: text.slice(0, 1024),
+    });
+    process.exit(13);
+  }
+  if (resp.status === 429) {
+    emit({
+      status: 'rate-limited',
+      message:
+        'The data MCP server is rate-limiting requests for this user (60 per minute). ' +
+        'Wait a minute and retry.',
+    });
+    process.exit(14);
+  }
+  if (!resp.ok) {
+    const text = await resp.text().catch(() => '');
+    fail(`MCP HTTP ${resp.status}: ${text.slice(0, 512)}`, 12);
+  }
+
+  const data = await resp.json().catch(() => null);
+  if (!data) {
+    fail('MCP returned non-JSON body', 12);
+  }
+  if (data.error) {
+    emit({
+      status: 'mcp-error',
+      method,
+      jsonrpc_error: data.error,
+    });
+    process.exit(12);
+  }
+
+  process.stdout.write(JSON.stringify(data.result ?? null) + '\n');
+  return data.result ?? null;
+}
+
+module.exports = {
+  fail,
+  emit,
+  parseArgs,
+  validateUserEmail,
+  getUserCognitoRefreshRecord,
+  refreshCognitoIdToken,
+  mintConsentUrl,
+  emitNeedsAuthAndExit,
+  callMcp,
+  cognitoRefreshSecretId,
+  PSD_DATA_MCP_URL,
+};

--- a/infra/agent-image/skills/psd-data/common.js
+++ b/infra/agent-image/skills/psd-data/common.js
@@ -20,10 +20,14 @@
 
 'use strict';
 
+// Load the AWS SDK from psd-workspace's already-installed copy. Both skills
+// would otherwise install the same `@aws-sdk/client-secrets-manager` tree;
+// importing absolutely keeps the image file-count identical to a no-psd-data
+// build. See Dockerfile for the rationale.
 const {
   SecretsManagerClient,
   GetSecretValueCommand,
-} = require('@aws-sdk/client-secrets-manager');
+} = require('/opt/psd-skills/psd-workspace/node_modules/@aws-sdk/client-secrets-manager');
 
 const REGION = process.env.AWS_REGION || 'us-east-1';
 const ENVIRONMENT = process.env.ENVIRONMENT || 'dev';

--- a/infra/agent-image/skills/psd-data/package.json
+++ b/infra/agent-image/skills/psd-data/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "psd-data",
+  "version": "1.0.0",
+  "private": true,
+  "description": "OpenClaw skill: PSD data warehouse access via psd-data-mcp. Cognito-authenticated, row-level-security-enforced.",
+  "main": "run.js",
+  "dependencies": {
+    "@aws-sdk/client-secrets-manager": "^3.0.0"
+  }
+}

--- a/infra/agent-image/skills/psd-data/package.json
+++ b/infra/agent-image/skills/psd-data/package.json
@@ -2,9 +2,6 @@
   "name": "psd-data",
   "version": "1.0.0",
   "private": true,
-  "description": "OpenClaw skill: PSD data warehouse access via psd-data-mcp. Cognito-authenticated, row-level-security-enforced.",
-  "main": "run.js",
-  "dependencies": {
-    "@aws-sdk/client-secrets-manager": "^3.0.0"
-  }
+  "description": "OpenClaw skill: PSD data warehouse access via psd-data-mcp. Cognito-authenticated, row-level-security-enforced. @aws-sdk/client-secrets-manager is resolved at runtime via a symlink to psd-workspace's node_modules (see Dockerfile).",
+  "main": "run.js"
 }

--- a/infra/agent-image/skills/psd-data/run.js
+++ b/infra/agent-image/skills/psd-data/run.js
@@ -45,7 +45,7 @@ function usage() {
     [
       'Usage: node run.js <subcommand> --user <email> [...]',
       '',
-      'Subcommands:',
+      'Typed subcommands (validated args, recommended for known tools):',
       '  tables [--detailed]',
       '  schema --table <name|json-array>',
       '  permissions --table <name|json-array>',
@@ -54,6 +54,10 @@ function usage() {
       '  lesson-delete --uuid <id>',
       '  lesson-check --task <text> --tables <json> [--columns <json>]',
       '  lesson-rate --id <int> --rating <helpful|unhelpful> [--feedback <text>]',
+      '',
+      'Discovery / passthrough (use when a typed subcommand does not exist):',
+      '  list                              MCP tools/list — names + descriptions + inputSchema',
+      '  call --tool <name> --args <json>  MCP tools/call passthrough for any tool',
       '',
     ].join('\n')
   );
@@ -105,6 +109,25 @@ async function main() {
   const ownerEmail = args.user;
 
   switch (subcommand) {
+    case 'list': {
+      // Discovery — surface the MCP server's current tool catalog so the
+      // agent can detect new tools or schema changes without a redeploy.
+      await callMcp('tools/list', {}, ownerEmail);
+      return;
+    }
+
+    case 'call': {
+      // Generic passthrough — invoke any MCP tool by name with a
+      // JSON-encoded arguments object. Use this when a tool exists on
+      // the server but does not yet have a typed subcommand here.
+      const toolName = requireArg(args, 'tool');
+      const argsRaw = args.args === undefined || args.args === true ? '{}' : args.args;
+      const toolArgs = parseJsonArg('args', argsRaw);
+      const params = { name: toolName, arguments: toolArgs };
+      await callMcp('tools/call', params, ownerEmail);
+      return;
+    }
+
     case 'tables': {
       const params = {
         name: 'list_available_tables',

--- a/infra/agent-image/skills/psd-data/run.js
+++ b/infra/agent-image/skills/psd-data/run.js
@@ -1,0 +1,228 @@
+#!/usr/bin/env node
+/**
+ * run.js — psd-data skill entrypoint.
+ *
+ * Subcommands mirror the 8 tools exposed by psd-data-mcp. Every subcommand
+ * requires `--user <caller-email>` so the skill can look up the caller's
+ * Cognito refresh token in Secrets Manager.
+ *
+ * Usage:
+ *   node run.js tables --user <email> [--detailed]
+ *   node run.js schema --user <email> --table <name|json-array>
+ *   node run.js permissions --user <email> --table <name|json-array>
+ *   node run.js query --user <email> --reason <text> --sql <sql>
+ *                     [--export] [--view-results] [--limit N] [--offset N]
+ *   node run.js lesson-save --user <email> --lesson <text> --tables <json>
+ *                           --task <text> --category <enum>
+ *                           --significance <1-10> [--columns <json>]
+ *   node run.js lesson-delete --user <email> --uuid <id>
+ *   node run.js lesson-check --user <email> --task <text> --tables <json>
+ *                            [--columns <json>]
+ *   node run.js lesson-rate --user <email> --id <int>
+ *                           --rating <helpful|unhelpful> [--feedback <text>]
+ *
+ * Exit codes:
+ *   0   success (JSON-RPC result printed to stdout)
+ *   1   usage / config error
+ *   2   internal / unexpected
+ *   10  needs-auth (no stored refresh token, or it's been revoked)
+ *   12  upstream MCP error (JSON-RPC error or non-2xx without auth/perm meaning)
+ *   13  forbidden (HTTP 403 — user not in userpermissions table)
+ *   14  rate-limited (HTTP 429)
+ */
+
+'use strict';
+
+const {
+  fail,
+  parseArgs,
+  validateUserEmail,
+  callMcp,
+} = require('./common');
+
+function usage() {
+  process.stdout.write(
+    [
+      'Usage: node run.js <subcommand> --user <email> [...]',
+      '',
+      'Subcommands:',
+      '  tables [--detailed]',
+      '  schema --table <name|json-array>',
+      '  permissions --table <name|json-array>',
+      '  query --reason <text> --sql <sql> [--export] [--view-results] [--limit N] [--offset N]',
+      '  lesson-save --lesson <text> --tables <json> --task <text> --category <enum> --significance <1-10> [--columns <json>]',
+      '  lesson-delete --uuid <id>',
+      '  lesson-check --task <text> --tables <json> [--columns <json>]',
+      '  lesson-rate --id <int> --rating <helpful|unhelpful> [--feedback <text>]',
+      '',
+    ].join('\n')
+  );
+}
+
+function parseJsonArg(name, raw) {
+  if (raw === undefined) return undefined;
+  if (typeof raw !== 'string') return raw;
+  try {
+    return JSON.parse(raw);
+  } catch (err) {
+    fail(`--${name} must be valid JSON: ${err.message}`);
+    return undefined; // unreachable
+  }
+}
+
+function parseIntArg(name, raw) {
+  if (raw === undefined || raw === true) return undefined;
+  const n = Number(raw);
+  if (!Number.isFinite(n) || !Number.isInteger(n)) {
+    fail(`--${name} must be an integer`);
+  }
+  return n;
+}
+
+function requireArg(args, name) {
+  if (args[name] === undefined || args[name] === true || args[name] === '') {
+    fail(`--${name.replace(/_/g, '-')} is required`);
+  }
+  return args[name];
+}
+
+async function main() {
+  const subcommand = process.argv[2];
+  if (!subcommand || subcommand === '--help' || subcommand === '-h') {
+    usage();
+    process.exit(0);
+  }
+
+  // parseArgs skips argv[0..1]; ours adds argv[2] = subcommand. Shift so
+  // parseArgs reads flags starting at index 3.
+  const args = parseArgs([process.argv[0], process.argv[1], ...process.argv.slice(3)]);
+  if (args.help) {
+    usage();
+    process.exit(0);
+  }
+
+  validateUserEmail(args.user);
+  const ownerEmail = args.user;
+
+  switch (subcommand) {
+    case 'tables': {
+      const params = {
+        name: 'list_available_tables',
+        arguments: { detailed: !!args.detailed },
+      };
+      await callMcp('tools/call', params, ownerEmail);
+      return;
+    }
+
+    case 'schema': {
+      const table = requireArg(args, 'table');
+      // Accept a JSON array or a bare name.
+      const arg =
+        typeof table === 'string' && table.trim().startsWith('[')
+          ? parseJsonArg('table', table)
+          : table;
+      const params = {
+        name: 'inspect_table_schema',
+        arguments: { table_name: arg },
+      };
+      await callMcp('tools/call', params, ownerEmail);
+      return;
+    }
+
+    case 'permissions': {
+      const table = requireArg(args, 'table');
+      const arg =
+        typeof table === 'string' && table.trim().startsWith('[')
+          ? parseJsonArg('table', table)
+          : table;
+      const params = {
+        name: 'view_table_permissions',
+        arguments: { table_name: arg },
+      };
+      await callMcp('tools/call', params, ownerEmail);
+      return;
+    }
+
+    case 'query': {
+      const reason = requireArg(args, 'reason');
+      const sql = requireArg(args, 'sql');
+      const toolArgs = { reason, sql_query: sql };
+      if (args['export']) toolArgs.export = true;
+      if (args.view_results) toolArgs.view_results = true;
+      const limit = parseIntArg('limit', args.limit);
+      const offset = parseIntArg('offset', args.offset);
+      if (limit !== undefined) toolArgs.limit = limit;
+      if (offset !== undefined) toolArgs.offset = offset;
+      const params = { name: 'query_data', arguments: toolArgs };
+      await callMcp('tools/call', params, ownerEmail);
+      return;
+    }
+
+    case 'lesson-save': {
+      const lesson = requireArg(args, 'lesson');
+      const tablesInvolved = parseJsonArg('tables', requireArg(args, 'tables'));
+      const taskContext = requireArg(args, 'task');
+      const category = requireArg(args, 'category');
+      const significance = parseIntArg('significance', requireArg(args, 'significance'));
+      const columnsInvolved =
+        args.columns !== undefined ? parseJsonArg('columns', args.columns) : undefined;
+      const toolArgs = {
+        lesson,
+        tables_involved: tablesInvolved,
+        task_context: taskContext,
+        category,
+        significance,
+      };
+      if (columnsInvolved !== undefined) toolArgs.columns_involved = columnsInvolved;
+      const params = { name: 'save_lesson', arguments: toolArgs };
+      await callMcp('tools/call', params, ownerEmail);
+      return;
+    }
+
+    case 'lesson-delete': {
+      const uuid = requireArg(args, 'uuid');
+      const params = {
+        name: 'delete_lesson',
+        arguments: { lesson_uuid: uuid },
+      };
+      await callMcp('tools/call', params, ownerEmail);
+      return;
+    }
+
+    case 'lesson-check': {
+      const task = requireArg(args, 'task');
+      const tables = parseJsonArg('tables', requireArg(args, 'tables'));
+      const toolArgs = { task_description: task, tables };
+      if (args.columns !== undefined) {
+        toolArgs.columns = parseJsonArg('columns', args.columns);
+      }
+      const params = { name: 'check_lessons', arguments: toolArgs };
+      await callMcp('tools/call', params, ownerEmail);
+      return;
+    }
+
+    case 'lesson-rate': {
+      const id = parseIntArg('id', requireArg(args, 'id'));
+      const rating = requireArg(args, 'rating');
+      if (rating !== 'helpful' && rating !== 'unhelpful') {
+        fail('--rating must be "helpful" or "unhelpful"');
+      }
+      const toolArgs = { lesson_id: id, rating };
+      if (rating === 'unhelpful') {
+        toolArgs.feedback = requireArg(args, 'feedback');
+      } else if (args.feedback !== undefined && args.feedback !== true) {
+        toolArgs.feedback = args.feedback;
+      }
+      const params = { name: 'rate_lesson', arguments: toolArgs };
+      await callMcp('tools/call', params, ownerEmail);
+      return;
+    }
+
+    default:
+      fail(`Unknown subcommand: ${subcommand}. Run with --help to see options.`);
+  }
+}
+
+main().catch((err) => {
+  fail(err instanceof Error ? err.message : String(err), 2);
+});

--- a/infra/agent-image/skills/psd-data/run.js
+++ b/infra/agent-image/skills/psd-data/run.js
@@ -170,8 +170,10 @@ async function main() {
       const reason = requireArg(args, 'reason');
       const sql = requireArg(args, 'sql');
       const toolArgs = { reason, sql_query: sql };
-      if (args['export']) toolArgs.export = true;
-      if (args.view_results) toolArgs.view_results = true;
+      // parseArgs returns the string "false" for `--flag false`, which is
+      // truthy. Explicitly convert to boolean so --export false / --view-results false work.
+      if (args['export'] !== undefined) toolArgs.export = args['export'] === true || args['export'] === 'true';
+      if (args.view_results !== undefined) toolArgs.view_results = args.view_results === true || args.view_results === 'true';
       const limit = parseIntArg('limit', args.limit);
       const offset = parseIntArg('offset', args.offset);
       if (limit !== undefined) toolArgs.limit = limit;

--- a/infra/agent-image/skills/psd-image-gen/SKILL.md
+++ b/infra/agent-image/skills/psd-image-gen/SKILL.md
@@ -17,12 +17,26 @@ Generate an image from a prompt using OpenAI `gpt-image-2`. The image is uploade
 node /opt/psd-skills/psd-image-gen/generate.js \
   --user <email> \
   --prompt "<image description>" \
+  [--image <path-to-reference-image>] \
   [--size 1024x1024 | 1024x1536 | 1536x1024 | auto] \
   [--quality low | medium | high | auto] \
   [--background opaque | transparent | auto]
 ```
 
-Returns JSON: `{ "url": "...", "s3Key": "public-images/.../...png", "model": "gpt-image-2", "prompt": "...", "size": "...", "sharing": "public-by-link" }`.
+Returns JSON: `{ "url": "...", "s3Key": "public-images/.../...png", "model": "gpt-image-2", "prompt": "...", "size": "...", "mode": "generate"|"edit", "sharing": "public-by-link" }`.
+
+### With a reference image (logo, brand asset, layout)
+
+When the user asks for a flyer / header / social card that must include a PSD logo or other supplied artwork, fetch the asset first (typically via `psd-brand-guidelines`) and pass its local path with `--image`. The skill then calls OpenAI's `/v1/images/edits` endpoint so the model composes around the supplied image rather than hallucinating a similar one.
+
+```bash
+node /opt/psd-skills/psd-image-gen/generate.js \
+  --user <email> \
+  --image /home/node/workspace/brand/psd-logo.png \
+  --prompt "School newsletter header with this logo top-left, navy/gold palette, space for a date on the right."
+```
+
+Accepted reference-image formats: `.png`, `.jpg`/`.jpeg`, `.webp`, `.gif`. Max 8 MB. Multiple reference images are not supported in this version — pick the single most important asset.
 
 ## Required Reply Format
 

--- a/infra/agent-image/skills/psd-image-gen/generate.js
+++ b/infra/agent-image/skills/psd-image-gen/generate.js
@@ -18,6 +18,7 @@
 
 const { execFileSync } = require('node:child_process');
 const { randomUUID } = require('node:crypto');
+const fs = require('node:fs');
 const path = require('node:path');
 
 const { S3Client, PutObjectCommand } = require('@aws-sdk/client-s3');
@@ -44,6 +45,20 @@ const MODEL_ID = 'gpt-image-2';
 const ALLOWED_SIZES = new Set(['1024x1024', '1024x1536', '1536x1024', 'auto']);
 const ALLOWED_QUALITIES = new Set(['low', 'medium', 'high', 'auto']);
 const ALLOWED_BACKGROUNDS = new Set(['opaque', 'transparent', 'auto']);
+// Reference-image input — psd-brand-guidelines drops logo files in the
+// workspace, then the agent passes one via --image to compose branded
+// outputs through OpenAI's /v1/images/edits endpoint. The endpoint expects
+// each image as a data URL inside an `images: [{ image_url }]` array.
+const ALLOWED_IMAGE_EXTS = new Map([
+  ['.png', 'image/png'],
+  ['.jpg', 'image/jpeg'],
+  ['.jpeg', 'image/jpeg'],
+  ['.webp', 'image/webp'],
+  ['.gif', 'image/gif'],
+]);
+// OpenAI's edits endpoint accepts up to ~20MB per image. Cap at 8MB to keep
+// JSON payload reasonable (base64 inflates 33%, so 8MB → ~11MB on the wire).
+const MAX_REFERENCE_IMAGE_BYTES = 8 * 1024 * 1024;
 
 const CREDENTIALS_GET = path.resolve(
   __dirname,
@@ -189,6 +204,72 @@ function readSharedOpenAIKey(userEmail) {
   return parsed.value;
 }
 
+/**
+ * Read a reference image from disk and return `{ dataUrl, mime }`.
+ * Validates the extension is one OpenAI accepts and the file size is
+ * under MAX_REFERENCE_IMAGE_BYTES so we fail fast with a clear message
+ * rather than blowing up the JSON payload.
+ */
+function loadReferenceImage(imagePath) {
+  let stat;
+  try {
+    stat = fs.statSync(imagePath);
+  } catch (err) {
+    fail(`--image file not found or unreadable: ${imagePath} (${err.message})`, 'bad_args');
+  }
+  if (!stat.isFile()) {
+    fail(`--image path is not a file: ${imagePath}`, 'bad_args');
+  }
+  if (stat.size > MAX_REFERENCE_IMAGE_BYTES) {
+    fail(
+      `--image file is ${stat.size} bytes; maximum is ${MAX_REFERENCE_IMAGE_BYTES}`,
+      'bad_args',
+    );
+  }
+  const ext = path.extname(imagePath).toLowerCase();
+  const mime = ALLOWED_IMAGE_EXTS.get(ext);
+  if (!mime) {
+    fail(
+      `--image extension ${ext || '(none)'} not supported. Allowed: ${[...ALLOWED_IMAGE_EXTS.keys()].join(', ')}`,
+      'bad_args',
+    );
+  }
+  const base64 = fs.readFileSync(imagePath).toString('base64');
+  return { dataUrl: `data:${mime};base64,${base64}`, mime };
+}
+
+async function editWithImage(apiKey, params, referenceDataUrl) {
+  const body = {
+    model: MODEL_ID,
+    images: [{ image_url: referenceDataUrl }],
+    prompt: params.prompt,
+  };
+  if (params.size && params.size !== 'auto') body.size = params.size;
+  if (params.quality && params.quality !== 'auto') body.quality = params.quality;
+  if (params.background && params.background !== 'auto') body.background = params.background;
+
+  const resp = await fetch('https://api.openai.com/v1/images/edits', {
+    method: 'POST',
+    headers: {
+      'Authorization': `Bearer ${apiKey}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(body),
+  });
+
+  if (!resp.ok) {
+    const text = await resp.text().catch(() => '');
+    fail(`OpenAI API ${resp.status}: ${text.slice(0, 500)}`, 'upstream_error');
+  }
+
+  const data = await resp.json();
+  const first = (data && Array.isArray(data.data)) ? data.data[0] : null;
+  if (!first || !first.b64_json) {
+    fail('OpenAI response missing b64_json image data', 'upstream_error');
+  }
+  return Buffer.from(first.b64_json, 'base64');
+}
+
 async function generateImage(apiKey, params) {
   const body = { model: MODEL_ID, prompt: params.prompt };
   if (params.size && params.size !== 'auto') body.size = params.size;
@@ -251,7 +332,7 @@ async function uploadAndShare(bytes, userEmail) {
 async function main() {
   const args = parseArgs(process.argv);
   if (args.help) {
-    console.log('Usage: generate.js --user <email> --prompt "<text>" [--size auto|1024x1024|1024x1536|1536x1024] [--quality auto|low|medium|high] [--background auto|opaque|transparent]');
+    console.log('Usage: generate.js --user <email> --prompt "<text>" [--image <path>] [--size auto|1024x1024|1024x1536|1536x1024] [--quality auto|low|medium|high] [--background auto|opaque|transparent]');
     process.exit(0);
   }
   if (!validateEmail(args.user)) {
@@ -285,9 +366,22 @@ async function main() {
     fail('WORKSPACE_BUCKET env var not set — cannot upload generated image', 'misconfigured');
   }
 
+  // --image is optional. When present it must be a real path (no `--image`
+  // followed by another flag) and selects the /v1/images/edits endpoint so
+  // the model composes the output around the reference image. Validate the
+  // path up front — same tier as size/quality checks — so we fail fast
+  // before the RBAC shell-out + API-key fetch.
+  const imagePath = args.image && args.image !== true ? String(args.image) : null;
+  // Load + validate the reference image up front so a bad path fails fast,
+  // before the RBAC shell-out and API-key fetch.
+  const referenceImage = imagePath ? loadReferenceImage(imagePath) : null;
+
   enforceCapability(args.user);
   const apiKey = readSharedOpenAIKey(args.user);
-  const bytes = await generateImage(apiKey, { prompt: args.prompt, size, quality, background });
+  const params = { prompt: args.prompt, size, quality, background };
+  const bytes = referenceImage
+    ? await editWithImage(apiKey, params, referenceImage.dataUrl)
+    : await generateImage(apiKey, params);
   const { url, key } = await uploadAndShare(bytes, args.user);
 
   emit({
@@ -298,6 +392,7 @@ async function main() {
     size,
     quality,
     background,
+    mode: referenceImage ? 'edit' : 'generate',
     // The URL is unsigned and does not expire. Anyone with the link can fetch
     // until the object is deleted (manual lifecycle policy may be added later).
     sharing: 'public-by-link',

--- a/infra/agent-image/skills/psd-rules/SKILL.md
+++ b/infra/agent-image/skills/psd-rules/SKILL.md
@@ -274,6 +274,22 @@ caller `hagelk@psd401.net` authoring a "weekly digest" skill →
 
 ---
 
+## Rule 12 — Always reply with something
+
+**Every turn must produce at least one short user-visible sentence (or emoji). Never end a turn with an empty assistant message.**
+
+**Why:** The harness has a hard fallback for empty turns — if you produce zero user-visible text it sends the literal string `"I processed your message but had no response."` to chat on your behalf. That string is awkward, looks broken to the user, and writes a misleading `empty_response` record into `agent_failures`. The fallback exists for crashes and timeouts — do not trigger it on routine turns.
+
+**How to apply:**
+
+- **Pure acknowledgments ("Perfect!", "Thanks", "Got it", "Cool")** → one-token reply is fine. "Anytime." / "👍" / "Glad it worked." Pick one and ship it. Do not stay silent.
+- **Tool calls with no remaining narrative** → after the last skill returns, write the one-line summary or paste the URL. Do not exit the turn on tool output alone.
+- **Forbidden under any circumstance:** an assistant turn whose final user-visible text is the empty string.
+
+The reply can be one character. It cannot be zero characters.
+
+---
+
 ## Self-check before send
 
 Run this checklist mentally before every reply:
@@ -287,5 +303,6 @@ Run this checklist mentally before every reply:
 7. ✅ For any task a skill covers, did I call the skill — not replicate it in Bash?
 8. ✅ If the last tool result had a `url` field, is that exact URL pasted on its own line in my reply? Prose description ≠ URL.
 9. ✅ If I could not fulfill any part of the request, did I call `psd-failure-report` before sending?
+10. ✅ Is the user-visible text **non-empty**? (Acknowledgments count — even one emoji counts. Empty does not.)
 
 If any answer is "no" — fix the reply before sending.

--- a/infra/agent-image/skills/psd-workspace/SKILL.md
+++ b/infra/agent-image/skills/psd-workspace/SKILL.md
@@ -13,7 +13,7 @@ Google Workspace access for the user's data, gated by Phase 1 boundaries (#912).
 
 Phase 1 introduces two parallel OAuth identities per user. The `--scope` flag selects which:
 
-- `--scope user` (**default**) — OAuth on the human user (e.g. `hagelk@psd401.net`). Narrow scopes: `gmail.readonly`, `gmail.compose`, `calendar`, `tasks`, `drive.file`. Use this for reading the user's mail, managing their tasks, writing to their calendar, creating new Drive files for them.
+- `--scope user` (**default**) — OAuth on the human user (e.g. `hagelk@psd401.net`). Scopes: `gmail.modify` (read + draft + send + archive/label, no permanent delete), `calendar`, `tasks`, `drive.file`. Use this for reading the user's mail, managing their tasks, writing to their calendar, creating new Drive files for them. Sending is gated by behavioral rules — always confirm before actually sending.
 - `--scope agent` — OAuth on the agent identity (e.g. `agnt_hagelk@psd401.net`). Broad scopes. Use this for actions the agent takes *as itself* (the agent's own calendar, drafts owned by the agent, agent-owned Drive folder).
 
 If you omit `--scope`, the skill defaults to `user`. Phase 1 work is overwhelmingly on user data.

--- a/infra/agent-image/skills/psd-workspace/common.js
+++ b/infra/agent-image/skills/psd-workspace/common.js
@@ -28,9 +28,8 @@ const AGENT_INTERNAL_API_KEY_SECRET_ID = process.env.AGENT_INTERNAL_API_KEY_SECR
 
 // Two slots per user (#912 Phase 1 — see secrets-manager.ts):
 //   'agent_account' = OAuth on agnt_<uniqname>@psd401.net (broad scopes)
-//   'user_account'  = OAuth on the human user (narrow Phase 1 scopes:
-//                     gmail.readonly, gmail.compose, calendar, tasks,
-//                     drive.file)
+//   'user_account'  = OAuth on the human user (scopes:
+//                     gmail.modify, calendar, tasks, drive.file)
 //
 // The user_account path is suffixed (-user) so revocation tools can iterate
 // by prefix and tell the slots apart.
@@ -236,10 +235,15 @@ function execGws(commandString, accessToken) {
 // argv-tokenized command before exec.
 //
 // Phase 1 product policy:
-//   - No sending mail (drafts only — user must hit send themselves)
+//   - No sending mail (drafts only — user must hit send themselves).
+//     Note: the OAuth grant on the user_account scope is now gmail.modify
+//     (upgraded from gmail.compose) so the agent can archive/label on the
+//     user's behalf. gmail.modify ALSO carries send capability at the API
+//     level, so the regex below is now the sole barrier against the agent
+//     actually putting a message on the wire. Treat this list as load-bearing.
 //   - No deleting anything (mail, events, files, tasks)
-//   - No modifying user-created mail (modify labels via gmail.users.messages.modify
-//     is allowed for marking-as-read / archiving, but trash is not)
+//   - Archive / label-modify allowed via gmail.users.messages.modify;
+//     trashing / permanent delete still blocked below.
 //
 // Each entry: {pattern: regex, reason: human-readable explanation}.
 // `pattern` matches against the SPACE-JOINED argv tokens, lowercased — so

--- a/infra/agent-image/skills/psd-workspace/run.js
+++ b/infra/agent-image/skills/psd-workspace/run.js
@@ -9,8 +9,10 @@
  * the skill uses to authenticate the gws call:
  *
  *   --scope user (default for Phase 1) →
- *     OAuth on the human user's identity (hagelk@psd401.net), narrow scopes
- *     (gmail.readonly, gmail.compose, calendar, tasks, drive.file). Use for
+ *     OAuth on the human user's identity (hagelk@psd401.net), scopes
+ *     (gmail.modify, calendar, tasks, drive.file). gmail.modify covers
+ *     read + draft + archive/label + (technically) send — sending is
+ *     blocked by the skill's regex gate, not by the OAuth scope. Use for
  *     reading/writing the human's own data.
  *
  *   --scope agent →

--- a/infra/agent-image/workspace_sync.py
+++ b/infra/agent-image/workspace_sync.py
@@ -89,6 +89,7 @@ _SKIP_RELATIVE_PREFIXES = (
     "skills/gws-",
     "skills/psd-brand-guidelines/",
     "skills/psd-credentials/",
+    "skills/psd-data/",
     "skills/psd-failure-report/",
     "skills/psd-freshservice/",
     "skills/psd-github/",

--- a/infra/bin/infra.ts
+++ b/infra/bin/infra.ts
@@ -173,6 +173,9 @@ const devAgentPlatformStack = new AgentPlatformStack(app, 'AIStudio-AgentPlatfor
 });
 devAgentPlatformStack.addDependency(devDbStack);
 devAgentPlatformStack.addDependency(devGuardrailsStack);
+// Cognito user-pool exports are imported via Fn.importValue for the
+// psd-data skill env vars (AUTH_COGNITO_USER_POOL_ID, AUTH_COGNITO_CLIENT_ID).
+devAgentPlatformStack.addDependency(devAuthStack);
 cdk.Tags.of(devAgentPlatformStack).add('Environment', 'Dev');
 Object.entries(standardTags).forEach(([key, value]) => cdk.Tags.of(devAgentPlatformStack).add(key, value));
 
@@ -317,6 +320,7 @@ const prodAgentPlatformStack = new AgentPlatformStack(app, 'AIStudio-AgentPlatfo
 });
 prodAgentPlatformStack.addDependency(prodDbStack);
 prodAgentPlatformStack.addDependency(prodGuardrailsStack);
+prodAgentPlatformStack.addDependency(prodAuthStack);
 cdk.Tags.of(prodAgentPlatformStack).add('Environment', 'Prod');
 Object.entries(standardTags).forEach(([key, value]) => cdk.Tags.of(prodAgentPlatformStack).add(key, value));
 

--- a/infra/database/migrations.json
+++ b/infra/database/migrations.json
@@ -71,6 +71,7 @@
     "073-agent-workspace-token-kind.sql",
     "074-deep-research-capability.sql",
     "075-skill-required-capability.sql",
-    "076-agent-failures.sql"
+    "076-agent-failures.sql",
+    "077-agent-workspace-consent-nonces-cognito-data.sql"
   ]
 }

--- a/infra/database/schema/077-agent-workspace-consent-nonces-cognito-data.sql
+++ b/infra/database/schema/077-agent-workspace-consent-nonces-cognito-data.sql
@@ -1,0 +1,30 @@
+-- Migration 077: Widen psd_agent_workspace_consent_nonces.token_kind to allow
+-- 'cognito_data' alongside the existing 'agent_account' / 'user_account'.
+--
+-- Why: the data-MCP integration reuses this table's nonce + per-owner
+-- rate-limit infrastructure to issue one-time consent URLs for Cognito
+-- refresh-token capture (kind = 'cognito_data'). The Drizzle schema's
+-- `$type<>()` declaration was widened in the application code, but the
+-- DB-level CHECK constraint from migration 073 still only allowed the
+-- two original kinds, so inserts with 'cognito_data' failed with:
+--
+--   new row for relation "psd_agent_workspace_consent_nonces" violates
+--   check constraint "psd_agent_workspace_consent_nonces_token_kind_check"
+--
+-- The column is varchar(16); 'cognito_data' is 12 chars so no length
+-- change is needed. Only the CHECK constraint needs to be re-stated.
+--
+-- The psd_agent_workspace_tokens table keeps its narrower CHECK
+-- (agent_account, user_account only) because the agent's cognito-refresh
+-- credential is stored at a different Secrets Manager path —
+-- psd-agent-creds/{env}/user/{email}/cognito-refresh — not in this table.
+
+UPDATE migration_log SET status = 'completed'
+WHERE description = '077-agent-workspace-consent-nonces-cognito-data.sql' AND status = 'failed';
+
+ALTER TABLE psd_agent_workspace_consent_nonces
+    DROP CONSTRAINT IF EXISTS psd_agent_workspace_consent_nonces_token_kind_check;
+
+ALTER TABLE psd_agent_workspace_consent_nonces
+    ADD CONSTRAINT psd_agent_workspace_consent_nonces_token_kind_check
+    CHECK (token_kind IN ('agent_account', 'user_account', 'cognito_data'));

--- a/infra/lib/agent-platform-stack.ts
+++ b/infra/lib/agent-platform-stack.ts
@@ -1,6 +1,5 @@
 import * as cdk from 'aws-cdk-lib';
 import { Construct } from 'constructs';
-import * as crypto from 'crypto';
 import * as ec2 from 'aws-cdk-lib/aws-ec2';
 import * as ecr from 'aws-cdk-lib/aws-ecr';
 import * as s3 from 'aws-cdk-lib/aws-s3';
@@ -1150,19 +1149,25 @@ export class AgentPlatformStack extends cdk.Stack {
         : (imageTag ?? 'unset'),
     };
 
-    // Hash the env-var config so non-image deploys rotate session IDs.
+    // Fingerprint the env-var config so non-image deploys rotate session IDs.
     // cdk.Fn.importValue tokens stringify to deterministic placeholders, so
-    // an upstream value change won't bump the hash — but env-var ADD/REMOVE
-    // or literal-value changes (URLs, ARN templates, defaults) will.
-    const configHash = crypto
-      .createHash('sha256')
-      .update(JSON.stringify(runtimeEnvVars))
-      .digest('hex')
-      .substring(0, 8);
+    // an upstream value change won't bump the fingerprint — but env-var
+    // ADD/REMOVE or literal-value changes (URLs, ARN templates, defaults)
+    // will. DJB2 is intentional: this is a non-security fingerprint, and
+    // sha256 here trips CodeQL's password-hash detector with a false
+    // positive because the dict references (but does not contain) secrets.
+    const configFingerprint = (() => {
+      const s = JSON.stringify(runtimeEnvVars);
+      let h = 5381;
+      for (let i = 0; i < s.length; i++) {
+        h = ((h * 33) ^ s.charCodeAt(i)) >>> 0;
+      }
+      return h.toString(16).padStart(8, '0');
+    })();
 
     const agentBuildTag = imageDigest
-      ? `${imageDigest.replace('sha256:', '').substring(0, 12)}-${configHash}`
-      : `${imageTag ?? ''}-${configHash}`;
+      ? `${imageDigest.replace('sha256:', '').substring(0, 12)}-${configFingerprint}`
+      : `${imageTag ?? ''}-${configFingerprint}`;
 
     const artifact = imageDigest
       ? agentcore.AgentRuntimeArtifact.fromImageUri(

--- a/infra/lib/agent-platform-stack.ts
+++ b/infra/lib/agent-platform-stack.ts
@@ -1172,6 +1172,24 @@ export class AgentPlatformStack extends cdk.Stack {
           // Empty string is harmless at runtime — the skill fails with an
           // explicit error message if a consent URL is ever actually required.
           APP_BASE_URL: props.appBaseUrl ?? '',
+          // psd-data skill — wires the agent to the PSD data MCP server.
+          // The MCP URL is a CDK context override (psdDataMcpUrl) so dev /
+          // staging can target a different deployment without code changes.
+          // Default is the prod Lambda URL.
+          PSD_DATA_MCP_URL:
+            (this.node.tryGetContext('psdDataMcpUrl') as string | undefined)
+            ?? 'https://l3jpggwgsojgql275k6axcboue0syeuq.lambda-url.us-west-2.on.aws/mcp',
+          // Cognito identifiers — used by the psd-data skill to refresh
+          // the caller's stored refresh token into a fresh id_token. We
+          // import these from AuthStack's CloudFormation exports rather
+          // than threading them through stack props.
+          AUTH_COGNITO_USER_POOL_ID: cdk.Fn.importValue(
+            `${environment}-CognitoUserPoolId`,
+          ),
+          AUTH_COGNITO_CLIENT_ID: cdk.Fn.importValue(
+            `${environment}-CognitoUserPoolClientId`,
+          ),
+          AUTH_COGNITO_REGION: this.region,
           // Identity marker — surfaced in container startup log so we can
           // verify the running code matches the deployed image manifest.
           BUILD_MARKER: imageDigest

--- a/infra/lib/agent-platform-stack.ts
+++ b/infra/lib/agent-platform-stack.ts
@@ -1173,12 +1173,12 @@ export class AgentPlatformStack extends cdk.Stack {
           // explicit error message if a consent URL is ever actually required.
           APP_BASE_URL: props.appBaseUrl ?? '',
           // psd-data skill — wires the agent to the PSD data MCP server.
-          // The MCP URL is a CDK context override (psdDataMcpUrl) so dev /
-          // staging can target a different deployment without code changes.
-          // Default is the prod Lambda URL.
+          // REQUIRED: pass -c psdDataMcpUrl=<url> at synth/deploy time.
+          // An empty string causes the skill to fail loudly (missing URL),
+          // which is safer than silently routing all environments to prod.
           PSD_DATA_MCP_URL:
             (this.node.tryGetContext('psdDataMcpUrl') as string | undefined)
-            ?? 'https://l3jpggwgsojgql275k6axcboue0syeuq.lambda-url.us-west-2.on.aws/mcp',
+            ?? '',
           // Cognito identifiers — used by the psd-data skill to refresh
           // the caller's stored refresh token into a fresh id_token. We
           // import these from AuthStack's CloudFormation exports rather

--- a/infra/lib/agent-platform-stack.ts
+++ b/infra/lib/agent-platform-stack.ts
@@ -1,5 +1,6 @@
 import * as cdk from 'aws-cdk-lib';
 import { Construct } from 'constructs';
+import * as crypto from 'crypto';
 import * as ec2 from 'aws-cdk-lib/aws-ec2';
 import * as ecr from 'aws-cdk-lib/aws-ecr';
 import * as s3 from 'aws-cdk-lib/aws-s3';
@@ -1111,6 +1112,58 @@ export class AgentPlatformStack extends cdk.Stack {
     const imageTag = this.node.tryGetContext('agentImageTag') as string | undefined;
     const imageDigest = this.node.tryGetContext('agentImageDigest') as string | undefined;
 
+    // Runtime environment variables shared by the AgentCore Runtime AND used
+    // to derive AGENT_BUILD_TAG. Extracting them lets us hash the config so
+    // that env-var-only deploys (no image change) still rotate session IDs.
+    // Without this, AgentCore sticky-routes existing sessions back to old
+    // microVMs whose env snapshot pre-dates the new config.
+    const runtimeEnvVars: Record<string, string> = {
+      ENVIRONMENT: environment,
+      WORKSPACE_BUCKET: this.workspaceBucket.bucketName,
+      USERS_TABLE: this.usersTable.tableName,
+      SIGNALS_TABLE: this.signalsTable.tableName,
+      SCHEDULES_TABLE: schedulesTable.tableName,
+      EVENTBRIDGE_SCHEDULE_GROUP: `psd-agent-${environment}`,
+      CRON_LAMBDA_ARN: `arn:aws:lambda:${this.region}:${this.account}:function:psd-agent-cron-${environment}`,
+      EVENTBRIDGE_ROLE_ARN: `arn:aws:iam::${this.account}:role/psd-agent-scheduler-invoke-${environment}`,
+      GUARDRAIL_ARN: props.guardrailArn,
+      DATABASE_RESOURCE_ARN: props.databaseResourceArn,
+      DATABASE_SECRET_ARN: props.databaseSecretArn,
+      DATABASE_NAME: props.databaseName ?? 'aistudio',
+      BEDROCK_API_KEY_SECRET_ARN: this.bedrockApiKeySecret.secretArn,
+      SKILL_BUILDER_LAMBDA_ARN: `arn:aws:lambda:${this.region}:${this.account}:function:psd-agent-skill-builder-${environment}`,
+      GOOGLE_OAUTH_CLIENT_SECRET_ID: googleOAuthClientSecret.secretName,
+      AGENT_INTERNAL_API_KEY_SECRET_ID: agentInternalApiKeySecret.secretName,
+      APP_BASE_URL: props.appBaseUrl ?? '',
+      PSD_DATA_MCP_URL:
+        (this.node.tryGetContext('psdDataMcpUrl') as string | undefined)
+        ?? 'https://l3jpggwgsojgql275k6axcboue0syeuq.lambda-url.us-west-2.on.aws/mcp',
+      AUTH_COGNITO_USER_POOL_ID: cdk.Fn.importValue(
+        `${environment}-CognitoUserPoolId`,
+      ),
+      AUTH_COGNITO_CLIENT_ID: cdk.Fn.importValue(
+        `${environment}-CognitoUserPoolClientId`,
+      ),
+      AUTH_COGNITO_REGION: this.region,
+      BUILD_MARKER: imageDigest
+        ? `${imageTag ?? 'no-tag'}@${imageDigest}`
+        : (imageTag ?? 'unset'),
+    };
+
+    // Hash the env-var config so non-image deploys rotate session IDs.
+    // cdk.Fn.importValue tokens stringify to deterministic placeholders, so
+    // an upstream value change won't bump the hash — but env-var ADD/REMOVE
+    // or literal-value changes (URLs, ARN templates, defaults) will.
+    const configHash = crypto
+      .createHash('sha256')
+      .update(JSON.stringify(runtimeEnvVars))
+      .digest('hex')
+      .substring(0, 8);
+
+    const agentBuildTag = imageDigest
+      ? `${imageDigest.replace('sha256:', '').substring(0, 12)}-${configHash}`
+      : `${imageTag ?? ''}-${configHash}`;
+
     const artifact = imageDigest
       ? agentcore.AgentRuntimeArtifact.fromImageUri(
           `${this.ecrRepository.repositoryUri}@${imageDigest}`,
@@ -1137,66 +1190,7 @@ export class AgentPlatformStack extends cdk.Stack {
           },
         }),
         description: `PSD AI Agent Platform runtime (${environment})`,
-        environmentVariables: {
-          ENVIRONMENT: environment,
-          WORKSPACE_BUCKET: this.workspaceBucket.bucketName,
-          USERS_TABLE: this.usersTable.tableName,
-          SIGNALS_TABLE: this.signalsTable.tableName,
-          SCHEDULES_TABLE: schedulesTable.tableName,
-          // Inputs for the psd-schedules OpenClaw skill. The skill writes
-          // EventBridge Scheduler entries directly under the AgentCore role.
-          // Compute ARNs / names from stable identifiers so we don't need to
-          // reorder this block before the Scheduler constructs are declared;
-          // CDK dependency tracking still links them through the IAM grants.
-          EVENTBRIDGE_SCHEDULE_GROUP: `psd-agent-${environment}`,
-          CRON_LAMBDA_ARN: `arn:aws:lambda:${this.region}:${this.account}:function:psd-agent-cron-${environment}`,
-          EVENTBRIDGE_ROLE_ARN: `arn:aws:iam::${this.account}:role/psd-agent-scheduler-invoke-${environment}`,
-          GUARDRAIL_ARN: props.guardrailArn,
-          DATABASE_RESOURCE_ARN: props.databaseResourceArn,
-          DATABASE_SECRET_ARN: props.databaseSecretArn,
-          DATABASE_NAME: props.databaseName ?? 'aistudio',
-          // ARN of the Secrets Manager secret holding the Bedrock API key.
-          // `agentcore_wrapper.py` fetches this on startup and exports its
-          // value as AWS_BEARER_TOKEN_BEDROCK so OpenClaw can authenticate
-          // to Bedrock Mantle (the OpenAI-compatible endpoint). Using a
-          // reference rather than embedding the secret value keeps rotation
-          // seamless — new microVMs just re-read the latest version.
-          BEDROCK_API_KEY_SECRET_ARN: this.bedrockApiKeySecret.secretArn,
-          // Skill Builder Lambda ARN — used by the psd-skills-meta skill
-          // to trigger async scan + promotion of agent-authored drafts.
-          SKILL_BUILDER_LAMBDA_ARN: `arn:aws:lambda:${this.region}:${this.account}:function:psd-agent-skill-builder-${environment}`,
-          // Google Workspace OAuth secrets — used by psd-workspace skill (#912)
-          GOOGLE_OAUTH_CLIENT_SECRET_ID: googleOAuthClientSecret.secretName,
-          AGENT_INTERNAL_API_KEY_SECRET_ID: agentInternalApiKeySecret.secretName,
-          // Base URL the psd-workspace skill uses to reach /api/agent/consent-link.
-          // Empty string is harmless at runtime — the skill fails with an
-          // explicit error message if a consent URL is ever actually required.
-          APP_BASE_URL: props.appBaseUrl ?? '',
-          // psd-data skill — wires the agent to the PSD data MCP server.
-          // Same Lambda URL for dev and prod (the MCP server trusts both
-          // Cognito pools), so we hardcode rather than threading through
-          // CDK context. Override at deploy time with -c psdDataMcpUrl=<url>
-          // if a future environment needs a different endpoint.
-          PSD_DATA_MCP_URL:
-            (this.node.tryGetContext('psdDataMcpUrl') as string | undefined)
-            ?? 'https://l3jpggwgsojgql275k6axcboue0syeuq.lambda-url.us-west-2.on.aws/mcp',
-          // Cognito identifiers — used by the psd-data skill to refresh
-          // the caller's stored refresh token into a fresh id_token. We
-          // import these from AuthStack's CloudFormation exports rather
-          // than threading them through stack props.
-          AUTH_COGNITO_USER_POOL_ID: cdk.Fn.importValue(
-            `${environment}-CognitoUserPoolId`,
-          ),
-          AUTH_COGNITO_CLIENT_ID: cdk.Fn.importValue(
-            `${environment}-CognitoUserPoolClientId`,
-          ),
-          AUTH_COGNITO_REGION: this.region,
-          // Identity marker — surfaced in container startup log so we can
-          // verify the running code matches the deployed image manifest.
-          BUILD_MARKER: imageDigest
-            ? `${imageTag ?? 'no-tag'}@${imageDigest}`
-            : (imageTag ?? 'unset'),
-        },
+        environmentVariables: runtimeEnvVars,
         lifecycleConfiguration: {
           idleRuntimeSessionTimeout: cdk.Duration.minutes(config.agent.microVmIdleTimeoutMinutes),
         },
@@ -1667,16 +1661,16 @@ export class AgentPlatformStack extends cdk.Stack {
         // from SSM at runtime because the Runtime resource is conditionally
         // created only when an image tag is provided via CDK context.
         //
-        // AGENT_BUILD_TAG — short stable identifier for the deployed AgentCore
-        // image. Mixed into the AgentCore session ID so every deploy
-        // invalidates sticky-routed microVMs. Without this, AgentCore happily
-        // serves an existing user's session from a microVM running an OLD
-        // image until idleRuntimeSessionTimeout, which can be hours for an
-        // active user — a real correctness/security risk at scale. Empty
-        // string is fine; it just means we did not pin a digest this deploy.
-        AGENT_BUILD_TAG: imageDigest
-          ? imageDigest.replace('sha256:', '').substring(0, 12)
-          : (imageTag ?? ''),
+        // AGENT_BUILD_TAG — identifier mixed into the AgentCore session ID
+        // so deploys invalidate sticky-routed microVMs. Composed of:
+        //   - imageDigest (or tag) — rotates on image change
+        //   - configHash — rotates on env-var change (computed above)
+        // Either kind of change forces the next user message to spawn a
+        // fresh microVM with the current env snapshot. Without the
+        // configHash component, an env-only deploy leaves users pinned to
+        // the OLD microVM until idleRuntimeSessionTimeout (hours for an
+        // active user).
+        AGENT_BUILD_TAG: agentBuildTag,
       },
       vpc,
       vpcSubnets: { subnetType: ec2.SubnetType.PRIVATE_WITH_EGRESS },

--- a/infra/lib/agent-platform-stack.ts
+++ b/infra/lib/agent-platform-stack.ts
@@ -1173,12 +1173,13 @@ export class AgentPlatformStack extends cdk.Stack {
           // explicit error message if a consent URL is ever actually required.
           APP_BASE_URL: props.appBaseUrl ?? '',
           // psd-data skill — wires the agent to the PSD data MCP server.
-          // REQUIRED: pass -c psdDataMcpUrl=<url> at synth/deploy time.
-          // An empty string causes the skill to fail loudly (missing URL),
-          // which is safer than silently routing all environments to prod.
+          // Same Lambda URL for dev and prod (the MCP server trusts both
+          // Cognito pools), so we hardcode rather than threading through
+          // CDK context. Override at deploy time with -c psdDataMcpUrl=<url>
+          // if a future environment needs a different endpoint.
           PSD_DATA_MCP_URL:
             (this.node.tryGetContext('psdDataMcpUrl') as string | undefined)
-            ?? '',
+            ?? 'https://l3jpggwgsojgql275k6axcboue0syeuq.lambda-url.us-west-2.on.aws/mcp',
           // Cognito identifiers — used by the psd-data skill to refresh
           // the caller's stored refresh token into a fresh id_token. We
           // import these from AuthStack's CloudFormation exports rather

--- a/lib/agent-workspace/consent-token.ts
+++ b/lib/agent-workspace/consent-token.ts
@@ -15,7 +15,16 @@ import { createLogger, sanitizeForLogging } from "@/lib/logger"
 
 const log = createLogger({ module: "consent-token" })
 
-export type ConsentTokenKind = "agent_account" | "user_account"
+/**
+ * Which credential slot the consent flow is capturing.
+ *
+ *   'agent_account' — Google OAuth for agnt_<uniqname>@psd401.net (broad scopes)
+ *   'user_account'  — Google OAuth for the user themselves (narrow scopes)
+ *   'cognito_data'  — Cognito refresh token for the data-MCP integration.
+ *                     Captured by the /agent-connect-data page, stored at
+ *                     psd-agent-creds/{env}/user/{email}/cognito-refresh.
+ */
+export type ConsentTokenKind = "agent_account" | "user_account" | "cognito_data"
 
 export interface ConsentTokenPayload {
   /** Human user email (e.g. hagelk@psd401.net) */
@@ -116,7 +125,11 @@ export async function verifyConsentToken(token: string): Promise<ConsentTokenPay
 
     // Validate kind if present. Absent = legacy token, treat as agent_account.
     let resolvedKind: ConsentTokenKind | undefined
-    if (kind === "agent_account" || kind === "user_account") {
+    if (
+      kind === "agent_account" ||
+      kind === "user_account" ||
+      kind === "cognito_data"
+    ) {
       resolvedKind = kind
     } else if (kind !== undefined) {
       log.warn("Consent token has unknown kind", { kind })

--- a/lib/auth/agent-token-sync.ts
+++ b/lib/auth/agent-token-sync.ts
@@ -105,22 +105,33 @@ export async function syncCognitoRefreshForAgent(
     return null
   }
 
-  // We need at minimum the user pool ID + client ID + region to make the
-  // stored token usable. If these aren't configured we still log a warning
-  // but don't write a half-populated record.
-  const userPoolId =
-    process.env.AUTH_COGNITO_USER_POOL_ID ?? process.env.COGNITO_USER_POOL_ID ?? null
+  // The agent uses client_id + region to refresh the token. user_pool_id is
+  // stored alongside for traceability but is not required for the refresh
+  // flow — derive it from AUTH_COGNITO_ISSUER when AUTH_COGNITO_USER_POOL_ID
+  // is absent (the web ECS task only sets the issuer).
   const clientId =
     process.env.AUTH_COGNITO_CLIENT_ID ?? process.env.COGNITO_CLIENT_ID ?? null
-  const region =
-    process.env.AUTH_COGNITO_REGION ?? process.env.AWS_REGION ?? "us-east-1"
-  if (!userPoolId || !clientId) {
+  if (!clientId) {
     log.warn(
-      "Skipping cognito-refresh sync — AUTH_COGNITO_USER_POOL_ID / AUTH_COGNITO_CLIENT_ID not set",
-      sanitizeForLogging({ ownerEmail, hasPoolId: !!userPoolId, hasClientId: !!clientId }),
+      "Skipping cognito-refresh sync — AUTH_COGNITO_CLIENT_ID not set",
+      sanitizeForLogging({ ownerEmail }),
     )
     return null
   }
+  // Issuer format: https://cognito-idp.<region>.amazonaws.com/<pool-id>
+  const issuer = process.env.AUTH_COGNITO_ISSUER ?? ""
+  const issuerMatch = issuer.match(
+    /^https:\/\/cognito-idp\.([a-z0-9-]+)\.amazonaws\.com\/([a-z0-9-_]+)$/i,
+  )
+  const userPoolId =
+    process.env.AUTH_COGNITO_USER_POOL_ID ??
+    process.env.COGNITO_USER_POOL_ID ??
+    (issuerMatch ? issuerMatch[2] : "unknown")
+  const region =
+    process.env.AUTH_COGNITO_REGION ??
+    (issuerMatch ? issuerMatch[1] : undefined) ??
+    process.env.AWS_REGION ??
+    "us-east-1"
 
   const secretId = cognitoRefreshSecretId(ownerEmail)
   const payload: CognitoRefreshTokenRecord = {

--- a/lib/auth/agent-token-sync.ts
+++ b/lib/auth/agent-token-sync.ts
@@ -1,0 +1,219 @@
+/**
+ * Agent Token Sync — persist Cognito refresh tokens for the AgentCore agent.
+ *
+ * The agent (AgentCore runtime, OpenClaw container, Google Chat front door)
+ * runs in dev today, while the user community logs into AI Studio prod.
+ * The agent cannot read the user's NextAuth session cookie across
+ * environments, so we mirror the refresh token into Secrets Manager at a
+ * path the agent's IAM role can read.
+ *
+ * Two trigger points write here:
+ *
+ *   1. NextAuth JWT callback — on initial sign-in and on every silent
+ *      refresh (`auth.ts`). Best-effort; failures must not break login.
+ *   2. /agent-connect-data consent page — when the agent forces an auth
+ *      because no token exists (or it's expired). Cross-environment path:
+ *      a prod user clicks the consent URL, lands here in *dev*, and the
+ *      page sends them through Cognito to mint a refresh token in dev.
+ *
+ * Storage path mirrors the `psd-credentials` / `psd-workspace` convention:
+ *   psd-agent-creds/{environment}/user/{ownerEmail}/cognito-refresh
+ *
+ * Payload shape (JSON):
+ *   {
+ *     refresh_token: string,
+ *     obtained_at: ISO timestamp,
+ *     user_pool_id: string,
+ *     client_id: string,
+ *     region: string
+ *   }
+ *
+ * IAM: the AgentCore role has `secretsmanager:GetSecretValue` on
+ * `psd-agent-creds/{env}/*` (agent-platform-stack.ts:856–858). The Next.js
+ * task role has `CreateSecret` / `PutSecretValue` on
+ * `psd-agent-creds/{env}/user/*` (agent-platform-stack.ts:885–923) — the
+ * same perms used by `lib/agent-workspace/secrets-manager.ts`.
+ */
+
+import { createLogger, sanitizeForLogging } from "@/lib/logger"
+import { SAFE_EMAIL_RE } from "@/lib/agent-workspace/validation"
+
+const log = createLogger({ module: "agent-token-sync" })
+
+export interface CognitoRefreshTokenRecord {
+  refresh_token: string
+  obtained_at: string
+  user_pool_id: string
+  client_id: string
+  region: string
+}
+
+export function cognitoRefreshSecretId(ownerEmail: string): string {
+  if (!SAFE_EMAIL_RE.test(ownerEmail)) {
+    throw new Error(`Invalid ownerEmail for Secrets Manager path: ${ownerEmail}`)
+  }
+  const environment =
+    process.env.ENVIRONMENT ?? process.env.DEPLOY_ENVIRONMENT ?? "dev"
+  return `psd-agent-creds/${environment}/user/${ownerEmail}/cognito-refresh`
+}
+
+let _smClient:
+  | InstanceType<
+      typeof import("@aws-sdk/client-secrets-manager").SecretsManagerClient
+    >
+  | null = null
+
+async function getSecretsManagerClient() {
+  if (_smClient) return _smClient
+  const { SecretsManagerClient } = await import("@aws-sdk/client-secrets-manager")
+  _smClient = new SecretsManagerClient({})
+  return _smClient
+}
+
+/**
+ * Persist (or refresh) the user's Cognito refresh token in Secrets Manager.
+ *
+ * This is intentionally **fire-and-forget** from the caller's perspective:
+ * NextAuth callbacks invoke it without `await`, and a failure here must not
+ * block sign-in. Errors are logged at WARN level.
+ *
+ * @returns the secret ARN on success, null in local dev (skipped) or if the
+ *          required env vars aren't set.
+ */
+export async function syncCognitoRefreshForAgent(
+  ownerEmail: string,
+  refreshToken: string,
+): Promise<string | null> {
+  if (!refreshToken || typeof refreshToken !== "string") {
+    log.debug("Skipping cognito-refresh sync — no refresh token in payload", {
+      ownerEmail: ownerEmail || "unknown",
+    })
+    return null
+  }
+  if (!SAFE_EMAIL_RE.test(ownerEmail)) {
+    log.warn("Skipping cognito-refresh sync — invalid ownerEmail", {
+      ownerEmail: ownerEmail || "unknown",
+    })
+    return null
+  }
+
+  // Local dev: nothing to sync to. The agent stack is not deployed locally.
+  if (process.env.NODE_ENV === "development" && !process.env.FORCE_AGENT_TOKEN_SYNC) {
+    log.info("Local dev — skipping Secrets Manager write for cognito-refresh", {
+      ownerEmail,
+    })
+    return null
+  }
+
+  // We need at minimum the user pool ID + client ID + region to make the
+  // stored token usable. If these aren't configured we still log a warning
+  // but don't write a half-populated record.
+  const userPoolId =
+    process.env.AUTH_COGNITO_USER_POOL_ID ?? process.env.COGNITO_USER_POOL_ID ?? null
+  const clientId =
+    process.env.AUTH_COGNITO_CLIENT_ID ?? process.env.COGNITO_CLIENT_ID ?? null
+  const region =
+    process.env.AUTH_COGNITO_REGION ?? process.env.AWS_REGION ?? "us-east-1"
+  if (!userPoolId || !clientId) {
+    log.warn(
+      "Skipping cognito-refresh sync — AUTH_COGNITO_USER_POOL_ID / AUTH_COGNITO_CLIENT_ID not set",
+      sanitizeForLogging({ ownerEmail, hasPoolId: !!userPoolId, hasClientId: !!clientId }),
+    )
+    return null
+  }
+
+  const secretId = cognitoRefreshSecretId(ownerEmail)
+  const payload: CognitoRefreshTokenRecord = {
+    refresh_token: refreshToken,
+    obtained_at: new Date().toISOString(),
+    user_pool_id: userPoolId,
+    client_id: clientId,
+    region,
+  }
+  const secretString = JSON.stringify(payload)
+
+  const {
+    PutSecretValueCommand,
+    CreateSecretCommand,
+    ResourceNotFoundException,
+  } = await import("@aws-sdk/client-secrets-manager")
+  const client = await getSecretsManagerClient()
+  const environment =
+    process.env.ENVIRONMENT ?? process.env.DEPLOY_ENVIRONMENT ?? "dev"
+
+  try {
+    const resp = await client.send(
+      new PutSecretValueCommand({
+        SecretId: secretId,
+        SecretString: secretString,
+      }),
+    )
+    log.info("Cognito refresh token rotated in Secrets Manager", { secretId })
+    return resp.ARN ?? null
+  } catch (error) {
+    if (error instanceof ResourceNotFoundException) {
+      try {
+        const created = await client.send(
+          new CreateSecretCommand({
+            Name: secretId,
+            SecretString: secretString,
+            Description: `Cognito refresh token for ${ownerEmail} — captured for agent data-MCP access`,
+            Tags: [
+              { Key: "Environment", Value: environment },
+              { Key: "ManagedBy", Value: "aistudio" },
+              { Key: "OwnerEmail", Value: ownerEmail },
+              { Key: "Purpose", Value: "agent-cognito-refresh" },
+            ],
+          }),
+        )
+        log.info("Cognito refresh token secret created in Secrets Manager", {
+          secretId,
+        })
+        return created.ARN ?? null
+      } catch (createError) {
+        // Two concurrent first-writes can race. The loser sees
+        // ResourceExistsException and falls through to PutSecretValue.
+        if (
+          createError instanceof Error &&
+          createError.name === "ResourceExistsException"
+        ) {
+          try {
+            const retry = await client.send(
+              new PutSecretValueCommand({
+                SecretId: secretId,
+                SecretString: secretString,
+              }),
+            )
+            log.info(
+              "Cognito refresh token stored after concurrent secret creation",
+              { secretId },
+            )
+            return retry.ARN ?? null
+          } catch (retryError) {
+            log.warn("Cognito refresh token sync retry failed", {
+              secretId,
+              error:
+                retryError instanceof Error
+                  ? retryError.message
+                  : String(retryError),
+            })
+            return null
+          }
+        }
+        log.warn("Cognito refresh token CreateSecret failed", {
+          secretId,
+          error:
+            createError instanceof Error
+              ? createError.message
+              : String(createError),
+        })
+        return null
+      }
+    }
+    log.warn("Cognito refresh token PutSecretValue failed", {
+      secretId,
+      error: error instanceof Error ? error.message : String(error),
+    })
+    return null
+  }
+}

--- a/lib/auth/agent-token-sync.ts
+++ b/lib/auth/agent-token-sync.ts
@@ -173,7 +173,6 @@ export async function syncCognitoRefreshForAgent(
               { Key: "Environment", Value: environment },
               { Key: "ManagedBy", Value: "aistudio" },
               { Key: "OwnerEmail", Value: ownerEmail },
-              { Key: "Purpose", Value: "agent-cognito-refresh" },
             ],
           }),
         )

--- a/lib/db/schema/tables/agent-workspace-consent-nonces.ts
+++ b/lib/db/schema/tables/agent-workspace-consent-nonces.ts
@@ -23,10 +23,16 @@ export const psdAgentWorkspaceConsentNonces = pgTable("psd_agent_workspace_conse
   // identities from just the nonce (the OAuth `state` parameter no longer
   // carries the full consent JWT — the nonce alone is sufficient).
   agentEmail: varchar("agent_email", { length: 255 }).notNull(),
-  // Which OAuth identity is being consented (#912 Phase 1, migration 073).
-  // 'agent_account' = agnt_<uniqname>; 'user_account' = the user themself.
+  // Which credential slot is being consented.
+  //  - 'agent_account' = Google OAuth for agnt_<uniqname> (#912 Phase 1)
+  //  - 'user_account'  = Google OAuth for the user themself
+  //  - 'cognito_data'  = Cognito refresh-token capture for the agent's
+  //                      data-MCP integration. Reuses this table because
+  //                      the per-owner rate-limit + nonce-replay protection
+  //                      are exactly what we need; the consume step writes
+  //                      to a different secret path.
   tokenKind: varchar("token_kind", { length: 16 })
-    .$type<"agent_account" | "user_account">()
+    .$type<"agent_account" | "user_account" | "cognito_data">()
     .notNull()
     .default("agent_account"),
   createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),


### PR DESCRIPTION
## Summary

Wires the AgentCore-deployed agent to the PSD data warehouse via `psd-data-mcp` (HTTP+JSON-RPC, Cognito JWT bearer auth). Closes the gap for users invoking the agent from Google Chat — where there is no live AI Studio session to forward an id_token from.

Two pieces, both required because the agent runs in **dev** while users log into AI Studio **prod**:

1. **Auto-capture** on every AI Studio sign-in / silent refresh — `auth.ts` JWT callback fire-and-forget-mirrors the Cognito refresh token to Secrets Manager at `psd-agent-creds/{env}/user/{email}/cognito-refresh`.
2. **On-demand consent flow** — when the agent has no stored token, the `psd-data` skill mints a signed `/agent-connect-data?token=…` URL via `/api/agent/consent-link?kind=cognito_data` and emits a `needs-auth` payload (exit 10). User clicks, signs into AI Studio, the new Server Component captures the refresh token and stores it. Agent retries on the next turn.

## Components

- **`lib/auth/agent-token-sync.ts`** — Put-or-create on Secrets Manager. Graceful in local dev / when env vars absent.
- **`auth.ts`** — Background mirror at the two NextAuth insertion points.
- **`/agent-connect-data` page** — Server Component. Verifies JWT, requires session, atomically burns nonce, writes secret, renders confirmation. Replay-safe.
- **`/api/agent/consent-link`** — accepts `kind: "cognito_data"`, returns `/agent-connect-data` URL.
- **`actions/agent-workspace.actions.ts`** — rejects `cognito_data` kinds at the Workspace OAuth entry/callback as defence-in-depth.
- **`infra/agent-image/skills/psd-data/`** — new OpenClaw skill (Node, mirrors `psd-workspace` shape). 8 subcommands matching the MCP tools (tables, schema, permissions, query, lesson-save/delete/check/rate). Every command requires `--user`.
- **`infra/lib/agent-platform-stack.ts`** — inject `PSD_DATA_MCP_URL` (CDK context override), `AUTH_COGNITO_USER_POOL_ID/CLIENT_ID/REGION` (Fn.importValue from AuthStack).
- **Dockerfile** + **workspace_sync.py** — install + skip-list as usual.

## Auth flow at a glance

```
[user signs into AI Studio]
        ↓
NextAuth jwt() callback → mirror refresh token to SM (fire-and-forget)

[user asks agent in Chat to query data]
        ↓
psd-data skill: SM read → Cognito InitiateAuth (REFRESH_TOKEN_AUTH)
        ↓
fresh id_token → POST psd-data-mcp /mcp
        ↓
RLS-rewritten query → result back to user

[secret missing or refresh revoked]
        ↓
skill mints /agent-connect-data link, emits needs-auth (exit 10)
        ↓
agent posts link in Chat per rule 9 (own line, no markdown)
        ↓
user clicks, signs into AI Studio
        ↓
/agent-connect-data captures refresh token, writes SM, burns nonce
        ↓
user re-asks → agent succeeds
```

## Exit-code contract for the skill

| Code | Meaning |
|------|---------|
| 0 | Success — JSON-RPC result on stdout |
| 10 | needs-auth — paste `consent_chat_hyperlink` on its own line |
| 12 | Upstream MCP error |
| 13 | Forbidden (user not in PSD warehouse `userpermissions`) |
| 14 | Rate-limited |

## Verification

- [x] `bun run typecheck` → 0 errors
- [x] `bun run lint` → 0 errors
- [x] `bunx cdk synth -c agentImageTag=test` → env vars resolve via `Fn.importValue`
- [x] Skill `bun install` clean; modules load
- [ ] Build + push image (in progress)
- [ ] Deploy to AgentCore-Dev
- [ ] End-to-end consent flow: brand-new user → click link → re-ask → tables list returns
- [ ] End-to-end auto-capture: sign into AI Studio → verify secret rotates
- [ ] Negative: user not in `userpermissions` → agent surfaces 403 with data-team pointer

## Out of scope

- Nexus / agent convergence on a shared MCP client config
- Admin UI for the MCP server URL (CDK context for now)
- Multi-MCP fan-out