### PR TITLE
fix: #1232 - isolate WIF broker in a dedicated mint Lambda (confused-deputy hardening)

### DIFF
--- a/app/api/agent/account-request/route.ts
+++ b/app/api/agent/account-request/route.ts
@@ -59,9 +59,9 @@ function isStudentUsername(localPart: string): boolean {
 }
 
 /**
- * Map a broker error to its HTTP response, or null if it isn't one of the
- * broker's typed errors (caller decides). Shared by the derive-guard and the
- * probe so the instanceof branching lives in one place.
+ * Map a broker error (thrown by the mint boundary — Lambda or in-process) to its
+ * HTTP response, or null if it isn't one of the broker's typed errors (caller
+ * decides). Keeps the instanceof branching in one place.
  */
 function mapBrokerError(err: unknown, requestId: string): NextResponse | null {
   if (err instanceof InvalidOwnerError) {
@@ -75,9 +75,10 @@ function mapBrokerError(err: unknown, requestId: string): NextResponse | null {
 }
 
 /**
- * Derive + domain-guard the agnt_ target, then probe the broker for existence.
- * Returns a TERMINAL response (active / 400 / 503 / 502), or null to signal the
- * caller should proceed to the sheet write (account not provisioned yet).
+ * Probe the mint boundary for the agnt_ account's existence (the boundary derives
+ * agnt_<owner> and domain-guards internally). Returns a TERMINAL response
+ * (active / 400 / 503 / 502), or null to signal the caller should proceed to the
+ * sheet write (account not provisioned yet).
  */
 async function probeAgentAccount(ownerEmail: string, requestId: string): Promise<NextResponse | null> {
   try {

--- a/app/api/agent/account-request/route.ts
+++ b/app/api/agent/account-request/route.ts
@@ -23,6 +23,16 @@
  * The endpoint is idempotent — any number of calls for the same user result in
  * at most one sheet row.
  *
+ * CONFUSED-DEPUTY ISOLATION (#1232 hardening): this route is a THIN PROXY. Both
+ * WIF-backed steps — the existence probe (mint) and the OneSync sheet write —
+ * run in the dedicated `psd-agent-mint-{env}` Lambda (the sole AWS principal the
+ * Google WIF provider trusts), reached via IAM-authed `lambda:InvokeFunction`.
+ * The frontend passes only ownerEmail/username; the `agnt_` derivation happens
+ * INSIDE the Lambda, so a frontend compromise can never `signJwt(sub=<human>)`.
+ * Auth + validation + student guard + error→HTTP mapping are unchanged. (When
+ * AGENT_MINT_LAMBDA_NAME is unset — local dev/tests — the boundary runs the
+ * broker/sheet in-process, where there is no real WIF anyway.)
+ *
  * Part of #1233.
  */
 
@@ -31,18 +41,15 @@ import { createLogger, generateRequestId, sanitizeForLogging } from "@/lib/logge
 import { SAFE_EMAIL_RE } from "@/lib/agent-workspace/validation"
 import { validateInternalSecret } from "@/lib/agent-workspace/internal-auth"
 import {
-  mintAgentWorkspaceToken,
-  deriveAgentEmail,
-  loadBrokerConfig,
   AccountNotProvisionedError,
   BrokerNotConfiguredError,
   InvalidOwnerError,
 } from "@/lib/agent-workspace/dwd-token-broker"
+import { ProvisioningNotConfiguredError } from "@/lib/agent-workspace/agent-provisioning-sheet"
 import {
-  createSheetsGateway,
-  ensureAgentUsernameRow,
-  ProvisioningNotConfiguredError,
-} from "@/lib/agent-workspace/agent-provisioning-sheet"
+  mintAgentWorkspaceTokenViaBoundary,
+  provisionAgentAccountViaBoundary,
+} from "@/lib/agent-workspace/mint-client"
 
 const log = createLogger({ module: "agent-account-request" })
 
@@ -74,16 +81,11 @@ function mapBrokerError(err: unknown, requestId: string): NextResponse | null {
  */
 async function probeAgentAccount(ownerEmail: string, requestId: string): Promise<NextResponse | null> {
   try {
-    const cfg = await loadBrokerConfig()
-    deriveAgentEmail(ownerEmail, cfg.allowedDomain)
-  } catch (err) {
-    const mapped = mapBrokerError(err, requestId)
-    if (mapped) return mapped
-    throw err
-  }
-
-  try {
-    await mintAgentWorkspaceToken(ownerEmail)
+    // The mint boundary derives `agnt_<owner>` and enforces the domain guard
+    // INSIDE the mint Lambda (or in-process for local dev); a successful mint
+    // proves the account exists. InvalidOwner / not-configured surface as the
+    // same typed errors, mapped to 400 / 503 by mapBrokerError below.
+    await mintAgentWorkspaceTokenViaBoundary(ownerEmail)
     log.info("account-request: agnt_ account already active", sanitizeForLogging({ ownerEmail, requestId }))
     return NextResponse.json({ status: "active" })
   } catch (err) {
@@ -136,9 +138,10 @@ export async function POST(request: NextRequest) {
   const probeResult = await probeAgentAccount(ownerEmail, requestId)
   if (probeResult) return probeResult
 
-  // 2. Dedupe + append the bare username to the OneSync sheet.
+  // 2. Dedupe + append the bare username to the OneSync sheet (via the mint
+  // Lambda boundary, or in-process for local dev/tests).
   try {
-    const { written } = await ensureAgentUsernameRow(localPart, createSheetsGateway())
+    const { written } = await provisionAgentAccountViaBoundary(localPart)
     log.info("account-request: agnt_ account queued via sheet", sanitizeForLogging({ ownerEmail, requestId, written }))
     return NextResponse.json({ status: "requested" })
   } catch (err) {

--- a/app/api/agent/workspace-token/route.ts
+++ b/app/api/agent/workspace-token/route.ts
@@ -19,16 +19,28 @@
  * body has no such field — which keeps the domain-wide credential usable only
  * for `agnt_` accounts (never a human mailbox).
  *
+ * CONFUSED-DEPUTY ISOLATION (#1232 hardening): this route is a THIN PROXY. The
+ * WIF/signJwt work runs in the dedicated `psd-agent-mint-{env}` Lambda (the sole
+ * AWS principal the Google WIF provider trusts), reached here via an IAM-authed
+ * `lambda:InvokeFunction` (mintAgentWorkspaceTokenViaBoundary). The Next.js
+ * frontend NO LONGER holds the WIF credential, so a frontend RCE/SSRF can at most
+ * invoke the mint Lambda — which ALWAYS derives `agnt_<owner>` server-side and
+ * can never `signJwt(sub=<arbitrary human>)`. Auth + validation + rate limiting +
+ * error→HTTP mapping below are unchanged; only the broker call moved behind the
+ * Lambda boundary. (When AGENT_MINT_LAMBDA_NAME is unset — local dev/tests — the
+ * boundary runs the broker in-process, where there is no real WIF anyway.)
+ *
  * SECURITY / KNOWN LIMITATION (codex review P1, #1232 open item): the caller is
  * authenticated ONLY by the shared internal secret, then `ownerEmail` is trusted
  * from the body. The agent runtime can read that secret, so a prompt-driven
- * agent could request a token for a DIFFERENT owner's `agnt_` account. Current
- * containment: the derivation guard confines the blast radius to `agnt_`
- * accounts (agent-generated content, never a human's mailbox), and the secret is
- * a container-only credential. Binding the token to a *verified* caller identity
- * (a signed owner assertion injected by the OpenClaw runtime, not a body field)
- * is the documented follow-up in #1232 ("If OpenClaw can inject the signed-in
- * user's verified email…") and requires runtime support that does not exist yet.
+ * agent could request a token for a DIFFERENT owner's `agnt_` account. Post-
+ * isolation blast radius: a frontend or secret compromise can obtain tokens for
+ * `agnt_` accounts (agent-generated content, never a human's mailbox) — it can
+ * NOT reach an arbitrary psd401.net mailbox, because the WIF credential lives
+ * only in the mint Lambda's role and the derivation guard runs INSIDE that
+ * boundary. Binding the token to a *verified* caller identity (a signed owner
+ * assertion injected by the OpenClaw runtime, not a body field) is the documented
+ * follow-up in #1232 and requires runtime support that does not exist yet.
  *
  * Part of #1232.
  */
@@ -37,8 +49,8 @@ import { NextRequest, NextResponse } from "next/server"
 import { createLogger, generateRequestId, sanitizeForLogging } from "@/lib/logger"
 import { SAFE_EMAIL_RE } from "@/lib/agent-workspace/validation"
 import { validateInternalSecret } from "@/lib/agent-workspace/internal-auth"
+import { mintAgentWorkspaceTokenViaBoundary } from "@/lib/agent-workspace/mint-client"
 import {
-  mintAgentWorkspaceToken,
   AccountNotProvisionedError,
   BrokerNotConfiguredError,
   InvalidOwnerError,
@@ -110,7 +122,9 @@ export async function POST(request: NextRequest) {
   }
 
   try {
-    const { accessToken, expiresAt, agentEmail } = await mintAgentWorkspaceToken(ownerEmail)
+    // Delegates to the isolated mint Lambda when AGENT_MINT_LAMBDA_NAME is set
+    // (every deployed env); runs the broker in-process only for local dev/tests.
+    const { accessToken, expiresAt, agentEmail } = await mintAgentWorkspaceTokenViaBoundary(ownerEmail)
     // Audit trail for a domain-wide credential — owner, agent, requestId. Never
     // the token value.
     log.info("Workspace token minted", sanitizeForLogging({ ownerEmail, agentEmail, expiresAt, requestId }))

--- a/docs/features/agent-workspace-integration.md
+++ b/docs/features/agent-workspace-integration.md
@@ -15,6 +15,18 @@ tokens for two slots:
   broker** (`POST /api/agent/workspace-token`). Agent accounts are created
   automatically via the OneSync sheet (**#1233**); interactive sign-in on
   `agnt_*` accounts is blocked at the Google layer.
+  - **Confused-deputy isolation (#1232 hardening):** the DWD broker and the
+    OneSync sheet writer do **not** run in the Next.js app. They run in a
+    dedicated **mint Lambda** (`psd-agent-mint-{env}`) with its own least-
+    privilege role, which is the **sole AWS principal the Google WIF provider
+    trusts**. The `/api/agent/workspace-token` and `/api/agent/account-request`
+    routes are thin proxies that reach the mint Lambda via an IAM-authed
+    `lambda:InvokeFunction`. So a frontend RCE/SSRF can at most *invoke* the mint
+    Lambda — which always derives `agnt_<owner>` server-side — and can never
+    reach the WIF credential to `signJwt(sub=<arbitrary human>)`. Blast radius of
+    a frontend compromise: **any `agnt_` account** (agent-generated content), not
+    any psd401.net mailbox. (When `AGENT_MINT_LAMBDA_NAME` is unset — local dev —
+    the routes run the broker in-process; there is no real WIF locally.)
 
 ## Components
 
@@ -22,8 +34,9 @@ tokens for two slots:
 |---|---|---|
 | DB | `psd_agent_workspace_tokens`, `psd_agent_workspace_consent_nonces` (migration 071) | Token manifest (user slot lifecycle; agent slot shows "Auto (DWD)") + one-time consent nonces |
 | API | `POST /api/agent/consent-link` | Agent→app, mints signed consent URLs (**user slot only** — agent_account is rejected, #1232) |
-| API | `POST /api/agent/workspace-token` | Agent→app DWD broker; mints a ~1h agent-slot access token (#1232). 404 `account-not-provisioned` when the agnt_ account isn't made yet |
-| API | `POST /api/agent/account-request` | Router→app; appends the username to the OneSync `agents` sheet to auto-provision the agnt_ account (#1233) |
+| API | `POST /api/agent/workspace-token` | Agent→app; **thin proxy** to the mint Lambda; mints a ~1h agent-slot access token (#1232). 404 `account-not-provisioned` when the agnt_ account isn't made yet |
+| API | `POST /api/agent/account-request` | Router→app; **thin proxy** to the mint Lambda (probe + OneSync `agents` sheet append) to auto-provision the agnt_ account (#1233) |
+| Lambda | `psd-agent-mint-{env}` (AgentPlatformStack, role `psd-agent-mint-execution-role-{env}`) | **#1232 isolation** — the sole WIF principal. Houses the DWD broker + provisioning-sheet writer; derives `agnt_<owner>` server-side. Role grants only `secretsmanager:GetSecretValue` on `psd-agent/{env}/*` + logs; the frontend holds only `lambda:InvokeFunction` on it. |
 | UI | `/agent-connect`, `/agent-connect/callback` | Public OAuth bootstrap (off-nav) |
 | Admin | "Workspace" tab in `/admin/agents` | Per-user status dashboard |
 | Skill | `infra/agent-image/skills/psd-workspace/` | Agent-side `gws` wrapper |
@@ -57,9 +70,11 @@ tokens for two slots:
 
 1. User asks the agent to act AS itself (`--scope agent`).
 2. Skill POSTs `/api/agent/workspace-token` (`{ownerEmail}`, PSK Bearer).
-3. Broker derives `agnt_<owner-localpart>@psd401.net` server-side and mints a
-   ~1h access token via WIF → service-account signJwt → jwt-bearer exchange.
-4. If the agnt_ account doesn't exist yet, the broker returns 404
+3. The route (thin proxy) invokes the **mint Lambda**, which derives
+   `agnt_<owner-localpart>@psd401.net` server-side and mints a ~1h access token
+   via WIF → service-account signJwt → jwt-bearer exchange. Only the mint
+   Lambda's role can perform the WIF leg (the frontend cannot).
+4. If the agnt_ account doesn't exist yet, the mint Lambda returns 404
    `account-not-provisioned`; the skill emits `{status:"account-provisioning"}`
    exit 14 (the router has already kicked off auto-provisioning, #1233). No
    consent link — the user just retries in ~30 min.
@@ -97,18 +112,38 @@ paste it verbatim into Chat and stop the turn. Exit 14 carries **no** URL.
 4. Set `GOOGLE_WORKSPACE_CLIENT_ID` / `GOOGLE_WORKSPACE_CLIENT_SECRET` in the
    Next.js environment (same values as step 2).
 5. **DWD broker + provisioning (#1232/#1233)** — IT provisions a Google service
-   account with domain-wide delegation + a workload-identity-federation trust for
-   the app's AWS role, then populate ONE Secrets Manager secret (no CDK context
-   flags — aistudio is a public repo):
+   account with domain-wide delegation + a workload-identity-federation trust,
+   then populate ONE Secrets Manager secret (no CDK context flags — aistudio is a
+   public repo):
    ```bash
    aws secretsmanager create-secret \
      --name psd-agent/dev/gcp-dwd-config \
      --tags Key=Environment,Value=dev Key=ManagedBy,Value=aistudio \
      --secret-string '{"projectNumber":"…","wifPoolId":"…","wifProviderId":"…","serviceAccountEmail":"…@….iam.gserviceaccount.com","provisioningSheetId":"…"}'
    ```
-   The app reads it lazily (5-min cached); until it exists the broker fails closed
-   (503 / `not-configured`) and provisioning is skipped. (Local dev may instead set
-   the `GCP_*` / `AGENT_PROVISIONING_SHEET_ID` env vars.)
+   The mint Lambda reads it lazily (5-min cached); until it exists the broker
+   fails closed (503 / `not-configured`) and provisioning is skipped. (Local dev
+   may instead set the `GCP_*` / `AGENT_PROVISIONING_SHEET_ID` env vars.)
+
+   **WIF trusts the mint role, NOT the frontend role (#1232 hardening).** The WIF
+   provider condition and the SA `principalSet` bindings must reference the mint
+   Lambda's role, whose ARN is stable and deterministic:
+   - Role ARN: `arn:aws:iam::<account>:role/psd-agent-mint-execution-role-{env}`
+   - Assumed-role principal (what Google's STS sees): `arn:aws:sts::<account>:assumed-role/psd-agent-mint-execution-role-{env}/*`
+
+   Reese, when wiring (or re-pointing off the old frontend-role trust) the
+   Google side against the mint role:
+   1. Set the WIF provider (`mint-service`) attribute condition to accept the
+      mint role's assumed-role ARN above (replacing the frontend ECS task role).
+   2. Move the `roles/iam.workloadIdentityUser` **and**
+      `roles/iam.serviceAccountTokenCreator` `principalSet` bindings on the DWD
+      service account to the mint role's WIF principal.
+
+   The mint Lambda authenticates keylessly (google-auth-library `AwsClient`
+   resolves the Lambda role's ambient credentials via the Fargate/Lambda
+   container-credentials endpoint the same way it did for the ECS task role — see
+   the `credential_source` note in `lib/agent-workspace/gcp-wif.ts`); no
+   service-account key is downloaded.
 6. **Agent gateway (#1230)** — populate ONE JSON secret with both the n8n MCP
    Server Trigger URL and its bearer token (again, no CDK context flag):
    ```bash

--- a/docs/learnings/build-errors/2026-07-15-ci-typecheck-includes-tests-stale-tsbuildinfo-masks-ts2556.md
+++ b/docs/learnings/build-errors/2026-07-15-ci-typecheck-includes-tests-stale-tsbuildinfo-masks-ts2556.md
@@ -1,0 +1,29 @@
+---
+title: CI tsc --noEmit type-checks tests/ too; stale tsbuildinfo can hide a real failure locally
+category: build-errors
+tags: [typescript, tsc, incremental, tsbuildinfo, jest, TS2556, ci]
+severity: medium
+date: 2026-07-15
+source: auto — /work
+applicable_to: project
+---
+
+## What Happened
+
+PR #1236 (#1232) passed `bun run typecheck` locally but CI's `tsc --noEmit` failed with TS2556 on a jest mock in `tests/unit/agent-mint-client.test.ts` / `agent-mint-lambda-handler.test.ts`.
+
+## Root Cause
+
+- Root `tsconfig.json` `exclude` is only `["node_modules", "infra"]` — `tests/` is type-checked by `tsc --noEmit` same as app code. Easy to assume tests are excluded; they aren't.
+- `tsconfig.json` has `"incremental": true`. A local `bun run typecheck` run can reuse a stale `.tsbuildinfo` and report success even after introducing a real type error, while CI always runs clean and fails. `rm` the tsbuildinfo file to force a full reproduction locally.
+- Specific TS2556 cause: `const createGatewayMock = jest.fn(() => ({ gateway: true }))` gives the mock a no-arg (empty-tuple) parameter type. Code elsewhere spread captured args into it — `(...a) => createGatewayMock(...a)` — which TS rejects because the spread argument isn't assignable to an empty tuple.
+
+## Solution
+
+- Give the mock a rest param so its inferred signature accepts any args: `jest.fn((..._a: unknown[]) => ({ gateway: true }))`.
+- To reproduce a CI-only typecheck failure locally, delete the incremental build cache first (find the `tsBuildInfoFile`/default `.tsbuildinfo` and remove it) before re-running `bun run typecheck`.
+
+## Prevention
+
+- Don't trust a passing local `bun run typecheck` after touching a test file if the working tree has stale build artifacts — clear incremental cache when a CI mismatch is suspected.
+- When writing a `jest.fn()` mock that stands in for a function whose call site passes variable/spread args, default to a rest-param signature (`(..._a: unknown[]) => ...`) instead of a no-arg arrow, to avoid tuple-arity mismatches under strict TS.

--- a/docs/learnings/infrastructure/2026-07-15-cdk-esbuild-bundle-app-tree-handler-source-hash.md
+++ b/docs/learnings/infrastructure/2026-07-15-cdk-esbuild-bundle-app-tree-handler-source-hash.md
@@ -1,0 +1,33 @@
+---
+title: Bundling an app-tree TS handler into a CDK Lambda — SOURCE hash + local esbuild, not fromAsset OUTPUT
+category: infrastructure
+tags: [cdk, lambda, esbuild, assetHashType, bundling, fromAsset, agent-workspace]
+severity: medium
+date: 2026-07-15
+source: auto — /work
+applicable_to: project
+---
+
+## What Happened
+
+PR #1236 (#1232) added a new `psd-agent-mint-{env}` Lambda whose handler (`lib/agent-workspace/mint-lambda-handler.ts`) lives in the Next.js app tree, not under `infra/`, so it can share the broker/sheet-writer modules and their existing jest unit tests.
+
+## Root Cause
+
+`lambda.Code.fromAsset` needs to know both how to bundle app-tree TypeScript (esbuild, path aliases, external packages) and how to hash the asset for change detection. Getting either wrong either breaks CDK unit tests (which synth with bundling disabled) or produces a stale/incorrect deploy hash.
+
+## Solution
+
+In `infra/lib/agent-platform-stack.ts`:
+- Point `lambda.Code.fromAsset(path.join(__dirname, '..', '..', 'lib', 'agent-workspace'), ...)` at the app source directory.
+- Set `assetHashType: cdk.AssetHashType.SOURCE` (repo convention — every existing agent Lambda uses this) — NOT `OUTPUT`. `OUTPUT` misbehaves/throws when CDK unit tests synth with bundling disabled (`aws:cdk:bundling-stacks: []`), since there is no output to hash yet.
+- Bundle via `bundling.local.tryBundle(outputDir)`, invoking the repo-root esbuild binary directly (`node_modules/.bin/esbuild`) rather than the Docker bundling image: `--bundle --platform=node --target=node22 --format=cjs --outfile=<outputDir>/index.js --tsconfig=<repoRoot>/tsconfig.json --external:@aws-sdk/*`.
+- Resolve the `@/*` path alias via `--tsconfig=<repo>/tsconfig.json` (matches app import style).
+- Mark `@aws-sdk/*` external — it's present in the Node 20/22 Lambda runtime, no need to bundle it.
+- Bundle `google-auth-library` and `winston` inline (not present in the runtime).
+- The Docker `bundling.command` fallback intentionally fails loud (`exit 1` with a message) rather than attempting a bundle — the small `lib/agent-workspace` asset dir alone can't produce a correct bundle without the repo-root esbuild/tsconfig, so local bundling is the required path (consistent with other agent Lambdas).
+
+## Prevention
+
+- Before wiring the CDK construct, manually run the exact esbuild command and load the resulting bundle in `node` to confirm it resolves correctly — cheaper than debugging a bad synth/deploy.
+- When adding a new app-tree-backed Lambda, grep other agent Lambdas in `agent-platform-stack.ts` for the same `tryBundle`/`assetHashType: SOURCE` pattern rather than re-deriving it.

--- a/docs/learnings/infrastructure/2026-07-15-cross-stack-lambda-invoke-grant-via-constructed-arn.md
+++ b/docs/learnings/infrastructure/2026-07-15-cross-stack-lambda-invoke-grant-via-constructed-arn.md
@@ -1,0 +1,27 @@
+---
+title: Grant cross-stack lambda:InvokeFunction on a constructed ARN, not a cross-stack object import
+category: infrastructure
+tags: [cdk, iam, lambda, cross-stack, circular-dependency, ServiceRoleFactory, agent-workspace]
+severity: medium
+date: 2026-07-15
+source: auto — /work
+applicable_to: project
+---
+
+## What Happened
+
+PR #1236 (#1232) needed the frontend ECS task role (`FrontendStack`) to invoke a new Lambda defined in `AgentPlatformStack`, without creating a new cross-stack coupling in the wrong direction.
+
+## Root Cause
+
+Granting `lambda:InvokeFunction` the "normal" way (`mintLambda.grantInvoke(taskRole)`) requires importing the `lambda.Function` object across stacks, which creates a stack dependency. `FrontendStack` already depends on `AgentPlatformStack`, so this particular direction wouldn't have been circular here, but the pattern is fragile in general and unnecessary when the target name is known ahead of time.
+
+## Solution
+
+- In `infra/lib/constructs/ecs-service.ts`, grant `lambda:InvokeFunction` on a manually **constructed ARN string** built from the deterministic function name (`psd-agent-mint-{environment}`), instead of importing the `lambda.Function` object from `AgentPlatformStack`.
+- This works because `ServiceRoleFactory`-created roles/functions use stable, predictable names (`<functionName>-execution-role-<env>` for the role; `<functionName>-<env>` for the Lambda) — the same determinism that lets IT (Google WIF admin) pre-configure trust before deploy (see the confused-deputy isolation learning) also lets a sibling stack construct the ARN without an object reference.
+
+## Prevention
+
+- When a cross-stack IAM grant only needs a resource ARN (not the construct's other properties), prefer building the ARN from a deterministic resource name over importing the construct — avoids adding a new stack dependency edge, especially useful when the dependency direction is uncertain or could become circular later.
+- Confirm the target resource's naming really is deterministic (fixed `functionName`, not CDK auto-generated) before relying on this pattern.

--- a/docs/learnings/security/2026-07-15-wif-confused-deputy-needs-infrastructural-isolation.md
+++ b/docs/learnings/security/2026-07-15-wif-confused-deputy-needs-infrastructural-isolation.md
@@ -1,0 +1,28 @@
+---
+title: Keyless GCP WIF credential must live in its own least-privilege Lambda, not shared app compute
+category: security
+tags: [wif, workload-identity-federation, confused-deputy, gcp, lambda, iam, least-privilege, agent-workspace]
+severity: critical
+date: 2026-07-15
+source: auto — /work
+applicable_to: project
+---
+
+## What Happened
+
+PR #1236 (#1232) hardened the GCP Workload-Identity-Federation (WIF) domain-wide-delegation broker (`lib/agent-workspace/gcp-wif.ts`). The broker previously ran inside the shared frontend ECS task, which resolves its WIF credential from the ambient AWS role via the container-credentials endpoint.
+
+## Root Cause
+
+WIF is keyless — the Google STS provider trusts *any* caller holding the bound AWS role's credentials, not a specific process. Because the frontend ECS task role was that bound principal, any code execution inside the same task (RCE, SSRF, a compromised dependency) could impersonate the service account and call `signJwt(sub=<arbitrary user>)`, minting a Google Workspace token for any `psd401.net` mailbox — including staff Gmail/Drive, far beyond the intended `agnt_*` service accounts. An app-layer guard that validates/derives the `sub` (`deriveAgentEmail`) does NOT close this gap: it runs in the same bypassable process as the vulnerability.
+
+## Solution
+
+- Moved both WIF consumers (DWD token broker + provisioning-sheet writer) into a new dedicated `psd-agent-mint-{env}` Lambda (`infra/lib/agent-platform-stack.ts`) with its own `ServiceRoleFactory` role — the SOLE AWS principal the Google WIF provider trusts (IT points the provider's principalSet condition at this exact, deterministic role ARN).
+- That role gets only `secretsmanager:GetSecretValue` on `psd-agent/{env}/*` + CloudWatch Logs + VPC ENI (`AWSLambdaVPCAccessExecutionRole`). No other AWS grant is needed — WIF verification is an implicit `GetCallerIdentity` Google's STS performs against the role's ambient credentials.
+- The frontend ECS task role loses all WIF-related access and gets only `lambda:InvokeFunction` on the mint Lambda (see `constructs/ecs-service.ts`). The Lambda handler always derives `agnt_<owner>` server-side — a frontend compromise can invoke the Lambda but can never make it sign a token for an arbitrary human.
+
+## Prevention
+
+- Treat "which AWS principal is bound to a keyless external-identity federation" as a security boundary decision, not an implementation detail — that principal must be the smallest possible blast radius (a single-purpose Lambda/role), never a shared multi-tenant compute role (ECS task, general-purpose Lambda).
+- App-layer input validation/derivation guards are defense-in-depth, not the boundary — verify isolation at the IAM/infrastructure layer first.

--- a/infra/lib/agent-platform-stack.ts
+++ b/infra/lib/agent-platform-stack.ts
@@ -117,6 +117,14 @@ export class AgentPlatformStack extends cdk.Stack {
   public readonly cronLambdaRole: iam.Role;
   /** Router Lambda function */
   public readonly routerLambda: lambda.Function;
+  /**
+   * Isolated mint Lambda (#1232) — the SOLE AWS principal the GCP WIF provider
+   * trusts. Houses the DWD token broker + provisioning-sheet writer so a frontend
+   * compromise can never reach the WIF credential / signJwt an arbitrary sub.
+   */
+  public readonly mintLambda: lambda.Function;
+  /** Mint Lambda IAM role — the intended WIF principal (stable, deterministic ARN). */
+  public readonly mintLambdaRole: iam.Role;
   /** SQS queue for Google Chat Pub/Sub messages */
   public readonly routerQueue: sqs.Queue;
   /** Google service account credentials secret */
@@ -2761,6 +2769,154 @@ export class AgentPlatformStack extends cdk.Stack {
     // account-request call to the Next.js app. (The router role's `secrets: []`
     // means this explicit grant is required.)
     agentInternalApiKeySecret.grantRead(this.routerLambdaRole);
+
+    // =====================================================================
+    // 9b. Agent Mint Lambda — confused-deputy isolation (#1232 hardening)
+    // =====================================================================
+    // SECURITY BOUNDARY: this Lambda is the ONLY AWS principal the Google
+    // Workload-Identity-Federation provider `mint-service` trusts. It houses
+    // BOTH WIF consumers — the DWD token broker (mintAgentWorkspaceToken) and
+    // the OneSync provisioning-sheet writer — so the Next.js frontend NO LONGER
+    // holds the WIF credential. A frontend RCE/SSRF can at most
+    // `lambda:InvokeFunction` this function, whose handler ALWAYS derives
+    // `agnt_<owner>` server-side (deriveAgentEmail) and can never
+    // `signJwt(sub=<arbitrary human>)`. Blast radius shrinks from "any
+    // psd401.net mailbox (incl. staff gmail/drive)" to "any agnt_ account".
+    //
+    // The role name is STABLE + DETERMINISTIC (`psd-agent-mint-execution-role-
+    // ${environment}` via ServiceRoleFactory) so its ARN is known pre-deploy and
+    // survives redeploys — IT (Reese) points the Google-side WIF provider
+    // condition + SA principalSet bindings at this exact ARN.
+    //
+    // Least privilege: the role gets ONLY Secrets Manager read on
+    // `psd-agent/${environment}/*` (the gcp-dwd-config secret) + CloudWatch Logs
+    // + VPC ENI (AWSLambdaVPCAccessExecutionRole). WIF itself needs NO extra AWS
+    // grant — it uses the role's ambient credentials via an implicit
+    // GetCallerIdentity that Google's STS verifies.
+    const mintSecretsArn = `arn:aws:secretsmanager:${this.region}:${this.account}:secret:psd-agent/${environment}/*`;
+    this.mintLambdaRole = ServiceRoleFactory.createLambdaRole(this, 'AgentMintLambdaRole', {
+      functionName: 'psd-agent-mint',
+      environment,
+      region: this.region,
+      account: this.account,
+      vpcEnabled: false,
+      // Grant the one secret read directly (exact scoped ARN) rather than via the
+      // factory `secrets` array, whose startsWith("arn:") token heuristic
+      // double-wraps constructed ARNs (same reason the router does this).
+      secrets: [],
+      additionalPolicies: [
+        new iam.PolicyDocument({
+          statements: [
+            new iam.PolicyStatement({
+              sid: 'ReadGcpDwdConfigSecret',
+              effect: iam.Effect.ALLOW,
+              actions: ['secretsmanager:GetSecretValue'],
+              resources: [mintSecretsArn],
+            }),
+          ],
+        }),
+      ],
+    });
+    // ENI operations (VPC) + CloudWatch Logs via the AWS managed policy — the
+    // same pattern the router uses (the ServiceRoleFactory policy validator
+    // rejects the ENI wildcard resources, so they come from the managed policy).
+    this.mintLambdaRole.addManagedPolicy(
+      iam.ManagedPolicy.fromAwsManagedPolicyName('service-role/AWSLambdaVPCAccessExecutionRole'),
+    );
+
+    const mintLogGroup = new logs.LogGroup(this, 'AgentMintLogGroup', {
+      logGroupName: `/aws/lambda/psd-agent-mint-${environment}`,
+      retention: config.monitoring.logRetention,
+      removalPolicy: environment === 'prod'
+        ? cdk.RemovalPolicy.RETAIN
+        : cdk.RemovalPolicy.DESTROY,
+    });
+    cdk.Tags.of(mintLogGroup).add('Environment', environment);
+    cdk.Tags.of(mintLogGroup).add('ManagedBy', 'cdk');
+
+    // The handler lives in the APP tree (lib/agent-workspace/mint-lambda-handler.ts)
+    // so it shares the exact broker/sheet modules + their unit tests. esbuild
+    // bundles it at synth: `@/*` resolved via the repo tsconfig, `@aws-sdk/*`
+    // left external (present in the Node 22 runtime), google-auth-library/winston
+    // bundled inline.
+    //
+    // assetHashType=SOURCE over `lib/agent-workspace` (repo convention — every
+    // other agent Lambda hashes its own source dir): any change to the broker,
+    // sheet writer, WIF, config, contract, or handler re-hashes and redeploys the
+    // function. (A change to `lib/logger` alone — the one dependency outside this
+    // dir — won't retrigger; it's stable and behaviourally inert here.) SOURCE
+    // also keeps the CDK assertion tests synthesizable with bundling disabled
+    // (`aws:cdk:bundling-stacks: []`) — the dir stages as-is without esbuild.
+    this.mintLambda = new lambda.Function(this, 'AgentMintLambda', {
+      functionName: `psd-agent-mint-${environment}`,
+      runtime: AGENT_LAMBDA_RUNTIME,
+      handler: 'index.handler',
+      role: this.mintLambdaRole,
+      code: lambda.Code.fromAsset(
+        path.join(__dirname, '..', '..', 'lib', 'agent-workspace'),
+        {
+          assetHashType: cdk.AssetHashType.SOURCE,
+          bundling: {
+            image: AGENT_LAMBDA_RUNTIME.bundlingImage,
+            local: {
+              tryBundle(outputDir: string): boolean {
+                try {
+                  const repoRoot = path.join(__dirname, '..', '..');
+                  const esbuildBin = path.join(repoRoot, 'node_modules', '.bin', 'esbuild');
+                  const entry = path.join(repoRoot, 'lib', 'agent-workspace', 'mint-lambda-handler.ts');
+                  const tsconfig = path.join(repoRoot, 'tsconfig.json');
+                  const outfile = path.join(outputDir, 'index.js');
+                  execSync(
+                    `'${esbuildBin}' '${entry}' --bundle --platform=node ` +
+                    `--target=node22 --format=cjs '--outfile=${outfile}' ` +
+                    `'--tsconfig=${tsconfig}' '--external:@aws-sdk/*' --log-level=warning`,
+                    { cwd: repoRoot, stdio: 'inherit' },
+                  );
+                  return true;
+                } catch (e) {
+                  // eslint-disable-next-line no-console
+                  console.error('psd-agent-mint esbuild bundling failed:', e);
+                  return false;
+                }
+              },
+            },
+            // The app handler + esbuild are NOT in this small asset dir, so the
+            // Docker fallback cannot produce a correct bundle. Fail LOUD rather
+            // than ship an empty asset — local esbuild bundling is the primary
+            // (and required) path, consistent with the other agent Lambdas.
+            command: [
+              'bash', '-c',
+              'echo "psd-agent-mint requires local esbuild bundling from the repo root." >&2; exit 1',
+            ],
+          },
+        },
+      ),
+      // Lightweight: a few sequential Google HTTPS calls (STS → impersonation →
+      // signJwt → token exchange) + google-auth-library crypto. 512 MB / 30 s is
+      // generous for that path.
+      memorySize: 512,
+      timeout: cdk.Duration.seconds(30),
+      architecture: lambda.Architecture.ARM_64,
+      logGroup: mintLogGroup,
+      tracing: config.monitoring.tracingEnabled
+        ? lambda.Tracing.ACTIVE
+        : lambda.Tracing.DISABLED,
+      environment: {
+        ENVIRONMENT: environment,
+        NODE_ENV: 'production',
+        // The broker + sheet writer read the consolidated GCP DWD config secret
+        // lazily (5-min cached) and fail CLOSED until IT populates it — same
+        // deploy-cleanly-before-values pattern as the ECS task.
+        GCP_DWD_CONFIG_SECRET_ID: `psd-agent/${environment}/gcp-dwd-config`,
+      },
+      vpc,
+      // Private-with-egress so the Lambda can reach Google's public endpoints
+      // (sts / iamcredentials / oauth2 / sheets.googleapis.com) via NAT and
+      // Secrets Manager via its VPC interface endpoint — matches the router.
+      vpcSubnets: { subnetType: ec2.SubnetType.PRIVATE_WITH_EGRESS },
+    });
+    cdk.Tags.of(this.mintLambda).add('Environment', environment);
+    cdk.Tags.of(this.mintLambda).add('ManagedBy', 'cdk');
 
     // -------------------------------------------------------------------------
     // Async job-runner (issue #1138 — "the 14-minute wall")

--- a/infra/lib/constructs/ecs-service.ts
+++ b/infra/lib/constructs/ecs-service.ts
@@ -443,6 +443,15 @@ export class EcsServiceConstruct extends Construct {
                 `arn:aws:lambda:${cdk.Stack.of(this).region}:${cdk.Stack.of(this).account}:function:psd-agent-skill-builder-${environment}`,
                 // #1203: admin "Sync now" async-invokes the hourly group-sync Lambda
                 `arn:aws:lambda:${cdk.Stack.of(this).region}:${cdk.Stack.of(this).account}:function:psd-group-sync-${environment}`,
+                // #1232 confused-deputy isolation: the /api/agent/workspace-token
+                // and /api/agent/account-request routes invoke the isolated mint
+                // Lambda instead of running WIF/signJwt in-process. INVOKE-ONLY —
+                // the frontend never holds the WIF credential; the mint Lambda's
+                // own role is the sole principal the Google WIF provider trusts.
+                // Constructed ARN (deterministic function name) to avoid a
+                // FrontendStack ↔ AgentPlatformStack circular dependency — the
+                // Lambda object is intentionally NOT imported cross-stack.
+                `arn:aws:lambda:${cdk.Stack.of(this).region}:${cdk.Stack.of(this).account}:function:psd-agent-mint-${environment}`,
               ],
             }),
             // Issue #925: write SKILL.md draft folders to the agent workspace
@@ -735,6 +744,14 @@ export class EcsServiceConstruct extends Construct {
         // above. The ECS task role already holds GetSecretValue on
         // psd-agent/${environment}/* (below), so no new IAM grant is required.
         GCP_DWD_CONFIG_SECRET_ID: `psd-agent/${environment}/gcp-dwd-config`,
+        // #1232 confused-deputy isolation: the DWD workspace-token + account-
+        // request routes proxy to this dedicated mint Lambda (IAM-authed
+        // InvokeFunction) instead of performing WIF/signJwt in-process. Setting
+        // this env var switches the routes into Lambda mode; when it is UNSET
+        // (local dev) they fall back to running the broker in-process (no real
+        // WIF locally). The task role's lambda:InvokeFunction grant above is
+        // scoped to exactly this function.
+        AGENT_MINT_LAMBDA_NAME: `psd-agent-mint-${environment}`,
         // Memory optimization - 70% of container memory
         NODE_OPTIONS: `--max-old-space-size=${Math.floor(memory * 0.7)}`,
         // Application configuration

--- a/infra/test/agent-mint-lambda.test.ts
+++ b/infra/test/agent-mint-lambda.test.ts
@@ -1,0 +1,172 @@
+/**
+ * CDK assertion test for the isolated mint Lambda (#1232 confused-deputy
+ * hardening).
+ *
+ * Asserts the security-critical infra invariants IT (Reese) and the blast-radius
+ * argument depend on:
+ *   1. a dedicated `psd-agent-mint-<env>` Lambda in the VPC (private-with-egress);
+ *   2. a STABLE, DETERMINISTIC role name (`psd-agent-mint-execution-role-<env>`)
+ *      — the ARN IT points the Google WIF provider + SA principalSet at;
+ *   3. that role grants ONLY `secretsmanager:GetSecretValue` on
+ *      `psd-agent/<env>/*` (least privilege — WIF itself needs no AWS grant), and
+ *      is the role the mint Lambda actually runs as.
+ *
+ * Synth harness mirrors agent-platform-mcp-key.test.ts: inject a remapped VPC
+ * context blob under the test account, force the AgentCore runtime via
+ * `agentImageTag`, and disable Lambda asset bundling so the test never runs
+ * esbuild / bun install.
+ */
+import * as fs from 'fs';
+import * as path from 'path';
+import * as cdk from 'aws-cdk-lib';
+import { Template } from 'aws-cdk-lib/assertions';
+import { AgentPlatformStack } from '../lib/agent-platform-stack';
+import { EnvironmentConfig } from '../lib/constructs';
+
+const TEST_ACCOUNT = '123456789012';
+const REGION = 'us-east-1';
+const ENV = 'dev';
+const MINT_FN = `psd-agent-mint-${ENV}`;
+const MINT_ROLE_NAME = `psd-agent-mint-execution-role-${ENV}`;
+
+const REAL_VPC_KEY =
+  'vpc-provider:account=390844780692:filter.tag:Name=aistudio-dev-vpc:region=us-east-1:returnAsymmetricSubnets=true';
+const TEST_VPC_KEY = `vpc-provider:account=${TEST_ACCOUNT}:filter.tag:Name=aistudio-${ENV}-vpc:region=${REGION}:returnAsymmetricSubnets=true`;
+
+function buildTemplate(): Template {
+  const cdkContext = JSON.parse(
+    fs.readFileSync(path.join(__dirname, '..', 'cdk.context.json'), 'utf8')
+  ) as Record<string, unknown>;
+
+  const vpcBlob = JSON.parse(JSON.stringify(cdkContext[REAL_VPC_KEY])) as {
+    subnetGroups: Array<{ subnets: Array<{ availabilityZone: string }> }>;
+  };
+  for (const group of vpcBlob.subnetGroups) {
+    for (const subnet of group.subnets) {
+      if (subnet.availabilityZone === 'us-east-1a') subnet.availabilityZone = 'us-east-1c';
+    }
+  }
+
+  const app = new cdk.App({
+    context: {
+      ...cdkContext,
+      [TEST_VPC_KEY]: vpcBlob,
+      'aws:cdk:bundling-stacks': [],
+      agentImageTag: 'test-image-tag',
+    },
+  });
+
+  const stack = new AgentPlatformStack(app, `AIStudio-AgentPlatformStack-${ENV}`, {
+    environment: ENV,
+    config: EnvironmentConfig.get(ENV),
+    databaseResourceArn: `arn:aws:rds:${REGION}:${TEST_ACCOUNT}:cluster:aistudio-${ENV}`,
+    databaseSecretArn: `arn:aws:secretsmanager:${REGION}:${TEST_ACCOUNT}:secret:aistudio-${ENV}-db-AbCdEf`,
+    databaseHost: `aistudio-${ENV}.cluster-abc.${REGION}.rds.amazonaws.com`,
+    databaseName: 'aistudio',
+    guardrailArn: `arn:aws:bedrock:${REGION}:${TEST_ACCOUNT}:guardrail/test`,
+    guardrailId: 'test-guardrail-id',
+    alertEmail: 'alerts@psd401.net',
+    appBaseUrl: `https://${ENV}.aistudio.psd401.ai`,
+    env: { account: TEST_ACCOUNT, region: REGION },
+  });
+
+  return Template.fromStack(stack);
+}
+
+interface Statement { Sid?: string; Effect?: string; Action?: unknown; Resource?: unknown }
+
+/** Collect every IAM statement attached to the role with the given RoleName. */
+function statementsForRole(template: Template, roleName: string): Statement[] {
+  const roles = template.findResources('AWS::IAM::Role');
+  const roleEntry = Object.entries(roles).find(
+    ([, r]) => (r as { Properties?: { RoleName?: string } }).Properties?.RoleName === roleName
+  );
+  expect(roleEntry).toBeDefined();
+  const [roleLogicalId, role] = roleEntry!;
+
+  const statements: Statement[] = [];
+  // Inline policies declared directly on the role.
+  const inline = (role as { Properties?: { Policies?: Array<{ PolicyDocument?: { Statement?: Statement[] } }> } })
+    .Properties?.Policies ?? [];
+  for (const p of inline) {
+    if (Array.isArray(p.PolicyDocument?.Statement)) statements.push(...p.PolicyDocument!.Statement!);
+  }
+  // Standalone AWS::IAM::Policy resources attached to this role.
+  for (const policy of Object.values(template.findResources('AWS::IAM::Policy'))) {
+    const props = (policy as { Properties?: { Roles?: unknown[]; PolicyDocument?: { Statement?: Statement[] } } }).Properties;
+    const rolesRefJson = JSON.stringify(props?.Roles ?? []);
+    if (rolesRefJson.includes(roleLogicalId) && Array.isArray(props?.PolicyDocument?.Statement)) {
+      statements.push(...props!.PolicyDocument!.Statement!);
+    }
+  }
+  return statements;
+}
+
+describe('AgentPlatformStack — isolated mint Lambda (#1232)', () => {
+  let template: Template;
+  beforeAll(() => {
+    template = buildTemplate();
+  });
+
+  it('creates the psd-agent-mint-<env> Lambda in the VPC with the DWD config secret id', () => {
+    template.hasResourceProperties('AWS::Lambda::Function', {
+      FunctionName: MINT_FN,
+      Environment: {
+        Variables: {
+          GCP_DWD_CONFIG_SECRET_ID: `psd-agent/${ENV}/gcp-dwd-config`,
+          ENVIRONMENT: ENV,
+        },
+      },
+    });
+    // Runs inside the VPC (private-with-egress) — VpcConfig present.
+    const fns = template.findResources('AWS::Lambda::Function');
+    const mint = Object.values(fns).find(
+      (f) => (f as { Properties?: { FunctionName?: string } }).Properties?.FunctionName === MINT_FN
+    ) as { Properties?: { VpcConfig?: unknown; Role?: unknown } } | undefined;
+    expect(mint?.Properties?.VpcConfig).toBeDefined();
+  });
+
+  it('pins a STABLE, deterministic mint role name (the ARN IT points WIF at)', () => {
+    template.hasResourceProperties('AWS::IAM::Role', {
+      RoleName: MINT_ROLE_NAME,
+    });
+  });
+
+  it('the mint Lambda runs AS the mint role (not a shared role)', () => {
+    const roles = template.findResources('AWS::IAM::Role');
+    const mintRoleId = Object.entries(roles).find(
+      ([, r]) => (r as { Properties?: { RoleName?: string } }).Properties?.RoleName === MINT_ROLE_NAME
+    )?.[0];
+    expect(mintRoleId).toBeDefined();
+
+    const fns = template.findResources('AWS::Lambda::Function');
+    const mint = Object.values(fns).find(
+      (f) => (f as { Properties?: { FunctionName?: string } }).Properties?.FunctionName === MINT_FN
+    ) as { Properties?: { Role?: unknown } } | undefined;
+    expect(JSON.stringify(mint?.Properties?.Role)).toContain(mintRoleId!);
+  });
+
+  it('the mint role grants ONLY GetSecretValue on psd-agent/<env>/* (least privilege)', () => {
+    const statements = statementsForRole(template, MINT_ROLE_NAME);
+
+    // The single data grant: read the gcp-dwd-config secret family.
+    const secretStmt = statements.find((s) => s.Sid === 'ReadGcpDwdConfigSecret');
+    expect(secretStmt).toBeDefined();
+    expect(secretStmt!.Effect).toBe('Allow');
+    const actions = Array.isArray(secretStmt!.Action) ? secretStmt!.Action : [secretStmt!.Action];
+    expect(actions).toEqual(['secretsmanager:GetSecretValue']);
+    expect(JSON.stringify(secretStmt!.Resource)).toContain(`secret:psd-agent/${ENV}/*`);
+
+    // WIF is keyless — the role must NOT carry any IAM-Credentials / signJwt /
+    // STS-impersonation grant, and must NOT be able to write secrets or invoke
+    // other Lambdas. Assert no statement grants such actions (beyond the factory
+    // base logging + x-ray, which are logs:/xray: only).
+    const allActions = statements
+      .flatMap((s) => (Array.isArray(s.Action) ? s.Action : [s.Action]))
+      .filter((a): a is string => typeof a === 'string');
+    const forbidden = allActions.filter((a) =>
+      /iam:|sts:|signjwt|secretsmanager:PutSecretValue|lambda:InvokeFunction|bedrock/i.test(a)
+    );
+    expect(forbidden).toEqual([]);
+  });
+});

--- a/infra/test/unit/ecs-service-mint-invoke.test.ts
+++ b/infra/test/unit/ecs-service-mint-invoke.test.ts
@@ -1,0 +1,122 @@
+/**
+ * CDK assertion test for the frontend ECS task role's mint-Lambda grant
+ * (#1232 confused-deputy hardening).
+ *
+ * The frontend must be able to INVOKE the isolated mint Lambda — and nothing
+ * more. It must NOT hold the WIF credential or any richer permission on that
+ * function. Asserts:
+ *   1. the task role grants lambda:InvokeFunction on the constructed
+ *      `psd-agent-mint-<env>` ARN (constructed string, NOT a cross-stack import,
+ *      so there is no FrontendStack ↔ AgentPlatformStack circular dependency);
+ *   2. that grant is INVOKE-ONLY (the statement carrying the mint ARN has exactly
+ *      the lambda:InvokeFunction action);
+ *   3. the container is told which function to call via AGENT_MINT_LAMBDA_NAME.
+ */
+import * as cdk from 'aws-cdk-lib';
+import * as ec2 from 'aws-cdk-lib/aws-ec2';
+import { Template } from 'aws-cdk-lib/assertions';
+import { EcsServiceConstruct } from '../../lib/constructs/ecs-service';
+
+const ENV = 'dev';
+const MINT_FN = `psd-agent-mint-${ENV}`;
+
+function synthTemplate(): Template {
+  const app = new cdk.App();
+  const stack = new cdk.Stack(app, 'TestStack', {
+    env: { account: '123456789012', region: 'us-east-1' },
+  });
+  const vpc = new ec2.Vpc(stack, 'TestVpc', { maxAzs: 2 });
+  const secretArn = (name: string) =>
+    `arn:aws:secretsmanager:us-east-1:123456789012:secret:aistudio-${ENV}-${name}-AbCdEf`;
+
+  new EcsServiceConstruct(stack, 'EcsService', {
+    vpc,
+    environment: ENV,
+    documentsBucketName: `aistudio-${ENV}-documents`,
+    agentWorkspaceBucketName: `aistudio-${ENV}-agent-workspace`,
+    atriumSandboxOrigin: 'https://sandbox.example.com',
+    dockerImageSource: 'fromEcrRepository',
+    authUrl: `https://${ENV}.aistudio.psd401.ai`,
+    cognitoClientId: 'test-client-id',
+    cognitoIssuer: 'https://cognito-idp.us-east-1.amazonaws.com/us-east-1_testpool',
+    rdsResourceArn: 'arn:aws:rds:us-east-1:123456789012:cluster:aistudio-dev-cluster',
+    rdsSecretArn: secretArn('db'),
+    authSecretArn: secretArn('auth'),
+    internalApiSecretArn: secretArn('internal-api'),
+    collabJwtSecretArn: secretArn('collab-jwt'),
+    guardrailHashSecretArn: secretArn('guardrail-hash'),
+  });
+
+  return Template.fromStack(stack);
+}
+
+interface Statement { Effect?: string; Action?: unknown; Resource?: unknown }
+
+function allStatements(template: Template): Statement[] {
+  const statements: Statement[] = [];
+  // Standalone AWS::IAM::Policy resources.
+  for (const policy of Object.values(template.findResources('AWS::IAM::Policy'))) {
+    const doc = (policy as { Properties?: { PolicyDocument?: { Statement?: Statement[] } } })
+      .Properties?.PolicyDocument?.Statement;
+    if (Array.isArray(doc)) statements.push(...doc);
+  }
+  // Inline policies declared on roles (the task role's InvokeFunction grant lives
+  // here, inside the RDSDataAPIAccess inline document).
+  for (const role of Object.values(template.findResources('AWS::IAM::Role'))) {
+    const inline = (role as { Properties?: { Policies?: Array<{ PolicyDocument?: { Statement?: Statement[] } }> } })
+      .Properties?.Policies ?? [];
+    for (const p of inline) {
+      if (Array.isArray(p.PolicyDocument?.Statement)) statements.push(...p.PolicyDocument!.Statement!);
+    }
+  }
+  return statements;
+}
+
+describe('ECS task role — mint Lambda invoke-only grant (#1232)', () => {
+  let template: Template;
+  beforeAll(() => {
+    template = synthTemplate();
+  });
+
+  it('grants lambda:InvokeFunction on the constructed psd-agent-mint-<env> ARN', () => {
+    const statements = allStatements(template);
+    const mintStmt = statements.find(
+      (s) => JSON.stringify(s.Resource ?? '').includes(`function:${MINT_FN}`)
+    );
+    expect(mintStmt).toBeDefined();
+    expect(mintStmt!.Effect).toBe('Allow');
+  });
+
+  it('is INVOKE-ONLY — the statement carrying the mint ARN grants exactly lambda:InvokeFunction', () => {
+    const statements = allStatements(template);
+    const mintStmt = statements.find(
+      (s) => JSON.stringify(s.Resource ?? '').includes(`function:${MINT_FN}`)
+    );
+    expect(mintStmt).toBeDefined();
+    const actions = Array.isArray(mintStmt!.Action) ? mintStmt!.Action : [mintStmt!.Action];
+    expect(actions).toEqual(['lambda:InvokeFunction']);
+  });
+
+  it('the grant is a constructed ARN string, not a cross-stack Fn::ImportValue', () => {
+    const statements = allStatements(template);
+    const mintStmt = statements.find(
+      (s) => JSON.stringify(s.Resource ?? '').includes(`function:${MINT_FN}`)
+    )!;
+    // A constructed ARN resolves via Fn::Join over the region/account; a
+    // cross-stack import would surface as Fn::ImportValue (the circular-dep trap).
+    expect(JSON.stringify(mintStmt.Resource)).not.toContain('Fn::ImportValue');
+  });
+
+  it('sets AGENT_MINT_LAMBDA_NAME on the frontend container', () => {
+    const taskDefs = template.findResources('AWS::ECS::TaskDefinition');
+    const envPairs: Array<{ Name?: string; Value?: unknown }> = [];
+    for (const td of Object.values(taskDefs)) {
+      const containers = (td as { Properties?: { ContainerDefinitions?: Array<{ Environment?: Array<{ Name?: string; Value?: unknown }> }> } })
+        .Properties?.ContainerDefinitions ?? [];
+      for (const c of containers) if (Array.isArray(c.Environment)) envPairs.push(...c.Environment);
+    }
+    const mintEnv = envPairs.find((e) => e.Name === 'AGENT_MINT_LAMBDA_NAME');
+    expect(mintEnv).toBeDefined();
+    expect(mintEnv!.Value).toBe(MINT_FN);
+  });
+});

--- a/lib/agent-workspace/gcp-wif.ts
+++ b/lib/agent-workspace/gcp-wif.ts
@@ -48,13 +48,19 @@ export async function getImpersonatedAccessToken(
       subject_token_type: "urn:ietf:params:aws:token-type:aws4_request",
       token_url: "https://sts.googleapis.com/v1/token",
       // AWS credential source. google-auth-library's AwsClient resolves the
-      // app's AWS role credentials from the standard AWS credential chain (on
-      // ECS Fargate this is AWS_CONTAINER_CREDENTIALS_RELATIVE_URI). The regional
-      // GetCallerIdentity URL is required; {region} is filled from AWS_REGION.
-      // NOTE: verify this credential_source against the real WIF trust once IT
-      // (Reese) delivers the pool/provider — ECS container creds vs IMDS is the
-      // one thing that can differ from this default and cannot be validated
-      // until the Google side exists.
+      // ambient AWS role credentials from the standard AWS credential chain. As
+      // of #1232 this code runs in the isolated mint Lambda (psd-agent-mint-{env}),
+      // where those creds come from the Lambda container-credentials endpoint
+      // (AWS_CONTAINER_CREDENTIALS_FULL_URI) — the same keyless resolution that
+      // worked for the ECS task role (AWS_CONTAINER_CREDENTIALS_RELATIVE_URI); no
+      // service-account key is downloaded. The regional GetCallerIdentity URL is
+      // required; {region} is filled from AWS_REGION (set by the Lambda runtime).
+      // NOTE: the Google-side WIF provider condition + SA principalSet must trust
+      // the MINT LAMBDA's role assumed-role ARN
+      // (arn:aws:sts::<account>:assumed-role/psd-agent-mint-execution-role-{env}/*),
+      // NOT the frontend ECS task role — see docs/features/agent-workspace-
+      // integration.md (Reese coordination). Verify container-creds vs IMDS
+      // against the real trust once IT delivers the pool/provider.
       credential_source: {
         environment_id: "aws1",
         regional_cred_verification_url:

--- a/lib/agent-workspace/mint-client.ts
+++ b/lib/agent-workspace/mint-client.ts
@@ -1,0 +1,142 @@
+/**
+ * Frontend → mint Lambda invoker (#1232 confused-deputy hardening).
+ *
+ * The `/api/agent/workspace-token` and `/api/agent/account-request` routes call
+ * these helpers instead of the DWD broker / provisioning-sheet directly. In
+ * EVERY deployed environment `AGENT_MINT_LAMBDA_NAME` is set, so the WIF-backed
+ * work runs in the isolated `psd-agent-mint-{env}` Lambda (IAM-authed
+ * InvokeFunction) — the frontend never touches the WIF credential and cannot
+ * `signJwt` an arbitrary sub.
+ *
+ * LOCAL-DEV / TEST FALLBACK: when `AGENT_MINT_LAMBDA_NAME` is UNSET (local dev,
+ * unit tests) the helpers run the shared broker/sheet modules IN-PROCESS exactly
+ * as the routes did before this change. There is no real WIF locally, so no
+ * isolation is lost — and the isolation holds in every deployed env, where the
+ * env var is always set. The typed error classes thrown here are the SAME broker
+ * classes the routes already `instanceof`-match, so the routes' error → HTTP
+ * mapping is byte-identical in both modes.
+ */
+
+import {
+  mintAgentWorkspaceToken,
+  AccountNotProvisionedError,
+  BrokerNotConfiguredError,
+  InvalidOwnerError,
+  type MintedToken,
+} from "@/lib/agent-workspace/dwd-token-broker"
+import {
+  createSheetsGateway,
+  ensureAgentUsernameRow,
+  ProvisioningNotConfiguredError,
+} from "@/lib/agent-workspace/agent-provisioning-sheet"
+import {
+  isMintTokenSuccess,
+  isMintTokenNotProvisioned,
+  isProvisionSuccess,
+  isMintError,
+  type MintLambdaRequest,
+  type MintTokenResponse,
+  type ProvisionAccountResponse,
+  type MintErrorResponse,
+} from "@/lib/agent-workspace/mint-contract"
+
+/** The mint Lambda function name, or undefined when running in-process (local dev/tests). */
+export function getMintLambdaName(): string | undefined {
+  const name = process.env.AGENT_MINT_LAMBDA_NAME?.trim()
+  return name ? name : undefined
+}
+
+// Cache the Lambda client across invocations (module singleton), mirroring the
+// secrets-manager client caching. Imported lazily so the AWS SDK never loads in
+// the in-process path (local dev / tests that never set AGENT_MINT_LAMBDA_NAME).
+let _lambdaClient: InstanceType<typeof import("@aws-sdk/client-lambda").LambdaClient> | null = null
+
+async function invokeMintLambda(functionName: string, payload: MintLambdaRequest): Promise<unknown> {
+  const { LambdaClient, InvokeCommand } = await import("@aws-sdk/client-lambda")
+  if (!_lambdaClient) _lambdaClient = new LambdaClient({})
+  const res = await _lambdaClient.send(
+    new InvokeCommand({
+      FunctionName: functionName,
+      InvocationType: "RequestResponse",
+      Payload: Buffer.from(JSON.stringify(payload)),
+    })
+  )
+  // An unhandled Lambda exception surfaces as FunctionError (infra failure) — the
+  // handler is designed never to throw, so this means the Lambda itself broke.
+  if (res.FunctionError) {
+    const detail = res.Payload ? Buffer.from(res.Payload).toString("utf8").slice(0, 300) : ""
+    throw new Error(`mint lambda FunctionError (${res.FunctionError}): ${detail}`)
+  }
+  const text = res.Payload ? Buffer.from(res.Payload).toString("utf8") : ""
+  if (!text) throw new Error("mint lambda returned an empty payload")
+  return JSON.parse(text) as unknown
+}
+
+/**
+ * Reconstruct the broker's typed Error from the boundary's structured code, so
+ * the routes' existing `instanceof` mapping produces identical HTTP responses.
+ */
+function reconstructError(res: MintErrorResponse): Error {
+  const msg = res.error || "mint boundary error"
+  switch (res.code) {
+    case "INVALID_OWNER":
+      return new InvalidOwnerError(msg)
+    case "BROKER_NOT_CONFIGURED":
+      return new BrokerNotConfiguredError(msg)
+    case "PROVISIONING_NOT_CONFIGURED":
+      return new ProvisioningNotConfiguredError(msg)
+    default:
+      return new Error(msg)
+  }
+}
+
+/**
+ * Mint a ~1h DWD token for the owner's `agnt_` account through the isolation
+ * boundary. Throws the SAME typed errors as the in-process broker
+ * (AccountNotProvisionedError / InvalidOwnerError / BrokerNotConfiguredError /
+ * generic Error) so callers are agnostic to which mode ran.
+ */
+export async function mintAgentWorkspaceTokenViaBoundary(ownerEmail: string): Promise<MintedToken> {
+  const functionName = getMintLambdaName()
+  if (!functionName) {
+    // In-process fallback — the shared broker derives agnt_ and performs WIF.
+    return mintAgentWorkspaceToken(ownerEmail)
+  }
+  const res = (await invokeMintLambda(functionName, { op: "mint-token", ownerEmail })) as MintTokenResponse
+  if (isMintTokenSuccess(res)) {
+    return { accessToken: res.accessToken, expiresAt: res.expiresAt, agentEmail: res.agentEmail }
+  }
+  if (isMintTokenNotProvisioned(res)) {
+    throw new AccountNotProvisionedError(res.agentEmail ?? "")
+  }
+  if (isMintError(res)) {
+    throw reconstructError(res)
+  }
+  throw new Error("mint lambda returned an unrecognized mint-token response")
+}
+
+/**
+ * Queue the owner's bare username in the OneSync provisioning sheet through the
+ * isolation boundary. Throws the SAME typed errors as the in-process sheet
+ * writer (ProvisioningNotConfiguredError / BrokerNotConfiguredError / generic).
+ */
+export async function provisionAgentAccountViaBoundary(username: string): Promise<{ written: boolean }> {
+  const functionName = getMintLambdaName()
+  if (!functionName) {
+    // In-process fallback — the shared sheet writer performs WIF (spreadsheets scope).
+    return ensureAgentUsernameRow(username, createSheetsGateway())
+  }
+  const res = (await invokeMintLambda(functionName, { op: "provision-account", username })) as ProvisionAccountResponse
+  if (isProvisionSuccess(res)) {
+    return { written: res.written }
+  }
+  if (isMintError(res)) {
+    throw reconstructError(res)
+  }
+  throw new Error("mint lambda returned an unrecognized provision-account response")
+}
+
+/** Test-only: reset the cached Lambda client between tests. */
+export function __resetMintClientForTests(): void {
+  _lambdaClient = null
+}

--- a/lib/agent-workspace/mint-client.ts
+++ b/lib/agent-workspace/mint-client.ts
@@ -69,7 +69,14 @@ async function invokeMintLambda(functionName: string, payload: MintLambdaRequest
   }
   const text = res.Payload ? Buffer.from(res.Payload).toString("utf8") : ""
   if (!text) throw new Error("mint lambda returned an empty payload")
-  return JSON.parse(text) as unknown
+  // Guard the parsed value: JSON.parse("null") / a bare scalar would otherwise
+  // reach the isMint* narrowing helpers, which access properties and would throw
+  // an opaque TypeError instead of a clear boundary error (gemini review).
+  const parsed: unknown = JSON.parse(text)
+  if (!parsed || typeof parsed !== "object") {
+    throw new Error("mint lambda returned a non-object JSON payload")
+  }
+  return parsed
 }
 
 /**

--- a/lib/agent-workspace/mint-contract.ts
+++ b/lib/agent-workspace/mint-contract.ts
@@ -1,0 +1,75 @@
+/**
+ * Internal contract between the frontend `/api/agent/*` routes and the isolated
+ * mint Lambda (`psd-agent-mint-{env}`) — confused-deputy isolation for the GCP
+ * Workload-Identity-Federation (WIF) credential (#1232 hardening).
+ *
+ * WHY THIS BOUNDARY EXISTS: the WIF provider trusts an AWS role, and whoever
+ * holds that role's ambient credentials can impersonate the DWD service account
+ * and `signJwt(sub=<any user>)` — i.e. mint a Google token for ANY psd401.net
+ * mailbox (gmail.modify + drive included). Running the broker in the Next.js
+ * frontend meant a frontend RCE/SSRF reaching the task-role creds could do
+ * exactly that. Moving both WIF consumers into a dedicated Lambda with its OWN
+ * role — the SOLE principal the WIF provider trusts — shrinks the blast radius
+ * of a frontend compromise from "any mailbox" to "InvokeFunction the mint
+ * Lambda", which ALWAYS derives `agnt_<owner>` server-side and can never target
+ * an arbitrary sub. The frontend passes only `ownerEmail` / `username` across
+ * this boundary — never a target agent address.
+ *
+ * These are plain data types (no runtime deps) so BOTH the Lambda handler and
+ * the frontend invoker can import them without dragging WIF code into the app
+ * bundle.
+ */
+
+/** Ops the mint Lambda accepts. */
+export interface MintTokenRequest {
+  op: "mint-token"
+  /** The signed-in owner's email; the Lambda derives `agnt_<localpart>` itself. */
+  ownerEmail: string
+}
+export interface ProvisionAccountRequest {
+  op: "provision-account"
+  /** The owner's bare username (localpart) to queue in the OneSync sheet. */
+  username: string
+}
+export type MintLambdaRequest = MintTokenRequest | ProvisionAccountRequest
+
+/**
+ * Structured error codes carried across the Lambda boundary. Typed Error
+ * classes don't survive JSON serialization, so the Lambda returns a `code` and
+ * the invoker reconstructs the matching broker error class — keeping the routes'
+ * existing `instanceof` → HTTP mapping byte-identical in both Lambda and
+ * in-process (local-dev) modes.
+ */
+export type MintErrorCode =
+  | "INVALID_OWNER"
+  | "BROKER_NOT_CONFIGURED"
+  | "PROVISIONING_NOT_CONFIGURED"
+  | "INTERNAL"
+
+export interface MintErrorResponse {
+  error: string
+  code: MintErrorCode
+}
+
+/** mint-token success | not-provisioned | structured error. */
+export type MintTokenSuccess = { accessToken: string; expiresAt: string; agentEmail: string }
+export type MintTokenNotProvisioned = { status: "account-not-provisioned"; agentEmail?: string }
+export type MintTokenResponse = MintTokenSuccess | MintTokenNotProvisioned | MintErrorResponse
+
+/** provision-account success | structured error. */
+export type ProvisionAccountSuccess = { written: boolean }
+export type ProvisionAccountResponse = ProvisionAccountSuccess | MintErrorResponse
+
+/** Narrowing helpers (shared by handler + invoker so the shape checks match). */
+export function isMintTokenSuccess(r: MintTokenResponse): r is MintTokenSuccess {
+  return typeof (r as MintTokenSuccess).accessToken === "string"
+}
+export function isMintTokenNotProvisioned(r: MintTokenResponse): r is MintTokenNotProvisioned {
+  return (r as MintTokenNotProvisioned).status === "account-not-provisioned"
+}
+export function isProvisionSuccess(r: ProvisionAccountResponse): r is ProvisionAccountSuccess {
+  return typeof (r as ProvisionAccountSuccess).written === "boolean"
+}
+export function isMintError(r: MintTokenResponse | ProvisionAccountResponse): r is MintErrorResponse {
+  return typeof (r as MintErrorResponse).code === "string" && typeof (r as MintErrorResponse).error === "string"
+}

--- a/lib/agent-workspace/mint-lambda-handler.ts
+++ b/lib/agent-workspace/mint-lambda-handler.ts
@@ -1,0 +1,118 @@
+/**
+ * Isolated mint Lambda handler (#1232 confused-deputy hardening).
+ *
+ * This handler is the SOLE principal that performs GCP Workload-Identity-
+ * Federation (WIF) + service-account impersonation for the agent workspace
+ * integration. It runs in the dedicated `psd-agent-mint-{env}` Lambda under its
+ * OWN least-privilege role — the ONLY AWS identity the Google WIF provider
+ * trusts. The Next.js frontend NO LONGER holds that trust; it can only
+ * `lambda:InvokeFunction` this handler.
+ *
+ * BLAST-RADIUS INVARIANT (the whole point of this file): every WIF-backed
+ * operation here derives the target account as `agnt_<owner-localpart>@domain`
+ * SERVER-SIDE (deriveAgentEmail, inside mintAgentWorkspaceToken) or appends the
+ * caller's OWN bare username to the OneSync sheet. There is deliberately NO code
+ * path that accepts a caller-supplied target `sub`. So even a fully-compromised
+ * frontend that can invoke this Lambda at will can only ever obtain a token for
+ * an `agnt_` account (agent-generated content) — never a human's mailbox, never
+ * an arbitrary `signJwt(sub=...)`. That is the intended codex-P1 residual, and
+ * this boundary is what enforces it in infrastructure rather than app code the
+ * attacker could bypass.
+ *
+ * The handler NEVER throws for an expected outcome — it returns a structured
+ * result the frontend invoker maps back to the same HTTP responses the routes
+ * produced when the broker ran in-process.
+ */
+
+import { createLogger, sanitizeForLogging } from "@/lib/logger"
+import {
+  mintAgentWorkspaceToken,
+  AccountNotProvisionedError,
+  BrokerNotConfiguredError,
+  InvalidOwnerError,
+} from "@/lib/agent-workspace/dwd-token-broker"
+import {
+  createSheetsGateway,
+  ensureAgentUsernameRow,
+  ProvisioningNotConfiguredError,
+} from "@/lib/agent-workspace/agent-provisioning-sheet"
+import type {
+  MintLambdaRequest,
+  MintTokenResponse,
+  ProvisionAccountResponse,
+  MintErrorResponse,
+} from "@/lib/agent-workspace/mint-contract"
+
+const log = createLogger({ module: "agent-mint-lambda" })
+
+/** Common error → structured-response mapper (shared by both ops). */
+function toErrorResponse(err: unknown): MintErrorResponse {
+  if (err instanceof InvalidOwnerError) return { error: err.message, code: "INVALID_OWNER" }
+  if (err instanceof BrokerNotConfiguredError) return { error: err.message, code: "BROKER_NOT_CONFIGURED" }
+  if (err instanceof ProvisioningNotConfiguredError) return { error: err.message, code: "PROVISIONING_NOT_CONFIGURED" }
+  return { error: err instanceof Error ? err.message : String(err), code: "INTERNAL" }
+}
+
+/**
+ * mint-token: derive `agnt_<owner>` (INSIDE mintAgentWorkspaceToken) and mint a
+ * ~1h DWD token for it. AccountNotProvisionedError is an EXPECTED outcome, not an
+ * error — it is returned as a distinct status the account-request flow probes on.
+ */
+async function handleMintToken(ownerEmail: unknown): Promise<MintTokenResponse> {
+  if (typeof ownerEmail !== "string" || ownerEmail.length === 0) {
+    return { error: "ownerEmail is required", code: "INVALID_OWNER" }
+  }
+  try {
+    const minted = await mintAgentWorkspaceToken(ownerEmail)
+    return { accessToken: minted.accessToken, expiresAt: minted.expiresAt, agentEmail: minted.agentEmail }
+  } catch (err) {
+    if (err instanceof AccountNotProvisionedError) {
+      return { status: "account-not-provisioned", agentEmail: err.agentEmail }
+    }
+    return toErrorResponse(err)
+  }
+}
+
+/**
+ * provision-account: append the caller's OWN bare username to the OneSync sheet
+ * (idempotent). No agnt_ derivation needed — the sheet stores the plain username
+ * and OneSync creates `agnt_<username>` on its next run.
+ */
+async function handleProvisionAccount(username: unknown): Promise<ProvisionAccountResponse> {
+  if (typeof username !== "string" || username.length === 0) {
+    return { error: "username is required", code: "INTERNAL" }
+  }
+  try {
+    const { written } = await ensureAgentUsernameRow(username, createSheetsGateway())
+    return { written }
+  } catch (err) {
+    return toErrorResponse(err)
+  }
+}
+
+/**
+ * Pure dispatch — exported for direct unit testing (no AWS Lambda envelope).
+ * Returns a structured result for every op; an unknown op is an INTERNAL error.
+ */
+export async function handleMintEvent(
+  event: MintLambdaRequest
+): Promise<MintTokenResponse | ProvisionAccountResponse> {
+  const op = (event as { op?: unknown } | null | undefined)?.op
+  switch (op) {
+    case "mint-token":
+      return handleMintToken((event as { ownerEmail?: unknown }).ownerEmail)
+    case "provision-account":
+      return handleProvisionAccount((event as { username?: unknown }).username)
+    default:
+      return { error: `Unknown mint op: ${String(op)}`, code: "INTERNAL" }
+  }
+}
+
+/** AWS Lambda entrypoint (bundled to index.handler). */
+export async function handler(
+  event: MintLambdaRequest
+): Promise<MintTokenResponse | ProvisionAccountResponse> {
+  const op = (event as { op?: unknown } | null | undefined)?.op
+  log.info("mint lambda invoked", sanitizeForLogging({ op }))
+  return handleMintEvent(event)
+}

--- a/tests/unit/agent-mint-client.test.ts
+++ b/tests/unit/agent-mint-client.test.ts
@@ -1,0 +1,174 @@
+/**
+ * Frontend → mint Lambda invoker (#1232 confused-deputy hardening).
+ *
+ * Asserts the two modes of the boundary:
+ *   - Lambda mode (AGENT_MINT_LAMBDA_NAME set — every deployed env): the helper
+ *     invokes the mint Lambda via an IAM-authed InvokeCommand, translates the
+ *     structured result back into the SAME typed errors the routes map, and
+ *     — the security-critical property — NEVER runs the WIF broker/sheet
+ *     in-process.
+ *   - In-process fallback (env unset — local dev/tests): the helper calls the
+ *     shared broker/sheet directly and never touches the Lambda SDK.
+ */
+
+const mintMock = jest.fn()
+jest.mock("@/lib/agent-workspace/dwd-token-broker", () => {
+  class AccountNotProvisionedError extends Error {
+    agentEmail: string
+    constructor(agentEmail: string) {
+      super(`Agent account ${agentEmail} is not provisioned yet`)
+      this.name = "AccountNotProvisionedError"
+      this.agentEmail = agentEmail
+    }
+  }
+  class BrokerNotConfiguredError extends Error {}
+  class InvalidOwnerError extends Error {}
+  return {
+    mintAgentWorkspaceToken: (...a: unknown[]) => mintMock(...a),
+    AccountNotProvisionedError,
+    BrokerNotConfiguredError,
+    InvalidOwnerError,
+  }
+})
+
+const ensureRowMock = jest.fn()
+const createGatewayMock = jest.fn(() => ({ gateway: true }))
+jest.mock("@/lib/agent-workspace/agent-provisioning-sheet", () => {
+  class ProvisioningNotConfiguredError extends Error {}
+  return {
+    ensureAgentUsernameRow: (...a: unknown[]) => ensureRowMock(...a),
+    createSheetsGateway: (...a: unknown[]) => createGatewayMock(...a),
+    ProvisioningNotConfiguredError,
+  }
+})
+
+const sendMock = jest.fn()
+const invokeCommandMock = jest.fn((input: unknown) => ({ input }))
+const lambdaClientCtor = jest.fn(() => ({ send: sendMock }))
+jest.mock("@aws-sdk/client-lambda", () => ({
+  LambdaClient: lambdaClientCtor,
+  InvokeCommand: invokeCommandMock,
+}))
+
+import {
+  mintAgentWorkspaceTokenViaBoundary,
+  provisionAgentAccountViaBoundary,
+  __resetMintClientForTests,
+} from "@/lib/agent-workspace/mint-client"
+import {
+  AccountNotProvisionedError,
+  BrokerNotConfiguredError,
+  InvalidOwnerError,
+} from "@/lib/agent-workspace/dwd-token-broker"
+import { ProvisioningNotConfiguredError } from "@/lib/agent-workspace/agent-provisioning-sheet"
+
+/** Decode the InvokeCommand payload the client sent (Buffer → parsed JSON). */
+function sentPayload(callIndex = 0): { FunctionName: string; InvocationType: string; op: string; [k: string]: unknown } {
+  const input = invokeCommandMock.mock.calls[callIndex][0] as {
+    FunctionName: string
+    InvocationType: string
+    Payload: Uint8Array
+  }
+  const parsed = JSON.parse(Buffer.from(input.Payload).toString("utf8")) as Record<string, unknown>
+  return { FunctionName: input.FunctionName, InvocationType: input.InvocationType, ...parsed } as never
+}
+
+function lambdaReplies(response: unknown): void {
+  sendMock.mockResolvedValue({ Payload: Buffer.from(JSON.stringify(response)) })
+}
+
+const ORIGINAL_ENV = process.env.AGENT_MINT_LAMBDA_NAME
+
+beforeEach(() => {
+  mintMock.mockReset()
+  ensureRowMock.mockReset()
+  createGatewayMock.mockClear()
+  sendMock.mockReset()
+  invokeCommandMock.mockClear()
+  lambdaClientCtor.mockClear()
+  __resetMintClientForTests()
+})
+afterAll(() => {
+  if (ORIGINAL_ENV === undefined) delete process.env.AGENT_MINT_LAMBDA_NAME
+  else process.env.AGENT_MINT_LAMBDA_NAME = ORIGINAL_ENV
+})
+
+describe("mint-client — Lambda mode (AGENT_MINT_LAMBDA_NAME set)", () => {
+  beforeEach(() => {
+    process.env.AGENT_MINT_LAMBDA_NAME = "psd-agent-mint-dev"
+  })
+
+  it("invokes the mint Lambda for a token and NEVER runs WIF in-process", async () => {
+    lambdaReplies({ accessToken: "ya29.at", expiresAt: "2026-07-15T01:00:00Z", agentEmail: "agnt_hagelk@psd401.net" })
+    const minted = await mintAgentWorkspaceTokenViaBoundary("hagelk@psd401.net")
+    expect(minted).toEqual({ accessToken: "ya29.at", expiresAt: "2026-07-15T01:00:00Z", agentEmail: "agnt_hagelk@psd401.net" })
+    // The isolated Lambda was invoked with the right FunctionName + RequestResponse.
+    const p = sentPayload()
+    expect(p.FunctionName).toBe("psd-agent-mint-dev")
+    expect(p.InvocationType).toBe("RequestResponse")
+    expect(p.op).toBe("mint-token")
+    expect(p.ownerEmail).toBe("hagelk@psd401.net")
+    // CRITICAL: the in-process broker (WIF/signJwt) did NOT run.
+    expect(mintMock).not.toHaveBeenCalled()
+  })
+
+  it("reconstructs AccountNotProvisionedError from a not-provisioned reply", async () => {
+    lambdaReplies({ status: "account-not-provisioned", agentEmail: "agnt_new@psd401.net" })
+    await expect(mintAgentWorkspaceTokenViaBoundary("new@psd401.net")).rejects.toBeInstanceOf(AccountNotProvisionedError)
+    expect(mintMock).not.toHaveBeenCalled()
+  })
+
+  it("reconstructs InvalidOwnerError from an INVALID_OWNER reply", async () => {
+    lambdaReplies({ error: "ownerEmail domain must be psd401.net", code: "INVALID_OWNER" })
+    await expect(mintAgentWorkspaceTokenViaBoundary("x@gmail.com")).rejects.toBeInstanceOf(InvalidOwnerError)
+  })
+
+  it("reconstructs BrokerNotConfiguredError from a BROKER_NOT_CONFIGURED reply", async () => {
+    lambdaReplies({ error: "missing GCP config", code: "BROKER_NOT_CONFIGURED" })
+    await expect(mintAgentWorkspaceTokenViaBoundary("hagelk@psd401.net")).rejects.toBeInstanceOf(BrokerNotConfiguredError)
+  })
+
+  it("throws a generic Error when the Lambda itself failed (FunctionError)", async () => {
+    sendMock.mockResolvedValue({ FunctionError: "Unhandled", Payload: Buffer.from('{"errorMessage":"boom"}') })
+    await expect(mintAgentWorkspaceTokenViaBoundary("hagelk@psd401.net")).rejects.toThrow(/FunctionError/)
+  })
+
+  it("invokes the mint Lambda for provisioning and NEVER writes the sheet in-process", async () => {
+    lambdaReplies({ written: true })
+    const r = await provisionAgentAccountViaBoundary("pratzm")
+    expect(r).toEqual({ written: true })
+    const p = sentPayload()
+    expect(p.op).toBe("provision-account")
+    expect(p.username).toBe("pratzm")
+    expect(ensureRowMock).not.toHaveBeenCalled()
+    expect(createGatewayMock).not.toHaveBeenCalled()
+  })
+
+  it("reconstructs ProvisioningNotConfiguredError from a provision error reply", async () => {
+    lambdaReplies({ error: "no sheet id", code: "PROVISIONING_NOT_CONFIGURED" })
+    await expect(provisionAgentAccountViaBoundary("pratzm")).rejects.toBeInstanceOf(ProvisioningNotConfiguredError)
+  })
+})
+
+describe("mint-client — in-process fallback (env unset)", () => {
+  beforeEach(() => {
+    delete process.env.AGENT_MINT_LAMBDA_NAME
+  })
+
+  it("runs the broker in-process and never touches the Lambda SDK", async () => {
+    mintMock.mockResolvedValue({ accessToken: "t", expiresAt: "x", agentEmail: "agnt_hagelk@psd401.net" })
+    const minted = await mintAgentWorkspaceTokenViaBoundary("hagelk@psd401.net")
+    expect(minted).toEqual({ accessToken: "t", expiresAt: "x", agentEmail: "agnt_hagelk@psd401.net" })
+    expect(mintMock).toHaveBeenCalledWith("hagelk@psd401.net")
+    expect(invokeCommandMock).not.toHaveBeenCalled()
+    expect(lambdaClientCtor).not.toHaveBeenCalled()
+  })
+
+  it("runs the sheet writer in-process and never touches the Lambda SDK", async () => {
+    ensureRowMock.mockResolvedValue({ written: false })
+    const r = await provisionAgentAccountViaBoundary("pratzm")
+    expect(r).toEqual({ written: false })
+    expect(ensureRowMock).toHaveBeenCalledWith("pratzm", { gateway: true })
+    expect(invokeCommandMock).not.toHaveBeenCalled()
+  })
+})

--- a/tests/unit/agent-mint-client.test.ts
+++ b/tests/unit/agent-mint-client.test.ts
@@ -32,7 +32,7 @@ jest.mock("@/lib/agent-workspace/dwd-token-broker", () => {
 })
 
 const ensureRowMock = jest.fn()
-const createGatewayMock = jest.fn(() => ({ gateway: true }))
+const createGatewayMock = jest.fn((..._a: unknown[]) => ({ gateway: true }))
 jest.mock("@/lib/agent-workspace/agent-provisioning-sheet", () => {
   class ProvisioningNotConfiguredError extends Error {}
   return {

--- a/tests/unit/agent-mint-lambda-handler.test.ts
+++ b/tests/unit/agent-mint-lambda-handler.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Isolated mint Lambda handler (#1232 confused-deputy hardening).
+ *
+ * Asserts op routing, typed-error → structured-code mapping, the not-provisioned
+ * distinct outcome, and — the security-critical property — that the handler
+ * forwards ONLY the caller's ownerEmail to the broker (the agnt_ derivation runs
+ * INSIDE mintAgentWorkspaceToken), never a caller-injected target sub/agentEmail.
+ */
+
+jest.mock("@/lib/logger", () => ({
+  createLogger: () => ({ info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() }),
+  sanitizeForLogging: (x: unknown) => x,
+}))
+
+const mintMock = jest.fn()
+jest.mock("@/lib/agent-workspace/dwd-token-broker", () => {
+  class AccountNotProvisionedError extends Error {
+    agentEmail: string
+    constructor(agentEmail: string) {
+      super(`Agent account ${agentEmail} is not provisioned yet`)
+      this.name = "AccountNotProvisionedError"
+      this.agentEmail = agentEmail
+    }
+  }
+  class BrokerNotConfiguredError extends Error {}
+  class InvalidOwnerError extends Error {}
+  return {
+    mintAgentWorkspaceToken: (...a: unknown[]) => mintMock(...a),
+    AccountNotProvisionedError,
+    BrokerNotConfiguredError,
+    InvalidOwnerError,
+  }
+})
+
+const ensureRowMock = jest.fn()
+const createGatewayMock = jest.fn(() => ({ gateway: true }))
+jest.mock("@/lib/agent-workspace/agent-provisioning-sheet", () => {
+  class ProvisioningNotConfiguredError extends Error {}
+  return {
+    ensureAgentUsernameRow: (...a: unknown[]) => ensureRowMock(...a),
+    createSheetsGateway: (...a: unknown[]) => createGatewayMock(...a),
+    ProvisioningNotConfiguredError,
+  }
+})
+
+import { handleMintEvent } from "@/lib/agent-workspace/mint-lambda-handler"
+import {
+  AccountNotProvisionedError,
+  BrokerNotConfiguredError,
+  InvalidOwnerError,
+} from "@/lib/agent-workspace/dwd-token-broker"
+import { ProvisioningNotConfiguredError } from "@/lib/agent-workspace/agent-provisioning-sheet"
+
+beforeEach(() => {
+  mintMock.mockReset()
+  ensureRowMock.mockReset()
+  createGatewayMock.mockClear()
+})
+
+describe("mint lambda handler — mint-token op", () => {
+  it("returns accessToken/expiresAt/agentEmail on success", async () => {
+    mintMock.mockResolvedValue({ accessToken: "ya29.at", expiresAt: "2026-07-15T01:00:00Z", agentEmail: "agnt_hagelk@psd401.net" })
+    const r = await handleMintEvent({ op: "mint-token", ownerEmail: "hagelk@psd401.net" })
+    expect(r).toEqual({ accessToken: "ya29.at", expiresAt: "2026-07-15T01:00:00Z", agentEmail: "agnt_hagelk@psd401.net" })
+  })
+
+  it("maps AccountNotProvisionedError to a distinct not-provisioned status (not an error)", async () => {
+    mintMock.mockRejectedValue(new AccountNotProvisionedError("agnt_new@psd401.net"))
+    const r = await handleMintEvent({ op: "mint-token", ownerEmail: "new@psd401.net" })
+    expect(r).toEqual({ status: "account-not-provisioned", agentEmail: "agnt_new@psd401.net" })
+  })
+
+  it("maps InvalidOwnerError to code INVALID_OWNER", async () => {
+    mintMock.mockRejectedValue(new InvalidOwnerError("ownerEmail domain must be psd401.net"))
+    const r = await handleMintEvent({ op: "mint-token", ownerEmail: "x@gmail.com" })
+    expect(r).toEqual({ error: "ownerEmail domain must be psd401.net", code: "INVALID_OWNER" })
+  })
+
+  it("maps BrokerNotConfiguredError to code BROKER_NOT_CONFIGURED", async () => {
+    mintMock.mockRejectedValue(new BrokerNotConfiguredError("missing GCP_PROJECT_NUMBER"))
+    const r = await handleMintEvent({ op: "mint-token", ownerEmail: "hagelk@psd401.net" })
+    expect(r).toEqual({ error: "missing GCP_PROJECT_NUMBER", code: "BROKER_NOT_CONFIGURED" })
+  })
+
+  it("maps an unexpected failure to code INTERNAL", async () => {
+    mintMock.mockRejectedValue(new Error("STS boom"))
+    const r = await handleMintEvent({ op: "mint-token", ownerEmail: "hagelk@psd401.net" })
+    expect(r).toEqual({ error: "STS boom", code: "INTERNAL" })
+  })
+
+  it("rejects a missing/empty ownerEmail with INVALID_OWNER and never calls the broker", async () => {
+    const r = await handleMintEvent({ op: "mint-token" } as never)
+    expect(r).toEqual({ error: "ownerEmail is required", code: "INVALID_OWNER" })
+    expect(mintMock).not.toHaveBeenCalled()
+  })
+
+  it("SECURITY: forwards ONLY ownerEmail to the broker — an injected target sub/agentEmail is ignored", async () => {
+    mintMock.mockResolvedValue({ accessToken: "t", expiresAt: "x", agentEmail: "agnt_hagelk@psd401.net" })
+    // A malicious caller tries to smuggle a victim target alongside ownerEmail.
+    await handleMintEvent({
+      op: "mint-token",
+      ownerEmail: "hagelk@psd401.net",
+      sub: "victim@psd401.net",
+      agentEmail: "agnt_victim@psd401.net",
+    } as never)
+    // The broker (which derives agnt_ itself) is called with the owner email only,
+    // and with exactly ONE argument — no target address can cross the boundary.
+    expect(mintMock).toHaveBeenCalledTimes(1)
+    expect(mintMock).toHaveBeenCalledWith("hagelk@psd401.net")
+  })
+})
+
+describe("mint lambda handler — provision-account op", () => {
+  it("returns { written } on success", async () => {
+    ensureRowMock.mockResolvedValue({ written: true })
+    const r = await handleMintEvent({ op: "provision-account", username: "pratzm" })
+    expect(r).toEqual({ written: true })
+    expect(ensureRowMock).toHaveBeenCalledWith("pratzm", { gateway: true })
+  })
+
+  it("maps ProvisioningNotConfiguredError to code PROVISIONING_NOT_CONFIGURED", async () => {
+    ensureRowMock.mockRejectedValue(new ProvisioningNotConfiguredError("no sheet id"))
+    const r = await handleMintEvent({ op: "provision-account", username: "pratzm" })
+    expect(r).toEqual({ error: "no sheet id", code: "PROVISIONING_NOT_CONFIGURED" })
+  })
+
+  it("rejects a missing/empty username with INTERNAL and never touches the sheet", async () => {
+    const r = await handleMintEvent({ op: "provision-account" } as never)
+    expect(r).toEqual({ error: "username is required", code: "INTERNAL" })
+    expect(ensureRowMock).not.toHaveBeenCalled()
+  })
+})
+
+describe("mint lambda handler — dispatch", () => {
+  it("returns INTERNAL for an unknown op", async () => {
+    const r = await handleMintEvent({ op: "delete-everything" } as never)
+    expect(r).toEqual({ error: "Unknown mint op: delete-everything", code: "INTERNAL" })
+    expect(mintMock).not.toHaveBeenCalled()
+    expect(ensureRowMock).not.toHaveBeenCalled()
+  })
+})

--- a/tests/unit/agent-mint-lambda-handler.test.ts
+++ b/tests/unit/agent-mint-lambda-handler.test.ts
@@ -33,7 +33,7 @@ jest.mock("@/lib/agent-workspace/dwd-token-broker", () => {
 })
 
 const ensureRowMock = jest.fn()
-const createGatewayMock = jest.fn(() => ({ gateway: true }))
+const createGatewayMock = jest.fn((..._a: unknown[]) => ({ gateway: true }))
 jest.mock("@/lib/agent-workspace/agent-provisioning-sheet", () => {
   class ProvisioningNotConfiguredError extends Error {}
   return {


### PR DESCRIPTION
## Summary

Confused-deputy isolation for the GCP Workload-Identity-Federation (WIF)
credential (#1232 hardening). Follow-on to PR #1235.

**The finding (verified against code):** the WIF provider `mint-service` trusted
the entire **frontend ECS task role**, and the DWD token broker + provisioning-
sheet writer ran **in-process in the Next.js app**. `lib/agent-workspace/gcp-wif.ts`
builds `ExternalAccountClient` off the ambient AWS task-role creds (Fargate
container-creds endpoint). So any frontend RCE/SSRF reaching those creds could do
WIF → SA cloud-platform token → `signJwt(sub=ANY user, 8 DWD scopes)` → jwt-bearer
→ an access token for **any mailbox in psd401.net** (gmail.modify + drive
included). The app-layer `deriveAgentEmail`/`agnt_` guard did **not** contain this
— it only ran in app code the attacker bypasses.

**The fix — dedicated mint Lambda + dedicated role:**

- New **`psd-agent-mint-{env}`** Lambda (AgentPlatformStack) with a stable,
  deterministic role **`psd-agent-mint-execution-role-{env}`** — the **sole AWS
  principal the WIF provider trusts**. It houses both WIF consumers (broker +
  sheet writer) via the shared app-tree handler `lib/agent-workspace/mint-lambda-handler.ts`,
  bundled at synth with esbuild (`@/*` via repo tsconfig, `@aws-sdk/*` external,
  google-auth-library/winston inline). VPC private-with-egress (Google endpoints
  via NAT + Secrets Manager via interface endpoint). Role grants **only**
  `secretsmanager:GetSecretValue` on `psd-agent/{env}/*` + CloudWatch Logs + VPC
  ENI. WIF is keyless — no extra AWS grant.
- The two routes (`workspace-token`, `account-request`) become **thin proxies**:
  auth + validation + rate limit + error→HTTP mapping unchanged; the in-process
  broker/sheet call is replaced by an IAM-authed `lambda:InvokeFunction`.
  External request/response shapes + status codes are **byte-identical**, so the
  psd-workspace skill and agent-router hook need no changes. `deriveAgentEmail`
  runs **inside** the Lambda — the frontend passes only `ownerEmail`/`username`,
  never a target sub.
- Frontend ECS task role gains `lambda:InvokeFunction` on the **constructed** mint
  ARN only (no cross-stack import → no circular dep), and `AGENT_MINT_LAMBDA_NAME`
  is set on the container. When that env var is unset (local dev) the routes fall
  back to running the broker in-process (no real WIF locally).

**Blast-radius outcome:** after this, a frontend compromise can only
`InvokeFunction` the mint Lambda, which always derives `agnt_` server-side and
only appends usernames — it can **not** `signJwt` an arbitrary sub. Blast radius
shrinks from **"any psd401.net mailbox incl. staff gmail/drive"** to **"any
`agnt_` account"** (the intended codex-P1 residual).

Cedar unaffected (the agent container still calls the same `/api/agent/*` route
URLs; the Google calls moved to the Lambda, which is not agent-governed). No
agent image rebuild (skills unchanged).

## Coordination — IT (Reese), before this can mint in a deployed env

WIF must trust the **mint role**, not the frontend role. Both against the stable
ARN (dev account `390844780692`):

- Role ARN: `arn:aws:iam::390844780692:role/psd-agent-mint-execution-role-dev`
- Assumed-role principal (what Google's STS sees):
  `arn:aws:sts::390844780692:assumed-role/psd-agent-mint-execution-role-dev/*`

1. Set the WIF provider (`mint-service`) attribute condition to accept the mint
   role's assumed-role ARN above, **replacing** the frontend role
   `AIStudio-FrontendStack-EC-EcsServiceTaskRoleBE1DE1B-Dca6EfSysKpJ`.
2. Move the `roles/iam.workloadIdentityUser` **and**
   `roles/iam.serviceAccountTokenCreator` `principalSet` bindings on SA
   `agnt-token-broker@psd-agnt-token-broker.iam.gserviceaccount.com` to the new
   mint role.

## Changes

- `lib/agent-workspace/mint-contract.ts`, `mint-lambda-handler.ts`,
  `mint-client.ts` (new); `gcp-wif.ts` credential_source note.
- `app/api/agent/workspace-token/route.ts`, `account-request/route.ts` — thin
  proxies.
- `infra/lib/agent-platform-stack.ts` — mint Lambda + role.
- `infra/lib/constructs/ecs-service.ts` — invoke-only grant + env var.
- Tests + `docs/features/agent-workspace-integration.md`.

## Verification (all green locally before opening)

- App: Lint ✅ (changed source clean) · Typecheck ✅ · Jest ✅ (67 agent-workspace
  tests incl. the existing suite + new handler/client tests).
- Infra: `tsc --noEmit` ✅ · `cdk synth` ✅ (AgentPlatformStack + FrontendStack-ECS,
  **no circular dependency**; the mint Lambda bundled via esbuild during synth) ·
  new CDK assertion tests ✅ (mint role secret-scoped + WIF principal; frontend
  invoke-only on the constructed ARN + env var). Pre-existing infra failures
  (`aurora-cost-dashboard`, `optimized-lambda`) are untouched by this change.

## Evidence

_N/A — no UI surface. Backend/infra security isolation; route request/response
contracts are byte-identical (verified by the existing route tests + new invoker
contract tests)._

## Deploy (Hagel)

AgentPlatformStack + FrontendStack-ECS — slots into the canonical full-stack
deploy command. No agent image rebuild. Secrets `psd-agent/dev/agent-gateway`
and `psd-agent/dev/gcp-dwd-config` already exist; do not recreate.

Part of #1232.
