### PR TITLE
fix(B-016): lib/ai — image SSRF, PDF Unicode, Google client scoping

### DIFF
--- a/lib/ai/document-generation-service.ts
+++ b/lib/ai/document-generation-service.ts
@@ -134,8 +134,10 @@ function wrapPdfLines(
  * Greek, most math/arrow symbols). Replace those code points with "?" so a single
  * such character no longer fails the entire PDF request (REV-COR-499). ASCII/CP1252
  * text is returned unchanged via the whole-string fast path.
+ *
+ * Exported for unit testing.
  */
-function sanitizeForWinAnsi(
+export function sanitizeForWinAnsi(
   text: string,
   font: { encodeText(t: string): unknown }
 ): string {
@@ -145,11 +147,30 @@ function sanitizeForWinAnsi(
   } catch {
     let out = "";
     let replaced = 0;
+    // Cache per-character encodability: natural-language text is highly repetitive,
+    // so this turns the fallback from O(N) encodeText calls into O(unique chars).
+    const cache = new Map<string, boolean>();
     for (const ch of text) {
-      try {
-        font.encodeText(ch);
+      // \r/\n never reach drawText directly — wrapPdfLines splits on them first —
+      // so preserve them unconditionally instead of letting the WinAnsi control-
+      // character rejection turn every line break into "?".
+      if (ch === "\n" || ch === "\r") {
         out += ch;
-      } catch {
+        continue;
+      }
+      let ok = cache.get(ch);
+      if (ok === undefined) {
+        try {
+          font.encodeText(ch);
+          ok = true;
+        } catch {
+          ok = false;
+        }
+        cache.set(ch, ok);
+      }
+      if (ok) {
+        out += ch;
+      } else {
         out += "?";
         replaced++;
       }

--- a/lib/ai/document-generation-service.ts
+++ b/lib/ai/document-generation-service.ts
@@ -128,11 +128,50 @@ function wrapPdfLines(
   return out;
 }
 
+/**
+ * pdf-lib's StandardFonts (Helvetica) use WinAnsi (CP1252) encoding, so drawText
+ * and width measurement throw on any character outside CP1252 (emoji, CJK, Cyrillic,
+ * Greek, most math/arrow symbols). Replace those code points with "?" so a single
+ * such character no longer fails the entire PDF request (REV-COR-499). ASCII/CP1252
+ * text is returned unchanged via the whole-string fast path.
+ */
+function sanitizeForWinAnsi(
+  text: string,
+  font: { encodeText(t: string): unknown }
+): string {
+  try {
+    font.encodeText(text);
+    return text;
+  } catch {
+    let out = "";
+    let replaced = 0;
+    for (const ch of text) {
+      try {
+        font.encodeText(ch);
+        out += ch;
+      } catch {
+        out += "?";
+        replaced++;
+      }
+    }
+    if (replaced > 0) {
+      log.warn("Replaced non-WinAnsi characters in PDF text", { replaced });
+    }
+    return out;
+  }
+}
+
 async function buildPdf(title: string | undefined, content: string): Promise<Uint8Array> {
   const { PDFDocument, StandardFonts } = await import("pdf-lib");
   const pdf = await PDFDocument.create();
   const font = await pdf.embedFont(StandardFonts.Helvetica);
   const bold = await pdf.embedFont(StandardFonts.HelveticaBold);
+
+  // Standard fonts can only encode WinAnsi (CP1252); sanitize so non-CP1252
+  // characters degrade to "?" instead of throwing (REV-COR-499). `font` and `bold`
+  // share the same WinAnsi encoding, so validating against `font` covers both.
+  const safeTitle = title === undefined ? undefined : sanitizeForWinAnsi(title, font);
+  const safeContent = sanitizeForWinAnsi(content, font);
 
   const pageWidth = 612;
   const pageHeight = 792;
@@ -153,11 +192,11 @@ async function buildPdf(title: string | undefined, content: string): Promise<Uin
     y -= size + 4;
   };
 
-  if (title) {
-    for (const l of wrapPdfLines(title, bold, 18, maxWidth)) drawLine(l, bold, 18);
+  if (safeTitle) {
+    for (const l of wrapPdfLines(safeTitle, bold, 18, maxWidth)) drawLine(l, bold, 18);
     y -= 8;
   }
-  for (const l of wrapPdfLines(content, font, fontSize, maxWidth)) {
+  for (const l of wrapPdfLines(safeContent, font, fontSize, maxWidth)) {
     if (l === "") {
       y -= lineHeight / 2;
       continue;

--- a/lib/ai/image-generation-service.ts
+++ b/lib/ai/image-generation-service.ts
@@ -36,6 +36,42 @@ interface GeminiGenerateTextResult {
 const log = createLogger({ module: 'image-generation-service' });
 
 const MAX_REFERENCE_REDIRECTS = 5;
+/** Mirrors `lib/agents/agent-tools/web-fetch.ts` FETCH_TIMEOUT_MS/MAX_BYTES bounds. */
+const REFERENCE_IMAGE_TIMEOUT_MS = 10_000;
+const REFERENCE_IMAGE_MAX_BYTES = 10_000_000;
+/** Actual HTTP redirect codes — excludes 304 Not Modified and other non-redirect 3xx. */
+const REDIRECT_STATUS_CODES = new Set([301, 302, 303, 307, 308]);
+
+/** Read a response body without buffering past `maxBytes`, aborting the stream early. */
+async function readBoundedArrayBuffer(res: Response, maxBytes: number): Promise<ArrayBuffer> {
+  if (!res.body) {
+    const buffer = await res.arrayBuffer();
+    if (buffer.byteLength > maxBytes) {
+      throw createImageError('NO_IMAGE', 'Reference image exceeds maximum allowed size');
+    }
+    return buffer;
+  }
+  const reader = res.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  for (;;) {
+    const result = await reader.read();
+    if (result.done) break;
+    total += result.value.byteLength;
+    if (total > maxBytes) {
+      await reader.cancel();
+      throw createImageError('NO_IMAGE', 'Reference image exceeds maximum allowed size');
+    }
+    chunks.push(result.value);
+  }
+  const out = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    out.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return out.buffer;
+}
 
 /**
  * Fetch a caller-supplied reference-image URL with SSRF protection (REV-COR-497).
@@ -47,6 +83,11 @@ const MAX_REFERENCE_REDIRECTS = 5;
  * can 302 to an internal one — by following redirects manually. Returns the raw
  * bytes + content-type so callers can pass base64 to the AI SDK instead of a raw URL
  * (so the SDK never fetches an unguarded URL server-side).
+ *
+ * Bounded like the sibling `web-fetch.ts` guard: a request timeout so a slow/stalled
+ * origin can't hang the request indefinitely, and a streamed size cap so a large
+ * response can't exhaust memory (checked incrementally, not just via Content-Length,
+ * since that header can be absent or lie).
  *
  * Exported for unit testing.
  */
@@ -63,19 +104,31 @@ export async function fetchReferenceImageSafely(
       });
       throw createImageError('NO_IMAGE', 'Reference image URL is not allowed');
     }
-    const res = await fetch(currentUrl, { redirect: 'manual' });
-    if (res.status >= 300 && res.status < 400) {
+    const res = await fetch(currentUrl, {
+      redirect: 'manual',
+      signal: AbortSignal.timeout(REFERENCE_IMAGE_TIMEOUT_MS),
+    });
+    if (REDIRECT_STATUS_CODES.has(res.status)) {
       const location = res.headers.get('location');
-      if (!location) break;
+      if (!location) {
+        throw createImageError(
+          'NO_IMAGE',
+          `Redirect response missing Location header (status ${res.status})`
+        );
+      }
       currentUrl = new URL(location, currentUrl).toString();
       continue;
     }
     if (!res.ok) {
       throw createImageError('NO_IMAGE', `Failed to fetch reference image (status ${res.status})`);
     }
-    const arrayBuffer = await res.arrayBuffer();
-    const mimeType = res.headers.get('content-type') || 'image/png';
-    return { data: arrayBuffer, mimeType };
+    const contentLength = res.headers.get('content-length');
+    if (contentLength && Number(contentLength) > REFERENCE_IMAGE_MAX_BYTES) {
+      throw createImageError('NO_IMAGE', 'Reference image exceeds maximum allowed size');
+    }
+    const data = await readBoundedArrayBuffer(res, REFERENCE_IMAGE_MAX_BYTES);
+    const mimeType = (res.headers.get('content-type') || 'image/png').split(';')[0].trim();
+    return { data, mimeType };
   }
   throw createImageError('NO_IMAGE', 'Too many redirects fetching reference image');
 }

--- a/lib/ai/image-generation-service.ts
+++ b/lib/ai/image-generation-service.ts
@@ -18,6 +18,7 @@ import { GetObjectCommand } from '@aws-sdk/client-s3';
 import { createLogger, generateRequestId } from '@/lib/logger';
 import { Settings } from '@/lib/settings-manager';
 import { ErrorFactories } from '@/lib/error-utils';
+import { assertSafeFetchUrl } from '@/lib/agents/agent-tools/web-fetch';
 
 // Type for OpenAI image size
 type OpenAIImageSize = '256x256' | '512x512' | '1024x1024' | '1792x1024' | '1024x1792';
@@ -33,6 +34,51 @@ interface GeminiGenerateTextResult {
 }
 
 const log = createLogger({ module: 'image-generation-service' });
+
+const MAX_REFERENCE_REDIRECTS = 5;
+
+/**
+ * Fetch a caller-supplied reference-image URL with SSRF protection (REV-COR-497).
+ *
+ * Reference-image `url`s originate from user chat message parts, so they are
+ * untrusted. Validate the host against the shared SSRF guard (`assertSafeFetchUrl`
+ * blocks private/loopback/link-local/cloud-metadata hosts and non-http(s) schemes)
+ * BEFORE issuing the request, and re-validate on every redirect hop — a public host
+ * can 302 to an internal one — by following redirects manually. Returns the raw
+ * bytes + content-type so callers can pass base64 to the AI SDK instead of a raw URL
+ * (so the SDK never fetches an unguarded URL server-side).
+ *
+ * Exported for unit testing.
+ */
+export async function fetchReferenceImageSafely(
+  rawUrl: string
+): Promise<{ data: ArrayBuffer; mimeType: string }> {
+  let currentUrl = rawUrl;
+  for (let hop = 0; hop <= MAX_REFERENCE_REDIRECTS; hop++) {
+    try {
+      assertSafeFetchUrl(currentUrl);
+    } catch (e) {
+      log.warn('Blocked unsafe reference-image URL', {
+        reason: e instanceof Error ? e.message : String(e),
+      });
+      throw createImageError('NO_IMAGE', 'Reference image URL is not allowed');
+    }
+    const res = await fetch(currentUrl, { redirect: 'manual' });
+    if (res.status >= 300 && res.status < 400) {
+      const location = res.headers.get('location');
+      if (!location) break;
+      currentUrl = new URL(location, currentUrl).toString();
+      continue;
+    }
+    if (!res.ok) {
+      throw createImageError('NO_IMAGE', `Failed to fetch reference image (status ${res.status})`);
+    }
+    const arrayBuffer = await res.arrayBuffer();
+    const mimeType = res.headers.get('content-type') || 'image/png';
+    return { data: arrayBuffer, mimeType };
+  }
+  throw createImageError('NO_IMAGE', 'Too many redirects fetching reference image');
+}
 
 // Cache S3 client to avoid repeated async calls
 let s3ClientCache: S3Client | null = null;
@@ -219,11 +265,9 @@ async function generateWithOpenAIDirect(
         type: ref.mimeType || 'image/png',
       });
     } else if (ref.url) {
-      const fetched = await fetch(ref.url);
-      if (!fetched.ok) {
-        throw createImageError('NO_IMAGE', 'Failed to fetch reference image');
-      }
-      blob = await fetched.blob();
+      // ref.url is user-controlled — fetch it through the SSRF guard (REV-COR-497).
+      const { data, mimeType } = await fetchReferenceImageSafely(ref.url);
+      blob = new Blob([data], { type: ref.mimeType || mimeType });
     } else {
       throw createImageError('NO_IMAGE', 'Reference image has no base64 or url');
     }
@@ -398,8 +442,11 @@ async function generateWithOpenAI(
           // AI SDK accepts base64 strings (with or without data URL prefix)
           imageInputs.push(refImage.base64);
         } else if (refImage.url) {
-          // AI SDK also accepts URLs
-          imageInputs.push(refImage.url);
+          // Pre-download user-controlled URLs through the SSRF guard and pass base64,
+          // so the AI SDK never fetches an unguarded URL server-side (REV-COR-497).
+          // base64 is the same shape the SDK accepts on the branch above.
+          const { data, mimeType } = await fetchReferenceImageSafely(refImage.url);
+          imageInputs.push(`data:${mimeType};base64,${Buffer.from(data).toString('base64')}`);
         }
       }
 
@@ -557,10 +604,14 @@ async function generateWithGemini(
             mimeType
           });
         } else if (refImage.url) {
-          // Gemini can fetch images from URLs
+          // Pre-download user-controlled URLs through the SSRF guard and pass base64,
+          // so the SDK never fetches an unguarded URL server-side (REV-COR-497). This
+          // matches the base64 branch shape above.
+          const { data, mimeType } = await fetchReferenceImageSafely(refImage.url);
           contentParts.push({
             type: 'image',
-            image: refImage.url
+            image: Buffer.from(data).toString('base64'),
+            mimeType: refImage.mimeType || mimeType
           });
         }
       }

--- a/lib/ai/provider-factory.ts
+++ b/lib/ai/provider-factory.ts
@@ -1,6 +1,6 @@
 import { createOpenAI } from '@ai-sdk/openai';
 import { createAzure } from '@ai-sdk/azure';
-import { google } from '@ai-sdk/google';
+import { createGoogleGenerativeAI } from '@ai-sdk/google';
 import { createAmazonBedrock } from '@ai-sdk/amazon-bedrock';
 import { Settings } from '@/lib/settings-manager';
 import { ErrorFactories } from '@/lib/error-utils';
@@ -97,8 +97,10 @@ async function createGoogleModel(modelId: string): Promise<LanguageModel> {
     }
 
     log.debug(`Creating Google model: ${modelId}`);
-    // Set environment variable for Google SDK
-    process.env.GOOGLE_GENERATIVE_AI_API_KEY = apiKey;
+    // Scope the DB-sourced key to this client instead of mutating process.env at
+    // request time (REV-COR-505 / REV-REF-034). Mirrors gemini-adapter.ts and
+    // image-generation-service.ts.
+    const google = createGoogleGenerativeAI({ apiKey });
     return google(modelId);
   } catch (error) {
     log.error('Failed to create Google model', { modelId, error });

--- a/lib/tools/provider-native-tools.ts
+++ b/lib/tools/provider-native-tools.ts
@@ -1,5 +1,5 @@
 import { createOpenAI } from '@ai-sdk/openai'
-import { google } from '@ai-sdk/google'
+import { createGoogleGenerativeAI } from '@ai-sdk/google'
 import { Settings } from '@/lib/settings-manager'
 import { createLogger } from '@/lib/logger'
 import type { ToolSet } from 'ai'
@@ -116,8 +116,9 @@ async function createGoogleNativeTools(enabledTools: string[]): Promise<ToolSet>
       return {}
     }
 
-    // Set environment variable for Google SDK
-    process.env.GOOGLE_GENERATIVE_AI_API_KEY = apiKey
+    // Scope the key to a per-call client instead of mutating process.env
+    // (REV-REF-034). Mirrors gemini-adapter.ts / provider-factory.ts.
+    const google = createGoogleGenerativeAI({ apiKey })
 
     // Web search tool - accept both friendly name and provider name
     const hasWebSearch = enabledTools.some(t =>

--- a/tests/unit/lib/ai/document-generation-service.test.ts
+++ b/tests/unit/lib/ai/document-generation-service.test.ts
@@ -106,6 +106,29 @@ describe("generateDocument", () => {
     expect(result.filename.endsWith(".txt")).toBe(true);
   });
 
+  it("renders a PDF with non-WinAnsi characters (emoji/CJK/Cyrillic/Greek) instead of throwing (REV-COR-499)", async () => {
+    const result = await generateDocument({
+      format: "pdf",
+      title: "Unicode 😀 Report 日本語",
+      content: "Hello 😀 world — café 日本語 Привет Ωμέγα ↦ ∑",
+      userId: "42",
+    });
+    expect(result.format).toBe("pdf");
+    expect(result.bytes).toBeGreaterThan(0);
+    expect(sendMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("still renders an ASCII/CP1252-only PDF (regression, REV-COR-499)", async () => {
+    const result = await generateDocument({
+      format: "pdf",
+      title: "Plain Report",
+      content: "Hello world.\n\nSecond paragraph — café, résumé, naïve.",
+      userId: "42",
+    });
+    expect(result.format).toBe("pdf");
+    expect(result.bytes).toBeGreaterThan(0);
+  });
+
   describe("isDocumentFormat", () => {
     it("accepts known formats and rejects others", () => {
       expect(isDocumentFormat("pdf")).toBe(true);

--- a/tests/unit/lib/ai/document-generation-service.test.ts
+++ b/tests/unit/lib/ai/document-generation-service.test.ts
@@ -38,8 +38,21 @@ jest.mock("@/lib/settings-manager", () => ({
 import {
   generateDocument,
   isDocumentFormat,
+  sanitizeForWinAnsi,
 } from "@/lib/ai/document-generation-service";
 import { DOCUMENT_FORMATS } from "@/lib/agents/agent-tools/descriptors";
+
+/** A font stub that rejects a fixed set of "non-WinAnsi" characters, like pdf-lib's StandardFonts. */
+function makeFontStub(unencodable: Set<string>) {
+  return {
+    encodeText(t: string) {
+      for (const ch of t) {
+        if (unencodable.has(ch)) throw new Error(`cannot encode ${ch}`);
+      }
+      return t;
+    },
+  };
+}
 
 describe("generateDocument", () => {
   beforeEach(() => {
@@ -127,6 +140,33 @@ describe("generateDocument", () => {
     });
     expect(result.format).toBe("pdf");
     expect(result.bytes).toBeGreaterThan(0);
+  });
+
+  describe("sanitizeForWinAnsi", () => {
+    // pdf-lib's real StandardFonts reject "\n" too, which is what drives both bugs
+    // this covers: line breaks surviving the fallback, and the fallback being cached.
+    const font = makeFontStub(new Set(["\n", "😀"]));
+
+    it("preserves line breaks when the fallback path is triggered by an unencodable character", () => {
+      const result = sanitizeForWinAnsi("Hello 😀\n\nSecond paragraph.", font);
+      expect(result).toBe("Hello ?\n\nSecond paragraph.");
+    });
+
+    it("returns ASCII/CP1252 text unchanged via the whole-string fast path", () => {
+      expect(sanitizeForWinAnsi("Plain text, no issues.", font)).toBe(
+        "Plain text, no issues."
+      );
+    });
+
+    it("caches per-character encodability instead of re-checking repeated characters", () => {
+      const encodeTextSpy = jest.spyOn(font, "encodeText");
+      const repeated = "😀".repeat(50);
+      encodeTextSpy.mockClear();
+      sanitizeForWinAnsi(repeated, font);
+      // 1 call for the whole-string fast-path attempt, then 1 more per UNIQUE
+      // character in the fallback (just "😀") — not 50.
+      expect(encodeTextSpy).toHaveBeenCalledTimes(2);
+    });
   });
 
   describe("isDocumentFormat", () => {

--- a/tests/unit/lib/ai/image-generation-service.test.ts
+++ b/tests/unit/lib/ai/image-generation-service.test.ts
@@ -67,4 +67,97 @@ describe("fetchReferenceImageSafely — SSRF guard (REV-COR-497)", () => {
     // Hop 0 (public) fetched; hop 1 (metadata) blocked before fetching.
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
+
+  it("passes an AbortSignal so a hanging origin cannot stall the request indefinitely", async () => {
+    fetchMock.mockResolvedValueOnce({
+      status: 200,
+      ok: true,
+      headers: { get: (k: string) => (k.toLowerCase() === "content-type" ? "image/png" : null) },
+      arrayBuffer: async () => new ArrayBuffer(0),
+    });
+    await fetchReferenceImageSafely("https://example.com/ref.png");
+    const options = fetchMock.mock.calls[0][1];
+    expect(options.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it("rejects a 304 Not Modified instead of treating it as a redirect", async () => {
+    fetchMock.mockResolvedValueOnce({
+      status: 304,
+      ok: false,
+      headers: { get: () => null },
+    });
+    await expect(fetchReferenceImageSafely("https://example.com/ref.png")).rejects.toThrow(
+      /status 304/
+    );
+  });
+
+  it("rejects a redirect response with no Location header instead of silently stopping", async () => {
+    fetchMock.mockResolvedValueOnce({
+      status: 302,
+      ok: false,
+      headers: { get: () => null },
+    });
+    await expect(fetchReferenceImageSafely("https://example.com/redirect")).rejects.toThrow(
+      /Location/
+    );
+  });
+
+  it("rejects a response whose Content-Length exceeds the size cap before buffering", async () => {
+    const arrayBuffer = jest.fn();
+    fetchMock.mockResolvedValueOnce({
+      status: 200,
+      ok: true,
+      headers: {
+        get: (k: string) => {
+          const key = k.toLowerCase();
+          if (key === "content-type") return "image/png";
+          if (key === "content-length") return "50000000";
+          return null;
+        },
+      },
+      arrayBuffer,
+    });
+    await expect(
+      fetchReferenceImageSafely("https://example.com/huge.png")
+    ).rejects.toThrow(/exceeds maximum allowed size/);
+    expect(arrayBuffer).not.toHaveBeenCalled();
+  });
+
+  it("bounds a streamed response with no Content-Length by size, not just the header", async () => {
+    const bigChunk = new Uint8Array(6_000_000);
+    let call = 0;
+    const reader = {
+      read: jest.fn(async () => {
+        call += 1;
+        if (call <= 2) return { done: false, value: bigChunk };
+        return { done: true, value: undefined };
+      }),
+      cancel: jest.fn(async () => {}),
+    };
+    fetchMock.mockResolvedValueOnce({
+      status: 200,
+      ok: true,
+      headers: { get: (k: string) => (k.toLowerCase() === "content-type" ? "image/png" : null) },
+      body: { getReader: () => reader },
+    });
+    await expect(
+      fetchReferenceImageSafely("https://example.com/stream.png")
+    ).rejects.toThrow(/exceeds maximum allowed size/);
+    expect(reader.cancel).toHaveBeenCalled();
+  });
+
+  it("strips Content-Type parameters so the mime type is canonical", async () => {
+    const body = new TextEncoder().encode("PNGDATA").buffer;
+    fetchMock.mockResolvedValueOnce({
+      status: 200,
+      ok: true,
+      headers: {
+        get: (k: string) =>
+          k.toLowerCase() === "content-type" ? "image/png; charset=binary" : null,
+      },
+      arrayBuffer: async () => body,
+    });
+    const { mimeType } = await fetchReferenceImageSafely("https://example.com/ref.png");
+    expect(mimeType).toBe("image/png");
+  });
 });

--- a/tests/unit/lib/ai/image-generation-service.test.ts
+++ b/tests/unit/lib/ai/image-generation-service.test.ts
@@ -1,0 +1,70 @@
+/**
+ * @jest-environment node
+ *
+ * SSRF guard for server-side reference-image fetching (REV-COR-497).
+ * Uses the global `jest` (not @jest/globals) so jest.mock hoisting works.
+ */
+import { fetchReferenceImageSafely } from "@/lib/ai/image-generation-service";
+
+describe("fetchReferenceImageSafely — SSRF guard (REV-COR-497)", () => {
+  let fetchMock: jest.Mock;
+
+  beforeEach(() => {
+    fetchMock = jest.fn();
+    global.fetch = fetchMock as unknown as typeof fetch;
+  });
+
+  it("rejects the cloud-metadata IP before issuing any request", async () => {
+    await expect(
+      fetchReferenceImageSafely("http://169.254.169.254/latest/meta-data/")
+    ).rejects.toThrow();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects the ECS credentials endpoint before issuing any request", async () => {
+    await expect(fetchReferenceImageSafely("http://169.254.170.2/creds")).rejects.toThrow();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects a loopback URL before issuing any request", async () => {
+    await expect(fetchReferenceImageSafely("http://127.0.0.1/x.png")).rejects.toThrow();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects a private RFC-1918 URL before issuing any request", async () => {
+    await expect(fetchReferenceImageSafely("http://10.0.0.5/x.png")).rejects.toThrow();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("fetches a public URL and returns bytes + content type", async () => {
+    const body = new TextEncoder().encode("PNGDATA").buffer;
+    fetchMock.mockResolvedValueOnce({
+      status: 200,
+      ok: true,
+      headers: {
+        get: (k: string) => (k.toLowerCase() === "content-type" ? "image/png" : null),
+      },
+      arrayBuffer: async () => body,
+    });
+    const { data, mimeType } = await fetchReferenceImageSafely("https://example.com/ref.png");
+    expect(mimeType).toBe("image/png");
+    expect(Buffer.from(data).toString()).toBe("PNGDATA");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-validates redirects: a public URL that 302s to the metadata IP is rejected", async () => {
+    fetchMock.mockResolvedValueOnce({
+      status: 302,
+      ok: false,
+      headers: {
+        get: (k: string) =>
+          k.toLowerCase() === "location" ? "http://169.254.169.254/" : null,
+      },
+    });
+    await expect(
+      fetchReferenceImageSafely("https://example.com/redirect")
+    ).rejects.toThrow();
+    // Hop 0 (public) fetched; hop 1 (metadata) blocked before fetching.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/unit/lib/ai/provider-factory-google.test.ts
+++ b/tests/unit/lib/ai/provider-factory-google.test.ts
@@ -1,0 +1,67 @@
+/**
+ * @jest-environment node
+ *
+ * Google provider client construction (REV-COR-505 / REV-REF-034): both the model
+ * factory and the native-tools builder must construct a per-call
+ * `createGoogleGenerativeAI({ apiKey })` client and must NOT mutate
+ * `process.env.GOOGLE_GENERATIVE_AI_API_KEY`.
+ *
+ * Uses the global `jest` (not @jest/globals) so jest.mock hoisting works.
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+const googleSearchTool = { __googleSearch: true };
+const createGoogleGenerativeAIMock = jest.fn((_opts: unknown) =>
+  Object.assign((modelId: string) => ({ modelId, provider: "google" }), {
+    tools: { googleSearch: jest.fn(() => googleSearchTool) },
+  })
+);
+
+jest.mock("@ai-sdk/google", () => ({
+  createGoogleGenerativeAI: (opts: unknown) => createGoogleGenerativeAIMock(opts),
+}));
+
+jest.mock("@/lib/settings-manager", () => ({
+  Settings: {
+    getGoogleAI: jest.fn().mockResolvedValue("test-google-key"),
+    getOpenAI: jest.fn(),
+    getBedrock: jest.fn(),
+    getAzure: jest.fn(),
+  },
+}));
+
+import { createProviderModel } from "@/lib/ai/provider-factory";
+import { createProviderNativeTools } from "@/lib/tools/provider-native-tools";
+
+const ENV_KEY = "GOOGLE_GENERATIVE_AI_API_KEY";
+
+describe("Google client construction (REV-COR-505 / REV-REF-034)", () => {
+  beforeEach(() => {
+    createGoogleGenerativeAIMock.mockClear();
+    delete process.env[ENV_KEY];
+  });
+
+  it("createProviderModel('google') builds a scoped client and does not touch process.env", async () => {
+    const model = await createProviderModel("google", "gemini-2.5-flash");
+    expect(createGoogleGenerativeAIMock).toHaveBeenCalledWith({ apiKey: "test-google-key" });
+    expect(model).toBeDefined();
+    expect(process.env[ENV_KEY]).toBeUndefined();
+  });
+
+  it("createProviderNativeTools('google') builds google_search without touching process.env", async () => {
+    const tools = await createProviderNativeTools("google", "gemini-2.5-flash", ["webSearch"]);
+    expect(createGoogleGenerativeAIMock).toHaveBeenCalledWith({ apiKey: "test-google-key" });
+    expect((tools as Record<string, unknown>).google_search).toBeDefined();
+    expect(process.env[ENV_KEY]).toBeUndefined();
+  });
+
+  it("neither source module assigns process.env.GOOGLE_GENERATIVE_AI_API_KEY (REF-034)", () => {
+    const root = path.join(__dirname, "..", "..", "..", "..");
+    const assignRe = /process\.env\.GOOGLE_GENERATIVE_AI_API_KEY\s*=/;
+    for (const rel of ["lib/ai/provider-factory.ts", "lib/tools/provider-native-tools.ts"]) {
+      const src = fs.readFileSync(path.join(root, rel), "utf8");
+      expect(assignRe.test(src)).toBe(false);
+    }
+  });
+});


### PR DESCRIPTION
## Batch B-016 — lib/ai

All **4** findings implemented (1 High, 2 Medium, 1 Low). **No deferrals.** `bun run lint` (0 errors) + `bun run typecheck` pass; **23 affected tests pass**.

| ID | Sev | Fix |
|----|-----|-----|
| **REV-COR-497** | High | **Reference-image SSRF.** `image-generation-service` fetched caller-supplied reference-image URLs (straight from user chat parts) server-side with no host validation — blind SSRF reaching private/loopback/link-local and cloud-metadata (`169.254.169.254`, ECS creds `169.254.170.2`). Added `fetchReferenceImageSafely()`: validates the host via the shared `assertSafeFetchUrl` guard **before** the request and re-validates **every redirect hop** (`redirect: 'manual'`). All three reference-URL sites route through it — the direct `/images/edits` fetch and the two AI-SDK paths (`generateImage`, Gemini `generateText`) now **pre-download through the guard and pass base64**, so the SDK never fetches an unguarded URL. base64 / S3-key paths unchanged. |
| **REV-COR-499** | Med | **PDF Unicode crash.** pdf-lib `StandardFonts` use WinAnsi (CP1252), so one emoji/CJK/Cyrillic/Greek/symbol char threw and failed the whole PDF. `buildPdf` now sanitizes title/content against the font (whole-string fast path → per-char fallback replacing unencodable code points with `?`, logging the count) before wrapping/drawing. Only the PDF branch changed. |
| **REV-REF-034** | Med | **Google client env-mutation (dup).** `provider-factory.createGoogleModel` **and** `provider-native-tools.createGoogleNativeTools` mutated `process.env.GOOGLE_GENERATIVE_AI_API_KEY` then used the shared `google` singleton. Both now build a per-call `createGoogleGenerativeAI({ apiKey })` client (matching `gemini-adapter.ts`) and no longer assign the env var. Reference adapter untouched. |
| **REV-COR-505** | Low | Same env-mutation in `createGoogleModel` (the provider-factory half of REF-034) — resolved by the scoped-client switch above. |

### Determination for REV-COR-497 Done-when #3 (AI-SDK paths)
The OpenAI edits endpoint and Gemini both need image **bytes**, so the SDKs would download a raw `url` server-side. Rather than rely on SDK internals, all URL inputs are **pre-downloaded through the guarded fetch and passed as base64** (the same shape the existing base64 branches use), so no raw user URL is ever handed to the SDK. Documented in code comments.

### Verification
- Confirmed `assertSafeFetchUrl` blocks `169.254.0.0/16` (IMDS), loopback, RFC-1918, ULA/link-local IPv6 — so the guard covers the exact attack.
- Verified **nothing reads** `GOOGLE_GENERATIVE_AI_API_KEY` and **no assignment sites remain** across `lib`/`app`/`actions` (REF-034 grep Done-when).
- Tests: `image-generation-service.test.ts` (6: metadata/ECS/loopback/RFC-1918 rejected pre-fetch, public fetched, redirect-to-internal rejected), `document-generation-service.test.ts` (+2: emoji/CJK PDF resolves, ASCII regression), `provider-factory-google.test.ts` (3: scoped client + no env mutation + source grep).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HWA2JRbkae8HCRsZwoEJXw
