### PR TITLE
fix: #1090 - Atrium Phase 5 post-merge follow-ups (publish gate, route params, events, scheduler identity)

### DIFF
--- a/actions/db/atrium/unpublish-document.ts
+++ b/actions/db/atrium/unpublish-document.ts
@@ -19,6 +19,7 @@ import {
 } from "@/lib/logger";
 import { createSuccess, handleError, ErrorFactories } from "@/lib/error-utils";
 import { publishService } from "@/lib/content/publish-service";
+import { ApprovalRequiredError } from "@/lib/content/errors";
 import type { ActionState } from "@/types";
 import { hasCapabilityAccess } from "@/utils/roles";
 import { getServerSession } from "@/lib/auth/server-session";
@@ -74,6 +75,21 @@ export async function unpublishDocumentAction(
     return createSuccess(result, "Document unpublished");
   } catch (error) {
     timer({ status: "error" });
+    // §26.4 gate: taking a public destination offline without authority is a
+    // pending-approval outcome (approval-queue event emitted in the service), not a
+    // failure — surface it distinctly so the editor can show an amber "submitted
+    // for review" caption, mirroring publishDocumentAction. Defensive: the shipped
+    // editor only unpublishes from `intranet` (which never trips the gate), but the
+    // service accepts public destinations.
+    if (error instanceof ApprovalRequiredError) {
+      log.info("Unpublish requires approval", { requestId });
+      return {
+        isSuccess: false,
+        approvalRequired: true,
+        message:
+          "Unpublishing from this destination requires administrator approval — your request has been submitted for review.",
+      };
+    }
     return handleError(error, "Failed to unpublish document", {
       context: "unpublishDocumentAction",
       requestId,

--- a/app/api/assistant-architect/execute/scheduled/route.ts
+++ b/app/api/assistant-architect/execute/scheduled/route.ts
@@ -9,6 +9,8 @@ import { promptResults, scheduledExecutions } from '@/lib/db/schema';
 import { unifiedStreamingService } from '@/lib/streaming/unified-streaming-service';
 import { retrieveKnowledgeForPrompt, formatKnowledgeContext } from '@/lib/assistant-architect/knowledge-retrieval';
 import { createRepositoryTools } from '@/lib/tools/repository-tools';
+import { buildAutonomousRequesterForIdentity } from '@/lib/content';
+import type { Requester } from '@/lib/content/types';
 import type { StreamRequest } from '@/lib/streaming/types';
 import type { UIMessage } from 'ai';
 import jwt from 'jsonwebtoken';
@@ -69,6 +71,14 @@ interface PromptExecutionContext {
   userCognitoSub: string;
   assistantOwnerSub?: string;
   userId: number;
+  /**
+   * The autonomous agent Requester the run executes as (§25 service identity),
+   * when the schedule specified an `agent_identity_id`. Null = the run authors any
+   * Atrium content as the owning user. Threaded here so the content-authoring tools
+   * (a later wiring) resolve their write permission from the identity's scopes, not
+   * the user's full human authority.
+   */
+  agentRequester: Requester | null;
 }
 
 /**
@@ -110,6 +120,54 @@ function validateInternalRequest(req: NextRequest): { scheduleId: string; execut
   } catch (error) {
     log.warn('JWT verification failed', { error: error instanceof Error ? error.message : String(error) });
     return null;
+  }
+}
+
+/**
+ * Resolve the service-identity Requester for a scheduled run (§25). Returns the
+ * `agent-autonomous` Requester when `agentIdentityId` is set and active, `null`
+ * when the schedule runs as the owning user (no identity), or an error `Response`
+ * (HTTP 422) when a requested identity is missing/inactive — the run FAILS CLOSED
+ * rather than silently executing with the user's authority.
+ *
+ * Extracted from `POST` to keep that handler within the complexity/line budget.
+ */
+async function resolveScheduledAgentRequester(
+  agentIdentityId: string | null | undefined,
+  ctx: { scheduleId: number; userId: number; requestId: string; timer: ReturnType<typeof startTimer>; log: ReturnType<typeof createLogger> }
+): Promise<{ requester: Requester | null } | { errorResponse: Response }> {
+  if (!agentIdentityId) return { requester: null };
+  try {
+    const requester = await buildAutonomousRequesterForIdentity(agentIdentityId);
+    ctx.log.info('Scheduled run resolved to an agent service-identity', {
+      scheduleId: ctx.scheduleId,
+      userId: ctx.userId,
+      agentIdentityId,
+      agentLabel:
+        requester.kind === 'agent-autonomous' ? requester.agentLabel : undefined,
+    });
+    return { requester };
+  } catch (identityError) {
+    ctx.log.error('Scheduled run requested an inactive/unknown agent identity; aborting', {
+      scheduleId: ctx.scheduleId,
+      userId: ctx.userId,
+      agentIdentityId,
+      error:
+        identityError instanceof Error ? identityError.message : String(identityError),
+    });
+    ctx.timer({ status: 'error', reason: 'invalid_agent_identity' });
+    return {
+      errorResponse: new Response(
+        JSON.stringify({
+          error: 'Invalid agent identity',
+          message:
+            'The schedule references an agent identity that is not active. ' +
+            'Re-activate it or clear the identity to run as the owning user.',
+          requestId: ctx.requestId,
+        }),
+        { status: 422, headers: { 'Content-Type': 'application/json' } }
+      ),
+    };
   }
 }
 
@@ -215,19 +273,21 @@ export async function POST(req: NextRequest) {
 
     const { scheduleId, toolId, inputs, userId, triggeredBy, scheduledAt, agentIdentityId } = validationResult.data;
 
-    // Atrium Phase 5 (#1055): service-identity execution is groundwork only — the
-    // column + Lambda forwarding land in this PR, but running the assistant under
-    // an agent-autonomous Requester (so its content authoring is system-owned +
-    // scope-bounded) is not yet wired. Surface this LOUDLY rather than silently
-    // executing as the owning user, so an operator who set agent_identity_id gets
-    // a signal it had no effect.
-    if (agentIdentityId) {
-      log.warn(
-        'Scheduled run requested an agent service-identity, but service-identity ' +
-        'execution is not yet implemented; running under the owning user instead',
-        { scheduleId, userId, agentIdentityId }
-      );
-    }
+    // Atrium Phase 5 (#1055, §25): resolve the schedule's optional agent service
+    // identity into an `agent-autonomous` Requester so any Atrium content the run
+    // authors is system-owned, agent-stamped, and bounded by the identity's OWN
+    // scopes (never the user's full human authority). Fails CLOSED — a
+    // missing/inactive identity aborts the run (422) instead of silently running as
+    // the owning user. See `resolveScheduledAgentRequester`.
+    const agentResolution = await resolveScheduledAgentRequester(agentIdentityId, {
+      scheduleId,
+      userId,
+      requestId,
+      timer,
+      log,
+    });
+    if ('errorResponse' in agentResolution) return agentResolution.errorResponse;
+    const agentRequester = agentResolution.requester;
 
     log.info('Scheduled execution request parsed', sanitizeForLogging({
       scheduleId,
@@ -357,7 +417,11 @@ export async function POST(req: NextRequest) {
       executionId,
       userCognitoSub,
       assistantOwnerSub: architect.userId ? String(architect.userId) : undefined,
-      userId
+      userId,
+      // The resolved service-identity Requester (null when the schedule runs as the
+      // owning user). Threaded so the content-authoring tool wiring reads its write
+      // authority from the identity's scopes.
+      agentRequester
     };
 
     try {
@@ -548,6 +612,18 @@ export async function POST(req: NextRequest) {
 }
 
 /**
+ * A stable label for the identity a run authors content AS — an autonomous service
+ * identity (§25) when one was resolved, otherwise the owning user. Kept as a small
+ * helper so the caller stays within the complexity budget.
+ */
+function describeWriteIdentity(context: PromptExecutionContext): string {
+  const req = context.agentRequester;
+  return req?.kind === 'agent-autonomous'
+    ? `agent:${req.agentId}`
+    : `user:${context.userId}`;
+}
+
+/**
  * Execute prompt chain server-side without SSE
  * Collects complete response in memory
  */
@@ -560,7 +636,10 @@ async function executePromptChainServerSide(
 ) {
   log.info('Starting server-side prompt chain execution', {
     promptCount: prompts.length,
-    executionId: context.executionId
+    executionId: context.executionId,
+    // Record the effective write identity for the run so the audit trail shows
+    // whether content was authored as a bounded service identity (§25) or the user.
+    writeIdentity: describeWriteIdentity(context)
   });
 
   for (const prompt of prompts) {

--- a/app/api/v1/content/[id]/publish/[destination]/route.ts
+++ b/app/api/v1/content/[id]/publish/[destination]/route.ts
@@ -18,6 +18,7 @@ import {
 } from "@/lib/api";
 import {
   ApprovalRequiredError,
+  hasPublishPublicScope,
   publishService,
   recordContentAudit,
 } from "@/lib/content";
@@ -64,7 +65,7 @@ export const DELETE = withApiAuth(async (request: NextRequest, auth, requestId) 
 
   // Same authority key as publish/set_visibility/create: an EXPLICIT
   // content:publish_public scope, never a session's wildcard ["*"].
-  const hasPublishPublicCapability = auth.scopes.includes("content:publish_public");
+  const hasPublishPublicCapability = hasPublishPublicScope(auth.scopes);
 
   try {
     // Session humans must also hold the atrium-content capability (see helper).

--- a/app/api/v1/content/[id]/publish/[destination]/route.ts
+++ b/app/api/v1/content/[id]/publish/[destination]/route.ts
@@ -14,7 +14,6 @@ import {
   requireScope,
   createApiResponse,
   createErrorResponse,
-  extractStringParam,
 } from "@/lib/api";
 import {
   ApprovalRequiredError,
@@ -38,14 +37,19 @@ const DESTINATIONS: PublishDestination[] = [
   "google",
 ];
 
-export const DELETE = withApiAuth(async (request: NextRequest, auth, requestId) => {
+export const DELETE = withApiAuth(async (request: NextRequest, auth, requestId, params) => {
   const scopeError = requireScope(auth, "content:publish_internal", requestId);
   if (scopeError) return scopeError;
 
   const log = createLogger({ requestId, route: "api.v1.content.unpublish" });
 
-  const id = extractStringParam(request.url, "content");
-  const destinationRaw = extractStringParam(request.url, "publish");
+  // Real Next.js route params (from [id]/publish/[destination]) — NOT parsed from
+  // the URL by segment name. `extractStringParam(url, "publish")` misparses when
+  // the id slug is literally "publish" (e.g. /content/publish/publish/schoology →
+  // it returns the "publish" path literal as the destination, a 400 that leaves
+  // the object un-unpublishable).
+  const id = params.id;
+  const destinationRaw = params.destination;
   if (!id) {
     return createErrorResponse(requestId, 400, "VALIDATION_ERROR", "Missing content id");
   }

--- a/app/api/v1/content/[id]/publish/route.ts
+++ b/app/api/v1/content/[id]/publish/route.ts
@@ -19,6 +19,7 @@ import {
 import { z } from "zod";
 import {
   ApprovalRequiredError,
+  hasPublishPublicScope,
   publishService,
   recordContentAudit,
 } from "@/lib/content";
@@ -59,7 +60,7 @@ export const POST = withApiAuth(async (request: NextRequest, auth, requestId) =>
   // token's EXPLICIT content:publish_public scope. A session's wildcard ["*"]
   // must NOT auto-grant it (every logged-in human would otherwise bypass the
   // gate) — admin humans still pass via req.isAdmin inside the service.
-  const hasPublishPublicCapability = auth.scopes.includes("content:publish_public");
+  const hasPublishPublicCapability = hasPublishPublicScope(auth.scopes);
 
   try {
     // Session humans must also hold the atrium-content capability (see helper).

--- a/app/api/v1/content/[id]/publish/route.ts
+++ b/app/api/v1/content/[id]/publish/route.ts
@@ -13,7 +13,6 @@ import {
   requireScope,
   createApiResponse,
   createErrorResponse,
-  extractStringParam,
   parseRequestBody,
 } from "@/lib/api";
 import { z } from "zod";
@@ -37,13 +36,14 @@ const publishBodySchema = z.object({
   visibility: restVisibilitySchema.optional(),
 });
 
-export const POST = withApiAuth(async (request: NextRequest, auth, requestId) => {
+export const POST = withApiAuth(async (request: NextRequest, auth, requestId, params) => {
   const scopeError = requireScope(auth, "content:publish_internal", requestId);
   if (scopeError) return scopeError;
 
   const log = createLogger({ requestId, route: "api.v1.content.publish" });
 
-  const id = extractStringParam(request.url, "content");
+  // Real Next.js [id] route param — collision-free vs. parsing the URL by segment.
+  const id = params.id;
   if (!id) {
     return createErrorResponse(requestId, 400, "VALIDATION_ERROR", "Missing content id");
   }

--- a/app/api/v1/content/[id]/route.ts
+++ b/app/api/v1/content/[id]/route.ts
@@ -12,7 +12,6 @@ import {
   requireScope,
   createApiResponse,
   createErrorResponse,
-  extractStringParam,
   parseRequestBody,
 } from "@/lib/api";
 import { z } from "zod";
@@ -42,11 +41,13 @@ const updateBodySchema = z.object({
 // GET — object + current version
 // ============================================
 
-export const GET = withApiAuth(async (request: NextRequest, auth, requestId) => {
+export const GET = withApiAuth(async (request: NextRequest, auth, requestId, params) => {
   const scopeError = requireScope(auth, "content:read", requestId);
   if (scopeError) return scopeError;
 
-  const id = extractStringParam(request.url, "content");
+  // Real Next.js [id] route param — collision-free vs. parsing the URL by segment
+  // name (a slug of "content" would misparse with extractStringParam).
+  const id = params.id;
   if (!id) {
     return createErrorResponse(requestId, 400, "VALIDATION_ERROR", "Missing content id");
   }
@@ -67,13 +68,13 @@ export const GET = withApiAuth(async (request: NextRequest, auth, requestId) => 
 // PATCH — update metadata
 // ============================================
 
-export const PATCH = withApiAuth(async (request: NextRequest, auth, requestId) => {
+export const PATCH = withApiAuth(async (request: NextRequest, auth, requestId, params) => {
   const scopeError = requireScope(auth, "content:update", requestId);
   if (scopeError) return scopeError;
 
   const log = createLogger({ requestId, route: "api.v1.content.update" });
 
-  const id = extractStringParam(request.url, "content");
+  const id = params.id;
   if (!id) {
     return createErrorResponse(requestId, 400, "VALIDATION_ERROR", "Missing content id");
   }

--- a/app/api/v1/content/[id]/versions/route.ts
+++ b/app/api/v1/content/[id]/versions/route.ts
@@ -12,7 +12,6 @@ import {
   requireScope,
   createApiResponse,
   createErrorResponse,
-  extractStringParam,
   parseRequestBody,
 } from "@/lib/api";
 import { z } from "zod";
@@ -36,11 +35,12 @@ const createVersionBodySchema = z.object({
 // GET — list versions
 // ============================================
 
-export const GET = withApiAuth(async (request: NextRequest, auth, requestId) => {
+export const GET = withApiAuth(async (request: NextRequest, auth, requestId, params) => {
   const scopeError = requireScope(auth, "content:read", requestId);
   if (scopeError) return scopeError;
 
-  const id = extractStringParam(request.url, "content");
+  // Real Next.js [id] route param — collision-free vs. parsing the URL by segment.
+  const id = params.id;
   if (!id) {
     return createErrorResponse(requestId, 400, "VALIDATION_ERROR", "Missing content id");
   }
@@ -63,13 +63,13 @@ export const GET = withApiAuth(async (request: NextRequest, auth, requestId) => 
 // POST — create a new version
 // ============================================
 
-export const POST = withApiAuth(async (request: NextRequest, auth, requestId) => {
+export const POST = withApiAuth(async (request: NextRequest, auth, requestId, params) => {
   const scopeError = requireScope(auth, "content:update", requestId);
   if (scopeError) return scopeError;
 
   const log = createLogger({ requestId, route: "api.v1.content.createVersion" });
 
-  const id = extractStringParam(request.url, "content");
+  const id = params.id;
   if (!id) {
     return createErrorResponse(requestId, 400, "VALIDATION_ERROR", "Missing content id");
   }

--- a/app/api/v1/content/[id]/visibility/route.ts
+++ b/app/api/v1/content/[id]/visibility/route.ts
@@ -21,6 +21,7 @@ import {
 import {
   ApprovalRequiredError,
   contentService,
+  hasPublishPublicScope,
   recordContentAudit,
   visibilityService,
 } from "@/lib/content";
@@ -54,7 +55,7 @@ export const PATCH = withApiAuth(async (request: NextRequest, auth, requestId) =
 
   // Same authority key as the publish endpoint: an EXPLICIT content:publish_public
   // scope, never a session's wildcard ["*"] (admin humans pass via req.isAdmin).
-  const hasPublishPublicCapability = auth.scopes.includes("content:publish_public");
+  const hasPublishPublicCapability = hasPublishPublicScope(auth.scopes);
 
   try {
     // Session humans must also hold the atrium-content capability (see helper).

--- a/app/api/v1/content/[id]/visibility/route.ts
+++ b/app/api/v1/content/[id]/visibility/route.ts
@@ -15,7 +15,6 @@ import {
   requireScope,
   createApiResponse,
   createErrorResponse,
-  extractStringParam,
   parseRequestBody,
 } from "@/lib/api";
 import {
@@ -34,13 +33,14 @@ import {
 import { assertContentAuthoringCapability } from "@/lib/content/surface-helpers";
 import { createLogger } from "@/lib/logger";
 
-export const PATCH = withApiAuth(async (request: NextRequest, auth, requestId) => {
+export const PATCH = withApiAuth(async (request: NextRequest, auth, requestId, params) => {
   const scopeError = requireScope(auth, "content:update", requestId);
   if (scopeError) return scopeError;
 
   const log = createLogger({ requestId, route: "api.v1.content.setVisibility" });
 
-  const id = extractStringParam(request.url, "content");
+  // Real Next.js [id] route param — collision-free vs. parsing the URL by segment.
+  const id = params.id;
   if (!id) {
     return createErrorResponse(requestId, 400, "VALIDATION_ERROR", "Missing content id");
   }

--- a/app/api/v1/content/route.ts
+++ b/app/api/v1/content/route.ts
@@ -20,6 +20,7 @@ import { z } from "zod";
 import {
   ApprovalRequiredError,
   contentService,
+  hasPublishPublicScope,
   recordContentAudit,
   requesterFromApiAuth,
 } from "@/lib/content";
@@ -118,7 +119,7 @@ export const POST = withApiAuth(async (request: NextRequest, auth, requestId) =>
 
   // Same authority key as publish/set_visibility: an EXPLICIT content:publish_public
   // scope, never a session's wildcard ["*"] (admin humans pass via req.isAdmin).
-  const hasPublishPublicCapability = auth.scopes.includes("content:publish_public");
+  const hasPublishPublicCapability = hasPublishPublicScope(auth.scopes);
 
   try {
     // Session humans must ALSO hold the atrium-content capability (scope alone is

--- a/components/atrium/DocumentEditor.tsx
+++ b/components/atrium/DocumentEditor.tsx
@@ -184,6 +184,7 @@ export function DocumentEditor({ idOrSlug, userId }: DocumentEditorProps) {
   const {
     message,
     actionError,
+    pendingApproval,
     busy,
     handleSnapshot,
     handlePublish,
@@ -205,10 +206,18 @@ export function DocumentEditor({ idOrSlug, userId }: DocumentEditorProps) {
       </div>
       {message && (
         <p
+          // A pending-approval outcome is announced as a status (not an error) and
+          // styled amber — distinct from the red error and the neutral success
+          // captions, mirroring VisibilityChip's §26.4 pending notice.
           aria-live="polite"
+          role={pendingApproval ? "status" : undefined}
           className={cn(
             "text-xs",
-            actionError ? "text-destructive" : "text-muted-foreground"
+            actionError
+              ? "text-destructive"
+              : pendingApproval
+                ? "text-amber-600"
+                : "text-muted-foreground"
           )}
         >
           {message}

--- a/components/atrium/use-editor-actions.ts
+++ b/components/atrium/use-editor-actions.ts
@@ -10,7 +10,12 @@
  *
  * `busy` blocks re-entry while an action runs — a double-click can't fire two
  * publish/unpublish calls, whose nav-item side effects race outside the row lock.
- * `actionError` distinguishes a red error caption from a neutral success one.
+ * `actionError` distinguishes a red error caption from a neutral success one, and
+ * `pendingApproval` an amber "submitted for review" caption from either — mirroring
+ * `VisibilityChip`, so a §26.4 public publish/unpublish that returns
+ * `approvalRequired` is NOT shown as a failure. Latent today (the shipped editor
+ * pins `destination: "intranet"`, which never triggers the gate), but wired so any
+ * future public-destination button surfaces the pending-approval outcome correctly.
  */
 
 import { useCallback, useState, type RefObject } from "react";
@@ -30,10 +35,23 @@ interface UseEditorActionsParams {
 export interface EditorActions {
   message: string | null;
   actionError: boolean;
+  /** True when the last action returned a §26.4 pending-approval outcome. */
+  pendingApproval: boolean;
   busy: boolean;
   handleSnapshot: () => void;
   handlePublish: () => void;
   handleUnpublish: () => void;
+}
+
+/**
+ * The outcome of a toolbar action. `pending` (a §26.4 approval-required result) is
+ * neither success nor error: it is a distinct amber "submitted for review" state,
+ * so a caller must not collapse it into the `ok` boolean.
+ */
+interface ActionOutcome {
+  ok: boolean;
+  text: string;
+  pending?: boolean;
 }
 
 export function useEditorActions({
@@ -43,16 +61,21 @@ export function useEditorActions({
 }: UseEditorActionsParams): EditorActions {
   const [message, setMessage] = useState<string | null>(null);
   const [actionError, setActionError] = useState(false);
+  const [pendingApproval, setPendingApproval] = useState(false);
   const [busy, setBusy] = useState(false);
 
   // Run a toolbar action with shared busy/feedback handling: blocks re-entry
-  // while one is in flight, records success vs. error for the caption styling.
+  // while one is in flight, records success / error / pending-approval for the
+  // caption styling. A `pending` outcome is NOT an error — clear the error flag so
+  // the caption renders amber (review submitted), not red (failed).
   const runAction = useCallback(
-    async (run: () => Promise<{ ok: boolean; text: string }>) => {
+    async (run: () => Promise<ActionOutcome>) => {
       setBusy(true);
       try {
-        const { ok, text } = await run();
-        setActionError(!ok);
+        const { ok, text, pending } = await run();
+        setPendingApproval(pending ?? false);
+        // A pending-approval outcome is not a failure even though `ok` is false.
+        setActionError(!ok && !pending);
         setMessage(text);
       } finally {
         setBusy(false);
@@ -81,12 +104,21 @@ export function useEditorActions({
     const target = docNameRef.current ?? idOrSlug;
     void runAction(async () => {
       const result = await publishDocumentAction(target, { destination: "intranet" });
-      return {
-        ok: result.isSuccess,
-        text: result.isSuccess
-          ? "Published to intranet"
-          : result.message ?? "Publish failed",
-      };
+      if (result.isSuccess) {
+        return { ok: true, text: "Published to intranet" };
+      }
+      // §26.4: a public-destination publish the caller can't authorize returns a
+      // pending-approval outcome (not a failure) — surface it amber, like
+      // VisibilityChip. `intranet` never trips this today; wired for future
+      // public-destination publish buttons.
+      if (result.approvalRequired) {
+        return {
+          ok: false,
+          pending: true,
+          text: result.message ?? "Submitted for approval.",
+        };
+      }
+      return { ok: false, text: result.message ?? "Publish failed" };
     });
   }, [idOrSlug, docNameRef, runAction]);
 
@@ -106,16 +138,36 @@ export function useEditorActions({
     const target = docNameRef.current ?? idOrSlug;
     void runAction(async () => {
       const result = await unpublishDocumentAction(target, { destination: "intranet" });
-      return {
-        ok: result.isSuccess,
-        text: result.isSuccess
-          ? result.data.unpublished
+      if (result.isSuccess) {
+        return {
+          ok: true,
+          text: result.data.unpublished
             ? "Unpublished from intranet"
-            : "Not currently published"
-          : result.message ?? "Unpublish failed",
-      };
+            : "Not currently published",
+        };
+      }
+      // §26.4: taking a public destination offline needs the same authority as
+      // publishing it — an unauthorized caller gets a pending-approval outcome.
+      // `intranet` never trips this today; wired for future public-destination
+      // unpublish buttons (mirrors handlePublish).
+      if (result.approvalRequired) {
+        return {
+          ok: false,
+          pending: true,
+          text: result.message ?? "Submitted for approval.",
+        };
+      }
+      return { ok: false, text: result.message ?? "Unpublish failed" };
     });
   }, [idOrSlug, docNameRef, runAction]);
 
-  return { message, actionError, busy, handleSnapshot, handlePublish, handleUnpublish };
+  return {
+    message,
+    actionError,
+    pendingApproval,
+    busy,
+    handleSnapshot,
+    handlePublish,
+    handleUnpublish,
+  };
 }

--- a/components/atrium/use-editor-actions.ts
+++ b/components/atrium/use-editor-actions.ts
@@ -23,6 +23,7 @@ import type { Editor } from "@tiptap/react";
 import { snapshotDocumentAction } from "@/actions/db/atrium/snapshot-document";
 import { publishDocumentAction } from "@/actions/db/atrium/publish-document";
 import { unpublishDocumentAction } from "@/actions/db/atrium/unpublish-document";
+import type { ActionState } from "@/types";
 
 interface UseEditorActionsParams {
   editor: Editor | null;
@@ -45,13 +46,47 @@ export interface EditorActions {
 
 /**
  * The outcome of a toolbar action. `pending` (a §26.4 approval-required result) is
- * neither success nor error: it is a distinct amber "submitted for review" state,
- * so a caller must not collapse it into the `ok` boolean.
+ * neither success nor error: it is a distinct amber "submitted for review" state.
+ * A discriminated union (rather than `{ ok: boolean; pending?: boolean }`) makes
+ * the invalid `{ ok: true, pending: true }` combination unrepresentable.
  */
-interface ActionOutcome {
-  ok: boolean;
-  text: string;
-  pending?: boolean;
+type ActionOutcome =
+  | { status: "success"; text: string }
+  | { status: "pending"; text: string }
+  | { status: "error"; text: string };
+
+/**
+ * Maps a server action's `ActionState`-shaped result to an `ActionOutcome` for
+ * `runAction`'s shared success/error/pending-approval handling — the identical
+ * `isSuccess` / `approvalRequired` / else branching `handlePublish` and
+ * `handleUnpublish` both need, centralized so a third action doesn't hand-copy it
+ * again. `successText` may depend on the resolved data (e.g. unpublish's
+ * "Not currently published" vs "Unpublished from intranet"), so it accepts either
+ * a fixed string or a function of `result.data`.
+ */
+function mapActionResult<T>(
+  result: ActionState<T>,
+  opts: {
+    successText: string | ((data: T) => string);
+    failureFallback: string;
+  }
+): ActionOutcome {
+  if (result.isSuccess) {
+    const text =
+      typeof opts.successText === "function"
+        ? opts.successText(result.data)
+        : opts.successText;
+    return { status: "success", text };
+  }
+  // §26.4: an approval-required result is NOT a failure — surface it amber, like
+  // VisibilityChip, instead of red.
+  if (result.approvalRequired) {
+    return {
+      status: "pending",
+      text: result.message ?? "Submitted for approval.",
+    };
+  }
+  return { status: "error", text: result.message ?? opts.failureFallback };
 }
 
 export function useEditorActions({
@@ -66,17 +101,15 @@ export function useEditorActions({
 
   // Run a toolbar action with shared busy/feedback handling: blocks re-entry
   // while one is in flight, records success / error / pending-approval for the
-  // caption styling. A `pending` outcome is NOT an error — clear the error flag so
-  // the caption renders amber (review submitted), not red (failed).
+  // caption styling.
   const runAction = useCallback(
     async (run: () => Promise<ActionOutcome>) => {
       setBusy(true);
       try {
-        const { ok, text, pending } = await run();
-        setPendingApproval(pending ?? false);
-        // A pending-approval outcome is not a failure even though `ok` is false.
-        setActionError(!ok && !pending);
-        setMessage(text);
+        const outcome = await run();
+        setPendingApproval(outcome.status === "pending");
+        setActionError(outcome.status === "error");
+        setMessage(outcome.text);
       } finally {
         setBusy(false);
       }
@@ -93,10 +126,10 @@ export function useEditorActions({
     const body = editor.storage.markdown.getMarkdown();
     void runAction(async () => {
       const result = await snapshotDocumentAction(target, { body });
-      return {
-        ok: result.isSuccess,
-        text: result.isSuccess ? "Snapshot saved" : result.message ?? "Snapshot failed",
-      };
+      return mapActionResult(result, {
+        successText: "Snapshot saved",
+        failureFallback: "Snapshot failed",
+      });
     });
   }, [editor, idOrSlug, docNameRef, runAction]);
 
@@ -104,21 +137,13 @@ export function useEditorActions({
     const target = docNameRef.current ?? idOrSlug;
     void runAction(async () => {
       const result = await publishDocumentAction(target, { destination: "intranet" });
-      if (result.isSuccess) {
-        return { ok: true, text: "Published to intranet" };
-      }
-      // §26.4: a public-destination publish the caller can't authorize returns a
-      // pending-approval outcome (not a failure) — surface it amber, like
-      // VisibilityChip. `intranet` never trips this today; wired for future
-      // public-destination publish buttons.
-      if (result.approvalRequired) {
-        return {
-          ok: false,
-          pending: true,
-          text: result.message ?? "Submitted for approval.",
-        };
-      }
-      return { ok: false, text: result.message ?? "Publish failed" };
+      // §26.4: `intranet` never trips the public-publish gate today; wired for
+      // future public-destination publish buttons (mapActionResult surfaces an
+      // `approvalRequired` result as `pending`, not `error`).
+      return mapActionResult(result, {
+        successText: "Published to intranet",
+        failureFallback: "Publish failed",
+      });
     });
   }, [idOrSlug, docNameRef, runAction]);
 
@@ -138,26 +163,14 @@ export function useEditorActions({
     const target = docNameRef.current ?? idOrSlug;
     void runAction(async () => {
       const result = await unpublishDocumentAction(target, { destination: "intranet" });
-      if (result.isSuccess) {
-        return {
-          ok: true,
-          text: result.data.unpublished
-            ? "Unpublished from intranet"
-            : "Not currently published",
-        };
-      }
       // §26.4: taking a public destination offline needs the same authority as
-      // publishing it — an unauthorized caller gets a pending-approval outcome.
-      // `intranet` never trips this today; wired for future public-destination
-      // unpublish buttons (mirrors handlePublish).
-      if (result.approvalRequired) {
-        return {
-          ok: false,
-          pending: true,
-          text: result.message ?? "Submitted for approval.",
-        };
-      }
-      return { ok: false, text: result.message ?? "Unpublish failed" };
+      // publishing it — `intranet` never trips this today; wired for future
+      // public-destination unpublish buttons (mirrors handlePublish).
+      return mapActionResult(result, {
+        successText: (data) =>
+          data.unpublished ? "Unpublished from intranet" : "Not currently published",
+        failureFallback: "Unpublish failed",
+      });
     });
   }, [idOrSlug, docNameRef, runAction]);
 

--- a/docs/learnings/api-patterns/2026-07-01-parse-route-params-by-position-not-segment-name.md
+++ b/docs/learnings/api-patterns/2026-07-01-parse-route-params-by-position-not-segment-name.md
@@ -1,0 +1,47 @@
+---
+title: Parse dynamic route params from real Next.js params, not by URL segment name
+category: api-patterns
+tags:
+  - nextjs
+  - route-params
+  - withApiAuth
+  - extractStringParam
+  - slug-collision
+  - atrium
+severity: medium
+date: 2026-07-01
+source: auto — /lfg #1090
+applicable_to: project
+---
+
+## What Happened
+
+`lib/api/route-helpers.ts` `extractStringParam(url, segmentName)` locates a path
+segment by `indexOf(segmentName)` and returns the **next** segment. That misparses
+whenever a dynamic value equals a path literal. Concretely, for the route
+`/api/v1/content/[id]/publish/[destination]`, a content slug of `"publish"` makes
+`DELETE /api/v1/content/publish/publish/schoology` →
+`extractStringParam(url, "publish")` return the `"publish"` **path literal** as the
+destination → "Invalid destination" 400 → the object is un-unpublishable. The
+`[id]` routes have the same class if a slug equals `"content"`.
+
+## The Rule
+
+In App Router route handlers, read dynamic params from the **real Next.js route
+params**, never by parsing the URL by segment name. Next passes the route context
+as the handler's second argument; `context.params` is a `Promise` (Next 15+) that
+resolves to the matched `{ [param]: value }`.
+
+## The Fix
+
+`withApiAuth` (the auth/rate-limit HOC) previously dropped the route context. It
+now accepts `(request, context?)`, awaits `context.params`, and passes the resolved
+object as a **4th** handler argument (backward compatible — the ~16 non-dynamic
+handlers ignore it and receive `{}`). Atrium content routes now read `params.id` /
+`params.destination` directly. Type the resolved params as
+`Record<string, string | undefined>` (not `Record<string, string>`) so a handler
+must null-check a key that isn't a real segment; the routes already guard
+`if (!id) return 400`.
+
+Left the ~5 non-Atrium routes still using `extractStringParam` untouched (out of
+scope) — they can adopt real params in a follow-up.

--- a/docs/learnings/security/2026-07-01-idempotency-check-toctou-before-for-update.md
+++ b/docs/learnings/security/2026-07-01-idempotency-check-toctou-before-for-update.md
@@ -1,0 +1,71 @@
+---
+title: An idempotency short-circuit read BEFORE FOR UPDATE can bypass a security gate (TOCTOU)
+category: security
+tags:
+  - TOCTOU
+  - FOR-UPDATE
+  - authorization-gate
+  - idempotency
+  - race-condition
+  - drizzle
+  - atrium
+severity: high
+date: 2026-07-01
+source: auto — /lfg #1090 (PR #1091 review)
+applicable_to: project
+---
+
+## What Happened
+
+Issue #1090 asked to stop the Atrium §26.4 public-publish gate from firing on
+idempotent no-op saves (re-saving already-public content spuriously required
+approval). The first fix gated on an *actual state change*:
+`input.visibility?.level === "public" && currentLevel !== "public"`. But
+`currentLevel` was read **before** the transaction acquired its `FOR UPDATE`
+lock (a pre-transaction `loadPublishable` / a standalone `currentVisibilityLevel`
+SELECT).
+
+Three independent PR reviewers (chatgpt-codex P2 ×2, Copilot ×3) converged on the
+same hole: between that pre-read and the locked write, a concurrent request can
+**narrow** the object (public → internal). Then the "already public → no-op"
+branch is evaluated against a stale `public`, the gate is skipped, and
+`setLevelInTx` widens the row back to `public` — an unauthorized caller reaching
+`public` with **no `ApprovalRequiredError`, no approval event, no review**. A
+`currentVisibilityLevel()` returning `null` on a concurrent delete had a related
+bug: it was treated as "not public" → `ApprovalRequiredError` instead of the 404
+the transaction's `FOR UPDATE` guard would raise.
+
+## The Rule
+
+When a security/authorization decision depends on a mutable row value AND the
+same request then writes that row, **make the decision inside the transaction,
+reading the value from the `FOR UPDATE`-locked row** — never from a pre-lock read.
+A read taken before the lock is a classic TOCTOU: the state can change between the
+check and the write, and an idempotency "skip the gate when nothing changes"
+optimization is exactly the shape that turns a stale read into a gate bypass.
+
+## The Fix
+
+- `publishService.publish`: split the gate. The `public_web`-destination branch is
+  level-**independent**, so it stays pre-transaction (and must precede the
+  adapter-not-implemented check so an unauthorized caller still gets the approval
+  signal). The visibility-**widen** branch (level-dependent) moved *inside* the
+  transaction, reading `locked[0].visibilityLevel` under the `FOR UPDATE` lock.
+- `visibilityService.setLevel`: the whole gate moved inside the existing
+  `executeTransaction`, reading the current level from the same locked row that
+  guards the write. This also fixed the null-on-delete case (the lock lookup 404s
+  first, so the gate never sees a null level).
+- Throwing `ApprovalRequiredError` inside the tx rolls it back → nothing is
+  widened/published. The best-effort `void contentEvents.emit(...)` is safe to
+  call right before the throw, even inside the tx, because `emit` swallows its own
+  errors and never rejects (`snsPublishBestEffort`).
+
+## Testing Note
+
+Moving the gate into the transaction changed what the mocked-DB unit tests must
+seed: a *rejected* widen now OPENS a transaction (reads the locked row, then
+throws), so the test must seed the `FOR UPDATE` lock lookup with a **non-public**
+locked row for the gate to fire — and assert on the thrown error + emitted event,
+not on `executeTransactionCalls === 0`. Add an explicit "no-op re-save of
+already-public content passes without approval" case (seed a **public** locked
+row) to lock in the idempotency behavior against the locked level.

--- a/lib/api/with-api-auth.ts
+++ b/lib/api/with-api-auth.ts
@@ -36,8 +36,14 @@ import { authenticateRequest, createErrorResponse } from "./auth-middleware";
 import type { ApiAuthContext } from "./auth-middleware";
 import { checkRateLimit, createRateLimitResponse, addRateLimitHeaders, recordUsage } from "./rate-limiter";
 
-/** Resolved dynamic route params, e.g. `{ id: "abc", destination: "intranet" }`. */
-export type RouteParams = Record<string, string>;
+/**
+ * Resolved dynamic route params, e.g. `{ id: "abc", destination: "intranet" }`.
+ * Values are typed `string | undefined` (not `string`) so a handler reading a key
+ * that does not correspond to a real `[param]` segment — or any key on a
+ * non-dynamic route, which receives `{}` — is forced to null-check rather than
+ * getting a false `string`. The Atrium content routes all guard with `if (!id)`.
+ */
+export type RouteParams = Record<string, string | undefined>;
 
 type ApiRouteHandler = (
   request: NextRequest,

--- a/lib/api/with-api-auth.ts
+++ b/lib/api/with-api-auth.ts
@@ -91,9 +91,11 @@ export function withApiAuth(
       return response;
     }
 
-    // Step 3: Execute handler
+    // Step 3: Execute handler. Both the try (success) and catch (500) branches
+    // assign `response` + `statusCode`, so no initializer is needed — and a `= 200`
+    // default would be dead (never read before reassignment: no-useless-assignment).
     let response: NextResponse;
-    let statusCode = 200;
+    let statusCode: number;
 
     try {
       // Resolve Next's dynamic route params (a Promise in the App Router) once and

--- a/lib/api/with-api-auth.ts
+++ b/lib/api/with-api-auth.ts
@@ -16,6 +16,18 @@
  *   return createApiResponse({ message: "Hello" }, requestId);
  * });
  * ```
+ *
+ * Dynamic routes get their real Next.js route params as a 4th handler argument —
+ * `params` is a plain, already-resolved `Record<string, string>` (the wrapper
+ * awaits Next's `params` Promise). Prefer this over parsing the URL with
+ * `extractStringParam`, which finds a path segment by NAME and can misparse when a
+ * slug value equals a path literal (e.g. a content slug of `"publish"`):
+ * ```typescript
+ * export const DELETE = withApiAuth(async (req, auth, requestId, params) => {
+ *   const id = params.id;               // the real [id] segment, collision-free
+ *   const destination = params.destination;
+ * });
+ * ```
  */
 
 import { NextRequest, NextResponse } from "next/server";
@@ -24,19 +36,36 @@ import { authenticateRequest, createErrorResponse } from "./auth-middleware";
 import type { ApiAuthContext } from "./auth-middleware";
 import { checkRateLimit, createRateLimitResponse, addRateLimitHeaders, recordUsage } from "./rate-limiter";
 
+/** Resolved dynamic route params, e.g. `{ id: "abc", destination: "intranet" }`. */
+export type RouteParams = Record<string, string>;
+
 type ApiRouteHandler = (
   request: NextRequest,
   auth: ApiAuthContext,
-  requestId: string
+  requestId: string,
+  params: RouteParams
 ) => Promise<NextResponse>;
+
+/**
+ * The route context Next.js passes as the SECOND argument to a route handler.
+ * `params` is a Promise in the App Router (Next 15+); the wrapper awaits it before
+ * handing a plain object to the handler. Optional so a non-dynamic route (no
+ * `[param]` segment) still type-checks — its handler receives `{}`.
+ */
+interface RouteContext {
+  params?: Promise<RouteParams>;
+}
 
 /**
  * Wrap an API route handler with authentication, rate limiting, and usage logging.
  */
 export function withApiAuth(
   handler: ApiRouteHandler
-): (request: NextRequest) => Promise<NextResponse> {
-  return async (request: NextRequest): Promise<NextResponse> => {
+): (request: NextRequest, context?: RouteContext) => Promise<NextResponse> {
+  return async (
+    request: NextRequest,
+    context?: RouteContext
+  ): Promise<NextResponse> => {
     const requestId = generateRequestId();
     const timer = startTimer("apiRequest");
     const log = createLogger({ requestId, action: "withApiAuth" });
@@ -67,7 +96,11 @@ export function withApiAuth(
     let statusCode = 200;
 
     try {
-      response = await handler(request, auth, requestId);
+      // Resolve Next's dynamic route params (a Promise in the App Router) once and
+      // hand the handler a plain object. A non-dynamic route has no `params`, so
+      // default to `{}` — the handler simply ignores the argument.
+      const params = context?.params ? await context.params : {};
+      response = await handler(request, auth, requestId, params);
       statusCode = response.status;
     } catch (error) {
       log.error("Unhandled error in API handler", {

--- a/lib/content/content-service.ts
+++ b/lib/content/content-service.ts
@@ -232,11 +232,13 @@ export const contentService = {
 
     // The §26.4 public-visibility gate, BEFORE any write. Emit the approval-queue
     // signal (parity with publish/set_visibility) then throw — nothing is created.
+    // Fire-and-forget (`void`, not `await`): `emit` swallows its own errors, so
+    // awaiting only adds an SNS round-trip to the response path.
     if (
       input.visibility?.level === "public" &&
       !canPublishPublic(req, opts.hasPublishPublicCapability ?? false)
     ) {
-      await contentEvents.emit("content.public_publish_requested", {
+      void contentEvents.emit("content.public_publish_requested", {
         objectId: "",
         destination: "create",
         actorKind: actorKindOf(req),
@@ -314,7 +316,7 @@ export const contentService = {
       // to "public" HERE without an explicit visibility, so emit the same
       // approval-queue signal before failing closed — otherwise SNS consumers
       // miss this denied-public-create case that Gate 1 covers.
-      await contentEvents.emit("content.public_publish_requested", {
+      void contentEvents.emit("content.public_publish_requested", {
         objectId: "",
         destination: "create",
         actorKind: actorKindOf(req),

--- a/lib/content/helpers.ts
+++ b/lib/content/helpers.ts
@@ -234,6 +234,11 @@ export function canPublishPublic(
  * explicitly-granted `content:publish_public` scope passes (admins still pass via
  * `req.isAdmin` inside the service).
  */
-export function hasPublishPublicScope(scopes: string[]): boolean {
-  return scopes.includes("content:publish_public");
+export function hasPublishPublicScope(
+  scopes: string[] | null | undefined
+): boolean {
+  // Null-safe: every call site passes a real `string[]` (auth/MCP `scopes`), but
+  // accepting null/undefined defensively means a malformed auth context can never
+  // turn this authority check into a runtime crash — it simply denies.
+  return scopes?.includes("content:publish_public") ?? false;
 }

--- a/lib/content/helpers.ts
+++ b/lib/content/helpers.ts
@@ -220,3 +220,20 @@ export function canPublishPublic(
     return req.scopes.includes("content:publish_public");
   return false;
 }
+
+/**
+ * Whether an authenticated API/MCP caller's token scopes include the EXPLICIT
+ * `content:publish_public` scope — the value the REST/MCP surfaces pass to the
+ * service's §26.4 gate as `hasPublishPublicCapability`.
+ *
+ * Every content REST route and MCP handler that resolves this authority computes
+ * the same `scopes.includes("content:publish_public")`; this is the single point
+ * of truth so the scope string is not hand-typed at ~7 call sites (a typo would
+ * silently fail-open — the gate would never see the scope). A `.includes` over the
+ * exact string, so a session wildcard `["*"]` deliberately does NOT match: only an
+ * explicitly-granted `content:publish_public` scope passes (admins still pass via
+ * `req.isAdmin` inside the service).
+ */
+export function hasPublishPublicScope(scopes: string[]): boolean {
+  return scopes.includes("content:publish_public");
+}

--- a/lib/content/helpers.ts
+++ b/lib/content/helpers.ts
@@ -228,11 +228,13 @@ export function canPublishPublic(
  *
  * Every content REST route and MCP handler that resolves this authority computes
  * the same `scopes.includes("content:publish_public")`; this is the single point
- * of truth so the scope string is not hand-typed at ~7 call sites (a typo would
- * silently fail-open — the gate would never see the scope). A `.includes` over the
- * exact string, so a session wildcard `["*"]` deliberately does NOT match: only an
- * explicitly-granted `content:publish_public` scope passes (admins still pass via
- * `req.isAdmin` inside the service).
+ * of truth so the scope string is not hand-typed at ~7 call sites. A typo at a
+ * call site would fail CLOSED (the scope would never be recognized, so an
+ * authorized caller is wrongly gated), which is safe but a silent, hard-to-spot
+ * bug — centralizing the literal removes that whole class of drift. A `.includes`
+ * over the exact string, so a session wildcard `["*"]` deliberately does NOT
+ * match: only an explicitly-granted `content:publish_public` scope passes (admins
+ * still pass via `req.isAdmin` inside the service).
  */
 export function hasPublishPublicScope(
   scopes: string[] | null | undefined

--- a/lib/content/helpers.ts
+++ b/lib/content/helpers.ts
@@ -8,7 +8,9 @@
  */
 
 import { ErrorFactories } from "@/lib/error-utils";
-import { ForbiddenError } from "./errors";
+import { ApprovalRequiredError, ForbiddenError } from "./errors";
+import { contentEvents } from "./events";
+import type { PublishDestination } from "./publish-adapters/types";
 import type { Principal, Requester } from "./types";
 
 /**
@@ -243,4 +245,41 @@ export function hasPublishPublicScope(
   // accepting null/undefined defensively means a malformed auth context can never
   // turn this authority check into a runtime crash — it simply denies.
   return scopes?.includes("content:publish_public") ?? false;
+}
+
+/**
+ * §26.4 — emit the approval-queue signal and throw `ApprovalRequiredError` for an
+ * unauthorized public exposure. Shared by every §26.4 gate site (`publishService`'s
+ * pre-tx destination check + in-tx visibility-widen check, and
+ * `visibilityService.setLevel`'s in-tx widen check) so the emitted event shape and
+ * fail-closed behavior stay identical everywhere this security boundary is
+ * enforced — a future gate site cannot drift by hand-rolling its own emit-then-throw.
+ *
+ * `eventPayload`/`errorContext` are passed through as-is (rather than derived from
+ * a single shape) because callers intentionally differ: `publishService` includes
+ * `slug`/`destination` in the emitted event (readable in the approval-queue UI)
+ * but only `destination`/`objectId` in the thrown error's `details`, while
+ * `visibilityService.setLevel` has no destination concept and passes `objectId`
+ * alone to both.
+ *
+ * `void` emit is fire-and-forget (best-effort; `emit` swallows its own errors and
+ * never rejects), safe even right before a throw — including inside a
+ * transaction, where the throw rolls the tx back.
+ */
+export function raisePublishApprovalRequired(
+  req: Requester,
+  message: string,
+  eventPayload: {
+    objectId: string;
+    slug?: string;
+    destination?: PublishDestination;
+  },
+  errorContext: Record<string, unknown>
+): never {
+  void contentEvents.emit("content.public_publish_requested", {
+    ...eventPayload,
+    actorKind: actorKindOf(req),
+    agentLabel: req.kind === "user" ? null : req.agentLabel,
+  });
+  throw new ApprovalRequiredError(message, errorContext);
 }

--- a/lib/content/index.ts
+++ b/lib/content/index.ts
@@ -51,6 +51,7 @@ export {
   assertCanEdit,
   canEdit,
   canPublishPublic,
+  hasPublishPublicScope,
   principalOf,
   slugifyTitle,
 } from "./helpers";

--- a/lib/content/index.ts
+++ b/lib/content/index.ts
@@ -33,6 +33,7 @@ export type {
 export {
   requesterFromApiAuth,
   buildDelegatedRequester,
+  buildAutonomousRequesterForIdentity,
 } from "./requester-from-auth";
 export type { RequesterAuthInput } from "./requester-from-auth";
 

--- a/lib/content/publish-service.ts
+++ b/lib/content/publish-service.ts
@@ -120,6 +120,23 @@ async function loadPublishable(
   return rows[0] ?? null;
 }
 
+/**
+ * Whether a publish request is an ACTUAL public exposure that the §26.4 gate must
+ * review. A `public_web` destination always is (its adapter is unimplemented today,
+ * so there is no already-live state to compare). Widening visibility to `public`
+ * only exposes when the object is not ALREADY public — re-saving already-public
+ * content (visibility unchanged) is an idempotent no-op, not a new exposure, so it
+ * must NOT trip the gate (spuriously throwing ApprovalRequiredError + emitting the
+ * approval event for a non-admin owner who changed nothing).
+ */
+function isPublicFacingPublish(
+  input: PublishInput,
+  currentLevel: VisibilityLevel
+): boolean {
+  if (input.destination === "public_web") return true;
+  return input.visibility?.level === "public" && currentLevel !== "public";
+}
+
 export const publishService = {
   /**
    * Publish (or republish) an object's working head to a destination. Idempotent
@@ -168,22 +185,11 @@ export const publishService = {
     // non-admin humans need the capability. When the caller is not authorized,
     // emit the approval-queue signal and raise the structured ApprovalRequiredError
     // (surfaces map it to 202 / `approval_required`) — never silently publish
-    // unreviewed content to families/the public.
-    //
-    // Gate on an ACTUAL public exposure, not the target value alone: widening
-    // visibility to `public` only exposes when the object is not ALREADY public
-    // (`obj.visibilityLevel !== "public"`). Re-saving already-public content by a
-    // non-admin owner (visibility unchanged) is an idempotent no-op that must NOT
-    // spuriously throw `ApprovalRequiredError` + emit the approval event — a
-    // widen that changes nothing is not a new exposure to review. A `public_web`
-    // destination is always public-facing (its adapter is unimplemented today, so
-    // there is no already-live state to compare against).
-    const isPublicFacing =
-      input.destination === "public_web" ||
-      (input.visibility?.level === "public" &&
-        obj.visibilityLevel !== "public");
+    // unreviewed content to families/the public. `isPublicFacingPublish` gates on
+    // an ACTUAL public exposure, not the target value alone (see its JSDoc: a no-op
+    // re-save of already-public content must not trip the gate).
     if (
-      isPublicFacing &&
+      isPublicFacingPublish(input, obj.visibilityLevel) &&
       !canPublishPublic(req, opts.hasPublishPublicCapability ?? false)
     ) {
       // Fire-and-forget (best-effort, matches the audit-write pattern):

--- a/lib/content/publish-service.ts
+++ b/lib/content/publish-service.ts
@@ -121,20 +121,30 @@ async function loadPublishable(
 }
 
 /**
- * Whether a publish request is an ACTUAL public exposure that the §26.4 gate must
- * review. A `public_web` destination always is (its adapter is unimplemented today,
- * so there is no already-live state to compare). Widening visibility to `public`
- * only exposes when the object is not ALREADY public — re-saving already-public
- * content (visibility unchanged) is an idempotent no-op, not a new exposure, so it
- * must NOT trip the gate (spuriously throwing ApprovalRequiredError + emitting the
- * approval event for a non-admin owner who changed nothing).
+ * §26.4 — emit the approval-queue signal and throw `ApprovalRequiredError` for an
+ * unauthorized public-facing publish. Shared by the two gate sites (the pre-tx
+ * `public_web` destination branch and the in-tx visibility-widen branch) so the
+ * emit shape + message stay identical. `void` emit is fire-and-forget (best-effort;
+ * `emit` swallows its own errors and never rejects), safe even right before a throw
+ * — including inside a transaction, where the throw rolls the tx back.
  */
-function isPublicFacingPublish(
-  input: PublishInput,
-  currentLevel: VisibilityLevel
-): boolean {
-  if (input.destination === "public_web") return true;
-  return input.visibility?.level === "public" && currentLevel !== "public";
+function raisePublishApprovalRequired(
+  req: Requester,
+  objectId: string,
+  slug: string,
+  destination: PublishDestination
+): never {
+  void contentEvents.emit("content.public_publish_requested", {
+    objectId,
+    slug,
+    destination,
+    actorKind: actorKindOf(req),
+    agentLabel: req.kind === "user" ? null : req.agentLabel,
+  });
+  throw new ApprovalRequiredError(
+    "Publishing to a public destination requires approval",
+    { destination, objectId }
+  );
 }
 
 export const publishService = {
@@ -179,33 +189,23 @@ export const publishService = {
     }
     assertCanEdit(req, obj.ownerUserId);
 
-    // §26.4 — the public-publish gate. Targeting a public-facing destination, or
-    // widening visibility to `public`, requires `content:publish_public`:
-    // autonomous agents never hold it, under-scoped delegated agents lack it, and
-    // non-admin humans need the capability. When the caller is not authorized,
-    // emit the approval-queue signal and raise the structured ApprovalRequiredError
-    // (surfaces map it to 202 / `approval_required`) — never silently publish
-    // unreviewed content to families/the public. `isPublicFacingPublish` gates on
-    // an ACTUAL public exposure, not the target value alone (see its JSDoc: a no-op
-    // re-save of already-public content must not trip the gate).
-    if (
-      isPublicFacingPublish(input, obj.visibilityLevel) &&
-      !canPublishPublic(req, opts.hasPublishPublicCapability ?? false)
-    ) {
-      // Fire-and-forget (best-effort, matches the audit-write pattern):
-      // `contentEvents.emit` swallows its own errors (`snsPublishBestEffort` never
-      // throws), so awaiting it only adds an SNS round-trip to the response path.
-      void contentEvents.emit("content.public_publish_requested", {
-        objectId,
-        slug: obj.slug,
-        destination: input.destination,
-        actorKind: actorKindOf(req),
-        agentLabel: req.kind === "user" ? null : req.agentLabel,
-      });
-      throw new ApprovalRequiredError(
-        "Publishing to a public destination requires approval",
-        { destination: input.destination, objectId }
-      );
+    // Whether this caller holds the §26.4 public-publish authority (pure, no IO).
+    const mayPublishPublic = canPublishPublic(
+      req,
+      opts.hasPublishPublicCapability ?? false
+    );
+
+    // §26.4 gate — PART 1 (destination), evaluated pre-transaction because it does
+    // NOT depend on the object's current visibility (a `public_web` destination is
+    // ALWAYS a public exposure) and so is race-free here. It runs BEFORE the
+    // adapter-not-implemented check below so an unauthorized caller gets the
+    // approval signal, not a "not yet available" error. PART 2 — widening
+    // visibility to `public` — DOES depend on the current level, so it is evaluated
+    // inside the transaction against the FOR-UPDATE-locked row (see below), closing
+    // the TOCTOU hole where a concurrent narrow (public → internal) between a
+    // pre-read and the locked write would skip the gate on a real widen-back.
+    if (input.destination === "public_web" && !mayPublishPublic) {
+      raisePublishApprovalRequired(req, objectId, obj.slug, input.destination);
     }
 
     // Nothing is live without a working head: the publication's
@@ -249,13 +249,31 @@ export const publishService = {
         // `loadPublishable` above, but re-select inside the tx (a concurrent delete
         // could have removed it between the load and this lock); a missing row 404s.
         const locked = await tx
-          .select({ id: contentObjects.id })
+          .select({
+            id: contentObjects.id,
+            visibilityLevel: contentObjects.visibilityLevel,
+          })
           .from(contentObjects)
           .where(eq(contentObjects.id, objectId))
           .for("update")
           .limit(1);
         if (!locked[0]) {
           throw new NotFoundError("Content not found", { objectId });
+        }
+
+        // §26.4 gate — PART 2 (visibility widen), evaluated HERE against the locked
+        // row's CURRENT visibility so it is race-free: a widen to `public` is gated
+        // iff the locked row is not ALREADY public. A concurrent narrow can no
+        // longer slip between the check and the widen (both hold this lock), so an
+        // unauthorized caller can never widen-back-to-public un-approved. A no-op
+        // re-save of already-public content is not a new exposure and passes.
+        // Throwing here rolls the transaction back, so nothing is widened/published.
+        if (
+          input.visibility?.level === "public" &&
+          locked[0].visibilityLevel !== "public" &&
+          !mayPublishPublic
+        ) {
+          raisePublishApprovalRequired(req, objectId, obj.slug, input.destination);
         }
 
         // Optionally widen visibility in the same tx so the status change and

--- a/lib/content/publish-service.ts
+++ b/lib/content/publish-service.ts
@@ -37,6 +37,7 @@ import {
   assertCanEdit,
   authorUserIdOf,
   canPublishPublic,
+  raisePublishApprovalRequired,
 } from "./helpers";
 import { visibilityService } from "./visibility-service";
 import { contentEvents } from "./events";
@@ -120,32 +121,11 @@ async function loadPublishable(
   return rows[0] ?? null;
 }
 
-/**
- * §26.4 — emit the approval-queue signal and throw `ApprovalRequiredError` for an
- * unauthorized public-facing publish. Shared by the two gate sites (the pre-tx
- * `public_web` destination branch and the in-tx visibility-widen branch) so the
- * emit shape + message stay identical. `void` emit is fire-and-forget (best-effort;
- * `emit` swallows its own errors and never rejects), safe even right before a throw
- * — including inside a transaction, where the throw rolls the tx back.
- */
-function raisePublishApprovalRequired(
-  req: Requester,
-  objectId: string,
-  slug: string,
-  destination: PublishDestination
-): never {
-  void contentEvents.emit("content.public_publish_requested", {
-    objectId,
-    slug,
-    destination,
-    actorKind: actorKindOf(req),
-    agentLabel: req.kind === "user" ? null : req.agentLabel,
-  });
-  throw new ApprovalRequiredError(
-    "Publishing to a public destination requires approval",
-    { destination, objectId }
-  );
-}
+// §26.4 — this publish path's two gate sites (the pre-tx `public_web` destination
+// branch and the in-tx visibility-widen branch, below) both raise via the shared
+// `raisePublishApprovalRequired` (in `./helpers`, also used by
+// `visibilityService.setLevel`) so the message + emitted event shape stay
+// identical across every §26.4 gate site.
 
 export const publishService = {
   /**
@@ -205,7 +185,12 @@ export const publishService = {
     // the TOCTOU hole where a concurrent narrow (public → internal) between a
     // pre-read and the locked write would skip the gate on a real widen-back.
     if (input.destination === "public_web" && !mayPublishPublic) {
-      raisePublishApprovalRequired(req, objectId, obj.slug, input.destination);
+      raisePublishApprovalRequired(
+        req,
+        "Publishing to a public destination requires approval",
+        { objectId, slug: obj.slug, destination: input.destination },
+        { destination: input.destination, objectId }
+      );
     }
 
     // Nothing is live without a working head: the publication's
@@ -273,7 +258,12 @@ export const publishService = {
           locked[0].visibilityLevel !== "public" &&
           !mayPublishPublic
         ) {
-          raisePublishApprovalRequired(req, objectId, obj.slug, input.destination);
+          raisePublishApprovalRequired(
+            req,
+            "Publishing to a public destination requires approval",
+            { objectId, slug: obj.slug, destination: input.destination },
+            { destination: input.destination, objectId }
+          );
         }
 
         // Optionally widen visibility in the same tx so the status change and

--- a/lib/content/publish-service.ts
+++ b/lib/content/publish-service.ts
@@ -169,13 +169,27 @@ export const publishService = {
     // emit the approval-queue signal and raise the structured ApprovalRequiredError
     // (surfaces map it to 202 / `approval_required`) — never silently publish
     // unreviewed content to families/the public.
+    //
+    // Gate on an ACTUAL public exposure, not the target value alone: widening
+    // visibility to `public` only exposes when the object is not ALREADY public
+    // (`obj.visibilityLevel !== "public"`). Re-saving already-public content by a
+    // non-admin owner (visibility unchanged) is an idempotent no-op that must NOT
+    // spuriously throw `ApprovalRequiredError` + emit the approval event — a
+    // widen that changes nothing is not a new exposure to review. A `public_web`
+    // destination is always public-facing (its adapter is unimplemented today, so
+    // there is no already-live state to compare against).
     const isPublicFacing =
-      input.destination === "public_web" || input.visibility?.level === "public";
+      input.destination === "public_web" ||
+      (input.visibility?.level === "public" &&
+        obj.visibilityLevel !== "public");
     if (
       isPublicFacing &&
       !canPublishPublic(req, opts.hasPublishPublicCapability ?? false)
     ) {
-      await contentEvents.emit("content.public_publish_requested", {
+      // Fire-and-forget (best-effort, matches the audit-write pattern):
+      // `contentEvents.emit` swallows its own errors (`snsPublishBestEffort` never
+      // throws), so awaiting it only adds an SNS round-trip to the response path.
+      void contentEvents.emit("content.public_publish_requested", {
         objectId,
         slug: obj.slug,
         destination: input.destination,
@@ -344,8 +358,10 @@ export const publishService = {
 
     // Emit AFTER the commit + adapter side effect, exactly once per successful
     // publish (§27): re-index for retrieval, run connector pushes, notify. Best
-    // effort — a bus failure never rolls back the publish.
-    await contentEvents.emit("content.published", {
+    // effort — a bus failure never rolls back the publish. Fire-and-forget (`void`,
+    // not `await`): `emit` swallows its own errors, so awaiting only holds the
+    // response open for an SNS round-trip (matches the audit-write pattern).
+    void contentEvents.emit("content.published", {
       objectId,
       slug: obj.slug,
       versionId: publishedVersionId,
@@ -488,7 +504,8 @@ export const publishService = {
 
     // Emit after the commit + adapter teardown, only when a live publication was
     // actually removed (the `unpublished: false` no-op path returned above).
-    await contentEvents.emit("content.unpublished", {
+    // Fire-and-forget (`void`, not `await`): best-effort, never blocks the response.
+    void contentEvents.emit("content.unpublished", {
       objectId,
       slug: obj.slug,
       destination,

--- a/lib/content/requester-from-auth.ts
+++ b/lib/content/requester-from-auth.ts
@@ -181,7 +181,10 @@ export async function buildAutonomousRequesterForIdentity(
     agentId: identity.id,
     roleId: identity.roleId,
     roles: identity.roleName ? [identity.roleName] : [],
-    scopes: identity.scopes,
+    // `agent_identities.scopes` is NOT NULL (text[].notNull), so this is never
+    // null in practice — but coalesce defensively so a malformed/legacy row (or a
+    // test double) can never make a downstream `req.scopes.includes(...)` throw.
+    scopes: identity.scopes ?? [],
     agentLabel: identity.name,
   };
 }

--- a/lib/content/requester-from-auth.ts
+++ b/lib/content/requester-from-auth.ts
@@ -113,6 +113,80 @@ async function findAgentIdentity(oauthClientId: string): Promise<{
 }
 
 /**
+ * Look up the active autonomous agent identity by its PRIMARY KEY (`agent_identities.id`),
+ * including its own `scopes` column. Distinct from `findAgentIdentity` (which keys on
+ * `oauthClientId` and reads scopes from the OAuth token): a scheduled run has NO
+ * token, so the identity's authority MUST come from the row itself.
+ */
+async function findAgentIdentityById(agentIdentityId: string): Promise<{
+  id: string;
+  name: string;
+  roleId: number | null;
+  roleName: string | null;
+  scopes: string[];
+} | null> {
+  const rows = await executeQuery(
+    (db) =>
+      db
+        .select({
+          id: agentIdentities.id,
+          name: agentIdentities.name,
+          roleId: agentIdentities.roleId,
+          roleName: roles.name,
+          scopes: agentIdentities.scopes,
+        })
+        .from(agentIdentities)
+        .leftJoin(roles, eq(agentIdentities.roleId, roles.id))
+        .where(
+          and(
+            eq(agentIdentities.id, agentIdentityId),
+            eq(agentIdentities.isActive, true)
+          )
+        )
+        .limit(1),
+    "atrium.requesterFromAuth.findAgentById"
+  );
+  return rows[0] ?? null;
+}
+
+/**
+ * Build an `agent-autonomous` Requester from an `agent_identities.id` — the
+ * identity-first path a SCHEDULED Assistant Architect run uses (§25). Unlike
+ * `requesterFromApiAuth` (token-first: scopes come from the OAuth token), the
+ * scopes here come from the identity row, because a scheduled run carries no token.
+ *
+ * Fails CLOSED: throws `ForbiddenError` when the identity is missing, inactive, or
+ * deleted. A scheduled run that requested a specific service identity must NOT
+ * silently degrade to running as the owning user (that would grant the run the
+ * user's full human authority instead of the identity's bounded scopes) — the
+ * caller surfaces the failure so an operator who deactivated an identity sees the
+ * run stop, not quietly run with the wrong authority.
+ */
+export async function buildAutonomousRequesterForIdentity(
+  agentIdentityId: string
+): Promise<Requester> {
+  const log = createLogger({ action: "atrium.autonomousRequesterForIdentity" });
+  const identity = await findAgentIdentityById(agentIdentityId);
+  if (!identity) {
+    throw new ForbiddenError("No active agent identity for this id", {
+      agentIdentityId,
+    });
+  }
+  log.debug("Resolved agent-autonomous requester by id", {
+    agentId: identity.id,
+    agentLabel: identity.name,
+  });
+  return {
+    kind: "agent-autonomous",
+    agentId: identity.id,
+    roleId: identity.roleId,
+    roles: identity.roleName ? [identity.roleName] : [],
+    scopes: identity.scopes,
+    agentLabel: identity.name,
+  };
+}
+
+/**
  * Build the `agent-delegated` requester. Exposed (and unit-tested) on its own so
  * the grant-inheritance invariant is explicit: it carries the human's roles/org
  * but `principalOf` forces `isAdmin:false`, so a delegated agent can NEVER exceed

--- a/lib/content/version-service.ts
+++ b/lib/content/version-service.ts
@@ -339,8 +339,10 @@ export const versionService = {
     await flushSnapshotWrites(s3Writes);
 
     // Emit after the row commits + blobs flush (§27): drives re-index of the new
-    // head. Best-effort — never rolls back a committed version.
-    await contentEvents.emit("content.version_created", {
+    // head. Best-effort — never rolls back a committed version. Fire-and-forget
+    // (`void`, not `await`): `emit` swallows its own errors, so awaiting only holds
+    // the response open for an SNS round-trip (matches the audit-write pattern).
+    void contentEvents.emit("content.version_created", {
       objectId: obj.id,
       versionId: version.id,
       actorKind: actorKindOf(req),

--- a/lib/content/visibility-service.ts
+++ b/lib/content/visibility-service.ts
@@ -22,10 +22,13 @@ import {
   contentObjects,
   contentVisibilityGrants,
 } from "@/lib/db/schema";
-import { actorKindOf, canPublishPublic, principalOf } from "./helpers";
+import {
+  canPublishPublic,
+  principalOf,
+  raisePublishApprovalRequired,
+} from "./helpers";
 import { objectSelectFields, rowToObjectDTO, type ObjectRowAsText } from "./mappers";
-import { contentEvents } from "./events";
-import { ApprovalRequiredError, NotFoundError, ValidationError } from "./errors";
+import { NotFoundError, ValidationError } from "./errors";
 import { GRANT_KIND_SET, POSITIVE_INT_RE, VISIBILITY_LEVEL_SET } from "./validators";
 import type {
   ContentObjectDTO,
@@ -562,15 +565,13 @@ export const visibilityService = {
         rows[0].visibilityLevel !== "public" &&
         !mayPublishPublic
       ) {
-        // Fire-and-forget (best-effort): `emit` swallows its own errors and never
-        // rejects, so this detached promise cannot leave the tx in a bad state.
-        void contentEvents.emit("content.public_publish_requested", {
-          objectId,
-          actorKind: actorKindOf(req),
-          agentLabel: req.kind === "user" ? null : req.agentLabel,
-        });
-        throw new ApprovalRequiredError(
+        // Shared with `publishService`'s visibility-widen gate (`./helpers`) so the
+        // emitted event shape + fail-closed behavior stay identical across every
+        // §26.4 gate site.
+        raisePublishApprovalRequired(
+          req,
           "Widening visibility to public requires approval",
+          { objectId },
           { objectId }
         );
       }

--- a/lib/content/visibility-service.ts
+++ b/lib/content/visibility-service.ts
@@ -365,29 +365,6 @@ async function clearNonUserGrantsInTx(
     );
 }
 
-/**
- * Load an object's current visibility level, or null when the object is absent.
- * Used by `setLevel`'s §26.4 gate to distinguish a genuine widen-to-public (a new
- * exposure that needs review) from an idempotent re-save of already-public content
- * (unchanged level → no new exposure). A null result (absent object) is treated by
- * the caller as "not already public" — the transaction's FOR UPDATE guard then
- * surfaces the missing object as a clean 404.
- */
-async function currentVisibilityLevel(
-  objectId: string
-): Promise<VisibilityLevel | null> {
-  const rows = await executeQuery(
-    (db) =>
-      db
-        .select({ visibilityLevel: contentObjects.visibilityLevel })
-        .from(contentObjects)
-        .where(eq(contentObjects.id, objectId))
-        .limit(1),
-    "content.currentVisibilityLevel"
-  );
-  return rows[0]?.visibilityLevel ?? null;
-}
-
 /** Load the normalized grants for an object. */
 async function grantsFor(objectId: string): Promise<VisibilityGrant[]> {
   const rows = await executeQuery(
@@ -545,25 +522,48 @@ export const visibilityService = {
     visibility: VisibilityInput,
     opts: { hasPublishPublicCapability?: boolean } = {}
   ): Promise<{ visibilityLevel: VisibilityLevel }> {
-    // §26.4 — gate on an ACTUAL public exposure, not the target value alone.
-    // Setting the level to `public` only exposes when the object is not ALREADY
-    // public: re-saving already-public content (level unchanged) by a non-admin
-    // owner is an idempotent no-op that must NOT spuriously throw
-    // `ApprovalRequiredError` + emit the approval event. Load the current level
-    // ONLY when the target is `public` (the sole gated case) so a private/group/
-    // internal write pays no extra read. A missing object here is not
-    // authoritative existence-masking — the callers already ran `canView` +
-    // `assertCanEdit` before calling; if the row was concurrently deleted, the
-    // FOR UPDATE guard inside the transaction below still 404s.
-    if (visibility.level === "public") {
-      const currentLevel = await currentVisibilityLevel(objectId);
-      const isNewExposure = currentLevel !== "public";
+    // Whether this caller holds the §26.4 public-publish authority (pure, no IO).
+    // The ACTUAL gate decision (is this a NEW public exposure?) is made INSIDE the
+    // transaction against the FOR-UPDATE-locked level — never against a pre-lock
+    // read. Deciding it before the lock is a TOCTOU hole: a concurrent narrow
+    // (public → internal) between the read and the locked write would leave the
+    // "already public → no-op" branch taken against a stale `public`, letting an
+    // unauthorized widen-back-to-public slip past approval.
+    const mayPublishPublic = canPublishPublic(
+      req,
+      opts.hasPublishPublicCapability ?? false
+    );
+    await executeTransaction(async (tx) => {
+      // Guard against a missing object inside the tx so the level write does not
+      // silently no-op (UPDATE ... WHERE id = <absent> affects zero rows). Lock
+      // the row FOR UPDATE so a concurrent delete cannot slip between this check
+      // and the setLevelInTx update, and read the CURRENT level under the same lock
+      // for the §26.4 gate below (race-free).
+      const rows = await tx
+        .select({
+          id: contentObjects.id,
+          visibilityLevel: contentObjects.visibilityLevel,
+        })
+        .from(contentObjects)
+        .where(eq(contentObjects.id, objectId))
+        .for("update")
+        .limit(1);
+      if (!rows[0]) {
+        throw new NotFoundError("Content not found", { objectId });
+      }
+
+      // §26.4 — widening to `public` is gated iff the locked row is not ALREADY
+      // public (a no-op re-save of already-public content is not a new exposure and
+      // passes). Same privilege boundary as `publishService.publish`'s widen; here
+      // it is race-free because the check reads the level under the FOR UPDATE lock
+      // held through the write. Throwing rolls the transaction back — nothing widens.
       if (
-        isNewExposure &&
-        !canPublishPublic(req, opts.hasPublishPublicCapability ?? false)
+        visibility.level === "public" &&
+        rows[0].visibilityLevel !== "public" &&
+        !mayPublishPublic
       ) {
-        // Fire-and-forget (best-effort, matches the audit-write pattern): `emit`
-        // swallows its own errors, so awaiting only adds an SNS round-trip.
+        // Fire-and-forget (best-effort): `emit` swallows its own errors and never
+        // rejects, so this detached promise cannot leave the tx in a bad state.
         void contentEvents.emit("content.public_publish_requested", {
           objectId,
           actorKind: actorKindOf(req),
@@ -574,21 +574,7 @@ export const visibilityService = {
           { objectId }
         );
       }
-    }
-    await executeTransaction(async (tx) => {
-      // Guard against a missing object inside the tx so the level write does not
-      // silently no-op (UPDATE ... WHERE id = <absent> affects zero rows). Lock
-      // the row FOR UPDATE so a concurrent delete cannot slip between this check
-      // and the setLevelInTx update.
-      const rows = await tx
-        .select({ id: contentObjects.id })
-        .from(contentObjects)
-        .where(eq(contentObjects.id, objectId))
-        .for("update")
-        .limit(1);
-      if (!rows[0]) {
-        throw new NotFoundError("Content not found", { objectId });
-      }
+
       await setLevelInTx(tx, objectId, visibility);
     }, "content.setLevel");
     return { visibilityLevel: visibility.level };

--- a/lib/content/visibility-service.ts
+++ b/lib/content/visibility-service.ts
@@ -365,6 +365,29 @@ async function clearNonUserGrantsInTx(
     );
 }
 
+/**
+ * Load an object's current visibility level, or null when the object is absent.
+ * Used by `setLevel`'s §26.4 gate to distinguish a genuine widen-to-public (a new
+ * exposure that needs review) from an idempotent re-save of already-public content
+ * (unchanged level → no new exposure). A null result (absent object) is treated by
+ * the caller as "not already public" — the transaction's FOR UPDATE guard then
+ * surfaces the missing object as a clean 404.
+ */
+async function currentVisibilityLevel(
+  objectId: string
+): Promise<VisibilityLevel | null> {
+  const rows = await executeQuery(
+    (db) =>
+      db
+        .select({ visibilityLevel: contentObjects.visibilityLevel })
+        .from(contentObjects)
+        .where(eq(contentObjects.id, objectId))
+        .limit(1),
+    "content.currentVisibilityLevel"
+  );
+  return rows[0]?.visibilityLevel ?? null;
+}
+
 /** Load the normalized grants for an object. */
 async function grantsFor(objectId: string): Promise<VisibilityGrant[]> {
   const rows = await executeQuery(
@@ -522,19 +545,35 @@ export const visibilityService = {
     visibility: VisibilityInput,
     opts: { hasPublishPublicCapability?: boolean } = {}
   ): Promise<{ visibilityLevel: VisibilityLevel }> {
-    if (
-      visibility.level === "public" &&
-      !canPublishPublic(req, opts.hasPublishPublicCapability ?? false)
-    ) {
-      await contentEvents.emit("content.public_publish_requested", {
-        objectId,
-        actorKind: actorKindOf(req),
-        agentLabel: req.kind === "user" ? null : req.agentLabel,
-      });
-      throw new ApprovalRequiredError(
-        "Widening visibility to public requires approval",
-        { objectId }
-      );
+    // §26.4 — gate on an ACTUAL public exposure, not the target value alone.
+    // Setting the level to `public` only exposes when the object is not ALREADY
+    // public: re-saving already-public content (level unchanged) by a non-admin
+    // owner is an idempotent no-op that must NOT spuriously throw
+    // `ApprovalRequiredError` + emit the approval event. Load the current level
+    // ONLY when the target is `public` (the sole gated case) so a private/group/
+    // internal write pays no extra read. A missing object here is not
+    // authoritative existence-masking — the callers already ran `canView` +
+    // `assertCanEdit` before calling; if the row was concurrently deleted, the
+    // FOR UPDATE guard inside the transaction below still 404s.
+    if (visibility.level === "public") {
+      const currentLevel = await currentVisibilityLevel(objectId);
+      const isNewExposure = currentLevel !== "public";
+      if (
+        isNewExposure &&
+        !canPublishPublic(req, opts.hasPublishPublicCapability ?? false)
+      ) {
+        // Fire-and-forget (best-effort, matches the audit-write pattern): `emit`
+        // swallows its own errors, so awaiting only adds an SNS round-trip.
+        void contentEvents.emit("content.public_publish_requested", {
+          objectId,
+          actorKind: actorKindOf(req),
+          agentLabel: req.kind === "user" ? null : req.agentLabel,
+        });
+        throw new ApprovalRequiredError(
+          "Widening visibility to public requires approval",
+          { objectId }
+        );
+      }
     }
     await executeTransaction(async (tx) => {
       // Guard against a missing object inside the tx so the level write does not

--- a/lib/mcp/content-tool-handlers.ts
+++ b/lib/mcp/content-tool-handlers.ts
@@ -16,6 +16,7 @@ import { z } from "zod";
 import {
   ApprovalRequiredError,
   contentService,
+  hasPublishPublicScope,
   isContentError,
   publishService,
   recordContentAudit,
@@ -183,9 +184,7 @@ async function createContent(
     // Session humans must also hold the atrium-content capability (see helper).
     await assertContentAuthoringCapability(context);
     const collectionId = await resolveCollectionId(common.collection);
-    const hasPublishPublicCapability = context.scopes.includes(
-      "content:publish_public"
-    );
+    const hasPublishPublicCapability = hasPublishPublicScope(context.scopes);
     const created = await contentService.create(
       req,
       {
@@ -452,9 +451,7 @@ async function handleSetVisibility(
     // inside `setLevel` itself (§26.4) — same authority key as `publish_content`:
     // an EXPLICIT content:publish_public scope, never the session wildcard.
     const obj = await contentService.loadForEdit(req, parsed.data.id);
-    const hasPublishPublicCapability = context.scopes.includes(
-      "content:publish_public"
-    );
+    const hasPublishPublicCapability = hasPublishPublicScope(context.scopes);
     const result = await visibilityService.setLevel(
       req,
       obj.id,
@@ -505,9 +502,7 @@ async function handlePublishContent(
     // content:publish_public scope. A session's wildcard ["*"] must NOT auto-grant
     // it (every logged-in human would otherwise bypass the gate) — admin humans
     // still pass via req.isAdmin inside the service.
-    const hasPublishPublicCapability = context.scopes.includes(
-      "content:publish_public"
-    );
+    const hasPublishPublicCapability = hasPublishPublicScope(context.scopes);
     const result = await publishService.publish(
       req,
       parsed.data.id,

--- a/lib/oauth/drizzle-adapter.ts
+++ b/lib/oauth/drizzle-adapter.ts
@@ -21,6 +21,7 @@ import {
   oauthRefreshTokens,
 } from "@/lib/db/schema"
 import { createLogger } from "@/lib/logger"
+import { systemUserIdOrNull } from "@/lib/content/helpers"
 import { createHash } from "node:crypto"
 
 // ============================================
@@ -316,13 +317,16 @@ class DrizzleAdapter implements Adapter {
     const accountUserId = Number.parseInt(payload.accountId as string, 10)
     let userId = accountUserId
     if (Number.isNaN(userId)) {
-      const sysId = Number.parseInt(process.env.ATRIUM_SYSTEM_USER_ID ?? "", 10)
-      if (Number.isNaN(sysId)) {
-        // Operator misconfiguration (missing env var), not a type check —
-        // prefer-type-error's heuristic misreads the surrounding isNaN guard.
-        // eslint-disable-next-line unicorn/prefer-type-error
+      // Validate via the shared `systemUserIdOrNull()` (requires
+      // Number.isInteger(id) && id > 0) rather than a bare `!Number.isNaN(parseInt)`
+      // — the latter accepts `-1`, `1.5` (parseInt truncates → 1), and trailing
+      // garbage ("3abc"), any of which would insert a bogus owner id. A null here
+      // is an operator misconfiguration (missing/invalid env var), not bad client
+      // input, so surface it as a clear error.
+      const sysId = systemUserIdOrNull()
+      if (sysId == null) {
         throw new Error(
-          "Cannot persist a user-less access token (client_credentials) without ATRIUM_SYSTEM_USER_ID"
+          "Cannot persist a user-less access token (client_credentials) without a valid ATRIUM_SYSTEM_USER_ID (positive integer)"
         )
       }
       userId = sysId

--- a/tests/components/use-editor-actions.test.ts
+++ b/tests/components/use-editor-actions.test.ts
@@ -1,0 +1,130 @@
+/**
+ * useEditorActions hook tests (#1054 extract; §26.4 approval wiring, #1090).
+ *
+ * Covers the toolbar-action state machine the editor renders from:
+ *  - a successful publish/unpublish sets a neutral (non-error, non-pending) caption
+ *  - a §26.4 `approvalRequired` result maps to the amber `pendingApproval` state,
+ *    NOT the red `actionError` state (the regression this issue fixes: publish /
+ *    unpublish previously branched only on isSuccess, so a pending-approval outcome
+ *    was shown as a failure)
+ *  - a genuine failure still sets `actionError`
+ *
+ * The three server actions are mocked so the hook runs without a session/DB.
+ */
+
+import { renderHook, act, waitFor } from "@testing-library/react";
+import type { RefObject } from "react";
+
+const mockPublish =
+  jest.fn<Promise<unknown>, [string, { destination: string }]>();
+const mockUnpublish =
+  jest.fn<Promise<unknown>, [string, { destination: string }]>();
+const mockSnapshot = jest.fn<Promise<unknown>, [string, { body: string }]>();
+
+jest.mock("@/actions/db/atrium/publish-document", () => ({
+  publishDocumentAction: (...args: [string, { destination: string }]) =>
+    mockPublish(...args),
+}));
+jest.mock("@/actions/db/atrium/unpublish-document", () => ({
+  unpublishDocumentAction: (...args: [string, { destination: string }]) =>
+    mockUnpublish(...args),
+}));
+jest.mock("@/actions/db/atrium/snapshot-document", () => ({
+  snapshotDocumentAction: (...args: [string, { body: string }]) =>
+    mockSnapshot(...args),
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { useEditorActions } = require("@/components/atrium/use-editor-actions");
+
+// A resolved-UUID ref (the buttons only render once this is set); `editor` is not
+// touched by publish/unpublish, so null is fine for those paths.
+const docNameRef = { current: "obj-123" } as RefObject<string | null>;
+
+function setup() {
+  return renderHook(() =>
+    useEditorActions({ editor: null, idOrSlug: "my-slug", docNameRef })
+  );
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("useEditorActions — publish", () => {
+  it("maps a §26.4 approvalRequired result to pendingApproval (amber), not an error", async () => {
+    mockPublish.mockResolvedValue({
+      isSuccess: false,
+      approvalRequired: true,
+      message: "Publishing to this destination requires administrator approval.",
+    });
+
+    const { result } = setup();
+    act(() => result.current.handlePublish());
+
+    await waitFor(() => expect(result.current.busy).toBe(false));
+    expect(result.current.pendingApproval).toBe(true);
+    expect(result.current.actionError).toBe(false);
+    expect(result.current.message).toContain("approval");
+  });
+
+  it("sets a neutral success caption on a successful publish", async () => {
+    mockPublish.mockResolvedValue({ isSuccess: true, data: {} });
+
+    const { result } = setup();
+    act(() => result.current.handlePublish());
+
+    await waitFor(() => expect(result.current.busy).toBe(false));
+    expect(result.current.pendingApproval).toBe(false);
+    expect(result.current.actionError).toBe(false);
+    expect(result.current.message).toBe("Published to intranet");
+  });
+
+  it("sets actionError on a genuine publish failure", async () => {
+    mockPublish.mockResolvedValue({ isSuccess: false, message: "Publish failed" });
+
+    const { result } = setup();
+    act(() => result.current.handlePublish());
+
+    await waitFor(() => expect(result.current.busy).toBe(false));
+    expect(result.current.actionError).toBe(true);
+    expect(result.current.pendingApproval).toBe(false);
+  });
+});
+
+describe("useEditorActions — unpublish", () => {
+  beforeEach(() => {
+    // handleUnpublish confirms first; auto-confirm in the test environment.
+    jest.spyOn(window, "confirm").mockReturnValue(true);
+  });
+
+  it("maps a §26.4 approvalRequired unpublish result to pendingApproval, not an error", async () => {
+    mockUnpublish.mockResolvedValue({
+      isSuccess: false,
+      approvalRequired: true,
+      message: "Unpublishing requires administrator approval.",
+    });
+
+    const { result } = setup();
+    act(() => result.current.handleUnpublish());
+
+    await waitFor(() => expect(result.current.busy).toBe(false));
+    expect(result.current.pendingApproval).toBe(true);
+    expect(result.current.actionError).toBe(false);
+  });
+
+  it("reports the idempotent 'not currently published' outcome as a neutral success", async () => {
+    mockUnpublish.mockResolvedValue({
+      isSuccess: true,
+      data: { unpublished: false },
+    });
+
+    const { result } = setup();
+    act(() => result.current.handleUnpublish());
+
+    await waitFor(() => expect(result.current.busy).toBe(false));
+    expect(result.current.actionError).toBe(false);
+    expect(result.current.pendingApproval).toBe(false);
+    expect(result.current.message).toBe("Not currently published");
+  });
+});

--- a/tests/unit/atrium-content-helpers.test.ts
+++ b/tests/unit/atrium-content-helpers.test.ts
@@ -30,6 +30,7 @@ import {
   authorUserIdOf,
   canEdit,
   canPublishPublic,
+  hasPublishPublicScope,
   principalOf,
   scopesOf,
   slugCandidate,
@@ -245,6 +246,22 @@ describe("canPublishPublic (§26.4)", () => {
       scopes: ["content:publish_public"],
     };
     expect(canPublishPublic(withScope, true)).toBe(false);
+  });
+});
+
+describe("hasPublishPublicScope (REST/MCP scope check)", () => {
+  it("true only when the EXPLICIT content:publish_public scope is present", () => {
+    expect(hasPublishPublicScope(["content:create", "content:publish_public"])).toBe(true);
+    expect(hasPublishPublicScope(["content:create", "content:publish_internal"])).toBe(false);
+  });
+  it("does NOT treat a session wildcard as the scope (no fail-open)", () => {
+    // A session's ["*"] must not auto-grant the public-publish authority.
+    expect(hasPublishPublicScope(["*"])).toBe(false);
+  });
+  it("is null/undefined-safe: denies rather than throwing on a malformed context", () => {
+    expect(hasPublishPublicScope(null)).toBe(false);
+    expect(hasPublishPublicScope(undefined)).toBe(false);
+    expect(hasPublishPublicScope([])).toBe(false);
   });
 });
 

--- a/tests/unit/atrium-public-visibility-gate.test.ts
+++ b/tests/unit/atrium-public-visibility-gate.test.ts
@@ -235,33 +235,52 @@ describe("§26.4 gate — contentService.create with visibility.level = 'public'
 });
 
 describe("§26.4 gate — visibilityService.setLevel to 'public'", () => {
+  // The gate now runs INSIDE the transaction against the FOR-UPDATE-locked row
+  // (race-free), so a REJECTED widen still OPENS a transaction, reads the locked
+  // level, then throws ApprovalRequiredError — which rolls the tx back (nothing is
+  // written). Each rejected case seeds the lock lookup with a NON-public locked row
+  // so the gate is reached (a public locked row would be an idempotent no-op).
   it("REJECTS a non-admin user without publish_public (ApprovalRequiredError, no write)", async () => {
+    txResults = [[{ id: "o1", visibilityLevel: "internal" }]];
     await expect(
       visibilityService.setLevel(staffUser, "o1", { level: "public" })
     ).rejects.toThrow(ApprovalRequiredError);
-    expect(executeTransactionCalls).toBe(0); // level unchanged
     expect(emitCalls.map((c) => c.type)).toContain(
       "content.public_publish_requested"
     );
   });
 
   it("REJECTS an autonomous agent widening to public", async () => {
+    txResults = [[{ id: "o1", visibilityLevel: "internal" }]];
     await expect(
       visibilityService.setLevel(autonomousAgent, "o1", { level: "public" })
     ).rejects.toThrow(ApprovalRequiredError);
-    expect(executeTransactionCalls).toBe(0);
   });
 
   it("REJECTS a delegated agent lacking the publish_public grant", async () => {
+    txResults = [[{ id: "o1", visibilityLevel: "internal" }]];
     await expect(
       visibilityService.setLevel(delegatedNoGrant, "o1", { level: "public" })
     ).rejects.toThrow(ApprovalRequiredError);
-    expect(executeTransactionCalls).toBe(0);
+  });
+
+  it("does NOT gate a no-op re-save of ALREADY-public content (idempotent, race-safe)", async () => {
+    // The locked row is already public → widening to public changes nothing, so a
+    // non-admin owner without publish_public must pass WITHOUT approval (the exact
+    // regression #1090 fixes), and the check reads the level UNDER the lock.
+    txResults = [[{ id: "o1", visibilityLevel: "public" }]];
+    await expect(
+      visibilityService.setLevel(staffUser, "o1", { level: "public" })
+    ).resolves.toEqual({ visibilityLevel: "public" });
+    expect(
+      emitCalls.some((c) => c.type === "content.public_publish_requested")
+    ).toBe(false);
   });
 
   it("ALLOWS an admin to widen to public (proceeds to the write path)", async () => {
-    // Admin passes the gate; the write runs against the mocked tx (row present).
-    txResults = [[{ id: "o1" }]]; // FOR UPDATE lock finds the row
+    // Admin passes the gate; the write runs against the mocked tx. The locked row
+    // is currently internal (a genuine widen), and admin authority skips the gate.
+    txResults = [[{ id: "o1", visibilityLevel: "internal" }]];
     await expect(
       visibilityService.setLevel(adminUser, "o1", { level: "public" })
     ).resolves.toEqual({ visibilityLevel: "public" });
@@ -273,7 +292,7 @@ describe("§26.4 gate — visibilityService.setLevel to 'public'", () => {
   });
 
   it("ALLOWS a user WITH the explicit publish_public capability", async () => {
-    txResults = [[{ id: "o1" }]];
+    txResults = [[{ id: "o1", visibilityLevel: "internal" }]];
     await expect(
       visibilityService.setLevel(
         staffUser,
@@ -285,7 +304,7 @@ describe("§26.4 gate — visibilityService.setLevel to 'public'", () => {
   });
 
   it("does NOT gate a non-public setLevel (group/internal pass the gate)", async () => {
-    txResults = [[{ id: "o1" }]];
+    txResults = [[{ id: "o1", visibilityLevel: "private" }]];
     await expect(
       visibilityService.setLevel(staffUser, "o1", { level: "internal" })
     ).resolves.toEqual({ visibilityLevel: "internal" });

--- a/tests/unit/atrium-public-visibility-gate.test.ts
+++ b/tests/unit/atrium-public-visibility-gate.test.ts
@@ -11,9 +11,11 @@
  *
  * These tests prove the gate now fires on BOTH paths for callers WITHOUT
  * `content:publish_public`, and that authorized callers (admin / explicit
- * capability / delegated-with-grant) still pass. The gate runs BEFORE any DB
- * write, so the DB layer is mocked to fail loudly if it is reached on a rejected
- * request (asserting "nothing was written").
+ * capability / delegated-with-grant) still pass. On the `create` path the gate
+ * runs BEFORE any DB write (`executeTransactionCalls` stays 0 on rejection). On
+ * the `setLevel` path the gate runs INSIDE the transaction against the
+ * FOR-UPDATE-locked row (race-free — see #1090), so a rejection still opens a
+ * transaction; `txUpdateCalls` instead asserts the row UPDATE itself never runs.
  */
 
 // --- mocks (hoisted above imports by jest) ---
@@ -30,10 +32,18 @@ let executeQueryResults: unknown[] = [];
 // lets an ALLOWED (gate-passing) setLevel run its FOR UPDATE lookup + UPDATE
 // against a deterministic in-memory result instead of a real DB.
 let txResults: unknown[] = [];
+// Counts calls to `tx.update(...)` specifically — distinct from the FOR UPDATE
+// `.limit()` lock read — so a rejected gate can assert the row write itself
+// never ran, not just that `.limit()` (also used by the lock read) was called.
+let txUpdateCalls = 0;
 const txChain: Record<string, unknown> = {};
 const txProxy: unknown = new Proxy(txChain, {
   get(_t, prop: string | symbol) {
     if (prop === "then") return undefined;
+    if (prop === "update") {
+      txUpdateCalls += 1;
+      return () => txProxy;
+    }
     if (prop === "returning" || prop === "limit") {
       return () => (txResults.length ? txResults.shift() : []);
     }
@@ -130,6 +140,7 @@ const delegatedWithGrant: Requester = {
 beforeEach(() => {
   executeTransactionCalls = 0;
   executeQueryCalls = 0;
+  txUpdateCalls = 0;
   emitCalls = [];
   txResults = [];
   executeQueryResults = [];
@@ -248,6 +259,9 @@ describe("§26.4 gate — visibilityService.setLevel to 'public'", () => {
     expect(emitCalls.map((c) => c.type)).toContain(
       "content.public_publish_requested"
     );
+    // The gate must reject before the row UPDATE — a reorder that ran
+    // setLevelInTx first would still throw here but would have already written.
+    expect(txUpdateCalls).toBe(0);
   });
 
   it("REJECTS an autonomous agent widening to public", async () => {
@@ -255,6 +269,7 @@ describe("§26.4 gate — visibilityService.setLevel to 'public'", () => {
     await expect(
       visibilityService.setLevel(autonomousAgent, "o1", { level: "public" })
     ).rejects.toThrow(ApprovalRequiredError);
+    expect(txUpdateCalls).toBe(0);
   });
 
   it("REJECTS a delegated agent lacking the publish_public grant", async () => {
@@ -262,6 +277,7 @@ describe("§26.4 gate — visibilityService.setLevel to 'public'", () => {
     await expect(
       visibilityService.setLevel(delegatedNoGrant, "o1", { level: "public" })
     ).rejects.toThrow(ApprovalRequiredError);
+    expect(txUpdateCalls).toBe(0);
   });
 
   it("does NOT gate a no-op re-save of ALREADY-public content (idempotent, race-safe)", async () => {

--- a/tests/unit/atrium-publish-service.test.ts
+++ b/tests/unit/atrium-publish-service.test.ts
@@ -211,13 +211,32 @@ describe("publishService.publish", () => {
   });
 
   it("throws ApprovalRequiredError when widening visibility to public without publish_public", async () => {
-    // Public-facing is destination OR a visibility widening to `public`.
+    // A visibility widen to `public` is gated INSIDE the transaction against the
+    // FOR-UPDATE-locked level (race-free). Seed the lock lookup with a non-public
+    // locked row so the widen is a genuine new exposure and the gate fires.
+    txResults = [[{ id: "o1", visibilityLevel: "internal" }]];
     await expect(
       publishService.publish(owner, "o1", {
         destination: "intranet",
         visibility: { level: "public" },
       })
     ).rejects.toThrow(ApprovalRequiredError);
+  });
+
+  it("does NOT gate a no-op re-publish of ALREADY-public content (idempotent, race-safe)", async () => {
+    // The locked row is already public → re-publishing with visibility.level 'public'
+    // changes nothing, so a non-admin owner without publish_public passes WITHOUT
+    // approval (the #1090 regression), and the check reads the level UNDER the lock.
+    txResults = [
+      [{ id: "o1", visibilityLevel: "public" }], // FOR UPDATE lock (already public)
+      [{ id: "pub1" }], // publication upsert RETURNING
+    ];
+    await expect(
+      publishService.publish(owner, "o1", {
+        destination: "intranet",
+        visibility: { level: "public" },
+      })
+    ).resolves.toEqual({ publicationId: "pub1", publishedVersionId: "v1" });
   });
 
   it("admin past the gate to an unimplemented public destination fails BEFORE any write (no visibility leak)", async () => {

--- a/tests/unit/atrium-publish-service.test.ts
+++ b/tests/unit/atrium-publish-service.test.ts
@@ -221,6 +221,9 @@ describe("publishService.publish", () => {
         visibility: { level: "public" },
       })
     ).rejects.toThrow(ApprovalRequiredError);
+    // The gate must reject BEFORE the widen is written — a reorder that ran
+    // setLevelInTx first would still throw here but would have already widened.
+    expect(setLevelInTxCalls).toBe(0);
   });
 
   it("does NOT gate a no-op re-publish of ALREADY-public content (idempotent, race-safe)", async () => {

--- a/tests/unit/atrium-requester-from-auth.test.ts
+++ b/tests/unit/atrium-requester-from-auth.test.ts
@@ -17,6 +17,14 @@ let agentRows: Array<{
   roleId: number | null;
   roleName: string | null;
 }> = [];
+// The by-id lookup carries the identity's OWN scopes (a scheduled run has no token).
+let agentByIdRows: Array<{
+  id: string;
+  name: string;
+  roleId: number | null;
+  roleName: string | null;
+  scopes: string[];
+}> = [];
 let userRows: Array<{
   building: string | null;
   department: string | null;
@@ -27,6 +35,7 @@ let roleRows: Array<{ name: string }> = [];
 jest.mock("@/lib/db/drizzle-client", () => ({
   executeQuery: jest.fn(async (_fn: unknown, label: string) => {
     if (label === "atrium.requesterFromAuth.findAgent") return agentRows;
+    if (label === "atrium.requesterFromAuth.findAgentById") return agentByIdRows;
     if (label === "atrium.requesterFromAuth.loadUser") return userRows;
     if (label === "getUserRoles") return roleRows;
     return [];
@@ -40,6 +49,7 @@ jest.mock("@/lib/db/schema", () => ({
     roleId: "roleId",
     oauthClientId: "oauthClientId",
     isActive: "isActive",
+    scopes: "scopes",
   },
   roles: { id: "id", name: "name" },
   users: { id: "id", building: "building", department: "department", gradeLevels: "gradeLevels" },
@@ -54,6 +64,7 @@ jest.mock("drizzle-orm", () => ({
 import {
   requesterFromApiAuth,
   buildDelegatedRequester,
+  buildAutonomousRequesterForIdentity,
 } from "@/lib/content/requester-from-auth";
 import { principalOf } from "@/lib/content/helpers";
 
@@ -72,6 +83,7 @@ afterAll(() => {
 
 beforeEach(() => {
   agentRows = [];
+  agentByIdRows = [];
   userRows = [{ building: "High School", department: null, gradeLevels: null }];
   roleRows = [{ name: "staff" }];
   jest.clearAllMocks();
@@ -198,6 +210,52 @@ describe("requesterFromApiAuth", () => {
     if (req.kind !== "user") throw new Error("wrong kind");
     expect(req.userId).toBe(42);
     expect(req.isAdmin).toBe(false);
+  });
+});
+
+describe("buildAutonomousRequesterForIdentity (scheduled-run identity path)", () => {
+  it("builds an agent-autonomous requester from an active identity id, scopes from the row", async () => {
+    // A scheduled run carries no token, so the identity's authority is its OWN
+    // scopes column — not an OAuth token's scopes.
+    agentByIdRows = [
+      {
+        id: "agent-9",
+        name: "ship-reporter",
+        roleId: 5,
+        roleName: "staff",
+        scopes: ["content:create", "content:publish_internal"],
+      },
+    ];
+    const req = await buildAutonomousRequesterForIdentity("agent-9");
+    expect(req.kind).toBe("agent-autonomous");
+    if (req.kind !== "agent-autonomous") throw new Error("wrong kind");
+    expect(req.agentId).toBe("agent-9");
+    expect(req.roleId).toBe(5);
+    expect(req.roles).toEqual(["staff"]);
+    // Scopes come from the identity row, NOT a token.
+    expect(req.scopes).toEqual(["content:create", "content:publish_internal"]);
+    // The identity never carries content:publish_public (public-publish is human-held).
+    expect(req.scopes).not.toContain("content:publish_public");
+    expect(req.agentLabel).toBe("ship-reporter");
+  });
+
+  it("fails closed (throws) when the identity id is missing or inactive", async () => {
+    // No matching ACTIVE row (deactivated or unknown id) → throw, so a scheduled run
+    // aborts rather than silently running as the owning user with human authority.
+    agentByIdRows = [];
+    await expect(
+      buildAutonomousRequesterForIdentity("deactivated-agent")
+    ).rejects.toThrow(/No active agent identity/);
+  });
+
+  it("yields an empty roles array when the identity has no role", async () => {
+    agentByIdRows = [
+      { id: "agent-x", name: "role-less", roleId: null, roleName: null, scopes: ["content:create"] },
+    ];
+    const req = await buildAutonomousRequesterForIdentity("agent-x");
+    if (req.kind !== "agent-autonomous") throw new Error("wrong kind");
+    expect(req.roles).toEqual([]);
+    expect(req.roleId).toBeNull();
   });
 });
 

--- a/tests/unit/lib/api/with-api-auth.test.ts
+++ b/tests/unit/lib/api/with-api-auth.test.ts
@@ -122,7 +122,7 @@ describe("withApiAuth", () => {
   // Successful request flow
   // ------------------------------------------
   describe("successful request flow", () => {
-    it("should call handler with auth context and requestId", async () => {
+    it("should call handler with auth context, requestId, and resolved params", async () => {
       const handler = jest.fn<(...args: unknown[]) => Promise<unknown>>().mockResolvedValue(
         NextResponse.json({ data: "success" })
       )
@@ -131,10 +131,37 @@ describe("withApiAuth", () => {
       const request = createMockRequest()
       await wrappedHandler(request as never)
 
+      // No route context → the handler receives an empty params object as the 4th arg.
       expect(handler).toHaveBeenCalledWith(
         request,
         mockAuth,
-        expect.any(String) // requestId
+        expect.any(String), // requestId
+        {} // params (no dynamic segments)
+      )
+    })
+
+    it("should await and forward Next.js dynamic route params to the handler", async () => {
+      // A dynamic route ([id]/publish/[destination]) receives its params via the
+      // route context's `params` Promise. The wrapper must await it and hand the
+      // handler a plain object — so a route can read `params.id` collision-free
+      // instead of parsing the URL by segment name.
+      const handler = jest.fn<(...args: unknown[]) => Promise<unknown>>().mockResolvedValue(
+        NextResponse.json({ data: "ok" })
+      )
+
+      const wrappedHandler = withApiAuth(handler)
+      const request = createMockRequest()
+      // Mimic Next's context: params is a Promise (App Router, Next 15+). Use a
+      // slug that collides with a path literal to prove real params win.
+      await wrappedHandler(request as never, {
+        params: Promise.resolve({ id: "publish", destination: "schoology" }),
+      } as never)
+
+      expect(handler).toHaveBeenCalledWith(
+        request,
+        mockAuth,
+        expect.any(String),
+        { id: "publish", destination: "schoology" }
       )
     })
 


### PR DESCRIPTION
## Summary
Implements the deferred, non-blocking follow-ups from the AI review of PR #1088 (Atrium Phase 5 — Agent access), tracked in #1090. Correctness fixes, a latency/consistency pass, cleanup, and the scheduler identity last mile.

## Changes

**Correctness**
- **Public-publish gate no longer fires on idempotent no-op saves.** `publishService.publish()` and `visibilityService.setLevel()` computed `isPublicFacing` from the target value alone, so re-saving already-public content (visibility unchanged) by a non-admin owner spuriously threw `ApprovalRequiredError` + emitted `content.public_publish_requested`. Both now gate on an actual state change (`current visibilityLevel !== "public"`). A `public_web` destination stays unconditionally public-facing. Fails closed regardless.
- **`extractStringParam` segment-collision fixed** by threading real Next.js route params through `withApiAuth` (awaited `context.params`, passed as a 4th handler arg) and switching the 5 Atrium content dynamic routes to `params.id` / `params.destination`. Previously `DELETE /api/v1/content/publish/publish/schoology` (a content slug of `"publish"`) misparsed the destination → 400 → un-unpublishable. Backward compatible: the ~16 non-dynamic handlers ignore the new arg.

**Consistency / latency**
- **Service-layer `contentEvents.emit` is now fire-and-forget** (`void`, not `await`) in version-service, publish-service (published / unpublished / gate), visibility-service (gate), and the two content-service create gates. `emit` swallows its own errors (`snsPublishBestEffort` never throws), so awaiting only added an SNS round-trip to the response path (matches the `recordContentAudit` best-effort pattern).
- **`use-editor-actions` handles `approvalRequired`.** `handlePublish` / `handleUnpublish` now surface a §26.4 pending-approval outcome as a distinct amber "submitted for review" caption (via a new `pendingApproval` state) instead of a red failure, mirroring `VisibilityChip`. `unpublish-document` now maps `ApprovalRequiredError` like `publish-document` so the branch is reachable when a public-destination unpublish button is wired (latent today — the editor pins `intranet`).
- **`ATRIUM_SYSTEM_USER_ID` validated via `systemUserIdOrNull()`** in the OAuth adapter (was a bare `!Number.isNaN(parseInt)` that accepted `-1`, `1.5`, `"3abc"`).

**Cleanup**
- **Extracted `hasPublishPublicScope(scopes)`** — the `content:publish_public` scope check was hand-typed at 7 REST/MCP call sites (a typo would silently fail-open). Preserves the exact `.includes` semantics (a session wildcard `["*"]` still does not match).

**Known gap — scheduler last mile**
- The scheduled execute endpoint accepted `agent_identity_id` but only logged a warning. It now resolves the identity into an `agent-autonomous` Requester (`buildAutonomousRequesterForIdentity`, scopes read from the identity row since a scheduled run has no token) and **fails closed (422)** on a missing/inactive identity — no silent fallback to the user's authority. The Requester is threaded into `PromptExecutionContext` and stamped on the run log. Note: assistant-architect prompt execution currently wires only repository search tools into `promptTools`; binding the Atrium content-authoring tools (MCP-only today) to this Requester is a separate, larger feature — the tools have no prompt-execution consumer yet.

## Not addressed (documented in the issue as externally blocked)
- **OIDC JWT signing in prod/KMS** — node-oidc-provider needs an in-process private key; KMS keys are non-exportable, so prod JWT issuance stays disabled until an exportable OIDC signing key is supplied. No code change is possible here; the autonomous authorization logic is implemented + unit-tested regardless of transport.
- The remaining Cleanup bullets in the issue (`resolveCollectionId` dedup, `createVersion` post-snapshot reload) were explicitly gated in the issue on a broader refactor of those layers ("only worth it if that layer is refactored anyway") — out of scope for a follow-up pass.

## Verification (all green before opening)
- Typecheck: ✅ (`tsc --noEmit`, whole project)
- Lint: ✅ 0 errors (`eslint .`); no new warnings in touched files
- Tests: ✅ 1842 passed (`bun run test:ci` — full CI jest config, excludes e2e/perf)
- Atrium smokes: ✅ all pass (incl. the DB-backed visibility-reference smoke)
- OpenAPI: ✅ in sync (`openapi:check`) — no API contract change
- New tests: `use-editor-actions` (approvalRequired → pending, not error, for publish + unpublish), `with-api-auth` (params awaited + forwarded, using a colliding `publish` slug), `buildAutonomousRequesterForIdentity` (scopes-from-row, fail-closed on inactive id, role-less)

## Evidence
_N/A — no reachable new UI surface. The only UI change (an amber "submitted for review" caption in `DocumentEditor`) is latent: the shipped editor pins `destination: "intranet"`, which never triggers the §26.4 approval gate, so the pending-approval branch cannot be reached from the current UI. It is covered by a `renderHook` unit test (`tests/components/use-editor-actions.test.ts`) instead. All other changes are backend/service-layer._

Closes #1090
