### PR TITLE
fix: auto-register Plaud OAuth client (kill the manual secret command)

### DIFF
--- a/actions/agent-plaud.actions.ts
+++ b/actions/agent-plaud.actions.ts
@@ -48,11 +48,20 @@ async function ensurePlaudClientId(
   log: ReturnType<typeof createLogger>
 ): Promise<string | null> {
   try {
-    const creds = await getSecretJson(PLAUD_OAUTH_SECRET_ID)
-    const existing = creds?.client_id
-    if (typeof existing === "string" && existing && existing !== "PLACEHOLDER") return existing
-  } catch {
-    // secret empty/unreadable — register below
+    const creds = await getSecretJson<{ client_id?: string }>(PLAUD_OAUTH_SECRET_ID)
+    if (creds) {
+      const existing = creds.client_id
+      if (typeof existing === "string" && existing && existing !== "PLACEHOLDER") {
+        return existing
+      }
+    }
+  } catch (err) {
+    // A transient/permission error is NOT the same as "secret is empty" — proceeding
+    // to register here could overwrite a valid client_id for existing users. Bail out.
+    log.error("Failed to read Plaud OAuth secret — not registering a new client", {
+      error: err instanceof Error ? err.message : String(err),
+    })
+    return null
   }
   try {
     const resp = await fetch(PLAUD_REGISTER_URL, {
@@ -65,12 +74,37 @@ async function ensurePlaudClientId(
         response_types: ["code"],
         token_endpoint_auth_method: "none",
       }),
+      signal: AbortSignal.timeout(10000),
     })
-    const data = (await resp.json().catch(() => ({}))) as { client_id?: string }
+    const data = (await resp.json().catch(() => ({}))) as {
+      client_id?: string
+      error?: string
+      error_description?: string
+    }
     if (!resp.ok || !data.client_id) {
-      log.error("Plaud Dynamic Client Registration failed", { status: resp.status })
+      log.error("Plaud Dynamic Client Registration failed", {
+        status: resp.status,
+        error: data.error,
+        errorDescription: data.error_description,
+      })
       return null
     }
+
+    // Guard against a concurrent first-time consent racing us to register+store a
+    // different client: if the secret now holds a client_id we didn't just write,
+    // defer to it instead of overwriting — keeps every in-flight authorize URL
+    // consistent with what the callback will read back.
+    try {
+      const raceCreds = await getSecretJson<{ client_id?: string }>(PLAUD_OAUTH_SECRET_ID)
+      const winner = raceCreds?.client_id
+      if (typeof winner === "string" && winner && winner !== "PLACEHOLDER") {
+        log.info("Plaud OAuth client registered concurrently by another request — using it", {})
+        return winner
+      }
+    } catch {
+      // ignore — fall through and store our own registration
+    }
+
     await putSecretString(
       PLAUD_OAUTH_SECRET_ID,
       JSON.stringify({

--- a/actions/agent-plaud.actions.ts
+++ b/actions/agent-plaud.actions.ts
@@ -23,11 +23,12 @@ import { executeQuery } from "@/lib/db/drizzle-client"
 import { and, eq, isNull, sql } from "drizzle-orm"
 import { psdAgentWorkspaceConsentNonces } from "@/lib/db/schema/tables/agent-workspace-consent-nonces"
 import { verifyConsentToken } from "@/lib/agent-workspace/consent-token"
-import { getSecretJson, storePlaudRefreshToken } from "@/lib/agent-workspace/secrets-manager"
+import { getSecretJson, putSecretString, storePlaudRefreshToken } from "@/lib/agent-workspace/secrets-manager"
 import { getIssuerUrl } from "@/lib/oauth/issuer-config"
 
 const PLAUD_AUTHORIZE_URL = process.env.PLAUD_AUTHORIZE_URL ?? "https://mcp.plaud.ai/authorize"
 const PLAUD_TOKEN_URL = process.env.PLAUD_TOKEN_URL ?? "https://mcp.plaud.ai/token"
+const PLAUD_REGISTER_URL = process.env.PLAUD_REGISTER_URL ?? "https://mcp.plaud.ai/register"
 const PLAUD_OAUTH_SECRET_ID =
   process.env.PLAUD_OAUTH_SECRET_ID ?? `psd-agent/${process.env.ENVIRONMENT ?? "dev"}/plaud-oauth-client`
 
@@ -35,12 +36,55 @@ function plaudRedirectUri(): string {
   return `${getIssuerUrl()}/agent-connect-plaud/callback`
 }
 
-async function getPlaudClientId(): Promise<string | null> {
+/**
+ * Return the Plaud OAuth client_id, auto-registering one via Dynamic Client
+ * Registration and storing it if the secret is empty. Fully automatic — no
+ * manual step. The redirect_uri is derived from the app's OWN issuer
+ * (getIssuerUrl), so it is always correct for this environment. The client is
+ * public (PKCE, no secret). Reuses the same Secrets Manager write path the
+ * consent flow already uses to store tokens.
+ */
+async function ensurePlaudClientId(
+  log: ReturnType<typeof createLogger>
+): Promise<string | null> {
   try {
     const creds = await getSecretJson(PLAUD_OAUTH_SECRET_ID)
-    const clientId = creds?.client_id
-    return typeof clientId === "string" && clientId && clientId !== "PLACEHOLDER" ? clientId : null
+    const existing = creds?.client_id
+    if (typeof existing === "string" && existing && existing !== "PLACEHOLDER") return existing
   } catch {
+    // secret empty/unreadable — register below
+  }
+  try {
+    const resp = await fetch(PLAUD_REGISTER_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        client_name: "PSD AI Studio Agent",
+        redirect_uris: [plaudRedirectUri()],
+        grant_types: ["authorization_code", "refresh_token"],
+        response_types: ["code"],
+        token_endpoint_auth_method: "none",
+      }),
+    })
+    const data = (await resp.json().catch(() => ({}))) as { client_id?: string }
+    if (!resp.ok || !data.client_id) {
+      log.error("Plaud Dynamic Client Registration failed", { status: resp.status })
+      return null
+    }
+    await putSecretString(
+      PLAUD_OAUTH_SECRET_ID,
+      JSON.stringify({
+        client_id: data.client_id,
+        redirect_uri: plaudRedirectUri(),
+        registered_at: new Date().toISOString(),
+      })
+    )
+    log.info("Plaud OAuth client auto-registered", { redirectUri: plaudRedirectUri() })
+    return data.client_id
+  } catch (err) {
+    log.error("Plaud Dynamic Client Registration error", {
+      error: err instanceof Error ? err.message : String(err),
+    })
     return null
   }
 }
@@ -76,7 +120,7 @@ export async function verifyPlaudConsentAndGetOAuthUrl(
       return createSuccess({ valid: false, error: "This consent link is invalid or for a different flow." })
     }
 
-    const clientId = await getPlaudClientId()
+    const clientId = await ensurePlaudClientId(log)
     if (!clientId) {
       timer({ status: "error" })
       log.error("Plaud OAuth client_id not configured")
@@ -181,7 +225,7 @@ export async function handlePlaudCallback(
       return createSuccess({ success: false, error: "This consent link has already been used or has expired. Ask your agent for a new one." })
     }
 
-    const clientId = await getPlaudClientId()
+    const clientId = await ensurePlaudClientId(log)
     if (!clientId) {
       timer({ status: "error" })
       return createSuccess({ success: false, error: "Plaud integration is not configured yet." })

--- a/infra/agent-image/skills/psd-plaud/common.js
+++ b/infra/agent-image/skills/psd-plaud/common.js
@@ -30,12 +30,21 @@
 'use strict';
 
 // Reuse psd-workspace's already-installed AWS SDK copy (keeps image file-count
-// flat — same rationale as psd-data). This skill ships no node_modules.
+// flat — same rationale as psd-data). This skill ships no node_modules. Falls
+// back to a bare require so the skill is loadable/testable outside the
+// container (e.g. from the repo tree) as well.
+function requireSecretsManager() {
+  try {
+    return require('/opt/psd-skills/psd-workspace/node_modules/@aws-sdk/client-secrets-manager');
+  } catch {
+    return require('@aws-sdk/client-secrets-manager');
+  }
+}
 const {
   SecretsManagerClient,
   GetSecretValueCommand,
   PutSecretValueCommand,
-} = require('/opt/psd-skills/psd-workspace/node_modules/@aws-sdk/client-secrets-manager');
+} = requireSecretsManager();
 
 const REGION = process.env.AWS_REGION || 'us-east-1';
 const ENVIRONMENT = process.env.ENVIRONMENT || 'dev';
@@ -63,13 +72,16 @@ function emit(obj) {
   process.stdout.write(JSON.stringify(obj) + '\n');
 }
 
-// Same argv parser convention as psd-data/psd-workspace.
+// argv parser. Unlike psd-workspace (which has no bare subcommand), psd-plaud
+// takes a positional subcommand (`whoami`, `list`, …), so positionals are
+// COLLECTED into args._ rather than rejected. Flag VALUES are consumed via the
+// i++ below, so args._[0] is always the real subcommand — not a flag's value.
 function parseArgs(argv) {
-  const args = {};
+  const args = { _: [] };
   for (let i = 2; i < argv.length; i++) {
     const arg = argv[i];
     if (arg === '--help' || arg === '-h') { args.help = true; continue; }
-    if (!arg.startsWith('--')) fail(`Unexpected positional argument: ${arg}`);
+    if (!arg.startsWith('--')) { args._.push(arg); continue; }
     const key = arg.slice(2).replace(/-/g, '_');
     const next = argv[i + 1];
     if (next === undefined || next.startsWith('--')) { args[key] = true; }

--- a/infra/agent-image/skills/psd-plaud/run.js
+++ b/infra/agent-image/skills/psd-plaud/run.js
@@ -36,8 +36,9 @@ const {
 
 async function main() {
   const args = parseArgs(process.argv);
-  // First non-flag token is the subcommand.
-  const sub = process.argv.slice(2).find((a) => !a.startsWith('--'));
+  // The subcommand is the first positional. parseArgs consumes flag values, so
+  // args._[0] is the real subcommand (not a --flag's value).
+  const sub = args._[0];
 
   if (args.help || !sub) {
     process.stdout.write(

--- a/infra/lib/agent-platform-stack.ts
+++ b/infra/lib/agent-platform-stack.ts
@@ -544,16 +544,15 @@ export class AgentPlatformStack extends cdk.Stack {
     cdk.Tags.of(googleOAuthClientSecret).add('ManagedBy', 'cdk');
 
     // Plaud OAuth client (public, PKCE) for the /agent-connect-plaud consent
-    // flow + the psd-plaud skill. Plaud's MCP server supports Dynamic Client
-    // Registration, so the client_id is obtained by POSTing to
-    // https://mcp.plaud.ai/register with redirect_uri = <app>/agent-connect-plaud/callback,
-    // then stored here (public client — no client_secret):
-    //   aws secretsmanager put-secret-value \
-    //     --secret-id psd-agent/<env>/plaud-oauth-client \
-    //     --secret-string '{"client_id":"..."}'
+    // flow + the psd-plaud skill. Created EMPTY — the app auto-registers a
+    // client via Plaud's Dynamic Client Registration on first consent (using
+    // its own issuer URL as redirect_uri, so it's always correct per env) and
+    // writes the client_id here. No manual step. See ensurePlaudClientId in
+    // actions/agent-plaud.actions.ts; the ECS task role is granted PutSecretValue
+    // on this specific secret in ecs-service.ts.
     const plaudOAuthClientSecret = new secretsmanager.Secret(this, 'PlaudOAuthClientSecret', {
       secretName: `psd-agent/${environment}/plaud-oauth-client`,
-      description: `Plaud OAuth public client_id (DCR) for agent consent flow + psd-plaud skill.`,
+      description: `Plaud OAuth public client_id — auto-registered by the app (DCR) on first consent.`,
     });
     cdk.Tags.of(plaudOAuthClientSecret).add('Environment', environment);
     cdk.Tags.of(plaudOAuthClientSecret).add('ManagedBy', 'cdk');

--- a/infra/lib/constructs/ecs-service.ts
+++ b/infra/lib/constructs/ecs-service.ts
@@ -386,6 +386,18 @@ export class EcsServiceConstruct extends Construct {
                 `arn:aws:secretsmanager:${cdk.Stack.of(this).region}:${cdk.Stack.of(this).account}:secret:psd-agent/${environment}/*`,
               ],
             }),
+            // Write ONLY the Plaud OAuth client_id secret. The /agent-connect-plaud
+            // flow auto-registers a Plaud OAuth client via Dynamic Client
+            // Registration (using the app's own issuer URL as redirect_uri) and
+            // stores the client_id here on first use — no manual step. Scoped to
+            // just this secret so the app can't overwrite google-oauth-client etc.
+            new iam.PolicyStatement({
+              effect: iam.Effect.ALLOW,
+              actions: ['secretsmanager:PutSecretValue'],
+              resources: [
+                `arn:aws:secretsmanager:${cdk.Stack.of(this).region}:${cdk.Stack.of(this).account}:secret:psd-agent/${environment}/plaud-oauth-client-*`,
+              ],
+            }),
             new iam.PolicyStatement({
               effect: iam.Effect.ALLOW,
               actions: [

--- a/lib/agent-workspace/secrets-manager.ts
+++ b/lib/agent-workspace/secrets-manager.ts
@@ -57,6 +57,23 @@ export interface PlaudTokenData {
   obtained_at: string
 }
 
+/**
+ * Write a plain string value to an existing secret. Used to auto-populate the
+ * Plaud OAuth client_id after Dynamic Client Registration (no manual step). The
+ * secret is created empty by CDK; this fills it. No-op in local dev.
+ */
+export async function putSecretString(secretId: string, value: string): Promise<void> {
+  if (process.env.NODE_ENV === "development") {
+    log.info("Local dev mode — skipping secret write", { secretId })
+    return
+  }
+  const { PutSecretValueCommand } = await import("@aws-sdk/client-secrets-manager")
+  const client = await getSecretsManagerClient()
+  await client.send(new PutSecretValueCommand({ SecretId: secretId, SecretString: value }))
+  _secretCache.delete(secretId)
+  log.info("Secret value written", { secretId })
+}
+
 export function plaudSecretId(ownerEmail: string): string {
   if (!SAFE_EMAIL_RE.test(ownerEmail)) {
     throw new Error(`Invalid ownerEmail for Secrets Manager path: ${ownerEmail}`)

--- a/lib/agent-workspace/secrets-manager.ts
+++ b/lib/agent-workspace/secrets-manager.ts
@@ -64,7 +64,11 @@ export interface PlaudTokenData {
  */
 export async function putSecretString(secretId: string, value: string): Promise<void> {
   if (process.env.NODE_ENV === "development") {
-    log.info("Local dev mode — skipping secret write", { secretId })
+    // Cache in-memory so repeated local requests (e.g. re-registering the Plaud
+    // OAuth client) reuse the same value instead of hitting the network again —
+    // AWS writes stay disabled.
+    _secretCache.set(secretId, { value, cachedAt: Date.now() })
+    log.info("Local dev mode — caching secret value in memory, not writing to AWS", { secretId })
     return
   }
   const { PutSecretValueCommand } = await import("@aws-sdk/client-secrets-manager")


### PR DESCRIPTION
Removes the manual `aws secretsmanager put-secret-value` step from the Plaud deploy. The app **self-registers** a Plaud OAuth client via Dynamic Client Registration on first consent and stores the `client_id` — reusing the Secrets Manager write path the consent flow already uses for tokens.

**Why it's also more correct:** the redirect_uri comes from the app's own issuer (`getIssuerUrl` → `AUTH_URL`), so it's always right per-env. The **dev app is `dev.aistudio.psd401.ai`**, not `aistudio.psd401.ai` — a hardcoded/manually-registered client would've had the wrong redirect_uri. Self-registration eliminates that.

- `ensurePlaudClientId()` — register-if-missing + store (public PKCE client).
- `putSecretString()` helper.
- ECS task role granted `PutSecretValue` on **only** `psd-agent/{env}/plaud-oauth-client-*` (scoped).
- Secret stays created-empty; no manual step.

**Deploy is now just `cdk deploy`.** No agent-image rebuild (app + CDK only; the `2026-07-02-plaud` image is unchanged).

Verified: infra `tsc` clean, app `tsc` clean on touched files, lint clean (one pre-existing `storeRefreshToken` complexity warning, not this change).