### PR TITLE
fix(agent): ASCII-only description on the job-runner security group (deploy failure, #1138)

### DIFF
--- a/infra/lib/agent-platform-stack.ts
+++ b/infra/lib/agent-platform-stack.ts
@@ -2227,8 +2227,11 @@ export class AgentPlatformStack extends cdk.Stack {
 
     const jobRunnerSg = new ec2.SecurityGroup(this, 'JobRunnerSg', {
       vpc,
+      // EC2 GroupDescription is ASCII-only — a unicode dash here failed the
+      // whole 2026-07-07 deploy (CREATE_FAILED: "Character sets beyond ASCII
+      // are not supported"). Keep this string plain ASCII.
       description:
-        'psd-agent job-runner Fargate tasks — egress only (Aurora ingress is VPC-CIDR-wide)',
+        'psd-agent job-runner Fargate tasks - egress only (Aurora ingress is VPC-CIDR-wide)',
       allowAllOutbound: true,
     });
 


### PR DESCRIPTION
EC2 `GroupDescription` is ASCII-only; the em dash in `JobRunnerSg`'s description failed CREATE ("Character sets beyond ASCII are not supported") and rolled back the AgentPlatformStack deploy — the four sibling job-runner resources were cancellation casualties. One-character fix (em dash → hyphen) + constraint comment. Swept the full synthesized template: remaining non-ASCII values are in types that accept unicode (Secrets/CloudWatch/Lambda payload) and are already deployed. Synth verified ASCII-only. Part of #1138.