### PR TITLE
feat(agent): explicit in-district file sharing for agent-owned docs (#1138)

### DIFF
--- a/infra/agent-image/skills/psd-workspace/SKILL.md
+++ b/infra/agent-image/skills/psd-workspace/SKILL.md
@@ -166,21 +166,26 @@ These cannot be bypassed by phrasing. The skill returns exit code 13 with `statu
 - **No deletes.** Mail (delete/trash/batchDelete), events, calendars, Drive files, drive trash, tasks, tasklists.
 - **No permission changes.** `drive.permissions.create/update/delete`.
 
-**Narrow exception — share-to-caller handoff.** `drive.permissions.create` is permitted in ONE case: the agent shares a file it owns back to the conversation's caller, read-only. ALL of the following must be true:
+**Exception — explicit in-district shares of YOUR OWN files.** `drive.permissions.create` is permitted only on files the agent owns (`--scope agent`), only as `create` (never update/delete), and only in these explicit shapes:
 
-- `--scope agent` (file is in the agent's own Drive)
-- payload `type: "user"` (no domain / group / anyone)
-- payload `role: "reader"` or `"commenter"` (no writer / owner)
-- payload `emailAddress` matches the `--user` arg exactly (caller only; no third parties)
+- **Named person in the district:** `type: "user"`, `role: "reader"` or `"commenter"`, `emailAddress` ending `@psd401.net` — the caller or any district colleague.
+- **Whole district, read-only:** `type: "domain"`, `domain: "psd401.net"`, `role: "reader"` — use when a doc's link is going into a shared Chat space so every member can open it.
 
-Use this when you've created an artifact for the user (investigation report, generated doc, etc.) in your own Drive and need to hand it back. Example:
+Never allowed: `type: "anyone"` or `"group"`, external addresses/domains, `writer`/`owner` roles, or any permission change on user-owned files.
+
+Examples:
 
 ```bash
+# Hand an artifact back to the caller
 gws drive.permissions.create --scope agent --user hagelk@psd401.net \
   --json '{"fileId":"<id>","type":"user","role":"reader","emailAddress":"hagelk@psd401.net"}'
+
+# Make a doc readable district-wide before posting its link in a Chat space
+gws drive.permissions.create --scope agent --user hagelk@psd401.net \
+  --json '{"fileId":"<id>","type":"domain","role":"reader","domain":"psd401.net"}'
 ```
 
-Anything outside the narrow shape is still blocked.
+When you post a doc link into a shared Chat space, share it district-wide (domain/reader) FIRST — otherwise members hit "request access". Anything outside these shapes is still blocked.
 
 If a user explicitly asks the agent to send something, post the draft + a clear "I drafted it; reply 'send' if it's right" in Chat instead. The user clicks send themselves.
 

--- a/infra/agent-image/skills/psd-workspace/common.js
+++ b/infra/agent-image/skills/psd-workspace/common.js
@@ -426,28 +426,36 @@ const PHASE1_FORBIDDEN = [
     reason: 'modifying Drive sharing permissions (Phase 1: no permission changes)' },
 ];
 
+// District domain for the explicit-share exception. Env-overridable so
+// non-prod environments could narrow/redirect it; the default is the only
+// domain the platform serves.
+const AGENT_SHARE_DOMAIN = (process.env.AGENT_SHARE_DOMAIN || 'psd401.net').toLowerCase();
+
 /**
- * Narrow exception to the `drive.permissions.create` block: the agent is
- * permitted to share files it owns (scope === 'agent_account') back to the
- * caller who initiated the conversation, as `reader` or `commenter` only.
+ * Exception to the `drive.permissions.create` block: the agent may grant
+ * EXPLICIT, bounded permissions on files it owns (scope === 'agent_account').
  *
- * Rationale: when the agent creates artifacts on a user's behalf — investigation
- * reports, drafts, generated docs — it stores them in its own agent_account
- * Drive (because user_account scopes are intentionally narrow). Without this
- * exception, the user has no way to view the artifact, since the broad
- * `drive.permissions.create` block prevents even hand-back-to-owner sharing.
+ * Rationale: the agent stores artifacts it creates (reports, generated docs,
+ * meeting summaries) on its own agent_account Drive. Originally it could
+ * share them only back to the CALLER; product decision 2026-07-07 (Hagel,
+ * #1138 — team docs must land in shared Chat spaces) widened this to
+ * in-district sharing with explicit grants.
  *
  * Hard constraints (ALL must be true to allow):
- *   - context.scope is 'agent_account'  (sharing FROM the agent's own Drive)
- *   - context.ownerEmail matches the permission's emailAddress (caller only;
- *     no third-party shares, no domain shares, no anyone-with-link)
- *   - permission.type === 'user'        (no domain / group / anyone)
- *   - permission.role ∈ {reader, commenter}  (no writer/owner transfer)
+ *   - context.scope is 'agent_account'  (sharing FROM the agent's own Drive;
+ *     permission changes on user-owned files remain fully blocked)
+ *   - create only (update/delete remain blocked)
+ *   - EITHER type === 'user' with an @psd401.net emailAddress,
+ *     role ∈ {reader, commenter}
+ *   - OR     type === 'domain' with domain === psd401.net, role === 'reader'
+ *     (broad in-district visibility for docs posted to shared spaces)
+ *   - NEVER: type 'anyone' or 'group', external addresses/domains,
+ *     writer/owner roles.
  *
- * Returns true if the share request is the narrow caller-only handoff;
+ * Returns true if the share request fits the explicit in-district shape;
  * false otherwise. False means fall through to the existing block.
  */
-function isShareToCallerHandoff(commandString, context) {
+function isPermittedExplicitShare(commandString, context) {
   if (!context || context.scope !== 'agent_account' || !context.ownerEmail) {
     return false;
   }
@@ -456,36 +464,13 @@ function isShareToCallerHandoff(commandString, context) {
     return false;
   }
 
-  // Extract the --json payload without mutating it. We reuse the same brace-
-  // balanced parser idea as mutateJsonField but read-only.
-  const jsonFlagIdx = commandString.search(/--json\s+['"]?\{/);
-  if (jsonFlagIdx === -1) return false;
-  let i = jsonFlagIdx + '--json'.length;
-  while (i < commandString.length && /\s/.test(commandString[i])) i++;
-  if (commandString[i] === "'" || commandString[i] === '"') i++;
-  const jsonStart = i;
-  if (commandString[jsonStart] !== '{') return false;
-  let depth = 0;
-  let inString = false;
-  let stringChar = '';
-  let escape = false;
-  let jsonEnd = -1;
-  for (let j = jsonStart; j < commandString.length; j++) {
-    const ch = commandString[j];
-    if (escape) { escape = false; continue; }
-    if (ch === '\\') { escape = true; continue; }
-    if (inString) {
-      if (ch === stringChar) inString = false;
-      continue;
-    }
-    if (ch === '"' || ch === "'") { inString = true; stringChar = ch; continue; }
-    if (ch === '{') depth++;
-    else if (ch === '}') { depth--; if (depth === 0) { jsonEnd = j; break; } }
-  }
-  if (jsonEnd === -1) return false;
+  // Extract the --json payload without mutating it (shared helper — same
+  // brace-balanced scan marker injection uses).
+  const jsonStr = extractJsonArg(commandString);
+  if (!jsonStr) return false;
   let payload;
   try {
-    payload = JSON.parse(commandString.slice(jsonStart, jsonEnd + 1));
+    payload = JSON.parse(jsonStr);
   } catch {
     return false;
   }
@@ -501,12 +486,20 @@ function isShareToCallerHandoff(commandString, context) {
   const emailAddress = typeof perm.emailAddress === 'string'
     ? perm.emailAddress.toLowerCase()
     : '';
+  const domain = typeof perm.domain === 'string' ? perm.domain.toLowerCase() : '';
 
-  if (type !== 'user') return false;
-  if (role !== 'reader' && role !== 'commenter') return false;
-  if (emailAddress !== context.ownerEmail.toLowerCase()) return false;
-
-  return true;
+  if (type === 'user') {
+    // Explicit named recipient — must be in-district; reader/commenter only.
+    if (role !== 'reader' && role !== 'commenter') return false;
+    return emailAddress.endsWith(`@${AGENT_SHARE_DOMAIN}`);
+  }
+  if (type === 'domain') {
+    // Whole-district visibility (docs linked in shared Chat spaces) —
+    // read-only, and ONLY our own domain.
+    return role === 'reader' && domain === AGENT_SHARE_DOMAIN;
+  }
+  // 'anyone', 'group', and everything else stay blocked.
+  return false;
 }
 
 /**
@@ -527,10 +520,11 @@ function enforcePhase1Gates(commandString, context) {
   }
   for (const { pattern, reason } of PHASE1_FORBIDDEN) {
     if (pattern.test(commandString)) {
-      // Narrow exception: agent shares its own file with the caller, read-only.
+      // Exception: agent grants explicit, bounded in-district permissions
+      // on files it owns (see isPermittedExplicitShare).
       if (
         /\bdrive[\s.]+permissions[\s.]+create\b/i.test(commandString) &&
-        isShareToCallerHandoff(commandString, context)
+        isPermittedExplicitShare(commandString, context)
       ) {
         return { allowed: true };
       }

--- a/infra/agent-image/skills/psd-workspace/common.test.js
+++ b/infra/agent-image/skills/psd-workspace/common.test.js
@@ -83,8 +83,8 @@ describe('resolvePayloadFiles', () => {
   });
 
   test('gates see the real payload through the synthetic command', () => {
-    // A share-to-caller handoff via --json-file: the gate's payload
-    // validation must be able to read type/role/emailAddress.
+    // An explicit share via --json-file: the gate's payload validation must
+    // be able to read type/role/emailAddress through the file indirection.
     const p = tmpFile(JSON.stringify({
       fileId: 'f1', type: 'user', role: 'reader', emailAddress: 'hagelk@psd401.net',
     }));
@@ -96,9 +96,9 @@ describe('resolvePayloadFiles', () => {
       ownerEmail: 'hagelk@psd401.net',
     });
     expect(gate.allowed).toBe(true);
-    // Same command with a third-party recipient must stay blocked.
+    // External recipients must stay blocked even through a file payload.
     const p2 = tmpFile(JSON.stringify({
-      fileId: 'f1', type: 'user', role: 'reader', emailAddress: 'other@psd401.net',
+      fileId: 'f1', type: 'user', role: 'reader', emailAddress: 'evil@outside.com',
     }));
     const resolved2 = resolvePayloadFiles(`drive permissions create --json-file ${p2}`);
     const gate2 = enforcePhase1Gates(resolved2.syntheticCommand, {
@@ -117,6 +117,55 @@ describe('resolvePayloadFiles', () => {
     const mutated = extractJsonArg(marked);
     expect(mutated).toContain('Created by your agent');
     expect(JSON.parse(mutated).description).toContain('Daily sync');
+  });
+});
+
+describe('explicit in-district sharing (widened gate, 2026-07-07)', () => {
+  const CTX = { scope: 'agent_account', ownerEmail: 'hagelk@psd401.net' };
+  const share = (perm) =>
+    enforcePhase1Gates(
+      `drive permissions create --json '${JSON.stringify(perm)}'`,
+      CTX
+    ).allowed;
+
+  test('named district colleague (not the caller) is now allowed', () => {
+    expect(share({ fileId: 'f', type: 'user', role: 'reader', emailAddress: 'songstadw@psd401.net' })).toBe(true);
+    expect(share({ fileId: 'f', type: 'user', role: 'commenter', emailAddress: 'colleague@psd401.net' })).toBe(true);
+  });
+
+  test('domain-wide reader for psd401.net is allowed', () => {
+    expect(share({ fileId: 'f', type: 'domain', role: 'reader', domain: 'psd401.net' })).toBe(true);
+  });
+
+  test('domain shares are reader-only and our-domain-only', () => {
+    expect(share({ fileId: 'f', type: 'domain', role: 'commenter', domain: 'psd401.net' })).toBe(false);
+    expect(share({ fileId: 'f', type: 'domain', role: 'writer', domain: 'psd401.net' })).toBe(false);
+    expect(share({ fileId: 'f', type: 'domain', role: 'reader', domain: 'gmail.com' })).toBe(false);
+  });
+
+  test('external, anyone, group, and writer stay blocked', () => {
+    expect(share({ fileId: 'f', type: 'user', role: 'reader', emailAddress: 'evil@outside.com' })).toBe(false);
+    expect(share({ fileId: 'f', type: 'anyone', role: 'reader' })).toBe(false);
+    expect(share({ fileId: 'f', type: 'group', role: 'reader', emailAddress: 'staff@psd401.net' })).toBe(false);
+    expect(share({ fileId: 'f', type: 'user', role: 'writer', emailAddress: 'hagelk@psd401.net' })).toBe(false);
+  });
+
+  test('user scope and update/delete remain fully blocked', () => {
+    const userScope = enforcePhase1Gates(
+      `drive permissions create --json '{"fileId":"f","type":"user","role":"reader","emailAddress":"hagelk@psd401.net"}'`,
+      { scope: 'user_account', ownerEmail: 'hagelk@psd401.net' }
+    );
+    expect(userScope.allowed).toBe(false);
+    const update = enforcePhase1Gates(
+      `drive permissions update --json '{"fileId":"f","type":"domain","role":"reader","domain":"psd401.net"}'`,
+      CTX
+    );
+    expect(update.allowed).toBe(false);
+  });
+
+  test('a subtly-external email that merely CONTAINS the domain is blocked', () => {
+    expect(share({ fileId: 'f', type: 'user', role: 'reader', emailAddress: 'x@psd401.net.evil.com' })).toBe(false);
+    expect(share({ fileId: 'f', type: 'user', role: 'reader', emailAddress: 'psd401.net@gmail.com' })).toBe(false);
   });
 });
 


### PR DESCRIPTION
Product decision: agent-created docs must be openable by the team when posted to shared Chat spaces. Widens the Phase 1 share exception from caller-only to **explicit in-district**: named `@psd401.net` users (reader/commenter) or `domain:psd401.net` reader-only. Agent-owned files + create-only unchanged; anyone/group/external/writer/owner and all user-owned-file permission changes stay blocked (suffix-spoof addresses tested). Payload scan now reuses `extractJsonArg` (removes a 40-line duplicate). bun 23/23 (6 new adversarial cases); functionally exercised through run.js (domain-reader passes gate → credential stage; group/anyone → exit 13). Image-only change. Part of #1138.