### PR TITLE
feat(agent): OpenClaw native program — native tools, native Bedrock provider, honest config, 2026.7.1-beta.2 (#1138)

### DIFF
--- a/infra/agent-image/Dockerfile
+++ b/infra/agent-image/Dockerfile
@@ -35,18 +35,26 @@
 #     smoke test (docs/operations/agent-platform-setup.md) before trusting it.
 #
 # Multi-arch index digest (Docker picks arm64 at build time via --platform):
-#   ghcr.io/openclaw/openclaw:2026.6.11
-#   index: sha256:3814fb1f62f9cfc5944de088c5817c68c88b5d721feebe36420b666a90a61ce7
-#   arm64: sha256:0d5a5edced0af33baea44e0612d72f4d2cf75251613b48ea68ca14727faf2373
+#   ghcr.io/openclaw/openclaw:2026.7.1-beta.2
+#   index: sha256:0e5680d7d58d3b6c08afa0fc992f4ad319b5586f60923e1985b7c6f838c535d5
 #
-# Rollback target (previous good pin):
+# Why a PRERELEASE pin (2026-07-08, #1138): 2026.6.11 (last stable) ships the
+# P1 packaging bug openclaw#99677 — "reconcile is not a function" after every
+# auto-compaction — which aborted a live production run (the 7/6 Plaud task).
+# The fix (openclaw PR #99678) landed in 2026.7.1-beta.2, alongside fixes for
+# empty-reply surfacing (#100456) and compaction prechecks/mid-stream
+# recovery, all of which match failure classes we observed. Move this pin to
+# 2026.7.1 STABLE as soon as it publishes.
+#
+# Rollback targets (previous pins):
+#   2026.6.11  index sha256:3814fb1f62f9cfc5944de088c5817c68c88b5d721feebe36420b666a90a61ce7
 #   2026.4.20  index sha256:5db497263e85f266142ed6206644de4e401c5906cce835865981113c11486d64
 #
 # DO NOT revert to `:latest` or bump without (a) confirming the workspace
 # double-nesting fix by commit ancestry and (b) a clean end-to-end test that
 # includes the Morning Brief payload — a trivial "respond OK" prompt masks
 # session-completion regressions.
-FROM ghcr.io/openclaw/openclaw@sha256:3814fb1f62f9cfc5944de088c5817c68c88b5d721feebe36420b666a90a61ce7
+FROM ghcr.io/openclaw/openclaw@sha256:0e5680d7d58d3b6c08afa0fc992f4ad319b5586f60923e1985b7c6f838c535d5
 
 # Switch to root for installations
 USER root
@@ -199,11 +207,28 @@ RUN mkdir -p /home/node/.openclaw/memory
 # openclaw.json tuning notes (keep here — JSON can't carry comments and
 # OpenClaw's config validator rejects "//" pseudo-keys):
 #
-#   providers.amazon-bedrock — points at Bedrock Mantle, AWS's
-#   OpenAI-compatible endpoint for Bedrock. We used to run a local
-#   bedrock-proxy.js that translated OpenAI → Converse; Mantle removes that
-#   translation layer entirely. Result: we own no per-model format adapter
-#   code; any Bedrock model works by changing the `id` below.
+#   providers.amazon-bedrock — OpenClaw's NATIVE Bedrock provider
+#   (api bedrock-converse-stream, auth aws-sdk → execution-role credentials;
+#   AWS_REGION comes from runtimeEnvVars). Replaced the amazon-bedrock-mantle
+#   route through our local mantle_proxy on 2026-07-08 (#1138): measured
+#   17.7 tok/s median through the proxy path vs ~46 tok/s on Converse with
+#   the us. profile, and the proxy's 300s upstream timeout aborted a live
+#   background job. mantle_proxy.py is still LAUNCHED by the wrapper but is
+#   inert (no provider points at it) — kept as the config-only rollback path;
+#   remove after the native provider has a clean week.
+#   contextWindow is set to the HONEST 200k Converse limit (the prior 1M
+#   claim caused a real "Context overflow" abort); contextTokens 180000
+#   leaves compaction margin below it. params.cacheRetention "long" +
+#   contextPruning cache-ttl are the documented production caching pattern
+#   (heartbeat stays 0m: AgentCore microVMs idle out at 15 min, so a 55m
+#   cache-warm heartbeat can never fire). Model swaps remain one id string.
+#   tools.toolSearch=false (2026-07-08, #1138): toolSearch is an EXPERIMENTAL
+#   off-by-default mode we enabled for the GLM-5 token diet; with it every
+#   action costs search/describe/call round-trips through a JS sandbox
+#   (measured 35 model calls for an 8-API-call task). OpenClaw's docs:
+#   "Direct tool exposure is still the right default for small catalogs" —
+#   ours is ~30 tools, and Sonnet 5's prompt caching makes the schema prefix
+#   cheap. codeMode.timeoutMs is retained (inert unless code-mode returns).
 #
 #   agents.defaults.memorySearch — embedding provider for semantic search over
 #   the agent's local ~/.openclaw/memory/ files. OpenClaw's default provider is

--- a/infra/agent-image/openclaw.json
+++ b/infra/agent-image/openclaw.json
@@ -1,18 +1,17 @@
 {
   "models": {
     "providers": {
-      "amazon-bedrock-mantle": {
-        "baseUrl": "http://127.0.0.1:18791/anthropic",
-        "api": "anthropic-messages",
-        "auth": "api-key",
-        "apiKey": "env:AWS_BEARER_TOKEN_BEDROCK",
+      "amazon-bedrock": {
+        "baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
+        "api": "bedrock-converse-stream",
+        "auth": "aws-sdk",
         "models": [
           {
-            "id": "anthropic.claude-sonnet-5",
-            "name": "Claude Sonnet 5 (via Bedrock Mantle)",
+            "id": "us.anthropic.claude-sonnet-5",
+            "name": "Claude Sonnet 5 (Bedrock Converse, us. cross-region profile)",
             "reasoning": false,
             "input": ["text"],
-            "contextWindow": 1000000,
+            "contextWindow": 200000,
             "maxTokens": 32768,
             "cost": { "input": 3, "output": 15, "cacheRead": 0.3, "cacheWrite": 6 }
           }
@@ -23,10 +22,17 @@
   "agents": {
     "defaults": {
       "model": {
-        "primary": "amazon-bedrock-mantle/anthropic.claude-sonnet-5"
+        "primary": "amazon-bedrock/us.anthropic.claude-sonnet-5"
+      },
+      "params": {
+        "cacheRetention": "long"
       },
       "workspace": "/home/node/.openclaw",
-      "contextTokens": 200000,
+      "contextTokens": 180000,
+      "contextPruning": {
+        "mode": "cache-ttl",
+        "ttl": "1h"
+      },
       "heartbeat": {
         "every": "0m"
       },
@@ -37,7 +43,7 @@
     }
   },
   "tools": {
-    "toolSearch": true,
+    "toolSearch": false,
     "codeMode": {
       "timeoutMs": 60000
     },

--- a/infra/agent-image/skills/psd-rules/SKILL.md
+++ b/infra/agent-image/skills/psd-rules/SKILL.md
@@ -260,39 +260,24 @@ The reply can be one character. It cannot be zero.
 
 ---
 
-## Rule 14 — `tool_search_code` runs in a locked sandbox
+## Rule 14 — Call tools directly; batch multi-item work in ONE call
 
-Finding a tool runs a short JS body in an isolated subprocess that exposes **only** `console.log/warn/error` and `openclaw.tools.search`, `openclaw.tools.describe`, `openclaw.tools.call`. There is **no** `require`, `setTimeout`, `fetch`, `fs`, or network — using them throws `not defined` and wastes a full model round-trip.
+Your tools are exposed natively with schemas — call them directly. There is no `tool_search_code` sandbox, no `openclaw.tools.search/describe/call` API; do not write JavaScript to reach a tool.
 
-- **Search takes a plain string**, never an object: ✅ `openclaw.tools.search("create a calendar event")` ❌ `openclaw.tools.search({query: "..."})`.
-- Pattern: `const hits = await openclaw.tools.search("…"); if (!hits.length) return "No tools found"; const t = await openclaw.tools.describe(hits[0].id); return await openclaw.tools.call(t.id, {…});`
-- Do not import modules or use timers. Keep the body to search → describe → call.
+**Batch multi-item operations in ONE tool call.** Every model round-trip costs seconds of serving latency. N similar operations — sharing a doc with N people, N permission grants, N lookups — run as ONE `exec` call whose command loops, never N separate calls:
 
-**Why:** malformed search bodies (object query, `require`, `setTimeout`) error and retry, and every retry re-reads the entire context — a top token-waste source (observed 2026-07-02).
-
-**Batch multi-item operations in ONE script.** Every `tool_search_code` round-trip costs a full model iteration (~40s+ of serving latency). N similar operations — sharing a doc with N people, N permission grants, N lookups, N sends — go in ONE body with a loop, never N separate calls:
-
-```js
-const people = ["a@psd401.net", "b@psd401.net", "c@psd401.net"];
-const docs = ["<id1>", "<id2>"];
-const results = [];
-for (const doc of docs) for (const email of people) {
-  const r = await openclaw.tools.call("openclaw:core:exec", {command:
-    `node /opt/psd-skills/psd-workspace/run.js --user <caller> --scope agent --command "drive permissions create --json '{\"fileId\":\"${doc}\",\"type\":\"user\",\"role\":\"writer\",\"emailAddress\":\"${email}\"}'"`});
-  results.push({doc, email, ok: !r.error});
-}
-return results;
+```bash
+for EMAIL in whiteb@psd401.net herberr@psd401.net pratzm@psd401.net; do
+  for DOC in <id1> <id2>; do
+    node /opt/psd-skills/psd-workspace/run.js --user <caller> --scope agent \
+      --command "drive permissions create --json '{\"fileId\":\"$DOC\",\"type\":\"user\",\"role\":\"writer\",\"emailAddress\":\"$EMAIL\"}'"
+  done
+done
 ```
 
-**Why:** observed 2026-07-08: granting 2 docs × 4 people as separate calls burned 19 model iterations ≈ 14 minutes on a 30-second task — it hit the platform turn limit and had to be rescued by a background job. Batched, the same task is 3–4 iterations. Stay under the 60s sandbox ceiling: for more than ~10 sequential items, split into chunks of ~8 per call.
+Multi-line payloads still go through `--json-file`/`--body-file`/`--text-file` (write the file first in the same exec).
 
-**Long-running calls (the 60-second sandbox ceiling).** The sandbox kills any `tool_search_code` body after 60 s of execution — a slow inner call (Plaud digest, big gws write, a long exec) dies with `tool_search_code timed out` and you get nothing back, even though the underlying command may have kept running (side effects included).
-
-- **Never block on a slow call.** For any exec that could take more than ~30 s, pass a SHORT `yieldMs` (5000–10000). The call suspends and returns `status: "waiting"` with a `runId` well before the ceiling; resume it with `wait` on that `runId` to collect the result.
-- **Never poll with a long timeout.** A `process poll` timeout must stay ≤ 30000; poll repeatedly in separate tool calls rather than once with 90 s.
-- **If a call times out anyway**, assume its side effects MAY have happened — check before re-running anything that creates or sends.
-
-**Why:** observed 2026-07-06 (#1138): a Plaud digest exec with `yieldMs: 60000` and a 90 s poll both hit the sandbox timeout, the bridge looked "unresponsive," and a multi-step task died mid-run with documents half-created.
+**Why:** observed 2026-07-08 (#1138): granting 2 docs × 4 people as separate calls burned 35 model round-trips ≈ 22 minutes on a 30-second task and ended in a timeout crash. Batched, it is 2–3 round-trips.
 
 ---
 
@@ -303,7 +288,7 @@ return results;
 **Subagents are allowed — under a hard contract: HOLD YOUR TURN.**
 
 - Spawn subagents freely for parallel or isolated work (fan-out research, per-item processing).
-- **Never end your turn while any subagent is still running.** Wait for every child to report, collect the results, and deliver them in THIS turn's reply. A subagent that finishes after your turn ends is invisible — its announcement lands in the session where no one is listening (observed 2026-07-07: a completed audit never reached the user).
+- **Never end your turn while any subagent is still running.** Wait with `sessions_yield` (the supported mechanism — never busy-poll sessions_list/history or shell sleeps), collect every child's report, and deliver the results in THIS turn's reply. A subagent that finishes after your turn ends is invisible — its announcement lands in the session where no one is listening (observed 2026-07-07: a completed audit never reached the user).
 - Waiting past the platform's turn limit is fine: the platform moves the turn to a background job ("⏳ moved to a background job…") and the job keeps waiting for your children and posts the result. That path can deliver later; a bare promise cannot.
 - Never end a turn whose last sentence is a promise of future work (also Rule 4).
 

--- a/infra/lib/agent-platform-stack.ts
+++ b/infra/lib/agent-platform-stack.ts
@@ -491,7 +491,13 @@ export class AgentPlatformStack extends cdk.Stack {
               'bedrock:ConverseStream',
             ],
             resources: [
-              `arn:aws:bedrock:${this.region}::foundation-model/*`,
+              // Cross-region inference profiles (us.*) authorize against the
+              // DESTINATION region's foundation-model ARN — grant all three
+              // regions the us.* profiles span (same lesson as the guardrail
+              // profile, #1138).
+              `arn:aws:bedrock:us-east-1::foundation-model/*`,
+              `arn:aws:bedrock:us-east-2::foundation-model/*`,
+              `arn:aws:bedrock:us-west-2::foundation-model/*`,
               `arn:aws:bedrock:${this.region}:${this.account}:inference-profile/*`,
             ],
           }),
@@ -741,7 +747,12 @@ export class AgentPlatformStack extends cdk.Stack {
         'bedrock:ConverseStream',
       ],
       resources: [
-        `arn:aws:bedrock:${this.region}::foundation-model/*`,
+        // Cross-region us.* profiles authorize against the DESTINATION
+        // region's foundation-model ARN (verified live for the guardrail
+        // profile, #1138) — grant all three regions the profiles span.
+        `arn:aws:bedrock:us-east-1::foundation-model/*`,
+        `arn:aws:bedrock:us-east-2::foundation-model/*`,
+        `arn:aws:bedrock:us-west-2::foundation-model/*`,
         `arn:aws:bedrock:${this.region}:${this.account}:inference-profile/*`,
         // Cross-region inference profiles use region-less format (us, eu, ap)
         // See: https://docs.aws.amazon.com/bedrock/latest/userguide/cross-region-inference.html

--- a/lib/agents/platform-model.ts
+++ b/lib/agents/platform-model.ts
@@ -32,12 +32,16 @@
 export const AGENT_MODEL_ID = "claude-sonnet-5"
 
 /**
- * The model id OpenClaw SENDS to Mantle (the provider model `id` in
- * openclaw.json). Bedrock requires the `anthropic.` foundation-model form on
- * the request; `claude-sonnet-5` alone 404s ("model does not exist"). Distinct
- * from AGENT_MODEL_ID, which is the response/recorded form.
+ * The model id OpenClaw SENDS (the provider model `id` in openclaw.json).
+ * As of the #1138 native-provider program this is the Bedrock CROSS-REGION
+ * INFERENCE PROFILE form (`us.anthropic.…`) used with the native
+ * `amazon-bedrock` Converse provider — the plain foundation-model form is
+ * not invocable on-demand for Sonnet 5. Distinct from AGENT_MODEL_ID, the
+ * wrapper's recorded-fallback form; migration 092 seeds pricing for both
+ * plus the `anthropic.…` alias, and notes Converse echoes the `us.…` form
+ * on responses.
  */
-export const AGENT_REQUEST_MODEL_ID = "anthropic.claude-sonnet-5"
+export const AGENT_REQUEST_MODEL_ID = "us.anthropic.claude-sonnet-5"
 
 /** Human label for AGENT_MODEL_ID shown in the cost UI. */
 export const AGENT_MODEL_LABEL = "Claude Sonnet 5"


### PR DESCRIPTION
Implements decision-brief v2 (approved): run OpenClaw per its own docs instead of rebuilding. (1) `toolSearch: false` — the experimental sandbox mode drove 35 round-trips/task; Rule 14 rewritten for native tools + one-exec batching. (2) Native `amazon-bedrock` provider (Converse streaming, aws-sdk auth) replaces our mantle_proxy (17.7→~46 tok/s measured; kills the 300s-timeout crash class; proxy kept inert for rollback). (3) Honest contextWindow 200k (the 1M claim caused the overflow abort) + cacheRetention long + cache-ttl pruning. (4) Base image → 2026.7.1-beta.2 pinned digest (fixes openclaw#99677 reconcile abort + empty-reply + compaction prechecks; move to stable when published). IAM: foundation-model grants widened to the three us.* profile destination regions on both invoke statements. Python 113 OK, bun 28/28, synth clean; beta.2 schema validated at image build. Part of #1138.