### PR TITLE
fix(unified-content): complete live BDA audio/video validation

### DIFF
--- a/docs/features/google-group-sync.md
+++ b/docs/features/google-group-sync.md
@@ -105,8 +105,9 @@ The Lambda emits CloudWatch metrics in namespace **`AIStudio/GroupSync`** (dimen
 `GroupsDeactivated`, `MembersTotal`, `RolesGranted`, `RolesRevoked`,
 `RoleUsersChanged`, `SyncRunFailed`, and `SyncRunSucceeded`.
 
-Two alarms are defined in `infra/lib/processing-stack.ts` (notify the `alertEmail`
-CDK-context address when set):
+Two alarms are defined in `infra/lib/processing-stack.ts`. Both publish to the
+shared `aistudio-<environment>-monitoring-alarms` topic owned by MonitoringStack;
+that stack owns email and other delivery subscriptions:
 
 | Alarm | Fires when | Why |
 |---|---|---|
@@ -118,9 +119,11 @@ CDK-context address when set):
 > emitting `SyncRunSucceeded`, so the metric is permanently absent and
 > `psd-group-sync-staleness-<env>` sits in **ALARM** by design (`treatMissingData:
 > BREACHING`). This is expected onboarding noise, not an incident — notifications are
-> gated on `alertEmail`, so no page fires. It clears on the first successful sync once
-> the service account is configured. If an environment will never use group sync,
-> disable the alarm rather than leaving it red.
+> delivered through the shared monitoring topic. It clears on the first successful
+> sync once the service account is configured. Before enabling group sync in a new
+> environment, deploy MonitoringStack and confirm at least one delivery endpoint. If
+> an environment will never use group sync, disable the alarm rather than leaving it
+> red.
 
 Per-group failures are surfaced in **Admin → Groups**: each group shows a "Failed"
 badge (with the `last_sync_error` as tooltip) and `last_synced_at`; the header shows
@@ -130,7 +133,8 @@ an aggregate "Failed syncs" count (`groups.last_sync_error IS NOT NULL AND is_ac
 
 1. **Failure alarm**: temporarily point `GOOGLE_DIRECTORY_SA_SECRET_ARN` at a bad
    secret (or invoke with the SA secret revoked) so a run throws; confirm
-   `psd-group-sync-failure-<env>` → ALARM and the email fires; restore the setting.
+   `psd-group-sync-failure-<env>` → ALARM and the shared monitoring notification
+   fires; restore the setting.
 2. **Staleness alarm**: set `GROUP_SYNC_ENABLED=false` and let 3 hourly windows pass
    with no manual run; confirm `psd-group-sync-staleness-<env>` → ALARM (missing data
    breaches); re-enable and run "Sync now" to clear it.

--- a/docs/plans/2026-07-21-unified-content-platform.md
+++ b/docs/plans/2026-07-21-unified-content-platform.md
@@ -388,8 +388,8 @@ two worktrees should edit the same migration or contract file concurrently.
 - [x] Repository PDF dual-write/canonical-upload walking skeleton
 - [x] Foundation unit/integration/E2E tests
 - [x] Foundation/Office/image dev deployment and observability validation
-- [ ] Multimodal processing (Office/image deployed; audio/video implementation
-      and local verification complete, dev managed-service validation pending)
+- [x] Multimodal processing (Office, image, audio, and video deployed; real dev
+      managed-service validation passed)
 - [x] Retrieval v2 and visual search
 - [ ] Google Workspace sync
 - [ ] Universal product UI migration
@@ -596,8 +596,8 @@ not have access to `text-embedding-3-small`; the Bedrock default, immutable
 generation routing, lexical fallback, and automatic replay in this slice close
 that observed failure mode.
 
-The remaining checkpoint gate is a dev deployment and real BDA audio/video
-validation.
+The dev deployment and real BDA audio/video gate is closed by the managed-service
+validation checkpoint below.
 
 ### Retrieval v2 checkpoint (2026-07-22)
 
@@ -919,3 +919,57 @@ fencing, migration 124 owns a distinct handoff marker, Textract and BDA reset
 asymmetries have direct tests, activation-only messages use an explicit empty
 work contract, and processing-DLQ reconciliation precedes the outbox so recovered
 jobs can redispatch in the same maintenance cycle.
+
+### Multimodal managed-service validation checkpoint (2026-07-22)
+
+Issue #1264 was selected as the next delivery because the progress ledger and
+media checkpoint explicitly named a dev deployment plus real BDA audio/video as
+the remaining gate. The other incomplete workstream with an external prerequisite,
+Google synchronization, remains coupled to `psd-gcp-infra#1`.
+
+Live dev validation used nonpersonal synthetic WAV and MP4 sources carrying the
+marker `LANTERN HARBOR 1264`. It exposed an IAM contract gap that local SDK mocks
+could not reproduce: `InvokeDataAutomationAsync` is authorized against the
+generated `data-automation-invocation/*` ARN in addition to the selected BDA
+project and cross-region profile. The worker policy now includes that exact
+invocation namespace. Optional invocation tags were removed instead of expanding
+the shared permission boundary with `bedrock:TagResource`; durable correlation
+continues through the BDA client token, processing-job metrics, immutable source
+key, and run-specific artifact prefix.
+
+After the focused Processing stack deployment, both owned validation jobs
+succeeded on their first post-fix attempt through real Amazon Bedrock Data
+Automation. The audio result reported a 9,536 ms PCM WAV with three segments and
+the video result a 9,520 ms H.264 MP4 with one shot and two segments. Both source
+versions became available, clean, completed, and embedded. Active generation
+`03b012ef-ec52-4ca0-8194-5b454dad1cd2` published 12 Titan G1 text-embedded
+segments across six source versions; its audio and video chunks contain the
+synthetic marker and nonempty `timeStartMs`/`timeEndMs` citation locators. The
+canonical artifact set contains pinned source, layout, transcript/caption, and
+canonical-text rows produced by `aistudio-media-bda-v2`.
+
+Visual indexing was returned to its independent disabled flag after Cohere Embed
+v4 reported missing Marketplace entitlement. The previously active generation
+remained serving throughout, and this provider-enablement item does not affect
+the text-embedding or BDA media exit gate.
+
+Verification evidence for the managed-service validation slice:
+
+- Complete application CI: 278 suites and 3,125 tests passed with 60 intentional
+  skips. The focused media, retrieval-evaluation, citation, and migration set
+  passed 22 tests. Full lint completed with zero errors, and application,
+  infrastructure, unified-content worker, and embedding-worker typechecks pass.
+- Complete infrastructure/Lambda suite: 38 suites and 377 tests passed. The
+  production Next.js build, infrastructure build, all-stack no-lookup synthesis
+  of 31 dev/prod/shared templates, and both exact Linux Lambda artifact smokes
+  pass.
+- The real PostgreSQL migration/lifecycle smoke passed publication, retry and
+  recovery state, generation activation, retrieval/citation, idempotency,
+  quarantine, and cleanup checks.
+- Authenticated Playwright passed 257 tests with 51 intentional
+  environment-gated skips. The canonical repository matrix covers direct,
+  inline-text, PDF, Office, image, audio/video, terminal failure visibility, and
+  retry from the item row.
+- Dev processing and embedding DLQs remained empty. The live audio/video jobs,
+  pinned artifacts, active Titan embeddings, timestamp locators, and synthetic
+  transcript marker were verified directly against the canonical database.

--- a/docs/plans/2026-07-21-unified-content-platform.md
+++ b/docs/plans/2026-07-21-unified-content-platform.md
@@ -953,13 +953,28 @@ v4 reported missing Marketplace entitlement. The previously active generation
 remained serving throughout, and this provider-enablement item does not affect
 the text-embedding or BDA media exit gate.
 
+The deployment also exposed a notification-ownership defect: ProcessingStack
+created a second group-sync SNS topic and email subscription even though each
+environment already has a confirmed central MonitoringStack alarm topic. The
+duplicate subscription remained pending and made focused Processing deployments
+sensitive to the optional `alertEmail` context. Group-sync alarms now always
+publish to the deterministic `aistudio-<environment>-monitoring-alarms` topic;
+MonitoringStack remains the sole owner of delivery subscriptions. Dev and prod
+both have confirmed `techalerts@psd401.net` subscriptions on their shared topics,
+and synthesis guards prevent ProcessingStack from recreating the redundant topic
+or any email subscription. The focused dev update completed with both group-sync
+alarm actions targeting `aistudio-dev-monitoring-alarms`; the redundant topic is
+absent, and a labeled end-to-end notification was accepted by SNS as message
+`093c57a9-0ad1-5cab-a6f4-35728755bda0` without requiring another subscription
+confirmation.
+
 Verification evidence for the managed-service validation slice:
 
 - Complete application CI: 278 suites and 3,125 tests passed with 60 intentional
   skips. The focused media, retrieval-evaluation, citation, and migration set
   passed 22 tests. Full lint completed with zero errors, and application,
   infrastructure, unified-content worker, and embedding-worker typechecks pass.
-- Complete infrastructure/Lambda suite: 38 suites and 377 tests passed. The
+- Complete infrastructure/Lambda suite: 38 suites and 378 tests passed. The
   production Next.js build, infrastructure build, all-stack no-lookup synthesis
   of 31 dev/prod/shared templates, and both exact Linux Lambda artifact smokes
   pass.

--- a/infra/DEPLOYMENT_COMMANDS.md
+++ b/infra/DEPLOYMENT_COMMANDS.md
@@ -72,22 +72,21 @@ bunx cdk deploy AIStudio-StorageStack-Dev --exclusively
 bunx cdk deploy AIStudio-StorageStack-Prod --exclusively
 ```
 
-### ProcessingStack (Requires the existing alarm-email context)
+### ProcessingStack (No parameters needed)
 ```bash
 # Dev
 bunx cdk deploy AIStudio-ProcessingStack-Dev \
-  --context alertEmail=techalerts@psd401.net \
   --exclusively
 
 # Prod
 bunx cdk deploy AIStudio-ProcessingStack-Prod \
-  --context alertEmail=YOUR_PROD_ALERT_EMAIL \
   --exclusively
 ```
 
-The group-sync alarm topic and email subscription are conditional on
-`alertEmail`. Omitting a value that was used for the previous deployment removes
-those resources from the synthesized template.
+Group-sync alarms publish to the shared
+`aistudio-<environment>-monitoring-alarms` topic owned by MonitoringStack.
+Configure and confirm delivery endpoints when deploying MonitoringStack; a
+focused ProcessingStack deployment never creates or removes subscriptions.
 
 ### FrontendStack (Requires baseDomain)
 ```bash

--- a/infra/DEPLOYMENT_COMMANDS.md
+++ b/infra/DEPLOYMENT_COMMANDS.md
@@ -72,14 +72,22 @@ bunx cdk deploy AIStudio-StorageStack-Dev --exclusively
 bunx cdk deploy AIStudio-StorageStack-Prod --exclusively
 ```
 
-### ProcessingStack (No parameters needed after SSM setup)
+### ProcessingStack (Requires the existing alarm-email context)
 ```bash
 # Dev
-bunx cdk deploy AIStudio-ProcessingStack-Dev --exclusively
+bunx cdk deploy AIStudio-ProcessingStack-Dev \
+  --context alertEmail=techalerts@psd401.net \
+  --exclusively
 
 # Prod
-bunx cdk deploy AIStudio-ProcessingStack-Prod --exclusively
+bunx cdk deploy AIStudio-ProcessingStack-Prod \
+  --context alertEmail=YOUR_PROD_ALERT_EMAIL \
+  --exclusively
 ```
+
+The group-sync alarm topic and email subscription are conditional on
+`alertEmail`. Omitting a value that was used for the previous deployment removes
+those resources from the synthesized template.
 
 ### FrontendStack (Requires baseDomain)
 ```bash

--- a/infra/DEPLOYMENT_SAFETY_CHECKLIST.md
+++ b/infra/DEPLOYMENT_SAFETY_CHECKLIST.md
@@ -64,13 +64,15 @@ aws ssm get-parameters-by-path --path '/aistudio/dev' --recursive
 
 # 3. Deploy stacks that consume SSM parameters
 bunx cdk deploy AIStudio-ProcessingStack-Dev AIStudio-FrontendStack-Dev \
-  --context baseDomain=aistudio.psd401.ai \
-  --context alertEmail=techalerts@psd401.net
+  --context baseDomain=aistudio.psd401.ai
 ```
 
-`AIStudio-ProcessingStack-Dev` conditionally owns the group-sync alarm topic and
-subscription. Always preserve the existing `alertEmail` context; omitting it
-causes CDK to remove those monitoring resources.
+`AIStudio-ProcessingStack-Dev` routes group-sync alarms to the shared
+`aistudio-dev-monitoring-alarms` topic. MonitoringStack exclusively owns that
+topic and its confirmed delivery endpoints, so a focused ProcessingStack deploy
+cannot remove or recreate subscriptions. Verify MonitoringStack is deployed and
+the shared topic has at least one confirmed subscription before enabling group
+sync in a new environment.
 
 ## Post-Deployment Verification
 

--- a/infra/DEPLOYMENT_SAFETY_CHECKLIST.md
+++ b/infra/DEPLOYMENT_SAFETY_CHECKLIST.md
@@ -63,8 +63,14 @@ bunx cdk deploy AIStudio-DatabaseStack-Dev AIStudio-StorageStack-Dev --context b
 aws ssm get-parameters-by-path --path '/aistudio/dev' --recursive
 
 # 3. Deploy stacks that consume SSM parameters
-bunx cdk deploy AIStudio-ProcessingStack-Dev AIStudio-FrontendStack-Dev --context baseDomain=aistudio.psd401.ai
+bunx cdk deploy AIStudio-ProcessingStack-Dev AIStudio-FrontendStack-Dev \
+  --context baseDomain=aistudio.psd401.ai \
+  --context alertEmail=techalerts@psd401.net
 ```
+
+`AIStudio-ProcessingStack-Dev` conditionally owns the group-sync alarm topic and
+subscription. Always preserve the existing `alertEmail` context; omitting it
+causes CDK to remove those monitoring resources.
 
 ## Post-Deployment Verification
 

--- a/infra/bin/infra.ts
+++ b/infra/bin/infra.ts
@@ -244,7 +244,6 @@ Object.entries(standardTags).forEach(([key, value]) => cdk.Tags.of(devAgentPlatf
 
 const devProcessingStack = new ProcessingStack(app, 'AIStudio-ProcessingStack-Dev', {
   environment: 'dev',
-  alertEmail,
   env: { account: process.env.CDK_DEFAULT_ACCOUNT, region: process.env.CDK_DEFAULT_REGION },
 });
 devProcessingStack.addDependency(devDbStack); // Reads database SSM parameters and uses the shared VPC
@@ -411,7 +410,6 @@ Object.entries(standardTags).forEach(([key, value]) => cdk.Tags.of(prodAgentPlat
 
 const prodProcessingStack = new ProcessingStack(app, 'AIStudio-ProcessingStack-Prod', {
   environment: 'prod',
-  alertEmail,
   env: { account: process.env.CDK_DEFAULT_ACCOUNT, region: process.env.CDK_DEFAULT_REGION },
 });
 prodProcessingStack.addDependency(prodDbStack); // Reads database SSM parameters and uses the shared VPC

--- a/infra/lambdas/unified-content-processor/index.ts
+++ b/infra/lambdas/unified-content-processor/index.ts
@@ -331,7 +331,6 @@ async function downloadJsonObject(objectKey: string): Promise<unknown> {
 
 async function startMediaAnalysis(input: {
   clientToken: string;
-  jobId: string;
   sourceObjectKey: string;
   outputPrefix: string;
 }): Promise<string> {
@@ -349,10 +348,6 @@ async function startMediaAnalysis(input: {
         stage: "LIVE",
       },
       dataAutomationProfileArn,
-      tags: [
-        { key: "ManagedBy", value: "aistudio" },
-        { key: "RepositoryProcessingJob", value: input.jobId },
-      ],
     }),
   );
   if (!result.invocationArn) {
@@ -1026,7 +1021,6 @@ async function processMessage(message: ContentProcessingMessage, workerId: strin
     if (!invocationArn) {
       invocationArn = await startMediaAnalysis({
         clientToken,
-        jobId: message.jobId,
         sourceObjectKey: context.objectKey,
         outputPrefix: bdaState.outputPrefix,
       });

--- a/infra/lib/constructs/processing/unified-content-processing.ts
+++ b/infra/lib/constructs/processing/unified-content-processing.ts
@@ -345,6 +345,11 @@ export class UnifiedContentProcessing extends Construct {
                 actions: ["bedrock:InvokeDataAutomationAsync"],
                 resources: [
                   mediaProject.attrProjectArn,
+                  // The runtime authorizes creation of the asynchronous job
+                  // against the invocation ARN as well as the selected
+                  // project/profile. Without this resource the live service
+                  // rejects InvokeDataAutomationAsync before returning the ARN.
+                  `arn:${stack.partition}:bedrock:${stack.region}:${stack.account}:data-automation-invocation/*`,
                   ...["us-east-1", "us-east-2", "us-west-1", "us-west-2"].map(
                     (region) =>
                       `arn:${stack.partition}:bedrock:${region}:${stack.account}:data-automation-profile/us.data-automation-v1`

--- a/infra/lib/processing-stack.ts
+++ b/infra/lib/processing-stack.ts
@@ -26,11 +26,6 @@ export interface ProcessingStackProps extends cdk.StackProps {
   documentsBucketName?: string; // Optional for backward compatibility
   databaseResourceArn?: string; // Optional for backward compatibility
   databaseSecretArn?: string; // Optional for backward compatibility
-  // Email subscribed to the group-sync failure / staleness alarms (#1207).
-  // Sourced from the `alertEmail` CDK context, same as the other stacks. When
-  // absent the alarms are still created (and visible in CloudWatch) but have no
-  // notification target.
-  alertEmail?: string;
 }
 export class ProcessingStack extends cdk.Stack {
   public readonly fileProcessingQueue: sqs.Queue;
@@ -372,8 +367,14 @@ export class ProcessingStack extends cdk.Stack {
                   const inputDir = path.join(__dirname, '..', 'lambdas', 'embedding-generator');
                   execSync('bun install && bunx tsc', { cwd: inputDir, stdio: 'inherit' });
                   execSync(`cp -r dist/* ${outputDir}/`, { cwd: inputDir, stdio: 'inherit' });
-                  execSync(`cp package.json ${outputDir}/`, { cwd: inputDir, stdio: 'inherit' });
-                  execSync('bun install --production', { cwd: outputDir, stdio: 'inherit' });
+                  execSync(`cp package.json bun.lock ${outputDir}/`, {
+                    cwd: inputDir,
+                    stdio: 'inherit',
+                  });
+                  execSync('bun install --production --frozen-lockfile', {
+                    cwd: outputDir,
+                    stdio: 'inherit',
+                  });
                   return true;
                 } catch (e) {
                   process.stderr.write(`Local bundling failed, falling back to Docker: ${e}\n`);
@@ -640,8 +641,14 @@ export class ProcessingStack extends cdk.Stack {
                   const inputDir = path.join(__dirname, '..', 'lambdas', 'group-sync');
                   execSync('bun install && bunx tsc', { cwd: inputDir, stdio: 'inherit' });
                   execSync(`cp -r dist/* ${outputDir}/`, { cwd: inputDir, stdio: 'inherit' });
-                  execSync(`cp package.json ${outputDir}/`, { cwd: inputDir, stdio: 'inherit' });
-                  execSync('bun install --production', { cwd: outputDir, stdio: 'inherit' });
+                  execSync(`cp package.json bun.lock ${outputDir}/`, {
+                    cwd: inputDir,
+                    stdio: 'inherit',
+                  });
+                  execSync('bun install --production --frozen-lockfile', {
+                    cwd: outputDir,
+                    stdio: 'inherit',
+                  });
                   return true;
                 } catch (e) {
                   process.stderr.write(`Local bundling failed, falling back to Docker: ${e}\n`);
@@ -701,20 +708,18 @@ export class ProcessingStack extends cdk.Stack {
     //   2. Staleness alarm — no SUCCESSFUL run within the staleness window,
     //      which also catches "the schedule stopped firing entirely" (the custom
     //      SyncRunSucceeded metric goes absent → treatMissingData=BREACHING).
-    // Alarm actions are wired only when an alert email is configured; the alarms
-    // themselves always exist so their state is visible in CloudWatch.
-    let groupSyncAlarmTopic: sns.Topic | undefined;
-    if (props.alertEmail) {
-      groupSyncAlarmTopic = new sns.Topic(this, 'GroupSyncAlarmTopic', {
-        topicName: `psd-group-sync-alarms-${props.environment}`,
-        displayName: `PSD Group Sync Alarms (${props.environment})`,
-      });
-      groupSyncAlarmTopic.addSubscription(
-        new snsSubscriptions.EmailSubscription(props.alertEmail),
-      );
-      cdk.Tags.of(groupSyncAlarmTopic).add('Environment', props.environment);
-      cdk.Tags.of(groupSyncAlarmTopic).add('ManagedBy', 'cdk');
-    }
+    // Reuse the central alarm topic owned by MonitoringStack. Referencing its
+    // deterministic ARN avoids a cross-stack export dependency while keeping
+    // notification endpoints in one lifecycle owner. A focused ProcessingStack
+    // deployment therefore cannot remove or recreate confirmed subscriptions.
+    const groupSyncAlarmTopic = sns.Topic.fromTopicArn(
+      this,
+      'MonitoringAlarmTopic',
+      this.formatArn({
+        service: 'sns',
+        resource: `aistudio-${props.environment}-monitoring-alarms`,
+      }),
+    );
 
     // 1. Failure alarm — any errored invocation in the last hour. Missing data
     //    (no invocations) is NOT breaching here; the staleness alarm owns the
@@ -757,11 +762,9 @@ export class ProcessingStack extends cdk.Stack {
       treatMissingData: cloudwatch.TreatMissingData.BREACHING,
     });
 
-    if (groupSyncAlarmTopic) {
-      const alarmAction = new cloudwatchActions.SnsAction(groupSyncAlarmTopic);
-      groupSyncFailureAlarm.addAlarmAction(alarmAction);
-      groupSyncStalenessAlarm.addAlarmAction(alarmAction);
-    }
+    const alarmAction = new cloudwatchActions.SnsAction(groupSyncAlarmTopic);
+    groupSyncFailureAlarm.addAlarmAction(alarmAction);
+    groupSyncStalenessAlarm.addAlarmAction(alarmAction);
 
     // Outputs
     new cdk.CfnOutput(this, 'GroupSyncFunctionName', {

--- a/infra/test/unit/permission-boundary-construct.test.ts
+++ b/infra/test/unit/permission-boundary-construct.test.ts
@@ -56,6 +56,7 @@ describe("PermissionBoundaryConstruct", () => {
           "bedrock:GetDataAutomationStatus",
         ])
       );
+      expect(actions).not.toContain("bedrock:TagResource");
       expect(actions).not.toContain("bedrock:*");
     }
   );

--- a/infra/test/unit/processing-stack-embedding-access.test.ts
+++ b/infra/test/unit/processing-stack-embedding-access.test.ts
@@ -104,4 +104,29 @@ describe('ProcessingStack embedding visual-artifact access', () => {
       TreatMissingData: 'notBreaching',
     });
   });
+
+  it('routes group-sync alarms through the shared monitoring topic', () => {
+    const alarms = Object.values(
+      template.findResources('AWS::CloudWatch::Alarm'),
+    );
+
+    for (const alarmName of [
+      'psd-group-sync-failure-dev',
+      'psd-group-sync-staleness-dev',
+    ]) {
+      const alarm = alarms.find((resource) =>
+        JSON.stringify(resource).includes(`\"AlarmName\":\"${alarmName}\"`),
+      );
+      expect(alarm).toBeDefined();
+      expect(JSON.stringify(alarm)).toContain(
+        'aistudio-dev-monitoring-alarms',
+      );
+      expect(JSON.stringify(alarm)).not.toContain('psd-group-sync-alarms-dev');
+    }
+
+    const topics = template.findResources('AWS::SNS::Topic');
+    expect(JSON.stringify(topics)).not.toContain('psd-group-sync-alarms-dev');
+    const subscriptions = template.findResources('AWS::SNS::Subscription');
+    expect(JSON.stringify(subscriptions)).not.toContain('"Protocol":"email"');
+  });
 });

--- a/infra/test/unit/unified-content-processing.test.ts
+++ b/infra/test/unit/unified-content-processing.test.ts
@@ -432,6 +432,14 @@ describe("UnifiedContentProcessing", () => {
       "data-automation-profile/us.data-automation-v1"
     );
     expect(JSON.stringify(invoke?.Resource)).toContain("ProjectArn");
+    expect(JSON.stringify(invoke?.Resource)).toContain(
+      "data-automation-invocation/*"
+    );
+    expect(
+      statements.some((statement) =>
+        JSON.stringify(statement.Action).includes("bedrock:TagResource")
+      )
+    ).toBe(false);
     expect(status?.Action).toBe("bedrock:GetDataAutomationStatus");
     expect(JSON.stringify(status?.Resource)).toContain(
       "data-automation-invocation/*"


### PR DESCRIPTION
Closes #1264
Part of #1261

## Selection and acceptance criteria

I selected #1264 because the durable implementation plan explicitly named a dev deployment plus real Bedrock Data Automation audio/video processing as the next remaining gate. Google synchronization remains coupled to the external `psd-gcp-infra#1` prerequisite.

This PR closes the measurable remaining criteria:

- real audio and video sources complete through BDA in dev;
- canonical source versions become available, clean, completed, and embedded;
- active-generation audio/video chunks retain temporal citation locators and Titan embeddings;
- least-privilege IAM matches the live BDA authorization contract;
- retry, retrieval, artifact, build, infrastructure, and authenticated E2E gates pass;
- the durable progress ledger and deployment runbooks reflect the delivery.

## Implementation

- Authorize `bedrock:InvokeDataAutomationAsync` against the generated `data-automation-invocation/*` namespace in addition to the existing project and US profile resources.
- Remove optional BDA invocation tags instead of widening the shared permissions boundary with `bedrock:TagResource`. Correlation remains durable through the client token, processing-job metrics, immutable source key, and run-specific artifact prefix.
- Assert the invocation-ARN grant and absence of `TagResource` in the synthesized worker policy as the live-defect regression guard; also preserve the shared permissions boundary's lack of `TagResource` as a future least-privilege guard.
- Route group-sync alarms through the existing MonitoringStack alarm topic, making MonitoringStack the sole subscription owner and preventing focused ProcessingStack deploys from recreating or deleting confirmed endpoints.
- Package the ProcessingStack Lambda dependencies from committed Bun lockfiles so local CDK bundling is deterministic.
- Add a synthesis guard for both group-sync alarm actions, the absence of the redundant topic, and the absence of ProcessingStack-owned email subscriptions.
- Mark the multimodal ledger complete and record the live managed-service evidence.

## Live dev evidence

Two nonpersonal synthetic sources carrying `LANTERN HARBOR 1264` were processed through the deployed canonical worker:

- Audio version `4302718a-b3e6-4546-8e65-fab2f2241859`, job `1402c466-141b-49fe-9925-0fb1c33c8f03`: succeeded on the first post-fix attempt; 9,536 ms PCM WAV, 3 segments.
- Video version `ebf3efae-f138-4988-b342-96ff657fb3ad`, job `03f42e1d-0206-4ca7-b1a4-2b1000dd5ba6`: succeeded on the first post-fix attempt; 9,520 ms H.264 MP4, 1 shot, 2 segments.
- Active generation `03b012ef-ec52-4ca0-8194-5b454dad1cd2` published 12 Titan G1 text-embedded segments across 6 versions. Audio/video chunks contain the marker plus nonempty `timeStartMs`/`timeEndMs` locators.
- Canonical source, BDA layout, transcript/caption, and canonical-text artifacts are pinned to the source versions under `aistudio-media-bda-v2`.
- Processing and embedding DLQs remained empty.
- The focused ProcessingStack update completed with both group-sync alarm actions targeting the confirmed `aistudio-dev-monitoring-alarms` topic and no redundant `psd-group-sync-alarms-dev` topic. SNS accepted the labeled routing validation as message `093c57a9-0ad1-5cab-a6f4-35728755bda0`; no new email acceptance is required.

## Verification

- `bun run lint` — 0 errors
- `bun run typecheck`
- `bun run test:ci --runInBand` — 278 suites / 3,125 passed; 60 intentional skips
- focused media, retrieval-evaluation, citation, and migration tests — 22 passed
- `cd infra && bunx jest --runInBand --silent` — 38 suites / 378 passed
- infrastructure, unified-content worker, and embedding-worker typechecks
- `bun run build` and `cd infra && bun run build`
- all-stack no-lookup CDK synthesis — 31 dev/prod/shared templates
- exact unified-content and embedding Linux Lambda artifact smokes
- real PostgreSQL unified-content migration/lifecycle smoke
- authenticated Playwright — 257 passed; 51 intentional environment-gated skips (run twice, including the pre-push gate)
- real dev BDA audio/video processing and active-generation database verification
- GitHub CI — all 6 checks passed, including CodeQL, infrastructure validation, PostgreSQL lifecycle, and automated review

## Rollout and remaining risks

- No database migration or data rewrite is required. ProcessingStack no longer consumes `alertEmail`; MonitoringStack must exist and have a confirmed delivery endpoint before group sync is enabled in a new environment.
- `CONTENT_VISUAL_INDEX_ENABLED` is intentionally `false` after Cohere Embed v4 reported missing Marketplace entitlement. The existing active generation remained available; this is independent provider enablement, not a BDA media blocker.
- Dev and prod central monitoring topics already have confirmed `techalerts@psd401.net` subscriptions. The redundant pending dev subscription and topic were removed during the focused deployment; group-sync alarm delivery now uses the confirmed central route.
- The two clearly tagged #1264 synthetic fixtures remain in the dev validation repository as reproducible evidence.
