### PR TITLE
feat(nexus): route current questions through web search

### DIFF
--- a/actions/settings/nexus-router-settings.actions.ts
+++ b/actions/settings/nexus-router-settings.actions.ts
@@ -86,7 +86,7 @@ export async function updateNexusRouterSettings(
       await tx.insert(settings).values({
         key: NEXUS_ROUTER_CONFIG_KEY,
         value: serializedConfig,
-        description: "Nexus classifier, tier, family, image, instruction, and PSD-data routing configuration",
+        description: "Nexus classifier, tier, family, web-search, image, instruction, and PSD-data routing configuration",
         category: "ai",
         isSecret: false,
         updatedAt: now,
@@ -94,7 +94,7 @@ export async function updateNexusRouterSettings(
         target: settings.key,
         set: {
           value: serializedConfig,
-          description: "Nexus classifier, tier, family, image, instruction, and PSD-data routing configuration",
+          description: "Nexus classifier, tier, family, web-search, image, instruction, and PSD-data routing configuration",
           category: "ai",
           isSecret: false,
           updatedAt: now,

--- a/app/(protected)/admin/settings/_components/nexus-router-settings-card.tsx
+++ b/app/(protected)/admin/settings/_components/nexus-router-settings-card.tsx
@@ -47,6 +47,7 @@ export interface NexusRouterModelOption {
   family: Exclude<NexusModelFamily, "auto"> | null
   imageGeneration: boolean
   deepResearch: boolean
+  webSearch: boolean
 }
 
 export interface NexusRouterConnectorOption {
@@ -105,6 +106,14 @@ function replaceTierCandidate(
   }
 }
 
+function firstAvailableCandidate(
+  candidates: string[],
+  models: NexusRouterModelOption[]
+): string | undefined {
+  const available = new Set(models.map(model => model.modelId))
+  return candidates.find(candidate => available.has(candidate))
+}
+
 function RouterModelSelect({
   value,
   models,
@@ -161,6 +170,10 @@ export function NexusRouterSettingsCard({
   const googleTextModels = useMemo(
     () => textModels.filter(model => model.family === "google"),
     [textModels]
+  )
+  const googleWebSearchModels = useMemo(
+    () => googleTextModels.filter(model => model.webSearch),
+    [googleTextModels]
   )
 
   const save = async () => {
@@ -281,11 +294,11 @@ export function NexusRouterSettingsCard({
 
         <Separator />
 
-        <div className="grid gap-5 lg:grid-cols-3">
+        <div className="grid gap-5 lg:grid-cols-2 xl:grid-cols-4">
           <div className="space-y-2">
             <Label>Instructional questions</Label>
             <RouterModelSelect
-              value={config.specialists.instructionModels[0]}
+              value={firstAvailableCandidate(config.specialists.instructionModels, googleTextModels)}
               models={googleTextModels}
               automaticLabel="Automatic Gemini"
               testId="nexus-router-instruction-model"
@@ -300,9 +313,26 @@ export function NexusRouterSettingsCard({
             <p className="text-xs text-muted-foreground">Lesson plans, rubrics, curriculum, and pedagogy.</p>
           </div>
           <div className="space-y-2">
+            <Label>Web search</Label>
+            <RouterModelSelect
+              value={firstAvailableCandidate(config.specialists.webSearchModels, googleWebSearchModels)}
+              models={googleWebSearchModels}
+              automaticLabel="Automatic Gemini"
+              testId="nexus-router-web-search-model"
+              onChange={modelId => setConfig(current => ({
+                ...current,
+                specialists: {
+                  ...current.specialists,
+                  webSearchModels: modelId === AUTOMATIC ? [] : [modelId],
+                },
+              }))}
+            />
+            <p className="text-xs text-muted-foreground">Current information, news, prices, schedules, and explicit web lookups.</p>
+          </div>
+          <div className="space-y-2">
             <Label>Image generation</Label>
             <RouterModelSelect
-              value={config.specialists.imageModels[0]}
+              value={firstAvailableCandidate(config.specialists.imageModels, imageModels)}
               models={imageModels}
               automaticLabel="Automatic image model"
               testId="nexus-router-image-model"

--- a/app/(protected)/admin/settings/_components/nexus-router-settings-card.tsx
+++ b/app/(protected)/admin/settings/_components/nexus-router-settings-card.tsx
@@ -110,8 +110,7 @@ function firstAvailableCandidate(
   candidates: string[],
   models: NexusRouterModelOption[]
 ): string | undefined {
-  const available = new Set(models.map(model => model.modelId))
-  return candidates.find(candidate => available.has(candidate))
+  return candidates.find(candidate => models.some(model => model.modelId === candidate))
 }
 
 function RouterModelSelect({

--- a/app/(protected)/admin/settings/_components/settings-form.tsx
+++ b/app/(protected)/admin/settings/_components/settings-form.tsx
@@ -71,7 +71,7 @@ const commonSettings = [
   { key: "LATIMER_API_KEY", category: "ai_providers", description: "Latimer.ai API key", isSecret: true },
   { key: "NEXUS_ROUTER_MODE", category: "ai", description: "Nexus model router mode: active, shadow, or off", isSecret: false },
   { key: "ASSISTANT_ARCHITECT_ROUTER_MODE", category: "ai", description: "Assistant Architect model router mode: active, shadow, or off", isSecret: false },
-  { key: "NEXUS_ROUTER_CONFIG_V1", category: "ai", description: "JSON configuration for Nexus classifier, family/tier candidates, and image/PSD-data specialists", isSecret: false },
+  { key: "NEXUS_ROUTER_CONFIG_V1", category: "ai", description: "JSON configuration for Nexus classifier, family/tier candidates, and web-search/image/PSD-data specialists", isSecret: false },
   { key: "S3_BUCKET", category: "storage", description: "AWS S3 bucket name for document storage", isSecret: false },
   { key: "AWS_REGION", category: "storage", description: "AWS region for S3 operations", isSecret: false },
   { key: "GITHUB_ISSUE_TOKEN", category: "external_services", description: "GitHub personal access token for creating issues", isSecret: true },

--- a/app/(protected)/admin/settings/page.tsx
+++ b/app/(protected)/admin/settings/page.tsx
@@ -48,6 +48,8 @@ export default async function SettingsPage() {
             family: inferFamily(model),
             imageGeneration: hasCapability(model.capabilities, "imageGeneration"),
             deepResearch: hasCapability(model.capabilities, "deepResearch"),
+            webSearch: hasCapability(model.capabilities, "webSearch")
+              || hasCapability(model.capabilities, "grounding"),
           }))}
           nexusRouterConnectors={connectors}
         />

--- a/app/api/nexus/chat/route.ts
+++ b/app/api/nexus/chat/route.ts
@@ -52,7 +52,7 @@ import {
 } from '@/lib/skills/skill-tool-enforcement';
 import { readSkillMarkdown } from '@/lib/skills/skill-publish-pipeline';
 import { buildWorkspaceChatTools } from '@/lib/nexus/workspace-chat-tools';
-import { routeNexusRequest } from '@/lib/nexus/model-router/router';
+import { mergeRoutedToolNames, routeNexusRequest } from '@/lib/nexus/model-router/router';
 import { NexusSpecialistUnavailableError } from '@/lib/nexus/model-router/errors';
 import {
   nexusExperienceModeSchema,
@@ -839,6 +839,7 @@ async function resolveRequestRouting(args: {
   nexusMode: z.infer<typeof nexusExperienceModeSchema>;
   modelFamily: z.infer<typeof nexusModelFamilySchema>;
   manuallyEnabledConnectors: string[];
+  manuallyEnabledTools: string[];
   userId: number;
   sessionId: string;
   existingConversationId?: string;
@@ -859,6 +860,7 @@ async function resolveRequestRouting(args: {
     experienceMode: args.nexusMode,
     requestedFamily: args.nexusMode === 'advanced' ? args.modelFamily : 'auto',
     enabledConnectorIds: args.manuallyEnabledConnectors,
+    enabledToolNames: args.manuallyEnabledTools,
     userId: args.userId,
     hasImageInput: imageContext.hasImageInput,
     hasPreviousGeneratedImage: imageContext.hasPreviousGeneratedImage,
@@ -1173,6 +1175,34 @@ async function scopeFilterEnabledTools(
   return scoped;
 }
 
+function assertAutomaticToolsAvailable(
+  automaticToolNames: string[],
+  availableToolNames: string[]
+): void {
+  const available = new Set(availableToolNames);
+  if (automaticToolNames.some(toolName => !available.has(toolName))) {
+    throw new NexusSpecialistUnavailableError(
+      'web-search',
+      'Web search is not available for your account or the currently loaded skill. Ask an administrator to enable the Web Search tool.'
+    );
+  }
+}
+
+async function scopeRoutedEnabledTools(args: {
+  manuallyEnabledToolNames: string[];
+  automaticToolNames: string[];
+  userRoleNames: string[];
+  log: ReturnType<typeof createLogger>;
+}): Promise<string[]> {
+  const requested = mergeRoutedToolNames(
+    args.manuallyEnabledToolNames,
+    args.automaticToolNames
+  );
+  const scoped = await scopeFilterEnabledTools(requested, args.userRoleNames, args.log);
+  assertAutomaticToolsAvailable(args.automaticToolNames, scoped);
+  return scoped;
+}
+
 const NEXUS_BASE_SYSTEM_PROMPT = `You are a helpful AI assistant in the Nexus interface.
 
 When discussing hardware, networking equipment, or technical specifications, treat model numbers, part numbers, and product identifiers as publicly available product information. Do not suggest that such identifiers have been redacted or withheld.
@@ -1403,12 +1433,19 @@ export async function POST(req: Request) {
       nexusMode,
       modelFamily,
       manuallyEnabledConnectors,
+      manuallyEnabledTools: enabledTools,
       userId,
       sessionId: session.sub,
       existingConversationId: conversationIdValue,
     });
     const modelId = routing.modelId;
     const enabledConnectors = routing.connectorIds;
+    const catalogScopedEnabledTools = await scopeRoutedEnabledTools({
+      manuallyEnabledToolNames: enabledTools,
+      automaticToolNames: routing.automaticToolNames,
+      userRoleNames,
+      log,
+    });
 
     // 4a. Get selected model configuration
     const modelResult = await getValidatedModelConfig(modelId, log);
@@ -1493,12 +1530,13 @@ export async function POST(req: Request) {
     // then apply the bound skill's session binding (#925): allowed-tools pin over
     // built-in AND connector tools, plus SKILL.md instruction injection.
     const skillBinding = await applySkillSessionBinding({
-      scopedEnabledTools: await scopeFilterEnabledTools(enabledTools, userRoleNames, log),
+      scopedEnabledTools: catalogScopedEnabledTools,
       connectorToolResults,
       skillId,
       log,
     });
     const { scopedEnabledTools, effectiveConnectorToolResults, skillInstructions, skillName, skillAllowedTools } = skillBinding;
+    assertAutomaticToolsAvailable(routing.automaticToolNames, scopedEnabledTools);
 
     // 8c. Bind workspace content tools when a document/artifact is open beside the
     // chat (Atrium §1087). Server-built + canView/canEdit-gated; a bad/unviewable

--- a/docs/README.md
+++ b/docs/README.md
@@ -165,7 +165,7 @@ AI integration patterns using Vercel AI SDK v6, provider factory implementation,
 #### [features/nexus-conversation-architecture.md](./features/nexus-conversation-architecture.md) ⭐ **CRITICAL**
 **Complete Nexus conversation system architecture** - Component hierarchy, state management (conversationId vs stableConversationId vs ref), message flows, runtime memoization, format conversions, common pitfalls, and troubleshooting. **Read this before modifying conversation code.**
 
-**[Nexus model routing](./features/nexus-model-routing.md)** — Standard/Advanced UX, Nova Micro classification, family/tier resolution, automatic image and PSD-data MCP dispatch, configuration, fallbacks, and rollout modes.
+**[Nexus model routing](./features/nexus-model-routing.md)** — Standard/Advanced UX, Nova Micro classification, family/tier resolution, automatic web search, image and PSD-data MCP dispatch, configuration, fallbacks, and rollout modes.
 
 **[Assistant Architect model routing](./features/assistant-architect-model-routing.md)** — Standard/Advanced authoring, shared capability-aware tier routing, legacy compatibility, execution surfaces, and independent rollout controls.
 

--- a/docs/features/assistant-architect-model-routing.md
+++ b/docs/features/assistant-architect-model-routing.md
@@ -15,7 +15,7 @@ For every prompt-chain step, the runtime:
 5. enforces an Advanced family constraint and explicit function-calling or vision exclusions;
 6. executes the prompt and persists the routing decision in `prompt_results.input_data.modelRouting`.
 
-Agentic assistants route once per run after their author allow-list and executing-caller scopes have resolved the actual tool set. Image inputs require a vision-capable driving model. Image generation remains the authorized `images.generate` agent tool, and MCP connectors—including PSD-data—remain limited to the assistant's saved connector allow-list. The router does not silently attach connectors or broaden permissions.
+Agentic assistants route once per run after their author allow-list and executing-caller scopes have resolved the actual tool set. Image inputs require a vision-capable driving model. Image generation remains the authorized `images.generate` agent tool, MCP connectors—including PSD-data—remain limited to the assistant's saved connector allow-list, and web search remains an author-enabled prompt tool. When web search is enabled, the router selects a compatible provider/model; automatic prompt-based tool enablement remains Nexus-specific. The router does not silently attach connectors or broaden permissions.
 
 The same route adapter is used by the interactive UI, scheduled prompt chains, REST v1 execution, and MCP/job-completion execution. Agentic execution remains available only through its existing supported UI surface.
 

--- a/docs/features/nexus-model-routing.md
+++ b/docs/features/nexus-model-routing.md
@@ -6,10 +6,10 @@ Nexus defaults to **Standard** mode. Users see one Nexus experience instead of a
 
 1. Authenticate the user before classification.
 2. Apply the existing K-12 input guardrail and PII tokenization boundary before classifier traffic.
-3. Apply deterministic capability rules for image generation, PSD-data, and common instructional requests.
+3. Apply deterministic capability rules for image generation, PSD-data, web search/current information, and common instructional requests.
 4. Send ambiguous requests to Amazon Nova Micro on Bedrock for a provider-neutral `intent`, `tier`, `confidence`, and reason codes.
 5. Resolve an accessible, active Nexus model from the configured ordered candidates. If none is configured, use `providerMetadata.nexusRouterTier` or model-name conventions. If no tier match is available, use the closest tier in the requested family. Auto may finally use the existing client model as a safe fallback; an explicit Advanced family never silently crosses into another family.
-6. Automatically select an image-capable model for image intent or attach the existing database-backed PSD-data MCP server for PSD-data intent.
+6. Automatically select an image-capable model for image intent, attach the existing database-backed PSD-data MCP server for PSD-data intent, or select a web-search-capable Gemini model and enable its native Google Search tool for web-search intent.
 7. Persist the route decision on assistant-message metadata and expose it in `X-Nexus-Routing` for evaluation.
 
 The deterministic rules run before the model classifier because capability requirements are not discretionary. Classifier failure, timeout, malformed output, or confidence below the configured floor falls back to a conservative heuristic; ordinary requests default to Medium.
@@ -22,13 +22,13 @@ Set `NEXUS_ROUTER_MODE` in the settings table or environment:
 - `shadow`: classify and resolve, record `proposedModelId`, but execute the existing fallback model and connector list.
 - `off`: use the legacy fallback model and manually enabled connectors.
 
-The user-facing experience and runtime both default to active Standard routing. Use shadow mode explicitly when comparing proposed routes against existing production behavior. Stored routing metadata includes the config version, experience/runtime mode, requested and selected family, intent, tier, confidence, reason codes, decision source, selected/proposed model, fallback status, and PSD-data attachment status.
+The user-facing experience and runtime both default to active Standard routing. Use shadow mode explicitly when comparing proposed routes against existing production behavior. Stored routing metadata includes the config version, experience/runtime mode, requested and selected family, intent, tier, confidence, reason codes, decision source, selected/proposed model, fallback status, PSD-data attachment status, and automatic web-search status.
 An explicitly invalid runtime mode, or malformed router JSON while active, fails safely to shadow mode. A missing config is valid: the built-in specialist defaults and model metadata/name inference are used.
 
 ## Configuration
 
 `NEXUS_ROUTER_CONFIG_V1` is stored as JSON. Candidate values are `ai_models.model_id` strings (numeric database IDs are also accepted). Candidates are tried in order and remain subject to active/Nexus-enabled status and resource-access grants.
-Administrators manage the shared tier preferences and classifier plus independent Nexus and Assistant Architect rollout modes through the dedicated **Admin → System Settings → Model routing** card. Image and PSD-data specialists remain Nexus-specific. The generic settings table remains available for inspection and emergency edits.
+Administrators manage the shared tier preferences and classifier plus independent Nexus and Assistant Architect rollout modes through the dedicated **Admin → System Settings → Model routing** card. Web-search, image, and PSD-data specialists remain Nexus-specific. The generic settings table remains available for inspection and emergency edits.
 
 ```json
 {
@@ -63,6 +63,7 @@ Administrators manage the shared tier preferences and classifier plus independen
   "specialists": {
     "imageModels": ["gemini-3.1-flash-image"],
     "instructionModels": ["gemini-3.5-flash"],
+    "webSearchModels": ["gemini-3.5-flash", "gemini-3.1-pro-preview"],
     "psdDataConnectorName": "psd-data"
   },
   "confidenceFloor": 0.55
@@ -75,11 +76,13 @@ Assistant Architect reuses the text-model tier/family selection core and this co
 
 For PSD-data, prefer `specialists.psdDataConnectorId` when the server UUID is stable. Otherwise the router normalizes the configured name, so `psd-data`, `PSD Data`, and `psd_data` match the same registered server. Existing connector authorization and Cognito pass-through remain enforced by the connector service.
 
+For web search, choose an active, Nexus-enabled Google text model whose `capabilities` include `web_search` or `grounding`. Standard mode prefers `specialists.webSearchModels` in order and automatically enables the friendly `webSearch` tool, which the Google adapter materializes as `google_search`. The normal tool-catalog scope gate, resource grants, and any loaded skill's `allowed-tools` pin still apply. If the specialist model or tool is unavailable, the request returns a clear specialist-unavailable response instead of silently answering from model memory.
+
 ## User experience and persistence
 
 The user preference is stored in `nexus_user_preferences.settings` as `nexusMode` and `preferredModelFamily`. Standard is the default for users with no preference. The composer’s first menu contains only Standard and Advanced; Advanced opens a second flyout containing ChatGPT, Claude, and Gemini. The control does not remount the assistant runtime; current values are read from refs by the stable transport. In Standard, manual model/tool/MCP controls are hidden. In Advanced, the existing optional tool controls are available after a family is selected.
 
-Image routing intentionally overrides a family constraint because it requires a generation capability. PSD-data augments the selected response model with its data source, so its response model still honors the family constraint. General and instructional response models also honor Advanced family selection; Auto can use the configured instructional specialist. Specialist-only image and Deep Research models are excluded from ordinary response routing.
+Image routing intentionally overrides a family constraint because it requires a generation capability. PSD-data augments the selected response model with its data source, so its response model still honors the family constraint. Web search also honors Advanced family selection: Gemini and capable ChatGPT models can use their native search tools, while Claude through Bedrock reports that search is unavailable. General and instructional response models honor Advanced family selection; Auto can use the configured instructional specialist. Specialist-only image and Deep Research models are excluded from ordinary response routing.
 
 For follow-up image edits, the router checks the authenticated user's recent persisted assistant messages for the same conversation. This keeps elliptical requests such as “make it brighter” on the image path even when the image is not reattached, while preventing another user's conversation history from influencing routing.
 
@@ -91,4 +94,4 @@ For follow-up image edits, the router checks the authenticated user's recent per
 4. Inspect assistant `metadata.routing`, classifier/fallback logs, latency, cost, user retries, and route overrides.
 5. Promote to `active`, keeping the legacy fallback model available.
 
-Unit coverage lives in `lib/nexus/model-router/__tests__`. Deterministic authenticated UI and request-wire coverage for Standard/Advanced, every family, preference persistence, image intent, and PSD-data intent lives in `tests/e2e/nexus/model-router.spec.ts`; live-provider conversation coverage remains in the other Nexus specs.
+Unit coverage lives in `lib/nexus/model-router/__tests__`. Deterministic authenticated UI and request-wire coverage for Standard/Advanced, every family, preference persistence, image intent, web-search intent, and PSD-data intent lives in `tests/e2e/nexus/model-router.spec.ts`; live-provider conversation coverage remains in the other Nexus specs.

--- a/lib/assistant-architect/__tests__/model-router.test.ts
+++ b/lib/assistant-architect/__tests__/model-router.test.ts
@@ -28,7 +28,7 @@ const models = [
   { id: 1, name: "Nova Micro", provider: "amazon-bedrock", modelId: "nova-micro", active: true, architectEnabled: true, capabilities: "[]", providerMetadata: { modelRouterTier: "light" } },
   { id: 2, name: "Claude Sonnet", provider: "amazon-bedrock", modelId: "claude-sonnet", active: true, architectEnabled: true, capabilities: "[]", providerMetadata: { modelRouterTier: "medium", supports_function_calling: true } },
   { id: 3, name: "GPT Sol", provider: "openai", modelId: "gpt-sol", active: true, architectEnabled: true, capabilities: "[]", providerMetadata: { modelRouterTier: "high" } },
-  { id: 4, name: "Gemini Flash", provider: "google", modelId: "gemini-flash", active: true, architectEnabled: true, capabilities: "[]", providerMetadata: { modelRouterTier: "medium" } },
+  { id: 4, name: "Gemini Flash", provider: "google", modelId: "gemini-flash", active: true, architectEnabled: true, capabilities: '["web_search"]', providerMetadata: { modelRouterTier: "medium" } },
   { id: 5, name: "Nano Banana", provider: "google", modelId: "gemini-flash-image", active: true, architectEnabled: true, capabilities: '["image_generation"]', providerMetadata: { modelRouterTier: "light" } },
 ]
 const config = nexusRouterConfigSchema.parse({
@@ -124,6 +124,20 @@ describe("Assistant Architect model router", () => {
     })
     expect(result.modelId).toBe("claude-sonnet")
     expect(result.modelId).not.toContain("image")
+  })
+
+  it("selects a web-search-capable model when the author enabled the tool", async () => {
+    mockClassify.mockResolvedValue({
+      intent: "web-search", tier: "medium", confidence: 0.96,
+      reasonCodes: ["current_web_information"], source: "deterministic",
+    })
+    const result = await routeAssistantArchitectModel({
+      text: "Search the web for current guidance", userId: 7,
+      fallbackModelDbId: 1, routingMode: "standard",
+      requirements: { requiredTools: ["webSearch"] },
+    })
+    expect(result.modelId).toBe("gemini-flash")
+    expect(result.metadata.requiredTools).toEqual(["webSearch"])
   })
 
   it("records proposals without changing execution in shadow mode", async () => {

--- a/lib/nexus/model-router/__tests__/classifier.test.ts
+++ b/lib/nexus/model-router/__tests__/classifier.test.ts
@@ -34,6 +34,14 @@ describe("Nexus request classifier", () => {
     expect(deterministicClassify("Build a differentiated lesson plan")?.intent).toBe("instruction")
   })
 
+  it("routes explicit searches and time-sensitive facts to web search", () => {
+    expect(deterministicClassify("Search the web for the latest district guidance")?.intent)
+      .toBe("web-search")
+    expect(deterministicClassify("What is today's weather forecast for Tacoma?")?.intent)
+      .toBe("web-search")
+    expect(deterministicClassify("Improve the current paragraph in my draft")).toBeNull()
+  })
+
   it("recognizes an edit instruction when an image is attached", async () => {
     const decision = await classifyNexusRequest("Make this brighter", config, { hasImageInput: true })
     expect(decision).toMatchObject({ intent: "image", source: "deterministic" })

--- a/lib/nexus/model-router/__tests__/classifier.test.ts
+++ b/lib/nexus/model-router/__tests__/classifier.test.ts
@@ -39,7 +39,12 @@ describe("Nexus request classifier", () => {
       .toBe("web-search")
     expect(deterministicClassify("What is today's weather forecast for Tacoma?")?.intent)
       .toBe("web-search")
+    expect(deterministicClassify("What is the cost today for a first-class stamp?")?.intent)
+      .toBe("web-search")
+    expect(deterministicClassify("Show me technology news this week")?.intent)
+      .toBe("web-search")
     expect(deterministicClassify("Improve the current paragraph in my draft")).toBeNull()
+    expect(deterministicClassify("Summarize the current results in this spreadsheet")).toBeNull()
   })
 
   it("recognizes an edit instruction when an image is attached", async () => {

--- a/lib/nexus/model-router/__tests__/config.test.ts
+++ b/lib/nexus/model-router/__tests__/config.test.ts
@@ -18,6 +18,7 @@ describe("Nexus router configuration", () => {
     expect(result.mode).toBe("active")
     expect(result.config.classifier.modelId).toBe("us.amazon.nova-micro-v1:0")
     expect(result.config.specialists.imageModels[0]).toBe("gemini-3.1-flash-image-preview")
+    expect(result.config.specialists.webSearchModels[0]).toBe("gemini-3.5-flash")
   })
 
   it("loads ordered candidates and shadow mode from settings", async () => {

--- a/lib/nexus/model-router/__tests__/router.test.ts
+++ b/lib/nexus/model-router/__tests__/router.test.ts
@@ -17,14 +17,14 @@ jest.mock("@/lib/logger", () => ({
   createLogger: () => ({ info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() }),
 }))
 
-import { routeNexusRequest } from "../router"
+import { mergeRoutedToolNames, routeNexusRequest } from "../router"
 import { nexusRouterConfigSchema } from "../types"
 
 const models = [
   { id: 1, name: "GPT Luna", provider: "openai", modelId: "gpt-luna", capabilities: "[]", providerMetadata: { nexusRouterTier: "light" } },
   { id: 2, name: "GPT Terra", provider: "openai", modelId: "gpt-terra", capabilities: "[]", providerMetadata: { nexusRouterTier: "medium" } },
   { id: 3, name: "Claude Sonnet", provider: "amazon-bedrock", modelId: "us.anthropic.claude-sonnet", capabilities: "[]", providerMetadata: { nexusRouterTier: "medium" } },
-  { id: 4, name: "Gemini Flash", provider: "google", modelId: "gemini-flash", capabilities: "[]", providerMetadata: { nexusRouterTier: "medium" } },
+  { id: 4, name: "Gemini Flash", provider: "google", modelId: "gemini-flash", capabilities: '["web_search"]', providerMetadata: { nexusRouterTier: "medium" } },
   { id: 5, name: "Nano Banana", provider: "google", modelId: "gemini-3.1-flash-image", capabilities: '["image_generation"]', providerMetadata: { nexusRouterTier: "light" } },
   { id: 6, name: "Gemini Deep Research", provider: "google", modelId: "gemini-deep-research", capabilities: '["deep_research"]', providerMetadata: { nexusRouterTier: "high" } },
   { id: 7, name: "Amazon Nova Lite", provider: "amazon-bedrock", modelId: "us.amazon.nova-lite-v1:0", capabilities: "[]", providerMetadata: { nexusRouterTier: "light" } },
@@ -39,6 +39,7 @@ const config = nexusRouterConfigSchema.parse({
   specialists: {
     imageModels: ["gemini-3.1-flash-image"],
     instructionModels: ["gemini-flash"],
+    webSearchModels: ["gemini-flash"],
     psdDataConnectorName: "psd-data",
   },
 })
@@ -53,6 +54,13 @@ describe("Nexus model router", () => {
       intent: "general", tier: "medium", confidence: 0.9,
       reasonCodes: ["normal_request"], source: "classifier",
     })
+  })
+
+  it("merges automatic web search with manually enabled tools without duplicates", () => {
+    expect(mergeRoutedToolNames(
+      ["codeInterpreter", "webSearch"],
+      ["webSearch"]
+    )).toEqual(["codeInterpreter", "webSearch"])
   })
 
   it("constrains Advanced routing to the selected family", async () => {
@@ -108,6 +116,33 @@ describe("Nexus model router", () => {
     expect(result.connectorIds).toEqual(["54f0f531-f7ab-485e-bd6b-65a95c4bc871"])
     expect(result.automaticConnectorIds).toEqual(["54f0f531-f7ab-485e-bd6b-65a95c4bc871"])
     expect(result.metadata.autoAttachedPsdData).toBe(true)
+  })
+
+  it("routes current-information requests to Gemini and automatically enables web search", async () => {
+    mockClassify.mockResolvedValue({
+      intent: "web-search", tier: "medium", confidence: 0.96,
+      reasonCodes: ["current_web_information"], source: "deterministic",
+    })
+    const result = await routeNexusRequest({
+      text: "Search the web for today's weather", fallbackModelId: "gpt-terra",
+      experienceMode: "standard", requestedFamily: "auto",
+      enabledConnectorIds: [], userId: 7,
+    })
+    expect(result.modelId).toBe("gemini-flash")
+    expect(result.automaticToolNames).toEqual(["webSearch"])
+    expect(result.metadata.autoEnabledWebSearch).toBe(true)
+  })
+
+  it("fails clearly when the selected Advanced family cannot perform web search", async () => {
+    mockClassify.mockResolvedValue({
+      intent: "web-search", tier: "medium", confidence: 0.96,
+      reasonCodes: ["current_web_information"], source: "deterministic",
+    })
+    await expect(routeNexusRequest({
+      text: "Browse the web for current policy", fallbackModelId: "gpt-terra",
+      experienceMode: "advanced", requestedFamily: "anthropic",
+      enabledConnectorIds: [], userId: 7,
+    })).rejects.toThrow("Web search is not available")
   })
 
   it("records a proposed route but executes the fallback in shadow mode", async () => {

--- a/lib/nexus/model-router/classifier.ts
+++ b/lib/nexus/model-router/classifier.ts
@@ -19,7 +19,8 @@ const EXPLICIT_WEB_SEARCH_PHRASES = [
   "search online", "browse the web", "browse web", "browse the internet",
   "browse internet", "browse online", "web search", "internet search",
 ]
-const CURRENT_INFO_PATTERN = /\b(?:latest|current|today(?:'s)?|recent|up-to-date|right\s+now|this\s+(?:week|month|year))\b.{0,60}\b(?:news|weather|forecast|price|cost|stock|score|schedule|standings|results?|version|release|president|governor|mayor|ceo|law|policy|regulation|guidance)\b|\b(?:news|weather|forecast|price|stock|score|schedule|standings|results?|version|release|president|governor|mayor|ceo|law|policy|regulation|guidance)\b.{0,60}\b(?:latest|current|today(?:'s)?|recent|up-to-date|right\s+now)\b/i
+const CURRENT_INFO_PATTERN = /\b(?:latest|current|today(?:'s)?|recent|up-to-date|right\s+now|this\s+(?:week|month|year))\b.{0,60}\b(?:news|weather|forecast|price|cost|stock|score|schedule|standings|results?|version|release|president|governor|mayor|ceo|law|policy|regulation|guidance)\b|\b(?:news|weather|forecast|price|cost|stock|score|schedule|standings|results?|version|release|president|governor|mayor|ceo|law|policy|regulation|guidance)\b.{0,60}\b(?:latest|current|today(?:'s)?|recent|up-to-date|right\s+now|this\s+(?:week|month|year))\b/i
+const USER_SUPPLIED_CONTEXT_PATTERN = /\b(?:this|the|my|our|attached|uploaded|provided)\s+(?:spreadsheet|sheet|document|file|attachment|draft|paragraph|project|report|data|results?)\b|\b(?:spreadsheet|sheet|document|file|attachment|draft|paragraph|project|report|data)\b.{0,60}\b(?:attached|uploaded|provided|above|below)\b/i
 const HIGH_PATTERN = /\b(architecture|migration|security review|threat model|root cause|research report|multi-step|optimize|prove|complex analysis)\b/i
 const LIGHT_PATTERN = /^(hi|hello|thanks|thank you|yes|no|ok|okay)[!. ]*$|^(what is|who is|when is|where is|how many)\b|\b(define|translate|summarize briefly|quick question)\b/i
 
@@ -51,7 +52,8 @@ export function deterministicClassify(text: string, hasImageInput = false): Nexu
   if (PSD_PATTERN.test(text)) {
     return { intent: "psd-data", tier: "medium", confidence: 0.97, reasonCodes: ["psd_data_domain"], source: "deterministic" }
   }
-  if (requestsExplicitWebSearch(text) || CURRENT_INFO_PATTERN.test(text)) {
+  if (requestsExplicitWebSearch(text)
+    || (CURRENT_INFO_PATTERN.test(text) && !USER_SUPPLIED_CONTEXT_PATTERN.test(text))) {
     return { intent: "web-search", tier: "medium", confidence: 0.96, reasonCodes: ["current_web_information"], source: "deterministic" }
   }
   if (INSTRUCTION_PATTERN.test(text)) {

--- a/lib/nexus/model-router/classifier.ts
+++ b/lib/nexus/model-router/classifier.ts
@@ -14,6 +14,12 @@ const log = createLogger({ module: "nexus-model-router-classifier" })
 const IMAGE_PATTERN = /\b(generate|create|draw|design|make|edit|render)\b.{0,45}\b(image|picture|illustration|graphic|photo|poster|logo)\b|\b(image|picture|illustration|graphic|photo)\s+(generation|editing)\b/i
 const PSD_PATTERN = /\b(psd[- ]?data|power\s*school|student information system|student data|attendance|enrollment|gradebook|demographic)\b|\bmcp\s+(connection|connector|server|tools?)\b/i
 const INSTRUCTION_PATTERN = /\b(lesson plan|rubric|curriculum|learning objective|teaching strategy|differentiat(?:e|ion)|instructional|pedagogy|classroom activity|discussion questions)\b/i
+const EXPLICIT_WEB_SEARCH_PHRASES = [
+  "search the web", "search web", "search the internet", "search internet",
+  "search online", "browse the web", "browse web", "browse the internet",
+  "browse internet", "browse online", "web search", "internet search",
+]
+const CURRENT_INFO_PATTERN = /\b(?:latest|current|today(?:'s)?|recent|up-to-date|right\s+now|this\s+(?:week|month|year))\b.{0,60}\b(?:news|weather|forecast|price|cost|stock|score|schedule|standings|results?|version|release|president|governor|mayor|ceo|law|policy|regulation|guidance)\b|\b(?:news|weather|forecast|price|stock|score|schedule|standings|results?|version|release|president|governor|mayor|ceo|law|policy|regulation|guidance)\b.{0,60}\b(?:latest|current|today(?:'s)?|recent|up-to-date|right\s+now)\b/i
 const HIGH_PATTERN = /\b(architecture|migration|security review|threat model|root cause|research report|multi-step|optimize|prove|complex analysis)\b/i
 const LIGHT_PATTERN = /^(hi|hello|thanks|thank you|yes|no|ok|okay)[!. ]*$|^(what is|who is|when is|where is|how many)\b|\b(define|translate|summarize briefly|quick question)\b/i
 
@@ -24,6 +30,17 @@ const classifierOutputSchema = z.object({
   reasonCodes: z.array(z.string().min(1).max(80)).max(5).default(["nova_classifier"]),
 })
 
+function requestsExplicitWebSearch(text: string): boolean {
+  const normalized = text.toLowerCase().replaceAll(/\s+/g, " ")
+  if (EXPLICIT_WEB_SEARCH_PHRASES.some(phrase => normalized.includes(phrase))) {
+    return true
+  }
+  const lookUpIndex = normalized.indexOf("look up")
+  if (lookUpIndex < 0) return false
+  const lookupRequest = normalized.slice(lookUpIndex, lookUpIndex + 100)
+  return lookupRequest.includes("online") || lookupRequest.includes("on the web")
+}
+
 export function deterministicClassify(text: string, hasImageInput = false): NexusClassifierDecision | null {
   if (hasImageInput && /\b(edit|change|remove|add|make|turn|replace|retouch|restyle|improve|enhance)\b/i.test(text)) {
     return { intent: "image", tier: "medium", confidence: 0.98, reasonCodes: ["image_edit_request"], source: "deterministic" }
@@ -33,6 +50,9 @@ export function deterministicClassify(text: string, hasImageInput = false): Nexu
   }
   if (PSD_PATTERN.test(text)) {
     return { intent: "psd-data", tier: "medium", confidence: 0.97, reasonCodes: ["psd_data_domain"], source: "deterministic" }
+  }
+  if (requestsExplicitWebSearch(text) || CURRENT_INFO_PATTERN.test(text)) {
+    return { intent: "web-search", tier: "medium", confidence: 0.96, reasonCodes: ["current_web_information"], source: "deterministic" }
   }
   if (INSTRUCTION_PATTERN.test(text)) {
     return { intent: "instruction", tier: "medium", confidence: 0.95, reasonCodes: ["instruction_domain"], source: "deterministic" }
@@ -97,7 +117,7 @@ export async function classifyNexusRequest(
       maxOutputTokens: 120,
       temperature: 0,
       system: "You are a fast request router. Use the route_request tool. If tool use is unavailable, return JSON only with no markdown.",
-      prompt: `Classify the request for an education-focused assistant.\n\nIntent must be one of general, instruction, psd-data, image. Use instruction for pedagogy, lesson planning, rubrics, curriculum, differentiation, or teaching strategy. Use psd-data when answering requires district student-information-system records such as rosters, schedules, grades, attendance, enrollment, or student demographics; do not use it for generic advice about students. Use image when the user wants to generate or edit an image${context.hasImageInput ? "; an image is attached to this request" : ""}${context.hasPreviousGeneratedImage ? "; a previously generated image is available for follow-up edits, but use image intent only when the request refers to editing or transforming it" : ""}. Tier must be light for short/simple transformations and factual questions, medium for normal synthesis and planning, high only for complex multi-stage reasoning, architecture, difficult coding, or deep analysis.\n\nReturn exactly: {"intent":"general","tier":"medium","confidence":0.8,"reasonCodes":["short_reason"]}\n\nRequest:\n${text.slice(0, 8_000)}`,
+      prompt: `Classify the request for an education-focused assistant.\n\nIntent must be one of general, instruction, psd-data, web-search, image. Use instruction for pedagogy, lesson planning, rubrics, curriculum, differentiation, or teaching strategy. Use psd-data when answering requires district student-information-system records such as rosters, schedules, grades, attendance, enrollment, or student demographics; do not use it for generic advice about students. Use web-search when the user explicitly asks to search or browse the internet, or when a reliable answer requires current external information such as recent news, live weather, prices, schedules, scores, officeholders, laws, product releases, or current guidance. Do not use web-search merely because the word "current" refers to the user's supplied text or project. Use image when the user wants to generate or edit an image${context.hasImageInput ? "; an image is attached to this request" : ""}${context.hasPreviousGeneratedImage ? "; a previously generated image is available for follow-up edits, but use image intent only when the request refers to editing or transforming it" : ""}. Tier must be light for short/simple transformations and factual questions, medium for normal synthesis and planning, high only for complex multi-stage reasoning, architecture, difficult coding, or deep analysis.\n\nReturn exactly: {"intent":"general","tier":"medium","confidence":0.8,"reasonCodes":["short_reason"]}\n\nRequest:\n${text.slice(0, 8_000)}`,
       tools: {
         route_request: tool({
           description: "Return the routing decision for this request",

--- a/lib/nexus/model-router/errors.ts
+++ b/lib/nexus/model-router/errors.ts
@@ -1,9 +1,9 @@
 export class NexusSpecialistUnavailableError extends Error {
-  readonly specialist: "image" | "psd-data"
+  readonly specialist: "image" | "psd-data" | "web-search"
   readonly reconnectConnectorIds: string[]
 
   constructor(
-    specialist: "image" | "psd-data",
+    specialist: "image" | "psd-data" | "web-search",
     message: string,
     reconnectConnectorIds: string[] = []
   ) {

--- a/lib/nexus/model-router/router.ts
+++ b/lib/nexus/model-router/router.ts
@@ -32,6 +32,13 @@ const EXECUTABLE_PROVIDERS = new Set(["openai", "google", "amazon-bedrock", "azu
 export const inferFamily = inferModelFamily
 export const inferTier = inferModelTier
 
+export function mergeRoutedToolNames(
+  manuallyEnabledToolNames: string[],
+  automaticToolNames: string[]
+): string[] {
+  return [...new Set([...manuallyEnabledToolNames, ...automaticToolNames])]
+}
+
 function configuredCandidates(
   config: NexusRouterConfig,
   family: NexusModelFamily,
@@ -39,6 +46,7 @@ function configuredCandidates(
   intent: NexusRouterIntent
 ): string[] {
   if (intent === "image") return config.specialists.imageModels
+  if (intent === "web-search") return config.specialists.webSearchModels
   if (intent === "instruction" && family === "auto" && config.specialists.instructionModels.length > 0) {
     return config.specialists.instructionModels
   }
@@ -65,6 +73,7 @@ function selectModel(args: {
   intent: NexusRouterIntent
   fallbackModelId: string
   accessibleIds: Set<string>
+  requiredTools: string[]
 }): { model: NexusModelRow; fallbackUsed: boolean } {
   const configuredIds = configuredCandidates(args.config, args.family, args.tier, args.intent)
   if (args.intent === "image") {
@@ -96,12 +105,22 @@ function selectModel(args: {
     family: args.family,
     tier: args.tier,
     fallbackModelId: args.fallbackModelId,
+    requirements: {
+      requiredTools: args.requiredTools,
+    },
     additionalEligibility: model =>
       !hasCapability(model.capabilities, "imageGeneration")
-      && (args.intent !== "instruction" || args.family !== "auto" || inferFamily(model) === "google"),
+      && (args.intent !== "instruction" || args.family !== "auto" || inferFamily(model) === "google")
+      && (args.intent !== "web-search" || args.family !== "auto" || inferFamily(model) === "google"),
   })
   if (routed) return { model: routed.model as NexusModelRow, fallbackUsed: routed.fallbackUsed }
 
+  if (args.intent === "web-search") {
+    throw new NexusSpecialistUnavailableError(
+      "web-search",
+      "Web search is not available for your selected model family or account right now. Ask an administrator to configure an accessible Gemini web-search model."
+    )
+  }
   if (args.family !== "auto") {
     throw new Error(`No accessible Nexus model is available in the ${args.family} family`)
   }
@@ -167,6 +186,7 @@ export async function routeNexusRequest(args: {
   experienceMode: NexusExperienceMode
   requestedFamily: NexusModelFamily
   enabledConnectorIds: string[]
+  enabledToolNames?: string[]
   userId: number
   hasImageInput?: boolean
   hasPreviousGeneratedImage?: boolean
@@ -186,12 +206,13 @@ export async function routeNexusRequest(args: {
       modelId: fallback.modelId,
       connectorIds: args.enabledConnectorIds,
       automaticConnectorIds: [],
+      automaticToolNames: [],
       metadata: {
         version: config.version, runtimeMode: mode, experienceMode: args.experienceMode,
         requestedFamily: args.requestedFamily, selectedFamily: inferFamily(fallback) ?? "fallback",
         intent: "general", tier: inferTier(fallback), confidence: 1,
         reasonCodes: ["router_off"], decisionSource: "fallback", selectedModelId: fallback.modelId,
-        fallbackUsed: false, autoAttachedPsdData: false,
+        fallbackUsed: false, autoAttachedPsdData: false, autoEnabledWebSearch: false,
       },
     }
   }
@@ -200,9 +221,14 @@ export async function routeNexusRequest(args: {
     hasImageInput: args.hasImageInput,
     hasPreviousGeneratedImage: args.hasPreviousGeneratedImage,
   })
+  const requiredTools = [...new Set(args.enabledToolNames ?? [])]
+  if (decision.intent === "web-search" && !requiredTools.includes("webSearch")) {
+    requiredTools.push("webSearch")
+  }
   const selection = selectModelForRuntime({
     models, config, family: args.requestedFamily, tier: decision.tier,
     intent: decision.intent, fallbackModelId: args.fallbackModelId, accessibleIds,
+    requiredTools,
   }, mode, fallback)
   const psdConnectorId = await resolveAutomaticPsdConnector(decision.intent, config)
   if (mode === "active" && decision.intent === "psd-data" && !psdConnectorId) {
@@ -216,17 +242,20 @@ export async function routeNexusRequest(args: {
     : args.enabledConnectorIds
   const selected = mode === "shadow" ? fallback : selection.model
   const connectorIds = mode === "shadow" ? args.enabledConnectorIds : proposedConnectors
+  const autoEnabledWebSearch = mode === "active" && decision.intent === "web-search"
 
   log.info("Nexus request routed", {
     mode, intent: decision.intent, tier: decision.tier, requestedFamily: args.requestedFamily,
     selectedModelId: selected.modelId, proposedModelId: selection.model.modelId,
     fallbackUsed: selection.fallbackUsed, autoAttachedPsdData: !!psdConnectorId,
+    autoEnabledWebSearch,
   })
 
   return {
     modelId: selected.modelId,
     connectorIds,
     automaticConnectorIds: mode === "active" && psdConnectorId ? [psdConnectorId] : [],
+    automaticToolNames: autoEnabledWebSearch ? ["webSearch"] : [],
     metadata: {
       version: config.version,
       runtimeMode: mode,
@@ -242,6 +271,7 @@ export async function routeNexusRequest(args: {
       proposedModelId: mode === "shadow" ? selection.model.modelId : undefined,
       fallbackUsed: selection.fallbackUsed || (mode === "shadow" && selection.model.modelId !== fallback.modelId),
       autoAttachedPsdData: mode === "active" && !!psdConnectorId,
+      autoEnabledWebSearch,
     },
   }
 }

--- a/lib/nexus/model-router/types.ts
+++ b/lib/nexus/model-router/types.ts
@@ -3,7 +3,13 @@ import { z } from "zod"
 export const nexusExperienceModeSchema = z.enum(["standard", "advanced"])
 export const nexusModelFamilySchema = z.enum(["auto", "openai", "anthropic", "google"])
 export const nexusRouterTierSchema = z.enum(["light", "medium", "high"])
-export const nexusRouterIntentSchema = z.enum(["general", "instruction", "psd-data", "image"])
+export const nexusRouterIntentSchema = z.enum([
+  "general",
+  "instruction",
+  "psd-data",
+  "web-search",
+  "image",
+])
 export const nexusRouterRuntimeModeSchema = z.enum(["off", "shadow", "active"])
 
 export type NexusExperienceMode = z.infer<typeof nexusExperienceModeSchema>
@@ -50,11 +56,23 @@ export const nexusRouterConfigSchema = z.object({
       "gemini-3-flash-preview",
       "gemini-2.5-flash",
     ]),
+    webSearchModels: z.array(z.string().min(1)).max(10).default([
+      "gemini-3.5-flash",
+      "gemini-3.1-pro-preview",
+      "gemini-3-flash-preview",
+      "gemini-2.5-flash",
+    ]),
     psdDataConnectorId: z.string().uuid().optional(),
     psdDataConnectorName: z.string().min(1).max(255).default("psd-data"),
   }).default({
     imageModels: ["gemini-3.1-flash-image-preview", "gemini-3.1-flash-image"],
     instructionModels: ["gemini-3.5-flash", "gemini-3-flash-preview", "gemini-2.5-flash"],
+    webSearchModels: [
+      "gemini-3.5-flash",
+      "gemini-3.1-pro-preview",
+      "gemini-3-flash-preview",
+      "gemini-2.5-flash",
+    ],
     psdDataConnectorName: "psd-data",
   }),
   confidenceFloor: z.number().min(0).max(1).default(0.55),
@@ -85,11 +103,13 @@ export interface NexusRoutingMetadata {
   proposedModelId?: string
   fallbackUsed: boolean
   autoAttachedPsdData: boolean
+  autoEnabledWebSearch: boolean
 }
 
 export interface NexusRouteResult {
   modelId: string
   connectorIds: string[]
   automaticConnectorIds: string[]
+  automaticToolNames: string[]
   metadata: NexusRoutingMetadata
 }

--- a/tests/e2e/admin-nexus-router-settings.spec.ts
+++ b/tests/e2e/admin-nexus-router-settings.spec.ts
@@ -12,7 +12,7 @@ test.describe('Admin Nexus router settings', () => {
     await page.goto('/admin/settings')
   })
 
-  test('renders rollout, tier, classifier, image, instruction, and PSD-data controls', async ({ page }) => {
+  test('renders rollout, tier, classifier, web-search, image, instruction, and PSD-data controls', async ({ page }) => {
     await expect(page.getByTestId('nexus-router-settings-card')).toBeVisible()
     await expect(page.getByTestId('nexus-router-admin-mode')).toBeVisible()
     await expect(page.getByTestId('assistant-architect-router-admin-mode')).toBeVisible()
@@ -23,6 +23,7 @@ test.describe('Admin Nexus router settings', () => {
     await expect(page.getByTestId('nexus-router-anthropic-medium')).toBeVisible()
     await expect(page.getByTestId('nexus-router-google-medium')).toBeVisible()
     await expect(page.getByTestId('nexus-router-instruction-model')).toBeVisible()
+    await expect(page.getByTestId('nexus-router-web-search-model')).toBeVisible()
     await expect(page.getByTestId('nexus-router-image-model')).toBeVisible()
     await expect(page.getByTestId('nexus-router-psd-connector')).toBeVisible()
     await expect(page.getByTestId('nexus-router-classifier-model')).toHaveValue('us.amazon.nova-micro-v1:0')

--- a/tests/e2e/nexus/model-router.spec.ts
+++ b/tests/e2e/nexus/model-router.spec.ts
@@ -232,4 +232,16 @@ test.describe('Nexus model router — authenticated deterministic UI and wire co
     expect(JSON.stringify(body.messages.at(-1))).toContain(prompt)
     await expect(page.getByTestId('nexus-mcp-control')).toHaveCount(0)
   })
+
+  test('a current-information request goes through Standard without a manual web-search selection', async ({ page }) => {
+    await selectStandard(page)
+    const prompt = 'Search the web for the latest weather forecast in Tacoma'
+    const body = await capturePrompt(page, prompt)
+
+    expect(body.nexusMode).toBe('standard')
+    expect(body.modelFamily).toBe('auto')
+    expect(body.enabledTools ?? []).toEqual([])
+    expect(JSON.stringify(body.messages.at(-1))).toContain(prompt)
+    await expect(page.getByTestId('nexus-tools-control')).toHaveCount(0)
+  })
 })


### PR DESCRIPTION
## Summary

- classify explicit web lookups and time-sensitive questions as web-search intent
- route Standard requests to a configurable web-search-capable Gemini specialist and automatically enable native Google Search
- keep Advanced family constraints, returning a clear specialist-unavailable response when the chosen family cannot search
- preserve tool-catalog resource grants and loaded-skill allowed-tools restrictions
- add the Web Search specialist control to Admin Settings
- document configuration and Assistant Architect behavior

## Verification

- bun run lint: passed with zero errors
- bun run typecheck: passed
- bun run test:ci -- --runInBand --forceExit: 2,937 passed, 60 skipped
- targeted authenticated Playwright specs: 12 passed
- full pre-push authenticated Playwright suite: 241 passed, 58 skipped, 2 flaky tests passed on retry
- bun run build: passed
- git diff --check: passed

## Flaky tests observed

- Atrium archived-content view timed out once and passed on retry
- Decision graph admin view encountered a duplicate hidden locator once and passed on retry

Neither flaky test touches Nexus routing or the files in this change.