### PR TITLE
fix(B-015): align MCP allowlist SIS block with Cedar

### DIFF
--- a/infra/policies/mcp-allowlist.json
+++ b/infra/policies/mcp-allowlist.json
@@ -12,6 +12,6 @@
   "blockedPatterns": [
     "*powerschool*",
     "*studentvue*",
-    "*synergysis*"
+    "*synergy*"
   ]
 }

--- a/infra/test/mcp-allowlist-policy.test.ts
+++ b/infra/test/mcp-allowlist-policy.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Policy unit test for infra/policies/mcp-allowlist.json (REV-COR-487).
+ *
+ * The MCP allowlist is read at runtime (from S3) by AgentCore to gate MCP server
+ * endpoints. Its `blockedPatterns` must block the same Student-Information-System
+ * host families that the authoritative Cedar policy blocks. The Synergy pattern had
+ * drifted to `*synergysis*` (a substring that real Synergy hosts — synergy.<district>,
+ * synergy-sis.<...> — never contain), so the SIS block was dead against Synergy while
+ * Cedar correctly used `*synergy*`. This test asserts the two agree and that a
+ * representative Synergy hostname is blocked.
+ */
+import * as fs from 'fs';
+import * as path from 'path';
+
+const POLICIES_DIR = path.join(__dirname, '..', 'policies');
+const allowlist = JSON.parse(
+  fs.readFileSync(path.join(POLICIES_DIR, 'mcp-allowlist.json'), 'utf8')
+) as { blockedPatterns: string[]; allowedEndpoints: Array<{ url: string }> };
+const cedar = fs.readFileSync(
+  path.join(POLICIES_DIR, 'cedar', 'psd-agent-governance.cedar'),
+  'utf8'
+);
+
+// Allowlist/Cedar-style glob: `*` is the only metacharacter and matches any
+// sequence (including `/` and `.`), everything else is literal.
+function globToRegExp(pattern: string): RegExp {
+  const translated = pattern.replace(/[.*+?^${}()|[\]\\]/g, (ch) =>
+    ch === '*' ? '.*' : `\\${ch}`
+  );
+  return new RegExp(`^${translated}$`);
+}
+
+function isBlocked(url: string, patterns: string[]): boolean {
+  return patterns.some((p) => globToRegExp(p).test(url));
+}
+
+describe('mcp-allowlist blockedPatterns (REV-COR-487)', () => {
+  it('blocks representative Synergy SIS hostnames', () => {
+    expect(isBlocked('https://synergy.example.net', allowlist.blockedPatterns)).toBe(true);
+    expect(isBlocked('https://synergy-sis.district.org/api', allowlist.blockedPatterns)).toBe(true);
+    expect(isBlocked('https://synergy.district.k12.wa.us', allowlist.blockedPatterns)).toBe(true);
+  });
+
+  it('still blocks the other SIS families', () => {
+    expect(isBlocked('https://ps.powerschool.com', allowlist.blockedPatterns)).toBe(true);
+    expect(isBlocked('https://studentvue.district.edu', allowlist.blockedPatterns)).toBe(true);
+  });
+
+  it('does not block a legitimate allowlisted endpoint', () => {
+    expect(isBlocked('https://sheets.googleapis.com/v4/spreadsheets', allowlist.blockedPatterns)).toBe(
+      false
+    );
+    expect(isBlocked('https://mcp.psd401.net', allowlist.blockedPatterns)).toBe(false);
+  });
+
+  it('regression: the old *synergysis* pattern missed real Synergy hosts', () => {
+    // Proves why the fix was needed — the previous pattern never matched.
+    expect(globToRegExp('*synergysis*').test('https://synergy.example.net')).toBe(false);
+    // The corrected pattern must be present.
+    expect(allowlist.blockedPatterns).toContain('*synergy*');
+    expect(allowlist.blockedPatterns).not.toContain('*synergysis*');
+  });
+
+  it('agrees with the authoritative Cedar policy on the blocked SIS families', () => {
+    // Both files must block the same host families (Done-when #3).
+    for (const family of ['powerschool', 'studentvue', 'synergy']) {
+      expect(allowlist.blockedPatterns).toContain(`*${family}*`);
+      expect(cedar).toContain(`like "*${family}*"`);
+    }
+  });
+});


### PR DESCRIPTION
## Batch B-015 — infra/policies

**1 of 2** implemented; **1 deferred** with reason.

### Implemented

**REV-COR-487** (Medium) — `infra/policies/mcp-allowlist.json` blocked `*synergysis*`, a substring real Synergy SIS hosts (`synergy.<district>`, `synergy-sis.<...>`) never contain, so the MCP allowlist's SIS block was **dead against Synergy** while the authoritative Cedar policy correctly blocks `*synergy*`. Corrected the pattern to `*synergy*` so both files block the same host families. Per scope guardrails, `*powerschool*`/`*studentvue*`/`allowedEndpoints` and the Cedar file are untouched.

**Test** — `infra/test/mcp-allowlist-policy.test.ts` (5 cases, all passing): representative Synergy hostnames are blocked; the other SIS families still block; a legitimate `googleapis.com` endpoint is not blocked; the **old `*synergysis*` pattern demonstrably missed** real Synergy hosts (regression); and the JSON + Cedar policies **agree** on the blocked SIS families (Done-when #3).

### Deferred

**REV-INFRA-184** (High — Cedar egress allowlist wildcard bypass): the fix requires the Cedar policy to match on a **parsed `resource.host`** attribute instead of the raw `resource.url` (Cedar's `like` `*` matches `/` and `.`, so `https://evil.example/.google.com/x` satisfies `https://*.google.com/*`). But `resource.host` must be **populated by AgentCore's entitlement / request-context wiring**, which is:
- **not in this repo** — nothing in-repo reads/enforces the policy; AWS-managed AgentCore reads it from S3 at runtime and builds the Cedar request context; and
- **not in the named `.cedar` file** — the only file this finding scopes.

Changing `resource.url` → `resource.host` in the `.cedar` file alone would make every `unless` allowlist clause fail to match, so the default-deny `forbid` would **block ALL agent egress** (including legitimate googleapis calls) — an unsafe, deploy-breaking failure mode. The plan itself states the fix "requires coordination with the AgentCore entitlement wiring," which is outside the named scope. Reported rather than force-fit; needs the AgentCore-side change (populate host/path attributes) alongside the policy edit.

### Verification
`bun run lint` (0 errors) + `bun run typecheck` green; `cd infra && bunx tsc --noEmit` clean; policy test passes. WORKLIST: REV-COR-487 ticked, REV-INFRA-184 left unchecked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HWA2JRbkae8HCRsZwoEJXw
