### PR TITLE
fix(tools): version published catalog schema updates

### DIFF
--- a/docs/API/v1/generated/tool-catalog.openapi.json
+++ b/docs/API/v1/generated/tool-catalog.openapi.json
@@ -19,7 +19,7 @@
         "operationId": "listAssistants",
         "summary": "List assistants available for API execution",
         "x-tool-identifier": "assistants.list",
-        "x-tool-version": "v1",
+        "x-tool-version": "v2",
         "security": [
           {
             "ApiKeyAuth": [
@@ -49,7 +49,7 @@
         "summary": "Execute an assistant",
         "description": "Execute an assistant architect by id. Returns an SSE stream (default) or a 202 job (Accept: application/json).",
         "x-tool-identifier": "assistants.execute",
-        "x-tool-version": "v1",
+        "x-tool-version": "v2",
         "parameters": [
           {
             "name": "id",

--- a/lib/tools/catalog/ai-sdk-tools.ts
+++ b/lib/tools/catalog/ai-sdk-tools.ts
@@ -66,6 +66,11 @@ export interface ToolConfig {
 export interface AiSdkToolDef {
   /** Catalog `domain.action` identifier (e.g. `chat.web_search`). */
   identifier: string
+  /**
+   * Immutable catalog contract version. Bump whenever the projected schema
+   * changes after release.
+   */
+  version?: `v${number}`
   /** MCP/provider wire name — the catalog `name` (e.g. `web_search_preview`). */
   wireName: string
   /** Friendly key used by the UI registry + `enabledTools` (e.g. `webSearch`). */
@@ -91,6 +96,7 @@ export interface AiSdkToolDef {
 export const AI_SDK_TOOLS: readonly AiSdkToolDef[] = [
   {
     identifier: 'chat.show_chart',
+    version: 'v2',
     wireName: 'show_chart',
     friendlyName: 'showChart',
     description:
@@ -99,6 +105,7 @@ export const AI_SDK_TOOLS: readonly AiSdkToolDef[] = [
   },
   {
     identifier: 'chat.web_search',
+    version: 'v2',
     wireName: 'web_search_preview',
     friendlyName: 'webSearch',
     description: 'Search the web for current information and facts.',
@@ -111,6 +118,7 @@ export const AI_SDK_TOOLS: readonly AiSdkToolDef[] = [
   },
   {
     identifier: 'chat.code_interpreter',
+    version: 'v2',
     wireName: 'code_interpreter',
     friendlyName: 'codeInterpreter',
     description: 'Execute code and perform data analysis.',
@@ -123,6 +131,7 @@ export const AI_SDK_TOOLS: readonly AiSdkToolDef[] = [
   },
   {
     identifier: 'chat.generate_image',
+    version: 'v2',
     wireName: 'generateImage',
     friendlyName: 'generateImage',
     description:

--- a/lib/tools/catalog/manifest.ts
+++ b/lib/tools/catalog/manifest.ts
@@ -122,6 +122,8 @@ const MCP_TOOL_CATALOG_MAP: Record<string, McpCatalogMapping> = {
     identifier: "assistants.execute",
     requiredScope: "mcp:execute_assistant",
     internalScopes: ["mcp:execute_assistant"],
+    // v2: the published v1 schema predates the current execution inputs.
+    version: "v2",
     rest: {
       // REST callers use `assistants:execute` (see app/api/v1/assistants/[id]/execute);
       // distinct from the MCP scope, hence surfaceScopes rather than a shared array.
@@ -144,6 +146,8 @@ const MCP_TOOL_CATALOG_MAP: Record<string, McpCatalogMapping> = {
     identifier: "assistants.list",
     requiredScope: "mcp:list_assistants",
     internalScopes: ["mcp:list_assistants"],
+    // v2: the published v1 schema predates the current list filters.
+    version: "v2",
     rest: {
       // REST list route uses `assistants:list` (see app/api/v1/assistants GET).
       scopes: ["assistants:list"],
@@ -313,7 +317,7 @@ const MCP_MANIFEST_ENTRIES: ToolManifestEntry[] = MCP_TOOLS.map(
  */
 const AI_SDK_MANIFEST_ENTRIES: ToolManifestEntry[] = AI_SDK_TOOLS.map((tool) => ({
   identifier: tool.identifier,
-  version: "v1",
+  version: tool.version ?? "v1",
   name: tool.wireName,
   description: tool.description,
   inputSchema: { type: "object", properties: {} },

--- a/tests/unit/lib/tools/manifest-version-regressions.test.ts
+++ b/tests/unit/lib/tools/manifest-version-regressions.test.ts
@@ -1,0 +1,16 @@
+import { TOOL_MANIFEST } from "@/lib/tools/catalog/manifest"
+
+describe("tool manifest immutable contract versions", () => {
+  it.each([
+    "assistants.execute",
+    "assistants.list",
+    "chat.show_chart",
+    "chat.web_search",
+    "chat.code_interpreter",
+    "chat.generate_image",
+  ])("%s publishes its current schema as v2", (identifier) => {
+    expect(
+      TOOL_MANIFEST.find((entry) => entry.identifier === identifier)?.version
+    ).toBe("v2")
+  })
+})


### PR DESCRIPTION
Fixes production startup immutability violations found during the post-deploy audit.

Bumps the published contracts for:
- assistants.execute and assistants.list to v2
- chat.show_chart, chat.web_search, chat.code_interpreter, and chat.generate_image to v2

Older catalog rows remain retired; the current schemas are inserted under new immutable versions. Generated OpenAPI is updated for the REST assistant tools.

Validation:
- Catalog sync/version/OpenAPI tests: 37 passed
- Typecheck passed
- OpenAPI generated-file check passed
- No migration or CDK resource change