### PR TITLE
fix(atrium): bake OAuth readiness into CDK

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,10 @@ AUTH_URL=http://localhost:3000
 AUTH_SECRET=
 AUTH_COGNITO_CLIENT_ID=
 AUTH_COGNITO_ISSUER=https://cognito-idp.us-east-1.amazonaws.com/YOUR_USER_POOL_ID
+# Dedicated oidc-provider cookie key. FrontendStackEcs creates and injects this
+# automatically in AWS. Required for non-CDK production deployments; local
+# development falls back to AUTH_SECRET.
+# OIDC_COOKIE_SECRET=
 
 # Public Authentication Variables (Client-side)
 NEXT_PUBLIC_COGNITO_USER_POOL_ID=

--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -211,13 +211,18 @@ export async function GET() {
     }
   }
 
-  // 4. Verify that every task can load the shared OIDC signing key set. The
-  // check reports metadata only; private JWK material and the secret ARN are
-  // never included in the response or logs.
+  // 4. Verify that every task has the dedicated production cookie secret and
+  // can load the shared OIDC signing key set. The check reports metadata only;
+  // private key material, secret values, and secret ARNs are never included in
+  // the response or logs.
   try {
+    const { getOidcCookieSecret } = await import(
+      "@/lib/oauth/oidc-cookie-secret"
+    )
     const { getOidcSigningKeySet } = await import(
       "@/lib/oauth/oidc-signing-key-store"
     )
+    getOidcCookieSecret()
     const keySet = await getOidcSigningKeySet()
     healthCheck.checks.oauthSigning = {
       status: "healthy",
@@ -227,15 +232,18 @@ export async function GET() {
       source: keySet.source,
     }
   } catch (error) {
-    log.error("OIDC signing key health check failed", {
+    log.error("OIDC provider cryptographic health check failed", {
       errorType: error instanceof Error ? error.name : "UnknownError",
     })
     healthCheck.checks.oauthSigning = {
       status: "unhealthy",
-      configured: Boolean(process.env.OIDC_SIGNING_JWKS_SECRET_ARN),
-      error: "OIDC signing keys are unavailable",
+      configured: Boolean(
+        process.env.OIDC_COOKIE_SECRET &&
+          process.env.OIDC_SIGNING_JWKS_SECRET_ARN
+      ),
+      error: "OIDC provider cryptographic configuration is unavailable",
       hint:
-        "Check application logs and the deployment's signing-key configuration.",
+        "Check application logs and the deployment's cookie/signing-key configuration.",
     }
   }
 
@@ -281,7 +289,7 @@ export async function GET() {
 
     if (healthCheck.checks.oauthSigning.status !== "healthy") {
       healthCheck.diagnostics.hints.push(
-        "OAuth signing keys are unavailable. Token issuance fails closed until the shared OIDC key-set secret and ECS permissions are repaired."
+        "OAuth provider cryptographic configuration is unavailable. Token issuance fails closed until the dedicated cookie secret, shared OIDC key-set secret, and ECS permissions are repaired."
       )
     }
     

--- a/docs/ENVIRONMENT_VARIABLES.md
+++ b/docs/ENVIRONMENT_VARIABLES.md
@@ -12,6 +12,7 @@ This document provides a comprehensive guide to all environment variables requir
 | `AUTH_SECRET` | Secret for NextAuth.js session encryption | Generate with: `openssl rand -base64 32` | ✅ |
 | `AUTH_COGNITO_CLIENT_ID` | AWS Cognito client ID | From Auth stack outputs | ✅ |
 | `AUTH_COGNITO_ISSUER` | AWS Cognito issuer URL | `https://cognito-idp.us-east-1.amazonaws.com/<pool-id>` | ✅ |
+| `OIDC_COOKIE_SECRET` | Dedicated oidc-provider cookie encryption/signing key; created and injected by `FrontendStackEcs` | Generate with: `openssl rand -base64 32` | ✅ in production |
 
 ### Token Configuration
 

--- a/docs/features/oauth-provider.md
+++ b/docs/features/oauth-provider.md
@@ -130,7 +130,7 @@ authenticateRequest() → token starts with "sk-"?
 | `OIDC_SIGNING_JWKS_SECRET_ARN` | Production | — | Secrets Manager ARN for the shared OIDC-only RSA JWK set |
 | `KMS_SIGNING_KEY_ARN` | Prod only | — | Separate KMS key for delegated-agent JWT signing |
 | `KMS_SIGNING_KEY_KID` | Prod only | — | Delegated-token KMS key ID |
-| `OIDC_COOKIE_SECRET` | Recommended | NEXTAUTH_SECRET | Cookie encryption |
+| `OIDC_COOKIE_SECRET` | Production | AUTH_SECRET (local only) | Dedicated provider cookie encryption/signing key; provisioned and injected by `FrontendStackEcs` |
 | `NEXTAUTH_URL` | Yes | — | Issuer URL |
 
 See [OIDC signing-key operations](../operations/oauth-signing-keys.md) for the

--- a/docs/operations/oauth-signing-keys.md
+++ b/docs/operations/oauth-signing-keys.md
@@ -12,6 +12,11 @@ AI Studio deliberately uses two signing systems:
 | OIDC access and ID tokens | RSA-3072 JWK set in AWS Secrets Manager | Exportable to the ECS task because `oidc-provider` requires a private JWK |
 | Atrium delegated-agent tokens | AWS KMS asymmetric key | Non-exportable; signing occurs inside KMS |
 
+The OIDC provider also uses a separate symmetric
+`OIDC_COOKIE_SECRET` for its interaction, session, and state cookies. It must
+not reuse `AUTH_SECRET` in production. `FrontendStackEcs` creates the cookie
+secret and injects only its value into the ECS task at startup.
+
 The OIDC key is not a fallback for the KMS signer. It is a separate,
 OIDC-only key with a narrower purpose. Secrets Manager encrypts it at rest,
 CloudTrail records reads and writes, and IAM grants `GetSecretValue` only to the
@@ -26,9 +31,10 @@ token) is database-backed, so ALB routing and task restarts do not break a flow.
 
 ## Provisioning and deployment
 
-`AIStudio-FrontendStack-{environment}` creates and tags:
+`AIStudio-FrontendStack-ECS-{environment}` creates and tags:
 
 - `aistudio/{environment}/oauth/oidc-signing-jwks`
+- `aistudio/{environment}/oauth/oidc-cookie-secret`
 - `aistudio-oidc-key-bootstrap-{environment}`
 
 The custom resource generates the first RSA-3072 key only when the secret does
@@ -39,9 +45,10 @@ cannot start against the placeholder.
 Deploy in this order:
 
 1. Apply database migration `129-oauth-production-hardening.sql`.
-2. Run `cd infra && bunx cdk synth AIStudio-FrontendStack-Dev` (or Prod).
+2. Run `cd infra && bunx cdk synth AIStudio-FrontendStack-ECS-Dev --context baseDomain=<domain>` (or Prod).
 3. Deploy the frontend stack.
-4. Check `/api/health`; `checks.oauthSigning.status` must be `healthy`.
+4. Check `/api/health`; `checks.oauthSigning.status` must be `healthy`. This
+   verifies both the dedicated cookie key and the shared signing-key set.
 5. Check `/.well-known/openid-configuration` and `/api/oauth/jwks`.
 6. Complete a public-client S256 authorization-code flow and call one read and
    one write endpoint with the access JWT.
@@ -49,6 +56,12 @@ Deploy in this order:
 The OAuth route fails closed with HTTP 500 if the signing secret is absent,
 unreadable, malformed, or lacks exactly one active private RSA/RS256 key.
 There is no production local-key fallback.
+
+On the first deployment that introduces the dedicated cookie secret, any
+interactive OIDC authorization flow already in progress still carries cookies
+protected by the former session secret. Those short-lived flows must restart
+after deployment; issued access/ID tokens and future authorization flows are
+unaffected. Schedule the rollout accordingly and verify a fresh S256 flow.
 
 ## Rotation
 
@@ -93,14 +106,18 @@ issued-token lifetime causes valid in-flight tokens to fail.
 
 ## Incident response
 
-### Health reports a missing/unreadable secret
+### Health reports missing/unreadable OIDC cryptographic configuration
 
-1. Inspect the ECS task log for `OIDC signing key set unavailable`.
-2. Verify `OIDC_SIGNING_JWKS_SECRET_ARN` points to the environment's secret.
-3. Verify the ECS task role has `secretsmanager:GetSecretValue` for that ARN.
-4. Verify tags are `Environment={environment}` and `ManagedBy=cdk`.
-5. Validate the JSON structure without logging private fields.
-6. Restore the most recent known-good secret version, then force a new ECS
+1. Confirm the task definition injects `OIDC_COOKIE_SECRET` from
+   `aistudio/{environment}/oauth/oidc-cookie-secret`.
+2. Inspect the ECS task log for `OIDC provider cryptographic health check
+   failed` or `OIDC signing key set unavailable`.
+3. Verify `OIDC_SIGNING_JWKS_SECRET_ARN` points to the environment's secret.
+4. Verify the ECS task/execution roles have `secretsmanager:GetSecretValue` for
+   the corresponding secret ARNs.
+5. Verify tags are `Environment={environment}` and `ManagedBy=cdk`.
+6. Validate the signing-key JSON structure without logging private fields.
+7. Restore the most recent known-good secret version, then force a new ECS
    deployment or wait for the five-minute cache.
 
 ### Suspected OIDC private-key compromise

--- a/infra/lib/constructs/ecs-service.ts
+++ b/infra/lib/constructs/ecs-service.ts
@@ -138,6 +138,11 @@ export interface EcsServiceConstructProps {
    */
   guardrailHashSecretArn: string;
   /**
+   * Dedicated oidc-provider cookie encryption/signing secret ARN.
+   * Injected at task startup as OIDC_COOKIE_SECRET.
+   */
+  oidcCookieSecretArn: string;
+  /**
    * Shared private OIDC JWK set in Secrets Manager (#1285). Read lazily by the
    * application task role; never injected as an environment secret value.
    */
@@ -302,6 +307,7 @@ export class EcsServiceConstruct extends Construct {
         props.internalApiSecretArn,
         props.collabJwtSecretArn,
         props.guardrailHashSecretArn,
+        props.oidcCookieSecretArn,
         props.oidcSigningJwksSecretArn,
       ],
     }));
@@ -884,6 +890,12 @@ export class EcsServiceConstruct extends Construct {
         GUARDRAIL_HASH_SECRET: ecs.Secret.fromSecretsManager(
           secretsmanager.Secret.fromSecretCompleteArn(this, 'GuardrailHashSecret', props.guardrailHashSecretArn),
           'GUARDRAIL_HASH_SECRET'
+        ),
+        // Dedicated oidc-provider cookie key. This is intentionally separate
+        // from AUTH_SECRET and is required by production readiness checks.
+        OIDC_COOKIE_SECRET: ecs.Secret.fromSecretsManager(
+          secretsmanager.Secret.fromSecretCompleteArn(this, 'OidcCookieSecret', props.oidcCookieSecretArn),
+          'OIDC_COOKIE_SECRET'
         ),
         // Issue #603: Database credentials for postgres.js driver
         // The RDS secret contains a JSON object with: username, password, host, port, dbname

--- a/infra/lib/frontend-stack-ecs.ts
+++ b/infra/lib/frontend-stack-ecs.ts
@@ -174,6 +174,27 @@ export class FrontendStackEcs extends cdk.Stack {
     });
 
     // ============================================================================
+    // OIDC Provider Cookie Secret (#1285 deployment readiness)
+    // ============================================================================
+    // oidc-provider encrypts/signs its own interaction, session, and state
+    // cookies. Keep this key separate from AUTH_SECRET so a NextAuth session-key
+    // compromise does not extend to the OAuth provider. The value is injected
+    // into ECS at task start; operators never need to hand-configure it.
+    const oidcCookieSecret = new secretsmanager.Secret(this, 'OidcCookieSecret', {
+      secretName: `aistudio/${environment}/oauth/oidc-cookie-secret`,
+      description: 'Dedicated oidc-provider cookie encryption and signing secret',
+      generateSecretString: {
+        secretStringTemplate: JSON.stringify({}),
+        generateStringKey: 'OIDC_COOKIE_SECRET',
+        excludePunctuation: true,
+        passwordLength: 32,
+      },
+      removalPolicy: environment === 'prod' ? cdk.RemovalPolicy.RETAIN : cdk.RemovalPolicy.DESTROY,
+    });
+    cdk.Tags.of(oidcCookieSecret).add('Environment', environment);
+    cdk.Tags.of(oidcCookieSecret).add('ManagedBy', 'cdk');
+
+    // ============================================================================
     // OIDC Signing JWK Set (#1285)
     // ============================================================================
     // oidc-provider needs private JWK material at its JOSE boundary, while the
@@ -316,6 +337,8 @@ export class FrontendStackEcs extends cdk.Stack {
       collabJwtSecretArn: collabJwtSecret.secretArn,
       // Guardrail violation-log hash secret (#727, created above)
       guardrailHashSecretArn: guardrailHashSecret.secretArn,
+      // Dedicated oidc-provider cookie key (created above)
+      oidcCookieSecretArn: oidcCookieSecret.secretArn,
       // OIDC-only signing key set (#1285, created and bootstrapped above)
       oidcSigningJwksSecretArn: oidcSigningJwksSecret.secretArn,
       // K-12 Content Safety: Guardrails resources from GuardrailsStack

--- a/infra/test/unit/ecs-service-mint-invoke.test.ts
+++ b/infra/test/unit/ecs-service-mint-invoke.test.ts
@@ -45,6 +45,7 @@ function synthTemplate(): Template {
     internalApiSecretArn: secretArn('internal-api'),
     collabJwtSecretArn: secretArn('collab-jwt'),
     guardrailHashSecretArn: secretArn('guardrail-hash'),
+    oidcCookieSecretArn: secretArn('oidc-cookie'),
     oidcSigningJwksSecretArn: secretArn('oidc-signing'),
   });
 
@@ -124,6 +125,36 @@ describe('ECS task role — mint Lambda invoke-only grant (#1232)', () => {
     const mintEnv = envPairs.find((e) => e.Name === 'AGENT_MINT_LAMBDA_NAME');
     expect(mintEnv).toBeDefined();
     expect(mintEnv!.Value).toBe(MINT_FN);
+  });
+
+  it('injects the dedicated OIDC cookie secret into the frontend container', () => {
+    const taskDefs = template.findResources('AWS::ECS::TaskDefinition');
+    const secretPairs: Array<{ Name?: string; ValueFrom?: unknown }> = [];
+    for (const td of Object.values(taskDefs)) {
+      const containers = (
+        td as {
+          Properties?: {
+            ContainerDefinitions?: Array<{
+              Secrets?: Array<{ Name?: string; ValueFrom?: unknown }>;
+            }>;
+          };
+        }
+      ).Properties?.ContainerDefinitions ?? [];
+      for (const container of containers) {
+        if (Array.isArray(container.Secrets)) {
+          secretPairs.push(...container.Secrets);
+        }
+      }
+    }
+
+    const oidcCookieSecret = secretPairs.find(
+      (secret) => secret.Name === 'OIDC_COOKIE_SECRET'
+    );
+    expect(oidcCookieSecret).toBeDefined();
+    expect(JSON.stringify(oidcCookieSecret!.ValueFrom)).toContain('oidc-cookie');
+    expect(JSON.stringify(oidcCookieSecret!.ValueFrom)).toContain(
+      'OIDC_COOKIE_SECRET'
+    );
   });
 
   it('keeps legacy document storage permissions separate from permanent cleanup', () => {

--- a/infra/test/unit/ecs-service-stickiness.test.ts
+++ b/infra/test/unit/ecs-service-stickiness.test.ts
@@ -49,6 +49,7 @@ describe("ECS Service — ALB stickiness regression guard (#1105)", () => {
       internalApiSecretArn: secretArn("internal-api"),
       collabJwtSecretArn: secretArn("collab-jwt"),
       guardrailHashSecretArn: secretArn("guardrail-hash"),
+      oidcCookieSecretArn: secretArn("oidc-cookie"),
       oidcSigningJwksSecretArn: secretArn("oidc-signing"),
     })
 

--- a/lib/oauth/__tests__/oidc-cookie-secret.test.ts
+++ b/lib/oauth/__tests__/oidc-cookie-secret.test.ts
@@ -1,0 +1,83 @@
+import { getOidcCookieSecret } from "../oidc-cookie-secret"
+
+const ORIGINAL_ENV = {
+  NODE_ENV: process.env.NODE_ENV,
+  OIDC_COOKIE_SECRET: process.env.OIDC_COOKIE_SECRET,
+  AUTH_SECRET: process.env.AUTH_SECRET,
+  NEXTAUTH_SECRET: process.env.NEXTAUTH_SECRET,
+}
+
+function setNodeEnvironment(value: string | undefined): void {
+  if (value === undefined) {
+    Reflect.deleteProperty(process.env, "NODE_ENV")
+    return
+  }
+  Object.defineProperty(process.env, "NODE_ENV", {
+    configurable: true,
+    enumerable: true,
+    value,
+    writable: true,
+  })
+}
+
+function restoreEnvironment(): void {
+  setNodeEnvironment(ORIGINAL_ENV.NODE_ENV)
+  for (const [name, value] of Object.entries(ORIGINAL_ENV)) {
+    if (name === "NODE_ENV") continue
+    if (value === undefined) {
+      delete process.env[name]
+    } else {
+      process.env[name] = value
+    }
+  }
+}
+
+describe("getOidcCookieSecret", () => {
+  beforeEach(() => {
+    delete process.env.OIDC_COOKIE_SECRET
+    delete process.env.AUTH_SECRET
+    delete process.env.NEXTAUTH_SECRET
+  })
+
+  afterAll(restoreEnvironment)
+
+  it("uses the dedicated OIDC secret ahead of session secrets", () => {
+    process.env.OIDC_COOKIE_SECRET = "dedicated-secret"
+    process.env.AUTH_SECRET = "auth-secret"
+    process.env.NEXTAUTH_SECRET = "legacy-secret"
+
+    expect(getOidcCookieSecret()).toBe("dedicated-secret")
+  })
+
+  it("requires the dedicated secret in production", () => {
+    setNodeEnvironment("production")
+    process.env.AUTH_SECRET = "configured-session-secret"
+    process.env.NEXTAUTH_SECRET = "configured-legacy-session-secret"
+
+    expect(() => getOidcCookieSecret()).toThrow(
+      "OIDC_COOKIE_SECRET must be set in production"
+    )
+  })
+
+  it("falls back to the canonical AUTH_SECRET in local development", () => {
+    setNodeEnvironment("development")
+    process.env.AUTH_SECRET = "local-session-secret"
+
+    expect(getOidcCookieSecret()).toBe("local-session-secret")
+  })
+
+  it("supports the legacy NEXTAUTH_SECRET fallback outside production", () => {
+    setNodeEnvironment("test")
+    process.env.NEXTAUTH_SECRET = "legacy-local-secret"
+
+    expect(getOidcCookieSecret()).toBe("legacy-local-secret")
+  })
+
+  it("preserves legacy NEXTAUTH_SECRET precedence in local development", () => {
+    setNodeEnvironment("development")
+    process.env.AUTH_SECRET = "canonical-local-secret"
+    process.env.NEXTAUTH_SECRET = "existing-legacy-secret"
+
+    expect(getOidcCookieSecret()).toBe("existing-legacy-secret")
+  })
+})

--- a/lib/oauth/oidc-cookie-secret.ts
+++ b/lib/oauth/oidc-cookie-secret.ts
@@ -1,0 +1,31 @@
+/**
+ * Resolve the cookie encryption/signing secret used by oidc-provider.
+ *
+ * Production deployments require a dedicated key so a compromise of the
+ * NextAuth session key cannot also forge or decrypt OIDC provider cookies.
+ * FrontendStackEcs provisions and injects this value as OIDC_COOKIE_SECRET.
+ *
+ * Local development may reuse the legacy NEXTAUTH_SECRET or the canonical
+ * NextAuth v5 AUTH_SECRET to avoid requiring another generated secret. Preserve
+ * the legacy variable's precedence so existing local OIDC cookies remain valid
+ * when both variables are configured.
+ */
+export function getOidcCookieSecret(): string {
+  const dedicatedSecret = process.env.OIDC_COOKIE_SECRET
+  if (dedicatedSecret) {
+    return dedicatedSecret
+  }
+
+  if (process.env.NODE_ENV === "production") {
+    throw new Error(
+      "OIDC_COOKIE_SECRET must be set in production. " +
+        "Deploy FrontendStackEcs or generate one with: openssl rand -base64 32"
+    )
+  }
+
+  return (
+    process.env.NEXTAUTH_SECRET ??
+    process.env.AUTH_SECRET ??
+    "dev-oidc-cookie-secret-change-in-production"
+  )
+}

--- a/lib/oauth/oidc-provider-config.ts
+++ b/lib/oauth/oidc-provider-config.ts
@@ -10,6 +10,7 @@ import { DrizzleOidcAdapter } from "./drizzle-adapter"
 import { getOidcSigningKeySet } from "./oidc-signing-key-store"
 import { getIssuerUrl } from "./issuer-config"
 import { ALL_OAUTH_SCOPES } from "./oauth-scopes"
+import { getOidcCookieSecret } from "./oidc-cookie-secret"
 import { createLogger } from "@/lib/logger"
 
 // ============================================
@@ -283,19 +284,7 @@ export async function getOidcProvider(
     // Cookies
     // ==========================================
     cookies: {
-      keys: (() => {
-        const secret = process.env.OIDC_COOKIE_SECRET ?? process.env.NEXTAUTH_SECRET
-        if (!secret) {
-          if (process.env.NODE_ENV === "production") {
-            throw new Error(
-              "OIDC_COOKIE_SECRET or NEXTAUTH_SECRET must be set in production. " +
-              "Generate with: openssl rand -base64 32"
-            )
-          }
-          return ["dev-oidc-cookie-secret-change-in-production"]
-        }
-        return [secret]
-      })(),
+      keys: [getOidcCookieSecret()],
     },
   })
 

--- a/lib/tools/catalog/manifest.ts
+++ b/lib/tools/catalog/manifest.ts
@@ -172,16 +172,16 @@ const MCP_TOOL_CATALOG_MAP: Record<string, McpCatalogMapping> = {
     requiredScope: "content:create",
     internalScopes: ["content:create"],
     destructive: true,
-    // v2: `codeEncoding` added to the input schema (#1245 E2BIG fix).
-    version: "v2",
+    // v3: #1290 added `sourceRef`; v2 added `codeEncoding` (#1245).
+    version: "v3",
   },
   create_artifact: {
     identifier: "content.create_artifact",
     requiredScope: "content:create",
     internalScopes: ["content:create"],
     destructive: true,
-    // v2: `codeEncoding` added to the input schema (#1245 E2BIG fix).
-    version: "v2",
+    // v3: #1290 added `sourceRef`; v2 added `codeEncoding` (#1245).
+    version: "v3",
   },
   get_content: {
     identifier: "content.get",

--- a/tests/unit/atrium-mcp-content-tools.test.ts
+++ b/tests/unit/atrium-mcp-content-tools.test.ts
@@ -120,4 +120,17 @@ describe("Atrium MCP content tools registry", () => {
       expect(tool?.inputSchema.required ?? []).not.toContain("codeEncoding");
     }
   });
+
+  it("publishes sourceRef additions as v3 create-tool contracts", () => {
+    for (const name of ["create_document", "create_artifact"]) {
+      const tool = CONTENT_MCP_TOOLS.find((candidate) => candidate.name === name);
+      const manifestEntry = TOOL_MANIFEST.find(
+        (candidate) => candidate.name === name
+      );
+
+      expect(tool?.inputSchema.properties.sourceRef?.type).toBe("object");
+      expect(tool?.inputSchema.required ?? []).not.toContain("sourceRef");
+      expect(manifestEntry?.version).toBe("v3");
+    }
+  });
 });

--- a/tests/unit/health-route-oidc-readiness.test.ts
+++ b/tests/unit/health-route-oidc-readiness.test.ts
@@ -1,0 +1,78 @@
+/** @jest-environment node */
+
+const getOidcSigningKeySet = jest.fn(async () => ({
+  activeKid: "test-kid",
+  publicKeys: [{ kid: "test-kid" }],
+  source: "secrets-manager" as const,
+}))
+
+jest.mock("@/lib/db/drizzle-client", () => ({
+  validateDatabaseConnection: jest.fn(async () => ({ success: true })),
+}))
+jest.mock("@/lib/auth/server-session", () => ({
+  getServerSession: jest.fn(async () => null),
+}))
+jest.mock("@/lib/oauth/oidc-signing-key-store", () => ({
+  getOidcSigningKeySet,
+}))
+jest.mock("@/lib/logger", () => ({
+  createLogger: () => ({
+    info: jest.fn(),
+    debug: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  }),
+  generateRequestId: () => "health-request",
+  startTimer: () => jest.fn(),
+}))
+
+import { GET } from "@/app/api/health/route"
+
+function setNodeEnvironment(value: string | undefined): void {
+  if (value === undefined) {
+    Reflect.deleteProperty(process.env, "NODE_ENV")
+    return
+  }
+  Object.defineProperty(process.env, "NODE_ENV", {
+    configurable: true,
+    enumerable: true,
+    value,
+    writable: true,
+  })
+}
+
+describe("GET /api/health OIDC production readiness", () => {
+  const originalNodeEnv = process.env.NODE_ENV
+  const originalOidcCookieSecret = process.env.OIDC_COOKIE_SECRET
+  const originalSigningSecretArn = process.env.OIDC_SIGNING_JWKS_SECRET_ARN
+
+  beforeAll(() => {
+    setNodeEnvironment("production")
+    delete process.env.OIDC_COOKIE_SECRET
+    process.env.OIDC_SIGNING_JWKS_SECRET_ARN =
+      "arn:aws:secretsmanager:us-east-1:123456789012:secret:test"
+  })
+
+  afterAll(() => {
+    setNodeEnvironment(originalNodeEnv)
+    if (originalOidcCookieSecret === undefined) {
+      delete process.env.OIDC_COOKIE_SECRET
+    } else {
+      process.env.OIDC_COOKIE_SECRET = originalOidcCookieSecret
+    }
+    if (originalSigningSecretArn === undefined) {
+      delete process.env.OIDC_SIGNING_JWKS_SECRET_ARN
+    } else {
+      process.env.OIDC_SIGNING_JWKS_SECRET_ARN = originalSigningSecretArn
+    }
+  })
+
+  it("fails readiness before loading signing keys when the dedicated cookie key is absent", async () => {
+    const response = await GET()
+    const body = await response.json()
+
+    expect(response.status).toBe(503)
+    expect(body.checks.oauthSigning).toEqual({ status: "unhealthy" })
+    expect(getOidcSigningKeySet).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary
- provision a dedicated oidc-provider cookie secret in each frontend ECS stack and inject it into the task definition
- require the dedicated cookie key in production and include it in the existing OAuth cryptographic readiness check
- advance content.create_document and content.create_artifact to v3 for the sourceRef schema addition, preserving immutable v2 contracts
- add regression coverage and update environment and OAuth operations documentation

## Validation
- bun run lint (0 errors; 420 existing warnings)
- bun run typecheck
- bun run test:ci -- --runInBand (335 suites passed, 5 skipped; 3,469 tests passed, 60 skipped)
- bun run build
- bun run test:smoke:atrium
- infra: bun run build
- infra: bun run test -- --runInBand (40 suites, 396 tests passed)
- targeted OIDC, health, catalog sync, Atrium MCP, and ECS construct tests
- CDK synth for AIStudio-FrontendStack-ECS-Dev and AIStudio-FrontendStack-ECS-Prod with baseDomain context
- pre-push Playwright: 279 passed, 53 skipped

## Synthesized deployment contract
- dev secret: aistudio/dev/oauth/oidc-cookie-secret (destroy with dev stack)
- prod secret: aistudio/prod/oauth/oidc-cookie-secret (retain on replacement/deletion)
- both task definitions resolve OIDC_COOKIE_SECRET from the generated JSON field

## Deployment
No database migration is required. Deploy the frontend ECS stack, then verify /api/health, /api/oauth/.well-known/openid-configuration, and /api/oauth/jwks.

Refs #1285
Refs #1290