### PR TITLE
fix(content): make unified processing lifecycle resilient

### DIFF
--- a/actions/repositories/repository-items.actions.ts
+++ b/actions/repositories/repository-items.actions.ts
@@ -30,6 +30,7 @@ import {
 } from "@/lib/logger"
 import { revalidatePath } from "next/cache"
 import {
+  copyRepositorySourceToCanonicalNamespace,
   uploadDocument,
   getDocumentObjectMetadata,
   getDocumentSignedUrl,
@@ -40,9 +41,12 @@ import { toContentDispositionValue } from "@/lib/repositories/content-dispositio
 import {
   deleteRepositoryItemStorage,
   dispatchContentProcessingJob,
+  getCanonicalRepositoryItemStatuses,
   isCanonicalUploadContentType,
+  isRepositorySourceObjectKey,
   registerCanonicalTextIfEnabled,
   registerCanonicalUploadIfEnabled,
+  retryCanonicalRepositoryItem,
 } from "@/lib/repositories/content-platform"
 
 // Runtime-validated processing-status union (REV-COR-068): actions are network
@@ -53,15 +57,24 @@ function isProcessingStatus(s: string): s is ProcessingStatus {
   return (VALID_PROCESSING_STATUSES as readonly string[]).includes(s)
 }
 
+type RepositoryItemType =
+  | 'document'
+  | 'image'
+  | 'audio'
+  | 'video'
+  | 'url'
+  | 'text'
+
 export interface RepositoryItem {
   id: number
   repositoryId: number
-  type: 'document' | 'image' | 'url' | 'text'
+  type: RepositoryItemType
   name: string
   source: string
   metadata: Record<string, unknown>
   processingStatus: string
   processingError: string | null
+  canRetry?: boolean
   createdAt: Date
   updatedAt: Date
 }
@@ -132,6 +145,7 @@ async function shadowWriteCanonicalText(
       processingJobId: canonical.inspectJob.id,
       created: canonical.created,
     })
+    await updateRepositoryItemStatus(input.itemId, "pending", null)
     try {
       await dispatchContentProcessingJob({
         jobId: canonical.inspectJob.id,
@@ -147,6 +161,16 @@ async function shadowWriteCanonicalText(
       })
     }
   } catch (error) {
+    await updateRepositoryItemStatus(
+      input.itemId,
+      "failed",
+      "Canonical content registration failed. Retry this item."
+    ).catch((statusError) => {
+      log.error("Failed to expose canonical inline text registration failure", {
+        itemId: input.itemId,
+        error: statusError instanceof Error ? statusError.message : "Unknown error",
+      })
+    })
     log.error("Canonical inline text shadow write failed", {
       itemId: input.itemId,
       error: error instanceof Error ? error.message : "Unknown error",
@@ -177,6 +201,7 @@ async function shadowWriteCanonicalUpload(
       processingJobId: canonical.inspectJob.id,
       created: canonical.created,
     })
+    await updateRepositoryItemStatus(input.itemId, "pending", null)
     try {
       await dispatchContentProcessingJob({
         jobId: canonical.inspectJob.id,
@@ -192,6 +217,16 @@ async function shadowWriteCanonicalUpload(
       })
     }
   } catch (error) {
+    await updateRepositoryItemStatus(
+      input.itemId,
+      "failed",
+      "Canonical content registration failed. Retry this item."
+    ).catch((statusError) => {
+      log.error("Failed to expose canonical repository registration failure", {
+        itemId: input.itemId,
+        error: statusError instanceof Error ? statusError.message : "Unknown error",
+      })
+    })
     log.error("Canonical repository shadow write failed", {
       itemId: input.itemId,
       error: error instanceof Error ? error.message : "Unknown error",
@@ -202,11 +237,12 @@ async function shadowWriteCanonicalUpload(
 // Sanitize filename to prevent directory traversal and other security issues
 function sanitizeFilename(filename: string): string {
   // Remove any directory components and special characters
-  return filename
+  const sanitized = filename
     .replace(/[^\d.A-Za-z-]/g, '_') // Replace special chars with underscore
     .replace(/\.{2,}/g, '.') // Replace multiple dots with single dot
     .replace(/^\.+|\.+$/g, '') // Remove leading/trailing dots
     .slice(0, 255); // Limit length
+  return sanitized || "file"
 }
 
 // Raw repository item row shape returned by the Drizzle accessors
@@ -217,12 +253,13 @@ function mapToRepositoryItem(itemRaw: RawRepositoryItem): RepositoryItem {
   return {
     id: itemRaw.id,
     repositoryId: itemRaw.repositoryId,
-    type: itemRaw.type as 'document' | 'image' | 'url' | 'text',
+    type: itemRaw.type as RepositoryItemType,
     name: itemRaw.name,
     source: itemRaw.source,
     metadata: itemRaw.metadata ?? {},
     processingStatus: itemRaw.processingStatus ?? 'pending',
     processingError: itemRaw.processingError,
+    canRetry: false,
     createdAt: itemRaw.createdAt ?? new Date(),
     updatedAt: itemRaw.updatedAt ?? new Date()
   }
@@ -366,6 +403,7 @@ export async function addDocumentItem(
     
     const { key, url } = await uploadDocument({
       userId: userId.toString(),
+      repositoryId: input.repository_id,
       fileName: sanitizedFilename,
       fileContent,
       contentType: input.file.contentType,
@@ -514,8 +552,7 @@ export async function addDocumentWithPresignedUrl(
     // legitimate upload flow (generateUploadUrl) only ever mints keys under
     // repositories/${repositoryId}/. Reject any other key so a user cannot register
     // an arbitrary documents-bucket object onto their repo and presign-download it.
-    const expectedKeyPrefix = `repositories/${input.repository_id}/`
-    if (!input.s3Key.startsWith(expectedKeyPrefix)) {
+    if (!isRepositorySourceObjectKey(input.repository_id, input.s3Key)) {
       log.warn("Presigned upload denied - s3Key outside repository namespace", {
         userId,
         repositoryId: input.repository_id
@@ -574,12 +611,13 @@ export async function addDocumentWithPresignedUrl(
     const item: RepositoryItem = {
       id: itemRaw.id,
       repositoryId: itemRaw.repositoryId,
-      type: itemRaw.type as 'document' | 'image' | 'url' | 'text',
+      type: itemRaw.type as RepositoryItemType,
       name: itemRaw.name,
       source: itemRaw.source,
       metadata: itemRaw.metadata ?? {},
       processingStatus: itemRaw.processingStatus ?? 'pending',
       processingError: itemRaw.processingError,
+      canRetry: false,
       createdAt: itemRaw.createdAt ?? new Date(),
       updatedAt: itemRaw.updatedAt ?? new Date()
     }
@@ -733,12 +771,13 @@ export async function addUrlItem(
     const item: RepositoryItem = {
       id: itemRaw.id,
       repositoryId: itemRaw.repositoryId,
-      type: itemRaw.type as 'document' | 'image' | 'url' | 'text',
+      type: itemRaw.type as RepositoryItemType,
       name: itemRaw.name,
       source: itemRaw.source,
       metadata: itemRaw.metadata ?? {},
       processingStatus: itemRaw.processingStatus ?? 'pending',
       processingError: itemRaw.processingError,
+      canRetry: false,
       createdAt: itemRaw.createdAt ?? new Date(),
       updatedAt: itemRaw.updatedAt ?? new Date()
     }
@@ -910,12 +949,13 @@ export async function addTextItem(
     const item: RepositoryItem = {
       id: itemRaw.id,
       repositoryId: itemRaw.repositoryId,
-      type: itemRaw.type as 'document' | 'image' | 'url' | 'text',
+      type: itemRaw.type as RepositoryItemType,
       name: itemRaw.name,
       source: itemRaw.source,
       metadata: itemRaw.metadata ?? {},
       processingStatus: itemRaw.processingStatus ?? 'pending',
       processingError: itemRaw.processingError,
+      canRetry: false,
       createdAt: itemRaw.createdAt ?? new Date(),
       updatedAt: itemRaw.updatedAt ?? new Date()
     }
@@ -987,12 +1027,13 @@ export async function removeRepositoryItem(
     const item: RepositoryItem = {
       id: itemRaw.id,
       repositoryId: itemRaw.repositoryId,
-      type: itemRaw.type as 'document' | 'image' | 'url' | 'text',
+      type: itemRaw.type as RepositoryItemType,
       name: itemRaw.name,
       source: itemRaw.source,
       metadata: itemRaw.metadata ?? {},
       processingStatus: itemRaw.processingStatus ?? 'pending',
       processingError: itemRaw.processingError,
+      canRetry: false,
       createdAt: itemRaw.createdAt ?? new Date(),
       updatedAt: itemRaw.updatedAt ?? new Date()
     }
@@ -1009,25 +1050,16 @@ export async function removeRepositoryItem(
       throw ErrorFactories.authzOwnerRequired("remove items from repository")
     }
 
-    // Delete stored source and canonical derivatives before cascading DB rows.
-    if (item.type === 'document' || item.type === 'image') {
-      log.info("Deleting repository item objects from S3", {
-        itemId,
-        s3Key: item.source
-      })
-      
-      try {
-        const cleanup = await deleteRepositoryItemStorage(item)
-        log.info("Repository item objects deleted from S3 successfully", cleanup)
-      } catch (error) {
-        // Log error but continue with database deletion
-        log.error("Failed to delete from S3", {
-          itemId,
-          s3Key: item.source,
-          error: error instanceof Error ? error.message : "Unknown error"
-        })
-      }
-    }
+    // Clean every item type before cascading its version rows. The cleanup
+    // service distinguishes stored S3 sources from inline text/URLs and always
+    // removes canonical version artifacts. If cleanup fails, preserve the DB
+    // rows so the operation can be retried without losing the object manifest.
+    log.info("Deleting repository item objects from S3", {
+      itemId,
+      s3Key: item.source
+    })
+    const cleanup = await deleteRepositoryItemStorage(item)
+    log.info("Repository item objects deleted from S3 successfully", cleanup)
 
     // Delete from database via Drizzle (cascades to chunks)
     log.info("Deleting item from database", { itemId })
@@ -1093,21 +1125,32 @@ export async function listRepositoryItems(
 
     // Fetch repository items via Drizzle
     log.debug("Fetching repository items from database", { repositoryId })
-    const itemsRaw = await getRepositoryItems(repositoryId)
+    const [itemsRaw, canonicalStatuses] = await Promise.all([
+      getRepositoryItems(repositoryId),
+      getCanonicalRepositoryItemStatuses(repositoryId),
+    ])
 
     // Convert to action type
-    const items: RepositoryItem[] = itemsRaw.map(item => ({
-      id: item.id,
-      repositoryId: item.repositoryId,
-      type: item.type as 'document' | 'image' | 'url' | 'text',
-      name: item.name,
-      source: item.source,
-      metadata: item.metadata ?? {},
-      processingStatus: item.processingStatus ?? 'pending',
-      processingError: item.processingError,
-      createdAt: item.createdAt ?? new Date(),
-      updatedAt: item.updatedAt ?? new Date()
-    }))
+    const items: RepositoryItem[] = itemsRaw.map(item => {
+      const canonical = canonicalStatuses.get(item.id)
+      return {
+        id: item.id,
+        repositoryId: item.repositoryId,
+        type: item.type as RepositoryItemType,
+        name: item.name,
+        source: item.source,
+        metadata: item.metadata ?? {},
+        processingStatus:
+          canonical?.processingStatus ?? item.processingStatus ?? 'pending',
+        processingError: canonical?.processingError ?? item.processingError,
+        canRetry:
+          canonical?.canRetry ??
+          (item.processingStatus === "failed" &&
+            item.processingError?.startsWith("Canonical content registration failed") === true),
+        createdAt: item.createdAt ?? new Date(),
+        updatedAt: item.updatedAt ?? new Date()
+      }
+    })
 
     log.info("Repository items fetched successfully", {
       repositoryId,
@@ -1125,6 +1168,144 @@ export async function listRepositoryItems(
       requestId,
       operation: "listRepositoryItems",
       metadata: { repositoryId }
+    })
+  }
+}
+
+interface RepositoryItemRetryTarget {
+  itemVersionId: string
+  processingJobId: string
+}
+
+async function prepareRepositoryItemRetry(
+  item: RawRepositoryItem,
+  userId: number,
+  requestId: string
+): Promise<RepositoryItemRetryTarget> {
+  if (item.type === "text") {
+    const canonical = await registerCanonicalTextIfEnabled({
+      itemId: item.id,
+      repositoryId: item.repositoryId,
+      userId,
+      name: item.name,
+      content: item.source,
+      traceId: requestId,
+    })
+    if (!canonical) {
+      throw ErrorFactories.sysConfigurationError(
+        "Canonical content processing is disabled"
+      )
+    }
+    return {
+      itemVersionId: canonical.version.id,
+      processingJobId: canonical.inspectJob.id,
+    }
+  }
+
+  if (
+    item.currentVersionId &&
+    isRepositorySourceObjectKey(item.repositoryId, item.source)
+  ) {
+    return retryCanonicalRepositoryItem(item.id, requestId)
+  }
+
+  if (!["document", "image", "audio", "video"].includes(item.type)) {
+    throw ErrorFactories.invalidInput(
+      "item.type",
+      item.type,
+      "Only stored files and inline text can be reprocessed"
+    )
+  }
+
+  const metadata = item.metadata ?? {}
+  const originalFileName =
+    typeof metadata.originalFileName === "string"
+      ? metadata.originalFileName
+      : item.name
+  const copied = await copyRepositorySourceToCanonicalNamespace({
+    repositoryId: item.repositoryId,
+    sourceKey: item.source,
+    fileName: originalFileName,
+  })
+  const copiedMetadata = await getDocumentObjectMetadata(copied.key)
+  const declaredContentType =
+    copiedMetadata.contentType ??
+    (typeof metadata.contentType === "string" ? metadata.contentType : null)
+  if (!declaredContentType || copiedMetadata.contentLength <= 0) {
+    throw ErrorFactories.invalidInput(
+      "storedSourceMetadata",
+      copiedMetadata,
+      "A positive content length and content type are required"
+    )
+  }
+  const canonical = await registerCanonicalUploadIfEnabled({
+    itemId: item.id,
+    userId,
+    objectKey: copied.key,
+    originalFileName,
+    declaredContentType,
+    byteSize: copiedMetadata.contentLength,
+    traceId: requestId,
+  })
+  if (!canonical) {
+    throw ErrorFactories.sysConfigurationError(
+      "Canonical content processing is disabled"
+    )
+  }
+  return {
+    itemVersionId: canonical.version.id,
+    processingJobId: canonical.inspectJob.id,
+  }
+}
+
+export async function retryRepositoryItemProcessing(
+  itemId: number
+): Promise<ActionState<void>> {
+  const requestId = generateRequestId()
+  const timer = startTimer("retryRepositoryItemProcessing")
+  const log = createLogger({ requestId, action: "retryRepositoryItemProcessing" })
+
+  try {
+    const session = await getServerSession()
+    if (!session) throw ErrorFactories.authNoSession()
+    if (!(await hasCapabilityAccess("knowledge-repositories"))) {
+      throw ErrorFactories.authzToolAccessDenied("knowledge-repositories")
+    }
+
+    const item = await getRepositoryItemById(itemId)
+    if (!item) throw ErrorFactories.dbRecordNotFound("repository_items", itemId)
+    await assertNotSystemManagedRepository(item.repositoryId)
+    const userId = await getUserIdFromSession(session.sub)
+    if (!(await canModifyRepository(item.repositoryId, userId))) {
+      throw ErrorFactories.authzOwnerRequired("retry repository processing")
+    }
+
+    const retry = await prepareRepositoryItemRetry(item, userId, requestId)
+    try {
+      await dispatchContentProcessingJob({
+        jobId: retry.processingJobId,
+        itemVersionId: retry.itemVersionId,
+      })
+    } catch (dispatchError) {
+      // The durable pending job remains eligible for scheduled dispatch.
+      log.warn("Retried content is pending scheduled dispatch", {
+        itemId,
+        processingJobId: retry.processingJobId,
+        error:
+          dispatchError instanceof Error ? dispatchError.message : "Unknown error",
+      })
+    }
+
+    revalidatePath(`/repositories/${item.repositoryId}`)
+    timer({ status: "success", itemId })
+    return createSuccess(undefined as void, "Content processing restarted")
+  } catch (error) {
+    timer({ status: "error", itemId })
+    return handleError(error, "Failed to retry content processing.", {
+      context: "retryRepositoryItemProcessing",
+      requestId,
+      operation: "retryRepositoryItemProcessing",
+      metadata: { itemId },
     })
   }
 }
@@ -1188,12 +1369,13 @@ export async function searchRepositoryItems(
     const items: RepositoryItem[] = itemsRaw.map(item => ({
       id: item.id,
       repositoryId: item.repositoryId,
-      type: item.type as 'document' | 'image' | 'url' | 'text',
+      type: item.type as RepositoryItemType,
       name: item.name,
       source: item.source,
       metadata: item.metadata ?? {},
       processingStatus: item.processingStatus ?? 'pending',
       processingError: item.processingError,
+      canRetry: false,
       createdAt: item.createdAt ?? new Date(),
       updatedAt: item.updatedAt ?? new Date()
     }))
@@ -1465,7 +1647,12 @@ export async function getDocumentDownloadUrl(
     // Convert to action type
     const item: RepositoryItem = mapToRepositoryItem(itemRaw)
 
-    if (item.type !== 'document' && item.type !== 'image') {
+    if (
+      item.type !== 'document' &&
+      item.type !== 'image' &&
+      item.type !== 'audio' &&
+      item.type !== 'video'
+    ) {
       log.warn("Download URL requested for non-file item", {
         itemId,
         itemType: item.type

--- a/components/features/repositories/repository-item-list.tsx
+++ b/components/features/repositories/repository-item-list.tsx
@@ -6,6 +6,7 @@ import {
   listRepositoryItems,
   removeRepositoryItem,
   getDocumentDownloadUrl,
+  retryRepositoryItemProcessing,
 } from "@/actions/repositories/repository-items.actions"
 import { Button } from "@/components/ui/button"
 import {
@@ -37,7 +38,10 @@ import { Badge } from "@/components/ui/badge"
 import { useAction } from "@/lib/hooks/use-action"
 import {
   FileText,
+  Image as ImageIcon,
   Link,
+  Music,
+  RefreshCw,
   Type,
   Trash2,
   Loader2,
@@ -46,6 +50,7 @@ import {
   AlertCircle,
   CheckCircle,
   Clock,
+  Video,
 } from "lucide-react"
 import { format } from "date-fns"
 import { useToast } from "@/components/ui/use-toast"
@@ -68,6 +73,10 @@ export function RepositoryItemList({
   const { execute: executeRemove, isPending: isRemoving } = useAction(
     removeRepositoryItem
   )
+  const { execute: executeRetry, isPending: isRetrying } = useAction(
+    retryRepositoryItemProcessing
+  )
+  const [retryingItemId, setRetryingItemId] = useState<number | null>(null)
   const [refreshTrigger, setRefreshTrigger] = useState(0)
 
   useEffect(() => {
@@ -87,6 +96,7 @@ export function RepositoryItemList({
     const hasPendingItems = items.some(item => 
       item.processingStatus === 'pending' || 
       item.processingStatus === 'processing' ||
+      item.processingStatus === 'retrying' ||
       item.processingStatus === 'processing_embeddings' ||
       item.processingStatus === 'processing_ocr'
     )
@@ -121,7 +131,7 @@ export function RepositoryItemList({
   }
 
   async function handleDownload(item: RepositoryItem) {
-    if (item.type !== "document") return
+    if (!["document", "image", "audio", "video"].includes(item.type)) return
 
     const result = await getDocumentDownloadUrl(item.id)
     if (result.isSuccess && result.data) {
@@ -136,10 +146,35 @@ export function RepositoryItemList({
     }
   }
 
+  async function handleRetry(item: RepositoryItem) {
+    setRetryingItemId(item.id)
+    const result = await executeRetry(item.id)
+    if (result.isSuccess) {
+      toast({
+        title: "Processing restarted",
+        description: `${item.name} has been queued again.`,
+      })
+      setRefreshTrigger(prev => prev + 1)
+    } else {
+      toast({
+        title: "Retry failed",
+        description: result.message || "Failed to restart content processing",
+        variant: "destructive",
+      })
+    }
+    setRetryingItemId(null)
+  }
+
   function getItemIcon(type: string) {
     switch (type) {
       case "document":
         return <FileText className="h-4 w-4" />
+      case "image":
+        return <ImageIcon className="h-4 w-4" />
+      case "audio":
+        return <Music className="h-4 w-4" />
+      case "video":
+        return <Video className="h-4 w-4" />
       case "url":
         return <Link className="h-4 w-4" />
       case "text":
@@ -170,6 +205,13 @@ export function RepositoryItemList({
           <Badge variant="secondary" className="gap-1">
             <Clock className="h-3 w-3" />
             Processing
+          </Badge>
+        )
+      case "retrying":
+        return (
+          <Badge variant="secondary" className="gap-1">
+            <RefreshCw className="h-3 w-3" />
+            Retrying
           </Badge>
         )
       case "processing_embeddings":
@@ -279,13 +321,29 @@ export function RepositoryItemList({
                     </TableCell>
                     <TableCell className="text-right">
                       <div className="flex justify-end gap-2">
-                        {item.type === "document" && (
+                        {["document", "image", "audio", "video"].includes(item.type) && (
                           <Button
                             variant="ghost"
                             size="sm"
                             onClick={() => handleDownload(item)}
+                            aria-label={`Download ${item.name}`}
                           >
                             <Download className="h-4 w-4" />
+                          </Button>
+                        )}
+                        {item.canRetry && (
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            onClick={() => handleRetry(item)}
+                            disabled={isRetrying && retryingItemId === item.id}
+                            aria-label={`Retry processing ${item.name}`}
+                          >
+                            {isRetrying && retryingItemId === item.id ? (
+                              <Loader2 className="h-4 w-4 animate-spin" />
+                            ) : (
+                              <RefreshCw className="h-4 w-4" />
+                            )}
                           </Button>
                         )}
                         {item.type === "url" && (

--- a/docs/plans/2026-07-21-unified-content-platform.md
+++ b/docs/plans/2026-07-21-unified-content-platform.md
@@ -703,3 +703,61 @@ The remaining rollout check is deployment of this hardening slice, followed by
 live confirmation that the pre-cutover marker is searchable and that a new
 inline-text item advances through version, job, generation, embedding, and
 citation state in dev.
+
+### Unified-content runtime recovery checkpoint (2026-07-22)
+
+The first live hardening deployment exposed several related runtime gaps rather
+than one isolated upload bug: inline text used a source namespace the worker
+rejected, legacy completion could mask canonical failure, processor retries
+could remain failed or invisible for hours, embedding failures could strand a
+building generation, and Retrieval v2 could stop serving the last active
+version while its replacement was still indexing. This corrective slice treats
+the entire upload-to-retrieval lifecycle as one recoverable state machine:
+
+- Every direct, multipart, and inline source now uses the single strict
+  `repositories/{repositoryId}/{uuid}/{filename}` contract. Registration rejects
+  cross-repository, nested, traversal-like, and artifact keys before a job is
+  created. A bounded retry action copies legacy files into that namespace and
+  creates a fresh immutable version for legacy inline text.
+- Repository Manager projects the current canonical version, inspect job, and
+  index generation instead of trusting legacy item status. Users see Pending,
+  Processing, Retrying, Generating Embeddings, Embedded, or a terminal Failed
+  state with its reason and an authorized Retry control.
+- The processor distinguishes permanent source/contract failures from transient
+  service failures, uses a five-attempt exponential retry budget, persists a
+  pending database outbox before every SQS send, recovers pending and expired
+  leases on the minute sweep, and bounds external security/OCR/media waits.
+- Embedding work acknowledges stale generations, exposes a failure only on its
+  terminal SQS receive, fails only the current building generation, and leaves
+  the previous active generation serving. Activation requires all required text
+  and visual vectors.
+- Retrieval treats the repository's active generation as the immutable serving
+  snapshot, fits the selected hit before neighbors, keeps text/citations paired,
+  and bounds assistant tool payloads. Deletion now fails closed until source and
+  derivative cleanup succeeds for documents, images, audio, video, and inline
+  text.
+- Migration 122 automatically retires pre-hardening stranded embedding
+  generations and requeues recoverable current processor jobs. Content and
+  embedding DLQ, oldest-message, and worker-error alarms make future stalls
+  visible; queue-level processor redrive is bounded to five receives.
+
+Verification evidence for the runtime recovery slice:
+
+- Application CI suite: 275 suites passed, 5 skipped; 3,103 tests passed and 60
+  intentionally skipped. Full lint has zero errors, and application,
+  infrastructure, unified-content worker, and embedding-worker typechecks pass.
+- Infrastructure/Lambda suite: 35 suites and 359 tests passed. The production
+  Next.js build, complete infrastructure build, and synthesis of all 29 dev/prod
+  stacks pass with the real ARM64 worker bundles and migration asset.
+- Real PostgreSQL migration and smoke tests pass canonical status projection,
+  terminal failure, a fresh manual retry budget, managed-service wait metadata,
+  text/visual activation guards, active-generation retrieval/citations, and
+  cleanup.
+- Authenticated Playwright passed 255 tests with 53 intentional environment
+  skips, covering the full application and the repository contract for direct,
+  PDF, Office, image, audio, video, inline-text, canonical failure visibility,
+  and Failed → Retry → Pending recovery.
+
+The remaining rollout check is deployment of migration 122 and the corrected
+workers, followed by a fresh live PDF/image/inline-text matrix through Embedded
+and cited retrieval. No manual AWS CLI or database mutation is required.

--- a/infra/database/migrations.json
+++ b/infra/database/migrations.json
@@ -115,6 +115,7 @@
     "118-unified-content-image-ingestion.sql",
     "119-unified-content-media-ingestion.sql",
     "120-bedrock-repository-embeddings.sql",
-    "121-unified-content-retrieval-v2.sql"
+    "121-unified-content-retrieval-v2.sql",
+    "122-unified-content-runtime-recovery.sql"
   ]
 }

--- a/infra/database/schema/122-unified-content-runtime-recovery.sql
+++ b/infra/database/schema/122-unified-content-runtime-recovery.sql
@@ -1,0 +1,104 @@
+-- Migration 122: recover content stranded by the pre-hardening runtime.
+--
+-- Earlier workers could leave deterministic processor failures in `failed`
+-- before their DB retry budget was exhausted, while embedding failures left a
+-- generation `building` forever and only changed the legacy item status. The
+-- corrected workers never create either state. Requeue the affected current
+-- versions once so the deployment heals existing data without an AWS CLI or
+-- direct database runbook.
+
+-- A pre-hardening embedding failure cannot be resumed in-place because its SQS
+-- record may already be in the DLQ. Retire only building generations that are
+-- explicitly associated with a current item carrying the old terminal status.
+UPDATE repository_index_generations generation
+   SET status = 'failed',
+       error_message = COALESCE(
+         generation.error_message,
+         'Recovered from a pre-hardening embedding failure by migration 122'
+       )
+ WHERE generation.status = 'building'
+   AND EXISTS (
+     SELECT 1
+       FROM repository_item_chunks chunk
+       JOIN repository_items item
+         ON item.id = chunk.item_id
+        AND item.current_version_id = chunk.item_version_id
+      WHERE chunk.index_generation_id = generation.id
+        AND item.processing_status = 'embedding_failed'
+   );
+
+-- Replay the durable inspect job for those embedding failures. Reprocessing
+-- creates a new generation under the current provider descriptor and preserves
+-- the previous active generation until the replacement is fully embedded.
+UPDATE repository_processing_jobs job
+   SET status = 'pending',
+       attempt = 0,
+       max_attempts = GREATEST(job.max_attempts, 5),
+       available_at = now(),
+       lease_owner = NULL,
+       lease_expires_at = NULL,
+       last_error_code = 'RECOVERED_BY_MIGRATION_122',
+       last_error_message = NULL,
+       finished_at = NULL,
+       updated_at = now()
+ WHERE job.status = 'succeeded'
+   AND EXISTS (
+     SELECT 1
+       FROM repository_items item
+      WHERE item.current_version_id = job.item_version_id
+        AND item.processing_status = 'embedding_failed'
+   );
+
+-- Old processor failures were marked failed after each receive and therefore
+-- were invisible to the pending-job sweep. Give current versions one fresh,
+-- bounded budget; the corrected handler immediately closes permanent errors.
+UPDATE repository_processing_jobs job
+   SET status = 'pending',
+       attempt = 0,
+       max_attempts = GREATEST(job.max_attempts, 5),
+       available_at = now(),
+       lease_owner = NULL,
+       lease_expires_at = NULL,
+       last_error_code = 'RECOVERED_BY_MIGRATION_122',
+       last_error_message = NULL,
+       finished_at = NULL,
+       updated_at = now()
+ WHERE job.status = 'failed'
+   AND job.attempt < job.max_attempts
+   AND job.last_error_code IS DISTINCT FROM 'SECURITY_INSPECTION_BLOCKED'
+   AND EXISTS (
+     SELECT 1
+       FROM repository_items item
+       JOIN repository_item_versions version
+         ON version.id = item.current_version_id
+      WHERE version.id = job.item_version_id
+        AND item.lifecycle_status = 'active'
+        -- Never revive malware/policy-blocked content. Those terminal states
+        -- require a new source version, not an automatic processing retry.
+        AND version.storage_status <> 'blocked'
+        AND version.inspection_status <> 'blocked'
+   );
+
+UPDATE repository_item_versions version
+   SET storage_status = 'quarantined',
+       inspection_status = 'pending',
+       processing_status = 'pending'
+ WHERE EXISTS (
+   SELECT 1
+     FROM repository_processing_jobs job
+    WHERE job.item_version_id = version.id
+      AND job.status = 'pending'
+      AND job.last_error_code = 'RECOVERED_BY_MIGRATION_122'
+ );
+
+UPDATE repository_items item
+   SET processing_status = 'pending',
+       processing_error = NULL,
+       updated_at = now()
+ WHERE EXISTS (
+   SELECT 1
+     FROM repository_processing_jobs job
+    WHERE job.item_version_id = item.current_version_id
+      AND job.status = 'pending'
+      AND job.last_error_code = 'RECOVERED_BY_MIGRATION_122'
+ );

--- a/infra/jest.config.js
+++ b/infra/jest.config.js
@@ -5,6 +5,9 @@ module.exports = {
       testEnvironment: 'node',
       roots: ['<rootDir>/test'],
       testMatch: ['**/*.test.ts'],
+      // `tsc` emits ignored JavaScript beside the TypeScript source. Resolve
+      // TypeScript first so a prior build cannot make Jest exercise stale code.
+      moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
       transform: {
         '^.+\\.tsx?$': 'ts-jest'
       }
@@ -14,6 +17,7 @@ module.exports = {
       testEnvironment: 'node',
       roots: ['<rootDir>/lambdas'],
       testMatch: ['**/__tests__/**/*.test.ts'],
+      moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
       // agent-skill-builder's suite imports `bun:test` and runs under
       // `bun test`, not jest.
       testPathIgnorePatterns: ['<rootDir>/lambdas/agent-skill-builder/'],

--- a/infra/lambdas/embedding-generator/__tests__/generation-activation.test.ts
+++ b/infra/lambdas/embedding-generator/__tests__/generation-activation.test.ts
@@ -1,8 +1,10 @@
 import { activateCompletedGeneration } from '../generation-activation';
+import type { SQL } from 'drizzle-orm';
+import { PgDialect } from 'drizzle-orm/pg-core';
 
 describe('atomic generation activation', () => {
   test('returns the switched repository and all embedded items', async () => {
-    const execute = jest.fn().mockResolvedValue([
+    const execute = jest.fn(async (_query: SQL) => [
       { repository_id: 7, embedded_item_count: 3 },
     ]);
 
@@ -13,6 +15,21 @@ describe('atomic generation activation', () => {
       ),
     ).resolves.toEqual({ repository_id: 7, embedded_item_count: 3 });
     expect(execute).toHaveBeenCalledTimes(1);
+
+    const activationQuery = execute.mock.calls[0]?.[0];
+    expect(activationQuery).toBeDefined();
+    const query = new PgDialect().sqlToQuery(activationQuery as SQL);
+    const normalizedSql = query.sql.replace(/\s+/g, ' ');
+    expect(normalizedSql).toContain(
+      'AND EXISTS ( SELECT 1 FROM repository_item_chunks chunk'
+    );
+    expect(normalizedSql).toContain(
+      'AND NOT EXISTS ( SELECT 1 FROM repository_item_chunks chunk'
+    );
+    expect(normalizedSql).toContain('chunk.embedding IS NULL');
+    expect(normalizedSql).toContain('generation.visual_embedding_model IS NOT NULL');
+    expect(normalizedSql).toContain("chunk.modality IN ('image', 'video')");
+    expect(normalizedSql).toContain('chunk.visual_embedding IS NULL');
   });
 
   test('treats a superseded stale generation as a safe no-op', async () => {

--- a/infra/lambdas/embedding-generator/__tests__/generation-lifecycle.test.ts
+++ b/infra/lambdas/embedding-generator/__tests__/generation-lifecycle.test.ts
@@ -1,0 +1,64 @@
+import type { SQL } from 'drizzle-orm';
+import { PgDialect } from 'drizzle-orm/pg-core';
+import {
+  failBuildingGeneration,
+  isTerminalEmbeddingAttempt,
+  shouldSkipCanonicalGeneration,
+} from '../generation-lifecycle';
+
+describe('canonical embedding generation lifecycle', () => {
+  test('acknowledges superseded and failed generations as stale', () => {
+    expect(shouldSkipCanonicalGeneration('superseded')).toBe(true);
+    expect(shouldSkipCanonicalGeneration('failed')).toBe(true);
+    expect(shouldSkipCanonicalGeneration('building')).toBe(false);
+    expect(shouldSkipCanonicalGeneration('active')).toBe(false);
+  });
+
+  test('does not expose a terminal failure before the SQS retry budget is exhausted', () => {
+    expect(isTerminalEmbeddingAttempt(undefined)).toBe(false);
+    expect(isTerminalEmbeddingAttempt('1')).toBe(false);
+    expect(isTerminalEmbeddingAttempt('2')).toBe(false);
+    expect(isTerminalEmbeddingAttempt('3')).toBe(true);
+    expect(isTerminalEmbeddingAttempt('4')).toBe(true);
+    expect(isTerminalEmbeddingAttempt('invalid')).toBe(false);
+  });
+
+  test('fails only a building generation and its own newly published item', async () => {
+    const execute = jest.fn(async (_query: SQL) => [{ item_id: 42 }]);
+
+    await expect(
+      failBuildingGeneration(
+        {
+          generationId: '11111111-2222-4333-8444-555555555555',
+          itemId: 42,
+          errorMessage: 'provider unavailable',
+        },
+        execute
+      )
+    ).resolves.toBe(true);
+
+    const failureQuery = execute.mock.calls[0]?.[0];
+    expect(failureQuery).toBeDefined();
+    const normalizedSql = new PgDialect()
+      .sqlToQuery(failureQuery as SQL)
+      .sql.replace(/\s+/g, ' ');
+    expect(normalizedSql).toContain("generation.status = 'building'");
+    expect(normalizedSql).toContain("SET status = 'failed'");
+    expect(normalizedSql).toContain("processing_status = 'embedding_failed'");
+    expect(normalizedSql).toContain('chunk.index_generation_id =');
+    expect(normalizedSql).toContain('chunk.item_id = item.id');
+  });
+
+  test('treats a superseded-generation failure update as a no-op', async () => {
+    await expect(
+      failBuildingGeneration(
+        {
+          generationId: '11111111-2222-4333-8444-555555555555',
+          itemId: 42,
+          errorMessage: 'stale batch',
+        },
+        jest.fn(async (_query: SQL) => [])
+      )
+    ).resolves.toBe(false);
+  });
+});

--- a/infra/lambdas/embedding-generator/generation-activation.ts
+++ b/infra/lambdas/embedding-generator/generation-activation.ts
@@ -21,9 +21,27 @@ export async function activateCompletedGeneration(
   const rows = await execute(sql`
     WITH target AS (
       SELECT id, repository_id
-      FROM repository_index_generations
-      WHERE id = ${generationId}::uuid
-        AND status IN ('building', 'active')
+      FROM repository_index_generations generation
+      WHERE generation.id = ${generationId}::uuid
+        AND generation.status IN ('building', 'active')
+        AND EXISTS (
+          SELECT 1
+          FROM repository_item_chunks chunk
+          WHERE chunk.index_generation_id = generation.id
+        )
+        AND NOT EXISTS (
+          SELECT 1
+          FROM repository_item_chunks chunk
+          WHERE chunk.index_generation_id = generation.id
+            AND (
+              chunk.embedding IS NULL
+              OR (
+                generation.visual_embedding_model IS NOT NULL
+                AND chunk.modality IN ('image', 'video')
+                AND chunk.visual_embedding IS NULL
+              )
+            )
+        )
     ), switched AS (
       UPDATE repository_index_generations generation
       SET

--- a/infra/lambdas/embedding-generator/generation-lifecycle.ts
+++ b/infra/lambdas/embedding-generator/generation-lifecycle.ts
@@ -1,0 +1,74 @@
+import { sql, type SQL } from 'drizzle-orm';
+
+export type CanonicalGenerationStatus =
+  | 'building'
+  | 'active'
+  | 'superseded'
+  | 'failed';
+
+export type GenerationFailureExecutor = (
+  query: SQL,
+) => Promise<Array<{ item_id: number }>>;
+
+const DEFAULT_MAX_RECEIVE_COUNT = 3;
+
+/** Stale generations must acknowledge queued batches without doing model work. */
+export function shouldSkipCanonicalGeneration(
+  status: CanonicalGenerationStatus
+): boolean {
+  return status === 'superseded' || status === 'failed';
+}
+
+/**
+ * SQS moves a message to the embedding DLQ after the configured third failed
+ * receive. Do not expose a terminal item failure while SQS still has a retry.
+ */
+export function isTerminalEmbeddingAttempt(
+  approximateReceiveCount: string | undefined,
+  maxReceiveCount = DEFAULT_MAX_RECEIVE_COUNT
+): boolean {
+  const receiveCount = Number.parseInt(approximateReceiveCount ?? '1', 10);
+  return (
+    Number.isSafeInteger(receiveCount) &&
+    receiveCount >= Math.max(1, maxReceiveCount)
+  );
+}
+
+/**
+ * Fail only the current building generation. A batch from a generation that a
+ * newer publication superseded is a safe no-op and cannot overwrite item state.
+ * The previous active generation and repository serving pointer stay untouched.
+ */
+export async function failBuildingGeneration(
+  input: {
+    generationId: string;
+    itemId: number;
+    errorMessage: string;
+  },
+  execute: GenerationFailureExecutor
+): Promise<boolean> {
+  const rows = await execute(sql`
+    WITH failed_generation AS (
+      UPDATE repository_index_generations generation
+      SET status = 'failed',
+          error_message = ${input.errorMessage.slice(0, 4000)}
+      WHERE generation.id = ${input.generationId}::uuid
+        AND generation.status = 'building'
+      RETURNING generation.id
+    )
+    UPDATE repository_items item
+    SET processing_status = 'embedding_failed',
+        processing_error = ${input.errorMessage.slice(0, 4000)},
+        updated_at = now()
+    WHERE item.id = ${input.itemId}
+      AND EXISTS (SELECT 1 FROM failed_generation)
+      AND EXISTS (
+        SELECT 1
+        FROM repository_item_chunks chunk
+        WHERE chunk.index_generation_id = ${input.generationId}::uuid
+          AND chunk.item_id = item.id
+      )
+    RETURNING item.id::integer AS item_id
+  `);
+  return rows.length > 0;
+}

--- a/infra/lambdas/embedding-generator/index.ts
+++ b/infra/lambdas/embedding-generator/index.ts
@@ -27,6 +27,12 @@ import {
   parseEmbeddingVector,
 } from './embedding-provider';
 import { activateCompletedGeneration } from './generation-activation';
+import {
+  failBuildingGeneration,
+  isTerminalEmbeddingAttempt,
+  shouldSkipCanonicalGeneration,
+  type CanonicalGenerationStatus,
+} from './generation-lifecycle';
 
 const log = {
   info: (msg: string, meta?: Record<string, unknown>) =>
@@ -324,12 +330,13 @@ async function processRecord(record: SQSRecord, embSettings: EmbeddingSettings):
     let effectiveSettings = embSettings;
     if (message.generationId) {
       const [generation] = await db.execute<{
+        status: CanonicalGenerationStatus;
         embedding_model: string | null;
         embedding_dimensions: number | null;
         visual_embedding_model: string | null;
         visual_embedding_dimensions: number | null;
       }>(sql`
-        SELECT embedding_model, embedding_dimensions,
+        SELECT status, embedding_model, embedding_dimensions,
                visual_embedding_model, visual_embedding_dimensions
         FROM repository_index_generations
         WHERE id = ${message.generationId}::uuid
@@ -337,6 +344,12 @@ async function processRecord(record: SQSRecord, embSettings: EmbeddingSettings):
       `);
       if (!generation) {
         throw new Error(`Index generation ${message.generationId} was not found`);
+      }
+      if (shouldSkipCanonicalGeneration(generation.status)) {
+        log.info(`Skipping stale embedding generation ${message.generationId}`, {
+          status: generation.status,
+        });
+        return;
       }
       const descriptor = parseEmbeddingDescriptor(
         generation.embedding_model,
@@ -513,13 +526,52 @@ async function processRecord(record: SQSRecord, embSettings: EmbeddingSettings):
     const errorMessage = error instanceof Error ? error.message : String(error);
     log.error(`Failed to generate embeddings for item ${message.itemId}`, { error: errorMessage });
 
-    try {
-      await db
-        .update(repositoryItems)
-        .set({ processingStatus: 'embedding_failed', processingError: errorMessage, updatedAt: new Date() })
-        .where(eq(repositoryItems.id, message.itemId));
-    } catch (dbError) {
-      log.error(`Failed to mark item ${message.itemId} as embedding_failed`, { error: String(dbError) });
+    const terminalAttempt = isTerminalEmbeddingAttempt(
+      record.attributes.ApproximateReceiveCount
+    );
+    if (terminalAttempt) {
+      try {
+        if (message.generationId) {
+          const failed = await failBuildingGeneration(
+            {
+              generationId: message.generationId,
+              itemId: message.itemId,
+              errorMessage,
+            },
+            async (query) =>
+              (await db.execute<{ item_id: number }>(query)) as Array<{
+                item_id: number;
+              }>
+          );
+          log.info(`Canonical embedding generation terminal failure handled`, {
+            generationId: message.generationId,
+            itemId: message.itemId,
+            failedCurrentGeneration: failed,
+          });
+        } else {
+          await db
+            .update(repositoryItems)
+            .set({
+              processingStatus: 'embedding_failed',
+              processingError: errorMessage,
+              updatedAt: new Date(),
+            })
+            .where(eq(repositoryItems.id, message.itemId));
+        }
+      } catch (dbError) {
+        log.error(`Failed to record terminal embedding failure`, {
+          itemId: message.itemId,
+          generationId: message.generationId,
+          error: String(dbError),
+        });
+      }
+    } else {
+      log.info(`Embedding failure remains retryable`, {
+        itemId: message.itemId,
+        generationId: message.generationId,
+        approximateReceiveCount:
+          record.attributes.ApproximateReceiveCount ?? '1',
+      });
     }
 
     throw error;

--- a/infra/lambdas/unified-content-processor/__tests__/contract.test.ts
+++ b/infra/lambdas/unified-content-processor/__tests__/contract.test.ts
@@ -34,6 +34,12 @@ describe("unified content processor contract", () => {
     ).toBe(false);
     expect(isRepositoryObjectKey(7, "repositories/7/not-a-uuid/file.pdf"))
       .toBe(false);
+    expect(
+      isRepositoryObjectKey(
+        7,
+        "repositories/7/inline/11111111-2222-4333-8444-555555555555/notes.txt"
+      )
+    ).toBe(false);
   });
 
   test("fails closed while malware inspection is required", () => {

--- a/infra/lambdas/unified-content-processor/__tests__/lifecycle.test.ts
+++ b/infra/lambdas/unified-content-processor/__tests__/lifecycle.test.ts
@@ -1,0 +1,95 @@
+import {
+  classifyContentProcessingError,
+  PermanentContentProcessingError,
+  prepareDeferredProcessingMetrics,
+  processingRetryDelaySeconds,
+} from "../lifecycle";
+
+describe("unified content lifecycle policy", () => {
+  test("classifies deterministic source failures as terminal", () => {
+    expect(
+      classifyContentProcessingError(
+        new PermanentContentProcessingError(
+          "SOURCE_NAMESPACE_INVALID",
+          "Object is outside its repository namespace"
+        )
+      )
+    ).toEqual({
+      terminal: true,
+      code: "SOURCE_NAMESPACE_INVALID",
+      message: "Object is outside its repository namespace",
+    });
+  });
+
+  test("treats upstream 4xx errors as terminal except throttling", () => {
+    const invalid = Object.assign(new Error("Bad request"), {
+      name: "ValidationException",
+      $metadata: { httpStatusCode: 400 },
+    });
+    expect(classifyContentProcessingError(invalid)).toMatchObject({
+      terminal: true,
+      code: "VALIDATION_EXCEPTION",
+    });
+
+    const throttled = Object.assign(new Error("Rate exceeded"), {
+      name: "ThrottlingException",
+      $metadata: { httpStatusCode: 400 },
+    });
+    expect(classifyContentProcessingError(throttled)).toMatchObject({
+      terminal: false,
+      code: "TRANSIENT_PROCESSING_ERROR",
+    });
+  });
+
+  test("uses a short exponential retry with bounded jitter", () => {
+    expect(processingRetryDelaySeconds(1, () => 0)).toBe(4);
+    expect(processingRetryDelaySeconds(2, () => 0.5)).toBe(10);
+    expect(processingRetryDelaySeconds(20, () => 1)).toBe(900);
+  });
+
+  test("starts a wait clock and preserves it for the same reason", () => {
+    const started = prepareDeferredProcessingMetrics(
+      { provider: "guardduty" },
+      "AWAITING_SECURITY_SCAN",
+      new Date("2026-07-22T12:00:00.000Z")
+    );
+    expect(started).toMatchObject({
+      provider: "guardduty",
+      waitReason: "AWAITING_SECURITY_SCAN",
+      waitStartedAt: "2026-07-22T12:00:00.000Z",
+    });
+
+    expect(
+      prepareDeferredProcessingMetrics(
+        started,
+        "AWAITING_SECURITY_SCAN",
+        new Date("2026-07-22T13:59:59.000Z")
+      ).waitStartedAt
+    ).toBe("2026-07-22T12:00:00.000Z");
+  });
+
+  test("fails managed-service waits at their deadline and resets for a new stage", () => {
+    const scanWait = {
+      waitReason: "AWAITING_SECURITY_SCAN" as const,
+      waitStartedAt: "2026-07-22T12:00:00.000Z",
+    };
+    expect(() =>
+      prepareDeferredProcessingMetrics(
+        scanWait,
+        "AWAITING_SECURITY_SCAN",
+        new Date("2026-07-22T14:00:00.000Z")
+      )
+    ).toThrow("timed out");
+
+    expect(
+      prepareDeferredProcessingMetrics(
+        scanWait,
+        "AWAITING_OCR",
+        new Date("2026-07-22T14:00:00.000Z")
+      )
+    ).toMatchObject({
+      waitReason: "AWAITING_OCR",
+      waitStartedAt: "2026-07-22T14:00:00.000Z",
+    });
+  });
+});

--- a/infra/lambdas/unified-content-processor/contract.ts
+++ b/infra/lambdas/unified-content-processor/contract.ts
@@ -1,3 +1,5 @@
+import { isRepositorySourceObjectKey } from "../../../lib/repositories/content-platform/object-key";
+
 export interface ContentProcessingMessage {
   jobId: string;
   itemVersionId: string;
@@ -74,16 +76,7 @@ export function isRepositoryObjectKey(
   repositoryId: number,
   objectKey: string
 ): boolean {
-  const prefix = `repositories/${repositoryId}/`;
-  if (!objectKey.startsWith(prefix) || objectKey.includes("..")) return false;
-  const pathParts = objectKey.slice(prefix.length).split("/");
-  return (
-    pathParts.length === 2 &&
-    /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
-      pathParts[0] ?? ""
-    ) &&
-    (pathParts[1]?.length ?? 0) > 0
-  );
+  return isRepositorySourceObjectKey(repositoryId, objectKey);
 }
 
 export function decideMalwareInspection(

--- a/infra/lambdas/unified-content-processor/index.ts
+++ b/infra/lambdas/unified-content-processor/index.ts
@@ -83,6 +83,13 @@ import {
 } from "./contract";
 import { CONTENT_SWEEP_REDISPATCHABLE_STATUSES } from "../../../lib/repositories/content-platform/job-state";
 import {
+  classifyContentProcessingError,
+  PermanentContentProcessingError,
+  prepareDeferredProcessingMetrics,
+  processingRetryDelaySeconds,
+  type DeferredProcessingReason,
+} from "./lifecycle";
+import {
   repositoryEmbeddingConfigurationFromSettings,
   repositoryVisualEmbeddingConfiguration,
 } from "../../../lib/repositories/embedding-configuration";
@@ -210,12 +217,48 @@ async function claimJob(message: ContentProcessingMessage, workerId: string) {
     if (job.status === "running" && job.leaseExpiresAt && job.leaseExpiresAt.getTime() > Date.now()) {
       return null;
     }
+    if (job.status === "pending" && job.availableAt.getTime() > Date.now()) {
+      return null;
+    }
     if (job.attempt >= job.maxAttempts) {
+      const errorMessage = "Processing job exhausted its retry budget";
       await tx
         .update(repositoryItemVersions)
-        .set({ processingStatus: "failed" })
+        .set({ inspectionStatus: "error", processingStatus: "failed" })
         .where(eq(repositoryItemVersions.id, message.itemVersionId));
-      throw new Error("Processing job exhausted its retry budget");
+      const [version] = await tx
+        .select({ itemId: repositoryItemVersions.itemId })
+        .from(repositoryItemVersions)
+        .where(eq(repositoryItemVersions.id, message.itemVersionId))
+        .limit(1);
+      if (version) {
+        await tx
+          .update(repositoryItems)
+          .set({
+            processingStatus: "failed",
+            processingError: errorMessage,
+            updatedAt: new Date(),
+          })
+          .where(
+            and(
+              eq(repositoryItems.id, version.itemId),
+              eq(repositoryItems.currentVersionId, message.itemVersionId)
+            )
+          );
+      }
+      await tx
+        .update(repositoryProcessingJobs)
+        .set({
+          status: "failed",
+          lastErrorCode: "RETRY_BUDGET_EXHAUSTED",
+          lastErrorMessage: errorMessage,
+          leaseOwner: null,
+          leaseExpiresAt: null,
+          finishedAt: new Date(),
+          updatedAt: new Date(),
+        })
+        .where(eq(repositoryProcessingJobs.id, job.id));
+      return null;
     }
     const now = new Date();
     const [claimed] = await tx
@@ -231,6 +274,32 @@ async function claimJob(message: ContentProcessingMessage, workerId: string) {
       })
       .where(eq(repositoryProcessingJobs.id, job.id))
       .returning();
+    if (claimed && job.stage === "inspect") {
+      await tx
+        .update(repositoryItemVersions)
+        .set({ processingStatus: "processing" })
+        .where(eq(repositoryItemVersions.id, message.itemVersionId));
+      const [version] = await tx
+        .select({ itemId: repositoryItemVersions.itemId })
+        .from(repositoryItemVersions)
+        .where(eq(repositoryItemVersions.id, message.itemVersionId))
+        .limit(1);
+      if (version) {
+        await tx
+          .update(repositoryItems)
+          .set({
+            processingStatus: "processing",
+            processingError: null,
+            updatedAt: now,
+          })
+          .where(
+            and(
+              eq(repositoryItems.id, version.itemId),
+              eq(repositoryItems.currentVersionId, message.itemVersionId)
+            )
+          );
+      }
+    }
     return claimed ?? null;
   }, "contentProcessor.claimJob");
 }
@@ -238,9 +307,10 @@ async function claimJob(message: ContentProcessingMessage, workerId: string) {
 async function deferJob(
   message: ContentProcessingMessage,
   metrics: JobMetrics,
-  reason: string,
+  reason: DeferredProcessingReason,
   claimedAttempt: number,
 ): Promise<void> {
+  const deferredMetrics = prepareDeferredProcessingMetrics(metrics, reason);
   await executeQuery(
     (db) =>
       db
@@ -253,7 +323,7 @@ async function deferJob(
           // Waiting for an external policy/service is not a processing failure
           // and must not consume the finite retry budget.
           attempt: Math.max(0, claimedAttempt - 1),
-          metrics,
+          metrics: deferredMetrics,
           leaseOwner: null,
           leaseExpiresAt: null,
           lastErrorCode: reason,
@@ -275,7 +345,12 @@ async function deferJob(
       db
         .update(repositoryProcessingJobs)
         .set({ status: "queued", updatedAt: new Date() })
-        .where(eq(repositoryProcessingJobs.id, message.jobId)),
+        .where(
+          and(
+            eq(repositoryProcessingJobs.id, message.jobId),
+            eq(repositoryProcessingJobs.status, "pending")
+          )
+        ),
     "contentProcessor.markDeferredJobDispatched",
   );
 }
@@ -316,6 +391,7 @@ async function blockVersion(message: ContentProcessingMessage, status: string): 
       .update(repositoryProcessingJobs)
       .set({
         status: "failed",
+        attempt: sql`${repositoryProcessingJobs.maxAttempts}`,
         lastErrorCode: "SECURITY_INSPECTION_BLOCKED",
         lastErrorMessage: status,
         leaseOwner: null,
@@ -676,13 +752,24 @@ async function processMessage(message: ContentProcessingMessage, workerId: strin
         .limit(1),
     "contentProcessor.getVersion",
   );
-  if (!context?.objectKey) throw new Error("Item version has no S3 object key");
+  if (!context?.objectKey) {
+    throw new PermanentContentProcessingError(
+      "SOURCE_OBJECT_MISSING",
+      "Item version has no S3 object key"
+    );
+  }
   if (!isRepositoryObjectKey(context.repositoryId, context.objectKey)) {
-    throw new Error("Item version object key is outside its repository namespace");
+    throw new PermanentContentProcessingError(
+      "SOURCE_NAMESPACE_INVALID",
+      "Item version object key is outside its repository namespace"
+    );
   }
   const declaredContentType = context.declaredContentType;
   if (!declaredContentType) {
-    throw new Error("Item version has no declared content type");
+    throw new PermanentContentProcessingError(
+      "SOURCE_CONTENT_TYPE_MISSING",
+      "Item version has no declared content type"
+    );
   }
   const isPdf = declaredContentType === "application/pdf";
   const isImage = isImageContentType(declaredContentType);
@@ -695,7 +782,10 @@ async function processMessage(message: ContentProcessingMessage, workerId: strin
     !mediaKind &&
     !isOfficeContentType(declaredContentType)
   ) {
-    throw new Error("Unified content worker received an unsupported content type");
+    throw new PermanentContentProcessingError(
+      "SOURCE_CONTENT_TYPE_UNSUPPORTED",
+      "Unified content worker received an unsupported content type"
+    );
   }
 
   const config = await getConfig();
@@ -711,7 +801,10 @@ async function processMessage(message: ContentProcessingMessage, workerId: strin
           ? config.maxImageSizeMb
           : config.maxOfficeSizeMb) * 1024 ** 2;
   if (context.byteSize != null && context.byteSize > processingLimitBytes) {
-    throw new Error(`File exceeds the configured ${Math.floor(processingLimitBytes / 1024 ** 2)} MiB processing limit`);
+    throw new PermanentContentProcessingError(
+      "SOURCE_SIZE_LIMIT_EXCEEDED",
+      `File exceeds the configured ${Math.floor(processingLimitBytes / 1024 ** 2)} MiB processing limit`
+    );
   }
   let inspectionStatus: "clean" | "not_required" = "not_required";
   let inspectionDetails: Record<string, unknown> = { provider: "disabled" };
@@ -1070,24 +1163,136 @@ async function processMessage(message: ContentProcessingMessage, workerId: strin
   );
 }
 
-async function markFailed(message: ContentProcessingMessage, error: unknown): Promise<void> {
-  const errorMessage = error instanceof Error ? error.message : String(error);
-  await executeQuery(
-    (db) =>
-      db
+async function handleProcessingFailure(
+  message: ContentProcessingMessage,
+  error: unknown
+): Promise<void> {
+  const decision = classifyContentProcessingError(error);
+  const failure = await executeTransaction(async (tx) => {
+    const [job] = await tx
+      .select()
+      .from(repositoryProcessingJobs)
+      .where(eq(repositoryProcessingJobs.id, message.jobId))
+      .limit(1)
+      .for("update");
+    if (!job) return { action: "ignore" as const };
+    if (job.itemVersionId !== message.itemVersionId) {
+      log.error("Ignoring processing message with a mismatched item version", {
+        jobId: message.jobId,
+      });
+      return { action: "ignore" as const };
+    }
+    if (job.status === "succeeded" || job.status === "cancelled") {
+      return { action: "ignore" as const };
+    }
+
+    const terminal = decision.terminal || job.attempt >= job.maxAttempts;
+    const now = new Date();
+    if (terminal) {
+      const code = decision.terminal
+        ? decision.code
+        : "RETRY_BUDGET_EXHAUSTED";
+      await tx
         .update(repositoryProcessingJobs)
         .set({
           status: "failed",
+          // Close the budget so a stale/duplicate queue delivery cannot revive a
+          // deterministic or exhausted failure.
+          attempt: job.maxAttempts,
           leaseOwner: null,
           leaseExpiresAt: null,
-          lastErrorCode: "PROCESSING_ERROR",
-          lastErrorMessage: errorMessage.slice(0, 4000),
-          finishedAt: new Date(),
-          updatedAt: new Date(),
+          lastErrorCode: code,
+          lastErrorMessage: decision.message,
+          finishedAt: now,
+          updatedAt: now,
         })
-        .where(eq(repositoryProcessingJobs.id, message.jobId)),
-    "contentProcessor.failJob",
-  );
+        .where(eq(repositoryProcessingJobs.id, job.id));
+      await tx
+        .update(repositoryItemVersions)
+        .set({ inspectionStatus: "error", processingStatus: "failed" })
+        .where(eq(repositoryItemVersions.id, message.itemVersionId));
+      const [version] = await tx
+        .select({ itemId: repositoryItemVersions.itemId })
+        .from(repositoryItemVersions)
+        .where(eq(repositoryItemVersions.id, message.itemVersionId))
+        .limit(1);
+      if (version) {
+        await tx
+          .update(repositoryItems)
+          .set({
+            processingStatus: "failed",
+            processingError: decision.message,
+            updatedAt: now,
+          })
+          .where(
+            and(
+              eq(repositoryItems.id, version.itemId),
+              eq(repositoryItems.currentVersionId, message.itemVersionId)
+            )
+          );
+      }
+      return { action: "terminal" as const, code };
+    }
+
+    const delaySeconds = processingRetryDelaySeconds(job.attempt);
+    await tx
+      .update(repositoryProcessingJobs)
+      .set({
+        status: "pending",
+        availableAt: new Date(now.getTime() + delaySeconds * 1_000),
+        leaseOwner: null,
+        leaseExpiresAt: null,
+        lastErrorCode: decision.code,
+        lastErrorMessage: decision.message,
+        finishedAt: null,
+        updatedAt: now,
+      })
+      .where(eq(repositoryProcessingJobs.id, job.id));
+    return { action: "retry" as const, delaySeconds };
+  }, "contentProcessor.handleProcessingFailure");
+
+  if (failure.action !== "retry") {
+    log.info("Unified content failure recorded", {
+      jobId: message.jobId,
+      action: failure.action,
+      code: failure.action === "terminal" ? failure.code : undefined,
+    });
+    return;
+  }
+
+  try {
+    await sqs.send(
+      new SendMessageCommand({
+        QueueUrl: queueUrl,
+        MessageBody: JSON.stringify(message),
+        DelaySeconds: failure.delaySeconds,
+      })
+    );
+    const dispatchCutoff = new Date();
+    await executeQuery(
+      (db) =>
+        db
+          .update(repositoryProcessingJobs)
+          .set({ status: "queued", updatedAt: dispatchCutoff })
+          .where(
+            and(
+              eq(repositoryProcessingJobs.id, message.jobId),
+              eq(repositoryProcessingJobs.status, "pending")
+            )
+          ),
+      "contentProcessor.markRetryDispatched"
+    );
+  } catch (dispatchError) {
+    // The pending DB row is the outbox. The minute sweep will retry this send;
+    // acknowledging the current record avoids the 90-minute queue visibility gap.
+    log.error("Retry enqueue failed; pending sweep will recover the job", {
+      jobId: message.jobId,
+      error:
+        dispatchError instanceof Error
+          ? dispatchError.message
+          : String(dispatchError),
+    });
+  }
 }
 
 async function dispatchPendingJobs(): Promise<void> {
@@ -1133,7 +1338,23 @@ async function dispatchPendingJobs(): Promise<void> {
             leaseExpiresAt: null,
             updatedAt: new Date(),
           })
-          .where(eq(repositoryProcessingJobs.id, job.id)),
+          .where(
+            and(
+              eq(repositoryProcessingJobs.id, job.id),
+              or(
+                eq(repositoryProcessingJobs.status, "pending"),
+                and(
+                  eq(repositoryProcessingJobs.status, "running"),
+                  lte(repositoryProcessingJobs.leaseExpiresAt, now)
+                )
+              ),
+              lte(repositoryProcessingJobs.availableAt, now),
+              lt(
+                repositoryProcessingJobs.attempt,
+                repositoryProcessingJobs.maxAttempts
+              )
+            )
+          ),
       "contentProcessor.markDispatched",
     );
   }
@@ -1162,8 +1383,26 @@ export async function handler(event: SQSEvent | EventBridgeEvent<string, unknown
         messageId: record.messageId,
         error: error instanceof Error ? error.message : String(error),
       });
-      if (message) await markFailed(message, error).catch(() => undefined);
-      failures.push({ itemIdentifier: record.messageId });
+      if (message) {
+        try {
+          await handleProcessingFailure(message, error);
+        } catch (failureError) {
+          log.error("Failed to persist unified content failure state", {
+            messageId: record.messageId,
+            error:
+              failureError instanceof Error
+                ? failureError.message
+                : String(failureError),
+          });
+          // Only failure-state persistence errors rely on the queue's long
+          // visibility retry. Ordinary processing failures use the bounded DB
+          // outbox retry above.
+          failures.push({ itemIdentifier: record.messageId });
+        }
+      } else {
+        // Malformed records are retained in the DLQ for diagnosis.
+        failures.push({ itemIdentifier: record.messageId });
+      }
     }
   }
   return { batchItemFailures: failures };

--- a/infra/lambdas/unified-content-processor/lifecycle.ts
+++ b/infra/lambdas/unified-content-processor/lifecycle.ts
@@ -1,0 +1,148 @@
+/**
+ * Failure and wait policy for the unified content worker.
+ *
+ * Keep this module free of AWS/DB clients so the retry contract can be tested
+ * without importing the Lambda handler (whose clients are created at module load).
+ */
+
+export type DeferredProcessingReason =
+  | "CONTENT_PLATFORM_DISABLED"
+  | "AWAITING_SECURITY_SCAN"
+  | "AWAITING_OCR"
+  | "AWAITING_MEDIA_ANALYSIS";
+
+export interface DeferredProcessingMetrics {
+  waitReason?: DeferredProcessingReason;
+  waitStartedAt?: string;
+}
+export interface ProcessingFailureDecision {
+  terminal: boolean;
+  code: string;
+  message: string;
+}
+
+const DEFER_DEADLINE_MS: Readonly<Record<DeferredProcessingReason, number>> = {
+  CONTENT_PLATFORM_DISABLED: 24 * 60 * 60 * 1_000,
+  AWAITING_SECURITY_SCAN: 2 * 60 * 60 * 1_000,
+  AWAITING_OCR: 60 * 60 * 1_000,
+  AWAITING_MEDIA_ANALYSIS: 6 * 60 * 60 * 1_000,
+};
+
+const RETRYABLE_AWS_ERROR =
+  /(?:throttl|timeout|timedout|requesttimeout|serviceunavailable|internalserver|slowdown|temporar|network|connection)/i;
+
+const PERMANENT_MESSAGE =
+  /(?:outside (?:its|the) .*namespace|unsupported content type|has no S3 object key|has no declared content type|exceeds the configured|OCR is disabled|superseded item version|requires a clean malware inspection|segments? (?:cannot be empty|must have)|requires a page citation|must be stored as an artifact object|did not match|does not match the item version)/i;
+
+function errorMessage(error: unknown): string {
+  return (error instanceof Error ? error.message : String(error)).slice(0, 4_000);
+}
+
+function normalizedErrorCode(value: string, fallback: string): string {
+  const code = value
+    .replace(/([a-z])([A-Z])/g, "$1_$2")
+    .replace(/[^A-Za-z0-9_]+/g, "_")
+    .replace(/^_+|_+$/g, "")
+    .toUpperCase()
+    .slice(0, 128);
+  return code || fallback;
+}
+
+function awsHttpStatus(error: unknown): number | null {
+  if (typeof error !== "object" || error === null || !("$metadata" in error)) {
+    return null;
+  }
+  const metadata = error.$metadata;
+  if (
+    typeof metadata !== "object" ||
+    metadata === null ||
+    !("httpStatusCode" in metadata) ||
+    typeof metadata.httpStatusCode !== "number"
+  ) {
+    return null;
+  }
+  return metadata.httpStatusCode;
+}
+
+export class PermanentContentProcessingError extends Error {
+  readonly code: string;
+
+  constructor(code: string, message: string) {
+    super(message);
+    this.name = "PermanentContentProcessingError";
+    this.code = normalizedErrorCode(code, "PERMANENT_PROCESSING_ERROR");
+  }
+}
+
+/**
+ * Treat deterministic source/contract failures and non-retryable AWS 4xx errors
+ * as terminal. Unknown infrastructure/database failures retain the bounded retry
+ * budget because they are commonly transient.
+ */
+export function classifyContentProcessingError(
+  error: unknown
+): ProcessingFailureDecision {
+  const message = errorMessage(error);
+  if (error instanceof PermanentContentProcessingError) {
+    return { terminal: true, code: error.code, message };
+  }
+
+  const name = error instanceof Error ? error.name : "";
+  if (RETRYABLE_AWS_ERROR.test(name) || RETRYABLE_AWS_ERROR.test(message)) {
+    return { terminal: false, code: "TRANSIENT_PROCESSING_ERROR", message };
+  }
+
+  const httpStatus = awsHttpStatus(error);
+  if (httpStatus != null && httpStatus >= 400 && httpStatus < 500) {
+    return {
+      terminal: true,
+      code: normalizedErrorCode(name, "UPSTREAM_CLIENT_ERROR"),
+      message,
+    };
+  }
+  if (PERMANENT_MESSAGE.test(message)) {
+    return { terminal: true, code: "INVALID_SOURCE_CONTENT", message };
+  }
+  return { terminal: false, code: "TRANSIENT_PROCESSING_ERROR", message };
+}
+
+/** Five-second exponential retry, jittered and bounded by SQS's 15-minute delay. */
+export function processingRetryDelaySeconds(
+  attempt: number,
+  random: () => number = Math.random
+): number {
+  const safeAttempt = Math.max(1, Math.min(20, Math.floor(attempt)));
+  const base = Math.min(900, 5 * 2 ** (safeAttempt - 1));
+  const jitter = 0.75 + Math.min(1, Math.max(0, random())) * 0.5;
+  return Math.max(1, Math.min(900, Math.round(base * jitter)));
+}
+
+/**
+ * Start or continue one managed-service wait and fail it after a service-specific
+ * deadline. Changing wait reasons starts a new clock (for example scan -> OCR).
+ */
+export function prepareDeferredProcessingMetrics<T extends DeferredProcessingMetrics>(
+  metrics: T,
+  reason: DeferredProcessingReason,
+  now = new Date()
+): T & Required<DeferredProcessingMetrics> {
+  const existingStartedAt =
+    metrics.waitReason === reason && metrics.waitStartedAt
+      ? Date.parse(metrics.waitStartedAt)
+      : Number.NaN;
+  const startedAt = Number.isFinite(existingStartedAt)
+    ? existingStartedAt
+    : now.getTime();
+  const deadlineMs = DEFER_DEADLINE_MS[reason];
+  if (now.getTime() - startedAt >= deadlineMs) {
+    throw new PermanentContentProcessingError(
+      `${reason}_TIMEOUT`,
+      `Content processing timed out while ${reason.toLowerCase().replaceAll("_", " ")}`
+    );
+  }
+  return {
+    ...metrics,
+    waitReason: reason,
+    waitStartedAt: new Date(startedAt).toISOString(),
+  };
+}

--- a/infra/lib/constructs/processing/unified-content-processing.ts
+++ b/infra/lib/constructs/processing/unified-content-processing.ts
@@ -1,6 +1,7 @@
 import * as path from "path";
 import * as cdk from "aws-cdk-lib";
 import * as bedrock from "aws-cdk-lib/aws-bedrock";
+import * as cloudwatch from "aws-cdk-lib/aws-cloudwatch";
 import * as ec2 from "aws-cdk-lib/aws-ec2";
 import * as events from "aws-cdk-lib/aws-events";
 import * as eventsTargets from "aws-cdk-lib/aws-events-targets";
@@ -106,11 +107,46 @@ export class UnifiedContentProcessing extends Construct {
       // AWS recommends at least six times the Lambda timeout for SQS event
       // sources so throttling/backoff cannot expose the same record mid-run.
       visibilityTimeout: cdk.Duration.minutes(90),
-      deadLetterQueue: { queue: this.deadLetterQueue, maxReceiveCount: 20 },
+      // The durable database job owns the five-attempt processing budget.
+      // Queue-level retries are reserved for malformed records or failure-state
+      // persistence outages and must not remain invisible for 30 hours.
+      deadLetterQueue: { queue: this.deadLetterQueue, maxReceiveCount: 5 },
     });
     for (const resource of [this.deadLetterQueue, this.queue]) {
       cdk.Tags.of(resource).add("Environment", props.environment);
       cdk.Tags.of(resource).add("ManagedBy", "cdk");
+    }
+    const deadLetterAlarm = new cloudwatch.Alarm(this, "DeadLetterQueueAlarm", {
+      alarmName: `aistudio-${props.environment}-content-processing-dlq-visible`,
+      alarmDescription:
+        "Unified repository content records reached the DLQ and require diagnosis/redrive",
+      metric: this.deadLetterQueue.metricApproximateNumberOfMessagesVisible({
+        period: cdk.Duration.minutes(5),
+        statistic: "Maximum",
+      }),
+      threshold: 1,
+      evaluationPeriods: 1,
+      comparisonOperator:
+        cloudwatch.ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+      treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
+    });
+    const oldestMessageAlarm = new cloudwatch.Alarm(this, "OldestMessageAlarm", {
+      alarmName: `aistudio-${props.environment}-content-processing-oldest-message`,
+      alarmDescription:
+        "Unified repository content processing has not drained a message within 30 minutes",
+      metric: this.queue.metricApproximateAgeOfOldestMessage({
+        period: cdk.Duration.minutes(5),
+        statistic: "Maximum",
+      }),
+      threshold: cdk.Duration.minutes(30).toSeconds(),
+      evaluationPeriods: 2,
+      comparisonOperator:
+        cloudwatch.ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+      treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
+    });
+    for (const alarm of [deadLetterAlarm, oldestMessageAlarm]) {
+      cdk.Tags.of(alarm).add("Environment", props.environment);
+      cdk.Tags.of(alarm).add("ManagedBy", "cdk");
     }
 
     const malwareProtectionRole = new iam.Role(
@@ -387,6 +423,22 @@ export class UnifiedContentProcessing extends Construct {
     });
     cdk.Tags.of(this.worker).add("Environment", props.environment);
     cdk.Tags.of(this.worker).add("ManagedBy", "cdk");
+    const workerErrorAlarm = new cloudwatch.Alarm(this, "WorkerErrorAlarm", {
+      alarmName: `aistudio-${props.environment}-content-processing-worker-errors`,
+      alarmDescription:
+        "Unified repository content worker could not persist durable failure/retry state",
+      metric: this.worker.metricErrors({
+        period: cdk.Duration.minutes(5),
+        statistic: "Sum",
+      }),
+      threshold: 1,
+      evaluationPeriods: 1,
+      comparisonOperator:
+        cloudwatch.ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+      treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
+    });
+    cdk.Tags.of(workerErrorAlarm).add("Environment", props.environment);
+    cdk.Tags.of(workerErrorAlarm).add("ManagedBy", "cdk");
 
     this.worker.addEventSource(
       new lambdaEventSources.SqsEventSource(this.queue, {

--- a/infra/lib/processing-stack.ts
+++ b/infra/lib/processing-stack.ts
@@ -412,6 +412,56 @@ export class ProcessingStack extends cdk.Stack {
     cdk.Tags.of(embeddingGenerator).add('Environment', props.environment);
     cdk.Tags.of(embeddingGenerator).add('ManagedBy', 'cdk');
 
+    const embeddingDlqAlarm = new cloudwatch.Alarm(this, 'EmbeddingDlqAlarm', {
+      alarmName: `aistudio-${props.environment}-embedding-dlq-visible`,
+      alarmDescription:
+        'Repository embedding records reached the DLQ and require diagnosis or retry',
+      metric: embeddingDlq.metricApproximateNumberOfMessagesVisible({
+        period: cdk.Duration.minutes(5),
+        statistic: 'Maximum',
+      }),
+      threshold: 1,
+      evaluationPeriods: 1,
+      comparisonOperator:
+        cloudwatch.ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+      treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
+    });
+    const embeddingAgeAlarm = new cloudwatch.Alarm(this, 'EmbeddingAgeAlarm', {
+      alarmName: `aistudio-${props.environment}-embedding-oldest-message`,
+      alarmDescription:
+        'Repository embedding work has not drained within 30 minutes',
+      metric: this.embeddingQueue.metricApproximateAgeOfOldestMessage({
+        period: cdk.Duration.minutes(5),
+        statistic: 'Maximum',
+      }),
+      threshold: cdk.Duration.minutes(30).toSeconds(),
+      evaluationPeriods: 2,
+      comparisonOperator:
+        cloudwatch.ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+      treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
+    });
+    const embeddingErrorAlarm = new cloudwatch.Alarm(this, 'EmbeddingErrorAlarm', {
+      alarmName: `aistudio-${props.environment}-embedding-worker-errors`,
+      alarmDescription: 'Repository embedding worker invocations are failing',
+      metric: embeddingGenerator.metricErrors({
+        period: cdk.Duration.minutes(5),
+        statistic: 'Sum',
+      }),
+      threshold: 1,
+      evaluationPeriods: 1,
+      comparisonOperator:
+        cloudwatch.ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+      treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
+    });
+    for (const alarm of [
+      embeddingDlqAlarm,
+      embeddingAgeAlarm,
+      embeddingErrorAlarm,
+    ]) {
+      cdk.Tags.of(alarm).add('Environment', props.environment);
+      cdk.Tags.of(alarm).add('ManagedBy', 'cdk');
+    }
+
     // Textract Processor Lambda
     const textractProcessorRole = ServiceRoleFactory.createLambdaRole(this, 'TextractProcessorRole', {
       functionName: 'textract-processor',

--- a/infra/test/unit/processing-stack-embedding-access.test.ts
+++ b/infra/test/unit/processing-stack-embedding-access.test.ts
@@ -64,4 +64,35 @@ describe('ProcessingStack embedding visual-artifact access', () => {
       expect.arrayContaining(['s3:PutObject', 's3:DeleteObject']),
     );
   });
+
+  it('alarms on embedding backlog, terminal DLQ records, and worker failures', () => {
+    const app = new cdk.App();
+    const stack = new ProcessingStack(app, 'ProcessingAlarmTest', {
+      env: { account: '123456789012', region: 'us-east-1' },
+      environment: 'dev',
+      documentsBucketName: 'aistudio-dev-documents',
+      databaseResourceArn:
+        'arn:aws:rds:us-east-1:123456789012:cluster:aistudio-dev',
+      databaseSecretArn:
+        'arn:aws:secretsmanager:us-east-1:123456789012:secret:aistudio-dev',
+    });
+    const template = Template.fromStack(stack);
+
+    template.hasResourceProperties('AWS::CloudWatch::Alarm', {
+      AlarmName: 'aistudio-dev-embedding-dlq-visible',
+      Threshold: 1,
+      TreatMissingData: 'notBreaching',
+    });
+    template.hasResourceProperties('AWS::CloudWatch::Alarm', {
+      AlarmName: 'aistudio-dev-embedding-oldest-message',
+      Threshold: 1_800,
+      EvaluationPeriods: 2,
+      TreatMissingData: 'notBreaching',
+    });
+    template.hasResourceProperties('AWS::CloudWatch::Alarm', {
+      AlarmName: 'aistudio-dev-embedding-worker-errors',
+      Threshold: 1,
+      TreatMissingData: 'notBreaching',
+    });
+  });
 });

--- a/infra/test/unit/unified-content-processing.test.ts
+++ b/infra/test/unit/unified-content-processing.test.ts
@@ -42,7 +42,7 @@ describe("UnifiedContentProcessing", () => {
       QueueName: "aistudio-dev-content-processing-queue",
       SqsManagedSseEnabled: true,
       VisibilityTimeout: 5_400,
-      RedrivePolicy: Match.objectLike({ maxReceiveCount: 20 }),
+      RedrivePolicy: Match.objectLike({ maxReceiveCount: 5 }),
       Tags: Match.arrayWith([
         { Key: "Environment", Value: "dev" },
         { Key: "ManagedBy", Value: "cdk" },
@@ -52,6 +52,25 @@ describe("UnifiedContentProcessing", () => {
       QueueName: "aistudio-dev-content-processing-dlq",
       SqsManagedSseEnabled: true,
       MessageRetentionPeriod: 1_209_600,
+    });
+  });
+
+  test("alarms on stalled work, DLQ records, and worker persistence errors", () => {
+    template.hasResourceProperties("AWS::CloudWatch::Alarm", {
+      AlarmName: "aistudio-dev-content-processing-dlq-visible",
+      Threshold: 1,
+      TreatMissingData: "notBreaching",
+    });
+    template.hasResourceProperties("AWS::CloudWatch::Alarm", {
+      AlarmName: "aistudio-dev-content-processing-oldest-message",
+      Threshold: 1_800,
+      EvaluationPeriods: 2,
+      TreatMissingData: "notBreaching",
+    });
+    template.hasResourceProperties("AWS::CloudWatch::Alarm", {
+      AlarmName: "aistudio-dev-content-processing-worker-errors",
+      Threshold: 1,
+      TreatMissingData: "notBreaching",
     });
   });
 

--- a/jest.config.ci.js
+++ b/jest.config.ci.js
@@ -44,6 +44,13 @@ const customJestConfig = {
   transformIgnorePatterns: [
     'node_modules/(?!(lucide-react|next-auth|@next-auth|nanoid|uuid)/)'
   ],
+  // CDK synthesis copies the application (including manual mocks) into many
+  // asset folders. Exclude those generated modules from Jest's haste map so a
+  // prior synth cannot create hundreds of false duplicate-mock warnings.
+  modulePathIgnorePatterns: [
+    '<rootDir>/infra/cdk.out/',
+    '<rootDir>/.next/',
+  ],
   testPathIgnorePatterns: [
     '/node_modules/',
     '/tests/e2e/',

--- a/jest.config.js
+++ b/jest.config.js
@@ -39,6 +39,10 @@ const customJestConfig = {
   transformIgnorePatterns: [
     'node_modules/(?!(lucide-react|next-auth|@next-auth|nanoid)/)'
   ],
+  modulePathIgnorePatterns: [
+    '<rootDir>/infra/cdk.out/',
+    '<rootDir>/.next/',
+  ],
   testPathIgnorePatterns: [
     '/node_modules/',
     '/tests/e2e/',
@@ -49,4 +53,4 @@ const customJestConfig = {
   ]
 };
 
-module.exports = createJestConfig(customJestConfig); 
+module.exports = createJestConfig(customJestConfig);

--- a/lib/aws/s3-client.ts
+++ b/lib/aws/s3-client.ts
@@ -9,6 +9,7 @@ import {
   CreateBucketCommand,
   HeadBucketCommand,
   PutBucketCorsCommand,
+  CopyObjectCommand,
   BucketLocationConstraint,
 } from "@aws-sdk/client-s3"
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner"
@@ -16,6 +17,8 @@ import { createError } from "@/lib/error-utils"
 import { Settings } from "@/lib/settings-manager"
 import { Readable } from "node:stream"
 import { randomUUID } from "node:crypto"
+import { buildRepositorySourceObjectKey } from "@/lib/repositories/content-platform/object-key"
+import { sanitizeFileName } from "@/lib/aws/document-upload"
 
 // Cache S3 config to avoid repeated async calls
 let s3ConfigCache: { bucket: string | null; region: string | null } | null = null
@@ -60,6 +63,7 @@ export function clearS3Cache() {
 
 export interface UploadDocumentParams {
   userId: string
+  repositoryId?: number
   fileName: string
   fileContent: Buffer | Uint8Array | string
   contentType: string
@@ -87,6 +91,12 @@ export interface UploadRepositoryTextSourceParams {
   userId: number
   fileName: string
   content: string
+}
+
+export interface CopyRepositorySourceToCanonicalNamespaceParams {
+  repositoryId: number
+  sourceKey: string
+  fileName: string
 }
 
 // Ensure the documents bucket exists
@@ -155,6 +165,7 @@ export async function ensureDocumentsBucket(): Promise<void> {
 // Upload a document to S3
 export async function uploadDocument({
   userId,
+  repositoryId,
   fileName,
   fileContent,
   contentType,
@@ -167,7 +178,9 @@ export async function uploadDocument({
   const bucketName = config.bucket!
 
   const timestamp = Date.now()
-  const key = `${userId}/${timestamp}-${fileName}`
+  const key = repositoryId == null
+    ? `${userId}/${timestamp}-${fileName}`
+    : buildRepositorySourceObjectKey(repositoryId, fileName)
 
   try {
     const command = new PutObjectCommand({
@@ -219,7 +232,7 @@ export async function uploadRepositoryTextSource({
   const s3Client = await getS3Client()
   const config = await getS3Config()
   const body = Buffer.from(content, "utf8")
-  const key = `repositories/${repositoryId}/inline/${randomUUID()}/${fileName}`
+  const key = buildRepositorySourceObjectKey(repositoryId, fileName, randomUUID())
 
   await s3Client.send(
     new PutObjectCommand({
@@ -238,6 +251,42 @@ export async function uploadRepositoryTextSource({
   )
 
   return { key, byteSize: body.byteLength }
+}
+
+/**
+ * Copy a legacy repository source into the immutable namespace accepted by the
+ * unified processor. S3 preserves source metadata, content type, and tags by
+ * default because this request supplies no replacement directives.
+ */
+export async function copyRepositorySourceToCanonicalNamespace({
+  repositoryId,
+  sourceKey,
+  fileName,
+}: CopyRepositorySourceToCanonicalNamespaceParams): Promise<{ key: string }> {
+  if (!sourceKey.trim() || sourceKey.includes("..")) {
+    throw new Error("A safe source object key is required")
+  }
+  await ensureDocumentsBucket()
+
+  const s3Client = await getS3Client()
+  const config = await getS3Config()
+  const bucketName = config.bucket!
+  const safeFileName = sanitizeFileName(fileName)
+  const key = buildRepositorySourceObjectKey(repositoryId, safeFileName)
+  const encodedSourceKey = sourceKey
+    .split("/")
+    .map((part) => encodeURIComponent(part))
+    .join("/")
+
+  await s3Client.send(
+    new CopyObjectCommand({
+      Bucket: bucketName,
+      Key: key,
+      CopySource: `/${bucketName}/${encodedSourceKey}`,
+    })
+  )
+
+  return { key }
 }
 
 // Get a signed URL for a document

--- a/lib/db/schema/tables/repository-processing-jobs.ts
+++ b/lib/db/schema/tables/repository-processing-jobs.ts
@@ -31,6 +31,14 @@ export type RepositoryProcessingJobStatus =
   | "cancelled";
 
 export interface RepositoryProcessingMetrics {
+  /** Current managed-service wait, used to enforce a bounded deadline. */
+  waitReason?:
+    | "CONTENT_PLATFORM_DISABLED"
+    | "AWAITING_SECURITY_SCAN"
+    | "AWAITING_OCR"
+    | "AWAITING_MEDIA_ANALYSIS";
+  /** ISO timestamp at which the current managed-service wait began. */
+  waitStartedAt?: string;
   durationMs?: number;
   inputBytes?: number;
   outputBytes?: number;

--- a/lib/repositories/content-platform/dispatch-service.ts
+++ b/lib/repositories/content-platform/dispatch-service.ts
@@ -1,5 +1,5 @@
 import { SendMessageCommand, SQSClient } from "@aws-sdk/client-sqs";
-import { eq } from "drizzle-orm";
+import { and, eq, lte } from "drizzle-orm";
 import { executeQuery } from "@/lib/db/drizzle-client";
 import { repositoryProcessingJobs } from "@/lib/db/schema";
 
@@ -21,6 +21,28 @@ export async function dispatchContentProcessingJob(
   const queueUrl = process.env.CONTENT_PROCESSING_QUEUE_URL;
   if (!queueUrl) throw new Error("CONTENT_PROCESSING_QUEUE_URL is not configured");
 
+  // Completion/shadow-write calls are replayable. Do not re-enqueue a running,
+  // failed, cancelled, or already-succeeded job. A second eligibility check on
+  // the update below protects the send -> DB race without sacrificing the DB
+  // row's role as a durable outbox when SQS is unavailable.
+  const now = new Date();
+  const [eligible] = await executeQuery(
+    (db) =>
+      db
+        .select({ id: repositoryProcessingJobs.id })
+        .from(repositoryProcessingJobs)
+        .where(
+          and(
+            eq(repositoryProcessingJobs.id, message.jobId),
+            eq(repositoryProcessingJobs.status, "pending"),
+            lte(repositoryProcessingJobs.availableAt, now)
+          )
+        )
+        .limit(1),
+    "contentPlatform.getDispatchableProcessingJob"
+  );
+  if (!eligible) return;
+
   await sqs.send(
     new SendMessageCommand({
       QueueUrl: queueUrl,
@@ -39,7 +61,13 @@ export async function dispatchContentProcessingJob(
       db
         .update(repositoryProcessingJobs)
         .set({ status: "queued", updatedAt: new Date() })
-        .where(eq(repositoryProcessingJobs.id, message.jobId)),
+        .where(
+          and(
+            eq(repositoryProcessingJobs.id, message.jobId),
+            eq(repositoryProcessingJobs.status, "pending"),
+            lte(repositoryProcessingJobs.availableAt, now)
+          )
+        ),
     "contentPlatform.dispatchProcessingJob"
   );
 }

--- a/lib/repositories/content-platform/index.ts
+++ b/lib/repositories/content-platform/index.ts
@@ -10,3 +10,5 @@ export * from "./upload-service";
 export * from "./dispatch-service";
 export * from "./inline-text-ingestion";
 export * from "./text-processing";
+export * from "./status-service";
+export * from "./object-key";

--- a/lib/repositories/content-platform/ingestion-service.ts
+++ b/lib/repositories/content-platform/ingestion-service.ts
@@ -12,8 +12,10 @@ import { ErrorFactories } from "@/lib/error-utils";
 import { getContentPlatformConfig, isContentDualWriteActive } from "./config";
 import {
   buildProcessingIdempotencyKey,
+  CONTENT_PROCESSING_MAX_ATTEMPTS,
   CONTENT_PROCESSOR_CONTRACT_VERSION,
 } from "./job-state";
+import { isRepositorySourceObjectKey } from "./object-key";
 
 export interface RegisterCanonicalUploadInput {
   itemId: number;
@@ -78,7 +80,7 @@ async function ensureInspectJob(
       stage: "inspect",
       status: "pending",
       idempotencyKey,
-      maxAttempts: 20,
+      maxAttempts: CONTENT_PROCESSING_MAX_ATTEMPTS,
       traceId,
     })
     .returning();
@@ -100,13 +102,19 @@ export async function registerCanonicalUpload(
   return executeTransaction(
     async (tx) => {
       const [item] = await tx
-        .select({ id: repositoryItems.id })
+        .select({
+          id: repositoryItems.id,
+          repositoryId: repositoryItems.repositoryId,
+        })
         .from(repositoryItems)
         .where(eq(repositoryItems.id, input.itemId))
         .limit(1)
         .for("update");
       if (!item) {
         throw ErrorFactories.dbRecordNotFound("repository_items", input.itemId);
+      }
+      if (!isRepositorySourceObjectKey(item.repositoryId, input.objectKey)) {
+        throw new Error("Object key is outside the repository source namespace");
       }
 
       const [existing] = await tx
@@ -157,6 +165,8 @@ export async function registerCanonicalUpload(
         .set({
           currentVersionId: version.id,
           lifecycleStatus: "active",
+          processingStatus: "pending",
+          processingError: null,
           updatedAt: new Date(),
         })
         .where(eq(repositoryItems.id, input.itemId));

--- a/lib/repositories/content-platform/job-state.ts
+++ b/lib/repositories/content-platform/job-state.ts
@@ -6,9 +6,15 @@ import type {
 export const CONTENT_PROCESSOR_CONTRACT_VERSION = "unified-content-v1";
 
 /**
- * Only jobs that have never reached SQS are eligible for scheduled redispatch.
- * Failed Lambda records remain owned by SQS and are retried with its backoff;
- * sweeping them too creates a second live delivery for the same durable job.
+ * One automatic processing budget. A manual retry creates a fresh budget, while
+ * transient failures inside a budget use the worker's bounded exponential delay.
+ */
+export const CONTENT_PROCESSING_MAX_ATTEMPTS = 5;
+
+/**
+ * Pending is the durable outbox state. A transient worker failure is converted
+ * back to pending, explicitly requeued with a bounded delay, and then ACKed.
+ * The sweep recovers any pending job whose explicit SQS send was interrupted.
  */
 export const CONTENT_SWEEP_REDISPATCHABLE_STATUSES = ["pending"] as const satisfies
   readonly RepositoryProcessingJobStatus[];

--- a/lib/repositories/content-platform/object-key.ts
+++ b/lib/repositories/content-platform/object-key.ts
@@ -1,0 +1,46 @@
+import { randomUUID } from "node:crypto";
+
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+/**
+ * Return whether an S3 key is an immutable source object owned by one
+ * repository. Processor artifacts deliberately use a different namespace.
+ */
+export function isRepositorySourceObjectKey(
+  repositoryId: number,
+  objectKey: string
+): boolean {
+  if (!Number.isSafeInteger(repositoryId) || repositoryId <= 0) return false;
+  const prefix = `repositories/${repositoryId}/`;
+  if (!objectKey.startsWith(prefix) || objectKey.includes("..")) return false;
+  const pathParts = objectKey.slice(prefix.length).split("/");
+  return (
+    pathParts.length === 2 &&
+    UUID_PATTERN.test(pathParts[0] ?? "") &&
+    (pathParts[1]?.length ?? 0) > 0
+  );
+}
+
+/** Build the canonical repository source namespace accepted by the worker. */
+export function buildRepositorySourceObjectKey(
+  repositoryId: number,
+  fileName: string,
+  sourceId = randomUUID()
+): string {
+  if (!Number.isSafeInteger(repositoryId) || repositoryId <= 0) {
+    throw new Error("A valid repository id is required for a source object key");
+  }
+  if (!UUID_PATTERN.test(sourceId)) {
+    throw new Error("A valid source id is required for a source object key");
+  }
+  if (
+    !fileName.trim() ||
+    fileName.includes("/") ||
+    fileName.includes("\\") ||
+    fileName.includes("..")
+  ) {
+    throw new Error("A safe file name is required for a source object key");
+  }
+  return `repositories/${repositoryId}/${sourceId}/${fileName}`;
+}

--- a/lib/repositories/content-platform/status-service.ts
+++ b/lib/repositories/content-platform/status-service.ts
@@ -1,0 +1,283 @@
+import { and, desc, eq, sql } from "drizzle-orm";
+import { executeQuery, executeTransaction } from "@/lib/db/drizzle-client";
+import {
+  knowledgeRepositories,
+  repositoryIndexGenerations,
+  repositoryItemChunks,
+  repositoryItems,
+  repositoryItemVersions,
+  repositoryProcessingJobs,
+} from "@/lib/db/schema";
+import { CONTENT_PROCESSING_MAX_ATTEMPTS } from "./job-state";
+
+export type CanonicalItemProcessingStatus =
+  | "pending"
+  | "processing"
+  | "retrying"
+  | "processing_embeddings"
+  | "embedded"
+  | "failed";
+
+export interface CanonicalRepositoryItemStatus {
+  itemId: number;
+  processingStatus: CanonicalItemProcessingStatus;
+  processingError: string | null;
+  canRetry: boolean;
+}
+
+interface CanonicalStatusRow {
+  itemId: number;
+  versionStatus: "pending" | "processing" | "completed" | "failed" | "cancelled";
+  storageStatus: "quarantined" | "available" | "blocked" | "deleted";
+  inspectionStatus: "pending" | "clean" | "blocked" | "error" | "not_required";
+  jobStatus: "pending" | "queued" | "running" | "succeeded" | "failed" | "cancelled" | null;
+  jobAttempt: number | null;
+  jobMaxAttempts: number | null;
+  jobError: string | null;
+  active: boolean;
+  buildingGeneration: boolean;
+  failedGeneration: boolean;
+  generationError: string | null;
+}
+
+export function resolveCanonicalItemStatus(
+  row: CanonicalStatusRow
+): CanonicalRepositoryItemStatus {
+  if (row.active) {
+    return {
+      itemId: row.itemId,
+      processingStatus: "embedded",
+      processingError: null,
+      canRetry: false,
+    };
+  }
+
+  const terminalFailure =
+    row.versionStatus === "failed" ||
+    row.storageStatus === "blocked" ||
+    row.inspectionStatus === "blocked" ||
+    row.inspectionStatus === "error" ||
+    (row.failedGeneration &&
+      !row.buildingGeneration &&
+      row.versionStatus === "completed" &&
+      row.jobStatus === "succeeded") ||
+    (row.jobStatus === "failed" &&
+      row.jobAttempt !== null &&
+      row.jobMaxAttempts !== null &&
+      row.jobAttempt >= row.jobMaxAttempts);
+  if (terminalFailure) {
+    return {
+      itemId: row.itemId,
+      processingStatus: "failed",
+      processingError:
+        row.jobError ??
+        row.generationError ??
+        (row.inspectionStatus === "blocked"
+          ? "The file did not pass the required security inspection."
+          : "Content processing failed. Retry the item or contact support."),
+      canRetry: row.storageStatus !== "blocked" && row.inspectionStatus !== "blocked",
+    };
+  }
+
+  if (row.versionStatus === "completed") {
+    return {
+      itemId: row.itemId,
+      processingStatus: "processing_embeddings",
+      processingError: null,
+      canRetry: false,
+    };
+  }
+
+  if (row.jobStatus === "failed") {
+    return {
+      itemId: row.itemId,
+      processingStatus: "retrying",
+      processingError: null,
+      canRetry: false,
+    };
+  }
+
+  return {
+    itemId: row.itemId,
+    processingStatus:
+      row.jobStatus === "running" || row.versionStatus === "processing"
+        ? "processing"
+        : "pending",
+    processingError: null,
+    canRetry: false,
+  };
+}
+
+/**
+ * Project the canonical version/job/generation state used by Repository Manager.
+ * Legacy item status is deliberately not trusted once an immutable version exists.
+ */
+export async function getCanonicalRepositoryItemStatuses(
+  repositoryId: number
+): Promise<Map<number, CanonicalRepositoryItemStatus>> {
+  const rows = await executeQuery(
+    (db) =>
+      db
+        .select({
+          itemId: repositoryItems.id,
+          versionStatus: repositoryItemVersions.processingStatus,
+          storageStatus: repositoryItemVersions.storageStatus,
+          inspectionStatus: repositoryItemVersions.inspectionStatus,
+          jobStatus: repositoryProcessingJobs.status,
+          jobAttempt: repositoryProcessingJobs.attempt,
+          jobMaxAttempts: repositoryProcessingJobs.maxAttempts,
+          jobError: repositoryProcessingJobs.lastErrorMessage,
+          active: sql<boolean>`EXISTS (
+            SELECT 1
+            FROM ${repositoryItemChunks} active_chunk
+            WHERE active_chunk.item_version_id = ${repositoryItemVersions.id}
+              AND active_chunk.index_generation_id = ${knowledgeRepositories.activeIndexGenerationId}
+          )`,
+          buildingGeneration: sql<boolean>`EXISTS (
+            SELECT 1
+            FROM ${repositoryItemChunks} building_chunk
+            INNER JOIN ${repositoryIndexGenerations} building_generation
+              ON building_generation.id = building_chunk.index_generation_id
+            WHERE building_chunk.item_version_id = ${repositoryItemVersions.id}
+              AND building_generation.status = 'building'
+          )`,
+          failedGeneration: sql<boolean>`EXISTS (
+            SELECT 1
+            FROM ${repositoryItemChunks} failed_chunk
+            INNER JOIN ${repositoryIndexGenerations} failed_generation
+              ON failed_generation.id = failed_chunk.index_generation_id
+            WHERE failed_chunk.item_version_id = ${repositoryItemVersions.id}
+              AND failed_generation.status = 'failed'
+          )`,
+          generationError: sql<string | null>`(
+            SELECT failed_generation.error_message
+            FROM ${repositoryItemChunks} failed_chunk
+            INNER JOIN ${repositoryIndexGenerations} failed_generation
+              ON failed_generation.id = failed_chunk.index_generation_id
+            WHERE failed_chunk.item_version_id = ${repositoryItemVersions.id}
+              AND failed_generation.status = 'failed'
+            ORDER BY failed_generation.created_at DESC
+            LIMIT 1
+          )`,
+        })
+        .from(repositoryItems)
+        .innerJoin(
+          repositoryItemVersions,
+          eq(repositoryItemVersions.id, repositoryItems.currentVersionId)
+        )
+        .innerJoin(
+          knowledgeRepositories,
+          eq(knowledgeRepositories.id, repositoryItems.repositoryId)
+        )
+        .leftJoin(
+          repositoryProcessingJobs,
+          and(
+            eq(repositoryProcessingJobs.itemVersionId, repositoryItemVersions.id),
+            eq(repositoryProcessingJobs.stage, "inspect")
+          )
+        )
+        .where(eq(repositoryItems.repositoryId, repositoryId)),
+    "contentPlatform.getCanonicalRepositoryItemStatuses"
+  );
+
+  return new Map(
+    rows.map((row) => {
+      const status = resolveCanonicalItemStatus(row);
+      return [status.itemId, status];
+    })
+  );
+}
+
+export interface RetryCanonicalItemResult {
+  itemVersionId: string;
+  processingJobId: string;
+}
+
+/** Reset a terminal current version to its durable inspect job for reprocessing. */
+export async function retryCanonicalRepositoryItem(
+  itemId: number,
+  traceId?: string
+): Promise<RetryCanonicalItemResult> {
+  return executeTransaction(
+    async (tx) => {
+      const [context] = await tx
+        .select({
+          itemVersionId: repositoryItemVersions.id,
+          storageStatus: repositoryItemVersions.storageStatus,
+          inspectionStatus: repositoryItemVersions.inspectionStatus,
+        })
+        .from(repositoryItems)
+        .innerJoin(
+          repositoryItemVersions,
+          eq(repositoryItemVersions.id, repositoryItems.currentVersionId)
+        )
+        .where(eq(repositoryItems.id, itemId))
+        .limit(1)
+        .for("update");
+      if (!context) throw new Error("The item has no canonical version to retry");
+      if (context.storageStatus === "blocked" || context.inspectionStatus === "blocked") {
+        throw new Error("Security-blocked content cannot be retried");
+      }
+
+      const [job] = await tx
+        .select()
+        .from(repositoryProcessingJobs)
+        .where(eq(repositoryProcessingJobs.itemVersionId, context.itemVersionId))
+        .orderBy(desc(repositoryProcessingJobs.createdAt))
+        .limit(1)
+        .for("update");
+      if (!job) throw new Error("The item has no processing job to retry");
+      if (job.status !== "failed" && job.status !== "succeeded") {
+        throw new Error("The item is already being processed");
+      }
+
+      const now = new Date();
+      await tx
+        .update(repositoryIndexGenerations)
+        .set({
+          status: "failed",
+          errorMessage: "Superseded by a user-requested retry",
+        })
+        .where(
+          sql`${repositoryIndexGenerations.id} IN (
+            SELECT retry_chunk.index_generation_id
+            FROM ${repositoryItemChunks} retry_chunk
+            WHERE retry_chunk.item_version_id = ${context.itemVersionId}
+          ) AND ${repositoryIndexGenerations.status} = 'building'`
+        );
+      await tx
+        .update(repositoryProcessingJobs)
+        .set({
+          status: "pending",
+          maxAttempts: Math.max(
+            job.maxAttempts,
+            job.attempt + CONTENT_PROCESSING_MAX_ATTEMPTS
+          ),
+          availableAt: now,
+          leaseOwner: null,
+          leaseExpiresAt: null,
+          traceId: traceId ?? job.traceId,
+          lastErrorCode: null,
+          lastErrorMessage: null,
+          finishedAt: null,
+          updatedAt: now,
+        })
+        .where(eq(repositoryProcessingJobs.id, job.id));
+      await tx
+        .update(repositoryItemVersions)
+        .set({
+          storageStatus: "quarantined",
+          inspectionStatus: "pending",
+          processingStatus: "pending",
+        })
+        .where(eq(repositoryItemVersions.id, context.itemVersionId));
+      await tx
+        .update(repositoryItems)
+        .set({ processingStatus: "pending", processingError: null, updatedAt: now })
+        .where(eq(repositoryItems.id, itemId));
+
+      return { itemVersionId: context.itemVersionId, processingJobId: job.id };
+    },
+    "contentPlatform.retryCanonicalRepositoryItem"
+  );
+}

--- a/lib/repositories/content-platform/storage-cleanup.ts
+++ b/lib/repositories/content-platform/storage-cleanup.ts
@@ -55,14 +55,19 @@ export async function deleteRepositoryItemStorage(
   item: RepositoryStorageItem,
   dependencies: RepositoryStorageCleanupDependencies = defaultDependencies
 ): Promise<RepositoryStorageCleanupResult> {
-  if (item.type !== "document" && item.type !== "image") {
-    return { sourceObjectCount: 0, artifactObjectCount: 0 };
-  }
-
   const versions = await dependencies.getVersions(item.id);
 
   const sourceKeys = new Set<string>();
-  if (item.source.trim()) sourceKeys.add(item.source);
+  // URL and inline-text sources are user content, not object keys. Canonical
+  // text still has an immutable version object below and is cleaned through the
+  // version rows. File-backed legacy items may not have canonical versions yet,
+  // so retain their stored source key as a fallback.
+  if (
+    ["document", "image", "audio", "video"].includes(item.type) &&
+    item.source.trim()
+  ) {
+    sourceKeys.add(item.source);
+  }
   for (const version of versions) {
     if (version.objectKey?.trim()) sourceKeys.add(version.objectKey);
   }

--- a/lib/repositories/content-platform/upload-service.ts
+++ b/lib/repositories/content-platform/upload-service.ts
@@ -22,6 +22,7 @@ import { Settings } from "@/lib/settings-manager";
 import type { ContentPlatformConfig } from "./config";
 import {
   buildProcessingIdempotencyKey,
+  CONTENT_PROCESSING_MAX_ATTEMPTS,
   CONTENT_PROCESSOR_CONTRACT_VERSION,
 } from "./job-state";
 import { sourceRevisionForObjectKey } from "./ingestion-service";
@@ -32,6 +33,7 @@ import {
 } from "./media-processing";
 import { isOfficeContentType } from "./office-processing";
 import { isCanonicalTextContentType } from "./text-processing";
+import { buildRepositorySourceObjectKey } from "./object-key";
 
 export interface InitiateRepositoryUploadInput {
   repositoryId: number;
@@ -279,12 +281,15 @@ export async function initiateRepositoryUpload(
   const resolvedStorage = storage ?? (await createS3UploadStorage());
   const sessionId = randomUUID();
   const safeFileName = sanitizeFileName(input.fileName);
-  const objectKey = `repositories/${input.repositoryId}/${sessionId}/${safeFileName}`;
+  const objectKey = buildRepositorySourceObjectKey(
+    input.repositoryId,
+    safeFileName,
+    sessionId
+  );
   const expiresAt = new Date(Date.now() + UPLOAD_EXPIRY_SECONDS * 1000);
   const metadata = {
     repositoryId: String(input.repositoryId),
     uploadSessionId: sessionId,
-    originalFileName: input.fileName,
   };
 
   let uploadId: string | undefined;
@@ -534,7 +539,7 @@ export async function completeRepositoryUpload(
           stage: "inspect",
           status: "pending",
           idempotencyKey: buildProcessingIdempotencyKey(version.id, "inspect"),
-          maxAttempts: 20,
+          maxAttempts: CONTENT_PROCESSING_MAX_ATTEMPTS,
         })
         .returning({ id: repositoryProcessingJobs.id });
       if (!job) throw new Error("Failed to create repository processing job");

--- a/lib/repositories/retrieval-v2/service.ts
+++ b/lib/repositories/retrieval-v2/service.ts
@@ -314,7 +314,6 @@ async function denseCandidates(
             sql`, `
           )})
           AND item.lifecycle_status = 'active'
-          AND item.current_version_id = version.id
           AND version.storage_status = 'available'
           AND version.inspection_status IN ('clean', 'not_required')
           AND version.processing_status = 'completed'
@@ -357,7 +356,6 @@ async function lexicalCandidates(
             sql`, `
           )})
           AND item.lifecycle_status = 'active'
-          AND item.current_version_id = version.id
           AND version.storage_status = 'available'
           AND version.inspection_status IN ('clean', 'not_required')
           AND version.processing_status = 'completed'
@@ -466,7 +464,6 @@ async function visualCandidates(
           AND chunk.visual_embedding IS NOT NULL
           AND chunk.modality IN ('image', 'video')
           AND item.lifecycle_status = 'active'
-          AND item.current_version_id = version.id
           AND version.storage_status = 'available'
           AND version.inspection_status IN ('clean', 'not_required')
           AND version.processing_status = 'completed'
@@ -518,7 +515,6 @@ async function expandCandidate(
             OR chunk.chunk_index = ${candidate.parentChunkIndex ?? -1}
           )
           AND item.lifecycle_status = 'active'
-          AND item.current_version_id = version.id
           AND version.storage_status = 'available'
           AND version.inspection_status IN ('clean', 'not_required')
           AND version.processing_status = 'completed'
@@ -527,7 +523,7 @@ async function expandCandidate(
       `),
     "retrievalV2.expandContext"
   );
-  return (rows as unknown as Array<Record<string, unknown>>).flatMap((row) => {
+  const expanded = (rows as unknown as Array<Record<string, unknown>>).flatMap((row) => {
     const contextCandidate = mapCandidate(row, "lexical");
     try {
       return [
@@ -545,6 +541,41 @@ async function expandCandidate(
       return [];
     }
   });
+
+  // The active generation is the serving snapshot. Keep its selected hit first
+  // even when the database returns a preceding neighbor (or a newly registered
+  // current version points at content that has not reached the active generation
+  // yet). This also guarantees a tight context budget cannot consume itself on a
+  // neighbor and omit the semantic/lexical hit that earned the result.
+  let primary: RetrievalContextSegment | null = null;
+  try {
+    primary = {
+      chunkId: candidate.chunkId,
+      chunkIndex: candidate.chunkIndex,
+      content: candidate.content,
+      contextPrefix: candidate.contextPrefix,
+      modality: candidate.modality,
+      tokens: candidate.tokens,
+      citation: resolveRetrievalCitation(candidate),
+    };
+  } catch {
+    // fitContextBudget applies the same citation guard and will omit this
+    // candidate. Preserve the previous fail-closed behavior for malformed rows.
+  }
+
+  const neighbors = expanded
+    .filter((segment) => segment.chunkId !== candidate.chunkId)
+    .sort((left, right) => {
+      const leftIsParent = left.chunkIndex === candidate.parentChunkIndex;
+      const rightIsParent = right.chunkIndex === candidate.parentChunkIndex;
+      if (leftIsParent !== rightIsParent) return leftIsParent ? -1 : 1;
+      const distance =
+        Math.abs(left.chunkIndex - candidate.chunkIndex) -
+        Math.abs(right.chunkIndex - candidate.chunkIndex);
+      return distance || left.chunkIndex - right.chunkIndex;
+    });
+
+  return primary ? [primary, ...neighbors] : neighbors;
 }
 
 function fitContextBudget(

--- a/lib/repositories/search-service.ts
+++ b/lib/repositories/search-service.ts
@@ -157,7 +157,6 @@ export async function vectorSearch(
           WHERE c.embedding IS NOT NULL
             AND i.repository_id = ${repositoryId}
             AND i.lifecycle_status = 'active'
-            AND i.current_version_id = c.item_version_id
             AND r.lifecycle_status = 'active'
             AND c.index_generation_id = ${embeddingTarget?.generationId ?? null}
             AND v.storage_status = 'available'
@@ -264,7 +263,6 @@ export async function keywordSearch(
           WHERE to_tsvector('english', c.content) @@ plainto_tsquery('english', ${query})
             AND i.repository_id = ${repositoryId}
             AND i.lifecycle_status = 'active'
-            AND i.current_version_id = c.item_version_id
             AND r.lifecycle_status = 'active'
             AND r.active_index_generation_id = c.index_generation_id
             AND v.storage_status = 'available'

--- a/lib/tools/repository-tools.ts
+++ b/lib/tools/repository-tools.ts
@@ -88,14 +88,30 @@ async function searchAccessibleRepositories(
         ? {}
         : { denseWeight: request.vectorWeight }),
     });
-    return retrieval.results.map((result) => ({
-      content: result.content,
-      itemName: result.itemName,
-      similarity: result.similarity,
-      chunkIndex: result.chunkIndex,
-      citation: result.citations[0],
-      context: result.context,
-    }));
+    return retrieval.results.map((result) => {
+      const primaryContext = result.context.find(
+        (segment) => segment.chunkId === result.chunkId
+      );
+      const primaryCitation = result.citations.find(
+        (citation) => citation.chunkId === result.chunkId
+      );
+      return {
+        // Retrieval v2 budgets context, while result.content is the unbounded
+        // candidate text. Returning the fitted primary segment keeps the tool
+        // payload bounded and pairs its text with the citation for that chunk.
+        content: primaryContext?.content ?? result.content,
+        itemName: result.itemName,
+        similarity: result.similarity,
+        chunkIndex: result.chunkIndex,
+        citation: primaryCitation ?? primaryContext?.citation,
+        // `content` already contains the fitted primary segment; return only
+        // its surrounding segments here so the model does not receive the same
+        // budgeted text twice.
+        context: result.context.filter(
+          (segment) => segment.chunkId !== result.chunkId
+        ),
+      };
+    });
   }
 
   const perRepositoryResults = await Promise.all(

--- a/scripts/drizzle-helpers/lib/migration-utils.ts
+++ b/scripts/drizzle-helpers/lib/migration-utils.ts
@@ -12,7 +12,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 
 // Constants
-const DB_INIT_HANDLER_PATH = "./infra/database/lambda/db-init-handler.ts";
+const MIGRATIONS_MANIFEST_PATH = "./infra/database/migrations.json";
 
 /**
  * Get project root directory (absolute path)
@@ -39,30 +39,29 @@ export function getAbsolutePath(relativePath: string): string {
 
 /**
  * Get the next migration number based on existing migrations
- * Reads from MIGRATION_FILES array in db-init-handler.ts
+ * Reads from the migrations.json manifest shared by local and AWS runners.
  */
 export function getNextMigrationNumber(): number {
-  const handlerPath = getAbsolutePath(DB_INIT_HANDLER_PATH);
-  const handlerContent = fs.readFileSync(handlerPath, "utf-8");
-
-  // Extract MIGRATION_FILES array
-  const arrayMatch = handlerContent.match(
-    /const\s+MIGRATION_FILES\s*=\s*\[([\S\s]*?)];/
-  );
-  if (!arrayMatch) {
+  const manifestPath = getAbsolutePath(MIGRATIONS_MANIFEST_PATH);
+  const parsed = JSON.parse(fs.readFileSync(manifestPath, "utf-8")) as unknown;
+  if (
+    typeof parsed !== "object" ||
+    parsed === null ||
+    !("migrationFiles" in parsed) ||
+    !Array.isArray(parsed.migrationFiles) ||
+    !parsed.migrationFiles.every((filename) => typeof filename === "string")
+  ) {
     throw new Error(
-      `Could not find MIGRATION_FILES array in ${DB_INIT_HANDLER_PATH}`
+      `Invalid migrationFiles array in ${MIGRATIONS_MANIFEST_PATH}`
     );
   }
-
-  // Extract all migration filenames
-  const filenames = arrayMatch[1].match(/'([^']+\.sql)'/g) || [];
+  const filenames = parsed.migrationFiles as string[];
 
   // Find highest migration number
   let maxNumber = 9; // Start at 009 so first migration is 010
 
   for (const filename of filenames) {
-    const match = filename.match(/'(\d+)/);
+    const match = filename.match(/^(\d+)/);
     if (match) {
       const num = Number.parseInt(match[1], 10);
       if (num > maxNumber) {

--- a/scripts/drizzle-helpers/list-migrations.ts
+++ b/scripts/drizzle-helpers/list-migrations.ts
@@ -2,7 +2,7 @@
 /**
  * List Migrations Script
  *
- * Lists all migrations in the MIGRATION_FILES array and their status
+ * Lists all migrations in the shared migrations.json manifest and their status
  * (whether file exists in schema directory).
  *
  * Part of Epic #526 - RDS Data API to Drizzle ORM Migration
@@ -19,7 +19,11 @@ import { getAbsolutePath, getNextMigrationNumber } from "./lib/migration-utils";
 
 // Constants
 const LAMBDA_SCHEMA_DIR = "./infra/database/schema";
-const DB_INIT_HANDLER_PATH = "./infra/database/lambda/db-init-handler.ts";
+const MIGRATIONS_MANIFEST_PATH = "./infra/database/migrations.json";
+
+interface MigrationManifest {
+  migrationFiles: string[];
+}
 
 interface MigrationInfo {
   filename: string;
@@ -30,28 +34,30 @@ interface MigrationInfo {
 }
 
 /**
- * Get all migrations from MIGRATION_FILES array
+ * Get all migrations from the same manifest used by the database Lambda and
+ * local migration runner. The old handler-source parser broke when the Lambda
+ * moved to this single source of truth.
  */
 function getMigrations(): MigrationInfo[] {
-  const handlerPath = getAbsolutePath(DB_INIT_HANDLER_PATH);
-  const handlerContent = fs.readFileSync(handlerPath, "utf-8");
-
-  // Extract MIGRATION_FILES array
-  const arrayMatch = handlerContent.match(
-    /const\s+MIGRATION_FILES\s*=\s*\[([\S\s]*?)];/
-  );
-  if (!arrayMatch) {
+  const manifestPath = getAbsolutePath(MIGRATIONS_MANIFEST_PATH);
+  const parsed = JSON.parse(fs.readFileSync(manifestPath, "utf-8")) as unknown;
+  if (
+    typeof parsed !== "object" ||
+    parsed === null ||
+    !("migrationFiles" in parsed) ||
+    !Array.isArray(parsed.migrationFiles) ||
+    !parsed.migrationFiles.every(
+      (filename) => typeof filename === "string" && filename.endsWith(".sql")
+    )
+  ) {
     throw new Error(
-      `Could not find MIGRATION_FILES array in ${DB_INIT_HANDLER_PATH}`
+      `Invalid migrationFiles array in ${MIGRATIONS_MANIFEST_PATH}`
     );
   }
-
-  // Extract all migration filenames
-  const filenameMatches = arrayMatch[1].match(/'([^']+\.sql)'/g) || [];
+  const manifest = parsed as MigrationManifest;
   const migrations: MigrationInfo[] = [];
 
-  for (const match of filenameMatches) {
-    const filename = match.replace(/'/g, "");
+  for (const filename of manifest.migrationFiles) {
     const numberMatch = filename.match(/^(\d+)/);
     const number = numberMatch ? Number.parseInt(numberMatch[1], 10) : 0;
 
@@ -100,7 +106,7 @@ function main(): void {
   const migrations = getMigrations();
   const nextNumber = getNextMigrationNumber();
 
-  console.log(`Source: ${DB_INIT_HANDLER_PATH}`);
+  console.log(`Source: ${MIGRATIONS_MANIFEST_PATH}`);
   console.log(`Schema dir: ${LAMBDA_SCHEMA_DIR}`);
   console.log(`Total migrations: ${migrations.length}`);
   console.log(`Next number: ${String(nextNumber).padStart(3, "0")}`);

--- a/tests/e2e/fixtures/assistant-architect-seed.sql
+++ b/tests/e2e/fixtures/assistant-architect-seed.sql
@@ -1,8 +1,9 @@
 -- Assistant Architect fixture for the parallel-prompt persistence E2E
 -- (tests/e2e/assistant-architect-parallel-persistence.spec.ts).
 --
--- Seeds an APPROVED architect owned by the seeded admin (users.id = 2, cognito_sub
--- 'e2e-test-user') so it shows in the admin's "My Approved Assistants" list, plus
+-- Seeds an APPROVED architect owned by the seeded admin (resolved by stable
+-- cognito_sub, never a sequence-dependent numeric id) so it shows in the
+-- admin's "My Approved Assistants" list, plus
 -- two prompts at the SAME position in DIFFERENT parallel_groups so the ReactFlow
 -- prompts editor renders parallel prompt nodes. Idempotent.
 --
@@ -10,10 +11,12 @@
 -- model so the FK holds.
 
 INSERT INTO assistant_architects (id, name, description, status, user_id, is_parallel)
-VALUES (9000, 'E2E Parallel Architect',
-        'Fixture: two parallel prompts for persistence E2E', 'approved', 2, true)
+SELECT 9000, 'E2E Parallel Architect',
+       'Fixture: two parallel prompts for persistence E2E', 'approved', user_row.id, true
+FROM users user_row
+WHERE user_row.cognito_sub = 'e2e-test-user'
 ON CONFLICT (id) DO UPDATE
-  SET user_id = 2, status = 'approved', is_parallel = true,
+  SET user_id = EXCLUDED.user_id, status = 'approved', is_parallel = true,
       model_routing_mode = 'legacy', model_routing_family = NULL;
 
 INSERT INTO chain_prompts (id, assistant_architect_id, name, content, model_id, position, parallel_group)
@@ -26,13 +29,25 @@ ON CONFLICT (id) DO NOTHING;
 
 INSERT INTO assistant_architects
   (id, name, description, status, user_id, is_parallel, model_routing_mode, model_routing_family)
-VALUES
-  (9010, 'E2E Standard Routed Architect',
-   'Fixture: automatic Standard model routing', 'draft', 2, false, 'standard', NULL),
-  (9020, 'E2E Advanced Routed Architect',
-   'Fixture: automatic Claude-family routing', 'draft', 2, false, 'advanced', 'anthropic')
+SELECT fixture.id,
+       fixture.name,
+       fixture.description,
+       'draft',
+       user_row.id,
+       false,
+       fixture.routing_mode,
+       fixture.routing_family
+FROM users user_row
+CROSS JOIN (
+  VALUES
+    (9010, 'E2E Standard Routed Architect',
+     'Fixture: automatic Standard model routing', 'standard', NULL::varchar),
+    (9020, 'E2E Advanced Routed Architect',
+     'Fixture: automatic Claude-family routing', 'advanced', 'anthropic'::varchar)
+) AS fixture(id, name, description, routing_mode, routing_family)
+WHERE user_row.cognito_sub = 'e2e-test-user'
 ON CONFLICT (id) DO UPDATE
-  SET user_id = 2,
+  SET user_id = EXCLUDED.user_id,
       status = 'draft',
       model_routing_mode = EXCLUDED.model_routing_mode,
       model_routing_family = EXCLUDED.model_routing_family;

--- a/tests/e2e/fixtures/unified-content-repository-seed.sql
+++ b/tests/e2e/fixtures/unified-content-repository-seed.sql
@@ -25,3 +25,124 @@ WHERE u.cognito_sub = 'e2e-test-user'
     FROM knowledge_repositories r
     WHERE r.metadata ->> 'e2eFixture' = 'unified-content'
   );
+
+-- A deterministic terminal item proves that Repository Manager projects the
+-- canonical failure and that its Retry action resets the durable job/version.
+WITH fixture_context AS (
+  SELECT r.id AS repository_id, u.id AS user_id
+  FROM knowledge_repositories r
+  JOIN users u ON u.cognito_sub = 'e2e-test-user'
+  WHERE r.metadata ->> 'e2eFixture' = 'unified-content'
+  LIMIT 1
+)
+INSERT INTO repository_items (
+  repository_id,
+  type,
+  name,
+  source,
+  source_external_id,
+  lifecycle_status,
+  processing_status,
+  processing_error,
+  metadata
+)
+SELECT
+  fixture_context.repository_id,
+  'document',
+  'E2E failed processing fixture',
+  'repositories/' || fixture_context.repository_id ||
+    '/77777777-7777-4777-8777-777777777777/retry.pdf',
+  'e2e-unified-content-terminal-retry',
+  'active',
+  'failed',
+  'Simulated terminal processing failure',
+  '{"e2eFixture":"unified-content-terminal-retry"}'::jsonb
+FROM fixture_context
+WHERE NOT EXISTS (
+  SELECT 1
+  FROM repository_items item
+  WHERE item.source_external_id = 'e2e-unified-content-terminal-retry'
+);
+
+WITH fixture_item AS (
+  SELECT item.id, item.repository_id, u.id AS user_id
+  FROM repository_items item
+  JOIN knowledge_repositories repository ON repository.id = item.repository_id
+  JOIN users u ON u.cognito_sub = 'e2e-test-user'
+  WHERE item.source_external_id = 'e2e-unified-content-terminal-retry'
+    AND repository.metadata ->> 'e2eFixture' = 'unified-content'
+  LIMIT 1
+)
+INSERT INTO repository_item_versions (
+  id,
+  item_id,
+  version_number,
+  source_kind,
+  source_revision,
+  object_key,
+  declared_content_type,
+  byte_size,
+  storage_status,
+  inspection_status,
+  processing_status,
+  created_by
+)
+SELECT
+  '77777777-7777-4777-8777-777777777778'::uuid,
+  fixture_item.id,
+  1,
+  'upload',
+  'e2e-terminal-retry',
+  'repositories/' || fixture_item.repository_id ||
+    '/77777777-7777-4777-8777-777777777777/retry.pdf',
+  'application/pdf',
+  128,
+  'quarantined',
+  'error',
+  'failed',
+  fixture_item.user_id
+FROM fixture_item
+ON CONFLICT (id) DO NOTHING;
+
+UPDATE repository_items
+SET current_version_id = '77777777-7777-4777-8777-777777777778'::uuid,
+    processing_status = 'failed',
+    processing_error = 'Simulated terminal processing failure',
+    updated_at = now()
+WHERE source_external_id = 'e2e-unified-content-terminal-retry';
+
+INSERT INTO repository_processing_jobs (
+  id,
+  item_version_id,
+  stage,
+  status,
+  idempotency_key,
+  attempt,
+  max_attempts,
+  last_error_code,
+  last_error_message,
+  finished_at
+)
+VALUES (
+  '77777777-7777-4777-8777-777777777779'::uuid,
+  '77777777-7777-4777-8777-777777777778'::uuid,
+  'inspect',
+  'failed',
+  'e2e-terminal-retry:inspect',
+  5,
+  5,
+  'E2E_TERMINAL_FAILURE',
+  'Simulated terminal processing failure',
+  now()
+)
+ON CONFLICT (id) DO UPDATE
+SET status = 'failed',
+    attempt = 5,
+    max_attempts = 5,
+    available_at = now(),
+    lease_owner = NULL,
+    lease_expires_at = NULL,
+    last_error_code = 'E2E_TERMINAL_FAILURE',
+    last_error_message = 'Simulated terminal processing failure',
+    finished_at = now(),
+    updated_at = now();

--- a/tests/e2e/repository-upload-contract.functional.spec.ts
+++ b/tests/e2e/repository-upload-contract.functional.spec.ts
@@ -77,9 +77,39 @@ test.describe('Unified repository upload contract (authenticated)', () => {
 
     await expect(dialog).toBeHidden()
     await expect(page.getByText(itemName, { exact: true })).toBeVisible()
-    await expect(
-      page.getByRole('row').filter({ hasText: itemName })
-    ).toContainText(/Processed|Completed/i)
+    const itemRow = page.getByRole('row').filter({ hasText: itemName })
+    await expect(itemRow).toContainText(
+      // Local E2E keeps rollout flags disabled to avoid writing to a real S3
+      // bucket. Enabled canonical state projection is covered below with the
+      // deterministic failed-job fixture and by the PostgreSQL smoke suite.
+      /Processed|Pending|Processing|Retrying|Generating Embeddings|Embedded/i
+    )
+  })
+
+  test.describe('terminal processing recovery', () => {
+    // This intentionally mutates the one deterministic failed job to pending.
+    // Retrying the test itself would no longer start from the seeded state.
+    test.describe.configure({ retries: 0 })
+
+    test('shows the canonical failure and restarts it from the item row', async ({ page }) => {
+      await page.goto('/repositories')
+      const repositoryRow = page
+        .getByRole('row')
+        .filter({ hasText: 'E2E Unified Content Repository' })
+      await repositoryRow.getByRole('button').first().click()
+
+      const itemName = 'E2E failed processing fixture'
+      const itemRow = page.getByRole('row').filter({ hasText: itemName })
+      await expect(itemRow).toContainText('Failed')
+      await expect(itemRow).toContainText('Simulated terminal processing failure')
+
+      await itemRow
+        .getByRole('button', { name: `Retry processing ${itemName}` })
+        .click()
+
+      await expect(itemRow).toContainText('Pending')
+      await expect(itemRow).not.toContainText('Simulated terminal processing failure')
+    })
   })
 
   test('uploads and completes a canonical PDF without invoking the legacy action', async ({ page }) => {

--- a/tests/smoke/unified-content-foundation.smoke.ts
+++ b/tests/smoke/unified-content-foundation.smoke.ts
@@ -12,7 +12,7 @@
  */
 
 import assert from "node:assert/strict";
-import { eq, type SQL } from "drizzle-orm";
+import { eq, sql, type SQL } from "drizzle-orm";
 import { PDFDocument, StandardFonts } from "pdf-lib";
 import * as XLSX from "@e965/xlsx";
 import { closeDatabase, executeQuery } from "@/lib/db/drizzle-client";
@@ -32,6 +32,7 @@ import {
   extractOfficeDocument,
   extractCanonicalTextDocument,
   buildImageSearchDocument,
+  CONTENT_PROCESSING_MAX_ATTEMPTS,
   DEFAULT_CONTENT_PLATFORM_CONFIG,
   completeRepositoryUpload,
   initiateRepositoryUpload,
@@ -40,7 +41,9 @@ import {
   IMAGE_PROCESSOR_VERSION,
   publishDocumentVersion,
   publishPdfVersion,
+  getCanonicalRepositoryItemStatuses,
   registerCanonicalUpload,
+  retryCanonicalRepositoryItem,
   segmentPdfPages,
   type RepositoryUploadStorage,
 } from "@/lib/repositories/content-platform";
@@ -48,6 +51,7 @@ import { keywordSearch } from "@/lib/repositories/search-service";
 import { retrieveRepositoryContent } from "@/lib/repositories/retrieval-v2/service";
 import {
   activateCompletedGeneration,
+  type GenerationActivationExecutor,
   type GenerationActivationResult,
 } from "../../infra/lambdas/embedding-generator/generation-activation";
 
@@ -157,7 +161,7 @@ try {
           repositoryId: repository.id,
           type: "document",
           name: "reference.pdf",
-          source: `repositories/${repository.id}/fixture/reference.pdf`,
+          source: `repositories/${repository.id}/11111111-2222-4333-8444-555555555555/reference.pdf`,
           processingStatus: "pending",
         })
         .returning({ id: repositoryItems.id }),
@@ -168,7 +172,7 @@ try {
   const input = {
     itemId: item.id,
     userId: owner.id,
-    objectKey: `repositories/${repository.id}/fixture/reference.pdf`,
+    objectKey: `repositories/${repository.id}/11111111-2222-4333-8444-555555555555/reference.pdf`,
     originalFileName: "reference.pdf",
     declaredContentType: "application/pdf",
     byteSize: 4096,
@@ -212,7 +216,130 @@ try {
   assert.equal(jobs.length, 1);
   assert.equal(first.version.storageStatus, "quarantined");
   assert.equal(first.inspectJob.status, "pending");
+  assert.equal(first.inspectJob.maxAttempts, CONTENT_PROCESSING_MAX_ATTEMPTS);
   assert.equal(updatedItem?.currentVersionId, first.version.id);
+
+  await executeQuery(
+    (db) =>
+      db
+        .update(repositoryProcessingJobs)
+        .set({
+          metrics: {
+            waitReason: "AWAITING_SECURITY_SCAN",
+            waitStartedAt: "2026-07-22T12:00:00.000Z",
+          },
+        })
+        .where(eq(repositoryProcessingJobs.id, first.inspectJob.id)),
+    "smoke.unifiedContent.persistWaitDeadline"
+  );
+  const [waitingJob] = await executeQuery(
+    (db) =>
+      db
+        .select({ metrics: repositoryProcessingJobs.metrics })
+        .from(repositoryProcessingJobs)
+        .where(eq(repositoryProcessingJobs.id, first.inspectJob.id))
+        .limit(1),
+    "smoke.unifiedContent.readWaitDeadline"
+  );
+  assert.deepEqual(waitingJob?.metrics, {
+    waitReason: "AWAITING_SECURITY_SCAN",
+    waitStartedAt: "2026-07-22T12:00:00.000Z",
+  });
+
+  const [retryItem] = await executeQuery(
+    (db) =>
+      db
+        .insert(repositoryItems)
+        .values({
+          repositoryId: repository.id,
+          type: "document",
+          name: "retry-reference.pdf",
+          source: `repositories/${repository.id}/22222222-3333-4444-8555-666666666666/retry-reference.pdf`,
+          processingStatus: "pending",
+        })
+        .returning({ id: repositoryItems.id }),
+    "smoke.unifiedContent.createRetryItem"
+  );
+  assert.ok(retryItem);
+  const retryRegistration = await registerCanonicalUpload({
+    itemId: retryItem.id,
+    userId: owner.id,
+    objectKey: `repositories/${repository.id}/22222222-3333-4444-8555-666666666666/retry-reference.pdf`,
+    originalFileName: "retry-reference.pdf",
+    declaredContentType: "application/pdf",
+    byteSize: 4096,
+    traceId: "unified-content-smoke-retry",
+  });
+  await executeQuery(
+    (db) =>
+      db.execute(sql`
+        WITH failed_job AS (
+          UPDATE repository_processing_jobs
+          SET status = 'failed',
+              attempt = max_attempts,
+              last_error_message = 'simulated terminal processing failure',
+              finished_at = now()
+          WHERE id = ${retryRegistration.inspectJob.id}::uuid
+          RETURNING item_version_id
+        ), failed_version AS (
+          UPDATE repository_item_versions
+          SET inspection_status = 'error', processing_status = 'failed'
+          WHERE id IN (SELECT item_version_id FROM failed_job)
+          RETURNING item_id
+        )
+        UPDATE repository_items
+        SET processing_status = 'failed',
+            processing_error = 'simulated terminal processing failure'
+        WHERE id IN (SELECT item_id FROM failed_version)
+      `),
+    "smoke.unifiedContent.createTerminalRetryState"
+  );
+  const failedStatuses = await getCanonicalRepositoryItemStatuses(repository.id);
+  assert.deepEqual(failedStatuses.get(retryItem.id), {
+    itemId: retryItem.id,
+    processingStatus: "failed",
+    processingError: "simulated terminal processing failure",
+    canRetry: true,
+  });
+  const restarted = await retryCanonicalRepositoryItem(
+    retryItem.id,
+    "unified-content-smoke-manual-retry"
+  );
+  assert.equal(restarted.itemVersionId, retryRegistration.version.id);
+  assert.equal(restarted.processingJobId, retryRegistration.inspectJob.id);
+  const [restartedState] = await executeQuery(
+    (db) =>
+      db
+        .select({
+          jobStatus: repositoryProcessingJobs.status,
+          attempt: repositoryProcessingJobs.attempt,
+          maxAttempts: repositoryProcessingJobs.maxAttempts,
+          versionStatus: repositoryItemVersions.processingStatus,
+          storageStatus: repositoryItemVersions.storageStatus,
+          itemStatus: repositoryItems.processingStatus,
+        })
+        .from(repositoryProcessingJobs)
+        .innerJoin(
+          repositoryItemVersions,
+          eq(repositoryItemVersions.id, repositoryProcessingJobs.itemVersionId)
+        )
+        .innerJoin(
+          repositoryItems,
+          eq(repositoryItems.id, repositoryItemVersions.itemId)
+        )
+        .where(eq(repositoryProcessingJobs.id, retryRegistration.inspectJob.id))
+        .limit(1),
+    "smoke.unifiedContent.readRestartedState"
+  );
+  assert.equal(restartedState?.jobStatus, "pending");
+  assert.equal(restartedState?.attempt, CONTENT_PROCESSING_MAX_ATTEMPTS);
+  assert.equal(
+    restartedState?.maxAttempts,
+    CONTENT_PROCESSING_MAX_ATTEMPTS * 2
+  );
+  assert.equal(restartedState?.versionStatus, "pending");
+  assert.equal(restartedState?.storageStatus, "quarantined");
+  assert.equal(restartedState?.itemStatus, "pending");
 
   const publication = await publishPdfVersion({
     itemVersionId: first.version.id,
@@ -400,7 +527,7 @@ try {
           repositoryId: repository.id,
           type: "text",
           name: "Canonical text smoke",
-          source: `repositories/${repository.id}/fixture/reference.txt`,
+          source: `repositories/${repository.id}/11111111-2222-4333-8444-555555555555/reference.txt`,
           processingStatus: "pending",
         })
         .returning({ id: repositoryItems.id }),
@@ -410,7 +537,7 @@ try {
   const textRegistration = await registerCanonicalUpload({
     itemId: textItem.id,
     userId: owner.id,
-    objectKey: `repositories/${repository.id}/fixture/reference.txt`,
+    objectKey: `repositories/${repository.id}/11111111-2222-4333-8444-555555555555/reference.txt`,
     originalFileName: "reference.txt",
     declaredContentType: "text/plain",
     byteSize: 64,
@@ -457,7 +584,7 @@ try {
           repositoryId: repository.id,
           type: "document",
           name: "directory.xlsx",
-          source: `repositories/${repository.id}/fixture/directory.xlsx`,
+          source: `repositories/${repository.id}/11111111-2222-4333-8444-555555555555/directory.xlsx`,
           processingStatus: "pending",
         })
         .returning({ id: repositoryItems.id }),
@@ -467,7 +594,7 @@ try {
   const officeRegistration = await registerCanonicalUpload({
     itemId: officeItem.id,
     userId: owner.id,
-    objectKey: `repositories/${repository.id}/fixture/directory.xlsx`,
+    objectKey: `repositories/${repository.id}/11111111-2222-4333-8444-555555555555/directory.xlsx`,
     originalFileName: "directory.xlsx",
     declaredContentType: OFFICE_CONTENT_TYPES.xlsx,
     byteSize: 4096,
@@ -536,7 +663,7 @@ try {
           repositoryId: repository.id,
           type: "image",
           name: "evacuation-map.png",
-          source: `repositories/${repository.id}/fixture/evacuation-map.png`,
+          source: `repositories/${repository.id}/11111111-2222-4333-8444-555555555555/evacuation-map.png`,
           processingStatus: "pending",
         })
         .returning({ id: repositoryItems.id }),
@@ -546,7 +673,7 @@ try {
   const imageRegistration = await registerCanonicalUpload({
     itemId: imageItem.id,
     userId: owner.id,
-    objectKey: `repositories/${repository.id}/fixture/evacuation-map.png`,
+    objectKey: `repositories/${repository.id}/11111111-2222-4333-8444-555555555555/evacuation-map.png`,
     originalFileName: "evacuation-map.png",
     declaredContentType: "image/png",
     byteSize: 1024,
@@ -577,7 +704,7 @@ try {
       {
         kind: "image" as const,
         mediaType: "image/png",
-        objectKey: `repositories/${repository.id}/fixture/evacuation-map.png`,
+        objectKey: `repositories/${repository.id}/11111111-2222-4333-8444-555555555555/evacuation-map.png`,
         sha256: "a".repeat(64),
       },
       {
@@ -600,6 +727,8 @@ try {
     ],
     embeddingModel: "amazon-bedrock:amazon.titan-embed-text-v1",
     embeddingDimensions: 1536,
+    visualEmbeddingModel: "amazon-bedrock:cohere.embed-v4:0",
+    visualEmbeddingDimensions: 1536,
     segmentationVersion: "retrieval-v2",
   };
   const imagePublication = await publishDocumentVersion(imagePublicationInput);
@@ -641,17 +770,50 @@ try {
     canonicalOnly: true,
   });
   assert.equal(imageResultsBeforeActivation.length, 0);
+  const activationExecutor: GenerationActivationExecutor = async (query) => {
+    const rows = await executeQuery(
+      // The Lambda package has its own dependency boundary, so bridge its
+      // structurally identical Drizzle SQL object into the app workspace.
+      (db) => db.execute(query as unknown as SQL),
+      "smoke.unifiedContent.activateEmbeddedGeneration"
+    );
+    return rows as unknown as GenerationActivationResult[];
+  };
+  const incompleteActivation = await activateCompletedGeneration(
+    imagePublication.generationId,
+    activationExecutor
+  );
+  assert.equal(incompleteActivation, null);
+
+  const smokeVector = `[${Array.from({ length: 1536 }, () => "0.001").join(",")}]`;
+  await executeQuery(
+    (db) =>
+      db.execute(sql`
+        UPDATE repository_item_chunks
+        SET embedding = ${smokeVector}::vector
+        WHERE index_generation_id = ${imagePublication.generationId}::uuid
+      `),
+    "smoke.unifiedContent.completeTextEmbeddings"
+  );
+  const missingVisualActivation = await activateCompletedGeneration(
+    imagePublication.generationId,
+    activationExecutor
+  );
+  assert.equal(missingVisualActivation, null);
+
+  await executeQuery(
+    (db) =>
+      db.execute(sql`
+        UPDATE repository_item_chunks
+        SET visual_embedding = ${smokeVector}::vector
+        WHERE index_generation_id = ${imagePublication.generationId}::uuid
+          AND modality IN ('image', 'video')
+      `),
+    "smoke.unifiedContent.completeVisualEmbeddings"
+  );
   const activation = await activateCompletedGeneration(
     imagePublication.generationId,
-    async (query) => {
-      const rows = await executeQuery(
-        // The Lambda package has its own dependency boundary, so bridge its
-        // structurally identical Drizzle SQL object into the app workspace.
-        (db) => db.execute(query as unknown as SQL),
-        "smoke.unifiedContent.activateEmbeddedGeneration"
-      );
-      return rows as unknown as GenerationActivationResult[];
-    }
+    activationExecutor
   );
   assert.equal(activation?.repository_id, repository.id);
   assert.ok((activation?.embedded_item_count ?? 0) >= 3);

--- a/tests/unit/actions/repositories/repository-items-actions.test.ts
+++ b/tests/unit/actions/repositories/repository-items-actions.test.ts
@@ -28,8 +28,21 @@ const mockDispatchContentProcessingJob = jest.fn<(...a: unknown[]) => Promise<vo
 )
 const mockGetDocumentObjectMetadata = jest.fn<(...a: unknown[]) => Promise<unknown>>()
 const mockGetDocumentSignedUrl = jest.fn<(...a: unknown[]) => Promise<string>>()
+const mockCopyRepositorySourceToCanonicalNamespace = jest.fn<
+  (...a: unknown[]) => Promise<{ key: string }>
+>()
 const mockDeleteRepositoryItem = jest.fn<(...a: unknown[]) => Promise<number>>()
 const mockDeleteRepositoryItemStorage = jest.fn<(...a: unknown[]) => Promise<unknown>>()
+const mockGetCanonicalRepositoryItemStatuses = jest.fn<
+  (...a: unknown[]) => Promise<Map<number, {
+    processingStatus: string
+    processingError: string | null
+    canRetry: boolean
+  }>>
+>(() => Promise.resolve(new Map()))
+const mockRetryCanonicalRepositoryItem = jest.fn<
+  (...a: unknown[]) => Promise<{ itemVersionId: string; processingJobId: string }>
+>()
 const mockRegisterCanonicalTextIfEnabled = jest.fn<
   (...a: unknown[]) => Promise<unknown>
 >(() => Promise.resolve(null))
@@ -70,6 +83,7 @@ jest.mock('@/lib/db/drizzle-client', () => ({
   repositoryItemChunks: mockRepositoryItemChunksTable,
 }))
 jest.mock('@/lib/aws/s3-client', () => ({
+  copyRepositorySourceToCanonicalNamespace: mockCopyRepositorySourceToCanonicalNamespace,
   uploadDocument: mockUploadDocument,
   deleteDocument: jest.fn(),
   getDocumentObjectMetadata: mockGetDocumentObjectMetadata,
@@ -86,10 +100,18 @@ jest.mock('@/lib/repositories/content-platform', () => ({
     'text/markdown',
     'text/csv',
   ].includes(contentType),
+  isRepositorySourceObjectKey: (repositoryId: number, objectKey: string) =>
+    new RegExp(
+      `^repositories/${repositoryId}/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/[^/]+$`,
+      'i'
+    ).test(objectKey) &&
+    !objectKey.includes('..'),
   registerCanonicalTextIfEnabled: mockRegisterCanonicalTextIfEnabled,
   registerCanonicalUploadIfEnabled: mockRegisterCanonicalUploadIfEnabled,
   dispatchContentProcessingJob: mockDispatchContentProcessingJob,
   deleteRepositoryItemStorage: mockDeleteRepositoryItemStorage,
+  getCanonicalRepositoryItemStatuses: mockGetCanonicalRepositoryItemStatuses,
+  retryCanonicalRepositoryItem: mockRetryCanonicalRepositoryItem,
 }))
 jest.mock('next/cache', () => ({ revalidatePath: jest.fn() }))
 jest.mock('@/lib/logger', () => ({
@@ -106,6 +128,7 @@ describe('repository-items.actions (REV-COR-061 / REV-SEC-062 / REV-COR-068)', (
     mockHasCapabilityAccess.mockResolvedValue(true)
     mockGetUserIdFromSession.mockResolvedValue(1)
     mockCanModifyRepository.mockResolvedValue(true)
+    mockGetRepositoryItems.mockResolvedValue([])
     mockAssertRepositoryReadAccess.mockResolvedValue(undefined)
     mockAssertItemRepositoryReadAccess.mockResolvedValue(undefined)
     mockAssertNotSystemManagedRepository.mockResolvedValue(undefined)
@@ -113,9 +136,10 @@ describe('repository-items.actions (REV-COR-061 / REV-SEC-062 / REV-COR-068)', (
     mockRegisterCanonicalTextIfEnabled.mockResolvedValue(null)
     mockExecuteTransaction.mockReset()
     mockDispatchContentProcessingJob.mockResolvedValue(undefined)
+    mockUpdateRepositoryItemStatus.mockResolvedValue(undefined)
     mockUploadDocument.mockResolvedValue({
-      key: 'repositories/7/direct/document.pdf',
-      url: 's3://documents/repositories/7/direct/document.pdf',
+      key: 'repositories/7/11111111-2222-4333-8444-555555555555/document.pdf',
+      url: 's3://documents/repositories/7/11111111-2222-4333-8444-555555555555/document.pdf',
     })
     mockQueueFileForProcessing.mockResolvedValue('legacy-job')
     mockGetDocumentObjectMetadata.mockResolvedValue({
@@ -125,10 +149,18 @@ describe('repository-items.actions (REV-COR-061 / REV-SEC-062 / REV-COR-068)', (
       metadata: {},
     })
     mockGetDocumentSignedUrl.mockResolvedValue('https://download')
+    mockCopyRepositorySourceToCanonicalNamespace.mockResolvedValue({
+      key: 'repositories/5/11111111-2222-4333-8444-555555555555/legacy.pdf',
+    })
     mockDeleteRepositoryItem.mockResolvedValue(1)
     mockDeleteRepositoryItemStorage.mockResolvedValue({
       sourceObjectCount: 1,
       artifactObjectCount: 3,
+    })
+    mockGetCanonicalRepositoryItemStatuses.mockResolvedValue(new Map())
+    mockRetryCanonicalRepositoryItem.mockResolvedValue({
+      itemVersionId: 'aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee',
+      processingJobId: 'ffffffff-1111-4222-8333-444444444444',
     })
   })
 
@@ -143,6 +175,132 @@ describe('repository-items.actions (REV-COR-061 / REV-SEC-062 / REV-COR-068)', (
     const res = await mod.listRepositoryItems(5)
     expect(res.isSuccess).toBe(true)
     expect(mockGetRepositoryItems).toHaveBeenCalledWith(5)
+  })
+
+  it('projects canonical failure state instead of a misleading legacy completion', async () => {
+    mockGetRepositoryItems.mockResolvedValue([{
+      id: 38,
+      repositoryId: 5,
+      type: 'text',
+      name: 'Inline notes',
+      source: 'content',
+      metadata: {},
+      processingStatus: 'completed',
+      processingError: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    }])
+    mockGetCanonicalRepositoryItemStatuses.mockResolvedValue(new Map([[38, {
+      processingStatus: 'failed',
+      processingError: 'Item version object key is outside its repository namespace',
+      canRetry: true,
+    }]]))
+
+    const result = await mod.listRepositoryItems(5)
+
+    expect(result.isSuccess).toBe(true)
+    expect(result.data).toEqual([
+      expect.objectContaining({
+        id: 38,
+        processingStatus: 'failed',
+        processingError: 'Item version object key is outside its repository namespace',
+        canRetry: true,
+      }),
+    ])
+  })
+
+  it('retries a failed canonical item through its durable job', async () => {
+    mockGetRepositoryItemById.mockResolvedValue({
+      id: 38,
+      repositoryId: 5,
+      type: 'document',
+      source: 'repositories/5/11111111-2222-4333-8444-555555555555/source.pdf',
+      currentVersionId: 'aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee',
+    })
+
+    const result = await mod.retryRepositoryItemProcessing(38)
+
+    expect(result.isSuccess).toBe(true)
+    expect(mockRetryCanonicalRepositoryItem).toHaveBeenCalledWith(38, 't')
+    expect(mockDispatchContentProcessingJob).toHaveBeenCalledWith({
+      jobId: 'ffffffff-1111-4222-8333-444444444444',
+      itemVersionId: 'aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee',
+    })
+  })
+
+  it('repairs failed inline text by creating a fresh immutable source version', async () => {
+    mockGetRepositoryItemById.mockResolvedValue({
+      id: 38,
+      repositoryId: 5,
+      type: 'text',
+      name: 'Inline notes',
+      source: 'ORCHID-COMPASS-742',
+      currentVersionId: 'aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee',
+    })
+    mockRegisterCanonicalTextIfEnabled.mockResolvedValue({
+      created: true,
+      version: { id: 'bbbbbbbb-cccc-4ddd-8eee-ffffffffffff' },
+      inspectJob: { id: 'cccccccc-dddd-4eee-8fff-aaaaaaaaaaaa' },
+    })
+
+    const result = await mod.retryRepositoryItemProcessing(38)
+
+    expect(result.isSuccess).toBe(true)
+    expect(mockRegisterCanonicalTextIfEnabled).toHaveBeenCalledWith({
+      itemId: 38,
+      repositoryId: 5,
+      userId: 1,
+      name: 'Inline notes',
+      content: 'ORCHID-COMPASS-742',
+      traceId: 't',
+    })
+    expect(mockRetryCanonicalRepositoryItem).not.toHaveBeenCalled()
+    expect(mockDispatchContentProcessingJob).toHaveBeenCalledWith({
+      jobId: 'cccccccc-dddd-4eee-8fff-aaaaaaaaaaaa',
+      itemVersionId: 'bbbbbbbb-cccc-4ddd-8eee-ffffffffffff',
+    })
+  })
+
+  it('repairs a legacy file by copying it into the canonical source namespace', async () => {
+    mockGetRepositoryItemById.mockResolvedValue({
+      id: 39,
+      repositoryId: 5,
+      type: 'document',
+      name: 'Legacy document',
+      source: '1/1700000000-legacy.pdf',
+      metadata: {
+        originalFileName: 'legacy.pdf',
+        contentType: 'application/pdf',
+      },
+      currentVersionId: null,
+    })
+    mockRegisterCanonicalUploadIfEnabled.mockResolvedValue({
+      created: true,
+      version: { id: 'bbbbbbbb-cccc-4ddd-8eee-ffffffffffff' },
+      inspectJob: { id: 'cccccccc-dddd-4eee-8fff-aaaaaaaaaaaa' },
+    })
+
+    const result = await mod.retryRepositoryItemProcessing(39)
+
+    expect(result.isSuccess).toBe(true)
+    expect(mockCopyRepositorySourceToCanonicalNamespace).toHaveBeenCalledWith({
+      repositoryId: 5,
+      sourceKey: '1/1700000000-legacy.pdf',
+      fileName: 'legacy.pdf',
+    })
+    expect(mockRegisterCanonicalUploadIfEnabled).toHaveBeenCalledWith({
+      itemId: 39,
+      userId: 1,
+      objectKey: 'repositories/5/11111111-2222-4333-8444-555555555555/legacy.pdf',
+      originalFileName: 'legacy.pdf',
+      declaredContentType: 'application/pdf',
+      byteSize: 1,
+      traceId: 't',
+    })
+    expect(mockDispatchContentProcessingJob).toHaveBeenCalledWith({
+      jobId: 'cccccccc-dddd-4eee-8fff-aaaaaaaaaaaa',
+      itemVersionId: 'bbbbbbbb-cccc-4ddd-8eee-ffffffffffff',
+    })
   })
 
   it('addDocumentWithPresignedUrl rejects an s3Key outside the repository namespace (REV-SEC-062)', async () => {
@@ -164,7 +322,7 @@ describe('repository-items.actions (REV-COR-061 / REV-SEC-062 / REV-COR-068)', (
     const res = await mod.addDocumentWithPresignedUrl({
       repository_id: 7,
       name: 'doc',
-      s3Key: 'repositories/7/11111111-2222-3333-4444-555555555555/doc.pdf',
+      s3Key: 'repositories/7/11111111-2222-4333-8444-555555555555/doc.pdf',
       metadata: { contentType: 'application/pdf', size: 1, originalFileName: 'doc.pdf' },
     })
     expect(res.isSuccess).toBe(true)
@@ -172,12 +330,25 @@ describe('repository-items.actions (REV-COR-061 / REV-SEC-062 / REV-COR-068)', (
     expect(mockRegisterCanonicalUploadIfEnabled).toHaveBeenCalledWith({
       itemId: 1,
       userId: 1,
-      objectKey: 'repositories/7/11111111-2222-3333-4444-555555555555/doc.pdf',
+      objectKey: 'repositories/7/11111111-2222-4333-8444-555555555555/doc.pdf',
       originalFileName: 'doc.pdf',
       declaredContentType: 'application/pdf',
       byteSize: 1,
       traceId: 't',
     })
+  })
+
+  it('rejects a nested repository key that the canonical worker cannot process', async () => {
+    const res = await mod.addDocumentWithPresignedUrl({
+      repository_id: 7,
+      name: 'doc',
+      s3Key: 'repositories/7/inline/11111111-2222-4333-8444-555555555555/doc.pdf',
+      metadata: { contentType: 'application/pdf', size: 1, originalFileName: 'doc.pdf' },
+    })
+
+    expect(res.isSuccess).toBe(false)
+    expect(mockGetDocumentObjectMetadata).not.toHaveBeenCalled()
+    expect(mockCreateRepositoryItem).not.toHaveBeenCalled()
   })
 
   it('dispatches a canonical shadow-write job without replacing the legacy flow', async () => {
@@ -211,7 +382,7 @@ describe('repository-items.actions (REV-COR-061 / REV-SEC-062 / REV-COR-068)', (
       repositoryId: 7,
       type: 'document',
       name: 'Direct document',
-      source: 'repositories/7/direct/document.pdf',
+      source: 'repositories/7/11111111-2222-4333-8444-555555555555/document.pdf',
       metadata: {},
       processingStatus: 'pending',
       processingError: null,
@@ -236,10 +407,14 @@ describe('repository-items.actions (REV-COR-061 / REV-SEC-062 / REV-COR-068)', (
     })
 
     expect(result.isSuccess).toBe(true)
+    expect(mockUploadDocument).toHaveBeenCalledWith(expect.objectContaining({
+      repositoryId: 7,
+      fileName: 'document.pdf',
+    }))
     expect(mockRegisterCanonicalUploadIfEnabled).toHaveBeenCalledWith({
       itemId: 4,
       userId: 1,
-      objectKey: 'repositories/7/direct/document.pdf',
+      objectKey: 'repositories/7/11111111-2222-4333-8444-555555555555/document.pdf',
       originalFileName: 'document.pdf',
       declaredContentType: 'application/pdf',
       byteSize: 9,
@@ -251,7 +426,7 @@ describe('repository-items.actions (REV-COR-061 / REV-SEC-062 / REV-COR-068)', (
     })
     expect(mockQueueFileForProcessing).toHaveBeenCalledWith(
       4,
-      'repositories/7/direct/document.pdf',
+      'repositories/7/11111111-2222-4333-8444-555555555555/document.pdf',
       'Direct document',
       'application/pdf'
     )
@@ -267,7 +442,7 @@ describe('repository-items.actions (REV-COR-061 / REV-SEC-062 / REV-COR-068)', (
     const res = await mod.addDocumentWithPresignedUrl({
       repository_id: 7,
       name: 'doc',
-      s3Key: 'repositories/7/11111111-2222-3333-4444-555555555555/doc.pdf',
+      s3Key: 'repositories/7/11111111-2222-4333-8444-555555555555/doc.pdf',
       metadata: { contentType: 'application/pdf', size: 1, originalFileName: 'doc.pdf' },
     })
 
@@ -341,7 +516,7 @@ describe('repository-items.actions (REV-COR-061 / REV-SEC-062 / REV-COR-068)', (
     const res = await mod.addDocumentWithPresignedUrl({
       repository_id: 7,
       name: 'doc',
-      s3Key: 'repositories/7/11111111-2222-3333-4444-555555555555/doc.pdf',
+      s3Key: 'repositories/7/11111111-2222-4333-8444-555555555555/doc.pdf',
       metadata: { contentType: 'application/pdf', size: 1, originalFileName: 'doc.pdf' },
     })
 
@@ -380,10 +555,58 @@ describe('repository-items.actions (REV-COR-061 / REV-SEC-062 / REV-COR-068)', (
     const result = await mod.removeRepositoryItem(9)
 
     expect(result.isSuccess).toBe(true)
-    expect(mockDeleteRepositoryItemStorage).toHaveBeenCalledWith(image)
+    expect(mockDeleteRepositoryItemStorage).toHaveBeenCalledWith(
+      expect.objectContaining(image)
+    )
     expect(mockDeleteRepositoryItemStorage.mock.invocationCallOrder[0]).toBeLessThan(
       mockDeleteRepositoryItem.mock.invocationCallOrder[0]
     )
+  })
+
+  it('cleans canonical storage for inline text before deleting its manifest', async () => {
+    const textItem = {
+      id: 11,
+      repositoryId: 5,
+      type: 'text',
+      name: 'Emergency notes',
+      source: 'Inline text is not an S3 key',
+      metadata: {},
+      processingStatus: 'completed',
+      processingError: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    }
+    mockGetRepositoryItemById.mockResolvedValue(textItem)
+
+    const result = await mod.removeRepositoryItem(11)
+
+    expect(result.isSuccess).toBe(true)
+    expect(mockDeleteRepositoryItemStorage).toHaveBeenCalledWith(
+      expect.objectContaining(textItem)
+    )
+  })
+
+  it('preserves the item manifest when storage cleanup fails', async () => {
+    mockGetRepositoryItemById.mockResolvedValue({
+      id: 12,
+      repositoryId: 5,
+      type: 'video',
+      name: 'Training video',
+      source: 'repositories/5/11111111-2222-4333-8444-555555555555/training.mp4',
+      metadata: {},
+      processingStatus: 'completed',
+      processingError: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    })
+    mockDeleteRepositoryItemStorage.mockRejectedValueOnce(
+      new Error('storage unavailable')
+    )
+
+    const result = await mod.removeRepositoryItem(12)
+
+    expect(result.isSuccess).toBe(false)
+    expect(mockDeleteRepositoryItem).not.toHaveBeenCalled()
   })
 
   it('generates image download URLs through database-first S3 settings', async () => {

--- a/tests/unit/lib/repositories/content-platform-dispatch.test.ts
+++ b/tests/unit/lib/repositories/content-platform-dispatch.test.ts
@@ -1,0 +1,51 @@
+/** @jest-environment node */
+
+jest.mock("@aws-sdk/client-sqs", () => ({
+  SQSClient: jest.fn(() => ({ send: jest.fn() })),
+  SendMessageCommand: jest.fn((input: unknown) => ({ input })),
+}));
+
+jest.mock("@/lib/db/drizzle-client", () => ({
+  executeQuery: jest.fn(),
+}));
+
+import { SQSClient } from "@aws-sdk/client-sqs";
+import { executeQuery } from "@/lib/db/drizzle-client";
+import { dispatchContentProcessingJob } from "@/lib/repositories/content-platform/dispatch-service";
+
+const mockExecuteQuery = jest.mocked(executeQuery);
+const mockSqsSend = jest.mocked(SQSClient).mock.results[0]?.value.send as jest.Mock;
+
+const message = {
+  jobId: "11111111-2222-4333-8444-555555555555",
+  itemVersionId: "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee",
+};
+
+describe("canonical processing dispatch", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.CONTENT_PROCESSING_QUEUE_URL =
+      "https://sqs.us-east-1.amazonaws.com/123/content";
+  });
+
+  test("does not enqueue a replayed non-pending job", async () => {
+    mockExecuteQuery.mockResolvedValueOnce([]);
+
+    await dispatchContentProcessingJob(message);
+
+    expect(mockExecuteQuery).toHaveBeenCalledTimes(1);
+    expect(mockSqsSend).not.toHaveBeenCalled();
+  });
+
+  test("enqueues an eligible pending job and performs the guarded state update", async () => {
+    mockExecuteQuery
+      .mockResolvedValueOnce([{ id: message.jobId }])
+      .mockResolvedValueOnce([]);
+    mockSqsSend.mockResolvedValueOnce({ MessageId: "message-1" });
+
+    await dispatchContentProcessingJob(message);
+
+    expect(mockSqsSend).toHaveBeenCalledTimes(1);
+    expect(mockExecuteQuery).toHaveBeenCalledTimes(2);
+  });
+});

--- a/tests/unit/lib/repositories/content-platform-ingestion.test.ts
+++ b/tests/unit/lib/repositories/content-platform-ingestion.test.ts
@@ -22,6 +22,7 @@ describe("canonical upload registration rollout", () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    mockExecuteTransaction.mockReset();
     mockGetSettings.mockResolvedValue({});
   });
 
@@ -70,5 +71,40 @@ describe("canonical upload registration rollout", () => {
       })
     ).rejects.toThrow("SHA-256");
     expect(mockExecuteTransaction).not.toHaveBeenCalled();
+  });
+
+  it("rejects an object key owned by a different repository", async () => {
+    const forUpdate = jest.fn(() =>
+      Promise.resolve([{ id: 1, repositoryId: 3 }])
+    );
+    const tx = {
+      select: jest.fn(() => ({
+        from: jest.fn(() => ({
+          where: jest.fn(() => ({
+            limit: jest.fn(() => ({ for: forUpdate })),
+          })),
+        })),
+      })),
+    };
+    mockExecuteTransaction.mockImplementation(async (...args: unknown[]) => {
+      const operation = args[0];
+      if (typeof operation !== "function") {
+        throw new Error("Expected a transaction callback");
+      }
+      return (operation as (transaction: unknown) => Promise<unknown>)(tx);
+    });
+
+    await expect(
+      registerCanonicalUpload({
+        itemId: 1,
+        userId: 2,
+        objectKey:
+          "repositories/4/11111111-2222-4333-8444-555555555555/document.pdf",
+        originalFileName: "document.pdf",
+        declaredContentType: "application/pdf",
+        byteSize: 1024,
+      })
+    ).rejects.toThrow("outside the repository source namespace");
+    expect(forUpdate).toHaveBeenCalledWith("update");
   });
 });

--- a/tests/unit/lib/repositories/content-platform-inline-text.test.ts
+++ b/tests/unit/lib/repositories/content-platform-inline-text.test.ts
@@ -25,7 +25,7 @@ describe("canonical inline-text ingestion", () => {
     jest.clearAllMocks();
     mockGetSettings.mockResolvedValue({});
     mockUploadRepositoryTextSource.mockResolvedValue({
-      key: "repositories/7/inline/source.txt",
+      key: "repositories/7/11111111-2222-4333-8444-555555555555/source.txt",
       byteSize: 11,
     });
     mockRegisterCanonicalUpload.mockResolvedValue({
@@ -83,7 +83,8 @@ describe("canonical inline-text ingestion", () => {
     expect(mockRegisterCanonicalUpload).toHaveBeenCalledWith({
       itemId: 3,
       userId: 1,
-      objectKey: "repositories/7/inline/source.txt",
+      objectKey:
+        "repositories/7/11111111-2222-4333-8444-555555555555/source.txt",
       originalFileName: "Quick_reference_notes.txt",
       declaredContentType: "text/plain",
       byteSize: 11,

--- a/tests/unit/lib/repositories/content-platform-job-state.test.ts
+++ b/tests/unit/lib/repositories/content-platform-job-state.test.ts
@@ -3,6 +3,7 @@
 import {
   buildProcessingIdempotencyKey,
   canTransitionProcessingJob,
+  CONTENT_PROCESSING_MAX_ATTEMPTS,
   CONTENT_SWEEP_REDISPATCHABLE_STATUSES,
   transitionProcessingJob,
   type ProcessingJobState,
@@ -24,6 +25,10 @@ function pendingState(): ProcessingJobState {
 }
 
 describe("repository processing job state", () => {
+  it("bounds one automatic processing budget to five attempts", () => {
+    expect(CONTENT_PROCESSING_MAX_ATTEMPTS).toBe(5);
+  });
+
   it("runs the happy-path state machine with a bounded lease", () => {
     const queued = transitionProcessingJob(pendingState(), { type: "queue" }, now);
     const running = transitionProcessingJob(

--- a/tests/unit/lib/repositories/content-platform-object-key.test.ts
+++ b/tests/unit/lib/repositories/content-platform-object-key.test.ts
@@ -1,0 +1,47 @@
+/** @jest-environment node */
+
+import {
+  buildRepositorySourceObjectKey,
+  isRepositorySourceObjectKey,
+} from "@/lib/repositories/content-platform/object-key";
+
+describe("repository source object key contract", () => {
+  const sourceId = "11111111-2222-4333-8444-555555555555";
+
+  it("builds the exact two-segment namespace accepted by the processor", () => {
+    const key = buildRepositorySourceObjectKey(7, "handbook.pdf", sourceId);
+
+    expect(key).toBe(`repositories/7/${sourceId}/handbook.pdf`);
+    expect(isRepositorySourceObjectKey(7, key)).toBe(true);
+  });
+
+  it("rejects cross-repository, legacy nested, artifact, and traversal keys", () => {
+    expect(
+      isRepositorySourceObjectKey(8, `repositories/7/${sourceId}/handbook.pdf`)
+    ).toBe(false);
+    expect(
+      isRepositorySourceObjectKey(
+        7,
+        `repositories/7/inline/${sourceId}/handbook.pdf`
+      )
+    ).toBe(false);
+    expect(
+      isRepositorySourceObjectKey(
+        7,
+        `repositories/7/artifacts/${sourceId}/canonical.md`
+      )
+    ).toBe(false);
+    expect(
+      isRepositorySourceObjectKey(7, `repositories/7/${sourceId}/../secret.pdf`)
+    ).toBe(false);
+  });
+
+  it("refuses unsafe file names before creating an S3 key", () => {
+    expect(() =>
+      buildRepositorySourceObjectKey(7, "../secret.pdf", sourceId)
+    ).toThrow("safe file name");
+    expect(() =>
+      buildRepositorySourceObjectKey(7, "folder/secret.pdf", sourceId)
+    ).toThrow("safe file name");
+  });
+});

--- a/tests/unit/lib/repositories/content-platform-status.test.ts
+++ b/tests/unit/lib/repositories/content-platform-status.test.ts
@@ -1,0 +1,118 @@
+/** @jest-environment node */
+
+import { describe, expect, it } from "@jest/globals";
+import { resolveCanonicalItemStatus } from "@/lib/repositories/content-platform/status-service";
+
+function statusRow(
+  overrides: Partial<Parameters<typeof resolveCanonicalItemStatus>[0]> = {}
+): Parameters<typeof resolveCanonicalItemStatus>[0] {
+  return {
+    itemId: 7,
+    versionStatus: "pending",
+    storageStatus: "quarantined",
+    inspectionStatus: "pending",
+    jobStatus: "pending",
+    jobAttempt: 0,
+    jobMaxAttempts: 3,
+    jobError: null,
+    active: false,
+    buildingGeneration: false,
+    failedGeneration: false,
+    generationError: null,
+    ...overrides,
+  };
+}
+
+describe("canonical repository item status", () => {
+  it("treats an active canonical generation as authoritative", () => {
+    expect(
+      resolveCanonicalItemStatus(
+        statusRow({ active: true, jobStatus: "failed", jobError: "stale error" })
+      )
+    ).toEqual({
+      itemId: 7,
+      processingStatus: "embedded",
+      processingError: null,
+      canRetry: false,
+    });
+  });
+
+  it("shows a completed version as embedding until its generation activates", () => {
+    expect(
+      resolveCanonicalItemStatus(
+        statusRow({
+          versionStatus: "completed",
+          storageStatus: "available",
+          inspectionStatus: "clean",
+          jobStatus: "succeeded",
+        })
+      ).processingStatus
+    ).toBe("processing_embeddings");
+  });
+
+  it("exposes terminal job failures and permits a safe retry", () => {
+    expect(
+      resolveCanonicalItemStatus(
+        statusRow({
+          versionStatus: "failed",
+          jobStatus: "failed",
+          jobAttempt: 3,
+          jobMaxAttempts: 3,
+          jobError: "The document could not be parsed",
+        })
+      )
+    ).toEqual({
+      itemId: 7,
+      processingStatus: "failed",
+      processingError: "The document could not be parsed",
+      canRetry: true,
+    });
+  });
+
+  it("does not permit retrying content blocked by security inspection", () => {
+    expect(
+      resolveCanonicalItemStatus(
+        statusRow({
+          versionStatus: "failed",
+          storageStatus: "blocked",
+          inspectionStatus: "blocked",
+        })
+      ).canRetry
+    ).toBe(false);
+  });
+
+  it("keeps transient failed attempts in a retrying state", () => {
+    expect(
+      resolveCanonicalItemStatus(
+        statusRow({ jobStatus: "failed", jobAttempt: 1, jobMaxAttempts: 3 })
+      ).processingStatus
+    ).toBe("retrying");
+  });
+
+  it("does not let an older failed generation mask a user-requested retry", () => {
+    expect(
+      resolveCanonicalItemStatus(
+        statusRow({ failedGeneration: true, jobStatus: "pending" })
+      ).processingStatus
+    ).toBe("pending");
+  });
+
+  it("exposes a terminal failed embedding generation", () => {
+    expect(
+      resolveCanonicalItemStatus(
+        statusRow({
+          versionStatus: "completed",
+          storageStatus: "available",
+          inspectionStatus: "clean",
+          jobStatus: "succeeded",
+          failedGeneration: true,
+          generationError: "Embedding provider rejected the model",
+        })
+      )
+    ).toMatchObject({
+      processingStatus: "failed",
+      processingError: "Embedding provider rejected the model",
+      canRetry: true,
+    });
+  });
+});

--- a/tests/unit/lib/repositories/content-platform-storage-cleanup.test.ts
+++ b/tests/unit/lib/repositories/content-platform-storage-cleanup.test.ts
@@ -68,17 +68,99 @@ describe("canonical repository storage cleanup", () => {
     );
   });
 
-  it("does not touch storage or the database for text and URL items", async () => {
+  it("deletes canonical inline-text source objects without treating raw text as a key", async () => {
+    const cleanupDependencies = dependencies([
+      {
+        id: "11111111-2222-4333-8444-555555555555",
+        objectKey:
+          "repositories/7/aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee/inline.md",
+      },
+    ]);
+    mockDeleteRepositoryObjectsByPrefix.mockResolvedValueOnce(2);
+
     await expect(
       deleteRepositoryItemStorage({
         id: 42,
         repositoryId: 7,
         type: "text",
         source: "inline text",
-      }, dependencies([]))
+      }, cleanupDependencies)
+    ).resolves.toEqual({ sourceObjectCount: 1, artifactObjectCount: 2 });
+
+    expect(mockDeleteDocument).toHaveBeenCalledTimes(1);
+    expect(mockDeleteDocument).toHaveBeenCalledWith(
+      "repositories/7/aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee/inline.md"
+    );
+    expect(mockDeleteDocument).not.toHaveBeenCalledWith("inline text");
+    expect(mockDeleteRepositoryObjectsByPrefix).toHaveBeenCalledWith(
+      "repositories/7/artifacts/11111111-2222-4333-8444-555555555555/"
+    );
+  });
+
+  it.each(["audio", "video"])(
+    "deletes %s sources and BDA artifact namespaces",
+    async (type) => {
+      const cleanupDependencies = dependencies([
+        {
+          id: "11111111-2222-4333-8444-555555555555",
+          objectKey:
+            `repositories/7/aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee/source.${type}`,
+        },
+      ]);
+      mockDeleteRepositoryObjectsByPrefix.mockResolvedValueOnce(4);
+
+      await expect(
+        deleteRepositoryItemStorage(
+          {
+            id: 43,
+            repositoryId: 7,
+            type,
+            source:
+              `repositories/7/aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee/source.${type}`,
+          },
+          cleanupDependencies
+        )
+      ).resolves.toEqual({ sourceObjectCount: 1, artifactObjectCount: 4 });
+
+      expect(mockDeleteDocument).toHaveBeenCalledWith(
+        `repositories/7/aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee/source.${type}`
+      );
+      expect(mockDeleteRepositoryObjectsByPrefix).toHaveBeenCalledWith(
+        "repositories/7/artifacts/11111111-2222-4333-8444-555555555555/"
+      );
+    }
+  );
+
+  it("does not treat URL or legacy inline text sources as object keys", async () => {
+    const textDependencies = dependencies([]);
+    await expect(
+      deleteRepositoryItemStorage(
+        {
+          id: 44,
+          repositoryId: 7,
+          type: "text",
+          source: "legacy inline text",
+        },
+        textDependencies
+      )
+    ).resolves.toEqual({ sourceObjectCount: 0, artifactObjectCount: 0 });
+
+    const urlDependencies = dependencies([]);
+    await expect(
+      deleteRepositoryItemStorage(
+        {
+          id: 45,
+          repositoryId: 7,
+          type: "url",
+          source: "https://example.edu/policy",
+        },
+        urlDependencies
+      )
     ).resolves.toEqual({ sourceObjectCount: 0, artifactObjectCount: 0 });
 
     expect(mockDeleteDocument).not.toHaveBeenCalled();
     expect(mockDeleteRepositoryObjectsByPrefix).not.toHaveBeenCalled();
+    expect(textDependencies.getVersions).toHaveBeenCalledWith(44);
+    expect(urlDependencies.getVersions).toHaveBeenCalledWith(45);
   });
 });

--- a/tests/unit/lib/repositories/content-platform-upload.test.ts
+++ b/tests/unit/lib/repositories/content-platform-upload.test.ts
@@ -78,9 +78,31 @@ describe("canonical repository upload initiation", () => {
       /^repositories\/7\/[0-9a-f-]{36}\/Emergency_handbook\.pdf$/
     );
     expect(storage.createSingleUpload).toHaveBeenCalledWith(
-      expect.objectContaining({ contentType: "application/pdf" })
+      expect.objectContaining({
+        contentType: "application/pdf",
+        metadata: {
+          repositoryId: "7",
+          uploadSessionId: expect.any(String),
+        },
+      })
     );
     expect(mockExecuteQuery).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps Unicode original names in the database instead of S3 headers", async () => {
+    const storage = createStorage();
+
+    await initiateRepositoryUpload(
+      { ...baseInput, fileName: "Plan 🗺️.pdf" },
+      DEFAULT_CONTENT_PLATFORM_CONFIG,
+      storage
+    );
+
+    expect(storage.createSingleUpload).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metadata: expect.not.objectContaining({ originalFileName: expect.anything() }),
+      })
+    );
   });
 
   it("bounds the maximum 500 MiB PDF to at most 100 signed parts", async () => {

--- a/tests/unit/lib/repositories/retrieval-v2-service.test.ts
+++ b/tests/unit/lib/repositories/retrieval-v2-service.test.ts
@@ -1,6 +1,8 @@
 /** @jest-environment node */
 
 import type { RepositoryReranker } from "@/lib/repositories/retrieval-v2/bedrock-reranker";
+import type { SQL } from "drizzle-orm";
+import { PgDialect } from "drizzle-orm/pg-core";
 
 const mockExecuteQuery = jest.fn();
 const mockGetAccessibleRepositories = jest.fn();
@@ -197,6 +199,11 @@ describe("shared repository retrieval v2 service", () => {
   });
 
   it("never exceeds the tokenizer-counted context budget", async () => {
+    const longCandidate = {
+      ...row(1, 0.8, 0),
+      context_prefix: "Detailed section context ".repeat(50),
+      content: "Long policy text ".repeat(500),
+    };
     mockExecuteQuery
       .mockResolvedValueOnce([])
       .mockResolvedValueOnce([
@@ -210,15 +217,9 @@ describe("shared repository retrieval v2 service", () => {
           visual_embedding_dimensions: null,
         },
       ])
-      .mockResolvedValueOnce([row(1, 0.8, 0)])
+      .mockResolvedValueOnce([longCandidate])
       .mockResolvedValueOnce([])
-      .mockResolvedValueOnce([
-        {
-          ...row(1, 0, 0),
-          context_prefix: "Detailed section context ".repeat(50),
-          content: "Long policy text ".repeat(500),
-        },
-      ]);
+      .mockResolvedValueOnce([{ ...longCandidate, score: 0 }]);
 
     const response = await retrieveRepositoryContent({
       query: "policy",
@@ -233,6 +234,108 @@ describe("shared repository retrieval v2 service", () => {
     expect(response.results[0]?.context[0]?.content).toContain(
       "truncated to retrieval budget",
     );
+  });
+
+  it("fits the selected hit before neighbors when the context budget is tight", async () => {
+    const selected = {
+      ...row(50, 0.9, 5),
+      content: "PRIMARY-ANSWER ".repeat(80),
+      context_prefix: "Selected page",
+      source_locator: { page: 6 },
+    };
+    const precedingNeighbor = {
+      ...row(49, 0, 4),
+      content: "UNRELATED-NEIGHBOR ".repeat(80),
+      context_prefix: "Previous page",
+      source_locator: { page: 5 },
+    };
+    mockExecuteQuery
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([
+        {
+          repository_id: 7,
+          repository_name: "District Policies",
+          generation_id: generationId,
+          embedding_model: null,
+          embedding_dimensions: null,
+          visual_embedding_model: null,
+          visual_embedding_dimensions: null,
+        },
+      ])
+      .mockResolvedValueOnce([selected])
+      .mockResolvedValueOnce([])
+      // Reproduce PostgreSQL's former chunk-index ordering: neighbor first.
+      .mockResolvedValueOnce([precedingNeighbor, selected]);
+
+    const response = await retrieveRepositoryContent({
+      query: "primary answer",
+      repositoryIds: [7],
+      userCognitoSub: "user-sub",
+      mode: "keyword",
+      limit: 1,
+      tokenBudget: 100,
+    });
+
+    expect(response.results).toHaveLength(1);
+    expect(response.results[0]?.context[0]).toMatchObject({
+      chunkId: 50,
+      citation: { chunkId: 50, label: "Page 6" },
+    });
+    expect(response.results[0]?.context[0]?.content).toContain("PRIMARY-ANSWER");
+    expect(response.results[0]?.context[0]?.content).not.toContain(
+      "UNRELATED-NEIGHBOR"
+    );
+    expect(response.results[0]?.citations[0]?.chunkId).toBe(50);
+    expect(response.diagnostics.returnedTokens).toBeLessThanOrEqual(100);
+  });
+
+  it("serves the active generation without consulting the mutable current-version pointer", async () => {
+    const servingQueries: string[] = [];
+    const selected = row(70, 0.9, 0);
+    type RawQueryCallback = (db: {
+      execute(query: SQL): Promise<Array<Record<string, unknown>>>;
+    }) => Promise<Array<Record<string, unknown>>>;
+    const executeAndCapture = async (callbackValue: unknown) => {
+      const callback = callbackValue as RawQueryCallback;
+      return callback({
+        execute: async (query) => {
+          servingQueries.push(new PgDialect().sqlToQuery(query).sql);
+          return [selected];
+        },
+      });
+    };
+
+    mockExecuteQuery
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([
+        {
+          repository_id: 7,
+          repository_name: "District Policies",
+          generation_id: generationId,
+          embedding_model: null,
+          embedding_dimensions: null,
+          visual_embedding_model: null,
+          visual_embedding_dimensions: null,
+        },
+      ])
+      .mockImplementationOnce(executeAndCapture)
+      .mockResolvedValueOnce([])
+      .mockImplementationOnce(executeAndCapture);
+
+    const response = await retrieveRepositoryContent({
+      query: "last published policy",
+      repositoryIds: [7],
+      userCognitoSub: "user-sub",
+      mode: "keyword",
+      limit: 1,
+    });
+
+    expect(response.results[0]?.chunkId).toBe(70);
+    expect(servingQueries).toHaveLength(2);
+    for (const query of servingQueries) {
+      expect(query).toContain("chunk.index_generation_id =");
+      expect(query).not.toContain("item.current_version_id = version.id");
+    }
   });
 
   it("retrieves image segments in the generation-pinned visual vector space", async () => {

--- a/tests/unit/lib/s3-client.test.ts
+++ b/tests/unit/lib/s3-client.test.ts
@@ -1,6 +1,7 @@
 import { 
   uploadDocument, 
   uploadRepositoryTextSource,
+  copyRepositorySourceToCanonicalNamespace,
   getDocumentSignedUrl, 
   deleteDocument,
   deleteRepositoryObjectsByPrefix,
@@ -16,7 +17,8 @@ import {
   DeleteObjectsCommand,
   HeadObjectCommand,
   HeadBucketCommand,
-  ListObjectsV2Command
+  ListObjectsV2Command,
+  CopyObjectCommand,
 } from '@aws-sdk/client-s3';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 
@@ -128,6 +130,22 @@ describe('S3 Client', () => {
         expect.any(PutObjectCommand)
       );
     });
+
+    it('uses the canonical repository namespace for direct repository uploads', async () => {
+      mockS3Client.send.mockResolvedValue({});
+
+      const result = await uploadDocument({
+        userId: 'user-123',
+        repositoryId: 7,
+        fileName: 'handbook.pdf',
+        fileContent: Buffer.from('test content'),
+        contentType: 'application/pdf',
+      });
+
+      expect(result.key).toMatch(
+        /^repositories\/7\/[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\/handbook\.pdf$/i
+      );
+    });
   });
 
   describe('uploadRepositoryTextSource', () => {
@@ -144,12 +162,49 @@ describe('S3 Client', () => {
 
       expect(result).toEqual({
         key: expect.stringMatching(
-          /^repositories\/7\/inline\/[0-9a-f-]{36}\/Quick_reference\.txt$/
+          /^repositories\/7\/[0-9a-f-]{36}\/Quick_reference\.txt$/
         ),
         byteSize: 11,
       });
       expect(mockS3Client.send).toHaveBeenCalledWith(
         expect.any(PutObjectCommand)
+      );
+    });
+  });
+
+  describe('copyRepositorySourceToCanonicalNamespace', () => {
+    it('copies a legacy source to a canonical key while preserving S3 metadata', async () => {
+      mockS3Client.send.mockResolvedValue({});
+
+      const result = await copyRepositorySourceToCanonicalNamespace({
+        repositoryId: 7,
+        sourceKey: 'user-1/1700000000-Emergency Plan.pdf',
+        fileName: 'Emergency Plan.pdf',
+      });
+
+      expect(result.key).toMatch(
+        /^repositories\/7\/[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\/Emergency_Plan\.pdf$/i
+      );
+      expect(CopyObjectCommand).toHaveBeenCalledWith({
+        Bucket: 'test-bucket',
+        Key: result.key,
+        CopySource: '/test-bucket/user-1/1700000000-Emergency%20Plan.pdf',
+      });
+      expect(mockS3Client.send).toHaveBeenCalledWith(
+        expect.any(CopyObjectCommand)
+      );
+    });
+
+    it('rejects traversal-like legacy source keys before copying', async () => {
+      await expect(
+        copyRepositorySourceToCanonicalNamespace({
+          repositoryId: 7,
+          sourceKey: '../secret.pdf',
+          fileName: 'secret.pdf',
+        })
+      ).rejects.toThrow('safe source object key');
+      expect(mockS3Client.send).not.toHaveBeenCalledWith(
+        expect.any(CopyObjectCommand)
       );
     });
   });

--- a/tests/unit/lib/tools/repository-tools-retrieval-v2.test.ts
+++ b/tests/unit/lib/tools/repository-tools-retrieval-v2.test.ts
@@ -48,12 +48,35 @@ describe("repository assistant tools use retrieval v2", () => {
     mockRetrieve.mockResolvedValue({
       results: [
         {
+          chunkId: 30,
           content: "Emergency procedure",
           itemName: "Handbook",
           similarity: 0.8,
           chunkIndex: 2,
-          citations: [{ itemVersionId: "version", label: "Page 3" }],
-          context: [{ content: "Neighbor context" }],
+          citations: [
+            { chunkId: 29, itemVersionId: "version", label: "Page 2" },
+            { chunkId: 30, itemVersionId: "version", label: "Page 3" },
+          ],
+          context: [
+            {
+              chunkId: 29,
+              content: "Neighbor context",
+              citation: {
+                chunkId: 29,
+                itemVersionId: "version",
+                label: "Page 2",
+              },
+            },
+            {
+              chunkId: 30,
+              content: "Budgeted emergency procedure",
+              citation: {
+                chunkId: 30,
+                itemVersionId: "version",
+                label: "Page 3",
+              },
+            },
+          ],
         },
       ],
     });
@@ -77,7 +100,17 @@ describe("repository assistant tools use retrieval v2", () => {
     });
     expect(result).toMatchObject({
       success: true,
-      results: [{ citation: { itemVersionId: "version", label: "Page 3" } }],
+      results: [
+        {
+          content: "Budgeted emergency procedure",
+          citation: {
+            chunkId: 30,
+            itemVersionId: "version",
+            label: "Page 3",
+          },
+          context: [{ chunkId: 29, content: "Neighbor context" }],
+        },
+      ],
     });
   });
 

--- a/tests/unit/scripts/migration-utils.test.ts
+++ b/tests/unit/scripts/migration-utils.test.ts
@@ -1,0 +1,31 @@
+/** @jest-environment node */
+
+import fs from "node:fs";
+import { describe, expect, it } from "@jest/globals";
+import {
+  getAbsolutePath,
+  getNextMigrationNumber,
+} from "@/scripts/drizzle-helpers/lib/migration-utils";
+
+interface MigrationManifest {
+  migrationFiles: string[];
+}
+
+describe("migration utilities", () => {
+  it("derives the next number from the shared migrations manifest", () => {
+    const manifest = JSON.parse(
+      fs.readFileSync(
+        getAbsolutePath("infra/database/migrations.json"),
+        "utf8"
+      )
+    ) as MigrationManifest;
+    const highest = Math.max(
+      9,
+      ...manifest.migrationFiles.map((filename) =>
+        Number.parseInt(filename.match(/^(\d+)/)?.[1] ?? "0", 10)
+      )
+    );
+
+    expect(getNextMigrationNumber()).toBe(highest + 1);
+  });
+});

--- a/tests/unit/scripts/unified-content-runtime-recovery-migration.test.ts
+++ b/tests/unit/scripts/unified-content-runtime-recovery-migration.test.ts
@@ -1,0 +1,28 @@
+/** @jest-environment node */
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+describe("unified-content runtime recovery migration", () => {
+  const migration = readFileSync(
+    resolve(
+      process.cwd(),
+      "infra/database/schema/122-unified-content-runtime-recovery.sql"
+    ),
+    "utf8"
+  );
+
+  it("never revives security-blocked item versions", () => {
+    expect(migration).toContain(
+      "job.last_error_code IS DISTINCT FROM 'SECURITY_INSPECTION_BLOCKED'"
+    );
+    expect(migration).toContain("version.storage_status <> 'blocked'");
+    expect(migration).toContain("version.inspection_status <> 'blocked'");
+  });
+
+  it("only resets the current active item version into the pending outbox", () => {
+    expect(migration).toContain("version.id = job.item_version_id");
+    expect(migration).toContain("item.lifecycle_status = 'active'");
+    expect(migration).toContain("job.last_error_code = 'RECOVERED_BY_MIGRATION_122'");
+  });
+});


### PR DESCRIPTION
## Summary
- enforce one canonical source-object namespace across direct, multipart, image, media, Office, PDF, and inline uploads
- expose canonical processing status and authorized retry controls while preserving immutable versions
- add durable processor and embedding retry/terminal state, active-generation-safe retrieval, complete cleanup, and operational alarms
- recover eligible stranded work through migration 122 and repair migration discovery

## Verification
- application CI: 275 suites passed, 5 skipped; 3,103 passed, 60 skipped
- infrastructure/Lambda: 35 suites, 359 tests passed
- authenticated Playwright: 255 passed, 53 intentional environment skips
- real PostgreSQL migration parse/rollback and unified-content smoke suite passed
- production Next.js build and complete infrastructure build passed
- lint: 0 errors; root, infra, content-worker, and embedding-worker typechecks passed
- all 29 CDK stacks synthesized successfully

## Rollout
Deploy all stacks normally. Migration 122 and the corrected workers are included; no manual AWS CLI or database mutation is required. After deployment, verify fresh PDF, image, and inline-text items reach Embedded and return cited retrieval results.