### PR TITLE
feat: #940 — fix JPEG image upload crash in Nexus chat

### DIFF
--- a/app/(protected)/nexus/page.tsx
+++ b/app/(protected)/nexus/page.tsx
@@ -158,6 +158,23 @@ function ConversationRuntimeProvider({
       throwSessionExpired('Session expired during chat request — 401 from server')
     }
 
+    // Handle server errors (5xx) — throw so the AI SDK runtime can clean up.
+    // Without this, the SDK tries to parse a JSON error body as an SSE stream and
+    // crashes with an unhandled TypeError accessing .id on undefined message state.
+    if (response.status >= 500) {
+      let description = 'An error occurred. Please try again.'
+      try {
+        const errorData = await response.clone().json()
+        if (typeof errorData?.error === 'string') {
+          description = errorData.error
+        }
+      } catch {
+        // ignore parse failures — use generic description
+      }
+      toast.error('Chat request failed', { description, duration: 8000 })
+      throw new Error(description)
+    }
+
     // Handle model-not-found errors (404)
     // Note: We show a toast but still return the 404 response to let the AI SDK runtime
     // handle cleanup. This provides dual feedback: user-friendly toast + runtime error handling.

--- a/app/(protected)/nexus/page.tsx
+++ b/app/(protected)/nexus/page.tsx
@@ -166,7 +166,8 @@ function ConversationRuntimeProvider({
       try {
         const errorData = await response.clone().json()
         if (typeof errorData?.error === 'string') {
-          description = errorData.error
+          // Slice to prevent the server leaking internal details in long error messages
+          description = errorData.error.slice(0, 200)
         }
       } catch {
         // ignore parse failures — use generic description

--- a/app/api/nexus/chat/chat-helpers.ts
+++ b/app/api/nexus/chat/chat-helpers.ts
@@ -132,6 +132,18 @@ function processMessagePart(
   if (typedPart.type === 'image' && typedPart.image) {
     return { content: '', serialized: { type: 'image', metadata: { hasImage: true } } };
   }
+  // toCreateMessage converts image attachments to type:"file" parts with a url property.
+  // Detect these by checking mediaType or the data URL prefix so they are saved to the DB.
+  if (typedPart.type === 'file') {
+    const mediaType = typedPart.mediaType as string | undefined;
+    const url = typedPart.url as string | undefined;
+    if (
+      (typeof mediaType === 'string' && mediaType.startsWith('image/')) ||
+      (typeof url === 'string' && url.startsWith('data:image/'))
+    ) {
+      return { content: '', serialized: { type: 'image', metadata: { hasImage: true } } };
+    }
+  }
   return null;
 }
 

--- a/docs/learnings/ai-sdk/2026-05-28-assistant-ui-toCreatemessage-file-part-image-png-hardcode.md
+++ b/docs/learnings/ai-sdk/2026-05-28-assistant-ui-toCreatemessage-file-part-image-png-hardcode.md
@@ -1,0 +1,85 @@
+---
+title: assistant-ui toCreateMessage wraps image attachments as type:"file" with url and hardcodes mediaType:"image/png"
+category: ai-sdk
+tags:
+  - assistant-ui
+  - toCreateMessage
+  - file-parts
+  - image-upload
+  - mediaType
+  - nexus
+severity: high
+date: 2026-05-28
+source: auto — /work
+applicable_to: project
+---
+
+## What Happened
+
+JPEG uploads in Nexus chat crashed with a `TypeError` on `.id`. The AI SDK's stream
+parser received a non-stream body because the message save to the database had
+silently failed. The save failed because `processMessagePart` in `chat-helpers.ts`
+had no handler for `type:"file"` parts, so every message with an image attachment
+produced `parts: []` in the DB insert — then the follow-up `processMessagesWithAttachments`
+call to the route could not find the conversation, causing a 5xx that the SDK tried
+to parse as an SSE stream.
+
+## Root Cause
+
+`@assistant-ui/react-ai-sdk`'s `toCreateMessage` converts image attachments to
+**`type:"file"` parts** (not `type:"image"`). The part has a `url` property (not
+`image` or `data`) containing the base64 data URL, and it hardcodes
+`mediaType:"image/png"` regardless of the uploaded file's actual MIME type.
+
+The AI SDK's `convertToModelMessages` maps `part.url → data` for file parts
+internally (ai/dist/index.js ~line 9572), so these parts do reach the AI provider
+correctly — but any server-side code that only handles `type:"text"` and
+`type:"image"` will silently skip them.
+
+Additionally, because `mediaType` is always `"image/png"`, JPEG images sent to
+providers that care about MIME type (e.g. Claude via Bedrock) may be processed
+with incorrect framing. The fix is to extract the actual media type from the
+data URL prefix.
+
+## Solution
+
+In `processMessagePart` (and any equivalent server-side part handler), add a
+`type:"file"` case that detects image parts by checking `mediaType` or the data URL
+prefix:
+
+```typescript
+if (typedPart.type === 'file') {
+  const mediaType = typedPart.mediaType as string | undefined;
+  const url = typedPart.url as string | undefined;
+  if (
+    (typeof mediaType === 'string' && mediaType.startsWith('image/')) ||
+    (typeof url === 'string' && url.startsWith('data:image/'))
+  ) {
+    return { content: '', serialized: { type: 'image', metadata: { hasImage: true } } };
+  }
+}
+```
+
+To correct the media type before forwarding to the AI provider, extract it from
+the data URL and validate against an allowlist (see security note below):
+
+```typescript
+// In processMessagesWithAttachments
+if (partData.type === 'file' && typeof partData.url === 'string' && partData.url.startsWith('data:')) {
+  const actualMediaType = extractDataUrlMediaType(partData.url);
+  lightweightParts.push({ ...part, mediaType: actualMediaType ?? part.mediaType });
+}
+```
+
+## Prevention
+
+- Never assume `type:"image"` is the only format for image parts when using
+  `@assistant-ui/react-ai-sdk`. Always handle `type:"file"` parts with image
+  `mediaType` or `data:image/` URL prefixes.
+- When adding a new part type to `processMessagePart`, also update
+  `processMessagesWithAttachments` in `attachment-storage-service.ts` (both paths
+  must stay in sync).
+- `mediaType:"image/png"` from `toCreateMessage` is a hardcoded default — always
+  prefer the type extracted from the data URL itself.
+- See `lib/services/attachment-storage-service.ts` for the `extractDataUrlMediaType`
+  helper and `ALLOWED_IMAGE_MEDIA_TYPES` allowlist.

--- a/docs/learnings/security/2026-05-28-data-url-media-type-crlf-and-allowlist.md
+++ b/docs/learnings/security/2026-05-28-data-url-media-type-crlf-and-allowlist.md
@@ -1,0 +1,65 @@
+---
+title: Data URL media type extraction requires CRLF exclusion and MIME allowlist to prevent injection
+category: security
+tags:
+  - data-url
+  - media-type
+  - mime-type
+  - header-injection
+  - log-injection
+  - allowlist
+  - image-upload
+severity: high
+date: 2026-05-28
+source: auto — /work
+applicable_to: project
+---
+
+## What Happened
+
+When correcting the hardcoded `mediaType:"image/png"` set by `toCreateMessage`
+(see ai-sdk/2026-05-28 learning), the server extracts the real MIME type from the
+data URL prefix (e.g. `data:image/jpeg;base64,...`). Without sanitizing the
+extracted string, a crafted data URL such as `data:image/jpeg\r\nX-Injected:
+evil;base64,...` could inject arbitrary text into server logs or HTTP headers that
+include the media type.
+
+## Root Cause
+
+A naive regex like `/^data:([^;]+);/` captures everything up to the first `;`,
+including `\r` and `\n`. If the extracted string is written to a log field or
+forwarded as a Content-Type header, newline characters produce log/header injection.
+
+## Solution
+
+Exclude `;`, `,`, `\r`, and `\n` from the capture group, and validate the result
+against an explicit allowlist of known-good MIME types before use:
+
+```typescript
+// Exclude ;,\r\n from the captured segment to prevent header/log injection
+const match = /^data:([^;,\r\n]+)[;,]/.exec(url);
+if (!match) return null;
+const mediaType = match[1].toLowerCase().trim();
+
+const ALLOWED_IMAGE_MEDIA_TYPES = new Set([
+  'image/jpeg', 'image/png', 'image/gif',
+  'image/webp', 'image/bmp', 'image/tiff',
+]);
+
+return ALLOWED_IMAGE_MEDIA_TYPES.has(mediaType) ? mediaType : null;
+```
+
+Returning `null` for any type not in the allowlist means only known-safe types
+reach provider API requests or log statements.
+
+## Prevention
+
+- Any server-side extraction of a value embedded in user-controlled data (data
+  URLs, multipart boundaries, etc.) must exclude `\r` and `\n` from the capture
+  group.
+- Pair CRLF exclusion with a MIME type allowlist. Structural exclusion prevents
+  injection; the allowlist prevents unknown types from being forwarded.
+- See `lib/services/attachment-storage-service.ts` for the canonical
+  `extractDataUrlMediaType` implementation used in this project.
+- Apply the same pattern wherever file metadata (content type, filename) is
+  read from user-supplied data and later included in headers or logs.

--- a/lib/services/attachment-storage-service.ts
+++ b/lib/services/attachment-storage-service.ts
@@ -211,9 +211,9 @@ export async function processMessagesWithAttachments(
             partData as AttachmentContent,
             attachmentIndex++
           );
-          
+
           attachmentReferences.push(metadata);
-          
+
           // Replace with lightweight S3 reference for Lambda reconstruction
           lightweightParts.push({
             type: 'file' as const,
@@ -223,6 +223,28 @@ export async function processMessagesWithAttachments(
             s3Key: metadata.s3Key,
             attachmentId: metadata.attachmentId
           } as any); // eslint-disable-line @typescript-eslint/no-explicit-any
+        } else if (
+          partData.type === 'file' &&
+          typeof partData.url === 'string' &&
+          partData.url.startsWith('data:')
+        ) {
+          // toCreateMessage wraps image attachments as type:"file" with a url property containing
+          // the base64 data URL. It hardcodes mediaType:"image/png" regardless of actual format.
+          // Extract the correct media type from the data URL prefix so providers receive the
+          // right MIME type (e.g. image/jpeg for phone photos rather than image/png).
+          const actualMediaType = extractDataUrlMediaType(partData.url);
+          if (actualMediaType && actualMediaType !== partData.mediaType) {
+            log.info('Correcting mediaType for file part from data URL', {
+              detected: actualMediaType,
+              declared: partData.mediaType,
+            });
+            lightweightParts.push({
+              ...part,
+              mediaType: actualMediaType,
+            } as any); // eslint-disable-line @typescript-eslint/no-explicit-any
+          } else {
+            lightweightParts.push(part);
+          }
         } else {
           // Keep text and other parts as-is
           lightweightParts.push(part);
@@ -287,4 +309,13 @@ export async function reconstructMessagesWithAttachments(
 
 function sanitizeFileName(name: string): string {
   return name.replace(/[^\d.A-Za-z-]/g, '_').substring(0, 255);
+}
+
+/**
+ * Extract media type from a data URL (e.g. "data:image/jpeg;base64,..." → "image/jpeg").
+ * Returns null when the input is not a valid data URL.
+ */
+function extractDataUrlMediaType(url: string): string | null {
+  const match = /^data:([^;,]+)[;,]/.exec(url);
+  return match ? match[1] : null;
 }

--- a/lib/services/attachment-storage-service.ts
+++ b/lib/services/attachment-storage-service.ts
@@ -311,11 +311,28 @@ function sanitizeFileName(name: string): string {
   return name.replace(/[^\d.A-Za-z-]/g, '_').substring(0, 255);
 }
 
+// Allowlist of image MIME types that Nexus vision adapters are known to produce.
+// We only forward types on this list to AI providers so a crafted data URL cannot
+// inject arbitrary strings into provider API requests or server logs.
+const ALLOWED_IMAGE_MEDIA_TYPES = new Set([
+  'image/jpeg',
+  'image/png',
+  'image/gif',
+  'image/webp',
+  'image/bmp',
+  'image/tiff',
+]);
+
 /**
  * Extract media type from a data URL (e.g. "data:image/jpeg;base64,..." → "image/jpeg").
- * Returns null when the input is not a valid data URL.
+ * Returns null when the input is not a valid data URL or the extracted type is not
+ * in the allowlist of supported image MIME types.
+ * CRLF characters are excluded from the capture group to prevent log/header injection.
  */
 function extractDataUrlMediaType(url: string): string | null {
-  const match = /^data:([^;,]+)[;,]/.exec(url);
-  return match ? match[1] : null;
+  // Exclude ;,\r\n from the captured segment to prevent header/log injection
+  const match = /^data:([^;,\r\n]+)[;,]/.exec(url);
+  if (!match) return null;
+  const mediaType = match[1].toLowerCase().trim();
+  return ALLOWED_IMAGE_MEDIA_TYPES.has(mediaType) ? mediaType : null;
 }

--- a/lib/services/attachment-storage-service.ts
+++ b/lib/services/attachment-storage-service.ts
@@ -234,7 +234,7 @@ export async function processMessagesWithAttachments(
           // right MIME type (e.g. image/jpeg for phone photos rather than image/png).
           const actualMediaType = extractDataUrlMediaType(partData.url);
           if (actualMediaType && actualMediaType !== partData.mediaType) {
-            log.info('Correcting mediaType for file part from data URL', {
+            log.debug('Correcting mediaType for file part from data URL', {
               detected: actualMediaType,
               declared: partData.mediaType,
             });

--- a/tests/unit/api/nexus/chat-helpers-image-file.test.ts
+++ b/tests/unit/api/nexus/chat-helpers-image-file.test.ts
@@ -95,7 +95,7 @@ describe('extractUserContent — file-type image parts (Issue #940)', () => {
     expect(parts[1]).toEqual({ type: 'image', metadata: { hasImage: true } });
   });
 
-  it('returns empty parts for attachment-only messages (no text)', () => {
+  it('serializes image part for attachment-only messages (no text)', () => {
     // An image-only message with no text should save the image part to DB
     const message = {
       id: 'msg1',

--- a/tests/unit/api/nexus/chat-helpers-image-file.test.ts
+++ b/tests/unit/api/nexus/chat-helpers-image-file.test.ts
@@ -1,0 +1,114 @@
+/**
+ * @jest-environment node
+ *
+ * Tests for Issue #940: JPEG image uploads crash Nexus chat.
+ * Verifies that extractUserContent correctly handles type:"file" image parts
+ * produced by @assistant-ui/react-ai-sdk's toCreateMessage conversion.
+ */
+import { describe, it, expect } from '@jest/globals';
+import { extractUserContent } from '@/app/api/nexus/chat/chat-helpers';
+
+describe('extractUserContent — file-type image parts (Issue #940)', () => {
+  it('handles type:"file" part with image mediaType', () => {
+    const message = {
+      id: 'msg1',
+      role: 'user' as const,
+      parts: [
+        { type: 'text', text: 'what is in this photo?' },
+        { type: 'file', url: 'data:image/jpeg;base64,/9j/abc123', mediaType: 'image/jpeg', filename: 'photo.jpg' },
+      ],
+    };
+
+    const { content, parts } = extractUserContent(message);
+
+    expect(content).toBe('what is in this photo?');
+    expect(parts).toHaveLength(2);
+    expect(parts[0]).toEqual({ type: 'text', text: 'what is in this photo?' });
+    expect(parts[1]).toEqual({ type: 'image', metadata: { hasImage: true } });
+  });
+
+  it('handles type:"file" part with hardcoded image/png mediaType for a JPEG url', () => {
+    // toCreateMessage hardcodes "image/png" regardless of actual format
+    const message = {
+      id: 'msg1',
+      role: 'user' as const,
+      parts: [
+        { type: 'text', text: 'describe this' },
+        { type: 'file', url: 'data:image/jpeg;base64,/9j/abc123', mediaType: 'image/png' },
+      ],
+    };
+
+    const { content, parts } = extractUserContent(message);
+
+    expect(content).toBe('describe this');
+    // The image part should be saved even when mediaType says png but url says jpeg
+    expect(parts).toHaveLength(2);
+    expect(parts[1]).toEqual({ type: 'image', metadata: { hasImage: true } });
+  });
+
+  it('handles type:"file" part with image data URL when mediaType is missing', () => {
+    const message = {
+      id: 'msg1',
+      role: 'user' as const,
+      parts: [
+        { type: 'file', url: 'data:image/webp;base64,UklGRiAA', filename: 'image.webp' },
+      ],
+    };
+
+    const { parts } = extractUserContent(message);
+
+    expect(parts).toHaveLength(1);
+    expect(parts[0]).toEqual({ type: 'image', metadata: { hasImage: true } });
+  });
+
+  it('does not treat non-image file parts as images', () => {
+    const message = {
+      id: 'msg1',
+      role: 'user' as const,
+      parts: [
+        { type: 'text', text: 'here is a doc' },
+        { type: 'file', url: 'data:application/pdf;base64,JVBE', mediaType: 'application/pdf' },
+      ],
+    };
+
+    const { content, parts } = extractUserContent(message);
+
+    expect(content).toBe('here is a doc');
+    // The PDF file part should be dropped (not an image)
+    expect(parts).toHaveLength(1);
+    expect(parts[0]).toEqual({ type: 'text', text: 'here is a doc' });
+  });
+
+  it('preserves legacy type:"image" part handling unchanged', () => {
+    const message = {
+      id: 'msg1',
+      role: 'user' as const,
+      parts: [
+        { type: 'text', text: 'legacy image' },
+        { type: 'image', image: 'data:image/png;base64,abc' },
+      ],
+    };
+
+    const { parts } = extractUserContent(message);
+
+    expect(parts).toHaveLength(2);
+    expect(parts[1]).toEqual({ type: 'image', metadata: { hasImage: true } });
+  });
+
+  it('returns empty parts for attachment-only messages (no text)', () => {
+    // An image-only message with no text should save the image part to DB
+    const message = {
+      id: 'msg1',
+      role: 'user' as const,
+      parts: [
+        { type: 'file', url: 'data:image/jpeg;base64,/9j/abc', mediaType: 'image/png' },
+      ],
+    };
+
+    const { content, parts } = extractUserContent(message);
+
+    expect(content).toBe('');
+    expect(parts).toHaveLength(1);
+    expect(parts[0]).toEqual({ type: 'image', metadata: { hasImage: true } });
+  });
+});

--- a/tests/unit/lib/attachment-storage-image-mediatype.test.ts
+++ b/tests/unit/lib/attachment-storage-image-mediatype.test.ts
@@ -5,21 +5,13 @@
  * mediaType for type:"file" image parts produced by toCreateMessage, which
  * hardcodes "image/png" regardless of the actual image format.
  */
-import { describe, it, expect, jest } from '@jest/globals';
+import { describe, it, expect } from '@jest/globals';
 
-// Extract mock functions with mock* prefix — required by babel-plugin-jest-hoist
-// so they can be referenced inside jest.mock() factory functions.
-const mockS3Send = jest.fn().mockResolvedValue({});
-const mockS3Client = jest.fn().mockImplementation(() => ({ send: mockS3Send }));
-const mockPutObjectCommand = jest.fn();
-const mockGetObjectCommand = jest.fn();
-
-// Mock the AWS SDK S3 client so we don't need real credentials
-jest.mock('@aws-sdk/client-s3', () => ({
-  S3Client: mockS3Client,
-  PutObjectCommand: mockPutObjectCommand,
-  GetObjectCommand: mockGetObjectCommand,
-}));
+// Auto-mock the AWS SDK S3 client so we don't need real credentials.
+// No factory needed — the tests exercise the data-URL mediaType-correction
+// branch which never calls S3; only the module-level `new S3Client({})`
+// needs to succeed, which the automatic mock handles.
+jest.mock('@aws-sdk/client-s3');
 
 // Must set env before importing the module
 process.env.DOCUMENTS_BUCKET_NAME = 'test-documents-bucket';

--- a/tests/unit/lib/attachment-storage-image-mediatype.test.ts
+++ b/tests/unit/lib/attachment-storage-image-mediatype.test.ts
@@ -86,6 +86,46 @@ describe('processMessagesWithAttachments — mediaType correction (Issue #940)',
     expect(filePart?.mediaType).toBe('image/png');
   });
 
+  it('ignores crafted data URL with CRLF injection in media type', async () => {
+    // CRLF in the media type segment could inject log lines or HTTP headers
+    const craftedDataUrl = 'data:image/jpeg\r\nX-Injected: value;base64,/9j/abc';
+    const messages = [
+      makeMessage([
+        { type: 'file', url: craftedDataUrl, mediaType: 'image/png' },
+      ]),
+    ];
+
+    const { lightweightMessages } = await processMessagesWithAttachments('conv-id', messages);
+
+    const filePart = lightweightMessages[0].parts?.find((p: unknown) => {
+      const part = p as Record<string, unknown>;
+      return part.type === 'file';
+    }) as Record<string, unknown> | undefined;
+
+    // CRLF breaks the regex match, so mediaType should remain unchanged
+    expect(filePart?.mediaType).toBe('image/png');
+  });
+
+  it('ignores crafted data URL with non-image MIME type', async () => {
+    // Only allowlisted image types should be extracted
+    const craftedDataUrl = 'data:text/html;base64,PHNjcmlwdD4=';
+    const messages = [
+      makeMessage([
+        { type: 'file', url: craftedDataUrl, mediaType: 'image/png' },
+      ]),
+    ];
+
+    const { lightweightMessages } = await processMessagesWithAttachments('conv-id', messages);
+
+    const filePart = lightweightMessages[0].parts?.find((p: unknown) => {
+      const part = p as Record<string, unknown>;
+      return part.type === 'file';
+    }) as Record<string, unknown> | undefined;
+
+    // Non-image type not in allowlist — mediaType should remain unchanged
+    expect(filePart?.mediaType).toBe('image/png');
+  });
+
   it('does not modify non-data-url file parts', async () => {
     const messages = [
       makeMessage([

--- a/tests/unit/lib/attachment-storage-image-mediatype.test.ts
+++ b/tests/unit/lib/attachment-storage-image-mediatype.test.ts
@@ -5,7 +5,7 @@
  * mediaType for type:"file" image parts produced by toCreateMessage, which
  * hardcodes "image/png" regardless of the actual image format.
  */
-import { describe, it, expect, jest } from '@jest/globals';
+import { describe, it, expect } from '@jest/globals';
 
 // Mock the AWS SDK S3 client so we don't need real credentials
 jest.mock('@aws-sdk/client-s3', () => ({

--- a/tests/unit/lib/attachment-storage-image-mediatype.test.ts
+++ b/tests/unit/lib/attachment-storage-image-mediatype.test.ts
@@ -5,15 +5,20 @@
  * mediaType for type:"file" image parts produced by toCreateMessage, which
  * hardcodes "image/png" regardless of the actual image format.
  */
-import { describe, it, expect } from '@jest/globals';
+import { describe, it, expect, jest } from '@jest/globals';
+
+// Extract mock functions with mock* prefix — required by babel-plugin-jest-hoist
+// so they can be referenced inside jest.mock() factory functions.
+const mockS3Send = jest.fn().mockResolvedValue({});
+const mockS3Client = jest.fn().mockImplementation(() => ({ send: mockS3Send }));
+const mockPutObjectCommand = jest.fn();
+const mockGetObjectCommand = jest.fn();
 
 // Mock the AWS SDK S3 client so we don't need real credentials
 jest.mock('@aws-sdk/client-s3', () => ({
-  S3Client: jest.fn().mockImplementation(() => ({
-    send: jest.fn().mockResolvedValue({}),
-  })),
-  PutObjectCommand: jest.fn(),
-  GetObjectCommand: jest.fn(),
+  S3Client: mockS3Client,
+  PutObjectCommand: mockPutObjectCommand,
+  GetObjectCommand: mockGetObjectCommand,
 }));
 
 // Must set env before importing the module

--- a/tests/unit/lib/attachment-storage-image-mediatype.test.ts
+++ b/tests/unit/lib/attachment-storage-image-mediatype.test.ts
@@ -1,0 +1,128 @@
+/**
+ * @jest-environment node
+ *
+ * Tests for Issue #940: processMessagesWithAttachments correctly fixes the
+ * mediaType for type:"file" image parts produced by toCreateMessage, which
+ * hardcodes "image/png" regardless of the actual image format.
+ */
+import { describe, it, expect, beforeEach, jest } from '@jest/globals';
+
+// Mock the AWS SDK S3 client so we don't need real credentials
+jest.mock('@aws-sdk/client-s3', () => ({
+  S3Client: jest.fn().mockImplementation(() => ({
+    send: jest.fn().mockResolvedValue({}),
+  })),
+  PutObjectCommand: jest.fn(),
+  GetObjectCommand: jest.fn(),
+}));
+
+// Must set env before importing the module
+process.env.DOCUMENTS_BUCKET_NAME = 'test-documents-bucket';
+process.env.NODE_ENV = 'test';
+
+import { processMessagesWithAttachments } from '@/lib/services/attachment-storage-service';
+import type { UIMessage } from 'ai';
+
+const makeMessage = (parts: unknown[]): UIMessage =>
+  ({ id: 'msg1', role: 'user', parts, content: '' } as unknown as UIMessage);
+
+describe('processMessagesWithAttachments — mediaType correction (Issue #940)', () => {
+  it('corrects image/png → image/jpeg for a JPEG data URL', async () => {
+    const jpegDataUrl = 'data:image/jpeg;base64,/9j/4AAQSkZJRgAB';
+    const messages = [
+      makeMessage([
+        { type: 'text', text: 'describe this photo' },
+        { type: 'file', url: jpegDataUrl, mediaType: 'image/png', filename: 'photo.jpg' },
+      ]),
+    ];
+
+    const { lightweightMessages } = await processMessagesWithAttachments('conv-id', messages);
+
+    const filePart = lightweightMessages[0].parts?.find((p: unknown) => {
+      const part = p as Record<string, unknown>;
+      return part.type === 'file';
+    }) as Record<string, unknown> | undefined;
+
+    expect(filePart).toBeDefined();
+    expect(filePart?.mediaType).toBe('image/jpeg');
+    // url should be preserved unchanged (not replaced with s3://)
+    expect(filePart?.url).toBe(jpegDataUrl);
+  });
+
+  it('corrects image/png → image/webp for a WebP data URL', async () => {
+    const webpDataUrl = 'data:image/webp;base64,UklGRiAA';
+    const messages = [
+      makeMessage([
+        { type: 'file', url: webpDataUrl, mediaType: 'image/png' },
+      ]),
+    ];
+
+    const { lightweightMessages } = await processMessagesWithAttachments('conv-id', messages);
+
+    const filePart = lightweightMessages[0].parts?.find((p: unknown) => {
+      const part = p as Record<string, unknown>;
+      return part.type === 'file';
+    }) as Record<string, unknown> | undefined;
+
+    expect(filePart?.mediaType).toBe('image/webp');
+  });
+
+  it('leaves mediaType unchanged when it already matches the data URL', async () => {
+    const pngDataUrl = 'data:image/png;base64,iVBORw0KGgoAAAA';
+    const messages = [
+      makeMessage([
+        { type: 'file', url: pngDataUrl, mediaType: 'image/png' },
+      ]),
+    ];
+
+    const { lightweightMessages } = await processMessagesWithAttachments('conv-id', messages);
+
+    const filePart = lightweightMessages[0].parts?.find((p: unknown) => {
+      const part = p as Record<string, unknown>;
+      return part.type === 'file';
+    }) as Record<string, unknown> | undefined;
+
+    // Same as before — no update needed
+    expect(filePart?.mediaType).toBe('image/png');
+  });
+
+  it('does not modify non-data-url file parts', async () => {
+    const messages = [
+      makeMessage([
+        { type: 'file', url: 'https://example.com/file.jpg', mediaType: 'image/jpeg' },
+      ]),
+    ];
+
+    const { lightweightMessages } = await processMessagesWithAttachments('conv-id', messages);
+
+    const filePart = lightweightMessages[0].parts?.find((p: unknown) => {
+      const part = p as Record<string, unknown>;
+      return part.type === 'file';
+    }) as Record<string, unknown> | undefined;
+
+    // Should pass through unchanged
+    expect(filePart?.url).toBe('https://example.com/file.jpg');
+    expect(filePart?.mediaType).toBe('image/jpeg');
+  });
+
+  it('preserves text parts alongside the corrected file part', async () => {
+    const jpegDataUrl = 'data:image/jpeg;base64,/9j/abc';
+    const messages = [
+      makeMessage([
+        { type: 'text', text: 'what is this?' },
+        { type: 'file', url: jpegDataUrl, mediaType: 'image/png' },
+      ]),
+    ];
+
+    const { lightweightMessages } = await processMessagesWithAttachments('conv-id', messages);
+
+    const parts = lightweightMessages[0].parts as unknown[];
+    expect(parts).toHaveLength(2);
+
+    const textPart = parts.find((p) => (p as Record<string, unknown>).type === 'text') as Record<string, unknown>;
+    expect(textPart?.text).toBe('what is this?');
+
+    const filePart = parts.find((p) => (p as Record<string, unknown>).type === 'file') as Record<string, unknown>;
+    expect(filePart?.mediaType).toBe('image/jpeg');
+  });
+});

--- a/tests/unit/lib/attachment-storage-image-mediatype.test.ts
+++ b/tests/unit/lib/attachment-storage-image-mediatype.test.ts
@@ -5,12 +5,13 @@
  * mediaType for type:"file" image parts produced by toCreateMessage, which
  * hardcodes "image/png" regardless of the actual image format.
  */
-import { describe, it, expect, jest } from '@jest/globals';
+import { describe, it, expect } from '@jest/globals';
 
 // Auto-mock the AWS SDK S3 client so we don't need real credentials.
 // No factory needed — the tests exercise the data-URL mediaType-correction
 // branch which never calls S3; only the module-level `new S3Client({})`
 // needs to succeed, which the automatic mock handles.
+// Uses global jest (not imported) so SWC can hoist this call above all imports.
 jest.mock('@aws-sdk/client-s3');
 
 // Must set env before importing the module

--- a/tests/unit/lib/attachment-storage-image-mediatype.test.ts
+++ b/tests/unit/lib/attachment-storage-image-mediatype.test.ts
@@ -5,7 +5,7 @@
  * mediaType for type:"file" image parts produced by toCreateMessage, which
  * hardcodes "image/png" regardless of the actual image format.
  */
-import { describe, it, expect } from '@jest/globals';
+import { describe, it, expect, jest } from '@jest/globals';
 
 // Auto-mock the AWS SDK S3 client so we don't need real credentials.
 // No factory needed — the tests exercise the data-URL mediaType-correction

--- a/tests/unit/lib/attachment-storage-image-mediatype.test.ts
+++ b/tests/unit/lib/attachment-storage-image-mediatype.test.ts
@@ -7,17 +7,10 @@
  */
 import { describe, it, expect } from '@jest/globals';
 
-// Auto-mock the AWS SDK S3 client so we don't need real credentials.
-// No factory needed — the tests exercise the data-URL mediaType-correction
-// branch which never calls S3; only the module-level `new S3Client({})`
-// needs to succeed, which the automatic mock handles.
-// Uses global jest (not imported) so SWC can hoist this call above all imports.
-jest.mock('@aws-sdk/client-s3');
-
-// Must set env before importing the module
-process.env.DOCUMENTS_BUCKET_NAME = 'test-documents-bucket';
-process.env.NODE_ENV = 'test';
-
+// No jest.mock needed: every test case exercises the data-URL mediaType-correction
+// branch or the passthrough path — neither invokes s3Client.send(). The module-level
+// `new S3Client({})` succeeds in Node because AWS SDK v3 does not validate credentials
+// at construction time, only at request time.
 import { processMessagesWithAttachments } from '@/lib/services/attachment-storage-service';
 import type { UIMessage } from 'ai';
 

--- a/tests/unit/lib/attachment-storage-image-mediatype.test.ts
+++ b/tests/unit/lib/attachment-storage-image-mediatype.test.ts
@@ -5,7 +5,7 @@
  * mediaType for type:"file" image parts produced by toCreateMessage, which
  * hardcodes "image/png" regardless of the actual image format.
  */
-import { describe, it, expect, beforeEach, jest } from '@jest/globals';
+import { describe, it, expect, jest } from '@jest/globals';
 
 // Mock the AWS SDK S3 client so we don't need real credentials
 jest.mock('@aws-sdk/client-s3', () => ({

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -33,7 +33,8 @@
     "types": [
       "react",
       "react-dom",
-      "node"
+      "node",
+      "jest"
     ]
   },
   "include": [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -33,8 +33,7 @@
     "types": [
       "react",
       "react-dom",
-      "node",
-      "jest"
+      "node"
     ]
   },
   "include": [


### PR DESCRIPTION
## Summary

Implements #940 — fixes three contributing bugs that caused JPEG (and other non-PNG) image uploads to crash the Nexus chat with a server 500 and a client-side `TypeError: Cannot read properties of undefined (reading 'id')`.

## Root Cause

`@assistant-ui/react-ai-sdk`'s `toCreateMessage` converts image attachments to `type:"file"` parts with the data URL in a `url` field and **hardcodes `mediaType:"image/png"`** regardless of actual format. This created three downstream failures:

| # | File | Problem |
|---|------|---------|
| 1 | `chat-helpers.ts` | `processMessagePart` only handled `type:"image"` and `type:"text"` — image file parts were silently dropped from DB saves |
| 2 | `attachment-storage-service.ts` | `processMessagesWithAttachments` didn't detect `type:"file"` parts with data URLs, so the wrong `mediaType:"image/png"` reached the AI provider for JPEG/WebP uploads |
| 3 | `nexus/page.tsx` | `customFetch` had no 5xx handler — when the server returned a 500, the AI SDK tried to parse the JSON error body as an SSE stream and crashed with an unhandled `TypeError` |

## Changes

- **`app/api/nexus/chat/chat-helpers.ts`** — `processMessagePart` now detects `type:"file"` parts whose `mediaType` or `url` indicates an image and serialises them as image metadata in the DB
- **`lib/services/attachment-storage-service.ts`** — `processMessagesWithAttachments` now detects `type:"file"` parts with a `data:` URL, extracts the actual MIME type from the URL prefix (e.g. `image/jpeg`), and updates the `mediaType` field before messages reach the AI provider. Adds `extractDataUrlMediaType` helper with MIME allowlist and CRLF guard.
- **`app/(protected)/nexus/page.tsx`** — `customFetch` now intercepts 5xx responses, shows a user-friendly toast (capped at 200 chars), and throws a proper `Error` so the AI SDK can clean up rather than crashing with an unhandled rejection
- **`tests/unit/api/nexus/chat-helpers-image-file.test.ts`** — unit tests for the `extractUserContent` fix
- **`tests/unit/lib/attachment-storage-image-mediatype.test.ts`** — unit tests for the mediaType correction logic, including security cases (CRLF injection, non-image MIME types)

## Test Plan
- [x] Unit tests added for `processMessagePart` with `type:"file"` image parts
- [x] Unit tests added for `processMessagesWithAttachments` mediaType correction
- [x] Security audit passed (see audit comment)
- [ ] Manual: upload JPEG, PNG, WebP to Nexus at various conversation depths
- [ ] Manual: verify console shows no TypeError on image upload
- [ ] Manual: verify correct MIME type reaches AI provider (check server logs)
- [ ] Regression: verify image generation model flow unaffected
- [ ] Human review

Closes #940

---
*Opened by the lfg routine.*