### PR TITLE
feat(atrium): hard delete for content objects (owner/admin, unpublish-first)

### DIFF
--- a/actions/db/atrium/delete-content.ts
+++ b/actions/db/atrium/delete-content.ts
@@ -1,0 +1,82 @@
+"use server"
+
+/**
+ * Atrium delete-content server action (Atrium hard delete)
+ *
+ * The in-app (logged-in human) surface for PERMANENTLY deleting a content
+ * object — the Meridian "Delete" affordance in the editor's content-settings
+ * dialog. A thin wrapper over `contentService.delete`, which owns the guards:
+ * existence-masking (404 before 403), the owner/admin `assertCanDelete` gate, and
+ * the live-publication refusal (409 — delete never auto-unpublishes). It also
+ * writes the transactional `delete` audit row and cleans up the cascade + S3.
+ *
+ * Gate ordering mirrors `update-content.ts`: requester FIRST (an unauthenticated
+ * caller gets 401 "please log in", not 403), then the `atrium-content`
+ * feature-capability gate, then the service. `surface: "ui"` tags the audit row
+ * as an in-app human action.
+ *
+ * See docs/features/atrium-design-spec.md §11.2.
+ */
+
+import {
+  createLogger,
+  generateRequestId,
+  startTimer,
+  sanitizeForLogging,
+} from "@/lib/logger";
+import { createSuccess, handleError, ErrorFactories } from "@/lib/error-utils";
+import { contentService } from "@/lib/content";
+import type { DeletedContentSummary } from "@/lib/content";
+import type { ActionState } from "@/types";
+import { hasCapabilityAccess } from "@/utils/roles";
+import { getServerSession } from "@/lib/auth/server-session";
+import { getUserRequester } from "./requester";
+
+export async function deleteContentAction(
+  // Accepts a UUID OR a slug — `contentService.delete` resolves via
+  // `loadByIdOrSlug`, matching the other slug-tolerant actions.
+  idOrSlug: string
+): Promise<ActionState<DeletedContentSummary>> {
+  const requestId = generateRequestId();
+  const timer = startTimer("deleteContentAction");
+  const log = createLogger({ requestId, action: "deleteContentAction" });
+
+  try {
+    log.info("Action started: delete content", {
+      idOrSlug: sanitizeForLogging(idOrSlug),
+    });
+
+    if (!idOrSlug) {
+      throw ErrorFactories.missingRequiredField("idOrSlug");
+    }
+
+    // Session resolved ONCE, threaded through the requester build + capability
+    // check (see update-content.ts for the same-session rationale). Requester
+    // FIRST so an unauthenticated caller gets a 401, not a 403.
+    const session = await getServerSession();
+    const requester = await getUserRequester(requestId, session);
+    if (!(await hasCapabilityAccess("atrium-content", session!.sub))) {
+      throw ErrorFactories.authzToolAccessDenied("atrium-content");
+    }
+
+    // The service enforces existence-masking (404 before 403), the owner/admin
+    // delete gate, and the live-publication refusal (409). `ui` = in-app human.
+    const result = await contentService.delete(requester, idOrSlug, {
+      surface: "ui",
+    });
+
+    timer({ status: "success" });
+    log.info("Content deleted", {
+      objectId: result.id,
+      versionsDeleted: result.versionsDeleted,
+    });
+    return createSuccess(result, "Content deleted");
+  } catch (error) {
+    timer({ status: "error" });
+    return handleError(error, "Failed to delete content", {
+      context: "deleteContentAction",
+      requestId,
+      operation: "deleteContentAction",
+    });
+  }
+}

--- a/app/api/v1/content/[id]/route.ts
+++ b/app/api/v1/content/[id]/route.ts
@@ -1,7 +1,8 @@
 /**
  * Atrium Content Item Endpoint (Issue #1055, Phase 5 §23)
- * GET   /api/v1/content/:id — object + current version (permission-checked)
- * PATCH /api/v1/content/:id — update metadata (title, tags, collection, status)
+ * GET    /api/v1/content/:id — object + current version (permission-checked)
+ * PATCH  /api/v1/content/:id — update metadata (title, tags, collection, status)
+ * DELETE /api/v1/content/:id — hard-delete the object (owner/admin, no live pub)
  *
  * Mirrors the MCP get_content + update_content tools.
  */
@@ -117,6 +118,51 @@ export const PATCH = withApiAuth(async (request: NextRequest, auth, requestId, p
     void recordContentAudit({
       req,
       action: "update",
+      surface: "rest",
+      objectId: id,
+      outcome: "error",
+      error: err instanceof Error ? err.message : String(err),
+      requestId,
+    });
+    return contentErrorToResponse(err, requestId);
+  }
+});
+
+// ============================================
+// DELETE — hard-delete the object
+// ============================================
+
+export const DELETE = withApiAuth(async (request: NextRequest, auth, requestId, params) => {
+  const scopeError = requireScope(auth, "content:delete", requestId);
+  if (scopeError) return scopeError;
+
+  const log = createLogger({ requestId, route: "api.v1.content.delete" });
+
+  const id = params.id;
+  if (!id) {
+    return createErrorResponse(requestId, 400, "VALIDATION_ERROR", "Missing content id");
+  }
+
+  const resolved = await resolveRestRequester(auth, requestId);
+  if ("response" in resolved) return resolved.response;
+  const { req } = resolved;
+
+  try {
+    // Session humans must also hold the atrium-content capability (see helper).
+    await assertContentAuthoringCapability(auth);
+    // The service writes the transactional SUCCESS audit (with title/kind/owner
+    // details) inside the delete tx, so we deliberately do NOT recordContentAudit
+    // on success here — only on the error path below, matching PATCH.
+    const deleted = await contentService.delete(req, id, { surface: "rest" });
+    log.info("Deleted content via REST", {
+      objectId: deleted.id,
+      versionsDeleted: deleted.versionsDeleted,
+    });
+    return createApiResponse({ data: deleted, meta: { requestId } }, requestId);
+  } catch (err) {
+    void recordContentAudit({
+      req,
+      action: "delete",
       surface: "rest",
       objectId: id,
       outcome: "error",

--- a/components/atrium/ContentSettings.tsx
+++ b/components/atrium/ContentSettings.tsx
@@ -6,9 +6,12 @@
  *
  * The metadata surface `contentService.update` has had since Phase 0 but the UI
  * could not reach: rename the title, edit tags, move the object to another
- * collection, and archive/restore. Persists via `updateContentAction` (which
- * runs the capability gate + the service's canView/assertCanEdit gates
- * server-side), so this component is presentation only.
+ * collection, and archive/restore — plus a permanent hard DELETE (via
+ * `deleteContentAction`). Persists via `updateContentAction` / `deleteContentAction`
+ * (which run the capability gate + the service's canView/assertCanEdit/assertCanDelete
+ * gates server-side), so this component is presentation only. Delete is disabled
+ * for a published object (unpublish/archive first); the server refuses it
+ * authoritatively with a 409 regardless.
  *
  * The collection options come from `collectionTreeAction` — the SAME
  * visibility-filtered source the LibraryView sidebar uses — flattened with a
@@ -42,6 +45,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { updateContentAction } from "@/actions/db/atrium/update-content";
+import { deleteContentAction } from "@/actions/db/atrium/delete-content";
 import { collectionTreeAction } from "@/actions/db/atrium/collection-tree";
 import { meridianPortalClassName } from "@/lib/atrium/meridian-fonts";
 import type { CollectionTreeNode } from "@/lib/content";
@@ -118,6 +122,99 @@ async function runUpdate(
   } finally {
     setSaving(false);
   }
+}
+
+/**
+ * Confirm + run a permanent hard delete, then navigate. Module-level with the
+ * component's setters threaded in (mirrors `runUpdate`) so the component body stays
+ * under the max-lines-per-function lint. The `window.confirm` states permanence;
+ * on success the object is gone from every list and its routes 404, so we navigate
+ * back to the library. The server re-checks owner/admin and refuses (409) a still-
+ * published object regardless of the client-side disabled hint.
+ */
+async function runDelete(
+  objectId: string,
+  ctx: {
+    router: ReturnType<typeof useRouter>;
+    setDeleting: (v: boolean) => void;
+    setError: (v: string | null) => void;
+    setOpen: (v: boolean) => void;
+  }
+): Promise<void> {
+  const { router, setDeleting, setError, setOpen } = ctx;
+  if (
+    typeof window !== "undefined" &&
+    !window.confirm(
+      "Permanently delete this content? This removes it and ALL of its versions, " +
+        "comments, and history for everyone, and CANNOT be undone. To keep it " +
+        "recoverable instead, use Archive."
+    )
+  ) {
+    return;
+  }
+  setDeleting(true);
+  setError(null);
+  try {
+    const res = await deleteContentAction(objectId);
+    if (res.isSuccess) {
+      setOpen(false);
+      router.push("/atrium");
+    } else {
+      setError(res.message ?? "Could not delete this content");
+      log.warn("deleteContentAction failed", { message: res.message });
+    }
+  } catch (e) {
+    setError("Could not delete this content — please try again.");
+    log.error("deleteContentAction threw", {
+      error: e instanceof Error ? e.message : String(e),
+    });
+  } finally {
+    setDeleting(false);
+  }
+}
+
+/**
+ * The "Danger zone" hard-delete row. Extracted from ContentSettings so its body
+ * stays under the max-lines-per-function lint (mirrors SettingsFields). Delete is
+ * disabled while a publication is live (a published object must be
+ * unpublished/archived first); the server enforces the same refusal authoritatively.
+ */
+function DangerZone({
+  status,
+  deleting,
+  busy,
+  onDelete,
+}: {
+  status: "draft" | "published" | "archived";
+  deleting: boolean;
+  busy: boolean;
+  onDelete: () => void;
+}): React.JSX.Element {
+  return (
+    <div className="space-y-1.5 border-t border-border/60 pt-3">
+      <div className="flex items-center gap-2">
+        <Button
+          type="button"
+          size="sm"
+          variant="ghost"
+          disabled={busy || status === "published"}
+          onClick={onDelete}
+          className="text-destructive hover:text-destructive"
+        >
+          {deleting ? "Deleting…" : "Delete permanently"}
+        </Button>
+        {status === "published" && (
+          <span className="text-xs text-muted-foreground">
+            Unpublish or archive it before deleting.
+          </span>
+        )}
+      </div>
+      <p className="text-xs text-muted-foreground">
+        Permanently removes this content and all of its versions and history. This
+        cannot be undone — use Archive to keep it recoverable.
+      </p>
+    </div>
+  );
 }
 
 /** Parse the comma-separated tags input into trimmed, deduped tags. */
@@ -263,6 +360,7 @@ export function ContentSettings({
     collectionId ?? NO_COLLECTION
   );
   const [saving, setSaving] = useState(false);
+  const [deleting, setDeleting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   const [options, setOptions] = useState<CollectionOption[]>([]);
@@ -347,6 +445,17 @@ export function ContentSettings({
     [objectId, router]
   );
 
+  // Hard delete (permanent). Confirms permanence, then navigates back to the
+  // library on success (the object is gone from every list and its routes 404).
+  // Extracted to the module-level `runDelete` to keep this component under the
+  // max-lines-per-function lint.
+  const deleteContent = useCallback(
+    () => runDelete(objectId, { router, setDeleting, setError, setOpen }),
+    [objectId, router]
+  );
+
+  const busy = saving || deleting;
+
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogTrigger asChild>
@@ -363,8 +472,8 @@ export function ContentSettings({
         <DialogHeader>
           <DialogTitle>Content settings</DialogTitle>
           <DialogDescription>
-            Rename, tag, move, or archive this content. Body changes are made in
-            the editor.
+            Rename, tag, move, archive, or permanently delete this content. Body
+            changes are made in the editor.
           </DialogDescription>
         </DialogHeader>
 
@@ -378,8 +487,16 @@ export function ContentSettings({
             onCollection={setDraftCollection}
             options={options}
             status={status}
-            saving={saving}
+            saving={busy}
             onStatus={(next) => void setStatus(next)}
+          />
+
+          {/* Danger zone — permanent hard delete (extracted sub-component). */}
+          <DangerZone
+            status={status}
+            deleting={deleting}
+            busy={busy}
+            onDelete={() => void deleteContent()}
           />
 
           {error && <p className="text-sm text-destructive">{error}</p>}
@@ -390,11 +507,11 @@ export function ContentSettings({
             type="button"
             variant="ghost"
             onClick={() => handleOpenChange(false)}
-            disabled={saving}
+            disabled={busy}
           >
             Cancel
           </Button>
-          <Button type="button" onClick={() => void save()} disabled={saving}>
+          <Button type="button" onClick={() => void save()} disabled={busy}>
             {saving ? "Saving…" : "Save"}
           </Button>
         </DialogFooter>

--- a/docs/API/v1/context-graph.md
+++ b/docs/API/v1/context-graph.md
@@ -670,6 +670,7 @@ session-cookie path for these endpoints. Every response carries `X-Request-Id` a
 | `content:read` | List content, get an object, list versions |
 | `content:create` | Create content objects (and their initial version) |
 | `content:update` | Update metadata, create versions, set visibility |
+| `content:delete` | Hard-delete a content object (owner/admin only — service-gated) |
 | `content:publish_internal` | Publish to / unpublish from a destination |
 | `content:publish_public` | Publish to a public-facing destination without approval |
 | `content:delegate` | Mint short-lived delegated tokens (`POST /api/v1/agents/delegated-token`) — agent-held authority, never present in a minted token |
@@ -908,6 +909,48 @@ curl -X PATCH -H "Authorization: Bearer sk-your-key" \
 
 **Response `200`** — returns the updated object metadata (no `version`/`url`).
 **Response `404`** — `CONTENT_NOT_FOUND`.
+
+#### `DELETE /api/v1/content/{id}`
+
+**Hard-delete** a content object — permanently removes it and every dependent row
+(all versions, publications, live-collab state, comments, embed links, visibility
+grants, publish-approval requests, retrieval-index entry) plus its S3 bodies.
+Irreversible — prefer `PATCH { "status": "archived" }` for reversible cleanup.
+Requires `content:delete`.
+
+Guards (in order — an unviewable object never reveals its existence):
+
+- `404 CONTENT_NOT_FOUND` — the object does not exist, or the caller may not view it.
+- `403 CONTENT_FORBIDDEN` — viewable but the caller is not the OWNER (nor an admin).
+  A `content:delete` key can only delete content its owner owns.
+- `409 CONTENT_CONFLICT` — the object is still **live** at a publish destination.
+  Delete never auto-unpublishes; unpublish from every destination first, then delete.
+
+Any other kind/status (draft, archived, private, internal) is deletable — the guards
+above are the protection, not the lifecycle status. A `delete` row is appended to the
+content audit trail (capturing the removed title/kind/owner) before the row vanishes.
+
+**Example request:**
+
+```bash
+curl -X DELETE -H "Authorization: Bearer sk-your-key" \
+  "https://your-domain/api/v1/content/a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+```
+
+**Response `200`:**
+
+```json
+{
+  "data": {
+    "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+    "slug": "field-trip-form",
+    "title": "Field Trip Form",
+    "kind": "document",
+    "versionsDeleted": 3
+  },
+  "meta": { "requestId": "req_..." }
+}
+```
 
 ---
 

--- a/docs/API/v1/generated/capability-catalog.json
+++ b/docs/API/v1/generated/capability-catalog.json
@@ -2,7 +2,7 @@
   "summary": {
     "actions": 24,
     "features": 8,
-    "scopes": 24,
+    "scopes": 25,
     "agentInvocableActions": 17
   },
   "actions": [
@@ -650,6 +650,14 @@
       "scope": "content:delegate",
       "description": "Mint delegated Atrium content tokens on behalf of a user",
       "roles": [
+        "administrator"
+      ]
+    },
+    {
+      "scope": "content:delete",
+      "description": "Delete Atrium content objects (owner/admin only)",
+      "roles": [
+        "staff",
         "administrator"
       ]
     },

--- a/docs/API/v1/openapi.yaml
+++ b/docs/API/v1/openapi.yaml
@@ -20,10 +20,12 @@ info:
 
     Atrium content endpoints (`/api/v1/content/*`, `/api/v1/agents/delegated-token`)
     are **Bearer-only** (no session cookie) and gated by the content scopes:
-    `content:read`, `content:create`, `content:update`, `content:publish_internal`,
-    `content:publish_public`, and the agent-held minting authority
-    `content:delegate` (required by `POST /api/v1/agents/delegated-token`; never
-    present in a minted delegated token).
+    `content:read`, `content:create`, `content:update`, `content:delete`,
+    `content:publish_internal`, `content:publish_public`, and the agent-held minting
+    authority `content:delegate` (required by `POST /api/v1/agents/delegated-token`;
+    never present in a minted delegated token). `content:delete` is granted to staff
+    and administrator; the service still gates every delete to the object's OWNER or
+    an admin, so a key holding it can only remove content its owner owns.
 
     ## Rate Limiting
 
@@ -1340,6 +1342,85 @@ paths:
           $ref: "#/components/responses/Forbidden"
         "404":
           $ref: "#/components/responses/NotFound"
+        "429":
+          $ref: "#/components/responses/RateLimited"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+    delete:
+      operationId: deleteContent
+      tags: [Content]
+      summary: Delete a content object (hard delete)
+      description: |
+        PERMANENTLY deletes a content object and every dependent row (all versions,
+        publications, live-collab state, comments, embed links, visibility grants,
+        publish-approval requests, and its retrieval-index entry) plus its S3 bodies.
+        This is irreversible — prefer `PATCH` to `status: "archived"` for reversible
+        cleanup.
+
+        Guards, in order (an unviewable object never reveals its existence):
+        objects the caller may not view return `404` (not `403`); a viewable object
+        the caller does not OWN (and is not an admin) returns `403`; and an object
+        that is still LIVE at any publish destination returns `409` — delete never
+        auto-unpublishes, so the caller must unpublish everywhere first.
+
+        Requires `content:delete`. The service additionally enforces owner/admin, so
+        a key holding the scope can only delete content its owner owns. A `delete`
+        row is written to the append-only content audit trail (capturing the removed
+        object's title/kind/owner) before the object row disappears.
+      security:
+        - BearerAuth: []
+      responses:
+        "200":
+          description: The object was deleted; returns a summary of what was removed.
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [data, meta]
+                properties:
+                  data:
+                    type: object
+                    required: [id, slug, title, kind, versionsDeleted]
+                    properties:
+                      id:
+                        type: string
+                        format: uuid
+                      slug:
+                        type: string
+                      title:
+                        type: string
+                      kind:
+                        type: string
+                        enum: [document, artifact]
+                      versionsDeleted:
+                        type: integer
+                        description: Immutable version rows removed with the object.
+                  meta:
+                    type: object
+                    required: [requestId]
+                    properties:
+                      requestId:
+                        type: string
+          headers:
+            X-Request-Id:
+              $ref: "#/components/headers/X-Request-Id"
+            X-RateLimit-Limit:
+              $ref: "#/components/headers/X-RateLimit-Limit"
+            X-RateLimit-Remaining:
+              $ref: "#/components/headers/X-RateLimit-Remaining"
+            X-RateLimit-Reset:
+              $ref: "#/components/headers/X-RateLimit-Reset"
+        "400":
+          $ref: "#/components/responses/ValidationError"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          $ref: "#/components/responses/ContentConflict"
         "429":
           $ref: "#/components/responses/RateLimited"
         "500":

--- a/infra/agent-image/skills/psd-atrium/SKILL.md
+++ b/infra/agent-image/skills/psd-atrium/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: psd-atrium
-summary: Read and write AI Studio Atrium content — PSD's collaborative document + live-artifact workspace with an intranet publishing flow. Find/read/create/edit/archive documents and artifacts and publish them, version-based, over /api/v1/content. Artifacts fully support HTML/CSS/JavaScript (including <script>/<style>).
-description: Use this to work with Atrium, PSD's collaborative content workspace in AI Studio (documents + interactive artifacts, with an internal "intranet" publishing flow). Find and read Atrium documents/artifacts, create new ones, edit them (append or replace), archive them, and publish/unpublish to a destination. Interactive artifacts fully support real HTML, CSS, and JavaScript — including <script>, <style>, and inline style="…" — pass raw code; the skill base64-encodes it automatically so nothing is stripped or blocked (do NOT work around with legacy attributes like bgcolor/width). Atrium is REAL and live — never say the district has no content workspace. Version-based: reads return the last saved version and edits create a new version; the real-time collaborative editor rail is not reachable from here.
+summary: Read and write AI Studio Atrium content — PSD's collaborative document + live-artifact workspace with an intranet publishing flow. Find/read/create/edit/archive/delete documents and artifacts and publish them, version-based, over /api/v1/content. Artifacts fully support HTML/CSS/JavaScript (including <script>/<style>).
+description: Use this to work with Atrium, PSD's collaborative content workspace in AI Studio (documents + interactive artifacts, with an internal "intranet" publishing flow). Find and read Atrium documents/artifacts, create new ones, edit them (append or replace), archive them, hard-delete ones you own, and publish/unpublish to a destination. Interactive artifacts fully support real HTML, CSS, and JavaScript — including <script>, <style>, and inline style="…" — pass raw code; the skill base64-encodes it automatically so nothing is stripped or blocked (do NOT work around with legacy attributes like bgcolor/width). Atrium is REAL and live — never say the district has no content workspace. Version-based: reads return the last saved version and edits create a new version; the real-time collaborative editor rail is not reachable from here.
 allowed-tools: Bash(node:*)
 ---
 
@@ -111,17 +111,39 @@ body is returned inline (small content). For a large (externally stored) body, u
 `--mode replace` with the full text. Optional: `--body-format markdown|html|jsx`,
 `--summary <change note>`.
 
-### Archive (soft-remove — Phase 1 has no hard delete)
+### Archive (soft-remove — reversible)
 
 ```bash
 node run.js archive --id <id>
 ```
 
 Flips the object's status to `archived` (via the metadata PATCH; needs
-`content:update`, which the content key holds). Use it to clean up throwaway or
-superseded content you created — Atrium deliberately has no hard delete in Phase 1.
-Archiving also takes any live publication offline. An archived object still shows
-up under `find --status archived`.
+`content:update`, which the content key holds). Reversible, and the object still
+shows up under `find --status archived`. Archiving also takes any live publication
+offline. Prefer archive when you might want the content back; use `delete` (below)
+only when it should be gone for good.
+
+### Delete (HARD, permanent)
+
+```bash
+node run.js delete --id <id>
+```
+
+Permanently removes the object and **every** version, body, comment, and index
+entry. There is **no undo** — after this, `find`/`read` no longer return it and the
+reader/editor URLs 404. Needs `content:delete` (which the content key holds).
+
+Two guardrails the server enforces — relay either refusal verbatim:
+
+- **Owner-only.** You delete as the content key's owner, so you can only delete
+  content that owner owns. Deleting someone else's object returns a `403` error
+  (the object's existence is masked as `404` if you couldn't view it at all).
+- **Unpublish first.** A published object is refused with a clear `409` message
+  ("unpublish from … first"); delete NEVER auto-unpublishes. Run
+  `unpublish --id <id> --destination <d>` for each live destination, then `delete`.
+
+Use `archive` for reversible cleanup and `delete` only for permanent removal of
+throwaway/superseded content you own.
 
 ### Publish / unpublish (honor the approval gate)
 

--- a/infra/agent-image/skills/psd-atrium/run.js
+++ b/infra/agent-image/skills/psd-atrium/run.js
@@ -23,6 +23,7 @@
  *   node run.js edit --id <id> --body <text> [--mode replace|append]
  *                    [--body-format markdown|html|jsx] [--summary <s>]
  *   node run.js archive --id <id>
+ *   node run.js delete --id <id>
  *   node run.js set-visibility --id <id> --level private|group|internal|public
  *                    [--grants role:staff,building:GHS]
  *
@@ -80,7 +81,9 @@ function usage() {
       '                  [--visibility <level>] [--grants k:v,...]',
       '  edit --id <id> --body <text> [--mode replace|append]',
       '       [--body-format markdown|html|jsx] [--summary <s>]',
-      '  archive --id <id>   (soft-remove; no hard delete in Phase 1)',
+      '  archive --id <id>   (soft-remove: status -> archived, stays findable)',
+      '  delete  --id <id>   (HARD delete: permanent; owner/admin only; refused',
+      '                       while published — unpublish everywhere first)',
       '  set-visibility --id <id> --level private|group|internal|public',
       '                 [--grants role:staff,building:GHS]',
       '',
@@ -302,14 +305,27 @@ async function main() {
 
     case 'archive': {
       // Soft-remove: flip status to "archived" via the metadata PATCH (needs
-      // content:update, which the content key holds). Atrium Phase 1 has no hard
-      // delete by design, so this is how you clean up throwaway content you made.
-      // Archiving also takes any live publication offline (server-side).
+      // content:update, which the content key holds). Reversible and still findable
+      // under `find --status archived`. Archiving also takes any live publication
+      // offline (server-side). Use `delete` for permanent removal.
       const id = requireStr(args, 'id', 'id');
       const { payload } = await restFetch('PATCH', `/${encodeURIComponent(id)}`, {
         body: { status: 'archived' },
       });
       emit({ ...payload, archived: true });
+      return;
+    }
+
+    case 'delete': {
+      // HARD delete: permanently removes the object and every version/body. Needs
+      // content:delete (which the content key holds) AND you must OWN it (the key
+      // deletes as its owner) — a non-owner object comes back as an error you
+      // relay verbatim. Refused with a clear message while the object is published
+      // anywhere: delete NEVER auto-unpublishes — run `unpublish` first, then
+      // `delete`. Irreversible: there is no undo and `find` will no longer show it.
+      const id = requireStr(args, 'id', 'id');
+      const { payload } = await restFetch('DELETE', `/${encodeURIComponent(id)}`);
+      emit({ ...payload, deleted: true });
       return;
     }
 

--- a/infra/agent-image/skills/psd-atrium/run.test.js
+++ b/infra/agent-image/skills/psd-atrium/run.test.js
@@ -379,6 +379,39 @@ test('archive requires --id (exit 1)', async () => {
   expect(code).toBe(1);
 });
 
+test('delete DELETEs /<id> and flags deleted', async () => {
+  restResponder = () => ({
+    approvalRequired: false,
+    status: 200,
+    payload: { id: 'obj-1', slug: 'doc', title: 'Doc', kind: 'document', versionsDeleted: 2 },
+  });
+
+  await run('delete', '--id', 'obj-1');
+
+  expect(restCalls).toHaveLength(1);
+  expect(restCalls[0]).toMatchObject({ method: 'DELETE', path: '/obj-1' });
+  // No request body for a delete.
+  expect(restCalls[0].opts.body).toBeUndefined();
+  expect(emitted[0].deleted).toBe(true);
+  expect(emitted[0].title).toBe('Doc');
+  expect(emitted[0].versionsDeleted).toBe(2);
+});
+
+test('delete requires --id (exit 1)', async () => {
+  let code;
+  try {
+    await run('delete');
+  } catch (err) {
+    code = err.code;
+  }
+  expect(code).toBe(1);
+});
+
+test('delete url-encodes the id', async () => {
+  await run('delete', '--id', 'weird/id');
+  expect(restCalls[0].path).toBe('/weird%2Fid');
+});
+
 test('set-visibility PATCHes /<id>/visibility with level + grants', async () => {
   await run('set-visibility', '--id', 'obj-1', '--level', 'group', '--grants', 'role:staff');
   expect(restCalls[0]).toMatchObject({ method: 'PATCH', path: '/obj-1/visibility' });

--- a/infra/database/migrations.json
+++ b/infra/database/migrations.json
@@ -98,6 +98,7 @@
     "101-agent-workspace-canva.sql",
     "102-atrium-embed-links.sql",
     "103-atrium-content-cover-icon.sql",
-    "104-atrium-agent-service-user.sql"
+    "104-atrium-agent-service-user.sql",
+    "105-atrium-content-audit-details.sql"
   ]
 }

--- a/infra/database/schema/105-atrium-content-audit-details.sql
+++ b/infra/database/schema/105-atrium-content-audit-details.sql
@@ -1,0 +1,22 @@
+-- Migration 105: Atrium content-audit `details` column
+-- Part of "Atrium hard delete" (Epic #1059 follow-up). Adds a nullable JSONB
+-- `details` column to content_audit_logs so the append-only governance trail can
+-- capture STRUCTURED, action-specific context.
+--
+-- The immediate driver is hard delete: content_audit_logs.object_id has NO FK (by
+-- design — the trail must survive object deletion), but after a hard delete that
+-- object_id is a DANGLING UUID with no row to join for the title/kind/owner. The
+-- delete audit row therefore records the removed object's identity here
+-- (`{ title, kind, ownerUserId, versionsDeleted }`), captured inside the delete
+-- transaction BEFORE the object row disappears — the only durable record of WHAT
+-- was removed. Other actions may populate it later; today only `delete` writes it.
+--
+-- ADDITIVE, nullable, and idempotent (IF NOT EXISTS). No PL/pgSQL DO $$ blocks
+-- (the migration runner's statement splitter cannot handle dollar-quoted blocks —
+-- see 085/086/090/097/104). ALTER TABLE ... ADD COLUMN on content_audit_logs is
+-- fine under the master migration role: the table is created by migration 090
+-- (not one of the postgres-owned 001-005), so the 42501 privilege restriction that
+-- blocks ALTER on early objects does not apply here.
+
+ALTER TABLE content_audit_logs
+  ADD COLUMN IF NOT EXISTS details jsonb;

--- a/infra/lambdas/atrium-content-key-bootstrap/index.ts
+++ b/infra/lambdas/atrium-content-key-bootstrap/index.ts
@@ -106,6 +106,12 @@ export const KEY_SCOPES: readonly string[] = [
   'content:read',
   'content:create',
   'content:update',
+  // The agent may clean up its OWN junk: delete is owner/admin-gated in the
+  // service, so this key can only remove content the service user owns. Staying
+  // tethered to ROLE_SCOPES.staff's content:* subset (minus publish_public) keeps
+  // the drift-guard unit test green; the deployed key self-heals to this scope set
+  // on the next deploy via the scope-drift re-mint.
+  'content:delete',
   'content:publish_internal',
 ];
 

--- a/lib/api-keys/scopes.ts
+++ b/lib/api-keys/scopes.ts
@@ -45,6 +45,11 @@ export const API_SCOPES = {
   "content:read": "Read Atrium content objects and versions",
   "content:create": "Create Atrium content objects and initial versions",
   "content:update": "Update Atrium content object metadata and create new versions",
+  // Hard-delete an Atrium content object (owner/admin-gated in the service, so a
+  // key holding this can only remove content its OWNER owns). Separate from
+  // content:update so delete authority is granted deliberately, not as a
+  // side effect of edit access.
+  "content:delete": "Delete Atrium content objects (owner/admin only)",
   "content:publish_internal": "Publish Atrium content to internal destinations",
   "content:publish_public": "Publish Atrium content publicly",
   // Agent-held AUTHORITY scope (Atrium §26.1, #1059): permits an autonomous agent
@@ -89,6 +94,10 @@ export const ROLE_SCOPES: Record<string, ApiScope[]> = {
     "content:read",
     "content:create",
     "content:update",
+    // Staff may clean up (hard-delete) Atrium content — the service still gates
+    // every delete to the object's OWNER or an admin, so a staff key can only
+    // remove content that key's owner owns. "Agents do what people can."
+    "content:delete",
     "content:publish_internal",
   ],
   administrator: ALL_SCOPES,

--- a/lib/content/audit.ts
+++ b/lib/content/audit.ts
@@ -13,7 +13,7 @@
  */
 
 import { executeQuery } from "@/lib/db/drizzle-client";
-import { contentAuditLogs } from "@/lib/db/schema";
+import { contentAuditLogs, type ContentAuditDetails } from "@/lib/db/schema";
 import { createLogger } from "@/lib/logger";
 import { actorKindOf, agentIdOf, authorUserIdOf } from "./helpers";
 import type { PublishDestination } from "./publish-adapters/types";
@@ -26,12 +26,21 @@ export type ContentAuditAction =
   | "set_visibility"
   | "publish"
   | "unpublish"
+  // Hard delete (Epic #1059 follow-up). The object row disappears, so the delete
+  // audit carries the removed object's identity in `details` (see below).
+  | "delete"
   // OKF interoperability (Phase 8, #1103, §36.4). `export_okf` serializes a
   // collection to a portable bundle; `import_okf` writes a bundle into content.
   | "export_okf"
   | "import_okf";
 
-export type ContentAuditSurface = "mcp" | "rest";
+/**
+ * The surface the mutation arrived on. `ui` is a human acting through an in-app
+ * server action (e.g. the Meridian delete affordance); `mcp`/`rest` are the
+ * programmatic agent surfaces. The DB column is a plain varchar (not a pgEnum),
+ * so widening this union is a code-only change.
+ */
+export type ContentAuditSurface = "mcp" | "rest" | "ui";
 export type ContentAuditOutcome = "ok" | "error" | "approval_required";
 
 export interface ContentAuditEntry {
@@ -46,7 +55,39 @@ export interface ContentAuditEntry {
   outcome: ContentAuditOutcome;
   /** A short error message when `outcome !== "ok"`. */
   error?: string | null;
+  /**
+   * Structured, action-specific context. For a `delete` this records the removed
+   * object's identity (`{ title, kind, ownerUserId, versionsDeleted }`) captured
+   * before the row disappeared — the only durable record of what was deleted.
+   */
+  details?: ContentAuditDetails | null;
   requestId?: string | null;
+}
+
+/**
+ * Build the `content_audit_logs` INSERT values for one audit entry. Pure (no IO),
+ * so it is shared by the best-effort `recordContentAudit` AND the delete path,
+ * which writes its audit row INSIDE the delete transaction (`tx.insert(...)`) so
+ * the record and the removal commit atomically — no delete without an audit trail.
+ */
+export function contentAuditInsertValues(
+  entry: ContentAuditEntry
+): typeof contentAuditLogs.$inferInsert {
+  const { req } = entry;
+  return {
+    objectId: entry.objectId ?? null,
+    action: entry.action,
+    surface: entry.surface,
+    actorKind: actorKindOf(req),
+    actorUserId: authorUserIdOf(req),
+    agentId: agentIdOf(req),
+    agentLabel: req.kind === "user" ? null : req.agentLabel,
+    destination: entry.destination ?? null,
+    outcome: entry.outcome,
+    error: truncateError(entry.error),
+    details: entry.details ?? null,
+    requestId: entry.requestId ?? null,
+  };
 }
 
 let auditFailureCount = 0;
@@ -66,25 +107,10 @@ export async function recordContentAudit(entry: ContentAuditEntry): Promise<void
     requestId: entry.requestId ?? undefined,
     action: "content.audit",
   });
-  const { req } = entry;
-  const agentLabel = req.kind === "user" ? null : req.agentLabel;
 
   try {
     await executeQuery(
-      (db) =>
-        db.insert(contentAuditLogs).values({
-          objectId: entry.objectId ?? null,
-          action: entry.action,
-          surface: entry.surface,
-          actorKind: actorKindOf(req),
-          actorUserId: authorUserIdOf(req),
-          agentId: agentIdOf(req),
-          agentLabel,
-          destination: entry.destination ?? null,
-          outcome: entry.outcome,
-          error: truncateError(entry.error),
-          requestId: entry.requestId ?? null,
-        }),
+      (db) => db.insert(contentAuditLogs).values(contentAuditInsertValues(entry)),
       "recordContentAudit"
     );
   } catch (err) {

--- a/lib/content/collab/collab-server.ts
+++ b/lib/content/collab/collab-server.ts
@@ -285,6 +285,22 @@ async function seedAuthorAndMarkdown(
   return { by, markdown };
 }
 
+/**
+ * Thrown by `getOrCreateDoc` when the content object no longer exists (hard-deleted,
+ * or never existed): there is neither persisted `atrium_doc_state` NOR an object to
+ * seed a fresh draft from. The connection handler catches this and rejects the
+ * socket, so the doc-load path FAILS CLOSED post-delete — a still-valid pre-minted
+ * collab token (≤ its short TTL) cannot open a deleted document's room and get an
+ * empty editable doc. (New connections already fail closed at token-mint time via
+ * the mint route's canView/loadByIdOrSlug 404; this closes the in-TTL window.)
+ */
+class CollabDocNotFoundError extends Error {
+  constructor(docName: string) {
+    super(`Collab document ${docName} no longer exists`);
+    this.name = "CollabDocNotFoundError";
+  }
+}
+
 async function getOrCreateDoc(docName: string): Promise<DocEntry> {
   const existing = docs.get(docName);
   if (existing) return existing;
@@ -318,6 +334,14 @@ async function getOrCreateDoc(docName: string): Promise<DocEntry> {
           Y.applyUpdate(ydoc, Y.encodeStateAsUpdate(seeded), "init");
           entry.markdown = seed.markdown;
           await saveDocState(docName, Y.encodeStateAsUpdate(ydoc), seed.markdown);
+        } else {
+          // No persisted state AND no object to seed from ⇒ the content object does
+          // not exist (hard-deleted, or never existed). FAIL CLOSED rather than
+          // materialize an empty editable room for a non-existent object — a valid
+          // pre-minted token would otherwise open a just-deleted doc within its TTL.
+          // A brand-new document always has its content_objects row, so `seed` is
+          // non-null and this never fires for a legitimately empty new doc.
+          throw new CollabDocNotFoundError(docName);
         }
       }
 
@@ -495,6 +519,13 @@ export async function handleCollabConnection(
   try {
     entry = await getOrCreateDoc(docName);
   } catch (err) {
+    if (err instanceof CollabDocNotFoundError) {
+      // Expected post-delete (or a bad id): the object is gone. Fail closed with a
+      // "not found" close code, logged at info — this is not a server fault.
+      log.info("Collab doc no longer exists; rejecting connection", { docName });
+      rejectConn(4404, "Not found");
+      return;
+    }
     log.error("Failed to load collab doc, closing socket", {
       docName,
       error: err instanceof Error ? err.message : String(err),

--- a/lib/content/content-service.ts
+++ b/lib/content/content-service.ts
@@ -762,7 +762,9 @@ export const contentService = {
     const { retrievalService } = await import("./retrieval-service");
     await retrievalService.removeFromIndex(existing.id);
 
-    const versionsDeleted = await executeTransaction(async (tx) => {
+    let versionsDeleted: number;
+    try {
+      versionsDeleted = await executeTransaction(async (tx) => {
       // Lock the object row so a concurrent publish cannot slip a live publication
       // in between the pre-flight check and the delete (TOCTOU).
       const locked = await tx
@@ -838,7 +840,34 @@ export const contentService = {
       // end-of-statement check sees no dangling reference.
       await tx.delete(contentObjects).where(eq(contentObjects.id, existing.id));
       return vCount;
-    }, "content.delete");
+      }, "content.delete");
+    } catch (err) {
+      // The pre-flight index prune runs BEFORE this tx (it needs the not-yet-cascaded
+      // content_index_links to find the shared repository_item via the sanctioned
+      // removeFromIndex). If the AUTHORITATIVE in-tx guard then aborts the delete —
+      // a publish committed between the racy pre-flight liveDestinations() read and
+      // the FOR-UPDATE lock — the object stays live+published but has already been
+      // de-indexed. Re-index it (best-effort, fire-and-forget) so a REFUSED delete
+      // never silently drops still-live content out of assistant retrieval. Only the
+      // in-tx live-publication guard raises ConflictError inside the tx.
+      if (err instanceof ConflictError) {
+        void retrievalService
+          .indexObject(existing.id)
+          .catch((reindexError) =>
+            createLogger({ action: "content.delete" }).warn(
+              "Re-index after aborted delete failed (object left de-indexed until next publish/edit)",
+              {
+                objectId: existing.id,
+                error:
+                  reindexError instanceof Error
+                    ? reindexError.message
+                    : String(reindexError),
+              }
+            )
+          );
+      }
+      throw err;
+    }
 
     const log = createLogger({ action: "content.delete" });
     // Best-effort external cleanup AFTER commit — orphaned S3 keys are acceptable.

--- a/lib/content/content-service.ts
+++ b/lib/content/content-service.ts
@@ -11,19 +11,27 @@
  * driver); JSONB columns insert via `sql\`${safeJsonbStringify(v)}::jsonb\``.
  */
 
-import { eq, like, sql } from "drizzle-orm";
+import { and, count, eq, like, sql } from "drizzle-orm";
 import { createLogger } from "@/lib/logger";
 import {
   executeQuery,
   executeTransaction,
   type DbTransaction,
 } from "@/lib/db/drizzle-client";
-import { contentCollections, contentObjects } from "@/lib/db/schema";
+import {
+  contentAuditLogs,
+  contentCollections,
+  contentObjects,
+  contentPublications,
+  contentVersions,
+  navigationItems,
+} from "@/lib/db/schema";
 import { safeJsonbStringify } from "@/lib/db/json-utils";
 import {
   actorKindOf,
   agentIdOf,
   assertCanCreate,
+  assertCanDelete,
   assertCanEdit,
   canPublishPublic,
   persistPublishApprovalRequest,
@@ -31,6 +39,7 @@ import {
   slugifyTitle,
   systemUserId,
 } from "./helpers";
+import { contentAuditInsertValues, type ContentAuditSurface } from "./audit";
 import { contentEvents } from "./events";
 import { screenAgentBodyForWrite } from "./agent-screening";
 import {
@@ -47,6 +56,7 @@ import {
   ValidationError,
 } from "./errors";
 import type {
+  ContentKind,
   ContentObjectDTO,
   ContentObjectWithVersion,
   CreateObjectInput,
@@ -57,6 +67,16 @@ import type {
   VisibilityGrant,
   VisibilityLevel,
 } from "./types";
+
+/** What a successful hard delete returns — the identity of what was removed. */
+export interface DeletedContentSummary {
+  id: string;
+  slug: string;
+  title: string;
+  kind: ContentKind;
+  /** Immutable version rows removed with the object (cascade). */
+  versionsDeleted: number;
+}
 
 const UUID_RE =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
@@ -676,6 +696,189 @@ export const contentService = {
       await pruneRetrievalIndexBestEffort(existing.id);
     }
     return rowToObjectDTO(rows[0] as ObjectRowAsText);
+  },
+
+  /**
+   * HARD-DELETE an object: remove its row and every dependent row/body permanently.
+   * The single delete path for every surface (REST, skill, Nexus chat tool, UI).
+   *
+   * Guards, in strict order (an unviewable object must never reveal its existence):
+   *  1. 404 (NotFound) when the object doesn't exist OR the requester cannot
+   *     `canView` it — existence-masking BEFORE any permission signal.
+   *  2. 403 (Forbidden) unless the requester is the OWNER or an admin (agents also
+   *     need the `content:delete` scope) — `assertCanDelete`.
+   *  3. 409 (Conflict) when the object is LIVE at any destination — delete NEVER
+   *     auto-retracts a publication; the caller must `unpublish` first. Checked as
+   *     a fast pre-flight AND authoritatively on the FOR-UPDATE-locked row inside
+   *     the transaction (TOCTOU-safe, per the §26.4 gate-order lesson).
+   * Any kind/status otherwise (draft / archived / private / internal) is deletable —
+   * the guards above are the protection, not the lifecycle status.
+   *
+   * Ordering that makes an external-cleanup failure UNABLE to orphan DB state:
+   *  - Retrieval-index removal runs via the sanctioned `retrievalService.removeFromIndex`
+   *    BEFORE the delete tx (it reads `content_index_links` to find the SHARED
+   *    `repository_item`, which the object-delete cascade would otherwise erase —
+   *    leaving orphaned shared rows). It opens its own tx (can't nest) and is a
+   *    no-op for an unindexed object.
+   *  - ALL row deletes happen in ONE transaction: a `delete` audit row is written
+   *    (capturing title/kind/owner that the cascade erases), then the object row is
+   *    deleted — cascading `content_versions`, `content_publications`,
+   *    `atrium_doc_state`, `atrium_doc_comments`, `content_embed_links`,
+   *    `content_visibility_grants`, `content_publish_requests`, `content_index_links`
+   *    via their ON DELETE CASCADE FKs. `content_audit_logs` has no FK to the object,
+   *    so the trail SURVIVES.
+   *  - S3 body cleanup runs AFTER the commit, best-effort: an orphaned S3 key is
+   *    invisible (its DB rows are gone) and only logged, never rolled back into the
+   *    committed delete.
+   */
+  async delete(
+    req: Requester,
+    id: string,
+    opts: { surface: ContentAuditSurface }
+  ): Promise<DeletedContentSummary> {
+    const existing = await loadByIdOrSlug(id);
+    if (!existing) throw new NotFoundError("Content not found", { id });
+    // 404 (not 403) on a non-viewable object to avoid leaking existence, BEFORE
+    // the delete-permission check.
+    await assertViewable(req, existing, id);
+    // 403 unless owner/admin (agents also need content:delete).
+    assertCanDelete(req, existing.ownerUserId);
+
+    // Pre-flight: refuse while any destination is live (never auto-retract). This
+    // is a fast, racy rejection + a clear message; the tx re-checks authoritatively.
+    const { publishService } = await import("./publish-service");
+    const liveBefore = await publishService.liveDestinations(existing.id);
+    if (liveBefore.length > 0) {
+      throw new ConflictError(
+        `Cannot delete published content — unpublish from ${liveBefore.join(
+          ", "
+        )} first, then delete.`,
+        { objectId: existing.id, liveDestinations: liveBefore }
+      );
+    }
+
+    // Clean the SHARED retrieval index (repository_item + chunks) via the sanctioned
+    // inverse BEFORE the delete tx — see the method doc. Runs in its own tx.
+    const { retrievalService } = await import("./retrieval-service");
+    await retrievalService.removeFromIndex(existing.id);
+
+    const versionsDeleted = await executeTransaction(async (tx) => {
+      // Lock the object row so a concurrent publish cannot slip a live publication
+      // in between the pre-flight check and the delete (TOCTOU).
+      const locked = await tx
+        .select({ id: contentObjects.id })
+        .from(contentObjects)
+        .where(eq(contentObjects.id, existing.id))
+        .for("update")
+        .limit(1);
+      // Concurrent delete already removed it — surface cleanly, don't double-delete.
+      if (!locked[0]) {
+        throw new NotFoundError("Content not found", { id: existing.id });
+      }
+
+      // AUTHORITATIVE live-publication guard on the locked row.
+      const live = await tx
+        .select({ destination: contentPublications.destination })
+        .from(contentPublications)
+        .where(
+          and(
+            eq(contentPublications.objectId, existing.id),
+            eq(contentPublications.status, "live")
+          )
+        );
+      if (live.length > 0) {
+        throw new ConflictError(
+          `Cannot delete published content — unpublish from ${live
+            .map((l) => l.destination)
+            .join(", ")} first, then delete.`,
+          { objectId: existing.id }
+        );
+      }
+
+      const [versionCountRow] = await tx
+        .select({ value: count() })
+        .from(contentVersions)
+        .where(eq(contentVersions.objectId, existing.id));
+      const vCount = Number(versionCountRow?.value ?? 0);
+
+      // Audit BEFORE the row disappears (in-tx = atomic with the delete): the
+      // object_id becomes a dangling UUID after this, so `details` is the only
+      // durable record of what was removed.
+      await tx.insert(contentAuditLogs).values(
+        contentAuditInsertValues({
+          req,
+          action: "delete",
+          surface: opts.surface,
+          objectId: existing.id,
+          outcome: "ok",
+          details: {
+            title: existing.title,
+            kind: existing.kind,
+            ownerUserId: existing.ownerUserId,
+            versionsDeleted: vCount,
+          },
+        })
+      );
+
+      // Remove the object's intranet nav entry FIRST. `navigation_items.content_object_id`
+      // is ON DELETE NO ACTION (not cascade) and unpublish only SOFT-hides the row
+      // (navItemService.hideNavItem sets is_active=false, never deletes it), so a
+      // published-then-unpublished object still carries a nav row that would block the
+      // object delete's end-of-statement FK check. Deleting it in the SAME tx clears
+      // the reference before the object row goes. (A never-published object has none —
+      // this is a no-op.) A content nav item is a leaf, so nothing cascades off it.
+      await tx
+        .delete(navigationItems)
+        .where(eq(navigationItems.contentObjectId, existing.id));
+
+      // The object row + everything ON DELETE CASCADE hangs off it (versions,
+      // publications, doc_state, doc_comments, embed_links, visibility_grants,
+      // publish_requests, index_links). content_publications.published_version_id is
+      // NO ACTION but both it and the version cascade-delete here, so the deferred
+      // end-of-statement check sees no dangling reference.
+      await tx.delete(contentObjects).where(eq(contentObjects.id, existing.id));
+      return vCount;
+    }, "content.delete");
+
+    const log = createLogger({ action: "content.delete" });
+    // Best-effort external cleanup AFTER commit — orphaned S3 keys are acceptable.
+    // Lazy import (like publish-service/retrieval-service above): a static import
+    // pulls s3-store → settings-manager → drizzle into content-service's module
+    // graph, which breaks unit tests that import this module with only shallow mocks.
+    try {
+      const { s3Store } = await import("./storage/s3-store");
+      const s3KeysDeleted = await s3Store.deleteObjectTree(existing.id);
+      log.info("Deleted content object", {
+        objectId: existing.id,
+        slug: existing.slug,
+        kind: existing.kind,
+        versionsDeleted,
+        s3KeysDeleted,
+        surface: opts.surface,
+      });
+    } catch (s3Error) {
+      log.warn("Content deleted; S3 body cleanup failed (orphaned keys acceptable)", {
+        objectId: existing.id,
+        error: s3Error instanceof Error ? s3Error.message : String(s3Error),
+      });
+    }
+
+    // Lifecycle event AFTER commit, best-effort (never throws) — subscribers that
+    // cached the object learn it is gone.
+    void contentEvents.emit("content.deleted", {
+      objectId: existing.id,
+      slug: existing.slug,
+      actorKind: actorKindOf(req),
+      agentLabel: req.kind === "user" ? null : req.agentLabel,
+    });
+
+    return {
+      id: existing.id,
+      slug: existing.slug,
+      title: existing.title,
+      kind: existing.kind,
+      versionsDeleted,
+    };
   },
 };
 

--- a/lib/content/events.ts
+++ b/lib/content/events.ts
@@ -25,6 +25,8 @@ export type ContentEventType =
   | "content.published"
   | "content.version_created"
   | "content.unpublished"
+  // Hard delete (Epic #1059 follow-up): the object and all its rows/bodies are
+  | "content.deleted"
   | "content.public_publish_requested";
 
 export interface ContentEventPayload {

--- a/lib/content/helpers.ts
+++ b/lib/content/helpers.ts
@@ -223,6 +223,52 @@ export function assertCanEdit(req: Requester, ownerUserId: number): void {
 }
 
 /**
+ * Whether a requester may HARD-DELETE an object: the OWNER or an admin (and, for
+ * agent callers, holding the `content:delete` scope). Deliberately its OWN
+ * predicate rather than reusing `canEdit`, for two reasons:
+ *
+ *  1. Delete is irreversible; keeping it strictly owner-or-admin means a future
+ *     widening of `canEdit` (e.g. a "group collaborator can edit" grant) can never
+ *     silently hand out delete. The two authorities evolve independently.
+ *  2. It keys the agent authorization off the DELETE scope (`content:delete`), not
+ *     the UPDATE scope — so a key granted delete-but-not-update (or vice versa) is
+ *     evaluated against the correct scope, never the wrong one.
+ *
+ * Autonomous agents have no `userId`; they own via the configured system user, so
+ * ownership is checked against `systemUserId()`. A delegated agent may delete only
+ * content its human owns AND only with the delete scope.
+ */
+export function canDelete(req: Requester, ownerUserId: number): boolean {
+  const principal = principalOf(req);
+  if (principal.isAdmin) return true;
+
+  if (req.kind === "agent-autonomous") {
+    // Owns via the system user; must also hold the delete scope. A missing
+    // system-user config denies rather than throws (read/permission path).
+    const sysId = systemUserIdOrNull();
+    return (
+      sysId != null &&
+      ownerUserId === sysId &&
+      scopesOf(req).includes("content:delete")
+    );
+  }
+
+  if (principal.userId != null && principal.userId === ownerUserId) {
+    if (req.kind === "user") return true;
+    // Delegated agents additionally need the delete scope.
+    return scopesOf(req).includes("content:delete");
+  }
+  return false;
+}
+
+/** Throw `ForbiddenError` unless the requester may delete the object. */
+export function assertCanDelete(req: Requester, ownerUserId: number): void {
+  if (!canDelete(req, ownerUserId)) {
+    throw new ForbiddenError("Not permitted to delete this content");
+  }
+}
+
+/**
  * §26.4 — only humans (admins or holders of the `content.publish_public`
  * capability) and delegated agents the human granted `content:publish_public`
  * may publish publicly. Autonomous agents never hold it. Phase 0 exposes this

--- a/lib/content/index.ts
+++ b/lib/content/index.ts
@@ -9,6 +9,7 @@
  */
 
 export { contentService } from "./content-service";
+export type { DeletedContentSummary } from "./content-service";
 export { versionService } from "./version-service";
 export { visibilityService } from "./visibility-service";
 export { collectionService } from "./collection-service";
@@ -67,7 +68,9 @@ export {
 
 export {
   assertCanCreate,
+  assertCanDelete,
   assertCanEdit,
+  canDelete,
   canEdit,
   canPublishPublic,
   hasPublishPublicScope,

--- a/lib/content/publish-service.ts
+++ b/lib/content/publish-service.ts
@@ -929,6 +929,33 @@ export const publishService = {
   },
 
   /**
+   * The destinations at which an object is currently LIVE (status = 'live'), in no
+   * particular order. Empty when the object is published nowhere.
+   *
+   * Read-only, no lock — a fast pre-check for the hard-delete guard ("unpublish
+   * everywhere first") and the UI's disabled-Delete state. The AUTHORITATIVE
+   * delete guard re-checks the same condition on the FOR-UPDATE-locked object row
+   * inside the delete transaction, so this racy read is only an early rejection /
+   * a UI hint, never the security boundary.
+   */
+  async liveDestinations(objectId: string): Promise<PublishDestination[]> {
+    const rows = await executeQuery(
+      (db) =>
+        db
+          .select({ destination: contentPublications.destination })
+          .from(contentPublications)
+          .where(
+            and(
+              eq(contentPublications.objectId, objectId),
+              eq(contentPublications.status, "live")
+            )
+          ),
+      "publish.liveDestinations"
+    );
+    return rows.map((r) => r.destination as PublishDestination);
+  },
+
+  /**
    * Resolve a `live` publication by the object's slug at a destination — the
    * lookup the in-app reader (`/c/[slug]`) uses to find which version to serve.
    * Returns null when no object has that slug or it is not live at the

--- a/lib/content/storage/s3-store.ts
+++ b/lib/content/storage/s3-store.ts
@@ -18,7 +18,9 @@
  */
 
 import {
+  DeleteObjectsCommand,
   GetObjectCommand,
+  ListObjectsV2Command,
   PutObjectCommand,
   S3Client,
 } from "@aws-sdk/client-s3";
@@ -155,6 +157,56 @@ export const s3Store = {
       throw ErrorFactories.sysInternalError("S3 object has no body", { key });
     }
     return readStreamToString(response.Body);
+  },
+
+  /**
+   * Delete EVERY object under a content object's `atrium/objects/{objectId}/`
+   * prefix — all versions (`v{n}/…`) and assets. Used by the hard-delete path
+   * AFTER the DB rows are removed (issue: Atrium hard delete). Paginates the
+   * listing and batches deletes at the S3 API limit (1000 keys/request).
+   *
+   * Returns the number of keys deleted. The caller runs this best-effort
+   * post-commit: an orphaned S3 key is acceptable (invisible once its DB rows are
+   * gone) and logged, so DB commit ordering — commit first, then this — is what
+   * guarantees a failure here can never orphan the DB state. This method itself
+   * lets a hard AWS error propagate; the caller catches and logs it.
+   */
+  async deleteObjectTree(objectId: string): Promise<number> {
+    assertSafeSegment(objectId, "objectId");
+    const client = await getClient();
+    const { bucket } = await getConfig();
+    const prefix = `${ATRIUM_PREFIX}/objects/${objectId}/`;
+
+    let deleted = 0;
+    let continuationToken: string | undefined;
+    do {
+      const listed = await client.send(
+        new ListObjectsV2Command({
+          Bucket: bucket,
+          Prefix: prefix,
+          ContinuationToken: continuationToken,
+        })
+      );
+      const keys = (listed.Contents ?? [])
+        .map((o) => o.Key)
+        .filter((k): k is string => typeof k === "string");
+      // Batch delete in chunks of 1000 (the DeleteObjects hard limit).
+      for (let i = 0; i < keys.length; i += 1000) {
+        const chunk = keys.slice(i, i + 1000);
+        await client.send(
+          new DeleteObjectsCommand({
+            Bucket: bucket,
+            Delete: { Objects: chunk.map((Key) => ({ Key })), Quiet: true },
+          })
+        );
+        deleted += chunk.length;
+      }
+      continuationToken = listed.IsTruncated
+        ? listed.NextContinuationToken
+        : undefined;
+    } while (continuationToken);
+
+    return deleted;
   },
 
   /** Generate a presigned read URL for the given key (default 5 min TTL). */

--- a/lib/db/schema/tables/content-audit-logs.ts
+++ b/lib/db/schema/tables/content-audit-logs.ts
@@ -15,6 +15,7 @@
 
 import {
   integer,
+  jsonb,
   pgTable,
   text,
   timestamp,
@@ -24,6 +25,24 @@ import {
 import { users } from "./users";
 import { agentIdentities } from "./agent-identities";
 import { actorKindEnum, publishDestinationEnum } from "../enums";
+
+/**
+ * Structured, action-specific context on an audit event. Nullable — most actions
+ * store nothing here. Populated for `delete` with the removed object's identity
+ * (title/kind/owner) captured BEFORE the row disappeared: `object_id` alone is a
+ * dangling UUID after a hard delete, so this is the only record of WHAT was
+ * removed. See migration 105.
+ */
+export interface ContentAuditDetails {
+  /** The deleted object's title, captured pre-delete. */
+  title?: string;
+  /** The deleted object's kind (document | artifact). */
+  kind?: string;
+  /** The user id that owned the deleted object. */
+  ownerUserId?: number;
+  /** How many immutable version rows cascaded away with the object. */
+  versionsDeleted?: number;
+}
 
 export const contentAuditLogs = pgTable("content_audit_logs", {
   id: uuid("id").defaultRandom().primaryKey(),
@@ -48,6 +67,8 @@ export const contentAuditLogs = pgTable("content_audit_logs", {
   /** ok | error | approval_required */
   outcome: varchar("outcome", { length: 24 }).notNull(),
   error: text("error"),
+  /** Structured per-action context; the `delete` trail's record of what was removed. */
+  details: jsonb("details").$type<ContentAuditDetails>(),
   requestId: varchar("request_id", { length: 255 }),
   createdAt: timestamp("created_at").defaultNow().notNull(),
 });

--- a/lib/nexus/workspace-chat-tools.ts
+++ b/lib/nexus/workspace-chat-tools.ts
@@ -28,7 +28,7 @@
 
 import { tool, jsonSchema, type Tool, type ToolSet } from "ai";
 import { contentService } from "@/lib/content/content-service";
-import { canEdit } from "@/lib/content/helpers";
+import { canDelete, canEdit } from "@/lib/content/helpers";
 import { requesterForUserId } from "@/lib/content/requester-from-auth";
 import { applyAgentEdit, readAgentDocMarkdown } from "@/lib/content/collab/apply-agent-edit";
 import { snapshotLiveDocumentForPublish } from "@/lib/content/collab/snapshot-before-publish";
@@ -652,8 +652,15 @@ export async function buildWorkspaceChatTools(params: {
     // ITEM 2: publish/unpublish the OPEN object through the human publish gate.
     tools.publish_workspace_content = buildPublishTool({ op: "publish", objectId: obj.id, kind, userId, requestId, log });
     tools.unpublish_workspace_content = buildPublishTool({ op: "unpublish", objectId: obj.id, kind, userId, requestId, log });
-    // Hard delete of the OPEN object (owner/admin, refused while published). The
-    // service re-checks canDelete + live-publication per call.
+  }
+
+  // Hard delete of the OPEN object, bound on `canDelete` — NOT `canEdit`. helpers.ts
+  // documents canDelete as deliberately decoupled from canEdit (owner/admin only, so a
+  // future widening of edit — e.g. collaborator grants — can never silently imply
+  // delete). canDelete === canEdit for a session user today, but binding the LLM's
+  // delete affordance on the delete authority keeps it aligned with that discipline;
+  // the service still re-checks assertCanDelete + the live-publication guard per call.
+  if (canDelete(req, obj.ownerUserId)) {
     tools.delete_workspace_content = buildDeleteTool({ objectId: obj.id, kind, userId, log });
   }
 

--- a/lib/nexus/workspace-chat-tools.ts
+++ b/lib/nexus/workspace-chat-tools.ts
@@ -36,7 +36,13 @@ import { loadDocState } from "@/lib/content/collab/doc-state-store";
 import { screenAgentContent } from "@/lib/content/agent-screening";
 import { publishService } from "@/lib/content/publish-service";
 import { assertEditorDestination } from "@/lib/content/validators";
-import { ApprovalRequiredError, ValidationError } from "@/lib/content/errors";
+import {
+  ApprovalRequiredError,
+  ConflictError,
+  ForbiddenError,
+  NotFoundError,
+  ValidationError,
+} from "@/lib/content/errors";
 import { createLogger } from "@/lib/logger";
 
 /** Free-form attribution label stamped on the purple rail for chat-driven edits. */
@@ -435,6 +441,78 @@ function buildPublishTool(args: {
   });
 }
 
+/**
+ * Build the hard-delete tool for the WORKSPACE-bound object. Bound only when the
+ * session user can edit (owner/admin) the open object; the service re-checks
+ * canView (404-mask) → canDelete (owner/admin 403) → live-publication (409) on
+ * every call, so this is never a bypass. Runs as the SESSION user (`kind: "user"`),
+ * so a human can only delete content they own (or as admin) via chat.
+ */
+function buildDeleteTool(args: {
+  objectId: string;
+  kind: "document" | "artifact";
+  userId: number;
+  log: ReturnType<typeof createLogger>;
+}): Tool {
+  const { objectId, kind, userId, log } = args;
+  return tool({
+    description:
+      `PERMANENTLY delete the ${kind} open in the workspace panel — it and ALL its ` +
+      `versions, comments, and history are removed and CANNOT be recovered (this is ` +
+      `not archive). Only call this when the user has EXPLICITLY asked to permanently ` +
+      `delete this ${kind}; if there is any doubt, ask them to confirm first. It is ` +
+      `refused (returns blocked:true with a message) while the ${kind} is published ` +
+      `anywhere — then tell the user to unpublish it first. Only the owner or an ` +
+      `administrator may delete.`,
+    inputSchema: jsonSchema<Record<string, never>>({
+      type: "object",
+      properties: {},
+      additionalProperties: false,
+    }),
+    execute: async (): Promise<Record<string, unknown>> => {
+      const req = await requesterForUserId(userId);
+      if (!req) return { error: "Could not resolve your identity." };
+      try {
+        const deleted = await contentService.delete(req, objectId, {
+          surface: "ui",
+        });
+        log.info("workspace content deleted via chat", { objectId, kind });
+        return {
+          ok: true,
+          deleted: true,
+          title: deleted.title,
+          kind: deleted.kind,
+          message:
+            `Deleted "${deleted.title}". It is permanently gone; the workspace panel ` +
+            `will show it is no longer available.`,
+        };
+      } catch (err) {
+        // A live-publication refusal (409) is an ACTIONABLE, honest state — surface
+        // its message so the model tells the user to unpublish first, not a failure.
+        if (err instanceof ConflictError) {
+          return { blocked: true, reason: "published", message: err.message };
+        }
+        // 403 (not owner/admin) and 404 (existence-masked) are permission outcomes,
+        // reported without leaking which one it was beyond what the user may know.
+        if (err instanceof ForbiddenError) {
+          return {
+            error:
+              "You do not have permission to delete this item — only its owner or an administrator can.",
+          };
+        }
+        if (err instanceof NotFoundError) {
+          return { error: "That item is no longer available." };
+        }
+        log.warn("workspace delete failed", {
+          objectId,
+          error: err instanceof Error ? err.message : String(err),
+        });
+        return { error: "The item could not be deleted right now." };
+      }
+    },
+  });
+}
+
 /** Build the find-documents tool (ITEM 3): list Atrium documents the user can edit. */
 function buildFindDocumentsTool(userId: number, log: ReturnType<typeof createLogger>): Tool {
   return tool({
@@ -574,6 +652,9 @@ export async function buildWorkspaceChatTools(params: {
     // ITEM 2: publish/unpublish the OPEN object through the human publish gate.
     tools.publish_workspace_content = buildPublishTool({ op: "publish", objectId: obj.id, kind, userId, requestId, log });
     tools.unpublish_workspace_content = buildPublishTool({ op: "unpublish", objectId: obj.id, kind, userId, requestId, log });
+    // Hard delete of the OPEN object (owner/admin, refused while published). The
+    // service re-checks canDelete + live-publication per call.
+    tools.delete_workspace_content = buildDeleteTool({ objectId: obj.id, kind, userId, log });
   }
 
   // ITEM 3: let the agent find and edit OTHER Atrium documents the user can edit —
@@ -586,9 +667,11 @@ export async function buildWorkspaceChatTools(params: {
   const editHint = editable
     ? kind === "document"
       ? " You can edit it with the edit_workspace_document tool; your edits appear live in the panel." +
-        " You can also publish or unpublish it with publish_workspace_content / unpublish_workspace_content."
+        " You can also publish or unpublish it with publish_workspace_content / unpublish_workspace_content." +
+        " If the user EXPLICITLY asks to permanently delete it (not archive), use delete_workspace_content — it is irreversible and refused while the document is published."
       : " You can update it with the update_workspace_artifact tool (provide the complete new code)." +
-        " You can also publish or unpublish it with publish_workspace_content / unpublish_workspace_content."
+        " You can also publish or unpublish it with publish_workspace_content / unpublish_workspace_content." +
+        " If the user EXPLICITLY asks to permanently delete it (not archive), use delete_workspace_content — it is irreversible and refused while the artifact is published."
     : " It is read-only for this user.";
 
   // Escape the title via JSON.stringify: a content title is user-controlled and

--- a/tests/e2e/atrium-delete.functional.spec.ts
+++ b/tests/e2e/atrium-delete.functional.spec.ts
@@ -1,0 +1,117 @@
+import { test, expect } from './fixtures'
+import {
+  authenticateContext,
+  SEEDED_ADMIN_EMAIL,
+  SEEDED_ADMIN_SUB,
+} from './helpers/session-auth'
+
+/**
+ * E2E functional coverage for Atrium HARD DELETE (Atrium hard delete).
+ *
+ * Proves the delete contract end-to-end against the real service + DB:
+ *  - create → DELETE → 200, and the object is then GONE (GET 404).
+ *  - a PUBLISHED object is refused (409) until it is unpublished — delete never
+ *    auto-unpublishes.
+ *  - the in-app UI flow: open the editor's content-settings dialog, click
+ *    "Delete permanently", confirm, land back on the library, and the object 404s.
+ *
+ * Auth: mints a NextAuth session cookie for the seeded admin (helpers/session-auth).
+ * Requires AUTH_SECRET in env and the host :3100 dev server (NOT the prod-built
+ * :3000 container, which rejects the non-secure dev cookie). See
+ * docs/guides/e2e-authenticated-testing.md. Gated behind PLAYWRIGHT_AUTH_ENABLED so
+ * default CI (no seeded session) skips.
+ */
+
+test.describe('Atrium hard delete (authenticated)', () => {
+  test.skip(
+    process.env.PLAYWRIGHT_AUTH_ENABLED !== 'true',
+    'Requires authenticated session — set PLAYWRIGHT_AUTH_ENABLED=true and run against the host :3100 dev server (see docs/guides/e2e-authenticated-testing.md)'
+  )
+
+  test('create → DELETE → 200, then the object is gone (GET 404)', async ({ page }) => {
+    await authenticateContext(page.context(), SEEDED_ADMIN_EMAIL, SEEDED_ADMIN_SUB)
+
+    const created = await page.request.post('/api/v1/content', {
+      data: { kind: 'document', title: 'e2e delete probe', body: '# hi', bodyFormat: 'markdown' },
+    })
+    expect(created.status()).toBe(201)
+    const id = (await created.json())?.data?.id
+    expect(id).toBeTruthy()
+
+    const del = await page.request.delete(`/api/v1/content/${id}`)
+    expect(del.ok()).toBeTruthy()
+    const summary = (await del.json())?.data
+    expect(summary?.id).toBe(id)
+    expect(summary?.kind).toBe('document')
+
+    // It is gone: a GET now 404s (existence-masked), and a second DELETE 404s too.
+    const readAfter = await page.request.get(`/api/v1/content/${id}`)
+    expect(readAfter.status()).toBe(404)
+    const delAgain = await page.request.delete(`/api/v1/content/${id}`)
+    expect(delAgain.status()).toBe(404)
+  })
+
+  test('a PUBLISHED object is refused (409) until unpublished, then deletes', async ({ page }) => {
+    await authenticateContext(page.context(), SEEDED_ADMIN_EMAIL, SEEDED_ADMIN_SUB)
+
+    const created = await page.request.post('/api/v1/content', {
+      data: { kind: 'document', title: 'e2e delete-published probe', body: '# x', bodyFormat: 'markdown' },
+    })
+    expect(created.status()).toBe(201)
+    const id = (await created.json())?.data?.id
+    expect(id).toBeTruthy()
+
+    // Publish to the internal reader.
+    const pub = await page.request.post(`/api/v1/content/${id}/publish`, {
+      data: { destination: 'intranet' },
+    })
+    expect(pub.ok()).toBeTruthy()
+
+    // Delete is refused while live — never auto-unpublishes.
+    const blocked = await page.request.delete(`/api/v1/content/${id}`)
+    expect(blocked.status()).toBe(409)
+
+    // Unpublish, then delete succeeds.
+    const unpub = await page.request.delete(`/api/v1/content/${id}/publish/intranet`)
+    expect(unpub.ok()).toBeTruthy()
+
+    const del = await page.request.delete(`/api/v1/content/${id}`)
+    expect(del.ok()).toBeTruthy()
+
+    const readAfter = await page.request.get(`/api/v1/content/${id}`)
+    expect(readAfter.status()).toBe(404)
+  })
+
+  test('UI flow: Delete permanently in the editor settings → back to library, object 404s', async ({
+    page,
+  }) => {
+    await authenticateContext(page.context(), SEEDED_ADMIN_EMAIL, SEEDED_ADMIN_SUB)
+
+    const created = await page.request.post('/api/v1/content', {
+      data: { kind: 'document', title: 'e2e ui delete probe', body: '# ui', bodyFormat: 'markdown' },
+    })
+    expect(created.status()).toBe(201)
+    const id = (await created.json())?.data?.id
+    expect(id).toBeTruthy()
+
+    // The window.confirm permanence prompt: auto-accept it.
+    page.on('dialog', (dialog) => void dialog.accept())
+
+    await page.goto(`/atrium/${id}/edit`)
+    // Open the content-settings dialog (the gear in the editor topbar).
+    const gear = page.getByRole('button', { name: 'Content settings' })
+    await expect(gear).toBeVisible({ timeout: 15000 })
+    await gear.click()
+
+    const deleteBtn = page.getByRole('button', { name: 'Delete permanently' })
+    await expect(deleteBtn).toBeVisible()
+    await deleteBtn.click()
+
+    // The action navigates back to the library on success.
+    await page.waitForURL('**/atrium', { timeout: 15000 })
+
+    // The object is gone: the API 404s.
+    const readAfter = await page.request.get(`/api/v1/content/${id}`)
+    expect(readAfter.status()).toBe(404)
+  })
+})

--- a/tests/unit/atrium-can-delete.test.ts
+++ b/tests/unit/atrium-can-delete.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Pure-predicate tests for the hard-delete authorization gate (Atrium hard delete).
+ *
+ * `canDelete` is deliberately its OWN predicate (not `canEdit`): strictly
+ * owner-or-admin, and keyed off the `content:delete` scope for agent callers.
+ * These tests pin that contract so a future widening of `canEdit` can never
+ * silently hand out delete, and so the delete scope (not update) gates agents.
+ */
+
+jest.mock("@/lib/db/drizzle-client", () => ({
+  executeQuery: jest.fn(),
+}));
+jest.mock("@/lib/db/schema", () => ({}));
+jest.mock("@/lib/content/events", () => ({
+  contentEvents: { emit: jest.fn(async () => undefined) },
+}));
+
+import { canDelete, assertCanDelete } from "@/lib/content/helpers";
+import { ForbiddenError } from "@/lib/content/errors";
+import type { Requester } from "@/lib/content/types";
+
+const OWNER_ID = 7;
+const SYSTEM_USER_ID = 999;
+
+const userOwner: Requester = { kind: "user", userId: OWNER_ID, roles: ["staff"], isAdmin: false };
+const userOther: Requester = { kind: "user", userId: 8, roles: ["staff"], isAdmin: false };
+const userAdmin: Requester = { kind: "user", userId: 42, roles: ["administrator"], isAdmin: true };
+
+function delegated(scopes: string[], actingForUserId = OWNER_ID): Requester {
+  return {
+    kind: "agent-delegated",
+    actingForUserId,
+    agentLabel: "delegated",
+    scopes,
+    roles: ["staff"],
+    building: null,
+    department: null,
+    gradeLevels: null,
+  };
+}
+
+function autonomous(scopes: string[]): Requester {
+  return {
+    kind: "agent-autonomous",
+    agentId: "agent-2",
+    agentLabel: "autonomous",
+    scopes,
+    roles: ["staff"],
+  };
+}
+
+describe("canDelete — owner-or-admin, delete-scoped for agents", () => {
+  const saved = process.env.ATRIUM_SYSTEM_USER_ID;
+  beforeAll(() => {
+    process.env.ATRIUM_SYSTEM_USER_ID = String(SYSTEM_USER_ID);
+  });
+  afterAll(() => {
+    if (saved === undefined) delete process.env.ATRIUM_SYSTEM_USER_ID;
+    else process.env.ATRIUM_SYSTEM_USER_ID = saved;
+  });
+
+  it("owner (user) may delete their own object", () => {
+    expect(canDelete(userOwner, OWNER_ID)).toBe(true);
+  });
+
+  it("a non-owner user may NOT delete", () => {
+    expect(canDelete(userOther, OWNER_ID)).toBe(false);
+  });
+
+  it("an admin may delete anyone's object", () => {
+    expect(canDelete(userAdmin, OWNER_ID)).toBe(true);
+  });
+
+  it("a delegated agent acting for the owner needs the content:delete scope", () => {
+    expect(canDelete(delegated(["content:delete"]), OWNER_ID)).toBe(true);
+    // Holding UPDATE but not DELETE must NOT grant delete (scope keyed correctly).
+    expect(canDelete(delegated(["content:update"]), OWNER_ID)).toBe(false);
+    // Acting for a DIFFERENT user than the owner is never allowed.
+    expect(canDelete(delegated(["content:delete"], 8), OWNER_ID)).toBe(false);
+  });
+
+  it("an autonomous agent may delete only the system-user's content, with the delete scope", () => {
+    expect(canDelete(autonomous(["content:delete"]), SYSTEM_USER_ID)).toBe(true);
+    // Not the system user's content.
+    expect(canDelete(autonomous(["content:delete"]), OWNER_ID)).toBe(false);
+    // Missing the delete scope.
+    expect(canDelete(autonomous(["content:update"]), SYSTEM_USER_ID)).toBe(false);
+  });
+
+  it("assertCanDelete throws ForbiddenError for a non-owner", () => {
+    expect(() => assertCanDelete(userOther, OWNER_ID)).toThrow(ForbiddenError);
+    expect(() => assertCanDelete(userOwner, OWNER_ID)).not.toThrow();
+  });
+});

--- a/tests/unit/atrium-content-delete.test.ts
+++ b/tests/unit/atrium-content-delete.test.ts
@@ -128,8 +128,14 @@ jest.mock("@/lib/content/audit", () => ({
 const removeFromIndexMock = jest.fn(async (_id: string) => {
   callOrder.push("removeFromIndex");
 });
+const indexObjectMock = jest.fn(async (_id: string) => undefined);
 jest.mock("@/lib/content/retrieval-service", () => ({
-  retrievalService: { removeFromIndex: (id: string) => removeFromIndexMock(id) },
+  retrievalService: {
+    removeFromIndex: (id: string) => removeFromIndexMock(id),
+    // The delete path re-indexes a still-live object when the in-tx guard aborts
+    // the delete (409) after the pre-flight index prune (Claude/Codex review fix).
+    indexObject: (id: string) => indexObjectMock(id),
+  },
 }));
 
 const liveDestinationsMock = jest.fn(async (_id: string) => [] as string[]);
@@ -182,6 +188,7 @@ beforeEach(() => {
   assertCanDeleteMock.mockClear();
   assertCanDeleteMock.mockReset();
   removeFromIndexMock.mockClear();
+  indexObjectMock.mockClear();
   liveDestinationsMock.mockClear();
   liveDestinationsMock.mockResolvedValue([]);
   // Only clear call history — keep the default implementation that records the
@@ -251,6 +258,10 @@ describe("contentService.delete", () => {
     ).rejects.toBeInstanceOf(ConflictError);
     // No audit / no delete when the in-tx guard rejects.
     expect(txDeleteCalls).toHaveLength(0);
+    // The pre-flight prune already ran, so the refused (still-live) object is
+    // RE-INDEXED — a 409 must never leave live content out of retrieval.
+    expect(removeFromIndexMock).toHaveBeenCalledWith(OBJ_ID);
+    expect(indexObjectMock).toHaveBeenCalledWith(OBJ_ID);
   });
 
   it("deletes: prunes index BEFORE the tx, writes a delete audit with details, deletes the row, cleans S3 after", async () => {

--- a/tests/unit/atrium-content-delete.test.ts
+++ b/tests/unit/atrium-content-delete.test.ts
@@ -1,0 +1,304 @@
+/**
+ * Wiring tests for `contentService.delete` (Atrium hard delete).
+ *
+ * Validates the orchestration + guard ORDER without a real database:
+ *  - 404 existence-mask BEFORE any permission signal (assertCanDelete not reached
+ *    when the object is not viewable).
+ *  - 403 owner/admin gate (assertCanDelete).
+ *  - 409 live-publication refusal — both the fast pre-flight AND the authoritative
+ *    in-transaction re-check on the locked row (TOCTOU) — never auto-retracts.
+ *  - Retrieval-index cleanup (`removeFromIndex`, the sanctioned inverse) runs
+ *    BEFORE the delete transaction (the object-delete cascade would otherwise
+ *    erase the link that finds the shared repository_item).
+ *  - The `delete` audit row is written INSIDE the tx with `details`
+ *    (title/kind/owner/versionsDeleted) captured before the row vanishes.
+ *  - The object row is deleted (cascade removes children); S3 cleanup runs AFTER
+ *    the commit best-effort and an S3 failure does not fail the delete.
+ */
+
+const callOrder: string[] = [];
+const queryResults: Array<Array<Record<string, unknown>>> = [];
+const txSelectQueue: Array<Array<Record<string, unknown>>> = [];
+let capturedAuditEntry: Record<string, unknown> | null = null;
+const txDeleteCalls: unknown[] = [];
+
+jest.mock("@/lib/db/drizzle-client", () => ({
+  executeQuery: jest.fn(async () => queryResults.shift() ?? []),
+  executeTransaction: jest.fn(async (cb: (tx: unknown) => unknown) => {
+    callOrder.push("tx");
+    const tx = {
+      select: () => {
+        const result = txSelectQueue.shift() ?? [];
+        const chain: Record<string, unknown> = {};
+        chain.from = () => chain;
+        chain.where = () => chain;
+        chain.for = () => chain;
+        chain.limit = () => Promise.resolve(result);
+        chain.then = (
+          res: (v: unknown) => unknown,
+          rej: (e: unknown) => unknown
+        ) => Promise.resolve(result).then(res, rej);
+        return chain;
+      },
+      insert: () => ({
+        // The values here are the RETURN of the mocked contentAuditInsertValues
+        // (a sentinel). The audit ENTRY is captured by that mock, not here.
+        values: (_v: Record<string, unknown>) => Promise.resolve(),
+      }),
+      delete: () => ({
+        where: (w: unknown) => {
+          txDeleteCalls.push(w);
+          return Promise.resolve();
+        },
+      }),
+    };
+    return cb(tx);
+  }),
+}));
+jest.mock("@/lib/db/schema", () => ({
+  contentObjects: { id: "id", slug: "slug" },
+  contentCollections: {},
+  contentVersions: { objectId: "objectId" },
+  contentPublications: { objectId: "objectId", status: "status", destination: "destination" },
+  contentAuditLogs: {},
+  navigationItems: { contentObjectId: "contentObjectId" },
+}));
+jest.mock("@/lib/db/json-utils", () => ({
+  safeJsonbStringify: (v: unknown) => JSON.stringify(v),
+}));
+jest.mock("drizzle-orm", () => ({
+  and: (...a: unknown[]) => a,
+  count: () => "COUNT",
+  desc: (a: unknown) => a,
+  eq: (...a: unknown[]) => a,
+  like: (...a: unknown[]) => a,
+  sql: Object.assign((..._a: unknown[]) => ({}), { join: () => ({}) }),
+}));
+jest.mock("@/lib/content/mappers", () => ({
+  objectSelectFields: {},
+  rowToObjectDTO: (row: Record<string, unknown>) => row,
+}));
+jest.mock("@/lib/logger", () => ({
+  createLogger: () => ({
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  }),
+}));
+
+const canViewMock = jest.fn(async (..._a: unknown[]) => true);
+jest.mock("@/lib/content/visibility-service", () => ({
+  visibilityService: {
+    canView: (...a: unknown[]) => canViewMock(...a),
+    assertWritableLevel: jest.fn(),
+    applyGrantsForLevel: jest.fn(),
+  },
+}));
+jest.mock("@/lib/content/events", () => ({
+  contentEvents: { emit: jest.fn(async () => undefined) },
+}));
+jest.mock("@/lib/content/version-service", () => ({
+  snapshotInTx: jest.fn(),
+  versionService: { snapshot: jest.fn(), flushSnapshotWrites: jest.fn() },
+}));
+
+const assertCanDeleteMock = jest.fn();
+jest.mock("@/lib/content/helpers", () => ({
+  actorKindOf: () => "human",
+  agentIdOf: () => null,
+  authorUserIdOf: () => 7,
+  assertCanCreate: jest.fn(),
+  assertCanDelete: (...a: unknown[]) => assertCanDeleteMock(...a),
+  assertCanEdit: jest.fn(),
+  canPublishPublic: () => false,
+  persistPublishApprovalRequest: jest.fn(),
+  slugCandidate: (b: string) => b,
+  slugifyTitle: (t: string) => t,
+  systemUserId: () => 999,
+}));
+
+jest.mock("@/lib/content/audit", () => ({
+  contentAuditInsertValues: (entry: Record<string, unknown>) => {
+    capturedAuditEntry = entry;
+    return { _auditValues: true };
+  },
+}));
+
+const removeFromIndexMock = jest.fn(async (_id: string) => {
+  callOrder.push("removeFromIndex");
+});
+jest.mock("@/lib/content/retrieval-service", () => ({
+  retrievalService: { removeFromIndex: (id: string) => removeFromIndexMock(id) },
+}));
+
+const liveDestinationsMock = jest.fn(async (_id: string) => [] as string[]);
+jest.mock("@/lib/content/publish-service", () => ({
+  publishService: {
+    liveDestinations: (id: string) => liveDestinationsMock(id),
+    retractAllPublications: jest.fn(),
+  },
+}));
+
+const deleteObjectTreeMock = jest.fn(async (_id: string) => {
+  callOrder.push("s3");
+  return 3;
+});
+jest.mock("@/lib/content/storage/s3-store", () => ({
+  s3Store: { deleteObjectTree: (id: string) => deleteObjectTreeMock(id) },
+  ATRIUM_PREFIX: "atrium",
+}));
+
+import { contentService } from "@/lib/content/content-service";
+import {
+  ConflictError,
+  ForbiddenError,
+  NotFoundError,
+} from "@/lib/content/errors";
+import type { Requester } from "@/lib/content/types";
+
+const owner: Requester = { kind: "user", userId: 7, roles: ["staff"], isAdmin: false };
+
+const OBJ_ID = "11111111-1111-1111-1111-111111111111";
+const baseObj = {
+  id: OBJ_ID,
+  slug: "my-doc",
+  title: "My Doc",
+  kind: "document",
+  ownerUserId: 7,
+  visibilityLevel: "internal",
+  status: "draft",
+  tags: [],
+};
+
+beforeEach(() => {
+  callOrder.length = 0;
+  queryResults.length = 0;
+  txSelectQueue.length = 0;
+  txDeleteCalls.length = 0;
+  capturedAuditEntry = null;
+  canViewMock.mockClear();
+  canViewMock.mockResolvedValue(true);
+  assertCanDeleteMock.mockClear();
+  assertCanDeleteMock.mockReset();
+  removeFromIndexMock.mockClear();
+  liveDestinationsMock.mockClear();
+  liveDestinationsMock.mockResolvedValue([]);
+  // Only clear call history — keep the default implementation that records the
+  // "s3" call-order marker (mockResolvedValue would discard it).
+  deleteObjectTreeMock.mockClear();
+});
+
+/** Queue the tx SELECT results for a normal (deletable) object: lock, no live, 3 versions. */
+function queueSuccessfulTx() {
+  txSelectQueue.push(
+    [{ id: OBJ_ID }], // FOR UPDATE lock
+    [], // live publications (none)
+    [{ value: 3 }] // version count
+  );
+}
+
+describe("contentService.delete", () => {
+  it("404s (NotFound) and never reaches the permission check when not viewable", async () => {
+    queryResults.push([{ ...baseObj }]); // loadByIdOrSlug
+    canViewMock.mockResolvedValue(false);
+    await expect(contentService.delete(owner, OBJ_ID, { surface: "rest" })).rejects.toThrow(
+      NotFoundError
+    );
+    // Existence-mask precedes any permission signal.
+    expect(assertCanDeleteMock).not.toHaveBeenCalled();
+    expect(removeFromIndexMock).not.toHaveBeenCalled();
+  });
+
+  it("404s when the object does not exist", async () => {
+    queryResults.push([]); // loadByIdOrSlug → empty
+    await expect(contentService.delete(owner, OBJ_ID, { surface: "rest" })).rejects.toThrow(
+      NotFoundError
+    );
+  });
+
+  it("403s (Forbidden) when the requester is not owner/admin", async () => {
+    queryResults.push([{ ...baseObj }]);
+    assertCanDeleteMock.mockImplementation(() => {
+      throw new ForbiddenError("Not permitted to delete this content");
+    });
+    await expect(contentService.delete(owner, OBJ_ID, { surface: "rest" })).rejects.toThrow(
+      ForbiddenError
+    );
+    expect(removeFromIndexMock).not.toHaveBeenCalled();
+  });
+
+  it("409s (Conflict) on the fast pre-flight when a destination is live — never auto-retracts", async () => {
+    queryResults.push([{ ...baseObj, status: "published" }]);
+    liveDestinationsMock.mockResolvedValue(["intranet"]);
+    await expect(
+      contentService.delete(owner, OBJ_ID, { surface: "rest" })
+    ).rejects.toMatchObject({ status: 409 });
+    // Index is NOT pruned and nothing is deleted when the guard blocks.
+    expect(removeFromIndexMock).not.toHaveBeenCalled();
+    expect(txDeleteCalls).toHaveLength(0);
+  });
+
+  it("409s from the AUTHORITATIVE in-tx re-check even if the pre-flight passed (TOCTOU)", async () => {
+    queryResults.push([{ ...baseObj }]);
+    liveDestinationsMock.mockResolvedValue([]); // pre-flight sees none…
+    txSelectQueue.push(
+      [{ id: OBJ_ID }], // lock
+      [{ destination: "intranet" }] // …but the locked row IS live now
+    );
+    await expect(
+      contentService.delete(owner, OBJ_ID, { surface: "rest" })
+    ).rejects.toBeInstanceOf(ConflictError);
+    // No audit / no delete when the in-tx guard rejects.
+    expect(txDeleteCalls).toHaveLength(0);
+  });
+
+  it("deletes: prunes index BEFORE the tx, writes a delete audit with details, deletes the row, cleans S3 after", async () => {
+    queryResults.push([{ ...baseObj }]);
+    queueSuccessfulTx();
+
+    const result = await contentService.delete(owner, OBJ_ID, { surface: "ui" });
+
+    expect(result).toEqual({
+      id: OBJ_ID,
+      slug: "my-doc",
+      title: "My Doc",
+      kind: "document",
+      versionsDeleted: 3,
+    });
+
+    // Ordering: sanctioned index removal → transaction → S3 cleanup.
+    expect(callOrder).toEqual(["removeFromIndex", "tx", "s3"]);
+
+    // Two in-tx deletes: the object's nav entry (NO ACTION FK, not cascaded), then
+    // the object row (cascade removes the remaining children).
+    expect(txDeleteCalls).toHaveLength(2);
+
+    // The delete audit captured the identity the cascade erases.
+    expect(capturedAuditEntry).toMatchObject({
+      action: "delete",
+      surface: "ui",
+      objectId: OBJ_ID,
+      outcome: "ok",
+      details: {
+        title: "My Doc",
+        kind: "document",
+        ownerUserId: 7,
+        versionsDeleted: 3,
+      },
+    });
+
+    expect(deleteObjectTreeMock).toHaveBeenCalledWith(OBJ_ID);
+  });
+
+  it("still succeeds when S3 cleanup fails (best-effort, orphaned keys acceptable)", async () => {
+    queryResults.push([{ ...baseObj }]);
+    queueSuccessfulTx();
+    deleteObjectTreeMock.mockRejectedValueOnce(new Error("s3 boom"));
+
+    const result = await contentService.delete(owner, OBJ_ID, { surface: "rest" });
+    expect(result.id).toBe(OBJ_ID);
+    // The DB deletes (nav + object) committed regardless of the S3 failure.
+    expect(txDeleteCalls).toHaveLength(2);
+  });
+});

--- a/tests/unit/atrium-embed-deleted-artifact.test.ts
+++ b/tests/unit/atrium-embed-deleted-artifact.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Regression test for Atrium hard delete: an embed that points at a HARD-DELETED
+ * artifact must degrade to the quiet "unavailable" placeholder (never a broken
+ * render, never a leaked title/code). `resolveEmbedForReader` masks an absent
+ * object identically to a hidden one — deleting an artifact that other documents
+ * embed is safe by design (the resolver + the content_embed_links CASCADE handle it).
+ */
+
+const queryResults: Array<Array<Record<string, unknown>>> = [];
+
+jest.mock("@/lib/db/drizzle-client", () => ({
+  executeQuery: jest.fn(async () => queryResults.shift() ?? []),
+}));
+jest.mock("@/lib/db/schema", () => ({
+  contentObjects: {
+    id: "id",
+    kind: "kind",
+    ownerUserId: "ownerUserId",
+    visibilityLevel: "visibilityLevel",
+    title: "title",
+    slug: "slug",
+  },
+  contentPublications: {
+    objectId: "objectId",
+    destination: "destination",
+    status: "status",
+    publishedVersionId: "publishedVersionId",
+  },
+}));
+jest.mock("drizzle-orm", () => ({
+  and: (...a: unknown[]) => a,
+  eq: (...a: unknown[]) => a,
+}));
+jest.mock("@/lib/logger", () => ({
+  createLogger: () => ({ info: () => {}, warn: () => {}, error: () => {}, debug: () => {} }),
+}));
+const canViewMock = jest.fn(async (..._a: unknown[]) => true);
+jest.mock("@/lib/content/visibility-service", () => ({
+  visibilityService: { canView: (...a: unknown[]) => canViewMock(...a) },
+}));
+jest.mock("@/lib/content/version-service", () => ({
+  versionService: {
+    current: jest.fn(async () => ({ versionNumber: 1 })),
+    getById: jest.fn(async () => ({ versionNumber: 1 })),
+    loadArtifactCode: jest.fn(async () => "<html>live</html>"),
+  },
+}));
+jest.mock("@/lib/content/artifact-sandbox-config", () => ({
+  getArtifactSandboxRenderUrl: () => "https://sandbox.example/render",
+}));
+jest.mock("@/lib/content/embed-directive", () => ({ isArtifactId: () => true }));
+jest.mock("@/lib/content/render/document-parts", () => ({
+  renderDocumentToParts: () => [],
+}));
+
+import { resolveEmbedForReader } from "@/lib/content/embed-resolver";
+import type { Requester } from "@/lib/content/types";
+
+const requester: Requester = { kind: "user", userId: 7, roles: ["staff"], isAdmin: false };
+const ART_ID = "22222222-2222-2222-2222-222222222222";
+
+beforeEach(() => {
+  queryResults.length = 0;
+  canViewMock.mockClear();
+  canViewMock.mockResolvedValue(true);
+});
+
+describe("resolveEmbedForReader: deleted artifact degrades gracefully", () => {
+  it("returns an UNAVAILABLE placeholder (no title/href/code) for a deleted artifact id", async () => {
+    queryResults.push([]); // the artifact row is gone (hard-deleted)
+    const embed = await resolveEmbedForReader(ART_ID, {
+      audience: "internal",
+      requester,
+    });
+    expect(embed).toEqual({
+      artifactId: ART_ID,
+      available: false,
+      title: null,
+      href: null,
+      code: "",
+      sandboxSrc: null,
+    });
+    // Never even consults visibility for an absent object.
+    expect(canViewMock).not.toHaveBeenCalled();
+  });
+
+  it("still renders a live, viewable artifact (positive control — mask is delete-specific)", async () => {
+    queryResults.push([
+      {
+        id: ART_ID,
+        kind: "artifact",
+        ownerUserId: 7,
+        visibilityLevel: "internal",
+        title: "Live Chart",
+        slug: "live-chart",
+      },
+    ]);
+    const embed = await resolveEmbedForReader(ART_ID, {
+      audience: "internal",
+      requester,
+    });
+    expect(embed.available).toBe(true);
+    expect(embed.title).toBe("Live Chart");
+    expect(embed.code).toBe("<html>live</html>");
+  });
+});

--- a/tests/unit/lib/nexus/workspace-chat-tools.test.ts
+++ b/tests/unit/lib/nexus/workspace-chat-tools.test.ts
@@ -25,6 +25,7 @@ const createVersionMock = jest.fn();
 const deleteMock = jest.fn();
 const listMock = jest.fn();
 const canEditMock = jest.fn();
+const canDeleteMock = jest.fn();
 const requesterMock = jest.fn();
 const applyAgentEditMock = jest.fn();
 const readAgentDocMarkdownMock = jest.fn();
@@ -53,6 +54,7 @@ jest.mock("@/lib/content/collab/snapshot-before-publish", () => ({
 }));
 jest.mock("@/lib/content/helpers", () => ({
   canEdit: (...a: unknown[]) => canEditMock(...a),
+  canDelete: (...a: unknown[]) => canDeleteMock(...a),
 }));
 jest.mock("@/lib/content/requester-from-auth", () => ({
   requesterForUserId: (...a: unknown[]) => requesterMock(...a),
@@ -88,6 +90,10 @@ const exec = (t: unknown, args: unknown = {}) => (t as ExecTool).execute(args, {
 
 beforeEach(() => {
   jest.clearAllMocks();
+  // canDelete mirrors canEdit by default (identical for a session user), so tests
+  // that toggle canEditMock also drive the delete-tool bind. Override canDeleteMock
+  // alone to exercise the deliberate canDelete-vs-canEdit decoupling.
+  canDeleteMock.mockImplementation((...a: unknown[]) => canEditMock(...a));
   requesterMock.mockResolvedValue(REQ);
   screenMock.mockResolvedValue({ allowed: true });
   applyAgentEditMock.mockResolvedValue(undefined);
@@ -158,6 +164,18 @@ describe("buildWorkspaceChatTools", () => {
         "update_workspace_artifact",
       ].sort()
     );
+  });
+
+  it("does NOT bind delete_workspace_content when canDelete is false even if canEdit is true (decoupling)", async () => {
+    getMock.mockResolvedValue(DOC);
+    canEditMock.mockReturnValue(true);
+    // Simulate a future world where edit widened (e.g. collaborator grants) but the
+    // requester is not the owner/admin — delete must NOT be offered.
+    canDeleteMock.mockReturnValue(false);
+    const result = await buildWorkspaceChatTools({ workspaceIdOrSlug: "doc-1", userId: 7, requestId: "r" });
+    expect(Object.keys(result!.tools)).not.toContain("delete_workspace_content");
+    // Edit is still bound (canEdit true) — only delete is gated off.
+    expect(Object.keys(result!.tools)).toContain("edit_workspace_document");
   });
 
   it("delete_workspace_content deletes via the service (surface 'ui') and reports success", async () => {

--- a/tests/unit/lib/nexus/workspace-chat-tools.test.ts
+++ b/tests/unit/lib/nexus/workspace-chat-tools.test.ts
@@ -22,6 +22,7 @@ jest.mock("@/lib/content/render/html-sanitize", () => ({ sanitizeHtml: jest.fn()
 
 const getMock = jest.fn();
 const createVersionMock = jest.fn();
+const deleteMock = jest.fn();
 const listMock = jest.fn();
 const canEditMock = jest.fn();
 const requesterMock = jest.fn();
@@ -37,6 +38,7 @@ jest.mock("@/lib/content/content-service", () => ({
   contentService: {
     get: (...a: unknown[]) => getMock(...a),
     createVersion: (...a: unknown[]) => createVersionMock(...a),
+    delete: (...a: unknown[]) => deleteMock(...a),
     list: (...a: unknown[]) => listMock(...a),
   },
 }));
@@ -70,7 +72,11 @@ jest.mock("@/lib/logger", () => ({
 }));
 
 import { buildWorkspaceChatTools } from "@/lib/nexus/workspace-chat-tools";
-import { ApprovalRequiredError } from "@/lib/content/errors";
+import {
+  ApprovalRequiredError,
+  ConflictError,
+  ForbiddenError,
+} from "@/lib/content/errors";
 
 const REQ = { kind: "user", userId: 7, isAdmin: false };
 const DOC = { id: "doc-1", kind: "document", title: "My Doc", ownerUserId: 7, version: { bodyFormat: "markdown", bodyInline: "# Hi", versionNumber: 3 } };
@@ -92,6 +98,7 @@ beforeEach(() => {
   unpublishMock.mockResolvedValue({ unpublished: true });
   snapshotBeforePublishMock.mockResolvedValue(undefined);
   listMock.mockResolvedValue([]);
+  deleteMock.mockResolvedValue({ id: "doc-1", slug: "my-doc", title: "My Doc", kind: "document", versionsDeleted: 3 });
 });
 
 // The find/edit-by-id ITEM 3 tools are bound whenever a workspace is open (they
@@ -128,6 +135,7 @@ describe("buildWorkspaceChatTools", () => {
     expect(Object.keys(result!.tools).sort()).toEqual(
       [
         ...ITEM3,
+        "delete_workspace_content",
         "edit_workspace_document",
         "publish_workspace_content",
         "read_workspace_content",
@@ -143,12 +151,47 @@ describe("buildWorkspaceChatTools", () => {
     expect(Object.keys(result!.tools).sort()).toEqual(
       [
         ...ITEM3,
+        "delete_workspace_content",
         "publish_workspace_content",
         "read_workspace_content",
         "unpublish_workspace_content",
         "update_workspace_artifact",
       ].sort()
     );
+  });
+
+  it("delete_workspace_content deletes via the service (surface 'ui') and reports success", async () => {
+    getMock.mockResolvedValue(DOC);
+    canEditMock.mockReturnValue(true);
+    const { tools } = (await buildWorkspaceChatTools({ workspaceIdOrSlug: "doc-1", userId: 7, requestId: "r" }))!;
+    const out = (await exec(tools.delete_workspace_content)) as Record<string, unknown>;
+    expect(deleteMock).toHaveBeenCalledWith(REQ, "doc-1", { surface: "ui" });
+    expect(out.ok).toBe(true);
+    expect(out.deleted).toBe(true);
+    expect(out.title).toBe("My Doc");
+  });
+
+  it("delete_workspace_content surfaces the live-publication refusal (409) so the model relays it", async () => {
+    getMock.mockResolvedValue(DOC);
+    canEditMock.mockReturnValue(true);
+    deleteMock.mockRejectedValue(
+      new ConflictError("Cannot delete published content — unpublish from intranet first, then delete.")
+    );
+    const { tools } = (await buildWorkspaceChatTools({ workspaceIdOrSlug: "doc-1", userId: 7, requestId: "r" }))!;
+    const out = (await exec(tools.delete_workspace_content)) as Record<string, unknown>;
+    expect(out.blocked).toBe(true);
+    expect(out.reason).toBe("published");
+    expect(String(out.message)).toContain("unpublish");
+  });
+
+  it("delete_workspace_content returns a permission error (not blocked) on a Forbidden", async () => {
+    getMock.mockResolvedValue(DOC);
+    canEditMock.mockReturnValue(true);
+    deleteMock.mockRejectedValue(new ForbiddenError("Not permitted to delete this content"));
+    const { tools } = (await buildWorkspaceChatTools({ workspaceIdOrSlug: "doc-1", userId: 7, requestId: "r" }))!;
+    const out = (await exec(tools.delete_workspace_content)) as Record<string, unknown>;
+    expect(out.blocked).toBeUndefined();
+    expect(String(out.error)).toMatch(/permission|owner|administrator/i);
   });
 
   it("edit_workspace_document screens then applies via the agent bridge (append default)", async () => {


### PR DESCRIPTION
## Summary

Atrium (Epic #1059) shipped with no way to remove content — only status archival. This adds a real, safety-gated **hard delete** for content objects across every surface (service, REST v1, psd-atrium skill, Nexus workspace chat, and the Meridian UI), so the agent and users can clean up junk content.

## Guard semantics (all must hold; ordered so existence is never revealed)

- **404** existence-mask (`canView`) BEFORE any permission signal;
- **403** unless the requester is the object's **owner** or an **admin** (agents also need the new `content:delete` scope) — a dedicated `assertCanDelete` predicate, deliberately not `canEdit`, so a future widening of edit can never hand out delete;
- **409** while the object is **live at any publish destination** — delete NEVER auto-retracts; the caller must unpublish first. Checked as a fast pre-flight AND authoritatively on the FOR-UPDATE-locked row inside the delete transaction (TOCTOU-safe).

Any kind/status otherwise (draft / archived / private / internal) is deletable — the guards are the protection, not the lifecycle status.

## Cascade (one transaction; external cleanup ordered so failure can't orphan DB state)

- Retrieval-index removal runs via the sanctioned `retrievalService.removeFromIndex` **before** the tx (it reads `content_index_links` to find the SHARED `repository_item`; the object-delete cascade would otherwise erase that link and orphan the shared rows).
- In the tx: write a `delete` audit row capturing the removed object's title/kind/owner/versionsDeleted (the object_id becomes a dangling UUID after — the only durable record of what was removed), delete the object's intranet **nav entry** (`navigation_items.content_object_id` is `NO ACTION`, and unpublish only soft-hides it), then delete the object row — cascading `content_versions`, `content_publications`, `atrium_doc_state`, `atrium_doc_comments`, `content_embed_links`, `content_visibility_grants`, `content_publish_requests`, `content_index_links`. `content_audit_logs` has no FK to the object, so the trail SURVIVES.
- After commit (best-effort, logged): S3 body-tree delete (`atrium/objects/{id}/`) and a `content.deleted` event. Orphaned S3 keys are acceptable.

## Surfaces

- `contentService.delete` + `canDelete`/`assertCanDelete`.
- `DELETE /api/v1/content/{id}` — new `content:delete` scope (API_SCOPES + `ROLE_SCOPES.staff`; administrator via ALL_SCOPES; added to the key-bootstrap `KEY_SCOPES` so the scope-tether test stays green and the deployed agent key self-heals on the next deploy).
- psd-atrium skill: `delete` subcommand (owner / live-publication refusals relayed verbatim); Phase-1-no-delete claims removed.
- Nexus workspace chat: `delete_workspace_content` tool (session user, owner/admin, same service guards).
- UI: Meridian "Delete permanently" affordance in ContentSettings (owner/admin server-gated; confirm-permanence dialog; disabled with an explanation while a publication is live). Reader/editor routes 404 after deletion.
- Collab hardening: `getOrCreateDoc` now fails closed for a deleted object (a pre-minted collab token can no longer open a just-deleted doc's room within its TTL).

## Verification (all green before opening)

- Build/lint (zero-warning): ✅   Typecheck: ✅ (only pre-existing `.next/types` errors)
- Unit: ✅ 689 passed (full Atrium + Nexus + scopes suites), incl. new coverage for every guard (404-before-403, 403 owner/admin, 409 live pre-flight + in-tx TOCTOU, admin override, audit-with-details, removeFromIndex-before-tx ordering, nav + object cascade delete, S3 best-effort), the `canDelete` predicate, the embed-of-deleted mask, and the workspace `delete_workspace_content` tool.
- E2E: ✅ authed `atrium-delete.functional` (all 3) — create→delete→404, published→409→unpublish→delete, and the UI "Delete permanently" flow (open editor settings → confirm → back to library → 404).

## Evidence

The UI delete flow is exercised end-to-end by the authenticated E2E spec `tests/e2e/atrium-delete.functional.spec.ts` (test 3: open the editor content-settings dialog → click "Delete permanently" → confirm → land back on the library → the object 404s), which passes against the real service + DB on the :3100 host server. No static screenshots were captured for this change.

## Deploy-gated

- Migration 105 (`content_audit_logs.details`) applies on the next DB deploy (applied to local Postgres for the E2E run).
- The deployed psd-atrium agent key re-mints to the new `content:delete` scope set on the next AgentPlatformStack deploy (scope-drift re-mint).
- The agent image must be rebuilt/pushed for the skill's `delete` subcommand to reach the running agent.
