### PR TITLE
fix(infra): grant content worker repository object access

### DIFF
--- a/infra/lib/constructs/processing/unified-content-processing.ts
+++ b/infra/lib/constructs/processing/unified-content-processing.ts
@@ -169,7 +169,6 @@ export class UnifiedContentProcessing extends Construct {
         region: stack.region,
         account: stack.account,
         vpcEnabled: true,
-        s3Buckets: [props.documentsBucket.bucketName],
         // ServiceRoleFactory accepts physical queue names; unresolved ARN
         // tokens would be prefixed a second time and synthesize an invalid ARN.
         sqsQueues: [this.queue.queueName, props.embeddingQueue.queueName],
@@ -182,8 +181,17 @@ export class UnifiedContentProcessing extends Construct {
                 resources: [props.databaseSecretArn],
               }),
               new iam.PolicyStatement({
-                sid: "ReadGuardDutyObjectScanTag",
-                actions: ["s3:GetObjectTagging"],
+                // Do not use ServiceRoleFactory's generic s3Buckets grant here.
+                // Its bucket-tag condition is not evaluated for S3 object ARNs,
+                // so GetObject fails closed even when the bucket is tagged. This
+                // explicit prefix is both narrower and valid for object access.
+                sid: "CanonicalRepositoryObjectAccess",
+                actions: [
+                  "s3:GetObject",
+                  "s3:GetObjectVersion",
+                  "s3:GetObjectTagging",
+                  "s3:PutObject",
+                ],
                 resources: [
                   `${props.documentsBucket.bucketArn}/repositories/*`,
                 ],

--- a/infra/test/unit/unified-content-processing.test.ts
+++ b/infra/test/unit/unified-content-processing.test.ts
@@ -108,6 +108,41 @@ describe("UnifiedContentProcessing", () => {
     });
   });
 
+  test("grants the worker valid least-privilege access to canonical repository objects", () => {
+    type PolicyStatement = {
+      Sid?: string;
+      Effect?: string;
+      Action?: string[];
+      Resource?: unknown;
+      Condition?: unknown;
+    };
+    const statements = Object.values(
+      template.findResources("AWS::IAM::Role")
+    ).flatMap((role) =>
+      (role.Properties?.Policies ?? []).flatMap(
+        (policy: { PolicyDocument?: { Statement?: PolicyStatement[] } }) =>
+          policy.PolicyDocument?.Statement ?? []
+      )
+    );
+    const repositoryAccess = statements.find(
+      (statement) => statement.Sid === "CanonicalRepositoryObjectAccess"
+    );
+
+    expect(repositoryAccess).toMatchObject({
+      Effect: "Allow",
+      Action: [
+        "s3:GetObject",
+        "s3:GetObjectVersion",
+        "s3:GetObjectTagging",
+        "s3:PutObject",
+      ],
+    });
+    expect(JSON.stringify(repositoryAccess?.Resource)).toContain(
+      ":s3:::aistudio-dev-documents/repositories/*"
+    );
+    expect(repositoryAccess?.Condition).toBeUndefined();
+  });
+
   test("grants only the documented wildcard APIs", () => {
     const policies = template.findResources("AWS::IAM::Policy");
     const roles = template.findResources("AWS::IAM::Role");


### PR DESCRIPTION
## Summary
- replace the unified-content worker's unusable tag-conditioned generic S3 grant
- grant explicit least-privilege read/tag-read/write access only under the documents bucket's `repositories/*` prefix
- add a CDK assertion proving the effective object actions, scoped resource, and absence of the invalid condition

## Live failure reproduced
A deployed two-page PDF passed GuardDuty (`NO_THREATS_FOUND`) and reached the SQS-triggered Lambda, but the worker failed with `AccessDenied` on `s3:GetObject`. The generic ServiceRoleFactory policy's `aws:ResourceTag` condition is not satisfied for S3 object ARNs.

## Verification
- targeted worker CDK test: 5/5
- full infrastructure suite: 29 suites, 325 tests
- root lint: 0 errors (existing warnings only)
- root and infrastructure typechecks
- full all-stack CDK synth with real Lambda bundles
- inspected synthesized dev policy to confirm `repositories/*`, required object actions, and no condition

## E2E
Skipped with `SKIP_E2E=1`: this changes only the Lambda execution role policy. Live AWS ingestion testing will be repeated after deployment.