### PR TITLE
promote: session-lock boundary carve-out to prod (#1299 + #1300)

### DIFF
--- a/infra/lib/constructs/security/permission-boundaries/prod-boundary.json
+++ b/infra/lib/constructs/security/permission-boundaries/prod-boundary.json
@@ -208,7 +208,7 @@
         "dynamodb:DeleteItem"
       ],
       "NotResource": [
-        "arn:aws:dynamodb:*:390844780692:table/psd-agent-session-locks-*"
+        "arn:aws:dynamodb:*:*:table/psd-agent-session-locks-*"
       ],
       "Condition": {
         "BoolIfExists": {

--- a/infra/lib/constructs/security/permission-boundaries/prod-boundary.json
+++ b/infra/lib/constructs/security/permission-boundaries/prod-boundary.json
@@ -191,10 +191,25 @@
       "Effect": "Deny",
       "Action": [
         "s3:DeleteObject",
-        "dynamodb:DeleteItem",
         "lambda:DeleteFunction"
       ],
       "Resource": "*",
+      "Condition": {
+        "BoolIfExists": {
+          "aws:MultiFactorAuthPresent": "false"
+        }
+      }
+    },
+    {
+      "Sid": "RequireMFAForDynamoDBDeleteExceptAgentLocks",
+      "_comment": "The agent router (a Lambda service role, never MFA-present) must DeleteItem to release per-session locks (agent-router index.ts releaseSessionLock). The blanket MFA-deny above previously blocked it, so locks only expired via TTL (14m) causing same-session serialization. Keep the MFA requirement for every other table; carve out only the session-locks tables.",
+      "Effect": "Deny",
+      "Action": [
+        "dynamodb:DeleteItem"
+      ],
+      "NotResource": [
+        "arn:aws:dynamodb:*:390844780692:table/psd-agent-session-locks-*"
+      ],
       "Condition": {
         "BoolIfExists": {
           "aws:MultiFactorAuthPresent": "false"


### PR DESCRIPTION
Promotes the two boundary fixes to main so `AIStudio-PermissionBoundary-Prod` can deploy them:
- #1299 — carve `psd-agent-session-locks-*` out of the `dynamodb:DeleteItem` MFA-deny (fixes the agent router's session-lock release, which was blocked on prod → same-session slowness).
- #1300 — account-wildcard the carve-out (codex follow-up).

Scope: **one file** (`prod-boundary.json`), +16/-1. No other changes between main and dev.