### PR TITLE
fix: #993 — [FS#160488] Handle network errors & large spreadsheet payloads in Nexus

### DIFF
--- a/app/(protected)/nexus/page.tsx
+++ b/app/(protected)/nexus/page.tsx
@@ -41,6 +41,8 @@ const ConnectorToolsSchema = z.record(z.string(), z.object({
   serverName: z.string(),
 }))
 
+const ModelErrorSchema = z.object({ error: z.string().max(300) })
+
 // Loading spinner component for Suspense fallback
 function NexusLoadingSpinner() {
   return (
@@ -150,6 +152,10 @@ function ConversationRuntimeProvider({
     try {
       response = await fetch(input, init)
     } catch (networkError) {
+      // Intentional cancellation (stop button, navigation) — don't toast.
+      if (networkError instanceof Error && networkError.name === 'AbortError') {
+        throw networkError
+      }
       // TCP-level failures (connection drop, ALB timeout, offline) arrive here as
       // TypeError("Failed to fetch"). Show a friendly message instead of letting
       // the raw browser error string propagate to the output area.
@@ -212,9 +218,6 @@ function ConversationRuntimeProvider({
       try {
         const clonedResponse = response.clone()
         const rawData: unknown = await clonedResponse.json()
-        // Validate shape before trusting server-controlled string (security: unvalidated
-        // server text must not flow directly into rendered UI components).
-        const ModelErrorSchema = z.object({ error: z.string().max(300) })
         const parsed = ModelErrorSchema.safeParse(rawData)
         toast.error('Model Unavailable', {
           description: parsed.success

--- a/app/(protected)/nexus/page.tsx
+++ b/app/(protected)/nexus/page.tsx
@@ -146,7 +146,36 @@ function ConversationRuntimeProvider({
       throwSessionExpired('Pre-send check: session unauthenticated, blocking chat request')
     }
 
-    const response = await fetch(input, init)
+    let response: Response
+    try {
+      response = await fetch(input, init)
+    } catch (networkError) {
+      // TCP-level failures (connection drop, ALB timeout, offline) arrive here as
+      // TypeError("Failed to fetch"). Show a friendly message instead of letting
+      // the raw browser error string propagate to the output area.
+      const isOffline = typeof navigator !== 'undefined' && !navigator.onLine
+      log.warn('Chat request failed at network level', {
+        error: networkError instanceof Error ? networkError.message : String(networkError),
+        offline: isOffline,
+      })
+      toast.error('Connection error', {
+        description: isOffline
+          ? 'You appear to be offline. Check your connection and try again.'
+          : 'The request could not reach the server. Check your connection or try again.',
+        duration: 8000,
+      })
+      throw networkError
+    }
+
+    // Handle request-body-too-large errors (413)
+    if (response.status === 413) {
+      log.warn('Chat request rejected — payload too large (413)')
+      toast.error('Message too large', {
+        description: 'The attached file or message content is too large to process. Try uploading a smaller file or splitting it into parts.',
+        duration: 10_000,
+      })
+      throw new Error('Request payload too large. Please reduce the size of attached files.')
+    }
 
     // Handle session expiry — 401 returned when JWT is invalid or Cognito token refresh
     // failed overnight. Without this handler the AI SDK runtime tries to parse

--- a/app/(protected)/nexus/page.tsx
+++ b/app/(protected)/nexus/page.tsx
@@ -211,9 +211,15 @@ function ConversationRuntimeProvider({
     if (response.status === 404) {
       try {
         const clonedResponse = response.clone()
-        const errorData = await clonedResponse.json()
+        const rawData: unknown = await clonedResponse.json()
+        // Validate shape before trusting server-controlled string (security: unvalidated
+        // server text must not flow directly into rendered UI components).
+        const ModelErrorSchema = z.object({ error: z.string().max(300) })
+        const parsed = ModelErrorSchema.safeParse(rawData)
         toast.error('Model Unavailable', {
-          description: errorData.error || 'The selected model is no longer available. Please choose a different model.',
+          description: parsed.success
+            ? parsed.data.error
+            : 'The selected model is no longer available. Please choose a different model.',
           duration: 8000
         })
         log.warn('Selected model not found on server')

--- a/docs/learnings/ai-sdk/2026-05-28-customfetch-network-error-and-413-handling.md
+++ b/docs/learnings/ai-sdk/2026-05-28-customfetch-network-error-and-413-handling.md
@@ -1,0 +1,59 @@
+---
+title: customFetch must handle network-level errors and 413 responses before the AI SDK reads the body
+category: ai-sdk
+tags:
+  - ai-sdk
+  - customFetch
+  - streaming
+  - error-handling
+  - 413
+  - network-error
+severity: high
+date: 2026-05-28
+source: auto — lfg-issue-993
+applicable_to: project
+---
+
+## What Happened
+
+PR #1005 fixed two gaps in the Nexus `customFetch` wrapper that caused uncaught errors surfaced as generic "network error" toasts:
+
+1. **Network-level failures** — if the underlying `fetch()` threw (e.g., DNS failure, connection refused, timeout), the exception propagated unhandled through the AI SDK and appeared as an opaque crash rather than a user-readable message.
+2. **413 Payload Too Large** — when the request body exceeded the server limit, the server returned HTTP 413 before the AI SDK had a chance to handle it. Because `customFetch` did not check for 413 before returning the response, the SDK attempted to parse the 413 body as an SSE stream and produced a confusing error.
+
+## Root Cause
+
+`customFetch` previously only intercepted non-2xx responses that were processed by the SDK. Two cases fell outside that path:
+- `fetch()` itself can throw synchronously or reject its promise (network-layer failure); this was not wrapped in try/catch.
+- HTTP 413 arrives before any stream is established; the AI SDK has no special handling for it and will try to read the body as a stream.
+
+## Solution
+
+```typescript
+async function customFetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
+  let response: Response;
+
+  // 1. Wrap the underlying fetch in try/catch for network-level errors
+  try {
+    response = await fetch(input, init);
+  } catch (err) {
+    toast.error("Network error — check your connection and try again.");
+    throw err; // must re-throw so the AI SDK stops processing
+  }
+
+  // 2. Intercept 413 before the SDK body-reads the response
+  if (response.status === 413) {
+    toast.error("Your message or attachments are too large. Please reduce the size and try again.");
+    throw new Error("413 Payload Too Large");
+  }
+
+  // ... existing non-2xx handling ...
+  return response;
+}
+```
+
+## Prevention
+
+- Every `customFetch` implementation used with AI SDK streaming needs **both** a network-error try/catch around `fetch()` **and** an explicit `status === 413` check.
+- Always `throw` after calling `toast.error()` — returning a non-2xx or error response will cause the SDK stream parser to throw a cryptic TypeError (see `2026-03-12-customfetch-must-throw-after-toast.md`).
+- Add status checks for any other HTTP codes that arrive before a stream is established (e.g., 429 rate-limit, 503 overload) following the same pattern.

--- a/docs/learnings/security/2026-05-28-xlsx-markdown-injection-pipe-newline-sheet-name.md
+++ b/docs/learnings/security/2026-05-28-xlsx-markdown-injection-pipe-newline-sheet-name.md
@@ -1,0 +1,59 @@
+---
+title: SheetJS XLSX-to-Markdown conversion requires pipe, newline, and sheet-name escaping
+category: security
+tags:
+  - xlsx
+  - sheetjs
+  - markdown
+  - injection
+  - document-processing
+  - office-processor
+severity: high
+date: 2026-05-28
+source: auto — lfg-issue-993
+applicable_to: project
+---
+
+## What Happened
+
+PR #1005 fixed three injection vectors in `office-processor.ts` when rendering XLSX data as Markdown:
+
+1. **Pipe injection** — cell values containing `|` characters broke Markdown table syntax and could inject extra columns or rows.
+2. **Newline injection** — cell values containing `\n` or `\r` characters escaped the current table row and injected arbitrary Markdown below it.
+3. **Sheet name injection** — the sheet name was interpolated directly into a Markdown heading (`## SheetName`) without sanitization; a sheet named `Sheet1\n\n<script>` would inject HTML or break the document structure.
+
+## Root Cause
+
+SheetJS (`xlsx`) parses cell values as raw strings. When those strings are embedded verbatim into Markdown table syntax, special Markdown characters (`|`, `\n`, `\r`) are not content — they are structure. Treating cell data as safe text is incorrect because the Markdown renderer sees them as control characters.
+
+## Solution
+
+Escape cell values and sheet names at the point of Markdown construction:
+
+```typescript
+// Escape pipe and newline characters in cell values
+function escapeCellValue(value: string): string {
+  return value
+    .replace(/\|/g, "\\|")       // escape pipe to avoid table column break
+    .replace(/\r?\n/g, " ");     // flatten newlines to a space
+}
+
+// Sanitize sheet name before interpolating into a Markdown heading
+function sanitizeSheetName(name: string): string {
+  return name
+    .replace(/\|/g, "\\|")
+    .replace(/\r?\n/g, " ")
+    .trim();
+}
+
+// Usage
+const heading = `## ${sanitizeSheetName(ws.name)}\n\n`;
+const row = cells.map(escapeCellValue).join(" | ");
+```
+
+## Prevention
+
+- Any time SheetJS cell values or sheet metadata are embedded in Markdown (tables, headings, code blocks), apply pipe-and-newline escaping.
+- Treat sheet names as user-controlled even when they come from a "known" file — file contents are attacker-controlled in document-upload flows.
+- During PR self-review on XLSX processing code, search for all string interpolation sites involving cell data and verify each one escapes before embedding.
+- Also enforce `MAX_ROWS_PER_SHEET` truncation (500 rows) to prevent unbounded Lambda output that can exhaust memory or response size limits.

--- a/docs/learnings/security/2026-05-28-zod-validate-server-strings-before-toast.md
+++ b/docs/learnings/security/2026-05-28-zod-validate-server-strings-before-toast.md
@@ -1,0 +1,50 @@
+---
+title: Validate server-controlled strings with Zod before rendering in toast descriptions
+category: security
+tags:
+  - zod
+  - toast
+  - xss
+  - input-validation
+  - server-controlled
+severity: high
+date: 2026-05-28
+source: auto — lfg-issue-993
+applicable_to: project
+---
+
+## What Happened
+
+PR #1005 found a server-controlled string being passed directly from an API response into a `toast()` `description` field without validation. Although the current toast library renders descriptions as text (not HTML), the pattern is fragile: a future library upgrade or renderer change could allow XSS, and there is no contract enforcing that the server only returns safe strings.
+
+## Root Cause
+
+When a string from a server response is passed to a UI element without shape validation, the component implicitly trusts the server. In a compromised or misconfigured backend, the string could contain markup, script tags, or excessively long content intended to abuse the UI layer.
+
+## Solution
+
+Parse the server response through a Zod schema before accessing any string that will be rendered:
+
+```typescript
+import { z } from "zod";
+
+const ErrorResponseSchema = z.object({
+  message: z.string().max(500),   // enforce reasonable length
+});
+
+// In the customFetch / response handler:
+const body = await response.json();
+const parsed = ErrorResponseSchema.safeParse(body);
+const description = parsed.success
+  ? parsed.data.message
+  : "An unexpected error occurred.";
+
+toast.error("Request failed", { description });
+```
+
+## Prevention
+
+- Any string from a server response (API, Lambda, third-party) that is rendered in the UI must pass through a Zod schema first.
+- Apply `.max()` to string fields that feed UI labels, toasts, or headings — unbounded strings can cause layout abuse.
+- Use a safe fallback message when `safeParse` fails so the UI never goes silent on errors.
+- This pattern also applies to error messages returned from server actions before they're surfaced in form errors or alert components.

--- a/infra/lambdas/document-processor-v2/processors/__tests__/office-processor-helpers.test.ts
+++ b/infra/lambdas/document-processor-v2/processors/__tests__/office-processor-helpers.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Unit tests for OfficeProcessor static helper methods.
+ *
+ * Run via: cd infra/lambdas/document-processor-v2 && jest
+ * Note: the root jest.config.ci.js excludes /infra/ (infra has its own Jest config).
+ */
+
+import { OfficeProcessor } from '../office-processor';
+
+// Access private static methods for unit testing
+const escapeMdTableCell = (OfficeProcessor as unknown as Record<string, (v: unknown) => string>)['escapeMdTableCell'];
+const sanitizeSheetName = (OfficeProcessor as unknown as Record<string, (v: string) => string>)['sanitizeSheetName'];
+
+describe('OfficeProcessor.escapeMdTableCell', () => {
+  it('escapes pipe characters', () => {
+    expect(escapeMdTableCell('hello | world')).toBe('hello \\| world');
+  });
+
+  it('escapes backslashes before pipes', () => {
+    expect(escapeMdTableCell('back\\slash')).toBe('back\\\\slash');
+    expect(escapeMdTableCell('back\\|pipe')).toBe('back\\\\\\|pipe');
+  });
+
+  it('flattens newlines to a space', () => {
+    expect(escapeMdTableCell('line1\nline2')).toBe('line1 line2');
+    expect(escapeMdTableCell('line1\r\nline2')).toBe('line1 line2');
+    expect(escapeMdTableCell('a\n\nb')).toBe('a b');
+  });
+
+  it('returns empty string for null and undefined', () => {
+    expect(escapeMdTableCell(null)).toBe('');
+    expect(escapeMdTableCell(undefined)).toBe('');
+  });
+
+  it('coerces non-string values to string', () => {
+    expect(escapeMdTableCell(42)).toBe('42');
+    expect(escapeMdTableCell(true)).toBe('true');
+    expect(escapeMdTableCell(0)).toBe('0');
+  });
+
+  it('leaves safe text unchanged', () => {
+    expect(escapeMdTableCell('hello world')).toBe('hello world');
+    expect(escapeMdTableCell('')).toBe('');
+  });
+});
+
+describe('OfficeProcessor.sanitizeSheetName', () => {
+  it('escapes backslashes before other replacements', () => {
+    expect(sanitizeSheetName('back\\slash')).toBe('back\\\\slash');
+  });
+
+  it('replaces pipe characters with a space', () => {
+    expect(sanitizeSheetName('Sheet | Name')).toBe('Sheet   Name');
+  });
+
+  it('replaces newlines with a space', () => {
+    expect(sanitizeSheetName('Sheet\nName')).toBe('Sheet Name');
+    expect(sanitizeSheetName('Sheet\r\nName')).toBe('Sheet  Name');
+  });
+
+  it('replaces # characters with a space', () => {
+    expect(sanitizeSheetName('## Q1 2026')).toBe('   Q1 2026');
+  });
+
+  it('replaces backticks with a space', () => {
+    expect(sanitizeSheetName('Sheet`Name')).toBe('Sheet Name');
+  });
+
+  it('trims surrounding whitespace', () => {
+    expect(sanitizeSheetName('  Sheet  ')).toBe('Sheet');
+  });
+
+  it('falls back to "Sheet" for an empty result', () => {
+    expect(sanitizeSheetName('')).toBe('Sheet');
+    expect(sanitizeSheetName('   ')).toBe('Sheet');
+    expect(sanitizeSheetName('|||')).toBe('Sheet');
+  });
+
+  it('leaves safe names unchanged', () => {
+    expect(sanitizeSheetName('Q1 2026 Revenue')).toBe('Q1 2026 Revenue');
+  });
+});

--- a/infra/lambdas/document-processor-v2/processors/office-processor.ts
+++ b/infra/lambdas/document-processor-v2/processors/office-processor.ts
@@ -42,6 +42,17 @@ function sanitizeHTML(html: string): string {
   return sanitized;
 }
 
+interface XlsxSheetData {
+  name: unknown;
+  json: unknown[][];
+  rowCount: number;
+  columnCount: number;
+}
+
+interface XlsxContent {
+  sheets?: XlsxSheetData[];
+}
+
 export class OfficeProcessor implements DocumentProcessor {
   constructor(
     private documentType: 'docx' | 'xlsx' | 'pptx',
@@ -372,20 +383,22 @@ export class OfficeProcessor implements DocumentProcessor {
 
   // Sanitize a sheet name before interpolating into a Markdown heading.
   private static sanitizeSheetName(name: string): string {
-    return name.replace(/[\r\n|#`]/g, ' ').trim() || 'Sheet';
+    return name
+      .replace(/\\/g, '\\\\')
+      .replace(/[\r\n|#`]/g, ' ')
+      .trim() || 'Sheet';
   }
 
-  private convertXlsxToMarkdown(content: any): string {
+  private convertXlsxToMarkdown(content: XlsxContent): string {
     let markdown = '# Spreadsheet Data\n\n';
 
     if (content.sheets) {
-      content.sheets.forEach((sheet: any) => {
+      content.sheets.forEach((sheet: XlsxSheetData) => {
         const safeSheetName = OfficeProcessor.sanitizeSheetName(String(sheet.name ?? ''));
         markdown += `## ${safeSheetName}\n\n`;
 
         if (sheet.json && sheet.json.length > 0) {
-          // Convert JSON to markdown table
-          const rows = sheet.json as any[][];
+          const rows = sheet.json;
           if (rows.length > 0) {
             const headers = rows[0];
             markdown += '| ' + headers.map(OfficeProcessor.escapeMdTableCell).join(' | ') + ' |\n';
@@ -397,7 +410,7 @@ export class OfficeProcessor implements DocumentProcessor {
               ? allDataRows.slice(0, OfficeProcessor.MAX_ROWS_PER_SHEET)
               : allDataRows;
             markdown += dataRows
-              .map((row: any[]) => '| ' + row.map(OfficeProcessor.escapeMdTableCell).join(' | ') + ' |\n')
+              .map((row: unknown[]) => '| ' + row.map(OfficeProcessor.escapeMdTableCell).join(' | ') + ' |\n')
               .join('');
 
             if (truncated) {

--- a/infra/lambdas/document-processor-v2/processors/office-processor.ts
+++ b/infra/lambdas/document-processor-v2/processors/office-processor.ts
@@ -359,13 +359,18 @@ export class OfficeProcessor implements DocumentProcessor {
     return this.convertTextToMarkdown(content.text);
   }
 
+  // Row cap per sheet: keeps the markdown payload well within API route body limits.
+  // A typical row at 20 columns is ~200 bytes; 500 rows ≈ 100 KB per sheet, safe
+  // even with several sheets and a generous multiplier for wide/dense data.
+  private static readonly MAX_ROWS_PER_SHEET = 500;
+
   private convertXlsxToMarkdown(content: any): string {
     let markdown = '# Spreadsheet Data\n\n';
-    
+
     if (content.sheets) {
       content.sheets.forEach((sheet: any) => {
         markdown += `## ${sheet.name}\n\n`;
-        
+
         if (sheet.json && sheet.json.length > 0) {
           // Convert JSON to markdown table
           const rows = sheet.json as any[][];
@@ -374,18 +379,24 @@ export class OfficeProcessor implements DocumentProcessor {
             const headers = rows[0];
             markdown += '| ' + headers.join(' | ') + ' |\n';
             markdown += '| ' + headers.map(() => '---').join(' | ') + ' |\n';
-            
-            // Include all data rows for complete AI context
-            // Use array.map().join() for better performance with large datasets
-            const dataRows = rows.slice(1);
+
+            const allDataRows = rows.slice(1);
+            const truncated = allDataRows.length > OfficeProcessor.MAX_ROWS_PER_SHEET;
+            const dataRows = truncated
+              ? allDataRows.slice(0, OfficeProcessor.MAX_ROWS_PER_SHEET)
+              : allDataRows;
             markdown += dataRows.map((row: any[]) => '| ' + row.join(' | ') + ' |\n').join('');
+
+            if (truncated) {
+              markdown += `\n> ⚠️ **Showing first ${OfficeProcessor.MAX_ROWS_PER_SHEET} of ${allDataRows.length} rows.** Upload a filtered version of this sheet to analyze the full dataset.\n`;
+            }
           }
         }
-        
+
         markdown += `\n**Sheet Stats:** ${sheet.rowCount} rows, ${sheet.columnCount} columns\n\n`;
       });
     }
-    
+
     return markdown;
   }
 

--- a/infra/lambdas/document-processor-v2/processors/office-processor.ts
+++ b/infra/lambdas/document-processor-v2/processors/office-processor.ts
@@ -360,16 +360,13 @@ export class OfficeProcessor implements DocumentProcessor {
     return this.convertTextToMarkdown(content.text);
   }
 
-  // Row cap per sheet: keeps the markdown payload well within API route body limits.
-  // A typical row at 20 columns is ~200 bytes; 500 rows ≈ 100 KB per sheet, safe
-  // even with several sheets and a generous multiplier for wide/dense data.
+  // Cap rows per sheet so the Markdown payload stays within API route body limits.
   private static readonly MAX_ROWS_PER_SHEET = 500;
 
-  // Escape a spreadsheet cell value for safe embedding in a Markdown table cell.
-  // Pipe characters split columns; newlines break the row out of the table.
   private static escapeMdTableCell(value: unknown): string {
     return String(value ?? '')
       .replace(/[\r\n]+/g, ' ')
+      .replace(/\\/g, '\\\\')
       .replace(/\|/g, '\\|');
   }
 
@@ -390,7 +387,6 @@ export class OfficeProcessor implements DocumentProcessor {
           // Convert JSON to markdown table
           const rows = sheet.json as any[][];
           if (rows.length > 0) {
-            // Header row — escape pipe/newline in column names
             const headers = rows[0];
             markdown += '| ' + headers.map(OfficeProcessor.escapeMdTableCell).join(' | ') + ' |\n';
             markdown += '| ' + headers.map(() => '---').join(' | ') + ' |\n';

--- a/infra/lambdas/document-processor-v2/processors/office-processor.ts
+++ b/infra/lambdas/document-processor-v2/processors/office-processor.ts
@@ -165,7 +165,8 @@ export class OfficeProcessor implements DocumentProcessor {
       // Convert to JSON for structured data
       const json = XLSX.utils.sheet_to_json(sheet, { header: 1 });
       
-      combinedText += `\n\n## Sheet: ${sheetName}\n${csv}`;
+      const safeSheetName = OfficeProcessor.sanitizeSheetName(sheetName);
+      combinedText += `\n\n## Sheet: ${safeSheetName}\n${csv}`;
       
       sheetData.push({
         name: sheetName,
@@ -364,20 +365,34 @@ export class OfficeProcessor implements DocumentProcessor {
   // even with several sheets and a generous multiplier for wide/dense data.
   private static readonly MAX_ROWS_PER_SHEET = 500;
 
+  // Escape a spreadsheet cell value for safe embedding in a Markdown table cell.
+  // Pipe characters split columns; newlines break the row out of the table.
+  private static escapeMdTableCell(value: unknown): string {
+    return String(value ?? '')
+      .replace(/[\r\n]+/g, ' ')
+      .replace(/\|/g, '\\|');
+  }
+
+  // Sanitize a sheet name before interpolating into a Markdown heading.
+  private static sanitizeSheetName(name: string): string {
+    return name.replace(/[\r\n|#`]/g, ' ').trim() || 'Sheet';
+  }
+
   private convertXlsxToMarkdown(content: any): string {
     let markdown = '# Spreadsheet Data\n\n';
 
     if (content.sheets) {
       content.sheets.forEach((sheet: any) => {
-        markdown += `## ${sheet.name}\n\n`;
+        const safeSheetName = OfficeProcessor.sanitizeSheetName(String(sheet.name ?? ''));
+        markdown += `## ${safeSheetName}\n\n`;
 
         if (sheet.json && sheet.json.length > 0) {
           // Convert JSON to markdown table
           const rows = sheet.json as any[][];
           if (rows.length > 0) {
-            // Header row
+            // Header row — escape pipe/newline in column names
             const headers = rows[0];
-            markdown += '| ' + headers.join(' | ') + ' |\n';
+            markdown += '| ' + headers.map(OfficeProcessor.escapeMdTableCell).join(' | ') + ' |\n';
             markdown += '| ' + headers.map(() => '---').join(' | ') + ' |\n';
 
             const allDataRows = rows.slice(1);
@@ -385,7 +400,9 @@ export class OfficeProcessor implements DocumentProcessor {
             const dataRows = truncated
               ? allDataRows.slice(0, OfficeProcessor.MAX_ROWS_PER_SHEET)
               : allDataRows;
-            markdown += dataRows.map((row: any[]) => '| ' + row.join(' | ') + ' |\n').join('');
+            markdown += dataRows
+              .map((row: any[]) => '| ' + row.map(OfficeProcessor.escapeMdTableCell).join(' | ') + ' |\n')
+              .join('');
 
             if (truncated) {
               markdown += `\n> ⚠️ **Showing first ${OfficeProcessor.MAX_ROWS_PER_SHEET} of ${allDataRows.length} rows.** Upload a filtered version of this sheet to analyze the full dataset.\n`;


### PR DESCRIPTION
## Summary

Implements #993 — addresses two code-confirmed failure paths behind the "keep getting network error" reports in Nexus.

## Changes

- **`infra/lambdas/document-processor-v2/processors/office-processor.ts`**: Added `MAX_ROWS_PER_SHEET = 500` cap to `convertXlsxToMarkdown`. Previously included every row with no limit, producing POST bodies that could easily exceed the Next.js API route body limit for large datasets. Truncated output now includes a visible `> ⚠️ Showing first 500 of N rows` note so users know the dataset was trimmed and can upload a filtered version. Also added `escapeMdTableCell()` and `sanitizeSheetName()` helpers to prevent Markdown injection via crafted cell values and sheet names (security audit finding).

- **`app/(protected)/nexus/page.tsx`**: Hardened `customFetch` with two new error handlers:
  1. **Network error try/catch** — wraps the underlying `fetch()` call; TCP-level failures (ALB idle-timeout, offline, connection refused) previously surfaced verbatim as `"Failed to fetch"` in the output area. Now shows a user-friendly toast distinguishing offline vs. server-unreachable, then re-throws for AI SDK cleanup.
  2. **413 handler** — checks `response.status === 413` and shows a clear "Message too large" toast before throwing, preventing the SDK from attempting to parse a non-streaming error body as a stream.
  3. **404 toast validation** — the existing 404 handler now validates `errorData.error` through a Zod schema before rendering in the toast (security audit finding).

## Test Plan
- [x] Inline TypeScript reviewed — changes are well-typed; pre-existing env dep issues in typecheck are unrelated to these files
- [x] Logic reviewed: row truncation, cell escaping, sheet-name sanitization, and network error paths all exercised by inspection
- [x] `customFetch` catch block always re-throws (no silent swallow)
- [x] Security audit passed (3 HIGH findings fixed in-place; MEDIUM/LOW/INFO documented in audit comment)
- [ ] Human review

Closes #993

---
*Opened by the lfg routine.*