### PR TITLE
feat: #924 - Unified tool catalog (single source of truth across MCP, AI SDK, REST, internal agents)

### DIFF
--- a/app/api/nexus/chat/route.ts
+++ b/app/api/nexus/chat/route.ts
@@ -44,7 +44,7 @@ import { eq, and } from 'drizzle-orm';
 import { executeQuery } from '@/lib/db/drizzle-client';
 import { nexusConversations } from '@/lib/db/schema';
 import { getScopesForRoles } from '@/lib/api-keys/scopes';
-import { toolCatalog_instance } from '@/lib/tools/catalog/catalog';
+import { toolCatalogInstance } from '@/lib/tools/catalog/catalog';
 
 // Allow streaming responses up to 30 minutes. Deep Research runs take 5–25
 // minutes; standard chat and image-gen finish well within this window.
@@ -944,22 +944,22 @@ async function scanAttachmentPII(
 }
 
 /**
- * Resolve MCP connector tools for all enabled connectors (parallel fetch).
- * Pushes successful results into `connectorToolResults` (mutated) and returns the
- * list of connector IDs that failed to resolve. Extracted from POST to keep the
- * route handler's cyclomatic complexity within bounds.
+ * Resolve MCP connector tools for all enabled connectors (parallel fetch). Pure:
+ * returns the resolved results and the list of connector IDs that failed, without
+ * mutating any caller-supplied array. Extracted from POST to keep the route
+ * handler's cyclomatic complexity within bounds.
  */
 async function resolveConnectorTools(params: {
   enabledConnectors: string[];
   userId: number;
   userRoleNames: string[];
   idToken?: string;
-  connectorToolResults: McpConnectorToolsResult[];
   log: ReturnType<typeof createLogger>;
-}): Promise<string[]> {
-  const { enabledConnectors, userId, userRoleNames, idToken, connectorToolResults, log } = params;
-  const failedConnectorIds: string[] = [];
-  if (enabledConnectors.length === 0) return failedConnectorIds;
+}): Promise<{ resolved: McpConnectorToolsResult[]; failedIds: string[] }> {
+  const { enabledConnectors, userId, userRoleNames, idToken, log } = params;
+  const resolved: McpConnectorToolsResult[] = [];
+  const failedIds: string[] = [];
+  if (enabledConnectors.length === 0) return { resolved, failedIds };
 
   log.info('Resolving MCP connector tools', { connectorCount: enabledConnectors.length });
   const connectorOptions = idToken ? { idToken } : undefined;
@@ -968,9 +968,9 @@ async function resolveConnectorTools(params: {
   );
   for (const [i, result] of results.entries()) {
     if (result.status === 'fulfilled') {
-      connectorToolResults.push(result.value);
+      resolved.push(result.value);
     } else {
-      failedConnectorIds.push(enabledConnectors[i]);
+      failedIds.push(enabledConnectors[i]);
       log.warn('Failed to resolve connector tools', {
         serverId: enabledConnectors[i],
         error: result.reason instanceof Error ? result.reason.message : String(result.reason)
@@ -979,11 +979,11 @@ async function resolveConnectorTools(params: {
   }
   log.info('MCP connector tools resolved', {
     requested: enabledConnectors.length,
-    resolved: connectorToolResults.length,
-    failed: failedConnectorIds.length,
-    totalTools: connectorToolResults.reduce((sum, r) => sum + Object.keys(r.tools).length, 0)
+    resolved: resolved.length,
+    failed: failedIds.length,
+    totalTools: resolved.reduce((sum, r) => sum + Object.keys(r.tools).length, 0)
   });
-  return failedConnectorIds;
+  return { resolved, failedIds };
 }
 
 /**
@@ -998,7 +998,7 @@ async function scopeFilterEnabledTools(
   log: ReturnType<typeof createLogger>
 ): Promise<string[]> {
   const callerScopes = getScopesForRoles(userRoleNames);
-  const scoped = await toolCatalog_instance.filterAiSdkToolNames(enabledTools, callerScopes);
+  const scoped = await toolCatalogInstance.filterAiSdkToolNames(enabledTools, callerScopes);
   if (scoped.length !== enabledTools.length) {
     log.info('Tool catalog filtered enabled tools by scope', {
       requested: enabledTools.length,
@@ -1085,11 +1085,14 @@ export async function POST(req: Request) {
       messagesWithParts
     );
 
-    // 8. Resolve MCP connector tools (parallel fetch for all enabled connectors)
-    const failedConnectorIds = await resolveConnectorTools({
-      enabledConnectors, userId, userRoleNames, idToken: session.idToken,
-      connectorToolResults, log,
-    });
+    // 8. Resolve MCP connector tools (parallel fetch for all enabled connectors).
+    // connectorToolResults is hoisted for catch-block cleanup; append the resolved
+    // results rather than mutating inside the helper.
+    const { resolved: resolvedConnectorTools, failedIds: failedConnectorIds } =
+      await resolveConnectorTools({
+        enabledConnectors, userId, userRoleNames, idToken: session.idToken, log,
+      });
+    connectorToolResults.push(...resolvedConnectorTools);
 
     // 8b. Scope-gate built-in (AI SDK) tools via the unified tool catalog (#924).
     const scopedEnabledTools = await scopeFilterEnabledTools(enabledTools, userRoleNames, log);

--- a/app/api/nexus/chat/route.ts
+++ b/app/api/nexus/chat/route.ts
@@ -830,17 +830,6 @@ function extractPartText(part: Record<string, unknown>): string | null {
 }
 
 /**
- * Scan PII in file / document attachment parts of the last user message BEFORE
- * processMessagesWithAttachments moves their content to S3. Returns token
- * mappings produced by the scan and mutates `messagesWithParts` in-place so
- * that document text is tokenized before being stored.
- *
- * This runs at the route level so that:
- * 1. The extracted document text is available (not yet replaced with s3:// refs).
- * 2. Token mappings can be passed to executeStreaming as `precomputedInputTokenMappings`
- *    and merged with inline-text tokens from the streaming service's own scan.
- */
-/**
  * Collect extractable text from document/file parts of a message, paired with
  * their part index. Extracted from scanAttachmentPII to keep that function's
  * cyclomatic complexity within bounds.
@@ -859,6 +848,17 @@ function collectAttachmentTexts(
   return out;
 }
 
+/**
+ * Scan PII in file / document attachment parts of the last user message BEFORE
+ * processMessagesWithAttachments moves their content to S3. Returns token
+ * mappings produced by the scan and mutates `messagesWithParts` in-place so
+ * that document text is tokenized before being stored.
+ *
+ * This runs at the route level so that:
+ * 1. The extracted document text is available (not yet replaced with s3:// refs).
+ * 2. Token mappings can be passed to executeStreaming as `precomputedInputTokenMappings`
+ *    and merged with inline-text tokens from the streaming service's own scan.
+ */
 async function scanAttachmentPII(
   messagesWithParts: UIMessage[],
   sessionId: string,

--- a/app/api/nexus/chat/route.ts
+++ b/app/api/nexus/chat/route.ts
@@ -43,6 +43,8 @@ import {
 import { eq, and } from 'drizzle-orm';
 import { executeQuery } from '@/lib/db/drizzle-client';
 import { nexusConversations } from '@/lib/db/schema';
+import { getScopesForRoles } from '@/lib/api-keys/scopes';
+import { toolCatalog_instance } from '@/lib/tools/catalog/catalog';
 
 // Allow streaming responses up to 30 minutes. Deep Research runs take 5–25
 // minutes; standard chat and image-gen finish well within this window.
@@ -838,6 +840,25 @@ function extractPartText(part: Record<string, unknown>): string | null {
  * 2. Token mappings can be passed to executeStreaming as `precomputedInputTokenMappings`
  *    and merged with inline-text tokens from the streaming service's own scan.
  */
+/**
+ * Collect extractable text from document/file parts of a message, paired with
+ * their part index. Extracted from scanAttachmentPII to keep that function's
+ * cyclomatic complexity within bounds.
+ */
+function collectAttachmentTexts(
+  parts: unknown[]
+): Array<{ partIdx: number; text: string }> {
+  const out: Array<{ partIdx: number; text: string }> = [];
+  for (const [partIdx, part] of parts.entries()) {
+    const p = part as Record<string, unknown>;
+    if (p.type === 'document' || p.type === 'file') {
+      const text = extractPartText(p);
+      if (text) out.push({ partIdx, text });
+    }
+  }
+  return out;
+}
+
 async function scanAttachmentPII(
   messagesWithParts: UIMessage[],
   sessionId: string,
@@ -856,14 +877,7 @@ async function scanAttachmentPII(
   const lastUserMsg = messagesWithParts[lastUserIdx];
   if (!Array.isArray(lastUserMsg.parts)) return [];
 
-  const attachmentTexts: Array<{ partIdx: number; text: string }> = [];
-  lastUserMsg.parts.forEach((part, partIdx) => {
-    const p = part as Record<string, unknown>;
-    if (p.type === 'document' || p.type === 'file') {
-      const text = extractPartText(p);
-      if (text) attachmentTexts.push({ partIdx, text });
-    }
-  });
+  const attachmentTexts = collectAttachmentTexts(lastUserMsg.parts);
 
   if (attachmentTexts.length === 0) return [];
 
@@ -927,6 +941,71 @@ async function scanAttachmentPII(
   });
 
   return scanResult.tokens;
+}
+
+/**
+ * Resolve MCP connector tools for all enabled connectors (parallel fetch).
+ * Pushes successful results into `connectorToolResults` (mutated) and returns the
+ * list of connector IDs that failed to resolve. Extracted from POST to keep the
+ * route handler's cyclomatic complexity within bounds.
+ */
+async function resolveConnectorTools(params: {
+  enabledConnectors: string[];
+  userId: number;
+  userRoleNames: string[];
+  idToken?: string;
+  connectorToolResults: McpConnectorToolsResult[];
+  log: ReturnType<typeof createLogger>;
+}): Promise<string[]> {
+  const { enabledConnectors, userId, userRoleNames, idToken, connectorToolResults, log } = params;
+  const failedConnectorIds: string[] = [];
+  if (enabledConnectors.length === 0) return failedConnectorIds;
+
+  log.info('Resolving MCP connector tools', { connectorCount: enabledConnectors.length });
+  const connectorOptions = idToken ? { idToken } : undefined;
+  const results = await Promise.allSettled(
+    enabledConnectors.map(serverId => getConnectorTools(serverId, userId, userRoleNames, connectorOptions))
+  );
+  for (const [i, result] of results.entries()) {
+    if (result.status === 'fulfilled') {
+      connectorToolResults.push(result.value);
+    } else {
+      failedConnectorIds.push(enabledConnectors[i]);
+      log.warn('Failed to resolve connector tools', {
+        serverId: enabledConnectors[i],
+        error: result.reason instanceof Error ? result.reason.message : String(result.reason)
+      });
+    }
+  }
+  log.info('MCP connector tools resolved', {
+    requested: enabledConnectors.length,
+    resolved: connectorToolResults.length,
+    failed: failedConnectorIds.length,
+    totalTools: connectorToolResults.reduce((sum, r) => sum + Object.keys(r.tools).length, 0)
+  });
+  return failedConnectorIds;
+}
+
+/**
+ * Scope-gate built-in (AI SDK) tools via the unified tool catalog (#924). The
+ * client-supplied `enabledTools` is untrusted; the catalog drops any AI SDK tool
+ * the caller's role-derived scopes don't permit. Uncataloged tool names pass
+ * through unchanged (downstream model-capability filtering still applies).
+ */
+async function scopeFilterEnabledTools(
+  enabledTools: string[],
+  userRoleNames: string[],
+  log: ReturnType<typeof createLogger>
+): Promise<string[]> {
+  const callerScopes = getScopesForRoles(userRoleNames);
+  const scoped = await toolCatalog_instance.filterAiSdkToolNames(enabledTools, callerScopes);
+  if (scoped.length !== enabledTools.length) {
+    log.info('Tool catalog filtered enabled tools by scope', {
+      requested: enabledTools.length,
+      allowed: scoped.length,
+    });
+  }
+  return scoped;
 }
 
 /**
@@ -1007,31 +1086,13 @@ export async function POST(req: Request) {
     );
 
     // 8. Resolve MCP connector tools (parallel fetch for all enabled connectors)
-    const failedConnectorIds: string[] = [];
-    if (enabledConnectors.length > 0) {
-      log.info('Resolving MCP connector tools', { connectorCount: enabledConnectors.length });
-      const connectorOptions = session.idToken ? { idToken: session.idToken } : undefined;
-      const results = await Promise.allSettled(
-        enabledConnectors.map(serverId => getConnectorTools(serverId, userId, userRoleNames, connectorOptions))
-      );
-      for (const [i, result] of results.entries()) {
-        if (result.status === 'fulfilled') {
-          connectorToolResults.push(result.value);
-        } else {
-          failedConnectorIds.push(enabledConnectors[i]);
-          log.warn('Failed to resolve connector tools', {
-            serverId: enabledConnectors[i],
-            error: result.reason instanceof Error ? result.reason.message : String(result.reason)
-          });
-        }
-      }
-      log.info('MCP connector tools resolved', {
-        requested: enabledConnectors.length,
-        resolved: connectorToolResults.length,
-        failed: failedConnectorIds.length,
-        totalTools: connectorToolResults.reduce((sum, r) => sum + Object.keys(r.tools).length, 0)
-      });
-    }
+    const failedConnectorIds = await resolveConnectorTools({
+      enabledConnectors, userId, userRoleNames, idToken: session.idToken,
+      connectorToolResults, log,
+    });
+
+    // 8b. Scope-gate built-in (AI SDK) tools via the unified tool catalog (#924).
+    const scopedEnabledTools = await scopeFilterEnabledTools(enabledTools, userRoleNames, log);
 
     // 9. Execute streaming and return response
     // Once executeStreaming returns successfully, the streaming Response is in flight.
@@ -1045,7 +1106,7 @@ export async function POST(req: Request) {
       conversationId,
       conversationIdValue,
       conversationTitle,
-      enabledTools,
+      enabledTools: scopedEnabledTools,
       enabledConnectors,
       connectorToolResults,
       failedConnectorIds,
@@ -1064,35 +1125,46 @@ export async function POST(req: Request) {
     // is handled by onFinish inside the stream — AI SDK v6 guarantees onFinish is called
     // for all terminal states including errors (verified against ai@6.x).
     await closeMcpClients(connectorToolResults, log, 'catch');
+    return buildChatErrorResponse(error, requestId, log, timer);
+  }
+}
 
-    if (error instanceof ContentSafetyBlockedError) {
-      log.warn('Content blocked by safety guardrails', {
-        error: { message: error.message, name: error.name },
-        categories: error.blockedCategories,
-        source: error.source
-      });
-      timer({ status: 'blocked' });
-      return new Response(
-        JSON.stringify({
-          error: error.message,
-          code: 'CONTENT_BLOCKED',
-          categories: error.blockedCategories,
-          source: error.source,
-          requestId,
-        }),
-        { status: 400, headers: { 'Content-Type': 'application/json', 'X-Request-Id': requestId } }
-      );
-    }
-
-    log.error('Nexus chat API error', {
-      error: error instanceof Error ? { message: error.message, name: error.name } : String(error)
+/**
+ * Map a pre-stream POST error to an HTTP Response. Content-safety blocks return
+ * 400 with category detail; everything else returns a generic 500. Extracted
+ * from POST to keep the route handler's cyclomatic complexity within bounds.
+ */
+function buildChatErrorResponse(
+  error: unknown,
+  requestId: string,
+  log: ReturnType<typeof createLogger>,
+  timer: (data: Record<string, unknown>) => void
+): Response {
+  if (error instanceof ContentSafetyBlockedError) {
+    log.warn('Content blocked by safety guardrails', {
+      error: { message: error.message, name: error.name },
+      categories: error.blockedCategories,
+      source: error.source
     });
-
-    timer({ status: 'error' });
-
+    timer({ status: 'blocked' });
     return new Response(
-      JSON.stringify({ error: 'Failed to process chat request', requestId }),
-      { status: 500, headers: { 'Content-Type': 'application/json', 'X-Request-Id': requestId } }
+      JSON.stringify({
+        error: error.message,
+        code: 'CONTENT_BLOCKED',
+        categories: error.blockedCategories,
+        source: error.source,
+        requestId,
+      }),
+      { status: 400, headers: { 'Content-Type': 'application/json', 'X-Request-Id': requestId } }
     );
   }
+
+  log.error('Nexus chat API error', {
+    error: error instanceof Error ? { message: error.message, name: error.name } : String(error)
+  });
+  timer({ status: 'error' });
+  return new Response(
+    JSON.stringify({ error: 'Failed to process chat request', requestId }),
+    { status: 500, headers: { 'Content-Type': 'application/json', 'X-Request-Id': requestId } }
+  );
 }

--- a/docs/features/mcp-server.md
+++ b/docs/features/mcp-server.md
@@ -78,8 +78,31 @@ curl -X POST http://localhost:3000/api/mcp \
 POST /api/mcp → authenticateRequest() → checkRateLimit()
   → parseJsonRpcRequest() → handleJsonRpcRequest()
     → initialize | tools/list | tools/call | ping
-      → tool-handlers.ts → existing service layer
+      → ToolCatalog (lib/tools/catalog) → code handler / existing service layer
 ```
+
+### Catalog-backed dispatch (#924)
+
+As of the unified tool catalog (Epic #922, workstream #2), `tools/list` and
+`tools/call` resolve through the **`ToolCatalog`** (`lib/tools/catalog/catalog.ts`)
+rather than the static MCP registry:
+
+- `tools/list` returns catalog tools exposed on the `mcp` surface, filtered by the
+  caller's scopes.
+- `tools/call` resolves the tool in the catalog (scope-checked) and invokes its
+  code handler.
+
+The catalog is hybrid: **code-defined** tools live in a TypeScript manifest
+(`lib/tools/catalog/manifest.ts`) and are reconciled into the `tool_catalog` table
+on boot (`lib/tools/catalog/sync.ts`); **assistant/skill-derived** tools live in
+the `tool_catalog` table and are merged at runtime. Each catalog entry carries
+`surfaces`, `required_scopes`, `agent_callable`, and `version`. The 5 original MCP
+tools migrated to `domain.action` identifiers (e.g. `decisions.search`); their MCP
+wire `name` (`search_decisions`) is unchanged for client compatibility.
+
+> Note: external MCP tools resolved per-user via `lib/mcp/connector-service.ts`
+> are *consumed* tools, not part of this catalog (which tracks only tools AI Studio
+> itself *exposes*).
 
 ## Files
 
@@ -87,8 +110,12 @@ POST /api/mcp → authenticateRequest() → checkRateLimit()
 |------|---------|
 | `app/api/mcp/route.ts` | HTTP route handler |
 | `lib/mcp/types.ts` | Protocol type definitions |
-| `lib/mcp/tool-registry.ts` | Tool schemas + scope mapping |
+| `lib/mcp/tool-registry.ts` | Tool schemas + scope mapping (sourced into the catalog manifest) |
 | `lib/mcp/tool-handlers.ts` | Tool implementation adapters |
-| `lib/mcp/jsonrpc-handler.ts` | JSON-RPC 2.0 dispatcher |
+| `lib/mcp/jsonrpc-handler.ts` | JSON-RPC 2.0 dispatcher (catalog-backed) |
 | `lib/mcp/session-manager.ts` | Optional session tracking |
 | `lib/api-keys/scopes.ts` | MCP scope definitions |
+| `lib/tools/catalog/catalog.ts` | Unified `ToolCatalog` runtime (merge + filter + dispatch) |
+| `lib/tools/catalog/manifest.ts` | Code-defined tool catalog |
+| `lib/tools/catalog/sync.ts` | Boot-time `tool_catalog` reconciliation |
+| `lib/db/schema/tables/tool-catalog.ts` | `tool_catalog` table schema |

--- a/docs/learnings/security/2026-06-16-scope-gate-name-alias-bypass.md
+++ b/docs/learnings/security/2026-06-16-scope-gate-name-alias-bypass.md
@@ -1,0 +1,45 @@
+---
+title: Scope/auth gates that index by one name form silently fail open on valid aliases
+category: security
+tags:
+  - tool-catalog
+  - scope-gate
+  - auth-bypass
+  - name-mapping
+  - discriminated-union
+  - error-handling
+  - cache-stampede
+  - mcp
+  - drizzle
+  - code-review
+severity: critical
+date: 2026-06-16
+source: auto — /review-pr
+applicable_to: project
+---
+
+## What Happened
+
+PR #1032 (unified tool catalog, issue #924) review surfaced three compounding correctness and security issues across catalog.ts, manifest.ts, sync.ts, jsonrpc-handler.ts, route.ts, and migration 080. Two always-on correctness agents and two adversarial agents independently flagged the same top findings.
+
+## Root Cause
+
+1. **Name-alias scope bypass**: The scope/auth gate indexed by wire name (`web_search_preview`) but callers could supply a friendly alias (`webSearch`). The lookup missed, the gate evaluated against nothing, and access was granted silently. The pass-through branch had no log line, making the bypass unobservable.
+
+2. **String-encoded failure reason**: A failure reason was embedded in a human-readable error message string, then re-decoded downstream via `string.startsWith()`. Any wording tweak or i18n change silently mis-classifies the failure, and coincidental message matches produce false positives.
+
+3. **Hardcoded `isActive: true` in runtime projection**: A hybrid code-manifest + DB table hardcoded `isActive: true` when projecting code-managed rows, making admin DB toggles on `is_active` a no-op at runtime.
+
+## Solution
+
+1. **Normalize all tool name lookups through `TOOL_NAME_MAPPING` before any security check.** Never index a gate directly by the raw caller-supplied name. Add a structured log line in every pass-through branch so gaps are observable.
+
+2. **Return typed discriminated results** (`{ ok: false, reason: 'scope_denied' }`) instead of encoding the reason in a message string. Callers pattern-match on `reason`, not on text.
+
+3. **Read `is_active` from the DB row** when projecting code-managed catalog entries. The runtime must not override DB state with a compile-time constant.
+
+## Prevention
+
+- Any lookup used in an auth/scope decision: normalize the key first, assert the normalized form resolves, log if it does not.
+- Never re-parse human-readable strings for control flow — use typed discriminated unions.
+- When a DB column exists to control runtime behavior, the runtime projection must read that column, not hardcode a safe-seeming default.

--- a/docs/learnings/test-failures/2026-06-16-jest-mock-hoisting-disabled-by-jest-globals-import.md
+++ b/docs/learnings/test-failures/2026-06-16-jest-mock-hoisting-disabled-by-jest-globals-import.md
@@ -1,0 +1,37 @@
+---
+title: "Importing jest from @jest/globals disables jest.mock hoisting"
+category: test-failures
+tags:
+  - jest
+  - jest.mock
+  - hoisting
+  - "@jest/globals"
+  - eslint-complexity
+  - no-for-each
+  - advisory-lock
+  - catalog
+  - mcp
+  - boot-sync
+severity: high
+date: 2026-06-16
+source: auto — /work
+applicable_to: project
+---
+
+## What Happened
+
+During #924 (unified tool catalog), a test used `import { jest } from "@jest/globals"`. The mocks appeared to be set up correctly but the handler returned real output and mock call counts were always 0 — silent failure with no error thrown.
+
+## Root Cause
+
+`jest.mock()` hoisting is performed by babel-jest as a compile-time transform: it rewrites the file so `jest.mock(...)` calls are physically moved above all `import` statements. This only works when `jest` is the implicit global. When you `import { jest } from "@jest/globals"`, babel-jest treats it as a named import — it cannot hoist the call, so the mock runs *after* the real module has already been imported and bound.
+
+## Solution
+
+Remove `import { jest } from "@jest/globals"` and rely on the global `jest` object. babel-jest then hoists `jest.mock()` above the imports as intended, and mocks intercept the real module load.
+
+## Prevention
+
+- Do not import `jest` from `@jest/globals` in any file that calls `jest.mock()`.
+- If you need explicit typing for `jest` globals, use `/// <reference types="jest" />` or configure `@types/jest` instead of the named import.
+- When a mock shows 0 call count and the handler returns real values, check for this import pattern first — it is a silent failure with no thrown error.

--- a/infra/database/migrations.json
+++ b/infra/database/migrations.json
@@ -74,6 +74,7 @@
     "076-agent-failures.sql",
     "077-agent-workspace-consent-nonces-cognito-data.sql",
     "078-agent-deep-telemetry.sql",
-    "079-rename-tools-to-capabilities.sql"
+    "079-rename-tools-to-capabilities.sql",
+    "080-tool-catalog.sql"
   ]
 }

--- a/infra/database/schema/080-tool-catalog.sql
+++ b/infra/database/schema/080-tool-catalog.sql
@@ -1,0 +1,77 @@
+-- Migration 080: Unified tool catalog (tool_catalog table)
+-- Part of #924 (Epic #922, workstream #2 — Unify Agent Platform)
+--
+-- Introduces `tool_catalog`, the single source of truth for *invocable units*
+-- (tools) AI Studio exposes across the MCP server, AI SDK chat/Nexus, the REST
+-- API, and internal agent loops.
+--
+-- This is intentionally NOT the legacy `tools` table (the pre-#923 role-gated
+-- feature-flag registry kept as a compat shim and dropped in workstream #6). The
+-- canonical catalog uses a distinct table name so both can coexist during the
+-- migration window with no physical collision.
+--
+-- This migration is ADDITIVE and idempotent:
+--   1. Create `tool_catalog` (a row per (identifier, version)).
+--   2. Seed the 5 existing MCP tools with source = 'code' and surfaces = ['mcp'],
+--      preserving the exact required-scope mapping from lib/mcp/tool-registry.ts.
+--      The code manifest sync (lib/tools/catalog/sync.ts, run on app boot) owns
+--      these rows after deploy and keeps them in lockstep with the manifest.
+--
+-- NOTE: No PL/pgSQL triggers / DO $$ blocks. The RDS Data API migration runner's
+-- statement splitter cannot handle dollar-quoted blocks (see migration 079).
+-- `updated_at` is maintained by application code (Drizzle .set({ updatedAt })).
+
+-- Mark any previous failed attempts as completed so the runner stops retrying.
+UPDATE migration_log SET status = 'completed'
+WHERE description = '080-tool-catalog.sql' AND status = 'failed';
+
+-- 1. tool_catalog table
+CREATE TABLE IF NOT EXISTS tool_catalog (
+    id SERIAL PRIMARY KEY,
+    identifier VARCHAR(150) NOT NULL,
+    version VARCHAR(20) DEFAULT 'v1' NOT NULL,
+    name VARCHAR(150) NOT NULL,
+    description TEXT NOT NULL,
+    input_schema JSONB,
+    output_schema JSONB,
+    surfaces JSONB DEFAULT '[]'::jsonb NOT NULL,
+    required_scopes JSONB DEFAULT '[]'::jsonb NOT NULL,
+    agent_callable BOOLEAN DEFAULT true NOT NULL,
+    source VARCHAR(20) DEFAULT 'code' NOT NULL,
+    handler_ref VARCHAR(200),
+    is_active BOOLEAN DEFAULT true NOT NULL,
+    deprecated_at TIMESTAMP,
+    replaced_by VARCHAR(170),
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    CONSTRAINT tool_catalog_source_check CHECK (source IN ('code', 'assistant', 'skill')),
+    CONSTRAINT tool_catalog_identifier_version_key UNIQUE (identifier, version)
+);
+
+CREATE INDEX IF NOT EXISTS idx_tool_catalog_identifier ON tool_catalog (identifier);
+CREATE INDEX IF NOT EXISTS idx_tool_catalog_source ON tool_catalog (source);
+CREATE INDEX IF NOT EXISTS idx_tool_catalog_is_active ON tool_catalog (is_active);
+
+-- 2. Seed the existing 5 MCP tools. ON CONFLICT keeps this idempotent and lets
+-- the boot-time manifest sync take ownership of name/description/schema after
+-- deploy. surfaces = ['mcp'] initially per the issue's migration plan. The
+-- required_scopes mirror TOOL_SCOPE_MAP exactly. agent_callable defaults true;
+-- capture_decision is human-or-agent callable. All are code-sourced.
+INSERT INTO tool_catalog (identifier, version, name, description, surfaces, required_scopes, agent_callable, source, handler_ref)
+VALUES
+    ('decisions.search', 'v1', 'search_decisions',
+     'Search decision graph nodes by type, class, or text query. Returns paginated results.',
+     '["mcp"]'::jsonb, '["mcp:search_decisions"]'::jsonb, true, 'code', 'search_decisions'),
+    ('decisions.capture', 'v1', 'capture_decision',
+     'Capture a structured decision with full context (evidence, constraints, reasoning, alternatives). Creates a decision subgraph with completeness scoring.',
+     '["mcp"]'::jsonb, '["mcp:capture_decision"]'::jsonb, true, 'code', 'capture_decision'),
+    ('assistants.execute', 'v1', 'execute_assistant',
+     'Execute an AI assistant with the given inputs and return the final text result.',
+     '["mcp"]'::jsonb, '["mcp:execute_assistant"]'::jsonb, true, 'code', 'execute_assistant'),
+    ('assistants.list', 'v1', 'list_assistants',
+     'List AI assistants the authenticated user has access to execute.',
+     '["mcp"]'::jsonb, '["mcp:list_assistants"]'::jsonb, true, 'code', 'list_assistants'),
+    ('decisions.graph_get', 'v1', 'get_decision_graph',
+     'Get details of a specific decision node and all its connections (incoming and outgoing edges).',
+     '["mcp"]'::jsonb, '["mcp:get_decision_graph"]'::jsonb, true, 'code', 'get_decision_graph')
+ON CONFLICT (identifier, version) DO NOTHING;

--- a/infra/database/schema/080-tool-catalog.sql
+++ b/infra/database/schema/080-tool-catalog.sql
@@ -75,3 +75,23 @@ VALUES
      'Get details of a specific decision node and all its connections (incoming and outgoing edges).',
      '["mcp"]'::jsonb, '["mcp:get_decision_graph"]'::jsonb, true, 'code', 'get_decision_graph')
 ON CONFLICT (identifier, version) DO NOTHING;
+
+-- 3. Seed the AI SDK (chat / Nexus) tools. Descriptor-only entries — the concrete
+-- implementations are provider-native and built per request. surfaces = ['ai_sdk'].
+-- show_chart is universal (no scope); the rest require chat:write. The boot-time
+-- manifest sync owns these rows after deploy.
+INSERT INTO tool_catalog (identifier, version, name, description, surfaces, required_scopes, agent_callable, source, handler_ref)
+VALUES
+    ('chat.show_chart', 'v1', 'show_chart',
+     'Render a chart (bar, line, pie, etc.) from structured data on the client.',
+     '["ai_sdk"]'::jsonb, '[]'::jsonb, true, 'code', 'chat.show_chart'),
+    ('chat.web_search', 'v1', 'web_search_preview',
+     'Search the web for current information and facts.',
+     '["ai_sdk"]'::jsonb, '["chat:write"]'::jsonb, true, 'code', 'chat.web_search'),
+    ('chat.code_interpreter', 'v1', 'code_interpreter',
+     'Execute code and perform data analysis.',
+     '["ai_sdk"]'::jsonb, '["chat:write"]'::jsonb, true, 'code', 'chat.code_interpreter'),
+    ('chat.generate_image', 'v1', 'generateImage',
+     'Generate images from text descriptions using AI models.',
+     '["ai_sdk"]'::jsonb, '["chat:write"]'::jsonb, true, 'code', 'chat.generate_image')
+ON CONFLICT (identifier, version) DO NOTHING;

--- a/infra/database/schema/080-tool-catalog.sql
+++ b/infra/database/schema/080-tool-catalog.sql
@@ -44,7 +44,13 @@ CREATE TABLE IF NOT EXISTS tool_catalog (
     replaced_by VARCHAR(170),
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
-    CONSTRAINT tool_catalog_source_check CHECK (source IN ('code', 'assistant', 'skill')),
+    -- 'retired' marks a row that WAS code-managed but was removed from the
+    -- manifest: is_active=false + source='retired'. Distinct from 'assistant'
+    -- (a real assistant-derived tool) so observability/queries are not misled,
+    -- and from 'code' so a manifest re-add can detect the released row and
+    -- re-claim ownership (re-activating it) without clobbering an admin's
+    -- is_active toggle on a still-present code tool.
+    CONSTRAINT tool_catalog_source_check CHECK (source IN ('code', 'assistant', 'skill', 'retired')),
     CONSTRAINT tool_catalog_identifier_version_key UNIQUE (identifier, version)
 );
 
@@ -57,23 +63,28 @@ CREATE INDEX IF NOT EXISTS idx_tool_catalog_is_active ON tool_catalog (is_active
 -- deploy. surfaces = ['mcp'] initially per the issue's migration plan. The
 -- required_scopes mirror TOOL_SCOPE_MAP exactly. agent_callable defaults true;
 -- capture_decision is human-or-agent callable. All are code-sourced.
+--
+-- handler_ref is seeded with the canonical identifier (domain.action), matching
+-- what the manifest sync writes (handlerRef = entry.identifier). Seeding the old
+-- snake_case wire name here would differ from the manifest and trigger a spurious
+-- UPDATE for every row on the first boot sync.
 INSERT INTO tool_catalog (identifier, version, name, description, surfaces, required_scopes, agent_callable, source, handler_ref)
 VALUES
     ('decisions.search', 'v1', 'search_decisions',
      'Search decision graph nodes by type, class, or text query. Returns paginated results.',
-     '["mcp"]'::jsonb, '["mcp:search_decisions"]'::jsonb, true, 'code', 'search_decisions'),
+     '["mcp"]'::jsonb, '["mcp:search_decisions"]'::jsonb, true, 'code', 'decisions.search'),
     ('decisions.capture', 'v1', 'capture_decision',
      'Capture a structured decision with full context (evidence, constraints, reasoning, alternatives). Creates a decision subgraph with completeness scoring.',
-     '["mcp"]'::jsonb, '["mcp:capture_decision"]'::jsonb, true, 'code', 'capture_decision'),
+     '["mcp"]'::jsonb, '["mcp:capture_decision"]'::jsonb, true, 'code', 'decisions.capture'),
     ('assistants.execute', 'v1', 'execute_assistant',
      'Execute an AI assistant with the given inputs and return the final text result.',
-     '["mcp"]'::jsonb, '["mcp:execute_assistant"]'::jsonb, true, 'code', 'execute_assistant'),
+     '["mcp"]'::jsonb, '["mcp:execute_assistant"]'::jsonb, true, 'code', 'assistants.execute'),
     ('assistants.list', 'v1', 'list_assistants',
      'List AI assistants the authenticated user has access to execute.',
-     '["mcp"]'::jsonb, '["mcp:list_assistants"]'::jsonb, true, 'code', 'list_assistants'),
+     '["mcp"]'::jsonb, '["mcp:list_assistants"]'::jsonb, true, 'code', 'assistants.list'),
     ('decisions.graph_get', 'v1', 'get_decision_graph',
      'Get details of a specific decision node and all its connections (incoming and outgoing edges).',
-     '["mcp"]'::jsonb, '["mcp:get_decision_graph"]'::jsonb, true, 'code', 'get_decision_graph')
+     '["mcp"]'::jsonb, '["mcp:get_decision_graph"]'::jsonb, true, 'code', 'decisions.graph_get')
 ON CONFLICT (identifier, version) DO NOTHING;
 
 -- 3. Seed the AI SDK (chat / Nexus) tools. Descriptor-only entries — the concrete

--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -110,12 +110,47 @@ async function syncCapabilities(): Promise<void> {
 }
 
 /**
+ * Sync the tool catalog manifest to the database on startup.
+ *
+ * Issue #924 - registers code-defined tools (lib/tools/catalog/manifest.ts) into
+ * the tool_catalog table so adding a tool requires only a manifest entry +
+ * restart, no SQL migration. Idempotent, advisory-locked for safe concurrent
+ * replica boots. Non-blocking: failures are logged and never prevent startup.
+ */
+async function syncToolCatalog(): Promise<void> {
+  const { createLogger } = await import("@/lib/logger");
+  const log = createLogger({
+    context: "instrumentation",
+    operation: "toolCatalogSync",
+  });
+
+  try {
+    const { syncToolCatalogManifest } = await import(
+      "@/lib/tools/catalog/sync"
+    );
+    const result = await syncToolCatalogManifest();
+    log.info("Tool catalog manifest synced on startup", {
+      inserted: result.inserted.length,
+      updated: result.updated.length,
+      deactivated: result.deactivated.length,
+    });
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    // Don't fail startup on sync errors.
+    log.warn("Tool catalog manifest sync failed on startup", {
+      error: errorMessage,
+    });
+  }
+}
+
+/**
  * Next.js instrumentation register function
  *
  * Called once when the Next.js server starts. Used to:
  * 1. Register shutdown handlers for graceful connection cleanup
  * 2. Warm up the database connection pool to avoid cold start latency
  * 3. Sync the code capability manifest into the database (#923)
+ * 4. Sync the code tool catalog manifest into the database (#924)
  *
  * Only runs in Node.js runtime (not Edge runtime or during builds).
  */
@@ -144,6 +179,16 @@ export async function register(): Promise<void> {
     setImmediate(() => {
       syncCapabilities().catch(() => {
         // Errors already logged in syncCapabilities
+      });
+    });
+
+    // Sync tool catalog manifest (async, non-blocking). Same dispatch pattern as
+    // the capability sync; uses a distinct advisory lock so the two boot syncs do
+    // not serialize against each other. Failures are logged inside
+    // syncToolCatalog and never block startup.
+    setImmediate(() => {
+      syncToolCatalog().catch(() => {
+        // Errors already logged in syncToolCatalog
       });
     });
   }

--- a/lib/db/schema/index.ts
+++ b/lib/db/schema/index.ts
@@ -25,6 +25,7 @@ export * from "./tables/tools";
 export * from "./tables/role-tools";
 export * from "./tables/capabilities";
 export * from "./tables/role-capabilities";
+export * from "./tables/tool-catalog";
 
 // ============================================
 // AI Models

--- a/lib/db/schema/tables/tool-catalog.ts
+++ b/lib/db/schema/tables/tool-catalog.ts
@@ -1,0 +1,111 @@
+/**
+ * Tool Catalog Table Schema
+ *
+ * Issue #924 (Epic #922, workstream #2) — single source of truth for *invocable
+ * units* (tools) exposed by AI Studio across every surface: the MCP server, AI
+ * SDK chat/Nexus, the REST API, and internal agent loops.
+ *
+ * IMPORTANT — this is NOT the legacy `tools` table (`lib/db/schema/tables/tools.ts`),
+ * which is the pre-#923 role-gated *feature flag* registry kept alive as a compat
+ * shim and dropped in workstream #6. To avoid a physical name collision while that
+ * legacy table still exists, the canonical tool catalog lives in `tool_catalog`.
+ *
+ * ## Hybrid model (decision for this issue)
+ *
+ * Code-defined tools live in a TypeScript manifest (`lib/tools/catalog/manifest.ts`)
+ * and are reconciled into this table on boot by `lib/tools/catalog/sync.ts`
+ * (`source = 'code'`), exactly parallel to the capability manifest from #923.
+ * Assistant-derived and (future) skill-derived tools are written to this table by
+ * their own lifecycle hooks (`source = 'assistant'` / `'skill'`). A unified
+ * `ToolCatalog` (`lib/tools/catalog/catalog.ts`) merges manifest + DB at runtime.
+ *
+ * ## Columns of note
+ *
+ * - `identifier` — stable `domain.action` string ID (e.g. `decisions.search`,
+ *   `assistants.execute`). Immutable once shipped (changing it orphans references).
+ * - `version` — `v1`, `v2`, ... Multiple versions of the same logical tool can
+ *   coexist; the UNIQUE constraint is on `(identifier, version)`.
+ * - `surfaces` — JSON array of surfaces that expose this tool
+ *   (`mcp`, `ai_sdk`, `rest`, `internal`).
+ * - `required_scopes` — JSON array of API scope strings the caller must hold.
+ * - `agent_callable` — when false, internal agent loops may NOT invoke the tool
+ *   even if the scope allows it (human-only / destructive guard).
+ * - `source` — `code` (manifest-managed) | `assistant` | `skill`.
+ * - `handler_ref` — for `source = 'code'`, the manifest handler key; for
+ *   `assistant`/`skill`, a pointer (e.g. `assistant:42`) the dispatcher resolves.
+ * - `deprecated_at` / `replaced_by` — version lifecycle (replaced_by points at a
+ *   newer `identifier@version`).
+ *
+ * NOTE: No PL/pgSQL triggers / DO $$ blocks for `updated_at` — the RDS Data API
+ * migration runner's statement splitter cannot handle dollar-quoted blocks (see
+ * migration 079). `updated_at` is maintained by application code via Drizzle
+ * `.set({ updatedAt: new Date() })`.
+ */
+
+import { sql } from "drizzle-orm";
+import {
+  boolean,
+  check,
+  index,
+  jsonb,
+  pgTable,
+  serial,
+  text,
+  timestamp,
+  uniqueIndex,
+  varchar,
+} from "drizzle-orm/pg-core";
+
+/** Surfaces a catalog tool can be exposed on. */
+export type ToolSurface = "mcp" | "ai_sdk" | "rest" | "internal";
+
+/** Source of a catalog tool record. */
+export type ToolCatalogSource = "code" | "assistant" | "skill";
+
+export const toolCatalog = pgTable(
+  "tool_catalog",
+  {
+    id: serial("id").primaryKey(),
+    identifier: varchar("identifier", { length: 150 }).notNull(),
+    version: varchar("version", { length: 20 }).default("v1").notNull(),
+    name: varchar("name", { length: 150 }).notNull(),
+    description: text("description").notNull(),
+    inputSchema: jsonb("input_schema").$type<Record<string, unknown>>(),
+    outputSchema: jsonb("output_schema").$type<Record<string, unknown>>(),
+    surfaces: jsonb("surfaces").$type<ToolSurface[]>().default([]).notNull(),
+    requiredScopes: jsonb("required_scopes")
+      .$type<string[]>()
+      .default([])
+      .notNull(),
+    agentCallable: boolean("agent_callable").default(true).notNull(),
+    source: varchar("source", { length: 20 })
+      .$type<ToolCatalogSource>()
+      .default("code")
+      .notNull(),
+    handlerRef: varchar("handler_ref", { length: 200 }),
+    isActive: boolean("is_active").default(true).notNull(),
+    deprecatedAt: timestamp("deprecated_at"),
+    replacedBy: varchar("replaced_by", { length: 170 }),
+    createdAt: timestamp("created_at").defaultNow().notNull(),
+    updatedAt: timestamp("updated_at").defaultNow().notNull(),
+  },
+  (t) => [
+    // A logical tool is uniquely identified by (identifier, version). Mirrors the
+    // UNIQUE constraint in the migration so the Drizzle schema stays the faithful
+    // source of truth for drift detection / regeneration.
+    uniqueIndex("tool_catalog_identifier_version_key").on(
+      t.identifier,
+      t.version
+    ),
+    check(
+      "tool_catalog_source_check",
+      sql`${t.source} IN ('code', 'assistant', 'skill')`
+    ),
+    index("idx_tool_catalog_identifier").on(t.identifier),
+    index("idx_tool_catalog_source").on(t.source),
+    index("idx_tool_catalog_is_active").on(t.isActive),
+  ]
+);
+
+export type ToolCatalogRow = typeof toolCatalog.$inferSelect;
+export type NewToolCatalogRow = typeof toolCatalog.$inferInsert;

--- a/lib/db/schema/tables/tool-catalog.ts
+++ b/lib/db/schema/tables/tool-catalog.ts
@@ -59,8 +59,14 @@ import {
 /** Surfaces a catalog tool can be exposed on. */
 export type ToolSurface = "mcp" | "ai_sdk" | "rest" | "internal";
 
-/** Source of a catalog tool record. */
-export type ToolCatalogSource = "code" | "assistant" | "skill";
+/**
+ * Source of a catalog tool record.
+ * - `code` — manifest-managed (lib/tools/catalog/manifest.ts).
+ * - `assistant` / `skill` — dynamically registered via their lifecycle hooks.
+ * - `retired` — was code-managed but removed from the manifest; kept inactive so a
+ *   later manifest re-add can re-claim ownership. Never a live tool.
+ */
+export type ToolCatalogSource = "code" | "assistant" | "skill" | "retired";
 
 export const toolCatalog = pgTable(
   "tool_catalog",
@@ -99,7 +105,7 @@ export const toolCatalog = pgTable(
     ),
     check(
       "tool_catalog_source_check",
-      sql`${t.source} IN ('code', 'assistant', 'skill')`
+      sql`${t.source} IN ('code', 'assistant', 'skill', 'retired')`
     ),
     index("idx_tool_catalog_identifier").on(t.identifier),
     index("idx_tool_catalog_source").on(t.source),

--- a/lib/mcp/jsonrpc-handler.ts
+++ b/lib/mcp/jsonrpc-handler.ts
@@ -15,8 +15,7 @@ import {
   JSONRPC_ERRORS,
   MCP_PROTOCOL_VERSION,
 } from "./types"
-import { getToolsForScopes, hasToolScope } from "./tool-registry"
-import { TOOL_HANDLERS } from "./tool-handlers"
+import { toolCatalog_instance } from "@/lib/tools/catalog/catalog"
 import { createLogger } from "@/lib/logger"
 
 // ============================================
@@ -80,7 +79,7 @@ export async function handleJsonRpcRequest(
       return handleInitialize(rpcRequest)
 
     case "tools/list":
-      return handleToolsList(rpcRequest, context)
+      return handleToolsList(rpcRequest, context, log)
 
     case "tools/call":
       return handleToolsCall(rpcRequest, context, log)
@@ -128,11 +127,20 @@ function handleInitialize(rpcRequest: JsonRpcRequest): JsonRpcResponse {
 // tools/list
 // ============================================
 
-function handleToolsList(
+async function handleToolsList(
   rpcRequest: JsonRpcRequest,
-  context: McpToolContext
-): JsonRpcResponse {
-  const tools = getToolsForScopes(context.scopes)
+  context: McpToolContext,
+  log: ReturnType<typeof createLogger>
+): Promise<JsonRpcResponse> {
+  // Catalog-backed: list active tools exposed on the `mcp` surface and filtered
+  // by the caller's scopes. The catalog merges code-manifest tools (the 5
+  // migrated MCP tools) with any assistant/skill-derived MCP tools.
+  const tools = await toolCatalog_instance.list({
+    surface: "mcp",
+    scopes: context.scopes,
+  })
+
+  log.debug("tools/list resolved from catalog", { count: tools.length })
 
   return successResponse(rpcRequest.id, {
     tools: tools.map((t) => ({
@@ -162,22 +170,10 @@ async function handleToolsCall(
     )
   }
 
-  // Scope check
-  if (!hasToolScope(context.scopes, params.name)) {
-    log.warn("MCP tool scope denied", {
-      tool: params.name,
-      userId: context.userId,
-    })
-    return errorResponse(
-      rpcRequest.id,
-      JSONRPC_ERRORS.INVALID_PARAMS.code,
-      `Insufficient scope for tool: ${params.name}`
-    )
-  }
-
-  // Find handler
-  const handler = TOOL_HANDLERS[params.name]
-  if (!handler) {
+  // Resolve the catalog entry first so we can distinguish "unknown tool" from
+  // "scope denied" with the correct JSON-RPC error code.
+  const entry = await toolCatalog_instance.get(params.name)
+  if (!entry || !entry.isActive) {
     return errorResponse(
       rpcRequest.id,
       JSONRPC_ERRORS.METHOD_NOT_FOUND.code,
@@ -186,7 +182,41 @@ async function handleToolsCall(
   }
 
   try {
-    const result = await handler(params.arguments ?? {}, context)
+    // Catalog dispatch performs the scope check and invokes the code handler.
+    // Returns null when the tool has no in-process handler (e.g. an
+    // assistant/skill-derived tool dispatched through a different path).
+    const result = await toolCatalog_instance.dispatch(
+      params.name,
+      params.arguments ?? {},
+      context
+    )
+
+    if (result === null) {
+      log.warn("MCP tool has no dispatchable handler", { tool: params.name })
+      return errorResponse(
+        rpcRequest.id,
+        JSONRPC_ERRORS.METHOD_NOT_FOUND.code,
+        `Tool not dispatchable: ${params.name}`
+      )
+    }
+
+    // A scope denial is surfaced by dispatch() as an isError tool result. Map it
+    // back to the JSON-RPC INVALID_PARAMS code for protocol-correct errors.
+    if (result.isError) {
+      const text = result.content[0]?.text ?? ""
+      if (text.startsWith("Insufficient scope")) {
+        log.warn("MCP tool scope denied", {
+          tool: params.name,
+          userId: context.userId,
+        })
+        return errorResponse(
+          rpcRequest.id,
+          JSONRPC_ERRORS.INVALID_PARAMS.code,
+          text
+        )
+      }
+    }
+
     return successResponse(rpcRequest.id, result)
   } catch (error) {
     log.error("MCP tool execution error", {

--- a/lib/mcp/jsonrpc-handler.ts
+++ b/lib/mcp/jsonrpc-handler.ts
@@ -79,10 +79,10 @@ export async function handleJsonRpcRequest(
       return handleInitialize(rpcRequest)
 
     case "tools/list":
-      return handleToolsList(rpcRequest, context, log)
+      return await handleToolsList(rpcRequest, context, log)
 
     case "tools/call":
-      return handleToolsCall(rpcRequest, context, log)
+      return await handleToolsCall(rpcRequest, context, log)
 
     case "ping":
       return successResponse(rpcRequest.id, {})

--- a/lib/mcp/jsonrpc-handler.ts
+++ b/lib/mcp/jsonrpc-handler.ts
@@ -15,7 +15,7 @@ import {
   JSONRPC_ERRORS,
   MCP_PROTOCOL_VERSION,
 } from "./types"
-import { toolCatalog_instance } from "@/lib/tools/catalog/catalog"
+import { toolCatalogInstance } from "@/lib/tools/catalog/catalog"
 import { createLogger } from "@/lib/logger"
 
 // ============================================
@@ -135,7 +135,7 @@ async function handleToolsList(
   // Catalog-backed: list active tools exposed on the `mcp` surface and filtered
   // by the caller's scopes. The catalog merges code-manifest tools (the 5
   // migrated MCP tools) with any assistant/skill-derived MCP tools.
-  const tools = await toolCatalog_instance.list({
+  const tools = await toolCatalogInstance.list({
     surface: "mcp",
     scopes: context.scopes,
   })
@@ -170,54 +170,47 @@ async function handleToolsCall(
     )
   }
 
-  // Resolve the catalog entry first so we can distinguish "unknown tool" from
-  // "scope denied" with the correct JSON-RPC error code.
-  const entry = await toolCatalog_instance.get(params.name)
-  if (!entry || !entry.isActive) {
-    return errorResponse(
-      rpcRequest.id,
-      JSONRPC_ERRORS.METHOD_NOT_FOUND.code,
-      `Unknown tool: ${params.name}`
-    )
-  }
-
   try {
-    // Catalog dispatch performs the scope check and invokes the code handler.
-    // Returns null when the tool has no in-process handler (e.g. an
-    // assistant/skill-derived tool dispatched through a different path).
-    const result = await toolCatalog_instance.dispatch(
+    // Catalog dispatch owns the full flow: it resolves the MCP-surfaced tool,
+    // checks scope, and invokes the code handler, returning a typed discriminant
+    // so we map each failure to the correct JSON-RPC error code without sniffing
+    // message text.
+    const dispatchResult = await toolCatalogInstance.dispatch(
       params.name,
       params.arguments ?? {},
       context
     )
 
-    if (result === null) {
-      log.warn("MCP tool has no dispatchable handler", { tool: params.name })
-      return errorResponse(
-        rpcRequest.id,
-        JSONRPC_ERRORS.METHOD_NOT_FOUND.code,
-        `Tool not dispatchable: ${params.name}`
-      )
-    }
-
-    // A scope denial is surfaced by dispatch() as an isError tool result. Map it
-    // back to the JSON-RPC INVALID_PARAMS code for protocol-correct errors.
-    if (result.isError) {
-      const text = result.content[0]?.text ?? ""
-      if (text.startsWith("Insufficient scope")) {
-        log.warn("MCP tool scope denied", {
-          tool: params.name,
-          userId: context.userId,
-        })
-        return errorResponse(
-          rpcRequest.id,
-          JSONRPC_ERRORS.INVALID_PARAMS.code,
-          text
-        )
+    if (!dispatchResult.ok) {
+      switch (dispatchResult.reason) {
+        case "scope_denied":
+          log.warn("MCP tool scope denied", {
+            tool: params.name,
+            userId: context.userId,
+          })
+          return errorResponse(
+            rpcRequest.id,
+            JSONRPC_ERRORS.INVALID_PARAMS.code,
+            `Insufficient scope for tool: ${params.name}`
+          )
+        case "no_handler":
+          log.warn("MCP tool has no dispatchable handler", { tool: params.name })
+          return errorResponse(
+            rpcRequest.id,
+            JSONRPC_ERRORS.METHOD_NOT_FOUND.code,
+            `Tool not dispatchable: ${params.name}`
+          )
+        case "unknown":
+        default:
+          return errorResponse(
+            rpcRequest.id,
+            JSONRPC_ERRORS.METHOD_NOT_FOUND.code,
+            `Unknown tool: ${params.name}`
+          )
       }
     }
 
-    return successResponse(rpcRequest.id, result)
+    return successResponse(rpcRequest.id, dispatchResult.result)
   } catch (error) {
     log.error("MCP tool execution error", {
       tool: params.name,

--- a/lib/tools/catalog/catalog.ts
+++ b/lib/tools/catalog/catalog.ts
@@ -185,6 +185,34 @@ export class ToolCatalog {
     return entries;
   }
 
+  /**
+   * Filter a list of requested AI SDK tool names down to those the catalog
+   * exposes on the `ai_sdk` surface AND the caller's scopes permit. This is the
+   * server-side scope gate for built-in chat tools (the chat route receives the
+   * enabled-tools list from the client, which is otherwise untrusted).
+   *
+   * Tools not present in the catalog are passed through unchanged — model-
+   * capability filtering downstream still applies — so this never regresses an
+   * existing tool that has not yet been cataloged.
+   *
+   * @param requested - tool names the caller asked to enable.
+   * @param scopes - the caller's granted scopes.
+   * @returns the allowed subset of `requested`.
+   */
+  async filterAiSdkToolNames(
+    requested: string[],
+    scopes: string[]
+  ): Promise<string[]> {
+    const aiSdkTools = await this.list({ surface: "ai_sdk" });
+    // Index catalog AI SDK tools by wire name.
+    const byName = new Map(aiSdkTools.map((t) => [t.name, t]));
+    return requested.filter((name) => {
+      const entry = byName.get(name);
+      if (!entry) return true; // not cataloged -> leave to downstream filtering
+      return hasRequiredScopes(scopes, entry.requiredScopes);
+    });
+  }
+
   /** Resolve a single tool by identifier (latest matching version) or by name. */
   async get(identifierOrName: string): Promise<ToolCatalogEntry | undefined> {
     const all = await this.list({ includeInactive: true });

--- a/lib/tools/catalog/catalog.ts
+++ b/lib/tools/catalog/catalog.ts
@@ -1,0 +1,232 @@
+/**
+ * Unified Tool Catalog — runtime
+ *
+ * Issue #924 (Epic #922, workstream #2). The single runtime entry point every
+ * surface (MCP server, AI SDK chat/Nexus, REST, internal agents) uses to answer
+ * "what tools exist, who can call them, from which surfaces, with what schema?".
+ *
+ * Sources merged:
+ *   - Code-defined tools from the manifest (`lib/tools/catalog/manifest.ts`).
+ *     These carry their in-process `handler` and are always authoritative for
+ *     their identifier@version.
+ *   - DB-defined tools from `tool_catalog` where `source != 'code'` (assistant-
+ *     and skill-derived). Their handlers dispatch via `handlerRef` (e.g.
+ *     `assistant:42`), resolved by the caller's dispatcher — not held in process.
+ *
+ * The DB read is cached with a short TTL (mirroring settings-manager) because the
+ * catalog is consulted on every chat message and MCP request. Code-manifest
+ * entries need no DB round-trip.
+ *
+ * Scope filtering generalizes the MCP `getToolsForScopes()` pattern to all
+ * surfaces: a caller sees a tool only if it holds every `requiredScope` (or the
+ * `*` wildcard). `agentOnly` additionally drops `agentCallable = false` tools so
+ * internal agent loops cannot invoke human-only / destructive tools.
+ */
+
+import { ne } from "drizzle-orm";
+import { executeQuery } from "@/lib/db/drizzle-client";
+import { toolCatalog } from "@/lib/db/schema";
+import { createLogger } from "@/lib/logger";
+import type { McpToolHandler, McpToolResult, McpToolContext } from "@/lib/mcp/types";
+import { TOOL_MANIFEST } from "@/lib/tools/catalog/manifest";
+import type {
+  ToolCatalogEntry,
+  ToolCatalogFilter,
+  ToolManifestEntry,
+} from "@/lib/tools/catalog/types";
+
+const log = createLogger({ module: "tool-catalog" });
+
+/** DB cache TTL — matches settings-manager's 5-minute cache. */
+const DB_CACHE_TTL_MS = 5 * 60 * 1000;
+
+interface DbCache {
+  entries: ToolCatalogEntry[];
+  expiresAt: number;
+}
+
+/** In-process handler map for code-defined tools, keyed by identifier. */
+function buildHandlerMap(): Map<string, McpToolHandler> {
+  const map = new Map<string, McpToolHandler>();
+  for (const entry of TOOL_MANIFEST) {
+    if (entry.handler) {
+      map.set(entry.identifier, entry.handler);
+    }
+  }
+  return map;
+}
+
+/** Project a manifest entry into a runtime catalog entry. */
+function manifestToEntry(entry: ToolManifestEntry): ToolCatalogEntry {
+  return {
+    identifier: entry.identifier,
+    version: entry.version ?? "v1",
+    name: entry.name,
+    description: entry.description,
+    inputSchema: entry.inputSchema,
+    outputSchema: entry.outputSchema,
+    surfaces: entry.surfaces,
+    requiredScopes: entry.requiredScopes,
+    agentCallable: entry.agentCallable ?? true,
+    source: "code",
+    isActive: true,
+    handlerRef: entry.identifier,
+  };
+}
+
+/** True when `scopes` grant access to a tool requiring `requiredScopes`. */
+function hasRequiredScopes(scopes: string[], requiredScopes: string[]): boolean {
+  if (scopes.includes("*")) return true;
+  // A tool with no required scopes is open to any authenticated caller.
+  if (requiredScopes.length === 0) return true;
+  return requiredScopes.every((s) => scopes.includes(s));
+}
+
+/**
+ * The unified tool catalog. A module-level singleton (`toolCatalogInstance`)
+ * holds the DB cache; the manifest is read fresh from the imported constant.
+ */
+export class ToolCatalog {
+  private dbCache: DbCache | null = null;
+  private readonly handlers: Map<string, McpToolHandler> = buildHandlerMap();
+
+  /** Manifest-derived runtime entries (no DB round-trip). */
+  private manifestEntries(): ToolCatalogEntry[] {
+    return TOOL_MANIFEST.map(manifestToEntry);
+  }
+
+  /** Load non-code DB entries (assistant/skill), cached with a short TTL. */
+  private async dbEntries(): Promise<ToolCatalogEntry[]> {
+    const now = Date.now();
+    if (this.dbCache && this.dbCache.expiresAt > now) {
+      return this.dbCache.entries;
+    }
+
+    try {
+      const rows = await executeQuery(
+        (db) =>
+          db
+            .select()
+            .from(toolCatalog)
+            // Code rows are authoritative from the manifest; only merge the
+            // dynamic (assistant/skill) rows from the DB to avoid double-listing.
+            .where(ne(toolCatalog.source, "code")),
+        "toolCatalog.loadDbEntries"
+      );
+
+      const entries: ToolCatalogEntry[] = rows.map((r) => ({
+        identifier: r.identifier,
+        version: r.version,
+        name: r.name,
+        description: r.description,
+        inputSchema:
+          (r.inputSchema as ToolCatalogEntry["inputSchema"]) ?? {
+            type: "object",
+            properties: {},
+          },
+        outputSchema: r.outputSchema ?? undefined,
+        surfaces: r.surfaces ?? [],
+        requiredScopes: r.requiredScopes ?? [],
+        agentCallable: r.agentCallable,
+        source: r.source,
+        isActive: r.isActive,
+        handlerRef: r.handlerRef ?? undefined,
+      }));
+
+      this.dbCache = { entries, expiresAt: now + DB_CACHE_TTL_MS };
+      return entries;
+    } catch (error) {
+      // On DB failure, degrade gracefully to manifest-only rather than throwing
+      // and breaking every chat/MCP request. Log so the failure is observable.
+      log.error("Failed to load DB tool catalog entries; using manifest only", {
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return [];
+    }
+  }
+
+  /** Invalidate the DB cache (call after assistant/skill catalog writes). */
+  invalidate(): void {
+    this.dbCache = null;
+  }
+
+  /**
+   * List catalog tools, optionally filtered by scopes, surface, and
+   * agent-callability. Active-only by default. Manifest (code) entries win on an
+   * identifier@version collision with a DB row.
+   */
+  async list(filter: ToolCatalogFilter = {}): Promise<ToolCatalogEntry[]> {
+    const merged = new Map<string, ToolCatalogEntry>();
+    for (const e of await this.dbEntries()) {
+      merged.set(`${e.identifier}@${e.version}`, e);
+    }
+    // Manifest entries override DB rows for the same key (code is authoritative).
+    for (const e of this.manifestEntries()) {
+      merged.set(`${e.identifier}@${e.version}`, e);
+    }
+
+    let entries = [...merged.values()];
+
+    if (!filter.includeInactive) {
+      entries = entries.filter((e) => e.isActive);
+    }
+    if (filter.surface) {
+      entries = entries.filter((e) => e.surfaces.includes(filter.surface!));
+    }
+    if (filter.scopes) {
+      entries = entries.filter((e) =>
+        hasRequiredScopes(filter.scopes!, e.requiredScopes)
+      );
+    }
+    if (filter.agentOnly) {
+      entries = entries.filter((e) => e.agentCallable);
+    }
+
+    return entries;
+  }
+
+  /** Resolve a single tool by identifier (latest matching version) or by name. */
+  async get(identifierOrName: string): Promise<ToolCatalogEntry | undefined> {
+    const all = await this.list({ includeInactive: true });
+    return (
+      all.find((e) => e.identifier === identifierOrName) ??
+      all.find((e) => e.name === identifierOrName)
+    );
+  }
+
+  /**
+   * Dispatch an MCP `tools/call` for a code-defined tool. Resolves the tool by
+   * its MCP wire `name` (what clients send), checks scope + active state, and
+   * invokes the in-process handler.
+   *
+   * Returns `null` when the tool is unknown or has no in-process handler (the
+   * caller decides how to surface that — e.g. assistant/skill tools dispatch
+   * through a different path keyed on `handlerRef`).
+   */
+  async dispatch(
+    toolName: string,
+    args: Record<string, unknown>,
+    context: McpToolContext
+  ): Promise<McpToolResult | null> {
+    const entry = await this.get(toolName);
+    if (!entry || !entry.isActive) {
+      return null;
+    }
+    if (!hasRequiredScopes(context.scopes, entry.requiredScopes)) {
+      return {
+        content: [
+          { type: "text", text: `Insufficient scope for tool: ${toolName}` },
+        ],
+        isError: true,
+      };
+    }
+    const handler = this.handlers.get(entry.identifier);
+    if (!handler) {
+      return null;
+    }
+    return handler(args, context);
+  }
+}
+
+/** Process-wide singleton. */
+export const toolCatalog_instance = new ToolCatalog();

--- a/lib/tools/catalog/catalog.ts
+++ b/lib/tools/catalog/catalog.ts
@@ -28,6 +28,7 @@ import { toolCatalog } from "@/lib/db/schema";
 import { createLogger } from "@/lib/logger";
 import type { McpToolHandler, McpToolContext } from "@/lib/mcp/types";
 import { TOOL_MANIFEST } from "@/lib/tools/catalog/manifest";
+import { compareVersionsDesc } from "@/lib/tools/catalog/utils";
 import {
   getFriendlyToolName,
   getAllToolNamesForUI,
@@ -103,25 +104,6 @@ function manifestToEntry(
   };
 }
 
-/**
- * Sort entries so the highest version wins for a given identifier. Versions are
- * `v1`, `v2`, ... — compared numerically on the trailing digits, falling back to
- * a locale string compare so non-`vN` versions still order deterministically.
- */
-function versionRank(version: string): number {
-  const m = /^v(\d+)$/.exec(version);
-  return m ? Number(m[1]) : Number.NaN;
-}
-
-function compareVersionsDesc(a: string, b: string): number {
-  const ra = versionRank(a);
-  const rb = versionRank(b);
-  if (!Number.isNaN(ra) && !Number.isNaN(rb)) return rb - ra;
-  if (!Number.isNaN(ra)) return -1; // numeric versions sort ahead of non-numeric
-  if (!Number.isNaN(rb)) return 1;
-  return b.localeCompare(a);
-}
-
 /** True when `scopes` grant access to a tool requiring `requiredScopes`. */
 function hasRequiredScopes(scopes: string[], requiredScopes: string[]): boolean {
   if (scopes.includes("*")) return true;
@@ -177,7 +159,14 @@ export class ToolCatalog {
         const entries: ToolCatalogEntry[] = [];
         const inactiveCodeKeys = new Set<string>();
         for (const r of rows) {
-          if (r.source === "code") {
+          // Treat both 'code' and 'retired' rows as code-managed for is_active
+          // tracking. A retired row is a code tool removed from the manifest;
+          // if it is later re-added, its admin-disabled state must still be
+          // honored. Without including 'retired' here, the row would leak into
+          // the non-code `entries` list and its key would never reach
+          // `inactiveCodeKeys`, so a re-added tool would spuriously project as
+          // active. (PR #1032 review finding #1.)
+          if (r.source === "code" || r.source === "retired") {
             if (!r.isActive) {
               inactiveCodeKeys.add(entryKey(r.identifier, r.version));
             }
@@ -223,7 +212,17 @@ export class ToolCatalog {
     return this.dbPromise;
   }
 
-  /** Invalidate the DB cache (call after assistant/skill catalog writes). */
+  /**
+   * Invalidate the DB cache (call after assistant/skill catalog writes).
+   *
+   * Note: clearing `dbPromise` here only detaches the reference — it does not
+   * cancel an in-flight `dbState()` query (the underlying fetch cannot be
+   * aborted). Callers already `await`ing the prior promise still receive its
+   * result, but that result is no longer cached (the load's `finally` nulls
+   * `dbPromise` and the cache was cleared), so the next caller issues a fresh
+   * query. This is correctness-safe — it only costs an extra round-trip under
+   * concurrent invalidations. (PR #1032 review finding #2.)
+   */
   invalidate(): void {
     this.dbCache = null;
     this.dbPromise = null;
@@ -294,8 +293,11 @@ export class ToolCatalog {
       const entry = byName.get(name) ?? this.resolveAiSdkAlias(name, byName);
       if (!entry) {
         // Not cataloged under any known name -> leave to downstream
-        // model-capability filtering. Log so the bypass is observable.
-        log.debug("Requested tool not in catalog; passing through unscoped", {
+        // model-capability filtering. Log at `info` (not `debug`) so the scope
+        // bypass is observable in production: operators can monitor the rate of
+        // uncataloged tool names reaching the AI SDK surface. (PR #1032 review
+        // finding #4.)
+        log.info("Requested tool not in catalog; passing through unscoped", {
           tool: name,
         });
         return true;

--- a/lib/tools/catalog/catalog.ts
+++ b/lib/tools/catalog/catalog.ts
@@ -23,15 +23,19 @@
  * internal agent loops cannot invoke human-only / destructive tools.
  */
 
-import { ne } from "drizzle-orm";
 import { executeQuery } from "@/lib/db/drizzle-client";
 import { toolCatalog } from "@/lib/db/schema";
 import { createLogger } from "@/lib/logger";
-import type { McpToolHandler, McpToolResult, McpToolContext } from "@/lib/mcp/types";
+import type { McpToolHandler, McpToolContext } from "@/lib/mcp/types";
 import { TOOL_MANIFEST } from "@/lib/tools/catalog/manifest";
+import {
+  getFriendlyToolName,
+  getAllToolNamesForUI,
+} from "@/lib/tools/tool-name-mapping";
 import type {
   ToolCatalogEntry,
   ToolCatalogFilter,
+  ToolDispatchResult,
   ToolManifestEntry,
 } from "@/lib/tools/catalog/types";
 
@@ -40,8 +44,20 @@ const log = createLogger({ module: "tool-catalog" });
 /** DB cache TTL — matches settings-manager's 5-minute cache. */
 const DB_CACHE_TTL_MS = 5 * 60 * 1000;
 
-interface DbCache {
+interface DbState {
+  /** Non-code (assistant/skill) DB entries, merged into the runtime catalog. */
   entries: ToolCatalogEntry[];
+  /**
+   * `is_active` state of code-managed rows, keyed by `identifier@version`. Lets an
+   * admin disable a code tool in the DB and have the runtime honor it (the manifest
+   * projection otherwise always reports a code tool as active). Only rows recorded
+   * as inactive are tracked; absence means active.
+   */
+  inactiveCodeKeys: Set<string>;
+}
+
+interface DbCache {
+  state: DbState;
   expiresAt: number;
 }
 
@@ -56,11 +72,24 @@ function buildHandlerMap(): Map<string, McpToolHandler> {
   return map;
 }
 
-/** Project a manifest entry into a runtime catalog entry. */
-function manifestToEntry(entry: ToolManifestEntry): ToolCatalogEntry {
+/** The `identifier@version` key used to dedupe and look up entries. */
+function entryKey(identifier: string, version: string): string {
+  return `${identifier}@${version}`;
+}
+
+/**
+ * Project a manifest entry into a runtime catalog entry. `isActive` defaults to
+ * true but is overridden to false when an admin has disabled the code row in the
+ * DB (passed via `inactiveCodeKeys`), so DB disables are honored at runtime.
+ */
+function manifestToEntry(
+  entry: ToolManifestEntry,
+  inactiveCodeKeys: Set<string>
+): ToolCatalogEntry {
+  const version = entry.version ?? "v1";
   return {
     identifier: entry.identifier,
-    version: entry.version ?? "v1",
+    version,
     name: entry.name,
     description: entry.description,
     inputSchema: entry.inputSchema,
@@ -69,9 +98,28 @@ function manifestToEntry(entry: ToolManifestEntry): ToolCatalogEntry {
     requiredScopes: entry.requiredScopes,
     agentCallable: entry.agentCallable ?? true,
     source: "code",
-    isActive: true,
+    isActive: !inactiveCodeKeys.has(entryKey(entry.identifier, version)),
     handlerRef: entry.identifier,
   };
+}
+
+/**
+ * Sort entries so the highest version wins for a given identifier. Versions are
+ * `v1`, `v2`, ... — compared numerically on the trailing digits, falling back to
+ * a locale string compare so non-`vN` versions still order deterministically.
+ */
+function versionRank(version: string): number {
+  const m = /^v(\d+)$/.exec(version);
+  return m ? Number(m[1]) : Number.NaN;
+}
+
+function compareVersionsDesc(a: string, b: string): number {
+  const ra = versionRank(a);
+  const rb = versionRank(b);
+  if (!Number.isNaN(ra) && !Number.isNaN(rb)) return rb - ra;
+  if (!Number.isNaN(ra)) return -1; // numeric versions sort ahead of non-numeric
+  if (!Number.isNaN(rb)) return 1;
+  return b.localeCompare(a);
 }
 
 /** True when `scopes` grant access to a tool requiring `requiredScopes`. */
@@ -88,66 +136,97 @@ function hasRequiredScopes(scopes: string[], requiredScopes: string[]): boolean 
  */
 export class ToolCatalog {
   private dbCache: DbCache | null = null;
+  /**
+   * In-flight DB load. Concurrent callers that arrive while a load is running
+   * reuse this promise instead of each issuing their own query — prevents a cache
+   * stampede on cold start / after `invalidate()`.
+   */
+  private dbPromise: Promise<DbState> | null = null;
   private readonly handlers: Map<string, McpToolHandler> = buildHandlerMap();
 
   /** Manifest-derived runtime entries (no DB round-trip). */
-  private manifestEntries(): ToolCatalogEntry[] {
-    return TOOL_MANIFEST.map(manifestToEntry);
+  private manifestEntries(inactiveCodeKeys: Set<string>): ToolCatalogEntry[] {
+    return TOOL_MANIFEST.map((e) => manifestToEntry(e, inactiveCodeKeys));
   }
 
-  /** Load non-code DB entries (assistant/skill), cached with a short TTL. */
-  private async dbEntries(): Promise<ToolCatalogEntry[]> {
+  /**
+   * Load DB state (non-code entries + code-row inactive set), cached with a short
+   * TTL. Concurrent callers share one in-flight query. On DB failure, degrades to
+   * the last good cache (even if expired) and finally to an empty state, so a
+   * transient outage never throws into every chat/MCP request.
+   */
+  private async dbState(): Promise<DbState> {
     const now = Date.now();
     if (this.dbCache && this.dbCache.expiresAt > now) {
-      return this.dbCache.entries;
+      return this.dbCache.state;
+    }
+    if (this.dbPromise) {
+      return this.dbPromise;
     }
 
-    try {
-      const rows = await executeQuery(
-        (db) =>
-          db
-            .select()
-            .from(toolCatalog)
-            // Code rows are authoritative from the manifest; only merge the
-            // dynamic (assistant/skill) rows from the DB to avoid double-listing.
-            .where(ne(toolCatalog.source, "code")),
-        "toolCatalog.loadDbEntries"
-      );
+    this.dbPromise = (async () => {
+      try {
+        const rows = await executeQuery(
+          (db) => db.select().from(toolCatalog),
+          "toolCatalog.loadDbEntries"
+        );
 
-      const entries: ToolCatalogEntry[] = rows.map((r) => ({
-        identifier: r.identifier,
-        version: r.version,
-        name: r.name,
-        description: r.description,
-        inputSchema:
-          (r.inputSchema as ToolCatalogEntry["inputSchema"]) ?? {
-            type: "object",
-            properties: {},
-          },
-        outputSchema: r.outputSchema ?? undefined,
-        surfaces: r.surfaces ?? [],
-        requiredScopes: r.requiredScopes ?? [],
-        agentCallable: r.agentCallable,
-        source: r.source,
-        isActive: r.isActive,
-        handlerRef: r.handlerRef ?? undefined,
-      }));
+        // Code rows are authoritative from the manifest; only merge the dynamic
+        // (assistant/skill) rows to avoid double-listing. But still read code
+        // rows' is_active so an admin DB disable is honored at runtime.
+        const entries: ToolCatalogEntry[] = [];
+        const inactiveCodeKeys = new Set<string>();
+        for (const r of rows) {
+          if (r.source === "code") {
+            if (!r.isActive) {
+              inactiveCodeKeys.add(entryKey(r.identifier, r.version));
+            }
+            continue;
+          }
+          entries.push({
+            identifier: r.identifier,
+            version: r.version,
+            name: r.name,
+            description: r.description,
+            inputSchema:
+              (r.inputSchema as ToolCatalogEntry["inputSchema"]) ?? {
+                type: "object",
+                properties: {},
+              },
+            outputSchema: r.outputSchema ?? undefined,
+            surfaces: r.surfaces ?? [],
+            requiredScopes: r.requiredScopes ?? [],
+            agentCallable: r.agentCallable,
+            source: r.source,
+            isActive: r.isActive,
+            handlerRef: r.handlerRef ?? undefined,
+          });
+        }
 
-      this.dbCache = { entries, expiresAt: now + DB_CACHE_TTL_MS };
-      return entries;
-    } catch (error) {
-      // On DB failure, degrade gracefully to manifest-only rather than throwing
-      // and breaking every chat/MCP request. Log so the failure is observable.
-      log.error("Failed to load DB tool catalog entries; using manifest only", {
-        error: error instanceof Error ? error.message : String(error),
-      });
-      return [];
-    }
+        const state: DbState = { entries, inactiveCodeKeys };
+        this.dbCache = { state, expiresAt: Date.now() + DB_CACHE_TTL_MS };
+        return state;
+      } catch (error) {
+        // On DB failure, degrade gracefully rather than throwing and breaking
+        // every chat/MCP request. Prefer the last good cache (even expired) over
+        // an empty state so a transient outage does not hide assistant/skill
+        // tools or spuriously re-enable an admin-disabled code tool.
+        log.error("Failed to load DB tool catalog entries; using last cache or manifest only", {
+          error: error instanceof Error ? error.message : String(error),
+        });
+        return this.dbCache?.state ?? { entries: [], inactiveCodeKeys: new Set() };
+      } finally {
+        this.dbPromise = null;
+      }
+    })();
+
+    return this.dbPromise;
   }
 
   /** Invalidate the DB cache (call after assistant/skill catalog writes). */
   invalidate(): void {
     this.dbCache = null;
+    this.dbPromise = null;
   }
 
   /**
@@ -156,13 +235,15 @@ export class ToolCatalog {
    * identifier@version collision with a DB row.
    */
   async list(filter: ToolCatalogFilter = {}): Promise<ToolCatalogEntry[]> {
+    const { entries: dbEntries, inactiveCodeKeys } = await this.dbState();
     const merged = new Map<string, ToolCatalogEntry>();
-    for (const e of await this.dbEntries()) {
-      merged.set(`${e.identifier}@${e.version}`, e);
+    for (const e of dbEntries) {
+      merged.set(entryKey(e.identifier, e.version), e);
     }
-    // Manifest entries override DB rows for the same key (code is authoritative).
-    for (const e of this.manifestEntries()) {
-      merged.set(`${e.identifier}@${e.version}`, e);
+    // Manifest entries override DB rows for the same key (code is authoritative),
+    // but honor an admin's DB is_active=false via inactiveCodeKeys.
+    for (const e of this.manifestEntries(inactiveCodeKeys)) {
+      merged.set(entryKey(e.identifier, e.version), e);
     }
 
     let entries = [...merged.values()];
@@ -204,57 +285,100 @@ export class ToolCatalog {
     scopes: string[]
   ): Promise<string[]> {
     const aiSdkTools = await this.list({ surface: "ai_sdk" });
-    // Index catalog AI SDK tools by wire name.
+    // Index catalog AI SDK tools by wire name. The client may send a friendly
+    // alias (e.g. "webSearch") rather than the catalog wire name
+    // ("web_search_preview"); normalize through TOOL_NAME_MAPPING so the scope
+    // gate is not silently bypassed for aliased tools.
     const byName = new Map(aiSdkTools.map((t) => [t.name, t]));
     return requested.filter((name) => {
-      const entry = byName.get(name);
-      if (!entry) return true; // not cataloged -> leave to downstream filtering
+      const entry = byName.get(name) ?? this.resolveAiSdkAlias(name, byName);
+      if (!entry) {
+        // Not cataloged under any known name -> leave to downstream
+        // model-capability filtering. Log so the bypass is observable.
+        log.debug("Requested tool not in catalog; passing through unscoped", {
+          tool: name,
+        });
+        return true;
+      }
       return hasRequiredScopes(scopes, entry.requiredScopes);
     });
   }
 
-  /** Resolve a single tool by identifier (latest matching version) or by name. */
+  /**
+   * Resolve a client-supplied AI SDK tool alias (e.g. "webSearch") to its catalog
+   * entry. Walks every provider wire name registered for the friendly name so an
+   * OpenAI/Google/Bedrock-specific name also maps back to the same catalog row.
+   */
+  private resolveAiSdkAlias(
+    name: string,
+    byName: Map<string, ToolCatalogEntry>
+  ): ToolCatalogEntry | undefined {
+    const friendly = getFriendlyToolName(name);
+    if (!friendly) return undefined;
+    // The catalog wire `name` is one of the provider-specific names registered
+    // for this friendly tool (e.g. "web_search_preview"). Try every known alias
+    // (friendly + each provider wire name) until one matches a catalog entry.
+    for (const candidate of getAllToolNamesForUI(friendly)) {
+      const entry = byName.get(candidate);
+      if (entry) return entry;
+    }
+    return undefined;
+  }
+
+  /**
+   * Resolve a single tool by identifier or by name, preferring the highest
+   * version when multiple exist for the same identifier.
+   */
   async get(identifierOrName: string): Promise<ToolCatalogEntry | undefined> {
     const all = await this.list({ includeInactive: true });
-    return (
-      all.find((e) => e.identifier === identifierOrName) ??
-      all.find((e) => e.name === identifierOrName)
+    const matches = all.filter(
+      (e) => e.identifier === identifierOrName || e.name === identifierOrName
     );
+    if (matches.length === 0) return undefined;
+    // Prefer identifier matches over name matches, then highest version.
+    matches.sort((a, b) => {
+      const aId = a.identifier === identifierOrName ? 0 : 1;
+      const bId = b.identifier === identifierOrName ? 0 : 1;
+      if (aId !== bId) return aId - bId;
+      return compareVersionsDesc(a.version, b.version);
+    });
+    return matches[0];
   }
 
   /**
    * Dispatch an MCP `tools/call` for a code-defined tool. Resolves the tool by
-   * its MCP wire `name` (what clients send), checks scope + active state, and
-   * invokes the in-process handler.
+   * its MCP wire `name` (what clients send) on the `mcp` surface, checks scope +
+   * active state, and invokes the in-process handler.
    *
-   * Returns `null` when the tool is unknown or has no in-process handler (the
-   * caller decides how to surface that — e.g. assistant/skill tools dispatch
-   * through a different path keyed on `handlerRef`).
+   * Returns a typed {@link ToolDispatchResult} so the caller maps each failure to
+   * the correct protocol error code without inspecting message text:
+   *   - `reason: 'unknown'` — no active tool exposed on the MCP surface by that
+   *     name (also covers ai_sdk-only tools, which must not leak via MCP).
+   *   - `reason: 'scope_denied'` — found, but the caller lacks the required scope.
+   *   - `reason: 'no_handler'` — found and scoped, but no in-process handler (e.g.
+   *     an assistant/skill tool dispatched through a different `handlerRef` path).
    */
   async dispatch(
     toolName: string,
     args: Record<string, unknown>,
     context: McpToolContext
-  ): Promise<McpToolResult | null> {
+  ): Promise<ToolDispatchResult> {
     const entry = await this.get(toolName);
-    if (!entry || !entry.isActive) {
-      return null;
+    // Restrict to MCP-surfaced tools so MCP semantics stay consistent: an
+    // ai_sdk-only tool must report as unknown over MCP rather than leaking.
+    if (!entry || !entry.isActive || !entry.surfaces.includes("mcp")) {
+      return { ok: false, reason: "unknown" };
     }
     if (!hasRequiredScopes(context.scopes, entry.requiredScopes)) {
-      return {
-        content: [
-          { type: "text", text: `Insufficient scope for tool: ${toolName}` },
-        ],
-        isError: true,
-      };
+      return { ok: false, reason: "scope_denied" };
     }
     const handler = this.handlers.get(entry.identifier);
     if (!handler) {
-      return null;
+      return { ok: false, reason: "no_handler" };
     }
-    return handler(args, context);
+    return { ok: true, result: await handler(args, context) };
   }
 }
 
 /** Process-wide singleton. */
-export const toolCatalog_instance = new ToolCatalog();
+export const toolCatalogInstance = new ToolCatalog();

--- a/lib/tools/catalog/catalog.ts
+++ b/lib/tools/catalog/catalog.ts
@@ -200,10 +200,23 @@ export class ToolCatalog {
         // every chat/MCP request. Prefer the last good cache (even expired) over
         // an empty state so a transient outage does not hide assistant/skill
         // tools or spuriously re-enable an admin-disabled code tool.
-        log.error("Failed to load DB tool catalog entries; using last cache or manifest only", {
-          error: error instanceof Error ? error.message : String(error),
-        });
-        return this.dbCache?.state ?? { entries: [], inactiveCodeKeys: new Set() };
+        if (this.dbCache) {
+          log.error("Failed to load DB tool catalog entries; serving last good cache", {
+            error: error instanceof Error ? error.message : String(error),
+          });
+          return this.dbCache.state;
+        }
+        // Cold start with no warm cache: we cannot read `inactiveCodeKeys`, so
+        // every code tool projects as active. This means an admin's DB-level
+        // disable of a code tool is NOT honored until the DB recovers and the
+        // cache warms. Surface this distinctly so on-call knows admin disables
+        // may be temporarily ignored (vs. the warm-cache path, which is safe).
+        // (PR #1032 review finding #1.)
+        log.error(
+          "Failed to load DB tool catalog entries on cold start; admin DB disables NOT honored until DB recovers",
+          { error: error instanceof Error ? error.message : String(error) }
+        );
+        return { entries: [], inactiveCodeKeys: new Set() };
       } finally {
         this.dbPromise = null;
       }
@@ -289,21 +302,38 @@ export class ToolCatalog {
     // ("web_search_preview"); normalize through TOOL_NAME_MAPPING so the scope
     // gate is not silently bypassed for aliased tools.
     const byName = new Map(aiSdkTools.map((t) => [t.name, t]));
-    return requested.filter((name) => {
+    // Cap the number of per-name pass-through logs so a client sending many
+    // fabricated tool names cannot flood the logs with one `info` line each;
+    // overflow is collapsed into a single aggregated warning. The pass-through
+    // itself is still bounded by downstream model-capability filtering. (PR
+    // #1032 review finding #2.)
+    const UNCATALOGED_LOG_CAP = 5;
+    const uncataloged: string[] = [];
+    const allowed = requested.filter((name) => {
       const entry = byName.get(name) ?? this.resolveAiSdkAlias(name, byName);
       if (!entry) {
         // Not cataloged under any known name -> leave to downstream
         // model-capability filtering. Log at `info` (not `debug`) so the scope
         // bypass is observable in production: operators can monitor the rate of
-        // uncataloged tool names reaching the AI SDK surface. (PR #1032 review
-        // finding #4.)
-        log.info("Requested tool not in catalog; passing through unscoped", {
-          tool: name,
-        });
+        // uncataloged tool names reaching the AI SDK surface.
+        if (uncataloged.length < UNCATALOGED_LOG_CAP) {
+          log.info("Requested tool not in catalog; passing through unscoped", {
+            tool: name,
+          });
+        }
+        uncataloged.push(name);
         return true;
       }
       return hasRequiredScopes(scopes, entry.requiredScopes);
     });
+    if (uncataloged.length > UNCATALOGED_LOG_CAP) {
+      log.warn("Many uncataloged tool names passed through unscoped in one request", {
+        total: uncataloged.length,
+        logged: UNCATALOGED_LOG_CAP,
+        suppressed: uncataloged.length - UNCATALOGED_LOG_CAP,
+      });
+    }
+    return allowed;
   }
 
   /**
@@ -330,6 +360,11 @@ export class ToolCatalog {
   /**
    * Resolve a single tool by identifier or by name, preferring the highest
    * version when multiple exist for the same identifier.
+   *
+   * Intentionally includes inactive entries (`includeInactive: true`): callers
+   * such as {@link dispatch} need to distinguish "found but disabled" (reject as
+   * unknown to avoid leaking tool existence) from "never existed". They re-check
+   * `entry.isActive` themselves.
    */
   async get(identifierOrName: string): Promise<ToolCatalogEntry | undefined> {
     const all = await this.list({ includeInactive: true });
@@ -365,6 +400,8 @@ export class ToolCatalog {
     args: Record<string, unknown>,
     context: McpToolContext
   ): Promise<ToolDispatchResult> {
+    // `get()` returns inactive entries too, so re-check `isActive` here: a
+    // found-but-disabled tool must report as unknown (not leak its existence).
     const entry = await this.get(toolName);
     // Restrict to MCP-surfaced tools so MCP semantics stay consistent: an
     // ai_sdk-only tool must report as unknown over MCP rather than leaking.

--- a/lib/tools/catalog/manifest.ts
+++ b/lib/tools/catalog/manifest.ts
@@ -38,6 +38,7 @@ import { MCP_TOOLS } from "@/lib/mcp/tool-registry";
 import { TOOL_HANDLERS } from "@/lib/mcp/tool-handlers";
 import type { McpToolDefinition } from "@/lib/mcp/types";
 import type { ToolManifestEntry } from "./types";
+import { compareVersionsDesc } from "./utils";
 
 /** Source value applied to every manifest-managed catalog row. */
 export const MANIFEST_TOOL_SOURCE = "code" as const;
@@ -179,22 +180,8 @@ export function getManifestEntry(
   const matches = TOOL_MANIFEST.filter((e) => e.identifier === identifier);
   if (matches.length === 0) return undefined;
   return matches.reduce((latest, entry) =>
-    compareManifestVersionsDesc(entry.version ?? "v1", latest.version ?? "v1") < 0
+    compareVersionsDesc(entry.version ?? "v1", latest.version ?? "v1") < 0
       ? entry
       : latest
   );
-}
-
-/** Order two versions so the highest sorts first (negative = `a` is newer). */
-function compareManifestVersionsDesc(a: string, b: string): number {
-  const rank = (v: string): number => {
-    const m = /^v(\d+)$/.exec(v);
-    return m ? Number(m[1]) : Number.NaN;
-  };
-  const ra = rank(a);
-  const rb = rank(b);
-  if (!Number.isNaN(ra) && !Number.isNaN(rb)) return rb - ra;
-  if (!Number.isNaN(ra)) return -1;
-  if (!Number.isNaN(rb)) return 1;
-  return b.localeCompare(a);
 }

--- a/lib/tools/catalog/manifest.ts
+++ b/lib/tools/catalog/manifest.ts
@@ -104,11 +104,68 @@ const MCP_MANIFEST_ENTRIES: ToolManifestEntry[] = MCP_TOOLS.map(
 );
 
 /**
+ * AI SDK tools exposed in chat / Nexus. These are descriptor-only catalog
+ * entries (no in-process MCP `handler`): the concrete tool implementations are
+ * provider-native and built dynamically per request by
+ * `lib/tools/provider-native-tools.ts`. Cataloging them gives the catalog a
+ * complete `surfaces: ['ai_sdk']` view and a single place to scope-gate which
+ * built-in tools a caller may use.
+ *
+ * `show_chart` is universal (always enabled, no scope). The optional tools carry
+ * `chat:write` so a caller without chat write cannot enable them. `name` matches
+ * the wire/registry name the chat route already uses.
+ */
+const AI_SDK_MANIFEST_ENTRIES: ToolManifestEntry[] = [
+  {
+    identifier: "chat.show_chart",
+    version: "v1",
+    name: "show_chart",
+    description:
+      "Render a chart (bar, line, pie, etc.) from structured data on the client.",
+    inputSchema: { type: "object", properties: {} },
+    surfaces: ["ai_sdk"],
+    requiredScopes: [],
+    agentCallable: true,
+  },
+  {
+    identifier: "chat.web_search",
+    version: "v1",
+    name: "web_search_preview",
+    description: "Search the web for current information and facts.",
+    inputSchema: { type: "object", properties: {} },
+    surfaces: ["ai_sdk"],
+    requiredScopes: ["chat:write"],
+    agentCallable: true,
+  },
+  {
+    identifier: "chat.code_interpreter",
+    version: "v1",
+    name: "code_interpreter",
+    description: "Execute code and perform data analysis.",
+    inputSchema: { type: "object", properties: {} },
+    surfaces: ["ai_sdk"],
+    requiredScopes: ["chat:write"],
+    agentCallable: true,
+  },
+  {
+    identifier: "chat.generate_image",
+    version: "v1",
+    name: "generateImage",
+    description: "Generate images from text descriptions using AI models.",
+    inputSchema: { type: "object", properties: {} },
+    surfaces: ["ai_sdk"],
+    requiredScopes: ["chat:write"],
+    agentCallable: true,
+  },
+];
+
+/**
  * The code-managed tool catalog. Boot-time sync reconciles `tool_catalog` to
  * this list; the runtime `ToolCatalog` merges it with DB-sourced entries.
  */
 export const TOOL_MANIFEST: readonly ToolManifestEntry[] = [
   ...MCP_MANIFEST_ENTRIES,
+  ...AI_SDK_MANIFEST_ENTRIES,
 ];
 
 /** Resolve a manifest entry by `domain.action` identifier (latest version). */

--- a/lib/tools/catalog/manifest.ts
+++ b/lib/tools/catalog/manifest.ts
@@ -168,9 +168,33 @@ export const TOOL_MANIFEST: readonly ToolManifestEntry[] = [
   ...AI_SDK_MANIFEST_ENTRIES,
 ];
 
-/** Resolve a manifest entry by `domain.action` identifier (latest version). */
+/**
+ * Resolve a manifest entry by `domain.action` identifier, returning the highest
+ * version when more than one exists. Versions are `v1`, `v2`, ...; non-`vN` values
+ * fall back to a string compare so resolution stays deterministic.
+ */
 export function getManifestEntry(
   identifier: string
 ): ToolManifestEntry | undefined {
-  return TOOL_MANIFEST.find((e) => e.identifier === identifier);
+  const matches = TOOL_MANIFEST.filter((e) => e.identifier === identifier);
+  if (matches.length === 0) return undefined;
+  return matches.reduce((latest, entry) =>
+    compareManifestVersionsDesc(entry.version ?? "v1", latest.version ?? "v1") < 0
+      ? entry
+      : latest
+  );
+}
+
+/** Order two versions so the highest sorts first (negative = `a` is newer). */
+function compareManifestVersionsDesc(a: string, b: string): number {
+  const rank = (v: string): number => {
+    const m = /^v(\d+)$/.exec(v);
+    return m ? Number(m[1]) : Number.NaN;
+  };
+  const ra = rank(a);
+  const rb = rank(b);
+  if (!Number.isNaN(ra) && !Number.isNaN(rb)) return rb - ra;
+  if (!Number.isNaN(ra)) return -1;
+  if (!Number.isNaN(rb)) return 1;
+  return b.localeCompare(a);
 }

--- a/lib/tools/catalog/manifest.ts
+++ b/lib/tools/catalog/manifest.ts
@@ -1,0 +1,119 @@
+/**
+ * Tool Catalog Manifest
+ *
+ * Issue #924 (Epic #922, workstream #2) — the code-defined half of the hybrid
+ * tool catalog. Add an entry here, restart the server, and the boot-time sync
+ * (`lib/tools/catalog/sync.ts`) reconciles it into the `tool_catalog` table with
+ * `source = 'code'`. No SQL migration, no per-surface wiring.
+ *
+ * This is the direct parallel of `lib/capabilities/manifest.ts` (#923), but for
+ * *invocable tools* rather than role-gated UI feature flags.
+ *
+ * ## Identifier convention (decision for this issue)
+ *
+ * `domain.action` (dot-separated), e.g. `decisions.search`, `assistants.execute`.
+ * Chosen over the legacy MCP wire names (`search_decisions`) because the catalog
+ * spans multiple surfaces and the `domain.action` form namespaces cleanly and
+ * reads well in OpenAPI / REST paths. The MCP wire `name` stays the snake_case
+ * value (e.g. `search_decisions`) for backward compatibility with existing MCP
+ * clients — that is the `name` field, distinct from `identifier`.
+ *
+ * ## Rules
+ *
+ * - `identifier` (+ `version`) is the stable key. Never change a shipped
+ *   identifier; it would orphan DB rows and references.
+ * - The manifest owns `name`, `description`, schemas, `surfaces`,
+ *   `requiredScopes`, `agentCallable`, and `handlerRef` for `source = 'code'`
+ *   rows. The sync writes these; it never flips `is_active` (admin disables in
+ *   the DB survive restarts).
+ * - Removing an entry does NOT hard-delete the row; the sync deactivates it
+ *   (and demotes it so a later re-add re-claims ownership).
+ *
+ * Assistant- and skill-derived tools are NOT listed here — they are written to
+ * `tool_catalog` by their own lifecycle hooks with `source = 'assistant'` /
+ * `'skill'` and merged at runtime by `ToolCatalog`.
+ */
+
+import { MCP_TOOLS } from "@/lib/mcp/tool-registry";
+import { TOOL_HANDLERS } from "@/lib/mcp/tool-handlers";
+import type { McpToolDefinition } from "@/lib/mcp/types";
+import type { ToolManifestEntry } from "./types";
+
+/** Source value applied to every manifest-managed catalog row. */
+export const MANIFEST_TOOL_SOURCE = "code" as const;
+
+/**
+ * Map each existing MCP wire tool to its canonical catalog identifier + scope.
+ * Keeps the schema/description single-sourced from `MCP_TOOLS` while assigning
+ * the new `domain.action` identifier and the required scope.
+ */
+const MCP_TOOL_CATALOG_MAP: Record<
+  string,
+  { identifier: string; requiredScope: string }
+> = {
+  search_decisions: {
+    identifier: "decisions.search",
+    requiredScope: "mcp:search_decisions",
+  },
+  capture_decision: {
+    identifier: "decisions.capture",
+    requiredScope: "mcp:capture_decision",
+  },
+  execute_assistant: {
+    identifier: "assistants.execute",
+    requiredScope: "mcp:execute_assistant",
+  },
+  list_assistants: {
+    identifier: "assistants.list",
+    requiredScope: "mcp:list_assistants",
+  },
+  get_decision_graph: {
+    identifier: "decisions.graph_get",
+    requiredScope: "mcp:get_decision_graph",
+  },
+};
+
+/**
+ * The 5 MCP tools, projected into catalog manifest entries. Schemas/descriptions
+ * come straight from `MCP_TOOLS`; handlers from `TOOL_HANDLERS`. `surfaces` is
+ * `['mcp']` initially per the issue's migration plan (expand as appropriate).
+ */
+const MCP_MANIFEST_ENTRIES: ToolManifestEntry[] = MCP_TOOLS.map(
+  (tool: McpToolDefinition): ToolManifestEntry => {
+    const mapping = MCP_TOOL_CATALOG_MAP[tool.name];
+    if (!mapping) {
+      // A new MCP tool was added without a catalog mapping. Fail loudly at module
+      // load (and in tests) rather than silently dropping it from the catalog.
+      throw new Error(
+        `MCP tool "${tool.name}" has no catalog identifier mapping in ` +
+          `lib/tools/catalog/manifest.ts (MCP_TOOL_CATALOG_MAP). Add one.`
+      );
+    }
+    return {
+      identifier: mapping.identifier,
+      version: "v1",
+      name: tool.name,
+      description: tool.description,
+      inputSchema: tool.inputSchema,
+      surfaces: ["mcp"],
+      requiredScopes: [mapping.requiredScope],
+      agentCallable: true,
+      handler: TOOL_HANDLERS[tool.name],
+    };
+  }
+);
+
+/**
+ * The code-managed tool catalog. Boot-time sync reconciles `tool_catalog` to
+ * this list; the runtime `ToolCatalog` merges it with DB-sourced entries.
+ */
+export const TOOL_MANIFEST: readonly ToolManifestEntry[] = [
+  ...MCP_MANIFEST_ENTRIES,
+];
+
+/** Resolve a manifest entry by `domain.action` identifier (latest version). */
+export function getManifestEntry(
+  identifier: string
+): ToolManifestEntry | undefined {
+  return TOOL_MANIFEST.find((e) => e.identifier === identifier);
+}

--- a/lib/tools/catalog/sync.ts
+++ b/lib/tools/catalog/sync.ts
@@ -68,6 +68,151 @@ function sameJson(a: unknown, b: unknown): boolean {
   return JSON.stringify(a ?? null) === JSON.stringify(b ?? null);
 }
 
+/** Transaction handle type as provided by executeTransaction. */
+type Tx = Parameters<Parameters<typeof executeTransaction>[0]>[0];
+
+/** A normalized manifest entry (version + agentCallable defaults applied). */
+type NormalizedEntry = ToolManifestEntry & {
+  version: string;
+  agentCallable: boolean;
+};
+
+/** Snapshot of an existing tool_catalog row (manifest-comparable fields). */
+interface ExistingRow {
+  id: number;
+  identifier: string;
+  version: string;
+  name: string;
+  description: string;
+  inputSchema: unknown;
+  outputSchema: unknown;
+  surfaces: string[] | null;
+  requiredScopes: string[] | null;
+  agentCallable: boolean;
+  handlerRef: string | null;
+  source: string;
+  isActive: boolean;
+}
+
+/** True when an existing row differs from the manifest entry (needs an UPDATE). */
+function rowNeedsUpdate(
+  existingRow: ExistingRow,
+  entry: NormalizedEntry,
+  handlerRef: string,
+  claimingOwnership: boolean
+): boolean {
+  return (
+    existingRow.name !== entry.name ||
+    existingRow.description !== entry.description ||
+    !sameJson(existingRow.inputSchema, entry.inputSchema) ||
+    !sameJson(existingRow.outputSchema, entry.outputSchema ?? null) ||
+    !sameStringArray(existingRow.surfaces ?? [], entry.surfaces) ||
+    !sameStringArray(existingRow.requiredScopes ?? [], entry.requiredScopes) ||
+    existingRow.agentCallable !== entry.agentCallable ||
+    (existingRow.handlerRef ?? null) !== handlerRef ||
+    claimingOwnership
+  );
+}
+
+/**
+ * Insert a new code tool, or update an existing one when a manifest field
+ * changed. Returns the action taken so the caller can record it.
+ */
+async function upsertEntry(
+  tx: Tx,
+  entry: NormalizedEntry,
+  existingRow: ExistingRow | undefined
+): Promise<"inserted" | "updated" | "unchanged"> {
+  const handlerRef = entry.identifier; // manifest dispatches by identifier
+
+  if (existingRow === undefined) {
+    await tx.insert(toolCatalog).values({
+      identifier: entry.identifier,
+      version: entry.version,
+      name: entry.name,
+      description: entry.description,
+      inputSchema: entry.inputSchema,
+      outputSchema: entry.outputSchema ?? null,
+      surfaces: entry.surfaces,
+      requiredScopes: entry.requiredScopes,
+      agentCallable: entry.agentCallable,
+      source: MANIFEST_TOOL_SOURCE,
+      handlerRef,
+      isActive: true,
+    });
+    return "inserted";
+  }
+
+  // Claiming a released/foreign row (source != 'code') re-activates it.
+  const claimingOwnership = existingRow.source !== MANIFEST_TOOL_SOURCE;
+  if (!rowNeedsUpdate(existingRow, entry, handlerRef, claimingOwnership)) {
+    return "unchanged";
+  }
+
+  await tx
+    .update(toolCatalog)
+    .set({
+      name: entry.name,
+      description: entry.description,
+      inputSchema: entry.inputSchema,
+      outputSchema: entry.outputSchema ?? null,
+      surfaces: entry.surfaces,
+      requiredScopes: entry.requiredScopes,
+      agentCallable: entry.agentCallable,
+      handlerRef,
+      source: MANIFEST_TOOL_SOURCE,
+      // Only (re)activate when claiming a released/foreign row. Preserve an
+      // admin's is_active toggle on an already-owned row.
+      ...(claimingOwnership ? { isActive: true } : {}),
+      updatedAt: new Date(),
+    })
+    .where(eq(toolCatalog.id, existingRow.id));
+  return "updated";
+}
+
+/**
+ * Deactivate + demote code tools no longer present in the manifest. Only touches
+ * rows the manifest currently owns (source = 'code'); assistant/skill rows are
+ * never affected. Returns the keys deactivated. Diffs in app code (not notInArray
+ * on a composite key) so version-scoped removal works correctly.
+ */
+async function deactivateOrphans(
+  tx: Tx,
+  manifestKeys: string[]
+): Promise<string[]> {
+  const manifestKeySet = new Set(manifestKeys);
+  const deactivated: string[] = [];
+  const orphanCandidates = await tx
+    .select({
+      id: toolCatalog.id,
+      identifier: toolCatalog.identifier,
+      version: toolCatalog.version,
+    })
+    .from(toolCatalog)
+    .where(
+      and(
+        eq(toolCatalog.source, MANIFEST_TOOL_SOURCE),
+        eq(toolCatalog.isActive, true)
+      )
+    );
+
+  for (const row of orphanCandidates) {
+    const rowKey = keyOf(row.identifier, row.version);
+    if (!manifestKeySet.has(rowKey)) {
+      await tx
+        .update(toolCatalog)
+        .set({
+          isActive: false,
+          source: RELEASED_SOURCE,
+          updatedAt: new Date(),
+        })
+        .where(eq(toolCatalog.id, row.id));
+      deactivated.push(rowKey);
+    }
+  }
+  return deactivated;
+}
+
 /**
  * Sync the tool catalog manifest into the database. Safe to call repeatedly.
  *
@@ -130,7 +275,7 @@ export async function syncToolCatalogManifest(
         const updated: string[] = [];
 
         // Snapshot existing rows for the manifest identifiers in one query.
-        const existing = await tx
+        const existing = (await tx
           .select({
             id: toolCatalog.id,
             identifier: toolCatalog.identifier,
@@ -147,7 +292,9 @@ export async function syncToolCatalogManifest(
             isActive: toolCatalog.isActive,
           })
           .from(toolCatalog)
-          .where(inArray(toolCatalog.identifier, manifestIdentifiers));
+          .where(
+            inArray(toolCatalog.identifier, manifestIdentifiers)
+          )) as ExistingRow[];
 
         const existingByKey = new Map(
           existing.map((row) => [keyOf(row.identifier, row.version), row])
@@ -155,108 +302,12 @@ export async function syncToolCatalogManifest(
 
         for (const entry of normalized) {
           const key = keyOf(entry.identifier, entry.version);
-          const existingRow = existingByKey.get(key);
-          const handlerRef = entry.identifier; // manifest dispatches by identifier
-
-          if (existingRow === undefined) {
-            // INSERT new code tool.
-            await tx.insert(toolCatalog).values({
-              identifier: entry.identifier,
-              version: entry.version,
-              name: entry.name,
-              description: entry.description,
-              inputSchema: entry.inputSchema,
-              outputSchema: entry.outputSchema ?? null,
-              surfaces: entry.surfaces,
-              requiredScopes: entry.requiredScopes,
-              agentCallable: entry.agentCallable,
-              source: MANIFEST_TOOL_SOURCE,
-              handlerRef,
-              isActive: true,
-            });
-            inserted.push(key);
-          } else {
-            // UPDATE manifest-owned fields, but only when something changed.
-            // Claiming a released/foreign row (source != 'code') re-activates it.
-            const claimingOwnership =
-              existingRow.source !== MANIFEST_TOOL_SOURCE;
-            const needsUpdate =
-              existingRow.name !== entry.name ||
-              existingRow.description !== entry.description ||
-              !sameJson(existingRow.inputSchema, entry.inputSchema) ||
-              !sameJson(
-                existingRow.outputSchema,
-                entry.outputSchema ?? null
-              ) ||
-              !sameStringArray(existingRow.surfaces ?? [], entry.surfaces) ||
-              !sameStringArray(
-                existingRow.requiredScopes ?? [],
-                entry.requiredScopes
-              ) ||
-              existingRow.agentCallable !== entry.agentCallable ||
-              (existingRow.handlerRef ?? null) !== handlerRef ||
-              claimingOwnership;
-
-            if (needsUpdate) {
-              await tx
-                .update(toolCatalog)
-                .set({
-                  name: entry.name,
-                  description: entry.description,
-                  inputSchema: entry.inputSchema,
-                  outputSchema: entry.outputSchema ?? null,
-                  surfaces: entry.surfaces,
-                  requiredScopes: entry.requiredScopes,
-                  agentCallable: entry.agentCallable,
-                  handlerRef,
-                  source: MANIFEST_TOOL_SOURCE,
-                  // Only (re)activate when claiming a released/foreign row.
-                  // Preserve an admin's is_active toggle on an owned row.
-                  ...(claimingOwnership ? { isActive: true } : {}),
-                  updatedAt: new Date(),
-                })
-                .where(eq(toolCatalog.id, existingRow.id));
-              updated.push(key);
-            }
-          }
+          const action = await upsertEntry(tx, entry, existingByKey.get(key));
+          if (action === "inserted") inserted.push(key);
+          else if (action === "updated") updated.push(key);
         }
 
-        // DEACTIVATE code tools no longer in the manifest, AND demote them so a
-        // later manifest re-add re-claims ownership (via the claimingOwnership
-        // branch above). Only touches rows the manifest currently owns
-        // (source = 'code'); assistant/skill rows are never affected. We diff in
-        // app code (not notInArray on a composite key) so version-scoped removal
-        // works correctly.
-        const manifestKeySet = new Set(manifestKeys);
-        const deactivated: string[] = [];
-        const orphanCandidates = await tx
-          .select({
-            id: toolCatalog.id,
-            identifier: toolCatalog.identifier,
-            version: toolCatalog.version,
-          })
-          .from(toolCatalog)
-          .where(
-            and(
-              eq(toolCatalog.source, MANIFEST_TOOL_SOURCE),
-              eq(toolCatalog.isActive, true)
-            )
-          );
-
-        for (const row of orphanCandidates) {
-          const rowKey = keyOf(row.identifier, row.version);
-          if (!manifestKeySet.has(rowKey)) {
-            await tx
-              .update(toolCatalog)
-              .set({
-                isActive: false,
-                source: RELEASED_SOURCE,
-                updatedAt: new Date(),
-              })
-              .where(eq(toolCatalog.id, row.id));
-            deactivated.push(rowKey);
-          }
-        }
+        const deactivated = await deactivateOrphans(tx, manifestKeys);
 
         return { inserted, updated, deactivated };
       },

--- a/lib/tools/catalog/sync.ts
+++ b/lib/tools/catalog/sync.ts
@@ -13,9 +13,9 @@
  *     disables a code tool in the DB must stay disabled across restarts. Claiming
  *     ownership of a previously-released row (source != 'code') re-activates it.
  *   - DEACTIVATE code tools no longer in the manifest by setting
- *     `is_active = false` AND demoting `source = 'assistant'` (releases the row so
- *     a later manifest re-add re-claims ownership). Rows with
- *     `source != 'code'` (assistant/skill-derived) are never touched.
+ *     `is_active = false` AND demoting `source = 'retired'` (releases the row so a
+ *     later manifest re-add re-claims ownership). Rows with `source != 'code'`
+ *     (assistant/skill-derived) are never touched.
  *
  * Concurrency: wrapped in a transaction holding a session-scoped advisory lock
  * (`pg_advisory_xact_lock`) so multiple ECS replicas booting at once serialize
@@ -41,8 +41,12 @@ import type { ToolManifestEntry } from "@/lib/tools/catalog/types";
  */
 const SYNC_ADVISORY_LOCK_KEY = 924_001;
 
-/** Source a deactivated/released code row is demoted to. */
-const RELEASED_SOURCE = "assistant" as const;
+/**
+ * Source a deactivated/released code row is demoted to. Distinct from
+ * 'assistant' (a real assistant-derived tool) so a dead code tool is not
+ * mislabeled in the DB, and from 'code' so a manifest re-add re-claims ownership.
+ */
+const RELEASED_SOURCE = "retired" as const;
 
 export interface ToolCatalogSyncResult {
   inserted: string[];
@@ -196,19 +200,27 @@ async function deactivateOrphans(
       )
     );
 
+  const orphanIds: number[] = [];
   for (const row of orphanCandidates) {
     const rowKey = keyOf(row.identifier, row.version);
     if (!manifestKeySet.has(rowKey)) {
-      await tx
-        .update(toolCatalog)
-        .set({
-          isActive: false,
-          source: RELEASED_SOURCE,
-          updatedAt: new Date(),
-        })
-        .where(eq(toolCatalog.id, row.id));
+      orphanIds.push(row.id);
       deactivated.push(rowKey);
     }
+  }
+
+  // Batch the deactivation: the update values are identical for every orphan, so a
+  // single statement avoids N sequential round-trips inside the advisory-locked
+  // transaction (which would hold locks longer during a large manifest removal).
+  if (orphanIds.length > 0) {
+    await tx
+      .update(toolCatalog)
+      .set({
+        isActive: false,
+        source: RELEASED_SOURCE,
+        updatedAt: new Date(),
+      })
+      .where(inArray(toolCatalog.id, orphanIds));
   }
   return deactivated;
 }

--- a/lib/tools/catalog/sync.ts
+++ b/lib/tools/catalog/sync.ts
@@ -1,0 +1,280 @@
+/**
+ * Tool Catalog Manifest Sync
+ *
+ * Issue #924 (Epic #922, workstream #2) — reconciles the `tool_catalog` table to
+ * the code manifest (`lib/tools/catalog/manifest.ts`) on app boot / deploy.
+ * Direct parallel of the capability sync (`lib/capabilities/sync.ts`, #923).
+ *
+ * Behavior (idempotent):
+ *   - INSERT code tools present in the manifest but not in the DB.
+ *   - UPDATE name/description/schema/surfaces/required_scopes/agent_callable/
+ *     handler_ref/source for code tools that exist in both, but ONLY when a value
+ *     actually changed. The manifest never flips `is_active`: an admin who
+ *     disables a code tool in the DB must stay disabled across restarts. Claiming
+ *     ownership of a previously-released row (source != 'code') re-activates it.
+ *   - DEACTIVATE code tools no longer in the manifest by setting
+ *     `is_active = false` AND demoting `source = 'assistant'` (releases the row so
+ *     a later manifest re-add re-claims ownership). Rows with
+ *     `source != 'code'` (assistant/skill-derived) are never touched.
+ *
+ * Concurrency: wrapped in a transaction holding a session-scoped advisory lock
+ * (`pg_advisory_xact_lock`) so multiple ECS replicas booting at once serialize
+ * the sync rather than racing. The lock auto-releases at transaction end.
+ *
+ * A logical tool is keyed by `(identifier, version)`. The sync matches on that
+ * composite key so multiple versions of the same identifier coexist.
+ */
+
+import { and, eq, inArray, sql } from "drizzle-orm";
+import { executeTransaction } from "@/lib/db/drizzle-client";
+import { toolCatalog } from "@/lib/db/schema";
+import { createLogger, generateRequestId, startTimer } from "@/lib/logger";
+import {
+  TOOL_MANIFEST,
+  MANIFEST_TOOL_SOURCE,
+} from "@/lib/tools/catalog/manifest";
+import type { ToolManifestEntry } from "@/lib/tools/catalog/types";
+
+/**
+ * Advisory lock key for the tool catalog sync. Distinct from the capability sync
+ * key (923_001) so the two boot syncs do not serialize against each other.
+ */
+const SYNC_ADVISORY_LOCK_KEY = 924_001;
+
+/** Source a deactivated/released code row is demoted to. */
+const RELEASED_SOURCE = "assistant" as const;
+
+export interface ToolCatalogSyncResult {
+  inserted: string[];
+  updated: string[];
+  deactivated: string[];
+}
+
+/** Composite key for a logical tool. */
+function keyOf(identifier: string, version: string): string {
+  return `${identifier}@${version}`;
+}
+
+/** Normalize an array for stable equality comparison (order-insensitive). */
+function sameStringArray(a: string[], b: string[]): boolean {
+  if (a.length !== b.length) return false;
+  const sa = [...a].sort();
+  const sb = [...b].sort();
+  return sa.every((v, i) => v === sb[i]);
+}
+
+/** Stable JSON comparison for schema objects (null/undefined collapse to null). */
+function sameJson(a: unknown, b: unknown): boolean {
+  return JSON.stringify(a ?? null) === JSON.stringify(b ?? null);
+}
+
+/**
+ * Sync the tool catalog manifest into the database. Safe to call repeatedly.
+ *
+ * @param manifest - Override the manifest (used by tests). Defaults to
+ *                    TOOL_MANIFEST.
+ */
+export async function syncToolCatalogManifest(
+  manifest: readonly ToolManifestEntry[] = TOOL_MANIFEST
+): Promise<ToolCatalogSyncResult> {
+  const requestId = generateRequestId();
+  const timer = startTimer("syncToolCatalogManifest");
+  const log = createLogger({ requestId, operation: "syncToolCatalogManifest" });
+
+  // Normalize manifest entries to (identifier, version) with v1 default.
+  const normalized = manifest.map((e) => ({
+    ...e,
+    version: e.version ?? "v1",
+    agentCallable: e.agentCallable ?? true,
+  }));
+
+  const manifestKeys = normalized.map((e) => keyOf(e.identifier, e.version));
+
+  // Fail fast on a malformed manifest. Duplicate (identifier, version) pairs
+  // would otherwise hit the UNIQUE constraint mid-transaction and roll back the
+  // whole sync silently. A deterministic boot error is far easier to diagnose.
+  const duplicateKeys = manifestKeys.filter(
+    (k, i) => manifestKeys.indexOf(k) !== i
+  );
+  if (duplicateKeys.length > 0) {
+    throw new Error(
+      `TOOL_MANIFEST contains duplicate (identifier, version) pairs: ${[
+        ...new Set(duplicateKeys),
+      ].join(", ")}`
+    );
+  }
+
+  const manifestIdentifiers = normalized.map((e) => e.identifier);
+
+  log.info("Starting tool catalog manifest sync", {
+    manifestCount: normalized.length,
+  });
+
+  try {
+    const result = await executeTransaction<ToolCatalogSyncResult>(
+      async (tx) => {
+        // Serialize concurrent replica syncs. Auto-released at tx end.
+        await tx.execute(
+          sql`SELECT pg_advisory_xact_lock(${SYNC_ADVISORY_LOCK_KEY})`
+        );
+
+        // SAFETY: an empty manifest must be a no-op, NOT a mass-deactivate.
+        if (normalized.length === 0) {
+          log.warn(
+            "Empty tool catalog manifest — skipping sync to avoid mass deactivation"
+          );
+          return { inserted: [], updated: [], deactivated: [] };
+        }
+
+        const inserted: string[] = [];
+        const updated: string[] = [];
+
+        // Snapshot existing rows for the manifest identifiers in one query.
+        const existing = await tx
+          .select({
+            id: toolCatalog.id,
+            identifier: toolCatalog.identifier,
+            version: toolCatalog.version,
+            name: toolCatalog.name,
+            description: toolCatalog.description,
+            inputSchema: toolCatalog.inputSchema,
+            outputSchema: toolCatalog.outputSchema,
+            surfaces: toolCatalog.surfaces,
+            requiredScopes: toolCatalog.requiredScopes,
+            agentCallable: toolCatalog.agentCallable,
+            handlerRef: toolCatalog.handlerRef,
+            source: toolCatalog.source,
+            isActive: toolCatalog.isActive,
+          })
+          .from(toolCatalog)
+          .where(inArray(toolCatalog.identifier, manifestIdentifiers));
+
+        const existingByKey = new Map(
+          existing.map((row) => [keyOf(row.identifier, row.version), row])
+        );
+
+        for (const entry of normalized) {
+          const key = keyOf(entry.identifier, entry.version);
+          const existingRow = existingByKey.get(key);
+          const handlerRef = entry.identifier; // manifest dispatches by identifier
+
+          if (existingRow === undefined) {
+            // INSERT new code tool.
+            await tx.insert(toolCatalog).values({
+              identifier: entry.identifier,
+              version: entry.version,
+              name: entry.name,
+              description: entry.description,
+              inputSchema: entry.inputSchema,
+              outputSchema: entry.outputSchema ?? null,
+              surfaces: entry.surfaces,
+              requiredScopes: entry.requiredScopes,
+              agentCallable: entry.agentCallable,
+              source: MANIFEST_TOOL_SOURCE,
+              handlerRef,
+              isActive: true,
+            });
+            inserted.push(key);
+          } else {
+            // UPDATE manifest-owned fields, but only when something changed.
+            // Claiming a released/foreign row (source != 'code') re-activates it.
+            const claimingOwnership =
+              existingRow.source !== MANIFEST_TOOL_SOURCE;
+            const needsUpdate =
+              existingRow.name !== entry.name ||
+              existingRow.description !== entry.description ||
+              !sameJson(existingRow.inputSchema, entry.inputSchema) ||
+              !sameJson(
+                existingRow.outputSchema,
+                entry.outputSchema ?? null
+              ) ||
+              !sameStringArray(existingRow.surfaces ?? [], entry.surfaces) ||
+              !sameStringArray(
+                existingRow.requiredScopes ?? [],
+                entry.requiredScopes
+              ) ||
+              existingRow.agentCallable !== entry.agentCallable ||
+              (existingRow.handlerRef ?? null) !== handlerRef ||
+              claimingOwnership;
+
+            if (needsUpdate) {
+              await tx
+                .update(toolCatalog)
+                .set({
+                  name: entry.name,
+                  description: entry.description,
+                  inputSchema: entry.inputSchema,
+                  outputSchema: entry.outputSchema ?? null,
+                  surfaces: entry.surfaces,
+                  requiredScopes: entry.requiredScopes,
+                  agentCallable: entry.agentCallable,
+                  handlerRef,
+                  source: MANIFEST_TOOL_SOURCE,
+                  // Only (re)activate when claiming a released/foreign row.
+                  // Preserve an admin's is_active toggle on an owned row.
+                  ...(claimingOwnership ? { isActive: true } : {}),
+                  updatedAt: new Date(),
+                })
+                .where(eq(toolCatalog.id, existingRow.id));
+              updated.push(key);
+            }
+          }
+        }
+
+        // DEACTIVATE code tools no longer in the manifest, AND demote them so a
+        // later manifest re-add re-claims ownership (via the claimingOwnership
+        // branch above). Only touches rows the manifest currently owns
+        // (source = 'code'); assistant/skill rows are never affected. We diff in
+        // app code (not notInArray on a composite key) so version-scoped removal
+        // works correctly.
+        const manifestKeySet = new Set(manifestKeys);
+        const deactivated: string[] = [];
+        const orphanCandidates = await tx
+          .select({
+            id: toolCatalog.id,
+            identifier: toolCatalog.identifier,
+            version: toolCatalog.version,
+          })
+          .from(toolCatalog)
+          .where(
+            and(
+              eq(toolCatalog.source, MANIFEST_TOOL_SOURCE),
+              eq(toolCatalog.isActive, true)
+            )
+          );
+
+        for (const row of orphanCandidates) {
+          const rowKey = keyOf(row.identifier, row.version);
+          if (!manifestKeySet.has(rowKey)) {
+            await tx
+              .update(toolCatalog)
+              .set({
+                isActive: false,
+                source: RELEASED_SOURCE,
+                updatedAt: new Date(),
+              })
+              .where(eq(toolCatalog.id, row.id));
+            deactivated.push(rowKey);
+          }
+        }
+
+        return { inserted, updated, deactivated };
+      },
+      "syncToolCatalogManifest"
+    );
+
+    timer({ status: "success" });
+    log.info("Tool catalog manifest sync complete", {
+      inserted: result.inserted.length,
+      updated: result.updated.length,
+      deactivated: result.deactivated.length,
+    });
+    return result;
+  } catch (error) {
+    timer({ status: "error" });
+    log.error("Tool catalog manifest sync failed", {
+      error: error instanceof Error ? error.message : "Unknown error",
+    });
+    throw error;
+  }
+}

--- a/lib/tools/catalog/sync.ts
+++ b/lib/tools/catalog/sync.ts
@@ -67,9 +67,32 @@ function sameStringArray(a: string[], b: string[]): boolean {
   return sa.every((v, i) => v === sb[i]);
 }
 
-/** Stable JSON comparison for schema objects (null/undefined collapse to null). */
+/**
+ * Stable JSON comparison for schema objects (null/undefined collapse to null).
+ *
+ * Serializes with object keys sorted at every depth so the comparison is
+ * insensitive to key ordering. Postgres may store/return JSONB keys in a
+ * different order than the manifest declares them; a naive `JSON.stringify`
+ * would then report the stored schema as different from the manifest schema and
+ * trigger a spurious `UPDATE` on every sync. (PR #1032 review finding #7.)
+ */
 function sameJson(a: unknown, b: unknown): boolean {
-  return JSON.stringify(a ?? null) === JSON.stringify(b ?? null);
+  return stableStringify(a ?? null) === stableStringify(b ?? null);
+}
+
+/** JSON.stringify with object keys sorted recursively for order-stable output. */
+function stableStringify(value: unknown): string {
+  return JSON.stringify(value, (_key, val) => {
+    if (val && typeof val === "object" && !Array.isArray(val)) {
+      return Object.keys(val as Record<string, unknown>)
+        .sort()
+        .reduce<Record<string, unknown>>((acc, k) => {
+          acc[k] = (val as Record<string, unknown>)[k];
+          return acc;
+        }, {});
+    }
+    return val;
+  });
 }
 
 /** Transaction handle type as provided by executeTransaction. */

--- a/lib/tools/catalog/types.ts
+++ b/lib/tools/catalog/types.ts
@@ -16,9 +16,23 @@ import type {
   ToolSurface,
   ToolCatalogSource,
 } from "@/lib/db/schema/tables/tool-catalog";
-import type { McpToolDefinition, McpToolHandler } from "@/lib/mcp/types";
+import type {
+  McpToolDefinition,
+  McpToolHandler,
+  McpToolResult,
+} from "@/lib/mcp/types";
 
 export type { ToolSurface, ToolCatalogSource };
+
+/**
+ * Discriminated result of `ToolCatalog.dispatch()`. Carries the failure reason as
+ * a typed field rather than encoding it in a human-readable message string, so
+ * callers (e.g. the MCP JSON-RPC handler) map to protocol error codes by matching
+ * on `reason` — not by sniffing message text that can change or be localized.
+ */
+export type ToolDispatchResult =
+  | { ok: true; result: McpToolResult }
+  | { ok: false; reason: "unknown" | "scope_denied" | "no_handler" };
 
 /**
  * The merged, runtime-facing view of a single tool — produced by `ToolCatalog`

--- a/lib/tools/catalog/types.ts
+++ b/lib/tools/catalog/types.ts
@@ -1,0 +1,104 @@
+/**
+ * Unified Tool Catalog — shared types
+ *
+ * Issue #924 (Epic #922, workstream #2). These types are the contract shared by
+ * the code manifest (`manifest.ts`), the boot-time sync (`sync.ts`), and the
+ * runtime catalog (`catalog.ts`).
+ *
+ * A "tool" here is an *invocable unit* AI Studio exposes to callers — distinct
+ * from a "capability" (#923), which is a role-gated UI feature flag. Externally
+ * *consumed* MCP tools (per-user connector tools resolved by
+ * `lib/mcp/connector-service.ts`) are deliberately NOT cataloged here; the
+ * catalog tracks only tools AI Studio itself owns and exposes.
+ */
+
+import type {
+  ToolSurface,
+  ToolCatalogSource,
+} from "@/lib/db/schema/tables/tool-catalog";
+import type { McpToolDefinition, McpToolHandler } from "@/lib/mcp/types";
+
+export type { ToolSurface, ToolCatalogSource };
+
+/**
+ * The merged, runtime-facing view of a single tool — produced by `ToolCatalog`
+ * from either a manifest entry (`source = 'code'`) or a DB row
+ * (`source = 'assistant' | 'skill'`).
+ */
+export interface ToolCatalogEntry {
+  /** Stable `domain.action` ID. Immutable once shipped. */
+  identifier: string;
+  /** Version string (`v1`, `v2`, ...). */
+  version: string;
+  /** Model/human-facing tool name (what MCP `tools/list` reports as `name`). */
+  name: string;
+  /** Model/human-readable description. */
+  description: string;
+  /** JSON Schema for tool input (MCP `inputSchema` shape). */
+  inputSchema: McpToolDefinition["inputSchema"];
+  /** Optional JSON Schema for tool output. */
+  outputSchema?: Record<string, unknown>;
+  /** Surfaces that expose this tool. */
+  surfaces: ToolSurface[];
+  /** API scope strings the caller must hold to see/invoke this tool. */
+  requiredScopes: string[];
+  /** When false, internal agent loops may NOT invoke this tool. */
+  agentCallable: boolean;
+  /** Where this entry comes from. */
+  source: ToolCatalogSource;
+  /** Whether the tool is currently exposed. */
+  isActive: boolean;
+  /**
+   * Handler dispatch reference. For `source = 'code'` this is the manifest
+   * handler key. For `assistant`/`skill` it is a pointer the dispatcher resolves
+   * (e.g. `assistant:42`).
+   */
+  handlerRef?: string;
+}
+
+/**
+ * A single code-defined tool. Lives in the TypeScript manifest and is reconciled
+ * into the `tool_catalog` table on boot (`source = 'code'`). The `handler` is the
+ * in-process function the catalog dispatcher calls for MCP `tools/call`.
+ */
+export interface ToolManifestEntry {
+  /** Stable `domain.action` ID. Immutable once shipped. */
+  identifier: string;
+  /** Version string. Defaults to `v1` if omitted. */
+  version?: string;
+  /** Model/human-facing tool name (the MCP wire `name`). */
+  name: string;
+  /** Description shown to models and humans. */
+  description: string;
+  /** JSON Schema for tool input. */
+  inputSchema: McpToolDefinition["inputSchema"];
+  /** Optional JSON Schema for tool output. */
+  outputSchema?: Record<string, unknown>;
+  /** Surfaces this tool is exposed on. */
+  surfaces: ToolSurface[];
+  /** API scopes required to see/invoke this tool. */
+  requiredScopes: string[];
+  /**
+   * When false, internal agent loops may NOT invoke this tool even if the scope
+   * allows it (human-only / destructive guard). Defaults to true.
+   */
+  agentCallable?: boolean;
+  /**
+   * In-process handler invoked for MCP `tools/call`. The catalog dispatcher
+   * routes to this by `identifier`. Optional for surfaces (e.g. pure `ai_sdk`
+   * provider-native tools) that do not dispatch through the MCP handler path.
+   */
+  handler?: McpToolHandler;
+}
+
+/** Filter inputs for `ToolCatalog.list()`. */
+export interface ToolCatalogFilter {
+  /** Caller's granted scopes. `*` grants everything. Omit to skip scope filtering. */
+  scopes?: string[];
+  /** Only return tools exposed on this surface. */
+  surface?: ToolSurface;
+  /** When true, exclude tools with `agentCallable = false`. */
+  agentOnly?: boolean;
+  /** Include inactive tools (default: active only). */
+  includeInactive?: boolean;
+}

--- a/lib/tools/catalog/utils.ts
+++ b/lib/tools/catalog/utils.ts
@@ -1,0 +1,32 @@
+/**
+ * Unified Tool Catalog — shared utilities
+ *
+ * Issue #924 (Epic #922, workstream #2). Small pure helpers shared by the
+ * manifest (`manifest.ts`) and the runtime catalog (`catalog.ts`) to avoid
+ * duplicating version-ordering logic. (PR #1032 review finding #6.)
+ */
+
+/**
+ * Numeric rank of a version string. Versions are `v1`, `v2`, ...; the trailing
+ * digits are parsed numerically. Non-`vN` values return `NaN` so the comparator
+ * can fall back to a deterministic string compare.
+ */
+export function versionRank(version: string): number {
+  const m = /^v(\d+)$/.exec(version);
+  return m ? Number(m[1]) : Number.NaN;
+}
+
+/**
+ * Order two versions so the highest sorts first (negative = `a` is newer).
+ * Numeric (`vN`) versions sort ahead of non-numeric ones; ties between two
+ * non-numeric versions fall back to a reverse locale compare so ordering stays
+ * deterministic.
+ */
+export function compareVersionsDesc(a: string, b: string): number {
+  const ra = versionRank(a);
+  const rb = versionRank(b);
+  if (!Number.isNaN(ra) && !Number.isNaN(rb)) return rb - ra;
+  if (!Number.isNaN(ra)) return -1; // numeric versions sort ahead of non-numeric
+  if (!Number.isNaN(rb)) return 1;
+  return b.localeCompare(a);
+}

--- a/tests/e2e/mcp-tool-catalog.spec.ts
+++ b/tests/e2e/mcp-tool-catalog.spec.ts
@@ -1,0 +1,85 @@
+import { test, expect } from '@playwright/test'
+
+/**
+ * E2E tests for the catalog-backed MCP server (Issue #924, Epic #922 ws#2).
+ *
+ * Exercises the JSON-RPC 2.0 endpoint POST /api/mcp at the API level (no browser
+ * auth UI — MCP uses a Bearer API key). Covers the issue's e2e flows:
+ *   - MCP tools/list returns catalog-backed tools
+ *   - MCP tools/call dispatches via the catalog
+ *
+ * Auth note: the authenticated flows require an MCP API key (sk-...) with the
+ * relevant mcp:* scopes. Set MCP_E2E_API_KEY to run them; otherwise they skip
+ * (CI has no seeded key). The unauthenticated gate tests are CI-compatible and
+ * require no key. The deterministic catalog logic (merge, scope/surface filter,
+ * dispatch, boot auto-registration) is covered by unit + integration tests under
+ * tests/unit/lib/tools and tests/unit/lib/mcp/jsonrpc-catalog.test.ts.
+ */
+
+const MCP_KEY = process.env.MCP_E2E_API_KEY
+
+function rpc(method: string, params?: Record<string, unknown>, id = 1) {
+  return { jsonrpc: '2.0', method, id, ...(params ? { params } : {}) }
+}
+
+test.describe('MCP server — auth gate', () => {
+  test('POST /api/mcp without Authorization is rejected', async ({ request }) => {
+    const resp = await request.post('/api/mcp', { data: rpc('tools/list') })
+    // Unauthenticated requests must not reach the catalog. The auth middleware
+    // returns a 401 (exact body is auth-middleware's concern).
+    expect(resp.status()).toBe(401)
+  })
+
+  test('POST /api/mcp with an invalid bearer is rejected', async ({ request }) => {
+    const resp = await request.post('/api/mcp', {
+      headers: { Authorization: 'Bearer sk-not-a-real-key' },
+      data: rpc('tools/list'),
+    })
+    expect(resp.status()).toBe(401)
+  })
+})
+
+test.describe('MCP server — catalog-backed dispatch', () => {
+  test.skip(!MCP_KEY, 'Set MCP_E2E_API_KEY to run authenticated MCP flows')
+
+  test('tools/list returns catalog-backed tools', async ({ request }) => {
+    const resp = await request.post('/api/mcp', {
+      headers: { Authorization: `Bearer ${MCP_KEY}` },
+      data: rpc('tools/list'),
+    })
+    expect(resp.status()).toBe(200)
+    const body = await resp.json()
+    expect(body.jsonrpc).toBe('2.0')
+    const tools = body.result?.tools as Array<{ name: string; inputSchema: unknown }>
+    expect(Array.isArray(tools)).toBe(true)
+    // The catalog exposes the migrated MCP tools by their wire name.
+    const names = tools.map((t) => t.name)
+    expect(names).toContain('search_decisions')
+    // Every listed tool carries a JSON-Schema inputSchema from the catalog.
+    expect(tools.every((t) => typeof t.inputSchema === 'object')).toBe(true)
+  })
+
+  test('tools/call dispatches via the catalog', async ({ request }) => {
+    const resp = await request.post('/api/mcp', {
+      headers: { Authorization: `Bearer ${MCP_KEY}` },
+      data: rpc('tools/call', {
+        name: 'search_decisions',
+        arguments: { query: 'e2e smoke', limit: 1 },
+      }),
+    })
+    expect(resp.status()).toBe(200)
+    const body = await resp.json()
+    expect(body.jsonrpc).toBe('2.0')
+    // A successful dispatch returns an MCP tool result (content array).
+    expect(Array.isArray(body.result?.content)).toBe(true)
+  })
+
+  test('tools/call for an unknown tool returns METHOD_NOT_FOUND', async ({ request }) => {
+    const resp = await request.post('/api/mcp', {
+      headers: { Authorization: `Bearer ${MCP_KEY}` },
+      data: rpc('tools/call', { name: 'no_such_tool', arguments: {} }),
+    })
+    const body = await resp.json()
+    expect(body.error?.code).toBe(-32601)
+  })
+})

--- a/tests/unit/lib/mcp/jsonrpc-catalog.test.ts
+++ b/tests/unit/lib/mcp/jsonrpc-catalog.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, beforeEach } from "@jest/globals"
+
+// Integration test for the catalog-backed MCP JSON-RPC path (#924). Exercises the
+// acceptance-criteria flows:
+//   - MCP tools/list returns catalog-backed tools (scope-filtered)
+//   - MCP tools/call dispatches via the catalog handler
+// The DB layer is mocked so only manifest (code) tools are in play; tool handlers
+// are mocked so we can assert dispatch reaches them.
+
+let dbRows: Record<string, unknown>[] = []
+/* eslint-disable no-var */
+// `var` so jest.mock's hoisting can reference it from the mock factory.
+var searchHandler: jest.Mock
+/* eslint-enable no-var */
+searchHandler = jest.fn(async () => ({
+  content: [{ type: "text", text: "ok" }],
+}))
+
+jest.mock("drizzle-orm", () => ({
+  ne: (...args: unknown[]) => ({ op: "ne", args }),
+}))
+
+jest.mock("@/lib/db/schema", () => ({
+  toolCatalog: { table: "tool_catalog", source: "tool_catalog.source" },
+}))
+
+jest.mock("@/lib/db/drizzle-client", () => ({
+  executeQuery: jest.fn(() => Promise.resolve(dbRows)),
+}))
+
+jest.mock("@/lib/logger", () => ({
+  createLogger: () => ({
+    info: jest.fn(),
+    debug: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  }),
+}))
+
+jest.mock("@/lib/mcp/tool-handlers", () => ({
+  TOOL_HANDLERS: {
+    search_decisions: (
+      args: Record<string, unknown>,
+      context: unknown
+    ) => searchHandler(args, context),
+    capture_decision: jest.fn(),
+    execute_assistant: jest.fn(),
+    list_assistants: jest.fn(),
+    get_decision_graph: jest.fn(),
+  },
+}))
+
+import { handleJsonRpcRequest } from "@/lib/mcp/jsonrpc-handler"
+import type { McpToolContext } from "@/lib/mcp/types"
+
+function ctx(scopes: string[]): McpToolContext {
+  return { userId: 1, cognitoSub: "sub", scopes, requestId: "req" }
+}
+
+describe("MCP JSON-RPC via catalog", () => {
+  beforeEach(() => {
+    dbRows = []
+    searchHandler.mockClear()
+  })
+
+  it("tools/list returns catalog-backed MCP tools filtered by scope", async () => {
+    const res = await handleJsonRpcRequest(
+      { jsonrpc: "2.0", method: "tools/list", id: 1 },
+      ctx(["mcp:search_decisions"])
+    )
+    const result = res.result as { tools: { name: string }[] }
+    expect(result.tools.map((t) => t.name)).toEqual(["search_decisions"])
+  })
+
+  it("tools/list with wildcard returns all 5 MCP tools", async () => {
+    const res = await handleJsonRpcRequest(
+      { jsonrpc: "2.0", method: "tools/list", id: 2 },
+      ctx(["*"])
+    )
+    const result = res.result as { tools: { name: string }[] }
+    expect(result.tools).toHaveLength(5)
+  })
+
+  it("tools/call dispatches via the catalog handler", async () => {
+    const res = await handleJsonRpcRequest(
+      {
+        jsonrpc: "2.0",
+        method: "tools/call",
+        id: 3,
+        params: { name: "search_decisions", arguments: { query: "x" } },
+      },
+      ctx(["mcp:search_decisions"])
+    )
+    expect(searchHandler).toHaveBeenCalledTimes(1)
+    expect(res.result).toEqual({ content: [{ type: "text", text: "ok" }] })
+  })
+
+  it("tools/call denies a tool the caller lacks scope for (INVALID_PARAMS)", async () => {
+    const res = await handleJsonRpcRequest(
+      {
+        jsonrpc: "2.0",
+        method: "tools/call",
+        id: 4,
+        params: { name: "search_decisions", arguments: {} },
+      },
+      ctx([])
+    )
+    expect(searchHandler).not.toHaveBeenCalled()
+    expect(res.error?.code).toBe(-32602)
+    expect(res.error?.message).toMatch(/Insufficient scope/)
+  })
+
+  it("tools/call returns METHOD_NOT_FOUND for an unknown tool", async () => {
+    const res = await handleJsonRpcRequest(
+      {
+        jsonrpc: "2.0",
+        method: "tools/call",
+        id: 5,
+        params: { name: "no_such_tool", arguments: {} },
+      },
+      ctx(["*"])
+    )
+    expect(res.error?.code).toBe(-32601)
+  })
+})

--- a/tests/unit/lib/mcp/jsonrpc-catalog.test.ts
+++ b/tests/unit/lib/mcp/jsonrpc-catalog.test.ts
@@ -52,6 +52,14 @@ jest.mock("@/lib/mcp/tool-handlers", () => ({
 
 import { handleJsonRpcRequest } from "@/lib/mcp/jsonrpc-handler"
 import type { McpToolContext } from "@/lib/mcp/types"
+import { TOOL_MANIFEST } from "@/lib/tools/catalog/manifest"
+
+// Derive the expected MCP tool count from the manifest so this test self-updates
+// when an MCP tool is added/removed, rather than asserting a hardcoded length.
+// (PR #1032 review finding #10.)
+const MCP_TOOL_COUNT = TOOL_MANIFEST.filter((t) =>
+  t.surfaces.includes("mcp")
+).length
 
 function ctx(scopes: string[]): McpToolContext {
   return { userId: 1, cognitoSub: "sub", scopes, requestId: "req" }
@@ -72,13 +80,13 @@ describe("MCP JSON-RPC via catalog", () => {
     expect(result.tools.map((t) => t.name)).toEqual(["search_decisions"])
   })
 
-  it("tools/list with wildcard returns all 5 MCP tools", async () => {
+  it("tools/list with wildcard returns all MCP tools", async () => {
     const res = await handleJsonRpcRequest(
       { jsonrpc: "2.0", method: "tools/list", id: 2 },
       ctx(["*"])
     )
     const result = res.result as { tools: { name: string }[] }
-    expect(result.tools).toHaveLength(5)
+    expect(result.tools).toHaveLength(MCP_TOOL_COUNT)
   })
 
   it("tools/call dispatches via the catalog handler", async () => {

--- a/tests/unit/lib/tools/catalog-sync.test.ts
+++ b/tests/unit/lib/tools/catalog-sync.test.ts
@@ -19,7 +19,7 @@ interface FakeTool {
   requiredScopes: string[]
   agentCallable: boolean
   handlerRef: string | null
-  source: "code" | "assistant" | "skill"
+  source: "code" | "assistant" | "skill" | "retired"
   isActive: boolean
 }
 
@@ -155,31 +155,39 @@ function makeTx() {
     update() {
       return {
         set(vals: Record<string, unknown>) {
+          const applyVals = (row: FakeTool) => {
+            if (vals.name !== undefined) row.name = String(vals.name)
+            if (vals.description !== undefined)
+              row.description = String(vals.description)
+            if (vals.inputSchema !== undefined)
+              row.inputSchema = vals.inputSchema
+            if (vals.outputSchema !== undefined)
+              row.outputSchema = vals.outputSchema
+            if (vals.surfaces !== undefined)
+              row.surfaces = vals.surfaces as string[]
+            if (vals.requiredScopes !== undefined)
+              row.requiredScopes = vals.requiredScopes as string[]
+            if (vals.agentCallable !== undefined)
+              row.agentCallable = Boolean(vals.agentCallable)
+            if (vals.handlerRef !== undefined)
+              row.handlerRef = vals.handlerRef as string | null
+            if (vals.source !== undefined)
+              row.source = vals.source as FakeTool["source"]
+            if (vals.isActive !== undefined)
+              row.isActive = Boolean(vals.isActive)
+          }
           return {
             where(cond: { op: string; args: unknown[] }) {
               if (cond?.op === "eq") {
                 const id = Number((cond.args as unknown[])[1])
                 const row = fakeTools.find((t) => t.id === id)
-                if (row) {
-                  if (vals.name !== undefined) row.name = String(vals.name)
-                  if (vals.description !== undefined)
-                    row.description = String(vals.description)
-                  if (vals.inputSchema !== undefined)
-                    row.inputSchema = vals.inputSchema
-                  if (vals.outputSchema !== undefined)
-                    row.outputSchema = vals.outputSchema
-                  if (vals.surfaces !== undefined)
-                    row.surfaces = vals.surfaces as string[]
-                  if (vals.requiredScopes !== undefined)
-                    row.requiredScopes = vals.requiredScopes as string[]
-                  if (vals.agentCallable !== undefined)
-                    row.agentCallable = Boolean(vals.agentCallable)
-                  if (vals.handlerRef !== undefined)
-                    row.handlerRef = vals.handlerRef as string | null
-                  if (vals.source !== undefined)
-                    row.source = vals.source as FakeTool["source"]
-                  if (vals.isActive !== undefined)
-                    row.isActive = Boolean(vals.isActive)
+                if (row) applyVals(row)
+              } else if (cond?.op === "inArray") {
+                // Batch deactivation: args[1] is the array of ids.
+                const ids = (cond.args as unknown[])[1] as number[]
+                const idSet = new Set(ids.map((n) => Number(n)))
+                for (const row of fakeTools) {
+                  if (idSet.has(row.id)) applyVals(row)
                 }
               }
               return Promise.resolve(undefined)
@@ -268,7 +276,7 @@ describe("syncToolCatalogManifest", () => {
     expect(result.deactivated).toEqual(["decisions.capture@v1"])
     const dropped = fakeTools.find((t) => t.identifier === "decisions.capture")!
     expect(dropped.isActive).toBe(false)
-    expect(dropped.source).toBe("assistant") // demoted/released
+    expect(dropped.source).toBe("retired") // demoted/released
   })
 
   it("never touches assistant/skill-derived rows during deactivation", async () => {
@@ -299,10 +307,11 @@ describe("syncToolCatalogManifest", () => {
     await runSync([entry()])
     // Release it by removing from manifest.
     await runSync([])
-    // Empty manifest is a guarded no-op, so manually release for the test.
+    // Empty manifest is a guarded no-op, so manually release for the test
+    // (mirrors deactivateOrphans demoting a removed code row to 'retired').
     const row = fakeTools[0]
     row.isActive = false
-    row.source = "assistant"
+    row.source = "retired"
 
     const result = await runSync([entry()])
     expect(result.updated).toContain("decisions.search@v1")

--- a/tests/unit/lib/tools/catalog-sync.test.ts
+++ b/tests/unit/lib/tools/catalog-sync.test.ts
@@ -1,0 +1,326 @@
+import { describe, it, expect, beforeEach } from "@jest/globals"
+
+// ============================================
+// Stateful in-memory fake for the tool_catalog table. We mock executeTransaction
+// to drive the sync's chained Drizzle calls against this fake so we can assert
+// insert/update/deactivate/idempotency precisely. Mirrors the capabilities sync
+// test (tests/unit/lib/capabilities/sync.test.ts).
+// ============================================
+
+interface FakeTool {
+  id: number
+  identifier: string
+  version: string
+  name: string
+  description: string
+  inputSchema: unknown
+  outputSchema: unknown
+  surfaces: string[]
+  requiredScopes: string[]
+  agentCallable: boolean
+  handlerRef: string | null
+  source: "code" | "assistant" | "skill"
+  isActive: boolean
+}
+
+/* eslint-disable no-var */
+var fakeTools: FakeTool[]
+var nextToolId: number
+/* eslint-enable no-var */
+
+jest.mock("@/lib/db/schema", () => ({
+  toolCatalog: {
+    table: "tool_catalog",
+    id: "tool_catalog.id",
+    identifier: "tool_catalog.identifier",
+    version: "tool_catalog.version",
+    source: "tool_catalog.source",
+    isActive: "tool_catalog.isActive",
+  },
+}))
+
+jest.mock("drizzle-orm", () => ({
+  eq: (...args: unknown[]) => ({ op: "eq", args }),
+  and: (...args: unknown[]) => ({ op: "and", args }),
+  inArray: (...args: unknown[]) => ({ op: "inArray", args }),
+  ne: (...args: unknown[]) => ({ op: "ne", args }),
+  sql: (() => {
+    const fn = (...args: unknown[]) => ({ op: "sql", args })
+    return fn
+  })(),
+}))
+
+jest.mock("@/lib/logger", () => ({
+  createLogger: () => ({
+    info: jest.fn(),
+    debug: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  }),
+  generateRequestId: () => "test-id",
+  startTimer: () => jest.fn(),
+}))
+
+// sync.ts imports the manifest (-> tool-handlers -> DB layer). Mock the handlers
+// so the manifest builds without pulling the real DB modules. The sync test
+// drives its own manifest via runSync(), so handler identity is irrelevant here.
+jest.mock("@/lib/mcp/tool-handlers", () => ({
+  TOOL_HANDLERS: {
+    search_decisions: jest.fn(),
+    capture_decision: jest.fn(),
+    execute_assistant: jest.fn(),
+    list_assistants: jest.fn(),
+    get_decision_graph: jest.fn(),
+  },
+}))
+
+function snapshotRow(t: FakeTool) {
+  return {
+    id: t.id,
+    identifier: t.identifier,
+    version: t.version,
+    name: t.name,
+    description: t.description,
+    inputSchema: t.inputSchema,
+    outputSchema: t.outputSchema,
+    surfaces: t.surfaces,
+    requiredScopes: t.requiredScopes,
+    agentCallable: t.agentCallable,
+    handlerRef: t.handlerRef,
+    source: t.source,
+    isActive: t.isActive,
+  }
+}
+
+function makeTx() {
+  // Track which select() the sync is issuing. The sync issues two selects:
+  //  1. snapshot of manifest identifiers (.from().where())
+  //  2. orphan candidates (.from().where()) — distinguished by being the 2nd
+  //     select call in the run.
+  let selectCount = 0
+  return {
+    execute: jest.fn(() => Promise.resolve([])),
+
+    select() {
+      const which = selectCount++
+      return {
+        from() {
+          return {
+            where() {
+              if (which === 0) {
+                // snapshot of all rows (sync filters by identifier in SQL; the
+                // fake returns all and the sync matches by composite key).
+                return Promise.resolve(fakeTools.map(snapshotRow))
+              }
+              // orphan candidates: active code rows.
+              return Promise.resolve(
+                fakeTools
+                  .filter((t) => t.source === "code" && t.isActive)
+                  .map((t) => ({
+                    id: t.id,
+                    identifier: t.identifier,
+                    version: t.version,
+                  }))
+              )
+            },
+          }
+        },
+      }
+    },
+
+    insert() {
+      return {
+        values(vals: Record<string, unknown>) {
+          const row: FakeTool = {
+            id: nextToolId++,
+            identifier: String(vals.identifier),
+            version: String(vals.version ?? "v1"),
+            name: String(vals.name),
+            description: String(vals.description),
+            inputSchema: vals.inputSchema ?? null,
+            outputSchema: vals.outputSchema ?? null,
+            surfaces: (vals.surfaces as string[]) ?? [],
+            requiredScopes: (vals.requiredScopes as string[]) ?? [],
+            agentCallable: vals.agentCallable !== false,
+            handlerRef: (vals.handlerRef as string | null) ?? null,
+            source: (vals.source as FakeTool["source"]) ?? "code",
+            isActive: vals.isActive !== false,
+          }
+          fakeTools.push(row)
+          return Promise.resolve(undefined)
+        },
+      }
+    },
+
+    update() {
+      return {
+        set(vals: Record<string, unknown>) {
+          return {
+            where(cond: { op: string; args: unknown[] }) {
+              if (cond?.op === "eq") {
+                const id = Number((cond.args as unknown[])[1])
+                const row = fakeTools.find((t) => t.id === id)
+                if (row) {
+                  if (vals.name !== undefined) row.name = String(vals.name)
+                  if (vals.description !== undefined)
+                    row.description = String(vals.description)
+                  if (vals.inputSchema !== undefined)
+                    row.inputSchema = vals.inputSchema
+                  if (vals.outputSchema !== undefined)
+                    row.outputSchema = vals.outputSchema
+                  if (vals.surfaces !== undefined)
+                    row.surfaces = vals.surfaces as string[]
+                  if (vals.requiredScopes !== undefined)
+                    row.requiredScopes = vals.requiredScopes as string[]
+                  if (vals.agentCallable !== undefined)
+                    row.agentCallable = Boolean(vals.agentCallable)
+                  if (vals.handlerRef !== undefined)
+                    row.handlerRef = vals.handlerRef as string | null
+                  if (vals.source !== undefined)
+                    row.source = vals.source as FakeTool["source"]
+                  if (vals.isActive !== undefined)
+                    row.isActive = Boolean(vals.isActive)
+                }
+              }
+              return Promise.resolve(undefined)
+            },
+          }
+        },
+      }
+    },
+  }
+}
+
+jest.mock("@/lib/db/drizzle-client", () => ({
+  executeQuery: jest.fn(() => Promise.resolve([])),
+  executeTransaction: jest.fn((cb: (tx: unknown) => Promise<unknown>) =>
+    cb(makeTx())
+  ),
+}))
+
+import { syncToolCatalogManifest } from "@/lib/tools/catalog/sync"
+import type { ToolManifestEntry } from "@/lib/tools/catalog/types"
+
+function resetState() {
+  fakeTools = []
+  nextToolId = 100
+}
+
+function runSync(manifest: ToolManifestEntry[]) {
+  return syncToolCatalogManifest(manifest)
+}
+
+function entry(over: Partial<ToolManifestEntry> = {}): ToolManifestEntry {
+  return {
+    identifier: "decisions.search",
+    version: "v1",
+    name: "search_decisions",
+    description: "Search decisions",
+    inputSchema: { type: "object", properties: {} },
+    surfaces: ["mcp"],
+    requiredScopes: ["mcp:search_decisions"],
+    agentCallable: true,
+    ...over,
+  }
+}
+
+describe("syncToolCatalogManifest", () => {
+  beforeEach(() => {
+    resetState()
+  })
+
+  it("inserts new tools that are not in the DB", async () => {
+    const result = await runSync([entry()])
+    expect(result.inserted).toEqual(["decisions.search@v1"])
+    expect(result.updated).toEqual([])
+    expect(fakeTools).toHaveLength(1)
+    expect(fakeTools[0]).toMatchObject({
+      identifier: "decisions.search",
+      version: "v1",
+      source: "code",
+      isActive: true,
+      handlerRef: "decisions.search",
+    })
+  })
+
+  it("is idempotent — a second sync with no changes is a no-op", async () => {
+    await runSync([entry()])
+    const second = await runSync([entry()])
+    expect(second.inserted).toEqual([])
+    expect(second.updated).toEqual([])
+    expect(second.deactivated).toEqual([])
+    expect(fakeTools).toHaveLength(1)
+  })
+
+  it("updates only when a manifest field changes", async () => {
+    await runSync([entry()])
+    const result = await runSync([entry({ description: "New description" })])
+    expect(result.updated).toEqual(["decisions.search@v1"])
+    expect(fakeTools[0].description).toBe("New description")
+  })
+
+  it("deactivates and demotes a code tool removed from the manifest", async () => {
+    await runSync([entry(), entry({ identifier: "decisions.capture", name: "capture_decision" })])
+    expect(fakeTools).toHaveLength(2)
+
+    // Drop decisions.capture from the manifest.
+    const result = await runSync([entry()])
+    expect(result.deactivated).toEqual(["decisions.capture@v1"])
+    const dropped = fakeTools.find((t) => t.identifier === "decisions.capture")!
+    expect(dropped.isActive).toBe(false)
+    expect(dropped.source).toBe("assistant") // demoted/released
+  })
+
+  it("never touches assistant/skill-derived rows during deactivation", async () => {
+    await runSync([entry()])
+    // Simulate an assistant-derived row in the DB.
+    fakeTools.push({
+      id: 999,
+      identifier: "assistants.custom",
+      version: "v1",
+      name: "custom",
+      description: "x",
+      inputSchema: null,
+      outputSchema: null,
+      surfaces: ["mcp"],
+      requiredScopes: [],
+      agentCallable: true,
+      handlerRef: "assistant:7",
+      source: "assistant",
+      isActive: true,
+    })
+    await runSync([entry()])
+    const assistantRow = fakeTools.find((t) => t.id === 999)!
+    expect(assistantRow.isActive).toBe(true)
+    expect(assistantRow.source).toBe("assistant")
+  })
+
+  it("re-claims ownership of a previously-released row (reactivates)", async () => {
+    await runSync([entry()])
+    // Release it by removing from manifest.
+    await runSync([])
+    // Empty manifest is a guarded no-op, so manually release for the test.
+    const row = fakeTools[0]
+    row.isActive = false
+    row.source = "assistant"
+
+    const result = await runSync([entry()])
+    expect(result.updated).toContain("decisions.search@v1")
+    expect(fakeTools[0].isActive).toBe(true)
+    expect(fakeTools[0].source).toBe("code")
+  })
+
+  it("throws on duplicate (identifier, version) pairs", async () => {
+    await expect(runSync([entry(), entry()])).rejects.toThrow(
+      /duplicate \(identifier, version\)/
+    )
+  })
+
+  it("skips an empty manifest to avoid mass deactivation", async () => {
+    await runSync([entry()])
+    const result = await runSync([])
+    expect(result.inserted).toEqual([])
+    expect(result.deactivated).toEqual([])
+    expect(fakeTools[0].isActive).toBe(true)
+  })
+})

--- a/tests/unit/lib/tools/catalog.test.ts
+++ b/tests/unit/lib/tools/catalog.test.ts
@@ -18,14 +18,21 @@ jest.mock("@/lib/db/drizzle-client", () => ({
   executeQuery: jest.fn(() => Promise.resolve(dbRows)),
 }))
 
-jest.mock("@/lib/logger", () => ({
-  createLogger: () => ({
+// Shared logger singleton so tests can inspect the same instance the catalog
+// captures at module load. The singleton lives entirely inside the (hoisted)
+// factory — referencing any top-level `const` here would throw, because
+// `import { ToolCatalog }` is hoisted above this file and calls createLogger()
+// before top-level declarations initialize. Tests retrieve the instance via
+// `jest.requireMock("@/lib/logger").createLogger()` (idempotent — same object).
+jest.mock("@/lib/logger", () => {
+  const singleton = {
     info: jest.fn(),
     debug: jest.fn(),
     warn: jest.fn(),
     error: jest.fn(),
-  }),
-}))
+  }
+  return { createLogger: () => singleton }
+})
 
 // The manifest imports tool-handlers (real service/DB layer) for code-tool
 // handlers. Mock it so the manifest builds without pulling the DB modules.
@@ -40,6 +47,15 @@ jest.mock("@/lib/mcp/tool-handlers", () => ({
 }))
 
 import { ToolCatalog } from "@/lib/tools/catalog/catalog"
+import { TOOL_MANIFEST } from "@/lib/tools/catalog/manifest"
+
+// Derive expected MCP tool count from the manifest rather than hardcoding it,
+// so adding/removing an MCP-surface manifest tool updates these assertions
+// automatically (a hardcoded count would silently pass even if a newly-added
+// MCP tool were incorrectly filtered out). (PR #1032 review finding #3.)
+const MCP_TOOL_COUNT = TOOL_MANIFEST.filter((t) =>
+  t.surfaces.includes("mcp")
+).length
 
 describe("ToolCatalog", () => {
   beforeEach(() => {
@@ -59,7 +75,7 @@ describe("ToolCatalog", () => {
   it("wildcard scope sees all MCP tools", async () => {
     const catalog = new ToolCatalog()
     const tools = await catalog.list({ surface: "mcp", scopes: ["*"] })
-    expect(tools.length).toBe(5)
+    expect(tools.length).toBe(MCP_TOOL_COUNT)
     expect(tools.every((t) => t.surfaces.includes("mcp"))).toBe(true)
   })
 
@@ -238,7 +254,63 @@ describe("ToolCatalog", () => {
     executeQuery.mockRejectedValueOnce(new Error("db down"))
     const catalog = new ToolCatalog()
     const tools = await catalog.list({ surface: "mcp", scopes: ["*"] })
-    // The 5 manifest MCP tools are still returned.
-    expect(tools.length).toBe(5)
+    // The manifest MCP tools are still returned.
+    expect(tools.length).toBe(MCP_TOOL_COUNT)
+  })
+
+  it("invalidate() busts the DB cache so a later list() sees new rows", async () => {
+    const catalog = new ToolCatalog()
+    // Warm the cache with no DB rows.
+    const before = await catalog.list({ surface: "mcp", scopes: ["*"] })
+    expect(before.some((t) => t.name === "late_assistant")).toBe(false)
+
+    // Add a DB row, then invalidate so the next list() re-reads from the DB
+    // instead of serving the warm (now-stale) cache.
+    dbRows = [
+      {
+        identifier: "assistants.late",
+        version: "v1",
+        name: "late_assistant",
+        description: "x",
+        inputSchema: { type: "object", properties: {} },
+        outputSchema: null,
+        surfaces: ["mcp"],
+        requiredScopes: [],
+        agentCallable: true,
+        source: "assistant",
+        isActive: true,
+        handlerRef: "assistant:7",
+      },
+    ]
+    catalog.invalidate()
+
+    const after = await catalog.list({ surface: "mcp", scopes: ["*"] })
+    expect(after.some((t) => t.name === "late_assistant")).toBe(true)
+  })
+
+  it("filterAiSdkToolNames caps per-name pass-through logging and warns on overflow", async () => {
+    // The catalog captures the shared logger at module load; retrieve the same
+    // singleton instance (createLogger returns the same object every call).
+    const { createLogger } = jest.requireMock("@/lib/logger") as {
+      createLogger: () => { info: jest.Mock; warn: jest.Mock }
+    }
+    const mockLogger = createLogger()
+    mockLogger.info.mockClear()
+    mockLogger.warn.mockClear()
+
+    const catalog = new ToolCatalog()
+    // 8 fabricated names -> all pass through, but only 5 info logs + 1 warn.
+    const fabricated = Array.from({ length: 8 }, (_, i) => `fake_tool_${i}`)
+    const allowed = await catalog.filterAiSdkToolNames(fabricated, [])
+    expect(allowed.sort()).toEqual(fabricated.sort())
+
+    const infoCalls = mockLogger.info.mock.calls.filter(
+      (c) => c[0] === "Requested tool not in catalog; passing through unscoped"
+    )
+    expect(infoCalls.length).toBe(5)
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      "Many uncataloged tool names passed through unscoped in one request",
+      expect.objectContaining({ total: 8, logged: 5, suppressed: 3 })
+    )
   })
 })

--- a/tests/unit/lib/tools/catalog.test.ts
+++ b/tests/unit/lib/tools/catalog.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect, beforeEach } from "@jest/globals"
+
+// The catalog reads non-code rows from the DB; mock that to a controllable set.
+// Manifest (code) entries are read from the real manifest constant.
+let dbRows: Record<string, unknown>[] = []
+
+jest.mock("drizzle-orm", () => ({
+  ne: (...args: unknown[]) => ({ op: "ne", args }),
+}))
+
+jest.mock("@/lib/db/schema", () => ({
+  toolCatalog: { table: "tool_catalog", source: "tool_catalog.source" },
+}))
+
+jest.mock("@/lib/db/drizzle-client", () => ({
+  executeQuery: jest.fn(() => Promise.resolve(dbRows)),
+}))
+
+jest.mock("@/lib/logger", () => ({
+  createLogger: () => ({
+    info: jest.fn(),
+    debug: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  }),
+}))
+
+// The manifest imports tool-handlers (real service/DB layer) for code-tool
+// handlers. Mock it so the manifest builds without pulling the DB modules.
+jest.mock("@/lib/mcp/tool-handlers", () => ({
+  TOOL_HANDLERS: {
+    search_decisions: jest.fn(),
+    capture_decision: jest.fn(),
+    execute_assistant: jest.fn(),
+    list_assistants: jest.fn(),
+    get_decision_graph: jest.fn(),
+  },
+}))
+
+import { ToolCatalog } from "@/lib/tools/catalog/catalog"
+
+describe("ToolCatalog", () => {
+  beforeEach(() => {
+    dbRows = []
+  })
+
+  it("lists MCP-surface tools and filters by scope", async () => {
+    const catalog = new ToolCatalog()
+    // Caller with only search scope sees exactly one MCP tool.
+    const tools = await catalog.list({
+      surface: "mcp",
+      scopes: ["mcp:search_decisions"],
+    })
+    expect(tools.map((t) => t.name)).toEqual(["search_decisions"])
+  })
+
+  it("wildcard scope sees all MCP tools", async () => {
+    const catalog = new ToolCatalog()
+    const tools = await catalog.list({ surface: "mcp", scopes: ["*"] })
+    expect(tools.length).toBe(5)
+    expect(tools.every((t) => t.surfaces.includes("mcp"))).toBe(true)
+  })
+
+  it("filters AI SDK tools by surface", async () => {
+    const catalog = new ToolCatalog()
+    const tools = await catalog.list({ surface: "ai_sdk", scopes: ["*"] })
+    const names = tools.map((t) => t.name).sort()
+    expect(names).toEqual([
+      "code_interpreter",
+      "generateImage",
+      "show_chart",
+      "web_search_preview",
+    ])
+  })
+
+  it("filterAiSdkToolNames drops tools the caller lacks scope for", async () => {
+    const catalog = new ToolCatalog()
+    // No chat:write -> only show_chart (no scope) survives; an uncataloged name
+    // passes through untouched.
+    const allowed = await catalog.filterAiSdkToolNames(
+      ["show_chart", "web_search_preview", "uncataloged_tool"],
+      []
+    )
+    expect(allowed.sort()).toEqual(["show_chart", "uncataloged_tool"])
+  })
+
+  it("filterAiSdkToolNames keeps scoped tools when the scope is held", async () => {
+    const catalog = new ToolCatalog()
+    const allowed = await catalog.filterAiSdkToolNames(
+      ["show_chart", "web_search_preview"],
+      ["chat:write"]
+    )
+    expect(allowed.sort()).toEqual(["show_chart", "web_search_preview"])
+  })
+
+  it("agentOnly excludes non-agent-callable DB tools", async () => {
+    dbRows = [
+      {
+        identifier: "assistants.destructive",
+        version: "v1",
+        name: "destructive",
+        description: "x",
+        inputSchema: { type: "object", properties: {} },
+        outputSchema: null,
+        surfaces: ["mcp"],
+        requiredScopes: [],
+        agentCallable: false,
+        source: "assistant",
+        isActive: true,
+        handlerRef: "assistant:1",
+      },
+    ]
+    const catalog = new ToolCatalog()
+    const all = await catalog.list({ surface: "mcp", scopes: ["*"] })
+    expect(all.some((t) => t.name === "destructive")).toBe(true)
+    const agentTools = await catalog.list({
+      surface: "mcp",
+      scopes: ["*"],
+      agentOnly: true,
+    })
+    expect(agentTools.some((t) => t.name === "destructive")).toBe(false)
+  })
+
+  it("merges DB (assistant) tools with manifest tools", async () => {
+    dbRows = [
+      {
+        identifier: "assistants.custom",
+        version: "v1",
+        name: "custom_assistant",
+        description: "x",
+        inputSchema: { type: "object", properties: {} },
+        outputSchema: null,
+        surfaces: ["mcp"],
+        requiredScopes: [],
+        agentCallable: true,
+        source: "assistant",
+        isActive: true,
+        handlerRef: "assistant:42",
+      },
+    ]
+    const catalog = new ToolCatalog()
+    const tools = await catalog.list({ surface: "mcp", scopes: ["*"] })
+    expect(tools.some((t) => t.name === "custom_assistant")).toBe(true)
+    expect(tools.some((t) => t.name === "search_decisions")).toBe(true)
+  })
+
+  it("dispatch denies a tool the caller lacks scope for", async () => {
+    const catalog = new ToolCatalog()
+    const result = await catalog.dispatch(
+      "search_decisions",
+      {},
+      { userId: 1, cognitoSub: "s", scopes: [], requestId: "r" }
+    )
+    expect(result?.isError).toBe(true)
+    expect(result?.content[0]?.text).toMatch(/Insufficient scope/)
+  })
+
+  it("dispatch returns null for an unknown tool", async () => {
+    const catalog = new ToolCatalog()
+    const result = await catalog.dispatch(
+      "no_such_tool",
+      {},
+      { userId: 1, cognitoSub: "s", scopes: ["*"], requestId: "r" }
+    )
+    expect(result).toBeNull()
+  })
+
+  it("degrades to manifest-only when the DB read fails", async () => {
+    const { executeQuery } = jest.requireMock("@/lib/db/drizzle-client") as {
+      executeQuery: jest.Mock
+    }
+    executeQuery.mockRejectedValueOnce(new Error("db down"))
+    const catalog = new ToolCatalog()
+    const tools = await catalog.list({ surface: "mcp", scopes: ["*"] })
+    // The 5 manifest MCP tools are still returned.
+    expect(tools.length).toBe(5)
+  })
+})

--- a/tests/unit/lib/tools/catalog.test.ts
+++ b/tests/unit/lib/tools/catalog.test.ts
@@ -6,6 +6,8 @@ let dbRows: Record<string, unknown>[] = []
 
 jest.mock("drizzle-orm", () => ({
   ne: (...args: unknown[]) => ({ op: "ne", args }),
+  eq: (...args: unknown[]) => ({ op: "eq", args }),
+  inArray: (...args: unknown[]) => ({ op: "inArray", args }),
 }))
 
 jest.mock("@/lib/db/schema", () => ({
@@ -64,13 +66,16 @@ describe("ToolCatalog", () => {
   it("filters AI SDK tools by surface", async () => {
     const catalog = new ToolCatalog()
     const tools = await catalog.list({ surface: "ai_sdk", scopes: ["*"] })
-    const names = tools.map((t) => t.name).sort()
-    expect(names).toEqual([
+    const names = tools.map((t) => t.name)
+    // Assert membership (not exact length/order) so adding a manifest tool does
+    // not break this test.
+    expect(names).toEqual(expect.arrayContaining([
       "code_interpreter",
       "generateImage",
       "show_chart",
       "web_search_preview",
-    ])
+    ]))
+    expect(tools.every((t) => t.surfaces.includes("ai_sdk"))).toBe(true)
   })
 
   it("filterAiSdkToolNames drops tools the caller lacks scope for", async () => {
@@ -91,6 +96,54 @@ describe("ToolCatalog", () => {
       ["chat:write"]
     )
     expect(allowed.sort()).toEqual(["show_chart", "web_search_preview"])
+  })
+
+  it("filterAiSdkToolNames scope-gates client-supplied friendly aliases", async () => {
+    const catalog = new ToolCatalog()
+    // The client sends the friendly names (webSearch/codeInterpreter), not the
+    // catalog wire names. Without chat:write these must be dropped, not passed
+    // through as 'uncataloged'.
+    const denied = await catalog.filterAiSdkToolNames(
+      ["webSearch", "codeInterpreter"],
+      []
+    )
+    expect(denied).toEqual([])
+
+    const allowed = await catalog.filterAiSdkToolNames(
+      ["webSearch", "codeInterpreter"],
+      ["chat:write"]
+    )
+    expect(allowed.sort()).toEqual(["codeInterpreter", "webSearch"])
+  })
+
+  it("respects an admin-disabled code tool (DB is_active=false)", async () => {
+    dbRows = [
+      {
+        identifier: "decisions.search",
+        version: "v1",
+        name: "search_decisions",
+        description: "x",
+        inputSchema: { type: "object", properties: {} },
+        outputSchema: null,
+        surfaces: ["mcp"],
+        requiredScopes: ["mcp:search_decisions"],
+        agentCallable: true,
+        source: "code",
+        isActive: false,
+        handlerRef: "decisions.search",
+      },
+    ]
+    const catalog = new ToolCatalog()
+    const tools = await catalog.list({ surface: "mcp", scopes: ["*"] })
+    // The manifest projection must NOT force the admin-disabled tool back to active.
+    expect(tools.some((t) => t.name === "search_decisions")).toBe(false)
+    // Dispatch of the disabled tool is rejected as unknown.
+    const result = await catalog.dispatch(
+      "search_decisions",
+      {},
+      { userId: 1, cognitoSub: "s", scopes: ["*"], requestId: "r" }
+    )
+    expect(result.ok).toBe(false)
   })
 
   it("agentOnly excludes non-agent-callable DB tools", async () => {
@@ -151,18 +204,31 @@ describe("ToolCatalog", () => {
       {},
       { userId: 1, cognitoSub: "s", scopes: [], requestId: "r" }
     )
-    expect(result?.isError).toBe(true)
-    expect(result?.content[0]?.text).toMatch(/Insufficient scope/)
+    expect(result.ok).toBe(false)
+    expect(result.ok === false && result.reason).toBe("scope_denied")
   })
 
-  it("dispatch returns null for an unknown tool", async () => {
+  it("dispatch reports unknown for an unknown tool", async () => {
     const catalog = new ToolCatalog()
     const result = await catalog.dispatch(
       "no_such_tool",
       {},
       { userId: 1, cognitoSub: "s", scopes: ["*"], requestId: "r" }
     )
-    expect(result).toBeNull()
+    expect(result.ok).toBe(false)
+    expect(result.ok === false && result.reason).toBe("unknown")
+  })
+
+  it("dispatch reports unknown for an ai_sdk-only tool over MCP", async () => {
+    const catalog = new ToolCatalog()
+    // show_chart is an ai_sdk surface tool; it must not be dispatchable via MCP.
+    const result = await catalog.dispatch(
+      "show_chart",
+      {},
+      { userId: 1, cognitoSub: "s", scopes: ["*"], requestId: "r" }
+    )
+    expect(result.ok).toBe(false)
+    expect(result.ok === false && result.reason).toBe("unknown")
   })
 
   it("degrades to manifest-only when the DB read fails", async () => {


### PR DESCRIPTION
## Summary
Implements #924 (Epic #922, workstream #2) — a canonical catalog of invocable units (tools) read by every surface, replacing the disconnected MCP registry / ad-hoc AI SDK tool lists.

## Key design decisions
- **Hybrid catalog**: code-defined tools live in a TypeScript manifest (`lib/tools/catalog/manifest.ts`), reconciled into a new `tool_catalog` DB table on boot (`lib/tools/catalog/sync.ts`, parallel to the #923 capability sync). Assistant/skill-derived tools live in the table; a runtime `ToolCatalog` merges both with a 5-min TTL cache.
- **Table name `tool_catalog`** (not `tools`): the legacy `tools` table (pre-#923 feature-flag shim) still exists until workstream #6, so a distinct name avoids a physical collision.
- **Identifier convention `domain.action`** (e.g. `decisions.search`); the MCP wire `name` (`search_decisions`) is preserved for client compatibility.

## Changes
- New `tool_catalog` table: migration 080 (additive, idempotent, no DO $$ blocks, ON CONFLICT seeds) + Drizzle schema. Columns: identifier, version, name, description, input/output schema, surfaces, required_scopes, agent_callable, source, handler_ref, is_active, deprecated_at, replaced_by. UNIQUE(identifier, version).
- Migrated the 5 MCP tools + 4 AI SDK tools into the catalog manifest/seed.
- MCP `tools/list` and `tools/call` (`lib/mcp/jsonrpc-handler.ts`) now dispatch via the catalog (surface + scope filtering; JSON-RPC error semantics preserved).
- Nexus chat route scope-gates client-supplied `enabledTools` via the catalog (first server-side gate for built-in tools).
- Boot-time catalog sync wired in `instrumentation.ts` (distinct advisory lock, non-blocking).
- `docs/features/mcp-server.md` updated for catalog-backed dispatch.

## Completion Criteria
- [x] Unit and integration tests pass (580 unit pass; 23 new tests for catalog merge/filter/dispatch, boot-sync idempotency/deactivation, and full JSON-RPC tools/list + tools/call path)
- [x] E2E tests pass — flows: `MCP tools/list returns catalog-backed tools`, `MCP tools/call dispatches via catalog` (tests/e2e/mcp-tool-catalog.spec.ts; auth-gate tests CI-compatible, authenticated flows skip without MCP_E2E_API_KEY per repo convention)
- [x] Zero lint warnings on every touched file (incl. fixing a pre-existing no-for-each warning in the touched route file)
- [x] Type check clean (no new `any`, no new TS errors)

## Scope notes
- REST API v1 OpenAPI auto-generation and internal-agent runtime resolution are catalog-ready (`surfaces` includes `rest`/`internal`, `agent_callable` enforced by `ToolCatalog.list({ agentOnly })`) but not separately wired here — there are no v1 tool-backed routes or an internal agent loop in this repo to retrofit yet. The catalog is the single source those surfaces will read from.
- External per-user MCP connector tools (`connector-service.ts`) remain *consumed* tools, outside the catalog, as the issue specifies.

## Touched Files
- app/api/nexus/chat/route.ts
- docs/features/mcp-server.md
- infra/database/migrations.json
- infra/database/schema/080-tool-catalog.sql
- instrumentation.ts
- lib/db/schema/index.ts
- lib/db/schema/tables/tool-catalog.ts
- lib/mcp/jsonrpc-handler.ts
- lib/tools/catalog/catalog.ts
- lib/tools/catalog/manifest.ts
- lib/tools/catalog/sync.ts
- lib/tools/catalog/types.ts
- tests/e2e/mcp-tool-catalog.spec.ts
- tests/unit/lib/mcp/jsonrpc-catalog.test.ts
- tests/unit/lib/tools/catalog-sync.test.ts
- tests/unit/lib/tools/catalog.test.ts

Closes #924