### PR TITLE
fix: agent Google Chat reliability — session conflict, gws bypass, guardrail IAM, failure observability

### DIFF
--- a/infra/agent-image/Dockerfile
+++ b/infra/agent-image/Dockerfile
@@ -98,8 +98,15 @@ RUN set -eux; \
     uv --version
 
 # Google Workspace CLI (#912) — Rust single binary invoked by the psd-workspace
-# skill. ARM64 matches AgentCore runtime. The skill passes OAuth access tokens
-# via the GOOGLE_ACCESS_TOKEN env var.
+# skill. ARM64 matches AgentCore runtime. run.js/common.js authenticate each
+# call by exporting the per-user OAuth access token as GOOGLE_WORKSPACE_CLI_TOKEN
+# (gws ignores GOOGLE_ACCESS_TOKEN — see common.js execGws).
+#
+# The real binary is installed as /usr/local/bin/gws.real and a refuse-by-default
+# wrapper is installed as /usr/local/bin/gws. Every `gws` from the agent's exec
+# tool resolves the wrapper first; run.js reaches gws.real directly. See
+# bin/gws-wrapper.sh for rationale (incident: 2026-07-01 — bare `gws chat spaces
+# list` → 401 → wrong "no credentials" answer + Phase 1 gate-bypass surface).
 #
 # Pinned version + SHA256 come from the official release's .sha256 sidecar.
 # When bumping, run:
@@ -107,14 +114,21 @@ RUN set -eux; \
 # and paste the hex digest into GWS_SHA256 below.
 ARG GWS_VERSION=0.22.5
 ARG GWS_SHA256=94490295d9580e1e88574e715a0a162991747d12d62f8c7b8dcc8268b6c1cea0
+# COPY --chmod so the wrapper mode lands in one layer (layer count is
+# load-bearing for AgentCore's Firecracker snapshotter — see gh install below).
+COPY --chmod=755 bin/gws-wrapper.sh /usr/local/bin/gws
+# Install the real gws binary as /usr/local/bin/gws.real. The final
+# `gws --version` verifies the wrapper delegates introspection to it.
 RUN set -eux; \
     curl -fsSL -o /tmp/gws.tar.gz \
       "https://github.com/googleworkspace/cli/releases/download/v${GWS_VERSION}/google-workspace-cli-aarch64-unknown-linux-gnu.tar.gz"; \
     echo "${GWS_SHA256}  /tmp/gws.tar.gz" | sha256sum -c -; \
-    tar -xzf /tmp/gws.tar.gz -C /usr/local/bin --strip-components=0 ./gws; \
+    tar -xzf /tmp/gws.tar.gz -C /tmp --strip-components=0 ./gws; \
+    mv /tmp/gws /usr/local/bin/gws.real; \
     rm /tmp/gws.tar.gz; \
-    chmod +x /usr/local/bin/gws; \
-    gws --version
+    chmod +x /usr/local/bin/gws.real; \
+    /usr/local/bin/gws.real --version; \
+    /usr/local/bin/gws --version
 
 # GitHub CLI (#965 follow-on) — single Go binary so the agent can read PRs,
 # issues, and run gh-api calls without us shipping a custom skill. ARM64

--- a/infra/agent-image/agentcore_wrapper.py
+++ b/infra/agent-image/agentcore_wrapper.py
@@ -643,6 +643,13 @@ def main():
                 # agent_message_content + agent_tool_invocations.
                 "messages": result.messages,
                 "tool_calls": result.tool_calls,
+                # Error-turn signal (harness_adapter TurnResult.failed). The
+                # router reads metadata.failed so a 0-token error turn (e.g. an
+                # OpenClaw session-init conflict) is flagged, not logged as a
+                # clean "Message processed" success. The harness already wrote
+                # the agent_failures row for these.
+                "failed": result.failed,
+                "error_class": result.error_class,
             }
 
         logger.info(

--- a/infra/agent-image/bin/gws-wrapper.sh
+++ b/infra/agent-image/bin/gws-wrapper.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# gws-wrapper.sh — refuse-by-default wrapper around the Google Workspace CLI.
+#
+# Installed at /usr/local/bin/gws inside the agent container; the real binary
+# lives at /usr/local/bin/gws.real. Every `gws` invocation from the agent's
+# `exec` tool or any subprocess resolves this wrapper first (PATH lookup).
+#
+# Rationale: the ONLY sanctioned path to Google Workspace is the psd-workspace
+# skill —
+#     node /opt/psd-skills/psd-workspace/run.js --user <email> \
+#          --command "gws <subcommand> ..." [--scope user|agent]
+# run.js/common.js are the only place that (a) injects the per-user OAuth
+# access token and (b) enforces the Phase 1 hard gates (no send, no delete, no
+# permission changes) plus marker/audit injection. run.js reaches the real
+# binary directly at /usr/local/bin/gws.real, so it is unaffected by this
+# wrapper.
+#
+# A BARE `gws ...` from the model has NO token (→ 401 "No credentials
+# provided") AND bypasses every Phase 1 gate. On 2026-07-01 the agent ran a
+# bare `gws chat spaces list`, got the 401, and told the user "the agent
+# account isn't set up with Google Workspace credentials" — a wrong answer
+# from a self-inflicted auth failure, and a live gate-bypass surface.
+#
+# This wrapper is the structural backstop. The companion textual rules live in
+# skills/psd-rules/SKILL.md (Rule 9) and skills/psd-workspace/SKILL.md.
+#
+# Residual risk (documented, not closed here): the container's exec tool could
+# in principle invoke /usr/local/bin/gws.real directly. Closing that requires
+# scoping the AgentCore role away from the workspace secrets and/or removing
+# the raw exec tool from the OpenClaw profile — tracked separately.
+
+set -uo pipefail
+
+REAL_GWS="/usr/local/bin/gws.real"
+
+# If the real binary somehow isn't present, loud-fail rather than silently
+# degrade to an unwrapped gws on PATH.
+if [ ! -x "$REAL_GWS" ]; then
+  echo "gws-wrapper: real gws binary missing at $REAL_GWS — refusing to run." >&2
+  exit 127
+fi
+
+# Identify the first positional (non-flag) token — the gws subcommand.
+sub=""
+for arg in "$@"; do
+  case "$arg" in
+    -*) : ;;            # flag — skip
+    *)  sub="$arg"; break ;;
+  esac
+done
+
+# Allow auth-free introspection straight through to the real binary so the
+# model can still discover the command surface (psd-workspace SKILL.md tells
+# it to "run `gws schema <method>` first"). These touch no user data.
+case "${1:-}" in
+  --version|-V|--help|-h)
+    exec "$REAL_GWS" "$@"
+    ;;
+esac
+case "$sub" in
+  schema|help|version)
+    exec "$REAL_GWS" "$@"
+    ;;
+esac
+
+# Everything else touches user data and MUST go through the skill.
+cat >&2 <<'EOF'
+gws-wrapper: direct `gws` calls are disabled inside the agent.
+
+All Google Workspace access must go through the psd-workspace skill, which
+injects the OAuth token and enforces the Phase 1 safety gates:
+
+  node /opt/psd-skills/psd-workspace/run.js --user <caller-email> \
+       --command "gws <subcommand> ..." [--scope user|agent]
+
+A bare `gws` has no credentials (it will 401) and bypasses the send/delete/
+permission-change gates. If you were about to report "no Workspace
+credentials are set up," that conclusion is wrong — route through run.js.
+EOF
+exit 13

--- a/infra/agent-image/bin/gws-wrapper.sh
+++ b/infra/agent-image/bin/gws-wrapper.sh
@@ -8,7 +8,7 @@
 # Rationale: the ONLY sanctioned path to Google Workspace is the psd-workspace
 # skill —
 #     node /opt/psd-skills/psd-workspace/run.js --user <email> \
-#          --command "gws <subcommand> ..." [--scope user|agent]
+#          --command "<gws subcommand> ..." [--scope user|agent]
 # run.js/common.js are the only place that (a) injects the per-user OAuth
 # access token and (b) enforces the Phase 1 hard gates (no send, no delete, no
 # permission changes) plus marker/audit injection. run.js reaches the real
@@ -71,7 +71,7 @@ All Google Workspace access must go through the psd-workspace skill, which
 injects the OAuth token and enforces the Phase 1 safety gates:
 
   node /opt/psd-skills/psd-workspace/run.js --user <caller-email> \
-       --command "gws <subcommand> ..." [--scope user|agent]
+       --command "<gws subcommand> ..." [--scope user|agent]
 
 A bare `gws` has no credentials (it will 401) and bypasses the send/delete/
 permission-change gates. If you were about to report "no Workspace

--- a/infra/agent-image/harness_adapter.py
+++ b/infra/agent-image/harness_adapter.py
@@ -47,6 +47,12 @@ class TurnResult:
     latency_ms: int = 0
     messages: List[Dict[str, Any]] = dataclasses.field(default_factory=list)
     tool_calls: List[Dict[str, Any]] = dataclasses.field(default_factory=list)
+    # Set True when this turn is an error/degraded return (session conflict,
+    # deadline, empty response, WS failure) rather than a real answer. The
+    # wrapper forwards this to the router (metadata.failed) so a 0-token error
+    # turn is no longer logged as a clean "Message processed" success.
+    failed: bool = False
+    error_class: Optional[str] = None
 
 
 def _format_for_chat(text: str) -> str:
@@ -352,6 +358,57 @@ class OpenClawAdapter(HarnessAdapter):
                 except Exception as exc:  # noqa: BLE001
                     logger.warning("tools.catalog probe failed: %s", str(exc)[:200])
 
+                # Step 2.5: Defensively abort any lingering reply session for
+                # this sessionKey before sending (#session-conflict fix).
+                #
+                # OpenClaw keys its server-side reply session on sessionKey,
+                # which we reuse across turns (the stable AgentCore session_id).
+                # A prior turn's reply session can survive that turn's
+                # ws.close() and then reject the next chat.send with "reply
+                # session initialization conflicted" — observed 2026-07-01,
+                # where every follow-up turn returned "I encountered an error."
+                # The router already serializes turns per session (a DynamoDB
+                # session lock; see agent-router waitForSessionLock), so no
+                # legitimate work for this sessionKey is active here — a
+                # pre-send chat.abort is therefore safe and clears the wedged
+                # state. chat.abort takes `sessionKey` per the OpenClaw gateway
+                # protocol (sessions.reset would additionally wipe stored
+                # conversation state, so we deliberately do NOT use it here).
+                # Kill switch: OPENCLAW_PRESEND_ABORT=0.
+                if os.environ.get("OPENCLAW_PRESEND_ABORT", "1") != "0":
+                    try:
+                        abort_id = str(uuid.uuid4())
+                        ws.send(json.dumps({
+                            "type": "req",
+                            "id": abort_id,
+                            "method": "chat.abort",
+                            "params": {"sessionKey": session_id or "default"},
+                        }))
+                        # Drain until the abort ack (bounded ~5s). Any
+                        # intervening `aborted` chat event for the stale session
+                        # is consumed here so it can't leak into the chat.send
+                        # event loop below. The main loop resets settimeout(60).
+                        ws.settimeout(5)
+                        abort_deadline = time.time() + 5
+                        while time.time() < abort_deadline:
+                            try:
+                                raw_a = ws.recv()
+                            except websocket.WebSocketTimeoutException:
+                                break
+                            msg_a = json.loads(raw_a)
+                            if (msg_a.get("type") == "res"
+                                    and msg_a.get("id") == abort_id):
+                                logger.info(
+                                    "pre-send chat.abort ack: ok=%s",
+                                    msg_a.get("ok"),
+                                )
+                                break
+                    except Exception as exc:  # noqa: BLE001
+                        logger.warning(
+                            "pre-send chat.abort failed (continuing): %s",
+                            str(exc)[:200],
+                        )
+
                 # Step 3: Send chat message
                 #
                 # sessionKey MUST be per-invocation caller, not "global".
@@ -600,10 +657,28 @@ class OpenClawAdapter(HarnessAdapter):
                             break
 
                         elif state == "error":
+                            err_msg = payload.get("errorMessage", "unknown")
                             logger.error(
                                 "chat event error: %s | full_payload=%s",
-                                payload.get("errorMessage", "unknown"),
+                                err_msg,
                                 json.dumps(payload)[:800],
+                            )
+                            # Previously returned silently — no failure signal.
+                            # This is where OpenClaw's "reply session
+                            # initialization conflicted" surfaces, so recording
+                            # it is what makes the session-conflict class of
+                            # failure visible in agent_failures / the alarm.
+                            record_failure(
+                                source="harness",
+                                severity="error",
+                                error_class="OpenClawChatError",
+                                error_message=str(err_msg),
+                                session_id=session_id,
+                                model=observed_model or model_override,
+                                context={
+                                    "phase": "chat_event_error",
+                                    "last_state": last_state,
+                                },
                             )
                             err_text = (
                                 _format_for_chat(response_text)
@@ -618,6 +693,8 @@ class OpenClawAdapter(HarnessAdapter):
                                 latency_ms=int((time.time() - chat_send_at) * 1000),
                                 messages=messages_log,
                                 tool_calls=tool_calls,
+                                failed=True,
+                                error_class="OpenClawChatError",
                             )
 
                         elif state == "aborted":
@@ -637,12 +714,24 @@ class OpenClawAdapter(HarnessAdapter):
                         if not msg.get("ok"):
                             error = msg.get("error", {})
                             logger.error("chat.send error: %s", json.dumps(error)[:500])
+                            # Previously returned silently — no failure signal.
+                            record_failure(
+                                source="harness",
+                                severity="error",
+                                error_class="OpenClawChatSendError",
+                                error_message=json.dumps(error)[:2000],
+                                session_id=session_id,
+                                model=observed_model or model_override,
+                                context={"phase": "chat_send_res"},
+                            )
                             return TurnResult(
                                 text="I encountered an error processing your message.",
                                 model=observed_model,
                                 latency_ms=int((time.time() - chat_send_at) * 1000),
                                 messages=messages_log,
                                 tool_calls=tool_calls,
+                                failed=True,
+                                error_class="OpenClawChatSendError",
                             )
                         res_payload = msg.get("payload", {})
                         # Final res may carry the authoritative usage object.
@@ -684,11 +773,18 @@ class OpenClawAdapter(HarnessAdapter):
                 model=observed_model,
                 messages=messages_log,
                 tool_calls=tool_calls,
+                failed=True,
+                error_class="WebSocketError",
             )
 
         latency_ms = int((time.time() - chat_send_at) * 1000)
 
-        def _result(text: str) -> TurnResult:
+        def _result(
+            text: str,
+            *,
+            failed: bool = False,
+            error_class: Optional[str] = None,
+        ) -> TurnResult:
             assistant = text or ""
             log = list(messages_log)
             if assistant:
@@ -701,6 +797,8 @@ class OpenClawAdapter(HarnessAdapter):
                 latency_ms=latency_ms,
                 messages=log,
                 tool_calls=tool_calls,
+                failed=failed,
+                error_class=error_class,
             )
 
         if not got_final:
@@ -739,7 +837,9 @@ class OpenClawAdapter(HarnessAdapter):
             )
             return _result(
                 "I wasn't able to finish responding in time — the agent "
-                "stalled. Please try again in a moment."
+                "stalled. Please try again in a moment.",
+                failed=True,
+                error_class="ChatDeadlineExpired",
             )
 
         logger.info(
@@ -772,7 +872,11 @@ class OpenClawAdapter(HarnessAdapter):
                 "first_events": first_event_types,
             },
         )
-        return _result("I processed your message but had no response.")
+        return _result(
+            "I processed your message but had no response.",
+            failed=True,
+            error_class="EmptyAgentResponse",
+        )
 
     @staticmethod
     def _extract_text(content) -> str:

--- a/infra/agent-image/harness_adapter.py
+++ b/infra/agent-image/harness_adapter.py
@@ -395,14 +395,18 @@ class OpenClawAdapter(HarnessAdapter):
                                 raw_a = ws.recv()
                             except websocket.WebSocketTimeoutException:
                                 break
-                            msg_a = json.loads(raw_a)
-                            if (msg_a.get("type") == "res"
-                                    and msg_a.get("id") == abort_id):
-                                logger.info(
-                                    "pre-send chat.abort ack: ok=%s",
-                                    msg_a.get("ok"),
-                                )
-                                break
+                            try:
+                                msg_a = json.loads(raw_a)
+                                if (isinstance(msg_a, dict)
+                                        and msg_a.get("type") == "res"
+                                        and msg_a.get("id") == abort_id):
+                                    logger.info(
+                                        "pre-send chat.abort ack: ok=%s",
+                                        msg_a.get("ok"),
+                                    )
+                                    break
+                            except (json.JSONDecodeError, ValueError):
+                                continue
                     except Exception as exc:  # noqa: BLE001
                         logger.warning(
                             "pre-send chat.abort failed (continuing): %s",
@@ -817,7 +821,28 @@ class OpenClawAdapter(HarnessAdapter):
                 raw_event_samples[0] if raw_event_samples else "",
             )
             if response_text:
-                return _result(_format_for_chat(response_text.strip()))
+                record_failure(
+                    source="harness",
+                    severity="warn",
+                    error_class="ChatDeadlineExpiredPartial",
+                    error_message=(
+                        f"chat deadline expired with partial response "
+                        f"(last_state={last_state})"
+                    ),
+                    session_id=session_id,
+                    model=observed_model or model_override,
+                    context={
+                        "phase": "deadline",
+                        "last_state": last_state,
+                        "event_counts": event_counts,
+                        "first_events": first_event_types,
+                    },
+                )
+                return _result(
+                    _format_for_chat(response_text.strip()),
+                    failed=True,
+                    error_class="ChatDeadlineExpiredPartial",
+                )
             record_failure(
                 source="harness",
                 severity="error",

--- a/infra/agent-image/skills/psd-workspace/common.js
+++ b/infra/agent-image/skills/psd-workspace/common.js
@@ -12,6 +12,7 @@
 'use strict';
 
 const { spawnSync } = require('node:child_process');
+const fs = require('node:fs');
 
 const {
   SecretsManagerClient,
@@ -215,7 +216,14 @@ function execGws(commandString, accessToken) {
   if (tokens.length === 0) {
     fail('--command is empty');
   }
-  const result = spawnSync('gws', tokens, {
+  // Call the real binary directly. In the agent container the model-facing
+  // `gws` on PATH is a refuse-by-default wrapper (bin/gws-wrapper.sh) that
+  // blocks direct data access; run.js is the only sanctioned caller, so it
+  // must reach the unwrapped binary at /usr/local/bin/gws.real. Local/dev
+  // images that ship no wrapper fall back to `gws` on PATH.
+  const REAL_GWS = '/usr/local/bin/gws.real';
+  const bin = fs.existsSync(REAL_GWS) ? REAL_GWS : 'gws';
+  const result = spawnSync(bin, tokens, {
     env: { ...process.env, GOOGLE_WORKSPACE_CLI_TOKEN: accessToken },
     stdio: ['ignore', 'inherit', 'inherit'],
   });

--- a/infra/lambdas/agent-router/index.ts
+++ b/infra/lambdas/agent-router/index.ts
@@ -1265,6 +1265,9 @@ async function invokeAgentCore(
           latencyMs: 0,
           messages: [],
           toolCalls: [],
+          failed: true,
+          errorClass: `AgentCoreThrottled_${response.status}`,
+          errorSource: 'router',
         };
       }
 

--- a/infra/lambdas/agent-router/index.ts
+++ b/infra/lambdas/agent-router/index.ts
@@ -1124,6 +1124,20 @@ async function invokeAgentCore(
     started_at: string;
     finished_at: string;
   }>;
+  /**
+   * True when this turn is an error/degraded return rather than a real answer
+   * (harness-reported via metadata.failed, or a router-side invocation error).
+   * The caller flags these instead of logging a clean "Message processed".
+   */
+  failed?: boolean;
+  /** Short class for the failure (e.g. OpenClawChatError, AgentCoreHttpError). */
+  errorClass?: string;
+  /**
+   * Which layer detected the failure. 'harness' failures are already recorded
+   * in agent_failures by the container, so the router only logs them; 'router'
+   * failures are recorded by the caller (nothing else saw them).
+   */
+  errorSource?: 'harness' | 'router';
 }> {
   // Resolve the AgentCore Runtime ID — check env var, then module-level cache,
   // then SSM. Cached at module scope with TTL to avoid redundant SSM API calls
@@ -1166,6 +1180,9 @@ async function invokeAgentCore(
       latencyMs: 0,
       messages: [],
       toolCalls: [],
+      failed: true,
+      errorClass: 'AgentNotDeployed',
+      errorSource: 'router',
     };
   }
 
@@ -1261,6 +1278,9 @@ async function invokeAgentCore(
         latencyMs: 0,
         messages: [],
         toolCalls: [],
+        failed: true,
+        errorClass: `AgentCoreHttpError_${response.status}`,
+        errorSource: 'router',
       };
     }
 
@@ -1332,6 +1352,13 @@ async function invokeAgentCore(
       latencyMs: (metadata.latency_ms as number) || 0,
       messages,
       toolCalls,
+      // Harness-reported error turn (e.g. OpenClaw session-init conflict). The
+      // container already wrote the agent_failures row; the caller only logs
+      // this so it isn't recorded as a clean success.
+      failed: metadata.failed === true,
+      errorClass:
+        typeof metadata.error_class === 'string' ? metadata.error_class : undefined,
+      errorSource: metadata.failed === true ? 'harness' : undefined,
     };
   } catch (error) {
     log.error('AgentCore invocation error', {
@@ -1348,6 +1375,10 @@ async function invokeAgentCore(
       latencyMs: 0,
       messages: [],
       toolCalls: [],
+      failed: true,
+      errorClass:
+        error instanceof Error ? error.name || 'AgentCoreInvocationError' : 'AgentCoreInvocationError',
+      errorSource: 'router',
     };
   }
 }
@@ -1681,6 +1712,53 @@ async function recordFailure(
       originalSeverity: params.severity,
     });
   }
+}
+
+/**
+ * Observe a failed agent turn without changing the user-facing behavior (the
+ * error text is still delivered to Chat by the caller). Fixes the gap where a
+ * 0-token error turn — e.g. an OpenClaw session-init conflict — was logged as a
+ * clean "Message processed" success and left no alertable signal.
+ *
+ * Harness-origin failures (errorSource === 'harness') are already persisted in
+ * agent_failures by the container, so we only log them here to avoid a
+ * double-counted row. Router-origin failures (invocation errors) are persisted
+ * here since nothing else recorded them. Returns whether the turn was failed so
+ * the caller can suppress its success log.
+ */
+async function flagFailedTurn(
+  agentResult: {
+    failed?: boolean;
+    errorClass?: string;
+    errorSource?: 'harness' | 'router';
+    response: string;
+    model: string | null;
+  },
+  ctx: { userId: string; sessionId: string; latencyMs: number },
+  log: ReturnType<typeof createLogger>,
+): Promise<boolean> {
+  if (!agentResult.failed) return false;
+  log.warn('Agent returned an error turn', {
+    errorClass: agentResult.errorClass ?? 'unknown',
+    errorSource: agentResult.errorSource ?? 'unknown',
+    latencyMs: ctx.latencyMs,
+  });
+  if (agentResult.errorSource === 'router') {
+    await recordFailure(
+      {
+        source: 'router',
+        severity: 'error',
+        userId: ctx.userId,
+        sessionId: ctx.sessionId,
+        model: agentResult.model,
+        errorClass: agentResult.errorClass ?? 'AgentCoreError',
+        errorMessage: agentResult.response,
+        context: { phase: 'agentcore_invoke' },
+      },
+      log,
+    );
+  }
+  return true;
 }
 
 function classifyError(err: unknown): { errorClass: string; message: string; stack: string | null } {
@@ -2534,13 +2612,20 @@ async function processRecord(
         log
       );
 
-      log.info('Cross-user invocation processed', {
-        invoker: senderEmail,
-        agentOwner: targetUser.email,
-        model: agentResult.model,
-        source: crossUserInvocation.source,
-        latencyMs,
-      });
+      const crossTurnFailed = await flagFailedTurn(
+        agentResult,
+        { userId: senderEmail, sessionId: crossSessionId, latencyMs },
+        log,
+      );
+      if (!crossTurnFailed) {
+        log.info('Cross-user invocation processed', {
+          invoker: senderEmail,
+          agentOwner: targetUser.email,
+          model: agentResult.model,
+          source: crossUserInvocation.source,
+          latencyMs,
+        });
+      }
       return;
     }
   }
@@ -2659,11 +2744,18 @@ async function processRecord(
     log
   );
 
-  log.info('Message processed', {
-    sender: senderName,
-    model: agentResult.model,
-    latencyMs,
-    inputTokens: agentResult.inputTokens,
-    outputTokens: agentResult.outputTokens,
-  });
+  const turnFailed = await flagFailedTurn(
+    agentResult,
+    { userId: senderEmail, sessionId, latencyMs },
+    log,
+  );
+  if (!turnFailed) {
+    log.info('Message processed', {
+      sender: senderName,
+      model: agentResult.model,
+      latencyMs,
+      inputTokens: agentResult.inputTokens,
+      outputTokens: agentResult.outputTokens,
+    });
+  }
 }

--- a/infra/lib/agent-platform-stack.ts
+++ b/infra/lib/agent-platform-stack.ts
@@ -827,7 +827,14 @@ export class AgentPlatformStack extends cdk.Stack {
         'bedrock:ApplyGuardrail',
         'bedrock:GetGuardrail',
       ],
-      resources: [props.guardrailArn],
+      // The guardrail uses cross-region inference (guardrails-stack.ts
+      // crossRegionConfig), so ApplyGuardrail authorizes against BOTH the
+      // guardrail ARN AND the system-defined guardrail-profile ARN. Granting
+      // only the guardrail ARN yields AccessDenied on every call.
+      resources: [
+        props.guardrailArn,
+        `arn:aws:bedrock:${this.region}:${this.account}:guardrail-profile/us.guardrail.v1:0`,
+      ],
     }));
 
     // DynamoDB read/write — agent container accesses USERS_TABLE and SIGNALS_TABLE
@@ -1034,7 +1041,14 @@ export class AgentPlatformStack extends cdk.Stack {
             sid: 'GuardrailsInvoke',
             effect: iam.Effect.ALLOW,
             actions: ['bedrock:ApplyGuardrail', 'bedrock:GetGuardrail'],
-            resources: [props.guardrailArn],
+            // Cross-region inference (guardrails-stack.ts crossRegionConfig)
+            // makes ApplyGuardrail authorize against BOTH the guardrail ARN
+            // and the system-defined guardrail-profile ARN. Omitting the
+            // profile ARN caused AccessDenied on 100% of router turns.
+            resources: [
+              props.guardrailArn,
+              `arn:aws:bedrock:${this.region}:${this.account}:guardrail-profile/us.guardrail.v1:0`,
+            ],
           })],
         }),
         // AgentCore session invoke

--- a/infra/lib/guardrails-stack.ts
+++ b/infra/lib/guardrails-stack.ts
@@ -278,7 +278,14 @@ export class GuardrailsStack extends cdk.Stack {
             'bedrock:ApplyGuardrail',
             'bedrock:GetGuardrail',
           ],
-          resources: [this.guardrail.attrGuardrailArn],
+          // Cross-region inference (crossRegionConfig above) makes
+          // ApplyGuardrail authorize against BOTH the guardrail ARN and the
+          // system-defined guardrail-profile ARN. Consumers of this policy
+          // (e.g. the ECS frontend) otherwise get AccessDenied on the profile.
+          resources: [
+            this.guardrail.attrGuardrailArn,
+            `arn:aws:bedrock:${cdk.Stack.of(this).region}:${cdk.Stack.of(this).account}:guardrail-profile/us.guardrail.v1:0`,
+          ],
         }),
         // Comprehend PII detection (requires wildcard - AWS limitation)
         new iam.PolicyStatement({


### PR DESCRIPTION
## Context

Fixes the cluster of failures from the PSD AI Agent Google Chat session on 2026-07-01: two `I encountered an error` replies, one wrong "no credentials" answer, and 100% guardrail-telemetry failure. Every root cause was verified against live CloudWatch logs + source. None were a Google Chat client problem.

## Workstreams

**WS1 — Guardrail IAM (100% `ApplyGuardrail` AccessDenied).** The guardrail uses cross-region inference, so Bedrock authorizes against BOTH the guardrail ARN and the `guardrail-profile/us.guardrail.v1:0` ARN. All three grants listed only the guardrail ARN → denied every turn. Added the profile ARN to the router role, the agentCore execution role, and `getGuardrailsAccessPolicy` (ECS frontend). Confirmed present in `cdk synth`.

**WS2 — gws bypass + wrong "no credentials" answer.** The model ran a bare `gws` via the exec tool; `gws` was unwrapped on PATH, so it had no OAuth token (401) AND bypassed the Phase 1 hard gates. Mirrored the existing `gh` wrapper: new `bin/gws-wrapper.sh` (refuse data ops → point at run.js; allow auth-free `schema`/`--version`), real binary moved to `gws.real`, `common.js` calls `gws.real`. ⚠️ Adds one image layer — watch for the AgentCore 54-layer overlay-mount limit.

**WS3 — failure observability.** The two OpenClaw error paths returned silently (no `record_failure`), and the router logged error turns as clean `Message processed` successes. Both silent paths now record; `TurnResult.failed`/`error_class` is threaded harness → wrapper metadata → router; new `flagFailedTurn()` logs every failed turn and persists only router-origin failures (no double-count).

**WS4 — OpenClaw "reply session initialization conflicted" (deep).** Verified the v4 gateway protocol: `chat.abort` takes `sessionKey` (aborts active work); `sessions.reset` also wipes conversation state (not used). Added a defensive pre-send `chat.abort` to clear a wedged reply session left by a prior turn — safe because the router already serializes turns per session. Kill switch `OPENCLAW_PRESEND_ABORT=0`. ⚠️ Needs live validation against the deployed gateway.

**WS5 — Chat-app allowlist.** Admin action already completed by the owner; optional router short-circuit intentionally not built.

## Verification
- `tsc --noEmit` clean (infra + agent-router); all changed Python byte-compiles
- `cdk synth` of GuardrailsStack-Dev + AgentPlatformStack-Dev succeeds with the profile ARN in all three IAM statements
- gws wrapper allow/refuse branches tested against a stub binary

## Deploy
1. Build/push new agent image (`infra/agent-image/build-and-push.sh`) → tag + digest
2. One canonical `cdk deploy` (full stack list) with the new `agentImageTag`/`agentImageDigest` — deploys IAM + router lambda + new image/runtime