### PR TITLE
feat: #892 — Update react-patterns.md with 6 new patterns from March-April learnings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -440,6 +440,12 @@ const role = ServiceRoleFactory.createLambdaRole(this, 'MyFunctionRole', {
 - **Don't** put `key` on Provider/context wrapper components
 - **Don't** use boolean `useRef` for init guards on parameterized routes — use ID-tracking refs
 - **Don't** place hooks after conditional returns
+- **Don't** include `isLoading` state in polling `useEffect` deps — use `useRef` to prevent timer churn
+- **Don't** rely on `clearTimeout` alone for polling cleanup — pair with a `cancelled = true` flag
+- **Don't** assign callback refs inside `useEffect` — assign synchronously in the render body to close the stale-ref timing gap
+- **Don't** return internal state getters from hooks when the caller also supplies `fn` — use `onFailure(count)` event callbacks
+- When a hook `.catch()` mutates a ref and re-throws, callers read the pre-mutation value — use `onFailure(count)` or add `+1`
+- **Don't** pass unstable adapter references to `useChatRuntime` — use ref-based getters with empty dep arrays to prevent runtime re-initialization and duplicate messages
 
 ## 📖 Documentation
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -444,7 +444,7 @@ const role = ServiceRoleFactory.createLambdaRole(this, 'MyFunctionRole', {
 - **Don't** rely on `clearTimeout` alone for polling cleanup — pair with a `cancelled = true` flag
 - **Don't** assign callback refs inside `useEffect` — assign synchronously in the render body to close the stale-ref timing gap
 - **Don't** return internal state getters from hooks when the caller also supplies `fn` — use `onFailure(count)` event callbacks
-- When a hook `.catch()` mutates a ref and re-throws, callers read the pre-mutation value — use `onFailure(count)` or add `+1`
+- **Don't** read a ref mutated inside a hook's `.catch()` without `+1` — use `onFailure(count)` callback instead (callers see pre-mutation value)
 - **Don't** pass unstable adapter references to `useChatRuntime` — use ref-based getters with empty dep arrays to prevent runtime re-initialization and duplicate messages
 
 ## 📖 Documentation

--- a/docs/guides/react-patterns.md
+++ b/docs/guides/react-patterns.md
@@ -195,9 +195,14 @@ useEffect(() => {
     timer = setTimeout(poll, interval)
   }
   const poll = () => {
-    fetchData().finally(() => {
-      if (!cancelled) scheduleNext()
-    })
+    fetchData()
+      .then(() => { if (!cancelled) scheduleNext() })
+      .catch((err) => {
+        // Always handle rejections — unhandled promise rejections in useEffect
+        // closures are not caught by React error boundaries.
+        log.warn('poll failed', err)
+        if (!cancelled) scheduleNext() // retry or stop based on your error strategy
+      })
   }
 
   poll()
@@ -210,8 +215,9 @@ useEffect(() => {
 
 **Rules:**
 - Any `.then()` or `.finally()` inside a polling `useEffect` must guard on a `cancelled` flag
-- Use `.finally()` instead of `.then()` so `scheduleNext` fires on both success and failure
 - Always pair `clearTimeout` with a `cancelled = true` assignment in cleanup
+- **Always add a `.catch()`** — unhandled promise rejections inside `useEffect` closures bypass React error boundaries and can produce silent polling failures
+- Handle errors inside `fetchData` or at the `.catch()` on the polling chain; do not let rejections go unhandled
 
 *See also: Polling Timer Churn section above — `cancelled` flag and `useRef` for `isLoading` are complementary; both are needed.*
 
@@ -300,6 +306,8 @@ conversationIdRef.current = conversationId // synchronous render-body assignment
 const historyAdapter = useMemo(
   () => createHistoryAdapter(() => conversationIdRef.current),
   [] // empty deps — instance never recreated
+  // The empty array is intentional: the ref object is stable across renders;
+  // conversationIdRef.current always returns the latest value via the getter.
 )
 ```
 
@@ -307,6 +315,7 @@ const historyAdapter = useMemo(
 - Any object passed to `useChatRuntime` (adapter, runtime config) must have a stable reference across renders
 - When the adapter needs a value that changes over time, pass a ref-based getter, not the value directly
 - Treat `useChatRuntime` adapter props like `useEffect` cleanup functions — new reference = runtime teardown and re-initialization
+- The empty `useMemo` dep array here is correct, not an `exhaustive-deps` oversight — the getter function captures the ref object (stable), not the ref's value
 
 ---
 

--- a/docs/guides/react-patterns.md
+++ b/docs/guides/react-patterns.md
@@ -137,6 +137,7 @@ When refactoring inline form fields into extracted components:
 // WRONG — isLoading state in deps causes timer to reset on every toggle
 const [isLoading, setIsLoading] = useState(false)
 useEffect(() => {
+  let timer: ReturnType<typeof setTimeout>
   const poll = async () => {
     setIsLoading(true)
     await fetchData()

--- a/docs/guides/react-patterns.md
+++ b/docs/guides/react-patterns.md
@@ -149,6 +149,7 @@ useEffect(() => {
 }, [isLoading, interval]) // isLoading change triggers teardown/recreate
 
 // CORRECT — ref mutation doesn't trigger the effect
+const { status } = useSession() // primitive string — won't churn deps
 const isLoadingRef = useRef(false)
 useEffect(() => {
   let timer: ReturnType<typeof setTimeout>

--- a/docs/guides/react-patterns.md
+++ b/docs/guides/react-patterns.md
@@ -1,6 +1,6 @@
 # React Patterns Guide
 
-Recurring patterns and pitfalls specific to this codebase. Consolidated from 7 react-patterns and 2 frontend learnings.
+Recurring patterns and pitfalls specific to this codebase. Consolidated from 13 react-patterns and 2 frontend learnings.
 
 ## Initialization Guards: Use ID-Tracking Refs
 
@@ -129,6 +129,185 @@ When refactoring inline form fields into extracted components:
 - [ ] Character counters and `onBlur` validation triggers preserved
 - [ ] Don't wrap `useState` setters in `useCallback` — React guarantees they're referentially stable across renders, so wrapping is redundant
 
+## Polling Timer Churn: Track `isLoading` via `useRef`
+
+`isLoading` state inside a polling `useEffect` dep array causes the effect to tear down and re-run on every fetch cycle (false → true → false), collapsing the intended backoff interval to near-zero.
+
+```typescript
+// WRONG — isLoading state in deps causes timer to reset on every toggle
+const [isLoading, setIsLoading] = useState(false)
+useEffect(() => {
+  const poll = async () => {
+    setIsLoading(true)
+    await fetchData()
+    setIsLoading(false)
+    timer = setTimeout(poll, interval)
+  }
+  poll()
+  return () => clearTimeout(timer)
+}, [isLoading, interval]) // isLoading change triggers teardown/recreate
+
+// CORRECT — ref mutation doesn't trigger the effect
+const isLoadingRef = useRef(false)
+useEffect(() => {
+  let timer: ReturnType<typeof setTimeout>
+  const poll = async () => {
+    if (isLoadingRef.current) return
+    isLoadingRef.current = true
+    try {
+      await fetchData()
+    } finally {
+      isLoadingRef.current = false
+      timer = setTimeout(poll, currentInterval)
+    }
+  }
+  poll()
+  return () => clearTimeout(timer)
+}, [status, currentInterval]) // status is a primitive (useSession().status)
+```
+
+**Rules:**
+- Audit every `useEffect` dep: if it changes inside the effect's async callback, convert to `useRef`
+- Prefer `useSession().status` (primitive string) over `session` (object) for session-gated effects
+- Use `setTimeout` chains for dynamic intervals; `setInterval` only when interval is fixed
+
+## Polling Cleanup: Pair `clearTimeout` with a `cancelled` Flag
+
+`clearTimeout` only cancels a timer that hasn't fired yet — it does not stop a `.then()` continuation already in the microtask queue. Without a `cancelled` guard, the loop continues after `useEffect` cleanup.
+
+```typescript
+// WRONG — clearTimeout cannot stop a .then() already queued
+useEffect(() => {
+  let timer: ReturnType<typeof setTimeout>
+  const scheduleNext = () => { timer = setTimeout(poll, interval) }
+  const poll = () => { fetchData().then(scheduleNext) } // leaks after cleanup
+  poll()
+  return () => clearTimeout(timer) // too late if .then() already in flight
+}, [interval])
+
+// CORRECT — cancelled flag stops the chain regardless of timing
+useEffect(() => {
+  let cancelled = false
+  let timer: ReturnType<typeof setTimeout>
+
+  const scheduleNext = () => {
+    if (cancelled) return
+    timer = setTimeout(poll, interval)
+  }
+  const poll = () => {
+    fetchData().finally(() => {
+      if (!cancelled) scheduleNext()
+    })
+  }
+
+  poll()
+  return () => {
+    cancelled = true
+    clearTimeout(timer)
+  }
+}, [interval])
+```
+
+**Rules:**
+- Any `.then()` or `.finally()` inside a polling `useEffect` must guard on a `cancelled` flag
+- Use `.finally()` instead of `.then()` so `scheduleNext` fires on both success and failure
+- Always pair `clearTimeout` with a `cancelled = true` assignment in cleanup
+
+*See also: Polling Timer Churn section above — `cancelled` flag and `useRef` for `isLoading` are complementary; both are needed.*
+
+## Callback Ref Timing: Assign in Render Body, Not `useEffect`
+
+Updating a callback ref inside `useEffect` introduces a timing gap: between render and effect flush, queued timers or microtask continuations can fire and call the stale function from the previous render.
+
+```typescript
+// WRONG — gap between render and effect flush; stale function can be called
+useEffect(() => {
+  onFailureRef.current = onFailure
+}, [onFailure])
+
+// CORRECT — ref is current before any timer or microtask can fire
+onFailureRef.current = onFailure  // synchronous in render body
+```
+
+React docs explicitly recommend this "event handler ref" pattern for stabilizing callback props. The ref object is stable; only `.current` changes.
+
+**Smell:** A `useEffect` whose only body is `someRef.current = someValue` should be a render-body assignment instead.
+
+## Hook Catch/Microtask Ordering: Caller Sees Stale Ref
+
+When a hook's `.catch()` mutates a ref and re-throws, the caller's `catch` block runs in the **same microtask tick as the re-throw** — before the hook's internal `.catch()` executes. The ref is stale-by-1 at the point the caller reads it.
+
+```typescript
+// Inside hook (simplified)
+const poll = () =>
+  fetchData().catch((err) => {
+    consecutiveFailuresRef.current += 1  // not yet incremented when caller catch fires
+    throw err
+  })
+
+// Caller
+poll().catch(() => {
+  // consecutiveFailuresRef.current here is STILL the pre-increment value
+  log.warn('failures', consecutiveFailuresRef.current)     // wrong
+  log.warn('failures', consecutiveFailuresRef.current + 1) // correct
+})
+```
+
+**Better solution:** expose an `onFailure(count)` callback on the hook (see Hook Circular Dependency section below) — the hook calls it with the accurate post-increment value, eliminating the `+1` arithmetic.
+
+**Rule:** Any ref mutated inside a `.catch()` that also re-throws: assume callers read the pre-mutation value.
+
+## Hook Circular Dependency: Use `onFailure` Callback, Not a Getter
+
+A hook that returns an internal-state accessor (e.g., `getConsecutiveFailures()`) creates a circular dependency when the caller also supplies the hook's `fn` argument that needs to read that state — `fn` must reference the getter, but the getter doesn't exist until after the hook call that receives `fn`.
+
+```typescript
+// WRONG — circular forward-reference, requires ESLint suppression
+const { getConsecutiveFailures } = usePollingWithBackoff({ fn: fetchResults })
+// fetchResults needs getConsecutiveFailures, but it's declared after the hook call
+
+// CORRECT — hook calls onFailure with accurate post-increment value
+usePollingWithBackoff({
+  fn: fetchResults,
+  onFailure: (consecutiveFailures) => {
+    if (consecutiveFailures >= THRESHOLD) reconnect()
+  },
+})
+```
+
+The circular dependency disappears entirely — the caller never holds a stale reference to internal state.
+
+**Rules:**
+- When a hook caller needs to react to internal hook state inside the `fn` it passes in, expose an event callback (`onFailure`, `onRetry`) not a state accessor
+- Return getters only when the caller needs to read state outside the `fn` lifecycle (e.g., in a separate event handler)
+- Callbacks receive accurate post-event state; getters require callers to reason about microtask ordering and staleness
+
+## assistant-ui Adapter Ref Stability
+
+Passing an unstable history adapter to `useChatRuntime` causes the runtime to detect a changed adapter and re-call `load()`, producing duplicate messages during streaming.
+
+```typescript
+// WRONG — new adapter instance on every render when conversationId changes
+const historyAdapter = useMemo(
+  () => createHistoryAdapter(conversationId),
+  [conversationId] // null → UUID transition creates new adapter mid-stream
+)
+
+// CORRECT — stable adapter instance; reads latest value via ref getter
+const conversationIdRef = useRef(conversationId)
+conversationIdRef.current = conversationId // synchronous render-body assignment
+
+const historyAdapter = useMemo(
+  () => createHistoryAdapter(() => conversationIdRef.current),
+  [] // empty deps — instance never recreated
+)
+```
+
+**Rules:**
+- Any object passed to `useChatRuntime` (adapter, runtime config) must have a stable reference across renders
+- When the adapter needs a value that changes over time, pass a ref-based getter, not the value directly
+- Treat `useChatRuntime` adapter props like `useEffect` cleanup functions — new reference = runtime teardown and re-initialization
+
 ---
 
-*Source: `docs/learnings/react-patterns/` and `docs/learnings/frontend/` (2026-02-19 through 2026-02-26)*
+*Source: `docs/learnings/react-patterns/` and `docs/learnings/frontend/` (2026-02-19 through 2026-04-08)*


### PR DESCRIPTION
## Summary

Implements #892 — adds 6 new React patterns discovered in March–April 2026 to `docs/guides/react-patterns.md` and expands the `### React` pitfalls section in `CLAUDE.md`.

## Changes

- `docs/guides/react-patterns.md` — 6 new sections added; consolidated count updated 7→13; source footer date range extended to 2026-04-08
- `CLAUDE.md` — 6 new bullet points added to the `### React` pitfalls section

### New patterns documented

| Pattern | Source learning |
|---------|----------------|
| **Polling Timer Churn** — `isLoading` state in `useEffect` deps collapses backoff interval; use `useRef` | `2026-03-11-polling-useref-isloading-dep-timer-churn` |
| **Polling Cleanup** — `clearTimeout` alone can't stop a `.then()` already in the microtask queue; pair with `cancelled` flag | `2026-03-11-polling-then-survives-cleartimeout` |
| **Callback Ref Timing** — assigning callback refs in `useEffect` creates a stale-ref timing gap; assign in render body | `2026-03-12-callback-ref-sync-render-body-not-useeffect` |
| **Hook Catch/Microtask Ordering** — caller's `catch` runs before hook's internal `.catch()` mutates the ref; value is stale-by-1 | `2026-03-12-hook-catch-reads-stale-ref-before-internal-handler` |
| **Hook Circular Dependency** — returning a getter creates a forward-reference when caller also supplies `fn`; use `onFailure(count)` callback | `2026-03-12-hook-circular-dep-use-callback-option` |
| **assistant-ui Adapter Ref Stability** — unstable adapter reference triggers `useChatRuntime` re-initialization and duplicate messages during streaming | `2026-04-08-assistant-ui-adapter-ref-stability-prevents-duplicate-messages` |

## Test Plan

- [x] Documentation-only change — no runtime behaviour modified
- [x] All 6 source learning files read and content faithfully summarised
- [x] Code snippets validated against the original learning files
- [x] CLAUDE.md React section cross-references `docs/guides/react-patterns.md`
- [x] Security audit — PASSED_WITH_NOTES (LOW/INFO findings fixed in-place, see audit comment)
- [ ] Human review

Closes #892

---
*Opened by the lfg routine.*