### PR TITLE
feat(agent): deploy-time bootstrap for the Atrium content key — zero manual provisioning

### DIFF
--- a/docs/features/atrium-agent-access.md
+++ b/docs/features/atrium-agent-access.md
@@ -96,29 +96,58 @@ its writes are trusted + attributed to the owner and are NOT §28.3-screened (th
 runs only for true agent-identity writes; see the Safety invariants above). Not the
 asking user, either; per-user delegation is the future phase below.
 
-Deployment prerequisites (mirrors the `psd-canva` #1176 prereq pattern):
+### Deployment — zero-touch (no manual credential steps)
 
-1. **Mint a content-scoped `sk-` key.** In AI Studio → **Settings → API Keys**,
-   as a user whose role grants the content scopes (staff or administrator), mint a
-   key holding `content:read content:create content:update
-   content:publish_internal`. Grant `content:publish_public` only if the agent
-   should publish publicly without the approval gate (otherwise public publishes
-   return `approval_required`, which is the intended safe default).
-2. **Populate the secret** the CDK stack creates
-   (`psd-agent/{env}/atrium-content-api-key`) with the **raw** key string:
+The content key is **provisioned automatically at deploy time**. There is no
+"mint a key in the UI" or `put-secret-value` step. Two pieces do it:
 
-   ```bash
-   aws secretsmanager put-secret-value \
-     --secret-id psd-agent/<env>/atrium-content-api-key \
-     --secret-string 'sk-...'
-   ```
+1. **Migration `104-atrium-agent-service-user.sql`** seeds a dedicated service
+   user (`cognito_sub = service-account:psd-atrium-agent`, email
+   `atrium-agent-service@psd401.net`, display name **"PSD Agent (service)"**) and
+   grants it the **staff** role — the minimum role that grants internal Atrium
+   visibility and makes the `content:read/create/update/publish_internal` scopes
+   eligible.
+2. **The `AtriumContentKeyProvisioner` custom resource**
+   (`infra/lambdas/atrium-content-key-bootstrap/`, wired in
+   `infra/lib/agent-platform-stack.ts`) runs on every `cdk deploy` and
+   **idempotently** ensures `psd-agent/{env}/atrium-content-api-key` holds a
+   valid, active `sk-` key owned by that service user, scoped to
+   `content:read content:create content:update content:publish_internal`
+   (**not** `content:publish_public` — the §26.4 public-publish approval gate
+   stays; public publishes return `approval_required`). The DB stores only the
+   Argon2id hash; the plaintext is written to the secret and never logged.
 
-3. **Runtime env** (wired by `infra/lib/agent-platform-stack.ts`, no manual step):
-   `AISTUDIO_CONTENT_API_KEY_SECRET_ID` points the skill at that secret;
-   `APP_BASE_URL` supplies the `/api/v1/content` base. (`AISTUDIO_CONTENT_API_KEY`
-   may be set directly for local/dev instead of the secret.)
-4. **Rebuild + redeploy the agent image** — the agent discovers the skill only
+**Idempotency contract** (the custom resource re-runs each deploy — self-healing):
+
+| Secret state | Action |
+| --- | --- |
+| holds a valid, active, sufficiently-scoped key owned by the service user | **no-op** |
+| empty / malformed | **mint** |
+| points at a missing, inactive, revoked, or under-scoped key | **re-mint** (and revoke the service user's other active keys, so exactly one stays live) |
+
+**Rotation:** delete the secret value **or** revoke/delete the `api_keys` row →
+the next `cdk deploy` re-mints. (No dedicated rotation Lambda; a redeploy is the
+rotation trigger.)
+
+**Runtime env** (wired by `infra/lib/agent-platform-stack.ts`, no manual step):
+`AISTUDIO_CONTENT_API_KEY_SECRET_ID` points the skill at that secret;
+`APP_BASE_URL` supplies the `/api/v1/content` base. (`AISTUDIO_CONTENT_API_KEY`
+may be set directly for local/dev instead of the secret.)
+
+**The only remaining human steps:**
+
+1. **`cdk deploy`** — applies migration 104 and runs the key-bootstrap custom
+   resource (DatabaseStack deploys before AgentPlatformStack, so the service user
+   exists before the key is minted).
+2. **Rebuild + redeploy the agent image** — the agent discovers the skill only
    after `infra/agent-image` is rebuilt and the AgentCore runtime redeployed.
+
+Provenance & screening: writes land as the service user (a `user`/`kind:"user"`
+requester), attributed to **"PSD Agent (service)"** as a human `authorActor`, and
+are **not** §28.3-screened — platform guardrails run telemetry-only by product
+decision, and the `sk-`/owner path is the trusted-caller path (see the Safety
+invariants above). True agent-identity (delegated/autonomous) writes remain
+screened and attributed to the agent.
 
 ## Acting on behalf of a specific user (delegated tokens)
 
@@ -159,7 +188,7 @@ Boot-log check: `Local: http://localhost:3000` = healthy;
 | Symptom | Likely cause |
 |---|---|
 | 401 from `/api/mcp` using `AGENT_INTERNAL_API_KEY` | Wrong credential class — mint an `sk-` key (see gotcha above) |
-| `psd-atrium` exits 11 (unauthorized / not configured) | The content key isn't set — populate `psd-agent/{env}/atrium-content-api-key` (or `AISTUDIO_CONTENT_API_KEY`) with a content-scoped `sk-` key (see Path 2 prereqs) |
+| `psd-atrium` exits 11 (unauthorized / not configured) | The content key isn't in the secret. It is auto-provisioned by the `AtriumContentKeyProvisioner` custom resource on `cdk deploy` — check its CloudWatch logs (`/aws/lambda/psd-agent-atrium-key-bootstrap-<env>`). A re-deploy re-mints. (`AISTUDIO_CONTENT_API_KEY` may be set directly for local/dev.) |
 | `psd-atrium publish` returns `approval_required` | Public destination without `content:publish_public` — expected; relay the message so the user knows it's queued |
 | 403 `INSUFFICIENT_SCOPE` on a content tool | Key lacks the scope in the table above |
 | `publish_content` returns `approval_required` | Public destination — needs human/admin `content:publish_public`; internal destinations publish directly |

--- a/infra/database/migrations.json
+++ b/infra/database/migrations.json
@@ -97,6 +97,7 @@
     "100-agent-iteration-telemetry.sql",
     "101-agent-workspace-canva.sql",
     "102-atrium-embed-links.sql",
-    "103-atrium-content-cover-icon.sql"
+    "103-atrium-content-cover-icon.sql",
+    "104-atrium-agent-service-user.sql"
   ]
 }

--- a/infra/database/schema/104-atrium-agent-service-user.sql
+++ b/infra/database/schema/104-atrium-agent-service-user.sql
@@ -1,0 +1,59 @@
+-- Migration 104: Atrium agent service user
+-- Part of the zero-touch provisioning for the psd-atrium agent credential
+-- (follow-up to PR #1195). PR #1195 added the psd-atrium OpenClaw skill + the
+-- empty `psd-agent/<env>/atrium-content-api-key` secret, but left TWO manual
+-- steps: (1) a human minted a content-scoped `sk-` key in AI Studio Settings,
+-- (2) a human ran `aws secretsmanager put-secret-value`. This migration removes
+-- the human owner of that key: it seeds a dedicated SERVICE USER that owns the
+-- auto-minted key. The KEY itself is minted at deploy time by the
+-- atrium-content-key-bootstrap custom resource (a random secret cannot live in
+-- a committed migration), which resolves this user by its cognito_sub sentinel.
+--
+-- Why a service user (not a human): the psd-atrium skill authenticates with an
+-- `sk-` key and acts as the key's OWNER (requesterFromApiAuth -> `user`
+-- requester, visibility-gated by that user's roles — lib/content/requester-from-auth.ts).
+-- Attributing writes to a dedicated service account keeps provenance legible in
+-- the Atrium UI ("PSD Agent (service)") instead of borrowing a real staffer's
+-- identity.
+--
+-- Identity model: `users.id` is a serial int (not a UUID), and `users.email`
+-- carries NO unique constraint — only `cognito_sub` is unique. So the
+-- deterministic, idempotent handle for this row is a `cognito_sub` SENTINEL
+-- (`service-account:psd-atrium-agent`). It is intentionally NOT a UUID, so it
+-- can never collide with a real Cognito subject (which are UUIDs) and the
+-- account can never be logged into via Cognito. The bootstrap Lambda looks the
+-- row up by this exact sentinel.
+--
+-- Role: the service user is granted the `staff` role via `user_roles`. Staff is
+-- the minimum role that grants INTERNAL Atrium content visibility and makes the
+-- content:read/create/update/publish_internal scopes eligible for the owned key
+-- (lib/api-keys/scopes.ts ROLE_SCOPES.staff; verified working with a staff key
+-- in PR #1195's functional test). `content:publish_public` is deliberately NOT
+-- granted — the §26.4 public-publish approval gate stays.
+--
+-- ADDITIVE and idempotent (re-runs are no-ops). No PL/pgSQL DO $$ blocks (the
+-- migration runner's statement splitter cannot handle dollar-quoted blocks — see
+-- 085/086/090/097). INSERTs into the postgres-owned users/user_roles tables are
+-- fine under the master migration role (only ALTER on postgres-owned objects is
+-- restricted — see 085).
+
+-- 1. Service user. Deterministic identity via the unique cognito_sub sentinel.
+--    first_name/last_name compose to "PSD Agent (service)" for UI provenance.
+INSERT INTO users (cognito_sub, email, first_name, last_name)
+SELECT 'service-account:psd-atrium-agent',
+       'atrium-agent-service@psd401.net',
+       'PSD Agent',
+       '(service)'
+WHERE NOT EXISTS (
+  SELECT 1 FROM users WHERE cognito_sub = 'service-account:psd-atrium-agent'
+);
+
+-- 2. Grant the service user the `staff` role (internal content visibility +
+--    content scope eligibility). Idempotent via the user_roles unique
+--    (user_id, role_id) constraint.
+INSERT INTO user_roles (user_id, role_id)
+SELECT u.id, r.id
+FROM users u
+JOIN roles r ON r.name = 'staff'
+WHERE u.cognito_sub = 'service-account:psd-atrium-agent'
+ON CONFLICT (user_id, role_id) DO NOTHING;

--- a/infra/lambdas/atrium-content-key-bootstrap/__tests__/index.test.ts
+++ b/infra/lambdas/atrium-content-key-bootstrap/__tests__/index.test.ts
@@ -1,0 +1,275 @@
+/**
+ * Unit tests for the atrium-content-key-bootstrap custom resource.
+ *
+ * Covers the idempotency contract with an in-memory fake of the SM/DB ops:
+ *   - empty secret            -> MINT
+ *   - valid existing key      -> NO-OP
+ *   - stale/orphaned secret   -> RE-MINT
+ *   - scope drift             -> RE-MINT
+ *   - inactive/revoked key    -> RE-MINT
+ *   - missing service user    -> throws
+ * plus the real hash-wasm Argon2id round-trip and the pure helpers.
+ *
+ * Runs under the "lambdas" project in infra/jest.config.js. Requires a local
+ * `bun install` in this lambda dir (hash-wasm + @aws-sdk/* resolvable).
+ */
+import {
+  ensureContentKey,
+  generateRawKey,
+  keyPrefixOf,
+  isValidKeyFormat,
+  hashKey,
+  verifyKey,
+  coversScopes,
+  type ContentKeyOps,
+  type ExistingKeyRow,
+  type EnsureConfig,
+  type Logger,
+} from '../index';
+
+const REQUIRED_SCOPES = [
+  'content:read',
+  'content:create',
+  'content:update',
+  'content:publish_internal',
+];
+
+const CFG: EnsureConfig = {
+  serviceUserCognitoSub: 'service-account:psd-atrium-agent',
+  keyName: 'psd-atrium agent (auto-provisioned)',
+  requiredScopes: REQUIRED_SCOPES,
+};
+
+const SERVICE_USER_ID = 3;
+
+interface FakeState {
+  secret: string | null;
+  userId: number | null;
+  keys: Array<{ userId: number; keyPrefix: string } & ExistingKeyRow>;
+}
+
+interface FakeOps extends ContentKeyOps {
+  state: FakeState;
+  writeSecret: jest.Mock;
+  insertKey: jest.Mock;
+  revokeActiveKeys: jest.Mock;
+}
+
+function makeOps(initial: Partial<FakeState>): FakeOps {
+  const state: FakeState = {
+    secret: initial.secret ?? null,
+    userId: initial.userId === undefined ? SERVICE_USER_ID : initial.userId,
+    keys: initial.keys ?? [],
+  };
+  const writeSecret = jest.fn(async (rawKey: string) => {
+    state.secret = rawKey;
+  });
+  const insertKey = jest.fn(
+    async (row: { userId: number; keyPrefix: string; keyHash: string; scopes: string[] }) => {
+      state.keys.push({
+        userId: row.userId,
+        keyPrefix: row.keyPrefix,
+        keyHash: row.keyHash,
+        scopes: row.scopes,
+        isActive: true,
+        revoked: false,
+      });
+    }
+  );
+  const revokeActiveKeys = jest.fn(async (userId: number) => {
+    for (const k of state.keys) {
+      if (k.userId === userId && k.isActive) {
+        k.isActive = false;
+        k.revoked = true;
+      }
+    }
+  });
+  return {
+    state,
+    writeSecret,
+    insertKey,
+    revokeActiveKeys,
+    async readSecret() {
+      return state.secret;
+    },
+    async resolveServiceUserId() {
+      return state.userId;
+    },
+    async keysByPrefix(prefix, userId) {
+      return state.keys
+        .filter((k) => k.keyPrefix === prefix && k.userId === userId)
+        .map(({ keyHash, scopes, isActive, revoked }) => ({ keyHash, scopes, isActive, revoked }));
+    },
+  };
+}
+
+const noopLog: Logger = { info: () => {}, warn: () => {}, error: () => {} };
+
+// hash-wasm Argon2id is real WASM crypto (~tens of ms). Give jest headroom.
+jest.setTimeout(30_000);
+
+describe('pure helpers', () => {
+  it('generateRawKey produces sk- + 64 hex and validates', () => {
+    const raw = generateRawKey();
+    expect(raw).toMatch(/^sk-[0-9a-f]{64}$/);
+    expect(isValidKeyFormat(raw)).toBe(true);
+    expect(keyPrefixOf(raw)).toBe(raw.slice(3, 11));
+  });
+
+  it('isValidKeyFormat rejects malformed inputs', () => {
+    expect(isValidKeyFormat('')).toBe(false);
+    expect(isValidKeyFormat('nope')).toBe(false);
+    expect(isValidKeyFormat('sk-XYZ')).toBe(false);
+    expect(isValidKeyFormat('sk-' + 'a'.repeat(63))).toBe(false);
+  });
+
+  it('hashKey + verifyKey round-trip (real Argon2id PHC)', async () => {
+    const raw = generateRawKey();
+    const hash = await hashKey(raw);
+    expect(hash).toMatch(/^\$argon2id\$v=19\$m=65536,t=3,p=4\$/);
+    expect(await verifyKey(raw, hash)).toBe(true);
+    expect(await verifyKey(raw + 'x', hash)).toBe(false);
+  });
+
+  it('coversScopes requires every required scope', () => {
+    expect(coversScopes(REQUIRED_SCOPES, REQUIRED_SCOPES)).toBe(true);
+    expect(coversScopes([...REQUIRED_SCOPES, 'content:publish_public'], REQUIRED_SCOPES)).toBe(true);
+    expect(coversScopes(['content:read'], REQUIRED_SCOPES)).toBe(false);
+  });
+});
+
+describe('ensureContentKey idempotency', () => {
+  it('empty secret -> MINT (key stored, valid, correctly scoped)', async () => {
+    const ops = makeOps({ secret: null });
+    const outcome = await ensureContentKey(ops, CFG, noopLog);
+
+    expect(outcome).toBe('minted');
+    expect(ops.revokeActiveKeys).toHaveBeenCalledWith(SERVICE_USER_ID);
+    expect(ops.insertKey).toHaveBeenCalledTimes(1);
+    expect(ops.writeSecret).toHaveBeenCalledTimes(1);
+
+    // The stored secret is a valid sk- key whose hash+scopes landed in the DB.
+    const stored = ops.state.secret!;
+    expect(isValidKeyFormat(stored)).toBe(true);
+    const row = ops.state.keys.find((k) => k.keyPrefix === keyPrefixOf(stored))!;
+    expect(row).toBeDefined();
+    expect(row.userId).toBe(SERVICE_USER_ID);
+    expect(row.scopes).toEqual(REQUIRED_SCOPES);
+    expect(row.scopes).not.toContain('content:publish_public');
+    expect(await verifyKey(stored, row.keyHash)).toBe(true);
+  });
+
+  it('valid existing key -> NO-OP (no mint, no secret write, no revoke)', async () => {
+    const raw = generateRawKey();
+    const hash = await hashKey(raw);
+    const ops = makeOps({
+      secret: raw,
+      keys: [
+        {
+          userId: SERVICE_USER_ID,
+          keyPrefix: keyPrefixOf(raw),
+          keyHash: hash,
+          scopes: REQUIRED_SCOPES,
+          isActive: true,
+          revoked: false,
+        },
+      ],
+    });
+
+    const outcome = await ensureContentKey(ops, CFG, noopLog);
+
+    expect(outcome).toBe('noop');
+    expect(ops.insertKey).not.toHaveBeenCalled();
+    expect(ops.writeSecret).not.toHaveBeenCalled();
+    expect(ops.revokeActiveKeys).not.toHaveBeenCalled();
+    expect(ops.state.secret).toBe(raw);
+  });
+
+  it('stale/orphaned secret (no matching active row) -> RE-MINT', async () => {
+    // Secret holds a well-formed sk- key, but there is NO api_keys row for it
+    // (e.g. the row was deleted for rotation).
+    const orphan = generateRawKey();
+    const ops = makeOps({ secret: orphan, keys: [] });
+
+    const outcome = await ensureContentKey(ops, CFG, noopLog);
+
+    expect(outcome).toBe('minted');
+    expect(ops.insertKey).toHaveBeenCalledTimes(1);
+    const stored = ops.state.secret!;
+    expect(stored).not.toBe(orphan);
+    expect(isValidKeyFormat(stored)).toBe(true);
+  });
+
+  it('scope drift (row missing a required scope) -> RE-MINT', async () => {
+    const raw = generateRawKey();
+    const hash = await hashKey(raw);
+    const ops = makeOps({
+      secret: raw,
+      keys: [
+        {
+          userId: SERVICE_USER_ID,
+          keyPrefix: keyPrefixOf(raw),
+          keyHash: hash,
+          scopes: ['content:read', 'content:create'], // missing update + publish_internal
+          isActive: true,
+          revoked: false,
+        },
+      ],
+    });
+
+    const outcome = await ensureContentKey(ops, CFG, noopLog);
+    expect(outcome).toBe('minted');
+    expect(ops.state.secret).not.toBe(raw);
+  });
+
+  it('inactive/revoked key -> RE-MINT', async () => {
+    const raw = generateRawKey();
+    const hash = await hashKey(raw);
+    const ops = makeOps({
+      secret: raw,
+      keys: [
+        {
+          userId: SERVICE_USER_ID,
+          keyPrefix: keyPrefixOf(raw),
+          keyHash: hash,
+          scopes: REQUIRED_SCOPES,
+          isActive: false,
+          revoked: true,
+        },
+      ],
+    });
+
+    const outcome = await ensureContentKey(ops, CFG, noopLog);
+    expect(outcome).toBe('minted');
+    expect(ops.revokeActiveKeys).toHaveBeenCalledWith(SERVICE_USER_ID);
+  });
+
+  it('malformed secret string -> MINT', async () => {
+    const ops = makeOps({ secret: 'not-a-key' });
+    const outcome = await ensureContentKey(ops, CFG, noopLog);
+    expect(outcome).toBe('minted');
+    expect(isValidKeyFormat(ops.state.secret!)).toBe(true);
+  });
+
+  it('missing service user -> throws (migration must run first)', async () => {
+    const ops = makeOps({ secret: null, userId: null });
+    await expect(ensureContentKey(ops, CFG, noopLog)).rejects.toThrow(/service user not found/i);
+    expect(ops.insertKey).not.toHaveBeenCalled();
+    expect(ops.writeSecret).not.toHaveBeenCalled();
+  });
+
+  it('never logs the plaintext key', async () => {
+    const lines: string[] = [];
+    const capturing: Logger = {
+      info: (m, meta) => lines.push(m + ' ' + JSON.stringify(meta ?? {})),
+      warn: (m, meta) => lines.push(m + ' ' + JSON.stringify(meta ?? {})),
+      error: (m, meta) => lines.push(m + ' ' + JSON.stringify(meta ?? {})),
+    };
+    const ops = makeOps({ secret: null });
+    await ensureContentKey(ops, CFG, capturing);
+    const plaintext = ops.state.secret!;
+    for (const line of lines) {
+      expect(line).not.toContain(plaintext);
+    }
+  });
+});

--- a/infra/lambdas/atrium-content-key-bootstrap/__tests__/index.test.ts
+++ b/infra/lambdas/atrium-content-key-bootstrap/__tests__/index.test.ts
@@ -553,25 +553,24 @@ describe('handler (CloudFormation custom resource entry point)', () => {
     process.env = { ...savedEnv };
   });
 
-  it('Delete -> SUCCESS no-op preserving the incoming PhysicalResourceId', async () => {
+  it('Delete -> clean no-op return preserving the incoming PhysicalResourceId', async () => {
+    // Provider-framework contract: a normal return IS success (no Status field).
     const res = await handler({
       ...BASE_EVENT,
       RequestType: 'Delete',
       PhysicalResourceId: 'atrium-content-key-bootstrap',
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } as any);
-    expect(res.Status).toBe('SUCCESS');
     expect(res.PhysicalResourceId).toBe('atrium-content-key-bootstrap');
     expect(rdsSend).not.toHaveBeenCalled();
     expect(smSend).not.toHaveBeenCalled();
   });
 
-  it('Create with a missing service user -> SUCCESS with Outcome=skipped-migration-pending', async () => {
+  it('Create with a missing service user -> returns Outcome=skipped-migration-pending (no throw)', async () => {
     rdsSend.mockResolvedValue({ records: [] }); // resolveServiceUserId -> null
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const res = await handler({ ...BASE_EVENT, RequestType: 'Create' } as any);
-    expect(res.Status).toBe('SUCCESS');
-    expect((res as { Data?: { Outcome?: string } }).Data?.Outcome).toBe('skipped-migration-pending');
+    expect(res.Data?.Outcome).toBe('skipped-migration-pending');
   });
 
   it('Create end-to-end mint: resolve user -> empty secret -> txn replace -> secret write -> SUCCESS minted', async () => {
@@ -599,18 +598,26 @@ describe('handler (CloudFormation custom resource entry point)', () => {
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const res = await handler({ ...BASE_EVENT, RequestType: 'Create' } as any);
-    expect(res.Status).toBe('SUCCESS');
-    expect((res as { Data?: { Outcome?: string } }).Data?.Outcome).toBe('minted');
+    expect(res.Data?.Outcome).toBe('minted');
     expect(written).toHaveLength(1);
     expect(isValidKeyFormat(written[0])).toBe(true);
   });
 
-  it('missing required env var -> FAILED with the var named in Reason', async () => {
+  it('failures THROW (the Provider framework signals CFN FAILED only via a throw)', async () => {
+    // A returned Status:'FAILED' object would be read as SUCCESS by the CDK
+    // custom-resources Provider — so errors must propagate out of the handler.
     delete process.env.DB_CLUSTER_ARN;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const res = await handler({ ...BASE_EVENT, RequestType: 'Update', PhysicalResourceId: 'p-1' } as any);
-    expect(res.Status).toBe('FAILED');
-    expect(res.Reason).toContain('DB_CLUSTER_ARN');
-    expect(res.PhysicalResourceId).toBe('p-1');
+    await expect(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      handler({ ...BASE_EVENT, RequestType: 'Update', PhysicalResourceId: 'p-1' } as any)
+    ).rejects.toThrow('DB_CLUSTER_ARN');
+  });
+
+  it('a transient AWS error propagates as a throw (never swallowed into a return)', async () => {
+    rdsSend.mockRejectedValue(new Error('rds throttled'));
+    await expect(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      handler({ ...BASE_EVENT, RequestType: 'Create' } as any)
+    ).rejects.toThrow('rds throttled');
   });
 });

--- a/infra/lambdas/atrium-content-key-bootstrap/__tests__/index.test.ts
+++ b/infra/lambdas/atrium-content-key-bootstrap/__tests__/index.test.ts
@@ -2,13 +2,24 @@
  * Unit tests for the atrium-content-key-bootstrap custom resource.
  *
  * Covers the idempotency contract with an in-memory fake of the SM/DB ops:
- *   - empty secret            -> MINT
- *   - valid existing key      -> NO-OP
- *   - stale/orphaned secret   -> RE-MINT
- *   - scope drift             -> RE-MINT
- *   - inactive/revoked key    -> RE-MINT
- *   - missing service user    -> throws
- * plus the real hash-wasm Argon2id round-trip and the pure helpers.
+ *   - empty secret                      -> MINT
+ *   - valid existing key                -> NO-OP
+ *   - stale/orphaned secret             -> RE-MINT
+ *   - scope drift (missing OR extra)    -> RE-MINT (exact-match semantics)
+ *   - inactive and/or revoked key       -> RE-MINT (each condition isolated)
+ *   - missing service user              -> SUCCESS, skipped-migration-pending
+ * plus:
+ *   - the CROSS-LIBRARY Argon2 interop: the app's native `argon2` (the exact
+ *     dependency lib/api-keys/argon2-loader.ts loads) must verify a
+ *     hash-wasm-produced PHC string (adversarial review P1 — previously only
+ *     claimed in a comment, never tested)
+ *   - KEY_SCOPES tethered to lib/api-keys/scopes.ts ROLE_SCOPES.staff and
+ *     excluding content:publish_public (security review P2 — drift guard)
+ *   - buildRdsOps field parsing against realistic RDS Data API shapes,
+ *     including the revoked_at tagged-union case where `isNull` is OMITTED on
+ *     non-null fields (the shape that exposed the revoked-inversion bug)
+ *   - the CloudFormation handler's routing: Delete no-op, Create/Update mint,
+ *     skipped-migration-pending passthrough, FAILED on missing env
  *
  * Runs under the "lambdas" project in infra/jest.config.js. Requires a local
  * `bun install` in this lambda dir (hash-wasm + @aws-sdk/* resolvable).
@@ -20,23 +31,30 @@ import {
   isValidKeyFormat,
   hashKey,
   verifyKey,
-  coversScopes,
+  scopesMatch,
+  buildRdsOps,
+  handler,
+  KEY_SCOPES,
+  KEY_NAME,
   type ContentKeyOps,
   type ExistingKeyRow,
   type EnsureConfig,
   type Logger,
 } from '../index';
+import { RDSDataClient } from '@aws-sdk/client-rds-data';
+import {
+  SecretsManagerClient,
+  ResourceNotFoundException,
+} from '@aws-sdk/client-secrets-manager';
+// The app's REAL scope registry — the single source of truth the minted key's
+// scopes must stay tethered to (relative import; scopes.ts is dependency-free).
+import { ROLE_SCOPES } from '../../../../lib/api-keys/scopes';
 
-const REQUIRED_SCOPES = [
-  'content:read',
-  'content:create',
-  'content:update',
-  'content:publish_internal',
-];
+const REQUIRED_SCOPES = [...KEY_SCOPES];
 
 const CFG: EnsureConfig = {
   serviceUserCognitoSub: 'service-account:psd-atrium-agent',
-  keyName: 'psd-atrium agent (auto-provisioned)',
+  keyName: KEY_NAME,
   requiredScopes: REQUIRED_SCOPES,
 };
 
@@ -51,8 +69,7 @@ interface FakeState {
 interface FakeOps extends ContentKeyOps {
   state: FakeState;
   writeSecret: jest.Mock;
-  insertKey: jest.Mock;
-  revokeActiveKeys: jest.Mock;
+  replaceActiveKey: jest.Mock;
 }
 
 function makeOps(initial: Partial<FakeState>): FakeOps {
@@ -64,31 +81,29 @@ function makeOps(initial: Partial<FakeState>): FakeOps {
   const writeSecret = jest.fn(async (rawKey: string) => {
     state.secret = rawKey;
   });
-  const insertKey = jest.fn(
-    async (row: { userId: number; keyPrefix: string; keyHash: string; scopes: string[] }) => {
+  const replaceActiveKey = jest.fn(
+    async (row: { userId: number; keyPrefix: string; keyHash: string; scopes: readonly string[] }) => {
+      // Mirrors the real transactional semantics: revoke-all then insert, atomically.
+      for (const k of state.keys) {
+        if (k.userId === row.userId && k.isActive) {
+          k.isActive = false;
+          k.revoked = true;
+        }
+      }
       state.keys.push({
         userId: row.userId,
         keyPrefix: row.keyPrefix,
         keyHash: row.keyHash,
-        scopes: row.scopes,
+        scopes: [...row.scopes],
         isActive: true,
         revoked: false,
       });
     }
   );
-  const revokeActiveKeys = jest.fn(async (userId: number) => {
-    for (const k of state.keys) {
-      if (k.userId === userId && k.isActive) {
-        k.isActive = false;
-        k.revoked = true;
-      }
-    }
-  });
   return {
     state,
     writeSecret,
-    insertKey,
-    revokeActiveKeys,
+    replaceActiveKey,
     async readSecret() {
       return state.secret;
     },
@@ -131,10 +146,45 @@ describe('pure helpers', () => {
     expect(await verifyKey(raw + 'x', hash)).toBe(false);
   });
 
-  it('coversScopes requires every required scope', () => {
-    expect(coversScopes(REQUIRED_SCOPES, REQUIRED_SCOPES)).toBe(true);
-    expect(coversScopes([...REQUIRED_SCOPES, 'content:publish_public'], REQUIRED_SCOPES)).toBe(true);
-    expect(coversScopes(['content:read'], REQUIRED_SCOPES)).toBe(false);
+  it('scopesMatch is exact set equality — subset AND superset both fail', () => {
+    expect(scopesMatch(REQUIRED_SCOPES, REQUIRED_SCOPES)).toBe(true);
+    expect(scopesMatch([...REQUIRED_SCOPES].reverse(), REQUIRED_SCOPES)).toBe(true);
+    expect(scopesMatch(['content:read'], REQUIRED_SCOPES)).toBe(false);
+    // An over-scoped key must NOT count as matching — least-privilege
+    // reductions to KEY_SCOPES must trigger a re-mint.
+    expect(scopesMatch([...REQUIRED_SCOPES, 'content:publish_public'], REQUIRED_SCOPES)).toBe(false);
+  });
+});
+
+describe('cross-library Argon2 interop (the claim validateApiKey depends on)', () => {
+  it("the app's native argon2.verify() accepts a hash-wasm PHC string", async () => {
+    // The exact library lib/api-keys/argon2-loader.ts loads at runtime,
+    // resolved from the repo root node_modules.
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const nativeArgon2 = require('argon2') as {
+      verify(hash: string, plain: string): Promise<boolean>;
+    };
+    const raw = generateRawKey();
+    const wasmHash = await hashKey(raw);
+    await expect(nativeArgon2.verify(wasmHash, raw)).resolves.toBe(true);
+    await expect(nativeArgon2.verify(wasmHash, raw + 'x')).resolves.toBe(false);
+  });
+});
+
+describe('KEY_SCOPES drift guard (tethered to lib/api-keys/scopes.ts)', () => {
+  it('exactly matches the content:* subset of ROLE_SCOPES.staff', () => {
+    const staffContent = ROLE_SCOPES.staff.filter((s: string) => s.startsWith('content:') && s !== 'content:publish_public');
+    expect(new Set(KEY_SCOPES)).toEqual(new Set(staffContent));
+  });
+
+  it('never includes content:publish_public (§26.4 approval gate is human/admin-held)', () => {
+    expect(KEY_SCOPES).not.toContain('content:publish_public');
+  });
+
+  it('every minted scope is actually grantable to the staff role', () => {
+    for (const scope of KEY_SCOPES) {
+      expect(ROLE_SCOPES.staff).toContain(scope);
+    }
   });
 });
 
@@ -144,8 +194,7 @@ describe('ensureContentKey idempotency', () => {
     const outcome = await ensureContentKey(ops, CFG, noopLog);
 
     expect(outcome).toBe('minted');
-    expect(ops.revokeActiveKeys).toHaveBeenCalledWith(SERVICE_USER_ID);
-    expect(ops.insertKey).toHaveBeenCalledTimes(1);
+    expect(ops.replaceActiveKey).toHaveBeenCalledTimes(1);
     expect(ops.writeSecret).toHaveBeenCalledTimes(1);
 
     // The stored secret is a valid sk- key whose hash+scopes landed in the DB.
@@ -159,7 +208,7 @@ describe('ensureContentKey idempotency', () => {
     expect(await verifyKey(stored, row.keyHash)).toBe(true);
   });
 
-  it('valid existing key -> NO-OP (no mint, no secret write, no revoke)', async () => {
+  it('valid existing key -> NO-OP (no mint, no secret write)', async () => {
     const raw = generateRawKey();
     const hash = await hashKey(raw);
     const ops = makeOps({
@@ -179,22 +228,19 @@ describe('ensureContentKey idempotency', () => {
     const outcome = await ensureContentKey(ops, CFG, noopLog);
 
     expect(outcome).toBe('noop');
-    expect(ops.insertKey).not.toHaveBeenCalled();
+    expect(ops.replaceActiveKey).not.toHaveBeenCalled();
     expect(ops.writeSecret).not.toHaveBeenCalled();
-    expect(ops.revokeActiveKeys).not.toHaveBeenCalled();
     expect(ops.state.secret).toBe(raw);
   });
 
   it('stale/orphaned secret (no matching active row) -> RE-MINT', async () => {
-    // Secret holds a well-formed sk- key, but there is NO api_keys row for it
-    // (e.g. the row was deleted for rotation).
     const orphan = generateRawKey();
     const ops = makeOps({ secret: orphan, keys: [] });
 
     const outcome = await ensureContentKey(ops, CFG, noopLog);
 
     expect(outcome).toBe('minted');
-    expect(ops.insertKey).toHaveBeenCalledTimes(1);
+    expect(ops.replaceActiveKey).toHaveBeenCalledTimes(1);
     const stored = ops.state.secret!;
     expect(stored).not.toBe(orphan);
     expect(isValidKeyFormat(stored)).toBe(true);
@@ -222,7 +268,31 @@ describe('ensureContentKey idempotency', () => {
     expect(ops.state.secret).not.toBe(raw);
   });
 
-  it('inactive/revoked key -> RE-MINT', async () => {
+  it('scope drift (row holds an EXTRA scope) -> RE-MINT (narrowing propagates)', async () => {
+    const raw = generateRawKey();
+    const hash = await hashKey(raw);
+    const ops = makeOps({
+      secret: raw,
+      keys: [
+        {
+          userId: SERVICE_USER_ID,
+          keyPrefix: keyPrefixOf(raw),
+          keyHash: hash,
+          scopes: [...REQUIRED_SCOPES, 'content:publish_public'],
+          isActive: true,
+          revoked: false,
+        },
+      ],
+    });
+
+    const outcome = await ensureContentKey(ops, CFG, noopLog);
+    expect(outcome).toBe('minted');
+    const stored = ops.state.secret!;
+    const row = ops.state.keys.find((k) => k.keyPrefix === keyPrefixOf(stored) && k.isActive)!;
+    expect(row.scopes).toEqual(REQUIRED_SCOPES);
+  });
+
+  it('inactive key -> RE-MINT', async () => {
     const raw = generateRawKey();
     const hash = await hashKey(raw);
     const ops = makeOps({
@@ -241,7 +311,31 @@ describe('ensureContentKey idempotency', () => {
 
     const outcome = await ensureContentKey(ops, CFG, noopLog);
     expect(outcome).toBe('minted');
-    expect(ops.revokeActiveKeys).toHaveBeenCalledWith(SERVICE_USER_ID);
+    expect(ops.replaceActiveKey).toHaveBeenCalledTimes(1);
+  });
+
+  it('revoked-but-still-active row (revoked_at set, is_active true) -> RE-MINT', async () => {
+    // The exact decoupled state the revoked-inversion bug would have accepted:
+    // is_active alone says "valid", revoked_at says "revoked". revoked MUST win.
+    const raw = generateRawKey();
+    const hash = await hashKey(raw);
+    const ops = makeOps({
+      secret: raw,
+      keys: [
+        {
+          userId: SERVICE_USER_ID,
+          keyPrefix: keyPrefixOf(raw),
+          keyHash: hash,
+          scopes: REQUIRED_SCOPES,
+          isActive: true,
+          revoked: true,
+        },
+      ],
+    });
+
+    const outcome = await ensureContentKey(ops, CFG, noopLog);
+    expect(outcome).toBe('minted');
+    expect(ops.state.secret).not.toBe(raw);
   });
 
   it('malformed secret string -> MINT', async () => {
@@ -251,11 +345,19 @@ describe('ensureContentKey idempotency', () => {
     expect(isValidKeyFormat(ops.state.secret!)).toBe(true);
   });
 
-  it('missing service user -> throws (migration must run first)', async () => {
+  it('missing service user -> skipped-migration-pending (never a throw/stack-wedge)', async () => {
+    const errors: string[] = [];
+    const log: Logger = {
+      info: () => {},
+      warn: () => {},
+      error: (m) => errors.push(m),
+    };
     const ops = makeOps({ secret: null, userId: null });
-    await expect(ensureContentKey(ops, CFG, noopLog)).rejects.toThrow(/service user not found/i);
-    expect(ops.insertKey).not.toHaveBeenCalled();
+    const outcome = await ensureContentKey(ops, CFG, log);
+    expect(outcome).toBe('skipped-migration-pending');
+    expect(ops.replaceActiveKey).not.toHaveBeenCalled();
     expect(ops.writeSecret).not.toHaveBeenCalled();
+    expect(errors.join(' ')).toMatch(/service user not found/i);
   });
 
   it('never logs the plaintext key', async () => {
@@ -271,5 +373,244 @@ describe('ensureContentKey idempotency', () => {
     for (const line of lines) {
       expect(line).not.toContain(plaintext);
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildRdsOps — the REAL field parsing, against realistic RDS Data API shapes
+// (correctness review P2: this layer previously had zero coverage; the fake
+// ops bypassed the tagged-union parsing entirely).
+// ---------------------------------------------------------------------------
+
+describe('buildRdsOps field parsing (mocked AWS clients)', () => {
+  const OPS_CFG = {
+    clusterArn: 'arn:cluster',
+    secretArn: 'arn:db-secret',
+    database: 'aistudio',
+    contentKeySecretId: 'arn:content-secret',
+    serviceUserCognitoSub: 'service-account:psd-atrium-agent',
+  };
+
+  let rdsSend: jest.SpyInstance;
+  let smSend: jest.SpyInstance;
+
+  beforeEach(() => {
+    rdsSend = jest.spyOn(RDSDataClient.prototype, 'send');
+    smSend = jest.spyOn(SecretsManagerClient.prototype, 'send');
+  });
+  afterEach(() => {
+    rdsSend.mockRestore();
+    smSend.mockRestore();
+  });
+
+  it('keysByPrefix: revoked_at PRESENT (isNull omitted, the real AWS shape) -> revoked=true', async () => {
+    rdsSend.mockResolvedValueOnce({
+      records: [
+        [
+          { stringValue: '$argon2id$hash' },
+          { stringValue: JSON.stringify(REQUIRED_SCOPES) },
+          { booleanValue: true },
+          { stringValue: '2026-07-12 01:00:00' }, // isNull OMITTED — not false
+        ],
+      ],
+    });
+    const rows = await buildRdsOps(OPS_CFG).keysByPrefix('deadbeef', 3);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].revoked).toBe(true);
+    expect(rows[0].isActive).toBe(true);
+  });
+
+  it('keysByPrefix: revoked_at NULL (isNull true) -> revoked=false', async () => {
+    rdsSend.mockResolvedValueOnce({
+      records: [
+        [
+          { stringValue: '$argon2id$hash' },
+          { stringValue: JSON.stringify(REQUIRED_SCOPES) },
+          { booleanValue: true },
+          { isNull: true },
+        ],
+      ],
+    });
+    const rows = await buildRdsOps(OPS_CFG).keysByPrefix('deadbeef', 3);
+    expect(rows[0].revoked).toBe(false);
+  });
+
+  it('keysByPrefix: malformed scopes JSON degrades to [] (row treated as scope-drifted)', async () => {
+    rdsSend.mockResolvedValueOnce({
+      records: [
+        [
+          { stringValue: '$argon2id$hash' },
+          { stringValue: 'not-json' },
+          { booleanValue: true },
+          { isNull: true },
+        ],
+      ],
+    });
+    const rows = await buildRdsOps(OPS_CFG).keysByPrefix('deadbeef', 3);
+    expect(rows[0].scopes).toEqual([]);
+  });
+
+  it('resolveServiceUserId: longValue extraction and missing-row null', async () => {
+    rdsSend.mockResolvedValueOnce({ records: [[{ longValue: 42 }]] });
+    await expect(buildRdsOps(OPS_CFG).resolveServiceUserId()).resolves.toBe(42);
+    rdsSend.mockResolvedValueOnce({ records: [] });
+    await expect(buildRdsOps(OPS_CFG).resolveServiceUserId()).resolves.toBeNull();
+  });
+
+  it('readSecret: ResourceNotFoundException (no version yet) -> null; other errors propagate', async () => {
+    smSend.mockRejectedValueOnce(
+      new ResourceNotFoundException({ message: 'no version', $metadata: {} })
+    );
+    await expect(buildRdsOps(OPS_CFG).readSecret()).resolves.toBeNull();
+
+    smSend.mockRejectedValueOnce(new Error('AccessDenied'));
+    await expect(buildRdsOps(OPS_CFG).readSecret()).rejects.toThrow('AccessDenied');
+  });
+
+  it('replaceActiveKey: begin -> revoke -> insert -> commit, one transactionId throughout', async () => {
+    const calls: string[] = [];
+    rdsSend.mockImplementation(async (cmd: { constructor: { name: string }; input?: Record<string, unknown> }) => {
+      calls.push(cmd.constructor.name);
+      if (cmd.constructor.name === 'BeginTransactionCommand') return { transactionId: 'tx-1' };
+      if (cmd.constructor.name === 'ExecuteStatementCommand') {
+        expect((cmd.input as { transactionId?: string }).transactionId).toBe('tx-1');
+        return { records: [] };
+      }
+      return {};
+    });
+    await buildRdsOps(OPS_CFG).replaceActiveKey({
+      userId: 3,
+      name: KEY_NAME,
+      keyPrefix: 'deadbeef',
+      keyHash: '$argon2id$hash',
+      scopes: REQUIRED_SCOPES,
+    });
+    expect(calls).toEqual([
+      'BeginTransactionCommand',
+      'ExecuteStatementCommand',
+      'ExecuteStatementCommand',
+      'CommitTransactionCommand',
+    ]);
+  });
+
+  it('replaceActiveKey: a failing statement rolls back and rethrows', async () => {
+    const calls: string[] = [];
+    rdsSend.mockImplementation(async (cmd: { constructor: { name: string } }) => {
+      calls.push(cmd.constructor.name);
+      if (cmd.constructor.name === 'BeginTransactionCommand') return { transactionId: 'tx-1' };
+      if (cmd.constructor.name === 'ExecuteStatementCommand') throw new Error('insert failed');
+      return {};
+    });
+    await expect(
+      buildRdsOps(OPS_CFG).replaceActiveKey({
+        userId: 3,
+        name: KEY_NAME,
+        keyPrefix: 'deadbeef',
+        keyHash: 'h',
+        scopes: REQUIRED_SCOPES,
+      })
+    ).rejects.toThrow('insert failed');
+    expect(calls).toContain('RollbackTransactionCommand');
+    expect(calls).not.toContain('CommitTransactionCommand');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// CloudFormation handler routing (correctness review P2: previously untested)
+// ---------------------------------------------------------------------------
+
+describe('handler (CloudFormation custom resource entry point)', () => {
+  const BASE_EVENT = {
+    StackId: 'stack-1',
+    RequestId: 'req-1',
+    LogicalResourceId: 'AtriumContentKeyProvisioner',
+    ResponseURL: 'https://example.invalid',
+    ResourceType: 'Custom::AtriumContentKey',
+    ServiceToken: 'token',
+    ResourceProperties: { ServiceToken: 'token', Nonce: '1' },
+  };
+
+  const ENV = {
+    DB_CLUSTER_ARN: 'arn:cluster',
+    DB_SECRET_ARN: 'arn:db-secret',
+    DB_NAME: 'aistudio',
+    CONTENT_KEY_SECRET_ID: 'arn:content-secret',
+    SERVICE_USER_COGNITO_SUB: 'service-account:psd-atrium-agent',
+  };
+
+  let rdsSend: jest.SpyInstance;
+  let smSend: jest.SpyInstance;
+  const savedEnv = { ...process.env };
+
+  beforeEach(() => {
+    Object.assign(process.env, ENV);
+    rdsSend = jest.spyOn(RDSDataClient.prototype, 'send');
+    smSend = jest.spyOn(SecretsManagerClient.prototype, 'send');
+  });
+  afterEach(() => {
+    rdsSend.mockRestore();
+    smSend.mockRestore();
+    process.env = { ...savedEnv };
+  });
+
+  it('Delete -> SUCCESS no-op preserving the incoming PhysicalResourceId', async () => {
+    const res = await handler({
+      ...BASE_EVENT,
+      RequestType: 'Delete',
+      PhysicalResourceId: 'atrium-content-key-bootstrap',
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+    expect(res.Status).toBe('SUCCESS');
+    expect(res.PhysicalResourceId).toBe('atrium-content-key-bootstrap');
+    expect(rdsSend).not.toHaveBeenCalled();
+    expect(smSend).not.toHaveBeenCalled();
+  });
+
+  it('Create with a missing service user -> SUCCESS with Outcome=skipped-migration-pending', async () => {
+    rdsSend.mockResolvedValue({ records: [] }); // resolveServiceUserId -> null
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const res = await handler({ ...BASE_EVENT, RequestType: 'Create' } as any);
+    expect(res.Status).toBe('SUCCESS');
+    expect((res as { Data?: { Outcome?: string } }).Data?.Outcome).toBe('skipped-migration-pending');
+  });
+
+  it('Create end-to-end mint: resolve user -> empty secret -> txn replace -> secret write -> SUCCESS minted', async () => {
+    rdsSend.mockImplementation(async (cmd: { constructor: { name: string }; input?: Record<string, unknown> }) => {
+      const name = cmd.constructor.name;
+      if (name === 'BeginTransactionCommand') return { transactionId: 'tx-9' };
+      if (name === 'ExecuteStatementCommand') {
+        const sql = String((cmd.input as { sql?: string }).sql ?? '');
+        if (sql.includes('SELECT id FROM users')) return { records: [[{ longValue: 7 }]] };
+        return { records: [] };
+      }
+      return {};
+    });
+    const written: string[] = [];
+    smSend.mockImplementation(async (cmd: { constructor: { name: string }; input?: Record<string, unknown> }) => {
+      if (cmd.constructor.name === 'GetSecretValueCommand') {
+        throw new ResourceNotFoundException({ message: 'no version', $metadata: {} });
+      }
+      if (cmd.constructor.name === 'PutSecretValueCommand') {
+        written.push(String((cmd.input as { SecretString?: string }).SecretString));
+        return {};
+      }
+      return {};
+    });
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const res = await handler({ ...BASE_EVENT, RequestType: 'Create' } as any);
+    expect(res.Status).toBe('SUCCESS');
+    expect((res as { Data?: { Outcome?: string } }).Data?.Outcome).toBe('minted');
+    expect(written).toHaveLength(1);
+    expect(isValidKeyFormat(written[0])).toBe(true);
+  });
+
+  it('missing required env var -> FAILED with the var named in Reason', async () => {
+    delete process.env.DB_CLUSTER_ARN;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const res = await handler({ ...BASE_EVENT, RequestType: 'Update', PhysicalResourceId: 'p-1' } as any);
+    expect(res.Status).toBe('FAILED');
+    expect(res.Reason).toContain('DB_CLUSTER_ARN');
+    expect(res.PhysicalResourceId).toBe('p-1');
   });
 });

--- a/infra/lambdas/atrium-content-key-bootstrap/index.ts
+++ b/infra/lambdas/atrium-content-key-bootstrap/index.ts
@@ -25,12 +25,26 @@
  * written to Secrets Manager and is NEVER logged. Hashing uses `hash-wasm`
  * (pure-WASM Argon2id) with the SAME parameters as the app's native `argon2`
  * loader (lib/api-keys/argon2-loader.ts) — the two produce interoperable PHC
- * strings (verified: native `argon2.verify()` accepts a hash-wasm hash), so the
- * app's `validateApiKey` authenticates the key with no code change. WASM avoids
+ * strings, so the app's `validateApiKey` authenticates the key with no code
+ * change. The cross-library claim is enforced by a unit test that verifies a
+ * hash-wasm-produced hash with the app's native `argon2.verify()` (hash-wasm is
+ * pinned exact so a bump can't silently change PHC encoding). WASM avoids
  * shipping a native, arch-specific `.node` binary in the Lambda bundle.
  *
+ * Failure posture: a MISSING service user (migration 104 not applied yet — e.g.
+ * a partial single-stack deploy against a cluster whose DatabaseStack predates
+ * the migration) is reported as SUCCESS with Outcome `skipped-migration-pending`
+ * plus an error log, NOT a CFN FAILED. A FAILED here rolls back the ENTIRE
+ * shared AgentPlatformStack, and the CFN rollback re-invokes this handler with
+ * the same inputs — which would fail again and wedge the stack in
+ * UPDATE_ROLLBACK_FAILED. Skipping degrades to "key not provisioned yet"; the
+ * per-deploy Nonce re-runs the bootstrap on the next (full) deploy, which
+ * self-heals. Transient AWS errors still fail loudly (retry = redeploy).
+ *
  * DB access is the repo's standard Aurora deploy-pipeline pattern: the RDS Data
- * API (rds-data:ExecuteStatement), same as the db-init migration Lambda.
+ * API (rds-data:ExecuteStatement), same as the db-init migration Lambda. The
+ * revoke-old + insert-new pair runs inside ONE Data API transaction so a crash
+ * between them cannot leave the two DB states disagreeing.
  */
 
 import crypto from 'node:crypto';
@@ -38,6 +52,9 @@ import { argon2id, argon2Verify } from 'hash-wasm';
 import {
   RDSDataClient,
   ExecuteStatementCommand,
+  BeginTransactionCommand,
+  CommitTransactionCommand,
+  RollbackTransactionCommand,
   type SqlParameter,
   type Field,
 } from '@aws-sdk/client-rds-data';
@@ -45,6 +62,7 @@ import {
   SecretsManagerClient,
   GetSecretValueCommand,
   PutSecretValueCommand,
+  ResourceNotFoundException,
 } from '@aws-sdk/client-secrets-manager';
 import type {
   CloudFormationCustomResourceEvent,
@@ -66,6 +84,22 @@ const ARGON2_ITERATIONS = 3;
 const ARGON2_PARALLELISM = 4;
 const ARGON2_HASH_LENGTH = 32;
 const ARGON2_SALT_BYTES = 16;
+
+// ---------------------------------------------------------------------------
+// Key identity — single source of truth (the CDK stack passes neither; a
+// duplicated literal in the stack drifted from the Lambda's fallback once).
+// KEY_SCOPES must stay a subset of ROLE_SCOPES.staff's content:* scopes and
+// MUST NOT include content:publish_public (the §26.4 public-publish approval
+// gate is deliberately human/admin-held) — enforced by a unit test against
+// lib/api-keys/scopes.ts.
+// ---------------------------------------------------------------------------
+export const KEY_NAME = 'psd-atrium agent (auto-provisioned)';
+export const KEY_SCOPES: readonly string[] = [
+  'content:read',
+  'content:create',
+  'content:update',
+  'content:publish_internal',
+];
 
 // ---------------------------------------------------------------------------
 // Pure crypto helpers (exported for unit tests)
@@ -107,10 +141,15 @@ export async function verifyKey(rawKey: string, phcHash: string): Promise<boolea
   }
 }
 
-/** True iff `keyScopes` covers every scope in `required` (exact-match only). */
-export function coversScopes(keyScopes: string[], required: string[]): boolean {
+/**
+ * True iff the key's scopes are EXACTLY the required set (order-insensitive).
+ * Set-equality, not subset: a live key that holds MORE than required (e.g.
+ * KEY_SCOPES was narrowed in a later deploy) must also re-mint, or a
+ * least-privilege reduction would never propagate to the standing credential.
+ */
+export function scopesMatch(keyScopes: readonly string[], required: readonly string[]): boolean {
   const held = new Set(keyScopes);
-  return required.every((s) => held.has(s));
+  return held.size === new Set(required).size && required.every((s) => held.has(s));
 }
 
 // ---------------------------------------------------------------------------
@@ -134,25 +173,27 @@ export interface ContentKeyOps {
   resolveServiceUserId(): Promise<number | null>;
   /** All api_keys rows for (prefix, userId) — usually 0 or 1. */
   keysByPrefix(prefix: string, userId: number): Promise<ExistingKeyRow[]>;
-  /** Revoke every currently-active key owned by the service user. */
-  revokeActiveKeys(userId: number): Promise<void>;
-  /** Insert a new active api_keys row owned by the service user. */
-  insertKey(row: {
+  /**
+   * Atomically revoke every currently-active key owned by the service user AND
+   * insert the new active row — ONE transaction, so a crash between the two
+   * cannot leave the service user with zero (or two) active keys recorded.
+   */
+  replaceActiveKey(row: {
     userId: number;
     name: string;
     keyPrefix: string;
     keyHash: string;
-    scopes: string[];
+    scopes: readonly string[];
   }): Promise<void>;
 }
 
 export interface EnsureConfig {
   serviceUserCognitoSub: string;
   keyName: string;
-  requiredScopes: string[];
+  requiredScopes: readonly string[];
 }
 
-export type EnsureOutcome = 'noop' | 'minted';
+export type EnsureOutcome = 'noop' | 'minted' | 'skipped-migration-pending';
 
 export interface Logger {
   info(msg: string, meta?: Record<string, unknown>): void;
@@ -162,12 +203,16 @@ export interface Logger {
 
 /**
  * Core idempotency logic. Returns `noop` when the secret already holds a valid,
- * active, sufficiently-scoped key owned by the service user; otherwise mints a
- * fresh key, revokes the service user's other active keys, and returns `minted`.
+ * active key owned by the service user whose scopes EXACTLY match the required
+ * set; otherwise mints a fresh key (revoke-old + insert-new in one transaction
+ * via `ops.replaceActiveKey`) and returns `minted`.
  *
- * NEVER logs the raw key. Throws when the service user row is missing (the
- * migration must have run first — the stack orders AgentPlatformStack after
- * DatabaseStack, so this is a genuine misconfiguration worth failing loudly on).
+ * NEVER logs the raw key. A missing service user row (migration 104 not applied
+ * to this cluster yet) returns `skipped-migration-pending` with an error log
+ * instead of throwing: a throw here becomes a CFN FAILED that rolls back — and
+ * can wedge — the entire shared AgentPlatformStack, whereas skipping degrades to
+ * "key not provisioned yet" and self-heals on the next full deploy (the Nonce
+ * re-fires this handler every deploy).
  */
 export async function ensureContentKey(
   ops: ContentKeyOps,
@@ -176,10 +221,15 @@ export async function ensureContentKey(
 ): Promise<EnsureOutcome> {
   const userId = await ops.resolveServiceUserId();
   if (userId == null) {
-    throw new Error(
-      `Atrium service user not found (cognito_sub=${cfg.serviceUserCognitoSub}). ` +
-        `Migration 104-atrium-agent-service-user.sql must run before this bootstrap.`
+    log.error(
+      'Atrium service user not found — skipping key provisioning (self-heals on the next full deploy)',
+      {
+        cognitoSub: cfg.serviceUserCognitoSub,
+        remediation:
+          'Deploy AIStudio-DatabaseStack first (migration 104-atrium-agent-service-user.sql), then redeploy this stack — use the canonical full deploy, never a partial one.',
+      }
     );
+    return 'skipped-migration-pending';
   }
 
   const current = await ops.readSecret();
@@ -188,7 +238,7 @@ export async function ensureContentKey(
     const candidates = await ops.keysByPrefix(prefix, userId);
     for (const row of candidates) {
       if (!row.isActive || row.revoked) continue;
-      if (!coversScopes(row.scopes, cfg.requiredScopes)) continue;
+      if (!scopesMatch(row.scopes, cfg.requiredScopes)) continue;
       if (await verifyKey(current, row.keyHash)) {
         log.info('Atrium content key present and valid — no-op', {
           keyPrefix: `${KEY_PREFIX}${prefix}`,
@@ -196,21 +246,20 @@ export async function ensureContentKey(
         return 'noop';
       }
     }
-    log.warn('Secret holds a key with no matching active/scoped api_keys row — re-minting', {
+    log.warn('Secret holds a key with no matching active/exactly-scoped api_keys row — re-minting', {
       keyPrefix: `${KEY_PREFIX}${prefix}`,
     });
   } else {
     log.info('Secret empty or malformed — minting Atrium content key', {});
   }
 
-  // Mint. Revoke the service user's other active keys FIRST so exactly one
-  // active service key exists (cleans orphans left by a cleared secret).
-  await ops.revokeActiveKeys(userId);
-
+  // Mint: revoke-old + insert-new atomically (exactly one active service key),
+  // then persist the plaintext. If the secret write fails after the DB commit,
+  // the deploy fails loudly and the next run's re-mint sweeps the orphaned row.
   const rawKey = generateRawKey();
   const keyPrefix = keyPrefixOf(rawKey);
   const keyHash = await hashKey(rawKey);
-  await ops.insertKey({
+  await ops.replaceActiveKey({
     userId,
     name: cfg.keyName,
     keyPrefix,
@@ -250,7 +299,7 @@ export interface RdsOpsConfig {
 }
 
 export function buildRdsOps(cfg: RdsOpsConfig): ContentKeyOps {
-  const exec = async (sql: string, parameters?: SqlParameter[]) =>
+  const exec = async (sql: string, parameters?: SqlParameter[], transactionId?: string) =>
     rds.send(
       new ExecuteStatementCommand({
         resourceArn: cfg.clusterArn,
@@ -258,6 +307,7 @@ export function buildRdsOps(cfg: RdsOpsConfig): ContentKeyOps {
         database: cfg.database,
         sql,
         parameters,
+        transactionId,
         includeResultMetadata: true,
       })
     );
@@ -273,7 +323,7 @@ export function buildRdsOps(cfg: RdsOpsConfig): ContentKeyOps {
       } catch (err) {
         // A secret created by CDK with no value has no version -> ResourceNotFound.
         // Treat as empty; any other error propagates (fail the deploy loudly).
-        if ((err as { name?: string })?.name === 'ResourceNotFoundException') {
+        if (err instanceof ResourceNotFoundException) {
           return null;
         }
         throw err;
@@ -324,32 +374,66 @@ export function buildRdsOps(cfg: RdsOpsConfig): ContentKeyOps {
           keyHash: fieldStr(rec[0]) ?? '',
           scopes,
           isActive: rec[2]?.booleanValue === true,
-          revoked: !(rec[3]?.isNull ?? true),
+          // RDS Data API OMITS `isNull` on non-null fields (it does not send
+          // `isNull: false`), so `!(isNull ?? true)` was permanently false.
+          // A non-null `revoked_at` surfaces via fieldStr's stringValue path.
+          revoked: fieldStr(rec[3]) !== null,
         };
       });
     },
 
-    async revokeActiveKeys(userId: number) {
-      await exec(
-        `UPDATE api_keys
-            SET is_active = false, revoked_at = now(), updated_at = now()
-          WHERE user_id = :uid AND is_active = true`,
-        [{ name: 'uid', value: { longValue: userId } }]
+    async replaceActiveKey(row) {
+      // Revoke-old + insert-new inside ONE Data API transaction: a crash
+      // between the statements can never commit a half-replaced key state.
+      const { transactionId } = await rds.send(
+        new BeginTransactionCommand({
+          resourceArn: cfg.clusterArn,
+          secretArn: cfg.secretArn,
+          database: cfg.database,
+        })
       );
-    },
-
-    async insertKey(row) {
-      await exec(
-        `INSERT INTO api_keys (user_id, name, key_prefix, key_hash, scopes)
-         VALUES (:uid, :name, :prefix, :hash, CAST(:scopes AS jsonb))`,
-        [
-          { name: 'uid', value: { longValue: row.userId } },
-          strParam('name', row.name),
-          strParam('prefix', row.keyPrefix),
-          strParam('hash', row.keyHash),
-          strParam('scopes', JSON.stringify(row.scopes)),
-        ]
-      );
+      if (!transactionId) throw new Error('RDS Data API returned no transactionId');
+      try {
+        await exec(
+          `UPDATE api_keys
+              SET is_active = false, revoked_at = now(), updated_at = now()
+            WHERE user_id = :uid AND is_active = true`,
+          [{ name: 'uid', value: { longValue: row.userId } }],
+          transactionId
+        );
+        await exec(
+          `INSERT INTO api_keys (user_id, name, key_prefix, key_hash, scopes)
+           VALUES (:uid, :name, :prefix, :hash, CAST(:scopes AS jsonb))`,
+          [
+            { name: 'uid', value: { longValue: row.userId } },
+            strParam('name', row.name),
+            strParam('prefix', row.keyPrefix),
+            strParam('hash', row.keyHash),
+            strParam('scopes', JSON.stringify(row.scopes)),
+          ],
+          transactionId
+        );
+        await rds.send(
+          new CommitTransactionCommand({
+            resourceArn: cfg.clusterArn,
+            secretArn: cfg.secretArn,
+            transactionId,
+          })
+        );
+      } catch (err) {
+        try {
+          await rds.send(
+            new RollbackTransactionCommand({
+              resourceArn: cfg.clusterArn,
+              secretArn: cfg.secretArn,
+              transactionId,
+            })
+          );
+        } catch {
+          // Rollback is best-effort; the Data API expires abandoned txns itself.
+        }
+        throw err;
+      }
     },
   };
 }
@@ -369,14 +453,6 @@ const consoleLogger: Logger = {
   warn: (msg, meta) => console.warn(msg, meta ? JSON.stringify(meta) : ''),
   error: (msg, meta) => console.error(msg, meta ? JSON.stringify(meta) : ''),
 };
-
-function parseScopes(raw: string): string[] {
-  const parsed = JSON.parse(raw);
-  if (!Array.isArray(parsed) || parsed.some((s) => typeof s !== 'string' || s.length === 0)) {
-    throw new Error('KEY_SCOPES must be a non-empty JSON array of strings');
-  }
-  return parsed as string[];
-}
 
 // ---------------------------------------------------------------------------
 // CloudFormation Custom Resource handler
@@ -410,15 +486,14 @@ export async function handler(
       contentKeySecretId: must('CONTENT_KEY_SECRET_ID'),
       serviceUserCognitoSub: must('SERVICE_USER_COGNITO_SUB'),
     };
-    const requiredScopes = parseScopes(must('KEY_SCOPES'));
     const ops = buildRdsOps(cfg);
 
     const outcome = await ensureContentKey(
       ops,
       {
         serviceUserCognitoSub: cfg.serviceUserCognitoSub,
-        keyName: process.env.KEY_NAME || 'psd-atrium agent (auto-provisioned)',
-        requiredScopes,
+        keyName: KEY_NAME,
+        requiredScopes: KEY_SCOPES,
       },
       consoleLogger
     );
@@ -426,7 +501,7 @@ export async function handler(
     return {
       ...base,
       Status: 'SUCCESS',
-      PhysicalResourceId: 'atrium-content-key-bootstrap',
+      PhysicalResourceId: physicalId,
       Data: { Outcome: outcome },
     };
   } catch (err) {

--- a/infra/lambdas/atrium-content-key-bootstrap/index.ts
+++ b/infra/lambdas/atrium-content-key-bootstrap/index.ts
@@ -64,10 +64,18 @@ import {
   PutSecretValueCommand,
   ResourceNotFoundException,
 } from '@aws-sdk/client-secrets-manager';
-import type {
-  CloudFormationCustomResourceEvent,
-  CloudFormationCustomResourceResponse,
-} from 'aws-lambda';
+import type { CloudFormationCustomResourceEvent } from 'aws-lambda';
+
+/**
+ * Return shape for the CDK `custom-resources.Provider` framework's onEvent
+ * handler. The framework — NOT this Lambda — posts the CFN response: a normal
+ * return means SUCCESS (only PhysicalResourceId/Data/NoEcho are read; a
+ * `Status` field would be IGNORED), and a FAILURE is signaled by THROWING.
+ */
+interface ProviderOnEventResponse {
+  PhysicalResourceId: string;
+  Data?: Record<string, string>;
+}
 
 // ---------------------------------------------------------------------------
 // Key format + Argon2 params — MUST match lib/api-keys/key-service.ts and
@@ -460,14 +468,9 @@ const consoleLogger: Logger = {
 
 export async function handler(
   event: CloudFormationCustomResourceEvent
-): Promise<CloudFormationCustomResourceResponse> {
+): Promise<ProviderOnEventResponse> {
   console.info('event', JSON.stringify({ RequestType: event.RequestType, LogicalResourceId: event.LogicalResourceId }));
 
-  const base = {
-    StackId: event.StackId,
-    RequestId: event.RequestId,
-    LogicalResourceId: event.LogicalResourceId,
-  };
   const physicalId =
     'PhysicalResourceId' in event ? event.PhysicalResourceId : 'atrium-content-key-bootstrap';
 
@@ -476,7 +479,7 @@ export async function handler(
       // Leave the key + secret in place: the secret is CDK-owned and destroyed
       // with the stack in dev; revoking here would strand the running agent if a
       // stack is merely replaced. Nothing to do.
-      return { ...base, Status: 'SUCCESS', PhysicalResourceId: physicalId };
+      return { PhysicalResourceId: physicalId };
     }
 
     const cfg: RdsOpsConfig = {
@@ -498,19 +501,12 @@ export async function handler(
       consoleLogger
     );
 
-    return {
-      ...base,
-      Status: 'SUCCESS',
-      PhysicalResourceId: physicalId,
-      Data: { Outcome: outcome },
-    };
+    return { PhysicalResourceId: physicalId, Data: { Outcome: outcome } };
   } catch (err) {
+    // The Provider framework signals CFN failure ONLY via a throw — a returned
+    // `Status: 'FAILED'` object would be read as SUCCESS and silently swallow
+    // the error. Log for CloudWatch, then rethrow so the deploy fails loudly.
     console.error('atrium-content-key-bootstrap error', err instanceof Error ? err.message : String(err));
-    return {
-      ...base,
-      Status: 'FAILED',
-      Reason: err instanceof Error ? err.message : String(err),
-      PhysicalResourceId: physicalId,
-    };
+    throw err;
   }
 }

--- a/infra/lambdas/atrium-content-key-bootstrap/index.ts
+++ b/infra/lambdas/atrium-content-key-bootstrap/index.ts
@@ -1,0 +1,441 @@
+/**
+ * Atrium Content Key Bootstrap — CloudFormation Custom Resource.
+ *
+ * Zero-touch provisioning for the psd-atrium agent credential (follow-up to
+ * PR #1195). PR #1195 shipped the psd-atrium OpenClaw skill + an EMPTY
+ * `psd-agent/<env>/atrium-content-api-key` secret, but a human still had to
+ * (1) mint a content-scoped `sk-` key in AI Studio Settings and (2) run
+ * `aws secretsmanager put-secret-value`. This custom resource removes BOTH
+ * manual steps: on every `cdk deploy` it idempotently ensures the secret holds
+ * a valid, active, content-scoped key owned by the migration-seeded service
+ * user (migration 104, `cognito_sub = service-account:psd-atrium-agent`).
+ *
+ * Idempotency contract (runs on Create AND Update — the stack passes a per-deploy
+ * Nonce so Update always fires, making the resource self-healing):
+ *   - secret holds a valid+active key owned by the service user, whose scopes
+ *     cover the required set -> NO-OP.
+ *   - secret empty / malformed / points at a missing|inactive|revoked key, or
+ *     the key's scopes no longer cover the required set -> MINT a fresh key,
+ *     revoke any other active keys the service user owns (so exactly one active
+ *     service key exists), store the plaintext in the secret.
+ * Rotation = delete the secret value OR revoke/delete the api_keys row; the next
+ * deploy re-mints.
+ *
+ * The DB stores ONLY the Argon2id hash (never the plaintext). The plaintext is
+ * written to Secrets Manager and is NEVER logged. Hashing uses `hash-wasm`
+ * (pure-WASM Argon2id) with the SAME parameters as the app's native `argon2`
+ * loader (lib/api-keys/argon2-loader.ts) — the two produce interoperable PHC
+ * strings (verified: native `argon2.verify()` accepts a hash-wasm hash), so the
+ * app's `validateApiKey` authenticates the key with no code change. WASM avoids
+ * shipping a native, arch-specific `.node` binary in the Lambda bundle.
+ *
+ * DB access is the repo's standard Aurora deploy-pipeline pattern: the RDS Data
+ * API (rds-data:ExecuteStatement), same as the db-init migration Lambda.
+ */
+
+import crypto from 'node:crypto';
+import { argon2id, argon2Verify } from 'hash-wasm';
+import {
+  RDSDataClient,
+  ExecuteStatementCommand,
+  type SqlParameter,
+  type Field,
+} from '@aws-sdk/client-rds-data';
+import {
+  SecretsManagerClient,
+  GetSecretValueCommand,
+  PutSecretValueCommand,
+} from '@aws-sdk/client-secrets-manager';
+import type {
+  CloudFormationCustomResourceEvent,
+  CloudFormationCustomResourceResponse,
+} from 'aws-lambda';
+
+// ---------------------------------------------------------------------------
+// Key format + Argon2 params — MUST match lib/api-keys/key-service.ts and
+// lib/api-keys/argon2-loader.ts, or the app's validateApiKey() will reject the
+// minted key.
+// ---------------------------------------------------------------------------
+const KEY_PREFIX = 'sk-';
+const KEY_BYTES = 32; // 256-bit
+const KEY_HEX_LENGTH = KEY_BYTES * 2; // 64 hex chars
+const DISPLAY_PREFIX_LENGTH = 8; // first 8 hex chars stored for lookup + display
+const KEY_FORMAT_REGEX = new RegExp(`^sk-[0-9a-f]{${KEY_HEX_LENGTH}}$`);
+const ARGON2_MEMORY_KIB = 65536; // 64 MB
+const ARGON2_ITERATIONS = 3;
+const ARGON2_PARALLELISM = 4;
+const ARGON2_HASH_LENGTH = 32;
+const ARGON2_SALT_BYTES = 16;
+
+// ---------------------------------------------------------------------------
+// Pure crypto helpers (exported for unit tests)
+// ---------------------------------------------------------------------------
+
+/** Generate a `sk-` + 64-hex random key, identical in shape to generateApiKey. */
+export function generateRawKey(): string {
+  return `${KEY_PREFIX}${crypto.randomBytes(KEY_BYTES).toString('hex')}`;
+}
+
+/** First 8 hex chars after the `sk-` prefix — the indexed lookup handle. */
+export function keyPrefixOf(rawKey: string): string {
+  return rawKey.slice(KEY_PREFIX.length, KEY_PREFIX.length + DISPLAY_PREFIX_LENGTH);
+}
+
+export function isValidKeyFormat(rawKey: string): boolean {
+  return typeof rawKey === 'string' && KEY_FORMAT_REGEX.test(rawKey);
+}
+
+/** Argon2id-hash a raw key into a PHC string the app's argon2.verify() accepts. */
+export async function hashKey(rawKey: string): Promise<string> {
+  return argon2id({
+    password: rawKey,
+    salt: crypto.randomBytes(ARGON2_SALT_BYTES),
+    parallelism: ARGON2_PARALLELISM,
+    iterations: ARGON2_ITERATIONS,
+    memorySize: ARGON2_MEMORY_KIB,
+    hashLength: ARGON2_HASH_LENGTH,
+    outputType: 'encoded',
+  });
+}
+
+/** Verify a raw key against a stored PHC hash (constant-time, in hash-wasm). */
+export async function verifyKey(rawKey: string, phcHash: string): Promise<boolean> {
+  try {
+    return await argon2Verify({ password: rawKey, hash: phcHash });
+  } catch {
+    return false;
+  }
+}
+
+/** True iff `keyScopes` covers every scope in `required` (exact-match only). */
+export function coversScopes(keyScopes: string[], required: string[]): boolean {
+  const held = new Set(keyScopes);
+  return required.every((s) => held.has(s));
+}
+
+// ---------------------------------------------------------------------------
+// Injectable operations — the seam that makes idempotency unit-testable with
+// fake SM/DB. `buildRdsOps` wires the real RDS Data API + Secrets Manager.
+// ---------------------------------------------------------------------------
+
+export interface ExistingKeyRow {
+  keyHash: string;
+  scopes: string[];
+  isActive: boolean;
+  revoked: boolean;
+}
+
+export interface ContentKeyOps {
+  /** Current secret string, or null when the secret has no value yet. */
+  readSecret(): Promise<string | null>;
+  /** Store the raw plaintext key as the secret value. */
+  writeSecret(rawKey: string): Promise<void>;
+  /** Resolve the service user's numeric id by its cognito_sub sentinel, or null. */
+  resolveServiceUserId(): Promise<number | null>;
+  /** All api_keys rows for (prefix, userId) — usually 0 or 1. */
+  keysByPrefix(prefix: string, userId: number): Promise<ExistingKeyRow[]>;
+  /** Revoke every currently-active key owned by the service user. */
+  revokeActiveKeys(userId: number): Promise<void>;
+  /** Insert a new active api_keys row owned by the service user. */
+  insertKey(row: {
+    userId: number;
+    name: string;
+    keyPrefix: string;
+    keyHash: string;
+    scopes: string[];
+  }): Promise<void>;
+}
+
+export interface EnsureConfig {
+  serviceUserCognitoSub: string;
+  keyName: string;
+  requiredScopes: string[];
+}
+
+export type EnsureOutcome = 'noop' | 'minted';
+
+export interface Logger {
+  info(msg: string, meta?: Record<string, unknown>): void;
+  warn(msg: string, meta?: Record<string, unknown>): void;
+  error(msg: string, meta?: Record<string, unknown>): void;
+}
+
+/**
+ * Core idempotency logic. Returns `noop` when the secret already holds a valid,
+ * active, sufficiently-scoped key owned by the service user; otherwise mints a
+ * fresh key, revokes the service user's other active keys, and returns `minted`.
+ *
+ * NEVER logs the raw key. Throws when the service user row is missing (the
+ * migration must have run first — the stack orders AgentPlatformStack after
+ * DatabaseStack, so this is a genuine misconfiguration worth failing loudly on).
+ */
+export async function ensureContentKey(
+  ops: ContentKeyOps,
+  cfg: EnsureConfig,
+  log: Logger
+): Promise<EnsureOutcome> {
+  const userId = await ops.resolveServiceUserId();
+  if (userId == null) {
+    throw new Error(
+      `Atrium service user not found (cognito_sub=${cfg.serviceUserCognitoSub}). ` +
+        `Migration 104-atrium-agent-service-user.sql must run before this bootstrap.`
+    );
+  }
+
+  const current = await ops.readSecret();
+  if (current && isValidKeyFormat(current)) {
+    const prefix = keyPrefixOf(current);
+    const candidates = await ops.keysByPrefix(prefix, userId);
+    for (const row of candidates) {
+      if (!row.isActive || row.revoked) continue;
+      if (!coversScopes(row.scopes, cfg.requiredScopes)) continue;
+      if (await verifyKey(current, row.keyHash)) {
+        log.info('Atrium content key present and valid — no-op', {
+          keyPrefix: `${KEY_PREFIX}${prefix}`,
+        });
+        return 'noop';
+      }
+    }
+    log.warn('Secret holds a key with no matching active/scoped api_keys row — re-minting', {
+      keyPrefix: `${KEY_PREFIX}${prefix}`,
+    });
+  } else {
+    log.info('Secret empty or malformed — minting Atrium content key', {});
+  }
+
+  // Mint. Revoke the service user's other active keys FIRST so exactly one
+  // active service key exists (cleans orphans left by a cleared secret).
+  await ops.revokeActiveKeys(userId);
+
+  const rawKey = generateRawKey();
+  const keyPrefix = keyPrefixOf(rawKey);
+  const keyHash = await hashKey(rawKey);
+  await ops.insertKey({
+    userId,
+    name: cfg.keyName,
+    keyPrefix,
+    keyHash,
+    scopes: cfg.requiredScopes,
+  });
+  await ops.writeSecret(rawKey);
+  log.info('Minted Atrium content key', {
+    keyPrefix: `${KEY_PREFIX}${keyPrefix}`,
+    scopes: cfg.requiredScopes,
+  });
+  return 'minted';
+}
+
+// ---------------------------------------------------------------------------
+// RDS Data API + Secrets Manager wiring (the real ops)
+// ---------------------------------------------------------------------------
+
+const rds = new RDSDataClient({});
+const secrets = new SecretsManagerClient({});
+
+function strParam(name: string, value: string): SqlParameter {
+  return { name, value: { stringValue: value } };
+}
+
+function fieldStr(field: Field | undefined): string | null {
+  if (!field || field.isNull) return null;
+  return field.stringValue ?? null;
+}
+
+export interface RdsOpsConfig {
+  clusterArn: string;
+  secretArn: string;
+  database: string;
+  contentKeySecretId: string;
+  serviceUserCognitoSub: string;
+}
+
+export function buildRdsOps(cfg: RdsOpsConfig): ContentKeyOps {
+  const exec = async (sql: string, parameters?: SqlParameter[]) =>
+    rds.send(
+      new ExecuteStatementCommand({
+        resourceArn: cfg.clusterArn,
+        secretArn: cfg.secretArn,
+        database: cfg.database,
+        sql,
+        parameters,
+        includeResultMetadata: true,
+      })
+    );
+
+  return {
+    async readSecret() {
+      try {
+        const resp = await secrets.send(
+          new GetSecretValueCommand({ SecretId: cfg.contentKeySecretId })
+        );
+        const value = resp.SecretString?.trim();
+        return value && value.length > 0 ? value : null;
+      } catch (err) {
+        // A secret created by CDK with no value has no version -> ResourceNotFound.
+        // Treat as empty; any other error propagates (fail the deploy loudly).
+        if ((err as { name?: string })?.name === 'ResourceNotFoundException') {
+          return null;
+        }
+        throw err;
+      }
+    },
+
+    async writeSecret(rawKey: string) {
+      await secrets.send(
+        new PutSecretValueCommand({
+          SecretId: cfg.contentKeySecretId,
+          SecretString: rawKey,
+        })
+      );
+    },
+
+    async resolveServiceUserId() {
+      const resp = await exec(
+        `SELECT id FROM users WHERE cognito_sub = :sub LIMIT 1`,
+        [strParam('sub', cfg.serviceUserCognitoSub)]
+      );
+      const rec = resp.records?.[0];
+      const id = rec?.[0]?.longValue;
+      return typeof id === 'number' ? id : null;
+    },
+
+    async keysByPrefix(prefix: string, userId: number) {
+      const resp = await exec(
+        `SELECT key_hash, scopes, is_active, revoked_at
+           FROM api_keys
+          WHERE key_prefix = :prefix AND user_id = :uid`,
+        [
+          strParam('prefix', prefix),
+          { name: 'uid', value: { longValue: userId } },
+        ]
+      );
+      return (resp.records ?? []).map((rec) => {
+        const scopesRaw = fieldStr(rec[1]);
+        let scopes: string[] = [];
+        if (scopesRaw) {
+          try {
+            const parsed = JSON.parse(scopesRaw);
+            if (Array.isArray(parsed)) scopes = parsed.filter((s) => typeof s === 'string');
+          } catch {
+            scopes = [];
+          }
+        }
+        return {
+          keyHash: fieldStr(rec[0]) ?? '',
+          scopes,
+          isActive: rec[2]?.booleanValue === true,
+          revoked: !(rec[3]?.isNull ?? true),
+        };
+      });
+    },
+
+    async revokeActiveKeys(userId: number) {
+      await exec(
+        `UPDATE api_keys
+            SET is_active = false, revoked_at = now(), updated_at = now()
+          WHERE user_id = :uid AND is_active = true`,
+        [{ name: 'uid', value: { longValue: userId } }]
+      );
+    },
+
+    async insertKey(row) {
+      await exec(
+        `INSERT INTO api_keys (user_id, name, key_prefix, key_hash, scopes)
+         VALUES (:uid, :name, :prefix, :hash, CAST(:scopes AS jsonb))`,
+        [
+          { name: 'uid', value: { longValue: row.userId } },
+          strParam('name', row.name),
+          strParam('prefix', row.keyPrefix),
+          strParam('hash', row.keyHash),
+          strParam('scopes', JSON.stringify(row.scopes)),
+        ]
+      );
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Env + config
+// ---------------------------------------------------------------------------
+
+function must(name: string): string {
+  const v = process.env[name];
+  if (!v) throw new Error(`${name} env var is required`);
+  return v;
+}
+
+const consoleLogger: Logger = {
+  info: (msg, meta) => console.info(msg, meta ? JSON.stringify(meta) : ''),
+  warn: (msg, meta) => console.warn(msg, meta ? JSON.stringify(meta) : ''),
+  error: (msg, meta) => console.error(msg, meta ? JSON.stringify(meta) : ''),
+};
+
+function parseScopes(raw: string): string[] {
+  const parsed = JSON.parse(raw);
+  if (!Array.isArray(parsed) || parsed.some((s) => typeof s !== 'string' || s.length === 0)) {
+    throw new Error('KEY_SCOPES must be a non-empty JSON array of strings');
+  }
+  return parsed as string[];
+}
+
+// ---------------------------------------------------------------------------
+// CloudFormation Custom Resource handler
+// ---------------------------------------------------------------------------
+
+export async function handler(
+  event: CloudFormationCustomResourceEvent
+): Promise<CloudFormationCustomResourceResponse> {
+  console.info('event', JSON.stringify({ RequestType: event.RequestType, LogicalResourceId: event.LogicalResourceId }));
+
+  const base = {
+    StackId: event.StackId,
+    RequestId: event.RequestId,
+    LogicalResourceId: event.LogicalResourceId,
+  };
+  const physicalId =
+    'PhysicalResourceId' in event ? event.PhysicalResourceId : 'atrium-content-key-bootstrap';
+
+  try {
+    if (event.RequestType === 'Delete') {
+      // Leave the key + secret in place: the secret is CDK-owned and destroyed
+      // with the stack in dev; revoking here would strand the running agent if a
+      // stack is merely replaced. Nothing to do.
+      return { ...base, Status: 'SUCCESS', PhysicalResourceId: physicalId };
+    }
+
+    const cfg: RdsOpsConfig = {
+      clusterArn: must('DB_CLUSTER_ARN'),
+      secretArn: must('DB_SECRET_ARN'),
+      database: must('DB_NAME'),
+      contentKeySecretId: must('CONTENT_KEY_SECRET_ID'),
+      serviceUserCognitoSub: must('SERVICE_USER_COGNITO_SUB'),
+    };
+    const requiredScopes = parseScopes(must('KEY_SCOPES'));
+    const ops = buildRdsOps(cfg);
+
+    const outcome = await ensureContentKey(
+      ops,
+      {
+        serviceUserCognitoSub: cfg.serviceUserCognitoSub,
+        keyName: process.env.KEY_NAME || 'psd-atrium agent (auto-provisioned)',
+        requiredScopes,
+      },
+      consoleLogger
+    );
+
+    return {
+      ...base,
+      Status: 'SUCCESS',
+      PhysicalResourceId: 'atrium-content-key-bootstrap',
+      Data: { Outcome: outcome },
+    };
+  } catch (err) {
+    console.error('atrium-content-key-bootstrap error', err instanceof Error ? err.message : String(err));
+    return {
+      ...base,
+      Status: 'FAILED',
+      Reason: err instanceof Error ? err.message : String(err),
+      PhysicalResourceId: physicalId,
+    };
+  }
+}

--- a/infra/lambdas/atrium-content-key-bootstrap/package.json
+++ b/infra/lambdas/atrium-content-key-bootstrap/package.json
@@ -1,7 +1,7 @@
 {
   "name": "atrium-content-key-bootstrap",
   "version": "1.0.0",
-  "description": "CloudFormation custom resource — idempotently mints the content-scoped sk- key for the psd-atrium skill and stores it in Secrets Manager (zero-touch provisioning)",
+  "description": "CloudFormation custom resource \u2014 idempotently mints the content-scoped sk- key for the psd-atrium skill and stores it in Secrets Manager (zero-touch provisioning)",
   "main": "dist/index.js",
   "scripts": {
     "build": "tsc",
@@ -10,7 +10,7 @@
   "dependencies": {
     "@aws-sdk/client-rds-data": "^3.0.0",
     "@aws-sdk/client-secrets-manager": "^3.0.0",
-    "hash-wasm": "^4.12.0"
+    "hash-wasm": "4.12.0"
   },
   "devDependencies": {
     "@types/aws-lambda": "^8.10.145",

--- a/infra/lambdas/atrium-content-key-bootstrap/package.json
+++ b/infra/lambdas/atrium-content-key-bootstrap/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "atrium-content-key-bootstrap",
+  "version": "1.0.0",
+  "description": "CloudFormation custom resource — idempotently mints the content-scoped sk- key for the psd-atrium skill and stores it in Secrets Manager (zero-touch provisioning)",
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "tsc",
+    "prebuild": "rm -rf dist"
+  },
+  "dependencies": {
+    "@aws-sdk/client-rds-data": "^3.0.0",
+    "@aws-sdk/client-secrets-manager": "^3.0.0",
+    "hash-wasm": "^4.12.0"
+  },
+  "devDependencies": {
+    "@types/aws-lambda": "^8.10.145",
+    "@types/node": "^20.0.0",
+    "typescript": "^5.0.0"
+  }
+}

--- a/infra/lambdas/atrium-content-key-bootstrap/tsconfig.json
+++ b/infra/lambdas/atrium-content-key-bootstrap/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "lib": ["ES2022"],
+    "outDir": "./dist",
+    "rootDir": "./",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "moduleResolution": "node",
+    "declaration": false,
+    "sourceMap": true,
+    "types": ["node"]
+  },
+  "include": ["index.ts"],
+  "exclude": ["node_modules", "dist", "__tests__"]
+}

--- a/infra/lib/agent-platform-stack.ts
+++ b/infra/lib/agent-platform-stack.ts
@@ -586,19 +586,19 @@ export class AgentPlatformStack extends cdk.Stack {
 
     // Atrium content API key (#1055 Path 2) for the psd-atrium skill. A scoped
     // `sk-` key holding content: scopes (content:read/create/update/
-    // publish_internal), minted in AI Studio → Settings → API Keys by an owner
-    // whose role grants those scopes (staff or administrator). Created EMPTY
-    // (Google/Canva pattern); populated after deploy with the raw key string:
-    //   aws secretsmanager put-secret-value \
-    //     --secret-id psd-agent/<env>/atrium-content-api-key \
-    //     --secret-string 'sk-...'
+    // publish_internal). Created empty, then AUTO-POPULATED on every deploy by
+    // the AtriumContentKeyBootstrapLambda custom resource (section 4g below),
+    // which idempotently mints the key for the migration-104 service user —
+    // DO NOT populate it manually; a hand-written value is detected as
+    // stale/unowned and replaced on the next deploy. Rotation: clear the secret
+    // value or revoke the api_keys row, then deploy.
     // Read (not written) by the AgentCore runtime, which already holds
     // GetSecretValue on psd-agent/${environment}/* (see the execution-role policy
     // below) — so no new IAM grant is required. The value is a RAW sk- string,
     // NOT JSON (the skill reads SecretString verbatim).
     const atriumContentApiKeySecret = new secretsmanager.Secret(this, 'AtriumContentApiKeySecret', {
       secretName: `psd-agent/${environment}/atrium-content-api-key`,
-      description: `Scoped sk- content API key for the psd-atrium skill (Atrium /api/v1/content access). Populate after minting a content-scoped key in AI Studio Settings → API Keys. Issue #1055.`,
+      description: `Scoped sk- content API key for the psd-atrium skill (Atrium /api/v1/content access). AUTO-POPULATED each deploy by AtriumContentKeyBootstrapLambda — do not set manually. Issue #1055.`,
     });
     cdk.Tags.of(atriumContentApiKeySecret).add('Environment', environment);
     cdk.Tags.of(atriumContentApiKeySecret).add('ManagedBy', 'cdk');
@@ -794,9 +794,15 @@ export class AgentPlatformStack extends cdk.Stack {
     //     The DB stores only the hash; the plaintext goes to the secret and is
     //     never logged.
     //   - Idempotent: no-op when the secret already holds a valid key; re-mints
-    //     when the secret is empty/stale or the key is revoked/under-scoped.
+    //     when the secret is empty/stale or the key is revoked/scope-drifted
+    //     (exact scope match — a scope REDUCTION also re-mints).
     //   - Runs AFTER DatabaseStack (bin/infra.ts addDependency), so migration
-    //     104 (the service user) has been applied before it mints.
+    //     104 (the service user) has been applied before it mints. That ordering
+    //     only holds for `cdk deploy --all`; a partial single-stack deploy
+    //     against a cluster missing migration 104 does NOT fail the stack — the
+    //     Lambda logs an error and reports Outcome=skipped-migration-pending
+    //     (a CFN FAILED would roll back, and could wedge, this entire shared
+    //     stack). The next full deploy self-heals via the per-deploy Nonce.
     //
     // Least-privilege role (ServiceRoleFactory): RDS Data API on the cluster +
     // read the DB credential secret + read/write ONLY the content-key secret.
@@ -882,8 +888,12 @@ export class AgentPlatformStack extends cdk.Stack {
           },
         },
       ),
-      memorySize: 256,
-      timeout: cdk.Duration.minutes(2),
+      // 512 MB: Argon2id reserves 64 MB for the hash itself atop the Node/WASM
+      // baseline — 256 left thin headroom, and an OOM mid-mint is exactly the
+      // crash the transactional replace exists to survive. 5 min: dev Aurora
+      // auto-pauses to 0 ACU; a cold resume can exceed the old 2-min budget.
+      memorySize: 512,
+      timeout: cdk.Duration.minutes(5),
       architecture: lambda.Architecture.ARM_64,
       logGroup: atriumKeyBootstrapLogGroup,
       environment: {
@@ -892,16 +902,8 @@ export class AgentPlatformStack extends cdk.Stack {
         DB_NAME: props.databaseName ?? 'aistudio',
         CONTENT_KEY_SECRET_ID: atriumContentApiKeySecret.secretArn,
         SERVICE_USER_COGNITO_SUB: 'service-account:psd-atrium-agent',
-        KEY_NAME: 'psd-atrium agent (auto-provisioned)',
-        // Content scopes: read/create/update/publish_internal — NOT
-        // publish_public (the §26.4 public-publish approval gate stays).
-        KEY_SCOPES: JSON.stringify([
-          'content:read',
-          'content:create',
-          'content:update',
-          'content:publish_internal',
-        ]),
-        ENVIRONMENT: environment,
+        // Key name + scopes live as constants in the Lambda (single source of
+        // truth, unit-tested against ROLE_SCOPES.staff — see index.ts KEY_SCOPES).
       },
     });
 

--- a/infra/lib/agent-platform-stack.ts
+++ b/infra/lib/agent-platform-stack.ts
@@ -779,6 +779,149 @@ export class AgentPlatformStack extends cdk.Stack {
     });
 
     // =====================================================================
+    // 4g. Atrium content API key — deploy-time zero-touch provisioning
+    // =====================================================================
+    // Removes the two manual steps PR #1195 left behind (mint an `sk-` key in
+    // AI Studio Settings + `aws secretsmanager put-secret-value`). This custom
+    // resource idempotently ensures `atriumContentApiKeySecret` (created above)
+    // holds a valid, active, content-scoped key owned by the service user seeded
+    // by migration 104 (`cognito_sub = service-account:psd-atrium-agent`).
+    //
+    //   - Reuses the repo's Aurora deploy pattern: the RDS Data API
+    //     (rds-data:ExecuteStatement, same as the db-init migration Lambda).
+    //   - Argon2id-hashes the key with hash-wasm using the SAME params as the
+    //     app's argon2 loader, so `validateApiKey` authenticates it unchanged.
+    //     The DB stores only the hash; the plaintext goes to the secret and is
+    //     never logged.
+    //   - Idempotent: no-op when the secret already holds a valid key; re-mints
+    //     when the secret is empty/stale or the key is revoked/under-scoped.
+    //   - Runs AFTER DatabaseStack (bin/infra.ts addDependency), so migration
+    //     104 (the service user) has been applied before it mints.
+    //
+    // Least-privilege role (ServiceRoleFactory): RDS Data API on the cluster +
+    // read the DB credential secret + read/write ONLY the content-key secret.
+    // Secrets are granted directly via additionalPolicies (not the factory's
+    // `secrets` array) to avoid the token double-wrap on cross-stack ARNs.
+    const atriumKeyBootstrapRole = ServiceRoleFactory.createLambdaRole(this, 'AtriumContentKeyBootstrapRole', {
+      functionName: 'psd-agent-atrium-key-bootstrap',
+      environment,
+      region: this.region,
+      account: this.account,
+      vpcEnabled: false,
+      secrets: [],
+      additionalPolicies: [
+        new iam.PolicyDocument({
+          statements: [
+            new iam.PolicyStatement({
+              sid: 'AuroraDataApi',
+              effect: iam.Effect.ALLOW,
+              actions: ['rds-data:ExecuteStatement', 'rds-data:BatchExecuteStatement'],
+              resources: [props.databaseResourceArn],
+            }),
+            new iam.PolicyStatement({
+              sid: 'ReadDatabaseSecret',
+              effect: iam.Effect.ALLOW,
+              actions: ['secretsmanager:GetSecretValue'],
+              resources: [props.databaseSecretArn],
+            }),
+            new iam.PolicyStatement({
+              sid: 'ReadWriteContentKeySecret',
+              effect: iam.Effect.ALLOW,
+              actions: ['secretsmanager:GetSecretValue', 'secretsmanager:PutSecretValue'],
+              resources: [atriumContentApiKeySecret.secretArn],
+            }),
+          ],
+        }),
+      ],
+    });
+
+    const atriumKeyBootstrapLogGroup = new logs.LogGroup(this, 'AtriumContentKeyBootstrapLogGroup', {
+      logGroupName: `/aws/lambda/psd-agent-atrium-key-bootstrap-${environment}`,
+      retention: config.monitoring.logRetention,
+      removalPolicy: environment === 'prod'
+        ? cdk.RemovalPolicy.RETAIN
+        : cdk.RemovalPolicy.DESTROY,
+    });
+
+    const atriumKeyBootstrap = new lambda.Function(this, 'AtriumContentKeyBootstrapLambda', {
+      functionName: `psd-agent-atrium-key-bootstrap-${environment}`,
+      role: atriumKeyBootstrapRole,
+      runtime: AGENT_LAMBDA_RUNTIME,
+      handler: 'index.handler',
+      code: lambda.Code.fromAsset(
+        path.join(__dirname, '..', 'lambdas', 'atrium-content-key-bootstrap'),
+        {
+          assetHashType: cdk.AssetHashType.SOURCE,
+          bundling: {
+            image: AGENT_LAMBDA_RUNTIME.bundlingImage,
+            local: {
+              tryBundle(outputDir: string): boolean {
+                try {
+                  const inputDir = path.join(__dirname, '..', 'lambdas', 'atrium-content-key-bootstrap');
+                  execSync('bun install && bunx tsc', { cwd: inputDir, stdio: 'inherit' });
+                  execSync(`cp -r dist/* ${outputDir}/`, { cwd: inputDir, stdio: 'inherit' });
+                  execSync(`cp package.json ${outputDir}/`, { cwd: inputDir, stdio: 'inherit' });
+                  execSync('bun install --production', { cwd: outputDir, stdio: 'inherit' });
+                  return true;
+                } catch (e) {
+                  // eslint-disable-next-line no-console
+                  console.error('Local bundling failed, falling back to Docker:', e);
+                  return false;
+                }
+              },
+            },
+            command: [
+              'bash', '-c',
+              [
+                'npm install', 'npm run build',
+                'cp -r dist/* /asset-output/',
+                'cp package.json /asset-output/',
+                'cd /asset-output && npm install --production',
+              ].join(' && '),
+            ],
+          },
+        },
+      ),
+      memorySize: 256,
+      timeout: cdk.Duration.minutes(2),
+      architecture: lambda.Architecture.ARM_64,
+      logGroup: atriumKeyBootstrapLogGroup,
+      environment: {
+        DB_CLUSTER_ARN: props.databaseResourceArn,
+        DB_SECRET_ARN: props.databaseSecretArn,
+        DB_NAME: props.databaseName ?? 'aistudio',
+        CONTENT_KEY_SECRET_ID: atriumContentApiKeySecret.secretArn,
+        SERVICE_USER_COGNITO_SUB: 'service-account:psd-atrium-agent',
+        KEY_NAME: 'psd-atrium agent (auto-provisioned)',
+        // Content scopes: read/create/update/publish_internal — NOT
+        // publish_public (the §26.4 public-publish approval gate stays).
+        KEY_SCOPES: JSON.stringify([
+          'content:read',
+          'content:create',
+          'content:update',
+          'content:publish_internal',
+        ]),
+        ENVIRONMENT: environment,
+      },
+    });
+
+    const atriumKeyProvider = new customResources.Provider(this, 'AtriumContentKeyProvider', {
+      onEventHandler: atriumKeyBootstrap,
+    });
+    const atriumKeyProvisioner = new cdk.CustomResource(this, 'AtriumContentKeyProvisioner', {
+      serviceToken: atriumKeyProvider.serviceToken,
+      properties: {
+        // Bump on every synth so the custom resource's Update handler fires on
+        // EVERY deploy. The ensure logic is idempotent (a no-op when the key is
+        // valid), so re-running is cheap; the benefit is self-healing — a
+        // cleared secret or revoked key row is re-minted on the next deploy,
+        // which is exactly the documented rotation story.
+        Nonce: Date.now().toString(),
+      },
+    });
+    atriumKeyProvisioner.node.addDependency(atriumContentApiKeySecret);
+
+    // =====================================================================
     // 5. IAM Roles
     // =====================================================================
 

--- a/infra/lib/agent-platform-stack.ts
+++ b/infra/lib/agent-platform-stack.ts
@@ -788,7 +788,9 @@ export class AgentPlatformStack extends cdk.Stack {
     // by migration 104 (`cognito_sub = service-account:psd-atrium-agent`).
     //
     //   - Reuses the repo's Aurora deploy pattern: the RDS Data API
-    //     (rds-data:ExecuteStatement, same as the db-init migration Lambda).
+    //     (rds-data:ExecuteStatement/BatchExecuteStatement, same as the db-init
+    //     migration Lambda, plus BeginTransaction/CommitTransaction/
+    //     RollbackTransaction for the revoke+insert replace transaction).
     //   - Argon2id-hashes the key with hash-wasm using the SAME params as the
     //     app's argon2 loader, so `validateApiKey` authenticates it unchanged.
     //     The DB stores only the hash; the plaintext goes to the secret and is
@@ -821,7 +823,13 @@ export class AgentPlatformStack extends cdk.Stack {
             new iam.PolicyStatement({
               sid: 'AuroraDataApi',
               effect: iam.Effect.ALLOW,
-              actions: ['rds-data:ExecuteStatement', 'rds-data:BatchExecuteStatement'],
+              actions: [
+                'rds-data:ExecuteStatement',
+                'rds-data:BatchExecuteStatement',
+                'rds-data:BeginTransaction',
+                'rds-data:CommitTransaction',
+                'rds-data:RollbackTransaction',
+              ],
               resources: [props.databaseResourceArn],
             }),
             new iam.PolicyStatement({


### PR DESCRIPTION
Eliminates the two manual provisioning steps PR #1195 left behind (mint an `sk-` key in AI Studio Settings + `aws secretsmanager put-secret-value`). After a normal `cdk deploy`, the deployed agent's Atrium credential exists with **zero human steps**.

## How it works
- **Migration 104** seeds a service user (`cognito_sub = service-account:psd-atrium-agent`, staff role) — idempotent, splitter-safe, backed by real unique constraints (verified against immutable 002).
- **`AtriumContentKeyBootstrapLambda`** (CloudFormation custom resource, fired on every deploy via a per-deploy Nonce) idempotently ensures `psd-agent/<env>/atrium-content-api-key` holds a valid, active key owned by that service user:
  - secret valid + active + scopes EXACTLY match → no-op
  - empty / malformed / orphaned / revoked / scope-drifted (missing **or extra** scope) → re-mint: revoke-old + insert-new in **one RDS Data API transaction**, then write the plaintext to the secret (never logged; DB stores only the Argon2id hash)
  - **Rotation** = clear the secret value or revoke the key row → next deploy re-mints.
- Scopes: `content:read create update publish_internal` — `content:publish_public` deliberately excluded (§26.4 approval gate stays human/admin-held), enforced by a unit test tethered to `ROLE_SCOPES.staff`.
- Hashing: `hash-wasm` Argon2id (pinned exact) with the app's exact params; **cross-library interop is now tested** — the app's native `argon2.verify()` verifies a hash-wasm PHC string in CI.

## Failure posture (deliberate)
A missing service user (partial single-stack deploy against a cluster whose DatabaseStack predates migration 104) does **not** fail the stack — a CFN FAILED would roll back the entire shared AgentPlatformStack and the rollback's re-invoke would wedge it in `UPDATE_ROLLBACK_FAILED`. Instead it logs an error and returns `Outcome=skipped-migration-pending`; the next full deploy self-heals. Transient AWS errors still fail loudly.

## Review round (5 agents: security, correctness, adversarial, sql/migration, simplicity)
All confirmed findings fixed in the final commit — details in its message. Highlights: the `revoked`-flag inversion (RDS Data API omits `isNull` on non-null fields — the flag could never be true), the untested argon2 interop claim, the stack-wedge failure mode, un-transacted revoke→insert, scope-drift guard, stale Console-visible secret description still instructing the manual flow, 512MB/5min capacity for Argon2 + Aurora cold-resume.

Deliberately NOT added (documented decisions): scheduled rotation (the per-deploy re-validation + secret-clear rotation covers the need; simplicity review endorsed the restraint), IAM tag-conditions on the three exact-ARN grants (matches the established pattern for this grant shape in the same stack), Secrets Manager `AWSPREVIOUS` retention (inherent SM versioning; prior value is an already-revoked key).

## Verification
- Lambda suite 29 tests (idempotency matrix incl. isolated revoked+active state, realistic Data API field shapes, transactional replace commit/rollback ordering, CFN handler routing incl. end-to-end mint, argon2 interop, scope tether); full lambdas project 95/95.
- Migration 104 applied to local Docker postgres; real mint verified end-to-end on `:3100`: auto-minted key authenticated `/api/v1/content` (find/create/read/edit/publish_internal 200s, publish_public → 202 approval_required, no/bad key → 401).
- `cdk synth` + infra tsc green; pre-push full suite green.

## Remaining human steps
`cdk deploy` (canonical full deploy). The agent image containing the psd-atrium skill is already built and pushed (`psd-agent-base-dev:2026-07-12-initial`).

https://claude.ai/code/session_01WsTsgEPEP39VJExUXaY9sz
