### PR TITLE
fix: reclaim Docker layers to clear AgentCore overlay-mount ceiling (agent outage hotfix)

### DIFF
--- a/infra/agent-image/Dockerfile
+++ b/infra/agent-image/Dockerfile
@@ -266,13 +266,19 @@ COPY MEMORY.md /home/node/.openclaw/MEMORY.md
 # Loaded via openclaw.json skills.load.extraDirs. Install dependencies at
 # build time so the agent container starts fast.
 COPY skills /opt/psd-skills
-RUN cd /opt/psd-skills/psd-schedules && npm install --omit=dev --no-audit --no-fund
-RUN cd /opt/psd-skills/psd-credentials && npm install --omit=dev --no-audit --no-fund
-RUN cd /opt/psd-skills/psd-skills-meta && npm install --omit=dev --no-audit --no-fund
-RUN cd /opt/psd-skills/psd-workspace && npm install --omit=dev --no-audit --no-fund
-RUN cd /opt/psd-skills/psd-image-gen && npm install --omit=dev --no-audit --no-fund
-RUN cd /opt/psd-skills/psd-failure-report && npm install --omit=dev --no-audit --no-fund
-RUN cd /opt/psd-skills/psd-email-triage && npm install --omit=dev --no-audit --no-fund
+# Skill dependencies. Consolidated into a SINGLE RUN (was 7 separate RUNs) to
+# stay well under AgentCore's Firecracker overlay-mount layer ceiling — the base
+# image sits at the edge (53 layers) and a 54th layer fails to mount with
+# "Failed to mount overlay: No such file or directory" (agent outage 2026-07-02,
+# caused by adding the gws-wrapper COPY at 53). Absolute `cd` paths so the chain
+# is independent of prior CWD. Keep new skills in this RUN, not new RUNs.
+RUN cd /opt/psd-skills/psd-schedules && npm install --omit=dev --no-audit --no-fund && \
+    cd /opt/psd-skills/psd-credentials && npm install --omit=dev --no-audit --no-fund && \
+    cd /opt/psd-skills/psd-skills-meta && npm install --omit=dev --no-audit --no-fund && \
+    cd /opt/psd-skills/psd-workspace && npm install --omit=dev --no-audit --no-fund && \
+    cd /opt/psd-skills/psd-image-gen && npm install --omit=dev --no-audit --no-fund && \
+    cd /opt/psd-skills/psd-failure-report && npm install --omit=dev --no-audit --no-fund && \
+    cd /opt/psd-skills/psd-email-triage && npm install --omit=dev --no-audit --no-fund
 # chat-card has zero npm deps. chat-chart's npm install is paired with the
 # matplotlib install above — both stay disabled until we figure out the
 # AgentCore overlay-mount failure. With both off the image boots cleanly


### PR DESCRIPTION
## Outage hotfix

PR #1093 pushed the agent base image to **54 layers**; AgentCore's Firecracker snapshotter fails to mount overlays at 54+. Every new microVM failed to start (`Failed to mount overlay: No such file or directory`), returning HTTP 424 to the router → no responses to users (2026-07-02).

**Root cause (verified via ECR manifest layer counts):** last-good image = 53 layers (the exact edge); the PR #1093 image = 54 (the gws-wrapper COPY added the 54th).

**Fix:** consolidate the 7 per-skill `npm install` RUN steps into one → reclaims 6 layers (image → **48**, verified via ECR manifest). Clears the ceiling with headroom so a future single-layer add can't re-trigger this. No functional change — same installs/order, absolute `cd` paths, identical `&&`/`set -e` semantics.

**Corrected image (already built + pushed):** `2026-07-02-chat-reliability-r3` / `sha256:be67730de659def67d8e1bfd7fd24b6004f81f308796aee31dbaa9df687c4914` (48 layers). Deploying this digest restores service with all WS1–4 fixes intact.