### PR TITLE
fix: two deployed-dev blockers for Nexus workspace tool calls (guardrail-profile IAM grant + collab WS bundle)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,14 +54,23 @@ ENV RDS_SECRET_ARN=${RDS_SECRET_ARN}
 RUN --mount=type=cache,target=/app/.next/cache \
     node_modules/.bin/next build --webpack
 
-# Bundle voice WebSocket handler as a self-contained CJS artifact for voice-server.js.
-# The script fails the build if any non-builtin runtime externals leak into the bundle.
-# Writing into .next/standalone ensures the runner-stage COPY picks it up automatically.
-RUN node scripts/build-voice-ws-handler.mjs
-
-# Bundle the Atrium collaboration WebSocket handler the same way (#1051), so
-# voice-server.js can load ./collab-handler-bundle.cjs at runtime.
-RUN node scripts/build-collab-ws-handler.mjs
+# Bundle the voice AND Atrium-collab WebSocket handlers as self-contained CJS
+# artifacts for voice-server.js. Each script fails the build if a non-builtin
+# runtime external leaks in. Writing into .next/standalone ensures the runner-stage
+# COPY picks them up.
+#
+# BUILT IN ONE LAYER (2026-07-06): they were previously two separate RUN steps.
+# In the deployed image the voice bundle was present but the collab bundle was
+# MISSING ("Cannot find module ./collab-handler-bundle.cjs" → collab disabled →
+# workspace panel stuck "Connecting…" and agent doc edits fail) — the second
+# RUN layer's output was not surviving into the standalone COPY under BuildKit.
+# Producing both in a single layer (the one that demonstrably IS copied) and
+# asserting both files exist makes a missing bundle a LOUD build failure instead
+# of a silent runtime one.
+RUN node scripts/build-voice-ws-handler.mjs \
+ && node scripts/build-collab-ws-handler.mjs \
+ && test -f .next/standalone/ws-handler-bundle.cjs \
+ && test -f .next/standalone/collab-handler-bundle.cjs
 
 # ============================================================================
 # Stage 3: Production Runner

--- a/infra/lib/constructs/ecs-service.ts
+++ b/infra/lib/constructs/ecs-service.ts
@@ -519,8 +519,16 @@ export class EcsServiceConstruct extends Construct {
                 'arn:aws:bedrock:*:*:provisioned-model/*',
               ],
             }),
-            // K-12 Content Safety: Bedrock Guardrails API access
-            // Uses specific ARN from GuardrailsStack when provided, falls back to wildcard
+            // K-12 Content Safety: Bedrock Guardrails API access.
+            // CROSS-REGION-INFERENCE GOTCHA (2026-07-06 prod outage): ApplyGuardrail
+            // on a guardrail that uses a cross-region inference PROFILE authorizes
+            // against BOTH the guardrail ARN AND the guardrail-PROFILE ARN
+            // (e.g. .../guardrail-profile/us.guardrail.v1:0). Granting only the
+            // guardrail ARN yields 100% AccessDenied on the profile — which made
+            // ContentSafetyService fail and, worse, made Atrium §28.3 agent-write
+            // screening fail CLOSED (every workspace/agent content edit rejected).
+            // Grant the profile ARNs alongside the guardrail. (See PR #1093 for the
+            // agent-router equivalent.)
             new iam.PolicyStatement({
               effect: iam.Effect.ALLOW,
               actions: [
@@ -528,8 +536,16 @@ export class EcsServiceConstruct extends Construct {
                 'bedrock:GetGuardrail',
               ],
               resources: props.guardrailArn
-                ? [props.guardrailArn]
-                : [`arn:aws:bedrock:${cdk.Stack.of(this).region}:${cdk.Stack.of(this).account}:guardrail/*`],
+                ? [
+                    props.guardrailArn,
+                    // Cross-region inference profile ARNs (region-qualified, e.g.
+                    // us.guardrail.*) the guardrail resolves to at apply time.
+                    `arn:aws:bedrock:${cdk.Stack.of(this).region}:${cdk.Stack.of(this).account}:guardrail-profile/*`,
+                  ]
+                : [
+                    `arn:aws:bedrock:${cdk.Stack.of(this).region}:${cdk.Stack.of(this).account}:guardrail/*`,
+                    `arn:aws:bedrock:${cdk.Stack.of(this).region}:${cdk.Stack.of(this).account}:guardrail-profile/*`,
+                  ],
             }),
             // K-12 Content Safety: Amazon Comprehend for PII detection
             new iam.PolicyStatement({

--- a/infra/lib/constructs/ecs-service.ts
+++ b/infra/lib/constructs/ecs-service.ts
@@ -538,13 +538,15 @@ export class EcsServiceConstruct extends Construct {
               resources: props.guardrailArn
                 ? [
                     props.guardrailArn,
-                    // Cross-region inference profile ARNs (region-qualified, e.g.
-                    // us.guardrail.*) the guardrail resolves to at apply time.
-                    `arn:aws:bedrock:${cdk.Stack.of(this).region}:${cdk.Stack.of(this).account}:guardrail-profile/*`,
+                    // The system-defined cross-region inference profile the
+                    // guardrail resolves to at apply time. Scoped to the exact
+                    // profile id (NOT a wildcard) to match the proven grants in
+                    // guardrails-stack.ts and agent-platform-stack.ts (PR #1093).
+                    `arn:aws:bedrock:${cdk.Stack.of(this).region}:${cdk.Stack.of(this).account}:guardrail-profile/us.guardrail.v1:0`,
                   ]
                 : [
                     `arn:aws:bedrock:${cdk.Stack.of(this).region}:${cdk.Stack.of(this).account}:guardrail/*`,
-                    `arn:aws:bedrock:${cdk.Stack.of(this).region}:${cdk.Stack.of(this).account}:guardrail-profile/*`,
+                    `arn:aws:bedrock:${cdk.Stack.of(this).region}:${cdk.Stack.of(this).account}:guardrail-profile/us.guardrail.v1:0`,
                   ],
             }),
             // K-12 Content Safety: Amazon Comprehend for PII detection


### PR DESCRIPTION
## Why

After deploying the §1087 chat-edits-workspace feature (#1136), the deployed **dev** environment showed two runtime failures the local Playwright harness could not exercise (Bedrock screening is disabled without creds; the WS bundle only exists in the built image):

- Chat replied, but every **workspace tool call** returned `Content could not be safety-screened right now. Please retry shortly.` ("temporary issue with the safety screening system").
- The workspace **panel stayed stuck on "Connecting…"**.

Both are deploy/packaging-level, not app-logic, and both were found in CloudWatch `/ecs/aistudio-dev`.

## Fix 1 — grant `bedrock:ApplyGuardrail` on the guardrail-**profile** ARN

CloudWatch:
```
User: ...EcsServiceTaskRole... is not authorized to perform: bedrock:ApplyGuardrail
on resource: arn:aws:bedrock:us-east-1:...:guardrail-profile/us.guardrail.v1:0
```
The guardrail uses **cross-region inference**, so `ApplyGuardrail` authorizes against **both** the guardrail ARN **and** the region-qualified `guardrail-profile/*` ARN. The task role was granted only the guardrail ARN → 100% AccessDenied on the profile. That made `ContentSafetyService` fail and, critically, made **Atrium §28.3 agent-write screening fail closed** — every workspace/agent content edit was rejected. Same class as the agent-router fix in #1093.

`infra/lib/constructs/ecs-service.ts`: add `guardrail-profile/*` to both the specific-ARN and wildcard branches of the `ApplyGuardrail`/`GetGuardrail` statement.

## Fix 2 — build the voice + collab WS bundles in ONE Docker layer

CloudWatch (same image):
```
[atrium-collab] Collab WebSocket disabled: handler not found at ./collab-handler-bundle.cjs
[voice-server] WebSocket handler registered       ← sibling bundle loaded fine
```
Both bundles are esbuild-produced into `.next/standalone/` and picked up by the same `COPY .next/standalone ./`. Voice loaded, collab did not — the collab bundle simply wasn't in the built image. They were **two separate `RUN` layers**, and the second layer's output was not surviving into the standalone `COPY` under BuildKit (CDK `fromAsset` build). Without the collab handler the workspace collab WS never starts → panel "Connecting…" forever and agent doc edits can't push.

`Dockerfile`: build **both** bundles in a single `RUN` layer and `test -f` **assert** both exist, so a missing bundle is a loud build failure instead of a silent runtime one.

## Deploy note

Takes effect on the next **FrontendStack** deploy: the IAM grant updates the task role, and CDK `fromAsset` rebuilds the image (picking up the collab bundle). The canonical full deploy covers both.

## Testing
- `infra` `tsc --noEmit` clean.
- Verified locally both bundle scripts emit their `.cjs` into `.next/standalone/` with only Node built-in externals (`voice: OK / collab: OK`), then removed the local artifacts.
- Screening AccessDenied and the collab-disabled boot line are deploy-only; they were diagnosed from CloudWatch and cannot be reproduced by the dev-server harness (guardrails self-disable without AWS creds; the WS bundle exists only in the built image).