### PR TITLE
docs: token-efficient agent skill authoring standard + tighten 5 descriptions

### DIFF
--- a/docs/guides/agent-skill-authoring.md
+++ b/docs/guides/agent-skill-authoring.md
@@ -1,0 +1,119 @@
+# Agent Skill Authoring — Token-Efficient Standard
+
+How to write PSD agent skills (`infra/agent-image/skills/<name>/SKILL.md`) so we can
+add **dozens** of skills without growing the model's per-call cost. Read this before
+adding a skill.
+
+## Why this matters (the cost model)
+
+Every model call in a turn re-reads the **system prompt** (the cached "prefix").
+The agent makes ~5–20 model calls per turn, so **anything in the prefix is paid for
+N times per turn**. Skills advertise into that prefix.
+
+OpenClaw uses **progressive disclosure** ([docs](https://docs.openclaw.ai/tools/skills)):
+
+- **Always loaded** into the system prompt: each skill's `name` + `description`,
+  compiled into a compact block. This is the *only* per-skill cost that scales with
+  skill count.
+- **Loaded on-demand**: the full `SKILL.md` body — only when the model decides the
+  skill is relevant and reads it.
+
+**Consequence:** skill *count* is cheap **iff** descriptions are tight. A verbose
+description is the one way a skill bloats every turn. At 26 skills, ~40-token
+descriptions ≈ **1k** always-on tokens; ~150-token descriptions ≈ **4k**. At 100+
+skills that gap is what re-reads on every model call.
+
+## The one rule
+
+> `description` is the only always-loaded, model-facing text. Keep it to **1–2
+> sentences (~30–50 tokens)**. It must answer **what it does + when to use it
+> (trigger words)**. Everything else goes in the body.
+
+## Frontmatter contract (what OpenClaw actually reads)
+
+| Field | Loaded into system prompt? | Use |
+|-------|---------------------------|-----|
+| `name` | ✅ always | kebab-case identifier |
+| `description` | ✅ always | **tight** what + when (trigger words) |
+| `allowed-tools` | no | advisory tool scope (e.g. `Bash(node:*)`) |
+| `user-invocable`, `disable-model-invocation`, … | no | behavior flags |
+| **`summary`** | **❌ not read by OpenClaw** | **required by the PSD skill catalog** (`psd-skills-meta`) — a one-line catalog entry. Keep it, but it never reaches the model. |
+
+**`summary` vs `description` — two different audiences:**
+- `summary` → the PSD skill **catalog** (a DB row via `psd-skills-meta`; validation
+  *requires* it). One line. Not in the model prompt. **Keep it.**
+- `description` → the **model's** system prompt (OpenClaw injects it on every turn).
+  Tight + trigger-rich. **This is the one you optimize.**
+
+Do **not** rely on `summary` for model triggering — OpenClaw ignores it. If a skill's
+good trigger line lives only in `summary` (e.g. `chat-chart`'s "REQUIRED for
+chart/graph/plot"), copy it into `description` so the model actually sees it.
+
+## `description`: do / don't
+
+```yaml
+# ❌ mechanism belongs in the body — this is paid on every model call, every turn
+description: Wraps the `gws` CLI. Fetches a refresh token from AWS Secrets Manager,
+  exchanges it for an access token, and executes `gws` subcommands against Google
+  APIs as the agent's own identity. If the token is stale it mints a consent URL and
+  returns a structured error; paste the consent_url verbatim... [130+ tokens]
+
+# ✅ what + when, ~35 tokens; the rest lives in the body (loaded only when used)
+description: Google Workspace (Gmail, Calendar, Drive, Docs, Meet, Chat) as the
+  user's agent account. Use for email, calendar, files, or Workspace lookups.
+```
+
+Checklist for a good `description`:
+- One sentence of **what**, one short clause of **when/trigger words** the user would say.
+- No API flows, secret names, S3 paths, envelope formats, capability gating, output shapes — **all body**.
+- Written for the model deciding *whether to open this skill*, not for a human reading docs.
+
+## Body best practices (the on-demand part)
+
+The body is only loaded when the skill triggers, so detail here is "free" per-turn —
+but keep it focused so the on-demand load is small and the model acts on the first read:
+
+- **Lead with the exact invocation** the model runs (copy-paste command).
+- State inputs, outputs, and the exit/error contract concretely.
+- Put **large** reference content (full CLI surfaces, long schemas, big examples) in
+  **separate files** the skill reads on demand, not inline in `SKILL.md`.
+- 2–3 input→output examples beat prose.
+
+## Copy-paste template
+
+```markdown
+---
+name: my-skill
+summary: <one line for the PSD skill catalog — required by psd-skills-meta>
+description: <what it does in one sentence> + <when to use / trigger words>. Keep ~30–50 tokens.
+allowed-tools: Bash(node:*)
+---
+
+# my-skill
+
+<1–2 lines: what this is and the boundary/guarantee that matters.>
+
+## Invoke
+
+    node /opt/psd-skills/my-skill/run.js --user <caller-email> --command "..."
+
+## Inputs / outputs / errors
+
+- Input: ...
+- Success (exit 0): ...
+- Errors: exit N → ...
+
+## Examples
+
+    # <goal>
+    node .../run.js --user a@b.org --command "..."   # → <result>
+```
+
+## Adding a skill — checklist
+
+1. `description` is 1–2 sentences with trigger words; **no `summary`** field.
+2. Mechanism/detail is in the body, not the description.
+3. Large references are separate on-demand files.
+4. Register deps in the consolidated skills `RUN` in the Dockerfile (do **not** add a
+   new `RUN` layer — see the AgentCore overlay-mount ceiling note in the Dockerfile).
+5. Rebuild + push the image; the new skill advertises at ~40 tokens.

--- a/infra/agent-image/skills/chat-chart/SKILL.md
+++ b/infra/agent-image/skills/chat-chart/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: chat-chart
 summary: REQUIRED for any user request containing "chart", "graph", "plot", or "visualize" — renders inline bar/line/pie/scatter in Google Chat.
-description: Renders a chart from a small data payload and emits a PSD_AGENT_RICH_V1 envelope containing a cardsV2 entry with the chart as an inline image. The Router Lambda lifts the envelope into the Chat message so the user sees the chart in their DM. Two engines — QuickChart.io (fast, external) for clearly-public data, and local matplotlib (private, slower) for anything sensitive. Default engine picks `local` if `--sensitive` is set OR if the data trips an inline PII regex; otherwise `quickchart`.
+description: Render an inline bar/line/pie/scatter chart in Google Chat from a small data payload. REQUIRED whenever the user asks to "chart", "graph", "plot", or "visualize" data.
 allowed-tools: Bash(node:*)
 ---
 

--- a/infra/agent-image/skills/psd-email-triage/SKILL.md
+++ b/infra/agent-image/skills/psd-email-triage/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: psd-email-triage
 summary: Smart email triage — opt-in, per-user rules, Gmail labels, daily digest, Chat escalations. Configure entirely from chat.
-description: When the user asks to start triaging their email (or to adjust rules / escalation / digest / labels for an already-enabled triage setup), call this skill. The skill writes to a per-user DynamoDB row that a background Lambda reads every 5 minutes; the Lambda classifies new mail using rules + Bedrock Nova Micro, applies Gmail labels, and posts escalation cards to chat when something important arrives. Phase 1 of the email triage feature.
+description: Set up or adjust smart email triage — per-user rules, Gmail labels, daily digest, and Chat escalations. Use when the user wants to start or change triaging their inbox.
 allowed-tools: Bash(node:*)
 ---
 

--- a/infra/agent-image/skills/psd-freshservice/SKILL.md
+++ b/infra/agent-image/skills/psd-freshservice/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: psd-freshservice
 summary: Manage Freshservice tickets, approvals, and team summaries — uses each caller's own personal API key, stored per-user in Secrets Manager.
-description: Operate against the PSD Freshservice instance (psd401.freshservice.com) with the caller's personal API key. On first invocation per user, the skill prompts the user to paste their Freshservice API key (Profile → API Key) and stores it via psd-credentials so future calls are silent. Supports listing/searching/getting/creating/updating tickets, adding notes, agent and workspace lookup, approval queues, and daily/weekly Technology workspace summaries.
+description: Manage PSD Freshservice tickets — list/search/create/update, notes, approvals, and Technology-workspace summaries. Use for helpdesk/IT tickets, approvals, or ticket lookups.
 allowed-tools: Bash(node:*)
 ---
 

--- a/infra/agent-image/skills/psd-image-gen/SKILL.md
+++ b/infra/agent-image/skills/psd-image-gen/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: psd-image-gen
 summary: Generate images with OpenAI gpt-image-2 — shared API key, district-funded.
-description: Generates an image from a text prompt via OpenAI's gpt-image-2 model, uploads the PNG to a public-by-link S3 prefix, and returns an unsigned HTTPS URL the agent can surface in chat. Uses a shared (district-funded) OpenAI API key from Secrets Manager — usage costs accrue centrally. Restricted by the `skill.image-gen` capability; users without the capability will be refused at invocation time (the skill remains visible in the catalog until OpenClaw supports per-session filtering). Output includes the URL, model, and resolved size; never the API key.
+description: Generate an image from a text prompt (OpenAI gpt-image-2) and return a shareable HTTPS URL. Use for image generation — "make/create/generate a picture or image", logos, illustrations, visuals.
 allowed-tools: Bash(node:*)
 ---
 

--- a/infra/agent-image/skills/psd-workspace/SKILL.md
+++ b/infra/agent-image/skills/psd-workspace/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: psd-workspace
 summary: Google Workspace operations (Gmail, Calendar, Drive, Docs, Meet, Chat) via the user's dedicated agent account.
-description: Wraps the `gws` CLI. Fetches a refresh token from AWS Secrets Manager, exchanges it for an access token, and executes `gws` subcommands against Google APIs as the agent's own Workspace identity (e.g. `agnt_hagelk@psd401.net`). If the agent has no token yet — or the token is stale — the skill mints a one-time consent URL and returns a structured error. Your job in that case is to paste the `consent_url` verbatim into your Chat reply and ask the user to click it.
+description: Google Workspace (Gmail, Calendar, Drive, Docs, Sheets, Slides, Meet, Chat) as the user's agent account. Use for reading or writing email, calendar events, files, or any Workspace data.
 allowed-tools: Bash(node:*)
 ---
 


### PR DESCRIPTION
## What & why
Lets us add **dozens** of agent skills without growing per-call prefix cost. Verified against OpenClaw docs + code:
- OpenClaw **progressive-discloses** skills — only `name`+`description` are injected into the system prompt (paid on *every* model call, ~5–20×/turn); the `SKILL.md` body loads **on-demand**.
- So skill **count is cheap iff descriptions are tight**. Standard: `description` = 1–2 sentences (~30–50 tok, what + when/trigger words); mechanism goes in the body.
- `summary` is **not** read by OpenClaw but **is required** by the `psd-skills-meta` catalog (`author.js`) — keep it; optimize `description` separately.
- Some skills stashed their best trigger phrase in `summary` (e.g. `chat-chart`'s "REQUIRED for chart/graph/plot"), where the model never saw it → folded into `description`.

## Changes
- **New:** `docs/guides/agent-skill-authoring.md` — the standard + copy-paste template + frontmatter contract + token math.
- **Tightened** the 5 most verbose descriptions (120–149 tok → **41–48 tok** each): `psd-image-gen`, `chat-chart`, `psd-workspace`, `psd-freshservice`, `psd-email-triage`. Mechanism moved to the already-present body; **no behavior change**.

## Effect
- Adding a skill now costs ~40 prefix tokens instead of ~150.
- Takes effect on the next agent image rebuild (e.g. when the ~10 queued skills land).

## Verify
- YAML frontmatter parses for all 5 (name/summary/description present).
- Bodies unchanged.