### PR TITLE
fix(agent): direct-Mantle provider — the working, probed serving path (#1138)

### DIFF
--- a/infra/agent-image/Dockerfile
+++ b/infra/agent-image/Dockerfile
@@ -207,15 +207,25 @@ RUN mkdir -p /home/node/.openclaw/memory
 # openclaw.json tuning notes (keep here — JSON can't carry comments and
 # OpenClaw's config validator rejects "//" pseudo-keys):
 #
-#   providers.amazon-bedrock — OpenClaw's NATIVE Bedrock provider
-#   (api bedrock-converse-stream, auth aws-sdk → execution-role credentials;
-#   AWS_REGION comes from runtimeEnvVars). Replaced the amazon-bedrock-mantle
-#   route through our local mantle_proxy on 2026-07-08 (#1138): measured
-#   17.7 tok/s median through the proxy path vs ~46 tok/s on Converse with
-#   the us. profile, and the proxy's 300s upstream timeout aborted a live
-#   background job. mantle_proxy.py is still LAUNCHED by the wrapper but is
-#   inert (no provider points at it) — kept as the config-only rollback path;
-#   remove after the native provider has a clean week.
+#   providers.amazon-bedrock-mantle — DIRECT to Bedrock Mantle's
+#   anthropic-messages endpoint (https://bedrock-mantle.us-east-1.api.aws),
+#   NO local proxy in the path (#1138, 2026-07-08). History: our
+#   mantle_proxy added full-body logging overhead and a 300s upstream
+#   timeout that aborted a live background job; measured 17.7 tok/s median
+#   through the proxy vs 36-71 tok/s hitting Mantle directly (same prompt,
+#   same model). Auth: Mantle accepts the bearer token via the x-api-key
+#   header (verified live), which is what OpenClaw's anthropic-messages
+#   provider sends; the wrapper still INLINES the literal token into this
+#   provider's apiKey at boot because OpenClaw does not resolve the
+#   env:AWS_BEARER_TOKEN_BEDROCK indirection on this path (verified with a
+#   header-capture probe — the literal string "env:..." went on the wire).
+#   NOTE: the bedrock-converse-stream native provider was attempted first
+#   and ABANDONED: the amazon-bedrock extension exists in the OpenClaw repo
+#   at this tag but is NOT shipped in the distribution image, and vendoring
+#   it via plugins.load.paths loads but never registers its API handler on
+#   this build. Revisit when a stable release ships the extension.
+#   mantle_proxy.py is still launched by the wrapper but nothing points at
+#   it; remove after direct-Mantle has a clean week.
 #   contextWindow is set to the HONEST 200k Converse limit (the prior 1M
 #   claim caused a real "Context overflow" abort); contextTokens 180000
 #   leaves compaction margin below it. params.cacheRetention "long" +

--- a/infra/agent-image/openclaw.json
+++ b/infra/agent-image/openclaw.json
@@ -1,14 +1,15 @@
 {
   "models": {
     "providers": {
-      "amazon-bedrock": {
-        "baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
-        "api": "bedrock-converse-stream",
-        "auth": "aws-sdk",
+      "amazon-bedrock-mantle": {
+        "baseUrl": "https://bedrock-mantle.us-east-1.api.aws/anthropic",
+        "api": "anthropic-messages",
+        "auth": "api-key",
+        "apiKey": "env:AWS_BEARER_TOKEN_BEDROCK",
         "models": [
           {
-            "id": "us.anthropic.claude-sonnet-5",
-            "name": "Claude Sonnet 5 (Bedrock Converse, us. cross-region profile)",
+            "id": "anthropic.claude-sonnet-5",
+            "name": "Claude Sonnet 5 (Bedrock Mantle, direct)",
             "reasoning": false,
             "input": ["text"],
             "contextWindow": 200000,
@@ -22,7 +23,7 @@
   "agents": {
     "defaults": {
       "model": {
-        "primary": "amazon-bedrock/us.anthropic.claude-sonnet-5"
+        "primary": "amazon-bedrock-mantle/anthropic.claude-sonnet-5"
       },
       "params": {
         "cacheRetention": "long"

--- a/lib/agents/platform-model.ts
+++ b/lib/agents/platform-model.ts
@@ -33,15 +33,14 @@ export const AGENT_MODEL_ID = "claude-sonnet-5"
 
 /**
  * The model id OpenClaw SENDS (the provider model `id` in openclaw.json).
- * As of the #1138 native-provider program this is the Bedrock CROSS-REGION
- * INFERENCE PROFILE form (`us.anthropic.…`) used with the native
- * `amazon-bedrock` Converse provider — the plain foundation-model form is
- * not invocable on-demand for Sonnet 5. Distinct from AGENT_MODEL_ID, the
- * wrapper's recorded-fallback form; migration 092 seeds pricing for both
- * plus the `anthropic.…` alias, and notes Converse echoes the `us.…` form
- * on responses.
+ * The provider talks DIRECTLY to Bedrock Mantle's anthropic-messages
+ * endpoint (#1138: the local logging proxy is out of the path; Mantle
+ * accepts x-api-key with the bearer token — verified live), and Mantle
+ * requires the `anthropic.` foundation-model form on the request. The
+ * short-lived us.-profile form from the abandoned bedrock-converse-stream
+ * attempt is still priced in migration 092 as an alias.
  */
-export const AGENT_REQUEST_MODEL_ID = "us.anthropic.claude-sonnet-5"
+export const AGENT_REQUEST_MODEL_ID = "anthropic.claude-sonnet-5"
 
 /** Human label for AGENT_MODEL_ID shown in the cost UI. */
 export const AGENT_MODEL_LABEL = "Claude Sonnet 5"


### PR DESCRIPTION
Replaces #1157's `bedrock-converse-stream` provider, which cannot work on any published OpenClaw image (the amazon-bedrock extension isn't shipped; vendoring loads but never registers the API handler — all variants probed). Decisive finding: **Mantle direct is 36–71 tok/s** — our logging proxy was the slow layer (17.7 tok/s median), not Mantle. Config: real Mantle endpoint, months-proven anthropic-messages shape, wrapper token-inlining path intact (Mantle accepts x-api-key — verified; OpenClaw doesn't resolve env: indirection — header-capture verified). Everything else from #1157 stays (toolSearch off, honest window, caching, beta.2). **Probed end-to-end locally: full agent turn on the r11 image + this config = correct answer in 5.0s including boot.** platform-model 4/4; suites OK. Part of #1138.