### PR TITLE
fix(bug-report): #1016 — include user identity in bug report description body

### DIFF
--- a/actions/create-freshservice-ticket.actions.ts
+++ b/actions/create-freshservice-ticket.actions.ts
@@ -102,6 +102,9 @@ export async function createFreshserviceTicketAction(
     
     let response: Response
 
+    const requesterName = (typeof session.name === 'string' ? session.name.trim() : '')
+      || [session.givenName, session.familyName].filter(Boolean).join(' ').trim()
+
     // Reconstruct screenshot from base64 data URL if provided
     const hasAttachment = screenshotData && screenshotData.startsWith('data:')
 
@@ -148,10 +151,8 @@ export async function createFreshserviceTicketAction(
       freshserviceFormData.append('subject', title)
       freshserviceFormData.append('description', description)
       freshserviceFormData.append('email', session.email || 'noreply@psd401.org')
-      const multipartSessionName = typeof session.name === 'string' ? session.name.trim() : ''
-      const multipartRequesterName = multipartSessionName || [session.givenName, session.familyName].filter(Boolean).join(' ').trim()
-      if (multipartRequesterName) {
-        freshserviceFormData.append('name', multipartRequesterName)
+      if (requesterName) {
+        freshserviceFormData.append('name', requesterName)
       }
       freshserviceFormData.append('priority', settings.priority)
       freshserviceFormData.append('status', settings.status)
@@ -195,11 +196,8 @@ export async function createFreshserviceTicketAction(
         type: settings.ticketType
       }
       
-      // Add requester name if available — prefer combined name, fall back to given+family
-      const jsonSessionName = typeof session.name === 'string' ? session.name.trim() : ''
-      const jsonRequesterName = jsonSessionName || [session.givenName, session.familyName].filter(Boolean).join(' ').trim()
-      if (jsonRequesterName) {
-        ticketData.name = jsonRequesterName
+      if (requesterName) {
+        ticketData.name = requesterName
       }
 
       // Add workspace_id for JSON requests

--- a/actions/create-freshservice-ticket.actions.ts
+++ b/actions/create-freshservice-ticket.actions.ts
@@ -148,7 +148,8 @@ export async function createFreshserviceTicketAction(
       freshserviceFormData.append('subject', title)
       freshserviceFormData.append('description', description)
       freshserviceFormData.append('email', session.email || 'noreply@psd401.org')
-      const multipartRequesterName = [session.givenName, session.familyName].filter(Boolean).join(' ').trim()
+      const multipartSessionName = typeof session.name === 'string' ? session.name.trim() : ''
+      const multipartRequesterName = multipartSessionName || [session.givenName, session.familyName].filter(Boolean).join(' ').trim()
       if (multipartRequesterName) {
         freshserviceFormData.append('name', multipartRequesterName)
       }
@@ -194,8 +195,9 @@ export async function createFreshserviceTicketAction(
         type: settings.ticketType
       }
       
-      // Add requester name if available
-      const jsonRequesterName = [session.givenName, session.familyName].filter(Boolean).join(' ').trim()
+      // Add requester name if available — prefer combined name, fall back to given+family
+      const jsonSessionName = typeof session.name === 'string' ? session.name.trim() : ''
+      const jsonRequesterName = jsonSessionName || [session.givenName, session.familyName].filter(Boolean).join(' ').trim()
       if (jsonRequesterName) {
         ticketData.name = jsonRequesterName
       }

--- a/actions/create-freshservice-ticket.actions.ts
+++ b/actions/create-freshservice-ticket.actions.ts
@@ -148,6 +148,10 @@ export async function createFreshserviceTicketAction(
       freshserviceFormData.append('subject', title)
       freshserviceFormData.append('description', description)
       freshserviceFormData.append('email', session.email || 'noreply@psd401.org')
+      const multipartRequesterName = [session.givenName, session.familyName].filter(Boolean).join(' ').trim()
+      if (multipartRequesterName) {
+        freshserviceFormData.append('name', multipartRequesterName)
+      }
       freshserviceFormData.append('priority', settings.priority)
       freshserviceFormData.append('status', settings.status)
       freshserviceFormData.append('department_id', settings.departmentId)
@@ -190,6 +194,12 @@ export async function createFreshserviceTicketAction(
         type: settings.ticketType
       }
       
+      // Add requester name if available
+      const jsonRequesterName = [session.givenName, session.familyName].filter(Boolean).join(' ').trim()
+      if (jsonRequesterName) {
+        ticketData.name = jsonRequesterName
+      }
+
       // Add workspace_id for JSON requests
       if (settings.workspaceId) {
         ticketData.workspace_id = Number.parseInt(settings.workspaceId)

--- a/components/navigation/navbar-nested.tsx
+++ b/components/navigation/navbar-nested.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import Image from 'next/image';
 import Link from 'next/link';
 import { useSession } from 'next-auth/react';
+import type { Session } from 'next-auth';
 import { motion, AnimatePresence } from 'framer-motion';
 import { LogOut, Settings, Bug, LucideIcon, Image as ImageIcon, X } from 'lucide-react';
 import { ScrollArea } from '@/components/ui/scroll-area';
@@ -365,7 +366,7 @@ function readFileAsDataUrl(file: File): Promise<string> {
   });
 }
 
-function collectBugReportMetadata(userDescription: string, steps: string, consoleErrors: string[], isAuthenticated: boolean): string {
+function collectBugReportMetadata(userDescription: string, steps: string, consoleErrors: string[], session: Session | null | undefined): string {
   const sections: string[] = [];
 
   // User description - escape HTML
@@ -407,11 +408,17 @@ function collectBugReportMetadata(userDescription: string, steps: string, consol
     sections.push(`Pixel Ratio: ${window.devicePixelRatio}`);
   }
 
-  // Session - use isAuthenticated param instead of localStorage
+  // Session info
   sections.push('<br><br><strong>=== SESSION INFO ===</strong>');
   sections.push(`Timestamp: ${new Date().toISOString()}`);
   sections.push(`Timezone: ${Intl.DateTimeFormat().resolvedOptions().timeZone}`);
-  sections.push(`Authenticated: ${isAuthenticated ? 'Yes' : 'No'}`);
+  sections.push(`Authenticated: ${session ? 'Yes' : 'No'}`);
+  if (session?.user) {
+    sections.push(`User Email: ${escapeHtml(session.user.email ?? 'N/A')}`);
+    const displayName = session.user.name ?? [session.user.givenName, session.user.familyName].filter(Boolean).join(' ') || 'N/A';
+    sections.push(`User Name: ${escapeHtml(displayName)}`);
+    sections.push(`User ID: ${escapeHtml(session.user.id ?? 'N/A')}`);
+  }
   if (typeof window !== 'undefined' && window.localStorage) {
     sections.push(`Local Storage Items: ${window.localStorage.length}`);
   }
@@ -532,7 +539,7 @@ function BugReportModal({ isExpanded }: BugReportModalProps) {
       const steps = stepsEl instanceof HTMLTextAreaElement ? stepsEl.value : '';
 
       // Build rich description with all metadata
-      const fullDescription = collectBugReportMetadata(descriptionText, steps, consoleErrors, !!session);
+      const fullDescription = collectBugReportMetadata(descriptionText, steps, consoleErrors, session);
 
       const formData = new FormData();
       formData.append('title', title);

--- a/components/navigation/navbar-nested.tsx
+++ b/components/navigation/navbar-nested.tsx
@@ -415,7 +415,7 @@ function collectBugReportMetadata(userDescription: string, steps: string, consol
   sections.push(`Authenticated: ${session ? 'Yes' : 'No'}`);
   if (session?.user) {
     sections.push(`User Email: ${escapeHtml(session.user.email ?? 'N/A')}`);
-    const displayName = session.user.name ?? [session.user.givenName, session.user.familyName].filter(Boolean).join(' ') || 'N/A';
+    const displayName = session.user.name ?? ([session.user.givenName, session.user.familyName].filter(Boolean).join(' ') || 'N/A');
     sections.push(`User Name: ${escapeHtml(displayName)}`);
     sections.push(`User ID: ${escapeHtml(session.user.id ?? 'N/A')}`);
   }


### PR DESCRIPTION
## Summary

Implements #1016 — bug reports submitted via the in-app widget did not include the reporter's email, name, or user ID in the description body, making follow-up difficult for support staff.

## Root Cause

`collectBugReportMetadata()` in `components/navigation/navbar-nested.tsx` accepted `isAuthenticated: boolean` and only wrote `Authenticated: Yes/No` in the SESSION INFO section. The call site passed `!!session` (a boolean coercion), silently stripping all identity information from the full session object.

## Changes

- `components/navigation/navbar-nested.tsx`
  - Change `collectBugReportMetadata()` parameter from `isAuthenticated: boolean` to `session: Session | null | undefined`
  - Write `User Email`, `User Name`, and `User ID` into the SESSION INFO section when user is authenticated
  - Update call site to pass the full `session` object instead of `!!session`
  - Add `import type { Session } from 'next-auth'`

- `actions/create-freshservice-ticket.actions.ts`
  - Add requester `name` field (first + last name) to both the multipart/form-data and JSON FreshService API request paths so the ticket requester name is also set correctly in FreshService

## Test Plan
- [x] TypeScript typecheck passes (`bunx tsc --noEmit` — no errors in changed files)
- [x] ESLint passes (no warnings/errors in changed files)
- [x] Inline tests passing
- [x] Security audit — PASSED (see audit comment)
- [ ] Human review — verify bug report description body now shows user identity fields

Closes #1016

---
*Opened by the lfg routine.*