### PR TITLE
fix(iam): permission boundary allows PassRole to ecs-tasks for job-runner roles (#1138)

### DIFF
--- a/infra/lib/constructs/security/permission-boundaries/dev-boundary.json
+++ b/infra/lib/constructs/security/permission-boundaries/dev-boundary.json
@@ -53,7 +53,20 @@
       "Action": "iam:PassRole",
       "Resource": "arn:aws:iam::*:role/psd-agent-scheduler-invoke-*",
       "Condition": {
-        "StringEquals": { "iam:PassedToService": "scheduler.amazonaws.com" }
+        "StringEquals": {
+          "iam:PassedToService": "scheduler.amazonaws.com"
+        }
+      }
+    },
+    {
+      "Sid": "AllowPassRoleToEcsTasks",
+      "Effect": "Allow",
+      "Action": "iam:PassRole",
+      "Resource": "arn:aws:iam::*:role/*JobRunner*",
+      "Condition": {
+        "StringEquals": {
+          "iam:PassedToService": "ecs-tasks.amazonaws.com"
+        }
       }
     },
     {

--- a/infra/lib/constructs/security/permission-boundaries/prod-boundary.json
+++ b/infra/lib/constructs/security/permission-boundaries/prod-boundary.json
@@ -73,7 +73,20 @@
       "Action": "iam:PassRole",
       "Resource": "arn:aws:iam::*:role/psd-agent-scheduler-invoke-*",
       "Condition": {
-        "StringEquals": { "iam:PassedToService": "scheduler.amazonaws.com" }
+        "StringEquals": {
+          "iam:PassedToService": "scheduler.amazonaws.com"
+        }
+      }
+    },
+    {
+      "Sid": "AllowPassRoleToEcsTasks",
+      "Effect": "Allow",
+      "Action": "iam:PassRole",
+      "Resource": "arn:aws:iam::*:role/*JobRunner*",
+      "Condition": {
+        "StringEquals": {
+          "iam:PassedToService": "ecs-tasks.amazonaws.com"
+        }
       }
     },
     {


### PR DESCRIPTION
First live job promotion failed: the router's PassRole grant is nullified by the AIStudio permission boundary, which only allowed PassRole to `scheduler.amazonaws.com`. Adds `AllowPassRoleToEcsTasks` (mirrors the scheduler precedent: resource `role/*JobRunner*`, condition `iam:PassedToService=ecs-tasks.amazonaws.com`) to dev AND prod boundaries. dev already allows `ecs:*`, prod allows `ecs:RunTask` — PassRole was the only gap. Fallback worked as designed (failure frame, not silence). CDK-only; redeploy with the same r8 image context. Part of #1138.