### PR TITLE
fix(pii): #971 — tokenize PII in file attachment text before sending to AI model

### DIFF
--- a/app/api/nexus/chat/route.ts
+++ b/app/api/nexus/chat/route.ts
@@ -9,6 +9,8 @@ import { processMessagesWithAttachments } from '@/lib/services/attachment-storag
 import { unifiedStreamingService } from '@/lib/streaming/unified-streaming-service';
 import type { StreamRequest } from '@/lib/streaming/types';
 import { ContentSafetyBlockedError } from '@/lib/streaming/types';
+import { getContentSafetyService } from '@/lib/safety';
+import type { TokenMapping } from '@/lib/safety/types';
 import { getModelConfig } from '@/lib/ai/model-config';
 import { getConnectorTools } from '@/lib/mcp/connector-service';
 import type { McpConnectorToolsResult } from '@/lib/mcp/connector-types';
@@ -131,16 +133,20 @@ async function executeStreaming(params: {
   dbModelId: number;
   log: ReturnType<typeof createLogger>;
   timer: (data: Record<string, unknown>) => void;
+  precomputedInputTokenMappings?: TokenMapping[];
 }): Promise<Response> {
   const {
     messages, modelConfig, userId, sessionId, conversationId,
     conversationIdValue, conversationTitle, enabledTools, enabledConnectors,
-    connectorToolResults, failedConnectorIds, reasoningEffort, responseMode, requestId, dbModelId, log, timer
+    connectorToolResults, failedConnectorIds, reasoningEffort, responseMode,
+    requestId, dbModelId, log, timer, precomputedInputTokenMappings
   } = params;
 
   const systemPrompt = `You are a helpful AI assistant in the Nexus interface.
 
-When discussing hardware, networking equipment, or technical specifications, treat model numbers, part numbers, and product identifiers as publicly available product information. Do not suggest that such identifiers have been redacted or withheld.`;
+When discussing hardware, networking equipment, or technical specifications, treat model numbers, part numbers, and product identifiers as publicly available product information. Do not suggest that such identifiers have been redacted or withheld.
+
+IMPORTANT: If text contains privacy tokens like [PII:xxxx-xxxx-xxxx-xxxx], preserve them exactly as written. Do not modify, expand, or interpret these tokens.`;
 
   // When MCP connectors are enabled, pre-merge adapter tools + connector tools
   // and pass as request.tools so the streaming service uses them directly
@@ -172,6 +178,7 @@ When discussing hardware, networking equipment, or technical specifications, tre
     // 10 steps is a reasonable upper bound for MCP tool chains (fetch→process→respond).
     maxSteps: connectorToolResults.length > 0 ? 10 : undefined,
     options: { reasoningEffort, responseMode },
+    precomputedInputTokenMappings,
     callbacks: {
       onFinish: createOnFinishCallback({ conversationId, dbModelId, connectorToolResults, log, timer }),
       onError: async (error: Error) => {
@@ -787,6 +794,127 @@ async function setupConversation(params: {
 }
 
 /**
+ * Extract plain text from a single message part (document or file type).
+ * Returns null when the part has no accessible text (e.g. an S3-only reference).
+ */
+function extractPartText(part: Record<string, unknown>): string | null {
+  const raw = part.content ?? part.data;
+  if (typeof raw === 'string' && raw.trim()) return raw;
+  if (Array.isArray(raw)) {
+    const segments = raw
+      .filter(
+        (cp): cp is { type: string; text: string } =>
+          typeof cp === 'object' && cp !== null &&
+          (cp as Record<string, unknown>).type === 'text' &&
+          typeof (cp as Record<string, unknown>).text === 'string'
+      )
+      .map(cp => cp.text);
+    if (segments.length > 0) return segments.join('\n');
+  }
+  return null;
+}
+
+/**
+ * Scan PII in file / document attachment parts of the last user message BEFORE
+ * processMessagesWithAttachments moves their content to S3. Returns token
+ * mappings produced by the scan and mutates `messagesWithParts` in-place so
+ * that document text is tokenized before being stored.
+ *
+ * This runs at the route level so that:
+ * 1. The extracted document text is available (not yet replaced with s3:// refs).
+ * 2. Token mappings can be passed to executeStreaming as `precomputedInputTokenMappings`
+ *    and merged with inline-text tokens from the streaming service's own scan.
+ */
+async function scanAttachmentPII(
+  messagesWithParts: UIMessage[],
+  sessionId: string,
+  log: ReturnType<typeof createLogger>,
+  requestId: string
+): Promise<TokenMapping[]> {
+  const contentSafetyService = getContentSafetyService();
+  if (!contentSafetyService.isPiiTokenizationEnabled()) return [];
+
+  const lastUserIdx = messagesWithParts.length - 1 -
+    [...messagesWithParts].reverse().findIndex(m => m.role === 'user');
+  if (lastUserIdx < 0) return [];
+
+  const lastUserMsg = messagesWithParts[lastUserIdx];
+  if (!Array.isArray(lastUserMsg.parts)) return [];
+
+  const attachmentTexts: Array<{ partIdx: number; text: string }> = [];
+  lastUserMsg.parts.forEach((part, partIdx) => {
+    const p = part as Record<string, unknown>;
+    if (p.type === 'document' || p.type === 'file') {
+      const text = extractPartText(p);
+      if (text) attachmentTexts.push({ partIdx, text });
+    }
+  });
+
+  if (attachmentTexts.length === 0) return [];
+
+  const combinedText = attachmentTexts.map(a => a.text).join('\n');
+  log.info('Running pre-flight PII scan on attachment text', {
+    requestId,
+    attachmentCount: attachmentTexts.length,
+    combinedLength: combinedText.length,
+  });
+
+  let scanResult;
+  try {
+    scanResult = await contentSafetyService.processInput(combinedText, sessionId);
+  } catch (err) {
+    log.warn('Pre-flight attachment PII scan failed — continuing without tokenization', {
+      requestId,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return [];
+  }
+
+  if (!scanResult.tokens || scanResult.tokens.length === 0) return [];
+
+  // Build a quick-lookup map: original value → token string
+  const replacements = new Map(scanResult.tokens.map(t => [t.original, t.token]));
+
+  // Apply tokenization to each attachment part text in-place
+  const updatedParts = [...lastUserMsg.parts];
+  for (const { partIdx, text } of attachmentTexts) {
+    let tokenizedText = text;
+    for (const [original, token] of replacements) {
+      tokenizedText = tokenizedText.replaceAll(original, token);
+    }
+    if (tokenizedText === text) continue;
+
+    const originalPart = updatedParts[partIdx] as Record<string, unknown>;
+    // Preserve whichever field held the text (content vs data)
+    const field = originalPart.content !== undefined ? 'content' : 'data';
+    const rawValue = originalPart[field];
+
+    if (typeof rawValue === 'string') {
+      updatedParts[partIdx] = { ...originalPart, [field]: tokenizedText } as typeof updatedParts[number];
+    } else if (Array.isArray(rawValue)) {
+      const tokenizedArray = rawValue.map(cp => {
+        const cpObj = cp as Record<string, unknown>;
+        if (cpObj.type === 'text' && typeof cpObj.text === 'string') {
+          let t = cpObj.text;
+          for (const [orig, tok] of replacements) t = t.replaceAll(orig, tok);
+          return { ...cpObj, text: t };
+        }
+        return cp;
+      });
+      updatedParts[partIdx] = { ...originalPart, [field]: tokenizedArray } as typeof updatedParts[number];
+    }
+  }
+
+  messagesWithParts[lastUserIdx] = { ...lastUserMsg, parts: updatedParts };
+  log.info('Pre-flight attachment PII tokenized', {
+    requestId,
+    tokenCount: scanResult.tokens.length,
+  });
+
+  return scanResult.tokens;
+}
+
+/**
  * Nexus Chat API - Native Streaming with AI SDK v5
  */
 export async function POST(req: Request) {
@@ -850,8 +978,14 @@ export async function POST(req: Request) {
     if ('error' in convSetup) return convSetup.error;
     const { conversationId, conversationTitle } = convSetup;
 
-    // 7. Convert messages and process attachments
+    // 7. Convert messages and process attachments.
+    // Run a pre-flight PII scan on attachment text BEFORE calling
+    // processMessagesWithAttachments so we can tokenize document content while
+    // it is still accessible (the call below replaces it with S3 references).
     const messagesWithParts = convertMessagesToPartsFormat(messages as UIMessage[]);
+    const precomputedInputTokenMappings = await scanAttachmentPII(
+      messagesWithParts, session.sub, log, requestId
+    );
     const { lightweightMessages } = await processMessagesWithAttachments(
       conversationId,
       messagesWithParts
@@ -905,7 +1039,8 @@ export async function POST(req: Request) {
       requestId,
       dbModelId,
       log,
-      timer
+      timer,
+      precomputedInputTokenMappings,
     });
 
   } catch (error) {

--- a/app/api/nexus/chat/route.ts
+++ b/app/api/nexus/chat/route.ts
@@ -861,18 +861,16 @@ async function scanAttachmentPII(
     combinedLength: combinedText.length,
   });
 
-  let scanResult;
-  try {
-    scanResult = await contentSafetyService.processInput(combinedText, sessionId);
-  } catch (err) {
-    log.warn('Pre-flight attachment PII scan failed — continuing without tokenization', {
-      requestId,
-      error: err instanceof Error ? err.message : String(err),
+  const scanResult = await contentSafetyService.processInput(combinedText, sessionId)
+    .catch((err: unknown) => {
+      log.warn('Pre-flight attachment PII scan failed — continuing without tokenization', {
+        requestId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      return null;
     });
-    return [];
-  }
 
-  if (!scanResult.tokens || scanResult.tokens.length === 0) return [];
+  if (!scanResult || !scanResult.tokens || scanResult.tokens.length === 0) return [];
 
   // Build a quick-lookup map: original value → placeholder string (e.g. "[PII:uuid]")
   // TokenMapping.token is the raw UUID; TokenMapping.placeholder is the formatted

--- a/app/api/nexus/chat/route.ts
+++ b/app/api/nexus/chat/route.ts
@@ -814,45 +814,16 @@ function extractPartText(part: Record<string, unknown>): string | null {
   return null;
 }
 
-// AWS Comprehend DetectPiiEntities hard limit in UTF-8 bytes.
-// We leave a 5 KB headroom to account for multi-byte characters.
-const COMPREHEND_MAX_BYTES = 95_000;
-
-/**
- * Truncate `text` to at most `maxBytes` UTF-8 bytes, respecting code-point
- * boundaries so we never produce an invalid surrogate pair.
- */
-function truncateToBytes(text: string, maxBytes: number): string {
-  if (Buffer.byteLength(text, 'utf8') <= maxBytes) return text;
-  // Binary-search the safe truncation point
-  let lo = 0;
-  let hi = text.length;
-  while (lo < hi) {
-    const mid = Math.ceil((lo + hi) / 2);
-    if (Buffer.byteLength(text.slice(0, mid), 'utf8') <= maxBytes) lo = mid;
-    else hi = mid - 1;
-  }
-  return text.slice(0, lo);
-}
-
 /**
  * Scan PII in file / document attachment parts of the last user message BEFORE
- * processMessagesWithAttachments moves their content to S3.
+ * processMessagesWithAttachments moves their content to S3. Returns token
+ * mappings produced by the scan and mutates `messagesWithParts` in-place so
+ * that document text is tokenized before being stored.
  *
- * Design choices:
- * - Each attachment is scanned individually to avoid cross-boundary Comprehend
- *   detections that can't be written back accurately.
- * - Each attachment is truncated to COMPREHEND_MAX_BYTES (95 KB) to stay within
- *   the Comprehend DetectPiiEntities API limit; text beyond that limit is sent
- *   to the model un-tokenized but a warning is logged.
- * - We use `scanResult.processedContent` (the already-tokenized text returned
- *   by the service) to update the part content, so we inherit the service's
- *   exact offset-based replacement rather than doing our own string-level
- *   replaceAll that could cause substring over-tokenization.
- * - `scanResult.allowed` is checked; if attachment content is blocked by
- *   Bedrock Guardrails it throws ContentSafetyBlockedError like inline text does.
- * - Token mappings from all attachments are merged (using a Map to deduplicate
- *   by placeholder so the same PII value across attachments gets one token).
+ * This runs at the route level so that:
+ * 1. The extracted document text is available (not yet replaced with s3:// refs).
+ * 2. Token mappings can be passed to executeStreaming as `precomputedInputTokenMappings`
+ *    and merged with inline-text tokens from the streaming service's own scan.
  */
 async function scanAttachmentPII(
   messagesWithParts: UIMessage[],
@@ -863,106 +834,74 @@ async function scanAttachmentPII(
   const contentSafetyService = getContentSafetyService();
   if (!contentSafetyService.isPiiTokenizationEnabled()) return [];
 
-  const lastUserIdx = messagesWithParts.length - 1 -
-    [...messagesWithParts].reverse().findIndex(m => m.role === 'user');
-  if (lastUserIdx < 0) return [];
+  // findIndex returns -1 when no user message exists; check before computing the index
+  // to avoid the silent out-of-bounds: length-1-(-1) = length (always positive).
+  const reversedIdx = [...messagesWithParts].reverse().findIndex(m => m.role === 'user');
+  if (reversedIdx === -1) return [];
+  const lastUserIdx = messagesWithParts.length - 1 - reversedIdx;
 
   const lastUserMsg = messagesWithParts[lastUserIdx];
   if (!Array.isArray(lastUserMsg.parts)) return [];
 
-  // Collect attachment parts that have extractable text
-  const attachmentEntries: Array<{ partIdx: number; text: string }> = [];
+  const attachmentTexts: Array<{ partIdx: number; text: string }> = [];
   lastUserMsg.parts.forEach((part, partIdx) => {
     const p = part as Record<string, unknown>;
     if (p.type === 'document' || p.type === 'file') {
       const text = extractPartText(p);
-      if (text) attachmentEntries.push({ partIdx, text });
+      if (text) attachmentTexts.push({ partIdx, text });
     }
   });
 
-  if (attachmentEntries.length === 0) return [];
+  if (attachmentTexts.length === 0) return [];
 
+  const combinedText = attachmentTexts.map(a => a.text).join('\n');
   log.info('Running pre-flight PII scan on attachment text', {
     requestId,
-    attachmentCount: attachmentEntries.length,
+    attachmentCount: attachmentTexts.length,
+    combinedLength: combinedText.length,
   });
 
-  // Merged token map: placeholder → TokenMapping (deduplicates same PII across attachments)
-  const mergedTokens = new Map<string, TokenMapping>();
+  let scanResult;
+  try {
+    scanResult = await contentSafetyService.processInput(combinedText, sessionId);
+  } catch (err) {
+    log.warn('Pre-flight attachment PII scan failed — continuing without tokenization', {
+      requestId,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return [];
+  }
+
+  if (!scanResult.tokens || scanResult.tokens.length === 0) return [];
+
+  // Build a quick-lookup map: original value → placeholder string (e.g. "[PII:uuid]")
+  // TokenMapping.token is the raw UUID; TokenMapping.placeholder is the formatted
+  // [PII:uuid] string that the model receives and the detokenizer looks up.
+  const replacements = new Map(scanResult.tokens.map(t => [t.original, t.placeholder]));
+
+  // Apply tokenization to each attachment part text in-place
   const updatedParts = [...lastUserMsg.parts];
-
-  for (const { partIdx, text } of attachmentEntries) {
-    // Enforce Comprehend 100 KB limit per attachment
-    const safeText = truncateToBytes(text, COMPREHEND_MAX_BYTES);
-    if (safeText.length < text.length) {
-      log.warn('Attachment text truncated before PII scan — content exceeds Comprehend limit', {
-        requestId,
-        originalLength: text.length,
-        truncatedLength: safeText.length,
-        partIdx,
-      });
+  for (const { partIdx, text } of attachmentTexts) {
+    let tokenizedText = text;
+    for (const [original, placeholder] of replacements) {
+      tokenizedText = tokenizedText.replaceAll(original, placeholder);
     }
-
-    let scanResult;
-    try {
-      scanResult = await contentSafetyService.processInput(safeText, sessionId);
-    } catch (err) {
-      log.warn('Pre-flight attachment PII scan failed — skipping attachment', {
-        requestId,
-        partIdx,
-        error: err instanceof Error ? err.message : String(err),
-      });
-      continue;
-    }
-
-    // Surface content blocks from Bedrock Guardrails (same as inline-text check)
-    if (!scanResult.allowed) {
-      throw new ContentSafetyBlockedError(
-        scanResult.blockedMessage || 'Content blocked by safety guardrails',
-        scanResult.blockedCategories || [],
-        'input'
-      );
-    }
-
-    if (!scanResult.tokens || scanResult.tokens.length === 0) continue;
-
-    // Accumulate tokens (deduplicate by placeholder across attachments)
-    for (const t of scanResult.tokens) {
-      mergedTokens.set(t.placeholder, t);
-    }
-
-    // Use processedContent (offset-based tokenization from the service) as the
-    // replacement text. For truncated attachments we only have tokenized text
-    // for safeText; the truncated tail is appended un-tokenized.
-    const tokenizedHead = scanResult.hasPII
-      ? scanResult.processedContent
-      : safeText;
-    const tokenizedText = text.length > safeText.length
-      ? tokenizedHead + text.slice(safeText.length)
-      : tokenizedHead;
-
     if (tokenizedText === text) continue;
 
     const originalPart = updatedParts[partIdx] as Record<string, unknown>;
+    // Preserve whichever field held the text (content vs data)
     const field = originalPart.content !== undefined ? 'content' : 'data';
     const rawValue = originalPart[field];
 
     if (typeof rawValue === 'string') {
       updatedParts[partIdx] = { ...originalPart, [field]: tokenizedText } as typeof updatedParts[number];
     } else if (Array.isArray(rawValue)) {
-      // ContentPart[] — apply original→placeholder substitutions per text segment.
-      // Comprehend's NER is context-aware so substring collisions are rare in practice.
-      const knownOriginals = new Map(
-        scanResult.tokens.map(t => [t.original, t.placeholder])
-      );
       const tokenizedArray = rawValue.map(cp => {
         const cpObj = cp as Record<string, unknown>;
         if (cpObj.type === 'text' && typeof cpObj.text === 'string') {
-          let segText = cpObj.text as string;
-          for (const [orig, ph] of knownOriginals) {
-            segText = segText.replaceAll(orig, ph);
-          }
-          return { ...cpObj, text: segText };
+          let tokenizedSegment = cpObj.text;
+          for (const [orig, ph] of replacements) tokenizedSegment = tokenizedSegment.replaceAll(orig, ph);
+          return { ...cpObj, text: tokenizedSegment };
         }
         return cp;
       });
@@ -970,15 +909,13 @@ async function scanAttachmentPII(
     }
   }
 
-  if (mergedTokens.size === 0) return [];
-
   messagesWithParts[lastUserIdx] = { ...lastUserMsg, parts: updatedParts };
-  const allTokens = Array.from(mergedTokens.values());
   log.info('Pre-flight attachment PII tokenized', {
     requestId,
-    tokenCount: allTokens.length,
+    tokenCount: scanResult.tokens.length,
   });
-  return allTokens;
+
+  return scanResult.tokens;
 }
 
 /**

--- a/app/api/nexus/chat/route.ts
+++ b/app/api/nexus/chat/route.ts
@@ -814,16 +814,45 @@ function extractPartText(part: Record<string, unknown>): string | null {
   return null;
 }
 
+// AWS Comprehend DetectPiiEntities hard limit in UTF-8 bytes.
+// We leave a 5 KB headroom to account for multi-byte characters.
+const COMPREHEND_MAX_BYTES = 95_000;
+
+/**
+ * Truncate `text` to at most `maxBytes` UTF-8 bytes, respecting code-point
+ * boundaries so we never produce an invalid surrogate pair.
+ */
+function truncateToBytes(text: string, maxBytes: number): string {
+  if (Buffer.byteLength(text, 'utf8') <= maxBytes) return text;
+  // Binary-search the safe truncation point
+  let lo = 0;
+  let hi = text.length;
+  while (lo < hi) {
+    const mid = Math.ceil((lo + hi) / 2);
+    if (Buffer.byteLength(text.slice(0, mid), 'utf8') <= maxBytes) lo = mid;
+    else hi = mid - 1;
+  }
+  return text.slice(0, lo);
+}
+
 /**
  * Scan PII in file / document attachment parts of the last user message BEFORE
- * processMessagesWithAttachments moves their content to S3. Returns token
- * mappings produced by the scan and mutates `messagesWithParts` in-place so
- * that document text is tokenized before being stored.
+ * processMessagesWithAttachments moves their content to S3.
  *
- * This runs at the route level so that:
- * 1. The extracted document text is available (not yet replaced with s3:// refs).
- * 2. Token mappings can be passed to executeStreaming as `precomputedInputTokenMappings`
- *    and merged with inline-text tokens from the streaming service's own scan.
+ * Design choices:
+ * - Each attachment is scanned individually to avoid cross-boundary Comprehend
+ *   detections that can't be written back accurately.
+ * - Each attachment is truncated to COMPREHEND_MAX_BYTES (95 KB) to stay within
+ *   the Comprehend DetectPiiEntities API limit; text beyond that limit is sent
+ *   to the model un-tokenized but a warning is logged.
+ * - We use `scanResult.processedContent` (the already-tokenized text returned
+ *   by the service) to update the part content, so we inherit the service's
+ *   exact offset-based replacement rather than doing our own string-level
+ *   replaceAll that could cause substring over-tokenization.
+ * - `scanResult.allowed` is checked; if attachment content is blocked by
+ *   Bedrock Guardrails it throws ContentSafetyBlockedError like inline text does.
+ * - Token mappings from all attachments are merged (using a Map to deduplicate
+ *   by placeholder so the same PII value across attachments gets one token).
  */
 async function scanAttachmentPII(
   messagesWithParts: UIMessage[],
@@ -841,63 +870,99 @@ async function scanAttachmentPII(
   const lastUserMsg = messagesWithParts[lastUserIdx];
   if (!Array.isArray(lastUserMsg.parts)) return [];
 
-  const attachmentTexts: Array<{ partIdx: number; text: string }> = [];
+  // Collect attachment parts that have extractable text
+  const attachmentEntries: Array<{ partIdx: number; text: string }> = [];
   lastUserMsg.parts.forEach((part, partIdx) => {
     const p = part as Record<string, unknown>;
     if (p.type === 'document' || p.type === 'file') {
       const text = extractPartText(p);
-      if (text) attachmentTexts.push({ partIdx, text });
+      if (text) attachmentEntries.push({ partIdx, text });
     }
   });
 
-  if (attachmentTexts.length === 0) return [];
+  if (attachmentEntries.length === 0) return [];
 
-  const combinedText = attachmentTexts.map(a => a.text).join('\n');
   log.info('Running pre-flight PII scan on attachment text', {
     requestId,
-    attachmentCount: attachmentTexts.length,
-    combinedLength: combinedText.length,
+    attachmentCount: attachmentEntries.length,
   });
 
-  let scanResult;
-  try {
-    scanResult = await contentSafetyService.processInput(combinedText, sessionId);
-  } catch (err) {
-    log.warn('Pre-flight attachment PII scan failed — continuing without tokenization', {
-      requestId,
-      error: err instanceof Error ? err.message : String(err),
-    });
-    return [];
-  }
-
-  if (!scanResult.tokens || scanResult.tokens.length === 0) return [];
-
-  // Build a quick-lookup map: original value → token string
-  const replacements = new Map(scanResult.tokens.map(t => [t.original, t.token]));
-
-  // Apply tokenization to each attachment part text in-place
+  // Merged token map: placeholder → TokenMapping (deduplicates same PII across attachments)
+  const mergedTokens = new Map<string, TokenMapping>();
   const updatedParts = [...lastUserMsg.parts];
-  for (const { partIdx, text } of attachmentTexts) {
-    let tokenizedText = text;
-    for (const [original, token] of replacements) {
-      tokenizedText = tokenizedText.replaceAll(original, token);
+
+  for (const { partIdx, text } of attachmentEntries) {
+    // Enforce Comprehend 100 KB limit per attachment
+    const safeText = truncateToBytes(text, COMPREHEND_MAX_BYTES);
+    if (safeText.length < text.length) {
+      log.warn('Attachment text truncated before PII scan — content exceeds Comprehend limit', {
+        requestId,
+        originalLength: text.length,
+        truncatedLength: safeText.length,
+        partIdx,
+      });
     }
+
+    let scanResult;
+    try {
+      scanResult = await contentSafetyService.processInput(safeText, sessionId);
+    } catch (err) {
+      log.warn('Pre-flight attachment PII scan failed — skipping attachment', {
+        requestId,
+        partIdx,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      continue;
+    }
+
+    // Surface content blocks from Bedrock Guardrails (same as inline-text check)
+    if (!scanResult.allowed) {
+      throw new ContentSafetyBlockedError(
+        scanResult.blockedMessage || 'Content blocked by safety guardrails',
+        scanResult.blockedCategories || [],
+        'input'
+      );
+    }
+
+    if (!scanResult.tokens || scanResult.tokens.length === 0) continue;
+
+    // Accumulate tokens (deduplicate by placeholder across attachments)
+    for (const t of scanResult.tokens) {
+      mergedTokens.set(t.placeholder, t);
+    }
+
+    // Use processedContent (offset-based tokenization from the service) as the
+    // replacement text. For truncated attachments we only have tokenized text
+    // for safeText; the truncated tail is appended un-tokenized.
+    const tokenizedHead = scanResult.hasPII
+      ? scanResult.processedContent
+      : safeText;
+    const tokenizedText = text.length > safeText.length
+      ? tokenizedHead + text.slice(safeText.length)
+      : tokenizedHead;
+
     if (tokenizedText === text) continue;
 
     const originalPart = updatedParts[partIdx] as Record<string, unknown>;
-    // Preserve whichever field held the text (content vs data)
     const field = originalPart.content !== undefined ? 'content' : 'data';
     const rawValue = originalPart[field];
 
     if (typeof rawValue === 'string') {
       updatedParts[partIdx] = { ...originalPart, [field]: tokenizedText } as typeof updatedParts[number];
     } else if (Array.isArray(rawValue)) {
+      // ContentPart[] — apply original→placeholder substitutions per text segment.
+      // Comprehend's NER is context-aware so substring collisions are rare in practice.
+      const knownOriginals = new Map(
+        scanResult.tokens.map(t => [t.original, t.placeholder])
+      );
       const tokenizedArray = rawValue.map(cp => {
         const cpObj = cp as Record<string, unknown>;
         if (cpObj.type === 'text' && typeof cpObj.text === 'string') {
-          let t = cpObj.text;
-          for (const [orig, tok] of replacements) t = t.replaceAll(orig, tok);
-          return { ...cpObj, text: t };
+          let segText = cpObj.text as string;
+          for (const [orig, ph] of knownOriginals) {
+            segText = segText.replaceAll(orig, ph);
+          }
+          return { ...cpObj, text: segText };
         }
         return cp;
       });
@@ -905,13 +970,15 @@ async function scanAttachmentPII(
     }
   }
 
+  if (mergedTokens.size === 0) return [];
+
   messagesWithParts[lastUserIdx] = { ...lastUserMsg, parts: updatedParts };
+  const allTokens = Array.from(mergedTokens.values());
   log.info('Pre-flight attachment PII tokenized', {
     requestId,
-    tokenCount: scanResult.tokens.length,
+    tokenCount: allTokens.length,
   });
-
-  return scanResult.tokens;
+  return allTokens;
 }
 
 /**

--- a/lib/streaming/__tests__/pii-attachment-scan.test.ts
+++ b/lib/streaming/__tests__/pii-attachment-scan.test.ts
@@ -1,0 +1,315 @@
+/**
+ * Tests for attachment-borne PII scanning (Issue #971)
+ *
+ * Verifies that:
+ * 1. extractPartText() correctly extracts text from document/file parts
+ *    in both string and ContentPart[] formats.
+ * 2. The scanAttachmentPII logic (mirrored here for unit testing) tokenizes
+ *    document text before processMessagesWithAttachments moves it to S3.
+ * 3. precomputedInputTokenMappings are merged into the detokenization
+ *    transform — tested by verifying the returned token array.
+ */
+
+import { describe, it, expect, jest } from '@jest/globals';
+
+// ---------------------------------------------------------------------------
+// Helper: build a fake UIMessage with mixed text + document parts
+// ---------------------------------------------------------------------------
+function makeMsgWithDocument(opts: {
+  inlineText?: string;
+  documentContent?: string | Array<{ type: string; text: string }>;
+  documentType?: 'document' | 'file';
+}) {
+  const parts: Array<Record<string, unknown>> = [];
+  if (opts.inlineText) parts.push({ type: 'text', text: opts.inlineText });
+  if (opts.documentContent !== undefined) {
+    parts.push({
+      type: opts.documentType ?? 'document',
+      name: 'template.docx',
+      contentType: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+      content: opts.documentContent,
+    });
+  }
+  return { id: 'msg-1', role: 'user' as const, parts };
+}
+
+// ---------------------------------------------------------------------------
+// extractPartText — mirrors the implementation in route.ts for pure-logic tests
+// ---------------------------------------------------------------------------
+function extractPartText(part: Record<string, unknown>): string | null {
+  const raw = part.content ?? part.data;
+  if (typeof raw === 'string' && (raw as string).trim()) return raw as string;
+  if (Array.isArray(raw)) {
+    const segments = (raw as Array<unknown>)
+      .filter(
+        (cp): cp is { type: string; text: string } =>
+          typeof cp === 'object' && cp !== null &&
+          (cp as Record<string, unknown>).type === 'text' &&
+          typeof (cp as Record<string, unknown>).text === 'string',
+      )
+      .map(cp => cp.text);
+    if (segments.length > 0) return segments.join('\n');
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// scanAttachmentPII — mirrors the logic from route.ts for unit testing
+// without importing the server-only route module.
+// ---------------------------------------------------------------------------
+type TokenMapping = { token: string; original: string; type: string };
+
+async function runScanAttachmentPII(
+  messagesWithParts: Array<{ id: string; role: string; parts: Array<Record<string, unknown>> }>,
+  safetyService: {
+    isPiiTokenizationEnabled: () => boolean;
+    processInput: (text: string, sessionId: string) => Promise<{
+      allowed: boolean;
+      tokens?: TokenMapping[];
+    }>;
+  },
+): Promise<TokenMapping[]> {
+  if (!safetyService.isPiiTokenizationEnabled()) return [];
+
+  const lastUserIdx = messagesWithParts.length - 1 -
+    [...messagesWithParts].reverse().findIndex(m => m.role === 'user');
+  if (lastUserIdx < 0) return [];
+
+  const lastUserMsg = messagesWithParts[lastUserIdx];
+  if (!Array.isArray(lastUserMsg.parts)) return [];
+
+  const attachmentTexts: Array<{ partIdx: number; text: string }> = [];
+  lastUserMsg.parts.forEach((part, partIdx) => {
+    if (part.type === 'document' || part.type === 'file') {
+      const text = extractPartText(part);
+      if (text) attachmentTexts.push({ partIdx, text });
+    }
+  });
+
+  if (attachmentTexts.length === 0) return [];
+
+  const combinedText = attachmentTexts.map(a => a.text).join('\n');
+  const scanResult = await safetyService.processInput(combinedText, 'session-1');
+  if (!scanResult.tokens || scanResult.tokens.length === 0) return [];
+
+  const replacements = new Map(scanResult.tokens.map(t => [t.original, t.token]));
+
+  const updatedParts = [...lastUserMsg.parts];
+  for (const { partIdx, text } of attachmentTexts) {
+    let tokenizedText = text;
+    for (const [original, token] of replacements) tokenizedText = tokenizedText.replaceAll(original, token);
+    if (tokenizedText === text) continue;
+
+    const originalPart = updatedParts[partIdx] as Record<string, unknown>;
+    const field = originalPart.content !== undefined ? 'content' : 'data';
+    const rawValue = originalPart[field];
+
+    if (typeof rawValue === 'string') {
+      updatedParts[partIdx] = { ...originalPart, [field]: tokenizedText };
+    } else if (Array.isArray(rawValue)) {
+      updatedParts[partIdx] = {
+        ...originalPart,
+        [field]: rawValue.map(cp => {
+          const cpObj = cp as Record<string, unknown>;
+          if (cpObj.type === 'text' && typeof cpObj.text === 'string') {
+            let t = cpObj.text as string;
+            for (const [orig, tok] of replacements) t = t.replaceAll(orig, tok);
+            return { ...cpObj, text: t };
+          }
+          return cp;
+        }),
+      };
+    }
+  }
+  messagesWithParts[lastUserIdx] = { ...lastUserMsg, parts: updatedParts };
+  return scanResult.tokens;
+}
+
+const mockTokens: TokenMapping[] = [
+  { token: '[PII:aaaa-bbbb-cccc-dddd-eeeeffff0000]', original: 'Kris', type: 'PERSON' },
+];
+
+function makeMockService(opts: { piiEnabled: boolean; tokens?: TokenMapping[] }) {
+  return {
+    isPiiTokenizationEnabled: () => opts.piiEnabled,
+    processInput: jest.fn().mockResolvedValue({
+      allowed: true,
+      tokens: opts.tokens ?? [],
+    }) as jest.MockedFunction<(text: string, sessionId: string) => Promise<{ allowed: boolean; tokens: TokenMapping[] }>>,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests: extractPartText
+// ---------------------------------------------------------------------------
+describe('extractPartText (attachment text extraction)', () => {
+  it('returns string content as-is', () => {
+    expect(extractPartText({ type: 'document', content: 'Dear Kris, please review.' }))
+      .toBe('Dear Kris, please review.');
+  });
+
+  it('returns null for empty string content', () => {
+    expect(extractPartText({ type: 'document', content: '' })).toBeNull();
+  });
+
+  it('returns null for whitespace-only content', () => {
+    expect(extractPartText({ type: 'document', content: '   ' })).toBeNull();
+  });
+
+  it('extracts and joins text from ContentPart[] content, skipping non-text parts', () => {
+    const part = {
+      type: 'document',
+      content: [
+        { type: 'text', text: 'Line 1' },
+        { type: 'image', url: 's3://bucket/img.png' },
+        { type: 'text', text: 'Line 2' },
+      ],
+    };
+    expect(extractPartText(part)).toBe('Line 1\nLine 2');
+  });
+
+  it('falls back to data field when content is absent', () => {
+    expect(extractPartText({ type: 'file', data: 'extracted from data field' }))
+      .toBe('extracted from data field');
+  });
+
+  it('returns null for S3-only file part (no content or data)', () => {
+    expect(extractPartText({ type: 'file', url: 's3://conversations/abc/attach-0' })).toBeNull();
+  });
+
+  it('returns null when both content and data are missing', () => {
+    expect(extractPartText({ type: 'document', name: 'template.docx' })).toBeNull();
+  });
+
+  it('returns null for ContentPart[] with no text entries', () => {
+    const part = { type: 'document', content: [{ type: 'image', url: 's3://img' }] };
+    expect(extractPartText(part)).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: scanAttachmentPII logic
+// ---------------------------------------------------------------------------
+describe('scanAttachmentPII — attachment PII tokenization', () => {
+  it('returns [] when PII tokenization is disabled', async () => {
+    const service = makeMockService({ piiEnabled: false });
+    const messages = [makeMsgWithDocument({ documentContent: 'Dear Kris,' })];
+    const tokens = await runScanAttachmentPII(messages as never, service);
+    expect(tokens).toEqual([]);
+    expect(service.processInput).not.toHaveBeenCalled();
+  });
+
+  it('returns [] when there are no document/file parts', async () => {
+    const service = makeMockService({ piiEnabled: true, tokens: mockTokens });
+    const messages = [{ id: 'msg-1', role: 'user', parts: [{ type: 'text', text: 'hi' }] }];
+    const tokens = await runScanAttachmentPII(messages as never, service);
+    expect(tokens).toEqual([]);
+    expect(service.processInput).not.toHaveBeenCalled();
+  });
+
+  it('returns [] when document part has no extractable text (S3 ref)', async () => {
+    const service = makeMockService({ piiEnabled: true, tokens: mockTokens });
+    const messages = [
+      {
+        id: 'msg-1',
+        role: 'user',
+        parts: [{ type: 'file', url: 's3://bucket/obj', mediaType: 'application/pdf' }],
+      },
+    ];
+    const tokens = await runScanAttachmentPII(messages as never, service);
+    expect(tokens).toEqual([]);
+    expect(service.processInput).not.toHaveBeenCalled();
+  });
+
+  it('scans document text and returns token mappings', async () => {
+    const service = makeMockService({ piiEnabled: true, tokens: mockTokens });
+    const messages = [makeMsgWithDocument({ documentContent: 'Dear Kris, please review.' })];
+    const tokens = await runScanAttachmentPII(messages as never, service);
+    expect(tokens).toEqual(mockTokens);
+    expect(service.processInput).toHaveBeenCalledWith('Dear Kris, please review.', 'session-1');
+  });
+
+  it('replaces PII in string content field in-place', async () => {
+    const service = makeMockService({ piiEnabled: true, tokens: mockTokens });
+    const messages = [makeMsgWithDocument({ documentContent: 'Hi Kris' })];
+    await runScanAttachmentPII(messages as never, service);
+    const docPart = messages[0].parts.find(p => p.type === 'document') as Record<string, unknown>;
+    expect(docPart.content).toBe('Hi [PII:aaaa-bbbb-cccc-dddd-eeeeffff0000]');
+  });
+
+  it('replaces PII in ContentPart[] content field in-place', async () => {
+    const service = makeMockService({ piiEnabled: true, tokens: mockTokens });
+    const messages = [
+      makeMsgWithDocument({
+        documentContent: [
+          { type: 'text', text: 'Dear Kris,' },
+          { type: 'text', text: 'No PII here.' },
+        ],
+      }),
+    ];
+    await runScanAttachmentPII(messages as never, service);
+    const docPart = messages[0].parts.find(p => p.type === 'document') as Record<string, unknown>;
+    const content = docPart.content as Array<{ type: string; text: string }>;
+    expect(content[0].text).toBe('Dear [PII:aaaa-bbbb-cccc-dddd-eeeeffff0000],');
+    expect(content[1].text).toBe('No PII here.');
+  });
+
+  it('replaces PII in data field when content is absent', async () => {
+    const service = makeMockService({ piiEnabled: true, tokens: mockTokens });
+    const messages = [
+      {
+        id: 'msg-1',
+        role: 'user',
+        parts: [{ type: 'file', data: 'Hi Kris from data field.' }],
+      },
+    ];
+    await runScanAttachmentPII(messages as never, service);
+    const filePart = messages[0].parts[0] as Record<string, unknown>;
+    expect(filePart.data).toBe('Hi [PII:aaaa-bbbb-cccc-dddd-eeeeffff0000] from data field.');
+  });
+
+  it('combines text from multiple attachment parts for the scan', async () => {
+    const service = makeMockService({ piiEnabled: true, tokens: mockTokens });
+    const messages = [
+      {
+        id: 'msg-1',
+        role: 'user',
+        parts: [
+          { type: 'document', content: 'Document 1: Hi Kris.' },
+          { type: 'file', data: 'Document 2: Also Kris.' },
+        ],
+      },
+    ];
+    await runScanAttachmentPII(messages as never, service);
+    expect(service.processInput).toHaveBeenCalledWith(
+      'Document 1: Hi Kris.\nDocument 2: Also Kris.',
+      'session-1',
+    );
+  });
+
+  it('returns [] when scan finds no tokens', async () => {
+    const service = makeMockService({ piiEnabled: true, tokens: [] });
+    const messages = [makeMsgWithDocument({ documentContent: 'No names here.' })];
+    const tokens = await runScanAttachmentPII(messages as never, service);
+    expect(tokens).toEqual([]);
+  });
+
+  it('leaves parts unchanged when scan returns no tokens', async () => {
+    const service = makeMockService({ piiEnabled: true, tokens: [] });
+    const messages = [makeMsgWithDocument({ documentContent: 'No names here.' })];
+    await runScanAttachmentPII(messages as never, service);
+    const docPart = messages[0].parts.find(p => p.type === 'document') as Record<string, unknown>;
+    expect(docPart.content).toBe('No names here.');
+  });
+
+  it('works correctly when the last user message has both text and document parts', async () => {
+    const service = makeMockService({ piiEnabled: true, tokens: mockTokens });
+    const messages = [
+      makeMsgWithDocument({ inlineText: 'Please review this.', documentContent: 'Kris signed here.' }),
+    ];
+    const tokens = await runScanAttachmentPII(messages as never, service);
+    expect(tokens).toEqual(mockTokens);
+    // Only the document part should be scanned, not the inline text
+    expect(service.processInput).toHaveBeenCalledWith('Kris signed here.', 'session-1');
+  });
+});

--- a/lib/streaming/__tests__/pii-attachment-scan.test.ts
+++ b/lib/streaming/__tests__/pii-attachment-scan.test.ts
@@ -146,7 +146,7 @@ const mockTokens: TokenMapping[] = [
 function makeMockService(opts: { piiEnabled: boolean; tokens?: TokenMapping[] }) {
   return {
     isPiiTokenizationEnabled: () => opts.piiEnabled,
-    processInput: jest.fn().mockResolvedValue({
+    processInput: (jest.fn() as jest.Mock<any>).mockResolvedValue({
       allowed: true,
       tokens: opts.tokens ?? [],
     }),

--- a/lib/streaming/__tests__/pii-attachment-scan.test.ts
+++ b/lib/streaming/__tests__/pii-attachment-scan.test.ts
@@ -57,7 +57,10 @@ function extractPartText(part: Record<string, unknown>): string | null {
 // scanAttachmentPII — mirrors the logic from route.ts for unit testing
 // without importing the server-only route module.
 // ---------------------------------------------------------------------------
-type TokenMapping = { token: string; placeholder: string; original: string; type: string };
+
+// Matches the shape of lib/safety/types.ts TokenMapping.
+// token: raw UUID; placeholder: formatted "[PII:uuid]" string used in text.
+type TokenMapping = { token: string; original: string; type: string; placeholder: string };
 
 async function runScanAttachmentPII(
   messagesWithParts: Array<{ id: string; role: string; parts: Array<Record<string, unknown>> }>,
@@ -71,9 +74,11 @@ async function runScanAttachmentPII(
 ): Promise<TokenMapping[]> {
   if (!safetyService.isPiiTokenizationEnabled()) return [];
 
-  const lastUserIdx = messagesWithParts.length - 1 -
-    [...messagesWithParts].reverse().findIndex(m => m.role === 'user');
-  if (lastUserIdx < 0) return [];
+  // findIndex returns -1 when no user message exists; check before computing
+  // the index to avoid the silent out-of-bounds: length-1-(-1) = length.
+  const reversedIdx = [...messagesWithParts].reverse().findIndex(m => m.role === 'user');
+  if (reversedIdx === -1) return [];
+  const lastUserIdx = messagesWithParts.length - 1 - reversedIdx;
 
   const lastUserMsg = messagesWithParts[lastUserIdx];
   if (!Array.isArray(lastUserMsg.parts)) return [];
@@ -92,12 +97,14 @@ async function runScanAttachmentPII(
   const scanResult = await safetyService.processInput(combinedText, 'session-1');
   if (!scanResult.tokens || scanResult.tokens.length === 0) return [];
 
+  // Use placeholder ("[PII:uuid]") not token (raw UUID) — the placeholder is
+  // what gets embedded in the text and what the detokenizer searches for.
   const replacements = new Map(scanResult.tokens.map(t => [t.original, t.placeholder]));
 
   const updatedParts = [...lastUserMsg.parts];
   for (const { partIdx, text } of attachmentTexts) {
     let tokenizedText = text;
-    for (const [original, token] of replacements) tokenizedText = tokenizedText.replaceAll(original, token);
+    for (const [original, placeholder] of replacements) tokenizedText = tokenizedText.replaceAll(original, placeholder);
     if (tokenizedText === text) continue;
 
     const originalPart = updatedParts[partIdx] as Record<string, unknown>;
@@ -112,9 +119,9 @@ async function runScanAttachmentPII(
         [field]: rawValue.map(cp => {
           const cpObj = cp as Record<string, unknown>;
           if (cpObj.type === 'text' && typeof cpObj.text === 'string') {
-            let t = cpObj.text as string;
-            for (const [orig, ph] of replacements) t = t.replaceAll(orig, ph);
-            return { ...cpObj, text: t };
+            let seg = cpObj.text as string;
+            for (const [orig, ph] of replacements) seg = seg.replaceAll(orig, ph);
+            return { ...cpObj, text: seg };
           }
           return cp;
         }),
@@ -125,12 +132,14 @@ async function runScanAttachmentPII(
   return scanResult.tokens;
 }
 
+// token: raw UUID (as produced by the real PII tokenization service)
+// placeholder: formatted "[PII:uuid]" string embedded in text
 const mockTokens: TokenMapping[] = [
   {
     token: 'aaaa-bbbb-cccc-dddd-eeeeffff0000',
-    placeholder: '[PII:aaaa-bbbb-cccc-dddd-eeeeffff0000]',
     original: 'Kris',
     type: 'PERSON',
+    placeholder: '[PII:aaaa-bbbb-cccc-dddd-eeeeffff0000]',
   },
 ];
 
@@ -234,7 +243,7 @@ describe('scanAttachmentPII — attachment PII tokenization', () => {
     expect(service.processInput).toHaveBeenCalledWith('Dear Kris, please review.', 'session-1');
   });
 
-  it('replaces PII in string content field in-place', async () => {
+  it('replaces PII in string content field using placeholder (not raw token UUID)', async () => {
     const service = makeMockService({ piiEnabled: true, tokens: mockTokens });
     const messages = [makeMsgWithDocument({ documentContent: 'Hi Kris' })];
     await runScanAttachmentPII(messages as never, service);

--- a/lib/streaming/__tests__/pii-attachment-scan.test.ts
+++ b/lib/streaming/__tests__/pii-attachment-scan.test.ts
@@ -149,7 +149,7 @@ function makeMockService(opts: { piiEnabled: boolean; tokens?: TokenMapping[] })
     processInput: jest.fn().mockResolvedValue({
       allowed: true,
       tokens: opts.tokens ?? [],
-    }) as jest.MockedFunction<(text: string, sessionId: string) => Promise<{ allowed: boolean; tokens: TokenMapping[] }>>,
+    }) as jest.Mock,
   };
 }
 

--- a/lib/streaming/__tests__/pii-attachment-scan.test.ts
+++ b/lib/streaming/__tests__/pii-attachment-scan.test.ts
@@ -149,7 +149,7 @@ function makeMockService(opts: { piiEnabled: boolean; tokens?: TokenMapping[] })
     processInput: jest.fn().mockResolvedValue({
       allowed: true,
       tokens: opts.tokens ?? [],
-    }) as jest.Mock,
+    }),
   };
 }
 

--- a/lib/streaming/__tests__/pii-attachment-scan.test.ts
+++ b/lib/streaming/__tests__/pii-attachment-scan.test.ts
@@ -57,7 +57,7 @@ function extractPartText(part: Record<string, unknown>): string | null {
 // scanAttachmentPII — mirrors the logic from route.ts for unit testing
 // without importing the server-only route module.
 // ---------------------------------------------------------------------------
-type TokenMapping = { token: string; original: string; type: string };
+type TokenMapping = { token: string; placeholder: string; original: string; type: string };
 
 async function runScanAttachmentPII(
   messagesWithParts: Array<{ id: string; role: string; parts: Array<Record<string, unknown>> }>,
@@ -92,7 +92,7 @@ async function runScanAttachmentPII(
   const scanResult = await safetyService.processInput(combinedText, 'session-1');
   if (!scanResult.tokens || scanResult.tokens.length === 0) return [];
 
-  const replacements = new Map(scanResult.tokens.map(t => [t.original, t.token]));
+  const replacements = new Map(scanResult.tokens.map(t => [t.original, t.placeholder]));
 
   const updatedParts = [...lastUserMsg.parts];
   for (const { partIdx, text } of attachmentTexts) {
@@ -113,7 +113,7 @@ async function runScanAttachmentPII(
           const cpObj = cp as Record<string, unknown>;
           if (cpObj.type === 'text' && typeof cpObj.text === 'string') {
             let t = cpObj.text as string;
-            for (const [orig, tok] of replacements) t = t.replaceAll(orig, tok);
+            for (const [orig, ph] of replacements) t = t.replaceAll(orig, ph);
             return { ...cpObj, text: t };
           }
           return cp;
@@ -126,7 +126,12 @@ async function runScanAttachmentPII(
 }
 
 const mockTokens: TokenMapping[] = [
-  { token: '[PII:aaaa-bbbb-cccc-dddd-eeeeffff0000]', original: 'Kris', type: 'PERSON' },
+  {
+    token: 'aaaa-bbbb-cccc-dddd-eeeeffff0000',
+    placeholder: '[PII:aaaa-bbbb-cccc-dddd-eeeeffff0000]',
+    original: 'Kris',
+    type: 'PERSON',
+  },
 ];
 
 function makeMockService(opts: { piiEnabled: boolean; tokens?: TokenMapping[] }) {

--- a/lib/streaming/types.ts
+++ b/lib/streaming/types.ts
@@ -1,4 +1,5 @@
 import type { UIMessage, LanguageModel, ModelMessage, ToolSet } from 'ai';
+import type { TokenMapping } from '@/lib/safety/types';
 import type { SSEEventEmitter } from '@/types/sse-events';
 import type { SSEEvent } from './sse-event-types';
 
@@ -74,6 +75,14 @@ export interface StreamRequest {
   
   // Callbacks for streaming events
   callbacks?: StreamingCallbacks;
+
+  /**
+   * Token mappings pre-computed by the route (e.g. from scanning attachment text
+   * before it is moved to S3). These are merged with any tokens produced by the
+   * streaming service's own inline-text scan so the detokenization transform can
+   * reverse PII from both inline text and document attachments.
+   */
+  precomputedInputTokenMappings?: TokenMapping[];
 }
 
 export interface StreamResponse {

--- a/lib/streaming/unified-streaming-service.ts
+++ b/lib/streaming/unified-streaming-service.ts
@@ -262,16 +262,43 @@ interface OutputSafetyCheckResult {
 }
 
 /**
- * Extract text content from a UIMessage (AI SDK v5 format)
+ * Extract text content from a UIMessage (AI SDK v6 format).
+ * Handles both inline text parts and document/file parts that may still contain
+ * their extracted text (i.e. before they are moved to S3 by processMessagesWithAttachments).
  */
-function extractTextFromUIMessage(message: { parts?: Array<{ type: string; text?: string }> }): string {
+function extractTextFromUIMessage(
+  message: { parts?: Array<{ type: string; text?: string; content?: unknown; data?: unknown }> }
+): string {
   if (!message.parts || !Array.isArray(message.parts)) {
     return '';
   }
-  return message.parts
-    .filter((part) => part.type === 'text' && part.text)
-    .map((part) => part.text)
-    .join('\n');
+  const segments: string[] = [];
+  for (const part of message.parts) {
+    if (part.type === 'text' && part.text) {
+      segments.push(part.text);
+      continue;
+    }
+    // Extract text from document / file parts when their content is still present
+    // (i.e. the message has not yet been through processMessagesWithAttachments).
+    if (part.type === 'document' || part.type === 'file') {
+      const raw = (part as { content?: unknown; data?: unknown }).content
+        ?? (part as { content?: unknown; data?: unknown }).data;
+      if (typeof raw === 'string' && raw) {
+        segments.push(raw);
+      } else if (Array.isArray(raw)) {
+        for (const cp of raw) {
+          if (
+            typeof cp === 'object' && cp !== null &&
+            (cp as Record<string, unknown>).type === 'text' &&
+            typeof (cp as Record<string, unknown>).text === 'string'
+          ) {
+            segments.push((cp as { text: string }).text);
+          }
+        }
+      }
+    }
+  }
+  return segments.join('\n');
 }
 
 /**
@@ -821,9 +848,16 @@ export class UnifiedStreamingService {
           source: request.source
         });
 
+        // Merge inline-scan tokens with any tokens pre-computed at the route
+        // level (e.g. from scanning attachment / document text before S3 storage).
+        const allTokenMappings: TokenMapping[] = [
+          ...(request.precomputedInputTokenMappings || []),
+          ...(inputSafetyResult?.tokens || []),
+        ];
+
         return buildStreamResponse({
           result, requestId, capabilities, telemetryConfig,
-          tokenMappings: inputSafetyResult?.tokens || [],
+          tokenMappings: allTokenMappings,
           log
         });
         


### PR DESCRIPTION
## Summary

Fixes #971 (FS#155286 — `[PII]=Kris` placeholder visible in chat response when PII originates from an uploaded file attachment).

The root cause was a two-stage gap in the PII pipeline:
1. `extractTextFromUIMessage()` only read `type === &#39;text&#39;` parts, silently skipping document/file attachment parts.
2. The safety check runs **after** `processMessagesWithAttachments` has moved attachment content to S3, so even a fixed extractor would see empty lightweight references.

## Changes

| File | Change |
|------|--------|
| `lib/streaming/types.ts` | Add `precomputedInputTokenMappings?: TokenMapping[]` to `StreamRequest` |
| `lib/streaming/unified-streaming-service.ts` | `extractTextFromUIMessage()` now handles document/file parts (string, ContentPart[], data field). `stream()` merges precomputed tokens with inline-scan tokens for the detokenization transform. |
| `app/api/nexus/chat/route.ts` | New `extractPartText()` helper + `scanAttachmentPII()` that runs before `processMessagesWithAttachments`, tokenizes PII in document content in-place, and returns mappings. System prompt adds Fix 2 (Option C): instruct model to preserve `[PII:uuid]` tokens verbatim. |
| `lib/streaming/__tests__/pii-attachment-scan.test.ts` | 19 new unit tests for `extractPartText` and `scanAttachmentPII` logic |

## How it works

```
User uploads template.docx (contains "Kris")
  ↓
convertMessagesToPartsFormat()
  ↓
scanAttachmentPII()          ← NEW: Comprehend sees "Kris", emits [PII:uuid]
  Document part content updated in-place with tokenized text
  Token mappings held in precomputedInputTokenMappings
  ↓
processMessagesWithAttachments()
  Tokenized document content stored in S3
  ↓
executeStreaming({ precomputedInputTokenMappings })
  ├─ checkInputContentSafety()  — inline text scan (unchanged)
  └─ allTokenMappings = precomputed + inline tokens
     → detokenization transform covers both sources
  ↓
Model sees [PII:uuid] instead of "Kris"
  ↓
Response stream: [PII:uuid] → detokenized → "Kris" ✓
```

## Test Plan

- [x] 19 new unit tests passing (`bun test lib/streaming/__tests__/pii-attachment-scan.test.ts`)
- [x] Existing streaming tests unaffected (96 pass, 5 pre-existing failures from missing node_modules)
- [x] test-specialist agent passed
- [x] work-validator agent passed
- [x] Security audit — completed (5 findings, all resolved in commit `8a947d6b`; see [audit comment](https://github.com/psd401/aistudio/pull/989#issuecomment-4450762244))
- [ ] Human review

## Acceptance Criteria Coverage

- [x] Uploading a document with personal names tokenizes those names before the model sees them
- [x] AI responses display original names (no `[PII:uuid]` leakage) — detokenization transform covers attachment tokens
- [x] Bedrock Guardrails conflict mitigated — system prompt instructs model to preserve `[PII:uuid]` tokens verbatim
- [x] All existing PII tests unaffected
- [x] New test for attachment-borne PII added

Closes #971

---
*Opened by the lfg routine.*

---
_Generated by [Claude Code](https://claude.ai/code/session_01GSPeHd5oRURM6x6nR3P3pA)_