### PR TITLE
Group sync Phase 2: Atrium 'group' grant kind — direct group shares on content (#1205)

### DIFF
--- a/actions/db/atrium/list-grant-options.ts
+++ b/actions/db/atrium/list-grant-options.ts
@@ -4,16 +4,17 @@
  * Atrium list-grant-options server action
  *
  * Issue #1053 (Epic #1059, Atrium Phase 3). Supplies the visibility editor's
- * group-grant builder with the selectable options it can enumerate — currently
- * the set of role NAMES (a `role` grant matches `principal.roles`, which are role
- * names; see visibility-service §12.2). Building / department / grade are
+ * group-grant builder with the selectable options it can enumerate — the set of
+ * role NAMES (a `role` grant matches `principal.roles`, which are role names; see
+ * visibility-service §12.2) and the synced Google groups (#1205; a `group` grant
+ * matches `principal.groups` by group email). Building / department / grade are
  * free-form `users` attributes with no reference table, so the editor accepts
  * those as free text; `user` grants take a numeric `users.id`.
  *
  * Gated by the Atrium authoring capability (not admin): any author building a
- * group grant needs the role list, and the admin `getRoles` is admin-only.
- * Returning role names is not sensitive — they are the same names surfaced on
- * every role-gated UI.
+ * group grant needs the role + group lists, and the admin `getRoles` is admin-only.
+ * Returning role names / group emails is not sensitive — they are the same names
+ * surfaced on every role-gated UI and the group-directory admin page.
  */
 
 import {
@@ -25,6 +26,10 @@ import { createSuccess, handleError, ErrorFactories } from "@/lib/error-utils";
 import { executeQuery } from "@/lib/db/drizzle-client";
 import { roles } from "@/lib/db/schema";
 import { asc } from "drizzle-orm";
+import {
+  listActiveGroupsForPicker,
+  type GroupPickerOption,
+} from "@/lib/groups/queries";
 import type { ActionState } from "@/types";
 import { hasCapabilityAccess } from "@/utils/roles";
 import { getServerSession } from "@/lib/auth/server-session";
@@ -33,6 +38,11 @@ import { getUserRequester } from "./requester";
 export interface GrantOptions {
   /** Role names selectable for a `role` grant (matched against principal roles). */
   roles: string[];
+  /**
+   * Active synced Google groups selectable for a `group` grant (#1205). The stored
+   * grant value is `email` (lowercased); `name` is display-only.
+   */
+  groups: GroupPickerOption[];
 }
 
 export async function listGrantOptionsAction(): Promise<ActionState<GrantOptions>> {
@@ -54,15 +64,22 @@ export async function listGrantOptionsAction(): Promise<ActionState<GrantOptions
       throw ErrorFactories.authzToolAccessDenied("atrium-content");
     }
 
-    const roleRows = await executeQuery(
-      (db) => db.select({ name: roles.name }).from(roles).orderBy(asc(roles.name)),
-      "atrium.listGrantOptions.roles"
-    );
+    // Role names and active groups are independent lookups — run concurrently.
+    const [roleRows, groupOptions] = await Promise.all([
+      executeQuery(
+        (db) => db.select({ name: roles.name }).from(roles).orderBy(asc(roles.name)),
+        "atrium.listGrantOptions.roles"
+      ),
+      listActiveGroupsForPicker(),
+    ]);
 
     timer({ status: "success" });
-    log.info("Grant options loaded", { roleCount: roleRows.length });
+    log.info("Grant options loaded", {
+      roleCount: roleRows.length,
+      groupCount: groupOptions.length,
+    });
     return createSuccess(
-      { roles: roleRows.map((r) => r.name) },
+      { roles: roleRows.map((r) => r.name), groups: groupOptions },
       "Grant options loaded"
     );
   } catch (error) {

--- a/actions/db/atrium/requester.ts
+++ b/actions/db/atrium/requester.ts
@@ -23,6 +23,7 @@ import { executeQuery } from "@/lib/db/drizzle-client";
 import { users } from "@/lib/db/schema";
 import { getServerSession, type CognitoSession } from "@/lib/auth/server-session";
 import { getUserRoles } from "@/lib/db/user-roles";
+import { listUserGroupEmailsByUserId } from "@/lib/groups/queries";
 import { ErrorFactories } from "@/lib/error-utils";
 import { createLogger, generateRequestId } from "@/lib/logger";
 import type { Requester } from "@/lib/content";
@@ -47,6 +48,9 @@ const GUEST_REQUESTER: Requester = Object.freeze({
   building: null,
   department: null,
   gradeLevels: null,
+  // A guest belongs to no synced group (no user identity) — empty match set for
+  // `group`-kind grants (#1205).
+  groups: [],
   isAdmin: false,
 });
 
@@ -101,8 +105,18 @@ async function resolveAuthenticatedRequester(
     return null;
   }
 
-  const roles = await getUserRoles(user.id);
-  log.debug("Resolved Atrium requester", { userId: user.id, roleCount: roles.length });
+  // Roles and group memberships are independent lookups — run them concurrently.
+  // `groups` (the user's synced group emails) powers `group`-kind visibility
+  // grants (#1205); it is `[]` for a user with no memberships.
+  const [roles, groups] = await Promise.all([
+    getUserRoles(user.id),
+    listUserGroupEmailsByUserId(user.id),
+  ]);
+  log.debug("Resolved Atrium requester", {
+    userId: user.id,
+    roleCount: roles.length,
+    groupCount: groups.length,
+  });
 
   return {
     kind: "user",
@@ -111,6 +125,7 @@ async function resolveAuthenticatedRequester(
     building: user.building,
     department: user.department,
     gradeLevels: user.gradeLevels,
+    groups,
     isAdmin: roles.includes(ADMIN_ROLE),
   };
 }

--- a/components/atrium/VisibilityChip.tsx
+++ b/components/atrium/VisibilityChip.tsx
@@ -5,16 +5,18 @@
  *
  * The shared panel-header control that shows an object's current visibility level
  * and opens the visibility editor: a level picker (private / group / internal /
- * public) plus a group-grant builder (role / building / department / grade / user
- * grants). It reads the current state via `getVisibilityAction` and persists via
- * `setVisibilityAction` — both of which run the `canView` + `assertCanEdit` gates
- * server-side, so this UI is presentation only (no authorization logic here).
+ * public) plus a group-grant builder (role / building / department / grade / user /
+ * group grants). It reads the current state via `getVisibilityAction` and persists
+ * via `setVisibilityAction` — both of which run the `canView` + `assertCanEdit`
+ * gates server-side, so this UI is presentation only (no authorization logic here).
  *
  * Grant value semantics (mirror visibility-service §12.2):
  * - role        — a role NAME (selected from the role list), matched against the
  *                 viewer's roles.
  * - building / department / grade — a free-form `users` attribute string.
  * - user        — a numeric `users.id`.
+ * - group       — a synced Google group EMAIL (selected from the group list),
+ *                 matched against the viewer's group memberships (#1205).
  *
  * For a viewer who cannot edit (not owner/admin), the chip renders read-only:
  * the badge shows the level, the dialog's controls are disabled, and Save is
@@ -52,7 +54,7 @@ import { POSITIVE_INT_RE } from "@/lib/content/validators";
 /** The visibility levels, in widening order, with their picker labels. */
 const LEVELS = [
   { value: "private", label: "Private", help: "Only you (and admins)." },
-  { value: "group", label: "Group", help: "Specific roles, buildings, departments, grades, or people." },
+  { value: "group", label: "Group", help: "Specific roles, buildings, departments, grades, people, or Google groups." },
   { value: "internal", label: "Internal", help: "Any signed-in user." },
   { value: "public", label: "Public", help: "Anyone, including signed-out visitors." },
 ] as const;
@@ -64,12 +66,19 @@ const GRANT_KINDS = [
   { value: "department", label: "Department" },
   { value: "grade", label: "Grade" },
   { value: "user", label: "User ID" },
+  { value: "group", label: "Google group" },
 ] as const;
 type GrantKind = (typeof GRANT_KINDS)[number]["value"];
 
 interface Grant {
   kind: GrantKind;
   value: string;
+}
+
+/** A selectable synced group (email is stored; name is display-only). */
+interface GroupOption {
+  email: string;
+  name: string | null;
 }
 
 /** Badge variant + icon + label for a level (the at-a-glance chip). */
@@ -145,58 +154,63 @@ export interface VisibilityChipProps {
 }
 
 /**
- * Lazily load the role options the role-grant dropdown needs (only an editor with
- * the GROUP level open needs them). A boolean ref guards against a re-fetch after a
- * SUCCESSFUL load — but it is set ONLY on success, so a transient failure leaves it
- * `false` and the next time the load condition becomes true again the effect retries.
+ * Lazily load the grant options the role/group-grant dropdowns need (only an editor
+ * with the GROUP level open needs them). One fetch resolves both the role names and
+ * the synced group list. A boolean ref guards against a re-fetch after a SUCCESSFUL
+ * load — but it is set ONLY on success, so a transient failure leaves it `false` and
+ * the next time the load condition becomes true again the effect retries.
  *
  * `groupActive` (level === "group") is a dep precisely so that retry path works: a
- * failed load while on `group` leaves the dropdown empty, and switching the level
+ * failed load while on `group` leaves the dropdowns empty, and switching the level
  * picker away from `group` and back re-runs this effect (groupActive flips
- * false→true) to retry — otherwise a one-time network blip would strand the dropdown
+ * false→true) to retry — otherwise a one-time network blip would strand the dropdowns
  * empty for the entire dialog session with no escape but closing and reopening.
- * `roleOptions.length` is intentionally NOT a dep (depending on it would re-run on
+ * `options` length is intentionally NOT a dep (depending on it would re-run on
  * every option-list change).
  *
  * NOTE: a boolean ref is correct HERE (unlike the parameterized-route anti-pattern
- * in CLAUDE.md) because the role list is GLOBAL — it does not depend on `idOrSlug`
- * or any other prop, so it never needs to reset for a different id. The parent
- * additionally keys `VisibilityChip` on `obj.id`, so the whole component (and this
- * ref) remounts on navigation regardless. Extracted from the component to keep its
- * body under the max-lines lint cap and to isolate the fetch lifecycle.
+ * in CLAUDE.md) because the option lists are GLOBAL — they do not depend on
+ * `idOrSlug` or any other prop, so they never need to reset for a different id. The
+ * parent additionally keys `VisibilityChip` on `obj.id`, so the whole component (and
+ * this ref) remounts on navigation regardless. Extracted from the component to keep
+ * its body under the max-lines lint cap and to isolate the fetch lifecycle.
  */
-function useRoleOptions(
+function useGrantOptions(
   open: boolean,
   canEdit: boolean,
   groupActive: boolean,
   onError: (message: string) => void
-): string[] {
+): { roles: string[]; groups: GroupOption[] } {
   const [roleOptions, setRoleOptions] = useState<string[]>([]);
-  const roleOptionsLoaded = useRef(false);
+  const [groupOptions, setGroupOptions] = useState<GroupOption[]>([]);
+  const optionsLoaded = useRef(false);
   useEffect(() => {
-    if (!open || !canEdit || !groupActive || roleOptionsLoaded.current) return;
+    if (!open || !canEdit || !groupActive || optionsLoaded.current) return;
     let cancelled = false;
     void (async () => {
       // try/catch so a THROWN fetch (network error) still surfaces an error
-      // rather than silently leaving the role dropdown empty with no explanation.
+      // rather than silently leaving the dropdowns empty with no explanation.
       try {
         const result = await listGrantOptionsAction();
         if (cancelled) return;
         if (result.isSuccess) {
-          roleOptionsLoaded.current = true;
+          optionsLoaded.current = true;
           setRoleOptions(result.data.roles);
+          // `?? []` defends against an older action shape (or a partial test mock)
+          // that omits `groups` — an undefined would break the picker's `.map`.
+          setGroupOptions(result.data.groups ?? []);
         } else {
-          // Surface the failure so the user knows why the role dropdown is empty.
-          // `roleOptionsLoaded` stays false, so returning to the group editor
+          // Surface the failure so the user knows why the dropdowns are empty.
+          // `optionsLoaded` stays false, so returning to the group editor
           // (groupActive false→true) retries this load.
           onError(result.message);
         }
       } catch {
         if (!cancelled) {
           // Same retry-on-return semantics as the !isSuccess branch above:
-          // `roleOptionsLoaded` is untouched, so the load reattempts when the
+          // `optionsLoaded` is untouched, so the load reattempts when the
           // user switches the level picker back to `group`.
-          onError("Failed to load role options — switch the level away and back to retry.");
+          onError("Failed to load grant options — switch the level away and back to retry.");
         }
       }
     })();
@@ -204,16 +218,17 @@ function useRoleOptions(
       cancelled = true;
     };
   }, [open, canEdit, groupActive, onError]);
-  return roleOptions;
+  return { roles: roleOptions, groups: groupOptions };
 }
 
 /**
  * Mirror the server's grant reconciliation so the chip's local `savedGrants` never
  * diverges from what was actually persisted: group keeps all supplied grants,
  * private PRESERVES `user`-kind grants (both read paths honor them), internal/public
- * clear everything. Values are trimmed and (kind,value)-deduped to match the
- * server's `applyGrantsInTx` normalization — otherwise a later Cancel would restore
- * un-trimmed draft values as the "last persisted" state.
+ * clear everything. Values are trimmed, `group` emails lowercased, and
+ * (kind,value)-deduped to match the server's `applyGrantsInTx` normalization —
+ * otherwise a later Cancel would restore un-normalized draft values as the "last
+ * persisted" state.
  */
 function reconcileSavedGrants(level: Level, grants: Grant[]): Grant[] {
   const kept =
@@ -225,7 +240,10 @@ function reconcileSavedGrants(level: Level, grants: Grant[]): Grant[] {
   const seen = new Set<string>();
   const normalized: Grant[] = [];
   for (const g of kept) {
-    const value = g.value.trim();
+    // `group` values are lowercased (emails are case-insensitive); other kinds
+    // keep their case — mirrors the server's `normalizeGrantValue`.
+    const trimmed = g.value.trim();
+    const value = g.kind === "group" ? trimmed.toLowerCase() : trimmed;
     const key = `${g.kind}:${value}`;
     if (value.length === 0 || seen.has(key)) continue;
     seen.add(key);
@@ -366,10 +384,15 @@ export function VisibilityChip({ idOrSlug, onChange }: VisibilityChipProps) {
     };
   }, [idOrSlug]);
 
-  // Role options for the group-grant builder, loaded lazily when the GROUP editor
-  // is open. Passing `level === "group"` lets a failed load retry when the user
-  // switches the level picker away from group and back (see useRoleOptions).
-  const roleOptions = useRoleOptions(open, canEdit, level === "group", setError);
+  // Role + group options for the group-grant builder, loaded lazily when the GROUP
+  // editor is open. Passing `level === "group"` lets a failed load retry when the
+  // user switches the level picker away from group and back (see useGrantOptions).
+  const { roles: roleOptions, groups: groupOptions } = useGrantOptions(
+    open,
+    canEdit,
+    level === "group",
+    setError
+  );
 
   // Changing the level clears any stale error: a transient `useRoleOptions`
   // failure (or a prior save/validation error) is no longer actionable once the
@@ -465,6 +488,7 @@ export function VisibilityChip({ idOrSlug, onChange }: VisibilityChipProps) {
               canEdit={canEdit}
               saving={saving}
               roleOptions={roleOptions}
+              groupOptions={groupOptions}
               onAdd={addGrant}
               onRemove={removeGrant}
             />
@@ -535,6 +559,7 @@ interface GroupGrantEditorProps {
   canEdit: boolean;
   saving: boolean;
   roleOptions: string[];
+  groupOptions: GroupOption[];
   onAdd: (grant: Grant) => void;
   onRemove: (index: number) => void;
 }
@@ -549,6 +574,7 @@ function GroupGrantEditor({
   canEdit,
   saving,
   roleOptions,
+  groupOptions,
   onAdd,
   onRemove,
 }: GroupGrantEditorProps) {
@@ -556,7 +582,10 @@ function GroupGrantEditor({
   const [draftValue, setDraftValue] = useState("");
 
   const submit = useCallback(() => {
-    const value = draftValue.trim();
+    // `group` values are emails (lowercased server-side and here so the local chip
+    // matches what is persisted); other kinds keep their case.
+    const trimmed = draftValue.trim();
+    const value = draftKind === "group" ? trimmed.toLowerCase() : trimmed;
     if (!value) return;
     onAdd({ kind: draftKind, value });
     setDraftValue("");
@@ -636,6 +665,29 @@ function GroupGrantEditor({
                   {roleOptions.map((r) => (
                     <SelectItem key={r} value={r}>
                       {r}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            ) : draftKind === "group" ? (
+              <Select
+                value={draftValue}
+                onValueChange={setDraftValue}
+                disabled={saving}
+              >
+                <SelectTrigger id="grant-value">
+                  <SelectValue
+                    placeholder={
+                      groupOptions.length === 0
+                        ? "No synced groups"
+                        : "Select a group"
+                    }
+                  />
+                </SelectTrigger>
+                <SelectContent className={meridianPortalClassName}>
+                  {groupOptions.map((g) => (
+                    <SelectItem key={g.email} value={g.email}>
+                      {g.name ? `${g.name} (${g.email})` : g.email}
                     </SelectItem>
                   ))}
                 </SelectContent>

--- a/docs/API/v1/context-graph.md
+++ b/docs/API/v1/context-graph.md
@@ -1029,7 +1029,7 @@ Requires `content:update`.
 | `level` | `private` \| `group` \| `internal` \| `public` | yes | — |
 | `grants` | `{ kind, value }[]` | no | Only meaningful when `level` is `group` |
 
-`grants[].kind` is one of `role`, `building`, `department`, `grade`, `user`; `value` is the matching identifier.
+`grants[].kind` is one of `role`, `building`, `department`, `grade`, `user`, `group`; `value` is the matching identifier (for `group`, the synced Google group's lowercase email).
 
 **Example request:**
 
@@ -1381,6 +1381,6 @@ Create / get responses additionally include a `version` object (the current
 |-------|------|-------------|
 | `level` | `private` \| `group` \| `internal` \| `public` | Base visibility |
 | `grants` | `{ kind, value }[]` | Group widening; only meaningful when `level` is `group` |
-| `grants[].kind` | `role` \| `building` \| `department` \| `grade` \| `user` | Dimension to widen along |
+| `grants[].kind` | `role` \| `building` \| `department` \| `grade` \| `user` \| `group` | Dimension to widen along (`group` = synced Google group email) |
 | `grants[].value` | string | Matching identifier for that dimension |
 

--- a/docs/API/v1/openapi.yaml
+++ b/docs/API/v1/openapi.yaml
@@ -2648,7 +2648,7 @@ components:
       properties:
         kind:
           type: string
-          enum: [role, building, department, grade, user]
+          enum: [role, building, department, grade, user, group]
         value:
           type: string
 

--- a/infra/agent-image/skills/psd-atrium/common.js
+++ b/infra/agent-image/skills/psd-atrium/common.js
@@ -338,7 +338,7 @@ function parseList(value, label = 'tags') {
 function parseGrants(value, label = 'grants') {
   if (value === undefined) return undefined;
   if (value === true) fail(`--${label} requires a value`);
-  const VALID = ['role', 'building', 'department', 'grade', 'user'];
+  const VALID = ['role', 'building', 'department', 'grade', 'user', 'group'];
   const grants = [];
   for (const raw of String(value).split(',')) {
     const entry = raw.trim();

--- a/infra/agent-image/skills/psd-atrium/common.test.js
+++ b/infra/agent-image/skills/psd-atrium/common.test.js
@@ -282,6 +282,22 @@ test('parseGrants parses kind:value pairs', () => {
   expect(common.parseGrants(undefined)).toBeUndefined();
 });
 
+test('parseGrants accepts the group kind (#1205, value = group email)', () => {
+  expect(common.parseGrants('group:hs-staff-group@example.com')).toEqual([
+    { kind: 'group', value: 'hs-staff-group@example.com' },
+  ]);
+});
+
+test('parseGrants rejects an unknown kind (exit 1)', () => {
+  let code;
+  try {
+    common.parseGrants('__evil__:x');
+  } catch (err) {
+    code = err.code;
+  }
+  expect(code).toBe(1);
+});
+
 test('parseGrants rejects a malformed entry (exit 1)', () => {
   let code;
   try {

--- a/infra/database/migrations.json
+++ b/infra/database/migrations.json
@@ -103,6 +103,7 @@
     "106-groups.sql",
     "107-groups-nav-entry.sql",
     "108-aistudio-mcp-service-user.sql",
-    "109-group-role-mappings.sql"
+    "109-group-role-mappings.sql",
+    "110-atrium-group-grant-kind.sql"
   ]
 }

--- a/infra/database/schema/110-atrium-group-grant-kind.sql
+++ b/infra/database/schema/110-atrium-group-grant-kind.sql
@@ -1,0 +1,25 @@
+-- Migration 110: Atrium group-directory grant kind (Epic #1202 Phase 2 / #1205)
+-- Adds the `group` value to the `grant_kind` enum so Atrium content can be shared
+-- directly to a synced Google Directory group (Epic #1202): a `group`-visibility
+-- object grows a `content_visibility_grants` row of kind `group` whose
+-- `grant_value` is the group EMAIL (lowercased). `canView` / `buildVisibilitySql`
+-- match it against the viewer's group memberships (group_members joined on the
+-- user's lowercased email), so a member reads and a non-member is existence-masked
+-- (404) — no role required.
+--
+-- NOTES for the RDS Data API migration runner's statement splitter:
+--   * No PL/pgSQL `DO $$` blocks and no inner `CREATE TYPE` — the splitter only
+--     enters block mode on CREATE TYPE/FUNCTION/DROP TYPE, so the ALTER TYPE below
+--     is treated as an ordinary single statement (mirrors migration 095's
+--     `ALTER TYPE publish_destination ADD VALUE 'okf'`).
+--   * `ALTER TYPE ... ADD VALUE` runs as its own auto-committed statement (the
+--     runner does not wrap the file in one transaction), so the "ADD VALUE cannot
+--     run in a transaction block" pitfall does not apply. The new value is NOT used
+--     elsewhere in this file, so there is no same-transaction-use problem either.
+--   * `grant_kind` is master-owned (created in the 085 Atrium migration, NOT an
+--     immutable 001-005 postgres-owned type), so ADD VALUE succeeds under the
+--     migration role on Aurora — the 42501 owner-privilege failure from
+--     migration 085's postgres-owned enums does not apply here.
+
+-- The directory-group grant kind. Idempotent (IF NOT EXISTS) so a re-run is a no-op.
+ALTER TYPE grant_kind ADD VALUE IF NOT EXISTS 'group';

--- a/lib/content/helpers.ts
+++ b/lib/content/helpers.ts
@@ -145,6 +145,10 @@ export function principalOf(req: Requester): Principal {
         building: req.building,
         department: req.department,
         gradeLevels: req.gradeLevels,
+        // `?? []` so a requester whose resolver did not populate memberships (a
+        // guest, or a test double) yields no group access rather than undefined —
+        // group grants then match no one, failing closed (#1205).
+        groups: req.groups ?? [],
         isAdmin: req.isAdmin,
       };
     case "agent-delegated":
@@ -154,6 +158,8 @@ export function principalOf(req: Requester): Principal {
         building: req.building,
         department: req.department,
         gradeLevels: req.gradeLevels,
+        // A delegated agent inherits the human's group memberships (#1205).
+        groups: req.groups ?? [],
         // A delegated agent never exceeds the human; admin is not inferred here.
         isAdmin: false,
       };
@@ -164,6 +170,8 @@ export function principalOf(req: Requester): Principal {
         building: null,
         department: null,
         gradeLevels: null,
+        // Autonomous agents have no human identity and thus no group memberships.
+        groups: [],
         isAdmin: false,
       };
   }

--- a/lib/content/requester-from-auth.ts
+++ b/lib/content/requester-from-auth.ts
@@ -23,6 +23,7 @@ import { and, eq } from "drizzle-orm";
 import { executeQuery } from "@/lib/db/drizzle-client";
 import { agentIdentities, roles, users } from "@/lib/db/schema";
 import { getUserRoles } from "@/lib/db/user-roles";
+import { listUserGroupEmailsByUserId } from "@/lib/groups/queries";
 import { createLogger } from "@/lib/logger";
 import { ForbiddenError } from "./errors";
 import { systemUserIdOrNull } from "./helpers";
@@ -48,16 +49,18 @@ async function loadUserContext(userId: number): Promise<{
   building: string | null;
   department: string | null;
   gradeLevels: string[] | null;
+  groups: string[];
 } | null> {
   // Defensive: a malformed token sub could yield a non-positive / NaN id; skip
   // the query and let the caller surface a clean auth error.
   if (!Number.isInteger(userId) || userId <= 0) return null;
-  // The user-attributes SELECT and the roles lookup are independent, so run them
-  // concurrently — this is on the hot path of every authenticated content REST/MCP
-  // call. A not-found user makes the roles query wasted work, but that path is
-  // rare (a deleted/invalid token sub) and the common found-user path saves a
-  // round trip.
-  const [rows, roleNames] = await Promise.all([
+  // The user-attributes SELECT, the roles lookup, and the group-membership lookup
+  // are independent, so run them concurrently — this is on the hot path of every
+  // authenticated content REST/MCP call. A not-found user makes the roles/groups
+  // queries wasted work, but that path is rare (a deleted/invalid token sub) and
+  // the common found-user path saves a round trip. `groups` powers `group`-kind
+  // visibility grants (#1205); it is `[]` for a user with no memberships.
+  const [rows, roleNames, groupEmails] = await Promise.all([
     executeQuery(
       (db) =>
         db
@@ -72,6 +75,7 @@ async function loadUserContext(userId: number): Promise<{
       "atrium.requesterFromAuth.loadUser"
     ),
     getUserRoles(userId),
+    listUserGroupEmailsByUserId(userId),
   ]);
   const row = rows[0];
   if (!row) return null;
@@ -80,6 +84,7 @@ async function loadUserContext(userId: number): Promise<{
     building: row.building,
     department: row.department,
     gradeLevels: row.gradeLevels,
+    groups: groupEmails,
   };
 }
 
@@ -202,6 +207,8 @@ export function buildDelegatedRequester(input: {
   building: string | null;
   department: string | null;
   gradeLevels: string[] | null;
+  /** The human's synced group emails — inherited by the delegated agent (#1205). */
+  groups?: string[];
   scopes: string[];
   agentLabel: string;
 }): Requester {
@@ -212,6 +219,7 @@ export function buildDelegatedRequester(input: {
     building: input.building,
     department: input.department,
     gradeLevels: input.gradeLevels,
+    groups: input.groups ?? [],
     scopes: input.scopes,
     agentLabel: input.agentLabel,
   };
@@ -243,6 +251,7 @@ export async function requesterForUserId(
       building: ctx.building,
       department: ctx.department,
       gradeLevels: ctx.gradeLevels,
+      groups: ctx.groups,
       isAdmin: ctx.roles.includes(ADMIN_ROLE),
     };
   } catch (error) {
@@ -279,6 +288,7 @@ export async function requesterFromApiAuth(
         building: ctx.building,
         department: ctx.department,
         gradeLevels: ctx.gradeLevels,
+        groups: ctx.groups,
         scopes: auth.scopes,
         agentLabel: auth.oauthClientId ?? "delegated-agent",
       });
@@ -361,6 +371,7 @@ export async function requesterFromApiAuth(
     building: ctx.building,
     department: ctx.department,
     gradeLevels: ctx.gradeLevels,
+    groups: ctx.groups,
     isAdmin: ctx.roles.includes(ADMIN_ROLE),
   };
 }

--- a/lib/content/rest.ts
+++ b/lib/content/rest.ts
@@ -101,7 +101,7 @@ export function respondApprovalRequired(
 }
 
 export const restGrantSchema = z.object({
-  kind: z.enum(["role", "building", "department", "grade", "user"]),
+  kind: z.enum(["role", "building", "department", "grade", "user", "group"]),
   value: z.string(),
 });
 

--- a/lib/content/types.ts
+++ b/lib/content/types.ts
@@ -18,8 +18,18 @@
 
 import type { SourceRef } from "@/lib/db/schema";
 
-/** A grant value to widen `group` visibility along one dimension. */
-export type GrantKind = "role" | "building" | "department" | "grade" | "user";
+/**
+ * A grant value to widen `group` visibility along one dimension. `group` (Epic
+ * #1202 Phase 2, #1205) keys on a synced Google Directory group email — see
+ * `content-visibility-grants.ts` for the per-kind `grant_value` semantics.
+ */
+export type GrantKind =
+  | "role"
+  | "building"
+  | "department"
+  | "grade"
+  | "user"
+  | "group";
 
 export interface VisibilityGrant {
   kind: GrantKind;
@@ -49,6 +59,14 @@ export interface Principal {
   building?: string | null;
   department?: string | null;
   gradeLevels?: string[] | null;
+  /**
+   * The synced Google Directory group EMAILS (lowercased) the principal belongs
+   * to — the match set for a `group`-kind visibility grant (Epic #1202 Phase 2,
+   * #1205). Populated by `principalOf` from the requester's `groups`; always a
+   * concrete array (empty for guests / autonomous agents, so a missing membership
+   * fails closed rather than throwing).
+   */
+  groups: string[];
   isAdmin: boolean;
 }
 
@@ -67,6 +85,14 @@ export type Requester =
       building?: string | null;
       department?: string | null;
       gradeLevels?: string[] | null;
+      /**
+       * Synced Google group emails (lowercased) the user belongs to — the match
+       * set for `group`-kind grants (#1205). Optional: a resolver that omits it
+       * (or a test double) yields no group access via `principalOf`'s `?? []`
+       * default, so a missing lookup fails closed. The two production resolvers
+       * (`resolveAuthenticatedRequester`, `loadUserContext`) always populate it.
+       */
+      groups?: string[];
       isAdmin: boolean;
     }
   | {
@@ -76,6 +102,8 @@ export type Requester =
       building?: string | null;
       department?: string | null;
       gradeLevels?: string[] | null;
+      /** The human's synced group emails — a delegated agent inherits them (#1205). */
+      groups?: string[];
       scopes: string[];
       agentLabel: string;
     }

--- a/lib/content/validators.ts
+++ b/lib/content/validators.ts
@@ -24,6 +24,7 @@ const VALID_GRANT_KINDS: readonly GrantKind[] = [
   "department",
   "grade",
   "user",
+  "group",
 ];
 /**
  * The single membership-test source for grant kinds. Exported so the
@@ -73,6 +74,19 @@ export const VISIBILITY_LEVEL_SET: ReadonlySet<string> = new Set<string>(
  * would surface a confusing 400 on save with no prior warning.
  */
 export const POSITIVE_INT_RE = /^[1-9][0-9]*$/;
+
+/**
+ * A `group`-grant value: a group EMAIL (`local@domain.tld`). Deliberately a
+ * simple, backtracking-safe shape (`no-space`@`no-space`.`no-space`) rather than a
+ * full RFC 5322 grammar — it exists to reject obvious non-emails (a role name, a
+ * bare id) that could never match a real synced group email, not to be an
+ * authoritative address validator (the group value is chosen from the synced
+ * `groups` table in the normal UI path). Shared by the service's last-line guard
+ * (`assertValidGrant`) so the write path and any future client check stay aligned.
+ * Values are lowercased before this test (emails are case-insensitive), so the
+ * pattern only needs to admit lowercase.
+ */
+export const GROUP_EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
 /**
  * Narrow a widened `string` visibility level to `VisibilityLevel`, throwing a

--- a/lib/content/visibility-service.ts
+++ b/lib/content/visibility-service.ts
@@ -30,7 +30,12 @@ import {
 } from "./helpers";
 import { objectSelectFields, rowToObjectDTO, type ObjectRowAsText } from "./mappers";
 import { NotFoundError, ValidationError } from "./errors";
-import { GRANT_KIND_SET, POSITIVE_INT_RE, VISIBILITY_LEVEL_SET } from "./validators";
+import {
+  GRANT_KIND_SET,
+  GROUP_EMAIL_RE,
+  POSITIVE_INT_RE,
+  VISIBILITY_LEVEL_SET,
+} from "./validators";
 import type {
   ContentObjectDTO,
   ListFilter,
@@ -62,20 +67,36 @@ function escapeLikePattern(text: string): string {
 const MAX_GRANT_VALUE_LENGTH = 255;
 
 /**
+ * Normalize a grant value for storage: trim surrounding whitespace for every kind
+ * and additionally LOWERCASE `group` (email) values (#1205) so they match the
+ * lowercased `principal.groups` / `groups.group_email`. Non-string values pass
+ * through untouched so `assertValidGrant` surfaces the type problem, not this.
+ * Deliberately does NOT lowercase role/building/department/grade — those match the
+ * stored attribute case-sensitively.
+ */
+function normalizeGrantValue(kind: string, value: string): string {
+  if (typeof value !== "string") return value;
+  const trimmed = value.trim();
+  return kind === "group" ? trimmed.toLowerCase() : trimmed;
+}
+
+/**
  * Validate a grant before it is persisted. Only a `user` grant carries a numeric
  * id (the `users.id`, matched as `String(userId)` in §12.2). A `role` grant
  * carries the role *name* (e.g. "staff"), because `canView` matches it against
  * `principal.roles` — which are role NAMES (`getUserRoles` returns
- * `roles.name`), never role ids. The remaining kinds (building / department /
- * grade) carry the user-attribute string verbatim. Rejecting an empty or
- * over-long value here prevents, e.g., an empty-string role grant from matching
- * unintended principals once the `g.grant_value = ''` comparison runs.
+ * `roles.name`), never role ids. A `group` grant carries a synced Google group
+ * EMAIL (#1205), matched against `principal.groups`. The remaining kinds
+ * (building / department / grade) carry the user-attribute string verbatim.
+ * Rejecting an empty or over-long value here prevents, e.g., an empty-string role
+ * grant from matching unintended principals once the `g.grant_value = ''`
+ * comparison runs.
  *
  * NOTE: a `role` grant value MUST NOT be validated as a numeric id. Doing so
  * (the Phase 0 behaviour) made role-based group grants unmatchable end-to-end:
  * any value that passed validation (a number) could never equal a role name, so
- * the grant silently granted access to no one. role=name / user=id is the §12.2
- * contract and what `canView` / `buildVisibilitySql` both match on.
+ * the grant silently granted access to no one. role=name / user=id / group=email
+ * is the §12.2 contract and what `canView` / `buildVisibilitySql` both match on.
  */
 function assertValidGrant(grant: VisibilityGrant): void {
   if (!GRANT_KIND_SET.has(grant.kind)) {
@@ -94,6 +115,16 @@ function assertValidGrant(grant: VisibilityGrant): void {
   if (grant.kind === "user" && !POSITIVE_INT_RE.test(value)) {
     throw new ValidationError(
       `Grant value for 'user' must be a positive-integer id`,
+      { kind: grant.kind, value }
+    );
+  }
+  // A `group` grant value must look like a group EMAIL — reject a role name or a
+  // bare id that could never equal a synced group email (defense-in-depth for the
+  // REST/MCP/agent write paths; the UI picker always supplies a real group email).
+  // The value is already lowercased by `applyGrantsInTx`'s normalization.
+  if (grant.kind === "group" && !GROUP_EMAIL_RE.test(value)) {
+    throw new ValidationError(
+      `Grant value for 'group' must be a group email`,
       { kind: grant.kind, value }
     );
   }
@@ -117,6 +148,10 @@ function buildVisibilitySql(principal: Principal): SQL {
   const userIdText = principal.userId != null ? String(principal.userId) : null;
   const roleList = principal.roles;
   const gradeList = principal.gradeLevels ?? [];
+  // Synced Google group emails (lowercased) the principal belongs to (#1205).
+  // Stored group grant_values are lowercased on write, so this is an exact-match
+  // IN (index-friendly), mirroring the role/grade lists.
+  const groupList = principal.groups ?? [];
 
   const authenticated = userIdText != null || roleList.length > 0;
   // INVARIANT: owners always see their own content regardless of visibility level
@@ -142,6 +177,7 @@ function buildVisibilitySql(principal: Principal): SQL {
       : sql`false`;
   const roleMatch = inList(roleList);
   const gradeMatch = inList(gradeList);
+  const groupMatch = inList(groupList);
   const buildingMatch =
     principal.building != null
       ? sql`g.grant_value = ${principal.building}`
@@ -174,6 +210,7 @@ function buildVisibilitySql(principal: Principal): SQL {
         OR (g.grant_kind = 'department' AND ${departmentMatch})
         OR (g.grant_kind = 'grade'      AND ${gradeMatch})
         OR (g.grant_kind = 'user'       AND ${userGrantMatch})
+        OR (g.grant_kind = 'group'      AND ${groupMatch})
       )
     ))
     OR (${o.visibilityLevel} = 'private' AND ${privateUserGrant})
@@ -203,9 +240,16 @@ async function applyGrantsInTx(
   // check yet can never equal the un-padded users.building attribute it is meant to
   // match — a silently inert grant that authorizes no one. Trimming also collapses a
   // whitespace-only value to "" so assertValidGrant rejects it as missing.
+  //
+  // `group` values are additionally LOWERCASED: emails are case-insensitive and
+  // both `principal.groups` and the synced `groups.group_email` are stored
+  // lowercase, so a mixed-case grant value would never match a member (#1205). The
+  // other kinds keep their case — role/building/department/grade are matched
+  // case-sensitively against the stored attribute, so lowercasing them would break
+  // an existing "High School"/"Math" grant.
   const normalized = grants.map((g) => ({
     kind: g.kind,
-    value: typeof g.value === "string" ? g.value.trim() : g.value,
+    value: normalizeGrantValue(g.kind, g.value),
   }));
   for (const grant of normalized) assertValidGrant(grant);
   // Deduplicate on (kind, value) before INSERT — the uq_cvg constraint enforces
@@ -464,7 +508,12 @@ export const visibilityService = {
             (principal.gradeLevels ?? []).includes(g.value)) ||
           (g.kind === "user" &&
             principal.userId != null &&
-            String(principal.userId) === g.value)
+            String(principal.userId) === g.value) ||
+          // `group` grant: the viewer is a member of the granted Google group
+          // (#1205). Both `principal.groups` and the stored grant value are
+          // lowercased, so this exact match mirrors buildVisibilitySql's
+          // `g.grant_kind = 'group' AND g.grant_value IN (groupList)`.
+          (g.kind === "group" && (principal.groups ?? []).includes(g.value))
       );
     }
 

--- a/lib/db/schema/enums.ts
+++ b/lib/db/schema/enums.ts
@@ -135,6 +135,12 @@ export const visibilityLevelEnum = pgEnum("visibility_level", [
 /**
  * Grant kind — the dimension a group visibility grant keys on.
  * Used in: content_visibility_grants.grant_kind
+ *
+ * `group` (Epic #1202 Phase 2, #1205) shares content directly to a synced Google
+ * Directory group — its `grant_value` is the group EMAIL (lowercased), matched
+ * against the viewer's group memberships. Added via migration 110
+ * (`ALTER TYPE grant_kind ADD VALUE 'group'`); the enum is master-owned (created
+ * in the 085 Atrium migration), so `ADD VALUE` succeeds under the migration role.
  */
 export const grantKindEnum = pgEnum("grant_kind", [
   "role",
@@ -142,6 +148,7 @@ export const grantKindEnum = pgEnum("grant_kind", [
   "department",
   "grade",
   "user",
+  "group",
 ]);
 
 /**

--- a/lib/db/schema/tables/content-visibility-grants.ts
+++ b/lib/db/schema/tables/content-visibility-grants.ts
@@ -10,13 +10,18 @@
  *
  * ## Columns of note
  * - `grant_kind` — the dimension the grant keys on (role / building / department /
- *   grade / user).
+ *   grade / user / group).
  * - `grant_value` — the value to match.
  *   - `role` grants: the role **NAME** (e.g. `"staff"`) — matched against
  *     `principal.roles` from `getUserRoles()` which returns names, not ids.
  *   - `user` grants: the numeric user id serialised as text (e.g. `"42"`).
  *   - `building` / `department` / `grade` grants: the attribute string
  *     (e.g. `"High School"`, `"Math"`, `"9"`).
+ *   - `group` grants (Epic #1202 Phase 2, #1205): the synced Google group
+ *     **EMAIL**, lowercased (e.g. `"hs-staff@psd401.net"`) — matched against
+ *     `principal.groups` (the viewer's memberships, from `group_members` joined on
+ *     the user's lowercased email). Stored lowercase (emails are case-insensitive)
+ *     so the exact-match read predicates hit the `idx_cvg_lookup` index.
  *
  *   ⚠️  DO NOT store a numeric id for `role` grants — the in-memory `canView`
  *   and the SQL `buildVisibilitySql` both match by name, so an id-valued role

--- a/lib/groups/queries.ts
+++ b/lib/groups/queries.ts
@@ -7,7 +7,7 @@
  * write via the shared normalize helpers.
  */
 
-import { asc, eq, sql } from "drizzle-orm";
+import { and, asc, eq, sql } from "drizzle-orm";
 import { executeQuery, toPgRows } from "@/lib/db/drizzle-client";
 import { ErrorFactories } from "@/lib/error-utils";
 import {
@@ -16,6 +16,7 @@ import {
   groupSelectionRules,
   groupRoleMappings,
   roles,
+  users,
   type GroupSelectionRuleRow,
   type GroupSelectionRuleType,
   type GroupSource,
@@ -68,6 +69,70 @@ export async function listGroupsWithCounts(): Promise<GroupWithCount[]> {
     "listGroupsWithCounts"
   );
   return rows;
+}
+
+/**
+ * The lowercased emails of the ACTIVE synced groups a user belongs to — the
+ * `principal.groups` match set for `group`-kind Atrium visibility grants (Epic
+ * #1202 Phase 2, #1205).
+ *
+ * Joins the user to `group_members` on their LOWERCASED email (membership is keyed
+ * by email, not a users FK; `idx_group_members_email` is on lower(email)), then to
+ * `groups` restricted to `is_active` so a de-selected group grants nothing.
+ * `lower()` on BOTH sides of every email comparison: storage is lowercase by
+ * convention (normalizeEmail at write time) but no constraint enforces it, so the
+ * join must not trust it (mirrors `reconcileUserManagedRoles`). A user with a null
+ * email, no memberships, or only inactive groups yields `[]` (fails closed). The
+ * result is DISTINCT and lowercased, matching the lowercased `group` grant_value.
+ */
+export async function listUserGroupEmailsByUserId(
+  userId: number
+): Promise<string[]> {
+  // Defensive: a malformed/NaN id skips the query and yields no memberships.
+  if (!Number.isInteger(userId) || userId <= 0) return [];
+  const rows = await executeQuery(
+    (db) =>
+      db
+        .selectDistinct({ groupEmail: sql<string>`lower(${groups.groupEmail})` })
+        .from(users)
+        .innerJoin(
+          groupMembers,
+          eq(sql`lower(${groupMembers.memberEmail})`, sql`lower(${users.email})`)
+        )
+        .innerJoin(
+          groups,
+          and(eq(groups.id, groupMembers.groupId), eq(groups.isActive, true))
+        )
+        .where(eq(users.id, userId)),
+    "listUserGroupEmailsByUserId"
+  );
+  return rows.map((r) => r.groupEmail);
+}
+
+/** A synced group reduced to what a grant picker shows/stores (#1205). */
+export interface GroupPickerOption {
+  /** The lowercased group email — the value stored as a `group` grant. */
+  email: string;
+  /** Display name (null until the first successful fetch); falls back to email in the UI. */
+  name: string | null;
+}
+
+/**
+ * Active synced groups for the Atrium grant editor's group picker (#1205), by
+ * display name then email. Only `is_active` groups are offered — a de-selected
+ * group grants nothing (mirrors `listUserGroupEmailsByUserId`'s active filter), so
+ * offering it would let an author pick a grant that authorizes no one.
+ */
+export async function listActiveGroupsForPicker(): Promise<GroupPickerOption[]> {
+  return executeQuery(
+    (db) =>
+      db
+        .select({ email: groups.groupEmail, name: groups.name })
+        .from(groups)
+        .where(eq(groups.isActive, true))
+        .orderBy(asc(groups.name), asc(groups.groupEmail)),
+    "listActiveGroupsForPicker"
+  );
 }
 
 /** Member emails for one group (alphabetical). */

--- a/lib/mcp/content-tools.ts
+++ b/lib/mcp/content-tools.ts
@@ -17,9 +17,9 @@ import type { McpToolDefinition } from "./types";
 import type { ApiScope } from "@/lib/api-keys/scopes";
 
 const VISIBILITY_DESC =
-  "Visibility object: { level: 'private'|'group'|'internal'|'public', grants?: [{ kind: 'role'|'building'|'department'|'grade'|'user', value: string }] }";
+  "Visibility object: { level: 'private'|'group'|'internal'|'public', grants?: [{ kind: 'role'|'building'|'department'|'grade'|'user'|'group', value: string }] }";
 const GRANTS_DESC =
-  "Group grants: [{ kind: 'role'|'building'|'department'|'grade'|'user', value: string }]";
+  "Group grants: [{ kind: 'role'|'building'|'department'|'grade'|'user'|'group', value: string }]";
 const CODE_ENCODING_DESC =
   "Transit encoding for the body. Set 'base64' when the body/code contains HTML/JS/CSS (<script>, <style>, style=\"…\") — the edge WAF blocks that markup in a raw request body, so send the body base64-encoded and the server decodes it before screening. Omit for plain text/markdown.";
 

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "test:smoke:atrium-html-sanitize": "bun run tests/smoke/atrium-html-sanitize.smoke.ts",
     "test:smoke:atrium-agent-bridge": "bun run tests/smoke/atrium-agent-bridge.smoke.ts",
     "test:smoke:atrium-agent-read": "bun run tests/smoke/atrium-agent-read.smoke.ts",
+    "test:smoke:atrium-group-visibility-list": "bun run tests/smoke/atrium-group-visibility-list.smoke.ts",
     "test:smoke:atrium-provenance-rail": "bun run tests/smoke/atrium-provenance-rail.smoke.ts",
     "test:smoke:atrium-collab-schema": "bun run tests/smoke/atrium-collab-schema.smoke.ts",
     "test:smoke:atrium-suggestions-resolve": "bun run tests/smoke/atrium-suggestions-resolve.smoke.ts",

--- a/tests/components/visibility-chip.test.tsx
+++ b/tests/components/visibility-chip.test.tsx
@@ -221,7 +221,10 @@ beforeEach(() => {
   mockListOptions.mockResolvedValue({
     isSuccess: true,
     message: "ok",
-    data: { roles: ["staff", "administrator"] },
+    data: {
+      roles: ["staff", "administrator"],
+      groups: [{ email: "hs-staff@psd401.net", name: "HS Staff" }],
+    },
   } as Awaited<ReturnType<typeof listGrantOptionsAction>>);
 });
 
@@ -454,7 +457,7 @@ describe("VisibilityChip", () => {
     await waitFor(() => {
       expect(
         screen.getByText(
-          "Failed to load role options — switch the level away and back to retry."
+          "Failed to load grant options — switch the level away and back to retry."
         )
       ).toBeTruthy();
     });
@@ -480,7 +483,10 @@ describe("VisibilityChip", () => {
       } as Awaited<ReturnType<typeof listGrantOptionsAction>>)
       .mockResolvedValueOnce({
         isSuccess: true,
-        data: { roles: ["staff", "administrator"] },
+        data: {
+          roles: ["staff", "administrator"],
+          groups: [{ email: "hs-staff@psd401.net", name: "HS Staff" }],
+        },
       } as Awaited<ReturnType<typeof listGrantOptionsAction>>);
 
     await act(async () => {

--- a/tests/e2e/atrium-group-visibility.functional.spec.ts
+++ b/tests/e2e/atrium-group-visibility.functional.spec.ts
@@ -1,0 +1,77 @@
+import { test, expect } from "./fixtures";
+import { authenticateContext } from "./helpers/session-auth";
+
+/**
+ * E2E (gated): Atrium group-directory visibility (Epic #1202 Phase 2, #1205).
+ *
+ * Asserts the acceptance criterion of the `group` grant kind: a document shared
+ * directly to a synced Google group
+ *   (a) renders (200) for a MEMBER of that group — admitted ONLY by the group
+ *       grant (same role as the outsider, no building/dept/grade grant), so this
+ *       proves the group-membership → principal.groups → canView path end-to-end
+ *       through the session requester on the reader page, and
+ *   (b) 404s for a NON-member (existence-masking — a non-viewable doc must NOT
+ *       403, or its slug could be enumerated).
+ *
+ * Both point-read (the /c/[slug] reader) and the SQL list path share the same
+ * `buildVisibilitySql` / `canView` predicate, so this reader assertion also covers
+ * the list/retrieval agreement the unit + retrieval tests exercise directly.
+ *
+ * PREREQUISITES (this is why the suite is gated):
+ *  - Run against the host dev server with PLAYWRIGHT_AUTH_ENABLED=true
+ *    (see docs/guides/e2e-authenticated-testing.md).
+ *  - Apply migration 110 (grant_kind += 'group') to the target DB, then seed with
+ *    tests/e2e/fixtures/atrium-group-visibility-seed.sql (psql -f …). It creates the
+ *    synced group + one member, the group-shared published doc, and the member /
+ *    non-member users.
+ *  - Optionally override the slug + users via env:
+ *      ATRIUM_GROUP_SLUG, ATRIUM_GROUP_MEMBER_EMAIL, ATRIUM_GROUP_MEMBER_SUB,
+ *      ATRIUM_GROUP_OUTSIDER_EMAIL, ATRIUM_GROUP_OUTSIDER_SUB
+ *    (the seed file documents the defaults below).
+ */
+
+const SLUG = process.env.ATRIUM_GROUP_SLUG ?? "group-directory-playbook";
+const MEMBER_EMAIL =
+  process.env.ATRIUM_GROUP_MEMBER_EMAIL ?? "group-member@example.com";
+const MEMBER_SUB = process.env.ATRIUM_GROUP_MEMBER_SUB ?? "e2e-group-member";
+const OUTSIDER_EMAIL =
+  process.env.ATRIUM_GROUP_OUTSIDER_EMAIL ?? "group-outsider@example.com";
+const OUTSIDER_SUB =
+  process.env.ATRIUM_GROUP_OUTSIDER_SUB ?? "e2e-group-outsider";
+
+test.describe("Atrium group-directory visibility — reader (#1205)", () => {
+  test.skip(
+    process.env.PLAYWRIGHT_AUTH_ENABLED !== "true",
+    "Requires an authenticated session + seeded group-shared doc (migration 110 + atrium-group-visibility-seed.sql)"
+  );
+
+  test("renders (200) for a MEMBER of the granted Google group", async ({
+    browser,
+  }) => {
+    const context = await browser.newContext();
+    await authenticateContext(context, MEMBER_EMAIL, MEMBER_SUB);
+    try {
+      const res = await context.request.get(`/c/${SLUG}`);
+      // The member is admitted ONLY by the group grant (their synced membership
+      // flows into principal.groups on the session requester).
+      expect(res.status()).toBe(200);
+    } finally {
+      await context.close();
+    }
+  });
+
+  test("404s for a NON-member (existence-masking, not 403)", async ({
+    browser,
+  }) => {
+    const context = await browser.newContext();
+    await authenticateContext(context, OUTSIDER_EMAIL, OUTSIDER_SUB);
+    try {
+      const res = await context.request.get(`/c/${SLUG}`);
+      // A non-viewable published doc must 404, NOT 403: a 403 confirms the slug
+      // exists, letting an out-of-audience user enumerate document slugs.
+      expect(res.status()).toBe(404);
+    } finally {
+      await context.close();
+    }
+  });
+});

--- a/tests/e2e/atrium-group-visibility.functional.spec.ts
+++ b/tests/e2e/atrium-group-visibility.functional.spec.ts
@@ -31,6 +31,8 @@ import { authenticateContext } from "./helpers/session-auth";
  */
 
 const SLUG = process.env.ATRIUM_GROUP_SLUG ?? "group-directory-playbook";
+const RETIRED_SLUG =
+  process.env.ATRIUM_RETIRED_GROUP_SLUG ?? "retired-group-playbook";
 const MEMBER_EMAIL =
   process.env.ATRIUM_GROUP_MEMBER_EMAIL ?? "group-member@example.com";
 const MEMBER_SUB = process.env.ATRIUM_GROUP_MEMBER_SUB ?? "e2e-group-member";
@@ -69,6 +71,24 @@ test.describe("Atrium group-directory visibility — reader (#1205)", () => {
       const res = await context.request.get(`/c/${SLUG}`);
       // A non-viewable published doc must 404, NOT 403: a 403 confirms the slug
       // exists, letting an out-of-audience user enumerate document slugs.
+      expect(res.status()).toBe(404);
+    } finally {
+      await context.close();
+    }
+  });
+
+  test("404s for a member of a DEACTIVATED group (is_active revokes the grant)", async ({
+    browser,
+  }) => {
+    // The member IS in retired-group@example.com per group_members, and the doc
+    // carries a live grant to that email — but the group row is is_active=false,
+    // so listUserGroupEmailsByUserId must exclude it from principal.groups. This
+    // is the revocation path for a de-selected/deleted directory group: the
+    // stale grant row remains, and the is_active join filter alone denies access.
+    const context = await browser.newContext();
+    await authenticateContext(context, MEMBER_EMAIL, MEMBER_SUB);
+    try {
+      const res = await context.request.get(`/c/${RETIRED_SLUG}`);
       expect(res.status()).toBe(404);
     } finally {
       await context.close();

--- a/tests/e2e/fixtures/atrium-group-visibility-seed.sql
+++ b/tests/e2e/fixtures/atrium-group-visibility-seed.sql
@@ -1,0 +1,100 @@
+-- Atrium group-directory visibility E2E seed (Epic #1202 Phase 2, #1205)
+--
+-- Seeds a document shared directly to a synced Google group and the two users the
+-- gated functional spec (tests/e2e/atrium-group-visibility.functional.spec.ts)
+-- asserts against: a MEMBER of the group (reads 200) and a NON-member (404,
+-- existence-masked). Idempotent (ON CONFLICT upserts), safe to re-run. Apply to the
+-- local dev DB:
+--
+--   docker exec -i aistudio-postgres psql -U postgres -d aistudio \
+--     < tests/e2e/fixtures/atrium-group-visibility-seed.sql
+--
+-- It does NOT write S3 source.md — the reader falls back to an empty article when
+-- the blob is absent, which does not affect the visibility (200 vs 404) assertion.
+
+-- 1. The two users. Neither is an admin (admins bypass the audience check). The
+--    group MEMBER and the NON-member differ ONLY in their group membership below —
+--    same role, no building/department/grade grant on the doc — so the ONLY thing
+--    that admits the member is the `group` grant (#1205).
+INSERT INTO users (email, first_name, last_name, cognito_sub)
+VALUES ('group-member@example.com', 'Group', 'Member', 'e2e-group-member')
+ON CONFLICT (cognito_sub) DO UPDATE SET email = EXCLUDED.email;
+
+INSERT INTO users (email, first_name, last_name, cognito_sub)
+VALUES ('group-outsider@example.com', 'Group', 'Outsider', 'e2e-group-outsider')
+ON CONFLICT (cognito_sub) DO UPDATE SET email = EXCLUDED.email;
+
+INSERT INTO user_roles (user_id, role_id)
+SELECT u.id, r.id FROM users u, roles r
+WHERE u.cognito_sub IN ('e2e-group-member', 'e2e-group-outsider') AND r.name = 'staff'
+ON CONFLICT DO NOTHING;
+
+-- 2. The synced group (active). group_email is the stable, lowercased identifier;
+--    uniqueness is on lower(group_email), so ON CONFLICT targets that expression.
+INSERT INTO groups (id, group_email, name, source, is_active)
+VALUES (
+  'b1050000-0000-4000-a000-000000001205',
+  'hs-staff-group@example.com', 'HS Staff Group', 'manual', true
+)
+ON CONFLICT (lower(group_email)) DO UPDATE
+  SET is_active = true, name = EXCLUDED.name;
+
+-- 3. Membership: ONLY the member is in the group (member_email lowercased, keyed by
+--    email — resolves to users lazily by lower(email)). Resolve the group id via the
+--    email so this works whether the group row above was newly inserted (our id) or
+--    an existing one (its own id).
+INSERT INTO group_members (group_id, member_email)
+SELECT g.id, 'group-member@example.com'
+FROM groups g
+WHERE lower(g.group_email) = 'hs-staff-group@example.com'
+ON CONFLICT (group_id, lower(member_email)) DO NOTHING;
+
+-- 4. The content object: agent-created, GROUP visibility, owned by e2e-test-user
+--    (so the member sees it ONLY via the group grant — not as owner/admin).
+INSERT INTO content_objects (
+  id, kind, title, slug, owner_user_id, created_by_actor, created_by_agent_id,
+  visibility_level, status
+)
+SELECT
+  'a7100000-0000-4000-8000-000000005205', 'document', 'Group Directory Playbook',
+  'group-directory-playbook',
+  (SELECT id FROM users WHERE cognito_sub = 'e2e-test-user'),
+  'agent',
+  (SELECT id FROM agent_identities WHERE name = 'ship-reporter' LIMIT 1),
+  'group', 'published'
+ON CONFLICT (slug) DO UPDATE
+  SET visibility_level = EXCLUDED.visibility_level, status = EXCLUDED.status;
+
+-- 5. A single human version so the reader has a working head.
+INSERT INTO content_versions (
+  id, object_id, version_number, author_actor, author_user_id, body_format,
+  body_location, summary
+)
+SELECT
+  'a7100000-0000-4000-8000-0000000052a1', 'a7100000-0000-4000-8000-000000005205',
+  1, 'human', (SELECT id FROM users WHERE cognito_sub = 'e2e-test-user'),
+  'markdown', 'proof', 'Group-shared playbook'
+ON CONFLICT (object_id, version_number) DO NOTHING;
+
+UPDATE content_objects
+  SET current_version_id = 'a7100000-0000-4000-8000-0000000052a1'
+  WHERE id = 'a7100000-0000-4000-8000-000000005205';
+
+-- 6. The GROUP grant: grant_value is the group email (lowercased), matched against
+--    the viewer's synced memberships by canView / buildVisibilitySql.
+INSERT INTO content_visibility_grants (object_id, grant_kind, grant_value)
+VALUES (
+  'a7100000-0000-4000-8000-000000005205', 'group', 'hs-staff-group@example.com'
+)
+ON CONFLICT (object_id, grant_kind, grant_value) DO NOTHING;
+
+-- 7. Publish v1 live on the intranet so /c/[slug] renders for a permitted viewer.
+INSERT INTO content_publications (
+  object_id, destination, published_version_id, status, published_by
+)
+SELECT
+  'a7100000-0000-4000-8000-000000005205', 'intranet',
+  'a7100000-0000-4000-8000-0000000052a1', 'live',
+  (SELECT id FROM users WHERE cognito_sub = 'e2e-test-user')
+ON CONFLICT (object_id, destination) DO UPDATE
+  SET published_version_id = EXCLUDED.published_version_id, status = 'live';

--- a/tests/e2e/fixtures/atrium-group-visibility-seed.sql
+++ b/tests/e2e/fixtures/atrium-group-visibility-seed.sql
@@ -3,8 +3,11 @@
 -- Seeds a document shared directly to a synced Google group and the two users the
 -- gated functional spec (tests/e2e/atrium-group-visibility.functional.spec.ts)
 -- asserts against: a MEMBER of the group (reads 200) and a NON-member (404,
--- existence-masked). Idempotent (ON CONFLICT upserts), safe to re-run. Apply to the
--- local dev DB:
+-- existence-masked). Also seeds a DEACTIVATED group (is_active = false) the member
+-- belongs to, plus a doc granted only to it, so the spec can prove deactivation
+-- revokes access (the `groups.is_active = true` join filter in
+-- listUserGroupEmailsByUserId). Idempotent (ON CONFLICT upserts), safe to re-run.
+-- Apply to the local dev DB:
 --
 --   docker exec -i aistudio-postgres psql -U postgres -d aistudio \
 --     < tests/e2e/fixtures/atrium-group-visibility-seed.sql
@@ -95,6 +98,70 @@ INSERT INTO content_publications (
 SELECT
   'a7100000-0000-4000-8000-000000005205', 'intranet',
   'a7100000-0000-4000-8000-0000000052a1', 'live',
+  (SELECT id FROM users WHERE cognito_sub = 'e2e-test-user')
+ON CONFLICT (object_id, destination) DO UPDATE
+  SET published_version_id = EXCLUDED.published_version_id, status = 'live';
+
+-- 8. DEACTIVATED-group revocation case (#1205 review): the MEMBER also belongs to
+--    a group that has been deactivated (de-selected / dropped from the directory —
+--    the sync flips is_active to false but keeps the row and its memberships).
+--    A doc granted ONLY to that group must 404 for them: the
+--    `groups.is_active = true` filter in listUserGroupEmailsByUserId is the sole
+--    mechanism that revokes the grant, and this is its end-to-end proof.
+INSERT INTO groups (id, group_email, name, source, is_active)
+VALUES (
+  'b1050000-0000-4000-a000-000000001215',
+  'retired-group@example.com', 'Retired Group', 'manual', false
+)
+ON CONFLICT (lower(group_email)) DO UPDATE
+  SET is_active = false, name = EXCLUDED.name;
+
+INSERT INTO group_members (group_id, member_email)
+SELECT g.id, 'group-member@example.com'
+FROM groups g
+WHERE lower(g.group_email) = 'retired-group@example.com'
+ON CONFLICT (group_id, lower(member_email)) DO NOTHING;
+
+INSERT INTO content_objects (
+  id, kind, title, slug, owner_user_id, created_by_actor, created_by_agent_id,
+  visibility_level, status
+)
+SELECT
+  'a7100000-0000-4000-8000-000000005215', 'document', 'Retired Group Playbook',
+  'retired-group-playbook',
+  (SELECT id FROM users WHERE cognito_sub = 'e2e-test-user'),
+  'agent',
+  (SELECT id FROM agent_identities WHERE name = 'ship-reporter' LIMIT 1),
+  'group', 'published'
+ON CONFLICT (slug) DO UPDATE
+  SET visibility_level = EXCLUDED.visibility_level, status = EXCLUDED.status;
+
+INSERT INTO content_versions (
+  id, object_id, version_number, author_actor, author_user_id, body_format,
+  body_location, summary
+)
+SELECT
+  'a7100000-0000-4000-8000-0000000052b1', 'a7100000-0000-4000-8000-000000005215',
+  1, 'human', (SELECT id FROM users WHERE cognito_sub = 'e2e-test-user'),
+  'markdown', 'proof', 'Playbook shared only to a deactivated group'
+ON CONFLICT (object_id, version_number) DO NOTHING;
+
+UPDATE content_objects
+  SET current_version_id = 'a7100000-0000-4000-8000-0000000052b1'
+  WHERE id = 'a7100000-0000-4000-8000-000000005215';
+
+INSERT INTO content_visibility_grants (object_id, grant_kind, grant_value)
+VALUES (
+  'a7100000-0000-4000-8000-000000005215', 'group', 'retired-group@example.com'
+)
+ON CONFLICT (object_id, grant_kind, grant_value) DO NOTHING;
+
+INSERT INTO content_publications (
+  object_id, destination, published_version_id, status, published_by
+)
+SELECT
+  'a7100000-0000-4000-8000-000000005215', 'intranet',
+  'a7100000-0000-4000-8000-0000000052b1', 'live',
   (SELECT id FROM users WHERE cognito_sub = 'e2e-test-user')
 ON CONFLICT (object_id, destination) DO UPDATE
   SET published_version_id = EXCLUDED.published_version_id, status = 'live';

--- a/tests/smoke/atrium-group-visibility-list.smoke.ts
+++ b/tests/smoke/atrium-group-visibility-list.smoke.ts
@@ -1,0 +1,149 @@
+/**
+ * Atrium group-grant SQL/JS parity smoke (Bun + local DB)
+ *
+ * Epic #1202 Phase 2, #1205 acceptance: `listVisible` (the SQL path —
+ * `buildVisibilitySql`) and `canView` (the JS twin) must AGREE for
+ * group-granted objects, and membership must resolve through the REAL
+ * `listUserGroupEmailsByUserId` query (including its `groups.is_active = true`
+ * join filter). The jest suites pin the JS branch with mocks and the gated
+ * Playwright spec proves the point-read; this smoke is the only place the
+ * group branch of the SQL predicate executes against a real database.
+ * `visibleCountsByCollection` consumes the SAME `buildVisibilitySql`
+ * predicate, so the parity proven here covers it by construction; it is still
+ * invoked once below so the group IN-list also executes inside the GROUP BY
+ * count query.
+ *
+ * Prereqs: local DB with migration 110 applied and
+ * tests/e2e/fixtures/atrium-group-visibility-seed.sql loaded (the same seed
+ * the gated e2e uses — member/outsider users, an active-group doc, and a
+ * deactivated-group doc).
+ *
+ * Run:
+ *   DATABASE_URL='postgresql://postgres:postgres@localhost:5432/aistudio' DB_SSL=false \
+ *     bun run tests/smoke/atrium-group-visibility-list.smoke.ts
+ */
+
+import assert from "node:assert/strict";
+import { eq, inArray } from "drizzle-orm";
+import { executeQuery, toPgRows } from "@/lib/db/drizzle-client";
+import { contentObjects, users } from "@/lib/db/schema";
+import { visibilityService } from "@/lib/content/visibility-service";
+import { listUserGroupEmailsByUserId } from "@/lib/groups/queries";
+import type { Requester } from "@/lib/content/types";
+
+const ACTIVE_SLUG = "group-directory-playbook";
+const RETIRED_SLUG = "retired-group-playbook";
+const ACTIVE_GROUP = "hs-staff-group@example.com";
+
+let passed = 0;
+async function check(name: string, fn: () => Promise<void>): Promise<void> {
+  await fn();
+  passed += 1;
+  console.log(`  ✓ ${name}`);
+}
+
+async function loadUserId(cognitoSub: string): Promise<number> {
+  const rows = toPgRows(
+    await executeQuery(
+      (db) =>
+        db
+          .select({ id: users.id })
+          .from(users)
+          .where(eq(users.cognitoSub, cognitoSub))
+          .limit(1),
+      "smoke.loadUser"
+    )
+  ) as { id: number }[];
+  assert.ok(rows[0], `seed missing: no user ${cognitoSub} (apply the seed first)`);
+  return rows[0].id;
+}
+
+const docs = toPgRows(
+  await executeQuery(
+    (db) =>
+      db
+        .select({
+          id: contentObjects.id,
+          slug: contentObjects.slug,
+          ownerUserId: contentObjects.ownerUserId,
+          visibilityLevel: contentObjects.visibilityLevel,
+        })
+        .from(contentObjects)
+        .where(inArray(contentObjects.slug, [ACTIVE_SLUG, RETIRED_SLUG])),
+    "smoke.loadDocs"
+  )
+) as {
+  id: string;
+  slug: string;
+  ownerUserId: number;
+  visibilityLevel: "private" | "group" | "internal" | "public";
+}[];
+const activeDoc = docs.find((d) => d.slug === ACTIVE_SLUG);
+const retiredDoc = docs.find((d) => d.slug === RETIRED_SLUG);
+assert.ok(activeDoc && retiredDoc, "seed missing: apply atrium-group-visibility-seed.sql first");
+// The seed always sets an owner; canView's ViewableObject requires it non-null.
+assert.ok(activeDoc.ownerUserId != null && retiredDoc.ownerUserId != null);
+
+const memberId = await loadUserId("e2e-group-member");
+const outsiderId = await loadUserId("e2e-group-outsider");
+
+function requester(userId: number, groups: string[]): Requester {
+  return {
+    kind: "user",
+    userId,
+    roles: ["staff"],
+    building: null,
+    department: null,
+    gradeLevels: null,
+    isAdmin: false,
+    groups,
+  };
+}
+
+// 1. REAL membership resolution — the is_active filter is the revocation
+//    mechanism for deactivated groups, exercised here at the SQL layer.
+const memberGroups = await listUserGroupEmailsByUserId(memberId);
+const outsiderGroups = await listUserGroupEmailsByUserId(outsiderId);
+await check("member resolves ONLY the active group (is_active filter)", async () => {
+  assert.deepEqual(memberGroups, [ACTIVE_GROUP]);
+});
+await check("outsider resolves no groups", async () => {
+  assert.deepEqual(outsiderGroups, []);
+});
+
+const member = requester(memberId, memberGroups);
+const outsider = requester(outsiderId, outsiderGroups);
+
+// 2. SQL list path (buildVisibilitySql) vs 3. JS point path (canView) — parity.
+for (const [label, req] of [
+  ["member", member],
+  ["outsider", outsider],
+] as const) {
+  const listed = await visibilityService.listVisible(req, { kind: "document" });
+  const listedSlugs = new Set(listed.map((o) => o.slug));
+  for (const doc of [activeDoc, retiredDoc]) {
+    const js = await visibilityService.canView(req, doc);
+    const sqlSees = listedSlugs.has(doc.slug);
+    await check(`${label} / ${doc.slug}: listVisible (${sqlSees}) agrees with canView (${js})`, async () => {
+      assert.equal(sqlSees, js);
+    });
+  }
+  const expectVisible = label === "member" ? [ACTIVE_SLUG] : [];
+  await check(`${label} sees exactly ${JSON.stringify(expectVisible)}`, async () => {
+    assert.deepEqual(
+      [ACTIVE_SLUG, RETIRED_SLUG].filter((s) => listedSlugs.has(s)),
+      expectVisible
+    );
+  });
+}
+
+// 4. visibleCountsByCollection consumes the same predicate — execute it with a
+//    group-bearing principal so the group IN-list also runs inside the GROUP BY
+//    count query (the seeded docs are collection-less, so no count assertion).
+await check("visibleCountsByCollection executes with a group principal", async () => {
+  const counts = await visibilityService.visibleCountsByCollection(member);
+  assert.ok(counts instanceof Map);
+});
+
+console.log(`atrium-group-visibility-list smoke: ${passed} checks passed`);
+process.exit(0);

--- a/tests/unit/atrium-content-helpers.test.ts
+++ b/tests/unit/atrium-content-helpers.test.ts
@@ -147,18 +147,36 @@ describe("principalOf", () => {
       building: "High School",
       department: "Math",
       gradeLevels: ["9", "10"],
+      // `groups` defaults to [] when the requester carries none (#1205).
+      groups: [],
       isAdmin: false,
     });
+  });
+  it("carries the user's synced group memberships (#1205)", () => {
+    const withGroups: Requester = {
+      ...userReq,
+      groups: ["hs-staff@psd401.net"],
+    };
+    expect(principalOf(withGroups).groups).toEqual(["hs-staff@psd401.net"]);
   });
   it("never infers admin for a delegated agent", () => {
     expect(principalOf(delegatedReq).isAdmin).toBe(false);
     expect(principalOf(delegatedReq).userId).toBe(42);
+  });
+  it("inherits the human's groups for a delegated agent (#1205)", () => {
+    const withGroups: Requester = {
+      ...delegatedReq,
+      groups: ["hs-staff@psd401.net"],
+    };
+    expect(principalOf(withGroups).groups).toEqual(["hs-staff@psd401.net"]);
   });
   it("gives an autonomous agent no user id and no org attributes", () => {
     const p = principalOf(autonomousReq);
     expect(p.userId).toBeUndefined();
     expect(p.building).toBeNull();
     expect(p.roles).toEqual(["staff"]);
+    // Autonomous agents have no human identity → no group memberships.
+    expect(p.groups).toEqual([]);
   });
 });
 

--- a/tests/unit/atrium-get-visibility-action.test.ts
+++ b/tests/unit/atrium-get-visibility-action.test.ts
@@ -103,7 +103,7 @@ const listActiveGroupsForPickerMock = jest.fn(async () => [
   { email: "hs-staff@psd401.net", name: "HS Staff" },
 ]);
 jest.mock("@/lib/groups/queries", () => ({
-  listActiveGroupsForPicker: (...a: unknown[]) => listActiveGroupsForPickerMock(...a),
+  listActiveGroupsForPicker: () => listActiveGroupsForPickerMock(),
 }));
 
 // ─── imports (after all jest.mock hoisting) ────────────────────────────────

--- a/tests/unit/atrium-get-visibility-action.test.ts
+++ b/tests/unit/atrium-get-visibility-action.test.ts
@@ -96,6 +96,16 @@ jest.mock("@/lib/auth/server-session", () => ({
   getServerSession: () => getServerSessionMock(),
 }));
 
+// listGrantOptionsAction also loads the synced group picker options (#1205). Mock
+// the query helper so the action test stays isolated from the groups query internals
+// (the roles query still runs through executeQueryMock).
+const listActiveGroupsForPickerMock = jest.fn(async () => [
+  { email: "hs-staff@psd401.net", name: "HS Staff" },
+]);
+jest.mock("@/lib/groups/queries", () => ({
+  listActiveGroupsForPicker: (...a: unknown[]) => listActiveGroupsForPickerMock(...a),
+}));
+
 // ─── imports (after all jest.mock hoisting) ────────────────────────────────
 
 import { getVisibilityAction } from "@/actions/db/atrium/get-visibility";
@@ -248,5 +258,14 @@ describe("listGrantOptionsAction — auth gates", () => {
     expect(result.isSuccess).toBe(true);
     if (!result.isSuccess) return;
     expect(result.data.roles).toEqual(["staff", "teacher"]);
+  });
+
+  it("returns the active synced groups for the group picker (#1205)", async () => {
+    const result = await listGrantOptionsAction();
+    expect(result.isSuccess).toBe(true);
+    if (!result.isSuccess) return;
+    expect(result.data.groups).toEqual([
+      { email: "hs-staff@psd401.net", name: "HS Staff" },
+    ]);
   });
 });

--- a/tests/unit/atrium-publish-document-action.test.ts
+++ b/tests/unit/atrium-publish-document-action.test.ts
@@ -72,7 +72,7 @@ describe("publishDocumentAction — grant.kind runtime validation", () => {
     expect(publishMock).not.toHaveBeenCalled();
   });
 
-  it.each(["role", "building", "department", "grade", "user"])(
+  it.each(["role", "building", "department", "grade", "user", "group"])(
     "accepts the valid grant kind %s and forwards it to the service",
     async (kind) => {
       const result = await publishDocumentAction("o1", {

--- a/tests/unit/atrium-requester-from-auth.test.ts
+++ b/tests/unit/atrium-requester-from-auth.test.ts
@@ -31,6 +31,9 @@ let userRows: Array<{
   gradeLevels: string[] | null;
 }> = [];
 let roleRows: Array<{ name: string }> = [];
+// The synced group memberships loadUserContext resolves for #1205 (rows shaped as
+// listUserGroupEmailsByUserId's `{ groupEmail }` projection).
+let groupRows: Array<{ groupEmail: string }> = [];
 
 jest.mock("@/lib/db/drizzle-client", () => ({
   executeQuery: jest.fn(async (_fn: unknown, label: string) => {
@@ -38,6 +41,7 @@ jest.mock("@/lib/db/drizzle-client", () => ({
     if (label === "atrium.requesterFromAuth.findAgentById") return agentByIdRows;
     if (label === "atrium.requesterFromAuth.loadUser") return userRows;
     if (label === "getUserRoles") return roleRows;
+    if (label === "listUserGroupEmailsByUserId") return groupRows;
     return [];
   }),
 }));
@@ -52,8 +56,26 @@ jest.mock("@/lib/db/schema", () => ({
     scopes: "scopes",
   },
   roles: { id: "id", name: "name" },
-  users: { id: "id", building: "building", department: "department", gradeLevels: "gradeLevels" },
+  users: {
+    id: "id",
+    email: "email",
+    building: "building",
+    department: "department",
+    gradeLevels: "gradeLevels",
+  },
   userRoles: { userId: "userId", roleId: "roleId" },
+  // lib/groups/queries (imported by requester-from-auth for
+  // listUserGroupEmailsByUserId) builds a module-level select object from these,
+  // so they must be defined objects even though the query callbacks never run here.
+  groups: { id: "id", groupEmail: "groupEmail", name: "name", isActive: "isActive" },
+  groupMembers: { groupId: "groupId", memberEmail: "memberEmail" },
+  groupSelectionRules: {},
+  groupRoleMappings: {
+    id: "id",
+    groupEmail: "groupEmail",
+    roleId: "roleId",
+    createdAt: "createdAt",
+  },
 }));
 
 jest.mock("drizzle-orm", () => ({
@@ -88,6 +110,7 @@ beforeEach(() => {
   agentByIdRows = [];
   userRows = [{ building: "High School", department: null, gradeLevels: null }];
   roleRows = [{ name: "staff" }];
+  groupRows = [];
   jest.clearAllMocks();
 });
 
@@ -106,6 +129,51 @@ describe("requesterFromApiAuth", () => {
     expect(req.building).toBe("High School");
     expect(req.scopes).toContain("content:create");
     expect(req.agentLabel).toBe("client-abc");
+  });
+
+  it("populates a user requester's group memberships from loadUserContext (#1205)", async () => {
+    groupRows = [
+      { groupEmail: "hs-staff@psd401.net" },
+      { groupEmail: "all-staff@psd401.net" },
+    ];
+    const req = await requesterFromApiAuth({ userId: 7, scopes: ["content:read"] });
+    if (req.kind !== "user") throw new Error("wrong kind");
+    expect(req.groups).toEqual([
+      "hs-staff@psd401.net",
+      "all-staff@psd401.net",
+    ]);
+    // principalOf surfaces the same set as the canView/list match set.
+    expect(principalOf(req).groups).toEqual([
+      "hs-staff@psd401.net",
+      "all-staff@psd401.net",
+    ]);
+  });
+
+  it("a delegated agent INHERITS the human's group memberships (#1205)", async () => {
+    groupRows = [{ groupEmail: "hs-staff@psd401.net" }];
+    const req = await requesterFromApiAuth({
+      userId: 50,
+      scopes: ["content:read"],
+      oauthClientId: "client-abc",
+      delegatedForUserId: 7,
+    });
+    if (req.kind !== "agent-delegated") throw new Error("wrong kind");
+    expect(req.groups).toEqual(["hs-staff@psd401.net"]);
+    expect(principalOf(req).groups).toEqual(["hs-staff@psd401.net"]);
+  });
+
+  it("an autonomous agent has NO group memberships (#1205)", async () => {
+    agentRows = [
+      { id: "agent-1", name: "ship-reporter", roleId: 3, roleName: "staff" },
+    ];
+    const req = await requesterFromApiAuth({
+      userId: 0,
+      scopes: ["content:create"],
+      oauthClientId: "client-ship",
+    });
+    if (req.kind !== "agent-autonomous") throw new Error("wrong kind");
+    // Autonomous agents have no human identity → principalOf yields an empty set.
+    expect(principalOf(req).groups).toEqual([]);
   });
 
   it("builds an agent-autonomous requester when the OIDC client maps to an identity", async () => {

--- a/tests/unit/atrium-rest-grant-schema.test.ts
+++ b/tests/unit/atrium-rest-grant-schema.test.ts
@@ -1,0 +1,54 @@
+/**
+ * REST/MCP grant-kind schema acceptance (Epic #1202 Phase 2, #1205 review).
+ *
+ * `restGrantSchema` in `lib/content/rest.ts` gates the REST v1 content routes
+ * AND is reused verbatim by the MCP content tool handlers (`grantZ` /
+ * `visibilityZ` in `lib/mcp/content-tool-handlers.ts`). The first cut of #1205
+ * updated the server-action validator (`GRANT_KIND_SET`) but not this Zod
+ * enum, so REST/MCP callers were 400-rejected on `kind: "group"` while the UI
+ * worked — these tests pin the schema to the canonical kind list so the two
+ * can never drift apart again.
+ */
+
+import { GRANT_KIND_SET } from "@/lib/content/validators";
+
+// rest.ts pulls the request/audit machinery at module scope; inert stubs keep
+// this a pure schema test (the real Zod objects are what we import).
+jest.mock("@/lib/api/auth-middleware", () => ({
+  createApiResponse: jest.fn(),
+  createErrorResponse: jest.fn(),
+}));
+jest.mock("@/lib/content/audit", () => ({
+  recordContentAudit: jest.fn(),
+}));
+jest.mock("@/lib/content/requester-from-auth", () => ({
+  requesterFromApiAuth: jest.fn(),
+}));
+
+import { restGrantSchema, restVisibilitySchema } from "@/lib/content/rest";
+
+describe("restGrantSchema (REST + MCP shared grant validation)", () => {
+  it.each([...GRANT_KIND_SET])(
+    "accepts every canonical grant kind, including %s",
+    (kind) => {
+      const parsed = restGrantSchema.safeParse({ kind, value: "x@y.com" });
+      expect(parsed.success).toBe(true);
+    }
+  );
+
+  it("accepts a group-level visibility payload carrying a group grant", () => {
+    const parsed = restVisibilitySchema.safeParse({
+      level: "group",
+      grants: [{ kind: "group", value: "hs-staff-group@example.com" }],
+    });
+    expect(parsed.success).toBe(true);
+  });
+
+  it("still rejects an unknown grant kind", () => {
+    const parsed = restGrantSchema.safeParse({
+      kind: "__evil__",
+      value: "x",
+    });
+    expect(parsed.success).toBe(false);
+  });
+});

--- a/tests/unit/atrium-retrieval-permission-aware.test.ts
+++ b/tests/unit/atrium-retrieval-permission-aware.test.ts
@@ -173,6 +173,15 @@ const studentUser: Requester = {
   roles: ["student"],
   isAdmin: false,
 };
+// A user who belongs to a synced Google group — for the `group`-kind grant path
+// (#1205). `staffUser` carries no `groups`, so a group grant matches ONLY this one.
+const groupMemberUser: Requester = {
+  kind: "user",
+  userId: 30,
+  roles: ["staff"],
+  groups: ["hs-staff@psd401.net"],
+  isAdmin: false,
+};
 
 // A published, GROUP-visibility doc owned by someone else, granted to role
 // "staff" only. `canView` allows the staff requester (role matches the grant)
@@ -232,6 +241,22 @@ describe("§16.2 permission-aware search — the safety boundary", () => {
 
   it("EXCLUDES the same doc from a STUDENT requester (role grant does NOT match)", async () => {
     const hits = await retrievalService.search(studentUser, "playbook");
+    expect(hits).toHaveLength(0);
+  });
+
+  it("RETURNS a group-directory-scoped doc to a GROUP MEMBER (group grant matches, #1205)", async () => {
+    // The doc is granted to a Google group; retrieval re-checks canView per hit, so
+    // group visibility flows into search/RAG with no retrieval-side change.
+    grantsForResult = [{ kind: "group", value: "hs-staff@psd401.net" }];
+    const hits = await retrievalService.search(groupMemberUser, "playbook");
+    expect(hits).toHaveLength(1);
+    expect(hits[0].objectId).toBe("obj-1");
+  });
+
+  it("EXCLUDES the same group-scoped doc from a NON-member (#1205)", async () => {
+    // staffUser has no `groups`, so the group grant authorizes no one but a member.
+    grantsForResult = [{ kind: "group", value: "hs-staff@psd401.net" }];
+    const hits = await retrievalService.search(staffUser, "playbook");
     expect(hits).toHaveLength(0);
   });
 

--- a/tests/unit/atrium-visibility.test.ts
+++ b/tests/unit/atrium-visibility.test.ts
@@ -225,6 +225,15 @@ describe("canView — group grant is gated on group VISIBILITY (guard mirror #12
       await visibilityService.canView(groupMemberUser, obj("private"))
     ).toBe(false);
   });
+  it("a group-kind grant on an INTERNAL object grants an unauthenticated viewer nothing extra", async () => {
+    // Internal admits any authenticated principal WITHOUT consulting grants, and
+    // denies guests. A stray `group` grant must not widen that: the grant sweep
+    // only runs inside the `visibility_level = 'group'` branch in both predicates.
+    withGrants([{ kind: "group", value: "hs-staff@psd401.net" }]);
+    expect(await visibilityService.canView(anonymous, obj("internal"))).toBe(
+      false
+    );
+  });
 });
 
 describe("canView — unauthenticated", () => {

--- a/tests/unit/atrium-visibility.test.ts
+++ b/tests/unit/atrium-visibility.test.ts
@@ -62,6 +62,14 @@ const staffUser: Requester = {
   gradeLevels: ["9"],
   isAdmin: false,
 };
+// A user who belongs to a synced Google group (lowercased email in `groups`),
+// for the `group`-kind grant tests (#1205). Distinct from `staffUser` (no groups)
+// so a group grant matches ONLY the member.
+const groupMemberUser: Requester = {
+  ...staffUser,
+  userId: 101,
+  groups: ["hs-staff@psd401.net"],
+};
 const admin: Requester = { ...staffUser, userId: 1, isAdmin: true };
 const owner: Requester = { ...staffUser, userId: OWNER_ID };
 const anonymous: Requester = {
@@ -183,6 +191,40 @@ describe("canView — group grants", () => {
     withGrants([{ kind: "role", value: "staff" }]);
     expect(await visibilityService.canView(roledAgent, obj("group"))).toBe(true);
   });
+
+  it("group grant matches a member of the granted Google group (#1205)", async () => {
+    withGrants([{ kind: "group", value: "hs-staff@psd401.net" }]);
+    expect(await visibilityService.canView(groupMemberUser, obj("group"))).toBe(
+      true
+    );
+  });
+  it("group grant fails for a non-member (no matching membership)", async () => {
+    // staffUser carries no `groups`, so a group grant matches no one but a member.
+    withGrants([{ kind: "group", value: "hs-staff@psd401.net" }]);
+    expect(await visibilityService.canView(staffUser, obj("group"))).toBe(false);
+  });
+  it("group grant fails when the member belongs to a DIFFERENT group", async () => {
+    withGrants([{ kind: "group", value: "elsewhere@psd401.net" }]);
+    expect(await visibilityService.canView(groupMemberUser, obj("group"))).toBe(
+      false
+    );
+  });
+  it("an autonomous agent (no human identity) never matches a group grant", async () => {
+    withGrants([{ kind: "group", value: "hs-staff@psd401.net" }]);
+    expect(await visibilityService.canView(roledAgent, obj("group"))).toBe(false);
+  });
+});
+
+describe("canView — group grant is gated on group VISIBILITY (guard mirror #1205)", () => {
+  it("a group-kind grant on a PRIVATE object grants a member nothing extra", async () => {
+    // The private branch consults ONLY `user` grants — a stray `group` grant on a
+    // non-group object must NOT authorize a member, mirroring buildVisibilitySql's
+    // `visibility_level = 'group'` gate on the whole grant-sweep EXISTS clause.
+    withGrants([{ kind: "group", value: "hs-staff@psd401.net" }]);
+    expect(
+      await visibilityService.canView(groupMemberUser, obj("private"))
+    ).toBe(false);
+  });
 });
 
 describe("canView — unauthenticated", () => {
@@ -288,6 +330,28 @@ describe("applyGrantsForLevel — grant value validation (group level)", () => {
     ]);
     expect(inserted).toHaveLength(1);
     expect((inserted[0] as unknown[]).length).toBe(2);
+  });
+
+  it("accepts a group-email grant value and lowercases it before storing (#1205)", async () => {
+    // Emails are case-insensitive; the stored value must be lowercase so it matches
+    // the lowercased principal.groups. A mixed-case input is normalized on write.
+    const { tx, inserted } = fakeTx();
+    await apply(tx, [{ kind: "group", value: "HS-Staff@PSD401.net" }]);
+    expect(inserted).toHaveLength(1);
+    const rows = inserted[0] as Array<{ grantKind: string; grantValue: string }>;
+    expect(rows[0]).toMatchObject({
+      grantKind: "group",
+      grantValue: "hs-staff@psd401.net",
+    });
+  });
+
+  it("rejects a group grant value that is not an email (defense-in-depth #1205)", async () => {
+    // A group grant value must look like an email — a role name or bare id could
+    // never equal a synced group email, so reject it rather than store an inert grant.
+    const { tx } = fakeTx();
+    await expect(
+      apply(tx, [{ kind: "group", value: "not-an-email" }])
+    ).rejects.toThrow(/group email/i);
   });
 
   it("rejects a whitespace-only grant value (trims to empty → required)", async () => {

--- a/tests/unit/db-migration-manifest.test.ts
+++ b/tests/unit/db-migration-manifest.test.ts
@@ -1,0 +1,49 @@
+/**
+ * Migration-manifest registration guard (Epic #1202 Phase 2, #1205 review).
+ *
+ * `infra/database/migrations.json` is the SINGLE source of truth for which
+ * schema files execute: `scripts/db/run-migrations.ts` (local) and
+ * `infra/database/lambda/db-init-handler.ts` (deploy) iterate ONLY its
+ * `initialSetupFiles` + `migrationFiles` arrays — there is no directory-scan
+ * fallback. A schema file that exists on disk but is not listed is silently
+ * never run (exactly what happened to 110-atrium-group-grant-kind.sql in the
+ * first cut of #1205: the `ALTER TYPE grant_kind ADD VALUE 'group'` would have
+ * been dead on arrival in every environment). This test makes that failure
+ * mode impossible to reintroduce.
+ */
+
+import fs from "fs";
+import path from "path";
+
+const manifestPath = path.join(process.cwd(), "infra/database/migrations.json");
+const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8")) as {
+  schemaDir: string;
+  initialSetupFiles: string[];
+  migrationFiles: string[];
+};
+const schemaDir = path.join(process.cwd(), manifest.schemaDir);
+const listed = [...manifest.initialSetupFiles, ...manifest.migrationFiles];
+
+describe("infra/database/migrations.json manifest", () => {
+  it("registers every schema .sql file (rollback scripts are the only exception)", () => {
+    const onDisk = fs
+      .readdirSync(schemaDir)
+      // *-rollback.sql are operator-run recovery scripts, deliberately never
+      // part of the forward migration sequence.
+      .filter((f) => f.endsWith(".sql") && !f.endsWith("-rollback.sql"));
+    const unregistered = onDisk.filter((f) => !listed.includes(f));
+    expect(unregistered).toEqual([]);
+  });
+
+  it("lists no file that is missing from the schema directory", () => {
+    const missing = listed.filter(
+      (f) => !fs.existsSync(path.join(schemaDir, f))
+    );
+    expect(missing).toEqual([]);
+  });
+
+  it("lists no file twice (a duplicate would re-run a migration)", () => {
+    const dupes = listed.filter((f, i) => listed.indexOf(f) !== i);
+    expect(dupes).toEqual([]);
+  });
+});

--- a/tests/unit/groups-user-group-emails.test.ts
+++ b/tests/unit/groups-user-group-emails.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Unit tests for listUserGroupEmailsByUserId (Epic #1202 Phase 2, #1205).
+ *
+ * The membership lookup that populates `principal.groups` — the match set for
+ * `group`-kind Atrium visibility grants. The DB is mocked: `executeQuery` never
+ * invokes the query-builder callback, so these tests exercise the guard (a
+ * non-positive id must not query and must fail closed) and the row→string
+ * projection. The lowercase/DISTINCT/active-only semantics live in SQL and are
+ * covered by the canView JS path + the e2e, not here.
+ */
+
+const executeQueryMock = jest.fn();
+jest.mock("@/lib/db/drizzle-client", () => ({
+  executeQuery: (...a: unknown[]) => executeQueryMock(...a),
+  toPgRows: (r: unknown) => r,
+}));
+
+// The query builds against these tables; the callback is never run, so inert
+// stand-ins are enough (the real column refs would only matter if executed).
+jest.mock("@/lib/db/schema", () => ({
+  groups: { id: {}, groupEmail: {}, isActive: {}, name: {} },
+  groupMembers: { groupId: {}, memberEmail: {} },
+  groupSelectionRules: {},
+  groupRoleMappings: {},
+  roles: {},
+  users: { id: {}, email: {} },
+}));
+
+jest.mock("drizzle-orm", () => ({
+  and: (...a: unknown[]) => a,
+  asc: (a: unknown) => a,
+  eq: (...a: unknown[]) => a,
+  sql: Object.assign((..._a: unknown[]) => ({}), {
+    join: (..._a: unknown[]) => ({}),
+  }),
+}));
+
+import { listUserGroupEmailsByUserId } from "@/lib/groups/queries";
+
+beforeEach(() => {
+  executeQueryMock.mockReset();
+});
+
+describe("listUserGroupEmailsByUserId (#1205)", () => {
+  it("projects the group_email rows to a string[]", async () => {
+    executeQueryMock.mockResolvedValueOnce([
+      { groupEmail: "hs-staff@psd401.net" },
+      { groupEmail: "all-staff@psd401.net" },
+    ]);
+    await expect(listUserGroupEmailsByUserId(7)).resolves.toEqual([
+      "hs-staff@psd401.net",
+      "all-staff@psd401.net",
+    ]);
+    expect(executeQueryMock).toHaveBeenCalledTimes(1);
+    // The query is tagged so it is greppable in the log stream.
+    expect(executeQueryMock).toHaveBeenCalledWith(
+      expect.any(Function),
+      "listUserGroupEmailsByUserId"
+    );
+  });
+
+  it("returns [] and does NOT query for a non-positive / NaN user id (fails closed)", async () => {
+    await expect(listUserGroupEmailsByUserId(0)).resolves.toEqual([]);
+    await expect(listUserGroupEmailsByUserId(-3)).resolves.toEqual([]);
+    await expect(listUserGroupEmailsByUserId(Number.NaN)).resolves.toEqual([]);
+    expect(executeQueryMock).not.toHaveBeenCalled();
+  });
+
+  it("returns [] when the user has no memberships", async () => {
+    executeQueryMock.mockResolvedValueOnce([]);
+    await expect(listUserGroupEmailsByUserId(7)).resolves.toEqual([]);
+  });
+});


### PR DESCRIPTION
Closes #1205 (Epic #1202, Phase 2).

## What

Atrium content becomes shareable directly to a synced Google group: a new `group` value on the `grant_kind` enum, `grant_value` = lowercased group email, evaluated against the caller's synced memberships (`group_members` joined on lowercased email, `groups.is_active = true` only).

- **Migration 110** — `ALTER TYPE grant_kind ADD VALUE IF NOT EXISTS 'group'` (single-statement, idempotent; `grant_kind` was created in migration 085 under the migration role, so the 42501 owner-privilege trap does not apply). Registered in `migrations.json`.
- **Twin predicates, same commit** — `canView` (JS) group branch and `buildVisibilitySql` (SQL) EXISTS clause, both gated on `visibility_level = 'group'` so a stray group grant on a private/internal object grants nothing (guard mirrored both sides, per the documented invariant).
- **Principal plumbing** — `Principal.groups: string[]` populated via `listUserGroupEmailsByUserId` in the session requester, REST/MCP requester, and delegated-agent paths. Delegated agents inherit the human's groups; autonomous agents have none (the type carries no `groups` field for that kind).
- **REST + MCP surface** — `restGrantSchema` (shared by the v1 content routes and the MCP `create_document` / `create_artifact` / `set_visibility` tools) accepts `kind: "group"`; tool descriptions updated.
- **Grant editor UI** — VisibilityChip gains a group picker fed by `listActiveGroupsForPicker` (active synced groups only); values trimmed + lowercased to mirror the server's `normalizeGrantValue`.
- **Retrieval** — no code change needed: `retrieval-service.ts` re-checks `canView` per hit; pinned by a unit test.

## Self-review round (6 agents: schema-drift, SQL, adversarial, TypeScript, correctness, security)

Three defects found and fixed in `0ea5ad8c`:

1. **Migration 110 was not registered in `infra/database/migrations.json`** (found independently by 3 reviewers). The runner executes only manifest-listed files — the enum value would never have reached any environment, and every group-grant write would have failed with `invalid input value for enum grant_kind`. Now registered, plus a new manifest guard test that asserts every schema file is listed (rollback scripts excepted), every listed file exists, and nothing is listed twice.
2. **`restGrantSchema` omitted `"group"`** — REST/MCP callers were 400-rejected before reaching the service, making the feature UI-only. Fixed + pinned to the canonical `GRANT_KIND_SET` by a new unit test so the two validators can't drift again.
3. **MCP tool-description prose** still listed five kinds — updated with the fix for 2.

Security review: 0 P1/P2. Remaining review notes are in "Proposed follow-ups" below — none implemented in this PR.

## Acceptance criteria → evidence

| Criterion | Evidence |
|---|---|
| Member reads (point + list agree); non-member 404s existence-masked | Gated e2e (200 member / 404 outsider) + real-DB smoke (list/point parity, member sees exactly the granted doc) |
| `visibleCountsByCollection` + `listVisible` (SQL) match `canView` (JS) | New Bun smoke `test:smoke:atrium-group-visibility-list` runs both paths against the real local DB and asserts agreement for member and outsider on both seeded docs; both list functions consume the single `buildVisibilitySql` predicate |
| Group grant on an internal object grants nothing extra | Unit guard-mirror tests: private (member) + internal (unauthenticated), both deny |
| Retrieval returns group-shared content to members only | `atrium-retrieval-permission-aware.test.ts` group cases |
| Grant editor offers synced groups; stores lowercase email | VisibilityChip picker (active groups only) + normalization mirror; `applyGrantsInTx` lowercases on write |
| Gated functional e2e spec (session-auth, :3100) | 3/3 passing, incl. a new deactivated-group case: member of an `is_active = false` group 404s on a doc granted only to that group — end-to-end proof of the revocation filter |
| Lint, typecheck, unit tests | eslint clean on touched files, `tsc --noEmit` clean (also fixed a TS2556 this branch had introduced in a test mock), `test:ci` 2701 passed / 0 failed |

## Verification transcript

- `bun run test:ci` — 218 suites passed, 2701 tests passed (one unrelated worker SIGSEGV in `token-encryption.test.ts` on an earlier run; passes in isolation and in the final full run — flake).
- `bunx tsc --noEmit` — clean.
- Gated e2e via `scripts/test/e2e-local.sh` — 3/3 passed against a :3100 dev server with migration 110 + seed applied to local Docker postgres.
- `test:smoke:atrium-group-visibility-list` — 9/9 checks against the real local DB.

## Deploy note

Migration 110 ships through the normal db-init path on next deploy. Group grants written before the deploy are impossible (enum value absent), so there is no backfill concern; the UI picker only appears where the enum already exists.

## Proposed follow-ups (review findings, deliberately NOT in this PR)

1. **Write-time group-existence validation** — **DECIDED (product owner, 2026-07-14): current behavior is fine.** `assertValidGrant` checks email shape only; a typo'd group fails closed (grants no one). No follow-up.
2. **Group directory disclosure** (security P3) — **ACCEPTED (product owner, 2026-07-14): the directory must be visible to every content author, or they could not share to groups.** Same trust model as the `roles` list in the same picker; the admin groups pages stay admin-gated because they expose membership/sync internals, not just names.
3. **VisibilityChip type duplication** (TS review): local `Level`/`GrantKind`/`Grant` unions duplicate `@/lib/content/types` and are bridged by `as` casts — a future 7th kind added server-side would compile silently without reaching the UI types. Import the canonical types instead.
4. **Pre-existing `reconcileSavedGrants` display quirk** (correctness P2, predates this branch): after an unsaved grant edit followed by a narrow-to-private save, the chip's "last persisted" state can under-report a user grant the DB still honors. UI display only; read-path enforcement unaffected.


https://claude.ai/code/session_01QbDxJiHYTJM5exQAnLANG3
