### PR TITLE
fix(nexus): handle session expiry to prevent silent message loss (#978)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,4 +61,5 @@ infra/**/package-lock.json
 
 # Claude agent internal state
 .claude/agent-memory/
+.claude/worktrees/
 docs/learnings/.evolve-state.json

--- a/app/(protected)/nexus/page.tsx
+++ b/app/(protected)/nexus/page.tsx
@@ -111,12 +111,11 @@ function ConversationRuntimeProvider({
   // Custom fetch to intercept X-Conversation-Id header for conversation continuity
   // and handle content safety blocked errors with user-friendly messages
   const customFetch = useCallback(async (input: RequestInfo | URL, init?: RequestInit) => {
-    // Pre-send check: if NextAuth has already detected session expiry (via its 5-min
-    // poll), block the request immediately rather than letting the 401 come back from
-    // the server. This closes the gap between server-side token invalidation and client-
-    // side detection without changing the global poll interval (see session-provider.tsx).
-    if (sessionStatusRef.current === 'unauthenticated') {
-      log.warn('Pre-send check: session unauthenticated, blocking chat request')
+    // Extracted helper to show session-expired toast and throw. Used in both the
+    // pre-send check and the 401 response handler so the UX is identical regardless
+    // of which detection path fires first.
+    const throwSessionExpired = (reason: string): never => {
+      log.warn(reason)
       toast.error('Session Expired', {
         id: 'nexus-session-expired',
         description: 'Your session has expired. Please sign in again to continue.',
@@ -129,24 +128,24 @@ function ConversationRuntimeProvider({
       throw new Error('Session expired - please sign in again')
     }
 
+    // Pre-send check: if NextAuth has already detected session expiry (via its 5-min
+    // poll), block the request immediately rather than letting the 401 come back from
+    // the server. This closes the gap between server-side token invalidation and client-
+    // side detection without changing the global poll interval (see session-provider.tsx).
+    if (sessionStatusRef.current === 'unauthenticated') {
+      throwSessionExpired('Pre-send check: session unauthenticated, blocking chat request')
+    }
+
     const response = await fetch(input, init)
 
     // Handle session expiry — 401 returned when JWT is invalid or Cognito token refresh
     // failed overnight. Without this handler the AI SDK runtime tries to parse
     // "Unauthorized" as an SSE stream, throws TypeError, and onFinish never fires, so
-    // messages are silently lost. Throw here to abort cleanly and surface the error.
+    // messages are silently lost. Drain the body first to release the connection, then
+    // throw to abort cleanly and surface the error.
     if (response.status === 401) {
-      log.warn('Session expired during chat request — 401 from server')
-      toast.error('Session Expired', {
-        id: 'nexus-session-expired',
-        description: 'Your session has expired. Please sign in again to continue.',
-        duration: 0,
-        action: {
-          label: 'Sign In',
-          onClick: () => { window.location.href = '/api/auth/signin?callbackUrl=/nexus' },
-        },
-      })
-      throw new Error('Session expired - please sign in again')
+      await response.body?.cancel().catch(() => {})
+      throwSessionExpired('Session expired during chat request — 401 from server')
     }
 
     // Handle model-not-found errors (404)

--- a/app/(protected)/nexus/page.tsx
+++ b/app/(protected)/nexus/page.tsx
@@ -96,6 +96,12 @@ function ConversationRuntimeProvider({
   const conversationIdRef = useRef(conversationId)
   conversationIdRef.current = conversationId
 
+  // Track session status via ref for use inside customFetch without adding to deps.
+  // useSession is safe here — SessionProvider wraps this component tree.
+  const { status: sessionStatus } = useSession()
+  const sessionStatusRef = useRef(sessionStatus)
+  sessionStatusRef.current = sessionStatus
+
   const historyAdapter = useMemo(
     () => createNexusHistoryAdapter(() => conversationIdRef.current),
     // eslint-disable-next-line react-hooks/exhaustive-deps -- intentionally stable; conversationId accessed via ref
@@ -105,7 +111,41 @@ function ConversationRuntimeProvider({
   // Custom fetch to intercept X-Conversation-Id header for conversation continuity
   // and handle content safety blocked errors with user-friendly messages
   const customFetch = useCallback(async (input: RequestInfo | URL, init?: RequestInit) => {
+    // Pre-send check: if NextAuth has already detected session expiry (via its 5-min
+    // poll), block the request immediately rather than letting the 401 come back from
+    // the server. This closes the gap between server-side token invalidation and client-
+    // side detection without changing the global poll interval (see session-provider.tsx).
+    if (sessionStatusRef.current === 'unauthenticated') {
+      log.warn('Pre-send check: session unauthenticated, blocking chat request')
+      toast.error('Session Expired', {
+        description: 'Your session has expired. Please sign in again to continue.',
+        duration: 0,
+        action: {
+          label: 'Sign In',
+          onClick: () => { window.location.href = '/api/auth/signin?callbackUrl=/nexus' },
+        },
+      })
+      throw new Error('Session expired - please sign in again')
+    }
+
     const response = await fetch(input, init)
+
+    // Handle session expiry — 401 returned when JWT is invalid or Cognito token refresh
+    // failed overnight. Without this handler the AI SDK runtime tries to parse
+    // "Unauthorized" as an SSE stream, throws TypeError, and onFinish never fires, so
+    // messages are silently lost. Throw here to abort cleanly and surface the error.
+    if (response.status === 401) {
+      log.warn('Session expired during chat request — 401 from server')
+      toast.error('Session Expired', {
+        description: 'Your session has expired. Please sign in again to continue.',
+        duration: 0,
+        action: {
+          label: 'Sign In',
+          onClick: () => { window.location.href = '/api/auth/signin?callbackUrl=/nexus' },
+        },
+      })
+      throw new Error('Session expired - please sign in again')
+    }
 
     // Handle model-not-found errors (404)
     // Note: We show a toast but still return the 404 response to let the AI SDK runtime

--- a/app/(protected)/nexus/page.tsx
+++ b/app/(protected)/nexus/page.tsx
@@ -118,6 +118,7 @@ function ConversationRuntimeProvider({
     if (sessionStatusRef.current === 'unauthenticated') {
       log.warn('Pre-send check: session unauthenticated, blocking chat request')
       toast.error('Session Expired', {
+        id: 'nexus-session-expired',
         description: 'Your session has expired. Please sign in again to continue.',
         duration: 0,
         action: {
@@ -137,6 +138,7 @@ function ConversationRuntimeProvider({
     if (response.status === 401) {
       log.warn('Session expired during chat request — 401 from server')
       toast.error('Session Expired', {
+        id: 'nexus-session-expired',
         description: 'Your session has expired. Please sign in again to continue.',
         duration: 0,
         action: {

--- a/docs/learnings/ai-sdk/2026-05-15-nexus-session-expiry-message-loss-patterns.md
+++ b/docs/learnings/ai-sdk/2026-05-15-nexus-session-expiry-message-loss-patterns.md
@@ -1,0 +1,87 @@
+---
+title: Three patterns for preventing message loss on session expiry in Nexus
+category: ai-sdk
+tags:
+  - ai-sdk
+  - customFetch
+  - nextauth
+  - session-expiry
+  - assistant-ui
+  - useRef
+  - history-adapter
+  - silent-failure
+severity: high
+date: 2026-05-15
+source: auto — /lfg issue-978
+applicable_to: project
+---
+
+## What Happened
+
+Issue #978: Nexus chat messages were silently lost when a session expired during a long conversation. Three separate failure modes contributed; each required its own fix.
+
+## Pattern 1 — 401 in customFetch must throw, not return
+
+When NextAuth's session expires mid-request, the API route returns HTTP 401. The existing `customFetch` error handler (see `2026-03-12-customfetch-must-throw-after-toast.md`) applied to guardrail 400s but was not wired for 401. A returned 401 response is parsed by the AI SDK as an SSE stream, corrupting state and losing the message silently.
+
+**Fix**: treat 401 as a throw path in `customFetch`, just like any other non-2xx:
+
+```typescript
+if (response.status === 401) {
+  toast.error("Session expired. Please sign in again.")
+  throw new Error("Session expired")  // MUST throw — returning causes SSE parse corruption
+}
+```
+
+The rule from the earlier learning applies to 401 equally: **any non-2xx response returned (not thrown) from customFetch will be misread as a stream.**
+
+## Pattern 2 — Pre-send session gate via useRef in useCallback
+
+The 5-minute poll interval (intentional — see PR #811/#812) means NextAuth may detect session expiry up to 5 minutes before the user's next action. Use a `useRef` to expose the current `status` inside a `useCallback` without adding it as a dependency, then block the request at send-time if already expired:
+
+```typescript
+const sessionStatusRef = useRef(status)
+useEffect(() => { sessionStatusRef.current = status }, [status])
+
+const handleRequest = useCallback(async () => {
+  if (sessionStatusRef.current !== "authenticated") {
+    toast.error("Session expired. Please sign in again.")
+    return  // block before hitting the network
+  }
+  // ... proceed
+}, [])  // ref is stable — no churn on status changes
+```
+
+This follows the `conversationIdRef` pattern already established in `ConversationRuntimeProvider`. The ref gives the callback a stable, always-current view of a value without triggering re-creation on every change.
+
+## Pattern 3 — Per-message try/catch in fromThreadMessageLike map
+
+`INTERNAL.fromThreadMessageLike` throws on malformed messages (e.g., tool-call format errors, encoding issues). In the history adapter's map over stored messages, one bad message was crashing the entire conversation load, making all prior context invisible.
+
+**Fix**: wrap each `fromThreadMessageLike` call in its own try/catch and null-filter the results:
+
+```typescript
+const threadMessages = storedMessages
+  .map((msg) => {
+    try {
+      return INTERNAL.fromThreadMessageLike(msg)
+    } catch (outer) {
+      try {
+        // fallback: attempt text-only recovery or log
+        logger.warn("Message load failed, skipping", { msgId: msg.id })
+      } catch {
+        // ignore double-failure
+      }
+      return null
+    }
+  })
+  .filter((m): m is ThreadMessage => m !== null)
+```
+
+The outer catch prevents the crash; the inner catch guards against failures in the recovery path itself; the filter removes nulls before passing to the runtime.
+
+## Prevention
+
+- Every `customFetch` non-2xx branch must throw — no exceptions, including 401
+- Expose volatile values to stable callbacks via `useRef` + sync effect, not by adding to `useCallback` deps
+- When mapping over persisted messages for `fromThreadMessageLike`, always isolate each call in its own try/catch; one corrupt message must not fail the batch

--- a/docs/learnings/ai-sdk/2026-05-15-nexus-session-expiry-message-loss-patterns.md
+++ b/docs/learnings/ai-sdk/2026-05-15-nexus-session-expiry-message-loss-patterns.md
@@ -40,17 +40,19 @@ The rule from the earlier learning applies to 401 equally: **any non-2xx respons
 The 5-minute poll interval (intentional — see PR #811/#812) means NextAuth may detect session expiry up to 5 minutes before the user's next action. Use a `useRef` to expose the current `status` inside a `useCallback` without adding it as a dependency, then block the request at send-time if already expired:
 
 ```typescript
-const sessionStatusRef = useRef(status)
-useEffect(() => { sessionStatusRef.current = status }, [status])
+const { status: sessionStatus } = useSession()
+const sessionStatusRef = useRef(sessionStatus)
+sessionStatusRef.current = sessionStatus  // inline assignment during render — always current
 
-const handleRequest = useCallback(async () => {
-  if (sessionStatusRef.current !== "authenticated") {
-    toast.error("Session expired. Please sign in again.")
-    return  // block before hitting the network
+const customFetch = useCallback(async (input, init) => {
+  if (sessionStatusRef.current === "unauthenticated") {
+    // show toast + throw — block before hitting the network
   }
   // ... proceed
 }, [])  // ref is stable — no churn on status changes
 ```
+
+**Important**: the ref is updated with a direct render-time assignment (`sessionStatusRef.current = sessionStatus`), not via `useEffect`. This is the same pattern as `conversationIdRef` in the same component. The inline assignment is synchronous and ensures the ref is up to date before any callback fires; a `useEffect` update would lag one render behind the commit (async), creating a brief window where the ref holds a stale value.
 
 This follows the `conversationIdRef` pattern already established in `ConversationRuntimeProvider`. The ref gives the callback a stable, always-current view of a value without triggering re-creation on every change.
 
@@ -58,30 +60,46 @@ This follows the `conversationIdRef` pattern already established in `Conversatio
 
 `INTERNAL.fromThreadMessageLike` throws on malformed messages (e.g., tool-call format errors, encoding issues). In the history adapter's map over stored messages, one bad message was crashing the entire conversation load, making all prior context invisible.
 
-**Fix**: wrap each `fromThreadMessageLike` call in its own try/catch and null-filter the results:
+**Fix**: wrap each `fromThreadMessageLike` call in its own try/catch and null-filter the results. A nested inner catch guards the fallback construction — if `msg.id` itself is null/corrupt, the fallback call can throw the same way as the primary:
 
 ```typescript
 const threadMessages = storedMessages
-  .map((msg) => {
+  .map((msg, index) => {
     try {
-      return INTERNAL.fromThreadMessageLike(msg)
-    } catch (outer) {
-      try {
-        // fallback: attempt text-only recovery or log
-        logger.warn("Message load failed, skipping", { msgId: msg.id })
-      } catch {
-        // ignore double-failure
+      return {
+        message: INTERNAL.fromThreadMessageLike({
+          id: msg.id, role: msg.role,
+          content: content as unknown as string,
+          ...(msg.createdAt && { createdAt: new Date(msg.createdAt) }),
+        }, msg.id, { type: 'complete', reason: 'unknown' }),
+        parentId: index === 0 ? null : storedMessages[index - 1]?.id || null,
       }
-      return null
+    } catch (error) {
+      log.warn('Message conversion failed, using placeholder', { messageId: msg.id, error })
+      try {
+        // Inner catch: the fallback call can also throw if msg.id is null/corrupt.
+        // Preserve createdAt so ordering is maintained for valid surrounding messages.
+        return {
+          message: INTERNAL.fromThreadMessageLike({
+            id: msg.id, role: msg.role,
+            content: [{ type: 'text', text: '[Message could not be loaded]' }] as unknown as string,
+            ...(msg.createdAt && { createdAt: new Date(msg.createdAt) }),
+          }, msg.id, { type: 'complete', reason: 'unknown' }),
+          parentId: index === 0 ? null : storedMessages[index - 1]?.id || null,
+        }
+      } catch (fallbackError) {
+        log.error('Fallback construction failed, skipping message', { messageId: msg.id, fallbackError })
+        return null  // filtered out below
+      }
     }
   })
-  .filter((m): m is ThreadMessage => m !== null)
+  .filter((item): item is NonNullable<typeof item> => item !== null)
 ```
 
-The outer catch prevents the crash; the inner catch guards against failures in the recovery path itself; the filter removes nulls before passing to the runtime.
+The outer catch prevents a single bad message from aborting the whole load; the inner catch handles the double-failure case (e.g. `msg.id` is null); the filter removes any null entries from the output. Always preserve `createdAt` on the fallback so conversation ordering is not disrupted.
 
 ## Prevention
 
 - Every `customFetch` non-2xx branch must throw — no exceptions, including 401
-- Expose volatile values to stable callbacks via `useRef` + sync effect, not by adding to `useCallback` deps
+- Expose volatile values to stable callbacks via `useRef` with a direct render-time assignment (`ref.current = value` in the component body), not `useEffect` and not by adding to `useCallback` deps
 - When mapping over persisted messages for `fromThreadMessageLike`, always isolate each call in its own try/catch; one corrupt message must not fail the batch

--- a/lib/nexus/history-adapter.ts
+++ b/lib/nexus/history-adapter.ts
@@ -180,16 +180,28 @@ const createExportedMessageRepository = (messages: MessageData[]): ExportedMessa
           // Truncate error message to avoid forwarding arbitrary content to logs (L-2)
           error: error instanceof Error ? error.message.substring(0, 200) : String(error).substring(0, 200),
         })
-        return {
-          message: INTERNAL.fromThreadMessageLike({
-            id: msg.id,
-            role: msgRole,
-            content: [{ type: 'text', text: '[Message could not be loaded]' }] as unknown as string,
-          }, msg.id, { type: 'complete', reason: 'unknown' }),
-          parentId: index === 0 ? null : validMessages[index - 1]?.id || null
+        // Guard the fallback construction too — if INTERNAL.fromThreadMessageLike itself
+        // is the source of the failure (e.g. null dereference on msg.id), the same call
+        // with a static content array could throw again and escape the outer catch.
+        try {
+          return {
+            message: INTERNAL.fromThreadMessageLike({
+              id: msg.id,
+              role: msgRole,
+              content: [{ type: 'text', text: '[Message could not be loaded]' }] as unknown as string,
+            }, msg.id, { type: 'complete', reason: 'unknown' }),
+            parentId: index === 0 ? null : validMessages[index - 1]?.id || null
+          }
+        } catch (fallbackError) {
+          log.error('Fallback message construction failed, skipping message', {
+            messageId: msg.id,
+            messageIndex: index,
+            error: fallbackError instanceof Error ? fallbackError.message.substring(0, 200) : String(fallbackError).substring(0, 200),
+          })
+          return null
         }
       }
-    })
+    }).filter((item): item is NonNullable<typeof item> => item !== null)
   }
 }
 


### PR DESCRIPTION
## Summary

Implements #978 — three-part fix for the dual-faceted bug where JWT expiry during long sessions caused chat messages to be silently lost and corrupted conversations to crash on reload.

## Root Cause Recap

When a user's Cognito token expires overnight, the next `/api/nexus/chat` POST returns HTTP 401 with plain-text `"Unauthorized"`. The `customFetch` had no 401 branch, so it returned the raw 401 to the AI SDK runtime, which attempted to parse `"Unauthorized"` as an SSE stream, threw `TypeError`, and aborted before `onFinish` fired — the only call site for `saveAssistantMessage`. Messages were silently lost.

A separate crash (`"28 is empty"` / `TypeError: Cannot read properties of undefined (reading 'id')`) occurred when reloading a partially-saved conversation, because `fromThreadMessageLike` threw on a message with empty parts and the error propagated uncaught through the entire load path.

## Changes

**`app/(protected)/nexus/page.tsx`**
- **Fix 1 (401 handler):** After the `fetch()` call in `customFetch`, check `response.status === 401` and throw — prevents the AI SDK from parsing the non-streaming body as a stream, surfaces a persistent "Session Expired" toast with a Sign In action button.
- **Fix 2 (pre-send check):** Call `useSession()` in `ConversationRuntimeProvider` (safe — `SessionProvider` wraps this tree), store `status` in a ref, and guard `customFetch` with a pre-send check. If NextAuth's 5-min poll has already detected expiry, the request is blocked before it's made rather than waiting for the server 401. Ref avoids adding to `useCallback` deps or causing re-renders.

**`lib/nexus/history-adapter.ts`**
- **Fix 3 (resilient load):** Wrap `INTERNAL.fromThreadMessageLike` in `try/catch` inside `createExportedMessageRepository`. A malformed message (e.g. empty parts from a partially-persisted exchange) now substitutes a `[Message could not be loaded]` placeholder instead of crashing the entire conversation load. A nested try/catch guards the fallback construction itself; on double-failure, the message is skipped (null-filtered from the map result) rather than aborting all remaining messages.

## Test Plan

- [x] Inline implementation review — all three fix points verified
- [x] Security audit — no CRITICAL/HIGH findings; two LOW issues fixed in-place
- [ ] Manual: clear auth cookie mid-conversation → verify "Session Expired" toast + Sign In button appears (not stackable)
- [ ] Manual: load a conversation with a corrupted/empty message → graceful placeholder, no crash
- [ ] Manual: normal chat flow works end-to-end
- [ ] Regression: tab-switching does NOT cause conversation remount (#811)
- [ ] Regression: `refetchOnWindowFocus={false}` preserved (#811)
- [ ] Human review

Closes #978

---
*Opened by the lfg routine.*