### PR TITLE
fix(nexus): surface upload errors as user-visible toasts (#1018)

### DIFF
--- a/app/(protected)/nexus/decision-capture/page.tsx
+++ b/app/(protected)/nexus/decision-capture/page.tsx
@@ -113,7 +113,10 @@ function DecisionRuntimeProvider({
         duration: 8000,
         action: {
           label: 'Sign in',
-          onClick: () => { window.location.href = '/api/auth/signin?callbackUrl=/nexus' },
+          onClick: () => {
+            const callbackUrl = encodeURIComponent(window.location.pathname + window.location.search)
+            window.location.href = `/api/auth/signin?callbackUrl=${callbackUrl}`
+          },
         },
       })
     } else {

--- a/app/(protected)/nexus/decision-capture/page.tsx
+++ b/app/(protected)/nexus/decision-capture/page.tsx
@@ -14,9 +14,11 @@ import { ConversationInitializer } from '../_components/conversation-initializer
 import { DecisionToolUIs } from './_components/tools/decision-tools-ui'
 import { ChartVisualizationUI } from '../_components/tools/chart-visualization-ui'
 import { createEnhancedNexusAttachmentAdapter } from '@/lib/nexus/enhanced-attachment-adapters'
+import { UploadClassifiedError } from '@/lib/errors/upload-errors'
 import { validateConversationId, navigateToDecisionCaptureConversation, navigateToNewDecisionCapture } from '@/lib/nexus/conversation-navigation'
 import { createLogger } from '@/lib/client-logger'
 import { handleContentBlockedResponse } from '@/lib/nexus/content-blocked-handler'
+import { toast } from 'sonner'
 
 /**
  * Decision Capture Page
@@ -98,6 +100,32 @@ function DecisionRuntimeProvider({
     })
   }, [])
 
+  const handleAttachmentError = useCallback((attachmentId: string, error: UploadClassifiedError | Error) => {
+    log.warn('Attachment processing failed', {
+      attachmentId,
+      code: error instanceof UploadClassifiedError ? error.code : undefined,
+      error: error.message,
+    })
+
+    if (error instanceof UploadClassifiedError && error.code === 'UNAUTHORIZED') {
+      toast.error('Session expired', {
+        description: 'Your session expired during file upload. Please sign in again.',
+        duration: 8000,
+        action: {
+          label: 'Sign in',
+          onClick: () => { window.location.href = '/api/auth/signin?callbackUrl=/nexus' },
+        },
+      })
+    } else {
+      toast.error('File upload failed', {
+        description: error instanceof UploadClassifiedError
+          ? `Upload error: ${error.code.replace(/_/g, ' ').toLowerCase()}.`
+          : 'The file could not be uploaded. Please try again.',
+        duration: 6000,
+      })
+    }
+  }, [])
+
   // Custom fetch to intercept conversation ID header and handle content safety blocks
   const customFetch = useCallback(async (input: RequestInfo | URL, init?: RequestInit) => {
     const response = await fetch(input, init)
@@ -121,8 +149,9 @@ function DecisionRuntimeProvider({
     return createEnhancedNexusAttachmentAdapter({
       onProcessingStart: handleAttachmentProcessingStart,
       onProcessingComplete: handleAttachmentProcessingComplete,
+      onError: handleAttachmentError,
     })
-  }, [handleAttachmentProcessingStart, handleAttachmentProcessingComplete])
+  }, [handleAttachmentProcessingStart, handleAttachmentProcessingComplete, handleAttachmentError])
 
   // Chat runtime — no model picker needed, model is admin-configured
   const runtime = useChatRuntime({

--- a/app/(protected)/nexus/page.tsx
+++ b/app/(protected)/nexus/page.tsx
@@ -689,7 +689,10 @@ function NexusPageContent() {
         duration: 8000,
         action: {
           label: 'Sign in',
-          onClick: () => { window.location.href = '/api/auth/signin?callbackUrl=/nexus' },
+          onClick: () => {
+            const callbackUrl = encodeURIComponent(window.location.pathname + window.location.search)
+            window.location.href = `/api/auth/signin?callbackUrl=${callbackUrl}`
+          },
         },
       })
     } else {

--- a/app/(protected)/nexus/page.tsx
+++ b/app/(protected)/nexus/page.tsx
@@ -19,6 +19,7 @@ import { ConnectorToolProvider, useConnectorTools } from './_components/tools/co
 import { ConnectorReconnectPrompt, ConnectorToolFallback } from './_components/tools/connector-tool-ui'
 import { useModelsWithPersistence } from '@/lib/hooks/use-models'
 import { createEnhancedNexusAttachmentAdapter } from '@/lib/nexus/enhanced-attachment-adapters'
+import { UploadClassifiedError } from '@/lib/errors/upload-errors'
 import { validateConversationId } from '@/lib/nexus/conversation-navigation'
 import type { SelectAiModel } from '@/types'
 import { createLogger } from '@/lib/client-logger'
@@ -675,6 +676,32 @@ function NexusPageContent() {
     log.debug('Attachment processing completed', { attachmentId })
   }, [])
 
+  const handleAttachmentError = useCallback((attachmentId: string, error: UploadClassifiedError | Error) => {
+    log.warn('Attachment processing failed', {
+      attachmentId,
+      code: error instanceof UploadClassifiedError ? error.code : undefined,
+      error: error.message,
+    })
+
+    if (error instanceof UploadClassifiedError && error.code === 'UNAUTHORIZED') {
+      toast.error('Session expired', {
+        description: 'Your session expired during file upload. Please sign in again.',
+        duration: 8000,
+        action: {
+          label: 'Sign in',
+          onClick: () => { window.location.href = '/api/auth/signin?callbackUrl=/nexus' },
+        },
+      })
+    } else {
+      toast.error('File upload failed', {
+        description: error instanceof UploadClassifiedError
+          ? `Upload error: ${error.code.replace(/_/g, ' ').toLowerCase()}.`
+          : 'The file could not be uploaded. Please try again.',
+        duration: 6000,
+      })
+    }
+  }, [])
+
   // Conversation ID callback for maintaining conversation continuity
   const handleConversationIdChange = useCallback((newConversationId: string) => {
     setConversationId(newConversationId)
@@ -714,8 +741,9 @@ function NexusPageContent() {
     return createEnhancedNexusAttachmentAdapter({
       onProcessingStart: handleAttachmentProcessingStart,
       onProcessingComplete: handleAttachmentProcessingComplete,
+      onError: handleAttachmentError,
     })
-  }, [handleAttachmentProcessingStart, handleAttachmentProcessingComplete])
+  }, [handleAttachmentProcessingStart, handleAttachmentProcessingComplete, handleAttachmentError])
 
   // Voice mode — check availability (adapter created inside NexusRuntimeWrapper via useVoiceSession)
   const voiceAvailability = useVoiceAvailability()

--- a/lib/nexus/enhanced-attachment-adapters.ts
+++ b/lib/nexus/enhanced-attachment-adapters.ts
@@ -15,6 +15,12 @@ const log = createLogger({ moduleName: 'enhanced-attachment-adapters' });
 export interface AttachmentProcessingCallbacks {
   onProcessingStart?: (attachmentId: string) => void;
   onProcessingComplete?: (attachmentId: string) => void;
+  /**
+   * Called when background processing fails (network error, 401, 5xx, etc.).
+   * The caller can show a toast, redirect to sign-in, or take other recovery actions.
+   * The error is the original (unredacted) error — do NOT pass to LLM context.
+   */
+  onError?: (attachmentId: string, error: UploadClassifiedError | Error) => void;
 }
 
 /**
@@ -222,6 +228,14 @@ export class HybridDocumentAdapter implements AttachmentAdapter {
       // Only controlled strings reach the LLM — unknown errors get a generic
       // message to prevent indirect prompt injection (OWASP LLM Top 10).
       const safeMessage = HybridDocumentAdapter.toSafeErrorMessage(rawMessage, errorCode);
+
+      // Notify caller of the error so they can show a toast or redirect.
+      // Pass the original error (not the redacted message) so callers can
+      // distinguish auth failures (UploadClassifiedError with code UNAUTHORIZED)
+      // from transient infrastructure errors and act accordingly.
+      if (this.callbacks?.onError) {
+        this.callbacks.onError(attachment.id, error instanceof Error ? error : new Error(rawMessage));
+      }
 
       return {
         id: attachment.id,

--- a/tests/unit/api/nexus/upload-v2-route.test.ts
+++ b/tests/unit/api/nexus/upload-v2-route.test.ts
@@ -51,7 +51,7 @@ jest.mock('next/server', () => {
   return { NextRequest: MockNextRequest, NextResponse };
 });
 
-import { describe, it, expect, jest, beforeEach } from '@jest/globals';
+import { describe, it, expect, beforeEach } from '@jest/globals';
 import { NextRequest } from 'next/server';
 
 // ── Mock order matters: must precede imports of our code ──────────────────────
@@ -98,11 +98,11 @@ import type { DocumentJob } from '@/lib/services/document-job-service';
 import { uploadToS3 } from '@/lib/aws/document-upload';
 import { sendToProcessingQueue } from '@/lib/aws/lambda-trigger';
 
-const mockGetServerSession = getServerSession as jest.MockedFunction<typeof getServerSession>;
-const mockCreateDocumentJob = createDocumentJob as jest.MockedFunction<typeof createDocumentJob>;
-const mockConfirmDocumentUpload = confirmDocumentUpload as jest.MockedFunction<typeof confirmDocumentUpload>;
-const mockUploadToS3 = uploadToS3 as jest.MockedFunction<typeof uploadToS3>;
-const mockSendToProcessingQueue = sendToProcessingQueue as jest.MockedFunction<typeof sendToProcessingQueue>;
+const mockGetServerSession = getServerSession as jest.Mock;
+const mockCreateDocumentJob = createDocumentJob as jest.Mock;
+const mockConfirmDocumentUpload = confirmDocumentUpload as jest.Mock;
+const mockUploadToS3 = uploadToS3 as jest.Mock;
+const mockSendToProcessingQueue = sendToProcessingQueue as jest.Mock;
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 

--- a/tests/unit/api/nexus/upload-v2-route.test.ts
+++ b/tests/unit/api/nexus/upload-v2-route.test.ts
@@ -33,7 +33,7 @@ jest.mock('@/lib/aws/lambda-trigger', () => ({
 }));
 
 jest.mock('@/lib/rate-limit', () => ({
-  apiRateLimit: jest.fn().mockResolvedValue(null),
+  apiRateLimit: { upload: (handler: (...args: unknown[]) => unknown) => handler },
 }));
 
 jest.mock('@/lib/logger', () => ({
@@ -146,8 +146,8 @@ describe('POST /api/documents/v2/upload', () => {
 
     it('accepts CSV files with text/csv MIME type', async () => {
       mockGetServerSession.mockResolvedValue(makeSession());
-      mockCreateDocumentJob.mockResolvedValue({ jobId: 'job-csv-1', s3Key: 'uploads/job-csv-1/data.csv' });
-      mockUploadToS3.mockResolvedValue(undefined);
+      mockCreateDocumentJob.mockResolvedValue({ id: 'job-csv-1' });
+      mockUploadToS3.mockResolvedValue({ s3Key: 'v2/uploads/job-csv-1/data.csv', sanitizedFileName: 'data.csv' });
       mockSendToProcessingQueue.mockResolvedValue(undefined);
       mockConfirmDocumentUpload.mockResolvedValue(undefined);
 
@@ -161,8 +161,8 @@ describe('POST /api/documents/v2/upload', () => {
 
     it('accepts CSV files with application/csv MIME type', async () => {
       mockGetServerSession.mockResolvedValue(makeSession());
-      mockCreateDocumentJob.mockResolvedValue({ jobId: 'job-csv-2', s3Key: 'uploads/job-csv-2/data.csv' });
-      mockUploadToS3.mockResolvedValue(undefined);
+      mockCreateDocumentJob.mockResolvedValue({ id: 'job-csv-2' });
+      mockUploadToS3.mockResolvedValue({ s3Key: 'v2/uploads/job-csv-2/data.csv', sanitizedFileName: 'data.csv' });
       mockSendToProcessingQueue.mockResolvedValue(undefined);
       mockConfirmDocumentUpload.mockResolvedValue(undefined);
 
@@ -176,8 +176,8 @@ describe('POST /api/documents/v2/upload', () => {
 
     it('accepts PDF files', async () => {
       mockGetServerSession.mockResolvedValue(makeSession());
-      mockCreateDocumentJob.mockResolvedValue({ jobId: 'job-pdf-1', s3Key: 'uploads/job-pdf-1/doc.pdf' });
-      mockUploadToS3.mockResolvedValue(undefined);
+      mockCreateDocumentJob.mockResolvedValue({ id: 'job-pdf-1' });
+      mockUploadToS3.mockResolvedValue({ s3Key: 'v2/uploads/job-pdf-1/doc.pdf', sanitizedFileName: 'doc.pdf' });
       mockSendToProcessingQueue.mockResolvedValue(undefined);
       mockConfirmDocumentUpload.mockResolvedValue(undefined);
 
@@ -211,8 +211,8 @@ describe('POST /api/documents/v2/upload', () => {
   describe('Successful upload flow', () => {
     it('uploads file to S3, queues processing job, and returns jobId', async () => {
       mockGetServerSession.mockResolvedValue(makeSession());
-      mockCreateDocumentJob.mockResolvedValue({ jobId: 'job-success-1', s3Key: 'uploads/job-success-1/data.csv' });
-      mockUploadToS3.mockResolvedValue(undefined);
+      mockCreateDocumentJob.mockResolvedValue({ id: 'job-success-1' });
+      mockUploadToS3.mockResolvedValue({ s3Key: 'v2/uploads/job-success-1/data.csv', sanitizedFileName: 'data.csv' });
       mockSendToProcessingQueue.mockResolvedValue(undefined);
       mockConfirmDocumentUpload.mockResolvedValue(undefined);
 
@@ -229,8 +229,8 @@ describe('POST /api/documents/v2/upload', () => {
 
     it('propagates processing options to the job queue', async () => {
       mockGetServerSession.mockResolvedValue(makeSession());
-      mockCreateDocumentJob.mockResolvedValue({ jobId: 'job-opts-1', s3Key: 'uploads/job-opts-1/doc.pdf' });
-      mockUploadToS3.mockResolvedValue(undefined);
+      mockCreateDocumentJob.mockResolvedValue({ id: 'job-opts-1' });
+      mockUploadToS3.mockResolvedValue({ s3Key: 'v2/uploads/job-opts-1/doc.pdf', sanitizedFileName: 'doc.pdf' });
       mockSendToProcessingQueue.mockResolvedValue(undefined);
       mockConfirmDocumentUpload.mockResolvedValue(undefined);
 
@@ -259,7 +259,7 @@ describe('POST /api/documents/v2/upload', () => {
   describe('Error handling', () => {
     it('returns 503 when S3 upload fails', async () => {
       mockGetServerSession.mockResolvedValue(makeSession());
-      mockCreateDocumentJob.mockResolvedValue({ jobId: 'job-err-1', s3Key: 'uploads/job-err-1/data.csv' });
+      mockCreateDocumentJob.mockResolvedValue({ id: 'job-err-1' });
       mockUploadToS3.mockRejectedValue(new Error('S3 bucket not found (NoSuchBucket)'));
 
       const req = makeRequest(makeFormData({}));
@@ -272,8 +272,8 @@ describe('POST /api/documents/v2/upload', () => {
 
     it('returns 503 when processing queue is unavailable', async () => {
       mockGetServerSession.mockResolvedValue(makeSession());
-      mockCreateDocumentJob.mockResolvedValue({ jobId: 'job-err-2', s3Key: 'uploads/job-err-2/data.csv' });
-      mockUploadToS3.mockResolvedValue(undefined);
+      mockCreateDocumentJob.mockResolvedValue({ id: 'job-err-2' });
+      mockUploadToS3.mockResolvedValue({ s3Key: 'v2/uploads/job-err-2/data.csv', sanitizedFileName: 'data.csv' });
       mockSendToProcessingQueue.mockRejectedValue(new Error('SQS processing_queue_url not configured'));
 
       const req = makeRequest(makeFormData({}));

--- a/tests/unit/api/nexus/upload-v2-route.test.ts
+++ b/tests/unit/api/nexus/upload-v2-route.test.ts
@@ -182,7 +182,6 @@ describe('POST /api/documents/v2/upload', () => {
     });
 
     it('returns 401 when session has no sub', async () => {
-      // @ts-expect-error intentionally testing malformed session
       mockGetServerSession.mockResolvedValue({ email: 'no-sub@test.com' });
 
       const req = makeRequest(makeFormData({}));

--- a/tests/unit/api/nexus/upload-v2-route.test.ts
+++ b/tests/unit/api/nexus/upload-v2-route.test.ts
@@ -10,6 +10,47 @@
  * Related issue: #1018 — CSV file uploads fail in Nexus
  */
 
+// ── next/server must be mocked FIRST so NextResponse is a usable constructor ──
+// NextResponse is not a valid constructor in the jsdom test environment without
+// this mock. NextRequest needs formData() support for the upload tests.
+jest.mock('next/server', () => {
+  class MockNextRequest {
+    url: string;
+    method: string;
+    private _fd: FormData | null;
+    constructor(url: string, init?: { method?: string; body?: FormData }) {
+      this.url = url;
+      this.method = init?.method || 'GET';
+      this._fd = (init?.body as FormData) || null;
+    }
+    async formData() {
+      return this._fd || new FormData();
+    }
+  }
+
+  class NextResponse {
+    body: string;
+    status: number;
+    headers: Map<string, string>;
+    constructor(body: string, init?: { status?: number; headers?: Record<string, string> }) {
+      this.body = body;
+      this.status = init?.status || 200;
+      this.headers = new Map(Object.entries(init?.headers || {}));
+    }
+    json() {
+      return Promise.resolve(JSON.parse(this.body));
+    }
+    static json(data: unknown, init?: { status?: number; headers?: Record<string, string> }) {
+      return new NextResponse(JSON.stringify(data), {
+        ...init,
+        headers: { 'Content-Type': 'application/json', ...(init?.headers || {}) },
+      });
+    }
+  }
+
+  return { NextRequest: MockNextRequest, NextResponse };
+});
+
 import { describe, it, expect, jest, beforeEach } from '@jest/globals';
 import { NextRequest } from 'next/server';
 

--- a/tests/unit/api/nexus/upload-v2-route.test.ts
+++ b/tests/unit/api/nexus/upload-v2-route.test.ts
@@ -1,0 +1,287 @@
+/**
+ * Unit tests for /api/documents/v2/upload/route.ts
+ *
+ * Covers:
+ * - Authentication (401 for unauthenticated requests)
+ * - File validation (missing file, unsupported type, size limit)
+ * - CSV file acceptance with correct MIME types
+ * - Successful upload flow (S3 + job creation + queue)
+ *
+ * Related issue: #1018 — CSV file uploads fail in Nexus
+ */
+
+import { describe, it, expect, jest, beforeEach } from '@jest/globals';
+import { NextRequest } from 'next/server';
+
+// ── Mock order matters: must precede imports of our code ──────────────────────
+
+jest.mock('@/lib/auth/server-session', () => ({
+  getServerSession: jest.fn(),
+}));
+
+jest.mock('@/lib/services/document-job-service', () => ({
+  createDocumentJob: jest.fn(),
+  confirmDocumentUpload: jest.fn(),
+}));
+
+jest.mock('@/lib/aws/document-upload', () => ({
+  uploadToS3: jest.fn(),
+}));
+
+jest.mock('@/lib/aws/lambda-trigger', () => ({
+  sendToProcessingQueue: jest.fn(),
+}));
+
+jest.mock('@/lib/rate-limit', () => ({
+  apiRateLimit: jest.fn().mockResolvedValue(null),
+}));
+
+jest.mock('@/lib/logger', () => ({
+  createLogger: jest.fn(() => ({
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  })),
+  generateRequestId: jest.fn(() => 'test-request-id'),
+  startTimer: jest.fn(() => jest.fn()),
+  sanitizeForLogging: jest.fn((d) => d),
+}));
+
+// ── Imports (after mocks) ──────────────────────────────────────────────────────
+
+import { POST } from '@/app/api/documents/v2/upload/route';
+import { getServerSession } from '@/lib/auth/server-session';
+import { createDocumentJob, confirmDocumentUpload } from '@/lib/services/document-job-service';
+import { uploadToS3 } from '@/lib/aws/document-upload';
+import { sendToProcessingQueue } from '@/lib/aws/lambda-trigger';
+
+const mockGetServerSession = getServerSession as jest.MockedFunction<typeof getServerSession>;
+const mockCreateDocumentJob = createDocumentJob as jest.MockedFunction<typeof createDocumentJob>;
+const mockConfirmDocumentUpload = confirmDocumentUpload as jest.MockedFunction<typeof confirmDocumentUpload>;
+const mockUploadToS3 = uploadToS3 as jest.MockedFunction<typeof uploadToS3>;
+const mockSendToProcessingQueue = sendToProcessingQueue as jest.MockedFunction<typeof sendToProcessingQueue>;
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeSession() {
+  return { sub: 'user-123', email: 'test@psd401.net', exp: 9999999999, iat: 1000000000 };
+}
+
+function makeFormData(opts: {
+  fileName?: string;
+  fileType?: string;
+  content?: string;
+  purpose?: string;
+}) {
+  const {
+    fileName = 'data.csv',
+    fileType = 'text/csv',
+    content = 'name,value\nalice,1',
+    purpose = 'chat',
+  } = opts;
+  const file = new File([content], fileName, { type: fileType });
+  const fd = new FormData();
+  fd.append('file', file);
+  fd.append('purpose', purpose);
+  fd.append('processingOptions', JSON.stringify({ extractText: true }));
+  return fd;
+}
+
+function makeRequest(fd: FormData) {
+  return new NextRequest('http://localhost/api/documents/v2/upload', {
+    method: 'POST',
+    body: fd,
+  });
+}
+
+// ── Setup ─────────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  process.env.DOCUMENTS_BUCKET_NAME = 'test-bucket';
+  process.env.PROCESSING_QUEUE_URL = 'https://sqs.test/queue';
+});
+
+// ── Tests ──────────────────────────────────────────────────────────────────────
+
+describe('POST /api/documents/v2/upload', () => {
+  describe('Authentication', () => {
+    it('returns 401 for unauthenticated requests', async () => {
+      mockGetServerSession.mockResolvedValue(null);
+
+      const req = makeRequest(makeFormData({}));
+      const res = await POST(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(401);
+      expect(body.code).toBe('UNAUTHORIZED');
+      expect(body.requestId).toBeDefined();
+    });
+
+    it('returns 401 when session has no sub', async () => {
+      // @ts-expect-error intentionally testing malformed session
+      mockGetServerSession.mockResolvedValue({ email: 'no-sub@test.com' });
+
+      const req = makeRequest(makeFormData({}));
+      const res = await POST(req);
+
+      expect(res.status).toBe(401);
+    });
+  });
+
+  describe('File validation', () => {
+    it('returns 400 when no file is attached', async () => {
+      mockGetServerSession.mockResolvedValue(makeSession());
+
+      const fd = new FormData();
+      fd.append('purpose', 'chat');
+      const req = makeRequest(fd);
+      const res = await POST(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.code).toBe('NO_FILE');
+    });
+
+    it('accepts CSV files with text/csv MIME type', async () => {
+      mockGetServerSession.mockResolvedValue(makeSession());
+      mockCreateDocumentJob.mockResolvedValue({ jobId: 'job-csv-1', s3Key: 'uploads/job-csv-1/data.csv' });
+      mockUploadToS3.mockResolvedValue(undefined);
+      mockSendToProcessingQueue.mockResolvedValue(undefined);
+      mockConfirmDocumentUpload.mockResolvedValue(undefined);
+
+      const req = makeRequest(makeFormData({ fileName: 'data.csv', fileType: 'text/csv' }));
+      const res = await POST(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.jobId).toBe('job-csv-1');
+    });
+
+    it('accepts CSV files with application/csv MIME type', async () => {
+      mockGetServerSession.mockResolvedValue(makeSession());
+      mockCreateDocumentJob.mockResolvedValue({ jobId: 'job-csv-2', s3Key: 'uploads/job-csv-2/data.csv' });
+      mockUploadToS3.mockResolvedValue(undefined);
+      mockSendToProcessingQueue.mockResolvedValue(undefined);
+      mockConfirmDocumentUpload.mockResolvedValue(undefined);
+
+      const req = makeRequest(makeFormData({ fileName: 'data.csv', fileType: 'application/csv' }));
+      const res = await POST(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.jobId).toBe('job-csv-2');
+    });
+
+    it('accepts PDF files', async () => {
+      mockGetServerSession.mockResolvedValue(makeSession());
+      mockCreateDocumentJob.mockResolvedValue({ jobId: 'job-pdf-1', s3Key: 'uploads/job-pdf-1/doc.pdf' });
+      mockUploadToS3.mockResolvedValue(undefined);
+      mockSendToProcessingQueue.mockResolvedValue(undefined);
+      mockConfirmDocumentUpload.mockResolvedValue(undefined);
+
+      const req = makeRequest(makeFormData({ fileName: 'doc.pdf', fileType: 'application/pdf', content: '%PDF-1.4' }));
+      const res = await POST(req);
+
+      expect(res.status).toBe(200);
+    });
+
+    it('returns 400 for files exceeding 500MB', async () => {
+      mockGetServerSession.mockResolvedValue(makeSession());
+
+      const bigContent = 'x'.repeat(10);
+      const fd = new FormData();
+      // Simulate a file that reports a large size via validation (override size via mock)
+      const file = new File([bigContent], 'huge.csv', { type: 'text/csv' });
+      Object.defineProperty(file, 'size', { value: 600 * 1024 * 1024 }); // 600MB
+      fd.append('file', file);
+      fd.append('purpose', 'chat');
+
+      const req = makeRequest(fd);
+      const res = await POST(req);
+      const body = await res.json();
+
+      // Zod validation catches the size limit
+      expect(res.status).toBe(400);
+      expect(body.code).toBe('VALIDATION_ERROR');
+    });
+  });
+
+  describe('Successful upload flow', () => {
+    it('uploads file to S3, queues processing job, and returns jobId', async () => {
+      mockGetServerSession.mockResolvedValue(makeSession());
+      mockCreateDocumentJob.mockResolvedValue({ jobId: 'job-success-1', s3Key: 'uploads/job-success-1/data.csv' });
+      mockUploadToS3.mockResolvedValue(undefined);
+      mockSendToProcessingQueue.mockResolvedValue(undefined);
+      mockConfirmDocumentUpload.mockResolvedValue(undefined);
+
+      const req = makeRequest(makeFormData({ fileName: 'data.csv', fileType: 'text/csv' }));
+      const res = await POST(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.jobId).toBe('job-success-1');
+      expect(mockUploadToS3).toHaveBeenCalledTimes(1);
+      expect(mockSendToProcessingQueue).toHaveBeenCalledTimes(1);
+      expect(mockConfirmDocumentUpload).toHaveBeenCalledTimes(1);
+    });
+
+    it('propagates processing options to the job queue', async () => {
+      mockGetServerSession.mockResolvedValue(makeSession());
+      mockCreateDocumentJob.mockResolvedValue({ jobId: 'job-opts-1', s3Key: 'uploads/job-opts-1/doc.pdf' });
+      mockUploadToS3.mockResolvedValue(undefined);
+      mockSendToProcessingQueue.mockResolvedValue(undefined);
+      mockConfirmDocumentUpload.mockResolvedValue(undefined);
+
+      const fd = new FormData();
+      const file = new File(['%PDF-1.4'], 'doc.pdf', { type: 'application/pdf' });
+      fd.append('file', file);
+      fd.append('purpose', 'chat');
+      fd.append('processingOptions', JSON.stringify({
+        extractText: true,
+        convertToMarkdown: true,
+        extractImages: false,
+        ocrEnabled: true,
+      }));
+
+      const req = makeRequest(fd);
+      const res = await POST(req);
+
+      expect(res.status).toBe(200);
+      // Queue was called with the job ID
+      expect(mockSendToProcessingQueue).toHaveBeenCalledWith(
+        expect.objectContaining({ jobId: 'job-opts-1' })
+      );
+    });
+  });
+
+  describe('Error handling', () => {
+    it('returns 503 when S3 upload fails', async () => {
+      mockGetServerSession.mockResolvedValue(makeSession());
+      mockCreateDocumentJob.mockResolvedValue({ jobId: 'job-err-1', s3Key: 'uploads/job-err-1/data.csv' });
+      mockUploadToS3.mockRejectedValue(new Error('S3 bucket not found (NoSuchBucket)'));
+
+      const req = makeRequest(makeFormData({}));
+      const res = await POST(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(503);
+      expect(body.code).toBe('STORAGE_UNAVAILABLE');
+    });
+
+    it('returns 503 when processing queue is unavailable', async () => {
+      mockGetServerSession.mockResolvedValue(makeSession());
+      mockCreateDocumentJob.mockResolvedValue({ jobId: 'job-err-2', s3Key: 'uploads/job-err-2/data.csv' });
+      mockUploadToS3.mockResolvedValue(undefined);
+      mockSendToProcessingQueue.mockRejectedValue(new Error('SQS processing_queue_url not configured'));
+
+      const req = makeRequest(makeFormData({}));
+      const res = await POST(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(503);
+      expect(body.code).toBe('QUEUE_UNAVAILABLE');
+    });
+  });
+});

--- a/tests/unit/api/nexus/upload-v2-route.test.ts
+++ b/tests/unit/api/nexus/upload-v2-route.test.ts
@@ -1,4 +1,6 @@
 /**
+ * @jest-environment node
+ *
  * Unit tests for /api/documents/v2/upload/route.ts
  *
  * Covers:
@@ -8,11 +10,13 @@
  * - Successful upload flow (S3 + job creation + queue)
  *
  * Related issue: #1018 — CSV file uploads fail in Nexus
+ *
+ * Uses @jest-environment node because the route calls file.stream() which requires
+ * Node.js's native File/Blob stream support (not available in jsdom).
  */
 
 // ── next/server must be mocked FIRST so NextResponse is a usable constructor ──
-// NextResponse is not a valid constructor in the jsdom test environment without
-// this mock. NextRequest needs formData() support for the upload tests.
+// NextRequest needs formData() support for the upload tests.
 jest.mock('next/server', () => {
   class MockNextRequest {
     url: string;

--- a/tests/unit/api/nexus/upload-v2-route.test.ts
+++ b/tests/unit/api/nexus/upload-v2-route.test.ts
@@ -53,6 +53,7 @@ jest.mock('@/lib/logger', () => ({
 import { POST } from '@/app/api/documents/v2/upload/route';
 import { getServerSession } from '@/lib/auth/server-session';
 import { createDocumentJob, confirmDocumentUpload } from '@/lib/services/document-job-service';
+import type { DocumentJob } from '@/lib/services/document-job-service';
 import { uploadToS3 } from '@/lib/aws/document-upload';
 import { sendToProcessingQueue } from '@/lib/aws/lambda-trigger';
 
@@ -93,6 +94,26 @@ function makeRequest(fd: FormData) {
     method: 'POST',
     body: fd,
   });
+}
+
+function makeDocumentJob(id: string): DocumentJob {
+  return {
+    id,
+    userId: 'user-123',
+    fileName: 'data.csv',
+    fileSize: 100,
+    fileType: 'text/csv',
+    purpose: 'chat',
+    processingOptions: {
+      extractText: true,
+      convertToMarkdown: false,
+      extractImages: false,
+      generateEmbeddings: false,
+      ocrEnabled: false,
+    },
+    status: 'pending',
+    createdAt: '2026-01-01T00:00:00.000Z',
+  };
 }
 
 // ── Setup ─────────────────────────────────────────────────────────────────────
@@ -146,8 +167,8 @@ describe('POST /api/documents/v2/upload', () => {
 
     it('accepts CSV files with text/csv MIME type', async () => {
       mockGetServerSession.mockResolvedValue(makeSession());
-      mockCreateDocumentJob.mockResolvedValue({ id: 'job-csv-1' });
-      mockUploadToS3.mockResolvedValue({ s3Key: 'v2/uploads/job-csv-1/data.csv', sanitizedFileName: 'data.csv' });
+      mockCreateDocumentJob.mockResolvedValue(makeDocumentJob('job-csv-1'));
+      mockUploadToS3.mockResolvedValue({ s3Key: 'v2/uploads/job-csv-1/data.csv', bucket: 'test-bucket', sanitizedFileName: 'data.csv' });
       mockSendToProcessingQueue.mockResolvedValue(undefined);
       mockConfirmDocumentUpload.mockResolvedValue(undefined);
 
@@ -161,8 +182,8 @@ describe('POST /api/documents/v2/upload', () => {
 
     it('accepts CSV files with application/csv MIME type', async () => {
       mockGetServerSession.mockResolvedValue(makeSession());
-      mockCreateDocumentJob.mockResolvedValue({ id: 'job-csv-2' });
-      mockUploadToS3.mockResolvedValue({ s3Key: 'v2/uploads/job-csv-2/data.csv', sanitizedFileName: 'data.csv' });
+      mockCreateDocumentJob.mockResolvedValue(makeDocumentJob('job-csv-2'));
+      mockUploadToS3.mockResolvedValue({ s3Key: 'v2/uploads/job-csv-2/data.csv', bucket: 'test-bucket', sanitizedFileName: 'data.csv' });
       mockSendToProcessingQueue.mockResolvedValue(undefined);
       mockConfirmDocumentUpload.mockResolvedValue(undefined);
 
@@ -176,8 +197,8 @@ describe('POST /api/documents/v2/upload', () => {
 
     it('accepts PDF files', async () => {
       mockGetServerSession.mockResolvedValue(makeSession());
-      mockCreateDocumentJob.mockResolvedValue({ id: 'job-pdf-1' });
-      mockUploadToS3.mockResolvedValue({ s3Key: 'v2/uploads/job-pdf-1/doc.pdf', sanitizedFileName: 'doc.pdf' });
+      mockCreateDocumentJob.mockResolvedValue(makeDocumentJob('job-pdf-1'));
+      mockUploadToS3.mockResolvedValue({ s3Key: 'v2/uploads/job-pdf-1/doc.pdf', bucket: 'test-bucket', sanitizedFileName: 'doc.pdf' });
       mockSendToProcessingQueue.mockResolvedValue(undefined);
       mockConfirmDocumentUpload.mockResolvedValue(undefined);
 
@@ -211,8 +232,8 @@ describe('POST /api/documents/v2/upload', () => {
   describe('Successful upload flow', () => {
     it('uploads file to S3, queues processing job, and returns jobId', async () => {
       mockGetServerSession.mockResolvedValue(makeSession());
-      mockCreateDocumentJob.mockResolvedValue({ id: 'job-success-1' });
-      mockUploadToS3.mockResolvedValue({ s3Key: 'v2/uploads/job-success-1/data.csv', sanitizedFileName: 'data.csv' });
+      mockCreateDocumentJob.mockResolvedValue(makeDocumentJob('job-success-1'));
+      mockUploadToS3.mockResolvedValue({ s3Key: 'v2/uploads/job-success-1/data.csv', bucket: 'test-bucket', sanitizedFileName: 'data.csv' });
       mockSendToProcessingQueue.mockResolvedValue(undefined);
       mockConfirmDocumentUpload.mockResolvedValue(undefined);
 
@@ -229,8 +250,8 @@ describe('POST /api/documents/v2/upload', () => {
 
     it('propagates processing options to the job queue', async () => {
       mockGetServerSession.mockResolvedValue(makeSession());
-      mockCreateDocumentJob.mockResolvedValue({ id: 'job-opts-1' });
-      mockUploadToS3.mockResolvedValue({ s3Key: 'v2/uploads/job-opts-1/doc.pdf', sanitizedFileName: 'doc.pdf' });
+      mockCreateDocumentJob.mockResolvedValue(makeDocumentJob('job-opts-1'));
+      mockUploadToS3.mockResolvedValue({ s3Key: 'v2/uploads/job-opts-1/doc.pdf', bucket: 'test-bucket', sanitizedFileName: 'doc.pdf' });
       mockSendToProcessingQueue.mockResolvedValue(undefined);
       mockConfirmDocumentUpload.mockResolvedValue(undefined);
 
@@ -259,7 +280,7 @@ describe('POST /api/documents/v2/upload', () => {
   describe('Error handling', () => {
     it('returns 503 when S3 upload fails', async () => {
       mockGetServerSession.mockResolvedValue(makeSession());
-      mockCreateDocumentJob.mockResolvedValue({ id: 'job-err-1' });
+      mockCreateDocumentJob.mockResolvedValue(makeDocumentJob('job-err-1'));
       mockUploadToS3.mockRejectedValue(new Error('S3 bucket not found (NoSuchBucket)'));
 
       const req = makeRequest(makeFormData({}));
@@ -272,8 +293,8 @@ describe('POST /api/documents/v2/upload', () => {
 
     it('returns 503 when processing queue is unavailable', async () => {
       mockGetServerSession.mockResolvedValue(makeSession());
-      mockCreateDocumentJob.mockResolvedValue({ id: 'job-err-2' });
-      mockUploadToS3.mockResolvedValue({ s3Key: 'v2/uploads/job-err-2/data.csv', sanitizedFileName: 'data.csv' });
+      mockCreateDocumentJob.mockResolvedValue(makeDocumentJob('job-err-2'));
+      mockUploadToS3.mockResolvedValue({ s3Key: 'v2/uploads/job-err-2/data.csv', bucket: 'test-bucket', sanitizedFileName: 'data.csv' });
       mockSendToProcessingQueue.mockRejectedValue(new Error('SQS processing_queue_url not configured'));
 
       const req = makeRequest(makeFormData({}));


### PR DESCRIPTION
## Summary

Fixes #1018 — CSV (and all file) uploads in Nexus silently swallowed errors. When the upload API returned 401 (session expiry) or 5xx (S3/SQS unavailable), `HybridDocumentAdapter` caught the exception, embedded a redacted error message in the attachment content, and returned `'complete'` status — giving users zero visible feedback and leaving the chat in an ambiguous state.

**Root cause**: `AttachmentProcessingCallbacks` had no `onError` channel, so callers had no way to react to upload failures. The error was silently embedded in the attachment text passed to the LLM context.

**Fix**:
- Add `onError?: (attachmentId, error) => void` to `AttachmentProcessingCallbacks`
- Fire it in the `processServerSide` catch block (before returning the error-embedded attachment)
- Wire up `handleAttachmentError` in both Nexus pages: shows a `sonner` toast; `UNAUTHORIZED` errors surface a "Session expired" toast with a Sign In action

## Changes

| File | Change |
|------|--------|
| `lib/nexus/enhanced-attachment-adapters.ts` | Add `onError?` callback to interface; invoke in catch block |
| `app/(protected)/nexus/page.tsx` | Add `handleAttachmentError` useCallback with toast logic; wire into adapter |
| `app/(protected)/nexus/decision-capture/page.tsx` | Same error handler pattern |
| `tests/unit/api/nexus/upload-v2-route.test.ts` | New unit tests for upload route (auth, validation, CSV types, S3/SQS error paths) |

## Error UX

| Scenario | Toast shown |
|----------|-------------|
| Session expired (401) | "Session expired" with "Sign in" action button, 8s |
| Any other upload failure | "File upload failed" with readable error code, 6s |

## Test plan

- [ ] Upload a CSV file while authenticated → succeeds (existing behavior unchanged)
- [ ] Upload with an expired session → "Session expired" toast appears with Sign In button
- [ ] Upload when S3/SQS unavailable → "File upload failed" toast appears
- [ ] Decision Capture page has the same toast behavior
- [ ] Existing adapter tests pass: `lib/nexus/__tests__/enhanced-attachment-adapters.test.ts`
- [ ] New route unit tests: `tests/unit/api/nexus/upload-v2-route.test.ts`

> Note: `bun run lint` and `bun run typecheck` require installed `node_modules` (npm registry unreachable in the CI sandbox for this run). CI pipeline will validate on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Emy2FnXpviktCTPeWmh2Vx

---
_Generated by [Claude Code](https://claude.ai/code/session_01Emy2FnXpviktCTPeWmh2Vx)_