### PR TITLE
fix(B-002): agent-skill-builder hardening (RCE, audit gate, zip-slip)

### DIFF
--- a/infra/lambdas/agent-skill-builder/__tests__/index.test.ts
+++ b/infra/lambdas/agent-skill-builder/__tests__/index.test.ts
@@ -114,11 +114,33 @@ describe('auditInstalledDeps (REV-INFRA-062)', () => {
     expect(warnings.some((w) => /not evaluated/i.test(w.message))).toBe(true);
   });
 
-  test('audit tooling throwing degrades gracefully with a WARNING', () => {
+  test('audit tooling throwing (no stdout) degrades gracefully with a WARNING', () => {
     const warnings: Warn[] = [];
     const fakeExec = () => {
       throw new Error('spawn npm ENOENT');
     };
+    const out = auditInstalledDeps('/work', collectingLogger(warnings), fakeExec);
+    expect(out).toEqual([]);
+    expect(warnings.some((w) => /not evaluated/i.test(w.message))).toBe(true);
+  });
+
+  test('npm audit exiting non-zero for real vulnerabilities still parses stdout from the thrown error', () => {
+    const warnings: Warn[] = [];
+    const fakeExec = () => {
+      const err = new Error('Command failed') as Error & { stdout: string };
+      err.stdout = JSON.stringify({
+        vulnerabilities: { minimist: { severity: 'critical', name: 'minimist' } },
+      });
+      throw err;
+    };
+    const out = auditInstalledDeps('/work', collectingLogger(warnings), fakeExec);
+    expect(out).toEqual([{ severity: 'critical', title: 'minimist' }]);
+    expect(warnings.length).toBe(0);
+  });
+
+  test('a top-level `error` field (registry/auth failure) degrades gracefully with a WARNING, never a silent clean', () => {
+    const warnings: Warn[] = [];
+    const fakeExec = () => JSON.stringify({ error: { code: 'E401', summary: 'unauthorized' } });
     const out = auditInstalledDeps('/work', collectingLogger(warnings), fakeExec);
     expect(out).toEqual([]);
     expect(warnings.some((w) => /not evaluated/i.test(w.message))).toBe(true);

--- a/infra/lambdas/agent-skill-builder/__tests__/index.test.ts
+++ b/infra/lambdas/agent-skill-builder/__tests__/index.test.ts
@@ -1,0 +1,200 @@
+/**
+ * Tests for agent-skill-builder security hardening (B-002):
+ *   REV-INFRA-061 — npm install must run with lifecycle scripts DISABLED (RCE).
+ *   REV-INFRA-062 — dependency audit runs post-install and gates promotion.
+ *   REV-INFRA-063 — S3 download rejects path-traversing keys (zip-slip).
+ *
+ * Run from infra/lambdas/agent-skill-builder/:  bun test
+ *
+ * Placed under __tests__/ so the lambda's `tsc` build (tsconfig include:
+ * ["*.ts"], non-recursive) does not compile it; bun test discovers it directly
+ * and strips the type-only `aws-lambda` import at runtime.
+ */
+
+import { test, expect, describe } from 'bun:test';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { execSync } from 'child_process';
+
+import {
+  installSkillDependencies,
+  auditInstalledDeps,
+  downloadSkillFromS3,
+} from '../index';
+
+type Warn = { message: string; meta?: Record<string, unknown> };
+function collectingLogger(warnings: Warn[]) {
+  return {
+    info: () => {},
+    warn: (message: string, meta?: Record<string, unknown>) => warnings.push({ message, meta }),
+    error: () => {},
+  };
+}
+
+function makeSkillDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'skillbuild-'));
+}
+
+// A postinstall that writes a sentinel file into the package cwd. If it runs,
+// the sentinel exists — i.e. arbitrary code executed during the build.
+const MALICIOUS_PKG = JSON.stringify({
+  name: 'evil-skill',
+  version: '1.0.0',
+  scripts: { postinstall: "node -e \"require('fs').writeFileSync('PWNED','x')\"" },
+});
+
+describe('installSkillDependencies (REV-INFRA-061)', () => {
+  test('does NOT execute a malicious postinstall lifecycle script', () => {
+    const dir = makeSkillDir();
+    try {
+      fs.writeFileSync(path.join(dir, 'package.json'), MALICIOUS_PKG);
+      installSkillDependencies(dir);
+      expect(fs.existsSync(path.join(dir, 'PWNED'))).toBe(false);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('control: the same postinstall DOES run without --ignore-scripts (fixture is valid)', () => {
+    const dir = makeSkillDir();
+    try {
+      fs.writeFileSync(path.join(dir, 'package.json'), MALICIOUS_PKG);
+      execSync('npm install --production --no-audit --no-fund', {
+        cwd: dir,
+        stdio: 'pipe',
+        env: { ...process.env, HOME: '/tmp', npm_config_cache: '/tmp/.npm' },
+      });
+      expect(fs.existsSync(path.join(dir, 'PWNED'))).toBe(true);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('a benign skill (no scripts, no deps) installs without error', () => {
+    const dir = makeSkillDir();
+    try {
+      fs.writeFileSync(
+        path.join(dir, 'package.json'),
+        JSON.stringify({ name: 'good-skill', version: '1.0.0' }),
+      );
+      expect(() => installSkillDependencies(dir)).not.toThrow();
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('auditInstalledDeps (REV-INFRA-062)', () => {
+  test('returns high/critical advisories parsed from audit JSON', () => {
+    const warnings: Warn[] = [];
+    const fakeExec = () =>
+      JSON.stringify({
+        vulnerabilities: {
+          lodash: { severity: 'high', name: 'lodash' },
+          ms: { severity: 'critical', name: 'ms' },
+          chalk: { severity: 'low', name: 'chalk' }, // below threshold — ignored
+        },
+      });
+    const out = auditInstalledDeps('/work', collectingLogger(warnings), fakeExec);
+    expect(out.map((o) => o.severity).sort()).toEqual(['critical', 'high']);
+    expect(warnings.length).toBe(0);
+  });
+
+  test('a clean dependency tree yields no advisories', () => {
+    const fakeExec = () => JSON.stringify({ vulnerabilities: {} });
+    expect(auditInstalledDeps('/work', collectingLogger([]), fakeExec)).toEqual([]);
+  });
+
+  test('unparseable audit output degrades gracefully with a WARNING (never a silent pass)', () => {
+    const warnings: Warn[] = [];
+    const fakeExec = () => 'npm error code ENOLOCK\nThis is not JSON';
+    const out = auditInstalledDeps('/work', collectingLogger(warnings), fakeExec);
+    expect(out).toEqual([]);
+    expect(warnings.some((w) => /not evaluated/i.test(w.message))).toBe(true);
+  });
+
+  test('audit tooling throwing degrades gracefully with a WARNING', () => {
+    const warnings: Warn[] = [];
+    const fakeExec = () => {
+      throw new Error('spawn npm ENOENT');
+    };
+    const out = auditInstalledDeps('/work', collectingLogger(warnings), fakeExec);
+    expect(out).toEqual([]);
+    expect(warnings.some((w) => /not evaluated/i.test(w.message))).toBe(true);
+  });
+});
+
+describe('downloadSkillFromS3 path-traversal guard (REV-INFRA-063)', () => {
+  function fakeS3(keys: string[], getCalls: string[]) {
+    return {
+      send: async (cmd: { constructor: { name: string }; input?: { Key?: string } }) => {
+        const name = cmd.constructor.name;
+        if (name === 'ListObjectsV2Command') {
+          return { Contents: keys.map((Key) => ({ Key })), NextContinuationToken: undefined };
+        }
+        if (name === 'GetObjectCommand') {
+          getCalls.push(cmd.input?.Key ?? '');
+          async function* body() {
+            yield Buffer.from('file-content');
+          }
+          return { Body: body() };
+        }
+        throw new Error(`unexpected command ${name}`);
+      },
+    };
+  }
+
+  test('skips traversing keys, downloads only in-root keys, and warns', async () => {
+    const destDir = makeSkillDir();
+    const warnings: Warn[] = [];
+    const getCalls: string[] = [];
+    const prefix = 'drafts/skill-1/';
+    const keys = [
+      `${prefix}src/index.js`, // benign nested
+      `${prefix}../../evil.txt`, // zip-slip escape (resolves outside destDir)
+      `${prefix}ok.md`, // benign top-level
+    ];
+    try {
+      await downloadSkillFromS3(
+        prefix,
+        destDir,
+        collectingLogger(warnings),
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        fakeS3(keys, getCalls) as any,
+      );
+
+      // benign files were written to the correct relative paths
+      expect(fs.existsSync(path.join(destDir, 'src', 'index.js'))).toBe(true);
+      expect(fs.existsSync(path.join(destDir, 'ok.md'))).toBe(true);
+      // the escaping object was never fetched or written
+      expect(getCalls).toEqual([`${prefix}src/index.js`, `${prefix}ok.md`]);
+      expect(fs.existsSync(path.resolve(destDir, '..', '..', 'evil.txt'))).toBe(false);
+      // and it was logged
+      expect(
+        warnings.some((w) => String(w.meta?.key ?? '').includes('../../evil.txt')),
+      ).toBe(true);
+    } finally {
+      fs.rmSync(destDir, { recursive: true, force: true });
+    }
+  });
+
+  test('normal nested keys still download to the correct relative path', async () => {
+    const destDir = makeSkillDir();
+    const getCalls: string[] = [];
+    const prefix = 'drafts/skill-2/';
+    const keys = [`${prefix}a/b/c.ts`];
+    try {
+      await downloadSkillFromS3(
+        prefix,
+        destDir,
+        collectingLogger([]),
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        fakeS3(keys, getCalls) as any,
+      );
+      expect(fs.existsSync(path.join(destDir, 'a', 'b', 'c.ts'))).toBe(true);
+    } finally {
+      fs.rmSync(destDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/infra/lambdas/agent-skill-builder/index.ts
+++ b/infra/lambdas/agent-skill-builder/index.ts
@@ -17,7 +17,7 @@
 
 import { S3Client, GetObjectCommand, PutObjectCommand, ListObjectsV2Command } from '@aws-sdk/client-s3';
 import { RDSDataClient, ExecuteStatementCommand } from '@aws-sdk/client-rds-data';
-import { execSync } from 'child_process';
+import { execSync, type ExecSyncOptionsWithStringEncoding } from 'child_process';
 import * as fs from 'fs';
 import * as path from 'path';
 import type { Handler } from 'aws-lambda';
@@ -128,15 +128,17 @@ export const handler: Handler<SkillBuildEvent> = async (event) => {
 
   try {
     // 1. Download skill files from S3
-    await downloadSkillFromS3(event.s3Key, workDir);
+    await downloadSkillFromS3(event.s3Key, workDir, log);
 
     // 2. Run automated scan
     const findings = await scanSkill(workDir);
 
-    // 3. Check if scan is clean
+    // 3. Check if scan is clean. Dependency-vulnerability auditing does NOT run
+    // here — `npm audit` needs a resolved lockfile/node_modules, which don't
+    // exist pre-install, so it runs post-install below (REV-INFRA-062). This
+    // gate covers the pre-install secret/PII checks only.
     const isFlagged = findings.secrets.length > 0 ||
-      findings.pii.length > 0 ||
-      findings.npmAudit.some(a => a.severity === 'critical' || a.severity === 'high');
+      findings.pii.length > 0;
 
     if (isFlagged) {
       // Update DB: mark as flagged with findings
@@ -156,16 +158,7 @@ export const handler: Handler<SkillBuildEvent> = async (event) => {
     const packageJsonPath = path.join(workDir, 'package.json');
     if (fs.existsSync(packageJsonPath)) {
       try {
-        execSync('npm install --production --no-audit --no-fund', {
-          cwd: workDir,
-          timeout: 120_000, // 2 min max for npm install
-          stdio: 'pipe',
-          env: {
-            ...process.env,
-            HOME: '/tmp',
-            npm_config_cache: '/tmp/.npm',
-          },
-        });
+        installSkillDependencies(workDir);
       } catch (npmErr: unknown) {
         const message = npmErr instanceof Error ? npmErr.message : String(npmErr);
         await updateSkillStatus(event.skillId, 'flagged', {
@@ -183,6 +176,32 @@ export const handler: Handler<SkillBuildEvent> = async (event) => {
           status: 'build_failed',
           skillId: event.skillId,
           error: message.substring(0, 500),
+        };
+      }
+
+      // 4b. Audit the *resolved* dependency tree now that `npm install` has
+      // produced a package-lock.json + node_modules. npm audit is a no-op
+      // (ENOLOCK) before install, which is why the pre-install scan could never
+      // catch dependency CVEs (REV-INFRA-062). A high/critical advisory flags
+      // the skill and skips promotion — nothing has been uploaded yet.
+      const npmAudit = auditInstalledDeps(workDir, log);
+      if (npmAudit.some(a => a.severity === 'critical' || a.severity === 'high')) {
+        const auditFindings: ScanFindings = {
+          secrets: [],
+          pii: [],
+          npmAudit,
+          skillMdLint: [],
+          summary: `${npmAudit.length} high/critical npm vulnerability(ies)`,
+        };
+        await updateSkillStatus(event.skillId, 'flagged', auditFindings);
+        await writeAuditLog(event.skillId, 'scan_flagged', event.actorUserId, {
+          findings: auditFindings.summary,
+        });
+
+        return {
+          status: 'flagged',
+          skillId: event.skillId,
+          findings: auditFindings,
         };
       }
     }
@@ -231,15 +250,22 @@ export const handler: Handler<SkillBuildEvent> = async (event) => {
   }
 };
 
-async function downloadSkillFromS3(prefix: string, destDir: string): Promise<void> {
+export async function downloadSkillFromS3(
+  prefix: string,
+  destDir: string,
+  log: LambdaLogger,
+  s3Client: S3Client = s3,
+): Promise<void> {
   fs.mkdirSync(destDir, { recursive: true });
 
   // H5 fix: Paginate ListObjectsV2 to handle skills with >1000 files
   const normalizedPrefix = prefix.endsWith('/') ? prefix : `${prefix}/`;
   let continuationToken: string | undefined;
+  // Resolve the work-dir root once for the traversal containment check below.
+  const destRoot = path.resolve(destDir) + path.sep;
 
   do {
-    const listResp = await s3.send(new ListObjectsV2Command({
+    const listResp = await s3Client.send(new ListObjectsV2Command({
       Bucket: BUCKET,
       Prefix: normalizedPrefix,
       ContinuationToken: continuationToken,
@@ -248,11 +274,21 @@ async function downloadSkillFromS3(prefix: string, destDir: string): Promise<voi
     for (const obj of listResp.Contents || []) {
       if (!obj.Key || obj.Key.endsWith('/')) continue;
 
-      const relativePath = obj.Key.slice(prefix.length).replace(/^\//, '');
-      const destPath = path.join(destDir, relativePath);
+      const relativePath = obj.Key.slice(prefix.length).replace(/^\/+/, '');
+      // Path-traversal guard (REV-INFRA-063): S3 keys are user-influenced —
+      // draft filenames become key suffixes — and may contain `..` segments.
+      // path.join/resolve would normalize `../../x` to a path OUTSIDE destDir,
+      // a zip-slip write into /tmp (npm cache, another concurrent build's work
+      // dir) that undermines the scan. Reject any key whose resolved
+      // destination escapes the per-build work dir.
+      const destPath = path.resolve(destDir, relativePath);
+      if (!destPath.startsWith(destRoot)) {
+        log.warn('Skipping S3 object with path-traversing key', { key: obj.Key });
+        continue;
+      }
       fs.mkdirSync(path.dirname(destPath), { recursive: true });
 
-      const getResp = await s3.send(new GetObjectCommand({
+      const getResp = await s3Client.send(new GetObjectCommand({
         Bucket: BUCKET,
         Key: obj.Key,
       }));
@@ -406,39 +442,12 @@ async function scanSkill(skillDir: string): Promise<ScanFindings> {
     }
   }
 
-  // npm audit (best-effort, skip if package.json missing)
-  const pkgPath = path.join(skillDir, 'package.json');
-  if (fs.existsSync(pkgPath)) {
-    try {
-      const auditOutput = execSync('npm audit --json --production 2>/dev/null || true', {
-        cwd: skillDir,
-        timeout: 30_000,
-        encoding: 'utf-8',
-        env: {
-          ...process.env,
-          HOME: '/tmp',
-          npm_config_cache: '/tmp/.npm',
-        },
-      });
-
-      try {
-        const audit = JSON.parse(auditOutput);
-        const vulns = audit.vulnerabilities || {};
-        for (const [, info] of Object.entries(vulns) as [string, { severity: string; name: string }][]) {
-          if (info.severity === 'high' || info.severity === 'critical') {
-            findings.npmAudit.push({
-              severity: info.severity,
-              title: info.name || 'unknown',
-            });
-          }
-        }
-      } catch {
-        // audit JSON parse failure — not a blocker
-      }
-    } catch {
-      // npm audit failed — not a blocker
-    }
-  }
+  // NOTE: dependency-vulnerability auditing (npm audit) intentionally does NOT
+  // run here. Before `npm install` there is no package-lock.json / node_modules,
+  // so `npm audit` is a no-op (ENOLOCK) and never sees a single advisory — which
+  // made this gate a no-op (REV-INFRA-062). The audit now runs post-install via
+  // auditInstalledDeps() in the handler, against the resolved dependency tree.
+  // findings.npmAudit is populated there, not here.
 
   // Build summary
   const parts: string[] = [];
@@ -449,6 +458,90 @@ async function scanSkill(skillDir: string): Promise<ScanFindings> {
   findings.summary = parts.length > 0 ? parts.join(', ') : 'clean';
 
   return findings;
+}
+
+/**
+ * Install a skill's production dependencies with npm lifecycle scripts DISABLED.
+ *
+ * `--ignore-scripts` (belt-and-suspenders: also `npm_config_ignore_scripts`) is
+ * load-bearing SECURITY, not an optimization: this installs a user-submitted,
+ * unvetted skill's dependencies, and npm runs preinstall/install/postinstall
+ * lifecycle scripts by default — arbitrary code execution under the Lambda's
+ * execution role. The pre-install scan never inspects lifecycle scripts, so a
+ * `postinstall` in the skill's own package.json (or any dependency) would
+ * otherwise run unchecked. See REV-INFRA-061.
+ */
+export function installSkillDependencies(workDir: string): void {
+  execSync('npm install --production --ignore-scripts --no-audit --no-fund', {
+    cwd: workDir,
+    timeout: 120_000, // 2 min max for npm install
+    stdio: 'pipe',
+    env: {
+      ...process.env,
+      HOME: '/tmp',
+      npm_config_cache: '/tmp/.npm',
+      npm_config_ignore_scripts: 'true',
+    },
+  });
+}
+
+/**
+ * Audit the *resolved* dependency tree for known high/critical advisories.
+ *
+ * Runs AFTER `installSkillDependencies`, when a package-lock.json + node_modules
+ * exist — `npm audit` is a no-op (ENOLOCK) without them, which is why the
+ * pre-install scan could never see dependency vulns (REV-INFRA-062).
+ *
+ * Graceful degradation (documented behavior): if the audit tooling itself
+ * cannot produce parseable JSON (npm/network error), we log a WARNING and
+ * return []. A tooling error is therefore VISIBLE in logs, never a silent
+ * "clean" — but it does not hard-block promotion, matching the best-effort
+ * intent of the other scan steps. `exec` is injectable for testing.
+ */
+export function auditInstalledDeps(
+  dir: string,
+  log: LambdaLogger,
+  exec: (command: string, options: ExecSyncOptionsWithStringEncoding) => string = execSync,
+): { severity: string; title: string }[] {
+  const results: { severity: string; title: string }[] = [];
+
+  let auditOutput: string;
+  try {
+    // `|| true` so a non-zero exit (npm audit returns 1 when vulns exist) still
+    // yields the JSON on stdout instead of throwing before we can parse it.
+    auditOutput = exec('npm audit --json --production 2>/dev/null || true', {
+      cwd: dir,
+      timeout: 30_000,
+      encoding: 'utf-8',
+      env: {
+        ...process.env,
+        HOME: '/tmp',
+        npm_config_cache: '/tmp/.npm',
+      },
+    });
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    log.warn('npm audit could not run; dependency vulnerabilities were NOT evaluated', {
+      error: message.substring(0, 300),
+    });
+    return results;
+  }
+
+  let audit: { vulnerabilities?: Record<string, { severity?: string; name?: string }> };
+  try {
+    audit = JSON.parse(auditOutput);
+  } catch {
+    log.warn('npm audit produced no parseable JSON; dependency vulnerabilities were NOT evaluated');
+    return results;
+  }
+
+  const vulns = audit.vulnerabilities || {};
+  for (const [, info] of Object.entries(vulns)) {
+    if (info.severity === 'high' || info.severity === 'critical') {
+      results.push({ severity: info.severity, title: info.name || 'unknown' });
+    }
+  }
+  return results;
 }
 
 async function updateSkillStatus(

--- a/infra/lambdas/agent-skill-builder/index.ts
+++ b/infra/lambdas/agent-skill-builder/index.ts
@@ -274,7 +274,7 @@ export async function downloadSkillFromS3(
     for (const obj of listResp.Contents || []) {
       if (!obj.Key || obj.Key.endsWith('/')) continue;
 
-      const relativePath = obj.Key.slice(prefix.length).replace(/^\/+/, '');
+      const relativePath = obj.Key.slice(normalizedPrefix.length);
       // Path-traversal guard (REV-INFRA-063): S3 keys are user-influenced —
       // draft filenames become key suffixes — and may contain `..` segments.
       // path.join/resolve would normalize `../../x` to a path OUTSIDE destDir,
@@ -475,7 +475,10 @@ export function installSkillDependencies(workDir: string): void {
   execSync('npm install --production --ignore-scripts --no-audit --no-fund', {
     cwd: workDir,
     timeout: 120_000, // 2 min max for npm install
-    stdio: 'pipe',
+    // Only stderr is inspected on failure; piping stdout too risks exceeding
+    // Node's default maxBuffer on a verbose install and throwing a
+    // false-positive error.
+    stdio: ['ignore', 'ignore', 'pipe'],
     env: {
       ...process.env,
       HOME: '/tmp',
@@ -507,9 +510,12 @@ export function auditInstalledDeps(
 
   let auditOutput: string;
   try {
-    // `|| true` so a non-zero exit (npm audit returns 1 when vulns exist) still
-    // yields the JSON on stdout instead of throwing before we can parse it.
-    auditOutput = exec('npm audit --json --production 2>/dev/null || true', {
+    // npm audit exits non-zero when vulnerabilities are found, but still
+    // writes the JSON report to stdout — capture it from the thrown error
+    // below instead of silencing the exit code, so a genuine tooling/network
+    // failure (which also exits non-zero, with no usable stdout) is still
+    // visible instead of masquerading as "no vulnerabilities".
+    auditOutput = exec('npm audit --json --production', {
       cwd: dir,
       timeout: 30_000,
       encoding: 'utf-8',
@@ -520,14 +526,19 @@ export function auditInstalledDeps(
       },
     });
   } catch (err: unknown) {
-    const message = err instanceof Error ? err.message : String(err);
-    log.warn('npm audit could not run; dependency vulnerabilities were NOT evaluated', {
-      error: message.substring(0, 300),
-    });
-    return results;
+    const stdout = (err as { stdout?: string | Buffer } | undefined)?.stdout;
+    if (stdout) {
+      auditOutput = typeof stdout === 'string' ? stdout : stdout.toString('utf-8');
+    } else {
+      const message = err instanceof Error ? err.message : String(err);
+      log.warn('npm audit could not run; dependency vulnerabilities were NOT evaluated', {
+        error: message.substring(0, 300),
+      });
+      return results;
+    }
   }
 
-  let audit: { vulnerabilities?: Record<string, { severity?: string; name?: string }> };
+  let audit: { error?: unknown; vulnerabilities?: Record<string, { severity?: string; name?: string }> };
   try {
     audit = JSON.parse(auditOutput);
   } catch {
@@ -535,7 +546,20 @@ export function auditInstalledDeps(
     return results;
   }
 
-  const vulns = audit.vulnerabilities || {};
+  // A registry/auth failure can still exit with valid JSON that carries a
+  // top-level `error` and no `vulnerabilities` key at all (distinct from a
+  // clean tree, which reports `vulnerabilities: {}`). Treat that the same as
+  // a tooling failure — a visible warning, never a silent "clean" — since
+  // the whole point of this gate is that a failed audit must not look like
+  // a passed one.
+  if (audit.error || !audit.vulnerabilities) {
+    log.warn('npm audit did not evaluate dependencies; dependency vulnerabilities were NOT evaluated', {
+      error: audit.error ? JSON.stringify(audit.error).substring(0, 300) : undefined,
+    });
+    return results;
+  }
+
+  const vulns = audit.vulnerabilities;
   for (const [, info] of Object.entries(vulns)) {
     if (info.severity === 'high' || info.severity === 'critical') {
       results.push({ severity: info.severity, title: info.name || 'unknown' });

--- a/infra/lambdas/agent-skill-builder/package.json
+++ b/infra/lambdas/agent-skill-builder/package.json
@@ -5,7 +5,8 @@
   "main": "dist/index.js",
   "scripts": {
     "build": "tsc",
-    "prebuild": "rm -rf dist"
+    "prebuild": "rm -rf dist",
+    "test": "bun test"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.0.0",

--- a/infra/package.json
+++ b/infra/package.json
@@ -5,11 +5,12 @@
     "infra": "bin/infra.js"
   },
   "scripts": {
-    "build": "tsc",
+    "build": "tsc && bun run test:lambdas",
     "build:lambdas": "./build-lambdas.sh",
     "build:all": "bun run build && bun run build:lambdas",
     "watch": "tsc -w",
     "test": "jest",
+    "test:lambdas": "cd lambdas/agent-skill-builder && bun install && bun run test",
     "cdk": "cdk"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

Remediation batch **B-002** — 3 findings, all in one file:
`infra/lambdas/agent-skill-builder/index.ts`. This Lambda downloads a
**user-submitted** skill draft from S3, scans it, runs `npm install`, and
promotes it — with a role that can read the Aurora master secret, run RDS Data
API statements, read/write the whole workspace bucket, and reach the internet.

## Findings fixed

| ID | Severity | Fix |
|----|----------|-----|
| **REV-INFRA-061** | **Critical (RCE)** | `npm install` ran unvetted skill code with npm **lifecycle scripts enabled** → a `postinstall` in the skill or any dependency executed arbitrary code under the Lambda role (user-triggered, no human gate). Install now runs `--ignore-scripts` (+ `npm_config_ignore_scripts=true`), extracted to `installSkillDependencies()`. |
| **REV-INFRA-062** | Medium | `npm audit` ran in the **pre-install** scan — before any lockfile/`node_modules` existed — so it always errored (ENOLOCK) into a bare `catch`, making the "block high/critical vulns" gate a no-op. Audit now runs **post-install** (`auditInstalledDeps()`) against the resolved tree; a high/critical advisory flags the skill and skips promotion. Tooling errors degrade gracefully with a **visible warning**, never a silent pass. |
| **REV-INFRA-063** | Medium | `downloadSkillFromS3` wrote each S3 object to a `path.join`'d path with no containment check; a draft key with `..` could escape the `/tmp` work dir (zip-slip). It now `path.resolve`s each destination and **skips-and-warns** on any key that escapes the per-build root. |

## Testing

`infra/lambdas/agent-skill-builder/__tests__/index.test.ts` — **9 tests, all green** via `bun test` (the Lambda is a bun project with its own `node_modules`; infra's ts-jest can't compile it under its `NodeNext` tsconfig, and the file lives in `__tests__/` so the Lambda's own `tsc` build skips it):

- **061**: real `npm install` on a fixture whose `postinstall` writes a sentinel — `installSkillDependencies` does **not** create it; a control **without** `--ignore-scripts` **does** (proving the fixture is valid); a benign skill installs without error.
- **062**: `auditInstalledDeps` returns high/critical advisories from parsed audit JSON, ignores below-threshold, returns `[]` for a clean tree, and degrades gracefully with a warning on unparseable output **and** on a thrown tooling error.
- **063**: a synthetic listing with a `<prefix>/../../evil.txt` key is skipped (never fetched, warned) while benign nested keys download to the correct relative path.

Gates: Lambda `tsc --noEmit` clean · root `bun run lint` **0 errors** · root `bun run typecheck` **clean**.

## Scope notes

- Pushed with the repo's documented `SKIP_E2E=1` — the pre-push hook runs the authenticated Playwright **web-UI** E2E suite, which has no bearing on this Lambda and needs a local `AUTH_SECRET` + seeded DB.
- **Not covered here (integration, needs live AWS + npm registry):** the end-to-end handler status transitions (benign draft → `promoted`; vulnerable draft → `flagged` and not uploaded). Every security-critical primitive those transitions depend on is unit-proven above; driving the full handler requires S3 + RDS Data API + the npm advisory DB.
- The **IAM least-privilege tightening** in the REV-INFRA-061 plan (scope the role off the DB master secret / whole bucket) is an explicit **separate follow-up**, intentionally not bundled into this fix.
- Related cross-lens duplicates resolved by these changes: REV-COR-391 (061), REV-COR-392 (062), REV-COR-393 (063).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HWA2JRbkae8HCRsZwoEJXw
