### PR TITLE
fix(atrium): support JS/CSS artifact code via base64 codeEncoding (WAF-opaque transit)

### DIFF
--- a/actions/db/atrium/create-version.ts
+++ b/actions/db/atrium/create-version.ts
@@ -20,13 +20,23 @@ import {
 import { createSuccess, handleError, ErrorFactories } from "@/lib/error-utils";
 import { contentService } from "@/lib/content";
 import type { ContentObjectWithVersion, SnapshotInput } from "@/lib/content";
+import {
+  decodeContentBody,
+  type ContentCodeEncoding,
+} from "@/lib/content/code-encoding";
 import type { ActionState } from "@/types";
 import { hasCapabilityAccess } from "@/utils/roles";
 import { getUserRequester } from "./requester";
 
 export async function createVersionAction(
   objectId: string,
-  input: SnapshotInput
+  input: SnapshotInput,
+  // The in-app artifact editor base64-encodes `input.body` and passes
+  // `codeEncoding: "base64"` so artifact code containing <script>/<style> is
+  // opaque to the edge WAF (CrossSiteScripting_BODY) on the server-action POST.
+  // The body is decoded here BEFORE the service screens/size-caps it. Omit for
+  // raw text (the pre-existing contract is unchanged).
+  opts?: { codeEncoding?: ContentCodeEncoding }
 ): Promise<ActionState<ContentObjectWithVersion>> {
   const requestId = generateRequestId();
   const timer = startTimer("createVersionAction");
@@ -38,6 +48,7 @@ export async function createVersionAction(
       input: sanitizeForLogging({
         bodyFormat: input?.bodyFormat,
         hasBody: typeof input?.body === "string",
+        codeEncoding: opts?.codeEncoding,
         summary: input?.summary,
       }),
     });
@@ -51,11 +62,15 @@ export async function createVersionAction(
     if (!(await hasCapabilityAccess("atrium-content"))) {
       throw ErrorFactories.authzToolAccessDenied("atrium-content");
     }
-    const result = await contentService.createVersion(
-      requester,
-      objectId,
-      input
-    );
+    // Decode a base64 (WAF-opaque) body to real content before it reaches the
+    // service. `input.body` is a required string, so a raw pass-through stays a
+    // string; the base64 branch returns a string or throws a ValidationError.
+    const body =
+      decodeContentBody(input.body, opts?.codeEncoding) ?? input.body;
+    const result = await contentService.createVersion(requester, objectId, {
+      ...input,
+      body,
+    });
 
     timer({ status: "success" });
     log.info("Version created", {

--- a/app/api/v1/content/[id]/versions/route.ts
+++ b/app/api/v1/content/[id]/versions/route.ts
@@ -23,11 +23,15 @@ import {
 } from "@/lib/content";
 import { contentErrorToResponse, resolveRestRequester } from "@/lib/content/rest";
 import { assertContentAuthoringCapability } from "@/lib/content/surface-helpers";
+import { decodeContentBody } from "@/lib/content/code-encoding";
 import { createLogger } from "@/lib/logger";
 
 const createVersionBodySchema = z.object({
   body: z.string().min(1),
   bodyFormat: z.enum(["markdown", "html", "jsx"]).optional(),
+  // Send `"base64"` so artifact code with <script>/<style> is opaque to the ALB
+  // WAF; the server decodes before §28.3 screening / size caps. Omit for raw text.
+  codeEncoding: z.enum(["base64"]).optional(),
   summary: z.string().max(2000).optional(),
 });
 
@@ -85,8 +89,12 @@ export const POST = withApiAuth(async (request: NextRequest, auth, requestId, pa
   try {
     // Session humans must also hold the atrium-content capability (see helper).
     await assertContentAuthoringCapability(auth);
+    // Decode a base64 (WAF-opaque) body BEFORE the service screens/size-caps it.
+    // `input.body` is a required non-empty string (zod), so a raw pass-through is
+    // always a string and the base64 branch either returns a string or throws.
+    const body = decodeContentBody(input.body, input.codeEncoding) ?? input.body;
     const result = await contentService.createVersion(req, id, {
-      body: input.body,
+      body,
       bodyFormat: input.bodyFormat,
       summary: input.summary,
     });

--- a/app/api/v1/content/route.ts
+++ b/app/api/v1/content/route.ts
@@ -33,6 +33,7 @@ import {
   contentDeepLink,
   resolveCollectionId,
 } from "@/lib/content/surface-helpers";
+import { decodeContentBody } from "@/lib/content/code-encoding";
 import { createLogger } from "@/lib/logger";
 
 const listQuerySchema = z.object({
@@ -51,6 +52,10 @@ const createBodySchema = z.object({
   collectionId: z.string().min(1).optional(),
   body: z.string().optional(),
   bodyFormat: z.enum(["markdown", "html", "jsx"]).optional(),
+  // Transit encoding for `body`. Send `"base64"` so artifact code containing
+  // <script>/<style> is opaque to the ALB WAF's CrossSiteScripting_BODY rule; the
+  // server decodes it here BEFORE §28.3 screening / size caps. Omit for raw text.
+  codeEncoding: z.enum(["base64"]).optional(),
   visibility: restVisibilitySchema.optional(),
   tags: z.array(z.string()).optional(),
 });
@@ -127,6 +132,10 @@ export const POST = withApiAuth(async (request: NextRequest, auth, requestId) =>
     // Session humans must ALSO hold the atrium-content capability (scope alone is
     // the wildcard ["*"] for a session); sk-/OIDC callers are gated by scope.
     await assertContentAuthoringCapability(auth);
+    // Decode a base64 (WAF-opaque) body to its real content BEFORE the service's
+    // §28.3 screening + size caps run — screening always sees decoded content.
+    // Invalid base64 / over-cap throws a ValidationError (mapped to 400 below).
+    const body = decodeContentBody(input.body, input.codeEncoding);
     const collectionId = await resolveCollectionId(input.collectionId);
     const created = await contentService.create(
       req,
@@ -134,7 +143,7 @@ export const POST = withApiAuth(async (request: NextRequest, auth, requestId) =>
         kind: input.kind,
         title: input.title,
         collectionId,
-        body: input.body,
+        body,
         bodyFormat: input.bodyFormat,
         visibility: input.visibility,
         tags: input.tags,

--- a/components/atrium/ArtifactCanvas.tsx
+++ b/components/atrium/ArtifactCanvas.tsx
@@ -38,6 +38,25 @@ import "@/styles/atrium-content.css";
 type Tab = "preview" | "code";
 type LoadState = "loading" | "ready" | "error";
 
+/**
+ * UTF-8-safe base64 encode of artifact code for the save request. The edge WAF
+ * (CrossSiteScripting_BODY) blocks a raw request body containing <script>/<style>
+ * — the exact markup a legitimate artifact carries — so the code is sent
+ * base64-encoded (an inert `[A-Za-z0-9+/=]` string) and decoded server-side
+ * before screening. `btoa` only accepts Latin-1, so encode to UTF-8 bytes first,
+ * chunking to stay clear of the String.fromCharCode argument-count limit on large
+ * artifacts.
+ */
+function toBase64Utf8(text: string): string {
+  const bytes = new TextEncoder().encode(text);
+  let binary = "";
+  const CHUNK = 0x8000;
+  for (let i = 0; i < bytes.length; i += CHUNK) {
+    binary += String.fromCharCode(...bytes.subarray(i, i + CHUNK));
+  }
+  return btoa(binary);
+}
+
 /** Label for a version in the dropdown: "v3 · AI (current)". */
 function versionLabel(v: VersionSummary): string {
   // "· human" (not "· you"): VersionSummary intentionally omits authorUserId
@@ -377,10 +396,13 @@ export function ArtifactCanvas({ idOrSlug, canEdit = false, sandboxSrc = null }:
       // committing any version/selection state into the wrong canvas.
       const saveSeq = loadSeqRef.current;
       const target = objectIdRef.current ?? idOrSlug;
-      const result = await createVersionAction(target, {
-        body: next,
-        bodyFormat,
-      });
+      // base64-encode the code so a <script>/<style>-bearing artifact is opaque to
+      // the edge WAF on this server-action POST; the action decodes before write.
+      const result = await createVersionAction(
+        target,
+        { body: toBase64Utf8(next), bodyFormat },
+        { codeEncoding: "base64" }
+      );
       if (saveSeq !== loadSeqRef.current) return; // object changed during save
       if (!result.isSuccess) {
         // Surface to the CodeEditor's save handler (it shows the message).

--- a/docs/API/v1/context-graph.md
+++ b/docs/API/v1/context-graph.md
@@ -774,10 +774,24 @@ initial version (v1) is snapshotted. Requires `content:create`.
 | `kind` | `document` \| `artifact` | yes | — |
 | `title` | string | yes | 1-500 chars |
 | `collectionId` | string | no | Collection slug or UUID; resolved server-side |
-| `body` | string | no | markdown (document) or code (artifact). Omit to create no v1 |
+| `body` | string | no | markdown (document) or code (artifact). Omit to create no v1. base64 when `codeEncoding: "base64"` |
 | `bodyFormat` | `markdown` \| `html` \| `jsx` | no | — |
+| `codeEncoding` | `base64` | no | Transit encoding for `body` (see below) |
 | `visibility` | object | no | `{ level, grants? }` (see Visibility below). Defaults to the collection default, else `private` |
 | `tags` | string[] | no | — |
+
+**Artifact code with JS/CSS — `codeEncoding: "base64"`:** artifacts are self-contained
+HTML/JS/CSS, so their code legitimately contains `<script>`, `<style>`, and inline
+`style="…"`. The edge WAF (AWS managed `CrossSiteScripting_BODY`) inspects every raw
+request body and BLOCKS that markup with a bare `403` (the request never reaches the
+app). To send it, set `codeEncoding: "base64"` and put the **base64-encoded** body in
+`body`; the server decodes it BEFORE the §28.3 screening and the decoded-size cap
+(max 5,000,000 decoded bytes) run, so screening always operates on the real content.
+Invalid base64 → `400 CONTENT_VALIDATION`. base64's alphabet carries no XSS signature,
+so the WAF stays fully active for every other request. Omit `codeEncoding` for plain
+text/markdown (raw body — unchanged behavior). The same field is accepted by
+`POST /content/{id}/versions`. Artifact code is rendered only inside a cross-origin
+sandboxed iframe (§28.1), never on the app origin.
 
 **Example request:**
 
@@ -792,6 +806,22 @@ curl -X POST -H "Authorization: Bearer sk-your-key" \
     "bodyFormat": "markdown",
     "visibility": { "level": "group", "grants": [{ "kind": "role", "value": "staff" }] },
     "tags": ["policy"]
+  }' \
+  "https://your-domain/api/v1/content"
+```
+
+**Example — an artifact with JS/CSS (base64):**
+
+```bash
+# body is base64("<html><style>…</style><script>…</script></html>")
+curl -X POST -H "Authorization: Bearer sk-your-key" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "kind": "artifact",
+    "title": "Enrollment Chart",
+    "bodyFormat": "html",
+    "codeEncoding": "base64",
+    "body": "PGh0bWw+PHN0eWxlPi4uLjwvc3R5bGU+PHNjcmlwdD4uLi48L3NjcmlwdD48L2h0bWw+"
   }' \
   "https://your-domain/api/v1/content"
 ```
@@ -921,8 +951,9 @@ Snapshot a new version from `body` and make it the current version. Requires `co
 
 | Field | Type | Required | Constraints |
 |-------|------|----------|-------------|
-| `body` | string | yes | min 1 char |
+| `body` | string | yes | min 1 char. base64 when `codeEncoding: "base64"` |
 | `bodyFormat` | `markdown` \| `html` \| `jsx` | no | — |
+| `codeEncoding` | `base64` | no | Set `base64` when `body` is artifact code with `<script>`/`<style>` — decoded server-side before screening/size cap (see `POST /content`). Invalid base64 → 400 |
 | `summary` | string | no | max 2000 chars — change note |
 
 **Example request:**

--- a/docs/API/v1/openapi.yaml
+++ b/docs/API/v1/openapi.yaml
@@ -2731,10 +2731,24 @@ components:
           description: Collection slug or UUID; resolved to a collection id server-side.
         body:
           type: string
-          description: Initial body (markdown for a document, code for an artifact). When omitted, no v1 is created.
+          description: >-
+            Initial body (markdown for a document, code for an artifact). When
+            omitted, no v1 is created. If `codeEncoding` is `base64`, this field
+            is the base64-encoded body and is decoded server-side before
+            screening and size caps.
         bodyFormat:
           type: string
           enum: [markdown, html, jsx]
+        codeEncoding:
+          type: string
+          enum: [base64]
+          description: >-
+            Transit encoding for `body`. Set `base64` when the body contains
+            HTML/JS/CSS (e.g. `<script>`, `<style>`, `style="…"`): the edge WAF
+            blocks that markup in a raw request body, so send the body
+            base64-encoded and the server decodes it BEFORE §28.3 screening and
+            the decoded-size cap (max 5,000,000 decoded bytes). Invalid base64 →
+            400. Omit for plain text/markdown (raw body, unchanged behavior).
         visibility:
           $ref: "#/components/schemas/ContentVisibility"
         tags:
@@ -2771,9 +2785,21 @@ components:
         body:
           type: string
           minLength: 1
+          description: >-
+            New body. If `codeEncoding` is `base64`, this is the base64-encoded
+            body, decoded server-side before screening and the size cap.
         bodyFormat:
           type: string
           enum: [markdown, html, jsx]
+        codeEncoding:
+          type: string
+          enum: [base64]
+          description: >-
+            Transit encoding for `body`. Set `base64` when the body contains
+            HTML/JS/CSS (`<script>`, `<style>`, `style="…"`) so it is opaque to
+            the edge WAF; the server decodes it BEFORE §28.3 screening and the
+            decoded-size cap (max 5,000,000 decoded bytes). Invalid base64 → 400.
+            Omit for plain text/markdown.
         summary:
           type: string
           maxLength: 2000

--- a/infra/agent-image/skills/psd-atrium/SKILL.md
+++ b/infra/agent-image/skills/psd-atrium/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: psd-atrium
-summary: Read and write AI Studio Atrium content — PSD's collaborative document + live-artifact workspace with an intranet publishing flow. Find/read/create/edit documents and artifacts and publish them, version-based, over /api/v1/content.
-description: Use this to work with Atrium, PSD's collaborative content workspace in AI Studio (documents + interactive artifacts, with an internal "intranet" publishing flow). Find and read Atrium documents/artifacts, create new ones, edit them (append or replace), and publish/unpublish to a destination. Atrium is REAL and live — never say the district has no content workspace. Version-based: reads return the last saved version and edits create a new version; the real-time collaborative editor rail is not reachable from here.
+summary: Read and write AI Studio Atrium content — PSD's collaborative document + live-artifact workspace with an intranet publishing flow. Find/read/create/edit/archive documents and artifacts and publish them, version-based, over /api/v1/content. Artifacts fully support HTML/CSS/JavaScript (including <script>/<style>).
+description: Use this to work with Atrium, PSD's collaborative content workspace in AI Studio (documents + interactive artifacts, with an internal "intranet" publishing flow). Find and read Atrium documents/artifacts, create new ones, edit them (append or replace), archive them, and publish/unpublish to a destination. Interactive artifacts fully support real HTML, CSS, and JavaScript — including <script>, <style>, and inline style="…" — pass raw code; the skill base64-encodes it automatically so nothing is stripped or blocked (do NOT work around with legacy attributes like bgcolor/width). Atrium is REAL and live — never say the district has no content workspace. Version-based: reads return the last saved version and edits create a new version; the real-time collaborative editor rail is not reachable from here.
 allowed-tools: Bash(node:*)
 ---
 
@@ -74,8 +74,17 @@ node run.js read --id <uuid-or-slug>
 
 ```bash
 node run.js create-document --title "Sample" --markdown "# Hello" [--collection <slug|id>] [--tags a,b]
-node run.js create-artifact --title "Chart" --code "<html>…</html>" --body-format html
+node run.js create-artifact --title "Chart" --code "<html><style>…</style><script>…</script></html>" --body-format html
 ```
+
+> **Artifact code fully supports HTML, CSS, and JavaScript — including
+> `<script>`, `<style>`, and inline `style="…"`.** Pass raw code; the skill
+> base64-encodes every write body automatically so it is opaque to AI Studio's
+> edge firewall (which would otherwise 403 a raw body that looks like markup) and
+> decoded server-side before it is stored. There is **no need** to avoid `<script>`
+> / `<style>` or fall back to legacy attributes like `bgcolor`/`width` — real
+> JS/CSS is the intended way to build an artifact. Artifacts render only inside a
+> cross-origin sandboxed iframe, never on the app origin.
 
 Optional on both: `--visibility private|group|internal|public` and
 `--grants role:staff,building:GHS` (group grants). Requesting `public` needs the
@@ -101,6 +110,18 @@ node run.js edit --id <id> --body "extra paragraph" --mode append # append to sa
 body is returned inline (small content). For a large (externally stored) body, use
 `--mode replace` with the full text. Optional: `--body-format markdown|html|jsx`,
 `--summary <change note>`.
+
+### Archive (soft-remove — Phase 1 has no hard delete)
+
+```bash
+node run.js archive --id <id>
+```
+
+Flips the object's status to `archived` (via the metadata PATCH; needs
+`content:update`, which the content key holds). Use it to clean up throwaway or
+superseded content you created — Atrium deliberately has no hard delete in Phase 1.
+Archiving also takes any live publication offline. An archived object still shows
+up under `find --status archived`.
 
 ### Publish / unpublish (honor the approval gate)
 

--- a/infra/agent-image/skills/psd-atrium/common.js
+++ b/infra/agent-image/skills/psd-atrium/common.js
@@ -50,6 +50,33 @@ function emit(obj) {
 }
 
 /**
+ * base64-encode a content body for transit. AI Studio's edge WAF blocks any
+ * request body that looks like reflected XSS (`<script>`, `<style>`, `style="…"`,
+ * `onerror=`) via the managed CrossSiteScripting_BODY rule — which is exactly the
+ * markup a real Atrium ARTIFACT carries — returning a bare 403 with no detail.
+ * base64's alphabet (`[A-Za-z0-9+/=]`) contains none of those characters, so an
+ * encoded body is inert to the WAF; the server decodes it (via the request's
+ * `codeEncoding: "base64"` flag) BEFORE screening/size caps. JS/CSS artifact code
+ * is therefore fully supported — this makes it opaque in transit, not stripped.
+ */
+function encodeContentBody(text) {
+  return Buffer.from(String(text), 'utf8').toString('base64');
+}
+
+/**
+ * Return a REST write body with its `body` field base64-encoded and
+ * `codeEncoding: "base64"` set, so <script>/<style>-bearing content survives the
+ * edge WAF. A no-op when there is no body to send (e.g. a metadata-only create),
+ * so an empty document is posted unchanged.
+ */
+function withEncodedBody(body) {
+  if (!body || typeof body.body !== 'string' || body.body.length === 0) {
+    return body;
+  }
+  return { ...body, body: encodeContentBody(body.body), codeEncoding: 'base64' };
+}
+
+/**
  * Minimal long-form argv parser. `--foo bar` and `--foo` (boolean) supported;
  * dashes in key names become underscores. Mirrors psd-aistudio/psd-data.
  */
@@ -338,4 +365,6 @@ module.exports = {
   resolveContentBaseUrl,
   resolveApiKey,
   restFetch,
+  encodeContentBody,
+  withEncodedBody,
 };

--- a/infra/agent-image/skills/psd-atrium/common.test.js
+++ b/infra/agent-image/skills/psd-atrium/common.test.js
@@ -242,6 +242,38 @@ test('parseList rejects a value-less flag (exit 1) instead of silently dropping 
   expect(code).toBe(1);
 });
 
+test('encodeContentBody base64-encodes UTF-8 and round-trips', () => {
+  const text = '<script>alert("héllo — 日本")</script>';
+  const encoded = common.encodeContentBody(text);
+  // Canonical base64: no XSS-signature characters for the WAF to match.
+  expect(encoded).toMatch(/^[A-Za-z0-9+/]+={0,2}$/);
+  expect(encoded).not.toContain('<');
+  // Canonical base64 (re-decode → re-encode is a fixed point).
+  expect(Buffer.from(encoded, 'base64').toString('base64')).toBe(encoded);
+  expect(Buffer.from(encoded, 'base64').toString('utf8')).toBe(text);
+});
+
+test('withEncodedBody encodes a present body and sets codeEncoding', () => {
+  const out = common.withEncodedBody({ body: '<style>b{}</style>', bodyFormat: 'html' });
+  expect(out.codeEncoding).toBe('base64');
+  expect(out.bodyFormat).toBe('html');
+  expect(Buffer.from(out.body, 'base64').toString('utf8')).toBe('<style>b{}</style>');
+});
+
+test('withEncodedBody is a no-op when there is no body (metadata-only create)', () => {
+  const input = { kind: 'document', title: 'T', body: undefined };
+  const out = common.withEncodedBody(input);
+  expect(out.body).toBeUndefined();
+  expect(out.codeEncoding).toBeUndefined();
+  expect(out).toEqual(input);
+});
+
+test('withEncodedBody leaves an empty-string body unencoded (no codeEncoding)', () => {
+  const out = common.withEncodedBody({ body: '' });
+  expect(out.codeEncoding).toBeUndefined();
+  expect(out.body).toBe('');
+});
+
 test('parseGrants parses kind:value pairs', () => {
   expect(common.parseGrants('role:staff,building:GHS')).toEqual([
     { kind: 'role', value: 'staff' },

--- a/infra/agent-image/skills/psd-atrium/run.js
+++ b/infra/agent-image/skills/psd-atrium/run.js
@@ -22,8 +22,14 @@
  *                    [--visibility <level>] [--grants ...]
  *   node run.js edit --id <id> --body <text> [--mode replace|append]
  *                    [--body-format markdown|html|jsx] [--summary <s>]
+ *   node run.js archive --id <id>
  *   node run.js set-visibility --id <id> --level private|group|internal|public
  *                    [--grants role:staff,building:GHS]
+ *
+ * Artifact code is HTML/JS/CSS (including <script>/<style>) and is FULLY
+ * supported: run.js base64-encodes every write body automatically (codeEncoding:
+ * "base64") so the code is opaque to the edge WAF and decoded server-side before
+ * screening. Pass raw code — do not escape or strip tags.
  *   node run.js publish --id <id> [--destination intranet|public_web|schoology|google|okf]
  *   node run.js unpublish --id <id> --destination intranet|public_web|schoology|google
  *
@@ -45,6 +51,7 @@ const {
   parseList,
   parseGrants,
   restFetch,
+  withEncodedBody,
 } = require('./common');
 
 const KINDS = ['document', 'artifact'];
@@ -73,8 +80,12 @@ function usage() {
       '                  [--visibility <level>] [--grants k:v,...]',
       '  edit --id <id> --body <text> [--mode replace|append]',
       '       [--body-format markdown|html|jsx] [--summary <s>]',
+      '  archive --id <id>   (soft-remove; no hard delete in Phase 1)',
       '  set-visibility --id <id> --level private|group|internal|public',
       '                 [--grants role:staff,building:GHS]',
+      '',
+      'Artifact code (HTML/JS/CSS, incl. <script>/<style>) is fully supported and',
+      'sent base64-encoded automatically — you pass raw code, nothing to escape.',
       '',
       'Publish (§26.4 — a public destination you may not publish directly returns',
       'a queued-for-approval result; relay its message verbatim):',
@@ -222,7 +233,9 @@ async function main() {
         visibility,
         tags: parseList(args.tags, 'tags'),
       };
-      const { payload } = await restFetch('POST', '', { body });
+      // base64-encode the body so <script>/<style> in a fenced block survives the
+      // edge WAF; the server decodes before screening (no-op when bodyless).
+      const { payload } = await restFetch('POST', '', { body: withEncodedBody(body) });
       emitCreated(payload, visibility);
       return;
     }
@@ -242,7 +255,9 @@ async function main() {
         visibility,
         tags: parseList(args.tags, 'tags'),
       };
-      const { payload } = await restFetch('POST', '', { body });
+      // Artifact code is HTML/JS/CSS — ALWAYS base64-encode it so <script>/<style>
+      // is opaque to the edge WAF; the server decodes it before screening.
+      const { payload } = await restFetch('POST', '', { body: withEncodedBody(body) });
       emitCreated(payload, visibility);
       return;
     }
@@ -276,10 +291,25 @@ async function main() {
         if (!bodyFormat) bodyFormat = version.bodyFormat;
       }
 
+      // base64-encode the new body so <script>/<style> content survives the edge
+      // WAF; the server decodes it before screening.
       const { payload } = await restFetch('POST', `/${encodeURIComponent(id)}/versions`, {
-        body: { body: finalBody, bodyFormat, summary },
+        body: withEncodedBody({ body: finalBody, bodyFormat, summary }),
       });
       emit({ ...payload, mode });
+      return;
+    }
+
+    case 'archive': {
+      // Soft-remove: flip status to "archived" via the metadata PATCH (needs
+      // content:update, which the content key holds). Atrium Phase 1 has no hard
+      // delete by design, so this is how you clean up throwaway content you made.
+      // Archiving also takes any live publication offline (server-side).
+      const id = requireStr(args, 'id', 'id');
+      const { payload } = await restFetch('PATCH', `/${encodeURIComponent(id)}`, {
+        body: { status: 'archived' },
+      });
+      emit({ ...payload, archived: true });
       return;
     }
 

--- a/infra/agent-image/skills/psd-atrium/run.test.js
+++ b/infra/agent-image/skills/psd-atrium/run.test.js
@@ -180,22 +180,32 @@ test('read requires --id (exit 1)', async () => {
   expect(code).toBe(1);
 });
 
-test('create-document POSTs / with kind=document and markdown body', async () => {
+test('create-document POSTs / with kind=document and a base64-encoded markdown body', async () => {
   restResponder = () => ({ approvalRequired: false, status: 201, payload: { id: 'obj-9', slug: 'doc' } });
 
   await run('create-document', '--title', 'Sample', '--markdown', '# Hello', '--collection', 'lessons', '--tags', 'a,b');
 
   expect(restCalls[0].method).toBe('POST');
   expect(restCalls[0].path).toBe('');
+  // Body is base64-encoded in transit with codeEncoding: 'base64' so the edge WAF
+  // never inspects raw markup; the server decodes it before screening.
   expect(restCalls[0].opts.body).toEqual({
     kind: 'document',
     title: 'Sample',
     collectionId: 'lessons',
-    body: '# Hello',
+    body: Buffer.from('# Hello', 'utf8').toString('base64'),
     bodyFormat: 'markdown',
+    codeEncoding: 'base64',
     visibility: undefined,
     tags: ['a', 'b'],
   });
+});
+
+test('create-document with no --markdown sends no body and no codeEncoding', async () => {
+  await run('create-document', '--title', 'Empty');
+  const body = restCalls[0].opts.body;
+  expect(body.body).toBeUndefined();
+  expect(body.codeEncoding).toBeUndefined();
 });
 
 test('create-document carries a visibility object built from --visibility/--grants', async () => {
@@ -250,14 +260,29 @@ test('a value-less optional flag is a usage error (exit 1), not silently dropped
   expect(code).toBe(1);
 });
 
-test('create-artifact POSTs / with kind=artifact, code→body, and bodyFormat', async () => {
+test('create-artifact POSTs / with kind=artifact, base64 code→body, and bodyFormat', async () => {
   await run('create-artifact', '--title', 'Chart', '--code', '<html></html>', '--body-format', 'html');
-  expect(restCalls[0].opts.body).toMatchObject({
+  const body = restCalls[0].opts.body;
+  expect(body).toMatchObject({
     kind: 'artifact',
     title: 'Chart',
-    body: '<html></html>',
     bodyFormat: 'html',
+    codeEncoding: 'base64',
   });
+  expect(Buffer.from(body.body, 'base64').toString('utf8')).toBe('<html></html>');
+});
+
+test('create-artifact with <script>/<style> produces a WAF-opaque base64 body', async () => {
+  const code =
+    '<html><style>b{color:red}</style><script>alert(1)</script></html>';
+  await run('create-artifact', '--title', 'X', '--code', code, '--body-format', 'html');
+  const body = restCalls[0].opts.body;
+  expect(body.codeEncoding).toBe('base64');
+  // Canonical base64: no <, >, ", : — so the WAF's CrossSiteScripting_BODY rule
+  // has no XSS signature to match. The server round-trips it back to the real code.
+  expect(body.body).toMatch(/^[A-Za-z0-9+/]+={0,2}$/);
+  expect(body.body).not.toContain('<script');
+  expect(Buffer.from(body.body, 'base64').toString('utf8')).toBe(code);
 });
 
 test('create-artifact requires --body-format (exit 1)', async () => {
@@ -277,7 +302,12 @@ test('edit (replace) POSTs a new version with the given body', async () => {
 
   expect(restCalls).toHaveLength(1);
   expect(restCalls[0]).toMatchObject({ method: 'POST', path: '/obj-1/versions' });
-  expect(restCalls[0].opts.body).toEqual({ body: 'new text', bodyFormat: undefined, summary: 'rev' });
+  expect(restCalls[0].opts.body).toEqual({
+    body: Buffer.from('new text', 'utf8').toString('base64'),
+    bodyFormat: undefined,
+    summary: 'rev',
+    codeEncoding: 'base64',
+  });
   expect(emitted[0].mode).toBe('replace');
 });
 
@@ -297,7 +327,11 @@ test('edit (append) reads the saved body then POSTs the concatenation', async ()
 
   expect(restCalls[0]).toMatchObject({ method: 'GET', path: '/obj-1' });
   expect(restCalls[1]).toMatchObject({ method: 'POST', path: '/obj-1/versions' });
-  expect(restCalls[1].opts.body.body).toBe('first\n\nsecond');
+  // The concatenated body is base64-encoded in transit; it decodes to the join.
+  expect(restCalls[1].opts.body.codeEncoding).toBe('base64');
+  expect(Buffer.from(restCalls[1].opts.body.body, 'base64').toString('utf8')).toBe(
+    'first\n\nsecond'
+  );
   expect(restCalls[1].opts.body.bodyFormat).toBe('markdown');
 });
 
@@ -317,6 +351,32 @@ test('edit (append) fails cleanly when the current body is not inline', async ()
   expect(code).toBe(1);
   // Only the GET happened; no version was written.
   expect(restCalls).toHaveLength(1);
+});
+
+test('archive PATCHes /<id> with status archived', async () => {
+  restResponder = () => ({
+    approvalRequired: false,
+    status: 200,
+    payload: { id: 'obj-1', slug: 'doc', status: 'archived' },
+  });
+
+  await run('archive', '--id', 'obj-1');
+
+  expect(restCalls).toHaveLength(1);
+  expect(restCalls[0]).toMatchObject({ method: 'PATCH', path: '/obj-1' });
+  expect(restCalls[0].opts.body).toEqual({ status: 'archived' });
+  expect(emitted[0].archived).toBe(true);
+  expect(emitted[0].status).toBe('archived');
+});
+
+test('archive requires --id (exit 1)', async () => {
+  let code;
+  try {
+    await run('archive');
+  } catch (err) {
+    code = err.code;
+  }
+  expect(code).toBe(1);
 });
 
 test('set-visibility PATCHes /<id>/visibility with level + grants', async () => {

--- a/lib/content/code-encoding.ts
+++ b/lib/content/code-encoding.ts
@@ -74,7 +74,15 @@ export function decodeContentBody(
   encoding: ContentCodeEncoding | undefined
 ): string | undefined {
   if (encoding === undefined) return body;
-  // encoding === "base64" (the only member today).
+  // Defensive boundary check: only "base64" is supported today. A caller that
+  // bypasses the zod enum (e.g. via a cast, or a future untyped caller) with an
+  // unsupported value is REJECTED here rather than silently decoded as base64 —
+  // the repo pattern of validating enum-like input at the service boundary, not
+  // only at the API/action layer. `String(encoding)` keeps this a genuine runtime
+  // guard (the static type is already narrowed to the sole member).
+  if (String(encoding) !== "base64") {
+    throw new ValidationError(`Unsupported codeEncoding: ${String(encoding)}`);
+  }
   if (typeof body !== "string") {
     throw new ValidationError(
       "codeEncoding was set but no body was provided to decode"

--- a/lib/content/code-encoding.ts
+++ b/lib/content/code-encoding.ts
@@ -1,0 +1,122 @@
+/**
+ * Atrium content-body transit encoding (WAF-opaque artifact code).
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * The ALB in front of AI Studio runs AWS WAF with the managed
+ * `AWSManagedRulesCommonRuleSet` (see `infra/lib/frontend-stack-ecs.ts`). That
+ * rule set's `CrossSiteScripting_BODY` sub-rule inspects EVERY request body and
+ * BLOCKS anything that looks like reflected XSS — `<script>`, `<style>`,
+ * `style="…"`, `onerror=`, `javascript:`, etc. It is NOT excluded (only
+ * `SizeRestrictions_BODY` + `GenericRFI_BODY` are) and it is NOT path-scoped, so
+ * it fires on any POST/PUT whose body carries that markup — including a perfectly
+ * legitimate Atrium ARTIFACT whose whole point is to be self-contained HTML/JS/CSS.
+ * The agent saw this as a bare `403 Forbidden` with no detail (a WAF block never
+ * reaches the app, so no app error is produced).
+ *
+ * THE FIX (keep the WAF fully intact)
+ * -----------------------------------
+ * Rather than carve a hole in the WAF's XSS inspection for the content-write
+ * paths, artifact code is sent base64-ENCODED. base64's alphabet is
+ * `[A-Za-z0-9+/=]` — it contains no `<`, `>`, `"`, `:` or whitespace, so an
+ * encoded body can never contain `<script`, `onerror=` or any other XSS
+ * signature. The WAF sees inert text and lets it through; every other request in
+ * the app still gets full XSS body inspection. The server decodes here, at the
+ * transport boundary, BEFORE the §28.3 guardrails/PII screening and the size
+ * caps run — so screening always operates on the real, decoded content, never on
+ * the opaque wrapper.
+ *
+ * Artifact code is DATA, not app-origin script: it is rendered exclusively inside
+ * the cross-origin `allow-scripts`-only sandbox (§28.1), never on the app origin,
+ * so decoding it server-side introduces no new execution surface.
+ *
+ * This helper is the ONE decode point shared by the REST routes
+ * (`POST /api/v1/content`, `POST /api/v1/content/:id/versions`), the MCP
+ * create/version tools, and the in-app `createVersionAction` server action.
+ */
+
+import { ValidationError } from "./errors";
+
+/** The transit encodings a content-write surface accepts for its body. */
+export const CONTENT_CODE_ENCODINGS = ["base64"] as const;
+export type ContentCodeEncoding = (typeof CONTENT_CODE_ENCODINGS)[number];
+
+/**
+ * Max size (bytes) of a base64-DECODED content body accepted on the
+ * `codeEncoding` path. base64 CANNOT amplify (a decoded payload is 3/4 of its
+ * encoded length), so this is a defense-in-depth sanity bound on client-supplied
+ * encoded content, NOT a product content-length limit. Sized to match the
+ * existing generous per-content-body bound the repo already applies to OKF
+ * imports (`OKF_IMPORT_MAX_FILE_CONTENT_CHARS`, `lib/content/rest.ts`) so a
+ * legitimately large artifact/document is never constrained.
+ */
+export const MAX_DECODED_BODY_BYTES = 5_000_000;
+
+/** Canonical (padded, non-url-safe) base64: groups of 4, standard alphabet. */
+const BASE64_RE = /^[A-Za-z0-9+/]+={0,2}$/;
+
+/**
+ * Decode a content body according to its declared transit `encoding`.
+ *
+ * - `encoding === undefined` → the body is returned UNCHANGED (the pre-existing
+ *   raw contract; callers that never opt in are byte-for-byte unaffected).
+ * - `encoding === "base64"` → `body` is validated as canonical base64, decoded to
+ *   a UTF-8 string, and bounded by {@link MAX_DECODED_BODY_BYTES}.
+ *
+ * Throws a `ValidationError` (surfaced as HTTP 400) when `codeEncoding` is set but
+ * no body is supplied, when the body is not valid base64, or when the decoded
+ * content exceeds the size cap. Never returns silently-garbled content: Node's
+ * `Buffer.from(x, "base64")` is lenient (it drops invalid characters and stops at
+ * the first bad byte), so the input is STRICTLY validated before decoding.
+ */
+export function decodeContentBody(
+  body: string | undefined,
+  encoding: ContentCodeEncoding | undefined
+): string | undefined {
+  if (encoding === undefined) return body;
+  // encoding === "base64" (the only member today).
+  if (typeof body !== "string") {
+    throw new ValidationError(
+      "codeEncoding was set but no body was provided to decode"
+    );
+  }
+  return decodeBase64Body(body);
+}
+
+/** Strictly validate + decode a canonical base64 content body (UTF-8). */
+function decodeBase64Body(encoded: string): string {
+  const normalized = encoded.trim();
+  if (normalized.length === 0) {
+    throw new ValidationError("codeEncoding \"base64\" body is empty");
+  }
+  // Reject non-base64 input up front so a corrupted payload / a raw `<script>`
+  // that slipped past a mis-set flag fails with a clear 400 instead of decoding
+  // to garbage (Buffer.from is lenient and would silently truncate).
+  if (normalized.length % 4 !== 0 || !BASE64_RE.test(normalized)) {
+    throw new ValidationError("Invalid base64 content body (codeEncoding)");
+  }
+  // Allocation guard: reject clearly-oversized input BEFORE decoding a huge
+  // buffer, using the MINIMUM possible decoded size. A canonical base64 string of
+  // length L decodes to (L/4)·3 − p bytes (p = 0–2 padding chars), so
+  // ⌊L·3/4⌋ overestimates the true size by at most 2 — the `+ 2` slack keeps a
+  // payload whose real decoded size is exactly the cap from being false-rejected
+  // here (the exact byte check below is authoritative).
+  const approxDecodedBytes = Math.floor((normalized.length * 3) / 4);
+  if (approxDecodedBytes > MAX_DECODED_BODY_BYTES + 2) {
+    throw new ValidationError(
+      `Decoded content exceeds the ${MAX_DECODED_BODY_BYTES}-byte limit`
+    );
+  }
+  const decoded = Buffer.from(normalized, "base64").toString("utf8");
+  if (decoded.length === 0) {
+    // All-padding / degenerate input (e.g. "====") decodes to nothing.
+    throw new ValidationError("Invalid base64 content body (codeEncoding)");
+  }
+  // Exact post-decode byte bound (the pre-check above is an allocation guard).
+  if (Buffer.byteLength(decoded, "utf8") > MAX_DECODED_BODY_BYTES) {
+    throw new ValidationError(
+      `Decoded content exceeds the ${MAX_DECODED_BODY_BYTES}-byte limit`
+    );
+  }
+  return decoded;
+}

--- a/lib/mcp/content-tool-handlers.ts
+++ b/lib/mcp/content-tool-handlers.ts
@@ -33,6 +33,10 @@ import {
   contentDeepLink,
   resolveCollectionId,
 } from "@/lib/content/surface-helpers";
+import {
+  decodeContentBody,
+  type ContentCodeEncoding,
+} from "@/lib/content/code-encoding";
 // Reuse the REST-side schemas verbatim so MCP and REST validate the same grant /
 // visibility contract from ONE definition (they were byte-identical copies).
 import {
@@ -159,6 +163,8 @@ const createDocumentSchema = z.object({
   title: z.string().min(1).max(500),
   collection: z.string().min(1).max(200).optional(),
   markdown: z.string().optional(),
+  // `"base64"` marks `markdown` as WAF-opaque base64 (decoded before screening).
+  codeEncoding: z.enum(["base64"]).optional(),
   visibility: visibilityZ.optional(),
   tags: z.array(z.string()).optional(),
 });
@@ -179,7 +185,11 @@ async function createContent(
     visibility?: z.infer<typeof visibilityZ>;
     tags?: string[];
   },
-  body: { body?: string; bodyFormat?: "markdown" | "html" | "jsx" }
+  body: {
+    body?: string;
+    bodyFormat?: "markdown" | "html" | "jsx";
+    codeEncoding?: ContentCodeEncoding;
+  }
 ): Promise<McpToolResult> {
   const resolved = await resolveReq(context);
   if ("result" in resolved) return resolved.result;
@@ -187,6 +197,9 @@ async function createContent(
   try {
     // Session humans must also hold the atrium-content capability (see helper).
     await assertContentAuthoringCapability(context);
+    // Decode a base64 (WAF-opaque) body BEFORE the service's §28.3 screening +
+    // size caps — screening always sees the real, decoded content.
+    const decodedBody = decodeContentBody(body.body, body.codeEncoding);
     const collectionId = await resolveCollectionId(common.collection);
     const hasPublishPublicCapability = hasPublishPublicScope(context.scopes);
     const created = await contentService.create(
@@ -195,7 +208,7 @@ async function createContent(
         kind,
         title: common.title,
         collectionId,
-        body: body.body,
+        body: decodedBody,
         bodyFormat: body.bodyFormat,
         visibility: common.visibility,
         tags: common.tags,
@@ -227,12 +240,13 @@ async function handleCreateDocument(
 ): Promise<McpToolResult> {
   const parsed = createDocumentSchema.safeParse(args);
   if (!parsed.success) return zodFail(parsed.error);
-  const { title, collection, markdown, visibility, tags } = parsed.data;
+  const { title, collection, markdown, codeEncoding, visibility, tags } =
+    parsed.data;
   return createContent(
     context,
     "document",
     { title, collection, visibility, tags },
-    { body: markdown, bodyFormat: markdown ? "markdown" : undefined }
+    { body: markdown, bodyFormat: markdown ? "markdown" : undefined, codeEncoding }
   );
 }
 
@@ -242,6 +256,10 @@ const createArtifactSchema = z.object({
   collection: z.string().min(1).max(200).optional(),
   code: z.string().min(1),
   bodyFormat: z.enum(["html", "jsx"]),
+  // `"base64"` marks `code` as WAF-opaque base64 — REQUIRED in practice for
+  // artifact code that contains <script>/<style> (the ALB WAF blocks that markup
+  // in a raw body). Decoded before §28.3 screening / size caps.
+  codeEncoding: z.enum(["base64"]).optional(),
   visibility: visibilityZ.optional(),
   tags: z.array(z.string()).optional(),
 });
@@ -252,12 +270,13 @@ async function handleCreateArtifact(
 ): Promise<McpToolResult> {
   const parsed = createArtifactSchema.safeParse(args);
   if (!parsed.success) return zodFail(parsed.error);
-  const { title, collection, code, bodyFormat, visibility, tags } = parsed.data;
+  const { title, collection, code, bodyFormat, codeEncoding, visibility, tags } =
+    parsed.data;
   return createContent(
     context,
     "artifact",
     { title, collection, visibility, tags },
-    { body: code, bodyFormat }
+    { body: code, bodyFormat, codeEncoding }
   );
 }
 
@@ -397,6 +416,8 @@ const createVersionSchema = z.object({
   id: z.string().min(1),
   body: z.string().min(1),
   bodyFormat: z.enum(["markdown", "html", "jsx"]).optional(),
+  // `"base64"` marks `body` as WAF-opaque base64 (decoded before screening).
+  codeEncoding: z.enum(["base64"]).optional(),
   summary: z.string().optional(),
 });
 
@@ -412,8 +433,12 @@ async function handleCreateVersion(
   try {
     // Session humans must also hold the atrium-content capability (see helper).
     await assertContentAuthoringCapability(context);
+    // Decode a base64 (WAF-opaque) body BEFORE the service screens/size-caps it.
+    const decodedBody =
+      decodeContentBody(parsed.data.body, parsed.data.codeEncoding) ??
+      parsed.data.body;
     const result = await contentService.createVersion(req, parsed.data.id, {
-      body: parsed.data.body,
+      body: decodedBody,
       bodyFormat: parsed.data.bodyFormat,
       summary: parsed.data.summary,
     });

--- a/lib/mcp/content-tools.ts
+++ b/lib/mcp/content-tools.ts
@@ -20,6 +20,8 @@ const VISIBILITY_DESC =
   "Visibility object: { level: 'private'|'group'|'internal'|'public', grants?: [{ kind: 'role'|'building'|'department'|'grade'|'user', value: string }] }";
 const GRANTS_DESC =
   "Group grants: [{ kind: 'role'|'building'|'department'|'grade'|'user', value: string }]";
+const CODE_ENCODING_DESC =
+  "Transit encoding for the body. Set 'base64' when the body/code contains HTML/JS/CSS (<script>, <style>, style=\"…\") — the edge WAF blocks that markup in a raw request body, so send the body base64-encoded and the server decodes it before screening. Omit for plain text/markdown.";
 
 export const CONTENT_TOOL_SCOPE_MAP: Record<string, ApiScope> = {
   create_document: "content:create",
@@ -55,6 +57,11 @@ export const CONTENT_MCP_TOOLS: McpToolDefinition[] = [
         title: { type: "string", description: "Document title" },
         collection: { type: "string", description: "Collection slug or id (optional)" },
         markdown: { type: "string", description: "Initial body; markdown only" },
+        codeEncoding: {
+          type: "string",
+          enum: ["base64"],
+          description: CODE_ENCODING_DESC,
+        },
         visibility: { type: "object", description: VISIBILITY_DESC },
         tags: { type: "array", items: { type: "string" }, description: "Tags" },
       },
@@ -72,6 +79,11 @@ export const CONTENT_MCP_TOOLS: McpToolDefinition[] = [
         collection: { type: "string", description: "Collection slug or id (optional)" },
         code: { type: "string", description: "Artifact source (HTML/JS or JSX)" },
         bodyFormat: { type: "string", enum: ["html", "jsx"], description: "Body format" },
+        codeEncoding: {
+          type: "string",
+          enum: ["base64"],
+          description: CODE_ENCODING_DESC,
+        },
         visibility: { type: "object", description: VISIBILITY_DESC },
         tags: { type: "array", items: { type: "string" }, description: "Tags" },
       },
@@ -145,6 +157,11 @@ export const CONTENT_MCP_TOOLS: McpToolDefinition[] = [
           type: "string",
           enum: ["markdown", "html", "jsx"],
           description: "Body format",
+        },
+        codeEncoding: {
+          type: "string",
+          enum: ["base64"],
+          description: CODE_ENCODING_DESC,
         },
         summary: { type: "string", description: "Optional change summary" },
       },

--- a/tests/e2e/atrium-content-api.functional.spec.ts
+++ b/tests/e2e/atrium-content-api.functional.spec.ts
@@ -80,4 +80,58 @@ test.describe('Atrium content v1 — session capability gate (authenticated)', (
     const body = await res.json()
     expect(body?.data?.id).toBeTruthy()
   })
+
+  test('codeEncoding base64 -> a <script>/<style> artifact round-trips as the DECODED code', async ({
+    page,
+  }) => {
+    await authenticateContext(page.context(), SEEDED_ADMIN_EMAIL, SEEDED_ADMIN_SUB)
+    // Real artifact code — exactly the markup the edge WAF's CrossSiteScripting_BODY
+    // rule blocks in a RAW body (and which this base64 path makes opaque in transit).
+    const code =
+      '<html><head><style>body{background:#0af;font-family:sans-serif}</style></head>' +
+      '<body><h1>Chart</h1><script>document.body.dataset.ready="1";console.log("hi")</script></body></html>'
+    const encoded = Buffer.from(code, 'utf8').toString('base64')
+
+    const res = await page.request.post('/api/v1/content', {
+      data: {
+        kind: 'artifact',
+        title: 'e2e base64 script artifact',
+        bodyFormat: 'html',
+        codeEncoding: 'base64',
+        body: encoded,
+      },
+    })
+    expect(res.status()).toBe(201)
+    const created = await res.json()
+    const id = created?.data?.id
+    expect(id).toBeTruthy()
+    // The server DECODED the base64 before storing: the inline artifact body is the
+    // real <script>/<style> code, NOT the base64 wrapper. This is the whole contract
+    // (screening + storage operate on decoded content). Small artifacts store inline.
+    expect(created?.data?.version?.bodyInline).toBe(code)
+
+    // And it reads back the same decoded code via GET (what the reader/sandbox loads).
+    const read = await page.request.get(`/api/v1/content/${id}`)
+    expect(read.ok()).toBeTruthy()
+    const fetched = await read.json()
+    expect(fetched?.data?.version?.bodyInline).toBe(code)
+  })
+
+  test('codeEncoding base64 with an invalid body -> 400 (never silently stored)', async ({
+    page,
+  }) => {
+    await authenticateContext(page.context(), SEEDED_ADMIN_EMAIL, SEEDED_ADMIN_SUB)
+    const res = await page.request.post('/api/v1/content', {
+      data: {
+        kind: 'artifact',
+        title: 'e2e invalid base64 artifact',
+        bodyFormat: 'html',
+        codeEncoding: 'base64',
+        // Contains characters outside the base64 alphabet — a raw <script> that a
+        // mis-set flag would otherwise decode to garbage.
+        body: '<script>not base64</script>',
+      },
+    })
+    expect(res.status()).toBe(400)
+  })
 })

--- a/tests/unit/atrium-code-encoding.test.ts
+++ b/tests/unit/atrium-code-encoding.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Unit tests for `decodeContentBody` — the WAF-opaque base64 transit decoder for
+ * Atrium content bodies (artifact code / document markdown).
+ *
+ * The edge WAF (AWSManagedRulesCommonRuleSet → CrossSiteScripting_BODY) blocks any
+ * raw request body containing <script>/<style>/style="…" — exactly what a real
+ * artifact carries. The content-write surfaces therefore accept the body
+ * base64-encoded (inert to the WAF) and decode it HERE, before §28.3 screening and
+ * the size caps run. These tests pin:
+ *   - a valid base64 body decodes to its exact UTF-8 content,
+ *   - an undefined `codeEncoding` passes the body through unchanged (raw contract),
+ *   - invalid / non-canonical / oversized base64 throws a ValidationError (→ 400),
+ *   - the encoded form of <script>-bearing code is WAF-opaque (no XSS signature).
+ */
+
+import {
+  decodeContentBody,
+  MAX_DECODED_BODY_BYTES,
+} from "@/lib/content/code-encoding";
+import { ValidationError } from "@/lib/content/errors";
+
+const b64 = (s: string) => Buffer.from(s, "utf8").toString("base64");
+
+describe("decodeContentBody", () => {
+  it("passes the body through unchanged when no encoding is set", () => {
+    expect(decodeContentBody("<script>raw</script>", undefined)).toBe(
+      "<script>raw</script>"
+    );
+    expect(decodeContentBody(undefined, undefined)).toBeUndefined();
+  });
+
+  it("decodes a valid base64 body to its exact UTF-8 content", () => {
+    const code = '<html><style>b{color:red}</style><script>alert("héllo 日本")</script></html>';
+    expect(decodeContentBody(b64(code), "base64")).toBe(code);
+  });
+
+  it("the base64 wrapper carries no XSS signature (WAF-opaque)", () => {
+    const encoded = b64("<script>alert(1)</script>");
+    expect(encoded).toMatch(/^[A-Za-z0-9+/]+={0,2}$/);
+    expect(encoded).not.toContain("<");
+    expect(encoded).not.toContain("<script");
+  });
+
+  it("throws a ValidationError (400) when codeEncoding is set but no body is given", () => {
+    expect(() => decodeContentBody(undefined, "base64")).toThrow(ValidationError);
+  });
+
+  it("throws on a raw (non-base64) body that slipped past a mis-set flag", () => {
+    // Contains `<`, spaces — not base64; would otherwise decode to garbage.
+    expect(() => decodeContentBody("<script>not base64</script>", "base64")).toThrow(
+      ValidationError
+    );
+  });
+
+  it("throws on a wrong-length / non-canonical base64 string", () => {
+    // Length not a multiple of 4.
+    expect(() => decodeContentBody("YWJj YQ", "base64")).toThrow(ValidationError);
+    // All-padding degenerate input decodes to nothing.
+    expect(() => decodeContentBody("====", "base64")).toThrow(ValidationError);
+    // Empty / whitespace.
+    expect(() => decodeContentBody("   ", "base64")).toThrow(ValidationError);
+  });
+
+  it("enforces the decoded-size cap", () => {
+    const tooBig = b64("x".repeat(MAX_DECODED_BODY_BYTES + 1));
+    expect(() => decodeContentBody(tooBig, "base64")).toThrow(ValidationError);
+    // A body exactly at the cap is accepted.
+    const atCap = b64("x".repeat(MAX_DECODED_BODY_BYTES));
+    expect(decodeContentBody(atCap, "base64")).toHaveLength(MAX_DECODED_BODY_BYTES);
+  });
+});

--- a/tests/unit/atrium-code-encoding.test.ts
+++ b/tests/unit/atrium-code-encoding.test.ts
@@ -45,6 +45,13 @@ describe("decodeContentBody", () => {
     expect(() => decodeContentBody(undefined, "base64")).toThrow(ValidationError);
   });
 
+  it("rejects an unsupported encoding value that bypasses the schema (cast)", () => {
+    // A caller that slips a non-"base64" value past the zod enum via a cast must
+    // be rejected at the boundary, not silently decoded as base64.
+    const bad = "gzip" as unknown as Parameters<typeof decodeContentBody>[1];
+    expect(() => decodeContentBody("aGVsbG8=", bad)).toThrow(ValidationError);
+  });
+
   it("throws on a raw (non-base64) body that slipped past a mis-set flag", () => {
     // Contains `<`, spaces — not base64; would otherwise decode to garbage.
     expect(() => decodeContentBody("<script>not base64</script>", "base64")).toThrow(

--- a/tests/unit/atrium-content-code-encoding-routes.test.ts
+++ b/tests/unit/atrium-content-code-encoding-routes.test.ts
@@ -1,0 +1,197 @@
+/**
+ * `codeEncoding: "base64"` decode on the REST content-write routes
+ * (`POST /api/v1/content` create + `POST /api/v1/content/:id/versions`).
+ *
+ * These drive the real route handlers (withApiAuth unwrapped to the identity) and
+ * assert the transit contract:
+ *   - a base64 body is DECODED before `contentService.create` / `.createVersion`
+ *     is called — i.e. the service (and its §28.3 guardrails/PII screening, which
+ *     reads `input.body`) always sees the real, decoded content, never the wrapper,
+ *   - an invalid base64 body is a 400 (ValidationError → contentErrorToResponse)
+ *     and the service is NEVER called,
+ *   - an omitted `codeEncoding` passes the raw body straight through (back-compat).
+ *
+ * The decode helper itself (`decodeContentBody`) is NOT mocked here — the point is
+ * the route wiring — so its real validation runs.
+ */
+
+const mockCreate = jest.fn();
+const mockCreateVersion = jest.fn();
+const mockParseRequestBody = jest.fn();
+const mockResolveRestRequester = jest.fn();
+const mockContentErrorToResponse = jest.fn();
+const mockCreateApiResponse = jest.fn();
+const mockResolveCollectionId = jest.fn();
+
+jest.mock("@/lib/api", () => ({
+  withApiAuth: (handler: unknown) => handler,
+  requireScope: jest.fn(() => null),
+  createApiResponse: (...a: unknown[]) => mockCreateApiResponse(...a),
+  createErrorResponse: jest.fn(() => ({ __marker: "error" })),
+  parseRequestBody: (...a: unknown[]) => mockParseRequestBody(...a),
+}));
+
+jest.mock("@/lib/content", () => {
+  class MockApprovalRequiredError extends Error {}
+  return {
+    ApprovalRequiredError: MockApprovalRequiredError,
+    contentService: {
+      create: (...a: unknown[]) => mockCreate(...a),
+      createVersion: (...a: unknown[]) => mockCreateVersion(...a),
+    },
+    versionService: { list: jest.fn() },
+    hasPublishPublicScope: jest.fn(() => false),
+    recordContentAudit: jest.fn(),
+    requesterFromApiAuth: jest.fn(),
+  };
+});
+
+jest.mock("@/lib/content/rest", () => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { z } = require("zod") as typeof import("zod");
+  return {
+    contentErrorToResponse: (...a: unknown[]) => mockContentErrorToResponse(...a),
+    resolveRestRequester: (...a: unknown[]) => mockResolveRestRequester(...a),
+    restVisibilitySchema: z.object({
+      level: z.enum(["private", "group", "internal", "public"]),
+    }),
+  };
+});
+
+jest.mock("@/lib/content/surface-helpers", () => ({
+  assertContentAuthoringCapability: jest.fn(),
+  contentDeepLink: (slug: string) => `/c/${slug}`,
+  resolveCollectionId: (...a: unknown[]) => mockResolveCollectionId(...a),
+}));
+
+import type { NextRequest } from "next/server";
+import { POST as CREATE } from "@/app/api/v1/content/route";
+import { POST as CREATE_VERSION } from "@/app/api/v1/content/[id]/versions/route";
+import { ValidationError } from "@/lib/content/errors";
+
+const REQ = { kind: "user", userId: 7, roles: ["staff"], isAdmin: false };
+const AUTH = { scopes: ["content:create", "content:update"], cognitoSub: "sub-7" };
+const b64 = (s: string) => Buffer.from(s, "utf8").toString("base64");
+
+type CreateHandler = (
+  request: NextRequest,
+  auth: typeof AUTH,
+  requestId: string
+) => Promise<unknown>;
+type VersionHandler = (
+  request: NextRequest,
+  auth: typeof AUTH,
+  requestId: string,
+  params: { id: string }
+) => Promise<unknown>;
+
+const createHandler = CREATE as unknown as CreateHandler;
+const versionHandler = CREATE_VERSION as unknown as VersionHandler;
+
+const request = { url: "https://app.test/api/v1/content" } as unknown as NextRequest;
+
+const ARTIFACT_CODE =
+  '<html><style>b{color:red}</style><script>alert("x")</script></html>';
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockResolveRestRequester.mockResolvedValue({ req: REQ });
+  mockResolveCollectionId.mockResolvedValue(undefined);
+  mockCreate.mockResolvedValue({ id: "obj-1", slug: "art", visibilityLevel: "private" });
+  mockCreateVersion.mockResolvedValue({ id: "obj-1", slug: "art", version: { id: "v2" } });
+  mockContentErrorToResponse.mockReturnValue({ __marker: "content-error" });
+  mockCreateApiResponse.mockReturnValue({ __marker: "ok" });
+});
+
+describe("POST /api/v1/content — codeEncoding decode", () => {
+  it("decodes a base64 artifact body before contentService.create (screening sees decoded content)", async () => {
+    mockParseRequestBody.mockResolvedValue({
+      data: {
+        kind: "artifact",
+        title: "Chart",
+        body: b64(ARTIFACT_CODE),
+        bodyFormat: "html",
+        codeEncoding: "base64",
+      },
+    });
+
+    await createHandler(request, AUTH, "req-1");
+
+    expect(mockCreate).toHaveBeenCalledTimes(1);
+    // The service (which runs §28.3 screening on input.body) receives the DECODED
+    // artifact code, never the base64 wrapper.
+    expect(mockCreate).toHaveBeenCalledWith(
+      REQ,
+      expect.objectContaining({ body: ARTIFACT_CODE }),
+      expect.anything()
+    );
+  });
+
+  it("passes a raw body straight through when codeEncoding is omitted", async () => {
+    mockParseRequestBody.mockResolvedValue({
+      data: { kind: "document", title: "Doc", body: "# hello", bodyFormat: "markdown" },
+    });
+
+    await createHandler(request, AUTH, "req-2");
+
+    expect(mockCreate).toHaveBeenCalledWith(
+      REQ,
+      expect.objectContaining({ body: "# hello" }),
+      expect.anything()
+    );
+  });
+
+  it("rejects an invalid base64 body with a 400 and never calls the service", async () => {
+    mockParseRequestBody.mockResolvedValue({
+      data: {
+        kind: "artifact",
+        title: "Bad",
+        body: "<script>not base64</script>",
+        bodyFormat: "html",
+        codeEncoding: "base64",
+      },
+    });
+
+    const result = await createHandler(request, AUTH, "req-3");
+
+    expect(mockCreate).not.toHaveBeenCalled();
+    // ValidationError's constructor hardcodes status 400 → contentErrorToResponse
+    // maps it to a 400 envelope.
+    expect(mockContentErrorToResponse).toHaveBeenCalledWith(
+      expect.any(ValidationError),
+      expect.anything()
+    );
+    expect(result).toEqual({ __marker: "content-error" });
+  });
+});
+
+describe("POST /api/v1/content/:id/versions — codeEncoding decode", () => {
+  it("decodes a base64 body before contentService.createVersion", async () => {
+    mockParseRequestBody.mockResolvedValue({
+      data: { body: b64(ARTIFACT_CODE), bodyFormat: "html", codeEncoding: "base64" },
+    });
+
+    await versionHandler(request, AUTH, "req-4", { id: "obj-1" });
+
+    expect(mockCreateVersion).toHaveBeenCalledTimes(1);
+    expect(mockCreateVersion).toHaveBeenCalledWith(
+      REQ,
+      "obj-1",
+      expect.objectContaining({ body: ARTIFACT_CODE })
+    );
+  });
+
+  it("rejects invalid base64 with a 400 and never calls the service", async () => {
+    mockParseRequestBody.mockResolvedValue({
+      data: { body: "!!!not-base64!!!", bodyFormat: "html", codeEncoding: "base64" },
+    });
+
+    await versionHandler(request, AUTH, "req-5", { id: "obj-1" });
+
+    expect(mockCreateVersion).not.toHaveBeenCalled();
+    expect(mockContentErrorToResponse).toHaveBeenCalledWith(
+      expect.any(ValidationError),
+      expect.anything()
+    );
+  });
+});

--- a/tests/unit/atrium-mcp-content-tools.test.ts
+++ b/tests/unit/atrium-mcp-content-tools.test.ts
@@ -108,4 +108,16 @@ describe("Atrium MCP content tools registry", () => {
     // Optional: `query` must not be in required.
     expect(tool?.inputSchema.required ?? []).not.toContain("query");
   });
+
+  it("the body-carrying create/version tools expose an optional codeEncoding: base64", () => {
+    // WAF-opaque transit: an artifact whose code contains <script>/<style> must be
+    // sendable base64-encoded so the edge WAF's CrossSiteScripting_BODY rule can't
+    // match it. Every tool that carries a body offers the flag; it stays optional
+    // (a bodyless / plain-text call omits it).
+    for (const name of ["create_document", "create_artifact", "create_version"]) {
+      const tool = CONTENT_MCP_TOOLS.find((t) => t.name === name);
+      expect(tool?.inputSchema.properties.codeEncoding?.enum).toEqual(["base64"]);
+      expect(tool?.inputSchema.required ?? []).not.toContain("codeEncoding");
+    }
+  });
 });


### PR DESCRIPTION
## Summary

Atrium artifacts are self-contained HTML/JS/CSS, so their code legitimately
contains `<script>`, `<style>`, and inline `style="…"`. The ALB WAF's managed
`AWSManagedRulesCommonRuleSet` → **`CrossSiteScripting_BODY`** rule inspects every
request body and **blocks** that markup with a bare `403` (the request never reaches
the app, so no app error is produced). The deployed `psd-atrium` agent hit this on
`POST /api/v1/content` and worked around it with legacy table attributes; a **human**
saving a `<script>`-bearing artifact in the browser hits the identical block on the
`createVersion` server-action POST — a latent production bug in the core artifact
feature, not just a skill problem.

This makes artifact code **opaque in transit** (optional base64 `codeEncoding`) so
the WAF stays **fully intact** for the entire app, while JS/CSS artifacts work
everywhere.

## Root cause (evidence)

Confirmed from **live WAF sampled requests** on the dev WebACL (WAF logging is not
configured, so this came from `aws wafv2 get-sampled-requests`):

```
URI /api/v1/content  POST  →  Action: BLOCK
RuleNameWithinRuleGroup: AWS#AWSManagedRulesCommonRuleSet#CrossSiteScripting_BODY
```

The rule is **not excluded** (only `SizeRestrictions_BODY` + `GenericRFI_BODY` are)
and **not path-scoped** — it fires on any write body carrying that markup. The
in-app browser artifact-save path (`ArtifactCanvas` → `createVersionAction`, same
ALB) is affected too (browser artifact *create* is title-only, so only the
version/edit path carries code).

## Changes

**Fix — keep the WAF fully intact via base64 opaque transit (no WAF change):**

- **`lib/content/code-encoding.ts`** (new) — `decodeContentBody()`, the single
  decode point. Strictly validates canonical base64 (rejects raw/garbage with a
  400 rather than silently decoding), enforces a 5,000,000-byte decoded-size cap
  (aligned with the existing OKF per-file content bound; base64 cannot amplify so
  this is a defense-in-depth sanity bound), and passes an undefined encoding
  through unchanged (the raw contract is byte-for-byte preserved).
- **REST** `POST /api/v1/content` + `POST /api/v1/content/{id}/versions` — add
  optional `codeEncoding:"base64"`; decode at the boundary **before**
  `contentService` runs §28.3 screening + size caps, so screening always sees the
  real, decoded content.
- **MCP** `create_document` / `create_artifact` / `create_version` — same optional
  `codeEncoding` so the MCP agent surface matches REST.
- **Browser** `createVersionAction` + `ArtifactCanvas` — the artifact editor
  base64-encodes the code (UTF-8-safe, chunked) and the server action decodes it,
  closing the human-save path with the WAF intact.
- **`psd-atrium` skill** — always base64-encodes every write body (create-document
  / create-artifact / edit) and sets `codeEncoding:"base64"`; new **`archive`**
  subcommand (`status:"archived"` via the existing PATCH); SKILL.md + frontmatter
  description now state plainly that JS/CSS artifact code is fully supported and
  auto-encoded (correcting the agent's WAF-workaround memory).
- **Docs** — `docs/API/v1/openapi.yaml` + `docs/API/v1/context-graph.md` document
  the new `codeEncoding` field, the size cap, the 400-on-invalid behavior, and the
  sandbox security model.

**Why no WAF scope-down:** base64 covers every write path (agent REST, MCP, human
browser), so the WAF's `CrossSiteScripting_BODY` body inspection stays fully active
for the whole app — strictly more secure than carving a per-path hole in XSS
inspection, and locally verifiable. Artifact code is data, rendered exclusively in
the cross-origin `allow-scripts`-only sandbox (§28.1), never on the app origin.

## Verification (all green before opening)

- **Typecheck:** 0 new errors (33 pre-existing `.next/types` errors unchanged).
- **Lint:** clean on all changed source files.
- **Unit (jest):** `atrium-code-encoding` (valid/invalid/non-canonical/oversized/
  pass-through/WAF-opacity), `atrium-content-code-encoding-routes` (routes decode
  **before** the service so screening sees decoded content; invalid base64 → 400),
  `atrium-mcp-content-tools` (schema parity). Full affected atrium suite: 137 passed.
- **Skill (bun):** 47 tests — encode round-trip + WAF-opacity, `archive`, no-op on
  bodyless create.
- **Functional E2E (authed, host :3100):** a `<script>/<style>` artifact created
  with `codeEncoding:"base64"` returns `version.bodyInline` equal to the **decoded**
  code (create response AND follow-up GET) — the server decodes before storing;
  invalid base64 → 400. Local has no WAF, so this proves the API contract; the
  WAF-layer block is only provable post-deploy.
- **Full authed Atrium E2E on :3100:** 59 passed, 2 skipped (both gated on
  `ATRIUM_SANDBOX_ORIGIN`, unset locally). Pre-push full app suite: 209 passed, 49
  skipped, 2 flaky (passed on retry; unrelated timing flakes).

## Evidence

N/A — no UI surface. This is an API/transit-contract change; the artifact rendering
surface is unchanged, and the cross-origin sandbox render is gated on
`ATRIUM_SANDBOX_ORIGIN` (unset locally). End-to-end proof is the functional E2E
above (base64 `<script>` artifact round-trips as decoded code).

## Deploy-gated / follow-ups

- **Frontend image + deploy** required for the fix to take effect in dev/prod
  (app code + WAF-opaque behavior). No CDK/infra change. No DB migration.
- **Agent image rebuild** (`infra/agent-image/build-and-push.sh`) required for the
  `psd-atrium` skill changes to reach the deployed agent.
- **Dev test-artifact cleanup:** a small set of throwaway dev artifacts can be
  archived with the new `archive` subcommand (or `PATCH {status:"archived"}`);
  handled out-of-band (details in the session notes).

https://claude.ai/code/session_01WsTsgEPEP39VJExUXaY9sz
