### PR TITLE
fix(agent-image): mid-turn compaction guard, bedrock memory plugin, venv-absolute python

### DIFF
--- a/infra/agent-image/Dockerfile
+++ b/infra/agent-image/Dockerfile
@@ -374,6 +374,19 @@ COPY skills /opt/psd-skills
 # "Failed to mount overlay: No such file or directory" (agent outage 2026-07-02,
 # caused by adding the gws-wrapper COPY at 53). Absolute `cd` paths so the chain
 # is independent of prior CWD. Keep new skills in this RUN, not new RUNs.
+#
+# The tail of this RUN also vendors the @openclaw/amazon-bedrock-provider
+# plugin: it registers the "bedrock" memory-embedding adapter that
+# openclaw.json's memorySearch.provider names. The published OpenClaw base
+# image ships with NO bundled extensions (they're an opt-in OPENCLAW_EXTENSIONS
+# build arg of the upstream Dockerfile), so memory sync failed every cycle with
+# "Unknown memory embedding provider: bedrock" (2026-07-10). It must live under
+# /opt (image-owned): ~/.openclaw is runtime-persistent storage that shadows
+# anything written there at build time. Loaded via openclaw.json
+# plugins.load.paths. Version-pinned to the same OpenClaw release this image
+# pins (2026.6.11); npm verifies the registry integrity hash on pack. The
+# tarball is self-contained (bundleDependencies: @aws-sdk clients ship inside
+# it, with an npm-shrinkwrap.json), so no npm install runs after extraction.
 RUN cd /opt/psd-skills/psd-schedules && npm install --omit=dev --no-audit --no-fund && \
     cd /opt/psd-skills/psd-credentials && npm install --omit=dev --no-audit --no-fund && \
     cd /opt/psd-skills/psd-skills-meta && npm install --omit=dev --no-audit --no-fund && \
@@ -381,7 +394,13 @@ RUN cd /opt/psd-skills/psd-schedules && npm install --omit=dev --no-audit --no-f
     cd /opt/psd-skills/psd-image-gen && npm install --omit=dev --no-audit --no-fund && \
     cd /opt/psd-skills/psd-html-artifact && npm install --omit=dev --no-audit --no-fund && \
     cd /opt/psd-skills/psd-failure-report && npm install --omit=dev --no-audit --no-fund && \
-    cd /opt/psd-skills/psd-email-triage && npm install --omit=dev --no-audit --no-fund
+    cd /opt/psd-skills/psd-email-triage && npm install --omit=dev --no-audit --no-fund && \
+    mkdir -p /opt/openclaw-plugins && cd /opt/openclaw-plugins && \
+    npm pack @openclaw/amazon-bedrock-provider@2026.6.11 && \
+    tar -xzf openclaw-amazon-bedrock-provider-2026.6.11.tgz && \
+    mv package amazon-bedrock && \
+    rm openclaw-amazon-bedrock-provider-2026.6.11.tgz && \
+    test -f /opt/openclaw-plugins/amazon-bedrock/openclaw.plugin.json
 # chat-card has zero npm deps. chat-chart's npm install is paired with the
 # matplotlib install above — both stay disabled until we figure out the
 # AgentCore overlay-mount failure. With both off the image boots cleanly

--- a/infra/agent-image/openclaw.json
+++ b/infra/agent-image/openclaw.json
@@ -40,6 +40,11 @@
       "heartbeat": {
         "every": "0m"
       },
+      "compaction": {
+        "midTurnPrecheck": {
+          "enabled": true
+        }
+      },
       "memorySearch": {
         "provider": "bedrock",
         "model": "amazon.titan-embed-text-v2:0"
@@ -63,9 +68,20 @@
     "enabled": false
   },
   "plugins": {
+    "load": {
+      "paths": ["/opt/openclaw-plugins/amazon-bedrock"]
+    },
     "entries": {
       "active-memory": {
         "enabled": false
+      },
+      "amazon-bedrock": {
+        "enabled": true,
+        "config": {
+          "discovery": {
+            "enabled": false
+          }
+        }
       }
     }
   },

--- a/infra/agent-image/skills/psd-last30days/SKILL.md
+++ b/infra/agent-image/skills/psd-last30days/SKILL.md
@@ -2,7 +2,7 @@
 name: psd-last30days
 summary: Research what people said about a topic in the last ~30 days across keyless social/community sources (Hacker News, Reddit, arXiv, GitHub, Google News) and return a grounded, cited brief — in chat, as an S3 HTML artifact, or both.
 description: Research recent chatter on a topic — "what did people actually say about X in the last ~30 days?" Fans out across free, keyless sources (Hacker News, Reddit, arXiv, GitHub, Google News), ranks by engagement/recency, de-duplicates, and returns a source-cited brief you synthesize. Default output is a Markdown brief in chat; on request it also (or instead) produces a self-contained HTML page uploaded to S3 and shareable by link. Use for trend/pulse/"what's new" research on a person, product, company, or topic.
-allowed-tools: Bash(python3:*)
+allowed-tools: Bash(python3:*), Bash(/opt/agentcore-venv/bin/python3:*)
 ---
 
 # psd-last30days
@@ -40,7 +40,7 @@ path to the caller). For the default Markdown mode it is optional but harmless.
 ## Usage
 
 ```bash
-python3 /opt/psd-skills/psd-last30days/scripts/last30days.py --topic "<topic>"
+/opt/agentcore-venv/bin/python3 /opt/psd-skills/psd-last30days/scripts/last30days.py --topic "<topic>"
 ```
 
 Options:
@@ -56,16 +56,16 @@ Options:
 
 ```bash
 # Default: Markdown brief in chat
-python3 /opt/psd-skills/psd-last30days/scripts/last30days.py --topic "llama 4" --days 14
+/opt/agentcore-venv/bin/python3 /opt/psd-skills/psd-last30days/scripts/last30days.py --topic "llama 4" --days 14
 
 # Only two sources, tighter list
-python3 /opt/psd-skills/psd-last30days/scripts/last30days.py --topic "chromebooks in schools" --sources web,hackernews
+/opt/agentcore-venv/bin/python3 /opt/psd-skills/psd-last30days/scripts/last30days.py --topic "chromebooks in schools" --sources web,hackernews
 
 # HTML artifact uploaded to S3 (public-by-link)
-python3 /opt/psd-skills/psd-last30days/scripts/last30days.py --user name@psd401.net --topic "gpt-5" --format html
+/opt/agentcore-venv/bin/python3 /opt/psd-skills/psd-last30days/scripts/last30days.py --user name@psd401.net --topic "gpt-5" --format html
 
 # Both: brief in chat AND an S3 HTML link
-python3 /opt/psd-skills/psd-last30days/scripts/last30days.py --user name@psd401.net --topic "gpt-5" --format both
+/opt/agentcore-venv/bin/python3 /opt/psd-skills/psd-last30days/scripts/last30days.py --user name@psd401.net --topic "gpt-5" --format both
 ```
 
 ## Output modes — how to choose

--- a/infra/agent-image/skills/psd-last30days/SKILL.md
+++ b/infra/agent-image/skills/psd-last30days/SKILL.md
@@ -2,7 +2,7 @@
 name: psd-last30days
 summary: Research what people said about a topic in the last ~30 days across keyless social/community sources (Hacker News, Reddit, arXiv, GitHub, Google News) and return a grounded, cited brief — in chat, as an S3 HTML artifact, or both.
 description: Research recent chatter on a topic — "what did people actually say about X in the last ~30 days?" Fans out across free, keyless sources (Hacker News, Reddit, arXiv, GitHub, Google News), ranks by engagement/recency, de-duplicates, and returns a source-cited brief you synthesize. Default output is a Markdown brief in chat; on request it also (or instead) produces a self-contained HTML page uploaded to S3 and shareable by link. Use for trend/pulse/"what's new" research on a person, product, company, or topic.
-allowed-tools: Bash(python3:*), Bash(/opt/agentcore-venv/bin/python3:*)
+allowed-tools: Bash(/opt/agentcore-venv/bin/python3:*)
 ---
 
 # psd-last30days

--- a/infra/agent-image/skills/psd-pdf-to-markdown/SKILL.md
+++ b/infra/agent-image/skills/psd-pdf-to-markdown/SKILL.md
@@ -2,7 +2,7 @@
 name: psd-pdf-to-markdown
 summary: Convert a PDF (from a URL, workspace S3 key, or container path) into clean Markdown with tables preserved — no image files, no model download.
 description: Convert a PDF to clean Markdown with tables preserved and images dropped. Use when the user wants to turn a PDF into Markdown or extract a PDF's text/tables for further processing. Input is a public URL, a workspace S3 key, or a container file path.
-allowed-tools: Bash(python3:*)
+allowed-tools: Bash(python3:*), Bash(/opt/agentcore-venv/bin/python3:*)
 ---
 
 # psd-pdf-to-markdown
@@ -32,9 +32,9 @@ header regardless of source.
 ## Usage
 
 ```bash
-python3 /opt/psd-skills/psd-pdf-to-markdown/scripts/convert.py --url "https://example.com/report.pdf"
-python3 /opt/psd-skills/psd-pdf-to-markdown/scripts/convert.py --user <email> --s3-key "public-images/<email>/report.pdf"
-python3 /opt/psd-skills/psd-pdf-to-markdown/scripts/convert.py --path "/home/node/workspace/report.pdf"
+/opt/agentcore-venv/bin/python3 /opt/psd-skills/psd-pdf-to-markdown/scripts/convert.py --url "https://example.com/report.pdf"
+/opt/agentcore-venv/bin/python3 /opt/psd-skills/psd-pdf-to-markdown/scripts/convert.py --user <email> --s3-key "public-images/<email>/report.pdf"
+/opt/agentcore-venv/bin/python3 /opt/psd-skills/psd-pdf-to-markdown/scripts/convert.py --path "/home/node/workspace/report.pdf"
 ```
 
 Options:

--- a/infra/agent-image/skills/psd-pdf-to-markdown/SKILL.md
+++ b/infra/agent-image/skills/psd-pdf-to-markdown/SKILL.md
@@ -2,7 +2,7 @@
 name: psd-pdf-to-markdown
 summary: Convert a PDF (from a URL, workspace S3 key, or container path) into clean Markdown with tables preserved — no image files, no model download.
 description: Convert a PDF to clean Markdown with tables preserved and images dropped. Use when the user wants to turn a PDF into Markdown or extract a PDF's text/tables for further processing. Input is a public URL, a workspace S3 key, or a container file path.
-allowed-tools: Bash(python3:*), Bash(/opt/agentcore-venv/bin/python3:*)
+allowed-tools: Bash(/opt/agentcore-venv/bin/python3:*)
 ---
 
 # psd-pdf-to-markdown

--- a/infra/agent-image/skills/psd-tts/SKILL.md
+++ b/infra/agent-image/skills/psd-tts/SKILL.md
@@ -2,7 +2,7 @@
 name: psd-tts
 summary: Turn text into a shareable MP3 with Amazon Polly (generative voices) and return a public HTTPS link — narration, briefings, audio summaries.
 description: Convert text to natural-sounding speech (MP3) with Amazon Polly and return a shareable HTTPS URL. Use when asked to read something aloud, narrate a document, or make an audio version or podcast of text.
-allowed-tools: Bash(python3:*)
+allowed-tools: Bash(python3:*), Bash(/opt/agentcore-venv/bin/python3:*)
 ---
 
 # psd-tts
@@ -24,9 +24,9 @@ and the MP3 chunks are concatenated automatically.
 Text comes from `--text`, `--file`, or stdin (safe for long input):
 
 ```bash
-python3 /opt/psd-skills/psd-tts/scripts/synthesize.py --user <email> --text "Good morning. Here is today's briefing."
+/opt/agentcore-venv/bin/python3 /opt/psd-skills/psd-tts/scripts/synthesize.py --user <email> --text "Good morning. Here is today's briefing."
 
-printf '%s' "$LONG_TEXT" | python3 /opt/psd-skills/psd-tts/scripts/synthesize.py --user <email> --voice Matthew
+printf '%s' "$LONG_TEXT" | /opt/agentcore-venv/bin/python3 /opt/psd-skills/psd-tts/scripts/synthesize.py --user <email> --voice Matthew
 ```
 
 Options:

--- a/infra/agent-image/skills/psd-tts/SKILL.md
+++ b/infra/agent-image/skills/psd-tts/SKILL.md
@@ -2,7 +2,7 @@
 name: psd-tts
 summary: Turn text into a shareable MP3 with Amazon Polly (generative voices) and return a public HTTPS link — narration, briefings, audio summaries.
 description: Convert text to natural-sounding speech (MP3) with Amazon Polly and return a shareable HTTPS URL. Use when asked to read something aloud, narrate a document, or make an audio version or podcast of text.
-allowed-tools: Bash(python3:*), Bash(/opt/agentcore-venv/bin/python3:*)
+allowed-tools: Bash(/opt/agentcore-venv/bin/python3:*)
 ---
 
 # psd-tts


### PR DESCRIPTION
## Summary
Fixes the three production bugs found in tonight's AgentCore runtime logs (2026-07-10 evening session, `/aws/bedrock-agentcore/runtimes/psd_agent_dev-*`):

1. **Context overflow killing long turns** — `compactionAttempts=0` at ~180k tokens: OpenClaw 2026.6.11 only auto-compacts at turn start; the mid-tool-loop guard is opt-in and was off. Enables `agents.defaults.compaction.midTurnPrecheck.enabled` (verified against the pinned tag's docs — truncates/compacts + retries instead of hard-failing). Root cause of both '⚠️ I couldn't finish that' aborts and the 'busy processing another request' session-lock replies.
2. **Memory embedding sync dead** — 'Unknown memory embedding provider: bedrock' every cycle: the `bedrock` adapter is registered by `@openclaw/amazon-bedrock-provider`, and the published base image ships zero bundled extensions. Vendors the plugin (pinned `2026.6.11`, self-contained tarball: bundled @aws-sdk deps + shrinkwrap, manifest-existence asserted) under `/opt/openclaw-plugins` — image-owned, NOT the runtime-persistent `~/.openclaw` — folded into the existing consolidated RUN (54-layer Firecracker ceiling, no new layer), loaded via `plugins.load.paths`, model discovery OFF (embedding contract only; Mantle remains the sole chat path). Auth (`AWS_BEARER_TOKEN_BEDROCK`, `AWS_REGION`) already wired.
3. **TTS/boto3 spawn-context failure** — plain `python3` in SKILL.mds resolves to the boto3-less system python when spawned from node child processes (hit live tonight by the user's morning-brief skill). Hardens `psd-tts`, `psd-last30days` (S3-HTML mode also needs boto3), and `psd-pdf-to-markdown` to absolute `/opt/agentcore-venv/bin/python3`.

## Verification
- openclaw.json parses; every config key verified against openclaw `v2026.6.11` source/docs (`compaction.midTurnPrecheck`, `plugins.load.paths`, plugin manifest `enabledByDefault`/`memoryEmbeddingProviders`).
- `npm pack` smoke-tested locally: tarball name, `package/` layout, `openclaw.plugin.json` (id `amazon-bedrock`, embeddings `[bedrock]`), bundled `node_modules/@aws-sdk` all confirmed.
- The probe-gated image build (boot probe + canary turn) runs in parallel as the functional gate — CI does not build Docker images.

Post-deploy checks for tomorrow's 6 AM 'Morning Dispatch' run: no more `memory sync failed (watch)` spam, no `Context overflow ... compactionAttempts=0`, TTS produces the podcast MP3.

https://claude.ai/code/session_019dVBkHTmcbtyFHRDLJi1Sy