### PR TITLE
fix(security): account-wildcard the session-lock boundary carve-out (codex follow-up to #1299)

### DIFF
--- a/infra/lib/constructs/security/permission-boundaries/prod-boundary.json
+++ b/infra/lib/constructs/security/permission-boundaries/prod-boundary.json
@@ -208,7 +208,7 @@
         "dynamodb:DeleteItem"
       ],
       "NotResource": [
-        "arn:aws:dynamodb:*:390844780692:table/psd-agent-session-locks-*"
+        "arn:aws:dynamodb:*:*:table/psd-agent-session-locks-*"
       ],
       "Condition": {
         "BoolIfExists": {


### PR DESCRIPTION
Follow-up to #1299 addressing the Codex P2: the `NotResource` in `RequireMFAForDynamoDBDeleteExceptAgentLocks` hardcoded account `390844780692`. The rest of `prod-boundary.json` uses `*` for the account (e.g. `AllowPassRoleToScheduler`), so a different deployment account would leave the router's session-lock `DeleteItem` denied.

Change: `arn:aws:dynamodb:*:390844780692:table/psd-agent-session-locks-*` → `arn:aws:dynamodb:*:*:table/psd-agent-session-locks-*`. Table-name-scoped, account-agnostic, matches file convention. Not yet deployed — rides the same promote as #1299.