### PR TITLE
fix(agent): #1138 round 3 — narration segment separators, chat --text-file, native-Docs guidance

### DIFF
--- a/infra/agent-image/harness_adapter.py
+++ b/infra/agent-image/harness_adapter.py
@@ -510,6 +510,11 @@ class OpenClawAdapter(HarnessAdapter):
                 # final `event:chat` state=final arrives with an empty message
                 # and is now just a completion signal).
                 agent_assistant_accum: str = ""
+                # True when tool activity arrived after accumulated assistant
+                # text — the next assistant delta starts a NEW narration
+                # segment and gets a blank-line separator (issue #1138 F4;
+                # the run-on "…in Plaud.Good, done…" came from this path).
+                assistant_boundary_pending: bool = False
                 # Allow recv() to sit idle for up to 60s between events
                 # without raising — long tool calls (web_fetch, model
                 # inference on a big prompt) produce gaps with no stream
@@ -606,14 +611,29 @@ class OpenClawAdapter(HarnessAdapter):
                             )
                             cumulative = self._extract_text(data.get("message"))
                             if isinstance(increment, str) and increment:
-                                agent_assistant_accum = (
-                                    increment
-                                    if replace
-                                    else agent_assistant_accum + increment
+                                agent_assistant_accum = self._accumulate_assistant(
+                                    agent_assistant_accum,
+                                    increment,
+                                    replace,
+                                    assistant_boundary_pending,
                                 )
+                                assistant_boundary_pending = False
                             elif isinstance(cumulative, str) and cumulative:
                                 agent_assistant_accum = cumulative
+                                assistant_boundary_pending = False
+                        elif stream in ("item", "command_output"):
+                            # Newer OpenClaw builds report tool activity as
+                            # `item`/`command_output` streams. Tool activity
+                            # after accumulated text means the next assistant
+                            # delta starts a NEW narration segment — mark the
+                            # boundary so segments don't run together
+                            # ("...in Plaud.Good, done..."), issue #1138 F4.
+                            if agent_assistant_accum:
+                                assistant_boundary_pending = True
                         elif stream == "tool_call" and isinstance(data, dict):
+                            # Same boundary rule for protocol-v3 tool events.
+                            if agent_assistant_accum:
+                                assistant_boundary_pending = True
                             tool_id = (
                                 data.get("id")
                                 or data.get("toolCallId")
@@ -626,6 +646,8 @@ class OpenClawAdapter(HarnessAdapter):
                                 "started_at": time.time(),
                             }
                         elif stream == "tool_result" and isinstance(data, dict):
+                            if agent_assistant_accum:
+                                assistant_boundary_pending = True
                             tool_id = (
                                 data.get("id")
                                 or data.get("toolCallId")
@@ -934,6 +956,29 @@ class OpenClawAdapter(HarnessAdapter):
             failed=True,
             error_class="EmptyAgentResponse",
         )
+
+    @staticmethod
+    def _accumulate_assistant(
+        accum: str,
+        increment: str,
+        replace: bool,
+        boundary_pending: bool,
+    ) -> str:
+        """Append a streamed assistant increment to the turn accumulator.
+
+        `replace` resets the buffer (protocol v4 replace-mode delta).
+        `boundary_pending` means tool activity separated this increment from
+        the previously accumulated text — i.e. the model started a NEW
+        narration segment — so join with a blank line instead of butting the
+        segments together (issue #1138 F4: "…in Plaud.Good, done…").
+        Increments within one segment must never get separators; the caller
+        only sets `boundary_pending` on tool events.
+        """
+        if replace:
+            return increment
+        if boundary_pending and accum and increment:
+            return accum + "\n\n" + increment
+        return accum + increment
 
     @staticmethod
     def _extract_text(content) -> str:

--- a/infra/agent-image/skills/psd-workspace/SKILL.md
+++ b/infra/agent-image/skills/psd-workspace/SKILL.md
@@ -118,9 +118,15 @@ node /opt/psd-skills/psd-workspace/run.js \
 node /opt/psd-skills/psd-workspace/run.js \
   --user hagelk@psd401.net \
   --command "gmail +draft --to bill@psd401.net --subject 'Follow up' --body-file /tmp/draft-body.txt"
+
+# Chat message text (+send) uses --text-file (replaces --text)
+node /opt/psd-skills/psd-workspace/run.js \
+  --user hagelk@psd401.net --scope agent \
+  --command "chat +send --space spaces/XXXX --text-file /tmp/chatmsg.txt"
 ```
 
-Rules: the path must be absolute; use `--json-file` OR `--json`, never both;
+Rules: the path must be absolute; use the file form OR the inline flag, never
+both (`--json`/`--json-file`, `--body`/`--body-file`, `--text`/`--text-file`);
 one of each flag per command. The file content is handed to gws as exactly one
 argv token — quoting rules never apply to it. Phase 1 gates and marker
 injection still see the real payload (they run against the resolved content),
@@ -129,6 +135,28 @@ refused, and file-based payloads still get audit markers.
 
 Use inline `--json` only for short, quote-free payloads you compose yourself
 (IDs, dates, enum values). Anything containing prose goes through a file.
+
+## Writing Google Docs: NATIVE formatting, never markdown
+
+Google Docs does not render markdown — `# Heading`, `**bold**`, and `- bullet`
+pasted as text show up literally and read as broken. When writing doc content
+via `docs documents batchUpdate`:
+
+- Insert plain text with `insertText` (no markdown syntax in the text).
+- Make headings with `updateParagraphStyle` +
+  `paragraphStyle.namedStyleType: "HEADING_1"` (…`HEADING_6`) over the
+  heading's range.
+- Make bullet/numbered lists with `createParagraphBullets`
+  (`bulletPreset: "BULLET_DISC_CIRCLE_SQUARE"` or
+  `"NUMBERED_DECIMAL_ALPHA_ROMAN"`) over the paragraphs' range.
+- Bold/italic with `updateTextStyle` (`textStyle.bold: true`, `italic`) +
+  `fields`.
+
+Batch ALL requests for a section into ONE `batchUpdate` call (one `--json-file`
+payload with a `requests` array) — one call per doc, not one call per
+formatting operation. Compose the payload in a file and pass it with
+`--json-file` (see above); index math is easiest when you insert text first
+and style ranges immediately after, back-to-front.
 
 ## Phase 1 boundaries (hard gates — refused at the skill layer)
 

--- a/infra/agent-image/skills/psd-workspace/common.js
+++ b/infra/agent-image/skills/psd-workspace/common.js
@@ -230,6 +230,10 @@ function splitCommand(cmd) {
 const PAYLOAD_PLACEHOLDERS = {
   '--json-file': { flag: '--json', placeholder: '@@PSD_PAYLOAD_JSON@@', kind: 'json' },
   '--body-file': { flag: '--body', placeholder: '@@PSD_PAYLOAD_BODY@@', kind: 'text' },
+  // chat +send message text. Added after the live 2026-07-07 run: the agent
+  // GUESSED `--text-file` while fumbling +send syntax against the clock —
+  // it's the natural generalization of the two flags above, so make it real.
+  '--text-file': { flag: '--text', placeholder: '@@PSD_PAYLOAD_TEXT@@', kind: 'text' },
 };
 
 /**

--- a/infra/agent-image/skills/psd-workspace/common.test.js
+++ b/infra/agent-image/skills/psd-workspace/common.test.js
@@ -175,6 +175,31 @@ describe('resolvePayloadFiles error paths (fail() exits — run via subprocess)'
   });
 });
 
+describe('--text-file (chat +send message text)', () => {
+  test('resolves like --body-file with its own placeholder', () => {
+    const msg = "Team — two docs from the 7/1 meeting:\n1) Summary\n2) Todos ('74 items')";
+    const p = tmpFile(msg, '.txt');
+    const resolved = resolvePayloadFiles(
+      `chat +send --space spaces/XXXX --text-file ${p}`
+    );
+    expect(resolved.payloads['@@PSD_PAYLOAD_TEXT@@']).toBe(msg);
+    expect(resolved.execCommand).toContain('--text @@PSD_PAYLOAD_TEXT@@');
+    expect(resolved.execCommand).not.toContain('--text-file');
+  });
+
+  test('--text and --text-file together are rejected', () => {
+    const p = tmpFile('hi', '.txt');
+    const r = spawnSync(
+      process.execPath,
+      ['-e', `require('${__dirname}/common.js').resolvePayloadFiles(process.argv[1])`,
+        `chat +send --text 'inline' --text-file ${p}`],
+      { encoding: 'utf8' }
+    );
+    expect(r.status).toBe(1);
+    expect(r.stderr).toContain('not both');
+  });
+});
+
 describe('quoted file paths (review finding 2)', () => {
   test('a quoted absolute path resolves like an unquoted one', () => {
     const payload = { a: 1 };

--- a/infra/agent-image/test_harness_adapter.py
+++ b/infra/agent-image/test_harness_adapter.py
@@ -98,3 +98,30 @@ class TestFrameFailedPartial(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestAccumulateAssistant(unittest.TestCase):
+    """Boundary-aware accumulation of streamed assistant segments (#1138 F4)."""
+
+    @staticmethod
+    def acc(accum, increment, replace, boundary_pending):
+        return OpenClawAdapter._accumulate_assistant(
+            accum, increment, replace, boundary_pending
+        )
+
+    def test_increments_within_a_segment_join_without_separator(self):
+        a = self.acc("", "Now let's find", False, False)
+        a = self.acc(a, " recordings.", False, False)
+        self.assertEqual(a, "Now let's find recordings.")
+
+    def test_boundary_after_tool_activity_inserts_blank_line(self):
+        a = self.acc("Now let's find recordings from 7/1 in Plaud.", "Good, done.", False, True)
+        self.assertEqual(
+            a, "Now let's find recordings from 7/1 in Plaud.\n\nGood, done."
+        )
+
+    def test_replace_resets_buffer_regardless_of_boundary(self):
+        self.assertEqual(self.acc("old text", "fresh", True, True), "fresh")
+
+    def test_boundary_with_empty_accum_adds_no_leading_separator(self):
+        self.assertEqual(self.acc("", "First words", False, True), "First words")


### PR DESCRIPTION
## Summary
Fixes from the 2026-07-07 13:19Z Plaud run (post-#1145): the task completed transcript→docs→share and died at the 14-min deadline while fumbling `chat +send` flag syntax. Agent-image only.

1. **Narration run-ons on the accumulator path** — #1141's blank-line join covered `_extract_text` but the deadline-partial text comes from `agent_assistant_accum`, which butted segments together across tool calls. New `_accumulate_assistant()` + boundary flag set on tool activity (`tool_call`/`tool_result`/`item`/`command_output` streams); within-segment deltas still join bare. +4 tests.
2. **`--text-file` for chat +send** — the agent guessed this flag live (generalizing `--json-file`/`--body-file`) and burned its last seconds on the gws error. Made it real via the existing placeholder table; conflict check inherited. +2 tests.
3. **Native-Docs guidance in SKILL.md** — the run pasted markdown into Google Docs (renders literally). Documents Docs API structured requests (`namedStyleType` headings, `createParagraphBullets`, `updateTextStyle`) and one-batchUpdate-per-section via `--json-file`.

**Not addressed (product decision, tracked in #1138):** the 14-minute turn ceiling (Lambda 15-min hard max upstream).

## Verification
- Python unittest 104/104 (harness 14); skill bun tests 17/17
- No router/CDK changes — image rebuild only to ship

Part of #1138