### PR TITLE
perf: agent token diet — contextTokens cap, tool_search_code contract, build-time config validation

### DIFF
--- a/infra/agent-image/Dockerfile
+++ b/infra/agent-image/Dockerfile
@@ -221,6 +221,15 @@ RUN mkdir -p /home/node/.openclaw/memory
 #   config.model — requires adding a second model to bedrock-proxy. Until
 #   then the sub-agent adds ~5-10s to every turn's wall-clock latency.
 COPY openclaw.json /home/node/.openclaw/openclaw.json
+# Build-time config sanity check (post-2026-07-02 config-risk hardening): surface
+# any openclaw.json schema/key errors at BUILD time instead of at runtime (a
+# rejected config would stop the gateway from starting = an outage). Non-fatal
+# for now — until we confirm `config validate` needs no live runtime env, we
+# only echo a marker on nonzero so a false-positive can't block the build. Read
+# the `[config-validate]` lines in the build log; harden to fatal once trusted.
+RUN HOME=/home/node openclaw config validate 2>&1 | sed 's/^/[config-validate] /'; \
+    HOME=/home/node openclaw config validate >/dev/null 2>&1 \
+      || echo "[config-validate] NONZERO EXIT — inspect openclaw.json before deploying"
 # OpenClaw auto-injects SOUL.md as the system prompt every turn.
 # NOTE: Do NOT put HTML comments or TODO notes in this file — they are
 # visible to the LLM. Keep roadmap notes here in the Dockerfile instead.

--- a/infra/agent-image/Dockerfile
+++ b/infra/agent-image/Dockerfile
@@ -227,9 +227,13 @@ COPY openclaw.json /home/node/.openclaw/openclaw.json
 # for now — until we confirm `config validate` needs no live runtime env, we
 # only echo a marker on nonzero so a false-positive can't block the build. Read
 # the `[config-validate]` lines in the build log; harden to fatal once trusted.
-RUN HOME=/home/node openclaw config validate 2>&1 | sed 's/^/[config-validate] /'; \
-    HOME=/home/node openclaw config validate >/dev/null 2>&1 \
-      || echo "[config-validate] NONZERO EXIT — inspect openclaw.json before deploying"
+RUN HOME=/home/node openclaw config validate >/tmp/config-validate.log 2>&1; \
+    STATUS=$?; \
+    sed 's/^/[config-validate] /' /tmp/config-validate.log; \
+    rm -f /tmp/config-validate.log; \
+    if [ "$STATUS" -ne 0 ]; then \
+      echo "[config-validate] NONZERO EXIT — inspect openclaw.json before deploying"; \
+    fi
 # OpenClaw auto-injects SOUL.md as the system prompt every turn.
 # NOTE: Do NOT put HTML comments or TODO notes in this file — they are
 # visible to the LLM. Keep roadmap notes here in the Dockerfile instead.

--- a/infra/agent-image/openclaw.json
+++ b/infra/agent-image/openclaw.json
@@ -26,6 +26,7 @@
         "primary": "amazon-bedrock-mantle/anthropic.claude-sonnet-5"
       },
       "workspace": "/home/node/.openclaw",
+      "contextTokens": 100000,
       "heartbeat": {
         "every": "0m"
       }

--- a/infra/agent-image/skills/psd-rules/SKILL.md
+++ b/infra/agent-image/skills/psd-rules/SKILL.md
@@ -259,6 +259,18 @@ The reply can be one character. It cannot be zero.
 
 ---
 
+## Rule 14 — `tool_search_code` runs in a locked sandbox
+
+Finding a tool runs a short JS body in an isolated subprocess that exposes **only** `console.log/warn/error` and `openclaw.tools.search`, `openclaw.tools.describe`, `openclaw.tools.call`. There is **no** `require`, `setTimeout`, `fetch`, `fs`, or network — using them throws `not defined` and wastes a full model round-trip.
+
+- **Search takes a plain string**, never an object: ✅ `openclaw.tools.search("create a calendar event")` ❌ `openclaw.tools.search({query: "..."})`.
+- Pattern: `const hits = await openclaw.tools.search("…"); const t = await openclaw.tools.describe(hits[0].id); return await openclaw.tools.call(t.id, {…});`
+- Do not import modules or use timers. Keep the body to search → describe → call.
+
+**Why:** malformed search bodies (object query, `require`, `setTimeout`) error and retry, and every retry re-reads the entire context — a top token-waste source (observed 2026-07-02).
+
+---
+
 ## Self-check before send
 
 Run this mentally before every reply:

--- a/infra/agent-image/skills/psd-rules/SKILL.md
+++ b/infra/agent-image/skills/psd-rules/SKILL.md
@@ -264,7 +264,7 @@ The reply can be one character. It cannot be zero.
 Finding a tool runs a short JS body in an isolated subprocess that exposes **only** `console.log/warn/error` and `openclaw.tools.search`, `openclaw.tools.describe`, `openclaw.tools.call`. There is **no** `require`, `setTimeout`, `fetch`, `fs`, or network — using them throws `not defined` and wastes a full model round-trip.
 
 - **Search takes a plain string**, never an object: ✅ `openclaw.tools.search("create a calendar event")` ❌ `openclaw.tools.search({query: "..."})`.
-- Pattern: `const hits = await openclaw.tools.search("…"); const t = await openclaw.tools.describe(hits[0].id); return await openclaw.tools.call(t.id, {…});`
+- Pattern: `const hits = await openclaw.tools.search("…"); if (!hits.length) return "No tools found"; const t = await openclaw.tools.describe(hits[0].id); return await openclaw.tools.call(t.id, {…});`
 - Do not import modules or use timers. Keep the body to search → describe → call.
 
 **Why:** malformed search bodies (object query, `require`, `setTimeout`) error and retry, and every retry re-reads the entire context — a top token-waste source (observed 2026-07-02).

--- a/infra/agent-image/skills/psd-rules/SKILL.md
+++ b/infra/agent-image/skills/psd-rules/SKILL.md
@@ -273,18 +273,4 @@ Finding a tool runs a short JS body in an isolated subprocess that exposes **onl
 
 ## Self-check before send
 
-Run this mentally before every reply:
-
-1. ✅ Stripped all "Let me…" / "Now let me…" sentences?
-2. ✅ All URLs from skill output, not constructed by me?
-3. ✅ Cited memory files for past-facts, or admitted I don't know?
-4. ✅ Did the work now (or scheduled it), not an empty promise?
-5. ✅ Reply length proportional to information density?
-6. ✅ Updated the memory files this turn?
-7. ✅ For any task a skill covers, called the skill — not replicated it in Bash?
-8. ✅ If the last tool result had a `url`, is that exact URL on its own line? (Prose ≠ URL.)
-9. ✅ If I couldn't fulfill any part, called `psd-failure-report` before sending?
-10. ✅ Is the user-visible text **non-empty**? (Even one emoji counts.)
-11. ✅ Any non-reversible `gh` / `git push` this turn? If yes, did the user authorize it this same turn?
-
-If any answer is "no" — fix the reply before sending.
+Before every reply, confirm: no "Let me…"/scratchpad (R1); every URL is from a skill, and any `url` field is on its own line (R2/R9); no fabricated facts or outcomes (R3); did the work now, not an empty promise (R4); reply length matches information density and memory files updated (R5/R7); for any task a skill covers, called the skill (R9); called `psd-failure-report` if any part failed (R11); user-visible text is non-empty (R12); no non-reversible `gh`/`git push` unless the user authorized it this same turn (R13). If any is "no," fix the reply first.


### PR DESCRIPTION
## Goal
Cut the agent's per-turn token cost, especially the runaway deep turns (the 138k-prefix × ~17-call = 2.38M-token turns). Pairs with #1095 (skill authoring standard — makes adding skills cheap).

## Changes (all agent-image; no CDK change)
- **`openclaw.json`: `agents.defaults.contextTokens = 100000`** (was default 200000). Bounds per-turn context accumulation; only affects turns that would exceed 100k (normal turns are 22–47k, untouched). Verified key (docs.openclaw.ai/gateway/config-agents).
- **`psd-rules` Rule 14 — `tool_search_code` sandbox contract.** The tool-search body runs in an isolated subprocess exposing only `console.*` + `openclaw.tools.{search,describe,call}` — no `require`/`setTimeout`/Node (verified). The model repeatedly failed it and retried, each retry re-reading the full context. Rule 14 gives the correct contract (string query; search→describe→call).
- **Dockerfile: build-time `openclaw config validate`** — surfaces bad config keys at BUILD, not as a runtime gateway failure (lesson from the 2026-07-02 overlay-mount outage). Non-fatal this round; build log shows `[config-validate] Config valid`.
- **`psd-rules` self-check condensed** — rules stated in full above are unchanged; no behavioral rule removed.

## Verified before requesting deploy
- Build-time `openclaw config validate` → **`Config valid`** (OpenClaw accepts `contextTokens`).
- ECR manifest: **49 layers** (≤53 ceiling).
- Image `2026-07-02-token-diet-r4` / `sha256:d6fff70695cfe1b5a26f28b41e057e2d8221742d501b1a4799fff72b4a1a667a`.

## Honest scope
Typical-turn static floor is mostly OpenClaw's own base prompt (not ours); this PR targets the expensive accumulation tail + wasted iterations, which dominate cost.