### PR TITLE
fix(admin): constrain admin layout width to max-w-7xl on wide monitors (#1015)

### DIFF
--- a/app/(protected)/admin/layout.tsx
+++ b/app/(protected)/admin/layout.tsx
@@ -11,8 +11,8 @@ export default async function AdminLayout({
   return (
     <div className="flex min-h-screen">
       <NavbarNested fullHeight />
-      <main className="flex-1 lg:pl-[68px] min-w-0">
-        <div className="bg-white p-4 sm:p-6 md:p-8 max-w-7xl mx-auto">
+      <main className="flex-1 lg:pl-[68px] min-w-0 bg-white">
+        <div className="p-4 sm:p-6 md:p-8 max-w-7xl mx-auto">
           {children}
         </div>
       </main>

--- a/app/(protected)/admin/layout.tsx
+++ b/app/(protected)/admin/layout.tsx
@@ -11,8 +11,8 @@ export default async function AdminLayout({
   return (
     <div className="flex min-h-screen">
       <NavbarNested fullHeight />
-      <main className="flex-1 lg:pl-[68px]">
-        <div className="bg-white p-4 sm:p-6 md:p-8">
+      <main className="flex-1 lg:pl-[68px] min-w-0">
+        <div className="bg-white p-4 sm:p-6 md:p-8 max-w-7xl mx-auto">
           {children}
         </div>
       </main>


### PR DESCRIPTION
## Summary

Fixes #1015 — on wide monitors (2560×1440 reported), the entire admin section (`/admin/models`, `/admin/settings`, and all 13 other admin pages) expanded unboundedly because the `<main>` flex-child had no max-width constraint.

**Root cause** (from triage): `app/(protected)/admin/layout.tsx` applied `flex-1` to `<main>` with no `max-w-*` on either the main element or its inner content div, causing the full viewport width (minus the 68px sidebar) to flow into every admin page's content area.

## Changes

Single file changed — `app/(protected)/admin/layout.tsx`:

- Add `max-w-7xl mx-auto` to the inner content `<div>` — caps all admin content at 1280px and centers it horizontally. Covers all 13 admin routes in one place (models, settings, users, roles, assistants, agents, prompts, repositories, connectors, graph, activity, navigation, oauth-clients).
- Add `min-w-0` to `<main>` — prevents the flex child from overflowing its container, which can happen when a constrained inner element pushes against an unconstrained flex parent.

No per-page changes required.

## Test Plan

- [ ] Navigate to `/admin/models` on a wide monitor (≥1280px viewport) and confirm the content is capped and centered
- [ ] Navigate to `/admin/settings` and confirm the same
- [ ] Verify on a normal laptop screen (1440×900) that the layout is unchanged / not clipped
- [ ] Confirm the models data table still scrolls horizontally when columns exceed container width

## Security

No auth, data, or API changes — pure CSS layout constraint.

---
*Opened by the lfg routine. Closes #1015*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UDeC5MrLuiJtAyHmyNro5i

---
_Generated by [Claude Code](https://claude.ai/code/session_01UDeC5MrLuiJtAyHmyNro5i)_