### PR TITLE
fix(B-009): nexus API hardening

### DIFF
--- a/app/api/nexus/chat/__tests__/chat-helpers-atomic.test.ts
+++ b/app/api/nexus/chat/__tests__/chat-helpers-atomic.test.ts
@@ -1,0 +1,82 @@
+/**
+ * @jest-environment node
+ *
+ * Tests that saveUserMessage / saveAssistantMessage persist the message row and the
+ * conversation-stats update inside a SINGLE executeTransaction (REV-DB-046 /
+ * REV-COR-220), so a failure between the two can never desync message_count from the
+ * actual nexus_messages rows.
+ */
+
+const mockExecuteQuery = jest.fn()
+const mockExecuteTransaction = jest.fn()
+jest.mock('@/lib/db/drizzle-client', () => ({
+  executeQuery: (...a: unknown[]) => mockExecuteQuery(...a),
+  executeTransaction: (...a: unknown[]) => mockExecuteTransaction(...a),
+}))
+
+jest.mock('@/lib/logger', () => ({
+  createLogger: jest.fn(() => ({ info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() })),
+  generateRequestId: jest.fn(() => 'rid'),
+  startTimer: jest.fn(() => jest.fn()),
+  sanitizeForLogging: jest.fn((d: unknown) => d),
+}))
+
+import { saveUserMessage, saveAssistantMessage } from '../chat-helpers'
+
+// A chainable fake `tx` recording which write builders were invoked.
+function makeTx() {
+  const insertValues = jest.fn(async () => {})
+  const updateWhere = jest.fn(async () => {})
+  const updateSet = jest.fn(() => ({ where: updateWhere }))
+  const tx = {
+    insert: jest.fn(() => ({ values: insertValues })),
+    update: jest.fn(() => ({ set: updateSet })),
+  }
+  return { tx, insertValues, updateWhere }
+}
+
+describe('nexus message saves are transactional (REV-DB-046 / REV-COR-220)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('saveUserMessage inserts the message and updates stats in one executeTransaction', async () => {
+    const { tx, insertValues, updateWhere } = makeTx()
+    mockExecuteTransaction.mockImplementation(async (cb: (t: unknown) => Promise<unknown>) => cb(tx))
+
+    await saveUserMessage({ conversationId: 'c1', content: 'hi', parts: [{ type: 'text', text: 'hi' }], dbModelId: 5 })
+
+    // Exactly one atomic unit; no separate non-transactional query.
+    expect(mockExecuteTransaction).toHaveBeenCalledTimes(1)
+    expect(mockExecuteTransaction.mock.calls[0][1]).toBe('saveUserMessage')
+    expect(mockExecuteQuery).not.toHaveBeenCalled()
+    // Both the insert and the stats update ran inside the transaction.
+    expect(insertValues).toHaveBeenCalledTimes(1)
+    expect(updateWhere).toHaveBeenCalledTimes(1)
+    expect(tx.insert).toHaveBeenCalledTimes(1)
+    expect(tx.update).toHaveBeenCalledTimes(1)
+  })
+
+  it('saveAssistantMessage inserts + updates stats in one executeTransaction', async () => {
+    const { tx, insertValues, updateWhere } = makeTx()
+    mockExecuteTransaction.mockImplementation(async (cb: (t: unknown) => Promise<unknown>) => cb(tx))
+
+    await saveAssistantMessage({
+      conversationId: 'c1', text: 'answer', usage: { totalTokens: 10 }, finishReason: 'stop', dbModelId: 5,
+    })
+
+    expect(mockExecuteTransaction).toHaveBeenCalledTimes(1)
+    expect(mockExecuteTransaction.mock.calls[0][1]).toBe('saveAssistantMessage')
+    expect(mockExecuteQuery).not.toHaveBeenCalled()
+    expect(insertValues).toHaveBeenCalledTimes(1)
+    expect(updateWhere).toHaveBeenCalledTimes(1)
+  })
+
+  it('propagates (rolls back) when the transaction fails — the whole save rejects', async () => {
+    mockExecuteTransaction.mockRejectedValue(new Error('stats update failed'))
+
+    await expect(
+      saveUserMessage({ conversationId: 'c1', content: 'hi', parts: [], dbModelId: 5 })
+    ).rejects.toThrow('stats update failed')
+  })
+})

--- a/app/api/nexus/chat/chat-helpers.ts
+++ b/app/api/nexus/chat/chat-helpers.ts
@@ -200,8 +200,11 @@ export async function saveUserMessage(params: {
 }): Promise<void> {
   const { conversationId, content, parts, dbModelId } = params;
 
-  await executeQuery(
-    (db) => db.insert(nexusMessages)
+  // REV-DB-046 / REV-COR-220: insert the message and bump the conversation stats in
+  // one transaction so a failure between them can never leave message_count out of
+  // sync with the actual nexus_messages rows. Mirrors saveConversationSteps.
+  await executeTransaction(async (tx) => {
+    await tx.insert(nexusMessages)
       .values({
         conversationId,
         role: 'user',
@@ -210,21 +213,16 @@ export async function saveUserMessage(params: {
         modelId: dbModelId,
         metadata: sql`${safeJsonbStringify({})}::jsonb`,
         createdAt: new Date()
-      }),
-    'saveUserMessage'
-  );
+      });
 
-  // Update conversation's last_message_at and message_count
-  await executeQuery(
-    (db) => db.update(nexusConversations)
+    await tx.update(nexusConversations)
       .set({
         lastMessageAt: new Date(),
         messageCount: sql`${nexusConversations.messageCount} + 1`,
         updatedAt: new Date()
       })
-      .where(eq(nexusConversations.id, conversationId)),
-    'updateConversationAfterUserMessage'
-  );
+      .where(eq(nexusConversations.id, conversationId));
+  }, 'saveUserMessage');
 
   log.debug('User message saved to nexus_messages');
 }
@@ -391,8 +389,11 @@ export async function saveAssistantMessage(params: {
   }
 
   const now = new Date();
-  await executeQuery(
-    (db) => db.insert(nexusMessages)
+  // REV-DB-046 / REV-COR-220: insert the message and bump message_count / total_tokens
+  // atomically so a failure between them cannot desync the conversation counters from
+  // the actual nexus_messages rows. Mirrors saveConversationSteps.
+  await executeTransaction(async (tx) => {
+    await tx.insert(nexusMessages)
       .values({
         conversationId,
         role: 'assistant',
@@ -404,21 +405,17 @@ export async function saveAssistantMessage(params: {
         metadata: sql`${safeJsonbStringify({})}::jsonb`,
         createdAt: now,
         updatedAt: now
-      }),
-    'saveAssistantMessage'
-  );
+      });
 
-  await executeQuery(
-    (db) => db.update(nexusConversations)
+    await tx.update(nexusConversations)
       .set({
         messageCount: sql`${nexusConversations.messageCount} + 1`,
         totalTokens: sql`${nexusConversations.totalTokens} + ${usage?.totalTokens || 0}`,
         lastMessageAt: new Date(),
         updatedAt: new Date()
       })
-      .where(eq(nexusConversations.id, conversationId)),
-    'updateConversationAfterAssistantMessage'
-  );
+      .where(eq(nexusConversations.id, conversationId));
+  }, 'saveAssistantMessage');
 
   log.info('Assistant message saved successfully', {
     conversationId,

--- a/app/api/nexus/chat/image-generation-handler.ts
+++ b/app/api/nexus/chat/image-generation-handler.ts
@@ -4,12 +4,24 @@
  */
 import { UIMessage, createUIMessageStream, createUIMessageStreamResponse } from 'ai';
 import { sql, and, desc, eq } from 'drizzle-orm';
-import { executeQuery } from '@/lib/db/drizzle-client';
+import { executeQuery, executeTransaction } from '@/lib/db/drizzle-client';
 import { nexusConversations, nexusMessages } from '@/lib/db/schema';
 import { getAttachmentFromS3 } from '@/lib/services/attachment-storage-service';
 import { sanitizeTextForDatabase } from '@/lib/utils/text-sanitizer';
 import { safeJsonbStringify } from '@/lib/db/json-utils';
+import { assertSafeFetchUrl } from '@/lib/agents/agent-tools/web-fetch';
 import { createLogger } from '@/lib/logger';
+
+/**
+ * A client-supplied reference `s3Key` (or `s3://` URL) must live under the
+ * ownership-verified conversation's own attachment prefix (REV-SEC-144). Attachment
+ * keys are written as `conversations/${conversationId}/attachments/...`, so any key
+ * outside that prefix points at another conversation/user's object and must be
+ * rejected before any S3 read.
+ */
+function isKeyInConversationPrefix(s3Key: string, conversationId: string): boolean {
+  return s3Key.startsWith(`conversations/${conversationId}/attachments/`);
+}
 
 const log = createLogger({ route: 'api.nexus.chat.image' });
 
@@ -187,36 +199,102 @@ export async function getOrCreateImageConversation(params: {
 }
 
 /**
- * Save user message for image generation
+ * Persist an image-generation exchange atomically (REV-DB-047 / REV-COR-220).
+ *
+ * The user-prompt row, the assistant image row, and the conversation-stats
+ * increment previously ran as three independent queries with a hardcoded
+ * `message_count + 2`, so a failure between them left the counter out of sync with
+ * the actual rows. Wrapping all three in one executeTransaction makes the `+2`
+ * guaranteed correct (both rows are inserted in the same unit). Image generation
+ * and S3 access are side effects and stay OUTSIDE this transaction — only the DB
+ * writes are inside.
  */
-export async function saveImageUserMessage(params: {
+export async function persistImageExchange(params: {
   conversationId: string;
   imagePrompt: string;
+  imageResult: {
+    imageUrl: string;
+    s3Key?: string;
+    model?: string;
+    provider?: string;
+    altText?: string;
+    dimensions?: { width: number; height: number };
+    estimatedCost?: number;
+  };
   dbModelId: number;
 }): Promise<void> {
-  const { conversationId, imagePrompt, dbModelId } = params;
+  const { conversationId, imagePrompt, imageResult, dbModelId } = params;
 
-  await executeQuery(
-    (db) => db.insert(nexusMessages)
-      .values({
-        id: crypto.randomUUID(),
-        conversationId,
-        role: 'user',
-        content: imagePrompt,
-        parts: sql`${safeJsonbStringify([{ type: 'text', text: imagePrompt }])}::jsonb`,
-        modelId: dbModelId,
-        metadata: sql`${safeJsonbStringify({})}::jsonb`,
-        createdAt: new Date()
-      }),
-    'saveImageUserMessage'
-  );
+  // Build assistant parts/content outside the transaction (pure computation).
+  const messageParts: Array<{
+    type: string;
+    text?: string;
+    imageUrl?: string;
+    s3Key?: string;
+    altText?: string;
+  }> = [];
+
+  if (imageResult.altText && imageResult.altText.trim()) {
+    messageParts.push({ type: 'text', text: imageResult.altText.trim() });
+  }
+
+  messageParts.push({
+    type: 'image',
+    imageUrl: imageResult.imageUrl,
+    s3Key: imageResult.s3Key,
+    altText: 'Generated image'
+  });
+
+  const assistantMessageContent = JSON.stringify({
+    type: 'image',
+    imageUrl: imageResult.imageUrl,
+    s3Key: imageResult.s3Key,
+    model: imageResult.model,
+    provider: imageResult.provider,
+    altText: imageResult.altText,
+    dimensions: imageResult.dimensions
+  });
+
+  await executeTransaction(async (tx) => {
+    await tx.insert(nexusMessages).values({
+      id: crypto.randomUUID(),
+      conversationId,
+      role: 'user',
+      content: imagePrompt,
+      parts: sql`${safeJsonbStringify([{ type: 'text', text: imagePrompt }])}::jsonb`,
+      modelId: dbModelId,
+      metadata: sql`${safeJsonbStringify({})}::jsonb`,
+      createdAt: new Date()
+    });
+
+    await tx.insert(nexusMessages).values({
+      conversationId,
+      role: 'assistant',
+      content: assistantMessageContent,
+      parts: sql`${safeJsonbStringify(messageParts)}::jsonb`,
+      modelId: dbModelId,
+      metadata: sql`${safeJsonbStringify({
+        generationType: 'image',
+        estimatedCost: imageResult.estimatedCost
+      })}::jsonb`,
+      createdAt: new Date()
+    });
+
+    // Both rows are inserted in this same transaction, so `+ 2` cannot desync.
+    await tx.update(nexusConversations).set({
+      messageCount: sql`${nexusConversations.messageCount} + 2`,
+      lastMessageAt: new Date(),
+      updatedAt: new Date()
+    }).where(eq(nexusConversations.id, conversationId));
+  }, 'persistImageExchange');
 }
 
 /**
  * Extract reference images from message parts
  */
 export async function extractReferenceImages(
-  lastMessage: ImageGenerationParams['messages'][0] | undefined
+  lastMessage: ImageGenerationParams['messages'][0] | undefined,
+  conversationId: string
 ): Promise<ReferenceImage[]> {
   const referenceImages: ReferenceImage[] = [];
 
@@ -242,9 +320,9 @@ export async function extractReferenceImages(
 
   for (const part of partsArray) {
     if (part.type === 'image') {
-      await handleImagePart(part, referenceImages);
+      await handleImagePart(part, referenceImages, conversationId);
     } else if (part.type === 'file') {
-      await handleFilePart(part, referenceImages);
+      await handleFilePart(part, referenceImages, conversationId);
     }
   }
 
@@ -253,9 +331,16 @@ export async function extractReferenceImages(
 
 async function handleImagePart(
   part: { s3Key?: string; image?: string; imageUrl?: string },
-  referenceImages: ReferenceImage[]
+  referenceImages: ReferenceImage[],
+  conversationId: string
 ): Promise<void> {
   if (part.s3Key) {
+    // REV-SEC-144: only read an s3Key that lives under this conversation's own
+    // attachment prefix — a client can otherwise reference another tenant's key.
+    if (!isKeyInConversationPrefix(part.s3Key, conversationId)) {
+      log.warn('Rejected reference image s3Key outside conversation prefix', { conversationId });
+      return;
+    }
     try {
       const attachmentData = await getAttachmentFromS3(part.s3Key);
       if (attachmentData.image) {
@@ -279,12 +364,31 @@ async function handleImagePart(
     // Logging explicitly is safer than a silent fallback to an unusable URL.
     log.warn('Image part has s3:// URL but no s3Key — cannot retrieve');
   } else if (part.imageUrl) {
-    // s3Key is intentionally omitted — it is provably undefined here because
-    // the first branch (if part.s3Key) already handles parts that carry an s3Key.
+    // REV-SEC-142: a client-supplied reference URL is fetched server-side
+    // downstream; reject private/loopback/link-local/metadata targets (SSRF)
+    // before it can become a reference image. https-only in production.
+    if (!isSafeReferenceUrl(part.imageUrl)) {
+      log.warn('Rejected unsafe reference image URL (SSRF guard)');
+      return;
+    }
     referenceImages.push({
       url: part.imageUrl,
       role: 'reference'
     });
+  }
+}
+
+/**
+ * SSRF guard for a client-supplied reference-image URL (REV-SEC-142). Wraps the
+ * shared assertSafeFetchUrl (blocks private/loopback/link-local/metadata hosts;
+ * https-only in production) and returns a boolean so callers can skip+log.
+ */
+function isSafeReferenceUrl(url: string): boolean {
+  try {
+    assertSafeFetchUrl(url);
+    return true;
+  } catch {
+    return false;
   }
 }
 
@@ -330,7 +434,8 @@ const ALLOWED_IMAGE_MIMES = new Set([
 
 async function handleFilePart(
   part: { mediaType?: string; mimeType?: string; s3Key?: string; url?: string; data?: string },
-  referenceImages: ReferenceImage[]
+  referenceImages: ReferenceImage[],
+  conversationId: string
 ): Promise<void> {
   const mimeType = part.mediaType || part.mimeType || '';
   if (!ALLOWED_IMAGE_MIMES.has(mimeType)) {
@@ -339,6 +444,12 @@ async function handleFilePart(
 
   const s3Key = getS3KeyFromPart(part);
   if (s3Key) {
+    // REV-SEC-144: reject a client-supplied key (incl. s3:// URLs) that is not
+    // under this conversation's own attachment prefix before any S3 read.
+    if (!isKeyInConversationPrefix(s3Key, conversationId)) {
+      log.warn('Rejected reference file s3Key outside conversation prefix', { conversationId });
+      return;
+    }
     await handleS3FileImage(s3Key, mimeType, referenceImages);
     return;
   }
@@ -352,6 +463,12 @@ async function handleFilePart(
   }
 
   if (part.url) {
+    // REV-SEC-142: part.url here is a non-s3:// URL (getS3KeyFromPart already
+    // handled s3://). Reject SSRF targets before it becomes a fetched reference.
+    if (!isSafeReferenceUrl(part.url)) {
+      log.warn('Rejected unsafe reference file URL (SSRF guard)');
+      return;
+    }
     referenceImages.push({ url: part.url, mimeType, role: 'reference' });
   }
 }
@@ -400,87 +517,6 @@ export async function getPreviousGeneratedImages(
   }
 
   return referenceImages;
-}
-
-/**
- * Save assistant message with generated image
- */
-export async function saveImageAssistantMessage(params: {
-  conversationId: string;
-  imageResult: {
-    imageUrl: string;
-    s3Key?: string;
-    model?: string;
-    provider?: string;
-    altText?: string;
-    dimensions?: { width: number; height: number };
-    estimatedCost?: number;
-  };
-  dbModelId: number;
-}): Promise<void> {
-  const { conversationId, imageResult, dbModelId } = params;
-
-  const messageParts: Array<{
-    type: string;
-    text?: string;
-    imageUrl?: string;
-    s3Key?: string;
-    altText?: string;
-  }> = [];
-
-  if (imageResult.altText && imageResult.altText.trim()) {
-    messageParts.push({ type: 'text', text: imageResult.altText.trim() });
-  }
-
-  messageParts.push({
-    type: 'image',
-    imageUrl: imageResult.imageUrl,
-    s3Key: imageResult.s3Key,
-    altText: 'Generated image'
-  });
-
-  const assistantMessageContent = JSON.stringify({
-    type: 'image',
-    imageUrl: imageResult.imageUrl,
-    s3Key: imageResult.s3Key,
-    model: imageResult.model,
-    provider: imageResult.provider,
-    altText: imageResult.altText,
-    dimensions: imageResult.dimensions
-  });
-
-  await executeQuery(
-    (db) => db.insert(nexusMessages)
-      .values({
-        conversationId,
-        role: 'assistant',
-        content: assistantMessageContent,
-        parts: sql`${safeJsonbStringify(messageParts)}::jsonb`,
-        modelId: dbModelId,
-        metadata: sql`${safeJsonbStringify({
-          generationType: 'image',
-          estimatedCost: imageResult.estimatedCost
-        })}::jsonb`,
-        createdAt: new Date()
-      }),
-    'saveImageAssistantMessage'
-  );
-}
-
-/**
- * Update conversation stats after image generation
- */
-export async function updateImageConversationStats(conversationId: string): Promise<void> {
-  await executeQuery(
-    (db) => db.update(nexusConversations)
-      .set({
-        messageCount: sql`${nexusConversations.messageCount} + 2`,
-        lastMessageAt: new Date(),
-        updatedAt: new Date()
-      })
-      .where(eq(nexusConversations.id, conversationId)),
-    'updateImageConversationStats'
-  );
 }
 
 /**

--- a/app/api/nexus/chat/jobs/[jobId]/__tests__/route.test.ts
+++ b/app/api/nexus/chat/jobs/[jobId]/__tests__/route.test.ts
@@ -1,0 +1,95 @@
+/**
+ * @jest-environment node
+ *
+ * Tests the job-poll fallback save idempotency (REV-COR-226). A completed job whose
+ * assistant response was not yet persisted is saved via an upsert keyed on a
+ * deterministic `job-<jobId>` id, so concurrent completed-status polls converge on a
+ * single nexus_messages row instead of the previous racy SELECT-then-INSERT.
+ */
+
+const mockAuthenticatePollingRequest = jest.fn()
+const mockValidateJobOwnership = jest.fn()
+jest.mock('@/lib/auth/optimized-polling-auth', () => ({
+  authenticatePollingRequest: (...a: unknown[]) => mockAuthenticatePollingRequest(...a),
+  validateJobOwnership: (...a: unknown[]) => mockValidateJobOwnership(...a),
+}))
+
+const mockGetJob = jest.fn()
+const mockGetOptimalPollingInterval = jest.fn()
+jest.mock('@/lib/streaming/job-management-service', () => ({
+  jobManagementService: {
+    getJob: (...a: unknown[]) => mockGetJob(...a),
+    getOptimalPollingInterval: (...a: unknown[]) => mockGetOptimalPollingInterval(...a),
+  },
+}))
+
+const mockExecuteQuery = jest.fn()
+jest.mock('@/lib/db/drizzle-client', () => ({
+  executeQuery: (...a: unknown[]) => mockExecuteQuery(...a),
+}))
+
+const mockUpsertMessageWithStats = jest.fn()
+jest.mock('@/lib/db/drizzle', () => ({
+  upsertMessageWithStats: (...a: unknown[]) => mockUpsertMessageWithStats(...a),
+}))
+
+jest.mock('@/lib/logger', () => ({
+  createLogger: jest.fn(() => ({ info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() })),
+  generateRequestId: jest.fn(() => 'rid'),
+  startTimer: jest.fn(() => jest.fn()),
+}))
+
+import { GET } from '../route'
+
+const JOB_ID = 'job-uuid-1'
+const CONVO = 'convo-1'
+
+function ctx() {
+  return { params: Promise.resolve({ jobId: JOB_ID }) }
+}
+
+function completedJob() {
+  return {
+    id: JOB_ID,
+    userId: 1,
+    status: 'completed',
+    modelId: 9,
+    nexusConversationId: CONVO,
+    responseData: { text: 'the final answer', usage: { totalTokens: 5 }, finishReason: 'stop' },
+    partialContent: null,
+    createdAt: new Date('2026-01-01T00:00:00Z'),
+  }
+}
+
+describe('GET nexus job poll fallback idempotency (REV-COR-226)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockAuthenticatePollingRequest.mockResolvedValue({ isAuthorized: true, userId: 1, authMethod: 'cache', authTime: 1 })
+    mockValidateJobOwnership.mockReturnValue({ authorized: true })
+    mockGetOptimalPollingInterval.mockResolvedValue(1000)
+    mockUpsertMessageWithStats.mockResolvedValue({})
+  })
+
+  it('saves the fallback assistant message via upsert keyed on a deterministic job id', async () => {
+    mockGetJob.mockResolvedValue(completedJob())
+    // No existing assistant message yet → fallback save path runs.
+    mockExecuteQuery.mockResolvedValue([])
+
+    await GET({} as Request, ctx())
+
+    expect(mockUpsertMessageWithStats).toHaveBeenCalledTimes(1)
+    // Deterministic id derived from the job — concurrent polls converge on this row.
+    expect(mockUpsertMessageWithStats.mock.calls[0][0]).toBe(`job-${JOB_ID}`)
+    expect(mockUpsertMessageWithStats.mock.calls[0][1]).toBe(CONVO)
+    expect(mockUpsertMessageWithStats.mock.calls[0][2]).toMatchObject({ role: 'assistant' })
+  })
+
+  it('does not save when an assistant message already exists (stream onFinish saved it)', async () => {
+    mockGetJob.mockResolvedValue(completedJob())
+    mockExecuteQuery.mockResolvedValue([{ id: 'already-saved' }])
+
+    await GET({} as Request, ctx())
+
+    expect(mockUpsertMessageWithStats).not.toHaveBeenCalled()
+  })
+})

--- a/app/api/nexus/chat/jobs/[jobId]/route.ts
+++ b/app/api/nexus/chat/jobs/[jobId]/route.ts
@@ -2,7 +2,7 @@ import { authenticatePollingRequest, validateJobOwnership } from '@/lib/auth/opt
 import { createLogger, generateRequestId, startTimer } from '@/lib/logger';
 import { jobManagementService } from '@/lib/streaming/job-management-service';
 import type { UniversalPollingStatus } from '@/lib/streaming/job-management-service';
-import { createMessageWithStats } from '@/lib/db/drizzle';
+import { upsertMessageWithStats } from '@/lib/db/drizzle';
 import { executeQuery } from '@/lib/db/drizzle-client';
 import { nexusMessages } from '@/lib/db/schema';
 import { eq, and, gte } from 'drizzle-orm';
@@ -161,16 +161,19 @@ export async function GET(
             finishReason: responseData?.finishReason
           });
 
-          // Save assistant response and update conversation stats in one operation
-          await createMessageWithStats({
-            conversationId: job.nexusConversationId,
+          // Save the fallback assistant response idempotently (REV-COR-226). The
+          // prior plain INSERT after a SELECT was a TOCTOU race: two concurrent
+          // completed-status polls could both observe zero rows and both insert,
+          // duplicating the assistant message. Upserting on a deterministic,
+          // job-derived id makes concurrent writers converge on a single row.
+          await upsertMessageWithStats(`job-${jobId}`, job.nexusConversationId, {
             role: 'assistant',
             content: assistantText,
             parts: [{ type: 'text', text: assistantText }],
             modelId: job.modelId,
             tokenUsage: responseData?.usage || {},
             finishReason: (responseData?.finishReason as string) || 'stop',
-            metadata: { savedVia: 'api-fallback' },
+            metadata: { savedVia: 'api-fallback', jobId },
           });
 
           log.info('Assistant message saved via API fallback successfully', {

--- a/app/api/nexus/chat/route.ts
+++ b/app/api/nexus/chat/route.ts
@@ -3,7 +3,6 @@ import { z } from 'zod';
 import { getServerSession } from '@/lib/auth/server-session';
 import { getCurrentUserAction } from '@/actions/db/get-current-user-action';
 import { createLogger, generateRequestId, startTimer, sanitizeForLogging } from '@/lib/logger';
-import { getAIModelById } from '@/lib/db/drizzle';
 import { hasCapability } from '@/lib/ai/capability-utils';
 import { processMessagesWithAttachments } from '@/lib/services/attachment-storage-service';
 import { unifiedStreamingService } from '@/lib/streaming/unified-streaming-service';
@@ -20,11 +19,9 @@ import {
   extractImagePrompt,
   validateImagePrompt,
   getOrCreateImageConversation,
-  saveImageUserMessage,
   extractReferenceImages,
   getPreviousGeneratedImages,
-  saveImageAssistantMessage,
-  updateImageConversationStats,
+  persistImageExchange,
   createImageStreamResponse,
   handleImageGenerationError,
 } from './image-generation-handler';
@@ -329,13 +326,11 @@ async function handleImageGeneration(params: {
 
   const { conversationId, title: conversationTitle } = convResult;
 
-  // Save user message
-  await saveImageUserMessage({ conversationId, imagePrompt, dbModelId });
-
   try {
-    // Extract reference images from message
+    // Extract reference images from message. Pass conversationId so client-supplied
+    // s3Keys can be validated against this conversation's own prefix (REV-SEC-144).
     const lastMessage = messages[messages.length - 1];
-    let referenceImages = await extractReferenceImages(lastMessage);
+    let referenceImages = await extractReferenceImages(lastMessage, conversationId);
 
     // If no reference images and existing conversation, check previous messages
     if (existingConversationId && referenceImages.length === 0) {
@@ -367,9 +362,10 @@ async function handleImageGeneration(params: {
       referenceImages: referenceImages.length > 0 ? referenceImages : undefined
     });
 
-    // Save assistant message and update stats
-    await saveImageAssistantMessage({ conversationId, imageResult, dbModelId });
-    await updateImageConversationStats(conversationId);
+    // Persist the user prompt + assistant image + stats atomically (REV-DB-047 /
+    // REV-COR-220). Kept after generation (a side effect) so a generation failure
+    // leaves no partial rows and no desynced message_count.
+    await persistImageExchange({ conversationId, imagePrompt, imageResult, dbModelId });
 
     timer({ status: 'success', conversationId });
 
@@ -739,9 +735,11 @@ async function getValidatedModelConfig(
   }
 
   const dbModelId = modelConfig.id;
-  const modelWithCapabilities = await getAIModelById(dbModelId);
-  const isImageGenerationModel = hasCapability(modelWithCapabilities?.capabilities, 'imageGeneration');
-  const isDeepResearchModel = hasCapability(modelWithCapabilities?.capabilities, 'deepResearch');
+  // REV-PERF-002: derive capability flags from the row getModelConfig already
+  // fetched — the previous getAIModelById(dbModelId) here was a second SELECT of the
+  // identical ai_models row on every chat/image/deep-research request.
+  const isImageGenerationModel = hasCapability(modelConfig.capabilities, 'imageGeneration');
+  const isDeepResearchModel = hasCapability(modelConfig.capabilities, 'deepResearch');
 
   return { modelConfig, dbModelId, isImageGenerationModel, isDeepResearchModel };
 }

--- a/app/api/nexus/conversations/[id]/messages/__tests__/route.test.ts
+++ b/app/api/nexus/conversations/[id]/messages/__tests__/route.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Tests for GET /api/nexus/conversations/[id]/messages presign gate (REV-SEC-143).
+ *
+ * The route regenerates a presigned S3 GET URL for image parts carrying an s3Key.
+ * Because that s3Key ultimately originates from client-supplied parts, only keys
+ * that belong to THIS conversation (its attachment prefix or its generated-image
+ * prefix) may be signed — a planted key pointing at another user's object must
+ * never be presigned.
+ */
+
+const mockGetServerSession = jest.fn()
+jest.mock('@/lib/auth/server-session', () => ({
+  getServerSession: (...a: unknown[]) => mockGetServerSession(...a),
+}))
+
+const mockGetCurrentUserAction = jest.fn()
+jest.mock('@/actions/db/get-current-user-action', () => ({
+  getCurrentUserAction: (...a: unknown[]) => mockGetCurrentUserAction(...a),
+}))
+
+const mockGetMessagesByConversation = jest.fn()
+const mockGetMessageCount = jest.fn()
+const mockGetConversationById = jest.fn()
+jest.mock('@/lib/db/drizzle', () => ({
+  getMessagesByConversation: (...a: unknown[]) => mockGetMessagesByConversation(...a),
+  getMessageCount: (...a: unknown[]) => mockGetMessageCount(...a),
+  getConversationById: (...a: unknown[]) => mockGetConversationById(...a),
+  DEFAULT_MESSAGE_LIMIT: 50,
+  MAX_MESSAGE_LIMIT: 100,
+}))
+
+const mockGetDocumentSignedUrl = jest.fn()
+jest.mock('@/lib/aws/s3-client', () => ({
+  getDocumentSignedUrl: (...a: unknown[]) => mockGetDocumentSignedUrl(...a),
+}))
+
+jest.mock('@/lib/utils/text-sanitizer', () => ({
+  decodeHtmlEntitiesDeep: (v: unknown) => v,
+}))
+
+jest.mock('@/lib/logger', () => ({
+  createLogger: jest.fn(() => ({ info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() })),
+  generateRequestId: jest.fn(() => 'test-request-id'),
+  startTimer: jest.fn(() => jest.fn()),
+}))
+
+class TestResponse {
+  private _body: string
+  status: number
+  constructor(body?: string, init?: { status?: number }) {
+    this._body = typeof body === 'string' ? body : ''
+    this.status = init?.status ?? 200
+  }
+  async text() { return this._body }
+  async json() { return JSON.parse(this._body || 'null') }
+  static json(body: unknown, init?: { status?: number }) {
+    return new TestResponse(JSON.stringify(body), init)
+  }
+}
+;(global as unknown as { Response: unknown }).Response = TestResponse
+
+import type { NextRequest } from 'next/server'
+import { GET } from '../route'
+
+const CONVO = 'cccccccc-1111-4111-8111-cccccccccccc'
+
+function req() {
+  return { url: `http://localhost/api/nexus/conversations/${CONVO}/messages` } as unknown as NextRequest
+}
+function ctx() {
+  return { params: Promise.resolve({ id: CONVO }) }
+}
+
+function imageMessage(s3Key: string) {
+  return [{
+    id: 'm1',
+    role: 'assistant',
+    content: null,
+    parts: [{ type: 'image', s3Key }],
+    createdAt: new Date(),
+    metadata: null,
+  }]
+}
+
+describe('GET conversations/[id]/messages presign gate (REV-SEC-143)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockGetServerSession.mockResolvedValue({ sub: 'caller-sub' })
+    mockGetCurrentUserAction.mockResolvedValue({ isSuccess: true, data: { user: { id: 1 } } })
+    mockGetConversationById.mockResolvedValue({ id: CONVO, title: 'T', modelUsed: null })
+    mockGetMessageCount.mockResolvedValue(1)
+    mockGetDocumentSignedUrl.mockResolvedValue('https://s3.example/SIGNED')
+  })
+
+  it('never presigns an s3Key outside the conversation prefix', async () => {
+    // Planted key pointing at another user's uploaded document.
+    mockGetMessagesByConversation.mockResolvedValue(imageMessage('3/1699999999-secret.pdf'))
+
+    const res = await GET(req(), ctx())
+    const body = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(mockGetDocumentSignedUrl).not.toHaveBeenCalled()
+    // No presigned URL leaked into the response.
+    expect(JSON.stringify(body)).not.toContain('SIGNED')
+  })
+
+  it('presigns a key that belongs to this conversation (attachment prefix)', async () => {
+    const key = `conversations/${CONVO}/attachments/m1-0-ref.png`
+    mockGetMessagesByConversation.mockResolvedValue(imageMessage(key))
+
+    const res = await GET(req(), ctx())
+    const body = await res.json()
+
+    expect(mockGetDocumentSignedUrl).toHaveBeenCalledWith({ key, expiresIn: 3600 })
+    expect(JSON.stringify(body)).toContain('SIGNED')
+  })
+
+  it('presigns a key under this conversation generated-images prefix', async () => {
+    const key = `v2/generated-images/${CONVO}/123-model.png`
+    mockGetMessagesByConversation.mockResolvedValue(imageMessage(key))
+
+    await GET(req(), ctx())
+
+    expect(mockGetDocumentSignedUrl).toHaveBeenCalledWith({ key, expiresIn: 3600 })
+  })
+
+  it('returns 404 when the caller does not own the conversation', async () => {
+    mockGetConversationById.mockResolvedValue(null)
+
+    const res = await GET(req(), ctx())
+
+    expect(res.status).toBe(404)
+    expect(mockGetMessagesByConversation).not.toHaveBeenCalled()
+  })
+})

--- a/app/api/nexus/conversations/[id]/messages/route.ts
+++ b/app/api/nexus/conversations/[id]/messages/route.ts
@@ -28,6 +28,20 @@ interface NexusMessageResponse {
 const MAX_CONTENT_LENGTH = 50000
 
 /**
+ * REV-SEC-143: a stored image `s3Key` ultimately originates from client-supplied
+ * message parts, so only presign a key that provably belongs to the conversation
+ * being read. Attachment objects live under `conversations/<id>/...` and
+ * server-generated images under `v2/generated-images/<id>/...`; any other key
+ * (e.g. another user's upload at `<userId>/<ts>-file.pdf`) must never be signed.
+ */
+function isKeyForConversation(s3Key: string, conversationId: string): boolean {
+  return (
+    s3Key.startsWith(`conversations/${conversationId}/`) ||
+    s3Key.startsWith(`v2/generated-images/${conversationId}/`)
+  )
+}
+
+/**
  * Truncate content to prevent memory issues
  */
 function truncateContent(content: string): string {
@@ -41,7 +55,7 @@ function truncateContent(content: string): string {
  * Convert a part to content format, handling images as markdown and passing through tool parts.
  * For image parts with s3Key, generates a fresh presigned URL to replace expired ones.
  */
-async function convertPartToTextContent(part: MessagePart): Promise<ContentPart | null> {
+async function convertPartToTextContent(part: MessagePart, conversationId: string): Promise<ContentPart | null> {
   const partType = part.type as string
 
   if (partType === 'text') {
@@ -54,7 +68,9 @@ async function convertPartToTextContent(part: MessagePart): Promise<ContentPart 
   if (partType === 'image') {
     // Refresh presigned URL from s3Key if available (fixes expired URL issue)
     const s3Key = part.s3Key
-    if (s3Key) {
+    // REV-SEC-143: only presign a key that belongs to THIS conversation — a
+    // client-planted s3Key pointing at another user's object must never be signed.
+    if (s3Key && isKeyForConversation(s3Key, conversationId)) {
       try {
         const freshUrl = await getDocumentSignedUrl({ key: s3Key, expiresIn: 3600 })
         return { type: 'text', text: `![Generated Image](${freshUrl})` }
@@ -66,8 +82,11 @@ async function convertPartToTextContent(part: MessagePart): Promise<ContentPart 
           error: error instanceof Error ? error.message : String(error)
         })
       }
+    } else if (s3Key) {
+      const log = createLogger({ context: 'convertPartToTextContent' })
+      log.warn('Refusing to presign s3Key outside the conversation prefix', { conversationId })
     }
-    // Fallback to stored imageUrl if no s3Key or URL generation failed
+    // Fallback to stored imageUrl if no (valid) s3Key or URL generation failed
     const imageUrl = part.imageUrl
     return imageUrl ? { type: 'text', text: `![Generated Image](${imageUrl})` } : null
   }
@@ -98,8 +117,8 @@ async function convertPartToTextContent(part: MessagePart): Promise<ContentPart 
  * Truncate parts content and ensure at least one part.
  * Async to support presigned URL refresh for image parts.
  */
-async function truncatePartsContent(parts: MessagePart[]): Promise<ContentPart[]> {
-  const results = await Promise.all(parts.map(part => convertPartToTextContent(part)))
+async function truncatePartsContent(parts: MessagePart[], conversationId: string): Promise<ContentPart[]> {
+  const results = await Promise.all(parts.map(part => convertPartToTextContent(part, conversationId)))
   const converted = results.filter((part): part is ContentPart => part !== null)
   return converted.length > 0 ? converted : [{ type: 'text', text: '' }]
 }
@@ -160,12 +179,12 @@ async function convertMessageToAiSdk(msg: {
   parts?: MessagePart[] | null
   createdAt?: Date | null
   metadata?: Record<string, unknown> | null
-}): Promise<NexusMessageResponse> {
+}, conversationId: string): Promise<NexusMessageResponse> {
   const truncatedContent = msg.content ? truncateContent(msg.content) : null
   let truncatedParts: ContentPart[] | null = null
 
   if (msg.parts && Array.isArray(msg.parts)) {
-    truncatedParts = await truncatePartsContent(msg.parts)
+    truncatedParts = await truncatePartsContent(msg.parts, conversationId)
   }
 
   const baseMessage = {
@@ -252,8 +271,12 @@ export async function GET(
     })
     const totalCount = await getMessageCount(conversationId)
 
-    // Convert to AI SDK format (async for presigned URL refresh)
-    const aiSdkMessages = await Promise.all(messages.map(convertMessageToAiSdk))
+    // Convert to AI SDK format (async for presigned URL refresh). Pass the
+    // ownership-verified conversationId so only this conversation's own image keys
+    // are presigned (REV-SEC-143).
+    const aiSdkMessages = await Promise.all(
+      messages.map(msg => convertMessageToAiSdk(msg, conversationId!))
+    )
 
     timer({ status: 'success' })
     log.info('Messages retrieved', { conversationId, userId, messageCount: messages.length })

--- a/app/api/nexus/decision-chat/__tests__/route.test.ts
+++ b/app/api/nexus/decision-chat/__tests__/route.test.ts
@@ -1,0 +1,169 @@
+/**
+ * @jest-environment node
+ *
+ * Tests for POST /api/nexus/decision-chat:
+ *  - REV-SEC-141: a client-supplied conversationId owned by a different user is
+ *    rejected (404) before any message is written.
+ *  - REV-COR-228: the onFinish callback persists multi-step tool turns via
+ *    saveConversationSteps (steps.length > 1), mirroring the main chat route, instead
+ *    of collapsing them into a single assistant message.
+ */
+
+const mockGetServerSession = jest.fn()
+jest.mock('@/lib/auth/server-session', () => ({
+  getServerSession: (...a: unknown[]) => mockGetServerSession(...a),
+}))
+
+const mockGetCurrentUserAction = jest.fn()
+jest.mock('@/actions/db/get-current-user-action', () => ({
+  getCurrentUserAction: (...a: unknown[]) => mockGetCurrentUserAction(...a),
+}))
+
+const mockHasCapabilityAccess = jest.fn()
+jest.mock('@/utils/roles', () => ({
+  hasCapabilityAccess: (...a: unknown[]) => mockHasCapabilityAccess(...a),
+}))
+
+const mockGetRequiredSetting = jest.fn()
+jest.mock('@/lib/settings-manager', () => ({
+  getRequiredSetting: (...a: unknown[]) => mockGetRequiredSetting(...a),
+}))
+
+const mockGetModelConfig = jest.fn()
+jest.mock('@/lib/ai/model-config', () => ({
+  getModelConfig: (...a: unknown[]) => mockGetModelConfig(...a),
+}))
+
+const mockGetConversationById = jest.fn()
+jest.mock('@/lib/db/drizzle/nexus-conversations', () => ({
+  getConversationById: (...a: unknown[]) => mockGetConversationById(...a),
+}))
+
+const mockProcessMessagesWithAttachments = jest.fn()
+jest.mock('@/lib/services/attachment-storage-service', () => ({
+  processMessagesWithAttachments: (...a: unknown[]) => mockProcessMessagesWithAttachments(...a),
+}))
+
+let capturedStreamRequest: { callbacks?: { onFinish?: (e: unknown) => Promise<void> } } | undefined
+const mockStream = jest.fn()
+jest.mock('@/lib/streaming/unified-streaming-service', () => ({
+  unifiedStreamingService: { stream: (...a: unknown[]) => mockStream(...a) },
+}))
+
+const mockGetDecisionFrameworkPrompt = jest.fn()
+jest.mock('@/lib/graph/decision-framework', () => ({
+  getDecisionFrameworkPrompt: (...a: unknown[]) => mockGetDecisionFrameworkPrompt(...a),
+}))
+
+const mockCreateDecisionCaptureTools = jest.fn()
+jest.mock('@/lib/tools/decision-capture-tools', () => ({
+  createDecisionCaptureTools: (...a: unknown[]) => mockCreateDecisionCaptureTools(...a),
+}))
+
+const mockSaveUserMessage = jest.fn()
+const mockSaveAssistantMessage = jest.fn()
+const mockSaveConversationSteps = jest.fn()
+const mockCreateConversation = jest.fn()
+jest.mock('../../chat/chat-helpers', () => ({
+  generateConversationTitle: () => 'Title',
+  createConversation: (...a: unknown[]) => mockCreateConversation(...a),
+  extractUserContent: () => ({ content: 'hi', parts: [{ type: 'text', text: 'hi' }] }),
+  saveUserMessage: (...a: unknown[]) => mockSaveUserMessage(...a),
+  convertMessagesToPartsFormat: (m: unknown) => m,
+  saveAssistantMessage: (...a: unknown[]) => mockSaveAssistantMessage(...a),
+  saveConversationSteps: (...a: unknown[]) => mockSaveConversationSteps(...a),
+}))
+
+jest.mock('@/lib/logger', () => ({
+  createLogger: jest.fn(() => ({ info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() })),
+  generateRequestId: jest.fn(() => 'rid'),
+  startTimer: jest.fn(() => jest.fn()),
+  sanitizeForLogging: jest.fn((d: unknown) => d),
+}))
+
+import { POST } from '../route'
+
+const CONVO = 'dddddddd-1111-4111-8111-dddddddddddd'
+
+function req(conversationId: string | null) {
+  return {
+    json: async () => ({
+      messages: [{ id: '1', role: 'user', parts: [{ type: 'text', text: 'hi' }] }],
+      conversationId,
+    }),
+  } as unknown as Request
+}
+
+describe('POST /api/nexus/decision-chat (REV-SEC-141 / REV-COR-228)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    capturedStreamRequest = undefined
+    mockGetServerSession.mockResolvedValue({ sub: 'caller-sub' })
+    mockGetCurrentUserAction.mockResolvedValue({ isSuccess: true, data: { user: { id: 1 } } })
+    mockHasCapabilityAccess.mockResolvedValue(true)
+    mockGetRequiredSetting.mockResolvedValue('decision-model')
+    mockGetModelConfig.mockResolvedValue({ id: 9, provider: 'google', model_id: 'gemini', capabilities: {} })
+    mockProcessMessagesWithAttachments.mockResolvedValue({ lightweightMessages: [] })
+    mockGetDecisionFrameworkPrompt.mockResolvedValue('framework')
+    mockCreateDecisionCaptureTools.mockReturnValue({})
+    mockStream.mockImplementation(async (streamRequest: unknown) => {
+      capturedStreamRequest = streamRequest as { callbacks?: { onFinish?: (e: unknown) => Promise<void> } }
+      return {
+        capabilities: { supportsReasoning: false },
+        result: { toUIMessageStreamResponse: () => new Response('stream', { status: 200 }) },
+      }
+    })
+  })
+
+  it('rejects a conversationId owned by a different user with 404 and writes nothing (REV-SEC-141)', async () => {
+    mockGetConversationById.mockResolvedValue(null) // not owned by caller
+
+    const res = await POST(req(CONVO))
+
+    expect(res.status).toBe(404)
+    // Ownership query filters by BOTH id and userId.
+    expect(mockGetConversationById).toHaveBeenCalledWith(CONVO, 1)
+    // No message written, no streaming started.
+    expect(mockSaveUserMessage).not.toHaveBeenCalled()
+    expect(mockStream).not.toHaveBeenCalled()
+  })
+
+  it('lets the owner save into their own existing conversation (REV-SEC-141)', async () => {
+    mockGetConversationById.mockResolvedValue({ id: CONVO, userId: 1 })
+
+    const res = await POST(req(CONVO))
+
+    expect(res.status).toBe(200)
+    expect(mockSaveUserMessage).toHaveBeenCalledTimes(1)
+    expect(mockStream).toHaveBeenCalledTimes(1)
+  })
+
+  it('onFinish persists a multi-step turn via saveConversationSteps (REV-COR-228)', async () => {
+    mockGetConversationById.mockResolvedValue({ id: CONVO, userId: 1 })
+    await POST(req(CONVO))
+
+    const onFinish = capturedStreamRequest?.callbacks?.onFinish
+    expect(typeof onFinish).toBe('function')
+
+    await onFinish!({
+      text: 'done',
+      usage: { totalTokens: 3 },
+      finishReason: 'stop',
+      steps: [{ text: 'a' }, { text: 'b' }], // > 1 step
+    })
+
+    expect(mockSaveConversationSteps).toHaveBeenCalledTimes(1)
+    expect(mockSaveAssistantMessage).not.toHaveBeenCalled()
+  })
+
+  it('onFinish persists a single-step turn via saveAssistantMessage (REV-COR-228)', async () => {
+    mockGetConversationById.mockResolvedValue({ id: CONVO, userId: 1 })
+    await POST(req(CONVO))
+
+    const onFinish = capturedStreamRequest?.callbacks?.onFinish
+    await onFinish!({ text: 'just text', usage: {}, finishReason: 'stop' }) // no steps
+
+    expect(mockSaveAssistantMessage).toHaveBeenCalledTimes(1)
+    expect(mockSaveConversationSteps).not.toHaveBeenCalled()
+  })
+})

--- a/app/api/nexus/decision-chat/route.ts
+++ b/app/api/nexus/decision-chat/route.ts
@@ -22,6 +22,7 @@ import { getDecisionFrameworkPrompt } from '@/lib/graph/decision-framework';
 import { getRequiredSetting } from '@/lib/settings-manager';
 import { createDecisionCaptureTools } from '@/lib/tools/decision-capture-tools';
 import { hasCapabilityAccess } from '@/utils/roles';
+import { getConversationById } from '@/lib/db/drizzle/nexus-conversations';
 
 import {
   generateConversationTitle,
@@ -30,6 +31,8 @@ import {
   saveUserMessage,
   convertMessagesToPartsFormat,
   saveAssistantMessage,
+  saveConversationSteps,
+  type StepData,
 } from '../chat/chat-helpers';
 
 // Allow streaming responses up to 5 minutes
@@ -241,8 +244,10 @@ async function setupConversation(params: {
   userId: number;
   modelId: string;
   dbModelId: number;
+  requestId: string;
+  log: ReturnType<typeof createLogger>;
 }): Promise<{ conversationId: string; conversationTitle: string } | { error: Response }> {
-  const { conversationIdValue, messages, userId, modelId, dbModelId } = params;
+  const { conversationIdValue, messages, userId, modelId, dbModelId, requestId, log } = params;
 
   let conversationId = conversationIdValue || '';
   let conversationTitle = 'New Decision Capture';
@@ -257,6 +262,22 @@ async function setupConversation(params: {
     });
     if ('error' in convResult) return convResult;
     conversationId = convResult.conversationId;
+  } else {
+    // Verify the authenticated user owns this conversation before writing to it
+    // (REV-SEC-141). nexus_conversations/nexus_messages are shared across all Nexus
+    // surfaces, so an unverified client-supplied conversationId would let any user
+    // inject messages/attachments into another user's conversation. Mirrors the
+    // main chat route's ownership gate; getConversationById filters by id AND userId.
+    const conversation = await getConversationById(conversationId, userId);
+    if (!conversation) {
+      log.warn('Conversation ownership check failed — access denied', { conversationId, userId });
+      return {
+        error: new Response(
+          JSON.stringify({ error: 'Conversation not found or access denied', requestId }),
+          { status: 404, headers: { 'Content-Type': 'application/json' } }
+        )
+      };
+    }
   }
 
   // Save user message
@@ -334,6 +355,7 @@ async function executeStreaming(params: {
     usage,
     finishReason,
     toolCalls,
+    steps,
   }: {
     text: string;
     usage?: { promptTokens?: number; completionTokens?: number; totalTokens?: number };
@@ -344,16 +366,28 @@ async function executeStreaming(params: {
       args: Record<string, unknown>;
       result?: unknown;
     }>;
+    steps?: StepData[];
   }) => {
     log.info('Stream finished, saving assistant message', {
       conversationId,
       hasText: !!text,
       textLength: text?.length || 0,
       toolCallCount: toolCalls?.length || 0,
+      stepCount: steps?.length ?? 0,
     });
 
     try {
-      await saveAssistantMessage({ conversationId, text, usage, finishReason, toolCalls, dbModelId });
+      if (steps && steps.length > 1) {
+        // Multi-step agentic loop (search_graph_nodes → propose_decision → …):
+        // save each step as a separate assistant message to preserve the correct
+        // turn structure for replay. Consolidating into one message breaks
+        // convertToModelMessages — it cannot reconstruct multi-turn
+        // tool_use/tool_result pairs, throwing AI_MissingToolResultsError on the
+        // next user turn. Mirrors the main chat route (REV-COR-228 / Issue #977).
+        await saveConversationSteps({ conversationId, steps, dbModelId, usage, finishReason });
+      } else {
+        await saveAssistantMessage({ conversationId, text, usage, finishReason, toolCalls, dbModelId });
+      }
     } catch (saveError) {
       log.error('Failed to save assistant message', { error: saveError, conversationId });
     }
@@ -440,6 +474,7 @@ export async function POST(req: Request) {
     const convSetup = await setupConversation({
       conversationIdValue, messages, userId,
       modelId: modelConfig.model_id, dbModelId,
+      requestId, log,
     });
     if ('error' in convSetup) return convSetup.error;
     const { conversationId, conversationTitle } = convSetup;

--- a/app/api/nexus/messages/__tests__/route.test.ts
+++ b/app/api/nexus/messages/__tests__/route.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Tests for POST /api/nexus/messages (REV-SEC-145 scoped upsert + REV-SEC-143
+ * strip client storage refs).
+ *
+ * SEC-145: the upsert keys on a client-supplied messageId whose conflict target is
+ * the message PK alone, so a caller could overwrite another user's message by
+ * pairing their own owned conversationId with the victim's messageId. The fix
+ * rejects a messageId that already exists under a different conversation.
+ * SEC-143: client-supplied s3Key/imageUrl storage references are stripped from
+ * inbound parts (only server save paths may set them).
+ */
+
+const mockGetServerSession = jest.fn()
+jest.mock('@/lib/auth/server-session', () => ({
+  getServerSession: (...a: unknown[]) => mockGetServerSession(...a),
+}))
+
+const mockGetCurrentUserAction = jest.fn()
+jest.mock('@/actions/db/get-current-user-action', () => ({
+  getCurrentUserAction: (...a: unknown[]) => mockGetCurrentUserAction(...a),
+}))
+
+const mockUpsertMessageWithStats = jest.fn()
+const mockGetConversationById = jest.fn()
+const mockGetMessageById = jest.fn()
+jest.mock('@/lib/db/drizzle', () => ({
+  upsertMessageWithStats: (...a: unknown[]) => mockUpsertMessageWithStats(...a),
+  getConversationById: (...a: unknown[]) => mockGetConversationById(...a),
+  getMessageById: (...a: unknown[]) => mockGetMessageById(...a),
+}))
+
+jest.mock('@/lib/logger', () => ({
+  createLogger: jest.fn(() => ({ info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() })),
+  generateRequestId: jest.fn(() => 'test-request-id'),
+  startTimer: jest.fn(() => jest.fn()),
+  sanitizeForLogging: jest.fn((d: unknown) => d),
+}))
+
+// jsdom's global Response.json() returns the raw body string and lacks .text().
+// Install a faithful replacement (the route uses `new Response()` / `Response.json`).
+class TestResponse {
+  private _body: string
+  status: number
+  constructor(body?: string, init?: { status?: number }) {
+    this._body = typeof body === 'string' ? body : ''
+    this.status = init?.status ?? 200
+  }
+  async text() { return this._body }
+  async json() { return JSON.parse(this._body || 'null') }
+  static json(body: unknown, init?: { status?: number }) {
+    return new TestResponse(JSON.stringify(body), init)
+  }
+}
+;(global as unknown as { Response: unknown }).Response = TestResponse
+
+import type { NextRequest } from 'next/server'
+import { POST } from '../route'
+
+const USER_ID = 1
+const OWN_CONVO = 'aaaaaaaa-1111-4111-8111-aaaaaaaaaaaa'
+
+function req(body: unknown) {
+  return { json: async () => body } as unknown as NextRequest
+}
+
+describe('POST /api/nexus/messages (REV-SEC-145 / REV-SEC-143)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockGetServerSession.mockResolvedValue({ sub: 'caller-sub' })
+    mockGetCurrentUserAction.mockResolvedValue({ isSuccess: true, data: { user: { id: USER_ID } } })
+    mockGetConversationById.mockResolvedValue({ id: OWN_CONVO, userId: USER_ID })
+    mockUpsertMessageWithStats.mockResolvedValue({})
+  })
+
+  it('rejects an upsert whose messageId belongs to a different conversation (REV-SEC-145)', async () => {
+    // The messageId already exists under a conversation the caller does NOT own.
+    mockGetMessageById.mockResolvedValue({ id: 'msg-victim', conversationId: 'victim-convo' })
+
+    const res = await POST(req({
+      conversationId: OWN_CONVO, // owned by caller (passes the ownership gate)
+      messageId: 'msg-victim',
+      role: 'assistant',
+      content: 'tampered',
+    }))
+
+    expect(res.status).toBe(409)
+    // The victim's row is never overwritten.
+    expect(mockUpsertMessageWithStats).not.toHaveBeenCalled()
+  })
+
+  it('allows the owner to update an existing message in their own conversation', async () => {
+    mockGetMessageById.mockResolvedValue({ id: 'msg-own', conversationId: OWN_CONVO })
+
+    const res = await POST(req({
+      conversationId: OWN_CONVO,
+      messageId: 'msg-own',
+      role: 'assistant',
+      content: 'edited',
+    }))
+
+    expect(res.status).toBe(200)
+    expect(mockUpsertMessageWithStats).toHaveBeenCalledTimes(1)
+  })
+
+  it('strips client-supplied s3Key/imageUrl from parts before persisting (REV-SEC-143)', async () => {
+    mockGetMessageById.mockResolvedValue(null) // new message
+
+    await POST(req({
+      conversationId: OWN_CONVO,
+      messageId: 'msg-new',
+      role: 'assistant',
+      parts: [
+        { type: 'image', imageUrl: 'https://evil/x', s3Key: '3/1699-secret.pdf', altText: 'a' },
+        { type: 'text', text: 'hello' },
+      ],
+    }))
+
+    expect(mockUpsertMessageWithStats).toHaveBeenCalledTimes(1)
+    const persistedParts = (mockUpsertMessageWithStats.mock.calls[0][2] as { parts: Array<Record<string, unknown>> }).parts
+    // Storage refs removed; other fields preserved.
+    expect(persistedParts[0]).toEqual({ type: 'image', altText: 'a' })
+    expect(persistedParts[0]).not.toHaveProperty('s3Key')
+    expect(persistedParts[0]).not.toHaveProperty('imageUrl')
+    expect(persistedParts[1]).toEqual({ type: 'text', text: 'hello' })
+  })
+
+  it('returns 404 when the caller does not own the conversation', async () => {
+    mockGetConversationById.mockResolvedValue(null)
+
+    const res = await POST(req({
+      conversationId: 'someone-elses', messageId: 'm', role: 'user', content: 'x',
+    }))
+
+    expect(res.status).toBe(404)
+    expect(mockGetMessageById).not.toHaveBeenCalled()
+    expect(mockUpsertMessageWithStats).not.toHaveBeenCalled()
+  })
+})

--- a/app/api/nexus/messages/route.ts
+++ b/app/api/nexus/messages/route.ts
@@ -5,9 +5,30 @@ import { NextRequest } from 'next/server'
 import {
   upsertMessageWithStats,
   getConversationById,
+  getMessageById,
   type MessagePart,
   type TokenUsage,
 } from '@/lib/db/drizzle'
+
+/**
+ * REV-SEC-143: storage-reference fields (s3Key / imageUrl) must only be set by the
+ * server's own image/attachment save paths. Strip them from client-supplied parts so
+ * a caller cannot plant a key/URL that a later presign step would trust. Returns new
+ * objects (never mutates the input parts).
+ */
+function stripClientStorageRefs(parts: MessagePart[] | undefined): MessagePart[] | undefined {
+  if (!Array.isArray(parts)) return parts
+  return parts.map(part => {
+    if (part && typeof part === 'object' && ('s3Key' in part || 'imageUrl' in part)) {
+      const { s3Key: _s3Key, imageUrl: _imageUrl, ...rest } = part as MessagePart & {
+        s3Key?: unknown
+        imageUrl?: unknown
+      }
+      return rest as MessagePart
+    }
+    return part
+  })
+}
 
 /**
  * POST /api/nexus/messages - Save a message to a conversation
@@ -94,11 +115,30 @@ export async function POST(req: NextRequest) {
       return new Response('Conversation not found', { status: 404 })
     }
 
+    // REV-SEC-145: the upsert keys on the global message id, but ownership was only
+    // checked on the conversation. Reject a messageId that already exists under a
+    // DIFFERENT conversation so a caller cannot overwrite another user's message by
+    // supplying their own owned conversationId together with the victim's messageId.
+    const existingMessage = await getMessageById(messageId)
+    if (existingMessage && existingMessage.conversationId !== conversationId) {
+      log.warn('Rejected message upsert — messageId belongs to a different conversation', {
+        messageId, requestConversationId: conversationId
+      })
+      timer({ status: 'error', reason: 'message_conversation_mismatch' })
+      return new Response(
+        JSON.stringify({ error: 'Message could not be saved' }),
+        { status: 409, headers: { 'Content-Type': 'application/json' } }
+      )
+    }
+
+    // REV-SEC-143: never persist client-supplied storage references.
+    const sanitizedParts = stripClientStorageRefs(parts)
+
     // Upsert message and update conversation stats using Drizzle
     await upsertMessageWithStats(messageId, conversationId, {
       role,
       content: content || undefined,
-      parts: parts || undefined,
+      parts: sanitizedParts || undefined,
       modelId: modelId || undefined,
       reasoningContent: reasoningContent || undefined,
       tokenUsage: tokenUsage || undefined,

--- a/lib/ai/__tests__/model-config.test.ts
+++ b/lib/ai/__tests__/model-config.test.ts
@@ -1,0 +1,73 @@
+/**
+ * @jest-environment node
+ *
+ * Tests getModelConfig (REV-PERF-002). It now returns `capabilities` so the Nexus
+ * chat route can derive image/deep-research routing from this single fetched row
+ * instead of re-reading the same ai_models row. The active/nexusEnabled gate is
+ * preserved.
+ */
+
+const mockGetAIModelById = jest.fn()
+const mockGetAIModelByModelId = jest.fn()
+jest.mock('@/lib/db/drizzle', () => ({
+  getAIModelById: (...a: unknown[]) => mockGetAIModelById(...a),
+  getAIModelByModelId: (...a: unknown[]) => mockGetAIModelByModelId(...a),
+}))
+
+jest.mock('@/lib/logger', () => ({
+  createLogger: jest.fn(() => ({ info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() })),
+}))
+
+import { getModelConfig } from '../model-config'
+
+const activeModel = {
+  id: 42,
+  name: 'Gemini',
+  provider: 'google',
+  modelId: 'gemini-2.0-flash',
+  active: true,
+  nexusEnabled: true,
+  capabilities: { imageGeneration: true },
+}
+
+describe('getModelConfig (REV-PERF-002)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('returns capabilities alongside the trimmed config (so the route needs no 2nd fetch)', async () => {
+    mockGetAIModelByModelId.mockResolvedValue(activeModel)
+
+    const result = await getModelConfig('gemini-2.0-flash')
+
+    expect(result).toEqual({
+      id: 42,
+      name: 'Gemini',
+      provider: 'google',
+      model_id: 'gemini-2.0-flash',
+      capabilities: { imageGeneration: true },
+    })
+    // Only one ai_models read for a string model id.
+    expect(mockGetAIModelByModelId).toHaveBeenCalledTimes(1)
+    expect(mockGetAIModelById).not.toHaveBeenCalled()
+  })
+
+  it('resolves a numeric model id with a single lookup', async () => {
+    mockGetAIModelById.mockResolvedValue(activeModel)
+
+    const result = await getModelConfig(42)
+
+    expect(result?.capabilities).toEqual({ imageGeneration: true })
+    expect(mockGetAIModelById).toHaveBeenCalledTimes(1)
+  })
+
+  it('returns null for an inactive model (gate preserved)', async () => {
+    mockGetAIModelByModelId.mockResolvedValue({ ...activeModel, active: false })
+    expect(await getModelConfig('gemini-2.0-flash')).toBeNull()
+  })
+
+  it('returns null for a non-nexus model (gate preserved)', async () => {
+    mockGetAIModelByModelId.mockResolvedValue({ ...activeModel, nexusEnabled: false })
+    expect(await getModelConfig('gemini-2.0-flash')).toBeNull()
+  })
+})

--- a/lib/ai/model-config.ts
+++ b/lib/ai/model-config.ts
@@ -43,6 +43,10 @@ export async function getModelConfig(modelId: string | number) {
     id: model.id,
     name: model.name,
     provider: model.provider,
-    model_id: model.modelId
+    model_id: model.modelId,
+    // Include capabilities so callers (e.g. Nexus chat) can derive image/deep-research
+    // routing from this single fetched row instead of re-reading the same ai_models
+    // row via getAIModelById (REV-PERF-002).
+    capabilities: model.capabilities
   };
 }

--- a/tests/unit/api/nexus/image-generation-handler.test.ts
+++ b/tests/unit/api/nexus/image-generation-handler.test.ts
@@ -2,12 +2,31 @@
  * @jest-environment node
  */
 import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+
+// Use the global `jest` (not the @jest/globals import) so next/jest's SWC hoists
+// this jest.mock above the handler import.
+const mockGetAttachmentFromS3 = jest.fn();
+jest.mock('@/lib/services/attachment-storage-service', () => ({
+  getAttachmentFromS3: (key: string) => mockGetAttachmentFromS3(key),
+}));
+
+const mockExecuteQuery = jest.fn();
+const mockExecuteTransaction = jest.fn();
+jest.mock('@/lib/db/drizzle-client', () => ({
+  executeQuery: (...a: unknown[]) => mockExecuteQuery(...a),
+  executeTransaction: (...a: unknown[]) => mockExecuteTransaction(...a),
+}));
+
 import {
   extractImagePrompt,
   validateImagePrompt,
   extractReferenceImages,
+  persistImageExchange,
   handleImageGenerationError
 } from '@/app/api/nexus/chat/image-generation-handler';
+
+const CONVO = 'conv-123';
+const IN_PREFIX_KEY = `conversations/${CONVO}/attachments/msg-0-ref.png`;
 
 describe('extractImagePrompt', () => {
   it('returns empty string when messages array is empty', () => {
@@ -72,13 +91,17 @@ describe('validateImagePrompt', () => {
 });
 
 describe('extractReferenceImages', () => {
+  beforeEach(() => {
+    mockGetAttachmentFromS3.mockReset();
+  });
+
   it('returns empty array when lastMessage is undefined', async () => {
-    const result = await extractReferenceImages(undefined);
+    const result = await extractReferenceImages(undefined, CONVO);
     expect(result).toEqual([]);
   });
 
   it('returns empty array when message has no parts', async () => {
-    const result = await extractReferenceImages({ id: '1', role: 'user' });
+    const result = await extractReferenceImages({ id: '1', role: 'user' }, CONVO);
     expect(result).toEqual([]);
   });
 
@@ -87,7 +110,7 @@ describe('extractReferenceImages', () => {
       id: '1',
       role: 'user',
       parts: 'not-an-array' as unknown as Array<{ type: string }>
-    });
+    }, CONVO);
     expect(result).toEqual([]);
   });
 
@@ -96,7 +119,7 @@ describe('extractReferenceImages', () => {
       id: '1',
       role: 'user',
       parts: [{ type: 'text', text: 'draw something' }]
-    });
+    }, CONVO);
     expect(result).toEqual([]);
   });
 
@@ -105,7 +128,7 @@ describe('extractReferenceImages', () => {
       id: '1',
       role: 'user',
       parts: [{ type: 'file', mediaType: 'image/svg+xml', data: 'PHN2Zz4=' }]
-    });
+    }, CONVO);
     expect(result).toEqual([]);
   });
 
@@ -114,7 +137,7 @@ describe('extractReferenceImages', () => {
       id: '1',
       role: 'user',
       parts: [{ type: 'file', mediaType: 'image/jpeg', data: '/9j/4AAQ' }]
-    });
+    }, CONVO);
     expect(result.length).toBe(1);
     expect(result[0].mimeType).toBe('image/jpeg');
   });
@@ -124,8 +147,112 @@ describe('extractReferenceImages', () => {
       id: '1',
       role: 'user',
       parts: [{ type: 'image', image: 's3://bucket/key.png' }]
-    });
+    }, CONVO);
     expect(result).toEqual([]);
+  });
+
+  // REV-SEC-144: reject client-supplied S3 keys outside the conversation's prefix
+  it('rejects an image s3Key outside the conversation prefix (never reads S3)', async () => {
+    const result = await extractReferenceImages({
+      id: '1',
+      role: 'user',
+      parts: [{ type: 'image', s3Key: 'conversations/OTHER-CONVO/attachments/secret.png' }]
+    }, CONVO);
+    expect(result).toEqual([]);
+    expect(mockGetAttachmentFromS3).not.toHaveBeenCalled();
+  });
+
+  it('rejects a file s3Key (via s3:// url) outside the conversation prefix', async () => {
+    const result = await extractReferenceImages({
+      id: '1',
+      role: 'user',
+      parts: [{ type: 'file', mediaType: 'image/png', url: 's3://bucket/conversations/OTHER/attachments/x.png' }]
+    }, CONVO);
+    expect(result).toEqual([]);
+    expect(mockGetAttachmentFromS3).not.toHaveBeenCalled();
+  });
+
+  it('loads an image reference whose s3Key is within the conversation prefix', async () => {
+    mockGetAttachmentFromS3.mockResolvedValue({ type: 'image', image: 'BASE64DATA', contentType: 'image/png' });
+    const result = await extractReferenceImages({
+      id: '1',
+      role: 'user',
+      parts: [{ type: 'image', s3Key: IN_PREFIX_KEY }]
+    }, CONVO);
+    expect(mockGetAttachmentFromS3).toHaveBeenCalledWith(IN_PREFIX_KEY);
+    expect(result.length).toBe(1);
+    expect(result[0].base64).toBe('BASE64DATA');
+  });
+
+  // REV-SEC-142: reject SSRF targets in client-supplied reference URLs
+  it('rejects an image imageUrl pointing at the cloud metadata endpoint (SSRF)', async () => {
+    const result = await extractReferenceImages({
+      id: '1',
+      role: 'user',
+      parts: [{ type: 'image', imageUrl: 'http://169.254.169.254/latest/meta-data/iam/' }]
+    }, CONVO);
+    expect(result).toEqual([]);
+  });
+
+  it('rejects a file url pointing at loopback (SSRF)', async () => {
+    const result = await extractReferenceImages({
+      id: '1',
+      role: 'user',
+      parts: [{ type: 'file', mediaType: 'image/png', url: 'http://127.0.0.1:8080/internal.png' }]
+    }, CONVO);
+    expect(result).toEqual([]);
+  });
+
+  it('allows a normal public https image URL reference', async () => {
+    const result = await extractReferenceImages({
+      id: '1',
+      role: 'user',
+      parts: [{ type: 'image', imageUrl: 'https://example.com/cat.png' }]
+    }, CONVO);
+    expect(result.length).toBe(1);
+    expect(result[0].url).toBe('https://example.com/cat.png');
+  });
+});
+
+describe('persistImageExchange (REV-DB-047 / REV-COR-220)', () => {
+  function makeTx() {
+    const insertValues = jest.fn(async () => {});
+    const updateWhere = jest.fn(async () => {});
+    const updateSet = jest.fn(() => ({ where: updateWhere }));
+    const tx = {
+      insert: jest.fn(() => ({ values: insertValues })),
+      update: jest.fn(() => ({ set: updateSet })),
+    };
+    return { tx, insertValues, updateWhere };
+  }
+
+  beforeEach(() => {
+    mockExecuteTransaction.mockReset();
+    mockExecuteQuery.mockReset();
+  });
+
+  const imageResult = { imageUrl: 'https://s3/img.png', s3Key: 'v2/generated-images/c1/x.png', altText: 'a cat' };
+
+  it('inserts both messages and the stats update inside one executeTransaction', async () => {
+    const { tx, insertValues, updateWhere } = makeTx();
+    mockExecuteTransaction.mockImplementation(async (cb: (t: unknown) => Promise<unknown>) => cb(tx));
+
+    await persistImageExchange({ conversationId: 'c1', imagePrompt: 'draw a cat', imageResult, dbModelId: 7 });
+
+    expect(mockExecuteTransaction).toHaveBeenCalledTimes(1);
+    expect(mockExecuteTransaction.mock.calls[0][1]).toBe('persistImageExchange');
+    expect(mockExecuteQuery).not.toHaveBeenCalled();
+    // user row + assistant row = two inserts, then one stats update — all atomic.
+    expect(insertValues).toHaveBeenCalledTimes(2);
+    expect(updateWhere).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects (rolls back) when the transaction fails', async () => {
+    mockExecuteTransaction.mockRejectedValue(new Error('insert failed'));
+
+    await expect(
+      persistImageExchange({ conversationId: 'c1', imagePrompt: 'x', imageResult, dbModelId: 7 })
+    ).rejects.toThrow('insert failed');
   });
 });
 


### PR DESCRIPTION
Batch **B-009** (`review/tools/batches.json`) — security/correctness/perf hardening across the Nexus API surface. **11 of 12** findings implemented exactly as scoped; **1 deferred** with rationale. Followed `docs/features/nexus-conversation-architecture.md` (CLAUDE.md rule #6) for the multi-step persistence + atomicity patterns.

## Implemented (11)

### Security — IDOR / SSRF (High)
| ID | Fix |
|----|-----|
| **REV-SEC-141** | decision-chat wrote messages into a client-supplied `conversationId` with no ownership check (any decision-capture user could inject turns into another user's conversation). `setupConversation` now verifies `getConversationById(id, userId)` and returns **404** before any write. |
| **REV-SEC-142** | Client reference-image URLs were fetched server-side with no SSRF guard. `handleImagePart`/`handleFilePart` now validate them with the shared `assertSafeFetchUrl` (blocks private/loopback/link-local/metadata; https-only in prod) **at the point of acceptance**, so an unsafe URL never reaches a fetch. |
| **REV-SEC-143** | The messages GET route presigned **any** stored image `s3Key` (client-originated) against the shared documents bucket — a confused-deputy IDOR. It now only presigns keys under this conversation's own prefix (`conversations/<id>/` or `v2/generated-images/<id>/`); the messages POST route strips client-supplied `s3Key`/`imageUrl`. |

### Security — object-level authz (Medium)
| ID | Fix |
|----|-----|
| **REV-SEC-144** | Reference-image `s3Key`/`s3://` keys from client parts are rejected unless under this conversation's attachments prefix, before any `getAttachmentFromS3`. |
| **REV-SEC-145** | `POST /api/nexus/messages` upserted on a client `messageId` whose conflict target was the PK alone, letting a caller overwrite another user's message. It now rejects (**409**) a `messageId` that already exists under a different conversation (route-layer check). |

### Database atomicity (Medium / Low)
| ID | Fix |
|----|-----|
| **REV-DB-046** / **REV-COR-220** | `saveUserMessage`/`saveAssistantMessage` now wrap insert + conversation-stats update in one `executeTransaction` (was two separate queries that could desync `message_count`). |
| **REV-DB-047** / **REV-COR-220** | Image generation persisted 3 rows non-atomically with a hardcoded `message_count + 2`. Consolidated into a transactional `persistImageExchange` (both inserts + stats in one `executeTransaction`), called once by the chat route after generation. |

### Correctness (Medium)
| ID | Fix |
|----|-----|
| **REV-COR-226** | The job-poll fallback save used a racy SELECT-then-INSERT that could duplicate assistant messages under concurrent polls. It now upserts on a deterministic `job-<jobId>` id so concurrent writers converge on one row. |
| **REV-COR-228** | decision-chat ran `maxSteps=10` but always saved one consolidated assistant message (Issue #977 regression). `onFinish` now branches on `steps.length > 1` to `saveConversationSteps`, mirroring the main chat route — multi-step tool turns reload without `AI_MissingToolResultsError`. |

### Performance (Medium)
| ID | Fix |
|----|-----|
| **REV-PERF-002** | Every Nexus chat request read the same `ai_models` row twice. `getModelConfig` now returns `capabilities` so the route derives image/deep-research routing from that single row; the second `getAIModelById` fetch is removed. |

## Deferred (1) — reported rather than exceeding scope

- **REV-TEST-006** (streaming tests don't exercise the SUT): rewriting `streaming.test.ts` to invoke the fragile ~700-line Nexus chat route as an integration test — plus the assistant-architect adapter, a **second named file outside this batch's area** — is a large, destabilization-prone effort disproportionate to a Medium testing finding in this security-focused batch, and the plan's lightweight fallback requires filing an external follow-up issue. Left for a dedicated test-infrastructure pass.

## Scope notes
- **REV-SEC-142**: the SSRF is fully closed at the acceptance layer (`image-generation-handler.ts`, this batch). The plan's optional second-layer sink guard in `lib/ai/image-generation-service.ts` is **owned by B-016** and left to that batch to avoid a cross-batch conflict.
- **REV-SEC-145**: implemented via the plan's route-layer option (pre-upsert check in `messages/route.ts`) to avoid touching `lib/db/drizzle/nexus-messages.ts`, which is owned by B-160/B-188.
- **REV-DB-047**: its transactional fix necessarily updates its caller in `app/api/nexus/chat/route.ts` (a B-009 file via PERF-002), exactly as the plan's fix description requires ("the route then calls one function instead of three").

## Tests (6 new files + 1 updated — 49 assertions, all passing)
- **decision-chat**: cross-user → 404 + no write + ownership query by `(id, userId)`; owner saves; onFinish multi-step → `saveConversationSteps`, single-step → `saveAssistantMessage`.
- **image-generation-handler**: SSRF URL rejection (metadata/loopback), s3Key prefix rejection + in-prefix load, `persistImageExchange` atomicity + rollback.
- **messages GET**: out-of-prefix s3Key never presigned; in-prefix (attachment + generated-image) presigned; cross-user 404.
- **messages POST**: cross-conversation messageId → 409; client `s3Key`/`imageUrl` stripped; ownership 404.
- **chat-helpers**: saves use one `executeTransaction`; failure rolls back.
- **jobs poll**: fallback upsert keyed on `job-<jobId>`; skip when already saved.
- **model-config**: capabilities returned; single lookup; inactive/non-nexus → null.

### Verification
- `bun run typecheck` — **0 errors**
- `bun run lint` — **0 errors** (the touched handlers already exceeded complexity/max-lines on `dev`; the added security branches introduce no new warning lines)
- `bunx jest app/api/nexus tests/unit/api/nexus lib/ai` — **13 suites, 98 tests passing** (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HWA2JRbkae8HCRsZwoEJXw