### PR TITLE
feat(agent-platform): deep telemetry, dashboard tabs, email triage

### DIFF
--- a/actions/admin/agent-conversations.actions.ts
+++ b/actions/admin/agent-conversations.actions.ts
@@ -120,8 +120,10 @@ export async function listAgentConversations(
     )
 
     // Tool-call counts in one extra query, then merge.
+    // Use Object.create(null) to avoid prototype pollution from DB-sourced
+    // sessionId keys (see docs/guides/silent-failure-patterns.md).
     const sessionIds = rows.map((r) => r.sessionId)
-    let toolCounts: Record<string, number> = {}
+    const toolCounts: Record<string, number> = Object.create(null)
     if (sessionIds.length > 0) {
       const toolRows = await executeQuery(
         (db) =>
@@ -135,7 +137,7 @@ export async function listAgentConversations(
             .groupBy(agentToolInvocations.sessionId),
         "agentConversations.toolCounts",
       )
-      toolCounts = Object.fromEntries(toolRows.map((r) => [r.sessionId, r.count]))
+      for (const r of toolRows) toolCounts[r.sessionId] = r.count
     }
 
     const items: ConversationListItem[] = rows.map((r) => ({

--- a/actions/admin/agent-conversations.actions.ts
+++ b/actions/admin/agent-conversations.actions.ts
@@ -34,7 +34,7 @@ export interface ConversationListItem {
   totalInputTokens: number
   totalOutputTokens: number
   models: string[]
-  hasError: boolean
+  hasGuardrailBlock: boolean
 }
 
 export interface ConversationDetailMessage {
@@ -109,7 +109,7 @@ export async function listAgentConversations(
             totalInputTokens: sql<number>`COALESCE(SUM(${agentMessages.inputTokens}), 0)::int`,
             totalOutputTokens: sql<number>`COALESCE(SUM(${agentMessages.outputTokens}), 0)::int`,
             models: sql<string[]>`array_remove(array_agg(DISTINCT ${agentMessages.model}), NULL)`,
-            hasError: sql<boolean>`bool_or(${agentMessages.guardrailBlocked})`,
+            hasGuardrailBlock: sql<boolean>`bool_or(${agentMessages.guardrailBlocked})`,
           })
           .from(agentMessages)
           .where(conditions)
@@ -155,7 +155,7 @@ export async function listAgentConversations(
       totalInputTokens: r.totalInputTokens,
       totalOutputTokens: r.totalOutputTokens,
       models: r.models ?? [],
-      hasError: r.hasError ?? false,
+      hasGuardrailBlock: r.hasGuardrailBlock ?? false,
     }))
 
     timer({ status: "success" })
@@ -204,6 +204,10 @@ export async function getAgentConversationDetail(
 
     // Content + tool queries are independent — run in parallel to cut
     // latency by ~2x (both keyed by sessionId, no dependency).
+    // Limits prevent an extremely long session (500+ turns at 64KB/row)
+    // from pulling 32MB+ into ECS memory.
+    const CONTENT_LIMIT = 500
+    const TOOL_LIMIT = 1000
     const [contentRows, toolRows] = await Promise.all([
       executeQuery(
         (db) =>
@@ -211,7 +215,8 @@ export async function getAgentConversationDetail(
             .select()
             .from(agentMessageContent)
             .where(eq(agentMessageContent.sessionId, sessionId))
-            .orderBy(agentMessageContent.createdAt),
+            .orderBy(agentMessageContent.createdAt)
+            .limit(CONTENT_LIMIT),
         "agentConversations.detail.content",
       ),
       executeQuery(
@@ -220,7 +225,8 @@ export async function getAgentConversationDetail(
             .select()
             .from(agentToolInvocations)
             .where(eq(agentToolInvocations.sessionId, sessionId))
-            .orderBy(agentToolInvocations.startedAt),
+            .orderBy(agentToolInvocations.startedAt)
+            .limit(TOOL_LIMIT),
         "agentConversations.detail.tools",
       ),
     ])

--- a/actions/admin/agent-conversations.actions.ts
+++ b/actions/admin/agent-conversations.actions.ts
@@ -1,0 +1,277 @@
+"use server"
+
+/**
+ * Admin server actions for the Conversations tab on /admin/agents.
+ *
+ * Reads from agent_messages (summary) + agent_message_content (full text)
+ * + agent_tool_invocations (timeline). Admin-only. Capped queries to
+ * keep the dashboard snappy; deep filtering can be added later when we
+ * see what admins actually search for.
+ *
+ * Privacy contract: viewing requires the `administrator` role. The tables
+ * have a 90-day retention sweep (see agent-telemetry-prune Lambda) so
+ * the blast radius is bounded.
+ */
+
+import { and, desc, eq, gte, sql } from "drizzle-orm"
+
+import { requireRole } from "@/lib/auth/role-helpers"
+import { handleError, createSuccess } from "@/lib/error-utils"
+import { createLogger, generateRequestId, startTimer } from "@/lib/logger"
+import { executeQuery } from "@/lib/db/drizzle-client"
+import { agentMessages } from "@/lib/db/schema/tables/agent-messages"
+import { agentMessageContent } from "@/lib/db/schema/tables/agent-message-content"
+import { agentToolInvocations } from "@/lib/db/schema/tables/agent-tool-invocations"
+import type { ActionState } from "@/types"
+
+export interface ConversationListItem {
+  sessionId: string
+  userId: string
+  startedAt: string
+  lastTurnAt: string
+  turnCount: number
+  toolCallCount: number
+  totalInputTokens: number
+  totalOutputTokens: number
+  models: string[]
+  hasError: boolean
+}
+
+export interface ConversationDetailMessage {
+  role: string
+  contentText: string
+  contentTruncated: boolean
+  createdAt: string
+}
+
+export interface ConversationDetailTool {
+  toolName: string
+  status: string
+  errorText: string | null
+  durationMs: number
+  startedAt: string
+  finishedAt: string
+  toolArgs: Record<string, unknown> | null
+  toolResult: Record<string, unknown> | null
+}
+
+export interface ConversationDetail {
+  sessionId: string
+  userId: string
+  turns: Array<{
+    messageId: number
+    model: string | null
+    createdAt: string
+    latencyMs: number
+    inputTokens: number
+    outputTokens: number
+    messages: ConversationDetailMessage[]
+    tools: ConversationDetailTool[]
+  }>
+}
+
+const DEFAULT_DAYS = 7
+
+/**
+ * List sessions, newest activity first. Each row is one session with
+ * aggregated counters across all of its turns. Defaults to the last 7
+ * days so the table stays fast; admin can scope wider via filters.
+ */
+export async function listAgentConversations(
+  daysBack: number = DEFAULT_DAYS,
+  userIdFilter?: string,
+): Promise<ActionState<ConversationListItem[]>> {
+  const requestId = generateRequestId()
+  const timer = startTimer("listAgentConversations")
+  const log = createLogger({ requestId, action: "listAgentConversations" })
+
+  try {
+    await requireRole("administrator")
+    const days = Math.min(Math.max(1, daysBack), 90)
+    const cutoff = new Date(Date.now() - days * 86400_000)
+
+    const conditions = userIdFilter
+      ? and(
+          gte(agentMessages.createdAt, cutoff),
+          eq(agentMessages.userId, userIdFilter.toLowerCase()),
+        )
+      : gte(agentMessages.createdAt, cutoff)
+
+    const rows = await executeQuery(
+      (db) =>
+        db
+          .select({
+            sessionId: agentMessages.sessionId,
+            userId: agentMessages.userId,
+            startedAt: sql<string>`MIN(${agentMessages.createdAt})::text`,
+            lastTurnAt: sql<string>`MAX(${agentMessages.createdAt})::text`,
+            turnCount: sql<number>`COUNT(*)::int`,
+            totalInputTokens: sql<number>`COALESCE(SUM(${agentMessages.inputTokens}), 0)::int`,
+            totalOutputTokens: sql<number>`COALESCE(SUM(${agentMessages.outputTokens}), 0)::int`,
+            models: sql<string[]>`array_remove(array_agg(DISTINCT ${agentMessages.model}), NULL)`,
+            hasError: sql<boolean>`bool_or(${agentMessages.guardrailBlocked})`,
+          })
+          .from(agentMessages)
+          .where(conditions)
+          .groupBy(agentMessages.sessionId, agentMessages.userId)
+          .orderBy(desc(sql`MAX(${agentMessages.createdAt})`))
+          .limit(200),
+      "agentConversations.list",
+    )
+
+    // Tool-call counts in one extra query, then merge.
+    const sessionIds = rows.map((r) => r.sessionId)
+    let toolCounts: Record<string, number> = {}
+    if (sessionIds.length > 0) {
+      const toolRows = await executeQuery(
+        (db) =>
+          db
+            .select({
+              sessionId: agentToolInvocations.sessionId,
+              count: sql<number>`COUNT(*)::int`,
+            })
+            .from(agentToolInvocations)
+            .where(gte(agentToolInvocations.startedAt, cutoff))
+            .groupBy(agentToolInvocations.sessionId),
+        "agentConversations.toolCounts",
+      )
+      toolCounts = Object.fromEntries(toolRows.map((r) => [r.sessionId, r.count]))
+    }
+
+    const items: ConversationListItem[] = rows.map((r) => ({
+      sessionId: r.sessionId,
+      userId: r.userId,
+      startedAt: r.startedAt,
+      lastTurnAt: r.lastTurnAt,
+      turnCount: r.turnCount,
+      toolCallCount: toolCounts[r.sessionId] ?? 0,
+      totalInputTokens: r.totalInputTokens,
+      totalOutputTokens: r.totalOutputTokens,
+      models: r.models ?? [],
+      hasError: r.hasError ?? false,
+    }))
+
+    timer({ status: "success" })
+    log.info("Listed conversations", { count: items.length, days })
+    return createSuccess(items)
+  } catch (error) {
+    timer({ status: "error" })
+    return handleError(error, "Failed to list agent conversations", {
+      context: "listAgentConversations",
+      requestId,
+      operation: "listAgentConversations",
+    })
+  }
+}
+
+/**
+ * Full transcript + tool timeline for one session. Joins
+ * agent_messages → agent_message_content → agent_tool_invocations and
+ * groups by turn (message_id). Ordered chronologically within each turn.
+ */
+export async function getAgentConversationDetail(
+  sessionId: string,
+): Promise<ActionState<ConversationDetail | null>> {
+  const requestId = generateRequestId()
+  const timer = startTimer("getAgentConversationDetail")
+  const log = createLogger({ requestId, action: "getAgentConversationDetail" })
+
+  try {
+    await requireRole("administrator")
+    if (!sessionId.trim()) {
+      return createSuccess(null, "No session id provided")
+    }
+
+    const turnRows = await executeQuery(
+      (db) =>
+        db
+          .select()
+          .from(agentMessages)
+          .where(eq(agentMessages.sessionId, sessionId))
+          .orderBy(agentMessages.createdAt),
+      "agentConversations.detail.turns",
+    )
+    if (turnRows.length === 0) {
+      return createSuccess(null, "Session not found")
+    }
+
+    const contentRows = await executeQuery(
+      (db) =>
+        db
+          .select()
+          .from(agentMessageContent)
+          .where(eq(agentMessageContent.sessionId, sessionId))
+          .orderBy(agentMessageContent.createdAt),
+      "agentConversations.detail.content",
+    )
+    const toolRows = await executeQuery(
+      (db) =>
+        db
+          .select()
+          .from(agentToolInvocations)
+          .where(eq(agentToolInvocations.sessionId, sessionId))
+          .orderBy(agentToolInvocations.startedAt),
+      "agentConversations.detail.tools",
+    )
+
+    // Group by messageId so the UI can render per-turn nicely.
+    const byMessage = new Map<number, { messages: ConversationDetailMessage[]; tools: ConversationDetailTool[] }>()
+    for (const t of turnRows) byMessage.set(t.id, { messages: [], tools: [] })
+    for (const c of contentRows) {
+      const bucket = byMessage.get(c.messageId) ?? { messages: [], tools: [] }
+      bucket.messages.push({
+        role: c.role,
+        contentText: c.contentText,
+        contentTruncated: c.contentTruncated,
+        createdAt: c.createdAt.toISOString(),
+      })
+      byMessage.set(c.messageId, bucket)
+    }
+    for (const t of toolRows) {
+      const bucket = byMessage.get(t.messageId) ?? { messages: [], tools: [] }
+      bucket.tools.push({
+        toolName: t.toolName,
+        status: t.status,
+        errorText: t.errorText,
+        durationMs: t.durationMs,
+        startedAt: t.startedAt.toISOString(),
+        finishedAt: t.finishedAt.toISOString(),
+        toolArgs: t.toolArgs ?? null,
+        toolResult: t.toolResult ?? null,
+      })
+      byMessage.set(t.messageId, bucket)
+    }
+
+    const detail: ConversationDetail = {
+      sessionId,
+      userId: turnRows[0].userId,
+      turns: turnRows.map((t) => {
+        const bucket = byMessage.get(t.id) ?? { messages: [], tools: [] }
+        return {
+          messageId: t.id,
+          model: t.model,
+          createdAt: t.createdAt.toISOString(),
+          latencyMs: t.latencyMs,
+          inputTokens: t.inputTokens,
+          outputTokens: t.outputTokens,
+          messages: bucket.messages,
+          tools: bucket.tools,
+        }
+      }),
+    }
+
+    timer({ status: "success" })
+    log.info("Fetched conversation detail", {
+      sessionId,
+      turns: detail.turns.length,
+    })
+    return createSuccess(detail)
+  } catch (error) {
+    timer({ status: "error" })
+    return handleError(error, "Failed to fetch conversation detail", {
+      context: "getAgentConversationDetail",
+      requestId,
+      operation: "getAgentConversationDetail",
+    })
+  }
+}

--- a/actions/admin/agent-conversations.actions.ts
+++ b/actions/admin/agent-conversations.actions.ts
@@ -13,11 +13,11 @@
  * the blast radius is bounded.
  */
 
-import { and, desc, eq, gte, sql } from "drizzle-orm"
+import { and, desc, eq, gte, inArray, sql } from "drizzle-orm"
 
 import { requireRole } from "@/lib/auth/role-helpers"
 import { handleError, createSuccess } from "@/lib/error-utils"
-import { createLogger, generateRequestId, startTimer } from "@/lib/logger"
+import { createLogger, generateRequestId, startTimer, sanitizeForLogging } from "@/lib/logger"
 import { executeQuery } from "@/lib/db/drizzle-client"
 import { agentMessages } from "@/lib/db/schema/tables/agent-messages"
 import { agentMessageContent } from "@/lib/db/schema/tables/agent-message-content"
@@ -133,7 +133,12 @@ export async function listAgentConversations(
               count: sql<number>`COUNT(*)::int`,
             })
             .from(agentToolInvocations)
-            .where(gte(agentToolInvocations.startedAt, cutoff))
+            .where(
+              and(
+                gte(agentToolInvocations.startedAt, cutoff),
+                inArray(agentToolInvocations.sessionId, sessionIds),
+              ),
+            )
             .groupBy(agentToolInvocations.sessionId),
         "agentConversations.toolCounts",
       )
@@ -197,24 +202,28 @@ export async function getAgentConversationDetail(
       return createSuccess(null, "Session not found")
     }
 
-    const contentRows = await executeQuery(
-      (db) =>
-        db
-          .select()
-          .from(agentMessageContent)
-          .where(eq(agentMessageContent.sessionId, sessionId))
-          .orderBy(agentMessageContent.createdAt),
-      "agentConversations.detail.content",
-    )
-    const toolRows = await executeQuery(
-      (db) =>
-        db
-          .select()
-          .from(agentToolInvocations)
-          .where(eq(agentToolInvocations.sessionId, sessionId))
-          .orderBy(agentToolInvocations.startedAt),
-      "agentConversations.detail.tools",
-    )
+    // Content + tool queries are independent — run in parallel to cut
+    // latency by ~2x (both keyed by sessionId, no dependency).
+    const [contentRows, toolRows] = await Promise.all([
+      executeQuery(
+        (db) =>
+          db
+            .select()
+            .from(agentMessageContent)
+            .where(eq(agentMessageContent.sessionId, sessionId))
+            .orderBy(agentMessageContent.createdAt),
+        "agentConversations.detail.content",
+      ),
+      executeQuery(
+        (db) =>
+          db
+            .select()
+            .from(agentToolInvocations)
+            .where(eq(agentToolInvocations.sessionId, sessionId))
+            .orderBy(agentToolInvocations.startedAt),
+        "agentConversations.detail.tools",
+      ),
+    ])
 
     // Group by messageId so the UI can render per-turn nicely.
     const byMessage = new Map<number, { messages: ConversationDetailMessage[]; tools: ConversationDetailTool[] }>()
@@ -263,10 +272,10 @@ export async function getAgentConversationDetail(
     }
 
     timer({ status: "success" })
-    log.info("Fetched conversation detail", {
+    log.info("Fetched conversation detail", sanitizeForLogging({
       sessionId,
       turns: detail.turns.length,
-    })
+    }))
     return createSuccess(detail)
   } catch (error) {
     timer({ status: "error" })

--- a/actions/admin/agent-conversations.actions.ts
+++ b/actions/admin/agent-conversations.actions.ts
@@ -252,7 +252,7 @@ export async function getAgentConversationDetail(
         errorText: t.errorText,
         durationMs: t.durationMs,
         startedAt: t.startedAt.toISOString(),
-        finishedAt: t.finishedAt.toISOString(),
+        finishedAt: t.finishedAt?.toISOString() ?? t.startedAt.toISOString(),
         toolArgs: t.toolArgs ?? null,
         toolResult: t.toolResult ?? null,
       })

--- a/actions/admin/agent-credentials.actions.ts
+++ b/actions/admin/agent-credentials.actions.ts
@@ -4,8 +4,8 @@ import { createLogger, generateRequestId, startTimer, sanitizeForLogging } from 
 import { handleError, createSuccess } from "@/lib/error-utils"
 import type { ActionState } from "@/types"
 import { requireRole } from "@/lib/auth/role-helpers"
-import { executeQuery } from "@/lib/db/drizzle-client"
-import { desc, eq } from "drizzle-orm"
+import { executeQuery, executeTransaction } from "@/lib/db/drizzle-client"
+import { and, desc, eq } from "drizzle-orm"
 import { isRedirectError } from "next/dist/client/components/redirect-error"
 import { psdAgentCredentialsAudit } from "@/lib/db/schema/tables/agent-credentials-audit"
 import { psdAgentCredentialReads } from "@/lib/db/schema/tables/agent-credential-reads"
@@ -293,6 +293,10 @@ export async function logCredentialProvisioningAction(
 
 // Lowercase alphanumeric, hyphens, and underscores; must start with a letter (1-128 chars)
 const CREDENTIAL_NAME_RE = /^[a-z][\d_a-z-]{0,127}$/
+// Sanitize requestedBy for safe inclusion in Secrets Manager paths — prevent
+// directory traversal (e.g. `attacker@x.com/../shared`). Only allow
+// characters that appear in email addresses + reasonable identifiers.
+const SAFE_PATH_SEGMENT_RE = /^[\w.@-]+$/
 
 // Module-scoped client — reuses the HTTP connection pool across calls
 let _smClient: InstanceType<typeof import("@aws-sdk/client-secrets-manager").SecretsManagerClient> | null = null
@@ -396,6 +400,15 @@ export async function provisionCredentialFromRequest(
     )
     if (validationError) return validationError
 
+    // Validate requestedBy to prevent directory traversal in the secret path
+    if (!SAFE_PATH_SEGMENT_RE.test(request.requestedBy)) {
+      return handleError(
+        new Error("Invalid requestedBy"),
+        "The requesting user's identifier contains invalid characters.",
+        { context: "provisionCredentialFromRequest", requestId: rid, operation: "provisionCredentialFromRequest" },
+      )
+    }
+
     const environment = process.env.ENVIRONMENT ?? process.env.DEPLOY_ENVIRONMENT ?? "dev"
     const secretId =
       scope === "user"
@@ -424,14 +437,14 @@ export async function provisionCredentialFromRequest(
         ResourceNotFoundException,
       } = await import("@aws-sdk/client-secrets-manager")
       const client = await getProvisionSecretsClient()
+      // Tags must align with the ECS task role's TagKeys condition
+      // (Environment, ManagedBy, OwnerEmail) — see ecs-service.ts.
+      // Extra tags like costCenter/requestedBy/scope would cause
+      // AccessDenied from the IAM boundary.
       const tags = [
         { Key: "Environment", Value: environment },
         { Key: "ManagedBy", Value: "aistudio" },
-        { Key: "costCenter", Value: "ai-agents" },
-        { Key: "requestedBy", Value: request.requestedBy },
-        ...(scope === "user"
-          ? [{ Key: "scope", Value: "user" }]
-          : [{ Key: "scope", Value: "shared" }]),
+        { Key: "OwnerEmail", Value: request.requestedBy },
       ]
       try {
         await client.send(
@@ -467,12 +480,13 @@ export async function provisionCredentialFromRequest(
       }
     }
 
-    // Step 3 + 4: flip request to fulfilled + write audit entry. Best-
-    // effort if the audit insert fails; the row update is the
-    // load-bearing one.
-    await executeQuery(
-      (db) =>
-        db
+    // Step 3 + 4: atomically flip request to fulfilled + write audit
+    // entry. The WHERE includes status='pending' so a concurrent admin
+    // clicking the same button gets a clean "already fulfilled" error
+    // instead of silently overwriting the secret.
+    const updated = await executeTransaction(
+      async (tx) => {
+        const result = await tx
           .update(psdAgentCredentialRequests)
           .set({
             status: "fulfilled",
@@ -480,20 +494,34 @@ export async function provisionCredentialFromRequest(
             resolvedAt: new Date(),
             updatedAt: new Date(),
           })
-          .where(eq(psdAgentCredentialRequests.id, requestId)),
-      "agentCredentials.markFulfilled",
-    )
-    await executeQuery(
-      (db) =>
-        db.insert(psdAgentCredentialsAudit).values({
+          .where(
+            and(
+              eq(psdAgentCredentialRequests.id, requestId),
+              eq(psdAgentCredentialRequests.status, "pending"),
+            ),
+          )
+          .returning({ id: psdAgentCredentialRequests.id })
+        if (result.length === 0) {
+          throw new Error("Request is no longer pending — another admin may have already provisioned it.")
+        }
+        await tx.insert(psdAgentCredentialsAudit).values({
           credentialName: request.credentialName,
           scope,
           action,
           actorUserId: adminUserId,
           details: { secretId, requestId, requestedBy: request.requestedBy },
-        }),
-      "agentCredentials.provisionAuditFromRequest",
+        })
+        return result
+      },
+      "agentCredentials.fulfillAndAudit",
     )
+    if (updated.length === 0) {
+      return handleError(
+        new Error("Concurrent provisioning"),
+        "Request was already fulfilled by another admin. Reload and verify.",
+        { context: "provisionCredentialFromRequest", requestId: rid, operation: "provisionCredentialFromRequest" },
+      )
+    }
 
     timer({ status: "success" })
     return createSuccess(

--- a/actions/admin/agent-credentials.actions.ts
+++ b/actions/admin/agent-credentials.actions.ts
@@ -533,6 +533,12 @@ export async function provisionCredentialFromRequest(
   } catch (error) {
     if (isRedirectError(error)) throw error
     timer({ status: "error" })
+    // NOTE: Partial consistency window — if the DB transaction threw after
+    // the Secrets Manager write succeeded, the secret exists in AWS but the
+    // request row is still 'pending'. This is safe: a retry will hit the
+    // PutSecretValueCommand path (rotation), overwrite the value, and the
+    // DB transaction will succeed on the second attempt. The audit trail
+    // will only record the successful attempt.
     return handleError(error, "Failed to provision credential from request", {
       context: "provisionCredentialFromRequest",
       requestId: rid,

--- a/actions/admin/agent-credentials.actions.ts
+++ b/actions/admin/agent-credentials.actions.ts
@@ -361,10 +361,15 @@ export async function provisionCredentialFromRequest(
   const rid = generateRequestId()
   const timer = startTimer("provisionCredentialFromRequest")
   const log = createLogger({ requestId: rid, action: "provisionCredentialFromRequest" })
+  // Track whether the Secrets Manager write succeeded for partial-consistency detection
+  let smWriteSucceeded = false
+  let secretIdForErrorLog = ""
+  let adminUserIdForErrorLog: number | string = ""
 
   try {
     const currentUser = await requireRole("administrator")
     const adminUserId = currentUser.user.id
+    adminUserIdForErrorLog = adminUserId
 
     // Step 1: Load the request row.
     const rows = await executeQuery(
@@ -414,6 +419,7 @@ export async function provisionCredentialFromRequest(
       scope === "user"
         ? `psd-agent-creds/${environment}/user/${request.requestedBy}/${request.credentialName}`
         : `psd-agent-creds/${environment}/shared/${request.credentialName}`
+    secretIdForErrorLog = secretId
 
     log.info("Provisioning credential from request", {
       requestId,
@@ -452,6 +458,7 @@ export async function provisionCredentialFromRequest(
         )
         await client.send(new TagResourceCommand({ SecretId: secretId, Tags: tags }))
         action = "rotated"
+        smWriteSucceeded = true
         log.info("Secret rotated", { secretId })
       } catch (putError) {
         if (!(putError instanceof ResourceNotFoundException)) throw putError
@@ -465,6 +472,7 @@ export async function provisionCredentialFromRequest(
             }),
           )
           action = "created"
+          smWriteSucceeded = true
           log.info("Secret created", { secretId })
         } catch (createError: unknown) {
           if (!(createError instanceof Error) || createError.name !== "ResourceExistsException") {
@@ -475,6 +483,7 @@ export async function provisionCredentialFromRequest(
           )
           await client.send(new TagResourceCommand({ SecretId: secretId, Tags: tags }))
           action = "rotated"
+          smWriteSucceeded = true
           log.info("Secret rotated (race recovery)", { secretId })
         }
       }
@@ -533,12 +542,20 @@ export async function provisionCredentialFromRequest(
   } catch (error) {
     if (isRedirectError(error)) throw error
     timer({ status: "error" })
-    // NOTE: Partial consistency window — if the DB transaction threw after
+    // Partial consistency window — if the DB transaction threw after
     // the Secrets Manager write succeeded, the secret exists in AWS but the
-    // request row is still 'pending'. This is safe: a retry will hit the
-    // PutSecretValueCommand path (rotation), overwrite the value, and the
-    // DB transaction will succeed on the second attempt. The audit trail
-    // will only record the successful attempt.
+    // request row is still 'pending'. A retry will hit the
+    // PutSecretValueCommand path (rotation) and succeed. Emit a structured
+    // error so CloudWatch Alarms can detect this state.
+    if (smWriteSucceeded) {
+      log.error("PARTIAL_CONSISTENCY: Secrets Manager write succeeded but DB transaction failed", {
+        secretId: secretIdForErrorLog,
+        requestId,
+        scope,
+        adminUserId: adminUserIdForErrorLog,
+        error: error instanceof Error ? error.message : String(error),
+      })
+    }
     return handleError(error, "Failed to provision credential from request", {
       context: "provisionCredentialFromRequest",
       requestId: rid,

--- a/actions/admin/agent-credentials.actions.ts
+++ b/actions/admin/agent-credentials.actions.ts
@@ -331,6 +331,188 @@ function validateSecretInputs(name: string, value: string, requestId: string): A
   return null
 }
 
+/**
+ * Provision the secret for a pending credential request in one atomic
+ * admin action:
+ *   1. Load the pending request row (must be status='pending').
+ *   2. Write the secret value to AWS Secrets Manager at the right path
+ *      (shared OR user scope, per the admin's choice in the modal).
+ *   3. Mark the request `fulfilled` with the admin's identity.
+ *   4. Write an audit entry.
+ *
+ * The previous flow let admins flip the request to `fulfilled` without
+ * ever creating the secret — the agent would then keep failing because
+ * the path it expected didn't exist. This action keeps the two writes
+ * coupled so the row never lies.
+ *
+ * `scope` defaults to `shared`. Use `user` when the credential is
+ * per-user (e.g. someone's personal GitHub PAT) — the secret then lands
+ * at `psd-agent-creds/<env>/user/<requestedBy>/<credentialName>`.
+ */
+export async function provisionCredentialFromRequest(
+  requestId: number,
+  secretValue: string,
+  scope: "shared" | "user" = "shared",
+): Promise<ActionState<{ secretId: string; action: "created" | "rotated" }>> {
+  const rid = generateRequestId()
+  const timer = startTimer("provisionCredentialFromRequest")
+  const log = createLogger({ requestId: rid, action: "provisionCredentialFromRequest" })
+
+  try {
+    const currentUser = await requireRole("administrator")
+    const adminUserId = currentUser.user.id
+
+    // Step 1: Load the request row.
+    const rows = await executeQuery(
+      (db) =>
+        db
+          .select()
+          .from(psdAgentCredentialRequests)
+          .where(eq(psdAgentCredentialRequests.id, requestId))
+          .limit(1),
+      "agentCredentials.loadRequest",
+    )
+    if (rows.length === 0) {
+      return handleError(
+        new Error("Request not found"),
+        "Credential request not found.",
+        { context: "provisionCredentialFromRequest", requestId: rid, operation: "provisionCredentialFromRequest" },
+      )
+    }
+    const request = rows[0]
+    if (request.status !== "pending") {
+      return handleError(
+        new Error("Request not pending"),
+        `Request is already ${request.status}. Reload and try again if you need to re-provision.`,
+        { context: "provisionCredentialFromRequest", requestId: rid, operation: "provisionCredentialFromRequest" },
+      )
+    }
+
+    // Validate inputs against the same rules as provisionSharedSecret.
+    const validationError = validateSecretInputs(
+      request.credentialName,
+      secretValue,
+      rid,
+    )
+    if (validationError) return validationError
+
+    const environment = process.env.ENVIRONMENT ?? process.env.DEPLOY_ENVIRONMENT ?? "dev"
+    const secretId =
+      scope === "user"
+        ? `psd-agent-creds/${environment}/user/${request.requestedBy}/${request.credentialName}`
+        : `psd-agent-creds/${environment}/shared/${request.credentialName}`
+
+    log.info("Provisioning credential from request", {
+      requestId,
+      secretId,
+      scope,
+      adminUserId,
+    })
+
+    let action: "created" | "rotated"
+
+    if (process.env.NODE_ENV === "development") {
+      // Local dev shortcut — skip the actual Secrets Manager write so
+      // contributors can iterate on the UI without AWS creds.
+      log.info("Local dev — skipping Secrets Manager write", { secretId })
+      action = "created"
+    } else {
+      const {
+        PutSecretValueCommand,
+        CreateSecretCommand,
+        TagResourceCommand,
+        ResourceNotFoundException,
+      } = await import("@aws-sdk/client-secrets-manager")
+      const client = await getProvisionSecretsClient()
+      const tags = [
+        { Key: "Environment", Value: environment },
+        { Key: "ManagedBy", Value: "aistudio" },
+        { Key: "costCenter", Value: "ai-agents" },
+        { Key: "requestedBy", Value: request.requestedBy },
+        ...(scope === "user"
+          ? [{ Key: "scope", Value: "user" }]
+          : [{ Key: "scope", Value: "shared" }]),
+      ]
+      try {
+        await client.send(
+          new PutSecretValueCommand({ SecretId: secretId, SecretString: secretValue }),
+        )
+        await client.send(new TagResourceCommand({ SecretId: secretId, Tags: tags }))
+        action = "rotated"
+        log.info("Secret rotated", { secretId })
+      } catch (putError) {
+        if (!(putError instanceof ResourceNotFoundException)) throw putError
+        try {
+          await client.send(
+            new CreateSecretCommand({
+              Name: secretId,
+              SecretString: secretValue,
+              Description: `Agent credential ${request.credentialName} (${scope}) — request #${requestId}`,
+              Tags: tags,
+            }),
+          )
+          action = "created"
+          log.info("Secret created", { secretId })
+        } catch (createError: unknown) {
+          if (!(createError instanceof Error) || createError.name !== "ResourceExistsException") {
+            throw createError
+          }
+          await client.send(
+            new PutSecretValueCommand({ SecretId: secretId, SecretString: secretValue }),
+          )
+          await client.send(new TagResourceCommand({ SecretId: secretId, Tags: tags }))
+          action = "rotated"
+          log.info("Secret rotated (race recovery)", { secretId })
+        }
+      }
+    }
+
+    // Step 3 + 4: flip request to fulfilled + write audit entry. Best-
+    // effort if the audit insert fails; the row update is the
+    // load-bearing one.
+    await executeQuery(
+      (db) =>
+        db
+          .update(psdAgentCredentialRequests)
+          .set({
+            status: "fulfilled",
+            resolvedBy: adminUserId,
+            resolvedAt: new Date(),
+            updatedAt: new Date(),
+          })
+          .where(eq(psdAgentCredentialRequests.id, requestId)),
+      "agentCredentials.markFulfilled",
+    )
+    await executeQuery(
+      (db) =>
+        db.insert(psdAgentCredentialsAudit).values({
+          credentialName: request.credentialName,
+          scope,
+          action,
+          actorUserId: adminUserId,
+          details: { secretId, requestId, requestedBy: request.requestedBy },
+        }),
+      "agentCredentials.provisionAuditFromRequest",
+    )
+
+    timer({ status: "success" })
+    return createSuccess(
+      { secretId, action },
+      action === "created"
+        ? `Provisioned secret ${secretId} and marked request fulfilled.`
+        : `Rotated existing secret ${secretId} and marked request fulfilled.`,
+    )
+  } catch (error) {
+    if (isRedirectError(error)) throw error
+    timer({ status: "error" })
+    return handleError(error, "Failed to provision credential from request", {
+      context: "provisionCredentialFromRequest",
+      requestId: rid,
+      operation: "provisionCredentialFromRequest",
+    })
+  }
+}
+
 /** Provision (create or rotate) a shared secret in AWS Secrets Manager. */
 export async function provisionSharedSecret(
   name: string,

--- a/actions/admin/agent-health.actions.ts
+++ b/actions/admin/agent-health.actions.ts
@@ -6,10 +6,11 @@ import type { ActionState } from "@/types"
 import { requireRole } from "@/lib/auth/role-helpers"
 import { executeQuery } from "@/lib/db/drizzle-client"
 import { stripJsonQuotes, pgTimestampAsText } from "@/lib/db/drizzle-helpers"
-import { sql, desc, eq } from "drizzle-orm"
+import { and, desc, eq, gte, isNotNull, sql } from "drizzle-orm"
 import { agentHealthSnapshots } from "@/lib/db/schema/tables/agent-health-snapshots"
 import { agentPatterns } from "@/lib/db/schema/tables/agent-patterns"
 import { agentHealthScanRuns } from "@/lib/db/schema/tables/agent-health-scan-runs"
+import { agentMessages } from "@/lib/db/schema/tables/agent-messages"
 import { agentPatternScanRuns } from "@/lib/db/schema/tables/agent-pattern-scan-runs"
 
 export interface AgentHealthRow {
@@ -319,6 +320,117 @@ export async function getAgentPatterns(
       context: "getAgentPatterns",
       requestId,
       operation: "getAgentPatterns",
+    })
+  }
+}
+
+export interface RawSignalRow {
+  topic: string
+  signalCount: number
+  uniqueUsers: number
+  lastSeenAt: string
+}
+
+export interface RawSignalsEnvelope {
+  rows: RawSignalRow[]
+  daysBack: number
+  totalMessages: number
+  classifiedMessages: number
+  unclassifiedMessages: number
+}
+
+/**
+ * Raw signal volume by topic over the last N days, straight from
+ * agent_messages.topic. Bypasses the pattern scanner's suppression
+ * threshold so admins can see what the topic classifier actually
+ * catches in real traffic — useful for tuning the classifier's
+ * keyword patterns and for sanity-checking the Patterns panel when
+ * it's empty.
+ *
+ * Returns both per-topic counts AND the unclassified count so admins
+ * can see classifier coverage rate. Privacy: per-topic counts cross
+ * many users; we don't return per-user counts (would defeat the
+ * cross-building privacy guarantee).
+ */
+export async function getAgentRawSignals(
+  daysBack = 7,
+): Promise<ActionState<RawSignalsEnvelope>> {
+  const requestId = generateRequestId()
+  const timer = startTimer("getAgentRawSignals")
+  const log = createLogger({ requestId, action: "getAgentRawSignals" })
+
+  try {
+    await requireRole("administrator")
+    const safeDays = Math.min(Math.max(1, daysBack), 90)
+    const cutoff = new Date(Date.now() - safeDays * 86400_000)
+
+    const [perTopic, totals] = await Promise.all([
+      executeQuery(
+        (db) =>
+          db
+            .select({
+              topic: agentMessages.topic,
+              signalCount: sql<number>`COUNT(*)::int`,
+              uniqueUsers: sql<number>`COUNT(DISTINCT ${agentMessages.userId})::int`,
+              lastSeenAt: sql<string>`MAX(${agentMessages.createdAt})::text`,
+            })
+            .from(agentMessages)
+            .where(
+              and(
+                gte(agentMessages.createdAt, cutoff),
+                isNotNull(agentMessages.topic),
+              ),
+            )
+            .groupBy(agentMessages.topic)
+            .orderBy(desc(sql`COUNT(*)`))
+            .limit(50),
+        "agentMessages.rawSignalsByTopic",
+      ),
+      executeQuery(
+        (db) =>
+          db
+            .select({
+              total: sql<number>`COUNT(*)::int`,
+              classified: sql<number>`COUNT(${agentMessages.topic})::int`,
+            })
+            .from(agentMessages)
+            .where(gte(agentMessages.createdAt, cutoff)),
+        "agentMessages.signalsCoverage",
+      ),
+    ])
+
+    const total = totals[0]?.total ?? 0
+    const classified = totals[0]?.classified ?? 0
+
+    const rows: RawSignalRow[] = perTopic
+      .filter((r) => r.topic !== null)
+      .map((r) => ({
+        topic: r.topic ?? "(null)",
+        signalCount: Number(r.signalCount),
+        uniqueUsers: Number(r.uniqueUsers),
+        lastSeenAt: r.lastSeenAt,
+      }))
+
+    timer({ status: "success" })
+    log.info("Raw signals loaded", {
+      topicsFound: rows.length,
+      daysBack: safeDays,
+      total,
+      classified,
+    })
+    return createSuccess({
+      rows,
+      daysBack: safeDays,
+      totalMessages: total,
+      classifiedMessages: classified,
+      unclassifiedMessages: total - classified,
+    })
+  } catch (error) {
+    timer({ status: "error" })
+    return handleError(error, "Failed to load raw signals", {
+      context: "getAgentRawSignals",
+      requestId,
+      operation: "getAgentRawSignals",
     })
   }
 }

--- a/actions/admin/agent-triage.actions.ts
+++ b/actions/admin/agent-triage.actions.ts
@@ -127,8 +127,14 @@ export async function getTriageSummaryList(): Promise<
           TableName: TRIAGE_TABLE,
           ExclusiveStartKey: lastKey,
           // Only fetch fields needed for TriageSummaryRow — avoids pulling
-          // large recentDecisions / learnedPatterns arrays for every row.
-          ProjectionExpression: "userEmail, enabled, enabledAt, disabledAt, lastPollAt, digestEnabled, rules, escalation, recentDecisions, learnedPatterns",
+          // bulky JSONB blobs that we don't surface in the list view.
+          // `rules` is a DynamoDB RESERVED KEYWORD — must be aliased via
+          // ExpressionAttributeNames or the entire Scan returns
+          // ValidationException and the action returns an empty list. Bug
+          // 2026-05-28: this aliasing was missing on first ship and the
+          // Triage tab silently showed no users despite a populated table.
+          ProjectionExpression: "userEmail, enabled, enabledAt, disabledAt, lastPollAt, digestEnabled, #rules, escalation, recentDecisions, learnedPatterns",
+          ExpressionAttributeNames: { "#rules": "rules" },
         }),
       )
       for (const item of (resp.Items ?? []) as Array<{

--- a/actions/admin/agent-triage.actions.ts
+++ b/actions/admin/agent-triage.actions.ts
@@ -126,6 +126,9 @@ export async function getTriageSummaryList(): Promise<
         new ScanCommand({
           TableName: TRIAGE_TABLE,
           ExclusiveStartKey: lastKey,
+          // Only fetch fields needed for TriageSummaryRow — avoids pulling
+          // large recentDecisions / learnedPatterns arrays for every row.
+          ProjectionExpression: "userEmail, enabled, enabledAt, disabledAt, lastPollAt, digestEnabled, rules, escalation, recentDecisions, learnedPatterns",
         }),
       )
       for (const item of (resp.Items ?? []) as Array<{

--- a/actions/admin/agent-triage.actions.ts
+++ b/actions/admin/agent-triage.actions.ts
@@ -1,0 +1,388 @@
+"use server"
+
+/**
+ * Admin server actions for the email triage feature.
+ *
+ * All actions require the `administrator` role and return `ActionState`.
+ * Backing store is DynamoDB `psd-agent-triage-<env>` — direct AWS SDK
+ * calls rather than going through Drizzle/Postgres because the table
+ * lives in the agent platform stack, not the AI Studio main DB.
+ */
+
+import {
+  DynamoDBClient,
+} from "@aws-sdk/client-dynamodb"
+import {
+  DeleteCommand,
+  DynamoDBDocumentClient,
+  GetCommand,
+  ScanCommand,
+  UpdateCommand,
+} from "@aws-sdk/lib-dynamodb"
+
+import { requireRole } from "@/lib/auth/role-helpers"
+import { handleError, createSuccess } from "@/lib/error-utils"
+import { createLogger, generateRequestId } from "@/lib/logger"
+import type { ActionState } from "@/types"
+
+const REGION = process.env.AWS_REGION ?? "us-east-1"
+const ENVIRONMENT = process.env.ENVIRONMENT ?? "dev"
+const TRIAGE_TABLE = process.env.TRIAGE_TABLE ?? `psd-agent-triage-${ENVIRONMENT}`
+
+let cached: DynamoDBDocumentClient | null = null
+function ddb(): DynamoDBDocumentClient {
+  if (!cached) {
+    cached = DynamoDBDocumentClient.from(new DynamoDBClient({ region: REGION }))
+  }
+  return cached
+}
+
+export interface TriageStateSummary {
+  userEmail: string
+  enabled: boolean
+  enabledAt?: string
+  disabledAt?: string | null
+  labels?: Record<string, string>
+  labelIdsByKey?: Record<string, string>
+  lastHistoryId?: string
+  lastPollAt?: string
+  digest?: {
+    enabled: boolean
+    time?: string
+    tz?: string
+  }
+  counts: {
+    vipSenders: number
+    muteSenders: number
+    keywordRules: number
+    escalationSenders: number
+    escalationKeywords: number
+    recentDecisions: number
+    recentCorrections: number
+    learnedPatterns: number
+  }
+  recentDecisions: Array<{
+    messageId: string
+    label: string
+    source: string
+    reason: string
+    confidence: number
+    ts: string
+    fromEmail: string
+    subject: string
+  }>
+  recentCorrections: Array<{
+    messageId: string
+    fromLabel: string
+    toLabel: string
+    ts: string
+  }>
+}
+
+/**
+ * One row per opted-in user, suitable for the dashboard's Triage tab.
+ * Lightweight projection — no recentDecisions/recentCorrections arrays,
+ * just counts and the last-decision summary. Scan is paginated; capped
+ * at 500 users in dev/prod since a real district will stay under 1000.
+ */
+export interface TriageSummaryRow {
+  userEmail: string
+  enabled: boolean
+  enabledAt?: string
+  disabledAt?: string | null
+  lastPollAt?: string
+  digestEnabled: boolean
+  ruleCount: number
+  escalationCount: number
+  recentDecisionsCount: number
+  learnedPatternsCount: number
+  lastDecision?: {
+    ts: string
+    label: string
+    fromEmail: string
+    subject: string
+  } | null
+}
+
+export async function getTriageSummaryList(): Promise<
+  ActionState<TriageSummaryRow[]>
+> {
+  const requestId = generateRequestId()
+  const log = createLogger({ requestId, action: "getTriageSummaryList" })
+  try {
+    await requireRole("administrator")
+    log.info("Scanning triage table for summary list")
+
+    const rows: TriageSummaryRow[] = []
+    let lastKey: Record<string, unknown> | undefined
+    let pagesScanned = 0
+    const MAX_PAGES = 5 // ~5 × 1MB = up to ~5000 rows
+    do {
+      const resp = await ddb().send(
+        // @ts-expect-error — nested @smithy/types version mismatch between
+        // @aws-sdk/lib-dynamodb and @aws-sdk/client-dynamodb. Same pattern as
+        // GetCommand/UpdateCommand/DeleteCommand below.
+        new ScanCommand({
+          TableName: TRIAGE_TABLE,
+          ExclusiveStartKey: lastKey,
+        }),
+      )
+      for (const item of (resp.Items ?? []) as Array<{
+        userEmail: string
+        enabled?: boolean
+        enabledAt?: string
+        disabledAt?: string | null
+        lastPollAt?: string
+        digestEnabled?: boolean
+        rules?: {
+          vipSenders?: unknown[]
+          muteSenders?: unknown[]
+          keywordRules?: unknown[]
+        }
+        escalation?: {
+          senders?: unknown[]
+          keywords?: unknown[]
+        }
+        recentDecisions?: Array<{
+          ts: string
+          label: string
+          fromEmail: string
+          subject: string
+        }>
+        learnedPatterns?: unknown[]
+      }>) {
+        const recent = item.recentDecisions ?? []
+        const last = recent.length > 0 ? recent[recent.length - 1] : null
+        rows.push({
+          userEmail: item.userEmail,
+          enabled: Boolean(item.enabled),
+          enabledAt: item.enabledAt,
+          disabledAt: item.disabledAt ?? null,
+          lastPollAt: item.lastPollAt,
+          digestEnabled: item.digestEnabled !== false,
+          ruleCount:
+            (item.rules?.vipSenders?.length ?? 0) +
+            (item.rules?.muteSenders?.length ?? 0) +
+            (item.rules?.keywordRules?.length ?? 0),
+          escalationCount:
+            (item.escalation?.senders?.length ?? 0) +
+            (item.escalation?.keywords?.length ?? 0),
+          recentDecisionsCount: recent.length,
+          learnedPatternsCount: item.learnedPatterns?.length ?? 0,
+          lastDecision: last
+            ? {
+                ts: last.ts,
+                label: last.label,
+                fromEmail: last.fromEmail,
+                subject: last.subject,
+              }
+            : null,
+        })
+      }
+      lastKey = resp.LastEvaluatedKey
+      pagesScanned++
+      if (pagesScanned >= MAX_PAGES) {
+        log.warn("Triage scan hit page cap; truncating", { pages: pagesScanned })
+        break
+      }
+    } while (lastKey)
+
+    // Sort newest enable first so admin sees most recent setup at top.
+    rows.sort((a, b) => (b.enabledAt ?? "").localeCompare(a.enabledAt ?? ""))
+    return createSuccess(rows, `Found ${rows.length} triage rows`)
+  } catch (error) {
+    return handleError(error, "Failed to list triage rows", {
+      context: "getTriageSummaryList",
+      requestId,
+      operation: "getTriageSummaryList",
+    })
+  }
+}
+
+export async function getTriageState(
+  userEmail: string,
+): Promise<ActionState<TriageStateSummary | null>> {
+  const requestId = generateRequestId()
+  const log = createLogger({ requestId, action: "getTriageState" })
+  try {
+    await requireRole("administrator")
+    log.info("Fetching triage state", { userEmail })
+
+    const resp = await ddb().send(
+      // @ts-expect-error — nested @smithy/types version mismatch (see above).
+      new GetCommand({
+        TableName: TRIAGE_TABLE,
+        Key: { userEmail: userEmail.toLowerCase() },
+      }),
+    )
+    if (!resp.Item) return createSuccess(null, "No triage row found")
+
+    const row = resp.Item as {
+      userEmail: string
+      enabled?: boolean
+      enabledAt?: string
+      disabledAt?: string | null
+      labels?: Record<string, string>
+      labelIdsByKey?: Record<string, string>
+      lastHistoryId?: string
+      lastPollAt?: string
+      digestEnabled?: boolean
+      digestTime?: string
+      digestTz?: string
+      rules?: {
+        vipSenders?: unknown[]
+        muteSenders?: unknown[]
+        keywordRules?: unknown[]
+      }
+      escalation?: {
+        senders?: unknown[]
+        keywords?: unknown[]
+      }
+      recentDecisions?: TriageStateSummary["recentDecisions"]
+      recentCorrections?: TriageStateSummary["recentCorrections"]
+      learnedPatterns?: unknown[]
+    }
+
+    const summary: TriageStateSummary = {
+      userEmail: row.userEmail,
+      enabled: Boolean(row.enabled),
+      enabledAt: row.enabledAt,
+      disabledAt: row.disabledAt ?? null,
+      labels: row.labels,
+      labelIdsByKey: row.labelIdsByKey,
+      lastHistoryId: row.lastHistoryId,
+      lastPollAt: row.lastPollAt,
+      digest: {
+        enabled: row.digestEnabled !== false,
+        time: row.digestTime,
+        tz: row.digestTz,
+      },
+      counts: {
+        vipSenders: row.rules?.vipSenders?.length ?? 0,
+        muteSenders: row.rules?.muteSenders?.length ?? 0,
+        keywordRules: row.rules?.keywordRules?.length ?? 0,
+        escalationSenders: row.escalation?.senders?.length ?? 0,
+        escalationKeywords: row.escalation?.keywords?.length ?? 0,
+        recentDecisions: row.recentDecisions?.length ?? 0,
+        recentCorrections: row.recentCorrections?.length ?? 0,
+        learnedPatterns: row.learnedPatterns?.length ?? 0,
+      },
+      recentDecisions: (row.recentDecisions ?? []).slice(-20).reverse(),
+      recentCorrections: (row.recentCorrections ?? []).slice(-20).reverse(),
+    }
+
+    return createSuccess(summary, "Triage state retrieved")
+  } catch (error) {
+    return handleError(error, "Failed to fetch triage state", {
+      context: "getTriageState",
+      requestId,
+      operation: "getTriageState",
+    })
+  }
+}
+
+/**
+ * Pause triage for a user (sets enabled=false). Keeps rules, learned
+ * patterns, and Gmail labels intact. Re-enable by calling
+ * triage.enable from the agent.
+ */
+export async function pauseTriage(userEmail: string): Promise<ActionState<void>> {
+  const requestId = generateRequestId()
+  const log = createLogger({ requestId, action: "pauseTriage" })
+  try {
+    await requireRole("administrator")
+    log.warn("Admin pausing user's triage", { userEmail })
+    await ddb().send(
+      // @ts-expect-error — nested @smithy/types version mismatch (see above).
+      new UpdateCommand({
+        TableName: TRIAGE_TABLE,
+        Key: { userEmail: userEmail.toLowerCase() },
+        UpdateExpression: "SET enabled = :f, disabledAt = :now, adminPausedAt = :now",
+        ExpressionAttributeValues: {
+          ":f": false,
+          ":now": new Date().toISOString(),
+        },
+      }),
+    )
+    return createSuccess(undefined, `Paused triage for ${userEmail}`)
+  } catch (error) {
+    return handleError(error, "Failed to pause triage", {
+      context: "pauseTriage",
+      requestId,
+      operation: "pauseTriage",
+    })
+  }
+}
+
+/**
+ * Clear learned patterns + correction history. Doesn't change rules
+ * the user authored, doesn't disable triage. Use when a user reports
+ * "the classifier suddenly went weird" and you want to reset only the
+ * adaptive layer.
+ */
+export async function resetLearnedPatterns(
+  userEmail: string,
+): Promise<ActionState<void>> {
+  const requestId = generateRequestId()
+  const log = createLogger({ requestId, action: "resetLearnedPatterns" })
+  try {
+    await requireRole("administrator")
+    log.warn("Admin resetting learned patterns", { userEmail })
+    await ddb().send(
+      // @ts-expect-error — nested @smithy/types version mismatch (see above).
+      new UpdateCommand({
+        TableName: TRIAGE_TABLE,
+        Key: { userEmail: userEmail.toLowerCase() },
+        UpdateExpression:
+          "SET learnedPatterns = :empty, recentCorrections = :empty, adminResetAt = :now",
+        ExpressionAttributeValues: {
+          ":empty": [],
+          ":now": new Date().toISOString(),
+        },
+      }),
+    )
+    return createSuccess(undefined, `Cleared learned patterns for ${userEmail}`)
+  } catch (error) {
+    return handleError(error, "Failed to reset learned patterns", {
+      context: "resetLearnedPatterns",
+      requestId,
+      operation: "resetLearnedPatterns",
+    })
+  }
+}
+
+/**
+ * Force re-onboarding by deleting the user's triage row. The agent
+ * skill will treat them as new the next time they ask to enable. Does
+ * NOT delete Gmail labels or the digest schedule — those are the
+ * user's to manage from chat (`disable --forget`).
+ *
+ * Use this when a user's state is corrupt and we'd rather start over.
+ */
+export async function forceReonboard(
+  userEmail: string,
+): Promise<ActionState<void>> {
+  const requestId = generateRequestId()
+  const log = createLogger({ requestId, action: "forceReonboard" })
+  try {
+    await requireRole("administrator")
+    log.warn("Admin forcing re-onboard (delete row)", { userEmail })
+    await ddb().send(
+      // @ts-expect-error — nested @smithy/types version mismatch (see above).
+      new DeleteCommand({
+        TableName: TRIAGE_TABLE,
+        Key: { userEmail: userEmail.toLowerCase() },
+      }),
+    )
+    return createSuccess(
+      undefined,
+      `Deleted triage row for ${userEmail}. Gmail labels and digest schedule are NOT deleted — user can clean those up via 'disable --forget' from chat.`,
+    )
+  } catch (error) {
+    return handleError(error, "Failed to force re-onboard", {
+      context: "forceReonboard",
+      requestId,
+      operation: "forceReonboard",
+    })
+  }
+}

--- a/actions/admin/agent-triage.actions.ts
+++ b/actions/admin/agent-triage.actions.ts
@@ -22,7 +22,7 @@ import {
 
 import { requireRole } from "@/lib/auth/role-helpers"
 import { handleError, createSuccess } from "@/lib/error-utils"
-import { createLogger, generateRequestId } from "@/lib/logger"
+import { createLogger, generateRequestId, startTimer, sanitizeForLogging } from "@/lib/logger"
 import type { ActionState } from "@/types"
 
 const REGION = process.env.AWS_REGION ?? "us-east-1"
@@ -108,6 +108,7 @@ export async function getTriageSummaryList(): Promise<
   ActionState<TriageSummaryRow[]>
 > {
   const requestId = generateRequestId()
+  const timer = startTimer("getTriageSummaryList")
   const log = createLogger({ requestId, action: "getTriageSummaryList" })
   try {
     await requireRole("administrator")
@@ -189,8 +190,10 @@ export async function getTriageSummaryList(): Promise<
 
     // Sort newest enable first so admin sees most recent setup at top.
     rows.sort((a, b) => (b.enabledAt ?? "").localeCompare(a.enabledAt ?? ""))
+    timer({ status: "success" })
     return createSuccess(rows, `Found ${rows.length} triage rows`)
   } catch (error) {
+    timer({ status: "error" })
     return handleError(error, "Failed to list triage rows", {
       context: "getTriageSummaryList",
       requestId,
@@ -203,10 +206,11 @@ export async function getTriageState(
   userEmail: string,
 ): Promise<ActionState<TriageStateSummary | null>> {
   const requestId = generateRequestId()
+  const timer = startTimer("getTriageState")
   const log = createLogger({ requestId, action: "getTriageState" })
   try {
     await requireRole("administrator")
-    log.info("Fetching triage state", { userEmail })
+    log.info("Fetching triage state", sanitizeForLogging({ userEmail }))
 
     const resp = await ddb().send(
       // @ts-expect-error — nested @smithy/types version mismatch (see above).
@@ -271,8 +275,10 @@ export async function getTriageState(
       recentCorrections: (row.recentCorrections ?? []).slice(-20).reverse(),
     }
 
+    timer({ status: "success" })
     return createSuccess(summary, "Triage state retrieved")
   } catch (error) {
+    timer({ status: "error" })
     return handleError(error, "Failed to fetch triage state", {
       context: "getTriageState",
       requestId,
@@ -288,24 +294,37 @@ export async function getTriageState(
  */
 export async function pauseTriage(userEmail: string): Promise<ActionState<void>> {
   const requestId = generateRequestId()
+  const timer = startTimer("pauseTriage")
   const log = createLogger({ requestId, action: "pauseTriage" })
   try {
     await requireRole("administrator")
-    log.warn("Admin pausing user's triage", { userEmail })
+    log.warn("Admin pausing user's triage", sanitizeForLogging({ userEmail }))
     await ddb().send(
       // @ts-expect-error — nested @smithy/types version mismatch (see above).
       new UpdateCommand({
         TableName: TRIAGE_TABLE,
         Key: { userEmail: userEmail.toLowerCase() },
         UpdateExpression: "SET enabled = :f, disabledAt = :now, adminPausedAt = :now",
+        ConditionExpression: "attribute_exists(userEmail)",
         ExpressionAttributeValues: {
           ":f": false,
           ":now": new Date().toISOString(),
         },
       }),
     )
+    timer({ status: "success" })
     return createSuccess(undefined, `Paused triage for ${userEmail}`)
   } catch (error) {
+    // ConditionalCheckFailed means the user doesn't have a triage row
+    if ((error as { name?: string }).name === "ConditionalCheckFailedException") {
+      timer({ status: "error" })
+      return handleError(
+        error as Error,
+        `No triage row found for ${userEmail} — user may not have opted in yet.`,
+        { context: "pauseTriage", requestId, operation: "pauseTriage" },
+      )
+    }
+    timer({ status: "error" })
     return handleError(error, "Failed to pause triage", {
       context: "pauseTriage",
       requestId,
@@ -324,10 +343,11 @@ export async function resetLearnedPatterns(
   userEmail: string,
 ): Promise<ActionState<void>> {
   const requestId = generateRequestId()
+  const timer = startTimer("resetLearnedPatterns")
   const log = createLogger({ requestId, action: "resetLearnedPatterns" })
   try {
     await requireRole("administrator")
-    log.warn("Admin resetting learned patterns", { userEmail })
+    log.warn("Admin resetting learned patterns", sanitizeForLogging({ userEmail }))
     await ddb().send(
       // @ts-expect-error — nested @smithy/types version mismatch (see above).
       new UpdateCommand({
@@ -335,14 +355,25 @@ export async function resetLearnedPatterns(
         Key: { userEmail: userEmail.toLowerCase() },
         UpdateExpression:
           "SET learnedPatterns = :empty, recentCorrections = :empty, adminResetAt = :now",
+        ConditionExpression: "attribute_exists(userEmail)",
         ExpressionAttributeValues: {
           ":empty": [],
           ":now": new Date().toISOString(),
         },
       }),
     )
+    timer({ status: "success" })
     return createSuccess(undefined, `Cleared learned patterns for ${userEmail}`)
   } catch (error) {
+    if ((error as { name?: string }).name === "ConditionalCheckFailedException") {
+      timer({ status: "error" })
+      return handleError(
+        error as Error,
+        `No triage row found for ${userEmail} — user may not have opted in yet.`,
+        { context: "resetLearnedPatterns", requestId, operation: "resetLearnedPatterns" },
+      )
+    }
+    timer({ status: "error" })
     return handleError(error, "Failed to reset learned patterns", {
       context: "resetLearnedPatterns",
       requestId,
@@ -363,10 +394,11 @@ export async function forceReonboard(
   userEmail: string,
 ): Promise<ActionState<void>> {
   const requestId = generateRequestId()
+  const timer = startTimer("forceReonboard")
   const log = createLogger({ requestId, action: "forceReonboard" })
   try {
     await requireRole("administrator")
-    log.warn("Admin forcing re-onboard (delete row)", { userEmail })
+    log.warn("Admin forcing re-onboard (delete row)", sanitizeForLogging({ userEmail }))
     await ddb().send(
       // @ts-expect-error — nested @smithy/types version mismatch (see above).
       new DeleteCommand({
@@ -374,11 +406,13 @@ export async function forceReonboard(
         Key: { userEmail: userEmail.toLowerCase() },
       }),
     )
+    timer({ status: "success" })
     return createSuccess(
       undefined,
       `Deleted triage row for ${userEmail}. Gmail labels and digest schedule are NOT deleted — user can clean those up via 'disable --forget' from chat.`,
     )
   } catch (error) {
+    timer({ status: "error" })
     return handleError(error, "Failed to force re-onboard", {
       context: "forceReonboard",
       requestId,

--- a/app/(protected)/admin/agents/[userEmail]/triage/_components/triage-detail-client.tsx
+++ b/app/(protected)/admin/agents/[userEmail]/triage/_components/triage-detail-client.tsx
@@ -1,0 +1,285 @@
+"use client"
+
+import { useCallback, useEffect, useState } from "react"
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Skeleton } from "@/components/ui/skeleton"
+import { useToast } from "@/components/ui/use-toast"
+import {
+  forceReonboard,
+  getTriageState,
+  pauseTriage,
+  resetLearnedPatterns,
+  type TriageStateSummary,
+} from "@/actions/admin/agent-triage.actions"
+
+interface Props {
+  userEmail: string
+}
+
+type DialogKind = null | "pause" | "reset" | "reonboard"
+
+export function TriageDetailClient({ userEmail }: Props) {
+  const { toast } = useToast()
+  const [state, setState] = useState<TriageStateSummary | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [actionLoading, setActionLoading] = useState(false)
+  const [dialog, setDialog] = useState<DialogKind>(null)
+
+  const refresh = useCallback(async () => {
+    setLoading(true)
+    const r = await getTriageState(userEmail)
+    if (r.isSuccess) {
+      setState(r.data)
+    } else {
+      toast({
+        title: "Failed to load triage state",
+        description: r.message,
+        variant: "destructive",
+      })
+    }
+    setLoading(false)
+  }, [userEmail, toast])
+
+  useEffect(() => {
+    refresh()
+  }, [refresh])
+
+  const runAction = useCallback(
+    async (kind: Exclude<DialogKind, null>) => {
+      setActionLoading(true)
+      const handler =
+        kind === "pause"
+          ? pauseTriage
+          : kind === "reset"
+            ? resetLearnedPatterns
+            : forceReonboard
+      const r = await handler(userEmail)
+      setActionLoading(false)
+      setDialog(null)
+      if (r.isSuccess) {
+        toast({ title: "Success", description: r.message })
+        refresh()
+      } else {
+        toast({
+          title: "Failed",
+          description: r.message,
+          variant: "destructive",
+        })
+      }
+    },
+    [userEmail, toast, refresh],
+  )
+
+  if (loading) {
+    return (
+      <div className="space-y-4">
+        <h1 className="text-2xl font-semibold">Email Triage · {userEmail}</h1>
+        <Skeleton className="h-24 w-full" />
+        <Skeleton className="h-64 w-full" />
+      </div>
+    )
+  }
+
+  if (!state) {
+    return (
+      <div className="space-y-4">
+        <h1 className="text-2xl font-semibold">Email Triage · {userEmail}</h1>
+        <Card>
+          <CardContent className="pt-6 text-muted-foreground">
+            No triage row for this user. They have not enabled triage yet, or it
+            has been forcefully reset.
+          </CardContent>
+        </Card>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-start justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold">Email Triage · {state.userEmail}</h1>
+          <p className="text-sm text-muted-foreground">
+            Read-only admin view. User-facing operations happen in chat.
+          </p>
+        </div>
+        <div className="flex gap-2">
+          <Button
+            variant="secondary"
+            disabled={!state.enabled}
+            onClick={() => setDialog("pause")}
+          >
+            Pause
+          </Button>
+          <Button variant="secondary" onClick={() => setDialog("reset")}>
+            Reset learned
+          </Button>
+          <Button variant="destructive" onClick={() => setDialog("reonboard")}>
+            Force re-onboard
+          </Button>
+        </div>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Status</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <dl className="grid grid-cols-2 gap-x-8 gap-y-2 text-sm md:grid-cols-3">
+            <KeyVal k="Enabled" v={state.enabled ? "Yes" : "No"} />
+            {state.enabledAt && <KeyVal k="Enabled at" v={state.enabledAt} />}
+            {state.disabledAt && <KeyVal k="Disabled at" v={state.disabledAt} />}
+            {state.lastPollAt && <KeyVal k="Last poll" v={state.lastPollAt} />}
+            <KeyVal k="lastHistoryId" v={state.lastHistoryId ?? "(unset)"} />
+            <KeyVal
+              k="Digest"
+              v={
+                state.digest?.enabled
+                  ? `${state.digest.time ?? "?"} ${state.digest.tz ?? ""}`
+                  : "off"
+              }
+            />
+          </dl>
+        </CardContent>
+      </Card>
+
+      {state.labels && (
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">Labels</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-1 text-sm">
+            {Object.entries(state.labels).map(([k, name]) => (
+              <div key={k} className="flex gap-3">
+                <span className="w-24 text-muted-foreground">{k}</span>
+                <span className="font-mono">{name}</span>
+                <span className="font-mono text-muted-foreground">
+                  {state.labelIdsByKey?.[k] ?? ""}
+                </span>
+              </div>
+            ))}
+          </CardContent>
+        </Card>
+      )}
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Counts</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <dl className="grid grid-cols-2 gap-x-8 gap-y-2 text-sm md:grid-cols-4">
+            <KeyVal k="VIPs" v={state.counts.vipSenders} />
+            <KeyVal k="Muted" v={state.counts.muteSenders} />
+            <KeyVal k="Keyword rules" v={state.counts.keywordRules} />
+            <KeyVal k="Escalation senders" v={state.counts.escalationSenders} />
+            <KeyVal k="Escalation keywords" v={state.counts.escalationKeywords} />
+            <KeyVal k="Recent decisions" v={state.counts.recentDecisions} />
+            <KeyVal k="Corrections" v={state.counts.recentCorrections} />
+            <KeyVal k="Learned patterns" v={state.counts.learnedPatterns} />
+          </dl>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Recent decisions (newest first)</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {state.recentDecisions.length === 0 ? (
+            <p className="text-sm text-muted-foreground">(none yet)</p>
+          ) : (
+            <div className="space-y-2 text-sm">
+              {state.recentDecisions.map((d) => (
+                <div key={d.messageId} className="border-b py-2 last:border-0">
+                  <div className="flex justify-between">
+                    <span className="font-medium">{d.subject || "(no subject)"}</span>
+                    <span className="font-mono text-muted-foreground">{d.label}</span>
+                  </div>
+                  <div className="text-xs text-muted-foreground">
+                    {d.fromEmail} · {d.source} · confidence {d.confidence.toFixed(2)} · {d.reason}
+                  </div>
+                  <div className="text-xs text-muted-foreground">{d.ts}</div>
+                </div>
+              ))}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {state.recentCorrections.length > 0 && (
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">Recent corrections</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="space-y-2 text-sm">
+              {state.recentCorrections.map((c) => (
+                <div key={`${c.messageId}-${c.ts}`} className="border-b py-1 last:border-0">
+                  <span className="font-mono">{c.fromLabel}</span> →{" "}
+                  <span className="font-mono">{c.toLabel}</span>
+                  <span className="ml-2 text-xs text-muted-foreground">{c.ts}</span>
+                </div>
+              ))}
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      <AlertDialog
+        open={dialog !== null}
+        onOpenChange={(open) => !open && setDialog(null)}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>
+              {dialog === "pause" && "Pause triage?"}
+              {dialog === "reset" && "Reset learned patterns?"}
+              {dialog === "reonboard" && "Force re-onboard?"}
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              {dialog === "pause" &&
+                `Stops the classifier for ${userEmail}. Rules and Gmail labels stay intact — they can re-enable from chat.`}
+              {dialog === "reset" &&
+                `Clears learned patterns and correction history for ${userEmail}. Does not change user-authored rules or disable triage.`}
+              {dialog === "reonboard" &&
+                `Deletes the entire triage DDB row for ${userEmail}. Their Gmail labels and digest schedule are NOT deleted — they will need 'disable --forget' from chat to clean those up. Use this when the row is corrupt.`}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={actionLoading}>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              disabled={actionLoading}
+              onClick={(e) => {
+                e.preventDefault()
+                if (dialog) runAction(dialog)
+              }}
+            >
+              {actionLoading ? "Working..." : "Confirm"}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  )
+}
+
+function KeyVal({ k, v }: { k: string; v: string | number | null | undefined }) {
+  return (
+    <div>
+      <dt className="text-muted-foreground">{k}</dt>
+      <dd className="font-mono">{v ?? "—"}</dd>
+    </div>
+  )
+}

--- a/app/(protected)/admin/agents/[userEmail]/triage/_components/triage-detail-client.tsx
+++ b/app/(protected)/admin/agents/[userEmail]/triage/_components/triage-detail-client.tsx
@@ -52,8 +52,13 @@ export function TriageDetailClient({ userEmail }: Props) {
     setLoading(false)
   }, [userEmail, toast])
 
+  // Fire-and-forget load on mount + when refresh callback identity changes
+  // (userEmail/toast change). The setState calls inside `refresh()` happen
+  // AFTER an `await`, not synchronously in the effect tick, so the cascading
+  // render the rule warns about doesn't actually occur here.
   useEffect(() => {
-    refresh()
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    void refresh()
   }, [refresh])
 
   const runAction = useCallback(

--- a/app/(protected)/admin/agents/[userEmail]/triage/_components/triage-detail-client.tsx
+++ b/app/(protected)/admin/agents/[userEmail]/triage/_components/triage-detail-client.tsx
@@ -75,7 +75,7 @@ export function TriageDetailClient({ userEmail }: Props) {
       setDialog(null)
       if (r.isSuccess) {
         toast({ title: "Success", description: r.message })
-        refresh()
+        void refresh()
       } else {
         toast({
           title: "Failed",

--- a/app/(protected)/admin/agents/[userEmail]/triage/page.tsx
+++ b/app/(protected)/admin/agents/[userEmail]/triage/page.tsx
@@ -1,0 +1,25 @@
+/**
+ * Admin sub-page — per-user email triage state.
+ *
+ * Read-only view for support cases. Shows enabled state, rule counts,
+ * recent decisions, Gmail label IDs, and three action buttons (pause,
+ * reset learned patterns, force re-onboarding). Per the email-triage
+ * Phase 1 plan, this is the ONLY web UI for the feature; the user-
+ * facing flow is entirely through chat.
+ *
+ * Route: /admin/agents/[userEmail]/triage
+ */
+
+import { requireRole } from "@/lib/auth/role-helpers"
+import { TriageDetailClient } from "./_components/triage-detail-client"
+
+interface PageProps {
+  params: Promise<{ userEmail: string }>
+}
+
+export default async function AdminAgentsTriagePage({ params }: PageProps) {
+  await requireRole("administrator")
+  const { userEmail } = await params
+  const decoded = decodeURIComponent(userEmail).toLowerCase()
+  return <TriageDetailClient userEmail={decoded} />
+}

--- a/app/(protected)/admin/agents/_components/agent-conversations.tsx
+++ b/app/(protected)/admin/agents/_components/agent-conversations.tsx
@@ -206,7 +206,7 @@ export function AgentConversationsTab() {
                       )}
                     </TableCell>
                     <TableCell>
-                      {s.hasError ? (
+                      {s.hasGuardrailBlock ? (
                         <Badge variant="destructive">guardrail</Badge>
                       ) : (
                         <Badge variant="secondary">ok</Badge>

--- a/app/(protected)/admin/agents/_components/agent-conversations.tsx
+++ b/app/(protected)/admin/agents/_components/agent-conversations.tsx
@@ -61,6 +61,7 @@ export function AgentConversationsTab() {
   const [loading, setLoading] = useState(true)
   const [days, setDays] = useState<string>("7")
   const [userFilter, setUserFilter] = useState("")
+  const [activeUserFilter, setActiveUserFilter] = useState("")
   const [selectedSession, setSelectedSession] = useState<string | null>(null)
   const [detail, setDetail] = useState<ConversationDetail | null>(null)
   const [detailLoading, setDetailLoading] = useState(false)
@@ -70,7 +71,7 @@ export function AgentConversationsTab() {
     try {
       const r = await listAgentConversations(
         Number(days),
-        userFilter.trim() || undefined,
+        activeUserFilter.trim() || undefined,
       )
       if (r.isSuccess && r.data) {
         setItems(r.data)
@@ -84,10 +85,10 @@ export function AgentConversationsTab() {
     } finally {
       setLoading(false)
     }
-  }, [days, userFilter, toast])
+  }, [days, activeUserFilter, toast])
 
   useEffect(() => {
-    load()
+    void load()
   }, [load])
 
   const openSession = useCallback(
@@ -145,10 +146,10 @@ export function AgentConversationsTab() {
               value={userFilter}
               onChange={(e) => setUserFilter(e.target.value)}
               onKeyDown={(e) => {
-                if (e.key === "Enter") load()
+                if (e.key === "Enter") setActiveUserFilter(userFilter)
               }}
             />
-            <Button variant="outline" size="sm" onClick={load}>
+            <Button variant="outline" size="sm" onClick={() => setActiveUserFilter(userFilter)}>
               Apply
             </Button>
           </div>
@@ -304,8 +305,8 @@ function ConversationDetailView({ detail }: { detail: ConversationDetail }) {
               No content captured for this turn (pre-rollout).
             </div>
           )}
-          {turn.messages.map((m, mi) => (
-            <div key={mi} className="space-y-1">
+          {turn.messages.map((m) => (
+            <div key={`${m.createdAt}-${m.role}`} className="space-y-1">
               <Badge
                 variant={m.role === "user" ? "default" : "secondary"}
                 className="text-[10px] py-0"
@@ -325,8 +326,8 @@ function ConversationDetailView({ detail }: { detail: ConversationDetail }) {
               <div className="text-xs font-medium text-muted-foreground">
                 Tool calls
               </div>
-              {turn.tools.map((t, ti) => (
-                <details key={ti} className="text-xs border rounded p-2">
+              {turn.tools.map((t) => (
+                <details key={`${t.startedAt}-${t.toolName}`} className="text-xs border rounded p-2">
                   <summary className="cursor-pointer flex items-center gap-2">
                     <Badge variant="outline" className="text-[10px] py-0">
                       {t.toolName}

--- a/app/(protected)/admin/agents/_components/agent-conversations.tsx
+++ b/app/(protected)/admin/agents/_components/agent-conversations.tsx
@@ -305,8 +305,8 @@ function ConversationDetailView({ detail }: { detail: ConversationDetail }) {
               No content captured for this turn (pre-rollout).
             </div>
           )}
-          {turn.messages.map((m) => (
-            <div key={`${m.createdAt}-${m.role}`} className="space-y-1">
+          {turn.messages.map((m, mi) => (
+            <div key={`${turn.messageId}-msg-${mi}`} className="space-y-1">
               <Badge
                 variant={m.role === "user" ? "default" : "secondary"}
                 className="text-[10px] py-0"
@@ -326,8 +326,8 @@ function ConversationDetailView({ detail }: { detail: ConversationDetail }) {
               <div className="text-xs font-medium text-muted-foreground">
                 Tool calls
               </div>
-              {turn.tools.map((t) => (
-                <details key={`${t.startedAt}-${t.toolName}`} className="text-xs border rounded p-2">
+              {turn.tools.map((t, ti) => (
+                <details key={`${turn.messageId}-tool-${ti}`} className="text-xs border rounded p-2">
                   <summary className="cursor-pointer flex items-center gap-2">
                     <Badge variant="outline" className="text-[10px] py-0">
                       {t.toolName}

--- a/app/(protected)/admin/agents/_components/agent-conversations.tsx
+++ b/app/(protected)/admin/agents/_components/agent-conversations.tsx
@@ -1,0 +1,365 @@
+"use client"
+
+import { useCallback, useEffect, useState } from "react"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Skeleton } from "@/components/ui/skeleton"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
+import { useToast } from "@/components/ui/use-toast"
+import {
+  listAgentConversations,
+  getAgentConversationDetail,
+  type ConversationListItem,
+  type ConversationDetail,
+} from "@/actions/admin/agent-conversations.actions"
+import { formatDate } from "@/lib/date-utils"
+
+const DAYS_OPTIONS = [
+  { value: "1", label: "Last 24h" },
+  { value: "7", label: "Last 7 days" },
+  { value: "30", label: "Last 30 days" },
+  { value: "90", label: "Last 90 days" },
+]
+
+export function AgentConversationsTab() {
+  const { toast } = useToast()
+  const [items, setItems] = useState<ConversationListItem[]>([])
+  const [loading, setLoading] = useState(true)
+  const [days, setDays] = useState<string>("7")
+  const [userFilter, setUserFilter] = useState("")
+  const [selectedSession, setSelectedSession] = useState<string | null>(null)
+  const [detail, setDetail] = useState<ConversationDetail | null>(null)
+  const [detailLoading, setDetailLoading] = useState(false)
+
+  const load = useCallback(async () => {
+    setLoading(true)
+    try {
+      const r = await listAgentConversations(
+        Number(days),
+        userFilter.trim() || undefined,
+      )
+      if (r.isSuccess && r.data) {
+        setItems(r.data)
+      } else {
+        toast({
+          title: "Failed to load conversations",
+          description: r.message,
+          variant: "destructive",
+        })
+      }
+    } finally {
+      setLoading(false)
+    }
+  }, [days, userFilter, toast])
+
+  useEffect(() => {
+    load()
+  }, [load])
+
+  const openSession = useCallback(
+    async (sessionId: string) => {
+      setSelectedSession(sessionId)
+      setDetailLoading(true)
+      setDetail(null)
+      try {
+        const r = await getAgentConversationDetail(sessionId)
+        if (r.isSuccess && r.data) {
+          setDetail(r.data)
+        } else if (r.isSuccess) {
+          // null data = session not found
+          setDetail(null)
+        } else {
+          toast({
+            title: "Failed to load session",
+            description: r.message,
+            variant: "destructive",
+          })
+        }
+      } finally {
+        setDetailLoading(false)
+      }
+    },
+    [toast],
+  )
+
+  return (
+    <div className="space-y-4">
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Conversations</CardTitle>
+          <p className="text-xs text-muted-foreground mt-1">
+            Full transcripts + tool invocations per session. 90-day retention
+            on content; the per-turn metadata (above, in Usage) is kept
+            longer. Admin-only.
+          </p>
+          <div className="flex items-center gap-2 mt-3">
+            <Select value={days} onValueChange={setDays}>
+              <SelectTrigger className="w-[160px] h-8 text-sm">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {DAYS_OPTIONS.map((o) => (
+                  <SelectItem key={o.value} value={o.value}>
+                    {o.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <Input
+              className="h-8 text-sm w-[260px]"
+              placeholder="Filter by user (email/id)"
+              value={userFilter}
+              onChange={(e) => setUserFilter(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") load()
+              }}
+            />
+            <Button variant="outline" size="sm" onClick={load}>
+              Apply
+            </Button>
+          </div>
+        </CardHeader>
+        <CardContent>
+          {loading ? (
+            <Skeleton className="h-48 w-full" />
+          ) : items.length === 0 ? (
+            <div className="h-32 flex items-center justify-center text-sm text-muted-foreground">
+              No conversations in the selected window.
+            </div>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Last turn</TableHead>
+                  <TableHead>User</TableHead>
+                  <TableHead className="text-right">Turns</TableHead>
+                  <TableHead className="text-right">Tools</TableHead>
+                  <TableHead className="text-right">Tokens (in/out)</TableHead>
+                  <TableHead>Models</TableHead>
+                  <TableHead>Status</TableHead>
+                  <TableHead></TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {items.map((s) => (
+                  <TableRow key={s.sessionId}>
+                    <TableCell className="text-xs">
+                      {formatDate(s.lastTurnAt, true)}
+                    </TableCell>
+                    <TableCell className="font-mono text-xs">{s.userId}</TableCell>
+                    <TableCell className="text-right">{s.turnCount}</TableCell>
+                    <TableCell className="text-right">
+                      {s.toolCallCount}
+                    </TableCell>
+                    <TableCell className="text-right text-muted-foreground text-xs">
+                      {s.totalInputTokens.toLocaleString()} /{" "}
+                      {s.totalOutputTokens.toLocaleString()}
+                    </TableCell>
+                    <TableCell className="text-xs">
+                      {s.models.length === 0 ? (
+                        <span className="text-muted-foreground">—</span>
+                      ) : (
+                        s.models.map((m) => (
+                          <Badge
+                            key={m}
+                            variant="outline"
+                            className="text-[10px] py-0 mr-1"
+                          >
+                            {m}
+                          </Badge>
+                        ))
+                      )}
+                    </TableCell>
+                    <TableCell>
+                      {s.hasError ? (
+                        <Badge variant="destructive">guardrail</Badge>
+                      ) : (
+                        <Badge variant="secondary">ok</Badge>
+                      )}
+                    </TableCell>
+                    <TableCell>
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        onClick={() => openSession(s.sessionId)}
+                      >
+                        View
+                      </Button>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )}
+        </CardContent>
+      </Card>
+
+      <Sheet
+        open={selectedSession !== null}
+        onOpenChange={(open) => {
+          if (!open) {
+            setSelectedSession(null)
+            setDetail(null)
+          }
+        }}
+      >
+        <SheetContent className="w-full sm:max-w-2xl overflow-y-auto">
+          <SheetHeader>
+            <SheetTitle>Session detail</SheetTitle>
+            <SheetDescription className="font-mono text-xs break-all">
+              {selectedSession}
+            </SheetDescription>
+          </SheetHeader>
+          <div className="mt-4 space-y-4">
+            {detailLoading && <Skeleton className="h-40 w-full" />}
+            {!detailLoading && detail === null && selectedSession && (
+              <div className="text-sm text-muted-foreground">
+                Session not found. It may have aged out of the 90-day window,
+                or no content was captured for this session (older messages
+                predate the deep-telemetry rollout).
+              </div>
+            )}
+            {!detailLoading && detail && (
+              <ConversationDetailView detail={detail} />
+            )}
+          </div>
+        </SheetContent>
+      </Sheet>
+    </div>
+  )
+}
+
+function ConversationDetailView({ detail }: { detail: ConversationDetail }) {
+  return (
+    <div className="space-y-6">
+      <div className="text-xs text-muted-foreground">
+        User: <span className="font-mono">{detail.userId}</span> ·{" "}
+        {detail.turns.length} turn{detail.turns.length === 1 ? "" : "s"}
+      </div>
+      {detail.turns.length === 0 && (
+        <div className="text-sm text-muted-foreground">
+          No turns recorded — agent_messages has a row but no content was
+          captured. This is normal for sessions that started before the
+          deep-telemetry writers shipped.
+        </div>
+      )}
+      {detail.turns.map((turn, i) => (
+        <div key={turn.messageId} className="border rounded p-3 space-y-3">
+          <div className="flex items-center justify-between text-xs text-muted-foreground">
+            <div className="flex items-center gap-2">
+              <Badge variant="outline" className="text-[10px]">
+                Turn {i + 1}
+              </Badge>
+              <span>{formatDate(turn.createdAt, true)}</span>
+              {turn.model && (
+                <Badge variant="secondary" className="text-[10px] py-0">
+                  {turn.model}
+                </Badge>
+              )}
+            </div>
+            <div className="space-x-2">
+              <span>{turn.latencyMs} ms</span>
+              <span>
+                {turn.inputTokens.toLocaleString()} in /{" "}
+                {turn.outputTokens.toLocaleString()} out
+              </span>
+            </div>
+          </div>
+          {turn.messages.length === 0 && (
+            <div className="text-xs text-muted-foreground italic">
+              No content captured for this turn (pre-rollout).
+            </div>
+          )}
+          {turn.messages.map((m, mi) => (
+            <div key={mi} className="space-y-1">
+              <Badge
+                variant={m.role === "user" ? "default" : "secondary"}
+                className="text-[10px] py-0"
+              >
+                {m.role}
+              </Badge>
+              <pre className="text-xs whitespace-pre-wrap break-words bg-muted/40 rounded p-2">
+                {m.contentText}
+                {m.contentTruncated && (
+                  <span className="text-muted-foreground">… [truncated]</span>
+                )}
+              </pre>
+            </div>
+          ))}
+          {turn.tools.length > 0 && (
+            <div className="space-y-2">
+              <div className="text-xs font-medium text-muted-foreground">
+                Tool calls
+              </div>
+              {turn.tools.map((t, ti) => (
+                <details key={ti} className="text-xs border rounded p-2">
+                  <summary className="cursor-pointer flex items-center gap-2">
+                    <Badge variant="outline" className="text-[10px] py-0">
+                      {t.toolName}
+                    </Badge>
+                    <span className="text-muted-foreground">
+                      {t.durationMs} ms ·{" "}
+                    </span>
+                    {t.status === "success" ? (
+                      <Badge variant="secondary" className="text-[10px] py-0">
+                        success
+                      </Badge>
+                    ) : (
+                      <Badge variant="destructive" className="text-[10px] py-0">
+                        {t.status}
+                      </Badge>
+                    )}
+                  </summary>
+                  {t.errorText && (
+                    <pre className="mt-2 text-xs text-destructive whitespace-pre-wrap">
+                      {t.errorText}
+                    </pre>
+                  )}
+                  {t.toolArgs && (
+                    <div className="mt-2">
+                      <div className="text-muted-foreground">args:</div>
+                      <pre className="text-[11px] bg-muted/40 rounded p-1 overflow-auto">
+                        {JSON.stringify(t.toolArgs, null, 2)}
+                      </pre>
+                    </div>
+                  )}
+                  {t.toolResult && (
+                    <div className="mt-2">
+                      <div className="text-muted-foreground">result:</div>
+                      <pre className="text-[11px] bg-muted/40 rounded p-1 overflow-auto">
+                        {JSON.stringify(t.toolResult, null, 2)}
+                      </pre>
+                    </div>
+                  )}
+                </details>
+              ))}
+            </div>
+          )}
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/app/(protected)/admin/agents/_components/agent-conversations.tsx
+++ b/app/(protected)/admin/agents/_components/agent-conversations.tsx
@@ -37,6 +37,17 @@ import {
 } from "@/actions/admin/agent-conversations.actions"
 import { formatDate } from "@/lib/date-utils"
 
+/**
+ * Strip Unicode control characters (except common whitespace) that could
+ * corrupt the display. React's JSX escaping prevents XSS, but control
+ * chars can cause invisible rendering artifacts in the conversation viewer.
+ */
+// eslint-disable-next-line no-control-regex
+const CONTROL_CHAR_RE = /[\u0000-\u0008\u000B\u000C\u000E-\u001F\u007F\u200B-\u200F\uFEFF]/g
+function sanitizeDisplayText(text: string): string {
+  return text.replace(CONTROL_CHAR_RE, "")
+}
+
 const DAYS_OPTIONS = [
   { value: "1", label: "Last 24h" },
   { value: "7", label: "Last 7 days" },
@@ -302,7 +313,7 @@ function ConversationDetailView({ detail }: { detail: ConversationDetail }) {
                 {m.role}
               </Badge>
               <pre className="text-xs whitespace-pre-wrap break-words bg-muted/40 rounded p-2">
-                {m.contentText}
+                {sanitizeDisplayText(m.contentText)}
                 {m.contentTruncated && (
                   <span className="text-muted-foreground">… [truncated]</span>
                 )}
@@ -335,7 +346,7 @@ function ConversationDetailView({ detail }: { detail: ConversationDetail }) {
                   </summary>
                   {t.errorText && (
                     <pre className="mt-2 text-xs text-destructive whitespace-pre-wrap">
-                      {t.errorText}
+                      {sanitizeDisplayText(t.errorText)}
                     </pre>
                   )}
                   {t.toolArgs && (

--- a/app/(protected)/admin/agents/_components/agent-cost-view.tsx
+++ b/app/(protected)/admin/agents/_components/agent-cost-view.tsx
@@ -92,9 +92,25 @@ export function AgentCostView({ data, loading = false }: Props) {
           <CardTitle className="text-base">Daily spend (Cost Explorer, costCenter=ai-agents)</CardTitle>
         </CardHeader>
         <CardContent>
-          {data.daily.length === 0 ? (
-            <div className="h-32 flex items-center justify-center text-muted-foreground text-sm">
-              No billed activity in window.
+          {data.daily.length === 0 || data.totalUsd === 0 ? (
+            <div className="h-40 flex flex-col items-center justify-center gap-2 text-sm">
+              <div className="text-muted-foreground">No billed activity in window.</div>
+              <div className="text-xs text-muted-foreground max-w-lg text-center">
+                If you expect spend here, the most common cause is that{" "}
+                <code className="text-[11px]">costCenter</code> is not yet
+                activated as a cost-allocation tag. The IAM role IS tagged, but
+                AWS requires manual activation in{" "}
+                <a
+                  className="underline"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  href="https://us-east-1.console.aws.amazon.com/billing/home#/tags"
+                >
+                  Billing → Cost allocation tags
+                </a>
+                . Activate <code className="text-[11px]">costCenter</code>; new
+                spend appears in Cost Explorer ~24h later.
+              </div>
             </div>
           ) : (
             <div className="h-64">

--- a/app/(protected)/admin/agents/_components/agent-dashboard-client.tsx
+++ b/app/(protected)/admin/agents/_components/agent-dashboard-client.tsx
@@ -48,8 +48,10 @@ import {
 import {
   getAgentHealthSummary,
   getAgentPatterns,
+  getAgentRawSignals,
   type AgentHealthSummary,
   type AgentPatternsEnvelope,
+  type RawSignalsEnvelope,
 } from "@/actions/admin/agent-health.actions"
 import {
   getAgentCostSummary,
@@ -94,6 +96,7 @@ interface LoaderSetters {
   setHealthSummary: (v: AgentHealthSummary | null) => void
   setCostSummary: (v: AgentCostSummary | null) => void
   setPatterns: (v: AgentPatternsEnvelope) => void
+  setRawSignals: (v: RawSignalsEnvelope | null) => void
   setTriageList: (v: TriageSummaryRow[]) => void
 }
 
@@ -163,11 +166,22 @@ function buildLoaders(
       }
     },
     patterns: async () => {
-      const r = await getAgentPatterns()
-      if (r.isSuccess && r.data) {
-        ctx.setPatterns(r.data)
+      // Load detected patterns + raw signals in parallel — the raw signal
+      // counts let admins see classifier coverage even when zero patterns
+      // cross the suppression threshold.
+      const [p, rs] = await Promise.all([
+        getAgentPatterns(),
+        getAgentRawSignals(7),
+      ])
+      if (p.isSuccess && p.data) {
+        ctx.setPatterns(p.data)
+      } else if (!p.isSuccess) {
+        ctx.showError("patterns", p.message)
+      }
+      if (rs.isSuccess && rs.data) {
+        ctx.setRawSignals(rs.data)
       } else {
-        ctx.showError("patterns", r.message)
+        ctx.setRawSignals(null)
       }
     },
     triage: async () => {
@@ -258,6 +272,7 @@ function DashboardTabs({
   healthSummary,
   costSummary,
   patterns,
+  rawSignals,
   triageList,
 }: {
   activeTab: DashboardTab
@@ -272,6 +287,7 @@ function DashboardTabs({
   healthSummary: AgentHealthSummary | null
   costSummary: AgentCostSummary | null
   patterns: AgentPatternsEnvelope
+  rawSignals: RawSignalsEnvelope | null
   triageList: TriageSummaryRow[]
 }) {
   return (
@@ -323,7 +339,7 @@ function DashboardTabs({
       </TabsContent>
 
       <TabsContent value="patterns" className="mt-4">
-        <AgentPatternsTable data={patterns} loading={tabLoading} />
+        <AgentPatternsTable data={patterns} rawSignals={rawSignals} loading={tabLoading} />
       </TabsContent>
 
       <TabsContent value="skills" className="mt-4">
@@ -370,6 +386,7 @@ export function AgentDashboardClient() {
     rows: [],
     lastScan: null,
   })
+  const [rawSignals, setRawSignals] = useState<RawSignalsEnvelope | null>(null)
   const [triageList, setTriageList] = useState<TriageSummaryRow[]>([])
   const [tabLoading, setTabLoading] = useState(false)
 
@@ -409,7 +426,7 @@ export function AgentDashboardClient() {
     () => buildLoaders({
       setDailyUsage, setModelBreakdown, setUserUsage, setGuardrailEvents,
       setFeedbackList, setHealthSummary, setCostSummary, setPatterns,
-      setTriageList,
+      setRawSignals, setTriageList,
       showError,
     }),
     [showError]
@@ -506,6 +523,7 @@ export function AgentDashboardClient() {
         healthSummary={healthSummary}
         costSummary={costSummary}
         patterns={patterns}
+        rawSignals={rawSignals}
         triageList={triageList}
       />
     </div>

--- a/app/(protected)/admin/agents/_components/agent-dashboard-client.tsx
+++ b/app/(protected)/admin/agents/_components/agent-dashboard-client.tsx
@@ -27,6 +27,8 @@ import { SkillsListClient } from "../skills/_components/skills-list-client"
 import { CredentialsClient } from "../credentials/_components/credentials-client"
 import { AgentWorkspaceTable } from "./agent-workspace-table"
 import { AgentFailuresClient } from "./agent-failures-client"
+import { AgentTriageTable } from "./agent-triage-table"
+import { AgentConversationsTab } from "./agent-conversations"
 
 import {
   getAgentTelemetryStats,
@@ -54,6 +56,10 @@ import {
   type AgentCostSummary,
   type CostDateRange,
 } from "@/actions/admin/agent-cost.actions"
+import {
+  getTriageSummaryList,
+  type TriageSummaryRow,
+} from "@/actions/admin/agent-triage.actions"
 
 type DashboardTab =
   | "usage"
@@ -67,6 +73,8 @@ type DashboardTab =
   | "credentials"
   | "workspace"
   | "failures"
+  | "triage"
+  | "conversations"
 
 /**
  * Map telemetry date range to Cost Explorer range.
@@ -86,6 +94,7 @@ interface LoaderSetters {
   setHealthSummary: (v: AgentHealthSummary | null) => void
   setCostSummary: (v: AgentCostSummary | null) => void
   setPatterns: (v: AgentPatternsEnvelope) => void
+  setTriageList: (v: TriageSummaryRow[]) => void
 }
 
 interface LoaderContext extends LoaderSetters {
@@ -161,12 +170,21 @@ function buildLoaders(
         ctx.showError("patterns", r.message)
       }
     },
-    // Skills, credentials, and workspace tabs are self-contained — their client
-    // components handle their own loading. No work needed from the dashboard loader.
+    triage: async () => {
+      const r = await getTriageSummaryList()
+      if (r.isSuccess && r.data) {
+        ctx.setTriageList(r.data)
+      } else {
+        ctx.showError("triage", r.message)
+      }
+    },
+    // Skills, credentials, workspace, failures, and conversations tabs are
+    // self-contained — their client components handle their own loading.
     skills: async () => {},
     credentials: async () => {},
     workspace: async () => {},
     failures: async () => {},
+    conversations: async () => {},
   }
 }
 
@@ -240,6 +258,7 @@ function DashboardTabs({
   healthSummary,
   costSummary,
   patterns,
+  triageList,
 }: {
   activeTab: DashboardTab
   onTabChange: (tab: string) => void
@@ -253,6 +272,7 @@ function DashboardTabs({
   healthSummary: AgentHealthSummary | null
   costSummary: AgentCostSummary | null
   patterns: AgentPatternsEnvelope
+  triageList: TriageSummaryRow[]
 }) {
   return (
     <Tabs value={activeTab} onValueChange={onTabChange}>
@@ -268,6 +288,8 @@ function DashboardTabs({
         <TabsTrigger value="skills">Skills</TabsTrigger>
         <TabsTrigger value="credentials">Credentials</TabsTrigger>
         <TabsTrigger value="workspace">Workspace</TabsTrigger>
+        <TabsTrigger value="triage">Triage</TabsTrigger>
+        <TabsTrigger value="conversations">Conversations</TabsTrigger>
       </TabsList>
 
       <TabsContent value="usage" className="mt-4 space-y-6">
@@ -319,6 +341,14 @@ function DashboardTabs({
       <TabsContent value="failures" className="mt-4">
         <AgentFailuresClient />
       </TabsContent>
+
+      <TabsContent value="triage" className="mt-4">
+        <AgentTriageTable data={triageList} loading={tabLoading} />
+      </TabsContent>
+
+      <TabsContent value="conversations" className="mt-4">
+        <AgentConversationsTab />
+      </TabsContent>
     </Tabs>
   )
 }
@@ -340,6 +370,7 @@ export function AgentDashboardClient() {
     rows: [],
     lastScan: null,
   })
+  const [triageList, setTriageList] = useState<TriageSummaryRow[]>([])
   const [tabLoading, setTabLoading] = useState(false)
 
   // Request version counter — prevents stale responses from overwriting
@@ -378,6 +409,7 @@ export function AgentDashboardClient() {
     () => buildLoaders({
       setDailyUsage, setModelBreakdown, setUserUsage, setGuardrailEvents,
       setFeedbackList, setHealthSummary, setCostSummary, setPatterns,
+      setTriageList,
       showError,
     }),
     [showError]
@@ -474,6 +506,7 @@ export function AgentDashboardClient() {
         healthSummary={healthSummary}
         costSummary={costSummary}
         patterns={patterns}
+        triageList={triageList}
       />
     </div>
   )

--- a/app/(protected)/admin/agents/_components/agent-patterns-table.tsx
+++ b/app/(protected)/admin/agents/_components/agent-patterns-table.tsx
@@ -58,19 +58,50 @@ export function AgentPatternsTable({ data, loading = false }: Props) {
           </div>
         )}
         {rows.length === 0 ? (
-          <div className="h-40 flex flex-col items-center justify-center gap-2 text-sm">
-            <div className="text-muted-foreground">
-              {lastScan
-                ? "Scanner ran but no patterns met the suppression threshold."
-                : "Pattern scanner has not run yet."}
-            </div>
-            <div className="text-xs text-muted-foreground max-w-md text-center">
-              Scanner runs Sundays 23:00 UTC. Patterns are suppressed below 3
-              signals / 2 buildings (privacy guarantee). If{" "}
-              <code className="text-[11px]">agent_pattern_scan_runs</code>{" "}
-              stays empty despite agent_messages activity, the Lambda is
-              likely failing silently — check CloudWatch logs.
-            </div>
+          <div className="h-44 flex flex-col items-center justify-center gap-2 text-sm">
+            {!lastScan && (
+              <>
+                <div className="text-muted-foreground">
+                  Pattern scanner has not run yet.
+                </div>
+                <div className="text-xs text-muted-foreground max-w-md text-center">
+                  Scanner is scheduled for Sundays 23:00 UTC via EventBridge.
+                  If <code className="text-[11px]">agent_pattern_scan_runs</code>{" "}
+                  stays empty after the next Sunday, check the Lambda&apos;s
+                  CloudWatch logs.
+                </div>
+              </>
+            )}
+            {lastScan && lastScan.signalsTotal === 0 && (
+              <>
+                <div className="text-muted-foreground">
+                  Scanner ran cleanly but the signal store was empty.
+                </div>
+                <div className="text-xs text-muted-foreground max-w-lg text-center">
+                  The topic classifier produced no signals from recent agent
+                  traffic. This means the K-12 admin keyword taxonomy in{" "}
+                  <code className="text-[11px]">topic-classifier.ts</code>{" "}
+                  didn&apos;t match any messages — typical when most traffic is
+                  developer / system testing rather than school operations.
+                  Expand the keyword patterns to broaden coverage, or wait
+                  until production K-12 traffic builds up.
+                </div>
+              </>
+            )}
+            {lastScan && lastScan.signalsTotal > 0 && (
+              <>
+                <div className="text-muted-foreground">
+                  Scanner ran. {lastScan.signalsTotal} signals classified but
+                  no cross-building patterns met the 3-signal / 2-building
+                  suppression threshold.
+                </div>
+                <div className="text-xs text-muted-foreground max-w-md text-center">
+                  Privacy floor — patterns only surface when at least 3 signals
+                  span at least 2 buildings in the same week. Below that we
+                  consider them potentially identifying.
+                </div>
+              </>
+            )}
           </div>
         ) : (
           <Table>

--- a/app/(protected)/admin/agents/_components/agent-patterns-table.tsx
+++ b/app/(protected)/admin/agents/_components/agent-patterns-table.tsx
@@ -14,15 +14,23 @@ import {
 import type {
   AgentPatternRow,
   AgentPatternsEnvelope,
+  RawSignalsEnvelope,
 } from "@/actions/admin/agent-health.actions"
 import { formatDate } from "@/lib/date-utils"
 
 interface Props {
   data: AgentPatternsEnvelope
+  /**
+   * Raw per-topic signal counts straight from agent_messages.topic
+   * — bypasses the suppression threshold so admins can see what the
+   * classifier actually catches in real traffic. Optional so the
+   * component still renders if the loader fails / not yet wired.
+   */
+  rawSignals?: RawSignalsEnvelope | null
   loading?: boolean
 }
 
-export function AgentPatternsTable({ data, loading = false }: Props) {
+export function AgentPatternsTable({ data, rawSignals = null, loading = false }: Props) {
   const rows: AgentPatternRow[] = data.rows
   const lastScan = data.lastScan
   if (loading) {
@@ -147,6 +155,68 @@ export function AgentPatternsTable({ data, loading = false }: Props) {
           </Table>
         )}
       </CardContent>
+      {rawSignals && <RawSignalsSection signals={rawSignals} />}
     </Card>
+  )
+}
+
+function RawSignalsSection({ signals }: { signals: RawSignalsEnvelope }) {
+  const coveragePct = signals.totalMessages > 0
+    ? Math.round((signals.classifiedMessages / signals.totalMessages) * 100)
+    : 0
+
+  return (
+    <div className="border-t mx-6 pt-4 pb-6 space-y-3">
+      <div className="flex items-center justify-between">
+        <div>
+          <h3 className="text-sm font-medium">Raw signal volume (last {signals.daysBack}d)</h3>
+          <p className="text-xs text-muted-foreground mt-0.5">
+            Per-topic counts straight from <code className="text-[11px]">agent_messages.topic</code>
+            {" "}— bypasses the suppression threshold. Useful for tuning the
+            classifier when the panel above is empty.
+          </p>
+        </div>
+        <div className="text-xs text-muted-foreground text-right">
+          <div>
+            <span className="font-semibold text-foreground">{signals.classifiedMessages}</span> / {signals.totalMessages} classified ({coveragePct}%)
+          </div>
+          <div className="text-[11px]">
+            {signals.unclassifiedMessages} unclassified
+          </div>
+        </div>
+      </div>
+      {signals.rows.length === 0 ? (
+        <div className="text-xs text-muted-foreground italic">
+          No classified signals in this window. Either no agent traffic, or
+          the <code className="text-[11px]">topic-classifier.ts</code> patterns
+          didn&apos;t match the message content.
+        </div>
+      ) : (
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Topic</TableHead>
+              <TableHead className="text-right">Signals</TableHead>
+              <TableHead className="text-right">Unique users</TableHead>
+              <TableHead>Last seen</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {signals.rows.map((r) => (
+              <TableRow key={r.topic}>
+                <TableCell className="text-sm font-medium">{r.topic}</TableCell>
+                <TableCell className="text-right">{r.signalCount}</TableCell>
+                <TableCell className="text-right text-muted-foreground">
+                  {r.uniqueUsers}
+                </TableCell>
+                <TableCell className="text-xs text-muted-foreground">
+                  {formatDate(r.lastSeenAt, true)}
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      )}
+    </div>
   )
 }

--- a/app/(protected)/admin/agents/_components/agent-triage-table.tsx
+++ b/app/(protected)/admin/agents/_components/agent-triage-table.tsx
@@ -1,0 +1,130 @@
+"use client"
+
+import Link from "next/link"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Skeleton } from "@/components/ui/skeleton"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
+import type { TriageSummaryRow } from "@/actions/admin/agent-triage.actions"
+import { formatDate } from "@/lib/date-utils"
+
+interface Props {
+  data: TriageSummaryRow[]
+  loading?: boolean
+}
+
+export function AgentTriageTable({ data, loading = false }: Props) {
+  if (loading) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Email Triage</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <Skeleton className="h-48 w-full" />
+        </CardContent>
+      </Card>
+    )
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">Email Triage</CardTitle>
+        <p className="text-xs text-muted-foreground mt-1">
+          Per-user opt-in state for the @psd/Important / @psd/Later / @psd/News
+          / @psd/Task workflow. Click Manage to see decisions, rules, and admin
+          actions for a single user.
+        </p>
+      </CardHeader>
+      <CardContent>
+        {data.length === 0 ? (
+          <div className="h-32 flex flex-col items-center justify-center gap-1 text-sm text-muted-foreground">
+            <div>No users have opted in to email triage yet.</div>
+            <div className="text-xs">
+              Users opt in by asking their agent in Chat: &quot;start triaging
+              my email.&quot;
+            </div>
+          </div>
+        ) : (
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>User</TableHead>
+                <TableHead>Status</TableHead>
+                <TableHead className="text-right">Rules</TableHead>
+                <TableHead className="text-right">Escalations</TableHead>
+                <TableHead className="text-right">Recent decisions</TableHead>
+                <TableHead className="text-right">Learned</TableHead>
+                <TableHead>Last decision</TableHead>
+                <TableHead>Last poll</TableHead>
+                <TableHead></TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {data.map((r) => (
+                <TableRow key={r.userEmail}>
+                  <TableCell className="font-mono text-xs">
+                    {r.userEmail}
+                  </TableCell>
+                  <TableCell>
+                    {r.enabled ? (
+                      <Badge variant="default">enabled</Badge>
+                    ) : (
+                      <Badge variant="secondary">paused</Badge>
+                    )}
+                  </TableCell>
+                  <TableCell className="text-right">{r.ruleCount}</TableCell>
+                  <TableCell className="text-right">
+                    {r.escalationCount}
+                  </TableCell>
+                  <TableCell className="text-right">
+                    {r.recentDecisionsCount}
+                  </TableCell>
+                  <TableCell className="text-right text-muted-foreground">
+                    {r.learnedPatternsCount}
+                  </TableCell>
+                  <TableCell className="text-xs">
+                    {r.lastDecision ? (
+                      <span title={r.lastDecision.subject}>
+                        <Badge
+                          variant="outline"
+                          className="mr-1 text-[10px] py-0"
+                        >
+                          {r.lastDecision.label}
+                        </Badge>
+                        {formatDate(r.lastDecision.ts, true)}
+                      </span>
+                    ) : (
+                      <span className="text-muted-foreground">—</span>
+                    )}
+                  </TableCell>
+                  <TableCell className="text-xs text-muted-foreground">
+                    {r.lastPollAt ? formatDate(r.lastPollAt, true) : "—"}
+                  </TableCell>
+                  <TableCell>
+                    <Link
+                      href={`/admin/agents/${encodeURIComponent(r.userEmail)}/triage`}
+                    >
+                      <Button variant="outline" size="sm">
+                        Manage
+                      </Button>
+                    </Link>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/app/(protected)/admin/agents/credentials/_components/credentials-client.tsx
+++ b/app/(protected)/admin/agents/credentials/_components/credentials-client.tsx
@@ -93,14 +93,14 @@ export function CredentialsClient() {
   }, [])
 
   useEffect(() => {
-    loadAll()
+    void loadAll()
   }, [loadAll])
 
   const handleResolve = async (id: number, status: "fulfilled" | "rejected") => {
     const result = await resolveCredentialRequest(id, status)
     if (result.isSuccess) {
       toast({ title: `Request ${status}` })
-      loadAll()
+      void loadAll()
     } else {
       toast({
         title: "Error",
@@ -148,7 +148,7 @@ export function CredentialsClient() {
         setProvisionRequest(null)
         setProvisionValue("")
         setProvisionScope("shared")
-        loadAll()
+        void loadAll()
       } else {
         toast({
           title: "Provisioning failed",

--- a/app/(protected)/admin/agents/credentials/_components/credentials-client.tsx
+++ b/app/(protected)/admin/agents/credentials/_components/credentials-client.tsx
@@ -33,12 +33,28 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
 import { IconRefresh, IconCheck, IconX, IconLock, IconPlus } from "@tabler/icons-react"
 import {
   getCredentialReads,
   getCredentialRequests,
   getCredentialAuditLog,
   resolveCredentialRequest,
+  provisionCredentialFromRequest,
   provisionSharedSecret,
   type CredentialReadRow,
   type CredentialRequestRow,
@@ -52,6 +68,12 @@ export function CredentialsClient() {
   const [requests, setRequests] = useState<CredentialRequestRow[]>([])
   const [auditLog, setAuditLog] = useState<CredentialAuditRow[]>([])
   const [loading, setLoading] = useState(true)
+  // Provision-from-request dialog state — opens when admin clicks ✓ on a
+  // pending request. Forces secret+scope entry before flipping the row.
+  const [provisionRequest, setProvisionRequest] = useState<CredentialRequestRow | null>(null)
+  const [provisionValue, setProvisionValue] = useState("")
+  const [provisionScope, setProvisionScope] = useState<"shared" | "user">("shared")
+  const [provisionBusy, setProvisionBusy] = useState(false)
 
   const loadAll = useCallback(async () => {
     setLoading(true)
@@ -88,6 +110,57 @@ export function CredentialsClient() {
     }
   }
 
+  const openProvisionDialog = (request: CredentialRequestRow) => {
+    setProvisionRequest(request)
+    setProvisionValue("")
+    setProvisionScope("shared")
+  }
+
+  const closeProvisionDialog = () => {
+    if (provisionBusy) return
+    setProvisionRequest(null)
+    setProvisionValue("")
+    setProvisionScope("shared")
+  }
+
+  const handleProvisionFromRequest = async () => {
+    if (!provisionRequest) return
+    if (!provisionValue.trim()) {
+      toast({
+        title: "Secret value required",
+        description: "Paste the secret value before provisioning.",
+        variant: "destructive",
+      })
+      return
+    }
+    setProvisionBusy(true)
+    try {
+      const result = await provisionCredentialFromRequest(
+        provisionRequest.id,
+        provisionValue,
+        provisionScope,
+      )
+      if (result.isSuccess) {
+        toast({
+          title: result.data?.action === "rotated" ? "Secret rotated" : "Secret provisioned",
+          description: result.message,
+        })
+        setProvisionRequest(null)
+        setProvisionValue("")
+        setProvisionScope("shared")
+        loadAll()
+      } else {
+        toast({
+          title: "Provisioning failed",
+          description: result.message || "Could not provision secret.",
+          variant: "destructive",
+        })
+      }
+    } finally {
+      setProvisionBusy(false)
+    }
+  }
+
   const pendingCount = requests.filter((r) => r.status === "pending").length
 
   return (
@@ -113,7 +186,12 @@ export function CredentialsClient() {
         </TabsList>
 
         <TabsContent value="requests" className="mt-4">
-          <RequestsTable requests={requests} loading={loading} onResolve={handleResolve} />
+          <RequestsTable
+            requests={requests}
+            loading={loading}
+            onResolve={handleResolve}
+            onProvision={openProvisionDialog}
+          />
         </TabsContent>
 
         <TabsContent value="provision" className="mt-4">
@@ -128,6 +206,82 @@ export function CredentialsClient() {
           <AuditTable auditLog={auditLog} loading={loading} />
         </TabsContent>
       </Tabs>
+
+      <Dialog
+        open={provisionRequest !== null}
+        onOpenChange={(open) => {
+          if (!open) closeProvisionDialog()
+        }}
+      >
+        <DialogContent className="sm:max-w-lg">
+          <DialogHeader>
+            <DialogTitle>Provision credential</DialogTitle>
+            <DialogDescription>
+              Pastes the secret value into AWS Secrets Manager and marks the
+              request fulfilled in one step. The value is never logged or
+              persisted in the database; only the audit metadata is.
+            </DialogDescription>
+          </DialogHeader>
+          {provisionRequest && (
+            <div className="space-y-3 text-sm">
+              <div className="grid grid-cols-[120px_1fr] gap-y-1.5">
+                <div className="text-muted-foreground">Credential</div>
+                <div className="font-mono">{provisionRequest.credentialName}</div>
+                <div className="text-muted-foreground">Requested by</div>
+                <div>{provisionRequest.requestedBy}</div>
+                <div className="text-muted-foreground">Skill</div>
+                <div>{provisionRequest.skillContext || "—"}</div>
+                <div className="text-muted-foreground">Reason</div>
+                <div className="text-xs">{provisionRequest.reason}</div>
+              </div>
+              <div className="space-y-1.5">
+                <Label htmlFor="provision-scope">Scope</Label>
+                <Select
+                  value={provisionScope}
+                  onValueChange={(v) => setProvisionScope(v as "shared" | "user")}
+                >
+                  <SelectTrigger id="provision-scope">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="shared">
+                      shared — psd-agent-creds/&lt;env&gt;/shared/{provisionRequest.credentialName}
+                    </SelectItem>
+                    <SelectItem value="user">
+                      user — psd-agent-creds/&lt;env&gt;/user/{provisionRequest.requestedBy}/{provisionRequest.credentialName}
+                    </SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="space-y-1.5">
+                <Label htmlFor="provision-value">Secret value</Label>
+                <Textarea
+                  id="provision-value"
+                  value={provisionValue}
+                  onChange={(e) => setProvisionValue(e.target.value)}
+                  rows={5}
+                  placeholder="Paste the secret value here (will be written to AWS Secrets Manager)"
+                  spellCheck={false}
+                  autoComplete="off"
+                  data-1p-ignore
+                />
+                <p className="text-xs text-muted-foreground">
+                  The value is sent directly to AWS Secrets Manager. Don&apos;t
+                  paste descriptions or labels — only the raw secret.
+                </p>
+              </div>
+            </div>
+          )}
+          <DialogFooter>
+            <Button variant="outline" onClick={closeProvisionDialog} disabled={provisionBusy}>
+              Cancel
+            </Button>
+            <Button onClick={handleProvisionFromRequest} disabled={provisionBusy}>
+              {provisionBusy ? "Provisioning…" : "Provision + mark fulfilled"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   )
 }
@@ -254,11 +408,12 @@ function ProvisionForm({ onSuccess }: { onSuccess: () => void }) {
 }
 
 function RequestsTable({
-  requests, loading, onResolve,
+  requests, loading, onResolve, onProvision,
 }: {
   requests: CredentialRequestRow[]
   loading: boolean
   onResolve: (id: number, status: "fulfilled" | "rejected") => void
+  onProvision: (request: CredentialRequestRow) => void
 }) {
   return (
     <div className="rounded-md border">
@@ -318,12 +473,13 @@ function RequestsTable({
                   {req.status === "pending" && (
                     <div className="flex gap-1">
                       <Button
-                        size="icon"
-                        variant="ghost"
-                        onClick={() => onResolve(req.id, "fulfilled")}
-                        title="Mark as fulfilled"
+                        size="sm"
+                        variant="default"
+                        onClick={() => onProvision(req)}
+                        title="Provision secret + mark fulfilled"
                       >
-                        <IconCheck className="h-4 w-4" />
+                        <IconCheck className="h-4 w-4 mr-1" />
+                        Provision
                       </Button>
                       <Button
                         size="icon"

--- a/app/api/agent/feedback/route.ts
+++ b/app/api/agent/feedback/route.ts
@@ -19,7 +19,6 @@
 import { NextRequest, NextResponse } from "next/server"
 import { createLogger, generateRequestId, sanitizeForLogging } from "@/lib/logger"
 import { executeQuery } from "@/lib/db/drizzle-client"
-import { sql } from "drizzle-orm"
 import { agentFeedback } from "@/lib/db/schema/tables/agent-feedback"
 import { getSecretString } from "@/lib/agent-workspace/secrets-manager"
 import { timingSafeEqual } from "node:crypto"
@@ -87,7 +86,6 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
             target: [agentFeedback.userId, agentFeedback.messageId],
             set: {
               thumbsUp: body.thumbsUp!,
-              createdAt: sql`NOW()`,
             },
           }),
       "agentFeedback.insertOrUpdate",

--- a/app/api/agent/feedback/route.ts
+++ b/app/api/agent/feedback/route.ts
@@ -1,0 +1,113 @@
+/**
+ * Agent Feedback Capture
+ *
+ * POST /api/agent/feedback
+ * Auth: Bearer {shared-secret} from psd-agent/{env}/internal-api-key
+ *
+ * Records a thumbs-up / thumbs-down on a specific agent_messages row.
+ * Called by the agent-router (or agent-cron) Lambda when a user clicks
+ * a feedback button on a Chat card. UNIQUE(user_id, message_id) means
+ * a second click for the same user+message updates the previous vote
+ * via an ON CONFLICT DO UPDATE.
+ *
+ * The route itself is dumb — it doesn't validate the user actually saw
+ * that message. The agent Lambda is the trust boundary: only it knows
+ * the messageId for a given Chat card and authenticates with the shared
+ * secret. Anyone with the shared secret can write any feedback row.
+ */
+
+import { NextRequest, NextResponse } from "next/server"
+import { createLogger, generateRequestId, sanitizeForLogging } from "@/lib/logger"
+import { executeQuery } from "@/lib/db/drizzle-client"
+import { sql } from "drizzle-orm"
+import { agentFeedback } from "@/lib/db/schema/tables/agent-feedback"
+import { getSecretString } from "@/lib/agent-workspace/secrets-manager"
+import { timingSafeEqual } from "node:crypto"
+
+const log = createLogger({ module: "agent-feedback" })
+
+async function getExpectedSecret(): Promise<string | null> {
+  const envVal = process.env.AGENT_INTERNAL_API_KEY
+  if (envVal) return envVal
+  const id = process.env.AGENT_INTERNAL_API_KEY_SECRET_ID
+  if (!id) return null
+  return getSecretString(id)
+}
+
+function authorized(req: NextRequest, expected: string): boolean {
+  const header = req.headers.get("authorization") ?? ""
+  const match = /^Bearer\s+(.+)$/.exec(header)
+  if (!match) return false
+  const presented = match[1].trim()
+  const a = Buffer.from(presented, "utf8")
+  const b = Buffer.from(expected, "utf8")
+  if (a.length !== b.length) return false
+  return timingSafeEqual(a, b)
+}
+
+interface FeedbackBody {
+  userId?: string
+  messageId?: number
+  thumbsUp?: boolean
+}
+
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  const requestId = generateRequestId()
+  try {
+    const expected = await getExpectedSecret()
+    if (!expected) {
+      log.error("AGENT_INTERNAL_API_KEY not configured", { requestId })
+      return NextResponse.json(
+        { error: "Feedback endpoint not configured" },
+        { status: 503 },
+      )
+    }
+    if (!authorized(req, expected)) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+    }
+
+    const body = (await req.json().catch(() => null)) as FeedbackBody | null
+    if (!body || !body.userId || typeof body.messageId !== "number" || typeof body.thumbsUp !== "boolean") {
+      return NextResponse.json(
+        { error: "Body must be { userId: string, messageId: number, thumbsUp: boolean }" },
+        { status: 400 },
+      )
+    }
+
+    await executeQuery(
+      (db) =>
+        db
+          .insert(agentFeedback)
+          .values({
+            userId: body.userId!,
+            messageId: body.messageId!,
+            thumbsUp: body.thumbsUp!,
+          })
+          .onConflictDoUpdate({
+            target: [agentFeedback.userId, agentFeedback.messageId],
+            set: {
+              thumbsUp: body.thumbsUp!,
+              createdAt: sql`NOW()`,
+            },
+          }),
+      "agentFeedback.insertOrUpdate",
+    )
+
+    log.info(
+      "Feedback recorded",
+      sanitizeForLogging({
+        requestId,
+        userId: body.userId,
+        messageId: body.messageId,
+        thumbsUp: body.thumbsUp,
+      }),
+    )
+    return NextResponse.json({ ok: true })
+  } catch (err) {
+    log.error("Feedback write failed", {
+      requestId,
+      error: err instanceof Error ? err.message : String(err),
+    })
+    return NextResponse.json({ error: "Internal error" }, { status: 500 })
+  }
+}

--- a/app/api/agent/feedback/route.ts
+++ b/app/api/agent/feedback/route.ts
@@ -66,7 +66,7 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
     }
 
     const body = (await req.json().catch(() => null)) as FeedbackBody | null
-    if (!body || !body.userId || typeof body.messageId !== "number" || typeof body.thumbsUp !== "boolean") {
+    if (!body || typeof body.userId !== "string" || !body.userId || typeof body.messageId !== "number" || typeof body.thumbsUp !== "boolean") {
       return NextResponse.json(
         { error: "Body must be { userId: string, messageId: number, thumbsUp: boolean }" },
         { status: 400 },

--- a/bun.lock
+++ b/bun.lock
@@ -29,6 +29,7 @@
         "@aws-sdk/client-sqs": "^3.982.0",
         "@aws-sdk/client-ssm": "^3.982.0",
         "@aws-sdk/credential-providers": "^3.982.0",
+        "@aws-sdk/lib-dynamodb": "~3.982.0",
         "@aws-sdk/s3-request-presigner": "^3.982.0",
         "@aws-sdk/util-dynamodb": "^3.982.0",
         "@dnd-kit/core": "^6.3.1",
@@ -323,6 +324,8 @@
     "@aws-sdk/endpoint-cache": ["@aws-sdk/endpoint-cache@3.972.2", "", { "dependencies": { "mnemonist": "0.38.3", "tslib": "^2.6.2" } }, "sha512-3L7mwqSLJ6ouZZKtCntoNF0HTYDNs1FDQqkGjoPWXcv1p0gnLotaDmLq1rIDqfu4ucOit0Re3ioLyYDUTpSroA=="],
 
     "@aws-sdk/eventstream-handler-node": ["@aws-sdk/eventstream-handler-node@3.972.4", "", { "dependencies": { "@aws-sdk/types": "^3.973.1", "@smithy/eventstream-codec": "^4.2.8", "@smithy/types": "^4.12.0", "tslib": "^2.6.2" } }, "sha512-LPIN505kUqL3xwtoGYgYkctkUUuVUD4pzZfSo+CahavNft+zty5xWYWhKfnZOKBkYCMUl2Hl/9mkoPeYwxfQvQ=="],
+
+    "@aws-sdk/lib-dynamodb": ["@aws-sdk/lib-dynamodb@3.982.0", "", { "dependencies": { "@aws-sdk/core": "^3.973.6", "@aws-sdk/util-dynamodb": "3.982.0", "@smithy/core": "^3.22.0", "@smithy/smithy-client": "^4.11.1", "@smithy/types": "^4.12.0", "tslib": "^2.6.2" }, "peerDependencies": { "@aws-sdk/client-dynamodb": "3.982.0" } }, "sha512-7wdaH3OcG7tRWD+9Mm6iN/u/Ccw3Ley/m8nSeTFocBj4fqkJwpa4k3vfS1uLlDqynnn6NIXPSrpuikzE1nlwSA=="],
 
     "@aws-sdk/middleware-bucket-endpoint": ["@aws-sdk/middleware-bucket-endpoint@3.972.3", "", { "dependencies": { "@aws-sdk/types": "^3.973.1", "@aws-sdk/util-arn-parser": "^3.972.2", "@smithy/node-config-provider": "^4.3.8", "@smithy/protocol-http": "^5.3.8", "@smithy/types": "^4.12.0", "@smithy/util-config-provider": "^4.2.0", "tslib": "^2.6.2" } }, "sha512-fmbgWYirF67YF1GfD7cg5N6HHQ96EyRNx/rDIrTF277/zTWVuPI2qS/ZHgofwR1NZPe/NWvoppflQY01LrbVLg=="],
 
@@ -3712,6 +3715,14 @@
 
     "@aws-sdk/credential-provider-cognito-identity/@aws-sdk/client-cognito-identity": ["@aws-sdk/client-cognito-identity@3.980.0", "", { "dependencies": { "@aws-crypto/sha256-browser": "5.2.0", "@aws-crypto/sha256-js": "5.2.0", "@aws-sdk/core": "^3.973.5", "@aws-sdk/credential-provider-node": "^3.972.4", "@aws-sdk/middleware-host-header": "^3.972.3", "@aws-sdk/middleware-logger": "^3.972.3", "@aws-sdk/middleware-recursion-detection": "^3.972.3", "@aws-sdk/middleware-user-agent": "^3.972.5", "@aws-sdk/region-config-resolver": "^3.972.3", "@aws-sdk/types": "^3.973.1", "@aws-sdk/util-endpoints": "3.980.0", "@aws-sdk/util-user-agent-browser": "^3.972.3", "@aws-sdk/util-user-agent-node": "^3.972.3", "@smithy/config-resolver": "^4.4.6", "@smithy/core": "^3.22.0", "@smithy/fetch-http-handler": "^5.3.9", "@smithy/hash-node": "^4.2.8", "@smithy/invalid-dependency": "^4.2.8", "@smithy/middleware-content-length": "^4.2.8", "@smithy/middleware-endpoint": "^4.4.12", "@smithy/middleware-retry": "^4.4.29", "@smithy/middleware-serde": "^4.2.9", "@smithy/middleware-stack": "^4.2.8", "@smithy/node-config-provider": "^4.3.8", "@smithy/node-http-handler": "^4.4.8", "@smithy/protocol-http": "^5.3.8", "@smithy/smithy-client": "^4.11.1", "@smithy/types": "^4.12.0", "@smithy/url-parser": "^4.2.8", "@smithy/util-base64": "^4.3.0", "@smithy/util-body-length-browser": "^4.2.0", "@smithy/util-body-length-node": "^4.2.1", "@smithy/util-defaults-mode-browser": "^4.3.28", "@smithy/util-defaults-mode-node": "^4.2.31", "@smithy/util-endpoints": "^3.2.8", "@smithy/util-middleware": "^4.2.8", "@smithy/util-retry": "^4.2.8", "@smithy/util-utf8": "^4.2.0", "tslib": "^2.6.2" } }, "sha512-nLgMW2drTzv+dTo3ORCcotQPcrUaTQ+xoaDTdSaUXdZO7zbbVyk7ysE5GDTnJdZWcUjHOSB8xfNQhOTTNVPhFw=="],
 
+    "@aws-sdk/lib-dynamodb/@aws-sdk/core": ["@aws-sdk/core@3.974.4", "", { "dependencies": { "@aws-sdk/types": "^3.973.8", "@aws-sdk/xml-builder": "^3.972.18", "@smithy/core": "^3.23.16", "@smithy/node-config-provider": "^4.3.14", "@smithy/property-provider": "^4.2.14", "@smithy/protocol-http": "^5.3.14", "@smithy/signature-v4": "^5.3.14", "@smithy/smithy-client": "^4.12.12", "@smithy/types": "^4.14.1", "@smithy/util-base64": "^4.3.2", "@smithy/util-middleware": "^4.2.14", "@smithy/util-retry": "^4.3.3", "@smithy/util-utf8": "^4.2.2", "tslib": "^2.6.2" } }, "sha512-EbVgyzQ83/Lf6oh1O4vYY47tuYw3Aosthh865LNU77KyotKz+uvEBNmsl/bSVS/vG+IU39mCqcOHrnhmhF4lug=="],
+
+    "@aws-sdk/lib-dynamodb/@smithy/core": ["@smithy/core@3.23.16", "", { "dependencies": { "@smithy/protocol-http": "^5.3.14", "@smithy/types": "^4.14.1", "@smithy/url-parser": "^4.2.14", "@smithy/util-base64": "^4.3.2", "@smithy/util-body-length-browser": "^4.2.2", "@smithy/util-middleware": "^4.2.14", "@smithy/util-stream": "^4.5.24", "@smithy/util-utf8": "^4.2.2", "@smithy/uuid": "^1.1.2", "tslib": "^2.6.2" } }, "sha512-JStomOrINQA1VqNEopLsgcdgwd42au7mykKqVr30XFw89wLt9sDxJDi4djVPRwQmmzyTGy/uOvTc2ultMpFi1w=="],
+
+    "@aws-sdk/lib-dynamodb/@smithy/smithy-client": ["@smithy/smithy-client@4.12.12", "", { "dependencies": { "@smithy/core": "^3.23.16", "@smithy/middleware-endpoint": "^4.4.31", "@smithy/middleware-stack": "^4.2.14", "@smithy/protocol-http": "^5.3.14", "@smithy/types": "^4.14.1", "@smithy/util-stream": "^4.5.24", "tslib": "^2.6.2" } }, "sha512-daO7SJn4eM6ArbmrEs+/BTbH7af8AEbSL3OMQdcRvvn8tuUcR5rU2n6DgxIV53aXMS42uwK8NgKKCh5XgqYOPQ=="],
+
+    "@aws-sdk/lib-dynamodb/@smithy/types": ["@smithy/types@4.14.1", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-59b5HtSVrVR/eYNei3BUj3DCPKD/G7EtDDe7OEJE7i7FtQFugYo6MxbotS8mVJkLNVf8gYaAlEBwwtJ9HzhWSg=="],
+
     "@aws-sdk/xml-builder/fast-xml-parser": ["fast-xml-parser@5.3.4", "", { "dependencies": { "strnum": "^2.1.0" }, "bin": { "fxparser": "src/cli/cli.js" } }, "sha512-EFd6afGmXlCx8H8WTZHhAoDaWaGyuIBoZJ2mknrNxug+aZKjkp0a0dlars9Izl+jF+7Gu1/5f/2h68cQpe0IiA=="],
 
     "@babel/core/semver": ["semver@6.3.1", "", { "bin": "bin/semver.js" }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
@@ -4246,6 +4257,50 @@
 
     "@aws-sdk/credential-provider-cognito-identity/@aws-sdk/client-cognito-identity/@aws-sdk/util-endpoints": ["@aws-sdk/util-endpoints@3.980.0", "", { "dependencies": { "@aws-sdk/types": "^3.973.1", "@smithy/types": "^4.12.0", "@smithy/url-parser": "^4.2.8", "@smithy/util-endpoints": "^3.2.8", "tslib": "^2.6.2" } }, "sha512-AjKBNEc+rjOZQE1HwcD9aCELqg1GmUj1rtICKuY8cgwB73xJ4U/kNyqKKpN2k9emGqlfDY2D8itIp/vDc6OKpw=="],
 
+    "@aws-sdk/lib-dynamodb/@aws-sdk/core/@aws-sdk/types": ["@aws-sdk/types@3.973.8", "", { "dependencies": { "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw=="],
+
+    "@aws-sdk/lib-dynamodb/@aws-sdk/core/@aws-sdk/xml-builder": ["@aws-sdk/xml-builder@3.972.18", "", { "dependencies": { "@smithy/types": "^4.14.1", "fast-xml-parser": "5.5.8", "tslib": "^2.6.2" } }, "sha512-BMDNVG1ETXRhl1tnisQiYBef3RShJ1kfZA7x7afivTFMLirfHNTb6U71K569HNXhSXbQZsweHvSDZ6euBw8hPA=="],
+
+    "@aws-sdk/lib-dynamodb/@aws-sdk/core/@smithy/node-config-provider": ["@smithy/node-config-provider@4.3.14", "", { "dependencies": { "@smithy/property-provider": "^4.2.14", "@smithy/shared-ini-file-loader": "^4.4.9", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-S+gFjyo/weSVL0P1b9Ts8C/CwIfNCgUPikk3sl6QVsfE/uUuO+QsF+NsE/JkpvWqqyz1wg7HFdiaZuj5CoBMRg=="],
+
+    "@aws-sdk/lib-dynamodb/@aws-sdk/core/@smithy/property-provider": ["@smithy/property-provider@4.2.14", "", { "dependencies": { "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-WuM31CgfsnQ/10i7NYr0PyxqknD72Y5uMfUMVSniPjbEPceiTErb4eIqJQ+pdxNEAUEWrewrGjIRjVbVHsxZiQ=="],
+
+    "@aws-sdk/lib-dynamodb/@aws-sdk/core/@smithy/protocol-http": ["@smithy/protocol-http@5.3.14", "", { "dependencies": { "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-dN5F8kHx8RNU0r+pCwNmFZyz6ChjMkzShy/zup6MtkRmmix4vZzJdW+di7x//b1LiynIev88FM18ie+wwPcQtQ=="],
+
+    "@aws-sdk/lib-dynamodb/@aws-sdk/core/@smithy/signature-v4": ["@smithy/signature-v4@5.3.14", "", { "dependencies": { "@smithy/is-array-buffer": "^4.2.2", "@smithy/protocol-http": "^5.3.14", "@smithy/types": "^4.14.1", "@smithy/util-hex-encoding": "^4.2.2", "@smithy/util-middleware": "^4.2.14", "@smithy/util-uri-escape": "^4.2.2", "@smithy/util-utf8": "^4.2.2", "tslib": "^2.6.2" } }, "sha512-1D9Y/nmlVjCeSivCbhZ7hgEpmHyY1h0GvpSZt3l0xcD9JjmjVC1CHOozS6+Gh+/ldMH8JuJ6cujObQqfayAVFA=="],
+
+    "@aws-sdk/lib-dynamodb/@aws-sdk/core/@smithy/util-base64": ["@smithy/util-base64@4.3.2", "", { "dependencies": { "@smithy/util-buffer-from": "^4.2.2", "@smithy/util-utf8": "^4.2.2", "tslib": "^2.6.2" } }, "sha512-XRH6b0H/5A3SgblmMa5ErXQ2XKhfbQB+Fm/oyLZ2O2kCUrwgg55bU0RekmzAhuwOjA9qdN5VU2BprOvGGUkOOQ=="],
+
+    "@aws-sdk/lib-dynamodb/@aws-sdk/core/@smithy/util-middleware": ["@smithy/util-middleware@4.2.14", "", { "dependencies": { "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-1Su2vj9RYNDEv/V+2E+jXkkwGsgR7dc4sfHn9Z7ruzQHJIEni9zzw5CauvRXlFJfmgcqYP8fWa0dkh2Q2YaQyw=="],
+
+    "@aws-sdk/lib-dynamodb/@aws-sdk/core/@smithy/util-retry": ["@smithy/util-retry@4.3.3", "", { "dependencies": { "@smithy/service-error-classification": "^4.3.0", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-idjUvd4M9Jj6rXkhqw4H4reHoweuK4ZxYWyOrEp4N2rOF5VtaOlQGLDQJva/8WanNXk9ScQtsAb7o5UHGvFm4A=="],
+
+    "@aws-sdk/lib-dynamodb/@aws-sdk/core/@smithy/util-utf8": ["@smithy/util-utf8@4.2.2", "", { "dependencies": { "@smithy/util-buffer-from": "^4.2.2", "tslib": "^2.6.2" } }, "sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw=="],
+
+    "@aws-sdk/lib-dynamodb/@smithy/core/@smithy/protocol-http": ["@smithy/protocol-http@5.3.14", "", { "dependencies": { "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-dN5F8kHx8RNU0r+pCwNmFZyz6ChjMkzShy/zup6MtkRmmix4vZzJdW+di7x//b1LiynIev88FM18ie+wwPcQtQ=="],
+
+    "@aws-sdk/lib-dynamodb/@smithy/core/@smithy/url-parser": ["@smithy/url-parser@4.2.14", "", { "dependencies": { "@smithy/querystring-parser": "^4.2.14", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-p06BiBigJ8bTA3MgnOfCtDUWnAMY0YfedO/GRpmc7p+wg3KW8vbXy1xwSu5ASy0wV7rRYtlfZOIKH4XqfhjSQQ=="],
+
+    "@aws-sdk/lib-dynamodb/@smithy/core/@smithy/util-base64": ["@smithy/util-base64@4.3.2", "", { "dependencies": { "@smithy/util-buffer-from": "^4.2.2", "@smithy/util-utf8": "^4.2.2", "tslib": "^2.6.2" } }, "sha512-XRH6b0H/5A3SgblmMa5ErXQ2XKhfbQB+Fm/oyLZ2O2kCUrwgg55bU0RekmzAhuwOjA9qdN5VU2BprOvGGUkOOQ=="],
+
+    "@aws-sdk/lib-dynamodb/@smithy/core/@smithy/util-body-length-browser": ["@smithy/util-body-length-browser@4.2.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-JKCrLNOup3OOgmzeaKQwi4ZCTWlYR5H4Gm1r2uTMVBXoemo1UEghk5vtMi1xSu2ymgKVGW631e2fp9/R610ZjQ=="],
+
+    "@aws-sdk/lib-dynamodb/@smithy/core/@smithy/util-middleware": ["@smithy/util-middleware@4.2.14", "", { "dependencies": { "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-1Su2vj9RYNDEv/V+2E+jXkkwGsgR7dc4sfHn9Z7ruzQHJIEni9zzw5CauvRXlFJfmgcqYP8fWa0dkh2Q2YaQyw=="],
+
+    "@aws-sdk/lib-dynamodb/@smithy/core/@smithy/util-stream": ["@smithy/util-stream@4.5.24", "", { "dependencies": { "@smithy/fetch-http-handler": "^5.3.17", "@smithy/node-http-handler": "^4.6.0", "@smithy/types": "^4.14.1", "@smithy/util-base64": "^4.3.2", "@smithy/util-buffer-from": "^4.2.2", "@smithy/util-hex-encoding": "^4.2.2", "@smithy/util-utf8": "^4.2.2", "tslib": "^2.6.2" } }, "sha512-na5vv2mBSDzXewLEEoWGI7LQQkfpmFEomBsmOpzLFjqGctm0iMwXY5lAwesY9pIaErkccW0qzEOUcYP+WKneXg=="],
+
+    "@aws-sdk/lib-dynamodb/@smithy/core/@smithy/util-utf8": ["@smithy/util-utf8@4.2.2", "", { "dependencies": { "@smithy/util-buffer-from": "^4.2.2", "tslib": "^2.6.2" } }, "sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw=="],
+
+    "@aws-sdk/lib-dynamodb/@smithy/core/@smithy/uuid": ["@smithy/uuid@1.1.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-O/IEdcCUKkubz60tFbGA7ceITTAJsty+lBjNoorP4Z6XRqaFb/OjQjZODophEcuq68nKm6/0r+6/lLQ+XVpk8g=="],
+
+    "@aws-sdk/lib-dynamodb/@smithy/smithy-client/@smithy/middleware-endpoint": ["@smithy/middleware-endpoint@4.4.31", "", { "dependencies": { "@smithy/core": "^3.23.16", "@smithy/middleware-serde": "^4.2.19", "@smithy/node-config-provider": "^4.3.14", "@smithy/shared-ini-file-loader": "^4.4.9", "@smithy/types": "^4.14.1", "@smithy/url-parser": "^4.2.14", "@smithy/util-middleware": "^4.2.14", "tslib": "^2.6.2" } }, "sha512-KJPdCIN2kOE2aGmqZd7eUTr4WQwOGgtLWgUkswGJggs7rBcQYQjcZMEDa3C0DwbOiXS9L8/wDoQHkfxBYLfiLw=="],
+
+    "@aws-sdk/lib-dynamodb/@smithy/smithy-client/@smithy/middleware-stack": ["@smithy/middleware-stack@4.2.14", "", { "dependencies": { "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-2dvkUKLuFdKsCRmOE4Mn63co0Djtsm+JMh0bYZQupN1pJwMeE8FmQmRLLzzEMN0dnNi7CDCYYH8F0EVwWiPBeA=="],
+
+    "@aws-sdk/lib-dynamodb/@smithy/smithy-client/@smithy/protocol-http": ["@smithy/protocol-http@5.3.14", "", { "dependencies": { "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-dN5F8kHx8RNU0r+pCwNmFZyz6ChjMkzShy/zup6MtkRmmix4vZzJdW+di7x//b1LiynIev88FM18ie+wwPcQtQ=="],
+
+    "@aws-sdk/lib-dynamodb/@smithy/smithy-client/@smithy/util-stream": ["@smithy/util-stream@4.5.24", "", { "dependencies": { "@smithy/fetch-http-handler": "^5.3.17", "@smithy/node-http-handler": "^4.6.0", "@smithy/types": "^4.14.1", "@smithy/util-base64": "^4.3.2", "@smithy/util-buffer-from": "^4.2.2", "@smithy/util-hex-encoding": "^4.2.2", "@smithy/util-utf8": "^4.2.2", "tslib": "^2.6.2" } }, "sha512-na5vv2mBSDzXewLEEoWGI7LQQkfpmFEomBsmOpzLFjqGctm0iMwXY5lAwesY9pIaErkccW0qzEOUcYP+WKneXg=="],
+
     "@aws-sdk/xml-builder/fast-xml-parser/strnum": ["strnum@2.1.2", "", {}, "sha512-l63NF9y/cLROq/yqKXSLtcMeeyOfnSQlfMSlzFt/K73oIaD8DGaQWd7Z34X9GPiKqP5rbSh84Hl4bOlLcjiSrQ=="],
 
     "@esbuild-kit/core-utils/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.18.20", "", { "os": "android", "cpu": "arm" }, "sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw=="],
@@ -4560,6 +4615,58 @@
 
     "@aws-sdk/client-sts/@aws-sdk/credential-provider-node/@aws-sdk/credential-provider-sso/@aws-sdk/token-providers": ["@aws-sdk/token-providers@3.723.0", "", { "dependencies": { "@aws-sdk/types": "3.723.0", "@smithy/property-provider": "^4.0.0", "@smithy/shared-ini-file-loader": "^4.0.0", "@smithy/types": "^4.0.0", "tslib": "^2.6.2" }, "peerDependencies": { "@aws-sdk/client-sso-oidc": "^3.723.0" } }, "sha512-hniWi1x4JHVwKElANh9afKIMUhAutHVBRD8zo6usr0PAoj+Waf220+1ULS74GXtLXAPCiNXl5Og+PHA7xT8ElQ=="],
 
+    "@aws-sdk/lib-dynamodb/@aws-sdk/core/@aws-sdk/xml-builder/fast-xml-parser": ["fast-xml-parser@5.5.8", "", { "dependencies": { "fast-xml-builder": "^1.1.4", "path-expression-matcher": "^1.2.0", "strnum": "^2.2.0" }, "bin": { "fxparser": "src/cli/cli.js" } }, "sha512-Z7Fh2nVQSb2d+poDViM063ix2ZGt9jmY1nWhPfHBOK2Hgnb/OW3P4Et3P/81SEej0J7QbWtJqxO05h8QYfK7LQ=="],
+
+    "@aws-sdk/lib-dynamodb/@aws-sdk/core/@smithy/node-config-provider/@smithy/shared-ini-file-loader": ["@smithy/shared-ini-file-loader@4.4.9", "", { "dependencies": { "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-495/V2I15SHgedSJoDPD23JuSfKAp726ZI1V0wtjB07Wh7q/0tri/0e0DLefZCHgxZonrGKt/OCTpAtP1wE1kQ=="],
+
+    "@aws-sdk/lib-dynamodb/@aws-sdk/core/@smithy/signature-v4/@smithy/is-array-buffer": ["@smithy/is-array-buffer@4.2.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-n6rQ4N8Jj4YTQO3YFrlgZuwKodf4zUFs7EJIWH86pSCWBaAtAGBFfCM7Wx6D2bBJ2xqFNxGBSrUWswT3M0VJow=="],
+
+    "@aws-sdk/lib-dynamodb/@aws-sdk/core/@smithy/signature-v4/@smithy/util-hex-encoding": ["@smithy/util-hex-encoding@4.2.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-Qcz3W5vuHK4sLQdyT93k/rfrUwdJ8/HZ+nMUOyGdpeGA1Wxt65zYwi3oEl9kOM+RswvYq90fzkNDahPS8K0OIg=="],
+
+    "@aws-sdk/lib-dynamodb/@aws-sdk/core/@smithy/signature-v4/@smithy/util-uri-escape": ["@smithy/util-uri-escape@4.2.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-2kAStBlvq+lTXHyAZYfJRb/DfS3rsinLiwb+69SstC9Vb0s9vNWkRwpnj918Pfi85mzi42sOqdV72OLxWAISnw=="],
+
+    "@aws-sdk/lib-dynamodb/@aws-sdk/core/@smithy/util-base64/@smithy/util-buffer-from": ["@smithy/util-buffer-from@4.2.2", "", { "dependencies": { "@smithy/is-array-buffer": "^4.2.2", "tslib": "^2.6.2" } }, "sha512-FDXD7cvUoFWwN6vtQfEta540Y/YBe5JneK3SoZg9bThSoOAC/eGeYEua6RkBgKjGa/sz6Y+DuBZj3+YEY21y4Q=="],
+
+    "@aws-sdk/lib-dynamodb/@aws-sdk/core/@smithy/util-retry/@smithy/service-error-classification": ["@smithy/service-error-classification@4.3.0", "", { "dependencies": { "@smithy/types": "^4.14.1" } }, "sha512-9jKsBYQRPR0xBLgc2415RsA5PIcP2sis4oBdN9s0D13cg1B1284mNTjx9Yc+BEERXzuPm5ObktI96OxsKh8E9A=="],
+
+    "@aws-sdk/lib-dynamodb/@aws-sdk/core/@smithy/util-utf8/@smithy/util-buffer-from": ["@smithy/util-buffer-from@4.2.2", "", { "dependencies": { "@smithy/is-array-buffer": "^4.2.2", "tslib": "^2.6.2" } }, "sha512-FDXD7cvUoFWwN6vtQfEta540Y/YBe5JneK3SoZg9bThSoOAC/eGeYEua6RkBgKjGa/sz6Y+DuBZj3+YEY21y4Q=="],
+
+    "@aws-sdk/lib-dynamodb/@smithy/core/@smithy/url-parser/@smithy/querystring-parser": ["@smithy/querystring-parser@4.2.14", "", { "dependencies": { "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-hr+YyqBD23GVvRxGGrcc/oOeNlK3PzT5Fu4dzrDXxzS1LpFiuL2PQQqKPs87M79aW7ziMs+nvB3qdw77SqE7Lw=="],
+
+    "@aws-sdk/lib-dynamodb/@smithy/core/@smithy/util-base64/@smithy/util-buffer-from": ["@smithy/util-buffer-from@4.2.2", "", { "dependencies": { "@smithy/is-array-buffer": "^4.2.2", "tslib": "^2.6.2" } }, "sha512-FDXD7cvUoFWwN6vtQfEta540Y/YBe5JneK3SoZg9bThSoOAC/eGeYEua6RkBgKjGa/sz6Y+DuBZj3+YEY21y4Q=="],
+
+    "@aws-sdk/lib-dynamodb/@smithy/core/@smithy/util-stream/@smithy/fetch-http-handler": ["@smithy/fetch-http-handler@5.3.17", "", { "dependencies": { "@smithy/protocol-http": "^5.3.14", "@smithy/querystring-builder": "^4.2.14", "@smithy/types": "^4.14.1", "@smithy/util-base64": "^4.3.2", "tslib": "^2.6.2" } }, "sha512-bXOvQzaSm6MnmLaWA1elgfQcAtN4UP3vXqV97bHuoOrHQOJiLT3ds6o9eo5bqd0TJfRFpzdGnDQdW3FACiAVdw=="],
+
+    "@aws-sdk/lib-dynamodb/@smithy/core/@smithy/util-stream/@smithy/node-http-handler": ["@smithy/node-http-handler@4.6.0", "", { "dependencies": { "@smithy/protocol-http": "^5.3.14", "@smithy/querystring-builder": "^4.2.14", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-P734cAoTFtuGfWa/R3jgBnGlURt2w9bYEBwQNMKf58sRM9RShirB2mKwLsVP+jlG/wxpCu8abv8NxdUts8tdLA=="],
+
+    "@aws-sdk/lib-dynamodb/@smithy/core/@smithy/util-stream/@smithy/util-buffer-from": ["@smithy/util-buffer-from@4.2.2", "", { "dependencies": { "@smithy/is-array-buffer": "^4.2.2", "tslib": "^2.6.2" } }, "sha512-FDXD7cvUoFWwN6vtQfEta540Y/YBe5JneK3SoZg9bThSoOAC/eGeYEua6RkBgKjGa/sz6Y+DuBZj3+YEY21y4Q=="],
+
+    "@aws-sdk/lib-dynamodb/@smithy/core/@smithy/util-stream/@smithy/util-hex-encoding": ["@smithy/util-hex-encoding@4.2.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-Qcz3W5vuHK4sLQdyT93k/rfrUwdJ8/HZ+nMUOyGdpeGA1Wxt65zYwi3oEl9kOM+RswvYq90fzkNDahPS8K0OIg=="],
+
+    "@aws-sdk/lib-dynamodb/@smithy/core/@smithy/util-utf8/@smithy/util-buffer-from": ["@smithy/util-buffer-from@4.2.2", "", { "dependencies": { "@smithy/is-array-buffer": "^4.2.2", "tslib": "^2.6.2" } }, "sha512-FDXD7cvUoFWwN6vtQfEta540Y/YBe5JneK3SoZg9bThSoOAC/eGeYEua6RkBgKjGa/sz6Y+DuBZj3+YEY21y4Q=="],
+
+    "@aws-sdk/lib-dynamodb/@smithy/smithy-client/@smithy/middleware-endpoint/@smithy/middleware-serde": ["@smithy/middleware-serde@4.2.19", "", { "dependencies": { "@smithy/core": "^3.23.16", "@smithy/protocol-http": "^5.3.14", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-Q6y+W9h3iYVMCKWDoVge+OC1LKFqbEKaq8SIWG2X2bWJRpd/6dDLyICcNLT6PbjH3Rr6bmg/SeDB25XFOFfeEw=="],
+
+    "@aws-sdk/lib-dynamodb/@smithy/smithy-client/@smithy/middleware-endpoint/@smithy/node-config-provider": ["@smithy/node-config-provider@4.3.14", "", { "dependencies": { "@smithy/property-provider": "^4.2.14", "@smithy/shared-ini-file-loader": "^4.4.9", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-S+gFjyo/weSVL0P1b9Ts8C/CwIfNCgUPikk3sl6QVsfE/uUuO+QsF+NsE/JkpvWqqyz1wg7HFdiaZuj5CoBMRg=="],
+
+    "@aws-sdk/lib-dynamodb/@smithy/smithy-client/@smithy/middleware-endpoint/@smithy/shared-ini-file-loader": ["@smithy/shared-ini-file-loader@4.4.9", "", { "dependencies": { "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-495/V2I15SHgedSJoDPD23JuSfKAp726ZI1V0wtjB07Wh7q/0tri/0e0DLefZCHgxZonrGKt/OCTpAtP1wE1kQ=="],
+
+    "@aws-sdk/lib-dynamodb/@smithy/smithy-client/@smithy/middleware-endpoint/@smithy/url-parser": ["@smithy/url-parser@4.2.14", "", { "dependencies": { "@smithy/querystring-parser": "^4.2.14", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-p06BiBigJ8bTA3MgnOfCtDUWnAMY0YfedO/GRpmc7p+wg3KW8vbXy1xwSu5ASy0wV7rRYtlfZOIKH4XqfhjSQQ=="],
+
+    "@aws-sdk/lib-dynamodb/@smithy/smithy-client/@smithy/middleware-endpoint/@smithy/util-middleware": ["@smithy/util-middleware@4.2.14", "", { "dependencies": { "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-1Su2vj9RYNDEv/V+2E+jXkkwGsgR7dc4sfHn9Z7ruzQHJIEni9zzw5CauvRXlFJfmgcqYP8fWa0dkh2Q2YaQyw=="],
+
+    "@aws-sdk/lib-dynamodb/@smithy/smithy-client/@smithy/util-stream/@smithy/fetch-http-handler": ["@smithy/fetch-http-handler@5.3.17", "", { "dependencies": { "@smithy/protocol-http": "^5.3.14", "@smithy/querystring-builder": "^4.2.14", "@smithy/types": "^4.14.1", "@smithy/util-base64": "^4.3.2", "tslib": "^2.6.2" } }, "sha512-bXOvQzaSm6MnmLaWA1elgfQcAtN4UP3vXqV97bHuoOrHQOJiLT3ds6o9eo5bqd0TJfRFpzdGnDQdW3FACiAVdw=="],
+
+    "@aws-sdk/lib-dynamodb/@smithy/smithy-client/@smithy/util-stream/@smithy/node-http-handler": ["@smithy/node-http-handler@4.6.0", "", { "dependencies": { "@smithy/protocol-http": "^5.3.14", "@smithy/querystring-builder": "^4.2.14", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-P734cAoTFtuGfWa/R3jgBnGlURt2w9bYEBwQNMKf58sRM9RShirB2mKwLsVP+jlG/wxpCu8abv8NxdUts8tdLA=="],
+
+    "@aws-sdk/lib-dynamodb/@smithy/smithy-client/@smithy/util-stream/@smithy/util-base64": ["@smithy/util-base64@4.3.2", "", { "dependencies": { "@smithy/util-buffer-from": "^4.2.2", "@smithy/util-utf8": "^4.2.2", "tslib": "^2.6.2" } }, "sha512-XRH6b0H/5A3SgblmMa5ErXQ2XKhfbQB+Fm/oyLZ2O2kCUrwgg55bU0RekmzAhuwOjA9qdN5VU2BprOvGGUkOOQ=="],
+
+    "@aws-sdk/lib-dynamodb/@smithy/smithy-client/@smithy/util-stream/@smithy/util-buffer-from": ["@smithy/util-buffer-from@4.2.2", "", { "dependencies": { "@smithy/is-array-buffer": "^4.2.2", "tslib": "^2.6.2" } }, "sha512-FDXD7cvUoFWwN6vtQfEta540Y/YBe5JneK3SoZg9bThSoOAC/eGeYEua6RkBgKjGa/sz6Y+DuBZj3+YEY21y4Q=="],
+
+    "@aws-sdk/lib-dynamodb/@smithy/smithy-client/@smithy/util-stream/@smithy/util-hex-encoding": ["@smithy/util-hex-encoding@4.2.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-Qcz3W5vuHK4sLQdyT93k/rfrUwdJ8/HZ+nMUOyGdpeGA1Wxt65zYwi3oEl9kOM+RswvYq90fzkNDahPS8K0OIg=="],
+
+    "@aws-sdk/lib-dynamodb/@smithy/smithy-client/@smithy/util-stream/@smithy/util-utf8": ["@smithy/util-utf8@4.2.2", "", { "dependencies": { "@smithy/util-buffer-from": "^4.2.2", "tslib": "^2.6.2" } }, "sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw=="],
+
     "@istanbuljs/load-nyc-config/find-up/locate-path/p-locate": ["p-locate@4.1.0", "", { "dependencies": { "p-limit": "^2.2.0" } }, "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A=="],
 
     "pkg-dir/find-up/locate-path/p-locate": ["p-locate@4.1.0", "", { "dependencies": { "p-limit": "^2.2.0" } }, "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A=="],
@@ -4588,6 +4695,32 @@
 
     "@aws-sdk/client-cost-explorer/@smithy/smithy-client/@smithy/util-stream/@smithy/util-buffer-from/@smithy/is-array-buffer": ["@smithy/is-array-buffer@4.2.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-n6rQ4N8Jj4YTQO3YFrlgZuwKodf4zUFs7EJIWH86pSCWBaAtAGBFfCM7Wx6D2bBJ2xqFNxGBSrUWswT3M0VJow=="],
 
+    "@aws-sdk/lib-dynamodb/@aws-sdk/core/@aws-sdk/xml-builder/fast-xml-parser/strnum": ["strnum@2.2.3", "", {}, "sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg=="],
+
+    "@aws-sdk/lib-dynamodb/@aws-sdk/core/@smithy/util-base64/@smithy/util-buffer-from/@smithy/is-array-buffer": ["@smithy/is-array-buffer@4.2.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-n6rQ4N8Jj4YTQO3YFrlgZuwKodf4zUFs7EJIWH86pSCWBaAtAGBFfCM7Wx6D2bBJ2xqFNxGBSrUWswT3M0VJow=="],
+
+    "@aws-sdk/lib-dynamodb/@aws-sdk/core/@smithy/util-utf8/@smithy/util-buffer-from/@smithy/is-array-buffer": ["@smithy/is-array-buffer@4.2.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-n6rQ4N8Jj4YTQO3YFrlgZuwKodf4zUFs7EJIWH86pSCWBaAtAGBFfCM7Wx6D2bBJ2xqFNxGBSrUWswT3M0VJow=="],
+
+    "@aws-sdk/lib-dynamodb/@smithy/core/@smithy/util-base64/@smithy/util-buffer-from/@smithy/is-array-buffer": ["@smithy/is-array-buffer@4.2.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-n6rQ4N8Jj4YTQO3YFrlgZuwKodf4zUFs7EJIWH86pSCWBaAtAGBFfCM7Wx6D2bBJ2xqFNxGBSrUWswT3M0VJow=="],
+
+    "@aws-sdk/lib-dynamodb/@smithy/core/@smithy/util-stream/@smithy/fetch-http-handler/@smithy/querystring-builder": ["@smithy/querystring-builder@4.2.14", "", { "dependencies": { "@smithy/types": "^4.14.1", "@smithy/util-uri-escape": "^4.2.2", "tslib": "^2.6.2" } }, "sha512-XYA5Z0IqTeF+5XDdh4BBmSA0HvbgVZIyv4cmOoUheDNR57K1HgBp9ukUMx3Cr3XpDHHpLBnexPE3LAtDsZkj2A=="],
+
+    "@aws-sdk/lib-dynamodb/@smithy/core/@smithy/util-stream/@smithy/node-http-handler/@smithy/querystring-builder": ["@smithy/querystring-builder@4.2.14", "", { "dependencies": { "@smithy/types": "^4.14.1", "@smithy/util-uri-escape": "^4.2.2", "tslib": "^2.6.2" } }, "sha512-XYA5Z0IqTeF+5XDdh4BBmSA0HvbgVZIyv4cmOoUheDNR57K1HgBp9ukUMx3Cr3XpDHHpLBnexPE3LAtDsZkj2A=="],
+
+    "@aws-sdk/lib-dynamodb/@smithy/core/@smithy/util-stream/@smithy/util-buffer-from/@smithy/is-array-buffer": ["@smithy/is-array-buffer@4.2.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-n6rQ4N8Jj4YTQO3YFrlgZuwKodf4zUFs7EJIWH86pSCWBaAtAGBFfCM7Wx6D2bBJ2xqFNxGBSrUWswT3M0VJow=="],
+
+    "@aws-sdk/lib-dynamodb/@smithy/core/@smithy/util-utf8/@smithy/util-buffer-from/@smithy/is-array-buffer": ["@smithy/is-array-buffer@4.2.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-n6rQ4N8Jj4YTQO3YFrlgZuwKodf4zUFs7EJIWH86pSCWBaAtAGBFfCM7Wx6D2bBJ2xqFNxGBSrUWswT3M0VJow=="],
+
+    "@aws-sdk/lib-dynamodb/@smithy/smithy-client/@smithy/middleware-endpoint/@smithy/node-config-provider/@smithy/property-provider": ["@smithy/property-provider@4.2.14", "", { "dependencies": { "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-WuM31CgfsnQ/10i7NYr0PyxqknD72Y5uMfUMVSniPjbEPceiTErb4eIqJQ+pdxNEAUEWrewrGjIRjVbVHsxZiQ=="],
+
+    "@aws-sdk/lib-dynamodb/@smithy/smithy-client/@smithy/middleware-endpoint/@smithy/url-parser/@smithy/querystring-parser": ["@smithy/querystring-parser@4.2.14", "", { "dependencies": { "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-hr+YyqBD23GVvRxGGrcc/oOeNlK3PzT5Fu4dzrDXxzS1LpFiuL2PQQqKPs87M79aW7ziMs+nvB3qdw77SqE7Lw=="],
+
+    "@aws-sdk/lib-dynamodb/@smithy/smithy-client/@smithy/util-stream/@smithy/fetch-http-handler/@smithy/querystring-builder": ["@smithy/querystring-builder@4.2.14", "", { "dependencies": { "@smithy/types": "^4.14.1", "@smithy/util-uri-escape": "^4.2.2", "tslib": "^2.6.2" } }, "sha512-XYA5Z0IqTeF+5XDdh4BBmSA0HvbgVZIyv4cmOoUheDNR57K1HgBp9ukUMx3Cr3XpDHHpLBnexPE3LAtDsZkj2A=="],
+
+    "@aws-sdk/lib-dynamodb/@smithy/smithy-client/@smithy/util-stream/@smithy/node-http-handler/@smithy/querystring-builder": ["@smithy/querystring-builder@4.2.14", "", { "dependencies": { "@smithy/types": "^4.14.1", "@smithy/util-uri-escape": "^4.2.2", "tslib": "^2.6.2" } }, "sha512-XYA5Z0IqTeF+5XDdh4BBmSA0HvbgVZIyv4cmOoUheDNR57K1HgBp9ukUMx3Cr3XpDHHpLBnexPE3LAtDsZkj2A=="],
+
+    "@aws-sdk/lib-dynamodb/@smithy/smithy-client/@smithy/util-stream/@smithy/util-buffer-from/@smithy/is-array-buffer": ["@smithy/is-array-buffer@4.2.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-n6rQ4N8Jj4YTQO3YFrlgZuwKodf4zUFs7EJIWH86pSCWBaAtAGBFfCM7Wx6D2bBJ2xqFNxGBSrUWswT3M0VJow=="],
+
     "@istanbuljs/load-nyc-config/find-up/locate-path/p-locate/p-limit": ["p-limit@2.3.0", "", { "dependencies": { "p-try": "^2.0.0" } }, "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w=="],
 
     "pkg-dir/find-up/locate-path/p-locate/p-limit": ["p-limit@2.3.0", "", { "dependencies": { "p-try": "^2.0.0" } }, "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w=="],
@@ -4605,6 +4738,14 @@
     "@aws-sdk/client-cost-explorer/@aws-sdk/credential-provider-node/@aws-sdk/credential-provider-web-identity/@aws-sdk/nested-clients/@aws-sdk/signature-v4-multi-region/@aws-sdk/middleware-sdk-s3": ["@aws-sdk/middleware-sdk-s3@3.972.33", "", { "dependencies": { "@aws-sdk/core": "^3.974.4", "@aws-sdk/types": "^3.973.8", "@aws-sdk/util-arn-parser": "^3.972.3", "@smithy/core": "^3.23.16", "@smithy/node-config-provider": "^4.3.14", "@smithy/protocol-http": "^5.3.14", "@smithy/signature-v4": "^5.3.14", "@smithy/smithy-client": "^4.12.12", "@smithy/types": "^4.14.1", "@smithy/util-config-provider": "^4.2.2", "@smithy/util-middleware": "^4.2.14", "@smithy/util-stream": "^4.5.24", "@smithy/util-utf8": "^4.2.2", "tslib": "^2.6.2" } }, "sha512-n8Eh/+kq3u/EodLr8n6sQupu03QGjf122RHXCTGLaHSkavz/2beSKpRlq2oDgfmJZNkAkWF113xbyaUmyOd+YA=="],
 
     "@aws-sdk/client-cost-explorer/@aws-sdk/credential-provider-node/@aws-sdk/credential-provider-web-identity/@aws-sdk/nested-clients/@aws-sdk/signature-v4-multi-region/@smithy/signature-v4": ["@smithy/signature-v4@5.3.14", "", { "dependencies": { "@smithy/is-array-buffer": "^4.2.2", "@smithy/protocol-http": "^5.3.14", "@smithy/types": "^4.14.1", "@smithy/util-hex-encoding": "^4.2.2", "@smithy/util-middleware": "^4.2.14", "@smithy/util-uri-escape": "^4.2.2", "@smithy/util-utf8": "^4.2.2", "tslib": "^2.6.2" } }, "sha512-1D9Y/nmlVjCeSivCbhZ7hgEpmHyY1h0GvpSZt3l0xcD9JjmjVC1CHOozS6+Gh+/ldMH8JuJ6cujObQqfayAVFA=="],
+
+    "@aws-sdk/lib-dynamodb/@smithy/core/@smithy/util-stream/@smithy/fetch-http-handler/@smithy/querystring-builder/@smithy/util-uri-escape": ["@smithy/util-uri-escape@4.2.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-2kAStBlvq+lTXHyAZYfJRb/DfS3rsinLiwb+69SstC9Vb0s9vNWkRwpnj918Pfi85mzi42sOqdV72OLxWAISnw=="],
+
+    "@aws-sdk/lib-dynamodb/@smithy/core/@smithy/util-stream/@smithy/node-http-handler/@smithy/querystring-builder/@smithy/util-uri-escape": ["@smithy/util-uri-escape@4.2.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-2kAStBlvq+lTXHyAZYfJRb/DfS3rsinLiwb+69SstC9Vb0s9vNWkRwpnj918Pfi85mzi42sOqdV72OLxWAISnw=="],
+
+    "@aws-sdk/lib-dynamodb/@smithy/smithy-client/@smithy/util-stream/@smithy/fetch-http-handler/@smithy/querystring-builder/@smithy/util-uri-escape": ["@smithy/util-uri-escape@4.2.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-2kAStBlvq+lTXHyAZYfJRb/DfS3rsinLiwb+69SstC9Vb0s9vNWkRwpnj918Pfi85mzi42sOqdV72OLxWAISnw=="],
+
+    "@aws-sdk/lib-dynamodb/@smithy/smithy-client/@smithy/util-stream/@smithy/node-http-handler/@smithy/querystring-builder/@smithy/util-uri-escape": ["@smithy/util-uri-escape@4.2.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-2kAStBlvq+lTXHyAZYfJRb/DfS3rsinLiwb+69SstC9Vb0s9vNWkRwpnj918Pfi85mzi42sOqdV72OLxWAISnw=="],
 
     "@aws-sdk/client-cost-explorer/@aws-sdk/credential-provider-node/@aws-sdk/credential-provider-ini/@aws-sdk/nested-clients/@aws-sdk/signature-v4-multi-region/@aws-sdk/middleware-sdk-s3/@aws-sdk/util-arn-parser": ["@aws-sdk/util-arn-parser@3.972.3", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-HzSD8PMFrvgi2Kserxuff5VitNq2sgf3w9qxmskKDiDTThWfVteJxuCS9JXiPIPtmCrp+7N9asfIaVhBFORllA=="],
 

--- a/docs/operations/email-triage.md
+++ b/docs/operations/email-triage.md
@@ -4,8 +4,6 @@ Smart email triage for the PSD AI Agent. Phase 1 — agent-native opt-in,
 per-user rules, Gmail labels, Bedrock Nova Micro fallback classifier,
 Chat escalations, daily digest, admin sub-page.
 
-Plan: `/Users/hagelk/.claude/plans/everything-is-good-to-graceful-twilight.md`
-
 Phase 2 tracker: <https://github.com/psd401/aistudio/issues/996>
 
 ---

--- a/docs/operations/email-triage.md
+++ b/docs/operations/email-triage.md
@@ -1,0 +1,282 @@
+# Email Triage — Operations
+
+Smart email triage for the PSD AI Agent. Phase 1 — agent-native opt-in,
+per-user rules, Gmail labels, Bedrock Nova Micro fallback classifier,
+Chat escalations, daily digest, admin sub-page.
+
+Plan: `/Users/hagelk/.claude/plans/everything-is-good-to-graceful-twilight.md`
+
+Phase 2 tracker: <https://github.com/psd401/aistudio/issues/996>
+
+---
+
+## Architecture at a glance
+
+```
+User in Chat ───────────► PSD AI Agent (existing OpenClaw container)
+                            │ tool call
+                            ▼
+                  psd-email-triage skill
+                  (read/write rules, create Gmail labels,
+                   schedule digest)
+                            │
+                            ▼
+               psd-agent-triage-<env>   ◄────────── reads every 5 min
+               (DynamoDB, one row/user)             ┌─────────────────────────────┐
+                            ▲                       │ psd-agent-triage-poll-<env>  │
+                            │                       │ Lambda — rate(5 minutes)    │
+                            │ records               │  Gmail history → rules →    │
+                            │ decisions             │  Nova Micro → labels →      │
+                            │ corrections           │  Chat escalation card       │
+                            │                       └─────────────────────────────┘
+                            │
+               ┌────────────┴─────────────┐
+               │                          │
+               ▼                          ▼
+   psd-agent-triage-digest-<env>     /admin/agents/[userEmail]/triage
+   Lambda — daily per user           Admin read-only view + support actions
+   (EventBridge Scheduler)
+```
+
+Three deployable artefacts:
+- DynamoDB table `psd-agent-triage-<env>` (added in `infra/lib/agent-platform-stack.ts`).
+- Two Lambdas (`agent-triage-poll`, `agent-triage-digest`) under `infra/lambdas/`.
+- One skill (`psd-email-triage`) bundled into the agent image.
+
+Plus one Next.js admin page (`/admin/agents/[userEmail]/triage`).
+
+---
+
+## Onboarding (user-facing)
+
+```
+User: "Hey agent, start triaging my email"
+Agent: <enable card; user clicks [Yes]>
+Agent calls: node /opt/psd-skills/psd-email-triage/run.js enable --user <email>
+```
+
+The skill:
+1. Calls the user's `user_account` OAuth slot (requires the
+   `gmail.modify` scope, already granted as of PR #913).
+2. Creates 3 Gmail labels: `@psd/Important`, `@psd/Later`, `@psd/News`
+   (nested under `@psd` because Gmail treats `/` as hierarchy — confirmed
+   via smoke test 2026-05-21).
+3. Captures Gmail's current `historyId` so the classifier only sees mail
+   that arrives AFTER opt-in (no retroactive classification — that's a
+   Phase 2 item).
+4. Seeds default rules: a small `muteSenders` list for `noreply@*`-style
+   patterns and two keyword rules (newsletter → news; external+urgent →
+   later as anti-spam-spoof).
+5. Creates an EventBridge Scheduler entry for the daily digest (default
+   08:00 in user's tz).
+
+The classifier Lambda starts processing on the next 5-minute tick.
+
+---
+
+## Per-email pipeline (classifier Lambda)
+
+For each opted-in user every 5 minutes:
+
+1. **Refresh access token** via `workspace-token.ts` (Lambda-local copy
+   of the helper in `lib/agent/`; reads the user's `user_account` slot
+   from Secrets Manager, exchanges refresh token for an access token).
+2. **Pull Gmail history** since `lastHistoryId` (only `messageAdded`,
+   `labelAdded`, `labelRemoved` events).
+3. For each new message: **deterministic rules first** (VIP → important,
+   mute → later, thread-with-user-reply → important, keyword rules in
+   order). If undecided, **call Bedrock Nova Micro** with a small system
+   prompt summarising the user's rules + sender/subject/snippet. Default
+   to `later` if model confidence < 0.6.
+4. **Apply Gmail label** via `messages.modify`. **All three labels also
+   remove `INBOX`** — the design treats labels as mutually-exclusive
+   folders so the user reviews each in one place. Inbox empty = triage
+   caught up. The Chat escalation is the "look at this now" signal
+   for the rare cases that warrant interruption.
+5. **Maybe escalate to Chat** — if the label matches the user's
+   `escalation.labelTriggers` AND (no sender/keyword filter OR the
+   sender/keyword matches), post a card to the user's DM via the Chat
+   API.
+6. **Detect user-driven label changes** — if a recent classification
+   contradicts what the user just did (e.g. they moved an `@psd/Later`
+   message back into Inbox), record as a `recentCorrections` entry
+   (Phase 1 only records; Phase 2 acts on them).
+7. **Advance the cursor** in DDB.
+
+---
+
+## Operational knobs (env vars)
+
+`psd-agent-triage-poll` Lambda:
+
+| Env var | Default | What it does |
+|---------|---------|--------------|
+| `TRIAGE_TABLE` | `psd-agent-triage-<env>` | DDB table name |
+| `TRIAGE_USER_BATCH` | `10` | Users processed in parallel per batch within a tick |
+| `TRIAGE_LLM_MODEL_ID` | `us.amazon.nova-micro-v1:0` | Bedrock model for the ambiguous-classification fallback. Set to `us.anthropic.claude-3-5-haiku-...` to swap to Haiku without a redeploy (the role grants both). |
+| `GOOGLE_CREDENTIALS_SECRET_ARN` | (set by CDK) | Chat-bot service-account JSON for escalation posts |
+| `AWS_REGION` | (Lambda runtime) | DDB / Bedrock / Secrets region |
+
+`psd-agent-triage-digest` Lambda:
+
+| Env var | What it does |
+|---------|--------------|
+| `TRIAGE_TABLE` | DDB table |
+| `GOOGLE_CREDENTIALS_SECRET_ARN` | Chat creds for the digest card |
+
+Agent skill (in the container, env injected by `agent-platform-stack.ts`):
+
+| Env var | What it does |
+|---------|--------------|
+| `TRIAGE_TABLE` | DDB table |
+| `EVENTBRIDGE_SCHEDULE_GROUP` | Scheduler group for digest entries |
+| `EVENTBRIDGE_ROLE_ARN` | Role the Scheduler assumes to invoke the digest Lambda |
+| `TRIAGE_DIGEST_LAMBDA_ARN` | Target for the per-user digest schedule |
+
+---
+
+## Smoke-test sequence (post-deploy)
+
+1. **Stack deploys cleanly** —
+   ```
+   cd infra && bunx cdk diff AIStudio-AgentPlatformStack-Dev
+   ```
+   Expect: new DDB table, two Lambdas, EventBridge Rule, log groups.
+2. **Agent image rebuilds** —
+   ```
+   cd infra/agent-image && ./build-and-push.sh $(date +%Y-%m-%d)-email-triage
+   ```
+   Expect: image layer count stays under 54 (Phase 1 estimate: 50 with
+   the new skill's npm install).
+3. **Opt-in test** — DM the agent: "start triaging my email". Click
+   `[Yes, start watching]`. Verify:
+   - Gmail sidebar shows the three labels under the `@psd` group.
+   - DDB row created (`enabled=true`, `classifierStartHistoryId` set).
+   - Admin sub-page renders cleanly at
+     `/admin/agents/<your-email>/triage`.
+4. **Classification smoke test** — send yourself a known spammy email
+   from an external address with "urgent" in the subject. Wait one
+   poll cycle. Expect: `@psd/Later`, archived from Inbox, no Chat ping.
+5. **VIP escalation** —
+   - In Chat: "Always page me from <colleague>@psd401.net"
+   - Have that colleague send you a test message.
+   - Expect: `@psd/Important` label, **and** a Chat card escalation.
+6. **Training correction** — in Gmail, move one of the `@psd/Later`
+   messages back to Inbox manually. After the next poll, in Chat: "show
+   recent corrections". Expect: a correction row.
+7. **Daily digest** — in Chat: "digest time 17:00" (or near-future).
+   Wait. Expect: a card lands in your DM at that time with sections per
+   label.
+
+---
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| Skill returns `code: "needs-auth"` on enable | User hasn't done `user_account` OAuth | Send them the consent link via the existing workspace flow |
+| Skill returns `code: "needs-auth"` on rules update after a working enable | Refresh token revoked (Google admin or user revoked) | Run the consent flow again |
+| Classifier Lambda logs `cursor_too_old_reset` | User's `lastHistoryId` is > 7 days old (Gmail history retention) | Self-healing — Lambda re-anchors to current historyId |
+| Classifier Lambda logs `llm_classify_failed` | Bedrock throttle, model unavailable, or prompt-too-large | Check CloudWatch for upstream error; classifier safely defaults to `later` for those messages |
+| All classifications return `later` regardless of content | Model confidence floor (0.6) not being met — investigate prompt or swap model | Set `TRIAGE_LLM_MODEL_ID=us.anthropic.claude-3-5-haiku-...` |
+| Daily digest never arrives | EventBridge Scheduler entry missing or Scheduler can't invoke the Lambda | Check `aws scheduler get-schedule --group-name psd-agent-<env> --name triage-digest-<userslug>` |
+| Admin sub-page shows "No triage row" but user says triage is on | DDB row was deleted (admin re-onboard) but user hasn't re-enabled yet | User runs `enable` again from chat |
+| Escalation posts not appearing in Chat | DM space resource name missing on the triage row OR Chat bot lacks DM space access | Check `dmSpaceName` field in DDB row; the user must have DM'd the bot at least once |
+
+---
+
+## Phase 1.5 — `@psd/Task` user-gesture task creation
+
+The `@psd/Task` label is a fourth default label the user can apply
+manually in Gmail. The classifier never assigns it. When the polling
+Lambda detects a user-applied `@psd/Task` label, it (optionally)
+invokes AgentCore so the user's agent creates a task in their
+preferred task system (Life OS, Google Tasks, anything they've
+configured a skill for).
+
+### Behaviour matrix
+
+| `tasksMode` | Behaviour on `@psd/Task` label |
+|-------------|--------------------------------|
+| `none` (default) | Lambda does nothing. The message keeps the `@psd/Task` label. Useful for users who want the label as a manual holding bay with no automation. |
+| `invoke-agent` | Lambda invokes AgentCore with the email metadata. The user's agent reads their `MEMORY.md` to determine how to create the task (which skill, which system, which labels). On success: email is archived (both `INBOX` and `@psd/Task` removed) — end state is All Mail only. On failure: email is left alone and a Chat card surfaces the failure reason. |
+
+### Required agent-side configuration
+
+For `invoke-agent` to work, the user adds a memory entry telling the
+agent how to handle the request. Example for a Life OS user:
+
+```markdown
+## Email Triage → Life OS Task Creation
+
+When the email-triage system invokes you with a prompt tagged
+`[psd-email-triage task request]`, create a GitHub issue in
+krishagel/life-os:
+  - Title: the email's subject
+  - Body: from + Gmail link + snippet
+  - Labels: status:inbox, priority:p2, type:task, source:email, owner:hagel
+
+Reply with one line:
+  - Success: `Created life-os issue #<n>: <title>`
+  - Failure: `FAILED: <reason>`
+
+No additional commentary.
+```
+
+A Google Tasks user writes the equivalent telling the agent to call
+the `gws-tasks` skill instead.
+
+### Reply contract (parsed by Lambda)
+
+```
+Created <system> <type> <id>: <title>     ← success
+FAILED: <reason>                          ← failure
+```
+
+`<system>` and `<type>` are user-defined (e.g. `life-os issue`, `google-tasks task`). `<id>` is whatever identifier the user's task system returns (e.g. `#1234`, `abc-xyz`). The Lambda extracts the id for the audit trail; it doesn't try to interpret `<system>` or `<type>` beyond matching the line pattern.
+
+### Dedup
+
+Thread-level labelling is naturally dedup'd: when the agent succeeds, the Lambda removes the `@psd/Task` label from the message AND removes INBOX. Subsequent thread activity arrives without `@psd/Task`, so no re-fire. To retry after a failure, the user removes and re-adds the label manually (deliberate gesture → fresh attempt).
+
+### Latency
+
+Same 5-minute polling window as the classifier (no Phase 1.5 push). The user labels an email and waits up to 5 minutes for the task to appear in their task system. The agent invocation itself adds another 10–30 seconds. Users get a Chat confirmation card if `tasks notify-success on` is set.
+
+### Cost
+
+Each task gesture invokes AgentCore once (~$0.01–0.05 per invocation depending on the agent's reasoning length). At typical tasking volumes (5–20 per day per power user) this is negligible.
+
+---
+
+## Phase 1 known limitations
+
+Listed here, all tracked in #996:
+- No Gmail push subscription — escalations are bounded by the 5-minute polling cadence.
+- No retroactive classification — only mail received after enable gets sorted.
+- `learnedPatterns` array is populated by Phase 2; Phase 1 only records `recentCorrections`.
+- Single-Lambda scan over all opted-in users — caps at 1000 per invocation. Fan-out comes with Phase 2.
+
+---
+
+## Costs at scale (1000 users projection)
+
+- Bedrock Nova Micro at ~$0.0001/classification × ~50 ambiguous emails/user/day = $0.005/user/day = ~$1825/yr.
+- DynamoDB at on-demand pricing with 1000 users × ~3 writes/min during business hours ≈ negligible (<$50/yr).
+- Lambda execution (5-min poll × 1000 users sequentially batched 10-at-a-time) ≈ $400/yr.
+
+Aggregate: comfortably under $3k/yr for the whole org, before any cost optimisations.
+
+---
+
+## Files touched in Phase 1
+
+- `infra/lib/agent-platform-stack.ts` — table, both Lambdas, EventBridge Rule, env vars.
+- `infra/lambdas/agent-triage-poll/` — classifier Lambda + unit tests for rules + LLM parser.
+- `infra/lambdas/agent-triage-digest/` — digest Lambda.
+- `infra/agent-image/skills/psd-email-triage/` — agent skill.
+- `infra/agent-image/Dockerfile` — npm install for the new skill (+1 layer).
+- `lib/agent/workspace-token.ts` — canonical TS token helper (Lambdas keep a local copy).
+- `app/(protected)/admin/agents/[userEmail]/triage/` — admin sub-page.
+- `actions/admin/agent-triage.actions.ts` — admin server actions.
+- This file.

--- a/infra/agent-image/Dockerfile
+++ b/infra/agent-image/Dockerfile
@@ -219,11 +219,16 @@ RUN cd /opt/psd-skills/psd-skills-meta && npm install --omit=dev --no-audit --no
 RUN cd /opt/psd-skills/psd-workspace && npm install --omit=dev --no-audit --no-fund
 RUN cd /opt/psd-skills/psd-image-gen && npm install --omit=dev --no-audit --no-fund
 RUN cd /opt/psd-skills/psd-failure-report && npm install --omit=dev --no-audit --no-fund
+RUN cd /opt/psd-skills/psd-email-triage && npm install --omit=dev --no-audit --no-fund
 # chat-card has zero npm deps. chat-chart's npm install is paired with the
 # matplotlib install above — both stay disabled until we figure out the
 # AgentCore overlay-mount failure. With both off the image boots cleanly
 # and chat-chart works in QuickChart mode (lazy require in run.js skips
 # the AWS SDK load).
+# psd-email-triage (Phase 1 email triage) has three @aws-sdk/* deps for
+# DynamoDB + EventBridge Scheduler; the npm install adds one layer (we
+# were at 49, target 50 — well under the 54-layer Firecracker ceiling
+# from the 2026-05-18 incident).
 # psd-data has zero npm install of its own. Its common.js require()s
 # `@aws-sdk/client-secrets-manager` from psd-workspace's already-installed
 # tree via an absolute path. No symlink, no duplicate install — keeps the

--- a/infra/agent-image/agentcore_wrapper.py
+++ b/infra/agent-image/agentcore_wrapper.py
@@ -494,18 +494,49 @@ def main():
                 elapsed = int(time.time() - invocation_start)
                 yield {"type": "heartbeat", "elapsed_s": elapsed}
 
-        logger.info(
-            "Invocation complete: session=%s response_length=%d elapsed_s=%d",
-            session_id, len(result), int(time.time() - invocation_start),
-        )
-
-        yield {
-            "result": result,
-            "metadata": {
+        # Adapter contract: TurnResult preferred; legacy str still
+        # accepted so older adapters keep working during a phased rollout.
+        if isinstance(result, str):
+            reply_text = result
+            metadata: dict = {
                 "session_id": session_id,
                 "user_id": user_email,
                 "model": model_override or "default",
-            },
+            }
+        else:
+            reply_text = result.text or ""
+            metadata = {
+                "session_id": session_id,
+                "user_id": user_email,
+                # Real values when the harness surfaces them; fall through
+                # to the override or "default" so the router's coalesce
+                # logic still has something sane.
+                "model": result.model or model_override or "default",
+                "input_tokens": result.tokens_in,
+                "output_tokens": result.tokens_out,
+                "latency_ms": result.latency_ms,
+                # Deep-telemetry payload: per-turn messages + tool calls.
+                # The router reads these and inserts into
+                # agent_message_content + agent_tool_invocations.
+                "messages": result.messages,
+                "tool_calls": result.tool_calls,
+            }
+
+        logger.info(
+            "Invocation complete: session=%s response_length=%d elapsed_s=%d "
+            "model=%s tokens_in=%s tokens_out=%s tool_calls=%d",
+            session_id,
+            len(reply_text),
+            int(time.time() - invocation_start),
+            metadata.get("model"),
+            metadata.get("input_tokens"),
+            metadata.get("output_tokens"),
+            len(metadata.get("tool_calls") or []),
+        )
+
+        yield {
+            "result": reply_text,
+            "metadata": metadata,
         }
 
     logger.info(

--- a/infra/agent-image/harness_adapter.py
+++ b/infra/agent-image/harness_adapter.py
@@ -6,6 +6,7 @@ without changing the AgentCore wrapper. Each adapter implements the same interfa
 """
 
 import abc
+import dataclasses
 import json
 import logging
 import os
@@ -13,12 +14,39 @@ import subprocess
 import sys
 import time
 import uuid
-from typing import Optional
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional, Union
 
 from agent_failures import record_failure
 from chat_format import markdown_to_chat
 
 logger = logging.getLogger("harness_adapter")
+
+
+@dataclasses.dataclass
+class TurnResult:
+    """Structured result of a single agent turn.
+
+    Replaces the old `process() -> str` contract so the wrapper can pass
+    real model / token / latency / tool metadata down to the router
+    Lambda, which writes:
+      - agent_messages (model, input_tokens, output_tokens, latency_ms)
+      - agent_message_content (per-turn role/content rows)
+      - agent_tool_invocations (per-turn tool calls with args + result)
+
+    `text` is the user-visible reply (already passed through
+    chat_format markdown→Chat-subset). Empty zero/None values are
+    acceptable when the harness doesn't surface the data — the writer
+    coalesces gracefully.
+    """
+
+    text: str
+    model: Optional[str] = None
+    tokens_in: int = 0
+    tokens_out: int = 0
+    latency_ms: int = 0
+    messages: List[Dict[str, Any]] = dataclasses.field(default_factory=list)
+    tool_calls: List[Dict[str, Any]] = dataclasses.field(default_factory=list)
 
 
 def _format_for_chat(text: str) -> str:
@@ -44,8 +72,15 @@ class HarnessAdapter(abc.ABC):
     """Abstract base class for agent harness adapters."""
 
     @abc.abstractmethod
-    def process(self, message: str, session_id: str, model_override: Optional[str] = None) -> str:
-        """Send a message to the harness and return the response."""
+    def process(
+        self,
+        message: str,
+        session_id: str,
+        model_override: Optional[str] = None,
+    ) -> Union[str, TurnResult]:
+        """Send a message to the harness and return either a plain string
+        (legacy contract) or a TurnResult (preferred). Wrapper accepts
+        both."""
 
     @abc.abstractmethod
     def configure(self, config: dict) -> None:
@@ -163,11 +198,21 @@ class OpenClawAdapter(HarnessAdapter):
             f"OpenClaw gateway did not become ready within {timeout}s"
         )
 
-    def process(self, message: str, session_id: str, model_override: Optional[str] = None) -> str:
-        """Send a message to OpenClaw via WebSocket and return the response.
+    def process(
+        self,
+        message: str,
+        session_id: str,
+        model_override: Optional[str] = None,
+    ) -> TurnResult:
+        """Send a message to OpenClaw via WebSocket and return a TurnResult.
 
         Uses the native OpenClaw gateway WebSocket protocol:
         connect.challenge → connect (auth) → chat.send → collect chat events
+
+        Captures (best-effort) the real model id, token usage, tool calls,
+        and latency from the event stream so the router Lambda can write
+        proper telemetry into agent_messages + agent_message_content +
+        agent_tool_invocations.
         """
         if not self._ready:
             raise RuntimeError(
@@ -175,11 +220,26 @@ class OpenClawAdapter(HarnessAdapter):
                 "must be called before process()"
             )
 
+        # Track metadata across the whole turn. The user message is the
+        # first content entry; we'll append assistant + tool entries as
+        # the event stream completes.
+        observed_model: Optional[str] = model_override
+        tokens_in = 0
+        tokens_out = 0
+        tool_calls: List[Dict[str, Any]] = []
+        tool_starts: Dict[str, Dict[str, Any]] = {}
+        messages_log: List[Dict[str, Any]] = [
+            {"role": "user", "content": message}
+        ]
+
         try:
             import websocket  # websocket-client library
         except ImportError:
             logger.error("websocket-client not installed, falling back to error")
-            return "Agent communication library not available. Please contact an administrator."
+            return TurnResult(
+                text="Agent communication library not available. Please contact an administrator.",
+                model=observed_model,
+            )
 
         gateway_token = self.GATEWAY_TOKEN
         ws_url = f"ws://127.0.0.1:{self._gateway_port}"
@@ -200,7 +260,10 @@ class OpenClawAdapter(HarnessAdapter):
 
         if ws is None:
             logger.error("Failed to connect to gateway after 3 attempts: %s", last_error)
-            return f"I'm temporarily unable to respond. Error: {str(last_error)[:100]}"
+            return TurnResult(
+                text=f"I'm temporarily unable to respond. Error: {str(last_error)[:100]}",
+                model=observed_model,
+            )
 
         try:
 
@@ -239,7 +302,10 @@ class OpenClawAdapter(HarnessAdapter):
                         break
 
                 if not connect_resp.get("ok"):
-                    return f"[WS_AUTH_FAIL] {json.dumps(connect_resp)[:800]}"
+                    return TurnResult(
+                        text=f"[WS_AUTH_FAIL] {json.dumps(connect_resp)[:800]}",
+                        model=observed_model,
+                    )
 
                 # Diagnostic: ask the gateway what tools are actually
                 # wired for the default agent. If the model says "let me
@@ -286,6 +352,10 @@ class OpenClawAdapter(HarnessAdapter):
                 # AgentCore runtime gives us a stable per-user session_id;
                 # use it directly.
                 chat_id = str(uuid.uuid4())
+                # Latency clock starts the instant we hand the message to
+                # the gateway. final_state event stops it. Captured before
+                # ws.send so we don't count our own serialization.
+                chat_send_at = time.time()
                 ws.send(json.dumps({
                     "type": "req",
                     "id": chat_id,
@@ -371,13 +441,35 @@ class OpenClawAdapter(HarnessAdapter):
                     if mtype == "event" and mevent == "agent":
                         # Agent events carry streaming content per OpenClaw's
                         # AgentEventSchema: {runId, seq, stream, ts, data}.
-                        # stream="assistant" holds model output; stream=
-                        # "thinking" is reasoning which we intentionally drop
-                        # from user-facing replies. Tool events are ignored
-                        # here — they surface via their own channel.
+                        # We extract:
+                        #   stream="assistant" → accumulate the user-visible
+                        #     reply (drops markdown formatting later via
+                        #     chat_format).
+                        #   stream="thinking" → drop (reasoning isn't shown
+                        #     to the user and isn't useful for telemetry).
+                        #   stream="tool_call" / stream="tool_result" →
+                        #     record into tool_calls for the Conversations
+                        #     dashboard tab.
+                        # Also opportunistically capture `model` whenever
+                        # the harness reports it on any event so we can
+                        # surface the real model id in agent_messages.
                         agent_payload = msg.get("payload", {})
                         stream = agent_payload.get("stream")
                         data = agent_payload.get("data", {})
+                        if isinstance(data, dict):
+                            model_hint = data.get("model") or data.get("modelId")
+                            if isinstance(model_hint, str) and model_hint:
+                                observed_model = model_hint
+                            # Token usage may appear on a 'usage' field on
+                            # the final assistant event in newer builds.
+                            usage = data.get("usage")
+                            if isinstance(usage, dict):
+                                ti = usage.get("input_tokens") or usage.get("prompt_tokens")
+                                to = usage.get("output_tokens") or usage.get("completion_tokens")
+                                if isinstance(ti, int):
+                                    tokens_in = max(tokens_in, ti)
+                                if isinstance(to, int):
+                                    tokens_out = max(tokens_out, to)
                         if stream == "assistant" and isinstance(data, dict):
                             delta = (
                                 data.get("delta")
@@ -387,6 +479,51 @@ class OpenClawAdapter(HarnessAdapter):
                             )
                             if isinstance(delta, str) and delta:
                                 agent_assistant_accum += delta
+                        elif stream == "tool_call" and isinstance(data, dict):
+                            tool_id = (
+                                data.get("id")
+                                or data.get("toolCallId")
+                                or data.get("callId")
+                                or str(uuid.uuid4())
+                            )
+                            tool_starts[tool_id] = {
+                                "name": data.get("name") or data.get("tool") or "unknown",
+                                "args": data.get("arguments") or data.get("args") or data.get("input"),
+                                "started_at": time.time(),
+                            }
+                        elif stream == "tool_result" and isinstance(data, dict):
+                            tool_id = (
+                                data.get("id")
+                                or data.get("toolCallId")
+                                or data.get("callId")
+                                or ""
+                            )
+                            start = tool_starts.pop(tool_id, None)
+                            now = time.time()
+                            started_at = start["started_at"] if start else now
+                            entry = {
+                                "name": (start or {}).get("name")
+                                or data.get("name")
+                                or "unknown",
+                                "args": (start or {}).get("args"),
+                                "result": data.get("result")
+                                or data.get("output")
+                                or data.get("content"),
+                                "status": data.get("status")
+                                or ("error" if data.get("error") else "success"),
+                                "error_text": (
+                                    str(data.get("error"))[:2000]
+                                    if data.get("error") else None
+                                ),
+                                "duration_ms": int(max(0, (now - started_at) * 1000)),
+                                "started_at": datetime.fromtimestamp(
+                                    started_at, tz=timezone.utc
+                                ).isoformat(),
+                                "finished_at": datetime.fromtimestamp(
+                                    now, tz=timezone.utc
+                                ).isoformat(),
+                            }
+                            tool_calls.append(entry)
 
                     elif mtype == "event" and mevent == "chat":
                         payload = msg.get("payload", {})
@@ -421,7 +558,20 @@ class OpenClawAdapter(HarnessAdapter):
                                 payload.get("errorMessage", "unknown"),
                                 json.dumps(payload)[:800],
                             )
-                            return _format_for_chat(response_text) if response_text else "I encountered an error processing your message."
+                            err_text = (
+                                _format_for_chat(response_text)
+                                if response_text
+                                else "I encountered an error processing your message."
+                            )
+                            return TurnResult(
+                                text=err_text,
+                                model=observed_model,
+                                tokens_in=tokens_in,
+                                tokens_out=tokens_out,
+                                latency_ms=int((time.time() - chat_send_at) * 1000),
+                                messages=messages_log,
+                                tool_calls=tool_calls,
+                            )
 
                         elif state == "aborted":
                             logger.warning("chat aborted: payload=%s", json.dumps(payload)[:500])
@@ -431,8 +581,27 @@ class OpenClawAdapter(HarnessAdapter):
                         if not msg.get("ok"):
                             error = msg.get("error", {})
                             logger.error("chat.send error: %s", json.dumps(error)[:500])
-                            return "I encountered an error processing your message."
-                        status = msg.get("payload", {}).get("status")
+                            return TurnResult(
+                                text="I encountered an error processing your message.",
+                                model=observed_model,
+                                latency_ms=int((time.time() - chat_send_at) * 1000),
+                                messages=messages_log,
+                                tool_calls=tool_calls,
+                            )
+                        res_payload = msg.get("payload", {})
+                        # Final res may carry the authoritative usage object.
+                        usage = res_payload.get("usage")
+                        if isinstance(usage, dict):
+                            ti = usage.get("input_tokens") or usage.get("prompt_tokens")
+                            to = usage.get("output_tokens") or usage.get("completion_tokens")
+                            if isinstance(ti, int):
+                                tokens_in = max(tokens_in, ti)
+                            if isinstance(to, int):
+                                tokens_out = max(tokens_out, to)
+                        model_field = res_payload.get("model") or res_payload.get("modelId")
+                        if isinstance(model_field, str) and model_field:
+                            observed_model = model_field
+                        status = res_payload.get("status")
                         if status in {"started", "accepted"}:
                             continue
                         if status in {"final", "done"}:
@@ -454,12 +623,31 @@ class OpenClawAdapter(HarnessAdapter):
                 model=model_override,
                 context={"phase": "websocket"},
             )
-            return "I'm temporarily unable to respond. The agent process may be restarting."
+            return TurnResult(
+                text="I'm temporarily unable to respond. The agent process may be restarting.",
+                model=observed_model,
+                messages=messages_log,
+                tool_calls=tool_calls,
+            )
+
+        latency_ms = int((time.time() - chat_send_at) * 1000)
+
+        def _result(text: str) -> TurnResult:
+            assistant = text or ""
+            log = list(messages_log)
+            if assistant:
+                log.append({"role": "assistant", "content": assistant})
+            return TurnResult(
+                text=assistant,
+                model=observed_model,
+                tokens_in=tokens_in,
+                tokens_out=tokens_out,
+                latency_ms=latency_ms,
+                messages=log,
+                tool_calls=tool_calls,
+            )
 
         if not got_final:
-            # Deadline hit but the agent may have already streamed a full
-            # response via event:agent. Prefer partial content over the
-            # "stalled" apology when we have something to show.
             if not response_text and agent_assistant_accum:
                 response_text = agent_assistant_accum
             logger.error(
@@ -475,7 +663,7 @@ class OpenClawAdapter(HarnessAdapter):
                 raw_event_samples[0] if raw_event_samples else "",
             )
             if response_text:
-                return _format_for_chat(response_text.strip())
+                return _result(_format_for_chat(response_text.strip()))
             record_failure(
                 source="harness",
                 severity="error",
@@ -485,7 +673,7 @@ class OpenClawAdapter(HarnessAdapter):
                     f"(last_state={last_state})"
                 ),
                 session_id=session_id,
-                model=model_override,
+                model=observed_model or model_override,
                 context={
                     "phase": "deadline",
                     "last_state": last_state,
@@ -493,22 +681,26 @@ class OpenClawAdapter(HarnessAdapter):
                     "first_events": first_event_types,
                 },
             )
-            return (
+            return _result(
                 "I wasn't able to finish responding in time — the agent "
                 "stalled. Please try again in a moment."
             )
 
-        # Happy path: still log the event summary so we can audit whether
-        # tool_call / tool_result / thinking events ever flowed for this turn.
         logger.info(
-            "chat turn ok: resp_len=%d last_state=%s event_counts=%s",
+            "chat turn ok: resp_len=%d last_state=%s event_counts=%s "
+            "model=%s tokens_in=%d tokens_out=%d latency_ms=%d tool_calls=%d",
             len(response_text),
             last_state,
             json.dumps(event_counts),
+            observed_model or "unknown",
+            tokens_in,
+            tokens_out,
+            latency_ms,
+            len(tool_calls),
         )
 
         if response_text.strip():
-            return _format_for_chat(response_text.strip())
+            return _result(_format_for_chat(response_text.strip()))
         record_failure(
             source="harness",
             severity="empty_response",
@@ -517,14 +709,14 @@ class OpenClawAdapter(HarnessAdapter):
                 "Agent reached final state but produced no user-visible text"
             ),
             session_id=session_id,
-            model=model_override,
+            model=observed_model or model_override,
             context={
                 "last_state": last_state,
                 "event_counts": event_counts,
                 "first_events": first_event_types,
             },
         )
-        return "I processed your message but had no response."
+        return _result("I processed your message but had no response.")
 
     @staticmethod
     def _extract_text(content) -> str:

--- a/infra/agent-image/harness_adapter.py
+++ b/infra/agent-image/harness_adapter.py
@@ -439,6 +439,23 @@ class OpenClawAdapter(HarnessAdapter):
                         raw_event_samples.append(raw[:600] if isinstance(raw, str) else str(raw)[:600])
 
                     if mtype == "event" and mevent == "agent":
+                        # DIAGNOSTIC (remove after schema discovery): log the
+                        # first occurrence of each unique `stream` value with
+                        # a payload sample so we can see what OpenClaw
+                        # actually emits for model id / token usage / tool
+                        # calls. The speculative field-name extraction below
+                        # produced model=unknown + 0 tool_calls in initial
+                        # runs (2026-05-28).
+                        _stream_val = (msg.get("payload", {}) or {}).get("stream")
+                        if isinstance(_stream_val, str):
+                            _diag_key = f"_seen_stream::{_stream_val}"
+                            if _diag_key not in event_counts:
+                                event_counts[_diag_key] = 1
+                                logger.info(
+                                    "openclaw_event_sample stream=%s payload=%s",
+                                    _stream_val,
+                                    json.dumps(msg.get("payload", {}))[:1500],
+                                )
                         # Agent events carry streaming content per OpenClaw's
                         # AgentEventSchema: {runId, seq, stream, ts, data}.
                         # We extract:
@@ -578,6 +595,15 @@ class OpenClawAdapter(HarnessAdapter):
                             break
 
                     elif mtype == "res" and msg.get("id") == chat_id:
+                        # DIAGNOSTIC (remove after schema discovery): dump
+                        # the final res payload so we can see if usage /
+                        # model lives here vs on agent events.
+                        if "_seen_chat_res" not in event_counts:
+                            event_counts["_seen_chat_res"] = 1
+                            logger.info(
+                                "openclaw_chat_res_sample payload=%s",
+                                json.dumps(msg.get("payload", {}))[:1500],
+                            )
                         if not msg.get("ok"):
                             error = msg.get("error", {})
                             logger.error("chat.send error: %s", json.dumps(error)[:500])

--- a/infra/agent-image/skills/psd-email-triage/SKILL.md
+++ b/infra/agent-image/skills/psd-email-triage/SKILL.md
@@ -1,0 +1,159 @@
+---
+name: psd-email-triage
+summary: Smart email triage — opt-in, per-user rules, Gmail labels, daily digest, Chat escalations. Configure entirely from chat.
+description: When the user asks to start triaging their email (or to adjust rules / escalation / digest / labels for an already-enabled triage setup), call this skill. The skill writes to a per-user DynamoDB row that a background Lambda reads every 5 minutes; the Lambda classifies new mail using rules + Bedrock Nova Micro, applies Gmail labels, and posts escalation cards to chat when something important arrives. Phase 1 of the email triage feature.
+allowed-tools: Bash(node:*)
+---
+
+# psd-email-triage
+
+Smart email triage controlled entirely through chat. The user says things like "start triaging my email", "ignore vendor-x", "always page me when CEO emails", "show recent classifications", "stop triaging" — and this skill writes the rules into DynamoDB where a background Lambda (`psd-agent-triage-poll-<env>`) picks them up on its next 5-minute tick.
+
+**The skill itself does not classify mail.** It manages CONFIG. The classifier Lambda does the per-email work.
+
+## When to call this skill
+
+- User explicitly asks to enable / disable / configure email triage
+- User says "ignore X", "always page me from Y", "auto-archive newsletters" → translate to a `rules.*` or `escalation.*` subcommand
+- User asks "show recent triage", "what did you classify?" → `training recent`
+- User says "I keep getting Important on noisy senders" → `training correct` + `rules mute`
+- User wants a daily summary → `digest enable` / `digest time HH:MM`
+
+Don't call this skill for:
+- Generic Gmail operations (use `psd-workspace` / `gws-*`)
+- The classifier's runtime behaviour (that's the Lambda — see `docs/operations/email-triage.md`)
+
+## Quick reference
+
+```bash
+node /opt/psd-skills/psd-email-triage/run.js <subcommand> --user <email> [args]
+```
+
+`--user <email>` is required on every call (matches the existing skill convention; comes from the `[caller: …]` header).
+
+### Lifecycle
+
+| Subcommand | Effect |
+|------------|--------|
+| `enable` | Create Gmail labels (default `@psd/Important`, `@psd/Later`, `@psd/News`), seed default rules, anchor Gmail history cursor, optionally schedule daily digest. Idempotent — running `enable` on an already-enabled triage is a no-op that returns current status. |
+| `disable` | Pause classification. Keeps rules + labels intact for re-enable. |
+| `disable --forget` | Hard reset: clears rules, learned patterns, decision history; deletes Gmail labels; removes digest schedule. |
+| `status` | Returns enabled state, label set, rule counts, last poll, recent decision counts. |
+
+### Rules
+
+| Subcommand | Effect |
+|------------|--------|
+| `rules list` | Show all configured rules grouped by type. |
+| `rules add-vip <email>` | Always classify as Important. Beats every other rule. |
+| `rules mute <pattern>` | Auto-archive sender. Supports `*` wildcards (e.g. `noreply@*`, `*.vendor.com`). |
+| `rules add-keyword <kw> --label <important\|later\|news> [--subject\|--snippet\|--from <domain>\|--external]` | Add a keyword rule. Defaults to subject-match. |
+| `rules remove <type> <value>` | Remove a rule. `type` is `vip`, `mute`, or `keyword`. |
+
+### Escalation (Chat pings)
+
+| Subcommand | Effect |
+|------------|--------|
+| `escalation list` | Show current escalation senders + keywords + label triggers. |
+| `escalation add-sender <email>` | Always Chat-ping when this sender's mail classifies as Important. |
+| `escalation add-keyword <kw>` | Always Chat-ping when an Important message's subject/snippet contains this keyword. |
+| `escalation remove <type> <value>` | Remove an escalation rule. `type` is `sender` or `keyword`. |
+| `escalation labels <label1,label2>` | Override which labels trigger Chat. Default: `important` only. |
+
+### Training feedback
+
+| Subcommand | Effect |
+|------------|--------|
+| `training recent [--limit N]` | Last N classifications (default 20) with sender, subject, label, source (rule vs llm), confidence, reason. |
+| `training correct <messageId> <newLabel>` | Re-label one message in Gmail and record a training signal. |
+
+### Simulation
+
+| Subcommand | Effect |
+|------------|--------|
+| `simulate --from <email> [--subject "..."] [--snippet "..."] [--external] [--has-user-reply]` | Dry-run the rule engine against a synthetic email. Useful for "would my mute rule catch this?" without waiting for real mail. |
+
+### Labels
+
+| Subcommand | Effect |
+|------------|--------|
+| `labels list` | Show current label names + Gmail label IDs. |
+| `labels rename <key> <new-name>` | Rename one of `important` / `later` / `news` (renames the Gmail label too). |
+
+### Digest
+
+| Subcommand | Effect |
+|------------|--------|
+| `digest enable` | Schedule a daily summary card at the user's configured time. |
+| `digest disable` | Remove the daily schedule (rules/labels stay). |
+| `digest time <HH:MM>` | Set the time (24-hour, user's timezone from the agent users table). Default `08:00`. |
+
+### Tasks (user-gesture, Phase 1.5)
+
+When the user applies the `@psd/Task` label to a Gmail message, the classifier
+Lambda detects the gesture. What happens next depends on `tasksMode`:
+
+| Subcommand | Effect |
+|------------|--------|
+| `tasks mode none` | (default) Lambda ignores the label — the message just sits with `@psd/Task` applied. No automation. |
+| `tasks mode invoke-agent` | Lambda invokes AgentCore with the email metadata. The user's agent (per their `MEMORY.md` instructions + skills) creates a task in their preferred task system. On success the email is archived (INBOX + @psd/Task removed). On failure the email is left alone and a Chat card surfaces the reason. |
+| `tasks notify-success on\|off` | (default off) When on, every successful task creation posts a one-line confirmation card to Chat. Failures always notify regardless. |
+| `tasks status` | Returns current mode, notify setting, recent task-creation entries. |
+
+For `invoke-agent` mode to actually create tasks, the user's `MEMORY.md` must
+include instructions for what to do when invoked with a `[psd-email-triage
+task request]` prompt. The reply must be exactly one line in either
+`Created <system> <type> <id>: <title>` or `FAILED: <reason>` shape — the
+Lambda parses this deterministically.
+
+## Output
+
+stdout is JSON — one object per call. Shape:
+
+```json
+{
+  "ok": true,
+  "subcommand": "enable",
+  "summary": "Watching <email>. 3 Gmail labels created. Default rules seeded.",
+  "data": { /* subcommand-specific */ }
+}
+```
+
+On error: `{ "ok": false, "subcommand": "...", "error": "...", "code": "..." }`.
+
+The agent should:
+- Show `summary` to the user as the headline
+- Use `data` to render any follow-on cards (rule lists, training tables, etc.) via `chat-card`
+
+## Examples
+
+### Onboarding
+
+```bash
+node /opt/psd-skills/psd-email-triage/run.js enable --user hagelk@psd401.net
+```
+
+### "Ignore noisy vendor X"
+
+```bash
+node /opt/psd-skills/psd-email-triage/run.js rules mute "noreply@vendor-x.com" --user hagelk@psd401.net
+```
+
+### "Always page me when the CEO emails"
+
+```bash
+node /opt/psd-skills/psd-email-triage/run.js escalation add-sender ceo@psd401.net --user hagelk@psd401.net
+```
+
+### "I'm getting Important on github noreplies"
+
+```bash
+# 1. Move recent github noreply messages to Later
+node /opt/psd-skills/psd-email-triage/run.js training correct <messageId> later --user hagelk@psd401.net
+# 2. Add a mute rule so future ones auto-go
+node /opt/psd-skills/psd-email-triage/run.js rules mute "noreply@github.com" --user hagelk@psd401.net
+```
+
+## Rule 13 reminder
+
+If the user says "set this up for the whole organisation" or anything that touches OTHER USERS' triage rows, **refuse**. This skill is strictly per-caller. Multi-user setup is admin work and lives at `/admin/agents/[userEmail]/triage`.

--- a/infra/agent-image/skills/psd-email-triage/lib.js
+++ b/infra/agent-image/skills/psd-email-triage/lib.js
@@ -1,0 +1,423 @@
+/**
+ * Shared helpers for the psd-email-triage skill.
+ *
+ * Three concerns bundled here for simplicity:
+ *   - DynamoDB I/O on the psd-agent-triage-<env> table
+ *   - Gmail label management via the psd-workspace common.js token helper
+ *     (we reuse, not duplicate, the per-user OAuth refresh)
+ *   - EventBridge Scheduler entries for the daily digest
+ *
+ * Kept in one file because the skill is small and the boundaries are
+ * straightforward. If this grows past ~600 lines, split.
+ *
+ * Rules engine is a port of infra/lambdas/agent-triage-poll/rules.ts —
+ * keep behaviour-equivalent so the skill's `simulate` subcommand matches
+ * what the classifier Lambda would actually do.
+ */
+
+'use strict';
+
+const { DynamoDBClient } = require('@aws-sdk/client-dynamodb');
+const {
+  DynamoDBDocumentClient,
+  GetCommand,
+  UpdateCommand,
+  DeleteCommand,
+} = require('@aws-sdk/lib-dynamodb');
+const {
+  SchedulerClient,
+  CreateScheduleCommand,
+  UpdateScheduleCommand,
+  DeleteScheduleCommand,
+  GetScheduleCommand,
+} = require('@aws-sdk/client-scheduler');
+
+// Reuse the per-user OAuth machinery from psd-workspace. Absolute
+// require path matches the pattern psd-data uses — avoids duplicating
+// refresh-token + Secrets Manager code in every skill.
+const WS = require('/opt/psd-skills/psd-workspace/common.js');
+
+const REGION = process.env.AWS_REGION || 'us-east-1';
+const ENVIRONMENT = process.env.ENVIRONMENT || 'dev';
+const TRIAGE_TABLE = process.env.TRIAGE_TABLE || `psd-agent-triage-${ENVIRONMENT}`;
+const SCHEDULER_GROUP = process.env.EVENTBRIDGE_SCHEDULE_GROUP || `psd-agent-${ENVIRONMENT}`;
+const SCHEDULER_INVOKE_ROLE_ARN = process.env.EVENTBRIDGE_ROLE_ARN || '';
+const TRIAGE_DIGEST_LAMBDA_ARN =
+  process.env.TRIAGE_DIGEST_LAMBDA_ARN ||
+  `arn:aws:lambda:${REGION}:${process.env.AWS_ACCOUNT || ''}:function:psd-agent-triage-digest-${ENVIRONMENT}`;
+
+const ddb = DynamoDBDocumentClient.from(
+  new DynamoDBClient({ region: REGION }),
+  { marshallOptions: { removeUndefinedValues: true } },
+);
+const scheduler = new SchedulerClient({ region: REGION });
+
+// =====================================================================
+// DynamoDB I/O
+// =====================================================================
+
+const DEFAULT_LABELS = {
+  important: '@psd/Important',
+  later: '@psd/Later',
+  news: '@psd/News',
+  // User-only gesture label. The classifier never assigns this — when
+  // the user labels an email with @psd/Task, the polling Lambda detects
+  // the labelsAdded event and (if tasksMode=invoke-agent) invokes
+  // AgentCore to create a task per the user's MEMORY.md instructions.
+  // See docs/operations/email-triage.md and Phase 1.5 design notes.
+  task: '@psd/Task',
+};
+
+const DEFAULT_RULES = {
+  vipSenders: [],
+  muteSenders: [
+    'noreply@*',
+    'notifications@github.com',
+    'jira-noreply@*',
+  ],
+  keywordRules: [
+    { subject_contains: 'newsletter', label: 'news' },
+    { subject_contains: 'urgent', external: true, label: 'later' },
+  ],
+};
+
+const DEFAULT_ESCALATION = {
+  senders: [],
+  keywords: [],
+  labelTriggers: ['important'],
+};
+
+async function getRow(userEmail) {
+  const r = await ddb.send(
+    new GetCommand({ TableName: TRIAGE_TABLE, Key: { userEmail } }),
+  );
+  return r.Item || null;
+}
+
+async function deleteRow(userEmail) {
+  await ddb.send(
+    new DeleteCommand({ TableName: TRIAGE_TABLE, Key: { userEmail } }),
+  );
+}
+
+async function updateRow(userEmail, attrs) {
+  // attrs is a flat object {name: value}; we build SET key = :v entries.
+  // Strip the partition key if a caller accidentally includes it —
+  // DDB rejects UpdateItem expressions that touch key attributes
+  // (2026-05-21 incident: cmd_enable's newRow object included
+  // userEmail and the whole enable flow failed). Belt-and-suspenders
+  // with the cmd_enable comment.
+  const names = {};
+  const values = {};
+  const sets = [];
+  let i = 0;
+  for (const [k, v] of Object.entries(attrs)) {
+    if (k === 'userEmail') continue;
+    const ek = `#k${i}`;
+    const ev = `:v${i}`;
+    names[ek] = k;
+    values[ev] = v;
+    sets.push(`${ek} = ${ev}`);
+    i++;
+  }
+  if (sets.length === 0) {
+    // Nothing to set — bail rather than send a malformed UpdateExpression.
+    return;
+  }
+  await ddb.send(
+    new UpdateCommand({
+      TableName: TRIAGE_TABLE,
+      Key: { userEmail },
+      UpdateExpression: 'SET ' + sets.join(', '),
+      ExpressionAttributeNames: names,
+      ExpressionAttributeValues: values,
+    }),
+  );
+}
+
+// =====================================================================
+// Gmail label management
+// =====================================================================
+
+let _cachedOAuthClient = null;
+async function getOAuthClient() {
+  if (_cachedOAuthClient) return _cachedOAuthClient;
+  _cachedOAuthClient = await WS.getSecretJson(WS.GOOGLE_OAUTH_CLIENT_SECRET_ID);
+  return _cachedOAuthClient;
+}
+
+async function getUserAccessToken(userEmail) {
+  // Use the user_account slot — gmail.modify is in that scope set.
+  const token = await WS.getUserWorkspaceToken(userEmail, 'user_account');
+  if (!token) {
+    const err = new Error('User has not consented to workspace access yet');
+    err.code = 'needs-auth';
+    throw err;
+  }
+  const client = await getOAuthClient();
+  const refreshed = await WS.refreshAccessToken(
+    token.refresh_token,
+    client.client_id,
+    client.client_secret,
+  );
+  return refreshed.access_token;
+}
+
+async function gmailFetch(accessToken, path, init = {}) {
+  const resp = await fetch(`https://gmail.googleapis.com/gmail/v1/users/me${path}`, {
+    ...init,
+    headers: {
+      ...(init.headers || {}),
+      Authorization: `Bearer ${accessToken}`,
+      'Content-Type': 'application/json',
+    },
+  });
+  return resp;
+}
+
+async function getCurrentHistoryId(accessToken) {
+  const resp = await gmailFetch(accessToken, '/profile');
+  if (!resp.ok) {
+    throw new Error(`Gmail profile fetch failed: ${resp.status} ${await resp.text()}`);
+  }
+  const j = await resp.json();
+  return j.historyId;
+}
+
+async function listLabels(accessToken) {
+  const resp = await gmailFetch(accessToken, '/labels');
+  if (!resp.ok) {
+    throw new Error(`Gmail labels.list failed: ${resp.status} ${await resp.text()}`);
+  }
+  const j = await resp.json();
+  return j.labels || [];
+}
+
+async function createLabel(accessToken, name) {
+  const resp = await gmailFetch(accessToken, '/labels', {
+    method: 'POST',
+    body: JSON.stringify({
+      name,
+      labelListVisibility: 'labelShow',
+      messageListVisibility: 'show',
+    }),
+  });
+  if (!resp.ok) {
+    // 409 = already exists; find it and return.
+    const existing = await listLabels(accessToken);
+    const match = existing.find((l) => l.name === name);
+    if (match) return match;
+    throw new Error(`Gmail labels.create failed for "${name}": ${resp.status} ${await resp.text()}`);
+  }
+  return await resp.json();
+}
+
+async function renameLabel(accessToken, labelId, newName) {
+  const resp = await gmailFetch(accessToken, `/labels/${labelId}`, {
+    method: 'PATCH',
+    body: JSON.stringify({ name: newName }),
+  });
+  if (!resp.ok) {
+    throw new Error(`Gmail labels.patch failed: ${resp.status} ${await resp.text()}`);
+  }
+  return await resp.json();
+}
+
+async function deleteLabel(accessToken, labelId) {
+  const resp = await gmailFetch(accessToken, `/labels/${labelId}`, { method: 'DELETE' });
+  if (resp.status !== 204 && resp.status !== 404) {
+    throw new Error(`Gmail labels.delete failed: ${resp.status} ${await resp.text()}`);
+  }
+}
+
+async function modifyMessage(accessToken, messageId, addLabelIds, removeLabelIds = []) {
+  const resp = await gmailFetch(accessToken, `/messages/${messageId}/modify`, {
+    method: 'POST',
+    body: JSON.stringify({ addLabelIds, removeLabelIds }),
+  });
+  if (!resp.ok) {
+    throw new Error(`Gmail messages.modify failed: ${resp.status} ${await resp.text()}`);
+  }
+}
+
+/**
+ * Ensure the 3 triage labels exist in Gmail; return a map of
+ * { important: id, later: id, news: id } and the canonical name map.
+ *
+ * Idempotent — if the label already exists, we keep the existing one.
+ */
+async function ensureLabels(accessToken, labels) {
+  const existing = await listLabels(accessToken);
+  const byName = new Map(existing.map((l) => [l.name, l]));
+  const ids = {};
+  for (const [key, name] of Object.entries(labels)) {
+    if (byName.has(name)) {
+      ids[key] = byName.get(name).id;
+    } else {
+      const created = await createLabel(accessToken, name);
+      ids[key] = created.id;
+    }
+  }
+  return ids;
+}
+
+// =====================================================================
+// EventBridge Scheduler — daily digest
+// =====================================================================
+
+function digestScheduleName(userEmail) {
+  // Scheduler names are <= 64 chars; email local parts are usually short.
+  // We slug + suffix to make it unique without collisions.
+  const slug = userEmail.replace(/[^a-zA-Z0-9]/g, '-').slice(0, 50);
+  return `triage-digest-${slug}`;
+}
+
+function buildDigestCronExpr(timeHHMM, _tz) {
+  // EventBridge Scheduler accepts a cron(min hour day-of-month month day-of-week year) expression with a TIMEZONE field set on the schedule itself.
+  // We store the time in the user's tz and pass tz as a separate field so
+  // Scheduler does the timezone math.
+  const [hStr, mStr] = String(timeHHMM).split(':');
+  const h = parseInt(hStr, 10);
+  const m = parseInt(mStr, 10);
+  if (!Number.isFinite(h) || !Number.isFinite(m) || h < 0 || h > 23 || m < 0 || m > 59) {
+    throw new Error(`Invalid digest time "${timeHHMM}" — expected HH:MM 24-hour`);
+  }
+  // EventBridge cron: minutes hours day-of-month month day-of-week year
+  return `cron(${m} ${h} * * ? *)`;
+}
+
+async function upsertDigestSchedule(userEmail, timeHHMM, tz) {
+  if (!SCHEDULER_INVOKE_ROLE_ARN) {
+    throw new Error('EVENTBRIDGE_ROLE_ARN env var not set — cannot create digest schedule');
+  }
+  const name = digestScheduleName(userEmail);
+  const expr = buildDigestCronExpr(timeHHMM, tz);
+  const input = {
+    Name: name,
+    GroupName: SCHEDULER_GROUP,
+    ScheduleExpression: expr,
+    ScheduleExpressionTimezone: tz || 'America/Los_Angeles',
+    FlexibleTimeWindow: { Mode: 'OFF' },
+    Target: {
+      Arn: TRIAGE_DIGEST_LAMBDA_ARN,
+      RoleArn: SCHEDULER_INVOKE_ROLE_ARN,
+      Input: JSON.stringify({ userEmail }),
+    },
+    State: 'ENABLED',
+  };
+  // Try create; on conflict, update.
+  try {
+    await scheduler.send(new CreateScheduleCommand(input));
+  } catch (err) {
+    if (err && err.name === 'ConflictException') {
+      await scheduler.send(new UpdateScheduleCommand(input));
+    } else {
+      throw err;
+    }
+  }
+  return `arn:aws:scheduler:${REGION}:${process.env.AWS_ACCOUNT || '*'}:schedule/${SCHEDULER_GROUP}/${name}`;
+}
+
+async function deleteDigestSchedule(userEmail) {
+  const name = digestScheduleName(userEmail);
+  try {
+    await scheduler.send(
+      new DeleteScheduleCommand({ Name: name, GroupName: SCHEDULER_GROUP }),
+    );
+  } catch (err) {
+    if (err && err.name === 'ResourceNotFoundException') return;
+    throw err;
+  }
+}
+
+// =====================================================================
+// Rules engine — JS port of infra/lambdas/agent-triage-poll/rules.ts.
+// Used only by the `simulate` subcommand; the real classifier path runs
+// the TS version. Keep behaviour-equivalent.
+// =====================================================================
+
+function wildcardMatch(pattern, value) {
+  if (!pattern || !value) return false;
+  const p = String(pattern).toLowerCase();
+  const v = String(value).toLowerCase();
+  if (!p.includes('*')) return p === v;
+  const escaped = p.replace(/[-/\\^$+?.()|[\]{}]/g, '\\$&').replace(/\*/g, '.*');
+  return new RegExp('^' + escaped + '$').test(v);
+}
+
+function matchesKeywordRule(rule, features) {
+  if (rule.external && features.isInternal) return false;
+  if (rule.from_domain && features.fromDomain !== String(rule.from_domain).toLowerCase()) {
+    return false;
+  }
+  if (
+    rule.subject_contains &&
+    !features.subjectLower.includes(String(rule.subject_contains).toLowerCase())
+  ) {
+    return false;
+  }
+  if (
+    rule.snippet_contains &&
+    !features.snippetLower.includes(String(rule.snippet_contains).toLowerCase())
+  ) {
+    return false;
+  }
+  return Boolean(rule.from_domain || rule.subject_contains || rule.snippet_contains);
+}
+
+function applyRules(features, rules) {
+  if ((rules.vipSenders || []).includes(features.fromEmail)) {
+    return { label: 'important', reason: `vip:${features.fromEmail}`, source: 'rule' };
+  }
+  for (const pattern of rules.muteSenders || []) {
+    if (
+      wildcardMatch(pattern, features.fromEmail) ||
+      wildcardMatch(pattern, features.fromDomain)
+    ) {
+      return { label: 'later', reason: `mute:${pattern}`, source: 'rule' };
+    }
+  }
+  if (features.hasUserReply) {
+    return { label: 'important', reason: 'thread:user-replied-here', source: 'rule' };
+  }
+  for (const rule of rules.keywordRules || []) {
+    if (matchesKeywordRule(rule, features)) {
+      const desc = rule.subject_contains
+        ? `subject~"${rule.subject_contains}"`
+        : rule.snippet_contains
+          ? `snippet~"${rule.snippet_contains}"`
+          : rule.from_domain
+            ? `from_domain=${rule.from_domain}`
+            : 'rule';
+      return { label: rule.label, reason: `keyword:${desc}`, source: 'rule' };
+    }
+  }
+  return { decided: false, reason: 'no-rule-match' };
+}
+
+module.exports = {
+  // constants
+  DEFAULT_LABELS,
+  DEFAULT_RULES,
+  DEFAULT_ESCALATION,
+  TRIAGE_TABLE,
+  ENVIRONMENT,
+  // ddb
+  getRow,
+  updateRow,
+  deleteRow,
+  // gmail
+  getUserAccessToken,
+  getCurrentHistoryId,
+  ensureLabels,
+  listLabels,
+  createLabel,
+  renameLabel,
+  deleteLabel,
+  modifyMessage,
+  // scheduler
+  upsertDigestSchedule,
+  deleteDigestSchedule,
+  // rules
+  applyRules,
+};

--- a/infra/agent-image/skills/psd-email-triage/lib.js
+++ b/infra/agent-image/skills/psd-email-triage/lib.js
@@ -29,7 +29,6 @@ const {
   CreateScheduleCommand,
   UpdateScheduleCommand,
   DeleteScheduleCommand,
-  GetScheduleCommand,
 } = require('@aws-sdk/client-scheduler');
 
 // Reuse the per-user OAuth machinery from psd-workspace. Absolute

--- a/infra/agent-image/skills/psd-email-triage/package.json
+++ b/infra/agent-image/skills/psd-email-triage/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "psd-email-triage",
+  "version": "1.0.0",
+  "description": "OpenClaw skill — agent-facing CLI for the smart email triage feature. Configures per-user rules, escalation, digest, labels in Gmail, and reads/writes the triage state in DynamoDB.",
+  "private": true,
+  "dependencies": {
+    "@aws-sdk/client-dynamodb": "^3.0.0",
+    "@aws-sdk/lib-dynamodb": "^3.0.0",
+    "@aws-sdk/client-scheduler": "^3.0.0"
+  }
+}

--- a/infra/agent-image/skills/psd-email-triage/run.js
+++ b/infra/agent-image/skills/psd-email-triage/run.js
@@ -1,0 +1,702 @@
+#!/usr/bin/env node
+/**
+ * psd-email-triage — agent-facing CLI for the smart email triage feature.
+ *
+ * Dispatches subcommands documented in SKILL.md. Every call returns one
+ * JSON line on stdout — `{ ok, subcommand, summary, data? }` on success
+ * or `{ ok: false, subcommand, error, code }` on failure. The agent
+ * reads this in its tool result and decides whether to render a card
+ * or just acknowledge.
+ *
+ * All state lives in DynamoDB `psd-agent-triage-<env>`. Gmail labels are
+ * created via the user's `user_account` OAuth slot (gmail.modify). The
+ * digest is an EventBridge Scheduler entry per opted-in user.
+ */
+
+'use strict';
+
+const lib = require('./lib');
+
+// ---------------------------------------------------------------------
+// CLI parsing
+// ---------------------------------------------------------------------
+
+function parseArgs(argv) {
+  // argv = [node, run.js, subcmd, ...rest]
+  const args = { _subcmd: argv[2] || null, _positional: [] };
+  for (let i = 3; i < argv.length; i++) {
+    const tok = argv[i];
+    if (tok.startsWith('--')) {
+      const key = tok.slice(2);
+      const next = argv[i + 1];
+      if (next === undefined || next.startsWith('--')) {
+        args[key] = true;
+      } else {
+        args[key] = next;
+        i++;
+      }
+    } else {
+      args._positional.push(tok);
+    }
+  }
+  return args;
+}
+
+function emit(payload) {
+  process.stdout.write(JSON.stringify(payload) + '\n');
+}
+
+function bail(code, message, subcommand) {
+  emit({ ok: false, subcommand, error: message, code });
+  process.exit(1);
+}
+
+function requireUser(args, subcmd) {
+  const u = args.user;
+  if (!u || typeof u !== 'string') {
+    bail('missing-user', '--user <email> is required', subcmd);
+  }
+  if (!/^[\w%+.-]+@[\w.-]+\.[A-Za-z]{2,}$/.test(u)) {
+    bail('bad-user', `--user "${u}" is not a valid email`, subcmd);
+  }
+  return u.toLowerCase();
+}
+
+function requirePositional(args, n, subcmd) {
+  if (args._positional.length < n) {
+    bail('missing-args', `Expected ${n} positional argument(s)`, subcmd);
+  }
+  return args._positional;
+}
+
+// ---------------------------------------------------------------------
+// Subcommands
+// ---------------------------------------------------------------------
+
+async function cmd_enable(args) {
+  const user = requireUser(args, 'enable');
+  const existing = await lib.getRow(user);
+  const accessToken = await lib.getUserAccessToken(user);
+
+  // Merge: defaults first (so new keys like `task` get picked up on
+  // re-enable), existing user-renamed keys win (so we don't trample
+  // their `@psd/P0` rename). Phase 1.5 added the `task` key so users
+  // who enabled before that ship need a way to get it without resetting.
+  const labels = {
+    ...lib.DEFAULT_LABELS,
+    ...((existing && existing.labels) || {}),
+  };
+  const labelIdsByKey = await lib.ensureLabels(accessToken, labels);
+
+  // Idempotent path for already-enabled users — refresh labels (so
+  // schema additions like Phase 1.5's `task` label propagate) without
+  // resetting cursor, rules, escalation, or digest state. This is the
+  // "refresh my email triage setup" path.
+  if (existing && existing.enabled) {
+    const labelsChanged =
+      JSON.stringify(labels) !== JSON.stringify(existing.labels || {}) ||
+      JSON.stringify(labelIdsByKey) !== JSON.stringify(existing.labelIdsByKey || {});
+    if (labelsChanged) {
+      await lib.updateRow(user, { labels, labelIdsByKey });
+    }
+    emit({
+      ok: true,
+      subcommand: 'enable',
+      summary: labelsChanged
+        ? `Refreshed: triage was already enabled, labels updated to ${Object.values(labels).join(', ')}.`
+        : `Triage already enabled for ${user}. No changes needed.`,
+      data: { alreadyEnabled: true, labels, labelIdsByKey, refreshed: labelsChanged },
+    });
+    return;
+  }
+  const startHistoryId = await lib.getCurrentHistoryId(accessToken);
+
+  const internalDomain = user.split('@')[1];
+  const now = new Date().toISOString();
+
+  const newRow = {
+    enabled: true,
+    enabledAt: now,
+    disabledAt: null,
+    classifierStartHistoryId: startHistoryId,
+    lastHistoryId: startHistoryId,
+    lastPollAt: now,
+    labels,
+    labelIdsByKey,
+    rules: (existing && existing.rules) || lib.DEFAULT_RULES,
+    escalation: (existing && existing.escalation) || lib.DEFAULT_ESCALATION,
+    digestEnabled: existing ? existing.digestEnabled !== false : true,
+    digestTime: (existing && existing.digestTime) || '08:00',
+    digestTz: (existing && existing.digestTz) || 'America/Los_Angeles',
+    recentDecisions: (existing && existing.recentDecisions) || [],
+    recentCorrections: (existing && existing.recentCorrections) || [],
+    learnedPatterns: (existing && existing.learnedPatterns) || [],
+    internalDomain,
+    // NOTE: do NOT include `userEmail` here. It's the DynamoDB partition
+    // key — UpdateCommand passes it via Key{userEmail} and DDB refuses
+    // to modify PK attributes in the SET expression. lib.updateRow()
+    // also guards against this, but keeping the bag clean here too.
+  };
+
+  // Build digest schedule first; if it fails, we still want to be able
+  // to persist the rest of the row (digest is recoverable).
+  let digestArn = null;
+  let digestNote = null;
+  if (newRow.digestEnabled) {
+    try {
+      digestArn = await lib.upsertDigestSchedule(
+        user,
+        newRow.digestTime,
+        newRow.digestTz,
+      );
+    } catch (err) {
+      digestNote = `Digest schedule deferred (${err.message}). Re-run 'digest enable' once env is configured.`;
+      newRow.digestEnabled = false;
+    }
+  }
+  newRow.digestScheduleArn = digestArn;
+
+  await lib.updateRow(user, newRow);
+
+  emit({
+    ok: true,
+    subcommand: 'enable',
+    summary:
+      `Watching ${user}. Gmail labels: ${Object.values(labels).join(', ')}. ` +
+      `Default rules seeded. Cursor anchored at historyId ${startHistoryId}.` +
+      (digestNote ? ' ' + digestNote : ''),
+    data: { labels, labelIdsByKey, startHistoryId, digestArn },
+  });
+}
+
+async function cmd_disable(args) {
+  const user = requireUser(args, 'disable');
+  const row = await lib.getRow(user);
+  if (!row) {
+    emit({ ok: true, subcommand: 'disable', summary: `No triage configured for ${user}. Nothing to do.` });
+    return;
+  }
+  const forget = args.forget === true;
+  const now = new Date().toISOString();
+
+  if (!forget) {
+    await lib.updateRow(user, { enabled: false, disabledAt: now });
+    // Pause digest too — preserves the schedule config for re-enable.
+    if (row.digestEnabled && row.digestScheduleArn) {
+      try { await lib.deleteDigestSchedule(user); } catch (_) {}
+    }
+    emit({
+      ok: true,
+      subcommand: 'disable',
+      summary: `Paused triage for ${user}. Rules and labels are kept. Re-enable anytime.`,
+    });
+    return;
+  }
+
+  // --forget: nuke state, delete labels, remove schedule.
+  let labelsDeleted = 0;
+  try {
+    const accessToken = await lib.getUserAccessToken(user);
+    for (const [, labelId] of Object.entries(row.labelIdsByKey || {})) {
+      try { await lib.deleteLabel(accessToken, labelId); labelsDeleted++; } catch (_) {}
+    }
+  } catch (_) {
+    // If OAuth fails, leave labels — better than crashing the forget.
+  }
+  try { await lib.deleteDigestSchedule(user); } catch (_) {}
+  await lib.deleteRow(user);
+
+  emit({
+    ok: true,
+    subcommand: 'disable',
+    summary: `Forgot all triage state for ${user}. Deleted ${labelsDeleted} Gmail labels.`,
+  });
+}
+
+async function cmd_status(args) {
+  const user = requireUser(args, 'status');
+  const row = await lib.getRow(user);
+  if (!row) {
+    emit({
+      ok: true,
+      subcommand: 'status',
+      summary: `Triage is not enabled for ${user}. Call 'enable' to start.`,
+      data: { enabled: false },
+    });
+    return;
+  }
+  emit({
+    ok: true,
+    subcommand: 'status',
+    summary:
+      `${row.enabled ? 'Active' : 'Paused'} · ` +
+      `${(row.rules.vipSenders || []).length} VIPs · ` +
+      `${(row.rules.muteSenders || []).length} muted · ` +
+      `${(row.rules.keywordRules || []).length} keyword rules · ` +
+      `${(row.recentDecisions || []).length} recent decisions · ` +
+      `digest ${row.digestEnabled ? `${row.digestTime} ${row.digestTz || ''}` : 'off'}.`,
+    data: {
+      enabled: row.enabled,
+      enabledAt: row.enabledAt,
+      disabledAt: row.disabledAt,
+      labels: row.labels,
+      lastPollAt: row.lastPollAt,
+      counts: {
+        vipSenders: (row.rules.vipSenders || []).length,
+        muteSenders: (row.rules.muteSenders || []).length,
+        keywordRules: (row.rules.keywordRules || []).length,
+        escalationSenders: (row.escalation.senders || []).length,
+        escalationKeywords: (row.escalation.keywords || []).length,
+        recentDecisions: (row.recentDecisions || []).length,
+        recentCorrections: (row.recentCorrections || []).length,
+      },
+      digest: {
+        enabled: row.digestEnabled,
+        time: row.digestTime,
+        tz: row.digestTz,
+      },
+    },
+  });
+}
+
+// ---------------------------------------------------------------------
+// rules.*
+// ---------------------------------------------------------------------
+
+async function requireEnabledRow(user, subcommand) {
+  const row = await lib.getRow(user);
+  if (!row) {
+    bail('not-enabled', `Triage not enabled for ${user}. Call 'enable' first.`, subcommand);
+  }
+  return row;
+}
+
+async function cmd_rules(args) {
+  const verb = args._positional[0];
+  if (verb === 'list') {
+    const user = requireUser(args, 'rules list');
+    const row = await requireEnabledRow(user, 'rules list');
+    emit({
+      ok: true,
+      subcommand: 'rules list',
+      summary: 'Current rules',
+      data: { rules: row.rules },
+    });
+    return;
+  }
+  if (verb === 'add-vip') {
+    const user = requireUser(args, 'rules add-vip');
+    const [, email] = requirePositional(args, 2, 'rules add-vip');
+    const row = await requireEnabledRow(user, 'rules add-vip');
+    const vips = Array.from(new Set([...(row.rules.vipSenders || []), email.toLowerCase()]));
+    await lib.updateRow(user, { rules: { ...row.rules, vipSenders: vips } });
+    emit({ ok: true, subcommand: 'rules add-vip', summary: `Added VIP: ${email}` });
+    return;
+  }
+  if (verb === 'mute') {
+    const user = requireUser(args, 'rules mute');
+    const [, pattern] = requirePositional(args, 2, 'rules mute');
+    const row = await requireEnabledRow(user, 'rules mute');
+    const muted = Array.from(new Set([...(row.rules.muteSenders || []), pattern.toLowerCase()]));
+    await lib.updateRow(user, { rules: { ...row.rules, muteSenders: muted } });
+    emit({ ok: true, subcommand: 'rules mute', summary: `Muted: ${pattern}` });
+    return;
+  }
+  if (verb === 'add-keyword') {
+    const user = requireUser(args, 'rules add-keyword');
+    const [, keyword] = requirePositional(args, 2, 'rules add-keyword');
+    const label = args.label || 'later';
+    if (!['important', 'later', 'news'].includes(label)) {
+      bail('bad-label', `--label must be important|later|news (got "${label}")`, 'rules add-keyword');
+    }
+    const row = await requireEnabledRow(user, 'rules add-keyword');
+    const rule = { label };
+    if (args.snippet) rule.snippet_contains = keyword;
+    else if (args.from) rule.from_domain = args.from;
+    else rule.subject_contains = keyword;
+    if (args.external === true) rule.external = true;
+    const next = [...(row.rules.keywordRules || []), rule];
+    await lib.updateRow(user, { rules: { ...row.rules, keywordRules: next } });
+    emit({
+      ok: true,
+      subcommand: 'rules add-keyword',
+      summary: `Keyword rule added: "${keyword}" → ${label}`,
+      data: { rule },
+    });
+    return;
+  }
+  if (verb === 'remove') {
+    const user = requireUser(args, 'rules remove');
+    const [, type, value] = requirePositional(args, 3, 'rules remove');
+    const row = await requireEnabledRow(user, 'rules remove');
+    const next = { ...row.rules };
+    if (type === 'vip') {
+      next.vipSenders = (row.rules.vipSenders || []).filter((v) => v !== value.toLowerCase());
+    } else if (type === 'mute') {
+      next.muteSenders = (row.rules.muteSenders || []).filter((v) => v !== value.toLowerCase());
+    } else if (type === 'keyword') {
+      // Match on subject_contains / snippet_contains / from_domain.
+      next.keywordRules = (row.rules.keywordRules || []).filter((r) => {
+        return r.subject_contains !== value && r.snippet_contains !== value && r.from_domain !== value;
+      });
+    } else {
+      bail('bad-type', `Unknown rule type "${type}"`, 'rules remove');
+    }
+    await lib.updateRow(user, { rules: next });
+    emit({ ok: true, subcommand: 'rules remove', summary: `Removed ${type}: ${value}` });
+    return;
+  }
+  bail('bad-verb', `Unknown rules subcommand: ${verb}`, 'rules');
+}
+
+// ---------------------------------------------------------------------
+// escalation.*
+// ---------------------------------------------------------------------
+
+async function cmd_escalation(args) {
+  const verb = args._positional[0];
+  if (verb === 'list') {
+    const user = requireUser(args, 'escalation list');
+    const row = await requireEnabledRow(user, 'escalation list');
+    emit({
+      ok: true,
+      subcommand: 'escalation list',
+      summary: 'Current escalation rules',
+      data: { escalation: row.escalation },
+    });
+    return;
+  }
+  if (verb === 'add-sender') {
+    const user = requireUser(args, 'escalation add-sender');
+    const [, email] = requirePositional(args, 2, 'escalation add-sender');
+    const row = await requireEnabledRow(user, 'escalation add-sender');
+    const senders = Array.from(new Set([...(row.escalation.senders || []), email.toLowerCase()]));
+    await lib.updateRow(user, { escalation: { ...row.escalation, senders } });
+    emit({ ok: true, subcommand: 'escalation add-sender', summary: `Will ping for: ${email}` });
+    return;
+  }
+  if (verb === 'add-keyword') {
+    const user = requireUser(args, 'escalation add-keyword');
+    const [, keyword] = requirePositional(args, 2, 'escalation add-keyword');
+    const row = await requireEnabledRow(user, 'escalation add-keyword');
+    const keywords = Array.from(new Set([...(row.escalation.keywords || []), keyword]));
+    await lib.updateRow(user, { escalation: { ...row.escalation, keywords } });
+    emit({ ok: true, subcommand: 'escalation add-keyword', summary: `Will ping when "${keyword}" appears in Important mail` });
+    return;
+  }
+  if (verb === 'remove') {
+    const user = requireUser(args, 'escalation remove');
+    const [, type, value] = requirePositional(args, 3, 'escalation remove');
+    const row = await requireEnabledRow(user, 'escalation remove');
+    const next = { ...row.escalation };
+    if (type === 'sender') next.senders = (row.escalation.senders || []).filter((v) => v !== value.toLowerCase());
+    else if (type === 'keyword') next.keywords = (row.escalation.keywords || []).filter((v) => v !== value);
+    else bail('bad-type', `Unknown escalation type "${type}"`, 'escalation remove');
+    await lib.updateRow(user, { escalation: next });
+    emit({ ok: true, subcommand: 'escalation remove', summary: `Removed escalation ${type}: ${value}` });
+    return;
+  }
+  if (verb === 'labels') {
+    const user = requireUser(args, 'escalation labels');
+    const [, labels] = requirePositional(args, 2, 'escalation labels');
+    const triggers = labels.split(',').map((l) => l.trim()).filter(Boolean);
+    for (const t of triggers) {
+      if (!['important', 'later', 'news'].includes(t)) {
+        bail('bad-label', `Unknown label "${t}" (use important|later|news)`, 'escalation labels');
+      }
+    }
+    const row = await requireEnabledRow(user, 'escalation labels');
+    await lib.updateRow(user, { escalation: { ...row.escalation, labelTriggers: triggers } });
+    emit({ ok: true, subcommand: 'escalation labels', summary: `Label triggers set to: ${triggers.join(', ')}` });
+    return;
+  }
+  bail('bad-verb', `Unknown escalation subcommand: ${verb}`, 'escalation');
+}
+
+// ---------------------------------------------------------------------
+// training.*
+// ---------------------------------------------------------------------
+
+async function cmd_training(args) {
+  const verb = args._positional[0];
+  if (verb === 'recent') {
+    const user = requireUser(args, 'training recent');
+    const row = await requireEnabledRow(user, 'training recent');
+    const limit = parseInt(args.limit || '20', 10);
+    const decisions = (row.recentDecisions || []).slice(-limit).reverse();
+    emit({
+      ok: true,
+      subcommand: 'training recent',
+      summary: `${decisions.length} recent decision(s)`,
+      data: { decisions, corrections: (row.recentCorrections || []).slice(-limit).reverse() },
+    });
+    return;
+  }
+  if (verb === 'correct') {
+    const user = requireUser(args, 'training correct');
+    const [, messageId, newLabel] = requirePositional(args, 3, 'training correct');
+    if (!['important', 'later', 'news'].includes(newLabel)) {
+      bail('bad-label', `newLabel must be important|later|news (got "${newLabel}")`, 'training correct');
+    }
+    const row = await requireEnabledRow(user, 'training correct');
+    const prior = (row.recentDecisions || []).find((d) => d.messageId === messageId);
+    const fromLabel = prior ? prior.label : 'unknown';
+    const accessToken = await lib.getUserAccessToken(user);
+
+    // Swap labels in Gmail.
+    const newLabelId = (row.labelIdsByKey || {})[newLabel];
+    if (!newLabelId) bail('missing-label', `Gmail label for "${newLabel}" not configured`, 'training correct');
+    const removeLabelIds = [];
+    for (const [k, id] of Object.entries(row.labelIdsByKey || {})) {
+      if (k !== newLabel) removeLabelIds.push(id);
+    }
+    // If the correction is to important, also re-inbox the message.
+    const addLabelIds = [newLabelId];
+    // All three labels are "folders" — the message belongs in exactly
+    // one place. Important is the user's @psd/Important folder, not a
+    // dual-tagged Inbox+label entry. Matches the classifier Lambda.
+    removeLabelIds.push('INBOX');
+    await lib.modifyMessage(accessToken, messageId, addLabelIds, removeLabelIds);
+
+    const correction = {
+      messageId,
+      fromLabel,
+      toLabel: newLabel,
+      ts: new Date().toISOString(),
+      source: 'user-correction',
+    };
+    const corrections = [...(row.recentCorrections || []), correction].slice(-50);
+    await lib.updateRow(user, { recentCorrections: corrections });
+
+    emit({
+      ok: true,
+      subcommand: 'training correct',
+      summary: `Re-labeled message ${messageId}: ${fromLabel} → ${newLabel}`,
+      data: { correction },
+    });
+    return;
+  }
+  bail('bad-verb', `Unknown training subcommand: ${verb}`, 'training');
+}
+
+// ---------------------------------------------------------------------
+// simulate
+// ---------------------------------------------------------------------
+
+async function cmd_simulate(args) {
+  const user = requireUser(args, 'simulate');
+  const row = await requireEnabledRow(user, 'simulate');
+  const fromEmail = (args.from || '').toLowerCase();
+  if (!fromEmail) bail('missing-from', '--from <email> is required', 'simulate');
+  const internalDomain = row.internalDomain || user.split('@')[1];
+  const features = {
+    fromEmail,
+    fromDomain: fromEmail.split('@')[1] || '',
+    isInternal: (fromEmail.split('@')[1] || '').toLowerCase() === internalDomain.toLowerCase(),
+    subject: args.subject || '',
+    subjectLower: (args.subject || '').toLowerCase(),
+    snippetLower: (args.snippet || '').toLowerCase(),
+    hasUserReply: args['has-user-reply'] === true,
+  };
+  const decision = lib.applyRules(features, row.rules);
+  emit({
+    ok: true,
+    subcommand: 'simulate',
+    summary: 'label' in decision
+      ? `Would label as ${decision.label} (${decision.reason})`
+      : `Rules engine undecided — classifier would call Bedrock Nova Micro for the final decision`,
+    data: { features, decision },
+  });
+}
+
+// ---------------------------------------------------------------------
+// labels.*
+// ---------------------------------------------------------------------
+
+async function cmd_labels(args) {
+  const verb = args._positional[0];
+  if (verb === 'list') {
+    const user = requireUser(args, 'labels list');
+    const row = await requireEnabledRow(user, 'labels list');
+    emit({
+      ok: true,
+      subcommand: 'labels list',
+      summary: 'Current labels',
+      data: { labels: row.labels, labelIdsByKey: row.labelIdsByKey },
+    });
+    return;
+  }
+  if (verb === 'rename') {
+    const user = requireUser(args, 'labels rename');
+    const [, key, newName] = requirePositional(args, 3, 'labels rename');
+    if (!['important', 'later', 'news'].includes(key)) {
+      bail('bad-key', `Label key must be important|later|news (got "${key}")`, 'labels rename');
+    }
+    const row = await requireEnabledRow(user, 'labels rename');
+    const labelId = (row.labelIdsByKey || {})[key];
+    if (!labelId) bail('missing-label', `Gmail label for "${key}" not configured`, 'labels rename');
+    const accessToken = await lib.getUserAccessToken(user);
+    await lib.renameLabel(accessToken, labelId, newName);
+    await lib.updateRow(user, {
+      labels: { ...row.labels, [key]: newName },
+    });
+    emit({ ok: true, subcommand: 'labels rename', summary: `Renamed ${key} → ${newName}` });
+    return;
+  }
+  bail('bad-verb', `Unknown labels subcommand: ${verb}`, 'labels');
+}
+
+// ---------------------------------------------------------------------
+// digest.*
+// ---------------------------------------------------------------------
+
+async function cmd_digest(args) {
+  const verb = args._positional[0];
+  const user = requireUser(args, `digest ${verb}`);
+  const row = await requireEnabledRow(user, `digest ${verb}`);
+  if (verb === 'enable') {
+    const arn = await lib.upsertDigestSchedule(user, row.digestTime || '08:00', row.digestTz || 'America/Los_Angeles');
+    await lib.updateRow(user, { digestEnabled: true, digestScheduleArn: arn });
+    emit({ ok: true, subcommand: 'digest enable', summary: `Daily digest scheduled for ${row.digestTime || '08:00'} ${row.digestTz || ''}.` });
+    return;
+  }
+  if (verb === 'disable') {
+    try { await lib.deleteDigestSchedule(user); } catch (_) {}
+    await lib.updateRow(user, { digestEnabled: false });
+    emit({ ok: true, subcommand: 'digest disable', summary: 'Daily digest disabled.' });
+    return;
+  }
+  if (verb === 'time') {
+    const [, time] = requirePositional(args, 2, 'digest time');
+    if (!/^([01]?\d|2[0-3]):[0-5]\d$/.test(time)) {
+      bail('bad-time', `Time must be HH:MM 24-hour (got "${time}")`, 'digest time');
+    }
+    if (row.digestEnabled) {
+      await lib.upsertDigestSchedule(user, time, row.digestTz || 'America/Los_Angeles');
+    }
+    await lib.updateRow(user, { digestTime: time });
+    emit({ ok: true, subcommand: 'digest time', summary: `Digest time set to ${time}` });
+    return;
+  }
+  bail('bad-verb', `Unknown digest subcommand: ${verb}`, 'digest');
+}
+
+// ---------------------------------------------------------------------
+// tasks.* — Phase 1.5 user-gesture task creation
+// ---------------------------------------------------------------------
+
+async function cmd_tasks(args) {
+  const verb = args._positional[0];
+  const user = requireUser(args, `tasks ${verb}`);
+  const row = await requireEnabledRow(user, `tasks ${verb}`);
+
+  if (verb === 'mode') {
+    const [, mode] = requirePositional(args, 2, 'tasks mode');
+    if (mode !== 'none' && mode !== 'invoke-agent') {
+      bail('bad-mode', `mode must be 'none' or 'invoke-agent' (got "${mode}")`, 'tasks mode');
+    }
+    const updates = { tasksMode: mode };
+    let labelCreated = false;
+    // Lazily create the @psd/Task Gmail label if it's missing — when
+    // a user upgrades from a pre-Phase-1.5 enable to invoke-agent mode,
+    // they need the label to exist before the gesture works.
+    if (mode === 'invoke-agent' && !((row.labelIdsByKey || {}).task)) {
+      const accessToken = await lib.getUserAccessToken(user);
+      const labels = {
+        ...lib.DEFAULT_LABELS,
+        ...(row.labels || {}),
+      };
+      const labelIdsByKey = await lib.ensureLabels(accessToken, labels);
+      updates.labels = labels;
+      updates.labelIdsByKey = labelIdsByKey;
+      labelCreated = true;
+    }
+    await lib.updateRow(user, updates);
+    emit({
+      ok: true,
+      subcommand: 'tasks mode',
+      summary: mode === 'invoke-agent'
+        ? `Task gestures will now invoke your agent to create tasks per your MEMORY.md instructions.${labelCreated ? ' Created the @psd/Task Gmail label.' : ''}`
+        : `Task gestures will be ignored — emails labeled @psd/Task just sit there. No automation.`,
+      data: { tasksMode: mode, labelCreated },
+    });
+    return;
+  }
+
+  if (verb === 'notify-success') {
+    const [, flag] = requirePositional(args, 2, 'tasks notify-success');
+    const on = flag === 'on' || flag === 'true' || flag === '1';
+    await lib.updateRow(user, { tasksNotifySuccess: on });
+    emit({
+      ok: true,
+      subcommand: 'tasks notify-success',
+      summary: on
+        ? 'Success notifications enabled — Chat card will confirm each task creation.'
+        : 'Success notifications disabled — task creations will be silent (failures still notify).',
+    });
+    return;
+  }
+
+  if (verb === 'status') {
+    emit({
+      ok: true,
+      subcommand: 'tasks status',
+      summary:
+        `Task mode: ${row.tasksMode || 'none'} · ` +
+        `Success notify: ${row.tasksNotifySuccess ? 'on' : 'off'} · ` +
+        `${(row.recentTaskCreations || []).length} recent task(s) created`,
+      data: {
+        tasksMode: row.tasksMode || 'none',
+        tasksNotifySuccess: Boolean(row.tasksNotifySuccess),
+        recentTaskCreations: (row.recentTaskCreations || []).slice(-10).reverse(),
+        taskLabelName: (row.labels || {}).task || '@psd/Task',
+      },
+    });
+    return;
+  }
+
+  bail('bad-verb', `Unknown tasks subcommand: ${verb} (try 'mode', 'notify-success', 'status')`, 'tasks');
+}
+
+// ---------------------------------------------------------------------
+// Dispatcher
+// ---------------------------------------------------------------------
+
+const COMMANDS = {
+  enable: cmd_enable,
+  disable: cmd_disable,
+  status: cmd_status,
+  rules: cmd_rules,
+  escalation: cmd_escalation,
+  training: cmd_training,
+  simulate: cmd_simulate,
+  labels: cmd_labels,
+  digest: cmd_digest,
+  tasks: cmd_tasks,
+};
+
+async function main() {
+  const args = parseArgs(process.argv);
+  if (!args._subcmd || args.help === true) {
+    process.stdout.write(
+      'Usage: psd-email-triage <subcommand> --user <email> [args]\n' +
+      'Subcommands: ' + Object.keys(COMMANDS).join(', ') + '\n' +
+      'See /opt/psd-skills/psd-email-triage/SKILL.md for full reference.\n',
+    );
+    process.exit(args.help === true ? 0 : 2);
+  }
+  const fn = COMMANDS[args._subcmd];
+  if (!fn) {
+    bail('unknown-subcommand', `Unknown subcommand: ${args._subcmd}`, args._subcmd);
+  }
+  try {
+    await fn(args);
+  } catch (err) {
+    const code = (err && err.code) || 'unexpected-error';
+    const msg = err && err.message ? err.message : String(err);
+    emit({ ok: false, subcommand: args._subcmd, error: msg, code });
+    process.exit(1);
+  }
+}
+
+main();

--- a/infra/database/migrations.json
+++ b/infra/database/migrations.json
@@ -72,6 +72,7 @@
     "074-deep-research-capability.sql",
     "075-skill-required-capability.sql",
     "076-agent-failures.sql",
-    "077-agent-workspace-consent-nonces-cognito-data.sql"
+    "077-agent-workspace-consent-nonces-cognito-data.sql",
+    "078-agent-deep-telemetry.sql"
   ]
 }

--- a/infra/database/schema/078-agent-deep-telemetry.sql
+++ b/infra/database/schema/078-agent-deep-telemetry.sql
@@ -1,0 +1,64 @@
+-- Migration 078: Deep telemetry for the Agent Platform.
+-- ---------------------------------------------------------------------------
+-- Adds two new tables that let the admin dashboard inspect full conversation
+-- content + tool invocations for every agent turn. Drives the Conversations
+-- tab. Both tables FK to agent_messages so a single CASCADE delete cleans
+-- everything related to a turn.
+--
+-- Content size limits enforced in the writer:
+--   agent_message_content.content_text   — capped at 64KB
+--   agent_tool_invocations.tool_args     — capped at 16KB (after stringify)
+--   agent_tool_invocations.tool_result   — capped at 16KB (after stringify)
+--
+-- A separate daily Lambda (agent-telemetry-prune) deletes rows in these
+-- tables older than 90 days. The summary rows in agent_messages are kept.
+-- ---------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS agent_message_content (
+  id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  message_id BIGINT NOT NULL REFERENCES agent_messages(id) ON DELETE CASCADE,
+  -- Denormalized to keep the dashboard queries off the FK on hot paths.
+  session_id VARCHAR(512) NOT NULL,
+  user_email VARCHAR(255) NOT NULL,
+  role VARCHAR(16) NOT NULL CHECK (role IN ('user', 'assistant', 'system', 'tool')),
+  content_text TEXT NOT NULL,
+  -- True when the writer truncated to the 64KB cap (Postgres TOAST handles
+  -- the underlying storage; the flag lets the UI surface "transcript clipped").
+  content_truncated BOOLEAN NOT NULL DEFAULT false,
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_agent_message_content_session
+  ON agent_message_content (session_id, created_at);
+CREATE INDEX IF NOT EXISTS idx_agent_message_content_user
+  ON agent_message_content (user_email, created_at);
+CREATE INDEX IF NOT EXISTS idx_agent_message_content_created_at
+  ON agent_message_content (created_at);
+
+
+CREATE TABLE IF NOT EXISTS agent_tool_invocations (
+  id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  message_id BIGINT NOT NULL REFERENCES agent_messages(id) ON DELETE CASCADE,
+  session_id VARCHAR(512) NOT NULL,
+  user_email VARCHAR(255) NOT NULL,
+  tool_name VARCHAR(255) NOT NULL,
+  -- JSONB so the dashboard can query inside args (e.g. "all psd-github tool
+  -- calls with repo=krishagel/life-os") without a separate index strategy.
+  tool_args JSONB,
+  tool_result JSONB,
+  status VARCHAR(16) NOT NULL CHECK (status IN ('success', 'error', 'timeout')),
+  error_text TEXT,
+  duration_ms INTEGER NOT NULL DEFAULT 0,
+  started_at TIMESTAMP WITH TIME ZONE NOT NULL,
+  finished_at TIMESTAMP WITH TIME ZONE NOT NULL,
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_agent_tool_invocations_tool
+  ON agent_tool_invocations (tool_name, started_at);
+CREATE INDEX IF NOT EXISTS idx_agent_tool_invocations_session
+  ON agent_tool_invocations (session_id, started_at);
+CREATE INDEX IF NOT EXISTS idx_agent_tool_invocations_user
+  ON agent_tool_invocations (user_email, started_at);
+CREATE INDEX IF NOT EXISTS idx_agent_tool_invocations_created_at
+  ON agent_tool_invocations (created_at);

--- a/infra/database/schema/078-agent-deep-telemetry.sql
+++ b/infra/database/schema/078-agent-deep-telemetry.sql
@@ -28,6 +28,8 @@ CREATE TABLE IF NOT EXISTS agent_message_content (
   created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
 );
 
+CREATE INDEX IF NOT EXISTS idx_agent_message_content_message_id
+  ON agent_message_content (message_id);
 CREATE INDEX IF NOT EXISTS idx_agent_message_content_session
   ON agent_message_content (session_id, created_at);
 CREATE INDEX IF NOT EXISTS idx_agent_message_content_user
@@ -54,6 +56,8 @@ CREATE TABLE IF NOT EXISTS agent_tool_invocations (
   created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
 );
 
+CREATE INDEX IF NOT EXISTS idx_agent_tool_invocations_message_id
+  ON agent_tool_invocations (message_id);
 CREATE INDEX IF NOT EXISTS idx_agent_tool_invocations_tool
   ON agent_tool_invocations (tool_name, started_at);
 CREATE INDEX IF NOT EXISTS idx_agent_tool_invocations_session

--- a/infra/lambdas/agent-router/index.ts
+++ b/infra/lambdas/agent-router/index.ts
@@ -1516,9 +1516,24 @@ async function logTelemetry(
     // best-effort: failure here logs but doesn't surface to the user.
     // Empty arrays are normal for sessions whose harness doesn't surface
     // the data yet.
+    //
+    // Hard cap on rows per turn to prevent a misbehaving harness from
+    // firing thousands of parallel INSERTs and exhausting the Aurora
+    // connection pool. 200 messages + 200 tool calls is already generous;
+    // normal turns have <10 of each.
+    const MAX_MESSAGES_PER_TURN = 200;
+    const MAX_TOOLS_PER_TURN = 200;
     const writes: Promise<unknown>[] = [];
     if (messageId && params.messages && params.messages.length > 0) {
-      for (const m of params.messages) {
+      const cappedMessages = params.messages.slice(0, MAX_MESSAGES_PER_TURN);
+      if (params.messages.length > MAX_MESSAGES_PER_TURN) {
+        log.warn('Deep telemetry message cap hit — truncating', {
+          actual: params.messages.length,
+          cap: MAX_MESSAGES_PER_TURN,
+          sessionId: params.sessionId,
+        });
+      }
+      for (const m of cappedMessages) {
         const { value, truncated } = truncateContent(m.content);
         writes.push(
           sql`INSERT INTO agent_message_content
@@ -1529,7 +1544,15 @@ async function logTelemetry(
       }
     }
     if (messageId && params.toolCalls && params.toolCalls.length > 0) {
-      for (const t of params.toolCalls) {
+      const cappedToolCalls = params.toolCalls.slice(0, MAX_TOOLS_PER_TURN);
+      if (params.toolCalls.length > MAX_TOOLS_PER_TURN) {
+        log.warn('Deep telemetry tool-call cap hit — truncating', {
+          actual: params.toolCalls.length,
+          cap: MAX_TOOLS_PER_TURN,
+          sessionId: params.sessionId,
+        });
+      }
+      for (const t of cappedToolCalls) {
         writes.push(
           sql`INSERT INTO agent_tool_invocations
               (message_id, session_id, user_email, tool_name, tool_args,

--- a/infra/lambdas/agent-router/index.ts
+++ b/infra/lambdas/agent-router/index.ts
@@ -1101,7 +1101,27 @@ async function invokeAgentCore(
     /** Ephemeral thread context for cross-user invocations */
     threadContext?: string;
   }
-): Promise<{ response: string; inputTokens: number; outputTokens: number; model: string | null }> {
+): Promise<{
+  response: string;
+  inputTokens: number;
+  outputTokens: number;
+  model: string | null;
+  /** Wall-clock ms reported by the harness from chat.send to final. */
+  latencyMs: number;
+  /** Per-turn message log (role + content_text). Empty when harness doesn't surface it. */
+  messages: Array<{ role: string; content: string }>;
+  /** Per-turn tool calls. Empty when harness doesn't surface them. */
+  toolCalls: Array<{
+    name: string;
+    args: unknown;
+    result: unknown;
+    status: 'success' | 'error' | 'timeout';
+    error_text: string | null;
+    duration_ms: number;
+    started_at: string;
+    finished_at: string;
+  }>;
+}> {
   // Resolve the AgentCore Runtime ID — check env var, then module-level cache,
   // then SSM. Cached at module scope with TTL to avoid redundant SSM API calls
   // on every invocation (~5–20ms + cost per call).
@@ -1138,6 +1158,9 @@ async function invokeAgentCore(
       inputTokens: 0,
       outputTokens: 0,
       model: null,
+      latencyMs: 0,
+      messages: [],
+      toolCalls: [],
     };
   }
 
@@ -1211,20 +1234,24 @@ async function invokeAgentCore(
 
       if (response.status === 503 || response.status === 429) {
         return {
-          response:
-            "I'm temporarily busy. Please try again in a moment.",
+          response: "I'm temporarily busy. Please try again in a moment.",
           inputTokens: 0,
           outputTokens: 0,
           model: null,
+          latencyMs: 0,
+          messages: [],
+          toolCalls: [],
         };
       }
 
       return {
-        response:
-          'I encountered an error processing your message. Please try again.',
+        response: 'I encountered an error processing your message. Please try again.',
         inputTokens: 0,
         outputTokens: 0,
         model: null,
+        latencyMs: 0,
+        messages: [],
+        toolCalls: [],
       };
     }
 
@@ -1242,11 +1269,50 @@ async function invokeAgentCore(
     const result = (responseBody.result as string) || 'No response from agent.';
     const metadata = (responseBody.metadata as Record<string, unknown>) || {};
 
+    // Best-effort coercion — the harness MAY surface these fields, but
+    // each defaults safely when missing so older harness versions don't
+    // break the writer.
+    const rawMessages = (metadata.messages as unknown) ?? [];
+    const messages = Array.isArray(rawMessages)
+      ? (rawMessages as Array<Record<string, unknown>>)
+          .map((m) => ({
+            role: typeof m.role === 'string' ? m.role : 'assistant',
+            content: typeof m.content === 'string' ? m.content : '',
+          }))
+          .filter((m) => m.content.length > 0)
+      : [];
+    const rawToolCalls = (metadata.tool_calls as unknown) ?? [];
+    type RawToolCall = Record<string, unknown>;
+    const toolCalls = Array.isArray(rawToolCalls)
+      ? (rawToolCalls as RawToolCall[]).map((t) => ({
+          name: typeof t.name === 'string' ? t.name : 'unknown',
+          args: t.args ?? null,
+          result: t.result ?? null,
+          status:
+            t.status === 'success' || t.status === 'error' || t.status === 'timeout'
+              ? (t.status as 'success' | 'error' | 'timeout')
+              : 'success',
+          error_text: typeof t.error_text === 'string' ? t.error_text : null,
+          duration_ms: typeof t.duration_ms === 'number' ? t.duration_ms : 0,
+          started_at:
+            typeof t.started_at === 'string'
+              ? t.started_at
+              : new Date().toISOString(),
+          finished_at:
+            typeof t.finished_at === 'string'
+              ? t.finished_at
+              : new Date().toISOString(),
+        }))
+      : [];
+
     return {
       response: result,
       inputTokens: (metadata.input_tokens as number) || 0,
       outputTokens: (metadata.output_tokens as number) || 0,
       model: (metadata.model as string) || 'kimi-k2.5',
+      latencyMs: (metadata.latency_ms as number) || 0,
+      messages,
+      toolCalls,
     };
   } catch (error) {
     log.error('AgentCore invocation error', {
@@ -1258,6 +1324,9 @@ async function invokeAgentCore(
       inputTokens: 0,
       outputTokens: 0,
       model: null,
+      latencyMs: 0,
+      messages: [],
+      toolCalls: [],
     };
   }
 }
@@ -1346,6 +1415,37 @@ async function sendGoogleChatResponse(
 // Telemetry
 // ---------------------------------------------------------------------------
 
+/** Content text cap before truncation — 64KB matches the migration. */
+const CONTENT_CHAR_CAP = 64_000;
+/** Stringified JSON cap for tool args/result — 16KB matches the migration. */
+const TOOL_JSON_CHAR_CAP = 16_000;
+
+function truncateContent(text: string): { value: string; truncated: boolean } {
+  if (text.length <= CONTENT_CHAR_CAP) return { value: text, truncated: false };
+  return { value: text.slice(0, CONTENT_CHAR_CAP), truncated: true };
+}
+
+/**
+ * Encode `value` as a JSON string for storage in a jsonb column. postgres.js
+ * has a `sql.json()` helper but it expects a typed JSONValue and we're
+ * working with `unknown` from the harness — easier to stringify ourselves
+ * and let postgres.js pass it through verbatim into the jsonb column.
+ */
+function truncateJsonValue(value: unknown): string | null {
+  if (value === null || value === undefined) return null;
+  let s: string;
+  try {
+    s = JSON.stringify(value);
+  } catch {
+    return JSON.stringify({ _truncated: true, error: 'JSON.stringify failed' });
+  }
+  if (s.length <= TOOL_JSON_CHAR_CAP) return s;
+  return JSON.stringify({
+    _truncated: true,
+    preview: s.slice(0, TOOL_JSON_CHAR_CAP - 32),
+  });
+}
+
 async function logTelemetry(
   params: {
     userId: string;
@@ -1362,6 +1462,19 @@ async function logTelemetry(
     agentOwnerId?: string;
     /** Fixed-taxonomy topic label from the classifier; null when [private], unclassified, or classifier disabled */
     topic?: Topic | null;
+    /** Per-turn message log for the deep-telemetry Conversations tab. */
+    messages?: Array<{ role: string; content: string }>;
+    /** Per-turn tool invocations for the Conversations timeline. */
+    toolCalls?: Array<{
+      name: string;
+      args: unknown;
+      result: unknown;
+      status: 'success' | 'error' | 'timeout';
+      error_text: string | null;
+      duration_ms: number;
+      started_at: string;
+      finished_at: string;
+    }>;
   },
   log: ReturnType<typeof createLogger>
 ): Promise<void> {
@@ -1377,23 +1490,18 @@ async function logTelemetry(
     const agentOwnerId = params.agentOwnerId ?? null;
     const topic = params.topic ?? null;
 
-    // Run both telemetry writes in parallel — they're independent.
-    // Uses direct PostgreSQL (postgres.js) consistent with the rest of the app,
-    // instead of RDS Data API which adds ~100-300ms latency per call.
-    await Promise.all([
-      // Insert message-level telemetry
-      // invoked_by and agent_owner_id are NULL for normal (owner) invocations
-      sql`INSERT INTO agent_messages
+    // Insert agent_messages first to get the id, then fan out to the
+    // deep-telemetry tables. The session upsert is independent and can
+    // run in parallel with the message insert.
+    const [messageRow] = await Promise.all([
+      sql<{ id: number }[]>`INSERT INTO agent_messages
           (user_id, session_id, model, input_tokens, output_tokens,
            latency_ms, guardrail_blocked, space_name, invoked_by, agent_owner_id, topic, created_at)
           VALUES (${params.userId}, ${params.sessionId}, ${params.model},
                   ${params.inputTokens}, ${params.outputTokens},
                   ${params.latencyMs}, ${params.guardrailBlocked},
-                  ${params.spaceName}, ${invokedBy}, ${agentOwnerId}, ${topic}, NOW())`,
-
-      // Upsert session-level aggregates — creates the session row on first message,
-      // increments counters on subsequent messages. Uses ON CONFLICT on session_id
-      // unique constraint to achieve idempotent upserts.
+                  ${params.spaceName}, ${invokedBy}, ${agentOwnerId}, ${topic}, NOW())
+          RETURNING id`,
       sql`INSERT INTO agent_sessions
           (user_id, session_id, session_start, total_messages, total_tokens, created_at, updated_at)
           VALUES (${params.userId}, ${params.sessionId}, NOW(), 1, ${totalTokens}, NOW(), NOW())
@@ -1402,6 +1510,51 @@ async function logTelemetry(
             total_tokens = agent_sessions.total_tokens + EXCLUDED.total_tokens,
             session_end = NOW()`,
     ]);
+    const messageId = messageRow[0]?.id;
+
+    // Deep telemetry — content + tool invocations. Both are
+    // best-effort: failure here logs but doesn't surface to the user.
+    // Empty arrays are normal for sessions whose harness doesn't surface
+    // the data yet.
+    const writes: Promise<unknown>[] = [];
+    if (messageId && params.messages && params.messages.length > 0) {
+      for (const m of params.messages) {
+        const { value, truncated } = truncateContent(m.content);
+        writes.push(
+          sql`INSERT INTO agent_message_content
+              (message_id, session_id, user_email, role, content_text, content_truncated, created_at)
+              VALUES (${messageId}, ${params.sessionId}, ${params.userId},
+                      ${m.role}, ${value}, ${truncated}, NOW())`,
+        );
+      }
+    }
+    if (messageId && params.toolCalls && params.toolCalls.length > 0) {
+      for (const t of params.toolCalls) {
+        writes.push(
+          sql`INSERT INTO agent_tool_invocations
+              (message_id, session_id, user_email, tool_name, tool_args,
+               tool_result, status, error_text, duration_ms, started_at, finished_at, created_at)
+              VALUES (${messageId}, ${params.sessionId}, ${params.userId},
+                      ${t.name},
+                      ${truncateJsonValue(t.args)}::jsonb,
+                      ${truncateJsonValue(t.result)}::jsonb,
+                      ${t.status}, ${t.error_text}, ${t.duration_ms},
+                      ${t.started_at}, ${t.finished_at}, NOW())`,
+        );
+      }
+    }
+    if (writes.length > 0) {
+      try {
+        await Promise.all(writes);
+      } catch (deepErr) {
+        log.error('Failed to write deep telemetry rows', {
+          error: deepErr instanceof Error ? deepErr.message : String(deepErr),
+          messageId,
+          contentCount: params.messages?.length ?? 0,
+          toolCount: params.toolCalls?.length ?? 0,
+        });
+      }
+    }
   } catch (error) {
     // Telemetry failure should not affect user experience
     log.error('Failed to write telemetry', {
@@ -2292,7 +2445,12 @@ async function processRecord(
       //   agentOwnerId = whose agent was consulted (resource consumption attribution)
       // This means "messages by userId" includes both self-sent and cross-user-initiated.
       // To query "messages consuming X's agent resources", filter by agentOwnerId.
-      const latencyMs = Date.now() - startTime;
+      // Prefer the harness-reported latency_ms (covers exactly chat.send →
+      // final) over the router-wall-clock — they only differ by a few ms
+      // but the harness number is what we want in the dashboard.
+      const latencyMs = agentResult.latencyMs > 0
+        ? agentResult.latencyMs
+        : Date.now() - startTime;
       await logTelemetry(
         {
           userId: senderEmail,
@@ -2306,6 +2464,8 @@ async function processRecord(
           invokedBy: senderEmail,
           agentOwnerId: targetUser.email,
           topic,
+          messages: agentResult.messages,
+          toolCalls: agentResult.toolCalls,
         },
         log
       );
@@ -2403,7 +2563,11 @@ async function processRecord(
   await sendGoogleChatResponse(spaceName, threadName, finalResponse, log);
 
   // Step 7: Log telemetry
-  const latencyMs = Date.now() - startTime;
+  // Prefer the harness-reported latency_ms when available so the dashboard
+  // shows chat.send → final, not the entire router execution.
+  const latencyMs = agentResult.latencyMs > 0
+    ? agentResult.latencyMs
+    : Date.now() - startTime;
   await logTelemetry(
     {
       userId: senderEmail,
@@ -2418,6 +2582,8 @@ async function processRecord(
       guardrailBlocked: guardrailResult.wouldHaveBlocked,
       spaceName,
       topic,
+      messages: agentResult.messages,
+      toolCalls: agentResult.toolCalls,
     },
     log
   );

--- a/infra/lambdas/agent-router/topic-classifier.ts
+++ b/infra/lambdas/agent-router/topic-classifier.ts
@@ -15,7 +15,13 @@
 // Fixed taxonomy. Must remain stable over time so longitudinal patterns are
 // comparable. Additions are acceptable; renames/deletions break historical
 // signal data. Keep labels broad enough to avoid proxying individual users.
+//
+// First-match-wins in TAXONOMY order, so list the most specific buckets
+// first (K-12 admin) and the catch-all categories last (general code/help).
+// Otherwise "the principal asked about the curriculum budget" gets caught
+// by `budget-inquiry` instead of the more specific `curriculum-request`.
 export const TAXONOMY = [
+  // ──────────── K-12 admin (original taxonomy, most specific) ────────────
   'attendance-policy',
   'curriculum-request',
   'behavior-support',
@@ -26,6 +32,18 @@ export const TAXONOMY = [
   'professional-development',
   'parent-communication',
   'scheduling-conflict',
+  // ──────────── Communication + workflow ────────────
+  'email-triage',
+  'meeting-prep',
+  'document-drafting',
+  'task-planning',
+  // ──────────── Tech ops + agent platform ────────────
+  'agent-platform-ops',
+  'skill-development',
+  'data-engineering',
+  'ai-model-discussion',
+  'general-development',
+  'incident-response',
 ] as const;
 
 export type Topic = (typeof TAXONOMY)[number];
@@ -116,7 +134,117 @@ const KEYWORDS: Record<Topic, RegExp[]> = {
     /\bconflict/i,
     /\breschedule/i,
     /\bovertime\b/i,
-    /\bmeeting/i,
+  ],
+  // ──────────── Communication + workflow ────────────
+  'email-triage': [
+    /\btriag/i,
+    /\binbox\b/i,
+    /\bgmail\b/i,
+    /\bemail (rule|filter|label|sort|cleanup)/i,
+    /\b@psd\/(important|later|news|task)\b/i,
+  ],
+  'meeting-prep': [
+    /\bmeeting\b/i,
+    /\bagenda\b/i,
+    /\bone[- ]on[- ]one\b/i,
+    /\b1:1\b/,
+    /\bstandup\b/i,
+    /\bretrospective\b/i,
+    /\bkick[- ]?off\b/i,
+  ],
+  'document-drafting': [
+    /\bdraft (a|an|the|me|some)\b/i,
+    /\bwrite (a|an|the|me|some)\b/i,
+    /\bmemo\b/i,
+    /\bproposal\b/i,
+    /\bnewsletter\b/i,
+    /\bsummariz/i,
+    /\boutline\b/i,
+    /\bsop\b/i,
+  ],
+  'task-planning': [
+    /\btask\b/i,
+    /\bto[- ]?do\b/i,
+    /\bbacklog\b/i,
+    /\bsprint\b/i,
+    /\bmilestone\b/i,
+    /\bplan(ning)?\b/i,
+    /\broadmap\b/i,
+    /\bdeadline\b/i,
+  ],
+  // ──────────── Tech ops + agent platform ────────────
+  'agent-platform-ops': [
+    /\bagentcore\b/i,
+    /\bopenclaw\b/i,
+    /\bbedrock\b/i,
+    /\bcdk\b/i,
+    /\bcloudformation\b/i,
+    /\bdeploy/i,
+    /\blambda\b/i,
+    /\becr\b/i,
+    /\bdocker\b/i,
+    /\bIAM\b/i,
+    /\bsecrets manager\b/i,
+  ],
+  'skill-development': [
+    /\bskill (build|develop|register|deploy)/i,
+    /\bbundled skill/i,
+    /\bSKILL\.md\b/i,
+    /\bharness\b/i,
+    /\btool (catalog|registr|definition)/i,
+    /\bMCP server\b/i,
+  ],
+  'data-engineering': [
+    /\bmigration\b/i,
+    /\bschema\b/i,
+    /\bpostgres/i,
+    /\baurora\b/i,
+    /\bdynamodb\b/i,
+    /\bdrizzle\b/i,
+    /\bquery (performance|plan|optimization)/i,
+    /\bindex (creation|tuning|missing)/i,
+  ],
+  'ai-model-discussion': [
+    /\bclaude\b/i,
+    /\bgpt[- ]?[0-9]?\b/i,
+    /\bllm\b/i,
+    /\bopen ?ai\b/i,
+    /\banthropic\b/i,
+    /\bnova micro\b/i,
+    /\bsonnet\b/i,
+    /\bhaiku\b/i,
+    /\bopus\b/i,
+    /\bmodel (selection|swap|choice|comparison)/i,
+    /\btoken usage\b/i,
+    /\bprompt (engineering|tuning|template)/i,
+  ],
+  'general-development': [
+    /\brefactor\b/i,
+    /\btypecheck\b/i,
+    /\bunit test\b/i,
+    /\bpull request\b/i,
+    /\bcommit\b/i,
+    /\bbranch\b/i,
+    /\bgit\b/i,
+    /\bnpm\b/i,
+    /\bbun\b/i,
+    /\beslint\b/i,
+    /\bfix (the|a|that|this|my)\b/i,
+    /\bbug\b/i,
+    /\bdebug/i,
+    /\berror\b/i,
+    /\bstack trace\b/i,
+  ],
+  'incident-response': [
+    /\bincident\b/i,
+    /\boutage\b/i,
+    /\bpostmortem\b/i,
+    /\bpost[- ]mortem\b/i,
+    /\b(p0|p1|sev[- ]?\d)\b/i,
+    /\brollback\b/i,
+    /\bhotfix\b/i,
+    /\b5xx\b/i,
+    /\bcloudwatch alarm/i,
   ],
 };
 

--- a/infra/lambdas/agent-skill-initializer/index.ts
+++ b/infra/lambdas/agent-skill-initializer/index.ts
@@ -1,0 +1,179 @@
+/**
+ * Agent Skill Initializer
+ *
+ * Invoked by a CDK Custom Resource on every AgentPlatformStack deploy.
+ * Receives the manifest of image-bundled skills (built at synth time
+ * from `infra/agent-image/skills/{name}/SKILL.md` frontmatter) and
+ * UPSERTs each one into `psd_agent_skills` with scope=shared and
+ * scan_status=clean.
+ *
+ * Bundled skills are pre-vetted (they ship in the agent image, code-
+ * reviewed and built by us), so the security scan is skipped — the
+ * scope='shared' + scan_status='clean' combination is the same state a
+ * user-submitted skill would land in after the skill-builder Lambda's
+ * scan completes.
+ *
+ * Idempotent: re-running with the same manifest is a no-op (UPSERT only
+ * bumps the version when the source hash changes). Skills removed from
+ * the image manifest are NOT auto-deleted from the DB — that's an
+ * explicit admin action via the Skills tab.
+ *
+ * Env vars:
+ *   DATABASE_HOST         — Aurora host
+ *   DATABASE_SECRET_ARN   — Aurora credentials secret
+ *   DATABASE_NAME         — default 'aistudio'
+ *   DATABASE_PORT         — default 5432
+ *   IMAGE_TAG             — current agent image tag (stored in s3_key for traceability)
+ */
+
+import {
+  SecretsManagerClient,
+  GetSecretValueCommand,
+} from "@aws-sdk/client-secrets-manager"
+import postgres from "postgres"
+
+const DATABASE_HOST = process.env.DATABASE_HOST || ""
+const DATABASE_SECRET_ARN = process.env.DATABASE_SECRET_ARN || ""
+const DATABASE_NAME = process.env.DATABASE_NAME || "aistudio"
+const DATABASE_PORT = parseInt(process.env.DATABASE_PORT || "5432", 10)
+
+const secrets = new SecretsManagerClient({})
+
+let sqlClient: postgres.Sql | null = null
+async function getSql(): Promise<postgres.Sql> {
+  if (sqlClient) return sqlClient
+  const res = await secrets.send(
+    new GetSecretValueCommand({ SecretId: DATABASE_SECRET_ARN }),
+  )
+  if (!res.SecretString) throw new Error("Database secret missing SecretString")
+  const creds = JSON.parse(res.SecretString) as {
+    username: string
+    password: string
+  }
+  sqlClient = postgres({
+    host: DATABASE_HOST,
+    port: DATABASE_PORT,
+    database: DATABASE_NAME,
+    username: creds.username,
+    password: creds.password,
+    ssl: "require",
+    max: 2,
+    idle_timeout: 20,
+    connect_timeout: 10,
+  })
+  return sqlClient
+}
+
+interface SkillManifestEntry {
+  name: string
+  summary: string
+  description?: string
+  sourceHash: string
+  imageTag: string
+}
+
+interface CustomResourceEvent {
+  RequestType: "Create" | "Update" | "Delete"
+  ResourceProperties: {
+    ServiceToken?: string
+    skills?: SkillManifestEntry[]
+    imageTag?: string
+    /** Trigger string forces CDK to invoke this Custom Resource on every deploy. */
+    trigger?: string
+  }
+}
+
+interface CustomResourceResponse {
+  PhysicalResourceId: string
+  Data: { upserted: number; skipped: number; imageTag: string }
+}
+
+async function upsertSkills(
+  skills: SkillManifestEntry[],
+  imageTag: string,
+): Promise<{ upserted: number; skipped: number }> {
+  if (skills.length === 0) return { upserted: 0, skipped: 0 }
+  const sql = await getSql()
+  let upserted = 0
+  let skipped = 0
+
+  for (const skill of skills) {
+    if (!skill.name || !skill.summary || !skill.sourceHash) {
+      skipped++
+      continue
+    }
+    // s3Key column stores `image:<tag>:<name>` for bundled skills — there's
+    // no real S3 object, but the column is NOT NULL and this string is
+    // both a stable identifier and a useful breadcrumb in the dashboard.
+    const s3Key = `image:${imageTag}:${skill.name}`
+    // UPSERT keyed on the partial unique index (name) WHERE scope='shared'.
+    // The summary and s3Key get refreshed on every deploy; version bumps
+    // when the source hash changes.
+    const result = await sql<{ id: string; version: number }[]>`
+      INSERT INTO psd_agent_skills
+        (name, scope, s3_key, version, summary, scan_status, created_at, updated_at)
+      VALUES
+        (${skill.name}, 'shared', ${s3Key}, 1, ${skill.summary}, 'clean', NOW(), NOW())
+      ON CONFLICT (name) WHERE scope = 'shared'
+      DO UPDATE SET
+        s3_key = EXCLUDED.s3_key,
+        summary = EXCLUDED.summary,
+        scan_status = 'clean',
+        version = CASE
+          WHEN psd_agent_skills.s3_key = EXCLUDED.s3_key THEN psd_agent_skills.version
+          ELSE psd_agent_skills.version + 1
+        END,
+        updated_at = NOW()
+      RETURNING id, version
+    `
+    if (result.length > 0) upserted++
+  }
+  return { upserted, skipped }
+}
+
+export const handler = async (
+  event: CustomResourceEvent,
+): Promise<CustomResourceResponse> => {
+  // eslint-disable-next-line no-console
+  console.log(
+    JSON.stringify({
+      level: "INFO",
+      logger: "agent-skill-initializer",
+      evt: "invoke",
+      requestType: event.RequestType,
+      skillCount: event.ResourceProperties.skills?.length ?? 0,
+      imageTag: event.ResourceProperties.imageTag ?? "unknown",
+    }),
+  )
+
+  // Delete is a no-op — image-bundled skills shouldn't be wiped from the
+  // DB when the stack is destroyed; an admin can clean up via the
+  // Skills tab if needed.
+  if (event.RequestType === "Delete") {
+    return {
+      PhysicalResourceId: "agent-skill-initializer",
+      Data: { upserted: 0, skipped: 0, imageTag: "n/a" },
+    }
+  }
+
+  const skills = event.ResourceProperties.skills ?? []
+  const imageTag = event.ResourceProperties.imageTag ?? "unknown"
+  const { upserted, skipped } = await upsertSkills(skills, imageTag)
+
+  // eslint-disable-next-line no-console
+  console.log(
+    JSON.stringify({
+      level: "INFO",
+      logger: "agent-skill-initializer",
+      evt: "complete",
+      upserted,
+      skipped,
+      imageTag,
+    }),
+  )
+
+  return {
+    PhysicalResourceId: "agent-skill-initializer",
+    Data: { upserted, skipped, imageTag },
+  }
+}

--- a/infra/lambdas/agent-skill-initializer/package.json
+++ b/infra/lambdas/agent-skill-initializer/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "agent-skill-initializer",
+  "version": "1.0.0",
+  "description": "Upserts the bundled image skills into psd_agent_skills. Invoked by a CDK Custom Resource on every AgentPlatformStack deploy.",
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "tsc",
+    "prebuild": "rm -rf dist"
+  },
+  "dependencies": {
+    "@aws-sdk/client-secrets-manager": "^3.0.0",
+    "postgres": "^3.4.0"
+  },
+  "devDependencies": {
+    "@types/aws-lambda": "^8.10.145",
+    "@types/node": "^20.0.0",
+    "typescript": "^5.0.0"
+  }
+}

--- a/infra/lambdas/agent-skill-initializer/tsconfig.json
+++ b/infra/lambdas/agent-skill-initializer/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "lib": ["ES2022"],
+    "outDir": "./dist",
+    "rootDir": "./",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "moduleResolution": "node",
+    "declaration": false,
+    "sourceMap": true,
+    "types": ["node"]
+  },
+  "include": ["*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/infra/lambdas/agent-telemetry-prune/index.ts
+++ b/infra/lambdas/agent-telemetry-prune/index.ts
@@ -19,6 +19,7 @@
  *                            Aurora's locking ceiling.
  */
 
+import type { ScheduledHandler } from "aws-lambda"
 import {
   SecretsManagerClient,
   GetSecretValueCommand,
@@ -82,7 +83,19 @@ async function pruneTable(
   const SAFETY_CAP = 1_000_000
   // eslint-disable-next-line no-constant-condition
   while (true) {
-    if (deleted >= SAFETY_CAP) break
+    if (deleted >= SAFETY_CAP) {
+      // eslint-disable-next-line no-console
+      console.log(JSON.stringify({
+        level: "WARN",
+        logger: "agent-telemetry-prune",
+        evt: "safety_cap_hit",
+        table,
+        deleted,
+        safetyCap: SAFETY_CAP,
+        message: "Daily prune may be falling behind — SAFETY_CAP reached before table was fully swept",
+      }))
+      break
+    }
     const rows = await sql<{ id: number }[]>`
       DELETE FROM ${sql(table)}
       WHERE id IN (
@@ -99,7 +112,10 @@ async function pruneTable(
   return { deleted, batches }
 }
 
-export const handler = async (): Promise<PruneResult> => {
+// ScheduledHandler requires Promise<void> but we return PruneResult for
+// CloudWatch structured logging. Lambda runtime accepts any return value —
+// EventBridge scheduled invocations don't read the response payload.
+export const handler = async (_event: Parameters<ScheduledHandler>[0]): Promise<PruneResult> => {
   const cutoff = new Date(Date.now() - RETENTION_DAYS * 86400_000)
   const cutoffIso = cutoff.toISOString()
   // eslint-disable-next-line no-console

--- a/infra/lambdas/agent-telemetry-prune/index.ts
+++ b/infra/lambdas/agent-telemetry-prune/index.ts
@@ -1,0 +1,138 @@
+/**
+ * Agent Telemetry Retention Sweep
+ *
+ * Runs daily (default 04:00 UTC). Deletes rows in agent_message_content
+ * and agent_tool_invocations older than RETENTION_DAYS (default 90 days)
+ * to bound the privacy/disk blast radius of the deep-telemetry tables.
+ *
+ * The aggregated summary rows in agent_messages, agent_sessions, etc.
+ * are NOT pruned by this Lambda — they're cheap and useful indefinitely.
+ *
+ * Env vars:
+ *   DATABASE_HOST         — Aurora host
+ *   DATABASE_SECRET_ARN   — Aurora credentials secret
+ *   DATABASE_NAME         — Aurora database (default aistudio)
+ *   DATABASE_PORT         — default 5432
+ *   RETENTION_DAYS        — default 90
+ *   PRUNE_BATCH           — rows to delete per statement, default 5000.
+ *                            Keeps each DELETE statement under
+ *                            Aurora's locking ceiling.
+ */
+
+import {
+  SecretsManagerClient,
+  GetSecretValueCommand,
+} from "@aws-sdk/client-secrets-manager"
+import postgres from "postgres"
+
+const DATABASE_HOST = process.env.DATABASE_HOST || ""
+const DATABASE_SECRET_ARN = process.env.DATABASE_SECRET_ARN || ""
+const DATABASE_NAME = process.env.DATABASE_NAME || "aistudio"
+const DATABASE_PORT = parseInt(process.env.DATABASE_PORT || "5432", 10)
+const RETENTION_DAYS = parseInt(process.env.RETENTION_DAYS || "90", 10)
+const PRUNE_BATCH = parseInt(process.env.PRUNE_BATCH || "5000", 10)
+
+const secrets = new SecretsManagerClient({})
+
+let sqlClient: postgres.Sql | null = null
+async function getSql(): Promise<postgres.Sql> {
+  if (sqlClient) return sqlClient
+  const res = await secrets.send(
+    new GetSecretValueCommand({ SecretId: DATABASE_SECRET_ARN }),
+  )
+  if (!res.SecretString) throw new Error("Database secret missing SecretString")
+  const creds = JSON.parse(res.SecretString) as {
+    username: string
+    password: string
+  }
+  sqlClient = postgres({
+    host: DATABASE_HOST,
+    port: DATABASE_PORT,
+    database: DATABASE_NAME,
+    username: creds.username,
+    password: creds.password,
+    ssl: "require",
+    max: 2,
+    idle_timeout: 20,
+    connect_timeout: 10,
+  })
+  return sqlClient
+}
+
+interface PruneResult {
+  contentDeleted: number
+  toolsDeleted: number
+  cutoffIso: string
+  retentionDays: number
+  batches: number
+}
+
+/**
+ * Delete in batches so a single DELETE doesn't lock huge ranges of the
+ * tables. Loops until either the batch returns 0 rows or we've hit a
+ * safety cap (1M rows) to avoid runaway loops.
+ */
+async function pruneTable(
+  sql: postgres.Sql,
+  table: "agent_message_content" | "agent_tool_invocations",
+  cutoffIso: string,
+): Promise<{ deleted: number; batches: number }> {
+  let deleted = 0
+  let batches = 0
+  const SAFETY_CAP = 1_000_000
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    if (deleted >= SAFETY_CAP) break
+    const rows = await sql<{ id: number }[]>`
+      DELETE FROM ${sql(table)}
+      WHERE id IN (
+        SELECT id FROM ${sql(table)}
+        WHERE created_at < ${cutoffIso}::timestamptz
+        LIMIT ${PRUNE_BATCH}
+      )
+      RETURNING id
+    `
+    if (rows.length === 0) break
+    deleted += rows.length
+    batches++
+  }
+  return { deleted, batches }
+}
+
+export const handler = async (): Promise<PruneResult> => {
+  const cutoff = new Date(Date.now() - RETENTION_DAYS * 86400_000)
+  const cutoffIso = cutoff.toISOString()
+  // eslint-disable-next-line no-console
+  console.log(
+    JSON.stringify({
+      level: "INFO",
+      logger: "agent-telemetry-prune",
+      evt: "prune_start",
+      cutoffIso,
+      retentionDays: RETENTION_DAYS,
+      batchSize: PRUNE_BATCH,
+    }),
+  )
+
+  const sql = await getSql()
+  const content = await pruneTable(sql, "agent_message_content", cutoffIso)
+  const tools = await pruneTable(sql, "agent_tool_invocations", cutoffIso)
+
+  const result: PruneResult = {
+    contentDeleted: content.deleted,
+    toolsDeleted: tools.deleted,
+    cutoffIso,
+    retentionDays: RETENTION_DAYS,
+    batches: content.batches + tools.batches,
+  }
+  // eslint-disable-next-line no-console
+  console.log(
+    JSON.stringify({
+      level: "INFO",
+      logger: "agent-telemetry-prune",
+      evt: "prune_complete",
+      ...result,
+    }),
+  )
+  return result
+}

--- a/infra/lambdas/agent-telemetry-prune/package.json
+++ b/infra/lambdas/agent-telemetry-prune/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "agent-telemetry-prune",
+  "version": "1.0.0",
+  "description": "Daily retention sweep — deletes agent_message_content and agent_tool_invocations rows older than RETENTION_DAYS (default 90).",
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "tsc",
+    "prebuild": "rm -rf dist"
+  },
+  "dependencies": {
+    "@aws-sdk/client-secrets-manager": "^3.0.0",
+    "postgres": "^3.4.0"
+  },
+  "devDependencies": {
+    "@types/aws-lambda": "^8.10.145",
+    "@types/node": "^20.0.0",
+    "typescript": "^5.0.0"
+  }
+}

--- a/infra/lambdas/agent-telemetry-prune/tsconfig.json
+++ b/infra/lambdas/agent-telemetry-prune/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "lib": ["ES2022"],
+    "outDir": "./dist",
+    "rootDir": "./",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "moduleResolution": "node",
+    "declaration": false,
+    "sourceMap": true,
+    "types": ["node"]
+  },
+  "include": ["*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/infra/lambdas/agent-triage-digest/index.ts
+++ b/infra/lambdas/agent-triage-digest/index.ts
@@ -182,7 +182,7 @@ export const handler: Handler<DigestEvent, void> = async (event) => {
   try {
     await client.spaces.messages.create({
       parent: triage.dmSpaceName,
-      requestBody: requestBody as never,
+      requestBody,
     });
     log("INFO", "digest_posted", {
       user: userEmail,

--- a/infra/lambdas/agent-triage-digest/index.ts
+++ b/infra/lambdas/agent-triage-digest/index.ts
@@ -1,0 +1,218 @@
+/**
+ * Daily Email Triage Digest Lambda
+ *
+ * Invoked per-user via EventBridge Scheduler at the user's configured
+ * `digestTime` (in their timezone). Reads the last 24 hours of
+ * `recentDecisions` from the triage DDB row and posts a card to the
+ * user's Chat DM summarising what got filed.
+ *
+ * Cheap and templated — no LLM call. Failure does NOT cascade; if the
+ * Chat post fails we just log and exit, the next day's run picks up.
+ *
+ * Event shape (from the skill's upsertDigestSchedule):
+ *   { "userEmail": "hagelk@psd401.net" }
+ */
+
+import type { Handler } from "aws-lambda";
+import {
+  DynamoDBClient,
+} from "@aws-sdk/client-dynamodb";
+import {
+  DynamoDBDocumentClient,
+  GetCommand,
+} from "@aws-sdk/lib-dynamodb";
+import {
+  GetSecretValueCommand,
+  SecretsManagerClient,
+} from "@aws-sdk/client-secrets-manager";
+import * as chatPkg from "@googleapis/chat";
+
+interface DigestEvent {
+  userEmail: string;
+}
+
+interface DecisionRecord {
+  messageId: string;
+  threadId: string;
+  label: "important" | "later" | "news";
+  source: "rule" | "llm";
+  reason: string;
+  confidence: number;
+  ts: string;
+  fromEmail: string;
+  subject: string;
+}
+
+interface TriageRow {
+  userEmail: string;
+  enabled: boolean;
+  dmSpaceName?: string;
+  labels?: Record<string, string>;
+  recentDecisions?: DecisionRecord[];
+  digestEnabled?: boolean;
+}
+
+const REGION = process.env.AWS_REGION ?? "us-east-1";
+const TRIAGE_TABLE = process.env.TRIAGE_TABLE ?? "";
+const GOOGLE_CREDENTIALS_SECRET_ARN =
+  process.env.GOOGLE_CREDENTIALS_SECRET_ARN ?? "";
+
+const ddb = DynamoDBDocumentClient.from(new DynamoDBClient({ region: REGION }));
+const sm = new SecretsManagerClient({ region: REGION });
+
+let cachedClient: ReturnType<typeof chatPkg.chat> | null = null;
+let cachedCredsAt = 0;
+
+async function getChatClient(): Promise<ReturnType<typeof chatPkg.chat>> {
+  if (cachedClient && Date.now() - cachedCredsAt < 10 * 60_000) {
+    return cachedClient;
+  }
+  const resp = await sm.send(
+    new GetSecretValueCommand({ SecretId: GOOGLE_CREDENTIALS_SECRET_ARN }),
+  );
+  if (!resp.SecretString) throw new Error("Chat credentials secret empty");
+  const credentials = JSON.parse(resp.SecretString);
+  const auth = new chatPkg.auth.GoogleAuth({
+    credentials,
+    scopes: ["https://www.googleapis.com/auth/chat.bot"],
+  });
+  cachedClient = chatPkg.chat({ version: "v1", auth });
+  cachedCredsAt = Date.now();
+  return cachedClient;
+}
+
+function log(level: "INFO" | "WARN" | "ERROR", evt: string, fields: Record<string, unknown>) {
+  // eslint-disable-next-line no-console
+  console.log(
+    JSON.stringify({
+      level,
+      logger: "triage-digest",
+      evt,
+      timestamp: new Date().toISOString(),
+      ...fields,
+    }),
+  );
+}
+
+export const handler: Handler<DigestEvent, void> = async (event) => {
+  const userEmail = event?.userEmail;
+  if (!userEmail) {
+    log("ERROR", "missing_user", { event });
+    return;
+  }
+
+  const row = await ddb.send(
+    new GetCommand({ TableName: TRIAGE_TABLE, Key: { userEmail } }),
+  );
+  const triage = row.Item as TriageRow | undefined;
+  if (!triage || !triage.enabled) {
+    log("INFO", "skip_disabled", { user: userEmail });
+    return;
+  }
+  if (!triage.dmSpaceName) {
+    log("WARN", "no_dm_space", { user: userEmail });
+    return;
+  }
+  if (triage.digestEnabled === false) {
+    log("INFO", "skip_digest_off", { user: userEmail });
+    return;
+  }
+
+  // Last 24h of decisions.
+  const since = Date.now() - 24 * 60 * 60_000;
+  const recent = (triage.recentDecisions ?? []).filter((d) => {
+    const t = Date.parse(d.ts);
+    return Number.isFinite(t) && t >= since;
+  });
+
+  const buckets: Record<string, DecisionRecord[]> = {
+    important: [],
+    later: [],
+    news: [],
+  };
+  for (const d of recent) {
+    if (buckets[d.label]) buckets[d.label].push(d);
+  }
+
+  const labels = triage.labels ?? {
+    important: "@psd/Important",
+    later: "@psd/Later",
+    news: "@psd/News",
+  };
+
+  const dateStr = new Date().toLocaleDateString("en-US", {
+    weekday: "short",
+    month: "short",
+    day: "numeric",
+  });
+
+  const sections = [
+    {
+      header: `${labels.important} · ${buckets.important.length}`,
+      widgets: buildSectionWidgets(buckets.important, 5),
+    },
+    {
+      header: `${labels.later} · ${buckets.later.length}`,
+      widgets: buildSectionWidgets(buckets.later, 3),
+    },
+    {
+      header: `${labels.news} · ${buckets.news.length}`,
+      widgets: buildSectionWidgets(buckets.news, 3),
+    },
+  ];
+
+  const card = {
+    header: {
+      title: `📬 Triage digest · ${dateStr}`,
+      subtitle: `${recent.length} message${recent.length === 1 ? "" : "s"} sorted in the last 24h`,
+    },
+    sections,
+  };
+
+  const client = await getChatClient();
+  const requestBody: Record<string, unknown> = {
+    text: `Triage digest · ${recent.length} sorted in the last 24h`,
+    cardsV2: [{ cardId: `triage-digest-${Date.now()}`, card }],
+  };
+  try {
+    await client.spaces.messages.create({
+      parent: triage.dmSpaceName,
+      requestBody: requestBody as never,
+    });
+    log("INFO", "digest_posted", {
+      user: userEmail,
+      counts: {
+        important: buckets.important.length,
+        later: buckets.later.length,
+        news: buckets.news.length,
+      },
+    });
+  } catch (err) {
+    log("ERROR", "post_failed", {
+      user: userEmail,
+      err: err instanceof Error ? err.message : String(err),
+    });
+  }
+};
+
+function buildSectionWidgets(decisions: DecisionRecord[], max: number): unknown[] {
+  if (decisions.length === 0) {
+    return [{ textParagraph: { text: "_(none)_" } }];
+  }
+  const slice = decisions.slice(-max).reverse();
+  const widgets: unknown[] = slice.map((d) => ({
+    decoratedText: {
+      topLabel: d.fromEmail,
+      text: d.subject || "(no subject)",
+      bottomLabel: `${d.source} · ${d.reason}`,
+    },
+  }));
+  if (decisions.length > max) {
+    widgets.push({
+      textParagraph: {
+        text: `_…and ${decisions.length - max} more_`,
+      },
+    });
+  }
+  return widgets;
+}

--- a/infra/lambdas/agent-triage-digest/index.ts
+++ b/infra/lambdas/agent-triage-digest/index.ts
@@ -110,7 +110,12 @@ export const handler: Handler<DigestEvent, void> = async (event) => {
     return;
   }
   if (!triage.dmSpaceName) {
-    log("WARN", "no_dm_space", { user: userEmail });
+    // The enable flow doesn't populate dmSpaceName; it gets backfilled
+    // on the first escalation or task gesture in the poll Lambda.
+    // If it's still missing here, the user hasn't had an escalation
+    // yet. Skip digest rather than fail — next poll escalation will
+    // backfill the DM space and future digests will work.
+    log("WARN", "no_dm_space_skipping_digest", { user: userEmail });
     return;
   }
   if (triage.digestEnabled === false) {

--- a/infra/lambdas/agent-triage-digest/package.json
+++ b/infra/lambdas/agent-triage-digest/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "agent-triage-digest",
+  "version": "1.0.0",
+  "description": "Daily digest Lambda for email triage. Invoked per-user via EventBridge Scheduler at the user's configured digest time; renders a Chat card summarising the last 24h of classifications.",
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "tsc",
+    "prebuild": "rm -rf dist"
+  },
+  "dependencies": {
+    "@aws-sdk/client-dynamodb": "^3.0.0",
+    "@aws-sdk/client-secrets-manager": "^3.0.0",
+    "@aws-sdk/lib-dynamodb": "^3.0.0",
+    "@googleapis/chat": "^5.0.0"
+  },
+  "devDependencies": {
+    "@types/aws-lambda": "^8.10.145",
+    "@types/node": "^20.0.0",
+    "typescript": "^5.0.0"
+  }
+}

--- a/infra/lambdas/agent-triage-digest/tsconfig.json
+++ b/infra/lambdas/agent-triage-digest/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "lib": ["ES2022"],
+    "outDir": "./dist",
+    "rootDir": "./",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "moduleResolution": "node",
+    "declaration": false,
+    "sourceMap": true,
+    "types": ["node"]
+  },
+  "include": ["*.ts"],
+  "exclude": ["node_modules", "dist", "*.test.ts"]
+}

--- a/infra/lambdas/agent-triage-poll/agentcore.test.ts
+++ b/infra/lambdas/agent-triage-poll/agentcore.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Tests for the agent-reply parser. The actual AgentCore invocation is
+ * integration territory; this just locks the parser's tolerance for the
+ * various shapes Bedrock + agent skill can return.
+ */
+import { describe, expect, test } from "bun:test";
+import { parseAgentReply } from "./agentcore";
+
+describe("parseAgentReply", () => {
+  test("success — life-os issue", () => {
+    const r = parseAgentReply("Created life-os issue #1234: Review the new policy draft");
+    expect(r).toMatchObject({ ok: true, taskRef: "#1234" });
+  });
+
+  test("success — google tasks", () => {
+    const r = parseAgentReply("Created google-tasks task abc-xyz-123: Reply to legal");
+    expect(r).toMatchObject({ ok: true, taskRef: "abc-xyz-123" });
+  });
+
+  test("failure", () => {
+    const r = parseAgentReply("FAILED: gh CLI not authenticated");
+    expect(r).toMatchObject({ ok: false, reason: "gh CLI not authenticated" });
+  });
+
+  test("AgentCore JSON envelope wrapping", () => {
+    const r = parseAgentReply(
+      JSON.stringify({ result: "Created life-os issue #42: Schedule one-on-one" }),
+    );
+    expect(r).toMatchObject({ ok: true, taskRef: "#42" });
+  });
+
+  test("AgentCore JSON envelope with `message` key", () => {
+    const r = parseAgentReply(
+      JSON.stringify({ message: "FAILED: rate-limited by github" }),
+    );
+    expect(r).toMatchObject({ ok: false, reason: "rate-limited by github" });
+  });
+
+  test("multi-line reply — picks the first matching line", () => {
+    const r = parseAgentReply(
+      "OK, working on it.\nCreated life-os issue #99: x\nDone.",
+    );
+    expect(r).toMatchObject({ ok: true, taskRef: "#99" });
+  });
+
+  test("empty reply", () => {
+    expect(parseAgentReply("")).toMatchObject({ ok: false, reason: "empty agent reply" });
+  });
+
+  test("unparseable reply", () => {
+    const r = parseAgentReply("I think I handled it. Should be in your queue now.");
+    expect(r).toMatchObject({ ok: false });
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.reason).toContain("unparseable");
+    }
+  });
+
+  test("FAILED line takes precedence over later Created line", () => {
+    const r = parseAgentReply("FAILED: github 503\nCreated life-os issue #1: stub");
+    expect(r).toMatchObject({ ok: false, reason: "github 503" });
+  });
+
+  test("AgentCore SSE stream — success in last data event", () => {
+    const sse = [
+      `data: {"type": "start", "session_id": "x-y-z"}`,
+      ``,
+      `data: {"type": "heartbeat", "elapsed_s": 30}`,
+      ``,
+      `data: {"result": "Created life-os issue #777: Reply to legal"}`,
+      ``,
+    ].join("\n");
+    expect(parseAgentReply(sse)).toMatchObject({ ok: true, taskRef: "#777" });
+  });
+
+  test("AgentCore SSE stream — failure in last data event", () => {
+    const sse = [
+      `data: {"type": "start"}`,
+      ``,
+      `data: {"result": "FAILED: gh CLI not authenticated"}`,
+      ``,
+    ].join("\n");
+    expect(parseAgentReply(sse)).toMatchObject({
+      ok: false,
+      reason: "gh CLI not authenticated",
+    });
+  });
+
+  test("AgentCore SSE stream — conversational reply with no pattern", () => {
+    // This is the actual 2026-05-22 bug — agent replied with prose
+    // because the MEMORY.md snippet wasn't in place. Parser should
+    // surface the prose as the failure reason rather than choking.
+    const sse = [
+      `data: {"type": "start", "session_id": "hagelk-task-19e154b19e1d6951-1779483775544"}`,
+      ``,
+      `data: {"type": "heartbeat", "elapsed_s": 30}`,
+      ``,
+      `data: {"result": "I need to check my task management capabilities and figure out where to put this."}`,
+      ``,
+    ].join("\n");
+    const r = parseAgentReply(sse);
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.reason).toContain("unparseable");
+      expect(r.reason).toContain("I need to check");
+    }
+  });
+});

--- a/infra/lambdas/agent-triage-poll/agentcore.ts
+++ b/infra/lambdas/agent-triage-poll/agentcore.ts
@@ -1,0 +1,388 @@
+/**
+ * AgentCore invocation for the @psd/Task user-gesture path.
+ *
+ * The classifier Lambda hands off to the user's agent (per their MEMORY.md
+ * instructions and loaded skills) to actually create the task in whatever
+ * task system they prefer. We just deliver the email metadata in a
+ * structured prompt the agent already knows how to handle (per the user's
+ * memory entry titled "Email Triage → Life OS Task Creation" or
+ * equivalent).
+ *
+ * The reply contract is intentionally tiny:
+ *   Created life-os issue #<n>: <title>     ← success
+ *   FAILED: <reason>                         ← failure
+ *
+ * Anything else gets classified as "unparseable" and treated like a
+ * failure. The agent's MEMORY.md instructions are responsible for
+ * enforcing this format.
+ */
+
+import {
+  BedrockAgentCoreClient,
+  InvokeAgentRuntimeCommand,
+} from "@aws-sdk/client-bedrock-agentcore";
+import { SSMClient, GetParameterCommand } from "@aws-sdk/client-ssm";
+
+import { fetchTaskInstructions } from "./memory";
+
+/**
+ * Hard wall-clock budget for a single AgentCore invocation. Without this
+ * the SDK call can hang up to the Lambda's 5-minute timeout, which kills
+ * the whole tick mid-flight (cursor doesn't advance, gestures replay
+ * forever — observed 2026-05-22). 90 seconds is enough for the agent
+ * to read the prompt, run one `gh issue create`, and reply.
+ */
+const AGENTCORE_INVOKE_TIMEOUT_MS = 90_000;
+
+const REGION = process.env.AWS_REGION ?? "us-east-1";
+const ENVIRONMENT = process.env.ENVIRONMENT ?? "dev";
+
+let cached: BedrockAgentCoreClient | null = null;
+function client(): BedrockAgentCoreClient {
+  if (!cached) cached = new BedrockAgentCoreClient({ region: REGION });
+  return cached;
+}
+
+let cachedRuntimeId: string | null = null;
+let cachedAt = 0;
+const RUNTIME_ID_TTL_MS = 5 * 60 * 1000; // 5-minute cache; matches router pattern
+
+/**
+ * Resolve the AgentCore Runtime ID. Tries (in order):
+ *   1. AGENTCORE_RUNTIME_ID env var (if set explicitly at deploy time)
+ *   2. SSM parameter /aistudio/<env>/agentcore-runtime-id
+ *   3. cached value from a previous call within TTL
+ *
+ * Returns null if neither source produces a value — caller treats that
+ * as a configuration error and surfaces FAILED to the user.
+ */
+async function resolveRuntimeId(): Promise<string | null> {
+  if (process.env.AGENTCORE_RUNTIME_ID) {
+    return process.env.AGENTCORE_RUNTIME_ID;
+  }
+  if (cachedRuntimeId && Date.now() - cachedAt < RUNTIME_ID_TTL_MS) {
+    return cachedRuntimeId;
+  }
+  try {
+    const ssm = new SSMClient({ region: REGION });
+    const resp = await ssm.send(
+      new GetParameterCommand({
+        Name: `/aistudio/${ENVIRONMENT}/agentcore-runtime-id`,
+      }),
+    );
+    const value = resp.Parameter?.Value ?? "";
+    if (value) {
+      cachedRuntimeId = value;
+      cachedAt = Date.now();
+      return value;
+    }
+  } catch {
+    /* parameter missing — caller surfaces error */
+  }
+  return null;
+}
+
+export interface TaskCreationContext {
+  userEmail: string;
+  workspacePrefix: string;
+  agentcoreRuntimeId?: string;
+  subject: string;
+  fromEmail: string;
+  snippet: string;
+  threadId: string;
+  messageId: string;
+}
+
+export type TaskCreationResult =
+  | { ok: true; taskRef: string; rawReply: string }
+  | { ok: false; reason: string; rawReply: string };
+
+const SUCCESS_PATTERN = /Created\s+([^\s#]+(?:\s+[^\s#]+)*?)\s+(?:issue|task)\s+(#?\w+[\w/-]*)\s*:?\s*(.+)?/i;
+// Looser fallback: "Created <anything>: <title>" with no id. Captures the
+// title as the taskRef so downstream still has something to display.
+const SUCCESS_FALLBACK_PATTERN = /Created\s+(.+?)\s*:\s*(.+)$/i;
+const FAILED_PATTERN = /FAILED:\s*(.+?)\s*$/im;
+
+/**
+ * Build the session ID for an AgentCore invocation.
+ *
+ * AgentCore requires session IDs of length [33, 64]. We use:
+ *   <prefix-up-to-30>-task-<full-messageId-16hex>-<unix-ms-13digits>
+ * which is reliably 35-65 chars and gives every gesture a unique
+ * session (no context bleed between distinct task creations).
+ *
+ * Includes the full 13-digit unix-ms timestamp so back-to-back
+ * gestures within the same second still get distinct sessions.
+ */
+function buildSessionId(workspacePrefix: string, messageId: string): string {
+  const prefix = (workspacePrefix || "unknown").slice(0, 30);
+  const mid = (messageId || "00000000").slice(0, 16);
+  const ts = Date.now().toString();
+  const id = `${prefix}-task-${mid}-${ts}`;
+  // Floor + ceiling. The cron Lambda has hit the upper bound before
+  // when usernames + prefixes balloon; same guards here.
+  if (id.length < 33) {
+    // Pad with the message id again to ensure minimum length is met.
+    return `${id}-${mid}`.slice(0, 64);
+  }
+  return id.slice(0, 64);
+}
+
+function buildPrompt(ctx: TaskCreationContext, userInstructions: string): string {
+  // SELF-CONTAINED prompt. We do NOT depend on MEMORY.md or AGENTS.md
+  // being loaded — agents may gate those files on "main session only"
+  // heuristics that exclude programmatic invocations like this one.
+  // Everything the agent needs to act on this request is embedded
+  // below. If the agent later cross-references MEMORY.md for richer
+  // context (label conventions, repo defaults), that's a bonus, not
+  // a requirement.
+  //
+  // The tag at the top is the agent's recognition signal for any
+  // out-of-band per-user logic the user has configured to refine the
+  // default behavior (e.g. extra labels, target repo override).
+  // Deliver the email metadata + the user's OWN task-creation
+  // instructions (pulled from their MEMORY.md by the Lambda). NOTHING
+  // about which task system to use lives in this file — that's the
+  // user's call, expressed in their MEMORY.md.
+  return [
+    "[psd-email-triage task request]",
+    "",
+    "The user labeled this email as a task. Follow the YOUR INSTRUCTIONS",
+    "block below EXACTLY — it's the user's own configuration. Do not",
+    "substitute a different task system. Do not read MEMORY.md or any",
+    "other file first; the relevant section is already inlined below.",
+    "Then reply with ONE line per the REPLY FORMAT.",
+    "",
+    "===== YOUR INSTRUCTIONS (verbatim from the user's MEMORY.md) =====",
+    userInstructions,
+    "===== END INSTRUCTIONS =====",
+    "",
+    "EMAIL:",
+    `  Subject: ${ctx.subject}`,
+    `  From: ${ctx.fromEmail}`,
+    `  Gmail link: https://mail.google.com/mail/u/0/#all/${ctx.messageId}`,
+    `  Thread ID: ${ctx.threadId}`,
+    `  Message ID: ${ctx.messageId}`,
+    "  Body:",
+    ctx.snippet.slice(0, 4000),
+    "",
+    "REPLY — exactly one line, no markdown, no preamble:",
+    "  Created <ref>: <title>      ← on success (ref can be a URL, id, anything you choose)",
+    "  FAILED: <one-sentence reason>",
+    "",
+    "Do not ask follow-up questions. Do not respond conversationally.",
+    "Anything other than these two formats is treated as failure.",
+  ].join("\n");
+}
+
+export async function requestTaskCreation(
+  ctx: TaskCreationContext,
+): Promise<TaskCreationResult> {
+  const runtimeId = ctx.agentcoreRuntimeId || (await resolveRuntimeId());
+  if (!runtimeId) {
+    return {
+      ok: false,
+      reason: "AGENTCORE_RUNTIME_ID not configured (env or SSM)",
+      rawReply: "",
+    };
+  }
+
+  // Pull the user's task-creation instructions from their MEMORY.md. If
+  // they haven't written a section for this, fail fast with a clear
+  // message — don't let the agent guess.
+  const userInstructions = await fetchTaskInstructions(ctx.workspacePrefix);
+  if (!userInstructions) {
+    return {
+      ok: false,
+      reason:
+        "No task-creation instructions found in your MEMORY.md. Add a section titled '## Email Triage → Task Creation' with the exact command to run.",
+      rawReply: "",
+    };
+  }
+
+  const sessionId = buildSessionId(ctx.workspacePrefix, ctx.messageId);
+  const prompt = buildPrompt(ctx, userInstructions);
+
+  const cmd = new InvokeAgentRuntimeCommand({
+    agentRuntimeArn: runtimeId.startsWith("arn:")
+      ? runtimeId
+      : `arn:aws:bedrock-agentcore:${REGION}:${process.env.AWS_ACCOUNT ?? ""}:runtime/${runtimeId}`,
+    runtimeSessionId: sessionId,
+    payload: new TextEncoder().encode(
+      JSON.stringify({
+        prompt,
+        // Field names match agentcore_wrapper.py's `invoke()` payload
+        // contract (see agent-image/agentcore_wrapper.py).
+        user_email: ctx.userEmail,
+        workspace_prefix: ctx.workspacePrefix,
+      }),
+    ),
+    qualifier: "DEFAULT",
+  });
+
+  // Hard timeout via AbortController. The SDK call itself doesn't honor
+  // it for streaming, so we also race the consumer loop against a timer.
+  const controller = new AbortController();
+  const timeoutHandle = setTimeout(
+    () => controller.abort(),
+    AGENTCORE_INVOKE_TIMEOUT_MS,
+  );
+  let raw = "";
+  try {
+    const resp = await client().send(cmd, { abortSignal: controller.signal });
+    if (resp.response) {
+      const stream = resp.response as AsyncIterable<Uint8Array>;
+      const decoder = new TextDecoder();
+      const deadline = Date.now() + AGENTCORE_INVOKE_TIMEOUT_MS;
+      for await (const chunk of stream) {
+        raw += decoder.decode(chunk, { stream: true });
+        if (Date.now() > deadline) {
+          controller.abort();
+          return {
+            ok: false,
+            reason: `AgentCore invocation timed out after ${AGENTCORE_INVOKE_TIMEOUT_MS / 1000}s`,
+            rawReply: raw,
+          };
+        }
+      }
+      raw += decoder.decode();
+    } else if ("statusCode" in (resp as object)) {
+      const maybeBody = (resp as unknown as { payload?: Uint8Array }).payload;
+      if (maybeBody) raw = new TextDecoder().decode(maybeBody);
+    }
+  } catch (err) {
+    return {
+      ok: false,
+      reason: `AgentCore invocation error: ${err instanceof Error ? err.message : String(err)}`,
+      rawReply: raw,
+    };
+  } finally {
+    clearTimeout(timeoutHandle);
+  }
+
+  return parseAgentReply(raw);
+}
+
+/**
+ * Parse the agent's reply for either:
+ *   Created <system> issue #<n>: <title>
+ *   Created <system> task <id>: <title>
+ *   FAILED: <reason>
+ *
+ * Tolerant of:
+ *   - AgentCore SSE streaming: `data: {...}\n\ndata: {...}\n\n...`
+ *     with intermediate heartbeats and a final `{"result": "..."}` event.
+ *   - JSON envelope wrapping like `{"result": "...", "message": "..."}`.
+ *   - Markdown code-fence wrappers.
+ *   - Conversational replies — we scan all text content for any line
+ *     matching the success or failure pattern; first match wins.
+ */
+export function parseAgentReply(raw: string): TaskCreationResult {
+  if (!raw || !raw.trim()) {
+    return { ok: false, reason: "empty agent reply", rawReply: raw };
+  }
+
+  // Extract all text content from the reply, walking SSE → JSON
+  // → plain. We're tolerant because AgentCore's response shape is
+  // moving target across runtime versions.
+  const bodies = extractBodies(raw);
+
+  // First pass: look for explicit FAILED or Created patterns in any
+  // body line. First match wins (within a body), bodies in order of
+  // discovery (which is the order AgentCore emitted them).
+  for (const body of bodies) {
+    for (const line of body.split(/\r?\n/)) {
+      const failMatch = line.match(FAILED_PATTERN);
+      if (failMatch) {
+        return { ok: false, reason: failMatch[1].trim(), rawReply: raw };
+      }
+      const okMatch = line.match(SUCCESS_PATTERN);
+      if (okMatch) {
+        const taskRef = (okMatch[2] ?? "").trim();
+        return { ok: true, taskRef, rawReply: raw };
+      }
+    }
+  }
+  // Second pass: loose "Created X: title" with no id.
+  for (const body of bodies) {
+    for (const line of body.split(/\r?\n/)) {
+      const okMatch = line.match(SUCCESS_FALLBACK_PATTERN);
+      if (okMatch) {
+        const taskRef = (okMatch[1] ?? "task").trim().slice(0, 64);
+        return { ok: true, taskRef, rawReply: raw };
+      }
+    }
+  }
+
+  // No pattern match — return the last body's first 200 chars as the
+  // failure reason. That's typically the agent's prose explaining
+  // why it didn't (or couldn't) follow the contract.
+  const lastBody = bodies[bodies.length - 1] ?? "";
+  return {
+    ok: false,
+    reason: `unparseable agent reply: ${lastBody.slice(0, 200) || raw.slice(0, 200)}`,
+    rawReply: raw,
+  };
+}
+
+/**
+ * Walk the raw reply and pull out every text body we can find. Handles:
+ *   - Raw text → returned as-is
+ *   - Single JSON object → result/message/reply field extracted
+ *   - SSE stream (`data: {...}\n\n`) → each event's result/message
+ *     extracted in order
+ *   - Markdown code-fence wrappers stripped
+ */
+function extractBodies(raw: string): string[] {
+  const bodies: string[] = [];
+
+  // Detect SSE format: at least one line starts with `data: `.
+  const sseLines = raw.match(/^data:\s.+$/gm);
+  if (sseLines && sseLines.length > 0) {
+    for (const line of sseLines) {
+      const payload = line.replace(/^data:\s/, "").trim();
+      // The terminating `[DONE]` sentinel is from OpenAI-style streams;
+      // AgentCore doesn't use it but be safe.
+      if (payload === "[DONE]") continue;
+      try {
+        const obj = JSON.parse(payload);
+        const text =
+          (obj as { result?: string }).result ??
+          (obj as { message?: string }).message ??
+          (obj as { reply?: string }).reply ??
+          (obj as { content?: string }).content;
+        if (typeof text === "string" && text.trim()) {
+          bodies.push(stripFences(text));
+        }
+      } catch {
+        // Non-JSON SSE event; ignore.
+      }
+    }
+    if (bodies.length > 0) return bodies;
+  }
+
+  // Try the whole thing as a single JSON envelope.
+  try {
+    const obj = JSON.parse(raw.trim());
+    if (obj && typeof obj === "object") {
+      const text =
+        (obj as { result?: string }).result ??
+        (obj as { message?: string }).message ??
+        (obj as { reply?: string }).reply ??
+        (obj as { content?: string }).content;
+      if (typeof text === "string") return [stripFences(text)];
+    }
+  } catch {
+    /* not JSON */
+  }
+
+  // Plain text — return as-is, with any code-fence wrapping stripped.
+  return [stripFences(raw)];
+}
+
+function stripFences(s: string): string {
+  return s
+    .replace(/^```(?:json)?\s*/i, "")
+    .replace(/```\s*$/, "")
+    .trim();
+}

--- a/infra/lambdas/agent-triage-poll/chat.ts
+++ b/infra/lambdas/agent-triage-poll/chat.ts
@@ -186,7 +186,7 @@ export async function postEscalation(params: EscalationParams): Promise<void> {
   };
   await client.spaces.messages.create({
     parent: params.dmSpaceName,
-    requestBody: requestBody as never,
+    requestBody,
   });
 }
 
@@ -295,6 +295,6 @@ export async function postTaskOutcome(params: TaskOutcomeParams): Promise<void> 
   };
   await client.spaces.messages.create({
     parent: params.dmSpaceName,
-    requestBody: requestBody as never,
+    requestBody,
   });
 }

--- a/infra/lambdas/agent-triage-poll/chat.ts
+++ b/infra/lambdas/agent-triage-poll/chat.ts
@@ -1,0 +1,300 @@
+/**
+ * Post an escalation card to a user's Chat DM.
+ *
+ * Mirrors the message shape the cron Lambda uses (`sendChatMessage`)
+ * including the rich-output envelope handling, so the user gets a
+ * proper card rather than plain text.
+ *
+ * The Chat API client uses the SAME Google credentials secret as the
+ * cron Lambda — service-account JWT, scope `chat.bot`.
+ */
+
+import {
+  GetSecretValueCommand,
+  SecretsManagerClient,
+} from "@aws-sdk/client-secrets-manager";
+import * as chatPkg from "@googleapis/chat";
+
+import type { GmailMessageMeta } from "./types";
+import type { Label } from "./rules";
+
+const GOOGLE_CREDENTIALS_SECRET_ARN =
+  process.env.GOOGLE_CREDENTIALS_SECRET_ARN ?? "";
+
+let cachedSecret: { json: string; fetchedAt: number } | null = null;
+let cachedClient: ReturnType<typeof chatPkg.chat> | null = null;
+
+async function getCredentials(): Promise<Record<string, unknown>> {
+  // 10-minute cache, matches the cron Lambda's TTL.
+  if (cachedSecret && Date.now() - cachedSecret.fetchedAt < 10 * 60_000) {
+    return JSON.parse(cachedSecret.json);
+  }
+  const sm = new SecretsManagerClient({
+    region: process.env.AWS_REGION ?? "us-east-1",
+  });
+  const resp = await sm.send(
+    new GetSecretValueCommand({ SecretId: GOOGLE_CREDENTIALS_SECRET_ARN }),
+  );
+  if (!resp.SecretString) {
+    throw new Error("Google credentials secret has no SecretString");
+  }
+  cachedSecret = { json: resp.SecretString, fetchedAt: Date.now() };
+  cachedClient = null; // force re-init with fresh creds
+  return JSON.parse(resp.SecretString);
+}
+
+async function getChatClient(): Promise<ReturnType<typeof chatPkg.chat>> {
+  if (cachedClient) return cachedClient;
+  const credentials = await getCredentials();
+  const googleAuth = new chatPkg.auth.GoogleAuth({
+    credentials,
+    scopes: ["https://www.googleapis.com/auth/chat.bot"],
+  });
+  cachedClient = chatPkg.chat({ version: "v1", auth: googleAuth });
+  return cachedClient;
+}
+
+/**
+ * Find the bot's DM space with a given user, identified by the
+ * Google Chat user resource name (`users/<id>`). The bot's Chat client
+ * lists all spaces it's a member of and matches by HUMAN member name.
+ *
+ * O(spaces × members-in-each-space) — cheap because the bot only has
+ * DM spaces with users who've messaged it (typically <100). Match-on-
+ * first means most lookups exit early.
+ *
+ * Mirrors the cron Lambda's `resolveDmSpace`. Returns null if no DM
+ * found, which the caller surfaces as "user hasn't DM'd the bot yet."
+ */
+export async function resolveDmSpace(googleIdentity: string): Promise<string | null> {
+  try {
+    const client = await getChatClient();
+    let pageToken: string | undefined;
+    let scanned = 0;
+    do {
+      const resp = await client.spaces.list({ pageToken, pageSize: 100 });
+      const spaces = resp.data.spaces || [];
+      scanned += spaces.length;
+      for (const space of spaces) {
+        if (!space.name || !space.singleUserBotDm) continue;
+        const membersResp = await client.spaces.members.list({
+          parent: space.name,
+          pageSize: 10,
+        });
+        for (const m of membersResp.data.memberships || []) {
+          if (m.member?.type === "HUMAN" && m.member?.name === googleIdentity) {
+            return space.name;
+          }
+        }
+      }
+      pageToken = resp.data.nextPageToken || undefined;
+    } while (pageToken);
+    // eslint-disable-next-line no-console
+    console.log(JSON.stringify({
+      level: "WARN", logger: "triage-poll", evt: "dm_space_not_found",
+      googleIdentity, spacesScanned: scanned,
+    }));
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.log(JSON.stringify({
+      level: "ERROR", logger: "triage-poll", evt: "dm_space_resolve_error",
+      googleIdentity,
+      err: error instanceof Error ? error.message : String(error),
+    }));
+  }
+  return null;
+}
+
+export interface EscalationParams {
+  dmSpaceName: string;
+  userEmail: string;
+  label: Label;
+  message: GmailMessageMeta;
+  reason: string;
+}
+
+/**
+ * Post a card escalation to the user's DM. Card shows:
+ *   header: "📬 Triage flagged"
+ *   key/value rows for label, sender, subject
+ *   text paragraph with snippet
+ *   button: "Open in Gmail"
+ */
+export async function postEscalation(params: EscalationParams): Promise<void> {
+  const client = await getChatClient();
+
+  const labelDisplay =
+    params.label === "important"
+      ? "Important"
+      : params.label === "later"
+        ? "Later"
+        : "News";
+
+  const cardsV2 = [
+    {
+      cardId: `triage-${params.message.id}`,
+      card: {
+        header: {
+          title: "📬 Triage flagged a message",
+          subtitle: `${labelDisplay} · ${params.reason}`,
+        },
+        sections: [
+          {
+            widgets: [
+              {
+                decoratedText: {
+                  topLabel: "From",
+                  text: params.message.fromEmail,
+                },
+              },
+              {
+                decoratedText: {
+                  topLabel: "Subject",
+                  text: params.message.subject || "(no subject)",
+                },
+              },
+              ...(params.message.snippet
+                ? [{ textParagraph: { text: truncate(params.message.snippet, 400) } }]
+                : []),
+              {
+                buttonList: {
+                  buttons: [
+                    {
+                      text: "Open in Gmail",
+                      onClick: {
+                        openLink: {
+                          url: `https://mail.google.com/mail/u/0/#inbox/${params.message.id}`,
+                        },
+                      },
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        ],
+      },
+    },
+  ];
+
+  // cardsV2 isn't in the @googleapis/chat 5.0 type schema yet (it
+  // accepts the field, just not in TS types). Cast through unknown for
+  // the same reason the cron Lambda does.
+  const requestBody: Record<string, unknown> = {
+    text: `Triage flagged: ${params.message.subject || params.message.fromEmail}`,
+    cardsV2,
+  };
+  await client.spaces.messages.create({
+    parent: params.dmSpaceName,
+    requestBody: requestBody as never,
+  });
+}
+
+function truncate(s: string, n: number): string {
+  if (s.length <= n) return s;
+  return s.slice(0, n - 1) + "…";
+}
+
+export interface TaskOutcomeParams {
+  dmSpaceName: string;
+  subject: string;
+  fromEmail: string;
+  messageId: string;
+  ok: boolean;
+  taskRef?: string;
+  reason?: string;
+}
+
+/**
+ * Post a one-line outcome card to the user's DM when a @psd/Task
+ * gesture finishes — either with the success ref or with the failure
+ * reason. Used by Phase 1.5 of the email triage feature.
+ *
+ * Success cards only fire when the user has `tasksNotifySuccess=true`
+ * on their triage row; failure cards always fire so the user knows
+ * their gesture didn't take effect.
+ */
+export async function postTaskOutcome(params: TaskOutcomeParams): Promise<void> {
+  const client = await getChatClient();
+  const card = params.ok
+    ? {
+        cardId: `triage-task-ok-${params.messageId}`,
+        card: {
+          header: {
+            title: "✓ Tasked",
+            subtitle: `${params.taskRef ?? "task created"} · ${params.fromEmail}`,
+          },
+          sections: [
+            {
+              widgets: [
+                {
+                  textParagraph: {
+                    text: truncate(params.subject || "(no subject)", 200),
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      }
+    : {
+        cardId: `triage-task-fail-${params.messageId}`,
+        card: {
+          header: {
+            title: "⚠️ Task creation failed",
+            subtitle: params.fromEmail,
+          },
+          sections: [
+            {
+              widgets: [
+                {
+                  decoratedText: {
+                    topLabel: "Subject",
+                    text: truncate(params.subject || "(no subject)", 200),
+                  },
+                },
+                {
+                  decoratedText: {
+                    topLabel: "Reason",
+                    text: truncate(params.reason ?? "unknown", 400),
+                  },
+                },
+                {
+                  textParagraph: {
+                    text:
+                      "The email is still in your @psd/Task label. To retry, " +
+                      "remove the label and re-apply it — the next 5-minute " +
+                      "tick will pick it up.",
+                  },
+                },
+                {
+                  buttonList: {
+                    buttons: [
+                      {
+                        text: "Open in Gmail",
+                        onClick: {
+                          openLink: {
+                            url: `https://mail.google.com/mail/u/0/#all/${params.messageId}`,
+                          },
+                        },
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      };
+
+  const requestBody: Record<string, unknown> = {
+    text: params.ok
+      ? `✓ Tasked: ${params.subject || params.fromEmail}${params.taskRef ? ` → ${params.taskRef}` : ""}`
+      : `⚠️ Task creation failed for ${params.subject || params.fromEmail}: ${params.reason ?? "unknown"}`,
+    cardsV2: [card],
+  };
+  await client.spaces.messages.create({
+    parent: params.dmSpaceName,
+    requestBody: requestBody as never,
+  });
+}

--- a/infra/lambdas/agent-triage-poll/gmail.ts
+++ b/infra/lambdas/agent-triage-poll/gmail.ts
@@ -175,15 +175,22 @@ export async function getMessageFullBody(
   return body.slice(0, maxChars);
 }
 
+/**
+ * Walk MIME parts for a text/plain body. We deliberately do NOT decode
+ * text/html ourselves — naive HTML stripping is a known source of
+ * sanitization bugs (CodeQL flagged it in prior iterations) and the
+ * downstream consumer (LLM prompt) doesn't render HTML anyway. When
+ * only HTML is available, callers fall back to Gmail's `snippet` field
+ * which Gmail already extracts as plain text.
+ */
 function extractPlainText(part: MessagePart | undefined): string | null {
   if (!part) return null;
-  // Single-part text — decode if it matches text/*.
-  if (part.body?.data && (!part.mimeType || part.mimeType.startsWith("text/"))) {
-    const decoded = decodeBase64Url(part.body.data);
-    if (part.mimeType === "text/html") return stripHtml(decoded);
-    return decoded;
+  if (
+    part.body?.data &&
+    (!part.mimeType || part.mimeType === "text/plain")
+  ) {
+    return decodeBase64Url(part.body.data);
   }
-  // Multipart — walk children, prefer text/plain.
   if (part.parts) {
     const plain = part.parts.find((p) => p.mimeType === "text/plain");
     if (plain?.body?.data) return decodeBase64Url(plain.body.data);
@@ -198,21 +205,6 @@ function extractPlainText(part: MessagePart | undefined): string | null {
 function decodeBase64Url(data: string): string {
   const b64 = data.replace(/-/g, "+").replace(/_/g, "/");
   return Buffer.from(b64, "base64").toString("utf8");
-}
-
-function stripHtml(html: string): string {
-  return html
-    .replace(/<style[\s\S]*?<\/style>/gi, "")
-    .replace(/<script[\s\S]*?<\/script>/gi, "")
-    .replace(/<[^>]+>/g, " ")
-    .replace(/&nbsp;/g, " ")
-    .replace(/&amp;/g, "&")
-    .replace(/&lt;/g, "<")
-    .replace(/&gt;/g, ">")
-    .replace(/&quot;/g, '"')
-    .replace(/&#39;/g, "'")
-    .replace(/\s+/g, " ")
-    .trim();
 }
 
 /** Pull `From` header → bare email; falls back to the raw header value. */

--- a/infra/lambdas/agent-triage-poll/gmail.ts
+++ b/infra/lambdas/agent-triage-poll/gmail.ts
@@ -1,0 +1,302 @@
+/**
+ * Thin Gmail REST client used by the classifier Lambda.
+ *
+ * Direct `fetch` against the v1 REST endpoints — we don't need the full
+ * `@googleapis/gmail` package's surface (it pulls in ~5 MB of generated
+ * code we'd only use 5% of) and keeping the deps tight matters for
+ * Lambda cold start.
+ */
+
+export interface HistoryEvent {
+  id: string;
+  messages?: { id: string; threadId: string }[];
+  messagesAdded?: { message: { id: string; threadId: string; labelIds?: string[] } }[];
+  labelsAdded?: {
+    message: { id: string; threadId: string; labelIds?: string[] };
+    labelIds: string[];
+  }[];
+  labelsRemoved?: {
+    message: { id: string; threadId: string; labelIds?: string[] };
+    labelIds: string[];
+  }[];
+}
+
+export interface HistoryResponse {
+  history?: HistoryEvent[];
+  historyId?: string;
+  nextPageToken?: string;
+}
+
+export interface MessageResponse {
+  id: string;
+  threadId: string;
+  labelIds?: string[];
+  snippet?: string;
+  internalDate?: string;
+  payload?: MessagePart;
+}
+
+interface MessagePart {
+  mimeType?: string;
+  headers?: { name: string; value: string }[];
+  body?: { data?: string; size?: number };
+  parts?: MessagePart[];
+}
+
+const GMAIL_BASE = "https://gmail.googleapis.com/gmail/v1/users/me";
+
+async function gmailFetch(
+  accessToken: string,
+  path: string,
+  init: RequestInit = {},
+): Promise<Response> {
+  const resp = await fetch(`${GMAIL_BASE}${path}`, {
+    ...init,
+    headers: {
+      ...(init.headers ?? {}),
+      Authorization: `Bearer ${accessToken}`,
+      "Content-Type": "application/json",
+    },
+  });
+  return resp;
+}
+
+/**
+ * Get the user's current Gmail historyId. Used at enable time to anchor
+ * the classifier's starting cursor — we only classify mail received
+ * after the user opts in.
+ */
+export async function getCurrentHistoryId(accessToken: string): Promise<string> {
+  const resp = await gmailFetch(accessToken, "/profile");
+  if (!resp.ok) {
+    throw new Error(`Gmail profile fetch failed: ${resp.status} ${await resp.text()}`);
+  }
+  const profile = (await resp.json()) as { historyId: string };
+  return profile.historyId;
+}
+
+/**
+ * Fetch the diff of mailbox events since `startHistoryId`.
+ *
+ * Gmail returns up to 100 events per call; we follow `nextPageToken`
+ * until exhausted. We request only the history types we care about so
+ * we skip unrelated noise (e.g. drafts).
+ *
+ * If the cursor is too old (>7 days, Gmail's history retention), the
+ * call returns 404. The caller handles re-anchoring on the current
+ * historyId in that case.
+ */
+export async function listHistory(
+  accessToken: string,
+  startHistoryId: string,
+): Promise<{ events: HistoryEvent[]; latestHistoryId?: string; tooOld: boolean }> {
+  const events: HistoryEvent[] = [];
+  let pageToken: string | undefined;
+  let latestHistoryId: string | undefined;
+  let tooOld = false;
+
+  do {
+    const params = new URLSearchParams({
+      startHistoryId,
+      historyTypes: "messageAdded",
+      maxResults: "100",
+    });
+    // Repeated params for the array case.
+    params.append("historyTypes", "labelAdded");
+    params.append("historyTypes", "labelRemoved");
+    if (pageToken) params.set("pageToken", pageToken);
+
+    const resp = await gmailFetch(accessToken, `/history?${params.toString()}`);
+    if (resp.status === 404) {
+      tooOld = true;
+      break;
+    }
+    if (!resp.ok) {
+      throw new Error(
+        `Gmail history.list failed: ${resp.status} ${await resp.text()}`,
+      );
+    }
+    const data = (await resp.json()) as HistoryResponse;
+    if (data.history) events.push(...data.history);
+    if (data.historyId) latestHistoryId = data.historyId;
+    pageToken = data.nextPageToken;
+  } while (pageToken);
+
+  return { events, latestHistoryId, tooOld };
+}
+
+/**
+ * Fetch the metadata of a single message — sender, subject, snippet,
+ * labelIds. We deliberately use `format=metadata` to avoid downloading
+ * full bodies (and exposing them to Bedrock prompt input).
+ */
+export async function getMessageMetadata(
+  accessToken: string,
+  messageId: string,
+): Promise<MessageResponse | null> {
+  const params = new URLSearchParams({
+    format: "metadata",
+    // Only the headers we actually use.
+    metadataHeaders: "From",
+  });
+  params.append("metadataHeaders", "Subject");
+  params.append("metadataHeaders", "Date");
+  const resp = await gmailFetch(accessToken, `/messages/${messageId}?${params.toString()}`);
+  if (resp.status === 404 || resp.status === 410) return null;
+  if (!resp.ok) {
+    throw new Error(
+      `Gmail message fetch failed: ${resp.status} ${await resp.text()}`,
+    );
+  }
+  return (await resp.json()) as MessageResponse;
+}
+
+/**
+ * Fetch the full plain-text body of a message, cap at `maxChars`. Used
+ * by the @psd/Task gesture so the agent can detect urgency markers
+ * ("by EOD", "tomorrow", "ASAP") that wouldn't fit in the 400-char
+ * snippet. Walks MIME parts depth-first; prefers `text/plain` over
+ * `text/html`; falls back to snippet if no readable body found.
+ */
+export async function getMessageFullBody(
+  accessToken: string,
+  messageId: string,
+  maxChars = 4000,
+): Promise<string | null> {
+  const resp = await gmailFetch(accessToken, `/messages/${messageId}?format=full`);
+  if (resp.status === 404 || resp.status === 410) return null;
+  if (!resp.ok) {
+    throw new Error(
+      `Gmail full message fetch failed: ${resp.status} ${await resp.text()}`,
+    );
+  }
+  const msg = (await resp.json()) as MessageResponse;
+  const body = extractPlainText(msg.payload) ?? msg.snippet ?? "";
+  return body.slice(0, maxChars);
+}
+
+function extractPlainText(part: MessagePart | undefined): string | null {
+  if (!part) return null;
+  // Single-part text — decode if it matches text/*.
+  if (part.body?.data && (!part.mimeType || part.mimeType.startsWith("text/"))) {
+    const decoded = decodeBase64Url(part.body.data);
+    if (part.mimeType === "text/html") return stripHtml(decoded);
+    return decoded;
+  }
+  // Multipart — walk children, prefer text/plain.
+  if (part.parts) {
+    const plain = part.parts.find((p) => p.mimeType === "text/plain");
+    if (plain?.body?.data) return decodeBase64Url(plain.body.data);
+    for (const child of part.parts) {
+      const found = extractPlainText(child);
+      if (found) return found;
+    }
+  }
+  return null;
+}
+
+function decodeBase64Url(data: string): string {
+  const b64 = data.replace(/-/g, "+").replace(/_/g, "/");
+  return Buffer.from(b64, "base64").toString("utf8");
+}
+
+function stripHtml(html: string): string {
+  return html
+    .replace(/<style[\s\S]*?<\/style>/gi, "")
+    .replace(/<script[\s\S]*?<\/script>/gi, "")
+    .replace(/<[^>]+>/g, " ")
+    .replace(/&nbsp;/g, " ")
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+/** Pull `From` header → bare email; falls back to the raw header value. */
+export function extractFromEmail(msg: MessageResponse): string {
+  const fromHeader = msg.payload?.headers?.find((h) => h.name.toLowerCase() === "from")?.value ?? "";
+  // Match `Name <addr@host>` or bare `addr@host`. Lowercase.
+  const match = fromHeader.match(/<([^>]+)>/) ?? fromHeader.match(/([\w.+-]+@[\w.-]+\.[a-zA-Z]{2,})/);
+  return (match ? match[1] : fromHeader).trim().toLowerCase();
+}
+
+export function extractSubject(msg: MessageResponse): string {
+  return (
+    msg.payload?.headers?.find((h) => h.name.toLowerCase() === "subject")?.value ?? ""
+  );
+}
+
+/**
+ * Add a label to a message (we never REMOVE labels — that's user
+ * territory). `removeLabelIds: ["INBOX"]` auto-archives, used when the
+ * decision is `later` or `news`.
+ */
+export async function modifyMessage(
+  accessToken: string,
+  messageId: string,
+  addLabelIds: string[],
+  removeLabelIds: string[] = [],
+): Promise<void> {
+  const resp = await gmailFetch(accessToken, `/messages/${messageId}/modify`, {
+    method: "POST",
+    body: JSON.stringify({ addLabelIds, removeLabelIds }),
+  });
+  if (!resp.ok) {
+    throw new Error(
+      `Gmail messages.modify failed for ${messageId}: ${resp.status} ${await resp.text()}`,
+    );
+  }
+}
+
+/**
+ * Modify labels on EVERY message in a thread. Used by the @psd/Task
+ * gesture archive step so that labeling any single message in a thread
+ * causes the whole thread to be archived (matches Gmail's UX where a
+ * thread shows in Inbox if any message has INBOX). Avoids the
+ * 2026-05-22 dup-issue bug where threads with multiple messages each
+ * fired their own labelsAdded event → multiple gestures → multiple
+ * GitHub issues.
+ */
+export async function modifyThread(
+  accessToken: string,
+  threadId: string,
+  addLabelIds: string[],
+  removeLabelIds: string[] = [],
+): Promise<void> {
+  const resp = await gmailFetch(accessToken, `/threads/${threadId}/modify`, {
+    method: "POST",
+    body: JSON.stringify({ addLabelIds, removeLabelIds }),
+  });
+  if (!resp.ok) {
+    throw new Error(
+      `Gmail threads.modify failed for ${threadId}: ${resp.status} ${await resp.text()}`,
+    );
+  }
+}
+
+/**
+ * Check whether the user has a SENT message in the same thread. Used
+ * by the rules engine's "user-replied-here" signal — a strong indicator
+ * that incoming mail in this thread matters.
+ *
+ * Cheap: thread metadata + label scan, no body download.
+ */
+export async function threadHasUserReply(
+  accessToken: string,
+  threadId: string,
+): Promise<boolean> {
+  const resp = await gmailFetch(
+    accessToken,
+    `/threads/${threadId}?format=minimal`,
+  );
+  if (!resp.ok) return false;
+  const data = (await resp.json()) as {
+    messages?: { labelIds?: string[] }[];
+  };
+  return Boolean(
+    data.messages?.some((m) => (m.labelIds ?? []).includes("SENT")),
+  );
+}

--- a/infra/lambdas/agent-triage-poll/index.ts
+++ b/infra/lambdas/agent-triage-poll/index.ts
@@ -47,7 +47,6 @@ import {
   claimTaskGesture,
   releaseTaskGestureClaim,
   getGoogleIdentityForEmail,
-  getTriageRow,
   getUserProfile,
   listEnabledUsers,
   recordPollResult,
@@ -521,24 +520,18 @@ function detectCorrection(
   if (!prior) return null;
 
   const inboxAdded = evt.labelIds.includes("INBOX");
-  const inboxRemoved = false; // labelsRemoved branch handles this, but we
-                              // don't have a clean way to tell here — the
-                              // shared handler treats both branches the
-                              // same. Phase 2 splits them properly.
+  // NOTE: detecting INBOX removal would require knowing whether this
+  // event came from labelsAdded or labelsRemoved. The current caller
+  // mixes both branches together, so we can only catch the
+  // archive→inbox direction (user un-archived something we classified
+  // as later/news). Catching the inbox→archive direction needs the
+  // caller to split the two branches first.
 
   if (prior.label !== "important" && inboxAdded) {
     return {
       messageId: evt.message.id,
       fromLabel: prior.label,
       toLabel: "inbox",
-      ts: new Date().toISOString(),
-    };
-  }
-  if (prior.label === "important" && inboxRemoved) {
-    return {
-      messageId: evt.message.id,
-      fromLabel: prior.label,
-      toLabel: "later",
       ts: new Date().toISOString(),
     };
   }

--- a/infra/lambdas/agent-triage-poll/index.ts
+++ b/infra/lambdas/agent-triage-poll/index.ts
@@ -192,12 +192,16 @@ async function processUser(row: TriageRow): Promise<void> {
       }
     }
 
-    // User-driven label changes → training signal.
-    for (const evt of [
-      ...(event.labelsAdded ?? []),
-      ...(event.labelsRemoved ?? []),
-    ]) {
-      const correction = detectCorrection(row, evt, event.labelsRemoved?.includes(evt) ? "removed" : "added");
+    // User-driven label changes → training signal. Iterate
+    // labelsAdded and labelsRemoved separately instead of combining
+    // into one array — avoids an O(N²) .includes() check and makes
+    // the direction unambiguous.
+    for (const evt of event.labelsAdded ?? []) {
+      const correction = detectCorrection(row, evt, "added");
+      if (correction) newCorrections.push(correction);
+    }
+    for (const evt of event.labelsRemoved ?? []) {
+      const correction = detectCorrection(row, evt, "removed");
       if (correction) newCorrections.push(correction);
     }
 

--- a/infra/lambdas/agent-triage-poll/index.ts
+++ b/infra/lambdas/agent-triage-poll/index.ts
@@ -437,30 +437,49 @@ async function classifyAndLabel(
   // Step 3: maybe escalate to Chat.
   let escalated = false;
   const esc = shouldEscalate(result.label, features, row.escalation);
-  if (esc.escalate && row.dmSpaceName) {
-    try {
-      await postEscalation({
-        dmSpaceName: row.dmSpaceName,
-        userEmail: row.userEmail,
-        label: result.label,
-        message: {
-          id: msgRef.id,
-          threadId: msgRef.threadId,
-          fromEmail: features.fromEmail,
-          subject: features.subject,
-          snippet: meta.snippet ?? "",
-          internalDate: meta.internalDate ?? "",
-          labelIds: meta.labelIds ?? [],
-        },
-        reason: esc.reason,
-      });
-      escalated = true;
-    } catch (err) {
-      log("ERROR", "escalation_failed", {
-        user: row.userEmail,
-        messageId: msgRef.id,
-        err: err instanceof Error ? err.message : String(err),
-      });
+  if (esc.escalate) {
+    // Resolve the DM space lazily — enable flow doesn't populate it,
+    // so the first escalation for a new user triggers the lookup and
+    // backfills the row for subsequent calls.
+    let dmSpace = row.dmSpaceName;
+    if (!dmSpace) {
+      const gid = await getGoogleIdentityForEmail(row.userEmail);
+      if (gid) {
+        dmSpace = await resolveDmSpace(gid) ?? undefined;
+        if (dmSpace) {
+          await backfillDmSpaceName(row.userEmail, dmSpace);
+          log("INFO", "dm_space_backfilled_escalation", {
+            user: row.userEmail,
+            space: dmSpace,
+          });
+        }
+      }
+    }
+    if (dmSpace) {
+      try {
+        await postEscalation({
+          dmSpaceName: dmSpace,
+          userEmail: row.userEmail,
+          label: result.label,
+          message: {
+            id: msgRef.id,
+            threadId: msgRef.threadId,
+            fromEmail: features.fromEmail,
+            subject: features.subject,
+            snippet: meta.snippet ?? "",
+            internalDate: meta.internalDate ?? "",
+            labelIds: meta.labelIds ?? [],
+          },
+          reason: esc.reason,
+        });
+        escalated = true;
+      } catch (err) {
+        log("ERROR", "escalation_failed", {
+          user: row.userEmail,
+          messageId: msgRef.id,
+          err: err instanceof Error ? err.message : String(err),
+        });
+      }
     }
   }
 
@@ -514,20 +533,17 @@ function detectCorrection(
     message: { id: string; labelIds?: string[] };
     labelIds: string[];
   },
-  _direction: "added" | "removed",
+  direction: "added" | "removed",
 ): CorrectionRecord | null {
   const prior = (row.recentDecisions ?? []).find((d) => d.messageId === evt.message.id);
   if (!prior) return null;
 
-  const inboxAdded = evt.labelIds.includes("INBOX");
-  // NOTE: detecting INBOX removal would require knowing whether this
-  // event came from labelsAdded or labelsRemoved. The current caller
-  // mixes both branches together, so we can only catch the
-  // archive→inbox direction (user un-archived something we classified
-  // as later/news). Catching the inbox→archive direction needs the
-  // caller to split the two branches first.
+  const inboxInEvent = evt.labelIds.includes("INBOX");
 
-  if (prior.label !== "important" && inboxAdded) {
+  // Direction "added" + INBOX in labelIds = user moved message back to
+  // inbox (un-archived) after we classified it as later/news → we got
+  // it wrong, they DID want to see it.
+  if (direction === "added" && inboxInEvent && prior.label !== "important") {
     return {
       messageId: evt.message.id,
       fromLabel: prior.label,
@@ -535,6 +551,19 @@ function detectCorrection(
       ts: new Date().toISOString(),
     };
   }
+
+  // Direction "removed" + INBOX in labelIds = user archived a message
+  // we classified as "important" → we got it wrong, they didn't want
+  // to see it. Previously this branch was dead (hardcoded false).
+  if (direction === "removed" && inboxInEvent && prior.label === "important") {
+    return {
+      messageId: evt.message.id,
+      fromLabel: prior.label,
+      toLabel: "archived",
+      ts: new Date().toISOString(),
+    };
+  }
+
   return null;
 }
 

--- a/infra/lambdas/agent-triage-poll/index.ts
+++ b/infra/lambdas/agent-triage-poll/index.ts
@@ -1,0 +1,753 @@
+/**
+ * Email Triage Classifier Lambda
+ *
+ * Triggered every 5 minutes by an EventBridge Rule. For each opted-in
+ * user in the triage table:
+ *   1. Mint a fresh Gmail access token (via lib/agent/workspace-token).
+ *   2. Pull the user's Gmail history since their last cursor.
+ *   3. For each new message: apply rules → maybe LLM → apply label →
+ *      maybe escalate to Chat.
+ *   4. For each user-driven label change: record as training signal.
+ *   5. Advance cursor.
+ *
+ * The Lambda processes users in parallel batches of TRIAGE_USER_BATCH so
+ * one slow user doesn't block the rest. Per-user errors are logged and
+ * skipped — the next 5-minute tick picks up where it left off.
+ */
+
+import type { ScheduledHandler } from "aws-lambda";
+
+import {
+  getFreshAccessTokenForUser,
+  workspaceSecretId,
+} from "./workspace-token";
+
+import {
+  extractFromEmail,
+  extractSubject,
+  getCurrentHistoryId,
+  getMessageFullBody,
+  getMessageMetadata,
+  listHistory,
+  modifyMessage,
+  modifyThread,
+  threadHasUserReply,
+  type HistoryEvent,
+} from "./gmail";
+import { classifyWithLLM } from "./llm";
+import {
+  applyRules,
+  shouldEscalate,
+  type EmailFeatures,
+  type Label,
+} from "./rules";
+import { postEscalation, postTaskOutcome, resolveDmSpace } from "./chat";
+import {
+  backfillDmSpaceName,
+  claimTaskGesture,
+  releaseTaskGestureClaim,
+  getGoogleIdentityForEmail,
+  getTriageRow,
+  getUserProfile,
+  listEnabledUsers,
+  recordPollResult,
+  recordTaskCreated,
+  resetCursor,
+} from "./storage";
+import { requestTaskCreation } from "./agentcore";
+import type {
+  ClassifierResult,
+  CorrectionRecord,
+  DecisionRecord,
+  TriageRow,
+} from "./types";
+
+const ENV = process.env.ENVIRONMENT ?? "dev";
+const REGION = process.env.AWS_REGION ?? "us-east-1";
+const USER_BATCH = parseInt(process.env.TRIAGE_USER_BATCH ?? "10", 10);
+const RULES_CONFIDENCE_FLOOR = 0.6;
+
+function log(level: "INFO" | "WARN" | "ERROR", evt: string, fields: Record<string, unknown>) {
+  // eslint-disable-next-line no-console
+  console.log(
+    JSON.stringify({
+      level,
+      logger: "triage-poll",
+      evt,
+      timestamp: new Date().toISOString(),
+      ...fields,
+    }),
+  );
+}
+
+export const handler: ScheduledHandler = async () => {
+  const startedAt = Date.now();
+  const users = await listEnabledUsers();
+  log("INFO", "tick_start", { opted_in: users.length });
+
+  for (let i = 0; i < users.length; i += USER_BATCH) {
+    const batch = users.slice(i, i + USER_BATCH);
+    await Promise.all(batch.map((row) => processUserSafe(row)));
+  }
+
+  log("INFO", "tick_complete", {
+    opted_in: users.length,
+    elapsed_ms: Date.now() - startedAt,
+  });
+};
+
+async function processUserSafe(row: TriageRow): Promise<void> {
+  try {
+    await processUser(row);
+  } catch (err) {
+    log("ERROR", "user_processing_failed", {
+      user: row.userEmail,
+      err: err instanceof Error ? err.message : String(err),
+    });
+  }
+}
+
+async function processUser(row: TriageRow): Promise<void> {
+  const t0 = Date.now();
+
+  // Acquire access token.
+  let accessToken: string;
+  try {
+    const token = await getFreshAccessTokenForUser(
+      row.userEmail,
+      ENV,
+      "user_account",
+      REGION,
+    );
+    if (!token) {
+      log("WARN", "no_token", {
+        user: row.userEmail,
+        secretId: workspaceSecretId(row.userEmail, ENV, "user_account"),
+      });
+      return;
+    }
+    accessToken = token.access_token;
+  } catch (err) {
+    const errAny = err as Error & { code?: string };
+    if (errAny.code === "invalid_grant") {
+      // The user needs to re-consent. Phase 1 doesn't auto-disable —
+      // we just log and skip; the next tick will skip again. The
+      // agent will surface this when the user next interacts.
+      log("WARN", "invalid_grant", { user: row.userEmail });
+      return;
+    }
+    throw err;
+  }
+
+  // Anchor cursor — when missing or on first run we capture "now" so we
+  // only classify forward.
+  let startHistoryId = row.lastHistoryId ?? row.classifierStartHistoryId;
+  if (!startHistoryId) {
+    startHistoryId = await getCurrentHistoryId(accessToken);
+    await resetCursor(row.userEmail, startHistoryId);
+    log("INFO", "cursor_anchored", { user: row.userEmail, historyId: startHistoryId });
+    return; // nothing to do this tick — wait for next mail
+  }
+
+  // Pull diff.
+  const { events, latestHistoryId, tooOld } = await listHistory(
+    accessToken,
+    startHistoryId,
+  );
+  if (tooOld) {
+    const fresh = await getCurrentHistoryId(accessToken);
+    await resetCursor(row.userEmail, fresh);
+    log("WARN", "cursor_too_old_reset", {
+      user: row.userEmail,
+      stale: startHistoryId,
+      fresh,
+    });
+    return;
+  }
+
+  const newDecisions: DecisionRecord[] = [];
+  const newCorrections: CorrectionRecord[] = [];
+  // Map of threadId → one representative messageId. When the user
+  // labels a thread, Gmail fires a labelsAdded event for EACH message
+  // in the thread — keying by thread (not message) collapses those
+  // into a single gesture per thread. Bug 2026-05-22: keying by
+  // messageId created N issues for an N-message thread.
+  const taskGestures = new Map<string, string>();
+  let escalated = 0;
+
+  for (const event of events) {
+    // New messages → classify + label.
+    for (const m of event.messagesAdded ?? []) {
+      try {
+        const decision = await classifyAndLabel(row, accessToken, m.message);
+        if (decision) {
+          newDecisions.push(decision.decision);
+          if (decision.escalated) escalated++;
+        }
+      } catch (err) {
+        log("ERROR", "classify_failed", {
+          user: row.userEmail,
+          messageId: m.message.id,
+          err: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+
+    // User-driven label changes → training signal.
+    for (const evt of [
+      ...(event.labelsAdded ?? []),
+      ...(event.labelsRemoved ?? []),
+    ]) {
+      const correction = detectCorrection(row, evt, event.labelsRemoved?.includes(evt) ? "removed" : "added");
+      if (correction) newCorrections.push(correction);
+    }
+
+    // @psd/Task user gesture — collect into a dedup set so re-labeled
+    // threads only fire once per tick. The classifier never assigns
+    // @psd/Task itself, so any labelsAdded event for it is user-driven
+    // (or programmatic from another tool — both count as "create a
+    // task").
+    const taskLabelId = row.labelIdsByKey?.task;
+    if (taskLabelId) {
+      for (const evt of event.labelsAdded ?? []) {
+        if (evt.labelIds?.includes(taskLabelId)) {
+          // Key by threadId — first message in this thread to fire
+          // wins as the representative. Subsequent labelsAdded events
+          // for the same thread (because Gmail fires one per message
+          // when a thread is labeled) are no-ops.
+          if (!taskGestures.has(evt.message.threadId)) {
+            taskGestures.set(evt.message.threadId, evt.message.id);
+          }
+        }
+      }
+    }
+  }
+
+  // Advance cursor FIRST, before any expensive gesture processing.
+  // Reason: AgentCore calls can take ~100s each. If we processed
+  // gestures first and the Lambda timed out, the cursor would stay
+  // put and the next tick would replay the same labelsAdded events,
+  // creating duplicates forever (observed 2026-05-22).
+  //
+  // The claim mechanism (claimTaskGesture) is the durable defense
+  // against duplicates within a 30-min window; cursor advancement
+  // ensures we don't reprocess the same Gmail history events at all.
+  const cursor = latestHistoryId ?? startHistoryId;
+  await recordPollResult(
+    row.userEmail,
+    { lastHistoryId: cursor, lastPollAt: new Date().toISOString() },
+    newDecisions,
+    newCorrections,
+  );
+
+  // Process task gestures sequentially with a per-tick wall-clock
+  // budget. Each AgentCore call is hard-capped at ~90s; we cap the
+  // total at TASK_GESTURE_BUDGET_MS so a backlog can't starve other
+  // users (and so the Lambda timeout never bites). Any unprocessed
+  // gestures are logged — they'll be picked up next time the user
+  // re-applies the @psd/Task label (an intentional retry gesture).
+  const TASK_GESTURE_BUDGET_MS = 180_000;
+  if (taskGestures.size > 0 && row.tasksMode === "invoke-agent") {
+    const gestureStart = Date.now();
+    let processed = 0;
+    let deferred = 0;
+    for (const messageId of taskGestures.values()) {
+      if (Date.now() - gestureStart > TASK_GESTURE_BUDGET_MS) {
+        deferred++;
+        continue;
+      }
+      try {
+        await processTaskGesture(row, accessToken, messageId);
+        processed++;
+      } catch (err) {
+        log("ERROR", "task_gesture_failed", {
+          user: row.userEmail,
+          messageId,
+          err: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+    if (deferred > 0) {
+      log("WARN", "task_gestures_deferred", {
+        user: row.userEmail,
+        processed,
+        deferred,
+        elapsed_ms: Date.now() - gestureStart,
+      });
+    }
+  } else if (taskGestures.size > 0) {
+    log("INFO", "task_gesture_ignored_mode_none", {
+      user: row.userEmail,
+      count: taskGestures.size,
+    });
+  }
+
+  log("INFO", "user_processed", {
+    user: row.userEmail,
+    new_msgs: newDecisions.length,
+    corrections: newCorrections.length,
+    escalations: escalated,
+    task_gestures: taskGestures.size,
+    elapsed_ms: Date.now() - t0,
+  });
+}
+
+// Gmail's built-in system labels. Anything else on a message means a
+// human or a Gmail filter has already classified it — we shouldn't
+// overwrite their decision with our own label. The classifier respects
+// existing organisation.
+//
+// CATEGORY_* covers Gmail's Promotions/Social/Updates/Forums/etc.
+// auto-categorisation — those keep INBOX so they're still "fresh" mail
+// the user hasn't classified yet, so we DO want to classify them. We
+// only skip CATEGORY_* when paired with another non-system label that
+// indicates explicit filter action.
+const GMAIL_SYSTEM_LABELS = new Set([
+  "INBOX",
+  "UNREAD",
+  "STARRED",
+  "IMPORTANT",
+  "SENT",
+  "DRAFT",
+  "TRASH",
+  "SPAM",
+  "CHAT",
+  "CATEGORY_PERSONAL",
+  "CATEGORY_SOCIAL",
+  "CATEGORY_PROMOTIONS",
+  "CATEGORY_UPDATES",
+  "CATEGORY_FORUMS",
+  "CATEGORY_RESERVATIONS",
+  "CATEGORY_PURCHASES",
+]);
+
+/**
+ * Decide whether a message has already been triaged by something other
+ * than us — a Gmail filter, a user action, or anything that already
+ * organised the message.
+ *
+ * Skip rules:
+ *   1. Any user-defined label that isn't one of ours → filter/user
+ *      already classified it.
+ *   2. INBOX is absent → either a "Skip Inbox" filter archived it, the
+ *      user manually archived before we got there, or it's a draft/sent
+ *      we shouldn't touch.
+ *
+ * On 2026-05-22 hagelk reported messages with existing filter labels
+ * were being double-labelled with @psd/Later. This guard prevents that
+ * from recurring.
+ */
+function shouldSkipMessage(
+  row: TriageRow,
+  labelIds: string[] | undefined,
+): { skip: true; reason: string } | { skip: false } {
+  const labels = labelIds ?? [];
+  if (!labels.includes("INBOX")) {
+    return { skip: true, reason: "no-inbox" };
+  }
+  const ourLabelIds = new Set(Object.values(row.labelIdsByKey ?? {}));
+  const nonSystemNonOurs = labels.filter(
+    (id) => !GMAIL_SYSTEM_LABELS.has(id) && !ourLabelIds.has(id),
+  );
+  if (nonSystemNonOurs.length > 0) {
+    return { skip: true, reason: `existing-labels:${nonSystemNonOurs.join(",")}` };
+  }
+  return { skip: false };
+}
+
+async function classifyAndLabel(
+  row: TriageRow,
+  accessToken: string,
+  msgRef: { id: string; threadId: string; labelIds?: string[] },
+): Promise<{ decision: DecisionRecord; escalated: boolean } | null> {
+  // Fetch metadata — needed for sender + subject + snippet.
+  const meta = await getMessageMetadata(accessToken, msgRef.id);
+  if (!meta) return null;
+
+  // Respect anything that already triaged this message (Gmail filters,
+  // the user's own labelling, Skip-Inbox filters, etc.). meta.labelIds
+  // is the current authoritative state from Gmail; msgRef.labelIds from
+  // the history event can be stale by ~seconds. We trust meta.
+  const skip = shouldSkipMessage(row, meta.labelIds);
+  if (skip.skip) {
+    log("INFO", "skip_already_triaged", {
+      user: row.userEmail,
+      messageId: msgRef.id,
+      reason: skip.reason,
+    });
+    return null;
+  }
+
+  const features = await buildFeatures(row, accessToken, meta);
+
+  // Step 1: deterministic rules.
+  let result: ClassifierResult;
+  const ruleDecision = applyRules(features, row.rules);
+  if ("label" in ruleDecision) {
+    result = {
+      label: ruleDecision.label,
+      confidence: 1, // rule matches are certain
+      reason: ruleDecision.reason,
+      source: "rule",
+    };
+  } else {
+    // Step 2: LLM fallback.
+    const internalDomain = row.internalDomain ?? row.userEmail.split("@")[1] ?? "";
+    const llm = await classifyWithLLM(features, row.rules, internalDomain);
+    // Safety net: anything below the confidence floor defaults to `later`
+    // so we never blast something into `important` on a guess.
+    const finalLabel: Label = llm.confidence >= RULES_CONFIDENCE_FLOOR ? llm.label : "later";
+    result = {
+      label: finalLabel,
+      confidence: llm.confidence,
+      reason: llm.confidence < RULES_CONFIDENCE_FLOOR
+        ? `low-confidence (${llm.reason})`
+        : llm.reason,
+      source: "llm",
+    };
+  }
+
+  // Apply the label via Gmail.
+  const labelId = row.labelIdsByKey?.[result.label];
+  if (!labelId) {
+    log("WARN", "missing_label_id", { user: row.userEmail, key: result.label });
+    return null;
+  }
+  // Always archive — INBOX comes off for every classification, not
+  // just later/news. User treats labels as folders (each message lives
+  // in exactly one place), so Important goes to @psd/Important AND is
+  // removed from Inbox. Chat escalation is the "you need to look at
+  // this NOW" signal; the @psd/Important label is the home folder.
+  // Updated 2026-05-22 per user feedback — original design kept Important
+  // dual-labelled in Inbox, which doubled the user's review surface.
+  const removeLabelIds = ["INBOX"];
+  await modifyMessage(accessToken, msgRef.id, [labelId], removeLabelIds);
+
+  const record: DecisionRecord = {
+    messageId: msgRef.id,
+    threadId: msgRef.threadId,
+    label: result.label,
+    source: result.source,
+    reason: result.reason,
+    confidence: result.confidence,
+    ts: new Date().toISOString(),
+    fromEmail: features.fromEmail,
+    subject: features.subject,
+  };
+
+  // Step 3: maybe escalate to Chat.
+  let escalated = false;
+  const esc = shouldEscalate(result.label, features, row.escalation);
+  if (esc.escalate && row.dmSpaceName) {
+    try {
+      await postEscalation({
+        dmSpaceName: row.dmSpaceName,
+        userEmail: row.userEmail,
+        label: result.label,
+        message: {
+          id: msgRef.id,
+          threadId: msgRef.threadId,
+          fromEmail: features.fromEmail,
+          subject: features.subject,
+          snippet: meta.snippet ?? "",
+          internalDate: meta.internalDate ?? "",
+          labelIds: meta.labelIds ?? [],
+        },
+        reason: esc.reason,
+      });
+      escalated = true;
+    } catch (err) {
+      log("ERROR", "escalation_failed", {
+        user: row.userEmail,
+        messageId: msgRef.id,
+        err: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  return { decision: record, escalated };
+}
+
+async function buildFeatures(
+  row: TriageRow,
+  accessToken: string,
+  meta: NonNullable<Awaited<ReturnType<typeof getMessageMetadata>>>,
+): Promise<EmailFeatures> {
+  const fromEmail = extractFromEmail(meta);
+  const subject = extractSubject(meta);
+  const snippet = meta.snippet ?? "";
+  const fromDomain = fromEmail.split("@")[1] ?? "";
+  const internalDomain = row.internalDomain ?? row.userEmail.split("@")[1] ?? "";
+  const isInternal = fromDomain.toLowerCase() === internalDomain.toLowerCase();
+  let hasUserReply = false;
+  if (meta.threadId) {
+    try {
+      hasUserReply = await threadHasUserReply(accessToken, meta.threadId);
+    } catch {
+      // Treat as no-reply; rules engine falls back to other signals.
+    }
+  }
+  return {
+    fromEmail,
+    fromDomain,
+    isInternal,
+    subject,
+    subjectLower: subject.toLowerCase(),
+    snippetLower: snippet.toLowerCase(),
+    hasUserReply,
+  };
+}
+
+/**
+ * Detect when the user moved a recently-classified message between
+ * labels in a way that contradicts our prior decision. We only record
+ * INBOX-direction movement: removing INBOX (= archiving) by the user
+ * after we labeled `important` means we got it wrong (they didn't want
+ * to see it); adding INBOX after we labeled `later` means we got it
+ * wrong (they DID want to see it).
+ *
+ * Phase 1 records corrections only. Phase 2 will act on them to update
+ * `learnedPatterns`.
+ */
+function detectCorrection(
+  row: TriageRow,
+  evt: {
+    message: { id: string; labelIds?: string[] };
+    labelIds: string[];
+  },
+  _direction: "added" | "removed",
+): CorrectionRecord | null {
+  const prior = (row.recentDecisions ?? []).find((d) => d.messageId === evt.message.id);
+  if (!prior) return null;
+
+  const inboxAdded = evt.labelIds.includes("INBOX");
+  const inboxRemoved = false; // labelsRemoved branch handles this, but we
+                              // don't have a clean way to tell here — the
+                              // shared handler treats both branches the
+                              // same. Phase 2 splits them properly.
+
+  if (prior.label !== "important" && inboxAdded) {
+    return {
+      messageId: evt.message.id,
+      fromLabel: prior.label,
+      toLabel: "inbox",
+      ts: new Date().toISOString(),
+    };
+  }
+  if (prior.label === "important" && inboxRemoved) {
+    return {
+      messageId: evt.message.id,
+      fromLabel: prior.label,
+      toLabel: "later",
+      ts: new Date().toISOString(),
+    };
+  }
+  return null;
+}
+
+// Re-exported for unit tests outside the handler.
+export { detectCorrection };
+
+/**
+ * Handle a single @psd/Task user gesture.
+ *
+ *   1. Fetch the email metadata so the AgentCore prompt is well-formed.
+ *   2. Invoke AgentCore — the user's MEMORY.md tells the agent how to
+ *      create the task in their preferred system. We deliver metadata,
+ *      the agent does the work.
+ *   3. Parse the agent's terse reply for success/failure.
+ *   4. On success: archive (remove INBOX + remove @psd/Task) so the
+ *      message ends up in All Mail only — exactly one home.
+ *   5. On success: record an audit trail entry (recentTaskCreations).
+ *   6. On success: optional confirmation card if tasksNotifySuccess=true.
+ *   7. On failure: leave the email as-is (still in Inbox + @psd/Task)
+ *      and post a Chat card explaining the failure + the retry path.
+ *
+ * Failures intentionally don't roll back any state — the email keeps
+ * its label so a remove + re-add gesture from the user re-triggers
+ * cleanly on the next tick.
+ */
+async function processTaskGesture(
+  row: TriageRow,
+  accessToken: string,
+  messageId: string,
+): Promise<void> {
+  const t0 = Date.now();
+  // Atomic claim — if another tick already started this gesture, bail.
+  // Defends against AgentCore-slow + cursor-not-advanced + concurrent-tick
+  // duplication. The claim lives for 30 minutes; expired claims are
+  // treated as available again so a stuck invocation can be re-tried.
+  const claimed = await claimTaskGesture(row.userEmail, messageId);
+  if (!claimed) {
+    log("INFO", "task_gesture_already_claimed", {
+      user: row.userEmail,
+      messageId,
+    });
+    return;
+  }
+  const meta = await getMessageMetadata(accessToken, messageId);
+  if (!meta) {
+    log("WARN", "task_gesture_meta_missing", {
+      user: row.userEmail,
+      messageId,
+    });
+    return;
+  }
+  // If the @psd/Task label is no longer on the message, the gesture has
+  // either already been handled (label removed by a prior tick) or the
+  // user un-labeled it. Either way, don't re-process the stale
+  // labelsAdded event sitting in Gmail's 7-day history window.
+  const taskLabelId = row.labelIdsByKey?.task;
+  if (taskLabelId && !(meta.labelIds ?? []).includes(taskLabelId)) {
+    log("INFO", "task_gesture_stale_label_removed", {
+      user: row.userEmail,
+      messageId,
+    });
+    return;
+  }
+  const fromEmail = extractFromEmail(meta);
+  const subject = extractSubject(meta);
+  // Fetch the full body so the agent can apply urgency-detection rules
+  // (the 400-char snippet often cuts off "by Friday" or "EOD" markers).
+  // Falls back to snippet if the body fetch fails.
+  let bodyText = meta.snippet ?? "";
+  try {
+    const full = await getMessageFullBody(accessToken, messageId);
+    if (full && full.trim()) bodyText = full;
+  } catch (err) {
+    log("WARN", "task_gesture_body_fetch_failed", {
+      user: row.userEmail,
+      messageId,
+      err: err instanceof Error ? err.message : String(err),
+    });
+  }
+
+  // Resolve the user's actual S3 workspace prefix (e.g.
+  // `hagelk-db0f32b5`) from the users table. Don't derive it from the
+  // email's local-part — that loses the random suffix and the
+  // resulting S3 path won't exist (bug observed 2026-05-22).
+  const profile = await getUserProfile(row.userEmail);
+  const workspacePrefix = profile?.workspacePrefix;
+  if (!workspacePrefix) {
+    log("ERROR", "task_gesture_no_workspace_prefix", {
+      user: row.userEmail,
+      messageId,
+    });
+    return;
+  }
+
+  const result = await requestTaskCreation({
+    userEmail: row.userEmail,
+    workspacePrefix,
+    agentcoreRuntimeId: row.agentcoreRuntimeId,
+    subject,
+    fromEmail,
+    snippet: bodyText,
+    threadId: meta.threadId,
+    messageId,
+  });
+
+  // Resolve DM space lazily for the Chat outcome posts. The triage row
+  // doesn't always have it cached (users who haven't received a digest
+  // or escalation yet) — look it up via the bot's Chat API and persist
+  // back to the row for next time. Same pattern the cron Lambda uses.
+  let dmSpaceName = row.dmSpaceName;
+  if (!dmSpaceName) {
+    const gid = await getGoogleIdentityForEmail(row.userEmail);
+    if (gid) {
+      dmSpaceName = await resolveDmSpace(gid) ?? undefined;
+      if (dmSpaceName) {
+        await backfillDmSpaceName(row.userEmail, dmSpaceName);
+        log("INFO", "dm_space_backfilled", {
+          user: row.userEmail,
+          space: dmSpaceName,
+        });
+      }
+    }
+  }
+
+  if (result.ok) {
+    // Archive the WHOLE THREAD: drop INBOX + remove @psd/Task from
+    // every message in the thread. Modifying just the one message
+    // would leave other messages in the thread still tagged, which
+    // (a) confuses the user and (b) lets the next tick re-fire on
+    // those other messages' labelsAdded events.
+    const taskLabelId = row.labelIdsByKey?.task;
+    const removeLabelIds = ["INBOX"];
+    if (taskLabelId) removeLabelIds.push(taskLabelId);
+    try {
+      await modifyThread(accessToken, meta.threadId, [], removeLabelIds);
+    } catch (err) {
+      // Modify failed — task exists upstream but email isn't archived.
+      // Surface as a partial-success warning; user will see both the
+      // task in their system AND the email still in their @psd/Task
+      // label. Cleanup is manual but not catastrophic.
+      log("WARN", "task_archive_failed", {
+        user: row.userEmail,
+        messageId,
+        taskRef: result.taskRef,
+        err: err instanceof Error ? err.message : String(err),
+      });
+    }
+    await recordTaskCreated(
+      row.userEmail,
+      messageId,
+      result.taskRef,
+      new Date().toISOString(),
+    );
+    log("INFO", "task_gesture_ok", {
+      user: row.userEmail,
+      messageId,
+      taskRef: result.taskRef,
+      elapsed_ms: Date.now() - t0,
+    });
+    if (row.tasksNotifySuccess && dmSpaceName) {
+      try {
+        await postTaskOutcome({
+          dmSpaceName,
+          subject,
+          fromEmail,
+          messageId,
+          ok: true,
+          taskRef: result.taskRef,
+        });
+      } catch (err) {
+        log("WARN", "task_success_notify_failed", {
+          user: row.userEmail,
+          messageId,
+          err: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+    return;
+  }
+
+  // Failure path — log, release the claim so a retry (next tick or
+  // user re-label) isn't blocked, surface to Chat, leave email state
+  // untouched.
+  await releaseTaskGestureClaim(row.userEmail, messageId);
+  log("ERROR", "task_gesture_failed", {
+    user: row.userEmail,
+    messageId,
+    reason: result.reason,
+    elapsed_ms: Date.now() - t0,
+  });
+  if (dmSpaceName) {
+    try {
+      await postTaskOutcome({
+        dmSpaceName,
+        subject,
+        fromEmail,
+        messageId,
+        ok: false,
+        reason: result.reason,
+      });
+    } catch (err) {
+      log("WARN", "task_failure_notify_failed", {
+        user: row.userEmail,
+        messageId,
+        err: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+}

--- a/infra/lambdas/agent-triage-poll/llm.test.ts
+++ b/infra/lambdas/agent-triage-poll/llm.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Unit tests for parseLLMOutput. The Bedrock call itself is integration
+ * territory — these tests just cover the parser's tolerance for the
+ * various shapes Nova Micro is known to emit (markdown-wrapped JSON,
+ * stray prose, trailing punctuation).
+ */
+import { describe, expect, test } from "bun:test";
+import { parseLLMOutput } from "./llm";
+
+describe("parseLLMOutput", () => {
+  test("clean JSON line", () => {
+    expect(
+      parseLLMOutput('{"label":"important","confidence":0.92,"reason":"direct human ask"}'),
+    ).toEqual({
+      label: "important",
+      confidence: 0.92,
+      reason: "direct human ask",
+    });
+  });
+
+  test("markdown-fenced JSON", () => {
+    expect(
+      parseLLMOutput(
+        '```json\n{"label":"later","confidence":0.6,"reason":"newsletter"}\n```',
+      ),
+    ).toEqual({ label: "later", confidence: 0.6, reason: "newsletter" });
+  });
+
+  test("trailing period after closing brace", () => {
+    expect(
+      parseLLMOutput('{"label":"news","confidence":0.8,"reason":"vendor blast"}.'),
+    ).toEqual({ label: "news", confidence: 0.8, reason: "vendor blast" });
+  });
+
+  test("prepended prose then JSON object", () => {
+    expect(
+      parseLLMOutput('Here is the answer: {"label":"important","confidence":0.7,"reason":"PR review"}'),
+    ).toEqual({ label: "important", confidence: 0.7, reason: "PR review" });
+  });
+
+  test("invalid label falls back to later", () => {
+    expect(
+      parseLLMOutput('{"label":"urgent","confidence":0.9,"reason":"x"}'),
+    ).toMatchObject({ label: "later" });
+  });
+
+  test("out-of-range confidence falls back to 0", () => {
+    expect(
+      parseLLMOutput('{"label":"important","confidence":2.5,"reason":"x"}'),
+    ).toMatchObject({ confidence: 0 });
+  });
+
+  test("empty string", () => {
+    expect(parseLLMOutput("")).toMatchObject({ label: "later", confidence: 0 });
+  });
+
+  test("garbage", () => {
+    expect(parseLLMOutput("nope")).toMatchObject({ label: "later", confidence: 0 });
+  });
+
+  test("missing reason", () => {
+    expect(
+      parseLLMOutput('{"label":"news","confidence":0.7}'),
+    ).toMatchObject({ label: "news", confidence: 0.7, reason: "no-reason" });
+  });
+});

--- a/infra/lambdas/agent-triage-poll/llm.ts
+++ b/infra/lambdas/agent-triage-poll/llm.ts
@@ -1,0 +1,216 @@
+/**
+ * Bedrock Nova Micro classifier — fallback when the deterministic rules
+ * engine returns `undecided`.
+ *
+ * Why Nova Micro: cheapest Bedrock model available, fast (<1s typical),
+ * good enough at "classify this short email into one of N buckets"
+ * which is essentially what we're doing. Per-call cost ~$0.0001 with
+ * the small prompt we send. Annual cost projection at 1000 users ≈
+ * $900/yr in the worst case — well under what SaneBox costs at scale.
+ *
+ * Why not the agent's main model: the agent runs glm-5 (per the
+ * Mantle proxy logs). That's a much heavier model and we'd pay 10-20x
+ * per classification. Triage is a hot path that needs to be tiny.
+ *
+ * Fail-safe: if Bedrock returns garbage or the response can't be parsed,
+ * we default to `later` (the lowest-noise classification). The user can
+ * always correct it via training feedback.
+ */
+
+import {
+  BedrockRuntimeClient,
+  ConverseCommand,
+  type ContentBlock,
+} from "@aws-sdk/client-bedrock-runtime";
+
+import type { Label, TriageRules } from "./rules";
+import type { EmailFeatures } from "./rules";
+
+const MODEL_ID = process.env.TRIAGE_LLM_MODEL_ID ?? "us.amazon.nova-micro-v1:0";
+
+let cachedClient: BedrockRuntimeClient | null = null;
+
+function client(): BedrockRuntimeClient {
+  if (!cachedClient) {
+    cachedClient = new BedrockRuntimeClient({
+      region: process.env.AWS_REGION ?? "us-east-1",
+    });
+  }
+  return cachedClient;
+}
+
+export interface LLMDecision {
+  label: Label;
+  confidence: number;
+  reason: string;
+}
+
+/**
+ * Classify one email. Returns the label, confidence (0-1), and a short
+ * one-line reason the agent can echo back to the user during training
+ * review.
+ */
+export async function classifyWithLLM(
+  features: EmailFeatures,
+  rules: TriageRules,
+  userInternalDomain: string,
+): Promise<LLMDecision> {
+  const systemPrompt = buildSystemPrompt(rules, userInternalDomain);
+  const userPrompt = buildUserPrompt(features);
+
+  try {
+    const resp = await client().send(
+      new ConverseCommand({
+        modelId: MODEL_ID,
+        system: [{ text: systemPrompt }],
+        messages: [
+          {
+            role: "user",
+            content: [{ text: userPrompt }],
+          },
+        ],
+        inferenceConfig: {
+          // Tiny output — we want a JSON line, not prose.
+          maxTokens: 120,
+          // Low temperature so the same email gets the same label across runs.
+          temperature: 0.1,
+          topP: 0.9,
+        },
+      }),
+    );
+
+    const blocks: ContentBlock[] =
+      resp.output?.message?.content ?? [];
+    const text = blocks
+      .map((b) => ("text" in b && b.text ? b.text : ""))
+      .join("")
+      .trim();
+
+    return parseLLMOutput(text);
+  } catch (err) {
+    // Hard-fail safe: any Bedrock or parse error → fall through to
+    // `later`. We DO log the error so CloudWatch shows real
+    // misconfigurations (model not enabled, throttle, etc.).
+    // eslint-disable-next-line no-console
+    console.error(
+      JSON.stringify({
+        level: "ERROR",
+        evt: "llm_classify_failed",
+        err: err instanceof Error ? err.message : String(err),
+      }),
+    );
+    return {
+      label: "later",
+      confidence: 0,
+      reason: "llm-error-default",
+    };
+  }
+}
+
+function buildSystemPrompt(
+  rules: TriageRules,
+  userInternalDomain: string,
+): string {
+  const vip = rules.vipSenders.length
+    ? rules.vipSenders.join(", ")
+    : "(none — anyone is fair game)";
+  const muted = rules.muteSenders.length
+    ? rules.muteSenders.join(", ")
+    : "(none configured)";
+  const keywords =
+    rules.keywordRules.length === 0
+      ? "(none configured)"
+      : rules.keywordRules
+          .map((r) => {
+            const parts: string[] = [];
+            if (r.subject_contains) parts.push(`subject contains "${r.subject_contains}"`);
+            if (r.snippet_contains) parts.push(`body contains "${r.snippet_contains}"`);
+            if (r.from_domain) parts.push(`from ${r.from_domain}`);
+            if (r.external) parts.push("external sender");
+            return `- ${parts.join(" + ")} → ${r.label}`;
+          })
+          .join("\n");
+
+  return [
+    `You classify incoming emails for a Peninsula School District (PSD) employee into one of three Gmail labels:`,
+    `  - important: needs attention soon. Real work, real people, real decisions.`,
+    `  - later:     can wait. Notifications, FYI, low-priority discussion.`,
+    `  - news:      pure information. Newsletters, marketing, vendor blasts.`,
+    ``,
+    `Reply with EXACTLY one JSON line, no preamble or markdown, in this shape:`,
+    `  {"label":"important|later|news","confidence":0.0-1.0,"reason":"<8-word phrase>"}`,
+    ``,
+    `Confidence calibration:`,
+    `  0.9+  obvious case (signature human conversation, clear newsletter)`,
+    `  0.6+  reasonable signal but not certain`,
+    `  <0.6  genuine ambiguity — Lambda will default to "later" anyway`,
+    ``,
+    `Heuristics (in priority order):`,
+    `  1. Spam pretends to be urgent. External senders shouting "URGENT" without a thread or prior contact → almost always later.`,
+    `  2. Internal threads from this user's org (${userInternalDomain}) get the benefit of the doubt.`,
+    `  3. Single-recipient direct mail from a real person beats broadcast/list mail.`,
+    `  4. Numeric-sender domains, "noreply", "donotreply", marketing patterns → news.`,
+    `  5. Calendar invites are not in scope here — Gmail's own system handles those.`,
+    ``,
+    `User's configured rules for context (already attempted and didn't match — you are the fallback):`,
+    `  VIP senders: ${vip}`,
+    `  Muted senders: ${muted}`,
+    `  Keyword rules:`,
+    `${keywords}`,
+  ].join("\n");
+}
+
+function buildUserPrompt(features: EmailFeatures): string {
+  // Keep this small — Nova Micro is cheap per token but we still want
+  // throughput at scale. Truncate to ~1500 chars max.
+  const snippet =
+    features.snippetLower.length > 400
+      ? features.snippetLower.slice(0, 400) + "…"
+      : features.snippetLower;
+  return [
+    `From: ${features.fromEmail} (${features.isInternal ? "internal" : "external"})`,
+    `Subject: ${features.subject}`,
+    `Snippet: ${snippet}`,
+    `Has-prior-reply-from-user: ${features.hasUserReply}`,
+  ].join("\n");
+}
+
+/**
+ * Parse the model's one-line JSON output. Tolerant of: surrounding
+ * markdown fences (some Nova outputs wrap JSON in ```), extra whitespace,
+ * the model adding a trailing period.
+ *
+ * Always returns a valid decision — falls back to `later` confidence=0
+ * on any parse failure rather than throwing.
+ */
+export function parseLLMOutput(text: string): LLMDecision {
+  if (!text) return { label: "later", confidence: 0, reason: "empty-llm-output" };
+  let cleaned = text.trim();
+  // Strip markdown code fences if present.
+  cleaned = cleaned.replace(/^```(?:json)?\s*/i, "").replace(/```\s*$/, "").trim();
+  // Strip a possible trailing period after the closing brace.
+  cleaned = cleaned.replace(/}\s*\.\s*$/, "}");
+  // Find the JSON object within (model might prepend a stray "answer:").
+  const firstBrace = cleaned.indexOf("{");
+  const lastBrace = cleaned.lastIndexOf("}");
+  if (firstBrace < 0 || lastBrace <= firstBrace) {
+    return { label: "later", confidence: 0, reason: `unparseable: ${text.slice(0, 80)}` };
+  }
+  const jsonSlice = cleaned.slice(firstBrace, lastBrace + 1);
+  let parsed: { label?: string; confidence?: number; reason?: string };
+  try {
+    parsed = JSON.parse(jsonSlice);
+  } catch {
+    return { label: "later", confidence: 0, reason: `unparseable: ${text.slice(0, 80)}` };
+  }
+  const label: Label =
+    parsed.label === "important" || parsed.label === "later" || parsed.label === "news"
+      ? parsed.label
+      : "later";
+  const confidence =
+    typeof parsed.confidence === "number" && parsed.confidence >= 0 && parsed.confidence <= 1
+      ? parsed.confidence
+      : 0;
+  const reason = typeof parsed.reason === "string" ? parsed.reason.slice(0, 120) : "no-reason";
+  return { label, confidence, reason };
+}

--- a/infra/lambdas/agent-triage-poll/memory.test.ts
+++ b/infra/lambdas/agent-triage-poll/memory.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from "bun:test";
+import { extractSection } from "./memory";
+
+describe("extractSection", () => {
+  test("finds 'Email Triage → Life OS Task Creation' under any heading depth", () => {
+    const md = [
+      "## Other Section",
+      "Some content.",
+      "",
+      "### Email Triage → Life OS Task Creation",
+      "Run gh issue create --repo krishagel/life-os --label status:inbox",
+      "",
+      "## Next Section",
+      "Other stuff.",
+    ].join("\n");
+    const section = extractSection(md);
+    expect(section).toContain("gh issue create");
+    expect(section).not.toContain("Other Section");
+    expect(section).not.toContain("Next Section");
+  });
+
+  test("returns null when no matching heading", () => {
+    const md = "## Random\nNothing relevant here.";
+    expect(extractSection(md)).toBeNull();
+  });
+
+  test("includes nested deeper subsections", () => {
+    const md = [
+      "## Email Triage → Task Creation",
+      "Body line 1.",
+      "",
+      "### Sub-detail",
+      "Sub body.",
+      "",
+      "## Next Top-Level",
+      "Other.",
+    ].join("\n");
+    const section = extractSection(md);
+    expect(section).toContain("Body line 1");
+    expect(section).toContain("Sub-detail");
+    expect(section).toContain("Sub body");
+    expect(section).not.toContain("Next Top-Level");
+  });
+
+  test("matches arrow variants and case-insensitive", () => {
+    const md = "### EMAIL TRIAGE -> TASK CREATION\nDo stuff.";
+    expect(extractSection(md)).toContain("Do stuff");
+  });
+});

--- a/infra/lambdas/agent-triage-poll/memory.ts
+++ b/infra/lambdas/agent-triage-poll/memory.ts
@@ -1,0 +1,119 @@
+/**
+ * Pull the user's MEMORY.md from their S3 workspace and extract the
+ * "Email Triage" section. The Lambda passes that section verbatim into
+ * the AgentCore prompt so the agent uses the user's own task-creation
+ * instructions instead of guessing from its loaded skills.
+ *
+ * Why this lives in the Lambda (and not "let the agent read it"):
+ * the agent's behavior around MEMORY.md is inconsistent — sometimes it
+ * reads it, sometimes it falls back to whatever skill is loaded (which
+ * was creating Google Tasks for hagelk despite Life OS being the user's
+ * configured system). Reading the relevant section here and embedding
+ * it in the prompt makes the user's intent inescapable.
+ */
+
+import { GetObjectCommand, S3Client } from "@aws-sdk/client-s3";
+
+const REGION = process.env.AWS_REGION ?? "us-east-1";
+const BUCKET = process.env.WORKSPACE_BUCKET ?? "";
+
+let s3Client: S3Client | null = null;
+function s3(): S3Client {
+  if (!s3Client) s3Client = new S3Client({ region: REGION });
+  return s3Client;
+}
+
+interface CacheEntry {
+  section: string | null;
+  fetchedAt: number;
+}
+const cache = new Map<string, CacheEntry>();
+const CACHE_TTL_MS = 5 * 60_000;
+
+/**
+ * Heading patterns the user can use to mark the section. Match any of
+ * these (case-insensitive) — we want to be tolerant of slight wording
+ * differences across users.
+ */
+const SECTION_HEADERS = [
+  /^#{1,4}\s*email\s*triage\s*→\s*(?:life\s*os\s*)?task\s*creation/i,
+  /^#{1,4}\s*email\s*triage\s*->.*task\s*creation/i,
+  /^#{1,4}\s*email\s*triage\s+task\s+creation/i,
+  /^#{1,4}\s*psd-email-triage\s+task\s+request/i,
+  /^#{1,4}\s*task\s+creation\s+from\s+email/i,
+];
+
+/**
+ * Fetch the user's MEMORY.md and return the "Email Triage" section's
+ * body (everything from the matching heading until the next heading of
+ * equal-or-lower depth, exclusive of headings themselves).
+ *
+ * Returns null if:
+ *   - WORKSPACE_BUCKET env var isn't set (deploy misconfig)
+ *   - workspacePrefix is empty
+ *   - MEMORY.md doesn't exist
+ *   - No matching section heading found
+ *
+ * Caller treats null as "user hasn't configured task instructions" and
+ * surfaces a clear FAILED reason instead of letting the agent guess.
+ */
+export async function fetchTaskInstructions(
+  workspacePrefix: string,
+): Promise<string | null> {
+  if (!BUCKET || !workspacePrefix) return null;
+
+  const cached = cache.get(workspacePrefix);
+  if (cached && Date.now() - cached.fetchedAt < CACHE_TTL_MS) {
+    return cached.section;
+  }
+
+  let body: string;
+  try {
+    const resp = await s3().send(
+      new GetObjectCommand({
+        Bucket: BUCKET,
+        Key: `${workspacePrefix}/MEMORY.md`,
+      }),
+    );
+    if (!resp.Body) {
+      cache.set(workspacePrefix, { section: null, fetchedAt: Date.now() });
+      return null;
+    }
+    body = await resp.Body.transformToString();
+  } catch {
+    cache.set(workspacePrefix, { section: null, fetchedAt: Date.now() });
+    return null;
+  }
+
+  const section = extractSection(body);
+  cache.set(workspacePrefix, { section, fetchedAt: Date.now() });
+  return section;
+}
+
+export function extractSection(markdown: string): string | null {
+  const lines = markdown.split(/\r?\n/);
+  let startIdx = -1;
+  let startDepth = 0;
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    for (const pat of SECTION_HEADERS) {
+      if (pat.test(line)) {
+        startIdx = i + 1;
+        startDepth = (line.match(/^#+/) ?? [""])[0].length;
+        break;
+      }
+    }
+    if (startIdx >= 0) break;
+  }
+  if (startIdx < 0) return null;
+
+  let endIdx = lines.length;
+  for (let i = startIdx; i < lines.length; i++) {
+    const m = lines[i].match(/^(#+)\s/);
+    if (m && m[1].length <= startDepth) {
+      endIdx = i;
+      break;
+    }
+  }
+  return lines.slice(startIdx, endIdx).join("\n").trim() || null;
+}

--- a/infra/lambdas/agent-triage-poll/package.json
+++ b/infra/lambdas/agent-triage-poll/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "agent-triage-poll",
+  "version": "1.0.0",
+  "description": "Email triage classifier — every 5 minutes, fetches Gmail history for opted-in users, classifies new mail via deterministic rules + Bedrock Nova Micro, applies labels, detects user-driven label changes as training signals, posts Chat escalations.",
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "tsc",
+    "prebuild": "rm -rf dist"
+  },
+  "dependencies": {
+    "@aws-sdk/client-bedrock-agentcore": "^3.1052.0",
+    "@aws-sdk/client-bedrock-runtime": "^3.0.0",
+    "@aws-sdk/client-dynamodb": "^3.0.0",
+    "@aws-sdk/client-s3": "^3.0.0",
+    "@aws-sdk/client-secrets-manager": "^3.0.0",
+    "@aws-sdk/client-ssm": "^3.1052.0",
+    "@aws-sdk/lib-dynamodb": "^3.0.0",
+    "@googleapis/chat": "^5.0.0"
+  },
+  "devDependencies": {
+    "@types/aws-lambda": "^8.10.145",
+    "@types/node": "^20.0.0",
+    "typescript": "^5.0.0"
+  }
+}

--- a/infra/lambdas/agent-triage-poll/rules.test.ts
+++ b/infra/lambdas/agent-triage-poll/rules.test.ts
@@ -1,0 +1,221 @@
+/**
+ * Unit tests for the deterministic rule engine.
+ *
+ * Run: bun test rules.test.ts
+ */
+import { describe, expect, test } from "bun:test";
+
+import {
+  applyRules,
+  shouldEscalate,
+  wildcardMatch,
+  type EmailFeatures,
+  type TriageRules,
+  type EscalationConfig,
+} from "./rules";
+
+function makeFeatures(overrides: Partial<EmailFeatures> = {}): EmailFeatures {
+  return {
+    fromEmail: "alice@psd401.net",
+    fromDomain: "psd401.net",
+    isInternal: true,
+    subject: "Hi",
+    subjectLower: "hi",
+    snippetLower: "just checking in",
+    hasUserReply: false,
+    ...overrides,
+  };
+}
+
+const emptyRules: TriageRules = {
+  vipSenders: [],
+  muteSenders: [],
+  keywordRules: [],
+};
+
+describe("wildcardMatch", () => {
+  test("exact match", () => {
+    expect(wildcardMatch("hi@example.com", "hi@example.com")).toBe(true);
+  });
+  test("case insensitive", () => {
+    expect(wildcardMatch("Hi@Example.com", "hi@example.com")).toBe(true);
+  });
+  test("prefix wildcard", () => {
+    expect(wildcardMatch("noreply@*", "noreply@github.com")).toBe(true);
+    expect(wildcardMatch("noreply@*", "kris@github.com")).toBe(false);
+  });
+  test("suffix wildcard", () => {
+    expect(wildcardMatch("*.psd401.net", "mail.psd401.net")).toBe(true);
+    expect(wildcardMatch("*.psd401.net", "psd401.net")).toBe(false);
+  });
+  test("middle wildcard", () => {
+    expect(wildcardMatch("alerts*@datadog.com", "alerts-noreply@datadog.com")).toBe(true);
+  });
+  test("empty inputs are false", () => {
+    expect(wildcardMatch("", "a")).toBe(false);
+    expect(wildcardMatch("a", "")).toBe(false);
+  });
+});
+
+describe("applyRules", () => {
+  test("undecided when no rules match", () => {
+    const r = applyRules(makeFeatures(), emptyRules);
+    expect(r).toEqual({ decided: false, reason: "no-rule-match" });
+  });
+
+  test("vip sender → important", () => {
+    const r = applyRules(
+      makeFeatures({ fromEmail: "ceo@psd401.net" }),
+      { ...emptyRules, vipSenders: ["ceo@psd401.net"] },
+    );
+    expect(r).toMatchObject({ label: "important", source: "rule" });
+  });
+
+  test("mute sender → later (wildcard)", () => {
+    const r = applyRules(
+      makeFeatures({ fromEmail: "noreply@github.com", fromDomain: "github.com" }),
+      { ...emptyRules, muteSenders: ["noreply@*"] },
+    );
+    expect(r).toMatchObject({ label: "later", source: "rule" });
+  });
+
+  test("vip beats mute when sender appears in both", () => {
+    const r = applyRules(
+      makeFeatures({ fromEmail: "ceo@psd401.net" }),
+      {
+        ...emptyRules,
+        vipSenders: ["ceo@psd401.net"],
+        muteSenders: ["*@psd401.net"],
+      },
+    );
+    expect(r).toMatchObject({ label: "important" });
+  });
+
+  test("user-replied thread → important (no other rule needed)", () => {
+    const r = applyRules(
+      makeFeatures({ hasUserReply: true }),
+      emptyRules,
+    );
+    expect(r).toMatchObject({ label: "important", reason: "thread:user-replied-here" });
+  });
+
+  test("user-replied thread loses to mute (we still hide noise)", () => {
+    const r = applyRules(
+      makeFeatures({
+        fromEmail: "noreply@github.com",
+        fromDomain: "github.com",
+        hasUserReply: true,
+      }),
+      { ...emptyRules, muteSenders: ["noreply@*"] },
+    );
+    expect(r).toMatchObject({ label: "later" });
+  });
+
+  test("keyword rule: subject contains 'newsletter' → news", () => {
+    const r = applyRules(
+      makeFeatures({ subject: "Daily Newsletter", subjectLower: "daily newsletter" }),
+      {
+        ...emptyRules,
+        keywordRules: [{ subject_contains: "newsletter", label: "news" }],
+      },
+    );
+    expect(r).toMatchObject({ label: "news" });
+  });
+
+  test("external+keyword: external sender with 'urgent' → later", () => {
+    const r = applyRules(
+      makeFeatures({
+        fromEmail: "blast@spammy.co",
+        fromDomain: "spammy.co",
+        isInternal: false,
+        subjectLower: "urgent: act now",
+      }),
+      {
+        ...emptyRules,
+        keywordRules: [
+          {
+            subject_contains: "urgent",
+            external: true,
+            label: "later",
+          },
+        ],
+      },
+    );
+    expect(r).toMatchObject({ label: "later" });
+  });
+
+  test("rule with only `external` (no positive criterion) does NOT match", () => {
+    const r = applyRules(
+      makeFeatures({ isInternal: false }),
+      {
+        ...emptyRules,
+        keywordRules: [{ external: true, label: "later" }],
+      },
+    );
+    expect(r).toEqual({ decided: false, reason: "no-rule-match" });
+  });
+
+  test("first matching keyword rule wins", () => {
+    const r = applyRules(
+      makeFeatures({ subjectLower: "newsletter — urgent action" }),
+      {
+        ...emptyRules,
+        keywordRules: [
+          { subject_contains: "newsletter", label: "news" },
+          { subject_contains: "urgent", label: "later" },
+        ],
+      },
+    );
+    expect(r).toMatchObject({ label: "news" });
+  });
+});
+
+describe("shouldEscalate", () => {
+  const base: EscalationConfig = {
+    senders: [],
+    keywords: [],
+    labelTriggers: ["important"],
+  };
+
+  test("non-important labels never escalate", () => {
+    expect(shouldEscalate("later", makeFeatures(), base)).toEqual({ escalate: false });
+    expect(shouldEscalate("news", makeFeatures(), base)).toEqual({ escalate: false });
+  });
+
+  test("important + empty sender/keyword lists → escalate (label-only trigger)", () => {
+    const r = shouldEscalate("important", makeFeatures(), base);
+    expect(r).toMatchObject({ escalate: true, reason: "label:important" });
+  });
+
+  test("important + sender in escalation list → escalate", () => {
+    const r = shouldEscalate(
+      "important",
+      makeFeatures({ fromEmail: "ceo@psd401.net" }),
+      { ...base, senders: ["ceo@psd401.net"] },
+    );
+    expect(r).toMatchObject({ escalate: true, reason: "sender:ceo@psd401.net" });
+  });
+
+  test("important + sender NOT in list (list non-empty) → no escalate", () => {
+    const r = shouldEscalate(
+      "important",
+      makeFeatures({ fromEmail: "intern@psd401.net" }),
+      { ...base, senders: ["ceo@psd401.net"] },
+    );
+    expect(r).toEqual({ escalate: false });
+  });
+
+  test("important + subject contains escalation keyword → escalate", () => {
+    const r = shouldEscalate(
+      "important",
+      makeFeatures({ subjectLower: "p0: outage" }),
+      { ...base, keywords: ["p0"] },
+    );
+    expect(r).toMatchObject({ escalate: true, reason: "keyword:p0" });
+  });
+
+  test("important label not in labelTriggers → no escalate", () => {
+    const r = shouldEscalate("important", makeFeatures(), { ...base, labelTriggers: [] });
+    expect(r).toEqual({ escalate: false });
+  });
+});

--- a/infra/lambdas/agent-triage-poll/rules.ts
+++ b/infra/lambdas/agent-triage-poll/rules.ts
@@ -1,0 +1,213 @@
+/**
+ * Deterministic rule engine for the email triage classifier.
+ *
+ * Runs FIRST on every incoming email — most messages have an unambiguous
+ * answer (VIP sender, known noreply, newsletter, etc.) and we shouldn't
+ * pay a Bedrock call for them. Only when this returns `undecided` does
+ * the Lambda fall through to the LLM classifier.
+ *
+ * Kept in its own file so it's trivially unit-testable without an AWS
+ * SDK or Gmail mock — pure functions in, label decision out.
+ */
+
+export type Label = "important" | "later" | "news";
+
+export interface EmailFeatures {
+  /** Sender's email address, lowercased. */
+  fromEmail: string;
+  /** Domain portion of the sender (after `@`), lowercased. */
+  fromDomain: string;
+  /** True when the sender's domain matches the user's organisation. */
+  isInternal: boolean;
+  /** Subject line, raw (case preserved for matching). */
+  subject: string;
+  /** Lowercased subject, for case-insensitive matching. */
+  subjectLower: string;
+  /** Body snippet (first ~200 chars), lowercased. */
+  snippetLower: string;
+  /** True when there's a prior thread the user has participated in. */
+  hasUserReply: boolean;
+}
+
+export interface KeywordRule {
+  /** Whole subject substring match, lowercased. */
+  subject_contains?: string;
+  /** Body snippet substring match, lowercased. */
+  snippet_contains?: string;
+  /** Sender domain match. */
+  from_domain?: string;
+  /** Require the sender to be external (not in user's org). */
+  external?: boolean;
+  /** Label to apply when this rule matches. */
+  label: Label;
+}
+
+export interface TriageRules {
+  /** Exact sender addresses (lowercased) that always go to `important`. */
+  vipSenders: string[];
+  /**
+   * Sender patterns to auto-archive (label as `later` then UI hides via
+   * filter). Each entry is a string with optional `*` wildcards. The
+   * wildcard is matched against email and domain.
+   */
+  muteSenders: string[];
+  /** Keyword rules applied in order; first match wins. */
+  keywordRules: KeywordRule[];
+}
+
+export type RuleDecision =
+  | { label: Label; reason: string; source: "rule" }
+  | { decided: false; reason: string };
+
+/**
+ * Apply deterministic rules in priority order:
+ *   1. VIP sender → important
+ *   2. Mute sender → later
+ *   3. User has prior reply in thread → important (we infer engagement)
+ *   4. Keyword rules → first match
+ *   5. Otherwise → undecided (caller invokes LLM)
+ */
+export function applyRules(
+  features: EmailFeatures,
+  rules: TriageRules,
+): RuleDecision {
+  // VIPs are exact-match (no wildcards) — explicit, fast.
+  if (rules.vipSenders.includes(features.fromEmail)) {
+    return {
+      label: "important",
+      reason: `vip:${features.fromEmail}`,
+      source: "rule",
+    };
+  }
+
+  // Mute matches against email or domain with `*` wildcards. Patterns
+  // are compiled lazily — we expect each list to be small (< 50
+  // entries) so per-message regex compile is fine.
+  for (const pattern of rules.muteSenders) {
+    if (
+      wildcardMatch(pattern, features.fromEmail) ||
+      wildcardMatch(pattern, features.fromDomain)
+    ) {
+      return {
+        label: "later",
+        reason: `mute:${pattern}`,
+        source: "rule",
+      };
+    }
+  }
+
+  // Thread participation: if the user has previously replied in this
+  // thread (Gmail's `SENT` label appearing in history), the new message
+  // is highly likely to matter. Strong signal — beats keyword rules.
+  if (features.hasUserReply) {
+    return {
+      label: "important",
+      reason: "thread:user-replied-here",
+      source: "rule",
+    };
+  }
+
+  // Keyword rules — first match wins.
+  for (const rule of rules.keywordRules) {
+    if (matchesKeywordRule(rule, features)) {
+      const desc =
+        rule.subject_contains
+          ? `subject~"${rule.subject_contains}"`
+          : rule.snippet_contains
+            ? `snippet~"${rule.snippet_contains}"`
+            : rule.from_domain
+              ? `from_domain=${rule.from_domain}`
+              : "rule";
+      return {
+        label: rule.label,
+        reason: `keyword:${desc}`,
+        source: "rule",
+      };
+    }
+  }
+
+  return { decided: false, reason: "no-rule-match" };
+}
+
+function matchesKeywordRule(
+  rule: KeywordRule,
+  features: EmailFeatures,
+): boolean {
+  if (rule.external && features.isInternal) return false;
+  if (rule.from_domain && features.fromDomain !== rule.from_domain.toLowerCase()) {
+    return false;
+  }
+  if (
+    rule.subject_contains &&
+    !features.subjectLower.includes(rule.subject_contains.toLowerCase())
+  ) {
+    return false;
+  }
+  if (
+    rule.snippet_contains &&
+    !features.snippetLower.includes(rule.snippet_contains.toLowerCase())
+  ) {
+    return false;
+  }
+  // Require at least one positive criterion — a rule with only an
+  // `external` filter would match everything external; that's almost
+  // certainly a misconfiguration, so we refuse to match.
+  return Boolean(
+    rule.from_domain || rule.subject_contains || rule.snippet_contains,
+  );
+}
+
+/**
+ * Tiny wildcard matcher: `*` matches any run of characters, anchored at
+ * both ends. Case-insensitive. Used for `noreply@*` and `*.vendor.com`
+ * shapes that users will hand-write — full regex would be overkill and
+ * footgun-prone.
+ */
+export function wildcardMatch(pattern: string, value: string): boolean {
+  if (!pattern || !value) return false;
+  const p = pattern.toLowerCase();
+  const v = value.toLowerCase();
+  if (!p.includes("*")) return p === v;
+  // Escape regex special chars except `*`, then turn `*` into `.*`.
+  const escaped = p.replace(/[-/\\^$+?.()|[\]{}]/g, "\\$&").replace(/\*/g, ".*");
+  return new RegExp(`^${escaped}$`).test(v);
+}
+
+/**
+ * Decide whether a classified message should escalate to a Chat ping.
+ * Independent of the labeling decision so the user can tune them
+ * separately.
+ */
+export interface EscalationConfig {
+  senders: string[];
+  keywords: string[];
+  labelTriggers: Label[];
+}
+
+export function shouldEscalate(
+  label: Label,
+  features: EmailFeatures,
+  escalation: EscalationConfig,
+): { escalate: true; reason: string } | { escalate: false } {
+  if (!escalation.labelTriggers.includes(label)) {
+    return { escalate: false };
+  }
+  if (escalation.senders.includes(features.fromEmail)) {
+    return { escalate: true, reason: `sender:${features.fromEmail}` };
+  }
+  for (const kw of escalation.keywords) {
+    const kwLower = kw.toLowerCase();
+    if (
+      features.subjectLower.includes(kwLower) ||
+      features.snippetLower.includes(kwLower)
+    ) {
+      return { escalate: true, reason: `keyword:${kw}` };
+    }
+  }
+  // If labelTriggers is set but no sender/keyword match, the LABEL alone
+  // is the trigger. This is the "everything important pings me" default.
+  if (escalation.senders.length === 0 && escalation.keywords.length === 0) {
+    return { escalate: true, reason: `label:${label}` };
+  }
+  return { escalate: false };
+}

--- a/infra/lambdas/agent-triage-poll/storage.ts
+++ b/infra/lambdas/agent-triage-poll/storage.ts
@@ -1,0 +1,381 @@
+/**
+ * DynamoDB helpers for the triage table — Document Client wrapper
+ * around the table created in agent-platform-stack.ts.
+ *
+ * One row per user. Read-modify-write isn't atomic but it doesn't need
+ * to be: the classifier Lambda is the only writer for the cursor/decision
+ * fields (5-min schedule, single writer), and the agent skill is the
+ * only writer for rules/escalation (per-user, low frequency).
+ */
+
+import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
+import {
+  DynamoDBDocumentClient,
+  GetCommand,
+  ScanCommand,
+  UpdateCommand,
+} from "@aws-sdk/lib-dynamodb";
+
+import type {
+  CorrectionRecord,
+  DecisionRecord,
+  TriageRow,
+} from "./types";
+
+const TABLE = process.env.TRIAGE_TABLE ?? "";
+
+let cached: DynamoDBDocumentClient | null = null;
+function ddb(): DynamoDBDocumentClient {
+  if (!cached) {
+    cached = DynamoDBDocumentClient.from(
+      new DynamoDBClient({ region: process.env.AWS_REGION ?? "us-east-1" }),
+      { marshallOptions: { removeUndefinedValues: true, convertClassInstanceToMap: true } },
+    );
+  }
+  return cached;
+}
+
+/**
+ * Scan all rows with `enabled = true`. At 1000-user scale this is one
+ * page of <100 KB — paginate just in case it grows past the 1 MB scan
+ * page size.
+ */
+export async function listEnabledUsers(): Promise<TriageRow[]> {
+  const rows: TriageRow[] = [];
+  let lastKey: Record<string, unknown> | undefined;
+  do {
+    const resp = await ddb().send(
+      new ScanCommand({
+        TableName: TABLE,
+        FilterExpression: "enabled = :t",
+        ExpressionAttributeValues: { ":t": true },
+        ExclusiveStartKey: lastKey,
+      }),
+    );
+    rows.push(...((resp.Items ?? []) as TriageRow[]));
+    lastKey = resp.LastEvaluatedKey;
+  } while (lastKey);
+  return rows;
+}
+
+export async function getTriageRow(userEmail: string): Promise<TriageRow | null> {
+  const resp = await ddb().send(
+    new GetCommand({ TableName: TABLE, Key: { userEmail } }),
+  );
+  return (resp.Item as TriageRow) ?? null;
+}
+
+const USERS_TABLE = process.env.USERS_TABLE ?? "";
+
+/**
+ * Find a user's googleIdentity from the agent users table by email.
+ * Used by the @psd/Task gesture path to resolve a DM space when one
+ * isn't cached on the triage row yet. Returns null when the user has
+ * never been registered (shouldn't happen for enabled triage users,
+ * but be defensive).
+ */
+export async function getGoogleIdentityForEmail(
+  email: string,
+): Promise<string | null> {
+  const profile = await getUserProfile(email);
+  return profile?.googleIdentity ?? null;
+}
+
+/**
+ * Look up a user's full profile from the agent users table by email.
+ * Returns `workspacePrefix` (the S3 prefix the agent mounts) and
+ * `googleIdentity` (the Chat user resource name). Result is cached
+ * for 5 minutes per email to avoid hammering DDB on every gesture.
+ *
+ * `workspacePrefix` is the actual S3 prefix (e.g. `hagelk-db0f32b5`,
+ * NOT just the local-part of the email). Deriving it from the email
+ * loses the random suffix — bug observed 2026-05-22 when MEMORY.md
+ * couldn't be fetched.
+ */
+const profileCache = new Map<string, { profile: UserProfile | null; t: number }>();
+const PROFILE_TTL_MS = 5 * 60_000;
+
+export interface UserProfile {
+  googleIdentity?: string;
+  workspacePrefix?: string;
+}
+
+export async function getUserProfile(email: string): Promise<UserProfile | null> {
+  if (!USERS_TABLE) return null;
+  const cached = profileCache.get(email);
+  if (cached && Date.now() - cached.t < PROFILE_TTL_MS) return cached.profile;
+  // Paginate the scan — DynamoDB applies FilterExpression AFTER the
+  // page read, so a Limit:1 with a filter often returns 0 items even
+  // when the table contains a match (bug 2026-05-22: hagelk's row was
+  // past the first scan page). Iterate pages until we find a match.
+  const lowered = email.toLowerCase();
+  let lastKey: Record<string, unknown> | undefined;
+  let item: UserProfile | undefined;
+  do {
+    const resp = await ddb().send(
+      new ScanCommand({
+        TableName: USERS_TABLE,
+        FilterExpression: "email = :e",
+        ExpressionAttributeValues: { ":e": lowered },
+        ExclusiveStartKey: lastKey,
+      }),
+    );
+    if (resp.Items && resp.Items.length > 0) {
+      item = resp.Items[0] as UserProfile;
+      break;
+    }
+    lastKey = resp.LastEvaluatedKey;
+  } while (lastKey);
+  const profile = item
+    ? {
+        googleIdentity: item.googleIdentity,
+        workspacePrefix: item.workspacePrefix,
+      }
+    : null;
+  profileCache.set(email, { profile, t: Date.now() });
+  return profile;
+}
+
+/**
+ * Atomically claim a task gesture for processing. Writes
+ * `taskGestureClaims.<messageId> = nowIso` only if the messageId isn't
+ * already claimed (or its claim is older than `ttlMinutes`).
+ *
+ * Returns true if the claim was acquired (caller should proceed with
+ * AgentCore invocation), false if someone else already holds it
+ * (caller should skip).
+ *
+ * This is the durable defense against the 2026-05-22 duplicate-task
+ * loop: AgentCore takes ~100s, Gmail's history.list returns the same
+ * labelsAdded event in the next tick's window, and we have no other
+ * way to know "we already started on this." With the claim, even if
+ * concurrency=1 fails or the cursor doesn't advance fast enough, the
+ * second attempt sees the existing claim and bails.
+ */
+export async function claimTaskGesture(
+  userEmail: string,
+  messageId: string,
+  ttlMinutes = 30,
+): Promise<boolean> {
+  const nowIso = new Date().toISOString();
+  const ttlCutoffIso = new Date(Date.now() - ttlMinutes * 60_000).toISOString();
+  try {
+    await ddb().send(
+      new UpdateCommand({
+        TableName: TABLE,
+        Key: { userEmail },
+        UpdateExpression:
+          "SET taskGestureClaims.#mid = :now",
+        ConditionExpression:
+          "attribute_not_exists(taskGestureClaims) OR " +
+          "attribute_not_exists(taskGestureClaims.#mid) OR " +
+          "taskGestureClaims.#mid < :ttl",
+        ExpressionAttributeNames: { "#mid": messageId },
+        ExpressionAttributeValues: { ":now": nowIso, ":ttl": ttlCutoffIso },
+      }),
+    );
+    return true;
+  } catch (err) {
+    // ConditionalCheckFailed means someone else holds it.
+    if ((err as { name?: string }).name === "ConditionalCheckFailedException") {
+      return false;
+    }
+    // The claims map doesn't exist yet — initialize it then retry.
+    if (
+      (err as { name?: string }).name === "ValidationException" &&
+      String((err as Error).message).includes("document path")
+    ) {
+      await ddb().send(
+        new UpdateCommand({
+          TableName: TABLE,
+          Key: { userEmail },
+          UpdateExpression:
+            "SET taskGestureClaims = if_not_exists(taskGestureClaims, :empty)",
+          ExpressionAttributeValues: { ":empty": {} },
+        }),
+      );
+      return claimTaskGesture(userEmail, messageId, ttlMinutes);
+    }
+    throw err;
+  }
+}
+
+/**
+ * Release a claim that didn't result in a successful task creation, so
+ * the next tick (or a manual re-label by the user) can retry cleanly.
+ * Only successes should keep the claim — failures aren't a real
+ * downstream side-effect to dedupe.
+ */
+export async function releaseTaskGestureClaim(
+  userEmail: string,
+  messageId: string,
+): Promise<void> {
+  try {
+    await ddb().send(
+      new UpdateCommand({
+        TableName: TABLE,
+        Key: { userEmail },
+        UpdateExpression: "REMOVE taskGestureClaims.#mid",
+        ExpressionAttributeNames: { "#mid": messageId },
+      }),
+    );
+  } catch {
+    // Best-effort — if the path doesn't exist or the attribute is gone,
+    // there's nothing to release. Don't throw.
+  }
+}
+
+/** Persist a freshly-resolved DM space resource name onto the triage row. */
+export async function backfillDmSpaceName(
+  userEmail: string,
+  dmSpaceName: string,
+): Promise<void> {
+  await ddb().send(
+    new UpdateCommand({
+      TableName: TABLE,
+      Key: { userEmail },
+      UpdateExpression: "SET dmSpaceName = :s",
+      ExpressionAttributeValues: { ":s": dmSpaceName },
+    }),
+  );
+}
+
+/**
+ * Update the cursor and append to the rolling decisions/corrections
+ * arrays. We use DynamoDB list_append + a separate trimming step so the
+ * arrays stay at most ~20 elements long.
+ *
+ * Calls UpdateItem twice when trimming is needed: once to append, once
+ * to slice. The two-step is fine because the classifier Lambda is the
+ * only writer for these fields — no one else races us.
+ */
+export async function recordPollResult(
+  userEmail: string,
+  cursorUpdate: {
+    lastHistoryId: string;
+    lastPollAt: string;
+  },
+  newDecisions: DecisionRecord[],
+  newCorrections: CorrectionRecord[],
+): Promise<void> {
+  const RECENT_MAX = 20;
+
+  // Append + cursor update in one call so the cursor moves only when
+  // we successfully recorded what we did at this cursor.
+  if (newDecisions.length > 0 || newCorrections.length > 0) {
+    await ddb().send(
+      new UpdateCommand({
+        TableName: TABLE,
+        Key: { userEmail },
+        UpdateExpression: [
+          "SET lastHistoryId = :h",
+          "lastPollAt = :p",
+          newDecisions.length > 0
+            ? "recentDecisions = list_append(if_not_exists(recentDecisions, :empty), :d)"
+            : null,
+          newCorrections.length > 0
+            ? "recentCorrections = list_append(if_not_exists(recentCorrections, :empty), :c)"
+            : null,
+        ]
+          .filter(Boolean)
+          .join(", "),
+        ExpressionAttributeValues: {
+          ":h": cursorUpdate.lastHistoryId,
+          ":p": cursorUpdate.lastPollAt,
+          ":empty": [],
+          ...(newDecisions.length > 0 ? { ":d": newDecisions } : {}),
+          ...(newCorrections.length > 0 ? { ":c": newCorrections } : {}),
+        },
+      }),
+    );
+    // Re-read and trim — separate call because DynamoDB doesn't have an
+    // atomic "append then truncate to last N" primitive. Cost: one extra
+    // RU per poll-with-new-decisions. Fine at our scale.
+    const row = await getTriageRow(userEmail);
+    if (row) {
+      const trimmedDecisions = (row.recentDecisions ?? []).slice(-RECENT_MAX);
+      const trimmedCorrections = (row.recentCorrections ?? []).slice(-RECENT_MAX);
+      if (
+        trimmedDecisions.length < (row.recentDecisions ?? []).length ||
+        trimmedCorrections.length < (row.recentCorrections ?? []).length
+      ) {
+        await ddb().send(
+          new UpdateCommand({
+            TableName: TABLE,
+            Key: { userEmail },
+            UpdateExpression: "SET recentDecisions = :d, recentCorrections = :c",
+            ExpressionAttributeValues: {
+              ":d": trimmedDecisions,
+              ":c": trimmedCorrections,
+            },
+          }),
+        );
+      }
+    }
+  } else {
+    // Nothing happened — just advance the cursor so we don't re-scan
+    // the same empty window next time.
+    await ddb().send(
+      new UpdateCommand({
+        TableName: TABLE,
+        Key: { userEmail },
+        UpdateExpression: "SET lastHistoryId = :h, lastPollAt = :p",
+        ExpressionAttributeValues: {
+          ":h": cursorUpdate.lastHistoryId,
+          ":p": cursorUpdate.lastPollAt,
+        },
+      }),
+    );
+  }
+}
+
+/**
+ * Mark a single message as having had a task successfully created.
+ * Stored on a separate attribute so the lookup by messageId is O(1).
+ * Used by the @psd/Task gesture path (Phase 1.5) — when the user
+ * re-labels a message, we DO want to re-create a task (matches the
+ * "removing and re-adding is a deliberate fresh gesture" rule), so
+ * this isn't a dedup key; it's just an audit trail.
+ */
+export async function recordTaskCreated(
+  userEmail: string,
+  messageId: string,
+  taskRef: string,
+  ts: string,
+): Promise<void> {
+  await ddb().send(
+    new UpdateCommand({
+      TableName: TABLE,
+      Key: { userEmail },
+      UpdateExpression:
+        "SET recentTaskCreations = list_append(if_not_exists(recentTaskCreations, :empty), :entry)",
+      ExpressionAttributeValues: {
+        ":empty": [],
+        ":entry": [{ messageId, taskRef, ts }],
+      },
+    }),
+  );
+}
+
+/**
+ * Hard-reset the cursor — used when Gmail rejects our startHistoryId
+ * as too old (>7 days retention) and we have to re-anchor to "now."
+ * We log a warning so the operator dashboard can show "this user
+ * stopped getting classified for N days, just recovered."
+ */
+export async function resetCursor(
+  userEmail: string,
+  freshHistoryId: string,
+): Promise<void> {
+  await ddb().send(
+    new UpdateCommand({
+      TableName: TABLE,
+      Key: { userEmail },
+      UpdateExpression: "SET lastHistoryId = :h, lastPollAt = :p, cursorResetAt = :p",
+      ExpressionAttributeValues: {
+        ":h": freshHistoryId,
+        ":p": new Date().toISOString(),
+      },
+    }),
+  );
+}

--- a/infra/lambdas/agent-triage-poll/storage.ts
+++ b/infra/lambdas/agent-triage-poll/storage.ts
@@ -12,6 +12,7 @@ import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
 import {
   DynamoDBDocumentClient,
   GetCommand,
+  QueryCommand,
   ScanCommand,
   UpdateCommand,
 } from "@aws-sdk/lib-dynamodb";
@@ -104,28 +105,44 @@ export async function getUserProfile(email: string): Promise<UserProfile | null>
   if (!USERS_TABLE) return null;
   const cached = profileCache.get(email);
   if (cached && Date.now() - cached.t < PROFILE_TTL_MS) return cached.profile;
-  // Paginate the scan — DynamoDB applies FilterExpression AFTER the
-  // page read, so a Limit:1 with a filter often returns 0 items even
-  // when the table contains a match (bug 2026-05-22: hagelk's row was
-  // past the first scan page). Iterate pages until we find a match.
+  // Use the email-index GSI (same as agent-router's resolveUserByEmailPrefix)
+  // instead of a full-table Scan. O(1) vs O(N) and avoids the multi-page
+  // pagination bug that hit Scan on 2026-05-22.
   const lowered = email.toLowerCase();
-  let lastKey: Record<string, unknown> | undefined;
   let item: UserProfile | undefined;
-  do {
+  try {
     const resp = await ddb().send(
-      new ScanCommand({
+      new QueryCommand({
         TableName: USERS_TABLE,
-        FilterExpression: "email = :e",
+        IndexName: "email-index",
+        KeyConditionExpression: "email = :e",
         ExpressionAttributeValues: { ":e": lowered },
-        ExclusiveStartKey: lastKey,
+        Limit: 1,
       }),
     );
     if (resp.Items && resp.Items.length > 0) {
       item = resp.Items[0] as UserProfile;
-      break;
     }
-    lastKey = resp.LastEvaluatedKey;
-  } while (lastKey);
+  } catch {
+    // Fall back to Scan if GSI doesn't exist (e.g., local dev). This
+    // preserves backward compatibility while preferring the fast path.
+    let lastKey: Record<string, unknown> | undefined;
+    do {
+      const resp = await ddb().send(
+        new ScanCommand({
+          TableName: USERS_TABLE,
+          FilterExpression: "email = :e",
+          ExpressionAttributeValues: { ":e": lowered },
+          ExclusiveStartKey: lastKey,
+        }),
+      );
+      if (resp.Items && resp.Items.length > 0) {
+        item = resp.Items[0] as UserProfile;
+        break;
+      }
+      lastKey = resp.LastEvaluatedKey;
+    } while (lastKey);
+  }
   const profile = item
     ? {
         googleIdentity: item.googleIdentity,
@@ -156,6 +173,7 @@ export async function claimTaskGesture(
   userEmail: string,
   messageId: string,
   ttlMinutes = 30,
+  _depth = 0,
 ): Promise<boolean> {
   const nowIso = new Date().toISOString();
   const ttlCutoffIso = new Date(Date.now() - ttlMinutes * 60_000).toISOString();
@@ -181,7 +199,10 @@ export async function claimTaskGesture(
       return false;
     }
     // The claims map doesn't exist yet — initialize it then retry.
+    // Depth guard prevents infinite recursion if the init + retry
+    // both fail for an unexpected reason.
     if (
+      _depth < 1 &&
       (err as { name?: string }).name === "ValidationException" &&
       String((err as Error).message).includes("document path")
     ) {
@@ -194,7 +215,7 @@ export async function claimTaskGesture(
           ExpressionAttributeValues: { ":empty": {} },
         }),
       );
-      return claimTaskGesture(userEmail, messageId, ttlMinutes);
+      return claimTaskGesture(userEmail, messageId, ttlMinutes, _depth + 1);
     }
     throw err;
   }

--- a/infra/lambdas/agent-triage-poll/storage.ts
+++ b/infra/lambdas/agent-triage-poll/storage.ts
@@ -364,6 +364,8 @@ export async function recordTaskCreated(
   taskRef: string,
   ts: string,
 ): Promise<void> {
+  const RECENT_MAX = 20;
+  // Append the new entry.
   await ddb().send(
     new UpdateCommand({
       TableName: TABLE,
@@ -376,6 +378,23 @@ export async function recordTaskCreated(
       },
     }),
   );
+  // Trim to keep at most RECENT_MAX entries (same rolling-window pattern
+  // as recentDecisions/recentCorrections in recordPollResult).
+  const row = await getTriageRow(userEmail);
+  if (row) {
+    const current = (row as unknown as { recentTaskCreations?: unknown[] }).recentTaskCreations ?? [];
+    if (current.length > RECENT_MAX) {
+      const trimmed = current.slice(-RECENT_MAX);
+      await ddb().send(
+        new UpdateCommand({
+          TableName: TABLE,
+          Key: { userEmail },
+          UpdateExpression: "SET recentTaskCreations = :t",
+          ExpressionAttributeValues: { ":t": trimmed },
+        }),
+      );
+    }
+  }
 }
 
 /**

--- a/infra/lambdas/agent-triage-poll/tsconfig.json
+++ b/infra/lambdas/agent-triage-poll/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "lib": ["ES2022"],
+    "outDir": "./dist",
+    "rootDir": "./",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "moduleResolution": "node",
+    "declaration": false,
+    "sourceMap": true,
+    "types": ["node"]
+  },
+  "include": ["*.ts"],
+  "exclude": ["node_modules", "dist", "*.test.ts"]
+}

--- a/infra/lambdas/agent-triage-poll/types.ts
+++ b/infra/lambdas/agent-triage-poll/types.ts
@@ -86,7 +86,13 @@ export interface DecisionRecord {
 export interface CorrectionRecord {
   messageId: string;
   fromLabel: Label;
-  toLabel: Label | "inbox";
+  /**
+   * Where the user moved the message:
+   *   "inbox"    — un-archived (added INBOX back) something we labelled later/news
+   *   "archived" — archived (removed INBOX) something we labelled important
+   *   Label      — directly re-labelled to one of our three slots
+   */
+  toLabel: Label | "inbox" | "archived";
   ts: string;
 }
 

--- a/infra/lambdas/agent-triage-poll/types.ts
+++ b/infra/lambdas/agent-triage-poll/types.ts
@@ -1,0 +1,114 @@
+/**
+ * Shared types for the triage classifier Lambda.
+ *
+ * Mirrors the DynamoDB row shape defined in
+ * infra/lib/agent-platform-stack.ts (AgentEmailTriageTable). Keep both
+ * in sync when adding new attributes.
+ */
+
+import type { Label, TriageRules, EscalationConfig } from "./rules";
+
+export type { Label, TriageRules, EscalationConfig };
+
+/**
+ * Label keys present in the DDB row. The three classifier-assignable
+ * labels (`Label` type from rules) plus `"task"` which is user-only —
+ * applied by the human in Gmail and never by the classifier itself.
+ */
+export type LabelKey = Label | "task";
+
+/** Modes for the user-gesture task-creation feature (Phase 1.5). */
+export type TasksMode = "none" | "invoke-agent";
+
+export interface TriageRow {
+  userEmail: string;
+  enabled: boolean;
+  enabledAt?: string;
+  disabledAt?: string | null;
+  classifierStartHistoryId?: string;
+  lastHistoryId?: string;
+  lastPollAt?: string;
+  labels: Partial<Record<LabelKey, string>>;
+  labelIdsByKey: Partial<Record<LabelKey, string>>;
+  rules: TriageRules;
+  escalation: EscalationConfig;
+  digestEnabled: boolean;
+  digestTime?: string;
+  digestTz?: string;
+  digestScheduleArn?: string;
+  recentDecisions: DecisionRecord[];
+  recentCorrections: CorrectionRecord[];
+  learnedPatterns?: LearnedPattern[];
+  /** Internal-domain hint, set on enable from the user's email. */
+  internalDomain?: string;
+  /** Chat DM space resource name, set on enable when known. */
+  dmSpaceName?: string;
+  /**
+   * Task-gesture feature: when the user labels an email with `@psd/Task`,
+   * what does the system do?
+   *   - `none`      — leave the message in the @psd/Task label, do nothing
+   *   - `invoke-agent` — fire AgentCore with the email metadata so the
+   *     user's agent (per their MEMORY.md instructions + skills) creates
+   *     a task in their preferred task system. On success the email is
+   *     archived (INBOX + @psd/Task removed).
+   *
+   * Default: `none`. Set via the agent skill (`triage tasks mode …`).
+   */
+  tasksMode?: TasksMode;
+  /**
+   * When task-creation succeeds, post a one-line confirmation card to
+   * Chat. Defaults to `false`; user can flip on while building trust in
+   * the workflow. Failures always surface in Chat regardless.
+   */
+  tasksNotifySuccess?: boolean;
+  /**
+   * AgentCore Runtime ID to invoke for task-creation requests. Comes
+   * from the AGENTCORE_RUNTIME_ID env var if absent on the row (the
+   * Lambda falls back to env). Stored on the row so future per-user
+   * runtime pinning is possible without code changes.
+   */
+  agentcoreRuntimeId?: string;
+}
+
+export interface DecisionRecord {
+  messageId: string;
+  threadId: string;
+  label: Label;
+  source: "rule" | "llm";
+  reason: string;
+  confidence: number;
+  ts: string;
+  /** Snapshot of sender + subject so we can show training context later. */
+  fromEmail: string;
+  subject: string;
+}
+
+export interface CorrectionRecord {
+  messageId: string;
+  fromLabel: Label;
+  toLabel: Label | "inbox";
+  ts: string;
+}
+
+export interface LearnedPattern {
+  pattern: string;
+  weight: number;
+  source: string;
+}
+
+export interface GmailMessageMeta {
+  id: string;
+  threadId: string;
+  fromEmail: string;
+  subject: string;
+  snippet: string;
+  internalDate: string;
+  labelIds: string[];
+}
+
+export interface ClassifierResult {
+  label: Label;
+  confidence: number;
+  reason: string;
+  source: "rule" | "llm";
+}

--- a/infra/lambdas/agent-triage-poll/workspace-token.ts
+++ b/infra/lambdas/agent-triage-poll/workspace-token.ts
@@ -1,0 +1,201 @@
+/**
+ * Per-user Google Workspace OAuth token helper for AWS Lambdas.
+ *
+ * COPY of /lib/agent/workspace-token.ts. The Lambda's bundle step uses
+ * `lambda.Code.fromAsset` on this per-Lambda directory, so cross-tree
+ * TypeScript imports don't survive the bundle. Same pattern the
+ * rich-envelope helper uses across the router + cron Lambdas. Keep
+ * this file byte-identical to the canonical copy (except this header).
+ *
+ * Mirrors the runtime semantics of the agent container's
+ * `infra/agent-image/skills/psd-workspace/common.js` so a Lambda can mint a
+ * fresh access token from the same Secrets Manager slot the skill reads
+ * from. Keep all three byte-equivalent in behavior:
+ *   - same secret naming (`psd-agent-creds/<env>/user/<email>/<slot>`)
+ *   - same refresh-token grant flow against accounts.google.com
+ *   - same `invalid_grant` surfacing so callers can mark a user as
+ *     needing re-consent
+ *
+ * Why a parallel implementation rather than a literal shared file: the
+ * container skill is JS running under Node 20 with a different bundling
+ * boundary; the Lambdas bundle their own ESM/CJS. Going through a single
+ * shared module would require a build-time copy step that's more pain
+ * than maintaining two ~40-line implementations.
+ *
+ * Used by:
+ *   infra/lambdas/agent-triage-poll/
+ *   infra/lambdas/agent-triage-digest/
+ *
+ * NOT used by Next.js server actions today (those have their own
+ * Drizzle-tangled OAuth callback flow). Could be in future if we want a
+ * single source of truth for refresh; for now Phase 1 keeps them
+ * separate to avoid a Next.js → Lambda refactor risk.
+ */
+
+import {
+  SecretsManagerClient,
+  GetSecretValueCommand,
+  ResourceNotFoundException,
+} from "@aws-sdk/client-secrets-manager";
+
+export type WorkspaceSlotKind = "agent_account" | "user_account";
+
+export interface WorkspaceTokenRecord {
+  refresh_token: string;
+  granted_scopes: string[];
+  obtained_at: string;
+}
+
+export interface OAuthClientCredentials {
+  client_id: string;
+  client_secret: string;
+}
+
+export interface FreshAccessToken {
+  access_token: string;
+  expires_in: number;
+  scope?: string;
+}
+
+/**
+ * Build the Secrets Manager id for a user's workspace token. Matches the
+ * shape the OAuth callback writes (actions/agent-workspace.actions.ts) and
+ * the shape the agent skill reads (psd-workspace/common.js).
+ */
+export function workspaceSecretId(
+  userEmail: string,
+  env: string,
+  kind: WorkspaceSlotKind = "agent_account",
+): string {
+  const slot =
+    kind === "user_account" ? "google-workspace-user" : "google-workspace";
+  return `psd-agent-creds/${env}/user/${userEmail}/${slot}`;
+}
+
+/**
+ * Build the Secrets Manager id for the shared OAuth client credentials.
+ * One record per environment, shared across all users.
+ */
+export function oauthClientSecretId(env: string): string {
+  return `psd-agent/${env}/google-oauth-client`;
+}
+
+let cachedClient: SecretsManagerClient | null = null;
+function smClient(region: string): SecretsManagerClient {
+  if (!cachedClient) cachedClient = new SecretsManagerClient({ region });
+  return cachedClient;
+}
+
+async function getSecretJson<T>(
+  secretId: string,
+  region: string,
+): Promise<T | null> {
+  try {
+    const r = await smClient(region).send(
+      new GetSecretValueCommand({ SecretId: secretId }),
+    );
+    if (!r.SecretString) {
+      throw new Error(`Secret ${secretId} has no SecretString value`);
+    }
+    return JSON.parse(r.SecretString) as T;
+  } catch (err) {
+    if (err instanceof ResourceNotFoundException) return null;
+    throw err;
+  }
+}
+
+/**
+ * Read a user's workspace refresh-token record. Returns null when the user
+ * hasn't completed the OAuth flow for the given slot yet.
+ */
+export async function getUserWorkspaceToken(
+  userEmail: string,
+  env: string,
+  kind: WorkspaceSlotKind,
+  region: string = "us-east-1",
+): Promise<WorkspaceTokenRecord | null> {
+  return getSecretJson<WorkspaceTokenRecord>(
+    workspaceSecretId(userEmail, env, kind),
+    region,
+  );
+}
+
+/**
+ * Read the shared OAuth client credentials. Throws if the secret is
+ * missing — that's a misconfiguration the Lambda can't recover from.
+ */
+export async function getOAuthClient(
+  env: string,
+  region: string = "us-east-1",
+): Promise<OAuthClientCredentials> {
+  const r = await getSecretJson<OAuthClientCredentials>(
+    oauthClientSecretId(env),
+    region,
+  );
+  if (!r) {
+    throw new Error(
+      `OAuth client secret not found at ${oauthClientSecretId(env)} — ` +
+        "this is a configuration error, not a per-user issue.",
+    );
+  }
+  return r;
+}
+
+/**
+ * Exchange a long-lived refresh token for a short-lived access token.
+ * Throws with `(err as Error & {code: string}).code === "invalid_grant"` on
+ * revocation so the caller can disable triage for the user and surface a
+ * re-consent prompt the next time the user talks to the agent.
+ */
+export async function refreshAccessToken(
+  refreshToken: string,
+  client: OAuthClientCredentials,
+): Promise<FreshAccessToken> {
+  const body = new URLSearchParams({
+    client_id: client.client_id,
+    client_secret: client.client_secret,
+    refresh_token: refreshToken,
+    grant_type: "refresh_token",
+  });
+  const resp = await fetch("https://oauth2.googleapis.com/token", {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: body.toString(),
+  });
+  const data = (await resp.json().catch(() => ({}))) as {
+    access_token?: string;
+    expires_in?: number;
+    scope?: string;
+    error?: string;
+  };
+  if (!resp.ok || !data.access_token) {
+    const err = new Error(
+      `Google token exchange failed: ${resp.status} ${data.error ?? ""}`,
+    ) as Error & { code: string };
+    err.code = data.error ?? `http_${resp.status}`;
+    throw err;
+  }
+  return {
+    access_token: data.access_token,
+    expires_in: data.expires_in ?? 3600,
+    scope: data.scope,
+  };
+}
+
+/**
+ * Convenience: fetch the user's refresh token, exchange it, return a
+ * fresh access token. Returns null when the user hasn't consented yet
+ * (caller should prompt re-consent). Throws on `invalid_grant` so the
+ * caller can mark the user as needing re-consent.
+ */
+export async function getFreshAccessTokenForUser(
+  userEmail: string,
+  env: string,
+  kind: WorkspaceSlotKind,
+  region: string = "us-east-1",
+): Promise<FreshAccessToken | null> {
+  const tokenRecord = await getUserWorkspaceToken(userEmail, env, kind, region);
+  if (!tokenRecord) return null;
+  const client = await getOAuthClient(env, region);
+  return refreshAccessToken(tokenRecord.refresh_token, client);
+}

--- a/infra/lib/agent-platform-stack.ts
+++ b/infra/lib/agent-platform-stack.ts
@@ -1570,9 +1570,8 @@ export class AgentPlatformStack extends cdk.Stack {
     // Polls Gmail history for opted-in users every 5 minutes. For each
     // new message: deterministic rules → maybe Nova Micro fallback →
     // apply Gmail label → maybe Chat escalation. For each user-driven
-    // label change: record as training signal. See plan in
-    // /Users/hagelk/.claude/plans/everything-is-good-to-graceful-twilight.md
-    // and docs/operations/email-triage.md.
+    // label change: record as training signal.
+    // See docs/operations/email-triage.md.
     //
     // 5-minute polling is the load-bearing primitive for Phase 1. Phase 2
     // (#996) adds Gmail push subscriptions for sub-minute escalation
@@ -1732,9 +1731,10 @@ export class AgentPlatformStack extends cdk.Stack {
         },
       ),
       memorySize: 1024,
-      // 5 minutes — we batch up to 1000 users per tick and need
-      // headroom for slow Gmail / Bedrock calls. Phase 2 fans out
-      // wide enough to drop this to ~2 minutes.
+      // 5 minutes — processes enabled users in parallel batches of
+      // TRIAGE_USER_BATCH (10). At ~90s per user for task gestures
+      // and <1s for classify-only, the budget handles the current
+      // rollout size. Phase 2 will fan out wider to reduce this.
       timeout: cdk.Duration.minutes(5),
       role: triagePollRole,
       logGroup: triagePollLogGroup,
@@ -2650,7 +2650,7 @@ export class AgentPlatformStack extends cdk.Stack {
       environment,
       region: this.region,
       account: this.account,
-      vpcEnabled: false,
+      vpcEnabled: true,
       additionalPolicies: [
         new iam.PolicyDocument({
           statements: [new iam.PolicyStatement({
@@ -2662,9 +2662,6 @@ export class AgentPlatformStack extends cdk.Stack {
         }),
       ],
     });
-    pruneLambdaRole.addManagedPolicy(
-      iam.ManagedPolicy.fromAwsManagedPolicyName('service-role/AWSLambdaVPCAccessExecutionRole'),
-    );
 
     const pruneLogGroup = new logs.LogGroup(this, 'AgentTelemetryPruneLogGroup', {
       logGroupName: `/aws/lambda/psd-agent-telemetry-prune-${environment}`,
@@ -2731,11 +2728,13 @@ export class AgentPlatformStack extends cdk.Stack {
     cdk.Tags.of(pruneLambda).add('Environment', environment);
     cdk.Tags.of(pruneLambda).add('ManagedBy', 'cdk');
 
-    new events.Rule(this, 'AgentTelemetryPruneSchedule', {
+    const pruneSchedule = new events.Rule(this, 'AgentTelemetryPruneSchedule', {
       description: 'Daily 04:00 UTC — prune agent_message_content + agent_tool_invocations older than 90 days',
       schedule: events.Schedule.cron({ minute: '0', hour: '4' }),
       targets: [new eventsTargets.LambdaFunction(pruneLambda)],
     });
+    cdk.Tags.of(pruneSchedule).add('Environment', environment);
+    cdk.Tags.of(pruneSchedule).add('ManagedBy', 'cdk');
 
     // =====================================================================
     // 9c. Bundled-Skill Initializer Lambda + Custom Resource

--- a/infra/lib/agent-platform-stack.ts
+++ b/infra/lib/agent-platform-stack.ts
@@ -2650,12 +2650,16 @@ export class AgentPlatformStack extends cdk.Stack {
     // radius of the deep-telemetry tables. Aggregated summaries in
     // agent_messages stay forever — only the bulky content/tool-call data
     // is pruned. Daily, 04:00 UTC.
+    // vpcEnabled: false — VPC access added manually via managed policy below
+    // to avoid ServiceRoleFactory's policy validator flagging the ec2 ENI
+    // wildcard resources required for VPC-attached Lambdas. Same workaround
+    // as the pattern-scanner Lambda above.
     const pruneLambdaRole = ServiceRoleFactory.createLambdaRole(this, 'AgentTelemetryPruneRole', {
       functionName: 'psd-agent-telemetry-prune',
       environment,
       region: this.region,
       account: this.account,
-      vpcEnabled: true,
+      vpcEnabled: false,
       additionalPolicies: [
         new iam.PolicyDocument({
           statements: [new iam.PolicyStatement({
@@ -2667,6 +2671,9 @@ export class AgentPlatformStack extends cdk.Stack {
         }),
       ],
     });
+    pruneLambdaRole.addManagedPolicy(
+      iam.ManagedPolicy.fromAwsManagedPolicyName('service-role/AWSLambdaVPCAccessExecutionRole'),
+    );
 
     const pruneLogGroup = new logs.LogGroup(this, 'AgentTelemetryPruneLogGroup', {
       logGroupName: `/aws/lambda/psd-agent-telemetry-prune-${environment}`,
@@ -2792,12 +2799,15 @@ export class AgentPlatformStack extends cdk.Stack {
       return out;
     })();
 
+    // vpcEnabled: false — VPC access added manually via managed policy below
+    // to avoid ServiceRoleFactory's wildcard-ENI policy validator. Same
+    // pattern as the pattern-scanner + telemetry-prune Lambdas.
     const skillInitLambdaRole = ServiceRoleFactory.createLambdaRole(this, 'AgentSkillInitializerRole', {
       functionName: 'psd-agent-skill-initializer',
       environment,
       region: this.region,
       account: this.account,
-      vpcEnabled: true,
+      vpcEnabled: false,
       additionalPolicies: [
         new iam.PolicyDocument({
           statements: [new iam.PolicyStatement({
@@ -2809,6 +2819,9 @@ export class AgentPlatformStack extends cdk.Stack {
         }),
       ],
     });
+    skillInitLambdaRole.addManagedPolicy(
+      iam.ManagedPolicy.fromAwsManagedPolicyName('service-role/AWSLambdaVPCAccessExecutionRole'),
+    );
 
     const skillInitLogGroup = new logs.LogGroup(this, 'AgentSkillInitializerLogGroup', {
       logGroupName: `/aws/lambda/psd-agent-skill-initializer-${environment}`,

--- a/infra/lib/agent-platform-stack.ts
+++ b/infra/lib/agent-platform-stack.ts
@@ -2626,8 +2626,12 @@ export class AgentPlatformStack extends cdk.Stack {
         DATABASE_HOST: props.databaseHost,
         DATABASE_SECRET_ARN: props.databaseSecretArn,
         DATABASE_NAME: props.databaseName ?? 'aistudio',
-        MIN_SIGNALS: '3',
-        MIN_BUILDINGS: '2',
+        // Privacy suppression thresholds — patterns are only emitted when
+        // they meet these floors. Production keeps the privacy floor at
+        // 3 signals across 2 buildings; dev drops it to 1/1 so every
+        // classified signal surfaces immediately for development.
+        MIN_SIGNALS: environment === 'prod' ? '3' : '1',
+        MIN_BUILDINGS: environment === 'prod' ? '2' : '1',
         SPIKE_RATIO: '2.0',
         ROLLING_WEEKS: '4',
       },

--- a/infra/lib/agent-platform-stack.ts
+++ b/infra/lib/agent-platform-stack.ts
@@ -124,6 +124,13 @@ export class AgentPlatformStack extends cdk.Stack {
 
     const { environment, config } = props;
 
+    // Lambda function names as constants — referenced by both the
+    // runtimeEnvVars block (line ~1167) and the Lambda definitions below.
+    // Prevents silent breakage if a function name ever changes.
+    const triageDigestFunctionName = `psd-agent-triage-digest-${environment}`;
+    const cronFunctionName = `psd-agent-cron-${environment}`;
+    const skillBuilderFunctionName = `psd-agent-skill-builder-${environment}`;
+
     // Validate required ARN props at synth time to surface errors early
     // rather than waiting for opaque CloudFormation deploy-time failures.
     if (!props.guardrailArn) {
@@ -988,7 +995,7 @@ export class AgentPlatformStack extends cdk.Stack {
       effect: iam.Effect.ALLOW,
       actions: ['lambda:InvokeFunction'],
       resources: [
-        `arn:aws:lambda:${this.region}:${this.account}:function:psd-agent-skill-builder-${environment}`,
+        `arn:aws:lambda:${this.region}:${this.account}:function:${skillBuilderFunctionName}`,
       ],
     }));
 
@@ -1139,7 +1146,7 @@ export class AgentPlatformStack extends cdk.Stack {
         effect: iam.Effect.ALLOW,
         actions: ['logs:CreateLogStream', 'logs:PutLogEvents'],
         resources: [
-          `arn:aws:logs:${this.region}:${this.account}:log-group:/aws/lambda/psd-agent-cron-${environment}:*`,
+          `arn:aws:logs:${this.region}:${this.account}:log-group:/aws/lambda/${cronFunctionName}:*`,
         ],
       }),
     );
@@ -1172,18 +1179,15 @@ export class AgentPlatformStack extends cdk.Stack {
       SCHEDULES_TABLE: schedulesTable.tableName,
       TRIAGE_TABLE: this.triageTable.tableName,
       EVENTBRIDGE_SCHEDULE_GROUP: `psd-agent-${environment}`,
-      CRON_LAMBDA_ARN: `arn:aws:lambda:${this.region}:${this.account}:function:psd-agent-cron-${environment}`,
-      // Digest target for the psd-email-triage skill's `digest.*`
-      // subcommands — constructed by naming convention so we don't have
-      // to forward-declare the Lambda above this env-vars block.
-      TRIAGE_DIGEST_LAMBDA_ARN: `arn:aws:lambda:${this.region}:${this.account}:function:psd-agent-triage-digest-${environment}`,
+      CRON_LAMBDA_ARN: `arn:aws:lambda:${this.region}:${this.account}:function:${cronFunctionName}`,
+      TRIAGE_DIGEST_LAMBDA_ARN: `arn:aws:lambda:${this.region}:${this.account}:function:${triageDigestFunctionName}`,
       EVENTBRIDGE_ROLE_ARN: `arn:aws:iam::${this.account}:role/psd-agent-scheduler-invoke-${environment}`,
       GUARDRAIL_ARN: props.guardrailArn,
       DATABASE_RESOURCE_ARN: props.databaseResourceArn,
       DATABASE_SECRET_ARN: props.databaseSecretArn,
       DATABASE_NAME: props.databaseName ?? 'aistudio',
       BEDROCK_API_KEY_SECRET_ARN: this.bedrockApiKeySecret.secretArn,
-      SKILL_BUILDER_LAMBDA_ARN: `arn:aws:lambda:${this.region}:${this.account}:function:psd-agent-skill-builder-${environment}`,
+      SKILL_BUILDER_LAMBDA_ARN: `arn:aws:lambda:${this.region}:${this.account}:function:${skillBuilderFunctionName}`,
       GOOGLE_OAUTH_CLIENT_SECRET_ID: googleOAuthClientSecret.secretName,
       AGENT_INTERNAL_API_KEY_SECRET_ID: agentInternalApiKeySecret.secretName,
       APP_BASE_URL: props.appBaseUrl ?? '',
@@ -1314,7 +1318,7 @@ export class AgentPlatformStack extends cdk.Stack {
     });
 
     const skillBuilderLogGroup = new logs.LogGroup(this, 'SkillBuilderLogGroup', {
-      logGroupName: `/aws/lambda/psd-agent-skill-builder-${environment}`,
+      logGroupName: `/aws/lambda/${skillBuilderFunctionName}`,
       retention: config.monitoring.logRetention,
       removalPolicy: environment === 'prod'
         ? cdk.RemovalPolicy.RETAIN
@@ -1324,7 +1328,7 @@ export class AgentPlatformStack extends cdk.Stack {
     cdk.Tags.of(skillBuilderLogGroup).add('ManagedBy', 'cdk');
 
     const skillBuilderLambda = new lambda.Function(this, 'SkillBuilderLambda', {
-      functionName: `psd-agent-skill-builder-${environment}`,
+      functionName: skillBuilderFunctionName,
       runtime: lambda.Runtime.NODEJS_20_X,
       handler: 'index.handler',
       code: lambda.Code.fromAsset(
@@ -1397,7 +1401,7 @@ export class AgentPlatformStack extends cdk.Stack {
     // between a schedule row and an EventBridge Scheduler entry.
 
     const cronLogGroup = new logs.LogGroup(this, 'CronLogGroup', {
-      logGroupName: `/aws/lambda/psd-agent-cron-${environment}`,
+      logGroupName: `/aws/lambda/${cronFunctionName}`,
       retention: config.monitoring.logRetention,
       removalPolicy: environment === 'prod'
         ? cdk.RemovalPolicy.RETAIN
@@ -1407,7 +1411,7 @@ export class AgentPlatformStack extends cdk.Stack {
     cdk.Tags.of(cronLogGroup).add('ManagedBy', 'cdk');
 
     const cronLambda = new lambda.Function(this, 'CronLambda', {
-      functionName: `psd-agent-cron-${environment}`,
+      functionName: cronFunctionName,
       runtime: lambda.Runtime.NODEJS_20_X,
       handler: 'index.handler',
       code: lambda.Code.fromAsset(
@@ -1811,7 +1815,7 @@ export class AgentPlatformStack extends cdk.Stack {
     });
 
     const triageDigestLogGroup = new logs.LogGroup(this, 'TriageDigestLogGroup', {
-      logGroupName: `/aws/lambda/psd-agent-triage-digest-${environment}`,
+      logGroupName: `/aws/lambda/${triageDigestFunctionName}`,
       retention: config.monitoring.logRetention,
       removalPolicy: environment === 'prod'
         ? cdk.RemovalPolicy.RETAIN
@@ -1825,12 +1829,12 @@ export class AgentPlatformStack extends cdk.Stack {
       effect: iam.Effect.ALLOW,
       actions: ['logs:CreateLogStream', 'logs:PutLogEvents'],
       resources: [
-        `arn:aws:logs:${this.region}:${this.account}:log-group:/aws/lambda/psd-agent-triage-digest-${environment}:*`,
+        `arn:aws:logs:${this.region}:${this.account}:log-group:/aws/lambda/${triageDigestFunctionName}:*`,
       ],
     }));
 
     const triageDigestLambda = new lambda.Function(this, 'TriageDigestLambda', {
-      functionName: `psd-agent-triage-digest-${environment}`,
+      functionName: triageDigestFunctionName,
       runtime: lambda.Runtime.NODEJS_20_X,
       handler: 'index.handler',
       code: lambda.Code.fromAsset(

--- a/infra/lib/agent-platform-stack.ts
+++ b/infra/lib/agent-platform-stack.ts
@@ -94,6 +94,8 @@ export class AgentPlatformStack extends cdk.Stack {
   /** DynamoDB table for Chat message idempotency (dedup of retries) */
   public readonly messageDedupTable: dynamodb.Table;
   public readonly sessionLocksTable: dynamodb.Table;
+  /** DynamoDB table for per-user email triage state (Phase 1 of email triage feature) */
+  public readonly triageTable: dynamodb.Table;
   /** IAM user that owns the Bedrock API key (service-specific credential) */
   public readonly bedrockApiUser: iam.User;
   /** Secrets Manager secret carrying the Bedrock API key for Mantle auth */
@@ -320,6 +322,47 @@ export class AgentPlatformStack extends cdk.Stack {
     });
     cdk.Tags.of(this.sessionLocksTable).add('Environment', environment);
     cdk.Tags.of(this.sessionLocksTable).add('ManagedBy', 'cdk');
+
+    // 4c-bis. Email Triage table — per-user state for the smart email
+    // triage feature (Phase 1). One row per user; the row exists whether
+    // or not the user has opted in (created lazily on first enable).
+    //
+    // Attributes (not enforced at the table level, but the consumer
+    // expects):
+    //   userEmail            string  (PK)
+    //   enabled              bool
+    //   enabledAt/disabledAt ISO ts
+    //   classifierStartHistoryId string  (Gmail history cursor at enable)
+    //   lastHistoryId        string  (cursor, updated every poll)
+    //   lastPollAt           ISO ts
+    //   labels               map<key,string>   (e.g. important → "@psd/Important")
+    //   labelIdsByKey        map<key,string>   (Gmail label IDs, cached)
+    //   rules                map<…>
+    //   escalation           map<…>
+    //   digestEnabled        bool
+    //   digestTime           "HH:MM"
+    //   digestTz             IANA tz
+    //   digestScheduleArn    string  (EventBridge Scheduler entry, for delete)
+    //   recentDecisions      list<map> (rolling 20)
+    //   recentCorrections    list<map> (rolling 20)
+    //   learnedPatterns      list<map> (populated in Phase 2)
+    //
+    // PITR ON: rules are user-curated and learned patterns accumulate over
+    // weeks — losing them on accidental table deletion would be a real
+    // regression. Pay-per-request keeps cost negligible at single-user
+    // scale and elastic for the planned 1000-user rollout.
+    this.triageTable = new dynamodb.Table(this, 'AgentEmailTriageTable', {
+      tableName: `psd-agent-triage-${environment}`,
+      partitionKey: { name: 'userEmail', type: dynamodb.AttributeType.STRING },
+      billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
+      encryption: dynamodb.TableEncryption.AWS_MANAGED,
+      pointInTimeRecoverySpecification: { pointInTimeRecoveryEnabled: true },
+      removalPolicy: environment === 'prod'
+        ? cdk.RemovalPolicy.RETAIN
+        : cdk.RemovalPolicy.DESTROY,
+    });
+    cdk.Tags.of(this.triageTable).add('Environment', environment);
+    cdk.Tags.of(this.triageTable).add('ManagedBy', 'cdk');
 
     // 4d. Inter-Agent Communication table — tracks agent-to-agent messages
     // for rate limiting and anti-loop detection. Uses TTL for automatic cleanup.
@@ -799,6 +842,9 @@ export class AgentPlatformStack extends cdk.Stack {
         `${this.signalsTable.tableArn}/index/*`,
         schedulesTable.tableArn,
         `${schedulesTable.tableArn}/index/*`,
+        // Email triage state (Phase 1) — agent skill reads/writes per-user
+        // rules, label IDs, escalation lists, and recent decisions/corrections.
+        this.triageTable.tableArn,
       ],
     }));
 
@@ -1122,8 +1168,13 @@ export class AgentPlatformStack extends cdk.Stack {
       USERS_TABLE: this.usersTable.tableName,
       SIGNALS_TABLE: this.signalsTable.tableName,
       SCHEDULES_TABLE: schedulesTable.tableName,
+      TRIAGE_TABLE: this.triageTable.tableName,
       EVENTBRIDGE_SCHEDULE_GROUP: `psd-agent-${environment}`,
       CRON_LAMBDA_ARN: `arn:aws:lambda:${this.region}:${this.account}:function:psd-agent-cron-${environment}`,
+      // Digest target for the psd-email-triage skill's `digest.*`
+      // subcommands — constructed by naming convention so we don't have
+      // to forward-declare the Lambda above this env-vars block.
+      TRIAGE_DIGEST_LAMBDA_ARN: `arn:aws:lambda:${this.region}:${this.account}:function:psd-agent-triage-digest-${environment}`,
       EVENTBRIDGE_ROLE_ARN: `arn:aws:iam::${this.account}:role/psd-agent-scheduler-invoke-${environment}`,
       GUARDRAIL_ARN: props.guardrailArn,
       DATABASE_RESOURCE_ARN: props.databaseResourceArn,
@@ -1510,6 +1561,329 @@ export class AgentPlatformStack extends cdk.Stack {
         },
       },
     }));
+
+    // =====================================================================
+    // 7d. Email Triage Classifier Lambda — psd-agent-triage-poll
+    // =====================================================================
+    // Polls Gmail history for opted-in users every 5 minutes. For each
+    // new message: deterministic rules → maybe Nova Micro fallback →
+    // apply Gmail label → maybe Chat escalation. For each user-driven
+    // label change: record as training signal. See plan in
+    // /Users/hagelk/.claude/plans/everything-is-good-to-graceful-twilight.md
+    // and docs/operations/email-triage.md.
+    //
+    // 5-minute polling is the load-bearing primitive for Phase 1. Phase 2
+    // (#996) adds Gmail push subscriptions for sub-minute escalation
+    // latency; polling stays as the fallback there.
+    const triagePollRole = ServiceRoleFactory.createLambdaRole(this, 'TriagePollLambdaRole', {
+      functionName: 'psd-agent-triage-poll',
+      environment,
+      region: this.region,
+      account: this.account,
+      vpcEnabled: false,
+      // ServiceRoleFactory grants base DynamoDB CRUD on the named tables;
+      // the additional resources policy below covers per-user OAuth
+      // secrets and Bedrock invocation.
+      dynamodbTables: [this.usersTable.tableName, this.triageTable.tableName],
+      additionalPolicies: [
+        // Per-user OAuth refresh tokens + the shared OAuth client creds.
+        // Wildcard on per-user path because we evaluate every opted-in
+        // user each tick and don't know the set in advance.
+        new iam.PolicyDocument({
+          statements: [new iam.PolicyStatement({
+            sid: 'WorkspaceTokenRead',
+            effect: iam.Effect.ALLOW,
+            actions: ['secretsmanager:GetSecretValue'],
+            resources: [
+              `arn:aws:secretsmanager:${this.region}:${this.account}:secret:psd-agent-creds/${environment}/user/*`,
+              `arn:aws:secretsmanager:${this.region}:${this.account}:secret:psd-agent/${environment}/google-oauth-client-*`,
+              this.googleCredentialsSecret.secretArn,
+            ],
+          })],
+        }),
+        // Bedrock Nova Micro for the LLM fallback path.
+        //
+        // Cross-region inference profiles (`us.*` prefix) route the actual
+        // model invocation to whichever underlying region has capacity —
+        // observed us-west-2 in production (2026-05-22 incident: every
+        // call returned 403 because the policy only granted us-east-1).
+        // Use wildcard region on the foundation-model resource so the
+        // inference profile's downstream invocations are authorised
+        // regardless of where AWS routes them. Inference-profile resource
+        // stays scoped to this region/account because the profile itself
+        // is regional.
+        new iam.PolicyDocument({
+          statements: [new iam.PolicyStatement({
+            sid: 'BedrockNovaMicroInvoke',
+            effect: iam.Effect.ALLOW,
+            actions: ['bedrock:InvokeModel', 'bedrock:Converse'],
+            resources: [
+              `arn:aws:bedrock:*::foundation-model/amazon.nova-micro-v1:0`,
+              `arn:aws:bedrock:*::foundation-model/us.amazon.nova-micro-v1:0`,
+              `arn:aws:bedrock:${this.region}:${this.account}:inference-profile/us.amazon.nova-micro-v1:0`,
+              // Haiku as the documented fallback if Nova Micro quality is poor —
+              // grant now so swap-in doesn't require an IAM change. Same
+              // cross-region wildcard for the same reason as nova-micro.
+              `arn:aws:bedrock:*::foundation-model/anthropic.claude-3-5-haiku-20241022-v1:0`,
+              `arn:aws:bedrock:${this.region}:${this.account}:inference-profile/us.anthropic.claude-3-5-haiku-20241022-v1:0`,
+            ],
+          })],
+        }),
+        // AgentCore Runtime invocation — Phase 1.5 @psd/Task gesture
+        // hands off to the user's agent (per their MEMORY.md
+        // instructions + skills) to create a task in their preferred
+        // task system. Scoped to all runtimes in the account/region;
+        // the per-runtime ID is set via env var.
+        new iam.PolicyDocument({
+          statements: [new iam.PolicyStatement({
+            sid: 'AgentCoreInvokeForTasks',
+            effect: iam.Effect.ALLOW,
+            actions: [
+              'bedrock-agentcore:InvokeAgentRuntime',
+              'bedrock-agentcore:InvokeAgentRuntimeForUser',
+            ],
+            resources: [
+              `arn:aws:bedrock-agentcore:${this.region}:${this.account}:runtime/*`,
+            ],
+          })],
+        }),
+        // SSM Parameter Store — same pattern the cron Lambda uses to
+        // resolve the AgentCore Runtime ID at runtime rather than
+        // pinning at deploy time.
+        new iam.PolicyDocument({
+          statements: [new iam.PolicyStatement({
+            sid: 'SSMParameterReadForRuntimeId',
+            effect: iam.Effect.ALLOW,
+            actions: ['ssm:GetParameter', 'ssm:GetParameters'],
+            resources: [
+              `arn:aws:ssm:${this.region}:${this.account}:parameter/aistudio/${environment}/*`,
+            ],
+          })],
+        }),
+      ],
+    });
+
+    const triagePollLogGroup = new logs.LogGroup(this, 'TriagePollLogGroup', {
+      logGroupName: `/aws/lambda/psd-agent-triage-poll-${environment}`,
+      retention: config.monitoring.logRetention,
+      removalPolicy: environment === 'prod'
+        ? cdk.RemovalPolicy.RETAIN
+        : cdk.RemovalPolicy.DESTROY,
+    });
+    cdk.Tags.of(triagePollLogGroup).add('Environment', environment);
+    cdk.Tags.of(triagePollLogGroup).add('ManagedBy', 'cdk');
+
+    triagePollRole.addToPolicy(new iam.PolicyStatement({
+      sid: 'TriagePollLogsCorrectArn',
+      effect: iam.Effect.ALLOW,
+      actions: ['logs:CreateLogStream', 'logs:PutLogEvents'],
+      resources: [
+        `arn:aws:logs:${this.region}:${this.account}:log-group:/aws/lambda/psd-agent-triage-poll-${environment}:*`,
+      ],
+    }));
+
+    // Read MEMORY.md from each user's S3 workspace prefix.
+    triagePollRole.addToPolicy(new iam.PolicyStatement({
+      sid: 'TriagePollReadWorkspaceMemory',
+      effect: iam.Effect.ALLOW,
+      actions: ['s3:GetObject'],
+      resources: [`${this.workspaceBucket.bucketArn}/*/MEMORY.md`],
+    }));
+
+    const triagePollLambda = new lambda.Function(this, 'TriagePollLambda', {
+      functionName: `psd-agent-triage-poll-${environment}`,
+      runtime: lambda.Runtime.NODEJS_20_X,
+      handler: 'index.handler',
+      code: lambda.Code.fromAsset(
+        path.join(__dirname, '..', 'lambdas', 'agent-triage-poll'),
+        {
+          assetHashType: cdk.AssetHashType.SOURCE,
+          bundling: {
+            image: lambda.Runtime.NODEJS_20_X.bundlingImage,
+            local: {
+              tryBundle(outputDir: string): boolean {
+                try {
+                  const inputDir = path.join(__dirname, '..', 'lambdas', 'agent-triage-poll');
+                  execSync('bun install && bunx tsc', { cwd: inputDir, stdio: 'inherit' });
+                  execSync(`cp -r dist/* ${outputDir}/`, { cwd: inputDir, stdio: 'inherit' });
+                  execSync(`cp package.json ${outputDir}/`, { cwd: inputDir, stdio: 'inherit' });
+                  execSync('bun install --production', { cwd: outputDir, stdio: 'inherit' });
+                  return true;
+                } catch (e) {
+                  // eslint-disable-next-line no-console
+                  console.error('Local bundling failed, falling back to Docker:', e);
+                  return false;
+                }
+              },
+            },
+            command: [
+              'bash', '-c',
+              [
+                'npm install',
+                'npm run build',
+                'cp -r dist/* /asset-output/',
+                'cp package.json /asset-output/',
+                'cd /asset-output && npm install --production',
+              ].join(' && '),
+            ],
+          },
+        },
+      ),
+      memorySize: 1024,
+      // 5 minutes — we batch up to 1000 users per tick and need
+      // headroom for slow Gmail / Bedrock calls. Phase 2 fans out
+      // wide enough to drop this to ~2 minutes.
+      timeout: cdk.Duration.minutes(5),
+      role: triagePollRole,
+      logGroup: triagePollLogGroup,
+      environment: {
+        ENVIRONMENT: environment,
+        TRIAGE_TABLE: this.triageTable.tableName,
+        USERS_TABLE: this.usersTable.tableName,
+        GOOGLE_CREDENTIALS_SECRET_ARN: this.googleCredentialsSecret.secretArn,
+        // Lambda reads <prefix>/MEMORY.md from this bucket to extract the
+        // user's task-creation instructions and embed them in the
+        // AgentCore prompt verbatim.
+        WORKSPACE_BUCKET: this.workspaceBucket.bucketName,
+        TRIAGE_USER_BATCH: '10',
+        // Override knob — set to 'us.anthropic.claude-3-5-haiku-...' to
+        // fall back from Nova Micro without redeploy.
+        TRIAGE_LLM_MODEL_ID: 'us.amazon.nova-micro-v1:0',
+        // AGENTCORE_RUNTIME_ID intentionally NOT set — resolved from SSM
+        // at runtime (same pattern as router/cron Lambdas). The runtime
+        // resource is created conditionally on `--context agentImageTag`
+        // so we can't reliably build the env var at deploy time.
+        // The Lambda's agentcore.ts module does the SSM lookup on cold
+        // start, caches the result, and uses it for @psd/Task gestures.
+        AWS_ACCOUNT: this.account,
+      },
+      architecture: lambda.Architecture.ARM_64,
+      // Hard concurrency cap of 1 — the Lambda processes a per-user
+      // history cursor in DDB without read-modify-write locking, so two
+      // concurrent invocations would re-process the same labelsAdded
+      // events and duplicate downstream side-effects (#duplicate-task
+      // bug observed 2026-05-22). With a 5-minute schedule and ~2-minute
+      // typical invocations this is safe; if an invocation runs long
+      // EventBridge skips the next firing rather than queuing.
+      reservedConcurrentExecutions: 1,
+    });
+    cdk.Tags.of(triagePollLambda).add('Environment', environment);
+    cdk.Tags.of(triagePollLambda).add('ManagedBy', 'cdk');
+
+    // EventBridge Rule fires the poller every 5 minutes. Rule (not
+    // Scheduler) is the right primitive for a global fixed cadence —
+    // simpler IAM + no per-invocation payload.
+    const triagePollRule = new events.Rule(this, 'TriagePollRule', {
+      ruleName: `psd-agent-triage-poll-${environment}`,
+      schedule: events.Schedule.rate(cdk.Duration.minutes(5)),
+      description: 'Every-5-minute trigger for the email triage classifier',
+    });
+    triagePollRule.addTarget(new eventsTargets.LambdaFunction(triagePollLambda));
+    cdk.Tags.of(triagePollRule).add('Environment', environment);
+    cdk.Tags.of(triagePollRule).add('ManagedBy', 'cdk');
+
+    // =====================================================================
+    // 7e. Triage Digest Lambda — psd-agent-triage-digest
+    // =====================================================================
+    // Per-user, invoked by EventBridge Scheduler at the user's configured
+    // digestTime. Renders a Chat card summarising last 24h of decisions.
+    // No LLM call — templated. Failure does not cascade.
+    const triageDigestRole = ServiceRoleFactory.createLambdaRole(this, 'TriageDigestLambdaRole', {
+      functionName: 'psd-agent-triage-digest',
+      environment,
+      region: this.region,
+      account: this.account,
+      vpcEnabled: false,
+      dynamodbTables: [this.triageTable.tableName],
+      additionalPolicies: [
+        new iam.PolicyDocument({
+          statements: [new iam.PolicyStatement({
+            sid: 'GoogleChatCredsRead',
+            effect: iam.Effect.ALLOW,
+            actions: ['secretsmanager:GetSecretValue'],
+            resources: [this.googleCredentialsSecret.secretArn],
+          })],
+        }),
+      ],
+    });
+
+    const triageDigestLogGroup = new logs.LogGroup(this, 'TriageDigestLogGroup', {
+      logGroupName: `/aws/lambda/psd-agent-triage-digest-${environment}`,
+      retention: config.monitoring.logRetention,
+      removalPolicy: environment === 'prod'
+        ? cdk.RemovalPolicy.RETAIN
+        : cdk.RemovalPolicy.DESTROY,
+    });
+    cdk.Tags.of(triageDigestLogGroup).add('Environment', environment);
+    cdk.Tags.of(triageDigestLogGroup).add('ManagedBy', 'cdk');
+
+    triageDigestRole.addToPolicy(new iam.PolicyStatement({
+      sid: 'TriageDigestLogsCorrectArn',
+      effect: iam.Effect.ALLOW,
+      actions: ['logs:CreateLogStream', 'logs:PutLogEvents'],
+      resources: [
+        `arn:aws:logs:${this.region}:${this.account}:log-group:/aws/lambda/psd-agent-triage-digest-${environment}:*`,
+      ],
+    }));
+
+    const triageDigestLambda = new lambda.Function(this, 'TriageDigestLambda', {
+      functionName: `psd-agent-triage-digest-${environment}`,
+      runtime: lambda.Runtime.NODEJS_20_X,
+      handler: 'index.handler',
+      code: lambda.Code.fromAsset(
+        path.join(__dirname, '..', 'lambdas', 'agent-triage-digest'),
+        {
+          assetHashType: cdk.AssetHashType.SOURCE,
+          bundling: {
+            image: lambda.Runtime.NODEJS_20_X.bundlingImage,
+            local: {
+              tryBundle(outputDir: string): boolean {
+                try {
+                  const inputDir = path.join(__dirname, '..', 'lambdas', 'agent-triage-digest');
+                  execSync('bun install && bunx tsc', { cwd: inputDir, stdio: 'inherit' });
+                  execSync(`cp -r dist/* ${outputDir}/`, { cwd: inputDir, stdio: 'inherit' });
+                  execSync(`cp package.json ${outputDir}/`, { cwd: inputDir, stdio: 'inherit' });
+                  execSync('bun install --production', { cwd: outputDir, stdio: 'inherit' });
+                  return true;
+                } catch (e) {
+                  // eslint-disable-next-line no-console
+                  console.error('Local bundling failed, falling back to Docker:', e);
+                  return false;
+                }
+              },
+            },
+            command: [
+              'bash', '-c',
+              [
+                'npm install',
+                'npm run build',
+                'cp -r dist/* /asset-output/',
+                'cp package.json /asset-output/',
+                'cd /asset-output && npm install --production',
+              ].join(' && '),
+            ],
+          },
+        },
+      ),
+      memorySize: 512,
+      timeout: cdk.Duration.minutes(2),
+      role: triageDigestRole,
+      logGroup: triageDigestLogGroup,
+      environment: {
+        ENVIRONMENT: environment,
+        TRIAGE_TABLE: this.triageTable.tableName,
+        GOOGLE_CREDENTIALS_SECRET_ARN: this.googleCredentialsSecret.secretArn,
+      },
+      architecture: lambda.Architecture.ARM_64,
+    });
+    cdk.Tags.of(triageDigestLambda).add('Environment', environment);
+    cdk.Tags.of(triageDigestLambda).add('ManagedBy', 'cdk');
+
+    // The digest Lambda is invoked by per-user EventBridge Scheduler
+    // entries created by the agent skill. Grant the scheduler invoke
+    // role permission to call this Lambda (same role already covers
+    // the cron Lambda) so the skill's CreateSchedule calls succeed.
+    triageDigestLambda.grantInvoke(schedulerInvokeRole);
 
     // =====================================================================
     // 8. SQS Queue — Google Chat Pub/Sub Inbound
@@ -2259,6 +2633,106 @@ export class AgentPlatformStack extends cdk.Stack {
       description: 'Weekly cross-building topic convergence scan',
       schedule: events.Schedule.cron({ minute: '0', hour: '23', weekDay: 'SUN' }),
       targets: [new eventsTargets.LambdaFunction(patternLambda)],
+    });
+
+    // =====================================================================
+    // 9b. Telemetry Retention Sweep Lambda — agent-telemetry-prune
+    // =====================================================================
+    // Deletes rows from agent_message_content + agent_tool_invocations older
+    // than RETENTION_DAYS (default 90) to bound the privacy + disk blast
+    // radius of the deep-telemetry tables. Aggregated summaries in
+    // agent_messages stay forever — only the bulky content/tool-call data
+    // is pruned. Daily, 04:00 UTC.
+    const pruneLambdaRole = ServiceRoleFactory.createLambdaRole(this, 'AgentTelemetryPruneRole', {
+      functionName: 'psd-agent-telemetry-prune',
+      environment,
+      region: this.region,
+      account: this.account,
+      vpcEnabled: false,
+      additionalPolicies: [
+        new iam.PolicyDocument({
+          statements: [new iam.PolicyStatement({
+            sid: 'AuroraConnect',
+            effect: iam.Effect.ALLOW,
+            actions: ['secretsmanager:GetSecretValue'],
+            resources: [props.databaseSecretArn],
+          })],
+        }),
+      ],
+    });
+    pruneLambdaRole.addManagedPolicy(
+      iam.ManagedPolicy.fromAwsManagedPolicyName('service-role/AWSLambdaVPCAccessExecutionRole'),
+    );
+
+    const pruneLogGroup = new logs.LogGroup(this, 'AgentTelemetryPruneLogGroup', {
+      logGroupName: `/aws/lambda/psd-agent-telemetry-prune-${environment}`,
+      retention: config.monitoring.logRetention,
+      removalPolicy: environment === 'prod'
+        ? cdk.RemovalPolicy.RETAIN
+        : cdk.RemovalPolicy.DESTROY,
+    });
+
+    const pruneLambda = new lambda.Function(this, 'AgentTelemetryPruneLambda', {
+      functionName: `psd-agent-telemetry-prune-${environment}`,
+      runtime: lambda.Runtime.NODEJS_20_X,
+      handler: 'index.handler',
+      code: lambda.Code.fromAsset(
+        path.join(__dirname, '..', 'lambdas', 'agent-telemetry-prune'),
+        {
+          assetHashType: cdk.AssetHashType.SOURCE,
+          bundling: {
+            image: lambda.Runtime.NODEJS_20_X.bundlingImage,
+            local: {
+              tryBundle(outputDir: string): boolean {
+                try {
+                  const inputDir = path.join(__dirname, '..', 'lambdas', 'agent-telemetry-prune');
+                  execSync('bun install && bunx tsc', { cwd: inputDir, stdio: 'inherit' });
+                  execSync(`cp -r dist/* ${outputDir}/`, { cwd: inputDir, stdio: 'inherit' });
+                  execSync(`cp package.json ${outputDir}/`, { cwd: inputDir, stdio: 'inherit' });
+                  execSync('bun install --production', { cwd: outputDir, stdio: 'inherit' });
+                  return true;
+                } catch (e) {
+                  // eslint-disable-next-line no-console
+                  console.error('Local bundling failed, falling back to Docker:', e);
+                  return false;
+                }
+              },
+            },
+            command: [
+              'bash', '-c',
+              [
+                'npm install', 'npm run build',
+                'cp -r dist/* /asset-output/',
+                'cp package.json /asset-output/',
+                'cd /asset-output && npm install --production',
+              ].join(' && '),
+            ],
+          },
+        },
+      ),
+      memorySize: 512,
+      timeout: cdk.Duration.minutes(10),
+      architecture: lambda.Architecture.ARM_64,
+      role: pruneLambdaRole,
+      logGroup: pruneLogGroup,
+      vpc,
+      vpcSubnets: { subnetType: ec2.SubnetType.PRIVATE_WITH_EGRESS },
+      environment: {
+        ENVIRONMENT: environment,
+        DATABASE_HOST: props.databaseHost,
+        DATABASE_SECRET_ARN: props.databaseSecretArn,
+        DATABASE_NAME: props.databaseName ?? 'aistudio',
+        RETENTION_DAYS: '90',
+        PRUNE_BATCH: '5000',
+      },
+    });
+    cdk.Tags.of(pruneLambda).add('Environment', environment);
+    cdk.Tags.of(pruneLambda).add('ManagedBy', 'cdk');
+
+    new events.Rule(this, 'AgentTelemetryPruneSchedule', {
+      description: 'Daily 04:00 UTC — prune agent_message_content + agent_tool_invocations older than 90 days',
+      schedule: events.Schedule.cron({ minute: '0', hour: '4' }),
+      targets: [new eventsTargets.LambdaFunction(pruneLambda)],
     });
 
     // =====================================================================

--- a/infra/lib/agent-platform-stack.ts
+++ b/infra/lib/agent-platform-stack.ts
@@ -24,6 +24,8 @@ import * as apigwv2Integrations from 'aws-cdk-lib/aws-apigatewayv2-integrations'
 import * as eventsTargets from 'aws-cdk-lib/aws-events-targets';
 import * as customResources from 'aws-cdk-lib/custom-resources';
 import * as path from 'path';
+import * as fs from 'fs';
+import * as crypto from 'crypto';
 import { execSync } from 'child_process';
 // ALPHA CDK CONSTRUCT: @aws-cdk/aws-bedrock-agentcore-alpha has no API stability
 // guarantee and may introduce breaking changes on any release. Version is pinned
@@ -2733,6 +2735,194 @@ export class AgentPlatformStack extends cdk.Stack {
       description: 'Daily 04:00 UTC — prune agent_message_content + agent_tool_invocations older than 90 days',
       schedule: events.Schedule.cron({ minute: '0', hour: '4' }),
       targets: [new eventsTargets.LambdaFunction(pruneLambda)],
+    });
+
+    // =====================================================================
+    // 9c. Bundled-Skill Initializer Lambda + Custom Resource
+    // =====================================================================
+    // On every deploy, walk infra/agent-image/skills/* SKILL.md frontmatter
+    // and UPSERT each skill into psd_agent_skills with scope=shared so the
+    // /admin/agents Skills tab shows the real bundled skills, not just
+    // greetings-demo. Idempotent: same manifest = no DB churn; image
+    // updates bump the s3_key → version increments.
+
+    const bundledSkillsDir = path.join(__dirname, '..', 'agent-image', 'skills');
+    interface BundledSkillManifestEntry {
+      name: string;
+      summary: string;
+      description?: string;
+      sourceHash: string;
+      imageTag: string;
+    }
+    const bundledSkillsManifest: BundledSkillManifestEntry[] = (() => {
+      if (!fs.existsSync(bundledSkillsDir)) return [];
+      const out: BundledSkillManifestEntry[] = [];
+      for (const entry of fs.readdirSync(bundledSkillsDir)) {
+        const skillMdPath = path.join(bundledSkillsDir, entry, 'SKILL.md');
+        if (!fs.existsSync(skillMdPath)) continue;
+        const raw = fs.readFileSync(skillMdPath, 'utf8');
+        const fm = raw.match(/^---\n([\s\S]*?)\n---/);
+        if (!fm) continue;
+        const lines = fm[1].split('\n');
+        let name = '';
+        let summary = '';
+        let description = '';
+        for (const line of lines) {
+          const m = line.match(/^(name|summary|description):\s*(.*)$/);
+          if (!m) continue;
+          if (m[1] === 'name') name = m[2].trim();
+          else if (m[1] === 'summary') summary = m[2].trim();
+          else if (m[1] === 'description') description = m[2].trim();
+        }
+        if (!name) continue;
+        const sourceHash = crypto.createHash('sha256').update(raw).digest('hex');
+        out.push({
+          name,
+          summary: summary || `Bundled skill: ${name}`,
+          description,
+          sourceHash,
+          // Resolved by the lambda at invoke time via env var
+          imageTag: 'unknown',
+        });
+      }
+      return out;
+    })();
+
+    const skillInitLambdaRole = ServiceRoleFactory.createLambdaRole(this, 'AgentSkillInitializerRole', {
+      functionName: 'psd-agent-skill-initializer',
+      environment,
+      region: this.region,
+      account: this.account,
+      vpcEnabled: false,
+      additionalPolicies: [
+        new iam.PolicyDocument({
+          statements: [new iam.PolicyStatement({
+            sid: 'AuroraConnect',
+            effect: iam.Effect.ALLOW,
+            actions: ['secretsmanager:GetSecretValue'],
+            resources: [props.databaseSecretArn],
+          })],
+        }),
+      ],
+    });
+    skillInitLambdaRole.addManagedPolicy(
+      iam.ManagedPolicy.fromAwsManagedPolicyName('service-role/AWSLambdaVPCAccessExecutionRole'),
+    );
+
+    const skillInitLogGroup = new logs.LogGroup(this, 'AgentSkillInitializerLogGroup', {
+      logGroupName: `/aws/lambda/psd-agent-skill-initializer-${environment}`,
+      retention: config.monitoring.logRetention,
+      removalPolicy: environment === 'prod'
+        ? cdk.RemovalPolicy.RETAIN
+        : cdk.RemovalPolicy.DESTROY,
+    });
+
+    const skillInitLambda = new lambda.Function(this, 'AgentSkillInitializerLambda', {
+      functionName: `psd-agent-skill-initializer-${environment}`,
+      runtime: lambda.Runtime.NODEJS_20_X,
+      handler: 'index.handler',
+      code: lambda.Code.fromAsset(
+        path.join(__dirname, '..', 'lambdas', 'agent-skill-initializer'),
+        {
+          assetHashType: cdk.AssetHashType.SOURCE,
+          bundling: {
+            image: lambda.Runtime.NODEJS_20_X.bundlingImage,
+            local: {
+              tryBundle(outputDir: string): boolean {
+                try {
+                  const inputDir = path.join(__dirname, '..', 'lambdas', 'agent-skill-initializer');
+                  execSync('bun install && bunx tsc', { cwd: inputDir, stdio: 'inherit' });
+                  execSync(`cp -r dist/* ${outputDir}/`, { cwd: inputDir, stdio: 'inherit' });
+                  execSync(`cp package.json ${outputDir}/`, { cwd: inputDir, stdio: 'inherit' });
+                  execSync('bun install --production', { cwd: outputDir, stdio: 'inherit' });
+                  return true;
+                } catch (e) {
+                  // eslint-disable-next-line no-console
+                  console.error('Local bundling failed, falling back to Docker:', e);
+                  return false;
+                }
+              },
+            },
+            command: [
+              'bash', '-c',
+              [
+                'npm install', 'npm run build',
+                'cp -r dist/* /asset-output/',
+                'cp package.json /asset-output/',
+                'cd /asset-output && npm install --production',
+              ].join(' && '),
+            ],
+          },
+        },
+      ),
+      memorySize: 512,
+      timeout: cdk.Duration.minutes(2),
+      architecture: lambda.Architecture.ARM_64,
+      role: skillInitLambdaRole,
+      logGroup: skillInitLogGroup,
+      vpc,
+      vpcSubnets: { subnetType: ec2.SubnetType.PRIVATE_WITH_EGRESS },
+      environment: {
+        ENVIRONMENT: environment,
+        DATABASE_HOST: props.databaseHost,
+        DATABASE_SECRET_ARN: props.databaseSecretArn,
+        DATABASE_NAME: props.databaseName ?? 'aistudio',
+      },
+    });
+    cdk.Tags.of(skillInitLambda).add('Environment', environment);
+    cdk.Tags.of(skillInitLambda).add('ManagedBy', 'cdk');
+
+    // Trigger string forces the Custom Resource to re-fire on every deploy
+    // so manifest updates land even when the Lambda code hash is unchanged.
+    const skillInitTrigger = bundledSkillsManifest
+      .map((s) => `${s.name}:${s.sourceHash.slice(0, 8)}`)
+      .sort()
+      .join(',');
+
+    const agentImageTagContext = this.node.tryGetContext('agentImageTag') ?? 'unset';
+
+    new customResources.AwsCustomResource(this, 'AgentSkillInitializerCR', {
+      onCreate: {
+        service: 'Lambda',
+        action: 'invoke',
+        parameters: {
+          FunctionName: skillInitLambda.functionName,
+          Payload: JSON.stringify({
+            RequestType: 'Create',
+            ResourceProperties: {
+              skills: bundledSkillsManifest,
+              imageTag: agentImageTagContext,
+              trigger: skillInitTrigger,
+            },
+          }),
+        },
+        physicalResourceId: customResources.PhysicalResourceId.of('agent-skill-initializer'),
+      },
+      onUpdate: {
+        service: 'Lambda',
+        action: 'invoke',
+        parameters: {
+          FunctionName: skillInitLambda.functionName,
+          Payload: JSON.stringify({
+            RequestType: 'Update',
+            ResourceProperties: {
+              skills: bundledSkillsManifest,
+              imageTag: agentImageTagContext,
+              trigger: skillInitTrigger,
+            },
+          }),
+        },
+        physicalResourceId: customResources.PhysicalResourceId.of('agent-skill-initializer'),
+      },
+      // No onDelete — bundled skills stay in the DB if the stack is destroyed.
+      // An admin can clean up via the Skills tab if they want a wipe.
+      policy: customResources.AwsCustomResourcePolicy.fromStatements([
+        new iam.PolicyStatement({
+          actions: ['lambda:InvokeFunction'],
+          resources: [skillInitLambda.functionArn],
+        }),
+      ]),
+      installLatestAwsSdk: false,
     });
 
     // =====================================================================

--- a/infra/lib/agent-platform-stack.ts
+++ b/infra/lib/agent-platform-stack.ts
@@ -1731,11 +1731,12 @@ export class AgentPlatformStack extends cdk.Stack {
         },
       ),
       memorySize: 1024,
-      // 5 minutes — processes enabled users in parallel batches of
-      // TRIAGE_USER_BATCH (10). At ~90s per user for task gestures
-      // and <1s for classify-only, the budget handles the current
-      // rollout size. Phase 2 will fan out wider to reduce this.
-      timeout: cdk.Duration.minutes(5),
+      // 4.5 minutes — 30s safety margin below the 5-minute EventBridge
+      // schedule interval. With reservedConcurrentExecutions=1, an
+      // invocation that hits the full timeout would silently drop the
+      // next scheduled firing (no retry, no DLQ). The 30s gap ensures
+      // the next invocation can start cleanly.
+      timeout: cdk.Duration.seconds(270),
       role: triagePollRole,
       logGroup: triagePollLogGroup,
       environment: {
@@ -2792,7 +2793,7 @@ export class AgentPlatformStack extends cdk.Stack {
       environment,
       region: this.region,
       account: this.account,
-      vpcEnabled: false,
+      vpcEnabled: true,
       additionalPolicies: [
         new iam.PolicyDocument({
           statements: [new iam.PolicyStatement({
@@ -2804,9 +2805,6 @@ export class AgentPlatformStack extends cdk.Stack {
         }),
       ],
     });
-    skillInitLambdaRole.addManagedPolicy(
-      iam.ManagedPolicy.fromAwsManagedPolicyName('service-role/AWSLambdaVPCAccessExecutionRole'),
-    );
 
     const skillInitLogGroup = new logs.LogGroup(this, 'AgentSkillInitializerLogGroup', {
       logGroupName: `/aws/lambda/psd-agent-skill-initializer-${environment}`,

--- a/infra/lib/constructs/ecs-service.ts
+++ b/infra/lib/constructs/ecs-service.ts
@@ -403,6 +403,33 @@ export class EcsServiceConstruct extends Construct {
                 `arn:aws:dynamodb:${cdk.Stack.of(this).region}:${cdk.Stack.of(this).account}:table/AIStudio-*-${environment}`,
               ],
             }),
+            // Agent platform tables (psd-agent-*-<env>) — the admin
+            // dashboard's Triage tab scans psd-agent-triage-<env>. Other
+            // agent platform tables (users, signals, skills) are admin
+            // read-only too. Update/Put limited to triage so the admin
+            // Pause/Reset actions in /admin/agents/[userEmail]/triage
+            // can write back; everything else is read-only.
+            new iam.PolicyStatement({
+              effect: iam.Effect.ALLOW,
+              actions: [
+                'dynamodb:GetItem',
+                'dynamodb:Query',
+                'dynamodb:Scan',
+              ],
+              resources: [
+                `arn:aws:dynamodb:${cdk.Stack.of(this).region}:${cdk.Stack.of(this).account}:table/psd-agent-*-${environment}`,
+              ],
+            }),
+            new iam.PolicyStatement({
+              effect: iam.Effect.ALLOW,
+              actions: [
+                'dynamodb:UpdateItem',
+                'dynamodb:DeleteItem',
+              ],
+              resources: [
+                `arn:aws:dynamodb:${cdk.Stack.of(this).region}:${cdk.Stack.of(this).account}:table/psd-agent-triage-${environment}`,
+              ],
+            }),
             new iam.PolicyStatement({
               effect: iam.Effect.ALLOW,
               actions: [

--- a/infra/lib/constructs/security/permission-boundaries/dev-boundary.json
+++ b/infra/lib/constructs/security/permission-boundaries/dev-boundary.json
@@ -130,7 +130,11 @@
         "route53:*",
         "cloudfront:*",
         "globalaccelerator:*",
-        "s3:*"
+        "s3:*",
+        "bedrock:InvokeModel",
+        "bedrock:InvokeModelWithResponseStream",
+        "bedrock:Converse",
+        "bedrock:ConverseStream"
       ],
       "Resource": "*",
       "Condition": {

--- a/infra/lib/constructs/security/permission-boundaries/dev-boundary.json
+++ b/infra/lib/constructs/security/permission-boundaries/dev-boundary.json
@@ -123,6 +123,7 @@
     },
     {
       "Sid": "DenyRegionRestriction",
+      "_comment": "Bedrock actions are in NotAction because cross-region inference profiles route invocations to arbitrary regions. Model access is scoped by per-Lambda resource policies, not by this boundary.",
       "Effect": "Deny",
       "NotAction": [
         "iam:*",

--- a/infra/lib/constructs/security/permission-boundaries/prod-boundary.json
+++ b/infra/lib/constructs/security/permission-boundaries/prod-boundary.json
@@ -147,7 +147,11 @@
         "route53:*",
         "cloudfront:*",
         "globalaccelerator:*",
-        "s3:*"
+        "s3:*",
+        "bedrock:InvokeModel",
+        "bedrock:InvokeModelWithResponseStream",
+        "bedrock:Converse",
+        "bedrock:ConverseStream"
       ],
       "Resource": "*",
       "Condition": {

--- a/infra/lib/constructs/security/permission-boundaries/prod-boundary.json
+++ b/infra/lib/constructs/security/permission-boundaries/prod-boundary.json
@@ -140,6 +140,7 @@
     },
     {
       "Sid": "DenyRegionRestriction",
+      "_comment": "Bedrock actions are in NotAction because cross-region inference profiles route invocations to arbitrary regions. Model access is scoped by per-Lambda resource policies, not by this boundary.",
       "Effect": "Deny",
       "NotAction": [
         "iam:*",

--- a/lib/agent/workspace-token.ts
+++ b/lib/agent/workspace-token.ts
@@ -1,0 +1,195 @@
+/**
+ * Per-user Google Workspace OAuth token helper for AWS Lambdas.
+ *
+ * Mirrors the runtime semantics of the agent container's
+ * `infra/agent-image/skills/psd-workspace/common.js` so a Lambda can mint a
+ * fresh access token from the same Secrets Manager slot the skill reads
+ * from. Keep the two byte-for-byte equivalent in behavior:
+ *   - same secret naming (`psd-agent-creds/<env>/user/<email>/<slot>`)
+ *   - same refresh-token grant flow against accounts.google.com
+ *   - same `invalid_grant` surfacing so callers can mark a user as
+ *     needing re-consent
+ *
+ * Why a parallel implementation rather than a literal shared file: the
+ * container skill is JS running under Node 20 with a different bundling
+ * boundary; the Lambdas bundle their own ESM/CJS. Going through a single
+ * shared module would require a build-time copy step that's more pain
+ * than maintaining two ~40-line implementations.
+ *
+ * Used by:
+ *   infra/lambdas/agent-triage-poll/
+ *   infra/lambdas/agent-triage-digest/
+ *
+ * NOT used by Next.js server actions today (those have their own
+ * Drizzle-tangled OAuth callback flow). Could be in future if we want a
+ * single source of truth for refresh; for now Phase 1 keeps them
+ * separate to avoid a Next.js → Lambda refactor risk.
+ */
+
+import {
+  SecretsManagerClient,
+  GetSecretValueCommand,
+  ResourceNotFoundException,
+} from "@aws-sdk/client-secrets-manager";
+
+export type WorkspaceSlotKind = "agent_account" | "user_account";
+
+export interface WorkspaceTokenRecord {
+  refresh_token: string;
+  granted_scopes: string[];
+  obtained_at: string;
+}
+
+export interface OAuthClientCredentials {
+  client_id: string;
+  client_secret: string;
+}
+
+export interface FreshAccessToken {
+  access_token: string;
+  expires_in: number;
+  scope?: string;
+}
+
+/**
+ * Build the Secrets Manager id for a user's workspace token. Matches the
+ * shape the OAuth callback writes (actions/agent-workspace.actions.ts) and
+ * the shape the agent skill reads (psd-workspace/common.js).
+ */
+export function workspaceSecretId(
+  userEmail: string,
+  env: string,
+  kind: WorkspaceSlotKind = "agent_account",
+): string {
+  const slot =
+    kind === "user_account" ? "google-workspace-user" : "google-workspace";
+  return `psd-agent-creds/${env}/user/${userEmail}/${slot}`;
+}
+
+/**
+ * Build the Secrets Manager id for the shared OAuth client credentials.
+ * One record per environment, shared across all users.
+ */
+export function oauthClientSecretId(env: string): string {
+  return `psd-agent/${env}/google-oauth-client`;
+}
+
+let cachedClient: SecretsManagerClient | null = null;
+function smClient(region: string): SecretsManagerClient {
+  if (!cachedClient) cachedClient = new SecretsManagerClient({ region });
+  return cachedClient;
+}
+
+async function getSecretJson<T>(
+  secretId: string,
+  region: string,
+): Promise<T | null> {
+  try {
+    const r = await smClient(region).send(
+      new GetSecretValueCommand({ SecretId: secretId }),
+    );
+    if (!r.SecretString) {
+      throw new Error(`Secret ${secretId} has no SecretString value`);
+    }
+    return JSON.parse(r.SecretString) as T;
+  } catch (err) {
+    if (err instanceof ResourceNotFoundException) return null;
+    throw err;
+  }
+}
+
+/**
+ * Read a user's workspace refresh-token record. Returns null when the user
+ * hasn't completed the OAuth flow for the given slot yet.
+ */
+export async function getUserWorkspaceToken(
+  userEmail: string,
+  env: string,
+  kind: WorkspaceSlotKind,
+  region: string = "us-east-1",
+): Promise<WorkspaceTokenRecord | null> {
+  return getSecretJson<WorkspaceTokenRecord>(
+    workspaceSecretId(userEmail, env, kind),
+    region,
+  );
+}
+
+/**
+ * Read the shared OAuth client credentials. Throws if the secret is
+ * missing — that's a misconfiguration the Lambda can't recover from.
+ */
+export async function getOAuthClient(
+  env: string,
+  region: string = "us-east-1",
+): Promise<OAuthClientCredentials> {
+  const r = await getSecretJson<OAuthClientCredentials>(
+    oauthClientSecretId(env),
+    region,
+  );
+  if (!r) {
+    throw new Error(
+      `OAuth client secret not found at ${oauthClientSecretId(env)} — ` +
+        "this is a configuration error, not a per-user issue.",
+    );
+  }
+  return r;
+}
+
+/**
+ * Exchange a long-lived refresh token for a short-lived access token.
+ * Throws with `(err as Error & {code: string}).code === "invalid_grant"` on
+ * revocation so the caller can disable triage for the user and surface a
+ * re-consent prompt the next time the user talks to the agent.
+ */
+export async function refreshAccessToken(
+  refreshToken: string,
+  client: OAuthClientCredentials,
+): Promise<FreshAccessToken> {
+  const body = new URLSearchParams({
+    client_id: client.client_id,
+    client_secret: client.client_secret,
+    refresh_token: refreshToken,
+    grant_type: "refresh_token",
+  });
+  const resp = await fetch("https://oauth2.googleapis.com/token", {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: body.toString(),
+  });
+  const data = (await resp.json().catch(() => ({}))) as {
+    access_token?: string;
+    expires_in?: number;
+    scope?: string;
+    error?: string;
+  };
+  if (!resp.ok || !data.access_token) {
+    const err = new Error(
+      `Google token exchange failed: ${resp.status} ${data.error ?? ""}`,
+    ) as Error & { code: string };
+    err.code = data.error ?? `http_${resp.status}`;
+    throw err;
+  }
+  return {
+    access_token: data.access_token,
+    expires_in: data.expires_in ?? 3600,
+    scope: data.scope,
+  };
+}
+
+/**
+ * Convenience: fetch the user's refresh token, exchange it, return a
+ * fresh access token. Returns null when the user hasn't consented yet
+ * (caller should prompt re-consent). Throws on `invalid_grant` so the
+ * caller can mark the user as needing re-consent.
+ */
+export async function getFreshAccessTokenForUser(
+  userEmail: string,
+  env: string,
+  kind: WorkspaceSlotKind,
+  region: string = "us-east-1",
+): Promise<FreshAccessToken | null> {
+  const tokenRecord = await getUserWorkspaceToken(userEmail, env, kind, region);
+  if (!tokenRecord) return null;
+  const client = await getOAuthClient(env, region);
+  return refreshAccessToken(tokenRecord.refresh_token, client);
+}

--- a/lib/db/schema/index.ts
+++ b/lib/db/schema/index.ts
@@ -145,6 +145,8 @@ export * from "./tables/agent-patterns";
 export * from "./tables/agent-failures";
 export * from "./tables/agent-pattern-scan-runs";
 export * from "./tables/agent-health-scan-runs";
+export * from "./tables/agent-message-content";
+export * from "./tables/agent-tool-invocations";
 
 // ============================================
 // Agent Skills Platform (#910)

--- a/lib/db/schema/tables/agent-message-content.ts
+++ b/lib/db/schema/tables/agent-message-content.ts
@@ -37,6 +37,7 @@ export const agentMessageContent = pgTable(
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
   },
   (table) => [
+    index("idx_agent_message_content_message_id").on(table.messageId),
     index("idx_agent_message_content_session").on(table.sessionId, table.createdAt),
     index("idx_agent_message_content_user").on(table.userEmail, table.createdAt),
     index("idx_agent_message_content_created_at").on(table.createdAt),

--- a/lib/db/schema/tables/agent-message-content.ts
+++ b/lib/db/schema/tables/agent-message-content.ts
@@ -1,0 +1,44 @@
+/**
+ * Agent Message Content Table Schema (migration 078).
+ *
+ * Stores the full text of every turn — user prompts, assistant replies,
+ * tool exchange messages — so the admin Conversations tab can show a
+ * complete transcript. Capped at 64KB per row by the writer; the
+ * `content_truncated` flag tells the UI when content was clipped.
+ *
+ * Retention: 90 days (enforced by the agent-telemetry-prune Lambda).
+ * The aggregated summary in `agent_messages` is kept indefinitely.
+ */
+
+import {
+  bigint,
+  boolean,
+  index,
+  pgTable,
+  text,
+  timestamp,
+  varchar,
+} from "drizzle-orm/pg-core";
+
+import { agentMessages } from "./agent-messages";
+
+export const agentMessageContent = pgTable(
+  "agent_message_content",
+  {
+    id: bigint("id", { mode: "number" }).generatedAlwaysAsIdentity().primaryKey(),
+    messageId: bigint("message_id", { mode: "number" })
+      .notNull()
+      .references(() => agentMessages.id, { onDelete: "cascade" }),
+    sessionId: varchar("session_id", { length: 512 }).notNull(),
+    userEmail: varchar("user_email", { length: 255 }).notNull(),
+    role: varchar("role", { length: 16 }).notNull(),
+    contentText: text("content_text").notNull(),
+    contentTruncated: boolean("content_truncated").notNull().default(false),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [
+    index("idx_agent_message_content_session").on(table.sessionId, table.createdAt),
+    index("idx_agent_message_content_user").on(table.userEmail, table.createdAt),
+    index("idx_agent_message_content_created_at").on(table.createdAt),
+  ],
+);

--- a/lib/db/schema/tables/agent-message-content.ts
+++ b/lib/db/schema/tables/agent-message-content.ts
@@ -30,6 +30,9 @@ export const agentMessageContent = pgTable(
       .notNull()
       .references(() => agentMessages.id, { onDelete: "cascade" }),
     sessionId: varchar("session_id", { length: 512 }).notNull(),
+    /** Stores the user's email address. Named `user_email` (vs. `user_id` in
+     *  the parent `agent_messages` table) to clarify the value is an email,
+     *  not a UUID — the legacy `user_id` column also stores email. */
     userEmail: varchar("user_email", { length: 255 }).notNull(),
     role: varchar("role", { length: 16 }).notNull(),
     contentText: text("content_text").notNull(),

--- a/lib/db/schema/tables/agent-tool-invocations.ts
+++ b/lib/db/schema/tables/agent-tool-invocations.ts
@@ -31,6 +31,9 @@ export const agentToolInvocations = pgTable(
       .notNull()
       .references(() => agentMessages.id, { onDelete: "cascade" }),
     sessionId: varchar("session_id", { length: 512 }).notNull(),
+    /** Stores the user's email address. Named `user_email` (vs. `user_id` in
+     *  the parent `agent_messages` table) to clarify the value is an email,
+     *  not a UUID — the legacy `user_id` column also stores email. */
     userEmail: varchar("user_email", { length: 255 }).notNull(),
     toolName: varchar("tool_name", { length: 255 }).notNull(),
     toolArgs: jsonb("tool_args").$type<Record<string, unknown> | null>(),

--- a/lib/db/schema/tables/agent-tool-invocations.ts
+++ b/lib/db/schema/tables/agent-tool-invocations.ts
@@ -43,6 +43,7 @@ export const agentToolInvocations = pgTable(
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
   },
   (table) => [
+    index("idx_agent_tool_invocations_message_id").on(table.messageId),
     index("idx_agent_tool_invocations_tool").on(table.toolName, table.startedAt),
     index("idx_agent_tool_invocations_session").on(table.sessionId, table.startedAt),
     index("idx_agent_tool_invocations_user").on(table.userEmail, table.startedAt),

--- a/lib/db/schema/tables/agent-tool-invocations.ts
+++ b/lib/db/schema/tables/agent-tool-invocations.ts
@@ -1,0 +1,51 @@
+/**
+ * Agent Tool Invocations Table Schema (migration 078).
+ *
+ * One row per tool call the agent made during a turn. Carries the args
+ * (JSONB), result (JSONB), status, and timing so the admin Conversations
+ * tab can render a chronological tool timeline alongside the transcript.
+ *
+ * tool_args / tool_result are capped at 16KB each by the writer
+ * (truncation marker lives inside the JSON object as `{ "_truncated": true }`
+ * by convention). Retention: 90 days, pruned by agent-telemetry-prune.
+ */
+
+import {
+  bigint,
+  index,
+  integer,
+  jsonb,
+  pgTable,
+  text,
+  timestamp,
+  varchar,
+} from "drizzle-orm/pg-core";
+
+import { agentMessages } from "./agent-messages";
+
+export const agentToolInvocations = pgTable(
+  "agent_tool_invocations",
+  {
+    id: bigint("id", { mode: "number" }).generatedAlwaysAsIdentity().primaryKey(),
+    messageId: bigint("message_id", { mode: "number" })
+      .notNull()
+      .references(() => agentMessages.id, { onDelete: "cascade" }),
+    sessionId: varchar("session_id", { length: 512 }).notNull(),
+    userEmail: varchar("user_email", { length: 255 }).notNull(),
+    toolName: varchar("tool_name", { length: 255 }).notNull(),
+    toolArgs: jsonb("tool_args").$type<Record<string, unknown> | null>(),
+    toolResult: jsonb("tool_result").$type<Record<string, unknown> | null>(),
+    status: varchar("status", { length: 16 }).notNull(),
+    errorText: text("error_text"),
+    durationMs: integer("duration_ms").notNull().default(0),
+    startedAt: timestamp("started_at", { withTimezone: true }).notNull(),
+    finishedAt: timestamp("finished_at", { withTimezone: true }).notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [
+    index("idx_agent_tool_invocations_tool").on(table.toolName, table.startedAt),
+    index("idx_agent_tool_invocations_session").on(table.sessionId, table.startedAt),
+    index("idx_agent_tool_invocations_user").on(table.userEmail, table.startedAt),
+    index("idx_agent_tool_invocations_created_at").on(table.createdAt),
+  ],
+);

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "@aws-sdk/client-sqs": "^3.982.0",
     "@aws-sdk/client-ssm": "^3.982.0",
     "@aws-sdk/credential-providers": "^3.982.0",
+    "@aws-sdk/lib-dynamodb": "~3.982.0",
     "@aws-sdk/s3-request-presigner": "^3.982.0",
     "@aws-sdk/util-dynamodb": "^3.982.0",
     "@dnd-kit/core": "^6.3.1",


### PR DESCRIPTION
## Summary
- Adds **Triage** and **Conversations** tabs to /admin/agents.
- Fixes the empty/wrong existing tabs: Usage (real model + tokens + latency), Cost (tag-activation guidance), Patterns (truthful empty states), Credentials (paste-secret modal).
- Captures **full conversation transcripts + tool-call timelines** for every agent turn (new schema + writes from the harness through the router).
- **Auto-registers bundled image skills** so the Skills tab lists chat-card / psd-github / psd-workspace / etc. instead of only greetings-demo.
- Lands the **email triage Phase 1** feature (consolidates work from prior sessions that was untracked on `dev`).
- Adds a 90-day **retention sweep Lambda** for the deep-telemetry tables.

## Telemetry pipeline — top to bottom

```
OpenClaw events → harness_adapter.TurnResult → agentcore_wrapper metadata
   → agent-router invokeAgentCore() → logTelemetry()
     ├─ agent_messages (model, tokens_in, tokens_out, latency_ms)
     ├─ agent_message_content (one row per role/content, 64KB cap)
     └─ agent_tool_invocations (one row per tool call, args+result jsonb)
```

The harness extracts model id from agent event payloads, sums token usage from whichever event carries it, measures latency from chat.send → final, and builds a per-turn tool timeline from `event:agent` `stream="tool_call"` / `stream="tool_result"` events. The wrapper passes everything through to the router with a legacy-string fallback so older harness builds still write usable rows.

## What's in each tab now
| Tab | Status |
|---|---|
| Usage | Real model / tokens / latency once new image deploys. |
| Cost | Honest empty-state with one-click link to activate ` costCenter` in Billing (must run from payer account, AWS Organizations limitation). |
| Patterns | Three differentiated empty-states. |
| Credentials | Paste-secret modal — provisions Secrets Manager + flips status + audit log, atomically. |
| Skills | Auto-registers every bundled image skill on each deploy. |
| **Triage (new)** | Lists opted-in users + per-user Manage link. |
| **Conversations (new)** | Full transcript + tool timeline drilldown, filterable. |

## Schema
- Migration **078**: ` agent_message_content` + ` agent_tool_invocations`. CASCADE on ` agent_messages`; indexes on session_id / user_email / tool_name + created_at.
- Daily prune Lambda (` psd-agent-telemetry-prune-<env>`) — 04:00 UTC, 90-day retention, 5000-row batches. Aggregated ` agent_messages` summary rows kept indefinitely.

## Email triage (Phase 1)
- DynamoDB ` psd-agent-triage-<env>` (per-user state).
- ` psd-agent-triage-poll-<env>` Lambda — 5-min schedule, rules + Nova Micro classifier, label apply + Chat escalation cards, ` @psd/Task` gesture → AgentCore handoff (90s timeout, per-message claim).
- ` psd-agent-triage-digest-<env>` Lambda — per-user daily Scheduler.
- ` psd-email-triage` skill — enable/disable/configure from Chat.
- ` /admin/agents/[userEmail]/triage` — admin detail with Pause / Reset / Re-onboard.

## Cost-allocation tag (one-time manual step, payer-account only)
` ` ` 
aws ce update-cost-allocation-tags-status \
  --cost-allocation-tags-status TagKey=costCenter,Status=Active
` ` ` 

## Test plan
After deploy (canonical command, current image tag, then rebuild + redeploy the image once for the new harness):

- [ ] Migration 078 runs; both new tables exist.
- [ ] Skill initializer Custom Resource invokes the Lambda; ` psd_agent_skills` populates with every bundled skill (scope=shared, scan_status=clean).
- [ ] Triage tab lists opted-in users; Manage link opens the existing per-user detail page.
- [ ] Cost tab shows the activation explanation + Billing console link.
- [ ] Patterns tab shows the right differentiated empty-state.
- [ ] Credentials tab → click Provision on a pending request → modal → paste secret + pick scope → secret lands in Secrets Manager + request flips fulfilled + audit row.
- [ ] After agent-image rebuild + redeploy: send an agent message → Usage tab shows real model id (e.g. ` anthropic.claude-3-5-sonnet-...`) with non-zero tokens + correct latency. Conversations tab → find the session → drilldown shows transcript + tool call timeline.
- [ ] ` psd-agent-telemetry-prune-<env>` exists with the daily 04:00 UTC EventBridge schedule. Invoke with ` RETENTION_DAYS=0` to verify cleanup path.