### PR TITLE
fix(infra): ASCII-only security group description (deploy blocker)

### DIFF
--- a/infra/lib/agent-platform-stack.ts
+++ b/infra/lib/agent-platform-stack.ts
@@ -2431,7 +2431,7 @@ export class AgentPlatformStack extends cdk.Stack {
     cdk.Tags.of(healthLambda).add('ManagedBy', 'cdk');
 
     new events.Rule(this, 'AgentHealthDailySchedule', {
-      description: 'Daily S3 workspace scan → agent_health_snapshots',
+      description: 'Daily S3 workspace scan to agent_health_snapshots',
       schedule: events.Schedule.rate(cdk.Duration.days(1)),
       targets: [new eventsTargets.LambdaFunction(healthLambda)],
     });
@@ -2745,7 +2745,7 @@ export class AgentPlatformStack extends cdk.Stack {
     cdk.Tags.of(pruneLambda).add('ManagedBy', 'cdk');
 
     const pruneSchedule = new events.Rule(this, 'AgentTelemetryPruneSchedule', {
-      description: 'Daily 04:00 UTC — prune agent_message_content + agent_tool_invocations older than 90 days',
+      description: 'Daily 04:00 UTC - prune agent_message_content + agent_tool_invocations older than 90 days',
       schedule: events.Schedule.cron({ minute: '0', hour: '4' }),
       targets: [new eventsTargets.LambdaFunction(pruneLambda)],
     });

--- a/infra/lib/processing-stack.ts
+++ b/infra/lib/processing-stack.ts
@@ -292,7 +292,7 @@ export class ProcessingStack extends cdk.Stack {
 
     const embeddingGeneratorSg = new ec2.SecurityGroup(this, 'EmbeddingGeneratorSg', {
       vpc,
-      description: 'Security group for embedding-generator Lambda (postgres.js → Aurora)',
+      description: 'Security group for embedding-generator Lambda (postgres.js to Aurora)',
       allowAllOutbound: true,
     });
 


### PR DESCRIPTION
Fixes a CloudFormation `CREATE_FAILED` on `AIStudio-ProcessingStack-Dev`:

```
Value (Security group for embedding-generator Lambda (postgres.js → Aurora))
for parameter GroupDescription is invalid. Character sets beyond ASCII are
not supported.
```

EC2 `SecurityGroup` `GroupDescription` is **ASCII-only**. The embedding-generator SG description (added in #1019) used a Unicode arrow (`→`). Replaced with `to`. Also ASCII-ified two EventBridge rule descriptions in `agent-platform-stack.ts` as a precaution (not blockers — EventBridge allows Unicode).

**Verified:** `cd infra && bun run build` clean; `cdk synth AIStudio-ProcessingStack-Dev` succeeds with an ASCII GroupDescription; no non-ASCII left in any `description:` value across `infra/lib`. Only description text changed — no logic.