### PR TITLE
fix(tool-catalog): bump versions for seven tools whose published schemas drifted

### DIFF
--- a/lib/tools/catalog/manifest.ts
+++ b/lib/tools/catalog/manifest.ts
@@ -84,9 +84,10 @@ interface McpCatalogMapping {
    * schema in `lib/mcp/tool-registry.ts` changes, bump this (v1 -> v2 -> ...)
    * or the sync refuses the update and the deployed catalog keeps serving the
    * old contract while logging "Tool version immutability violation" on every
-   * boot.
+   * boot. Typed as `v${number}` so values missing the v prefix ("2", "latest")
+   * fail to compile; the version resolver ranks strict vN forms.
    */
-  version?: string;
+  version?: `v${number}`;
 }
 
 const MCP_TOOL_CATALOG_MAP: Record<string, McpCatalogMapping> = {

--- a/lib/tools/catalog/manifest.ts
+++ b/lib/tools/catalog/manifest.ts
@@ -78,6 +78,15 @@ interface McpCatalogMapping {
    * executing it (Issue #926). Defaults to false.
    */
   destructive?: boolean;
+  /**
+   * Catalog version for this tool (defaults to "v1"). A published version's
+   * input/output schema is FROZEN by the sync (Issue #927) — whenever a tool's
+   * schema in `lib/mcp/tool-registry.ts` changes, bump this (v1 -> v2 -> ...)
+   * or the sync refuses the update and the deployed catalog keeps serving the
+   * old contract while logging "Tool version immutability violation" on every
+   * boot.
+   */
+  version?: string;
 }
 
 const MCP_TOOL_CATALOG_MAP: Record<string, McpCatalogMapping> = {
@@ -95,6 +104,8 @@ const MCP_TOOL_CATALOG_MAP: Record<string, McpCatalogMapping> = {
     identifier: "decisions.search",
     requiredScope: "mcp:search_decisions",
     internalScopes: ["mcp:search_decisions"],
+    // v2: #1252 added semantic `q` to the input schema.
+    version: "v2",
   },
   capture_decision: {
     identifier: "decisions.capture",
@@ -103,6 +114,8 @@ const MCP_TOOL_CATALOG_MAP: Record<string, McpCatalogMapping> = {
     // Writes new decision-graph nodes/edges — gated behind human confirmation in
     // an agent loop (#926).
     destructive: true,
+    // v2: #1252 added supersedes/consulted/notified to the input schema.
+    version: "v2",
   },
   execute_assistant: {
     identifier: "assistants.execute",
@@ -145,6 +158,8 @@ const MCP_TOOL_CATALOG_MAP: Record<string, McpCatalogMapping> = {
     identifier: "decisions.graph_get",
     requiredScope: "mcp:get_decision_graph",
     internalScopes: ["mcp:get_decision_graph"],
+    // v2: #1252 added `depth` to the input schema (decision-package retrieval).
+    version: "v2",
   },
   // Atrium content tools (Phase 5, Issue #1055). MCP-only catalog entries (the
   // REST surface is hand-documented in docs/API/v1/openapi.yaml, not generated
@@ -156,12 +171,16 @@ const MCP_TOOL_CATALOG_MAP: Record<string, McpCatalogMapping> = {
     requiredScope: "content:create",
     internalScopes: ["content:create"],
     destructive: true,
+    // v2: `codeEncoding` added to the input schema (#1245 E2BIG fix).
+    version: "v2",
   },
   create_artifact: {
     identifier: "content.create_artifact",
     requiredScope: "content:create",
     internalScopes: ["content:create"],
     destructive: true,
+    // v2: `codeEncoding` added to the input schema (#1245 E2BIG fix).
+    version: "v2",
   },
   get_content: {
     identifier: "content.get",
@@ -184,12 +203,16 @@ const MCP_TOOL_CATALOG_MAP: Record<string, McpCatalogMapping> = {
     requiredScope: "content:update",
     internalScopes: ["content:update"],
     destructive: true,
+    // v2: `codeEncoding` added to the input schema (#1245 E2BIG fix).
+    version: "v2",
   },
   set_visibility: {
     identifier: "content.set_visibility",
     requiredScope: "content:update",
     internalScopes: ["content:update"],
     destructive: true,
+    // v2: grants description gained the 'group' kind (directory groups, #1206).
+    version: "v2",
   },
   publish_content: {
     identifier: "content.publish",
@@ -259,7 +282,7 @@ const MCP_MANIFEST_ENTRIES: ToolManifestEntry[] = MCP_TOOLS.map(
 
     return {
       identifier: mapping.identifier,
-      version: "v1",
+      version: mapping.version ?? "v1",
       name: tool.name,
       description: tool.description,
       inputSchema: tool.inputSchema,

--- a/tests/unit/lib/tools/catalog.test.ts
+++ b/tests/unit/lib/tools/catalog.test.ts
@@ -97,7 +97,9 @@ describe("ToolCatalog", () => {
     dbRows = [
       {
         identifier: "decisions.search",
-        version: "v1",
+        // Must match the manifest's CURRENT version — the DB-beats-manifest
+        // assertion only holds when both sides describe the same version.
+        version: "v2",
         name: "search_decisions",
         description: "published description",
         inputSchema: publishedSchema,
@@ -177,7 +179,9 @@ describe("ToolCatalog", () => {
     dbRows = [
       {
         identifier: "decisions.search",
-        version: "v1",
+        // Matches the manifest's current version so the disable applies to the
+        // row the manifest would otherwise project.
+        version: "v2",
         name: "search_decisions",
         description: "x",
         inputSchema: { type: "object", properties: {} },
@@ -669,11 +673,12 @@ describe("ToolCatalog", () => {
       const mockLogger = createLogger()
       mockLogger.warn.mockClear()
 
-      // A deprecated CODE tool (search_decisions v1) — admin deprecated it in DB.
+      // A deprecated CODE tool (search_decisions v2, the manifest's current
+      // version) — admin deprecated it in DB.
       dbRows = [
         {
           identifier: "decisions.search",
-          version: "v1",
+          version: "v2",
           name: "search_decisions",
           description: "x",
           inputSchema: { type: "object", properties: {} },
@@ -684,7 +689,7 @@ describe("ToolCatalog", () => {
           source: "code",
           isActive: true,
           deprecatedAt: new Date("2026-01-01T00:00:00Z"),
-          replacedBy: "decisions.search@v2",
+          replacedBy: "decisions.search@v3",
           removalDate: new Date("2026-04-01T00:00:00Z"),
           handlerRef: "decisions.search",
         },
@@ -700,10 +705,10 @@ describe("ToolCatalog", () => {
       expect(mockLogger.warn).toHaveBeenCalledWith(
         "deprecated_tool_invocation",
         expect.objectContaining({
-          tool: "decisions.search@v1",
+          tool: "decisions.search@v2",
           callerType: "mcp_client",
           callerId: "7",
-          replacedBy: "decisions.search@v2",
+          replacedBy: "decisions.search@v3",
         })
       )
     })


### PR DESCRIPTION
## Summary

Post-deploy verification of #1255 on AWS dev surfaced repeating boot-time errors from the tool-catalog sync: **"Tool version immutability violation: manifest changed a published version's schema; refusing update — bump the version instead."** Verified against the live Aurora dev catalog: seven code tools' input schemas were edited in place after publication, so the sync refuses the update and the deployed catalog keeps serving the OLD contracts (e.g. `decisions.search` advertises no `q`, `decisions.graph_get` no `depth`, `decisions.capture` none of the supersession fields).

## Fix
Applied the remedy the sync itself prescribes — version bumps, via a new optional `version` field on `McpCatalogMapping` (default "v1") with a doc comment explaining the freeze contract:

| Tool | Bump | Schema change that triggered the freeze |
|------|------|------|
| `decisions.search` | v2 | semantic `q` (#1252) |
| `decisions.graph_get` | v2 | `depth` (#1252) |
| `decisions.capture` | v2 | `supersedes`/`consulted`/`notified` (#1252) |
| `content.create_document` | v2 | `codeEncoding` (#1245 E2BIG fix) |
| `content.create_artifact` | v2 | `codeEncoding` (#1245) |
| `content.create_version` | v2 | `codeEncoding` (#1245) |
| `content.set_visibility` | v2 | grants description gained `'group'` kind (#1206) |

On the next deploy the sync inserts the v2 rows, the version resolver serves latest, and `deactivateOrphans` retires the stale v1 rows. Catalog test fixtures pinned to `decisions.search@v1` move to v2 (they assert DB-authority over the manifest for the SAME version, noted inline).

## Verification
- `bun run test:ci`: 2932 passed (catalog + MCP suites 122)
- typecheck 0, eslint clean, `capabilities:check` in sync
- Full authenticated pre-push E2E wall passed on push
- Requires a dev deploy after merge for the catalog sync to publish the v2 rows

https://claude.ai/code/session_01CmWuEDemKxKwooWpwoLJBW