### PR TITLE
fix(ecs): bind standalone server to 0.0.0.0 so the agent-bridge loopback can connect

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -192,6 +192,9 @@ Tool integration for Assistant Architect prompts.
 #### [features/nexus-workspace-chat-editing.md](./features/nexus-workspace-chat-editing.md)
 **Nexus workspace chat editing (§1087)** — when a document/artifact is open beside the chat, the chat can read + edit it (live Yjs document edits via the agent bridge, artifact edits via `createVersion`); server-bound, canView/canEdit-gated, §28.3-screened.
 
+#### [features/atrium-agent-access.md](./features/atrium-agent-access.md)
+**Connecting agents to Atrium content** — how a local MCP client (Claude Code etc.) or the PSD AI Agents (OpenClaw) read/write Atrium documents: API-key setup, the MCP content tools + scope table, the version-based vs live-document distinction, delegated tokens, and the loopback binding hazard for the live bridge.
+
 #### [features/assistant-architect-json-import-spec.md](./features/assistant-architect-json-import-spec.md)
 **Complete JSON import specification** for generating valid assistant import files. Includes schema reference, field types, variable substitution, execution patterns, and comprehensive examples.
 

--- a/docs/features/atrium-agent-access.md
+++ b/docs/features/atrium-agent-access.md
@@ -1,0 +1,135 @@
+# Connecting Agents to Atrium Content
+
+How external agents — a local MCP client (Claude Code, Claude Desktop, any MCP
+client) or the PSD AI Agents (OpenClaw on AgentCore) — read and write Atrium
+documents and artifacts, what each path can and cannot do, and how the live
+collaborative document fits in.
+
+> Transport, auth plumbing, and the full MCP tool registry live in
+> [mcp-server.md](./mcp-server.md). The in-app chat editing path is documented in
+> [nexus-workspace-chat-editing.md](./nexus-workspace-chat-editing.md). This page
+> is the Atrium-specific integration guide.
+
+## The one distinction that matters: version-based vs. live
+
+Atrium content has **two write surfaces**:
+
+| Surface | What it touches | Who can use it today |
+|---|---|---|
+| **Version-based** (MCP content tools, `/api/v1` content endpoints) | Persisted content objects + version snapshots. Reads return the last saved version; writes create a new version. | Any holder of an `sk-` API key with `content:*` scopes — local agents, scripts, OpenClaw skills. |
+| **Live document bridge** (`POST /api/content/[id]/agent-bridge`) | The live Yjs document open in the collaborative editor — edits appear in real time on the purple agent rail, including `comment` and `suggest` (track-changes) ops. | **Logged-in humans only** (session auth). The session is the authorization conduit; `X-Agent-Id` is attribution. In-app Nexus workspace chat uses this via a server-side loopback. Autonomous-agent auth (API keys / delegated tokens) is a designed later phase — not available yet. |
+
+Consequences for external agents:
+
+- `get_content` returns the **last saved version** — a document being edited live
+  in the collab editor may be ahead of what the agent reads until someone
+  snapshots a version.
+- External agent writes land as **new versions**, not live-editor keystrokes.
+  Humans see them in the version history, not on the purple rail.
+- If you need an external agent on the live rail, that is the agent-bridge
+  API-key phase — file it as a feature, don't work around it.
+
+## Path 1 — Local agent / any MCP client
+
+1. **Mint a key:** AI Studio → **Settings → API Keys**. Administrators can grant
+   all scopes; grant the minimum the agent needs (see scope table below).
+2. **Connect** to the MCP endpoint with the key as a bearer token:
+
+   ```bash
+   # Claude Code
+   claude mcp add --transport http aistudio https://dev.aistudio.psd401.ai/api/mcp \
+     --header "Authorization: Bearer sk-YOUR_KEY"
+   ```
+
+   Any MCP client works the same way: Streamable HTTP `POST /api/mcp`,
+   `Authorization: Bearer sk-…`.
+
+3. **Use the content tools** (defined in `lib/mcp/content-tools.ts`, scope
+   enforcement in `CONTENT_TOOL_SCOPE_MAP`):
+
+   | Tool | Required scope | Notes |
+   |---|---|---|
+   | `get_content` | `content:read` | Object + last saved version |
+   | `list_content` | `content:read` | |
+   | `create_document` | `content:create` | Markdown documents; created **private + draft** |
+   | `create_artifact` | `content:create` | Created **private + draft** |
+   | `update_content` | `content:update` | Metadata |
+   | `create_version` | `content:update` | The version-based "edit" |
+   | `set_visibility` | `content:update` | |
+   | `publish_content` | `content:publish_internal` | Public destinations additionally require the human/admin-held `content:publish_public` — the tool surfaces a structured `approval_required` signal instead of publishing |
+   | `unpublish_content` | `content:publish_internal` | Taking down a **public** destination is gated the same as putting it up (§26.4) |
+   | `export_okf` | `content:read` | `--audience public` additionally needs `content:publish_public` |
+   | `import_okf` | `content:create` | Imports land private + draft |
+
+**Safety invariants that apply to every agent write:** content is screened
+(§28.3 Bedrock Guardrails + PII telemetry) before persisting; agent-created
+objects start **private + draft** (create → widen, never create-public);
+everything is attributed to the agent identity.
+
+## Path 2 — PSD AI Agents (OpenClaw on AgentCore)
+
+**Today:** the deployed `psd-aistudio` skill
+(`infra/agent-image/skills/psd-aistudio/`) is **discovery-only**. It calls the
+`describe_capabilities` meta-tool over `/api/mcp` with a `platform:read`-scoped
+key (from `AISTUDIO_MCP_API_KEY` or Secrets Manager via
+`AISTUDIO_MCP_API_KEY_SECRET_ID`) so the agent always knows what AI Studio can
+do — it deliberately does not execute content actions.
+
+**Gotcha:** `AGENT_INTERNAL_API_KEY` is a pre-shared key for the internal agent
+endpoints — it is **not scope-aware and cannot authenticate to `/api/mcp`**.
+Content access needs its own `sk-` key.
+
+**To give the agents Atrium abilities** (the follow-up build):
+
+1. Mint an `sk-` key with the content scopes above.
+2. Store it in Secrets Manager under the `psd-agent/{env}/…` convention (mirror
+   the `AISTUDIO_MCP_API_KEY_SECRET_ID` pattern the discovery skill already uses).
+3. Add a skill (e.g. `infra/agent-image/skills/psd-atrium/`) wrapping the MCP
+   content tools, following the `psd-aistudio` runner shape.
+
+The agent then works **version-based**, like any other MCP caller — same
+semantics, same private+draft + screening invariants.
+
+## Acting on behalf of a specific user (delegated tokens)
+
+`POST /api/v1/agents/delegated-token` mints a **short-lived (300 s) delegated
+token** that acts as a named human user. Requirements:
+
+- The caller must be an **OIDC client-credentials agent client** holding the
+  agent-held `content:delegate` scope — a user session or `sk-` key **cannot**
+  mint one even with the scope.
+- A delegated token can never carry `content:delegate` itself.
+
+Status: the endpoint is implemented server-side, but the OIDC agent client it
+requires is **not provisioned in our infrastructure yet**. Until then, agents
+act as their own identity (attribution: the agent), not as a user.
+
+Details: `docs/API/v1/context-graph.md` (§`POST /api/v1/agents/delegated-token`).
+
+## How the live bridge actually works (for maintainers)
+
+`POST /api/content/[id]/agent-bridge` (ops: `replace` / `append` / `comment` /
+`suggest`) and the Nexus workspace-chat tools both funnel through
+`lib/content/collab/apply-agent-edit.ts`, which connects to this same process's
+collab websocket **over loopback** (`ws://127.0.0.1:$PORT/api/atrium-collab`) as
+a y-sync client, so edits land on the exact Y.Doc connected editors hold.
+
+Operational hazard: the loopback requires the server to be bound to an interface
+that includes `127.0.0.1`. ECS injects `HOSTNAME=<task hostname>` at runtime,
+which once made the standalone server bind eth0 only and broke every agent
+read/write in deployed environments while browsers worked fine (PR #1189). The
+fix (`entrypoint.sh` exports `HOSTNAME=0.0.0.0`) plus a boot-time loopback
+self-check are documented in
+`docs/learnings/infrastructure/2026-07-11-ecs-hostname-injection-breaks-loopback.md`.
+Boot-log check: `Local: http://localhost:3000` = healthy;
+`Local: http://<hostname>:3000` = loopback dead.
+
+## Troubleshooting
+
+| Symptom | Likely cause |
+|---|---|
+| 401 from `/api/mcp` using `AGENT_INTERNAL_API_KEY` | Wrong credential class — mint an `sk-` key (see gotcha above) |
+| 403 `INSUFFICIENT_SCOPE` on a content tool | Key lacks the scope in the table above |
+| `publish_content` returns `approval_required` | Public destination — needs human/admin `content:publish_public`; internal destinations publish directly |
+| Agent reads stale document text | Expected: `get_content` returns the last saved **version**; live editor changes appear after a snapshot |
+| Workspace chat says the live document service is unreachable | Loopback binding regression — check the boot log `Local:` line and the `loopback self-check` line (see maintainers section) |

--- a/docs/features/mcp-server.md
+++ b/docs/features/mcp-server.md
@@ -31,6 +31,8 @@ Three auth paths supported:
 | `list_assistants` | `mcp:list_assistants` | List accessible assistants |
 | `get_decision_graph` | `mcp:get_decision_graph` | Get node details + connections |
 
+**Atrium content tools** (`create_document`, `create_artifact`, `get_content`, `list_content`, `update_content`, `create_version`, `set_visibility`, `publish_content`, `unpublish_content`, `export_okf`, `import_okf`) are registered alongside these, scoped via `content:*` — see [atrium-agent-access.md](./atrium-agent-access.md) for the per-tool scope table, semantics (version-based, private+draft, §28.3-screened), and agent integration guide.
+
 ## Protocol Methods
 
 | Method | Purpose |

--- a/docs/learnings/infrastructure/2026-07-11-ecs-hostname-injection-breaks-loopback.md
+++ b/docs/learnings/infrastructure/2026-07-11-ecs-hostname-injection-breaks-loopback.md
@@ -1,0 +1,64 @@
+# ECS injects HOSTNAME at runtime, silently overriding Dockerfile ENV — breaks Next.js standalone loopback
+
+**Date:** 2026-07-11
+**PR:** #1189
+**Severity:** P1 — Nexus workspace chat could not read or edit live Atrium documents in any deployed environment; the agent-bridge loopback had been broken in ECS since #1051 shipped.
+
+## What happened
+
+The Next.js standalone server (`server.js`, wrapped by `voice-server.js`) binds to
+`process.env.HOSTNAME || '0.0.0.0'`. Both Dockerfiles set `ENV HOSTNAME=0.0.0.0` —
+the documented Next.js-in-Docker pattern. But at runtime the ECS/Docker layer
+injects `HOSTNAME=<task hostname>` (e.g. `ip-10-0-1-86.ec2.internal`) into the
+container environment, overriding the image ENV. The server then listened **only
+on the eth0 interface**; nothing listened on `127.0.0.1`.
+
+Every server-to-itself connection failed with `ECONNREFUSED`:
+- the Atrium agent bridge collab websocket (`ws://127.0.0.1:$PORT/api/atrium-collab`)
+  used by `applyAgentEdit` / `applyAgentComment` / `applyAgentSuggestion` /
+  `readAgentDocMarkdown` → surfaced in chat as `collab websocket error`.
+
+Browser traffic arrives via the ALB on eth0, so the collab editor panel connected
+fine — the breakage was invisible except to the agent path.
+
+## Why local verification missed it
+
+Local dev servers (`server.ts`, `e2e-local.sh`) bind hostnames that include
+loopback, so every local test — unit, Bun smoke, authed Playwright E2E driving
+real LLM tool calls — passed honestly. The deployed topology (runtime-injected
+`HOSTNAME`) is not reproducible by any test that doesn't run the production
+standalone server with a clobbered `HOSTNAME`.
+
+## Diagnostic signature
+
+Boot log is conclusive and takes one look:
+
+```
+- Local:    http://ip-10-0-1-86.ec2.internal:3000   ← BROKEN (hostname-bound)
+- Local:    http://localhost:3000                    ← healthy (0.0.0.0-bound)
+```
+
+When Next binds `0.0.0.0` the `Local:` line says `localhost`. If it shows a
+hostname/IP, loopback is dead. (The `Network:` line shows the machine address in
+BOTH cases — do not diagnose from it.)
+
+## Fix
+
+- `entrypoint.sh` exports `HOSTNAME=0.0.0.0` immediately before
+  `exec su-exec nextjs "$@"` — the last point in the startup chain, wins over
+  every injection layer.
+- `voice-server.js` runs a boot-time loopback self-check: logs the bound address
+  and TCP-probes `127.0.0.1:$PORT`; failure emits one CloudWatch ERROR naming the
+  agent bridge as the casualty.
+
+## Rules
+
+1. **A Dockerfile `ENV HOSTNAME=...` is not authoritative** — ECS/Docker inject
+   `HOSTNAME` at runtime. Force interface bindings in the entrypoint (or in code),
+   never rely on image ENV for `HOSTNAME`.
+2. **Any feature that dials the server from inside the server (loopback) must have
+   a deployed-environment reachability check** — a boot-time self-check log line
+   at minimum. Local E2E cannot cover deployed binding/topology.
+3. **When a deployed WS/HTTP client fails while browsers work, read the boot
+   log's `Local:` line first** — it distinguishes binding problems from handler,
+   origin, or auth problems in seconds.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -53,8 +53,23 @@ else
   # Non-fatal: Container can still start, but image optimization will be disabled
 fi
 
+# Force the Next.js standalone server to bind all interfaces (issue: Nexus/Atrium
+# agent-bridge loopback).
+#
+# The Dockerfile sets ENV HOSTNAME=0.0.0.0, but at runtime the container gets
+# HOSTNAME=<task hostname> (ECS/Docker inject it; a shell can re-set it too), and
+# Next.js standalone server.js binds to process.env.HOSTNAME. The result: the app
+# listened ONLY on the task's eth0 interface (boot log showed
+# "Local: http://ip-10-0-1-86.ec2.internal:3000" instead of "Local: http://localhost:3000"),
+# so nothing listened on 127.0.0.1 and every server-to-itself connection — the
+# Atrium agent-bridge collab websocket (ws://127.0.0.1:$PORT/api/atrium-collab) —
+# was refused ("collab websocket error"). ALB traffic still worked, which is why
+# only the agent read/write path failed. Exporting here, at the last step before
+# exec, wins over every earlier layer.
+export HOSTNAME=0.0.0.0
+
 # Execute the container's original command as the nextjs user
 # su-exec switches to nextjs user and execs the command, replacing this shell process
 # This ensures proper signal handling (SIGTERM, SIGINT) and runs app as non-root
-echo "[entrypoint] Starting application as nextjs user: $@"
+echo "[entrypoint] Starting application as nextjs user: $@ (HOSTNAME=$HOSTNAME)"
 exec su-exec nextjs "$@"

--- a/voice-server.js
+++ b/voice-server.js
@@ -23,6 +23,7 @@
 
 /* eslint-disable no-undef, @typescript-eslint/no-require-imports, unicorn/prefer-node-protocol -- CJS script outside Next.js runtime */
 const http = require('http')
+const net = require('net')
 const { WebSocketServer } = require('ws')
 const { parse } = require('url')
 
@@ -135,6 +136,38 @@ function isOriginAllowed(request) {
 }
 
 /**
+ * Boot-time loopback self-check.
+ *
+ * The Atrium agent bridge (lib/content/collab/apply-agent-edit.ts) connects to
+ * this same process at ws://127.0.0.1:$PORT — it only works if the server is
+ * bound to an interface that includes loopback (0.0.0.0). ECS/Docker inject
+ * HOSTNAME=<task hostname> at runtime, which silently overrides the Dockerfile's
+ * ENV HOSTNAME=0.0.0.0 and makes Next.js standalone bind eth0 only; every agent
+ * read/write then fails with "collab websocket error" while browser traffic (via
+ * the ALB) keeps working. entrypoint.sh now forces HOSTNAME=0.0.0.0; this check
+ * makes any regression a single unambiguous CloudWatch ERROR line at boot.
+ */
+function runLoopbackSelfCheck(server) {
+  const addr = server.address()
+  if (!addr || typeof addr !== 'object') return
+  console.log(`[voice-server] HTTP server bound to ${addr.address}:${addr.port}`) // eslint-disable-line no-console
+  const probe = net.connect({ host: '127.0.0.1', port: addr.port })
+  const timer = setTimeout(() => {
+    probe.destroy()
+    console.error(`[voice-server] ERROR: loopback self-check TIMED OUT — 127.0.0.1:${addr.port} unreachable; the Atrium agent bridge (workspace chat read/edit) will fail. Bound address is ${addr.address}; HOSTNAME env was likely overridden — see entrypoint.sh.`) // eslint-disable-line no-console
+  }, 3000)
+  probe.on('connect', () => {
+    clearTimeout(timer)
+    probe.end()
+    console.log(`[voice-server] loopback self-check OK (127.0.0.1:${addr.port} reachable — agent bridge can connect)`) // eslint-disable-line no-console
+  })
+  probe.on('error', (err) => {
+    clearTimeout(timer)
+    console.error(`[voice-server] ERROR: loopback self-check FAILED (${err.message}) — 127.0.0.1:${addr.port} refused; the Atrium agent bridge (workspace chat read/edit) will fail. Bound address is ${addr.address}; HOSTNAME env was likely overridden — see entrypoint.sh.`) // eslint-disable-line no-console
+  })
+}
+
+/**
  * Intercept http.createServer to attach WebSocket upgrade handling.
  * Next.js standalone server.js calls http.createServer internally.
  */
@@ -144,6 +177,9 @@ http.createServer = function (...args) {
   const server = originalCreateServer(...args)
 
   if (!wss) {
+    // Self-check once the (first) server starts listening — this is the server
+    // Next.js standalone binds, the same one the agent bridge dials over loopback.
+    server.on('listening', () => runLoopbackSelfCheck(server))
     // maxPayload must match WS_MAX_PAYLOAD in lib/voice/constants.ts (64KB)
     wss = new WebSocketServer({ noServer: true, maxPayload: 65536 })
     // Separate WS server for Atrium collab (larger payload for Yjs sync frames).

--- a/voice-server.js
+++ b/voice-server.js
@@ -152,18 +152,24 @@ function runLoopbackSelfCheck(server) {
   if (!addr || typeof addr !== 'object') return
   console.log(`[voice-server] HTTP server bound to ${addr.address}:${addr.port}`) // eslint-disable-line no-console
   const probe = net.connect({ host: '127.0.0.1', port: addr.port })
-  const timer = setTimeout(() => {
+  // Single-outcome guard: destroy() from the timeout handler can itself emit
+  // 'error' (and vice versa), which would double-log the verdict.
+  let finished = false
+  const finish = (fn) => {
+    if (finished) return
+    finished = true
+    clearTimeout(timer)
     probe.destroy()
-    console.error(`[voice-server] ERROR: loopback self-check TIMED OUT — 127.0.0.1:${addr.port} unreachable; the Atrium agent bridge (workspace chat read/edit) will fail. Bound address is ${addr.address}; HOSTNAME env was likely overridden — see entrypoint.sh.`) // eslint-disable-line no-console
+    fn()
+  }
+  const timer = setTimeout(() => {
+    finish(() => console.error(`[voice-server] ERROR: loopback self-check TIMED OUT — 127.0.0.1:${addr.port} unreachable; the Atrium agent bridge (workspace chat read/edit) will fail. Bound address is ${addr.address}; HOSTNAME env was likely overridden — see entrypoint.sh.`)) // eslint-disable-line no-console
   }, 3000)
   probe.on('connect', () => {
-    clearTimeout(timer)
-    probe.end()
-    console.log(`[voice-server] loopback self-check OK (127.0.0.1:${addr.port} reachable — agent bridge can connect)`) // eslint-disable-line no-console
+    finish(() => console.log(`[voice-server] loopback self-check OK (127.0.0.1:${addr.port} reachable — agent bridge can connect)`)) // eslint-disable-line no-console
   })
   probe.on('error', (err) => {
-    clearTimeout(timer)
-    console.error(`[voice-server] ERROR: loopback self-check FAILED (${err.message}) — 127.0.0.1:${addr.port} refused; the Atrium agent bridge (workspace chat read/edit) will fail. Bound address is ${addr.address}; HOSTNAME env was likely overridden — see entrypoint.sh.`) // eslint-disable-line no-console
+    finish(() => console.error(`[voice-server] ERROR: loopback self-check FAILED (${err.message}) — 127.0.0.1:${addr.port} refused; the Atrium agent bridge (workspace chat read/edit) will fail. Bound address is ${addr.address}; HOSTNAME env was likely overridden — see entrypoint.sh.`)) // eslint-disable-line no-console
   })
 }
 


### PR DESCRIPTION
## Root cause

Nexus workspace chat could not read or edit live Atrium documents **in the deployed environment** (worked locally — the basis of PR #1186's verification). CloudWatch shows every agent read/write failing with `collab websocket error`, both before and after the #1186 deploy — the agent-bridge loopback has been broken in ECS since it shipped (#1051).

The Next.js standalone server binds to `process.env.HOSTNAME`. At runtime, the ECS/Docker layer injects `HOSTNAME=<task hostname>`, silently overriding the Dockerfile's `ENV HOSTNAME=0.0.0.0`. Deployed boot log (dev, task from today):

```
- Local:         http://ip-10-0-1-86.ec2.internal:3000    ← should be http://localhost:3000
- Network:       http://ip-10-0-1-86.ec2.internal:3000
```

The server listens **only on eth0**. Nothing listens on `127.0.0.1`, so every server-to-itself connection — the Atrium agent bridge collab websocket (`ws://127.0.0.1:$PORT/api/atrium-collab`, used by `applyAgentEdit` / `applyAgentComment` / `applyAgentSuggestion` / `readAgentDocMarkdown`) — is `ECONNREFUSED`. Browser traffic arrives via the ALB on eth0, which is why the collab editor panel connected fine while workspace chat could neither read nor write. (Verified not to be the origin check: no `Origin rejected` lines in CloudWatch, and Node's native WebSocket sends no Origin header → the loopback remote-address branch allows it.)

## Changes

- **`entrypoint.sh`** — `export HOSTNAME=0.0.0.0` immediately before `exec su-exec nextjs "$@"`. Last point in the startup chain; wins over the runtime injection and any shell re-set.
- **`voice-server.js`** — boot-time loopback self-check: logs the actual bound address on `listening` and TCP-probes `127.0.0.1:$PORT`. Failure = one unambiguous CloudWatch ERROR line naming the agent bridge as the casualty, instead of silent tool errors.

## Verification (real production standalone build)

`next build --webpack` + both WS handler bundles + `node voice-server.js`, run both ways:

| Config | TCP `127.0.0.1` | WS upgrade to `/api/atrium-collab/<id>` | Boot log |
|---|---|---|---|
| `HOSTNAME=<LAN IP>` (reproduces ECS) | `ECONNREFUSED` | unreachable | `Local: http://<ip>:3998` + self-check **ERROR** |
| `HOSTNAME=0.0.0.0` (fix) | connects | **101 accepted**, reaches registered collab handler through the production origin-check path | `Local: http://localhost:3998` + self-check OK |

## Post-deploy acceptance

1. Boot log shows `Local: http://localhost:3000` and `[voice-server] loopback self-check OK`.
2. Workspace chat `read_workspace_content` returns the live document text (not `bodyUnavailable`).
3. `edit_workspace_document` lands on the purple agent rail.

No app/TS code changes; no migrations. Ships via the normal frontend image build in `cdk deploy`.


https://claude.ai/code/session_01ML6Cx3Pr7WqPhMXYasjNkg
