### PR TITLE
fix(cdk): exclude .claude worktrees and .next-e2e from frontend image asset

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -13,6 +13,12 @@ yarn-error.log*
 .next-e2e
 out
 
+# Claude Code session worktrees — a full second copy of the repo (own
+# node_modules/.next-e2e) that can be actively churning while another session
+# works there. Never part of the image; also excluded in the CDK asset list
+# (infra/lib/constructs/ecs-service.ts) which governs deploy fingerprinting.
+.claude
+
 # Testing
 coverage
 .jest

--- a/infra/lib/constructs/ecs-service.ts
+++ b/infra/lib/constructs/ecs-service.ts
@@ -678,6 +678,16 @@ export class EcsServiceConstruct extends Construct {
             'tests/',         // Exclude test files
             '*.md',           // Exclude documentation
             '.env*',          // Exclude environment files (use secrets instead)
+            // Claude Code session worktrees — a full second copy of the repo
+            // (own node_modules / .next-e2e) that can be ACTIVELY CHURNING while
+            // another session works there; asset fingerprinting races the file
+            // deletions (lstat ENOENT aborts `cdk deploy`) and bloats the context.
+            '.claude/',
+            // Local E2E runner build dir (NEXT_DIST_DIR=.next-e2e) — volatile
+            // turbopack cache during suite runs, multi-GB when idle. Already in
+            // .dockerignore; must ALSO be here because this exclude list governs
+            // the CDK fingerprint walk.
+            '.next-e2e/',
           ],
         });
 


### PR DESCRIPTION
## Problem

`cdk deploy` aborted during asset fingerprinting:

```
Error: ENOENT: no such file or directory, lstat '.../.claude/worktrees/feature-meridian-shell/.next-e2e/dev/cache/turbopack/.../00001340.sst'
```

The frontend `DockerImageAsset` uses the repo root as its build context, and its `exclude` list predates Claude Code worktrees. The CDK fingerprint walk descended into `.claude/worktrees/<branch>/` — a full second copy of the repo — while a concurrent session's E2E run was churning turbopack cache files there; files deleted between readdir and lstat abort the deploy. Even idle, the worktree adds gigabytes to fingerprinting and the docker context.

## Fix

- `ecs-service.ts`: add `.claude/` + `.next-e2e/` to the `fromAsset` exclude list (this list governs the fingerprint walk; `.dockerignore` patterns are context-root anchored and don't cover nested worktree paths).
- `.dockerignore`: add `.claude` for raw docker-build parity.

## Verification

Full canonical 14-stack synth with the same context flags as the failing deploy completes successfully **while the peer session is actively writing to its worktree** — the exact previously-failing condition. Exit 0, only pre-existing LOW advisory warnings.

No image content change (excluded dirs were never COPY'd); asset hash changes because the fingerprint input set changes — expected.

https://claude.ai/code/session_01ML6Cx3Pr7WqPhMXYasjNkg