### PR TITLE
feat: #1059 — Nexus workspace panel (spec §17): edit Atrium content beside the chat

### DIFF
--- a/actions/db/atrium/workspace-panel.ts
+++ b/actions/db/atrium/workspace-panel.ts
@@ -1,0 +1,96 @@
+"use server";
+
+/**
+ * Nexus workspace-panel loader (Epic #1059, spec §17)
+ *
+ * The ONE server round-trip behind the Nexus WorkspacePanel: resolves everything
+ * the panel needs to mount the kind-specific Atrium editor beside the chat —
+ * object metadata, the caller's integer user id (the collaborative editor stamps
+ * it on edits), the canEdit hint, and (for artifacts) the server-resolved sandbox
+ * render URL that `ArtifactCanvas` requires.
+ *
+ * Mirrors the standalone edit page's gate EXACTLY (`app/(protected)/atrium/[id]/
+ * edit/page.tsx`): requester (401) → existence (404) → canView (404-mask; a
+ * non-viewable object is indistinguishable from an absent one). Edit permission
+ * is enforced AGAIN server-side by every write the editors perform — `canEdit`
+ * here is a UI hint only.
+ */
+
+import { generateRequestId, startTimer, createLogger } from "@/lib/logger";
+import { createSuccess, handleError, ErrorFactories } from "@/lib/error-utils";
+import { getUserRequester } from "./requester";
+import { contentService } from "@/lib/content/content-service";
+import { visibilityService } from "@/lib/content/visibility-service";
+import { canEdit as canEditOf } from "@/lib/content/helpers";
+import { getArtifactSandboxRenderUrl } from "@/lib/content/artifact-sandbox-config";
+import { NotFoundError } from "@/lib/content/errors";
+import type { ActionState } from "@/types";
+
+/** Everything the WorkspacePanel needs to mount the right editor. */
+export interface WorkspacePanelData {
+  id: string;
+  slug: string;
+  title: string;
+  kind: "document" | "artifact";
+  /** The signed-in user's integer id (stamped on collaborative edits). */
+  userId: number;
+  /** UI hint only — every write re-checks server-side. */
+  canEdit: boolean;
+  /** Artifact sandbox render URL (null for documents / unconfigured sandbox). */
+  sandboxSrc: string | null;
+}
+
+export async function loadWorkspacePanelAction(
+  idOrSlug: string
+): Promise<ActionState<WorkspacePanelData>> {
+  const requestId = generateRequestId();
+  const timer = startTimer("loadWorkspacePanelAction");
+  const log = createLogger({ requestId, action: "loadWorkspacePanelAction" });
+
+  try {
+    if (!idOrSlug || idOrSlug.length > 200) {
+      throw ErrorFactories.missingRequiredField("idOrSlug");
+    }
+
+    const requester = await getUserRequester(requestId);
+    const obj = await contentService.loadByIdOrSlug(idOrSlug);
+    if (!obj) throw new NotFoundError("Content not found", { idOrSlug });
+
+    const viewable = await visibilityService.canView(requester, {
+      id: obj.id,
+      ownerUserId: obj.ownerUserId,
+      visibilityLevel: obj.visibilityLevel,
+    });
+    // Existence-mask: a non-viewable object 404s exactly like an absent one.
+    if (!viewable) throw new NotFoundError("Content not found", { idOrSlug });
+
+    if (requester.kind !== "user" || requester.userId == null) {
+      // The panel is a browser surface; a non-user requester cannot occur via a
+      // server action, but fail closed rather than mint a bogus editor identity.
+      throw ErrorFactories.authNoSession();
+    }
+
+    timer({ status: "success" });
+    log.info("Workspace panel loaded", { objectId: obj.id, kind: obj.kind });
+    return createSuccess(
+      {
+        id: obj.id,
+        slug: obj.slug,
+        title: obj.title,
+        kind: obj.kind,
+        userId: requester.userId,
+        canEdit: canEditOf(requester, obj.ownerUserId),
+        sandboxSrc:
+          obj.kind === "artifact" ? getArtifactSandboxRenderUrl() : null,
+      },
+      "Workspace loaded"
+    );
+  } catch (error) {
+    timer({ status: "error" });
+    return handleError(error, "Failed to load the workspace item", {
+      context: "loadWorkspacePanelAction",
+      requestId,
+      operation: "loadWorkspacePanelAction",
+    });
+  }
+}

--- a/actions/db/atrium/workspace-panel.ts
+++ b/actions/db/atrium/workspace-panel.ts
@@ -53,6 +53,13 @@ export async function loadWorkspacePanelAction(
     }
 
     const requester = await getUserRequester(requestId);
+    // Belt-and-suspenders: getUserRequester only ever yields a `user` requester
+    // with a non-null userId (it throws otherwise), so this is unreachable — but
+    // fail closed BEFORE any DB work rather than mint a bogus editor identity.
+    if (requester.kind !== "user" || requester.userId == null) {
+      throw ErrorFactories.authNoSession();
+    }
+
     const obj = await contentService.loadByIdOrSlug(idOrSlug);
     if (!obj) throw new NotFoundError("Content not found", { idOrSlug });
 
@@ -63,12 +70,6 @@ export async function loadWorkspacePanelAction(
     });
     // Existence-mask: a non-viewable object 404s exactly like an absent one.
     if (!viewable) throw new NotFoundError("Content not found", { idOrSlug });
-
-    if (requester.kind !== "user" || requester.userId == null) {
-      // The panel is a browser surface; a non-user requester cannot occur via a
-      // server action, but fail closed rather than mint a bogus editor identity.
-      throw ErrorFactories.authNoSession();
-    }
 
     timer({ status: "success" });
     log.info("Workspace panel loaded", { objectId: obj.id, kind: obj.kind });

--- a/app/(protected)/atrium/[id]/edit/page.tsx
+++ b/app/(protected)/atrium/[id]/edit/page.tsx
@@ -75,6 +75,14 @@ export default async function AtriumEditPage({
   // the settings dialog is simply not rendered for read-only viewers.
   const headerControls = (
     <div className="flex shrink-0 items-center gap-2">
+      {/* Nexus workspace (spec §17): open this object BESIDE the chat so the
+          adjacent conversation becomes the re-prompt/tweak path. */}
+      <a
+        href={`/nexus?workspace=${obj.id}`}
+        className="rounded border px-2 py-1 text-xs text-muted-foreground hover:bg-accent"
+      >
+        Open beside chat
+      </a>
       {obj.kind === "document" && (
         <VersionMenu key={`versions-${obj.id}`} idOrSlug={obj.id} canEdit={userCanEdit} />
       )}

--- a/app/(protected)/nexus/page.tsx
+++ b/app/(protected)/nexus/page.tsx
@@ -744,11 +744,9 @@ function NexusPageContent() {
     // the live URL (not a hook value) so this callback keeps its exact deps —
     // per docs/features/nexus-conversation-architecture.md, destabilizing these
     // memoized callbacks risks runtime remounts.
-    const params = new URLSearchParams(window.location.search)
-    params.set('id', newConversationId)
     const keep = new URLSearchParams()
     keep.set('id', newConversationId)
-    const workspace = params.get('workspace')
+    const workspace = new URLSearchParams(window.location.search).get('workspace')
     if (workspace) keep.set('workspace', workspace)
     router.push(`/nexus?${keep.toString()}`, { scroll: false })
 
@@ -816,55 +814,55 @@ function NexusPageContent() {
                 pre-existing tree (initializer/runtime untouched); the Atrium
                 panel is a pure layout sibling keyed on ?workspace=. */}
             <div className="flex h-full min-h-0">
-            <div className="relative h-full min-w-0 flex-1">
-              {selectedModel ? (
-                <>
-                  {modelFallbackInfo && (
-                    <div className="px-4 pt-2">
-                      <ModelFallbackBanner
-                        originalModel={modelFallbackInfo.originalModel}
-                        fallbackModel={modelFallbackInfo.fallbackModel}
-                        onDismiss={() => setConversationModelId(null)}
-                      />
-                    </div>
-                  )}
-                  <ConversationInitializer
-                    conversationId={stableConversationId}
-                    onModelUsed={handleModelUsed}
-                  >
-                    {(initialMessages) => (
-                      <NexusRuntimeWrapper
-                        conversationId={conversationId}
-                        selectedModel={selectedModel}
-                        enabledTools={enabledTools}
-                        enabledConnectors={enabledConnectors}
-                        skillId={urlSkillId}
-                        attachmentAdapter={attachmentAdapter}
-                        voiceAvailable={voiceAvailability.available}
-                        voiceUnavailableReason={!voiceAvailability.available && !voiceAvailability.loading ? voiceAvailability.reason : undefined}
-                        initialMessages={initialMessages}
-                        onConversationIdChange={handleConversationIdChange}
-                        processingAttachments={processingAttachments}
-                        models={models}
-                        onModelChange={setSelectedModel}
-                        isLoadingModels={isLoadingModels}
-                        onToolsChange={onToolsChange}
-                        onConnectorsChange={onConnectorsChange}
-                      />
+              <div className="relative h-full min-w-0 flex-1">
+                {selectedModel ? (
+                  <>
+                    {modelFallbackInfo && (
+                      <div className="px-4 pt-2">
+                        <ModelFallbackBanner
+                          originalModel={modelFallbackInfo.originalModel}
+                          fallbackModel={modelFallbackInfo.fallbackModel}
+                          onDismiss={() => setConversationModelId(null)}
+                        />
+                      </div>
                     )}
-                  </ConversationInitializer>
-                </>
-              ) : (
-                <div className="flex h-full items-center justify-center">
-                  <div className="text-center">
-                    <div className="text-lg text-muted-foreground">Please select a model to start chatting</div>
+                    <ConversationInitializer
+                      conversationId={stableConversationId}
+                      onModelUsed={handleModelUsed}
+                    >
+                      {(initialMessages) => (
+                        <NexusRuntimeWrapper
+                          conversationId={conversationId}
+                          selectedModel={selectedModel}
+                          enabledTools={enabledTools}
+                          enabledConnectors={enabledConnectors}
+                          skillId={urlSkillId}
+                          attachmentAdapter={attachmentAdapter}
+                          voiceAvailable={voiceAvailability.available}
+                          voiceUnavailableReason={!voiceAvailability.available && !voiceAvailability.loading ? voiceAvailability.reason : undefined}
+                          initialMessages={initialMessages}
+                          onConversationIdChange={handleConversationIdChange}
+                          processingAttachments={processingAttachments}
+                          models={models}
+                          onModelChange={setSelectedModel}
+                          isLoadingModels={isLoadingModels}
+                          onToolsChange={onToolsChange}
+                          onConnectorsChange={onConnectorsChange}
+                        />
+                      )}
+                    </ConversationInitializer>
+                  </>
+                ) : (
+                  <div className="flex h-full items-center justify-center">
+                    <div className="text-center">
+                      <div className="text-lg text-muted-foreground">Please select a model to start chatting</div>
+                    </div>
                   </div>
-                </div>
+                )}
+              </div>
+              {urlWorkspaceId && (
+                <WorkspacePanel idOrSlug={urlWorkspaceId} onClose={closeWorkspace} />
               )}
-            </div>
-            {urlWorkspaceId && (
-              <WorkspacePanel idOrSlug={urlWorkspaceId} onClose={closeWorkspace} />
-            )}
             </div>
           </NexusShell>
         </NexusLayout>

--- a/app/(protected)/nexus/page.tsx
+++ b/app/(protected)/nexus/page.tsx
@@ -10,6 +10,7 @@ import { useEffect, useMemo, useCallback, useState, useRef, Suspense } from 'rea
 import { NexusShell } from './_components/layout/nexus-shell'
 import { NexusLayout } from './_components/layout/nexus-layout'
 import { ErrorBoundary } from './_components/error-boundary'
+import dynamic from 'next/dynamic'
 import { PromptAutoLoader } from './_components/prompt-auto-loader'
 import { ConversationInitializer } from './_components/conversation-initializer'
 import { z } from 'zod'
@@ -499,6 +500,15 @@ function NexusRuntimeWrapper({
 }
 
 // Component that uses useSearchParams - must be wrapped in Suspense
+// Atrium workspace panel (Epic #1059, spec §17). Client-only lazy chunk: the
+// collaborative editor / sandbox stack (TipTap+Yjs, CodeMirror) must not weigh
+// down the Nexus bundle when no workspace is open.
+const WorkspacePanel = dynamic(
+  () =>
+    import('@/components/atrium/WorkspacePanel').then((m) => m.WorkspacePanel),
+  { ssr: false }
+)
+
 function NexusPageContent() {
   const router = useRouter()
   const searchParams = useSearchParams()
@@ -543,6 +553,22 @@ function NexusPageContent() {
     const raw = searchParams.get('skillId')
     return raw && uuidSchema.safeParse(raw).success ? raw : undefined
   }, [searchParams])
+
+  // Atrium workspace panel (Epic #1059, spec §17): `?workspace=<id|slug>` opens
+  // the content editor BESIDE the chat as a pure layout sibling — the conversation
+  // tree (initializer/runtime/thread) never sees it. Loose validation only (the
+  // action canView-gates + 404-masks server-side); cap length like other params.
+  const urlWorkspaceId = useMemo(() => {
+    const raw = searchParams.get('workspace')
+    return raw && raw.length > 0 && raw.length <= 200 ? raw : null
+  }, [searchParams])
+  const closeWorkspace = useCallback(() => {
+    // Preserve every OTHER param (id/model/tool/...) — only `workspace` clears.
+    const params = new URLSearchParams(window.location.search)
+    params.delete('workspace')
+    const qs = params.toString()
+    router.replace(qs ? `/nexus?${qs}` : '/nexus', { scroll: false })
+  }, [router])
 
   // Load models and manage model selection
   const [preferredModelId, setPreferredModelId] = useState<string | null>(urlModelId)
@@ -711,9 +737,20 @@ function NexusPageContent() {
     // Clear fallback state — it's only relevant to the previously loaded conversation
     setConversationModelId(null)
 
-    // Update URL to reflect the current conversation
-    const newUrl = `/nexus?id=${newConversationId}`
-    router.push(newUrl, { scroll: false })
+    // Update URL to reflect the current conversation. PRESERVE an open Atrium
+    // workspace panel (`?workspace=`, Epic #1059 §17): without this, the ID
+    // assignment on a NEW conversation's first message would rewrite the URL to
+    // `/nexus?id=...` and slam the panel shut mid-stream. Read at call time from
+    // the live URL (not a hook value) so this callback keeps its exact deps —
+    // per docs/features/nexus-conversation-architecture.md, destabilizing these
+    // memoized callbacks risks runtime remounts.
+    const params = new URLSearchParams(window.location.search)
+    params.set('id', newConversationId)
+    const keep = new URLSearchParams()
+    keep.set('id', newConversationId)
+    const workspace = params.get('workspace')
+    if (workspace) keep.set('workspace', workspace)
+    router.push(`/nexus?${keep.toString()}`, { scroll: false })
 
     log.debug('Conversation ID updated', { newId: newConversationId })
   }, [router])
@@ -775,7 +812,11 @@ function NexusPageContent() {
       <ConnectorToolProvider>
         <NexusLayout conversationId={conversationId}>
           <NexusShell>
-            <div className="relative h-full">
+            {/* Workspace split (Epic #1059 §17): the chat column is the EXACT
+                pre-existing tree (initializer/runtime untouched); the Atrium
+                panel is a pure layout sibling keyed on ?workspace=. */}
+            <div className="flex h-full min-h-0">
+            <div className="relative h-full min-w-0 flex-1">
               {selectedModel ? (
                 <>
                   {modelFallbackInfo && (
@@ -820,6 +861,10 @@ function NexusPageContent() {
                   </div>
                 </div>
               )}
+            </div>
+            {urlWorkspaceId && (
+              <WorkspacePanel idOrSlug={urlWorkspaceId} onClose={closeWorkspace} />
+            )}
             </div>
           </NexusShell>
         </NexusLayout>

--- a/components/atrium/WorkspacePanel.tsx
+++ b/components/atrium/WorkspacePanel.tsx
@@ -72,7 +72,10 @@ export function WorkspacePanel({ idOrSlug, onClose }: WorkspacePanelProps) {
 
   return (
     <aside
-      className="flex h-full w-[44%] min-w-[380px] max-w-[720px] flex-col border-l bg-background"
+      // Desktop-only split: below md the 380px minimum + the chat column would
+      // force horizontal overflow, so the panel hides and the full-page editor
+      // (one click away) is the small-screen path.
+      className="hidden h-full w-[44%] min-w-[380px] max-w-[720px] flex-col border-l bg-background md:flex"
       aria-label="Workspace"
       data-testid="workspace-panel"
     >

--- a/components/atrium/WorkspacePanel.tsx
+++ b/components/atrium/WorkspacePanel.tsx
@@ -1,0 +1,129 @@
+"use client";
+
+/**
+ * Nexus workspace panel (Epic #1059, spec §17) — edit Atrium content BESIDE the chat.
+ *
+ * Mounted by the Nexus page as a pure LAYOUT SIBLING of the conversation tree,
+ * keyed on the `?workspace=<id|slug>` URL param. It deliberately touches NO
+ * conversation state (no runtime, no conversation id, no assistant-ui context) —
+ * the fragile Nexus streaming architecture (see
+ * docs/features/nexus-conversation-architecture.md) is completely unaware of it.
+ * "Re-prompt via adjacent chat" is exactly that: the chat sits beside this panel,
+ * so tweaking agent-drafted content is typing in the chat the user already has.
+ *
+ * The panel loads one canView-gated payload (`loadWorkspacePanelAction`, which
+ * 404-masks like the standalone edit page) and mounts the SAME kind-specific
+ * editors the full page uses — `DocumentEditor` (live collaborative editor) or
+ * `ArtifactCanvas` (Preview|Code + cross-origin sandbox). No editor logic is
+ * duplicated; the full-page experience stays one click away.
+ */
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { X, ExternalLink } from "lucide-react";
+import {
+  loadWorkspacePanelAction,
+  type WorkspacePanelData,
+} from "@/actions/db/atrium/workspace-panel";
+import { DocumentEditor } from "./DocumentEditor";
+import { ArtifactCanvas } from "./ArtifactCanvas";
+
+export interface WorkspacePanelProps {
+  /** Content object id or slug (the `?workspace=` param). */
+  idOrSlug: string;
+  /** Close the panel (the mount clears the URL param). */
+  onClose: () => void;
+}
+
+type PanelState =
+  | { status: "loading" }
+  | { status: "error"; message: string }
+  | { status: "ready"; data: WorkspacePanelData };
+
+export function WorkspacePanel({ idOrSlug, onClose }: WorkspacePanelProps) {
+  const [state, setState] = useState<PanelState>({ status: "loading" });
+  // ID change → reset to loading DURING RENDER (React's derived-state pattern —
+  // a synchronous setState inside the effect would trigger cascading renders).
+  // The effect below then loads exactly once per id ([idOrSlug] dep) with a
+  // cancelled flag so a stale response never lands on a newer id's panel.
+  const [loadedFor, setLoadedFor] = useState(idOrSlug);
+  if (loadedFor !== idOrSlug) {
+    setLoadedFor(idOrSlug);
+    setState({ status: "loading" });
+  }
+
+  useEffect(() => {
+    let cancelled = false;
+    void loadWorkspacePanelAction(idOrSlug).then((result) => {
+      if (cancelled) return;
+      if (result.isSuccess) {
+        setState({ status: "ready", data: result.data });
+      } else {
+        setState({
+          status: "error",
+          message: result.message ?? "This item could not be opened.",
+        });
+      }
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [idOrSlug]);
+
+  return (
+    <aside
+      className="flex h-full w-[44%] min-w-[380px] max-w-[720px] flex-col border-l bg-background"
+      aria-label="Workspace"
+      data-testid="workspace-panel"
+    >
+      <header className="flex items-center justify-between gap-2 border-b px-3 py-2">
+        <h2 className="truncate text-sm font-medium">
+          {state.status === "ready" ? state.data.title : "Workspace"}
+        </h2>
+        <div className="flex shrink-0 items-center gap-1">
+          {state.status === "ready" && (
+            <Link
+              href={`/atrium/${state.data.id}/edit`}
+              title="Open full page"
+              className="rounded p-1.5 text-muted-foreground hover:bg-accent"
+            >
+              <ExternalLink className="h-4 w-4" />
+              <span className="sr-only">Open full page</span>
+            </Link>
+          )}
+          <button
+            type="button"
+            onClick={onClose}
+            title="Close workspace"
+            data-testid="workspace-close"
+            className="rounded p-1.5 text-muted-foreground hover:bg-accent"
+          >
+            <X className="h-4 w-4" />
+            <span className="sr-only">Close workspace</span>
+          </button>
+        </div>
+      </header>
+
+      <div className="min-h-0 flex-1 overflow-y-auto">
+        {state.status === "loading" && (
+          <p className="p-4 text-sm text-muted-foreground">Loading workspace…</p>
+        )}
+        {state.status === "error" && (
+          <p role="alert" className="p-4 text-sm text-destructive">
+            {state.message}
+          </p>
+        )}
+        {state.status === "ready" &&
+          (state.data.kind === "document" ? (
+            <DocumentEditor idOrSlug={state.data.id} userId={state.data.userId} />
+          ) : (
+            <ArtifactCanvas
+              idOrSlug={state.data.id}
+              canEdit={state.data.canEdit}
+              sandboxSrc={state.data.sandboxSrc}
+            />
+          ))}
+      </div>
+    </aside>
+  );
+}

--- a/tests/e2e/nexus-workspace-panel.spec.ts
+++ b/tests/e2e/nexus-workspace-panel.spec.ts
@@ -1,0 +1,64 @@
+import { test, expect } from "./fixtures";
+import { authenticateContext } from "./helpers/session-auth";
+
+/**
+ * E2E (gated): Nexus workspace panel (Epic #1059, spec §17) — Atrium content
+ * edited BESIDE the chat.
+ *
+ * The critical assertions are CO-EXISTENCE ones (the panel must never disturb the
+ * fragile conversation tree — docs/features/nexus-conversation-architecture.md):
+ *  1. /nexus?workspace=<seeded doc> renders BOTH the chat composer AND the panel,
+ *     with the real collaborative editor connected inside the panel.
+ *  2. Typing in the panel's editor works (the §17 "edit beside chat" promise).
+ *  3. Closing the panel clears ONLY the workspace param and the chat remains.
+ *
+ * Reuses the standard editor seed (tests/e2e/fixtures/atrium-editor-seed.sql,
+ * admin-owned doc → canEdit) + the authed host dev server on :3100.
+ */
+
+const OBJ_ID =
+  process.env.ATRIUM_EDITOR_E2E_ID ?? "a7100000-0000-4000-8000-000000006060";
+
+test.describe("Nexus workspace panel (authenticated)", () => {
+  test.skip(
+    process.env.PLAYWRIGHT_AUTH_ENABLED !== "true",
+    "Requires the authed host dev server (collab WS) + seeded doc — see tests/e2e/fixtures/atrium-editor-seed.sql"
+  );
+
+  test("chat and workspace panel coexist; editing works; close preserves the chat", async ({
+    browser,
+  }) => {
+    const context = await browser.newContext();
+    await authenticateContext(context); // admin = the seeded doc's owner
+    try {
+      const page = await context.newPage();
+      await page.goto(`/nexus?workspace=${OBJ_ID}`);
+
+      // 1. BOTH surfaces render: the panel with the doc title, and the chat
+      //    composer (the conversation tree is intact beside it).
+      const panel = page.getByTestId("workspace-panel");
+      await expect(panel).toBeVisible({ timeout: 60000 });
+      const composer = page.locator('[role="textbox"], textarea').first();
+      await expect(composer).toBeVisible({ timeout: 60000 });
+
+      // 2. The REAL collaborative editor connects inside the panel and accepts
+      //    a human edit (the §17 edit-beside-chat loop).
+      const pm = panel.locator(".ProseMirror");
+      await expect(pm).toHaveAttribute("contenteditable", "true", { timeout: 60000 });
+      const marker = `WS ${Date.now()}`;
+      await pm.click();
+      await page.keyboard.press("End");
+      await page.keyboard.type(` ${marker}`);
+      await expect(pm).toContainText(marker, { timeout: 30000 });
+
+      // 3. Close: the panel unmounts, the workspace param clears, and the chat
+      //    composer is still there (no conversation-tree disturbance).
+      await page.getByTestId("workspace-close").click();
+      await expect(panel).toHaveCount(0, { timeout: 15000 });
+      await expect(page).toHaveURL(/\/nexus(?!.*workspace=)/, { timeout: 15000 });
+      await expect(composer).toBeVisible();
+    } finally {
+      await context.close();
+    }
+  });
+});

--- a/tests/unit/atrium-workspace-panel-action.test.ts
+++ b/tests/unit/atrium-workspace-panel-action.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Unit tests for loadWorkspacePanelAction (Epic #1059, spec §17) — the one
+ * canView-gated payload behind the Nexus workspace panel. Mirrors the standalone
+ * edit page's gate: 404 for absent, 404-MASK for non-viewable (never 403), and the
+ * kind-specific fields (sandboxSrc only for artifacts).
+ */
+
+const loadByIdOrSlugMock = jest.fn();
+jest.mock("@/lib/content/content-service", () => ({
+  contentService: { loadByIdOrSlug: (...a: unknown[]) => loadByIdOrSlugMock(...a) },
+}));
+
+const canViewMock = jest.fn();
+jest.mock("@/lib/content/visibility-service", () => ({
+  visibilityService: { canView: (...a: unknown[]) => canViewMock(...a) },
+}));
+
+const getUserRequesterMock = jest.fn();
+jest.mock("@/actions/db/atrium/requester", () => ({
+  getUserRequester: (...a: unknown[]) => getUserRequesterMock(...a),
+}));
+
+const sandboxUrlMock = jest.fn();
+jest.mock("@/lib/content/artifact-sandbox-config", () => ({
+  getArtifactSandboxRenderUrl: () => sandboxUrlMock(),
+}));
+
+import { loadWorkspacePanelAction } from "@/actions/db/atrium/workspace-panel";
+
+const OWNER = { kind: "user", userId: 7, roles: ["staff"], isAdmin: false };
+const OBJ = {
+  id: "obj-1",
+  slug: "my-doc",
+  title: "My Doc",
+  kind: "document",
+  ownerUserId: 7,
+  visibilityLevel: "private",
+};
+
+beforeEach(() => {
+  getUserRequesterMock.mockReset().mockResolvedValue(OWNER);
+  loadByIdOrSlugMock.mockReset().mockResolvedValue(OBJ);
+  canViewMock.mockReset().mockResolvedValue(true);
+  sandboxUrlMock.mockReset().mockReturnValue("https://sandbox.example/render");
+});
+
+describe("loadWorkspacePanelAction", () => {
+  it("returns the document payload (no sandboxSrc) with userId + canEdit for the owner", async () => {
+    const result = await loadWorkspacePanelAction("my-doc");
+    expect(result.isSuccess).toBe(true);
+    if (!result.isSuccess) return;
+    expect(result.data).toEqual({
+      id: "obj-1",
+      slug: "my-doc",
+      title: "My Doc",
+      kind: "document",
+      userId: 7,
+      canEdit: true,
+      sandboxSrc: null,
+    });
+  });
+
+  it("returns sandboxSrc for an artifact", async () => {
+    loadByIdOrSlugMock.mockResolvedValue({ ...OBJ, kind: "artifact" });
+    const result = await loadWorkspacePanelAction("obj-1");
+    expect(result.isSuccess).toBe(true);
+    if (!result.isSuccess) return;
+    expect(result.data.kind).toBe("artifact");
+    expect(result.data.sandboxSrc).toBe("https://sandbox.example/render");
+  });
+
+  it("fails for an absent object (404 semantics)", async () => {
+    loadByIdOrSlugMock.mockResolvedValue(null);
+    const result = await loadWorkspacePanelAction("missing");
+    expect(result.isSuccess).toBe(false);
+  });
+
+  it("404-MASKS a non-viewable object (indistinguishable from absent)", async () => {
+    canViewMock.mockResolvedValue(false);
+    const result = await loadWorkspacePanelAction("my-doc");
+    expect(result.isSuccess).toBe(false);
+    // The mask: same failure shape as the absent case — no 'forbidden' leak.
+    expect(result.message).not.toMatch(/forbidden|permission/i);
+  });
+
+  it("canEdit is false for a non-owner viewer (UI hint only)", async () => {
+    getUserRequesterMock.mockResolvedValue({ ...OWNER, userId: 99 });
+    loadByIdOrSlugMock.mockResolvedValue({ ...OBJ, visibilityLevel: "internal" });
+    const result = await loadWorkspacePanelAction("my-doc");
+    expect(result.isSuccess).toBe(true);
+    if (!result.isSuccess) return;
+    expect(result.data.canEdit).toBe(false);
+    expect(result.data.userId).toBe(99);
+  });
+
+  it("rejects an over-long idOrSlug before touching the DB", async () => {
+    const result = await loadWorkspacePanelAction("x".repeat(201));
+    expect(result.isSuccess).toBe(false);
+    expect(loadByIdOrSlugMock).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/atrium-workspace-panel.test.tsx
+++ b/tests/unit/atrium-workspace-panel.test.tsx
@@ -1,0 +1,131 @@
+/**
+ * Component smoke for the Nexus WorkspacePanel (Epic #1059, spec §17).
+ *
+ * The panel is a pure layout sibling of the fragile conversation tree, so its
+ * contract is small and worth pinning: loads via the canView-gated action, mounts
+ * the kind-specific editor with the action's payload, surfaces errors, closes via
+ * the callback, and RELOADS only when idOrSlug changes (ID-keyed guard).
+ *
+ * The heavy editors (TipTap/Yjs, sandbox) are mocked — their internals are covered
+ * by their own suites; the panel only routes props to them.
+ */
+
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { WorkspacePanel } from "@/components/atrium/WorkspacePanel";
+
+const loadMock = jest.fn();
+jest.mock("@/actions/db/atrium/workspace-panel", () => ({
+  loadWorkspacePanelAction: (...a: unknown[]) => loadMock(...a),
+}));
+
+// lucide-react ships ESM icons jest can't load — stub the two the panel uses
+// (established pattern: tests/components/visibility-chip.test.tsx).
+jest.mock("lucide-react", () => ({
+  X: () => <span data-testid="icon-x" />,
+  ExternalLink: () => <span data-testid="icon-external" />,
+}));
+
+// next/link's default export resolves undefined under this jest transform — a
+// plain anchor preserves the href-assertion surface.
+jest.mock("next/link", () => ({
+  __esModule: true,
+  default: ({ href, children }: { href: string; children: React.ReactNode }) => (
+    <a href={href}>{children}</a>
+  ),
+}));
+
+jest.mock("@/components/atrium/DocumentEditor", () => ({
+  DocumentEditor: ({ idOrSlug, userId }: { idOrSlug: string; userId: number }) => (
+    <div data-testid="doc-editor">{`doc:${idOrSlug}:u${userId}`}</div>
+  ),
+}));
+jest.mock("@/components/atrium/ArtifactCanvas", () => ({
+  ArtifactCanvas: ({
+    idOrSlug,
+    canEdit,
+    sandboxSrc,
+  }: {
+    idOrSlug: string;
+    canEdit?: boolean;
+    sandboxSrc?: string | null;
+  }) => (
+    <div data-testid="artifact-canvas">{`art:${idOrSlug}:${canEdit}:${sandboxSrc}`}</div>
+  ),
+}));
+
+const DOC = {
+  id: "obj-1",
+  slug: "my-doc",
+  title: "My Doc",
+  kind: "document" as const,
+  userId: 7,
+  canEdit: true,
+  sandboxSrc: null,
+};
+
+beforeEach(() => {
+  loadMock.mockReset();
+});
+
+describe("WorkspacePanel", () => {
+  it("loads and mounts the DocumentEditor with the action payload", async () => {
+    loadMock.mockResolvedValue({ isSuccess: true, data: DOC });
+    render(<WorkspacePanel idOrSlug="my-doc" onClose={jest.fn()} />);
+    expect(screen.getByText("Loading workspace…")).toBeInTheDocument();
+    await waitFor(() =>
+      expect(screen.getByTestId("doc-editor")).toHaveTextContent("doc:obj-1:u7")
+    );
+    expect(screen.getByRole("heading", { name: "My Doc" })).toBeInTheDocument();
+    expect(loadMock).toHaveBeenCalledWith("my-doc");
+  });
+
+  it("mounts the ArtifactCanvas (canEdit + sandboxSrc threaded) for artifacts", async () => {
+    loadMock.mockResolvedValue({
+      isSuccess: true,
+      data: { ...DOC, kind: "artifact", canEdit: false, sandboxSrc: "https://sb/render" },
+    });
+    render(<WorkspacePanel idOrSlug="obj-1" onClose={jest.fn()} />);
+    await waitFor(() =>
+      expect(screen.getByTestId("artifact-canvas")).toHaveTextContent(
+        "art:obj-1:false:https://sb/render"
+      )
+    );
+  });
+
+  it("surfaces a load failure as an alert (404-masked upstream)", async () => {
+    loadMock.mockResolvedValue({ isSuccess: false, message: "Content not found" });
+    render(<WorkspacePanel idOrSlug="missing" onClose={jest.fn()} />);
+    await waitFor(() =>
+      expect(screen.getByRole("alert")).toHaveTextContent("Content not found")
+    );
+  });
+
+  it("invokes onClose from the close control", async () => {
+    loadMock.mockResolvedValue({ isSuccess: true, data: DOC });
+    const onClose = jest.fn();
+    render(<WorkspacePanel idOrSlug="my-doc" onClose={onClose} />);
+    await waitFor(() => expect(screen.getByTestId("doc-editor")).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId("workspace-close"));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("reloads ONLY when idOrSlug changes (ID-keyed guard, not a boolean)", async () => {
+    loadMock.mockResolvedValue({ isSuccess: true, data: DOC });
+    const { rerender } = render(<WorkspacePanel idOrSlug="my-doc" onClose={jest.fn()} />);
+    await waitFor(() => expect(screen.getByTestId("doc-editor")).toBeInTheDocument());
+    expect(loadMock).toHaveBeenCalledTimes(1);
+
+    // Same id re-render → no reload.
+    rerender(<WorkspacePanel idOrSlug="my-doc" onClose={jest.fn()} />);
+    expect(loadMock).toHaveBeenCalledTimes(1);
+
+    // New id → reload.
+    loadMock.mockResolvedValue({
+      isSuccess: true,
+      data: { ...DOC, id: "obj-2", title: "Other" },
+    });
+    rerender(<WorkspacePanel idOrSlug="other-doc" onClose={jest.fn()} />);
+    await waitFor(() => expect(loadMock).toHaveBeenCalledTimes(2));
+    expect(loadMock).toHaveBeenLastCalledWith("other-doc");
+  });
+});


### PR DESCRIPTION
## Summary

The **final Epic #1059 deliverable**: the spec §17 workspace panel. Atrium documents and artifacts open **beside the Nexus chat** (`/nexus?workspace=<id|slug>`), making the adjacent conversation the re-prompt/tweak path.

## Design — zero contact with the fragile conversation tree
Read `docs/features/nexus-conversation-architecture.md` first (CLAUDE.md rule 6). The panel is a **pure layout sibling** mounted around the existing subtree — the initializer/runtime/Thread tree is byte-identical and never sees it. Two careful touches to the Nexus page only:
- `?workspace=` param read + a close handler that clears **only** that param
- `handleConversationIdChange` now **preserves** an open workspace when the first message assigns a conversation id (previously the URL rewrite would have slammed the panel shut mid-stream); read at call time so the memoized callback keeps its exact deps
- Panel is a client-only lazy chunk (`next/dynamic`, `ssr:false`) — the TipTap/Yjs + sandbox stack costs nothing when closed

## Reuse, not duplication
One canView-gated action (mirrors the edit page's exact 401→404→404-mask gate) supplies `{kind, userId, canEdit, sandboxSrc}`; the panel mounts the **same** `DocumentEditor` / `ArtifactCanvas` the full page uses (incl. comments/track-changes from #1123). "Open full page" is one click; entry point is an "Open beside chat" link on the edit page.

## Evidence
- **Regression proof:** the **entire existing Nexus functional E2E suite ran green alongside the new spec — 54 passed / 0 failed** on the seeded :3100 server. The conversation tree is provably undisturbed.
- New gated E2E: chat composer + panel coexist; the real collaborative editor connects and accepts a typed edit **inside the panel**; close clears only the param, chat remains.
- Unit: action gate ladder (6) + panel component smoke (5). Full jest **145 suites / 2046 tests** green; typecheck clean; lint 0 errors (nexus-page structural warnings pre-existing, ≤ dev baseline).

**This completes the Epic #1059 feature set** (audit PR #1115, delegated tokens #1120, comments/track-changes #1123, and this panel). After merge: close the epic with a completion summary. Follow-ups remain tracked in #1118.