### PR TITLE
feat: #977 — [FS#157050] Fix AI_MissingToolResultsError on multi-step MCP tool use

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -435,6 +435,8 @@ const role = ServiceRoleFactory.createLambdaRole(this, 'MyFunctionRole', {
 - **Don't** return `null` from a DB accessor for both not-found and error in an SWR cache — cache cannot distinguish the two; DB errors silently overwrite valid cached state with defaults
 - **Don't** pass a Web API `Blob` to `@google/genai` SDK methods — the SDK expects `{ data: base64string, mimeType: string }`, not a `Blob` object
 - **Don't** assume AWS SDK assessment objects are flat — check ALL sub-properties (e.g., `wordPolicy.customWords` AND `wordPolicy.managedWordLists`); missing one drops an entire blocking category from observability
+- **Don't** omit `state: 'output-available'` and `input` on tool-call UIMessage parts — `convertToModelMessages` silently skips the `tool_result` block, causing `AI_MissingToolResultsError` on replay
+- **Don't** consolidate multi-step MCP responses into a single DB row — persist each step separately inside `executeTransaction` or reload fails with consecutive user turns (see `chat-helpers.ts:saveConversationSteps`)
 
 ### React (see `docs/guides/react-patterns.md`)
 - **Don't** put `key` on Provider/context wrapper components

--- a/app/(protected)/nexus/_components/conversation-initializer.tsx
+++ b/app/(protected)/nexus/_components/conversation-initializer.tsx
@@ -70,7 +70,10 @@ export function convertContentToParts(content?: ApiMessageContent): UIMessagePar
         const args = part.args ?? {}
         // null means stream error before onFinish — treat same as no result
         const hasResult = part.result != null
-        const isError = part.isError === true
+        // Prefer the stored state (added in Issue #977 fix) over derived state so
+        // that output-error parts aren't silently downgraded to input-available.
+        const storedState = (part as Record<string, unknown>).state as string | undefined
+        const isError = part.isError === true || storedState === 'output-error'
         const input = typeof args === 'object' && args !== null ? args as Record<string, unknown> : {}
 
         let toolPart: StaticToolPart

--- a/app/(protected)/nexus/_components/conversation-initializer.tsx
+++ b/app/(protected)/nexus/_components/conversation-initializer.tsx
@@ -72,7 +72,10 @@ export function convertContentToParts(content?: ApiMessageContent): UIMessagePar
         const hasResult = part.result != null
         // Prefer the stored state (added in Issue #977 fix) over derived state so
         // that output-error parts aren't silently downgraded to input-available.
-        const storedState = (part as Record<string, unknown>).state as string | undefined
+        // Validate against the known enum to guard against corrupted JSONB values.
+        const VALID_STATES = new Set(['input-available', 'output-available', 'output-error'])
+        const rawState = (part as Record<string, unknown>).state
+        const storedState = typeof rawState === 'string' && VALID_STATES.has(rawState) ? rawState : undefined
         const isError = part.isError === true || storedState === 'output-error'
         const input = typeof args === 'object' && args !== null ? args as Record<string, unknown> : {}
 

--- a/app/(protected)/nexus/_components/conversation-initializer.tsx
+++ b/app/(protected)/nexus/_components/conversation-initializer.tsx
@@ -77,7 +77,7 @@ export function convertContentToParts(content?: ApiMessageContent): UIMessagePar
         // Prefer the stored state (added in Issue #977 fix) over derived state so
         // that output-error parts aren't silently downgraded to input-available.
         // Validate against the known enum to guard against corrupted JSONB values.
-        const rawState = (part as Record<string, unknown>).state
+        const rawState = (part as unknown as Record<string, unknown>).state
         const storedState = typeof rawState === 'string' && VALID_TOOL_STATES.has(rawState) ? rawState : undefined
         const isError = part.isError === true || storedState === 'output-error'
         const input = typeof args === 'object' && args !== null ? args as Record<string, unknown> : {}

--- a/app/(protected)/nexus/_components/conversation-initializer.tsx
+++ b/app/(protected)/nexus/_components/conversation-initializer.tsx
@@ -55,6 +55,10 @@ function isToolCallPart(part: MessagePart): part is MessagePart & {
          typeof part.toolCallId === 'string'
 }
 
+// Allowed states for stored tool-call parts — validated against this set when reading from
+// JSONB to guard against corrupted stored values (Issue #977 Defect 3 fix).
+const VALID_TOOL_STATES = new Set(['input-available', 'output-available', 'output-error'])
+
 /**
  * Helper to convert content parts to UIMessage parts format
  * Converts tool-call to static tool format (type: 'tool-{toolName}')
@@ -73,9 +77,8 @@ export function convertContentToParts(content?: ApiMessageContent): UIMessagePar
         // Prefer the stored state (added in Issue #977 fix) over derived state so
         // that output-error parts aren't silently downgraded to input-available.
         // Validate against the known enum to guard against corrupted JSONB values.
-        const VALID_STATES = new Set(['input-available', 'output-available', 'output-error'])
         const rawState = (part as Record<string, unknown>).state
-        const storedState = typeof rawState === 'string' && VALID_STATES.has(rawState) ? rawState : undefined
+        const storedState = typeof rawState === 'string' && VALID_TOOL_STATES.has(rawState) ? rawState : undefined
         const isError = part.isError === true || storedState === 'output-error'
         const input = typeof args === 'object' && args !== null ? args as Record<string, unknown> : {}
 

--- a/app/api/nexus/chat/chat-helpers.ts
+++ b/app/api/nexus/chat/chat-helpers.ts
@@ -277,6 +277,24 @@ type AssistantPart = {
   argsText?: string;
   result?: unknown;
   isError?: boolean;
+  // AI SDK v6 UIMessage tool-part fields — required by convertToModelMessages to emit tool_result blocks
+  state?: 'input-available' | 'output-available' | 'output-error';
+  input?: Record<string, unknown>;
+};
+
+/** Tool call data for a single streaming step */
+export type StepToolCallData = {
+  toolCallId: string;
+  toolName: string;
+  args: Record<string, unknown>;
+  result?: unknown;
+};
+
+/** A single resolved streaming step, used for per-step message persistence */
+export type StepData = {
+  text: string;
+  toolCalls: StepToolCallData[];
+  finishReason: string;
 };
 
 /**
@@ -299,17 +317,24 @@ function buildAssistantParts(
       // which causes assistant-ui's append-only argsText check to fail when the conversation
       // is reloaded and argsText is recomputed from the parsed args object. (Issue #798)
       const decodedArgs = decodeHtmlEntitiesDeep(tc.args) as Record<string, unknown>;
+      // null when extraction missed the result (e.g. stream error before onFinish).
+      // UI tool components handle null with loading/fallback states — verified in
+      // web-search-ui.tsx, code-interpreter-ui.tsx, chart-visualization-ui.tsx.
+      const hasResult = tc.result != null;
       parts.push({
         type: 'tool-call',
         toolCallId: tc.toolCallId,
         toolName: tc.toolName,
         args: decodedArgs,
         argsText: JSON.stringify(decodedArgs),
-        // null when extraction missed the result (e.g. stream error before onFinish).
-        // UI tool components handle null with loading/fallback states — verified in
-        // web-search-ui.tsx, code-interpreter-ui.tsx, chart-visualization-ui.tsx.
         result: tc.result ?? null,
         isError: false,
+        // AI SDK v6 UIMessage schema fields required by convertToModelMessages to emit
+        // paired tool_result blocks when this conversation is reloaded and replayed.
+        // Without state+input, convertToModelMessages emits tool_use without tool_result,
+        // causing AI_MissingToolResultsError on follow-up messages. (Issue #977)
+        state: hasResult ? 'output-available' : 'input-available',
+        input: decodedArgs,
       });
     }
   }
@@ -402,4 +427,115 @@ export async function saveAssistantMessage(params: {
   });
 }
 
+/**
+ * Insert a single assistant message row without updating conversation stats.
+ * Used by saveConversationSteps to insert multiple step messages before
+ * doing one consolidated stats update.
+ */
+async function insertAssistantMessageRow(params: {
+  conversationId: string;
+  sanitizedContent: string;
+  parts: AssistantPart[];
+  dbModelId: number;
+  finishReason: string;
+}): Promise<void> {
+  const { conversationId, sanitizedContent, parts, dbModelId, finishReason } = params;
+  const now = new Date();
+  await executeQuery(
+    (db) => db.insert(nexusMessages)
+      .values({
+        conversationId,
+        role: 'assistant',
+        content: sanitizedContent,
+        parts: sql`${safeJsonbStringify(parts)}::jsonb`,
+        modelId: dbModelId,
+        tokenUsage: sql`${safeJsonbStringify({ promptTokens: 0, completionTokens: 0, totalTokens: 0 })}::jsonb`,
+        finishReason,
+        metadata: sql`${safeJsonbStringify({})}::jsonb`,
+        createdAt: now,
+        updatedAt: now,
+      }),
+    'insertAssistantMessageRow'
+  );
+}
+
+/**
+ * Persist a multi-step tool-use response as separate per-step messages.
+ *
+ * When maxSteps > 1, the AI SDK runs an agentic loop where each step may
+ * produce tool calls. Consolidating all steps into one assistant message
+ * breaks conversation replay: convertToModelMessages cannot reconstruct
+ * the correct multi-turn (assistant→user→assistant) structure needed by
+ * Anthropic. Saving each step separately preserves that structure.
+ *
+ * Stats (messageCount, totalTokens) are updated once after all rows are
+ * inserted to avoid double-counting.
+ */
+export async function saveConversationSteps(params: {
+  conversationId: string;
+  steps: StepData[];
+  dbModelId: number;
+  usage?: { promptTokens?: number; completionTokens?: number; totalTokens?: number };
+  finishReason?: string;
+}): Promise<void> {
+  const { conversationId, steps, dbModelId, usage, finishReason } = params;
+
+  let savedCount = 0;
+
+  for (let i = 0; i < steps.length; i++) {
+    const step = steps[i];
+    const isLastStep = i === steps.length - 1;
+    const stepFinishReason = isLastStep ? (finishReason ?? 'stop') : step.finishReason;
+
+    const hasToolCalls = step.toolCalls.length > 0;
+    const hasText = step.text.length > 0;
+
+    if (!hasToolCalls && !hasText) continue;
+
+    const sanitizedContent = step.text ? sanitizeTextForDatabase(step.text) : '';
+    const parts = buildAssistantParts(sanitizedContent, hasToolCalls ? step.toolCalls : undefined);
+
+    await insertAssistantMessageRow({
+      conversationId,
+      sanitizedContent,
+      parts,
+      dbModelId,
+      finishReason: stepFinishReason,
+    });
+    savedCount++;
+
+    log.info('Saved step message', {
+      conversationId,
+      stepIndex: i,
+      isLastStep,
+      hasToolCalls,
+      toolCallCount: step.toolCalls.length,
+      hasText,
+    });
+  }
+
+  if (savedCount === 0) {
+    log.warn('No step messages had content to save', { conversationId });
+    return;
+  }
+
+  await executeQuery(
+    (db) => db.update(nexusConversations)
+      .set({
+        messageCount: sql`${nexusConversations.messageCount} + ${savedCount}`,
+        totalTokens: sql`${nexusConversations.totalTokens} + ${usage?.totalTokens ?? 0}`,
+        lastMessageAt: new Date(),
+        updatedAt: new Date(),
+      })
+      .where(eq(nexusConversations.id, conversationId)),
+    'updateConversationAfterSteps'
+  );
+
+  log.info('Multi-step response saved', {
+    conversationId,
+    stepCount: steps.length,
+    savedCount,
+    totalTokens: usage?.totalTokens,
+  });
+}
 

--- a/app/api/nexus/chat/chat-helpers.ts
+++ b/app/api/nexus/chat/chat-helpers.ts
@@ -470,7 +470,10 @@ export async function saveConversationSteps(params: {
     if (!hasToolCalls && !hasText) continue;
     const sanitizedContent = step.text ? sanitizeTextForDatabase(step.text) : '';
     const parts = buildAssistantParts(sanitizedContent, hasToolCalls ? step.toolCalls : undefined);
-    rowsToInsert.push({ sanitizedContent, parts, stepFinishReason, stepIndex: i, hasToolCalls, toolCallCount: step.toolCalls.length, hasText, isLastStep });
+    rowsToInsert.push({
+      sanitizedContent, parts, stepFinishReason, stepIndex: i,
+      hasToolCalls, toolCallCount: step.toolCalls.length, hasText, isLastStep,
+    });
   }
 
   if (rowsToInsert.length === 0) {

--- a/app/api/nexus/chat/chat-helpers.ts
+++ b/app/api/nexus/chat/chat-helpers.ts
@@ -428,38 +428,6 @@ export async function saveAssistantMessage(params: {
 }
 
 /**
- * Insert a single assistant message row without updating conversation stats.
- * Used by saveConversationSteps to insert multiple step messages before
- * doing one consolidated stats update.
- */
-async function insertAssistantMessageRow(params: {
-  conversationId: string;
-  sanitizedContent: string;
-  parts: AssistantPart[];
-  dbModelId: number;
-  finishReason: string;
-}): Promise<void> {
-  const { conversationId, sanitizedContent, parts, dbModelId, finishReason } = params;
-  const now = new Date();
-  await executeQuery(
-    (db) => db.insert(nexusMessages)
-      .values({
-        conversationId,
-        role: 'assistant',
-        content: sanitizedContent,
-        parts: sql`${safeJsonbStringify(parts)}::jsonb`,
-        modelId: dbModelId,
-        tokenUsage: sql`${safeJsonbStringify({ promptTokens: 0, completionTokens: 0, totalTokens: 0 })}::jsonb`,
-        finishReason,
-        metadata: sql`${safeJsonbStringify({})}::jsonb`,
-        createdAt: now,
-        updatedAt: now,
-      }),
-    'insertAssistantMessageRow'
-  );
-}
-
-/**
  * Persist a multi-step tool-use response as separate per-step messages.
  *
  * When maxSteps > 1, the AI SDK runs an agentic loop where each step may
@@ -557,4 +525,3 @@ export async function saveConversationSteps(params: {
     totalTokens: usage?.totalTokens,
   });
 }
-

--- a/app/api/nexus/chat/chat-helpers.ts
+++ b/app/api/nexus/chat/chat-helpers.ts
@@ -4,7 +4,7 @@
  */
 import { UIMessage } from 'ai';
 import { sql, eq } from 'drizzle-orm';
-import { executeQuery } from '@/lib/db/drizzle-client';
+import { executeQuery, executeTransaction } from '@/lib/db/drizzle-client';
 import { nexusConversations, nexusMessages } from '@/lib/db/schema';
 import { sanitizeTextForDatabase, decodeHtmlEntitiesDeep } from '@/lib/utils/text-sanitizer';
 import { safeJsonbStringify } from '@/lib/db/json-utils';
@@ -480,56 +480,75 @@ export async function saveConversationSteps(params: {
 }): Promise<void> {
   const { conversationId, steps, dbModelId, usage, finishReason } = params;
 
-  let savedCount = 0;
+  // Build all row data before opening a transaction (pure computation)
+  type RowData = {
+    sanitizedContent: string;
+    parts: AssistantPart[];
+    stepFinishReason: string;
+    stepIndex: number;
+    hasToolCalls: boolean;
+    toolCallCount: number;
+    hasText: boolean;
+    isLastStep: boolean;
+  };
 
+  const rowsToInsert: RowData[] = [];
   for (let i = 0; i < steps.length; i++) {
     const step = steps[i];
     const isLastStep = i === steps.length - 1;
     const stepFinishReason = isLastStep ? (finishReason ?? 'stop') : step.finishReason;
-
     const hasToolCalls = step.toolCalls.length > 0;
     const hasText = step.text.length > 0;
-
     if (!hasToolCalls && !hasText) continue;
-
     const sanitizedContent = step.text ? sanitizeTextForDatabase(step.text) : '';
     const parts = buildAssistantParts(sanitizedContent, hasToolCalls ? step.toolCalls : undefined);
-
-    await insertAssistantMessageRow({
-      conversationId,
-      sanitizedContent,
-      parts,
-      dbModelId,
-      finishReason: stepFinishReason,
-    });
-    savedCount++;
-
-    log.info('Saved step message', {
-      conversationId,
-      stepIndex: i,
-      isLastStep,
-      hasToolCalls,
-      toolCallCount: step.toolCalls.length,
-      hasText,
-    });
+    rowsToInsert.push({ sanitizedContent, parts, stepFinishReason, stepIndex: i, hasToolCalls, toolCallCount: step.toolCalls.length, hasText, isLastStep });
   }
 
-  if (savedCount === 0) {
+  if (rowsToInsert.length === 0) {
     log.warn('No step messages had content to save', { conversationId });
     return;
   }
 
-  await executeQuery(
-    (db) => db.update(nexusConversations)
+  const savedCount = rowsToInsert.length;
+  const now = new Date();
+
+  // All inserts + stats update in a single transaction to prevent partial writes
+  await executeTransaction(async (tx) => {
+    for (const row of rowsToInsert) {
+      await tx.insert(nexusMessages).values({
+        conversationId,
+        role: 'assistant',
+        content: row.sanitizedContent,
+        parts: sql`${safeJsonbStringify(row.parts)}::jsonb`,
+        modelId: dbModelId,
+        tokenUsage: sql`${safeJsonbStringify({ promptTokens: 0, completionTokens: 0, totalTokens: 0 })}::jsonb`,
+        finishReason: row.stepFinishReason,
+        metadata: sql`${safeJsonbStringify({})}::jsonb`,
+        createdAt: now,
+        updatedAt: now,
+      });
+    }
+    await tx.update(nexusConversations)
       .set({
         messageCount: sql`${nexusConversations.messageCount} + ${savedCount}`,
         totalTokens: sql`${nexusConversations.totalTokens} + ${usage?.totalTokens ?? 0}`,
         lastMessageAt: new Date(),
         updatedAt: new Date(),
       })
-      .where(eq(nexusConversations.id, conversationId)),
-    'updateConversationAfterSteps'
-  );
+      .where(eq(nexusConversations.id, conversationId));
+  }, 'saveConversationSteps');
+
+  for (const row of rowsToInsert) {
+    log.info('Saved step message', {
+      conversationId,
+      stepIndex: row.stepIndex,
+      isLastStep: row.isLastStep,
+      hasToolCalls: row.hasToolCalls,
+      toolCallCount: row.toolCallCount,
+      hasText: row.hasText,
+    });
+  }
 
   log.info('Multi-step response saved', {
     conversationId,

--- a/app/api/nexus/chat/chat-helpers.ts
+++ b/app/api/nexus/chat/chat-helpers.ts
@@ -479,14 +479,16 @@ export async function saveConversationSteps(params: {
   }
 
   const savedCount = rowsToInsert.length;
-  // Compute timestamp once so all step rows and the stats update share the same value.
-  // Using separate new Date() calls inside the transaction would produce microsecond
-  // skews between step createdAt and conversation lastMessageAt.
-  const now = new Date();
+  // Base timestamp for this batch. Each step row gets createdAt = baseTime + stepIndex
+  // milliseconds so that ORDER BY created_at always returns steps in the correct
+  // agentic sequence. All rows sharing the same timestamp would produce a
+  // nondeterministic read order and break multi-turn replay. (Issue #977)
+  const baseTime = new Date();
 
   // All inserts + stats update in a single transaction to prevent partial writes
   await executeTransaction(async (tx) => {
     for (const row of rowsToInsert) {
+      const createdAt = new Date(baseTime.getTime() + row.stepIndex);
       await tx.insert(nexusMessages).values({
         conversationId,
         role: 'assistant',
@@ -498,16 +500,16 @@ export async function saveConversationSteps(params: {
         tokenUsage: sql`${safeJsonbStringify({ promptTokens: 0, completionTokens: 0, totalTokens: 0 })}::jsonb`,
         finishReason: row.stepFinishReason,
         metadata: sql`${safeJsonbStringify({})}::jsonb`,
-        createdAt: now,
-        updatedAt: now,
+        createdAt,
+        updatedAt: baseTime,
       });
     }
     await tx.update(nexusConversations)
       .set({
         messageCount: sql`${nexusConversations.messageCount} + ${savedCount}`,
         totalTokens: sql`${nexusConversations.totalTokens} + ${usage?.totalTokens ?? 0}`,
-        lastMessageAt: now,
-        updatedAt: now,
+        lastMessageAt: new Date(baseTime.getTime() + rowsToInsert.length - 1),
+        updatedAt: baseTime,
       })
       .where(eq(nexusConversations.id, conversationId));
   }, 'saveConversationSteps');

--- a/app/api/nexus/chat/chat-helpers.ts
+++ b/app/api/nexus/chat/chat-helpers.ts
@@ -479,6 +479,9 @@ export async function saveConversationSteps(params: {
   }
 
   const savedCount = rowsToInsert.length;
+  // Compute timestamp once so all step rows and the stats update share the same value.
+  // Using separate new Date() calls inside the transaction would produce microsecond
+  // skews between step createdAt and conversation lastMessageAt.
   const now = new Date();
 
   // All inserts + stats update in a single transaction to prevent partial writes
@@ -490,6 +493,8 @@ export async function saveConversationSteps(params: {
         content: row.sanitizedContent,
         parts: sql`${safeJsonbStringify(row.parts)}::jsonb`,
         modelId: dbModelId,
+        // Token usage not available per-step; real totals are aggregated at the
+        // conversation level in the stats update below.
         tokenUsage: sql`${safeJsonbStringify({ promptTokens: 0, completionTokens: 0, totalTokens: 0 })}::jsonb`,
         finishReason: row.stepFinishReason,
         metadata: sql`${safeJsonbStringify({})}::jsonb`,
@@ -501,8 +506,8 @@ export async function saveConversationSteps(params: {
       .set({
         messageCount: sql`${nexusConversations.messageCount} + ${savedCount}`,
         totalTokens: sql`${nexusConversations.totalTokens} + ${usage?.totalTokens ?? 0}`,
-        lastMessageAt: new Date(),
-        updatedAt: new Date(),
+        lastMessageAt: now,
+        updatedAt: now,
       })
       .where(eq(nexusConversations.id, conversationId));
   }, 'saveConversationSteps');

--- a/app/api/nexus/chat/chat-helpers.ts
+++ b/app/api/nexus/chat/chat-helpers.ts
@@ -511,7 +511,7 @@ export async function saveConversationSteps(params: {
       .set({
         messageCount: sql`${nexusConversations.messageCount} + ${savedCount}`,
         totalTokens: sql`${nexusConversations.totalTokens} + ${usage?.totalTokens ?? 0}`,
-        lastMessageAt: new Date(baseTime.getTime() + (rowsToInsert[rowsToInsert.length - 1]?.stepIndex ?? 0)),
+        lastMessageAt: new Date(baseTime.getTime() + rowsToInsert[rowsToInsert.length - 1].stepIndex),
         updatedAt: baseTime,
       })
       .where(eq(nexusConversations.id, conversationId));

--- a/app/api/nexus/chat/chat-helpers.ts
+++ b/app/api/nexus/chat/chat-helpers.ts
@@ -508,7 +508,7 @@ export async function saveConversationSteps(params: {
       .set({
         messageCount: sql`${nexusConversations.messageCount} + ${savedCount}`,
         totalTokens: sql`${nexusConversations.totalTokens} + ${usage?.totalTokens ?? 0}`,
-        lastMessageAt: new Date(baseTime.getTime() + rowsToInsert.length - 1),
+        lastMessageAt: new Date(baseTime.getTime() + (rowsToInsert[rowsToInsert.length - 1]?.stepIndex ?? 0)),
         updatedAt: baseTime,
       })
       .where(eq(nexusConversations.id, conversationId));

--- a/app/api/nexus/chat/route.ts
+++ b/app/api/nexus/chat/route.ts
@@ -36,6 +36,7 @@ import {
   saveUserMessage,
   convertMessagesToPartsFormat,
   saveAssistantMessage,
+  saveConversationSteps,
 } from './chat-helpers';
 
 import { eq, and } from 'drizzle-orm';
@@ -78,7 +79,8 @@ function createOnFinishCallback(params: {
     text,
     usage,
     finishReason,
-    toolCalls
+    toolCalls,
+    steps,
   }: {
     text: string;
     usage?: { promptTokens?: number; completionTokens?: number; totalTokens?: number };
@@ -89,16 +91,30 @@ function createOnFinishCallback(params: {
       args: Record<string, unknown>;
       result?: unknown;
     }>;
+    steps?: Array<{
+      text: string;
+      toolCalls: Array<{ toolCallId: string; toolName: string; args: Record<string, unknown>; result?: unknown }>;
+      finishReason: string;
+    }>;
   }) => {
     log.info('Stream finished, saving assistant message', {
       conversationId,
       hasText: !!text,
       textLength: text?.length || 0,
-      toolCallCount: toolCalls?.length || 0
+      toolCallCount: toolCalls?.length || 0,
+      stepCount: steps?.length ?? 0,
     });
 
     try {
-      await saveAssistantMessage({ conversationId, text, usage, finishReason, toolCalls, dbModelId });
+      if (steps && steps.length > 1) {
+        // Multi-step agentic loop (MCP connectors): save each step as a separate
+        // assistant message to preserve the correct turn structure for replay.
+        // Consolidating into one message breaks convertToModelMessages — it cannot
+        // reconstruct multi-turn tool_use/tool_result pairs. (Issue #977)
+        await saveConversationSteps({ conversationId, steps, dbModelId, usage, finishReason });
+      } else {
+        await saveAssistantMessage({ conversationId, text, usage, finishReason, toolCalls, dbModelId });
+      }
     } catch (saveError) {
       log.error('Failed to save assistant message', { error: saveError, conversationId });
     }

--- a/app/api/nexus/chat/route.ts
+++ b/app/api/nexus/chat/route.ts
@@ -37,6 +37,7 @@ import {
   convertMessagesToPartsFormat,
   saveAssistantMessage,
   saveConversationSteps,
+  type StepData,
 } from './chat-helpers';
 
 import { eq, and } from 'drizzle-orm';
@@ -91,11 +92,7 @@ function createOnFinishCallback(params: {
       args: Record<string, unknown>;
       result?: unknown;
     }>;
-    steps?: Array<{
-      text: string;
-      toolCalls: Array<{ toolCallId: string; toolName: string; args: Record<string, unknown>; result?: unknown }>;
-      finishReason: string;
-    }>;
+    steps?: StepData[];
   }) => {
     log.info('Stream finished, saving assistant message', {
       conversationId,

--- a/docs/features/nexus-conversation-architecture.md
+++ b/docs/features/nexus-conversation-architecture.md
@@ -495,6 +495,22 @@ useEffect(() => {
 // The component doesn't remount, so useEffect only runs once
 ```
 
+### ❌ Pitfall 7: Consolidating multi-step MCP responses into a single DB row
+
+When MCP connector tools are enabled, `streamText` runs with `maxSteps > 1`, producing multiple assistant→tool→assistant turns in one streaming call. Writing all steps into a single `nexus_messages` row causes `convertToModelMessages()` to produce consecutive user turns on reload, which Anthropic's API rejects.
+
+```typescript
+// WRONG — one row for all steps; replay triggers AI_MissingToolResultsError / consecutive-user-turn rejection
+await saveAssistantMessage(conversationId, consolidatedContent)
+
+// CORRECT — saveConversationSteps() writes each step as a separate row inside executeTransaction
+await saveConversationSteps(conversationId, event.steps)
+// If existing rows are already consolidated, normalizeMultiStepMessages() pre-processes them
+// before passing to convertToModelMessages() without requiring a DB migration.
+```
+
+Additionally, every tool-call part must carry `state: 'output-available'` and `input: Record<string,unknown>`. Without both fields the SDK emits `tool_use` with no paired `tool_result`, causing Anthropic to reject the next user turn. See `app/api/nexus/chat/chat-helpers.ts` and `docs/guides/silent-failure-patterns.md` for the full patterns.
+
 ### ❌ Pitfall 6: Session object reference in useEffect deps
 
 ```typescript
@@ -682,6 +698,13 @@ After making changes to conversation handling, test ALL of these scenarios:
 ---
 
 ## Version History
+
+### May 2026 - Multi-Step MCP Tool-Use Persistence (Issue #977)
+- **Problem:** `AI_MissingToolResultsError` ("Expected toolResult blocks") on follow-up messages in conversations that previously used MCP connector tools
+- **Root Causes:** (1) Tool-call parts missing `state`/`input` fields required by `convertToModelMessages`; (2) multi-step responses consolidated into a single DB row, producing invalid Anthropic turn structure on reload; (3) `convertContentToParts` silently downgraded stored `state` fields
+- **Solution:** `buildAssistantParts` now sets `state` and `input` on every tool-call part; `saveConversationSteps()` persists each step as a separate row inside `executeTransaction`; `normalizeMultiStepMessages()` repairs existing consolidated rows without migration; `convertContentToParts` validates the stored `state` enum
+- **Files Changed:** `app/api/nexus/chat/chat-helpers.ts`, `app/api/nexus/chat/route.ts`, `lib/streaming/types.ts`, `lib/streaming/provider-adapters/base-adapter.ts`, `lib/streaming/unified-streaming-service.ts`, `lib/nexus/history-adapter.ts`, `app/(protected)/nexus/_components/conversation-initializer.tsx`
+- **Breaking:** None (backward-compatible; normalizer handles existing rows)
 
 ### January 2025 - Stable Conversation ID Pattern
 - **Problem:** Component remounting on conversation ID assignment, losing streaming state

--- a/docs/features/nexus-conversation-architecture.md
+++ b/docs/features/nexus-conversation-architecture.md
@@ -495,7 +495,7 @@ useEffect(() => {
 // The component doesn't remount, so useEffect only runs once
 ```
 
-### ❌ Pitfall 7: Consolidating multi-step MCP responses into a single DB row
+### ❌ Pitfall 6: Consolidating multi-step MCP responses into a single DB row
 
 When MCP connector tools are enabled, `streamText` runs with `maxSteps > 1`, producing multiple assistant→tool→assistant turns in one streaming call. Writing all steps into a single `nexus_messages` row causes `convertToModelMessages()` to produce consecutive user turns on reload, which Anthropic's API rejects.
 
@@ -511,7 +511,7 @@ await saveConversationSteps(conversationId, event.steps)
 
 Additionally, every tool-call part must carry `state: 'output-available'` and `input: Record<string,unknown>`. Without both fields the SDK emits `tool_use` with no paired `tool_result`, causing Anthropic to reject the next user turn. See `app/api/nexus/chat/chat-helpers.ts` and `docs/guides/silent-failure-patterns.md` for the full patterns.
 
-### ❌ Pitfall 6: Session object reference in useEffect deps
+### ❌ Pitfall 7: Session object reference in useEffect deps
 
 ```typescript
 // WRONG - new session object on every refetch triggers re-mount

--- a/docs/guides/silent-failure-patterns.md
+++ b/docs/guides/silent-failure-patterns.md
@@ -85,6 +85,60 @@ onFinish: async (event) => {
 }
 ```
 
+### `convertToModelMessages` requires `state` + `input` on every tool-call part
+
+AI SDK v6's `convertToModelMessages()` REQUIRES both `state: 'output-available'` AND `input: Record<string, unknown>` on every tool-call `UIMessage` part. If either field is missing, the SDK emits a `tool_use` block with no matching `tool_result` block, which Anthropic's API rejects on the next user turn with `AI_MissingToolResultsError: "Expected toolResult blocks"`.
+
+```typescript
+// WRONG — missing state and input; SDK silently omits the tool_result block
+{
+  type: 'tool-call',
+  toolCallId: 'tc_123',
+  toolName: 'my_tool',
+  args: { query: 'hello' },
+  // no state, no input → Anthropic rejects follow-up with AI_MissingToolResultsError
+}
+
+// CORRECT — both fields required for SDK to emit paired tool_use + tool_result
+{
+  type: 'tool-call',
+  toolCallId: 'tc_123',
+  toolName: 'my_tool',
+  args: { query: 'hello' },
+  state: 'output-available',   // required: one of 'input-available' | 'output-available' | 'output-error' | 'partial-call'
+  input: { query: 'hello' },   // required: mirrors args, used by SDK to reconstruct tool_result
+}
+```
+
+**Review rule:** Any code path that builds or persists assistant tool-call parts (especially `buildAssistantParts`, history adapters, and `convertContentToParts`) MUST set `state` and `input`. Also validate `state` against the allowed enum when reading it from storage — a stored `state: undefined` must not silently downgrade to `input-available`. See `app/api/nexus/chat/chat-helpers.ts` and `lib/nexus/history-adapter.ts`.
+
+### Multi-step MCP tool runs must persist per-step DB rows
+
+When `maxSteps > 1` (enabled for MCP connector runs), AI SDK v6's `streamText` may complete multiple assistant→tool→assistant turns in one streaming call. Consolidating these into a **single DB row** produces a message containing both tool-call parts AND text. On conversation reload, `convertToModelMessages()` cannot reconstruct the correct multi-turn Anthropic structure from a single row, producing consecutive user turns that the Anthropic API rejects.
+
+```typescript
+// WRONG — one consolidated row covers all steps; replay produces consecutive user turns
+await executeQuery(
+  (db) => db.insert(messages).values({
+    content: JSON.stringify(allStepsConsolidated), // tool-calls + text in one row
+  }),
+  'saveConversation'
+)
+
+// CORRECT — each step (assistant turn, tool result turn) gets its own row,
+// all written atomically inside a single executeTransaction
+await executeTransaction(async (tx) => {
+  for (const step of event.steps) {
+    await tx.insert(messages).values({ content: JSON.stringify(step.parts), role: 'assistant' })
+    if (step.toolResults.length > 0) {
+      await tx.insert(messages).values({ content: JSON.stringify(step.toolResults), role: 'tool' })
+    }
+  }
+}, 'saveConversationSteps')
+```
+
+**Review rule:** Any streaming handler that uses `maxSteps > 1` MUST call `saveConversationSteps()` (or equivalent) rather than a single-row persist. If existing conversations contain consolidated multi-step rows, a `normalizeMultiStepMessages()` pre-processing step is required before passing history to `convertToModelMessages()`. See `app/api/nexus/chat/chat-helpers.ts` (`saveConversationSteps`) and `lib/streaming/unified-streaming-service.ts` (`normalizeMultiStepMessages`).
+
 ### `execute()` return shape vs sanitization
 
 If `execute()` returns `{ id, success }`, any arg sanitization inside it is **dead code**. The frontend reads args from the streaming tool invocation object, not from `execute()` return.
@@ -288,4 +342,4 @@ text.replace(/&amp;/g, '&').replace(/&#(\d+);/g, (_, n) => String.fromCharCode(+
 
 ---
 
-*Source: learnings from database, ai-sdk, streaming, security, frontend, api-patterns, infrastructure, and monitoring categories (2026-02-18 through 2026-04-08)*
+*Source: learnings from database, ai-sdk, streaming, security, frontend, api-patterns, infrastructure, and monitoring categories (2026-02-18 through 2026-05-15)*

--- a/lib/nexus/history-adapter.ts
+++ b/lib/nexus/history-adapter.ts
@@ -84,6 +84,9 @@ type ContentPartLike =
       argsText: string;
       result?: unknown;
       isError?: boolean;
+      // AI SDK v6 UIMessage fields required by convertToModelMessages (Issue #977)
+      state: 'input-available' | 'output-available' | 'output-error';
+      input: JSONObject;
     }
 
 // We'll use a simple implementation since ExportedMessageRepository.fromArray may not be accessible
@@ -117,6 +120,15 @@ const createExportedMessageRepository = (messages: MessageData[]): ExportedMessa
               // switch and throws "Unsupported assistant message part type". (Issue #798)
               const args: JSONObject = (partData.args ?? {}) as JSONObject
 
+              // Derive state from result so convertToModelMessages emits paired
+              // tool_result blocks on conversation replay. Without state+input,
+              // convertToModelMessages emits tool_use without tool_result, causing
+              // AI_MissingToolResultsError on follow-up messages. (Issue #977)
+              const hasResult = partData.result != null
+              const isError = partData.isError === true
+              const state: 'input-available' | 'output-available' | 'output-error' =
+                isError ? 'output-error' : hasResult ? 'output-available' : 'input-available'
+
               const toolPart: ContentPartLike = {
                 type: 'tool-call',
                 toolCallId: partData.toolCallId,
@@ -124,7 +136,9 @@ const createExportedMessageRepository = (messages: MessageData[]): ExportedMessa
                 args,
                 argsText: JSON.stringify(args),
                 result: partData.result,
-                isError: partData.isError === true,
+                isError,
+                state,
+                input: args,
               }
               return toolPart
             }

--- a/lib/nexus/history-adapter.ts
+++ b/lib/nexus/history-adapter.ts
@@ -126,8 +126,14 @@ const createExportedMessageRepository = (messages: MessageData[]): ExportedMessa
               // AI_MissingToolResultsError on follow-up messages. (Issue #977)
               const hasResult = partData.result != null
               const isError = partData.isError === true
+              // Prefer the stored state field — a part persisted with state 'output-error'
+              // but isError=false and a non-null result would be wrongly classified as
+              // 'output-available' if we only checked isError and hasResult.
+              const rawState = (partData as unknown as Record<string, unknown>).state
               const state: 'input-available' | 'output-available' | 'output-error' =
-                isError ? 'output-error' : hasResult ? 'output-available' : 'input-available'
+                rawState === 'input-available' || rawState === 'output-available' || rawState === 'output-error'
+                  ? rawState
+                  : isError ? 'output-error' : hasResult ? 'output-available' : 'input-available'
 
               const toolPart: ContentPartLike = {
                 type: 'tool-call',

--- a/lib/streaming/provider-adapters/base-adapter.ts
+++ b/lib/streaming/provider-adapters/base-adapter.ts
@@ -239,6 +239,53 @@ export abstract class BaseProviderAdapter implements ProviderAdapter {
 
           // Transform to our expected format
           const usage = event.usage as StreamUsage;
+
+          // Build per-step breakdown for multi-step tool-use persistence.
+          // Each step's toolResults are matched to its toolCalls so the caller
+          // can persist them as separate messages and preserve the correct
+          // multi-turn structure on conversation replay. (Issue #977)
+          const rawSteps = (event as Record<string, unknown>).steps;
+          const steps = Array.isArray(rawSteps)
+            ? rawSteps.map((rawStep: unknown) => {
+                if (typeof rawStep !== 'object' || rawStep === null) {
+                  return { text: '', toolCalls: [], finishReason: 'stop' };
+                }
+                const s = rawStep as Record<string, unknown>;
+
+                const stepToolCalls: AccumulatedToolCall[] = [];
+                const rawCalls = s.toolCalls;
+                if (Array.isArray(rawCalls)) {
+                  for (const tc of rawCalls) {
+                    if (typeof tc !== 'object' || tc === null) continue;
+                    const tcTyped = tc as { toolCallId?: string; toolName?: string; args?: unknown; input?: unknown };
+                    if (typeof tcTyped.toolCallId !== 'string' || typeof tcTyped.toolName !== 'string') continue;
+                    stepToolCalls.push({
+                      toolCallId: tcTyped.toolCallId,
+                      toolName: tcTyped.toolName,
+                      args: ((tcTyped.input ?? tcTyped.args) as Record<string, unknown>) || {},
+                    });
+                  }
+                }
+
+                const rawResults = s.toolResults;
+                if (Array.isArray(rawResults)) {
+                  for (const tr of rawResults) {
+                    if (typeof tr !== 'object' || tr === null) continue;
+                    const trTyped = tr as { toolCallId?: string; output?: unknown };
+                    if (typeof trTyped.toolCallId !== 'string') continue;
+                    const match = stepToolCalls.find(tc => tc.toolCallId === trTyped.toolCallId);
+                    if (match) match.result = trTyped.output;
+                  }
+                }
+
+                return {
+                  text: typeof s.text === 'string' ? s.text : '',
+                  toolCalls: stepToolCalls,
+                  finishReason: typeof s.finishReason === 'string' ? s.finishReason : 'stop',
+                };
+              })
+            : undefined;
+
           const transformedData = {
             text: event.text || '',
             usage: usage ? {
@@ -247,7 +294,8 @@ export abstract class BaseProviderAdapter implements ProviderAdapter {
               totalTokens: usage.totalTokens || 0
             } : undefined,
             finishReason: event.finishReason || 'stop',
-            toolCalls: accumulatedToolCalls.length > 0 ? accumulatedToolCalls : undefined
+            toolCalls: accumulatedToolCalls.length > 0 ? accumulatedToolCalls : undefined,
+            steps: steps && steps.length > 1 ? steps : undefined,
           };
 
           // Call provider-specific finish handler

--- a/lib/streaming/provider-adapters/base-adapter.ts
+++ b/lib/streaming/provider-adapters/base-adapter.ts
@@ -244,6 +244,9 @@ export abstract class BaseProviderAdapter implements ProviderAdapter {
           // Each step's toolResults are matched to its toolCalls so the caller
           // can persist them as separate messages and preserve the correct
           // multi-turn structure on conversation replay. (Issue #977)
+          // AI SDK v6 TypeScript types don't declare `steps` on the onFinish event
+          // object, but the runtime value includes it for multi-step tool-use flows.
+          // Cast to access the field until the SDK's types are updated.
           const rawSteps = (event as Record<string, unknown>).steps;
           const steps = Array.isArray(rawSteps)
             ? rawSteps.map((rawStep: unknown) => {

--- a/lib/streaming/types.ts
+++ b/lib/streaming/types.ts
@@ -200,6 +200,13 @@ export interface ToolCallData {
   result?: unknown;  // Tool execution result for persistence
 }
 
+/** A single resolved streaming step for per-step persistence */
+export interface StepCallbackData {
+  text: string;
+  toolCalls: ToolCallData[];
+  finishReason: string;
+}
+
 export interface StreamingCallbacks {
   onProgress?: (event: StreamingProgress) => void;
   onReasoning?: (reasoning: string) => void;
@@ -216,6 +223,8 @@ export interface StreamingCallbacks {
     finishReason: string;
     /** Tool calls made during this response (from all steps) */
     toolCalls?: ToolCallData[];
+    /** Per-step breakdown — populated when maxSteps > 1 (MCP connector multi-step) */
+    steps?: StepCallbackData[];
   }) => void;
   onError?: (error: Error) => void;
 

--- a/lib/streaming/unified-streaming-service.ts
+++ b/lib/streaming/unified-streaming-service.ts
@@ -5,7 +5,7 @@ import { getProviderAdapter, type ProviderCapabilities } from './provider-adapte
 import { CircuitBreaker, CircuitBreakerOpenError } from './circuit-breaker';
 import { getContentSafetyService, type ContentSafetyResult } from '@/lib/safety';
 import type { TokenMapping } from '@/lib/safety/types';
-import type { StreamRequest, StreamResponse, StreamConfig, StreamingProgress, TelemetrySpan, TelemetryConfig } from './types';
+import type { StreamRequest, StreamResponse, StreamConfig, StreamingProgress, TelemetrySpan, TelemetryConfig, StepCallbackData } from './types';
 import { ContentSafetyBlockedError } from './types';
 
 // Logger for PII transform debugging
@@ -245,7 +245,7 @@ interface InputSafetyCheckOptions {
  * Options for output content safety check
  */
 interface OutputSafetyCheckOptions {
-  data: { text: string; usage?: { promptTokens: number; completionTokens: number; totalTokens: number; reasoningTokens?: number; totalCost?: number }; finishReason: string };
+  data: { text: string; usage?: { promptTokens: number; completionTokens: number; totalTokens: number; reasoningTokens?: number; totalCost?: number }; finishReason: string; steps?: StepCallbackData[] };
   request: StreamRequest;
   contentSafetyService: ReturnType<typeof getContentSafetyService>;
   log: ReturnType<typeof createLogger>;

--- a/lib/streaming/unified-streaming-service.ts
+++ b/lib/streaming/unified-streaming-service.ts
@@ -551,14 +551,15 @@ export function normalizeMultiStepMessages(messages: StreamRequest['messages']):
 
     const parts = msg.parts as AnyPart[];
     // At this point in the pipeline, messages have passed through convertContentToParts so
-    // tool parts use the static format type: 'tool-{toolName}' (e.g. 'tool-query_db').
-    // Exclude the literal string 'tool-call' (native AI SDK format) defensively —
-    // 'tool-call'.startsWith('tool-') is true, but native parts are unresolved and
-    // should never be split out as a separate turn.
+    // tool parts use the static format type: 'tool-{toolName}' and always carry a `state`
+    // field (e.g. 'tool-query_db' with state: 'output-available'). Native AI SDK parts
+    // use type: 'tool-call' and never have a `state` field. Using `'state' in p` as the
+    // discriminator is safer than `p.type !== 'tool-call'` because it handles tools named
+    // "call" correctly (their static format is also `type: 'tool-call'` but WITH state).
     const toolParts = parts.filter(p =>
       typeof p.type === 'string' &&
-      p.type !== 'tool-call' &&
-      (p.type as string).startsWith('tool-')
+      (p.type as string).startsWith('tool-') &&
+      'state' in p
     );
     const textParts = parts.filter(p => p.type === 'text');
 

--- a/lib/streaming/unified-streaming-service.ts
+++ b/lib/streaming/unified-streaming-service.ts
@@ -539,7 +539,7 @@ function validateAndCopyMessages(
  * This is safe for single-step responses too — splitting doesn't change the
  * semantic meaning, it only separates concerns across turns.
  */
-function normalizeMultiStepMessages(messages: StreamRequest['messages']): StreamRequest['messages'] {
+export function normalizeMultiStepMessages(messages: StreamRequest['messages']): StreamRequest['messages'] {
   type AnyPart = Record<string, unknown>;
   const normalized: StreamRequest['messages'] = [];
 

--- a/lib/streaming/unified-streaming-service.ts
+++ b/lib/streaming/unified-streaming-service.ts
@@ -550,6 +550,10 @@ export function normalizeMultiStepMessages(messages: StreamRequest['messages']):
     }
 
     const parts = msg.parts as AnyPart[];
+    // At this point in the pipeline, messages have passed through convertContentToParts so
+    // tool parts use the static format type: 'tool-{toolName}' (e.g. 'tool-query_db').
+    // 'tool-call'.startsWith('tool-') is also true, but native tool-call parts only appear
+    // before convertContentToParts runs, so this filter is safe for the normalized messages.
     const toolParts = parts.filter(p => typeof p.type === 'string' && (p.type as string).startsWith('tool-'));
     const textParts = parts.filter(p => p.type === 'text');
 

--- a/lib/streaming/unified-streaming-service.ts
+++ b/lib/streaming/unified-streaming-service.ts
@@ -520,27 +520,80 @@ function validateAndCopyMessages(
 }
 
 /**
+ * Normalize assistant UIMessages so convertToModelMessages can produce the
+ * correct multi-turn structure required by Anthropic (and other providers).
+ *
+ * When MCP connectors are used with maxSteps > 1, all tool calls from every
+ * step may be consolidated into a single assistant UIMessage (both during live
+ * sessions and after conversation reload from the DB). If that message also
+ * contains a text part, convertToModelMessages emits the tool_use and text
+ * blocks in one assistant turn and then emits the tool_result blocks as a
+ * synthetic user turn — followed by the real user follow-up, creating two
+ * consecutive user turns which Anthropic rejects.
+ *
+ * Fix: split any assistant message that has BOTH resolved tool parts AND a
+ * text part into two separate UIMessages (tool-only first, text-only second).
+ * convertToModelMessages then produces the valid pattern:
+ *   assistant[tool_use…] → user[tool_result…] → assistant[text] → user[follow-up]
+ *
+ * This is safe for single-step responses too — splitting doesn't change the
+ * semantic meaning, it only separates concerns across turns.
+ */
+function normalizeMultiStepMessages(messages: StreamRequest['messages']): StreamRequest['messages'] {
+  type AnyPart = Record<string, unknown>;
+  const normalized: StreamRequest['messages'] = [];
+
+  for (const msg of messages) {
+    if (msg.role !== 'assistant' || !Array.isArray(msg.parts) || msg.parts.length === 0) {
+      normalized.push(msg);
+      continue;
+    }
+
+    const parts = msg.parts as AnyPart[];
+    const toolParts = parts.filter(p => typeof p.type === 'string' && (p.type as string).startsWith('tool-'));
+    const textParts = parts.filter(p => p.type === 'text');
+
+    const hasResolvedTools = toolParts.some(p => p.state === 'output-available' || p.state === 'output-error');
+    const hasText = textParts.some(p => typeof p.text === 'string' && (p.text as string).length > 0);
+
+    if (hasResolvedTools && hasText) {
+      // Split: emit tool-only message first, then text-only message.
+      // Casting required because AnyPart[] is a narrower type than UIMessagePart[]
+      // but the structure is semantically valid for convertToModelMessages.
+      normalized.push({ ...msg, parts: toolParts as StreamRequest['messages'][0]['parts'] });
+      normalized.push({ ...msg, id: `${msg.id}-text`, parts: textParts as StreamRequest['messages'][0]['parts'] });
+    } else {
+      normalized.push(msg);
+    }
+  }
+
+  return normalized;
+}
+
+/**
  * Convert messages to model format with error handling
  */
 async function convertMessages(
   messages: StreamRequest['messages'],
   log: ReturnType<typeof createLogger>
 ) {
+  const normalizedMessages = normalizeMultiStepMessages(messages);
+
   log.info('Messages structure before conversion', {
-    messageCount: messages.length,
-    firstMessageRole: messages[0]?.role,
-    messageRoles: messages.map(m => m.role),
+    messageCount: normalizedMessages.length,
+    firstMessageRole: normalizedMessages[0]?.role,
+    messageRoles: normalizedMessages.map(m => m.role),
   });
 
   try {
-    return await convertToModelMessages(messages);
+    return await convertToModelMessages(normalizedMessages);
   } catch (conversionError) {
     const error = conversionError as Error;
     log.error('Failed to convert messages', {
       error: error.message,
       stack: error.stack,
-      messageCount: messages.length,
-      messageRoles: messages.map(m => m.role),
+      messageCount: normalizedMessages.length,
+      messageRoles: normalizedMessages.map(m => m.role),
     });
     throw new Error(`Message conversion failed: ${error.message}`);
   }

--- a/lib/streaming/unified-streaming-service.ts
+++ b/lib/streaming/unified-streaming-service.ts
@@ -552,9 +552,14 @@ export function normalizeMultiStepMessages(messages: StreamRequest['messages']):
     const parts = msg.parts as AnyPart[];
     // At this point in the pipeline, messages have passed through convertContentToParts so
     // tool parts use the static format type: 'tool-{toolName}' (e.g. 'tool-query_db').
-    // 'tool-call'.startsWith('tool-') is also true, but native tool-call parts only appear
-    // before convertContentToParts runs, so this filter is safe for the normalized messages.
-    const toolParts = parts.filter(p => typeof p.type === 'string' && (p.type as string).startsWith('tool-'));
+    // Exclude the literal string 'tool-call' (native AI SDK format) defensively —
+    // 'tool-call'.startsWith('tool-') is true, but native parts are unresolved and
+    // should never be split out as a separate turn.
+    const toolParts = parts.filter(p =>
+      typeof p.type === 'string' &&
+      p.type !== 'tool-call' &&
+      (p.type as string).startsWith('tool-')
+    );
     const textParts = parts.filter(p => p.type === 'text');
 
     const hasResolvedTools = toolParts.some(p => p.state === 'output-available' || p.state === 'output-error');

--- a/tests/unit/nexus/multi-step-tool-fix.test.ts
+++ b/tests/unit/nexus/multi-step-tool-fix.test.ts
@@ -1,0 +1,239 @@
+/**
+ * @jest-environment node
+ *
+ * Tests for the multi-step MCP tool-use fix (Issue #977).
+ *
+ * Covers three defects:
+ *  - Defect 1: tool-call parts stored without state/input fields
+ *  - Defect 2b: consolidated multi-step messages not normalized before convertToModelMessages
+ *  - Defect 3: missing/malformed state in convertContentToParts
+ */
+
+import { describe, it, expect } from '@jest/globals';
+import { convertContentToParts } from '@/app/(protected)/nexus/_components/conversation-initializer';
+import { normalizeMultiStepMessages } from '@/lib/streaming/unified-streaming-service';
+import type { UIMessage } from '@ai-sdk/react';
+
+// ---------------------------------------------------------------------------
+// convertContentToParts — Defect 1 & 3 fixes
+// ---------------------------------------------------------------------------
+
+describe('convertContentToParts', () => {
+  it('sets state=output-available for tool-call parts with result', () => {
+    const parts = convertContentToParts([
+      {
+        type: 'tool-call',
+        toolCallId: 'tc1',
+        toolName: 'query_db',
+        args: { query: 'SELECT 1' },
+        result: { rows: [{ id: 1 }] },
+        isError: false,
+      },
+    ]);
+
+    expect(parts).toHaveLength(1);
+    const toolPart = parts[0] as Record<string, unknown>;
+    expect(toolPart.type).toBe('tool-query_db');
+    expect(toolPart.state).toBe('output-available');
+    expect(toolPart.toolCallId).toBe('tc1');
+    expect(toolPart.output).toEqual({ rows: [{ id: 1 }] });
+  });
+
+  it('sets state=input-available for tool-call parts with null result', () => {
+    const parts = convertContentToParts([
+      {
+        type: 'tool-call',
+        toolCallId: 'tc2',
+        toolName: 'run_query',
+        args: {},
+        result: null,
+        isError: false,
+      },
+    ]);
+
+    expect(parts).toHaveLength(1);
+    const toolPart = parts[0] as Record<string, unknown>;
+    expect(toolPart.state).toBe('input-available');
+    expect(toolPart.output).toBeUndefined();
+  });
+
+  it('sets state=output-error when isError=true', () => {
+    const parts = convertContentToParts([
+      {
+        type: 'tool-call',
+        toolCallId: 'tc3',
+        toolName: 'fetch_data',
+        args: {},
+        result: 'Connection refused',
+        isError: true,
+      },
+    ]);
+
+    expect(parts).toHaveLength(1);
+    const toolPart = parts[0] as Record<string, unknown>;
+    expect(toolPart.state).toBe('output-error');
+  });
+
+  it('prefers stored state=output-error even when isError flag is missing (Defect 3 guard)', () => {
+    // Simulate a part that has the stored state field from the DB fix but no isError flag
+    const parts = convertContentToParts([
+      {
+        type: 'tool-call',
+        toolCallId: 'tc4',
+        toolName: 'fetch_data',
+        args: {},
+        result: 'some error',
+        isError: false,
+        // stored state from Issue #977 DB fix:
+        state: 'output-error',
+      } as Parameters<typeof convertContentToParts>[0] extends (infer T)[] ? T : never,
+    ]);
+
+    expect(parts).toHaveLength(1);
+    const toolPart = parts[0] as Record<string, unknown>;
+    expect(toolPart.state).toBe('output-error');
+  });
+
+  it('passes through text parts unchanged', () => {
+    const parts = convertContentToParts([{ type: 'text', text: 'hello world' }]);
+    expect(parts).toHaveLength(1);
+    expect(parts[0]).toEqual({ type: 'text', text: 'hello world' });
+  });
+
+  it('handles mixed text and tool-call parts', () => {
+    const parts = convertContentToParts([
+      { type: 'text', text: 'I will query the data.' },
+      {
+        type: 'tool-call',
+        toolCallId: 'tc5',
+        toolName: 'query_db',
+        args: {},
+        result: { count: 42 },
+        isError: false,
+      },
+    ]);
+
+    expect(parts).toHaveLength(2);
+    expect(parts[0]).toEqual({ type: 'text', text: 'I will query the data.' });
+    const toolPart = parts[1] as Record<string, unknown>;
+    expect(toolPart.state).toBe('output-available');
+  });
+
+  it('handles empty content array', () => {
+    const parts = convertContentToParts([]);
+    expect(parts).toEqual([]);
+  });
+
+  it('returns single text part for string content', () => {
+    const parts = convertContentToParts('hello');
+    expect(parts).toEqual([{ type: 'text', text: 'hello' }]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// normalizeMultiStepMessages — Defect 2b fix
+// ---------------------------------------------------------------------------
+
+describe('normalizeMultiStepMessages', () => {
+  function makeMsg(
+    id: string,
+    role: 'user' | 'assistant',
+    parts: Array<Record<string, unknown>>
+  ): UIMessage {
+    return { id, role, parts } as unknown as UIMessage;
+  }
+
+  it('splits assistant message with resolved tool parts AND text into two messages', () => {
+    const messages = [
+      makeMsg('u1', 'user', [{ type: 'text', text: 'query' }]),
+      makeMsg('a1', 'assistant', [
+        { type: 'tool-query_db', toolCallId: 'tc1', state: 'output-available', input: {}, output: { rows: [] } },
+        { type: 'tool-process', toolCallId: 'tc2', state: 'output-available', input: {}, output: 'done' },
+        { type: 'text', text: 'Here is the result.' },
+      ]),
+      makeMsg('u2', 'user', [{ type: 'text', text: 'follow-up' }]),
+    ];
+
+    const result = normalizeMultiStepMessages(messages as UIMessage[]);
+
+    // Original 3 messages → 4 after split
+    expect(result).toHaveLength(4);
+    expect(result[0].role).toBe('user');
+
+    // First assistant message: only tool parts
+    const toolMsg = result[1] as unknown as { role: string; parts: Array<Record<string, unknown>> };
+    expect(toolMsg.role).toBe('assistant');
+    expect(toolMsg.parts.every(p => (p.type as string).startsWith('tool-'))).toBe(true);
+    expect(toolMsg.parts).toHaveLength(2);
+
+    // Second assistant message: only text
+    const textMsg = result[2] as unknown as { role: string; parts: Array<Record<string, unknown>> };
+    expect(textMsg.role).toBe('assistant');
+    expect(textMsg.parts).toHaveLength(1);
+    expect(textMsg.parts[0].type).toBe('text');
+
+    // Follow-up user message unchanged
+    expect(result[3].role).toBe('user');
+  });
+
+  it('does NOT split assistant message that has only tool parts (no text)', () => {
+    const messages = [
+      makeMsg('a1', 'assistant', [
+        { type: 'tool-query_db', toolCallId: 'tc1', state: 'output-available', input: {}, output: {} },
+      ]),
+    ];
+
+    const result = normalizeMultiStepMessages(messages as UIMessage[]);
+    expect(result).toHaveLength(1);
+  });
+
+  it('does NOT split assistant message that has only text parts', () => {
+    const messages = [
+      makeMsg('a1', 'assistant', [{ type: 'text', text: 'hello' }]),
+    ];
+
+    const result = normalizeMultiStepMessages(messages as UIMessage[]);
+    expect(result).toHaveLength(1);
+  });
+
+  it('does NOT split when tool parts are in input-available state (unresolved)', () => {
+    const messages = [
+      makeMsg('a1', 'assistant', [
+        { type: 'tool-query_db', toolCallId: 'tc1', state: 'input-available', input: {} },
+        { type: 'text', text: 'calling tool...' },
+      ]),
+    ];
+
+    const result = normalizeMultiStepMessages(messages as UIMessage[]);
+    // No split because no resolved tools
+    expect(result).toHaveLength(1);
+  });
+
+  it('preserves user and system messages unchanged', () => {
+    const messages = [
+      makeMsg('u1', 'user', [{ type: 'text', text: 'hello' }]),
+    ];
+
+    const result = normalizeMultiStepMessages(messages as UIMessage[]);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toBe(messages[0]);
+  });
+
+  it('handles an empty message array', () => {
+    expect(normalizeMultiStepMessages([])).toEqual([]);
+  });
+
+  it('gives split text message a distinct ID to avoid key conflicts', () => {
+    const messages = [
+      makeMsg('msg-abc', 'assistant', [
+        { type: 'tool-query_db', toolCallId: 'tc1', state: 'output-available', input: {}, output: {} },
+        { type: 'text', text: 'Done.' },
+      ]),
+    ];
+
+    const result = normalizeMultiStepMessages(messages as UIMessage[]);
+    expect(result).toHaveLength(2);
+    expect(result[0].id).toBe('msg-abc');
+    expect(result[1].id).toBe('msg-abc-text');
+  });
+});

--- a/tests/unit/nexus/multi-step-tool-fix.test.ts
+++ b/tests/unit/nexus/multi-step-tool-fix.test.ts
@@ -263,6 +263,23 @@ describe('normalizeMultiStepMessages', () => {
     expect(normalizeMultiStepMessages([])).toEqual([]);
   });
 
+  it('does NOT split when parts use native tool-call format (no state field)', () => {
+    // Native AI SDK tool-call parts (type: 'tool-call', no `state` field) must not be
+    // mistaken for static-format resolved tool parts. A tool literally named "call"
+    // also produces type: 'tool-call' in static format BUT carries a `state` field —
+    // the discriminator is `'state' in p`, not `p.type !== 'tool-call'`.
+    const messages = [
+      makeMsg('a1', 'assistant', [
+        { type: 'tool-call', toolCallId: 'tc1', toolName: 'query_db', args: {} }, // native, no state
+        { type: 'text', text: 'calling tool...' },
+      ]),
+    ];
+
+    const result = normalizeMultiStepMessages(messages as UIMessage[]);
+    // No split because native 'tool-call' parts have no `state` field
+    expect(result).toHaveLength(1);
+  });
+
   it('gives split text message a distinct ID to avoid key conflicts', () => {
     const messages = [
       makeMsg('msg-abc', 'assistant', [

--- a/tests/unit/nexus/multi-step-tool-fix.test.ts
+++ b/tests/unit/nexus/multi-step-tool-fix.test.ts
@@ -9,6 +9,39 @@
  *  - Defect 3: missing/malformed state in convertContentToParts
  */
 
+// Mock heavy dependencies so the module can load in Jest's CJS environment.
+// unified-streaming-service.ts transitively loads provider-adapters/index.ts which
+// instantiates @ai-sdk/* adapter classes at module level — those packages can fail
+// to load without mocking. The existing unified-streaming-service.test.ts uses the
+// same strategy via jest.doMock + require(). Jest auto-hoists jest.mock() calls
+// above static import statements, so the mocks are registered before any module loads.
+jest.mock('@/lib/logger', () => ({
+  createLogger: () => ({
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  }),
+  generateRequestId: jest.fn(() => 'test-request-id'),
+  startTimer: jest.fn(() => jest.fn()),
+}));
+
+jest.mock('@/lib/streaming/provider-adapters', () => ({
+  getProviderAdapter: jest.fn(),
+}));
+
+jest.mock('@/lib/streaming/telemetry-service', () => ({
+  getTelemetryConfig: jest.fn(),
+}));
+
+jest.mock('@/lib/safety', () => ({
+  getContentSafetyService: jest.fn(() => ({
+    isEnabled: jest.fn(() => false),
+    processInput: jest.fn(),
+    processOutput: jest.fn(),
+  })),
+}));
+
 import { describe, it, expect } from '@jest/globals';
 import { convertContentToParts } from '@/app/(protected)/nexus/_components/conversation-initializer';
 import { normalizeMultiStepMessages } from '@/lib/streaming/unified-streaming-service';
@@ -75,7 +108,8 @@ describe('convertContentToParts', () => {
   });
 
   it('prefers stored state=output-error even when isError flag is missing (Defect 3 guard)', () => {
-    // Simulate a part that has the stored state field from the DB fix but no isError flag
+    // Simulate a part that has the stored state field from the DB fix but no isError flag.
+    // Cast via unknown to suppress excess-property error (state not in MessagePart schema).
     const parts = convertContentToParts([
       {
         type: 'tool-call',
@@ -84,9 +118,8 @@ describe('convertContentToParts', () => {
         args: {},
         result: 'some error',
         isError: false,
-        // stored state from Issue #977 DB fix:
         state: 'output-error',
-      } as Parameters<typeof convertContentToParts>[0] extends (infer T)[] ? T : never,
+      } as unknown as { type: 'tool-call'; toolCallId: string; toolName: string; args: Record<string, unknown>; result: unknown; isError: boolean },
     ]);
 
     expect(parts).toHaveLength(1);

--- a/tests/unit/nexus/multi-step-tool-fix.test.ts
+++ b/tests/unit/nexus/multi-step-tool-fix.test.ts
@@ -9,6 +9,13 @@
  *  - Defect 3: missing/malformed state in convertContentToParts
  */
 
+// jest must be imported before jest.mock() calls to satisfy TypeScript type-checking.
+// @jest/globals is used project-wide (not @types/jest globals) so jest is not
+// available as a global type without this import. Jest's babel transform hoists
+// jest.mock() calls above all imports at runtime, so the import order here only
+// matters for TypeScript, not for execution.
+import { jest } from '@jest/globals';
+
 // Mock heavy dependencies so the module can load in Jest's CJS environment.
 // unified-streaming-service.ts transitively loads provider-adapters/index.ts which
 // instantiates @ai-sdk/* adapter classes at module level — those packages can fail


### PR DESCRIPTION
## Summary

Fixes three interrelated defects causing `AI_MissingToolResultsError` / `Expected toolResult blocks` when users continue a Nexus conversation that used MCP connector tools (multi-step agentic loop).

- **Defect 1** — `buildAssistantParts()` stored tool-call parts without the `state` and `input` fields required by AI SDK v6's `convertToModelMessages()`. Without `state: 'output-available'`, the SDK emitted `tool_use` blocks with no matching `tool_result`, triggering Anthropic's validation error on replay.
- **Defect 2** — Multi-step responses (all steps from `maxSteps > 1` MCP runs) were consolidated into one DB assistant message. On reload, `convertToModelMessages` couldn't reconstruct the correct multi-turn structure and produced consecutive user turns, which Anthropic rejects.
- **Defect 3** — `convertContentToParts` had no guard for parts with stored `state: 'output-error'` that lacked the `isError` flag.

## Changes

**`app/api/nexus/chat/chat-helpers.ts`**
- Added `state` (`output-available` | `input-available`) and `input` fields to `AssistantPart` and `buildAssistantParts()` — matches AI SDK v6 UIMessage tool-part schema
- Added `StepToolCallData`, `StepData` types and exported `saveConversationSteps()` — persists each step as a separate assistant message, then updates conversation stats once (wrapped in `executeTransaction` for atomicity)

**`app/api/nexus/chat/route.ts`**
- Imported `saveConversationSteps`
- `createOnFinishCallback` now destructures `steps` from the finish event and calls `saveConversationSteps` when `steps.length > 1` (multi-step MCP run), falling back to `saveAssistantMessage` for single-step

**`lib/streaming/types.ts`**
- Added `StepCallbackData` interface and `steps?: StepCallbackData[]` to `StreamingCallbacks.onFinish`

**`lib/streaming/provider-adapters/base-adapter.ts`**
- Extended `transformedData` to include per-step breakdown from `event.steps` — builds `toolCalls` + matched `results` per step and passes them as `steps` to the `onFinish` callback

**`lib/streaming/unified-streaming-service.ts`**
- Added `normalizeMultiStepMessages()` — pre-processes the incoming messages array before `convertToModelMessages`: splits any assistant UIMessage that has both resolved tool parts AND a text part into tool-only and text-only messages. This fixes existing conversations already saved in the broken format without requiring a DB migration.

**`lib/nexus/history-adapter.ts`**
- `createExportedMessageRepository` now derives `state` and `input` from the stored `result`/`isError` fields so the `historyAdapter` path also produces parts compatible with `convertToModelMessages`

**`app/(protected)/nexus/_components/conversation-initializer.tsx`**
- `convertContentToParts` reads the stored `state` field (when present from the DB fix) to correctly handle `output-error` parts; validates the stored value against the allowed enum before use

**`tests/unit/nexus/multi-step-tool-fix.test.ts`**
- Unit tests for `convertContentToParts` state derivation and `normalizeMultiStepMessages` splitting logic

## Test Plan
- [x] Inline tests passing (unit tests added)
- [x] work-validator agent passed
- [x] Security audit — 2 HIGH fixed (H2: DB transaction wrapping, M2: state enum validation) in commit b25d2e54; remaining findings documented in [PR comment](https://github.com/psd401/aistudio/pull/991#issuecomment-4455853138)
- [ ] Human review: load a conversation that used MCP connector tools, send a follow-up — verify no `AI_MissingToolResultsError`
- [ ] Regression: single-step `show_chart` and web search tools still work
- [ ] Regression: tab switching does NOT cause conversation remount (#811)

Closes #977

---
*Opened by the lfg routine.*

---
_Generated by [Claude Code](https://claude.ai/code/session_01VdxJoRYUC65dUYdGgRUoPf)_