### PR TITLE
fix(security): carve session-locks out of prod boundary DeleteItem MFA-deny

### DIFF
--- a/infra/lib/constructs/security/permission-boundaries/prod-boundary.json
+++ b/infra/lib/constructs/security/permission-boundaries/prod-boundary.json
@@ -191,10 +191,25 @@
       "Effect": "Deny",
       "Action": [
         "s3:DeleteObject",
-        "dynamodb:DeleteItem",
         "lambda:DeleteFunction"
       ],
       "Resource": "*",
+      "Condition": {
+        "BoolIfExists": {
+          "aws:MultiFactorAuthPresent": "false"
+        }
+      }
+    },
+    {
+      "Sid": "RequireMFAForDynamoDBDeleteExceptAgentLocks",
+      "_comment": "The agent router (a Lambda service role, never MFA-present) must DeleteItem to release per-session locks (agent-router index.ts releaseSessionLock). The blanket MFA-deny above previously blocked it, so locks only expired via TTL (14m) causing same-session serialization. Keep the MFA requirement for every other table; carve out only the session-locks tables.",
+      "Effect": "Deny",
+      "Action": [
+        "dynamodb:DeleteItem"
+      ],
+      "NotResource": [
+        "arn:aws:dynamodb:*:390844780692:table/psd-agent-session-locks-*"
+      ],
       "Condition": {
         "BoolIfExists": {
           "aws:MultiFactorAuthPresent": "false"


### PR DESCRIPTION
## Problem (surfaced at the 2026-07-24 prod agent cutover)
The prod permission boundary statement `RequireMFAForSensitiveOperations` denies `dynamodb:DeleteItem` when `aws:MultiFactorAuthPresent=false`. That guard targets humans, but the **agent-router Lambda is a service role that never has MFA**, and it legitimately calls `DeleteItem` to release per-session locks ([agent-router/index.ts:567](https://github.com/psd401/aistudio/blob/dev/infra/lambdas/agent-router/index.ts#L567), `releaseSessionLock`).

On the first real prod turn the router logged: `not authorized to perform: dynamodb:DeleteItem on psd-agent-session-locks-prod with an explicit deny in a permissions boundary`. Locks then only expired via their 14-minute TTL, serializing a user's rapid same-session messages (observed as slow 2nd replies). Dev's boundary has no such deny, which is why this never appeared pre-cutover.

## Fix
Split the statement:
- Keep the blanket MFA-deny for `s3:DeleteObject` + `lambda:DeleteFunction`.
- Add `RequireMFAForDynamoDBDeleteExceptAgentLocks`: denies `dynamodb:DeleteItem` without MFA on **every table except** `psd-agent-session-locks-*`.

`session-locks` is the **only** table any agent service role deletes from (verified: a single `DeleteCommand` in agent source). MFA protection is preserved everywhere else. Only `prod-boundary.json` changes; `dev-boundary.json` is untouched.

## Verification
- JSON valid; `cdk synth AIStudio-PermissionBoundary-Prod` confirms the two statements render correctly (`dynamodb:DeleteItem` removed from the blanket deny; `NotResource` scopes the carve-out).

## Deploy
After merge: promote to main, then `AIStudio-PermissionBoundary-Prod`.