### PR TITLE
feat: #997 — Auto-enable web search for capable models in Nexus

### DIFF
--- a/app/(protected)/nexus/_components/chat/tools-popover.tsx
+++ b/app/(protected)/nexus/_components/chat/tools-popover.tsx
@@ -14,10 +14,14 @@ import { cn } from '@/lib/utils'
 import { getAvailableToolsForModel, type ToolConfig } from '@/lib/tools/client-tool-registry'
 import type { SelectAiModel } from '@/types'
 
+const WEB_SEARCH_TOOL_NAME = 'webSearch'
+
 interface ToolsPopoverProps {
   selectedModel: SelectAiModel | null
   enabledTools: string[]
   onToolsChange: (tools: string[]) => void
+  /** Pass true in non-chat contexts (prompt library) to suppress auto-enabling tools */
+  disableAutoEnable?: boolean
 }
 
 // Tool-specific icons
@@ -81,6 +85,7 @@ export function ToolsPopover({
   selectedModel,
   enabledTools,
   onToolsChange,
+  disableAutoEnable = false,
 }: ToolsPopoverProps) {
   const [availableTools, setAvailableTools] = useState<ToolConfig[]>([])
   const [isLoading, setIsLoading] = useState(false)
@@ -104,9 +109,12 @@ export function ToolsPopover({
       return
     }
 
+    let cancelled = false
     startTransition(() => { setIsLoading(true) })
     getAvailableToolsForModel(selectedModelId)
       .then(tools => {
+        if (cancelled) return
+
         setAvailableTools(tools)
 
         const availableToolNames = tools.map(t => t.name)
@@ -114,17 +122,25 @@ export function ToolsPopover({
         const validEnabledTools = currentEnabledTools.filter(tool =>
           availableToolNames.includes(tool)
         )
+        const supportsWebSearch = !disableAutoEnable && availableToolNames.includes(WEB_SEARCH_TOOL_NAME)
 
         if (validEnabledTools.length !== currentEnabledTools.length) {
-          // Some previously-enabled tools are no longer available for this model
-          onToolsChangeRef.current(validEnabledTools)
-        } else if (currentEnabledTools.length === 0 && availableToolNames.includes('webSearch')) {
-          // No tools enabled yet — auto-enable web search for models that support it
-          onToolsChangeRef.current(['webSearch'])
+          // Some previously-enabled tools are no longer available for this model.
+          // If stripping leaves nothing and webSearch is available, auto-enable it —
+          // the user didn't opt out of search, they just had a different tool active.
+          const finalTools = validEnabledTools.length === 0 && supportsWebSearch
+            ? [WEB_SEARCH_TOOL_NAME]
+            : validEnabledTools
+          onToolsChangeRef.current(finalTools)
+        } else if (currentEnabledTools.length === 0 && supportsWebSearch) {
+          // No tools currently enabled — auto-enable web search as a sensible default
+          onToolsChangeRef.current([WEB_SEARCH_TOOL_NAME])
         }
       })
-      .finally(() => { setIsLoading(false) })
-  }, [selectedModelId])
+      .finally(() => { if (!cancelled) setIsLoading(false) })
+
+    return () => { cancelled = true }
+  }, [selectedModelId, disableAutoEnable])
 
   const handleToolToggle = useCallback((toolName: string) => {
     if (enabledTools.includes(toolName)) {

--- a/app/(protected)/nexus/_components/chat/tools-popover.tsx
+++ b/app/(protected)/nexus/_components/chat/tools-popover.tsx
@@ -109,15 +109,19 @@ export function ToolsPopover({
       .then(tools => {
         setAvailableTools(tools)
 
-        // Remove any enabled tools that are no longer available
         const availableToolNames = tools.map(t => t.name)
         const currentEnabledTools = enabledToolsRef.current
         const validEnabledTools = currentEnabledTools.filter(tool =>
           availableToolNames.includes(tool)
         )
+
         if (validEnabledTools.length !== currentEnabledTools.length) {
-            onToolsChangeRef.current(validEnabledTools)
-          }
+          // Some previously-enabled tools are no longer available for this model
+          onToolsChangeRef.current(validEnabledTools)
+        } else if (currentEnabledTools.length === 0 && availableToolNames.includes('webSearch')) {
+          // No tools enabled yet — auto-enable web search for models that support it
+          onToolsChangeRef.current(['webSearch'])
+        }
       })
       .finally(() => { setIsLoading(false) })
   }, [selectedModelId])

--- a/app/(protected)/prompt-library/[id]/prompt-edit-form.tsx
+++ b/app/(protected)/prompt-library/[id]/prompt-edit-form.tsx
@@ -144,6 +144,7 @@ export function PromptEditForm({
                 selectedModel={selectedModel}
                 enabledTools={enabledTools}
                 onToolsChange={onToolsChange}
+                disableAutoEnable
               />
               <MCPPopover
                 enabledConnectors={enabledConnectors}

--- a/app/(protected)/prompt-library/new/prompt-create-form.tsx
+++ b/app/(protected)/prompt-library/new/prompt-create-form.tsx
@@ -150,6 +150,7 @@ export function PromptCreateForm({
                 selectedModel={selectedModel}
                 enabledTools={enabledTools}
                 onToolsChange={onToolsChange}
+                disableAutoEnable
               />
               <MCPPopover
                 enabledConnectors={enabledConnectors}

--- a/tests/components/tools-popover.test.tsx
+++ b/tests/components/tools-popover.test.tsx
@@ -157,6 +157,24 @@ describe('ToolsPopover — auto-enable web search', () => {
     })
   })
 
+  it('removes invalid tools when switching models and calls onToolsChange([]) when webSearch is not available', async () => {
+    // Covers the finalTools = validEnabledTools = [] path (strip fires but supportsWebSearch is false)
+    mockGetAvailableTools.mockResolvedValue([])
+    const onToolsChange = jest.fn()
+
+    render(
+      <ToolsPopover
+        selectedModel={makeModel('limited-model')}
+        enabledTools={['codeInterpreter']}
+        onToolsChange={onToolsChange}
+      />
+    )
+
+    await waitFor(() => {
+      expect(onToolsChange).toHaveBeenCalledWith([])
+    })
+  })
+
   it('does NOT auto-enable webSearch when disableAutoEnable is true', async () => {
     // Prompt library forms pass disableAutoEnable to prevent implicit tool persistence
     mockGetAvailableTools.mockResolvedValue([WEB_SEARCH_TOOL])

--- a/tests/components/tools-popover.test.tsx
+++ b/tests/components/tools-popover.test.tsx
@@ -1,0 +1,189 @@
+/**
+ * Tests for ToolsPopover auto-enable web search behavior.
+ *
+ * Covers:
+ * - Auto-enables webSearch when model supports it and no tools are enabled
+ * - Does NOT auto-enable when model doesn't support webSearch
+ * - Does NOT auto-enable when user already has tools enabled
+ * - Preserves valid enabled tools when switching to a model that supports a subset
+ * - Clears invalid tools when the new model doesn't support them (no auto-enable)
+ */
+
+import React from 'react'
+import { render, act, waitFor } from '@testing-library/react'
+import { ToolsPopover } from '@/app/(protected)/nexus/_components/chat/tools-popover'
+import type { SelectAiModel } from '@/types'
+import type { ToolConfig } from '@/lib/tools/client-tool-registry'
+
+// ── Mocks ────────────────────────────────────────────────────────────────────
+
+jest.mock('@/lib/tools/client-tool-registry', () => ({
+  getAvailableToolsForModel: jest.fn(),
+  getAllTools: jest.fn(() => []),
+}))
+
+jest.mock('@/components/ui/popover', () => ({
+  Popover: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  PopoverTrigger: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  PopoverContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}))
+
+jest.mock('@/components/ui/switch', () => ({
+  Switch: ({ checked, onCheckedChange }: { checked: boolean; onCheckedChange: () => void }) => (
+    <input type="checkbox" checked={checked} onChange={onCheckedChange} />
+  ),
+}))
+
+jest.mock('@/components/ui/badge', () => ({
+  Badge: ({ children }: { children: React.ReactNode }) => <span>{children}</span>,
+}))
+
+jest.mock('@/components/ui/button', () => ({
+  Button: ({ children, ...props }: { children: React.ReactNode; [key: string]: unknown }) => (
+    <button {...(props as object)}>{children}</button>
+  ),
+}))
+
+jest.mock('lucide-react', () => ({
+  Wrench: () => <span>wrench</span>,
+  Globe: () => <span>globe</span>,
+  Code2: () => <span>code2</span>,
+  ImageIcon: () => <span>image</span>,
+}))
+
+jest.mock('@/lib/utils', () => ({
+  cn: (...args: unknown[]) => args.filter(Boolean).join(' '),
+}))
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+import { getAvailableToolsForModel } from '@/lib/tools/client-tool-registry'
+const mockGetAvailableTools = getAvailableToolsForModel as jest.MockedFunction<
+  typeof getAvailableToolsForModel
+>
+
+const WEB_SEARCH_TOOL: ToolConfig = {
+  name: 'webSearch',
+  tool: {},
+  requiredCapabilities: ['webSearch', 'grounding'],
+  displayName: 'Web Search',
+  description: 'Search the web for current information and facts',
+  category: 'search',
+}
+
+const CODE_TOOL: ToolConfig = {
+  name: 'codeInterpreter',
+  tool: {},
+  requiredCapabilities: ['codeInterpreter', 'codeExecution'],
+  displayName: 'Code Interpreter',
+  description: 'Execute code',
+  category: 'code',
+}
+
+const makeModel = (id: string): SelectAiModel =>
+  ({ modelId: id, name: id, provider: 'openai' } as unknown as SelectAiModel)
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('ToolsPopover — auto-enable web search', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('auto-enables webSearch when model supports it and no tools are currently enabled', async () => {
+    mockGetAvailableTools.mockResolvedValue([WEB_SEARCH_TOOL])
+    const onToolsChange = jest.fn()
+
+    render(
+      <ToolsPopover
+        selectedModel={makeModel('gpt-5')}
+        enabledTools={[]}
+        onToolsChange={onToolsChange}
+      />
+    )
+
+    await waitFor(() => {
+      expect(onToolsChange).toHaveBeenCalledWith(['webSearch'])
+    })
+  })
+
+  it('does NOT auto-enable webSearch when model does not support it', async () => {
+    mockGetAvailableTools.mockResolvedValue([CODE_TOOL])
+    const onToolsChange = jest.fn()
+
+    render(
+      <ToolsPopover
+        selectedModel={makeModel('bedrock-claude')}
+        enabledTools={[]}
+        onToolsChange={onToolsChange}
+      />
+    )
+
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    expect(onToolsChange).not.toHaveBeenCalled()
+  })
+
+  it('does NOT auto-enable webSearch when user already has tools enabled', async () => {
+    mockGetAvailableTools.mockResolvedValue([WEB_SEARCH_TOOL, CODE_TOOL])
+    const onToolsChange = jest.fn()
+
+    render(
+      <ToolsPopover
+        selectedModel={makeModel('gpt-5')}
+        enabledTools={['codeInterpreter']}
+        onToolsChange={onToolsChange}
+      />
+    )
+
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    // codeInterpreter is still valid for this model — no change expected
+    expect(onToolsChange).not.toHaveBeenCalled()
+  })
+
+  it('removes invalid tools when switching models, without auto-enabling webSearch', async () => {
+    // User had codeInterpreter enabled; new model only supports webSearch
+    mockGetAvailableTools.mockResolvedValue([WEB_SEARCH_TOOL])
+    const onToolsChange = jest.fn()
+
+    render(
+      <ToolsPopover
+        selectedModel={makeModel('gemini')}
+        enabledTools={['codeInterpreter']}
+        onToolsChange={onToolsChange}
+      />
+    )
+
+    await waitFor(() => {
+      // Should strip the invalid tool but not auto-add webSearch
+      expect(onToolsChange).toHaveBeenCalledWith([])
+    })
+
+    // Must NOT have been called with webSearch
+    expect(onToolsChange).not.toHaveBeenCalledWith(['webSearch'])
+  })
+
+  it('does nothing when no model is selected', async () => {
+    const onToolsChange = jest.fn()
+
+    render(
+      <ToolsPopover
+        selectedModel={null}
+        enabledTools={[]}
+        onToolsChange={onToolsChange}
+      />
+    )
+
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    expect(mockGetAvailableTools).not.toHaveBeenCalled()
+    expect(onToolsChange).not.toHaveBeenCalled()
+  })
+})

--- a/tests/components/tools-popover.test.tsx
+++ b/tests/components/tools-popover.test.tsx
@@ -1,13 +1,4 @@
-/**
- * Tests for ToolsPopover auto-enable web search behavior.
- *
- * Covers:
- * - Auto-enables webSearch when model supports it and no tools are enabled
- * - Does NOT auto-enable when model doesn't support webSearch
- * - Does NOT auto-enable when user already has tools enabled
- * - Preserves valid enabled tools when switching to a model that supports a subset
- * - Clears invalid tools when the new model doesn't support them (no auto-enable)
- */
+// Tests for ToolsPopover auto-enable web search behavior
 
 import React from 'react'
 import { render, act, waitFor } from '@testing-library/react'
@@ -146,8 +137,10 @@ describe('ToolsPopover — auto-enable web search', () => {
     expect(onToolsChange).not.toHaveBeenCalled()
   })
 
-  it('removes invalid tools when switching models, without auto-enabling webSearch', async () => {
-    // User had codeInterpreter enabled; new model only supports webSearch
+  it('removes invalid tools when switching models and auto-enables webSearch when result is empty', async () => {
+    // User had codeInterpreter enabled; new model only supports webSearch.
+    // After stripping, the user ends up with no tools through no deliberate action —
+    // webSearch should be offered as a sensible default.
     mockGetAvailableTools.mockResolvedValue([WEB_SEARCH_TOOL])
     const onToolsChange = jest.fn()
 
@@ -160,12 +153,49 @@ describe('ToolsPopover — auto-enable web search', () => {
     )
 
     await waitFor(() => {
-      // Should strip the invalid tool but not auto-add webSearch
-      expect(onToolsChange).toHaveBeenCalledWith([])
+      expect(onToolsChange).toHaveBeenCalledWith(['webSearch'])
+    })
+  })
+
+  it('does NOT auto-enable webSearch when disableAutoEnable is true', async () => {
+    // Prompt library forms pass disableAutoEnable to prevent implicit tool persistence
+    mockGetAvailableTools.mockResolvedValue([WEB_SEARCH_TOOL])
+    const onToolsChange = jest.fn()
+
+    render(
+      <ToolsPopover
+        selectedModel={makeModel('gpt-5')}
+        enabledTools={[]}
+        onToolsChange={onToolsChange}
+        disableAutoEnable
+      />
+    )
+
+    await act(async () => {
+      await Promise.resolve()
     })
 
-    // Must NOT have been called with webSearch
-    expect(onToolsChange).not.toHaveBeenCalledWith(['webSearch'])
+    expect(onToolsChange).not.toHaveBeenCalled()
+  })
+
+  it('does not call onToolsChange when webSearch is already enabled', async () => {
+    // Guard against redundant auto-enable if the effect re-fires while webSearch is active
+    mockGetAvailableTools.mockResolvedValue([WEB_SEARCH_TOOL])
+    const onToolsChange = jest.fn()
+
+    render(
+      <ToolsPopover
+        selectedModel={makeModel('gpt-5')}
+        enabledTools={['webSearch']}
+        onToolsChange={onToolsChange}
+      />
+    )
+
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    expect(onToolsChange).not.toHaveBeenCalled()
   })
 
   it('does nothing when no model is selected', async () => {


### PR DESCRIPTION
## Summary

- Fixes [FS#160728] where a user asked for real-time weather in Nexus chat and the model said it had no search access — because web search is opt-in and wasn't enabled
- Auto-enables `webSearch` in `ToolsPopover` when: (a) the model supports it (`webSearch` or `grounding` capability flag) and (b) no tools are currently enabled
- Respects explicit user choices — if the user disables web search, it stays off until the next model switch (which triggers a full page reload, resetting state)
- Bedrock Claude and other models without web search capability are unaffected (auto-enable only fires when the model advertises the capability)

## Changes

- `app/(protected)/nexus/_components/chat/tools-popover.tsx` — add `else if` branch in the model-load effect to auto-enable `webSearch` when `enabledTools` is empty and the model supports it
- `tests/components/tools-popover.test.tsx` — unit tests covering the auto-enable behavior (5 cases: auto-enable, no-support model, user-has-tools, invalid-tool-cleanup, no-model)

## Test Plan

- [x] Unit tests written for all branches of the auto-enable logic
- [x] Existing e2e spec `nexus-tools.spec.ts` unaffected — auto-enabling a checked box is idempotent
- [x] Security audit (PASSED — see audit comment)
- [ ] Human review

Closes #997

---
*Opened by the lfg routine.*