### PR TITLE
feat: #1100 - live describe_capabilities MCP meta-tool + psd-aistudio skill

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,9 @@ jobs:
     - name: Check generated tool-catalog OpenAPI is in sync
       run: bun run openapi:check
 
+    - name: Check generated capability catalog is in sync
+      run: bun run capabilities:check
+
     - name: Run tests
       run: bun run test:ci
       env:

--- a/docs/API/v1/generated/capability-catalog.json
+++ b/docs/API/v1/generated/capability-catalog.json
@@ -1,0 +1,606 @@
+{
+  "summary": {
+    "actions": 24,
+    "features": 8,
+    "scopes": 24,
+    "agentInvocableActions": 17
+  },
+  "actions": [
+    {
+      "identifier": "assistants.execute",
+      "name": "execute_assistant",
+      "description": "Execute an AI assistant with the given inputs and return the final text result.",
+      "surfaces": [
+        "mcp",
+        "internal",
+        "rest"
+      ],
+      "requiredScopes": [
+        "mcp:execute_assistant"
+      ],
+      "destructive": false,
+      "agentInvocable": true
+    },
+    {
+      "identifier": "assistants.list",
+      "name": "list_assistants",
+      "description": "List AI assistants the authenticated user has access to execute.",
+      "surfaces": [
+        "mcp",
+        "internal",
+        "rest"
+      ],
+      "requiredScopes": [
+        "mcp:list_assistants"
+      ],
+      "destructive": false,
+      "agentInvocable": true
+    },
+    {
+      "identifier": "chat.code_interpreter",
+      "name": "code_interpreter",
+      "description": "Execute code and perform data analysis.",
+      "surfaces": [
+        "ai_sdk"
+      ],
+      "requiredScopes": [
+        "chat:write"
+      ],
+      "destructive": false,
+      "agentInvocable": false
+    },
+    {
+      "identifier": "chat.generate_image",
+      "name": "generateImage",
+      "description": "Generate images from text descriptions using AI models like GPT-Image-1, DALL-E 3, and Imagen 4.",
+      "surfaces": [
+        "ai_sdk"
+      ],
+      "requiredScopes": [
+        "chat:write"
+      ],
+      "destructive": false,
+      "agentInvocable": false
+    },
+    {
+      "identifier": "chat.show_chart",
+      "name": "show_chart",
+      "description": "Render a chart (bar, line, pie, etc.) from structured data on the client.",
+      "surfaces": [
+        "ai_sdk"
+      ],
+      "requiredScopes": [],
+      "destructive": false,
+      "agentInvocable": false
+    },
+    {
+      "identifier": "chat.web_search",
+      "name": "web_search_preview",
+      "description": "Search the web for current information and facts.",
+      "surfaces": [
+        "ai_sdk"
+      ],
+      "requiredScopes": [
+        "chat:write"
+      ],
+      "destructive": false,
+      "agentInvocable": false
+    },
+    {
+      "identifier": "content.create_artifact",
+      "name": "create_artifact",
+      "description": "Create an interactive artifact (HTML/JS or JSX) content object. Does not publish. Returns the object id, slug, and reader link.",
+      "surfaces": [
+        "mcp",
+        "internal"
+      ],
+      "requiredScopes": [
+        "content:create"
+      ],
+      "destructive": true,
+      "agentInvocable": true
+    },
+    {
+      "identifier": "content.create_document",
+      "name": "create_document",
+      "description": "Create a document (markdown) content object. Does not publish. Returns the object id, slug, and reader link.",
+      "surfaces": [
+        "mcp",
+        "internal"
+      ],
+      "requiredScopes": [
+        "content:create"
+      ],
+      "destructive": true,
+      "agentInvocable": true
+    },
+    {
+      "identifier": "content.create_version",
+      "name": "create_version",
+      "description": "Add a new version with new body content and an optional change summary.",
+      "surfaces": [
+        "mcp",
+        "internal"
+      ],
+      "requiredScopes": [
+        "content:update"
+      ],
+      "destructive": true,
+      "agentInvocable": true
+    },
+    {
+      "identifier": "content.export_okf",
+      "name": "export_okf",
+      "description": "Export a collection subtree as a portable Open Knowledge Format (OKF v0.1) bundle: one markdown-with-frontmatter concept file per content object, an index.md per collection, and a log.md change history. Every object is filtered by the caller's view permission. A 'public' audience produces an anonymous-safe (public-visibility-only) bundle and requires content:publish_public — without it the call returns a structured approval_required signal. Returns the bundle files inline plus its S3 location.",
+      "surfaces": [
+        "mcp",
+        "internal"
+      ],
+      "requiredScopes": [
+        "content:read"
+      ],
+      "destructive": false,
+      "agentInvocable": true
+    },
+    {
+      "identifier": "content.get",
+      "name": "get_content",
+      "description": "Fetch a content object and its current version by id or slug. Permission-checked (404 when not viewable).",
+      "surfaces": [
+        "mcp",
+        "internal"
+      ],
+      "requiredScopes": [
+        "content:read"
+      ],
+      "destructive": false,
+      "agentInvocable": true
+    },
+    {
+      "identifier": "content.import_okf",
+      "name": "import_okf",
+      "description": "Import an Open Knowledge Format bundle (the { files: [{ path, content }] } shape export_okf returns) into Atrium content. Reconstructs the collection tree from the bundle directories and creates one content object per concept file. Imported objects are agent-authored (actor_kind='agent') and created private + draft. Returns the created object + collection ids.",
+      "surfaces": [
+        "mcp",
+        "internal"
+      ],
+      "requiredScopes": [
+        "content:create"
+      ],
+      "destructive": true,
+      "agentInvocable": true
+    },
+    {
+      "identifier": "content.list",
+      "name": "list_content",
+      "description": "List content the caller may view. Filterable by kind, collection, tag, status, and title text.",
+      "surfaces": [
+        "mcp",
+        "internal"
+      ],
+      "requiredScopes": [
+        "content:read"
+      ],
+      "destructive": false,
+      "agentInvocable": true
+    },
+    {
+      "identifier": "content.publish",
+      "name": "publish_content",
+      "description": "Publish a content object to a destination. Public destinations require the human-held content:publish_public; without it the call returns a structured approval_required signal. 'okf' serializes the single object to a portable Open Knowledge Format concept bundle in S3 (internal-publish authority).",
+      "surfaces": [
+        "mcp",
+        "internal"
+      ],
+      "requiredScopes": [
+        "content:publish_internal"
+      ],
+      "destructive": true,
+      "agentInvocable": true
+    },
+    {
+      "identifier": "content.set_visibility",
+      "name": "set_visibility",
+      "description": "Set who can view the object (level + group grants).",
+      "surfaces": [
+        "mcp",
+        "internal"
+      ],
+      "requiredScopes": [
+        "content:update"
+      ],
+      "destructive": true,
+      "agentInvocable": true
+    },
+    {
+      "identifier": "content.unpublish",
+      "name": "unpublish_content",
+      "description": "Unpublish (take down) a content object from a destination. Idempotent: unpublishing an object that is not live there returns unpublished: false rather than erroring. Taking down a public-facing destination requires the human-held content:publish_public; without it the call returns a structured approval_required signal — the same §26.4 authority needed to publish it. Mirrors DELETE /api/v1/content/{id}/publish/{destination} (no okf: an okf publication is a serialized S3 bundle with no live surface to take down).",
+      "surfaces": [
+        "mcp",
+        "internal"
+      ],
+      "requiredScopes": [
+        "content:publish_internal"
+      ],
+      "destructive": true,
+      "agentInvocable": true
+    },
+    {
+      "identifier": "content.update",
+      "name": "update_content",
+      "description": "Update object metadata (title, tags, collection, status). Body changes use create_version.",
+      "surfaces": [
+        "mcp",
+        "internal"
+      ],
+      "requiredScopes": [
+        "content:update"
+      ],
+      "destructive": true,
+      "agentInvocable": true
+    },
+    {
+      "identifier": "decisions.capture",
+      "name": "capture_decision",
+      "description": "Capture a structured decision with full context (evidence, constraints, reasoning, alternatives). Creates a decision subgraph with completeness scoring.\n\nExample:\n{\n  \"decision\": \"Use PostgreSQL for data layer\",\n  \"decidedBy\": \"Engineering Team\",\n  \"reasoning\": \"Strong ACID guarantees needed for financial data\",\n  \"evidence\": [\"Benchmark shows 3x throughput vs MySQL\"],\n  \"constraints\": [\"Must support JSONB queries\"],\n  \"conditions\": [\"Revisit if write volume exceeds 50k ops/s\"],\n  \"alternatives_considered\": [\"MongoDB\", \"DynamoDB\"],\n  \"relatedTo\": [\"550e8400-e29b-41d4-a716-446655440000\"]\n}",
+      "surfaces": [
+        "mcp",
+        "internal"
+      ],
+      "requiredScopes": [
+        "mcp:capture_decision"
+      ],
+      "destructive": true,
+      "agentInvocable": true
+    },
+    {
+      "identifier": "decisions.graph_get",
+      "name": "get_decision_graph",
+      "description": "Get details of a specific decision node and all its connections (incoming and outgoing edges).",
+      "surfaces": [
+        "mcp",
+        "internal"
+      ],
+      "requiredScopes": [
+        "mcp:get_decision_graph"
+      ],
+      "destructive": false,
+      "agentInvocable": true
+    },
+    {
+      "identifier": "decisions.search",
+      "name": "search_decisions",
+      "description": "Search decision graph nodes by type, class, or text query. Returns paginated results.",
+      "surfaces": [
+        "mcp",
+        "internal"
+      ],
+      "requiredScopes": [
+        "mcp:search_decisions"
+      ],
+      "destructive": false,
+      "agentInvocable": true
+    },
+    {
+      "identifier": "documents.create",
+      "name": "generate_document",
+      "description": "Generate a downloadable document from text content and return a URL. Supported formats: pdf, docx (Word), xlsx (Excel — content is CSV rows), pptx (PowerPoint — slides separated by a line containing only '---'), and md/html/txt/csv. Use to deliver reports, spreadsheets, or slide decks.",
+      "surfaces": [
+        "internal"
+      ],
+      "requiredScopes": [
+        "chat:write"
+      ],
+      "destructive": false,
+      "agentInvocable": false
+    },
+    {
+      "identifier": "images.generate",
+      "name": "generate_image",
+      "description": "Generate an image from a text prompt using the platform's configured image model. Returns a URL to the generated image (stored securely). Use for diagrams, illustrations, or visual assets requested by the user.",
+      "surfaces": [
+        "internal"
+      ],
+      "requiredScopes": [
+        "chat:write"
+      ],
+      "destructive": false,
+      "agentInvocable": false
+    },
+    {
+      "identifier": "platform.describe_capabilities",
+      "name": "describe_capabilities",
+      "description": "Describe what AI Studio can do, live from the app's own registries. Returns invocable actions (with the surfaces/scopes each needs and whether the agent can invoke it over MCP), role-gated UI features to steer users toward, and a scope reference. Use this to discover current capabilities instead of relying on a static list.",
+      "surfaces": [
+        "mcp",
+        "internal"
+      ],
+      "requiredScopes": [
+        "platform:read"
+      ],
+      "destructive": false,
+      "agentInvocable": true
+    },
+    {
+      "identifier": "web.fetch",
+      "name": "web_fetch",
+      "description": "Fetch a single public web page over HTTPS and return its readable text content (scripts, styles, and markup stripped). Use to read documentation, articles, or reference pages the user links to. Private/internal hosts are blocked.",
+      "surfaces": [
+        "internal"
+      ],
+      "requiredScopes": [
+        "chat:write"
+      ],
+      "destructive": false,
+      "agentInvocable": false
+    }
+  ],
+  "features": [
+    {
+      "identifier": "assistant-architect",
+      "name": "Assistant Architect",
+      "description": "Build and schedule custom multi-step AI assistants.",
+      "defaultRoles": [
+        "administrator",
+        "staff"
+      ],
+      "humanDriven": true
+    },
+    {
+      "identifier": "atrium-content",
+      "name": "Atrium Content",
+      "description": "Create and version Atrium content objects (documents and artifacts).",
+      "defaultRoles": [
+        "administrator",
+        "staff"
+      ],
+      "humanDriven": true
+    },
+    {
+      "identifier": "decision-capture",
+      "name": "Decision Capture",
+      "description": "Extract and capture decisions from meeting transcripts into the context graph.",
+      "defaultRoles": [
+        "administrator"
+      ],
+      "humanDriven": true
+    },
+    {
+      "identifier": "internal-performance-monitoring",
+      "name": "Internal Performance Monitoring",
+      "description": "Access internal performance monitoring dashboards and metrics.",
+      "defaultRoles": [
+        "administrator"
+      ],
+      "humanDriven": true
+    },
+    {
+      "identifier": "internal-system-administration",
+      "name": "Internal System Administration",
+      "description": "Access internal system administration tooling and diagnostics.",
+      "defaultRoles": [
+        "administrator"
+      ],
+      "humanDriven": true
+    },
+    {
+      "identifier": "knowledge-repositories",
+      "name": "Knowledge Repositories",
+      "description": "Manage knowledge bases and document repositories for AI assistants.",
+      "defaultRoles": [
+        "administrator"
+      ],
+      "humanDriven": true
+    },
+    {
+      "identifier": "model-compare",
+      "name": "Model Compare",
+      "description": "Compare AI model responses side-by-side.",
+      "defaultRoles": [
+        "administrator",
+        "staff"
+      ],
+      "humanDriven": true
+    },
+    {
+      "identifier": "voice-mode",
+      "name": "Voice Mode",
+      "description": "Real-time voice conversations in Nexus using AI speech providers.",
+      "defaultRoles": [
+        "administrator"
+      ],
+      "humanDriven": true
+    }
+  ],
+  "scopes": [
+    {
+      "scope": "assistants:execute",
+      "description": "Execute any assistant via API",
+      "roles": [
+        "staff",
+        "administrator"
+      ]
+    },
+    {
+      "scope": "assistants:list",
+      "description": "List assistants available for API execution",
+      "roles": [
+        "staff",
+        "administrator"
+      ]
+    },
+    {
+      "scope": "assistants:read",
+      "description": "List and view assistant architects",
+      "roles": [
+        "staff",
+        "administrator"
+      ]
+    },
+    {
+      "scope": "assistants:write",
+      "description": "Create and modify assistant architects",
+      "roles": [
+        "administrator"
+      ]
+    },
+    {
+      "scope": "chat:read",
+      "description": "Read chat conversations",
+      "roles": [
+        "student",
+        "staff",
+        "administrator"
+      ]
+    },
+    {
+      "scope": "chat:write",
+      "description": "Create and send chat messages",
+      "roles": [
+        "student",
+        "staff",
+        "administrator"
+      ]
+    },
+    {
+      "scope": "content:create",
+      "description": "Create Atrium content objects and initial versions",
+      "roles": [
+        "staff",
+        "administrator"
+      ]
+    },
+    {
+      "scope": "content:delegate",
+      "description": "Mint delegated Atrium content tokens on behalf of a user",
+      "roles": [
+        "administrator"
+      ]
+    },
+    {
+      "scope": "content:publish_internal",
+      "description": "Publish Atrium content to internal destinations",
+      "roles": [
+        "staff",
+        "administrator"
+      ]
+    },
+    {
+      "scope": "content:publish_public",
+      "description": "Publish Atrium content publicly",
+      "roles": [
+        "administrator"
+      ]
+    },
+    {
+      "scope": "content:read",
+      "description": "Read Atrium content objects and versions",
+      "roles": [
+        "staff",
+        "administrator"
+      ]
+    },
+    {
+      "scope": "content:update",
+      "description": "Update Atrium content object metadata and create new versions",
+      "roles": [
+        "staff",
+        "administrator"
+      ]
+    },
+    {
+      "scope": "documents:read",
+      "description": "Read documents and attachments",
+      "roles": [
+        "staff",
+        "administrator"
+      ]
+    },
+    {
+      "scope": "documents:write",
+      "description": "Upload and manage documents",
+      "roles": [
+        "administrator"
+      ]
+    },
+    {
+      "scope": "graph:read",
+      "description": "Read context graph nodes and edges",
+      "roles": [
+        "staff",
+        "administrator"
+      ]
+    },
+    {
+      "scope": "graph:write",
+      "description": "Create, update, and delete graph nodes and edges",
+      "roles": [
+        "administrator"
+      ]
+    },
+    {
+      "scope": "mcp:capture_decision",
+      "description": "Create decision graph nodes and edges via MCP",
+      "roles": [
+        "administrator"
+      ]
+    },
+    {
+      "scope": "mcp:execute_assistant",
+      "description": "Execute an assistant via MCP",
+      "roles": [
+        "administrator"
+      ]
+    },
+    {
+      "scope": "mcp:get_decision_graph",
+      "description": "Get decision node details and connections via MCP",
+      "roles": [
+        "staff",
+        "administrator"
+      ]
+    },
+    {
+      "scope": "mcp:list_assistants",
+      "description": "List available assistants via MCP",
+      "roles": [
+        "staff",
+        "administrator"
+      ]
+    },
+    {
+      "scope": "mcp:search_decisions",
+      "description": "Search decision graph nodes via MCP",
+      "roles": [
+        "staff",
+        "administrator"
+      ]
+    },
+    {
+      "scope": "models:read",
+      "description": "List available AI models",
+      "roles": [
+        "staff",
+        "administrator"
+      ]
+    },
+    {
+      "scope": "platform:read",
+      "description": "Read the AI Studio capability catalog (actions, features, scopes)",
+      "roles": [
+        "student",
+        "staff",
+        "administrator"
+      ]
+    },
+    {
+      "scope": "tools:read",
+      "description": "List and view tool catalog entries and their versions",
+      "roles": [
+        "staff",
+        "administrator"
+      ]
+    }
+  ]
+}

--- a/docs/API/v1/generated/capability-catalog.json
+++ b/docs/API/v1/generated/capability-catalog.json
@@ -18,6 +18,17 @@
       "requiredScopes": [
         "mcp:execute_assistant"
       ],
+      "scopesBySurface": {
+        "mcp": [
+          "mcp:execute_assistant"
+        ],
+        "internal": [
+          "mcp:execute_assistant"
+        ],
+        "rest": [
+          "assistants:execute"
+        ]
+      },
       "destructive": false,
       "agentInvocable": true
     },
@@ -33,6 +44,17 @@
       "requiredScopes": [
         "mcp:list_assistants"
       ],
+      "scopesBySurface": {
+        "mcp": [
+          "mcp:list_assistants"
+        ],
+        "internal": [
+          "mcp:list_assistants"
+        ],
+        "rest": [
+          "assistants:list"
+        ]
+      },
       "destructive": false,
       "agentInvocable": true
     },
@@ -46,6 +68,11 @@
       "requiredScopes": [
         "chat:write"
       ],
+      "scopesBySurface": {
+        "ai_sdk": [
+          "chat:write"
+        ]
+      },
       "destructive": false,
       "agentInvocable": false
     },
@@ -59,6 +86,11 @@
       "requiredScopes": [
         "chat:write"
       ],
+      "scopesBySurface": {
+        "ai_sdk": [
+          "chat:write"
+        ]
+      },
       "destructive": false,
       "agentInvocable": false
     },
@@ -70,6 +102,9 @@
         "ai_sdk"
       ],
       "requiredScopes": [],
+      "scopesBySurface": {
+        "ai_sdk": []
+      },
       "destructive": false,
       "agentInvocable": false
     },
@@ -83,6 +118,11 @@
       "requiredScopes": [
         "chat:write"
       ],
+      "scopesBySurface": {
+        "ai_sdk": [
+          "chat:write"
+        ]
+      },
       "destructive": false,
       "agentInvocable": false
     },
@@ -97,6 +137,14 @@
       "requiredScopes": [
         "content:create"
       ],
+      "scopesBySurface": {
+        "mcp": [
+          "content:create"
+        ],
+        "internal": [
+          "content:create"
+        ]
+      },
       "destructive": true,
       "agentInvocable": true
     },
@@ -111,6 +159,14 @@
       "requiredScopes": [
         "content:create"
       ],
+      "scopesBySurface": {
+        "mcp": [
+          "content:create"
+        ],
+        "internal": [
+          "content:create"
+        ]
+      },
       "destructive": true,
       "agentInvocable": true
     },
@@ -125,6 +181,14 @@
       "requiredScopes": [
         "content:update"
       ],
+      "scopesBySurface": {
+        "mcp": [
+          "content:update"
+        ],
+        "internal": [
+          "content:update"
+        ]
+      },
       "destructive": true,
       "agentInvocable": true
     },
@@ -139,6 +203,14 @@
       "requiredScopes": [
         "content:read"
       ],
+      "scopesBySurface": {
+        "mcp": [
+          "content:read"
+        ],
+        "internal": [
+          "content:read"
+        ]
+      },
       "destructive": false,
       "agentInvocable": true
     },
@@ -153,6 +225,14 @@
       "requiredScopes": [
         "content:read"
       ],
+      "scopesBySurface": {
+        "mcp": [
+          "content:read"
+        ],
+        "internal": [
+          "content:read"
+        ]
+      },
       "destructive": false,
       "agentInvocable": true
     },
@@ -167,6 +247,14 @@
       "requiredScopes": [
         "content:create"
       ],
+      "scopesBySurface": {
+        "mcp": [
+          "content:create"
+        ],
+        "internal": [
+          "content:create"
+        ]
+      },
       "destructive": true,
       "agentInvocable": true
     },
@@ -181,6 +269,14 @@
       "requiredScopes": [
         "content:read"
       ],
+      "scopesBySurface": {
+        "mcp": [
+          "content:read"
+        ],
+        "internal": [
+          "content:read"
+        ]
+      },
       "destructive": false,
       "agentInvocable": true
     },
@@ -195,6 +291,14 @@
       "requiredScopes": [
         "content:publish_internal"
       ],
+      "scopesBySurface": {
+        "mcp": [
+          "content:publish_internal"
+        ],
+        "internal": [
+          "content:publish_internal"
+        ]
+      },
       "destructive": true,
       "agentInvocable": true
     },
@@ -209,6 +313,14 @@
       "requiredScopes": [
         "content:update"
       ],
+      "scopesBySurface": {
+        "mcp": [
+          "content:update"
+        ],
+        "internal": [
+          "content:update"
+        ]
+      },
       "destructive": true,
       "agentInvocable": true
     },
@@ -223,6 +335,14 @@
       "requiredScopes": [
         "content:publish_internal"
       ],
+      "scopesBySurface": {
+        "mcp": [
+          "content:publish_internal"
+        ],
+        "internal": [
+          "content:publish_internal"
+        ]
+      },
       "destructive": true,
       "agentInvocable": true
     },
@@ -237,6 +357,14 @@
       "requiredScopes": [
         "content:update"
       ],
+      "scopesBySurface": {
+        "mcp": [
+          "content:update"
+        ],
+        "internal": [
+          "content:update"
+        ]
+      },
       "destructive": true,
       "agentInvocable": true
     },
@@ -251,6 +379,14 @@
       "requiredScopes": [
         "mcp:capture_decision"
       ],
+      "scopesBySurface": {
+        "mcp": [
+          "mcp:capture_decision"
+        ],
+        "internal": [
+          "mcp:capture_decision"
+        ]
+      },
       "destructive": true,
       "agentInvocable": true
     },
@@ -265,6 +401,14 @@
       "requiredScopes": [
         "mcp:get_decision_graph"
       ],
+      "scopesBySurface": {
+        "mcp": [
+          "mcp:get_decision_graph"
+        ],
+        "internal": [
+          "mcp:get_decision_graph"
+        ]
+      },
       "destructive": false,
       "agentInvocable": true
     },
@@ -279,6 +423,14 @@
       "requiredScopes": [
         "mcp:search_decisions"
       ],
+      "scopesBySurface": {
+        "mcp": [
+          "mcp:search_decisions"
+        ],
+        "internal": [
+          "mcp:search_decisions"
+        ]
+      },
       "destructive": false,
       "agentInvocable": true
     },
@@ -292,6 +444,11 @@
       "requiredScopes": [
         "chat:write"
       ],
+      "scopesBySurface": {
+        "internal": [
+          "chat:write"
+        ]
+      },
       "destructive": false,
       "agentInvocable": false
     },
@@ -305,6 +462,11 @@
       "requiredScopes": [
         "chat:write"
       ],
+      "scopesBySurface": {
+        "internal": [
+          "chat:write"
+        ]
+      },
       "destructive": false,
       "agentInvocable": false
     },
@@ -319,6 +481,14 @@
       "requiredScopes": [
         "platform:read"
       ],
+      "scopesBySurface": {
+        "mcp": [
+          "platform:read"
+        ],
+        "internal": [
+          "platform:read"
+        ]
+      },
       "destructive": false,
       "agentInvocable": true
     },
@@ -332,6 +502,11 @@
       "requiredScopes": [
         "chat:write"
       ],
+      "scopesBySurface": {
+        "internal": [
+          "chat:write"
+        ]
+      },
       "destructive": false,
       "agentInvocable": false
     }

--- a/infra/agent-image/skills/psd-aistudio/SKILL.md
+++ b/infra/agent-image/skills/psd-aistudio/SKILL.md
@@ -22,9 +22,12 @@ web-app feature.
 `capabilities` returns three clearly separated sections:
 
 - **`actions[]`** — invocable tools. Each carries the `surfaces` it is exposed
-  on, the `requiredScopes` to call it, `destructive` (writes/deletes), and
-  **`agentInvocable`** — `true` when *you* can invoke it over MCP (surface
-  includes `mcp`), `false` when it exists but isn't reachable from here.
+  on, `requiredScopes` (the scope for the requested `--surface`, else the base
+  MCP scope), `scopesBySurface` (the exact scope needed on *each* surface — e.g.
+  `assistants:execute` on REST vs `mcp:execute_assistant` on MCP), `destructive`
+  (writes/deletes), and **`agentInvocable`** — `true` when *you* can invoke it
+  over MCP (surface includes `mcp`), `false` when it exists but isn't reachable
+  from here.
 - **`features[]`** — role-gated **web-app** features (Assistant Architect, Model
   Compare, Knowledge Repositories, Voice Mode, Atrium, …). These are
   human-driven UI you **steer the user to**; you cannot invoke them. Each lists

--- a/infra/agent-image/skills/psd-aistudio/SKILL.md
+++ b/infra/agent-image/skills/psd-aistudio/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: psd-aistudio
+summary: Live, always-current view of what AI Studio can do — invocable MCP actions and the web-app features to steer users toward — projected from the app's own source-of-truth registries via the describe_capabilities MCP meta-tool.
+description: Use this to know what AI Studio can currently do before you answer "can AI Studio…?" or steer a user to a feature. It calls AI Studio's describe_capabilities meta-tool over the existing /api/mcp endpoint, which projects the deployed app's own registries live, so new features appear the moment they deploy — never rely on a static list. Read-only: it discovers capabilities; it does not run app actions.
+allowed-tools: Bash(node:*)
+---
+
+# psd-aistudio
+
+A live catalog of **what AI Studio can do**, read straight from the deployed
+app's own source-of-truth registries. Because it is a projection of the running
+code (not a hand-maintained list), it can never fall behind: a feature that
+shipped this morning shows up here now.
+
+Use it to answer questions like "can AI Studio do X?", "what can I do in AI
+Studio?", or "where do I go to compare models?" — and to decide whether *you*
+(the agent) can perform an action over MCP or should instead point the user at a
+web-app feature.
+
+## What it returns
+
+`capabilities` returns three clearly separated sections:
+
+- **`actions[]`** — invocable tools. Each carries the `surfaces` it is exposed
+  on, the `requiredScopes` to call it, `destructive` (writes/deletes), and
+  **`agentInvocable`** — `true` when *you* can invoke it over MCP (surface
+  includes `mcp`), `false` when it exists but isn't reachable from here.
+- **`features[]`** — role-gated **web-app** features (Assistant Architect, Model
+  Compare, Knowledge Repositories, Voice Mode, Atrium, …). These are
+  human-driven UI you **steer the user to**; you cannot invoke them. Each lists
+  the `defaultRoles` that get access.
+- **`scopes[]`** — the API-scope reference (scope → description → which roles
+  hold it) so you can explain access requirements.
+
+Capabilities (UI, human) and scopes (API-key, programmatic) are **separate
+namespaces** — the tool never collapses them, and neither should you.
+
+## Authentication
+
+The skill authenticates with a single scoped API key (`sk-…`) holding the
+low-sensitivity **`platform:read`** scope — the catalog is non-sensitive product
+metadata, so there is no per-user identity to assume for v1. The key is read
+from `AISTUDIO_MCP_API_KEY`, or from Secrets Manager via
+`AISTUDIO_MCP_API_KEY_SECRET_ID`. You do not handle auth yourself.
+
+> **Deferred:** invoking real AI Studio actions (an action-executing passthrough)
+> is **not** part of this skill. That path — and the production per-user
+> credential it needs — is owned by the in-progress MCP action-tool work. This
+> skill is discovery-only; do not attempt to run app operations through it.
+
+## Subcommands
+
+### `capabilities` — the live capability catalog (use this first)
+
+```bash
+# Everything (actions + features + scopes)
+node /opt/psd-skills/psd-aistudio/run.js capabilities
+
+# Just the actions you can invoke over MCP
+node /opt/psd-skills/psd-aistudio/run.js capabilities --section actions --surface mcp
+
+# Find capabilities related to a topic
+node /opt/psd-skills/psd-aistudio/run.js capabilities --query "assistant"
+
+# Just the human-driven web-app features
+node /opt/psd-skills/psd-aistudio/run.js capabilities --section features
+```
+
+Flags:
+- `--section actions|features|scopes|all` — narrow the response (default `all`).
+- `--surface mcp|ai_sdk|rest|internal` — only actions on that surface (does not
+  affect features/scopes). Use `--surface mcp` to see exactly what you can call.
+- `--query <text>` — case-insensitive substring filter across
+  identifier/name/description/scope.
+
+### `list` — raw MCP tool list
+
+```bash
+node /opt/psd-skills/psd-aistudio/run.js list
+```
+
+The MCP server's current `tools/list` (scope-filtered to what this key can see):
+every tool name, description, and JSON-Schema `inputSchema`. Use this when you
+need a specific tool's **exact wire schema**; use `capabilities` for the broader
+"what can the platform do" picture.
+
+## Exit codes
+
+| Code | Meaning | Agent response |
+|------|---------|----------------|
+| 0 | Success — JSON result on stdout | Use the result |
+| 1 | Config / usage error | Surface the error, do not retry |
+| 11 | Unauthorized — key missing/invalid or lacks `platform:read` | Tell the user AI Studio access isn't configured; do not retry |
+| 12 | Upstream MCP error (JSON-RPC error, e.g. insufficient scope) or network | Surface the error verbatim |
+| 14 | Rate-limited | Wait a moment, retry once |
+
+## Rules
+
+1. **Prefer `capabilities` over memory.** Never state what AI Studio can/can't do
+   from a baked-in list — read it live. The catalog reflects the deployed code.
+2. **Respect `agentInvocable`.** If an action is `agentInvocable: false`, do not
+   claim you can run it; steer the user to the corresponding UI feature instead.
+3. **Don't collapse capabilities and scopes.** They are different namespaces.
+4. **Read-only.** This skill does not run app actions; do not try to make it.

--- a/infra/agent-image/skills/psd-aistudio/common.js
+++ b/infra/agent-image/skills/psd-aistudio/common.js
@@ -1,0 +1,201 @@
+/**
+ * Shared helpers for the psd-aistudio OpenClaw skill (Issue #1100).
+ *
+ * Thin JSON-RPC client for AI Studio's existing `/api/mcp` endpoint. Unlike
+ * psd-data (which mints a per-user Cognito id_token), this skill authenticates
+ * with a single scoped API key (`sk-…`) holding the low-sensitivity
+ * `platform:read` scope — the capability catalog is non-sensitive product
+ * metadata, not user data, so there is no per-user identity to assume for v1.
+ *
+ * Environment contract (set by infra/lib/agent-platform-stack.ts + deploy):
+ *   AISTUDIO_MCP_URL                 — AI Studio MCP JSON-RPC endpoint (/api/mcp)
+ *   AISTUDIO_MCP_API_KEY             — scoped `sk-…` key (platform:read). Direct.
+ *   AISTUDIO_MCP_API_KEY_SECRET_ID   — Secrets Manager id holding the `sk-…` key
+ *                                      (used when the direct env var is absent).
+ *
+ * The PRODUCTION agent-image credential (a dedicated agent service-account key,
+ * or per-user JWT) is shared with / dependent on the in-progress MCP action-tool
+ * work — this skill deliberately does NOT invent a second mechanism. Until that
+ * lands, set AISTUDIO_MCP_API_KEY (or the secret) to a dev `platform:read` key.
+ */
+
+'use strict';
+
+const AISTUDIO_MCP_URL = process.env.AISTUDIO_MCP_URL || '';
+const AISTUDIO_MCP_API_KEY = process.env.AISTUDIO_MCP_API_KEY || '';
+const AISTUDIO_MCP_API_KEY_SECRET_ID =
+  process.env.AISTUDIO_MCP_API_KEY_SECRET_ID || '';
+
+function fail(message, code = 1) {
+  process.stderr.write(`psd-aistudio: ${message}\n`);
+  process.exit(code);
+}
+
+function emit(obj) {
+  process.stdout.write(JSON.stringify(obj) + '\n');
+}
+
+/**
+ * Minimal long-form argv parser. `--foo bar` and `--foo` (boolean) supported;
+ * dashes in key names become underscores. Mirrors psd-data/psd-workspace.
+ */
+function parseArgs(argv) {
+  const args = {};
+  for (let i = 2; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === '--help' || arg === '-h') {
+      args.help = true;
+      continue;
+    }
+    if (!arg.startsWith('--')) {
+      fail(`Unexpected positional argument: ${arg}`);
+    }
+    const key = arg.slice(2).replace(/-/g, '_');
+    const next = argv[i + 1];
+    if (next === undefined || next.startsWith('--')) {
+      args[key] = true;
+    } else {
+      args[key] = next;
+      i++;
+    }
+  }
+  return args;
+}
+
+/**
+ * Load the AWS SDK the same way psd-data does — prefer psd-workspace's
+ * already-installed copy so this skill adds no image dependency, falling back to
+ * a bare require for local/testing. Only reached when the secret path is used.
+ */
+function requireSecretsManager() {
+  try {
+    return require('/opt/psd-skills/psd-workspace/node_modules/@aws-sdk/client-secrets-manager');
+  } catch {
+    return require('@aws-sdk/client-secrets-manager');
+  }
+}
+
+/**
+ * Resolve the scoped API key: the direct env var wins (dev + local validation);
+ * otherwise read it from Secrets Manager. Returns the raw `sk-…` string.
+ */
+async function resolveApiKey() {
+  if (AISTUDIO_MCP_API_KEY) return AISTUDIO_MCP_API_KEY;
+  if (AISTUDIO_MCP_API_KEY_SECRET_ID) {
+    const { SecretsManagerClient, GetSecretValueCommand } =
+      requireSecretsManager();
+    const client = new SecretsManagerClient({
+      region: process.env.AWS_REGION || 'us-east-1',
+    });
+    const resp = await client.send(
+      new GetSecretValueCommand({ SecretId: AISTUDIO_MCP_API_KEY_SECRET_ID })
+    );
+    const value = (resp.SecretString || '').trim();
+    if (!value) {
+      throw new Error(
+        `Secret ${AISTUDIO_MCP_API_KEY_SECRET_ID} has no SecretString value`
+      );
+    }
+    return value;
+  }
+  fail(
+    'No API key configured. Set AISTUDIO_MCP_API_KEY (a scoped sk- key holding ' +
+      'platform:read) or AISTUDIO_MCP_API_KEY_SECRET_ID. The production agent ' +
+      'credential is pending the MCP action-tool work (see SKILL.md).'
+  );
+  return ''; // unreachable
+}
+
+/**
+ * Single entry point for every MCP call. Handles auth (bearer sk- key), the
+ * JSON-RPC envelope, and uniform error surfacing. Writes the JSON-RPC result to
+ * stdout on success; emits a structured error and exits non-zero otherwise.
+ *
+ *   - method: MCP method name ('tools/call', 'tools/list', etc.)
+ *   - params: object — the JSON-RPC params field
+ *
+ * /api/mcp returns HTTP 200 with a JSON-RPC envelope for tool results AND
+ * tool-level errors (insufficient scope, unknown tool). Only auth/rate-limit/
+ * parse failures use HTTP status codes; handle both.
+ */
+async function callMcp(method, params) {
+  if (!AISTUDIO_MCP_URL) {
+    fail('AISTUDIO_MCP_URL is not set');
+  }
+
+  const apiKey = await resolveApiKey();
+
+  const requestId = Math.floor(Math.random() * 1e9);
+  const rpcBody = {
+    jsonrpc: '2.0',
+    id: requestId,
+    method,
+    params: params || {},
+  };
+
+  let resp;
+  try {
+    resp = await fetch(AISTUDIO_MCP_URL, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${apiKey}`,
+        'mcp-protocol-version': '2024-11-05',
+      },
+      body: JSON.stringify(rpcBody),
+    });
+  } catch (err) {
+    fail(`Network error calling AI Studio MCP: ${err.message}`, 12);
+  }
+
+  if (resp.status === 401) {
+    const text = await resp.text().catch(() => '');
+    emit({
+      status: 'unauthorized',
+      message:
+        'AI Studio MCP rejected the API key (401). The key must be a valid ' +
+        'sk- key holding the platform:read scope.',
+      detail: text.slice(0, 512),
+    });
+    process.exit(11);
+  }
+  if (resp.status === 429) {
+    emit({
+      status: 'rate-limited',
+      message:
+        'AI Studio MCP is rate-limiting requests for this key. Wait and retry.',
+    });
+    process.exit(14);
+  }
+
+  const data = await resp.json().catch(() => null);
+  if (!data) {
+    const text = resp.ok ? '' : ` (HTTP ${resp.status})`;
+    fail(`AI Studio MCP returned a non-JSON body${text}`, 12);
+  }
+
+  if (data.error) {
+    // Covers tool-level JSON-RPC errors, incl. "Insufficient scope for tool:
+    // describe_capabilities" (the caller's key lacks platform:read) and unknown
+    // tool. Surface verbatim; do not retry.
+    emit({
+      status: 'mcp-error',
+      method,
+      http_status: resp.status,
+      jsonrpc_error: data.error,
+    });
+    process.exit(12);
+  }
+
+  process.stdout.write(JSON.stringify(data.result ?? null) + '\n');
+  return data.result ?? null;
+}
+
+module.exports = {
+  fail,
+  emit,
+  parseArgs,
+  resolveApiKey,
+  callMcp,
+  AISTUDIO_MCP_URL,
+};

--- a/infra/agent-image/skills/psd-aistudio/common.js
+++ b/infra/agent-image/skills/psd-aistudio/common.js
@@ -82,26 +82,42 @@ function requireSecretsManager() {
 async function resolveApiKey() {
   if (AISTUDIO_MCP_API_KEY) return AISTUDIO_MCP_API_KEY;
   if (AISTUDIO_MCP_API_KEY_SECRET_ID) {
-    const { SecretsManagerClient, GetSecretValueCommand } =
-      requireSecretsManager();
-    const client = new SecretsManagerClient({
-      region: process.env.AWS_REGION || 'us-east-1',
-    });
-    const resp = await client.send(
-      new GetSecretValueCommand({ SecretId: AISTUDIO_MCP_API_KEY_SECRET_ID })
-    );
-    const value = (resp.SecretString || '').trim();
+    let value;
+    try {
+      const { SecretsManagerClient, GetSecretValueCommand } =
+        requireSecretsManager();
+      const client = new SecretsManagerClient({
+        region: process.env.AWS_REGION || 'us-east-1',
+      });
+      const resp = await client.send(
+        new GetSecretValueCommand({ SecretId: AISTUDIO_MCP_API_KEY_SECRET_ID })
+      );
+      value = (resp.SecretString || '').trim();
+    } catch (err) {
+      // A retrieval failure (permission / decryption / network) is an infra
+      // error, not a malformed invocation — surface it clearly (exit 12) instead
+      // of letting it bubble to the generic exit-2 handler.
+      fail(
+        `Failed to retrieve API key from Secrets Manager ` +
+          `(${AISTUDIO_MCP_API_KEY_SECRET_ID}): ${err.message}`,
+        12
+      );
+    }
+    // Secret exists but is empty — the credential is effectively missing.
     if (!value) {
-      throw new Error(
-        `Secret ${AISTUDIO_MCP_API_KEY_SECRET_ID} has no SecretString value`
+      fail(
+        `Secret ${AISTUDIO_MCP_API_KEY_SECRET_ID} has no SecretString value`,
+        11
       );
     }
     return value;
   }
+  // No credential configured at all — access to AI Studio is not set up.
   fail(
     'No API key configured. Set AISTUDIO_MCP_API_KEY (a scoped sk- key holding ' +
       'platform:read) or AISTUDIO_MCP_API_KEY_SECRET_ID. The production agent ' +
-      'credential is pending the MCP action-tool work (see SKILL.md).'
+      'credential is pending the MCP action-tool work (see SKILL.md).',
+    11
   );
   return ''; // unreachable
 }
@@ -185,6 +201,18 @@ async function callMcp(method, params) {
       jsonrpc_error: data.error,
     });
     process.exit(12);
+  }
+
+  // A non-2xx status with a JSON body but NO JSON-RPC error field (e.g. an infra
+  // 502/503 proxy page, or a Next.js framework error `{"message": "..."}`) must
+  // NOT be treated as success — otherwise we'd silently write `null` and exit 0,
+  // hiding the real HTTP status (CLAUDE.md silent-failure pattern). Fail loudly.
+  if (!resp.ok) {
+    fail(
+      `AI Studio MCP returned HTTP ${resp.status}: ` +
+        `${JSON.stringify(data).slice(0, 512)}`,
+      12
+    );
   }
 
   process.stdout.write(JSON.stringify(data.result ?? null) + '\n');

--- a/infra/agent-image/skills/psd-aistudio/package.json
+++ b/infra/agent-image/skills/psd-aistudio/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "psd-aistudio",
+  "version": "1.0.0",
+  "private": true,
+  "description": "OpenClaw skill: live AI Studio capability catalog via the describe_capabilities MCP meta-tool on /api/mcp. Read-only, authenticated with a scoped platform:read sk- key. @aws-sdk/client-secrets-manager (only for the secret-id auth path) is resolved at runtime via psd-workspace's node_modules — no image dependency of its own.",
+  "main": "run.js"
+}

--- a/infra/agent-image/skills/psd-aistudio/run.js
+++ b/infra/agent-image/skills/psd-aistudio/run.js
@@ -70,19 +70,24 @@ async function main() {
   switch (subcommand) {
     case 'capabilities': {
       const toolArgs = {};
-      if (args.section !== undefined && args.section !== true) {
+      // parseArgs sets a value-less flag (e.g. `--section` with nothing after it)
+      // to `true`; fail explicitly rather than silently ignoring the flag.
+      if (args.section !== undefined) {
+        if (args.section === true) fail('--section requires a value');
         if (!SECTIONS.includes(args.section)) {
           fail(`--section must be one of: ${SECTIONS.join(', ')}`);
         }
         toolArgs.section = args.section;
       }
-      if (args.surface !== undefined && args.surface !== true) {
+      if (args.surface !== undefined) {
+        if (args.surface === true) fail('--surface requires a value');
         if (!SURFACES.includes(args.surface)) {
           fail(`--surface must be one of: ${SURFACES.join(', ')}`);
         }
         toolArgs.surface = args.surface;
       }
-      if (args.query !== undefined && args.query !== true) {
+      if (args.query !== undefined) {
+        if (args.query === true) fail('--query requires a value');
         toolArgs.query = args.query;
       }
       await callMcp('tools/call', {

--- a/infra/agent-image/skills/psd-aistudio/run.js
+++ b/infra/agent-image/skills/psd-aistudio/run.js
@@ -1,0 +1,114 @@
+#!/usr/bin/env node
+/**
+ * run.js — psd-aistudio skill entrypoint (Issue #1100).
+ *
+ * Gives the agent a LIVE, always-current view of what AI Studio can do by
+ * calling the `describe_capabilities` meta-tool on AI Studio's existing
+ * `/api/mcp` endpoint. Read-only: it discovers capabilities, it does not invoke
+ * app actions (the action-executing passthrough is deferred to the MCP
+ * action-tool work, which brings per-user auth — see SKILL.md).
+ *
+ * Usage:
+ *   node run.js capabilities [--section actions|features|scopes|all]
+ *                            [--surface mcp|ai_sdk|rest|internal] [--query <text>]
+ *   node run.js list         # raw MCP tools/list (names + inputSchema)
+ *
+ * Exit codes:
+ *   0   success (JSON result printed to stdout)
+ *   1   usage / config error
+ *   2   internal / unexpected
+ *   11  unauthorized (API key missing/invalid or lacks platform:read)
+ *   12  upstream MCP error (JSON-RPC error, e.g. insufficient scope) or network
+ *   14  rate-limited
+ */
+
+'use strict';
+
+const { fail, parseArgs, callMcp } = require('./common');
+
+const SECTIONS = ['actions', 'features', 'scopes', 'all'];
+const SURFACES = ['mcp', 'ai_sdk', 'rest', 'internal'];
+
+function usage() {
+  process.stdout.write(
+    [
+      'Usage: node run.js <subcommand> [...]',
+      '',
+      'Subcommands (read-only):',
+      '  capabilities [--section actions|features|scopes|all]',
+      '               [--surface mcp|ai_sdk|rest|internal] [--query <text>]',
+      '      Live catalog of what AI Studio can do — invocable actions (with the',
+      '      scope each needs + whether the agent can invoke it over MCP),',
+      '      role-gated UI features to steer users toward, and a scope reference.',
+      '',
+      '  list',
+      '      Raw MCP tools/list — every tool name, description, and inputSchema the',
+      '      key can see. Use when you want the exact wire schema of a tool.',
+      '',
+    ].join('\n')
+  );
+}
+
+async function main() {
+  const subcommand = process.argv[2];
+  if (!subcommand || subcommand === '--help' || subcommand === '-h') {
+    usage();
+    process.exit(0);
+  }
+
+  // parseArgs reads flags starting at argv index 3 (after the subcommand).
+  const args = parseArgs([
+    process.argv[0],
+    process.argv[1],
+    ...process.argv.slice(3),
+  ]);
+  if (args.help) {
+    usage();
+    process.exit(0);
+  }
+
+  switch (subcommand) {
+    case 'capabilities': {
+      const toolArgs = {};
+      if (args.section !== undefined && args.section !== true) {
+        if (!SECTIONS.includes(args.section)) {
+          fail(`--section must be one of: ${SECTIONS.join(', ')}`);
+        }
+        toolArgs.section = args.section;
+      }
+      if (args.surface !== undefined && args.surface !== true) {
+        if (!SURFACES.includes(args.surface)) {
+          fail(`--surface must be one of: ${SURFACES.join(', ')}`);
+        }
+        toolArgs.surface = args.surface;
+      }
+      if (args.query !== undefined && args.query !== true) {
+        toolArgs.query = args.query;
+      }
+      await callMcp('tools/call', {
+        name: 'describe_capabilities',
+        arguments: toolArgs,
+      });
+      return;
+    }
+
+    case 'list': {
+      // Raw discovery — the MCP server's current tools/list (scope-filtered to
+      // what this key can see). Complements `capabilities` when you need a
+      // specific tool's exact inputSchema.
+      await callMcp('tools/list', {});
+      return;
+    }
+
+    default:
+      fail(`Unknown subcommand: ${subcommand}. Run with --help to see options.`);
+  }
+}
+
+if (require.main === module) {
+  main().catch((err) => {
+    fail(err instanceof Error ? err.message : String(err), 2);
+  });
+}
+
+module.exports = { main };

--- a/infra/lib/agent-platform-stack.ts
+++ b/infra/lib/agent-platform-stack.ts
@@ -1317,6 +1317,15 @@ export class AgentPlatformStack extends cdk.Stack {
       PSD_DATA_MCP_URL:
         (this.node.tryGetContext('psdDataMcpUrl') as string | undefined)
         ?? 'https://l3jpggwgsojgql275k6axcboue0syeuq.lambda-url.us-west-2.on.aws/mcp',
+      // AI Studio's own MCP endpoint (Issue #1100) — the psd-aistudio skill POSTs
+      // JSON-RPC here to read the live capability catalog (describe_capabilities).
+      // Derived from APP_BASE_URL so it always tracks the deployed web app;
+      // overridable via `-c aistudioMcpUrl=…` for a split/edge deployment.
+      AISTUDIO_MCP_URL:
+        (this.node.tryGetContext('aistudioMcpUrl') as string | undefined)
+        ?? (props.appBaseUrl
+          ? `${props.appBaseUrl.replace(/\/+$/, '')}/api/mcp`
+          : ''),
       AUTH_COGNITO_USER_POOL_ID: cdk.Fn.importValue(
         `${environment}-CognitoUserPoolId`,
       ),

--- a/lib/api-keys/scopes.ts
+++ b/lib/api-keys/scopes.ts
@@ -20,6 +20,14 @@ export const API_SCOPES = {
   "assistants:execute": "Execute any assistant via API",
   "models:read": "List available AI models",
   "tools:read": "List and view tool catalog entries and their versions",
+  // Platform capability catalog (Issue #1100). A low-sensitivity read scope over
+  // non-sensitive PRODUCT METADATA — the live projection of AI Studio's own
+  // registries (invocable actions, role-gated UI features, and the scope
+  // reference). Granted broadly (student/staff/administrator) so any authenticated
+  // caller — including the OpenClaw agent holding a scoped key — can discover what
+  // the platform can do via the `describe_capabilities` MCP meta-tool. It exposes
+  // no user data, only the shape of the app.
+  "platform:read": "Read the AI Studio capability catalog (actions, features, scopes)",
   "documents:read": "Read documents and attachments",
   "documents:write": "Upload and manage documents",
   "graph:read": "Read context graph nodes and edges",
@@ -60,7 +68,7 @@ export type ApiScope = keyof typeof API_SCOPES;
 const ALL_SCOPES = Object.keys(API_SCOPES) as ApiScope[];
 
 export const ROLE_SCOPES: Record<string, ApiScope[]> = {
-  student: ["chat:read", "chat:write"],
+  student: ["chat:read", "chat:write", "platform:read"],
   staff: [
     "chat:read",
     "chat:write",
@@ -69,6 +77,7 @@ export const ROLE_SCOPES: Record<string, ApiScope[]> = {
     "assistants:execute",
     "models:read",
     "tools:read",
+    "platform:read",
     "documents:read",
     "graph:read",
     "mcp:search_decisions",

--- a/lib/capabilities/capability-catalog.ts
+++ b/lib/capabilities/capability-catalog.ts
@@ -60,8 +60,21 @@ export interface CapabilityCatalogAction {
   description: string;
   /** Surfaces this action is exposed on. */
   surfaces: ToolSurface[];
-  /** Base API scope(s) a caller must hold to invoke it (the MCP-surface scopes). */
+  /**
+   * API scope(s) a caller must hold to invoke it. When the catalog was built with
+   * a `surface` filter, these are the scopes for THAT surface (e.g. REST's
+   * `assistants:execute`, not MCP's `mcp:execute_assistant`); otherwise they are
+   * the base scopes (the MCP-surface scopes). Use {@link scopesBySurface} for the
+   * unambiguous per-surface picture.
+   */
   requiredScopes: string[];
+  /**
+   * The scopes required on EACH surface this action exposes. A multi-surface tool
+   * often needs a different scope per surface (e.g. `mcp:execute_assistant` on
+   * `mcp` vs `assistants:execute` on `rest`), so reporting only the base scopes
+   * would mislead a REST/other-surface caller about what its key must hold.
+   */
+  scopesBySurface: Partial<Record<ToolSurface, string[]>>;
   /** True when the action writes/deletes/has external side effects. */
   destructive: boolean;
   /** True when reachable over `/api/mcp` (surface includes `mcp`). */
@@ -130,6 +143,20 @@ export interface BuildCapabilityCatalogOptions {
 }
 
 /**
+ * Resolve the scopes a caller must hold for a tool on a given surface. A
+ * `surfaceScopes` override REPLACES the base `requiredScopes` for that surface
+ * (e.g. REST `assistants:execute` vs MCP `mcp:execute_assistant`); otherwise the
+ * base scopes apply. Mirrors `requiredScopesForSurface` in the runtime catalog so
+ * the advertised scope matches what actually authorizes the call.
+ */
+function scopesForSurface(
+  entry: (typeof TOOL_MANIFEST)[number],
+  surface: ToolSurface
+): string[] {
+  return entry.surfaceScopes?.[surface] ?? entry.requiredScopes;
+}
+
+/**
  * Collapse `TOOL_MANIFEST` to one entry per identifier, keeping the highest
  * version. All manifest entries are `v1` today, but this keeps the projection
  * correct once multiple versions of a tool coexist.
@@ -145,15 +172,22 @@ function latestActionsPerIdentifier(): CapabilityCatalogAction[] {
       byIdentifier.set(entry.identifier, entry);
     }
   }
-  return [...byIdentifier.values()].map((entry) => ({
-    identifier: entry.identifier,
-    name: entry.name,
-    description: entry.description,
-    surfaces: entry.surfaces,
-    requiredScopes: entry.requiredScopes,
-    destructive: entry.destructive ?? false,
-    agentInvocable: entry.surfaces.includes("mcp"),
-  }));
+  return [...byIdentifier.values()].map((entry) => {
+    const scopesBySurface: Partial<Record<ToolSurface, string[]>> = {};
+    for (const surface of entry.surfaces) {
+      scopesBySurface[surface] = scopesForSurface(entry, surface);
+    }
+    return {
+      identifier: entry.identifier,
+      name: entry.name,
+      description: entry.description,
+      surfaces: entry.surfaces,
+      requiredScopes: entry.requiredScopes,
+      scopesBySurface,
+      destructive: entry.destructive ?? false,
+      agentInvocable: entry.surfaces.includes("mcp"),
+    };
+  });
 }
 
 /** Project `CAPABILITY_MANIFEST` into feature entries. */
@@ -212,7 +246,15 @@ export function buildCapabilityCatalog(
 
   if (opts.surface) {
     const surface = opts.surface;
-    actions = actions.filter((a) => a.surfaces.includes(surface));
+    // Narrow to the surface AND report that surface's scopes as `requiredScopes`
+    // (not the base MCP scopes), so a REST/etc. caller is told the scope its key
+    // actually needs. The full per-surface picture stays in `scopesBySurface`.
+    actions = actions
+      .filter((a) => a.surfaces.includes(surface))
+      .map((a) => ({
+        ...a,
+        requiredScopes: a.scopesBySurface[surface] ?? a.requiredScopes,
+      }));
   }
 
   if (opts.query) {

--- a/lib/capabilities/capability-catalog.ts
+++ b/lib/capabilities/capability-catalog.ts
@@ -1,0 +1,246 @@
+/**
+ * Capability Catalog — a live, deterministic projection of AI Studio's own
+ * source-of-truth registries into one "what can this platform do?" view.
+ *
+ * Issue #1100 (Epic #922). This is the AWARENESS/catalog layer: it lets the
+ * OpenClaw agent (and any scoped MCP caller) understand what AI Studio can do —
+ * both the actions it can invoke over `/api/mcp` and the web-app features it
+ * should steer a human toward — without any hand-maintained list that can drift.
+ *
+ * ## Freshness engine
+ *
+ * The catalog is rebuilt on every call from the three registries a developer
+ * *must* update to ship a feature:
+ *   - `TOOL_MANIFEST`      (invocable tools)        → {@link CapabilityCatalog.actions}
+ *   - `CAPABILITY_MANIFEST`(role-gated UI features) → {@link CapabilityCatalog.features}
+ *   - `API_SCOPES`/`ROLE_SCOPES` (API-key scopes)   → {@link CapabilityCatalog.scopes}
+ *
+ * There is no cached artifact and no second list to maintain: adding an entry to
+ * any of those registries appears here automatically, so the projection can never
+ * fall behind the deployed code.
+ *
+ * ## Two distinct namespaces (do NOT collapse)
+ *
+ * Per `docs/architecture/capabilities-and-scopes.md`, **capabilities** (role-gated
+ * UI features for humans) and **scopes** (API-key permissions for programmatic
+ * callers) are separate identifier namespaces. This builder keeps them in separate
+ * sections and never cross-maps a capability identifier to a scope. The `scopes`
+ * section is a *reference* the agent can use to explain access requirements, not a
+ * per-feature scope binding.
+ *
+ * ## Edge-safety
+ *
+ * This module reads ONLY pure-metadata modules (`TOOL_MANIFEST`,
+ * `CAPABILITY_MANIFEST`, `API_SCOPES`/`ROLE_SCOPES`). It must NEVER import a tool
+ * handler, the runtime catalog, the DB, or anything that transitively pulls
+ * `node:crypto` — the same rule documented at `lib/tools/catalog/manifest.ts`.
+ * Keeping it pure also makes it deterministic (no DB round-trip), which is what
+ * the committed drift-check (`scripts/capabilities/generate-catalog.ts`) relies on.
+ */
+
+import { CAPABILITY_MANIFEST } from "@/lib/capabilities/manifest";
+import { TOOL_MANIFEST } from "@/lib/tools/catalog/manifest";
+import { compareVersionsDesc } from "@/lib/tools/catalog/utils";
+import type { ToolSurface } from "@/lib/tools/catalog/types";
+import { API_SCOPES, ROLE_SCOPES } from "@/lib/api-keys/scopes";
+
+/**
+ * An invocable AI Studio action, projected from `TOOL_MANIFEST`. `agentInvocable`
+ * is true when the tool is exposed on the `mcp` surface — the only surface the
+ * OpenClaw agent can reach (it POSTs JSON-RPC to `/api/mcp`). Actions that are
+ * `internal`/`ai_sdk`/`rest`-only are still listed (so the agent knows they exist)
+ * but flagged `agentInvocable: false`.
+ */
+export interface CapabilityCatalogAction {
+  /** Stable `domain.action` identifier (e.g. `assistants.execute`). */
+  identifier: string;
+  /** MCP wire / model-facing tool name (e.g. `execute_assistant`). */
+  name: string;
+  /** Model/human-readable description. */
+  description: string;
+  /** Surfaces this action is exposed on. */
+  surfaces: ToolSurface[];
+  /** Base API scope(s) a caller must hold to invoke it (the MCP-surface scopes). */
+  requiredScopes: string[];
+  /** True when the action writes/deletes/has external side effects. */
+  destructive: boolean;
+  /** True when reachable over `/api/mcp` (surface includes `mcp`). */
+  agentInvocable: boolean;
+}
+
+/**
+ * A role-gated UI feature, projected from `CAPABILITY_MANIFEST`. The agent cannot
+ * invoke these (they are human-driven web-app features); it steers the user to them.
+ */
+export interface CapabilityCatalogFeature {
+  /** Stable capability identifier checked by `hasCapabilityAccess()`. */
+  identifier: string;
+  /** Human-readable feature name. */
+  name: string;
+  /** Description of the feature. */
+  description: string;
+  /** Role names granted the feature by default (seed-time). */
+  defaultRoles: string[];
+  /** Always true: features are human-driven UI, not agent-invocable. */
+  humanDriven: true;
+}
+
+/**
+ * An API-key scope, projected from `API_SCOPES` + `ROLE_SCOPES`. Reference only —
+ * lets the agent explain which roles hold which programmatic permission.
+ */
+export interface CapabilityCatalogScope {
+  /** The scope string (e.g. `assistants:execute`). */
+  scope: string;
+  /** Human-readable description of what the scope grants. */
+  description: string;
+  /** Role names that hold this scope (from `ROLE_SCOPES`). */
+  roles: string[];
+}
+
+/** The unified capability catalog returned by {@link buildCapabilityCatalog}. */
+export interface CapabilityCatalog {
+  /** Counts of what this response contains (0 for omitted sections). */
+  summary: {
+    actions: number;
+    features: number;
+    scopes: number;
+    /** Subset of `actions` reachable over `/api/mcp`. */
+    agentInvocableActions: number;
+  };
+  /** Invocable actions (present unless `section` narrows them out). */
+  actions?: CapabilityCatalogAction[];
+  /** Human-driven UI features (present unless `section` narrows them out). */
+  features?: CapabilityCatalogFeature[];
+  /** Scope reference (present unless `section` narrows them out). */
+  scopes?: CapabilityCatalogScope[];
+}
+
+/** Which section(s) to include. Defaults to `all`. */
+export type CapabilityCatalogSection = "actions" | "features" | "scopes" | "all";
+
+/** Options for {@link buildCapabilityCatalog}. */
+export interface BuildCapabilityCatalogOptions {
+  /** Limit the response to one section (default `all`). */
+  section?: CapabilityCatalogSection;
+  /** Only include actions exposed on this surface (does not affect features/scopes). */
+  surface?: ToolSurface;
+  /** Case-insensitive substring filter across identifier/name/description/scope. */
+  query?: string;
+}
+
+/**
+ * Collapse `TOOL_MANIFEST` to one entry per identifier, keeping the highest
+ * version. All manifest entries are `v1` today, but this keeps the projection
+ * correct once multiple versions of a tool coexist.
+ */
+function latestActionsPerIdentifier(): CapabilityCatalogAction[] {
+  const byIdentifier = new Map<string, (typeof TOOL_MANIFEST)[number]>();
+  for (const entry of TOOL_MANIFEST) {
+    const existing = byIdentifier.get(entry.identifier);
+    if (
+      !existing ||
+      compareVersionsDesc(entry.version ?? "v1", existing.version ?? "v1") < 0
+    ) {
+      byIdentifier.set(entry.identifier, entry);
+    }
+  }
+  return [...byIdentifier.values()].map((entry) => ({
+    identifier: entry.identifier,
+    name: entry.name,
+    description: entry.description,
+    surfaces: entry.surfaces,
+    requiredScopes: entry.requiredScopes,
+    destructive: entry.destructive ?? false,
+    agentInvocable: entry.surfaces.includes("mcp"),
+  }));
+}
+
+/** Project `CAPABILITY_MANIFEST` into feature entries. */
+function buildFeatures(): CapabilityCatalogFeature[] {
+  return CAPABILITY_MANIFEST.map((entry) => ({
+    identifier: entry.identifier,
+    name: entry.name,
+    description: entry.description,
+    defaultRoles: entry.defaultRoles ?? [],
+    humanDriven: true as const,
+  }));
+}
+
+/**
+ * Project `API_SCOPES` + `ROLE_SCOPES` into scope reference entries, annotating
+ * each scope with the roles that hold it. Role order follows `ROLE_SCOPES` key
+ * order (deterministic).
+ */
+function buildScopes(): CapabilityCatalogScope[] {
+  const roleNames = Object.keys(ROLE_SCOPES);
+  return (Object.entries(API_SCOPES) as [string, string][]).map(
+    ([scope, description]) => ({
+      scope,
+      description,
+      roles: roleNames.filter((role) =>
+        (ROLE_SCOPES[role] as string[]).includes(scope)
+      ),
+    })
+  );
+}
+
+/** Lowercased substring predicate over a set of fields. */
+function matchesQuery(query: string, ...fields: string[]): boolean {
+  const q = query.toLowerCase();
+  return fields.some((f) => f.toLowerCase().includes(q));
+}
+
+/**
+ * Build the capability catalog from AI Studio's live registries.
+ *
+ * Deterministic: identical registries + options always produce byte-identical
+ * output (arrays sorted by identifier/scope; no timestamps), which the committed
+ * drift-check depends on. Reads pure metadata only — safe to call on any runtime.
+ */
+export function buildCapabilityCatalog(
+  opts: BuildCapabilityCatalogOptions = {}
+): CapabilityCatalog {
+  const section = opts.section ?? "all";
+  const wantActions = section === "all" || section === "actions";
+  const wantFeatures = section === "all" || section === "features";
+  const wantScopes = section === "all" || section === "scopes";
+
+  let actions = wantActions ? latestActionsPerIdentifier() : [];
+  let features = wantFeatures ? buildFeatures() : [];
+  let scopes = wantScopes ? buildScopes() : [];
+
+  if (opts.surface) {
+    const surface = opts.surface;
+    actions = actions.filter((a) => a.surfaces.includes(surface));
+  }
+
+  if (opts.query) {
+    const query = opts.query;
+    actions = actions.filter((a) =>
+      matchesQuery(query, a.identifier, a.name, a.description)
+    );
+    features = features.filter((f) =>
+      matchesQuery(query, f.identifier, f.name, f.description)
+    );
+    scopes = scopes.filter((s) => matchesQuery(query, s.scope, s.description));
+  }
+
+  // Deterministic ordering so the generated catalog file (and the drift-check)
+  // is stable regardless of manifest declaration order.
+  actions.sort((a, b) => a.identifier.localeCompare(b.identifier));
+  features.sort((a, b) => a.identifier.localeCompare(b.identifier));
+  scopes.sort((a, b) => a.scope.localeCompare(b.scope));
+
+  return {
+    summary: {
+      actions: actions.length,
+      features: features.length,
+      scopes: scopes.length,
+      agentInvocableActions: actions.filter((a) => a.agentInvocable).length,
+    },
+    ...(wantActions ? { actions } : {}),
+    ...(wantFeatures ? { features } : {}),
+    ...(wantScopes ? { scopes } : {}),
+  };
+}

--- a/lib/capabilities/capability-catalog.ts
+++ b/lib/capabilities/capability-catalog.ts
@@ -259,8 +259,20 @@ export function buildCapabilityCatalog(
 
   if (opts.query) {
     const query = opts.query;
+    // Scope is a documented query field (the tool inputSchema + SKILL.md say the
+    // filter spans "identifier, name, description, and scope"), so an action must
+    // also match on the scopes it requires — e.g. query "platform:read" or
+    // "assistants:execute" should surface the actions gated by that scope, not
+    // just the scope reference entry.
     actions = actions.filter((a) =>
-      matchesQuery(query, a.identifier, a.name, a.description)
+      matchesQuery(
+        query,
+        a.identifier,
+        a.name,
+        a.description,
+        ...a.requiredScopes,
+        ...Object.values(a.scopesBySurface).flat()
+      )
     );
     features = features.filter((f) =>
       matchesQuery(query, f.identifier, f.name, f.description)

--- a/lib/mcp/tool-handlers.ts
+++ b/lib/mcp/tool-handlers.ts
@@ -82,19 +82,22 @@ const CATALOG_SURFACES: readonly ToolSurface[] = [
 async function handleDescribeCapabilities(
   args: Record<string, unknown>,
 ): Promise<McpToolResult> {
+  // Defensive: the MCP dispatcher always passes a sanitized object, but guard
+  // against a null/undefined args from any future internal caller.
+  const safeArgs = args ?? {}
   const section =
-    typeof args.section === "string" &&
-    CATALOG_SECTIONS.includes(args.section as CapabilityCatalogSection)
-      ? (args.section as CapabilityCatalogSection)
+    typeof safeArgs.section === "string" &&
+    CATALOG_SECTIONS.includes(safeArgs.section as CapabilityCatalogSection)
+      ? (safeArgs.section as CapabilityCatalogSection)
       : undefined
   const surface =
-    typeof args.surface === "string" &&
-    CATALOG_SURFACES.includes(args.surface as ToolSurface)
-      ? (args.surface as ToolSurface)
+    typeof safeArgs.surface === "string" &&
+    CATALOG_SURFACES.includes(safeArgs.surface as ToolSurface)
+      ? (safeArgs.surface as ToolSurface)
       : undefined
   const query =
-    typeof args.query === "string" && args.query.trim().length > 0
-      ? args.query
+    typeof safeArgs.query === "string" && safeArgs.query.trim().length > 0
+      ? safeArgs.query
       : undefined
 
   const catalog = buildCapabilityCatalog({ section, surface, query })

--- a/lib/mcp/tool-handlers.ts
+++ b/lib/mcp/tool-handlers.ts
@@ -26,12 +26,18 @@ import { listAccessibleAssistants } from "@/lib/api/assistant-service"
 import { isAdminByUserId } from "@/lib/api/route-helpers"
 import { AGENT_TOOL_HANDLERS } from "@/lib/agents/agent-tools"
 import { CONTENT_TOOL_HANDLERS } from "./content-tool-handlers"
+import {
+  buildCapabilityCatalog,
+  type CapabilityCatalogSection,
+} from "@/lib/capabilities/capability-catalog"
+import type { ToolSurface } from "@/lib/tools/catalog/types"
 
 // ============================================
 // Handler Map
 // ============================================
 
 export const TOOL_HANDLERS: Record<string, McpToolHandler> = {
+  describe_capabilities: handleDescribeCapabilities,
   search_decisions: handleSearchDecisions,
   capture_decision: handleCaptureDecision,
   execute_assistant: handleExecuteAssistant,
@@ -45,6 +51,57 @@ export const TOOL_HANDLERS: Record<string, McpToolHandler> = {
   // Atrium content tools (Phase 5, Issue #1055): create/get/list/update/version/
   // visibility/publish over the §11–§15 services.
   ...CONTENT_TOOL_HANDLERS,
+}
+
+// ============================================
+// describe_capabilities (Issue #1100)
+// ============================================
+
+const CATALOG_SECTIONS: readonly CapabilityCatalogSection[] = [
+  "actions",
+  "features",
+  "scopes",
+  "all",
+]
+const CATALOG_SURFACES: readonly ToolSurface[] = [
+  "mcp",
+  "ai_sdk",
+  "rest",
+  "internal",
+]
+
+/**
+ * Live projection of AI Studio's own registries (Issue #1100). Reads the
+ * capability builder ON EVERY CALL so the result always reflects the deployed
+ * code — the freshness guarantee. Pure/read-only: no auth beyond the
+ * `platform:read` scope the catalog already enforced before dispatch. Unknown
+ * `section`/`surface` values are ignored (fall back to the builder defaults)
+ * rather than erroring, so a slightly-off client argument still returns a useful
+ * catalog.
+ */
+async function handleDescribeCapabilities(
+  args: Record<string, unknown>,
+): Promise<McpToolResult> {
+  const section =
+    typeof args.section === "string" &&
+    CATALOG_SECTIONS.includes(args.section as CapabilityCatalogSection)
+      ? (args.section as CapabilityCatalogSection)
+      : undefined
+  const surface =
+    typeof args.surface === "string" &&
+    CATALOG_SURFACES.includes(args.surface as ToolSurface)
+      ? (args.surface as ToolSurface)
+      : undefined
+  const query =
+    typeof args.query === "string" && args.query.trim().length > 0
+      ? args.query
+      : undefined
+
+  const catalog = buildCapabilityCatalog({ section, surface, query })
+
+  return {
+    content: [{ type: "text", text: JSON.stringify(catalog) }],
+  }
 }
 
 // ============================================

--- a/lib/mcp/tool-registry.ts
+++ b/lib/mcp/tool-registry.ts
@@ -182,6 +182,39 @@ Example:
       required: ["nodeId"],
     },
   },
+  {
+    // Platform capability catalog (Issue #1100). A read-only meta-tool: a LIVE
+    // projection of AI Studio's own source-of-truth registries so the agent's
+    // understanding of what the platform can do never drifts from the deployed
+    // code. Returns `actions[]` (invocable tools, each flagged `agentInvocable`
+    // when reachable over MCP), `features[]` (role-gated UI features the agent
+    // steers users to), and a `scopes[]` reference.
+    name: "describe_capabilities",
+    description:
+      "Describe what AI Studio can do, live from the app's own registries. Returns invocable actions (with the surfaces/scopes each needs and whether the agent can invoke it over MCP), role-gated UI features to steer users toward, and a scope reference. Use this to discover current capabilities instead of relying on a static list.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        section: {
+          type: "string",
+          description:
+            "Limit the response to one section. Defaults to 'all'.",
+          enum: ["actions", "features", "scopes", "all"],
+        },
+        surface: {
+          type: "string",
+          description:
+            "Only include actions exposed on this surface (does not affect features/scopes).",
+          enum: ["mcp", "ai_sdk", "rest", "internal"],
+        },
+        query: {
+          type: "string",
+          description:
+            "Case-insensitive substring filter across identifier, name, description, and scope.",
+        },
+      },
+    },
+  },
   // Atrium content tools (Phase 5, Issue #1055) — listed so scoped callers
   // discover them via tools/list.
   ...CONTENT_MCP_TOOLS,

--- a/lib/oauth/oauth-scopes.ts
+++ b/lib/oauth/oauth-scopes.ts
@@ -33,8 +33,25 @@ const CONTENT_SCOPES = Object.keys(API_SCOPES).filter((s) =>
   s.startsWith("content:")
 )
 
-/** All scopes the OAuth provider supports (standard OIDC + MCP + Atrium content) */
-export const ALL_OAUTH_SCOPES = [...OIDC_SCOPES, ...MCP_SCOPES, ...CONTENT_SCOPES]
+// Platform capability-catalog scope (Issue #1100) — so OAuth/JWT MCP callers
+// (incl. the agent authenticating with an OAuth access token) can request
+// platform:read and reach the describe_capabilities meta-tool. Without this the
+// OIDC provider would neither advertise nor accept platform:read, and every
+// OAuth-authenticated tools/call for that tool would fail the scope check.
+const PLATFORM_SCOPES = Object.keys(API_SCOPES).filter((s) =>
+  s.startsWith("platform:")
+)
+
+/**
+ * All scopes the OAuth provider supports (standard OIDC + MCP + Atrium content +
+ * platform capability catalog).
+ */
+export const ALL_OAUTH_SCOPES = [
+  ...OIDC_SCOPES,
+  ...MCP_SCOPES,
+  ...CONTENT_SCOPES,
+  ...PLATFORM_SCOPES,
+]
 
 /**
  * Get a human-readable label for a scope.

--- a/lib/tools/catalog/manifest.ts
+++ b/lib/tools/catalog/manifest.ts
@@ -81,6 +81,16 @@ interface McpCatalogMapping {
 }
 
 const MCP_TOOL_CATALOG_MAP: Record<string, McpCatalogMapping> = {
+  // Platform capability catalog meta-tool (Issue #1100). Read-only projection of
+  // AI Studio's own registries. Gated by the low, broadly-granted `platform:read`
+  // scope so any authenticated caller (student/staff/administrator, and the
+  // scoped agent) can discover current capabilities. Non-destructive. Exposed on
+  // the `internal` surface too so an in-process agent loop can also read it.
+  describe_capabilities: {
+    identifier: "platform.describe_capabilities",
+    requiredScope: "platform:read",
+    internalScopes: ["platform:read"],
+  },
   search_decisions: {
     identifier: "decisions.search",
     requiredScope: "mcp:search_decisions",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,8 @@
     "migration:list": "tsx scripts/drizzle-helpers/list-migrations.ts",
     "openapi:generate": "bun scripts/openapi/generate-from-catalog.ts",
     "openapi:check": "bun scripts/openapi/generate-from-catalog.ts --check",
+    "capabilities:generate": "bun scripts/capabilities/generate-catalog.ts",
+    "capabilities:check": "bun scripts/capabilities/generate-catalog.ts --check",
     "db:up": "docker compose -f docker-compose.dev.yml up -d postgres",
     "db:down": "docker compose -f docker-compose.dev.yml down",
     "db:reset": "docker compose -f docker-compose.dev.yml down -v && docker compose -f docker-compose.dev.yml up -d postgres",

--- a/scripts/capabilities/generate-catalog.ts
+++ b/scripts/capabilities/generate-catalog.ts
@@ -1,0 +1,60 @@
+/**
+ * Capability catalog generator CLI (Issue #1100).
+ *
+ * Writes the committed snapshot of AI Studio's capability catalog — the live
+ * projection of `TOOL_MANIFEST` + `CAPABILITY_MANIFEST` + `API_SCOPES`/`ROLE_SCOPES`
+ * built by `lib/capabilities/capability-catalog.ts`. Mirrors the OpenAPI generator
+ * (`scripts/openapi/generate-from-catalog.ts`): the file is checked in, and CI runs
+ * `--check` so a registry change that isn't regenerated fails the build. This is the
+ * drift guard and the seed for a future OpenWiki capability page.
+ *
+ * Output: `docs/API/v1/generated/capability-catalog.json`.
+ *
+ * Usage:
+ *   bun run capabilities:generate     # write the catalog
+ *   bun run capabilities:check        # fail (exit 1) if the committed catalog drifts
+ */
+
+import { writeFileSync, readFileSync, mkdirSync, existsSync } from "node:fs"
+import { dirname, join } from "node:path"
+import { buildCapabilityCatalog } from "@/lib/capabilities/capability-catalog"
+
+const OUTPUT_PATH = join(
+  process.cwd(),
+  "docs/API/v1/generated/capability-catalog.json"
+)
+
+/** Deterministic, newline-terminated JSON so the committed file diffs cleanly. */
+function serialize(): string {
+  return JSON.stringify(buildCapabilityCatalog(), null, 2) + "\n"
+}
+
+function main(): void {
+  const check = process.argv.includes("--check")
+  const content = serialize()
+
+  if (check) {
+    if (!existsSync(OUTPUT_PATH)) {
+      console.error(
+        `[capabilities] ${OUTPUT_PATH} is missing. Run \`bun run capabilities:generate\`.`
+      )
+      process.exit(1)
+    }
+    const current = readFileSync(OUTPUT_PATH, "utf8")
+    if (current !== content) {
+      console.error(
+        "[capabilities] Generated capability catalog is out of date. " +
+          "Run `bun run capabilities:generate` and commit the result."
+      )
+      process.exit(1)
+    }
+    console.log("[capabilities] capability-catalog.json is in sync.")
+    return
+  }
+
+  mkdirSync(dirname(OUTPUT_PATH), { recursive: true })
+  writeFileSync(OUTPUT_PATH, content)
+  console.log(`[capabilities] Wrote ${OUTPUT_PATH}`)
+}
+
+main()

--- a/tests/e2e/mcp-describe-capabilities.spec.ts
+++ b/tests/e2e/mcp-describe-capabilities.spec.ts
@@ -1,0 +1,95 @@
+import { test, expect } from './fixtures'
+
+/**
+ * E2E flow `mcp-describe-capabilities` (Issue #1100).
+ *
+ * Exercises the live capability-catalog meta-tool on POST /api/mcp:
+ *   - GUARD (CI-safe, no key): an UNAUTHENTICATED caller never reaches the
+ *     catalog, so `describe_capabilities` is never exposed without a credential.
+ *   - FUNCTIONAL (gated): with a `platform:read` API key, tools/list surfaces the
+ *     tool and tools/call returns a catalog with both `actions[]` (invocable,
+ *     incl. `assistants.execute`) and `features[]` (UI map, incl. `model-compare`).
+ *
+ * The functional flow needs a seeded MCP API key (sk-…) holding `platform:read`;
+ * CI has none, so it skips unless PLATFORM_READ_E2E_API_KEY is set. The
+ * deterministic scope-gating + projection logic is covered by unit + integration
+ * tests (tests/unit/lib/capabilities/capability-catalog.test.ts and
+ * tests/unit/lib/mcp/describe-capabilities-tool.test.ts).
+ */
+
+const PLATFORM_KEY = process.env.PLATFORM_READ_E2E_API_KEY
+
+function rpc(method: string, params?: Record<string, unknown>, id = 1) {
+  return { jsonrpc: '2.0', method, id, ...(params ? { params } : {}) }
+}
+
+test.describe('describe_capabilities — auth gate (CI-safe)', () => {
+  test('unauthenticated tools/list does not expose describe_capabilities', async ({
+    request,
+  }) => {
+    const resp = await request.post('/api/mcp', { data: rpc('tools/list') })
+    // The auth middleware rejects before the catalog runs, so the tool is never
+    // listed without a credential.
+    expect(resp.status()).toBe(401)
+  })
+
+  test('unauthenticated tools/call describe_capabilities is rejected', async ({
+    request,
+  }) => {
+    const resp = await request.post('/api/mcp', {
+      data: rpc('tools/call', { name: 'describe_capabilities', arguments: {} }),
+    })
+    expect(resp.status()).toBe(401)
+  })
+})
+
+test.describe('describe_capabilities — platform:read caller', () => {
+  test.skip(
+    !PLATFORM_KEY,
+    'Set PLATFORM_READ_E2E_API_KEY (an sk- key holding platform:read) to run'
+  )
+
+  test('tools/list surfaces describe_capabilities for a platform:read key', async ({
+    request,
+  }) => {
+    const resp = await request.post('/api/mcp', {
+      headers: { Authorization: `Bearer ${PLATFORM_KEY}` },
+      data: rpc('tools/list'),
+    })
+    expect(resp.status()).toBe(200)
+    const body = await resp.json()
+    const names = (body.result?.tools as Array<{ name: string }>).map(
+      (t) => t.name
+    )
+    expect(names).toContain('describe_capabilities')
+  })
+
+  test('tools/call returns actions[] and features[] with known entries', async ({
+    request,
+  }) => {
+    const resp = await request.post('/api/mcp', {
+      headers: { Authorization: `Bearer ${PLATFORM_KEY}` },
+      data: rpc('tools/call', {
+        name: 'describe_capabilities',
+        arguments: {},
+      }),
+    })
+    expect(resp.status()).toBe(200)
+    const body = await resp.json()
+    // The MCP tool result carries the catalog JSON as a text content block.
+    const text = (body.result?.content as Array<{ text: string }>)[0].text
+    const catalog = JSON.parse(text) as {
+      actions: Array<{ identifier: string; agentInvocable: boolean }>
+      features: Array<{ identifier: string }>
+    }
+    expect(Array.isArray(catalog.actions)).toBe(true)
+    expect(Array.isArray(catalog.features)).toBe(true)
+    // Known invocable action + known UI feature (the two namespaces).
+    expect(
+      catalog.actions.some((a) => a.identifier === 'assistants.execute')
+    ).toBe(true)
+    expect(
+      catalog.features.some((f) => f.identifier === 'model-compare')
+    ).toBe(true)
+  })
+})

--- a/tests/unit/lib/capabilities/capability-catalog.test.ts
+++ b/tests/unit/lib/capabilities/capability-catalog.test.ts
@@ -144,6 +144,28 @@ describe("buildCapabilityCatalog", () => {
     )
   })
 
+  it("query filter also matches actions by required scope (docs say scope is searchable)", () => {
+    // A scope query surfaces the actions gated by that scope, not just the scope
+    // reference entry.
+    const byBaseScope = buildCapabilityCatalog({
+      section: "actions",
+      query: "platform:read",
+    })
+    expect(
+      byBaseScope.actions?.some(
+        (a) => a.identifier === "platform.describe_capabilities"
+      )
+    ).toBe(true)
+    // A per-surface (REST) scope also matches the action that requires it.
+    const byRestScope = buildCapabilityCatalog({
+      section: "actions",
+      query: "assistants:execute",
+    })
+    expect(
+      byRestScope.actions?.some((a) => a.identifier === "assistants.execute")
+    ).toBe(true)
+  })
+
   it("summary counts match the returned arrays, incl. agentInvocableActions", () => {
     const cat = buildCapabilityCatalog()
     expect(cat.summary.actions).toBe(cat.actions?.length)

--- a/tests/unit/lib/capabilities/capability-catalog.test.ts
+++ b/tests/unit/lib/capabilities/capability-catalog.test.ts
@@ -53,6 +53,35 @@ describe("buildCapabilityCatalog", () => {
     expect(aiSdkOnly?.agentInvocable).toBe(false)
   })
 
+  it("REST-surface view reports the REST override scope, not the base MCP scope", () => {
+    // Regression for the codex P2: describe_capabilities({surface:"rest"}) must not
+    // tell a REST/API-key caller to request the MCP scope, which won't authorize
+    // the REST endpoint.
+    const exec = buildCapabilityCatalog({
+      section: "actions",
+      surface: "rest",
+    }).actions?.find((a) => a.identifier === "assistants.execute")
+    expect(exec).toBeDefined()
+    expect(exec?.requiredScopes).toEqual(["assistants:execute"])
+    expect(exec?.scopesBySurface.rest).toEqual(["assistants:execute"])
+    expect(exec?.scopesBySurface.mcp).toEqual(["mcp:execute_assistant"])
+  })
+
+  it("unfiltered actions expose scopesBySurface for every surface, base requiredScopes default", () => {
+    const exec = buildCapabilityCatalog().actions?.find(
+      (a) => a.identifier === "assistants.execute"
+    )
+    // Default (no surface filter) reports the base scopes...
+    expect(exec?.requiredScopes).toEqual(["mcp:execute_assistant"])
+    // ...but the per-surface truth is always available.
+    expect(Object.keys(exec?.scopesBySurface ?? {}).sort()).toEqual([
+      "internal",
+      "mcp",
+      "rest",
+    ])
+    expect(exec?.scopesBySurface.rest).toEqual(["assistants:execute"])
+  })
+
   it("FRESHNESS: every CAPABILITY_MANIFEST entry is projected — no per-feature code", () => {
     // The core promise of #1100: the catalog is a projection, not a hand list.
     // Adding a CAPABILITY_MANIFEST entry surfaces here with zero other changes.

--- a/tests/unit/lib/capabilities/capability-catalog.test.ts
+++ b/tests/unit/lib/capabilities/capability-catalog.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect } from "@jest/globals"
+
+// Pure-builder unit tests (Issue #1100). buildCapabilityCatalog reads only the
+// real metadata registries (TOOL_MANIFEST, CAPABILITY_MANIFEST, API_SCOPES/
+// ROLE_SCOPES) — no DB, no handlers — so nothing needs mocking here.
+import { buildCapabilityCatalog } from "@/lib/capabilities/capability-catalog"
+import { CAPABILITY_MANIFEST } from "@/lib/capabilities/manifest"
+import { TOOL_MANIFEST } from "@/lib/tools/catalog/manifest"
+
+describe("buildCapabilityCatalog", () => {
+  it("includes a known action and a known feature (DoD)", () => {
+    const cat = buildCapabilityCatalog()
+    expect(cat.actions?.some((a) => a.identifier === "assistants.execute")).toBe(
+      true
+    )
+    expect(cat.features?.some((f) => f.identifier === "model-compare")).toBe(
+      true
+    )
+  })
+
+  it("projects describe_capabilities as an MCP-invocable action gated by platform:read", () => {
+    const action = buildCapabilityCatalog().actions?.find(
+      (a) => a.identifier === "platform.describe_capabilities"
+    )
+    expect(action).toBeDefined()
+    expect(action?.name).toBe("describe_capabilities")
+    expect(action?.agentInvocable).toBe(true)
+    expect(action?.requiredScopes).toContain("platform:read")
+    expect(action?.destructive).toBe(false)
+  })
+
+  it("exposes platform:read in the scope reference with the granting roles", () => {
+    const scope = buildCapabilityCatalog().scopes?.find(
+      (s) => s.scope === "platform:read"
+    )
+    expect(scope).toBeDefined()
+    expect(scope?.roles).toEqual(
+      expect.arrayContaining(["student", "staff", "administrator"])
+    )
+  })
+
+  it("flags destructive actions and marks non-MCP surfaces as not agent-invocable", () => {
+    const actions = buildCapabilityCatalog().actions ?? []
+    // A content mutation is destructive AND (on the mcp surface) agent-invocable.
+    const createDoc = actions.find((a) => a.identifier === "content.create_document")
+    expect(createDoc?.destructive).toBe(true)
+    expect(createDoc?.agentInvocable).toBe(true)
+    // An ai_sdk-only action exists but is NOT reachable over MCP.
+    const aiSdkOnly = actions.find(
+      (a) => a.surfaces.length === 1 && a.surfaces[0] === "ai_sdk"
+    )
+    expect(aiSdkOnly).toBeDefined()
+    expect(aiSdkOnly?.agentInvocable).toBe(false)
+  })
+
+  it("FRESHNESS: every CAPABILITY_MANIFEST entry is projected — no per-feature code", () => {
+    // The core promise of #1100: the catalog is a projection, not a hand list.
+    // Adding a CAPABILITY_MANIFEST entry surfaces here with zero other changes.
+    const featureIds = new Set(
+      buildCapabilityCatalog().features?.map((f) => f.identifier)
+    )
+    for (const entry of CAPABILITY_MANIFEST) {
+      expect(featureIds.has(entry.identifier)).toBe(true)
+    }
+    expect(buildCapabilityCatalog().features).toHaveLength(
+      CAPABILITY_MANIFEST.length
+    )
+  })
+
+  it("FRESHNESS: every TOOL_MANIFEST identifier is projected into actions (deduped)", () => {
+    const actionIds = new Set(
+      buildCapabilityCatalog().actions?.map((a) => a.identifier)
+    )
+    const manifestIds = new Set(TOOL_MANIFEST.map((e) => e.identifier))
+    for (const id of manifestIds) {
+      expect(actionIds.has(id)).toBe(true)
+    }
+    expect(buildCapabilityCatalog().actions).toHaveLength(manifestIds.size)
+  })
+
+  it("keeps capabilities and scopes as separate namespaces (no cross-mapping)", () => {
+    const cat = buildCapabilityCatalog()
+    for (const f of cat.features ?? []) {
+      expect(f).not.toHaveProperty("scope")
+      expect(f).not.toHaveProperty("requiredScopes")
+      expect(f.humanDriven).toBe(true)
+    }
+  })
+
+  it("section filter returns only the requested section", () => {
+    const cat = buildCapabilityCatalog({ section: "features" })
+    expect(cat.features).toBeDefined()
+    expect(cat.actions).toBeUndefined()
+    expect(cat.scopes).toBeUndefined()
+    expect(cat.summary.actions).toBe(0)
+    expect(cat.summary.features).toBe(CAPABILITY_MANIFEST.length)
+  })
+
+  it("surface filter narrows actions; every mcp action is agent-invocable", () => {
+    const cat = buildCapabilityCatalog({ section: "actions", surface: "mcp" })
+    expect(cat.actions?.length).toBeGreaterThan(0)
+    for (const a of cat.actions ?? []) {
+      expect(a.surfaces).toContain("mcp")
+      expect(a.agentInvocable).toBe(true)
+    }
+  })
+
+  it("query filter matches across identifier/name/description", () => {
+    const cat = buildCapabilityCatalog({ query: "describe_capabilities" })
+    expect(
+      cat.actions?.some((a) => a.identifier === "platform.describe_capabilities")
+    ).toBe(true)
+    expect(cat.actions?.some((a) => a.identifier === "decisions.search")).toBe(
+      false
+    )
+  })
+
+  it("summary counts match the returned arrays, incl. agentInvocableActions", () => {
+    const cat = buildCapabilityCatalog()
+    expect(cat.summary.actions).toBe(cat.actions?.length)
+    expect(cat.summary.features).toBe(cat.features?.length)
+    expect(cat.summary.scopes).toBe(cat.scopes?.length)
+    expect(cat.summary.agentInvocableActions).toBe(
+      cat.actions?.filter((a) => a.agentInvocable).length
+    )
+  })
+
+  it("is deterministic and sorted by identifier / scope", () => {
+    expect(JSON.stringify(buildCapabilityCatalog())).toBe(
+      JSON.stringify(buildCapabilityCatalog())
+    )
+    const cat = buildCapabilityCatalog()
+    const actionIds = cat.actions?.map((a) => a.identifier) ?? []
+    expect(actionIds).toEqual(
+      [...actionIds].sort((x, y) => x.localeCompare(y))
+    )
+    const scopeIds = cat.scopes?.map((s) => s.scope) ?? []
+    expect(scopeIds).toEqual([...scopeIds].sort((x, y) => x.localeCompare(y)))
+  })
+})

--- a/tests/unit/lib/mcp/describe-capabilities-tool.test.ts
+++ b/tests/unit/lib/mcp/describe-capabilities-tool.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect, beforeEach } from "@jest/globals"
+
+// Registration + scope-gating tests for the describe_capabilities MCP meta-tool
+// (Issue #1100). Proves the tool is wired across the catalog touchpoints and that
+// the platform:read scope gates both tools/list visibility and tools/call.
+//
+// Harness mirrors tests/unit/lib/mcp/jsonrpc-catalog.test.ts: the DB layer is
+// mocked (manifest/code tools only), and TOOL_HANDLERS is mocked so dispatch
+// resolves without pulling the real service/node:crypto graph. The
+// describe_capabilities handler here delegates to the REAL builder so the
+// tools/call assertion checks the actual projected catalog.
+
+let dbRows: Record<string, unknown>[] = []
+/* eslint-disable no-var */
+// `var` so the (hoisted) jest.mock factory can reference it, matching the sibling
+// jsonrpc-catalog harness.
+var describeHandler: jest.Mock
+/* eslint-enable no-var */
+
+jest.mock("drizzle-orm", () => ({
+  ne: (...args: unknown[]) => ({ op: "ne", args }),
+}))
+
+jest.mock("@/lib/db/schema", () => ({
+  toolCatalog: { table: "tool_catalog", source: "tool_catalog.source" },
+}))
+
+jest.mock("@/lib/db/drizzle-client", () => ({
+  executeQuery: jest.fn(() => Promise.resolve(dbRows)),
+}))
+
+jest.mock("@/lib/logger", () => ({
+  createLogger: () => ({
+    info: jest.fn(),
+    debug: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  }),
+}))
+
+jest.mock("@/lib/mcp/tool-handlers", () => ({
+  TOOL_HANDLERS: {
+    describe_capabilities: (
+      args: Record<string, unknown>,
+      context: unknown
+    ) => describeHandler(args, context),
+  },
+}))
+
+import { handleJsonRpcRequest } from "@/lib/mcp/jsonrpc-handler"
+import type { McpToolContext } from "@/lib/mcp/types"
+import { toolCatalogInstance } from "@/lib/tools/catalog/catalog"
+import { buildCapabilityCatalog } from "@/lib/capabilities/capability-catalog"
+
+// Delegate to the REAL builder so tools/call returns the actual catalog.
+describeHandler = jest.fn(async (args: Record<string, unknown>) => ({
+  content: [
+    { type: "text", text: JSON.stringify(buildCapabilityCatalog(args)) },
+  ],
+}))
+
+function ctx(scopes: string[]): McpToolContext {
+  return { userId: 1, cognitoSub: "sub", scopes, requestId: "req" }
+}
+
+describe("describe_capabilities MCP meta-tool (#1100)", () => {
+  beforeEach(() => {
+    dbRows = []
+    describeHandler.mockClear()
+    // Bust the module-level catalog's 5-min DB cache between tests.
+    toolCatalogInstance.invalidate()
+  })
+
+  it("tools/list exposes describe_capabilities to a platform:read caller", async () => {
+    const res = await handleJsonRpcRequest(
+      { jsonrpc: "2.0", method: "tools/list", id: 1 },
+      ctx(["platform:read"])
+    )
+    const result = res.result as { tools: { name: string }[] }
+    expect(result.tools.map((t) => t.name)).toContain("describe_capabilities")
+  })
+
+  it("tools/list hides describe_capabilities from a caller without platform:read", async () => {
+    const res = await handleJsonRpcRequest(
+      { jsonrpc: "2.0", method: "tools/list", id: 2 },
+      ctx(["mcp:search_decisions"])
+    )
+    const result = res.result as { tools: { name: string }[] }
+    expect(result.tools.map((t) => t.name)).not.toContain(
+      "describe_capabilities"
+    )
+  })
+
+  it("tools/call returns actions[] and features[] with the expected known entries", async () => {
+    const res = await handleJsonRpcRequest(
+      {
+        jsonrpc: "2.0",
+        method: "tools/call",
+        id: 3,
+        params: { name: "describe_capabilities", arguments: {} },
+      },
+      ctx(["platform:read"])
+    )
+    expect(describeHandler).toHaveBeenCalledTimes(1)
+    const result = res.result as { content: { text: string }[] }
+    const parsed = JSON.parse(result.content[0].text) as {
+      actions: { identifier: string; agentInvocable: boolean }[]
+      features: { identifier: string }[]
+    }
+    expect(Array.isArray(parsed.actions)).toBe(true)
+    expect(Array.isArray(parsed.features)).toBe(true)
+    expect(parsed.actions.some((a) => a.identifier === "assistants.execute")).toBe(
+      true
+    )
+    expect(parsed.features.some((f) => f.identifier === "model-compare")).toBe(
+      true
+    )
+    // The meta-tool advertises itself as agent-invocable.
+    expect(
+      parsed.actions.find(
+        (a) => a.identifier === "platform.describe_capabilities"
+      )?.agentInvocable
+    ).toBe(true)
+  })
+
+  it("tools/call denies a caller without platform:read (Insufficient scope)", async () => {
+    const res = await handleJsonRpcRequest(
+      {
+        jsonrpc: "2.0",
+        method: "tools/call",
+        id: 4,
+        params: { name: "describe_capabilities", arguments: {} },
+      },
+      ctx(["mcp:search_decisions"])
+    )
+    expect(describeHandler).not.toHaveBeenCalled()
+    expect(res.error?.code).toBe(-32602)
+    expect(res.error?.message).toMatch(/Insufficient scope/)
+  })
+})


### PR DESCRIPTION
## Summary
Implements #1100 — a live, always-current view of what AI Studio can do for the OpenClaw agent (and any scoped MCP caller), served as a read-only `describe_capabilities` meta-tool on the existing `/api/mcp`, plus a thin `psd-aistudio` skill. It is a **projection of the app's own source-of-truth registries** (the files a dev must update to ship a feature), so new features appear the moment their environment deploys — no agent rebuild, no hand-maintained list that can drift.

## Changes
- **Phase 1 — builder**: `lib/capabilities/capability-catalog.ts` — pure, Edge-safe, deterministic `buildCapabilityCatalog({section?,surface?,query?})`. Projects `TOOL_MANIFEST` → `actions[]` (each flagged `agentInvocable` when on the `mcp` surface, plus `surfaces`/`requiredScopes`/`destructive`), `CAPABILITY_MANIFEST` → `features[]` (human-driven UI, `defaultRoles`), and `API_SCOPES`/`ROLE_SCOPES` → `scopes[]` reference. Capabilities and scopes stay **separate identifier namespaces** (never cross-mapped) per `docs/architecture/capabilities-and-scopes.md`.
- **Phase 2 — live meta-tool**: `describe_capabilities` (`platform.describe_capabilities`) wired across the catalog touchpoints — `MCP_TOOLS` (`tool-registry.ts`), `MCP_TOOL_CATALOG_MAP` (`manifest.ts`, self-enforced at module load), `TOOL_HANDLERS` (`tool-handlers.ts`, reads the builder **on every call** = the freshness engine). New low, broadly-granted `platform:read` scope added to `API_SCOPES` + granted to student/staff/administrator in `ROLE_SCOPES`. (Note: the issue's "4th touchpoint" `TOOL_SCOPE_MAP` was removed in the epic #922 audit; scope now lives in `MCP_TOOL_CATALOG_MAP`.)
- **Phase 3 — skill + infra**: `infra/agent-image/skills/psd-aistudio/{SKILL.md,run.js,common.js,package.json}` — single `callMcp()` JSON-RPC chokepoint; `capabilities`/`list` commands; auth via a scoped `sk-` key holding `platform:read`. `AISTUDIO_MCP_URL` wired into `runtimeEnvVars` in `agent-platform-stack.ts` (derived from `APP_BASE_URL`). The action-executing passthrough + production per-user credential are **deferred** to the in-progress MCP action-tool work (documented in SKILL.md) — no second auth mechanism invented.
- **Phase 4 — drift guard**: `scripts/capabilities/generate-catalog.ts` + `capabilities:generate`/`capabilities:check` scripts + committed `docs/API/v1/generated/capability-catalog.json`; CI runs `capabilities:check` next to `openapi:check`.

## Verification (all green before opening)
- Build/typecheck: ✅ `tsc --noEmit` clean (app + `infra`)
- Lint (zero-warning in touched files): ✅ `eslint .` 0 errors; none of the changed files produce warnings
- Drift: ✅ `bun run capabilities:check` in sync
- Tests: ✅ `test:ci` — **2532 passed, 0 failed** (204 suites); new unit suites: builder (`capability-catalog.test.ts`) + MCP registration/scope-gating (`describe-capabilities-tool.test.ts`)
- E2E: ✅ flow `mcp-describe-capabilities` — 4/4 pass against a live `:3100` server (2 CI-safe guard + 2 gated functional)
- cdk synth: ✅ `AIStudio-AgentPlatformStack-Dev` synthesizes clean (`AISTUDIO_MCP_URL` in `runtimeEnvVars`)

## Runtime verification (live server + real platform:read key)
Ran against a real dev server on `:3100` with an `sk-` key actually minted in the DB:
- `psd-aistudio capabilities` → full map: **24 actions / 8 features / 24 scopes / 17 agent-invocable** (matches the committed catalog); `model-compare` feature present; `platform:read` roles = student/staff/administrator.
- `psd-aistudio list` (platform:read key) → `describe_capabilities` present (scope-filtered wire list).
- **Negative scope (live)**: a `chat:read`-only key sees no `describe_capabilities` in `tools/list` **and** gets `-32602 Insufficient scope for tool: describe_capabilities` on the call (skill exits 12) — proves the `platform:read` gate.
- **Freshness**: the builder unit test asserts `features.length === CAPABILITY_MANIFEST.length` and every manifest entry projects — i.e. adding a `CAPABILITY_MANIFEST` entry surfaces in the tool output with zero other code changes (the invariant #1100 requires, enforced permanently instead of a temp add/revert).

## Evidence
_N/A — no UI surface. This feature is an MCP meta-tool + agent CLI skill; verification is the API/E2E/runtime results above (no browser view to screenshot)._

## Known deferral (intentional — per issue #1100)
Per issue #1100's locked Phase-3 decision, the **production** agent-image credential (a dedicated agent service-account `sk-` key, or per-user JWT) is owned by / dependent on the **in-progress MCP action-tool work**, and the issue explicitly says *"do NOT invent a second mechanism"* here. So this PR wires only `AISTUDIO_MCP_URL`. The `psd-aistudio` skill reads its `platform:read` key from `AISTUDIO_MCP_API_KEY` / `AISTUDIO_MCP_API_KEY_SECRET_ID` and was **dev-validated end-to-end** against a running server with a real minted key; until the shared prod credential lands it fails cleanly (exit 11, clear message). This is a documented, phased-rollout gap, not a defect in this issue's scope — the DoD (dev-validated skill + live tool + drift guard) is fully met.

Closes #1100

