### PR TITLE
docs(agent): Rule 8 + run.js parity with the create-as-user gate (review, #1151)

### DIFF
--- a/infra/agent-image/skills/psd-rules/SKILL.md
+++ b/infra/agent-image/skills/psd-rules/SKILL.md
@@ -136,6 +136,7 @@ The `psd-workspace` skill enforces these at the code layer; know them so you don
 - **No modifying user-created content.** Read, summarize, comment, or draft alongside — never edit a doc/event/task the user owns.
 - **No external sharing.** Drive permission changes are blocked; don't share outside `psd401.net`.
 - **Always create-not-modify.** New drafts, events, tasks, files; the marker convention makes agent-created artifacts discoverable.
+- **Create Drive files/Docs/Sheets/Slides ONLY with `--scope agent`, then share explicitly.** Creating them with `--scope user` makes the USER the owner — impersonation — and is hard-blocked (exit 13, no exception, no phrasing gets around it).
 
 **Why:** Phase 1 is a trust-building period — the user must see what the agent does, intervene if wrong, and never wake up to a deleted message or a sent-without-review email.
 

--- a/infra/agent-image/skills/psd-workspace/common.test.js
+++ b/infra/agent-image/skills/psd-workspace/common.test.js
@@ -142,7 +142,10 @@ describe('user-scope file creation is impersonation — hard blocked (2026-07-07
   test('same creations are allowed on the agent slot', () => {
     for (const cmd of [
       `drive files create --json '{"name":"[Agent] x"}'`,
+      `drive files copy --params '{"fileId":"f1"}'`,
       `docs documents create --json '{"title":"Summary"}'`,
+      `sheets spreadsheets create --json '{"properties":{"title":"x"}}'`,
+      `slides presentations create --json '{"title":"x"}'`,
     ]) {
       expect(enforcePhase1Gates(cmd, AGENT_CTX).allowed).toBe(true);
     }

--- a/infra/agent-image/skills/psd-workspace/run.js
+++ b/infra/agent-image/skills/psd-workspace/run.js
@@ -23,6 +23,9 @@
  * Phase 1 hard gates: Send mail, delete operations, and modification of
  * user-created content are blocked at the skill layer regardless of scope —
  * the model cannot bypass these by phrasing the gws command differently.
+ * Additionally, file creation (Drive/Docs/Sheets/Slides) is blocked on the
+ * USER slot: files created there are owned by the user's account
+ * (impersonation). Create with --scope agent and share explicitly.
  *
  * Flow:
  *   1. Phase 1 gate check on --command (forbidden ops → exit 13)


### PR DESCRIPTION
Closes the three advisory items from #1151's review: Rule 8 gets the scope caveat (it's the agent's own refusal quick-reference), run.js docstring updated, agent-slot test coverage extended to all five gated commands. bun 27/27. The deny-id silent-no-op concern is covered by a post-deploy runtime smoke (attempt a subagent spawn → expect refusal). Image-only. Part of #1138.