### PR TITLE
fix(agent): #1138 follow-up — attachment S3 write grant, payload-file text transport, code-mode timeout

### DIFF
--- a/infra/agent-image/Dockerfile
+++ b/infra/agent-image/Dockerfile
@@ -250,6 +250,17 @@ RUN mkdir -p /home/node/.openclaw/memory
 #   TODO: give the sub-agent a dedicated fast model (Haiku/Nova) via
 #   config.model — requires adding a second model to bedrock-proxy. Until
 #   then the sub-agent adds ~5-10s to every turn's wall-clock latency.
+#
+#   tools.codeMode.timeoutMs=60000 — code-mode (tool_search_code) VM
+#   execution ceiling, raised from the 10s default to the documented max
+#   (docs/reference/code-mode.md range 100–60000). At 10s, any skill command
+#   slower than ~10s (Plaud digest, large gws call) died with
+#   "tool_search_code timed out" BEFORE exec could suspend into the
+#   status:"waiting" yield path — observed 2026-07-06 (#1138 follow-up): the
+#   agent's exec used yieldMs=60000, so the VM was killed at 10s, 50s before
+#   it would have yielded. 60s is a ceiling, not a delay: fast calls return
+#   as before. Pair with psd-rules guidance to use SHORT yieldMs (≤10s) so
+#   long commands suspend early instead of racing this timeout.
 COPY openclaw.json /home/node/.openclaw/openclaw.json
 # Build-time config sanity check (post-2026-07-02 config-risk hardening): surface
 # any openclaw.json schema/key errors at BUILD time instead of at runtime (a

--- a/infra/agent-image/openclaw.json
+++ b/infra/agent-image/openclaw.json
@@ -38,6 +38,9 @@
   },
   "tools": {
     "toolSearch": true,
+    "codeMode": {
+      "timeoutMs": 60000
+    },
     "deny": ["cron", "nodes", "gateway"]
   },
   "skills": {

--- a/infra/agent-image/skills/psd-rules/SKILL.md
+++ b/infra/agent-image/skills/psd-rules/SKILL.md
@@ -269,6 +269,14 @@ Finding a tool runs a short JS body in an isolated subprocess that exposes **onl
 
 **Why:** malformed search bodies (object query, `require`, `setTimeout`) error and retry, and every retry re-reads the entire context — a top token-waste source (observed 2026-07-02).
 
+**Long-running calls (the 60-second sandbox ceiling).** The sandbox kills any `tool_search_code` body after 60 s of execution — a slow inner call (Plaud digest, big gws write, a long exec) dies with `tool_search_code timed out` and you get nothing back, even though the underlying command may have kept running (side effects included).
+
+- **Never block on a slow call.** For any exec that could take more than ~30 s, pass a SHORT `yieldMs` (5000–10000). The call suspends and returns `status: "waiting"` with a `runId` well before the ceiling; resume it with `wait` on that `runId` to collect the result.
+- **Never poll with a long timeout.** A `process poll` timeout must stay ≤ 30000; poll repeatedly in separate tool calls rather than once with 90 s.
+- **If a call times out anyway**, assume its side effects MAY have happened — check before re-running anything that creates or sends.
+
+**Why:** observed 2026-07-06 (#1138): a Plaud digest exec with `yieldMs: 60000` and a 90 s poll both hit the sandbox timeout, the bridge looked "unresponsive," and a multi-step task died mid-run with documents half-created.
+
 ---
 
 ## Self-check before send

--- a/infra/agent-image/skills/psd-workspace/SKILL.md
+++ b/infra/agent-image/skills/psd-workspace/SKILL.md
@@ -95,6 +95,41 @@ node /opt/psd-skills/psd-workspace/run.js \
 node /opt/psd-skills/psd-workspace/run.js --user hagelk@psd401.net --command "--help"
 ```
 
+## Passing real text: `--json-file` / `--body-file` (REQUIRED for content writes)
+
+The `--command` tokenizer has **no escape syntax**: an apostrophe inside a
+single-quoted value, mixed quotes, or a newline breaks tokenization, and there
+is no way to fix it with more quoting. **Never inline document/email/event
+body text in `--json` or `--body`.** Instead, write the payload to a file
+first and reference it:
+
+```bash
+# 1. Write the payload to a file (any quotes/newlines/emoji are fine here)
+cat > /tmp/doc-payload.json <<'PAYLOAD'
+{"requests":[{"insertText":{"location":{"index":1},"text":"It's fine to use \"both\" quote kinds.\n\nNew paragraphs too."}}]}
+PAYLOAD
+
+# 2. Reference it with --json-file (replaces --json)
+node /opt/psd-skills/psd-workspace/run.js \
+  --user hagelk@psd401.net \
+  --command "docs documents batchUpdate --params '{\"documentId\":\"<id>\"}' --json-file /tmp/doc-payload.json"
+
+# Plain-text bodies (e.g. +draft) use --body-file (replaces --body)
+node /opt/psd-skills/psd-workspace/run.js \
+  --user hagelk@psd401.net \
+  --command "gmail +draft --to bill@psd401.net --subject 'Follow up' --body-file /tmp/draft-body.txt"
+```
+
+Rules: the path must be absolute; use `--json-file` OR `--json`, never both;
+one of each flag per command. The file content is handed to gws as exactly one
+argv token — quoting rules never apply to it. Phase 1 gates and marker
+injection still see the real payload (they run against the resolved content),
+so this is a transport mechanism, not a bypass: forbidden operations are still
+refused, and file-based payloads still get audit markers.
+
+Use inline `--json` only for short, quote-free payloads you compose yourself
+(IDs, dates, enum values). Anything containing prose goes through a file.
+
 ## Phase 1 boundaries (hard gates — refused at the skill layer)
 
 These cannot be bypassed by phrasing. The skill returns exit code 13 with `status: phase1-forbidden`:

--- a/infra/agent-image/skills/psd-workspace/common.js
+++ b/infra/agent-image/skills/psd-workspace/common.js
@@ -206,13 +206,117 @@ function splitCommand(cmd) {
   return tokens;
 }
 
+// ============================================================================
+// Payload files — safe transport for arbitrary text (#1138 follow-up)
+// ============================================================================
+//
+// splitCommand supports quoted segments but has NO escape syntax: a quote
+// character inside a same-quoted value terminates the token, so any content
+// with an apostrophe, mixed quotes, or newlines (i.e. real document text)
+// cannot ride inside --command at all. Observed live 2026-07-06: the agent
+// could not write Google Doc content ("no way to pass multi-word text via
+// this shim") and the task died. The fix: the model writes the content to a
+// file and references it with `--json-file <abs-path>` (JSON payloads) or
+// `--body-file <abs-path>` (plain-text bodies, e.g. +draft). The file's
+// content is delivered to gws as exactly ONE argv token — quoting rules
+// never apply to it.
+//
+// Ordering contract (see run.js): the resolved JSON is inlined into a
+// synthetic command string FIRST so Phase 1 gates (incl. the share-to-caller
+// payload validation) and marker injection see the real payload; execution
+// then swaps a whitespace-free placeholder token for the payload AFTER
+// splitCommand, so tokenization never touches the content.
+
+const PAYLOAD_PLACEHOLDERS = {
+  '--json-file': { flag: '--json', placeholder: '@@PSD_PAYLOAD_JSON@@', kind: 'json' },
+  '--body-file': { flag: '--body', placeholder: '@@PSD_PAYLOAD_BODY@@', kind: 'text' },
+};
+
+/**
+ * Resolve `--json-file` / `--body-file` references in a --command string.
+ *
+ * Returns null when neither flag is present. Otherwise returns:
+ *   {
+ *     execCommand:      command with each file flag replaced by
+ *                       `--json @@PSD_PAYLOAD_JSON@@` / `--body @@…@@`,
+ *     syntheticCommand: command with each file flag replaced by the REAL
+ *                       content inline (gates + markers run against this),
+ *     payloads:         { [placeholderToken]: content }
+ *   }
+ *
+ * Fails (exit 1) on: relative path, unreadable file, invalid JSON in a
+ * --json-file, duplicate use of the same flag, or --json-file alongside an
+ * inline --json (ambiguous — exactly one payload source allowed).
+ */
+function resolvePayloadFiles(commandString) {
+  if (!commandString || typeof commandString !== 'string') return null;
+  let execCommand = commandString;
+  let syntheticCommand = commandString;
+  const payloads = {};
+
+  for (const [fileFlag, spec] of Object.entries(PAYLOAD_PLACEHOLDERS)) {
+    const re = new RegExp(`(^|\\s)${fileFlag}\\s+(\\S+)`, 'g');
+    const matches = [...commandString.matchAll(re)];
+    if (matches.length === 0) continue;
+    if (matches.length > 1) {
+      fail(`${fileFlag} may appear at most once per command`);
+    }
+    if (fileFlag === '--json-file' && /(^|\s)--json\s/.test(commandString)) {
+      fail('use either --json or --json-file, not both');
+    }
+    const filePath = matches[0][2];
+    if (!filePath.startsWith('/')) {
+      fail(`${fileFlag} requires an absolute path (got "${filePath}")`);
+    }
+    let content;
+    try {
+      content = fs.readFileSync(filePath, 'utf8');
+    } catch (err) {
+      fail(`${fileFlag}: cannot read ${filePath}: ${err.message}`);
+    }
+    if (spec.kind === 'json') {
+      try {
+        // Minify so the synthetic inline command is single-line — the
+        // marker injector's brace scanner and the gate regexes both operate
+        // on it, and a compact form keeps their behavior identical to the
+        // inline --json path.
+        content = JSON.stringify(JSON.parse(content));
+      } catch (err) {
+        fail(`${fileFlag}: ${filePath} is not valid JSON: ${err.message}`);
+      }
+    }
+    payloads[spec.placeholder] = content;
+    execCommand = execCommand.replace(
+      re,
+      (m, lead) => `${lead}${spec.flag} ${spec.placeholder}`
+    );
+    syntheticCommand = syntheticCommand.replace(
+      re,
+      (m, lead) => `${lead}${spec.flag} ${content}`
+    );
+  }
+
+  return Object.keys(payloads).length > 0
+    ? { execCommand, syntheticCommand, payloads }
+    : null;
+}
+
 /**
  * Exec gws with GOOGLE_WORKSPACE_CLI_TOKEN set. Streams stdout; returns exit
  * code. gws ignores GOOGLE_ACCESS_TOKEN — must be GOOGLE_WORKSPACE_CLI_TOKEN
  * per the gws README "Pre-obtained Access Token" section.
+ *
+ * `payloads` (optional) maps placeholder tokens to payload-file contents
+ * (see resolvePayloadFiles). Substitution happens AFTER splitCommand, so the
+ * content becomes exactly one argv token regardless of quotes/newlines.
  */
-function execGws(commandString, accessToken) {
-  const tokens = splitCommand(commandString);
+function execGws(commandString, accessToken, payloads) {
+  let tokens = splitCommand(commandString);
+  if (payloads && typeof payloads === 'object') {
+    tokens = tokens.map((t) =>
+      Object.prototype.hasOwnProperty.call(payloads, t) ? payloads[t] : t
+    );
+  }
   if (tokens.length === 0) {
     fail('--command is empty');
   }
@@ -502,17 +606,17 @@ function injectMarkers(commandString) {
 }
 
 /**
- * Find the --json '{...}' argument in a gws command string and apply
- * `mutator` to the parsed object. Re-encode and splice back.
- *
- * Returns the original string if no --json arg or the JSON parse fails.
+ * Locate the --json '{...}' argument in a gws command string via a
+ * balanced-brace scan. Returns {jsonStart, jsonEnd, openQuote} (end
+ * inclusive) or null when there is no parseable --json object. Shared by
+ * mutateJsonField (marker injection) and extractJsonArg (payload-file flow).
  */
-function mutateJsonField(commandString, mutator) {
+function findJsonSpan(commandString) {
   // Match --json followed by a single-quoted or double-quoted JSON object.
   // The simple/robust approach: find --json, then balanced-brace scan from
   // the next non-quote character forward.
   const jsonFlagIdx = commandString.search(/--json\s+['"]?\{/);
-  if (jsonFlagIdx === -1) return commandString;
+  if (jsonFlagIdx === -1) return null;
 
   // Find the start of the JSON object (`{`). Skip the `--json` token,
   // any whitespace, and any opening quote.
@@ -524,7 +628,7 @@ function mutateJsonField(commandString, mutator) {
     i++;
   }
   const jsonStart = i;
-  if (commandString[jsonStart] !== '{') return commandString;
+  if (commandString[jsonStart] !== '{') return null;
 
   // Brace-balance scan to find the matching close.
   let depth = 0;
@@ -551,7 +655,32 @@ function mutateJsonField(commandString, mutator) {
       if (depth === 0) { jsonEnd = j; break; }
     }
   }
-  if (jsonEnd === -1) return commandString;
+  if (jsonEnd === -1) return null;
+  return { jsonStart, jsonEnd, openQuote };
+}
+
+/**
+ * Return the raw --json object substring from a command string, or null.
+ * Used by the payload-file flow to pull a marker-mutated JSON payload back
+ * out of the synthetic inline command before execution.
+ */
+function extractJsonArg(commandString) {
+  if (!commandString || typeof commandString !== 'string') return null;
+  const span = findJsonSpan(commandString);
+  if (!span) return null;
+  return commandString.slice(span.jsonStart, span.jsonEnd + 1);
+}
+
+/**
+ * Find the --json '{...}' argument in a gws command string and apply
+ * `mutator` to the parsed object. Re-encode and splice back.
+ *
+ * Returns the original string if no --json arg or the JSON parse fails.
+ */
+function mutateJsonField(commandString, mutator) {
+  const span = findJsonSpan(commandString);
+  if (!span) return commandString;
+  const { jsonStart, jsonEnd, openQuote } = span;
 
   const jsonStr = commandString.slice(jsonStart, jsonEnd + 1);
   let obj;
@@ -599,5 +728,7 @@ module.exports = {
   execGws,
   enforcePhase1Gates,
   injectMarkers,
+  resolvePayloadFiles,
+  extractJsonArg,
   PHASE1_FORBIDDEN,
 };

--- a/infra/agent-image/skills/psd-workspace/common.js
+++ b/infra/agent-image/skills/psd-workspace/common.js
@@ -261,10 +261,27 @@ function resolvePayloadFiles(commandString) {
     if (matches.length > 1) {
       fail(`${fileFlag} may appear at most once per command`);
     }
-    if (fileFlag === '--json-file' && /(^|\s)--json\s/.test(commandString)) {
-      fail('use either --json or --json-file, not both');
+    // Exactly one payload source per flag: reject the file form alongside its
+    // inline counterpart (--json + --json-file, --body + --body-file) —
+    // otherwise gws would receive two occurrences of the same flag and pick
+    // one silently. `--json\s` does not match `--json-file` (hyphen, not
+    // whitespace, follows), so the file flag never trips its own check.
+    const inlineRe = new RegExp(`(^|\\s)${spec.flag}\\s`);
+    if (inlineRe.test(commandString)) {
+      fail(`use either ${spec.flag} or ${fileFlag}, not both`);
     }
-    const filePath = matches[0][2];
+    let filePath = matches[0][2];
+    // Models habitually quote flag values (every SKILL.md example quotes
+    // --params). \S+ captures those quotes, so strip one matching
+    // surrounding pair before validating — otherwise a valid quoted path
+    // fails the absolute-path check with a misleading error.
+    if (
+      filePath.length >= 2 &&
+      ((filePath.startsWith("'") && filePath.endsWith("'")) ||
+        (filePath.startsWith('"') && filePath.endsWith('"')))
+    ) {
+      filePath = filePath.slice(1, -1);
+    }
     if (!filePath.startsWith('/')) {
       fail(`${fileFlag} requires an absolute path (got "${filePath}")`);
     }

--- a/infra/agent-image/skills/psd-workspace/common.test.js
+++ b/infra/agent-image/skills/psd-workspace/common.test.js
@@ -1,0 +1,169 @@
+/**
+ * Unit tests for psd-workspace command parsing + payload-file transport
+ * (#1138 follow-up: splitCommand has no escape syntax, so arbitrary text
+ * must travel via --json-file / --body-file).
+ *
+ * Run: bun test common.test.js (from this directory, after bun install).
+ */
+
+'use strict';
+
+const { describe, expect, test } = require('bun:test');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const {
+  splitCommand,
+  resolvePayloadFiles,
+  extractJsonArg,
+  injectMarkers,
+  enforcePhase1Gates,
+} = require('./common');
+
+function tmpFile(content, ext = '.json') {
+  const p = path.join(
+    fs.mkdtempSync(path.join(os.tmpdir(), 'psdws-test-')),
+    `payload${ext}`
+  );
+  fs.writeFileSync(p, content);
+  return p;
+}
+
+describe('splitCommand (documenting the limitation payload files solve)', () => {
+  test('quoted segments hold multi-word values', () => {
+    expect(splitCommand("gmail list --query 'is:unread from:bob'")).toEqual([
+      'gmail', 'list', '--query', 'is:unread from:bob',
+    ]);
+  });
+
+  test('an apostrophe inside single-quoted text breaks tokenization', () => {
+    // "it's" terminates the quote at the apostrophe — this is WHY payload
+    // files exist; if this ever starts passing, splitCommand grew escaping
+    // and the payload-file docs should be revisited.
+    const tokens = splitCommand("docs write --json '{\"text\":\"it's fine\"}'");
+    expect(tokens).not.toContain('{"text":"it\'s fine"}');
+  });
+});
+
+describe('resolvePayloadFiles', () => {
+  test('returns null when no file flags present', () => {
+    expect(resolvePayloadFiles('gmail users messages list --params x')).toBeNull();
+    expect(resolvePayloadFiles('')).toBeNull();
+  });
+
+  test('--json-file: minifies, inlines into synthetic, placeholder into exec', () => {
+    const payload = {
+      requests: [{ insertText: { text: "Multi word — with 'quotes' and \"both\" kinds.\nAnd a newline." } }],
+    };
+    const p = tmpFile(JSON.stringify(payload, null, 2));
+    const resolved = resolvePayloadFiles(
+      `docs documents batchUpdate --params '{"documentId":"d1"}' --json-file ${p}`
+    );
+    expect(resolved).not.toBeNull();
+    const minified = JSON.stringify(payload);
+    expect(resolved.payloads['@@PSD_PAYLOAD_JSON@@']).toBe(minified);
+    expect(resolved.syntheticCommand).toContain(`--json ${minified}`);
+    expect(resolved.execCommand).toContain('--json @@PSD_PAYLOAD_JSON@@');
+    expect(resolved.execCommand).not.toContain('--json-file');
+    // The exec command stays tokenizable: the placeholder is one token.
+    expect(splitCommand(resolved.execCommand)).toContain('@@PSD_PAYLOAD_JSON@@');
+  });
+
+  test('--body-file: raw text (not JSON-parsed) rides as body payload', () => {
+    const body = "Hi Bill,\n\nHere's the plan — \"phase one\" starts Monday.\n";
+    const p = tmpFile(body, '.txt');
+    const resolved = resolvePayloadFiles(
+      `gmail +draft --to bill@psd401.net --subject Update --body-file ${p}`
+    );
+    expect(resolved.payloads['@@PSD_PAYLOAD_BODY@@']).toBe(body);
+    expect(resolved.execCommand).toContain('--body @@PSD_PAYLOAD_BODY@@');
+    expect(resolved.syntheticCommand).toContain(body);
+  });
+
+  test('gates see the real payload through the synthetic command', () => {
+    // A share-to-caller handoff via --json-file: the gate's payload
+    // validation must be able to read type/role/emailAddress.
+    const p = tmpFile(JSON.stringify({
+      fileId: 'f1', type: 'user', role: 'reader', emailAddress: 'hagelk@psd401.net',
+    }));
+    const resolved = resolvePayloadFiles(
+      `drive permissions create --json-file ${p}`
+    );
+    const gate = enforcePhase1Gates(resolved.syntheticCommand, {
+      scope: 'agent_account',
+      ownerEmail: 'hagelk@psd401.net',
+    });
+    expect(gate.allowed).toBe(true);
+    // Same command with a third-party recipient must stay blocked.
+    const p2 = tmpFile(JSON.stringify({
+      fileId: 'f1', type: 'user', role: 'reader', emailAddress: 'other@psd401.net',
+    }));
+    const resolved2 = resolvePayloadFiles(`drive permissions create --json-file ${p2}`);
+    const gate2 = enforcePhase1Gates(resolved2.syntheticCommand, {
+      scope: 'agent_account',
+      ownerEmail: 'hagelk@psd401.net',
+    });
+    expect(gate2.allowed).toBe(false);
+  });
+
+  test('markers land in file-based calendar payloads via the synthetic path', () => {
+    const p = tmpFile(JSON.stringify({ summary: 'Standup', description: 'Daily sync' }));
+    const resolved = resolvePayloadFiles(
+      `calendar events insert --params '{"calendarId":"primary"}' --json-file ${p}`
+    );
+    const marked = injectMarkers(resolved.syntheticCommand);
+    const mutated = extractJsonArg(marked);
+    expect(mutated).toContain('Created by your agent');
+    expect(JSON.parse(mutated).description).toContain('Daily sync');
+  });
+});
+
+describe('extractJsonArg', () => {
+  test('returns the raw --json object', () => {
+    expect(extractJsonArg("x --json '{\"a\":1}' --other y")).toBe('{"a":1}');
+    expect(extractJsonArg('x --json {"a":{"b":2}}')).toBe('{"a":{"b":2}}');
+  });
+
+  test('returns null when absent or malformed', () => {
+    expect(extractJsonArg('gmail list')).toBeNull();
+    expect(extractJsonArg('x --json {unclosed')).toBeNull();
+    expect(extractJsonArg(null)).toBeNull();
+  });
+});
+
+describe('resolvePayloadFiles error paths (fail() exits — run via subprocess)', () => {
+  const runResolve = (command) =>
+    spawnSync(
+      process.execPath,
+      ['-e', `require('${__dirname}/common.js').resolvePayloadFiles(process.argv[1])`, command],
+      { encoding: 'utf8' }
+    );
+
+  test('relative path is rejected', () => {
+    const r = runResolve('docs write --json-file relative/path.json');
+    expect(r.status).toBe(1);
+    expect(r.stderr).toContain('absolute path');
+  });
+
+  test('unreadable file is rejected', () => {
+    const r = runResolve('docs write --json-file /nonexistent/nope.json');
+    expect(r.status).toBe(1);
+    expect(r.stderr).toContain('cannot read');
+  });
+
+  test('invalid JSON in --json-file is rejected', () => {
+    const p = tmpFile('not json at all');
+    const r = runResolve(`docs write --json-file ${p}`);
+    expect(r.status).toBe(1);
+    expect(r.stderr).toContain('not valid JSON');
+  });
+
+  test('--json and --json-file together are rejected', () => {
+    const p = tmpFile('{}');
+    const r = runResolve(`docs write --json '{}' --json-file ${p}`);
+    expect(r.status).toBe(1);
+    expect(r.stderr).toContain('not both');
+  });
+});

--- a/infra/agent-image/skills/psd-workspace/common.test.js
+++ b/infra/agent-image/skills/psd-workspace/common.test.js
@@ -166,4 +166,23 @@ describe('resolvePayloadFiles error paths (fail() exits — run via subprocess)'
     expect(r.status).toBe(1);
     expect(r.stderr).toContain('not both');
   });
+
+  test('--body and --body-file together are rejected (review finding 1)', () => {
+    const p = tmpFile('hello', '.txt');
+    const r = runResolve(`gmail +draft --body 'stale text' --body-file ${p}`);
+    expect(r.status).toBe(1);
+    expect(r.stderr).toContain('not both');
+  });
+});
+
+describe('quoted file paths (review finding 2)', () => {
+  test('a quoted absolute path resolves like an unquoted one', () => {
+    const payload = { a: 1 };
+    const p = tmpFile(JSON.stringify(payload));
+    for (const quoted of [`'${p}'`, `"${p}"`]) {
+      const resolved = resolvePayloadFiles(`docs write --json-file ${quoted}`);
+      expect(resolved).not.toBeNull();
+      expect(resolved.payloads['@@PSD_PAYLOAD_JSON@@']).toBe(JSON.stringify(payload));
+    }
+  });
 });

--- a/infra/agent-image/skills/psd-workspace/run.js
+++ b/infra/agent-image/skills/psd-workspace/run.js
@@ -60,6 +60,8 @@ const {
   execGws,
   enforcePhase1Gates,
   injectMarkers,
+  resolvePayloadFiles,
+  extractJsonArg,
 } = require('./common');
 
 async function main() {
@@ -86,11 +88,23 @@ async function main() {
   const ownerEmail = args.user;
   let command = args.command;
 
+  // 0. Payload files (#1138 follow-up) — `--json-file` / `--body-file`
+  // deliver arbitrary text (quotes, apostrophes, newlines) that cannot ride
+  // inside the --command string (splitCommand has no escape syntax). The
+  // gates and marker injection below run against `syntheticCommand`, which
+  // has the REAL file content inlined, so neither protection is blinded by
+  // the indirection; execution uses the placeholder form + payload map so
+  // tokenization never touches the content.
+  const resolvedPayloads = resolvePayloadFiles(command);
+  let guardedCommand = resolvedPayloads
+    ? resolvedPayloads.syntheticCommand
+    : command;
+
   // 1. Phase 1 hard gates — refused at the skill layer regardless of scope
   // or how the model phrases the request. The scope+ownerEmail context lets
   // the gate apply a narrow exception for share-to-caller handoffs (the
   // agent shares files it owns back to the conversation owner, read-only).
-  const gateCheck = enforcePhase1Gates(command, { scope, ownerEmail });
+  const gateCheck = enforcePhase1Gates(guardedCommand, { scope, ownerEmail });
   if (!gateCheck.allowed) {
     emit({
       status: 'phase1-forbidden',
@@ -104,8 +118,22 @@ async function main() {
   }
 
   // 2. Marker injection — calendar/drafts/tasks/drive get auto-markers so
-  // every artifact the agent touches is auditable as agent-touched.
-  command = injectMarkers(command);
+  // every artifact the agent touches is auditable as agent-touched. Runs on
+  // the synthetic (payload-inlined) form so file-based JSON payloads get
+  // markers too; the mutated JSON is pulled back into the payload map below.
+  guardedCommand = injectMarkers(guardedCommand);
+  if (resolvedPayloads) {
+    const jsonPlaceholder = '@@PSD_PAYLOAD_JSON@@';
+    if (resolvedPayloads.payloads[jsonPlaceholder]) {
+      const mutatedJson = extractJsonArg(guardedCommand);
+      if (mutatedJson) {
+        resolvedPayloads.payloads[jsonPlaceholder] = mutatedJson;
+      }
+    }
+    command = resolvedPayloads.execCommand;
+  } else {
+    command = guardedCommand;
+  }
 
   // 3. Per-user refresh-token record for the requested slot
   const tokenRecord = await getUserWorkspaceToken(ownerEmail, scope);
@@ -180,8 +208,13 @@ async function main() {
     fail('Token refresh returned no access_token');
   }
 
-  // Exec gws with the (possibly marker-injected) command
-  const code = execGws(command, access.access_token);
+  // Exec gws with the (possibly marker-injected) command. Payload-file
+  // contents are substituted as single argv tokens after tokenization.
+  const code = execGws(
+    command,
+    access.access_token,
+    resolvedPayloads ? resolvedPayloads.payloads : undefined
+  );
   process.exit(code);
 }
 

--- a/infra/lib/agent-platform-stack.ts
+++ b/infra/lib/agent-platform-stack.ts
@@ -1113,6 +1113,24 @@ export class AgentPlatformStack extends cdk.Stack {
       iam.ManagedPolicy.fromAwsManagedPolicyName('service-role/AWSLambdaVPCAccessExecutionRole'),
     );
 
+    // Attachment delivery (#1138 F1): the router writes Chat-upload bytes to
+    // s3://<workspace-bucket>/<workspacePrefix>/attachments/. This CANNOT rely
+    // on the ServiceRoleFactory s3Buckets grant above — that grant conditions
+    // object actions on `aws:ResourceTag/Environment|ManagedBy`, and S3 object
+    // operations provide NO resource tags at authorization time (the bucket's
+    // tags do not satisfy the key, despite the factory comment claiming they
+    // do), so every s3:PutObject through it is denied. Observed live:
+    // AccessDenied on .../attachments/...pdf, 2026-07-07 (#1138 follow-up).
+    // Grant the write narrowly (attachments keys only) without the inert
+    // condition. AbortMultipartUpload lets lib-storage clean up a failed
+    // multipart upload instead of leaving orphaned parts.
+    this.routerLambdaRole.addToPolicy(new iam.PolicyStatement({
+      sid: 'WorkspaceAttachmentWrite',
+      effect: iam.Effect.ALLOW,
+      actions: ['s3:PutObject', 's3:AbortMultipartUpload'],
+      resources: [`${this.workspaceBucket.bucketArn}/*/attachments/*`],
+    }));
+
     // Grant Secrets Manager read access directly (not through ServiceRoleFactory).
     // CDK cross-stack refs and new Secret() produce tokens that don't start with
     // "arn:" at synth time, causing ServiceRoleFactory to double-wrap the ARN.


### PR DESCRIPTION
## Summary
Post-deploy testing of #1141 showed both incident scenarios still failing. Three root causes, all fixed here (no web-app surface — infra + agent image only):

1. **Attachment byte-fetch died at S3** — `AccessDenied s3:PutObject` on `.../attachments/...pdf` (router log 03:34Z). The `ServiceRoleFactory` s3Buckets grant is **inert for S3 object actions**: its `aws:ResourceTag/*` conditions never match (S3 objects expose no resource tags at authz time; bucket tags don't satisfy the key, contrary to the factory's comment). Added a narrow unconditioned `WorkspaceAttachmentWrite` statement (PutObject + AbortMultipartUpload on `<bucket>/*/attachments/*`). Factory-wide audit tracked in reopened #1138.
2. **Agent couldn't write document content at all** — `splitCommand` has no escape syntax, so any apostrophe/mixed-quote/newline text can't ride in `--command`. New `--json-file` / `--body-file` payload transport: file content becomes exactly one argv token; Phase 1 gates + marker injection run against a synthetic command with the real content inlined (verified: forbidden ops still exit 13, share-to-caller validation still reads file payloads, markers land in file-based JSON). 13 new bun tests.
3. **`tool_search_code timed out` on every slow call** — code-mode VM default timeout is 10s; the agent's Plaud digest (`yieldMs: 60000`) and 90s poll were killed before they could suspend, reading as "sandbox unresponsive." Set `tools.codeMode.timeoutMs: 60000` (documented max, verified against OpenClaw `docs/reference/code-mode.md`) + psd-rules Rule 14 guidance (yieldMs ≤ 10s → suspend into `wait`; poll ≤ 30s; assume side effects on timeout).

## Verification
- Skill tests 13/13 (`bun test`), agent-image Python 100/100, `cdk synth` clean — `WorkspaceAttachmentWrite` renders on the router role.
- `run.js` functionally exercised: forbidden op via `--json-file` → exit 13; relative/unreadable/invalid-JSON/duplicate-flag errors all exit 1 with clear messages; permitted op reaches the credential stage.
- `openclaw.json` valid; the image build's `openclaw config validate` gate re-verifies the new key at build time.

## Deploy
1. Merge, rebuild agent image (openclaw.json / skills / Dockerfile comment), redeploy `AgentPlatformStack` (router IAM) via the canonical command.
2. Runtime acceptance: PDF upload → agent reads it; Plaud→Docs→POAD completes with doc content written.

Part of #1138 (reopened)