### PR TITLE
fix(infra): drop .next-e2e from Docker context + skip E2E on delete-only pushes

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,6 +7,10 @@ yarn-error.log*
 # Next.js
 .next
 .next/cache
+# Isolated build dir used by the local E2E runner (scripts/test/e2e-local.sh sets
+# NEXT_DIST_DIR=.next-e2e). It is gitignored but was NOT dockerignored, so on any
+# machine that has run the E2E suite it shipped ~7GB into the build context.
+.next-e2e
 out
 
 # Testing

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -3,12 +3,34 @@
 # Committed pre-push hook (travels with the repo via core.hooksPath=.githooks,
 # set by the package.json "prepare" script on `bun install`).
 #
-# Runs the authenticated Playwright E2E suite locally before every push — this
-# replaces the GitHub E2E job, which a clean CI runner cannot run without seeded
-# data, provider keys, and a committed AUTH_SECRET. See scripts/test/e2e-local.sh.
+# Runs the authenticated Playwright E2E suite locally before every push (except
+# delete-only pushes — see below) — this replaces the GitHub E2E job, which a
+# clean CI runner cannot run without seeded data, provider keys, and a committed
+# AUTH_SECRET. See scripts/test/e2e-local.sh.
 #
 # Bypass one push intentionally: SKIP_E2E=1 git push
 set -uo pipefail
 
 ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" || exit 0
+
+# Skip the suite when this push ONLY deletes refs — a deletion has nothing to
+# test, yet `git push origin --delete <branch>` would otherwise run the whole
+# E2E suite (a multi-minute hang for a no-op). Git feeds the pre-push hook one
+# line per ref on stdin: "<local ref> <local sha> <remote ref> <remote sha>".
+# A deletion sends an all-zero <local sha>. If every ref on stdin is all-zero,
+# this is a delete-only push, so skip. (No refs on stdin -> fall through and run,
+# the safe default.)
+only_deletes=1
+saw_ref=0
+while read -r _local_ref local_sha _remote_ref _remote_sha; do
+  saw_ref=1
+  case "$local_sha" in
+    *[!0]*) only_deletes=0 ;; # any non-zero char => a real update; must test
+  esac
+done
+if [ "$saw_ref" = 1 ] && [ "$only_deletes" = 1 ]; then
+  echo "pre-push: delete-only push — skipping E2E suite"
+  exit 0
+fi
+
 exec bash "$ROOT/scripts/test/e2e-local.sh"


### PR DESCRIPTION
## Why
Surfaced while diagnosing a dev ECS frontend deploy failure (`next build --webpack` → `cannot allocate memory`).

Two build-hygiene problems (neither is the OOM itself — that was Docker Desktop allocated only 7.7 GiB; raising it is the deploy fix):

### 1. `.dockerignore` — exclude `.next-e2e`
- `scripts/test/e2e-local.sh` builds into `NEXT_DIST_DIR=.next-e2e`. That dir is gitignored but was **not** dockerignored (`.dockerignore` only listed `.next` / `.next/cache`).
- Result: on any machine that ran the local E2E suite, ~7 GB of stale build cache shipped into the Docker context every build (observed: **7.48 GB context**, almost entirely `.next-e2e`).
- Fix: add `.next-e2e` (kept specific, not a `.next-*` glob, so `.next-env.d.ts` isn't excluded). Context drops to ~0.5 GB.

### 2. `.githooks/pre-push` — skip E2E on delete-only pushes
- The hook execs the full authenticated Playwright suite on **every** push, including `git push origin --delete <branch>` — a multi-minute hang for a no-op (hit during post-merge cleanup).
- Fix: parse the pre-push stdin ref lines; a deletion sends an all-zero `<local sha>`. If every ref is all-zero → delete-only → exit 0 without running. Mixed / normal / empty-stdin pushes still run (safe default).

## Verification
- `bash -n .githooks/pre-push` clean.
- Detection logic unit-checked: delete-only → SKIP; real → RUN; mixed → RUN; empty → RUN.
- No app code touched; CI (lint/typecheck/smokes/CDK) is the gate.