### PR TITLE
feat(agent): re-enable subagents under a hold-your-turn contract (#1138)

### DIFF
--- a/infra/agent-image/Dockerfile
+++ b/infra/agent-image/Dockerfile
@@ -251,14 +251,18 @@ RUN mkdir -p /home/node/.openclaw/memory
 #   config.model — requires adding a second model to bedrock-proxy. Until
 #   then the sub-agent adds ~5-10s to every turn's wall-clock latency.
 #
-#   tools.deny += sessions_spawn, subagents (2026-07-07, #1138) — OpenClaw
-#   subagents complete silently in THIS deployment: their "results
-#   auto-announce to your requester" lands in the OpenClaw session, but only
-#   an active chat turn can post to Google Chat, so the user never sees it.
-#   Observed live: a skill-audit ran to completion in a subagent and never
-#   reached the user. Long work must stay inline where the router's async-job
-#   promotion (#1147) can catch it. Tool ids verified against
-#   docs/gateway/config-tools.md (group:sessions table).
+#   Subagents (sessions_spawn) are ENABLED — with a behavioral contract.
+#   History (2026-07-07, #1138): they were briefly denied after a subagent's
+#   finished work never reached the user (completion announcements land in
+#   the OpenClaw session; only an ACTIVE chat turn can post to Google Chat).
+#   Product decision (Hagel): the capability is wanted — the failure was the
+#   USAGE pattern (main agent ended its turn while children ran). psd-rules
+#   Rule 15 now enforces hold-your-turn: spawn freely, but keep the turn
+#   open until every subagent reports, then reply. Long waits compose with
+#   the async-job promotion (#1147), which keeps the session delivering past
+#   the 14-min router ceiling. If silent-completion recurs DESPITE Rule 15,
+#   the deny list entries were "sessions_spawn", "subagents" (ids per
+#   OpenClaw docs/gateway/config-tools.md group:sessions).
 #
 #   tools.codeMode.timeoutMs=60000 — code-mode (tool_search_code) VM
 #   execution ceiling, raised from the 10s default to the documented max

--- a/infra/agent-image/openclaw.json
+++ b/infra/agent-image/openclaw.json
@@ -41,7 +41,7 @@
     "codeMode": {
       "timeoutMs": 60000
     },
-    "deny": ["cron", "nodes", "gateway", "sessions_spawn", "subagents"]
+    "deny": ["cron", "nodes", "gateway"]
   },
   "skills": {
     "load": {

--- a/infra/agent-image/skills/psd-rules/SKILL.md
+++ b/infra/agent-image/skills/psd-rules/SKILL.md
@@ -280,17 +280,18 @@ Finding a tool runs a short JS body in an isolated subprocess that exposes **onl
 
 ---
 
-## Rule 15 — No background promises; long work runs INLINE
+## Rule 15 — No background promises; subagents must finish INSIDE your turn
 
-**Never tell the user you will "work in the background," "report back," or "send it when it's done" and then end your turn.** You cannot start a turn on your own — once your turn ends, you are frozen until the user messages again, so every such promise is broken by construction. Subagent spawning is disabled for the same reason: a subagent's completion announcement has no path back to Google Chat (observed 2026-07-07: an audit ran to completion in a subagent and the user never heard anything).
+**Never tell the user you will "work in the background," "report back," or "send it when it's done" and then end your turn.** You cannot start a turn on your own — once your turn ends, you are frozen until the user messages again, so every such promise is broken by construction.
 
-**How to apply:**
+**Subagents are allowed — under a hard contract: HOLD YOUR TURN.**
 
-- Long task? **Do it now, inline, in this turn** — keep working until it is done. If it takes longer than the platform allows, the PLATFORM automatically moves the turn to a real background job and posts "⏳ moved to a background job…" — that system CAN deliver results later; you cannot.
+- Spawn subagents freely for parallel or isolated work (fan-out research, per-item processing).
+- **Never end your turn while any subagent is still running.** Wait for every child to report, collect the results, and deliver them in THIS turn's reply. A subagent that finishes after your turn ends is invisible — its announcement lands in the session where no one is listening (observed 2026-07-07: a completed audit never reached the user).
+- Waiting past the platform's turn limit is fine: the platform moves the turn to a background job ("⏳ moved to a background job…") and the job keeps waiting for your children and posts the result. That path can deliver later; a bare promise cannot.
 - Never end a turn whose last sentence is a promise of future work (also Rule 4).
-- If a turn ends with "⏳ moved to a background job", that was the platform, not you — the job continues your session and will post the result.
 
-**Why:** the model saying "I'll notify you when it's done" is the single most misleading thing it can say — nothing in the architecture makes that true except the platform's own promotion path.
+**Why:** the model saying "I'll notify you when it's done" is misleading unless the platform's own promotion path is the thing doing the notifying. Spawn-and-exit breaks delivery; spawn-and-wait composes with it.
 
 ---
 


### PR DESCRIPTION
Reverts #1151's `sessions_spawn`/`subagents` denial (owner decision: capability is wanted; the failure was spawn-and-exit, not subagents). Rule 15 rewritten to the hold-your-turn contract: spawn freely, never end a turn with children running — waiting composes with #1147's async-job promotion, which delivers past the 14-min ceiling. Impersonation gate + sharing rules untouched. openclaw.json valid; image build's config-validate gate re-checks. Post-deploy smoke: fan-out task delivers in-turn, never silently. Image-only. Part of #1138.