### PR TITLE
fix: mitigate unqualified NUMERIC/DECIMAL cast trigger for #1106 (CSV export missing numeric columns)

### DIFF
--- a/docs/learnings/logic/2026-07-05-regex-cast-detector-string-literals-and-passthrough-gap.md
+++ b/docs/learnings/logic/2026-07-05-regex-cast-detector-string-literals-and-passthrough-gap.md
@@ -1,0 +1,69 @@
+---
+title: Client-side regex detector for CAST(x AS NUMERIC) needed string-literal blanking, paren-depth matching, and dual entry-point wiring
+category: logic
+tags:
+  - psd-data
+  - mcp-skill
+  - regex
+  - sql
+  - false-positive
+  - passthrough-bypass
+  - infra-agent-image
+severity: medium
+date: 2026-07-05
+source: auto — /lfg (issue #1106, PR #1109)
+applicable_to: project
+---
+
+## What Happened
+
+Issue #1106 (FS#162394) needed a client-side pre-flight check in the `psd-data`
+MCP skill (`infra/agent-image/skills/psd-data/common.js`/`run.js`) that catches
+unqualified `CAST(x AS NUMERIC)` / `x::numeric` before sending SQL to the
+external `psd-data-mcp` Lambda, which rejects those casts without explicit
+precision. The first implementation used a naive `AS <TYPE>\s*\)` boundary
+regex to sidestep parsing nested-paren expressions like
+`CAST(ROUND(x,2) AS NUMERIC)`.
+
+## Root Cause
+
+Two separate gaps, both found only in review (not in the initial implementation):
+
+1. **Regex false positives**: matching on the `AS <TYPE>\)` boundary alone
+   also matched a bare column alias with no CAST at all
+   (`(SELECT id, score AS numeric) sub`) and cast-like text sitting inside a
+   SQL string literal (`WHERE note LIKE '%CAST(x AS NUMERIC)%'`).
+2. **Passthrough bypass**: the check was wired only into the typed `query`
+   subcommand. The skill's `call --tool query_data --args <json>` generic
+   passthrough — documented in SKILL.md as "a convenience, not a fence,
+   always available even for tools with a typed subcommand" — reached the
+   same underlying tool without going through the new check at all.
+
+## Solution
+
+- Detect actual `CAST(` tokens, then find the matching closing paren via
+  paren-depth tracking (not a boundary regex) so nested expressions resolve
+  correctly.
+- Blank out string-literal contents (handling `''`-escaped quotes) in a
+  pre-pass before scanning, so cast-like text inside literals is never
+  matched.
+- Wire `findUnqualifiedNumericCasts` into both the `query` subcommand AND the
+  `call --tool query_data` passthrough — the same validation must run at
+  every entry point that can reach the underlying tool, not just the "main"
+  one.
+
+## Prevention
+
+- When writing a regex-based detector for a code/SQL construct, don't stop at
+  a boundary-token match — check what else in valid input could produce that
+  same boundary text (bare aliases, comments, string literals). Blank
+  string/comment regions before scanning for keywords.
+- For nested/recursive constructs (CAST inside CAST, parens inside parens),
+  track paren depth to find the true closing boundary instead of a lazy
+  regex match on the first `)`.
+- When a CLI/skill exposes both a typed subcommand and a generic passthrough
+  for the same underlying tool (a common pattern — see also
+  `docs/learnings/security/2026-06-17-multi-surface-authorization-bypass.md`
+  for the same principle in an authz context), any client-side validation
+  added to the typed path must also be applied at the passthrough call site,
+  or it is trivially bypassable.

--- a/docs/learnings/workflow/2026-07-05-infra-agent-image-excluded-from-root-gates-plus-sandbox-network-block.md
+++ b/docs/learnings/workflow/2026-07-05-infra-agent-image-excluded-from-root-gates-plus-sandbox-network-block.md
@@ -1,0 +1,67 @@
+---
+title: infra/** is fully excluded from root tsconfig/eslint/jest — and this sandbox couldn't bun install at all
+category: workflow
+tags:
+  - infra-agent-image
+  - tsconfig
+  - eslint
+  - jest
+  - ci-gate
+  - sandbox-network
+  - bun-install
+severity: low
+date: 2026-07-05
+source: auto — /lfg (issue #1106, PR #1109)
+applicable_to: project
+---
+
+## What Happened
+
+PR #1109 (issue #1106) changed only
+`infra/agent-image/skills/psd-data/common.js`/`run.js`. Before spending effort
+getting `bun install` working, confirmed via direct grep that `infra/**` is
+excluded from the root `tsconfig.json`, `eslint.config.mjs`, AND
+`jest.config.js` — the latter has an explicit `/infra/` entry in
+`testPathIgnorePatterns` with the comment "Infra has its own Jest config."
+
+Separately (and orthogonally), this sandbox session could not run
+`bun install` at all: `node_modules` was completely empty on a fresh
+checkout, and `registry.npmjs.org` returned a direct 403 despite being listed
+in the agent-proxy's `noProxy` allowlist — meaning some other network-layer
+policy blocks it, unrelated to the documented proxy config. This blocked
+`bun run lint`/`typecheck`/`build`/`test:ci` entirely, for any diff, not just
+this one.
+
+## Root Cause
+
+`infra/` is intentionally a separate workspace with its own tooling config
+(see also `docs/learnings/devops/2026-02-18-npm-to-bun-migration-cascade.md`,
+which notes `infra/` stayed on npm during the bun migration). The root gates
+were never wired to cover it. The Python side of this same exclusion is
+already documented in
+`docs/learnings/workflow/2026-06-30-python-agent-image-tests-unittest-not-pytest.md`
+(unittest, not CI-gated) — this note extends the same "infra/agent-image is
+outside the root gate" fact to the JS/TS/jest side.
+
+## Solution
+
+For a change confined to `infra/agent-image/skills/*`, the actual regression-test
+convention is a per-directory `bun test` (see `psd-plaud`, `psd-summarize` for
+precedent), run manually — not CI-gated, and structurally unaffected by
+root build/lint/typecheck/jest regardless of whether those gates can even
+run in the current environment.
+
+## Prevention
+
+- Before trying to make root `lint`/`typecheck`/`test:ci` pass for an
+  infra/agent-image-only diff, confirm the change is actually in scope for
+  those gates — it likely isn't. Check `jest.config.js`
+  `testPathIgnorePatterns`, `eslint.config.mjs` ignores, and
+  `tsconfig.json` excludes for `/infra/` first.
+- If `bun install` fails with a fresh/empty `node_modules` and a 403 from
+  `registry.npmjs.org`, don't assume it's the documented agent-proxy — check
+  `$HTTPS_PROXY/__agentproxy/status` for per-tool fixes, but also consider a
+  separate network-layer block outside proxy config. This can make root
+  gates unrunnable for ANY diff in the current environment, not just
+  infra-scoped ones — don't burn time debugging it as if it were specific to
+  the change at hand.

--- a/docs/learnings/workflow/2026-07-05-word-external-root-cause-fixes-as-mitigation-not-confirmation.md
+++ b/docs/learnings/workflow/2026-07-05-word-external-root-cause-fixes-as-mitigation-not-confirmation.md
@@ -1,0 +1,54 @@
+---
+title: A fix for a bug whose root cause lives in code you can't inspect should be worded as "mitigates the leading hypothesis," not "fixes X"
+category: workflow
+tags:
+  - external-dependency
+  - root-cause-confidence
+  - pr-framing
+  - issue-closing
+  - lfg
+severity: medium
+date: 2026-07-05
+source: auto — /lfg (issue #1106, PR #1109)
+applicable_to: project
+---
+
+## What Happened
+
+Issue #1106 (FS#162394) was triaged with only MEDIUM-LOW confidence: the
+suspected root cause (an external Lambda, `psd-data-mcp`, not in this repo,
+rejecting SQL casts to NUMERIC/DECIMAL without explicit precision) could not
+be confirmed because the Lambda's source wasn't inspectable. The initial fix
+implementation's code comments and PR framing nonetheless used language like
+"the confirmed trigger" for what was still an unconfirmed hypothesis.
+Adversarial review flagged this — shipping with overclaiming language risks a
+human reviewer or a future agent treating the underlying issue as fully
+understood and closed when it isn't.
+
+## Root Cause
+
+It's tempting to write confident-sounding comments/PR descriptions once a fix
+is implemented, even when the fix only mitigates a *hypothesis* rather than a
+confirmed mechanism. The confidence level assigned during triage doesn't
+automatically carry forward into the language used once code is written.
+
+## Solution
+
+Reworded comments and PR description to say the client-side check "mitigates
+the leading hypothesis" rather than "fixes X" or "the confirmed trigger."
+
+## Prevention
+
+- When a fix addresses a bug whose root cause lives in code/infra you don't
+  own or can't inspect (an external Lambda, a third-party service, a vendored
+  binary), word the fix in comments and PR text as mitigating the *leading
+  hypothesis*, not as fixing a confirmed mechanism — unless you've actually
+  confirmed it (e.g., by reproducing against the real dependency).
+- Don't auto-close the originating issue via a `Closes #N` / `Fixes #N` PR
+  keyword when the actual mechanism remains unconfirmed. Reference the issue
+  (`Related to #N`, `Mitigates #N`) without closing it, so the issue stays
+  open for confirmation or a follow-up if the hypothesis turns out to be
+  wrong.
+- Carry the triage's confidence rating (e.g., MEDIUM-LOW) forward into the
+  PR description explicitly, rather than letting it silently upgrade to
+  "confirmed" once code exists.

--- a/infra/agent-image/skills/psd-data/SKILL.md
+++ b/infra/agent-image/skills/psd-data/SKILL.md
@@ -131,7 +131,14 @@ intent in plain English; do not pad with fluff.
 - Only `SELECT` queries are accepted; DDL / DML are rejected
 - Row-level security rewrites your query — do not write your own access
   filters; let the server do it
-- Casts to `NUMERIC` / `DECIMAL` without precision are rejected
+- **Always specify precision on `NUMERIC`/`DECIMAL` casts** — e.g.
+  `CAST(score AS NUMERIC(10,2))` or `score::NUMERIC(10,2)`, never bare
+  `CAST(score AS NUMERIC)` or `score::NUMERIC`. The server rejects
+  unqualified casts, which **silently drops that column** from the result
+  set and any `--export` CSV — the column looks blank/missing, not
+  errored. The skill validates this client-side and fails fast with the
+  offending fragment if you forget; if you ever see a numeric column
+  missing from an export, check your SQL for a bare cast first.
 
 ### Lessons
 

--- a/infra/agent-image/skills/psd-data/SKILL.md
+++ b/infra/agent-image/skills/psd-data/SKILL.md
@@ -36,6 +36,7 @@ You do not handle authentication directly. The skill:
 |------|---------|----------------|
 | 0 | Success — JSON-RPC result on stdout | Use the result |
 | 1 | Config / usage error | Surface the error, do not retry |
+| 1 (unqualified `NUMERIC`/`DECIMAL` cast) | `query`/`call` rejected your SQL client-side, before it reached the server | This one **is** safe to self-correct: add precision to the flagged cast (e.g. `NUMERIC(10,2)`) and retry the same call immediately — unlike other exit-1 errors, this isn't a malformed invocation |
 | 10 | needs-auth: no token, or token revoked | Paste `consent_chat_hyperlink` on its own line |
 | 12 | Upstream MCP error (JSON-RPC error or unexpected HTTP) | Surface the error verbatim |
 | 13 | Forbidden: user not in `userpermissions` table | Tell the user to ping the data team |
@@ -134,11 +135,18 @@ intent in plain English; do not pad with fluff.
 - **Always specify precision on `NUMERIC`/`DECIMAL` casts** — e.g.
   `CAST(score AS NUMERIC(10,2))` or `score::NUMERIC(10,2)`, never bare
   `CAST(score AS NUMERIC)` or `score::NUMERIC`. The server rejects
-  unqualified casts, which **silently drops that column** from the result
-  set and any `--export` CSV — the column looks blank/missing, not
-  errored. The skill validates this client-side and fails fast with the
-  offending fragment if you forget; if you ever see a numeric column
-  missing from an export, check your SQL for a bare cast first.
+  unqualified casts, and the leading hypothesis for a numeric column
+  going missing from a result set or `--export` CSV (looking
+  blank/missing rather than erroring) is exactly this pattern — though
+  the server's own logic hasn't been directly inspected, so treat this as
+  the best-known lead rather than a confirmed root cause. The skill
+  validates explicit `CAST(...)`/`::` casts client-side (both in `query`
+  and in `call --tool query_data`) and fails fast with the offending
+  fragment; it does **not** catch every way an unqualified `NUMERIC` can
+  arise — e.g. `AVG()`/`SUM()` over a numeric column can produce an
+  unqualified `NUMERIC` result with no `CAST`/`::` in the SQL text at all.
+  If you see a numeric column missing from an export and your SQL has no
+  bare cast, that's the next thing to suspect.
 
 ### Lessons
 

--- a/infra/agent-image/skills/psd-data/SKILL.md
+++ b/infra/agent-image/skills/psd-data/SKILL.md
@@ -36,7 +36,7 @@ You do not handle authentication directly. The skill:
 |------|---------|----------------|
 | 0 | Success — JSON-RPC result on stdout | Use the result |
 | 1 | Config / usage error | Surface the error, do not retry |
-| 1 (unqualified `NUMERIC`/`DECIMAL` cast) | `query`/`call` rejected your SQL client-side, before it reached the server | This one **is** safe to self-correct: add precision to the flagged cast (e.g. `NUMERIC(10,2)`) and retry the same call immediately — unlike other exit-1 errors, this isn't a malformed invocation |
+| 1 | Unqualified `NUMERIC`/`DECIMAL` cast — `query`/`call` rejected your SQL client-side, before it reached the server | This one **is** safe to self-correct: add precision to the flagged cast (e.g. `NUMERIC(10,2)`) and retry the same call immediately — unlike other exit-1 errors, this isn't a malformed invocation |
 | 10 | needs-auth: no token, or token revoked | Paste `consent_chat_hyperlink` on its own line |
 | 12 | Upstream MCP error (JSON-RPC error or unexpected HTTP) | Surface the error verbatim |
 | 13 | Forbidden: user not in `userpermissions` table | Tell the user to ping the data team |

--- a/infra/agent-image/skills/psd-data/common.js
+++ b/infra/agent-image/skills/psd-data/common.js
@@ -68,36 +68,74 @@ function emit(obj) {
 // query results/CSV exports) — the external Lambda's own source couldn't be
 // inspected during triage, so this check guards against the suspected
 // trigger, it does not confirm the server's actual behavior.
-const CAST_OPEN_RE = /\bCAST\s*\(/gi;
+const CAST_OPEN_RE = /\b(?:TRY_)?CAST\s*\(/gi;
 const UNQUALIFIED_CAST_TAIL_RE = /\bAS\s+(NUMERIC|DECIMAL)\s*$/i;
 const UNQUALIFIED_SHORTHAND_RE = /::\s*(NUMERIC|DECIMAL)\b(?!\s*\()/gi;
 
-// Blank out single-quoted string literal contents (preserving length/offsets
-// so match indices still line up with the original string) so neither regex
-// above fires on SQL text that merely *mentions* a cast inside a literal,
-// e.g. `WHERE note LIKE '%CAST(x AS NUMERIC)%'`. Handles '' as an escaped
-// quote; does not handle dollar-quoted strings (rare in this context).
+// Blank out single-quoted string literal contents and SQL comments
+// (preserving length/offsets so match indices still line up with the
+// original string) so neither regex above fires on SQL text that merely
+// *mentions* a cast inside a literal or a comment, e.g.
+// `WHERE note LIKE '%CAST(x AS NUMERIC)%'` or `-- CAST(x AS NUMERIC)`.
+// Handles '' and backslash as escaped quotes inside strings; does not
+// handle dollar-quoted strings (rare in this context).
 function blankStringLiterals(sql) {
   let out = '';
-  let inString = false;
-  for (let i = 0; i < sql.length; i++) {
+  let i = 0;
+  while (i < sql.length) {
     const ch = sql[i];
-    if (inString) {
-      if (ch === "'" && sql[i + 1] === "'") {
-        out += '  ';
-        i++;
-      } else if (ch === "'") {
-        inString = false;
+    const next = sql[i + 1];
+
+    if (ch === '-' && next === '-') {
+      out += '  ';
+      i += 2;
+      while (i < sql.length && sql[i] !== '\n') {
         out += ' ';
-      } else {
-        out += ch === '\n' ? '\n' : ' ';
+        i++;
       }
-    } else if (ch === "'") {
-      inString = true;
-      out += ' ';
-    } else {
-      out += ch;
+      continue;
     }
+
+    if (ch === '/' && next === '*') {
+      out += '  ';
+      i += 2;
+      while (i < sql.length) {
+        if (sql[i] === '*' && sql[i + 1] === '/') {
+          out += '  ';
+          i += 2;
+          break;
+        }
+        out += sql[i] === '\n' ? '\n' : ' ';
+        i++;
+      }
+      continue;
+    }
+
+    if (ch === "'") {
+      out += ' ';
+      i++;
+      while (i < sql.length) {
+        const curr = sql[i];
+        if (curr === '\\') {
+          out += '  ';
+          i += 2;
+        } else if (curr === "'" && sql[i + 1] === "'") {
+          out += '  ';
+          i += 2;
+        } else if (curr === "'") {
+          out += ' ';
+          i++;
+          break;
+        } else {
+          out += curr === '\n' ? '\n' : ' ';
+          i++;
+        }
+      }
+      continue;
+    }
+
+    out += ch;
+    i++;
   }
   return out;
 }
@@ -119,10 +157,11 @@ function findMatchingClose(sql, openIndex) {
 
 /**
  * Scan a SQL string for NUMERIC/DECIMAL casts with no explicit precision.
- * Only flags actual `CAST(...)` calls and `::TYPE` shorthand — not bare
- * `... AS numeric`/`... AS decimal` column aliases (which share the same
- * `AS <TYPE>)` text but aren't a cast at all) — and ignores anything inside
- * a string literal. Returns the matched fragments (empty if none).
+ * Only flags actual `CAST(...)`/`TRY_CAST(...)` calls and `::TYPE` shorthand
+ * — not bare `... AS numeric`/`... AS decimal` column aliases (which share
+ * the same `AS <TYPE>)` text but aren't a cast at all) — and ignores
+ * anything inside a string literal or a SQL comment. Returns the matched
+ * fragments (empty if none).
  */
 function findUnqualifiedNumericCasts(sql) {
   if (typeof sql !== 'string') return [];

--- a/infra/agent-image/skills/psd-data/common.js
+++ b/infra/agent-image/skills/psd-data/common.js
@@ -23,11 +23,20 @@
 // Load the AWS SDK from psd-workspace's already-installed copy. Both skills
 // would otherwise install the same `@aws-sdk/client-secrets-manager` tree;
 // importing absolutely keeps the image file-count identical to a no-psd-data
-// build. See Dockerfile for the rationale.
+// build. See Dockerfile for the rationale. Falls back to a bare require so
+// the skill is loadable/testable outside the container (e.g. from the repo
+// tree), matching the pattern in psd-plaud/common.js.
+function requireSecretsManager() {
+  try {
+    return require('/opt/psd-skills/psd-workspace/node_modules/@aws-sdk/client-secrets-manager');
+  } catch {
+    return require('@aws-sdk/client-secrets-manager');
+  }
+}
 const {
   SecretsManagerClient,
   GetSecretValueCommand,
-} = require('/opt/psd-skills/psd-workspace/node_modules/@aws-sdk/client-secrets-manager');
+} = requireSecretsManager();
 
 const REGION = process.env.AWS_REGION || 'us-east-1';
 const ENVIRONMENT = process.env.ENVIRONMENT || 'dev';
@@ -51,6 +60,31 @@ function fail(message, code = 1) {
 
 function emit(obj) {
   process.stdout.write(JSON.stringify(obj) + '\n');
+}
+
+// psd-data-mcp rejects NUMERIC/DECIMAL casts that don't specify precision
+// (see SKILL.md's "Hard rules"). Matching on the `AS <TYPE>)` / `::<TYPE>`
+// boundary — rather than trying to parse the whole CAST(...) expression —
+// keeps this robust against nested parens in the casted expression itself
+// (e.g. `CAST(ROUND(x, 2) AS NUMERIC)`).
+const UNQUALIFIED_CAST_RE = /\bAS\s+(NUMERIC|DECIMAL)\s*\)/gi;
+const UNQUALIFIED_SHORTHAND_RE = /::\s*(NUMERIC|DECIMAL)\b(?!\s*\()/gi;
+
+/**
+ * Scan a SQL string for NUMERIC/DECIMAL casts with no explicit precision —
+ * the pattern the MCP server silently rejects, which is the confirmed
+ * trigger for numeric columns disappearing from query results/CSV exports
+ * (FS#162394 / issue #1106). Returns the matched fragments (empty if none).
+ */
+function findUnqualifiedNumericCasts(sql) {
+  if (typeof sql !== 'string') return [];
+  const matches = [];
+  UNQUALIFIED_CAST_RE.lastIndex = 0;
+  let m;
+  while ((m = UNQUALIFIED_CAST_RE.exec(sql))) matches.push(m[0].trim());
+  UNQUALIFIED_SHORTHAND_RE.lastIndex = 0;
+  while ((m = UNQUALIFIED_SHORTHAND_RE.exec(sql))) matches.push(m[0].trim());
+  return matches;
 }
 
 /**
@@ -366,5 +400,6 @@ module.exports = {
   emitNeedsAuthAndExit,
   callMcp,
   cognitoRefreshSecretId,
+  findUnqualifiedNumericCasts,
   PSD_DATA_MCP_URL,
 };

--- a/infra/agent-image/skills/psd-data/common.js
+++ b/infra/agent-image/skills/psd-data/common.js
@@ -63,27 +63,91 @@ function emit(obj) {
 }
 
 // psd-data-mcp rejects NUMERIC/DECIMAL casts that don't specify precision
-// (see SKILL.md's "Hard rules"). Matching on the `AS <TYPE>)` / `::<TYPE>`
-// boundary — rather than trying to parse the whole CAST(...) expression —
-// keeps this robust against nested parens in the casted expression itself
-// (e.g. `CAST(ROUND(x, 2) AS NUMERIC)`).
-const UNQUALIFIED_CAST_RE = /\bAS\s+(NUMERIC|DECIMAL)\s*\)/gi;
+// (see SKILL.md's "Hard rules"). This is the leading, medium-confidence
+// hypothesis for FS#162394 / issue #1106 (numeric columns disappearing from
+// query results/CSV exports) — the external Lambda's own source couldn't be
+// inspected during triage, so this check guards against the suspected
+// trigger, it does not confirm the server's actual behavior.
+const CAST_OPEN_RE = /\bCAST\s*\(/gi;
+const UNQUALIFIED_CAST_TAIL_RE = /\bAS\s+(NUMERIC|DECIMAL)\s*$/i;
 const UNQUALIFIED_SHORTHAND_RE = /::\s*(NUMERIC|DECIMAL)\b(?!\s*\()/gi;
 
+// Blank out single-quoted string literal contents (preserving length/offsets
+// so match indices still line up with the original string) so neither regex
+// above fires on SQL text that merely *mentions* a cast inside a literal,
+// e.g. `WHERE note LIKE '%CAST(x AS NUMERIC)%'`. Handles '' as an escaped
+// quote; does not handle dollar-quoted strings (rare in this context).
+function blankStringLiterals(sql) {
+  let out = '';
+  let inString = false;
+  for (let i = 0; i < sql.length; i++) {
+    const ch = sql[i];
+    if (inString) {
+      if (ch === "'" && sql[i + 1] === "'") {
+        out += '  ';
+        i++;
+      } else if (ch === "'") {
+        inString = false;
+        out += ' ';
+      } else {
+        out += ch === '\n' ? '\n' : ' ';
+      }
+    } else if (ch === "'") {
+      inString = true;
+      out += ' ';
+    } else {
+      out += ch;
+    }
+  }
+  return out;
+}
+
+// Find the index of the ')' that closes the '(' at openIndex, accounting for
+// nested parens (e.g. `CAST(ROUND(x, 2) AS NUMERIC)`). Returns -1 if
+// unmatched (malformed SQL — the MCP server will reject it on its own).
+function findMatchingClose(sql, openIndex) {
+  let depth = 1;
+  for (let i = openIndex + 1; i < sql.length; i++) {
+    if (sql[i] === '(') depth++;
+    else if (sql[i] === ')') {
+      depth--;
+      if (depth === 0) return i;
+    }
+  }
+  return -1;
+}
+
 /**
- * Scan a SQL string for NUMERIC/DECIMAL casts with no explicit precision —
- * the pattern the MCP server silently rejects, which is the confirmed
- * trigger for numeric columns disappearing from query results/CSV exports
- * (FS#162394 / issue #1106). Returns the matched fragments (empty if none).
+ * Scan a SQL string for NUMERIC/DECIMAL casts with no explicit precision.
+ * Only flags actual `CAST(...)` calls and `::TYPE` shorthand — not bare
+ * `... AS numeric`/`... AS decimal` column aliases (which share the same
+ * `AS <TYPE>)` text but aren't a cast at all) — and ignores anything inside
+ * a string literal. Returns the matched fragments (empty if none).
  */
 function findUnqualifiedNumericCasts(sql) {
   if (typeof sql !== 'string') return [];
+  const scan = blankStringLiterals(sql);
   const matches = [];
-  UNQUALIFIED_CAST_RE.lastIndex = 0;
+
+  CAST_OPEN_RE.lastIndex = 0;
   let m;
-  while ((m = UNQUALIFIED_CAST_RE.exec(sql))) matches.push(m[0].trim());
+  while ((m = CAST_OPEN_RE.exec(scan))) {
+    const openParenIndex = m.index + m[0].length - 1;
+    const closeParenIndex = findMatchingClose(scan, openParenIndex);
+    if (closeParenIndex === -1) continue;
+    const inner = scan.slice(openParenIndex + 1, closeParenIndex);
+    if (UNQUALIFIED_CAST_TAIL_RE.test(inner)) {
+      matches.push(
+        sql.slice(m.index, closeParenIndex + 1).replace(/\s+/g, ' ').trim()
+      );
+    }
+  }
+
   UNQUALIFIED_SHORTHAND_RE.lastIndex = 0;
-  while ((m = UNQUALIFIED_SHORTHAND_RE.exec(sql))) matches.push(m[0].trim());
+  while ((m = UNQUALIFIED_SHORTHAND_RE.exec(scan))) {
+    matches.push(sql.slice(m.index, m.index + m[0].length).trim());
+  }
+
   return matches;
 }
 

--- a/infra/agent-image/skills/psd-data/common.js
+++ b/infra/agent-image/skills/psd-data/common.js
@@ -77,8 +77,10 @@ const UNQUALIFIED_SHORTHAND_RE = /::\s*(NUMERIC|DECIMAL)\b(?!\s*\()/gi;
 // original string) so neither regex above fires on SQL text that merely
 // *mentions* a cast inside a literal or a comment, e.g.
 // `WHERE note LIKE '%CAST(x AS NUMERIC)%'` or `-- CAST(x AS NUMERIC)`.
-// Handles '' and backslash as escaped quotes inside strings; does not
-// handle dollar-quoted strings (rare in this context).
+// Handles '' doubled-quote escapes in all string literals, and backslash
+// escapes only inside E'...' literals (matching Postgres's actual
+// standard_conforming_strings=on semantics); does not handle dollar-quoted
+// strings (rare in this context).
 function blankStringLiterals(sql) {
   let out = '';
   let i = 0;
@@ -112,11 +114,23 @@ function blankStringLiterals(sql) {
     }
 
     if (ch === "'") {
+      // Postgres only applies backslash-escaping inside E'...' literals
+      // (standard_conforming_strings = on, the default, makes backslash a
+      // plain character in a bare '...' literal — only '' doubling escapes
+      // a quote). Detect the E prefix so a plain '...' literal containing a
+      // stray backslash-quote sequence terminates where Postgres would
+      // actually terminate it, rather than swallowing the rest of the SQL.
+      const prevChar = sql[i - 1];
+      const prevPrevChar = sql[i - 2];
+      const isEscapeString =
+        prevChar !== undefined &&
+        /[eE]/.test(prevChar) &&
+        (prevPrevChar === undefined || !/[A-Za-z0-9_]/.test(prevPrevChar));
       out += ' ';
       i++;
       while (i < sql.length) {
         const curr = sql[i];
-        if (curr === '\\') {
+        if (isEscapeString && curr === '\\') {
           out += '  ';
           i += 2;
         } else if (curr === "'" && sql[i + 1] === "'") {

--- a/infra/agent-image/skills/psd-data/common.js
+++ b/infra/agent-image/skills/psd-data/common.js
@@ -99,16 +99,26 @@ function blankStringLiterals(sql) {
     }
 
     if (ch === '/' && next === '*') {
+      // Postgres block comments nest, so track depth rather than stopping
+      // at the first `*/` — otherwise a nested `/* ... */` would end the
+      // blanked region early and expose the remaining "still-outer-comment"
+      // text as live SQL to scan.
+      let depth = 1;
       out += '  ';
       i += 2;
-      while (i < sql.length) {
-        if (sql[i] === '*' && sql[i + 1] === '/') {
+      while (i < sql.length && depth > 0) {
+        if (sql[i] === '/' && sql[i + 1] === '*') {
+          depth++;
           out += '  ';
           i += 2;
-          break;
+        } else if (sql[i] === '*' && sql[i + 1] === '/') {
+          depth--;
+          out += '  ';
+          i += 2;
+        } else {
+          out += sql[i] === '\n' ? '\n' : ' ';
+          i++;
         }
-        out += sql[i] === '\n' ? '\n' : ' ';
-        i++;
       }
       continue;
     }

--- a/infra/agent-image/skills/psd-data/common.test.js
+++ b/infra/agent-image/skills/psd-data/common.test.js
@@ -4,6 +4,13 @@
  * agent's generated SQL casts to NUMERIC/DECIMAL without precision, which
  * psd-data-mcp rejects server-side. This client-side check catches the
  * pattern before the request ever leaves the skill.
+ *
+ * The scanner only flags actual `CAST(...)` calls and `::TYPE` shorthand —
+ * not bare `... AS numeric`/`... AS decimal` column aliases that share the
+ * same trailing text but aren't a cast, and not text inside string literals
+ * — both confirmed false-positive gaps found in self-review before this
+ * landed (see the `blankStringLiterals`/paren-depth-matching approach in
+ * common.js instead of the earlier boundary-only regex).
  */
 
 'use strict';
@@ -18,14 +25,14 @@ test('flags a bare CAST(...AS NUMERIC) with no precision', () => {
   const found = findUnqualifiedNumericCasts(
     'SELECT CAST(score AS NUMERIC) FROM iready_scores'
   );
-  expect(found).toEqual(['AS NUMERIC)']);
+  expect(found).toEqual(['CAST(score AS NUMERIC)']);
 });
 
 test('flags a bare CAST(...AS DECIMAL) with no precision', () => {
   const found = findUnqualifiedNumericCasts(
     'SELECT CAST(score AS DECIMAL) FROM iready_scores'
   );
-  expect(found).toEqual(['AS DECIMAL)']);
+  expect(found).toEqual(['CAST(score AS DECIMAL)']);
 });
 
 test('flags bare shorthand ::numeric with no precision', () => {
@@ -67,7 +74,16 @@ test('handles nested parens inside the casted expression', () => {
   const found = findUnqualifiedNumericCasts(
     'SELECT CAST(ROUND(score, 2) AS NUMERIC) FROM iready_scores'
   );
-  expect(found).toEqual(['AS NUMERIC)']);
+  expect(found).toEqual(['CAST(ROUND(score, 2) AS NUMERIC)']);
+});
+
+test('handles a nested CAST inside the casted expression independently', () => {
+  const found = findUnqualifiedNumericCasts(
+    'SELECT CAST(CAST(score AS INTEGER) AS NUMERIC) FROM iready_scores'
+  );
+  // Only the outer cast is unqualified; the inner CAST(...AS INTEGER) isn't
+  // NUMERIC/DECIMAL at all and must not be reported.
+  expect(found).toEqual(['CAST(CAST(score AS INTEGER) AS NUMERIC)']);
 });
 
 test('returns no matches for SQL with no numeric casts at all', () => {
@@ -81,17 +97,59 @@ test('finds every unqualified cast when several are present', () => {
   const found = findUnqualifiedNumericCasts(
     'SELECT CAST(math_score AS NUMERIC), reading_score::decimal FROM iready_scores'
   );
-  expect(found).toEqual(['AS NUMERIC)', '::decimal']);
+  expect(found).toEqual(['CAST(math_score AS NUMERIC)', '::decimal']);
 });
 
 test('is case-insensitive on the type keyword', () => {
   const found = findUnqualifiedNumericCasts(
     'SELECT CAST(score as Numeric) FROM iready_scores'
   );
-  expect(found).toEqual(['as Numeric)']);
+  expect(found).toEqual(['CAST(score as Numeric)']);
 });
 
 test('returns an empty array for non-string input', () => {
   expect(findUnqualifiedNumericCasts(undefined)).toEqual([]);
   expect(findUnqualifiedNumericCasts(null)).toEqual([]);
+});
+
+test('does not flag a bare column alias literally named "numeric" with no CAST at all', () => {
+  const found = findUnqualifiedNumericCasts(
+    'SELECT id, score AS numeric FROM (SELECT id, score) sub'
+  );
+  expect(found).toEqual([]);
+});
+
+test('does not flag a bare column alias literally named "decimal" as the last item in a subquery', () => {
+  const found = findUnqualifiedNumericCasts(
+    'SELECT * FROM (SELECT id, score AS decimal) sub'
+  );
+  expect(found).toEqual([]);
+});
+
+test('does not flag cast-like text inside a string literal', () => {
+  const found = findUnqualifiedNumericCasts(
+    "SELECT * FROM notes WHERE note_text LIKE '%CAST(x AS NUMERIC)%'"
+  );
+  expect(found).toEqual([]);
+});
+
+test('does not flag shorthand-like text inside a string literal', () => {
+  const found = findUnqualifiedNumericCasts(
+    "SELECT * FROM notes WHERE note_text LIKE '%score::decimal%'"
+  );
+  expect(found).toEqual([]);
+});
+
+test('still flags a real unqualified cast alongside an unrelated string literal', () => {
+  const found = findUnqualifiedNumericCasts(
+    "SELECT CAST(score AS NUMERIC), 'CAST(x AS NUMERIC) in a note' AS label FROM t"
+  );
+  expect(found).toEqual(['CAST(score AS NUMERIC)']);
+});
+
+test("handles '' escaped quotes inside string literals without breaking scan position", () => {
+  const found = findUnqualifiedNumericCasts(
+    "SELECT CAST(score AS NUMERIC), 'it''s CAST(x AS NUMERIC) here' AS label FROM t"
+  );
+  expect(found).toEqual(['CAST(score AS NUMERIC)']);
 });

--- a/infra/agent-image/skills/psd-data/common.test.js
+++ b/infra/agent-image/skills/psd-data/common.test.js
@@ -154,9 +154,20 @@ test("handles '' escaped quotes inside string literals without breaking scan pos
   expect(found).toEqual(['CAST(score AS NUMERIC)']);
 });
 
-test('handles backslash-escaped quotes inside string literals without breaking scan position', () => {
+test("handles backslash-escaped quotes inside E'' string literals without breaking scan position", () => {
   const found = findUnqualifiedNumericCasts(
-    "SELECT CAST(score AS NUMERIC), 'it\\'s CAST(x AS NUMERIC) here' AS label FROM t"
+    "SELECT CAST(score AS NUMERIC), E'it\\'s CAST(x AS NUMERIC) here' AS label FROM t"
+  );
+  expect(found).toEqual(['CAST(score AS NUMERIC)']);
+});
+
+test('does not let a backslash swallow a real cast in a standard (non-E) string literal', () => {
+  // Under Postgres's default standard_conforming_strings=on, a plain '...'
+  // literal does NOT treat backslash as an escape — only '' (doubled quote)
+  // does. So 'a\' terminates at that quote, and the CAST below is live SQL
+  // that must still be flagged, not swallowed as if it were inside a string.
+  const found = findUnqualifiedNumericCasts(
+    "SELECT 1 WHERE x = 'a\\' AND CAST(score AS NUMERIC) FROM t"
   );
   expect(found).toEqual(['CAST(score AS NUMERIC)']);
 });

--- a/infra/agent-image/skills/psd-data/common.test.js
+++ b/infra/agent-image/skills/psd-data/common.test.js
@@ -186,6 +186,16 @@ test('ignores unqualified casts inside multi-line comments', () => {
   expect(found).toEqual([]);
 });
 
+test('ignores unqualified casts inside nested multi-line comments', () => {
+  // Postgres block comments nest, so the whole span up to the *last* `*/`
+  // is one comment — a scanner that stops at the first `*/` would wrongly
+  // treat 'still-outer-comment CAST(x AS NUMERIC)' as live SQL.
+  const found = findUnqualifiedNumericCasts(
+    'SELECT id FROM t /* outer /* inner */ still-outer-comment CAST(score AS NUMERIC) */'
+  );
+  expect(found).toEqual([]);
+});
+
 test('flags a bare TRY_CAST(...AS NUMERIC) with no precision', () => {
   const found = findUnqualifiedNumericCasts(
     'SELECT TRY_CAST(score AS NUMERIC) FROM iready_scores'

--- a/infra/agent-image/skills/psd-data/common.test.js
+++ b/infra/agent-image/skills/psd-data/common.test.js
@@ -1,0 +1,97 @@
+/**
+ * Regression tests for findUnqualifiedNumericCasts (FS#162394 / issue #1106):
+ * numeric columns silently disappear from query results/CSV exports when the
+ * agent's generated SQL casts to NUMERIC/DECIMAL without precision, which
+ * psd-data-mcp rejects server-side. This client-side check catches the
+ * pattern before the request ever leaves the skill.
+ */
+
+'use strict';
+
+const { test, expect } = require('bun:test');
+
+require('./mcp-test-support');
+
+const { findUnqualifiedNumericCasts } = require('./common');
+
+test('flags a bare CAST(...AS NUMERIC) with no precision', () => {
+  const found = findUnqualifiedNumericCasts(
+    'SELECT CAST(score AS NUMERIC) FROM iready_scores'
+  );
+  expect(found).toEqual(['AS NUMERIC)']);
+});
+
+test('flags a bare CAST(...AS DECIMAL) with no precision', () => {
+  const found = findUnqualifiedNumericCasts(
+    'SELECT CAST(score AS DECIMAL) FROM iready_scores'
+  );
+  expect(found).toEqual(['AS DECIMAL)']);
+});
+
+test('flags bare shorthand ::numeric with no precision', () => {
+  const found = findUnqualifiedNumericCasts(
+    'SELECT score::numeric FROM iready_scores'
+  );
+  expect(found).toEqual(['::numeric']);
+});
+
+test('flags bare shorthand ::decimal with no precision', () => {
+  const found = findUnqualifiedNumericCasts(
+    'SELECT score::decimal FROM iready_scores'
+  );
+  expect(found).toEqual(['::decimal']);
+});
+
+test('does not flag CAST(...AS NUMERIC(10,2)) with explicit precision', () => {
+  const found = findUnqualifiedNumericCasts(
+    'SELECT CAST(score AS NUMERIC(10,2)) FROM iready_scores'
+  );
+  expect(found).toEqual([]);
+});
+
+test('does not flag ::numeric(10,2) shorthand with explicit precision', () => {
+  const found = findUnqualifiedNumericCasts(
+    'SELECT score::numeric(10,2) FROM iready_scores'
+  );
+  expect(found).toEqual([]);
+});
+
+test('does not flag CAST(...AS NUMERIC(10,2)) with whitespace before the parens', () => {
+  const found = findUnqualifiedNumericCasts(
+    'SELECT CAST(score AS NUMERIC (10,2)) FROM iready_scores'
+  );
+  expect(found).toEqual([]);
+});
+
+test('handles nested parens inside the casted expression', () => {
+  const found = findUnqualifiedNumericCasts(
+    'SELECT CAST(ROUND(score, 2) AS NUMERIC) FROM iready_scores'
+  );
+  expect(found).toEqual(['AS NUMERIC)']);
+});
+
+test('returns no matches for SQL with no numeric casts at all', () => {
+  const found = findUnqualifiedNumericCasts(
+    'SELECT student_id, first_name FROM students WHERE active = true'
+  );
+  expect(found).toEqual([]);
+});
+
+test('finds every unqualified cast when several are present', () => {
+  const found = findUnqualifiedNumericCasts(
+    'SELECT CAST(math_score AS NUMERIC), reading_score::decimal FROM iready_scores'
+  );
+  expect(found).toEqual(['AS NUMERIC)', '::decimal']);
+});
+
+test('is case-insensitive on the type keyword', () => {
+  const found = findUnqualifiedNumericCasts(
+    'SELECT CAST(score as Numeric) FROM iready_scores'
+  );
+  expect(found).toEqual(['as Numeric)']);
+});
+
+test('returns an empty array for non-string input', () => {
+  expect(findUnqualifiedNumericCasts(undefined)).toEqual([]);
+  expect(findUnqualifiedNumericCasts(null)).toEqual([]);
+});

--- a/infra/agent-image/skills/psd-data/common.test.js
+++ b/infra/agent-image/skills/psd-data/common.test.js
@@ -153,3 +153,38 @@ test("handles '' escaped quotes inside string literals without breaking scan pos
   );
   expect(found).toEqual(['CAST(score AS NUMERIC)']);
 });
+
+test('handles backslash-escaped quotes inside string literals without breaking scan position', () => {
+  const found = findUnqualifiedNumericCasts(
+    "SELECT CAST(score AS NUMERIC), 'it\\'s CAST(x AS NUMERIC) here' AS label FROM t"
+  );
+  expect(found).toEqual(['CAST(score AS NUMERIC)']);
+});
+
+test('ignores unqualified casts inside single-line comments', () => {
+  const found = findUnqualifiedNumericCasts(
+    'SELECT id FROM t -- CAST(score AS NUMERIC)\nSELECT score::numeric FROM t'
+  );
+  expect(found).toEqual(['::numeric']);
+});
+
+test('ignores unqualified casts inside multi-line comments', () => {
+  const found = findUnqualifiedNumericCasts(
+    'SELECT id FROM t /* CAST(score AS NUMERIC) */'
+  );
+  expect(found).toEqual([]);
+});
+
+test('flags a bare TRY_CAST(...AS NUMERIC) with no precision', () => {
+  const found = findUnqualifiedNumericCasts(
+    'SELECT TRY_CAST(score AS NUMERIC) FROM iready_scores'
+  );
+  expect(found).toEqual(['TRY_CAST(score AS NUMERIC)']);
+});
+
+test('does not flag TRY_CAST(...AS NUMERIC(10,2)) with explicit precision', () => {
+  const found = findUnqualifiedNumericCasts(
+    'SELECT TRY_CAST(score AS NUMERIC(10,2)) FROM iready_scores'
+  );
+  expect(found).toEqual([]);
+});

--- a/infra/agent-image/skills/psd-data/mcp-test-support.js
+++ b/infra/agent-image/skills/psd-data/mcp-test-support.js
@@ -1,0 +1,42 @@
+/**
+ * Shared Secrets Manager stub for psd-data's bun test files.
+ *
+ * Bun's `mock.module` registry is process-wide: `bun test` loads every
+ * *.test.js file into the same process, so two files independently calling
+ * `mock.module(...)` for the same specifier would clobber each other.
+ * Centralizing the registration here — required once by both run.test.js
+ * and common.test.js — keeps a single fake in effect for the whole test run.
+ * Mirrors psd-plaud/mcp-test-support.js.
+ */
+
+'use strict';
+
+const { mock } = require('bun:test');
+
+class FakeGetSecretValueCommand {
+  constructor(input) { this.input = input; }
+}
+
+const secretsStore = {};
+
+class FakeSecretsManagerClient {
+  async send(command) {
+    if (command instanceof FakeGetSecretValueCommand) {
+      const value = secretsStore[command.input.SecretId];
+      if (value === undefined) {
+        const err = new Error(`Secret ${command.input.SecretId} not found`);
+        err.name = 'ResourceNotFoundException';
+        throw err;
+      }
+      return { SecretString: JSON.stringify(value) };
+    }
+    throw new Error(`Unexpected Secrets Manager command: ${command.constructor.name}`);
+  }
+}
+
+mock.module('@aws-sdk/client-secrets-manager', () => ({
+  SecretsManagerClient: FakeSecretsManagerClient,
+  GetSecretValueCommand: FakeGetSecretValueCommand,
+}));
+
+module.exports = { secretsStore };

--- a/infra/agent-image/skills/psd-data/run.js
+++ b/infra/agent-image/skills/psd-data/run.js
@@ -38,6 +38,7 @@ const {
   parseArgs,
   validateUserEmail,
   callMcp,
+  findUnqualifiedNumericCasts,
 } = require('./common');
 
 function usage() {
@@ -169,6 +170,15 @@ async function main() {
     case 'query': {
       const reason = requireArg(args, 'reason');
       const sql = requireArg(args, 'sql');
+      const unqualifiedCasts = findUnqualifiedNumericCasts(sql);
+      if (unqualifiedCasts.length > 0) {
+        fail(
+          `SQL contains unqualified NUMERIC/DECIMAL cast(s): ${unqualifiedCasts.join(', ')}. ` +
+            'The psd-data-mcp server rejects casts without explicit precision, which drops ' +
+            'that column from the result set (and any CSV export). Add precision, e.g. ' +
+            'CAST(col AS NUMERIC(10,2)) or col::NUMERIC(10,2), then retry.'
+        );
+      }
       const toolArgs = { reason, sql_query: sql };
       // parseArgs returns the string "false" for `--flag false`, which is
       // truthy. Explicitly convert to boolean so --export false / --view-results false work.
@@ -248,6 +258,10 @@ async function main() {
   }
 }
 
-main().catch((err) => {
-  fail(err instanceof Error ? err.message : String(err), 2);
-});
+if (require.main === module) {
+  main().catch((err) => {
+    fail(err instanceof Error ? err.message : String(err), 2);
+  });
+}
+
+module.exports = { main };

--- a/infra/agent-image/skills/psd-data/run.js
+++ b/infra/agent-image/skills/psd-data/run.js
@@ -91,6 +91,22 @@ function requireArg(args, name) {
   return args[name];
 }
 
+// Shared by both the typed `query` subcommand and the `call` passthrough
+// (when it targets `query_data` directly) so a bare `CAST(x AS NUMERIC)`
+// can't slip through via the passthrough route — see SKILL.md's
+// "Hardcoded subcommands are a convenience, not a fence" note.
+function checkSqlOrFail(sql) {
+  const unqualifiedCasts = findUnqualifiedNumericCasts(sql);
+  if (unqualifiedCasts.length > 0) {
+    fail(
+      `SQL contains unqualified NUMERIC/DECIMAL cast(s): ${unqualifiedCasts.join(', ')}. ` +
+        'The psd-data-mcp server rejects casts without explicit precision, which drops ' +
+        'that column from the result set (and any CSV export). Add precision, e.g. ' +
+        'CAST(col AS NUMERIC(10,2)) or col::NUMERIC(10,2), then retry.'
+    );
+  }
+}
+
 async function main() {
   const subcommand = process.argv[2];
   if (!subcommand || subcommand === '--help' || subcommand === '-h') {
@@ -124,6 +140,9 @@ async function main() {
       const toolName = requireArg(args, 'tool');
       const argsRaw = args.args === undefined || args.args === true ? '{}' : args.args;
       const toolArgs = parseJsonArg('args', argsRaw);
+      if (toolName === 'query_data' && toolArgs && typeof toolArgs.sql_query === 'string') {
+        checkSqlOrFail(toolArgs.sql_query);
+      }
       const params = { name: toolName, arguments: toolArgs };
       await callMcp('tools/call', params, ownerEmail);
       return;
@@ -170,15 +189,7 @@ async function main() {
     case 'query': {
       const reason = requireArg(args, 'reason');
       const sql = requireArg(args, 'sql');
-      const unqualifiedCasts = findUnqualifiedNumericCasts(sql);
-      if (unqualifiedCasts.length > 0) {
-        fail(
-          `SQL contains unqualified NUMERIC/DECIMAL cast(s): ${unqualifiedCasts.join(', ')}. ` +
-            'The psd-data-mcp server rejects casts without explicit precision, which drops ' +
-            'that column from the result set (and any CSV export). Add precision, e.g. ' +
-            'CAST(col AS NUMERIC(10,2)) or col::NUMERIC(10,2), then retry.'
-        );
-      }
+      checkSqlOrFail(sql);
       const toolArgs = { reason, sql_query: sql };
       // parseArgs returns the string "false" for `--flag false`, which is
       // truthy. Explicitly convert to boolean so --export false / --view-results false work.

--- a/infra/agent-image/skills/psd-data/run.test.js
+++ b/infra/agent-image/skills/psd-data/run.test.js
@@ -34,6 +34,12 @@ common.callMcp = async (method, params, ownerEmail) => {
 
 const { main } = require('./run');
 
+// require() caches modules process-wide; clear run.js's entry now that
+// `main` has been extracted so a later require('./run') elsewhere in this
+// test process re-evaluates against the real (unstubbed) common.callMcp
+// instead of silently reusing this stub.
+delete require.cache[require.resolve('./run')];
+
 common.callMcp = originalCallMcp;
 
 const EMAIL = 'teacher@psd401.net';

--- a/infra/agent-image/skills/psd-data/run.test.js
+++ b/infra/agent-image/skills/psd-data/run.test.js
@@ -3,7 +3,11 @@
  * (FS#162394 / issue #1106): a bare NUMERIC/DECIMAL cast must be rejected
  * client-side, before the request ever reaches the MCP server, since the
  * server-side rejection silently drops the column from CSV exports instead
- * of surfacing a clear error.
+ * of surfacing a clear error. Also covers the `call --tool query_data`
+ * passthrough route — a gap found in self-review, since SKILL.md explicitly
+ * documents "call" as always available even for tools with a typed
+ * subcommand ("a convenience, not a fence"), so the check must apply there
+ * too, not just in the typed `query` case.
  *
  * common.js's callMcp is overridden on the shared module.exports object
  * BEFORE run.js is required, so run.js's top-level
@@ -110,4 +114,49 @@ test('query with no numeric casts reaches the MCP server unaffected', async () =
   ]);
   expect(mcpCalls).toHaveLength(1);
   expect(mcpCalls[0].params.name).toBe('query_data');
+});
+
+test('call --tool query_data with a bare cast is rejected before hitting the MCP server (passthrough bypass gap)', async () => {
+  let thrown;
+  try {
+    await runCli([
+      'call',
+      '--user', EMAIL,
+      '--tool', 'query_data',
+      '--args', JSON.stringify({
+        reason: 'iReady score export via passthrough',
+        sql_query: 'SELECT CAST(score AS NUMERIC) FROM iready_scores',
+      }),
+    ]);
+  } catch (err) {
+    thrown = err;
+  }
+  expect(thrown).toBeDefined();
+  expect(thrown.exitCode).toBe(1);
+  expect(mcpCalls).toHaveLength(0);
+});
+
+test('call --tool query_data with an explicit-precision cast reaches the MCP server', async () => {
+  await runCli([
+    'call',
+    '--user', EMAIL,
+    '--tool', 'query_data',
+    '--args', JSON.stringify({
+      reason: 'iReady score export via passthrough',
+      sql_query: 'SELECT CAST(score AS NUMERIC(10,2)) FROM iready_scores',
+    }),
+  ]);
+  expect(mcpCalls).toHaveLength(1);
+  expect(mcpCalls[0].params.name).toBe('query_data');
+});
+
+test('call --tool <other-tool> is never checked, even with cast-like text in its args', async () => {
+  await runCli([
+    'call',
+    '--user', EMAIL,
+    '--tool', 'list_available_tables',
+    '--args', JSON.stringify({ sql_query: 'SELECT CAST(score AS NUMERIC) FROM t' }),
+  ]);
+  expect(mcpCalls).toHaveLength(1);
+  expect(mcpCalls[0].params.name).toBe('list_available_tables');
 });

--- a/infra/agent-image/skills/psd-data/run.test.js
+++ b/infra/agent-image/skills/psd-data/run.test.js
@@ -1,0 +1,113 @@
+/**
+ * Regression tests for run.js's `query` subcommand pre-flight validation
+ * (FS#162394 / issue #1106): a bare NUMERIC/DECIMAL cast must be rejected
+ * client-side, before the request ever reaches the MCP server, since the
+ * server-side rejection silently drops the column from CSV exports instead
+ * of surfacing a clear error.
+ *
+ * common.js's callMcp is overridden on the shared module.exports object
+ * BEFORE run.js is required, so run.js's top-level
+ * `const { callMcp, ... } = require('./common')` destructures our stub
+ * instead of hitting the network/Secrets Manager. process.exit is also
+ * stubbed so a `fail()` call doesn't kill the test process.
+ */
+
+'use strict';
+
+const { test, expect, beforeEach, afterAll } = require('bun:test');
+
+require('./mcp-test-support'); // registers the shared Secrets Manager mock
+
+const common = require('./common');
+
+let mcpCalls;
+
+const originalCallMcp = common.callMcp;
+common.callMcp = async (method, params, ownerEmail) => {
+  mcpCalls.push({ method, params, ownerEmail });
+  return { ok: true };
+};
+
+const { main } = require('./run');
+
+common.callMcp = originalCallMcp;
+
+const EMAIL = 'teacher@psd401.net';
+const originalExit = process.exit;
+
+beforeEach(() => {
+  mcpCalls = [];
+  process.exit = (code) => {
+    throw Object.assign(new Error(`process.exit(${code})`), { exitCode: code });
+  };
+});
+
+afterAll(() => {
+  process.exit = originalExit;
+});
+
+async function runCli(argv) {
+  process.argv = ['node', 'run.js', ...argv];
+  await main();
+}
+
+test('query with an explicit-precision cast reaches the MCP server', async () => {
+  await runCli([
+    'query',
+    '--user', EMAIL,
+    '--reason', 'iReady score export',
+    '--sql', 'SELECT CAST(score AS NUMERIC(10,2)) FROM iready_scores',
+  ]);
+  expect(mcpCalls).toHaveLength(1);
+  expect(mcpCalls[0].params.name).toBe('query_data');
+  expect(mcpCalls[0].params.arguments.sql_query).toBe(
+    'SELECT CAST(score AS NUMERIC(10,2)) FROM iready_scores'
+  );
+});
+
+test('query with a bare CAST(...AS NUMERIC) is rejected before hitting the MCP server', async () => {
+  let thrown;
+  try {
+    await runCli([
+      'query',
+      '--user', EMAIL,
+      '--reason', 'iReady score export',
+      '--sql', 'SELECT CAST(score AS NUMERIC) FROM iready_scores',
+      '--export',
+    ]);
+  } catch (err) {
+    thrown = err;
+  }
+  expect(thrown).toBeDefined();
+  expect(thrown.exitCode).toBe(1);
+  expect(mcpCalls).toHaveLength(0); // never reached the MCP server
+});
+
+test('query with bare ::decimal shorthand is rejected before hitting the MCP server', async () => {
+  let thrown;
+  try {
+    await runCli([
+      'query',
+      '--user', EMAIL,
+      '--reason', 'iReady score export',
+      '--sql', 'SELECT score::decimal FROM iready_scores',
+      '--export',
+    ]);
+  } catch (err) {
+    thrown = err;
+  }
+  expect(thrown).toBeDefined();
+  expect(thrown.exitCode).toBe(1);
+  expect(mcpCalls).toHaveLength(0);
+});
+
+test('query with no numeric casts reaches the MCP server unaffected', async () => {
+  await runCli([
+    'query',
+    '--user', EMAIL,
+    '--reason', 'Headcount sanity check',
+    '--sql', 'SELECT COUNT(*) FROM students WHERE active = true',
+  ]);
+  expect(mcpCalls).toHaveLength(1);
+  expect(mcpCalls[0].params.name).toBe('query_data');
+});


### PR DESCRIPTION
## Description

Addresses #1106 (FS#162394 — "Unable to export numeric fields to csv").

**Scope note up front:** the confirmed root cause of this bug lives in an **external Lambda** (`psd-data-mcp`, outside this repo) whose source could not be inspected during triage — see the issue's own Diagnosis Brief (MEDIUM-LOW confidence). This PR does **not** fix that Lambda and does not claim to. It ships the one mitigation achievable from `psd401/aistudio`: hardening the `psd-data` agent skill (`infra/agent-image/skills/psd-data/`) against the leading hypothesis for the trigger.

### What changed

- **`common.js`** — added `findUnqualifiedNumericCasts(sql)`: scans SQL for `CAST(x AS NUMERIC)` / `CAST(x AS DECIMAL)` / `x::numeric` / `x::decimal` with no explicit precision (the documented "Hard rule" the MCP server enforces server-side — per the triage, an unqualified cast may be exactly what causes a numeric column to silently vanish from results/CSV instead of erroring). Uses proper `CAST(...)` paren-depth matching (not a naive boundary regex) and blanks out string-literal contents first, so it doesn't false-positive on a bare `AS numeric` column alias or on cast-like text inside a string literal — both were real gaps caught in self-review. Also blanks SQL comments (`--` and `/* */`, including nested block comments) and handles both `''`-doubled and `E'...'`-style backslash escaping, matching Postgres's real semantics.
- **`run.js`** — the `query` subcommand and the `call --tool query_data` passthrough (SKILL.md explicitly documents `call` as always available even when a typed subcommand exists — "a convenience, not a fence") both now fail fast client-side with an actionable message before the request ever reaches the server, instead of the column silently disappearing. Also added a `require.main === module` guard so `run.js` is unit-testable (matches the existing `psd-plaud` pattern).
- **`SKILL.md`** — reworded the "Hard rules" bullet to be explicit and actionable, added an exit-codes table row clarifying this new failure mode is safe to self-correct-and-retry (unlike other exit-1 errors), and documented the known remaining gap: `AVG()`/`SUM()` over a numeric column can produce an unqualified `NUMERIC` result with **no** `CAST`/`::` in the SQL text at all, which this text-scan approach cannot catch. If the reported symptom recurs with no bare cast in the query, that's the next lead.
- **`common.test.js`, `run.test.js`, `mcp-test-support.js`** — `bun:test` regression suite (33 tests) covering the cast-detection logic and both CLI call paths, following the existing pattern from the sibling `psd-plaud` skill.

### Why not close #1106

Per the adversarial self-review pass: shipping this without qualification risks a false sense of closure. The actual server-side behavior of `psd-data-mcp` is still unconfirmed, and this fix only covers the *textual*-cast trigger, not every way an unqualified NUMERIC could arise server-side. Recommend keeping #1106 open (or reduced-scope) until someone with visibility into the external Lambda can confirm the real mechanism — this PR narrows the search space and ships an immediate, low-risk guard, it doesn't close the investigation.

## Verification

- `infra/**` is excluded from this repo's root `tsconfig.json`, `eslint.config.mjs`, and `jest.config.js` (confirmed by direct inspection — `jest.config.js:46`: `'/infra/', // Infra has its own Jest config`), so this diff is structurally outside `bun run lint`/`typecheck`/`test:ci`'s scope regardless of environment.
- **Could not run** `bun run lint` / `typecheck` / `build` / `test:ci` in this session — the sandbox has no `node_modules` installed and network egress to `registry.npmjs.org` is denied by policy (confirmed 403 via direct curl, not proxy-relayed), so `bun install` cannot complete. This is an environment limitation, not caused by this diff (a fresh `dev` checkout in the same sandbox would fail identically). CI will run these on push.
- **Did run** the skill's own self-contained test suite (the established pattern for `infra/agent-image/skills/*`, not CI-gated — same as the sibling `psd-plaud`/`psd-summarize` skills, and the analogous Python tests in this same directory per `docs/learnings/workflow/2026-06-30-python-agent-image-tests-unittest-not-pytest.md`):
  ```
  cd infra/agent-image/skills/psd-data && bun test
  # 33 pass, 0 fail, 45 expect() calls
  ```
- E2E: not applicable — no `app/`, `components/`, or `actions/` files touched, so there's no Playwright-drivable UI surface change. The reported bug's actual flow (Nexus chat → data MCP query → CSV export) requires a live AgentCore container, live Cognito auth, and the live external Lambda — none of which exist in any local/CI sandbox for this repo. Pushed with `SKIP_E2E=1` (this repo's own documented bypass in `.githooks/pre-push`) since the authenticated local E2E suite needs a seeded `AUTH_SECRET` not present here, and nothing in this diff's surface is E2E-testable in the first place.
- Self-reviewed by 5 parallel review passes (security, correctness, adversarial, code-simplicity, agent-native-skill) before opening this PR; all findings from that pass are already fixed in the commits above. Additional rounds of automated review (Copilot, Gemini, Codex, claude[bot]) surfaced further edge cases (string-literal comment handling, `TRY_CAST`, backslash-escape semantics, nested block comments), all fixed in follow-up commits — see PR comments for details.

## Checklist

- [x] No `console.*` calls in production/shared code (n/a — this skill already uses `process.stdout/stderr` directly per its established pattern, unchanged by this diff)
- [x] N/A — no client component code touched
- [x] N/A — no client code touched
- [ ] Lint passes (`npm run lint`) — not run locally (see Verification); `infra/**` is excluded from this gate regardless
- [x] All tests pass (`bun test` in the skill dir — 33/33; see Verification for why root `npm test` doesn't apply)
- [x] Types/interfaces follow project conventions (plain CommonJS, matches sibling skills — `infra/**` isn't part of the TS project)
- [x] No type assertions
- [x] N/A — no database fields touched
- [ ] TypeScript strict mode errors resolved — n/a, `infra/**` excluded from `tsconfig.json`
- [x] No new environment variables
- [x] Documentation updated — `SKILL.md` updated as part of this fix
- [ ] Code reviewed and approved — self-reviewed (5 parallel agents) + 3 rounds of automated PR review; awaiting human/CI review
- [ ] App builds and runs without module errors — not verified locally (see Verification); CI will confirm

## Related Issues

Addresses #1106


---
_Generated by [Claude Code](https://claude.ai/code/session_01YKnkgo4uEiyV497yohw2p7)_
