### PR TITLE
docs: #891 — evolve: Update silent-failure-patterns.md with 6 new patterns from March-April learnings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -429,6 +429,12 @@ const role = ServiceRoleFactory.createLambdaRole(this, 'MyFunctionRole', {
 - **Don't** use `{}` as an accumulator for model/user-controlled keys — use `Object.create(null)`
 - **Don't** use static tool-call format (`tool-show_chart`) with `fromThreadMessageLike` — use `type: 'tool-call'` dynamic format
 - **Don't** chain `.replace()` for HTML entity decoding — use single-pass regex (see `lib/utils/text-sanitizer.ts`)
+- **Don't** use `response.json().catch(() => fallback)` without checking `response.ok` first — hides HTTP status codes; infra errors (502/503) become indistinguishable from app errors
+- **Don't** return (without throwing) from `customFetch` after showing a toast for non-2xx responses — AI SDK will try to parse the error body as SSE and throw a `TypeError`
+- **Don't** construct SNS Subject from variable-length arrays without a 100-char truncation guard — silent publish failures with no SDK error surfaced
+- **Don't** return `null` from a DB accessor for both not-found and error in an SWR cache — cache cannot distinguish the two; DB errors silently overwrite valid cached state with defaults
+- **Don't** pass a Web API `Blob` to `@google/genai` SDK methods — the SDK expects `{ data: base64string, mimeType: string }`, not a `Blob` object
+- **Don't** assume AWS SDK assessment objects are flat — check ALL sub-properties (e.g., `wordPolicy.customWords` AND `wordPolicy.managedWordLists`); missing one drops an entire blocking category from observability
 
 ### React (see `docs/guides/react-patterns.md`)
 - **Don't** put `key` on Provider/context wrapper components

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -468,5 +468,5 @@ const role = ServiceRoleFactory.createLambdaRole(this, 'MyFunctionRole', {
 **Knowledge Base**: Stored in S3, retrieved during execution
 
 ---
-*Token-optimized for Claude Code efficiency. Last updated: January 2025*
+*Token-optimized for Claude Code efficiency. Last updated: May 2026*
 *Infrastructure optimized via Epic #372 - AWS Well-Architected Framework aligned*

--- a/docs/guides/silent-failure-patterns.md
+++ b/docs/guides/silent-failure-patterns.md
@@ -2,7 +2,7 @@
 
 Bugs where code silently does the wrong thing instead of throwing. These are the hardest to catch in code review because they don't produce errors — they produce wrong results.
 
-Consolidated from ~8 learnings across database, AI SDK, streaming, and security categories.
+Consolidated from learnings across database, AI SDK, streaming, security, and API categories.
 
 ## Drizzle ORM
 
@@ -39,6 +39,29 @@ CREATE TRIGGER set_updated_at
 ```
 
 **Review rule:** Every new table with `updated_at` must have a trigger in the migration SQL.
+
+## Fetch / HTTP
+
+### `response.json().catch(() => fallback)` hides HTTP status codes
+
+Using `.catch()` on `.json()` as a fallback silently discards the HTTP status code and the actual error body. When an ALB returns 502/503 with an HTML body, `.json()` throws a parse error and the catch swallows all diagnostic signal — infra failures become indistinguishable from app errors.
+
+```typescript
+// WRONG — HTTP status code and error body are silently lost
+const data = await response.json().catch(() => ({ error: 'Upload failed' }))
+
+// CORRECT — check response.ok first, then parse with appropriate content-type handling
+if (!response.ok) {
+  const contentType = response.headers.get('content-type') ?? '';
+  const body = contentType.includes('application/json')
+    ? await response.json().catch(() => null)
+    : await response.text().catch(() => null);
+  throw new Error(`Request failed: HTTP ${response.status} — ${body ?? 'no body'}`);
+}
+const data = await response.json();
+```
+
+**Review rule:** Every `.json()` call on a fetch response must be preceded by a `response.ok` (or status code) check. Flag any `.catch(() => fallback)` on a `.json()` call as a potential diagnostic blackhole.
 
 ## AI SDK v6
 
@@ -80,6 +103,26 @@ const safeTitle = escapeHtml(toolInvocation.args.title)
 
 **Review rule:** Check what `execute()` actually returns. Sanitize at the render layer, not the execute layer.
 
+### `customFetch` must throw (not return) after showing a toast
+
+When a `customFetch` implementation shows a toast for an error response and then **returns** the response instead of throwing, the AI SDK `streamText` runtime receives a resolved promise and attempts to parse the non-streaming JSON error body as an SSE stream, producing a `TypeError`.
+
+```typescript
+// WRONG — AI SDK treats the resolved promise as a valid stream
+if (!response.ok) {
+  toast.error('Something went wrong');
+  return response; // SDK will try to parse HTML/JSON error body as SSE
+}
+
+// CORRECT — throw so the SDK never attempts stream parsing
+if (!response.ok) {
+  toast.error('Something went wrong');
+  throw new Error('Request failed'); // MUST throw — toast and throw are not mutually exclusive
+}
+```
+
+**Review rule:** Any `customFetch` with a non-2xx branch that returns instead of throwing will cause a `TypeError` in the SDK stream parser. Review all `customFetch` implementations for non-throwing error branches.
+
 ### In-place mutation of tool args
 
 Mutating AI SDK `args` in-place breaks `argsText` invariant in assistant-ui. Always return new objects from sanitization functions.
@@ -107,6 +150,82 @@ Only accepts `type: 'tool-call'` (dynamic format). Static formats like `tool-sho
 ```
 
 Also: HTML entities in tool args (e.g. `&amp;`) must be decoded at save boundary and at history load — `argsText` must match `JSON.stringify(args)` exactly or the append-only check fails.
+
+## AWS APIs
+
+### SNS Subject 100-char limit causes silent publish failures
+
+SNS `publish()` rejects subjects longer than 100 characters, but the SDK does not surface an error in normal success-path logging. Any dynamic Subject construction from variable-length arrays is a latent silent failure.
+
+```typescript
+// WRONG — joined categories can exceed 100 chars silently
+const subject = `Guardrail blocked: ${blockedCategories.join(', ')}`;
+await sns.publish({ TopicArn, Subject: subject, Message });
+
+// CORRECT — truncate before publishing
+const raw = `Guardrail blocked: ${blockedCategories.join(', ')}`;
+const subject = raw.length > 100 ? raw.slice(0, 97) + '...' : raw;
+await sns.publish({ TopicArn, Subject: subject, Message });
+```
+
+**Review rule:** Treat SNS Subject as a 100-char-max field. Flag any `array.join()` or template literal used as an SNS Subject without a length guard.
+
+### Bedrock guardrail assessment: check ALL sub-properties of SDK objects
+
+AWS SDK assessment objects often have multiple sub-properties. Iterating only one silently drops entire blocking categories from observability. For example, `WordPolicyAssessment` has both `customWords` and `managedWordLists` — PROFANITY is enforced via managed word lists and is invisible if only `customWords` is checked.
+
+```typescript
+// WRONG — misses PROFANITY (managed word list) blocks entirely
+wordPolicy?.customWords?.forEach(word => track(word));
+
+// CORRECT — covers both sub-properties
+wordPolicy?.customWords?.forEach(word => track(word));
+wordPolicy?.managedWordLists?.forEach(word => track(word));
+```
+
+**Review rule:** Before shipping any monitoring/extraction function that reads AWS SDK assessment objects, enumerate all properties of the relevant type via TypeDoc or SDK source. A missing sub-property silently drops an entire blocking category.
+
+## Caching
+
+### SWR cache: `null` return conflates not-found with error
+
+When a DB accessor returns `null` for both "row not found" and "DB error", a stale-while-revalidate cache cannot distinguish them. A background refresh that writes `null` back to the cache during a transient DB error silently overwrites valid cached state with a default/empty value.
+
+```typescript
+// WRONG — null from error overwrites cache; caller can't distinguish not-found from DB outage
+async function getSetting(key: string): Promise<Setting | null> {
+  try { return await db.query(...) } catch { return null }
+}
+
+// CORRECT — throw on error so SWR can retain stale cache; null = definitively not found
+async function getSetting(key: string): Promise<Setting | null> {
+  return await db.query(...) // throws on DB error; returns null only for missing rows
+}
+
+// In SWR refresh: on null/error, preserve existing cache rather than overwriting
+```
+
+**Review rule:** Before implementing SWR, audit the DB accessor's null semantics. If it returns null for errors, fix the accessor first. Background refresh callbacks must use a generation counter to avoid writing stale data after explicit cache invalidation.
+
+## Third-Party SDK Types
+
+### `@google/genai` SDK `Blob` is not the Web API `Blob`
+
+`@google/genai` defines its own `Blob` interface: `{ data: string; mimeType: string }` where `data` is base64-encoded. It is structurally incompatible with the browser/Node.js `Blob`. TypeScript may not catch the mismatch if the web `Blob` partially satisfies the structural check — the SDK silently receives an unusable object.
+
+```typescript
+// WRONG — web API Blob, silently fails inside the SDK
+await session.sendRealtimeInput({ audio: webBlob });
+
+// CORRECT — SDK Blob type: base64-encoded data with explicit mimeType
+const arrayBuffer = await webBlob.arrayBuffer();
+const base64 = Buffer.from(arrayBuffer).toString('base64');
+await session.sendRealtimeInput({
+  audio: { data: base64, mimeType: 'audio/pcm;rate=16000' }
+});
+```
+
+**Review rule:** When using `@google/genai`, any parameter typed as `Blob` is the SDK's custom type. Verify shapes directly in `node_modules/@google/genai/types.d.ts` before passing audio or binary data.
 
 ## Prototype Pollution
 
@@ -156,4 +275,4 @@ text.replace(/&amp;/g, '&').replace(/&#(\d+);/g, (_, n) => String.fromCharCode(+
 
 ---
 
-*Source: learnings from database, ai-sdk, streaming, security, and frontend categories (2026-02-18 through 2026-02-26)*
+*Source: learnings from database, ai-sdk, streaming, security, frontend, api-patterns, infrastructure, and monitoring categories (2026-02-18 through 2026-04-08)*

--- a/docs/guides/silent-failure-patterns.md
+++ b/docs/guides/silent-failure-patterns.md
@@ -56,7 +56,7 @@ if (!response.ok) {
   const body = contentType.includes('application/json')
     ? await response.json().catch(() => null)
     : await response.text().catch(() => null);
-  throw new Error(`Request failed: HTTP ${response.status} — ${body ?? 'no body'}`);
+  throw new Error(`Request failed: HTTP ${response.status} — ${typeof body === 'object' && body !== null ? JSON.stringify(body) : (body ?? 'no body')}`);
 }
 const data = await response.json();
 ```
@@ -203,6 +203,19 @@ async function getSetting(key: string): Promise<Setting | null> {
 }
 
 // In SWR refresh: on null/error, preserve existing cache rather than overwriting
+```
+
+**Generation counter pattern** — prevents a slow background refresh from overwriting cache with stale data after an explicit invalidation:
+
+```typescript
+let refreshGeneration = 0;
+
+async function refreshCache(key: string) {
+  const myGen = ++refreshGeneration;
+  const data = await fetchFreshData(key);
+  if (myGen !== refreshGeneration) return; // a newer refresh started; discard result
+  cache.set(key, data);
+}
 ```
 
 **Review rule:** Before implementing SWR, audit the DB accessor's null semantics. If it returns null for errors, fix the accessor first. Background refresh callbacks must use a generation counter to avoid writing stale data after explicit cache invalidation.

--- a/docs/learnings/documentation/2026-05-14-evolve-doc-only-task-patterns.md
+++ b/docs/learnings/documentation/2026-05-14-evolve-doc-only-task-patterns.md
@@ -1,0 +1,58 @@
+---
+title: Evolve tasks on documentation-only PRs follow a distinct three-step pattern
+category: documentation
+tags:
+  - evolve
+  - lfg
+  - documentation
+  - claude-md
+  - security-review
+severity: low
+date: 2026-05-14
+source: auto — /lfg issue-891
+applicable_to: project
+---
+
+## What Happened
+
+PR #986 (issue #891) was a documentation-only evolve task: add 6 new silent failure
+patterns from March–April learnings to `docs/guides/silent-failure-patterns.md` and
+mirror compact bullets for each into `CLAUDE.md`'s Silent Failures section.
+
+Three recurring pitfalls were identified during and after the run.
+
+## Root Cause
+
+Documentation evolve tasks differ from code tasks in ways that catch agents off-guard:
+
+1. **Research gap**: Agents that write the guide before reading all referenced learning
+   files produce incomplete or mismatched entries.
+2. **CLAUDE.md drift**: The Silent Failures section in `CLAUDE.md` is a compact mirror
+   of the full guide; new guide entries that are not also added to `CLAUDE.md` break the
+   implicit sync contract and reduce the value of both documents.
+3. **Wasted security-review time**: Running a full security audit on a pure-documentation
+   PR adds unnecessary latency — there is no executable code, so injection, SSRF, and
+   secret-leakage vectors do not apply. Wrong code *examples* framed as anti-patterns are
+   a skim-reading hazard at most (LOW risk).
+
+## Solution
+
+For documentation-only evolve tasks, follow this order:
+
+1. **Research first** — read every learning file referenced by the issue before writing
+   a single line of the guide. Match the existing guide's tone, heading style, and code
+   block conventions.
+2. **Mirror to CLAUDE.md** — for every new entry added to the guide, add a matching
+   compact bullet to the relevant `CLAUDE.md` section immediately (same PR, same commit).
+   The two documents must stay in sync.
+3. **Lightweight security pass** — for doc-only PRs, security review can be limited to
+   confirming no secrets, credentials, or live URLs are embedded. Skip the full SSRF /
+   injection / taint analysis — it does not apply.
+
+## Prevention
+
+- Before opening the PR, verify: (a) guide entry count == `CLAUDE.md` bullet count for
+  the same section, (b) footer date range on the guide is updated.
+- If the issue references specific learning files by path, read them all before writing.
+- Tag doc-only PRs clearly so automated security review pipelines can apply the
+  appropriate (lighter) rule set.


### PR DESCRIPTION
## Summary

Implements #891

Adds 6 new silent failure patterns to `docs/guides/silent-failure-patterns.md` from March–April 2026 learnings not yet documented in the guide, and adds corresponding one-liner entries to the `### Silent Failures` section of `CLAUDE.md`.

## Changes

- **Fetch / HTTP** — new section: `response.json().catch(() => fallback)` hides HTTP status codes; must check `response.ok` first
- **AI SDK v6** — new sub-section: `customFetch` must `throw` (not return) after showing a toast for non-2xx responses, otherwise AI SDK stream parser throws `TypeError`
- **AWS APIs** — new section: SNS Subject 100-char hard limit causes silent publish failures when joining arrays without length guard
- **AWS APIs** — new sub-section: Bedrock assessment objects — check ALL sub-properties (`wordPolicy.customWords` AND `wordPolicy.managedWordLists`)
- **Caching** — new section: SWR cache `null`-return ambiguity — DB accessor returning `null` for both not-found and error makes cache unable to distinguish states
- **Third-Party SDK Types** — new section: `@google/genai` SDK `Blob` is structurally incompatible with Web API `Blob`; requires `{ data: base64, mimeType }` shape
- `CLAUDE.md` `### Silent Failures` — 6 corresponding one-liner entries added
- Guide source footer date range updated to `2026-02-18 through 2026-04-08`

## Test Plan

- [x] Documentation-only change — no code logic modified
- [x] All 6 patterns sourced directly from learning files in `docs/learnings/`
- [x] `CLAUDE.md` entries match patterns in the guide
- [x] Security audit — PASSED (no CRITICAL/HIGH findings)
- [ ] Human review

Closes #891

---
*Opened by the lfg routine.*