### PR TITLE
feat: #1207 - Group sync Phase 4 hardening (email uniqueness, sync alarms, allowed_roles removal, docs)

### DIFF
--- a/actions/db/get-current-user-action.ts
+++ b/actions/db/get-current-user-action.ts
@@ -11,6 +11,7 @@ import {
   reconcileUserManagedRoles
 } from "@/lib/db/drizzle"
 import { getServerSession } from "@/lib/auth/server-session"
+import { defaultRoleForNewUser } from "@/lib/auth/default-role"
 import { ActionState } from "@/types"
 import { SelectUser } from "@/types/db-types"
 import { 
@@ -142,31 +143,37 @@ export async function getCurrentUserAction(): Promise<
         lastName: user.lastName
       })
 
-      // Assign default role using UPSERT pattern (ON CONFLICT DO NOTHING)
-      // Concurrent requests will safely skip if role already assigned
-      const isNumericUsername = /^\d+$/.test(username)
-      const defaultRole = isNumericUsername ? "student" : "staff"
+      // Assign the default role (legacy username heuristic — single source of
+      // truth in lib/auth/default-role.ts; group-sync reconciliation below is
+      // authoritative). `null` means "assign no default role" once the heuristic
+      // is retired (coverage-gated, #1207); today it never returns null.
+      const defaultRole = defaultRoleForNewUser(userEmail)
 
-      log.info("Assigning default role based on username (UPSERT)", {
-        username,
-        isNumeric: isNumericUsername,
-        assignedRole: defaultRole
-      })
-
-      // addUserRole runs in a transaction, handles role lookup, and increments
-      // role_version for session cache invalidation — consistent with resolveUserId
-      try {
-        await addUserRole(user!.id, defaultRole)
-        log.info(`${defaultRole} role assigned to user`, {
-          userId: user.id,
-          roleName: defaultRole
+      if (defaultRole) {
+        log.info("Assigning default role based on username (UPSERT)", {
+          username,
+          assignedRole: defaultRole
         })
-      } catch (roleError) {
-        // Non-fatal: user is provisioned but may lack a role until next login
-        log.warn("Default role assignment failed", {
-          userId: user.id,
-          attemptedRole: defaultRole,
-          error: roleError instanceof Error ? roleError.message : "Unknown error"
+
+        // addUserRole runs in a transaction, handles role lookup, and increments
+        // role_version for session cache invalidation — consistent with resolveUserId
+        try {
+          await addUserRole(user!.id, defaultRole)
+          log.info(`${defaultRole} role assigned to user`, {
+            userId: user.id,
+            roleName: defaultRole
+          })
+        } catch (roleError) {
+          // Non-fatal: user is provisioned but may lack a role until next login
+          log.warn("Default role assignment failed", {
+            userId: user.id,
+            attemptedRole: defaultRole,
+            error: roleError instanceof Error ? roleError.message : "Unknown error"
+          })
+        }
+      } else {
+        log.info("No default role assigned (heuristic retired) — relying on group-sync", {
+          userId: user.id
         })
       }
     }

--- a/actions/db/get-current-user-action.ts
+++ b/actions/db/get-current-user-action.ts
@@ -210,8 +210,29 @@ export async function getCurrentUserAction(): Promise<
       updatePayload.email = userEmail
     }
 
-    const updatedUser = await updateUser(user.id, updatePayload)
-    user = updatedUser as unknown as SelectUser
+    // The email refresh can violate uq_users_email_lower (migration 112, #1207) when
+    // the session's new address already belongs to a DIFFERENT user row (an aliased
+    // Workspace address, or a stale duplicate that predates the index). That must NOT
+    // hard-fail the whole "who am I" lookup and lock the user out — retry WITHOUT the
+    // email so last-sign-in/name still persist, keep the last-known email, and let an
+    // admin resolve the collision (report-duplicate-emails.ts). Consistent with the
+    // non-fatal treatment of the other authz-constraint writes in this PR.
+    try {
+      const updatedUser = await updateUser(user.id, updatePayload)
+      user = updatedUser as unknown as SelectUser
+    } catch (updateError) {
+      if ("email" in updatePayload) {
+        log.warn("Email refresh hit a uniqueness conflict — keeping last-known email", {
+          userId: user.id,
+          error: updateError instanceof Error ? updateError.message : "Unknown error"
+        })
+        const { email: _droppedEmail, ...withoutEmail } = updatePayload
+        const updatedUser = await updateUser(user.id, withoutEmail)
+        user = updatedUser as unknown as SelectUser
+      } else {
+        throw updateError
+      }
+    }
 
     // Reconcile managed (group-sync) roles from the user's current Google group
     // memberships BEFORE reading roles back, so the response reflects any

--- a/app/(protected)/admin/models/_components/json-import-dialog.tsx
+++ b/app/(protected)/admin/models/_components/json-import-dialog.tsx
@@ -20,7 +20,6 @@ interface ModelJsonInput {
   active?: boolean
   nexusEnabled?: boolean
   architectEnabled?: boolean
-  allowedRoles?: string[]
   inputCostPer1kTokens?: string
   outputCostPer1kTokens?: string
   cachedInputCostPer1kTokens?: string

--- a/app/(protected)/admin/models/_components/model-detail-modal.tsx
+++ b/app/(protected)/admin/models/_components/model-detail-modal.tsx
@@ -44,7 +44,6 @@ export interface ModelFormData {
   active: boolean
   nexusEnabled: boolean
   architectEnabled: boolean
-  allowedRoles: string[]
   // Pricing
   inputCostPer1kTokens: string | null
   outputCostPer1kTokens: string | null
@@ -71,7 +70,6 @@ const emptyFormData: ModelFormData = {
   active: true,
   nexusEnabled: true,
   architectEnabled: true,
-  allowedRoles: [],
   inputCostPer1kTokens: null,
   outputCostPer1kTokens: null,
   cachedInputCostPer1kTokens: null,
@@ -102,8 +100,6 @@ interface ModelDetailModalProps {
   onOpenChange: (open: boolean) => void
   onSave: (data: ModelFormData) => Promise<void>
   onDelete?: (model: SelectAiModel) => void
-  roleOptions: MultiSelectOption[]
-  roleLoading?: boolean
 }
 
 export function ModelDetailModal({
@@ -113,8 +109,6 @@ export function ModelDetailModal({
   onOpenChange,
   onSave,
   onDelete,
-  roleOptions,
-  roleLoading = false,
 }: ModelDetailModalProps) {
   const { toast } = useToast()
   const [formData, setFormData] = useState<ModelFormData>(emptyFormData)
@@ -155,12 +149,6 @@ export function ModelDetailModal({
         }
       }
 
-      // Parse allowed roles
-      let allowedRoles: string[] = []
-      if (model.allowedRoles && Array.isArray(model.allowedRoles)) {
-        allowedRoles = model.allowedRoles
-      }
-
       setFormData({
         id: model.id,
         name: model.name,
@@ -173,7 +161,6 @@ export function ModelDetailModal({
         active: model.active,
         nexusEnabled: model.nexusEnabled ?? true,
         architectEnabled: model.architectEnabled ?? true,
-        allowedRoles,
         inputCostPer1kTokens: model.inputCostPer1kTokens || null,
         outputCostPer1kTokens: model.outputCostPer1kTokens || null,
         cachedInputCostPer1kTokens: model.cachedInputCostPer1kTokens || null,
@@ -448,29 +435,6 @@ export function ModelDetailModal({
                       customPlaceholder="Add custom capability..."
                       className="w-full"
                     />
-                  </div>
-
-                  {/* Allowed Roles (legacy — superseded by per-resource grants, #1206) */}
-                  <div className="space-y-2">
-                    <Label>
-                      Allowed Roles (legacy)
-                      {roleLoading && (
-                        <span className="ml-2 text-xs text-muted-foreground">(Loading...)</span>
-                      )}
-                    </Label>
-                    <MultiSelect
-                      options={roleOptions}
-                      value={formData.allowedRoles}
-                      onChange={(v) => updateField("allowedRoles", v)}
-                      placeholder="All roles (unrestricted)"
-                      disabled
-                      className="w-full"
-                    />
-                    <p className="text-xs text-muted-foreground">
-                      Read-only. Access is now enforced by the <span className="font-medium">Access</span>{" "}
-                      editor below (roles + Google groups). This field was migrated into it and is
-                      retained only until it is removed in a later migration.
-                    </p>
                   </div>
 
                   {/* Access — authoritative per-resource grants (roles + groups), #1206 */}

--- a/app/(protected)/admin/models/_components/models-page-client.tsx
+++ b/app/(protected)/admin/models/_components/models-page-client.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState, useEffect, useCallback, useMemo } from "react"
+import { useState, useCallback, useMemo } from "react"
 import { useToast } from "@/components/ui/use-toast"
 import { Button } from "@/components/ui/button"
 import { IconRefresh, IconPlus, IconFileImport } from "@tabler/icons-react"
@@ -14,18 +14,10 @@ import { ModelsDataTable, type ModelTableRow } from "./models-data-table"
 import { ModelDetailModal, type ModelFormData } from "./model-detail-modal"
 
 import type { SelectAiModel } from "@/types/db-types"
-import type { MultiSelectOption } from "@/components/ui/multi-select"
 
 interface ModelsPageClientProps {
   initialModels: SelectAiModel[]
 }
-
-// Fallback role options
-const fallbackRoleOptions: MultiSelectOption[] = [
-  { value: "administrator", label: "Administrator", description: "Full system access" },
-  { value: "staff", label: "Staff", description: "Staff member access" },
-  { value: "student", label: "Student", description: "Basic user access" },
-]
 
 export function ModelsPageClient({ initialModels }: ModelsPageClientProps) {
   const { toast } = useToast()
@@ -33,8 +25,6 @@ export function ModelsPageClient({ initialModels }: ModelsPageClientProps) {
   // State
   const [models, setModels] = useState<SelectAiModel[]>(initialModels)
   const [loading, setLoading] = useState(false)
-  const [roleOptions, setRoleOptions] = useState<MultiSelectOption[]>(fallbackRoleOptions)
-  const [roleLoading, setRoleLoading] = useState(true)
   const [loadingToggles, setLoadingToggles] = useState<Set<number>>(new Set())
 
   // Filters
@@ -149,68 +139,10 @@ export function ModelsPageClient({ initialModels }: ModelsPageClientProps) {
     architectEnabled: model.architectEnabled ?? true,
   }))
 
-  // Fetch roles on mount
-  useEffect(() => {
-    let cancelled = false
-    const controller = new AbortController()
-
-    const fetchRoles = async () => {
-      try {
-        setRoleLoading(true)
-        const response = await fetch("/api/admin/roles", {
-          signal: controller.signal,
-        })
-
-        if (!response.ok || cancelled) {
-          setRoleOptions(fallbackRoleOptions)
-          return
-        }
-
-        const data = await response.json()
-
-        if (!data.isSuccess || !Array.isArray(data.data)) {
-          setRoleOptions(fallbackRoleOptions)
-          return
-        }
-
-        const options: MultiSelectOption[] = data.data
-          .filter(
-            (role: unknown): role is { id: string; name: string; description?: string } =>
-              role != null &&
-              typeof role === "object" &&
-              "id" in role &&
-              "name" in role &&
-              typeof (role as { id: unknown }).id === "string" &&
-              typeof (role as { name: unknown }).name === "string"
-          )
-          .map((role: { name: string; description?: string }) => ({
-            value: role.name,
-            label: role.name,
-            description: role.description || "User role",
-          }))
-
-        if (!cancelled) {
-          setRoleOptions(options.length > 0 ? options : fallbackRoleOptions)
-        }
-      } catch {
-        // Failed to fetch roles - fallback to defaults
-        if (!cancelled) {
-          setRoleOptions(fallbackRoleOptions)
-        }
-      } finally {
-        if (!cancelled) {
-          setRoleLoading(false)
-        }
-      }
-    }
-
-    fetchRoles()
-
-    return () => {
-      cancelled = true
-      controller.abort()
-    }
-  }, [])
+  // NOTE (#1207): the roles fetch (/api/admin/roles) was removed — it existed
+  // only to populate the legacy "Allowed Roles" model field, which is gone.
+  // Per-model role/group access is edited via the ResourceGrantsEditor inside the
+  // model modal (resource_access_grants).
 
   // Refresh data
   const loadData = useCallback(async () => {
@@ -559,7 +491,6 @@ export function ModelsPageClient({ initialModels }: ModelsPageClientProps) {
             data.capabilitiesList.length > 0
               ? JSON.stringify(data.capabilitiesList)
               : null,
-          allowedRoles: data.allowedRoles.length > 0 ? data.allowedRoles : null,
           nexusCapabilities:
             Object.keys(syncedNexusCapabilities).length > 0 ? syncedNexusCapabilities : null,
           providerMetadata:
@@ -703,8 +634,6 @@ export function ModelsPageClient({ initialModels }: ModelsPageClientProps) {
         onOpenChange={setModalOpen}
         onSave={handleSaveModel}
         onDelete={handleDeleteFromModal}
-        roleOptions={roleOptions}
-        roleLoading={roleLoading}
       />
 
       {/* Replacement Dialog */}

--- a/app/(protected)/compare/_components/compare-input.tsx
+++ b/app/(protected)/compare/_components/compare-input.tsx
@@ -76,7 +76,6 @@ export function CompareInput({
             placeholder="Select first model"
             showDescription={false}
             groupByProvider={true}
-            hideRoleRestricted={true}
             hideCapabilityMissing={true}
             aria-label="Select first model"
           />
@@ -93,7 +92,6 @@ export function CompareInput({
             placeholder="Select second model"
             showDescription={false}
             groupByProvider={true}
-            hideRoleRestricted={true}
             hideCapabilityMissing={true}
             aria-label="Select second model"
           />

--- a/app/api/admin/models/import/route.ts
+++ b/app/api/admin/models/import/route.ts
@@ -1,14 +1,16 @@
 import { NextResponse } from "next/server";
 import { requireAdmin } from "@/lib/auth/admin-check";
-import { bulkImportAIModels } from "@/lib/db/drizzle";
+import { bulkImportAIModels, getAIModelByModelId } from "@/lib/db/drizzle";
+import { setModelRoleGrantsFromNames } from "@/lib/db/drizzle/resource-access";
 import { createLogger, generateRequestId, startTimer } from "@/lib/logger";
 import { validateModel } from "@/lib/validators/model-import-validator";
 
-// NOTE (#1207): the legacy `allowedRoles` field was removed from the import format
-// along with the ai_models.allowed_roles column. Imported models start
-// unrestricted; per-model role/group access is set afterward via the
-// ResourceGrantsEditor (resource_access_grants). An `allowedRoles` key in an older
-// import file is accepted-but-ignored (validateModel no longer inspects it).
+// NOTE (#1207): the ai_models.allowed_roles COLUMN is gone, but the import format
+// still accepts the legacy `allowedRoles` field so older import files keep working.
+// It is now TRANSLATED into `role`-kind resource_access_grants after import (see the
+// bridge below) rather than written to a column. This is deliberate: dropping it
+// silently would leave a previously-restricted model with zero grant rows — i.e.
+// UNRESTRICTED (visible to everyone), since zero grants means "no restriction".
 
 // Maximum models per import
 const MAX_MODELS_PER_IMPORT = 100;
@@ -26,6 +28,8 @@ interface ModelJsonInput {
   active?: boolean;
   nexusEnabled?: boolean;
   architectEnabled?: boolean;
+  // Legacy access field — translated into role grants post-import (see header).
+  allowedRoles?: string[];
   inputCostPer1kTokens?: string;
   outputCostPer1kTokens?: string;
   cachedInputCostPer1kTokens?: string;
@@ -193,9 +197,27 @@ export async function POST(request: Request) {
     // Execute bulk import
     const result = await bulkImportAIModels(modelsToImport);
 
+    // Translate any legacy `allowedRoles` into `role`-kind resource_access_grants
+    // (#1207). Without this, an import that specified a role restriction would land
+    // as zero grant rows = UNRESTRICTED (visible to everyone). Only touches models
+    // that actually carry the field; preserves any group grants already set.
+    const byModelId = new Map<string, string[]>();
+    for (const model of models as ModelJsonInput[]) {
+      if (Array.isArray(model.allowedRoles)) {
+        byModelId.set(model.modelId, model.allowedRoles);
+      }
+    }
+    for (const [modelIdStr, roleNames] of byModelId) {
+      const persisted = await getAIModelByModelId(modelIdStr);
+      if (persisted) {
+        await setModelRoleGrantsFromNames(persisted.id, roleNames, null);
+      }
+    }
+
     log.info("Bulk import completed", {
       created: result.created,
       updated: result.updated,
+      roleGrantsTranslated: byModelId.size,
     });
     timer({ status: "success", created: result.created, updated: result.updated });
 

--- a/app/api/admin/models/import/route.ts
+++ b/app/api/admin/models/import/route.ts
@@ -1,9 +1,14 @@
 import { NextResponse } from "next/server";
 import { requireAdmin } from "@/lib/auth/admin-check";
-import { bulkImportAIModels, getAIModelByModelId } from "@/lib/db/drizzle";
-import { syncModelAllowedRoleGrants } from "@/lib/db/drizzle/resource-access";
+import { bulkImportAIModels } from "@/lib/db/drizzle";
 import { createLogger, generateRequestId, startTimer } from "@/lib/logger";
 import { validateModel } from "@/lib/validators/model-import-validator";
+
+// NOTE (#1207): the legacy `allowedRoles` field was removed from the import format
+// along with the ai_models.allowed_roles column. Imported models start
+// unrestricted; per-model role/group access is set afterward via the
+// ResourceGrantsEditor (resource_access_grants). An `allowedRoles` key in an older
+// import file is accepted-but-ignored (validateModel no longer inspects it).
 
 // Maximum models per import
 const MAX_MODELS_PER_IMPORT = 100;
@@ -21,7 +26,6 @@ interface ModelJsonInput {
   active?: boolean;
   nexusEnabled?: boolean;
   architectEnabled?: boolean;
-  allowedRoles?: string[];
   inputCostPer1kTokens?: string;
   outputCostPer1kTokens?: string;
   cachedInputCostPer1kTokens?: string;
@@ -173,7 +177,6 @@ export async function POST(request: Request) {
       active: model.active,
       nexusEnabled: model.nexusEnabled,
       architectEnabled: model.architectEnabled,
-      allowedRoles: model.allowedRoles,
       inputCostPer1kTokens: model.inputCostPer1kTokens
         ? String(model.inputCostPer1kTokens)
         : undefined,
@@ -189,18 +192,6 @@ export async function POST(request: Request) {
 
     // Execute bulk import
     const result = await bulkImportAIModels(modelsToImport);
-
-    // Bridge the legacy allowed_roles column into resource_access_grants
-    // (#1206 P1 follow-up) — without this, an imported model with allowedRoles
-    // set has zero grant rows and the new gate treats it as unrestricted.
-    // Reads back the persisted state so it reflects bulkImportAIModels' actual
-    // create-vs-preserve-existing merge, not just the raw request payload.
-    for (const modelId of modelIds) {
-      const persisted = await getAIModelByModelId(modelId);
-      if (persisted) {
-        await syncModelAllowedRoleGrants(persisted.id, persisted.allowedRoles, null);
-      }
-    }
 
     log.info("Bulk import completed", {
       created: result.created,

--- a/app/api/admin/models/route.ts
+++ b/app/api/admin/models/route.ts
@@ -1,96 +1,13 @@
 import { NextResponse } from 'next/server';
-import { getAIModels, getAIModelById, createAIModel, updateAIModel, deleteAIModel, getRoles } from '@/lib/db/drizzle';
-import { syncModelAllowedRoleGrants } from '@/lib/db/drizzle/resource-access';
+import { getAIModels, createAIModel, updateAIModel, deleteAIModel } from '@/lib/db/drizzle';
 import { requireAdmin } from '@/lib/auth/admin-check';
 import { createLogger, generateRequestId, startTimer } from '@/lib/logger';
 import { normalizeBoolean } from '@/lib/validations/api-schemas';
 
-/**
- * Validate and sanitize allowedRoles field
- * @param allowedRoles - The roles to validate (can be string or array)
- * @param log - Logger instance for warnings
- * @returns Validated array of role names or null (Drizzle handles serialization)
- */
-async function validateAllowedRoles(
-  allowedRoles: unknown,
-  log: ReturnType<typeof createLogger>
-): Promise<string[] | null> {
-  if (!allowedRoles) return null;
-
-  try {
-    // Parse if string
-    let roles: unknown;
-    if (typeof allowedRoles === 'string') {
-      // Try to parse as JSON
-      try {
-        roles = JSON.parse(allowedRoles);
-      } catch {
-        // Not JSON, treat as single role
-        roles = [allowedRoles];
-      }
-    } else {
-      roles = allowedRoles;
-    }
-
-    // Validate it's an array of strings
-    if (!Array.isArray(roles)) {
-      log.warn('Invalid allowedRoles format - not an array', { allowedRoles });
-      return null;
-    }
-
-    const validRoles = roles.filter(r => typeof r === 'string' && r.trim().length > 0);
-
-    if (validRoles.length === 0) {
-      return null;
-    }
-
-    // Validate against existing roles in the system
-    const existingRoles = await getRoles();
-    const existingRoleNames = existingRoles.map(r => r.name);
-    const filteredRoles = validRoles.filter(r => existingRoleNames.includes(r));
-
-    if (filteredRoles.length !== validRoles.length) {
-      const invalidRoles = validRoles.filter(r => !existingRoleNames.includes(r));
-      log.warn('Some roles do not exist in the system', {
-        invalidRoles,
-        validRoles: filteredRoles
-      });
-    }
-
-    // Return validated roles as array - Drizzle handles serialization
-    return filteredRoles.length > 0 ? filteredRoles : null;
-  } catch (error) {
-    log.warn('Failed to validate allowedRoles', {
-      allowedRoles,
-      error: error instanceof Error ? error.message : 'Unknown error'
-    });
-    return null;
-  }
-}
-
-/**
- * Whether two allowedRoles values name the same role set. Order- and
- * case-insensitive (grant matching lowercases role names); null/empty are
- * equivalent ("unrestricted").
- */
-function sameRoleSet(
-  a: string[] | null | undefined,
-  b: string[] | null | undefined
-): boolean {
-  const normalize = (v: string[] | null | undefined) =>
-    [...new Set((v ?? []).map((r) => r.toLowerCase()))].sort();
-  const na = normalize(a);
-  const nb = normalize(b);
-  return na.length === nb.length && na.every((r, i) => r === nb[i]);
-}
-
-/** Sync the allowed_roles → role-grants bridge only when the update actually changes the role set. */
-function shouldSyncAllowedRoles(
-  updates: { allowedRoles?: string[] | null },
-  prior: { allowedRoles: string[] | null } | null | undefined
-): boolean {
-  return 'allowedRoles' in updates && !sameRoleSet(prior?.allowedRoles, updates.allowedRoles);
-}
+// NOTE (#1207): per-model role/group access is set ONLY via the ResourceGrantsEditor
+// (resource_access_grants — see actions/db/resource-grants-actions.ts). The legacy
+// ai_models.allowed_roles column and its write-time grant bridge were removed here;
+// this route no longer reads, validates, writes, or bridges allowedRoles.
 
 /**
  * Validate and sanitize capabilities field
@@ -236,17 +153,15 @@ export async function POST(request: Request) {
 
     log.debug("Creating model", { modelName: body.name, provider: body.provider });
 
-    // Validate and sanitize capabilities and allowedRoles
+    // Validate and sanitize capabilities
     const validatedCapabilities = validateCapabilities(body.capabilities, log);
-    const validatedAllowedRoles = await validateAllowedRoles(body.allowedRoles, log);
-    
+
     const modelData = {
       name: body.name,
       modelId: body.modelId,
       provider: body.provider,
       description: body.description,
       capabilities: validatedCapabilities || undefined,
-      allowedRoles: validatedAllowedRoles || undefined,
       maxTokens: body.maxTokens ? Number.parseInt(body.maxTokens) : undefined,
       active: body.active ?? true,
       nexusEnabled: body.nexusEnabled ?? true,
@@ -268,13 +183,6 @@ export async function POST(request: Request) {
     };
 
     const model = await createAIModel(modelData);
-
-    // Bridge the legacy allowed_roles column into resource_access_grants
-    // (#1206 P1 follow-up) — without this, a model created with allowedRoles
-    // set has zero grant rows and the new gate treats it as unrestricted.
-    if ('allowedRoles' in body) {
-      await syncModelAllowedRoleGrants(model.id, validatedAllowedRoles, null);
-    }
 
     log.info("Model created successfully", { modelId: model.id });
     timer({ status: "success" });
@@ -322,12 +230,15 @@ export async function PUT(request: Request) {
     if ('capabilities' in updates) {
       updates.capabilities = validateCapabilities(updates.capabilities, log);
     }
-    
-    // Validate and sanitize allowedRoles if present
+
+    // NOTE (#1207): allowedRoles is no longer accepted here — role/group access
+    // is edited via the ResourceGrantsEditor (resource_access_grants). Strip any
+    // allowedRoles key an older client still echoes so it can never reach the
+    // (now-dropped) column via updateAIModel's `.set({ ...updates })` spread.
     if ('allowedRoles' in updates) {
-      updates.allowedRoles = await validateAllowedRoles(updates.allowedRoles, log);
+      delete updates.allowedRoles;
     }
-    
+
     // Convert maxTokens to number if present
     if (updates.maxTokens !== undefined) {
       updates.maxTokens = updates.maxTokens ? Number.parseInt(updates.maxTokens) : null;
@@ -353,22 +264,7 @@ export async function PUT(request: Request) {
       updates.pricingUpdatedAt = updates.pricingUpdatedAt.toISOString();
     }
 
-    // Snapshot the persisted allowedRoles BEFORE the update so the grant
-    // bridge below can tell a deliberate change from an unchanged echo.
-    const priorModel = await getAIModelById(id);
-
     const model = await updateAIModel(id, updates);
-
-    // Bridge the legacy allowed_roles column into resource_access_grants
-    // (#1206 P1 follow-up) — without this, an update that sets/clears
-    // allowedRoles drifts from the new gate, which reads grant rows only.
-    // Only sync on a REAL change: the admin modal renders allowedRoles as a
-    // read-only legacy field but still echoes it on every Save, while role
-    // grants are owned by the Access editor — an unconditional re-sync would
-    // clobber editor-set role grants back to the stale legacy value.
-    if (shouldSyncAllowedRoles(updates, priorModel)) {
-      await syncModelAllowedRoleGrants(id, updates.allowedRoles, null);
-    }
 
     log.info("Model updated successfully", { modelId: id });
     timer({ status: "success" });

--- a/components/features/assistant-architect/prompt-editor-modal.tsx
+++ b/components/features/assistant-architect/prompt-editor-modal.tsx
@@ -500,7 +500,6 @@ function SettingsColumn({
             placeholder="Select an AI model"
             className="bg-muted"
             requiredCapabilities={CHAT_CAPABILITIES}
-            hideRoleRestricted={true}
             hideCapabilityMissing={true}
           />
         </div>

--- a/components/features/model-selector/model-selector-form-adapter.tsx
+++ b/components/features/model-selector/model-selector-form-adapter.tsx
@@ -13,7 +13,6 @@ interface ModelSelectorFormAdapterProps {
   className?: string
   showDescription?: boolean
   requiredCapabilities?: string[]
-  hideRoleRestricted?: boolean
   hideCapabilityMissing?: boolean
 }
 
@@ -30,7 +29,6 @@ export function ModelSelectorFormAdapter({
   className,
   showDescription = true,
   requiredCapabilities = [],
-  hideRoleRestricted = false,
   hideCapabilityMissing = false
 }: ModelSelectorFormAdapterProps) {
   // Convert string ID to model object
@@ -55,7 +53,6 @@ export function ModelSelectorFormAdapter({
       showDescription={showDescription}
       groupByProvider={true}
       requiredCapabilities={requiredCapabilities}
-      hideRoleRestricted={hideRoleRestricted}
       hideCapabilityMissing={hideCapabilityMissing}
     />
   )

--- a/components/features/model-selector/model-selector-types.ts
+++ b/components/features/model-selector/model-selector-types.ts
@@ -10,14 +10,12 @@ export interface ModelSelectorProps {
   placeholder?: string
   disabled?: boolean
   className?: string
-  allowedRoles?: string[]
   groupByProvider?: boolean
   showDescription?: boolean
   virtualizeThreshold?: number
   searchable?: boolean
   loading?: boolean
   error?: string
-  hideRoleRestricted?: boolean
   hideCapabilityMissing?: boolean
   "aria-label"?: string
   "aria-describedby"?: string
@@ -36,7 +34,6 @@ export interface FilteredModel extends SelectAiModel {
   isAccessible: boolean
   accessDeniedReason?: string
   matchesCapabilities: boolean
-  hasRoleAccess: boolean
   missingCapabilities?: string[]
 }
 
@@ -45,10 +42,7 @@ export interface UseFilteredModelsOptions {
   requiredCapabilities?: string[]
   /** Model must have at least one of these capabilities (OR logic). Combined with requiredCapabilities (AND). */
   anyOfCapabilities?: string[]
-  allowedRoles?: string[]
-  userRoles?: string[]
   searchQuery?: string
-  hideRoleRestricted?: boolean
   hideCapabilityMissing?: boolean
 }
 

--- a/components/features/model-selector/model-selector.tsx
+++ b/components/features/model-selector/model-selector.tsx
@@ -13,7 +13,6 @@ import {
 } from "@/components/ui/command"
 import { IconRobot, IconChevronDown } from "@tabler/icons-react"
 import { cn } from "@/lib/utils"
-import { createLogger } from "@/lib/client-logger"
 import { useFilteredModels } from "./use-filtered-models"
 import { ModelSelectorItem } from "./model-selector-item"
 import type { ModelSelectorProps } from "./model-selector-types"
@@ -28,14 +27,12 @@ export function ModelSelector({
   placeholder = "Select a model",
   disabled = false,
   className,
-  allowedRoles = [],
   groupByProvider = true,
   showDescription = true,
   virtualizeThreshold = 50,
   searchable = true,
   loading = false,
   error,
-  hideRoleRestricted = false,
   hideCapabilityMissing = false,
   "aria-label": ariaLabel = "Select AI model",
   "aria-describedby": ariaDescribedBy
@@ -43,7 +40,6 @@ export function ModelSelector({
   const [open, setOpen] = useState(false)
   const [search, setSearch] = useState("")
   const [debouncedSearch, setDebouncedSearch] = useState("")
-  const [userRoles, setUserRoles] = useState<string[]>([])
   const commandListRef = useRef<HTMLDivElement>(null)
   const debounceTimerRef = useRef<NodeJS.Timeout | undefined>(undefined)
 
@@ -64,35 +60,11 @@ export function ModelSelector({
     }
   }, [search])
 
-  // Fetch user roles on mount. This drives ONLY the advisory in-dropdown
-  // labeling; server-side access is authoritative (#1206): GET /api/models
-  // already returns only the models this user may access, so an inaccessible
-  // model never reaches the client. On a roles-fetch failure we keep userRoles
-  // empty, which makes any still-listed role-restricted model render as
-  // INaccessible — a fail-CLOSED default, never fail-open. The former silent
-  // catch (which claimed to "show all models without role filtering") is
-  // replaced with an observable warning.
-  useEffect(() => {
-    const log = createLogger({ component: "ModelSelector" })
-    async function fetchUserRoles() {
-      try {
-        const response = await fetch('/api/user/roles')
-        if (response.ok) {
-          const data = await response.json()
-          setUserRoles(data.roles || [])
-        } else {
-          log.warn("Failed to fetch user roles for model selector; failing closed", {
-            status: response.status,
-          })
-        }
-      } catch (error) {
-        log.warn("Error fetching user roles for model selector; failing closed", {
-          error: error instanceof Error ? error.message : String(error),
-        })
-      }
-    }
-    fetchUserRoles()
-  }, [])
+  // NOTE (#1207): the ModelSelector no longer fetches the user's roles. Per-model
+  // role/group access is enforced server-side — GET /api/models filters the list
+  // through resource_access_grants (#1206), so an inaccessible model never reaches
+  // this component. The former /api/user/roles fetch existed only to drive the
+  // now-removed client-side role filter. Only capability filtering remains.
 
   const {
     filteredModels,
@@ -103,10 +75,7 @@ export function ModelSelector({
     models,
     requiredCapabilities,
     anyOfCapabilities,
-    allowedRoles,
-    userRoles,
     searchQuery: debouncedSearch,
-    hideRoleRestricted,
     hideCapabilityMissing
   })
 

--- a/components/features/model-selector/use-filtered-models.ts
+++ b/components/features/model-selector/use-filtered-models.ts
@@ -59,13 +59,17 @@ export function useFilteredModels({
   models,
   requiredCapabilities = [],
   anyOfCapabilities = [],
-  allowedRoles = [],
-  userRoles = [],
   searchQuery = "",
-  hideRoleRestricted = false,
   hideCapabilityMissing = false
 }: UseFilteredModelsOptions): UseFilteredModelsResult {
 
+  // NOTE (#1207): per-model ROLE access is enforced entirely server-side now —
+  // /api/models filters the list through resource_access_grants before it ever
+  // reaches the client, so a model the user cannot access is simply absent. The
+  // old client-side role filter (model.allowedRoles vs the user's roles) was
+  // advisory, fail-open, and duplicated that server gate; it was removed along
+  // with the ai_models.allowed_roles column. Only CAPABILITY filtering (a UI
+  // concern — which models can do image/vision/etc.) remains here.
   const result = useMemo(() => {
     let filteredModels: FilteredModel[] = models.map(model => {
       // Safely parse capabilities
@@ -84,19 +88,7 @@ export function useFilteredModels({
 
       const matchesCapabilities = matchesRequiredCapabilities && matchesAnyOfCapabilities
 
-      // Safely parse allowed roles for the model
-      const modelAllowedRoles = safeParseJsonArray(model.allowedRoles, [])
-
-      // Check role-based access
-      // If modelAllowedRoles is empty or null, model is accessible to all
-      const hasRoleAccess = modelAllowedRoles.length === 0 || 
-        modelAllowedRoles.some(role => userRoles.includes(role))
-      
-      // Check if user's allowed roles match (for component-level filtering)
-      const meetsAllowedRoles = allowedRoles.length === 0 ||
-        allowedRoles.some(role => userRoles.includes(role))
-
-      const isAccessible = matchesCapabilities && hasRoleAccess && meetsAllowedRoles
+      const isAccessible = matchesCapabilities
 
       // Combine AND-missing and anyOf-missing capabilities for accurate UI feedback
       const allMissingCapabilities = [
@@ -116,10 +108,6 @@ export function useFilteredModels({
         } else {
           accessDeniedReason = `Missing required capabilities`
         }
-      } else if (!hasRoleAccess) {
-        accessDeniedReason = `Requires role: ${modelAllowedRoles.join(' or ')}`
-      } else if (!meetsAllowedRoles) {
-        accessDeniedReason = `Your role doesn't have access to this feature`
       }
 
       return {
@@ -127,16 +115,10 @@ export function useFilteredModels({
         isAccessible,
         accessDeniedReason,
         matchesCapabilities,
-        hasRoleAccess,
         missingCapabilities: allMissingCapabilities.length > 0 ? allMissingCapabilities : undefined
       } as FilteredModel
     })
 
-    // Filter out role-restricted models if hideRoleRestricted is true
-    if (hideRoleRestricted) {
-      filteredModels = filteredModels.filter(model => model.hasRoleAccess)
-    }
-    
     // Filter out models missing capabilities if hideCapabilityMissing is true
     if (hideCapabilityMissing) {
       filteredModels = filteredModels.filter(model => model.matchesCapabilities)
@@ -184,7 +166,7 @@ export function useFilteredModels({
       totalCount,
       accessibleCount
     }
-  }, [models, requiredCapabilities, anyOfCapabilities, allowedRoles, userRoles, searchQuery, hideRoleRestricted, hideCapabilityMissing])
+  }, [models, requiredCapabilities, anyOfCapabilities, searchQuery, hideCapabilityMissing])
 
   return result
 }

--- a/docs/architecture/capabilities-and-scopes.md
+++ b/docs/architecture/capabilities-and-scopes.md
@@ -1,7 +1,7 @@
-# Capabilities vs. Scopes
+# Capabilities vs. Scopes vs. Resource Grants
 
-AI Studio has **two separate authorization systems**. They look similar (both
-gate access by string identifier) but serve different audiences, have different
+AI Studio has **three separate authorization axes**. They look similar (all gate
+access by string identifier) but serve different audiences, have different
 lifecycles, and must never be collapsed into one. This document explains the
 split, when to use each, and the anti-patterns that re-collapse them.
 
@@ -11,6 +11,10 @@ split, when to use each, and the anti-patterns that re-collapse them.
 >   `role_capabilities`.
 > - **Scope** — gates a programmatic API/MCP call made with an API key. Checked
 >   with `requireScope(auth, scope)`. Backed by `api_keys.scopes`.
+> - **Resource grant** — gates access to a specific **resource instance** (an AI
+>   model, an Assistant Architect assistant, an agent skill) by role **or** by a
+>   synced Google group. Checked with `userCanAccessResource(...)` /
+>   `filterAccessibleResourceIds(...)`. Backed by `resource_access_grants`.
 
 ---
 
@@ -78,23 +82,69 @@ Example scope identifiers (from `API_SCOPES`):
 
 ---
 
+## Resource grants — per-instance access by role or group
+
+A **resource grant** gates access to one specific **resource instance** — an AI
+model, an Assistant Architect assistant, or an agent skill — for a human. It is the
+third axis, added in Epic #1202 (Phase 3, #1206): where a Capability answers "may
+this user reach the Assistant Architect *feature*", a resource grant answers "may
+this user run *this particular assistant*".
+
+- **Function:** `userCanAccessResource(userId, resourceType, resourceId)` and the
+  batch `filterAccessibleResourceIds(userId, resourceType, ids)`
+  (`lib/db/drizzle/resource-access.ts`). Both are pure-SQL gates.
+- **Storage:** `resource_access_grants` — one row per
+  `(resource_type, resource_id, grant_kind, grant_value)` (migration 111).
+- **Audience:** a human authenticated via Cognito, resolving/executing a specific
+  model / assistant / skill.
+- **Enforcement points:** the execution/resolution paths (model resolution,
+  `GET /api/models` list filtering, assistant execute, skill invocation) — the
+  server is authoritative; UI filtering is advisory only.
+- **Grant kinds** (`grant_kind`):
+  - `role` → `grant_value` is a role **name** (matched case-insensitively against
+    the user's roles).
+  - `group` → `grant_value` is a synced Google group **email**, lowercased (matched
+    against the user's transitive membership of an **active** synced group — see
+    [google-group-sync.md](../features/google-group-sync.md)). This is how Google
+    group membership feeds per-resource access.
+
+**Semantics (memorize these — they mirror the retired `ai_models.allowed_roles`
+contract exactly):**
+
+- **Zero** grant rows for a resource = **unrestricted** (everyone may access).
+- **Any** matching grant row = allowed.
+- **Administrators always pass**, regardless of grants.
+
+> **History:** models used to carry a legacy `ai_models.allowed_roles` JSON column.
+> Phase 3 (#1206) backfilled it into `resource_access_grants` and moved all read
+> paths onto the grant table; Phase 4 (#1207) dropped the column and the client-side
+> role filter. There is no `allowed_roles` anymore — edit model/assistant/skill
+> access through the resource-grants editor, which writes `resource_access_grants`.
+
+---
+
 ## Why they are deliberately separate
 
-| Dimension | Capabilities | Scopes |
-|---|---|---|
-| **Audience** | Human in the UI | API key / programmatic client |
-| **Granted via** | Role assignment (`role_capabilities`) | Per-key selection, bounded by the key owner's roles |
-| **Checked by** | `hasCapabilityAccess(identifier)` | `requireScope(auth, scope)` |
-| **Backing store** | `capabilities` / `role_capabilities` | `api_keys.scopes` (JSON) |
-| **Identifier style** | feature slug (`assistant-architect`) | `resource:action` (`assistants:execute`) |
-| **Lifecycle** | follows a user's roles; changes when roles change | follows an API key; revoked when the key is rotated/deleted |
-| **Audit need** | "which humans can see feature X" | "what can this key/integration do" |
+| Dimension | Capabilities | Scopes | Resource grants |
+|---|---|---|---|
+| **Audience** | Human in the UI | API key / programmatic client | Human, per resource instance |
+| **Gates** | a UI **feature** | a programmatic **endpoint** | a specific **model/assistant/skill** |
+| **Granted via** | Role assignment (`role_capabilities`) | Per-key selection, bounded by the key owner's roles | Per-resource `role`/`group` grant rows |
+| **Checked by** | `hasCapabilityAccess(identifier)` | `requireScope(auth, scope)` | `userCanAccessResource(...)` / `filterAccessibleResourceIds(...)` |
+| **Backing store** | `capabilities` / `role_capabilities` | `api_keys.scopes` (JSON) | `resource_access_grants` |
+| **Identifier style** | feature slug (`assistant-architect`) | `resource:action` (`assistants:execute`) | `(resource_type, resource_id)` + role name / group email |
+| **Default when unset** | no access without a role grant | no access without the scope | **unrestricted** (zero rows = everyone) |
+| **Lifecycle** | follows a user's roles | follows an API key | follows the resource + its grant rows (and, for `group` grants, live sync membership) |
+| **Audit need** | "which humans can see feature X" | "what can this key/integration do" | "who can use this specific model/assistant/skill" |
 
-Collapsing them would force a single identifier namespace to serve two
+Collapsing them would force a single identifier namespace to serve different
 audiences with different revocation models and different blast radii. A leaked
-API key must be containable by revoking *the key* without touching any human's
-UI access; conversely, removing a user's UI capability must not silently widen
-or narrow what any API key can call.
+API key must be containable by revoking *the key* without touching any human's UI
+access; removing a user's UI capability must not silently widen or narrow what any
+API key can call; and restricting one model must not change feature-level access or
+any API scope. Note the **inverted default**: an ungranted Capability/Scope denies,
+but a resource with **no** grants is unrestricted (matching the model-access contract
+that predated the table).
 
 ---
 
@@ -111,17 +161,27 @@ Adding a new gated thing?
 │               in the layout / server action.
 │            3. (Optional) point a navigation_items.capability_id at it.
 │
-└─ Is it an endpoint a script / integration / MCP client calls with an API key?
-   (a /api/v1/* route, an MCP tool)
-         └─► SCOPE
-             1. Add the scope string to API_SCOPES in lib/api-keys/scopes.ts
-                and to the appropriate ROLE_SCOPES entries.
-             2. Gate the handler with requireScope(auth, "<resource:action>").
+├─ Is it an endpoint a script / integration / MCP client calls with an API key?
+│  (a /api/v1/* route, an MCP tool)
+│        └─► SCOPE
+│            1. Add the scope string to API_SCOPES in lib/api-keys/scopes.ts
+│               and to the appropriate ROLE_SCOPES entries.
+│            2. Gate the handler with requireScope(auth, "<resource:action>").
+│
+└─ Is it access to ONE specific model / assistant / skill instance, by role or
+   by Google group?
+         └─► RESOURCE GRANT
+             1. Nothing to register — grants are data. In the resource's admin
+                editor add role/group grants (writes resource_access_grants).
+             2. Gate the execution/resolution path with
+                userCanAccessResource(...) / filterAccessibleResourceIds(...).
+             3. Remember: zero grant rows = unrestricted; admins always pass.
 ```
 
 If a feature has **both** a UI surface and an API surface, it gets **both** a
 capability (for the UI) and a scope (for the API) — two identifiers, one per
-audience. They are not shared.
+audience. They are not shared. A per-instance restriction on top (e.g. "only staff
+may run *this* model") is a resource grant, independent of both.
 
 ---
 
@@ -163,5 +223,12 @@ audience. They are not shared.
 - Scopes (API access):
   - `lib/api-keys/scopes.ts` — `API_SCOPES`, `ROLE_SCOPES`, `getScopesForRoles`
   - `lib/api/auth-middleware.ts` — `requireScope`, `requireAssistantScope`
+- Resource grants (per-instance access):
+  - `lib/db/drizzle/resource-access.ts` — `userCanAccessResource`,
+    `filterAccessibleResourceIds`, `replaceResourceGrants`, `listResourceGrants`
+  - `lib/db/schema/tables/resource-access-grants.ts` — the grant table
+  - `components/features/resource-grants/` — the admin grants editor
+  - Google group membership: [features/google-group-sync.md](../features/google-group-sync.md)
 - History: Epic #922 (Unify Agent Platform), migration 079 (rename), Issue #928
-  / migration 084 (drop legacy tables).
+  / migration 084 (drop legacy tables). Resource grants: Epic #1202 Phase 3 (#1206,
+  migration 111); `ai_models.allowed_roles` dropped in Phase 4 (#1207, migration 113).

--- a/docs/features/google-group-sync.md
+++ b/docs/features/google-group-sync.md
@@ -1,0 +1,235 @@
+# Google Directory Group Sync
+
+Group membership from Google Workspace becomes a first-class authorization source
+in AI Studio: an hourly service-account sync mirrors selected Google groups (and
+their transitive membership) into the database, and that membership drives two
+things — a user's **roles** (via group→role mappings) and **per-resource access
+grants** on models, assistants, and agent skills. Authentication does **not**
+change: Cognito + Google OIDC stay exactly as deployed; groups arrive out-of-band.
+
+This is Epic #1202 (sub-issues #1203–#1207). This document is the architecture +
+operations reference; the authorization model it plugs into is described in
+[capabilities-and-scopes.md](../architecture/capabilities-and-scopes.md).
+
+---
+
+## Architecture
+
+```
+Google Workspace Directory
+        │  (hourly EventBridge rule + admin "Sync now")
+        ▼
+  group-sync Lambda  ── infra/lambdas/group-sync
+        │  service account (Cloud Identity API, or Admin SDK via DWD)
+        │  1. resolve selection (picks ∪ prefix rules)
+        │  2. fetch transitive membership per group
+        │  3. full-replace group_members per group (last-known-good fail-safety)
+        │  4. reconcile managed roles from the fresh membership
+        ▼
+   Postgres (Aurora)
+     groups · group_members · group_selection_rules       (membership, mig 106)
+     group_role_mappings                                   (group→role, mig 109)
+     user_roles.source = 'group-sync' | 'manual'           (managed-role flag, mig 109)
+     resource_access_grants (grant_kind 'role' | 'group')  (per-resource, mig 111)
+        ▲
+        │  reads
+   App (Next.js)
+     · role reconciliation at login (getCurrentUserAction) and JIT (resolveUserId)
+     · per-resource gate (lib/db/drizzle/resource-access.ts) on model/assistant/skill
+     · Atrium 'group' visibility grants (#1205)
+```
+
+### Data model
+
+| Table | Purpose | Key columns |
+|---|---|---|
+| `groups` | one row per synced Google group | `group_email` (unique on `lower()`), `is_active`, `last_synced_at`, `last_sync_error` |
+| `group_members` | transitive membership, keyed by **email** (not a users FK) | `group_id`, `member_email` (stored lowercased) |
+| `group_selection_rules` | admin selection config | `rule_type` (`pick`\|`prefix`), `value`, `is_active` |
+| `group_role_mappings` | group email → role | `group_email`, `role_id` |
+| `user_roles.source` | managed-role flag | `'group-sync'` (reconciler-owned) vs `'manual'` (admin/heuristic) |
+| `resource_access_grants` | per-resource role/group grants | `resource_type`, `resource_id`, `grant_kind`, `grant_value` |
+
+### Email is the authorization join key
+
+Membership is keyed by **email**, not a `users` foreign key, so a person who has
+never signed in still syncs; joins to `users` resolve lazily as
+`lower(users.email) = lower(group_members.member_email)`. Every email comparison in
+the reconcilers and the resource gate lowercases **both** sides. Because email is an
+authz join key it must be single-valued: migration 112 (#1207) adds a unique index
+on `lower(users.email)` — see [Duplicate-email remediation](#duplicate-email-remediation).
+
+### Fail-safety invariants (do not regress)
+
+- A per-group member-fetch failure keeps that group's **last-known-good** membership
+  (`replaceMembers` is never called for it; only `markError`). One group's failure
+  never aborts the others.
+- A whole-directory listing failure (or an empty listing) **skips deactivation** —
+  a partial sync must never mass-revoke. `pick` rules are always selected regardless.
+- Membership full-replace is transactional; a reader never sees a half-rebuilt group.
+- The **last-administrator guard** refuses to auto-revoke the final administrator
+  grant(s); it takes a shared advisory lock so the hourly bulk reconcile and the
+  login-time per-user reconcile serialize against each other.
+- Directory pagination is **exhaustive** (the client follows every `nextPageToken`),
+  so there are **no silent caps** — selection size is emitted as the `GroupsSelected`
+  metric and logged per run.
+
+---
+
+## Settings
+
+All configuration is database-first, in the `settings` table (Admin → Settings),
+read identically by the app (`lib/groups/settings.ts`) and the Lambda
+(`infra/lambdas/group-sync/config.ts`). Keys:
+
+| Setting key | Meaning |
+|---|---|
+| `GROUP_SYNC_ENABLED` | Master switch. Only the exact string `true` enables the **hourly** run. Manual "Sync now" runs whenever a SA secret is configured, even while paused. |
+| `GOOGLE_DIRECTORY_SA_SECRET_ARN` | Secrets Manager ARN of the Google service-account JSON key. Must match the `aistudio-<env>-google-directory-*` name family the Lambda's IAM role is scoped to. |
+| `GOOGLE_DIRECTORY_CUSTOMER_ID` | Cloud Identity customer id (e.g. `C0xxxxxxx`). Required for the Cloud Identity path. |
+| `GOOGLE_DIRECTORY_DWD_SUBJECT` | Optional admin email to impersonate. **Set** → Admin SDK Directory API via domain-wide delegation. **Unset** → Cloud Identity API with a Groups-Reader service account (no impersonation, preferred). |
+
+**Selection** (Admin → Groups) is stored in `group_selection_rules`: `pick` rows name
+an exact group email; `prefix` rows select every directory group whose email starts
+with the prefix. A pick always wins over a prefix. **Group→role mappings** (same admin
+page) populate `group_role_mappings`. The group directory and mappings are visible to
+all authors by design; there is no write-time group-existence validation (a mapping
+to a not-yet-synced group simply grants nothing until the group syncs).
+
+---
+
+## Observability (#1207)
+
+The Lambda emits CloudWatch metrics in namespace **`AIStudio/GroupSync`** (dimension
+`Environment`): `GroupsSelected`, `GroupsSynced`, `GroupsFailed`,
+`GroupsDeactivated`, `MembersTotal`, `RolesGranted`, `RolesRevoked`,
+`RoleUsersChanged`, `SyncRunFailed`, and `SyncRunSucceeded`.
+
+Two alarms are defined in `infra/lib/processing-stack.ts` (notify the `alertEmail`
+CDK-context address when set):
+
+| Alarm | Fires when | Why |
+|---|---|---|
+| `psd-group-sync-failure-<env>` | the Lambda's `Errors` metric ≥ 1 in an hour | a run executed but errored (directory outage, DB failure, crash/timeout). The handler re-throws on failure, so `Errors` captures both crashes and handled-then-rethrown failures. |
+| `psd-group-sync-staleness-<env>` | `SyncRunSucceeded` sum < 1 across 3 consecutive hours, **treat-missing-as-breaching** | no successful sync recently — including the case where the schedule stopped firing entirely (a dead Lambda emits nothing, so a self-emitted "seconds since last sync" gauge could not detect it). |
+
+Per-group failures are surfaced in **Admin → Groups**: each group shows a "Failed"
+badge (with the `last_sync_error` as tooltip) and `last_synced_at`; the header shows
+an aggregate "Failed syncs" count (`groups.last_sync_error IS NOT NULL AND is_active`).
+
+### Test-firing the alarms after deploy
+
+1. **Failure alarm**: temporarily point `GOOGLE_DIRECTORY_SA_SECRET_ARN` at a bad
+   secret (or invoke with the SA secret revoked) so a run throws; confirm
+   `psd-group-sync-failure-<env>` → ALARM and the email fires; restore the setting.
+2. **Staleness alarm**: set `GROUP_SYNC_ENABLED=false` and let 3 hourly windows pass
+   with no manual run; confirm `psd-group-sync-staleness-<env>` → ALARM (missing data
+   breaches); re-enable and run "Sync now" to clear it.
+
+---
+
+## Runbooks
+
+### Sync failure (alarm: `psd-group-sync-failure`)
+
+1. Read the Lambda logs: `/aws/lambda/psd-group-sync-<env>` (structured JSON).
+2. Common causes: expired/rotated SA key (fix the secret, then "Sync now"),
+   Directory API permission loss (re-grant Groups Reader / re-check DWD scopes),
+   Aurora unreachable (VPC/security-group/credentials).
+3. **Membership is safe** while you fix it: each failing group keeps its
+   last-known-good membership (`last_sync_error` is set, `last_synced_at` is not
+   touched). No mass-revoke occurs.
+4. After the fix, click **Sync now** and confirm `GroupsFailed` drops to 0 and the
+   per-group "Failed" badges clear.
+
+### Staleness (alarm: `psd-group-sync-staleness`)
+
+1. Check `GROUP_SYNC_ENABLED` is `true` and the hourly EventBridge rule
+   `GroupSyncHourlySchedule` is enabled.
+2. Check the Lambda isn't throttled (it has `reservedConcurrentExecutions: 1`; a
+   stuck manual run can block the scheduled one — confirm no long-running invocation).
+3. Run **Sync now**; confirm `SyncRunSucceeded` returns and the alarm clears.
+
+### Group rename in Google
+
+Group renames **are handled**: the group is keyed by `group_email`, and a renamed
+group re-enters the selection under its new email and syncs normally. Two operational
+notes:
+
+- **Selection lists reference emails.** A `pick` rule or a `group_role_mappings` row
+  names the group by its *old* email. After a rename, update the pick/mapping to the
+  new email (Admin → Groups) or the old email selects/maps nothing. Prefix rules that
+  still match the new email need no change.
+- The old-email `groups` row falls out of the selection and is flipped
+  `is_active=false` (never hard-deleted), so its membership survives if you re-add it.
+
+### Member email change (Workspace rename of a person)
+
+`group_members` tracks the directory's **current** address, but `users.email` is set
+at provisioning. On the member's next sign-in the app refreshes `users.email` from the
+session (`getCurrentUserAction`) so the join realigns. Between the rename and that next
+sign-in, the hourly bulk reconciler may drop the person's managed roles once
+(documented residual) — the login-time reconciler restores them. If a person seems to
+have lost group-driven roles after a rename, have them sign in again.
+
+### Duplicate-email remediation
+
+Migration 112 adds a unique index on `lower(users.email)`. It **fails the deploy** if
+the target database already has two rows with the same case-insensitive email — by
+design, so we never ship a partial index that hides the ambiguity. Before deploying:
+
+```bash
+DATABASE_URL=<target> bun run scripts/db/report-duplicate-emails.ts
+```
+
+- Exit 0 → no duplicates; migration 112 applies cleanly.
+- Exit 1 → duplicates printed (email + colliding user ids). **Remediate first**:
+  decide the surviving `users` row per email, re-point its foreign keys
+  (`user_roles`, conversations, documents, api_keys, …) from the duplicates onto the
+  survivor, delete the duplicates, then re-run the report until it exits 0.
+  Dedupe is a deliberate human step — never automated in a migration, and never
+  worked around by weakening the index to a partial one.
+
+---
+
+## Retiring the username heuristic (#1207)
+
+New-user provisioning assigns a default role from a username heuristic
+(`lib/auth/default-role.ts`: all-digit username → `student`, else `staff`). Group-sync
+is now the authoritative role source — both provisioning paths reconcile managed roles
+immediately after — so this heuristic only decides the role for a user in **no** mapped
+group. Reducing it to a no-role default (`defaultRoleForNewUser` returns `null`) is
+**coverage-gated**:
+
+```bash
+DATABASE_URL=<prod> bun run scripts/db/report-heuristic-only-roles.ts
+```
+
+Decision rule from the report's "manual roles NOT reproduced by group-sync":
+
+- **staff count ≈ 0** → safe to drop the non-numeric→`staff` branch (return `null` for
+  staff; rely on group-sync). New staff get `staff` at login-time reconciliation from
+  their mapped group.
+- **staff count large** → map the missing staff groups to the `staff` role first, then
+  re-run the report before dropping the branch.
+- The numeric→`student` branch is least-privilege and low-risk regardless.
+
+The change is a single edit in `lib/auth/default-role.ts` (return `null` for the
+retired branch); both call sites already guard on a `null` return.
+
+---
+
+## Key source locations
+
+- Lambda: `infra/lambdas/group-sync/` (`index.ts` handler, `sync.ts` reconciler core,
+  `directory-client.ts`, `db.ts`, `config.ts`)
+- CDK: `infra/lib/processing-stack.ts` (Lambda, hourly rule, alarms)
+- Reconcilers: `lib/db/drizzle/user-roles.ts` (`reconcileUserManagedRoles`),
+  `infra/lambdas/group-sync/db.ts` (`reconcileManagedRoles` bulk pass)
+- Per-resource gate: `lib/db/drizzle/resource-access.ts`
+- Admin UI: `app/(protected)/admin/groups/`
+- Reports: `scripts/db/report-duplicate-emails.ts`,
+  `scripts/db/report-heuristic-only-roles.ts`
+- Migrations: `106-groups`, `109-group-role-mappings`, `110-atrium-group-grant-kind`,
+  `111-resource-access-grants`, `112-users-email-unique`,
+  `113-drop-ai-models-allowed-roles`

--- a/docs/features/google-group-sync.md
+++ b/docs/features/google-group-sync.md
@@ -113,6 +113,15 @@ CDK-context address when set):
 | `psd-group-sync-failure-<env>` | the Lambda's `Errors` metric ≥ 1 in an hour | a run executed but errored (directory outage, DB failure, crash/timeout). The handler re-throws on failure, so `Errors` captures both crashes and handled-then-rethrown failures. |
 | `psd-group-sync-staleness-<env>` | `SyncRunSucceeded` sum < 1 across 3 consecutive hours, **treat-missing-as-breaching** | no successful sync recently — including the case where the schedule stopped firing entirely (a dead Lambda emits nothing, so a self-emitted "seconds since last sync" gauge could not detect it). |
 
+> **New-environment note:** when group sync is intentionally not configured
+> (`GOOGLE_DIRECTORY_SA_SECRET_ARN` unset), the Lambda returns `skipped` before
+> emitting `SyncRunSucceeded`, so the metric is permanently absent and
+> `psd-group-sync-staleness-<env>` sits in **ALARM** by design (`treatMissingData:
+> BREACHING`). This is expected onboarding noise, not an incident — notifications are
+> gated on `alertEmail`, so no page fires. It clears on the first successful sync once
+> the service account is configured. If an environment will never use group sync,
+> disable the alarm rather than leaving it red.
+
 Per-group failures are surfaced in **Admin → Groups**: each group shows a "Failed"
 badge (with the `last_sync_error` as tooltip) and `last_synced_at`; the header shows
 an aggregate "Failed syncs" count (`groups.last_sync_error IS NOT NULL AND is_active`).

--- a/docs/learnings/architecture/2026-07-14-group-sync-as-authz-source.md
+++ b/docs/learnings/architecture/2026-07-14-group-sync-as-authz-source.md
@@ -1,0 +1,102 @@
+---
+title: Making a scheduled directory sync an authorization source — email join keys, last-known-good fail-safety, and success-absence staleness
+category: architecture
+tags:
+  - authorization
+  - group-sync
+  - google-directory
+  - cloudwatch
+  - database
+  - migrations
+  - fail-safe
+severity: high
+date: 2026-07-14
+source: auto — /lfg (#1207, Epic #1202 Phase 4)
+applicable_to: project
+---
+
+## What Happened
+
+Epic #1202 turned Google Workspace group membership into an authorization source:
+an hourly service-account sync mirrors group membership into `group_members`
+(keyed by **email**), and that membership drives a user's roles and per-resource
+`resource_access_grants`. Phase 4 (#1207) hardened it. Four decisions are worth
+remembering because the "obvious" alternative is wrong for an **authz** source
+specifically:
+
+1. **Email became a join key with no uniqueness constraint.** Every reconciler
+   joins `lower(users.email) = lower(group_members.member_email)`, but `users.email`
+   had no unique index. Two rows sharing a case-insensitive email would each match
+   the same membership and could be granted/revoked inconsistently.
+
+2. **A migration that adds `UNIQUE (lower(email))` can silently no-op or silently
+   narrow.** In this repo's migration runners, a `duplicate key`/`already exists`
+   error is swallowed for idempotency — so a naive attempt to dedge duplicates with a
+   *partial* index would hide the ambiguity, and any error message that happens to
+   match the swallow list would mark a failed index as "applied".
+
+3. **Staleness of a scheduled job cannot be measured by the job itself.** The
+   instinct is to emit a "seconds since last successful sync" gauge. But a Lambda
+   that has stopped running (disabled schedule, throttle, broken deploy) emits
+   *nothing*, so that gauge never reports the very failure you care about.
+
+4. **Dropping the legacy `ai_models.allowed_roles` column looked risky** (it gates
+   model access) but was safe because all *read* paths had already moved to
+   `resource_access_grants` in Phase 3 — several places still `SELECT`ed the column
+   into a typed field but never used it for a decision (dead carries), and the model
+   list is filtered server-side, making the client-side role filter redundant.
+
+## Root Cause / Principle
+
+An authorization source has an asymmetric failure cost: **under-granting** briefly
+is an annoyance; **over-granting**, **mass-revoking**, or **going stale unnoticed**
+is a security or availability incident. That asymmetry dictates the design:
+
+- **The join key must be single-valued.** Add `CREATE UNIQUE INDEX ... ON
+  users (lower(email))`. NULLs are fine (distinct in a unique index) — no partial
+  `WHERE` needed. Make it **fail loud** on pre-existing duplicates rather than
+  dodging them: a plain `CREATE UNIQUE INDEX` raises `could not create unique
+  index ... is duplicated`, which does **not** match the runner's
+  `already exists`/`duplicate key` swallow list, so the deploy fails and forces
+  human dedupe. Ship a read-only pre-check script + a documented dedupe runbook, not
+  a partial index.
+
+- **Never mass-revoke on a degraded upstream.** Skip deactivation when the directory
+  listing is empty (an empty list is almost always an API glitch, not a real
+  de-selection); on a per-group fetch failure, keep that group's last-known-good
+  membership (`markError`, don't `replaceMembers`); paginate exhaustively so nothing
+  is silently capped.
+
+- **Detect staleness by the ABSENCE of success, from outside the job.** Emit a
+  `SyncRunSucceeded` = 1 metric on success (0 on failure) and alarm on
+  `sum(SyncRunSucceeded) < 1` over N periods with
+  `treatMissingData: BREACHING`. That single alarm catches "ran but failed" **and**
+  "did not run at all". Pair it with an alarm on the Lambda's built-in `Errors`
+  metric for the "ran and errored" case (the handler re-throws so `Errors` counts
+  both crashes and handled-then-rethrown failures).
+
+- **Retire a legacy authz column only after confirming reads moved, and grep for
+  dead carries.** `grep` both the snake_case (SQL) and camelCase (TS) spellings.
+  A field that is `SELECT`ed and typed but never read for a decision is safe to
+  remove; a server-side gate makes a client-side filter redundant (remove it, don't
+  leave two enforcement points that can drift). Strip the removed field defensively
+  on the write path (`delete updates.x`) so an older client echoing it can't reach a
+  dropped column via a `.set({ ...updates })` spread.
+
+## Also
+
+- Lowercase **both** sides of every email comparison even when storage is lowercased
+  by convention — no DB constraint enforces the convention, so the auth decision must
+  not trust it.
+- A last-administrator lockout guard that exists in two reconcile paths (hourly bulk +
+  login-time per-user) needs a **shared** Postgres advisory lock, or the two paths can
+  each read the other's uncommitted admin row as "surviving" and both revoke.
+- A default-role heuristic (`isNumeric ? student : staff`) is a legacy fallback once
+  group-sync is authoritative; retiring it to a no-role default is **coverage-gated** —
+  produce a report of users whose manual roles group-sync would *not* reproduce, and
+  centralize the heuristic to one helper so the eventual reduction is a single edit.
+
+## See also
+
+- Feature doc + runbooks: `docs/features/google-group-sync.md`
+- `docs/learnings/security/2026-07-01-idempotency-check-toctou-before-for-update.md`

--- a/infra/bin/infra.ts
+++ b/infra/bin/infra.ts
@@ -226,6 +226,7 @@ Object.entries(standardTags).forEach(([key, value]) => cdk.Tags.of(devAgentPlatf
 
 const devProcessingStack = new ProcessingStack(app, 'AIStudio-ProcessingStack-Dev', {
   environment: 'dev',
+  alertEmail,
   env: { account: process.env.CDK_DEFAULT_ACCOUNT, region: process.env.CDK_DEFAULT_REGION },
 });
 cdk.Tags.of(devProcessingStack).add('Environment', 'Dev');
@@ -389,6 +390,7 @@ Object.entries(standardTags).forEach(([key, value]) => cdk.Tags.of(prodAgentPlat
 
 const prodProcessingStack = new ProcessingStack(app, 'AIStudio-ProcessingStack-Prod', {
   environment: 'prod',
+  alertEmail,
   env: { account: process.env.CDK_DEFAULT_ACCOUNT, region: process.env.CDK_DEFAULT_REGION },
 });
 cdk.Tags.of(prodProcessingStack).add('Environment', 'Prod');

--- a/infra/database/migrations.json
+++ b/infra/database/migrations.json
@@ -105,6 +105,8 @@
     "108-aistudio-mcp-service-user.sql",
     "109-group-role-mappings.sql",
     "110-atrium-group-grant-kind.sql",
-    "111-resource-access-grants.sql"
+    "111-resource-access-grants.sql",
+    "112-users-email-unique.sql",
+    "113-drop-ai-models-allowed-roles.sql"
   ]
 }

--- a/infra/database/schema/112-users-email-unique.sql
+++ b/infra/database/schema/112-users-email-unique.sql
@@ -1,0 +1,51 @@
+-- Migration 112: unique index on lower(users.email) (Epic #1202, Phase 4 / #1207)
+--
+-- WHY. Since Phase 1 (#1204) group membership → role/resource authorization joins
+-- on the user's email, always as lower(users.email) = lower(gm.member_email) (see
+-- lib/db/drizzle/user-roles.ts#reconcileUserManagedRoles and
+-- lib/db/drizzle/resource-access.ts). Email is therefore an AUTHORIZATION JOIN KEY,
+-- but users.email carried NO uniqueness constraint — two rows sharing a
+-- case-insensitive email would each match the same group membership and could be
+-- granted/revoked inconsistently (and getUserByEmail would resolve
+-- non-deterministically). This index makes the join key single-valued.
+--
+-- SEMANTICS. Unique on lower(email), matching every read/write site (all of which
+-- already lowercase both sides). NULL emails are permitted and do NOT collide: a
+-- unique index treats each NULL as distinct, so the pre-provisioning /
+-- synthetic-fallback rows (get-current-user-action.ts writes
+-- `${cognitoSub}@cognito.local` only when a session truly has no email, and
+-- cognito_sub is itself UNIQUE) are unaffected. This is intentionally NOT a partial
+-- index over a subset of rows — see the anti-pattern note below.
+--
+-- FAIL-LOUD ON DUPLICATES (by design). If the target database already contains two
+-- rows with the same lower(email), CREATE UNIQUE INDEX raises
+--   ERROR: could not create unique index "uq_users_email_lower"
+--   DETAIL: Key (lower(email))=(...) is duplicated.
+-- That message matches neither the "already exists" nor the CREATE TYPE / ALTER
+-- TABLE special-cases in the migration runners (scripts/db/run-migrations.ts and
+-- infra/database/lambda/db-init-handler.ts), so the migration FAILS the deploy
+-- rather than silently skipping. This is deliberate: per #1207 we must never ship a
+-- partial index that quietly excludes the duplicate rows and leaves the authz join
+-- key ambiguous. If the deploy fails here, prod has duplicates that MUST be
+-- remediated first.
+--
+-- OPERATIONAL PRE-CHECK (run before deploying this migration to a populated DB):
+--   SELECT lower(email) AS email, count(*)
+--     FROM users
+--    WHERE email IS NOT NULL
+--    GROUP BY 1
+--   HAVING count(*) > 1;
+-- `bun run scripts/db/report-duplicate-emails.ts` prints exactly this, plus the
+-- offending row ids. Zero rows → this migration applies cleanly. Any rows → follow
+-- the dedupe runbook in docs/features/google-group-sync.md before deploying (merge
+-- the duplicate user rows / their FKs; do NOT drop this migration to a partial
+-- index to dodge them).
+--
+-- ADDITIVE and idempotent (IF NOT EXISTS). A plain (non-CONCURRENT) CREATE UNIQUE
+-- INDEX — CONCURRENTLY is incompatible with the RDS Data API and is rejected by the
+-- db-init validator; the users table is small and written infrequently, so the
+-- brief write lock is acceptable. Single statement, no PL/pgSQL DO $$ block (the
+-- runner's splitter only enters block mode on CREATE TYPE/FUNCTION/DROP TYPE).
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_users_email_lower
+  ON users (lower(email));

--- a/infra/database/schema/113-drop-ai-models-allowed-roles.sql
+++ b/infra/database/schema/113-drop-ai-models-allowed-roles.sql
@@ -15,13 +15,25 @@
 -- and the admin "Allowed Roles (legacy)" field are removed too — per-model
 -- role/group access is edited solely via the ResourceGrantsEditor.
 --
--- DEPLOY ORDERING. This migration ships in the SAME release as the code that stops
--- referencing the column. Follow the repo precedent (migrations 045/046/084 dropped
--- columns/tables the same way): during an ECS rolling deploy there is a brief window
--- where an old task might still SELECT allowed_roles; those queries are read-only and
--- their only caller (nexus model listing) already catches errors and returns [], so
--- the worst case is a momentarily-empty model list, never a crash or an access
--- escalation (execution stays gated by resource_access_grants throughout).
+-- DEPLOY ORDERING (read before deploying). This migration ships in the SAME release
+-- as the code that stops referencing the column, following the repo precedent for
+-- column/table drops (migrations 045 remove-chat-enabled-column, 046
+-- remove-nexus-capabilities-column, 084 drop-legacy-tools-tables). CDK runs the
+-- db-init custom resource during the stack update and the DatabaseStack deploys
+-- before the frontend (the frontend stacks depend on it), so during the ECS rolling
+-- replacement there is a brief window where OLD tasks still run the previous release,
+-- whose Drizzle `.select()` on ai_models includes `allowed_roles`. Reads from those
+-- old tasks fail while the window lasts:
+--   * nexus model listing (getModelsFromDatabase) catches the error and returns [],
+--   * but the admin model list and GET /api/models (getAIModels / getNexusEnabledModels)
+--     surface a 500 until the old task is replaced.
+-- This never escalates access (execution stays gated by resource_access_grants) and
+-- clears as soon as ECS finishes rolling. Impact is a transient error on model-list
+-- reads, not data loss. To make the drop zero-downtime, deploy during a low-traffic
+-- window, OR run this as an expand/contract two-step: cut a release that only removes
+-- the code references (keep the column), let ECS fully drain the old tasks, then apply
+-- this drop in the next deploy. The single-release path here matches existing repo
+-- practice; choose the two-step if a momentary model-list 500 is unacceptable.
 --
 -- ADDITIVE-SAFE and idempotent: DROP ... IF EXISTS on both the GIN index (024) and
 -- the column. A plain single-statement drop — no PL/pgSQL DO $$ block (the migration

--- a/infra/database/schema/113-drop-ai-models-allowed-roles.sql
+++ b/infra/database/schema/113-drop-ai-models-allowed-roles.sql
@@ -1,0 +1,35 @@
+-- Migration 113: drop ai_models.allowed_roles (Epic #1202, Phase 4 / #1207)
+--
+-- The legacy per-model role allow-list column (added in migration 024) is retired.
+-- Its role semantics were migrated to the generic resource_access_grants table in
+-- Phase 3 (migration 111 backfilled every allowed_roles entry into a ('model',
+-- resource_id, 'role', role_name) grant row), and ALL read paths now resolve model
+-- access exclusively through resource_access_grants:
+--   * lib/db/drizzle/resource-access.ts (userCanAccessResource /
+--     filterAccessibleResourceIds) — the authoritative execution gate,
+--   * GET /api/models — server-side filters the model list before it reaches the
+--     model-selector (the client role filter was removed in this release).
+-- The nexus provider factory / cost optimizer selected allowed_roles into a typed
+-- field but never USED it for any decision (verified in #1207); those dead selects
+-- are removed in the same release. The write-time bridge (syncModelAllowedRoleGrants)
+-- and the admin "Allowed Roles (legacy)" field are removed too — per-model
+-- role/group access is edited solely via the ResourceGrantsEditor.
+--
+-- DEPLOY ORDERING. This migration ships in the SAME release as the code that stops
+-- referencing the column. Follow the repo precedent (migrations 045/046/084 dropped
+-- columns/tables the same way): during an ECS rolling deploy there is a brief window
+-- where an old task might still SELECT allowed_roles; those queries are read-only and
+-- their only caller (nexus model listing) already catches errors and returns [], so
+-- the worst case is a momentarily-empty model list, never a crash or an access
+-- escalation (execution stays gated by resource_access_grants throughout).
+--
+-- ADDITIVE-SAFE and idempotent: DROP ... IF EXISTS on both the GIN index (024) and
+-- the column. A plain single-statement drop — no PL/pgSQL DO $$ block (the migration
+-- runner's splitter only enters block mode on CREATE TYPE/FUNCTION/DROP TYPE), and no
+-- CONCURRENTLY (rejected by the RDS Data API validator). DROP COLUMN also drops any
+-- remaining dependent objects (the GIN index) automatically; dropping the index first
+-- is explicit and keeps the intent auditable.
+
+DROP INDEX IF EXISTS idx_ai_models_allowed_roles;
+
+ALTER TABLE ai_models DROP COLUMN IF EXISTS allowed_roles;

--- a/infra/lambdas/group-sync/index.ts
+++ b/infra/lambdas/group-sync/index.ts
@@ -152,8 +152,18 @@ async function emitMetrics(
         { MetricName: "GroupsDeactivated", Value: result.deactivated, Unit: "Count", Dimensions: dims },
         { MetricName: "MembersTotal", Value: result.totalMembers, Unit: "Count", Dimensions: dims },
         { MetricName: "SyncRunFailed", Value: 0, Unit: "Count", Dimensions: dims },
+        // Staleness signal (#1207): 1 on every successful run. The CDK
+        // GroupSyncStalenessAlarm alarms when the SUM of this metric over the
+        // staleness window is < 1 with treatMissingData=BREACHING, so it fires for
+        // BOTH "ran but failed" (0 here) AND "did not run at all" (metric absent) —
+        // a self-emitted "seconds since last sync" gauge could not detect the
+        // latter because a dead Lambda emits nothing.
+        { MetricName: "SyncRunSucceeded", Value: 1, Unit: "Count", Dimensions: dims },
       ]
-    : [{ MetricName: "SyncRunFailed", Value: 1, Unit: "Count", Dimensions: dims }];
+    : [
+        { MetricName: "SyncRunFailed", Value: 1, Unit: "Count", Dimensions: dims },
+        { MetricName: "SyncRunSucceeded", Value: 0, Unit: "Count", Dimensions: dims },
+      ];
 
   if (roleReconcile) {
     metrics.push(

--- a/infra/lib/processing-stack.ts
+++ b/infra/lib/processing-stack.ts
@@ -10,6 +10,8 @@ import * as s3 from 'aws-cdk-lib/aws-s3';
 import * as dynamodb from 'aws-cdk-lib/aws-dynamodb';
 import * as sns from 'aws-cdk-lib/aws-sns';
 import * as snsSubscriptions from 'aws-cdk-lib/aws-sns-subscriptions';
+import * as cloudwatch from 'aws-cdk-lib/aws-cloudwatch';
+import * as cloudwatchActions from 'aws-cdk-lib/aws-cloudwatch-actions';
 import * as path from 'path';
 import * as ssm from 'aws-cdk-lib/aws-ssm';
 import * as events from 'aws-cdk-lib/aws-events';
@@ -24,6 +26,11 @@ export interface ProcessingStackProps extends cdk.StackProps {
   documentsBucketName?: string; // Optional for backward compatibility
   databaseResourceArn?: string; // Optional for backward compatibility
   databaseSecretArn?: string; // Optional for backward compatibility
+  // Email subscribed to the group-sync failure / staleness alarms (#1207).
+  // Sourced from the `alertEmail` CDK context, same as the other stacks. When
+  // absent the alarms are still created (and visible in CloudWatch) but have no
+  // notification target.
+  alertEmail?: string;
 }
 
 export class ProcessingStack extends cdk.Stack {
@@ -577,6 +584,81 @@ export class ProcessingStack extends cdk.Stack {
       schedule: events.Schedule.rate(cdk.Duration.hours(1)),
       targets: [new eventsTargets.LambdaFunction(groupSyncLambda)],
     });
+
+    // -----------------------------------------------------------------------
+    // Group-sync observability (Epic #1202, Phase 4 / #1207)
+    // -----------------------------------------------------------------------
+    // Group sync is an AUTHORIZATION source (membership drives roles + resource
+    // grants), so a silently-dead or persistently-failing sync degrades access
+    // control. Two alarms cover the two distinct failure shapes:
+    //   1. Failure alarm  — a run executed but errored (directory outage, DB
+    //      failure, crash/timeout). The handler re-throws on failure, so the
+    //      Lambda's built-in Errors metric captures BOTH unhandled crashes and
+    //      handled-then-rethrown sync failures in one signal.
+    //   2. Staleness alarm — no SUCCESSFUL run within the staleness window,
+    //      which also catches "the schedule stopped firing entirely" (the custom
+    //      SyncRunSucceeded metric goes absent → treatMissingData=BREACHING).
+    // Alarm actions are wired only when an alert email is configured; the alarms
+    // themselves always exist so their state is visible in CloudWatch.
+    let groupSyncAlarmTopic: sns.Topic | undefined;
+    if (props.alertEmail) {
+      groupSyncAlarmTopic = new sns.Topic(this, 'GroupSyncAlarmTopic', {
+        topicName: `psd-group-sync-alarms-${props.environment}`,
+        displayName: `PSD Group Sync Alarms (${props.environment})`,
+      });
+      groupSyncAlarmTopic.addSubscription(
+        new snsSubscriptions.EmailSubscription(props.alertEmail),
+      );
+      cdk.Tags.of(groupSyncAlarmTopic).add('Environment', props.environment);
+      cdk.Tags.of(groupSyncAlarmTopic).add('ManagedBy', 'cdk');
+    }
+
+    // 1. Failure alarm — any errored invocation in the last hour. Missing data
+    //    (no invocations) is NOT breaching here; the staleness alarm owns the
+    //    "not running at all" case.
+    const groupSyncFailureAlarm = new cloudwatch.Alarm(this, 'GroupSyncFailureAlarm', {
+      alarmName: `psd-group-sync-failure-${props.environment}`,
+      alarmDescription:
+        'Google Directory group-sync Lambda errored — membership/roles may be stale. ' +
+        'Check /aws/lambda/psd-group-sync logs; last-known-good membership is preserved per group.',
+      metric: groupSyncLambda.metricErrors({
+        period: cdk.Duration.hours(1),
+        statistic: 'Sum',
+      }),
+      threshold: 1,
+      evaluationPeriods: 1,
+      comparisonOperator: cloudwatch.ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+      treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
+    });
+
+    // 2. Staleness alarm — fewer than one successful sync across three
+    //    consecutive hourly windows (the hourly schedule should produce one
+    //    SyncRunSucceeded=1 per hour). BREACHING on missing data so a Lambda that
+    //    stops running (disabled schedule, throttle, broken deploy) trips it too.
+    const groupSyncStalenessAlarm = new cloudwatch.Alarm(this, 'GroupSyncStalenessAlarm', {
+      alarmName: `psd-group-sync-staleness-${props.environment}`,
+      alarmDescription:
+        'No successful Google Directory group sync in ~3 hours (time since last success exceeded threshold). ' +
+        'Group-driven roles/resource grants are frozen at their last-known-good state until sync recovers.',
+      metric: new cloudwatch.Metric({
+        namespace: 'AIStudio/GroupSync',
+        metricName: 'SyncRunSucceeded',
+        dimensionsMap: { Environment: props.environment },
+        period: cdk.Duration.hours(1),
+        statistic: 'Sum',
+      }),
+      threshold: 1,
+      evaluationPeriods: 3,
+      datapointsToAlarm: 3,
+      comparisonOperator: cloudwatch.ComparisonOperator.LESS_THAN_THRESHOLD,
+      treatMissingData: cloudwatch.TreatMissingData.BREACHING,
+    });
+
+    if (groupSyncAlarmTopic) {
+      const alarmAction = new cloudwatchActions.SnsAction(groupSyncAlarmTopic);
+      groupSyncFailureAlarm.addAlarmAction(alarmAction);
+      groupSyncStalenessAlarm.addAlarmAction(alarmAction);
+    }
 
     // Outputs
     new cdk.CfnOutput(this, 'GroupSyncFunctionName', {

--- a/lib/auth/default-role.ts
+++ b/lib/auth/default-role.ts
@@ -1,0 +1,38 @@
+/**
+ * Default role for a NEWLY-PROVISIONED user (Epic #1202, Phase 4 / #1207).
+ *
+ * Single source of truth for the username heuristic that used to be duplicated,
+ * verbatim, in lib/auth/resolve-user.ts and actions/db/get-current-user-action.ts.
+ * A K-12 convention: student accounts are all-digit ID emails
+ * (e.g. 123456@psd401.net), everyone else is staff. An empty/absent username
+ * resolves to 'staff' — the exact behavior of the prior inline
+ * `/^\d+$/.test("") === false` code.
+ *
+ * LEGACY FALLBACK — being retired. Group-sync is now the authoritative role source:
+ * both provisioning paths call the managed-role reconciler immediately AFTER
+ * assigning this default (reconcileUserManagedRoles), so a user who is a member of a
+ * mapped group receives their real role at provisioning regardless of this value.
+ * This heuristic therefore only decides the role for a user who is in NO mapped
+ * group.
+ *
+ * RETIREMENT IS COVERAGE-GATED (#1207). Reducing this to a no-role default —
+ * `return null` (assign nothing; rely entirely on group-sync) — is safe only once
+ * staff group→role coverage is confirmed, because otherwise a newly-provisioned
+ * staff member who is not yet in a mapped group would receive no role. Confirm with:
+ *
+ *   DATABASE_URL=<prod> bun run scripts/db/report-heuristic-only-roles.ts
+ *
+ * and follow the decision rule in docs/features/google-group-sync.md (§ "Retiring the
+ * username heuristic"). Until that report is run and approved, this preserves the
+ * pre-#1207 behavior EXACTLY — but now from one place, so the eventual reduction is a
+ * single edit here rather than two divergent copies.
+ *
+ * @returns the role name to assign, or `null` to assign no default role.
+ */
+export function defaultRoleForNewUser(email: string | null | undefined): string | null {
+  const username = (email ?? "").split("@")[0];
+  // Numeric username prefix → student (all-digit district student IDs); anything
+  // else (including an empty username) → staff.
+  const isNumeric = /^\d+$/.test(username);
+  return isNumeric ? "student" : "staff";
+}

--- a/lib/auth/resolve-user.ts
+++ b/lib/auth/resolve-user.ts
@@ -22,6 +22,7 @@ import {
 import { createLogger, sanitizeForLogging } from "@/lib/logger"
 import { ErrorFactories } from "@/lib/error-utils"
 import { ErrorCode } from "@/types/error-types"
+import { defaultRoleForNewUser } from "./default-role"
 import type { CognitoSession } from "./server-session"
 
 /**
@@ -125,42 +126,46 @@ export async function resolveUserId(
     )
   }
 
-  // Assign default role using addUserRole, which runs in a transaction and
-  // increments role_version for session cache invalidation.
-  // Numeric username prefix → student (K-12 district convention: student IDs
-  // are all-digit numbers, e.g. 123456@psd401.net). Non-numeric → staff.
-  // Defaults to least-privilege (student) when username cannot be determined.
-  const isNumeric = /^\d+$/.test(username) // already false for empty strings
-  const defaultRole = isNumeric ? "student" : "staff"
+  // Assign the default role (legacy username heuristic — the single source of
+  // truth is lib/auth/default-role.ts; group-sync reconciliation below is the
+  // authoritative role source and runs immediately after). `null` means "assign no
+  // default role" once the heuristic is retired; today it never returns null.
+  const defaultRole = defaultRoleForNewUser(session.email)
 
-  try {
-    await addUserRole(userId, defaultRole)
-    log.info("User provisioned with default role", {
-      userId,
-      role: defaultRole,
-    })
-  } catch (error) {
-    // Role assignment failure is non-fatal — user can still access the app,
-    // and getCurrentUserAction will handle role assignment on next full login.
-    // Distinguish a missing role record (expected in misconfigured envs) from
-    // infrastructure failures (DB connectivity, deadlock) which warrant error-level.
-    const isRoleNotFound =
-      error !== null &&
-      typeof error === "object" &&
-      "code" in error &&
-      (error as { code: unknown }).code === ErrorCode.DB_RECORD_NOT_FOUND
-    if (isRoleNotFound) {
-      log.warn("Default role not found in database — user provisioned without role", {
+  if (defaultRole) {
+    try {
+      await addUserRole(userId, defaultRole)
+      log.info("User provisioned with default role", {
         userId,
-        attemptedRole: defaultRole,
+        role: defaultRole,
       })
-    } else {
-      log.error("Role assignment failed — infrastructure error; user provisioned without role", {
-        userId,
-        attemptedRole: defaultRole,
-        error: error instanceof Error ? error.message : "Unknown error",
-      })
+    } catch (error) {
+      // Role assignment failure is non-fatal — user can still access the app,
+      // and getCurrentUserAction will handle role assignment on next full login.
+      // Distinguish a missing role record (expected in misconfigured envs) from
+      // infrastructure failures (DB connectivity, deadlock) which warrant error-level.
+      const isRoleNotFound =
+        error !== null &&
+        typeof error === "object" &&
+        "code" in error &&
+        (error as { code: unknown }).code === ErrorCode.DB_RECORD_NOT_FOUND
+      if (isRoleNotFound) {
+        log.warn("Default role not found in database — user provisioned without role", {
+          userId,
+          attemptedRole: defaultRole,
+        })
+      } else {
+        log.error("Role assignment failed — infrastructure error; user provisioned without role", {
+          userId,
+          attemptedRole: defaultRole,
+          error: error instanceof Error ? error.message : "Unknown error",
+        })
+      }
     }
+  } else {
+    log.info("No default role assigned (heuristic retired) — relying on group-sync", {
+      userId,
+    })
   }
 
   // New user just provisioned with the default (manual) role — reconcile any

--- a/lib/db/drizzle/ai-models.ts
+++ b/lib/db/drizzle/ai-models.ts
@@ -64,7 +64,6 @@ export interface AIModelData {
   provider: string;
   description?: string | null;
   capabilities?: string | null;
-  allowedRoles?: string[] | null;
   maxTokens?: number | null;
   active?: boolean;
   nexusEnabled?: boolean;
@@ -88,7 +87,6 @@ export interface AIModelUpdateData {
   provider?: string;
   description?: string | null;
   capabilities?: string | null;
-  allowedRoles?: string[] | null;
   maxTokens?: number | null;
   active?: boolean;
   nexusEnabled?: boolean;
@@ -123,7 +121,6 @@ export async function getAIModels() {
           modelId: aiModels.modelId,
           description: aiModels.description,
           capabilities: aiModels.capabilities,
-          allowedRoles: aiModels.allowedRoles,
           maxTokens: aiModels.maxTokens,
           active: aiModels.active,
           nexusEnabled: aiModels.nexusEnabled,
@@ -321,7 +318,6 @@ export async function createAIModel(modelData: AIModelData) {
           provider: modelData.provider,
           description: modelData.description,
           capabilities: modelData.capabilities,
-          allowedRoles: modelData.allowedRoles,
           maxTokens: modelData.maxTokens,
           active: modelData.active ?? true,
           nexusEnabled: modelData.nexusEnabled ?? true,
@@ -749,7 +745,6 @@ export interface BulkModelImportData {
   active?: boolean;
   nexusEnabled?: boolean;
   architectEnabled?: boolean;
-  allowedRoles?: string[] | null;
   inputCostPer1kTokens?: string | null;
   outputCostPer1kTokens?: string | null;
   cachedInputCostPer1kTokens?: string | null;
@@ -823,7 +818,6 @@ export async function bulkImportAIModels(
                 active: "active" in model ? model.active : existing.active,
                 nexusEnabled: "nexusEnabled" in model ? model.nexusEnabled : existing.nexusEnabled,
                 architectEnabled: "architectEnabled" in model ? model.architectEnabled : existing.architectEnabled,
-                allowedRoles: "allowedRoles" in model ? model.allowedRoles : existing.allowedRoles,
                 inputCostPer1kTokens:
                   "inputCostPer1kTokens" in model ? model.inputCostPer1kTokens : existing.inputCostPer1kTokens,
                 outputCostPer1kTokens:
@@ -846,7 +840,6 @@ export async function bulkImportAIModels(
               active: model.active ?? true,
               nexusEnabled: model.nexusEnabled ?? true,
               architectEnabled: model.architectEnabled ?? true,
-              allowedRoles: model.allowedRoles,
               inputCostPer1kTokens: model.inputCostPer1kTokens,
               outputCostPer1kTokens: model.outputCostPer1kTokens,
               cachedInputCostPer1kTokens: model.cachedInputCostPer1kTokens,

--- a/lib/db/drizzle/resource-access.ts
+++ b/lib/db/drizzle/resource-access.ts
@@ -315,33 +315,6 @@ export async function replaceResourceGrants(
 }
 
 /**
- * Sync a model's legacy `ai_models.allowed_roles` column into `role`-kind rows
- * in `resource_access_grants`, WITHOUT touching any `group`-kind grants the
- * admin grants editor may have set separately.
- *
- * Write-time bridge for the `allowed_roles` write paths (create/update/import,
- * #1206 P1 follow-up): the read gate (userCanAccessResource /
- * filterAccessibleResourceIds) is authoritative on resource_access_grants
- * alone, so a model created/imported/updated with allowedRoles set but no
- * synced grant rows would silently be UNRESTRICTED under the new gate — the
- * migration 111 backfill only ran once, at migration time. `allowedRoles`
- * null/empty clears all `role` grants (matches "no restriction"). Retired
- * along with the `allowed_roles` column in Phase 4 (#1207).
- */
-export async function syncModelAllowedRoleGrants(
-  modelId: number,
-  allowedRoles: string[] | null | undefined,
-  createdBy: number | null
-): Promise<void> {
-  const existing = await listResourceGrants("model", modelId);
-  const groupGrants = existing.filter((g) => g.grantKind === "group");
-  const roleGrants: ResourceGrant[] = (allowedRoles ?? [])
-    .filter((r): r is string => typeof r === "string" && r.trim().length > 0)
-    .map((r) => ({ grantKind: "role" as const, grantValue: r }));
-  await replaceResourceGrants("model", modelId, [...groupGrants, ...roleGrants], createdBy);
-}
-
-/**
  * Delete every grant for a resource (used when the resource itself is deleted, so
  * no orphan grants linger and get re-used if the serial id is recycled).
  */

--- a/lib/db/drizzle/resource-access.ts
+++ b/lib/db/drizzle/resource-access.ts
@@ -315,6 +315,29 @@ export async function replaceResourceGrants(
 }
 
 /**
+ * Translate a list of role NAMES into `role`-kind grants on a model, preserving any
+ * `group`-kind grants already set. Used only by the JSON import path (#1207): an
+ * import file may still carry the legacy `allowedRoles` field, and dropping it
+ * silently would leave the model with zero grants — i.e. UNRESTRICTED (visible to
+ * everyone) — since zero grant rows means "no restriction". Translating it into role
+ * grants keeps the import file's access intent. `allowedRoles` null/empty clears all
+ * `role` grants (matches "no restriction"). This takes role names directly and has
+ * NO dependency on the dropped `ai_models.allowed_roles` column.
+ */
+export async function setModelRoleGrantsFromNames(
+  modelId: number,
+  roleNames: string[] | null | undefined,
+  createdBy: number | null
+): Promise<void> {
+  const existing = await listResourceGrants("model", modelId);
+  const groupGrants = existing.filter((g) => g.grantKind === "group");
+  const roleGrants: ResourceGrant[] = (roleNames ?? [])
+    .filter((r): r is string => typeof r === "string" && r.trim().length > 0)
+    .map((r) => ({ grantKind: "role" as const, grantValue: r.trim() }));
+  await replaceResourceGrants("model", modelId, [...groupGrants, ...roleGrants], createdBy);
+}
+
+/**
  * Delete every grant for a resource (used when the resource itself is deleted, so
  * no orphan grants linger and get re-used if the serial id is recycled).
  */

--- a/lib/db/drizzle/users.ts
+++ b/lib/db/drizzle/users.ts
@@ -90,7 +90,15 @@ export async function getUserById(userId: number) {
 }
 
 /**
- * Get user by email address
+ * Get user by email address.
+ *
+ * Case-INSENSITIVE (`lower(email) = lower(:email)`) — email is an authorization join
+ * key and migration 112 (#1207) enforces uniqueness on `lower(email)`. A
+ * case-sensitive `=` here would miss an existing row when Cognito sends a
+ * differently-cased address, and the caller's fall-through insert/link would then
+ * violate `uq_users_email_lower` and lock the user out of provisioning. Lowercasing
+ * both sides also lets the query use that functional unique index.
+ *
  * @throws {DatabaseError} If user not found
  */
 export async function getUserByEmail(email: string) {
@@ -108,7 +116,7 @@ export async function getUserByEmail(email: string) {
           updatedAt: users.updatedAt,
         })
         .from(users)
-        .where(eq(users.email, email))
+        .where(eq(sql`lower(${users.email})`, email.toLowerCase()))
         .limit(1),
     "getUserByEmail"
   );

--- a/lib/db/schema/tables/ai-models.ts
+++ b/lib/db/schema/tables/ai-models.ts
@@ -32,7 +32,9 @@ export const aiModels = pgTable("ai_models", {
   updatedAt: timestamp("updated_at"),
   nexusEnabled: boolean("nexus_enabled").default(true).notNull(),
   architectEnabled: boolean("architect_enabled").default(true).notNull(),
-  allowedRoles: jsonb("allowed_roles").$type<string[]>(),
+  // NOTE: the legacy allowed_roles column was dropped in migration 113 (#1207).
+  // Per-model role/group access now lives solely in resource_access_grants
+  // (migration 111) — see lib/db/drizzle/resource-access.ts.
   inputCostPer1kTokens: numeric("input_cost_per_1k_tokens", {
     precision: 10,
     scale: 6,

--- a/lib/db/schema/tables/users.ts
+++ b/lib/db/schema/tables/users.ts
@@ -10,27 +10,39 @@ import {
   serial,
   text,
   timestamp,
+  uniqueIndex,
   varchar,
 } from "drizzle-orm/pg-core";
 import { sql } from "drizzle-orm";
 import type { UserProfile } from "@/lib/db/types/jsonb";
 
-export const users = pgTable("users", {
-  id: serial("id").primaryKey(),
-  cognitoSub: varchar("cognito_sub", { length: 255 }).unique(),
-  email: varchar("email", { length: 255 }),
-  firstName: varchar("first_name", { length: 255 }),
-  lastName: varchar("last_name", { length: 255 }),
-  lastSignInAt: timestamp("last_sign_in_at"),
-  createdAt: timestamp("created_at").defaultNow(),
-  updatedAt: timestamp("updated_at").defaultNow().notNull(),
-  oldClerkId: varchar("old_clerk_id", { length: 255 }).unique(),
-  roleVersion: integer("role_version").default(1),
-  // Profile fields (migration 051 - Issue #684)
-  jobTitle: varchar("job_title", { length: 255 }),
-  department: varchar("department", { length: 255 }),
-  building: varchar("building", { length: 255 }),
-  gradeLevels: text("grade_levels").array(),
-  bio: text("bio"),
-  profile: jsonb("profile").$type<UserProfile>().default(sql`'{}'::jsonb`),
-});
+export const users = pgTable(
+  "users",
+  {
+    id: serial("id").primaryKey(),
+    cognitoSub: varchar("cognito_sub", { length: 255 }).unique(),
+    email: varchar("email", { length: 255 }),
+    firstName: varchar("first_name", { length: 255 }),
+    lastName: varchar("last_name", { length: 255 }),
+    lastSignInAt: timestamp("last_sign_in_at"),
+    createdAt: timestamp("created_at").defaultNow(),
+    updatedAt: timestamp("updated_at").defaultNow().notNull(),
+    oldClerkId: varchar("old_clerk_id", { length: 255 }).unique(),
+    roleVersion: integer("role_version").default(1),
+    // Profile fields (migration 051 - Issue #684)
+    jobTitle: varchar("job_title", { length: 255 }),
+    department: varchar("department", { length: 255 }),
+    building: varchar("building", { length: 255 }),
+    gradeLevels: text("grade_levels").array(),
+    bio: text("bio"),
+    profile: jsonb("profile").$type<UserProfile>().default(sql`'{}'::jsonb`),
+  },
+  (table) => ({
+    // Email is an authorization join key (group membership → roles/resource
+    // grants join on lower(email)); migration 112 (#1207) enforces it is
+    // single-valued. NULLs are permitted and distinct (pre-provisioning rows).
+    emailLowerUnique: uniqueIndex("uq_users_email_lower").on(
+      sql`lower(${table.email})`
+    ),
+  })
+);

--- a/lib/streaming/nexus/cost-optimizer.ts
+++ b/lib/streaming/nexus/cost-optimizer.ts
@@ -42,7 +42,6 @@ interface TransformedModel extends DatabaseRow {
   supportsBatching?: boolean;
   capabilities?: string | string[] | null;
   providerMetadata?: Record<string, unknown>;
-  allowedRoles?: string[];
 }
 
 export interface CostOptimizationRequest {
@@ -302,8 +301,7 @@ export class CostOptimizer {
           max_concurrency as "maxConcurrency",
           supports_batching as "supportsBatching",
           capabilities,
-          provider_metadata as "providerMetadata",
-          allowed_roles as "allowedRoles"
+          provider_metadata as "providerMetadata"
         FROM ai_models
         WHERE active = true AND nexus_enabled = true
         ORDER BY provider, name

--- a/lib/streaming/nexus/nexus-provider-factory.ts
+++ b/lib/streaming/nexus/nexus-provider-factory.ts
@@ -22,7 +22,6 @@ interface DatabaseModelInfo extends DatabaseRow {
   supportsBatching?: boolean;
   capabilities?: string | string[] | null;
   providerMetadata?: Record<string, unknown>;
-  allowedRoles?: string[];
 }
 
 export interface NexusModelOptions {
@@ -464,8 +463,7 @@ export class NexusProviderFactory {
           max_concurrency as "maxConcurrency",
           supports_batching as "supportsBatching",
           capabilities,
-          provider_metadata as "providerMetadata",
-          allowed_roles as "allowedRoles"
+          provider_metadata as "providerMetadata"
         FROM ai_models
         WHERE enabled = true
         ORDER BY provider, model_id
@@ -497,8 +495,7 @@ export class NexusProviderFactory {
           max_concurrency as "maxConcurrency",
           supports_batching as "supportsBatching",
           capabilities,
-          provider_metadata as "providerMetadata",
-          allowed_roles as "allowedRoles"
+          provider_metadata as "providerMetadata"
         FROM ai_models
         WHERE provider = $1 AND model_id = $2 AND active = true
         LIMIT 1

--- a/lib/validators/model-import-validator.ts
+++ b/lib/validators/model-import-validator.ts
@@ -93,10 +93,19 @@ export function validateModel(
     }
   }
 
-  // NOTE (#1207): 'allowedRoles' was removed from the import format (the
-  // ai_models.allowed_roles column is gone). It is no longer validated — an older
-  // import file that still carries it imports fine, with the field ignored;
-  // per-model access is set afterward via the ResourceGrantsEditor.
+  // Array fields. 'allowedRoles' no longer maps to a column (#1207) — it is
+  // translated into role grants (resource_access_grants) after import — but it is
+  // still a meaningful, validated field so a malformed value fails loudly instead of
+  // silently importing a model with the wrong (or no) access restriction.
+  if (m.allowedRoles !== undefined) {
+    if (!Array.isArray(m.allowedRoles)) {
+      modelErrors.push(`${prefix}: 'allowedRoles' must be an array`);
+    } else if (
+      !(m.allowedRoles as unknown[]).every((r) => typeof r === "string")
+    ) {
+      modelErrors.push(`${prefix}: 'allowedRoles' must be an array of strings`);
+    }
+  }
 
   // Pricing fields (string numbers)
   const pricingFields = [

--- a/lib/validators/model-import-validator.ts
+++ b/lib/validators/model-import-validator.ts
@@ -93,16 +93,10 @@ export function validateModel(
     }
   }
 
-  // Array fields
-  if (m.allowedRoles !== undefined) {
-    if (!Array.isArray(m.allowedRoles)) {
-      modelErrors.push(`${prefix}: 'allowedRoles' must be an array`);
-    } else if (
-      !(m.allowedRoles as unknown[]).every((r) => typeof r === "string")
-    ) {
-      modelErrors.push(`${prefix}: 'allowedRoles' must be an array of strings`);
-    }
-  }
+  // NOTE (#1207): 'allowedRoles' was removed from the import format (the
+  // ai_models.allowed_roles column is gone). It is no longer validated — an older
+  // import file that still carries it imports fine, with the field ignored;
+  // per-model access is set afterward via the ResourceGrantsEditor.
 
   // Pricing fields (string numbers)
   const pricingFields = [

--- a/scripts/db/report-duplicate-emails.ts
+++ b/scripts/db/report-duplicate-emails.ts
@@ -1,0 +1,92 @@
+/**
+ * Duplicate-email pre-check for migration 112 (Epic #1202, Phase 4 / #1207).
+ *
+ * Migration 112 adds a UNIQUE index on lower(users.email) because email is an
+ * authorization join key (group membership → roles/resource grants join on it).
+ * A plain CREATE UNIQUE INDEX FAILS the deploy if the database already holds two
+ * rows with the same case-insensitive email — by design, so we never ship a
+ * partial index that silently hides the ambiguity.
+ *
+ * Run this against the TARGET database BEFORE deploying migration 112:
+ *   DATABASE_URL=postgres://... bun run scripts/db/report-duplicate-emails.ts
+ * (local dev defaults to the docker postgres, same as run-migrations.ts).
+ *
+ * Exit codes:
+ *   0 — no duplicates; migration 112 will apply cleanly.
+ *   1 — duplicates found (details printed); remediate per the dedupe runbook in
+ *       docs/features/google-group-sync.md before deploying.
+ *   2 — the script itself failed (connection/query error).
+ *
+ * READ-ONLY: this script never writes. Dedupe (merging user rows and their FKs) is
+ * a deliberate human step — see the runbook — never an automated migration.
+ */
+
+import postgres from "postgres";
+import { scriptLogger as log } from "./script-logger";
+
+const DATABASE_URL =
+  process.env.DATABASE_URL ||
+  "postgresql://postgres:postgres@localhost:5432/aistudio";
+const sslEnabled = process.env.DB_SSL !== "false";
+
+interface DuplicateGroup {
+  email: string;
+  count: number;
+  ids: number[];
+}
+
+async function main(): Promise<void> {
+  log.section("AI Studio - Duplicate Email Pre-Check (#1207 / migration 112)");
+  log.info("Database", { url: DATABASE_URL.replace(/:\/\/.*@/, "://*****@") });
+
+  const sql = postgres(DATABASE_URL, {
+    ssl: sslEnabled ? "require" : false,
+    max: 1,
+    idle_timeout: 20,
+    connect_timeout: 10,
+  });
+
+  try {
+    // One row per case-insensitive email that appears more than once, with the
+    // colliding user ids so an operator can decide which to keep/merge.
+    const rows = await sql<DuplicateGroup[]>`
+      SELECT lower(email) AS email,
+             count(*)::int AS count,
+             array_agg(id ORDER BY id) AS ids
+        FROM users
+       WHERE email IS NOT NULL
+       GROUP BY lower(email)
+      HAVING count(*) > 1
+       ORDER BY count(*) DESC, lower(email)
+    `;
+
+    if (rows.length === 0) {
+      log.success(
+        "No duplicate emails — migration 112 (unique index on lower(email)) will apply cleanly."
+      );
+      return;
+    }
+
+    const totalRows = rows.reduce((sum, r) => sum + r.count, 0);
+    log.fail(
+      `${rows.length} duplicated email(s) across ${totalRows} user rows — migration 112 WILL FAIL until remediated.`
+    );
+    for (const r of rows) {
+      log.warn("Duplicate email", { email: r.email, count: r.count, userIds: r.ids });
+    }
+    log.info(
+      "Remediate per the dedupe runbook (docs/features/google-group-sync.md) before deploying migration 112."
+    );
+    // Non-zero exit so CI / an operator script can gate the deploy on this.
+    process.exitCode = 1;
+  } finally {
+    await sql.end();
+  }
+}
+
+main().catch((error) => {
+  log.error("Duplicate-email pre-check failed to run", {
+    error: error instanceof Error ? error.message : String(error),
+  });
+  process.exit(2);
+});

--- a/scripts/db/report-heuristic-only-roles.ts
+++ b/scripts/db/report-heuristic-only-roles.ts
@@ -1,0 +1,168 @@
+/**
+ * Heuristic-only-role report (Epic #1202, Phase 4 / #1207).
+ *
+ * The user-provisioning path assigns a DEFAULT role from a username heuristic
+ * (`/^\d+$/.test(username) ? 'student' : 'staff'` — see lib/auth/resolve-user.ts and
+ * actions/db/get-current-user-action.ts). #1207 asks: once group→role mapping
+ * coverage is confirmed, remove or reduce that heuristic to a no-role default. This
+ * report quantifies the blast radius of doing so.
+ *
+ * WHY THIS IS A PROXY, NOT AN EXACT MEASURE. `addUserRole` stamps the default role
+ * with source='manual' (the column default) — identical to an admin-assigned role —
+ * so a heuristic-assigned role is NOT distinguishable from a hand-assigned one by
+ * source alone. The faithful proxy for "relies on the heuristic/manual default, not
+ * on group-sync" is: a user holds a role with source='manual' that group-sync would
+ * NOT compute for them (they are in no active group whose group_role_mapping grants
+ * that role). Those users would keep their role today (removal only changes NEW
+ * provisioning), but they are the shape of user who, if newly provisioned AFTER the
+ * heuristic is removed, would receive NO role.
+ *
+ * The "computed" set below mirrors reconcileManagedRoles / reconcileUserManagedRoles
+ * EXACTLY (active group, lower(email) join on both sides) so the coverage number is
+ * the same one the reconcilers act on.
+ *
+ * Run against the TARGET database (read-only; never writes):
+ *   DATABASE_URL=postgres://... bun run scripts/db/report-heuristic-only-roles.ts
+ *
+ * DECISION RULE (documented in docs/features/google-group-sync.md):
+ *   - "manual default role, no group-sync coverage" ≈ 0 for staff  → safe to drop
+ *     the non-numeric→staff branch (rely on group-sync for staff).
+ *   - large for staff → keep the staff default (or map the missing staff groups
+ *     first, then re-run this report).
+ *   - numeric→student is least-privilege and low-risk regardless.
+ */
+
+import postgres from "postgres";
+import { scriptLogger as log } from "./script-logger";
+
+const DATABASE_URL =
+  process.env.DATABASE_URL ||
+  "postgresql://postgres:postgres@localhost:5432/aistudio";
+const sslEnabled = process.env.DB_SSL !== "false";
+
+async function main(): Promise<void> {
+  log.section("AI Studio - Heuristic-Only-Role Report (#1207)");
+  log.info("Database", { url: DATABASE_URL.replace(/:\/\/.*@/, "://*****@") });
+
+  const sql = postgres(DATABASE_URL, {
+    ssl: sslEnabled ? "require" : false,
+    max: 1,
+    idle_timeout: 20,
+    connect_timeout: 10,
+  });
+
+  try {
+    // The (user_id, role_id) set group-sync WOULD compute — same join the
+    // reconcilers use (active group, lower(email) on both sides).
+    const computedCte = sql`
+      computed AS (
+        SELECT DISTINCT u.id AS user_id, grm.role_id
+          FROM group_role_mappings grm
+          JOIN groups g
+            ON lower(g.group_email) = lower(grm.group_email)
+           AND g.is_active = true
+          JOIN group_members gm ON gm.group_id = g.id
+          JOIN users u ON lower(u.email) = lower(gm.member_email)
+      )
+    `;
+
+    // 1. Population overview.
+    const [overview] = await sql<
+      { total_users: number; with_roles: number; without_roles: number }[]
+    >`
+      SELECT count(*)::int AS total_users,
+             count(*) FILTER (WHERE EXISTS (
+               SELECT 1 FROM user_roles ur WHERE ur.user_id = u.id
+             ))::int AS with_roles,
+             count(*) FILTER (WHERE NOT EXISTS (
+               SELECT 1 FROM user_roles ur WHERE ur.user_id = u.id
+             ))::int AS without_roles
+        FROM users u
+    `;
+    log.info("Population", { ...overview });
+
+    // 2. Per-role: manual grants that group-sync does NOT reproduce — the
+    //    heuristic/manual-reliant grants. Numeric-username breakdown lets us see
+    //    the student (numeric) vs staff (non-numeric) split the heuristic encodes.
+    const perRole = await sql<
+      {
+        role_name: string;
+        manual_no_group_coverage: number;
+        of_which_numeric_username: number;
+      }[]
+    >`
+      WITH ${computedCte}
+      SELECT r.name AS role_name,
+             count(*)::int AS manual_no_group_coverage,
+             count(*) FILTER (
+               WHERE split_part(u.email, '@', 1) ~ '^\\d+$'
+             )::int AS of_which_numeric_username
+        FROM user_roles ur
+        JOIN roles r ON r.id = ur.role_id
+        JOIN users u ON u.id = ur.user_id
+       WHERE ur.source = 'manual'
+         AND NOT EXISTS (
+           SELECT 1 FROM computed c
+            WHERE c.user_id = ur.user_id AND c.role_id = ur.role_id
+         )
+       GROUP BY r.name
+       ORDER BY manual_no_group_coverage DESC
+    `;
+    log.section("Manual roles NOT reproduced by group-sync (per role)");
+    if (perRole.length === 0) {
+      log.success("None — every manual role is also computed from a group mapping.");
+    } else {
+      for (const row of perRole) {
+        log.info(row.role_name, {
+          manualNoGroupCoverage: row.manual_no_group_coverage,
+          ofWhichNumericUsername: row.of_which_numeric_username,
+        });
+      }
+    }
+
+    // 3. Users whose ENTIRE role set is manual + uncovered by group-sync — the
+    //    clearest "would have no role if newly provisioned post-removal" cohort.
+    const [heuristicOnly] = await sql<
+      { count: number; numeric_username: number }[]
+    >`
+      WITH ${computedCte}
+      SELECT count(*)::int AS count,
+             count(*) FILTER (WHERE split_part(u.email, '@', 1) ~ '^\\d+$')::int
+               AS numeric_username
+        FROM users u
+       WHERE EXISTS (SELECT 1 FROM user_roles ur WHERE ur.user_id = u.id)
+         AND NOT EXISTS (
+           SELECT 1 FROM user_roles ur
+            WHERE ur.user_id = u.id
+              AND (
+                ur.source <> 'manual'
+                OR EXISTS (
+                  SELECT 1 FROM computed c
+                   WHERE c.user_id = ur.user_id AND c.role_id = ur.role_id
+                )
+              )
+         )
+    `;
+    log.section("Heuristic-reliant users (all roles manual + no group-sync coverage)");
+    log.info("Cohort", {
+      users: heuristicOnly?.count ?? 0,
+      numericUsername_student: heuristicOnly?.numeric_username ?? 0,
+      nonNumericUsername_staff:
+        (heuristicOnly?.count ?? 0) - (heuristicOnly?.numeric_username ?? 0),
+    });
+    log.info(
+      "Interpretation: if the heuristic were removed, NEW users of this shape would " +
+        "receive NO default role and rely entirely on group-sync. A large non-numeric " +
+        "(staff) count means map the missing staff groups before dropping the staff branch."
+    );
+  } finally {
+    await sql.end();
+  }
+}
+
+main().catch((error) => {
+  log.error("Heuristic-only-role report failed to run", {
+    error: error instanceof Error ? error.message : String(error),
+  });
+  process.exit(2);
+});

--- a/scripts/db/report-heuristic-only-roles.ts
+++ b/scripts/db/report-heuristic-only-roles.ts
@@ -53,8 +53,10 @@ async function main(): Promise<void> {
 
   try {
     // The (user_id, role_id) set group-sync WOULD compute — same join the
-    // reconcilers use (active group, lower(email) on both sides).
-    const computedCte = sql`
+    // reconcilers use (active group, lower(email) on both sides). A FUNCTION, not a
+    // stored fragment: postgres.js fragments carry per-use state, so build a fresh
+    // one at each interpolation (avoids reusing one fragment object across queries).
+    const computedCte = () => sql`
       computed AS (
         SELECT DISTINCT u.id AS user_id, grm.role_id
           FROM group_role_mappings grm
@@ -91,7 +93,7 @@ async function main(): Promise<void> {
         of_which_numeric_username: number;
       }[]
     >`
-      WITH ${computedCte}
+      WITH ${computedCte()}
       SELECT r.name AS role_name,
              count(*)::int AS manual_no_group_coverage,
              count(*) FILTER (
@@ -125,7 +127,7 @@ async function main(): Promise<void> {
     const [heuristicOnly] = await sql<
       { count: number; numeric_username: number }[]
     >`
-      WITH ${computedCte}
+      WITH ${computedCte()}
       SELECT count(*)::int AS count,
              count(*) FILTER (WHERE split_part(u.email, '@', 1) ~ '^\\d+$')::int
                AS numeric_username

--- a/scripts/db/seed-local.sql
+++ b/scripts/db/seed-local.sql
@@ -213,7 +213,7 @@ ALTER SEQUENCE ai_models_id_seq RESTART WITH 1;
 -- Insert current models
 INSERT INTO ai_models (
     name, model_id, provider, description, capabilities, max_tokens, active,
-    nexus_enabled, architect_enabled, allowed_roles,
+    nexus_enabled, architect_enabled,
     input_cost_per_1k_tokens, output_cost_per_1k_tokens, cached_input_cost_per_1k_tokens
 ) VALUES
 -- Google Gemini 3 Models
@@ -227,7 +227,6 @@ INSERT INTO ai_models (
     true,
     true,
     true,
-    NULL,
     0.002000,
     0.012000,
     0.000500
@@ -242,7 +241,6 @@ INSERT INTO ai_models (
     true,
     true,
     true,
-    NULL,
     0.000500,
     0.003000,
     0.000125
@@ -257,7 +255,6 @@ INSERT INTO ai_models (
     true,
     true,
     false,
-    NULL,
     0.002000,
     0.120000,
     NULL
@@ -272,7 +269,6 @@ INSERT INTO ai_models (
     true,
     true,
     true,
-    NULL,
     0.002000,
     0.012000,
     0.000200
@@ -287,7 +283,6 @@ INSERT INTO ai_models (
     true,
     true,
     false,
-    NULL,
     0.000250,
     0.001500,
     NULL
@@ -304,7 +299,6 @@ INSERT INTO ai_models (
     true,
     true,
     true,
-    NULL,
     0.001750,
     0.014000,
     0.000175
@@ -319,7 +313,6 @@ INSERT INTO ai_models (
     true,
     true,
     true,
-    '["administrator", "staff"]',
     0.001750,
     0.014000,
     0.000175
@@ -334,7 +327,6 @@ INSERT INTO ai_models (
     true,
     true,
     false,
-    NULL,
     0.010000,
     0.040000,
     NULL
@@ -351,7 +343,6 @@ INSERT INTO ai_models (
     true,
     true,
     true,
-    '["administrator", "staff"]',
     0.005000,
     0.025000,
     0.000500
@@ -366,7 +357,6 @@ INSERT INTO ai_models (
     true,
     true,
     true,
-    NULL,
     0.003000,
     0.015000,
     0.000300

--- a/tests/smoke/resource-access-grants.smoke.ts
+++ b/tests/smoke/resource-access-grants.smoke.ts
@@ -24,15 +24,13 @@
  */
 
 import assert from "node:assert/strict";
-import { eq, sql } from "drizzle-orm";
+import { eq } from "drizzle-orm";
 import { executeQuery, toPgRows } from "@/lib/db/drizzle-client";
 import { users } from "@/lib/db/schema";
 import {
   userCanAccessResource,
   filterAccessibleResourceIds,
   replaceResourceGrants,
-  syncModelAllowedRoleGrants,
-  listResourceGrants,
   deleteAllResourceGrants,
 } from "@/lib/db/drizzle/resource-access";
 
@@ -181,73 +179,15 @@ await check("batch: admin sees both (admin bypass)", async () => {
   assert.equal(accessible.has(UNRESTRICTED_ID), true);
 });
 
-// ROLE-ONLY SYNC — syncModelAllowedRoleGrants (the legacy allowed_roles bridge,
-// #1206) must replace ONLY the role grants and PRESERVE group grants, so the
-// model create/update/import write paths never clobber admin-set group grants.
-await replaceResourceGrants(
-  RES_TYPE,
-  RES_ID,
-  [
-    { grantKind: "role", grantValue: "staff" },
-    { grantKind: "group", grantValue: ACTIVE_GROUP },
-  ],
-  adminId
-);
-await syncModelAllowedRoleGrants(Number(RES_ID), ["student", "teacher"], adminId);
-await check("role-only sync swaps roles but keeps the group grant", async () => {
-  const grants = await listResourceGrants(RES_TYPE, RES_ID);
-  const roles = grants.filter((g) => g.grantKind === "role").map((g) => g.grantValue).sort();
-  const groups = grants.filter((g) => g.grantKind === "group").map((g) => g.grantValue);
-  assert.deepEqual(roles, ["student", "teacher"]);
-  assert.deepEqual(groups, [ACTIVE_GROUP.toLowerCase()]);
-});
-await check("role-only sync with null clears roles, still keeps the group grant", async () => {
-  await syncModelAllowedRoleGrants(Number(RES_ID), null, adminId);
-  const grants = await listResourceGrants(RES_TYPE, RES_ID);
-  assert.equal(grants.filter((g) => g.grantKind === "role").length, 0);
-  assert.equal(grants.filter((g) => g.grantKind === "group").length, 1);
-});
+// NOTE (#1207): the ROLE-ONLY SYNC checks (for the removed
+// syncModelAllowedRoleGrants bridge) and the BACKFILL-EQUIVALENCE check (which
+// queried the now-dropped ai_models.allowed_roles column) were removed here when
+// the column was retired in Phase 4. Model access is edited solely through the
+// resource_access_grants writers exercised above; the migration-111 backfill was a
+// one-time, already-completed step.
 
-// Restore a clean slate BEFORE the backfill-equivalence assertion so the
-// synthetic test grants on RES_ID (a non-existent model id) don't register as
-// "extra" model grant rows the real allowed_roles can't explain.
+// Restore a clean slate (idempotent, re-runnable) — clear the synthetic grants.
 await deleteAllResourceGrants(RES_TYPE, RES_ID);
-
-// BACKFILL EQUIVALENCE — migration 111 copied ai_models.allowed_roles into
-// resource_access_grants(kind='role'); the model-access matrix must be identical
-// pre/post (issue AC#6). Assert the set of (model, role) grants derived from
-// allowed_roles EXACTLY equals the backfilled 'model'/'role' grant rows — no
-// missing rows, no extras. Uses the same predicate the migration's INSERT used.
-await check("backfill: model role grants exactly reproduce allowed_roles", async () => {
-  const rows = toPgRows(
-    await executeQuery(
-      (db) =>
-        db.execute(sql`
-          WITH expected AS (
-            SELECT m.id::text AS resource_id, trim(role_name) AS role_name
-              FROM ai_models m,
-                   LATERAL jsonb_array_elements_text(m.allowed_roles) AS role_name
-             WHERE m.allowed_roles IS NOT NULL
-               AND jsonb_typeof(m.allowed_roles) = 'array'
-               AND jsonb_array_length(m.allowed_roles) > 0
-               AND length(trim(role_name)) > 0
-          ),
-          actual AS (
-            SELECT resource_id, grant_value AS role_name
-              FROM resource_access_grants
-             WHERE resource_type = 'model' AND grant_kind = 'role'
-          )
-          SELECT count(*)::int AS mismatches FROM (
-            (SELECT * FROM expected EXCEPT SELECT * FROM actual)
-            UNION ALL
-            (SELECT * FROM actual EXCEPT SELECT * FROM expected)
-          ) diff
-        `),
-      "smoke.backfillEquivalence"
-    )
-  ) as { mismatches: number }[];
-  assert.equal(rows[0]?.mismatches, 0, "allowed_roles <-> grant rows differ");
-});
 
 console.log(`resource-access-grants smoke: ${passed} checks passed`);
 process.exit(0);

--- a/tests/unit/lib/auth/default-role.test.ts
+++ b/tests/unit/lib/auth/default-role.test.ts
@@ -1,0 +1,35 @@
+/**
+ * @jest-environment node
+ *
+ * Locks in the behavior of the centralized default-role heuristic
+ * (lib/auth/default-role.ts, #1207). This function is the single source of truth
+ * for a security-relevant provisioning decision, and its whole purpose is to make
+ * the coverage-gated retirement "a one-line edit" — so a test guards against a
+ * future edit changing the numeric/non-numeric/empty behavior unintentionally.
+ */
+import { defaultRoleForNewUser } from "@/lib/auth/default-role"
+
+describe("defaultRoleForNewUser (#1207 legacy heuristic)", () => {
+  it("maps an all-digit username to student (K-12 student ID convention)", () => {
+    expect(defaultRoleForNewUser("123456@psd401.net")).toBe("student")
+    expect(defaultRoleForNewUser("0@psd401.net")).toBe("student")
+  })
+
+  it("maps a non-numeric username to staff", () => {
+    expect(defaultRoleForNewUser("jane.doe@psd401.net")).toBe("staff")
+    expect(defaultRoleForNewUser("teacher1@psd401.net")).toBe("staff") // digits present but not all-digit
+    expect(defaultRoleForNewUser("123abc@psd401.net")).toBe("staff")
+  })
+
+  it("defaults an empty / missing username or email to staff (matches the prior inline behavior)", () => {
+    expect(defaultRoleForNewUser("@psd401.net")).toBe("staff")
+    expect(defaultRoleForNewUser("")).toBe("staff")
+    expect(defaultRoleForNewUser(null)).toBe("staff")
+    expect(defaultRoleForNewUser(undefined)).toBe("staff")
+  })
+
+  it("keys only on the local part (text before @), ignoring a numeric domain", () => {
+    expect(defaultRoleForNewUser("jane@123.net")).toBe("staff")
+    expect(defaultRoleForNewUser("42@123.net")).toBe("student")
+  })
+})


### PR DESCRIPTION
## Summary
Implements #1207 — Epic #1202 Phase 4 hardening once group-driven access is live.

## Changes
- **Email as an authz join key** (`feat(db)`): migration 112 adds `UNIQUE INDEX ON users (lower(email))` (email now backs role/resource authorization). It **fails the deploy loudly** on pre-existing duplicates by design (never a silent partial index). Ships `scripts/db/report-duplicate-emails.ts` (read-only pre-check) + a dedupe runbook. Drizzle schema mirrors the index.
- **Sync observability** (`feat(infra)`): two CloudWatch alarms in `processing-stack.ts` — `GroupSyncFailureAlarm` (Lambda `Errors` >= 1; the handler re-throws so this covers crashes + handled failures) and `GroupSyncStalenessAlarm` (new `SyncRunSucceeded` metric absent/0 over 3h, `treatMissingData=BREACHING`, so it also catches "schedule stopped firing"). SNS+email gated on the `alertEmail` context. Per-group failures were already surfaced in Admin -> Groups (Failed badge + aggregate); directory pagination is exhaustive (no silent caps).
- **Drop `ai_models.allowed_roles`** (`feat(models)`): migration 113 drops the column + its GIN index after confirming **all read paths** use `resource_access_grants` (the nexus/cost-optimizer selects were dead carries; `GET /api/models` already filters server-side). Removes the write-time bridge, the legacy "Allowed Roles" model-modal field, and the **client-side `use-filtered-models` role filter** (+ the `/api/user/roles` fetch it drove). Access is now edited solely via the ResourceGrantsEditor.
- **Retire/reduce the username heuristic** (`refactor(auth)`): centralized the duplicated `isNumeric ? student : staff` into `lib/auth/default-role.ts` (returns role **or null**; both call sites guard on null), so reduction to a no-role default is a one-line edit. Ships `scripts/db/report-heuristic-only-roles.ts`. **Full removal is coverage-gated on the prod report** (see Open questions).
- **Docs**: added the **third authorization axis** (resource grants + groups) to `capabilities-and-scopes.md`; new `docs/features/google-group-sync.md` (architecture, settings, observability, runbooks: sync failure, staleness, group rename, member email change, dedupe, heuristic retirement); new learning `docs/learnings/architecture/2026-07-14-group-sync-as-authz-source.md`.

## Verification (all green before opening)
- Build/Typecheck: `bun run typecheck` clean; infra `tsc --noEmit` clean
- Lint (zero-warning gate): `bunx eslint .` — 0 errors (350 pre-existing complexity warnings, baselined)
- Tests: group-sync lambda `bun test` 14/14; resource-access grants smoke **18 checks** pass (role/group/admin/unrestricted matrix intact after the bridge removal)
- **Full authed E2E suite** (pre-push hook): **227 passed, 49 skipped**
- Migrations validated on a rolled-back temp DB: 112 rejects duplicates + succeeds de-duplicated + NULLs coexist; 113 idempotent + seed's 12 columns intact
- Reports executed against a local DB (real output)

## Evidence
UI change was verified locally (authenticated, `:3100`) with three screenshots — model Edit modal (the **Access** editor: Unrestricted -> Roles + Google groups, backed by `resource_access_grants`, is the sole access control; the legacy "Allowed Roles" field is gone), the models list (server-filtered by grants), and Admin -> Groups (sync status + "Failed syncs" per-group aggregate). Screenshots are **deliberately not committed to this public repo** (local admin-panel captures) and were shared with the reviewer out-of-band. The change is overwhelmingly migration/infra/backend/docs; the only UI delta is the removal of the deprecated field.

## Deploy notes (not auto-applied — hand to operator)
1. **Before deploying migration 112**: run `scripts/db/report-duplicate-emails.ts` against the target DB; remediate any duplicates (migration 112 fails loudly otherwise).
2. Deploy migrations 112 + 113 with this release (113 drops `allowed_roles` in the same release that stops referencing it).
3. Deploy `AIStudio-ProcessingStack-{Dev,Prod}` with `--context alertEmail=<addr>` to wire alarm notifications; test-fire per the runbook.

## Open questions
1. Heuristic full-removal is gated on the prod `report-heuristic-only-roles.ts` output — keep as-is (centralized), drop only non-numeric->staff, or full no-role default? (One-line change in `lib/auth/default-role.ts`.)

Closes #1207