### PR TITLE
docs(learnings): capture agentic-runtime learnings from #926

### DIFF
--- a/docs/learnings/integration/2026-06-17-ai-sdk-cost-cap-dead-code-stopwhen.md
+++ b/docs/learnings/integration/2026-06-17-ai-sdk-cost-cap-dead-code-stopwhen.md
@@ -1,0 +1,37 @@
+---
+title: AI SDK exposes token counts not dollar costs — a stored cost cap is dead code without a custom stopWhen predicate
+category: integration
+tags:
+  - ai-sdk
+  - cost-enforcement
+  - agentic
+  - streaming
+  - stopWhen
+  - dead-code
+  - 926
+severity: critical
+date: 2026-06-17
+source: auto — /lfg
+applicable_to: project
+---
+
+## What Happened
+
+Issue #926 stored a per-session cost cap in the database and surfaced it in the UI. The enforcement code (`isCostCapExceeded`) existed but was never called — no path connected it to the streaming loop. Agents ran without any cost ceiling.
+
+## Root Cause
+
+The AI SDK (`streamText` / `generateText`) reports only token counts (`usage.promptTokens`, `usage.completionTokens`) per step — there is no built-in dollar cost field. Without converting tokens to dollars using the per-model rate, there is nothing to compare against the stored cap. The enforcement function existed but assumed it would be called somewhere it never was.
+
+## Solution
+
+Wired a `stopWhen` predicate into the streaming base adapter that:
+1. Reads the per-token rates from the model row (stored in the DB alongside the model definition).
+2. Accumulates `(promptTokens * inputRate) + (completionTokens * outputRate)` across steps.
+3. Returns `true` (stop) when the running total exceeds the cap, which causes `streamText` to halt before the next step.
+
+## Prevention
+
+- A cost cap stored in the DB but not wired to a `stopWhen` or abort signal is dead code — treat it as a P1 on discovery.
+- The AI SDK never surfaces dollar cost; always thread per-token rates from the model row into any cost-enforcement predicate. Do not assume the SDK will provide this.
+- When adding any agentic feature with a resource limit (cost, steps, tokens), write a test that verifies the limit actually stops execution — not just that the stored value is set correctly.

--- a/docs/learnings/integration/2026-06-17-jest-esm-mcp-connector-lazy-import.md
+++ b/docs/learnings/integration/2026-06-17-jest-esm-mcp-connector-lazy-import.md
@@ -1,0 +1,40 @@
+---
+title: Jest fails at transform time when a module transitively imports ESM-only packages via MCP connector
+category: integration
+tags:
+  - jest
+  - esm
+  - mcp
+  - jest-esm
+  - transformIgnorePatterns
+  - mock-hoisting
+  - agentic
+  - 926
+severity: high
+date: 2026-06-17
+source: auto — /lfg
+applicable_to: project
+---
+
+## What Happened
+
+Unit tests for the agent runtime (issue #926) failed at transform time with `Unexpected token export`. The root cause was a transitive import chain: SUT → `lib/mcp/connector-service` → `@ai-sdk/mcp` → `pkce-challenge` (ESM-only package not in `transformIgnorePatterns`). Jest's CommonJS transform cannot handle it.
+
+A second related trap: importing `jest` from `@jest/globals` in the same file disables mock hoisting, so `jest.mock()` calls no longer run before imports. This caused `jest.requireMock()` to return the real module instead of the mock.
+
+## Root Cause
+
+1. `pkce-challenge` is ESM-only and not listed in `transformIgnorePatterns`, so any file that statically imports it (even transitively) breaks Jest's transform.
+2. `import { jest } from '@jest/globals'` opts the file out of Babel's automatic mock-hoisting transform. This is a known Jest ESM compatibility shim that has a side effect: `jest.mock()` at module scope no longer runs before static imports.
+
+## Solution
+
+1. Changed the SUT to lazy-import `connector-service` inside function bodies rather than at the top of the module. This removes the transitive ESM dependency from the static import graph at test time.
+2. Retrieved the mock via `jest.requireMock('../../lib/mcp/connector-service')` instead of a static import in the test file, so hoisting order does not matter.
+3. Removed `import { jest } from '@jest/globals'` and used the globally-available `jest` object instead.
+
+## Prevention
+
+- Do not statically import `lib/mcp/connector-service` (or any file that pulls in `@ai-sdk/mcp`) in files that must be unit-tested with Jest. Use lazy imports for that dependency.
+- Never use `import { jest } from '@jest/globals'` in test files that also use `jest.mock()` — the two are mutually exclusive in the current Jest setup.
+- When a test fails with `Unexpected token export`, the root cause is almost always an ESM package not in `transformIgnorePatterns`. Resolve by lazy-importing rather than extending the patterns list (the list grows unbounded otherwise).

--- a/docs/learnings/integration/2026-06-17-multi-surface-catalog-dispatch-hardcoded-surface.md
+++ b/docs/learnings/integration/2026-06-17-multi-surface-catalog-dispatch-hardcoded-surface.md
@@ -1,0 +1,34 @@
+---
+title: Hardcoded surface in catalog dispatch silently rejects tools on new surfaces
+category: integration
+tags:
+  - tool-catalog
+  - multi-surface-dispatch
+  - agentic
+  - ai-sdk
+  - mcp
+  - silent-failure
+  - 926
+severity: critical
+date: 2026-06-17
+source: auto — /lfg
+applicable_to: project
+---
+
+## What Happened
+
+Issue #926 added an 'internal' surface for the agentic Assistant Architect runtime. The catalog dispatch function had 'mcp' hardcoded as the surface, so every tool call from the agent runtime returned 'unknown' instead of resolving. The error was silent — no exception, just a dead dispatch result.
+
+## Root Cause
+
+`catalog.dispatch` had the surface hardcoded to `'mcp'` rather than accepting it as a parameter. This worked for the MCP path (which was the only caller) but silently broke any other surface. The hardcoded value also applied the wrong `surfaceScopes`, meaning even tools that happened to resolve would have been authorized against MCP scopes instead of the new surface's scopes.
+
+## Solution
+
+Added a `surface` parameter to the dispatch function so the caller declares which surface the tool call originates from. The 'internal' agent surface now passes `'internal'` and receives the correct scope resolution.
+
+## Prevention
+
+- Any function that routes tool calls through a catalog must accept `surface` as an explicit parameter — never hardcode it.
+- When adding a new surface, grep for hardcoded surface strings in dispatch/authorization code before wiring the first call.
+- Write a dispatch-level integration test for each surface that asserts tools resolve (not 'unknown') and scopes match the surface definition. A test for only the 'mcp' surface will not catch a regression introduced by a new surface.

--- a/docs/learnings/security/2026-06-17-catalog-scope-migration-all-siblings-and-ts-closure-narrowing.md
+++ b/docs/learnings/security/2026-06-17-catalog-scope-migration-all-siblings-and-ts-closure-narrowing.md
@@ -1,0 +1,40 @@
+---
+title: Migrate ALL sibling endpoints when introducing catalog-resolved scopes; avoid redundant re-fetch and TS closure casts
+category: security
+tags:
+  - authorization
+  - api-scopes
+  - tool-catalog
+  - typescript-narrowing
+  - code-review
+  - single-source-of-truth
+  - nextjs-route-handlers
+severity: high
+date: 2026-06-17
+source: auto — /review-pr
+applicable_to: project
+---
+
+## What Happened
+
+PR #1038 introduced a "single source of truth" pattern where authorization scopes are resolved from the tool catalog rather than hardcoded. The primary execute route was migrated, but the sibling GET `/api/v1/assistants` list route kept its hardcoded `"assistants:list"` scope string. The inconsistency was flagged across three consecutive review passes (Rounds 1, 2, and a @claude re-review) before it was fixed.
+
+Two additional cleanup items appeared in the same PR: `requireExecuteScope` was calling `getRequiredScopes()` (which re-fetched the catalog entry) even though the entry was already in scope; and a `filter.scopes as string[]` cast was needed only because TypeScript does not carry an outer `if (filter.scopes)` guard through an arrow function closure boundary.
+
+## Root Cause
+
+- **Incomplete migration**: When refactoring a pattern across an API surface (e.g., switching from hardcoded scopes to catalog-resolved ones), it is easy to update the "interesting" route (execute) and overlook the "boring" sibling (list). Code review caught this, but it took three passes.
+- **Redundant re-fetch**: The `getRequiredScopes` helper was designed for call sites that don't have the entry yet. Calling it when the entry is already in hand re-fetches unnecessarily and obscures the data flow.
+- **TypeScript closure narrowing**: A truthy `if (x)` check in the outer scope does not survive into an arrow function body — TypeScript treats closures as potentially stale. Binding `const scopes = filter.scopes` before the closure eliminates both the cast and the ambiguity.
+
+## Solution
+
+1. Replaced the hardcoded `"assistants:list"` scope in the GET route with `entry.surfaceScopes?.rest ?? entry.requiredScopes` — same catalog-resolution pattern used by the execute route.
+2. Removed the `getRequiredScopes()` call inside `requireExecuteScope`; read `entry.surfaceScopes?.rest ?? entry.requiredScopes` directly from the already-fetched entry.
+3. Introduced `const scopes = filter.scopes` before the arrow function to give TypeScript a narrowed local, removing the `as string[]` cast.
+
+## Prevention
+
+- When introducing a "single source of truth" pattern, enumerate ALL routes/handlers in the same API surface and migrate them in the same PR. A checklist comment in the PR description (e.g., "Routes migrated: execute ✓, list ✓, detail ✓") makes gaps visible to reviewers.
+- If a helper exists for "callers without the entry", don't call it when you already have the entry — read the field directly to keep data flow explicit.
+- When a TypeScript narrowing cast appears inside an arrow function, bind to a local `const` before the closure rather than casting — it is both safer and clearer.

--- a/docs/learnings/security/2026-06-17-multi-surface-authorization-bypass.md
+++ b/docs/learnings/security/2026-06-17-multi-surface-authorization-bypass.md
@@ -1,0 +1,39 @@
+---
+title: Parallel API surfaces silently bypass controls enforced only on one surface
+category: security
+tags:
+  - authorization
+  - multi-surface
+  - tool-catalog
+  - silent-fallback
+  - openapi
+  - code-review
+  - 924
+severity: critical
+date: 2026-06-17
+source: auto — /review-pr
+applicable_to: project
+---
+
+## What Happened
+
+PR #1038 (single-source AI SDK tool catalog, issue #924) review found that `tool_catalog.is_active` was enforced by the MCP dispatch path but not by the parallel REST execute route. Admin-disabled tools were callable via REST while being correctly blocked via MCP. Six independent review agents converged on the same finding.
+
+## Root Cause
+
+The MCP path enforced `is_active` through a shared dispatch layer. The REST execute route bypassed that layer and called the underlying service directly, so the active-state gate was never re-checked. Each surface assumed the other had already validated — neither had.
+
+A second distinct issue: the server registry recovered a tool's friendly name by reverse-mapping the wire name through `TOOL_NAME_MAPPING`. For any tool not in that table, the reverse-map returned `undefined` and silently fell back to the wire name. This made an unmapped tool use the wrong identity downstream without any log or error.
+
+## Solution
+
+1. Added an explicit `isActive` gate in the REST execute route returning 404 for disabled tools — authorization checks must live at every entry point, not assumed from a shared lower layer.
+2. Eliminated the reverse-map: carry `friendlyName` directly on the catalog entry so no lookup is needed and no fallback is possible.
+3. Replaced unchecked `as ToolCategory`/`as keyof ModelCapabilities` casts on DB-sourced data with runtime validation.
+4. De-duplicated capability filtering into a shared helper.
+
+## Prevention
+
+- When a control (active-state, scope, rate-limit) must hold across multiple API surfaces, enforce it at each entry point explicitly. Never assume a parallel surface has already checked.
+- Reverse-mapping an identity through a partial lookup table is a silent-fallback trap. Carry the canonical value forward from the point of origin instead of reconstructing it downstream.
+- In code review, enumerate all surfaces that can invoke a service and confirm each one independently enforces the same security invariants.

--- a/docs/learnings/security/2026-06-17-s3-listbucket-iam-bucket-arn.md
+++ b/docs/learnings/security/2026-06-17-s3-listbucket-iam-bucket-arn.md
@@ -1,0 +1,40 @@
+---
+title: "S3 ListBucket must be granted on bucket ARN, not object-prefix ARN"
+category: security
+tags:
+  - iam
+  - s3
+  - aws
+  - cdk
+  - least-privilege
+  - listbucket
+  - access-denied
+  - pr-review
+severity: high
+date: 2026-06-17
+source: auto — /review-pr
+applicable_to: project
+---
+
+## What Happened
+
+ECS task IAM policy granted `s3:PutObject`, `s3:PutObjectTagging`, and `s3:GetObject` on the agent workspace bucket with an object-prefix ARN (`arn:...:bucket/skills/*`). `s3:ListBucket` was omitted. Every `ListObjectsV2Command` call returned `AccessDenied` at runtime, breaking the skill detail page and zip export. `cdk synth` and deploy both succeeded silently.
+
+## Root Cause
+
+`s3:ListBucket` is a bucket-level action and must be scoped to the bare bucket ARN (`arn:aws:s3:::bucket-name`). Object-level actions (`Get*`, `Put*`, `Delete*`) take the object-prefix ARN (`arn:...:bucket-name/prefix/*`). Granting `ListBucket` on an object-prefix ARN is silently ignored by IAM — the action never matches.
+
+## Solution
+
+Split into two `PolicyStatement` blocks in CDK:
+
+1. **Bucket-level statement** — `s3:ListBucket` on the bucket ARN with an `s3:prefix` `StringLike` condition (`skills/*`) to keep scope narrow.
+2. **Object-level statement** — `s3:GetObject`, `s3:PutObject`, `s3:PutObjectTagging` on `arn:...:bucket-name/skills/*`.
+
+Verified via `cdk synth` — confirm the rendered CloudFormation shows separate statements with the correct ARN targets.
+
+## Prevention
+
+- When adding any S3 permissions in CDK, check whether each action is bucket-level or object-level before choosing the ARN.
+- Treat missing `ListBucket` as a blocking P1 in PR review whenever `ListObjectsV2` is used anywhere in the code path.
+- Run `cdk synth` and inspect the rendered IAM policy JSON — not just the CDK construct — to catch ARN mismatches before deploy.

--- a/docs/learnings/security/2026-06-18-stale-driver-comment-masked-sql-injection.md
+++ b/docs/learnings/security/2026-06-18-stale-driver-comment-masked-sql-injection.md
@@ -1,0 +1,33 @@
+---
+title: Stale driver workaround comment masked sql.raw() SQL injection vector
+category: security
+tags:
+  - sql-injection
+  - drizzle
+  - postgres-js
+  - stale-comments
+  - ai-streaming
+  - abort-signal
+  - pr-review
+  - agentic
+severity: critical
+date: 2026-06-18
+source: auto — /review-pr
+applicable_to: project
+---
+
+## What Happened
+
+PR #1041 (agentic assistant runtime, issue #926) contained `sql.raw()` calls with string-interpolated user-controlled values. A code comment cited "AWS Data API driver corrupts ENUM/JSONB parameter binding" as justification. Automated PR reviewers flagged this as a P1 SQL injection vector during round 1 review.
+
+## Root Cause
+
+The comment was written when the project used the AWS Data API driver, which had a known bug with `::jsonb` and `::enum` parameterized casts. The project had since migrated to the `postgres.js` driver (see `lib/db/drizzle-client.ts`), where parameterized binding with `::jsonb` and `::enum` casts works correctly. The stale comment was trusted at face value, leaving `sql.raw()` in place long after the limitation it described no longer applied.
+
+## Solution
+
+Replaced `sql.raw()` string interpolation with standard Drizzle parameterized queries using `::jsonb` and `::enum` casts. Verified the active driver in `lib/db/drizzle-client.ts` before making the change to confirm parameterized binding would work.
+
+## Prevention
+
+When a comment justifies a security-fragile pattern by citing a driver-specific limitation, verify the cited driver is still the active one before trusting the workaround. Check `lib/db/drizzle-client.ts` to confirm the current driver. Treat any `sql.raw()` with interpolated variables as a mandatory review stop — the burden of proof is on the caller to show parameterized alternatives were exhausted.

--- a/docs/learnings/workflow/2026-06-17-automated-reviewer-false-positives.md
+++ b/docs/learnings/workflow/2026-06-17-automated-reviewer-false-positives.md
@@ -1,0 +1,37 @@
+---
+title: Automated code reviewers emit confident false positives — always verify against source
+category: workflow
+tags:
+  - pr-review
+  - false-positives
+  - eslint-config
+  - typescript-narrowing
+  - code-review
+  - verification
+severity: high
+date: 2026-06-17
+source: auto — /review-pr
+applicable_to: project
+---
+
+## What Happened
+
+PR #1038 (tool catalog unification + per-surface scopes) received an automated code review with 7 findings, including a "P1 blocker" claiming `console.*` usage in `scripts/openapi/generate-from-catalog.ts` required `eslint-disable` comments. The claim was wrong — `eslint.config.mjs` Rule 5 already sets `no-console: off` for `scripts/**/*.ts`. CI lint was green throughout. Two other findings were also false positives: a "dead code" claim about `entry.version ?? v1` (ignored that `ToolManifestEntry.version` is optional, not always-defined), and a claim about remaining `.tool` consumers (a grep returned zero results).
+
+## Root Cause
+
+LLM-based reviewers frequently pattern-match on surface signals (e.g., `console.log` present → must add eslint-disable) without reading the actual eslint config or type definitions. Severity labels like "P1 blocker" are generated heuristically and carry no guarantee of correctness.
+
+## Solution
+
+For each finding, verify against the actual source before acting:
+- **Lint claims**: Check `eslint.config.mjs` glob overrides; run `bun run lint` to confirm.
+- **Dead code / optional-field claims**: Check the TypeScript interface/type definition directly.
+- **"Remaining consumers" claims**: Run a real grep against the codebase.
+- **Valid finding**: The `as string[]` cast in `requiredScopesForSurface` was real — hoisting the lookup to a local variable enabled TS narrowing and removed the cast.
+
+## Prevention
+
+- Treat automated review severity labels as suggestions, not facts.
+- Before changing code in response to a review finding, run the relevant verification command (lint, typecheck, grep) and read the relevant config/type file.
+- A green CI pipeline is stronger evidence than a reviewer's severity label.


### PR DESCRIPTION
Commits the eight learnings the learning-writer agents produced during the #926 agentic Assistant Architect work (PR #1041) and its review rounds. They were generated in the working tree but never committed; this records them in the tracked `docs/learnings/` knowledge base.

**integration/**
- `ai-sdk-cost-cap-dead-code-stopwhen`
- `jest-esm-mcp-connector-lazy-import`
- `multi-surface-catalog-dispatch-hardcoded-surface`

**security/**
- `catalog-scope-migration-all-siblings-and-ts-closure-narrowing`
- `multi-surface-authorization-bypass`
- `s3-listbucket-iam-bucket-arn`
- `stale-driver-comment-masked-sql-injection`

**workflow/**
- `automated-reviewer-false-positives`

Docs-only; no code changes. Scanned for secrets/PII (clean).