### PR TITLE
fix(oauth): refresh provider after signing-key rotation

### DIFF
--- a/lib/oauth/oidc-provider-config.ts
+++ b/lib/oauth/oidc-provider-config.ts
@@ -7,7 +7,10 @@
 
 import Provider from "oidc-provider"
 import { DrizzleOidcAdapter } from "./drizzle-adapter"
-import { getOidcSigningKeySet } from "./oidc-signing-key-store"
+import {
+  getOidcSigningKeySet,
+  type OidcSigningKeySet,
+} from "./oidc-signing-key-store"
 import { getIssuerUrl } from "./issuer-config"
 import { ALL_OAUTH_SCOPES } from "./oauth-scopes"
 import { getOidcCookieSecret } from "./oidc-cookie-secret"
@@ -27,6 +30,24 @@ interface OidcProviderOptions {
 
 let providerInstance: InstanceType<typeof Provider> | null = null
 let providerKeyFingerprint: string | null = null
+
+/**
+ * Rebuild the cached provider whenever its issuer, active signing key, or
+ * published verification-key material changes. In particular, a standby key
+ * becoming active does not change the set of key ids, so activeKid must be part
+ * of the identity or scheduled rotations keep signing with the retired key
+ * until the task restarts.
+ */
+export function createOidcProviderCacheFingerprint(
+  issuer: string,
+  oidcKeys: Pick<OidcSigningKeySet, "activeKid" | "publicKeys">
+): string {
+  return JSON.stringify({
+    issuer,
+    activeKid: oidcKeys.activeKid,
+    publicKeys: oidcKeys.publicKeys,
+  })
+}
 
 /**
  * Security guard (#1055): a client-credentials token is stamped
@@ -80,9 +101,7 @@ export async function getOidcProvider(
   const log = createLogger({ action: "oidcProvider.init" })
   const issuer = getIssuerUrl(options?.issuer)
   const oidcKeys = await getOidcSigningKeySet()
-  const keyFingerprint = oidcKeys.publicKeys
-    .map((key) => key.kid)
-    .join(":")
+  const keyFingerprint = createOidcProviderCacheFingerprint(issuer, oidcKeys)
   if (
     providerInstance &&
     providerKeyFingerprint === keyFingerprint

--- a/tests/unit/lib/oauth/oidc-provider-config.test.ts
+++ b/tests/unit/lib/oauth/oidc-provider-config.test.ts
@@ -1,0 +1,81 @@
+import type { JWK } from "jose"
+
+jest.mock("oidc-provider", () => ({
+  __esModule: true,
+  default: class MockProvider {},
+}))
+
+import { createOidcProviderCacheFingerprint } from "@/lib/oauth/oidc-provider-config"
+
+const oldPublicKey: JWK = {
+  kid: "old",
+  kty: "RSA",
+  alg: "RS256",
+  use: "sig",
+  n: "old-modulus",
+  e: "AQAB",
+}
+
+const newPublicKey: JWK = {
+  kid: "new",
+  kty: "RSA",
+  alg: "RS256",
+  use: "sig",
+  n: "new-modulus",
+  e: "AQAB",
+}
+
+describe("OIDC provider cache fingerprint", () => {
+  it("changes when a staged standby key becomes active", () => {
+    const publicKeys = [oldPublicKey, newPublicKey]
+
+    const beforeActivation = createOidcProviderCacheFingerprint(
+      "https://aistudio.example",
+      {
+        activeKid: "old",
+        publicKeys,
+      }
+    )
+    const afterActivation = createOidcProviderCacheFingerprint(
+      "https://aistudio.example",
+      {
+        activeKid: "new",
+        publicKeys,
+      }
+    )
+
+    expect(afterActivation).not.toBe(beforeActivation)
+  })
+
+  it("changes when the issuer changes with the same signing keys", () => {
+    const keys = {
+      activeKid: "old",
+      publicKeys: [oldPublicKey],
+    }
+
+    expect(
+      createOidcProviderCacheFingerprint("https://dev.example", keys)
+    ).not.toBe(
+      createOidcProviderCacheFingerprint("https://prod.example", keys)
+    )
+  })
+
+  it("changes when public key material changes under the same kid", () => {
+    const before = createOidcProviderCacheFingerprint(
+      "https://aistudio.example",
+      {
+        activeKid: "old",
+        publicKeys: [oldPublicKey],
+      }
+    )
+    const after = createOidcProviderCacheFingerprint(
+      "https://aistudio.example",
+      {
+        activeKid: "old",
+        publicKeys: [{ ...oldPublicKey, n: "replacement-modulus" }],
+      }
+    )
+
+    expect(after).not.toBe(before)
+  })
+})


### PR DESCRIPTION
Fixes the P1 review finding from production promotion PR #1316.

The provider cache fingerprint now includes the issuer, active signing key id, and full public verification-key material. A standby key becoming active therefore rebuilds the provider immediately instead of continuing to sign with the former active key until task restart.

Validation:
- OIDC provider/signing-store tests: 9 passed
- Typecheck passed
- Focused lint: 0 errors

No migration or infrastructure change.