### PR TITLE
fix(B-005): OAuth consent-decision hardening + revoke row-count check

### DIFF
--- a/actions/oauth/consent.actions.ts
+++ b/actions/oauth/consent.actions.ts
@@ -18,7 +18,6 @@ import { getServerSession } from "@/lib/auth/server-session"
 import { getUserIdByCognitoSubAsNumber } from "@/lib/db/drizzle/utils"
 import { executeQuery } from "@/lib/db/drizzle-client"
 import { oauthConsentDecisions } from "@/lib/db/schema"
-import { eq, and, gt } from "drizzle-orm"
 import { getIssuerUrl } from "@/lib/oauth/issuer-config"
 import type { ActionState } from "@/types/actions-types"
 
@@ -26,57 +25,15 @@ import type { ActionState } from "@/types/actions-types"
 // Types
 // ============================================
 
-interface ConsentDecision {
-  approved: boolean
-  userId: number
-  scopes: string[]
-  createdAt: number
-}
-
 interface ConsentResult {
   redirectTo: string
 }
 
-// ============================================
-// Consent Decision Persistence (Database)
-// ============================================
-
-/**
- * Retrieve and consume a consent decision from the database.
- * Returns undefined if not found or expired. Deletes after reading (consume-once).
- */
-export async function getConsentDecision(uid: string): Promise<ConsentDecision | undefined> {
-  const [decision] = await executeQuery(
-    (db) =>
-      db
-        .select()
-        .from(oauthConsentDecisions)
-        .where(
-          and(
-            eq(oauthConsentDecisions.uid, uid),
-            gt(oauthConsentDecisions.expiresAt, new Date())
-          )
-        )
-        .limit(1),
-    "getConsentDecision"
-  )
-
-  if (!decision) return undefined
-
-  // Consume once — delete after reading
-  await executeQuery(
-    (db) =>
-      db.delete(oauthConsentDecisions).where(eq(oauthConsentDecisions.uid, uid)),
-    "deleteConsentDecision"
-  )
-
-  return {
-    approved: decision.approved,
-    userId: decision.userId,
-    scopes: decision.scopes as string[],
-    createdAt: decision.createdAt.getTime(),
-  }
-}
+// NOTE: getConsentDecision moved to lib/oauth/consent-decisions.ts as
+// consumeConsentDecision (REV-COR-050). As an exported "use server" function it
+// was a public, unauthenticated endpoint that could destructively consume any
+// user's pending consent decision by uid. Its legitimate consumer is the OAuth
+// interaction route handler (a server-only module), not the action surface.
 
 // ============================================
 // Core Consent Processing

--- a/actions/oauth/oauth-client.actions.ts
+++ b/actions/oauth/oauth-client.actions.ts
@@ -273,14 +273,22 @@ export async function revokeOAuthClient(
 
     log.info("Revoking OAuth client", { clientId })
 
-    await executeQuery(
+    const revoked = await executeQuery(
       (db) =>
         db
           .update(oauthClients)
           .set({ isActive: false, updatedAt: new Date() })
-          .where(eq(oauthClients.clientId, clientId)),
+          .where(eq(oauthClients.clientId, clientId))
+          .returning({ id: oauthClients.id }),
       "revokeOAuthClient"
     )
+
+    if (revoked.length === 0) {
+      // No row matched — a typo, stale UI, an already-deleted client, or a race.
+      // Surface a failure instead of a false "revoked" success so an admin never
+      // believes an OAuth client is disabled while it is still active (REV-COR-055).
+      throw ErrorFactories.dbRecordNotFound("oauth_clients", clientId)
+    }
 
     timer({ status: "success" })
     log.info("OAuth client revoked", { clientId })

--- a/lib/oauth/consent-decisions.ts
+++ b/lib/oauth/consent-decisions.ts
@@ -1,0 +1,58 @@
+/**
+ * OAuth consent-decision consumption (server-only).
+ *
+ * Moved out of `actions/oauth/consent.actions.ts` (REV-COR-050): as an exported
+ * function in a `"use server"` module it was a public, unauthenticated endpoint
+ * that could destructively consume ANY user's pending consent decision by uid
+ * (uids travel in browser URLs / logs / referrers). The legitimate consumer is
+ * the OAuth interaction route handler acting on behalf of the OAuth flow — not a
+ * logged-in browser session — so the correct fix is removing it from the action
+ * surface, not gating it. `import "server-only"` makes a client import fail at
+ * build time.
+ */
+import "server-only"
+
+import { and, eq, gt } from "drizzle-orm"
+import { executeQuery } from "@/lib/db/drizzle-client"
+import { oauthConsentDecisions } from "@/lib/db/schema"
+
+export interface ConsentDecision {
+  approved: boolean
+  userId: number
+  scopes: string[]
+  createdAt: number
+}
+
+/**
+ * Atomically read-and-consume a consent decision (consume-once). A single
+ * `DELETE ... WHERE uid = $1 AND expires_at > now() RETURNING *` guarantees two
+ * concurrent readers can't both observe the row before either deletes it — the
+ * previous SELECT-then-DELETE broke that guarantee (REV-COR-050). Returns
+ * `undefined` when the uid is unknown or the decision has expired.
+ */
+export async function consumeConsentDecision(
+  uid: string
+): Promise<ConsentDecision | undefined> {
+  const [decision] = await executeQuery(
+    (db) =>
+      db
+        .delete(oauthConsentDecisions)
+        .where(
+          and(
+            eq(oauthConsentDecisions.uid, uid),
+            gt(oauthConsentDecisions.expiresAt, new Date())
+          )
+        )
+        .returning(),
+    "consumeConsentDecision"
+  )
+
+  if (!decision) return undefined
+
+  return {
+    approved: decision.approved,
+    userId: decision.userId,
+    scopes: decision.scopes as string[],
+    createdAt: decision.createdAt.getTime(),
+  }
+}

--- a/tests/unit/actions/oauth-client-actions.test.ts
+++ b/tests/unit/actions/oauth-client-actions.test.ts
@@ -1,0 +1,43 @@
+/**
+ * @jest-environment node
+ *
+ * revokeOAuthClient (REV-COR-055): a revoke that matches no client must return a
+ * failure ActionState, not a false "revoked" success.
+ */
+import { describe, it, expect, jest, beforeAll, beforeEach } from '@jest/globals'
+
+const mockRequireRole = jest.fn<() => Promise<void>>(() => Promise.resolve())
+const mockExecuteQuery = jest.fn<(...args: unknown[]) => Promise<unknown[]>>(() => Promise.resolve([]))
+
+jest.mock('@/lib/auth/role-helpers', () => ({ requireRole: mockRequireRole }))
+jest.mock('@/lib/db/drizzle-client', () => ({ executeQuery: mockExecuteQuery }))
+jest.mock('@/lib/auth/server-session', () => ({ getServerSession: jest.fn(() => Promise.resolve({ sub: 'admin' })) }))
+jest.mock('@/lib/db/drizzle/utils', () => ({ getUserIdByCognitoSubAsNumber: jest.fn(() => Promise.resolve(1)) }))
+jest.mock('@/lib/api-keys/argon2-loader', () => ({ hashArgon2: jest.fn() }))
+jest.mock('@/lib/db/schema', () => ({
+  oauthClients: { id: 'id', clientId: 'client_id', isActive: 'is_active', updatedAt: 'updated_at' },
+}))
+jest.mock('@/lib/logger', () => ({
+  createLogger: () => ({ info: jest.fn(), debug: jest.fn(), warn: jest.fn(), error: jest.fn() }),
+  generateRequestId: () => 't', startTimer: () => jest.fn(), sanitizeForLogging: (x: unknown) => x,
+  getLogContext: () => ({}),
+}))
+
+describe('revokeOAuthClient (REV-COR-055)', () => {
+  let revokeOAuthClient: typeof import('@/actions/oauth/oauth-client.actions').revokeOAuthClient
+  beforeAll(async () => { revokeOAuthClient = (await import('@/actions/oauth/oauth-client.actions')).revokeOAuthClient })
+  beforeEach(() => { jest.clearAllMocks(); mockRequireRole.mockResolvedValue(undefined) })
+
+  it('returns a failure when no client matches the id (no false success)', async () => {
+    mockExecuteQuery.mockResolvedValueOnce([]) // UPDATE matched 0 rows
+    const res = await revokeOAuthClient('does-not-exist')
+    expect(res.isSuccess).toBe(false)
+  })
+
+  it('returns success when an existing client is revoked', async () => {
+    mockExecuteQuery.mockResolvedValueOnce([{ id: 7 }]) // one row updated
+    const res = await revokeOAuthClient('client-abc')
+    expect(res.isSuccess).toBe(true)
+    expect(res.data).toEqual({ clientId: 'client-abc' })
+  })
+})

--- a/tests/unit/lib/oauth/consent-decisions.test.ts
+++ b/tests/unit/lib/oauth/consent-decisions.test.ts
@@ -1,0 +1,41 @@
+/**
+ * @jest-environment node
+ *
+ * consumeConsentDecision (REV-COR-050): atomic consume-once of an OAuth consent
+ * decision, moved out of the "use server" action surface into a server-only lib.
+ */
+import { describe, it, expect, jest, beforeAll, beforeEach } from '@jest/globals'
+
+jest.mock('server-only', () => ({}))
+const mockExecuteQuery = jest.fn<(...args: unknown[]) => Promise<unknown[]>>(() => Promise.resolve([]))
+jest.mock('@/lib/db/drizzle-client', () => ({ executeQuery: mockExecuteQuery }))
+jest.mock('@/lib/db/schema', () => ({ oauthConsentDecisions: { uid: 'uid', expiresAt: 'expires_at' } }))
+
+describe('consumeConsentDecision (REV-COR-050)', () => {
+  let consume: typeof import('@/lib/oauth/consent-decisions').consumeConsentDecision
+  beforeAll(async () => { consume = (await import('@/lib/oauth/consent-decisions')).consumeConsentDecision })
+  beforeEach(() => { jest.clearAllMocks() })
+
+  it('returns the mapped decision and consumes it in ONE atomic statement', async () => {
+    const row = { approved: true, userId: 42, scopes: ['read'], createdAt: new Date(1000) }
+    mockExecuteQuery.mockResolvedValueOnce([row])
+    const first = await consume('uid-1')
+    expect(first).toEqual({ approved: true, userId: 42, scopes: ['read'], createdAt: 1000 })
+    // Exactly one executeQuery — a single DELETE ... RETURNING, not select+delete.
+    expect(mockExecuteQuery).toHaveBeenCalledTimes(1)
+    expect(mockExecuteQuery.mock.calls[0][1]).toBe('consumeConsentDecision')
+  })
+
+  it('returns undefined on a second read of the same uid (already consumed)', async () => {
+    mockExecuteQuery.mockResolvedValueOnce([{ approved: true, userId: 1, scopes: [], createdAt: new Date() }])
+    mockExecuteQuery.mockResolvedValueOnce([]) // row deleted by the first consume
+    await consume('uid-2')
+    expect(await consume('uid-2')).toBeUndefined()
+  })
+
+  it('returns undefined for an unknown or expired uid (no matching row)', async () => {
+    mockExecuteQuery.mockResolvedValueOnce([])
+    expect(await consume('missing-or-expired')).toBeUndefined()
+    expect(mockExecuteQuery).toHaveBeenCalledTimes(1)
+  })
+})


### PR DESCRIPTION
## Summary

Remediation batch **B-005** (`actions/oauth`). **2 of the batch's 3 findings**; **REV-COR-049 is deferred** (see below).

## Findings fixed

| ID | Severity | Fix |
|----|----------|-----|
| **REV-COR-050** | Medium | `getConsentDecision` was an exported `"use server"` function — a public, unauthenticated endpoint that could **destructively consume any user's pending OAuth consent decision** by uid (uids travel in browser URLs / logs / referrers), and non-atomically (SELECT then DELETE → two concurrent readers could both consume it). Moved to a **server-only** module `lib/oauth/consent-decisions.ts` as `consumeConsentDecision`, using a single `DELETE … WHERE uid = $1 AND expires_at > now() RETURNING *` (atomic consume-once) + `import "server-only"`. `consent.actions.ts` now exports only the session-gated `approveConsent` / `denyConsent`. |
| **REV-COR-055** | Low | `revokeOAuthClient` ran an UPDATE and unconditionally reported success, so revoking a nonexistent/typo/already-deleted `clientId` silently no-op'd while the admin saw "OAuth client revoked". Now uses `.returning({ id })` and throws `dbRecordNotFound` on zero matches, surfacing a failure ActionState. |

## Testing — 5 tests, all green

- `tests/unit/lib/oauth/consent-decisions.test.ts` (3): consume returns the mapped decision in **exactly one** atomic `executeQuery`, returns `undefined` on a second read (already consumed), and `undefined` for an unknown/expired uid.
- `tests/unit/actions/oauth-client-actions.test.ts` (2): revoking an unknown `clientId` → `isSuccess: false`; revoking an existing client → success with the unchanged `{ clientId }` payload.

Gates: root `bun run lint` **0 errors**, `bun run typecheck` **clean**. Pushed with the documented `SKIP_E2E=1` (server-action code; the web-UI E2E suite needs a local secret).

## Deferred: REV-COR-049 (reported, not implemented)

REV-COR-049 (High) — the OAuth consent flow dead-ends: decisions are stored but never consumed and the redirect target route doesn't exist. The fix is to **build** the node-oidc-provider **interaction completion endpoint** (`GET /api/oauth/interaction/{uid}/{login,abort}`): load the interaction via `provider.interactionDetails`, consume the stored decision, find-or-create a `Grant`, and call `provider.interactionFinished` — a **security-critical OAuth token-issuance feature**.

Its Done-when requires *"an approve flow ends with an authorization code delivered to the client redirect URI"*, which the plan itself scopes as **Integration/E2E against a live oidc-provider + seeded client**. That can't be run or verified in this environment, and shipping **unverified OAuth completion / token-issuance code** is an unacceptable risk (a subtle `interactionFinished`/`Grant` mistake silently breaks the flow or mis-issues tokens). It belongs in a **dedicated feature PR** built against a runnable OAuth flow. Left **unticked** in `review/WORKLIST.md`.

This batch lands its prerequisite: **COR-050's `consumeConsentDecision` is the intended consumer** of that future endpoint (the plan explicitly notes the refactor "can land first or together").

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HWA2JRbkae8HCRsZwoEJXw
