### PR TITLE
fix(agent): psd-plaud sends file_id not id, handles MCP isError, psd-summarize sets anthropic_version

### DIFF
--- a/infra/agent-image/.dockerignore
+++ b/infra/agent-image/.dockerignore
@@ -30,3 +30,5 @@ node_modules/
 # Local-only test scratch
 test_*.py
 *.test.ts
+*.test.js
+mcp-test-support.js

--- a/infra/agent-image/skills/psd-plaud/SKILL.md
+++ b/infra/agent-image/skills/psd-plaud/SKILL.md
@@ -67,5 +67,7 @@ never enters your context, the chat, memory, or logs. Only reach for
 ## Notes
 
 - Read-only. There is no create/delete/share path.
-- Tool names/arg shapes follow Plaud's documented MCP tools; if a call fails on
-  an argument, run `tools` to see the live schema.
+- `file`/`digest`/`transcript`/`summary` call Plaud's MCP tools with the
+  recording id under the `file_id` argument key (confirmed live against
+  Plaud's MCP server) — not `id`. If a call still fails on an argument, run
+  `tools` to see the live schema.

--- a/infra/agent-image/skills/psd-plaud/common.js
+++ b/infra/agent-image/skills/psd-plaud/common.js
@@ -336,7 +336,13 @@ async function invokeTool(toolName, toolArgs, ownerEmail) {
   // guard the error text flows back to callers (e.g. digestRecording pipes it
   // into psd-summarize) as if it were real tool content.
   if (msg.result && msg.result.isError) {
-    emit({ status: 'mcp-error', tool: toolName, tool_error: extractTextFromResult(msg.result) || msg.result });
+    // Truncate like the HTTP-failure branches above — this text originates
+    // from the upstream MCP server, and digestRecording calls invokeTool
+    // specifically so raw tool content never reaches stdout uncontrolled;
+    // an error payload shouldn't be a wider bypass of that than a real HTTP
+    // failure already is.
+    const detail = extractTextFromResult(msg.result);
+    emit({ status: 'mcp-error', tool: toolName, tool_error: detail ? detail.slice(0, 400) : null });
     process.exit(12);
   }
   return msg.result ?? null;

--- a/infra/agent-image/skills/psd-plaud/common.js
+++ b/infra/agent-image/skills/psd-plaud/common.js
@@ -330,6 +330,15 @@ async function invokeTool(toolName, toolArgs, ownerEmail) {
     emit({ status: 'mcp-error', tool: toolName, jsonrpc_error: msg.error });
     process.exit(12);
   }
+  // Per the MCP spec, a tool-level failure is a JSON-RPC SUCCESS whose result
+  // carries isError:true with the error text in result.content — it is NOT
+  // surfaced via the top-level msg.error field checked above. Without this
+  // guard the error text flows back to callers (e.g. digestRecording pipes it
+  // into psd-summarize) as if it were real tool content.
+  if (msg.result && msg.result.isError) {
+    emit({ status: 'mcp-error', tool: toolName, tool_error: extractTextFromResult(msg.result) || msg.result });
+    process.exit(12);
+  }
   return msg.result ?? null;
 }
 
@@ -358,7 +367,7 @@ function extractTextFromResult(result) {
  * recording content (raw `transcript` is the explicit exception).
  */
 async function digestRecording(ownerEmail, id, opts) {
-  const result = await invokeTool('get_transcript', { id }, ownerEmail);
+  const result = await invokeTool('get_transcript', { file_id: id }, ownerEmail);
   const transcript = extractTextFromResult(result);
   if (!transcript) {
     emit({ status: 'empty', message: 'No transcript text is available for this recording.' });

--- a/infra/agent-image/skills/psd-plaud/common.test.js
+++ b/infra/agent-image/skills/psd-plaud/common.test.js
@@ -1,0 +1,151 @@
+/**
+ * Regression tests for common.js's MCP boundary (issue #1104 points 2 and 1b).
+ *
+ * 1. digestRecording must call get_transcript with `file_id`, not `id`.
+ * 2. invokeTool must treat a JSON-RPC SUCCESS whose result carries
+ *    `isError: true` (the MCP-spec shape for a tool-level failure) as a
+ *    failure — emitting a structured mcp-error and exiting 12 — instead of
+ *    returning `result` as if it were real tool content. Without this guard,
+ *    digestRecording would pipe the error text into psd-summarize as if it
+ *    were the transcript.
+ *
+ * The Secrets Manager and Plaud MCP/OAuth HTTP calls are stubbed so these
+ * tests exercise the real invokeTool/digestRecording logic end-to-end.
+ */
+
+'use strict';
+
+const { test, expect, beforeEach, afterEach, mock } = require('bun:test');
+
+const { secretsStore } = require('./mcp-test-support'); // registers the shared Secrets Manager mock
+
+const common = require('./common');
+
+const EMAIL = 'teacher@psd401.net';
+const PLAUD_TOKEN_SECRET_ID = `psd-agent-creds/dev/user/${EMAIL}/plaud`;
+const PLAUD_OAUTH_SECRET_ID = 'psd-agent/dev/plaud-oauth-client';
+
+let mcpToolResultQueue;
+let fetchCalls;
+let originalFetch;
+
+function jsonResponse(body, { headers = {} } = {}) {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'content-type': 'application/json', ...headers },
+  });
+}
+
+beforeEach(() => {
+  for (const key of Object.keys(secretsStore)) delete secretsStore[key];
+  secretsStore[PLAUD_TOKEN_SECRET_ID] = { refresh_token: 'stored-refresh', client_id: 'client-abc' };
+  secretsStore[PLAUD_OAUTH_SECRET_ID] = { client_id: 'client-abc' };
+  mcpToolResultQueue = [];
+  fetchCalls = [];
+  originalFetch = globalThis.fetch;
+  globalThis.fetch = mock(async (url, init = {}) => {
+    const u = String(url);
+    fetchCalls.push({ url: u, init });
+    if (u.includes('/token')) {
+      return jsonResponse({ access_token: 'access-tok', refresh_token: 'refreshed-tok', expires_in: 3600 });
+    }
+    if (u.includes('mcp.plaud.ai/mcp')) {
+      const body = JSON.parse(init.body);
+      if (body.method === 'initialize') {
+        return jsonResponse({ jsonrpc: '2.0', id: body.id, result: {} }, { headers: { 'mcp-session-id': 'sess-1' } });
+      }
+      if (body.method === 'notifications/initialized') {
+        return jsonResponse({});
+      }
+      if (body.method === 'tools/call') {
+        const result = mcpToolResultQueue.shift();
+        return jsonResponse({ jsonrpc: '2.0', id: body.id, result });
+      }
+    }
+    throw new Error(`Unexpected fetch to ${u}`);
+  });
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+function lastToolCallParams() {
+  const call = fetchCalls
+    .filter((c) => c.url.includes('mcp.plaud.ai/mcp'))
+    .map((c) => JSON.parse(c.init.body))
+    .find((b) => b.method === 'tools/call');
+  return call && call.params;
+}
+
+test('digestRecording calls get_transcript with file_id (not id)', async () => {
+  mcpToolResultQueue.push({ content: [{ type: 'text', text: 'raw transcript text' }] });
+  const cp = require('node:child_process');
+  const originalSpawnSync = cp.spawnSync;
+  cp.spawnSync = mock(() => ({
+    status: 0,
+    stdout: `${JSON.stringify({ status: 'ok', summary: 'summarized safely' })}\n`,
+    stderr: '',
+  }));
+  const originalWrite = process.stdout.write.bind(process.stdout);
+  const chunks = [];
+  process.stdout.write = (chunk) => { chunks.push(chunk); return true; };
+  try {
+    await common.digestRecording(EMAIL, 'rec-555', {});
+  } finally {
+    process.stdout.write = originalWrite;
+    cp.spawnSync = originalSpawnSync;
+  }
+  const params = lastToolCallParams();
+  expect(params.name).toBe('get_transcript');
+  expect(params.arguments).toEqual({ file_id: 'rec-555' });
+  expect(chunks.join('')).toContain('summarized safely');
+});
+
+test('invokeTool treats an isError:true tool result as a failure (exit 12, mcp-error)', async () => {
+  mcpToolResultQueue.push({
+    content: [{ type: 'text', text: 'Upstream Plaud error: transcript not ready' }],
+    isError: true,
+  });
+  const chunks = [];
+  const originalWrite = process.stdout.write.bind(process.stdout);
+  process.stdout.write = (chunk) => { chunks.push(chunk); return true; };
+  const originalExit = process.exit.bind(process);
+  let exitCode;
+  process.exit = (code) => { exitCode = code; throw new Error('__test_exit__'); };
+  try {
+    await expect(common.callTool('get_transcript', { file_id: 'rec-1' }, EMAIL)).rejects.toThrow('__test_exit__');
+  } finally {
+    process.stdout.write = originalWrite;
+    process.exit = originalExit;
+  }
+  expect(exitCode).toBe(12);
+  const emitted = JSON.parse(chunks.join(''));
+  expect(emitted.status).toBe('mcp-error');
+  expect(emitted.tool).toBe('get_transcript');
+});
+
+test('digestRecording does not pipe an isError tool result into psd-summarize', async () => {
+  mcpToolResultQueue.push({
+    content: [{ type: 'text', text: 'Upstream Plaud error: transcript not ready' }],
+    isError: true,
+  });
+  const cp = require('node:child_process');
+  const originalSpawnSync = cp.spawnSync;
+  let spawnCalled = false;
+  cp.spawnSync = mock(() => { spawnCalled = true; return { status: 0, stdout: '{}', stderr: '' }; });
+  const originalExit = process.exit.bind(process);
+  let exitCode;
+  process.exit = (code) => { exitCode = code; throw new Error('__test_exit__'); };
+  const originalWrite = process.stdout.write.bind(process.stdout);
+  process.stdout.write = () => true;
+  try {
+    await expect(common.digestRecording(EMAIL, 'rec-2', {})).rejects.toThrow('__test_exit__');
+  } finally {
+    process.exit = originalExit;
+    process.stdout.write = originalWrite;
+    cp.spawnSync = originalSpawnSync;
+  }
+  expect(exitCode).toBe(12);
+  expect(spawnCalled).toBe(false);
+});

--- a/infra/agent-image/skills/psd-plaud/mcp-test-support.js
+++ b/infra/agent-image/skills/psd-plaud/mcp-test-support.js
@@ -1,0 +1,53 @@
+/**
+ * Shared Secrets Manager stub for psd-plaud's bun test files.
+ *
+ * Bun's `mock.module` registry is process-wide: `bun test` loads every
+ * *.test.js file into the same process, so two files independently calling
+ * `mock.module('@aws-sdk/client-secrets-manager', ...)` would clobber each
+ * other (the later registration silently wins for both files). Centralizing
+ * the registration here — required once by both run.test.js and
+ * common.test.js — keeps a single fake in effect for the whole test run.
+ *
+ * `secretsStore` is a plain, mutable object keyed by SecretId; each test file
+ * populates/clears it in its own beforeEach.
+ */
+
+'use strict';
+
+const { mock } = require('bun:test');
+
+class FakeGetSecretValueCommand {
+  constructor(input) { this.input = input; }
+}
+class FakePutSecretValueCommand {
+  constructor(input) { this.input = input; }
+}
+
+const secretsStore = {};
+
+class FakeSecretsManagerClient {
+  async send(command) {
+    if (command instanceof FakeGetSecretValueCommand) {
+      const value = secretsStore[command.input.SecretId];
+      if (value === undefined) {
+        const err = new Error(`Secret ${command.input.SecretId} not found`);
+        err.name = 'ResourceNotFoundException';
+        throw err;
+      }
+      return { SecretString: JSON.stringify(value) };
+    }
+    if (command instanceof FakePutSecretValueCommand) {
+      secretsStore[command.input.SecretId] = JSON.parse(command.input.SecretString);
+      return {};
+    }
+    throw new Error(`Unexpected Secrets Manager command: ${command.constructor.name}`);
+  }
+}
+
+mock.module('@aws-sdk/client-secrets-manager', () => ({
+  SecretsManagerClient: FakeSecretsManagerClient,
+  GetSecretValueCommand: FakeGetSecretValueCommand,
+  PutSecretValueCommand: FakePutSecretValueCommand,
+}));
+
+module.exports = { secretsStore };

--- a/infra/agent-image/skills/psd-plaud/run.js
+++ b/infra/agent-image/skills/psd-plaud/run.js
@@ -22,10 +22,11 @@
  *
  * Exit codes: 0 ok · 1 usage · 10 needs-auth · 12 mcp/upstream error · 14 rate-limited.
  *
- * NOTE: the exact MCP tool names/arg keys are the documented ones
- * (list_files/get_file/get_note/get_transcript/get_current_user). Run
- * `tools` once after the first user authorizes to confirm arg shapes, then
- * pin them here if they differ.
+ * NOTE: tool names are list_files/get_file/get_note/get_transcript/
+ * get_current_user. get_file/get_note/get_transcript take the recording id
+ * under the `file_id` argument key (confirmed live against Plaud's MCP
+ * server) — list_files takes no id. Run `tools` if a call ever fails on an
+ * argument to re-confirm the live schema.
  */
 
 'use strict';
@@ -75,7 +76,7 @@ async function main() {
 
     case 'file': {
       if (!args.id || args.id === true) fail('file requires --id <recording-id>');
-      await callTool('get_file', { id: args.id }, userEmail);
+      await callTool('get_file', { file_id: args.id }, userEmail);
       break;
     }
 
@@ -91,13 +92,13 @@ async function main() {
 
     case 'transcript': {
       if (!args.id || args.id === true) fail('transcript requires --id <recording-id>');
-      await callTool('get_transcript', { id: args.id }, userEmail);
+      await callTool('get_transcript', { file_id: args.id }, userEmail);
       break;
     }
 
     case 'summary': {
       if (!args.id || args.id === true) fail('summary requires --id <recording-id>');
-      await callTool('get_note', { id: args.id }, userEmail);
+      await callTool('get_note', { file_id: args.id }, userEmail);
       break;
     }
 
@@ -106,4 +107,8 @@ async function main() {
   }
 }
 
-main().catch((err) => fail(err instanceof Error ? err.message : String(err)));
+if (require.main === module) {
+  main().catch((err) => fail(err instanceof Error ? err.message : String(err)));
+}
+
+module.exports = { main };

--- a/infra/agent-image/skills/psd-plaud/run.test.js
+++ b/infra/agent-image/skills/psd-plaud/run.test.js
@@ -1,0 +1,91 @@
+/**
+ * Regression tests for run.js's CLI subcommand → MCP tool-argument wiring.
+ *
+ * Confirms the fix for issue #1104 point 1: `file`/`transcript`/`summary`
+ * must call their MCP tools with the recording id under `file_id`, not `id`
+ * (Plaud's MCP server rejects `id` and every content fetch previously failed).
+ *
+ * common.js's callTool/digestRecording/listTools are overridden on the shared
+ * module.exports object BEFORE run.js is required, so run.js's top-level
+ * `const { callTool, ... } = require('./common')` destructures our stubs
+ * instead of hitting the network/Secrets Manager. The AWS SDK is mocked so
+ * requiring the (otherwise unmodified) common.js doesn't crash at module load.
+ */
+
+'use strict';
+
+const { test, expect, beforeEach } = require('bun:test');
+
+require('./mcp-test-support'); // registers the shared Secrets Manager mock
+
+const common = require('./common');
+
+let toolCalls;
+let digestCalls;
+
+// run.js destructures `const { callTool, digestRecording, listTools } =
+// require('./common')` at its own module-load time below — a one-time copy
+// of whatever those properties are AT THAT INSTANT. So the stubs only need
+// to be in place for the duration of that require() call; common.js's shared
+// module.exports object (visible to every other test file sharing Bun's
+// module cache, e.g. common.test.js) is restored immediately after, while
+// run.js's already-captured local bindings keep pointing at the stubs.
+const originalCallTool = common.callTool;
+const originalDigestRecording = common.digestRecording;
+const originalListTools = common.listTools;
+
+common.callTool = async (toolName, toolArgs, userEmail) => {
+  toolCalls.push({ toolName, toolArgs, userEmail });
+  return { ok: true };
+};
+common.digestRecording = async (userEmail, id, opts) => {
+  digestCalls.push({ userEmail, id, opts });
+};
+common.listTools = async () => {};
+
+const { main } = require('./run');
+
+common.callTool = originalCallTool;
+common.digestRecording = originalDigestRecording;
+common.listTools = originalListTools;
+
+const EMAIL = 'teacher@psd401.net';
+
+beforeEach(() => {
+  toolCalls = [];
+  digestCalls = [];
+});
+
+async function runCli(argv) {
+  process.argv = ['node', 'run.js', ...argv];
+  await main();
+}
+
+test('file subcommand sends file_id (not id) to the MCP tool', async () => {
+  await runCli(['--user', EMAIL, 'file', '--id', 'rec-123']);
+  expect(toolCalls).toHaveLength(1);
+  expect(toolCalls[0].toolName).toBe('get_file');
+  expect(toolCalls[0].toolArgs).toEqual({ file_id: 'rec-123' });
+  expect(toolCalls[0].toolArgs.id).toBeUndefined();
+});
+
+test('transcript subcommand sends file_id (not id) to the MCP tool', async () => {
+  await runCli(['--user', EMAIL, 'transcript', '--id', 'rec-999']);
+  expect(toolCalls).toHaveLength(1);
+  expect(toolCalls[0].toolName).toBe('get_transcript');
+  expect(toolCalls[0].toolArgs).toEqual({ file_id: 'rec-999' });
+});
+
+test('summary subcommand sends file_id (not id) to the MCP tool', async () => {
+  await runCli(['--user', EMAIL, 'summary', '--id', 'rec-777']);
+  expect(toolCalls).toHaveLength(1);
+  expect(toolCalls[0].toolName).toBe('get_note');
+  expect(toolCalls[0].toolArgs).toEqual({ file_id: 'rec-777' });
+});
+
+test('digest subcommand forwards the raw --id through to digestRecording', async () => {
+  await runCli(['--user', EMAIL, 'digest', '--id', 'rec-555']);
+  expect(digestCalls).toHaveLength(1);
+  expect(digestCalls[0].id).toBe('rec-555');
+  expect(toolCalls).toHaveLength(0); // digest never calls callTool directly
+});

--- a/infra/agent-image/skills/psd-summarize/run.js
+++ b/infra/agent-image/skills/psd-summarize/run.js
@@ -151,6 +151,7 @@ async function main() {
         Authorization: `Bearer ${BEARER}`,
       },
       body: JSON.stringify({
+        anthropic_version: 'bedrock-2023-05-31',
         model: MODEL_ID,
         max_tokens: 2000,
         system,

--- a/infra/agent-image/skills/psd-summarize/run.test.js
+++ b/infra/agent-image/skills/psd-summarize/run.test.js
@@ -1,0 +1,78 @@
+/**
+ * Regression test for issue #1104 point 3: the Mantle Anthropic Messages
+ * request body must include `anthropic_version` — Bedrock Mantle's Anthropic
+ * path requires it and returns HTTP 400 without it.
+ *
+ * run.js executes at require-time (no require.main guard — it's a stdin
+ * pipe-oriented script, not one with argv-driven subcommands like psd-plaud),
+ * so this test drives it as a real child process, stubbing stdin and the
+ * Mantle endpoint isn't possible without a live/mock HTTP server. Instead we
+ * spawn a local HTTP server that captures the request body and points
+ * MANTLE_ANTHROPIC_URL at it — exercising the real fetch call end-to-end.
+ */
+
+'use strict';
+
+const { test, expect, afterEach } = require('bun:test');
+const path = require('node:path');
+const { spawn } = require('node:child_process');
+
+let server;
+let capturedBody;
+
+function startCaptureServer() {
+  return new Promise((resolve) => {
+    server = Bun.serve({
+      port: 0,
+      async fetch(req) {
+        capturedBody = await req.json();
+        return new Response(
+          JSON.stringify({ content: [{ type: 'text', text: 'summary text' }] }),
+          { headers: { 'content-type': 'application/json' } },
+        );
+      },
+    });
+    resolve(server);
+  });
+}
+
+afterEach(() => {
+  if (server) { server.stop(true); server = undefined; }
+  capturedBody = undefined;
+});
+
+function runSummarize({ stdin }) {
+  return new Promise((resolve, reject) => {
+    const child = spawn('node', [path.join(__dirname, 'run.js')], {
+      env: {
+        ...process.env,
+        AWS_BEARER_TOKEN_BEDROCK: 'test-bearer-token',
+        MANTLE_ANTHROPIC_URL: `http://127.0.0.1:${server.port}/anthropic/v1/messages`,
+      },
+    });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (d) => { stdout += d; });
+    child.stderr.on('data', (d) => { stderr += d; });
+    child.on('close', (code) => resolve({ code, stdout, stderr }));
+    child.on('error', reject);
+    child.stdin.end(stdin);
+  });
+}
+
+test('request body to Mantle includes anthropic_version alongside model/max_tokens/system/messages', async () => {
+  await startCaptureServer();
+  const { code, stdout, stderr } = await runSummarize({ stdin: 'Some meeting notes to summarize.' });
+  expect(stderr).toBe('');
+  expect(code).toBe(0);
+  expect(capturedBody).toMatchObject({
+    anthropic_version: 'bedrock-2023-05-31',
+    model: expect.any(String),
+    max_tokens: expect.any(Number),
+    system: expect.any(String),
+    messages: expect.any(Array),
+  });
+  const parsed = JSON.parse(stdout);
+  expect(parsed.status).toBe('ok');
+  expect(parsed.summary).toBe('summary text');
+});


### PR DESCRIPTION
## Description

Fixes three confirmed defects in the `psd-plaud` / `psd-summarize` OpenClaw agent skills (`infra/agent-image/skills/`) that made the Plaud recording digest path unreadable end-to-end:

1. **Wrong MCP argument name.** `psd-plaud`'s `file`/`transcript`/`summary`/`digest` subcommands called Plaud's MCP tools (`get_file`/`get_transcript`/`get_note`) with the recording id under the key `id`, but Plaud's MCP server expects `file_id`. Every content fetch failed. Fixed at all four call sites (`run.js` ×3, `common.js`'s `digestRecording` ×1).
2. **Silently swallowed tool-level MCP errors.** Per the MCP spec, a tool-level failure is a JSON-RPC *success* whose `result` carries `isError: true` with the error text in `result.content` — it is not surfaced via the top-level JSON-RPC `error` field that `invokeTool` already checked. Without a guard for this shape, `digestRecording` would pipe an upstream error string into `psd-summarize` as if it were the real transcript. `invokeTool` now detects `result.isError` and fails (exit 12) instead.
3. **Missing `anthropic_version`.** `psd-summarize`'s direct fetch to Bedrock Mantle's Anthropic Messages endpoint omitted the required `anthropic_version` field, so every model call 400'd. Added `anthropic_version: 'bedrock-2023-05-31'`.

### Self-review fixes (applied after an internal security + correctness pass)
- The new `isError` branch initially emitted the upstream error text **verbatim and untruncated to stdout** — defeating the whole point of `digestRecording` piping through `psd-summarize` so raw content never reaches stdout uncontrolled. Now truncated to 400 chars, matching the existing HTTP-failure branches in the same file.
- The new `*.test.js` files and the `mcp-test-support.js` AWS-SDK mock harness weren't excluded from the Docker build context, so they'd have been copied into the production agent image via `COPY skills /opt/psd-skills`. Added them to `.dockerignore` (mirroring the existing `*.test.ts` exclusion).

### Scope note
`infra/**` is excluded from the root `eslint`, `tsconfig`, and `jest` configs — these are standalone CommonJS scripts baked into a separate Docker "agent image," not part of the Next.js app. The verification gate for this change is `node --check` + the new Bun regression tests, per the linked issue's own Definition of Done.

### Verification evidence
```
$ node --check infra/agent-image/skills/psd-plaud/run.js && echo OK
OK
$ node --check infra/agent-image/skills/psd-plaud/common.js && echo OK
OK
$ node --check infra/agent-image/skills/psd-summarize/run.js && echo OK
OK

$ bun test infra/agent-image/skills/psd-plaud infra/agent-image/skills/psd-summarize
 8 pass
 0 fail
 28 expect() calls
Ran 8 tests across 3 files.
```
New tests exercise the real fix end-to-end (mocked Secrets Manager + mocked Plaud MCP/OAuth fetch calls, real HTTP capture server for `psd-summarize`) — not just trivially-passing assertions. Independently re-verified by two review passes (runtime verification + security + correctness) after the self-review fixes.

Two DoD items are explicitly out of scope for this PR (blocked on external Plaud paid-plan API access, per the issue): the two manual live-token checks. No Playwright flow applies — this is a CLI skill with no web UI.

## Checklist

- [x] No `console.*` calls in the changed source files (these are standalone CLI scripts outside `@/lib/logger`'s reach — they use `process.stdout`/`process.stderr` directly per this skill's existing, pre-existing convention)
- [x] N/A — no client components touched
- [x] N/A — no client-side code touched
- [ ] Lint passes (`npm run lint`) — N/A, `infra/**` is excluded from the root eslint config (this is a separate Docker image, not app code)
- [x] All tests pass — `bun test infra/agent-image/skills/psd-plaud infra/agent-image/skills/psd-summarize` (8/8); root `jest` also excludes `/infra/`
- [x] Types/interfaces follow project conventions — N/A, plain CommonJS, no TypeScript in this directory
- [x] No type assertions (`as any`) without justification — N/A, no TypeScript
- [x] N/A — no database changes
- [ ] TypeScript strict mode errors resolved — N/A, `infra` is excluded from `tsconfig.json`
- [x] No new environment variables introduced
- [x] Documentation updated — `psd-plaud/SKILL.md` and a `run.js` doc comment updated to reflect the confirmed `file_id` argument key
- [x] Code reviewed — internal security-reviewer + correctness-reviewer passes completed, findings fixed (see above)
- [x] N/A — no Next.js build surface touched (standalone Docker agent image skill)

## Related Issues

Fixes #1104

---
_Generated by [Claude Code](https://claude.ai/code/session_01GDjQB7cgRrubpfd6uK3tWK)_