### PR TITLE
fix(agent): #1175 - add xz-utils to render Lambda image (unblocks cdk deploy)

### DIFF
--- a/infra/hyperframes-render/Dockerfile
+++ b/infra/hyperframes-render/Dockerfile
@@ -21,9 +21,11 @@ ARG HYPERFRAMES_VERSION=0.7.59
 
 # Runtime deps (ffmpeg + chromium + its shared libs + fonts, from upstream
 # Dockerfile.render) AND build deps for aws-lambda-ric's native addon
-# (g++/make/cmake/libcurl/python3). unzip is required by @puppeteer/browsers.
+# (g++/make/cmake/libcurl/python3). unzip is required by @puppeteer/browsers;
+# xz-utils by aws-lambda-ric's preinstall, which extracts a .tar.xz (curl) and
+# fails on the slim base with "tar (child): xz: Cannot exec" without it.
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    ca-certificates curl unzip ffmpeg chromium \
+    ca-certificates curl unzip xz-utils ffmpeg chromium \
     libgbm1 libnss3 libatk-bridge2.0-0 libdrm2 libxcomposite1 \
     libxdamage1 libxrandr2 libcups2 libasound2 libpangocairo-1.0-0 \
     libxshmfence1 libgtk-3-0 \


### PR DESCRIPTION
## Problem
`cdk deploy` failed building the **psd-hyperframes-render** Lambda container image (asset `HyperframesRender/Function/AssetImage`) at the `npm install` step:

```
npm error path /var/task/node_modules/aws-lambda-ric
npm error command sh -c ./scripts/preinstall.sh
npm error Extracting curl...
tar (child): xz: Cannot exec: No such file or directory
```

`aws-lambda-ric`'s preinstall builds a native addon and extracts a curl source `.tar.xz`. The `node:22-bookworm-slim` base image does not ship the `xz` binary, so `tar` can't decompress it → exit 2 → the whole stack deploy fails.

## Fix
Add `xz-utils` to the apt install line in `infra/hyperframes-render/Dockerfile`, alongside the other `aws-lambda-ric` build deps (`g++ make cmake libcurl4-openssl-dev python3`).

## Verification
Built locally with the same command cdk runs — `docker build --platform linux/amd64 .` — and the previously-failing `npm install --omit=dev` step now completes (`added 126 packages`, aws-lambda-ric native addon builds, image written). 

## Why it wasn't caught earlier
The render image is only **fingerprinted** by `cdk synth` in CI, never built; the standalone docker render smoke that would have caught it is a documented pre-deploy hand-off (`infra/hyperframes-render/README.md`). Unit tests mock the subprocess/S3.

Part of #1175

https://claude.ai/code/session_01KjbYARn9mvCKDPUXRVJWqs
