### PR TITLE
fix(content): harden post-deploy recovery handoff

### DIFF
--- a/actions/repositories/repository-items.actions.ts
+++ b/actions/repositories/repository-items.actions.ts
@@ -39,6 +39,7 @@ import { queueFileForProcessing, processUrl } from "@/lib/services/file-processi
 import { canModifyRepository, getUserIdFromSession } from "./repository-permissions"
 import { toContentDispositionValue } from "@/lib/repositories/content-disposition"
 import {
+  assertCanonicalRetryNotQuarantined,
   deleteRepositoryItemStorage,
   dispatchContentProcessingJob,
   getCanonicalRepositoryItemStatuses,
@@ -1182,6 +1183,10 @@ async function prepareRepositoryItemRetry(
   userId: number,
   requestId: string
 ): Promise<RepositoryItemRetryTarget> {
+  if (item.currentVersionId) {
+    await assertCanonicalRetryNotQuarantined(item.currentVersionId)
+  }
+
   if (item.type === "text") {
     const canonical = await registerCanonicalTextIfEnabled({
       itemId: item.id,

--- a/docs/plans/2026-07-21-unified-content-platform.md
+++ b/docs/plans/2026-07-21-unified-content-platform.md
@@ -761,3 +761,60 @@ Verification evidence for the runtime recovery slice:
 The remaining rollout check is deployment of migration 122 and the corrected
 workers, followed by a fresh live PDF/image/inline-text matrix through Embedded
 and cited retrieval. No manual AWS CLI or database mutation is required.
+
+### Post-deployment handoff hardening checkpoint (2026-07-22)
+
+Live validation of the runtime-recovery rollout exposed a deployment-order race:
+migrations run before the new Lambda code is active, so migration 122 released
+recoverable jobs while the previous worker was still able to consume them. The
+same validation also showed that terminal failed and cancelled jobs could be
+presented as non-terminal, and a clean-database smoke exposed a nondeterministic
+partial-unique-index conflict during generation activation. This hardening slice
+closes the complete set before another deployment:
+
+- Migrations 122 and 123 now quarantine eligible current inspect jobs as
+  `cancelled` with an infinite availability time and a versioned handoff marker.
+  Migration 123 safely repairs environments where the earlier form of migration
+  122 already ran. Already-serving generations, noncanonical source keys,
+  superseded versions, and security-blocked content are never reprocessed.
+- The new unified-content worker releases quarantined jobs in bounded,
+  transactionally claimed batches during its scheduled sweep. Release resets
+  attempts, leases, timestamps, errors, and provider metrics before normal
+  dispatch, so the previous worker cannot win the migration-to-code deployment
+  gap and stale Textract/BDA state cannot influence the retry.
+- Failed and cancelled inspect jobs are terminal in repository status
+  projection. Authorized manual retry accepts either state and creates a fresh
+  five-attempt budget with cleared inspection/provider state; only genuinely
+  pending work with prior attempts is shown as Retrying.
+- Generation activation now uses an ordered four-statement transaction: lock the
+  repository, supersede its current generation, activate the fully embedded
+  target, then publish the repository pointer and included items. The target is
+  rechecked at activation time and duplicate completion messages remain
+  idempotent, eliminating the partial unique-index ordering race.
+- The repository E2E fixture reproduces the exact live failed-job shape
+  (`attempt=1`, `max_attempts=20`, stale provider metrics), and the Assistant
+  Architect persistence test now opens its named deterministic fixture instead
+  of whichever architect happened to sort first.
+
+Verification evidence for the handoff hardening slice:
+
+- Application CI suite: 275 suites passed, 5 skipped; 3,107 tests passed and 60
+  intentionally skipped. Infrastructure/Lambda suite: 35 suites and 359 tests
+  passed, including the real ARM64 worker bundle.
+- Full authenticated Playwright passed 257 tests with 51 intentional
+  environment-gated skips and zero failures. The repository matrix covers inline
+  text, PDF, Office, image, audio, video, terminal failure visibility, and
+  Failed/Cancelled -> Retry -> Pending recovery.
+- Real PostgreSQL smoke passed the exact migration-before-worker handoff, old
+  worker exclusion, bounded new-worker release, retry-state reset, PDF/Office/
+  image publication and citations, ordered generation activation, duplicate
+  activation, the single-active-generation constraint, and cleanup.
+- Full lint completed with zero errors. Application, infrastructure,
+  unified-content worker, and embedding-worker typechecks pass. The production
+  Next.js build, complete infrastructure build, and all-stack no-lookup CDK
+  synthesis of 29 dev/prod templates pass.
+
+The remaining rollout check is one dev deployment followed by a single live
+inline-text/PDF/image matrix and verification that migration 123 jobs are
+released only by the new scheduled worker. No manual AWS CLI or database
+mutation is part of the rollout.

--- a/docs/plans/2026-07-21-unified-content-platform.md
+++ b/docs/plans/2026-07-21-unified-content-platform.md
@@ -773,7 +773,11 @@ partial-unique-index conflict during generation activation. This hardening slice
 closes the complete set before another deployment:
 
 - Migrations 122 and 123 now quarantine eligible current inspect jobs as
-  `cancelled` with an infinite availability time and a versioned handoff marker.
+  `cancelled` with an infinite availability time and a versioned handoff marker
+  in a dedicated column that stale worker writes cannot erase. A database check
+  constraint prevents any runtime from moving a marked row out of `cancelled`;
+  the replacement worker must clear the marker in the same atomic update that
+  returns it to `pending`.
   Migration 123 safely repairs environments where the earlier form of migration
   122 already ran, but only for its marker, its explicit recovery error, the
   observed deployment-disabled state, or the legacy embedding-failure state.
@@ -782,12 +786,12 @@ closes the complete set before another deployment:
   reprocessed.
 - The new unified-content worker releases quarantined jobs in bounded,
   transactionally claimed batches during its scheduled sweep, after a 20-minute
-  drain window longer than the previous Lambda's maximum execution time. It can
-  reclaim a marked row whose status was overwritten by an invocation already in
-  flight when the migration committed. Release resets attempts, leases,
-  timestamps, errors, and provider metrics before normal dispatch, so the
-  previous worker cannot win the migration-to-code deployment gap and stale
-  Textract/BDA state cannot influence the retry.
+  drain window longer than the previous Lambda's maximum execution time. A
+  metrics overwrite cannot erase eligibility, and the database rejects a stale
+  invocation's attempt to change the marked row's status or error. Release
+  resets attempts, leases, timestamps, errors, and provider metrics before
+  normal dispatch, so the previous worker cannot win the migration-to-code
+  deployment gap and stale Textract/BDA state cannot influence the retry.
 - Failed and cancelled inspect jobs are terminal in repository status
   projection. Authorized manual retry accepts either state and creates a fresh
   five-attempt budget with cleared inspection/provider state; only genuinely
@@ -812,11 +816,12 @@ Verification evidence for the handoff hardening slice:
   text, PDF, Office, image, audio, video, terminal failure visibility, and
   Failed/Cancelled -> Retry -> Pending recovery.
 - Real PostgreSQL smoke passed the exact migration-before-worker handoff,
-  preservation of unrelated terminal failures, old-worker exclusion, the
-  20-minute drain guard, bounded new-worker release, noncanonical-source
-  exclusion, retry-state reset, PDF/Office/image publication and citations,
-  ordered generation activation, duplicate activation, the single-active-
-  generation constraint, and cleanup.
+  preservation of unrelated terminal failures, old-worker exclusion, survival
+  of a stale metrics overwrite, database rejection of a stale status/error
+  transition, the 20-minute drain guard, bounded new-worker release,
+  noncanonical-source exclusion, retry-state reset, PDF/Office/image publication
+  and citations, ordered generation activation, duplicate activation, the
+  single-active-generation constraint, and cleanup.
 - Full lint completed with zero errors. Application, infrastructure,
   unified-content worker, and embedding-worker typechecks pass. The production
   Next.js build, complete infrastructure build, and all-stack no-lookup CDK

--- a/docs/plans/2026-07-21-unified-content-platform.md
+++ b/docs/plans/2026-07-21-unified-content-platform.md
@@ -794,8 +794,11 @@ closes the complete set before another deployment:
   deployment gap and stale Textract/BDA state cannot influence the retry.
 - Failed and cancelled inspect jobs are terminal in repository status
   projection. Authorized manual retry accepts either state and creates a fresh
-  five-attempt budget with cleared inspection/provider state; only genuinely
-  pending work with prior attempts is shown as Retrying.
+  five-attempt budget with cleared inspection/provider state. The sole exception
+  is a job carrying the durable post-deploy marker: it remains visibly Retrying,
+  exposes no manual Retry control, and every canonical or inline-text server
+  retry path rejects it until the replacement worker atomically releases the
+  quarantine after the drain window.
 - Generation activation now uses an ordered four-statement transaction: lock the
   repository, supersede its current generation, activate the fully embedded
   target, then publish the repository pointer and included items. The target is
@@ -808,7 +811,7 @@ closes the complete set before another deployment:
 
 Verification evidence for the handoff hardening slice:
 
-- Application CI suite: 275 suites passed, 5 skipped; 3,108 tests passed and 60
+- Application CI suite: 275 suites passed, 5 skipped; 3,110 tests passed and 60
   intentionally skipped. Infrastructure/Lambda suite: 35 suites and 359 tests
   passed, including the real ARM64 worker bundle.
 - Full authenticated Playwright passed 257 tests with 51 intentional
@@ -818,9 +821,10 @@ Verification evidence for the handoff hardening slice:
 - Real PostgreSQL smoke passed the exact migration-before-worker handoff,
   preservation of unrelated terminal failures, old-worker exclusion, survival
   of a stale metrics overwrite, database rejection of a stale status/error
-  transition, the 20-minute drain guard, bounded new-worker release,
-  noncanonical-source exclusion, retry-state reset, PDF/Office/image publication
-  and citations, ordered generation activation, duplicate activation, the
+  transition, UI suppression and server rejection of manual retry while marked,
+  the 20-minute drain guard, bounded new-worker release, noncanonical-source
+  exclusion, retry-state reset after release, PDF/Office/image publication and
+  citations, ordered generation activation, duplicate activation, the
   single-active-generation constraint, and cleanup.
 - Full lint completed with zero errors. Application, infrastructure,
   unified-content worker, and embedding-worker typechecks pass. The production

--- a/docs/plans/2026-07-21-unified-content-platform.md
+++ b/docs/plans/2026-07-21-unified-content-platform.md
@@ -775,13 +775,19 @@ closes the complete set before another deployment:
 - Migrations 122 and 123 now quarantine eligible current inspect jobs as
   `cancelled` with an infinite availability time and a versioned handoff marker.
   Migration 123 safely repairs environments where the earlier form of migration
-  122 already ran. Already-serving generations, noncanonical source keys,
-  superseded versions, and security-blocked content are never reprocessed.
+  122 already ran, but only for its marker, its explicit recovery error, the
+  observed deployment-disabled state, or the legacy embedding-failure state.
+  Unrelated terminal user failures, already-serving generations, noncanonical
+  source keys, superseded versions, and security-blocked content are never
+  reprocessed.
 - The new unified-content worker releases quarantined jobs in bounded,
-  transactionally claimed batches during its scheduled sweep. Release resets
-  attempts, leases, timestamps, errors, and provider metrics before normal
-  dispatch, so the previous worker cannot win the migration-to-code deployment
-  gap and stale Textract/BDA state cannot influence the retry.
+  transactionally claimed batches during its scheduled sweep, after a 20-minute
+  drain window longer than the previous Lambda's maximum execution time. It can
+  reclaim a marked row whose status was overwritten by an invocation already in
+  flight when the migration committed. Release resets attempts, leases,
+  timestamps, errors, and provider metrics before normal dispatch, so the
+  previous worker cannot win the migration-to-code deployment gap and stale
+  Textract/BDA state cannot influence the retry.
 - Failed and cancelled inspect jobs are terminal in repository status
   projection. Authorized manual retry accepts either state and creates a fresh
   five-attempt budget with cleared inspection/provider state; only genuinely
@@ -798,17 +804,19 @@ closes the complete set before another deployment:
 
 Verification evidence for the handoff hardening slice:
 
-- Application CI suite: 275 suites passed, 5 skipped; 3,107 tests passed and 60
+- Application CI suite: 275 suites passed, 5 skipped; 3,108 tests passed and 60
   intentionally skipped. Infrastructure/Lambda suite: 35 suites and 359 tests
   passed, including the real ARM64 worker bundle.
 - Full authenticated Playwright passed 257 tests with 51 intentional
   environment-gated skips and zero failures. The repository matrix covers inline
   text, PDF, Office, image, audio, video, terminal failure visibility, and
   Failed/Cancelled -> Retry -> Pending recovery.
-- Real PostgreSQL smoke passed the exact migration-before-worker handoff, old
-  worker exclusion, bounded new-worker release, retry-state reset, PDF/Office/
-  image publication and citations, ordered generation activation, duplicate
-  activation, the single-active-generation constraint, and cleanup.
+- Real PostgreSQL smoke passed the exact migration-before-worker handoff,
+  preservation of unrelated terminal failures, old-worker exclusion, the
+  20-minute drain guard, bounded new-worker release, noncanonical-source
+  exclusion, retry-state reset, PDF/Office/image publication and citations,
+  ordered generation activation, duplicate activation, the single-active-
+  generation constraint, and cleanup.
 - Full lint completed with zero errors. Application, infrastructure,
   unified-content worker, and embedding-worker typechecks pass. The production
   Next.js build, complete infrastructure build, and all-stack no-lookup CDK
@@ -816,5 +824,6 @@ Verification evidence for the handoff hardening slice:
 
 The remaining rollout check is one dev deployment followed by a single live
 inline-text/PDF/image matrix and verification that migration 123 jobs are
-released only by the new scheduled worker. No manual AWS CLI or database
-mutation is part of the rollout.
+released only by the new scheduled worker after the drain window. Recovery can
+therefore remain visibly quarantined for up to 20 minutes after the migration.
+No manual AWS CLI or database mutation is part of the rollout.

--- a/infra/database/migrations.json
+++ b/infra/database/migrations.json
@@ -116,6 +116,7 @@
     "119-unified-content-media-ingestion.sql",
     "120-bedrock-repository-embeddings.sql",
     "121-unified-content-retrieval-v2.sql",
-    "122-unified-content-runtime-recovery.sql"
+    "122-unified-content-runtime-recovery.sql",
+    "123-unified-content-postdeploy-handoff.sql"
   ]
 }

--- a/infra/database/schema/122-unified-content-runtime-recovery.sql
+++ b/infra/database/schema/122-unified-content-runtime-recovery.sql
@@ -3,9 +3,10 @@
 -- Earlier workers could leave deterministic processor failures in `failed`
 -- before their DB retry budget was exhausted, while embedding failures left a
 -- generation `building` forever and only changed the legacy item status. The
--- corrected workers never create either state. Requeue the affected current
--- versions once so the deployment heals existing data without an AWS CLI or
--- direct database runbook.
+-- corrected workers never create either state. Quarantine the affected current
+-- versions once so the replacement runtime, not a still-running old Lambda,
+-- releases them after the processing stack update. Migration 123 repeats this
+-- handoff for environments where the original migration 122 already ran.
 
 -- A pre-hardening embedding failure cannot be resumed in-place because its SQS
 -- record may already be in the DLQ. Retire only building generations that are
@@ -27,41 +28,61 @@ UPDATE repository_index_generations generation
         AND item.processing_status = 'embedding_failed'
    );
 
--- Replay the durable inspect job for those embedding failures. Reprocessing
--- creates a new generation under the current provider descriptor and preserves
--- the previous active generation until the replacement is fully embedded.
+-- Quarantine the durable inspect job for those embedding failures. `cancelled`
+-- is intentionally terminal to every old worker, including stale SQS receives.
 UPDATE repository_processing_jobs job
-   SET status = 'pending',
+   SET status = 'cancelled',
        attempt = 0,
-       max_attempts = GREATEST(job.max_attempts, 5),
-       available_at = now(),
+       max_attempts = 5,
+       available_at = 'infinity'::timestamptz,
        lease_owner = NULL,
        lease_expires_at = NULL,
-       last_error_code = 'RECOVERED_BY_MIGRATION_122',
-       last_error_message = NULL,
-       finished_at = NULL,
+       last_error_code = 'POST_DEPLOY_RECOVERY_QUARANTINED',
+       last_error_message = 'Awaiting the unified-content runtime v2 deployment',
+       metrics = '{"postDeployRecovery":"unified-content-runtime-v2"}'::jsonb,
+       started_at = NULL,
+       finished_at = now(),
        updated_at = now()
  WHERE job.status = 'succeeded'
    AND EXISTS (
      SELECT 1
        FROM repository_items item
-      WHERE item.current_version_id = job.item_version_id
+       JOIN repository_item_versions version
+         ON version.id = item.current_version_id
+      WHERE version.id = job.item_version_id
         AND item.processing_status = 'embedding_failed'
+        AND item.lifecycle_status = 'active'
+        AND version.storage_status <> 'blocked'
+        AND version.inspection_status <> 'blocked'
+        AND version.object_key ~ (
+          '^repositories/' || item.repository_id::text ||
+          '/[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89aAbB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}/[^/]+$'
+        )
+        AND NOT EXISTS (
+          SELECT 1
+          FROM repository_item_chunks active_chunk
+          JOIN knowledge_repositories repository
+            ON repository.id = item.repository_id
+          WHERE active_chunk.item_version_id = version.id
+            AND active_chunk.index_generation_id = repository.active_index_generation_id
+        )
    );
 
--- Old processor failures were marked failed after each receive and therefore
--- were invisible to the pending-job sweep. Give current versions one fresh,
--- bounded budget; the corrected handler immediately closes permanent errors.
+-- Old processor failures were marked failed after each receive. Quarantine only
+-- canonical, current, non-serving sources; invalid legacy keys require the UI
+-- retry path to create a fresh immutable version in the corrected namespace.
 UPDATE repository_processing_jobs job
-   SET status = 'pending',
+   SET status = 'cancelled',
        attempt = 0,
-       max_attempts = GREATEST(job.max_attempts, 5),
-       available_at = now(),
+       max_attempts = 5,
+       available_at = 'infinity'::timestamptz,
        lease_owner = NULL,
        lease_expires_at = NULL,
-       last_error_code = 'RECOVERED_BY_MIGRATION_122',
-       last_error_message = NULL,
-       finished_at = NULL,
+       last_error_code = 'POST_DEPLOY_RECOVERY_QUARANTINED',
+       last_error_message = 'Awaiting the unified-content runtime v2 deployment',
+       metrics = '{"postDeployRecovery":"unified-content-runtime-v2"}'::jsonb,
+       started_at = NULL,
+       finished_at = now(),
        updated_at = now()
  WHERE job.status = 'failed'
    AND job.attempt < job.max_attempts
@@ -77,28 +98,16 @@ UPDATE repository_processing_jobs job
         -- require a new source version, not an automatic processing retry.
         AND version.storage_status <> 'blocked'
         AND version.inspection_status <> 'blocked'
+        AND version.object_key ~ (
+          '^repositories/' || item.repository_id::text ||
+          '/[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89aAbB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}/[^/]+$'
+        )
+        AND NOT EXISTS (
+          SELECT 1
+          FROM repository_item_chunks active_chunk
+          JOIN knowledge_repositories repository
+            ON repository.id = item.repository_id
+          WHERE active_chunk.item_version_id = version.id
+            AND active_chunk.index_generation_id = repository.active_index_generation_id
+        )
    );
-
-UPDATE repository_item_versions version
-   SET storage_status = 'quarantined',
-       inspection_status = 'pending',
-       processing_status = 'pending'
- WHERE EXISTS (
-   SELECT 1
-     FROM repository_processing_jobs job
-    WHERE job.item_version_id = version.id
-      AND job.status = 'pending'
-      AND job.last_error_code = 'RECOVERED_BY_MIGRATION_122'
- );
-
-UPDATE repository_items item
-   SET processing_status = 'pending',
-       processing_error = NULL,
-       updated_at = now()
- WHERE EXISTS (
-   SELECT 1
-     FROM repository_processing_jobs job
-    WHERE job.item_version_id = item.current_version_id
-      AND job.status = 'pending'
-      AND job.last_error_code = 'RECOVERED_BY_MIGRATION_122'
- );

--- a/infra/database/schema/123-unified-content-postdeploy-handoff.sql
+++ b/infra/database/schema/123-unified-content-postdeploy-handoff.sql
@@ -1,0 +1,62 @@
+-- Migration 123: make unified-content recovery safe across CDK stack order.
+--
+-- Database migrations deploy before the processing Lambda during a full-stack
+-- rollout. Never make recovery jobs runnable here: the previous Lambda version
+-- could consume them with stale code. Instead mark a carefully bounded set as
+-- cancelled/inert. The replacement worker recognizes the metrics marker and
+-- atomically releases batches only after its own deployment is complete.
+
+UPDATE repository_processing_jobs job
+SET status = 'cancelled',
+    attempt = 0,
+    max_attempts = 5,
+    available_at = 'infinity'::timestamptz,
+    lease_owner = NULL,
+    lease_expires_at = NULL,
+    last_error_code = 'POST_DEPLOY_RECOVERY_QUARANTINED',
+    last_error_message = 'Awaiting the unified-content runtime v2 deployment',
+    metrics = '{"postDeployRecovery":"unified-content-runtime-v2"}'::jsonb,
+    started_at = NULL,
+    finished_at = now(),
+    updated_at = now()
+WHERE job.stage = 'inspect'
+  AND (
+    job.metrics ->> 'postDeployRecovery' = 'unified-content-runtime-v2'
+    OR job.status IN ('failed', 'cancelled')
+    OR (
+      job.status = 'pending'
+      AND job.last_error_code = 'RECOVERED_BY_MIGRATION_122'
+    )
+    OR (
+      job.status = 'succeeded'
+      AND EXISTS (
+        SELECT 1
+        FROM repository_items embedding_item
+        WHERE embedding_item.current_version_id = job.item_version_id
+          AND embedding_item.processing_status = 'embedding_failed'
+      )
+    )
+  )
+  AND job.last_error_code IS DISTINCT FROM 'SECURITY_INSPECTION_BLOCKED'
+  AND EXISTS (
+    SELECT 1
+    FROM repository_items item
+    JOIN repository_item_versions version
+      ON version.id = item.current_version_id
+    WHERE version.id = job.item_version_id
+      AND item.lifecycle_status = 'active'
+      AND version.storage_status <> 'blocked'
+      AND version.inspection_status <> 'blocked'
+      AND version.object_key ~ (
+        '^repositories/' || item.repository_id::text ||
+        '/[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89aAbB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}/[^/]+$'
+      )
+      AND NOT EXISTS (
+        SELECT 1
+        FROM repository_item_chunks active_chunk
+        JOIN knowledge_repositories repository
+          ON repository.id = item.repository_id
+        WHERE active_chunk.item_version_id = version.id
+          AND active_chunk.index_generation_id = repository.active_index_generation_id
+      )
+  );

--- a/infra/database/schema/123-unified-content-postdeploy-handoff.sql
+++ b/infra/database/schema/123-unified-content-postdeploy-handoff.sql
@@ -3,8 +3,21 @@
 -- Database migrations deploy before the processing Lambda during a full-stack
 -- rollout. Never make recovery jobs runnable here: the previous Lambda version
 -- could consume them with stale code. Instead mark a carefully bounded set as
--- cancelled/inert. The replacement worker recognizes the metrics marker and
+-- cancelled/inert. The replacement worker recognizes the durable marker and
 -- atomically releases batches only after its own deployment is complete.
+
+-- Keep the handoff marker outside `metrics`: an invocation of the previous
+-- worker may still finish after this migration and replace the metrics object it
+-- read before the migration. Old code does not know about this dedicated column
+-- and therefore cannot erase the handoff.
+ALTER TABLE repository_processing_jobs
+  ADD COLUMN IF NOT EXISTS post_deploy_recovery VARCHAR(64)
+    CONSTRAINT ck_repository_processing_postdeploy_cancelled
+    CHECK (post_deploy_recovery IS NULL OR status = 'cancelled');
+
+CREATE INDEX IF NOT EXISTS idx_repository_processing_postdeploy_recovery
+  ON repository_processing_jobs (updated_at, id)
+  WHERE post_deploy_recovery IS NOT NULL;
 
 UPDATE repository_processing_jobs job
 SET status = 'cancelled',
@@ -15,13 +28,15 @@ SET status = 'cancelled',
     lease_expires_at = NULL,
     last_error_code = 'POST_DEPLOY_RECOVERY_QUARANTINED',
     last_error_message = 'Awaiting the unified-content runtime v2 deployment',
+    post_deploy_recovery = 'unified-content-runtime-v2',
     metrics = '{"postDeployRecovery":"unified-content-runtime-v2"}'::jsonb,
     started_at = NULL,
     finished_at = now(),
     updated_at = now()
 WHERE job.stage = 'inspect'
   AND (
-    job.metrics ->> 'postDeployRecovery' = 'unified-content-runtime-v2'
+    job.post_deploy_recovery = 'unified-content-runtime-v2'
+    OR job.metrics ->> 'postDeployRecovery' = 'unified-content-runtime-v2'
     OR (
       job.status IN ('pending', 'queued', 'running', 'cancelled')
       AND job.last_error_code IN (

--- a/infra/database/schema/123-unified-content-postdeploy-handoff.sql
+++ b/infra/database/schema/123-unified-content-postdeploy-handoff.sql
@@ -22,10 +22,12 @@ SET status = 'cancelled',
 WHERE job.stage = 'inspect'
   AND (
     job.metrics ->> 'postDeployRecovery' = 'unified-content-runtime-v2'
-    OR job.status IN ('failed', 'cancelled')
     OR (
-      job.status = 'pending'
-      AND job.last_error_code = 'RECOVERED_BY_MIGRATION_122'
+      job.status IN ('pending', 'queued', 'running', 'cancelled')
+      AND job.last_error_code IN (
+        'RECOVERED_BY_MIGRATION_122',
+        'CONTENT_PLATFORM_DISABLED'
+      )
     )
     OR (
       job.status = 'succeeded'

--- a/infra/lambdas/embedding-generator/__tests__/generation-activation.test.ts
+++ b/infra/lambdas/embedding-generator/__tests__/generation-activation.test.ts
@@ -1,10 +1,9 @@
 import { activateCompletedGeneration } from '../generation-activation';
-import type { SQL } from 'drizzle-orm';
 import { PgDialect } from 'drizzle-orm/pg-core';
 
 describe('atomic generation activation', () => {
   test('returns the switched repository and all embedded items', async () => {
-    const execute = jest.fn(async (_query: SQL) => [
+    const execute = jest.fn(async () => [
       { repository_id: 7, embedded_item_count: 3 },
     ]);
 
@@ -16,10 +15,16 @@ describe('atomic generation activation', () => {
     ).resolves.toEqual({ repository_id: 7, embedded_item_count: 3 });
     expect(execute).toHaveBeenCalledTimes(1);
 
-    const activationQuery = execute.mock.calls[0]?.[0];
-    expect(activationQuery).toBeDefined();
-    const query = new PgDialect().sqlToQuery(activationQuery as SQL);
-    const normalizedSql = query.sql.replace(/\s+/g, ' ');
+    const plan = execute.mock.calls[0]?.[0];
+    expect(plan).toBeDefined();
+    const dialect = new PgDialect();
+    const normalizedSql = Object.values(plan ?? {})
+      .map((query) => dialect.sqlToQuery(query).sql)
+      .join(' ')
+      .replace(/\s+/g, ' ');
+    expect(normalizedSql).toContain('FOR UPDATE OF repository');
+    expect(normalizedSql).toContain("SET status = 'superseded'");
+    expect(normalizedSql).toContain("SET status = 'active'");
     expect(normalizedSql).toContain(
       'AND EXISTS ( SELECT 1 FROM repository_item_chunks chunk'
     );

--- a/infra/lambdas/embedding-generator/generation-activation.ts
+++ b/infra/lambdas/embedding-generator/generation-activation.ts
@@ -5,87 +5,122 @@ export interface GenerationActivationResult {
   embedded_item_count: number;
 }
 
+export interface GenerationActivationPlan {
+  lockRepository: SQL;
+  supersedeCurrent: SQL;
+  activateTarget: SQL;
+  publishTarget: SQL;
+}
+
 export type GenerationActivationExecutor = (
-  query: SQL,
+  plan: GenerationActivationPlan,
 ) => Promise<GenerationActivationResult[]>;
 
 /**
  * Atomically supersede the serving generation, activate the fully embedded
  * generation, move the repository pointer, and mark every included item ready.
  * A stale superseded generation is a safe no-op.
+ *
+ * The statements must run sequentially in one transaction. PostgreSQL's partial
+ * unique index for one active generation is immediate, so a single multi-row
+ * CASE update can nondeterministically activate the target before it supersedes
+ * the old row. The repository lock also serializes duplicate final SQS records.
  */
 export async function activateCompletedGeneration(
   generationId: string,
   execute: GenerationActivationExecutor,
 ): Promise<GenerationActivationResult | null> {
-  const rows = await execute(sql`
-    WITH target AS (
-      SELECT id, repository_id
-      FROM repository_index_generations generation
+  const eligibleTarget = sql`
+    SELECT generation.id, generation.repository_id
+    FROM repository_index_generations generation
+    WHERE generation.id = ${generationId}::uuid
+      AND generation.status IN ('building', 'active')
+      AND EXISTS (
+        SELECT 1
+        FROM repository_item_chunks chunk
+        WHERE chunk.index_generation_id = generation.id
+      )
+      AND NOT EXISTS (
+        SELECT 1
+        FROM repository_item_chunks chunk
+        WHERE chunk.index_generation_id = generation.id
+          AND (
+            chunk.embedding IS NULL
+            OR (
+              generation.visual_embedding_model IS NOT NULL
+              AND chunk.modality IN ('image', 'video')
+              AND chunk.visual_embedding IS NULL
+            )
+          )
+      )
+  `;
+
+  const rows = await execute({
+    lockRepository: sql`
+      SELECT repository.id
+      FROM knowledge_repositories repository
+      JOIN repository_index_generations generation
+        ON generation.repository_id = repository.id
       WHERE generation.id = ${generationId}::uuid
-        AND generation.status IN ('building', 'active')
+      FOR UPDATE OF repository
+    `,
+    supersedeCurrent: sql`
+      UPDATE repository_index_generations generation
+      SET status = 'superseded'
+      WHERE generation.status = 'active'
+        AND generation.id <> ${generationId}::uuid
+        AND generation.repository_id = (
+          SELECT target.repository_id FROM (${eligibleTarget}) target
+        )
+    `,
+    activateTarget: sql`
+      UPDATE repository_index_generations generation
+      SET status = 'active',
+          published_at = COALESCE(generation.published_at, now())
+      WHERE generation.id = ${generationId}::uuid
         AND EXISTS (
-          SELECT 1
-          FROM repository_item_chunks chunk
-          WHERE chunk.index_generation_id = generation.id
+          SELECT 1 FROM (${eligibleTarget}) target
+          WHERE target.id = generation.id
         )
         AND NOT EXISTS (
           SELECT 1
+          FROM repository_index_generations active_generation
+          WHERE active_generation.repository_id = generation.repository_id
+            AND active_generation.status = 'active'
+            AND active_generation.id <> generation.id
+        )
+    `,
+    publishTarget: sql`
+      WITH repository_switch AS (
+        UPDATE knowledge_repositories repository
+        SET active_index_generation_id = ${generationId}::uuid,
+            updated_at = now()
+        WHERE repository.id = (
+          SELECT generation.repository_id
+          FROM (${eligibleTarget}) target
+          JOIN repository_index_generations generation
+            ON generation.id = target.id
+          WHERE generation.status = 'active'
+        )
+        RETURNING repository.id
+      ), embedded_items AS (
+        UPDATE repository_items item
+        SET processing_status = 'embedded',
+            processing_error = NULL,
+            updated_at = now()
+        WHERE item.id IN (
+          SELECT DISTINCT chunk.item_id
           FROM repository_item_chunks chunk
-          WHERE chunk.index_generation_id = generation.id
-            AND (
-              chunk.embedding IS NULL
-              OR (
-                generation.visual_embedding_model IS NOT NULL
-                AND chunk.modality IN ('image', 'video')
-                AND chunk.visual_embedding IS NULL
-              )
-            )
+          WHERE chunk.index_generation_id = ${generationId}::uuid
         )
-    ), switched AS (
-      UPDATE repository_index_generations generation
-      SET
-        status = CASE
-          WHEN generation.id = ${generationId}::uuid THEN 'active'
-          ELSE 'superseded'
-        END,
-        published_at = CASE
-          WHEN generation.id = ${generationId}::uuid THEN now()
-          ELSE generation.published_at
-        END
-      FROM target
-      WHERE generation.repository_id = target.repository_id
-        AND (
-          generation.id = ${generationId}::uuid
-          OR generation.status = 'active'
-        )
-      RETURNING target.repository_id, generation.id
-    ), repository_switch AS (
-      UPDATE knowledge_repositories repository
-      SET active_index_generation_id = ${generationId}::uuid,
-          updated_at = now()
-      WHERE repository.id = (SELECT repository_id FROM target)
-        AND EXISTS (
-          SELECT 1 FROM switched WHERE id = ${generationId}::uuid
-        )
-      RETURNING repository.id
-    ), embedded_items AS (
-      UPDATE repository_items item
-      SET processing_status = 'embedded',
-          processing_error = NULL,
-          updated_at = now()
-      WHERE item.id IN (
-        SELECT DISTINCT chunk.item_id
-        FROM repository_item_chunks chunk
-        WHERE chunk.index_generation_id = ${generationId}::uuid
+          AND EXISTS (SELECT 1 FROM repository_switch)
+        RETURNING item.id
       )
-        AND EXISTS (SELECT 1 FROM repository_switch)
-      RETURNING item.id
-    )
-    SELECT
-      repository_switch.id::integer AS repository_id,
-      (SELECT count(*)::integer FROM embedded_items) AS embedded_item_count
-    FROM repository_switch
-  `);
+      SELECT
+        repository_switch.id::integer AS repository_id,
+        (SELECT count(*)::integer FROM embedded_items) AS embedded_item_count
+      FROM repository_switch
+    `,
+  });
   return rows[0] ?? null;
 }

--- a/infra/lambdas/embedding-generator/generation-activation.ts
+++ b/infra/lambdas/embedding-generator/generation-activation.ts
@@ -73,6 +73,9 @@ export async function activateCompletedGeneration(
           SELECT target.repository_id FROM (${eligibleTarget}) target
         )
     `,
+    // Defense in depth: the preceding statement already supersedes the current
+    // generation under the repository lock, but retain this invariant check if
+    // the ordered activation plan is ever reused by another executor.
     activateTarget: sql`
       UPDATE repository_index_generations generation
       SET status = 'active',

--- a/infra/lambdas/embedding-generator/index.ts
+++ b/infra/lambdas/embedding-generator/index.ts
@@ -501,14 +501,18 @@ async function processRecord(record: SQSRecord, embSettings: EmbeddingSettings):
       if (message.generationId) {
         await activateCompletedGeneration(
           message.generationId,
-          async (query) =>
-            (await db.execute<{
+          async (plan) => db.transaction(async (tx) => {
+            await tx.execute(plan.lockRepository);
+            await tx.execute(plan.supersedeCurrent);
+            await tx.execute(plan.activateTarget);
+            return (await tx.execute<{
               repository_id: number;
               embedded_item_count: number;
-            }>(query)) as Array<{
+            }>(plan.publishTarget)) as Array<{
               repository_id: number;
               embedded_item_count: number;
-            }>
+            }>;
+          })
         );
       } else {
         await db

--- a/infra/lambdas/unified-content-processor/index.ts
+++ b/infra/lambdas/unified-content-processor/index.ts
@@ -82,6 +82,7 @@ import {
   type ContentProcessingMessage,
 } from "./contract";
 import { CONTENT_SWEEP_REDISPATCHABLE_STATUSES } from "../../../lib/repositories/content-platform/job-state";
+import { releasePostDeployRecoveryJobs } from "../../../lib/repositories/content-platform/post-deploy-recovery";
 import {
   classifyContentProcessingError,
   PermanentContentProcessingError,
@@ -1368,6 +1369,12 @@ function isSqsEvent(event: SQSEvent | EventBridgeEvent<string, unknown>): event 
 export async function handler(event: SQSEvent | EventBridgeEvent<string, unknown>): Promise<SQSBatchResponse | void> {
   await ensureDatabaseCredentials();
   if (!isSqsEvent(event)) {
+    const released = await releasePostDeployRecoveryJobs();
+    if (released.length > 0) {
+      log.info("Released post-deployment unified content recovery jobs", {
+        count: released.length,
+      });
+    }
     await dispatchPendingJobs();
     return;
   }

--- a/lib/db/schema/tables/repository-processing-jobs.ts
+++ b/lib/db/schema/tables/repository-processing-jobs.ts
@@ -31,6 +31,8 @@ export type RepositoryProcessingJobStatus =
   | "cancelled";
 
 export interface RepositoryProcessingMetrics {
+  /** One-time deployment handoff; only the matching worker runtime may release it. */
+  postDeployRecovery?: "unified-content-runtime-v2";
   /** Current managed-service wait, used to enforce a bounded deadline. */
   waitReason?:
     | "CONTENT_PLATFORM_DISABLED"

--- a/lib/db/schema/tables/repository-processing-jobs.ts
+++ b/lib/db/schema/tables/repository-processing-jobs.ts
@@ -1,6 +1,8 @@
 /** Durable, idempotent processing-stage jobs for repository item versions. */
 
+import { sql } from "drizzle-orm";
 import {
+  check,
   index,
   integer,
   jsonb,
@@ -31,7 +33,7 @@ export type RepositoryProcessingJobStatus =
   | "cancelled";
 
 export interface RepositoryProcessingMetrics {
-  /** One-time deployment handoff; only the matching worker runtime may release it. */
+  /** Transitional migration-122 handoff copied into the durable column by migration 123. */
   postDeployRecovery?: "unified-content-runtime-v2";
   /** Current managed-service wait, used to enforce a bounded deadline. */
   waitReason?:
@@ -100,6 +102,10 @@ export const repositoryProcessingJobs = pgTable(
     traceId: varchar("trace_id", { length: 128 }),
     lastErrorCode: varchar("last_error_code", { length: 128 }),
     lastErrorMessage: text("last_error_message"),
+    /** Durable across stale worker writes; only the replacement runtime clears it. */
+    postDeployRecovery: varchar("post_deploy_recovery", { length: 64 }).$type<
+      "unified-content-runtime-v2"
+    >(),
     metrics: jsonb("metrics")
       .$type<RepositoryProcessingMetrics>()
       .default({})
@@ -112,6 +118,13 @@ export const repositoryProcessingJobs = pgTable(
   (t) => [
     unique("uq_repository_processing_idempotency").on(t.idempotencyKey),
     index("idx_repository_processing_version").on(t.itemVersionId, t.createdAt),
+    check(
+      "ck_repository_processing_postdeploy_cancelled",
+      sql`${t.postDeployRecovery} IS NULL OR ${t.status} = 'cancelled'`
+    ),
+    index("idx_repository_processing_postdeploy_recovery")
+      .on(t.updatedAt, t.id)
+      .where(sql`${t.postDeployRecovery} IS NOT NULL`),
   ]
 );
 

--- a/lib/repositories/content-platform/index.ts
+++ b/lib/repositories/content-platform/index.ts
@@ -12,3 +12,4 @@ export * from "./inline-text-ingestion";
 export * from "./text-processing";
 export * from "./status-service";
 export * from "./object-key";
+export * from "./post-deploy-recovery";

--- a/lib/repositories/content-platform/job-state.ts
+++ b/lib/repositories/content-platform/job-state.ts
@@ -46,6 +46,9 @@ const ALLOWED_TRANSITIONS: Record<
   running: ["succeeded", "failed", "cancelled"],
   succeeded: [],
   failed: ["pending", "cancelled"],
+  // Cancelled is terminal for the worker FSM. User retry and post-deploy
+  // release are separate, guarded transaction resets that also clear failure,
+  // lease, attempt, and provider state before returning the job to pending.
   cancelled: [],
 };
 

--- a/lib/repositories/content-platform/post-deploy-recovery.ts
+++ b/lib/repositories/content-platform/post-deploy-recovery.ts
@@ -1,0 +1,114 @@
+import { and, eq, inArray, sql } from "drizzle-orm";
+import {
+  executeTransaction,
+  toPgRows,
+} from "@/lib/db/drizzle-client";
+import {
+  repositoryItems,
+  repositoryItemVersions,
+} from "@/lib/db/schema";
+import { CONTENT_PROCESSING_MAX_ATTEMPTS } from "./job-state";
+
+export const POST_DEPLOY_RECOVERY_MARKER =
+  "unified-content-runtime-v2" as const;
+export const POST_DEPLOY_RECOVERY_BATCH_SIZE = 25;
+
+export interface ReleasedPostDeployRecoveryJob {
+  id: string;
+  itemVersionId: string;
+}
+
+/**
+ * Release one bounded batch of jobs quarantined by the database migration.
+ *
+ * The migration deliberately stores these jobs as `cancelled`, which every old
+ * worker treats as terminal even if a stale SQS delivery arrives between stack
+ * updates. This function ships with the replacement worker and is therefore the
+ * only code path that can atomically restore the job/version/item to pending.
+ */
+export async function releasePostDeployRecoveryJobs(): Promise<
+  ReleasedPostDeployRecoveryJob[]
+> {
+  return executeTransaction(
+    async (tx) => {
+      const releasedResult = await tx.execute(sql`
+        WITH selected AS (
+          SELECT job.id
+          FROM repository_processing_jobs job
+          JOIN repository_item_versions version
+            ON version.id = job.item_version_id
+          JOIN repository_items item
+            ON item.current_version_id = version.id
+          WHERE job.stage = 'inspect'
+            AND job.status = 'cancelled'
+            AND job.metrics ->> 'postDeployRecovery' = ${POST_DEPLOY_RECOVERY_MARKER}
+            AND item.lifecycle_status = 'active'
+            AND version.storage_status <> 'blocked'
+            AND version.inspection_status <> 'blocked'
+            AND version.object_key ~ (
+              '^repositories/' || item.repository_id::text ||
+              '/[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89aAbB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}/[^/]+$'
+            )
+            AND NOT EXISTS (
+              SELECT 1
+              FROM repository_item_chunks active_chunk
+              JOIN knowledge_repositories repository
+                ON repository.id = item.repository_id
+              WHERE active_chunk.item_version_id = version.id
+                AND active_chunk.index_generation_id = repository.active_index_generation_id
+            )
+          ORDER BY job.updated_at, job.id
+          FOR UPDATE OF job SKIP LOCKED
+          LIMIT ${POST_DEPLOY_RECOVERY_BATCH_SIZE}
+        )
+        UPDATE repository_processing_jobs job
+        SET status = 'pending',
+            attempt = 0,
+            max_attempts = ${CONTENT_PROCESSING_MAX_ATTEMPTS},
+            available_at = now(),
+            lease_owner = NULL,
+            lease_expires_at = NULL,
+            last_error_code = NULL,
+            last_error_message = NULL,
+            metrics = '{}'::jsonb,
+            started_at = NULL,
+            finished_at = NULL,
+            updated_at = now()
+        FROM selected
+        WHERE job.id = selected.id
+        RETURNING job.id, job.item_version_id
+      `);
+      const released = toPgRows<{ id: string; item_version_id: string }>(
+        releasedResult
+      ).map((row) => ({ id: row.id, itemVersionId: row.item_version_id }));
+      if (released.length === 0) return [];
+
+      const itemVersionIds = [...new Set(released.map((job) => job.itemVersionId))];
+      await tx
+        .update(repositoryItemVersions)
+        .set({
+          storageStatus: "quarantined",
+          inspectionStatus: "pending",
+          inspectionDetails: {},
+          processingStatus: "pending",
+        })
+        .where(inArray(repositoryItemVersions.id, itemVersionIds));
+      await tx
+        .update(repositoryItems)
+        .set({
+          processingStatus: "pending",
+          processingError: null,
+          updatedAt: new Date(),
+        })
+        .where(
+          and(
+            eq(repositoryItems.lifecycleStatus, "active"),
+            inArray(repositoryItems.currentVersionId, itemVersionIds)
+          )
+        );
+
+      return released;
+    },
+    "contentPlatform.releasePostDeployRecoveryJobs"
+  );
+}

--- a/lib/repositories/content-platform/post-deploy-recovery.ts
+++ b/lib/repositories/content-platform/post-deploy-recovery.ts
@@ -12,10 +12,19 @@ import { CONTENT_PROCESSING_MAX_ATTEMPTS } from "./job-state";
 export const POST_DEPLOY_RECOVERY_MARKER =
   "unified-content-runtime-v2" as const;
 export const POST_DEPLOY_RECOVERY_BATCH_SIZE = 25;
+/** Let every invocation of the previous 15-minute Lambda runtime drain first. */
+export const POST_DEPLOY_RECOVERY_GRACE_MINUTES = 20;
 
 export interface ReleasedPostDeployRecoveryJob {
   id: string;
   itemVersionId: string;
+}
+
+export interface ReleasePostDeployRecoveryOptions {
+  /** Testable clock; production always uses the current time. */
+  now?: Date;
+  /** Test override; production always uses the exported drain window. */
+  graceMinutes?: number;
 }
 
 /**
@@ -23,12 +32,20 @@ export interface ReleasedPostDeployRecoveryJob {
  *
  * The migration deliberately stores these jobs as `cancelled`, which every old
  * worker treats as terminal even if a stale SQS delivery arrives between stack
- * updates. This function ships with the replacement worker and is therefore the
- * only code path that can atomically restore the job/version/item to pending.
+ * updates. After a drain window longer than the old Lambda timeout, this function
+ * also recovers a marked row whose status was overwritten by an invocation that
+ * was already running when the migration committed. It ships with the replacement
+ * worker and is therefore the only automatic path that can atomically restore the
+ * job/version/item to pending.
  */
-export async function releasePostDeployRecoveryJobs(): Promise<
-  ReleasedPostDeployRecoveryJob[]
-> {
+export async function releasePostDeployRecoveryJobs(
+  options: ReleasePostDeployRecoveryOptions = {}
+): Promise<ReleasedPostDeployRecoveryJob[]> {
+  const graceMinutes =
+    options.graceMinutes ?? POST_DEPLOY_RECOVERY_GRACE_MINUTES;
+  const eligibleBefore = new Date(
+    (options.now ?? new Date()).getTime() - graceMinutes * 60_000
+  ).toISOString();
   return executeTransaction(
     async (tx) => {
       const releasedResult = await tx.execute(sql`
@@ -40,8 +57,9 @@ export async function releasePostDeployRecoveryJobs(): Promise<
           JOIN repository_items item
             ON item.current_version_id = version.id
           WHERE job.stage = 'inspect'
-            AND job.status = 'cancelled'
+            AND job.status IN ('cancelled', 'failed', 'pending', 'queued', 'running')
             AND job.metrics ->> 'postDeployRecovery' = ${POST_DEPLOY_RECOVERY_MARKER}
+            AND job.updated_at <= ${eligibleBefore}::timestamptz
             AND item.lifecycle_status = 'active'
             AND version.storage_status <> 'blocked'
             AND version.inspection_status <> 'blocked'

--- a/lib/repositories/content-platform/post-deploy-recovery.ts
+++ b/lib/repositories/content-platform/post-deploy-recovery.ts
@@ -32,11 +32,10 @@ export interface ReleasePostDeployRecoveryOptions {
  *
  * The migration deliberately stores these jobs as `cancelled`, which every old
  * worker treats as terminal even if a stale SQS delivery arrives between stack
- * updates. After a drain window longer than the old Lambda timeout, this function
- * also recovers a marked row whose status was overwritten by an invocation that
- * was already running when the migration committed. It ships with the replacement
- * worker and is therefore the only automatic path that can atomically restore the
- * job/version/item to pending.
+ * updates. A dedicated marker and database constraint prevent an invocation that
+ * was already running from making the row claimable again. After a drain window
+ * longer than the old Lambda timeout, this replacement-worker path atomically
+ * clears that marker while restoring the job/version/item to pending.
  */
 export async function releasePostDeployRecoveryJobs(
   options: ReleasePostDeployRecoveryOptions = {}

--- a/lib/repositories/content-platform/post-deploy-recovery.ts
+++ b/lib/repositories/content-platform/post-deploy-recovery.ts
@@ -58,7 +58,7 @@ export async function releasePostDeployRecoveryJobs(
             ON item.current_version_id = version.id
           WHERE job.stage = 'inspect'
             AND job.status IN ('cancelled', 'failed', 'pending', 'queued', 'running')
-            AND job.metrics ->> 'postDeployRecovery' = ${POST_DEPLOY_RECOVERY_MARKER}
+            AND job.post_deploy_recovery = ${POST_DEPLOY_RECOVERY_MARKER}
             AND job.updated_at <= ${eligibleBefore}::timestamptz
             AND item.lifecycle_status = 'active'
             AND version.storage_status <> 'blocked'
@@ -88,6 +88,7 @@ export async function releasePostDeployRecoveryJobs(
             lease_expires_at = NULL,
             last_error_code = NULL,
             last_error_message = NULL,
+            post_deploy_recovery = NULL,
             metrics = '{}'::jsonb,
             started_at = NULL,
             finished_at = NULL,

--- a/lib/repositories/content-platform/status-service.ts
+++ b/lib/repositories/content-platform/status-service.ts
@@ -34,6 +34,7 @@ interface CanonicalStatusRow {
   jobAttempt: number | null;
   jobMaxAttempts: number | null;
   jobError: string | null;
+  postDeployRecovery: "unified-content-runtime-v2" | null;
   active: boolean;
   buildingGeneration: boolean;
   failedGeneration: boolean;
@@ -47,6 +48,15 @@ export function resolveCanonicalItemStatus(
     return {
       itemId: row.itemId,
       processingStatus: "embedded",
+      processingError: null,
+      canRetry: false,
+    };
+  }
+
+  if (row.postDeployRecovery !== null) {
+    return {
+      itemId: row.itemId,
+      processingStatus: "retrying",
       processingError: null,
       canRetry: false,
     };
@@ -130,6 +140,7 @@ export async function getCanonicalRepositoryItemStatuses(
           jobAttempt: repositoryProcessingJobs.attempt,
           jobMaxAttempts: repositoryProcessingJobs.maxAttempts,
           jobError: repositoryProcessingJobs.lastErrorMessage,
+          postDeployRecovery: repositoryProcessingJobs.postDeployRecovery,
           active: sql<boolean>`EXISTS (
             SELECT 1
             FROM ${repositoryItemChunks} active_chunk
@@ -196,6 +207,35 @@ export interface RetryCanonicalItemResult {
   processingJobId: string;
 }
 
+const POST_DEPLOY_RECOVERY_RETRY_MESSAGE =
+  "This item is awaiting automatic post-deployment recovery";
+
+/** Prevent alternate retry paths from superseding a quarantined current version. */
+export async function assertCanonicalRetryNotQuarantined(
+  itemVersionId: string
+): Promise<void> {
+  const [job] = await executeQuery(
+    (db) =>
+      db
+        .select({
+          postDeployRecovery: repositoryProcessingJobs.postDeployRecovery,
+        })
+        .from(repositoryProcessingJobs)
+        .where(
+          and(
+            eq(repositoryProcessingJobs.itemVersionId, itemVersionId),
+            eq(repositoryProcessingJobs.stage, "inspect")
+          )
+        )
+        .orderBy(desc(repositoryProcessingJobs.createdAt))
+        .limit(1),
+    "contentPlatform.assertCanonicalRetryNotQuarantined"
+  );
+  if (job && job.postDeployRecovery !== null) {
+    throw new Error(POST_DEPLOY_RECOVERY_RETRY_MESSAGE);
+  }
+}
+
 /** Reset a terminal current version to its durable inspect job for reprocessing. */
 export async function retryCanonicalRepositoryItem(
   itemId: number,
@@ -235,6 +275,9 @@ export async function retryCanonicalRepositoryItem(
         .limit(1)
         .for("update");
       if (!job) throw new Error("The item has no processing job to retry");
+      if (job.postDeployRecovery !== null) {
+        throw new Error(POST_DEPLOY_RECOVERY_RETRY_MESSAGE);
+      }
       if (
         job.status !== "failed" &&
         job.status !== "cancelled" &&

--- a/lib/repositories/content-platform/status-service.ts
+++ b/lib/repositories/content-platform/status-service.ts
@@ -269,6 +269,7 @@ export async function retryCanonicalRepositoryItem(
           traceId: traceId ?? job.traceId,
           lastErrorCode: null,
           lastErrorMessage: null,
+          postDeployRecovery: null,
           metrics: {},
           startedAt: null,
           finishedAt: null,

--- a/lib/repositories/content-platform/status-service.ts
+++ b/lib/repositories/content-platform/status-service.ts
@@ -54,6 +54,7 @@ export function resolveCanonicalItemStatus(
 
   const terminalFailure =
     row.versionStatus === "failed" ||
+    row.versionStatus === "cancelled" ||
     row.storageStatus === "blocked" ||
     row.inspectionStatus === "blocked" ||
     row.inspectionStatus === "error" ||
@@ -61,10 +62,8 @@ export function resolveCanonicalItemStatus(
       !row.buildingGeneration &&
       row.versionStatus === "completed" &&
       row.jobStatus === "succeeded") ||
-    (row.jobStatus === "failed" &&
-      row.jobAttempt !== null &&
-      row.jobMaxAttempts !== null &&
-      row.jobAttempt >= row.jobMaxAttempts);
+    row.jobStatus === "failed" ||
+    row.jobStatus === "cancelled";
   if (terminalFailure) {
     return {
       itemId: row.itemId,
@@ -88,7 +87,11 @@ export function resolveCanonicalItemStatus(
     };
   }
 
-  if (row.jobStatus === "failed") {
+  if (
+    (row.jobStatus === "pending" || row.jobStatus === "queued") &&
+    row.jobAttempt !== null &&
+    row.jobAttempt > 0
+  ) {
     return {
       itemId: row.itemId,
       processingStatus: "retrying",
@@ -227,7 +230,11 @@ export async function retryCanonicalRepositoryItem(
         .limit(1)
         .for("update");
       if (!job) throw new Error("The item has no processing job to retry");
-      if (job.status !== "failed" && job.status !== "succeeded") {
+      if (
+        job.status !== "failed" &&
+        job.status !== "cancelled" &&
+        job.status !== "succeeded"
+      ) {
         throw new Error("The item is already being processed");
       }
 
@@ -249,16 +256,16 @@ export async function retryCanonicalRepositoryItem(
         .update(repositoryProcessingJobs)
         .set({
           status: "pending",
-          maxAttempts: Math.max(
-            job.maxAttempts,
-            job.attempt + CONTENT_PROCESSING_MAX_ATTEMPTS
-          ),
+          attempt: 0,
+          maxAttempts: CONTENT_PROCESSING_MAX_ATTEMPTS,
           availableAt: now,
           leaseOwner: null,
           leaseExpiresAt: null,
           traceId: traceId ?? job.traceId,
           lastErrorCode: null,
           lastErrorMessage: null,
+          metrics: {},
+          startedAt: null,
           finishedAt: null,
           updatedAt: now,
         })
@@ -268,6 +275,7 @@ export async function retryCanonicalRepositoryItem(
         .set({
           storageStatus: "quarantined",
           inspectionStatus: "pending",
+          inspectionDetails: {},
           processingStatus: "pending",
         })
         .where(eq(repositoryItemVersions.id, context.itemVersionId));

--- a/lib/repositories/content-platform/status-service.ts
+++ b/lib/repositories/content-platform/status-service.ts
@@ -225,7 +225,12 @@ export async function retryCanonicalRepositoryItem(
       const [job] = await tx
         .select()
         .from(repositoryProcessingJobs)
-        .where(eq(repositoryProcessingJobs.itemVersionId, context.itemVersionId))
+        .where(
+          and(
+            eq(repositoryProcessingJobs.itemVersionId, context.itemVersionId),
+            eq(repositoryProcessingJobs.stage, "inspect")
+          )
+        )
         .orderBy(desc(repositoryProcessingJobs.createdAt))
         .limit(1)
         .for("update");

--- a/tests/e2e/assistant-architect-parallel-persistence.spec.ts
+++ b/tests/e2e/assistant-architect-parallel-persistence.spec.ts
@@ -24,10 +24,10 @@ const Y_POSITION_TOLERANCE = 10 // px - tolerance for grouping nodes at same ver
 test.use({ storageState: 'tests/e2e/.auth/user-a.json' })
 
 /**
- * Open the ReactFlow prompts editor of the first architect the current user owns.
- * Navigates list -> real architect card -> its /edit/prompts route. The card body
- * isn't a link and there is no "Prompts" tab, so we read the card's Edit href and
- * go to "<href>/prompts" directly. Returns false when the user owns no architect.
+ * Open the ReactFlow prompts editor for the deterministic parallel fixture.
+ * Other E2E fixtures also create assistants, so selecting the first Edit link
+ * makes this layout contract depend on database ordering and can silently open a
+ * standard serial assistant. Returns false when the fixture was not seeded.
  */
 async function openPromptsEditor(page: Page): Promise<boolean> {
   await page.goto('/utilities/assistant-architect')
@@ -37,11 +37,11 @@ async function openPromptsEditor(page: Page): Promise<boolean> {
   // found" card has no such link, so this skips cleanly when the user owns none
   // (avoids matching shadcn's bg-card on the empty card).
   const editLink = page.locator(
-    'a[href^="/utilities/assistant-architect/"][href$="/edit"]'
+    'a[href="/utilities/assistant-architect/9000/edit"]'
   )
   if ((await editLink.count()) === 0) return false
 
-  const editHref = await editLink.first().getAttribute('href')
+  const editHref = await editLink.getAttribute('href')
   if (!editHref) return false
 
   await page.goto(editHref.replace(/\/edit$/, '/edit/prompts'))

--- a/tests/e2e/fixtures/unified-content-repository-seed.sql
+++ b/tests/e2e/fixtures/unified-content-repository-seed.sql
@@ -129,20 +129,22 @@ VALUES (
   'inspect',
   'failed',
   'e2e-terminal-retry:inspect',
-  5,
-  5,
+  1,
+  20,
   'E2E_TERMINAL_FAILURE',
   'Simulated terminal processing failure',
   now()
 )
 ON CONFLICT (id) DO UPDATE
 SET status = 'failed',
-    attempt = 5,
-    max_attempts = 5,
+    attempt = 1,
+    max_attempts = 20,
     available_at = now(),
     lease_owner = NULL,
     lease_expires_at = NULL,
     last_error_code = 'E2E_TERMINAL_FAILURE',
     last_error_message = 'Simulated terminal processing failure',
+    metrics = '{"textractJobId":"stale-e2e-job","waitReason":"AWAITING_OCR"}'::jsonb,
+    started_at = now(),
     finished_at = now(),
     updated_at = now();

--- a/tests/smoke/unified-content-foundation.smoke.ts
+++ b/tests/smoke/unified-content-foundation.smoke.ts
@@ -12,10 +12,16 @@
  */
 
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
 import { eq, sql, type SQL } from "drizzle-orm";
 import { PDFDocument, StandardFonts } from "pdf-lib";
 import * as XLSX from "@e965/xlsx";
-import { closeDatabase, executeQuery } from "@/lib/db/drizzle-client";
+import {
+  closeDatabase,
+  executeQuery,
+  executeTransaction,
+} from "@/lib/db/drizzle-client";
 import {
   knowledgeRepositories,
   repositoryArtifacts,
@@ -41,6 +47,8 @@ import {
   IMAGE_PROCESSOR_VERSION,
   publishDocumentVersion,
   publishPdfVersion,
+  POST_DEPLOY_RECOVERY_MARKER,
+  releasePostDeployRecoveryJobs,
   getCanonicalRepositoryItemStatuses,
   registerCanonicalUpload,
   retryCanonicalRepositoryItem,
@@ -56,6 +64,13 @@ import {
 } from "../../infra/lambdas/embedding-generator/generation-activation";
 
 const pdf = await PDFDocument.create();
+const postDeployHandoffSql = readFileSync(
+  resolve(
+    process.cwd(),
+    "infra/database/schema/123-unified-content-postdeploy-handoff.sql"
+  ),
+  "utf8"
+);
 const font = await pdf.embedFont(StandardFonts.Helvetica);
 for (const text of [
   "Page one contains the district emergency procedure and contact instructions.",
@@ -246,6 +261,8 @@ try {
     waitStartedAt: "2026-07-22T12:00:00.000Z",
   });
 
+  const retryObjectKey =
+    `repositories/${repository.id}/22222222-3333-4444-8555-666666666666/retry-reference.pdf`;
   const [retryItem] = await executeQuery(
     (db) =>
       db
@@ -254,7 +271,7 @@ try {
           repositoryId: repository.id,
           type: "document",
           name: "retry-reference.pdf",
-          source: `repositories/${repository.id}/22222222-3333-4444-8555-666666666666/retry-reference.pdf`,
+          source: retryObjectKey,
           processingStatus: "pending",
         })
         .returning({ id: repositoryItems.id }),
@@ -264,7 +281,7 @@ try {
   const retryRegistration = await registerCanonicalUpload({
     itemId: retryItem.id,
     userId: owner.id,
-    objectKey: `repositories/${repository.id}/22222222-3333-4444-8555-666666666666/retry-reference.pdf`,
+    objectKey: retryObjectKey,
     originalFileName: "retry-reference.pdf",
     declaredContentType: "application/pdf",
     byteSize: 4096,
@@ -276,8 +293,12 @@ try {
         WITH failed_job AS (
           UPDATE repository_processing_jobs
           SET status = 'failed',
-              attempt = max_attempts,
+              attempt = 1,
+              max_attempts = 20,
+              last_error_code = 'PROCESSING_ERROR',
               last_error_message = 'simulated terminal processing failure',
+              metrics = '{"textractJobId":"stale-provider-job","waitReason":"AWAITING_OCR"}'::jsonb,
+              started_at = now(),
               finished_at = now()
           WHERE id = ${retryRegistration.inspectJob.id}::uuid
           RETURNING item_version_id
@@ -301,6 +322,165 @@ try {
     processingError: "simulated terminal processing failure",
     canRetry: true,
   });
+
+  // Reproduce the real CDK order: the migration runs while the old worker is
+  // still deployed. It must leave the recovery job terminal and unavailable.
+  await executeQuery(
+    (db) => db.execute(sql.raw(postDeployHandoffSql)),
+    "smoke.unifiedContent.applyPostDeployHandoff"
+  );
+  const [quarantinedState] = await executeQuery(
+    (db) =>
+      db
+        .select({
+          jobStatus: repositoryProcessingJobs.status,
+          attempt: repositoryProcessingJobs.attempt,
+          maxAttempts: repositoryProcessingJobs.maxAttempts,
+          metrics: repositoryProcessingJobs.metrics,
+          availableAt: sql<string>`${repositoryProcessingJobs.availableAt}::text`,
+          versionStatus: repositoryItemVersions.processingStatus,
+          itemStatus: repositoryItems.processingStatus,
+        })
+        .from(repositoryProcessingJobs)
+        .innerJoin(
+          repositoryItemVersions,
+          eq(repositoryItemVersions.id, repositoryProcessingJobs.itemVersionId)
+        )
+        .innerJoin(
+          repositoryItems,
+          eq(repositoryItems.currentVersionId, repositoryItemVersions.id)
+        )
+        .where(eq(repositoryProcessingJobs.id, retryRegistration.inspectJob.id))
+        .limit(1),
+    "smoke.unifiedContent.readQuarantinedHandoff"
+  );
+  assert.equal(quarantinedState?.jobStatus, "cancelled");
+  assert.equal(quarantinedState?.attempt, 0);
+  assert.equal(
+    quarantinedState?.maxAttempts,
+    CONTENT_PROCESSING_MAX_ATTEMPTS
+  );
+  assert.deepEqual(quarantinedState?.metrics, {
+    postDeployRecovery: POST_DEPLOY_RECOVERY_MARKER,
+  });
+  assert.equal(quarantinedState?.availableAt, "infinity");
+  assert.equal(quarantinedState?.versionStatus, "failed");
+  assert.equal(quarantinedState?.itemStatus, "failed");
+
+  const [oldWorkerSweep] = await executeQuery(
+    (db) =>
+      db
+        .select({ count: sql<number>`count(*)::int` })
+        .from(repositoryProcessingJobs)
+        .where(
+          sql`${repositoryProcessingJobs.id} = ${retryRegistration.inspectJob.id}::uuid
+            AND ${repositoryProcessingJobs.status} = 'pending'
+            AND ${repositoryProcessingJobs.availableAt} <= now()`
+        ),
+    "smoke.unifiedContent.oldWorkerSweep"
+  );
+  assert.equal(oldWorkerSweep?.count, 0);
+
+  const released = await releasePostDeployRecoveryJobs();
+  assert.deepEqual(released, [
+    {
+      id: retryRegistration.inspectJob.id,
+      itemVersionId: retryRegistration.version.id,
+    },
+  ]);
+  const [releasedState] = await executeQuery(
+    (db) =>
+      db
+        .select({
+          jobStatus: repositoryProcessingJobs.status,
+          attempt: repositoryProcessingJobs.attempt,
+          maxAttempts: repositoryProcessingJobs.maxAttempts,
+          metrics: repositoryProcessingJobs.metrics,
+          versionStatus: repositoryItemVersions.processingStatus,
+          inspectionStatus: repositoryItemVersions.inspectionStatus,
+          itemStatus: repositoryItems.processingStatus,
+        })
+        .from(repositoryProcessingJobs)
+        .innerJoin(
+          repositoryItemVersions,
+          eq(repositoryItemVersions.id, repositoryProcessingJobs.itemVersionId)
+        )
+        .innerJoin(
+          repositoryItems,
+          eq(repositoryItems.currentVersionId, repositoryItemVersions.id)
+        )
+        .where(eq(repositoryProcessingJobs.id, retryRegistration.inspectJob.id))
+        .limit(1),
+    "smoke.unifiedContent.readReleasedHandoff"
+  );
+  assert.deepEqual(releasedState, {
+    jobStatus: "pending",
+    attempt: 0,
+    maxAttempts: CONTENT_PROCESSING_MAX_ATTEMPTS,
+    metrics: {},
+    versionStatus: "pending",
+    inspectionStatus: "pending",
+    itemStatus: "pending",
+  });
+
+  // Even a correctly marked row cannot bypass the canonical source namespace.
+  await executeTransaction(
+    async (tx) => {
+      await tx
+        .update(repositoryProcessingJobs)
+        .set({
+          status: "cancelled",
+          availableAt: sql`'infinity'::timestamptz`,
+          metrics: { postDeployRecovery: POST_DEPLOY_RECOVERY_MARKER },
+        })
+        .where(eq(repositoryProcessingJobs.id, retryRegistration.inspectJob.id));
+      await tx
+        .update(repositoryItemVersions)
+        .set({
+          objectKey: `repositories/${repository.id}/legacy/retry-reference.pdf`,
+        })
+        .where(eq(repositoryItemVersions.id, retryRegistration.version.id));
+    },
+    "smoke.unifiedContent.createNoncanonicalMarkedHandoff"
+  );
+  assert.deepEqual(await releasePostDeployRecoveryJobs(), []);
+  await executeQuery(
+    (db) =>
+      db
+        .update(repositoryItemVersions)
+        .set({ objectKey: retryObjectKey })
+        .where(eq(repositoryItemVersions.id, retryRegistration.version.id)),
+    "smoke.unifiedContent.restoreCanonicalRetrySource"
+  );
+
+  // A user retry gets another clean bounded budget even when the terminal row
+  // was cancelled and still carried provider state from an earlier runtime.
+  await executeQuery(
+    (db) =>
+      db.execute(sql`
+        WITH cancelled_job AS (
+          UPDATE repository_processing_jobs
+          SET status = 'cancelled',
+              attempt = 4,
+              max_attempts = 20,
+              metrics = '{"textractJobId":"stale-cancelled-job"}'::jsonb,
+              started_at = now(),
+              finished_at = now()
+          WHERE id = ${retryRegistration.inspectJob.id}::uuid
+          RETURNING item_version_id
+        ), cancelled_version AS (
+          UPDATE repository_item_versions
+          SET inspection_status = 'error', processing_status = 'cancelled'
+          WHERE id IN (SELECT item_version_id FROM cancelled_job)
+          RETURNING item_id
+        )
+        UPDATE repository_items
+        SET processing_status = 'failed',
+            processing_error = 'simulated cancelled deployment job'
+        WHERE id IN (SELECT item_id FROM cancelled_version)
+      `),
+    "smoke.unifiedContent.createCancelledRetryState"
+  );
   const restarted = await retryCanonicalRepositoryItem(
     retryItem.id,
     "unified-content-smoke-manual-retry"
@@ -314,6 +494,8 @@ try {
           jobStatus: repositoryProcessingJobs.status,
           attempt: repositoryProcessingJobs.attempt,
           maxAttempts: repositoryProcessingJobs.maxAttempts,
+          metrics: repositoryProcessingJobs.metrics,
+          startedAt: repositoryProcessingJobs.startedAt,
           versionStatus: repositoryItemVersions.processingStatus,
           storageStatus: repositoryItemVersions.storageStatus,
           itemStatus: repositoryItems.processingStatus,
@@ -332,11 +514,10 @@ try {
     "smoke.unifiedContent.readRestartedState"
   );
   assert.equal(restartedState?.jobStatus, "pending");
-  assert.equal(restartedState?.attempt, CONTENT_PROCESSING_MAX_ATTEMPTS);
-  assert.equal(
-    restartedState?.maxAttempts,
-    CONTENT_PROCESSING_MAX_ATTEMPTS * 2
-  );
+  assert.equal(restartedState?.attempt, 0);
+  assert.equal(restartedState?.maxAttempts, CONTENT_PROCESSING_MAX_ATTEMPTS);
+  assert.deepEqual(restartedState?.metrics, {});
+  assert.equal(restartedState?.startedAt, null);
   assert.equal(restartedState?.versionStatus, "pending");
   assert.equal(restartedState?.storageStatus, "quarantined");
   assert.equal(restartedState?.itemStatus, "pending");
@@ -770,11 +951,16 @@ try {
     canonicalOnly: true,
   });
   assert.equal(imageResultsBeforeActivation.length, 0);
-  const activationExecutor: GenerationActivationExecutor = async (query) => {
-    const rows = await executeQuery(
-      // The Lambda package has its own dependency boundary, so bridge its
-      // structurally identical Drizzle SQL object into the app workspace.
-      (db) => db.execute(query as unknown as SQL),
+  const activationExecutor: GenerationActivationExecutor = async (plan) => {
+    const rows = await executeTransaction(
+      async (tx) => {
+        // The Lambda package has its own dependency boundary, so bridge its
+        // structurally identical Drizzle SQL objects into the app workspace.
+        await tx.execute(plan.lockRepository as unknown as SQL);
+        await tx.execute(plan.supersedeCurrent as unknown as SQL);
+        await tx.execute(plan.activateTarget as unknown as SQL);
+        return tx.execute(plan.publishTarget as unknown as SQL);
+      },
       "smoke.unifiedContent.activateEmbeddedGeneration"
     );
     return rows as unknown as GenerationActivationResult[];
@@ -817,6 +1003,15 @@ try {
   );
   assert.equal(activation?.repository_id, repository.id);
   assert.ok((activation?.embedded_item_count ?? 0) >= 3);
+  const replayedActivation = await activateCompletedGeneration(
+    imagePublication.generationId,
+    activationExecutor
+  );
+  assert.equal(replayedActivation?.repository_id, repository.id);
+  assert.equal(
+    replayedActivation?.embedded_item_count,
+    activation?.embedded_item_count
+  );
   const imageResults = await keywordSearch("marked assembly", {
     repositoryId: repository.id,
     canonicalOnly: true,

--- a/tests/smoke/unified-content-foundation.smoke.ts
+++ b/tests/smoke/unified-content-foundation.smoke.ts
@@ -466,6 +466,43 @@ try {
   assert.equal(quarantinedState?.versionStatus, "pending");
   assert.equal(quarantinedState?.itemStatus, "pending");
 
+  const quarantinedStatuses = await getCanonicalRepositoryItemStatuses(
+    repository.id
+  );
+  assert.deepEqual(quarantinedStatuses.get(retryItem.id), {
+    itemId: retryItem.id,
+    processingStatus: "retrying",
+    processingError: null,
+    canRetry: false,
+  });
+  await assert.rejects(
+    retryCanonicalRepositoryItem(
+      retryItem.id,
+      "unified-content-smoke-quarantined-retry"
+    ),
+    /awaiting automatic post-deployment recovery/
+  );
+  const [blockedRetryState] = await executeQuery(
+    (db) =>
+      db
+        .select({
+          status: repositoryProcessingJobs.status,
+          attempt: repositoryProcessingJobs.attempt,
+          postDeployRecovery: repositoryProcessingJobs.postDeployRecovery,
+          availableAt: sql<string>`${repositoryProcessingJobs.availableAt}::text`,
+        })
+        .from(repositoryProcessingJobs)
+        .where(eq(repositoryProcessingJobs.id, retryRegistration.inspectJob.id))
+        .limit(1),
+    "smoke.unifiedContent.readBlockedQuarantineRetry"
+  );
+  assert.deepEqual(blockedRetryState, {
+    status: "cancelled",
+    attempt: 0,
+    postDeployRecovery: POST_DEPLOY_RECOVERY_MARKER,
+    availableAt: "infinity",
+  });
+
   const [oldWorkerSweep] = await executeQuery(
     (db) =>
       db
@@ -618,6 +655,18 @@ try {
         .set({ objectKey: retryObjectKey })
         .where(eq(repositoryItemVersions.id, retryRegistration.version.id)),
     "smoke.unifiedContent.restoreCanonicalRetrySource"
+  );
+  assert.deepEqual(
+    await releasePostDeployRecoveryJobs({
+      graceMinutes: 0,
+      now: new Date(Date.now() + 60_000),
+    }),
+    [
+      {
+        id: retryRegistration.inspectJob.id,
+        itemVersionId: retryRegistration.version.id,
+      },
+    ]
   );
 
   // A user retry gets another clean bounded budget even when the terminal row

--- a/tests/smoke/unified-content-foundation.smoke.ts
+++ b/tests/smoke/unified-content-foundation.smoke.ts
@@ -323,11 +323,87 @@ try {
     canRetry: true,
   });
 
-  // Reproduce the real CDK order: the migration runs while the old worker is
-  // still deployed. It must leave the recovery job terminal and unavailable.
+  // Migration 123 must not replay an unrelated terminal user failure merely
+  // because it is a current canonical inspect job.
   await executeQuery(
     (db) => db.execute(sql.raw(postDeployHandoffSql)),
     "smoke.unifiedContent.applyPostDeployHandoff"
+  );
+  const [untouchedFailure] = await executeQuery(
+    (db) =>
+      db
+        .select({
+          jobStatus: repositoryProcessingJobs.status,
+          attempt: repositoryProcessingJobs.attempt,
+          maxAttempts: repositoryProcessingJobs.maxAttempts,
+          errorCode: repositoryProcessingJobs.lastErrorCode,
+          metrics: repositoryProcessingJobs.metrics,
+          versionStatus: repositoryItemVersions.processingStatus,
+          itemStatus: repositoryItems.processingStatus,
+        })
+        .from(repositoryProcessingJobs)
+        .innerJoin(
+          repositoryItemVersions,
+          eq(repositoryItemVersions.id, repositoryProcessingJobs.itemVersionId)
+        )
+        .innerJoin(
+          repositoryItems,
+          eq(repositoryItems.currentVersionId, repositoryItemVersions.id)
+        )
+        .where(eq(repositoryProcessingJobs.id, retryRegistration.inspectJob.id))
+        .limit(1),
+    "smoke.unifiedContent.readUnrelatedTerminalFailure"
+  );
+  assert.deepEqual(untouchedFailure, {
+    jobStatus: "failed",
+    attempt: 1,
+    maxAttempts: 20,
+    errorCode: "PROCESSING_ERROR",
+    metrics: {
+      textractJobId: "stale-provider-job",
+      waitReason: "AWAITING_OCR",
+    },
+    versionStatus: "failed",
+    itemStatus: "failed",
+  });
+
+  // Reproduce the exact live post-migration state that requires the handoff:
+  // the old runtime cancelled a migration-122 replay while content processing
+  // was unavailable during deployment.
+  await executeQuery(
+    (db) =>
+      db.execute(sql`
+        WITH cancelled_job AS (
+          UPDATE repository_processing_jobs
+          SET status = 'cancelled',
+              attempt = 2,
+              max_attempts = 20,
+              last_error_code = 'CONTENT_PLATFORM_DISABLED',
+              last_error_message = 'old runtime could not read the canonical source',
+              metrics = '{}'::jsonb,
+              started_at = now(),
+              finished_at = now(),
+              updated_at = now()
+          WHERE id = ${retryRegistration.inspectJob.id}::uuid
+          RETURNING item_version_id
+        ), pending_version AS (
+          UPDATE repository_item_versions
+          SET storage_status = 'quarantined',
+              inspection_status = 'pending',
+              processing_status = 'pending'
+          WHERE id IN (SELECT item_version_id FROM cancelled_job)
+          RETURNING item_id
+        )
+        UPDATE repository_items
+        SET processing_status = 'pending',
+            processing_error = NULL
+        WHERE id IN (SELECT item_id FROM pending_version)
+      `),
+    "smoke.unifiedContent.createKnownPostDeployFailure"
+  );
+  await executeQuery(
+    (db) => db.execute(sql.raw(postDeployHandoffSql)),
+    "smoke.unifiedContent.reapplyPostDeployHandoff"
   );
   const [quarantinedState] = await executeQuery(
     (db) =>
@@ -364,8 +440,8 @@ try {
     postDeployRecovery: POST_DEPLOY_RECOVERY_MARKER,
   });
   assert.equal(quarantinedState?.availableAt, "infinity");
-  assert.equal(quarantinedState?.versionStatus, "failed");
-  assert.equal(quarantinedState?.itemStatus, "failed");
+  assert.equal(quarantinedState?.versionStatus, "pending");
+  assert.equal(quarantinedState?.itemStatus, "pending");
 
   const [oldWorkerSweep] = await executeQuery(
     (db) =>
@@ -381,7 +457,13 @@ try {
   );
   assert.equal(oldWorkerSweep?.count, 0);
 
-  const released = await releasePostDeployRecoveryJobs();
+  // The replacement runtime must wait longer than the old Lambda's maximum
+  // execution time before releasing a marked row.
+  assert.deepEqual(await releasePostDeployRecoveryJobs(), []);
+  const released = await releasePostDeployRecoveryJobs({
+    graceMinutes: 0,
+    now: new Date(Date.now() + 60_000),
+  });
   assert.deepEqual(released, [
     {
       id: retryRegistration.inspectJob.id,
@@ -443,7 +525,13 @@ try {
     },
     "smoke.unifiedContent.createNoncanonicalMarkedHandoff"
   );
-  assert.deepEqual(await releasePostDeployRecoveryJobs(), []);
+  assert.deepEqual(
+    await releasePostDeployRecoveryJobs({
+      graceMinutes: 0,
+      now: new Date(Date.now() + 60_000),
+    }),
+    []
+  );
   await executeQuery(
     (db) =>
       db
@@ -481,6 +569,21 @@ try {
       `),
     "smoke.unifiedContent.createCancelledRetryState"
   );
+  const [newerDownstreamJob] = await executeQuery(
+    (db) =>
+      db
+        .insert(repositoryProcessingJobs)
+        .values({
+          itemVersionId: retryRegistration.version.id,
+          stage: "normalize",
+          status: "succeeded",
+          idempotencyKey: `${retryRegistration.version.id}:normalize:smoke`,
+          finishedAt: new Date(),
+        })
+        .returning({ id: repositoryProcessingJobs.id }),
+    "smoke.unifiedContent.createNewerDownstreamJob"
+  );
+  assert.ok(newerDownstreamJob);
   const restarted = await retryCanonicalRepositoryItem(
     retryItem.id,
     "unified-content-smoke-manual-retry"
@@ -521,6 +624,16 @@ try {
   assert.equal(restartedState?.versionStatus, "pending");
   assert.equal(restartedState?.storageStatus, "quarantined");
   assert.equal(restartedState?.itemStatus, "pending");
+  const [downstreamState] = await executeQuery(
+    (db) =>
+      db
+        .select({ status: repositoryProcessingJobs.status })
+        .from(repositoryProcessingJobs)
+        .where(eq(repositoryProcessingJobs.id, newerDownstreamJob.id))
+        .limit(1),
+    "smoke.unifiedContent.readUnchangedDownstreamJob"
+  );
+  assert.equal(downstreamState?.status, "succeeded");
 
   const publication = await publishPdfVersion({
     itemVersionId: first.version.id,

--- a/tests/smoke/unified-content-foundation.smoke.ts
+++ b/tests/smoke/unified-content-foundation.smoke.ts
@@ -71,6 +71,24 @@ const postDeployHandoffSql = readFileSync(
   ),
   "utf8"
 );
+const postDeployHandoffStatements = postDeployHandoffSql
+  .split(/;\s*(?:\r?\n|$)/)
+  .map((statement) => statement.trim())
+  .filter((statement) => statement.length > 0);
+
+async function applyPostDeployHandoff(context: string): Promise<void> {
+  for (const [index, statement] of postDeployHandoffStatements.entries()) {
+    await executeQuery(
+      (db) => db.execute(sql.raw(statement)),
+      `${context}.${index + 1}`
+    );
+  }
+}
+
+// The deployment always migrates the database before the application or worker
+// loads the expanded Drizzle schema. Reproduce that order in the standalone
+// smoke, whose local database may predate this branch.
+await applyPostDeployHandoff("smoke.unifiedContent.ensurePostDeploySchema");
 const font = await pdf.embedFont(StandardFonts.Helvetica);
 for (const text of [
   "Page one contains the district emergency procedure and contact instructions.",
@@ -325,8 +343,7 @@ try {
 
   // Migration 123 must not replay an unrelated terminal user failure merely
   // because it is a current canonical inspect job.
-  await executeQuery(
-    (db) => db.execute(sql.raw(postDeployHandoffSql)),
+  await applyPostDeployHandoff(
     "smoke.unifiedContent.applyPostDeployHandoff"
   );
   const [untouchedFailure] = await executeQuery(
@@ -337,6 +354,7 @@ try {
           attempt: repositoryProcessingJobs.attempt,
           maxAttempts: repositoryProcessingJobs.maxAttempts,
           errorCode: repositoryProcessingJobs.lastErrorCode,
+          postDeployRecovery: repositoryProcessingJobs.postDeployRecovery,
           metrics: repositoryProcessingJobs.metrics,
           versionStatus: repositoryItemVersions.processingStatus,
           itemStatus: repositoryItems.processingStatus,
@@ -359,6 +377,7 @@ try {
     attempt: 1,
     maxAttempts: 20,
     errorCode: "PROCESSING_ERROR",
+    postDeployRecovery: null,
     metrics: {
       textractJobId: "stale-provider-job",
       waitReason: "AWAITING_OCR",
@@ -401,8 +420,7 @@ try {
       `),
     "smoke.unifiedContent.createKnownPostDeployFailure"
   );
-  await executeQuery(
-    (db) => db.execute(sql.raw(postDeployHandoffSql)),
+  await applyPostDeployHandoff(
     "smoke.unifiedContent.reapplyPostDeployHandoff"
   );
   const [quarantinedState] = await executeQuery(
@@ -412,6 +430,7 @@ try {
           jobStatus: repositoryProcessingJobs.status,
           attempt: repositoryProcessingJobs.attempt,
           maxAttempts: repositoryProcessingJobs.maxAttempts,
+          postDeployRecovery: repositoryProcessingJobs.postDeployRecovery,
           metrics: repositoryProcessingJobs.metrics,
           availableAt: sql<string>`${repositoryProcessingJobs.availableAt}::text`,
           versionStatus: repositoryItemVersions.processingStatus,
@@ -439,6 +458,10 @@ try {
   assert.deepEqual(quarantinedState?.metrics, {
     postDeployRecovery: POST_DEPLOY_RECOVERY_MARKER,
   });
+  assert.equal(
+    quarantinedState?.postDeployRecovery,
+    POST_DEPLOY_RECOVERY_MARKER
+  );
   assert.equal(quarantinedState?.availableAt, "infinity");
   assert.equal(quarantinedState?.versionStatus, "pending");
   assert.equal(quarantinedState?.itemStatus, "pending");
@@ -456,6 +479,59 @@ try {
     "smoke.unifiedContent.oldWorkerSweep"
   );
   assert.equal(oldWorkerSweep?.count, 0);
+
+  // A worker invocation that claimed the job before the migration may replace
+  // the complete metrics object after the migration commits. The durable column
+  // survives because old code does not know about it.
+  await executeQuery(
+    (db) =>
+      db
+        .update(repositoryProcessingJobs)
+        .set({
+          metrics: { waitReason: "CONTENT_PLATFORM_DISABLED" },
+          updatedAt: new Date(),
+        })
+        .where(eq(repositoryProcessingJobs.id, retryRegistration.inspectJob.id)),
+    "smoke.unifiedContent.simulateStaleWorkerMetricsOverwrite"
+  );
+
+  // Every actual stale completion/defer path also tries to move the status. The
+  // database invariant rejects that entire write, so old code cannot make the
+  // quarantined row claimable again before the replacement runtime releases it.
+  await assert.rejects(
+    executeQuery(
+      (db) =>
+        db
+          .update(repositoryProcessingJobs)
+          .set({
+            status: "queued",
+            lastErrorCode: "CONTENT_PLATFORM_DISABLED",
+            lastErrorMessage: "stale worker deferred after the migration",
+            metrics: { waitReason: "CONTENT_PLATFORM_DISABLED" },
+            updatedAt: new Date(),
+          })
+          .where(eq(repositoryProcessingJobs.id, retryRegistration.inspectJob.id)),
+      "smoke.unifiedContent.rejectStaleWorkerStatusOverwrite"
+    )
+  );
+  const [staleWriteState] = await executeQuery(
+    (db) =>
+      db
+        .select({
+          status: repositoryProcessingJobs.status,
+          postDeployRecovery: repositoryProcessingJobs.postDeployRecovery,
+          metrics: repositoryProcessingJobs.metrics,
+        })
+        .from(repositoryProcessingJobs)
+        .where(eq(repositoryProcessingJobs.id, retryRegistration.inspectJob.id))
+        .limit(1),
+    "smoke.unifiedContent.readStaleWorkerOverwrite"
+  );
+  assert.deepEqual(staleWriteState, {
+    status: "cancelled",
+    postDeployRecovery: POST_DEPLOY_RECOVERY_MARKER,
+    metrics: { waitReason: "CONTENT_PLATFORM_DISABLED" },
+  });
 
   // The replacement runtime must wait longer than the old Lambda's maximum
   // execution time before releasing a marked row.
@@ -477,6 +553,7 @@ try {
           jobStatus: repositoryProcessingJobs.status,
           attempt: repositoryProcessingJobs.attempt,
           maxAttempts: repositoryProcessingJobs.maxAttempts,
+          postDeployRecovery: repositoryProcessingJobs.postDeployRecovery,
           metrics: repositoryProcessingJobs.metrics,
           versionStatus: repositoryItemVersions.processingStatus,
           inspectionStatus: repositoryItemVersions.inspectionStatus,
@@ -499,6 +576,7 @@ try {
     jobStatus: "pending",
     attempt: 0,
     maxAttempts: CONTENT_PROCESSING_MAX_ATTEMPTS,
+    postDeployRecovery: null,
     metrics: {},
     versionStatus: "pending",
     inspectionStatus: "pending",
@@ -513,6 +591,7 @@ try {
         .set({
           status: "cancelled",
           availableAt: sql`'infinity'::timestamptz`,
+          postDeployRecovery: POST_DEPLOY_RECOVERY_MARKER,
           metrics: { postDeployRecovery: POST_DEPLOY_RECOVERY_MARKER },
         })
         .where(eq(repositoryProcessingJobs.id, retryRegistration.inspectJob.id));
@@ -597,6 +676,7 @@ try {
           jobStatus: repositoryProcessingJobs.status,
           attempt: repositoryProcessingJobs.attempt,
           maxAttempts: repositoryProcessingJobs.maxAttempts,
+          postDeployRecovery: repositoryProcessingJobs.postDeployRecovery,
           metrics: repositoryProcessingJobs.metrics,
           startedAt: repositoryProcessingJobs.startedAt,
           versionStatus: repositoryItemVersions.processingStatus,
@@ -619,6 +699,7 @@ try {
   assert.equal(restartedState?.jobStatus, "pending");
   assert.equal(restartedState?.attempt, 0);
   assert.equal(restartedState?.maxAttempts, CONTENT_PROCESSING_MAX_ATTEMPTS);
+  assert.equal(restartedState?.postDeployRecovery, null);
   assert.deepEqual(restartedState?.metrics, {});
   assert.equal(restartedState?.startedAt, null);
   assert.equal(restartedState?.versionStatus, "pending");

--- a/tests/unit/actions/repositories/repository-items-actions.test.ts
+++ b/tests/unit/actions/repositories/repository-items-actions.test.ts
@@ -43,6 +43,9 @@ const mockGetCanonicalRepositoryItemStatuses = jest.fn<
 const mockRetryCanonicalRepositoryItem = jest.fn<
   (...a: unknown[]) => Promise<{ itemVersionId: string; processingJobId: string }>
 >()
+const mockAssertCanonicalRetryNotQuarantined = jest.fn<
+  (...a: unknown[]) => Promise<void>
+>(() => Promise.resolve())
 const mockRegisterCanonicalTextIfEnabled = jest.fn<
   (...a: unknown[]) => Promise<unknown>
 >(() => Promise.resolve(null))
@@ -112,6 +115,7 @@ jest.mock('@/lib/repositories/content-platform', () => ({
   deleteRepositoryItemStorage: mockDeleteRepositoryItemStorage,
   getCanonicalRepositoryItemStatuses: mockGetCanonicalRepositoryItemStatuses,
   retryCanonicalRepositoryItem: mockRetryCanonicalRepositoryItem,
+  assertCanonicalRetryNotQuarantined: mockAssertCanonicalRetryNotQuarantined,
 }))
 jest.mock('next/cache', () => ({ revalidatePath: jest.fn() }))
 jest.mock('@/lib/logger', () => ({
@@ -162,6 +166,7 @@ describe('repository-items.actions (REV-COR-061 / REV-SEC-062 / REV-COR-068)', (
       itemVersionId: 'aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee',
       processingJobId: 'ffffffff-1111-4222-8333-444444444444',
     })
+    mockAssertCanonicalRetryNotQuarantined.mockResolvedValue(undefined)
   })
 
   it('listRepositoryItems denies a caller without read access (REV-COR-061)', async () => {
@@ -222,6 +227,9 @@ describe('repository-items.actions (REV-COR-061 / REV-SEC-062 / REV-COR-068)', (
 
     expect(result.isSuccess).toBe(true)
     expect(mockRetryCanonicalRepositoryItem).toHaveBeenCalledWith(38, 't')
+    expect(mockAssertCanonicalRetryNotQuarantined).toHaveBeenCalledWith(
+      'aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee'
+    )
     expect(mockDispatchContentProcessingJob).toHaveBeenCalledWith({
       jobId: 'ffffffff-1111-4222-8333-444444444444',
       itemVersionId: 'aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee',
@@ -254,11 +262,35 @@ describe('repository-items.actions (REV-COR-061 / REV-SEC-062 / REV-COR-068)', (
       content: 'ORCHID-COMPASS-742',
       traceId: 't',
     })
+    expect(mockAssertCanonicalRetryNotQuarantined).toHaveBeenCalledWith(
+      'aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee'
+    )
     expect(mockRetryCanonicalRepositoryItem).not.toHaveBeenCalled()
     expect(mockDispatchContentProcessingJob).toHaveBeenCalledWith({
       jobId: 'cccccccc-dddd-4eee-8fff-aaaaaaaaaaaa',
       itemVersionId: 'bbbbbbbb-cccc-4ddd-8eee-ffffffffffff',
     })
+  })
+
+  it('does not let inline text supersede a post-deployment recovery quarantine', async () => {
+    mockGetRepositoryItemById.mockResolvedValue({
+      id: 38,
+      repositoryId: 5,
+      type: 'text',
+      name: 'Inline notes',
+      source: 'ORCHID-COMPASS-742',
+      currentVersionId: 'aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee',
+    })
+    mockAssertCanonicalRetryNotQuarantined.mockRejectedValue(
+      new Error('This item is awaiting automatic post-deployment recovery')
+    )
+
+    const result = await mod.retryRepositoryItemProcessing(38)
+
+    expect(result.isSuccess).toBe(false)
+    expect(mockRegisterCanonicalTextIfEnabled).not.toHaveBeenCalled()
+    expect(mockRetryCanonicalRepositoryItem).not.toHaveBeenCalled()
+    expect(mockDispatchContentProcessingJob).not.toHaveBeenCalled()
   })
 
   it('repairs a legacy file by copying it into the canonical source namespace', async () => {

--- a/tests/unit/lib/repositories/content-platform-status.test.ts
+++ b/tests/unit/lib/repositories/content-platform-status.test.ts
@@ -15,6 +15,7 @@ function statusRow(
     jobAttempt: 0,
     jobMaxAttempts: 3,
     jobError: null,
+    postDeployRecovery: null,
     active: false,
     buildingGeneration: false,
     failedGeneration: false,
@@ -111,6 +112,24 @@ describe("canonical repository item status", () => {
       processingStatus: "failed",
       processingError: "Content processing was disabled during deployment",
       canRetry: true,
+    });
+  });
+
+  it("keeps post-deployment recovery quarantined and disables manual retry", () => {
+    expect(
+      resolveCanonicalItemStatus(
+        statusRow({
+          versionStatus: "cancelled",
+          jobStatus: "cancelled",
+          jobError: "Awaiting the replacement runtime",
+          postDeployRecovery: "unified-content-runtime-v2",
+        })
+      )
+    ).toEqual({
+      itemId: 7,
+      processingStatus: "retrying",
+      processingError: null,
+      canRetry: false,
     });
   });
 

--- a/tests/unit/lib/repositories/content-platform-status.test.ts
+++ b/tests/unit/lib/repositories/content-platform-status.test.ts
@@ -81,10 +81,43 @@ describe("canonical repository item status", () => {
     ).toBe(false);
   });
 
-  it("keeps transient failed attempts in a retrying state", () => {
+  it("exposes an early failed job as terminal instead of retrying forever", () => {
     expect(
       resolveCanonicalItemStatus(
-        statusRow({ jobStatus: "failed", jobAttempt: 1, jobMaxAttempts: 3 })
+        statusRow({
+          jobStatus: "failed",
+          jobAttempt: 1,
+          jobMaxAttempts: 20,
+          jobError: "Item version object key is outside its repository namespace",
+        })
+      )
+    ).toMatchObject({
+      processingStatus: "failed",
+      processingError: "Item version object key is outside its repository namespace",
+      canRetry: true,
+    });
+  });
+
+  it("exposes cancelled pre-deployment jobs as retryable failures", () => {
+    expect(
+      resolveCanonicalItemStatus(
+        statusRow({
+          versionStatus: "cancelled",
+          jobStatus: "cancelled",
+          jobError: "Content processing was disabled during deployment",
+        })
+      )
+    ).toMatchObject({
+      processingStatus: "failed",
+      processingError: "Content processing was disabled during deployment",
+      canRetry: true,
+    });
+  });
+
+  it("shows pending work with a consumed attempt as retrying", () => {
+    expect(
+      resolveCanonicalItemStatus(
+        statusRow({ jobStatus: "pending", jobAttempt: 1, jobMaxAttempts: 5 })
       ).processingStatus
     ).toBe("retrying");
   });

--- a/tests/unit/scripts/unified-content-runtime-recovery-migration.test.ts
+++ b/tests/unit/scripts/unified-content-runtime-recovery-migration.test.ts
@@ -44,6 +44,15 @@ describe("unified-content post-deployment handoff migration", () => {
   );
 
   it("quarantines recovery work so the old worker cannot claim it", () => {
+    expect(migration).toContain(
+      "ADD COLUMN IF NOT EXISTS post_deploy_recovery VARCHAR(64)"
+    );
+    expect(migration).toContain(
+      "CHECK (post_deploy_recovery IS NULL OR status = 'cancelled')"
+    );
+    expect(migration).toContain(
+      "post_deploy_recovery = 'unified-content-runtime-v2'"
+    );
     expect(migration).toContain("SET status = 'cancelled'");
     expect(migration).toContain("max_attempts = 5");
     expect(migration).toContain("available_at = 'infinity'::timestamptz");

--- a/tests/unit/scripts/unified-content-runtime-recovery-migration.test.ts
+++ b/tests/unit/scripts/unified-content-runtime-recovery-migration.test.ts
@@ -20,9 +20,47 @@ describe("unified-content runtime recovery migration", () => {
     expect(migration).toContain("version.inspection_status <> 'blocked'");
   });
 
-  it("only resets the current active item version into the pending outbox", () => {
+  it("only quarantines canonical current versions for the replacement worker", () => {
     expect(migration).toContain("version.id = job.item_version_id");
     expect(migration).toContain("item.lifecycle_status = 'active'");
-    expect(migration).toContain("job.last_error_code = 'RECOVERED_BY_MIGRATION_122'");
+    expect(migration).toContain("SET status = 'cancelled'");
+    expect(migration).toContain("available_at = 'infinity'::timestamptz");
+    expect(migration).toContain(
+      "'{\"postDeployRecovery\":\"unified-content-runtime-v2\"}'::jsonb"
+    );
+    expect(migration).toContain("AND version.object_key ~ (");
+    expect(migration).toContain("repository.active_index_generation_id");
+    expect(migration).not.toContain("SET status = 'pending'");
+  });
+});
+
+describe("unified-content post-deployment handoff migration", () => {
+  const migration = readFileSync(
+    resolve(
+      process.cwd(),
+      "infra/database/schema/123-unified-content-postdeploy-handoff.sql"
+    ),
+    "utf8"
+  );
+
+  it("quarantines recovery work so the old worker cannot claim it", () => {
+    expect(migration).toContain("SET status = 'cancelled'");
+    expect(migration).toContain("max_attempts = 5");
+    expect(migration).toContain("available_at = 'infinity'::timestamptz");
+    expect(migration).toContain(
+      "'{\"postDeployRecovery\":\"unified-content-runtime-v2\"}'::jsonb"
+    );
+    expect(migration).not.toContain("SET status = 'pending'");
+  });
+
+  it("excludes blocked, noncanonical, inactive, and already-serving versions", () => {
+    expect(migration).toContain(
+      "job.last_error_code IS DISTINCT FROM 'SECURITY_INSPECTION_BLOCKED'"
+    );
+    expect(migration).toContain("item.lifecycle_status = 'active'");
+    expect(migration).toContain("version.storage_status <> 'blocked'");
+    expect(migration).toContain("version.inspection_status <> 'blocked'");
+    expect(migration).toContain("AND version.object_key ~ (");
+    expect(migration).toContain("repository.active_index_generation_id");
   });
 });

--- a/tests/unit/scripts/unified-content-runtime-recovery-migration.test.ts
+++ b/tests/unit/scripts/unified-content-runtime-recovery-migration.test.ts
@@ -53,6 +53,13 @@ describe("unified-content post-deployment handoff migration", () => {
     expect(migration).not.toContain("SET status = 'pending'");
   });
 
+  it("matches only known migration-122 and deployment-runtime signatures", () => {
+    expect(migration).toContain("'RECOVERED_BY_MIGRATION_122'");
+    expect(migration).toContain("'CONTENT_PLATFORM_DISABLED'");
+    expect(migration).toContain("item.processing_status = 'embedding_failed'");
+    expect(migration).not.toContain("job.status IN ('failed', 'cancelled')");
+  });
+
   it("excludes blocked, noncanonical, inactive, and already-serving versions", () => {
     expect(migration).toContain(
       "job.last_error_code IS DISTINCT FROM 'SECURITY_INSPECTION_BLOCKED'"


### PR DESCRIPTION
## Summary

- eliminate the database-migration-before-Lambda race by quarantining recovery jobs with a durable marker and database constraint until the replacement unified-content worker releases bounded batches after a 20-minute old-runtime drain window
- restrict migration 123 to the explicit migration marker, `RECOVERED_BY_MIGRATION_122`, the observed `CONTENT_PLATFORM_DISABLED` deployment state, and legacy embedding failures; unrelated terminal user failures are preserved exactly
- make ordinary failed and cancelled inspect jobs terminal in Repository Manager and give authorized manual retries a clean five-attempt budget with cleared provider state
- keep post-deploy-quarantined jobs visibly retrying but non-actionable, with canonical and inline-text server retry guards until the replacement worker completes the drain-window release
- ensure manual retry targets only the canonical inspect job, even when newer downstream processing-stage rows exist
- serialize generation activation in one ordered transaction so PostgreSQL's single-active-generation constraint cannot fail nondeterministically
- make the Assistant Architect persistence E2E test open its deterministic parallel fixture

## Release safety

No manual AWS CLI or database mutation is required. Migration 123 leaves only known recovery work cancelled and unavailable to the old worker. Its dedicated marker survives stale metrics writes, while a database check constraint rejects any stale attempt to move a marked row out of `cancelled`. The replacement scheduled worker waits 20 minutes—longer than the previous Lambda's 15-minute timeout—then clears the marker in the same atomic update that returns the job to `pending`, while rechecking canonical/current/non-serving/security state.

## Verification

- application CI: 275 suites passed, 5 skipped; 3,110 tests passed, 60 skipped
- infrastructure/Lambda: 35 suites and 359 tests passed with real ARM64 worker bundles
- authenticated Playwright: 257 passed, 51 environment-gated skips, zero failures; repeated successfully by the mandatory pre-push hook before the backend-only review follow-up
- real PostgreSQL lifecycle smoke: unrelated terminal failure preservation, exact live deployment-failure quarantine, UI suppression and server rejection of manual retry while marked, durable marker survival after a complete metrics overwrite, database rejection of stale status/error writes, old-worker exclusion, 20-minute drain guard, canonical-source guard, inspect-only manual retry after release with a newer downstream job left untouched, retry reset, PDF/Office/image publication and citations, ordered/duplicate activation, uniqueness constraint, and cleanup
- lint: zero errors
- application, infrastructure, unified-content worker, and embedding-worker typechecks: passed
- production Next.js build: passed after the final functional source edit
- all-stack CDK synthesis: all 29 dev/prod templates passed
