### PR TITLE
fix(B-012): secret rotation hardening

### DIFF
--- a/infra/lambdas/secret-rotation/api-key/index.py
+++ b/infra/lambdas/secret-rotation/api-key/index.py
@@ -16,6 +16,7 @@ import json
 import logging
 import boto3
 import os
+import re
 from typing import Dict, Any
 import secrets
 import string
@@ -30,6 +31,41 @@ secretsmanager = boto3.client(
 )
 
 
+def sanitize_for_logging(text: str) -> str:
+    """Redact ARNs / IPs / emails from log messages (REV-INFRA-115)."""
+    if not text:
+        return text
+    text = re.sub(r'arn:aws:[^:]+:[^:]+:\d+:[^\s]+', '[ARN_REDACTED]', text)
+    text = re.sub(r'\d+\.\d+\.\d+\.\d+', '[IP_REDACTED]', text)
+    text = re.sub(r'[\w\.-]+@[\w\.-]+\.\w+', '[EMAIL_REDACTED]', text)
+    return text
+
+
+def sanitize_error(error: Exception) -> str:
+    """Sanitize an exception message for logging (REV-INFRA-115)."""
+    return sanitize_for_logging(str(error))
+
+
+def validate_rotation_request(arn: str, token: str) -> bool:
+    """
+    AWS-standard rotation preamble guard (REV-INFRA-109). Verifies rotation is
+    enabled, the token is staged for this secret, and it is AWSPENDING (not already
+    AWSCURRENT). Returns True if the caller should short-circuit (already current).
+    """
+    metadata = secretsmanager.describe_secret(SecretId=arn)
+    if not metadata.get('RotationEnabled', False):
+        raise ValueError("Secret is not enabled for rotation")
+    versions = metadata['VersionIdsToStages']
+    if token not in versions:
+        raise ValueError("Rotation token has no stage for this secret")
+    if "AWSCURRENT" in versions[token]:
+        logger.info("Rotation token is already AWSCURRENT; nothing to do")
+        return True
+    if "AWSPENDING" not in versions[token]:
+        raise ValueError("Rotation token is not staged as AWSPENDING")
+    return False
+
+
 def handler(event: Dict[str, Any], context: Any) -> None:
     """
     Main rotation handler for API keys
@@ -38,22 +74,31 @@ def handler(event: Dict[str, Any], context: Any) -> None:
         event: Event data from Secrets Manager
         context: Lambda context object
     """
-    logger.info(f"API Key rotation event: {json.dumps(event)}")
+    # Log only the step, never the full event/ARN/ClientRequestToken (REV-INFRA-115).
+    logger.info(f"Rotation event received for step: {event.get('Step')}")
 
     arn = event['SecretId']
     token = event['ClientRequestToken']
     step = event['Step']
 
-    if step == "createSecret":
-        create_secret(arn, token)
-    elif step == "setSecret":
-        set_secret(arn, token)
-    elif step == "testSecret":
-        test_secret(arn, token)
-    elif step == "finishSecret":
-        finish_secret(arn, token)
-    else:
-        raise ValueError(f"Invalid step: {step}")
+    try:
+        # AWS-standard preamble guard before acting on the step (REV-INFRA-109).
+        if validate_rotation_request(arn, token):
+            return
+
+        if step == "createSecret":
+            create_secret(arn, token)
+        elif step == "setSecret":
+            set_secret(arn, token)
+        elif step == "testSecret":
+            test_secret(arn, token)
+        elif step == "finishSecret":
+            finish_secret(arn, token)
+        else:
+            raise ValueError(f"Invalid step: {step}")
+    except Exception as e:
+        logger.error(f"Rotation failed: {sanitize_error(e)}")
+        raise
 
 
 def create_secret(arn: str, token: str) -> None:
@@ -171,13 +216,22 @@ def finish_secret(arn: str, token: str) -> None:
             current_version = version
             break
 
-    # Move AWSCURRENT stage to new version
-    secretsmanager.update_secret_version_stage(
-        SecretId=arn,
-        VersionStage="AWSCURRENT",
-        MoveToVersionId=token,
-        RemoveFromVersionId=current_version
-    )
+    # Move AWSCURRENT stage to new version. Never pass RemoveFromVersionId=None
+    # (REV-INFRA-109).
+    if current_version is not None:
+        secretsmanager.update_secret_version_stage(
+            SecretId=arn,
+            VersionStage="AWSCURRENT",
+            MoveToVersionId=token,
+            RemoveFromVersionId=current_version
+        )
+    else:
+        logger.warning("No AWSCURRENT version found to remove; setting AWSCURRENT without removal")
+        secretsmanager.update_secret_version_stage(
+            SecretId=arn,
+            VersionStage="AWSCURRENT",
+            MoveToVersionId=token
+        )
 
     logger.info("Successfully completed rotation")
 

--- a/infra/lambdas/secret-rotation/api-key/index.py
+++ b/infra/lambdas/secret-rotation/api-key/index.py
@@ -35,7 +35,7 @@ def sanitize_for_logging(text: str) -> str:
     """Redact ARNs / IPs / emails from log messages (REV-INFRA-115)."""
     if not text:
         return text
-    text = re.sub(r'arn:aws:[^:]+:[^:]+:\d+:[^\s]+', '[ARN_REDACTED]', text)
+    text = re.sub(r'arn:aws(?:-[a-z]+)*:[^:]*:[^:]*:\d*:[^\s]+', '[ARN_REDACTED]', text)
     text = re.sub(r'\d+\.\d+\.\d+\.\d+', '[IP_REDACTED]', text)
     text = re.sub(r'[\w\.-]+@[\w\.-]+\.\w+', '[EMAIL_REDACTED]', text)
     return text
@@ -107,7 +107,7 @@ def create_secret(arn: str, token: str) -> None:
 
     Creates a cryptographically secure random API key.
     """
-    logger.info(f"Creating new API key for {arn}")
+    logger.info(f"Creating new API key for {sanitize_for_logging(arn)}")
 
     # Check if AWSPENDING version already exists
     try:
@@ -163,7 +163,7 @@ def set_secret(arn: str, token: str) -> None:
     service to update. Override this function if you need to update
     an external service.
     """
-    logger.info(f"Set secret for {arn} - no-op for simple API keys")
+    logger.info(f"Set secret for {sanitize_for_logging(arn)} - no-op for simple API keys")
     # No action needed for simple API keys
     pass
 
@@ -174,7 +174,7 @@ def test_secret(arn: str, token: str) -> None:
 
     Validates that the new API key meets format requirements.
     """
-    logger.info(f"Testing API key for {arn}")
+    logger.info(f"Testing API key for {sanitize_for_logging(arn)}")
 
     # Get pending secret
     pending_secret = secretsmanager.get_secret_value(
@@ -201,7 +201,7 @@ def finish_secret(arn: str, token: str) -> None:
     """
     Finish the rotation by moving AWSCURRENT label
     """
-    logger.info(f"Finishing rotation for {arn}")
+    logger.info(f"Finishing rotation for {sanitize_for_logging(arn)}")
 
     # Get metadata about the secret
     metadata = secretsmanager.describe_secret(SecretId=arn)

--- a/infra/lambdas/secret-rotation/custom/index.py
+++ b/infra/lambdas/secret-rotation/custom/index.py
@@ -28,6 +28,14 @@ logger.setLevel(logging.INFO)
 # Explicit opt-in for self-contained secrets (no external consumer to update). When
 # unset, the placeholder set_secret fails loudly so a real secret is not marked
 # rotated without its new value being propagated/validated (REV-INFRA-107 / OVF2).
+#
+# Scope caveat: this is a Lambda-level flag, not a per-secret one. If this handler
+# is ever reused as the rotation Lambda for two different CUSTOM/CERTIFICATE
+# secrets — one genuinely self-contained and one with an external consumer — both
+# get the same set_secret behavior. Today `ManagedSecret.createRotationLambda`
+# (infra/lib/constructs/security/managed-secret.ts) only wires SECRETS_MANAGER_ENDPOINT
+# and provisions one Lambda per secret, so this is safe; a future consumer sharing
+# this Lambda across secrets would need a per-secret mechanism instead.
 ALLOW_PLACEHOLDER_ROTATION = os.environ.get('ALLOW_PLACEHOLDER_ROTATION', '').lower() in ('1', 'true', 'yes')
 
 # Initialize AWS clients
@@ -41,7 +49,7 @@ def sanitize_for_logging(text: str) -> str:
     """Redact ARNs / IPs / emails from log messages (REV-INFRA-115)."""
     if not text:
         return text
-    text = re.sub(r'arn:aws:[^:]+:[^:]+:\d+:[^\s]+', '[ARN_REDACTED]', text)
+    text = re.sub(r'arn:aws(?:-[a-z]+)*:[^:]*:[^:]*:\d*:[^\s]+', '[ARN_REDACTED]', text)
     text = re.sub(r'\d+\.\d+\.\d+\.\d+', '[IP_REDACTED]', text)
     text = re.sub(r'[\w\.-]+@[\w\.-]+\.\w+', '[EMAIL_REDACTED]', text)
     return text
@@ -117,7 +125,7 @@ def create_secret(arn: str, token: str) -> None:
     - A new password or token
     - Custom application-specific credentials
     """
-    logger.info(f"Creating new custom secret for {arn}")
+    logger.info(f"Creating new custom secret for {sanitize_for_logging(arn)}")
 
     # Check if AWSPENDING version already exists
     try:
@@ -143,7 +151,7 @@ def create_secret(arn: str, token: str) -> None:
             VersionStage="AWSCURRENT"
         )
         try:
-            parsed = json.loads(current_secret['SecretString'])
+            parsed = json.loads(current_secret.get('SecretString', ''))
             if isinstance(parsed, dict):
                 secret_dict = parsed
             else:
@@ -224,7 +232,7 @@ def test_secret(arn: str, token: str) -> None:
     # string meeting the generator's length invariant, for either the plain-string
     # or JSON {"value": ...} shape. (For a secret with an external consumer, extend
     # this with an authenticated round-trip before promotion.)
-    raw = pending_secret['SecretString']
+    raw = pending_secret.get('SecretString', '')
     try:
         parsed = json.loads(raw)
         value = parsed.get('value') if isinstance(parsed, dict) else parsed
@@ -241,7 +249,7 @@ def finish_secret(arn: str, token: str) -> None:
     """
     Step 4: Finish the rotation by moving AWSCURRENT label
     """
-    logger.info(f"Finishing rotation for {arn}")
+    logger.info(f"Finishing rotation for {sanitize_for_logging(arn)}")
 
     # Get metadata about the secret
     metadata = secretsmanager.describe_secret(SecretId=arn)

--- a/infra/lambdas/secret-rotation/custom/index.py
+++ b/infra/lambdas/secret-rotation/custom/index.py
@@ -17,6 +17,7 @@ import json
 import logging
 import boto3
 import os
+import re
 from typing import Dict, Any
 import secrets
 import string
@@ -24,11 +25,51 @@ import string
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
 
+# Explicit opt-in for self-contained secrets (no external consumer to update). When
+# unset, the placeholder set_secret fails loudly so a real secret is not marked
+# rotated without its new value being propagated/validated (REV-INFRA-107 / OVF2).
+ALLOW_PLACEHOLDER_ROTATION = os.environ.get('ALLOW_PLACEHOLDER_ROTATION', '').lower() in ('1', 'true', 'yes')
+
 # Initialize AWS clients
 secretsmanager = boto3.client(
     'secretsmanager',
     endpoint_url=os.environ.get('SECRETS_MANAGER_ENDPOINT')
 )
+
+
+def sanitize_for_logging(text: str) -> str:
+    """Redact ARNs / IPs / emails from log messages (REV-INFRA-115)."""
+    if not text:
+        return text
+    text = re.sub(r'arn:aws:[^:]+:[^:]+:\d+:[^\s]+', '[ARN_REDACTED]', text)
+    text = re.sub(r'\d+\.\d+\.\d+\.\d+', '[IP_REDACTED]', text)
+    text = re.sub(r'[\w\.-]+@[\w\.-]+\.\w+', '[EMAIL_REDACTED]', text)
+    return text
+
+
+def sanitize_error(error: Exception) -> str:
+    """Sanitize an exception message for logging (REV-INFRA-115)."""
+    return sanitize_for_logging(str(error))
+
+
+def validate_rotation_request(arn: str, token: str) -> bool:
+    """
+    AWS-standard rotation preamble guard (REV-INFRA-109). Verifies rotation is
+    enabled, the token is staged for this secret, and it is AWSPENDING (not already
+    AWSCURRENT). Returns True if the caller should short-circuit (already current).
+    """
+    metadata = secretsmanager.describe_secret(SecretId=arn)
+    if not metadata.get('RotationEnabled', False):
+        raise ValueError("Secret is not enabled for rotation")
+    versions = metadata['VersionIdsToStages']
+    if token not in versions:
+        raise ValueError("Rotation token has no stage for this secret")
+    if "AWSCURRENT" in versions[token]:
+        logger.info("Rotation token is already AWSCURRENT; nothing to do")
+        return True
+    if "AWSPENDING" not in versions[token]:
+        raise ValueError("Rotation token is not staged as AWSPENDING")
+    return False
 
 
 def handler(event: Dict[str, Any], context: Any) -> None:
@@ -39,22 +80,31 @@ def handler(event: Dict[str, Any], context: Any) -> None:
         event: Event data from Secrets Manager
         context: Lambda context object
     """
-    logger.info(f"Custom rotation event: {json.dumps(event)}")
+    # Log only the step, never the full event/ARN/ClientRequestToken (REV-INFRA-115).
+    logger.info(f"Rotation event received for step: {event.get('Step')}")
 
     arn = event['SecretId']
     token = event['ClientRequestToken']
     step = event['Step']
 
-    if step == "createSecret":
-        create_secret(arn, token)
-    elif step == "setSecret":
-        set_secret(arn, token)
-    elif step == "testSecret":
-        test_secret(arn, token)
-    elif step == "finishSecret":
-        finish_secret(arn, token)
-    else:
-        raise ValueError(f"Invalid step: {step}")
+    try:
+        # AWS-standard preamble guard before acting on the step (REV-INFRA-109).
+        if validate_rotation_request(arn, token):
+            return
+
+        if step == "createSecret":
+            create_secret(arn, token)
+        elif step == "setSecret":
+            set_secret(arn, token)
+        elif step == "testSecret":
+            test_secret(arn, token)
+        elif step == "finishSecret":
+            finish_secret(arn, token)
+        else:
+            raise ValueError(f"Invalid step: {step}")
+    except Exception as e:
+        logger.error(f"Rotation failed: {sanitize_error(e)}")
+        raise
 
 
 def create_secret(arn: str, token: str) -> None:
@@ -81,39 +131,46 @@ def create_secret(arn: str, token: str) -> None:
     except secretsmanager.exceptions.ResourceNotFoundException:
         pass
 
-    # Get current secret to preserve structure
+    # Preserve the current secret's SHAPE across rotation (REV-INFRA-107): a
+    # plain-string secret must stay a plain string, and a JSON secret keeps its
+    # other fields. The old code coerced a plain string into {'value': ...} (and
+    # replaced the whole dict when 'value' was absent, dropping sibling fields).
+    current_is_json = True
+    secret_dict: Dict[str, Any] = {}
     try:
         current_secret = secretsmanager.get_secret_value(
             SecretId=arn,
             VersionStage="AWSCURRENT"
         )
-        secret_dict = json.loads(current_secret['SecretString'])
-    except (secretsmanager.exceptions.ResourceNotFoundException, json.JSONDecodeError):
-        # No current version or not JSON, create new structure
-        secret_dict = {}
+        try:
+            parsed = json.loads(current_secret['SecretString'])
+            if isinstance(parsed, dict):
+                secret_dict = parsed
+            else:
+                current_is_json = False
+        except json.JSONDecodeError:
+            current_is_json = False
+    except secretsmanager.exceptions.ResourceNotFoundException:
+        # No current version — default to a JSON {"value": ...} structure.
+        current_is_json = True
 
-    # Generate new secret value
-    # TODO: Customize this based on your secret type
-    # Examples:
-    # - For certificates: Generate new certificate from CA
-    # - For encryption keys: Generate cryptographically secure random key
-    # - For service credentials: Create new credentials in target service
-
-    # Default: Generate secure random string
+    # Default: generate a cryptographically secure random string. (TODO: customize
+    # per secret type — e.g. mint a certificate from a CA, or a KMS key — when this
+    # handler is used for something other than a self-contained random value.)
     new_secret_value = generate_secure_secret(length=64)
 
-    # Update or set the secret value
-    # Customize the field name based on your secret structure
-    if 'value' in secret_dict:
+    if current_is_json:
         secret_dict['value'] = new_secret_value
+        new_secret_string = json.dumps(secret_dict)
     else:
-        secret_dict = {'value': new_secret_value}
+        # Plain-string secret — keep it a plain string.
+        new_secret_string = new_secret_value
 
     # Put new secret version
     secretsmanager.put_secret_value(
         SecretId=arn,
         ClientRequestToken=token,
-        SecretString=json.dumps(secret_dict),
+        SecretString=new_secret_string,
         VersionStages=['AWSPENDING']
     )
 
@@ -122,37 +179,23 @@ def create_secret(arn: str, token: str) -> None:
 
 def set_secret(arn: str, token: str) -> None:
     """
-    Step 2: Set the new secret in the target service
+    Step 2: Set the new secret in the target service.
 
-    Update the target service with the new secret value.
-
-    TODO: Implement service-specific update logic here.
-    Examples:
-    - Update application configuration
-    - Update service account credentials
-    - Deploy new certificate to servers
-    - Update encryption keys in key management system
+    This handler cannot push the new value to an external consumer. For a secret
+    with an external consumer, implement service-specific propagation here. For a
+    SELF-CONTAINED secret (no external consumer to update), set the
+    ALLOW_PLACEHOLDER_ROTATION env var to opt in — set_secret is then a documented
+    no-op. Otherwise it fails loudly, so the rotation does not silently promote a
+    value that was never propagated to its consumer (REV-INFRA-107 / REV-COR-435-OVF2).
     """
-    logger.info(f"Set secret for {arn}")
+    if not ALLOW_PLACEHOLDER_ROTATION:
+        raise NotImplementedError(
+            "Custom secret set_secret is not implemented for an external consumer. "
+            "Implement service-specific propagation, or set ALLOW_PLACEHOLDER_ROTATION=true "
+            "to declare this secret self-contained (no external consumer to update)."
+        )
 
-    # Get pending secret
-    pending_secret = secretsmanager.get_secret_value(
-        SecretId=arn,
-        VersionId=token,
-        VersionStage="AWSPENDING"
-    )
-
-    pending_dict = json.loads(pending_secret['SecretString'])
-
-    # TODO: Implement your custom logic to update the target service
-    # For example:
-    # - Call an API to update the secret
-    # - Update a configuration file
-    # - Deploy to servers
-    # - Update database records
-
-    logger.warning("Using placeholder set_secret - implement service-specific logic")
-    logger.info(f"Set secret completed for {arn}")
+    logger.info("set_secret is a documented no-op (self-contained secret; ALLOW_PLACEHOLDER_ROTATION set)")
 
 
 def test_secret(arn: str, token: str) -> None:
@@ -168,7 +211,7 @@ def test_secret(arn: str, token: str) -> None:
     - Test encryption/decryption with new key
     - Validate secret format and structure
     """
-    logger.info(f"Testing custom secret for {arn}")
+    logger.info("Validating new custom secret")
 
     # Get pending secret
     pending_secret = secretsmanager.get_secret_value(
@@ -177,20 +220,20 @@ def test_secret(arn: str, token: str) -> None:
         VersionStage="AWSPENDING"
     )
 
-    pending_dict = json.loads(pending_secret['SecretString'])
+    # Real format validation of the rotated value (REV-INFRA-107): a non-empty
+    # string meeting the generator's length invariant, for either the plain-string
+    # or JSON {"value": ...} shape. (For a secret with an external consumer, extend
+    # this with an authenticated round-trip before promotion.)
+    raw = pending_secret['SecretString']
+    try:
+        parsed = json.loads(raw)
+        value = parsed.get('value') if isinstance(parsed, dict) else parsed
+    except json.JSONDecodeError:
+        value = raw
 
-    # Basic validation: ensure secret has required structure
-    if not pending_dict or 'value' not in pending_dict:
-        raise ValueError("Custom secret missing required 'value' field")
+    if not isinstance(value, str) or len(value) < 32:
+        raise ValueError("Rotated custom secret value is missing or too short")
 
-    # TODO: Implement your custom validation logic here
-    # Examples:
-    # - Test authentication with new credentials
-    # - Verify certificate chain
-    # - Test encryption with new key
-    # - Make test API call
-
-    logger.warning("Using placeholder test_secret - implement service-specific validation")
     logger.info("Successfully validated new custom secret")
 
 
@@ -213,13 +256,22 @@ def finish_secret(arn: str, token: str) -> None:
             current_version = version
             break
 
-    # Move AWSCURRENT stage to new version
-    secretsmanager.update_secret_version_stage(
-        SecretId=arn,
-        VersionStage="AWSCURRENT",
-        MoveToVersionId=token,
-        RemoveFromVersionId=current_version
-    )
+    # Move AWSCURRENT stage to new version. Never pass RemoveFromVersionId=None
+    # (REV-INFRA-109).
+    if current_version is not None:
+        secretsmanager.update_secret_version_stage(
+            SecretId=arn,
+            VersionStage="AWSCURRENT",
+            MoveToVersionId=token,
+            RemoveFromVersionId=current_version
+        )
+    else:
+        logger.warning("No AWSCURRENT version found to remove; setting AWSCURRENT without removal")
+        secretsmanager.update_secret_version_stage(
+            SecretId=arn,
+            VersionStage="AWSCURRENT",
+            MoveToVersionId=token
+        )
 
     logger.info("Successfully completed custom secret rotation")
 

--- a/infra/lambdas/secret-rotation/database/index.py
+++ b/infra/lambdas/secret-rotation/database/index.py
@@ -54,7 +54,7 @@ def sanitize_for_logging(text: str) -> str:
         return text
 
     # Remove ARNs
-    text = re.sub(r'arn:aws:[^:]+:[^:]+:\d+:[^\s]+', '[ARN_REDACTED]', text)
+    text = re.sub(r'arn:aws(?:-[a-z]+)*:[^:]*:[^:]*:\d*:[^\s]+', '[ARN_REDACTED]', text)
     # Remove IP addresses
     text = re.sub(r'\d+\.\d+\.\d+\.\d+', '[IP_REDACTED]', text)
     # Remove email addresses
@@ -149,7 +149,7 @@ def create_secret(arn: str, token: str) -> None:
 
     Generates a new random password and stores it as AWSPENDING.
     """
-    logger.info(f"Creating new secret version for {arn}")
+    logger.info(f"Creating new secret version for {sanitize_for_logging(arn)}")
 
     # Check if AWSPENDING version already exists
     try:
@@ -199,7 +199,7 @@ def set_secret(arn: str, token: str) -> None:
 
     Updates the database user's password to match the AWSPENDING secret.
     """
-    logger.info(f"Setting secret in database for {arn}")
+    logger.info(f"Setting secret in database for {sanitize_for_logging(arn)}")
 
     # Get pending secret
     pending_secret = secretsmanager.get_secret_value(
@@ -251,7 +251,7 @@ def test_secret(arn: str, token: str) -> None:
 
     Attempts to connect to the database using the AWSPENDING credentials.
     """
-    logger.info(f"Testing secret for {arn}")
+    logger.info(f"Testing secret for {sanitize_for_logging(arn)}")
 
     # Get pending secret
     pending_secret = secretsmanager.get_secret_value(
@@ -286,7 +286,7 @@ def finish_secret(arn: str, token: str) -> None:
 
     Moves the AWSCURRENT label to the AWSPENDING version.
     """
-    logger.info(f"Finishing rotation for {arn}")
+    logger.info(f"Finishing rotation for {sanitize_for_logging(arn)}")
 
     # Get metadata about the secret
     metadata = secretsmanager.describe_secret(SecretId=arn)

--- a/infra/lambdas/secret-rotation/database/index.py
+++ b/infra/lambdas/secret-rotation/database/index.py
@@ -77,6 +77,33 @@ def sanitize_error(error: Exception) -> str:
     return sanitize_for_logging(error_str)
 
 
+def validate_rotation_request(arn: str, token: str) -> bool:
+    """
+    AWS-standard rotation preamble guard (REV-INFRA-109).
+
+    Verifies the secret has rotation enabled, the ClientRequestToken is actually
+    staged for this secret, and it is AWSPENDING (not already AWSCURRENT). Without
+    these checks the handler would act on out-of-order/stale invocations or on a
+    version Secrets Manager does not expect.
+
+    Returns:
+        True if the caller should short-circuit (token already AWSCURRENT).
+    """
+    metadata = secretsmanager.describe_secret(SecretId=arn)
+    if not metadata.get('RotationEnabled', False):
+        raise ValueError("Secret is not enabled for rotation")
+
+    versions = metadata['VersionIdsToStages']
+    if token not in versions:
+        raise ValueError("Rotation token has no stage for this secret")
+    if "AWSCURRENT" in versions[token]:
+        logger.info("Rotation token is already AWSCURRENT; nothing to do")
+        return True
+    if "AWSPENDING" not in versions[token]:
+        raise ValueError("Rotation token is not staged as AWSPENDING")
+    return False
+
+
 def handler(event: Dict[str, Any], context: Any) -> None:
     """
     Main rotation handler invoked by Secrets Manager
@@ -96,6 +123,10 @@ def handler(event: Dict[str, Any], context: Any) -> None:
     step = event['Step']
 
     try:
+        # AWS-standard preamble guard before acting on the step (REV-INFRA-109).
+        if validate_rotation_request(arn, token):
+            return
+
         # Dispatch to appropriate step handler
         if step == "createSecret":
             create_secret(arn, token)
@@ -143,7 +174,7 @@ def create_secret(arn: str, token: str) -> None:
     # Generate new password
     password_response = secretsmanager.get_random_password(
         PasswordLength=32,
-        ExcludeCharacters='/@"\'\\'',
+        ExcludeCharacters='/@"\'\\',
         ExcludePunctuation=False,
         RequireEachIncludedType=True
     )
@@ -271,13 +302,23 @@ def finish_secret(arn: str, token: str) -> None:
             current_version = version
             break
 
-    # Move AWSCURRENT stage to new version
-    secretsmanager.update_secret_version_stage(
-        SecretId=arn,
-        VersionStage="AWSCURRENT",
-        MoveToVersionId=token,
-        RemoveFromVersionId=current_version
-    )
+    # Move AWSCURRENT stage to new version. Never pass RemoveFromVersionId=None —
+    # if no AWSCURRENT version was found, omit it rather than sending an invalid
+    # argument to the API (REV-INFRA-109).
+    if current_version is not None:
+        secretsmanager.update_secret_version_stage(
+            SecretId=arn,
+            VersionStage="AWSCURRENT",
+            MoveToVersionId=token,
+            RemoveFromVersionId=current_version
+        )
+    else:
+        logger.warning("No AWSCURRENT version found to remove; setting AWSCURRENT without removal")
+        secretsmanager.update_secret_version_stage(
+            SecretId=arn,
+            VersionStage="AWSCURRENT",
+            MoveToVersionId=token
+        )
 
     logger.info("Successfully completed rotation")
 
@@ -297,11 +338,19 @@ def get_database_connection(secret_dict: Dict[str, Any]) -> Any:
     Returns:
         Database connection object
     """
+    # Require TLS on the rotation connection (REV-COR-435-OVF1 / REV-INFRA-108).
+    # libpq's default sslmode is 'prefer', which silently falls back to an
+    # UNENCRYPTED connection — over which set_secret transmits the freshly rotated
+    # ALTER USER password. Aurora/RDS accept TLS; 'require' guarantees encryption.
+    # Overridable via the secret's own `sslmode` for non-TLS targets, but the
+    # default enforces encryption.
+    sslmode = secret_dict.get('sslmode', 'require')
     return psycopg2.connect(
         host=secret_dict['host'],
         port=secret_dict.get('port', 5432),
         user=secret_dict['username'],
         password=secret_dict['password'],
         database=secret_dict.get('database', 'postgres'),
+        sslmode=sslmode,
         connect_timeout=5
     )

--- a/infra/lambdas/secret-rotation/oauth/index.py
+++ b/infra/lambdas/secret-rotation/oauth/index.py
@@ -29,7 +29,7 @@ def sanitize_for_logging(text: str) -> str:
     """Redact ARNs / IPs / emails from log messages (REV-INFRA-115)."""
     if not text:
         return text
-    text = re.sub(r'arn:aws:[^:]+:[^:]+:\d+:[^\s]+', '[ARN_REDACTED]', text)
+    text = re.sub(r'arn:aws(?:-[a-z]+)*:[^:]*:[^:]*:\d*:[^\s]+', '[ARN_REDACTED]', text)
     text = re.sub(r'\d+\.\d+\.\d+\.\d+', '[IP_REDACTED]', text)
     text = re.sub(r'[\w\.-]+@[\w\.-]+\.\w+', '[EMAIL_REDACTED]', text)
     return text
@@ -126,7 +126,7 @@ def set_secret(arn: str, token: str) -> None:
     is obtained from the provider and doesn't need to be "set"
     anywhere else.
     """
-    logger.info(f"Set secret for {arn} - no-op for OAuth tokens")
+    logger.info(f"Set secret for {sanitize_for_logging(arn)} - no-op for OAuth tokens")
     # OAuth tokens don't typically need to be set anywhere
     # They're retrieved from the provider and stored in Secrets Manager
     pass
@@ -139,7 +139,7 @@ def test_secret(arn: str, token: str) -> None:
     Validates that the new token works by making a test API call
     to the OAuth provider.
     """
-    logger.info(f"Testing OAuth token for {arn}")
+    logger.info(f"Testing OAuth token for {sanitize_for_logging(arn)}")
 
     # Get pending secret
     pending_secret = secretsmanager.get_secret_value(
@@ -168,7 +168,7 @@ def finish_secret(arn: str, token: str) -> None:
     """
     Step 4: Finish the rotation by moving AWSCURRENT label
     """
-    logger.info(f"Finishing rotation for {arn}")
+    logger.info(f"Finishing rotation for {sanitize_for_logging(arn)}")
 
     # Get metadata about the secret
     metadata = secretsmanager.describe_secret(SecretId=arn)

--- a/infra/lambdas/secret-rotation/oauth/index.py
+++ b/infra/lambdas/secret-rotation/oauth/index.py
@@ -12,6 +12,7 @@ import json
 import logging
 import boto3
 import os
+import re
 from typing import Dict, Any
 
 logger = logging.getLogger()
@@ -24,6 +25,41 @@ secretsmanager = boto3.client(
 )
 
 
+def sanitize_for_logging(text: str) -> str:
+    """Redact ARNs / IPs / emails from log messages (REV-INFRA-115)."""
+    if not text:
+        return text
+    text = re.sub(r'arn:aws:[^:]+:[^:]+:\d+:[^\s]+', '[ARN_REDACTED]', text)
+    text = re.sub(r'\d+\.\d+\.\d+\.\d+', '[IP_REDACTED]', text)
+    text = re.sub(r'[\w\.-]+@[\w\.-]+\.\w+', '[EMAIL_REDACTED]', text)
+    return text
+
+
+def sanitize_error(error: Exception) -> str:
+    """Sanitize an exception message for logging (REV-INFRA-115)."""
+    return sanitize_for_logging(str(error))
+
+
+def validate_rotation_request(arn: str, token: str) -> bool:
+    """
+    AWS-standard rotation preamble guard (REV-INFRA-109). Verifies rotation is
+    enabled, the token is staged for this secret, and it is AWSPENDING (not already
+    AWSCURRENT). Returns True if the caller should short-circuit (already current).
+    """
+    metadata = secretsmanager.describe_secret(SecretId=arn)
+    if not metadata.get('RotationEnabled', False):
+        raise ValueError("Secret is not enabled for rotation")
+    versions = metadata['VersionIdsToStages']
+    if token not in versions:
+        raise ValueError("Rotation token has no stage for this secret")
+    if "AWSCURRENT" in versions[token]:
+        logger.info("Rotation token is already AWSCURRENT; nothing to do")
+        return True
+    if "AWSPENDING" not in versions[token]:
+        raise ValueError("Rotation token is not staged as AWSPENDING")
+    return False
+
+
 def handler(event: Dict[str, Any], context: Any) -> None:
     """
     Main rotation handler for OAuth secrets
@@ -32,76 +68,54 @@ def handler(event: Dict[str, Any], context: Any) -> None:
         event: Event data from Secrets Manager
         context: Lambda context object
     """
-    logger.info(f"OAuth rotation event: {json.dumps(event)}")
+    # Log only the step, never the full event/ARN/ClientRequestToken (REV-INFRA-115).
+    logger.info(f"Rotation event received for step: {event.get('Step')}")
 
     arn = event['SecretId']
     token = event['ClientRequestToken']
     step = event['Step']
 
-    if step == "createSecret":
-        create_secret(arn, token)
-    elif step == "setSecret":
-        set_secret(arn, token)
-    elif step == "testSecret":
-        test_secret(arn, token)
-    elif step == "finishSecret":
-        finish_secret(arn, token)
-    else:
-        raise ValueError(f"Invalid step: {step}")
+    try:
+        # AWS-standard preamble guard before acting on the step (REV-INFRA-109).
+        if validate_rotation_request(arn, token):
+            return
+
+        if step == "createSecret":
+            create_secret(arn, token)
+        elif step == "setSecret":
+            set_secret(arn, token)
+        elif step == "testSecret":
+            test_secret(arn, token)
+        elif step == "finishSecret":
+            finish_secret(arn, token)
+        else:
+            raise ValueError(f"Invalid step: {step}")
+    except Exception as e:
+        logger.error(f"Rotation failed: {sanitize_error(e)}")
+        raise
 
 
 def create_secret(arn: str, token: str) -> None:
     """
-    Step 1: Create new OAuth credentials
+    Step 1: Create new OAuth credentials.
 
-    For OAuth tokens, this typically involves using a refresh token
-    to obtain new access tokens from the OAuth provider.
+    A real implementation must use the stored refresh_token to obtain a NEW
+    access_token from the OAuth provider. There is NO safe placeholder for OAuth:
+    the previous behaviour copied the current secret verbatim into AWSPENDING, so
+    Secrets Manager reported a successful rotation while the token never changed —
+    resetting the rotation clock and suppressing the rotation-failure alarm
+    (REV-INFRA-106 / REV-COR-435-OVF2).
+
+    Until provider-specific refresh is implemented, fail loudly so the rotation
+    surfaces as an error instead of silently promoting an AWSPENDING version whose
+    material is identical to AWSCURRENT.
     """
-    logger.info(f"Creating new OAuth token for {arn}")
-
-    # Check if AWSPENDING version already exists
-    try:
-        secretsmanager.get_secret_value(
-            SecretId=arn,
-            VersionId=token,
-            VersionStage="AWSPENDING"
-        )
-        logger.info("OAuth token version already exists, skipping creation")
-        return
-    except secretsmanager.exceptions.ResourceNotFoundException:
-        pass
-
-    # Get current secret
-    current_secret = secretsmanager.get_secret_value(
-        SecretId=arn,
-        VersionStage="AWSCURRENT"
+    logger.error("OAuth rotation is not implemented; refusing to promote an unchanged token")
+    raise NotImplementedError(
+        "OAuth secret rotation is not implemented. A provider-specific refresh-token "
+        "exchange that mints a new access_token is required before this secret can be "
+        "rotated. Implement the provider integration or disable rotation for this secret."
     )
-
-    secret_dict = json.loads(current_secret['SecretString'])
-
-    # TODO: Implement OAuth token refresh logic here
-    # This should use the refresh_token to get new access_token
-    # Example structure:
-    # {
-    #   "access_token": "new_access_token",
-    #   "refresh_token": "refresh_token",
-    #   "expires_in": 3600,
-    #   "token_type": "Bearer"
-    # }
-
-    # For now, we'll just copy the current secret as a placeholder
-    # In production, replace this with actual OAuth refresh logic
-    logger.warning("Using placeholder rotation - implement OAuth provider-specific logic")
-
-    # Put new secret version
-    secretsmanager.put_secret_value(
-        SecretId=arn,
-        ClientRequestToken=token,
-        SecretString=json.dumps(secret_dict),
-        VersionStages=['AWSPENDING']
-    )
-
-    logger.info("Successfully created new OAuth token version (placeholder)")
 
 
 def set_secret(arn: str, token: str) -> None:
@@ -169,12 +183,21 @@ def finish_secret(arn: str, token: str) -> None:
             current_version = version
             break
 
-    # Move AWSCURRENT stage to new version
-    secretsmanager.update_secret_version_stage(
-        SecretId=arn,
-        VersionStage="AWSCURRENT",
-        MoveToVersionId=token,
-        RemoveFromVersionId=current_version
-    )
+    # Move AWSCURRENT stage to new version. Never pass RemoveFromVersionId=None
+    # (REV-INFRA-109).
+    if current_version is not None:
+        secretsmanager.update_secret_version_stage(
+            SecretId=arn,
+            VersionStage="AWSCURRENT",
+            MoveToVersionId=token,
+            RemoveFromVersionId=current_version
+        )
+    else:
+        logger.warning("No AWSCURRENT version found to remove; setting AWSCURRENT without removal")
+        secretsmanager.update_secret_version_stage(
+            SecretId=arn,
+            VersionStage="AWSCURRENT",
+            MoveToVersionId=token
+        )
 
     logger.info("Successfully completed OAuth token rotation")

--- a/infra/lambdas/secret-rotation/tests/test_rotation_handlers.py
+++ b/infra/lambdas/secret-rotation/tests/test_rotation_handlers.py
@@ -248,7 +248,7 @@ def test_sanitize_for_logging_redacts_arn(mod):
     assert "[ARN_REDACTED]" in out
 
 
-@pytest.mark.parametrize("mod", [OAUTH, CUSTOM, APIKEY])
+@pytest.mark.parametrize("mod", ALL)
 def test_handler_logs_step_not_full_arn(mod, caplog):
     sm = make_sm()
     # short-circuit via the guard (token already AWSCURRENT) to avoid the full flow

--- a/infra/lambdas/secret-rotation/tests/test_rotation_handlers.py
+++ b/infra/lambdas/secret-rotation/tests/test_rotation_handlers.py
@@ -1,0 +1,270 @@
+"""
+Unit tests for the secret-rotation handlers (batch B-012).
+
+Covers:
+- REV-INFRA-109: AWS-standard step/stage guard + finish_secret None-guard (all four).
+- REV-INFRA-106 / REV-COR-435-OVF2: oauth create_secret fails loudly (no identical-material promotion).
+- REV-INFRA-107 / REV-COR-435-OVF2: custom set_secret gated, test_secret real validation, shape preserved.
+- REV-COR-435-OVF1 / REV-INFRA-108: database connection enforces TLS (sslmode=require).
+- REV-INFRA-115: handlers redact ARNs and log only the step, not the full event.
+
+Run: cd infra/lambdas/secret-rotation && uvx --with boto3 --with pytest pytest tests/
+"""
+
+import importlib.util
+import json
+import logging
+import os
+import sys
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+os.environ.setdefault("AWS_DEFAULT_REGION", "us-east-1")
+
+# The database handler imports psycopg2 at module load; mock it before loading so the
+# tests don't need the native binary. `from psycopg2 import sql` needs the submodule.
+_psycopg2 = mock.MagicMock()
+sys.modules["psycopg2"] = _psycopg2
+sys.modules["psycopg2.sql"] = _psycopg2.sql
+
+_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _load(name: str, subdir: str):
+    spec = importlib.util.spec_from_file_location(name, _ROOT / subdir / "index.py")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+DB = _load("rot_database", "database")
+OAUTH = _load("rot_oauth", "oauth")
+CUSTOM = _load("rot_custom", "custom")
+APIKEY = _load("rot_apikey", "api-key")
+
+ALL = [DB, OAUTH, CUSTOM, APIKEY]
+
+
+class _RNFE(Exception):
+    """Stand-in for secretsmanager.exceptions.ResourceNotFoundException."""
+
+
+def make_sm():
+    sm = mock.MagicMock()
+    sm.exceptions.ResourceNotFoundException = _RNFE
+    return sm
+
+
+# --------------------------------------------------------------------------------------
+# REV-INFRA-109 — step/stage guard
+# --------------------------------------------------------------------------------------
+
+@pytest.mark.parametrize("mod", ALL)
+def test_guard_rejects_when_rotation_disabled(mod):
+    mod.secretsmanager = make_sm()
+    mod.secretsmanager.describe_secret.return_value = {"RotationEnabled": False, "VersionIdsToStages": {}}
+    with pytest.raises(ValueError):
+        mod.validate_rotation_request("arn", "tok")
+
+
+@pytest.mark.parametrize("mod", ALL)
+def test_guard_rejects_token_not_pending(mod):
+    mod.secretsmanager = make_sm()
+    mod.secretsmanager.describe_secret.return_value = {
+        "RotationEnabled": True,
+        "VersionIdsToStages": {"tok": ["AWSPREVIOUS"]},  # not AWSPENDING
+    }
+    with pytest.raises(ValueError):
+        mod.validate_rotation_request("arn", "tok")
+
+
+@pytest.mark.parametrize("mod", ALL)
+def test_guard_rejects_token_unknown(mod):
+    mod.secretsmanager = make_sm()
+    mod.secretsmanager.describe_secret.return_value = {
+        "RotationEnabled": True,
+        "VersionIdsToStages": {"other": ["AWSPENDING"]},
+    }
+    with pytest.raises(ValueError):
+        mod.validate_rotation_request("arn", "tok")
+
+
+@pytest.mark.parametrize("mod", ALL)
+def test_guard_short_circuits_when_already_current(mod):
+    mod.secretsmanager = make_sm()
+    mod.secretsmanager.describe_secret.return_value = {
+        "RotationEnabled": True,
+        "VersionIdsToStages": {"tok": ["AWSCURRENT"]},
+    }
+    assert mod.validate_rotation_request("arn", "tok") is True
+
+
+@pytest.mark.parametrize("mod", ALL)
+def test_guard_allows_pending_token(mod):
+    mod.secretsmanager = make_sm()
+    mod.secretsmanager.describe_secret.return_value = {
+        "RotationEnabled": True,
+        "VersionIdsToStages": {"tok": ["AWSPENDING"]},
+    }
+    assert mod.validate_rotation_request("arn", "tok") is False
+
+
+# --------------------------------------------------------------------------------------
+# REV-INFRA-109 — finish_secret never passes RemoveFromVersionId=None
+# --------------------------------------------------------------------------------------
+
+@pytest.mark.parametrize("mod", ALL)
+def test_finish_secret_no_awscurrent_omits_remove(mod):
+    sm = make_sm()
+    sm.describe_secret.return_value = {"VersionIdsToStages": {"tok": ["AWSPENDING"]}}  # no AWSCURRENT
+    mod.secretsmanager = sm
+
+    mod.finish_secret("arn", "tok")
+
+    assert sm.update_secret_version_stage.call_count == 1
+    kwargs = sm.update_secret_version_stage.call_args.kwargs
+    # Must NOT pass RemoveFromVersionId=None.
+    assert kwargs.get("RemoveFromVersionId") is not None or "RemoveFromVersionId" not in kwargs
+    assert kwargs["MoveToVersionId"] == "tok"
+
+
+@pytest.mark.parametrize("mod", ALL)
+def test_finish_secret_removes_existing_current(mod):
+    sm = make_sm()
+    sm.describe_secret.return_value = {
+        "VersionIdsToStages": {"old": ["AWSCURRENT"], "tok": ["AWSPENDING"]}
+    }
+    mod.secretsmanager = sm
+
+    mod.finish_secret("arn", "tok")
+
+    kwargs = sm.update_secret_version_stage.call_args.kwargs
+    assert kwargs["RemoveFromVersionId"] == "old"
+    assert kwargs["MoveToVersionId"] == "tok"
+
+
+# --------------------------------------------------------------------------------------
+# REV-INFRA-106 / REV-COR-435-OVF2 — oauth fails loudly, never promotes identical material
+# --------------------------------------------------------------------------------------
+
+def test_oauth_create_secret_raises_and_never_puts():
+    OAUTH.secretsmanager = make_sm()
+    with pytest.raises(NotImplementedError):
+        OAUTH.create_secret("arn", "tok")
+    assert not OAUTH.secretsmanager.put_secret_value.called
+
+
+# --------------------------------------------------------------------------------------
+# REV-INFRA-107 / REV-COR-435-OVF2 — custom gated set + real test + shape preservation
+# --------------------------------------------------------------------------------------
+
+def test_custom_set_secret_raises_without_flag():
+    CUSTOM.ALLOW_PLACEHOLDER_ROTATION = False
+    CUSTOM.secretsmanager = make_sm()
+    with pytest.raises(NotImplementedError):
+        CUSTOM.set_secret("arn", "tok")
+
+
+def test_custom_set_secret_noop_with_flag():
+    CUSTOM.ALLOW_PLACEHOLDER_ROTATION = True
+    CUSTOM.secretsmanager = make_sm()
+    CUSTOM.set_secret("arn", "tok")  # must not raise
+    CUSTOM.ALLOW_PLACEHOLDER_ROTATION = False
+
+
+def test_custom_test_secret_rejects_short_value():
+    sm = make_sm()
+    sm.get_secret_value.return_value = {"SecretString": json.dumps({"value": "tooshort"})}
+    CUSTOM.secretsmanager = sm
+    with pytest.raises(ValueError):
+        CUSTOM.test_secret("arn", "tok")
+
+
+def test_custom_test_secret_accepts_valid_value():
+    sm = make_sm()
+    sm.get_secret_value.return_value = {"SecretString": json.dumps({"value": "x" * 64})}
+    CUSTOM.secretsmanager = sm
+    CUSTOM.test_secret("arn", "tok")  # must not raise
+
+
+def test_custom_create_preserves_plain_string_shape():
+    sm = make_sm()
+    # 1st call: AWSPENDING check -> not found; 2nd: AWSCURRENT -> a plain (non-JSON) string
+    sm.get_secret_value.side_effect = [_RNFE(), {"SecretString": "a-plain-old-secret-value"}]
+    CUSTOM.secretsmanager = sm
+
+    CUSTOM.create_secret("arn", "tok")
+
+    stored = sm.put_secret_value.call_args.kwargs["SecretString"]
+    # Stays a plain string (not coerced into a JSON {"value": ...} object).
+    assert not stored.strip().startswith("{")
+    assert stored != "a-plain-old-secret-value"  # value actually rotated
+
+
+def test_custom_create_preserves_json_and_sibling_fields():
+    sm = make_sm()
+    sm.get_secret_value.side_effect = [
+        _RNFE(),
+        {"SecretString": json.dumps({"value": "old", "kind": "cert"})},
+    ]
+    CUSTOM.secretsmanager = sm
+
+    CUSTOM.create_secret("arn", "tok")
+
+    stored = json.loads(sm.put_secret_value.call_args.kwargs["SecretString"])
+    assert stored["kind"] == "cert"      # sibling field preserved
+    assert stored["value"] != "old"      # value rotated
+
+
+# --------------------------------------------------------------------------------------
+# REV-COR-435-OVF1 / REV-INFRA-108 — database connection enforces TLS
+# --------------------------------------------------------------------------------------
+
+def test_database_connection_requires_tls():
+    _psycopg2.connect.reset_mock()
+    DB.get_database_connection({"host": "h", "username": "u", "password": "p"})
+    kwargs = _psycopg2.connect.call_args.kwargs
+    assert kwargs["sslmode"] == "require"
+
+
+def test_database_connection_sslmode_overridable():
+    _psycopg2.connect.reset_mock()
+    DB.get_database_connection({"host": "h", "username": "u", "password": "p", "sslmode": "verify-full"})
+    assert _psycopg2.connect.call_args.kwargs["sslmode"] == "verify-full"
+
+
+# --------------------------------------------------------------------------------------
+# REV-INFRA-115 — no full-event/ARN logging; ARNs redacted
+# --------------------------------------------------------------------------------------
+
+@pytest.mark.parametrize("mod", ALL)
+def test_sanitize_for_logging_redacts_arn(mod):
+    out = mod.sanitize_for_logging(
+        "arn:aws:secretsmanager:us-east-1:123456789012:secret:my-secret-AbCdEf"
+    )
+    assert "arn:aws" not in out
+    assert "[ARN_REDACTED]" in out
+
+
+@pytest.mark.parametrize("mod", [OAUTH, CUSTOM, APIKEY])
+def test_handler_logs_step_not_full_arn(mod, caplog):
+    sm = make_sm()
+    # short-circuit via the guard (token already AWSCURRENT) to avoid the full flow
+    sm.describe_secret.return_value = {"RotationEnabled": True, "VersionIdsToStages": {"tok": ["AWSCURRENT"]}}
+    mod.secretsmanager = sm
+
+    with caplog.at_level(logging.INFO):
+        mod.handler(
+            {
+                "SecretId": "arn:aws:secretsmanager:us-east-1:123456789012:secret:foo",
+                "ClientRequestToken": "tok",
+                "Step": "createSecret",
+            },
+            None,
+        )
+
+    messages = " ".join(r.getMessage() for r in caplog.records)
+    assert "createSecret" in messages  # step still logged for debugging
+    assert "arn:aws:secretsmanager" not in messages  # full ARN not dumped


### PR DESCRIPTION
## Batch B-012 — secret rotation hardening

Hardens the four Secrets Manager rotation Lambda handlers in `infra/lambdas/secret-rotation/` (`database`, `api-key`, `oauth`, `custom`). All **7** findings in the batch are implemented in scope — **no deferrals**.

### Findings

| ID | Sev | Fix |
|----|-----|-----|
| **REV-INFRA-106** | High | `oauth` `create_secret` raises `NotImplementedError` instead of copying the current token into AWSPENDING and reporting success (which reset the rotation clock and suppressed the failure alarm). No code path promotes AWSPENDING material identical to AWSCURRENT. |
| **REV-COR-435-OVF1** | Med | `database` `get_database_connection` now passes `sslmode='require'` (overridable per-secret) so the rotated `ALTER USER` password isn't sent over libpq's default `prefer` plaintext fallback. |
| **REV-COR-435-OVF2** | Med | `oauth` (raises) and `custom` (gated `set_secret` + real `test_secret`) can no longer mark a secret rotated without changing/validating its value. |
| **REV-INFRA-107** | Med | `custom` `create_secret` preserves the current secret's **shape** (plain string stays plain; JSON keeps sibling fields — the old code coerced/replaced the dict); `set_secret` raises unless `ALLOW_PLACEHOLDER_ROTATION` opts a self-contained secret in; `test_secret` does real length/format validation. |
| **REV-INFRA-108** | Med | Same TLS enforcement as OVF1 (`database` connection). |
| **REV-INFRA-109** | Med | All four handlers gained `validate_rotation_request` (checks `RotationEnabled`, token is staged for the secret, and stage is AWSPENDING; short-circuits when already AWSCURRENT); `finish_secret` never calls `update_secret_version_stage` with `RemoveFromVersionId=None`. |
| **REV-INFRA-115** | Low | Handlers log only the rotation **step** (never `json.dumps(event)` / the ARN) and share ARN/IP/email-sanitizing helpers. |

### Design notes
- **Fail-loudly is safe.** Verified (grep for `new ManagedSecret(` + `SecretType.OAUTH/CUSTOM/CERTIFICATE` with rotation) that **no live secret** is wired to the `oauth`/`custom` handlers, so raising cannot break a deployed rotation. This satisfies the "confirm which secrets use this handler" Done-when items without touching `managed-secret.ts` (referenced in the plans as evidence only).
- **Per-lambda helper copies, not a shared module.** Each handler is a separate `Code.fromAsset` per sub-directory, so the sanitize/validate helpers are copied into each handler rather than factored into a shared file that would break the asset boundary.

### Tests
`infra/lambdas/secret-rotation/tests/test_rotation_handlers.py` — **44 passing** cases (run via `uvx --with boto3 --with pytest pytest`), loading each same-named `index.py` via `importlib` and mocking `boto3`/`psycopg2`. Covers every "Done when" item runnable without live infra: TLS param, step-guard rejection/short-circuit, `finish_secret` None-guard, oauth-raises, custom gated-set / real-test / plain-string-shape-preserved, and ARN-redaction. The `tests/` dir is a **sibling** of the per-lambda asset subdirs, so it is not bundled into any deployed Lambda.

Gates: `bun run lint` (0 errors), `bun run typecheck` (clean), `py_compile` + `ruff` on all handlers. Python is outside the JS lint/typecheck scope, hence the pytest suite.

### ⚠️ Incidental fix (out of B-012 scope, transparent)
`database/index.py` had a **pre-existing** unterminated-string typo in `get_random_password(... ExcludeCharacters=...)` (an extra trailing quote) that made the **entire module unparseable on `dev`**. Because this batch edits that file and the module can't be `py_compile`d or tested otherwise, I fixed the single character. I left the pre-existing unused `Optional` import untouched (non-blocking, outside scope).

### Not runnable here (executor follow-up)
The OVF1 / INFRA-108 "validate against the **actual Aurora cluster**" and OVF1 "rotation completes end-to-end" checks require deployed infrastructure (no Docker/Aurora in this environment). The code fix is complete and unit-tested; live end-to-end verification remains an executor step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HWA2JRbkae8HCRsZwoEJXw
