### PR TITLE
fix(agent): block create-as-user impersonation + deny silent subagent spawning (#1138)

### DIFF
--- a/infra/agent-image/Dockerfile
+++ b/infra/agent-image/Dockerfile
@@ -251,6 +251,15 @@ RUN mkdir -p /home/node/.openclaw/memory
 #   config.model — requires adding a second model to bedrock-proxy. Until
 #   then the sub-agent adds ~5-10s to every turn's wall-clock latency.
 #
+#   tools.deny += sessions_spawn, subagents (2026-07-07, #1138) — OpenClaw
+#   subagents complete silently in THIS deployment: their "results
+#   auto-announce to your requester" lands in the OpenClaw session, but only
+#   an active chat turn can post to Google Chat, so the user never sees it.
+#   Observed live: a skill-audit ran to completion in a subagent and never
+#   reached the user. Long work must stay inline where the router's async-job
+#   promotion (#1147) can catch it. Tool ids verified against
+#   docs/gateway/config-tools.md (group:sessions table).
+#
 #   tools.codeMode.timeoutMs=60000 — code-mode (tool_search_code) VM
 #   execution ceiling, raised from the 10s default to the documented max
 #   (docs/reference/code-mode.md range 100–60000). At 10s, any skill command

--- a/infra/agent-image/openclaw.json
+++ b/infra/agent-image/openclaw.json
@@ -41,7 +41,7 @@
     "codeMode": {
       "timeoutMs": 60000
     },
-    "deny": ["cron", "nodes", "gateway"]
+    "deny": ["cron", "nodes", "gateway", "sessions_spawn", "subagents"]
   },
   "skills": {
     "load": {

--- a/infra/agent-image/skills/psd-rules/SKILL.md
+++ b/infra/agent-image/skills/psd-rules/SKILL.md
@@ -279,6 +279,20 @@ Finding a tool runs a short JS body in an isolated subprocess that exposes **onl
 
 ---
 
+## Rule 15 — No background promises; long work runs INLINE
+
+**Never tell the user you will "work in the background," "report back," or "send it when it's done" and then end your turn.** You cannot start a turn on your own — once your turn ends, you are frozen until the user messages again, so every such promise is broken by construction. Subagent spawning is disabled for the same reason: a subagent's completion announcement has no path back to Google Chat (observed 2026-07-07: an audit ran to completion in a subagent and the user never heard anything).
+
+**How to apply:**
+
+- Long task? **Do it now, inline, in this turn** — keep working until it is done. If it takes longer than the platform allows, the PLATFORM automatically moves the turn to a real background job and posts "⏳ moved to a background job…" — that system CAN deliver results later; you cannot.
+- Never end a turn whose last sentence is a promise of future work (also Rule 4).
+- If a turn ends with "⏳ moved to a background job", that was the platform, not you — the job continues your session and will post the result.
+
+**Why:** the model saying "I'll notify you when it's done" is the single most misleading thing it can say — nothing in the architecture makes that true except the platform's own promotion path.
+
+---
+
 ## Self-check before send
 
 Before every reply, confirm: no "Let me…"/scratchpad (R1); every URL is from a skill, and any `url` field is on its own line (R2/R9); no fabricated facts or outcomes (R3); did the work now, not an empty promise (R4); reply length matches information density and memory files updated (R5/R7); for any task a skill covers, called the skill (R9); called `psd-failure-report` if any part failed (R11); user-visible text is non-empty (R12); no non-reversible `gh`/`git push` unless the user authorized it this same turn (R13). If any is "no," fix the reply first.

--- a/infra/agent-image/skills/psd-workspace/SKILL.md
+++ b/infra/agent-image/skills/psd-workspace/SKILL.md
@@ -13,7 +13,7 @@ Google Workspace access for the user's data, gated by Phase 1 boundaries (#912).
 
 Phase 1 introduces two parallel OAuth identities per user. The `--scope` flag selects which:
 
-- `--scope user` (**default**) — OAuth on the human user (e.g. `hagelk@psd401.net`). Scopes: `gmail.modify` (read + draft + send + archive/label, no permanent delete), `calendar`, `tasks`, `drive.file`. Use this for reading the user's mail, managing their tasks, writing to their calendar, creating new Drive files for them. Sending is gated by behavioral rules — always confirm before actually sending.
+- `--scope user` (**default**) — OAuth on the human user (e.g. `hagelk@psd401.net`). Scopes: `gmail.modify` (read + draft + send + archive/label, no permanent delete), `calendar`, `tasks`, `drive.file`. Use this for reading the user's mail, managing their tasks, writing to their calendar. **NEVER for creating Drive files/Docs/Sheets/Slides** — a file created on this slot is OWNED BY THE USER, which is impersonation (hard-blocked at the skill layer, 2026-07-07). Every document you produce is created with `--scope agent` and shared explicitly. Sending is gated by behavioral rules — always confirm before actually sending.
 - `--scope agent` — OAuth on the agent identity (e.g. `agnt_hagelk@psd401.net`). Broad scopes. Use this for actions the agent takes *as itself* (the agent's own calendar, drafts owned by the agent, agent-owned Drive folder).
 
 If you omit `--scope`, the skill defaults to `user`. Phase 1 work is overwhelmingly on user data.
@@ -164,7 +164,8 @@ These cannot be bypassed by phrasing. The skill returns exit code 13 with `statu
 
 - **No sending mail.** `gmail.users.messages.send`, `gmail.users.drafts.send`, `+send`, `+reply`, `+reply-all`, `+forward` — all blocked. Drafts only.
 - **No deletes.** Mail (delete/trash/batchDelete), events, calendars, Drive files, drive trash, tasks, tasklists.
-- **No permission changes.** `drive.permissions.create/update/delete`.
+- **No permission changes.** `drive.permissions.create/update/delete` (except the explicit in-district shapes below).
+- **No file creation as the user.** `drive files create/copy`, `docs documents create`, `sheets spreadsheets create`, `slides presentations create` on `--scope user` are hard-blocked — a file created there is owned by the user's account (impersonation; no attribution trail). Create with `--scope agent`, then share explicitly. This has NO exception and no phrasing gets around it.
 
 **Exception — explicit in-district shares of YOUR OWN files.** `drive.permissions.create` is permitted only on files the agent owns (`--scope agent`), only as `create` (never update/delete), and only in these explicit shapes:
 

--- a/infra/agent-image/skills/psd-workspace/common.js
+++ b/infra/agent-image/skills/psd-workspace/common.js
@@ -382,6 +382,27 @@ function execGws(commandString, accessToken, payloads) {
 // `pattern` matches against the SPACE-JOINED argv tokens, lowercased — so
 // `gws gmail users messages send` and `gws gmail.users.messages.send` both
 // trigger the same rule.
+// Operations forbidden ONLY on the user OAuth slot (scope === 'user_account').
+//
+// Added 2026-07-07 (Hagel, #1138): the agent recreated documents OWNED BY THE
+// USER's account to route around the sharing gate ("do not create documents
+// as my account, that's a huge hole security-wise"). File creation as the
+// user is impersonation — every artifact must be owned by the agent identity
+// (auditable, gate-enforced sharing) and shared explicitly via
+// isPermittedExplicitShare. Drafts/calendar/tasks on the user slot remain
+// allowed: they are marker-stamped, land in review surfaces (Drafts folder,
+// own calendar), and were explicitly designed as user-slot writes.
+const USER_SCOPE_FORBIDDEN = [
+  { pattern: /\bdrive[\s.]+files[\s.]+(create|copy)\b/i,
+    reason: 'creating files owned by the user (create as the agent and share explicitly instead)' },
+  { pattern: /\bdocs[\s.]+documents[\s.]+create\b/i,
+    reason: 'creating a Google Doc owned by the user (create as the agent and share explicitly instead)' },
+  { pattern: /\bsheets[\s.]+spreadsheets[\s.]+create\b/i,
+    reason: 'creating a Google Sheet owned by the user (create as the agent and share explicitly instead)' },
+  { pattern: /\bslides[\s.]+presentations[\s.]+create\b/i,
+    reason: 'creating a Google Slides deck owned by the user (create as the agent and share explicitly instead)' },
+];
+
 const PHASE1_FORBIDDEN = [
   // Send mail — any path that puts a message on the wire
   { pattern: /\bgmail[\s.]+users[\s.]+messages[\s.]+send\b/i,
@@ -517,6 +538,18 @@ function isPermittedExplicitShare(commandString, context) {
 function enforcePhase1Gates(commandString, context) {
   if (!commandString || typeof commandString !== 'string') {
     return { allowed: true };
+  }
+  // Scope-conditional gates: file creation as the USER is impersonation
+  // (2026-07-07, see USER_SCOPE_FORBIDDEN). Checked first — these have no
+  // exceptions. Fail-closed default: when scope is missing/unknown we still
+  // apply the user-slot rules (run.js always passes a resolved scope; only
+  // a buggy caller would omit it, and the agent slot is the privileged one).
+  if (!context || context.scope !== 'agent_account') {
+    for (const { pattern, reason } of USER_SCOPE_FORBIDDEN) {
+      if (pattern.test(commandString)) {
+        return { allowed: false, reason };
+      }
+    }
   }
   for (const { pattern, reason } of PHASE1_FORBIDDEN) {
     if (pattern.test(commandString)) {

--- a/infra/agent-image/skills/psd-workspace/common.test.js
+++ b/infra/agent-image/skills/psd-workspace/common.test.js
@@ -120,6 +120,51 @@ describe('resolvePayloadFiles', () => {
   });
 });
 
+describe('user-scope file creation is impersonation — hard blocked (2026-07-07)', () => {
+  const USER_CTX = { scope: 'user_account', ownerEmail: 'hagelk@psd401.net' };
+  const AGENT_CTX = { scope: 'agent_account', ownerEmail: 'hagelk@psd401.net' };
+
+  test('drive/docs/sheets/slides creation blocked on the user slot', () => {
+    for (const cmd of [
+      `drive files create --json '{"name":"[Agent] x"}'`,
+      `drive files copy --params '{"fileId":"f1"}'`,
+      `docs documents create --json '{"title":"Summary"}'`,
+      `sheets spreadsheets create --json '{"properties":{"title":"x"}}'`,
+      `slides presentations create --json '{"title":"x"}'`,
+      'drive.files.create --json \'{"name":"x"}\'',
+    ]) {
+      const gate = enforcePhase1Gates(cmd, USER_CTX);
+      expect(gate.allowed).toBe(false);
+      expect(gate.reason).toContain('owned by the user');
+    }
+  });
+
+  test('same creations are allowed on the agent slot', () => {
+    for (const cmd of [
+      `drive files create --json '{"name":"[Agent] x"}'`,
+      `docs documents create --json '{"title":"Summary"}'`,
+    ]) {
+      expect(enforcePhase1Gates(cmd, AGENT_CTX).allowed).toBe(true);
+    }
+  });
+
+  test('missing/unknown scope fails closed to the user-slot rules', () => {
+    expect(enforcePhase1Gates(`docs documents create --json '{"title":"x"}'`, undefined).allowed).toBe(false);
+    expect(enforcePhase1Gates(`docs documents create --json '{"title":"x"}'`, { scope: 'weird' }).allowed).toBe(false);
+  });
+
+  test('user-slot reads and non-file writes are unaffected', () => {
+    for (const cmd of [
+      'drive files list --params \'{"q":"name contains x"}\'',
+      `calendar events insert --json '{"summary":"Standup"}'`,
+      `gmail +draft --to a@psd401.net --subject Hi --body ok`,
+      `tasks tasks insert --json '{"title":"x"}'`,
+    ]) {
+      expect(enforcePhase1Gates(cmd, USER_CTX).allowed).toBe(true);
+    }
+  });
+});
+
 describe('explicit in-district sharing (widened gate, 2026-07-07)', () => {
   const CTX = { scope: 'agent_account', ownerEmail: 'hagelk@psd401.net' };
   const share = (perm) =>


### PR DESCRIPTION
Two live-use defects (2026-07-07), closed at the code level:

1. **Create-as-user = impersonation, hard blocked.** The agent routed around the sharing gate by recreating docs under the user's own OAuth. New `USER_SCOPE_FORBIDDEN` gate: drive/docs/sheets/slides creation refused on `--scope user` (no exceptions, fail-closed on unknown scope). Drafts/calendar/tasks unchanged; agent-slot creation unchanged.
2. **OpenClaw subagents denied** (`sessions_spawn`, `subagents` — ids verified against OpenClaw docs). Subagent completions can't reach Google Chat in this architecture (observed: finished audit, silent user). Long work stays inline where #1147's promotion can actually deliver. psd-rules Rule 15: no background promises, ever.

**Verification:** psd-workspace 27/27 (4 new); run.js functional (user-scope create → exit 13; agent-scope → credential stage); python 109/109; openclaw.json valid + image-build config-validate gate re-checks the deny keys. Image-only change. Part of #1138.