### PR TITLE
feat: #925 - Skill platform (publish, catalog, tool-catalog registration, allowed-tools enforcement, zip export)

### DIFF
--- a/actions/admin/agent-skills.actions.ts
+++ b/actions/admin/agent-skills.actions.ts
@@ -260,6 +260,8 @@ export async function approveSkillToShared(
         // unified tool catalog so every surface can discover/invoke it.
         await registerSkillCatalogTool(tx, {
           skillId,
+          // psd_agent_skills.name stores the URL-safe slug (the serializer writes
+          // name: serialized.slug), not a human display name.
           slug: skill.name,
           summary: skill.summary,
         })

--- a/actions/admin/agent-skills.actions.ts
+++ b/actions/admin/agent-skills.actions.ts
@@ -1,7 +1,7 @@
 "use server"
 
 import { createLogger, generateRequestId, startTimer, sanitizeForLogging } from "@/lib/logger"
-import { handleError, createSuccess } from "@/lib/error-utils"
+import { handleError, createSuccess, ErrorFactories } from "@/lib/error-utils"
 import type { ActionState } from "@/types"
 import { requireRole } from "@/lib/auth/role-helpers"
 import { executeQuery, executeTransaction } from "@/lib/db/drizzle-client"
@@ -9,6 +9,11 @@ import { desc, eq, sql } from "drizzle-orm"
 import { psdAgentSkills } from "@/lib/db/schema/tables/agent-skills"
 import { psdAgentSkillAudit } from "@/lib/db/schema/tables/agent-skill-audit"
 import type { SkillScanFindings } from "@/lib/db/schema/tables/agent-skills"
+import {
+  registerSkillCatalogTool,
+  deactivateSkillCatalogTool,
+} from "@/lib/skills/skill-catalog-registration"
+import { toolCatalogInstance } from "@/lib/tools/catalog/catalog"
 
 export interface SkillRow {
   id: string
@@ -225,6 +230,21 @@ export async function approveSkillToShared(
 
     await executeTransaction(
       async (tx) => {
+        // Read the skill's slug + summary so the catalog tool can be registered
+        // atomically with the scope change.
+        const [skill] = await tx
+          .select({
+            name: psdAgentSkills.name,
+            summary: psdAgentSkills.summary,
+          })
+          .from(psdAgentSkills)
+          .where(eq(psdAgentSkills.id, skillId))
+          .limit(1)
+
+        if (!skill) {
+          throw ErrorFactories.dbRecordNotFound("psd_agent_skills", skillId)
+        }
+
         await tx
           .update(psdAgentSkills)
           .set({
@@ -236,6 +256,14 @@ export async function approveSkillToShared(
           })
           .where(eq(psdAgentSkills.id, skillId))
 
+        // AC#5: register the approved skill as a `source: 'skill'` tool in the
+        // unified tool catalog so every surface can discover/invoke it.
+        await registerSkillCatalogTool(tx, {
+          skillId,
+          slug: skill.name,
+          summary: skill.summary,
+        })
+
         await tx.insert(psdAgentSkillAudit).values({
           skillId,
           action: "approved_to_shared",
@@ -245,6 +273,9 @@ export async function approveSkillToShared(
       },
       "approveSkillToShared"
     )
+
+    // Bust the 5-minute catalog cache so the new skill tool is live immediately.
+    toolCatalogInstance.invalidate()
 
     timer({ status: "success" })
     log.info("Skill approved to shared", sanitizeForLogging({ skillId, adminUserId }))
@@ -282,10 +313,17 @@ export async function rejectSkill(
 
     await executeTransaction(
       async (tx) => {
-        await tx
+        const [skill] = await tx
           .update(psdAgentSkills)
           .set({ scope: "rejected", updatedAt: new Date() })
           .where(eq(psdAgentSkills.id, skillId))
+          .returning({ name: psdAgentSkills.name })
+
+        // A rejected skill must not remain invocable: deactivate any catalog row
+        // (no-op if it was never approved / registered).
+        if (skill?.name) {
+          await deactivateSkillCatalogTool(tx, skill.name)
+        }
 
         await tx.insert(psdAgentSkillAudit).values({
           skillId,
@@ -296,6 +334,8 @@ export async function rejectSkill(
       },
       "rejectSkill"
     )
+
+    toolCatalogInstance.invalidate()
 
     timer({ status: "success" })
     log.info("Skill rejected", sanitizeForLogging({ skillId, adminUserId }))
@@ -403,10 +443,18 @@ export async function deleteSkill(
           },
         })
 
+        // Deactivate any catalog row before removing the skill so it stops being
+        // offered (no-op if the skill was never approved / registered).
+        if (skill?.name) {
+          await deactivateSkillCatalogTool(tx, skill.name)
+        }
+
         await tx.delete(psdAgentSkills).where(eq(psdAgentSkills.id, skillId))
       },
       "deleteSkill"
     )
+
+    toolCatalogInstance.invalidate()
 
     timer({ status: "success" })
     log.info("Skill deleted", sanitizeForLogging({ skillId, adminUserId }))

--- a/actions/db/publish-skill.actions.ts
+++ b/actions/db/publish-skill.actions.ts
@@ -80,6 +80,16 @@ export async function publishAssistantArchitectAsSkillAction(
     }
     const architect = architectResult.data
 
+    // Verify the caller owns this assistant before serializing its content.
+    if (architect.userId !== ownerUserId) {
+      log.warn("Publish attempt for unowned assistant", {
+        assistantId,
+        assistantOwnerId: architect.userId,
+        requestorId: ownerUserId,
+      })
+      throw ErrorFactories.authzInsufficientPermissions("publish this assistant")
+    }
+
     // 2. Serialize to SKILL.md.
     const serialized = serializeAssistantToSkill({
       name: architect.name,

--- a/actions/db/publish-skill.actions.ts
+++ b/actions/db/publish-skill.actions.ts
@@ -1,0 +1,204 @@
+"use server"
+
+import { createLogger, generateRequestId, startTimer, sanitizeForLogging } from "@/lib/logger"
+import { handleError, createSuccess, ErrorFactories } from "@/lib/error-utils"
+import type { ActionState } from "@/types"
+import { getCurrentUserAction } from "@/actions/db/get-current-user-action"
+import { hasToolAccess } from "@/utils/roles"
+import { executeTransaction } from "@/lib/db/drizzle-client"
+import { eq, and, sql } from "drizzle-orm"
+import { psdAgentSkills } from "@/lib/db/schema/tables/agent-skills"
+import { psdAgentSkillAudit } from "@/lib/db/schema/tables/agent-skill-audit"
+import { getAssistantArchitectByIdAction } from "@/actions/db/assistant-architect-actions"
+import {
+  serializeAssistantToSkill,
+  type SerializerPrompt,
+} from "@/lib/skills/skill-serializer"
+import {
+  uploadSkillDraft,
+  invokeSkillScan,
+} from "@/lib/skills/skill-publish-pipeline"
+
+export interface PublishSkillResult {
+  skillId: string
+  slug: string
+  scanQueued: boolean
+}
+
+/**
+ * Publish an Assistant Architect as a draft SKILL.md skill (Issue #925).
+ *
+ * Flow:
+ *   1. Load the assistant (name, description, prompts, input fields).
+ *   2. Serialize to SKILL.md (pure — see skill-serializer.ts).
+ *   3. Upload the SKILL.md folder to the draft S3 prefix.
+ *   4. Register a `psd_agent_skills` row (scope=draft, scanStatus=pending) +
+ *      audit entry, inside a single transaction.
+ *   5. Best-effort invoke the scan pipeline (non-fatal).
+ *
+ * The skill always lands as a reviewable draft even if the scan invoke is
+ * skipped, satisfying the "lands in agent_skills with proper status" criterion.
+ */
+export async function publishAssistantArchitectAsSkillAction(
+  assistantId: string
+): Promise<ActionState<PublishSkillResult>> {
+  const requestId = generateRequestId()
+  const timer = startTimer("publishAssistantArchitectAsSkill")
+  const log = createLogger({ requestId, action: "publishAssistantArchitectAsSkill" })
+
+  try {
+    log.info("Action started", { assistantId })
+
+    // Auth: any user who can use the Assistant Architect tool may publish their
+    // assistant as a draft skill. Drafts require admin approval before sharing.
+    const currentUserResult = await getCurrentUserAction()
+    if (!currentUserResult.isSuccess || !currentUserResult.data) {
+      log.warn("Unauthorized publish attempt")
+      throw ErrorFactories.authNoSession()
+    }
+    const ownerUserId = currentUserResult.data.user.id
+    const ownerEmail = currentUserResult.data.user.email
+
+    if (!ownerEmail) {
+      throw ErrorFactories.invalidInput(
+        "email",
+        ownerEmail,
+        "Current user has no email; cannot publish skill"
+      )
+    }
+
+    const canUse = await hasToolAccess("assistant-architect")
+    if (!canUse) {
+      log.warn("User lacks assistant-architect access", { ownerUserId })
+      throw ErrorFactories.authzToolAccessDenied("assistant-architect")
+    }
+
+    // 1. Load the assistant with relations.
+    const architectResult = await getAssistantArchitectByIdAction(assistantId)
+    if (!architectResult.isSuccess || !architectResult.data) {
+      throw ErrorFactories.dbRecordNotFound("assistant_architects", assistantId)
+    }
+    const architect = architectResult.data
+
+    // 2. Serialize to SKILL.md.
+    const serialized = serializeAssistantToSkill({
+      name: architect.name,
+      description: architect.description ?? null,
+      inputFields: (architect.inputFields ?? []).map((f) => ({
+        name: f.name,
+        label: f.label ?? null,
+        fieldType: f.fieldType,
+        options: f.options,
+      })),
+      prompts: (architect.prompts ?? []).map<SerializerPrompt>((p) => ({
+        name: p.name,
+        content: p.content,
+        systemContext: p.systemContext ?? null,
+        position: p.position ?? null,
+        enabledTools: Array.isArray(p.enabledTools) ? p.enabledTools : [],
+      })),
+    })
+
+    // 3. Upload the SKILL.md folder to S3 (draft prefix).
+    const { draftPrefix, destinationPrefix } = await uploadSkillDraft({
+      ownerEmail,
+      slug: serialized.slug,
+      files: [{ path: "SKILL.md", content: serialized.skillMd }],
+    })
+
+    // 4. Register the draft skill row + audit entry atomically. Upsert on the
+    // (name, owner_user_id) partial unique index for draft scope so republishing
+    // the same assistant bumps the version in place (matches the infra author
+    // flow). updated_at must be set explicitly — no DB trigger.
+    const skillId = await executeTransaction(async (tx) => {
+      const [row] = await tx
+        .insert(psdAgentSkills)
+        .values({
+          name: serialized.slug,
+          scope: "draft",
+          ownerUserId,
+          s3Key: draftPrefix,
+          summary: serialized.summary,
+          scanStatus: "pending",
+        })
+        .onConflictDoUpdate({
+          target: [psdAgentSkills.name, psdAgentSkills.ownerUserId],
+          targetWhere: eq(psdAgentSkills.scope, "draft"),
+          set: {
+            s3Key: draftPrefix,
+            summary: serialized.summary,
+            scanStatus: "pending",
+            version: sql`${psdAgentSkills.version} + 1`,
+            updatedAt: new Date(),
+          },
+        })
+        .returning({ id: psdAgentSkills.id })
+
+      // Resolve id when ON CONFLICT did not return (defensive — returning() is
+      // populated on both insert and update for postgres.js, but guard anyway).
+      let resolvedId = row?.id
+      if (!resolvedId) {
+        const [existing] = await tx
+          .select({ id: psdAgentSkills.id })
+          .from(psdAgentSkills)
+          .where(
+            and(
+              eq(psdAgentSkills.name, serialized.slug),
+              eq(psdAgentSkills.ownerUserId, ownerUserId),
+              eq(psdAgentSkills.scope, "draft")
+            )
+          )
+          .limit(1)
+        resolvedId = existing?.id
+      }
+
+      if (!resolvedId) {
+        throw ErrorFactories.dbQueryFailed(
+          "register published skill",
+          new Error("No skill id returned after upsert")
+        )
+      }
+
+      await tx.insert(psdAgentSkillAudit).values({
+        skillId: resolvedId,
+        action: "published_from_architect",
+        actorUserId: ownerUserId,
+        details: {
+          assistantId,
+          slug: serialized.slug,
+          allowedTools: serialized.allowedTools,
+          s3Key: draftPrefix,
+        },
+      })
+
+      return resolvedId
+    }, "publishAssistantArchitectAsSkill")
+
+    // 5. Best-effort scan invoke (non-fatal). Outside the transaction.
+    const scanQueued = await invokeSkillScan({
+      skillId,
+      draftPrefix,
+      destinationPrefix,
+    })
+
+    timer({ status: "success" })
+    log.info(
+      "Assistant published as skill",
+      sanitizeForLogging({ assistantId, skillId, slug: serialized.slug, scanQueued })
+    )
+
+    return createSuccess(
+      { skillId, slug: serialized.slug, scanQueued },
+      scanQueued
+        ? "Published as a skill and queued for review."
+        : "Published as a draft skill. An administrator will review it."
+    )
+  } catch (error) {
+    timer({ status: "error" })
+    return handleError(error, "Failed to publish assistant as a skill", {
+      context: "publishAssistantArchitectAsSkill",
+      requestId,
+      operation: "publishAssistantArchitectAsSkill",
+    })
+  }
+}

--- a/actions/db/publish-skill.actions.ts
+++ b/actions/db/publish-skill.actions.ts
@@ -120,6 +120,7 @@ export async function publishAssistantArchitectAsSkillAction(
           s3Key: draftPrefix,
           summary: serialized.summary,
           scanStatus: "pending",
+          allowedTools: serialized.allowedTools,
         })
         .onConflictDoUpdate({
           target: [psdAgentSkills.name, psdAgentSkills.ownerUserId],
@@ -128,6 +129,7 @@ export async function publishAssistantArchitectAsSkillAction(
             s3Key: draftPrefix,
             summary: serialized.summary,
             scanStatus: "pending",
+            allowedTools: serialized.allowedTools,
             version: sql`${psdAgentSkills.version} + 1`,
             updatedAt: new Date(),
           },

--- a/actions/db/publish-skill.actions.ts
+++ b/actions/db/publish-skill.actions.ts
@@ -180,6 +180,9 @@ export async function publishAssistantArchitectAsSkillAction(
           slug: serialized.slug,
           allowedTools: serialized.allowedTools,
           s3Key: draftPrefix,
+          // Record the promotion target so an admin can re-trigger the scan
+          // Lambda without reconstructing the path from the draft prefix.
+          destinationPrefix,
         },
       })
 

--- a/actions/db/skills-catalog.actions.ts
+++ b/actions/db/skills-catalog.actions.ts
@@ -1,0 +1,159 @@
+"use server"
+
+import { createLogger, generateRequestId, startTimer } from "@/lib/logger"
+import { handleError, createSuccess, ErrorFactories } from "@/lib/error-utils"
+import type { ActionState } from "@/types"
+import { getServerSession } from "@/lib/auth/server-session"
+import { executeQuery } from "@/lib/db/drizzle-client"
+import { and, desc, eq } from "drizzle-orm"
+import { psdAgentSkills } from "@/lib/db/schema/tables/agent-skills"
+import { readSkillMarkdown } from "@/lib/skills/skill-publish-pipeline"
+
+/**
+ * User-facing skill catalog actions (Issue #925, AC#4).
+ *
+ * These expose only APPROVED skills (scope = 'shared', scanStatus = 'clean') to
+ * any authenticated user — the admin review surface (Epic #910) handles drafts,
+ * flagged, and rejected skills. Reads are intentionally narrow (no owner id, no
+ * scan findings) so the catalog can't leak review-only metadata.
+ */
+
+export interface CatalogSkill {
+  id: string
+  name: string
+  summary: string
+  version: number
+  allowedTools: string[]
+  updatedAt: string
+}
+
+export interface CatalogSkillDetail extends CatalogSkill {
+  /** Rendered SKILL.md text, or null if the artifact is not readable. */
+  skillMd: string | null
+}
+
+/** List approved skills for the catalog (newest first). */
+export async function getApprovedSkillsAction(): Promise<ActionState<CatalogSkill[]>> {
+  const requestId = generateRequestId()
+  const timer = startTimer("getApprovedSkills")
+  const log = createLogger({ requestId, action: "getApprovedSkills" })
+
+  try {
+    const session = await getServerSession()
+    if (!session) {
+      throw ErrorFactories.authNoSession()
+    }
+
+    const rows = await executeQuery(
+      (db) =>
+        db
+          .select({
+            id: psdAgentSkills.id,
+            name: psdAgentSkills.name,
+            summary: psdAgentSkills.summary,
+            version: psdAgentSkills.version,
+            allowedTools: psdAgentSkills.allowedTools,
+            updatedAt: psdAgentSkills.updatedAt,
+          })
+          .from(psdAgentSkills)
+          .where(
+            and(
+              eq(psdAgentSkills.scope, "shared"),
+              eq(psdAgentSkills.scanStatus, "clean")
+            )
+          )
+          .orderBy(desc(psdAgentSkills.updatedAt))
+          .limit(200),
+      "skillsCatalog.listApproved"
+    )
+
+    timer({ status: "success" })
+    log.info("Listed approved skills", { count: rows.length })
+
+    return createSuccess(
+      rows.map((r) => ({
+        id: r.id,
+        name: r.name,
+        summary: r.summary,
+        version: r.version,
+        allowedTools: Array.isArray(r.allowedTools) ? r.allowedTools : [],
+        updatedAt: r.updatedAt.toISOString(),
+      }))
+    )
+  } catch (error) {
+    timer({ status: "error" })
+    return handleError(error, "Failed to load skills catalog", {
+      context: "getApprovedSkills",
+      requestId,
+      operation: "getApprovedSkills",
+    })
+  }
+}
+
+/** Get one approved skill plus its rendered SKILL.md (for the detail page). */
+export async function getApprovedSkillDetailAction(
+  skillId: string
+): Promise<ActionState<CatalogSkillDetail>> {
+  const requestId = generateRequestId()
+  const timer = startTimer("getApprovedSkillDetail")
+  const log = createLogger({ requestId, action: "getApprovedSkillDetail" })
+
+  try {
+    const session = await getServerSession()
+    if (!session) {
+      throw ErrorFactories.authNoSession()
+    }
+
+    const [row] = await executeQuery(
+      (db) =>
+        db
+          .select({
+            id: psdAgentSkills.id,
+            name: psdAgentSkills.name,
+            summary: psdAgentSkills.summary,
+            version: psdAgentSkills.version,
+            allowedTools: psdAgentSkills.allowedTools,
+            updatedAt: psdAgentSkills.updatedAt,
+            s3Key: psdAgentSkills.s3Key,
+          })
+          .from(psdAgentSkills)
+          .where(
+            and(
+              eq(psdAgentSkills.id, skillId),
+              eq(psdAgentSkills.scope, "shared"),
+              eq(psdAgentSkills.scanStatus, "clean")
+            )
+          )
+          .limit(1),
+      "skillsCatalog.detail"
+    )
+
+    if (!row) {
+      throw ErrorFactories.dbRecordNotFound("psd_agent_skills", skillId)
+    }
+
+    // Best-effort read of the SKILL.md artifact for the preview. A missing
+    // artifact is non-fatal — the metadata still renders.
+    const skillMd = await readSkillMarkdown(row.s3Key)
+
+    timer({ status: "success" })
+    log.info("Loaded approved skill detail", { skillId, hasMarkdown: skillMd !== null })
+
+    return createSuccess({
+      id: row.id,
+      name: row.name,
+      summary: row.summary,
+      version: row.version,
+      allowedTools: Array.isArray(row.allowedTools) ? row.allowedTools : [],
+      updatedAt: row.updatedAt.toISOString(),
+      skillMd,
+    })
+  } catch (error) {
+    timer({ status: "error" })
+    return handleError(error, "Failed to load skill detail", {
+      context: "getApprovedSkillDetail",
+      requestId,
+      operation: "getApprovedSkillDetail",
+    })
+  }
+}

--- a/app/(protected)/admin/agents/_components/agent-dashboard-client.tsx
+++ b/app/(protected)/admin/agents/_components/agent-dashboard-client.tsx
@@ -24,6 +24,7 @@ import { AgentHealthTable } from "./agent-health-table"
 import { AgentCostView } from "./agent-cost-view"
 import { AgentPatternsTable } from "./agent-patterns-table"
 import { SkillsListClient } from "../skills/_components/skills-list-client"
+import { SkillReviewClient } from "../skills/review/_components/skill-review-client"
 import { CredentialsClient } from "../credentials/_components/credentials-client"
 import { AgentWorkspaceTable } from "./agent-workspace-table"
 import { AgentFailuresClient } from "./agent-failures-client"
@@ -72,6 +73,7 @@ type DashboardTab =
   | "cost"
   | "patterns"
   | "skills"
+  | "skillReview"
   | "credentials"
   | "workspace"
   | "failures"
@@ -195,6 +197,7 @@ function buildLoaders(
     // Skills, credentials, workspace, failures, and conversations tabs are
     // self-contained — their client components handle their own loading.
     skills: async () => {},
+    skillReview: async () => {},
     credentials: async () => {},
     workspace: async () => {},
     failures: async () => {},
@@ -302,6 +305,7 @@ function DashboardTabs({
         <TabsTrigger value="patterns">Patterns</TabsTrigger>
         <TabsTrigger value="feedback">Feedback</TabsTrigger>
         <TabsTrigger value="skills">Skills</TabsTrigger>
+        <TabsTrigger value="skillReview">Skill Review</TabsTrigger>
         <TabsTrigger value="credentials">Credentials</TabsTrigger>
         <TabsTrigger value="workspace">Workspace</TabsTrigger>
         <TabsTrigger value="triage">Triage</TabsTrigger>
@@ -344,6 +348,10 @@ function DashboardTabs({
 
       <TabsContent value="skills" className="mt-4">
         <SkillsListClient />
+      </TabsContent>
+
+      <TabsContent value="skillReview" className="mt-4">
+        <SkillReviewClient />
       </TabsContent>
 
       <TabsContent value="credentials" className="mt-4">

--- a/app/(protected)/nexus/page.tsx
+++ b/app/(protected)/nexus/page.tsx
@@ -65,6 +65,7 @@ interface ConversationRuntimeProviderProps {
   selectedModel: SelectAiModel | null
   enabledTools: string[]
   enabledConnectors: string[]
+  skillId?: string
   attachmentAdapter: AttachmentAdapter
   voiceAdapter?: RealtimeVoiceAdapter
   initialMessages?: UIMessage[]
@@ -84,6 +85,7 @@ function ConversationRuntimeProvider({
   selectedModel,
   enabledTools,
   enabledConnectors,
+  skillId,
   attachmentAdapter,
   voiceAdapter,
   initialMessages = [],
@@ -317,6 +319,8 @@ function ConversationRuntimeProvider({
           provider: model.provider,
           enabledTools,
           enabledConnectors,
+          // Bind the session to a skill so the server enforces its allowed-tools pin (#925).
+          skillId,
           conversationId: conversationIdRef.current || undefined
         }
       }
@@ -346,6 +350,7 @@ interface NexusRuntimeWrapperProps {
   selectedModel: SelectAiModel | null
   enabledTools: string[]
   enabledConnectors: string[]
+  skillId?: string
   attachmentAdapter: AttachmentAdapter
   voiceAvailable: boolean
   voiceUnavailableReason?: string
@@ -364,6 +369,7 @@ function NexusRuntimeWrapper({
   selectedModel,
   enabledTools,
   enabledConnectors,
+  skillId,
   attachmentAdapter,
   voiceAvailable,
   voiceUnavailableReason,
@@ -443,6 +449,7 @@ function NexusRuntimeWrapper({
       selectedModel={selectedModel}
       enabledTools={enabledTools}
       enabledConnectors={enabledConnectors}
+      skillId={skillId}
       attachmentAdapter={attachmentAdapter}
       voiceAdapter={voiceAdapter}
       initialMessages={initialMessages}
@@ -527,6 +534,13 @@ function NexusPageContent() {
       log.warn('URL connector params truncated or filtered', { rawCount: raw.length, validCount: validated.length })
     }
     return validated
+  }, [searchParams])
+
+  // Skill binding (#925): when arriving from a skill's "Use in chat" action, the
+  // session is bound to the skill so the server enforces its allowed-tools pin.
+  const urlSkillId = useMemo(() => {
+    const raw = searchParams.get('skillId')
+    return raw && uuidSchema.safeParse(raw).success ? raw : undefined
   }, [searchParams])
 
   // Load models and manage model selection
@@ -752,6 +766,7 @@ function NexusPageContent() {
                         selectedModel={selectedModel}
                         enabledTools={enabledTools}
                         enabledConnectors={enabledConnectors}
+                        skillId={urlSkillId}
                         attachmentAdapter={attachmentAdapter}
                         voiceAvailable={voiceAvailability.available}
                         voiceUnavailableReason={!voiceAvailability.available && !voiceAvailability.loading ? voiceAvailability.reason : undefined}

--- a/app/(protected)/skills/[id]/_components/skill-detail-client.tsx
+++ b/app/(protected)/skills/[id]/_components/skill-detail-client.tsx
@@ -1,0 +1,114 @@
+"use client"
+
+import { useMemo } from "react"
+import Link from "next/link"
+import { ArrowLeft, Download, MessageSquarePlus } from "lucide-react"
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+  CardContent,
+} from "@/components/ui/card"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Markdown } from "@/components/ui/markdown"
+import type { CatalogSkillDetail } from "@/actions/db/skills-catalog.actions"
+
+interface SkillDetailClientProps {
+  skill: CatalogSkillDetail
+}
+
+/**
+ * Build the "Use in chat" URL. Binds the Nexus session to the skill (skillId) so
+ * the server enforces its allowed-tools pin, and pre-enables the pinned tools via
+ * the existing `?tool=` param. A skill with no pin binds skillId only (the user
+ * keeps their default tool selection; server enforcement is a no-op).
+ */
+function buildUseInChatHref(skill: CatalogSkillDetail): string {
+  const params = new URLSearchParams()
+  params.set("skillId", skill.id)
+  for (const tool of skill.allowedTools) {
+    params.append("tool", tool)
+  }
+  return `/nexus?${params.toString()}`
+}
+
+export function SkillDetailClient({ skill }: SkillDetailClientProps) {
+  const useInChatHref = useMemo(() => buildUseInChatHref(skill), [skill])
+  const exportHref = `/api/skills/${skill.id}/export`
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center gap-2">
+        <Button asChild variant="ghost" size="icon" aria-label="Back to skills">
+          <Link href="/skills">
+            <ArrowLeft className="h-4 w-4" />
+          </Link>
+        </Button>
+        <h1 className="text-2xl font-semibold text-gray-900">{skill.name}</h1>
+        <Badge variant="secondary">v{skill.version}</Badge>
+      </div>
+
+      <div className="flex flex-wrap gap-3">
+        <Button asChild data-testid="use-in-chat">
+          <Link href={useInChatHref}>
+            <MessageSquarePlus className="mr-2 h-4 w-4" />
+            Use in chat
+          </Link>
+        </Button>
+        <Button asChild variant="outline" data-testid="export-zip">
+          {/* Plain anchor so the browser downloads the zip rather than client-routing. */}
+          <a href={exportHref} download>
+            <Download className="mr-2 h-4 w-4" />
+            Export as zip
+          </a>
+        </Button>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Summary</CardTitle>
+          <CardDescription>{skill.summary}</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div>
+            <h3 className="text-sm font-medium mb-2">Pinned tools</h3>
+            {skill.allowedTools.length === 0 ? (
+              <p className="text-sm text-muted-foreground">
+                No tools pinned — this skill may use any tool the caller already
+                has access to.
+              </p>
+            ) : (
+              <div className="flex flex-wrap gap-2">
+                {skill.allowedTools.map((tool) => (
+                  <Badge key={tool} variant="outline">
+                    {tool}
+                  </Badge>
+                ))}
+              </div>
+            )}
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">SKILL.md</CardTitle>
+          <CardDescription>
+            The canonical skill definition scanned by the platform.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {skill.skillMd ? (
+            <Markdown content={skill.skillMd} />
+          ) : (
+            <p className="text-sm text-muted-foreground">
+              The SKILL.md artifact is not available for preview.
+            </p>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/app/(protected)/skills/[id]/page.tsx
+++ b/app/(protected)/skills/[id]/page.tsx
@@ -1,0 +1,28 @@
+import { redirect, notFound } from "next/navigation"
+import { getServerSession } from "@/lib/auth/server-session"
+import { getApprovedSkillDetailAction } from "@/actions/db/skills-catalog.actions"
+import { SkillDetailClient } from "./_components/skill-detail-client"
+
+/**
+ * Skill detail page (Issue #925, AC#4). Shows the rendered SKILL.md preview,
+ * version, the skill's pinned tools, a "Use in chat" action that loads the skill
+ * into a Nexus session, and a zip export for Claude Code / Desktop.
+ */
+export default async function SkillDetailPage({
+  params,
+}: {
+  params: Promise<{ id: string }>
+}) {
+  const session = await getServerSession()
+  if (!session || !session.sub) {
+    redirect("/sign-in")
+  }
+
+  const { id } = await params
+  const result = await getApprovedSkillDetailAction(id)
+  if (!result.isSuccess || !result.data) {
+    notFound()
+  }
+
+  return <SkillDetailClient skill={result.data} />
+}

--- a/app/(protected)/skills/_components/skills-catalog-client.tsx
+++ b/app/(protected)/skills/_components/skills-catalog-client.tsx
@@ -1,0 +1,108 @@
+"use client"
+
+import { useMemo, useState } from "react"
+import Link from "next/link"
+import { Search, Wrench } from "lucide-react"
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+  CardContent,
+  CardFooter,
+} from "@/components/ui/card"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import type { CatalogSkill } from "@/actions/db/skills-catalog.actions"
+
+interface SkillsCatalogClientProps {
+  initialSkills: CatalogSkill[]
+}
+
+/**
+ * Client grid for the skill catalog (Issue #925, AC#4). Filters the approved
+ * skills client-side by name/summary and links each to its detail page.
+ */
+export function SkillsCatalogClient({ initialSkills }: SkillsCatalogClientProps) {
+  const [query, setQuery] = useState("")
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase()
+    if (!q) return initialSkills
+    return initialSkills.filter(
+      (s) =>
+        s.name.toLowerCase().includes(q) ||
+        s.summary.toLowerCase().includes(q)
+    )
+  }, [initialSkills, query])
+
+  if (initialSkills.length === 0) {
+    return (
+      <Card data-testid="skills-empty-state">
+        <CardContent className="py-10 text-center text-muted-foreground">
+          No approved skills yet. Publish an assistant as a skill from the
+          Assistant Architect, then an administrator can approve it here.
+        </CardContent>
+      </Card>
+    )
+  }
+
+  return (
+    <div className="space-y-4">
+      <Input
+        icon={<Search className="h-4 w-4" />}
+        placeholder="Search skills…"
+        value={query}
+        onChange={(e) => setQuery(e.target.value)}
+        aria-label="Search skills"
+        data-testid="skills-search"
+      />
+
+      {filtered.length === 0 ? (
+        <p className="text-sm text-muted-foreground py-6 text-center">
+          No skills match “{query}”.
+        </p>
+      ) : (
+        <div
+          className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6"
+          data-testid="skills-grid"
+        >
+          {filtered.map((skill) => (
+            <Card
+              key={skill.id}
+              className="flex flex-col"
+              data-testid="skill-card"
+            >
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2 text-base">
+                  <Wrench className="h-4 w-4 text-muted-foreground" />
+                  {skill.name}
+                </CardTitle>
+                <CardDescription className="line-clamp-3">
+                  {skill.summary}
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="flex-1">
+                <div className="flex flex-wrap items-center gap-2">
+                  <Badge variant="secondary">v{skill.version}</Badge>
+                  {skill.allowedTools.length > 0 && (
+                    <Badge variant="outline">
+                      {skill.allowedTools.length} pinned tool
+                      {skill.allowedTools.length === 1 ? "" : "s"}
+                    </Badge>
+                  )}
+                </div>
+              </CardContent>
+              <CardFooter>
+                <Button asChild variant="outline" className="w-full">
+                  <Link href={`/skills/${skill.id}`}>View skill</Link>
+                </Button>
+              </CardFooter>
+            </Card>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/app/(protected)/skills/_components/skills-catalog-client.tsx
+++ b/app/(protected)/skills/_components/skills-catalog-client.tsx
@@ -71,7 +71,7 @@ export function SkillsCatalogClient({ initialSkills }: SkillsCatalogClientProps)
           {filtered.map((skill) => (
             <Card
               key={skill.id}
-              className="flex flex-col"
+              className="group relative flex flex-col transition-all duration-200 hover:shadow-lg hover:-translate-y-0.5"
               data-testid="skill-card"
             >
               <CardHeader>

--- a/app/(protected)/skills/layout.tsx
+++ b/app/(protected)/skills/layout.tsx
@@ -1,0 +1,15 @@
+import StandardPageLayout from "@/components/layouts/standard-page-layout"
+
+/**
+ * Wraps the skill catalog pages in the standard app shell (NavbarNested sidebar +
+ * padded content container), matching every other section (e.g. the Assistant
+ * Architect). Without this, /skills rendered bare under (protected)/layout.tsx,
+ * which only provides UserProvider.
+ */
+export default function SkillsLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return <StandardPageLayout>{children}</StandardPageLayout>
+}

--- a/app/(protected)/skills/page.tsx
+++ b/app/(protected)/skills/page.tsx
@@ -1,0 +1,44 @@
+import { redirect } from "next/navigation"
+import { getServerSession } from "@/lib/auth/server-session"
+import { getApprovedSkillsAction } from "@/actions/db/skills-catalog.actions"
+import { PageBranding } from "@/components/ui/page-branding"
+import { Separator } from "@/components/ui/separator"
+import { SkillsCatalogClient } from "./_components/skills-catalog-client"
+
+export const metadata = {
+  title: "Skills",
+  description: "Browse approved skills and use them in a Nexus chat",
+}
+
+/**
+ * User-facing skill catalog (Issue #925, AC#4). Lists approved (shared + clean)
+ * skills for any authenticated user. Each card links to a detail page with a
+ * rendered SKILL.md preview, a "Use in chat" action, and a zip export.
+ */
+export default async function SkillsCatalogPage() {
+  const session = await getServerSession()
+  if (!session || !session.sub) {
+    redirect("/sign-in")
+  }
+
+  const result = await getApprovedSkillsAction()
+  const skills = result.isSuccess ? result.data : []
+
+  return (
+    <div className="space-y-6">
+      <div className="mb-6">
+        <PageBranding />
+        <div>
+          <h1 className="text-2xl font-semibold text-gray-900">Skills</h1>
+          <p className="text-sm text-muted-foreground mt-1">
+            Browse approved skills and load one into a Nexus chat
+          </p>
+        </div>
+      </div>
+
+      <Separator />
+
+      <SkillsCatalogClient initialSkills={skills} />
+    </div>
+  )
+}

--- a/app/(protected)/utilities/assistant-architect/[id]/edit/preview/_components/preview-submit-client.tsx
+++ b/app/(protected)/utilities/assistant-architect/[id]/edit/preview/_components/preview-submit-client.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation"
 import { AssistantArchitectStreaming } from "@/components/features/assistant-architect/assistant-architect-streaming"
 import { Button } from "@/components/ui/button"
 import { submitAssistantArchitectForApprovalAction } from "@/actions/db/assistant-architect-actions"
+import { publishAssistantArchitectAsSkillAction } from "@/actions/db/publish-skill.actions"
 import { toast } from "sonner"
 import { AlertCircle, CheckCircle2 } from "lucide-react"
 import { createLogger, generateRequestId } from "@/lib/client-logger"
@@ -20,6 +21,7 @@ export function PreviewSubmitClient({
   tool
 }: PreviewSubmitClientProps) {
   const [isLoading, setIsLoading] = useState(false)
+  const [isPublishing, setIsPublishing] = useState(false)
   const router = useRouter()
 
   const handleSubmit = async () => {
@@ -44,6 +46,30 @@ export function PreviewSubmitClient({
       toast.error("Failed to submit assistant")
     } finally {
       setIsLoading(false)
+    }
+  }
+
+  const handlePublishAsSkill = async () => {
+    const requestId = generateRequestId()
+    const log = createLogger({ requestId, component: "PreviewSubmitClient" })
+
+    try {
+      log.info("Publishing assistant as skill", { assistantId })
+      setIsPublishing(true)
+      const result = await publishAssistantArchitectAsSkillAction(assistantId)
+
+      if (result.isSuccess) {
+        log.info("Assistant published as skill", { assistantId, slug: result.data?.slug })
+        toast.success(result.message ?? "Published as a draft skill")
+      } else {
+        log.warn("Publish as skill failed", { assistantId, message: result.message })
+        toast.error(result.message)
+      }
+    } catch (error) {
+      log.error("Failed to publish assistant as skill", { assistantId, error })
+      toast.error("Failed to publish assistant as a skill")
+    } finally {
+      setIsPublishing(false)
     }
   }
 
@@ -83,12 +109,22 @@ export function PreviewSubmitClient({
           ))}
         </div>
 
-        <Button
-          onClick={handleSubmit}
-          disabled={isLoading || !allRequirementsMet}
-        >
-          {isLoading ? "Submitting..." : "Submit for Approval"}
-        </Button>
+        <div className="flex items-center gap-3">
+          <Button
+            variant="outline"
+            onClick={handlePublishAsSkill}
+            disabled={isPublishing || isLoading || !allRequirementsMet}
+            data-testid="publish-as-skill-button"
+          >
+            {isPublishing ? "Publishing..." : "Publish as Skill"}
+          </Button>
+          <Button
+            onClick={handleSubmit}
+            disabled={isLoading || isPublishing || !allRequirementsMet}
+          >
+            {isLoading ? "Submitting..." : "Submit for Approval"}
+          </Button>
+        </div>
       </div>
     </div>
   )

--- a/app/api/nexus/chat/route.ts
+++ b/app/api/nexus/chat/route.ts
@@ -45,6 +45,10 @@ import { executeQuery } from '@/lib/db/drizzle-client';
 import { nexusConversations } from '@/lib/db/schema';
 import { getScopesForRoles } from '@/lib/api-keys/scopes';
 import { toolCatalogInstance } from '@/lib/tools/catalog/catalog';
+import {
+  intersectSkillAllowedTools,
+  getApprovedSkillAllowedTools,
+} from '@/lib/skills/skill-tool-enforcement';
 
 // Allow streaming responses up to 30 minutes. Deep Research runs take 5–25
 // minutes; standard chat and image-gen finish well within this window.
@@ -273,6 +277,9 @@ const ChatRequestSchema = z.object({
   conversationId: z.string().nullable().optional(),
   enabledTools: z.array(z.string()).optional(),
   enabledConnectors: z.array(z.string().uuid()).max(10).optional(),
+  // When the session is bound to a published skill ("use in chat"), the skill's
+  // `allowed-tools` pin is enforced server-side over the client tool list (#925 AC#6).
+  skillId: z.string().uuid().optional(),
   reasoningEffort: z.enum(['minimal', 'low', 'medium', 'high']).optional(),
   responseMode: z.enum(['standard', 'priority', 'flex']).optional()
 });
@@ -1009,6 +1016,34 @@ async function scopeFilterEnabledTools(
 }
 
 /**
+ * Enforce a bound skill's `allowed-tools` pin over the (already scope-filtered)
+ * tool list (#925 AC#6). The client tool list is untrusted, so the pin is
+ * re-applied here whenever the session is bound to a skill. A skill with no pin
+ * (empty allowed-tools) or an unknown/unapproved id leaves the list unchanged.
+ */
+async function enforceSkillAllowedTools(
+  scopedEnabledTools: string[],
+  skillId: string | undefined,
+  log: ReturnType<typeof createLogger>
+): Promise<string[]> {
+  if (!skillId) return scopedEnabledTools;
+  const allowed = await getApprovedSkillAllowedTools(skillId);
+  if (allowed === null) {
+    log.warn('Session bound to unknown/unapproved skill; not enforcing tool pin', { skillId });
+    return scopedEnabledTools;
+  }
+  const enforced = intersectSkillAllowedTools(scopedEnabledTools, allowed);
+  if (enforced.length !== scopedEnabledTools.length) {
+    log.info('Skill allowed-tools pin applied', {
+      skillId,
+      before: scopedEnabledTools.length,
+      after: enforced.length,
+    });
+  }
+  return enforced;
+}
+
+/**
  * Nexus Chat API - Native Streaming with AI SDK v5
  */
 export async function POST(req: Request) {
@@ -1027,7 +1062,7 @@ export async function POST(req: Request) {
     const validation = validateRequest(body, requestId, log);
     if (!validation.valid) return validation.error;
 
-    const { messages, modelId, provider = 'openai', conversationId: existingConversationId, enabledTools = [], enabledConnectors = [] } = validation.data;
+    const { messages, modelId, provider = 'openai', conversationId: existingConversationId, enabledTools = [], enabledConnectors = [], skillId } = validation.data;
     const conversationIdValue = existingConversationId || undefined;
 
     // 2. Validate conversation ID format
@@ -1094,8 +1129,13 @@ export async function POST(req: Request) {
       });
     connectorToolResults.push(...resolvedConnectorTools);
 
-    // 8b. Scope-gate built-in (AI SDK) tools via the unified tool catalog (#924).
-    const scopedEnabledTools = await scopeFilterEnabledTools(enabledTools, userRoleNames, log);
+    // 8b. Scope-gate built-in (AI SDK) tools via the unified tool catalog (#924),
+    // then enforce the bound skill's allowed-tools pin if the session loaded one (#925).
+    const scopedEnabledTools = await enforceSkillAllowedTools(
+      await scopeFilterEnabledTools(enabledTools, userRoleNames, log),
+      skillId,
+      log
+    );
 
     // 9. Execute streaming and return response
     // Once executeStreaming returns successfully, the streaming Response is in flight.

--- a/app/api/skills/[id]/export/route.ts
+++ b/app/api/skills/[id]/export/route.ts
@@ -1,0 +1,113 @@
+import { NextRequest, NextResponse } from "next/server"
+import JSZip from "jszip"
+import { and, eq } from "drizzle-orm"
+import { getServerSession } from "@/lib/auth/server-session"
+import { createLogger, generateRequestId, startTimer } from "@/lib/logger"
+import { ErrorFactories, handleError } from "@/lib/error-utils"
+import { executeQuery } from "@/lib/db/drizzle-client"
+import { psdAgentSkills } from "@/lib/db/schema/tables/agent-skills"
+import { downloadSkillFolder } from "@/lib/skills/skill-publish-pipeline"
+
+/**
+ * Zip export of an approved skill's SKILL.md folder (Issue #925, AC#7).
+ *
+ * Streams the authored skill folder (SKILL.md + any bundled files, excluding the
+ * scan pipeline's node_modules) as a .zip so it can be dropped into Claude Code /
+ * Desktop. Only APPROVED skills (scope = 'shared', scanStatus = 'clean') are
+ * exportable, to any authenticated user.
+ *
+ * Runs on the Node.js runtime (AWS SDK + JSZip).
+ */
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+const SAFE_FILENAME_RE = /[^a-zA-Z0-9_.-]/g
+
+async function getHandler(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const requestId = generateRequestId()
+  const timer = startTimer("GET /api/skills/[id]/export")
+  const log = createLogger({ requestId, endpoint: "GET /api/skills/[id]/export" })
+
+  try {
+    const { id } = await params
+    if (!UUID_RE.test(id)) {
+      throw ErrorFactories.invalidInput("id", id, "must be a UUID")
+    }
+
+    const session = await getServerSession()
+    if (!session?.sub) {
+      log.warn("Unauthorized skill export attempt")
+      throw ErrorFactories.authNoSession()
+    }
+
+    const [skill] = await executeQuery(
+      (db) =>
+        db
+          .select({
+            name: psdAgentSkills.name,
+            s3Key: psdAgentSkills.s3Key,
+          })
+          .from(psdAgentSkills)
+          .where(
+            and(
+              eq(psdAgentSkills.id, id),
+              eq(psdAgentSkills.scope, "shared"),
+              eq(psdAgentSkills.scanStatus, "clean")
+            )
+          )
+          .limit(1),
+      "skillsExport.lookup"
+    )
+
+    if (!skill) {
+      return NextResponse.json({ error: "Skill not found" }, { status: 404 })
+    }
+
+    const files = await downloadSkillFolder(skill.s3Key)
+    if (files.length === 0) {
+      log.warn("No skill artifacts to export", { skillId: id })
+      return NextResponse.json(
+        { error: "Skill artifacts are not available for export" },
+        { status: 404 }
+      )
+    }
+
+    const zip = new JSZip()
+    const folder = zip.folder(skill.name) ?? zip
+    for (const file of files) {
+      folder.file(file.path, file.content)
+    }
+    const buffer = await zip.generateAsync({ type: "nodebuffer" })
+
+    const safeName = skill.name.replace(SAFE_FILENAME_RE, "-") || "skill"
+
+    timer({ status: "success" })
+    log.info("Exported skill as zip", { skillId: id, fileCount: files.length })
+
+    return new NextResponse(new Uint8Array(buffer), {
+      status: 200,
+      headers: {
+        "Content-Type": "application/zip",
+        "Content-Disposition": `attachment; filename="${safeName}.zip"`,
+        "Content-Length": String(buffer.length),
+        "Cache-Control": "no-store",
+      },
+    })
+  } catch (error) {
+    timer({ status: "error" })
+    const result = handleError(error, "Failed to export skill", {
+      context: "skillsExport",
+      requestId,
+      operation: "GET /api/skills/[id]/export",
+    })
+    return NextResponse.json(
+      { error: result.message },
+      { status: 500 }
+    )
+  }
+}
+
+export { getHandler as GET }

--- a/app/api/skills/[id]/export/route.ts
+++ b/app/api/skills/[id]/export/route.ts
@@ -7,6 +7,7 @@ import { ErrorFactories, handleError } from "@/lib/error-utils"
 import { executeQuery } from "@/lib/db/drizzle-client"
 import { psdAgentSkills } from "@/lib/db/schema/tables/agent-skills"
 import { downloadSkillFolder } from "@/lib/skills/skill-publish-pipeline"
+import { ErrorCode, ERROR_STATUS_CODES } from "@/types/error-types"
 
 /**
  * Zip export of an approved skill's SKILL.md folder (Issue #925, AC#7).
@@ -16,8 +17,10 @@ import { downloadSkillFolder } from "@/lib/skills/skill-publish-pipeline"
  * Desktop. Only APPROVED skills (scope = 'shared', scanStatus = 'clean') are
  * exportable, to any authenticated user.
  *
- * Runs on the Node.js runtime (AWS SDK + JSZip).
+ * Runs on the Node.js runtime (AWS SDK + JSZip). Without this the route may be
+ * placed on the Edge runtime, which lacks `Buffer` and breaks the AWS SDK.
  */
+export const runtime = "nodejs"
 
 const UUID_RE =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
@@ -103,10 +106,15 @@ async function getHandler(
       requestId,
       operation: "GET /api/skills/[id]/export",
     })
-    return NextResponse.json(
-      { error: result.message },
-      { status: 500 }
-    )
+    // Map the structured error code to its HTTP status so auth/validation
+    // failures surface as 401/400 instead of a blanket 500. handleError
+    // returns an ActionState (no status), so derive it from the error code.
+    const code = (error as { code?: string } | null)?.code
+    const status =
+      code && code in ERROR_STATUS_CODES
+        ? ERROR_STATUS_CODES[code as ErrorCode]
+        : 500
+    return NextResponse.json({ error: result.message }, { status })
   }
 }
 

--- a/bun.lock
+++ b/bun.lock
@@ -86,6 +86,7 @@
         "jose": "^6.1.3",
         "js-tiktoken": "^1.0.21",
         "jsonwebtoken": "^9.0.2",
+        "jszip": "^3.10.1",
         "katex": "^0.17.0",
         "lucide-react": "^1.18.0",
         "mammoth": "^1.11.0",
@@ -3015,7 +3016,7 @@
 
     "react-textarea-autosize": ["react-textarea-autosize@8.5.9", "", { "dependencies": { "@babel/runtime": "^7.20.13", "use-composed-ref": "^1.3.0", "use-latest": "^1.2.1" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-U1DGlIQN5AwgjTyOEnI1oCcMuEr1pv1qOtklB2l4nyMGbHzWrI0eFsYK0zos2YWqAolJyG0IWJaqWmWj5ETh0A=="],
 
-    "readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
+    "readable-stream": ["readable-stream@2.3.8", "", { "dependencies": { "core-util-is": "~1.0.0", "inherits": "~2.0.3", "isarray": "~1.0.0", "process-nextick-args": "~2.0.0", "safe-buffer": "~5.1.1", "string_decoder": "~1.1.1", "util-deprecate": "~1.0.1" } }, "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA=="],
 
     "recharts": ["recharts@3.7.0", "", { "dependencies": { "@reduxjs/toolkit": "1.x.x || 2.x.x", "clsx": "^2.1.1", "decimal.js-light": "^2.5.1", "es-toolkit": "^1.39.3", "eventemitter3": "^5.0.1", "immer": "^10.1.1", "react-redux": "8.x.x || 9.x.x", "reselect": "5.1.1", "tiny-invariant": "^1.3.3", "use-sync-external-store": "^1.2.2", "victory-vendor": "^37.0.2" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-l2VCsy3XXeraxIID9fx23eCb6iCBsxUQDnE8tWm6DFdszVAO7WVY/ChAD9wVit01y6B2PMupYiMmQwhgPHc9Ew=="],
 
@@ -4209,8 +4210,6 @@
 
     "jsonwebtoken/semver": ["semver@7.7.3", "", { "bin": "bin/semver.js" }, "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q=="],
 
-    "jszip/readable-stream": ["readable-stream@2.3.8", "", { "dependencies": { "core-util-is": "~1.0.0", "inherits": "~2.0.3", "isarray": "~1.0.0", "process-nextick-args": "~2.0.0", "safe-buffer": "~5.1.1", "string_decoder": "~1.1.1", "util-deprecate": "~1.0.1" } }, "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA=="],
-
     "koa/mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
 
     "lowlight/fault": ["fault@1.0.4", "", { "dependencies": { "format": "^0.2.0" } }, "sha512-CJ0HCB5tL5fYTEA7ToAq5+kTwd++Borf1/bifxd9iT70QcXr4MRrO3Llf8Ifs70q+SJcGHFtnIE/Nw6giCtECA=="],
@@ -4335,6 +4334,8 @@
 
     "react-shiki/unist-util-visit": ["unist-util-visit@5.1.0", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-is": "^6.0.0", "unist-util-visit-parents": "^6.0.0" } }, "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg=="],
 
+    "readable-stream/safe-buffer": ["safe-buffer@5.1.2", "", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
+
     "redent/indent-string": ["indent-string@4.0.0", "", {}, "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg=="],
 
     "redent/strip-indent": ["strip-indent@3.0.0", "", { "dependencies": { "min-indent": "^1.0.0" } }, "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ=="],
@@ -4380,6 +4381,10 @@
     "whatwg-encoding/iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
 
     "which-builtin-type/isarray": ["isarray@2.0.5", "", {}, "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="],
+
+    "winston/readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
+
+    "winston-transport/readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
 
     "wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
@@ -4858,8 +4863,6 @@
     "jest-snapshot/pretty-format/react-is": ["react-is@18.3.1", "", {}, "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="],
 
     "jest-validate/pretty-format/react-is": ["react-is@18.3.1", "", {}, "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="],
-
-    "jszip/readable-stream/safe-buffer": ["safe-buffer@5.1.2", "", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
 
     "koa/mime-types/mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
 

--- a/docs/learnings/integration/2026-06-17-nextjs-app-router-nodejs-runtime-required-for-aws-sdk.md
+++ b/docs/learnings/integration/2026-06-17-nextjs-app-router-nodejs-runtime-required-for-aws-sdk.md
@@ -1,0 +1,48 @@
+---
+title: Next.js App Router API routes using AWS SDK or Buffer must declare nodejs runtime
+category: integration
+tags:
+  - nextjs
+  - app-router
+  - edge-runtime
+  - aws-sdk
+  - api-routes
+  - error-handling
+  - http-status
+  - s3
+  - path-traversal
+  - pr-review
+severity: high
+date: 2026-06-17
+source: auto — /review-pr
+applicable_to: project
+---
+
+## What Happened
+
+PR #1034 (skill platform, Issue #925) review surfaced missing `export const runtime = "nodejs"` in App Router API routes that imported `@aws-sdk/*` clients or used `Buffer`/`JSZip`. Without the declaration Next.js can silently place these routes on the Edge runtime, where AWS SDK, Buffer, and Node-native modules are unavailable. The failure is runtime-only — typecheck, lint, and CI all pass green.
+
+## Root Cause
+
+Next.js App Router defaults to the Edge runtime for some API route configurations. When a route imports Node-only modules (`@aws-sdk/*`, `Buffer`, `JSZip`) without pinning the runtime, the mismatch only surfaces at request time in production.
+
+## Solution
+
+Add `export const runtime = "nodejs"` at the top of every App Router API route file (`app/api/**/route.ts`) that:
+- Imports any `@aws-sdk/*` client
+- Uses `Buffer`, `JSZip`, or other Node-native modules
+- Performs S3 or other AWS SDK operations
+
+This is the established project convention; all existing AWS SDK routes already pin it.
+
+Two additional patterns fixed in the same PR:
+
+**HTTP status from error code** — `handleError` returns an `ActionState` with no HTTP status. API route catch blocks must derive status from `AppError.code` via `ERROR_STATUS_CODES` in `types/error-types.ts` instead of returning a blanket `500`.
+
+**S3 key path guard** — S3-key-to-zip path construction should strip `../` sequences and leading `/` as defense-in-depth even when upload-time validation exists.
+
+## Prevention
+
+- Code-review checklist: any new `app/api/**/route.ts` that touches AWS SDK or Node builtins must include the runtime declaration.
+- Grep for `@aws-sdk` imports in route files and verify `runtime = "nodejs"` is present.
+- Lint rule or project template can enforce this; currently relies on review.

--- a/docs/learnings/workflow/2026-06-16-web-infra-pipeline-bridging-ecs-iam.md
+++ b/docs/learnings/workflow/2026-06-16-web-infra-pipeline-bridging-ecs-iam.md
@@ -1,0 +1,46 @@
+---
+title: Bridging web→infra pipelines — ECS IAM/env must be explicit, DB stays in Drizzle
+category: workflow
+tags:
+  - skills
+  - assistant-architect
+  - skill-md
+  - drizzle
+  - onConflictDoUpdate
+  - targetWhere
+  - ecs-iam
+  - ssm
+  - s3
+  - lambda-invoke
+  - eslint-ignore
+  - cdk-synth
+  - issue-925
+  - epic-922
+  - epic-910
+severity: high
+date: 2026-06-16
+source: auto — /work
+applicable_to: project
+---
+
+## What Happened
+
+Implemented the "Publish as Skill" slice of Issue #925 connecting the web Assistant Architect to the existing infra SKILL.md scan pipeline. The web app needed to upload a SKILL.md to S3, register a draft row in `psd_agent_skills`, then async-invoke the skill-builder Lambda — mirroring exactly what `infra/agent-image/skills/psd-skills-meta/common.js` does.
+
+## Root Cause
+
+The frontend ECS task had no awareness of the agent workspace bucket or skill-builder Lambda. Neither env vars nor IAM grants are inherited automatically — they must be added explicitly in `infra/lib/constructs/ecs-service.ts`.
+
+## Solution
+
+- **DB writes**: Stay in Drizzle via direct postgres.js connection — no RDS Data API needed. Used `onConflictDoUpdate` with `targetWhere` (supported in drizzle-orm 0.45.1) to match a partial unique index (`WHERE scope='draft'`).
+- **ECS env vars**: Added `AGENT_WORKSPACE_BUCKET` (resolved from SSM `/aistudio/{env}/agent-workspace-bucket-name`) and `SKILL_BUILDER_LAMBDA_ARN` (deterministic ARN constructed at synth time) to the env map in `ecs-service.ts`.
+- **ECS IAM**: Added `lambda:InvokeFunction` on the skill-builder ARN and `s3:PutObject`/`s3:GetObject` scoped to `skills/*` prefix in the agent workspace bucket — both as explicit policy statements in `ecs-service.ts`.
+- **S3 path + tags**: Mirrors infra author flow: `skills/user/{email}/drafts/{slug}/SKILL.md` with required S3 tags so the skill-builder Lambda recognises the object.
+- **Validated**: `bunx cdk synth AIStudio-FrontendStack-ECS-Dev -c baseDomain=...` clean before shipping.
+
+## Prevention
+
+- Any time the web app touches a new AWS resource (S3 bucket, Lambda, SSM param), update `infra/lib/constructs/ecs-service.ts` with both the env var and the IAM grant — it is never automatic.
+- When mirroring an infra-side pipeline in the web app, read the infra script first (`common.js` or equivalent) to match S3 key structure and tags exactly.
+- `eslint`'s "File ignored because of a matching ignore pattern" on `*.test.ts`, `*.spec.ts`, and infra files is config-by-design (`eslint.config.mjs`) and exits 0 under `--max-warnings 0` — not a code warning to fix.

--- a/infra/bin/infra.ts
+++ b/infra/bin/infra.ts
@@ -399,6 +399,7 @@ if (baseDomain) {
     baseDomain, // Passed via CDK context (e.g., aistudio.psd401.ai)
     customSubdomain: 'dev', // Creates dev.<baseDomain>
     documentsBucketName: devStorageStack.documentsBucketName,
+    agentWorkspaceBucketName: devAgentPlatformStack.workspaceBucket.bucketName, // #925
     useExistingVpc: setupDns, // Use VPC sharing in real deployments, create new VPC for CI validation
     setupDns, // Enable DNS/certificate setup (false for CI validation with example.com)
     env: { account: process.env.CDK_DEFAULT_ACCOUNT, region: process.env.CDK_DEFAULT_REGION },
@@ -407,6 +408,7 @@ if (baseDomain) {
   devFrontendStack.addDependency(devStorageStack); // Need bucket name
   devFrontendStack.addDependency(devAuthStack); // Need auth secret ARN export
   devFrontendStack.addDependency(devGuardrailsStack); // Need guardrails config exports
+  devFrontendStack.addDependency(devAgentPlatformStack); // Need agent workspace bucket name (#925)
   cdk.Tags.of(devFrontendStack).add('Environment', 'Dev');
   Object.entries(standardTags).forEach(([key, value]) => cdk.Tags.of(devFrontendStack).add(key, value));
 
@@ -418,6 +420,7 @@ if (baseDomain) {
     baseDomain, // Passed via CDK context (e.g., aistudio.psd401.ai)
     // No customSubdomain for prod - uses root baseDomain
     documentsBucketName: prodStorageStack.documentsBucketName,
+    agentWorkspaceBucketName: prodAgentPlatformStack.workspaceBucket.bucketName, // #925
     useExistingVpc: setupDns, // Use VPC sharing in real deployments, create new VPC for CI validation
     setupDns, // Enable DNS/certificate setup (false for CI validation with example.com)
     env: { account: process.env.CDK_DEFAULT_ACCOUNT, region: process.env.CDK_DEFAULT_REGION },
@@ -426,6 +429,7 @@ if (baseDomain) {
   prodFrontendStack.addDependency(prodStorageStack); // Need bucket name
   prodFrontendStack.addDependency(prodAuthStack); // Need auth secret ARN export
   prodFrontendStack.addDependency(prodGuardrailsStack); // Need guardrails config exports
+  prodFrontendStack.addDependency(prodAgentPlatformStack); // Need agent workspace bucket name (#925)
   cdk.Tags.of(prodFrontendStack).add('Environment', 'Prod');
   Object.entries(standardTags).forEach(([key, value]) => cdk.Tags.of(prodFrontendStack).add(key, value));
 

--- a/infra/database/migrations.json
+++ b/infra/database/migrations.json
@@ -75,6 +75,7 @@
     "077-agent-workspace-consent-nonces-cognito-data.sql",
     "078-agent-deep-telemetry.sql",
     "079-rename-tools-to-capabilities.sql",
-    "080-tool-catalog.sql"
+    "080-tool-catalog.sql",
+    "081-skill-platform-catalog.sql"
   ]
 }

--- a/infra/database/schema/081-skill-platform-catalog.sql
+++ b/infra/database/schema/081-skill-platform-catalog.sql
@@ -1,0 +1,33 @@
+-- Migration 081: Skill platform — allowed-tools persistence + catalog discoverability
+-- Part of #925 (Epic #922 — connect Epic #910 agent_skills to the SKILL.md pipeline)
+--
+-- Two additive changes:
+--   1. psd_agent_skills.allowed_tools — the skill's `allowed-tools` frontmatter,
+--      persisted on publish so it can be (a) registered into tool_catalog when the
+--      skill is approved (#925 AC#5) and (b) enforced at invocation time, where the
+--      session's tool set is intersected with this list (#925 AC#6). Previously the
+--      derived allowed-tools lived only in the SKILL.md frontmatter + the audit row,
+--      neither of which is queryable on the hot path.
+--   2. A top-level "Skills" navigation item pointing at the user-facing skill catalog
+--      (#925 AC#4). Visible to every authenticated user (requires_role = NULL).
+--
+-- ADDITIVE and idempotent. No PL/pgSQL triggers / DO $$ blocks (the RDS Data API
+-- migration runner's statement splitter cannot handle dollar-quoted blocks — see
+-- migration 079). allowed_tools is maintained by application code via Drizzle.
+
+-- Mark any previous failed attempts as completed so the runner stops retrying.
+UPDATE migration_log SET status = 'completed'
+WHERE description = '081-skill-platform-catalog.sql' AND status = 'failed';
+
+-- 1. allowed_tools column (defaults to an empty list = "no pin; open to all
+--    catalog tools the caller already holds", matching the serializer contract).
+ALTER TABLE psd_agent_skills
+    ADD COLUMN IF NOT EXISTS allowed_tools JSONB DEFAULT '[]'::jsonb NOT NULL;
+
+-- 2. User-facing skill catalog navigation entry (top-level, all authenticated users).
+INSERT INTO navigation_items (label, icon, link, parent_id, requires_role, position, is_active, type, description)
+SELECT 'Skills', 'IconBriefcase', '/skills', NULL, NULL, 35, true, 'link',
+       'Browse approved skills and use them in a Nexus chat'
+WHERE NOT EXISTS (
+    SELECT 1 FROM navigation_items WHERE link = '/skills'
+);

--- a/infra/lib/constructs/ecs-service.ts
+++ b/infra/lib/constructs/ecs-service.ts
@@ -17,6 +17,12 @@ export interface EcsServiceConstructProps {
   vpc: ec2.IVpc;
   environment: 'dev' | 'prod';
   documentsBucketName: string;
+  /**
+   * Agent workspace bucket name (holds published SKILL.md folders, #925).
+   * Passed as a cross-stack prop from AgentPlatformStack — same pattern as
+   * documentsBucketName — so the dependency + Export/Import is explicit.
+   */
+  agentWorkspaceBucketName: string;
   enableContainerInsights?: boolean;
   enableFargateSpot?: boolean;
   /**
@@ -133,15 +139,7 @@ export class EcsServiceConstruct extends Construct {
   constructor(scope: Construct, id: string, props: EcsServiceConstructProps) {
     super(scope, id);
 
-    const { vpc, environment, documentsBucketName } = props;
-
-    // Issue #925: agent workspace bucket holds published SKILL.md folders.
-    // Published to SSM by AgentPlatformStack. Resolved once and reused for both
-    // the container env and the task-role S3 grant below.
-    const agentWorkspaceBucketName = ssm.StringParameter.valueForStringParameter(
-      this,
-      `/aistudio/${environment}/agent-workspace-bucket-name`
-    );
+    const { vpc, environment, documentsBucketName, agentWorkspaceBucketName } = props;
 
     // ============================================================================
     // ECR Repository for container images

--- a/infra/lib/constructs/ecs-service.ts
+++ b/infra/lib/constructs/ecs-service.ts
@@ -404,7 +404,7 @@ export class EcsServiceConstruct extends Construct {
             // the skills/ prefix.
             new iam.PolicyStatement({
               effect: iam.Effect.ALLOW,
-              actions: ['s3:PutObject', 's3:GetObject'],
+              actions: ['s3:PutObject', 's3:PutObjectTagging', 's3:GetObject'],
               resources: [
                 `arn:aws:s3:::${agentWorkspaceBucketName}/skills/*`,
               ],

--- a/infra/lib/constructs/ecs-service.ts
+++ b/infra/lib/constructs/ecs-service.ts
@@ -402,6 +402,20 @@ export class EcsServiceConstruct extends Construct {
             // Issue #925: write SKILL.md draft folders to the agent workspace
             // bucket so the existing scan pipeline can pick them up. Scoped to
             // the skills/ prefix.
+            //
+            // ListBucket must target the bucket ARN (not the object-prefix ARN);
+            // ListObjectsV2 (used by listSkillObjectKeys for the detail-page
+            // SKILL.md preview and the zip export) fails with AccessDenied
+            // without it. The s3:prefix condition keeps the grant scoped to the
+            // skills/ tree.
+            new iam.PolicyStatement({
+              effect: iam.Effect.ALLOW,
+              actions: ['s3:ListBucket'],
+              resources: [`arn:aws:s3:::${agentWorkspaceBucketName}`],
+              conditions: {
+                StringLike: { 's3:prefix': ['skills/*'] },
+              },
+            }),
             new iam.PolicyStatement({
               effect: iam.Effect.ALLOW,
               actions: ['s3:PutObject', 's3:PutObjectTagging', 's3:GetObject'],

--- a/infra/lib/constructs/ecs-service.ts
+++ b/infra/lib/constructs/ecs-service.ts
@@ -135,6 +135,14 @@ export class EcsServiceConstruct extends Construct {
 
     const { vpc, environment, documentsBucketName } = props;
 
+    // Issue #925: agent workspace bucket holds published SKILL.md folders.
+    // Published to SSM by AgentPlatformStack. Resolved once and reused for both
+    // the container env and the task-role S3 grant below.
+    const agentWorkspaceBucketName = ssm.StringParameter.valueForStringParameter(
+      this,
+      `/aistudio/${environment}/agent-workspace-bucket-name`
+    );
+
     // ============================================================================
     // ECR Repository for container images
     // ============================================================================
@@ -387,6 +395,18 @@ export class EcsServiceConstruct extends Construct {
               actions: ['lambda:InvokeFunction'],
               resources: [
                 `arn:aws:lambda:${cdk.Stack.of(this).region}:${cdk.Stack.of(this).account}:function:aistudio-${environment}-schedule-executor`,
+                // Issue #925: skill-builder scans/promotes published skill drafts
+                `arn:aws:lambda:${cdk.Stack.of(this).region}:${cdk.Stack.of(this).account}:function:psd-agent-skill-builder-${environment}`,
+              ],
+            }),
+            // Issue #925: write SKILL.md draft folders to the agent workspace
+            // bucket so the existing scan pipeline can pick them up. Scoped to
+            // the skills/ prefix.
+            new iam.PolicyStatement({
+              effect: iam.Effect.ALLOW,
+              actions: ['s3:PutObject', 's3:GetObject'],
+              resources: [
+                `arn:aws:s3:::${agentWorkspaceBucketName}/skills/*`,
               ],
             }),
             new iam.PolicyStatement({
@@ -643,6 +663,12 @@ export class EcsServiceConstruct extends Construct {
         GUARDRAIL_VIOLATION_TOPIC_ARN: cdk.Fn.importValue(`${environment}-ViolationTopicArn`),
         CONTENT_SAFETY_ENABLED: 'true',
         PII_TOKENIZATION_ENABLED: 'true',
+        // Issue #925: Skill publishing pipeline. The agent workspace bucket
+        // (published to SSM by AgentPlatformStack) holds SKILL.md folders, and
+        // the skill-builder Lambda scans/promotes drafts. Both are optional at
+        // runtime — if absent, publishing falls back to a reviewable draft row.
+        AGENT_WORKSPACE_BUCKET: agentWorkspaceBucketName,
+        SKILL_BUILDER_LAMBDA_ARN: `arn:aws:lambda:${cdk.Stack.of(this).region}:${cdk.Stack.of(this).account}:function:psd-agent-skill-builder-${environment}`,
       },
       // Secrets injected from Secrets Manager at runtime
       secrets: {

--- a/infra/lib/frontend-stack-ecs.ts
+++ b/infra/lib/frontend-stack-ecs.ts
@@ -20,6 +20,7 @@ export interface FrontendStackEcsProps extends cdk.StackProps {
    */
   customSubdomain?: string;
   documentsBucketName?: string; // Optional for backward compatibility
+  agentWorkspaceBucketName?: string; // Optional for backward compatibility (#925)
   /**
    * If true, will look up existing VPC from database stack.
    * If false, will create a new VPC for ECS (not recommended - prefer VPC sharing)
@@ -62,6 +63,14 @@ export class FrontendStackEcs extends cdk.Stack {
     const documentsBucketName = props.documentsBucketName ||
       ssm.StringParameter.valueForStringParameter(
         this, `/aistudio/${environment}/documents-bucket-name`
+      );
+
+    // Agent workspace bucket (#925) — prefer the cross-stack prop from
+    // AgentPlatformStack; fall back to the SSM param for backward compatibility
+    // / partial deploys, mirroring documentsBucketName above.
+    const agentWorkspaceBucketName = props.agentWorkspaceBucketName ||
+      ssm.StringParameter.valueForStringParameter(
+        this, `/aistudio/${environment}/agent-workspace-bucket-name`
       );
 
     // ============================================================================
@@ -128,6 +137,7 @@ export class FrontendStackEcs extends cdk.Stack {
       vpc,
       environment,
       documentsBucketName,
+      agentWorkspaceBucketName,
       enableContainerInsights: true,
       enableFargateSpot: true, // Enable Fargate Spot for cost optimization
       spotRatio: environment === 'prod' ? 50 : 100, // 50% Spot in prod, 100% in dev

--- a/lib/db/drizzle-client.ts
+++ b/lib/db/drizzle-client.ts
@@ -184,6 +184,13 @@ export const db = new Proxy({} as ReturnType<typeof drizzle<typeof schema>>, {
  */
 export type DrizzleDB = typeof db;
 
+/**
+ * Type alias for the transaction client passed to `executeTransaction`'s
+ * callback. Lets helpers that participate in a caller-owned transaction type
+ * their `tx` parameter without re-deriving the `Parameters<...>` chain.
+ */
+export type DbTransaction = Parameters<Parameters<typeof db.transaction>[0]>[0];
+
 // ============================================
 // Result Type Helpers
 // ============================================

--- a/lib/db/schema/tables/agent-skills.ts
+++ b/lib/db/schema/tables/agent-skills.ts
@@ -50,6 +50,12 @@ export const psdAgentSkills = pgTable("psd_agent_skills", {
   s3Key: text("s3_key").notNull(),
   version: integer("version").notNull().default(1),
   summary: text("summary").notNull(),
+  // Added in migration 081. The skill's `allowed-tools` frontmatter (catalog tool
+  // identifiers), persisted on publish. Empty array = no pin (open to all catalog
+  // tools the caller already holds). Used to (a) register the skill into
+  // tool_catalog on approval and (b) intersect the session tool set at invocation
+  // time (Issue #925 AC#5/AC#6).
+  allowedTools: jsonb("allowed_tools").$type<string[]>().notNull().default([]),
   scanStatus: varchar("scan_status", { length: 16 }).$type<AgentSkillScanStatus>().notNull().default("pending"),
   scanFindings: jsonb("scan_findings").$type<SkillScanFindings>(),
   // Added in migration 075. NULL = open to all; non-null = capability required.

--- a/lib/skills/skill-catalog-registration.ts
+++ b/lib/skills/skill-catalog-registration.ts
@@ -1,0 +1,128 @@
+/**
+ * Skill → tool catalog registration (Issue #925, AC#5).
+ *
+ * When an admin approves a skill (draft → shared), it must register as a tool in
+ * the unified tool catalog (#924) with `source: 'skill'` so every surface (MCP,
+ * AI SDK chat/Nexus, internal agent loops) can discover and invoke it. When a
+ * skill is rejected or deleted, its catalog row is deactivated so it stops being
+ * offered without losing the (identifier, version) slot.
+ *
+ * The catalog read path (`lib/tools/catalog/catalog.ts`) merges every
+ * `source != 'code'` row into the runtime catalog, so an upsert here + a cache
+ * `invalidate()` is all that's needed to make an approved skill live.
+ *
+ * Pure helpers (`buildSkillCatalogIdentifier`, `buildSkillCatalogToolValues`) are
+ * exported separately so the identifier scheme and row shape stay unit-testable
+ * without a DB.
+ */
+
+import { and, eq } from "drizzle-orm";
+import { toolCatalog } from "@/lib/db/schema";
+import type { NewToolCatalogRow } from "@/lib/db/schema/tables/tool-catalog";
+import type { DbTransaction } from "@/lib/db/drizzle-client";
+
+/** Catalog version used for skill-derived tools. */
+export const SKILL_CATALOG_VERSION = "v1";
+
+/**
+ * Stable `domain.action` catalog identifier for a skill. Immutable once shipped —
+ * derived from the skill slug (which is itself stable for a given skill name).
+ */
+export function buildSkillCatalogIdentifier(slug: string): string {
+  return `skill.${slug}`;
+}
+
+/**
+ * MCP/AI-SDK wire name for a skill tool. Skill slugs are `[a-z0-9-]`; tool wire
+ * names allow `[a-zA-Z0-9_-]`, so the slug is used as-is.
+ */
+export function buildSkillCatalogToolName(slug: string): string {
+  return slug;
+}
+
+export interface SkillCatalogToolInput {
+  skillId: string;
+  slug: string;
+  summary: string;
+}
+
+/**
+ * Build the `tool_catalog` row for an approved skill. Pure — no DB access.
+ *
+ * - `surfaces`: skills are invocable from chat (`ai_sdk`), the MCP server
+ *   (`mcp`), and internal agent loops (`internal`).
+ * - `requiredScopes`: empty — a published skill is open to any authenticated
+ *   caller. Per-skill capability gating is handled separately by the skill's
+ *   `requiredCapability` (check_capability.js at invocation), not by catalog scope.
+ * - `handlerRef`: `skill:{id}` — the dispatcher resolves this to load + run the
+ *   skill folder from S3.
+ */
+export function buildSkillCatalogToolValues(
+  input: SkillCatalogToolInput
+): NewToolCatalogRow {
+  return {
+    identifier: buildSkillCatalogIdentifier(input.slug),
+    version: SKILL_CATALOG_VERSION,
+    name: buildSkillCatalogToolName(input.slug),
+    description: input.summary,
+    inputSchema: { type: "object", properties: {} },
+    surfaces: ["ai_sdk", "mcp", "internal"],
+    requiredScopes: [],
+    agentCallable: true,
+    source: "skill",
+    handlerRef: `skill:${input.skillId}`,
+    isActive: true,
+  };
+}
+
+/**
+ * Upsert the catalog row for an approved skill inside an existing transaction.
+ * Idempotent on `(identifier, version)`: re-approving the same skill refreshes
+ * its description/handler and re-activates it.
+ *
+ * NOTE: call `toolCatalogInstance.invalidate()` AFTER the transaction commits so
+ * the 5-minute DB cache doesn't keep serving the pre-approval state.
+ */
+export async function registerSkillCatalogTool(
+  tx: DbTransaction,
+  input: SkillCatalogToolInput
+): Promise<void> {
+  const values = buildSkillCatalogToolValues(input);
+  await tx
+    .insert(toolCatalog)
+    .values(values)
+    .onConflictDoUpdate({
+      target: [toolCatalog.identifier, toolCatalog.version],
+      set: {
+        name: values.name,
+        description: values.description,
+        surfaces: values.surfaces,
+        requiredScopes: values.requiredScopes,
+        agentCallable: values.agentCallable,
+        source: values.source,
+        handlerRef: values.handlerRef,
+        isActive: true,
+        updatedAt: new Date(),
+      },
+    });
+}
+
+/**
+ * Deactivate the catalog row for a skill (on reject/delete) inside an existing
+ * transaction. Soft-disable rather than delete so the (identifier, version) slot
+ * is preserved and a later re-approval can re-claim it. No-op if no row exists.
+ */
+export async function deactivateSkillCatalogTool(
+  tx: DbTransaction,
+  slug: string
+): Promise<void> {
+  await tx
+    .update(toolCatalog)
+    .set({ isActive: false, updatedAt: new Date() })
+    .where(
+      and(
+        eq(toolCatalog.identifier, buildSkillCatalogIdentifier(slug)),
+        eq(toolCatalog.version, SKILL_CATALOG_VERSION)
+      )
+    );
+}

--- a/lib/skills/skill-publish-pipeline.ts
+++ b/lib/skills/skill-publish-pipeline.ts
@@ -17,6 +17,8 @@
 import {
   S3Client,
   PutObjectCommand,
+  GetObjectCommand,
+  ListObjectsV2Command,
 } from "@aws-sdk/client-s3"
 import { LambdaClient, InvokeCommand } from "@aws-sdk/client-lambda"
 import { createLogger } from "@/lib/logger"
@@ -189,4 +191,110 @@ export async function invokeSkillScan(
     })
     return false
   }
+}
+
+// ---------------------------------------------------------------------------
+// Reads — used by the user-facing catalog (SKILL.md preview) and zip export.
+// These read from the SAME workspace bucket the publish flow writes to, NOT the
+// documents bucket that lib/aws/s3-client.ts targets.
+// ---------------------------------------------------------------------------
+
+export interface DownloadedSkillFile {
+  /** Relative path within the skill folder, e.g. "SKILL.md". */
+  path: string
+  /** UTF-8 text content. */
+  content: string
+}
+
+function requireBucket(): string {
+  const bucket = getSkillsBucket()
+  if (!bucket) {
+    throw new Error(
+      "Agent workspace bucket is not configured (AGENT_WORKSPACE_BUCKET). " +
+        "Cannot read skill artifacts."
+    )
+  }
+  return bucket
+}
+
+/**
+ * List object keys under a skill's S3 prefix. Paginates fully. Returns absolute
+ * S3 keys (including the prefix). `node_modules/` entries are excluded — they are
+ * build artifacts from the scan pipeline, not part of the authored skill folder.
+ */
+export async function listSkillObjectKeys(s3Prefix: string): Promise<string[]> {
+  const bucket = requireBucket()
+  const s3 = getS3()
+  const prefix = s3Prefix.endsWith("/") ? s3Prefix : `${s3Prefix}/`
+  const keys: string[] = []
+  let continuationToken: string | undefined
+
+  do {
+    const res = await s3.send(
+      new ListObjectsV2Command({
+        Bucket: bucket,
+        Prefix: prefix,
+        ContinuationToken: continuationToken,
+      })
+    )
+    for (const obj of res.Contents ?? []) {
+      if (!obj.Key) continue
+      const relative = obj.Key.slice(prefix.length)
+      if (relative === "" || relative.startsWith("node_modules/")) continue
+      keys.push(obj.Key)
+    }
+    continuationToken = res.IsTruncated ? res.NextContinuationToken : undefined
+  } while (continuationToken)
+
+  return keys
+}
+
+/** Download a single S3 object as UTF-8 text. */
+export async function downloadSkillObject(key: string): Promise<string> {
+  const bucket = requireBucket()
+  const s3 = getS3()
+  const res = await s3.send(
+    new GetObjectCommand({ Bucket: bucket, Key: key })
+  )
+  if (!res.Body) {
+    throw new Error(`No body returned from S3 for key "${key}"`)
+  }
+  // AWS SDK v3 Node stream helper.
+  return res.Body.transformToString("utf-8")
+}
+
+/**
+ * Read a skill's SKILL.md from its S3 prefix. Returns null if it is missing (the
+ * skill row may exist before the folder is fully written, or the artifact may be
+ * absent for legacy rows).
+ */
+export async function readSkillMarkdown(s3Prefix: string): Promise<string | null> {
+  const prefix = s3Prefix.endsWith("/") ? s3Prefix.slice(0, -1) : s3Prefix
+  try {
+    return await downloadSkillObject(`${prefix}/SKILL.md`)
+  } catch (error) {
+    log.warn("SKILL.md not readable for skill prefix", {
+      s3Prefix,
+      error: error instanceof Error ? error.message : String(error),
+    })
+    return null
+  }
+}
+
+/**
+ * Download all authored files in a skill folder (for zip export). Returns each
+ * file's path relative to the skill folder plus its UTF-8 content.
+ */
+export async function downloadSkillFolder(
+  s3Prefix: string
+): Promise<DownloadedSkillFile[]> {
+  const prefix = s3Prefix.endsWith("/") ? s3Prefix : `${s3Prefix}/`
+  const keys = await listSkillObjectKeys(s3Prefix)
+  const files = await Promise.all(
+    keys.map(async (key) => ({
+      path: key.slice(prefix.length),
+      content: await downloadSkillObject(key),
+    }))
+  )
+  return files
 }

--- a/lib/skills/skill-publish-pipeline.ts
+++ b/lib/skills/skill-publish-pipeline.ts
@@ -1,0 +1,171 @@
+/**
+ * Skill publish pipeline helpers (Issue #925).
+ *
+ * Bridges the web app to the existing infra-side skill scan pipeline:
+ *   1. Upload the serialized SKILL.md folder to the agent workspace S3 bucket
+ *      under the same `skills/user/{email}/drafts/{slug}/` prefix the
+ *      psd-skills-meta `author` command uses (infra/.../common.js).
+ *   2. (Best-effort) invoke the `agent-skill-builder` Lambda to scan + promote.
+ *
+ * The web app writes the `psd_agent_skills` row directly via Drizzle (it has a
+ * direct postgres.js connection), so the Lambda invoke is purely the scan +
+ * S3 promotion step. If the Lambda ARN is not wired into the ECS task, the
+ * invoke is skipped and the skill remains a `draft`/`pending` row that an admin
+ * can review — matching the non-fatal behaviour of the infra-side author flow.
+ */
+
+import {
+  S3Client,
+  PutObjectCommand,
+} from "@aws-sdk/client-s3"
+import { LambdaClient, InvokeCommand } from "@aws-sdk/client-lambda"
+import { createLogger } from "@/lib/logger"
+
+const log = createLogger({ service: "skill-publish-pipeline" })
+
+const REGION = process.env.AWS_REGION || process.env.AWS_DEFAULT_REGION || "us-east-1"
+const ENVIRONMENT = process.env.ENVIRONMENT || process.env.NODE_ENV || "dev"
+
+/**
+ * Resolve the agent workspace bucket name. Wired into the ECS task as
+ * AGENT_WORKSPACE_BUCKET (mirrors infra SSM /aistudio/{env}/agent-workspace-bucket-name).
+ */
+export function getSkillsBucket(): string | null {
+  return (
+    process.env.AGENT_WORKSPACE_BUCKET ||
+    process.env.WORKSPACE_BUCKET ||
+    null
+  )
+}
+
+/** Resolve the skill-builder Lambda ARN if it has been provisioned to ECS. */
+export function getSkillBuilderLambdaArn(): string | null {
+  return process.env.SKILL_BUILDER_LAMBDA_ARN || null
+}
+
+export interface SkillFile {
+  /** Relative path within the skill folder, e.g. "SKILL.md". */
+  path: string
+  /** UTF-8 text content. */
+  content: string
+  contentType?: string
+}
+
+export interface UploadSkillParams {
+  ownerEmail: string
+  slug: string
+  files: SkillFile[]
+}
+
+export interface UploadSkillResult {
+  /** S3 key prefix where the draft skill folder was written. */
+  draftPrefix: string
+  /** Where the scan pipeline would promote a clean skill. */
+  destinationPrefix: string
+}
+
+let s3ClientSingleton: S3Client | null = null
+function getS3(): S3Client {
+  if (!s3ClientSingleton) {
+    s3ClientSingleton = new S3Client({ region: REGION })
+  }
+  return s3ClientSingleton
+}
+
+/**
+ * Upload a serialized skill folder to the draft prefix in the workspace bucket.
+ * Tags objects identically to the infra author flow so existing lifecycle and
+ * tag-based IAM rules apply.
+ *
+ * @throws Error if the bucket is not configured.
+ */
+export async function uploadSkillDraft(
+  params: UploadSkillParams
+): Promise<UploadSkillResult> {
+  const bucket = getSkillsBucket()
+  if (!bucket) {
+    throw new Error(
+      "Agent workspace bucket is not configured (AGENT_WORKSPACE_BUCKET). " +
+        "Cannot publish skill to S3."
+    )
+  }
+
+  const { ownerEmail, slug, files } = params
+  const draftPrefix = `skills/user/${ownerEmail}/drafts/${slug}`
+  const destinationPrefix = `skills/user/${ownerEmail}/approved/${slug}`
+  const tagging = `Environment=${ENVIRONMENT}&ManagedBy=cdk&Scope=draft&Owner=${encodeURIComponent(
+    ownerEmail
+  )}`
+
+  const s3 = getS3()
+  for (const file of files) {
+    await s3.send(
+      new PutObjectCommand({
+        Bucket: bucket,
+        Key: `${draftPrefix}/${file.path}`,
+        Body: file.content,
+        ContentType: file.contentType ?? "text/markdown",
+        Tagging: tagging,
+      })
+    )
+  }
+
+  log.info("Uploaded skill draft to S3", {
+    bucket,
+    draftPrefix,
+    fileCount: files.length,
+  })
+
+  return { draftPrefix, destinationPrefix }
+}
+
+export interface InvokeScanParams {
+  skillId: string
+  draftPrefix: string
+  destinationPrefix: string
+}
+
+/**
+ * Best-effort invocation of the skill-builder Lambda for scanning + promotion.
+ * Returns true if the invoke was dispatched, false if skipped (no ARN) or it
+ * failed. Never throws — a failed scan-invoke leaves the skill as a pending
+ * draft that an admin can review/retry, exactly like the infra author flow.
+ */
+export async function invokeSkillScan(
+  params: InvokeScanParams
+): Promise<boolean> {
+  const arn = getSkillBuilderLambdaArn()
+  if (!arn) {
+    log.info("Skill-builder Lambda ARN not configured; skill stays as pending draft", {
+      skillId: params.skillId,
+    })
+    return false
+  }
+
+  try {
+    const client = new LambdaClient({ region: REGION })
+    await client.send(
+      new InvokeCommand({
+        FunctionName: arn,
+        InvocationType: "Event", // async — do not block the request
+        Payload: Buffer.from(
+          JSON.stringify({
+            skillId: params.skillId,
+            s3Key: params.draftPrefix,
+            destinationPrefix: params.destinationPrefix,
+            scope: "user",
+            ownerUserId: null, // resolved in the Lambda from the DB
+          })
+        ),
+      })
+    )
+    log.info("Dispatched skill-builder scan", { skillId: params.skillId })
+    return true
+  } catch (error) {
+    log.error("Skill-builder invoke failed (non-fatal)", {
+      skillId: params.skillId,
+      error: error instanceof Error ? error.message : String(error),
+    })
+    return false
+  }
+}

--- a/lib/skills/skill-publish-pipeline.ts
+++ b/lib/skills/skill-publish-pipeline.ts
@@ -64,6 +64,26 @@ export interface UploadSkillResult {
   destinationPrefix: string
 }
 
+/** RFC-lite email check (mirrors infra common.js validateUserEmail). */
+const EMAIL_RE = /^[^\s@/]+@[^\s@/]+\.[^\s@/]+$/
+/** S3/path-safe slug check (mirrors infra common.js SAFE_NAME_RE). */
+const SAFE_SLUG_RE = /^[a-zA-Z0-9_.-]+$/
+
+/**
+ * Validate the components that flow into the S3 key. Both are validated again
+ * here (defense in depth) even though the serializer produces a safe slug and
+ * the email comes from the authenticated session — neither must ever be able
+ * to inject "/" or ".." into the object key.
+ */
+function assertSafeKeyParts(ownerEmail: string, slug: string): void {
+  if (!EMAIL_RE.test(ownerEmail) || ownerEmail.includes("..")) {
+    throw new Error(`Invalid owner email for skill S3 key: "${ownerEmail}"`)
+  }
+  if (!SAFE_SLUG_RE.test(slug) || slug.includes("..")) {
+    throw new Error(`Invalid skill slug for S3 key: "${slug}"`)
+  }
+}
+
 let s3ClientSingleton: S3Client | null = null
 function getS3(): S3Client {
   if (!s3ClientSingleton) {
@@ -91,6 +111,7 @@ export async function uploadSkillDraft(
   }
 
   const { ownerEmail, slug, files } = params
+  assertSafeKeyParts(ownerEmail, slug)
   const draftPrefix = `skills/user/${ownerEmail}/drafts/${slug}`
   const destinationPrefix = `skills/user/${ownerEmail}/approved/${slug}`
   const tagging = `Environment=${ENVIRONMENT}&ManagedBy=cdk&Scope=draft&Owner=${encodeURIComponent(

--- a/lib/skills/skill-publish-pipeline.ts
+++ b/lib/skills/skill-publish-pipeline.ts
@@ -247,7 +247,17 @@ export async function listSkillObjectKeys(s3Prefix: string): Promise<string[]> {
     for (const obj of res.Contents ?? []) {
       if (!obj.Key) continue
       const relative = obj.Key.slice(prefix.length)
-      if (relative === "" || relative.startsWith("node_modules/")) continue
+      // Skip the prefix marker, scan-pipeline build artifacts, and any key whose
+      // relative path could escape the skill folder once zipped. `../` cannot
+      // occur in a normal upload (assertSafeKeyParts guards publish time), but a
+      // corrupted/rogue object key must never be able to write outside the folder.
+      if (
+        relative === "" ||
+        relative.startsWith("node_modules/") ||
+        relative.includes("../") ||
+        relative.startsWith("/")
+      )
+        continue
       keys.push(obj.Key)
     }
     continuationToken = res.IsTruncated ? res.NextContinuationToken : undefined

--- a/lib/skills/skill-publish-pipeline.ts
+++ b/lib/skills/skill-publish-pipeline.ts
@@ -100,6 +100,14 @@ function getS3(): S3Client {
   return s3ClientSingleton
 }
 
+let lambdaClientSingleton: LambdaClient | null = null
+function getLambda(): LambdaClient {
+  if (!lambdaClientSingleton) {
+    lambdaClientSingleton = new LambdaClient({ region: REGION })
+  }
+  return lambdaClientSingleton
+}
+
 /**
  * Upload a serialized skill folder to the draft prefix in the workspace bucket.
  * Tags objects identically to the infra author flow so existing lifecycle and
@@ -173,7 +181,7 @@ export async function invokeSkillScan(
   }
 
   try {
-    const client = new LambdaClient({ region: REGION })
+    const client = getLambda()
     await client.send(
       new InvokeCommand({
         FunctionName: arn,
@@ -205,6 +213,14 @@ export async function invokeSkillScan(
 // These read from the SAME workspace bucket the publish flow writes to, NOT the
 // documents bucket that lib/aws/s3-client.ts targets.
 // ---------------------------------------------------------------------------
+
+/**
+ * Bounds on a single skill's exportable folder. Only clean-scanned approved
+ * skills reach the zip export, so these are guardrails against a pathological /
+ * corrupted folder spiking ECS task memory — not a product limit on authoring.
+ */
+export const MAX_EXPORT_FILES = 50
+export const MAX_EXPORT_TOTAL_BYTES = 10 * 1024 * 1024 // 10 MB
 
 export interface DownloadedSkillFile {
   /** Relative path within the skill folder, e.g. "SKILL.md". */
@@ -307,11 +323,33 @@ export async function downloadSkillFolder(
 ): Promise<DownloadedSkillFile[]> {
   const prefix = s3Prefix.endsWith("/") ? s3Prefix : `${s3Prefix}/`
   const keys = await listSkillObjectKeys(s3Prefix)
+
+  // Cap file count before fanning out the downloads so a folder with thousands
+  // of objects cannot issue thousands of concurrent GetObject calls.
+  if (keys.length > MAX_EXPORT_FILES) {
+    throw new Error(
+      `Skill folder has ${keys.length} files, exceeding the export limit of ${MAX_EXPORT_FILES}.`
+    )
+  }
+
   const files = await Promise.all(
     keys.map(async (key) => ({
       path: key.slice(prefix.length),
       content: await downloadSkillObject(key),
     }))
   )
+
+  // Cap total decoded size so an oversized folder cannot spike ECS task memory
+  // while the zip is built in-memory.
+  const totalBytes = files.reduce(
+    (sum, f) => sum + Buffer.byteLength(f.content, "utf-8"),
+    0
+  )
+  if (totalBytes > MAX_EXPORT_TOTAL_BYTES) {
+    throw new Error(
+      `Skill folder is ${totalBytes} bytes, exceeding the export limit of ${MAX_EXPORT_TOTAL_BYTES} bytes.`
+    )
+  }
+
   return files
 }

--- a/lib/skills/skill-publish-pipeline.ts
+++ b/lib/skills/skill-publish-pipeline.ts
@@ -26,7 +26,7 @@ import { createLogger } from "@/lib/logger"
 const log = createLogger({ service: "skill-publish-pipeline" })
 
 const REGION = process.env.AWS_REGION || process.env.AWS_DEFAULT_REGION || "us-east-1"
-const ENVIRONMENT = process.env.ENVIRONMENT || process.env.NODE_ENV || "dev"
+const ENVIRONMENT = process.env.ENVIRONMENT || "dev"
 
 /**
  * Resolve the agent workspace bucket name. Wired into the ECS task as
@@ -116,8 +116,9 @@ export async function uploadSkillDraft(
   assertSafeKeyParts(ownerEmail, slug)
   const draftPrefix = `skills/user/${ownerEmail}/drafts/${slug}`
   const destinationPrefix = `skills/user/${ownerEmail}/approved/${slug}`
+  const safeOwnerEmail = ownerEmail.replace(/[^a-zA-Z0-9\s+=\-._ :/@]/g, "_")
   const tagging = `Environment=${ENVIRONMENT}&ManagedBy=cdk&Scope=draft&Owner=${encodeURIComponent(
-    ownerEmail
+    safeOwnerEmail
   )}`
 
   const s3 = getS3()

--- a/lib/skills/skill-publish-pipeline.ts
+++ b/lib/skills/skill-publish-pipeline.ts
@@ -22,6 +22,7 @@ import {
 } from "@aws-sdk/client-s3"
 import { LambdaClient, InvokeCommand } from "@aws-sdk/client-lambda"
 import { createLogger } from "@/lib/logger"
+import { getSetting } from "@/lib/settings-manager"
 
 const log = createLogger({ service: "skill-publish-pipeline" })
 
@@ -32,17 +33,22 @@ const ENVIRONMENT = process.env.ENVIRONMENT || "dev"
  * Resolve the agent workspace bucket name. Wired into the ECS task as
  * AGENT_WORKSPACE_BUCKET (mirrors infra SSM /aistudio/{env}/agent-workspace-bucket-name).
  */
-export function getSkillsBucket(): string | null {
+export async function getSkillsBucket(): Promise<string | null> {
+  // Settings table is canonical (admin-configurable, no redeploy). getSetting
+  // falls back to the AGENT_WORKSPACE_BUCKET env var — CDK-injected on ECS,
+  // set in .env.local for local dev.
   return (
-    process.env.AGENT_WORKSPACE_BUCKET ||
-    process.env.WORKSPACE_BUCKET ||
+    (await getSetting("AGENT_WORKSPACE_BUCKET")) ||
+    (await getSetting("WORKSPACE_BUCKET")) ||
     null
   )
 }
 
 /** Resolve the skill-builder Lambda ARN if it has been provisioned to ECS. */
-export function getSkillBuilderLambdaArn(): string | null {
-  return process.env.SKILL_BUILDER_LAMBDA_ARN || null
+export async function getSkillBuilderLambdaArn(): Promise<string | null> {
+  // Settings table first, env fallback (CDK-injected on ECS). Absent ⇒ the scan
+  // invoke is skipped and the skill stays a reviewable draft.
+  return (await getSetting("SKILL_BUILDER_LAMBDA_ARN")) || null
 }
 
 export interface SkillFile {
@@ -104,7 +110,7 @@ function getS3(): S3Client {
 export async function uploadSkillDraft(
   params: UploadSkillParams
 ): Promise<UploadSkillResult> {
-  const bucket = getSkillsBucket()
+  const bucket = await getSkillsBucket()
   if (!bucket) {
     throw new Error(
       "Agent workspace bucket is not configured (AGENT_WORKSPACE_BUCKET). " +
@@ -158,7 +164,7 @@ export interface InvokeScanParams {
 export async function invokeSkillScan(
   params: InvokeScanParams
 ): Promise<boolean> {
-  const arn = getSkillBuilderLambdaArn()
+  const arn = await getSkillBuilderLambdaArn()
   if (!arn) {
     log.info("Skill-builder Lambda ARN not configured; skill stays as pending draft", {
       skillId: params.skillId,
@@ -207,8 +213,8 @@ export interface DownloadedSkillFile {
   content: string
 }
 
-function requireBucket(): string {
-  const bucket = getSkillsBucket()
+async function requireBucket(): Promise<string> {
+  const bucket = await getSkillsBucket()
   if (!bucket) {
     throw new Error(
       "Agent workspace bucket is not configured (AGENT_WORKSPACE_BUCKET). " +
@@ -224,7 +230,7 @@ function requireBucket(): string {
  * build artifacts from the scan pipeline, not part of the authored skill folder.
  */
 export async function listSkillObjectKeys(s3Prefix: string): Promise<string[]> {
-  const bucket = requireBucket()
+  const bucket = await requireBucket()
   const s3 = getS3()
   const prefix = s3Prefix.endsWith("/") ? s3Prefix : `${s3Prefix}/`
   const keys: string[] = []
@@ -252,7 +258,7 @@ export async function listSkillObjectKeys(s3Prefix: string): Promise<string[]> {
 
 /** Download a single S3 object as UTF-8 text. */
 export async function downloadSkillObject(key: string): Promise<string> {
-  const bucket = requireBucket()
+  const bucket = await requireBucket()
   const s3 = getS3()
   const res = await s3.send(
     new GetObjectCommand({ Bucket: bucket, Key: key })

--- a/lib/skills/skill-serializer.ts
+++ b/lib/skills/skill-serializer.ts
@@ -90,7 +90,7 @@ function toYamlScalar(value: string): string {
   const oneLine = value.replace(/\s*\n\s*/g, " ").trim()
   const needsQuoting =
     oneLine === "" ||
-    /^[\s>|!&*#?@`%"'\-[\]{},]/.test(oneLine) ||
+    /^[\s>|!&*#?@`%"'\-\[\]{},]/.test(oneLine) ||
     /:\s/.test(oneLine) ||
     /\s#/.test(oneLine) ||
     oneLine.endsWith(":")
@@ -147,9 +147,9 @@ function renderInputFields(fields: SerializerInputField[]): string {
   }
   const lines = ["| Field | Label | Type |", "| --- | --- | --- |"]
   for (const f of fields) {
-    const label = (f.label ?? "").replace(/\|/g, "\\|").trim() || "—"
-    const name = f.name.replace(/\|/g, "\\|")
-    const type = f.fieldType.replace(/\|/g, "\\|")
+    const label = (f.label ?? "").replace(/\\/g, "\\\\").replace(/\|/g, "\\|").trim() || "—"
+    const name = f.name.replace(/\\/g, "\\\\").replace(/\|/g, "\\|")
+    const type = f.fieldType.replace(/\\/g, "\\\\").replace(/\|/g, "\\|")
     lines.push(`| \`${name}\` | ${label} | ${type} |`)
   }
   return lines.join("\n")
@@ -170,7 +170,7 @@ function renderPrompts(prompts: SerializerPrompt[]): string {
     if (p.systemContext && p.systemContext.trim()) {
       parts.push(`**System context**\n\n${p.systemContext.trim()}`)
     }
-    parts.push(`**Prompt**\n\n${p.content.trim()}`)
+    parts.push(`**Prompt**\n\n${(p.content ?? "").trim()}`)
     const tools = Array.isArray(p.enabledTools) ? p.enabledTools.filter(Boolean) : []
     if (tools.length > 0) {
       parts.push(`**Tools:** ${tools.join(", ")}`)

--- a/lib/skills/skill-serializer.ts
+++ b/lib/skills/skill-serializer.ts
@@ -90,7 +90,7 @@ function toYamlScalar(value: string): string {
   const oneLine = value.replace(/\s*\n\s*/g, " ").trim()
   const needsQuoting =
     oneLine === "" ||
-    /^[\s>|!&*#?@`%"'\-\[\]{},]/.test(oneLine) ||
+    /^[\s>|!&*#?@`%"'\-[\]{},]/.test(oneLine) ||
     /:\s/.test(oneLine) ||
     /\s#/.test(oneLine) ||
     oneLine.endsWith(":")

--- a/lib/skills/skill-serializer.ts
+++ b/lib/skills/skill-serializer.ts
@@ -1,0 +1,241 @@
+/**
+ * Assistant Architect → SKILL.md serializer (Issue #925).
+ *
+ * Pure functions that convert an Assistant Architect (name, description,
+ * chained prompts, input fields, enabled tools) into Anthropic's canonical
+ * SKILL.md format — the format AI Studio committed to in Epic #922.
+ *
+ * No I/O here. The server action (`publish-skill.actions.ts`) handles S3
+ * upload, DB registration, and the scan-pipeline invoke. Keeping serialization
+ * pure makes it unit-testable and reusable for the future zip-export flow.
+ *
+ * Frontmatter contract (matches infra/agent-image/skills/{name}/SKILL.md and
+ * the parser in agent-platform-stack.ts):
+ *   name          — slug (alphanumeric, hyphens, underscores, dots)
+ *   summary       — one-line catalog summary (required by the scanner)
+ *   description    — longer description
+ *   allowed-tools — derived from the assistant's enabled tools
+ */
+
+/** Minimal shape the serializer needs from an assistant's input field. */
+export interface SerializerInputField {
+  name: string
+  label: string | null
+  fieldType: string
+  options?: unknown
+}
+
+/** Minimal shape the serializer needs from an assistant's chained prompt. */
+export interface SerializerPrompt {
+  name: string
+  content: string
+  systemContext?: string | null
+  position?: number | null
+  enabledTools?: string[] | null
+}
+
+/** Minimal shape the serializer needs from the assistant itself. */
+export interface SerializerAssistant {
+  name: string
+  description: string | null
+  inputFields?: SerializerInputField[]
+  prompts?: SerializerPrompt[]
+}
+
+/** Result of serialization. */
+export interface SerializedSkill {
+  /** URL/S3-safe slug used as the skill `name` and folder. */
+  slug: string
+  /** Full SKILL.md text (frontmatter + body). */
+  skillMd: string
+  /** One-line summary placed in frontmatter and the agent_skills row. */
+  summary: string
+  /** Tool identifiers derived from the assistant, deduped and sorted. */
+  allowedTools: string[]
+}
+
+const SLUG_MAX_LENGTH = 64
+const SUMMARY_MAX_LENGTH = 200
+
+/**
+ * Convert an arbitrary assistant name into a SKILL.md-safe slug.
+ * Lowercase, alphanumeric + hyphens only, collapsed and trimmed.
+ * The scanner's SAFE_NAME_RE allows [a-zA-Z0-9_.-]; we deliberately produce a
+ * stricter, lowercase, hyphen-only slug for predictable, collision-resistant
+ * folder names.
+ */
+export function slugifySkillName(name: string): string {
+  const slug = name
+    .toLowerCase()
+    .normalize("NFKD")
+    // Strip accents/diacritics
+    .replace(/[̀-ͯ]/g, "")
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, SLUG_MAX_LENGTH)
+    .replace(/-+$/g, "")
+
+  return slug
+}
+
+/**
+ * Escape a value for safe inclusion on a single YAML frontmatter line.
+ * Strips newlines (frontmatter values are single-line) and trims. If the value
+ * contains characters that would break unquoted YAML (`:` followed by space,
+ * leading special chars), it is wrapped in double quotes with internal quotes
+ * escaped.
+ */
+function toYamlScalar(value: string): string {
+  const oneLine = value.replace(/\s*\n\s*/g, " ").trim()
+  const needsQuoting =
+    oneLine === "" ||
+    /^[\s>|!&*#?@`%"'\-[\]{},]/.test(oneLine) ||
+    /:\s/.test(oneLine) ||
+    /\s#/.test(oneLine) ||
+    oneLine.endsWith(":")
+
+  if (!needsQuoting) {
+    return oneLine
+  }
+  return `"${oneLine.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`
+}
+
+/**
+ * Derive the `allowed-tools` list from an assistant's prompts. Each prompt
+ * declares its tools in `enabledTools` (a JSONB string[]). We take the union,
+ * dedupe, and sort for deterministic output.
+ *
+ * Returns catalog tool identifiers as-is. AI-Studio-specific tools (e.g.
+ * `nexus.chat`) are passed through unchanged — the export documentation notes
+ * which references are platform-specific.
+ */
+export function deriveAllowedTools(prompts: SerializerPrompt[] = []): string[] {
+  const set = new Set<string>()
+  for (const prompt of prompts) {
+    const tools = Array.isArray(prompt.enabledTools) ? prompt.enabledTools : []
+    for (const tool of tools) {
+      const trimmed = typeof tool === "string" ? tool.trim() : ""
+      if (trimmed) set.add(trimmed)
+    }
+  }
+  return Array.from(set).sort((a, b) => a.localeCompare(b))
+}
+
+/**
+ * Build a one-line summary from the assistant's description, truncated to the
+ * scanner/catalog limit. Falls back to a generic line when no description.
+ */
+export function buildSummary(assistant: SerializerAssistant): string {
+  const raw = (assistant.description ?? "").replace(/\s*\n\s*/g, " ").trim()
+  const base =
+    raw.length > 0
+      ? raw
+      : `Published from the "${assistant.name}" assistant in AI Studio.`
+  if (base.length <= SUMMARY_MAX_LENGTH) return base
+  // Truncate on a word boundary where possible, leaving room for the ellipsis.
+  const truncated = base.slice(0, SUMMARY_MAX_LENGTH - 1)
+  const lastSpace = truncated.lastIndexOf(" ")
+  const cut = lastSpace > SUMMARY_MAX_LENGTH * 0.6 ? truncated.slice(0, lastSpace) : truncated
+  return `${cut.trimEnd()}…`
+}
+
+/** Render the markdown body documenting input fields. */
+function renderInputFields(fields: SerializerInputField[]): string {
+  if (fields.length === 0) {
+    return "_This assistant takes no structured inputs._"
+  }
+  const lines = ["| Field | Label | Type |", "| --- | --- | --- |"]
+  for (const f of fields) {
+    const label = (f.label ?? "").replace(/\|/g, "\\|").trim() || "—"
+    const name = f.name.replace(/\|/g, "\\|")
+    const type = f.fieldType.replace(/\|/g, "\\|")
+    lines.push(`| \`${name}\` | ${label} | ${type} |`)
+  }
+  return lines.join("\n")
+}
+
+/** Render the markdown body documenting the prompt chain. */
+function renderPrompts(prompts: SerializerPrompt[]): string {
+  if (prompts.length === 0) {
+    return "_No prompts defined._"
+  }
+  const ordered = [...prompts].sort(
+    (a, b) => (a.position ?? 0) - (b.position ?? 0)
+  )
+  const sections: string[] = []
+  for (const [idx, p] of ordered.entries()) {
+    const heading = `### Step ${idx + 1}: ${p.name || `Prompt ${idx + 1}`}`
+    const parts = [heading]
+    if (p.systemContext && p.systemContext.trim()) {
+      parts.push(`**System context**\n\n${p.systemContext.trim()}`)
+    }
+    parts.push(`**Prompt**\n\n${p.content.trim()}`)
+    const tools = Array.isArray(p.enabledTools) ? p.enabledTools.filter(Boolean) : []
+    if (tools.length > 0) {
+      parts.push(`**Tools:** ${tools.join(", ")}`)
+    }
+    sections.push(parts.join("\n\n"))
+  }
+  return sections.join("\n\n")
+}
+
+/**
+ * Serialize an assistant into a complete SKILL.md document plus metadata.
+ *
+ * @throws Error if the assistant name cannot produce a valid slug.
+ */
+export function serializeAssistantToSkill(
+  assistant: SerializerAssistant
+): SerializedSkill {
+  const slug = slugifySkillName(assistant.name)
+  if (!slug) {
+    throw new Error(
+      `Assistant name "${assistant.name}" does not produce a valid skill slug. ` +
+        "Provide a name with at least one alphanumeric character."
+    )
+  }
+
+  const summary = buildSummary(assistant)
+  const allowedTools = deriveAllowedTools(assistant.prompts ?? [])
+  const inputFields = assistant.inputFields ?? []
+  const prompts = assistant.prompts ?? []
+
+  const frontmatterLines = [
+    "---",
+    `name: ${toYamlScalar(slug)}`,
+    `summary: ${toYamlScalar(summary)}`,
+  ]
+  if (assistant.description && assistant.description.trim()) {
+    frontmatterLines.push(
+      `description: ${toYamlScalar(assistant.description)}`
+    )
+  }
+  // allowed-tools uses a comma-separated inline list when present. Omitting the
+  // key entirely (rather than an empty value) keeps the assistant open to all
+  // catalog tools the caller already has, matching infra skills that pin tools
+  // only when needed.
+  if (allowedTools.length > 0) {
+    frontmatterLines.push(`allowed-tools: ${allowedTools.join(", ")}`)
+  }
+  frontmatterLines.push("---")
+
+  const body = [
+    `# ${assistant.name}`,
+    assistant.description?.trim()
+      ? assistant.description.trim()
+      : "Published from an AI Studio Assistant Architect.",
+    "## Inputs",
+    renderInputFields(inputFields),
+    "## Instructions",
+    renderPrompts(prompts),
+    "---",
+    "_Published from AI Studio Assistant Architect. Some tool references " +
+      "(e.g. `nexus.chat`) are AI-Studio-specific and may need replacement " +
+      "when run outside the platform._",
+  ].join("\n\n")
+
+  const skillMd = `${frontmatterLines.join("\n")}\n\n${body}\n`
+
+  return { slug, skillMd, summary, allowedTools }
+}

--- a/lib/skills/skill-tool-enforcement.ts
+++ b/lib/skills/skill-tool-enforcement.ts
@@ -1,0 +1,73 @@
+/**
+ * Skill `allowed-tools` enforcement (Issue #925, AC#6).
+ *
+ * When a skill is loaded into a session, the tools the model may use are
+ * intersected with the skill's `allowed-tools` frontmatter:
+ *
+ *     effective = scoped(catalog tools for caller) ∩ skill.allowedTools
+ *
+ * The scope intersection already happens in the tool catalog
+ * (`filterAiSdkToolNames`). This module adds the skill-pin intersection and a
+ * thin accessor the Nexus chat route uses to enforce server-side (the client is
+ * untrusted — it can send any `enabledTools`, so the pin must be re-applied on
+ * the server whenever a session is bound to a skill).
+ *
+ * The pure {@link intersectSkillAllowedTools} is exported separately so the
+ * intersection semantics stay unit-testable without a DB.
+ */
+
+import { and, eq } from "drizzle-orm";
+import { executeQuery } from "@/lib/db/drizzle-client";
+import { psdAgentSkills } from "@/lib/db/schema/tables/agent-skills";
+
+/**
+ * Intersect a session's available tool names with a skill's `allowed-tools`.
+ *
+ * - An EMPTY `allowedTools` means the skill pins nothing (the serializer omits
+ *   the frontmatter key in that case), so the session keeps all of `available`.
+ * - A NON-EMPTY `allowedTools` restricts the session to the overlap, preserving
+ *   the order of `available`.
+ *
+ * Pure — no I/O. Callers are responsible for having already scope-filtered
+ * `available`.
+ */
+export function intersectSkillAllowedTools(
+  available: string[],
+  allowedTools: string[]
+): string[] {
+  if (allowedTools.length === 0) return [...available];
+  const pinned = new Set(allowedTools);
+  return available.filter((name) => pinned.has(name));
+}
+
+/**
+ * Fetch the persisted `allowed-tools` for an APPROVED skill (scope=shared,
+ * scanStatus=clean). Returns:
+ *   - `string[]` — the skill's allowed-tools (possibly empty = no pin) when the
+ *     skill exists and is approved.
+ *   - `null` — the skill id is unknown or not approved; callers MUST treat this
+ *     as "do not loosen" (leave the existing tool set unchanged) so a bogus id
+ *     can never widen access.
+ */
+export async function getApprovedSkillAllowedTools(
+  skillId: string
+): Promise<string[] | null> {
+  const rows = await executeQuery(
+    (db) =>
+      db
+        .select({ allowedTools: psdAgentSkills.allowedTools })
+        .from(psdAgentSkills)
+        .where(
+          and(
+            eq(psdAgentSkills.id, skillId),
+            eq(psdAgentSkills.scope, "shared"),
+            eq(psdAgentSkills.scanStatus, "clean")
+          )
+        )
+        .limit(1),
+    "skillEnforcement.allowedTools"
+  );
+  const row = rows[0];
+  if (!row) return null;
+  return Array.isArray(row.allowedTools) ? row.allowedTools : [];
+}

--- a/lib/skills/skill-tool-enforcement.ts
+++ b/lib/skills/skill-tool-enforcement.ts
@@ -48,6 +48,12 @@ export function intersectSkillAllowedTools(
  *   - `null` — the skill id is unknown or not approved; callers MUST treat this
  *     as "do not loosen" (leave the existing tool set unchanged) so a bogus id
  *     can never widen access.
+ *
+ * NOTE: this runs one indexed primary-key lookup per chat request for the
+ * lifetime of a skill-bound session. It is intentionally uncached so that an
+ * admin un-approving a skill takes effect immediately (no stale TTL window). If
+ * this lookup ever shows up in latency profiles, introduce a short-TTL cache
+ * keyed by skillId here — not in the calling route.
  */
 export async function getApprovedSkillAllowedTools(
   skillId: string

--- a/package.json
+++ b/package.json
@@ -128,6 +128,7 @@
     "jose": "^6.1.3",
     "js-tiktoken": "^1.0.21",
     "jsonwebtoken": "^9.0.2",
+    "jszip": "^3.10.1",
     "katex": "^0.17.0",
     "lucide-react": "^1.18.0",
     "mammoth": "^1.11.0",

--- a/tests/e2e/admin-skill-review.spec.ts
+++ b/tests/e2e/admin-skill-review.spec.ts
@@ -1,0 +1,50 @@
+import { test, expect } from '@playwright/test'
+
+/**
+ * E2E: admin-skill-review (Issue #925, AC#8 / AC#3).
+ *
+ * Verifies the admin review queue handles web-published skills end-to-end: the
+ * review page loads, and when a draft/flagged skill is present it exposes the
+ * "Approve to Shared" and "Reject" affordances that move a web-published draft
+ * through the existing Epic #910 pipeline. Resilient skip-if-absent style — the
+ * environment may lack admin auth or a pending skill.
+ */
+test.describe('Admin skill review', () => {
+  test('review queue exposes approve/reject for pending skills', async ({ page }) => {
+    await page.goto('/admin/agents/skills/review')
+
+    const url = page.url()
+    if (
+      url.includes('/auth') ||
+      url.includes('/sign-in') ||
+      url.includes('/login') ||
+      url.includes('/dashboard') ||
+      url.endsWith('/')
+    ) {
+      test.skip(true, 'No admin auth state available — run with a seeded administrator')
+      return
+    }
+
+    try {
+      await page.waitForSelector('h1, h2, main', { timeout: 10000 })
+    } catch {
+      test.skip(true, 'Skill review page did not load')
+      return
+    }
+
+    // The review queue heading should be present for an admin.
+    await expect(page.locator('main, body')).toBeVisible()
+
+    // If at least one skill is queued, the approve + reject controls must render.
+    const approve = page.locator('button:has-text("Approve to Shared")')
+    const reject = page.locator('button:has-text("Reject")')
+
+    if ((await approve.count()) === 0) {
+      test.skip(true, 'No pending skills in the review queue')
+      return
+    }
+
+    await expect(approve.first()).toBeVisible()
+    await expect(reject.first()).toBeVisible()
+  })
+})

--- a/tests/e2e/publish-skill-from-architect.spec.ts
+++ b/tests/e2e/publish-skill-from-architect.spec.ts
@@ -1,0 +1,77 @@
+import { test, expect } from '@playwright/test'
+
+/**
+ * E2E: publish-skill-from-architect (Issue #925).
+ *
+ * Verifies the "Publish as Skill" action on the Assistant Architect preview
+ * page. Follows the resilient, skip-if-absent style of the other architect
+ * specs — the test environment may not have a seeded, edit-ready assistant,
+ * so the test skips gracefully rather than failing on missing fixtures.
+ */
+test.describe('Publish skill from Assistant Architect', () => {
+  test('exposes a "Publish as Skill" action on the preview step', async ({ page }) => {
+    // Navigate to the assistant architect list.
+    await page.goto('/utilities/assistant-architect')
+
+    try {
+      await page.waitForSelector('h1, h2, main', { timeout: 10000 })
+    } catch {
+      test.skip(true, 'Assistant Architect page did not load')
+      return
+    }
+
+    // Find an editable assistant (owned drafts have an Edit affordance).
+    const editLink = page.locator(
+      'a[href*="/assistant-architect/"][href*="/edit"], a:has-text("Edit")'
+    )
+    if ((await editLink.count()) === 0) {
+      test.skip(true, 'No editable assistant available to publish')
+      return
+    }
+
+    await editLink.first().click()
+
+    // Move to the Preview & Submit step where publishing lives. The wizard
+    // exposes a Preview/Next control; fall back to direct URL navigation.
+    const previewNav = page.locator(
+      'a:has-text("Preview"), button:has-text("Preview"), a[href*="/preview"]'
+    )
+    if ((await previewNav.count()) > 0) {
+      await previewNav.first().click()
+    } else {
+      const url = new URL(page.url())
+      if (!url.pathname.endsWith('/preview')) {
+        await page.goto(`${url.pathname.replace(/\/$/, '')}/preview`)
+      }
+    }
+
+    // The Publish as Skill button must render on the preview/submit step.
+    const publishButton = page.locator('[data-testid="publish-as-skill-button"]')
+    try {
+      await publishButton.waitFor({ state: 'visible', timeout: 10000 })
+    } catch {
+      test.skip(true, 'Preview step not reachable for this assistant')
+      return
+    }
+
+    await expect(publishButton).toBeVisible()
+    await expect(publishButton).toHaveText(/Publish as Skill/i)
+
+    // If the assistant meets the publish requirements, the button is enabled.
+    // Triggering it should surface a success or error toast (never crash).
+    if (await publishButton.isEnabled()) {
+      await publishButton.click()
+
+      const toast = page.locator(
+        '[data-sonner-toast], [role="status"], .toast, [data-testid="toast"]'
+      )
+      try {
+        await toast.first().waitFor({ state: 'visible', timeout: 15000 })
+      } catch {
+        // Some environments render toasts transiently; the key assertion is
+        // that the page stays functional after the action.
+      }
+      await expect(page.locator('main, body')).toBeVisible()
+    }
+  })
+})

--- a/tests/e2e/skill-catalog-browse.spec.ts
+++ b/tests/e2e/skill-catalog-browse.spec.ts
@@ -1,0 +1,55 @@
+import { test, expect } from '@playwright/test'
+
+/**
+ * E2E: skill-catalog-browse (Issue #925, AC#8).
+ *
+ * Verifies the user-facing skill catalog at /skills: the page renders, shows
+ * either approved skill cards or the empty state, and (when a skill exists) the
+ * detail page exposes the SKILL.md preview plus the "Use in chat" and
+ * "Export as zip" actions. Resilient skip-if-absent style — the environment may
+ * have no approved skills or no auth state.
+ */
+test.describe('Skill catalog browse', () => {
+  test('lists approved skills and opens a detail page', async ({ page }) => {
+    await page.goto('/skills')
+
+    const url = page.url()
+    if (url.includes('/auth') || url.includes('/sign-in') || url.includes('/login')) {
+      test.skip(true, 'No auth state available — run with seeded users locally')
+      return
+    }
+
+    try {
+      await page.waitForSelector('h1, main', { timeout: 10000 })
+    } catch {
+      test.skip(true, 'Skills catalog page did not load')
+      return
+    }
+
+    // The catalog renders either a grid of skills or an explicit empty state.
+    const grid = page.locator('[data-testid="skills-grid"]')
+    const emptyState = page.locator('[data-testid="skills-empty-state"]')
+    await expect(grid.or(emptyState).first()).toBeVisible()
+
+    const cards = page.locator('[data-testid="skill-card"]')
+    if ((await cards.count()) === 0) {
+      test.skip(true, 'No approved skills to open')
+      return
+    }
+
+    // Open the first skill's detail page.
+    await cards.first().locator('a:has-text("View skill")').click()
+
+    // Detail page exposes the two primary actions and the SKILL.md section.
+    await expect(page.locator('[data-testid="use-in-chat"]')).toBeVisible()
+    await expect(page.locator('[data-testid="export-zip"]')).toBeVisible()
+    await expect(page.locator('text=SKILL.md').first()).toBeVisible()
+
+    // "Use in chat" binds the Nexus session to the skill via ?skillId=.
+    const useHref = await page
+      .locator('[data-testid="use-in-chat"]')
+      .getAttribute('href')
+    expect(useHref).toContain('/nexus?')
+    expect(useHref).toContain('skillId=')
+  })
+})

--- a/tests/unit/skill-catalog-registration.test.ts
+++ b/tests/unit/skill-catalog-registration.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Unit tests for skill → tool catalog registration helpers (Issue #925, AC#5).
+ * Pure functions only — the identifier scheme and catalog row shape.
+ */
+
+import {
+  buildSkillCatalogIdentifier,
+  buildSkillCatalogToolName,
+  buildSkillCatalogToolValues,
+  SKILL_CATALOG_VERSION,
+} from "@/lib/skills/skill-catalog-registration"
+
+describe("buildSkillCatalogIdentifier", () => {
+  it("namespaces the slug under skill.", () => {
+    expect(buildSkillCatalogIdentifier("my-skill")).toBe("skill.my-skill")
+  })
+})
+
+describe("buildSkillCatalogToolName", () => {
+  it("uses the slug as the wire name", () => {
+    expect(buildSkillCatalogToolName("my-skill")).toBe("my-skill")
+  })
+})
+
+describe("buildSkillCatalogToolValues", () => {
+  const values = buildSkillCatalogToolValues({
+    skillId: "11111111-1111-1111-1111-111111111111",
+    slug: "weather-helper",
+    summary: "Looks up the weather",
+  })
+
+  it("marks the row as a skill source", () => {
+    expect(values.source).toBe("skill")
+  })
+
+  it("points handlerRef at the skill id", () => {
+    expect(values.handlerRef).toBe("skill:11111111-1111-1111-1111-111111111111")
+  })
+
+  it("uses the stable skill identifier and version", () => {
+    expect(values.identifier).toBe("skill.weather-helper")
+    expect(values.version).toBe(SKILL_CATALOG_VERSION)
+  })
+
+  it("exposes the skill across chat, MCP, and internal agent surfaces", () => {
+    expect(values.surfaces).toEqual(["ai_sdk", "mcp", "internal"])
+  })
+
+  it("is open to any authenticated caller (no required scopes) and agent-callable", () => {
+    expect(values.requiredScopes).toEqual([])
+    expect(values.agentCallable).toBe(true)
+    expect(values.isActive).toBe(true)
+  })
+
+  it("carries the summary as the description", () => {
+    expect(values.description).toBe("Looks up the weather")
+  })
+
+  it("provides a generic object input schema", () => {
+    expect(values.inputSchema).toEqual({ type: "object", properties: {} })
+  })
+})

--- a/tests/unit/skill-publish-pipeline-export.test.ts
+++ b/tests/unit/skill-publish-pipeline-export.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Unit tests for the zip-export bounds in downloadSkillFolder (Issue #925, AC#7).
+ *
+ * Only clean-scanned approved skills reach the export, so the file-count and
+ * total-size caps are guardrails against a pathological/corrupted folder
+ * spiking ECS task memory — these tests pin that behaviour.
+ */
+
+const sendMock = jest.fn()
+
+jest.mock("@aws-sdk/client-s3", () => {
+  class ListObjectsV2Command {
+    constructor(public input: unknown) {}
+  }
+  class GetObjectCommand {
+    constructor(public input: { Key: string }) {}
+  }
+  class PutObjectCommand {
+    constructor(public input: unknown) {}
+  }
+  class S3Client {
+    send = sendMock
+  }
+  return { S3Client, ListObjectsV2Command, GetObjectCommand, PutObjectCommand }
+})
+
+jest.mock("@aws-sdk/client-lambda", () => ({
+  LambdaClient: class {
+    send = jest.fn()
+  },
+  InvokeCommand: class {
+    constructor(public input: unknown) {}
+  },
+}))
+
+jest.mock("@/lib/settings-manager", () => ({
+  getSetting: jest.fn(async (key: string) =>
+    key === "AGENT_WORKSPACE_BUCKET" ? "test-bucket" : null
+  ),
+}))
+
+jest.mock("@/lib/logger", () => ({
+  createLogger: () => ({
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  }),
+}))
+
+import {
+  downloadSkillFolder,
+  MAX_EXPORT_FILES,
+  MAX_EXPORT_TOTAL_BYTES,
+} from "@/lib/skills/skill-publish-pipeline"
+
+const PREFIX = "skills/user/a@b.com/approved/my-skill/"
+
+// Drive the mocked S3 client: a single ListObjectsV2 page returning `keys`,
+// then a GetObject per key returning `bodyFor(key)`.
+function wireS3(keys: string[], bodyFor: (key: string) => string) {
+  sendMock.mockReset()
+  sendMock.mockImplementation((command: { input: Record<string, unknown> }) => {
+    if ("Prefix" in command.input) {
+      return Promise.resolve({
+        Contents: keys.map((Key) => ({ Key })),
+        IsTruncated: false,
+      })
+    }
+    const key = command.input.Key as string
+    return Promise.resolve({
+      Body: { transformToString: async () => bodyFor(key) },
+    })
+  })
+}
+
+describe("downloadSkillFolder export bounds", () => {
+  it("returns files for a normal folder", async () => {
+    wireS3(
+      [`${PREFIX}SKILL.md`, `${PREFIX}helpers/util.md`],
+      (key) => `content of ${key}`
+    )
+
+    const files = await downloadSkillFolder(PREFIX)
+
+    expect(files).toHaveLength(2)
+    expect(files[0].path).toBe("SKILL.md")
+    expect(files[1].path).toBe("helpers/util.md")
+  })
+
+  it("rejects folders exceeding the file-count cap", async () => {
+    const keys = Array.from(
+      { length: MAX_EXPORT_FILES + 1 },
+      (_, i) => `${PREFIX}file-${i}.md`
+    )
+    wireS3(keys, () => "x")
+
+    await expect(downloadSkillFolder(PREFIX)).rejects.toThrow(
+      /exceeding the export limit of 50/
+    )
+  })
+
+  it("does not issue downloads when the file-count cap is exceeded", async () => {
+    const keys = Array.from(
+      { length: MAX_EXPORT_FILES + 1 },
+      (_, i) => `${PREFIX}file-${i}.md`
+    )
+    wireS3(keys, () => "x")
+
+    await expect(downloadSkillFolder(PREFIX)).rejects.toThrow()
+
+    // Only the ListObjectsV2 call should have fired — no GetObject fan-out.
+    expect(sendMock).toHaveBeenCalledTimes(1)
+  })
+
+  it("rejects folders exceeding the total-size cap", async () => {
+    // Two files whose combined size crosses the byte cap.
+    const half = "a".repeat(Math.floor(MAX_EXPORT_TOTAL_BYTES / 2) + 1)
+    wireS3([`${PREFIX}a.md`, `${PREFIX}b.md`], () => half)
+
+    await expect(downloadSkillFolder(PREFIX)).rejects.toThrow(
+      /exceeding the export limit of .* bytes/
+    )
+  })
+})

--- a/tests/unit/skill-serializer.test.ts
+++ b/tests/unit/skill-serializer.test.ts
@@ -1,0 +1,191 @@
+/**
+ * Unit tests for the Assistant Architect → SKILL.md serializer (Issue #925).
+ * Pure functions, no I/O — these validate the canonical SKILL.md output.
+ */
+
+import {
+  slugifySkillName,
+  deriveAllowedTools,
+  buildSummary,
+  serializeAssistantToSkill,
+  type SerializerAssistant,
+} from "@/lib/skills/skill-serializer"
+
+describe("slugifySkillName", () => {
+  it("lowercases and hyphenates", () => {
+    expect(slugifySkillName("My Cool Assistant")).toBe("my-cool-assistant")
+  })
+
+  it("strips non-alphanumeric and collapses hyphens", () => {
+    expect(slugifySkillName("Foo!!! __ Bar??")).toBe("foo-bar")
+  })
+
+  it("trims leading/trailing hyphens", () => {
+    expect(slugifySkillName("---Edge---")).toBe("edge")
+  })
+
+  it("strips accents", () => {
+    expect(slugifySkillName("Résumé Helper")).toBe("resume-helper")
+  })
+
+  it("returns empty string for names with no usable characters", () => {
+    expect(slugifySkillName("!!!")).toBe("")
+  })
+
+  it("truncates to 64 chars without trailing hyphen", () => {
+    const long = "a".repeat(80)
+    const slug = slugifySkillName(long)
+    expect(slug.length).toBeLessThanOrEqual(64)
+    expect(slug.endsWith("-")).toBe(false)
+  })
+})
+
+describe("deriveAllowedTools", () => {
+  it("returns empty for no prompts", () => {
+    expect(deriveAllowedTools([])).toEqual([])
+  })
+
+  it("unions, dedupes, and sorts tools across prompts", () => {
+    const tools = deriveAllowedTools([
+      { name: "p1", content: "x", enabledTools: ["web-search", "code"] },
+      { name: "p2", content: "y", enabledTools: ["code", "image-gen"] },
+    ])
+    expect(tools).toEqual(["code", "image-gen", "web-search"])
+  })
+
+  it("ignores empty/whitespace and non-array values", () => {
+    const tools = deriveAllowedTools([
+      { name: "p1", content: "x", enabledTools: ["  ", "code", ""] },
+      { name: "p2", content: "y", enabledTools: null },
+    ])
+    expect(tools).toEqual(["code"])
+  })
+})
+
+describe("buildSummary", () => {
+  it("uses the description when present", () => {
+    expect(
+      buildSummary({ name: "A", description: "Does a thing.", prompts: [] })
+    ).toBe("Does a thing.")
+  })
+
+  it("collapses newlines", () => {
+    expect(
+      buildSummary({ name: "A", description: "Line one\n  Line two", prompts: [] })
+    ).toBe("Line one Line two")
+  })
+
+  it("falls back when no description", () => {
+    expect(buildSummary({ name: "Helper", description: null })).toContain(
+      "Helper"
+    )
+  })
+
+  it("truncates over 200 chars with an ellipsis", () => {
+    const summary = buildSummary({
+      name: "A",
+      description: "word ".repeat(60), // 300 chars
+    })
+    expect(summary.length).toBeLessThanOrEqual(200)
+    expect(summary.endsWith("…")).toBe(true)
+  })
+})
+
+describe("serializeAssistantToSkill", () => {
+  const base: SerializerAssistant = {
+    name: "Lesson Planner",
+    description: "Generates differentiated lesson plans for K-12 teachers.",
+    inputFields: [
+      { name: "grade", label: "Grade level", fieldType: "short_text" },
+      { name: "topic", label: null, fieldType: "long_text" },
+    ],
+    prompts: [
+      {
+        name: "Outline",
+        content: "Create an outline for ${topic}.",
+        systemContext: "You are a curriculum designer.",
+        position: 0,
+        enabledTools: ["web-search"],
+      },
+      {
+        name: "Expand",
+        content: "Expand each section.",
+        position: 1,
+        enabledTools: ["code"],
+      },
+    ],
+  }
+
+  it("produces valid frontmatter delimited by ---", () => {
+    const { skillMd } = serializeAssistantToSkill(base)
+    expect(skillMd.startsWith("---\n")).toBe(true)
+    // closing delimiter present
+    expect(skillMd).toMatch(/\n---\n/)
+  })
+
+  it("includes name slug, summary, description, and sorted allowed-tools", () => {
+    const result = serializeAssistantToSkill(base)
+    expect(result.slug).toBe("lesson-planner")
+    expect(result.summary).toBe(
+      "Generates differentiated lesson plans for K-12 teachers."
+    )
+    expect(result.allowedTools).toEqual(["code", "web-search"])
+    expect(result.skillMd).toContain("name: lesson-planner")
+    expect(result.skillMd).toContain("allowed-tools: code, web-search")
+  })
+
+  it("renders input fields and prompt steps in the body", () => {
+    const { skillMd } = serializeAssistantToSkill(base)
+    expect(skillMd).toContain("| `grade` | Grade level | short_text |")
+    expect(skillMd).toContain("### Step 1: Outline")
+    expect(skillMd).toContain("### Step 2: Expand")
+    expect(skillMd).toContain("You are a curriculum designer.")
+  })
+
+  it("orders prompt steps by position", () => {
+    const out = serializeAssistantToSkill({
+      ...base,
+      prompts: [
+        { name: "Second", content: "b", position: 2, enabledTools: [] },
+        { name: "First", content: "a", position: 1, enabledTools: [] },
+      ],
+    })
+    const firstIdx = out.skillMd.indexOf("First")
+    const secondIdx = out.skillMd.indexOf("Second")
+    expect(firstIdx).toBeGreaterThan(-1)
+    expect(firstIdx).toBeLessThan(secondIdx)
+  })
+
+  it("omits allowed-tools key when there are no tools", () => {
+    const { skillMd } = serializeAssistantToSkill({
+      ...base,
+      prompts: [{ name: "P", content: "x", enabledTools: [] }],
+    })
+    expect(skillMd).not.toContain("allowed-tools:")
+  })
+
+  it("quotes summary values that would break YAML", () => {
+    const { skillMd } = serializeAssistantToSkill({
+      name: "Edge",
+      description: "key: value with a colon",
+      prompts: [],
+    })
+    expect(skillMd).toContain('summary: "key: value with a colon"')
+  })
+
+  it("handles empty input fields gracefully", () => {
+    const { skillMd } = serializeAssistantToSkill({
+      name: "NoInputs",
+      description: "x",
+      inputFields: [],
+      prompts: [{ name: "P", content: "y", enabledTools: [] }],
+    })
+    expect(skillMd).toContain("_This assistant takes no structured inputs._")
+  })
+
+  it("throws for names that cannot produce a slug", () => {
+    expect(() =>
+      serializeAssistantToSkill({ name: "!!!", description: "x", prompts: [] })
+    ).toThrow(/valid skill slug/)
+  })
+})

--- a/tests/unit/skill-tool-enforcement.test.ts
+++ b/tests/unit/skill-tool-enforcement.test.ts
@@ -1,9 +1,28 @@
 /**
  * Unit tests for skill allowed-tools enforcement (Issue #925, AC#6).
- * Pure intersection semantics only — DB access is exercised elsewhere.
+ * Covers the pure intersection semantics and the security-relevant DB accessor
+ * (`getApprovedSkillAllowedTools`), whose `null` return is the "do not loosen"
+ * signal for an unknown/unapproved skill id.
  */
 
-import { intersectSkillAllowedTools } from "@/lib/skills/skill-tool-enforcement"
+// Mock the DB layer so getApprovedSkillAllowedTools can be driven by the rows
+// executeQuery resolves to. The Drizzle query builder callback is never run.
+const executeQueryMock = jest.fn()
+jest.mock("@/lib/db/drizzle-client", () => ({
+  executeQuery: (...args: unknown[]) => executeQueryMock(...args),
+}))
+jest.mock("@/lib/db/schema/tables/agent-skills", () => ({
+  psdAgentSkills: {},
+}))
+jest.mock("drizzle-orm", () => ({
+  and: (...a: unknown[]) => a,
+  eq: (...a: unknown[]) => a,
+}))
+
+import {
+  intersectSkillAllowedTools,
+  getApprovedSkillAllowedTools,
+} from "@/lib/skills/skill-tool-enforcement"
 
 describe("intersectSkillAllowedTools", () => {
   it("returns all available tools when the skill pins nothing", () => {
@@ -47,5 +66,36 @@ describe("intersectSkillAllowedTools", () => {
     expect(
       intersectSkillAllowedTools(["a", "b", "c"], ["b"])
     ).toEqual(["b"])
+  })
+})
+
+describe("getApprovedSkillAllowedTools (DB path)", () => {
+  beforeEach(() => {
+    executeQueryMock.mockReset()
+  })
+
+  it("returns null when the skill id is unknown or not approved", async () => {
+    // No matching row (draft/rejected skill, or bogus id).
+    executeQueryMock.mockResolvedValue([])
+    await expect(
+      getApprovedSkillAllowedTools("00000000-0000-0000-0000-000000000000")
+    ).resolves.toBeNull()
+  })
+
+  it("returns the skill's allowed-tools when approved", async () => {
+    executeQueryMock.mockResolvedValue([
+      { allowedTools: ["webSearch", "imageGen"] },
+    ])
+    await expect(getApprovedSkillAllowedTools("skill-id")).resolves.toEqual([
+      "webSearch",
+      "imageGen",
+    ])
+  })
+
+  it("returns an empty array (no pin) when allowedTools is null in the row", async () => {
+    // An approved skill that pins nothing stores null/non-array; the accessor
+    // normalizes to [] so callers keep all available tools (no pin), NOT null.
+    executeQueryMock.mockResolvedValue([{ allowedTools: null }])
+    await expect(getApprovedSkillAllowedTools("skill-id")).resolves.toEqual([])
   })
 })

--- a/tests/unit/skill-tool-enforcement.test.ts
+++ b/tests/unit/skill-tool-enforcement.test.ts
@@ -1,0 +1,51 @@
+/**
+ * Unit tests for skill allowed-tools enforcement (Issue #925, AC#6).
+ * Pure intersection semantics only — DB access is exercised elsewhere.
+ */
+
+import { intersectSkillAllowedTools } from "@/lib/skills/skill-tool-enforcement"
+
+describe("intersectSkillAllowedTools", () => {
+  it("returns all available tools when the skill pins nothing", () => {
+    expect(
+      intersectSkillAllowedTools(["webSearch", "codeInterpreter"], [])
+    ).toEqual(["webSearch", "codeInterpreter"])
+  })
+
+  it("returns a copy, not the same array reference, for the no-pin case", () => {
+    const available = ["a", "b"]
+    const result = intersectSkillAllowedTools(available, [])
+    expect(result).toEqual(available)
+    expect(result).not.toBe(available)
+  })
+
+  it("restricts to the overlap when the skill pins tools", () => {
+    expect(
+      intersectSkillAllowedTools(
+        ["webSearch", "codeInterpreter", "imageGen"],
+        ["webSearch", "imageGen"]
+      )
+    ).toEqual(["webSearch", "imageGen"])
+  })
+
+  it("preserves the order of the available list, not the pin list", () => {
+    expect(
+      intersectSkillAllowedTools(
+        ["a", "b", "c"],
+        ["c", "a"]
+      )
+    ).toEqual(["a", "c"])
+  })
+
+  it("returns empty when the pin and available sets do not overlap", () => {
+    expect(
+      intersectSkillAllowedTools(["a", "b"], ["x", "y"])
+    ).toEqual([])
+  })
+
+  it("drops available tools the skill does not pin", () => {
+    expect(
+      intersectSkillAllowedTools(["a", "b", "c"], ["b"])
+    ).toEqual(["b"])
+  })
+})


### PR DESCRIPTION
## Summary

Implements **Issue #925 end to end** — the skill platform connecting the web-side Assistant Architect / Epic #910 `agent_skills` registry to the infra-side SKILL.md scan pipeline, the unified tool catalog (#924), and the Nexus runtime. All 8 acceptance criteria are addressed (earlier revisions of this PR delivered only AC#1–2; the rest are now built).

## Acceptance criteria

| AC | Status | Where |
|----|--------|-------|
| #1 "Publish as Skill" → valid SKILL.md | ✅ | `lib/skills/skill-serializer.ts`, preview button |
| #2 Flows through scan → `agent_skills` (proper status) | ✅ | `lib/skills/skill-publish-pipeline.ts`, `publish-skill.actions.ts` |
| #3 Admin review UI handles web-published skills | ✅ | Epic #910 review queue surfaces `draft`+`pending`; approve → `shared`+`clean` now also registers catalog tool; E2E added |
| #4 User catalog page (list + detail + use) | ✅ | `/skills`, `/skills/[id]`, `skills-catalog.actions.ts` |
| #5 Approved skill registered in tool catalog (`source: skill`) | ✅ | `lib/skills/skill-catalog-registration.ts` |
| #6 `allowed-tools` enforced at invocation | ✅ | `lib/skills/skill-tool-enforcement.ts` + Nexus chat route |
| #7 Zip export, loads in Claude Code | ✅ | `GET /api/skills/[id]/export` (jszip) |
| #8 E2E: publish / catalog-browse / admin-review | ✅ | `tests/e2e/*.spec.ts` |

## How it fits together

- **Persist allowed-tools** (migration `081`): adds `psd_agent_skills.allowed_tools` so the pin is queryable for both catalog registration and runtime enforcement (it previously lived only in the SKILL.md frontmatter + audit row). Publish writes it on insert + upsert.
- **Approval = catalog registration**: `approveSkillToShared` upserts a `source='skill'` row into `tool_catalog` (`identifier skill.<slug>`, `handlerRef skill:<id>`) in the same transaction; reject/delete deactivate it; the catalog cache is invalidated after each.
- **Invocation enforcement**: the "Use in chat" link binds the Nexus session to the skill (`?skillId=`), threaded through the runtime `body()`. The chat route re-applies the skill's allowed-tools pin server-side **after** scope filtering (the client tool list is untrusted). Empty pin = no restriction.
- **Catalog UX**: `/skills` lists approved (`shared`+`clean`) skills with search; the detail page renders the SKILL.md preview and offers "Use in chat" + "Export as zip". New workspace-bucket S3 readers were required because `lib/aws/s3-client.ts` targets the documents bucket, not the agent workspace bucket where skills live.
- **Zip export** streams the authored SKILL.md folder (excluding `node_modules` scan artifacts) for Claude Code / Desktop.

## Touched files & gates

New:
- `infra/database/schema/081-skill-platform-catalog.sql` — allowed_tools column + Skills nav (additive, idempotent, no DO$$ blocks)
- `lib/skills/skill-catalog-registration.ts` · `lib/skills/skill-tool-enforcement.ts`
- `actions/db/skills-catalog.actions.ts`
- `app/(protected)/skills/page.tsx` · `_components/skills-catalog-client.tsx` · `[id]/page.tsx` · `[id]/_components/skill-detail-client.tsx`
- `app/api/skills/[id]/export/route.ts`
- `tests/unit/skill-catalog-registration.test.ts` · `tests/unit/skill-tool-enforcement.test.ts`
- `tests/e2e/skill-catalog-browse.spec.ts` · `tests/e2e/admin-skill-review.spec.ts`

Modified:
- `lib/skills/skill-publish-pipeline.ts` (S3 readers) · `lib/skills/skill-serializer.ts` (prior) · `actions/db/publish-skill.actions.ts` (persist allowed_tools)
- `actions/admin/agent-skills.actions.ts` (catalog register/deactivate + invalidate)
- `lib/db/schema/tables/agent-skills.ts` (allowed_tools) · `lib/db/drizzle-client.ts` (`DbTransaction` export) · `infra/database/migrations.json`
- `app/api/nexus/chat/route.ts` (skillId + server-side pin enforcement) · `app/(protected)/nexus/page.tsx` (skillId binding)
- `package.json` / `bun.lock` (jszip)

Gates:
- ✅ **Unit/integration tests**: 15 new (registration + enforcement pure logic) pass; 21 serializer + 28 tool-catalog tests still green
- ✅ **E2E**: 3 specs parse + list; resilient skip-if-absent (no seeded data in CI)
- ✅ **Typecheck**: web `tsc --noEmit` and infra `tsc --noEmit` both exit 0; no new `any`
- ✅ **Lint**: `bun run lint` exit 0. New/modified source files are warning-clean **except** `app/(protected)/nexus/page.tsx`, which carries 5 **pre-existing** warnings (verified identical on `HEAD`). 2 are `Unused eslint-disable directive` false positives — removing the directives introduces 5 `react-hooks/refs` errors, so they are load-bearing. 3 are structural (`max-lines`/`complexity`) on the conversation-runtime functions; CLAUDE.md flags this file as fragile ("broken multiple times") and a refactor can't be verified without running the live Nexus app, so it was not attempted here.

## Notes / decisions
- Skill identifier collision: catalog identifier is `skill.<slug>`; the slug is already collision-resistant within owner+scope via the partial unique indexes.
- S3 location: web-published drafts stay at `skills/user/{email}/drafts/{slug}/` (matches infra author flow); approved artifacts read from the row's `s3_key`.
- Republish bumps the draft version in place (existing upsert behavior).

Closes #925