### PR TITLE
feat(nexus): add automatic model routing

### DIFF
--- a/.codex/README.md
+++ b/.codex/README.md
@@ -1,0 +1,15 @@
+# Local Codex configuration
+
+The project-level Codex configuration starts the AWS Labs PostgreSQL MCP server
+in read-only mode. Resource identifiers are intentionally not committed.
+
+Set these variables in the environment that launches Codex:
+
+```bash
+export AISTUDIO_DB_CLUSTER_ARN="arn:aws:rds:<region>:<account>:cluster:<cluster>"
+export AISTUDIO_DB_SECRET_ARN="arn:aws:secretsmanager:<region>:<account>:secret:<secret>"
+```
+
+Optional variables are `AISTUDIO_DB_NAME` (defaults to `aistudio`), `AWS_REGION`
+(defaults to `us-east-1`), and `AWS_PROFILE` (handled by the AWS SDK). The launcher
+fails with a clear message when either required identifier is missing.

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,24 @@
+[mcp_servers.awslabs-postgres-mcp-server]
+command = "uvx"
+args = [
+    "awslabs.postgres-mcp-server@1.0.9",
+    "--resource_arn",
+    "arn:aws:rds:us-east-1:390844780692:cluster:aistudio-dev-cluster",
+    "--secret_arn",
+    "arn:aws:secretsmanager:us-east-1:390844780692:secret:DbSecret685A0FA5-Tby3OSNjVCjb-i3YrMv",
+    "--database",
+    "aistudio",
+    "--region",
+    "us-east-1",
+    "--readonly",
+    "True",
+]
+
+[mcp_servers.awslabs-postgres-mcp-server.env]
+AWS_PROFILE = "default"
+AWS_REGION = "us-east-1"
+FASTMCP_LOG_LEVEL = "ERROR"
+
+[mcp_servers.playwright]
+command = "bunx"
+args = ["@playwright/mcp@latest"]

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,23 +1,6 @@
 [mcp_servers.awslabs-postgres-mcp-server]
-command = "uvx"
-args = [
-    "awslabs.postgres-mcp-server@1.0.9",
-    "--resource_arn",
-    "arn:aws:rds:us-east-1:390844780692:cluster:aistudio-dev-cluster",
-    "--secret_arn",
-    "arn:aws:secretsmanager:us-east-1:390844780692:secret:DbSecret685A0FA5-Tby3OSNjVCjb-i3YrMv",
-    "--database",
-    "aistudio",
-    "--region",
-    "us-east-1",
-    "--readonly",
-    "True",
-]
-
-[mcp_servers.awslabs-postgres-mcp-server.env]
-AWS_PROFILE = "default"
-AWS_REGION = "us-east-1"
-FASTMCP_LOG_LEVEL = "ERROR"
+command = "bash"
+args = [".codex/run-postgres-mcp.sh"]
 
 [mcp_servers.playwright]
 command = "bunx"

--- a/.codex/run-postgres-mcp.sh
+++ b/.codex/run-postgres-mcp.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${AISTUDIO_DB_CLUSTER_ARN:?Set AISTUDIO_DB_CLUSTER_ARN before starting Codex}"
+: "${AISTUDIO_DB_SECRET_ARN:?Set AISTUDIO_DB_SECRET_ARN before starting Codex}"
+
+exec uvx awslabs.postgres-mcp-server@1.0.9 \
+  --resource_arn "${AISTUDIO_DB_CLUSTER_ARN}" \
+  --secret_arn "${AISTUDIO_DB_SECRET_ARN}" \
+  --database "${AISTUDIO_DB_NAME:-aistudio}" \
+  --region "${AWS_REGION:-us-east-1}" \
+  --readonly True

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,410 @@
+# AGENTS.md
+
+AI Studio codebase guidance for Codex. Optimized for token efficiency and accuracy.
+
+## 🚀 Quick Reference
+
+```bash
+# Local Development (Issue #607)
+bun run db:up              # Start local PostgreSQL (Docker)
+bun run dev:local          # Run Next.js with local database
+bun run db:studio          # Open Drizzle Studio to inspect DB
+bun run db:psql            # Connect to local DB via psql
+bun run db:seed            # Create test users (admin/staff/student)
+bun run db:reset           # Reset database (destroys all data)
+
+# Development (without Docker)
+bun run dev                # Start dev server (port 3000)
+bun run build              # Build for production
+bun run lint               # MUST pass before commit
+bun run typecheck          # MUST pass before commit
+bun run test:e2e           # Run E2E tests
+
+# Infrastructure (from /infra)
+cd infra && bunx cdk deploy --all                          # Deploy all stacks
+cd infra && bunx cdk deploy AIStudio-FrontendStack-Dev     # Deploy single stack
+```
+
+## 🎯 Critical Rules
+
+1. **Type Safety**: NO `any` types. Full TypeScript. Run `bun run lint` and `bun run typecheck` on ENTIRE codebase before commits.
+2. **Database Migrations**: Files 001-005 are IMMUTABLE. Only add migrations 010+. Add filename to `migrationFiles` array in `/infra/database/migrations.json`.
+3. **Logging**: NEVER use `console.log/error`. Always use `@/lib/logger`. See patterns below. **Exception**: `voice-server.js` and other CJS standalone scripts that run outside the Next.js runtime cannot import `@/lib/logger` — use `console.*` with `// eslint-disable-line no-console` comments.
+4. **Git Flow**: PRs target `dev` branch, never `main`. Write detailed commit messages.
+5. **Testing**: Add E2E tests for new features (see `docs/guides/TESTING.md` — E2E Expectations section). Run locally via `bunx playwright test tests/e2e/`.
+6. **Nexus Conversations**: MUST read `/docs/features/nexus-conversation-architecture.md` before modifying conversation code. This system has broken multiple times - follow documented patterns exactly.
+7. **API Documentation**: When adding or modifying `/api/v1/` endpoints, update both `docs/API/v1/openapi.yaml` (OpenAPI spec) and `docs/API/v1/context-graph.md` (human-readable reference). Include request/response examples, error codes, and auth/scope requirements.
+
+## 🏗️ Architecture
+
+**Stack**: Next.js 15 App Router • ECS Fargate (SSR) • Aurora Serverless v2 • Cognito Auth
+
+**Core Patterns**:
+- Server Actions return `ActionState<T>`
+- Drizzle ORM for all DB operations (executeQuery/executeTransaction)
+- JWT sessions via NextAuth v5
+- Layered architecture (presentation → application → infrastructure)
+- **Reusable CDK constructs** for infrastructure consistency
+
+**File Structure**:
+```
+/app         → Pages & API routes
+/actions     → Server actions (*.actions.ts)
+/components  → UI components
+/lib         → Core utilities & adapters
+/infra       → AWS CDK infrastructure
+  ├── lib/constructs/        → Reusable CDK patterns
+  │   ├── security/          → IAM, secrets, roles
+  │   ├── network/           → VPC, shared networking
+  │   ├── compute/           → Lambda, ECS patterns
+  │   ├── monitoring/        → CloudWatch, ADOT
+  │   └── config/            → Environment configs
+  ├── lib/stacks/            → CDK stack definitions
+  └── database/              → RDS, migrations
+```
+
+## 🤖 AI Integration
+
+**AI SDK v6** with provider factory pattern:
+- Providers: OpenAI, Google (Gemini), Amazon Bedrock (Codex), Azure
+- Streaming: `streamText` for chat, SSE for assistant architect
+- Client: `@ai-sdk/react` with `useChat` hook
+
+**Provider Factory** (`/app/api/chat/lib/provider-factory.ts`):
+```typescript
+createProviderModel(provider: string, modelId: string): Promise<LanguageModel>
+```
+
+**Settings Management**:
+- Database-first with env fallback via `@/lib/settings-manager`
+- Cache with 5-minute TTL
+- AWS Lambda IAM role support for Bedrock
+
+## 📚 Document Processing
+
+**Supported**: PDF, DOCX, XLSX, PPTX, TXT, MD, CSV, JSON, XML, YAML (via `/lib/document-processing.ts` and `/lib/nexus/enhanced-attachment-adapters.ts`)
+**Storage**: S3 with presigned URLs for large files
+**Limits**: 500MB for Nexus attachments, 25MB for document processing (configurable per deployment)
+
+## 🗄️ Database Operations
+
+**ORM**: Drizzle ORM with postgres.js driver (direct PostgreSQL connection)
+
+**Always use Drizzle queries** - Import from `@/lib/db/drizzle` for type-safe operations:
+
+```typescript
+import { eq, and, desc } from "drizzle-orm";
+import { executeQuery, executeTransaction } from "@/lib/db/drizzle-client";
+import { users, userRoles, roles } from "@/lib/db/schema";
+
+// SELECT with type safety
+const user = await executeQuery(
+  (db) => db.select().from(users).where(eq(users.id, userId)).limit(1),
+  "getUserById"
+);
+
+// INSERT with returning
+const [newUser] = await executeQuery(
+  (db) => db.insert(users).values({ email, firstName }).returning(),
+  "createUser"
+);
+
+// UPDATE
+await executeQuery(
+  (db) => db.update(users).set({ firstName }).where(eq(users.id, userId)),
+  "updateUser"
+);
+
+// DELETE
+await executeQuery(
+  (db) => db.delete(users).where(eq(users.id, userId)),
+  "deleteUser"
+);
+```
+
+**Transactions** (automatic rollback on error):
+```typescript
+await executeTransaction(
+  async (tx) => {
+    await tx.delete(userRoles).where(eq(userRoles.userId, userId));
+    await tx.insert(userRoles).values(roleIds.map(id => ({ userId, roleId: id })));
+    // Side effects (emails, etc.) should be AFTER transaction, not inside
+  },
+  "updateUserRoles"
+);
+```
+
+**⚠️ CRITICAL - Transaction Pattern**:
+- ✅ Use `executeTransaction()` directly for multi-statement transactions
+- ✅ Transaction isolation levels are supported (serializable, repeatable read, etc.)
+- ❌ NEVER nest `db.transaction()` inside `executeQuery()`
+- See `/docs/database/drizzle-patterns.md` and `drizzle-client.ts` JSDoc
+
+**JSONB Columns** (type-safe via `.$type<T>()`):
+```typescript
+import type { UserSettings } from "@/lib/db/types/jsonb";
+
+// Schema definition
+settings: jsonb("settings").$type<UserSettings>(),
+
+// Query - TypeScript knows the shape
+user.settings.theme;  // "light" | "dark" | "system"
+```
+
+**Migrations** (see `/docs/database/drizzle-migration-guide.md`):
+```bash
+bun run drizzle:generate        # Generate from schema changes
+bun run migration:prepare       # Format for Lambda
+bun run migration:list          # List all migrations
+# Then add to migrationFiles array in /infra/database/migrations.json
+```
+
+**MCP tools for schema verification**:
+```bash
+mcp__awslabs_postgres-mcp-server__get_table_schema
+mcp__awslabs_postgres-mcp-server__run_query
+```
+
+**Aurora Serverless v2 Configuration**:
+- **Dev**: Auto-pause enabled (scales to 0 ACU when idle, saves ~$44/month)
+- **Prod**: Min 2 ACU, Max 8 ACU, always-on for reliability
+- **Connection**: postgres.js driver with connection pooling (max: 20, idle_timeout: 20s)
+- **Backups**: Automated daily snapshots, 7-day retention (dev), 30-day (prod)
+
+**Connection Management** (Issue #603):
+- Use `DATABASE_URL` for local dev (set in .env.local)
+- Use `DB_HOST/DB_USER/DB_PASSWORD` for ECS (auto-injected from Secrets Manager)
+- Connection pool auto-manages connections (max: 20 per container)
+- Graceful shutdown: Handled automatically via `instrumentation.ts`
+- Connection warmup: Pools are pre-initialized on server startup
+
+**Local Development Setup** (Issue #607):
+```bash
+# Quick Start (first time)
+bun run db:up              # Start PostgreSQL container
+bun run db:seed            # Create test users
+bun run dev:local          # Start Next.js with local DB
+
+# Daily workflow
+bun run db:up && bun run dev:local   # Start everything
+
+# Reset if database gets corrupted
+bun run db:reset           # Destroys all data, re-runs migrations
+bun run db:seed            # Re-create test users
+```
+
+**Local vs AWS Configuration**:
+| Environment | DATABASE_URL | DB_SSL |
+|-------------|--------------|--------|
+| Local Docker | `postgresql://postgres:postgres@localhost:5432/aistudio` | `false` |
+| AWS Aurora | `postgresql://user:pass@aurora-cluster:5432/aistudio` | `true` (default) |
+
+**Test Users** (after `bun run db:seed`):
+- `test@example.com` - administrator role
+- `staff@example.com` - staff role
+- `student@example.com` - student role
+
+**Raw SQL Results** (postgres.js driver):
+```typescript
+import { toPgRows, executeQuery } from "@/lib/db/drizzle-client";
+import { sql } from "drizzle-orm";
+
+// Raw SQL returns array-like object (no .rows property)
+const result = await executeQuery(
+  (db) => db.execute(sql`SELECT id, name FROM users WHERE active = true`),
+  "getActiveUsers"
+);
+const users = toPgRows<{ id: number; name: string }>(result);
+```
+
+**Troubleshooting**:
+- "Connection refused": Check VPC security groups allow traffic from ECS to Aurora
+- "Too many connections": Increase Aurora max_connections or reduce `DB_MAX_CONNECTIONS` per task
+- "SSL required": Ensure connection string includes `?sslmode=require` (auto-added by drizzle-client)
+- "Connection timeout": Check `DB_CONNECT_TIMEOUT` env var (default: 10s)
+- First request slow: Connection pool warmup happens on startup; check logs for "warmed up successfully"
+
+## 📝 Server Action Template
+
+```typescript
+"use server"
+import { createLogger, generateRequestId, startTimer, sanitizeForLogging } from "@/lib/logger"
+import { handleError, ErrorFactories, createSuccess } from "@/lib/error-utils"
+import { getServerSession } from "@/lib/auth/server-session"
+import { executeQuery } from "@/lib/db/drizzle-client"
+import { eq } from "drizzle-orm"
+import { users } from "@/lib/db/schema"
+
+export async function actionName(params: ParamsType): Promise<ActionState<ReturnType>> {
+  const requestId = generateRequestId()
+  const timer = startTimer("actionName")
+  const log = createLogger({ requestId, action: "actionName" })
+
+  try {
+    log.info("Action started", { params: sanitizeForLogging(params) })
+
+    // Auth check
+    const session = await getServerSession()
+    if (!session) {
+      log.warn("Unauthorized")
+      throw ErrorFactories.authNoSession()
+    }
+
+    // Business logic - use Drizzle ORM executeQuery
+    const result = await executeQuery(
+      (db) => db.select().from(users).where(eq(users.id, params.userId)),
+      "actionName"
+    )
+
+    timer({ status: "success" })
+    log.info("Action completed")
+    return createSuccess(result, "Success message")
+
+  } catch (error) {
+    timer({ status: "error" })
+    return handleError(error, "User-friendly error", {
+      context: "actionName",
+      requestId,
+      operation: "actionName"
+    })
+  }
+}
+```
+
+## 🧪 Testing
+
+**E2E Testing** (config: `playwright.config.ts`; `baseURL` via `PLAYWRIGHT_BASE_URL`, default `:3000`):
+- Run locally: `bunx playwright test tests/e2e/`
+- Add specs to `tests/e2e/`
+- **Two tiers**: *guard* specs run unauthenticated (CI-safe); *functional* specs mint a session and are gated by `PLAYWRIGHT_AUTH_ENABLED`. To run authenticated functional tests (drive the real UI as a logged-in user), use the host `:3100` dev server + `tests/e2e/helpers/session-auth.ts` — see **`docs/guides/e2e-authenticated-testing.md`** (covers the migration/seed prereqs and the `tokenLifetimeMs` + `addCookies` auth gotchas).
+- See `docs/guides/TESTING.md` (E2E Expectations section) for when tests are required
+
+## 🏗️ Infrastructure Patterns
+
+See [infra/AGENTS.md](infra/AGENTS.md) (auto-loads when working under `/infra`): VPC/networking, Lambda sizing, ECS Fargate, monitoring/ADOT, and cost optimization patterns.
+
+## 🔒 Security & IAM
+
+### Application Security
+- Routes under `/(protected)` require authentication
+- Role-based UI access via `hasCapabilityAccess("capability-id")` - checks if the user's roles grant a capability (see Permissions below)
+- Parameterized queries prevent SQL injection
+- All secrets in AWS Secrets Manager with automatic rotation
+- `sanitizeForLogging()` for PII protection
+
+### Permissions
+
+Two **separate** authorization systems — never collapse them. See
+`docs/architecture/capabilities-and-scopes.md` for the full split, decision
+tree, and anti-patterns.
+
+- **Capabilities** — role-gated **UI features** for logged-in humans (Nexus,
+  Assistant Architect, admin pages). Check with `hasCapabilityAccess(identifier)`
+  (`utils/roles.ts`). Backed by `capabilities` / `role_capabilities`; registry in
+  `lib/capabilities/manifest.ts`.
+- **Scopes** — permissions on **API keys** for programmatic/MCP callers (e.g.
+  `assistants:execute`, `chat:read`). Check with `requireScope(auth, scope)`
+  (`lib/api/auth-middleware.ts`). Backed by `api_keys.scopes`; defined in
+  `lib/api-keys/scopes.ts`.
+- **Don't** gate API/MCP endpoints with `hasCapabilityAccess()`, **don't** gate
+  UI features with `requireScope()`, and **don't** share an identifier across the
+  two systems.
+- Note: `hasCapabilityAccess` (user access) is unrelated to `hasCapability` in
+  `lib/ai/capability-utils.ts` (AI-model feature flags).
+
+### Infrastructure Security (IAM Least Privilege)
+**CRITICAL**: All new Lambda/ECS roles MUST use `ServiceRoleFactory` — see [infra/AGENTS.md](infra/AGENTS.md) for the pattern, tag-based access control, and secrets management.
+
+## 📦 Key Dependencies
+
+- Vercel AI SDK v6 (`ai`, `@ai-sdk/react`, `@ai-sdk/*` providers)
+- Next.js 16 App Router
+- NextAuth v5
+- AWS SDK v3 clients
+
+## 🚨 Common Pitfalls
+
+### Code Quality
+- **Don't** use `any` types - full TypeScript strict mode required
+- **Don't** use console methods - use `@/lib/logger` instead
+- **Don't** skip type checking - entire codebase must pass
+- **Don't** commit without running lint and typecheck
+
+### Git & Deployment
+- **Don't** create PRs against `main` - always use `dev`
+- **Don't** modify files 001-005 in `/infra/database/schema/` (immutable migrations)
+
+### Infrastructure
+- **Don't** create Lambda/ECS roles manually - use `ServiceRoleFactory`
+- **Don't** create resources without `Environment` and `ManagedBy` tags
+- **Don't** use `Vpc.fromVpcAttributes` - use `VPCProvider.getOrCreate()`
+- **Don't** hardcode secrets - use AWS Secrets Manager
+- **Don't** trust app code for DB schema - use MCP tools
+- **Don't** deploy infrastructure without running `bunx cdk synth` first
+
+### Security
+- **Don't** grant `resources: ['*']` in IAM policies (except where AWS requires it)
+- **Don't** allow cross-environment access (dev → prod blocked by tags)
+- **Don't** skip tag-based conditions in custom IAM policies
+- **Review** `docs/guides/auth-security-checklist.md` for any PR touching OAuth/auth flows
+
+### Silent Failures (see `docs/guides/silent-failure-patterns.md`)
+- **Don't** use `undefined` in Drizzle `.set()` for clearable fields — use `?? null`
+- **Don't** read `toolResults` from `onStepFinish` — always use `onFinish` `event.steps`
+- **Don't** mutate AI SDK tool `args` in-place — return new objects from sanitization
+- **Don't** put `session` (object) in `useEffect` deps — use `status` (primitive)
+- **Don't** create tables with `updated_at` without the PostgreSQL trigger
+- **Don't** use `{}` as an accumulator for model/user-controlled keys — use `Object.create(null)`
+- **Don't** use static tool-call format (`tool-show_chart`) with `fromThreadMessageLike` — use `type: 'tool-call'` dynamic format
+- **Don't** chain `.replace()` for HTML entity decoding — use single-pass regex (see `lib/utils/text-sanitizer.ts`)
+- **Don't** use `response.json().catch(() => fallback)` without checking `response.ok` first — hides HTTP status codes; infra errors (502/503) become indistinguishable from app errors
+- **Don't** return (without throwing) from `customFetch` after showing a toast for non-2xx responses — AI SDK will try to parse the error body as SSE and throw a `TypeError`
+- **Don't** construct SNS Subject from variable-length arrays without a 100-char truncation guard — silent publish failures with no SDK error surfaced
+- **Don't** return `null` from a DB accessor for both not-found and error in an SWR cache — cache cannot distinguish the two; DB errors silently overwrite valid cached state with defaults
+- **Don't** pass a Web API `Blob` to `@google/genai` SDK methods — the SDK expects `{ data: base64string, mimeType: string }`, not a `Blob` object
+- **Don't** assume AWS SDK assessment objects are flat — check ALL sub-properties (e.g., `wordPolicy.customWords` AND `wordPolicy.managedWordLists`); missing one drops an entire blocking category from observability
+- **Don't** omit `state: 'output-available'` and `input` on tool-call UIMessage parts — `convertToModelMessages` silently skips the `tool_result` block, causing `AI_MissingToolResultsError` on replay
+- **Don't** consolidate multi-step MCP responses into a single DB row — persist each step separately inside `executeTransaction` or reload fails with consecutive user turns (see `chat-helpers.ts:saveConversationSteps`)
+
+### React (see `docs/guides/react-patterns.md`)
+- **Don't** put `key` on Provider/context wrapper components
+- **Don't** use boolean `useRef` for init guards on parameterized routes — use ID-tracking refs
+- **Don't** place hooks after conditional returns
+- **Don't** include `isLoading` state in polling `useEffect` deps — use `useRef` to prevent timer churn
+- **Don't** rely on `clearTimeout` alone for polling cleanup — pair with a `cancelled = true` flag
+- **Don't** assign callback refs inside `useEffect` — assign synchronously in the render body to close the stale-ref timing gap
+- **Don't** return internal state getters from hooks when the caller also supplies `fn` — use `onFailure(count)` event callbacks
+- **Don't** read a ref mutated inside a hook's `.catch()` without `+1` — use `onFailure(count)` callback instead (callers see pre-mutation value)
+- **Don't** pass unstable adapter references to `useChatRuntime` — use ref-based getters with empty dep arrays to prevent runtime re-initialization and duplicate messages
+
+## 📖 Documentation
+
+**Structure:**
+```
+/docs/
+├── README.md           # Documentation index
+├── ARCHITECTURE.md     # System architecture
+├── DEPLOYMENT.md       # Deployment guide
+├── guides/            # Development guides
+├── features/          # Feature docs
+├── operations/        # Ops & monitoring
+└── archive/           # Historical docs
+```
+
+**Maintenance:**
+- Keep docs current with code changes
+- Archive completed implementations
+- Remove outdated content
+- Update index when adding docs
+
+**OpenWiki (agent wiki):** `openwiki/` is an auto-maintained, agent-navigable index of this codebase — start at [openwiki/quickstart.md](openwiki/quickstart.md) for a structured map before spelunking. It coexists with `/docs` (human-oriented). The tree is refreshed by `.github/workflows/openwiki-update.yml` on every `dev` push (opens a rolling `openwiki/update` PR, served by Bedrock GLM-5). Do not hand-edit `openwiki/`; it is regenerated.
+
+## 🎯 Repository Knowledge System
+
+**Assistant Architect**: Processes repository context for AI assistants
+**Embeddings**: Vector search via `/lib/repositories/search-service.ts`
+**Knowledge Base**: Stored in S3, retrieved during execution
+
+---
+*Token-optimized for Codex efficiency. Last updated: May 2026*
+*Infrastructure optimized via Epic #372 - AWS Well-Architected Framework aligned*

--- a/actions/settings/user-settings.actions.ts
+++ b/actions/settings/user-settings.actions.ts
@@ -28,8 +28,9 @@ import {
 } from "@/lib/db/drizzle"
 import { executeQuery } from "@/lib/db/drizzle-client"
 import { eq, sql } from "drizzle-orm"
-import { users } from "@/lib/db/schema"
-import type { UserProfile } from "@/lib/db/types/jsonb"
+import { nexusUserPreferences, users } from "@/lib/db/schema"
+import type { NexusUserSettings, UserProfile } from "@/lib/db/types/jsonb"
+import { z } from "zod"
 import {
   generateApiKey,
   revokeApiKey,
@@ -71,6 +72,101 @@ export interface CreateApiKeyInput {
   name: string
   scopes: string[]
   expiresAt?: Date
+}
+
+export interface NexusChatPreferences {
+  mode: "standard" | "advanced"
+  family: "auto" | "openai" | "anthropic" | "google"
+}
+
+const NexusChatPreferencesSchema = z.object({
+  mode: z.enum(["standard", "advanced"]),
+  family: z.enum(["auto", "openai", "anthropic", "google"]),
+})
+
+const DEFAULT_NEXUS_CHAT_PREFERENCES: NexusChatPreferences = {
+  mode: "standard",
+  family: "auto",
+}
+
+export async function getNexusChatPreferences(): Promise<ActionState<NexusChatPreferences>> {
+  const requestId = generateRequestId()
+  const timer = startTimer("getNexusChatPreferences")
+  try {
+    const session = await getServerSession()
+    if (!session) throw ErrorFactories.authNoSession()
+    const userId = await getUserIdByCognitoSubAsNumber(session.sub)
+    if (!userId) throw ErrorFactories.dbRecordNotFound("users", session.sub)
+
+    const [preference] = await executeQuery(
+      db => db.select({ settings: nexusUserPreferences.settings })
+        .from(nexusUserPreferences)
+        .where(eq(nexusUserPreferences.userId, userId))
+        .limit(1),
+      "getNexusChatPreferences"
+    )
+    const parsed = NexusChatPreferencesSchema.safeParse({
+      mode: preference?.settings?.nexusMode ?? DEFAULT_NEXUS_CHAT_PREFERENCES.mode,
+      family: preference?.settings?.preferredModelFamily ?? DEFAULT_NEXUS_CHAT_PREFERENCES.family,
+    })
+    timer({ status: "success" })
+    return createSuccess(parsed.success ? parsed.data : DEFAULT_NEXUS_CHAT_PREFERENCES)
+  } catch (error) {
+    timer({ status: "error" })
+    return handleError(error, "Failed to load Nexus preferences", {
+      context: "getNexusChatPreferences", requestId, operation: "getNexusChatPreferences",
+    })
+  }
+}
+
+export async function updateNexusChatPreferences(
+  input: NexusChatPreferences
+): Promise<ActionState<NexusChatPreferences>> {
+  const requestId = generateRequestId()
+  const timer = startTimer("updateNexusChatPreferences")
+  const log = createLogger({ requestId, action: "updateNexusChatPreferences" })
+  try {
+    const parsed = NexusChatPreferencesSchema.safeParse(input)
+    if (!parsed.success) {
+      throw ErrorFactories.validationFailed(parsed.error.issues.map(issue => ({
+        field: issue.path.join("."), message: issue.message,
+      })))
+    }
+    const session = await getServerSession()
+    if (!session) throw ErrorFactories.authNoSession()
+    const userId = await getUserIdByCognitoSubAsNumber(session.sub)
+    if (!userId) throw ErrorFactories.dbRecordNotFound("users", session.sub)
+
+    const [existing] = await executeQuery(
+      db => db.select({ settings: nexusUserPreferences.settings })
+        .from(nexusUserPreferences)
+        .where(eq(nexusUserPreferences.userId, userId))
+        .limit(1),
+      "getNexusChatPreferencesForUpdate"
+    )
+    const settings: NexusUserSettings = {
+      ...(existing?.settings ?? {}),
+      nexusMode: parsed.data.mode,
+      preferredModelFamily: parsed.data.family,
+    }
+    await executeQuery(
+      db => db.insert(nexusUserPreferences)
+        .values({ userId, settings, updatedAt: new Date() })
+        .onConflictDoUpdate({
+          target: nexusUserPreferences.userId,
+          set: { settings, updatedAt: new Date() },
+        }),
+      "updateNexusChatPreferences"
+    )
+    timer({ status: "success" })
+    log.info("Nexus chat preferences updated", { userId, ...parsed.data })
+    return createSuccess(parsed.data)
+  } catch (error) {
+    timer({ status: "error" })
+    return handleError(error, "Failed to update Nexus preferences", {
+      context: "updateNexusChatPreferences", requestId, operation: "updateNexusChatPreferences",
+    })
+  }
 }
 
 // ============================================

--- a/app/(protected)/admin/settings/_components/settings-client.test.tsx
+++ b/app/(protected)/admin/settings/_components/settings-client.test.tsx
@@ -254,6 +254,7 @@ jest.mock('react-hook-form', () => {
       }),
       formState: { errors: {} }
     }),
+    useWatch: ({ name }: { name: string }) => globalFormData[name],
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     Controller: ({ render }: any) => render({ field: { onChange: jest.fn(), value: '' } })
   }

--- a/app/(protected)/admin/settings/_components/settings-form.tsx
+++ b/app/(protected)/admin/settings/_components/settings-form.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { useEffect, useState, startTransition } from "react"
-import { useForm } from "react-hook-form"
+import { useForm, useWatch } from "react-hook-form"
 import { zodResolver } from "@hookform/resolvers/zod"
 import * as z from "zod"
 import {
@@ -69,6 +69,8 @@ const commonSettings = [
   { key: "GOOGLE_API_KEY", category: "ai_providers", description: "Google AI API key for Gemini models", isSecret: true },
   { key: "OPENAI_API_KEY", category: "ai_providers", description: "OpenAI API key for GPT models", isSecret: true },
   { key: "LATIMER_API_KEY", category: "ai_providers", description: "Latimer.ai API key", isSecret: true },
+  { key: "NEXUS_ROUTER_MODE", category: "ai", description: "Nexus model router mode: active, shadow, or off", isSecret: false },
+  { key: "NEXUS_ROUTER_CONFIG_V1", category: "ai", description: "JSON configuration for Nexus classifier, family/tier candidates, and image/PSD-data specialists", isSecret: false },
   { key: "S3_BUCKET", category: "storage", description: "AWS S3 bucket name for document storage", isSecret: false },
   { key: "AWS_REGION", category: "storage", description: "AWS region for S3 operations", isSecret: false },
   { key: "GITHUB_ISSUE_TOKEN", category: "external_services", description: "GitHub personal access token for creating issues", isSecret: true },
@@ -97,6 +99,7 @@ export function SettingsForm({ open, onOpenChange, onSave, setting }: SettingsFo
       isSecret: false
     }
   })
+  const selectedKey = useWatch({ control: form.control, name: "key" })
 
   useEffect(() => {
     if (!open) {
@@ -233,8 +236,8 @@ export function SettingsForm({ open, onOpenChange, onSave, setting }: SettingsFo
                           ? "Enter new value (leave empty to keep current value)" 
                           : "Enter the setting value"
                       }
-                      className="font-mono resize-none"
-                      rows={3}
+                      className="font-mono resize-y"
+                      rows={selectedKey === "NEXUS_ROUTER_CONFIG_V1" ? 14 : 3}
                     />
                   </FormControl>
                   <FormDescription>

--- a/app/(protected)/nexus/_components/chat/composer-controls.tsx
+++ b/app/(protected)/nexus/_components/chat/composer-controls.tsx
@@ -1,17 +1,19 @@
 'use client'
 
-import { ModelSelectorCompact } from './model-selector-compact'
+import { ModelFamilySelector } from './model-family-selector'
 import { ToolsPopover } from './tools-popover'
 import { SkillsPopover } from './skills-popover'
 import { MCPPopover } from './mcp-popover'
 import type { SelectAiModel } from '@/types'
+import type { NexusExperienceMode, NexusModelFamily } from '@/lib/nexus/model-router/types'
 
 interface ComposerControlsProps {
   // Model selection
-  models: SelectAiModel[]
   selectedModel: SelectAiModel | null
-  onModelChange: (model: SelectAiModel) => void
-  isLoadingModels?: boolean
+  routingMode: NexusExperienceMode
+  modelFamily: NexusModelFamily
+  onRoutingModeChange: (mode: NexusExperienceMode) => void
+  onModelFamilyChange: (family: NexusModelFamily) => void
   // Tool selection
   enabledTools: string[]
   onToolsChange: (tools: string[]) => void
@@ -27,10 +29,11 @@ interface ComposerControlsProps {
  * Positioned above the input area like Claude.ai.
  */
 export function ComposerControls({
-  models,
   selectedModel,
-  onModelChange,
-  isLoadingModels = false,
+  routingMode,
+  modelFamily,
+  onRoutingModeChange,
+  onModelFamilyChange,
   enabledTools,
   onToolsChange,
   enabledConnectors = [],
@@ -39,34 +42,26 @@ export function ComposerControls({
 }: ComposerControlsProps) {
   return (
     <div className="flex items-center gap-1 px-2 py-1.5 border-b border-border/50">
-      {/* Model Selector */}
-      <ModelSelectorCompact
-        models={models}
-        selectedModel={selectedModel}
-        onModelChange={onModelChange}
-        isLoading={isLoadingModels}
+      <ModelFamilySelector
+        mode={routingMode}
+        family={modelFamily}
+        onModeChange={onRoutingModeChange}
+        onFamilyChange={onModelFamilyChange}
       />
 
-      {/* Separator */}
-      <div className="h-4 w-px bg-border mx-1" />
-
-      {/* Tools */}
-      <ToolsPopover
-        selectedModel={selectedModel}
-        enabledTools={enabledTools}
-        onToolsChange={onToolsChange}
-      />
-
-      {/* Skills (placeholder) */}
-      <SkillsPopover disabled />
-
-      {/* MCP Connections */}
-      <MCPPopover
-        enabledConnectors={enabledConnectors}
-        onConnectorsChange={onConnectorsChange ?? (() => undefined)}
-        disabled={!onConnectorsChange || !selectedModel}
-        onReconnectSuccess={onReconnectSuccess}
-      />
+      {routingMode === 'advanced' && (
+        <>
+          <div className="h-4 w-px bg-border mx-1" />
+          <ToolsPopover selectedModel={selectedModel} enabledTools={enabledTools} onToolsChange={onToolsChange} />
+          <SkillsPopover disabled />
+          <MCPPopover
+            enabledConnectors={enabledConnectors}
+            onConnectorsChange={onConnectorsChange ?? (() => undefined)}
+            disabled={!onConnectorsChange || !selectedModel}
+            onReconnectSuccess={onReconnectSuccess}
+          />
+        </>
+      )}
     </div>
   )
 }

--- a/app/(protected)/nexus/_components/chat/mcp-popover.tsx
+++ b/app/(protected)/nexus/_components/chat/mcp-popover.tsx
@@ -262,6 +262,7 @@ export function MCPPopover({
     <Popover open={open} onOpenChange={setOpen}>
       <PopoverTrigger asChild>
         <Button
+          data-testid="nexus-mcp-control"
           variant="ghost"
           size="sm"
           className={cn(

--- a/app/(protected)/nexus/_components/chat/model-family-selector.tsx
+++ b/app/(protected)/nexus/_components/chat/model-family-selector.tsx
@@ -1,0 +1,74 @@
+"use client"
+
+import { useState } from "react"
+import { Bot, Check, ChevronDown, SlidersHorizontal } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
+import { cn } from "@/lib/utils"
+import type { NexusExperienceMode, NexusModelFamily } from "@/lib/nexus/model-router/types"
+
+const FAMILY_OPTIONS: Array<{ value: NexusModelFamily; label: string; description: string }> = [
+  { value: "auto", label: "Auto", description: "Let Nexus choose the best model family" },
+  { value: "openai", label: "ChatGPT", description: "Route within the OpenAI family" },
+  { value: "anthropic", label: "Claude", description: "Route within the Claude family" },
+  { value: "google", label: "Gemini", description: "Route within the Gemini family" },
+]
+
+export function ModelFamilySelector({
+  mode,
+  family,
+  onModeChange,
+  onFamilyChange,
+}: {
+  mode: NexusExperienceMode
+  family: NexusModelFamily
+  onModeChange: (mode: NexusExperienceMode) => void
+  onFamilyChange: (family: NexusModelFamily) => void
+}) {
+  const [open, setOpen] = useState(false)
+  const selectedLabel = FAMILY_OPTIONS.find(option => option.value === family)?.label ?? "Auto"
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button variant="ghost" size="sm" className="h-8 gap-1.5 text-xs" aria-label="Nexus routing mode">
+          {mode === "standard" ? <SlidersHorizontal className="h-3.5 w-3.5" /> : <Bot className="h-3.5 w-3.5" />}
+          <span>{mode === "standard" ? "Standard" : selectedLabel}</span>
+          <ChevronDown className="h-3 w-3 opacity-50" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-72 p-2" align="start">
+        <div className="mb-2 px-2 py-1">
+          <p className="text-sm font-medium">Nexus routing</p>
+          <p className="text-xs text-muted-foreground">Standard chooses automatically. Advanced lets you constrain the model family.</p>
+        </div>
+        <button
+          type="button"
+          data-testid="nexus-mode-standard"
+          className={cn("w-full rounded-md px-2 py-2 text-left hover:bg-muted", mode === "standard" && "bg-muted")}
+          onClick={() => { onModeChange("standard"); setOpen(false) }}
+        >
+          <span className="flex items-center justify-between text-sm font-medium">Standard {mode === "standard" && <Check className="h-4 w-4" />}</span>
+          <span className="text-xs text-muted-foreground">No model or tool decisions needed</span>
+        </button>
+        <div className="my-2 border-t" />
+        <p className="px-2 pb-1 text-xs font-medium text-muted-foreground">Advanced family</p>
+        {FAMILY_OPTIONS.map(option => (
+          <button
+            type="button"
+            key={option.value}
+            data-testid={`nexus-family-${option.value}`}
+            className={cn("w-full rounded-md px-2 py-2 text-left hover:bg-muted", mode === "advanced" && family === option.value && "bg-muted")}
+            onClick={() => { onFamilyChange(option.value); setOpen(false) }}
+          >
+            <span className="flex items-center justify-between text-sm font-medium">
+              {option.label}
+              {mode === "advanced" && family === option.value && <Check className="h-4 w-4" />}
+            </span>
+            <span className="text-xs text-muted-foreground">{option.description}</span>
+          </button>
+        ))}
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/app/(protected)/nexus/_components/chat/skills-popover.tsx
+++ b/app/(protected)/nexus/_components/chat/skills-popover.tsx
@@ -22,6 +22,7 @@ export function SkillsPopover({ disabled = true }: SkillsPopoverProps) {
     <Popover>
       <PopoverTrigger asChild>
         <Button
+          data-testid="nexus-skills-control"
           variant="ghost"
           size="sm"
           className="h-8 gap-1.5 text-xs"

--- a/app/(protected)/nexus/_components/chat/tools-popover.tsx
+++ b/app/(protected)/nexus/_components/chat/tools-popover.tsx
@@ -159,6 +159,7 @@ export function ToolsPopover({
     <Popover open={open} onOpenChange={setOpen}>
       <PopoverTrigger asChild>
         <Button
+          data-testid="nexus-tools-control"
           variant="ghost"
           size="sm"
           className={cn(

--- a/app/(protected)/nexus/page.tsx
+++ b/app/(protected)/nexus/page.tsx
@@ -32,6 +32,8 @@ import { VoiceModeOverlay } from './_components/voice-mode/voice-mode-overlay'
 import { VoiceButton, DisabledVoiceButton } from './_components/voice-mode/voice-button'
 import { useVoiceAvailability } from './_components/voice-mode/use-voice-availability'
 import { useVoiceSession } from './_components/voice-mode/use-voice-session'
+import { getNexusChatPreferences, updateNexusChatPreferences } from '@/actions/settings/user-settings.actions'
+import type { NexusExperienceMode, NexusModelFamily } from '@/lib/nexus/model-router/types'
 
 const log = createLogger({ moduleName: 'nexus-page' })
 const uuidSchema = z.string().uuid()
@@ -67,6 +69,8 @@ interface ConversationRuntimeProviderProps {
   selectedModel: SelectAiModel | null
   enabledTools: string[]
   enabledConnectors: string[]
+  routingMode: NexusExperienceMode
+  modelFamily: NexusModelFamily
   skillId?: string
   /** The open workspace object id/slug (`?workspace=`); binds §1087 content tools server-side. */
   workspaceId?: string
@@ -89,6 +93,8 @@ function ConversationRuntimeProvider({
   selectedModel,
   enabledTools,
   enabledConnectors,
+  routingMode,
+  modelFamily,
   skillId,
   workspaceId,
   attachmentAdapter,
@@ -123,6 +129,11 @@ function ConversationRuntimeProvider({
   // Guards against the transient null state while models are loading from localStorage.
   const selectedModelRef = useRef(selectedModel)
   selectedModelRef.current = selectedModel
+
+  const routingModeRef = useRef(routingMode)
+  routingModeRef.current = routingMode
+  const modelFamilyRef = useRef(modelFamily)
+  modelFamilyRef.current = modelFamily
 
   // Prevents the "Model not ready" toast from firing multiple times if body()
   // is called in rapid succession before models finish loading.
@@ -335,7 +346,9 @@ function ConversationRuntimeProvider({
           skillId,
           // Bind the open workspace object so the server offers §1087 read/edit tools.
           workspaceId: workspaceIdRef.current || undefined,
-          conversationId: conversationIdRef.current || undefined
+          conversationId: conversationIdRef.current || undefined,
+          nexusMode: routingModeRef.current,
+          modelFamily: routingModeRef.current === 'standard' ? 'auto' : modelFamilyRef.current,
         }
       }
     }),
@@ -364,6 +377,10 @@ interface NexusRuntimeWrapperProps {
   selectedModel: SelectAiModel | null
   enabledTools: string[]
   enabledConnectors: string[]
+  routingMode: NexusExperienceMode
+  modelFamily: NexusModelFamily
+  onRoutingModeChange: (mode: NexusExperienceMode) => void
+  onModelFamilyChange: (family: NexusModelFamily) => void
   skillId?: string
   /** Open workspace object id/slug (`?workspace=`); passed to the runtime for §1087 tools. */
   workspaceId?: string
@@ -373,9 +390,7 @@ interface NexusRuntimeWrapperProps {
   initialMessages: UIMessage[]
   onConversationIdChange: (id: string) => void
   processingAttachments: Set<string>
-  models: SelectAiModel[]
   onModelChange: (model: SelectAiModel) => void
-  isLoadingModels: boolean
   onToolsChange: (tools: string[]) => void
   onConnectorsChange: (connectors: string[]) => void
 }
@@ -385,6 +400,10 @@ function NexusRuntimeWrapper({
   selectedModel,
   enabledTools,
   enabledConnectors,
+  routingMode,
+  modelFamily,
+  onRoutingModeChange,
+  onModelFamilyChange,
   skillId,
   workspaceId,
   attachmentAdapter,
@@ -393,9 +412,7 @@ function NexusRuntimeWrapper({
   initialMessages,
   onConversationIdChange,
   processingAttachments,
-  models,
   onModelChange,
-  isLoadingModels,
   onToolsChange,
   onConnectorsChange,
 }: NexusRuntimeWrapperProps) {
@@ -466,6 +483,8 @@ function NexusRuntimeWrapper({
       selectedModel={selectedModel}
       enabledTools={enabledTools}
       enabledConnectors={enabledConnectors}
+      routingMode={routingMode}
+      modelFamily={modelFamily}
       skillId={skillId}
       workspaceId={workspaceId}
       attachmentAdapter={attachmentAdapter}
@@ -495,15 +514,17 @@ function NexusRuntimeWrapper({
         <Thread
           processingAttachments={processingAttachments}
           conversationId={conversationId}
-          models={models}
           selectedModel={selectedModel}
           onModelChange={onModelChange}
-          isLoadingModels={isLoadingModels}
           enabledTools={enabledTools}
           onToolsChange={onToolsChange}
           enabledConnectors={enabledConnectors}
           onConnectorsChange={onConnectorsChange}
           onReconnectSuccess={removeFailedServerId}
+          routingMode={routingMode}
+          modelFamily={modelFamily}
+          onRoutingModeChange={onRoutingModeChange}
+          onModelFamilyChange={onModelFamilyChange}
           toolFallback={ConnectorToolFallback}
           composerExtraActions={composerExtraActions}
         />
@@ -592,7 +613,6 @@ function NexusPageContent() {
     models,
     selectedModel,
     setSelectedModel: originalSetSelectedModel,
-    isLoading: isLoadingModels
   } = useModelsWithPersistence('nexus-model', ['chat'], preferredModelId)
 
   // Tool management state — single source of truth from urlTools
@@ -600,6 +620,56 @@ function NexusPageContent() {
 
   // Connector management state — single source of truth from urlConnectors
   const [enabledConnectors, setEnabledConnectors] = useState<string[]>(() => urlConnectors)
+
+  const [routingMode, setRoutingMode] = useState<NexusExperienceMode>('standard')
+  const [modelFamily, setModelFamily] = useState<NexusModelFamily>('auto')
+  const routingPreferenceTouchedRef = useRef(false)
+  const routerPreferenceSaveQueueRef = useRef<Promise<void>>(Promise.resolve())
+
+  useEffect(() => {
+    let cancelled = false
+    getNexusChatPreferences().then(result => {
+      if (cancelled || routingPreferenceTouchedRef.current || !result.isSuccess) return
+      setRoutingMode(result.data.mode)
+      setModelFamily(result.data.family)
+    }).catch(error => {
+      log.warn('Failed to load Nexus router preferences', {
+        error: error instanceof Error ? error.message : String(error),
+      })
+    })
+    return () => { cancelled = true }
+  }, [])
+
+  const persistRouterPreferences = useCallback((mode: NexusExperienceMode, family: NexusModelFamily) => {
+    routerPreferenceSaveQueueRef.current = routerPreferenceSaveQueueRef.current.then(async () => {
+      try {
+        const result = await updateNexusChatPreferences({ mode, family })
+        if (!result.isSuccess) toast.error('Could not save Nexus routing preference')
+      } catch (error) {
+        log.warn('Failed to save Nexus router preferences', {
+          error: error instanceof Error ? error.message : String(error),
+        })
+        toast.error('Could not save Nexus routing preference')
+      }
+    })
+  }, [])
+
+  const handleRoutingModeChange = useCallback((mode: NexusExperienceMode) => {
+    routingPreferenceTouchedRef.current = true
+    setRoutingMode(mode)
+    if (mode === 'standard') {
+      setEnabledTools([])
+      setEnabledConnectors([])
+    }
+    persistRouterPreferences(mode, modelFamily)
+  }, [modelFamily, persistRouterPreferences])
+
+  const handleModelFamilyChange = useCallback((family: NexusModelFamily) => {
+    routingPreferenceTouchedRef.current = true
+    setRoutingMode('advanced')
+    setModelFamily(family)
+    persistRouterPreferences('advanced', family)
+  }, [persistRouterPreferences])
 
   // Load prompt settings when promptId is present (lower priority than URL params)
   // Uses getPromptSettings to avoid incrementing view count (PromptAutoLoader handles the full view)
@@ -858,6 +928,10 @@ function NexusPageContent() {
                           selectedModel={selectedModel}
                           enabledTools={enabledTools}
                           enabledConnectors={enabledConnectors}
+                          routingMode={routingMode}
+                          modelFamily={modelFamily}
+                          onRoutingModeChange={handleRoutingModeChange}
+                          onModelFamilyChange={handleModelFamilyChange}
                           skillId={urlSkillId}
                           workspaceId={urlWorkspaceId ?? undefined}
                           attachmentAdapter={attachmentAdapter}
@@ -866,9 +940,7 @@ function NexusPageContent() {
                           initialMessages={initialMessages}
                           onConversationIdChange={handleConversationIdChange}
                           processingAttachments={processingAttachments}
-                          models={models}
                           onModelChange={setSelectedModel}
-                          isLoadingModels={isLoadingModels}
                           onToolsChange={onToolsChange}
                           onConnectorsChange={onConnectorsChange}
                         />

--- a/app/(protected)/settings/_components/preferences-tab.tsx
+++ b/app/(protected)/settings/_components/preferences-tab.tsx
@@ -1,34 +1,83 @@
 "use client"
 
-import { Settings2 } from "lucide-react"
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card"
+import { useState } from "react"
+import { Check, Sparkles } from "lucide-react"
+import { toast } from "sonner"
+import { updateNexusChatPreferences, type NexusChatPreferences } from "@/actions/settings/user-settings.actions"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { cn } from "@/lib/utils"
 
-export function PreferencesTab() {
+const FAMILIES: Array<{ value: NexusChatPreferences["family"]; label: string }> = [
+  { value: "auto", label: "Auto" },
+  { value: "openai", label: "ChatGPT" },
+  { value: "anthropic", label: "Claude" },
+  { value: "google", label: "Gemini" },
+]
+
+export function PreferencesTab({ initialPreferences }: { initialPreferences: NexusChatPreferences }) {
+  const [preferences, setPreferences] = useState(initialPreferences)
+  const [saving, setSaving] = useState(false)
+
+  const save = async () => {
+    setSaving(true)
+    try {
+      const result = await updateNexusChatPreferences(preferences)
+      if (!result.isSuccess) throw new Error(result.message)
+      toast.success("Nexus preferences saved")
+    } catch {
+      toast.error("Could not save Nexus preferences")
+    } finally {
+      setSaving(false)
+    }
+  }
+
   return (
     <Card>
       <CardHeader>
-        <CardTitle>Preferences</CardTitle>
-        <CardDescription>
-          Customize your AI Studio experience.
-        </CardDescription>
+        <CardTitle className="flex items-center gap-2"><Sparkles className="h-5 w-5" />Nexus chat</CardTitle>
+        <CardDescription>Let Nexus choose automatically, or constrain routing to a model family.</CardDescription>
       </CardHeader>
-      <CardContent>
-        <div className="flex flex-col items-center justify-center py-12 text-center">
-          <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-muted">
-            <Settings2 className="h-6 w-6 text-muted-foreground" />
-          </div>
-          <h3 className="font-semibold">Coming Soon</h3>
-          <p className="mt-1 max-w-sm text-sm text-muted-foreground">
-            Preference settings like theme, notification preferences, and
-            default AI model selection will be available here in a future update.
-          </p>
+      <CardContent className="space-y-5">
+        <div className="grid gap-3 sm:grid-cols-2">
+          {(["standard", "advanced"] as const).map(mode => (
+            <button
+              key={mode}
+              type="button"
+              data-testid={`nexus-preference-${mode}`}
+              className={cn("rounded-lg border p-4 text-left", preferences.mode === mode && "border-primary bg-primary/5")}
+              onClick={() => setPreferences(current => ({ ...current, mode }))}
+            >
+              <span className="flex items-center justify-between font-medium capitalize">
+                {mode}{preferences.mode === mode && <Check className="h-4 w-4" />}
+              </span>
+              <span className="mt-1 block text-sm text-muted-foreground">
+                {mode === "standard" ? "Nexus chooses the model and tools for you." : "Choose a family; Nexus still chooses the right power level."}
+              </span>
+            </button>
+          ))}
         </div>
+
+        {preferences.mode === "advanced" && (
+          <div>
+            <p className="mb-2 text-sm font-medium">Preferred model family</p>
+            <div className="flex flex-wrap gap-2">
+              {FAMILIES.map(option => (
+                <Button
+                  type="button"
+                  key={option.value}
+                  data-testid={`nexus-preference-family-${option.value}`}
+                  variant={preferences.family === option.value ? "default" : "outline"}
+                  onClick={() => setPreferences(current => ({ ...current, family: option.value }))}
+                >
+                  {option.label}
+                </Button>
+              ))}
+            </div>
+          </div>
+        )}
+
+        <Button data-testid="nexus-preference-save" type="button" onClick={save} disabled={saving}>{saving ? "Saving…" : "Save preferences"}</Button>
       </CardContent>
     </Card>
   )

--- a/app/(protected)/settings/_components/settings-client.tsx
+++ b/app/(protected)/settings/_components/settings-client.tsx
@@ -4,15 +4,16 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { ProfileTab } from "./profile-tab"
 import { ApiKeysTab } from "./api-keys-tab"
 import { PreferencesTab } from "./preferences-tab"
-import type { UserProfileData } from "@/actions/settings/user-settings.actions"
+import type { NexusChatPreferences, UserProfileData } from "@/actions/settings/user-settings.actions"
 import type { ApiKeyInfo } from "@/lib/api-keys/key-service"
 
 interface SettingsClientProps {
   profileData: UserProfileData | null
   apiKeys: ApiKeyInfo[]
+  nexusPreferences: NexusChatPreferences
 }
 
-export function SettingsClient({ profileData, apiKeys }: SettingsClientProps) {
+export function SettingsClient({ profileData, apiKeys, nexusPreferences }: SettingsClientProps) {
   return (
     <Tabs defaultValue="profile" className="w-full">
       <TabsList className="grid w-full grid-cols-3">
@@ -33,7 +34,7 @@ export function SettingsClient({ profileData, apiKeys }: SettingsClientProps) {
       </TabsContent>
 
       <TabsContent value="preferences" className="mt-6">
-        <PreferencesTab />
+        <PreferencesTab initialPreferences={nexusPreferences} />
       </TabsContent>
     </Tabs>
   )

--- a/app/(protected)/settings/page.tsx
+++ b/app/(protected)/settings/page.tsx
@@ -1,4 +1,4 @@
-import { getUserProfile, listUserApiKeys } from "@/actions/settings/user-settings.actions"
+import { getNexusChatPreferences, getUserProfile, listUserApiKeys } from "@/actions/settings/user-settings.actions"
 import { PageBranding } from "@/components/ui/page-branding"
 import { SettingsClient } from "./_components/settings-client"
 
@@ -7,9 +7,10 @@ export const metadata = {
 }
 
 export default async function SettingsPage() {
-  const [profileResult, keysResult] = await Promise.all([
+  const [profileResult, keysResult, preferencesResult] = await Promise.all([
     getUserProfile(),
     listUserApiKeys(),
+    getNexusChatPreferences(),
   ])
 
   return (
@@ -25,6 +26,7 @@ export default async function SettingsPage() {
       <SettingsClient
         profileData={profileResult.isSuccess ? profileResult.data : null}
         apiKeys={keysResult.isSuccess ? keysResult.data : []}
+        nexusPreferences={preferencesResult.isSuccess ? preferencesResult.data : { mode: "standard", family: "auto" }}
       />
     </div>
   )

--- a/app/api/agent/workspace-token/route.ts
+++ b/app/api/agent/workspace-token/route.ts
@@ -51,37 +51,16 @@ import { SAFE_EMAIL_RE } from "@/lib/agent-workspace/validation"
 import { validateInternalSecret } from "@/lib/agent-workspace/internal-auth"
 import { mintAgentWorkspaceTokenViaBoundary } from "@/lib/agent-workspace/mint-client"
 import {
+  checkAgentWorkspaceTokenRateLimit,
+  getAgentWorkspaceTokenRateLimit,
+} from "@/lib/agent-workspace/token-rate-limit"
+import {
   AccountNotProvisionedError,
   BrokerNotConfiguredError,
   InvalidOwnerError,
 } from "@/lib/agent-workspace/dwd-token-broker"
 
 const log = createLogger({ module: "agent-workspace-token" })
-
-/**
- * Per-owner mint rate limit (defense-in-depth behind the shared secret). The
- * cap is generous — a token lasts ~1h and the skill caches it within that
- * window, so legitimate minting is roughly hourly per owner. Fixed 1h window.
- *
- * NOTE: in-memory per-task (ECS runs multiple tasks) — the same non-atomic,
- * best-effort tradeoff consent-link documents. This bounds abuse of a single
- * task, not the fleet; a fleet-wide guard would need shared state (Redis/DB).
- */
-const RATE_LIMIT_PER_HOUR = Number(process.env.AGENT_WORKSPACE_TOKEN_RATE_LIMIT) || 120
-const RATE_WINDOW_MS = 60 * 60 * 1000
-const _mintWindow = new Map<string, { count: number; windowStart: number }>()
-
-function checkRateLimit(ownerEmail: string): boolean {
-  const now = Date.now()
-  const entry = _mintWindow.get(ownerEmail)
-  if (!entry || now - entry.windowStart >= RATE_WINDOW_MS) {
-    _mintWindow.set(ownerEmail, { count: 1, windowStart: now })
-    return true
-  }
-  if (entry.count >= RATE_LIMIT_PER_HOUR) return false
-  entry.count += 1
-  return true
-}
 
 export async function POST(request: NextRequest) {
   const requestId = generateRequestId()
@@ -113,10 +92,11 @@ export async function POST(request: NextRequest) {
   // rate limit, since Google treats both as the same mailbox (claude review).
   const ownerEmail = rawOwnerEmail.toLowerCase()
 
-  if (!checkRateLimit(ownerEmail)) {
+  if (!checkAgentWorkspaceTokenRateLimit(ownerEmail)) {
+    const rateLimit = getAgentWorkspaceTokenRateLimit()
     log.warn("Workspace-token rate limit exceeded", sanitizeForLogging({ ownerEmail, requestId }))
     return NextResponse.json(
-      { error: `Rate limit exceeded — max ${RATE_LIMIT_PER_HOUR} tokens per hour per user` },
+      { error: `Rate limit exceeded — max ${rateLimit} tokens per hour per user` },
       { status: 429, headers: { "Retry-After": "3600" } }
     )
   }
@@ -157,9 +137,4 @@ export async function POST(request: NextRequest) {
       { status: 502 }
     )
   }
-}
-
-/** Test-only: clear the in-memory rate-limit window between tests. */
-export function __resetRateLimitForTests(): void {
-  _mintWindow.clear()
 }

--- a/app/api/connectors/oauth/authorize/route.ts
+++ b/app/api/connectors/oauth/authorize/route.ts
@@ -28,19 +28,9 @@ import { nexusMcpServers } from "@/lib/db/schema"
 import { requireUserAccess, loadOAuthCredentials, rejectUnsafeMcpUrl } from "@/lib/mcp/connector-service"
 import { encryptToken } from "@/lib/crypto/token-encryption"
 import { getIssuerUrl } from "@/lib/oauth/issuer-config"
+import { getOAuthStateCookieName } from "@/lib/mcp/oauth-state"
 
 const log = createLogger({ action: "oauth-authorize" })
-
-/**
- * Builds a per-server cookie name for the encrypted PKCE state.
- * Using a per-server suffix allows concurrent OAuth flows for different
- * connectors without one overwriting the other's cookie.
- */
-export function getOAuthStateCookieName(serverId: string): string {
-  // Full UUID avoids collisions when only later segments differ.
-  // Dashes are valid in cookie names per RFC 6265.
-  return `mcp_oauth_state_${serverId}`
-}
 
 /** Max age for the state cookie (5 minutes — generous window for popup flow) */
 const STATE_COOKIE_MAX_AGE = 300

--- a/app/api/connectors/oauth/callback/route.ts
+++ b/app/api/connectors/oauth/callback/route.ts
@@ -29,7 +29,7 @@ import { nexusMcpServers, nexusMcpUserTokens } from "@/lib/db/schema"
 import { loadOAuthCredentials, rejectUnsafeMcpUrl } from "@/lib/mcp/connector-service"
 import { encryptToken, decryptToken } from "@/lib/crypto/token-encryption"
 import { getIssuerUrl } from "@/lib/oauth/issuer-config"
-import { getOAuthStateCookieName } from "../authorize/route"
+import { getOAuthStateCookieName } from "@/lib/mcp/oauth-state"
 
 const log = createLogger({ action: "oauth-callback" })
 

--- a/app/api/nexus/chat/chat-helpers.ts
+++ b/app/api/nexus/chat/chat-helpers.ts
@@ -368,8 +368,9 @@ export async function saveAssistantMessage(params: {
   finishReason?: string;
   toolCalls?: ToolCallData[];
   dbModelId: number;
+  metadata?: Record<string, unknown>;
 }): Promise<void> {
-  const { conversationId, text, usage, finishReason, toolCalls, dbModelId } = params;
+  const { conversationId, text, usage, finishReason, toolCalls, dbModelId, metadata = {} } = params;
 
   if (!hasMessageContent(text, toolCalls)) {
     log.warn('No text or tool calls to save for assistant message');
@@ -402,7 +403,7 @@ export async function saveAssistantMessage(params: {
         modelId: dbModelId,
         tokenUsage: sql`${safeJsonbStringify(tokenUsage)}::jsonb`,
         finishReason: finishReason || 'stop',
-        metadata: sql`${safeJsonbStringify({})}::jsonb`,
+        metadata: sql`${safeJsonbStringify(metadata)}::jsonb`,
         createdAt: now,
         updatedAt: now
       });
@@ -442,8 +443,9 @@ export async function saveConversationSteps(params: {
   dbModelId: number;
   usage?: { promptTokens?: number; completionTokens?: number; totalTokens?: number };
   finishReason?: string;
+  metadata?: Record<string, unknown>;
 }): Promise<void> {
-  const { conversationId, steps, dbModelId, usage, finishReason } = params;
+  const { conversationId, steps, dbModelId, usage, finishReason, metadata = {} } = params;
 
   // Build all row data before opening a transaction (pure computation)
   type RowData = {
@@ -499,7 +501,7 @@ export async function saveConversationSteps(params: {
         // conversation level in the stats update below.
         tokenUsage: sql`${safeJsonbStringify({ promptTokens: 0, completionTokens: 0, totalTokens: 0 })}::jsonb`,
         finishReason: row.stepFinishReason,
-        metadata: sql`${safeJsonbStringify({})}::jsonb`,
+        metadata: sql`${safeJsonbStringify({ ...metadata, routerStepIndex: row.stepIndex })}::jsonb`,
         createdAt,
         updatedAt: baseTime,
       });

--- a/app/api/nexus/chat/image-generation-handler.ts
+++ b/app/api/nexus/chat/image-generation-handler.ts
@@ -479,7 +479,8 @@ async function handleFilePart(
  * Get previous generated images from conversation
  */
 export async function getPreviousGeneratedImages(
-  conversationId: string
+  conversationId: string,
+  userId: number
 ): Promise<ReferenceImage[]> {
   const referenceImages: ReferenceImage[] = [];
 
@@ -487,10 +488,15 @@ export async function getPreviousGeneratedImages(
     (db) => db
       .select({ parts: nexusMessages.parts })
       .from(nexusMessages)
+      .innerJoin(
+        nexusConversations,
+        eq(nexusMessages.conversationId, nexusConversations.id)
+      )
       .where(
         and(
           eq(nexusMessages.conversationId, conversationId),
-          eq(nexusMessages.role, 'assistant')
+          eq(nexusMessages.role, 'assistant'),
+          eq(nexusConversations.userId, userId)
         )
       )
       .orderBy(desc(nexusMessages.createdAt))
@@ -519,6 +525,45 @@ export async function getPreviousGeneratedImages(
   }
 
   return referenceImages;
+}
+
+/**
+ * Determine whether routing can safely treat the current request as having image
+ * context. Persisted history is scoped to the authenticated owner because routing
+ * runs before the normal conversation ownership check.
+ */
+export async function getImageRoutingContext(params: {
+  messages: ImageGenerationParams['messages'];
+  conversationId?: string;
+  userId: number;
+}): Promise<{ hasImageInput: boolean; hasPreviousGeneratedImage: boolean }> {
+  const lastUserMessage = [...params.messages].reverse().find(message => message.role === 'user');
+  const hasImageInput = lastUserMessage?.parts?.some(part => {
+    const mimeType = part.mimeType ?? part.mediaType;
+    return part.type === 'image'
+      || (part.type === 'file' && typeof mimeType === 'string' && mimeType.startsWith('image/'));
+  }) ?? false;
+
+  if (hasImageInput || !params.conversationId) {
+    return { hasImageInput, hasPreviousGeneratedImage: false };
+  }
+
+  try {
+    const previousImages = await getPreviousGeneratedImages(params.conversationId, params.userId);
+    return {
+      hasImageInput: false,
+      hasPreviousGeneratedImage: previousImages.length > 0,
+    };
+  } catch (error) {
+    // Prior-image context improves routing but is not required for an ordinary
+    // chat request. Degrade to no context instead of turning a lookup failure
+    // into a pre-stream 500.
+    log.warn('Could not load previous image context for routing', {
+      conversationId: params.conversationId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return { hasImageInput: false, hasPreviousGeneratedImage: false };
+  }
 }
 
 /**

--- a/app/api/nexus/chat/image-generation-handler.ts
+++ b/app/api/nexus/chat/image-generation-handler.ts
@@ -222,8 +222,9 @@ export async function persistImageExchange(params: {
     estimatedCost?: number;
   };
   dbModelId: number;
+  routingMetadata?: Record<string, unknown>;
 }): Promise<void> {
-  const { conversationId, imagePrompt, imageResult, dbModelId } = params;
+  const { conversationId, imagePrompt, imageResult, dbModelId, routingMetadata = {} } = params;
 
   // Build assistant parts/content outside the transaction (pure computation).
   const messageParts: Array<{
@@ -275,7 +276,8 @@ export async function persistImageExchange(params: {
       modelId: dbModelId,
       metadata: sql`${safeJsonbStringify({
         generationType: 'image',
-        estimatedCost: imageResult.estimatedCost
+        estimatedCost: imageResult.estimatedCost,
+        routing: routingMetadata,
       })}::jsonb`,
       createdAt: new Date()
     });
@@ -528,8 +530,9 @@ export function createImageStreamResponse(params: {
   conversationTitle: string;
   isNewConversation: boolean;
   requestId: string;
+  routingMetadata?: Record<string, unknown>;
 }): Response {
-  const { imageResult, conversationId, conversationTitle, isNewConversation, requestId } = params;
+  const { imageResult, conversationId, conversationTitle, isNewConversation, requestId, routingMetadata } = params;
 
   let responseContent = '';
   if (imageResult.altText && imageResult.altText.trim()) {
@@ -547,6 +550,10 @@ export function createImageStreamResponse(params: {
 
   if (isNewConversation) {
     responseHeaders['X-Conversation-Title'] = encodeURIComponent(conversationTitle);
+  }
+  if (routingMetadata) {
+    const encodedRouting = encodeURIComponent(JSON.stringify(routingMetadata));
+    if (encodedRouting.length <= 4096) responseHeaders['X-Nexus-Routing'] = encodedRouting;
   }
 
   return createUIMessageStreamResponse({

--- a/app/api/nexus/chat/route.ts
+++ b/app/api/nexus/chat/route.ts
@@ -51,6 +51,12 @@ import {
 } from '@/lib/skills/skill-tool-enforcement';
 import { readSkillMarkdown } from '@/lib/skills/skill-publish-pipeline';
 import { buildWorkspaceChatTools } from '@/lib/nexus/workspace-chat-tools';
+import { routeNexusRequest } from '@/lib/nexus/model-router/router';
+import {
+  nexusExperienceModeSchema,
+  nexusModelFamilySchema,
+  type NexusRoutingMetadata,
+} from '@/lib/nexus/model-router/types';
 
 // Allow streaming responses up to 30 minutes. Deep Research runs take 5–25
 // minutes; standard chat and image-gen finish well within this window.
@@ -81,8 +87,9 @@ function createOnFinishCallback(params: {
   connectorToolResults: McpConnectorToolsResult[];
   log: ReturnType<typeof createLogger>;
   timer: (data: Record<string, unknown>) => void;
+  routingMetadata: NexusRoutingMetadata;
 }) {
-  const { conversationId, dbModelId, connectorToolResults, log, timer } = params;
+  const { conversationId, dbModelId, connectorToolResults, log, timer, routingMetadata } = params;
 
   return async ({
     text,
@@ -116,9 +123,15 @@ function createOnFinishCallback(params: {
         // assistant message to preserve the correct turn structure for replay.
         // Consolidating into one message breaks convertToModelMessages — it cannot
         // reconstruct multi-turn tool_use/tool_result pairs. (Issue #977)
-        await saveConversationSteps({ conversationId, steps, dbModelId, usage, finishReason });
+        await saveConversationSteps({
+          conversationId, steps, dbModelId, usage, finishReason,
+          metadata: { routing: routingMetadata },
+        });
       } else {
-        await saveAssistantMessage({ conversationId, text, usage, finishReason, toolCalls, dbModelId });
+        await saveAssistantMessage({
+          conversationId, text, usage, finishReason, toolCalls, dbModelId,
+          metadata: { routing: routingMetadata },
+        });
       }
     } catch (saveError) {
       log.error('Failed to save assistant message', { error: saveError, conversationId });
@@ -188,6 +201,7 @@ async function executeStreaming(params: {
   log: ReturnType<typeof createLogger>;
   timer: (data: Record<string, unknown>) => void;
   precomputedInputTokenMappings?: TokenMapping[];
+  routingMetadata: NexusRoutingMetadata;
 }): Promise<Response> {
   const {
     messages, modelConfig, userId, sessionId, conversationId,
@@ -195,7 +209,7 @@ async function executeStreaming(params: {
     connectorToolResults, failedConnectorIds, skillInstructions, skillName,
     workspaceTools, workspacePromptFragment,
     reasoningEffort, responseMode,
-    requestId, dbModelId, log, timer, precomputedInputTokenMappings
+    requestId, dbModelId, log, timer, precomputedInputTokenMappings, routingMetadata
   } = params;
 
   const systemPrompt = buildNexusSystemPrompt(skillInstructions, skillName, workspacePromptFragment);
@@ -235,7 +249,9 @@ async function executeStreaming(params: {
     options: { reasoningEffort, responseMode },
     precomputedInputTokenMappings,
     callbacks: {
-      onFinish: createOnFinishCallback({ conversationId, dbModelId, connectorToolResults, log, timer }),
+      onFinish: createOnFinishCallback({
+        conversationId, dbModelId, connectorToolResults, log, timer, routingMetadata,
+      }),
       onError: async (error: Error) => {
         log.warn('Stream error — closing MCP clients', { conversationId, error: error.message });
         await closeMcpClients(connectorToolResults, log, 'onError');
@@ -261,6 +277,9 @@ async function executeStreaming(params: {
     'X-Unified-Streaming': 'true',
     'X-Supports-Reasoning': streamResponse.capabilities.supportsReasoning.toString()
   };
+
+  const encodedRouting = encodeURIComponent(JSON.stringify(routingMetadata));
+  if (encodedRouting.length <= 4096) responseHeaders['X-Nexus-Routing'] = encodedRouting;
 
   if (!conversationIdValue && conversationId) {
     responseHeaders['X-Conversation-Id'] = conversationId;
@@ -321,7 +340,9 @@ const ChatRequestSchema = z.object({
   // only — the tool builder canView/canEdit-gates server-side; cap length like other params.
   workspaceId: z.string().min(1).max(200).optional(),
   reasoningEffort: z.enum(['minimal', 'low', 'medium', 'high']).optional(),
-  responseMode: z.enum(['standard', 'priority', 'flex']).optional()
+  responseMode: z.enum(['standard', 'priority', 'flex']).optional(),
+  nexusMode: nexusExperienceModeSchema.default('standard'),
+  modelFamily: nexusModelFamilySchema.default('auto'),
 });
 
 /**
@@ -337,10 +358,11 @@ async function handleImageGeneration(params: {
   requestId: string;
   timer: (data: Record<string, unknown>) => void;
   log: ReturnType<typeof createLogger>;
+  routingMetadata: NexusRoutingMetadata;
 }): Promise<Response> {
   const {
     messages, modelConfig, modelId, dbModelId, userId,
-    existingConversationId, requestId, timer, log
+    existingConversationId, requestId, timer, log, routingMetadata
   } = params;
 
   log.info('Image generation model detected - using direct API call');
@@ -408,7 +430,10 @@ async function handleImageGeneration(params: {
     // Persist the user prompt + assistant image + stats atomically (REV-DB-047 /
     // REV-COR-220). Kept after generation (a side effect) so a generation failure
     // leaves no partial rows and no desynced message_count.
-    await persistImageExchange({ conversationId, imagePrompt, imageResult, dbModelId });
+    await persistImageExchange({
+      conversationId, imagePrompt, imageResult, dbModelId,
+      routingMetadata: { ...routingMetadata },
+    });
 
     timer({ status: 'success', conversationId });
 
@@ -417,7 +442,8 @@ async function handleImageGeneration(params: {
       conversationId,
       conversationTitle,
       isNewConversation: !existingConversationId,
-      requestId
+      requestId,
+      routingMetadata: { ...routingMetadata },
     });
 
   } catch (imageError) {
@@ -470,10 +496,11 @@ async function handleDeepResearch(params: {
   timer: (data: Record<string, unknown>) => void;
   log: ReturnType<typeof createLogger>;
   abortSignal: AbortSignal;
+  routingMetadata: NexusRoutingMetadata;
 }): Promise<Response> {
   const {
     messages, modelConfig, modelId, dbModelId, userId,
-    existingConversationId, requestId, timer, log, abortSignal,
+    existingConversationId, requestId, timer, log, abortSignal, routingMetadata,
   } = params;
 
   log.info('Deep Research model detected — using Interactions API', {
@@ -524,6 +551,7 @@ async function handleDeepResearch(params: {
     'X-Request-Id': requestId,
     'X-Conversation-Id': conversationId,
     'X-Deep-Research': 'true',
+    'X-Nexus-Routing': encodeURIComponent(JSON.stringify(routingMetadata)),
   };
   if (isNewConversation) {
     responseHeaders['X-Conversation-Title'] = encodeURIComponent(conversationTitle);
@@ -590,6 +618,7 @@ async function handleDeepResearch(params: {
               text: persisted,
               finishReason: 'stop',
               dbModelId,
+              metadata: { routing: routingMetadata },
             });
           } catch (persistErr) {
             log.error('Failed to persist Deep Research message', {
@@ -647,6 +676,7 @@ async function routeSpecialModel(params: {
   timer: (data: Record<string, unknown>) => void;
   log: ReturnType<typeof createLogger>;
   abortSignal: AbortSignal;
+  routingMetadata: NexusRoutingMetadata;
 }): Promise<Response | null> {
   if (params.isImageGenerationModel) {
     // Note: abortSignal is intentionally not forwarded to handleImageGeneration.
@@ -663,6 +693,7 @@ async function routeSpecialModel(params: {
       requestId: params.requestId,
       timer: params.timer,
       log: params.log,
+      routingMetadata: params.routingMetadata,
     });
   }
   if (params.isDeepResearchModel) {
@@ -677,6 +708,7 @@ async function routeSpecialModel(params: {
       timer: params.timer,
       log: params.log,
       abortSignal: params.abortSignal,
+      routingMetadata: params.routingMetadata,
     });
   }
   return null;
@@ -730,6 +762,37 @@ function validateConversationId(id: string | undefined, requestId: string, log: 
   return null;
 }
 
+function requestHasImageInput(messages: z.infer<typeof ChatRequestSchema>['messages']): boolean {
+  const lastUserMessage = [...messages].reverse().find(message => message.role === 'user');
+  return lastUserMessage?.parts?.some(part => {
+    if (!part || typeof part !== 'object') return false;
+    const value = part as Record<string, unknown>;
+    const mimeType = value.mimeType ?? value.mediaType;
+    return value.type === 'image'
+      || (value.type === 'file' && typeof mimeType === 'string' && mimeType.startsWith('image/'));
+  }) ?? false;
+}
+
+function withProtectedLastUserText(
+  messages: z.infer<typeof ChatRequestSchema>['messages'],
+  protectedText: string
+): z.infer<typeof ChatRequestSchema>['messages'] {
+  const lastUserIndex = messages.findLastIndex(message => message.role === 'user');
+  if (lastUserIndex < 0) return messages;
+  return messages.map((message, index) => {
+    if (index !== lastUserIndex) return message;
+    const nonTextParts = (message.parts ?? []).filter(part => {
+      if (!part || typeof part !== 'object') return true;
+      return (part as Record<string, unknown>).type !== 'text';
+    });
+    return {
+      ...message,
+      content: protectedText,
+      parts: [{ type: 'text', text: protectedText }, ...nonTextParts],
+    };
+  });
+}
+
 /**
  * Authenticate user and return user ID or error response
  */
@@ -752,6 +815,59 @@ async function authenticateUser(
 
   const userRoleNames = currentUser.data.roles.map(r => r.name);
   return { userId: currentUser.data.user.id, userRoleNames, session };
+}
+
+/**
+ * Protect classifier traffic with the same K-12 guardrail and PII tokenization
+ * boundary as response-model traffic. The main stream performs its own pass so
+ * it can retain token mappings for output detokenization; this preflight exists
+ * specifically to ensure the internal router never receives raw PII.
+ */
+async function prepareRoutingText(text: string, sessionId: string): Promise<{
+  text: string;
+  contentModified: boolean;
+}> {
+  if (!text.trim()) return { text, contentModified: false };
+  const result = await getContentSafetyService().processInput(text, sessionId);
+  if (!result.allowed) {
+    throw new ContentSafetyBlockedError(
+      result.blockedMessage || 'Content blocked by safety guardrails',
+      result.blockedCategories || [],
+      'input'
+    );
+  }
+  return { text: result.processedContent, contentModified: result.contentModified };
+}
+
+async function resolveRequestRouting(args: {
+  messages: z.infer<typeof ChatRequestSchema>['messages'];
+  fallbackModelId: string;
+  nexusMode: z.infer<typeof nexusExperienceModeSchema>;
+  modelFamily: z.infer<typeof nexusModelFamilySchema>;
+  manuallyEnabledConnectors: string[];
+  userId: number;
+  sessionId: string;
+}): Promise<{
+  routing: Awaited<ReturnType<typeof routeNexusRequest>>;
+  specialRouteMessages: z.infer<typeof ChatRequestSchema>['messages'];
+}> {
+  const rawRoutingText = extractImagePrompt(args.messages);
+  const protectedRoutingInput = await prepareRoutingText(rawRoutingText, args.sessionId);
+  const routing = await routeNexusRequest({
+    text: protectedRoutingInput.text,
+    fallbackModelId: args.fallbackModelId,
+    experienceMode: args.nexusMode,
+    requestedFamily: args.nexusMode === 'advanced' ? args.modelFamily : 'auto',
+    enabledConnectorIds: args.manuallyEnabledConnectors,
+    userId: args.userId,
+    hasImageInput: requestHasImageInput(args.messages),
+  });
+  return {
+    routing,
+    specialRouteMessages: protectedRoutingInput.contentModified
+      ? withProtectedLastUserText(args.messages, protectedRoutingInput.text)
+      : args.messages,
+  };
 }
 
 /**
@@ -1251,21 +1367,48 @@ export async function POST(req: Request) {
     const validation = validateRequest(body, requestId, log);
     if (!validation.valid) return validation.error;
 
-    const { messages, modelId, provider = 'openai', conversationId: existingConversationId, enabledTools = [], enabledConnectors = [], skillId, workspaceId } = validation.data;
+    const {
+      messages,
+      modelId: fallbackModelId,
+      conversationId: existingConversationId,
+      enabledTools = [],
+      enabledConnectors: manuallyEnabledConnectors = [],
+      skillId,
+      workspaceId,
+      nexusMode,
+      modelFamily,
+    } = validation.data;
     const conversationIdValue = existingConversationId || undefined;
 
     // 2. Validate conversation ID format
     const convIdError = validateConversationId(conversationIdValue, requestId, log);
     if (convIdError) return convIdError;
 
-    log.info('Request parsed', sanitizeForLogging({ messageCount: messages.length, modelId, provider, hasConversationId: !!conversationIdValue, enabledTools }));
+    log.info('Request parsed', sanitizeForLogging({
+      messageCount: messages.length, fallbackModelId, nexusMode, modelFamily,
+      hasConversationId: !!conversationIdValue, enabledTools,
+    }));
 
     // 3. Authenticate user
     const authResult = await authenticateUser(log, timer);
     if ('error' in authResult) return authResult.error;
     const { userId, userRoleNames, session } = authResult;
 
-    // 4. Get model configuration
+    // 4. Classify and resolve the model. In shadow mode this records the proposed
+    // route while continuing to execute the client's existing safe fallback.
+    const { routing, specialRouteMessages } = await resolveRequestRouting({
+      messages,
+      fallbackModelId,
+      nexusMode,
+      modelFamily,
+      manuallyEnabledConnectors,
+      userId,
+      sessionId: session.sub,
+    });
+    const modelId = routing.modelId;
+    const enabledConnectors = routing.connectorIds;
+
+    // 4a. Get selected model configuration
     const modelResult = await getValidatedModelConfig(modelId, log);
     if ('error' in modelResult) return modelResult.error;
     const { modelConfig, dbModelId, isImageGenerationModel, isDeepResearchModel } = modelResult;
@@ -1296,16 +1439,18 @@ export async function POST(req: Request) {
     // the standard streaming pipeline.
     const specialRoute = await routeSpecialModel({
       isImageGenerationModel, isDeepResearchModel,
-      messages, modelConfig, modelId, dbModelId, userId,
+      messages: specialRouteMessages, modelConfig, modelId, dbModelId, userId,
       existingConversationId: conversationIdValue,
       requestId, timer, log,
       abortSignal: req.signal,
+      routingMetadata: routing.metadata,
     });
     if (specialRoute) return specialRoute;
 
     // 6. Setup conversation and save user message
     const convSetup = await setupConversation({
-      conversationIdValue, messages, userId, provider, modelId, dbModelId, requestId, log
+      conversationIdValue, messages, userId, provider: modelConfig.provider,
+      modelId, dbModelId, requestId, log
     });
     if ('error' in convSetup) return convSetup.error;
     const { conversationId, conversationTitle } = convSetup;
@@ -1381,6 +1526,7 @@ export async function POST(req: Request) {
       log,
       timer,
       precomputedInputTokenMappings,
+      routingMetadata: routing.metadata,
     });
 
   } catch (error) {

--- a/app/api/nexus/chat/route.ts
+++ b/app/api/nexus/chat/route.ts
@@ -22,6 +22,7 @@ import {
   getOrCreateImageConversation,
   extractReferenceImages,
   getPreviousGeneratedImages,
+  getImageRoutingContext,
   persistImageExchange,
   createImageStreamResponse,
   handleImageGenerationError,
@@ -399,7 +400,7 @@ async function handleImageGeneration(params: {
 
     // If no reference images and existing conversation, check previous messages
     if (existingConversationId && referenceImages.length === 0) {
-      referenceImages = await getPreviousGeneratedImages(existingConversationId);
+      referenceImages = await getPreviousGeneratedImages(existingConversationId, userId);
     }
 
     log.info('Image generation - extracted reference images', {
@@ -762,17 +763,6 @@ function validateConversationId(id: string | undefined, requestId: string, log: 
   return null;
 }
 
-function requestHasImageInput(messages: z.infer<typeof ChatRequestSchema>['messages']): boolean {
-  const lastUserMessage = [...messages].reverse().find(message => message.role === 'user');
-  return lastUserMessage?.parts?.some(part => {
-    if (!part || typeof part !== 'object') return false;
-    const value = part as Record<string, unknown>;
-    const mimeType = value.mimeType ?? value.mediaType;
-    return value.type === 'image'
-      || (value.type === 'file' && typeof mimeType === 'string' && mimeType.startsWith('image/'));
-  }) ?? false;
-}
-
 function withProtectedLastUserText(
   messages: z.infer<typeof ChatRequestSchema>['messages'],
   protectedText: string
@@ -847,12 +837,18 @@ async function resolveRequestRouting(args: {
   manuallyEnabledConnectors: string[];
   userId: number;
   sessionId: string;
+  existingConversationId?: string;
 }): Promise<{
   routing: Awaited<ReturnType<typeof routeNexusRequest>>;
   specialRouteMessages: z.infer<typeof ChatRequestSchema>['messages'];
 }> {
   const rawRoutingText = extractImagePrompt(args.messages);
   const protectedRoutingInput = await prepareRoutingText(rawRoutingText, args.sessionId);
+  const imageContext = await getImageRoutingContext({
+    messages: args.messages,
+    conversationId: args.existingConversationId,
+    userId: args.userId,
+  });
   const routing = await routeNexusRequest({
     text: protectedRoutingInput.text,
     fallbackModelId: args.fallbackModelId,
@@ -860,7 +856,8 @@ async function resolveRequestRouting(args: {
     requestedFamily: args.nexusMode === 'advanced' ? args.modelFamily : 'auto',
     enabledConnectorIds: args.manuallyEnabledConnectors,
     userId: args.userId,
-    hasImageInput: requestHasImageInput(args.messages),
+    hasImageInput: imageContext.hasImageInput,
+    hasPreviousGeneratedImage: imageContext.hasPreviousGeneratedImage,
   });
   return {
     routing,
@@ -1404,6 +1401,7 @@ export async function POST(req: Request) {
       manuallyEnabledConnectors,
       userId,
       sessionId: session.sub,
+      existingConversationId: conversationIdValue,
     });
     const modelId = routing.modelId;
     const enabledConnectors = routing.connectorIds;

--- a/components/assistant-ui/thread.tsx
+++ b/components/assistant-ui/thread.tsx
@@ -42,6 +42,7 @@ import {
 import { PromptSaveButton } from "@/app/(protected)/nexus/_components/chat/prompt-save-button";
 import { ComposerControls } from "@/app/(protected)/nexus/_components/chat/composer-controls";
 import type { SelectAiModel } from "@/types";
+import type { NexusExperienceMode, NexusModelFamily } from "@/lib/nexus/model-router/types";
 
 // Context for passing conversationId to message components
 const ConversationIdContext = createContext<string | null>(null);
@@ -51,7 +52,6 @@ export const useConversationId = () => useContext(ConversationIdContext);
 // ChatConfigContext and useChatConfig imported from @/lib/contexts/chat-config-context
 
 // Pre-defined constants to avoid creating new objects/arrays on every render
-const EMPTY_MODELS_ARRAY: SelectAiModel[] = [];
 const EMPTY_TOOLS_ARRAY: string[] = [];
 const EMPTY_CONNECTORS_ARRAY: string[] = [];
 
@@ -117,10 +117,12 @@ interface ThreadProps {
   processingAttachments?: Set<string>;
   conversationId?: string | null;
   // Model and tools for composer controls
-  models?: SelectAiModel[];
   selectedModel?: SelectAiModel | null;
   onModelChange?: (model: SelectAiModel) => void;
-  isLoadingModels?: boolean;
+  routingMode?: NexusExperienceMode;
+  modelFamily?: NexusModelFamily;
+  onRoutingModeChange?: (mode: NexusExperienceMode) => void;
+  onModelFamilyChange?: (family: NexusModelFamily) => void;
   enabledTools?: string[];
   onToolsChange?: (tools: string[]) => void;
   // Connector selection
@@ -138,10 +140,12 @@ interface ThreadProps {
 export const Thread: FC<ThreadProps> = ({
   processingAttachments,
   conversationId,
-  models = EMPTY_MODELS_ARRAY,
   selectedModel,
   onModelChange,
-  isLoadingModels = false,
+  routingMode = "standard",
+  modelFamily = "auto",
+  onRoutingModeChange,
+  onModelFamilyChange,
   enabledTools = EMPTY_TOOLS_ARRAY,
   onToolsChange,
   enabledConnectors = EMPTY_CONNECTORS_ARRAY,
@@ -193,10 +197,12 @@ export const Thread: FC<ThreadProps> = ({
 
           <Composer
             processingAttachments={processingAttachments}
-            models={models}
             selectedModel={selectedModel}
             onModelChange={onModelChange}
-            isLoadingModels={isLoadingModels}
+            routingMode={routingMode}
+            modelFamily={modelFamily}
+            onRoutingModeChange={onRoutingModeChange}
+            onModelFamilyChange={onModelFamilyChange}
             enabledTools={enabledTools}
             onToolsChange={onToolsChange}
             enabledConnectors={enabledConnectors}
@@ -307,10 +313,12 @@ const ThreadWelcomeSuggestions: FC<{ actions?: SuggestedAction[] }> = ({ actions
 
 interface ComposerProps {
   processingAttachments?: Set<string>;
-  models?: SelectAiModel[];
   selectedModel?: SelectAiModel | null;
   onModelChange?: (model: SelectAiModel) => void;
-  isLoadingModels?: boolean;
+  routingMode?: NexusExperienceMode;
+  modelFamily?: NexusModelFamily;
+  onRoutingModeChange?: (mode: NexusExperienceMode) => void;
+  onModelFamilyChange?: (family: NexusModelFamily) => void;
   enabledTools?: string[];
   onToolsChange?: (tools: string[]) => void;
   enabledConnectors?: string[];
@@ -322,10 +330,12 @@ interface ComposerProps {
 
 const Composer: FC<ComposerProps> = ({
   processingAttachments,
-  models = EMPTY_MODELS_ARRAY,
   selectedModel,
   onModelChange,
-  isLoadingModels = false,
+  routingMode = "standard",
+  modelFamily = "auto",
+  onRoutingModeChange,
+  onModelFamilyChange,
   enabledTools = EMPTY_TOOLS_ARRAY,
   onToolsChange,
   enabledConnectors = EMPTY_CONNECTORS_ARRAY,
@@ -342,12 +352,13 @@ const Composer: FC<ComposerProps> = ({
       </ThreadPrimitive.Empty>
       <ComposerPrimitive.Root className="relative flex w-full flex-col rounded-2xl border border-border focus-within:ring-2 focus-within:ring-black focus-within:ring-offset-2 dark:focus-within:ring-white overflow-hidden">
         {/* Control dock for model, tools, skills, MCP */}
-        {onModelChange && onToolsChange && (
+        {onModelChange && onToolsChange && onRoutingModeChange && onModelFamilyChange && (
           <ComposerControls
-            models={models}
             selectedModel={selectedModel ?? null}
-            onModelChange={onModelChange}
-            isLoadingModels={isLoadingModels}
+            routingMode={routingMode}
+            modelFamily={modelFamily}
+            onRoutingModeChange={onRoutingModeChange}
+            onModelFamilyChange={onModelFamilyChange}
             enabledTools={enabledTools}
             onToolsChange={onToolsChange}
             enabledConnectors={enabledConnectors}

--- a/docs/README.md
+++ b/docs/README.md
@@ -165,6 +165,8 @@ AI integration patterns using Vercel AI SDK v6, provider factory implementation,
 #### [features/nexus-conversation-architecture.md](./features/nexus-conversation-architecture.md) ⭐ **CRITICAL**
 **Complete Nexus conversation system architecture** - Component hierarchy, state management (conversationId vs stableConversationId vs ref), message flows, runtime memoization, format conversions, common pitfalls, and troubleshooting. **Read this before modifying conversation code.**
 
+**[Nexus model routing](./features/nexus-model-routing.md)** — Standard/Advanced UX, Nova Micro classification, family/tier resolution, automatic image and PSD-data MCP dispatch, configuration, fallbacks, and rollout modes.
+
 #### [features/navigation.md](./features/navigation.md)
 Dynamic navigation system with role-based menu items.
 

--- a/docs/features/nexus-model-routing.md
+++ b/docs/features/nexus-model-routing.md
@@ -1,0 +1,90 @@
+# Nexus model routing
+
+Nexus defaults to **Standard** mode. Users see one Nexus experience instead of an exact model, image-model, or MCP selector. The server classifies each request and chooses the appropriate model tier and capabilities. **Advanced** mode is opt-in and constrains routing to Auto, ChatGPT, Claude, or Gemini; the router still chooses the power level within that family.
+
+## Request flow
+
+1. Authenticate the user before classification.
+2. Apply the existing K-12 input guardrail and PII tokenization boundary before classifier traffic.
+3. Apply deterministic capability rules for image generation, PSD-data, and common instructional requests.
+4. Send ambiguous requests to Amazon Nova Micro on Bedrock for a provider-neutral `intent`, `tier`, `confidence`, and reason codes.
+5. Resolve an accessible, active Nexus model from the configured ordered candidates. If none is configured, use `providerMetadata.nexusRouterTier` or model-name conventions. If no tier match is available, use the closest tier in the requested family. Auto may finally use the existing client model as a safe fallback; an explicit Advanced family never silently crosses into another family.
+6. Automatically select an image-capable model for image intent or attach the existing database-backed PSD-data MCP server for PSD-data intent.
+7. Persist the route decision on assistant-message metadata and expose it in `X-Nexus-Routing` for evaluation.
+
+The deterministic rules run before the model classifier because capability requirements are not discretionary. Classifier failure, timeout, malformed output, or confidence below the configured floor falls back to a conservative heuristic; ordinary requests default to Medium.
+
+## Runtime modes
+
+Set `NEXUS_ROUTER_MODE` in the settings table or environment:
+
+- `active` (default): execute the routed model and automatic connector selection.
+- `shadow`: classify and resolve, record `proposedModelId`, but execute the existing fallback model and connector list.
+- `off`: use the legacy fallback model and manually enabled connectors.
+
+Use shadow mode to compare proposed routes against production traffic before changing execution. Stored routing metadata includes the config version, experience/runtime mode, requested and selected family, intent, tier, confidence, reason codes, decision source, selected/proposed model, fallback status, and PSD-data attachment status.
+An explicitly invalid runtime mode, or malformed router JSON while active, fails safely to shadow mode. A missing config is valid: the built-in specialist defaults and model metadata/name inference are used.
+
+## Configuration
+
+`NEXUS_ROUTER_CONFIG_V1` is a JSON setting. Candidate values are `ai_models.model_id` strings (numeric database IDs are also accepted). Candidates are tried in order and remain subject to active/Nexus-enabled status and resource-access grants.
+Administrators can add or edit both router keys under **Admin → System Settings → AI Configuration**; the JSON value field expands for the router config.
+
+```json
+{
+  "version": "2026-07-15.1",
+  "classifier": {
+    "provider": "amazon-bedrock",
+    "modelId": "us.amazon.nova-micro-v1:0",
+    "timeoutMs": 2500
+  },
+  "families": {
+    "openai": {
+      "light": ["gpt-5.6-luna"],
+      "medium": ["gpt-5.6-terra"],
+      "high": ["gpt-5.6-sol"]
+    },
+    "anthropic": {
+      "light": ["us.anthropic.claude-haiku-4-5-20251001-v1:0"],
+      "medium": ["us.anthropic.claude-sonnet-5"],
+      "high": ["us.anthropic.claude-opus-4-6-v1"]
+    },
+    "google": {
+      "light": ["gemini-3.1-flash-lite"],
+      "medium": ["gemini-3.5-flash"],
+      "high": ["gemini-3.1-pro-preview"]
+    }
+  },
+  "auto": {
+    "light": ["gpt-5.6-luna", "gemini-3.1-flash-lite"],
+    "medium": ["gpt-5.6-terra", "us.anthropic.claude-sonnet-5"],
+    "high": ["gpt-5.6-sol", "us.anthropic.claude-opus-4-6-v1"]
+  },
+  "specialists": {
+    "imageModels": ["gemini-3.1-flash-image"],
+    "instructionModels": ["gemini-3.5-flash"],
+    "psdDataConnectorName": "psd-data"
+  },
+  "confidenceFloor": 0.55
+}
+```
+
+The example IDs are illustrative and must match rows present in the deployment. Standard/Auto candidate lists are provider-neutral, so they may prefer Bedrock-native Nova or open-weight models as well as the named families. Advanced remains constrained to ChatGPT, Claude, or Gemini. For lighter administration, set `provider_metadata.nexusRouterTier` to `light`, `medium`, or `high` on model rows and leave candidate lists empty. Family is inferred where applicable from the provider/model ID. Explicit candidate arrays take priority.
+
+For PSD-data, prefer `specialists.psdDataConnectorId` when the server UUID is stable. Otherwise the router normalizes the configured name, so `psd-data`, `PSD Data`, and `psd_data` match the same registered server. Existing connector authorization and Cognito pass-through remain enforced by the connector service.
+
+## User experience and persistence
+
+The user preference is stored in `nexus_user_preferences.settings` as `nexusMode` and `preferredModelFamily`. Standard is the default for users with no preference. The composer’s routing control does not remount the assistant runtime; current values are read from refs by the stable transport. In Standard, manual model/tool/MCP controls are hidden. In Advanced, the family chooser and existing optional tool controls are available.
+
+Image routing intentionally overrides a family constraint because it requires a generation capability. PSD-data augments the selected response model with its data source, so its response model still honors the family constraint. General and instructional response models also honor Advanced family selection; Auto can use the configured instructional specialist. Specialist-only image and Deep Research models are excluded from ordinary response routing.
+
+## Verification and rollout
+
+1. Register candidate models in `ai_models`, including capabilities and resource grants.
+2. Confirm the ECS task role can invoke Bedrock foundation models and inference profiles (the shared ECS construct grants both).
+3. Configure the router JSON and start with `shadow` if evaluating an existing deployment.
+4. Inspect assistant `metadata.routing`, classifier/fallback logs, latency, cost, user retries, and route overrides.
+5. Promote to `active`, keeping the legacy fallback model available.
+
+Unit coverage lives in `lib/nexus/model-router/__tests__`. Deterministic authenticated UI and request-wire coverage for Standard/Advanced, every family, preference persistence, image intent, and PSD-data intent lives in `tests/e2e/nexus/model-router.spec.ts`; live-provider conversation coverage remains in the other Nexus specs.

--- a/docs/features/nexus-model-routing.md
+++ b/docs/features/nexus-model-routing.md
@@ -18,11 +18,11 @@ The deterministic rules run before the model classifier because capability requi
 
 Set `NEXUS_ROUTER_MODE` in the settings table or environment:
 
-- `active` (default): execute the routed model and automatic connector selection.
-- `shadow`: classify and resolve, record `proposedModelId`, but execute the existing fallback model and connector list.
+- `active`: execute the routed model and automatic connector selection.
+- `shadow` (default): classify and resolve, record `proposedModelId`, but execute the existing fallback model and connector list.
 - `off`: use the legacy fallback model and manually enabled connectors.
 
-Use shadow mode to compare proposed routes against production traffic before changing execution. Stored routing metadata includes the config version, experience/runtime mode, requested and selected family, intent, tier, confidence, reason codes, decision source, selected/proposed model, fallback status, and PSD-data attachment status.
+The user-facing experience still defaults to Standard; the independent runtime default is shadow so an existing deployment cannot change live model execution without an explicit administrator promotion. Use shadow mode to compare proposed routes against production traffic before changing execution. Stored routing metadata includes the config version, experience/runtime mode, requested and selected family, intent, tier, confidence, reason codes, decision source, selected/proposed model, fallback status, and PSD-data attachment status.
 An explicitly invalid runtime mode, or malformed router JSON while active, fails safely to shadow mode. A missing config is valid: the built-in specialist defaults and model metadata/name inference are used.
 
 ## Configuration
@@ -78,6 +78,8 @@ For PSD-data, prefer `specialists.psdDataConnectorId` when the server UUID is st
 The user preference is stored in `nexus_user_preferences.settings` as `nexusMode` and `preferredModelFamily`. Standard is the default for users with no preference. The composer’s routing control does not remount the assistant runtime; current values are read from refs by the stable transport. In Standard, manual model/tool/MCP controls are hidden. In Advanced, the family chooser and existing optional tool controls are available.
 
 Image routing intentionally overrides a family constraint because it requires a generation capability. PSD-data augments the selected response model with its data source, so its response model still honors the family constraint. General and instructional response models also honor Advanced family selection; Auto can use the configured instructional specialist. Specialist-only image and Deep Research models are excluded from ordinary response routing.
+
+For follow-up image edits, the router checks the authenticated user's recent persisted assistant messages for the same conversation. This keeps elliptical requests such as “make it brighter” on the image path even when the image is not reattached, while preventing another user's conversation history from influencing routing.
 
 ## Verification and rollout
 

--- a/lib/agent-workspace/token-rate-limit.ts
+++ b/lib/agent-workspace/token-rate-limit.ts
@@ -1,0 +1,32 @@
+/**
+ * Per-owner workspace-token mint rate limit.
+ *
+ * The cap is generous because a token lasts about an hour and clients cache it.
+ * The in-memory, per-task limit is defense in depth behind the internal shared
+ * secret. It bounds abuse of one task; a fleet-wide guard would require shared
+ * storage.
+ */
+const RATE_LIMIT_PER_HOUR = Number(process.env.AGENT_WORKSPACE_TOKEN_RATE_LIMIT) || 120
+const RATE_WINDOW_MS = 60 * 60 * 1000
+const mintWindow = new Map<string, { count: number; windowStart: number }>()
+
+export function checkAgentWorkspaceTokenRateLimit(ownerEmail: string): boolean {
+  const now = Date.now()
+  const entry = mintWindow.get(ownerEmail)
+  if (!entry || now - entry.windowStart >= RATE_WINDOW_MS) {
+    mintWindow.set(ownerEmail, { count: 1, windowStart: now })
+    return true
+  }
+  if (entry.count >= RATE_LIMIT_PER_HOUR) return false
+  entry.count += 1
+  return true
+}
+
+export function getAgentWorkspaceTokenRateLimit(): number {
+  return RATE_LIMIT_PER_HOUR
+}
+
+/** Test-only: clear the in-memory rate-limit window between tests. */
+export function resetAgentWorkspaceTokenRateLimitForTests(): void {
+  mintWindow.clear()
+}

--- a/lib/ai/image-generation-service.ts
+++ b/lib/ai/image-generation-service.ts
@@ -939,6 +939,8 @@ export function isImageGenerationModel(modelId: string): boolean {
     'gpt-image',
     'dall-e',
     'gemini-2.5-flash-image',
+    'gemini-3.1-flash-image',
+    'gemini-3.1-flash-lite-image',
     'gemini-3-pro-image',
     'imagen'
   ];

--- a/lib/api/with-api-auth.ts
+++ b/lib/api/with-api-auth.ts
@@ -55,11 +55,12 @@ type ApiRouteHandler = (
 /**
  * The route context Next.js passes as the SECOND argument to a route handler.
  * `params` is a Promise in the App Router (Next 15+); the wrapper awaits it before
- * handing a plain object to the handler. Optional so a non-dynamic route (no
- * `[param]` segment) still type-checks — its handler receives `{}`.
+ * handing a plain object to the handler. Both the context and its `params`
+ * promise are required by Next's route contract; non-dynamic routes receive a
+ * promise that resolves to `{}`.
  */
 interface RouteContext {
-  params?: Promise<RouteParams>;
+  params: Promise<RouteParams>;
 }
 
 /**
@@ -67,10 +68,10 @@ interface RouteContext {
  */
 export function withApiAuth(
   handler: ApiRouteHandler
-): (request: NextRequest, context?: RouteContext) => Promise<NextResponse> {
+): (request: NextRequest, context: RouteContext) => Promise<NextResponse> {
   return async (
     request: NextRequest,
-    context?: RouteContext
+    context: RouteContext
   ): Promise<NextResponse> => {
     const requestId = generateRequestId();
     const timer = startTimer("apiRequest");
@@ -105,8 +106,9 @@ export function withApiAuth(
 
     try {
       // Resolve Next's dynamic route params (a Promise in the App Router) once and
-      // hand the handler a plain object. A non-dynamic route has no `params`, so
-      // default to `{}` — the handler simply ignores the argument.
+      // hand the handler a plain object. For a non-dynamic route, Next resolves
+      // the promise to `{}` and the handler simply ignores the argument. Keep a
+      // runtime fallback for direct test/legacy calls made outside Next.
       const params = context?.params ? await context.params : {};
       response = await handler(request, auth, requestId, params);
       statusCode = response.status;

--- a/lib/db/types/jsonb/index.ts
+++ b/lib/db/types/jsonb/index.ts
@@ -152,6 +152,10 @@ export interface NexusUserSettings {
   theme?: "light" | "dark" | "system";
   notifications?: boolean;
   shortcuts?: Record<string, string>;
+  /** Standard hides model/tool routing controls; Advanced exposes a family constraint. */
+  nexusMode?: "standard" | "advanced";
+  /** Optional provider-family constraint used only in Advanced mode. */
+  preferredModelFamily?: "auto" | "openai" | "anthropic" | "google";
   [key: string]: unknown;
 }
 

--- a/lib/mcp/oauth-state.ts
+++ b/lib/mcp/oauth-state.ts
@@ -1,0 +1,11 @@
+/**
+ * Builds a per-server cookie name for encrypted MCP OAuth PKCE state.
+ *
+ * This lives outside the route module because Next route files may only export
+ * supported HTTP handlers and route configuration fields.
+ */
+export function getOAuthStateCookieName(serverId: string): string {
+  // Full UUID avoids collisions when only later segments differ.
+  // Dashes are valid in cookie names per RFC 6265.
+  return `mcp_oauth_state_${serverId}`
+}

--- a/lib/nexus/model-router/__tests__/classifier.test.ts
+++ b/lib/nexus/model-router/__tests__/classifier.test.ts
@@ -1,0 +1,74 @@
+/** @jest-environment node */
+
+const mockGenerateText = jest.fn()
+const mockCreateProviderModel = jest.fn()
+
+jest.mock("ai", () => ({
+  generateText: (...args: unknown[]) => mockGenerateText(...args),
+  tool: (definition: unknown) => definition,
+}))
+jest.mock("@/lib/ai/provider-factory", () => ({
+  createProviderModel: (...args: unknown[]) => mockCreateProviderModel(...args),
+}))
+jest.mock("@/lib/logger", () => ({
+  createLogger: () => ({ info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() }),
+}))
+
+import { classifyNexusRequest, deterministicClassify, heuristicFallback } from "../classifier"
+import { nexusRouterConfigSchema } from "../types"
+
+const config = nexusRouterConfigSchema.parse({})
+
+describe("Nexus request classifier", () => {
+  beforeEach(() => jest.clearAllMocks())
+
+  it("routes explicit image requests without spending a classifier call", async () => {
+    const decision = await classifyNexusRequest("Create an image of a school garden", config)
+    expect(decision).toMatchObject({ intent: "image", source: "deterministic" })
+    expect(mockCreateProviderModel).not.toHaveBeenCalled()
+  })
+
+  it("routes PSD-data and instructional requests deterministically", () => {
+    expect(deterministicClassify("Show attendance for this student")?.intent).toBe("psd-data")
+    expect(deterministicClassify("Build a differentiated lesson plan")?.intent).toBe("instruction")
+  })
+
+  it("recognizes an edit instruction when an image is attached", async () => {
+    const decision = await classifyNexusRequest("Make this brighter", config, { hasImageInput: true })
+    expect(decision).toMatchObject({ intent: "image", source: "deterministic" })
+    expect(mockCreateProviderModel).not.toHaveBeenCalled()
+  })
+
+  it("uses Nova Micro for ambiguous requests", async () => {
+    mockCreateProviderModel.mockResolvedValue({ modelId: "nova" })
+    mockGenerateText.mockResolvedValue({
+      text: '{"intent":"general","tier":"high","confidence":0.91,"reasonCodes":["multi_stage"]}',
+    })
+    const decision = await classifyNexusRequest("Compare these approaches and recommend a migration strategy", config)
+    expect(mockCreateProviderModel).toHaveBeenCalledWith("amazon-bedrock", "us.amazon.nova-micro-v1:0")
+    expect(decision).toMatchObject({ tier: "high", source: "classifier", confidence: 0.91 })
+  })
+
+  it("prefers the forced route tool result over free-form text", async () => {
+    mockCreateProviderModel.mockResolvedValue({ modelId: "nova" })
+    mockGenerateText.mockResolvedValue({
+      text: "not json",
+      toolCalls: [{
+        toolName: "route_request",
+        input: { intent: "general", tier: "light", confidence: 0.88, reasonCodes: ["simple"] },
+      }],
+    })
+    const decision = await classifyNexusRequest("Polish this sentence for a different audience", config)
+    expect(decision).toMatchObject({ tier: "light", source: "classifier", confidence: 0.88 })
+  })
+
+  it("fails safely to a medium heuristic when the classifier is unavailable", async () => {
+    mockCreateProviderModel.mockRejectedValue(new Error("Bedrock unavailable"))
+    const decision = await classifyNexusRequest("Please help me improve this paragraph for my audience", config)
+    expect(decision).toMatchObject({ tier: "medium", source: "fallback" })
+  })
+
+  it("keeps obvious short requests on the light tier", () => {
+    expect(heuristicFallback("Define photosynthesis").tier).toBe("light")
+  })
+})

--- a/lib/nexus/model-router/__tests__/classifier.test.ts
+++ b/lib/nexus/model-router/__tests__/classifier.test.ts
@@ -39,6 +39,14 @@ describe("Nexus request classifier", () => {
     expect(mockCreateProviderModel).not.toHaveBeenCalled()
   })
 
+  it("recognizes an elliptical edit when a previous generated image is available", async () => {
+    const decision = await classifyNexusRequest("Make it brighter", config, {
+      hasPreviousGeneratedImage: true,
+    })
+    expect(decision).toMatchObject({ intent: "image", source: "deterministic" })
+    expect(mockCreateProviderModel).not.toHaveBeenCalled()
+  })
+
   it("uses Nova Micro for ambiguous requests", async () => {
     mockCreateProviderModel.mockResolvedValue({ modelId: "nova" })
     mockGenerateText.mockResolvedValue({

--- a/lib/nexus/model-router/__tests__/config.test.ts
+++ b/lib/nexus/model-router/__tests__/config.test.ts
@@ -12,10 +12,10 @@ import { getNexusRouterConfig } from "../config"
 describe("Nexus router configuration", () => {
   beforeEach(() => jest.clearAllMocks())
 
-  it("defaults to active Nova Micro routing with Nano Banana image candidates", async () => {
+  it("defaults to shadow Nova Micro routing with Nano Banana image candidates", async () => {
     mockGetSettings.mockResolvedValue({ NEXUS_ROUTER_CONFIG_V1: null, NEXUS_ROUTER_MODE: null })
     const result = await getNexusRouterConfig()
-    expect(result.mode).toBe("active")
+    expect(result.mode).toBe("shadow")
     expect(result.config.classifier.modelId).toBe("us.amazon.nova-micro-v1:0")
     expect(result.config.specialists.imageModels[0]).toBe("gemini-3.1-flash-image-preview")
   })

--- a/lib/nexus/model-router/__tests__/config.test.ts
+++ b/lib/nexus/model-router/__tests__/config.test.ts
@@ -1,0 +1,49 @@
+/** @jest-environment node */
+
+const mockGetSettings = jest.fn()
+
+jest.mock("@/lib/settings-manager", () => ({ getSettings: (...args: unknown[]) => mockGetSettings(...args) }))
+jest.mock("@/lib/logger", () => ({
+  createLogger: () => ({ info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() }),
+}))
+
+import { getNexusRouterConfig } from "../config"
+
+describe("Nexus router configuration", () => {
+  beforeEach(() => jest.clearAllMocks())
+
+  it("defaults to active Nova Micro routing with Nano Banana image candidates", async () => {
+    mockGetSettings.mockResolvedValue({ NEXUS_ROUTER_CONFIG_V1: null, NEXUS_ROUTER_MODE: null })
+    const result = await getNexusRouterConfig()
+    expect(result.mode).toBe("active")
+    expect(result.config.classifier.modelId).toBe("us.amazon.nova-micro-v1:0")
+    expect(result.config.specialists.imageModels[0]).toBe("gemini-3.1-flash-image-preview")
+  })
+
+  it("loads ordered candidates and shadow mode from settings", async () => {
+    mockGetSettings.mockResolvedValue({
+      NEXUS_ROUTER_MODE: "shadow",
+      NEXUS_ROUTER_CONFIG_V1: JSON.stringify({
+        version: "test-2",
+        families: {
+          openai: { light: ["small"], medium: ["medium"], high: ["large"] },
+          anthropic: { light: [], medium: [], high: [] },
+          google: { light: [], medium: [], high: [] },
+        },
+      }),
+    })
+    const result = await getNexusRouterConfig()
+    expect(result.mode).toBe("shadow")
+    expect(result.config.families.openai.medium).toEqual(["medium"])
+  })
+
+  it("falls back safely when JSON or mode is invalid", async () => {
+    mockGetSettings.mockResolvedValue({
+      NEXUS_ROUTER_MODE: "broken",
+      NEXUS_ROUTER_CONFIG_V1: "{not-json",
+    })
+    const result = await getNexusRouterConfig()
+    expect(result.mode).toBe("shadow")
+    expect(result.config.confidenceFloor).toBe(0.55)
+  })
+})

--- a/lib/nexus/model-router/__tests__/router.test.ts
+++ b/lib/nexus/model-router/__tests__/router.test.ts
@@ -1,0 +1,193 @@
+/** @jest-environment node */
+
+const mockGetNexusEnabledModels = jest.fn()
+const mockFilterAccessibleResourceIds = jest.fn()
+const mockGetConfig = jest.fn()
+const mockClassify = jest.fn()
+const mockExecuteQuery = jest.fn()
+
+jest.mock("@/lib/db/drizzle", () => ({ getNexusEnabledModels: () => mockGetNexusEnabledModels() }))
+jest.mock("@/lib/db/drizzle/resource-access", () => ({
+  filterAccessibleResourceIds: (...args: unknown[]) => mockFilterAccessibleResourceIds(...args),
+}))
+jest.mock("@/lib/db/drizzle-client", () => ({ executeQuery: (...args: unknown[]) => mockExecuteQuery(...args) }))
+jest.mock("../config", () => ({ getNexusRouterConfig: () => mockGetConfig() }))
+jest.mock("../classifier", () => ({ classifyNexusRequest: (...args: unknown[]) => mockClassify(...args) }))
+jest.mock("@/lib/logger", () => ({
+  createLogger: () => ({ info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() }),
+}))
+
+import { routeNexusRequest } from "../router"
+import { nexusRouterConfigSchema } from "../types"
+
+const models = [
+  { id: 1, name: "GPT Luna", provider: "openai", modelId: "gpt-luna", capabilities: "[]", providerMetadata: { nexusRouterTier: "light" } },
+  { id: 2, name: "GPT Terra", provider: "openai", modelId: "gpt-terra", capabilities: "[]", providerMetadata: { nexusRouterTier: "medium" } },
+  { id: 3, name: "Claude Sonnet", provider: "amazon-bedrock", modelId: "us.anthropic.claude-sonnet", capabilities: "[]", providerMetadata: { nexusRouterTier: "medium" } },
+  { id: 4, name: "Gemini Flash", provider: "google", modelId: "gemini-flash", capabilities: "[]", providerMetadata: { nexusRouterTier: "medium" } },
+  { id: 5, name: "Nano Banana", provider: "google", modelId: "gemini-3.1-flash-image", capabilities: '["image_generation"]', providerMetadata: { nexusRouterTier: "light" } },
+  { id: 6, name: "Gemini Deep Research", provider: "google", modelId: "gemini-deep-research", capabilities: '["deep_research"]', providerMetadata: { nexusRouterTier: "high" } },
+  { id: 7, name: "Amazon Nova Lite", provider: "amazon-bedrock", modelId: "us.amazon.nova-lite-v1:0", capabilities: "[]", providerMetadata: { nexusRouterTier: "light" } },
+]
+
+const config = nexusRouterConfigSchema.parse({
+  families: {
+    openai: { light: ["gpt-luna"], medium: ["gpt-terra"], high: [] },
+    anthropic: { light: [], medium: ["us.anthropic.claude-sonnet"], high: [] },
+    google: { light: [], medium: ["gemini-flash"], high: [] },
+  },
+  specialists: {
+    imageModels: ["gemini-3.1-flash-image"],
+    instructionModels: ["gemini-flash"],
+    psdDataConnectorName: "psd-data",
+  },
+})
+
+describe("Nexus model router", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockGetNexusEnabledModels.mockResolvedValue(models)
+    mockFilterAccessibleResourceIds.mockResolvedValue(models.map(model => String(model.id)))
+    mockGetConfig.mockResolvedValue({ config, mode: "active" })
+    mockClassify.mockResolvedValue({
+      intent: "general", tier: "medium", confidence: 0.9,
+      reasonCodes: ["normal_request"], source: "classifier",
+    })
+  })
+
+  it("constrains Advanced routing to the selected family", async () => {
+    const result = await routeNexusRequest({
+      text: "Help", fallbackModelId: "gpt-terra", experienceMode: "advanced",
+      requestedFamily: "anthropic", enabledConnectorIds: [], userId: 7,
+    })
+    expect(result.modelId).toBe("us.anthropic.claude-sonnet")
+    expect(result.metadata.selectedFamily).toBe("anthropic")
+  })
+
+  it("allows Standard Auto tiers to prefer Bedrock-native models", async () => {
+    const bedrockFirstConfig = nexusRouterConfigSchema.parse({
+      auto: { light: ["us.amazon.nova-lite-v1:0"], medium: [], high: [] },
+    })
+    mockGetConfig.mockResolvedValue({ config: bedrockFirstConfig, mode: "active" })
+    mockClassify.mockResolvedValue({
+      intent: "general", tier: "light", confidence: 0.9,
+      reasonCodes: ["simple_request"], source: "classifier",
+    })
+
+    const result = await routeNexusRequest({
+      text: "Define photosynthesis", fallbackModelId: "gpt-terra", experienceMode: "standard",
+      requestedFamily: "auto", enabledConnectorIds: [], userId: 7,
+    })
+
+    expect(result.modelId).toBe("us.amazon.nova-lite-v1:0")
+    expect(result.metadata.selectedFamily).toBe("fallback")
+  })
+
+  it("uses the image specialist regardless of requested family", async () => {
+    mockClassify.mockResolvedValue({
+      intent: "image", tier: "medium", confidence: 0.99,
+      reasonCodes: ["explicit_image_request"], source: "deterministic",
+    })
+    const result = await routeNexusRequest({
+      text: "Create an image", fallbackModelId: "gpt-terra", experienceMode: "advanced",
+      requestedFamily: "anthropic", enabledConnectorIds: [], userId: 7,
+    })
+    expect(result.modelId).toBe("gemini-3.1-flash-image")
+  })
+
+  it("automatically attaches the database-backed PSD-data MCP server", async () => {
+    mockClassify.mockResolvedValue({
+      intent: "psd-data", tier: "medium", confidence: 0.98,
+      reasonCodes: ["psd_data_domain"], source: "deterministic",
+    })
+    mockExecuteQuery.mockResolvedValue([{ id: "54f0f531-f7ab-485e-bd6b-65a95c4bc871", name: "PSD Data" }])
+    const result = await routeNexusRequest({
+      text: "Get attendance", fallbackModelId: "gpt-terra", experienceMode: "standard",
+      requestedFamily: "auto", enabledConnectorIds: [], userId: 7,
+    })
+    expect(result.connectorIds).toEqual(["54f0f531-f7ab-485e-bd6b-65a95c4bc871"])
+    expect(result.metadata.autoAttachedPsdData).toBe(true)
+  })
+
+  it("records a proposed route but executes the fallback in shadow mode", async () => {
+    mockGetConfig.mockResolvedValue({ config, mode: "shadow" })
+    const result = await routeNexusRequest({
+      text: "Help", fallbackModelId: "gpt-terra", experienceMode: "advanced",
+      requestedFamily: "anthropic", enabledConnectorIds: [], userId: 7,
+    })
+    expect(result.modelId).toBe("gpt-terra")
+    expect(result.metadata.proposedModelId).toBe("us.anthropic.claude-sonnet")
+  })
+
+  it("stays in the Advanced family when the requested tier is unavailable", async () => {
+    mockClassify.mockResolvedValue({
+      intent: "general", tier: "high", confidence: 0.9,
+      reasonCodes: ["complex"], source: "classifier",
+    })
+    const result = await routeNexusRequest({
+      text: "Complex request", fallbackModelId: "gpt-terra", experienceMode: "advanced",
+      requestedFamily: "anthropic", enabledConnectorIds: [], userId: 7,
+    })
+    expect(result.modelId).toBe("us.anthropic.claude-sonnet")
+    expect(result.metadata.fallbackUsed).toBe(true)
+  })
+
+  it("does not silently cross an unavailable Advanced family", async () => {
+    mockFilterAccessibleResourceIds.mockResolvedValue(["1", "2", "4", "5", "6"])
+    await expect(routeNexusRequest({
+      text: "Help", fallbackModelId: "gpt-terra", experienceMode: "advanced",
+      requestedFamily: "anthropic", enabledConnectorIds: [], userId: 7,
+    })).rejects.toThrow("anthropic family")
+  })
+
+  it("keeps shadow mode non-disruptive when a proposed family is unavailable", async () => {
+    mockGetConfig.mockResolvedValue({ config, mode: "shadow" })
+    mockFilterAccessibleResourceIds.mockResolvedValue(["1", "2", "4", "5", "6"])
+    const result = await routeNexusRequest({
+      text: "Help", fallbackModelId: "gpt-terra", experienceMode: "advanced",
+      requestedFamily: "anthropic", enabledConnectorIds: [], userId: 7,
+    })
+    expect(result.modelId).toBe("gpt-terra")
+    expect(result.metadata.fallbackUsed).toBe(true)
+  })
+
+  it("never routes an ordinary request to a specialist-only Deep Research model", async () => {
+    mockClassify.mockResolvedValue({
+      intent: "general", tier: "high", confidence: 0.9,
+      reasonCodes: ["complex"], source: "classifier",
+    })
+    const result = await routeNexusRequest({
+      text: "Complex request", fallbackModelId: "gpt-terra", experienceMode: "standard",
+      requestedFamily: "auto", enabledConnectorIds: [], userId: 7,
+    })
+    expect(result.modelId).not.toBe("gemini-deep-research")
+    expect(result.modelId).toBe("gpt-terra")
+  })
+
+  it("fails clearly instead of answering an image request with a text model", async () => {
+    mockClassify.mockResolvedValue({
+      intent: "image", tier: "medium", confidence: 0.99,
+      reasonCodes: ["explicit_image_request"], source: "deterministic",
+    })
+    mockFilterAccessibleResourceIds.mockResolvedValue(["1", "2", "3", "4", "6"])
+    await expect(routeNexusRequest({
+      text: "Create an image", fallbackModelId: "gpt-terra", experienceMode: "standard",
+      requestedFamily: "auto", enabledConnectorIds: [], userId: 7,
+    })).rejects.toThrow("image-generation model")
+  })
+
+  it("continues without PSD-data when the connector lookup is unavailable", async () => {
+    mockClassify.mockResolvedValue({
+      intent: "psd-data", tier: "medium", confidence: 0.98,
+      reasonCodes: ["psd_data_domain"], source: "deterministic",
+    })
+    mockExecuteQuery.mockRejectedValue(new Error("database unavailable"))
+    const result = await routeNexusRequest({
+      text: "Get attendance", fallbackModelId: "gpt-terra", experienceMode: "standard",
+      requestedFamily: "auto", enabledConnectorIds: [], userId: 7,
+    })
+    expect(result.modelId).toBe("gpt-terra")
+    expect(result.connectorIds).toEqual([])
+    expect(result.metadata.autoAttachedPsdData).toBe(false)
+  })
+})

--- a/lib/nexus/model-router/classifier.ts
+++ b/lib/nexus/model-router/classifier.ts
@@ -1,0 +1,122 @@
+import { generateText, tool } from "ai"
+import { z } from "zod"
+import { createProviderModel } from "@/lib/ai/provider-factory"
+import { createLogger } from "@/lib/logger"
+import {
+  nexusRouterIntentSchema,
+  nexusRouterTierSchema,
+  type NexusClassifierDecision,
+  type NexusRouterConfig,
+} from "./types"
+
+const log = createLogger({ module: "nexus-model-router-classifier" })
+
+const IMAGE_PATTERN = /\b(generate|create|draw|design|make|edit|render)\b.{0,45}\b(image|picture|illustration|graphic|photo|poster|logo)\b|\b(image|picture|illustration|graphic|photo)\s+(generation|editing)\b/i
+const PSD_PATTERN = /\b(psd[- ]?data|power\s*school|student information system|student data|attendance|enrollment|gradebook|demographic)\b/i
+const INSTRUCTION_PATTERN = /\b(lesson plan|rubric|curriculum|learning objective|teaching strategy|differentiat(?:e|ion)|instructional|pedagogy|classroom activity|discussion questions)\b/i
+const HIGH_PATTERN = /\b(architecture|migration|security review|threat model|root cause|research report|multi-step|optimize|prove|complex analysis)\b/i
+const LIGHT_PATTERN = /^(hi|hello|thanks|thank you|yes|no|ok|okay)[!. ]*$|^(what is|who is|when is|where is|how many)\b|\b(define|translate|summarize briefly|quick question)\b/i
+
+const classifierOutputSchema = z.object({
+  intent: nexusRouterIntentSchema,
+  tier: nexusRouterTierSchema,
+  confidence: z.coerce.number().min(0).max(1),
+  reasonCodes: z.array(z.string().min(1).max(80)).max(5).default(["nova_classifier"]),
+})
+
+export function deterministicClassify(text: string, hasImageInput = false): NexusClassifierDecision | null {
+  if (hasImageInput && /\b(edit|change|remove|add|make|turn|replace|retouch|restyle|improve|enhance)\b/i.test(text)) {
+    return { intent: "image", tier: "medium", confidence: 0.98, reasonCodes: ["image_edit_request"], source: "deterministic" }
+  }
+  if (IMAGE_PATTERN.test(text)) {
+    return { intent: "image", tier: "medium", confidence: 0.99, reasonCodes: ["explicit_image_request"], source: "deterministic" }
+  }
+  if (PSD_PATTERN.test(text)) {
+    return { intent: "psd-data", tier: "medium", confidence: 0.97, reasonCodes: ["psd_data_domain"], source: "deterministic" }
+  }
+  if (INSTRUCTION_PATTERN.test(text)) {
+    return { intent: "instruction", tier: "medium", confidence: 0.95, reasonCodes: ["instruction_domain"], source: "deterministic" }
+  }
+  return null
+}
+
+export function heuristicFallback(text: string): NexusClassifierDecision {
+  const wordCount = text.trim().split(/\s+/).filter(Boolean).length
+  if (HIGH_PATTERN.test(text) || wordCount > 220) {
+    return { intent: "general", tier: "high", confidence: 0.5, reasonCodes: ["complexity_heuristic"], source: "fallback" }
+  }
+  if (LIGHT_PATTERN.test(text)) {
+    return { intent: "general", tier: "light", confidence: 0.5, reasonCodes: ["simple_request_heuristic"], source: "fallback" }
+  }
+  return { intent: "general", tier: "medium", confidence: 0.5, reasonCodes: ["safe_medium_fallback"], source: "fallback" }
+}
+
+function parseClassifierResponse(text: string): NexusClassifierDecision | null {
+  const jsonMatch = text.match(/\{[\s\S]*\}/)
+  if (!jsonMatch) return null
+  try {
+    const parsed = classifierOutputSchema.safeParse(JSON.parse(jsonMatch[0]))
+    if (!parsed.success) return null
+    return {
+      ...parsed.data,
+      source: "classifier",
+    }
+  } catch {
+    return null
+  }
+}
+
+function parseClassifierToolCall(toolCalls: unknown): NexusClassifierDecision | null {
+  if (!Array.isArray(toolCalls)) return null
+  for (const call of toolCalls) {
+    if (!call || typeof call !== "object") continue
+    const value = call as { toolName?: unknown; input?: unknown; args?: unknown }
+    if (value.toolName !== "route_request") continue
+    const parsed = classifierOutputSchema.safeParse(value.input ?? value.args)
+    if (parsed.success) return { ...parsed.data, source: "classifier" }
+  }
+  return null
+}
+
+export async function classifyNexusRequest(
+  text: string,
+  config: NexusRouterConfig,
+  context: { hasImageInput?: boolean } = {}
+): Promise<NexusClassifierDecision> {
+  const deterministic = deterministicClassify(text, context.hasImageInput)
+  if (deterministic) return deterministic
+
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), config.classifier.timeoutMs)
+  try {
+    const model = await createProviderModel(config.classifier.provider, config.classifier.modelId)
+    const result = await generateText({
+      model,
+      abortSignal: controller.signal,
+      maxOutputTokens: 120,
+      temperature: 0,
+      system: "You are a fast request router. Use the route_request tool. If tool use is unavailable, return JSON only with no markdown.",
+      prompt: `Classify the request for an education-focused assistant.\n\nIntent must be one of general, instruction, psd-data, image. Use instruction for pedagogy, lesson planning, rubrics, curriculum, differentiation, or teaching strategy. Use psd-data when answering requires district student-information-system records such as rosters, schedules, grades, attendance, enrollment, or student demographics; do not use it for generic advice about students. Use image when the user wants to generate or edit an image${context.hasImageInput ? "; an image is attached to this request" : ""}. Tier must be light for short/simple transformations and factual questions, medium for normal synthesis and planning, high only for complex multi-stage reasoning, architecture, difficult coding, or deep analysis.\n\nReturn exactly: {"intent":"general","tier":"medium","confidence":0.8,"reasonCodes":["short_reason"]}\n\nRequest:\n${text.slice(0, 8_000)}`,
+      tools: {
+        route_request: tool({
+          description: "Return the routing decision for this request",
+          inputSchema: classifierOutputSchema,
+        }),
+      },
+      toolChoice: { type: "tool", toolName: "route_request" },
+    })
+    const parsed = parseClassifierToolCall(result.toolCalls) ?? parseClassifierResponse(result.text)
+    if (parsed && parsed.confidence >= config.confidenceFloor) return parsed
+    log.warn("Nova classifier returned an invalid or low-confidence decision; using fallback", {
+      parsed: !!parsed,
+      confidence: parsed?.confidence,
+    })
+  } catch (error) {
+    log.warn("Nova classifier unavailable; using deterministic fallback", {
+      error: error instanceof Error ? error.message : String(error),
+    })
+  } finally {
+    clearTimeout(timeout)
+  }
+  return heuristicFallback(text)
+}

--- a/lib/nexus/model-router/classifier.ts
+++ b/lib/nexus/model-router/classifier.ts
@@ -81,9 +81,10 @@ function parseClassifierToolCall(toolCalls: unknown): NexusClassifierDecision | 
 export async function classifyNexusRequest(
   text: string,
   config: NexusRouterConfig,
-  context: { hasImageInput?: boolean } = {}
+  context: { hasImageInput?: boolean; hasPreviousGeneratedImage?: boolean } = {}
 ): Promise<NexusClassifierDecision> {
-  const deterministic = deterministicClassify(text, context.hasImageInput)
+  const hasImageContext = context.hasImageInput || context.hasPreviousGeneratedImage
+  const deterministic = deterministicClassify(text, hasImageContext)
   if (deterministic) return deterministic
 
   const controller = new AbortController()
@@ -96,7 +97,7 @@ export async function classifyNexusRequest(
       maxOutputTokens: 120,
       temperature: 0,
       system: "You are a fast request router. Use the route_request tool. If tool use is unavailable, return JSON only with no markdown.",
-      prompt: `Classify the request for an education-focused assistant.\n\nIntent must be one of general, instruction, psd-data, image. Use instruction for pedagogy, lesson planning, rubrics, curriculum, differentiation, or teaching strategy. Use psd-data when answering requires district student-information-system records such as rosters, schedules, grades, attendance, enrollment, or student demographics; do not use it for generic advice about students. Use image when the user wants to generate or edit an image${context.hasImageInput ? "; an image is attached to this request" : ""}. Tier must be light for short/simple transformations and factual questions, medium for normal synthesis and planning, high only for complex multi-stage reasoning, architecture, difficult coding, or deep analysis.\n\nReturn exactly: {"intent":"general","tier":"medium","confidence":0.8,"reasonCodes":["short_reason"]}\n\nRequest:\n${text.slice(0, 8_000)}`,
+      prompt: `Classify the request for an education-focused assistant.\n\nIntent must be one of general, instruction, psd-data, image. Use instruction for pedagogy, lesson planning, rubrics, curriculum, differentiation, or teaching strategy. Use psd-data when answering requires district student-information-system records such as rosters, schedules, grades, attendance, enrollment, or student demographics; do not use it for generic advice about students. Use image when the user wants to generate or edit an image${context.hasImageInput ? "; an image is attached to this request" : ""}${context.hasPreviousGeneratedImage ? "; a previously generated image is available for follow-up edits, but use image intent only when the request refers to editing or transforming it" : ""}. Tier must be light for short/simple transformations and factual questions, medium for normal synthesis and planning, high only for complex multi-stage reasoning, architecture, difficult coding, or deep analysis.\n\nReturn exactly: {"intent":"general","tier":"medium","confidence":0.8,"reasonCodes":["short_reason"]}\n\nRequest:\n${text.slice(0, 8_000)}`,
       tools: {
         route_request: tool({
           description: "Return the routing decision for this request",

--- a/lib/nexus/model-router/config.ts
+++ b/lib/nexus/model-router/config.ts
@@ -1,0 +1,47 @@
+import { getSettings } from "@/lib/settings-manager"
+import { createLogger } from "@/lib/logger"
+import {
+  nexusRouterConfigSchema,
+  nexusRouterRuntimeModeSchema,
+  type NexusRouterConfig,
+  type NexusRouterRuntimeMode,
+} from "./types"
+
+const log = createLogger({ module: "nexus-model-router-config" })
+
+export const NEXUS_ROUTER_CONFIG_KEY = "NEXUS_ROUTER_CONFIG_V1"
+export const NEXUS_ROUTER_MODE_KEY = "NEXUS_ROUTER_MODE"
+
+export async function getNexusRouterConfig(): Promise<{
+  config: NexusRouterConfig
+  mode: NexusRouterRuntimeMode
+}> {
+  const settings = await getSettings([NEXUS_ROUTER_CONFIG_KEY, NEXUS_ROUTER_MODE_KEY])
+  const rawMode = settings[NEXUS_ROUTER_MODE_KEY]
+  const modeResult = nexusRouterRuntimeModeSchema.safeParse(rawMode ?? "active")
+  const mode = modeResult.success ? modeResult.data : "shadow"
+  if (!modeResult.success) {
+    log.warn("Invalid Nexus router runtime mode; failing safely to shadow mode")
+  }
+
+  const rawConfig = settings[NEXUS_ROUTER_CONFIG_KEY]
+  if (!rawConfig) return { config: nexusRouterConfigSchema.parse({}), mode }
+
+  try {
+    const parsedJson: unknown = JSON.parse(rawConfig)
+    const parsedConfig = nexusRouterConfigSchema.safeParse(parsedJson)
+    if (parsedConfig.success) return { config: parsedConfig.data, mode }
+    log.warn("Invalid Nexus router configuration; using resilient defaults", {
+      issueCount: parsedConfig.error.issues.length,
+    })
+  } catch (error) {
+    log.warn("Could not parse Nexus router configuration; using resilient defaults", {
+      error: error instanceof Error ? error.message : String(error),
+    })
+  }
+
+  return {
+    config: nexusRouterConfigSchema.parse({}),
+    mode: mode === "active" ? "shadow" : mode,
+  }
+}

--- a/lib/nexus/model-router/config.ts
+++ b/lib/nexus/model-router/config.ts
@@ -18,7 +18,9 @@ export async function getNexusRouterConfig(): Promise<{
 }> {
   const settings = await getSettings([NEXUS_ROUTER_CONFIG_KEY, NEXUS_ROUTER_MODE_KEY])
   const rawMode = settings[NEXUS_ROUTER_MODE_KEY]
-  const modeResult = nexusRouterRuntimeModeSchema.safeParse(rawMode ?? "active")
+  // Existing deployments must explicitly promote the router after evaluating
+  // shadow metadata; a missing setting must never switch live traffic by itself.
+  const modeResult = nexusRouterRuntimeModeSchema.safeParse(rawMode ?? "shadow")
   const mode = modeResult.success ? modeResult.data : "shadow"
   if (!modeResult.success) {
     log.warn("Invalid Nexus router runtime mode; failing safely to shadow mode")

--- a/lib/nexus/model-router/router.ts
+++ b/lib/nexus/model-router/router.ts
@@ -1,0 +1,278 @@
+import { eq } from "drizzle-orm"
+import { getNexusEnabledModels } from "@/lib/db/drizzle"
+import { executeQuery } from "@/lib/db/drizzle-client"
+import { nexusMcpServers } from "@/lib/db/schema"
+import { filterAccessibleResourceIds } from "@/lib/db/drizzle/resource-access"
+import { createLogger } from "@/lib/logger"
+import { hasCapability } from "@/lib/ai/capability-utils"
+import { classifyNexusRequest } from "./classifier"
+import { getNexusRouterConfig } from "./config"
+import type {
+  NexusExperienceMode,
+  NexusModelFamily,
+  NexusRouteResult,
+  NexusRouterConfig,
+  NexusRouterIntent,
+  NexusRouterTier,
+} from "./types"
+
+const log = createLogger({ module: "nexus-model-router" })
+
+type NexusModelRow = Awaited<ReturnType<typeof getNexusEnabledModels>>[number]
+type ConcreteFamily = Exclude<NexusModelFamily, "auto">
+const EXECUTABLE_PROVIDERS = new Set(["openai", "google", "amazon-bedrock", "azure", "latimer"])
+
+function isSpecialistOnlyModel(model: NexusModelRow): boolean {
+  return hasCapability(model.capabilities, "imageGeneration")
+    || hasCapability(model.capabilities, "deepResearch")
+}
+
+export function inferFamily(model: NexusModelRow): ConcreteFamily | null {
+  const value = `${model.provider} ${model.modelId}`.toLowerCase()
+  if (value.includes("google") || value.includes("gemini")) return "google"
+  if (value.includes("anthropic") || value.includes("claude")) return "anthropic"
+  if (value.includes("openai") || value.includes("gpt-") || value.includes("azure")) return "openai"
+  return null
+}
+
+export function inferTier(model: NexusModelRow): NexusRouterTier {
+  const configured = model.providerMetadata?.nexusRouterTier
+  if (configured === "light" || configured === "medium" || configured === "high") return configured
+  const value = `${model.name} ${model.modelId}`.toLowerCase()
+  if (/haiku|flash-lite|flash lite|nano|mini|luna|micro/.test(value)) return "light"
+  if (/opus|fable|pro|sol|o3|o1|high/.test(value)) return "high"
+  return "medium"
+}
+
+function configuredCandidates(
+  config: NexusRouterConfig,
+  family: NexusModelFamily,
+  tier: NexusRouterTier,
+  intent: NexusRouterIntent
+): string[] {
+  if (intent === "image") return config.specialists.imageModels
+  if (intent === "instruction" && family === "auto" && config.specialists.instructionModels.length > 0) {
+    return config.specialists.instructionModels
+  }
+  if (family === "auto") return config.auto[tier]
+  return config.families[family][tier]
+}
+
+function firstAccessibleModel(
+  candidates: NexusModelRow[],
+  accessibleIds: Set<string>
+): NexusModelRow | null {
+  for (const candidate of candidates) {
+    if (!EXECUTABLE_PROVIDERS.has(candidate.provider.toLowerCase())) continue
+    if (accessibleIds.has(String(candidate.id))) return candidate
+  }
+  return null
+}
+
+function selectModel(args: {
+  models: NexusModelRow[]
+  config: NexusRouterConfig
+  family: NexusModelFamily
+  tier: NexusRouterTier
+  intent: NexusRouterIntent
+  fallbackModelId: string
+  accessibleIds: Set<string>
+}): { model: NexusModelRow; fallbackUsed: boolean } {
+  const configuredIds = configuredCandidates(args.config, args.family, args.tier, args.intent)
+  const configured = configuredIds
+    .map(id => args.models.find(model => model.modelId === id || String(model.id) === id))
+    .filter((model): model is NexusModelRow => {
+      if (!model) return false
+      if (args.intent === "image") {
+        return (model.provider === "google" || model.provider === "openai")
+          && hasCapability(model.capabilities, "imageGeneration")
+      }
+      if (isSpecialistOnlyModel(model)) return false
+      if (args.family !== "auto") return inferFamily(model) === args.family
+      if (args.intent === "instruction") return inferFamily(model) === "google"
+      // Standard/Auto is deliberately provider-neutral. Explicit candidates can
+      // therefore prefer Bedrock-native Nova or open-weight models even though
+      // they are not one of the three user-facing Advanced families.
+      return true
+    })
+  const configuredSelection = firstAccessibleModel(configured, args.accessibleIds)
+  if (configuredSelection) return { model: configuredSelection, fallbackUsed: false }
+
+  let inferred = args.models.filter(model => inferTier(model) === args.tier)
+  if (args.intent === "image") {
+    inferred = args.models.filter(model =>
+      (model.provider === "google" || model.provider === "openai")
+      && hasCapability(model.capabilities, "imageGeneration")
+    )
+  } else if (args.family === "auto" && args.intent === "instruction") {
+    inferred = inferred.filter(model => inferFamily(model) === "google" && !isSpecialistOnlyModel(model))
+  } else if (args.family !== "auto") {
+    inferred = inferred.filter(model => inferFamily(model) === args.family && !isSpecialistOnlyModel(model))
+  } else {
+    inferred = inferred.filter(model => !isSpecialistOnlyModel(model))
+  }
+  const inferredSelection = firstAccessibleModel(inferred, args.accessibleIds)
+  if (inferredSelection) return { model: inferredSelection, fallbackUsed: configuredIds.length > 0 }
+
+  if (args.intent !== "image") {
+    const tierPreference = [args.tier, "medium", "light", "high"] as const
+    const tierRank = new Map([...new Set(tierPreference)].map((tier, index) => [tier, index]))
+    const adjacentTierCandidates = args.models
+      .filter(model => {
+        const family = inferFamily(model)
+        if (isSpecialistOnlyModel(model)) return false
+        if (args.family !== "auto") return family === args.family
+        if (args.intent === "instruction") return family === "google"
+        return true
+      })
+      .sort((left, right) =>
+        (tierRank.get(inferTier(left)) ?? 99) - (tierRank.get(inferTier(right)) ?? 99)
+      )
+    const adjacentSelection = firstAccessibleModel(adjacentTierCandidates, args.accessibleIds)
+    if (adjacentSelection) return { model: adjacentSelection, fallbackUsed: true }
+  }
+
+  if (args.intent === "image") {
+    throw new Error("No accessible Nexus image-generation model is available")
+  }
+  if (args.family !== "auto") {
+    throw new Error(`No accessible Nexus model is available in the ${args.family} family`)
+  }
+
+  const fallback = args.models.find(model => model.modelId === args.fallbackModelId || String(model.id) === args.fallbackModelId)
+  if (fallback && !isSpecialistOnlyModel(fallback) && args.accessibleIds.has(String(fallback.id))) {
+    return { model: fallback, fallbackUsed: true }
+  }
+  const anyAccessible = firstAccessibleModel(
+    args.models.filter(model => !isSpecialistOnlyModel(model)),
+    args.accessibleIds
+  )
+  if (!anyAccessible) throw new Error("No accessible Nexus model is available")
+  return { model: anyAccessible, fallbackUsed: true }
+}
+
+async function resolvePsdDataConnector(config: NexusRouterConfig): Promise<string | null> {
+  if (config.specialists.psdDataConnectorId) {
+    const [row] = await executeQuery(
+      db => db.select({ id: nexusMcpServers.id }).from(nexusMcpServers)
+        .where(eq(nexusMcpServers.id, config.specialists.psdDataConnectorId!)).limit(1),
+      "resolvePsdDataConnectorById"
+    )
+    return row?.id ?? null
+  }
+  const rows = await executeQuery(
+    db => db.select({ id: nexusMcpServers.id, name: nexusMcpServers.name }).from(nexusMcpServers),
+    "resolvePsdDataConnectorByName"
+  )
+  const normalize = (value: string) => value.toLowerCase().replaceAll(/[^a-z0-9]/g, "")
+  const configuredName = normalize(config.specialists.psdDataConnectorName)
+  return rows.find(row => normalize(row.name) === configuredName)?.id ?? null
+}
+
+async function resolveAutomaticPsdConnector(
+  intent: NexusRouterIntent,
+  config: NexusRouterConfig
+): Promise<string | null> {
+  if (intent !== "psd-data") return null
+  try {
+    const connectorId = await resolvePsdDataConnector(config)
+    if (!connectorId) {
+      log.warn("PSD-data route requested but the configured database MCP server was not found")
+    }
+    return connectorId
+  } catch (error) {
+    log.warn("PSD-data MCP lookup failed; continuing with the routed model", {
+      error: error instanceof Error ? error.message : String(error),
+    })
+    return null
+  }
+}
+
+function selectModelForRuntime(
+  args: Parameters<typeof selectModel>[0],
+  mode: NexusRouteResult["metadata"]["runtimeMode"],
+  fallback: NexusModelRow
+): { model: NexusModelRow; fallbackUsed: boolean } {
+  try {
+    return selectModel(args)
+  } catch (error) {
+    if (mode !== "shadow") throw error
+    log.warn("Proposed route could not be resolved; shadow mode is retaining the legacy model", {
+      error: error instanceof Error ? error.message : String(error),
+    })
+    return { model: fallback, fallbackUsed: true }
+  }
+}
+
+export async function routeNexusRequest(args: {
+  text: string
+  fallbackModelId: string
+  experienceMode: NexusExperienceMode
+  requestedFamily: NexusModelFamily
+  enabledConnectorIds: string[]
+  userId: number
+  hasImageInput?: boolean
+}): Promise<NexusRouteResult> {
+  const { config, mode } = await getNexusRouterConfig()
+  const models = await getNexusEnabledModels()
+  const accessibleIds = new Set(await filterAccessibleResourceIds(
+    args.userId,
+    "model",
+    models.map(model => model.id)
+  ))
+  const fallback = models.find(model => model.modelId === args.fallbackModelId || String(model.id) === args.fallbackModelId)
+  if (!fallback) throw new Error("The fallback Nexus model is unavailable")
+
+  if (mode === "off") {
+    return {
+      modelId: fallback.modelId,
+      connectorIds: args.enabledConnectorIds,
+      metadata: {
+        version: config.version, runtimeMode: mode, experienceMode: args.experienceMode,
+        requestedFamily: args.requestedFamily, selectedFamily: inferFamily(fallback) ?? "fallback",
+        intent: "general", tier: inferTier(fallback), confidence: 1,
+        reasonCodes: ["router_off"], decisionSource: "fallback", selectedModelId: fallback.modelId,
+        fallbackUsed: false, autoAttachedPsdData: false,
+      },
+    }
+  }
+
+  const decision = await classifyNexusRequest(args.text, config, { hasImageInput: args.hasImageInput })
+  const selection = selectModelForRuntime({
+    models, config, family: args.requestedFamily, tier: decision.tier,
+    intent: decision.intent, fallbackModelId: args.fallbackModelId, accessibleIds,
+  }, mode, fallback)
+  const psdConnectorId = await resolveAutomaticPsdConnector(decision.intent, config)
+  const proposedConnectors = psdConnectorId
+    ? [...new Set([...args.enabledConnectorIds, psdConnectorId])]
+    : args.enabledConnectorIds
+  const selected = mode === "shadow" ? fallback : selection.model
+  const connectorIds = mode === "shadow" ? args.enabledConnectorIds : proposedConnectors
+
+  log.info("Nexus request routed", {
+    mode, intent: decision.intent, tier: decision.tier, requestedFamily: args.requestedFamily,
+    selectedModelId: selected.modelId, proposedModelId: selection.model.modelId,
+    fallbackUsed: selection.fallbackUsed, autoAttachedPsdData: !!psdConnectorId,
+  })
+
+  return {
+    modelId: selected.modelId,
+    connectorIds,
+    metadata: {
+      version: config.version,
+      runtimeMode: mode,
+      experienceMode: args.experienceMode,
+      requestedFamily: args.requestedFamily,
+      selectedFamily: inferFamily(selected) ?? "fallback",
+      intent: decision.intent,
+      tier: decision.tier,
+      confidence: decision.confidence,
+      reasonCodes: decision.reasonCodes,
+      decisionSource: decision.source,
+      selectedModelId: selected.modelId,
+      proposedModelId: mode === "shadow" ? selection.model.modelId : undefined,
+      fallbackUsed: selection.fallbackUsed || (mode === "shadow" && selection.model.modelId !== fallback.modelId),
+      autoAttachedPsdData: mode === "active" && !!psdConnectorId,
+    },
+  }
+}

--- a/lib/nexus/model-router/router.ts
+++ b/lib/nexus/model-router/router.ts
@@ -20,6 +20,8 @@ const log = createLogger({ module: "nexus-model-router" })
 
 type NexusModelRow = Awaited<ReturnType<typeof getNexusEnabledModels>>[number]
 type ConcreteFamily = Exclude<NexusModelFamily, "auto">
+// Latimer is intentionally executable only through provider-neutral Standard/Auto
+// candidates; it is not exposed as one of the three Advanced model families.
 const EXECUTABLE_PROVIDERS = new Set(["openai", "google", "amazon-bedrock", "azure", "latimer"])
 
 function isSpecialistOnlyModel(model: NexusModelRow): boolean {
@@ -212,6 +214,7 @@ export async function routeNexusRequest(args: {
   enabledConnectorIds: string[]
   userId: number
   hasImageInput?: boolean
+  hasPreviousGeneratedImage?: boolean
 }): Promise<NexusRouteResult> {
   const { config, mode } = await getNexusRouterConfig()
   const models = await getNexusEnabledModels()
@@ -237,7 +240,10 @@ export async function routeNexusRequest(args: {
     }
   }
 
-  const decision = await classifyNexusRequest(args.text, config, { hasImageInput: args.hasImageInput })
+  const decision = await classifyNexusRequest(args.text, config, {
+    hasImageInput: args.hasImageInput,
+    hasPreviousGeneratedImage: args.hasPreviousGeneratedImage,
+  })
   const selection = selectModelForRuntime({
     models, config, family: args.requestedFamily, tier: decision.tier,
     intent: decision.intent, fallbackModelId: args.fallbackModelId, accessibleIds,

--- a/lib/nexus/model-router/types.ts
+++ b/lib/nexus/model-router/types.ts
@@ -1,0 +1,94 @@
+import { z } from "zod"
+
+export const nexusExperienceModeSchema = z.enum(["standard", "advanced"])
+export const nexusModelFamilySchema = z.enum(["auto", "openai", "anthropic", "google"])
+export const nexusRouterTierSchema = z.enum(["light", "medium", "high"])
+export const nexusRouterIntentSchema = z.enum(["general", "instruction", "psd-data", "image"])
+export const nexusRouterRuntimeModeSchema = z.enum(["off", "shadow", "active"])
+
+export type NexusExperienceMode = z.infer<typeof nexusExperienceModeSchema>
+export type NexusModelFamily = z.infer<typeof nexusModelFamilySchema>
+export type NexusRouterTier = z.infer<typeof nexusRouterTierSchema>
+export type NexusRouterIntent = z.infer<typeof nexusRouterIntentSchema>
+export type NexusRouterRuntimeMode = z.infer<typeof nexusRouterRuntimeModeSchema>
+
+const candidateListSchema = z.array(z.string().min(1)).max(10).default([])
+const tierCandidatesSchema = z.object({
+  light: candidateListSchema,
+  medium: candidateListSchema,
+  high: candidateListSchema,
+})
+
+export const nexusRouterConfigSchema = z.object({
+  version: z.string().min(1).max(50).default("1"),
+  classifier: z.object({
+    provider: z.string().min(1).default("amazon-bedrock"),
+    modelId: z.string().min(1).default("us.amazon.nova-micro-v1:0"),
+    timeoutMs: z.number().int().min(500).max(10_000).default(2_500),
+  }).default({
+    provider: "amazon-bedrock",
+    modelId: "us.amazon.nova-micro-v1:0",
+    timeoutMs: 2_500,
+  }),
+  families: z.object({
+    openai: tierCandidatesSchema,
+    anthropic: tierCandidatesSchema,
+    google: tierCandidatesSchema,
+  }).default({
+    openai: { light: [], medium: [], high: [] },
+    anthropic: { light: [], medium: [], high: [] },
+    google: { light: [], medium: [], high: [] },
+  }),
+  auto: tierCandidatesSchema.default({ light: [], medium: [], high: [] }),
+  specialists: z.object({
+    imageModels: z.array(z.string().min(1)).max(10).default([
+      "gemini-3.1-flash-image-preview",
+      "gemini-3.1-flash-image",
+    ]),
+    instructionModels: z.array(z.string().min(1)).max(10).default([
+      "gemini-3.5-flash",
+      "gemini-3-flash-preview",
+      "gemini-2.5-flash",
+    ]),
+    psdDataConnectorId: z.string().uuid().optional(),
+    psdDataConnectorName: z.string().min(1).max(255).default("psd-data"),
+  }).default({
+    imageModels: ["gemini-3.1-flash-image-preview", "gemini-3.1-flash-image"],
+    instructionModels: ["gemini-3.5-flash", "gemini-3-flash-preview", "gemini-2.5-flash"],
+    psdDataConnectorName: "psd-data",
+  }),
+  confidenceFloor: z.number().min(0).max(1).default(0.55),
+})
+
+export type NexusRouterConfig = z.infer<typeof nexusRouterConfigSchema>
+
+export interface NexusClassifierDecision {
+  intent: NexusRouterIntent
+  tier: NexusRouterTier
+  confidence: number
+  reasonCodes: string[]
+  source: "deterministic" | "classifier" | "fallback"
+}
+
+export interface NexusRoutingMetadata {
+  version: string
+  runtimeMode: NexusRouterRuntimeMode
+  experienceMode: NexusExperienceMode
+  requestedFamily: NexusModelFamily
+  selectedFamily: Exclude<NexusModelFamily, "auto"> | "fallback"
+  intent: NexusRouterIntent
+  tier: NexusRouterTier
+  confidence: number
+  reasonCodes: string[]
+  decisionSource: NexusClassifierDecision["source"]
+  selectedModelId: string
+  proposedModelId?: string
+  fallbackUsed: boolean
+  autoAttachedPsdData: boolean
+}
+
+export interface NexusRouteResult {
+  modelId: string
+  connectorIds: string[]
+  metadata: NexusRoutingMetadata
+}

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,4 +1,19 @@
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
 /** @type {import('next').NextConfig} */
+
+const PROJECT_ROOT = path.dirname(fileURLToPath(import.meta.url))
+
+// Bun's isolated linker can install multiple physical copies of CodeMirror's
+// state/view packages, even when they resolve to the same version. CodeMirror
+// relies on instanceof checks for extension values, so bundling more than one
+// copy crashes the editor at runtime. Pin both bundlers to the root copies so
+// every CodeMirror extension shares the same module identity.
+const codeMirrorAliases = {
+  '@codemirror/state': './node_modules/@codemirror/state',
+  '@codemirror/view': './node_modules/@codemirror/view',
+}
 
 // Scope S3 image remote patterns to the application's own bucket/region
 // so next/image optimization cannot be used to proxy arbitrary S3 content.
@@ -35,6 +50,9 @@ const nextConfig = {
   // parallel Playwright load. See scripts/test/e2e-local.sh.
   distDir: process.env.NEXT_DIST_DIR || '.next',
   transpilePackages: ['recharts'],
+  turbopack: {
+    resolveAlias: codeMirrorAliases,
+  },
   serverExternalPackages: ['winston', 'logform', '@colors/colors', 'argon2', 'postgres', 'mammoth', 'pdf-parse', 'oidc-provider', 'ws',
     // Atrium collab (#1051): the agent-bridge route opens a y-websocket client to
     // the collab server. These pure-ESM Yjs libs must run as real Node modules on
@@ -115,6 +133,12 @@ const nextConfig = {
     config.cache = {
       type: 'memory',
       maxGenerations: 1,
+    };
+
+    config.resolve.alias = {
+      ...config.resolve.alias,
+      '@codemirror/state': path.join(PROJECT_ROOT, 'node_modules/@codemirror/state'),
+      '@codemirror/view': path.join(PROJECT_ROOT, 'node_modules/@codemirror/view'),
     };
 
     if (isServer) {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -28,7 +28,7 @@ import { defineConfig, devices } from '@playwright/test'
  * nexus CRUD/ownership, atrium) runs in CI.
  */
 const EXTERNAL_PROVIDER_SPECS =
-  /(voice-mode|assistant-architect-(streaming|tools|agentic-mode)|nexus-chat-tools|nexus-tools|model-compare-polling|nexus\/(chat-core|advanced))\.spec\.ts$/
+  /(voice-mode|assistant-architect-(streaming|tools|agentic-mode)|nexus-chat-tools|model-compare-polling|nexus\/(chat-core|advanced))\.spec\.ts$/
 
 export default defineConfig({
   testDir: './tests/e2e',

--- a/scripts/db/seed-local.sql
+++ b/scripts/db/seed-local.sql
@@ -75,6 +75,11 @@ FROM users u CROSS JOIN roles r
 WHERE u.email = 'staff@example.com' AND r.name = 'staff'
 ON CONFLICT (user_id, role_id) DO NOTHING;
 
+-- Keep the dedicated router E2E identity deterministic across local runs. Router
+-- tests use the staff account so they never race with the larger admin suite.
+DELETE FROM nexus_user_preferences
+WHERE user_id = (SELECT id FROM users WHERE cognito_sub = 'e2e-staff-user');
+
 -- Student user for testing student-level access.
 -- cognito_sub is the unique key (email is not); deterministic value keeps the
 -- seed idempotent (see staff user note above).

--- a/tests/e2e/nexus-chat-tools.spec.ts
+++ b/tests/e2e/nexus-chat-tools.spec.ts
@@ -24,7 +24,7 @@ import { test, expect } from './fixtures'
 
 function chatBody(enabledTools: string[]) {
   return {
-    messages: [{ role: 'user', content: 'hello' }],
+    messages: [{ id: 'tool-gate-message', role: 'user', content: 'hello' }],
     modelId: 'gpt-4o',
     provider: 'openai',
     enabledTools,

--- a/tests/e2e/nexus-tools.spec.ts
+++ b/tests/e2e/nexus-tools.spec.ts
@@ -19,10 +19,18 @@ test.describe('Nexus AI Tools Integration', () => {
     await page.waitForSelector('[data-testid="nexus-shell"]', { timeout: 10000 })
   })
 
-  // nexus auto-selects a model on load, so the composer's Tools control is enabled
-  // without a manual pick. Open the Tools popover and wait until its content shows.
+  // Standard intentionally hides manual tools. Opt into Advanced/Auto before
+  // exercising the legacy optional tool controls.
+  async function enableAdvanced(page: Page) {
+    const routing = page.getByRole('button', { name: 'Nexus routing mode' })
+    await routing.click()
+    await page.getByTestId('nexus-family-auto').click()
+    await expect(routing).toContainText('Auto')
+  }
+
   async function openTools(page: Page) {
-    const toolsButton = page.getByRole('button', { name: /Tools/ })
+    await enableAdvanced(page)
+    const toolsButton = page.getByTestId('nexus-tools-control')
     await expect(toolsButton).toBeEnabled({ timeout: 15000 })
     await toolsButton.click()
     await expect(page.getByRole('heading', { name: 'AI Tools' })).toBeVisible()
@@ -39,33 +47,26 @@ test.describe('Nexus AI Tools Integration', () => {
     }
   })
 
-  test('toggles a tool when the selected model offers one', async ({ page }) => {
+  test('toggles a tool when offered or clearly reports that none are available', async ({ page }) => {
     await openTools(page)
     const firstSwitch = page.getByRole('switch').first()
     const hasTools = await firstSwitch.isVisible().catch(() => false)
-    test.skip(!hasTools, 'The selected model offers no tools in this seed environment')
-    const wasOn = await firstSwitch.isChecked()
-    await firstSwitch.click()
-    await expect(firstSwitch).toBeChecked({ checked: !wasOn })
-    await firstSwitch.click()
-    await expect(firstSwitch).toBeChecked({ checked: wasOn })
+    if (hasTools) {
+      const wasOn = await firstSwitch.isChecked()
+      await firstSwitch.click()
+      await expect(firstSwitch).toBeChecked({ checked: !wasOn })
+      await firstSwitch.click()
+      await expect(firstSwitch).toBeChecked({ checked: wasOn })
+    } else {
+      await expect(page.getByText(/No tools available/i)).toBeVisible()
+    }
   })
 
-  test('opens the model picker and lists selectable models', async ({ page }) => {
-    const picker = page.getByRole('button', { name: /Select AI model/i })
-    await expect(picker).toBeVisible({ timeout: 15000 })
-    await picker.click()
-    await expect(page.getByRole('heading', { name: 'AI Model' })).toBeVisible()
-    await expect(page.getByText('Choose the model for this conversation')).toBeVisible()
+  test('Advanced uses family routing and never restores the exact-model picker', async ({ page }) => {
+    await enableAdvanced(page)
+    await expect(page.getByTestId('nexus-tools-control')).toBeVisible()
+    await expect(page.getByTestId('nexus-mcp-control')).toBeVisible()
+    await expect(page.getByRole('button', { name: /Select AI model/i })).toHaveCount(0)
   })
 
-})
-
-test.describe('Tool Registry API', () => {
-  test('should return available tools for a model', async ({ request }) => {
-    // This would test the API endpoint that returns model capabilities
-    // For now, we'll test that the model has nexus_capabilities data
-    
-    test.skip(true, 'API endpoint test - would require direct database access or API route')
-  })
 })

--- a/tests/e2e/nexus-workspace-chat-tools.spec.ts
+++ b/tests/e2e/nexus-workspace-chat-tools.spec.ts
@@ -9,9 +9,8 @@ import { authenticateContext } from "./helpers/session-auth";
  * they do NOT depend on a live LLM deciding to call a tool):
  *  1. With a workspace open, the chat request body carries `workspaceId` — the
  *     server uses it to bind read/edit content tools.
- *  2. Switching the model with a workspace open PRESERVES `?workspace=` (the
- *     model-change reset used to drop it, silently closing the open document and
- *     its content tools).
+ *  2. Switching the Advanced family with a workspace open PRESERVES
+ *     `?workspace=` and the open document/content tools.
  *
  * The live edit path (chat → agent bridge → live Yjs doc, chat → createVersion)
  * is proven separately; asserting it here would couple CI to a real model call.
@@ -21,11 +20,18 @@ import { authenticateContext } from "./helpers/session-auth";
 
 const OBJ_SLUG = process.env.ATRIUM_EDITOR_E2E_SLUG ?? "atrium-editor-e2e";
 
-async function pickAnyOtherModel(page: import("@playwright/test").Page) {
-  await page.locator('button[aria-label="Select AI model"]').first().click({ timeout: 10_000 });
-  const pop = page.locator('[data-radix-popper-content-wrapper], [role="dialog"]').last();
-  // Pick the second listed model (any change triggers the model-change reset).
-  await pop.locator("button").nth(1).click({ timeout: 5_000 });
+const MOCK_CHAT_STREAM = [
+  'data: {"type":"start","messageId":"e2e-workspace-assistant"}\n\n',
+  'data: {"type":"text-start","id":"e2e-workspace-text"}\n\n',
+  'data: {"type":"text-delta","id":"e2e-workspace-text","delta":"ok"}\n\n',
+  'data: {"type":"text-end","id":"e2e-workspace-text"}\n\n',
+  'data: {"type":"finish","finishReason":"stop"}\n\n',
+  'data: [DONE]\n\n',
+].join("");
+
+async function chooseClaudeFamily(page: import("@playwright/test").Page) {
+  await page.getByRole("button", { name: "Nexus routing mode" }).click();
+  await page.getByTestId("nexus-family-anthropic").click();
 }
 
 test.describe("Nexus workspace chat tools (§1087, authenticated)", () => {
@@ -34,26 +40,32 @@ test.describe("Nexus workspace chat tools (§1087, authenticated)", () => {
     "Requires the authed host dev server + seeded doc"
   );
 
-  test("chat request carries workspaceId, preserved across a model change", async ({ browser }) => {
+  test("chat request carries workspaceId, preserved across a family change", async ({ browser }) => {
     const context = await browser.newContext();
     await authenticateContext(context);
     try {
       const page = await context.newPage();
 
       const chatBodies: string[] = [];
-      page.on("request", (r) => {
-        if (r.url().includes("/api/nexus/chat") && r.method() === "POST") {
-          chatBodies.push(r.postData() ?? "");
-        }
-      });
+      await page.route("**/api/nexus/chat", async (route) => {
+        chatBodies.push(route.request().postData() ?? "");
+        await route.fulfill({
+          status: 200,
+          headers: {
+            "Content-Type": "text/event-stream",
+            "x-vercel-ai-ui-message-stream": "v1",
+          },
+          body: MOCK_CHAT_STREAM,
+        });
+      }, { times: 1 });
 
       await page.goto(`/nexus?workspace=${OBJ_SLUG}`);
       const panel = page.getByTestId("workspace-panel");
       await expect(panel).toBeVisible({ timeout: 60_000 });
 
-      // Switch the model — this triggers the clean-URL reset. It MUST keep the
-      // workspace open (regression: it used to reload to a bare /nexus).
-      await pickAnyOtherModel(page);
+      // Change the Advanced family. The router control must not disturb the
+      // workspace or fragile conversation runtime.
+      await chooseClaudeFamily(page);
       await expect(page).toHaveURL(/workspace=/, { timeout: 20_000 });
       await expect(page.getByTestId("workspace-panel")).toBeVisible({ timeout: 60_000 });
 

--- a/tests/e2e/nexus/advanced.spec.ts
+++ b/tests/e2e/nexus/advanced.spec.ts
@@ -2,7 +2,9 @@ import { test, expect } from '../fixtures'
 import { gotoNexus, sendMessage, waitForStreamingComplete, getConversationIdFromUrl } from './utils'
 import { authenticateContext } from '../helpers/session-auth'
 
-// Advanced Nexus E2E tests — fork conversation, model/tool/voice selectors, error handling.
+// Advanced Nexus E2E tests — fork conversation, voice, error handling, and persistence.
+// Deterministic model-router UI/wire coverage lives in model-router.spec.ts so it
+// remains runnable when live external-provider specs are excluded.
 
 // ── Fork API — Auth-independent ───────────────────────────────────────────────
 
@@ -88,9 +90,9 @@ test.describe('Nexus Fork Conversation — Authenticated', () => {
   })
 })
 
-// ── Model Selector UI — Authenticated ────────────────────────────────────────
+// ── Voice UI — Authenticated ─────────────────────────────────────────────────
 
-test.describe('Nexus Model Selector — Authenticated', () => {
+test.describe('Nexus Voice UI — Authenticated', () => {
   test.skip(
     !process.env.PLAYWRIGHT_AUTH_ENABLED,
     'Requires authenticated Playwright context — set PLAYWRIGHT_AUTH_ENABLED=true to run'
@@ -99,50 +101,6 @@ test.describe('Nexus Model Selector — Authenticated', () => {
   test.beforeEach(async ({ page }) => {
     await authenticateContext(page.context())
     await gotoNexus(page)
-  })
-
-  test('model selector renders and is interactive', async ({ page }) => {
-    // Use isVisible() + short waitFor instead of count() — count() doesn't auto-wait
-    // and can return 0 on a still-rendering page, causing silent false-passes.
-    let modelSelectorFound = false
-    try {
-      await page.locator('[data-testid="model-selector"]').waitFor({ state: 'visible', timeout: 3_000 })
-      modelSelectorFound = true
-    } catch {
-      // Not present — check fallback selector
-    }
-
-    if (modelSelectorFound) {
-      const modelSelector = page.locator('[data-testid="model-selector"]')
-      await expect(modelSelector).toBeVisible()
-      await modelSelector.click()
-      const options = page.locator('[data-testid="model-option"]')
-      await expect(options.first()).toBeVisible({ timeout: 5_000 })
-    } else {
-      // Model selector may use different structure — check for button/select
-      try {
-        await page
-          .locator('button')
-          .filter({ hasText: /model|gpt|claude|gemini/i })
-          .first()
-          .waitFor({ state: 'visible', timeout: 3_000 })
-        await expect(
-          page.locator('button').filter({ hasText: /model|gpt|claude|gemini/i }).first()
-        ).toBeVisible()
-      } catch {
-        test.skip(true, 'Model selector not present in this environment')
-      }
-    }
-  })
-
-  test('tool selector renders for models that support tools', async ({ page }) => {
-    // Use waitFor instead of count() to properly wait for rendering
-    try {
-      await page.locator('[data-testid="tool-selector"]').waitFor({ state: 'visible', timeout: 3_000 })
-      await expect(page.locator('[data-testid="tool-selector"]')).toBeVisible()
-    } catch {
-      test.skip(true, 'Tool selector not visible (model may not support tools)')
-    }
   })
 
   test('voice button renders (enabled or disabled state)', async ({ page }) => {
@@ -294,6 +252,47 @@ test.describe('Nexus Message Persistence — Authenticated', () => {
 
   test.beforeEach(async ({ page }) => {
     await authenticateContext(page.context())
+  })
+
+  test('a live response exposes and persists its model-router decision', async ({ page }) => {
+    await gotoNexus(page)
+    const routingButton = page.getByRole('button', { name: 'Nexus routing mode' })
+    await routingButton.click()
+    await page.getByTestId('nexus-mode-standard').click()
+
+    const responsePromise = page.waitForResponse(response =>
+      response.url().includes('/api/nexus/chat')
+      && response.request().method() === 'POST'
+      && response.status() === 200
+    )
+    await sendMessage(page, 'Reply with only the word routed')
+    const response = await responsePromise
+    const encodedRouting = await response.headerValue('x-nexus-routing')
+    expect(encodedRouting).toBeTruthy()
+
+    const responseRouting = JSON.parse(decodeURIComponent(encodedRouting!)) as Record<string, unknown>
+    expect(responseRouting.experienceMode).toBe('standard')
+    expect(responseRouting.requestedFamily).toBe('auto')
+    expect(typeof responseRouting.selectedModelId).toBe('string')
+    expect(['deterministic', 'classifier', 'fallback']).toContain(responseRouting.decisionSource)
+
+    await waitForStreamingComplete(page)
+    const conversationId = getConversationIdFromUrl(page)
+    expect(conversationId).toBeTruthy()
+    const stored = await page.evaluate(async id => {
+      const result = await fetch(`/api/nexus/conversations/${id}/messages`)
+      return result.json()
+    }, conversationId!)
+    const assistant = [...stored.messages]
+      .reverse()
+      .find((message: { role: string }) => message.role === 'assistant') as {
+        metadata?: { routing?: Record<string, unknown> }
+      } | undefined
+    expect(assistant?.metadata?.routing).toMatchObject({
+      experienceMode: 'standard',
+      requestedFamily: 'auto',
+      selectedModelId: responseRouting.selectedModelId,
+    })
   })
 
   test('messages sent in chat are retrievable from /api/nexus/conversations/<id>/messages', async ({

--- a/tests/e2e/nexus/model-router.spec.ts
+++ b/tests/e2e/nexus/model-router.spec.ts
@@ -1,0 +1,227 @@
+import { test, expect, type Page } from '../fixtures'
+import { authenticateContext } from '../helpers/session-auth'
+import { gotoNexus, sendMessage } from './utils'
+
+/**
+ * Deterministic E2E coverage for the Nexus model-router experience.
+ *
+ * These tests intercept the outbound chat request after the real authenticated
+ * UI constructs it. They therefore cover browser state → transport wiring without
+ * spending provider tokens or depending on Bedrock/OpenAI/Google availability.
+ * Router selection itself is exhaustively covered by the model-router unit suite.
+ * This file deliberately does not match Playwright's live-provider exclusion regex.
+ */
+
+const ROUTER_EMAIL = 'staff@example.com'
+const ROUTER_SUB = 'e2e-staff-user'
+
+interface CapturedChatBody {
+  messages: Array<Record<string, unknown>>
+  modelId: string
+  nexusMode: 'standard' | 'advanced'
+  modelFamily: 'auto' | 'openai' | 'anthropic' | 'google'
+  enabledTools?: string[]
+  enabledConnectors?: string[]
+}
+
+const MOCK_CHAT_STREAM = [
+  'data: {"type":"start","messageId":"e2e-router-assistant"}\n\n',
+  'data: {"type":"text-start","id":"e2e-router-text"}\n\n',
+  'data: {"type":"text-delta","id":"e2e-router-text","delta":"ok"}\n\n',
+  'data: {"type":"text-end","id":"e2e-router-text"}\n\n',
+  'data: {"type":"finish","finishReason":"stop"}\n\n',
+  'data: [DONE]\n\n',
+].join('')
+
+async function installChatCapture(page: Page): Promise<{ body: Promise<CapturedChatBody> }> {
+  let resolveBody: (body: CapturedChatBody) => void = () => undefined
+  let rejectBody: (error: Error) => void = () => undefined
+  const body = new Promise<CapturedChatBody>((resolve, reject) => {
+    resolveBody = resolve
+    rejectBody = reject
+  })
+
+  await page.route('**/api/nexus/chat', async route => {
+    try {
+      const requestBody = route.request().postDataJSON() as CapturedChatBody
+      await route.fulfill({
+        status: 200,
+        headers: {
+          'Content-Type': 'text/event-stream',
+          'x-vercel-ai-ui-message-stream': 'v1',
+        },
+        body: MOCK_CHAT_STREAM,
+      })
+      resolveBody(requestBody)
+    } catch (error) {
+      rejectBody(error instanceof Error ? error : new Error(String(error)))
+    }
+  }, { times: 1 })
+
+  return { body }
+}
+
+async function selectStandard(page: Page): Promise<void> {
+  const routing = page.getByRole('button', { name: 'Nexus routing mode' })
+  await routing.click()
+  await page.getByTestId('nexus-mode-standard').click()
+  await expect(routing).toContainText('Standard')
+}
+
+async function selectFamily(
+  page: Page,
+  family: CapturedChatBody['modelFamily'],
+  label: string
+): Promise<void> {
+  const routing = page.getByRole('button', { name: 'Nexus routing mode' })
+  await routing.click()
+  await page.getByTestId(`nexus-family-${family}`).click()
+  await expect(routing).toContainText(label)
+}
+
+async function capturePrompt(page: Page, prompt: string): Promise<CapturedChatBody> {
+  const capture = await installChatCapture(page)
+  await sendMessage(page, prompt)
+  return capture.body
+}
+
+test.describe('Nexus model router — authenticated deterministic UI and wire contract', () => {
+  // Every test uses the dedicated staff identity. The local seed clears only this
+  // identity's Nexus preference so the first test proves the fresh-user default.
+  test.describe.configure({ mode: 'serial' })
+  test.skip(
+    process.env.PLAYWRIGHT_AUTH_ENABLED !== 'true',
+    'Requires the authenticated host dev server; no external AI provider is used'
+  )
+
+  test.beforeEach(async ({ page }) => {
+    await authenticateContext(page.context(), ROUTER_EMAIL, ROUTER_SUB)
+    await gotoNexus(page)
+  })
+
+  test('a freshly seeded user starts in Standard with no exact-model or manual-tool controls', async ({ page }) => {
+    const routing = page.getByRole('button', { name: 'Nexus routing mode' })
+    await expect(routing).toContainText('Standard')
+    await expect(page.getByRole('button', { name: /Select AI model/i })).toHaveCount(0)
+    await expect(page.getByTestId('nexus-tools-control')).toHaveCount(0)
+    await expect(page.getByTestId('nexus-skills-control')).toHaveCount(0)
+    await expect(page.getByTestId('nexus-mcp-control')).toHaveCount(0)
+  })
+
+  test('Advanced exposes only family routing plus optional tools, skills, and MCP controls', async ({ page }) => {
+    const routing = page.getByRole('button', { name: 'Nexus routing mode' })
+    await routing.click()
+    await expect(page.getByTestId('nexus-mode-standard')).toBeVisible()
+    await expect(page.getByTestId('nexus-family-auto')).toBeVisible()
+    await expect(page.getByTestId('nexus-family-openai')).toContainText('ChatGPT')
+    await expect(page.getByTestId('nexus-family-anthropic')).toContainText('Claude')
+    await expect(page.getByTestId('nexus-family-google')).toContainText('Gemini')
+    await page.getByTestId('nexus-family-auto').click()
+
+    await expect(routing).toContainText('Auto')
+    await expect(page.getByRole('button', { name: /Select AI model/i })).toHaveCount(0)
+    await expect(page.getByTestId('nexus-tools-control')).toBeVisible()
+    await expect(page.getByTestId('nexus-skills-control')).toBeVisible()
+    await expect(page.getByTestId('nexus-skills-control')).toBeDisabled()
+    await expect(page.getByTestId('nexus-mcp-control')).toBeVisible()
+  })
+
+  test('the chat API rejects unsupported router modes and families before execution', async ({ page }) => {
+    const statuses = await page.evaluate(async () => {
+      const body = {
+        messages: [{ id: 'router-validation', role: 'user', content: 'hello' }],
+        modelId: 'gpt-4o-mini',
+      }
+      const [badMode, badFamily] = await Promise.all([
+        fetch('/api/nexus/chat', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ ...body, nexusMode: 'expert' }),
+        }),
+        fetch('/api/nexus/chat', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ ...body, nexusMode: 'advanced', modelFamily: 'other' }),
+        }),
+      ])
+      return [badMode.status, badFamily.status]
+    })
+    expect(statuses).toEqual([400, 400])
+  })
+
+  test('Standard sends the canonical standard/auto wire contract and clears manual selections', async ({ page }) => {
+    await selectFamily(page, 'anthropic', 'Claude')
+    await selectStandard(page)
+
+    const body = await capturePrompt(page, 'Explain photosynthesis briefly')
+    expect(body.nexusMode).toBe('standard')
+    expect(body.modelFamily).toBe('auto')
+    expect(body.enabledTools ?? []).toEqual([])
+    expect(body.enabledConnectors ?? []).toEqual([])
+    expect(body.modelId.length).toBeGreaterThan(0)
+  })
+
+  for (const option of [
+    { family: 'auto', label: 'Auto' },
+    { family: 'openai', label: 'ChatGPT' },
+    { family: 'anthropic', label: 'Claude' },
+    { family: 'google', label: 'Gemini' },
+  ] as const) {
+    test(`Advanced ${option.label} sends family=${option.family} without an exact-model choice`, async ({ page }) => {
+      await selectFamily(page, option.family, option.label)
+      const body = await capturePrompt(page, `Wire contract for ${option.label}`)
+
+      expect(body.nexusMode).toBe('advanced')
+      expect(body.modelFamily).toBe(option.family)
+      expect(body.modelId.length).toBeGreaterThan(0)
+      await expect(page.getByRole('button', { name: /Select AI model/i })).toHaveCount(0)
+    })
+  }
+
+  test('saved Advanced family and Standard mode both survive navigation and reload', async ({ page }) => {
+    await page.goto('/settings')
+    await page.getByRole('tab', { name: 'Preferences' }).click()
+    await page.getByTestId('nexus-preference-advanced').click()
+    await page.getByTestId('nexus-preference-family-anthropic').click()
+    await page.getByTestId('nexus-preference-save').click()
+    await expect(page.getByText('Nexus preferences saved')).toBeVisible()
+
+    await gotoNexus(page)
+    const routing = page.getByRole('button', { name: 'Nexus routing mode' })
+    await expect(routing).toContainText('Claude')
+
+    const standardSave = page.waitForResponse(response =>
+      response.request().method() === 'POST'
+      && new URL(response.url()).pathname === '/nexus'
+      && response.request().headers()['next-action'] !== undefined
+    )
+    await selectStandard(page)
+    await standardSave
+    await page.reload()
+    await page.waitForSelector('[data-testid="nexus-shell"]')
+    await expect(page.getByRole('button', { name: 'Nexus routing mode' })).toContainText('Standard')
+  })
+
+  test('an image request goes through Standard without an image-model button', async ({ page }) => {
+    await selectStandard(page)
+    const prompt = 'Create an image of a friendly owl reading a book'
+    const body = await capturePrompt(page, prompt)
+
+    expect(body.nexusMode).toBe('standard')
+    expect(body.modelFamily).toBe('auto')
+    expect(JSON.stringify(body.messages.at(-1))).toContain(prompt)
+    await expect(page.getByRole('button', { name: /Select AI model/i })).toHaveCount(0)
+  })
+
+  test('a PSD-data request goes through Standard without a manual MCP selection', async ({ page }) => {
+    await selectStandard(page)
+    const prompt = 'Show me attendance data for ninth grade students'
+    const body = await capturePrompt(page, prompt)
+
+    expect(body.nexusMode).toBe('standard')
+    expect(body.modelFamily).toBe('auto')
+    expect(body.enabledConnectors ?? []).toEqual([])
+    expect(JSON.stringify(body.messages.at(-1))).toContain(prompt)
+    await expect(page.getByTestId('nexus-mcp-control')).toHaveCount(0)
+  })
+})

--- a/tests/unit/agent-workspace-token-route.test.ts
+++ b/tests/unit/agent-workspace-token-route.test.ts
@@ -32,7 +32,8 @@ jest.mock("@/lib/agent-workspace/dwd-token-broker", () => {
   }
 })
 
-import { POST, __resetRateLimitForTests } from "@/app/api/agent/workspace-token/route"
+import { POST } from "@/app/api/agent/workspace-token/route"
+import { resetAgentWorkspaceTokenRateLimitForTests } from "@/lib/agent-workspace/token-rate-limit"
 import {
   AccountNotProvisionedError,
   BrokerNotConfiguredError,
@@ -49,7 +50,7 @@ import type { NextRequest } from "next/server"
 beforeEach(() => {
   authOk = true
   mintMock.mockReset()
-  __resetRateLimitForTests()
+  resetAgentWorkspaceTokenRateLimitForTests()
 })
 
 describe("POST /api/agent/workspace-token", () => {

--- a/tests/unit/api/nexus/image-generation-handler.test.ts
+++ b/tests/unit/api/nexus/image-generation-handler.test.ts
@@ -21,6 +21,7 @@ import {
   extractImagePrompt,
   validateImagePrompt,
   extractReferenceImages,
+  getImageRoutingContext,
   persistImageExchange,
   handleImageGenerationError
 } from '@/app/api/nexus/chat/image-generation-handler';
@@ -211,6 +212,64 @@ describe('extractReferenceImages', () => {
     }, CONVO);
     expect(result.length).toBe(1);
     expect(result[0].url).toBe('https://example.com/cat.png');
+  });
+});
+
+describe('getImageRoutingContext', () => {
+  beforeEach(() => {
+    mockExecuteQuery.mockReset();
+  });
+
+  it('uses an image attached to the current user turn without querying history', async () => {
+    const result = await getImageRoutingContext({
+      messages: [{
+        id: '1',
+        role: 'user',
+        parts: [{ type: 'file', mediaType: 'image/png' }],
+      }],
+      conversationId: CONVO,
+      userId: 42,
+    });
+
+    expect(result).toEqual({ hasImageInput: true, hasPreviousGeneratedImage: false });
+    expect(mockExecuteQuery).not.toHaveBeenCalled();
+  });
+
+  it('preserves persisted generated-image context for an elliptical follow-up edit', async () => {
+    mockExecuteQuery.mockResolvedValue([{
+      parts: [{ type: 'image', s3Key: `v2/generated-images/${CONVO}/latest.png` }],
+    }]);
+
+    const result = await getImageRoutingContext({
+      messages: [{ id: '2', role: 'user', parts: [{ type: 'text', text: 'Make it brighter' }] }],
+      conversationId: CONVO,
+      userId: 42,
+    });
+
+    expect(result).toEqual({ hasImageInput: false, hasPreviousGeneratedImage: true });
+    expect(mockExecuteQuery).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not invent previous image context when owned persisted history has none', async () => {
+    mockExecuteQuery.mockResolvedValue([{ parts: [{ type: 'text', text: 'No image here' }] }]);
+
+    const result = await getImageRoutingContext({
+      messages: [{ id: '3', role: 'user', parts: [{ type: 'text', text: 'Make it brighter' }] }],
+      conversationId: CONVO,
+      userId: 42,
+    });
+
+    expect(result).toEqual({ hasImageInput: false, hasPreviousGeneratedImage: false });
+  });
+
+  it('degrades to no prior image context when the optional history lookup fails', async () => {
+    mockExecuteQuery.mockRejectedValue(new Error('database unavailable'));
+
+    await expect(getImageRoutingContext({
+      messages: [{ id: '4', role: 'user', parts: [{ type: 'text', text: 'Make it brighter' }] }],
+      conversationId: CONVO,
+      userId: 42,
+    })).resolves.toEqual({ hasImageInput: false, hasPreviousGeneratedImage: false });
   });
 });
 


### PR DESCRIPTION
## What changed

- Replaced the default exact-model chooser with a **Standard** routing mode that automatically selects a light, medium, or high-capability model.
- Added an **Advanced** mode that keeps the choice intentionally small: Auto, ChatGPT, Claude, or Gemini. The router still chooses the appropriate model tier within the selected family.
- Added database-first router configuration, user preference persistence, active/shadow/off rollout modes, routing metadata, safety/PII signals, deterministic fallback behavior, and admin controls.
- Added automatic image-generation routing and automatic attachment of the existing database-loaded `psd-data` MCP server, so Standard users do not need separate model or tool buttons.
- Added Bedrock Nova Micro classification with heuristic fallback and configurable light/medium/high/image/instruction routes.
- Expanded unit, authenticated E2E, live-provider, persistence, validation, image-intent, and PSD-data intent coverage.
- Included the repository guidance updates requested for `AGENTS.md` and `.codex/config.toml`.

## Why

Nexus exposed too many implementation choices to most users. Standard mode now presents one chat experience and lets the system choose the least expensive model that can reliably handle the request. Advanced users can express a provider-family preference without needing to understand every model/version.

## Encountered errors fixed in this PR

- Fixed the pre-push Atrium CodeMirror crash caused by Bun installing multiple physical `@codemirror/state` / `@codemirror/view` instances. Turbopack and webpack now resolve every CodeMirror extension through the same root modules.
- Fixed Next 16 generated route-contract type errors by making the API auth wrapper expose the required route context and params promise.
- Removed unsupported non-route exports from two route modules by moving OAuth cookie naming and workspace-token rate-limit state into normal library modules.
- Fixed the CI settings save-flow tests by adding the new `useWatch` dependency to their `react-hook-form` mock.

## Operational impact

- Standard remains the default; existing users are migrated to a valid router preference without requiring a manual selection.
- Advanced family selection is a preference, not an exact model pin, so administrators can update family tier mappings centrally.
- Router decisions and fallbacks are observable in response headers and persisted conversation metadata.
- Rollout can be shadowed or disabled without reverting the UI work.

## Verification

- `bun run lint` — passed with 0 errors (existing warnings remain).
- `bun run typecheck` — passed, including generated Next route types.
- `bun run build` — passed with webpack.
- Router unit suite — 21/21 passed.
- API auth and workspace-token focused units — 21/21 passed.
- Full `test:ci` unit gate — 231 suites and 2,806 tests passed; 60 intentionally skipped.
- Authenticated deterministic router E2E — 15/15 passed.
- Live provider/router persistence E2E — 1/1 passed.
- Cold CodeMirror regression E2E — 1/1 passed.
- Full required pre-push E2E — 240 passed, 49 intentionally skipped, 1 unrelated collaboration timing test passed on retry; no genuine failures.

## Review notes

The PR targets `dev`. The three commits separate the model-router implementation, pre-push/runtime and Next 16 route-contract repairs, and CI test-mock repair for easier review.
