### PR TITLE
fix(infra): permit unified content OCR through boundary

### DIFF
--- a/infra/lib/constructs/security/permission-boundaries/dev-boundary.json
+++ b/infra/lib/constructs/security/permission-boundaries/dev-boundary.json
@@ -28,6 +28,8 @@
         "ecr:GetDownloadUrlForLayer",
         "ecr:BatchGetImage",
         "ecs:*",
+        "textract:StartDocumentTextDetection",
+        "textract:GetDocumentTextDetection",
         "bedrock:InvokeModel",
         "bedrock:InvokeModelWithResponseStream",
         "bedrock:CallWithBearerToken",

--- a/infra/lib/constructs/security/permission-boundaries/prod-boundary.json
+++ b/infra/lib/constructs/security/permission-boundaries/prod-boundary.json
@@ -7,6 +7,7 @@
       "Action": [
         "s3:GetObject",
         "s3:GetObjectVersion",
+        "s3:GetObjectTagging",
         "s3:PutObject",
         "s3:DeleteObject",
         "s3:ListBucket",
@@ -48,6 +49,8 @@
         "ecs:RunTask",
         "ecs:StopTask",
         "ecs:DescribeTasks",
+        "textract:StartDocumentTextDetection",
+        "textract:GetDocumentTextDetection",
         "bedrock:InvokeModel",
         "bedrock:InvokeModelWithResponseStream",
         "bedrock:CallWithBearerToken",

--- a/infra/test/unit/permission-boundary-construct.test.ts
+++ b/infra/test/unit/permission-boundary-construct.test.ts
@@ -1,0 +1,48 @@
+import * as cdk from "aws-cdk-lib";
+import { Template } from "aws-cdk-lib/assertions";
+import { PermissionBoundaryConstruct } from "../../lib/constructs/security/permission-boundary-construct";
+
+type PolicyStatement = {
+  Sid?: string;
+  Action?: string | string[];
+};
+
+function allowedActions(environment: "dev" | "prod"): string[] {
+  const app = new cdk.App();
+  const stack = new cdk.Stack(app, `PermissionBoundary-${environment}`, {
+    env: { account: "123456789012", region: "us-east-1" },
+  });
+  new PermissionBoundaryConstruct(stack, "Boundary", { environment });
+
+  const policies = Template.fromStack(stack).findResources(
+    "AWS::IAM::ManagedPolicy"
+  );
+  const statements = Object.values(policies).flatMap((policy) =>
+    (policy.Properties?.PolicyDocument?.Statement ?? []) as PolicyStatement[]
+  );
+  const allowedServices = statements.find(
+    (statement) => statement.Sid === "AllowedServices"
+  );
+  const actions = Array.isArray(allowedServices?.Action)
+    ? allowedServices.Action
+    : [allowedServices?.Action];
+  return actions.filter((action): action is string => Boolean(action));
+}
+
+describe("PermissionBoundaryConstruct", () => {
+  test.each(["dev", "prod"] as const)(
+    "%s permits the asynchronous OCR calls used by unified content processing",
+    (environment) => {
+      expect(allowedActions(environment)).toEqual(
+        expect.arrayContaining([
+          "textract:StartDocumentTextDetection",
+          "textract:GetDocumentTextDetection",
+        ])
+      );
+    }
+  );
+
+  test("prod permits the GuardDuty verdict lookup used before processing", () => {
+    expect(allowedActions("prod")).toContain("s3:GetObjectTagging");
+  });
+});


### PR DESCRIPTION
## Summary

- allow the unified-content worker asynchronous Textract calls through the CDK-managed dev and prod permission boundaries
- allow the production worker to read GuardDuty malware verdict tags
- add regression coverage that synthesizes both environment boundaries

## Live failure reproduced

The deployed worker role had a correct inline policy, but the shared permissions boundary rejected textract:StartDocumentTextDetection. A real PNG upload passed GuardDuty and then failed at OCR with that boundary denial.

## Verification

- bun run lint: 0 errors
- bun run typecheck
- application CI unit suite: 257 suites, 3,016 tests passed
- infrastructure Jest suite: 30 suites, 330 tests passed
- infrastructure build and unified worker typecheck
- agent skill builder Lambda tests: 11 passed
- CDK synth: AIStudio-PermissionBoundary-Dev and AIStudio-PermissionBoundary-Prod
- synthesized templates inspected for both Textract actions and production s3:GetObjectTagging

E2E was intentionally skipped with SKIP_E2E=1 because this is an IAM/CDK-only change with no UI or request-contract impact.