### PR TITLE
feat(agent): writer role for explicitly named district users (#1138)

### DIFF
--- a/infra/agent-image/skills/psd-workspace/SKILL.md
+++ b/infra/agent-image/skills/psd-workspace/SKILL.md
@@ -169,10 +169,10 @@ These cannot be bypassed by phrasing. The skill returns exit code 13 with `statu
 
 **Exception — explicit in-district shares of YOUR OWN files.** `drive.permissions.create` is permitted only on files the agent owns (`--scope agent`), only as `create` (never update/delete), and only in these explicit shapes:
 
-- **Named person in the district:** `type: "user"`, `role: "reader"` or `"commenter"`, `emailAddress` ending `@psd401.net` — the caller or any district colleague.
+- **Named person in the district:** `type: "user"`, `role: "reader"`, `"commenter"`, or `"writer"`, `emailAddress` ending `@psd401.net` — the caller or any district colleague. Writer is for explicitly named individuals only (e.g. each member of a team space, enumerated by name) — when a group needs to edit, grant each person, never the domain.
 - **Whole district, read-only:** `type: "domain"`, `domain: "psd401.net"`, `role: "reader"` — use when a doc's link is going into a shared Chat space so every member can open it.
 
-Never allowed: `type: "anyone"` or `"group"`, external addresses/domains, `writer`/`owner` roles, or any permission change on user-owned files.
+Never allowed: `type: "anyone"` or `"group"`, external addresses/domains, domain-wide `writer`, `owner` transfer, or any permission change on user-owned files.
 
 Examples:
 

--- a/infra/agent-image/skills/psd-workspace/common.js
+++ b/infra/agent-image/skills/psd-workspace/common.js
@@ -467,11 +467,14 @@ const AGENT_SHARE_DOMAIN = (process.env.AGENT_SHARE_DOMAIN || 'psd401.net').toLo
  *     permission changes on user-owned files remain fully blocked)
  *   - create only (update/delete remain blocked)
  *   - EITHER type === 'user' with an @psd401.net emailAddress,
- *     role ∈ {reader, commenter}
+ *     role ∈ {reader, commenter, writer} (writer added 2026-07-08, Hagel:
+ *     explicitly NAMED district individuals may edit agent-owned docs —
+ *     team collaboration on posted docs)
  *   - OR     type === 'domain' with domain === psd401.net, role === 'reader'
- *     (broad in-district visibility for docs posted to shared spaces)
+ *     (broad in-district visibility for docs posted to shared spaces;
+ *     domain-wide stays read-only — district-wide edit is vandalism surface)
  *   - NEVER: type 'anyone' or 'group', external addresses/domains,
- *     writer/owner roles.
+ *     owner transfer.
  *
  * Returns true if the share request fits the explicit in-district shape;
  * false otherwise. False means fall through to the existing block.
@@ -510,8 +513,11 @@ function isPermittedExplicitShare(commandString, context) {
   const domain = typeof perm.domain === 'string' ? perm.domain.toLowerCase() : '';
 
   if (type === 'user') {
-    // Explicit named recipient — must be in-district; reader/commenter only.
-    if (role !== 'reader' && role !== 'commenter') return false;
+    // Explicit named recipient — must be in-district. Writer allowed for
+    // named individuals (2026-07-08); owner transfer never.
+    if (role !== 'reader' && role !== 'commenter' && role !== 'writer') {
+      return false;
+    }
     return emailAddress.endsWith(`@${AGENT_SHARE_DOMAIN}`);
   }
   if (type === 'domain') {

--- a/infra/agent-image/skills/psd-workspace/common.test.js
+++ b/infra/agent-image/skills/psd-workspace/common.test.js
@@ -191,11 +191,19 @@ describe('explicit in-district sharing (widened gate, 2026-07-07)', () => {
     expect(share({ fileId: 'f', type: 'domain', role: 'reader', domain: 'gmail.com' })).toBe(false);
   });
 
-  test('external, anyone, group, and writer stay blocked', () => {
+  test('writer allowed for explicitly NAMED district users (2026-07-08)', () => {
+    expect(share({ fileId: 'f', type: 'user', role: 'writer', emailAddress: 'hagelk@psd401.net' })).toBe(true);
+    expect(share({ fileId: 'f', type: 'user', role: 'writer', emailAddress: 'songstadw@psd401.net' })).toBe(true);
+    // Writer never crosses the district boundary or widens to domain/owner.
+    expect(share({ fileId: 'f', type: 'user', role: 'writer', emailAddress: 'evil@outside.com' })).toBe(false);
+    expect(share({ fileId: 'f', type: 'domain', role: 'writer', domain: 'psd401.net' })).toBe(false);
+    expect(share({ fileId: 'f', type: 'user', role: 'owner', emailAddress: 'hagelk@psd401.net' })).toBe(false);
+  });
+
+  test('external, anyone, and group stay blocked', () => {
     expect(share({ fileId: 'f', type: 'user', role: 'reader', emailAddress: 'evil@outside.com' })).toBe(false);
     expect(share({ fileId: 'f', type: 'anyone', role: 'reader' })).toBe(false);
     expect(share({ fileId: 'f', type: 'group', role: 'reader', emailAddress: 'staff@psd401.net' })).toBe(false);
-    expect(share({ fileId: 'f', type: 'user', role: 'writer', emailAddress: 'hagelk@psd401.net' })).toBe(false);
   });
 
   test('user scope and update/delete remain fully blocked', () => {


### PR DESCRIPTION
Owner decision: named `@psd401.net` individuals may receive `writer` on agent-owned docs (group edit = enumerate members, grant each by name). Domain-wide stays reader-only; owner/anyone/group/external unchanged-blocked; user-owned files untouchable. bun 28/28; run.js functional (named writer → credential stage; owner → exit 13). Image-only. Part of #1138.