### PR TITLE
feat: Nexus workspace chat editing — chat edits the open document/artifact (Atrium §1087)

### DIFF
--- a/app/(protected)/nexus/page.tsx
+++ b/app/(protected)/nexus/page.tsx
@@ -68,6 +68,8 @@ interface ConversationRuntimeProviderProps {
   enabledTools: string[]
   enabledConnectors: string[]
   skillId?: string
+  /** The open workspace object id/slug (`?workspace=`); binds §1087 content tools server-side. */
+  workspaceId?: string
   attachmentAdapter: AttachmentAdapter
   voiceAdapter?: RealtimeVoiceAdapter
   initialMessages?: UIMessage[]
@@ -88,6 +90,7 @@ function ConversationRuntimeProvider({
   enabledTools,
   enabledConnectors,
   skillId,
+  workspaceId,
   attachmentAdapter,
   voiceAdapter,
   initialMessages = [],
@@ -101,6 +104,13 @@ function ConversationRuntimeProvider({
   // causing duplicate message rendering. (Issue #868)
   const conversationIdRef = useRef(conversationId)
   conversationIdRef.current = conversationId
+
+  // Track the open workspace id via ref so the transport body always sends the
+  // CURRENT value: the runtime is created once (stable), but the user can open /
+  // close / switch the workspace panel mid-conversation (§1087). Reading a ref
+  // keeps the sent workspaceId fresh without recreating the transport.
+  const workspaceIdRef = useRef(workspaceId)
+  workspaceIdRef.current = workspaceId
 
   // Track session status via ref for use inside customFetch without adding to deps.
   // useSession is safe here — SessionProvider wraps this component tree.
@@ -323,6 +333,8 @@ function ConversationRuntimeProvider({
           enabledConnectors,
           // Bind the session to a skill so the server enforces its allowed-tools pin (#925).
           skillId,
+          // Bind the open workspace object so the server offers §1087 read/edit tools.
+          workspaceId: workspaceIdRef.current || undefined,
           conversationId: conversationIdRef.current || undefined
         }
       }
@@ -353,6 +365,8 @@ interface NexusRuntimeWrapperProps {
   enabledTools: string[]
   enabledConnectors: string[]
   skillId?: string
+  /** Open workspace object id/slug (`?workspace=`); passed to the runtime for §1087 tools. */
+  workspaceId?: string
   attachmentAdapter: AttachmentAdapter
   voiceAvailable: boolean
   voiceUnavailableReason?: string
@@ -372,6 +386,7 @@ function NexusRuntimeWrapper({
   enabledTools,
   enabledConnectors,
   skillId,
+  workspaceId,
   attachmentAdapter,
   voiceAvailable,
   voiceUnavailableReason,
@@ -452,6 +467,7 @@ function NexusRuntimeWrapper({
       enabledTools={enabledTools}
       enabledConnectors={enabledConnectors}
       skillId={skillId}
+      workspaceId={workspaceId}
       attachmentAdapter={attachmentAdapter}
       voiceAdapter={voiceAdapter}
       initialMessages={initialMessages}
@@ -668,7 +684,13 @@ function NexusPageContent() {
     // component state is reset — equivalent to the previous reload() but targeting
     // the clean URL without ?id=.
     if (model && selectedModel && model.modelId !== selectedModel.modelId) {
-      window.location.href = '/nexus';
+      // Preserve an open workspace across the model-change reload (§1087): the
+      // clean-URL reset must not silently close the document/artifact the user is
+      // editing beside the chat (it would also drop the workspace content tools).
+      const workspace = new URLSearchParams(window.location.search).get('workspace');
+      window.location.href = workspace
+        ? `/nexus?workspace=${encodeURIComponent(workspace)}`
+        : '/nexus';
     }
   }, [originalSetSelectedModel, selectedModel])
 
@@ -837,6 +859,7 @@ function NexusPageContent() {
                           enabledTools={enabledTools}
                           enabledConnectors={enabledConnectors}
                           skillId={urlSkillId}
+                          workspaceId={urlWorkspaceId ?? undefined}
                           attachmentAdapter={attachmentAdapter}
                           voiceAvailable={voiceAvailability.available}
                           voiceUnavailableReason={!voiceAvailability.available && !voiceAvailability.loading ? voiceAvailability.reason : undefined}

--- a/app/api/nexus/chat/route.ts
+++ b/app/api/nexus/chat/route.ts
@@ -52,6 +52,7 @@ import {
   type ApprovedSkillSession,
 } from '@/lib/skills/skill-tool-enforcement';
 import { readSkillMarkdown } from '@/lib/skills/skill-publish-pipeline';
+import { buildWorkspaceChatTools } from '@/lib/nexus/workspace-chat-tools';
 
 // Allow streaming responses up to 30 minutes. Deep Research runs take 5–25
 // minutes; standard chat and image-gen finish well within this window.
@@ -135,6 +136,31 @@ function createOnFinishCallback(params: {
 }
 
 /**
+ * Pre-merge the adapter (universal) tools with per-user MCP connector tools and
+ * the open-workspace content tools (§1087). Returns undefined when neither
+ * connectors nor workspace tools are active (the streaming service then builds
+ * adapter tools itself from `enabledTools`). Connector + workspace tools take
+ * precedence over adapter tools on a name collision.
+ */
+async function buildMergedChatTools(params: {
+  enabledTools: string[];
+  connectorToolResults: McpConnectorToolsResult[];
+  workspaceTools?: ToolSet;
+}): Promise<ToolSet | undefined> {
+  const { enabledTools, connectorToolResults, workspaceTools } = params;
+  const hasWorkspaceTools = !!workspaceTools && Object.keys(workspaceTools).length > 0;
+  if (connectorToolResults.length === 0 && !hasWorkspaceTools) return undefined;
+  const merged: ToolSet = { ...(await createUniversalTools(enabledTools)) };
+  for (const result of connectorToolResults) {
+    Object.assign(merged, result.tools);
+  }
+  if (hasWorkspaceTools) {
+    Object.assign(merged, workspaceTools);
+  }
+  return merged;
+}
+
+/**
  * Execute streaming and return response
  */
 async function executeStreaming(params: {
@@ -153,6 +179,10 @@ async function executeStreaming(params: {
   skillInstructions?: string;
   /** Bound skill's name (labels the injected instruction block). */
   skillName?: string;
+  /** Server-built AI SDK tools for the open workspace object (Atrium §1087). */
+  workspaceTools?: ToolSet;
+  /** System-prompt line describing the open workspace object + how to edit it. */
+  workspacePromptFragment?: string;
   reasoningEffort: 'minimal' | 'low' | 'medium' | 'high';
   responseMode: 'standard' | 'flex' | 'priority';
   requestId: string;
@@ -165,24 +195,22 @@ async function executeStreaming(params: {
     messages, modelConfig, userId, sessionId, conversationId,
     conversationIdValue, conversationTitle, enabledTools, enabledConnectors,
     connectorToolResults, failedConnectorIds, skillInstructions, skillName,
+    workspaceTools, workspacePromptFragment,
     reasoningEffort, responseMode,
     requestId, dbModelId, log, timer, precomputedInputTokenMappings
   } = params;
 
-  const systemPrompt = buildNexusSystemPrompt(skillInstructions, skillName);
+  const systemPrompt = buildNexusSystemPrompt(skillInstructions, skillName, workspacePromptFragment);
 
-  // When MCP connectors are enabled, pre-merge adapter tools + connector tools
-  // and pass as request.tools so the streaming service uses them directly
-  // (skipping adapter.createTools to avoid redundant work).
-  // Connector tools take precedence on name collision.
-  let mergedTools: ToolSet | undefined;
-  if (connectorToolResults.length > 0) {
-    const adapterTools = await createUniversalTools(enabledTools);
-    mergedTools = { ...adapterTools };
-    for (const result of connectorToolResults) {
-      Object.assign(mergedTools, result.tools);
-    }
-  }
+  const hasWorkspaceTools = !!workspaceTools && Object.keys(workspaceTools).length > 0;
+  const multiStepToolsActive = connectorToolResults.length > 0 || hasWorkspaceTools;
+
+  // Pre-merge adapter + connector + workspace tools (undefined when none active).
+  const mergedTools = await buildMergedChatTools({
+    enabledTools,
+    connectorToolResults,
+    workspaceTools: hasWorkspaceTools ? workspaceTools : undefined,
+  });
 
   const streamRequest: StreamRequest = {
     messages,
@@ -196,10 +224,11 @@ async function executeStreaming(params: {
     enabledTools: mergedTools ? undefined : enabledTools,
     enabledConnectors,
     tools: mergedTools,
-    // maxSteps enables multi-step tool use (agent loop). Only needed when MCP connector
-    // tools are active — without connectors, the model uses single-step tool calls only.
-    // 10 steps is a reasonable upper bound for MCP tool chains (fetch→process→respond).
-    maxSteps: connectorToolResults.length > 0 ? 10 : undefined,
+    // maxSteps enables multi-step tool use (agent loop). Needed when MCP connector
+    // tools OR workspace content tools (§1087: read→edit→confirm) are active —
+    // without them the model uses single-step tool calls only. 10 steps is a
+    // reasonable upper bound for a read→edit→respond chain.
+    maxSteps: multiStepToolsActive ? 10 : undefined,
     options: { reasoningEffort, responseMode },
     precomputedInputTokenMappings,
     callbacks: {
@@ -284,6 +313,10 @@ const ChatRequestSchema = z.object({
   // When the session is bound to a published skill ("use in chat"), the skill's
   // `allowed-tools` pin is enforced server-side over the client tool list (#925 AC#6).
   skillId: z.string().uuid().optional(),
+  // When a workspace document/artifact is open beside the chat (`?workspace=<id|slug>`),
+  // the server binds read/edit tools for THAT object (Atrium §1087). Loose validation
+  // only — the tool builder canView/canEdit-gates server-side; cap length like other params.
+  workspaceId: z.string().min(1).max(200).optional(),
   reasoningEffort: z.enum(['minimal', 'low', 'medium', 'high']).optional(),
   responseMode: z.enum(['standard', 'priority', 'flex']).optional()
 });
@@ -1034,10 +1067,19 @@ IMPORTANT: If text contains privacy tokens like [PII:xxxx-xxxx-xxxx-xxxx], prese
  */
 function buildNexusSystemPrompt(
   skillInstructions: string | undefined,
-  skillName: string | undefined
+  skillName: string | undefined,
+  workspacePromptFragment?: string
 ): string {
-  if (!skillInstructions) return NEXUS_BASE_SYSTEM_PROMPT;
-  return `${NEXUS_BASE_SYSTEM_PROMPT}\n\n---\n\nThe user has loaded the skill "${skillName ?? 'skill'}" into this session. Follow its instructions below for this conversation.\n\n${skillInstructions}`;
+  let prompt = NEXUS_BASE_SYSTEM_PROMPT;
+  if (skillInstructions) {
+    prompt += `\n\n---\n\nThe user has loaded the skill "${skillName ?? 'skill'}" into this session. Follow its instructions below for this conversation.\n\n${skillInstructions}`;
+  }
+  // Atrium §1087: when a workspace document/artifact is open beside the chat,
+  // tell the model it can act on that object via the workspace tools.
+  if (workspacePromptFragment) {
+    prompt += `\n\n---\n\n${workspacePromptFragment}`;
+  }
+  return prompt;
 }
 
 /**
@@ -1123,6 +1165,21 @@ async function applySkillSessionBinding(args: {
 }
 
 /**
+ * Bind the open-workspace content tools for the chat request (Atrium §1087), or
+ * null when no workspace is open. Extracted so POST stays under the complexity
+ * budget; `buildWorkspaceChatTools` already canView/canEdit-gates and returns
+ * null on a bad/unviewable id.
+ */
+async function bindWorkspaceTools(
+  workspaceId: string | undefined,
+  userId: number,
+  requestId: string
+): Promise<Awaited<ReturnType<typeof buildWorkspaceChatTools>>> {
+  if (!workspaceId) return null;
+  return buildWorkspaceChatTools({ workspaceIdOrSlug: workspaceId, userId, requestId });
+}
+
+/**
  * Nexus Chat API - Native Streaming with AI SDK v5
  */
 export async function POST(req: Request) {
@@ -1141,7 +1198,7 @@ export async function POST(req: Request) {
     const validation = validateRequest(body, requestId, log);
     if (!validation.valid) return validation.error;
 
-    const { messages, modelId, provider = 'openai', conversationId: existingConversationId, enabledTools = [], enabledConnectors = [], skillId } = validation.data;
+    const { messages, modelId, provider = 'openai', conversationId: existingConversationId, enabledTools = [], enabledConnectors = [], skillId, workspaceId } = validation.data;
     const conversationIdValue = existingConversationId || undefined;
 
     // 2. Validate conversation ID format
@@ -1219,6 +1276,13 @@ export async function POST(req: Request) {
     });
     const { scopedEnabledTools, effectiveConnectorToolResults, skillInstructions, skillName } = skillBinding;
 
+    // 8c. Bind workspace content tools when a document/artifact is open beside the
+    // chat (Atrium §1087). Server-built + canView/canEdit-gated; a bad/unviewable
+    // `?workspace=` yields no tools (never breaks chat).
+    const workspace = await bindWorkspaceTools(workspaceId, userId, requestId);
+    const { tools: workspaceTools, systemPromptFragment: workspacePromptFragment } =
+      workspace ?? {};
+
     // 9. Execute streaming and return response
     // Once executeStreaming returns successfully, the streaming Response is in flight.
     // MCP client cleanup is handled inside onFinish (after all tool executions complete).
@@ -1239,6 +1303,8 @@ export async function POST(req: Request) {
       failedConnectorIds,
       skillInstructions,
       skillName,
+      workspaceTools,
+      workspacePromptFragment,
       reasoningEffort: validation.data.reasoningEffort || 'medium',
       responseMode: validation.data.responseMode || 'standard',
       requestId,

--- a/app/api/nexus/chat/route.ts
+++ b/app/api/nexus/chat/route.ts
@@ -221,7 +221,12 @@ async function executeStreaming(params: {
     conversationId,
     source: 'nexus',
     systemPrompt,
-    enabledTools: mergedTools ? undefined : enabledTools,
+    // Always pass the scoped enabledTools: when `tools` is also set (connector /
+    // workspace merge), the streaming service now merges the model's
+    // provider-native tools UNDER the pre-merged set so web search / code
+    // interpreter aren't dropped just because a connector or workspace is active
+    // (PR #1136 review). Without `tools`, this is the sole tool source as before.
+    enabledTools,
     enabledConnectors,
     tools: mergedTools,
     // maxSteps enables multi-step tool use (agent loop). Needed when MCP connector
@@ -1127,6 +1132,13 @@ async function applySkillSessionBinding(args: {
   effectiveConnectorToolResults: McpConnectorToolsResult[];
   skillInstructions: string | undefined;
   skillName: string | undefined;
+  /**
+   * The bound skill's `allowed-tools` pin (empty = no pin / no skill). Callers
+   * apply it to ANY additional tool set they add after this binding — e.g. the
+   * workspace content tools (§1087) — so a restrictive skill can't be widened by
+   * opening a workspace (PR #1136 review, codex P2).
+   */
+  skillAllowedTools: string[];
 }> {
   const { connectorToolResults, skillId, log } = args;
   const boundSkill = await loadBoundSkill(skillId, log);
@@ -1136,6 +1148,7 @@ async function applySkillSessionBinding(args: {
       effectiveConnectorToolResults: connectorToolResults,
       skillInstructions: undefined,
       skillName: undefined,
+      skillAllowedTools: [],
     };
   }
   const scopedEnabledTools = intersectSkillAllowedTools(
@@ -1161,7 +1174,27 @@ async function applySkillSessionBinding(args: {
     effectiveConnectorToolResults,
     skillInstructions: boundSkill.instructions ?? undefined,
     skillName: boundSkill.name,
+    skillAllowedTools: boundSkill.allowedTools,
   };
+}
+
+/**
+ * Apply a bound skill's `allowed-tools` pin to the workspace content tools
+ * (§1087 — PR #1136 review): with a non-empty pin, keep only workspace tools the
+ * skill explicitly allows (by tool name); an empty pin (no skill / unpinned)
+ * leaves them untouched. Prevents a restrictive skill from being silently widened
+ * with document/artifact-edit tools just because a workspace is open.
+ */
+function filterWorkspaceToolsBySkillPin(
+  tools: ToolSet | undefined,
+  skillAllowedTools: string[]
+): ToolSet | undefined {
+  if (!tools || skillAllowedTools.length === 0) return tools;
+  const allowedNames = intersectSkillAllowedTools(Object.keys(tools), skillAllowedTools);
+  const allowed = new Set(allowedNames);
+  return Object.fromEntries(
+    Object.entries(tools).filter(([name]) => allowed.has(name))
+  ) as ToolSet;
 }
 
 /**
@@ -1177,6 +1210,27 @@ async function bindWorkspaceTools(
 ): Promise<Awaited<ReturnType<typeof buildWorkspaceChatTools>>> {
   if (!workspaceId) return null;
   return buildWorkspaceChatTools({ workspaceIdOrSlug: workspaceId, userId, requestId });
+}
+
+/**
+ * Bind the §1087 workspace tools AND apply the bound skill's allowed-tools pin to
+ * them, returning the (possibly empty) tool set + the matching prompt fragment.
+ * Extracted so POST stays under the complexity budget (PR #1136 review).
+ */
+async function bindWorkspaceToolsForChat(args: {
+  workspaceId: string | undefined;
+  userId: number;
+  requestId: string;
+  skillAllowedTools: string[];
+}): Promise<{ workspaceTools: ToolSet | undefined; workspacePromptFragment: string | undefined }> {
+  const workspace = await bindWorkspaceTools(args.workspaceId, args.userId, args.requestId);
+  const workspaceTools = filterWorkspaceToolsBySkillPin(workspace?.tools, args.skillAllowedTools);
+  // Drop the prompt fragment when the pin filtered every workspace tool away.
+  const hasTools = !!workspaceTools && Object.keys(workspaceTools).length > 0;
+  return {
+    workspaceTools,
+    workspacePromptFragment: hasTools ? workspace?.systemPromptFragment : undefined,
+  };
 }
 
 /**
@@ -1274,14 +1328,16 @@ export async function POST(req: Request) {
       skillId,
       log,
     });
-    const { scopedEnabledTools, effectiveConnectorToolResults, skillInstructions, skillName } = skillBinding;
+    const { scopedEnabledTools, effectiveConnectorToolResults, skillInstructions, skillName, skillAllowedTools } = skillBinding;
 
     // 8c. Bind workspace content tools when a document/artifact is open beside the
     // chat (Atrium §1087). Server-built + canView/canEdit-gated; a bad/unviewable
-    // `?workspace=` yields no tools (never breaks chat).
-    const workspace = await bindWorkspaceTools(workspaceId, userId, requestId);
-    const { tools: workspaceTools, systemPromptFragment: workspacePromptFragment } =
-      workspace ?? {};
+    // `?workspace=` yields no tools (never breaks chat). A bound skill's
+    // allowed-tools pin still applies (a restrictive skill can't be widened by
+    // opening a workspace — PR #1136 review).
+    const { workspaceTools, workspacePromptFragment } = await bindWorkspaceToolsForChat({
+      workspaceId, userId, requestId, skillAllowedTools,
+    });
 
     // 9. Execute streaming and return response
     // Once executeStreaming returns successfully, the streaming Response is in flight.

--- a/docs/README.md
+++ b/docs/README.md
@@ -186,6 +186,9 @@ Tool integration for Assistant Architect prompts.
 #### [features/skill-publishing.md](./features/skill-publishing.md)
 **Skill publishing & export** — SKILL.md format, publish → scan → review pipeline, how skills are consumed (Nexus session binding vs `skill.{slug}` catalog tools), and the zip-export format + portability caveats for Claude Code / Desktop.
 
+#### [features/nexus-workspace-chat-editing.md](./features/nexus-workspace-chat-editing.md)
+**Nexus workspace chat editing (§1087)** — when a document/artifact is open beside the chat, the chat can read + edit it (live Yjs document edits via the agent bridge, artifact edits via `createVersion`); server-bound, canView/canEdit-gated, §28.3-screened.
+
 #### [features/assistant-architect-json-import-spec.md](./features/assistant-architect-json-import-spec.md)
 **Complete JSON import specification** for generating valid assistant import files. Includes schema reference, field types, variable substitution, execution patterns, and comprehensive examples.
 

--- a/docs/features/nexus-workspace-chat-editing.md
+++ b/docs/features/nexus-workspace-chat-editing.md
@@ -1,0 +1,63 @@
+# Nexus workspace chat editing (Atrium §1087)
+
+When an Atrium document or artifact is open beside the Nexus chat
+(`/nexus?workspace=<id|slug>`, the panel from Epic #1059 §17), the chat can
+**read and edit that open object** — the "re-prompt via adjacent chat" loop the
+design spec foregrounds (§1065/§1087). "Add a section about X", "rewrite this
+more formally", "change the button color" act on the panel, not just the chat.
+
+Before this, the panel was a pure layout sibling with no content tools in the
+chat surface, so asking the chat to change the open item did nothing.
+
+## How it works
+
+1. **Client** (`app/(protected)/nexus/page.tsx`): the open object's id/slug
+   (`?workspace=`) is sent on each chat request as `workspaceId`, via a ref so
+   opening/closing/switching the panel mid-conversation always sends the current
+   value. Switching the model preserves `?workspace=` (the model-change reset
+   used to drop it and silently close the panel).
+2. **Server** (`app/api/nexus/chat/route.ts` → `lib/nexus/workspace-chat-tools.ts`):
+   when `workspaceId` is present, the route binds a small set of AI SDK tools for
+   THAT object and injects a system-prompt line telling the model an object is
+   open. Tools are built **server-side** from the resolved id (never from the
+   client tool list), and the object is resolved through `contentService`
+   (canView 404-mask → canEdit 403) against the session user. `maxSteps` is
+   raised so the model can read → edit → respond in one turn.
+
+## Bound tools
+
+| Tool | When | Effect |
+|------|------|--------|
+| `read_workspace_content` | always (viewable object) | Returns the current title/kind/body so the model edits from the current content. |
+| `edit_workspace_document` | editable **document** | §28.3-screens the markdown, then writes it into the live Yjs doc via the agent bridge (`applyAgentEdit`) — it appears **immediately** in the panel with agent (purple-rail) attribution. `mode: append` (default) or `replace`. |
+| `update_workspace_artifact` | editable **artifact** | Creates a new version via `contentService.createVersion` (which canView/canEdit-gates and §28.3-screens the body); the new version appears in the artifact's version dropdown. |
+
+A caller who can view but not edit gets only `read_workspace_content`. An
+unknown/unviewable `?workspace=` yields **no** tools — a bad param never breaks
+chat.
+
+## Reuse (no new content logic)
+
+Every tool calls the SAME §11–§15 services the Atrium editors and the MCP content
+tools use — the agent bridge for live document edits, `contentService` for
+artifact versions — so screening, provenance, visibility, and version allocation
+are inherited, not reimplemented.
+
+## Verified
+
+- Unit: `tests/unit/lib/nexus/workspace-chat-tools.test.ts` (gating, read-only
+  vs editable, kind-specific tool, screening-refusal).
+- E2E: `tests/e2e/nexus-workspace-chat-tools.spec.ts` (the chat request carries
+  `workspaceId`, preserved across a model change).
+- Manually proven end-to-end on the :3100 collab server: a chat message drove
+  `read_workspace_content` → `edit_workspace_document` and the text appeared live
+  in the open editor with the purple agent rail; an artifact chat edit created a
+  new version.
+
+## Files
+
+- `lib/nexus/workspace-chat-tools.ts` — the tool set + system-prompt fragment
+- `app/api/nexus/chat/route.ts` — `workspaceId` schema field + `bindWorkspaceTools` + tool merge
+- `app/(protected)/nexus/page.tsx` — client `workspaceId` plumbing + model-change param preservation
+- `lib/content/collab/apply-agent-edit.ts` — the live document bridge (reused)
+- `lib/content/content-service.ts` — `createVersion` (reused, screens internally)

--- a/docs/features/nexus-workspace-chat-editing.md
+++ b/docs/features/nexus-workspace-chat-editing.md
@@ -36,6 +36,28 @@ A caller who can view but not edit gets only `read_workspace_content`. An
 unknown/unviewable `?workspace=` yields **no** tools — a bad param never breaks
 chat.
 
+### Safety & correctness invariants (PR #1136 review)
+
+- **Both edit paths are §28.3-screened.** The document path screens the markdown
+  before the bridge write. The artifact path screens the code **explicitly**
+  before `createVersion` — because the tool runs under a `kind:"user"` (human)
+  requester and `createVersion`'s internal screening only covers *agent*
+  requesters, so relying on it would persist model code unscreened.
+- **`read_workspace_content` never claims empty.** Documents read the
+  `atrium_doc_state.markdown` projection (the live text is in Yjs, not
+  `version.bodyInline`); when the current content can't be loaded (empty
+  projection, or a large artifact whose source lives at `bodyLocation`) it
+  returns `bodyUnavailable: true` so the model appends/edits conservatively
+  instead of rewriting from nothing.
+- **A bound skill's `allowed-tools` pin applies to workspace tools too** — a
+  restrictive skill can't be widened just by opening a workspace.
+- **Provider-native tools survive.** When workspace (or connector) tools are
+  merged, the streaming service now merges the model's provider-native tools
+  (web search / code interpreter) *under* them, instead of dropping them.
+- The open object's **title is `JSON.stringify`-escaped** before it enters the
+  system prompt (a title is user-controlled; raw newlines/quotes could inject
+  prompt structure).
+
 ## Reuse (no new content logic)
 
 Every tool calls the SAME §11–§15 services the Atrium editors and the MCP content

--- a/lib/nexus/workspace-chat-tools.ts
+++ b/lib/nexus/workspace-chat-tools.ts
@@ -31,6 +31,7 @@ import { contentService } from "@/lib/content/content-service";
 import { canEdit } from "@/lib/content/helpers";
 import { requesterForUserId } from "@/lib/content/requester-from-auth";
 import { applyAgentEdit } from "@/lib/content/collab/apply-agent-edit";
+import { loadDocState } from "@/lib/content/collab/doc-state-store";
 import { screenAgentContent } from "@/lib/content/agent-screening";
 import { createLogger } from "@/lib/logger";
 
@@ -50,7 +51,50 @@ interface ReadResult {
   title: string;
   kind: "document" | "artifact";
   bodyFormat: string | null;
+  /** Current content, or null when it is unavailable (never conflated with ""). */
   body: string | null;
+  /**
+   * True when the content exists but could not be inlined for reading (a large
+   * artifact whose source lives at `bodyLocation`). The model must then edit
+   * conservatively (append/targeted) rather than assume an empty item.
+   */
+  bodyUnavailable?: boolean;
+}
+
+/**
+ * Resolve the CURRENT body of the open object for reading (PR #1136 review):
+ * - documents keep their live text in the Yjs doc, projected to
+ *   `atrium_doc_state.markdown` — NOT in `version.bodyInline` (null for a live
+ *   collab doc). Read the projection, falling back to the version snapshot.
+ * - artifacts store small source inline (`bodyInline`); a large artifact's source
+ *   lives at `bodyLocation` with `bodyInline` null — report `bodyUnavailable`
+ *   rather than telling the model the item is empty (which would let a rewrite
+ *   clobber it).
+ */
+async function resolveReadBody(
+  obj: Awaited<ReturnType<typeof contentService.get>>
+): Promise<{ body: string | null; bodyUnavailable: boolean }> {
+  if (obj.kind === "document") {
+    // A live collaborative document keeps its text in the Yjs doc, projected to
+    // `atrium_doc_state.markdown`. That projection — not `version.bodyInline`
+    // (null for a live doc) — is the readable source. It may lag the very latest
+    // unsaved edits, but returning it beats claiming the doc is empty. When it is
+    // genuinely unavailable (empty projection, no snapshot), signal
+    // `bodyUnavailable` so the model appends/edits conservatively rather than
+    // rewriting from nothing (PR #1136 review).
+    const state = await loadDocState(obj.id);
+    const md =
+      state?.markdown && state.markdown.trim().length > 0
+        ? state.markdown
+        : obj.version?.bodyInline ?? null;
+    if (md !== null) return { body: md, bodyUnavailable: false };
+    return { body: null, bodyUnavailable: true };
+  }
+  // artifact: small source is inline; a large artifact's source lives at
+  // `bodyLocation` (bodyInline null) — report unavailable, never empty.
+  const inline = obj.version?.bodyInline ?? null;
+  if (inline !== null) return { body: inline, bodyUnavailable: false };
+  return { body: null, bodyUnavailable: obj.version != null };
 }
 
 /** Build the read tool (always available for an editable, viewable object). */
@@ -61,7 +105,7 @@ function buildReadTool(
 ): Tool {
   return tool({
     description:
-      "Read the current content of the document or artifact open in the workspace panel beside this chat. Call this before editing so your changes build on the current content.",
+      "Read the current content of the document or artifact open in the workspace panel beside this chat. Call this before editing so your changes build on the current content. If it returns bodyUnavailable, the item has content that could not be loaded — prefer appending or targeted edits over a full rewrite.",
     inputSchema: jsonSchema<Record<string, never>>({
       type: "object",
       properties: {},
@@ -72,11 +116,13 @@ function buildReadTool(
       if (!req) return { error: "Could not resolve your identity." };
       try {
         const obj = await contentService.get(req, idOrSlug);
+        const { body, bodyUnavailable } = await resolveReadBody(obj);
         return {
           title: obj.title,
           kind: obj.kind as "document" | "artifact",
           bodyFormat: obj.version?.bodyFormat ?? null,
-          body: obj.version?.bodyInline ?? "",
+          body,
+          ...(bodyUnavailable ? { bodyUnavailable: true } : {}),
         };
       } catch (err) {
         log.warn("read_workspace_content failed", {
@@ -160,6 +206,7 @@ function buildArtifactUpdateTool(
   objectId: string,
   bodyFormat: string,
   userId: number,
+  requestId: string,
   log: ReturnType<typeof createLogger>
 ): Tool {
   return tool({
@@ -189,8 +236,25 @@ function buildArtifactUpdateTool(
       }
       const req = await requesterForUserId(userId);
       if (!req) return { error: "Could not resolve your identity." };
+      // §28.3: this tool runs under a `kind: "user"` (human) requester, and
+      // contentService.createVersion only screens AGENT/delegated authors — so
+      // the model-generated code would be persisted UNSCREENED without this
+      // explicit gate (PR #1136 review, gemini/codex P1). Screen the agent-
+      // authored code here, mirroring the document edit path. Fail closed.
+      const verdict = await screenAgentContent(code, objectId, requestId);
+      if (!verdict.allowed) {
+        log.warn("update_workspace_artifact blocked by screening", {
+          objectId,
+          reason: verdict.reason,
+        });
+        return {
+          error:
+            verdict.message ??
+            "That content was blocked by the safety screen and was not saved.",
+        };
+      }
       try {
-        // createVersion enforces canView/canEdit and §28.3-screens the body.
+        // createVersion enforces canView/canEdit (screening already done above).
         const result = await contentService.createVersion(req, objectId, {
           body: code,
           bodyFormat: bodyFormat === "jsx" ? "jsx" : "html",
@@ -252,6 +316,7 @@ export async function buildWorkspaceChatTools(params: {
         obj.id,
         obj.version?.bodyFormat ?? "html",
         userId,
+        requestId,
         log
       );
     }
@@ -263,8 +328,12 @@ export async function buildWorkspaceChatTools(params: {
       : " You can update it with the update_workspace_artifact tool (provide the complete new code)."
     : " It is read-only for this user.";
 
+  // Escape the title via JSON.stringify: a content title is user-controlled and
+  // is interpolated into a SYSTEM instruction block, so a raw title with
+  // newlines/quotes could inject prompt structure (PR #1136 review, Copilot).
+  const safeTitle = JSON.stringify(obj.title);
   const systemPromptFragment =
-    `A ${kind} titled "${obj.title}" is open in the workspace panel beside this chat. ` +
+    `A ${kind} titled ${safeTitle} is open in the workspace panel beside this chat. ` +
     `When the user asks you to change, add to, or fix it, act on THAT ${kind} rather than answering in chat only. ` +
     `Call read_workspace_content first to see its current content.` +
     editHint;

--- a/lib/nexus/workspace-chat-tools.ts
+++ b/lib/nexus/workspace-chat-tools.ts
@@ -1,0 +1,280 @@
+/**
+ * Nexus workspace chat tools (Atrium §1087 re-prompt path).
+ *
+ * When a workspace document/artifact is open beside the chat (`?workspace=<id>`),
+ * these server-built AI SDK tools let the model READ and EDIT that open object so
+ * the user can tweak it by asking in chat — the "re-prompt via adjacent chat"
+ * loop the design spec foregrounds (§1065/§1087). They are the missing wiring:
+ * PR #1126 shipped the panel as a pure layout sibling with no content tools in
+ * the chat surface, so "ask the chat to change the doc" did nothing.
+ *
+ * Reuse (no new content logic): tools call the SAME §11–§15 services the Atrium
+ * editors and the MCP content tools use —
+ *   - documents  → `applyAgentEdit` (the agent bridge): a live y-sync write that
+ *     lands on the SAME Yjs doc the open editor is connected to, so the change
+ *     appears LIVE in the panel with agent (purple-rail) attribution. Markdown is
+ *     §28.3-screened first, exactly like the bridge route.
+ *   - artifacts  → `contentService.createVersion`: a new version (the version
+ *     dropdown in the canvas picks it up). `createVersion` screens the body
+ *     internally and enforces canView/canEdit.
+ *
+ * Security: built SERVER-SIDE from the resolved `workspaceId`, never from the
+ * client `enabledTools`, so the client cannot spoke them onto an object it can't
+ * edit. Every tool resolves the object through `contentService` (canView 404-mask
+ * → canEdit 403) against the SESSION user's requester. A caller who cannot edit
+ * gets only the read tool; an unknown/unviewable id yields NO tools (chat is
+ * never broken by a bad `?workspace=`).
+ */
+
+import { tool, jsonSchema, type Tool, type ToolSet } from "ai";
+import { contentService } from "@/lib/content/content-service";
+import { canEdit } from "@/lib/content/helpers";
+import { requesterForUserId } from "@/lib/content/requester-from-auth";
+import { applyAgentEdit } from "@/lib/content/collab/apply-agent-edit";
+import { screenAgentContent } from "@/lib/content/agent-screening";
+import { createLogger } from "@/lib/logger";
+
+/** Free-form attribution label stamped on the purple rail for chat-driven edits. */
+const NEXUS_CHAT_AGENT_LABEL = "nexus-chat";
+/** Bound on the markdown/code a single chat edit may write (mirrors the bridge). */
+const MAX_EDIT_BYTES = 512 * 1024;
+
+export interface WorkspaceChatTools {
+  /** AI SDK tools to merge into the model's tool set. */
+  tools: ToolSet;
+  /** A line appended to the system prompt describing the open object + how to edit it. */
+  systemPromptFragment: string;
+}
+
+interface ReadResult {
+  title: string;
+  kind: "document" | "artifact";
+  bodyFormat: string | null;
+  body: string | null;
+}
+
+/** Build the read tool (always available for an editable, viewable object). */
+function buildReadTool(
+  idOrSlug: string,
+  userId: number,
+  log: ReturnType<typeof createLogger>
+): Tool {
+  return tool({
+    description:
+      "Read the current content of the document or artifact open in the workspace panel beside this chat. Call this before editing so your changes build on the current content.",
+    inputSchema: jsonSchema<Record<string, never>>({
+      type: "object",
+      properties: {},
+      additionalProperties: false,
+    }),
+    execute: async (): Promise<ReadResult | { error: string }> => {
+      const req = await requesterForUserId(userId);
+      if (!req) return { error: "Could not resolve your identity." };
+      try {
+        const obj = await contentService.get(req, idOrSlug);
+        return {
+          title: obj.title,
+          kind: obj.kind as "document" | "artifact",
+          bodyFormat: obj.version?.bodyFormat ?? null,
+          body: obj.version?.bodyInline ?? "",
+        };
+      } catch (err) {
+        log.warn("read_workspace_content failed", {
+          error: err instanceof Error ? err.message : String(err),
+        });
+        return { error: "The workspace item could not be read." };
+      }
+    },
+  });
+}
+
+/** Build the live document-edit tool (documents only). */
+function buildDocumentEditTool(
+  objectId: string,
+  userId: number,
+  requestId: string,
+  log: ReturnType<typeof createLogger>
+): Tool {
+  return tool({
+    description:
+      "Edit the DOCUMENT open in the workspace panel. Your markdown is written into the live document and appears immediately in the panel, attributed to the assistant. Use mode 'append' to add to the end, or 'replace' to rewrite the whole document.",
+    inputSchema: jsonSchema<{ markdown: string; mode?: "append" | "replace" }>({
+      type: "object",
+      properties: {
+        markdown: {
+          type: "string",
+          description: "The markdown to write into the document.",
+        },
+        mode: {
+          type: "string",
+          enum: ["append", "replace"],
+          description:
+            "append (default) adds blocks at the end; replace rewrites the whole document.",
+        },
+      },
+      required: ["markdown"],
+      additionalProperties: false,
+    }),
+    execute: async (args): Promise<{ ok: true; mode: string } | { error: string }> => {
+      const markdown = typeof args?.markdown === "string" ? args.markdown : "";
+      const mode = args?.mode === "replace" ? "replace" : "append";
+      if (!markdown.trim()) return { error: "No markdown provided to write." };
+      if (Buffer.byteLength(markdown, "utf8") > MAX_EDIT_BYTES) {
+        return { error: "That edit is too large to apply in one step." };
+      }
+      // §28.3: screen the agent-authored markdown BEFORE writing (same gate as the
+      // agent-bridge route). Fail closed — blocked/unscreenable content is refused.
+      const verdict = await screenAgentContent(markdown, objectId, requestId);
+      if (!verdict.allowed) {
+        log.warn("edit_workspace_document blocked by screening", {
+          objectId,
+          reason: verdict.reason,
+        });
+        return {
+          error:
+            verdict.message ??
+            "That content was blocked by the safety screen and was not written.",
+        };
+      }
+      try {
+        await applyAgentEdit({
+          objectId,
+          markdown,
+          agentId: NEXUS_CHAT_AGENT_LABEL,
+          mode,
+        });
+        return { ok: true, mode };
+      } catch (err) {
+        log.error("edit_workspace_document apply failed", {
+          objectId,
+          error: err instanceof Error ? err.message : String(err),
+        });
+        return { error: "The edit could not be applied to the live document." };
+      }
+    },
+  });
+}
+
+/** Build the artifact-version tool (artifacts only). */
+function buildArtifactUpdateTool(
+  objectId: string,
+  bodyFormat: string,
+  userId: number,
+  log: ReturnType<typeof createLogger>
+): Tool {
+  return tool({
+    description:
+      "Update the ARTIFACT open in the workspace panel by creating a new version with the given full source code. The new version appears in the artifact's version dropdown. Provide the COMPLETE code (it replaces the current version's code), not a diff.",
+    inputSchema: jsonSchema<{ code: string; summary?: string }>({
+      type: "object",
+      properties: {
+        code: {
+          type: "string",
+          description: "The complete new source code for the artifact.",
+        },
+        summary: {
+          type: "string",
+          description: "A short summary of what changed (optional).",
+        },
+      },
+      required: ["code"],
+      additionalProperties: false,
+    }),
+    execute: async (args): Promise<{ ok: true; versionNumber: number } | { error: string }> => {
+      const code = typeof args?.code === "string" ? args.code : "";
+      const summary = typeof args?.summary === "string" ? args.summary : undefined;
+      if (!code.trim()) return { error: "No code provided for the new version." };
+      if (Buffer.byteLength(code, "utf8") > MAX_EDIT_BYTES) {
+        return { error: "That artifact is too large to save in one step." };
+      }
+      const req = await requesterForUserId(userId);
+      if (!req) return { error: "Could not resolve your identity." };
+      try {
+        // createVersion enforces canView/canEdit and §28.3-screens the body.
+        const result = await contentService.createVersion(req, objectId, {
+          body: code,
+          bodyFormat: bodyFormat === "jsx" ? "jsx" : "html",
+          summary,
+        });
+        return { ok: true, versionNumber: result.version?.versionNumber ?? 0 };
+      } catch (err) {
+        log.warn("update_workspace_artifact failed", {
+          objectId,
+          error: err instanceof Error ? err.message : String(err),
+        });
+        return {
+          error:
+            "The artifact could not be updated (it may be blocked by the safety screen or you may not have edit access).",
+        };
+      }
+    },
+  });
+}
+
+/**
+ * Build the workspace chat tool set for the object identified by `workspaceIdOrSlug`,
+ * or `null` when there is no editable/viewable object to bind (chat proceeds with
+ * no workspace tools — never an error).
+ */
+export async function buildWorkspaceChatTools(params: {
+  workspaceIdOrSlug: string;
+  userId: number;
+  requestId: string;
+}): Promise<WorkspaceChatTools | null> {
+  const { workspaceIdOrSlug, userId, requestId } = params;
+  const log = createLogger({ requestId, module: "nexus-workspace-tools" });
+
+  const req = await requesterForUserId(userId);
+  if (!req) return null;
+
+  // Resolve + canView-gate (contentService.get 404-masks a non-viewable object).
+  let obj: Awaited<ReturnType<typeof contentService.get>>;
+  try {
+    obj = await contentService.get(req, workspaceIdOrSlug);
+  } catch (err) {
+    log.info("No viewable workspace object to bind chat tools", {
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return null;
+  }
+
+  const kind = obj.kind as "document" | "artifact";
+  const editable = canEdit(req, obj.ownerUserId);
+  const tools: ToolSet = {
+    read_workspace_content: buildReadTool(obj.id, userId, log),
+  };
+
+  if (editable) {
+    if (kind === "document") {
+      tools.edit_workspace_document = buildDocumentEditTool(obj.id, userId, requestId, log);
+    } else {
+      tools.update_workspace_artifact = buildArtifactUpdateTool(
+        obj.id,
+        obj.version?.bodyFormat ?? "html",
+        userId,
+        log
+      );
+    }
+  }
+
+  const editHint = editable
+    ? kind === "document"
+      ? " You can edit it with the edit_workspace_document tool; your edits appear live in the panel."
+      : " You can update it with the update_workspace_artifact tool (provide the complete new code)."
+    : " It is read-only for this user.";
+
+  const systemPromptFragment =
+    `A ${kind} titled "${obj.title}" is open in the workspace panel beside this chat. ` +
+    `When the user asks you to change, add to, or fix it, act on THAT ${kind} rather than answering in chat only. ` +
+    `Call read_workspace_content first to see its current content.` +
+    editHint;
+
+  log.info("Workspace chat tools bound", {
+    objectId: obj.id,
+    kind,
+    editable,
+    toolCount: Object.keys(tools).length,
+  });
+
+  return { tools, systemPromptFragment };
+}

--- a/lib/streaming/unified-streaming-service.ts
+++ b/lib/streaming/unified-streaming-service.ts
@@ -703,57 +703,48 @@ async function getOrCreateTools(
   request: StreamRequest,
   adapter: Awaited<ReturnType<typeof getProviderAdapter>>
 ): Promise<StreamConfig['tools']> {
-  // When pre-resolved tools are provided (e.g., adapter + MCP connector tools
-  // already merged by the caller), use them directly and skip adapter.createTools()
-  // to avoid redundant work and unintended side effects.
+  // Build the adapter's tool set (universal + model-supported provider-native
+  // tools) from `enabledTools`, honoring the model's capability filter.
+  const buildAdapterTools = async (): Promise<StreamConfig['tools']> => {
+    const requestedTools = request.enabledTools || [];
+    if (requestedTools.length === 0) {
+      return adapter.createTools([]);
+    }
+    const supportedTools = adapter.getSupportedTools(request.modelId);
+    // If the adapter reports no supported tools, pass nothing to avoid
+    // "tool use in streaming mode" errors (e.g., Bedrock Claude models).
+    // createTools([]) still returns universal tools (show_chart) unconditionally.
+    if (supportedTools.length === 0) {
+      log.info('Model does not support provider-native tools, filtering all tool requests', {
+        modelId: request.modelId,
+        requestedCount: requestedTools.length,
+      });
+      return adapter.createTools([]);
+    }
+    const filteredTools = requestedTools.filter(tool => supportedTools.includes(tool));
+    if (filteredTools.length < requestedTools.length) {
+      log.info('Filtered unsupported tools for model', {
+        modelId: request.modelId,
+        requestedCount: requestedTools.length,
+        filteredCount: filteredTools.length,
+        droppedTools: requestedTools.filter(tool => !supportedTools.includes(tool)),
+      });
+    }
+    return adapter.createTools(filteredTools);
+  };
+
+  // When pre-resolved tools are provided (adapter + MCP connector + workspace
+  // tools merged by the caller), MERGE the adapter's provider-native tools UNDER
+  // them (pre-resolved tools win on a name collision) rather than replacing.
+  // Returning `request.tools` alone dropped provider-native tools (OpenAI web
+  // search / code interpreter) whenever a connector or workspace was active,
+  // even though the same `enabledTools` work without them (PR #1136 review).
   if (request.tools) {
-    return request.tools;
+    const adapterTools = await buildAdapterTools();
+    return { ...adapterTools, ...request.tools };
   }
 
-  const requestedTools = request.enabledTools || [];
-  if (requestedTools.length === 0) {
-    return adapter.createTools([]);
-  }
-
-  // Filter requested tools against model's supported capabilities
-  const supportedTools = adapter.getSupportedTools(request.modelId);
-
-  // If the adapter reports no supported tools, pass nothing to avoid
-  // "tool use in streaming mode" errors (e.g., Bedrock Claude models)
-  if (supportedTools.length === 0) {
-    log.info('Model does not support provider-native tools, filtering all tool requests', {
-      modelId: request.modelId,
-      requestedCount: requestedTools.length,
-    });
-    log.debug('Tool filtering detail (no provider-native tools)', {
-      modelId: request.modelId,
-      requestedTools,
-    });
-    // createTools([]) always returns universal tools (show_chart, etc.) regardless of
-    // the empty input — BaseProviderAdapter.createTools() calls createUniversalTools()
-    // unconditionally, and all concrete adapters call super or replicate this behaviour.
-    return adapter.createTools([]);
-  }
-
-  // Only pass through tools the model actually supports
-  const filteredTools = requestedTools.filter(tool => supportedTools.includes(tool));
-  if (filteredTools.length < requestedTools.length) {
-    const droppedTools = requestedTools.filter(tool => !supportedTools.includes(tool));
-    log.info('Filtered unsupported tools for model', {
-      modelId: request.modelId,
-      requestedCount: requestedTools.length,
-      filteredCount: filteredTools.length,
-      droppedTools,
-    });
-    log.debug('Tool filtering detail', {
-      modelId: request.modelId,
-      requestedTools,
-      supportedTools,
-      filteredTools,
-    });
-  }
-
-  return adapter.createTools(filteredTools);
+  return buildAdapterTools();
 }
 
 /**

--- a/tests/e2e/nexus-workspace-chat-tools.spec.ts
+++ b/tests/e2e/nexus-workspace-chat-tools.spec.ts
@@ -1,0 +1,78 @@
+import { test, expect } from "./fixtures";
+import { authenticateContext } from "./helpers/session-auth";
+
+/**
+ * E2E (gated): Nexus workspace chat tools wiring (Atrium §1087) — chat can act on
+ * the document/artifact open beside it.
+ *
+ * These assertions are DETERMINISTIC (they intercept the outbound chat request;
+ * they do NOT depend on a live LLM deciding to call a tool):
+ *  1. With a workspace open, the chat request body carries `workspaceId` — the
+ *     server uses it to bind read/edit content tools.
+ *  2. Switching the model with a workspace open PRESERVES `?workspace=` (the
+ *     model-change reset used to drop it, silently closing the open document and
+ *     its content tools).
+ *
+ * The live edit path (chat → agent bridge → live Yjs doc, chat → createVersion)
+ * is proven separately; asserting it here would couple CI to a real model call.
+ *
+ * Reuses the standard editor seed (admin-owned doc) + the authed host :3100 server.
+ */
+
+const OBJ_SLUG = process.env.ATRIUM_EDITOR_E2E_SLUG ?? "atrium-editor-e2e";
+
+async function pickAnyOtherModel(page: import("@playwright/test").Page) {
+  await page.locator('button[aria-label="Select AI model"]').first().click({ timeout: 10_000 });
+  const pop = page.locator('[data-radix-popper-content-wrapper], [role="dialog"]').last();
+  // Pick the second listed model (any change triggers the model-change reset).
+  await pop.locator("button").nth(1).click({ timeout: 5_000 });
+}
+
+test.describe("Nexus workspace chat tools (§1087, authenticated)", () => {
+  test.skip(
+    process.env.PLAYWRIGHT_AUTH_ENABLED !== "true",
+    "Requires the authed host dev server + seeded doc"
+  );
+
+  test("chat request carries workspaceId, preserved across a model change", async ({ browser }) => {
+    const context = await browser.newContext();
+    await authenticateContext(context);
+    try {
+      const page = await context.newPage();
+
+      const chatBodies: string[] = [];
+      page.on("request", (r) => {
+        if (r.url().includes("/api/nexus/chat") && r.method() === "POST") {
+          chatBodies.push(r.postData() ?? "");
+        }
+      });
+
+      await page.goto(`/nexus?workspace=${OBJ_SLUG}`);
+      const panel = page.getByTestId("workspace-panel");
+      await expect(panel).toBeVisible({ timeout: 60_000 });
+
+      // Switch the model — this triggers the clean-URL reset. It MUST keep the
+      // workspace open (regression: it used to reload to a bare /nexus).
+      await pickAnyOtherModel(page);
+      await expect(page).toHaveURL(/workspace=/, { timeout: 20_000 });
+      await expect(page.getByTestId("workspace-panel")).toBeVisible({ timeout: 60_000 });
+
+      // Send a message and assert the outbound body carries the workspace id, so
+      // the server binds the §1087 content tools for THIS object.
+      const input = page
+        .locator('textarea, [contenteditable="true"][role="textbox"], [data-testid="composer-input"]')
+        .first();
+      await input.click();
+      await input.fill("hello");
+      await page.keyboard.press("Enter");
+
+      await expect
+        .poll(() => chatBodies.some((b) => b.includes('"workspaceId"') && b.includes(OBJ_SLUG)), {
+          timeout: 30_000,
+        })
+        .toBe(true);
+    } finally {
+      await context.close();
+    }
+  });
+});

--- a/tests/unit/lib/nexus/workspace-chat-tools.test.ts
+++ b/tests/unit/lib/nexus/workspace-chat-tools.test.ts
@@ -26,6 +26,7 @@ const canEditMock = jest.fn();
 const requesterMock = jest.fn();
 const applyAgentEditMock = jest.fn();
 const screenMock = jest.fn();
+const loadDocStateMock = jest.fn();
 
 jest.mock("@/lib/content/content-service", () => ({
   contentService: {
@@ -41,6 +42,9 @@ jest.mock("@/lib/content/requester-from-auth", () => ({
 }));
 jest.mock("@/lib/content/collab/apply-agent-edit", () => ({
   applyAgentEdit: (...a: unknown[]) => applyAgentEditMock(...a),
+}));
+jest.mock("@/lib/content/collab/doc-state-store", () => ({
+  loadDocState: (...a: unknown[]) => loadDocStateMock(...a),
 }));
 jest.mock("@/lib/content/agent-screening", () => ({
   screenAgentContent: (...a: unknown[]) => screenMock(...a),
@@ -64,6 +68,7 @@ beforeEach(() => {
   requesterMock.mockResolvedValue(REQ);
   screenMock.mockResolvedValue({ allowed: true });
   applyAgentEditMock.mockResolvedValue(undefined);
+  loadDocStateMock.mockResolvedValue({ markdown: "# Live doc", revision: 5 });
 });
 
 describe("buildWorkspaceChatTools", () => {
@@ -123,12 +128,15 @@ describe("buildWorkspaceChatTools", () => {
     expect(out).toEqual({ error: "nope" });
   });
 
-  it("update_workspace_artifact creates a new version through contentService", async () => {
+  it("update_workspace_artifact SCREENS the code (§28.3) then creates a version", async () => {
     getMock.mockResolvedValue(ART);
     canEditMock.mockReturnValue(true);
     createVersionMock.mockResolvedValue({ version: { versionNumber: 3 } });
     const { tools } = (await buildWorkspaceChatTools({ workspaceIdOrSlug: "art-1", userId: 7, requestId: "r" }))!;
     const out = await exec(tools.update_workspace_artifact, { code: "<div>new</div>", summary: "tweak" });
+    // The human requester bypasses createVersion's internal screening, so the
+    // tool MUST screen explicitly before saving (PR #1136 review).
+    expect(screenMock).toHaveBeenCalledWith("<div>new</div>", "art-1", "r");
     expect(createVersionMock).toHaveBeenCalledWith(
       REQ,
       "art-1",
@@ -137,11 +145,47 @@ describe("buildWorkspaceChatTools", () => {
     expect(out).toEqual({ ok: true, versionNumber: 3 });
   });
 
-  it("read_workspace_content returns the current title/kind/body", async () => {
+  it("update_workspace_artifact refuses (and does NOT createVersion) when screening blocks", async () => {
+    getMock.mockResolvedValue(ART);
+    canEditMock.mockReturnValue(true);
+    screenMock.mockResolvedValue({ allowed: false, reason: "blocked", message: "nope" });
+    const { tools } = (await buildWorkspaceChatTools({ workspaceIdOrSlug: "art-1", userId: 7, requestId: "r" }))!;
+    const out = await exec(tools.update_workspace_artifact, { code: "bad code" });
+    expect(createVersionMock).not.toHaveBeenCalled();
+    expect(out).toEqual({ error: "nope" });
+  });
+
+  it("read_workspace_content reads the doc-state markdown projection for a document (not bodyInline)", async () => {
     getMock.mockResolvedValue(DOC);
     canEditMock.mockReturnValue(true);
+    loadDocStateMock.mockResolvedValue({ markdown: "# Live doc", revision: 5 });
     const { tools } = (await buildWorkspaceChatTools({ workspaceIdOrSlug: "doc-1", userId: 7, requestId: "r" }))!;
     const out = await exec(tools.read_workspace_content, {});
-    expect(out).toEqual({ title: "My Doc", kind: "document", bodyFormat: "markdown", body: "# Hi" });
+    expect(loadDocStateMock).toHaveBeenCalledWith("doc-1");
+    expect(out).toEqual({ title: "My Doc", kind: "document", bodyFormat: "markdown", body: "# Live doc" });
+  });
+
+  it("read_workspace_content flags bodyUnavailable for a document with an empty projection", async () => {
+    getMock.mockResolvedValue({ ...DOC, version: { bodyFormat: "markdown", bodyInline: null, versionNumber: 3 } });
+    canEditMock.mockReturnValue(true);
+    loadDocStateMock.mockResolvedValue({ markdown: "", revision: 5 });
+    const { tools } = (await buildWorkspaceChatTools({ workspaceIdOrSlug: "doc-1", userId: 7, requestId: "r" }))!;
+    const out = await exec(tools.read_workspace_content, {});
+    expect(out).toEqual({ title: "My Doc", kind: "document", bodyFormat: "markdown", body: null, bodyUnavailable: true });
+  });
+
+  it("read_workspace_content flags bodyUnavailable for a large artifact (bodyInline null)", async () => {
+    getMock.mockResolvedValue({ ...ART, version: { bodyFormat: "jsx", bodyInline: null, versionNumber: 2 } });
+    canEditMock.mockReturnValue(true);
+    const { tools } = (await buildWorkspaceChatTools({ workspaceIdOrSlug: "art-1", userId: 7, requestId: "r" }))!;
+    const out = await exec(tools.read_workspace_content, {});
+    // Must NOT report body "" (which would let the model rewrite from nothing).
+    expect(out).toEqual({
+      title: "My Art",
+      kind: "artifact",
+      bodyFormat: "jsx",
+      body: null,
+      bodyUnavailable: true,
+    });
   });
 });

--- a/tests/unit/lib/nexus/workspace-chat-tools.test.ts
+++ b/tests/unit/lib/nexus/workspace-chat-tools.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Unit tests for the Nexus workspace chat tools (Atrium §1087).
+ *
+ * Verifies the tool set the chat route binds when a workspace object is open:
+ *   - no tools when the id is unviewable / requester unresolved (chat unbroken);
+ *   - read-only tool when the caller cannot edit;
+ *   - the correct kind-specific edit tool (document → live bridge, artifact →
+ *     new version), each gated + screened;
+ *   - a document edit is §28.3-screened and refused when blocked.
+ */
+
+// NB: use the GLOBAL `jest` (do NOT `import { jest } from "@jest/globals"`) —
+// the import form suppresses babel-jest's jest.mock hoisting in this repo, so
+// the mocks below would not intercept the transitive content-service import.
+
+// content-service transitively pulls the ESM-only remark/rehype render stack,
+// which jest's CJS transform can't load. Stub the render modules (same pattern
+// as tests/unit/atrium-mcp-content-tools.test.ts) — the tools mock the service
+// itself, so rendering is never reached.
+jest.mock("@/lib/content/render/markdown-render", () => ({ renderMarkdownToHtml: jest.fn() }));
+jest.mock("@/lib/content/render/html-sanitize", () => ({ sanitizeHtml: jest.fn() }));
+
+const getMock = jest.fn();
+const createVersionMock = jest.fn();
+const canEditMock = jest.fn();
+const requesterMock = jest.fn();
+const applyAgentEditMock = jest.fn();
+const screenMock = jest.fn();
+
+jest.mock("@/lib/content/content-service", () => ({
+  contentService: {
+    get: (...a: unknown[]) => getMock(...a),
+    createVersion: (...a: unknown[]) => createVersionMock(...a),
+  },
+}));
+jest.mock("@/lib/content/helpers", () => ({
+  canEdit: (...a: unknown[]) => canEditMock(...a),
+}));
+jest.mock("@/lib/content/requester-from-auth", () => ({
+  requesterForUserId: (...a: unknown[]) => requesterMock(...a),
+}));
+jest.mock("@/lib/content/collab/apply-agent-edit", () => ({
+  applyAgentEdit: (...a: unknown[]) => applyAgentEditMock(...a),
+}));
+jest.mock("@/lib/content/agent-screening", () => ({
+  screenAgentContent: (...a: unknown[]) => screenMock(...a),
+}));
+jest.mock("@/lib/logger", () => ({
+  createLogger: () => ({ info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() }),
+}));
+
+import { buildWorkspaceChatTools } from "@/lib/nexus/workspace-chat-tools";
+
+const REQ = { kind: "user", userId: 7, isAdmin: false };
+const DOC = { id: "doc-1", kind: "document", title: "My Doc", ownerUserId: 7, version: { bodyFormat: "markdown", bodyInline: "# Hi", versionNumber: 3 } };
+const ART = { id: "art-1", kind: "artifact", title: "My Art", ownerUserId: 7, version: { bodyFormat: "jsx", bodyInline: "<div/>", versionNumber: 2 } };
+
+// Minimal shim to invoke an AI SDK tool's execute in tests.
+type ExecTool = { execute: (args: unknown, opts?: unknown) => Promise<unknown> };
+const exec = (t: unknown, args: unknown = {}) => (t as ExecTool).execute(args, {});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  requesterMock.mockResolvedValue(REQ);
+  screenMock.mockResolvedValue({ allowed: true });
+  applyAgentEditMock.mockResolvedValue(undefined);
+});
+
+describe("buildWorkspaceChatTools", () => {
+  it("returns null when the requester cannot be resolved", async () => {
+    requesterMock.mockResolvedValue(null);
+    const result = await buildWorkspaceChatTools({ workspaceIdOrSlug: "doc-1", userId: 7, requestId: "r" });
+    expect(result).toBeNull();
+  });
+
+  it("returns null when the object is not viewable (contentService.get throws)", async () => {
+    getMock.mockRejectedValue(new Error("Content not found"));
+    const result = await buildWorkspaceChatTools({ workspaceIdOrSlug: "nope", userId: 7, requestId: "r" });
+    expect(result).toBeNull();
+  });
+
+  it("binds ONLY the read tool when the caller cannot edit", async () => {
+    getMock.mockResolvedValue(DOC);
+    canEditMock.mockReturnValue(false);
+    const result = await buildWorkspaceChatTools({ workspaceIdOrSlug: "doc-1", userId: 7, requestId: "r" });
+    expect(Object.keys(result!.tools).sort()).toEqual(["read_workspace_content"]);
+    expect(result!.systemPromptFragment).toContain("read-only");
+  });
+
+  it("binds read + edit_workspace_document for an editable document", async () => {
+    getMock.mockResolvedValue(DOC);
+    canEditMock.mockReturnValue(true);
+    const result = await buildWorkspaceChatTools({ workspaceIdOrSlug: "doc-1", userId: 7, requestId: "r" });
+    expect(Object.keys(result!.tools).sort()).toEqual(["edit_workspace_document", "read_workspace_content"]);
+  });
+
+  it("binds read + update_workspace_artifact for an editable artifact", async () => {
+    getMock.mockResolvedValue(ART);
+    canEditMock.mockReturnValue(true);
+    const result = await buildWorkspaceChatTools({ workspaceIdOrSlug: "art-1", userId: 7, requestId: "r" });
+    expect(Object.keys(result!.tools).sort()).toEqual(["read_workspace_content", "update_workspace_artifact"]);
+  });
+
+  it("edit_workspace_document screens then applies via the agent bridge (append default)", async () => {
+    getMock.mockResolvedValue(DOC);
+    canEditMock.mockReturnValue(true);
+    const { tools } = (await buildWorkspaceChatTools({ workspaceIdOrSlug: "doc-1", userId: 7, requestId: "r" }))!;
+    const out = await exec(tools.edit_workspace_document, { markdown: "## New section" });
+    expect(screenMock).toHaveBeenCalledWith("## New section", "doc-1", "r");
+    expect(applyAgentEditMock).toHaveBeenCalledWith(
+      expect.objectContaining({ objectId: "doc-1", markdown: "## New section", mode: "append" })
+    );
+    expect(out).toEqual({ ok: true, mode: "append" });
+  });
+
+  it("edit_workspace_document refuses (and does NOT apply) when screening blocks", async () => {
+    getMock.mockResolvedValue(DOC);
+    canEditMock.mockReturnValue(true);
+    screenMock.mockResolvedValue({ allowed: false, reason: "blocked", message: "nope" });
+    const { tools } = (await buildWorkspaceChatTools({ workspaceIdOrSlug: "doc-1", userId: 7, requestId: "r" }))!;
+    const out = await exec(tools.edit_workspace_document, { markdown: "bad" });
+    expect(applyAgentEditMock).not.toHaveBeenCalled();
+    expect(out).toEqual({ error: "nope" });
+  });
+
+  it("update_workspace_artifact creates a new version through contentService", async () => {
+    getMock.mockResolvedValue(ART);
+    canEditMock.mockReturnValue(true);
+    createVersionMock.mockResolvedValue({ version: { versionNumber: 3 } });
+    const { tools } = (await buildWorkspaceChatTools({ workspaceIdOrSlug: "art-1", userId: 7, requestId: "r" }))!;
+    const out = await exec(tools.update_workspace_artifact, { code: "<div>new</div>", summary: "tweak" });
+    expect(createVersionMock).toHaveBeenCalledWith(
+      REQ,
+      "art-1",
+      expect.objectContaining({ body: "<div>new</div>", bodyFormat: "jsx", summary: "tweak" })
+    );
+    expect(out).toEqual({ ok: true, versionNumber: 3 });
+  });
+
+  it("read_workspace_content returns the current title/kind/body", async () => {
+    getMock.mockResolvedValue(DOC);
+    canEditMock.mockReturnValue(true);
+    const { tools } = (await buildWorkspaceChatTools({ workspaceIdOrSlug: "doc-1", userId: 7, requestId: "r" }))!;
+    const out = await exec(tools.read_workspace_content, {});
+    expect(out).toEqual({ title: "My Doc", kind: "document", bodyFormat: "markdown", body: "# Hi" });
+  });
+});


### PR DESCRIPTION
## Summary

Wires the Atrium design spec's **re-prompt path (§1065/§1087)**: when a document or artifact is open beside the Nexus chat (`?workspace=<id|slug>`, the Epic #1059 §17 panel), the chat can now **read and edit that open object**. Before this, the panel was a pure layout sibling with no content tools in the chat surface — chat and panel coexisted but couldn't interact, so "ask the chat to change the doc" did nothing.

This is the follow-through you asked for after #1131 (which fixed the panel *layout*).

## How it works

**Server** (`lib/nexus/workspace-chat-tools.ts` + `app/api/nexus/chat/route.ts`): a new `workspaceId` request field. When present, the route binds a small AI SDK tool set for **that** object and injects a system-prompt line. Tools are built **server-side** from the resolved id (never the client tool list), and the object is resolved through `contentService` (canView 404-mask → canEdit 403) against the session user. `maxSteps` is raised so the model can read → edit → respond in one turn.

| Tool | When | Effect |
|------|------|--------|
| `read_workspace_content` | always (viewable) | current title/kind/body so edits build on current content |
| `edit_workspace_document` | editable **document** | §28.3-screens markdown → writes to the **live Yjs doc** via the agent bridge (`applyAgentEdit`); appears **immediately** in the panel with agent (purple-rail) attribution; `append`(default)/`replace` |
| `update_workspace_artifact` | editable **artifact** | `contentService.createVersion` (canView/canEdit-gated + §28.3-screened); new version shows in the version dropdown |

A view-only caller gets only the read tool; an unknown/unviewable `?workspace=` yields **no** tools (a bad param never breaks chat). Every tool reuses the existing §11–§15 services — no new content logic, so screening/provenance/visibility/versioning are inherited.

**Client** (`app/(protected)/nexus/page.tsx`): threads the open workspace id to the chat transport via a ref (so opening/closing/switching mid-conversation always sends the current value). **Also fixes a real bug this feature exposed:** switching the model with a workspace open did `window.location.href = '/nexus'`, silently **dropping `?workspace=`** and closing the open document + its tools — it now preserves the param. This is what made the feature appear broken when the user changed models.

## Verification (you asked me to actually test it)

Proven **end-to-end** on the local `:3100` collab server:
- A chat message ("append a paragraph containing `WSMARK…`") drove `read_workspace_content` → `edit_workspace_document`, and the text appeared **live in the open editor with the purple agent rail** (screenshot: two chat-driven markers, both purple/agent-attributed).
- An artifact chat edit created **version 2** (`author_actor` recorded, body = the requested code), visible in the version dropdown.

Committed tests:
- **Unit** `tests/unit/lib/nexus/workspace-chat-tools.test.ts` (9): gating (unresolved requester / unviewable → null), read-only vs editable tool sets, kind-specific tool selection, document screen-then-bridge, screening-refusal blocks the write, artifact `createVersion` wiring, read-result shape.
- **E2E** `tests/e2e/nexus-workspace-chat-tools.spec.ts`: the chat request carries `workspaceId` **and** `?workspace=` survives a model change — deterministic (intercepts the request; no live-LLM dependency in CI).
- Existing `nexus-workspace-panel` + `nexus-chat-tools` E2E still pass (no regression to the fragile conversation tree).

## Gates
- [x] `bun run typecheck` clean
- [x] `bun run lint` — zero warnings on the new module + route; `page.tsx` pre-existing warnings unchanged (7→7; they're on the 192/270-line Nexus functions I deliberately didn't refactor per CLAUDE.md rule #6)
- [x] Unit (41 in the affected suites) + 3 E2E pass on the authed :3100 server

No new DB migrations, no infra changes.
