### PR TITLE
fix(B-003): web_fetch SSRF redirect guard + streaming/perf bounds

### DIFF
--- a/lib/agents/agent-tools/web-fetch.ts
+++ b/lib/agents/agent-tools/web-fetch.ts
@@ -15,8 +15,10 @@ import { createLogger } from "@/lib/logger";
 const DEFAULT_MAX_CHARS = 20_000;
 const HARD_MAX_CHARS = 100_000;
 /** Cap the raw body we read so a huge page can't exhaust memory. */
-const MAX_BYTES = 5_000_000;
+export const MAX_BYTES = 5_000_000;
 const FETCH_TIMEOUT_MS = 10_000;
+/** Cap redirect hops; each hop's target is re-validated by the SSRF guard. */
+const MAX_REDIRECTS = 5;
 
 function textResult(text: string, isError = false): McpToolResult {
   return { content: [{ type: "text", text }], isError };
@@ -38,10 +40,39 @@ function isPrivateIpv4(host: string): boolean {
   );
 }
 
+/**
+ * If `host` is an IPv4-compatible IPv6 literal (::/96, e.g. Node normalizes
+ * "::127.0.0.1" to the compressed hex "::7f00:1"), return the embedded IPv4 in
+ * dotted form; otherwise null. Excludes the ::ffff: IPv4-*mapped* range (handled
+ * by prefix) and the bare "::"/"::1" forms (handled in isPrivateIpv6). (COR-506)
+ */
+function embeddedIpv4FromCompatibleV6(host: string): string | null {
+  // 1–2 trailing 16-bit hex groups after "::" and nothing else. WHATWG URL emits
+  // the IPv4-compatible tail as hex groups, so reconstruct the 32-bit v4 from them.
+  const two = host.match(/^::([0-9a-f]{1,4}):([0-9a-f]{1,4})$/);
+  const one = host.match(/^::([0-9a-f]{1,4})$/);
+  let hi: number;
+  let lo: number;
+  if (two) {
+    hi = Number.parseInt(two[1], 16);
+    lo = Number.parseInt(two[2], 16);
+  } else if (one) {
+    hi = 0;
+    lo = Number.parseInt(one[1], 16);
+  } else {
+    return null;
+  }
+  if (!Number.isFinite(hi) || !Number.isFinite(lo)) return null;
+  return `${(hi >> 8) & 0xFF}.${hi & 0xFF}.${(lo >> 8) & 0xFF}.${lo & 0xFF}`;
+}
+
 /** True for an IPv6 loopback / unique-local / link-local / IPv4-mapped literal. */
 function isPrivateIpv6(host: string): boolean {
-  return (
+  if (
     host === "::1" ||
+    // Unspecified address; connecting to :: reaches localhost on many stacks.
+    // (COR-506)
+    host === "::" ||
     host.startsWith("fc") ||
     host.startsWith("fd") ||
     // Link-local fe80::/10 spans the fe80–febf prefixes, not just fe80.
@@ -50,7 +81,15 @@ function isPrivateIpv6(host: string): boolean {
     // Any IPv4-mapped form. URL normalizes full-form (0:0:0:0:0:ffff:…) to this
     // compressed prefix, so this also blocks ::ffff:<private-or-public-v4>.
     host.startsWith("::ffff:")
-  );
+  ) {
+    return true;
+  }
+  // IPv4-compatible IPv6 (::a.b.c.d, deprecated but still parsed/routed). Node
+  // normalizes these to compressed hex (e.g. "::7f00:1" for "::127.0.0.1"); the
+  // last 32 bits are an IPv4 address — evaluate it against the private ranges so
+  // "::127.0.0.1" is blocked while a public "::8.8.8.8" is not. (COR-506)
+  const v4 = embeddedIpv4FromCompatibleV6(host);
+  return v4 !== null && isPrivateIpv4(v4);
 }
 
 /** True for a host we must never fetch (internal name or private address). */
@@ -153,24 +192,116 @@ function isTextualContentType(contentType: string): boolean {
   );
 }
 
+/**
+ * Read a response body as a stream, stopping once `maxBytes` have been read, so
+ * peak memory is bounded to ~`maxBytes` regardless of what the server sends
+ * (REV-COR-500). Falls back to `res.text()` only when no stream body is present
+ * (e.g. 204s or test doubles), still bounding the returned length.
+ */
+async function readBoundedText(res: Response, maxBytes: number): Promise<string> {
+  if (!res.body) {
+    const t = await res.text();
+    return t.length > maxBytes ? t.slice(0, maxBytes) : t;
+  }
+  const reader = res.body.getReader();
+  const decoder = new TextDecoder("utf-8");
+  let received = 0;
+  let out = "";
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    if (!value) continue;
+    const room = maxBytes - received;
+    if (value.byteLength >= room) {
+      // Decode only up to the cap, then stop reading and release the stream.
+      out += decoder.decode(value.subarray(0, room));
+      await reader.cancel();
+      return out;
+    }
+    received += value.byteLength;
+    out += decoder.decode(value, { stream: true });
+  }
+  out += decoder.decode(); // flush any trailing multi-byte sequence
+  return out;
+}
+
 /** Read a fetched response into bounded, readable text. */
-async function readResponseText(res: Response, maxChars: number): Promise<string> {
+export async function readResponseText(res: Response, maxChars: number): Promise<string> {
   const contentType = (res.headers.get("content-type") || "").toLowerCase();
   if (!isTextualContentType(contentType)) {
     throw new Error(
       `non-text content (content-type: ${contentType || "unknown"})`
     );
   }
-  const raw = await res.text();
-  const bounded = raw.length > MAX_BYTES ? raw.slice(0, MAX_BYTES) : raw;
-  const isHtml = contentType.includes("html") || /<html[\s>]/i.test(bounded);
-  const text = isHtml ? htmlToText(bounded) : bounded.trim();
+  // Fast reject: an advertised Content-Length over the cap, before reading a
+  // single body byte (REV-COR-500).
+  const declaredLength = Number(res.headers.get("content-length"));
+  if (Number.isFinite(declaredLength) && declaredLength > MAX_BYTES) {
+    throw new Error(
+      `response too large (content-length ${declaredLength} > ${MAX_BYTES} bytes)`
+    );
+  }
+
+  const bounded = await readBoundedText(res, MAX_BYTES);
+  // Bound the working set BEFORE the expensive htmlToText passes (REV-PERF-005):
+  // HTML markup expands relative to visible text, so maxChars*8 (capped at
+  // MAX_BYTES) keeps enough source to still yield `maxChars` readable characters
+  // while limiting the regex passes to a few hundred KB instead of up to 5 MB.
+  const budget = Math.min(MAX_BYTES, maxChars * 8);
+  const workInput = bounded.length > budget ? bounded.slice(0, budget) : bounded;
+  const isHtml = contentType.includes("html") || /<html[\s>]/i.test(workInput);
+  const text = isHtml ? htmlToText(workInput) : workInput.trim();
   return text.length > maxChars ? `${text.slice(0, maxChars)}\n…[truncated]` : text;
 }
 
 function resolveMaxChars(value: unknown): number {
   const n = typeof value === "number" && value > 0 ? Math.floor(value) : DEFAULT_MAX_CHARS;
   return Math.min(HARD_MAX_CHARS, n);
+}
+
+/**
+ * Fetch `url`, following up to MAX_REDIRECTS redirects MANUALLY so every hop's
+ * target is re-validated by assertSafeFetchUrl. undici's redirect:"follow" would
+ * jump to an internal host (a 302 to 169.254.170.2 / localhost / a VPC service)
+ * without re-running the SSRF guard, turning this tool into an internal-read
+ * primitive (REV-COR-496). A single shared AbortSignal bounds the whole chain to
+ * FETCH_TIMEOUT_MS. Returns the final non-redirect Response; throws on a blocked
+ * redirect target, an invalid Location, or exceeding the hop cap.
+ */
+async function fetchWithGuardedRedirects(url: URL, signal: AbortSignal): Promise<Response> {
+  let currentUrl = url;
+  for (let hop = 0; ; hop++) {
+    const res = await fetch(currentUrl, {
+      signal,
+      redirect: "manual",
+      headers: { Accept: "text/html,text/plain,application/json;q=0.9,*/*;q=0.1" },
+    });
+
+    const isRedirect =
+      res.status >= 300 && res.status < 400 && res.headers.has("location");
+    if (!isRedirect) return res;
+
+    // Free the redirect response's socket before the next hop.
+    try {
+      await res.body?.cancel();
+    } catch {
+      /* ignore */
+    }
+    if (hop >= MAX_REDIRECTS) {
+      throw new Error(`too many redirects (> ${MAX_REDIRECTS})`);
+    }
+
+    const location = res.headers.get("location") || "";
+    let nextUrl: URL;
+    try {
+      nextUrl = new URL(location, currentUrl); // resolve a relative Location
+    } catch {
+      throw new Error(`invalid redirect target "${location}"`);
+    }
+    // Re-validate the redirect target's protocol + host (SSRF guard). Throws if
+    // the hop points at a private/loopback/internal host.
+    currentUrl = assertSafeFetchUrl(nextUrl.href);
+  }
 }
 
 export const handleWebFetch: McpToolHandler = async (args, context) => {
@@ -192,11 +323,10 @@ export const handleWebFetch: McpToolHandler = async (args, context) => {
   }
 
   try {
-    const res = await fetch(url, {
-      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
-      redirect: "follow",
-      headers: { Accept: "text/html,text/plain,application/json;q=0.9,*/*;q=0.1" },
-    });
+    const res = await fetchWithGuardedRedirects(
+      url,
+      AbortSignal.timeout(FETCH_TIMEOUT_MS)
+    );
     if (!res.ok) {
       return textResult(`Fetch failed: HTTP ${res.status} ${res.statusText}`, true);
     }

--- a/tests/unit/lib/agents/agent-tools/web-fetch.test.ts
+++ b/tests/unit/lib/agents/agent-tools/web-fetch.test.ts
@@ -9,6 +9,8 @@ import {
   assertSafeFetchUrl,
   htmlToText,
   handleWebFetch,
+  readResponseText,
+  MAX_BYTES,
 } from "@/lib/agents/agent-tools/web-fetch";
 import type { McpToolContext } from "@/lib/mcp/types";
 
@@ -61,6 +63,22 @@ describe("assertSafeFetchUrl", () => {
     "https://[feba::1]/x",
   ])("blocks private/internal target %s", (url) => {
     expect(() => assertSafeFetchUrl(url)).toThrow(/private|loopback|internal/i);
+  });
+
+  // REV-COR-506: IPv6 unspecified + IPv4-compatible gaps. Node normalizes
+  // "[::127.0.0.1]" to the compressed hex "::7f00:1", so the guard must decode
+  // the embedded IPv4 rather than match dotted digits.
+  it.each([
+    "https://[::]/x", // unspecified address → localhost on many stacks
+    "https://[::127.0.0.1]/x", // IPv4-compatible → normalizes to ::7f00:1
+  ])("blocks IPv6 gap target %s", (url) => {
+    expect(() => assertSafeFetchUrl(url)).toThrow(/private|loopback|internal/i);
+  });
+
+  it("still allows a public IPv6 literal", () => {
+    expect(
+      assertSafeFetchUrl("https://[2606:4700:4700::1111]/x").hostname
+    ).toBe("[2606:4700:4700::1111]");
   });
 
   it("rejects http in production but allows it in dev", () => {
@@ -170,5 +188,154 @@ describe("handleWebFetch", () => {
       ctx
     );
     expect(res.content[0].text).toMatch(/…\[truncated\]/);
+  });
+});
+
+describe("handleWebFetch redirect guard (REV-COR-496)", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  const redirectTo = (location: string, status = 302) =>
+    ({
+      ok: false,
+      status,
+      statusText: "Found",
+      headers: new Map([["location", location]]),
+    }) as unknown as Response;
+
+  const ok200Html = (body: string) =>
+    ({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      headers: new Map([["content-type", "text/html"]]),
+      text: async () => body,
+    }) as unknown as Response;
+
+  it.each([
+    "http://169.254.170.2/v2/credentials/abc", // ECS task-role credential endpoint
+    "http://169.254.169.254/latest/meta-data/", // EC2 IMDS
+    "http://localhost:8080/internal",
+  ])(
+    "refuses a redirect to internal host %s and never returns its body",
+    async (target) => {
+      // If the guard were bypassed, the second hop would fetch the internal host
+      // and its body would be returned. Stub that body with a unique sentinel and
+      // assert it never appears — and that the internal host was never fetched.
+      const fetchMock = jest
+        .fn()
+        .mockResolvedValueOnce(redirectTo(target))
+        .mockResolvedValueOnce(ok200Html("SECRET_INTERNAL_BODY_9c3f"));
+      global.fetch = fetchMock;
+      const res = await handleWebFetch({ url: "https://example.com/start" }, ctx);
+      expect(res.isError).toBe(true);
+      expect(res.content[0].text).not.toContain("SECRET_INTERNAL_BODY_9c3f");
+      // Only the first (public) hop was fetched; the internal host never was.
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    }
+  );
+
+  it("follows a legitimate http→https redirect on a public host and returns text", async () => {
+    global.fetch = jest
+      .fn()
+      .mockResolvedValueOnce(redirectTo("https://example.com/final", 301))
+      .mockResolvedValueOnce(ok200Html("<p>Final page</p>"));
+    const res = await handleWebFetch({ url: "http://example.com/start" }, ctx);
+    expect(res.isError).toBeFalsy();
+    expect(res.content[0].text).toContain("Final page");
+  });
+
+  it("bounds redirect hops and errors on an over-limit chain (no hang)", async () => {
+    const fetchMock = jest
+      .fn()
+      .mockResolvedValue(redirectTo("https://example.com/loop"));
+    global.fetch = fetchMock;
+    const res = await handleWebFetch({ url: "https://example.com/loop" }, ctx);
+    expect(res.isError).toBe(true);
+    expect(res.content[0].text).toMatch(/too many redirects/i);
+    // MAX_REDIRECTS = 5 → 6 fetches (hops 0..5) then bail.
+    expect(fetchMock).toHaveBeenCalledTimes(6);
+  });
+});
+
+describe("readResponseText byte cap (REV-COR-500)", () => {
+  it("stops reading at MAX_BYTES and cancels the stream", async () => {
+    const CHUNK = 1_000_000;
+    let enqueued = 0;
+    let cancelled = false;
+    const stream = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        enqueued += CHUNK;
+        controller.enqueue(new Uint8Array(CHUNK));
+      },
+      cancel() {
+        cancelled = true;
+      },
+    });
+    const res = {
+      headers: new Map([["content-type", "text/plain"]]),
+      body: stream,
+    } as unknown as Response;
+
+    const text = await readResponseText(res, 20_000);
+    expect(cancelled).toBe(true);
+    // Read at most the cap plus the single straddling chunk.
+    expect(enqueued).toBeLessThanOrEqual(MAX_BYTES + CHUNK);
+    expect(text.length).toBeLessThanOrEqual(20_020);
+  });
+
+  it("rejects an oversized Content-Length before reading the body", async () => {
+    // A ReadableStream calls `pull` eagerly on construction, so instrument the
+    // body's getReader instead: it must never be called — the content-length
+    // check rejects before any body access.
+    let readerCreated = false;
+    const res = {
+      headers: new Map<string, string>([
+        ["content-type", "text/plain"],
+        ["content-length", String(MAX_BYTES + 1)],
+      ]),
+      body: {
+        getReader() {
+          readerCreated = true;
+          return new ReadableStream<Uint8Array>().getReader();
+        },
+      },
+    } as unknown as Response;
+
+    await expect(readResponseText(res, 20_000)).rejects.toThrow(
+      /too large|content-length/i
+    );
+    expect(readerCreated).toBe(false);
+  });
+});
+
+describe("htmlToText input bounding (REV-PERF-005)", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("normalizes only a bounded slice of a large HTML body, not the full read", async () => {
+    const maxChars = 1000; // input budget = maxChars * 8 = 8000 chars
+    // ~9000 chars of HTML comments (each stripped to a space) push ENDMARKER
+    // past the 8000-char input budget. Visible text stays well under maxChars so
+    // the char cap does NOT fire — if ENDMARKER is absent it was cut at the INPUT
+    // boundary, proving normalization ran on the bounded slice, not the full 5 MB.
+    const filler = "<!-- x -->".repeat(900); // 9000 chars
+    const html = `<p>START</p>${filler}<p>ENDMARKER</p>`;
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      headers: new Map([["content-type", "text/html"]]),
+      text: async () => html,
+    } as unknown as Response);
+
+    const res = await handleWebFetch(
+      { url: "https://example.com/big", maxChars },
+      ctx
+    );
+    expect(res.content[0].text).toContain("START");
+    expect(res.content[0].text).not.toContain("ENDMARKER");
   });
 });


### PR DESCRIPTION
## Summary

Remediation batch **B-003**, scoped to `lib/agents/agent-tools/web-fetch.ts` — the `web.fetch` agent tool, reachable by any `chat:write` user (students and staff). **4 of the batch's 5 findings**; **REV-REF-031 is deferred** (see below).

## Findings fixed

| ID | Severity | Fix |
|----|----------|-----|
| **REV-COR-496** | **Critical (SSRF)** | Only the initial URL was validated, then fetched with `redirect:"follow"` — undici followed 3xx hops to **any** host unchecked, so a public server returning `302 Location: http://169.254.170.2/…` (ECS task-role creds), IMDS, or `localhost` turned the tool into an internal-read primitive with response reflection. Redirects are now followed **manually**; every hop is re-validated by `assertSafeFetchUrl`, hops are capped (`MAX_REDIRECTS=5`), and a single shared `AbortSignal` bounds the whole chain to 10s. |
| **REV-COR-500** | Medium | `readResponseText` buffered the **entire** body via `res.text()` before slicing, so peak memory was `bandwidth×10s`, not 5 MB. Now streams `res.body`, stops at `MAX_BYTES` (cancelling the stream), and fast-rejects an oversized `Content-Length` before reading a byte. |
| **REV-PERF-005** | Medium | `htmlToText` ran ~10 full-string regex passes over up to 5 MB then kept ~20 KB. The normalization **input** is now bounded to `min(MAX_BYTES, maxChars*8)` before the passes; `MAX_BYTES` stays the hard read cap and `htmlToText` is untouched (script/style/unclosed-tag guards intact). |
| **REV-COR-506** | Low | The IPv6 guard missed the unspecified address `::` and IPv4-compatible `::a.b.c.d`. `::` is now blocked, and the IPv4-compatible form — which Node normalizes to compressed **hex** (`::127.0.0.1` → `::7f00:1`) — is decoded to its embedded IPv4 and checked against the private ranges (so `::127.0.0.1` is blocked, public `::8.8.8.8` is not). |

## Testing

`tests/unit/lib/agents/agent-tools/web-fetch.test.ts` — **34 pass** (23 existing + 11 new):

- **496**: redirect to `169.254.170.2` / `169.254.169.254` / `localhost` → error result, internal body never returned, internal host **never fetched**; a legit `http→https` public redirect still returns text; an over-limit redirect chain errors (no hang, exactly 6 fetches).
- **500**: a streamed oversized body stops at ~`MAX_BYTES` and the stream is cancelled (asserted via a counting stream); an oversized `Content-Length` rejects before `getReader` is called.
- **PERF-005**: a 9 KB HTML body with `maxChars=1000` proves normalization runs on the **bounded slice** — a marker placed past the `maxChars*8` input budget is absent while visible text stays under the char cap (distinguishes input-bounding from output-slicing).
- **506**: `https://[::]/` and `https://[::127.0.0.1]/` rejected; a public IPv6 literal still allowed.

Gates: root `bun run lint` **0 errors**, `bun run typecheck` **clean**.

## Deferred: REV-REF-031 (reported, not implemented)

REV-REF-031 (consolidate the three hand-synced SSRF guards into one `lib/security/url-guard.ts`) names **`lib/mcp/connector-service.ts`** and **`actions/admin/connector.actions.ts`** in its scope. Those files are owned by other batches — **B-020** (`lib/mcp`, which has its own security findings REV-SEC-182/184 on that exact guard) and **B-140** (`actions/admin`). Implementing it here would:
- break the campaign's **one-file-per-batch isolation** (B-003 is keyed `lib/agents`), and
- collide with B-020/B-140's own planned edits to those guards.

So it can't be done **within B-003's scope** without reaching into two other batches' files. It belongs in a **dedicated cross-subsystem PR** (or folded into B-020). Left **unticked** in `review/WORKLIST.md`.

⚠️ Note for that follow-up: REF-031's Evidence #1 is a **real security gap** — `connector-service.ts`'s `rejectUnsafeMcpUrl` tests *unbracketed* IPv6 patterns against a *bracketed* hostname, so `http://[::1]/` is **not** rejected there in production. Worth prioritizing when the consolidation lands.

Also noted (COR-496 guardrail): `connector-service.ts` should be checked for the same `redirect:"follow"` pattern during that work — not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HWA2JRbkae8HCRsZwoEJXw
