### PR TITLE
fix: Nexus chat production outage (GUARDRAIL_HASH_SECRET) + workspace panel layout collapse

### DIFF
--- a/components/atrium/DocumentEditor.tsx
+++ b/components/atrium/DocumentEditor.tsx
@@ -52,9 +52,21 @@ export interface DocumentEditorProps {
   idOrSlug: string;
   /** The current user's id, stamped on their edits (green rail). */
   userId: number;
+  /**
+   * Layout context (Epic #1059 §17). `"page"` (default) is the full-width
+   * `/atrium/[id]/edit` page: the 288px comment rail sits BESIDE the editor.
+   * `"panel"` is the narrow Nexus workspace sibling (~380–720px), where a fixed
+   * 288px side rail would collapse the editor to an unreadable sliver — so the
+   * rail stacks BELOW the editor at full width instead.
+   */
+  layout?: "page" | "panel";
 }
 
-export function DocumentEditor({ idOrSlug, userId }: DocumentEditorProps) {
+export function DocumentEditor({
+  idOrSlug,
+  userId,
+  layout = "page",
+}: DocumentEditorProps) {
   // Lazily create the Y.Doc once (a null ref initializer reads clearer than the
   // `undefined as unknown as Y.Doc` cast). The lazy init below runs on the first
   // render before any consumer, so `ydoc` is always a live doc by use.
@@ -205,7 +217,7 @@ export function DocumentEditor({ idOrSlug, userId }: DocumentEditorProps) {
   const { suggesting, count: suggestionCount } = useSuggestionState(editor);
 
   return (
-    <div className="flex flex-col gap-2">
+    <div className={cn("flex flex-col gap-2", layout === "panel" && "p-3")}>
       <EditorToolbar
         status={status}
         canEdit={canEdit}
@@ -220,13 +232,19 @@ export function DocumentEditor({ idOrSlug, userId }: DocumentEditorProps) {
           if (editor) acceptAllSuggestions(editor);
         }}
       />
-      <div className="flex gap-4">
+      <div className={cn("flex gap-4", layout === "panel" && "flex-col")}>
         <div className="atrium-editor min-w-0 flex-1">
           <EditorContent editor={editor} className="atrium-content" />
         </div>
-        {/* Right rail: comment threads. Hidden on small screens; the anchors stay
-            in the doc regardless so a narrow viewport never loses comment data. */}
-        <div className="hidden w-72 shrink-0 md:block">
+        {/* Comment threads: a 288px right rail on the full PAGE (hidden on small
+            viewports); stacked full-width BELOW the editor in the narrow §17
+            workspace panel so the editor keeps the whole panel width. */}
+        <div
+          className={cn(
+            "shrink-0",
+            layout === "panel" ? "w-full border-t pt-3" : "hidden w-72 md:block"
+          )}
+        >
           <CommentSidebar idOrSlug={idOrSlug} editor={editor} canEdit={canEdit} />
         </div>
       </div>

--- a/components/atrium/EditorToolbar.tsx
+++ b/components/atrium/EditorToolbar.tsx
@@ -106,7 +106,11 @@ export function EditorToolbar({
         </span>
       )}
       {canEdit && (
-        <span className="ml-auto flex items-center gap-2">
+        // flex-wrap here too (PR #1131 review): the action group's min-content
+        // width (~500px across six controls) exceeds the workspace panel's
+        // 380px minimum, so without wrapping INSIDE the group the outer wrap
+        // still clips Publish/Unpublish off the panel edge.
+        <span className="ml-auto flex flex-wrap items-center justify-end gap-x-2 gap-y-1">
           {/* Track-changes toggle: while ON, edits become proposed suggestions. */}
           <Button
             type="button"

--- a/components/atrium/EditorToolbar.tsx
+++ b/components/atrium/EditorToolbar.tsx
@@ -76,7 +76,10 @@ export function EditorToolbar({
     useState<EditorPublishDestination>("intranet");
 
   return (
-    <div className="flex items-center gap-3 text-xs text-gray-500">
+    // flex-wrap so the status legend + action buttons wrap onto a second line in
+    // the narrow Nexus workspace panel (Epic #1059 §17) instead of clipping off
+    // the right edge. The full-width page has room and never wraps.
+    <div className="flex flex-wrap items-center gap-x-3 gap-y-2 text-xs text-gray-500">
       <span aria-live="polite">
         {status === "connecting" && "Connecting…"}
         {status === "ready" && (canEdit ? "Connected" : "Read-only")}

--- a/components/atrium/WorkspacePanel.tsx
+++ b/components/atrium/WorkspacePanel.tsx
@@ -118,7 +118,11 @@ export function WorkspacePanel({ idOrSlug, onClose }: WorkspacePanelProps) {
         )}
         {state.status === "ready" &&
           (state.data.kind === "document" ? (
-            <DocumentEditor idOrSlug={state.data.id} userId={state.data.userId} />
+            <DocumentEditor
+              idOrSlug={state.data.id}
+              userId={state.data.userId}
+              layout="panel"
+            />
           ) : (
             <ArtifactCanvas
               idOrSlug={state.data.id}

--- a/infra/lib/constructs/ecs-service.ts
+++ b/infra/lib/constructs/ecs-service.ts
@@ -131,6 +131,12 @@ export interface EcsServiceConstructProps {
    */
   collabJwtSecretArn: string;
   /**
+   * Guardrail violation-log hash secret ARN from Secrets Manager (#727).
+   * HMAC key for pseudonymizing session/user ids in guardrail-violation logs;
+   * without it the app logs a fixed 'redacted' placeholder (uncorrelatable).
+   */
+  guardrailHashSecretArn: string;
+  /**
    * K-12 Content Safety: Bedrock Guardrail ARN (from GuardrailsStack)
    * If provided, enables precise IAM scoping instead of wildcard
    */
@@ -289,6 +295,7 @@ export class EcsServiceConstruct extends Construct {
         props.authSecretArn,
         props.internalApiSecretArn,
         props.collabJwtSecretArn,
+        props.guardrailHashSecretArn,
       ],
     }));
 
@@ -325,6 +332,7 @@ export class EcsServiceConstruct extends Construct {
                 props.authSecretArn, // Include auth secret
                 props.internalApiSecretArn, // Include internal API secret
                 props.collabJwtSecretArn, // Include Atrium collab token signing secret (#1051)
+                props.guardrailHashSecretArn, // Include guardrail hash secret (#727)
               ],
             }),
             // Agent Workspace OAuth secrets — read+update for refresh tokens (#912).
@@ -764,6 +772,14 @@ export class EcsServiceConstruct extends Construct {
         COLLAB_JWT_SECRET: ecs.Secret.fromSecretsManager(
           secretsmanager.Secret.fromSecretCompleteArn(this, 'CollabJwtSecret', props.collabJwtSecretArn),
           'COLLAB_JWT_SECRET'
+        ),
+        // Guardrail violation-log hash secret (#727 / 2026-07-06 chat outage):
+        // enables real per-session HMAC pseudonymization in violation logs.
+        // The app degrades to a 'redacted' placeholder if this is ever missing —
+        // it must never take chat down again.
+        GUARDRAIL_HASH_SECRET: ecs.Secret.fromSecretsManager(
+          secretsmanager.Secret.fromSecretCompleteArn(this, 'GuardrailHashSecret', props.guardrailHashSecretArn),
+          'GUARDRAIL_HASH_SECRET'
         ),
         // Issue #603: Database credentials for postgres.js driver
         // The RDS secret contains a JSON object with: username, password, host, port, dbname

--- a/infra/lib/frontend-stack-ecs.ts
+++ b/infra/lib/frontend-stack-ecs.ts
@@ -148,6 +148,29 @@ export class FrontendStackEcs extends cdk.Stack {
     });
 
     // ============================================================================
+    // Guardrail Violation-Log Hash Secret (Issue #727 / chat outage 2026-07-06)
+    // ============================================================================
+    // HMAC key for pseudonymizing session/user ids in guardrail-violation logs
+    // (lib/safety/bedrock-guardrails-service.ts hashValue). Without a configured
+    // secret the app REFUSES to hash and logs a fixed 'redacted' placeholder —
+    // private but uncorrelatable, so per-student violation triage needs this set.
+    // A missing secret briefly took down every Nexus chat request when the app
+    // treated it as a production startup error; the secret is now provisioned
+    // here so real per-session hashing works, and the app degrades gracefully if
+    // it ever goes missing again. Injected as GUARDRAIL_HASH_SECRET below.
+    const guardrailHashSecret = new secretsmanager.Secret(this, 'GuardrailHashSecret', {
+      secretName: `aistudio-${environment}-guardrail-hash-secret`,
+      description: 'HMAC key for pseudonymizing ids in guardrail violation logs',
+      generateSecretString: {
+        secretStringTemplate: JSON.stringify({}),
+        generateStringKey: 'GUARDRAIL_HASH_SECRET',
+        excludePunctuation: true,
+        passwordLength: 32,
+      },
+      removalPolicy: environment === 'prod' ? cdk.RemovalPolicy.RETAIN : cdk.RemovalPolicy.DESTROY,
+    });
+
+    // ============================================================================
     // MCP Token Encryption Key (AES-256-GCM DEK)
     // ============================================================================
     // Random 64-character alphanumeric password used as HKDF input key material.
@@ -202,6 +225,8 @@ export class FrontendStackEcs extends cdk.Stack {
       internalApiSecretArn: internalApiSecret.secretArn,
       // Atrium collab token signing secret (#1051, created above)
       collabJwtSecretArn: collabJwtSecret.secretArn,
+      // Guardrail violation-log hash secret (#727, created above)
+      guardrailHashSecretArn: guardrailHashSecret.secretArn,
       // K-12 Content Safety: Guardrails resources from GuardrailsStack
       // These enable precise IAM scoping and DynamoDB access for PII tokenization
       guardrailArn: cdk.Fn.importValue(`${environment}-GuardrailArn`),

--- a/lib/safety/__tests__/bedrock-guardrails-service.test.ts
+++ b/lib/safety/__tests__/bedrock-guardrails-service.test.ts
@@ -605,15 +605,26 @@ describe('BedrockGuardrailsService - detection fingerprint (Issue #929)', () => 
     );
 
   it('should attach contentHash to topic detection log lines', async () => {
-    const service = createTestService();
-    await service.evaluateInput('any content that triggers a detection');
+    // A configured hash secret is required for real HMAC fingerprints: without
+    // one, hashValue() deliberately refuses to hash and emits the constant
+    // 'redacted' placeholder (PR #1131 — a missing secret must degrade
+    // privacy-safe instead of throwing/500ing chat). This test covers the
+    // WITH-secret hashing path; the without-secret placeholder is covered by
+    // tests/unit/lib/safety/bedrock-guardrails-hash.test.ts.
+    process.env.GUARDRAIL_HASH_SECRET = 'fingerprint-test-secret';
+    try {
+      const service = createTestService();
+      await service.evaluateInput('any content that triggers a detection');
 
-    const detectionCall = findDetectionCall();
-    expect(detectionCall).toBeDefined();
-    const meta = detectionCall![1] as { contentHash?: unknown; contentSnippet?: unknown };
-    expect(typeof meta.contentHash).toBe('string');
-    expect(meta.contentHash as string).toMatch(/^[a-f0-9]{16}$/);
-    expect(meta.contentSnippet).toBeUndefined();
+      const detectionCall = findDetectionCall();
+      expect(detectionCall).toBeDefined();
+      const meta = detectionCall![1] as { contentHash?: unknown; contentSnippet?: unknown };
+      expect(typeof meta.contentHash).toBe('string');
+      expect(meta.contentHash as string).toMatch(/^[a-f0-9]{16}$/);
+      expect(meta.contentSnippet).toBeUndefined();
+    } finally {
+      delete process.env.GUARDRAIL_HASH_SECRET;
+    }
   });
 
   it('should include contentSnippet only when GUARDRAIL_LOG_SNIPPET=true', async () => {

--- a/lib/safety/bedrock-guardrails-service.ts
+++ b/lib/safety/bedrock-guardrails-service.ts
@@ -82,15 +82,20 @@ export class BedrockGuardrailsService {
     };
   }
 
+  /** First non-empty of the provided override and the env fallback. */
+  private static firstSet(override: string | undefined, env: string | undefined, fallback = ''): string {
+    return override || env || fallback;
+  }
+
   /**
    * Build configuration from provided config and environment variables
    */
   private static buildConfig(region: string, config?: Partial<GuardrailsConfig>): GuardrailsConfig {
     return {
       region,
-      guardrailId: config?.guardrailId || process.env.BEDROCK_GUARDRAIL_ID || '',
-      guardrailVersion: config?.guardrailVersion || process.env.BEDROCK_GUARDRAIL_VERSION || 'DRAFT',
-      violationTopicArn: config?.violationTopicArn || process.env.GUARDRAIL_VIOLATION_TOPIC_ARN,
+      guardrailId: BedrockGuardrailsService.firstSet(config?.guardrailId, process.env.BEDROCK_GUARDRAIL_ID),
+      guardrailVersion: BedrockGuardrailsService.firstSet(config?.guardrailVersion, process.env.BEDROCK_GUARDRAIL_VERSION, 'DRAFT'),
+      violationTopicArn: BedrockGuardrailsService.firstSet(config?.violationTopicArn, process.env.GUARDRAIL_VIOLATION_TOPIC_ARN) || undefined,
       enableViolationNotifications: config?.enableViolationNotifications ?? true,
       enablePiiTokenization: config?.enablePiiTokenization ?? true,
       tokenTtlSeconds: config?.tokenTtlSeconds ?? 3600,
@@ -111,18 +116,26 @@ export class BedrockGuardrailsService {
     }
 
     // Issue #727: Validate GUARDRAIL_HASH_SECRET is set for privacy protection.
-    // In production the default literal is a real privacy hole: it lets anyone who
-    // reads the open-source repo pre-compute the HMAC of a known session/user id and
-    // correlate guardrail-violation logs across requests for a K-12 student. Treat a
-    // missing secret as a STARTUP ERROR in production; keep it a warning in dev/test
-    // so local runs and unit tests work without the env var.
+    // The old default literal was a real privacy hole: anyone who reads the
+    // open-source repo could pre-compute the HMAC of a known session/user id and
+    // correlate guardrail-violation logs across requests for a K-12 student.
+    //
+    // This USED to throw in production — which took down EVERY chat request when
+    // the env var was missing (the guardrails service is constructed lazily on
+    // the first chat request, so the "startup error" surfaced as a per-request
+    // 500 across the whole product; broke deployed dev, 2026-07-06). A missing
+    // secret must never cost availability: instead, hashValue() REFUSES to hash
+    // and emits a fixed 'redacted' placeholder — zero correlation is possible,
+    // which is strictly more private than default-secret hashing — and we log
+    // loudly (error in production, warn elsewhere) so ops wires the secret.
     if (!process.env.GUARDRAIL_HASH_SECRET && !config?.hashSecret) {
       if (process.env.NODE_ENV === 'production') {
-        throw new Error(
-          'GUARDRAIL_HASH_SECRET must be set in production: the default secret lets violation logs be correlated by session/user id, breaking student privacy.'
+        this.log.error(
+          'GUARDRAIL_HASH_SECRET is not set: guardrail violation logs will record a redacted placeholder instead of a per-session hash (violations cannot be correlated per user until the secret is configured). Set the GUARDRAIL_HASH_SECRET env var / ECS secret.'
         );
+      } else {
+        this.log.warn('GUARDRAIL_HASH_SECRET not configured - violation logs will use a redacted placeholder for session ID hashing');
       }
-      this.log.warn('GUARDRAIL_HASH_SECRET not configured - using default secret for session ID hashing (weakens privacy protection)');
     }
 
     // Issue #929: Warn when content snippet logging is active — snippets contain the
@@ -722,9 +735,17 @@ export class BedrockGuardrailsService {
    *
    * Uses a secret key to prevent rainbow table attacks on predictable values
    * like session IDs. The secret should be set via GUARDRAIL_HASH_SECRET env var.
+   *
+   * With NO secret configured this returns a fixed 'redacted' placeholder
+   * instead of falling back to a publicly-known default key: a repo-visible
+   * default lets anyone pre-compute HMACs of known ids and correlate a K-12
+   * student's violation logs, whereas a constant placeholder carries zero
+   * information. Availability is never traded for the secret (see
+   * logConfigurationWarnings).
    */
   private hashValue(value: string): string {
-    const secret = process.env.GUARDRAIL_HASH_SECRET || this.config.hashSecret || 'aistudio-guardrail-default-secret';
+    const secret = process.env.GUARDRAIL_HASH_SECRET || this.config.hashSecret;
+    if (!secret) return 'redacted';
     return createHmac('sha256', secret).update(value).digest('hex').substring(0, 16);
   }
 

--- a/tests/e2e/nexus-workspace-panel.spec.ts
+++ b/tests/e2e/nexus-workspace-panel.spec.ts
@@ -45,6 +45,26 @@ test.describe("Nexus workspace panel (authenticated)", () => {
       //    a human edit (the §17 edit-beside-chat loop).
       const pm = panel.locator(".ProseMirror");
       await expect(pm).toHaveAttribute("contenteditable", "true", { timeout: 60000 });
+
+      // 2b. Layout regression guard: the editor must NOT collapse to a sliver
+      //     beside the comment rail (the full-page `w-72 md:block` rail keyed off
+      //     the VIEWPORT would leave ~80px in this ~469px panel). In `layout=
+      //     "panel"` the rail stacks below, so the editor keeps the panel width.
+      //     Also: opening the panel must never cause horizontal page overflow.
+      const dims = await page.evaluate(() => {
+        const p = document.querySelector('[data-testid="workspace-panel"]') as HTMLElement | null;
+        const ed = document.querySelector(".atrium-editor") as HTMLElement | null;
+        const doc = document.documentElement;
+        return {
+          panelW: p ? p.getBoundingClientRect().width : 0,
+          editorW: ed ? ed.getBoundingClientRect().width : 0,
+          horizOverflow: doc.scrollWidth > doc.clientWidth,
+        };
+      });
+      expect(dims.horizOverflow).toBe(false);
+      expect(dims.panelW).toBeGreaterThan(0);
+      // Editor occupies the bulk of the panel (was ~17% when collapsed).
+      expect(dims.editorW).toBeGreaterThan(dims.panelW * 0.7);
       const marker = `WS ${Date.now()}`;
       await pm.click();
       await page.keyboard.press("End");

--- a/tests/e2e/nexus-workspace-panel.spec.ts
+++ b/tests/e2e/nexus-workspace-panel.spec.ts
@@ -53,12 +53,16 @@ test.describe("Nexus workspace panel (authenticated)", () => {
       //     Also: opening the panel must never cause horizontal page overflow.
       const dims = await page.evaluate(() => {
         const p = document.querySelector('[data-testid="workspace-panel"]') as HTMLElement | null;
-        const ed = document.querySelector(".atrium-editor") as HTMLElement | null;
+        // Scope the editor lookup to the PANEL so a second editor elsewhere on
+        // the page can never satisfy (or fail) this guard (PR #1131 review).
+        const ed = p?.querySelector(".atrium-editor") as HTMLElement | null;
         const doc = document.documentElement;
         return {
           panelW: p ? p.getBoundingClientRect().width : 0,
           editorW: ed ? ed.getBoundingClientRect().width : 0,
-          horizOverflow: doc.scrollWidth > doc.clientWidth,
+          // 1px tolerance: subpixel layout can round scrollWidth a hair past
+          // clientWidth without any real overflow (PR #1131 review).
+          horizOverflow: doc.scrollWidth > doc.clientWidth + 1,
         };
       });
       expect(dims.horizOverflow).toBe(false);

--- a/tests/unit/atrium-workspace-panel.test.tsx
+++ b/tests/unit/atrium-workspace-panel.test.tsx
@@ -35,8 +35,18 @@ jest.mock("next/link", () => ({
 }));
 
 jest.mock("@/components/atrium/DocumentEditor", () => ({
-  DocumentEditor: ({ idOrSlug, userId }: { idOrSlug: string; userId: number }) => (
-    <div data-testid="doc-editor">{`doc:${idOrSlug}:u${userId}`}</div>
+  // Echo the `layout` prop too: the panel MUST pass layout="panel" so the editor
+  // stacks its comment rail instead of collapsing beside it (Epic #1059 §17).
+  DocumentEditor: ({
+    idOrSlug,
+    userId,
+    layout,
+  }: {
+    idOrSlug: string;
+    userId: number;
+    layout?: string;
+  }) => (
+    <div data-testid="doc-editor">{`doc:${idOrSlug}:u${userId}:${layout}`}</div>
   ),
 }));
 jest.mock("@/components/atrium/ArtifactCanvas", () => ({
@@ -73,7 +83,7 @@ describe("WorkspacePanel", () => {
     render(<WorkspacePanel idOrSlug="my-doc" onClose={jest.fn()} />);
     expect(screen.getByText("Loading workspace…")).toBeInTheDocument();
     await waitFor(() =>
-      expect(screen.getByTestId("doc-editor")).toHaveTextContent("doc:obj-1:u7")
+      expect(screen.getByTestId("doc-editor")).toHaveTextContent("doc:obj-1:u7:panel")
     );
     expect(screen.getByRole("heading", { name: "My Doc" })).toBeInTheDocument();
     expect(loadMock).toHaveBeenCalledWith("my-doc");

--- a/tests/unit/lib/safety/bedrock-guardrails-hash.test.ts
+++ b/tests/unit/lib/safety/bedrock-guardrails-hash.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Regression tests for the GUARDRAIL_HASH_SECRET handling
+ * (Issue #727 hardening → 2026-07-06 chat outage).
+ *
+ * The old behavior THREW from the constructor when NODE_ENV=production and no
+ * hash secret was configured. Because the guardrails service is constructed
+ * lazily on the first chat request, that "startup error" actually surfaced as
+ * a 500 on EVERY Nexus chat request in any production-build environment
+ * missing the env var (it took down deployed dev). The contract now:
+ *
+ *   - construction NEVER throws over a missing hash secret;
+ *   - with no secret, hashValue() refuses to hash and returns the fixed
+ *     'redacted' placeholder (zero correlation possible — strictly more
+ *     private than HMAC-ing with the old repo-visible default literal);
+ *   - with a secret, ids are HMAC-pseudonymized as before.
+ */
+
+import { BedrockGuardrailsService } from "@/lib/safety/bedrock-guardrails-service";
+
+type HashCapable = { hashValue(value: string): string };
+
+const ORIGINAL_ENV = { ...process.env };
+
+function restoreEnv() {
+  process.env = { ...ORIGINAL_ENV };
+}
+
+afterEach(restoreEnv);
+
+describe("BedrockGuardrailsService hash-secret handling", () => {
+  it("does NOT throw in production when GUARDRAIL_HASH_SECRET is missing (chat availability)", () => {
+    process.env = {
+      ...ORIGINAL_ENV,
+      NODE_ENV: "production",
+      AWS_REGION: "us-east-1",
+    };
+    delete process.env.GUARDRAIL_HASH_SECRET;
+
+    expect(() => new BedrockGuardrailsService()).not.toThrow();
+  });
+
+  it("returns the fixed 'redacted' placeholder instead of hashing with a known default", () => {
+    process.env = {
+      ...ORIGINAL_ENV,
+      NODE_ENV: "production",
+      AWS_REGION: "us-east-1",
+    };
+    delete process.env.GUARDRAIL_HASH_SECRET;
+
+    const service = new BedrockGuardrailsService() as unknown as HashCapable;
+    // Two different ids map to the SAME constant — no correlation is possible.
+    expect(service.hashValue("session-a")).toBe("redacted");
+    expect(service.hashValue("session-b")).toBe("redacted");
+  });
+
+  it("HMAC-pseudonymizes ids when a secret IS configured", () => {
+    process.env = {
+      ...ORIGINAL_ENV,
+      NODE_ENV: "production",
+      AWS_REGION: "us-east-1",
+      GUARDRAIL_HASH_SECRET: "unit-test-secret",
+    };
+
+    const service = new BedrockGuardrailsService() as unknown as HashCapable;
+    const a = service.hashValue("session-a");
+    const b = service.hashValue("session-b");
+    expect(a).toMatch(/^[0-9a-f]{16}$/);
+    expect(b).toMatch(/^[0-9a-f]{16}$/);
+    expect(a).not.toBe(b);
+    // Deterministic for the same id (correlation works WITH the secret).
+    expect(service.hashValue("session-a")).toBe(a);
+    // And never the redacted placeholder.
+    expect(a).not.toBe("redacted");
+  });
+});


### PR DESCRIPTION
## Summary

Two fixes for the post-epic Nexus breakage, both reproduced and verified with Playwright + a local **webpack production build** (deployed-dev conditions):

1. **Every Nexus chat request 500'd on deployed dev** — missing `GUARDRAIL_HASH_SECRET`.
2. **Workspace panel document layout collapse** — the editor crushed to a ~80px sliver beside a viewport-keyed comment rail.

## 1. Chat outage — `GUARDRAIL_HASH_SECRET` (the "errors every time" report)

**Root cause:** commit `aef83dea` (Atrium PR #1062, review round 6) turned a missing `GUARDRAIL_HASH_SECRET` into a **throw when `NODE_ENV=production`**. The guardrails service is constructed lazily on the first chat request (`route → getContentSafetyService → BedrockGuardrailsService`), so the "startup error" surfaced as a 500 on **every** `/api/nexus/chat` request. The matching infra change was never made, so the first deploy carrying that commit bricked chat. CloudWatch (`/ecs/aistudio-dev`) confirms: `GUARDRAIL_HASH_SECRET must be set in production…` on every chat.

**Why it never reproduced locally:** the constructor early-returns into disabled mode when `AWS_REGION` is unset — the failure needs production `NODE_ENV` **+** `AWS_REGION` **+** no secret, which is exactly and only the deployed combination. Reproduced locally with `next build --webpack` + `AWS_REGION=us-east-1`: `{"error":"Failed to process chat request"}` on every message.

**App fix (availability is never traded for the secret):**
- No more throw. Missing secret → loud `log.error` (production) / warn (dev), and `hashValue()` **refuses to hash**, returning a fixed `'redacted'` placeholder instead of falling back to the repo-visible default literal. Zero correlation is possible — **strictly more private** than default-secret HMAC (the original #727 concern) — and chat stays up.

**Infra fix (real hashing after the next deploy):**
- New generated secret `aistudio-{env}-guardrail-hash-secret` (same pattern as `CollabJwtSecret`), threaded through `FrontendStackEcs → EcsService`, injected as the `GUARDRAIL_HASH_SECRET` container secret, added to both IAM secret-read lists. `bunx tsc --noEmit` + `cdk synth` clean.

**Verified:** on the fixed production build (with `AWS_REGION`, no secret) chat streams normally and the ops error logs once; with a secret, ids HMAC-pseudonymize (unit-tested: no-throw, placeholder, 16-hex deterministic HMAC).

## 2. Workspace panel document layout (unchanged from the original PR description)

`DocumentEditor` keys its 288px comment rail off the **viewport** (`hidden w-72 md:block`); inside the 380–720px panel the editor collapsed to ~17% width with character-wrapped text and a clipped toolbar. Fix: `layout="panel"` prop stacks the rail below the editor (page mode untouched), `EditorToolbar` gains `flex-wrap`. Verified at 1512px/1024px: editor ≈95% of panel width, no horizontal overflow; full-page editor byte-for-byte unchanged. Regression guards added (E2E width ratio + unit prop assertion).

## Verified end-to-end on the production build (`NODE_ENV=production` custom server, `AWS_REGION` + `COLLAB_JWT_SECRET` set): `nexus-workspace-panel` (edit-beside-chat incl. typing into the live editor), `atrium-editor-rail`, and `nexus-chat-tools` all pass. Chat replies confirmed across OpenAI, Google, and Bedrock models.

## Investigated, not bugs
- **PSD Data MCP 401 "Invalid token format"** — `cognito_passthrough` rejecting a minted E2E token; real sessions authenticate. Degrades gracefully.
- **`/api/notifications/stream` 429** — the 3-connection/user DoS cap under rapid test navigation + StrictMode; self-heals via client backoff.
- **Collab "Connection error" on the local prod server** — `COLLAB_JWT_SECRET` absent locally; correct fail-closed scope (collab only, chat unaffected) and **its ECS wiring already exists** (unlike the guardrail secret).
- **Artifact sandbox-origin notice** — expected local degradation; Edge-runtime compile warnings — pre-existing.

## Known gap (flagged, not in this PR)
The design spec's §1087 "re-prompt path" (chat messages that modify the open artifact call `create_version`) was **never wired into Nexus chat** — PR #1126 shipped the panel as a pure layout sibling with no content tools in the chat toolset. Today chat and panel coexist but chat cannot edit the open document/artifact. That's a feature build (workspace context + content tools in the chat surface), not a regression fix — happy to take it as a follow-up issue.

## Gates
- [x] `bun run typecheck` clean · lint zero warnings on all touched files (incl. clearing the pre-existing `buildConfig` complexity warning)
- [x] Unit: guardrails hash regression (3), workspace panel (5+11), editor tests pass
- [x] E2E on **production build**: 3/3 pass · chat verified streaming across 3 providers
- [x] `infra: tsc --noEmit` + `cdk synth` clean
