### PR TITLE
fix(agent): #1175 - static ffmpeg for render Lambda (Debian ffmpeg won't run on Lambda)

### DIFF
--- a/infra/hyperframes-render/Dockerfile
+++ b/infra/hyperframes-render/Dockerfile
@@ -59,6 +59,33 @@ RUN SHELL_PATH=$(find /opt/chrome-cache -name chrome-headless-shell -type f 2>/d
 # The upstream renderer, pinned.
 RUN npm install -g hyperframes@${HYPERFRAMES_VERSION} && hyperframes --version
 
+# Self-contained ffmpeg/ffprobe. The Debian `ffmpeg` package installed above is a
+# valid amd64 binary that runs fine under local emulation, but its hyperframes
+# preflight FAILS inside the AWS Lambda sandbox — "FFmpeg cannot start / Failed to
+# run /usr/bin/ffmpeg -version" (confirmed live on psd-hyperframes-render-dev,
+# #1175 follow-up). The Debian build dynamically loads 40+ shared libraries
+# (libplacebo, libvulkan, sdl2, GPU/desktop libs, …); that lib-loading is the one
+# thing that differs between working emulation and the failing Lambda. This BtbN
+# build statically bundles all codec libs into the binary (only glibc is dynamic,
+# which the base image provides and Node itself uses here), so it starts cleanly.
+# hyperframes uses it via HYPERFRAMES_FFMPEG_PATH / HYPERFRAMES_FFPROBE_PATH below.
+# Pinned to an immutable BtbN autobuild tag + verified against BtbN's published
+# SHA256 (matches the bun/uv/gh pin+checksum pattern above). xz-utils extracts it.
+ARG FFMPEG_BUILD=autobuild-2026-07-15-14-01
+ARG FFMPEG_ASSET=ffmpeg-n7.1.5-2-g998de74adf-linux64-gpl-7.1
+ARG FFMPEG_SHA256=ccd7b81376598a8730ee4ef1e78716f73308ede970e2e9234f790f799c1d6bf5
+RUN mkdir -p /opt/ffmpeg && cd /tmp && \
+    curl -fsSL -o ffmpeg.tar.xz \
+      "https://github.com/BtbN/FFmpeg-Builds/releases/download/${FFMPEG_BUILD}/${FFMPEG_ASSET}.tar.xz" && \
+    echo "${FFMPEG_SHA256}  ffmpeg.tar.xz" | sha256sum -c - && \
+    tar -xJf ffmpeg.tar.xz -C /opt/ffmpeg --strip-components=2 \
+      "${FFMPEG_ASSET}/bin/ffmpeg" "${FFMPEG_ASSET}/bin/ffprobe" && \
+    rm -f ffmpeg.tar.xz && \
+    chmod +x /opt/ffmpeg/ffmpeg /opt/ffmpeg/ffprobe && \
+    /opt/ffmpeg/ffmpeg -version | head -1 && /opt/ffmpeg/ffprobe -version | head -1
+ENV HYPERFRAMES_FFMPEG_PATH=/opt/ffmpeg/ffmpeg
+ENV HYPERFRAMES_FFPROBE_PATH=/opt/ffmpeg/ffprobe
+
 # Lambda handler + its runtime deps (aws-lambda-ric + @aws-sdk/client-s3).
 WORKDIR /var/task
 COPY package.json ./

--- a/infra/hyperframes-render/handler.js
+++ b/infra/hyperframes-render/handler.js
@@ -324,6 +324,9 @@ async function renderToMp4(compositionHtml, { fps, workDir, outPath }) {
       throw new RenderError('render_timeout', `Render exceeded ${RENDER_TIMEOUT_MS} ms. Shorten the scene or lower fps.`);
     }
     const detail = String((err && (err.stderr || err.message)) || err).slice(0, 800);
+    // Log to CloudWatch: the handler returns errors as data (never throws to the
+    // platform), so without this a render failure leaves no server-side trace.
+    console.error(`[render] hyperframes failed: code=${err && err.code} signal=${err && err.signal} detail=${detail}`);
     throw new RenderError('render_failed', `hyperframes render failed: ${detail}`);
   }
 
@@ -429,6 +432,30 @@ async function handler(event, deps = {}) {
     };
   }
 }
+
+/**
+ * One-time cold-start FFmpeg self-check, logged to CloudWatch. The full Debian
+ * ffmpeg failed its hyperframes preflight inside the Lambda sandbox (#1175
+ * follow-up); this records whether the configured binary actually runs on this
+ * environment, so a regression is diagnosable from logs rather than only the
+ * caller's error string. Non-blocking (async execFile) — never affects a render.
+ */
+function logFfmpegSelfCheck() {
+  const bin = process.env.HYPERFRAMES_FFMPEG_PATH || 'ffmpeg';
+  const started = Date.now();
+  execFile(bin, ['-version'], { timeout: 8000 }, (err, stdout) => {
+    const ms = Date.now() - started;
+    if (err) {
+      console.error(
+        `[ffmpeg-selfcheck] FAILED bin=${bin} code=${err.code} signal=${err.signal} killed=${err.killed} after=${ms}ms: ${String(err.message).slice(0, 200)}`,
+      );
+    } else {
+      console.log(`[ffmpeg-selfcheck] OK bin=${bin} after=${ms}ms — ${String(stdout).split('\n')[0]}`);
+    }
+  });
+}
+// Only in the real Lambda (AWS_LAMBDA_FUNCTION_NAME is set there, unset in tests).
+if (process.env.AWS_LAMBDA_FUNCTION_NAME) logFfmpegSelfCheck();
 
 module.exports = {
   handler,


### PR DESCRIPTION
## Problem
Every render on `psd-hyperframes-render-dev` failed with hyperframes' preflight error **"FFmpeg cannot start / Failed to run `/usr/bin/ffmpeg` -version"** (no exit code → a spawn/signal failure, not a clean error). The deploy succeeded and the Lambda runs; it fails at the ffmpeg preflight.

## Diagnosis (confirmed on the deployed Lambda)
- Invoked the deployed function directly (dryRun) → got the exact full message.
- Built the image locally + ran `/usr/bin/ffmpeg -version` at build: the Debian ffmpeg is a **valid amd64 ELF, all libs resolve, prints `ffmpeg version 5.1.9 … --arch=amd64`** — the binary is fine.
- hyperframes source: "FFmpeg cannot start" = binary **found but `-version` won't complete**.
- The Debian build dynamically loads **40+ shared libs** (libplacebo, libvulkan, sdl2, GPU/desktop). That lib-loading is the only difference between the working local run and the failing Lambda sandbox (Node/glibc runs fine on the same Lambda).

## Fix
Bake a self-contained ffmpeg/ffprobe that statically bundles all codec libs (only glibc dynamic) and point hyperframes at it via `HYPERFRAMES_FFMPEG_PATH`/`HYPERFRAMES_FFPROBE_PATH`.

**Supply chain (user-approved source):** `github.com/BtbN/FFmpeg-Builds`, immutable tag `autobuild-2026-07-15-14-01`, asset `ffmpeg-n7.1.5-2-g998de74adf-linux64-gpl-7.1.tar.xz`, **SHA256 `ccd7b813…`** verified in-Dockerfile via `sha256sum -c` (matches the bun/uv/gh pin+checksum pattern). Checksum + amd64 ELF verified out-of-band before pinning.

**Diagnosability:** the handler now logs render failures to CloudWatch (it returns errors as data, previously leaving no server-side trace) and runs a one-time cold-start `ffmpeg -version` self-check on Lambda.

## Verification
`docker build --platform linux/amd64` → `ffmpeg.tar.xz: OK` (checksum) + `ffmpeg`/`ffprobe -version` run (n7.1.5); 22 unit tests pass. Real-Lambda runtime confirmation is post-deploy (the cold-start self-check logs it) — local runtime is emulation-only on this arm64 host.

Part of #1175

https://claude.ai/code/session_01KjbYARn9mvCKDPUXRVJWqs
