### PR TITLE
fix: harden Retrieval v2 live cutover

### DIFF
--- a/actions/repositories/repository-items.actions.ts
+++ b/actions/repositories/repository-items.actions.ts
@@ -40,6 +40,8 @@ import { toContentDispositionValue } from "@/lib/repositories/content-dispositio
 import {
   deleteRepositoryItemStorage,
   dispatchContentProcessingJob,
+  isCanonicalUploadContentType,
+  registerCanonicalTextIfEnabled,
   registerCanonicalUploadIfEnabled,
 } from "@/lib/repositories/content-platform"
 
@@ -106,6 +108,94 @@ export interface AddDocumentWithPresignedUrlInput {
     contentType: string
     size: number
     originalFileName: string
+  }
+}
+
+async function shadowWriteCanonicalText(
+  input: {
+    itemId: number
+    repositoryId: number
+    userId: number
+    name: string
+    content: string
+    traceId: string
+  },
+  log: ReturnType<typeof createLogger>
+): Promise<void> {
+  try {
+    const canonical = await registerCanonicalTextIfEnabled(input)
+    if (!canonical) return
+
+    log.info("Canonical inline text version registered", {
+      itemId: input.itemId,
+      versionId: canonical.version.id,
+      processingJobId: canonical.inspectJob.id,
+      created: canonical.created,
+    })
+    try {
+      await dispatchContentProcessingJob({
+        jobId: canonical.inspectJob.id,
+        itemVersionId: canonical.version.id,
+      })
+    } catch (dispatchError) {
+      log.warn("Canonical inline text processing is pending scheduled dispatch", {
+        processingJobId: canonical.inspectJob.id,
+        error:
+          dispatchError instanceof Error
+            ? dispatchError.message
+            : "Unknown error",
+      })
+    }
+  } catch (error) {
+    log.error("Canonical inline text shadow write failed", {
+      itemId: input.itemId,
+      error: error instanceof Error ? error.message : "Unknown error",
+    })
+  }
+}
+
+async function shadowWriteCanonicalUpload(
+  input: {
+    itemId: number
+    userId: number
+    objectKey: string
+    originalFileName: string
+    declaredContentType: string
+    byteSize: number
+    traceId: string
+  },
+  log: ReturnType<typeof createLogger>
+): Promise<void> {
+  if (!isCanonicalUploadContentType(input.declaredContentType)) return
+  try {
+    const canonical = await registerCanonicalUploadIfEnabled(input)
+    if (!canonical) return
+
+    log.info("Canonical repository version registered", {
+      itemId: input.itemId,
+      versionId: canonical.version.id,
+      processingJobId: canonical.inspectJob.id,
+      created: canonical.created,
+    })
+    try {
+      await dispatchContentProcessingJob({
+        jobId: canonical.inspectJob.id,
+        itemVersionId: canonical.version.id,
+      })
+    } catch (dispatchError) {
+      log.warn("Canonical processing is pending scheduled dispatch", {
+        processingJobId: canonical.inspectJob.id,
+        error:
+          dispatchError instanceof Error
+            ? dispatchError.message
+            : "Unknown error",
+      })
+    }
+  } catch (error) {
+    log.error("Canonical repository shadow write failed", {
+      itemId: input.itemId,
+      error: error instanceof Error ? error.message : "Unknown error",
+    })
   }
 }
 
@@ -234,7 +324,7 @@ export async function addDocumentItem(
       })
       throw ErrorFactories.authzToolAccessDenied("knowledge-repositories")
     }
-    
+
     // Validate and sanitize inputs
     const validationError = validateAddDocumentInput(input)
     if (validationError) {
@@ -310,6 +400,19 @@ export async function addDocumentItem(
 
     // Convert to action type
     const item: RepositoryItem = mapToRepositoryItem(itemRaw)
+
+    await shadowWriteCanonicalUpload(
+      {
+        itemId: item.id,
+        userId,
+        objectKey: key,
+        originalFileName: sanitizedFilename,
+        declaredContentType: input.file.contentType,
+        byteSize: fileContent.byteLength,
+        traceId: requestId,
+      },
+      log
+    )
 
     // Queue the document for processing
     log.info("Queueing document for processing", {
@@ -487,8 +590,8 @@ export async function addDocumentWithPresignedUrl(
     // CONTENT_READ_V2_ENABLED is separately enabled. A shadow-write failure is
     // observable but does not make the existing upload disappear from the user;
     // the pending repository item can be reconciled and replayed safely.
-    try {
-      const canonical = await registerCanonicalUploadIfEnabled({
+    await shadowWriteCanonicalUpload(
+      {
         itemId: item.id,
         userId,
         objectKey: input.s3Key,
@@ -496,35 +599,9 @@ export async function addDocumentWithPresignedUrl(
         declaredContentType: input.metadata.contentType,
         byteSize: input.metadata.size,
         traceId: requestId,
-      })
-      if (canonical) {
-        log.info("Canonical repository version registered", {
-          itemId: item.id,
-          versionId: canonical.version.id,
-          processingJobId: canonical.inspectJob.id,
-          created: canonical.created,
-        })
-        try {
-          await dispatchContentProcessingJob({
-            jobId: canonical.inspectJob.id,
-            itemVersionId: canonical.version.id,
-          })
-        } catch (dispatchError) {
-          log.warn("Canonical processing is pending scheduled dispatch", {
-            processingJobId: canonical.inspectJob.id,
-            error:
-              dispatchError instanceof Error
-                ? dispatchError.message
-                : "Unknown error",
-          })
-        }
-      }
-    } catch (error) {
-      log.error("Canonical repository shadow write failed", {
-        itemId: item.id,
-        error: error instanceof Error ? error.message : "Unknown error",
-      })
-    }
+      },
+      log
+    )
 
     // Queue for processing (embedding generation, etc.)
     log.info("Queueing document for processing", {
@@ -739,6 +816,13 @@ export async function addTextItem(
       throw ErrorFactories.authzToolAccessDenied("knowledge-repositories")
     }
 
+    if (!input.name.trim()) {
+      return { isSuccess: false, message: "Name is required" }
+    }
+    if (!input.content.trim()) {
+      return { isSuccess: false, message: "Text content is required" }
+    }
+
     // Get the user ID from the cognito_sub
     log.debug("Getting user ID from session")
     const userId = await getUserIdFromSession(session.sub)
@@ -796,6 +880,22 @@ export async function addTextItem(
         return newItem.id;
       },
       'addTextItem'
+    )
+
+    // Inline text previously bypassed the canonical pipeline entirely. Keep
+    // the legacy row for rollback, but shadow-write a repository-scoped text
+    // object so Retrieval v2 receives an immutable version, generation,
+    // embeddings, and exact citation through the same worker as file uploads.
+    await shadowWriteCanonicalText(
+      {
+        itemId,
+        repositoryId: input.repository_id,
+        userId,
+        name: input.name,
+        content: input.content,
+        traceId: requestId,
+      },
+      log
     )
 
     // Fetch the created item via Drizzle

--- a/components/features/repositories/search-results.tsx
+++ b/components/features/repositories/search-results.tsx
@@ -29,7 +29,9 @@ function ResultCitation({ result }: { result: SearchResult }) {
       <MapPin className="ml-2 h-3 w-3" />
       {label}
       <span className="sr-only">
-        , source version {result.citation.versionNumber}
+        {result.citation.versionNumber > 0
+          ? `, source version ${result.citation.versionNumber}`
+          : ", legacy source pending canonical backfill"}
       </span>
     </>
   )

--- a/docs/plans/2026-07-21-unified-content-platform.md
+++ b/docs/plans/2026-07-21-unified-content-platform.md
@@ -657,3 +657,49 @@ Verification evidence:
 
 The remaining rollout check is a dev deployment followed by real Bedrock Cohere
 rerank/visual-embedding validation before visual indexing is enabled broadly.
+
+### Retrieval v2 live-hardening checkpoint (2026-07-22)
+
+The first dev cutover exposed two migration gaps that were not reproducible with
+new canonical file uploads alone: pre-cutover URL/text chunks disappeared when
+the v2 read flag was enabled, and newly created inline text still wrote only the
+legacy item/chunk rows. The hardening slice closes both gaps without weakening
+the single read-cutover boundary:
+
+- Completed legacy-only chunks remain available through an explicit,
+  repository-authorized lexical compatibility query until the same item appears
+  in the repository's active canonical generation. Canonical content then wins
+  automatically, so stale duplicate chunks cannot leak into results.
+- Inline text is stored as an immutable repository-scoped S3 source, registered
+  as a canonical version/job, and dispatched through the unified processor.
+  Plain text, Markdown, and CSV now receive strict UTF-8 validation,
+  tokenizer-aware segmentation, stable hashes, heading-aware locators, normal
+  publication, embedding, generation activation, and exact citations.
+- Both the direct legacy upload action and the presigned upload action now use
+  the same fail-open canonical shadow-write helper for every supported canonical
+  content type. A dispatch outage leaves an observable pending job for scheduled
+  recovery instead of hiding the user's successful legacy upload.
+- Retrieval diagnostics count repositories authorized by ACL even while they
+  have no active canonical generation, making the compatibility window visible
+  rather than reporting those repositories as unauthorized.
+
+Verification evidence for the hardening slice:
+
+- Application CI suite: 270 suites passed, 5 skipped; 3,070 tests passed and 60
+  intentionally skipped. Infrastructure/Lambda suite: 33 suites and 348 tests
+  passed.
+- The real PostgreSQL unified-content smoke passed canonical inline-text
+  publication/retrieval/citation and legacy compatibility, including automatic
+  legacy suppression after canonical activation and cleanup.
+- Full authenticated Playwright passed 248 tests with 58 environment-gated
+  skips. The new inline-text workflow and canonical PDF, Office, image, audio,
+  and video upload contracts all passed. One unrelated Atrium editor timing test
+  passed on retry 2 and was reported as flaky; there were no genuine failures.
+- Full lint completed with zero errors; root and worker typechecks, the complete
+  infrastructure build, the production Next.js build, and all-stack no-lookup
+  CDK synthesis passed.
+
+The remaining rollout check is deployment of this hardening slice, followed by
+live confirmation that the pre-cutover marker is searchable and that a new
+inline-text item advances through version, job, generation, embedding, and
+citation state in dev.

--- a/infra/lambdas/unified-content-processor/index.ts
+++ b/infra/lambdas/unified-content-processor/index.ts
@@ -58,6 +58,10 @@ import {
   isOfficeContentType,
 } from "../../../lib/repositories/content-platform/office-processing";
 import {
+  extractCanonicalTextDocument,
+  isCanonicalTextContentType,
+} from "../../../lib/repositories/content-platform/text-processing";
+import {
   MAX_INLINE_ARTIFACT_CHARACTERS,
   publishDocumentVersion,
   type PublishableArtifact,
@@ -663,6 +667,7 @@ async function processMessage(message: ContentProcessingMessage, workerId: strin
           objectKey: repositoryItemVersions.objectKey,
           declaredContentType: repositoryItemVersions.declaredContentType,
           byteSize: repositoryItemVersions.byteSize,
+          metadata: repositoryItemVersions.metadata,
           repositoryId: repositoryItems.repositoryId,
         })
         .from(repositoryItemVersions)
@@ -681,8 +686,15 @@ async function processMessage(message: ContentProcessingMessage, workerId: strin
   }
   const isPdf = declaredContentType === "application/pdf";
   const isImage = isImageContentType(declaredContentType);
+  const isText = isCanonicalTextContentType(declaredContentType);
   const mediaKind = mediaKindForContentType(declaredContentType);
-  if (!isPdf && !isImage && !mediaKind && !isOfficeContentType(declaredContentType)) {
+  if (
+    !isPdf &&
+    !isImage &&
+    !isText &&
+    !mediaKind &&
+    !isOfficeContentType(declaredContentType)
+  ) {
     throw new Error("Unified content worker received an unsupported content type");
   }
 
@@ -693,7 +705,11 @@ async function processMessage(message: ContentProcessingMessage, workerId: strin
   }
   const processingLimitBytes = mediaKind
     ? Math.min(maximumMediaBytes(mediaKind), config.maxFileSizeGb * 1024 ** 3)
-    : (isPdf ? config.maxPdfSizeMb : isImage ? config.maxImageSizeMb : config.maxOfficeSizeMb) * 1024 ** 2;
+    : (isPdf
+        ? config.maxPdfSizeMb
+        : isImage
+          ? config.maxImageSizeMb
+          : config.maxOfficeSizeMb) * 1024 ** 2;
   if (context.byteSize != null && context.byteSize > processingLimitBytes) {
     throw new Error(`File exceeds the configured ${Math.floor(processingLimitBytes / 1024 ** 2)} MiB processing limit`);
   }
@@ -869,6 +885,22 @@ async function processMessage(message: ContentProcessingMessage, workerId: strin
       canonicalText = extracted.canonicalText;
       processorVersion = extracted.processorVersion;
       processorName = "aistudio-office";
+      artifactMetadata = extracted.metadata;
+    } else if (isText) {
+      const metadata = (context.metadata ?? {}) as Record<string, unknown>;
+      const originalFileName =
+        typeof metadata.originalFileName === "string"
+          ? metadata.originalFileName
+          : undefined;
+      const extracted = extractCanonicalTextDocument(
+        source,
+        declaredContentType,
+        originalFileName
+      );
+      segments = extracted.segments;
+      canonicalText = extracted.canonicalText;
+      processorVersion = extracted.processorVersion;
+      processorName = "aistudio-text";
       artifactMetadata = extracted.metadata;
     } else {
       const prepared = await prepareRepositoryImage(source, declaredContentType);

--- a/lib/aws/s3-client.ts
+++ b/lib/aws/s3-client.ts
@@ -15,6 +15,7 @@ import { getSignedUrl } from "@aws-sdk/s3-request-presigner"
 import { createError } from "@/lib/error-utils"
 import { Settings } from "@/lib/settings-manager"
 import { Readable } from "node:stream"
+import { randomUUID } from "node:crypto"
 
 // Cache S3 config to avoid repeated async calls
 let s3ConfigCache: { bucket: string | null; region: string | null } | null = null
@@ -78,6 +79,14 @@ export interface PresignedUploadUrlParams {
   fileSize: number
   metadata?: Record<string, string>
   expiresIn?: number // seconds, default 3600 (1 hour)
+}
+
+export interface UploadRepositoryTextSourceParams {
+  repositoryId: number
+  itemId: number
+  userId: number
+  fileName: string
+  content: string
 }
 
 // Ensure the documents bucket exists
@@ -191,6 +200,44 @@ export async function uploadDocument({
       }
     })
   }
+}
+
+/**
+ * Persist inline repository text as an immutable canonical source object.
+ * Keeping it in the repository namespace lets the unified processor and
+ * storage cleanup use the same lifecycle as browser-uploaded files.
+ */
+export async function uploadRepositoryTextSource({
+  repositoryId,
+  itemId,
+  userId,
+  fileName,
+  content,
+}: UploadRepositoryTextSourceParams): Promise<{ key: string; byteSize: number }> {
+  await ensureDocumentsBucket()
+
+  const s3Client = await getS3Client()
+  const config = await getS3Config()
+  const body = Buffer.from(content, "utf8")
+  const key = `repositories/${repositoryId}/inline/${randomUUID()}/${fileName}`
+
+  await s3Client.send(
+    new PutObjectCommand({
+      Bucket: config.bucket!,
+      Key: key,
+      Body: body,
+      ContentType: "text/plain",
+      Metadata: {
+        repositoryId: repositoryId.toString(),
+        itemId: itemId.toString(),
+        userId: userId.toString(),
+        sourceKind: "text",
+        uploadedAt: new Date().toISOString(),
+      },
+    })
+  )
+
+  return { key, byteSize: body.byteLength }
 }
 
 // Get a signed URL for a document

--- a/lib/repositories/content-platform/index.ts
+++ b/lib/repositories/content-platform/index.ts
@@ -8,3 +8,5 @@ export * from "./publication-service";
 export * from "./storage-cleanup";
 export * from "./upload-service";
 export * from "./dispatch-service";
+export * from "./inline-text-ingestion";
+export * from "./text-processing";

--- a/lib/repositories/content-platform/inline-text-ingestion.ts
+++ b/lib/repositories/content-platform/inline-text-ingestion.ts
@@ -1,0 +1,71 @@
+import { createHash } from "node:crypto";
+import { uploadRepositoryTextSource } from "@/lib/aws/s3-client";
+import {
+  type CanonicalUploadRegistration,
+  registerCanonicalUpload,
+} from "./ingestion-service";
+import { getContentPlatformConfig, isContentDualWriteActive } from "./config";
+
+export interface RegisterCanonicalTextInput {
+  itemId: number;
+  repositoryId: number;
+  userId: number;
+  name: string;
+  content: string;
+  traceId?: string;
+}
+
+function textSourceFileName(name: string): string {
+  const sanitized = name
+    .trim()
+    .replace(/[^\d.A-Za-z-]/g, "_")
+    .replace(/\.{2,}/g, ".")
+    .replace(/^\.+|\.+$/g, "")
+    .slice(0, 240);
+  const base = sanitized || "repository-text";
+  return base.toLowerCase().endsWith(".txt") ? base : `${base}.txt`;
+}
+
+/**
+ * Shadow-write Repository Manager inline text through the same immutable S3,
+ * inspection, processing, generation, and embedding pipeline as uploaded files.
+ */
+export async function registerCanonicalTextIfEnabled(
+  input: RegisterCanonicalTextInput
+): Promise<CanonicalUploadRegistration | null> {
+  const config = await getContentPlatformConfig();
+  if (!isContentDualWriteActive(config)) return null;
+  if (!input.content.trim()) throw new Error("Text content is required");
+
+  const byteSize = Buffer.byteLength(input.content, "utf8");
+  const maximumBytes = Math.min(
+    config.maxFileSizeGb * 1024 ** 3,
+    config.maxOfficeSizeMb * 1024 ** 2
+  );
+  if (byteSize > maximumBytes) {
+    throw new Error(
+      `Text content must not exceed ${Math.floor(maximumBytes / 1024 ** 2)} MiB`
+    );
+  }
+
+  const sha256 = createHash("sha256").update(input.content, "utf8").digest("hex");
+  const originalFileName = textSourceFileName(input.name);
+  const source = await uploadRepositoryTextSource({
+    repositoryId: input.repositoryId,
+    itemId: input.itemId,
+    userId: input.userId,
+    fileName: originalFileName,
+    content: input.content,
+  });
+
+  return registerCanonicalUpload({
+    itemId: input.itemId,
+    userId: input.userId,
+    objectKey: source.key,
+    originalFileName,
+    declaredContentType: "text/plain",
+    byteSize: source.byteSize,
+    sha256,
+    traceId: input.traceId,
+  });
+}

--- a/lib/repositories/content-platform/text-processing.ts
+++ b/lib/repositories/content-platform/text-processing.ts
@@ -1,0 +1,150 @@
+import { createHash } from "node:crypto";
+import type { RepositorySourceLocator } from "@/lib/db/schema";
+import {
+  countRepositoryTokens,
+  splitTokenizerAwareText,
+} from "./token-segmentation";
+
+export const TEXT_PROCESSOR_VERSION = "structured-text-v1";
+
+export const TEXT_CONTENT_TYPES = [
+  "text/plain",
+  "text/markdown",
+  "text/csv",
+] as const;
+
+export type CanonicalTextContentType = (typeof TEXT_CONTENT_TYPES)[number];
+
+export interface CanonicalTextSegment {
+  content: string;
+  contentHash: string;
+  chunkIndex: number;
+  tokens: number;
+  sourceLocator: RepositorySourceLocator;
+  contextPrefix: string;
+  segmentLevel: "section" | "chunk";
+  parentChunkIndex?: number;
+}
+
+export interface CanonicalTextDocument {
+  canonicalText: string;
+  detectedContentType: CanonicalTextContentType;
+  processorVersion: string;
+  segments: CanonicalTextSegment[];
+  metadata: {
+    encoding: "utf-8";
+    characters: number;
+    lines: number;
+  };
+}
+
+interface TextSection {
+  heading: string | null;
+  content: string;
+}
+
+export function isCanonicalTextContentType(
+  contentType: string
+): contentType is CanonicalTextContentType {
+  return (TEXT_CONTENT_TYPES as readonly string[]).includes(contentType);
+}
+
+function normalizeText(source: Uint8Array): string {
+  let decoded: string;
+  try {
+    decoded = new TextDecoder("utf-8", { fatal: true }).decode(source);
+  } catch {
+    throw new Error("Text source is not valid UTF-8");
+  }
+  const normalized = decoded
+    .replace(/^\uFEFF/, "")
+    .replace(/\r\n?/g, "\n")
+    .replace(/[ \t]+\n/g, "\n")
+    .replace(/\n{4,}/g, "\n\n\n")
+    .trim();
+  if (normalized.includes("\0")) {
+    throw new Error("Text source contains binary null bytes");
+  }
+  if (!normalized) throw new Error("Text source has no searchable content");
+  return normalized;
+}
+
+function markdownSections(text: string): TextSection[] {
+  const sections: TextSection[] = [];
+  let heading: string | null = null;
+  let lines: string[] = [];
+  const flush = () => {
+    const content = lines.join("\n").trim();
+    if (content) sections.push({ heading, content });
+    lines = [];
+  };
+  for (const line of text.split("\n")) {
+    const match = /^(#{1,6})\s+(.+?)\s*$/.exec(line);
+    if (match) {
+      flush();
+      heading = match[2]?.trim().slice(0, 160) || null;
+    }
+    lines.push(line);
+  }
+  flush();
+  return sections;
+}
+
+function sourceLabel(fileName: string | undefined): string {
+  const value = fileName?.trim().slice(0, 160);
+  return value || "Repository text";
+}
+
+/** Decode, structurally segment, and cite UTF-8 repository text. */
+export function extractCanonicalTextDocument(
+  source: Uint8Array,
+  contentType: string,
+  fileName?: string
+): CanonicalTextDocument {
+  if (!isCanonicalTextContentType(contentType)) {
+    throw new Error("Unsupported canonical text content type");
+  }
+  const canonicalText = normalizeText(source);
+  const sections =
+    contentType === "text/markdown"
+      ? markdownSections(canonicalText)
+      : [{ heading: null, content: canonicalText }];
+  const label = sourceLabel(fileName);
+  const segments: CanonicalTextSegment[] = [];
+  for (const section of sections) {
+    const sectionStart = segments.length;
+    const chunks = splitTokenizerAwareText(section.content);
+    for (const [sectionChunkIndex, content] of chunks.entries()) {
+      const headingPath = [label];
+      if (section.heading) headingPath.push(section.heading);
+      if (chunks.length > 1) headingPath.push(`Part ${sectionChunkIndex + 1}`);
+      const contextPrefix = headingPath.join(" › ");
+      segments.push({
+        content,
+        contentHash: createHash("sha256").update(content).digest("hex"),
+        chunkIndex: segments.length,
+        tokens: countRepositoryTokens(`${contextPrefix}\n${content}`),
+        sourceLocator: { headingPath },
+        contextPrefix,
+        segmentLevel: sectionChunkIndex === 0 ? "section" : "chunk",
+        parentChunkIndex:
+          sectionChunkIndex === 0 ? undefined : sectionStart,
+      });
+    }
+  }
+  if (segments.length === 0) {
+    throw new Error("Text source has no searchable content");
+  }
+
+  return {
+    canonicalText,
+    detectedContentType: contentType,
+    processorVersion: TEXT_PROCESSOR_VERSION,
+    segments,
+    metadata: {
+      encoding: "utf-8",
+      characters: canonicalText.length,
+      lines: canonicalText.split("\n").length,
+    },
+  };
+}

--- a/lib/repositories/content-platform/upload-service.ts
+++ b/lib/repositories/content-platform/upload-service.ts
@@ -31,6 +31,7 @@ import {
   mediaKindForContentType,
 } from "./media-processing";
 import { isOfficeContentType } from "./office-processing";
+import { isCanonicalTextContentType } from "./text-processing";
 
 export interface InitiateRepositoryUploadInput {
   repositoryId: number;
@@ -110,6 +111,7 @@ export function isCanonicalUploadContentType(contentType: string): boolean {
   return (
     contentType === "application/pdf" ||
     isOfficeContentType(contentType) ||
+    isCanonicalTextContentType(contentType) ||
     isImageContentType(contentType) ||
     mediaKindForContentType(contentType) !== null
   );
@@ -144,7 +146,7 @@ function validateInitiation(
   }
   if (!isCanonicalUploadContentType(input.contentType)) {
     throw new Error(
-      "The canonical processor accepts PDF, Office, image, audio, and video files only"
+      "The canonical processor accepts PDF, Office, text, image, audio, and video files only"
     );
   }
   const mediaKind = mediaKindForContentType(input.contentType);

--- a/lib/repositories/retrieval-v2/service.ts
+++ b/lib/repositories/retrieval-v2/service.ts
@@ -103,6 +103,64 @@ function mapCandidate(
   };
 }
 
+function positiveInteger(value: unknown): number | undefined {
+  const parsed = Number(value);
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : undefined;
+}
+
+function legacySourceLocator(
+  row: Record<string, unknown>
+): RepositorySourceLocator {
+  const sourceLocator = parseRecord(row.source_locator) as RepositorySourceLocator;
+  if (Object.keys(sourceLocator).length > 0) return sourceLocator;
+
+  const metadata = parseRecord(row.metadata);
+  const page = positiveInteger(metadata.page ?? metadata.pageNumber);
+  if (page) return { page };
+  const paragraph = positiveInteger(metadata.paragraph ?? metadata.paragraphNumber);
+  if (paragraph) return { paragraph };
+  const slide = positiveInteger(metadata.slide ?? metadata.slideNumber);
+  if (slide) return { slide };
+
+  return { headingPath: [String(row.item_name ?? "Legacy repository source")] };
+}
+
+function mapLegacyCandidate(row: Record<string, unknown>): RetrievalCandidate {
+  const rawScore = Number(row.score) || 0;
+  const itemId = Number(row.item_id);
+  return {
+    chunkId: Number(row.chunk_id),
+    repositoryId: Number(row.repository_id),
+    repositoryName: String(row.repository_name ?? ""),
+    generationId: `legacy:${row.repository_id}`,
+    itemId,
+    itemStableId: String(row.item_stable_id),
+    itemName: String(row.item_name ?? ""),
+    itemVersionId: `legacy:${itemId}`,
+    versionNumber: 0,
+    artifactId: null,
+    content: String(row.content ?? ""),
+    contextPrefix: "",
+    chunkIndex: Number(row.chunk_index),
+    parentChunkIndex: null,
+    segmentLevel: "chunk",
+    modality: ALL_MODALITIES.includes(row.modality as RetrievalModality)
+      ? (row.modality as RetrievalModality)
+      : "text",
+    sourceLocator: legacySourceLocator(row),
+    tokens: Math.max(
+      1,
+      Number(row.tokens) || countRepositoryTokens(String(row.content ?? ""))
+    ),
+    metadata: {
+      ...parseRecord(row.metadata),
+      retrievalCompatibility: "legacy-v1",
+    },
+    fusedScore: 0,
+    lexicalScore: rawScore,
+  };
+}
+
 async function resolvePrincipal(cognitoSub: string): Promise<RetrievalPrincipal | null> {
   const user = await getUserByCognitoSub(cognitoSub);
   if (!user) return null;
@@ -315,6 +373,77 @@ async function lexicalCandidates(
   );
 }
 
+/**
+ * Keep pre-migration repository content searchable during the dual-write and
+ * backfill window. A legacy chunk is omitted as soon as that item has a chunk
+ * in the repository's active canonical generation, preventing stale duplicate
+ * disclosure while avoiding a read-cutover hole for URL/text items.
+ */
+async function legacyCompatibilityCandidates(
+  repositoryIds: number[],
+  principal: RetrievalPrincipal,
+  query: string,
+  modalities: RetrievalModality[],
+  limit: number
+): Promise<RetrievalCandidate[]> {
+  if (repositoryIds.length === 0) return [];
+  const rows = await executeQuery(
+    (db) =>
+      db.execute(sql`
+        SELECT
+          chunk.id AS chunk_id,
+          repository.id AS repository_id,
+          repository.name AS repository_name,
+          item.id AS item_id,
+          item.stable_id AS item_stable_id,
+          item.name AS item_name,
+          chunk.content,
+          chunk.chunk_index,
+          chunk.modality,
+          chunk.source_locator,
+          chunk.tokens,
+          chunk.metadata,
+          ts_rank_cd(
+            chunk.search_vector,
+            websearch_to_tsquery('english', ${query}),
+            32
+          ) AS score
+        FROM repository_item_chunks chunk
+        JOIN repository_items item ON item.id = chunk.item_id
+        JOIN knowledge_repositories repository ON repository.id = item.repository_id
+        WHERE repository.id IN (${sql.join(
+          repositoryIds.map((repositoryId) => sql`${repositoryId}`),
+          sql`, `
+        )})
+          AND chunk.item_version_id IS NULL
+          AND chunk.index_generation_id IS NULL
+          AND chunk.modality IN (${sql.join(
+            modalities.map((modality) => sql`${modality}`),
+            sql`, `
+          )})
+          AND item.lifecycle_status = 'active'
+          AND item.processing_status = 'completed'
+          AND repository.lifecycle_status = 'active'
+          AND (repository.metadata->>'systemManaged') IS DISTINCT FROM 'true'
+          AND ${accessFilter(principal)}
+          AND chunk.search_vector @@ websearch_to_tsquery('english', ${query})
+          AND NOT EXISTS (
+            SELECT 1
+            FROM repository_item_chunks current_chunk
+            WHERE current_chunk.item_id = item.id
+              AND current_chunk.item_version_id IS NOT NULL
+              AND current_chunk.index_generation_id = repository.active_index_generation_id
+          )
+        ORDER BY score DESC, chunk.id
+        LIMIT ${limit}
+      `),
+    "retrievalV2.legacyCompatibilityCandidates"
+  );
+  return (rows as unknown as Array<Record<string, unknown>>).map(
+    mapLegacyCandidate
+  );
+}
+
 async function visualCandidates(
   snapshot: RetrievalGenerationSnapshot,
   principal: RetrievalPrincipal,
@@ -358,6 +487,19 @@ async function expandCandidate(
   principal: RetrievalPrincipal,
   neighborCount: number
 ): Promise<RetrievalContextSegment[]> {
+  if (candidate.versionNumber === 0) {
+    return [
+      {
+        chunkId: candidate.chunkId,
+        chunkIndex: candidate.chunkIndex,
+        content: candidate.content,
+        contextPrefix: candidate.contextPrefix,
+        modality: candidate.modality,
+        tokens: candidate.tokens,
+        citation: resolveRetrievalCitation(candidate),
+      },
+    ];
+  }
   const lower = Math.max(0, candidate.chunkIndex - neighborCount);
   const upper = candidate.chunkIndex + neighborCount;
   const rows = await executeQuery(
@@ -603,6 +745,14 @@ export async function retrieveRepositoryContent(
             )
           )
         ).flat();
+  const legacyCompatibility = await legacyCompatibilityCandidates(
+    authorizedIds,
+    principal,
+    query,
+    modalities,
+    candidateLimit
+  );
+  lexical.push(...legacyCompatibility);
 
   const visual: RetrievalCandidate[] = [];
   if (config.visualIndexEnabled && mode !== "keyword") {
@@ -720,7 +870,7 @@ export async function retrieveRepositoryContent(
     diagnostics: {
       durationMs: Date.now() - startedAt,
       repositoriesRequested: repositoryIds.length,
-      repositoriesAuthorized: snapshots.length,
+      repositoriesAuthorized: authorizedIds.length,
       denseCandidates: dense.length,
       lexicalCandidates: lexical.length,
       visualCandidates: visual.length,

--- a/tests/e2e/repository-upload-contract.functional.spec.ts
+++ b/tests/e2e/repository-upload-contract.functional.spec.ts
@@ -56,6 +56,32 @@ test.describe('Unified repository upload contract (authenticated)', () => {
     })
   })
 
+  test('adds inline text through the repository item workflow', async ({ page }) => {
+    const itemName = `E2E inline retrieval ${Date.now()}`
+
+    await page.goto('/repositories')
+    const repositoryRow = page
+      .getByRole('row')
+      .filter({ hasText: 'E2E Unified Content Repository' })
+    await repositoryRow.getByRole('button').first().click()
+    await expect(page).toHaveURL(/\/repositories\/\d+$/)
+
+    await page.getByRole('button', { name: /Add (Item|your first item)/i }).first().click()
+    const dialog = page.getByRole('dialog')
+    await dialog.getByRole('tab', { name: 'Text' }).click()
+    await dialog.getByLabel('Name').fill(itemName)
+    await dialog
+      .getByLabel('Content')
+      .fill('ORCHID-COMPASS-E2E uses the silver lighthouse protocol.')
+    await dialog.getByRole('button', { name: 'Add Text' }).click()
+
+    await expect(dialog).toBeHidden()
+    await expect(page.getByText(itemName, { exact: true })).toBeVisible()
+    await expect(
+      page.getByRole('row').filter({ hasText: itemName })
+    ).toContainText(/Processed|Completed/i)
+  })
+
   test('uploads and completes a canonical PDF without invoking the legacy action', async ({ page }) => {
     let initiation: Record<string, unknown> | null = null
     let completion: Record<string, unknown> | null = null

--- a/tests/smoke/unified-content-foundation.smoke.ts
+++ b/tests/smoke/unified-content-foundation.smoke.ts
@@ -30,6 +30,7 @@ import {
 import {
   extractPdfText,
   extractOfficeDocument,
+  extractCanonicalTextDocument,
   buildImageSearchDocument,
   DEFAULT_CONTENT_PLATFORM_CONFIG,
   completeRepositoryUpload,
@@ -325,6 +326,128 @@ try {
     canonicalOnly: true,
   });
   assert.equal(isolatedResults.length, 0);
+
+  const [legacyOnlyItem] = await executeQuery(
+    (db) =>
+      db
+        .insert(repositoryItems)
+        .values({
+          repositoryId: repository.id,
+          type: "text",
+          name: "Legacy compatibility smoke",
+          source: "text_input",
+          processingStatus: "completed",
+        })
+        .returning({ id: repositoryItems.id }),
+    "smoke.unifiedContent.createLegacyOnlyItem"
+  );
+  assert.ok(legacyOnlyItem);
+  await executeQuery(
+    (db) =>
+      db.insert(repositoryItemChunks).values({
+        itemId: legacyOnlyItem.id,
+        content:
+          "ORCHID-COMPASS-SMOKE uses the silver lighthouse protocol",
+        chunkIndex: 0,
+        metadata: { source: "text_input" },
+      }),
+    "smoke.unifiedContent.createLegacyOnlyChunk"
+  );
+  const compatibilityResults = await retrieveRepositoryContent({
+    query: "ORCHID-COMPASS-SMOKE",
+    repositoryIds: [repository.id],
+    userCognitoSub: "e2e-test-user",
+    mode: "keyword",
+    rerank: false,
+  });
+  assert.equal(compatibilityResults.results.length, 1);
+  assert.equal(compatibilityResults.results[0]?.itemId, legacyOnlyItem.id);
+  assert.equal(compatibilityResults.results[0]?.versionNumber, 0);
+  assert.equal(
+    compatibilityResults.results[0]?.citations[0]?.label,
+    "Legacy compatibility smoke"
+  );
+  await executeQuery(
+    (db) =>
+      db
+        .update(repositoryItemChunks)
+        .set({ accessScope: { userIds: [] } })
+        .where(eq(repositoryItemChunks.itemId, legacyOnlyItem.id)),
+    "smoke.unifiedContent.restrictLegacyCompatibilitySegment"
+  );
+  const deniedCompatibilityResults = await retrieveRepositoryContent({
+    query: "ORCHID-COMPASS-SMOKE",
+    repositoryIds: [repository.id],
+    userCognitoSub: "e2e-test-user",
+    mode: "keyword",
+    rerank: false,
+  });
+  assert.equal(deniedCompatibilityResults.results.length, 0);
+  await executeQuery(
+    (db) =>
+      db
+        .update(repositoryItemChunks)
+        .set({ accessScope: {} })
+        .where(eq(repositoryItemChunks.itemId, legacyOnlyItem.id)),
+    "smoke.unifiedContent.restoreLegacyCompatibilitySegment"
+  );
+
+  const [textItem] = await executeQuery(
+    (db) =>
+      db
+        .insert(repositoryItems)
+        .values({
+          repositoryId: repository.id,
+          type: "text",
+          name: "Canonical text smoke",
+          source: `repositories/${repository.id}/fixture/reference.txt`,
+          processingStatus: "pending",
+        })
+        .returning({ id: repositoryItems.id }),
+    "smoke.unifiedContent.createTextItem"
+  );
+  assert.ok(textItem);
+  const textRegistration = await registerCanonicalUpload({
+    itemId: textItem.id,
+    userId: owner.id,
+    objectKey: `repositories/${repository.id}/fixture/reference.txt`,
+    originalFileName: "reference.txt",
+    declaredContentType: "text/plain",
+    byteSize: 64,
+    traceId: "unified-content-text-smoke",
+  });
+  const textExtraction = extractCanonicalTextDocument(
+    Buffer.from("MOONLIT-HARBOR-SMOKE uses the indigo compass procedure."),
+    "text/plain",
+    "reference.txt"
+  );
+  const textPublication = await publishDocumentVersion({
+    itemVersionId: textRegistration.version.id,
+    processorVersion: textExtraction.processorVersion,
+    processorName: "aistudio-text",
+    detectedContentType: textExtraction.detectedContentType,
+    inspectionStatus: "clean",
+    malwareScanRequired: true,
+    canonicalText: textExtraction.canonicalText,
+    segments: textExtraction.segments,
+    artifactMetadata: textExtraction.metadata,
+  });
+  const canonicalTextResults = await retrieveRepositoryContent({
+    query: "MOONLIT-HARBOR-SMOKE",
+    repositoryIds: [repository.id],
+    userCognitoSub: "e2e-test-user",
+    mode: "keyword",
+    rerank: false,
+  });
+  assert.equal(canonicalTextResults.results.length, 1);
+  assert.equal(
+    canonicalTextResults.results[0]?.generationId,
+    textPublication.generationId
+  );
+  assert.equal(
+    canonicalTextResults.results[0]?.citations[0]?.label,
+    "reference.txt"
+  );
 
   const [officeItem] = await executeQuery(
     (db) =>

--- a/tests/unit/actions/repositories/repository-items-actions.test.ts
+++ b/tests/unit/actions/repositories/repository-items-actions.test.ts
@@ -18,6 +18,8 @@ const mockGetRepositoryItems = jest.fn<(...a: unknown[]) => Promise<unknown[]>>(
 const mockGetRepositoryItemById = jest.fn<(...a: unknown[]) => Promise<unknown>>()
 const mockCreateRepositoryItem = jest.fn<(...a: unknown[]) => Promise<unknown>>()
 const mockUpdateRepositoryItemStatus = jest.fn<(...a: unknown[]) => Promise<unknown>>()
+const mockUploadDocument = jest.fn<(...a: unknown[]) => Promise<unknown>>()
+const mockQueueFileForProcessing = jest.fn<(...a: unknown[]) => Promise<unknown>>()
 const mockRegisterCanonicalUploadIfEnabled = jest.fn<(...a: unknown[]) => Promise<unknown>>(
   () => Promise.resolve(null)
 )
@@ -28,6 +30,14 @@ const mockGetDocumentObjectMetadata = jest.fn<(...a: unknown[]) => Promise<unkno
 const mockGetDocumentSignedUrl = jest.fn<(...a: unknown[]) => Promise<string>>()
 const mockDeleteRepositoryItem = jest.fn<(...a: unknown[]) => Promise<number>>()
 const mockDeleteRepositoryItemStorage = jest.fn<(...a: unknown[]) => Promise<unknown>>()
+const mockRegisterCanonicalTextIfEnabled = jest.fn<
+  (...a: unknown[]) => Promise<unknown>
+>(() => Promise.resolve(null))
+const mockExecuteTransaction = jest.fn<
+  (...a: unknown[]) => Promise<unknown>
+>()
+const mockRepositoryItemsTable = { table: 'repository_items' }
+const mockRepositoryItemChunksTable = { table: 'repository_item_chunks' }
 
 jest.mock('@/lib/auth/server-session', () => ({ getServerSession: mockGetServerSession }))
 jest.mock('@/utils/roles', () => ({ hasCapabilityAccess: mockHasCapabilityAccess }))
@@ -55,17 +65,28 @@ jest.mock('@/lib/db/drizzle', () => ({
 }))
 jest.mock('@/lib/db/drizzle-client', () => ({
   executeQuery: jest.fn(() => Promise.resolve([])),
-  executeTransaction: jest.fn(),
-  repositoryItems: {}, repositoryItemChunks: {},
+  executeTransaction: mockExecuteTransaction,
+  repositoryItems: mockRepositoryItemsTable,
+  repositoryItemChunks: mockRepositoryItemChunksTable,
 }))
 jest.mock('@/lib/aws/s3-client', () => ({
-  uploadDocument: jest.fn(),
+  uploadDocument: mockUploadDocument,
   deleteDocument: jest.fn(),
   getDocumentObjectMetadata: mockGetDocumentObjectMetadata,
   getDocumentSignedUrl: mockGetDocumentSignedUrl,
 }))
-jest.mock('@/lib/services/file-processing-service', () => ({ queueFileForProcessing: jest.fn(), processUrl: jest.fn() }))
+jest.mock('@/lib/services/file-processing-service', () => ({
+  queueFileForProcessing: mockQueueFileForProcessing,
+  processUrl: jest.fn(),
+}))
 jest.mock('@/lib/repositories/content-platform', () => ({
+  isCanonicalUploadContentType: (contentType: string) => [
+    'application/pdf',
+    'text/plain',
+    'text/markdown',
+    'text/csv',
+  ].includes(contentType),
+  registerCanonicalTextIfEnabled: mockRegisterCanonicalTextIfEnabled,
   registerCanonicalUploadIfEnabled: mockRegisterCanonicalUploadIfEnabled,
   dispatchContentProcessingJob: mockDispatchContentProcessingJob,
   deleteRepositoryItemStorage: mockDeleteRepositoryItemStorage,
@@ -89,7 +110,14 @@ describe('repository-items.actions (REV-COR-061 / REV-SEC-062 / REV-COR-068)', (
     mockAssertItemRepositoryReadAccess.mockResolvedValue(undefined)
     mockAssertNotSystemManagedRepository.mockResolvedValue(undefined)
     mockRegisterCanonicalUploadIfEnabled.mockResolvedValue(null)
+    mockRegisterCanonicalTextIfEnabled.mockResolvedValue(null)
+    mockExecuteTransaction.mockReset()
     mockDispatchContentProcessingJob.mockResolvedValue(undefined)
+    mockUploadDocument.mockResolvedValue({
+      key: 'repositories/7/direct/document.pdf',
+      url: 's3://documents/repositories/7/direct/document.pdf',
+    })
+    mockQueueFileForProcessing.mockResolvedValue('legacy-job')
     mockGetDocumentObjectMetadata.mockResolvedValue({
       contentLength: 1,
       contentType: 'application/pdf',
@@ -177,6 +205,58 @@ describe('repository-items.actions (REV-COR-061 / REV-SEC-062 / REV-COR-068)', (
     })
   })
 
+  it('registers direct document uploads with the canonical pipeline', async () => {
+    mockCreateRepositoryItem.mockResolvedValue({
+      id: 4,
+      repositoryId: 7,
+      type: 'document',
+      name: 'Direct document',
+      source: 'repositories/7/direct/document.pdf',
+      metadata: {},
+      processingStatus: 'pending',
+      processingError: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    })
+    mockRegisterCanonicalUploadIfEnabled.mockResolvedValue({
+      created: true,
+      version: { id: 'aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee' },
+      inspectJob: { id: 'ffffffff-1111-4222-8333-444444444444' },
+    })
+
+    const result = await mod.addDocumentItem({
+      repository_id: 7,
+      name: 'Direct document',
+      file: {
+        content: Buffer.from('pdf-bytes'),
+        contentType: 'application/pdf',
+        size: 9,
+        fileName: 'document.pdf',
+      },
+    })
+
+    expect(result.isSuccess).toBe(true)
+    expect(mockRegisterCanonicalUploadIfEnabled).toHaveBeenCalledWith({
+      itemId: 4,
+      userId: 1,
+      objectKey: 'repositories/7/direct/document.pdf',
+      originalFileName: 'document.pdf',
+      declaredContentType: 'application/pdf',
+      byteSize: 9,
+      traceId: 't',
+    })
+    expect(mockDispatchContentProcessingJob).toHaveBeenCalledWith({
+      jobId: 'ffffffff-1111-4222-8333-444444444444',
+      itemVersionId: 'aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee',
+    })
+    expect(mockQueueFileForProcessing).toHaveBeenCalledWith(
+      4,
+      'repositories/7/direct/document.pdf',
+      'Direct document',
+      'application/pdf'
+    )
+  })
+
   it('keeps the legacy upload available when the canonical shadow write fails', async () => {
     mockCreateRepositoryItem.mockResolvedValue({
       id: 2, repositoryId: 7, type: 'document', name: 'doc', source: 'repositories/7/abc/doc.pdf',
@@ -192,6 +272,62 @@ describe('repository-items.actions (REV-COR-061 / REV-SEC-062 / REV-COR-068)', (
     })
 
     expect(res.isSuccess).toBe(true)
+  })
+
+  it('dispatches inline text through the canonical processing pipeline', async () => {
+    const itemValues = jest.fn(() => ({
+      returning: jest.fn(() => Promise.resolve([{ id: 37 }])),
+    }))
+    const chunkValues = jest.fn(() => Promise.resolve())
+    const insert = jest.fn((table: unknown) =>
+      table === mockRepositoryItemsTable
+        ? { values: itemValues }
+        : { values: chunkValues }
+    )
+    mockExecuteTransaction.mockImplementation(async (...args: unknown[]) => {
+      const operation = args[0]
+      if (typeof operation !== 'function') {
+        throw new Error('Expected a transaction callback')
+      }
+      return (operation as (tx: unknown) => Promise<unknown>)({ insert })
+    })
+    mockGetRepositoryItemById.mockResolvedValue({
+      id: 37,
+      repositoryId: 7,
+      type: 'text',
+      name: 'Live validation',
+      source: 'ORCHID-COMPASS-742',
+      metadata: {},
+      processingStatus: 'completed',
+      processingError: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    })
+    mockRegisterCanonicalTextIfEnabled.mockResolvedValue({
+      created: true,
+      version: { id: 'aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee' },
+      inspectJob: { id: 'ffffffff-1111-4222-8333-444444444444' },
+    })
+
+    const result = await mod.addTextItem({
+      repository_id: 7,
+      name: 'Live validation',
+      content: 'ORCHID-COMPASS-742',
+    })
+
+    expect(result.isSuccess).toBe(true)
+    expect(mockRegisterCanonicalTextIfEnabled).toHaveBeenCalledWith({
+      itemId: 37,
+      repositoryId: 7,
+      userId: 1,
+      name: 'Live validation',
+      content: 'ORCHID-COMPASS-742',
+      traceId: 't',
+    })
+    expect(mockDispatchContentProcessingJob).toHaveBeenCalledWith({
+      jobId: 'ffffffff-1111-4222-8333-444444444444',
+      itemVersionId: 'aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee',
+    })
   })
 
   it('rejects a presigned upload when the stored object size differs', async () => {

--- a/tests/unit/lib/repositories/content-platform-inline-text.test.ts
+++ b/tests/unit/lib/repositories/content-platform-inline-text.test.ts
@@ -1,0 +1,119 @@
+/** @jest-environment node */
+
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+
+const mockGetSettings = jest.fn<
+  () => Promise<Record<string, string | null | undefined>>
+>();
+const mockUploadRepositoryTextSource = jest.fn<
+  (input: Record<string, unknown>) => Promise<{ key: string; byteSize: number }>
+>();
+const mockRegisterCanonicalUpload = jest.fn<
+  (input: Record<string, unknown>) => Promise<unknown>
+>();
+
+jest.mock("@/lib/settings-manager", () => ({ getSettings: mockGetSettings }));
+jest.mock("@/lib/aws/s3-client", () => ({
+  uploadRepositoryTextSource: mockUploadRepositoryTextSource,
+}));
+jest.mock("@/lib/repositories/content-platform/ingestion-service", () => ({
+  registerCanonicalUpload: mockRegisterCanonicalUpload,
+}));
+
+describe("canonical inline-text ingestion", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetSettings.mockResolvedValue({});
+    mockUploadRepositoryTextSource.mockResolvedValue({
+      key: "repositories/7/inline/source.txt",
+      byteSize: 11,
+    });
+    mockRegisterCanonicalUpload.mockResolvedValue({
+      version: { id: "version-1" },
+      inspectJob: { id: "job-1" },
+      created: true,
+    });
+  });
+
+  it("leaves the legacy write untouched while dual-write is disabled", async () => {
+    const { registerCanonicalTextIfEnabled } = await import(
+      "@/lib/repositories/content-platform/inline-text-ingestion"
+    );
+
+    await expect(
+      registerCanonicalTextIfEnabled({
+        itemId: 3,
+        repositoryId: 7,
+        userId: 1,
+        name: "Quick reference",
+        content: "hello world",
+      })
+    ).resolves.toBeNull();
+    expect(mockUploadRepositoryTextSource).not.toHaveBeenCalled();
+    expect(mockRegisterCanonicalUpload).not.toHaveBeenCalled();
+  });
+
+  it("stores inline text in the repository namespace and registers an immutable version", async () => {
+    mockGetSettings.mockResolvedValue({
+      CONTENT_PLATFORM_ENABLED: "true",
+      CONTENT_DUAL_WRITE_ENABLED: "true",
+    });
+    const { registerCanonicalTextIfEnabled } = await import(
+      "@/lib/repositories/content-platform/inline-text-ingestion"
+    );
+
+    await expect(
+      registerCanonicalTextIfEnabled({
+        itemId: 3,
+        repositoryId: 7,
+        userId: 1,
+        name: "Quick/reference notes",
+        content: "hello world",
+        traceId: "trace-1",
+      })
+    ).resolves.toEqual(expect.objectContaining({ created: true }));
+
+    expect(mockUploadRepositoryTextSource).toHaveBeenCalledWith({
+      itemId: 3,
+      repositoryId: 7,
+      userId: 1,
+      fileName: "Quick_reference_notes.txt",
+      content: "hello world",
+    });
+    expect(mockRegisterCanonicalUpload).toHaveBeenCalledWith({
+      itemId: 3,
+      userId: 1,
+      objectKey: "repositories/7/inline/source.txt",
+      originalFileName: "Quick_reference_notes.txt",
+      declaredContentType: "text/plain",
+      byteSize: 11,
+      sha256:
+        "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9",
+      traceId: "trace-1",
+    });
+  });
+
+  it("rejects inline text above the configured in-memory processing limit before upload", async () => {
+    mockGetSettings.mockResolvedValue({
+      CONTENT_PLATFORM_ENABLED: "true",
+      CONTENT_DUAL_WRITE_ENABLED: "true",
+      CONTENT_MAX_FILE_SIZE_GB: "1",
+      CONTENT_MAX_OFFICE_SIZE_MB: "1",
+    });
+    const { registerCanonicalTextIfEnabled } = await import(
+      "@/lib/repositories/content-platform/inline-text-ingestion"
+    );
+
+    await expect(
+      registerCanonicalTextIfEnabled({
+        itemId: 3,
+        repositoryId: 7,
+        userId: 1,
+        name: "Oversized notes",
+        content: "x".repeat(1024 ** 2 + 1),
+      })
+    ).rejects.toThrow("Text content must not exceed 1 MiB");
+    expect(mockUploadRepositoryTextSource).not.toHaveBeenCalled();
+    expect(mockRegisterCanonicalUpload).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/lib/repositories/content-platform-text-processing.test.ts
+++ b/tests/unit/lib/repositories/content-platform-text-processing.test.ts
@@ -1,0 +1,60 @@
+/** @jest-environment node */
+
+import {
+  extractCanonicalTextDocument,
+  isCanonicalTextContentType,
+  TEXT_PROCESSOR_VERSION,
+} from "@/lib/repositories/content-platform/text-processing";
+
+describe("canonical text processing", () => {
+  it("normalizes UTF-8 text into tokenizer-aware cited segments", () => {
+    const extracted = extractCanonicalTextDocument(
+      Buffer.from("Emergency protocol\r\n\r\nUse the silver lighthouse."),
+      "text/plain",
+      "quick-reference.txt"
+    );
+
+    expect(extracted.processorVersion).toBe(TEXT_PROCESSOR_VERSION);
+    expect(extracted.canonicalText).toBe(
+      "Emergency protocol\n\nUse the silver lighthouse."
+    );
+    expect(extracted.segments).toHaveLength(1);
+    expect(extracted.segments[0]).toMatchObject({
+      chunkIndex: 0,
+      sourceLocator: { headingPath: ["quick-reference.txt"] },
+      contextPrefix: "quick-reference.txt",
+      segmentLevel: "section",
+    });
+    expect(extracted.segments[0]?.contentHash).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it("preserves Markdown headings as exact source labels", () => {
+    const extracted = extractCanonicalTextDocument(
+      Buffer.from("# Safety\nUse exit A.\n\n## Contacts\nCall extension 4100."),
+      "text/markdown",
+      "handbook.md"
+    );
+
+    expect(extracted.segments.map((segment) => segment.sourceLocator)).toEqual([
+      { headingPath: ["handbook.md", "Safety"] },
+      { headingPath: ["handbook.md", "Contacts"] },
+    ]);
+    expect(extracted.metadata).toMatchObject({ encoding: "utf-8", lines: 5 });
+  });
+
+  it("accepts the canonical text allowlist and rejects binary or invalid UTF-8", () => {
+    expect(isCanonicalTextContentType("text/plain")).toBe(true);
+    expect(isCanonicalTextContentType("text/markdown")).toBe(true);
+    expect(isCanonicalTextContentType("text/csv")).toBe(true);
+    expect(isCanonicalTextContentType("application/zip")).toBe(false);
+    expect(() =>
+      extractCanonicalTextDocument(
+        Uint8Array.from([0xff, 0xfe, 0xfd]),
+        "text/plain"
+      )
+    ).toThrow("not valid UTF-8");
+    expect(() =>
+      extractCanonicalTextDocument(Buffer.from("safe\0binary"), "text/plain")
+    ).toThrow("binary null bytes");
+  });
+});

--- a/tests/unit/lib/repositories/content-platform-upload.test.ts
+++ b/tests/unit/lib/repositories/content-platform-upload.test.ts
@@ -120,11 +120,11 @@ describe("canonical repository upload initiation", () => {
 
     await expect(
       initiateRepositoryUpload(
-        { ...baseInput, contentType: "text/plain" },
+        { ...baseInput, contentType: "application/zip" },
         DEFAULT_CONTENT_PLATFORM_CONFIG,
         storage
       )
-    ).rejects.toThrow("PDF, Office, image, audio, and video files only");
+    ).rejects.toThrow("PDF, Office, text, image, audio, and video files only");
     await expect(
       initiateRepositoryUpload(
         { ...baseInput, byteSize: 500 * 1024 ** 2 + 1 },
@@ -134,6 +134,39 @@ describe("canonical repository upload initiation", () => {
     ).rejects.toThrow("500 MiB");
     expect(storage.createSingleUpload).not.toHaveBeenCalled();
     expect(storage.createMultipartUpload).not.toHaveBeenCalled();
+  });
+
+  it("accepts UTF-8 text formats using the bounded in-memory processor limit", async () => {
+    const storage = createStorage();
+
+    await expect(
+      initiateRepositoryUpload(
+        {
+          ...baseInput,
+          itemName: "Quick reference",
+          fileName: "quick-reference.txt",
+          contentType: "text/plain",
+          byteSize: 1024,
+        },
+        DEFAULT_CONTENT_PLATFORM_CONFIG,
+        storage
+      )
+    ).resolves.toMatchObject({ uploadMethod: "single" });
+    expect(storage.createSingleUpload).toHaveBeenCalledWith(
+      expect.objectContaining({ contentType: "text/plain" })
+    );
+    await expect(
+      initiateRepositoryUpload(
+        {
+          ...baseInput,
+          fileName: "oversized.csv",
+          contentType: "text/csv",
+          byteSize: 100 * 1024 ** 2 + 1,
+        },
+        DEFAULT_CONTENT_PLATFORM_CONFIG,
+        storage
+      )
+    ).rejects.toThrow("100 MiB");
   });
 
   it("accepts Office documents and enforces their independent size limit", async () => {

--- a/tests/unit/lib/repositories/retrieval-v2-service.test.ts
+++ b/tests/unit/lib/repositories/retrieval-v2-service.test.ts
@@ -94,6 +94,7 @@ describe("shared repository retrieval v2 service", () => {
       ])
       .mockResolvedValueOnce([row(1, 0.9, 0)])
       .mockResolvedValueOnce([row(1, 0.7, 0), row(2, 0.6, 1)])
+      .mockResolvedValueOnce([])
       .mockResolvedValueOnce([row(1, 0, 0)]);
 
     const response = await retrieveRepositoryContent(
@@ -172,6 +173,7 @@ describe("shared repository retrieval v2 service", () => {
         },
       ])
       .mockResolvedValueOnce([row(1, 0.8, 0), row(2, 0.7, 1)])
+      .mockResolvedValueOnce([])
       .mockResolvedValueOnce([row(1, 0, 0)])
       .mockResolvedValueOnce([row(2, 0, 1)]);
 
@@ -209,6 +211,7 @@ describe("shared repository retrieval v2 service", () => {
         },
       ])
       .mockResolvedValueOnce([row(1, 0.8, 0)])
+      .mockResolvedValueOnce([])
       .mockResolvedValueOnce([
         {
           ...row(1, 0, 0),
@@ -259,6 +262,7 @@ describe("shared repository retrieval v2 service", () => {
           visual_embedding_dimensions: 1536,
         },
       ])
+      .mockResolvedValueOnce([])
       .mockResolvedValueOnce([imageRow])
       .mockResolvedValueOnce([imageRow]);
 
@@ -285,5 +289,56 @@ describe("shared repository retrieval v2 service", () => {
       citations: [{ label: "Image region" }],
     });
     expect(response.diagnostics.visualCandidates).toBe(1);
+  });
+
+  it("keeps legacy-only chunks visible until their canonical item is published", async () => {
+    mockExecuteQuery
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([
+        {
+          chunk_id: 91,
+          repository_id: 7,
+          repository_name: "District Policies",
+          item_id: 37,
+          item_stable_id: "44444444-5555-4666-8777-888888888888",
+          item_name: "Live validation",
+          content: "ORCHID-COMPASS-742 uses the silver lighthouse protocol",
+          chunk_index: 0,
+          modality: "text",
+          source_locator: {},
+          tokens: 10,
+          metadata: { source: "text_input" },
+          score: 0.83,
+        },
+      ]);
+
+    const response = await retrieveRepositoryContent({
+      query: "ORCHID-COMPASS-742",
+      repositoryIds: [7],
+      userCognitoSub: "user-sub",
+      mode: "keyword",
+      limit: 1,
+    });
+
+    expect(response.results).toHaveLength(1);
+    expect(response.results[0]).toMatchObject({
+      chunkId: 91,
+      generationId: "legacy:7",
+      itemVersionId: "legacy:37",
+      versionNumber: 0,
+      citations: [
+        {
+          itemName: "Live validation",
+          label: "Live validation",
+        },
+      ],
+      metadata: { retrievalCompatibility: "legacy-v1" },
+    });
+    expect(response.diagnostics).toMatchObject({
+      repositoriesAuthorized: 1,
+      lexicalCandidates: 1,
+      returnedResults: 1,
+    });
   });
 });

--- a/tests/unit/lib/s3-client.test.ts
+++ b/tests/unit/lib/s3-client.test.ts
@@ -1,5 +1,6 @@
 import { 
   uploadDocument, 
+  uploadRepositoryTextSource,
   getDocumentSignedUrl, 
   deleteDocument,
   deleteRepositoryObjectsByPrefix,
@@ -123,6 +124,30 @@ describe('S3 Client', () => {
       await uploadDocument(params);
 
       // Just verify the upload succeeded and the right command was called
+      expect(mockS3Client.send).toHaveBeenCalledWith(
+        expect.any(PutObjectCommand)
+      );
+    });
+  });
+
+  describe('uploadRepositoryTextSource', () => {
+    it('stores inline text under the canonical repository namespace', async () => {
+      mockS3Client.send.mockResolvedValue({});
+
+      const result = await uploadRepositoryTextSource({
+        repositoryId: 7,
+        itemId: 37,
+        userId: 1,
+        fileName: 'Quick_reference.txt',
+        content: 'hello world',
+      });
+
+      expect(result).toEqual({
+        key: expect.stringMatching(
+          /^repositories\/7\/inline\/[0-9a-f-]{36}\/Quick_reference\.txt$/
+        ),
+        byteSize: 11,
+      });
       expect(mockS3Client.send).toHaveBeenCalledWith(
         expect.any(PutObjectCommand)
       );


### PR DESCRIPTION
## Summary

- keep authorized legacy-only repository chunks searchable during canonical backfill, suppressing them once the item enters the active generation
- enforce repository and per-segment ACLs on the compatibility path
- canonicalize inline text and supported legacy uploads through immutable S3 versions and the unified worker
- add structured UTF-8 text/Markdown/CSV extraction, tokenizer-aware segments, exact citations, diagnostics, and accessible legacy citation labeling

## Live root cause

The first dev cutover showed that pre-cutover URL/text chunks had no item version or index generation, so the v2-only query could not see them. Inline text creation also still wrote only legacy rows. This change closes both gaps without turning off Retrieval v2.

## Verification

- application CI suite: 270 suites passed; 3,070 tests passed; 5 suites / 60 tests intentionally skipped
- infrastructure suite: 33 suites / 348 tests passed
- focused final unit suite: 4 suites / 25 tests passed
- real PostgreSQL unified-content smoke passed, including legacy compatibility, segment ACL denial, canonical inline text, citations, generation activation, and cleanup
- full Playwright: 248 passed / 58 environment-gated skipped / zero genuine failures; one unrelated Atrium editor test passed on retry 2 and was reported flaky
- lint: zero errors
- root, unified-worker, and infrastructure typechecks/builds passed
- production Next.js build passed
- all-stack no-lookup CDK synthesis passed

## Rollout

After merge, deploy all stacks once. Then verify the existing ORCHID-COMPASS-742 marker is searchable and create one new inline text item to confirm canonical version, job, generation, embedding, and citation state.