### PR TITLE
feat(agent): #1175 - psd-hyperframes audio (--audio-url) + firmer reply-format

### DIFF
--- a/infra/agent-image/skills/psd-hyperframes/SKILL.md
+++ b/infra/agent-image/skills/psd-hyperframes/SKILL.md
@@ -90,6 +90,7 @@ node /opt/psd-skills/psd-hyperframes/render.js \
   --file scene.html \
   --duration 3 \
   [--css-file extra.css] [--js-file extra.js] \
+  [--audio-url <https-mp3-url>] \
   [--fps 30] [--width 1920] [--height 1080]
 ```
 
@@ -97,30 +98,57 @@ node /opt/psd-skills/psd-hyperframes/render.js \
 - `--css-file` / `--js-file` — optional extra CSS/JS injected into the composition
   (`<style>` before `</head>`, `<script>` before `</body>`). Prefer inlining directly in the
   HTML; these exist for convenience.
+- `--audio-url <https-url>` — optional narration/music track (see **Audio** below).
 - `--duration <seconds>` — **required**; must match the composition's `data-duration` and be ≤ 60.
 
 Returns JSON: `{ "url": "…", "s3Key": "public-images/<email>/<uuid>.mp4", "bytes": N, "fps": 30, "durationSeconds": 3, "width": 1920, "height": 1080, "sharing": "public-by-link" }`.
 
 ## Required Reply Format
 
-After the skill returns a result with a `url`, your **next chat message MUST contain the bare
-`url` on a line by itself** (Google Chat renders it as a downloadable/playable link):
+**This is the single most important step — do not skip it.** After the skill returns a `url`, your
+**very next chat message MUST paste the bare `url` on a line by itself** so the user gets a
+clickable/playable link. If the HTTPS `url` is not in your reply, the user got nothing.
 
 - ✅ Correct:
   ```
   Here's your video:
   https://psd-agents-dev-…​.s3.us-east-1.amazonaws.com/public-images/<email>/<uuid>.mp4
   ```
-- ❌ Wrong: describing the video without pasting the URL — the user cannot see the tool result.
+- ❌ Wrong: telling the user where it's saved (an `s3://…` path, "it's in S3", the container path)
+  instead of pasting the HTTPS `url` — that is NOT a clickable link, and the user cannot see the
+  tool result. Paste the `url`, don't describe it.
 - ❌ Wrong: wrapping the URL in `[label](url)` or `**bold**` — Google Chat corrupts these for
   long S3 URLs. Bare URL only.
 - ❌ Wrong: re-rendering or presigning the returned URL. It is already public-by-link with
   HTTP 200; do not touch it.
 
+## Audio (narration / music)
+
+hyperframes has **no separate audio input** — audio comes from an `<audio>` element in the
+composition, which hyperframes muxes into the MP4. Easiest path:
+
+1. Write the narration script, then call **psd-tts** to synthesize it — it returns a public HTTPS
+   MP3 `url`. Pick a voice/engine that fits the piece:
+   - `--engine long-form` (en-US: Danielle, Gregory, Patrick, Ruth) — best for narrating a script.
+   - `--engine generative` (default; **Ruth** = warm female, **Matthew** = clear male; also
+     Danielle, Joanna, Salli, Stephen, Tiffany, en-GB Amy/Brian) — most natural/expressive.
+   - `--engine neural` for the widest voice/language coverage.
+   - Full list: psd-tts `references/voices.md`.
+2. Pass that MP3 URL here as `--audio-url <url>`. The skill injects
+   `<audio src="…" data-start="0" data-duration="<your --duration>" data-track-index="0"
+   data-volume="1">` into the composition root; hyperframes pads/trims the clip to the video length.
+
+Notes:
+- `--audio-url` must be an `https://` URL (or a `data:audio/…` URI); the render Lambda fetches it.
+- For music instead of narration, pass any hosted MP3/WAV URL the same way.
+- Advanced: you can hand-author the `<audio>` element in the composition yourself instead of
+  `--audio-url` — the element contract is identical (`data-start`/`data-duration`/`data-track-index`/`data-volume`).
+
 ## Errors
 
 - **`bad_args`** — missing/invalid `--user`, no composition, bad `--duration`/`--fps`/dimensions,
-  a valueless `--css-file`/`--js-file`, a combined html+css+js payload over the 4 MB cap, or a
+  a valueless `--css-file`/`--js-file`, an `--audio-url` that isn't `https://` / `data:audio/`,
+  a combined html+css+js payload over the 4 MB cap, or a
   composition whose declared `data-duration` exceeds the 60 s cap or whose root
   `data-width`/`data-height` exceeds the 3840 px cap. Fix and retry.
 - **`misconfigured`** — the render function name (`HYPERFRAMES_RENDER_FUNCTION`) is not injected.

--- a/infra/agent-image/skills/psd-hyperframes/render.js
+++ b/infra/agent-image/skills/psd-hyperframes/render.js
@@ -110,6 +110,27 @@ function coerceInt(value, flag) {
 }
 
 /**
+ * Insert an <audio> track as the first child of the composition root (the
+ * element carrying data-composition-id) so hyperframes treats it as a timeline
+ * audio clip and muxes it into the MP4. `url` is pre-validated (https/data:audio,
+ * no quotes) by the caller. Falls back to before </body>, then appending, if the
+ * root element cannot be located.
+ */
+function injectAudioElement(html, url, durationSeconds) {
+  const audio =
+    `<audio src="${url}" data-start="0" data-duration="${durationSeconds}" ` +
+    `data-track-index="0" data-volume="1"></audio>`;
+  const rootOpen = html.match(/<[a-zA-Z][^>]*\bdata-composition-id\b[^>]*>/);
+  if (rootOpen) {
+    const at = rootOpen.index + rootOpen[0].length;
+    return `${html.slice(0, at)}\n${audio}${html.slice(at)}`;
+  }
+  const bodyAt = html.toLowerCase().lastIndexOf('</body>');
+  if (bodyAt !== -1) return `${html.slice(0, bodyAt)}${audio}\n${html.slice(bodyAt)}`;
+  return `${html}\n${audio}`;
+}
+
+/**
  * Validate the CLI args and assemble the render Lambda invoke payload.
  * Every invalid input fails fast with an actionable message.
  */
@@ -144,6 +165,20 @@ function buildPayload(args) {
   else if (args.js_file) js = readFileOrFail(String(args.js_file), '--js-file');
   else if (args.js === true) fail('--js requires a value', 'bad_args');
   else if (args.js) js = String(args.js);
+
+  // Optional audio track (narration / music). hyperframes has no separate audio
+  // input — it muxes audio from an <audio> element in the composition. --audio-url
+  // points at a hosted clip (e.g. a psd-tts MP3 URL); we inject the <audio> below.
+  // Restricted to https:// / data:audio so the value is safe to interpolate into
+  // the src attribute (no quotes/spaces/angle brackets).
+  let audioUrl;
+  if (args.audio_url === true) fail('--audio-url requires a URL', 'bad_args');
+  else if (args.audio_url) {
+    audioUrl = String(args.audio_url);
+    if (!/^https:\/\/[^\s"'<>]+$/.test(audioUrl) && !/^data:audio\/[^\s"'<>]+$/i.test(audioUrl)) {
+      fail('--audio-url must be an https:// URL or a data:audio/ URI (no spaces or quotes)', 'bad_args');
+    }
+  }
 
   const compositionBytes =
     Buffer.byteLength(html, 'utf8') +
@@ -188,6 +223,12 @@ function buildPayload(args) {
   if (args.dry_run !== undefined && args.dry_run !== true) {
     fail('--dry-run is a flag and takes no value', 'bad_args');
   }
+
+  // Bake the audio track into the composition root now that the duration is
+  // known: data-duration spans the whole video so hyperframes pads/trims the
+  // source clip to fit. Done here (not in the Lambda) so the render service
+  // needs no change — it just renders whatever composition it receives.
+  if (audioUrl) html = injectAudioElement(html, audioUrl, durationSeconds);
 
   const payload = { html, durationSeconds, fps, width, height, userEmail: args.user };
   if (css) payload.css = css;
@@ -250,6 +291,7 @@ async function main(argv = process.argv, deps = {}) {
     process.stdout.write(
       'Usage: render.js --user <email> --file <composition.html> --duration <sec> ' +
         '[--html "<inline>"] [--css-file <path>] [--js-file <path>] ' +
+        '[--audio-url <https-mp3-url>] ' +
         '[--fps 30] [--width 1920] [--height 1080] [--dry-run]\n',
     );
     process.exit(0);
@@ -281,6 +323,7 @@ module.exports = {
   main,
   parseArgs,
   buildPayload,
+  injectAudioElement,
   invokeRender,
   validateEmail,
   MAX_DURATION_SECONDS,

--- a/infra/agent-image/skills/psd-hyperframes/render.test.js
+++ b/infra/agent-image/skills/psd-hyperframes/render.test.js
@@ -162,6 +162,27 @@ test('buildPayload reads css/js from files and carries dryRun', () => {
   }
 });
 
+test('buildPayload injects an <audio> track from --audio-url into the composition root', () => {
+  const url = 'https://psd-agents-dev.s3.us-east-1.amazonaws.com/public-images/p@psd401.net/n.mp3';
+  const p = buildPayload(parseArgs(argv(
+    '--user', 'p@psd401.net', '--html', HTML, '--duration', '3', '--audio-url', url,
+  )));
+  expect(p.html).toContain(`<audio src="${url}"`);
+  expect(p.html).toContain('data-duration="3"');
+  expect(p.html).toContain('data-track-index="0"');
+  // Injected as the first child of the data-composition-id root element.
+  expect(p.html).toMatch(/data-composition-id="demo"[^>]*>\s*<audio /);
+});
+
+test('buildPayload rejects an unsafe / non-https --audio-url', () => {
+  const base = ['--user', 'p@psd401.net', '--html', HTML, '--duration', '3'];
+  expect(() => buildPayload(parseArgs(argv(...base, '--audio-url', 'http://insecure.example/n.mp3')))).toThrow(ExitError);
+  expect(lastJson().error).toBe('bad_args');
+  stdout = ''; // reset so lastJson() reads only the second failure
+  expect(() => buildPayload(parseArgs(argv(...base, '--audio-url', 'https://x/a" onerror=1')))).toThrow(ExitError);
+  expect(lastJson().error).toBe('bad_args');
+});
+
 // ── invokeRender (mocked LambdaClient) ───────────────────────────────────────
 
 function fakeClient(responder) {


### PR DESCRIPTION
Follow-ups from the first live psd-hyperframes renders (render itself now works).

## 1. Audio (`--audio-url`)
Renders were silent. hyperframes **does** support audio — it muxes an `<audio>` element from the composition into the MP4 (confirmed in the upstream source) — the skill just never exposed it.

`--audio-url <https-url>` (or `data:audio/…`): `render.js` validates it (https/data only, no quotes/spaces → safe to interpolate) and injects
```html
<audio src="…" data-start="0" data-duration="<--duration>" data-track-index="0" data-volume="1">
```
as the first child of the composition root. `data-duration` spans the whole video so hyperframes pads/trims the source to fit. **Injection is in the skill, not the render Lambda** — no render-Lambda change.

SKILL.md documents the **psd-tts → `--audio-url`** narration workflow, including voice/engine options (long-form Danielle/Gregory/Patrick/Ruth for narration; generative Ruth/Matthew/…; neural for coverage).

## 2. Reply-format
The agent described the S3 location (`s3://…`, "it's in S3") instead of pasting the clickable HTTPS URL. The contract already required the bare URL — this makes it firmer, leads with it, and names the exact mistake so the model pastes the URL proactively.

## Scope
**Agent-image only** (`render.js` + `SKILL.md`) — the render Lambda is untouched. Needs an agent-image rebuild + redeploy to take effect.

## Verification
Skill suite: 18 pass (2 new — audio injection into the root, unsafe-URL rejection). `node --check` clean.

Part of #1175

https://claude.ai/code/session_01KjbYARn9mvCKDPUXRVJWqs
