### PR TITLE
feat(agent-workspace): AGENT_DWD_SCOPES v3 — chat memberships + tasks

### DIFF
--- a/lib/agent-workspace/dwd-token-broker.ts
+++ b/lib/agent-workspace/dwd-token-broker.ts
@@ -54,6 +54,13 @@ export const AGENT_DWD_SCOPES = [
   "https://www.googleapis.com/auth/meetings.space.created",
   "https://www.googleapis.com/auth/chat.messages",
   "https://www.googleapis.com/auth/chat.spaces",
+  // v3 (2026-07-16): members.list/create in agent-managed spaces 403'd
+  // "insufficient authentication scopes" without chat.memberships;
+  // chat.memberships.app lets the agent add/remove the PSD Chat app itself.
+  "https://www.googleapis.com/auth/chat.memberships",
+  "https://www.googleapis.com/auth/chat.memberships.app",
+  // v3: agent-slot task lists (user-slot tasks ride the consent OAuth flow).
+  "https://www.googleapis.com/auth/tasks",
   "https://www.googleapis.com/auth/directory.readonly",
 ] as const
 


### PR DESCRIPTION
## Summary
Adds three scopes to `AGENT_DWD_SCOPES` (v3), matching the Domain-wide delegation grant entered in the Admin console on 2026-07-16 for the new TSD-owned broker SA:

- **`chat.memberships`** — probe-proven gap: with a live `agnt_` token, `spaces.members.list` returned 403 *"Request had insufficient authentication scopes"* while messages/spaces calls succeeded. This was the "agent can't see or add people in spaces it's a member of" failure reported by users.
- **`chat.memberships.app`** — lets the agent add/remove the PSD Chat app itself in spaces it creates, so agent-created project spaces stay bot-capable.
- **`tasks`** — agent-slot task lists (user-slot tasks ride the separate consent OAuth flow; unchanged).

## Context
Part of the agent dev→prod migration workstream. The broker was recreated under district control (`psd-aistudio-broker`, Terraform in `psd401/psd-gcp-infra`) and cut over on 2026-07-16 with 5/5 acceptance tests green. The console grant is already the v3 superset — inert until this constant ships, which is the safe ordering (grant ⊇ requested set; the reverse would break minting).

Forms API access deliberately needs **no** scope change: `drive` already authorizes `forms.create`/`get`/`responses.list` per Google's per-method docs; Forms was blocked by API enablement on the legacy broker project (probe: 403 `SERVICE_DISABLED` naming project 979866911739) and is fixed by `forms.googleapis.com` enablement on the new broker.

## Testing
- `tests/unit/dwd-token-broker.test.ts` 13/13 (the signJwt scope-claim assertion derives from the constant, so it tracks this change).
- Touched-file eslint clean; full `tsc --noEmit` clean; full pre-push suite passed locally.
- Live-token probes documented above (mint via `psd-agent-mint-dev`).

## Activation
Scopes take effect on the next `AIStudio-AgentPlatformStack-Dev` deploy (the mint Lambda bundles this constant at synth). No migration, no UI surface.
