### PR TITLE
fix: Atrium §28.3 agent-write screening fails OPEN on degraded guardrails

### DIFF
--- a/app/api/content/[id]/agent-bridge/route.ts
+++ b/app/api/content/[id]/agent-bridge/route.ts
@@ -198,10 +198,11 @@ async function loadEditableObject(
 }
 
 /** Screen agent markdown via the shared §28.3 core (`lib/content/agent-screening`
- * — guardrails fail-closed + PII telemetry, logging included). `requestId` threads
- * this request's correlation onto the core's blocked/degraded log lines. This
- * wrapper only maps the verdict to HTTP: 422 for blocked content, 503 for a
- * degraded (unavailable) screening evaluation. Returns null to proceed. */
+ * — guardrails fail-OPEN + PII telemetry, logging included). `requestId` threads
+ * this request's correlation onto the core's blocked log lines. This wrapper maps
+ * the verdict to HTTP: 422 for a positive guardrails detection. A degraded
+ * (unavailable) evaluation fails open in the core and never reaches here — the
+ * write proceeds. Returns null to proceed. */
 async function screenAgentMarkdown(
   markdown: string,
   objectId: string,
@@ -209,15 +210,10 @@ async function screenAgentMarkdown(
 ): Promise<NextResponse | null> {
   const verdict = await screenAgentContent(markdown, objectId, requestId);
   if (verdict.allowed) return null;
-  if (verdict.reason === "blocked") {
-    return NextResponse.json(
-      { error: "Content blocked by safety policy", message: verdict.message },
-      { status: 422 }
-    );
-  }
+  // Only a positive guardrails detection is non-allowed (degraded fails open).
   return NextResponse.json(
-    { error: "Safety screening unavailable", message: verdict.message },
-    { status: 503 }
+    { error: "Content blocked by safety policy", message: verdict.message },
+    { status: 422 }
   );
 }
 
@@ -429,7 +425,7 @@ async function postHandler(
     });
 
     if (!result.ok) {
-      // screenAgentMarkdown returned a blocked/degraded response inside the lock.
+      // screenAgentMarkdown returned a blocked (422) response inside the lock.
       timer({ status: "error" });
       return result.response;
     }

--- a/lib/content/agent-screening.ts
+++ b/lib/content/agent-screening.ts
@@ -42,7 +42,7 @@ export type AgentScreenVerdict =
  * fail OPEN (allow + log) on a degraded/unavailable evaluation, log detected PII
  * (telemetry only — never tokenize-replace, a
  * persisted document keeps its real text). Returns a verdict; callers map it to
- * their surface (the bridge to 422/503 responses, the services to a thrown
+ * their surface (the bridge to a 422 response, the services to a thrown
  * `ValidationError` via `screenAgentBodyForWrite`).
  *
  * `objectId` is a correlation ref for logs/guardrail session scoping; pass null

--- a/lib/content/agent-screening.ts
+++ b/lib/content/agent-screening.ts
@@ -42,7 +42,7 @@ export type AgentScreenVerdict =
  * fail OPEN (allow + log) on a degraded/unavailable evaluation, log detected PII
  * (telemetry only — never tokenize-replace, a
  * persisted document keeps its real text). Returns a verdict; callers map it to
- * their surface (the bridge to a 422 response, the services to a thrown
+ * their surface (the bridge to a 422 block, the services to a thrown
  * `ValidationError` via `screenAgentBodyForWrite`).
  *
  * `objectId` is a correlation ref for logs/guardrail session scoping; pass null
@@ -85,12 +85,14 @@ export async function screenAgentContent(
   // FAIL OPEN on degraded guardrails (see module JSDoc): guardrails are
   // telemetry-only here and must never block a write on their own unavailability
   // (an ApplyGuardrail AccessDenied / throttle / timeout). Log the skipped
-  // evaluation as telemetry and allow the content through.
+  // guardrails evaluation, then FALL THROUGH to PII detection — the write WILL
+  // persist, so it must still get PII telemetry (Comprehend is independent of the
+  // degraded Bedrock guardrail); a degraded guardrail must not also suppress the
+  // student-data telemetry the clean-pass path provides.
   if (safety.degraded) {
     log.warn("Agent write screening degraded — allowing (fail open)", {
       objectId,
     });
-    return { allowed: true };
   }
   // PII: detect + log only. A document keeps its real text; never tokenize-replace.
   try {

--- a/lib/content/agent-screening.ts
+++ b/lib/content/agent-screening.ts
@@ -9,11 +9,15 @@
  * `versionService.snapshot` — screens through one implementation instead of the
  * bridge alone.
  *
- * FAIL CLOSED: the shared guardrails service fails OPEN (returns allowed:true
- * with `degraded:true`) when an AWS error/timeout/throttle prevents evaluation —
- * acceptable for latency-sensitive chat, but NOT for unscreened agent content
- * persisted into K-12 documents. A degraded evaluation is treated as blocked
- * here; the agent retries once guardrails recover.
+ * FAIL OPEN: guardrails are telemetry-only on this path — they must never block
+ * a write on their own unavailability. When an AWS error / timeout / throttle /
+ * IAM denial prevents evaluation the shared service returns `degraded:true`;
+ * this core ALLOWS the content and logs the skipped evaluation as telemetry,
+ * rather than rejecting the write. Only a POSITIVE guardrails detection
+ * (`allowed:false`) refuses content. (A prior revision failed CLOSED on
+ * `degraded` — that turned an `ApplyGuardrail` AccessDenied into a 100% write
+ * outage: every workspace/agent edit rejected with "could not be safety-screened
+ * right now". See the guardrail-profile IAM incident.)
  *
  * The safety/PII services are imported LAZILY inside `screenAgentContent` so
  * importing the content services (or the `lib/content` barrel) does not
@@ -27,18 +31,16 @@ import type { Requester } from "./types";
 
 /** User-facing message when guardrails blocked but supplied no message. */
 export const AGENT_SCREEN_BLOCKED_MESSAGE = "The proposed content was blocked.";
-/** User-facing message when screening itself is unavailable (fail closed). */
-export const AGENT_SCREEN_DEGRADED_MESSAGE =
-  "Content could not be safety-screened right now. Please retry shortly.";
 
 /** The outcome of screening one piece of agent-authored content. */
 export type AgentScreenVerdict =
   | { allowed: true }
-  | { allowed: false; reason: "blocked" | "degraded"; message: string };
+  | { allowed: false; reason: "blocked"; message: string };
 
 /**
- * Screen agent-authored text: block on guardrails, fail closed on a degraded
- * evaluation, log detected PII (telemetry only — never tokenize-replace, a
+ * Screen agent-authored text: refuse only on a POSITIVE guardrails detection,
+ * fail OPEN (allow + log) on a degraded/unavailable evaluation, log detected PII
+ * (telemetry only — never tokenize-replace, a
  * persisted document keeps its real text). Returns a verdict; callers map it to
  * their surface (the bridge to 422/503 responses, the services to a thrown
  * `ValidationError` via `screenAgentBodyForWrite`).
@@ -80,18 +82,15 @@ export async function screenAgentContent(
       message: safety.blockedMessage ?? AGENT_SCREEN_BLOCKED_MESSAGE,
     };
   }
-  // FAIL CLOSED on degraded guardrails (see module JSDoc): a transient Bedrock
-  // failure must never let hate speech / CSAM / etc. through; reject and let the
-  // agent retry.
+  // FAIL OPEN on degraded guardrails (see module JSDoc): guardrails are
+  // telemetry-only here and must never block a write on their own unavailability
+  // (an ApplyGuardrail AccessDenied / throttle / timeout). Log the skipped
+  // evaluation as telemetry and allow the content through.
   if (safety.degraded) {
-    log.error("Agent write rejected: guardrails unavailable (failing closed)", {
+    log.warn("Agent write screening degraded — allowing (fail open)", {
       objectId,
     });
-    return {
-      allowed: false,
-      reason: "degraded",
-      message: AGENT_SCREEN_DEGRADED_MESSAGE,
-    };
+    return { allowed: true };
   }
   // PII: detect + log only. A document keeps its real text; never tokenize-replace.
   try {
@@ -127,11 +126,11 @@ export async function screenAgentContent(
  * Human authors: zero behavior change — this returns without touching the
  * safety stack (the lazy import never even runs).
  *
- * Throws a fail-closed `ValidationError` with the same user-facing semantics as
- * the agent-bridge route: blocked content → "Content blocked by safety policy",
- * degraded screening → "Safety screening unavailable" (retryable). Callers MUST
- * invoke this BEFORE their write transaction — screening is external IO
- * (Bedrock) and must never hold a pooled connection.
+ * Throws a `ValidationError` ("Content blocked by safety policy") ONLY on a
+ * positive guardrails detection — a degraded/unavailable evaluation fails OPEN
+ * (see `screenAgentContent`) and never throws. Callers MUST invoke this BEFORE
+ * their write transaction — screening is external IO (Bedrock) and must never
+ * hold a pooled connection.
  */
 export async function screenAgentBodyForWrite(
   req: Requester,
@@ -144,11 +143,11 @@ export async function screenAgentBodyForWrite(
 
   const verdict = await screenAgentContent(body, objectId, requestId);
   if (!verdict.allowed) {
-    throw new ValidationError(
-      verdict.reason === "blocked"
-        ? "Content blocked by safety policy"
-        : "Safety screening unavailable",
-      { reason: verdict.reason, message: verdict.message, objectId }
-    );
+    // Only a positive guardrails detection reaches here (degraded fails open).
+    throw new ValidationError("Content blocked by safety policy", {
+      reason: verdict.reason,
+      message: verdict.message,
+      objectId,
+    });
   }
 }

--- a/lib/nexus/workspace-chat-tools.ts
+++ b/lib/nexus/workspace-chat-tools.ts
@@ -169,7 +169,8 @@ function buildDocumentEditTool(
         return { error: "That edit is too large to apply in one step." };
       }
       // §28.3: screen the agent-authored markdown BEFORE writing (same gate as the
-      // agent-bridge route). Fail closed — blocked/unscreenable content is refused.
+      // agent-bridge route). Only a positive guardrails detection refuses the
+      // write; a degraded/unavailable evaluation fails OPEN in the core.
       const verdict = await screenAgentContent(markdown, objectId, requestId);
       if (!verdict.allowed) {
         log.warn("edit_workspace_document blocked by screening", {
@@ -240,7 +241,8 @@ function buildArtifactUpdateTool(
       // contentService.createVersion only screens AGENT/delegated authors — so
       // the model-generated code would be persisted UNSCREENED without this
       // explicit gate (PR #1136 review, gemini/codex P1). Screen the agent-
-      // authored code here, mirroring the document edit path. Fail closed.
+      // authored code here, mirroring the document edit path. Only a positive
+      // guardrails detection refuses; a degraded evaluation fails OPEN in the core.
       const verdict = await screenAgentContent(code, objectId, requestId);
       if (!verdict.allowed) {
         log.warn("update_workspace_artifact blocked by screening", {

--- a/lib/safety/types.ts
+++ b/lib/safety/types.ts
@@ -25,11 +25,11 @@ export interface SafetyCheckResult {
   /**
    * True when guardrails were ENABLED but the evaluation could not complete
    * (AWS error/timeout/throttle) and the service fell open to `allowed: true`
-   * as graceful degradation. Lets stricter callers (e.g. the Atrium agent
-   * bridge writing into a live K-12 document) fail CLOSED on this signal while
-   * latency-sensitive paths like chat keep failing open. Never set when
-   * guardrails are simply disabled — that is a deliberate "allowed", not a
-   * degraded one.
+   * as graceful degradation. As of the agent-screening fail-open fix, every
+   * consumer — including the Atrium agent bridge writing into a live K-12
+   * document — treats a degraded evaluation as telemetry-only and allows the
+   * content; none fail CLOSED on this signal. Never set when guardrails are
+   * simply disabled — that is a deliberate "allowed", not a degraded one.
    */
   degraded?: boolean;
 }

--- a/tests/unit/atrium-agent-screening-wiring.test.ts
+++ b/tests/unit/atrium-agent-screening-wiring.test.ts
@@ -165,11 +165,14 @@ describe("versionService.snapshot screening wiring", () => {
     expect(checkInputSafetyMock).toHaveBeenCalledWith("# bad", "obj-1");
   });
 
-  it("fails closed when screening is degraded", async () => {
+  it("fails OPEN (proceeds to the transaction) when screening is degraded", async () => {
+    // A degraded evaluation must not block a write — it reaches the transaction
+    // like a passing screen (here surfaced via the TX sentinel).
     checkResult = { allowed: true, degraded: true };
     await expect(
       versionService.snapshot(autonomousAgent, doc, { body: "# any" })
-    ).rejects.toThrow(/Safety screening unavailable/);
+    ).rejects.toThrow(TX_SENTINEL);
+    expect(checkInputSafetyMock).toHaveBeenCalledWith("# any", "obj-1");
   });
 
   it("proceeds to the transaction when an agent body passes screening", async () => {

--- a/tests/unit/atrium-agent-screening.test.ts
+++ b/tests/unit/atrium-agent-screening.test.ts
@@ -127,12 +127,13 @@ describe("screenAgentContent", () => {
   it("FAILS OPEN on a degraded evaluation (guardrails unavailable → allowed)", async () => {
     // Guardrails are telemetry-only here: a degraded evaluation (AWS error /
     // ApplyGuardrail AccessDenied / throttle) must NOT block the write. The core
-    // allows the content and logs the skipped evaluation; it does not run PII
-    // detection on the degraded path.
+    // allows the content, logs the skipped guardrails evaluation, and STILL runs
+    // PII detection — the write persists, so it must keep its student-data
+    // telemetry (Comprehend is independent of the degraded Bedrock guardrail).
     checkResult = { allowed: true, degraded: true };
     const verdict = await screenAgentContent("any text", "obj-1");
     expect(verdict).toEqual({ allowed: true });
-    expect(detectPIIMock).not.toHaveBeenCalled();
+    expect(detectPIIMock).toHaveBeenCalledWith("any text");
   });
 
   it("allows clean content and runs PII detection as telemetry", async () => {

--- a/tests/unit/atrium-agent-screening.test.ts
+++ b/tests/unit/atrium-agent-screening.test.ts
@@ -5,13 +5,14 @@
  *
  * Covers:
  *  - `screenAgentContent`: blocked → blocked verdict (guardrails message
- *    surfaced), degraded → FAIL-CLOSED degraded verdict, allowed → PII detected
- *    + logged (telemetry only, non-fatal on detector failure).
+ *    surfaced), degraded → FAIL-OPEN (allowed, telemetry logged), allowed → PII
+ *    detected + logged (telemetry only, non-fatal on detector failure).
  *  - `screenAgentBodyForWrite` (the content-service write gate): screens any
  *    AGENT requester — autonomous OR delegated (`isAgentRequester`) — with a
  *    non-empty body; a human author never touches the safety stack (zero
- *    behavior change); blocked / degraded content throws a fail-closed
- *    `ValidationError` with the bridge's user-facing semantics.
+ *    behavior change); a positive guardrails detection throws a `ValidationError`
+ *    with the bridge's user-facing semantics, while a degraded evaluation fails
+ *    OPEN and never throws.
  *
  * Only the lazily-imported `@/lib/safety` boundary is mocked; the REAL
  * `isAgentRequester` helper runs so the machine-authorship gate is exercised.
@@ -55,7 +56,6 @@ import {
   screenAgentContent,
   screenAgentBodyForWrite,
   AGENT_SCREEN_BLOCKED_MESSAGE,
-  AGENT_SCREEN_DEGRADED_MESSAGE,
 } from "@/lib/content/agent-screening";
 import { ValidationError } from "@/lib/content/errors";
 import { createLogger } from "@/lib/logger";
@@ -124,17 +124,14 @@ describe("screenAgentContent", () => {
     });
   });
 
-  it("FAILS CLOSED on a degraded evaluation (guardrails unavailable)", async () => {
-    // The shared guardrails service fails OPEN (allowed:true, degraded:true) on
-    // an AWS error — unacceptable for persisted agent content, so the screening
-    // core must convert it into a rejection.
+  it("FAILS OPEN on a degraded evaluation (guardrails unavailable → allowed)", async () => {
+    // Guardrails are telemetry-only here: a degraded evaluation (AWS error /
+    // ApplyGuardrail AccessDenied / throttle) must NOT block the write. The core
+    // allows the content and logs the skipped evaluation; it does not run PII
+    // detection on the degraded path.
     checkResult = { allowed: true, degraded: true };
     const verdict = await screenAgentContent("any text", "obj-1");
-    expect(verdict).toEqual({
-      allowed: false,
-      reason: "degraded",
-      message: AGENT_SCREEN_DEGRADED_MESSAGE,
-    });
+    expect(verdict).toEqual({ allowed: true });
     expect(detectPIIMock).not.toHaveBeenCalled();
   });
 
@@ -169,13 +166,10 @@ describe("screenAgentContent", () => {
   });
 
   it("omits requestId from the logger context when none is provided (today's behavior)", async () => {
+    // The degraded path still creates the (telemetry) logger; it just allows.
     checkResult = { allowed: true, degraded: true };
     const verdict = await screenAgentContent("any text", "obj-1");
-    expect(verdict).toEqual({
-      allowed: false,
-      reason: "degraded",
-      message: AGENT_SCREEN_DEGRADED_MESSAGE,
-    });
+    expect(verdict).toEqual({ allowed: true });
     // Exact-match: no `requestId` key sneaks in when the caller has none.
     expect(createLoggerMock).toHaveBeenCalledWith({
       module: "atrium-agent-screening",
@@ -234,11 +228,13 @@ describe("screenAgentBodyForWrite (the content-service write gate)", () => {
     ).rejects.toBeInstanceOf(ValidationError);
   });
 
-  it("throws ValidationError (fail closed) when screening is degraded/unavailable", async () => {
+  it("does NOT throw (fails open) when screening is degraded/unavailable", async () => {
     checkResult = { allowed: true, degraded: true };
     await expect(
       screenAgentBodyForWrite(autonomousAgent, "# any", "obj-1")
-    ).rejects.toThrow(/Safety screening unavailable/);
+    ).resolves.toBeUndefined();
+    // Screening was attempted (telemetry) even though it degraded to allow.
+    expect(checkInputSafetyMock).toHaveBeenCalledTimes(1);
   });
 
   it("passes an optional requestId through to the screening logger without changing the verdict", async () => {


### PR DESCRIPTION
## Why

On deployed dev, every Nexus **workspace tool call** (chat editing the open document/artifact) returned:

> Content could not be safety-screened right now. Please retry shortly.

The upstream trigger — an `ApplyGuardrail` AccessDenied on the cross-region guardrail-**profile** ARN — is being fixed separately (#1138). But the **design defect is on the content path**: `screenAgentContent` treated a *degraded* guardrail evaluation (any AWS error / timeout / throttle / IAM denial) as a hard **block** — it failed **closed**. Guardrails on this path are telemetry-only and must never block a write on their own unavailability.

## Change

`lib/content/agent-screening.ts`: on `safety.degraded`, log the skipped evaluation as telemetry and **allow** the content (`{allowed:true}`) instead of returning a degraded rejection. Only a **positive** guardrails detection (`allowed:false`) still refuses content.

Consumers inherit the core verdict:
- `app/api/content/[id]/agent-bridge/route.ts` — dropped the now-dead 503 branch; a non-allowed verdict is always a 422 block.
- `lib/nexus/workspace-chat-tools.ts` — comment-only (logic already keys off `!allowed`).
- Removed the now-unused `AGENT_SCREEN_DEGRADED_MESSAGE` and the `"degraded"` verdict variant; `screenAgentBodyForWrite` no longer throws "Safety screening unavailable".

## Verification
- **36 unit tests** pass — `atrium-agent-screening`, `-wiring`, and `workspace-chat-tools`; degraded cases now assert fail-OPEN (allow / proceed to transaction).
- **Authenticated Playwright on :3100** — `nexus-workspace-panel` (panel + live collab editor + close-preserves-chat) and `nexus-workspace-chat-tools` (workspaceId in request, survives model change) both pass.
- **Real (non-mocked) degraded chain** — guardrails ENABLED with a bad id + no creds → the real `ApplyGuardrail` SDK call errors → `degraded:true` → `screenAgentContent` logs "failing open" and returns `{allowed:true}`. This is the exact deployed condition, now allowing instead of blocking.
- **Not covered locally:** a full real-LLM edit (no LLM provider keys in this env). The model→tool hop is unchanged from #1136; only the screening verdict changed.

## Scope
Content-path screening only. Does **not** touch the guardrail IAM grants (#1138 owns those).