### PR TITLE
fix(B-011): document-processor-v2 hardening

### DIFF
--- a/infra/jest.config.js
+++ b/infra/jest.config.js
@@ -1,6 +1,13 @@
 module.exports = {
   testEnvironment: 'node',
-  roots: ['<rootDir>/test'],
+  // document-processor-v2 ships its own __tests__ dirs (chunkText, html-sanitizer,
+  // lambda-logger, office-processor, handler) that were previously invisible to any
+  // Jest run — `roots` scopes test *discovery* itself, not just filtering, so listing
+  // only `test` here made every lambda test file dead weight with zero CI signal.
+  // Scoped to this lambda (not all of infra/lambdas) to avoid pulling in sibling
+  // lambda test suites (agent-triage-poll, agent-router) that this change hasn't
+  // verified against this config.
+  roots: ['<rootDir>/test', '<rootDir>/lambdas/document-processor-v2'],
   testMatch: ['**/*.test.ts'],
   transform: {
     '^.+\\.tsx?$': 'ts-jest'

--- a/infra/lambdas/document-processor-v2/__tests__/handler.test.ts
+++ b/infra/lambdas/document-processor-v2/__tests__/handler.test.ts
@@ -91,3 +91,33 @@ describe('handler reportBatchItemFailures (REV-INFRA-091)', () => {
     expect(result.batchItemFailures.map((f) => f.itemIdentifier).sort()).toEqual(['m1', 'm2']);
   });
 });
+
+describe('handler poison-message reporting (REV-INFRA-097)', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('reports a record with an unparseable body as a batch item failure instead of dropping it', async () => {
+    const event = {
+      Records: [
+        record('j1', 'ok1.txt', 'm1'),
+        { messageId: 'poison', body: '{not valid json' },
+      ],
+    } as any;
+
+    const result = await handler(event, ctx);
+
+    expect(result.batchItemFailures).toEqual([{ itemIdentifier: 'poison' }]);
+  });
+
+  it('reports only parse failures when every record is unparseable (no processable items)', async () => {
+    const event = {
+      Records: [
+        { messageId: 'poison1', body: '{not valid json' },
+        { messageId: 'poison2', body: 'also not json' },
+      ],
+    } as any;
+
+    const result = await handler(event, ctx);
+
+    expect(result.batchItemFailures.map((f) => f.itemIdentifier).sort()).toEqual(['poison1', 'poison2']);
+  });
+});

--- a/infra/lambdas/document-processor-v2/__tests__/handler.test.ts
+++ b/infra/lambdas/document-processor-v2/__tests__/handler.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Unit tests for the SQS handler's reportBatchItemFailures contract (REV-INFRA-091).
+ *
+ * A mixed batch (some documents succeed, some reject) must return
+ * { batchItemFailures: [...] } listing exactly the failed records' itemIdentifiers,
+ * so SQS keeps only those messages for retry / DLQ redrive instead of deleting them.
+ */
+
+import { marshall } from '@aws-sdk/util-dynamodb';
+import { Readable } from 'stream';
+
+// DynamoDB: Query returns a job row (so updateJobStatus doesn't 404); Put resolves.
+const dynamoSend = jest.fn((command: any) => {
+  if (command?.input?.KeyConditionExpression) {
+    return Promise.resolve({ Items: [marshall({ jobId: 'j', fileName: 'f' })] });
+  }
+  return Promise.resolve({});
+});
+jest.mock('@aws-sdk/client-dynamodb', () => ({
+  DynamoDBClient: jest.fn(() => ({ send: dynamoSend })),
+  QueryCommand: class { constructor(public input: any) {} },
+  PutItemCommand: class { constructor(public input: any) {} },
+}));
+
+// S3: GetObject returns a small stream body.
+jest.mock('@aws-sdk/client-s3', () => ({
+  S3Client: jest.fn(() => ({ send: jest.fn(() => Promise.resolve({ Body: Readable.from([Buffer.from('data')]) })) })),
+  GetObjectCommand: class { constructor(public input: any) {} },
+  PutObjectCommand: class { constructor(public input: any) {} },
+}));
+
+jest.mock('@aws-sdk/client-sqs', () => ({
+  SQSClient: jest.fn(() => ({ send: jest.fn(() => Promise.resolve({})) })),
+  SendMessageCommand: class { constructor(public input: any) {} },
+}));
+
+// Factory: the processor rejects for a file named FAIL.txt, resolves otherwise.
+jest.mock('../processors/factory', () => ({
+  DocumentProcessorFactory: {
+    create: (_type: string, _config: unknown, _buf: Buffer, fileName: string) => ({
+      process: async () => {
+        if (fileName === 'FAIL.txt') throw new Error('processor boom');
+        return { text: 'ok', metadata: {} };
+      },
+    }),
+  },
+}));
+
+import { handler } from '../index';
+
+function record(jobId: string, fileName: string, messageId: string) {
+  return {
+    messageId,
+    body: JSON.stringify({
+      jobId, bucket: 'b', key: `k/${fileName}`, fileName, fileSize: 10, fileType: 'text/plain',
+      userId: 'u',
+      processingOptions: { extractText: true, convertToMarkdown: false, extractImages: false, generateEmbeddings: false, ocrEnabled: false },
+    }),
+  };
+}
+
+const ctx = { awsRequestId: 'req', memoryLimitInMB: '512', getRemainingTimeInMillis: () => 60000 } as any;
+
+describe('handler reportBatchItemFailures (REV-INFRA-091)', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('returns only the failed record itemIdentifiers for a mixed batch', async () => {
+    const event = {
+      Records: [
+        record('j1', 'ok1.txt', 'm1'),
+        record('j2', 'FAIL.txt', 'm2'),
+        record('j3', 'ok2.txt', 'm3'),
+      ],
+    } as any;
+
+    const result = await handler(event, ctx);
+
+    expect(result).toBeDefined();
+    expect(result.batchItemFailures).toEqual([{ itemIdentifier: 'm2' }]);
+  });
+
+  it('returns an empty batchItemFailures when all succeed', async () => {
+    const event = { Records: [record('j1', 'ok.txt', 'm1')] } as any;
+    const result = await handler(event, ctx);
+    expect(result.batchItemFailures).toEqual([]);
+  });
+
+  it('returns every itemIdentifier when the whole batch fails', async () => {
+    const event = { Records: [record('j1', 'FAIL.txt', 'm1'), record('j2', 'FAIL.txt', 'm2')] } as any;
+    const result = await handler(event, ctx);
+    expect(result.batchItemFailures.map((f) => f.itemIdentifier).sort()).toEqual(['m1', 'm2']);
+  });
+});

--- a/infra/lambdas/document-processor-v2/index.ts
+++ b/infra/lambdas/document-processor-v2/index.ts
@@ -287,9 +287,19 @@ interface ProcessingItem {
   messageId: string;
 }
 
+interface ExtractedRecords {
+  items: ProcessingItem[];
+  // messageIds whose body failed JSON.parse — reported as batchItemFailures too, so
+  // SQS retries/redrives them instead of deleting them as if they were processed
+  // (REV-INFRA-097): a void/skip here previously left them out of batchItemFailures
+  // entirely, and any record NOT in that list is treated by SQS as a success.
+  parseFailureMessageIds: string[];
+}
+
 // Extract processing contexts from SQS events
-function extractProcessingContexts(event: SQSEvent): ProcessingItem[] {
+function extractProcessingContexts(event: SQSEvent): ExtractedRecords {
   const items: ProcessingItem[] = [];
+  const parseFailureMessageIds: string[] = [];
 
   for (const record of event.Records) {
     try {
@@ -308,14 +318,17 @@ function extractProcessingContexts(event: SQSEvent): ProcessingItem[] {
         });
       }
     } catch (parseError) {
-      // An unparseable record is a poison message that retrying cannot fix; log and
-      // skip it (SQS deletes it) rather than retrying forever.
+      // A malformed body cannot be fixed by processing logic, but it CAN be fixed by
+      // a human (bad producer, truncated message, etc.) — report it as a batch item
+      // failure so it stays on the queue for SQS retry / DLQ redrive rather than
+      // being silently deleted as a false success (REV-INFRA-097).
       const logger = createLambdaLogger({ operation: 'extractProcessingContexts' });
-      logger.error('Failed to parse SQS record', parseError);
+      logger.error('Failed to parse SQS record', parseError, { messageId: record.messageId });
+      parseFailureMessageIds.push(record.messageId);
     }
   }
 
-  return items;
+  return { items, parseFailureMessageIds };
 }
 
 // Lambda handler
@@ -333,11 +346,19 @@ export async function handler(event: SQSEvent, context: Context): Promise<SQSBat
     remainingTime: context.getRemainingTimeInMillis()
   });
 
-  const items = extractProcessingContexts(event);
+  const { items, parseFailureMessageIds } = extractProcessingContexts(event);
+
+  // Parse failures are reported regardless of whether any record parsed successfully
+  // (REV-INFRA-097) — they are independent of the items array below.
+  const batchItemFailures: SQSBatchItemFailure[] = parseFailureMessageIds.map(
+    (messageId) => ({ itemIdentifier: messageId })
+  );
 
   if (items.length === 0) {
-    logger.warn('No valid processing contexts found in event');
-    return { batchItemFailures: [] };
+    logger.warn('No valid processing contexts found in event', {
+      parseFailureCount: parseFailureMessageIds.length
+    });
+    return { batchItemFailures };
   }
 
   // Process documents concurrently (but limited by Lambda concurrency settings)
@@ -350,7 +371,6 @@ export async function handler(event: SQSEvent, context: Context): Promise<SQSBat
   // records' itemIdentifiers keeps ONLY those messages on the queue for SQS retry and
   // DLQ redrive (maxReceiveCount reached) — the previous void return made Lambda treat
   // a partial-batch failure as a full success and silently delete the failed messages.
-  const batchItemFailures: SQSBatchItemFailure[] = [];
   results.forEach((result, index) => {
     if (result.status === 'rejected') {
       batchItemFailures.push({ itemIdentifier: items[index].messageId });
@@ -363,9 +383,9 @@ export async function handler(event: SQSEvent, context: Context): Promise<SQSBat
   });
 
   logger.info('Lambda execution completed', {
-    successCount: results.length - batchItemFailures.length,
+    successCount: results.length - (batchItemFailures.length - parseFailureMessageIds.length),
     failureCount: batchItemFailures.length,
-    totalCount: results.length
+    totalCount: results.length + parseFailureMessageIds.length
   });
 
   // An all-failed batch is naturally a subset of this: every itemIdentifier is

--- a/infra/lambdas/document-processor-v2/index.ts
+++ b/infra/lambdas/document-processor-v2/index.ts
@@ -1,4 +1,4 @@
-import { SQSEvent, Context } from 'aws-lambda';
+import { SQSEvent, Context, SQSBatchResponse, SQSBatchItemFailure } from 'aws-lambda';
 import { S3Client, GetObjectCommand, PutObjectCommand } from '@aws-sdk/client-s3';
 import { DynamoDBClient, PutItemCommand, QueryCommand } from '@aws-sdk/client-dynamodb';
 import { SQSClient, SendMessageCommand } from '@aws-sdk/client-sqs';
@@ -15,7 +15,6 @@ const sqsClient = new SQSClient({});
 const DOCUMENTS_BUCKET = process.env.DOCUMENTS_BUCKET_NAME!;
 const DOCUMENT_JOBS_TABLE = process.env.DOCUMENT_JOBS_TABLE!;
 const HIGH_MEMORY_QUEUE_URL = process.env.HIGH_MEMORY_QUEUE_URL;
-const DLQ_URL = process.env.DLQ_URL;
 const PROCESSOR_TYPE = process.env.PROCESSOR_TYPE || 'STANDARD'; // STANDARD or HIGH_MEMORY
 
 interface ProcessingContext {
@@ -140,34 +139,10 @@ async function sendToHighMemoryQueue(context: ProcessingContext): Promise<void> 
   logger.info('Job sent to high-memory queue', { jobId: context.jobId, queueUrl: HIGH_MEMORY_QUEUE_URL });
 }
 
-// Send to DLQ for manual review
-async function sendToDLQ(jobId: string, error: Error | any, context: ProcessingContext): Promise<void> {
-  const logger = createLambdaLogger({ operation: 'sendToDLQ', jobId });
-  if (!DLQ_URL) {
-    logger.error('DLQ_URL not configured');
-    return;
-  }
-  
-  try {
-    await sqsClient.send(new SendMessageCommand({
-      QueueUrl: DLQ_URL,
-      MessageBody: JSON.stringify({
-        jobId,
-        error: {
-          message: error.message,
-          stack: error.stack,
-        },
-        context,
-        timestamp: new Date().toISOString(),
-        processorType: PROCESSOR_TYPE,
-      }),
-    }));
-    
-    logger.info('Failed job sent to DLQ', { jobId, processorType: PROCESSOR_TYPE });
-  } catch (dlqError) {
-    logger.error('Failed to send to DLQ', dlqError);
-  }
-}
+// Failed documents are re-thrown from processDocument and reported by the handler via
+// batchItemFailures (REV-INFRA-091); SQS then retries and redrives them to the
+// configured DLQ (processingQueue.deadLetterQueue, maxReceiveCount) automatically, so
+// the previous eager manual DLQ send is no longer needed.
 
 // Stream to buffer converter
 async function streamToBuffer(stream: Readable): Promise<Buffer> {
@@ -296,94 +271,104 @@ async function processDocument(context: ProcessingContext): Promise<void> {
       failedAt: new Date().toISOString(),
       processingStage: 'failed',
     }, logger);
-    
-    // Send to DLQ for manual review
-    await sendToDLQ(jobId, error, context);
-    
-    throw error; // Re-throw to let Lambda handle retry logic
+
+    // Re-throw so the handler reports this record in batchItemFailures. SQS then
+    // retries it (maxReceiveCount) and redrives it to the DLQ on exhaustion
+    // (REV-INFRA-091). The previous eager sendToDLQ here fired on the FIRST failure,
+    // DLQ-ing transient failures before SQS's retry budget was used.
+    throw error;
   }
 }
 
+// A processing context paired with the SQS messageId it came from, so the handler
+// can report per-record success/failure via the reportBatchItemFailures contract.
+interface ProcessingItem {
+  context: ProcessingContext;
+  messageId: string;
+}
+
 // Extract processing contexts from SQS events
-function extractProcessingContexts(event: SQSEvent): ProcessingContext[] {
-  const contexts: ProcessingContext[] = [];
-  
+function extractProcessingContexts(event: SQSEvent): ProcessingItem[] {
+  const items: ProcessingItem[] = [];
+
   for (const record of event.Records) {
     try {
       const message = JSON.parse(record.body);
-      
+
       // Handle both direct processing messages and S3 event notifications
       if (message.jobId) {
-        // Direct processing message
-        contexts.push(message as ProcessingContext);
+        // Direct processing message — keep its messageId for batchItemFailures.
+        items.push({ context: message as ProcessingContext, messageId: record.messageId });
       } else if (message.Records && message.Records[0]?.s3) {
         // S3 event notification - skip since we use direct job processing
         const logger = createLambdaLogger({ operation: 'extractProcessingContexts' });
-        logger.info('Received S3 event but skipping in favor of direct job processing', { 
-          eventType: 'S3', 
-          objectKey: message.Records[0].s3.object.key 
+        logger.info('Received S3 event but skipping in favor of direct job processing', {
+          eventType: 'S3',
+          objectKey: message.Records[0].s3.object.key
         });
       }
     } catch (parseError) {
+      // An unparseable record is a poison message that retrying cannot fix; log and
+      // skip it (SQS deletes it) rather than retrying forever.
       const logger = createLambdaLogger({ operation: 'extractProcessingContexts' });
       logger.error('Failed to parse SQS record', parseError);
     }
   }
-  
-  return contexts;
+
+  return items;
 }
 
 // Lambda handler
-export async function handler(event: SQSEvent, context: Context): Promise<void> {
-  const logger = createLambdaLogger({ 
+export async function handler(event: SQSEvent, context: Context): Promise<SQSBatchResponse> {
+  const logger = createLambdaLogger({
     operation: 'lambda-handler',
     requestId: context.awsRequestId,
     processorType: PROCESSOR_TYPE
   });
-  
+
   logger.info('Lambda handler invoked', {
     recordCount: event.Records.length,
     processorType: PROCESSOR_TYPE,
     memoryLimit: context.memoryLimitInMB,
     remainingTime: context.getRemainingTimeInMillis()
   });
-  
-  const processingContexts = extractProcessingContexts(event);
-  
-  if (processingContexts.length === 0) {
+
+  const items = extractProcessingContexts(event);
+
+  if (items.length === 0) {
     logger.warn('No valid processing contexts found in event');
-    return;
+    return { batchItemFailures: [] };
   }
-  
+
   // Process documents concurrently (but limited by Lambda concurrency settings)
   const results = await Promise.allSettled(
-    processingContexts.map(ctx => processDocument(ctx))
+    items.map(item => processDocument(item.context))
   );
-  
-  // Check for failures
-  const failures = results.filter(r => r.status === 'rejected') as PromiseRejectedResult[];
-  
-  if (failures.length > 0) {
-    logger.error('Some documents failed to process', {
-      failureCount: failures.length,
-      totalCount: results.length,
-      failures: failures.map((failure, index) => ({
-        documentIndex: index,
-        reason: failure.reason
-      }))
-    });
-    
-    // If all documents failed, throw to trigger Lambda retry
-    if (failures.length === results.length) {
-      const error = new Error(`All ${failures.length} documents failed to process`);
-      logger.error('All documents failed - triggering Lambda retry', error);
-      throw error;
+
+  // Report per-record failures via the reportBatchItemFailures contract (REV-INFRA-091).
+  // Both SQS event sources set reportBatchItemFailures: true, so returning the failed
+  // records' itemIdentifiers keeps ONLY those messages on the queue for SQS retry and
+  // DLQ redrive (maxReceiveCount reached) — the previous void return made Lambda treat
+  // a partial-batch failure as a full success and silently delete the failed messages.
+  const batchItemFailures: SQSBatchItemFailure[] = [];
+  results.forEach((result, index) => {
+    if (result.status === 'rejected') {
+      batchItemFailures.push({ itemIdentifier: items[index].messageId });
+      logger.error('Document processing failed — record left on queue for retry', {
+        jobId: items[index].context.jobId,
+        messageId: items[index].messageId,
+        reason: result.reason instanceof Error ? result.reason.message : String(result.reason)
+      });
     }
-  }
-  
+  });
+
   logger.info('Lambda execution completed', {
-    successCount: results.length - failures.length,
-    failureCount: failures.length,
+    successCount: results.length - batchItemFailures.length,
+    failureCount: batchItemFailures.length,
     totalCount: results.length
   });
+
+  // An all-failed batch is naturally a subset of this: every itemIdentifier is
+  // returned, so SQS retries the whole batch.
+  return { batchItemFailures };
 }

--- a/infra/lambdas/document-processor-v2/package.json
+++ b/infra/lambdas/document-processor-v2/package.json
@@ -20,12 +20,14 @@
     "@e965/xlsx": "^0.20.3",
     "csv-parse": "^5.4.0",
     "marked": "^9.0.0",
-    "jszip": "^3.10.1"
+    "jszip": "^3.10.1",
+    "xml2js": "^0.6.2"
   },
   "devDependencies": {
     "@types/aws-lambda": "^8.10.119",
     "@types/node": "^20.5.0",
     "@types/pdf-parse": "^1.1.1",
+    "@types/xml2js": "^0.4.14",
     "typescript": "^5.1.6",
     "jest": "^29.6.2",
     "@types/jest": "^29.5.3"

--- a/infra/lambdas/document-processor-v2/processors/__tests__/chunk-text.test.ts
+++ b/infra/lambdas/document-processor-v2/processors/__tests__/chunk-text.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Unit tests for chunkText forward-progress / termination (REV-COR-406).
+ *
+ * Both OfficeProcessor.chunkText and TextProcessor.chunkText previously looped forever
+ * when the sentence/line break fell within `overlap` chars of the chunk start, because
+ * `startIndex = endIndex - overlap` moved the window backward (even negative) and the
+ * termination guard only checked `startIndex >= endIndex`.
+ */
+
+import { OfficeProcessor } from '../office-processor';
+import { TextProcessor } from '../text-processor';
+
+const config = { enableOCR: false, convertToMarkdown: false, extractImages: false, generateEmbeddings: true };
+
+type Chunk = { chunkIndex: number; content: string; metadata: { startIndex: number; endIndex: number } };
+
+const officeChunk = (text: string): Promise<Chunk[]> =>
+  (new OfficeProcessor('docx', config) as unknown as { chunkText: (t: string) => Promise<Chunk[]> }).chunkText(text);
+const textChunk = (text: string): Promise<Chunk[]> =>
+  (new TextProcessor(config) as unknown as { chunkText: (t: string) => Promise<Chunk[]> }).chunkText(text);
+
+// chunkSize 2000, overlap 200 → each iteration advances >= (2000 - 200) on the normal
+// path, so the number of chunks is bounded well under this ceiling.
+const MAX_CHUNKS = (len: number) => Math.ceil(len / (2000 - 200)) + 2;
+
+describe('chunkText terminates on pathological input (REV-COR-406)', () => {
+  const pathological = 'A.' + 'x'.repeat(5000); // only break char is '.' at index 1
+
+  it('OfficeProcessor terminates and returns a bounded number of chunks', async () => {
+    const chunks = await officeChunk(pathological);
+    expect(chunks.length).toBeGreaterThan(0);
+    expect(chunks.length).toBeLessThanOrEqual(MAX_CHUNKS(pathological.length));
+  });
+
+  it('TextProcessor terminates for an early-newline input', async () => {
+    const earlyNewline = 'A\n' + 'y'.repeat(5000);
+    const chunks = await textChunk(earlyNewline);
+    expect(chunks.length).toBeGreaterThan(0);
+    expect(chunks.length).toBeLessThanOrEqual(MAX_CHUNKS(earlyNewline.length));
+  });
+
+  it('startIndex never regresses — each chunk starts after the previous one', async () => {
+    const chunks = await officeChunk(pathological);
+    for (let i = 1; i < chunks.length; i++) {
+      expect(chunks[i].metadata.startIndex).toBeGreaterThan(chunks[i - 1].metadata.startIndex);
+      expect(chunks[i].metadata.startIndex).toBeGreaterThanOrEqual(0);
+    }
+  });
+});
+
+describe('chunkText normal-text behavior is unchanged (REV-COR-406)', () => {
+  it('overlaps consecutive chunks by ~200 chars on normal multi-sentence text', async () => {
+    // Build ~5000 chars of normal sentences.
+    const text = ('The quick brown fox jumps over the lazy dog. ').repeat(120);
+    const chunks = await officeChunk(text);
+    expect(chunks.length).toBeGreaterThan(1);
+    // Advancement is (endIndex - overlap): the next start is ~overlap before the prev end.
+    for (let i = 1; i < chunks.length; i++) {
+      const advance = chunks[i].metadata.startIndex - chunks[i - 1].metadata.startIndex;
+      expect(advance).toBeGreaterThan(0);
+      expect(advance).toBeLessThanOrEqual(2000); // never more than a chunk
+    }
+  });
+});

--- a/infra/lambdas/document-processor-v2/processors/__tests__/office-processor-docx-parse.test.ts
+++ b/infra/lambdas/document-processor-v2/processors/__tests__/office-processor-docx-parse.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Unit tests for OfficeProcessor.processDocx single-parse behavior (REV-PERF-032):
+ * mammoth.convertToHtml must only run when markdown conversion is requested.
+ */
+
+jest.mock('mammoth', () => ({
+  extractRawText: jest.fn(),
+  convertToHtml: jest.fn(),
+}));
+
+import * as mammoth from 'mammoth';
+import { OfficeProcessor } from '../office-processor';
+
+const mockExtract = mammoth.extractRawText as unknown as jest.Mock;
+const mockHtml = mammoth.convertToHtml as unknown as jest.Mock;
+
+const processDocx = (proc: OfficeProcessor, buf: Buffer): Promise<{ text: string; html?: string }> =>
+  (proc as unknown as { processDocx: (b: Buffer) => Promise<{ text: string; html?: string }> }).processDocx(buf);
+
+describe('processDocx (REV-PERF-032)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockExtract.mockResolvedValue({ value: 'the extracted text', messages: [] });
+    mockHtml.mockResolvedValue({ value: '<p>the html</p>' });
+  });
+
+  it('does NOT call convertToHtml on the text-only path', async () => {
+    const proc = new OfficeProcessor('docx', {
+      enableOCR: false, convertToMarkdown: false, extractImages: false, generateEmbeddings: false,
+    });
+
+    const result = await processDocx(proc, Buffer.from('x'));
+
+    expect(mockExtract).toHaveBeenCalledTimes(1);
+    expect(mockHtml).not.toHaveBeenCalled();
+    expect(result.text).toBe('the extracted text');
+    expect(result.html).toBeUndefined();
+  });
+
+  it('calls both parses when markdown IS requested', async () => {
+    const proc = new OfficeProcessor('docx', {
+      enableOCR: false, convertToMarkdown: true, extractImages: false, generateEmbeddings: false,
+    });
+
+    const result = await processDocx(proc, Buffer.from('x'));
+
+    expect(mockExtract).toHaveBeenCalledTimes(1);
+    expect(mockHtml).toHaveBeenCalledTimes(1);
+    expect(result.text).toBe('the extracted text');
+    expect(result.html).toBe('<p>the html</p>');
+  });
+});

--- a/infra/lambdas/document-processor-v2/processors/__tests__/office-processor-extraction.test.ts
+++ b/infra/lambdas/document-processor-v2/processors/__tests__/office-processor-extraction.test.ts
@@ -49,6 +49,24 @@ describe('processPptx slide enumeration (REV-COR-413)', () => {
   });
 });
 
+describe('convertPptxToMarkdown slide heading numbering (REV-INFRA-098)', () => {
+  const proc = new OfficeProcessor('pptx', config);
+  const convertMarkdown = (content: unknown): Promise<string> =>
+    (proc as unknown as { convertToMarkdown: (c: unknown, t: string) => Promise<string> })
+      .convertToMarkdown(content, 'pptx');
+
+  it('labels headings with the real slide id, not its array position, when numbering has a gap', async () => {
+    const buf = await pptxBuffer([1, 2, 4]); // slide3 deleted → gap
+    const extracted = await processPptx(proc, buf);
+    const markdown = await convertMarkdown(extracted);
+
+    expect(markdown).toContain('## Slide 1');
+    expect(markdown).toContain('## Slide 2');
+    expect(markdown).toContain('## Slide 4'); // would have been "## Slide 3" with index + 1
+    expect(markdown).not.toContain('## Slide 3');
+  });
+});
+
 describe('convertDocxToMarkdown newline preservation (REV-COR-408)', () => {
   const proc = new OfficeProcessor('docx', config);
   const convert = (content: unknown): string =>

--- a/infra/lambdas/document-processor-v2/processors/__tests__/office-processor-extraction.test.ts
+++ b/infra/lambdas/document-processor-v2/processors/__tests__/office-processor-extraction.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Unit tests for OfficeProcessor PPTX slide enumeration (REV-COR-413) and DOCX→Markdown
+ * newline preservation (REV-COR-408).
+ */
+
+import JSZip from 'jszip';
+import { OfficeProcessor } from '../office-processor';
+
+const config = { enableOCR: false, convertToMarkdown: true, extractImages: false, generateEmbeddings: false };
+
+function slideXml(text: string): string {
+  return `<p:sld><p:cSld><p:spTree><p:sp><p:txBody><a:p><a:r><a:t>${text}</a:t></a:r></a:p></p:txBody></p:sp></p:spTree></p:cSld></p:sld>`;
+}
+
+async function pptxBuffer(slideNumbers: number[]): Promise<Buffer> {
+  const zip = new JSZip();
+  for (const n of slideNumbers) {
+    zip.file(`ppt/slides/slide${n}.xml`, slideXml(`Slide ${n} content`));
+  }
+  return zip.generateAsync({ type: 'nodebuffer' });
+}
+
+const processPptx = (proc: OfficeProcessor, buf: Buffer): Promise<{ text: string; slides: Array<{ id: number }> }> =>
+  (proc as unknown as { processPptx: (b: Buffer) => Promise<{ text: string; slides: Array<{ id: number }> }> }).processPptx(buf);
+
+describe('processPptx slide enumeration (REV-COR-413)', () => {
+  const proc = new OfficeProcessor('pptx', config);
+
+  it('extracts all slides even when the numbering has a gap (1, 2, 4)', async () => {
+    const buf = await pptxBuffer([1, 2, 4]); // slide3 deleted → gap
+    const result = await processPptx(proc, buf);
+
+    expect(result.text).toContain('Slide 1 content');
+    expect(result.text).toContain('Slide 2 content');
+    expect(result.text).toContain('Slide 4 content'); // would have been dropped by the old loop
+    expect(result.slides.map((s) => s.id)).toEqual([1, 2, 4]);
+  });
+
+  it('extracts contiguous slides in order (regression)', async () => {
+    const buf = await pptxBuffer([1, 2, 3]);
+    const result = await processPptx(proc, buf);
+    expect(result.slides.map((s) => s.id)).toEqual([1, 2, 3]);
+  });
+
+  it('handles out-of-order archive entries by sorting numerically', async () => {
+    const buf = await pptxBuffer([4, 1, 2]); // inserted out of order
+    const result = await processPptx(proc, buf);
+    expect(result.slides.map((s) => s.id)).toEqual([1, 2, 4]);
+  });
+});
+
+describe('convertDocxToMarkdown newline preservation (REV-COR-408)', () => {
+  const proc = new OfficeProcessor('docx', config);
+  const convert = (content: unknown): string =>
+    (proc as unknown as { convertDocxToMarkdown: (c: unknown) => string }).convertDocxToMarkdown(content);
+
+  it('keeps heading and body on separate lines', () => {
+    const md = convert({ html: '<h2>Heading</h2><p>Body paragraph</p>' });
+    expect(md).toContain('\n');
+    // Heading marker at the start of a line.
+    expect(md.split('\n')[0]).toBe('## Heading');
+    expect(md).toContain('Body paragraph');
+    // Not flattened to a single line.
+    expect(md).not.toBe('## Heading Body paragraph');
+  });
+
+  it('still neutralizes injected script markup in the output', () => {
+    const md = convert({ html: '<h2>Title</h2><p>ok</p><script>alert(1)</script>' });
+    expect(md).not.toContain('<script>');
+    expect(md).toContain('## Title');
+  });
+});

--- a/infra/lambdas/document-processor-v2/processors/__tests__/office-processor-xlsx-truncation.test.ts
+++ b/infra/lambdas/document-processor-v2/processors/__tests__/office-processor-xlsx-truncation.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Unit tests for XLSX row-truncation surfacing (REV-INFRA-099).
+ *
+ * processXlsx caps parsing at MAX_XLSX_ROWS_PARSE (10,000) rows per sheet via the
+ * `sheetRows` option. A sheet that hits the cap must be flagged as truncated rather
+ * than reporting a partial row/text subset as if it were the complete sheet.
+ */
+
+import * as XLSX from '@e965/xlsx';
+import { OfficeProcessor } from '../office-processor';
+
+const config = { enableOCR: false, convertToMarkdown: true, extractImages: false, generateEmbeddings: false };
+
+function xlsxBuffer(rowCount: number): Buffer {
+  const rows = Array.from({ length: rowCount }, (_, i) => [`row${i}`]);
+  const worksheet = XLSX.utils.aoa_to_sheet(rows);
+  const workbook = XLSX.utils.book_new();
+  XLSX.utils.book_append_sheet(workbook, worksheet, 'Sheet1');
+  return XLSX.write(workbook, { type: 'buffer', bookType: 'xlsx' }) as Buffer;
+}
+
+type XlsxResult = {
+  text: string;
+  sheets: Array<{ rowCount: number; truncated: boolean }>;
+  metadata: { anySheetTruncated: boolean };
+};
+
+const processXlsx = (proc: OfficeProcessor, buf: Buffer): Promise<XlsxResult> =>
+  (proc as unknown as { processXlsx: (b: Buffer) => Promise<XlsxResult> }).processXlsx(buf);
+
+const convertMarkdown = (proc: OfficeProcessor, content: unknown): Promise<string> =>
+  (proc as unknown as { convertToMarkdown: (c: unknown, t: string) => Promise<string> })
+    .convertToMarkdown(content, 'xlsx');
+
+describe('processXlsx row-cap truncation (REV-INFRA-099)', () => {
+  const proc = new OfficeProcessor('xlsx', config);
+
+  it('flags a sheet as truncated when it hits the parse-time row cap', async () => {
+    const buf = xlsxBuffer(10005);
+    const result = await processXlsx(proc, buf);
+
+    expect(result.sheets[0].truncated).toBe(true);
+    expect(result.metadata.anySheetTruncated).toBe(true);
+    expect(result.text).toContain('parsing stopped');
+  });
+
+  it('does not flag a small sheet as truncated', async () => {
+    const buf = xlsxBuffer(50);
+    const result = await processXlsx(proc, buf);
+
+    expect(result.sheets[0].truncated).toBe(false);
+    expect(result.metadata.anySheetTruncated).toBe(false);
+    expect(result.text).not.toContain('parsing stopped');
+  });
+
+  it('surfaces the truncation warning in the generated markdown', async () => {
+    const buf = xlsxBuffer(10005);
+    const extracted = await processXlsx(proc, buf);
+    const markdown = await convertMarkdown(proc, extracted);
+
+    expect(markdown).toContain('true count unknown');
+  });
+});

--- a/infra/lambdas/document-processor-v2/processors/office-processor.ts
+++ b/infra/lambdas/document-processor-v2/processors/office-processor.ts
@@ -16,6 +16,7 @@ interface XlsxSheetData {
   json: unknown[][];
   rowCount: number;
   columnCount: number;
+  truncated: boolean;
 }
 
 interface XlsxContent {
@@ -171,7 +172,15 @@ export class OfficeProcessor implements DocumentProcessor {
       const json = XLSX.utils.sheet_to_json(sheet, { header: 1 }) as unknown[][];
 
       const safeSheetName = OfficeProcessor.sanitizeSheetName(sheetName);
+      // A row count that hits the parse-time cap doesn't mean the sheet HAS exactly
+      // that many rows — it means parsing stopped there, so the true count is unknown
+      // (REV-INFRA-099). Surface that rather than silently reporting a row/text subset
+      // as if it were the complete sheet.
+      const truncated = json.length >= OfficeProcessor.MAX_XLSX_ROWS_PARSE;
       combinedText += `\n\n## Sheet: ${safeSheetName}\n${csv}`;
+      if (truncated) {
+        combinedText += `\n\n> ⚠️ This sheet has ${OfficeProcessor.MAX_XLSX_ROWS_PARSE}+ rows; parsing stopped at the ${OfficeProcessor.MAX_XLSX_ROWS_PARSE}-row cap. The content and row count above are incomplete.`;
+      }
 
       sheetData.push({
         name: sheetName,
@@ -179,13 +188,14 @@ export class OfficeProcessor implements DocumentProcessor {
         csv,
         json,
         rowCount: json.length,
+        truncated,
         // Cap spread to avoid stack overflow on sheets with thousands of columns
         columnCount: json.length > 0
           ? Math.min(10000, Math.max(0, ...json.map((row) => Array.isArray(row) ? row.length : 0)))
           : 0,
       });
     });
-    
+
     return {
       text: combinedText.trim(),
       sheets: sheetData,
@@ -193,6 +203,8 @@ export class OfficeProcessor implements DocumentProcessor {
         sheetCount: workbook.SheetNames.length,
         sheetNames: workbook.SheetNames,
         totalRows: sheetData.reduce((sum, sheet) => sum + sheet.rowCount, 0),
+        // True total may be higher than totalRows above — see per-sheet `truncated`.
+        anySheetTruncated: sheetData.some((sheet) => sheet.truncated),
       }
     };
   }
@@ -427,7 +439,10 @@ export class OfficeProcessor implements DocumentProcessor {
           }
         }
 
-        markdown += `\n**Sheet Stats:** ${sheet.rowCount} rows, ${sheet.columnCount} columns\n\n`;
+        const rowStats = sheet.truncated
+          ? `${sheet.rowCount}+ rows (parsing capped here — true count unknown)`
+          : `${sheet.rowCount} rows`;
+        markdown += `\n**Sheet Stats:** ${rowStats}, ${sheet.columnCount} columns\n\n`;
       });
     }
 
@@ -439,9 +454,13 @@ export class OfficeProcessor implements DocumentProcessor {
     
     // Use structured slide data from node-pptx-parser if available
     if (content.slides && Array.isArray(content.slides)) {
-      content.slides.forEach((slide: any, index: number) => {
+      content.slides.forEach((slide: any) => {
         if (slide.text && slide.text.length > 0) {
-          markdown += `## Slide ${index + 1}\n\n`;
+          // Use the slide's actual archive-derived id (REV-COR-413), not its position in
+          // the array — when slide numbering has a gap (slide1, slide2, slide4), `index`
+          // would mislabel slide 4 as "Slide 3" here even though `combinedText` and
+          // `slides[].id` both correctly show 4.
+          markdown += `## Slide ${slide.id}\n\n`;
           
           // Join slide text with proper formatting
           const slideContent = slide.text.join('\n').trim();

--- a/infra/lambdas/document-processor-v2/processors/office-processor.ts
+++ b/infra/lambdas/document-processor-v2/processors/office-processor.ts
@@ -9,34 +9,7 @@ import * as XLSX from '@e965/xlsx';
 import JSZip from 'jszip';
 import { parseString } from 'xml2js';
 import { createLambdaLogger } from '../utils/lambda-logger';
-
-/**
- * Securely removes HTML tags to prevent injection attacks.
- *
- * Order matters: decode entities FIRST so that double-encoded sequences
- * (e.g. &amp;lt;script&amp;gt;) are resolved before tag stripping, preventing
- * double-decode bypass attacks (CLAUDE.md: use single-pass entity decode).
- */
-function sanitizeHTML(html: string): string {
-  // Step 1: Decode entities in a single pass with a lookup table to prevent
-  // the double-decode bypass that chained .replace() calls allow.
-  const entityMap: Record<string, string> = {
-    '&lt;': '<',
-    '&gt;': '>',
-    '&quot;': '"',
-    '&#x27;': "'",
-    '&#39;': "'",
-    '&amp;': '&',
-  };
-  let sanitized = html.replace(/&(?:lt|gt|quot|#x27|#39|amp);/g, (m) => entityMap[m] ?? m);
-
-  // Step 2: Strip all HTML tags in a single pass (no loop needed — global replace
-  // removes all non-overlapping tag matches in one sweep, avoiding O(n²) behaviour).
-  sanitized = sanitized.replace(/<[^>]*>/g, ' ');
-
-  // Step 3: Clean up whitespace
-  return sanitized.replace(/\s+/g, ' ').trim();
-}
+import { sanitizeHtml } from '../utils/html-sanitizer';
 
 interface XlsxSheetData {
   name: unknown;
@@ -137,16 +110,30 @@ export class OfficeProcessor implements DocumentProcessor {
   private async processDocx(buffer: Buffer): Promise<any> {
     const logger = createLambdaLogger({ operation: 'OfficeProcessor.processDocx' });
     logger.info('Processing DOCX document');
-    
-    // Extract raw text
+
+    // mammoth.convertToHtml re-unzips and fully re-parses the DOCX; its output is only
+    // consumed by convertDocxToMarkdown. Skip it entirely on the common text-only path,
+    // and when markdown IS requested run both parses concurrently (REV-PERF-032).
+    if (this.config.convertToMarkdown) {
+      const [textResult, htmlResult] = await Promise.all([
+        mammoth.extractRawText({ buffer }),
+        mammoth.convertToHtml({ buffer }),
+      ]);
+      return {
+        text: textResult.value,
+        html: htmlResult.value,
+        metadata: {
+          messages: textResult.messages,
+          wordCount: textResult.value.split(/\s+/).length,
+          characterCount: textResult.value.length,
+        }
+      };
+    }
+
     const textResult = await mammoth.extractRawText({ buffer });
-    
-    // Also extract with HTML for better structure understanding
-    const htmlResult = await mammoth.convertToHtml({ buffer });
-    
     return {
       text: textResult.value,
-      html: htmlResult.value,
+      html: undefined,
       metadata: {
         messages: textResult.messages,
         wordCount: textResult.value.split(/\s+/).length,
@@ -221,26 +208,34 @@ export class OfficeProcessor implements DocumentProcessor {
       
       // Extract text from all slides
       const slides: any[] = [];
-      let slideIndex = 1;
       let combinedText = '';
-      
-      // Process slides sequentially
-      while (true) {
-        const slideFile = zipData.file(`ppt/slides/slide${slideIndex}.xml`);
-        if (!slideFile) break;
-        
+
+      // Enumerate the slide entries actually present in the archive, sorted by their
+      // numeric index (REV-COR-413). PPTX does not guarantee contiguous slide file
+      // numbering — deleting a slide can leave a gap (slide1, slide2, slide4) — so
+      // the old `while(true)` that broke at the first missing index silently dropped
+      // every slide after a gap.
+      const slideNames = Object.keys(zipData.files)
+        .filter((name) => /^ppt\/slides\/slide\d+\.xml$/.test(name))
+        .sort((a, b) =>
+          Number(a.match(/slide(\d+)\.xml$/)![1]) - Number(b.match(/slide(\d+)\.xml$/)![1])
+        );
+
+      for (const name of slideNames) {
+        const slideFile = zipData.file(name);
+        if (!slideFile) continue;
+
+        const slideNumber = Number(name.match(/slide(\d+)\.xml$/)![1]);
         const slideXml = await slideFile.async('text');
-        const slideText = await this.extractTextFromSlideXml(slideXml, slideIndex);
-        
+        const slideText = await this.extractTextFromSlideXml(slideXml, slideNumber);
+
         if (slideText && slideText.length > 0) {
           slides.push({
-            id: slideIndex,
+            id: slideNumber,
             text: slideText
           });
-          combinedText += `\n\n## Slide ${slideIndex}\n\n${slideText.join('\n')}`;
+          combinedText += `\n\n## Slide ${slideNumber}\n\n${slideText.join('\n')}`;
         }
-        
-        slideIndex++;
       }
       
       if (slides.length === 0) {
@@ -367,9 +362,12 @@ export class OfficeProcessor implements DocumentProcessor {
           .replace(/<\/em>/g, '*')
           .replace(/<br[^>]*>/g, '\n')
           .replace(/\n{3,}/g, '\n\n'); // Clean up excessive newlines
-        
-        // Apply secure HTML sanitization to prevent injection attacks
-        const sanitizedMarkdown = sanitizeHTML(markdown);
+
+        // Apply secure HTML sanitization to prevent injection attacks. Preserve
+        // newlines (REV-COR-408) so the paragraph/heading structure just built above
+        // survives — the default sanitizer collapses every \n into a space, which
+        // flattened DOCX markdown to a single line.
+        const sanitizedMarkdown = sanitizeHtml(markdown, { preserveNewlines: true });
         return sanitizedMarkdown.trim();
       } catch (error) {
         const logger = createLambdaLogger({ operation: 'OfficeProcessor.convertDocxToMarkdown' });
@@ -520,16 +518,18 @@ export class OfficeProcessor implements DocumentProcessor {
     while (startIndex < text.length) {
       let endIndex = Math.min(startIndex + chunkSize, text.length);
       
-      // Try to break at sentence boundary
+      // Try to break at a sentence boundary — but only when the break still leaves
+      // a chunk larger than the overlap. Otherwise `endIndex - overlap` would move
+      // the next window BACKWARD and the loop would never terminate (REV-COR-406).
       if (endIndex < text.length) {
         const lastSentenceEnd = text.lastIndexOf('.', endIndex);
-        if (lastSentenceEnd > startIndex) {
+        if (lastSentenceEnd > startIndex && (lastSentenceEnd + 1 - startIndex) > overlap) {
           endIndex = lastSentenceEnd + 1;
         }
       }
-      
+
       const chunkContent = text.substring(startIndex, endIndex).trim();
-      
+
       if (chunkContent.length > 0) {
         chunks.push({
           chunkIndex,
@@ -543,9 +543,17 @@ export class OfficeProcessor implements DocumentProcessor {
         });
         chunkIndex++;
       }
-      
-      startIndex = endIndex - overlap;
-      if (startIndex >= endIndex) break;
+
+      // Once a chunk reaches the end of the text, everything is covered — stop
+      // (REV-COR-406). Without this the loop would keep emitting tiny overlapping
+      // tail windows because `endIndex - overlap` sits behind `startIndex` near the end.
+      if (endIndex >= text.length) break;
+
+      // Advance with guaranteed forward progress (REV-COR-406): never regress and
+      // always move at least one character past the previous start.
+      const nextStart = Math.max(startIndex + 1, endIndex - overlap);
+      if (nextStart <= startIndex) break; // defensive; should be unreachable
+      startIndex = nextStart;
     }
     
     const logger = createLambdaLogger({ operation: 'OfficeProcessor.chunkText' });

--- a/infra/lambdas/document-processor-v2/processors/text-processor.ts
+++ b/infra/lambdas/document-processor-v2/processors/text-processor.ts
@@ -8,38 +8,11 @@ import { parse as csvParse } from 'csv-parse/sync';
 import { marked } from 'marked';
 import { createLambdaLogger } from '../utils/lambda-logger';
 import { sanitizeTextWithMetrics } from '../../../../lib/utils/text-sanitizer';
-
-/**
- * Securely removes HTML tags to prevent injection attacks
- * This function handles malformed HTML and prevents bypassing attempts
- */
-function sanitizeHTML(html: string): string {
-  // First, iteratively remove HTML tags until none remain
-  // This prevents bypassing through nested or malformed tags
-  let sanitized = html;
-  let previousLength = 0;
-  
-  while (sanitized.length !== previousLength && /<[^>]*>/g.test(sanitized)) {
-    previousLength = sanitized.length;
-    sanitized = sanitized.replace(/<[^>]*>/g, ' ');
-  }
-  
-  // AFTER tags are removed, safely decode HTML entities (prevents security bypass)
-  sanitized = sanitized
-    .replace(/&lt;/g, '<')
-    .replace(/&gt;/g, '>')
-    .replace(/&quot;/g, '"')
-    .replace(/&#x27;/g, "'")
-    .replace(/&#39;/g, "'")
-    .replace(/&amp;/g, '&');
-  
-  // Clean up extra whitespace created by tag removal
-  sanitized = sanitized
-    .replace(/\s+/g, ' ')
-    .trim();
-    
-  return sanitized;
-}
+// REV-COR-409 / REV-INFRA-094: use the shared decode-first sanitizer. TextProcessor's
+// own copy stripped tags BEFORE decoding entities, so entity-encoded markup
+// (&lt;script&gt;) round-tripped into live <script>. Both processors now share one
+// correct implementation.
+import { sanitizeHtml } from '../utils/html-sanitizer';
 
 export class TextProcessor implements DocumentProcessor {
   constructor(private config: ProcessorConfig) {}
@@ -202,7 +175,7 @@ export class TextProcessor implements DocumentProcessor {
     try {
       // Convert markdown to plain text for text field
       const html = await marked.parse(content);
-      const plainText = sanitizeHTML(html).trim();
+      const plainText = sanitizeHtml(html).trim();
       
       return {
         text: plainText,
@@ -444,19 +417,21 @@ export class TextProcessor implements DocumentProcessor {
     while (startIndex < text.length) {
       let endIndex = Math.min(startIndex + chunkSize, text.length);
       
-      // Try to break at sentence or line boundary
+      // Try to break at a sentence or line boundary — but only when the break still
+      // leaves a chunk larger than the overlap. Otherwise `endIndex - overlap` would
+      // move the next window BACKWARD and the loop would never terminate (REV-COR-406).
       if (endIndex < text.length) {
         const lastSentenceEnd = text.lastIndexOf('.', endIndex);
         const lastLineEnd = text.lastIndexOf('\n', endIndex);
         const breakPoint = Math.max(lastSentenceEnd, lastLineEnd);
-        
-        if (breakPoint > startIndex) {
+
+        if (breakPoint > startIndex && (breakPoint + 1 - startIndex) > overlap) {
           endIndex = breakPoint + 1;
         }
       }
-      
+
       const chunkContent = text.substring(startIndex, endIndex).trim();
-      
+
       if (chunkContent.length > 0) {
         chunks.push({
           chunkIndex,
@@ -470,9 +445,17 @@ export class TextProcessor implements DocumentProcessor {
         });
         chunkIndex++;
       }
-      
-      startIndex = endIndex - overlap;
-      if (startIndex >= endIndex) break;
+
+      // Once a chunk reaches the end of the text, everything is covered — stop
+      // (REV-COR-406). Without this the loop would keep emitting tiny overlapping
+      // tail windows because `endIndex - overlap` sits behind `startIndex` near the end.
+      if (endIndex >= text.length) break;
+
+      // Advance with guaranteed forward progress (REV-COR-406): never regress and
+      // always move at least one character past the previous start.
+      const nextStart = Math.max(startIndex + 1, endIndex - overlap);
+      if (nextStart <= startIndex) break; // defensive; should be unreachable
+      startIndex = nextStart;
     }
     
     const logger = createLambdaLogger({ operation: 'TextProcessor.chunkText' });

--- a/infra/lambdas/document-processor-v2/utils/__tests__/html-sanitizer.test.ts
+++ b/infra/lambdas/document-processor-v2/utils/__tests__/html-sanitizer.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Unit tests for the shared HTML sanitizer (REV-COR-409 / REV-INFRA-094 / REV-COR-408).
+ *
+ * Run via: cd infra && jest lambdas/document-processor-v2 (ts-jest)
+ */
+
+import { sanitizeHtml } from '../html-sanitizer';
+
+describe('sanitizeHtml — decode-first bypass (REV-COR-409 / REV-INFRA-094)', () => {
+  it('does not re-introduce <script> from entity-encoded input', () => {
+    const out = sanitizeHtml('&lt;script&gt;alert(1)&lt;/script&gt;');
+    expect(out).not.toContain('<script>');
+    expect(out).not.toContain('</script>');
+    expect(out).not.toContain('<');
+    expect(out).not.toContain('>');
+    // The inert text survives, but not as live markup.
+    expect(out).toContain('alert(1)');
+  });
+
+  it('does not re-introduce <img onerror> from entity-encoded input', () => {
+    const out = sanitizeHtml('&lt;img src=x onerror=alert(1)&gt;');
+    expect(out).not.toContain('<img');
+    expect(out).not.toContain('<');
+  });
+
+  it('strips live tags and keeps their text', () => {
+    expect(sanitizeHtml('<b>bold</b> text')).toBe('bold text');
+  });
+
+  it('resolves double-encoded sequences without producing live markup', () => {
+    // &amp;lt; decodes to &lt; (a literal, not a tag opener).
+    const out = sanitizeHtml('&amp;lt;script&amp;gt;');
+    expect(out).not.toContain('<script>');
+  });
+
+  it('passes plain text through unchanged', () => {
+    expect(sanitizeHtml('just some words')).toBe('just some words');
+  });
+});
+
+describe('sanitizeHtml — preserveNewlines (REV-COR-408)', () => {
+  it('keeps block breaks when preserveNewlines is set', () => {
+    const out = sanitizeHtml('## Heading\n\nBody paragraph', { preserveNewlines: true });
+    expect(out).toContain('\n');
+    // Heading marker stays at the start of a line.
+    expect(out.split('\n')[0]).toBe('## Heading');
+    expect(out).toContain('Body paragraph');
+  });
+
+  it('collapses all whitespace (including newlines) by default', () => {
+    expect(sanitizeHtml('## Heading\n\nBody')).toBe('## Heading Body');
+  });
+
+  it('still strips tags in preserveNewlines mode', () => {
+    const out = sanitizeHtml('# Title\n\n<script>alert(1)</script>text', { preserveNewlines: true });
+    expect(out).not.toContain('<script>');
+    expect(out).toContain('# Title');
+  });
+});

--- a/infra/lambdas/document-processor-v2/utils/__tests__/html-sanitizer.test.ts
+++ b/infra/lambdas/document-processor-v2/utils/__tests__/html-sanitizer.test.ts
@@ -36,6 +36,28 @@ describe('sanitizeHtml — decode-first bypass (REV-COR-409 / REV-INFRA-094)', (
   it('passes plain text through unchanged', () => {
     expect(sanitizeHtml('just some words')).toBe('just some words');
   });
+
+  it('does not re-introduce <script> from decimal-entity-encoded input (REV-INFRA-096)', () => {
+    // &#60; = '<', &#62; = '>' — a numeric-entity bypass of the old named-only decoder.
+    const out = sanitizeHtml('&#60;script&#62;alert(1)&#60;/script&#62;');
+    expect(out).not.toContain('<script>');
+    expect(out).not.toContain('<');
+    expect(out).not.toContain('>');
+    expect(out).toContain('alert(1)');
+  });
+
+  it('does not re-introduce <script> from hex-entity-encoded input (REV-INFRA-096)', () => {
+    // &#x3c; = '<', &#x3e; = '>'
+    const out = sanitizeHtml('&#x3c;script&#x3e;alert(1)&#x3c;/script&#x3e;');
+    expect(out).not.toContain('<script>');
+    expect(out).not.toContain('<');
+    expect(out).not.toContain('>');
+    expect(out).toContain('alert(1)');
+  });
+
+  it('leaves an unrecognized or malformed entity untouched', () => {
+    expect(sanitizeHtml('AT&T; &nosuchentity; &#zzz;')).toBe('AT&T; &nosuchentity; &#zzz;');
+  });
 });
 
 describe('sanitizeHtml — preserveNewlines (REV-COR-408)', () => {

--- a/infra/lambdas/document-processor-v2/utils/__tests__/lambda-logger.test.ts
+++ b/infra/lambdas/document-processor-v2/utils/__tests__/lambda-logger.test.ts
@@ -35,6 +35,12 @@ describe('LambdaLogger.sanitizeData (REV-INFRA-095)', () => {
     expect(sanitize('processing document report.pdf')).toBe('processing document report.pdf');
   });
 
+  it('redacts quoted keys/values in serialized JSON-like strings (REV-INFRA-096)', () => {
+    expect(sanitize('"token": "supersecret"')).toBe('"token": "[REDACTED]"');
+    expect(sanitize("token='supersecret'")).toBe("token='[REDACTED]'");
+    expect(sanitize('{"apiKey":"sk-abc123"}')).toBe('{"apiKey":"[REDACTED]"}');
+  });
+
   it('does not pollute Object.prototype from a __proto__ key', () => {
     const payload = JSON.parse('{"__proto__": {"polluted": true}, "safe": 1}');
     const out = sanitize(payload);

--- a/infra/lambdas/document-processor-v2/utils/__tests__/lambda-logger.test.ts
+++ b/infra/lambdas/document-processor-v2/utils/__tests__/lambda-logger.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Unit tests for LambdaLogger.sanitizeData value redaction + proto safety (REV-INFRA-095).
+ */
+
+import { createLambdaLogger } from '../lambda-logger';
+
+// sanitizeData is private; access it through a cast for unit testing.
+const sanitize = (data: unknown): any =>
+  (createLambdaLogger() as unknown as { sanitizeData: (d: unknown) => any }).sanitizeData(data);
+
+describe('LambdaLogger.sanitizeData (REV-INFRA-095)', () => {
+  it('redacts the VALUE of a sensitive key, not the key name', () => {
+    expect(sanitize({ apiToken: 'abc123' })).toEqual({ apiToken: '[REDACTED]' });
+    expect(sanitize({ password: 'hunter2' })).toEqual({ password: '[REDACTED]' });
+    expect(sanitize({ secretKey: 'sk-1' })).toEqual({ secretKey: '[REDACTED]' });
+    expect(sanitize({ authorization: 'Bearer x' })).toEqual({ authorization: '[REDACTED]' });
+  });
+
+  it('does not over-redact benign keys containing "key" as a substring', () => {
+    expect(sanitize({ s3Key: 'conversations/abc/x.png' })).toEqual({ s3Key: 'conversations/abc/x.png' });
+    expect(sanitize({ chunkKey: 'chunk-1' })).toEqual({ chunkKey: 'chunk-1' });
+    expect(sanitize({ publicKey: 'pk-1' })).toEqual({ publicKey: 'pk-1' });
+  });
+
+  it('redacts the secret VALUE inside a string, not the keyword', () => {
+    const out = sanitize('Authorization: Bearer abc123.def');
+    expect(out).not.toContain('abc123.def');
+    // The keyword name is preserved (not masked as the old regex did).
+    expect(out).toContain('Authorization');
+    expect(out).toContain('[REDACTED]');
+    expect(sanitize('token=supersecret')).toBe('token=[REDACTED]');
+  });
+
+  it('does not mangle a plain string with no key=value secret', () => {
+    expect(sanitize('processing document report.pdf')).toBe('processing document report.pdf');
+  });
+
+  it('does not pollute Object.prototype from a __proto__ key', () => {
+    const payload = JSON.parse('{"__proto__": {"polluted": true}, "safe": 1}');
+    const out = sanitize(payload);
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+    expect((Object.prototype as Record<string, unknown>).polluted).toBeUndefined();
+    expect(out.safe).toBe(1);
+  });
+
+  it('recurses into nested objects and arrays', () => {
+    expect(sanitize({ outer: { apiKey: 'k', name: 'ok' } })).toEqual({
+      outer: { apiKey: '[REDACTED]', name: 'ok' },
+    });
+    expect(sanitize([{ password: 'p' }])).toEqual([{ password: '[REDACTED]' }]);
+  });
+});

--- a/infra/lambdas/document-processor-v2/utils/html-sanitizer.ts
+++ b/infra/lambdas/document-processor-v2/utils/html-sanitizer.ts
@@ -1,0 +1,49 @@
+/**
+ * Shared HTML sanitizer for document-processor-v2 (REV-COR-409 / REV-INFRA-094).
+ *
+ * Both OfficeProcessor and TextProcessor previously defined their own `sanitizeHTML`
+ * with OPPOSITE orderings — OfficeProcessor decoded entities first (correct) while
+ * TextProcessor stripped tags first and decoded after (a double-decode bypass that
+ * let entity-encoded markup like `&lt;script&gt;` round-trip into live `<script>`).
+ * This single canonical implementation removes that divergence and is kept inside the
+ * Lambda package so it never crosses the Code.fromAsset boundary (REV-INFRA-092).
+ *
+ * Order (security-critical):
+ *   1. single-pass entity decode (lookup table — never chained .replace())
+ *   2. strip all `<...>` tags in one global pass
+ *   3. whitespace cleanup
+ *
+ * `preserveNewlines` (REV-COR-408): keep line breaks so DOCX-derived Markdown retains
+ * its paragraph/heading structure instead of collapsing to a single line.
+ */
+
+const ENTITY_MAP: Record<string, string> = {
+  '&lt;': '<',
+  '&gt;': '>',
+  '&quot;': '"',
+  '&#x27;': "'",
+  '&#39;': "'",
+  '&amp;': '&',
+};
+
+export function sanitizeHtml(html: string, opts?: { preserveNewlines?: boolean }): string {
+  // Step 1: decode entities FIRST, in one pass, so entity-encoded markup is resolved
+  // before tag stripping (prevents the strip-then-decode bypass).
+  let sanitized = html.replace(/&(?:lt|gt|quot|#x27|#39|amp);/g, (m) => ENTITY_MAP[m] ?? m);
+
+  // Step 2: strip all HTML tags in a single global pass (global replace removes every
+  // non-overlapping match in one sweep — no loop, no O(n^2)).
+  sanitized = sanitized.replace(/<[^>]*>/g, ' ');
+
+  // Step 3: whitespace cleanup.
+  if (opts?.preserveNewlines) {
+    // Collapse horizontal whitespace runs to a single space but keep newlines; trim
+    // spaces around each newline and collapse 3+ blank lines to one.
+    return sanitized
+      .replace(/[^\S\n]+/g, ' ')
+      .replace(/ *\n */g, '\n')
+      .replace(/\n{3,}/g, '\n\n')
+      .trim();
+  }
+  return sanitized.replace(/\s+/g, ' ').trim();
+}

--- a/infra/lambdas/document-processor-v2/utils/html-sanitizer.ts
+++ b/infra/lambdas/document-processor-v2/utils/html-sanitizer.ts
@@ -9,27 +9,39 @@
  * Lambda package so it never crosses the Code.fromAsset boundary (REV-INFRA-092).
  *
  * Order (security-critical):
- *   1. single-pass entity decode (lookup table — never chained .replace())
+ *   1. single-pass entity decode — named, decimal (&#60;), and hexadecimal (&#x3c;)
+ *      (lookup table for named entities — never chained .replace())
  *   2. strip all `<...>` tags in one global pass
  *   3. whitespace cleanup
+ *
+ * Decoding only named entities let numeric-encoded tags (e.g. `&#60;script&#62;`)
+ * bypass tag-stripping entirely — the sanitizer would pass them through as harmless
+ * text, but a downstream HTML renderer decodes them back into a live `<script>`.
  *
  * `preserveNewlines` (REV-COR-408): keep line breaks so DOCX-derived Markdown retains
  * its paragraph/heading structure instead of collapsing to a single line.
  */
 
-const ENTITY_MAP: Record<string, string> = {
-  '&lt;': '<',
-  '&gt;': '>',
-  '&quot;': '"',
-  '&#x27;': "'",
-  '&#39;': "'",
-  '&amp;': '&',
+const NAMED_ENTITIES: Record<string, string> = {
+  lt: '<',
+  gt: '>',
+  quot: '"',
+  apos: "'",
+  amp: '&',
 };
 
 export function sanitizeHtml(html: string, opts?: { preserveNewlines?: boolean }): string {
   // Step 1: decode entities FIRST, in one pass, so entity-encoded markup is resolved
-  // before tag stripping (prevents the strip-then-decode bypass).
-  let sanitized = html.replace(/&(?:lt|gt|quot|#x27|#39|amp);/g, (m) => ENTITY_MAP[m] ?? m);
+  // before tag stripping (prevents the strip-then-decode bypass). Handles named
+  // (&amp;), decimal (&#38;), and hexadecimal (&#x26;) forms in the same pass.
+  let sanitized = html.replace(/&(#x[0-9a-fA-F]+|#[0-9]+|[a-zA-Z][a-zA-Z0-9]*);/g, (match, body) => {
+    if (body[0] === '#') {
+      const isHex = body[1] === 'x' || body[1] === 'X';
+      const code = isHex ? parseInt(body.slice(2), 16) : parseInt(body.slice(1), 10);
+      return Number.isNaN(code) ? match : String.fromCodePoint(code);
+    }
+    return NAMED_ENTITIES[body] ?? match;
+  });
 
   // Step 2: strip all HTML tags in a single global pass (global replace removes every
   // non-overlapping match in one sweep — no loop, no O(n^2)).

--- a/infra/lambdas/document-processor-v2/utils/lambda-logger.ts
+++ b/infra/lambdas/document-processor-v2/utils/lambda-logger.ts
@@ -48,8 +48,17 @@ export class LambdaLogger {
     }
 
     if (typeof data === 'string') {
-      // Remove potentially sensitive information
-      return data.replace(/password|secret|key|token|auth/gi, '[REDACTED]');
+      // Redact secret VALUES, not the keyword names (REV-INFRA-095). The old regex
+      // replaced the literal words password/secret/key/token/auth wherever they
+      // appeared, so `Authorization: Bearer abc123` became `[REDACTED]orization:
+      // Bearer abc123` — masking a harmless word while leaking the token in full.
+      // This redacts the value after a sensitive key (`key=VALUE`, `key: VALUE`,
+      // `Authorization: Bearer VALUE`). Free-form message strings are otherwise NOT
+      // deep-scrubbed — callers must avoid interpolating secrets into messages.
+      return data.replace(
+        /\b(password|passwd|secret|token|api[_-]?key|access[_-]?key|authorization|auth[_-]?token)\b(\s*[:=]\s*)(?:bearer\s+)?[^\s"',;})&]+/gi,
+        '$1$2[REDACTED]'
+      );
     }
 
     if (Array.isArray(data)) {
@@ -57,12 +66,17 @@ export class LambdaLogger {
     }
 
     if (typeof data === 'object') {
-      const sanitized: any = {};
+      // Object.create(null) so a document-controlled `__proto__`/`constructor` key
+      // cannot pollute Object.prototype via `sanitized[key] = ...` (REV-INFRA-095).
+      const sanitized: Record<string, unknown> = Object.create(null);
       for (const [key, value] of Object.entries(data)) {
-        if (key.toLowerCase().includes('password') || 
-            key.toLowerCase().includes('secret') || 
-            key.toLowerCase().includes('key') ||
-            key.toLowerCase().includes('token')) {
+        const lower = key.toLowerCase();
+        // Redact when the KEY names a secret. Word-ish matches (not a bare `key`
+        // substring) so benign keys like s3Key / chunkKey / publicKey are not
+        // over-redacted, while `auth` is included for parity with the string branch.
+        const isSensitive =
+          LambdaLogger.SENSITIVE_KEY_RE.test(lower) || lower === 'key' || lower === 'auth';
+        if (isSensitive) {
           sanitized[key] = '[REDACTED]';
         } else {
           sanitized[key] = this.sanitizeData(value);
@@ -73,6 +87,9 @@ export class LambdaLogger {
 
     return data;
   }
+
+  private static readonly SENSITIVE_KEY_RE =
+    /password|passwd|secret|token|credential|api[_-]?key|access[_-]?key|authorization|auth[_-]?token/i;
 
   info(message: string, data?: any): void {
     // In Lambda, console.log goes to CloudWatch automatically

--- a/infra/lambdas/document-processor-v2/utils/lambda-logger.ts
+++ b/infra/lambdas/document-processor-v2/utils/lambda-logger.ts
@@ -53,11 +53,14 @@ export class LambdaLogger {
       // appeared, so `Authorization: Bearer abc123` became `[REDACTED]orization:
       // Bearer abc123` — masking a harmless word while leaking the token in full.
       // This redacts the value after a sensitive key (`key=VALUE`, `key: VALUE`,
-      // `Authorization: Bearer VALUE`). Free-form message strings are otherwise NOT
-      // deep-scrubbed — callers must avoid interpolating secrets into messages.
+      // `Authorization: Bearer VALUE`), including quoted forms common in serialized
+      // JSON/XML (`"token": "supersecret"`, `token="supersecret"`) (REV-INFRA-096) —
+      // the unquoted-only version missed these entirely. Free-form message strings
+      // are otherwise NOT deep-scrubbed — callers must avoid interpolating secrets
+      // into messages.
       return data.replace(
-        /\b(password|passwd|secret|token|api[_-]?key|access[_-]?key|authorization|auth[_-]?token)\b(\s*[:=]\s*)(?:bearer\s+)?[^\s"',;})&]+/gi,
-        '$1$2[REDACTED]'
+        /(["']?)\b(password|passwd|secret|token|api[_-]?key|access[_-]?key|authorization|auth[_-]?token)\b\1(\s*[:=]\s*)(["']?)((?:bearer\s+)?)([^\s"',;})&]+)\4/gi,
+        '$1$2$1$3$4$5[REDACTED]$4'
       );
     }
 


### PR DESCRIPTION
Batch **B-011** (`infra/lambdas/document-processor-v2`). **9 of 12** findings implemented; **3 deferred** (cross-batch build pipeline / out-of-scope reader). Lambda tests run via the infra ts-jest config (root jest excludes `/infra/`).

## Implemented (9)

### Correctness (High)
| ID | Fix |
|----|-----|
| **REV-COR-406** | `chunkText` (both processors) could loop forever when the sentence/line break fell within `overlap` of the chunk start. The advance is now `max(startIndex+1, endIndex-overlap)` (never regresses) and the loop terminates once a chunk reaches the end; the sentence break is only taken when it keeps the chunk larger than the overlap. |
| **REV-INFRA-091** | The SQS handler returned `void`, so a partial-batch failure made Lambda delete **all** messages incl. the failed ones. It now returns `{ batchItemFailures }` per failed record → those messages stay on the queue for SQS retry + DLQ redrive (queues already have `deadLetterQueue`/`maxReceiveCount`). The eager, premature manual `sendToDLQ` is removed in favor of SQS redrive. |

### Dependencies (High)
| ID | Fix |
|----|-----|
| **REV-INFRA-093** | `xml2js` (used for PPTX) was imported but missing from `package.json`. Added `xml2js` + `@types/xml2js`; import-vs-manifest audit confirms no other undeclared deps (`stream` is a Node builtin). |

### Correctness / Security (Medium)
| ID | Fix |
|----|-----|
| **REV-COR-409** / **REV-INFRA-094** | `TextProcessor.sanitizeHTML` stripped tags **before** decoding entities, so `&lt;script&gt;` round-tripped into live `<script>`. Both processors now share one canonical **decode-first single-pass** sanitizer (`utils/html-sanitizer.ts`, kept in-package). |
| **REV-COR-408** | `convertDocxToMarkdown` ran its Markdown through the newline-collapsing sanitizer, flattening DOCX output to one line. The shared sanitizer now has a `preserveNewlines` mode for the Markdown path. |
| **REV-COR-413** | `processPptx` broke at the first slide-numbering gap, dropping every later slide. It now enumerates the actual `ppt/slides/slideN.xml` entries, sorted numerically. |
| **REV-INFRA-095** | `LambdaLogger.sanitizeData` redacted keyword **names** (leaking the value). It now redacts secret **values** (`key=VALUE` / `Authorization: Bearer VALUE`), uses a word-ish key list (`s3Key`/`chunkKey`/`publicKey` not over-redacted, `auth` included), and uses `Object.create(null)` to prevent `__proto__` pollution. |

### Performance (Medium)
| ID | Fix |
|----|-----|
| **REV-PERF-032** | `processDocx` ran mammoth twice even on the text-only path. `convertToHtml` now runs only when markdown is requested, and both parses run concurrently when both are needed. |

## Deferred (3) — reported rather than exceeding scope

- **REV-COR-407** (dist never built) & **REV-INFRA-092** (cross-tree import breaks the `tsc` build): completing these requires a build step / CDK bundling in `infra/lib/document-processing-stack.ts` (**owned by B-014/B-112/B-154/B-181**) and `infra/build-lambdas.sh` (**owned by B-137**, whose `REV-INFRA-100` is that exact build wiring). Cross-batch build pipeline; INFRA-092's cross-tree import is left untouched.
- **REV-PERF-026** (per-tick job-status read-modify-write): eliminating the Query-read / single-row (Done-when items 1-2) drops `fileName`/`fileSize`/`fileType`/`purpose`/`processingOptions` on progress rows, which the out-of-scope reader (`getJobStatus` → `app/api/documents/v2/jobs/[jobId]/route.ts`) reads from the latest full-copy row. Coalescing alone doesn't satisfy items 1-2; the fix needs the reader/service coordinated — cross-file.

## Tests (6 new files — 41 assertions passing via ts-jest)
- **html-sanitizer**: decode-first bypass (no live `<script>` from entities), `preserveNewlines`.
- **chunk-text**: pathological `"A."+x*5000` / early-newline inputs terminate with bounded chunk counts, non-regressing `startIndex`; normal-text overlap unchanged.
- **lambda-logger**: value (not key) redaction; `s3Key`/`chunkKey` not over-redacted; `__proto__` payload doesn't pollute `Object.prototype`.
- **office-processor-extraction**: PPTX gap `(1,2,4)` extracts all three; DOCX markdown keeps heading/body on separate lines; script still neutralized.
- **office-processor-docx-parse**: `convertToHtml` not called on the text-only path.
- **handler**: mixed batch returns exactly the failed records' `itemIdentifier`s.

> Pre-existing/out-of-scope: `office-processor-helpers.test.ts`'s `sanitizeSheetName` case fails on `dev` independent of this batch — no B-011 finding covers `sanitizeSheetName`, so it's left untouched.

## Verification
- `bun run typecheck` (root) — **0 errors**; `bun run lint` (root) — **0 errors** (root excludes `infra`; lambda changes are type-checked + exercised by ts-jest)
- `jest lambdas/document-processor-v2` (infra ts-jest) — **41 B-011 assertions passing** (1 pre-existing unrelated failure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HWA2JRbkae8HCRsZwoEJXw