### PR TITLE
fix(infra): grant exact embedding queue dispatch

### DIFF
--- a/infra/lib/constructs/processing/unified-content-processing.ts
+++ b/infra/lib/constructs/processing/unified-content-processing.ts
@@ -171,7 +171,11 @@ export class UnifiedContentProcessing extends Construct {
         vpcEnabled: true,
         // ServiceRoleFactory accepts physical queue names; unresolved ARN
         // tokens would be prefixed a second time and synthesize an invalid ARN.
-        sqsQueues: [this.queue.queueName, props.embeddingQueue.queueName],
+        // This queue is owned and tagged by this construct, so the factory's
+        // resource-tag conditions are guaranteed to match. Embedding dispatch
+        // uses an explicit queue-ARN grant below because shared queues may have
+        // stack-level tags whose values do not match those conditions.
+        sqsQueues: [this.queue.queueName],
         additionalPolicies: [
           new iam.PolicyDocument({
             statements: [
@@ -179,6 +183,11 @@ export class UnifiedContentProcessing extends Construct {
                 sid: "AuroraSecretAccess",
                 actions: ["secretsmanager:GetSecretValue"],
                 resources: [props.databaseSecretArn],
+              }),
+              new iam.PolicyStatement({
+                sid: "CanonicalEmbeddingDispatch",
+                actions: ["sqs:SendMessage"],
+                resources: [props.embeddingQueue.queueArn],
               }),
               new iam.PolicyStatement({
                 // Do not use ServiceRoleFactory's generic s3Buckets grant here.

--- a/infra/test/unit/unified-content-processing.test.ts
+++ b/infra/test/unit/unified-content-processing.test.ts
@@ -143,6 +143,37 @@ describe("UnifiedContentProcessing", () => {
     expect(repositoryAccess?.Condition).toBeUndefined();
   });
 
+  test("dispatches embeddings through an exact queue ARN without tag conditions", () => {
+    type PolicyStatement = {
+      Sid?: string;
+      Effect?: string;
+      Action?: string | string[];
+      Resource?: unknown;
+      Condition?: unknown;
+    };
+    const statements = Object.values(
+      template.findResources("AWS::IAM::Role")
+    ).flatMap((role) =>
+      (role.Properties?.Policies ?? []).flatMap(
+        (policy: { PolicyDocument?: { Statement?: PolicyStatement[] } }) =>
+          policy.PolicyDocument?.Statement ?? []
+      )
+    );
+    const embeddingDispatch = statements.find(
+      (statement) => statement.Sid === "CanonicalEmbeddingDispatch"
+    );
+
+    expect(embeddingDispatch).toMatchObject({
+      Effect: "Allow",
+      Action: "sqs:SendMessage",
+    });
+    expect(embeddingDispatch?.Resource).toEqual({
+      "Fn::GetAtt": [expect.stringMatching(/^EmbeddingQueue/), "Arn"],
+    });
+    expect(JSON.stringify(embeddingDispatch?.Resource)).not.toContain("*");
+    expect(embeddingDispatch?.Condition).toBeUndefined();
+  });
+
   test("grants only the documented wildcard APIs", () => {
     const policies = template.findResources("AWS::IAM::Policy");
     const roles = template.findResources("AWS::IAM::Role");


### PR DESCRIPTION
## Summary

- replace the unified-content worker generic tag-conditioned embedding queue access with an exact-ARN sqs:SendMessage grant
- keep the worker content queue on the ServiceRoleFactory tag-conditioned policy because that queue is owned and tagged by the construct
- add regression coverage proving the embedding grant has no wildcard and no tag condition

## Live failure reproduced

A fresh PNG passed GuardDuty, started and completed Textract OCR, and reached publication. Embedding dispatch then failed because the shared embedding queue is tagged Environment=Dev without ManagedBy=cdk while the generic role policy requires Environment=dev and ManagedBy=cdk.

## Verification

- targeted unified-content CDK suite: 7 passed
- application CI suite: 257 suites and 3,016 tests passed
- infrastructure/Lambda suite: 30 suites and 331 tests passed
- agent skill-builder Lambda tests: 11 passed
- lint: 0 errors
- typecheck and infrastructure build passed
- AIStudio-ProcessingStack-Dev synthesized successfully
- synthesized CanonicalEmbeddingDispatch statement inspected: exact queue ARN, sqs:SendMessage only, no condition

E2E was intentionally skipped with SKIP_E2E=1 because this is an IAM/CDK-only change with no UI or request-contract impact.