### PR TITLE
feat(agent): async job-runner — deadline-hit turns finish in a background Fargate task (#1138)

### DIFF
--- a/infra/agent-image/agentcore_wrapper.py
+++ b/infra/agent-image/agentcore_wrapper.py
@@ -547,6 +547,14 @@ def main():
         display_name = payload.get("user_display_name", "")
         workspace_prefix = payload.get("workspace_prefix", "")
         model_override = payload.get("model")
+        # Optional turn-deadline override (async-job runner, #1138). Only the
+        # job runner sends this; interactive router turns omit it and get the
+        # 840s default. Non-int garbage degrades to None (default behavior).
+        raw_deadline = payload.get("deadline_s")
+        try:
+            deadline_s = int(raw_deadline) if raw_deadline is not None else None
+        except (TypeError, ValueError):
+            deadline_s = None
         # Cross-user invocation fields
         invoked_by_email = payload.get("invoked_by_email", "")
         invoked_by_display_name = payload.get("invoked_by_display_name", "")
@@ -688,7 +696,8 @@ def main():
         # baseline must be fully read before process_task is scheduled.
         usage_baseline = await loop.run_in_executor(None, read_proxy_usage)
         process_task = loop.run_in_executor(
-            None, adapter.process, framed, session_id, model_override
+            None, adapter.process, framed, session_id, model_override,
+            deadline_s,
         )
 
         # Heartbeat every 30s while adapter.process runs in the executor.

--- a/infra/agent-image/harness_adapter.py
+++ b/infra/agent-image/harness_adapter.py
@@ -109,10 +109,12 @@ class HarnessAdapter(abc.ABC):
         message: str,
         session_id: str,
         model_override: Optional[str] = None,
+        deadline_s: Optional[int] = None,
     ) -> Union[str, TurnResult]:
         """Send a message to the harness and return either a plain string
         (legacy contract) or a TurnResult (preferred). Wrapper accepts
-        both."""
+        both. `deadline_s` (async-job path, #1138) overrides the turn
+        deadline; None keeps the interactive default."""
 
     @abc.abstractmethod
     def configure(self, config: dict) -> None:
@@ -235,6 +237,7 @@ class OpenClawAdapter(HarnessAdapter):
         message: str,
         session_id: str,
         model_override: Optional[str] = None,
+        deadline_s: Optional[int] = None,
     ) -> TurnResult:
         """Send a message to OpenClaw via WebSocket and return a TurnResult.
 
@@ -488,15 +491,7 @@ class OpenClawAdapter(HarnessAdapter):
                 # 14 min — 30s under the cron Lambda's 14:30 AbortSignal so
                 # the harness gets a chance to return whatever it has
                 # accumulated before the client kills the connection.
-                default_deadline_s = 840
-                try:
-                    deadline_s = int(os.environ.get(
-                        "OPENCLAW_CHAT_DEADLINE_S",
-                        str(default_deadline_s),
-                    ))
-                except ValueError:
-                    deadline_s = default_deadline_s
-                deadline_s = max(60, min(840, deadline_s))
+                deadline_s = self._resolve_deadline_s(deadline_s)
                 deadline = time.time() + deadline_s
                 got_final = False
                 event_counts: dict = {}
@@ -956,6 +951,32 @@ class OpenClawAdapter(HarnessAdapter):
             failed=True,
             error_class="EmptyAgentResponse",
         )
+
+    @staticmethod
+    def _resolve_deadline_s(override) -> int:
+        """Resolve the turn deadline in seconds.
+
+        `override` is the payload-supplied deadline from the async-job runner
+        (#1138): the promoted job leg holds the SSE stream for up to 2 hours,
+        so the override clamps to [60, 7200] (ceiling approved 2026-07-07).
+        Interactive turns send no override and keep the env-var/default path
+        clamped to [60, 840] — bounded by the router Lambda's 15-min ceiling.
+        Garbage values degrade to the 840s default, never raise.
+        """
+        default_deadline_s = 840
+        if override is not None:
+            try:
+                return max(60, min(7200, int(override)))
+            except (TypeError, ValueError):
+                return default_deadline_s
+        try:
+            value = int(os.environ.get(
+                "OPENCLAW_CHAT_DEADLINE_S",
+                str(default_deadline_s),
+            ))
+        except ValueError:
+            value = default_deadline_s
+        return max(60, min(840, value))
 
     @staticmethod
     def _accumulate_assistant(

--- a/infra/agent-image/test_harness_adapter.py
+++ b/infra/agent-image/test_harness_adapter.py
@@ -125,3 +125,29 @@ class TestAccumulateAssistant(unittest.TestCase):
 
     def test_boundary_with_empty_accum_adds_no_leading_separator(self):
         self.assertEqual(self.acc("", "First words", False, True), "First words")
+
+
+class TestResolveDeadline(unittest.TestCase):
+    """Turn-deadline resolution incl. the async-job override (#1138)."""
+
+    resolve = staticmethod(OpenClawAdapter._resolve_deadline_s)
+
+    def test_no_override_defaults_to_840(self):
+        self.assertEqual(self.resolve(None), 840)
+
+    def test_job_override_passes_within_ceiling(self):
+        self.assertEqual(self.resolve(7200), 7200)
+        self.assertEqual(self.resolve(3600), 3600)
+
+    def test_job_override_clamps_to_bounds(self):
+        self.assertEqual(self.resolve(50000), 7200)
+        self.assertEqual(self.resolve(5), 60)
+
+    def test_garbage_override_degrades_to_default(self):
+        self.assertEqual(self.resolve("not-a-number"), 840)
+
+    def test_env_path_still_clamped_to_840(self):
+        import os
+        from unittest import mock
+        with mock.patch.dict(os.environ, {"OPENCLAW_CHAT_DEADLINE_S": "7200"}):
+            self.assertEqual(self.resolve(None), 840)

--- a/infra/lambdas/agent-router/.dockerignore
+++ b/infra/lambdas/agent-router/.dockerignore
@@ -1,0 +1,5 @@
+# Keep the job-runner image build context small and machine-independent.
+node_modules/
+dist/
+*.test.ts
+cdk.out/

--- a/infra/lambdas/agent-router/Dockerfile
+++ b/infra/lambdas/agent-router/Dockerfile
@@ -1,0 +1,22 @@
+# Async job-runner image (issue #1138) — the SAME agent-router package
+# running as an on-demand ECS Fargate task instead of a Lambda. Built by CDK
+# (ContainerImage.fromAsset in agent-platform-stack.ts); the Lambda bundling
+# path is untouched and continues to run index.handler.
+#
+# ARM64 to match the platform's Graviton preference; node:20-slim mirrors the
+# Lambda's NODEJS_20_X runtime so both entrypoints run the same Node major.
+
+FROM public.ecr.aws/docker/library/node:20-slim AS build
+WORKDIR /app
+COPY package.json tsconfig.json ./
+COPY *.ts ./
+RUN npm install --no-audit --no-fund && npx tsc
+
+FROM public.ecr.aws/docker/library/node:20-slim
+WORKDIR /app
+ENV NODE_ENV=production
+COPY --from=build /app/dist ./dist
+COPY package.json ./
+RUN npm install --omit=dev --no-audit --no-fund && npm cache clean --force
+
+CMD ["node", "dist/job-main.js"]

--- a/infra/lambdas/agent-router/index.ts
+++ b/infra/lambdas/agent-router/index.ts
@@ -40,6 +40,7 @@ import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
 import {
   DeleteCommand,
   DynamoDBDocumentClient,
+  GetCommand,
   PutCommand,
   QueryCommand,
   UpdateCommand,
@@ -54,6 +55,7 @@ import { SignatureV4 } from '@smithy/signature-v4';
 import { Sha256 } from '@aws-crypto/sha256-js';
 import { defaultProvider } from '@aws-sdk/credential-provider-node';
 import { HttpRequest } from '@smithy/protocol-http';
+import { ECSClient, RunTaskCommand } from '@aws-sdk/client-ecs';
 import { S3Client } from '@aws-sdk/client-s3';
 import { Upload } from '@aws-sdk/lib-storage';
 import { Context as LambdaContext, SQSBatchResponse, SQSEvent, SQSRecord } from 'aws-lambda';
@@ -70,6 +72,10 @@ import {
   type ChatAnnotation,
   type ChatAttachment,
 } from './attachments';
+import {
+  buildJobPayload,
+  shouldPromoteToJob,
+} from './job-promotion';
 
 // ---------------------------------------------------------------------------
 // Structured logging (Lambda-compatible, no console.* per CLAUDE.md exception)
@@ -116,6 +122,7 @@ const dynamoClient = DynamoDBDocumentClient.from(new DynamoDBClient({}));
 const secretsClient = new SecretsManagerClient({});
 const ssmClient = new SSMClient({});
 const s3Client = new S3Client({});
+const ecsClient = new ECSClient({});
 
 // SigV4 signer — promoted to module scope to avoid re-creating the credential
 // provider chain on every invocation. In a Lambda context credentials are stable
@@ -142,7 +149,13 @@ const agentCoreSigner = new SignatureV4({
 // timeout, and the Lambda's own 15-min ceiling is the only upper bound.
 // `connectTimeout` stays at 10s because establishing the TLS handshake
 // should always be fast; if it isn't, that's a real networking problem.
-const AGENTCORE_TIMEOUT_MS = 14 * 60 * 1000;
+//
+// AGENTCORE_TIMEOUT_MS_OVERRIDE (issue #1138 async jobs): the job-runner
+// Fargate task reuses this module outside Lambda and must hold the SSE
+// stream for up to the 2h job deadline + margin — it sets this env var.
+// The Lambda path leaves it unset and keeps the 14-min default.
+const AGENTCORE_TIMEOUT_MS =
+  parseInt(process.env.AGENTCORE_TIMEOUT_MS_OVERRIDE || '', 10) || 14 * 60 * 1000;
 const agentCoreDispatcher = new UndiciAgent({
   headersTimeout: AGENTCORE_TIMEOUT_MS,
   bodyTimeout: AGENTCORE_TIMEOUT_MS,
@@ -483,7 +496,8 @@ const LOCK_PASS_THROUGH = '__lock-pass-through__';
  */
 async function tryAcquireSessionLock(
   sessionId: string,
-  log: ReturnType<typeof createLogger>
+  log: ReturnType<typeof createLogger>,
+  kind: 'turn' | 'job' = 'turn'
 ): Promise<string | null> {
   const tableName = process.env.SESSION_LOCKS_TABLE;
   if (!tableName) return LOCK_PASS_THROUGH; // Lock disabled (e.g. local) — pass through.
@@ -494,7 +508,11 @@ async function tryAcquireSessionLock(
     await dynamoClient.send(
       new PutCommand({
         TableName: tableName,
-        Item: { sessionId, expiresAt, lockToken, claimedAt: new Date().toISOString() },
+        // `kind: 'job'` marks a lock held by the async job-runner (#1138) —
+        // the router replies "still working on your earlier task" instantly
+        // instead of making the user wait out the 13-min lock poll. The
+        // runner renews expiresAt every ~10 min (renewSessionLock).
+        Item: { sessionId, expiresAt, lockToken, kind, claimedAt: new Date().toISOString() },
         ConditionExpression: 'attribute_not_exists(sessionId) OR expiresAt < :now',
         ExpressionAttributeValues: { ':now': Math.floor(Date.now() / 1000) },
       })
@@ -545,6 +563,81 @@ async function releaseSessionLock(
     log.warn('Session lock release failed; relying on TTL backstop', {
       error: error instanceof Error ? error.message : String(error),
     });
+  }
+}
+
+/**
+ * Renew a held session lock by extending expiresAt another 14 minutes,
+ * conditioned on still owning it (lockToken match). The async job-runner
+ * (#1138) calls this every ~10 min for up to the 2h job ceiling so the
+ * `kind='job'` marker stays live while the job runs. Returns false when the
+ * lock was lost (expired + re-acquired by someone else) — the runner keeps
+ * going regardless (losing the lock affects messaging UX, not correctness;
+ * OpenClaw serializes the session itself).
+ */
+async function renewSessionLock(
+  sessionId: string,
+  lockToken: string,
+  log: ReturnType<typeof createLogger>
+): Promise<boolean> {
+  const tableName = process.env.SESSION_LOCKS_TABLE;
+  if (!tableName || lockToken === LOCK_PASS_THROUGH) return true;
+  try {
+    await dynamoClient.send(
+      new UpdateCommand({
+        TableName: tableName,
+        Key: { sessionId },
+        UpdateExpression: 'SET expiresAt = :exp',
+        ConditionExpression: 'lockToken = :tok',
+        ExpressionAttributeValues: {
+          ':exp': Math.floor(Date.now() / 1000) + 14 * 60,
+          ':tok': lockToken,
+        },
+      })
+    );
+    return true;
+  } catch (error) {
+    const errName = (error as { name?: string } | null)?.name;
+    if (errName === 'ConditionalCheckFailedException') {
+      log.warn('Session lock renewal lost ownership — continuing without lock');
+      return false;
+    }
+    log.warn('Session lock renewal failed; will retry on next interval', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return true; // Transient DDB error — keep renewing.
+  }
+}
+
+/**
+ * True when an ACTIVE `kind='job'` lock holds this session — a background
+ * job is still running (#1138). Fail-open on errors: a DDB blip must not
+ * block normal message processing.
+ */
+async function isJobLockActive(
+  sessionId: string,
+  log: ReturnType<typeof createLogger>
+): Promise<boolean> {
+  const tableName = process.env.SESSION_LOCKS_TABLE;
+  if (!tableName) return false;
+  try {
+    const result = await dynamoClient.send(
+      new GetCommand({ TableName: tableName, Key: { sessionId } })
+    );
+    const item = result.Item as
+      | { kind?: string; expiresAt?: number }
+      | undefined;
+    return (
+      !!item &&
+      item.kind === 'job' &&
+      typeof item.expiresAt === 'number' &&
+      item.expiresAt > Math.floor(Date.now() / 1000)
+    );
+  } catch (error) {
+    log.warn('Job-lock check failed; treating as no job', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return false;
   }
 }
 
@@ -1125,6 +1218,14 @@ async function invokeAgentCore(
     /** Files the user attached in Chat (issue #1138 F1). Rendered into the
      * prompt header by the container so the agent knows a file arrived. */
     attachments?: AgentAttachment[];
+    /**
+     * Turn-deadline override in seconds (async job-runner only, #1138).
+     * The wrapper passes it to the harness, which clamps to [60, 7200].
+     * Interactive turns omit it (container default: 840s).
+     */
+    deadlineS?: number;
+    /** Pre-resolved runtime id — skips the env/SSM lookup (job-runner). */
+    runtimeIdOverride?: string;
   }
 ): Promise<{
   response: string;
@@ -1164,10 +1265,12 @@ async function invokeAgentCore(
    */
   errorSource?: 'harness' | 'router';
 }> {
-  // Resolve the AgentCore Runtime ID — check env var, then module-level cache,
-  // then SSM. Cached at module scope with TTL to avoid redundant SSM API calls
-  // on every invocation (~5–20ms + cost per call).
-  let runtimeId = process.env.AGENTCORE_RUNTIME_ID || '';
+  // Resolve the AgentCore Runtime ID — explicit override (job-runner passes
+  // the id the router already resolved), then env var, then module-level
+  // cache, then SSM. Cached at module scope with TTL to avoid redundant SSM
+  // API calls on every invocation (~5–20ms + cost per call).
+  let runtimeId =
+    userContext?.runtimeIdOverride || process.env.AGENTCORE_RUNTIME_ID || '';
   if (!runtimeId) {
     if (
       cachedRuntimeId &&
@@ -1245,6 +1348,9 @@ async function invokeAgentCore(
       ...(userContext?.attachments?.length
         ? { attachments: userContext.attachments }
         : {}),
+      // Turn-deadline override (async job-runner only, #1138): harness
+      // clamps to [60, 7200]. Interactive turns omit it (default 840s).
+      ...(userContext?.deadlineS ? { deadline_s: userContext.deadlineS } : {}),
     });
 
     const request = new HttpRequest({
@@ -1534,6 +1640,132 @@ async function fetchChatUploads(
         error: error instanceof Error ? error.message : String(error),
       });
     }
+  }
+}
+
+/**
+ * Promote a deadline-expired turn to a background ECS job (#1138).
+ *
+ * Called when a MESSAGE turn returns ChatDeadlineExpired(Partial): instead
+ * of posting the failure-framed partial, the router pre-acquires a
+ * `kind='job'` session lock, launches the job-runner Fargate task with a
+ * JOB_PAYLOAD env override, and posts a background ack. The runner resumes
+ * the SAME AgentCore session with a 2-hour deadline and posts the final
+ * answer when done.
+ *
+ * Returns true when the job launched (caller returns; nothing more to send).
+ * Returns false on ANY failure — missing config, no runtime id, lock
+ * contention, RunTask error — and the caller falls through to today's
+ * behavior (post the failure frame). Promotion must never make things
+ * worse than the status quo.
+ */
+async function promoteToJob(
+  input: {
+    sessionId: string;
+    userEmail: string;
+    displayName: string;
+    workspacePrefix: string;
+    spaceName: string;
+    threadName?: string;
+    isDM: boolean;
+    originalPrompt: string;
+  },
+  log: ReturnType<typeof createLogger>
+): Promise<boolean> {
+  const clusterArn = process.env.JOB_CLUSTER_ARN || '';
+  const taskDefArn = process.env.JOB_TASK_DEF_ARN || '';
+  const subnets = (process.env.JOB_SUBNETS || '').split(',').filter(Boolean);
+  const securityGroup = process.env.JOB_SECURITY_GROUP || '';
+  const containerName = process.env.JOB_CONTAINER_NAME || 'job-runner';
+  if (!clusterArn || !taskDefArn || subnets.length === 0 || !securityGroup) {
+    log.warn('Job promotion not configured — falling back to failure frame');
+    return false;
+  }
+
+  // The turn that just expired resolved the runtime id moments ago — reuse
+  // the env value or the warm module cache; no fresh SSM call.
+  const runtimeId = process.env.AGENTCORE_RUNTIME_ID || cachedRuntimeId || '';
+  if (!runtimeId) {
+    log.warn('Job promotion aborted — no resolved AgentCore runtime id');
+    return false;
+  }
+
+  // Pre-acquire the job lock so there is no unlocked gap between promotion
+  // and the runner's first renewal (~60s task cold start). If someone else
+  // grabbed the session in the meantime, skip promotion.
+  const jobLockToken = await tryAcquireSessionLock(input.sessionId, log, 'job');
+  if (jobLockToken === null) {
+    log.warn('Job promotion aborted — session lock contended');
+    return false;
+  }
+
+  try {
+    const payload = buildJobPayload({
+      sessionId: input.sessionId,
+      lockToken: jobLockToken,
+      runtimeId,
+      userEmail: input.userEmail,
+      displayName: input.displayName,
+      workspacePrefix: input.workspacePrefix,
+      spaceName: input.spaceName,
+      threadName: input.threadName,
+      isDM: input.isDM,
+      originalPrompt: input.originalPrompt,
+    });
+
+    const result = await ecsClient.send(
+      new RunTaskCommand({
+        cluster: clusterArn,
+        taskDefinition: taskDefArn,
+        launchType: 'FARGATE',
+        count: 1,
+        startedBy: 'agent-router-promotion',
+        networkConfiguration: {
+          awsvpcConfiguration: {
+            subnets,
+            securityGroups: [securityGroup],
+            assignPublicIp: 'DISABLED',
+          },
+        },
+        overrides: {
+          containerOverrides: [
+            {
+              name: containerName,
+              environment: [{ name: 'JOB_PAYLOAD', value: payload }],
+            },
+          ],
+        },
+      })
+    );
+    if (result.failures && result.failures.length > 0) {
+      throw new Error(
+        `RunTask failures: ${result.failures
+          .map((f) => `${f.reason ?? 'unknown'}${f.detail ? ` (${f.detail})` : ''}`)
+          .join('; ')}`
+      );
+    }
+
+    await sendGoogleChatResponse(
+      input.spaceName,
+      input.threadName,
+      '⏳ This is taking longer than one pass allows — I\'ve moved it to a ' +
+        'background job and will post the result here when it\'s done.',
+      log
+    );
+
+    log.info('Turn promoted to background job', {
+      sessionId: input.sessionId,
+      taskArn: result.tasks?.[0]?.taskArn ?? 'unknown',
+    });
+    return true;
+  } catch (error) {
+    // Roll back the job lock so the fallback path (and the user's next
+    // message) isn't blocked behind a job that never started.
+    await releaseSessionLock(input.sessionId, jobLockToken, log);
+    log.error('Job promotion failed — falling back to failure frame', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return false;
   }
 }
 
@@ -2802,6 +3034,18 @@ async function processRecord(
   // place (adds workspacePath on success); never throws.
   await fetchChatUploads(attachments, user.workspacePrefix, log);
 
+  // Background job in flight (#1138)? Reply instantly instead of making the
+  // user wait out the 13-minute lock poll below just to hear "busy".
+  if (await isJobLockActive(sessionId, log)) {
+    await sendGoogleChatResponse(
+      spaceName, threadName,
+      "I'm still working on your earlier task in the background — I'll post " +
+        'the result here when it\'s done.',
+      log,
+    );
+    return;
+  }
+
   // Serialize per-session invocations. Two messages back-to-back from the
   // same user/space share this session ID and would otherwise hit the same
   // OpenClaw turn loop concurrently — the second turn comes back empty.
@@ -2844,6 +3088,52 @@ async function processRecord(
       totalTokens,
       threshold: TOKEN_LIMIT,
     });
+  }
+
+  // Step 5b: Async-job promotion (#1138). A turn that ran out of clock —
+  // not one that broke — moves to a background job that resumes the SAME
+  // session with a 2-hour budget. On success: log first-leg telemetry and
+  // stop (the ack was posted inside promoteToJob; the runner posts the
+  // final answer). On ANY promotion failure: fall through and deliver the
+  // failure-framed partial exactly as before.
+  if (shouldPromoteToJob(agentResult.errorClass)) {
+    const promoted = await promoteToJob(
+      {
+        sessionId,
+        userEmail: senderEmail,
+        displayName: senderDisplayName,
+        workspacePrefix: user.workspacePrefix,
+        spaceName,
+        threadName,
+        isDM: chatEvent.space.type === 'DM',
+        originalPrompt: messageText,
+      },
+      log
+    );
+    if (promoted) {
+      const promotedLatencyMs = agentResult.latencyMs > 0
+        ? agentResult.latencyMs
+        : Date.now() - startTime;
+      await logTelemetry(
+        {
+          userId: senderEmail,
+          sessionId,
+          model: agentResult.model,
+          inputTokens: agentResult.inputTokens,
+          outputTokens: agentResult.outputTokens,
+          cacheReadInputTokens: agentResult.cacheReadInputTokens,
+          cacheWriteInputTokens: agentResult.cacheWriteInputTokens,
+          latencyMs: promotedLatencyMs,
+          guardrailBlocked: guardrailResult.wouldHaveBlocked,
+          spaceName,
+          topic,
+          messages: agentResult.messages,
+          toolCalls: agentResult.toolCalls,
+        },
+        log
+      );
+      return;
+    }
   }
 
   // KNOWN GAP: Output is not run through Bedrock Guardrails.
@@ -2915,3 +3205,19 @@ async function processRecord(
     });
   }
 }
+
+// ---------------------------------------------------------------------------
+// Exports for the async job-runner entrypoint (job-main.ts, issue #1138).
+// The runner is the same compiled package running as an ECS Fargate task —
+// it reuses the router's AgentCore invocation, Chat delivery, telemetry,
+// failure recording, and session-lock helpers outside Lambda.
+// ---------------------------------------------------------------------------
+export {
+  createLogger,
+  invokeAgentCore,
+  sendGoogleChatResponse,
+  logTelemetry,
+  recordFailure,
+  renewSessionLock,
+  releaseSessionLock,
+};

--- a/infra/lambdas/agent-router/job-main.ts
+++ b/infra/lambdas/agent-router/job-main.ts
@@ -1,0 +1,191 @@
+/**
+ * Async job-runner entrypoint (issue #1138, "the 14-minute wall").
+ *
+ * Runs as an on-demand ECS Fargate task, launched by the router Lambda when
+ * an interactive turn hits the 14-minute deadline (see promoteToJob in
+ * index.ts). Reuses the router's own modules — invokeAgentCore, Chat
+ * delivery, telemetry, session locks — outside Lambda, where nothing caps
+ * execution at 15 minutes. The AgentCore invocation itself may run up to
+ * the 2-hour job ceiling (harness clamps payload deadline_s to 7200); the
+ * wrapper's ~30s SSE heartbeats keep the stream alive throughout.
+ *
+ * Contract:
+ *   - JOB_PAYLOAD env var carries the job (see job-promotion.ts).
+ *   - AGENTCORE_TIMEOUT_MS_OVERRIDE is set on the task definition so the
+ *     undici dispatcher in index.ts outlives the 2h invocation.
+ *   - The router pre-acquired the kind='job' session lock; this process
+ *     renews it every 10 minutes and releases it on exit.
+ *   - ALWAYS posts something to the originating space: the final answer,
+ *     the harness's failure frame, or a runner-error message. No silent
+ *     deaths.
+ */
+
+import {
+  buildContinuationPrompt,
+  JOB_DEADLINE_S,
+  parseJobPayload,
+} from './job-promotion';
+import {
+  createLogger,
+  invokeAgentCore,
+  logTelemetry,
+  recordFailure,
+  releaseSessionLock,
+  renewSessionLock,
+  sendGoogleChatResponse,
+} from './index';
+
+const RENEW_INTERVAL_MS = 10 * 60 * 1000;
+
+async function main(): Promise<number> {
+  const log = createLogger({ service: 'agent-job-runner' });
+
+  // A broken payload means there is no Chat destination to post to —
+  // log loudly and exit nonzero (CloudWatch is the record).
+  const job = parseJobPayload(process.env.JOB_PAYLOAD);
+
+  log.info('Background job started', {
+    sessionId: job.sessionId,
+    userEmail: job.userEmail,
+    space: job.spaceName,
+    deadlineS: JOB_DEADLINE_S,
+  });
+
+  // Keep the kind='job' lock alive for the duration — the router uses it to
+  // answer mid-job user messages instantly with "still working".
+  const renewTimer = setInterval(() => {
+    void renewSessionLock(job.sessionId, job.lockToken, log);
+  }, RENEW_INTERVAL_MS);
+
+  const startTime = Date.now();
+  try {
+    const agentResult = await invokeAgentCore(
+      buildContinuationPrompt(job.promptExcerpt),
+      job.userEmail,
+      job.sessionId,
+      log,
+      {
+        displayName: job.displayName,
+        workspacePrefix: job.workspacePrefix,
+        deadlineS: JOB_DEADLINE_S,
+        runtimeIdOverride: job.runtimeId,
+      }
+    );
+
+    // Deliver exactly like the router's Step 6: truncate the raw response,
+    // then prefix in shared spaces. A failed turn's response is already the
+    // harness's failure frame — posting it satisfies "always post something".
+    const maxLength = 4096;
+    const truncationSuffix = '\n\n_(Response truncated — ask me to continue)_';
+    const prefix = job.isDM ? '' : `[${job.displayName}'s Agent] `;
+    const availableLength = maxLength - prefix.length;
+    const truncatedResponse =
+      agentResult.response.length > availableLength
+        ? agentResult.response.substring(0, availableLength - truncationSuffix.length) +
+          truncationSuffix
+        : agentResult.response;
+    await sendGoogleChatResponse(
+      job.spaceName,
+      job.threadName,
+      `${prefix}${truncatedResponse}`,
+      log
+    );
+
+    const latencyMs =
+      agentResult.latencyMs > 0 ? agentResult.latencyMs : Date.now() - startTime;
+    await logTelemetry(
+      {
+        userId: job.userEmail,
+        sessionId: job.sessionId,
+        model: agentResult.model,
+        inputTokens: agentResult.inputTokens,
+        outputTokens: agentResult.outputTokens,
+        cacheReadInputTokens: agentResult.cacheReadInputTokens,
+        cacheWriteInputTokens: agentResult.cacheWriteInputTokens,
+        latencyMs,
+        // Guardrails ran on the original message in the first leg.
+        guardrailBlocked: false,
+        spaceName: job.spaceName,
+        messages: agentResult.messages,
+        toolCalls: agentResult.toolCalls,
+      },
+      log
+    );
+
+    if (agentResult.failed) {
+      // Harness-side failures were already recorded by the container; a
+      // router-source failure (e.g. HTTP error) gets recorded here so the
+      // job leg is visible in agent_failures.
+      if (agentResult.errorSource === 'router') {
+        await recordFailure(
+          {
+            source: 'router',
+            severity: 'error',
+            userId: job.userEmail,
+            sessionId: job.sessionId,
+            model: agentResult.model,
+            errorClass: agentResult.errorClass ?? 'JobLegError',
+            errorMessage: agentResult.response,
+            context: { phase: 'job_runner' },
+          },
+          log
+        );
+      }
+      log.warn('Background job finished with a failed turn', {
+        errorClass: agentResult.errorClass ?? 'unknown',
+        latencyMs,
+      });
+    } else {
+      log.info('Background job completed', {
+        sessionId: job.sessionId,
+        latencyMs,
+        outputTokens: agentResult.outputTokens,
+      });
+    }
+    return 0;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    // Best-effort user notification — the job must never die silently.
+    try {
+      await sendGoogleChatResponse(
+        job.spaceName,
+        job.threadName,
+        '⚠️ The background job hit an internal error and could not finish. ' +
+          'Some steps may have already completed — ask me to check before ' +
+          'retrying.',
+        log
+      );
+    } catch (sendError) {
+      log.error('Failed to post job-error message to Chat', {
+        error:
+          sendError instanceof Error ? sendError.message : String(sendError),
+      });
+    }
+    await recordFailure(
+      {
+        source: 'router',
+        severity: 'error',
+        userId: job.userEmail,
+        sessionId: job.sessionId,
+        errorClass: 'JobRunnerError',
+        errorMessage: message,
+        context: { phase: 'job_runner' },
+      },
+      log
+    );
+    return 1;
+  } finally {
+    clearInterval(renewTimer);
+    await releaseSessionLock(job.sessionId, job.lockToken, log);
+  }
+}
+
+// The postgres pool keeps the event loop alive — exit explicitly.
+main()
+  .then((code) => process.exit(code))
+  .catch((error) => {
+    process.stderr.write(
+      `job-runner fatal: ${error instanceof Error ? error.stack ?? error.message : String(error)}\n`
+    );
+    process.exit(1);
+  });

--- a/infra/lambdas/agent-router/job-main.ts
+++ b/infra/lambdas/agent-router/job-main.ts
@@ -37,12 +37,46 @@ import {
 
 const RENEW_INTERVAL_MS = 10 * 60 * 1000;
 
+/**
+ * Best-effort lock release when JOB_PAYLOAD fails full validation (review,
+ * #1147): the router pre-acquired the kind='job' lock BEFORE launching this
+ * task, so bailing on a malformed payload without releasing would leave
+ * users hearing "still working on your earlier task" until the 14-min TTL
+ * expires. sessionId/lockToken are extracted loosely — independent of the
+ * rest of the payload being valid.
+ */
+async function releaseLockFromRawPayload(
+  raw: string | undefined,
+  log: ReturnType<typeof createLogger>
+): Promise<void> {
+  if (!raw) return;
+  try {
+    const loose = JSON.parse(raw) as Record<string, unknown>;
+    if (
+      typeof loose.sessionId === 'string' && loose.sessionId &&
+      typeof loose.lockToken === 'string' && loose.lockToken
+    ) {
+      await releaseSessionLock(loose.sessionId, loose.lockToken, log);
+      log.warn('Released job lock after payload validation failure');
+    }
+  } catch {
+    // Not even loosely parseable — nothing recoverable; TTL self-heals.
+  }
+}
+
 async function main(): Promise<number> {
   const log = createLogger({ service: 'agent-job-runner' });
 
   // A broken payload means there is no Chat destination to post to —
-  // log loudly and exit nonzero (CloudWatch is the record).
-  const job = parseJobPayload(process.env.JOB_PAYLOAD);
+  // log loudly, release the pre-acquired lock if recoverable, and exit
+  // nonzero (CloudWatch is the record).
+  let job: ReturnType<typeof parseJobPayload>;
+  try {
+    job = parseJobPayload(process.env.JOB_PAYLOAD);
+  } catch (error) {
+    await releaseLockFromRawPayload(process.env.JOB_PAYLOAD, log);
+    throw error;
+  }
 
   log.info('Background job started', {
     sessionId: job.sessionId,

--- a/infra/lambdas/agent-router/job-promotion.test.ts
+++ b/infra/lambdas/agent-router/job-promotion.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Unit tests for async-job promotion logic (issue #1138).
+ *
+ * Run: bun test job-promotion.test.ts (from this directory).
+ */
+
+import { describe, expect, test } from 'bun:test';
+
+import {
+  buildContinuationPrompt,
+  buildJobPayload,
+  JOB_DEADLINE_S,
+  parseJobPayload,
+  shouldPromoteToJob,
+} from './job-promotion';
+
+describe('shouldPromoteToJob', () => {
+  test('deadline classes promote', () => {
+    expect(shouldPromoteToJob('ChatDeadlineExpired')).toBe(true);
+    expect(shouldPromoteToJob('ChatDeadlineExpiredPartial')).toBe(true);
+  });
+
+  test('real errors and clean turns do NOT promote', () => {
+    expect(shouldPromoteToJob('OpenClawChatError')).toBe(false);
+    expect(shouldPromoteToJob('EmptyAgentResponse')).toBe(false);
+    expect(shouldPromoteToJob('AgentCoreHttpError_500')).toBe(false);
+    expect(shouldPromoteToJob(undefined)).toBe(false);
+    expect(shouldPromoteToJob('')).toBe(false);
+  });
+});
+
+const BASE = {
+  sessionId: 'user-abc123-deadbeef-tag',
+  lockToken: 'tok-1',
+  runtimeId: 'psd_agent_dev-XYZ',
+  userEmail: 'hagelk@psd401.net',
+  displayName: 'Kris Hagel',
+  workspacePrefix: 'hagelk-abc123',
+  spaceName: 'spaces/AAA',
+  isDM: true,
+  originalPrompt: 'do the big task',
+};
+
+describe('buildJobPayload / parseJobPayload round-trip', () => {
+  test('round-trips all fields', () => {
+    const parsed = parseJobPayload(buildJobPayload({ ...BASE, threadName: 'spaces/AAA/threads/t1' }));
+    expect(parsed.sessionId).toBe(BASE.sessionId);
+    expect(parsed.lockToken).toBe(BASE.lockToken);
+    expect(parsed.runtimeId).toBe(BASE.runtimeId);
+    expect(parsed.userEmail).toBe(BASE.userEmail);
+    expect(parsed.workspacePrefix).toBe(BASE.workspacePrefix);
+    expect(parsed.spaceName).toBe(BASE.spaceName);
+    expect(parsed.threadName).toBe('spaces/AAA/threads/t1');
+    expect(parsed.isDM).toBe(true);
+    expect(parsed.promptExcerpt).toBe('do the big task');
+  });
+
+  test('omits threadName when absent (top-level message)', () => {
+    const parsed = parseJobPayload(buildJobPayload(BASE));
+    expect(parsed.threadName).toBeUndefined();
+  });
+
+  test('prompt excerpt truncates to keep the payload under the RunTask 8KiB cap', () => {
+    const parsed = parseJobPayload(
+      buildJobPayload({ ...BASE, originalPrompt: 'x'.repeat(10_000) })
+    );
+    expect(parsed.promptExcerpt.length).toBe(2000);
+    expect(buildJobPayload({ ...BASE, originalPrompt: 'x'.repeat(10_000) }).length).toBeLessThan(4096);
+  });
+
+  test('parse rejects empty, invalid JSON, and missing fields', () => {
+    expect(() => parseJobPayload(undefined)).toThrow('empty');
+    expect(() => parseJobPayload('not json')).toThrow('not valid JSON');
+    const missing = JSON.stringify({ sessionId: 's' });
+    expect(() => parseJobPayload(missing)).toThrow('lockToken');
+  });
+});
+
+describe('buildContinuationPrompt', () => {
+  test('includes the job-continuation marker, side-effect caution, and excerpt', () => {
+    const prompt = buildContinuationPrompt('summarize the 7/1 meeting');
+    expect(prompt).toContain('[job-continuation]');
+    expect(prompt).toContain('re-running');
+    expect(prompt).toContain('summarize the 7/1 meeting');
+  });
+
+  test('no excerpt → no dangling excerpt block', () => {
+    expect(buildContinuationPrompt('')).not.toContain('original request excerpt');
+  });
+});
+
+describe('JOB_DEADLINE_S', () => {
+  test('matches the approved 2-hour ceiling (harness clamp mirror)', () => {
+    expect(JOB_DEADLINE_S).toBe(7200);
+  });
+});

--- a/infra/lambdas/agent-router/job-promotion.ts
+++ b/infra/lambdas/agent-router/job-promotion.ts
@@ -1,0 +1,145 @@
+/**
+ * Async-job promotion — pure logic (issue #1138, "the 14-minute wall").
+ *
+ * A multi-step agent turn that cannot finish inside the router Lambda's
+ * ~14-minute window is promoted EXACTLY ONCE into a long-lived ECS Fargate
+ * job-runner task, which re-invokes the SAME AgentCore session with a
+ * continuation prompt and a 2-hour deadline (AgentCore invocations may run
+ * up to 8h; the Lambda caller was the only 15-minute wall).
+ *
+ * This module holds the dependency-free pieces (promotion predicate, job
+ * payload build/parse, continuation prompt) so they can be unit tested
+ * without the Lambda runtime — the ECS RunTask wiring stays in index.ts.
+ */
+
+/** Turn error classes that mean "ran out of clock", not "broke". */
+const DEADLINE_ERROR_CLASSES = new Set([
+  'ChatDeadlineExpired',
+  'ChatDeadlineExpiredPartial',
+]);
+
+/**
+ * Job leg ceiling: 2 hours (approved 2026-07-07). Mirrors the harness clamp
+ * in agent-image/harness_adapter.py (_resolve_deadline_s, max 7200).
+ */
+export const JOB_DEADLINE_S = 7200;
+
+/** True when a failed turn should be promoted to a background job. */
+export function shouldPromoteToJob(errorClass: string | undefined): boolean {
+  return !!errorClass && DEADLINE_ERROR_CLASSES.has(errorClass);
+}
+
+/**
+ * Everything the job-runner needs to resume and deliver the turn. Carried
+ * as a single JSON env var on the RunTask container override — AWS caps the
+ * total override payload at 8 KiB, hence the prompt excerpt truncation in
+ * buildJobPayload (the session already holds the full original prompt in
+ * its OpenClaw history; the excerpt is context garnish for the continuation
+ * message, not the source of truth).
+ */
+export interface JobPayload {
+  /** AgentCore session to resume (sticky-routes to the same microVM). */
+  sessionId: string;
+  /** Session-lock token the router pre-acquired with kind='job'. */
+  lockToken: string;
+  /** Resolved AgentCore runtime id/ARN (runner skips the SSM lookup). */
+  runtimeId: string;
+  userEmail: string;
+  displayName: string;
+  workspacePrefix: string;
+  spaceName: string;
+  threadName?: string;
+  /** In shared spaces the reply is prefixed [Name's Agent]; DMs are not. */
+  isDM: boolean;
+  /** Truncated excerpt of the original request (context only, see above). */
+  promptExcerpt: string;
+}
+
+const PROMPT_EXCERPT_MAX = 2000;
+
+export function buildJobPayload(input: {
+  sessionId: string;
+  lockToken: string;
+  runtimeId: string;
+  userEmail: string;
+  displayName: string;
+  workspacePrefix: string;
+  spaceName: string;
+  threadName?: string;
+  isDM: boolean;
+  originalPrompt: string;
+}): string {
+  const payload: JobPayload = {
+    sessionId: input.sessionId,
+    lockToken: input.lockToken,
+    runtimeId: input.runtimeId,
+    userEmail: input.userEmail,
+    displayName: input.displayName,
+    workspacePrefix: input.workspacePrefix,
+    spaceName: input.spaceName,
+    ...(input.threadName ? { threadName: input.threadName } : {}),
+    isDM: input.isDM,
+    promptExcerpt: (input.originalPrompt || '').slice(0, PROMPT_EXCERPT_MAX),
+  };
+  return JSON.stringify(payload);
+}
+
+/**
+ * Parse + validate a JOB_PAYLOAD env value in the runner. Throws with a
+ * field-specific message on anything missing — the runner catches, logs,
+ * and exits nonzero (there is no Chat destination to post to if the payload
+ * itself is broken).
+ */
+export function parseJobPayload(raw: string | undefined): JobPayload {
+  if (!raw) throw new Error('JOB_PAYLOAD env var is empty');
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    throw new Error('JOB_PAYLOAD is not valid JSON');
+  }
+  const obj = parsed as Record<string, unknown>;
+  const requireString = (field: string): string => {
+    const v = obj[field];
+    if (typeof v !== 'string' || !v) {
+      throw new Error(`JOB_PAYLOAD missing required field: ${field}`);
+    }
+    return v;
+  };
+  return {
+    sessionId: requireString('sessionId'),
+    lockToken: requireString('lockToken'),
+    runtimeId: requireString('runtimeId'),
+    userEmail: requireString('userEmail'),
+    displayName: typeof obj.displayName === 'string' ? obj.displayName : '',
+    workspacePrefix: requireString('workspacePrefix'),
+    spaceName: requireString('spaceName'),
+    ...(typeof obj.threadName === 'string' && obj.threadName
+      ? { threadName: obj.threadName }
+      : {}),
+    isDM: obj.isDM === true,
+    promptExcerpt:
+      typeof obj.promptExcerpt === 'string' ? obj.promptExcerpt : '',
+  };
+}
+
+/**
+ * The continuation message sent to the resumed session. The session's
+ * OpenClaw history already contains the original request and every tool
+ * call the first leg ran — this message only needs to say "keep going,
+ * carefully".
+ */
+export function buildContinuationPrompt(promptExcerpt: string): string {
+  const excerpt = promptExcerpt
+    ? `\n\n[original request excerpt: ${promptExcerpt}]`
+    : '';
+  return (
+    '[job-continuation] Your previous turn hit the platform time limit ' +
+    'mid-task and has been moved to a background job with a much longer ' +
+    'budget. Continue the task from where you stopped. Before re-running ' +
+    'ANY side effect (document creation, sharing, posting, sending), check ' +
+    'whether it already completed in your earlier work and skip it if so. ' +
+    'When everything is done, reply with the complete final answer for the ' +
+    `user.${excerpt}`
+  );
+}

--- a/infra/lambdas/agent-router/package.json
+++ b/infra/lambdas/agent-router/package.json
@@ -1,7 +1,7 @@
 {
   "name": "agent-router",
   "version": "1.0.0",
-  "description": "Agent Router Lambda — Routes Google Chat messages through Bedrock Guardrails to AgentCore",
+  "description": "Agent Router Lambda \u2014 Routes Google Chat messages through Bedrock Guardrails to AgentCore",
   "main": "dist/index.js",
   "scripts": {
     "build": "tsc",
@@ -11,15 +11,16 @@
     "@aws-crypto/sha256-js": "^5.0.0",
     "@aws-sdk/client-bedrock-runtime": "^3.0.0",
     "@aws-sdk/client-dynamodb": "^3.0.0",
+    "@aws-sdk/client-ecs": "^3.0.0",
     "@aws-sdk/client-s3": "^3.0.0",
     "@aws-sdk/client-secrets-manager": "^3.0.0",
     "@aws-sdk/client-ssm": "^3.0.0",
     "@aws-sdk/credential-provider-node": "^3.0.0",
     "@aws-sdk/lib-dynamodb": "^3.0.0",
     "@aws-sdk/lib-storage": "^3.0.0",
+    "@googleapis/chat": "^5.0.0",
     "@smithy/protocol-http": "^4.0.0",
     "@smithy/signature-v4": "^4.0.0",
-    "@googleapis/chat": "^5.0.0",
     "postgres": "^3.4.0",
     "undici": "^6.0.0"
   },

--- a/infra/lib/agent-platform-stack.ts
+++ b/infra/lib/agent-platform-stack.ts
@@ -2,6 +2,8 @@ import * as cdk from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import * as ec2 from 'aws-cdk-lib/aws-ec2';
 import * as ecr from 'aws-cdk-lib/aws-ecr';
+import * as ecrAssets from 'aws-cdk-lib/aws-ecr-assets';
+import * as ecs from 'aws-cdk-lib/aws-ecs';
 import * as s3 from 'aws-cdk-lib/aws-s3';
 import * as s3deploy from 'aws-cdk-lib/aws-s3-deployment';
 import * as dynamodb from 'aws-cdk-lib/aws-dynamodb';
@@ -2146,6 +2148,125 @@ export class AgentPlatformStack extends cdk.Stack {
 
     cdk.Tags.of(this.routerLambda).add('Environment', environment);
     cdk.Tags.of(this.routerLambda).add('ManagedBy', 'cdk');
+
+    // -------------------------------------------------------------------------
+    // Async job-runner (issue #1138 — "the 14-minute wall")
+    //
+    // A multi-step agent turn that hits the router's 14-minute deadline is
+    // promoted ONCE to an on-demand Fargate task (promoteToJob in the router).
+    // The task runs the SAME compiled agent-router package with a different
+    // entrypoint (dist/job-main.js), resumes the same AgentCore session with a
+    // 2-hour deadline (AgentCore invocations may run up to 8h — only the
+    // Lambda caller was capped at 15 min), and posts the final answer to the
+    // originating Chat space. No always-on compute: the cluster is free and
+    // tasks exist only while a job runs.
+    // -------------------------------------------------------------------------
+    const jobCluster = new ecs.Cluster(this, 'JobRunnerCluster', {
+      clusterName: `psd-agent-jobs-${environment}`,
+      vpc,
+      containerInsightsV2: ecs.ContainerInsights.DISABLED,
+    });
+
+    const jobLogGroup = new logs.LogGroup(this, 'JobRunnerLogGroup', {
+      logGroupName: `/ecs/psd-agent-job-runner-${environment}`,
+      retention: logs.RetentionDays.ONE_MONTH,
+      removalPolicy: cdk.RemovalPolicy.DESTROY,
+    });
+
+    const jobTaskDef = new ecs.FargateTaskDefinition(this, 'JobRunnerTaskDef', {
+      family: `psd-agent-job-runner-${environment}`,
+      // I/O-bound: the task mostly holds an SSE stream open while the
+      // AgentCore microVM does the work. 512/1024 is generous headroom.
+      cpu: 512,
+      memoryLimitMiB: 1024,
+      runtimePlatform: {
+        cpuArchitecture: ecs.CpuArchitecture.ARM64,
+        operatingSystemFamily: ecs.OperatingSystemFamily.LINUX,
+      },
+    });
+
+    jobTaskDef.addContainer('job-runner', {
+      containerName: 'job-runner',
+      image: ecs.ContainerImage.fromAsset(
+        path.join(__dirname, '..', 'lambdas', 'agent-router'),
+        { file: 'Dockerfile', platform: ecrAssets.Platform.LINUX_ARM64 },
+      ),
+      logging: ecs.LogDrivers.awsLogs({
+        logGroup: jobLogGroup,
+        streamPrefix: 'job',
+      }),
+      environment: {
+        ENVIRONMENT: environment,
+        // Region for the SDK clients the shared router module constructs.
+        AWS_REGION: this.region,
+        AWS_ACCOUNT_ID: this.account,
+        NODE_ENV: 'production',
+        SESSION_LOCKS_TABLE: this.sessionLocksTable.tableName,
+        GOOGLE_CREDENTIALS_SECRET_ARN: this.googleCredentialsSecret.secretArn,
+        DATABASE_HOST: props.databaseHost,
+        DATABASE_SECRET_ARN: props.databaseSecretArn,
+        DATABASE_NAME: props.databaseName || 'aistudio',
+        // The undici dispatcher must outlive the 2h job deadline: 2h05m.
+        AGENTCORE_TIMEOUT_MS_OVERRIDE: String((2 * 60 + 5) * 60 * 1000),
+        // JOB_PAYLOAD is injected per-run via RunTask containerOverrides.
+      },
+    });
+
+    // Task role — mirrors ONLY what job-main.ts touches: AgentCore invoke,
+    // the two secrets, the session-locks table, and (via awslogs) the log
+    // group on the execution role.
+    jobTaskDef.addToTaskRolePolicy(new iam.PolicyStatement({
+      sid: 'AgentCoreInvoke',
+      effect: iam.Effect.ALLOW,
+      actions: ['bedrock-agentcore:InvokeAgentRuntime', 'bedrock-agentcore:InvokeAgentRuntimeForUser'],
+      resources: [`arn:aws:bedrock-agentcore:${this.region}:${this.account}:runtime/*`],
+    }));
+    this.googleCredentialsSecret.grantRead(jobTaskDef.taskRole);
+    dbSecret.grantRead(jobTaskDef.taskRole);
+    this.sessionLocksTable.grantReadWriteData(jobTaskDef.taskRole);
+
+    const jobRunnerSg = new ec2.SecurityGroup(this, 'JobRunnerSg', {
+      vpc,
+      description:
+        'psd-agent job-runner Fargate tasks — egress only (Aurora ingress is VPC-CIDR-wide)',
+      allowAllOutbound: true,
+    });
+
+    // Router promotes turns by launching the task. RunTask needs the task-def
+    // ARN and PassRole on both roles the task assumes.
+    this.routerLambdaRole.addToPolicy(new iam.PolicyStatement({
+      sid: 'JobRunnerLaunch',
+      effect: iam.Effect.ALLOW,
+      actions: ['ecs:RunTask'],
+      resources: [jobTaskDef.taskDefinitionArn],
+    }));
+    this.routerLambdaRole.addToPolicy(new iam.PolicyStatement({
+      sid: 'JobRunnerPassRole',
+      effect: iam.Effect.ALLOW,
+      actions: ['iam:PassRole'],
+      resources: [
+        jobTaskDef.taskRole.roleArn,
+        jobTaskDef.obtainExecutionRole().roleArn,
+      ],
+      conditions: {
+        StringEquals: { 'iam:PassedToService': 'ecs-tasks.amazonaws.com' },
+      },
+    }));
+
+    this.routerLambda.addEnvironment('JOB_CLUSTER_ARN', jobCluster.clusterArn);
+    this.routerLambda.addEnvironment('JOB_TASK_DEF_ARN', jobTaskDef.taskDefinitionArn);
+    this.routerLambda.addEnvironment(
+      'JOB_SUBNETS',
+      vpc.selectSubnets({ subnetType: ec2.SubnetType.PRIVATE_WITH_EGRESS })
+        .subnetIds.join(','),
+    );
+    this.routerLambda.addEnvironment('JOB_SECURITY_GROUP', jobRunnerSg.securityGroupId);
+    this.routerLambda.addEnvironment('JOB_CONTAINER_NAME', 'job-runner');
+
+    cdk.Tags.of(jobCluster).add('Environment', environment);
+    cdk.Tags.of(jobCluster).add('ManagedBy', 'cdk');
+    cdk.Tags.of(jobLogGroup).add('Environment', environment);
+    cdk.Tags.of(jobLogGroup).add('ManagedBy', 'cdk');
 
     // Wire SQS → Lambda trigger
     // NOTE on duplicate processing: With batchSize=1 and 18-min visibility timeout


### PR DESCRIPTION
## Summary
Kills the 14-minute wall (approved plan). AgentCore invocations run up to **8 hours** — only the router Lambda's 15-min cap was ending long turns. **Single-seam promotion**: fast path untouched; a turn that returns `ChatDeadlineExpired(Partial)` is promoted exactly once to an on-demand ECS Fargate task that resumes the **same** AgentCore session with a **2-hour** deadline (owner-approved ceiling) and posts the final answer whenever it's done.

## How it works
- **Router**: on deadline errorClass → pre-acquire `kind='job'` session lock → `ecs:RunTask` with a `JOB_PAYLOAD` env override → post "⏳ moved to a background job" ack. **Any** promotion failure releases the lock and falls back to today's failure-framed partial. Mid-job user messages get an instant "still working" reply (`isJobLockActive` check before the 13-min lock poll).
- **Runner** (`job-main.ts`): the same compiled agent-router package with a second entrypoint — reuses `invokeAgentCore`, Chat delivery + rich envelope, telemetry, failure recording, and locks. Renews the lock every 10 min, always posts something (answer / harness frame / runner-error), explicit exit.
- **Container**: optional payload `deadline_s` → harness clamp `[60, 7200]` (interactive path keeps `[60, 840]`).
- **CDK**: free cluster + ARM64 task def (512/1024) via `ContainerImage.fromAsset`, scoped task role, `RunTask`+`PassRole` (condition `PassedToService=ecs-tasks`) on the router role, egress-only SG (Aurora ingress is VPC-CIDR-wide already).

## Verification
- Router bun 35/35 (9 new job-promotion tests: promotion predicate, payload round-trip + 8KiB truncation, parse fail-fast, continuation prompt)
- Agent-image Python 109/109 (5 new deadline-resolver clamp tests)
- `cdk synth` clean; cluster/taskdef/IAM/router-env verified in the rendered template
- Job-runner image **built for linux/arm64 and boot-tested**: missing payload → exit 1 `JOB_PAYLOAD env var is empty`; partial payload → exit 1 naming the missing field
- Runtime acceptance post-deploy: re-run the Plaud→Docs→POAD task (ack at ~14 min, background completion posts to the DM), mid-job message answers instantly, RunTask-failure fallback

## Non-goals (v1, per plan)
No jobs table/dashboard, no interim progress posts, no cross-user/cron promotion, no chaining (one promotion, then done or failure frame).

Part of #1138