### PR TITLE
fix: #1237 - provisioning sheet fills column A instead of inserting a row

### DIFF
--- a/lib/agent-workspace/agent-provisioning-sheet.ts
+++ b/lib/agent-workspace/agent-provisioning-sheet.ts
@@ -70,15 +70,16 @@ export function usernameAlreadyPresent(columnA: readonly string[], username: str
 export interface SheetsGateway {
   /** Read the values in column A of the agents tab (top-to-bottom, incl. header). */
   readColumnA(): Promise<string[]>
-  /** Append `username` as a new row at the bottom of column A. */
+  /** Fill `username` into the first empty cell of column A (no row inserted). */
   appendUsername(username: string): Promise<void>
 }
 
 /**
- * Ensure exactly one row for `username` exists in the sheet. Returns whether a
- * new row was written (false = a prior request already queued it). Safe under
- * two simultaneous requests for DIFFERENT users because append inserts a new
- * row rather than targeting a computed index.
+ * Ensure exactly one row for `username` exists in the sheet. Returns whether the
+ * cell was written (false = a prior request already queued it). Safe under two
+ * simultaneous requests for DIFFERENT users: append resolves the target cell
+ * server-side atomically, so concurrent writes land in distinct rows — it fills
+ * the first empty column-A cell rather than inserting a row (#1237).
  */
 export async function ensureAgentUsernameRow(
   username: string,
@@ -110,11 +111,12 @@ export interface SheetsGatewayDeps {
  * The production Sheets gateway. Reads/writes column A of the agents tab via the
  * Sheets REST API using a spreadsheets-scoped, WIF-impersonated SA token.
  *
- * append uses values.append on range `<tab>!A:A` with INSERT_ROWS. Column A is
- * plain data (the formulas live in other columns), so append targets the bottom
- * of that column. NOTE: verify append's table detection against the real sheet
- * once it exists (adjacent formula columns can occasionally confuse append); if
- * it misbehaves, switch to read-A -> update first-empty-cell -> read-back-verify.
+ * append uses values.append on range `<tab>!A:A` with insertDataOption=OVERWRITE.
+ * The `agents` tab has pre-formatted rows (formulas dragged down in columns B+;
+ * column A blank until used), so append's table detection lands on the first
+ * empty column-A cell and OVERWRITE FILLS it. INSERT_ROWS was wrong — it inserted
+ * a fresh, formula-less row, so OneSync saw a username with every other column
+ * blank (#1237). Only column A is written, so the B+ formulas are untouched.
  */
 export function createSheetsGateway(deps: SheetsGatewayDeps = {}): SheetsGateway {
   const fetchImpl = deps.fetchImpl ?? fetch
@@ -153,7 +155,7 @@ export function createSheetsGateway(deps: SheetsGatewayDeps = {}): SheetsGateway
       const [token, baseUrl] = await Promise.all([getToken(), base()])
       const url =
         `${baseUrl}/values/${encodeURIComponent(range)}:append` +
-        `?valueInputOption=RAW&insertDataOption=INSERT_ROWS`
+        `?valueInputOption=RAW&insertDataOption=OVERWRITE`
       const res = await fetchImpl(url, {
         method: "POST",
         headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },

--- a/tests/unit/agent-provisioning-sheet.test.ts
+++ b/tests/unit/agent-provisioning-sheet.test.ts
@@ -78,14 +78,18 @@ describe("createSheetsGateway (Sheets REST)", () => {
     expect(call[1].headers.Authorization).toBe("Bearer sa-token")
   })
 
-  it("appendUsername POSTs values.append with INSERT_ROWS and the username", async () => {
+  it("appendUsername fills column A via values.append with OVERWRITE (never INSERT_ROWS) — #1237", async () => {
     const fetchImpl = jest.fn(async () => ({ ok: true, json: async () => ({}) })) as unknown as typeof fetch
     const gw = createSheetsGateway({ fetchImpl, getAccessToken: async () => "sa-token" })
     await gw.appendUsername("pratzm")
     const [url, init] = (fetchImpl as jest.Mock).mock.calls[0]
     expect(url).toContain(":append")
-    expect(url).toContain("insertDataOption=INSERT_ROWS")
+    // OVERWRITE fills the first empty column-A cell of a pre-formatted formula
+    // row; INSERT_ROWS inserted a formula-less row and broke provisioning (#1237).
+    expect(url).toContain("insertDataOption=OVERWRITE")
+    expect(url).not.toContain("INSERT_ROWS")
     expect(init.method).toBe("POST")
+    // Only column A is written, so adjacent formula columns (B+) are untouched.
     expect(JSON.parse(init.body).values).toEqual([["pratzm"]])
   })
 


### PR DESCRIPTION
## Bug (#1237)

The #1233 provisioning writer called Sheets `values.append` with `insertDataOption=INSERT_ROWS`, inserting a fresh, formula-less row. The OneSync `agents` tab is pre-formatted (formulas dragged down columns B+ derive everything from the bare username in column A via the `staff_info` lookup), so an inserted row left every other column blank — OneSync provisioned nothing — and the insert broke the pre-filled formula rows.

## Fix (issue Option 1)

`insertDataOption=INSERT_ROWS` → `OVERWRITE`. append's table detection already targets the first empty column-A cell (confirmed on the real sheet by @pratzm); OVERWRITE fills that existing cell instead of inserting a row. Only column A is written, so B+ formulas are untouched, and append's server-side atomicity keeps concurrent writes for different users in distinct rows.

## Changes
- `lib/agent-workspace/agent-provisioning-sheet.ts` — the one-parameter fix + doc updates (fill-in-place semantics; dropped the resolved append NOTE).
- `tests/unit/agent-provisioning-sheet.test.ts` — pin OVERWRITE (assert no INSERT_ROWS) + single-column write.

## Verification
- Unit: 6/6 pass (pins the API-call shape).
- Live formula-sheet verification is the sheet owner's — @pratzm offered to pair in #1237. Per direction, no live sheet writes from here.

## Acceptance criteria (#1237)
- [x] Writes bare username into first empty column-A cell (no row insert) — OVERWRITE + single-column body
- [x] Idempotency preserved (`usernameAlreadyPresent` dedupe unchanged)
- [x] Concurrent different-user requests land in distinct rows (append server-side atomicity)
- [x] Unit tests pin fill-in-place behavior

Closes #1237

https://claude.ai/code/session_017FwibWMuzAtnMuvHFAYiPo
