### PR TITLE
release: promote Atrium OAuth public-client scope fix

### DIFF
--- a/actions/oauth/oauth-client.actions.ts
+++ b/actions/oauth/oauth-client.actions.ts
@@ -23,6 +23,7 @@ import {
   OAUTH_APPLICATION_TYPES,
   type OAuthApplicationType,
 } from "@/lib/oauth/redirect-uri-policy"
+import { withPublicClientRequiredScopes } from "@/lib/oauth/oauth-scopes"
 import type { ActionState } from "@/types"
 
 // ============================================
@@ -202,6 +203,10 @@ export async function createOAuthClient(
       ? "none"
       : (validated.tokenEndpointAuthMethod ?? "none")
     const isConfidential = authMethod === "client_secret_post"
+    const allowedScopes =
+      authMethod === "none"
+        ? withPublicClientRequiredScopes(validated.allowedScopes)
+        : [...new Set(validated.allowedScopes)]
 
     let clientSecret: string | undefined
     let clientSecretHash: string | null = null
@@ -221,7 +226,7 @@ export async function createOAuthClient(
             applicationType: validated.applicationType,
             clientSecretHash,
             redirectUris: uriValidation.normalizedUris,
-            allowedScopes: validated.allowedScopes,
+            allowedScopes,
             grantTypes: ["authorization_code", "refresh_token"],
             responseTypes: ["code"],
             tokenEndpointAuthMethod: authMethod,

--- a/app/(protected)/admin/oauth-clients/_components/client-form-sheet.tsx
+++ b/app/(protected)/admin/oauth-clients/_components/client-form-sheet.tsx
@@ -20,6 +20,12 @@ import {
 } from "@/components/ui/select"
 import { createOAuthClient } from "@/actions/oauth/oauth-client.actions"
 import { API_SCOPES } from "@/lib/api-keys/scopes"
+import {
+  getScopeLabel,
+  OIDC_SCOPES,
+  PUBLIC_CLIENT_REQUIRED_OIDC_SCOPES,
+  withPublicClientRequiredScopes,
+} from "@/lib/oauth/oauth-scopes"
 import type { OAuthApplicationType } from "@/lib/oauth/redirect-uri-policy"
 
 // ============================================
@@ -31,8 +37,12 @@ interface Props {
 }
 
 // ============================================
-// Available MCP Scopes
+// Available Scopes
 // ============================================
+
+const OIDC_SCOPE_OPTIONS = OIDC_SCOPES.map(
+  (scope) => [scope, getScopeLabel(scope)] as const
+)
 
 const MCP_SCOPES = Object.entries(API_SCOPES).filter(([key]) =>
   key.startsWith("mcp:")
@@ -40,6 +50,10 @@ const MCP_SCOPES = Object.entries(API_SCOPES).filter(([key]) =>
 
 const OTHER_SCOPES = Object.entries(API_SCOPES).filter(
   ([key]) => !key.startsWith("mcp:")
+)
+
+const REQUIRED_PUBLIC_SCOPE_SET = new Set<string>(
+  PUBLIC_CLIENT_REQUIRED_OIDC_SCOPES
 )
 
 // ============================================
@@ -52,7 +66,9 @@ export function ClientFormSheet({ onSuccess }: Props) {
     useState<OAuthApplicationType>("web")
   const [redirectUri, setRedirectUri] = useState("")
   const [authMethod, setAuthMethod] = useState<"none" | "client_secret_post">("none")
-  const [selectedScopes, setSelectedScopes] = useState<string[]>([])
+  const [selectedScopes, setSelectedScopes] = useState<string[]>(() =>
+    withPublicClientRequiredScopes([])
+  )
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [createdSecret, setCreatedSecret] = useState<string | null>(null)
@@ -149,7 +165,12 @@ export function ClientFormSheet({ onSuccess }: Props) {
           onValueChange={(value) => {
             const nextType = value as OAuthApplicationType
             setApplicationType(nextType)
-            if (nextType !== "web") setAuthMethod("none")
+            if (nextType !== "web") {
+              setAuthMethod("none")
+              setSelectedScopes((scopes) =>
+                withPublicClientRequiredScopes(scopes)
+              )
+            }
           }}
         >
           <SelectTrigger id="applicationType">
@@ -198,7 +219,15 @@ export function ClientFormSheet({ onSuccess }: Props) {
         <Select
           value={authMethod}
           disabled={applicationType !== "web"}
-          onValueChange={(v) => setAuthMethod(v as "none" | "client_secret_post")}
+          onValueChange={(v) => {
+            const nextAuthMethod = v as "none" | "client_secret_post"
+            setAuthMethod(nextAuthMethod)
+            if (nextAuthMethod === "none") {
+              setSelectedScopes((scopes) =>
+                withPublicClientRequiredScopes(scopes)
+              )
+            }
+          }}
         >
           <SelectTrigger id="authMethod">
             <SelectValue />
@@ -216,6 +245,34 @@ export function ClientFormSheet({ onSuccess }: Props) {
             is mandatory.
           </p>
         )}
+      </div>
+
+      <div>
+        <Label className="mb-2 block">OIDC Scopes</Label>
+        <div className="space-y-2">
+          {OIDC_SCOPE_OPTIONS.map(([scope, description]) => {
+            const isRequiredPublicScope =
+              authMethod === "none" && REQUIRED_PUBLIC_SCOPE_SET.has(scope)
+
+            return (
+              <label
+                key={scope}
+                className="flex items-center gap-2 text-sm cursor-pointer"
+              >
+                <Checkbox
+                  checked={selectedScopes.includes(scope)}
+                  disabled={isRequiredPublicScope}
+                  onCheckedChange={() => toggleScope(scope)}
+                />
+                <span className="font-mono text-xs">{scope}</span>
+                <span className="text-muted-foreground">
+                  — {description}
+                  {isRequiredPublicScope ? " (required for public clients)" : ""}
+                </span>
+              </label>
+            )
+          })}
+        </div>
       </div>
 
       <div>

--- a/docs/features/oauth-provider.md
+++ b/docs/features/oauth-provider.md
@@ -67,6 +67,9 @@ Returns the standard OpenID Connect discovery document with all endpoint URLs.
 OAuth clients are managed at `/admin/oauth-clients`:
 - Register web, browser-extension, and native clients
 - Configure redirect URIs and allowed scopes
+- Public clients automatically include `openid`, `profile`, and
+  `offline_access`; the admin form displays these as required, and the database
+  enforces the same invariant
 - Revoke clients (deactivates all issued tokens)
 
 Redirect URI validation is application-aware:

--- a/docs/guides/oauth-integration.md
+++ b/docs/guides/oauth-integration.md
@@ -174,6 +174,10 @@ Reusing an old refresh token is treated as replay and revokes the grant family.
 - `email` — User's email address
 - `offline_access` — Enables refresh tokens
 
+Public clients (`token_endpoint_auth_method: none`) are registered with
+`openid`, `profile`, and `offline_access` automatically. Administrators may add
+`email` and supported API scopes, but cannot remove the public-client baseline.
+
 ### API Scopes
 - `chat:read`, `chat:write` — Chat operations
 - `assistants:read`, `assistants:write`, `assistants:list`, `assistants:execute` — Assistants

--- a/infra/database/migrations.json
+++ b/infra/database/migrations.json
@@ -125,6 +125,7 @@
     "128-atrium-content-assets.sql",
     "129-oauth-production-hardening.sql",
     "130-oauth-application-types.sql",
-    "131-admin-hub-nav-cleanup.sql"
+    "131-admin-hub-nav-cleanup.sql",
+    "132-oauth-public-client-scopes.sql"
   ]
 }

--- a/infra/database/schema/132-oauth-public-client-scopes.sql
+++ b/infra/database/schema/132-oauth-public-client-scopes.sql
@@ -1,0 +1,52 @@
+-- =====================================================
+-- Migration: 132-oauth-public-client-scopes.sql
+-- Description: Enforce the required OIDC scopes for public PKCE clients
+-- Dependencies: 053-oauth-provider-tables.sql,
+--               130-oauth-application-types.sql
+--
+-- Public authorization-code clients need the OIDC identity scopes requested by
+-- Atrium Capture and offline access for their registered refresh-token grant.
+-- Repair existing rows in place so deployed clients keep the same client IDs
+-- and redirects, then protect direct database registrations with a constraint.
+--
+-- Rollback:
+-- ALTER TABLE oauth_clients DROP CONSTRAINT IF EXISTS
+--   oauth_clients_public_oidc_scopes;
+-- Scope additions are intentionally retained on rollback because removing them
+-- would immediately break deployed public clients.
+-- =====================================================
+
+UPDATE oauth_clients
+SET
+  allowed_scopes =
+    allowed_scopes
+    || CASE
+      WHEN allowed_scopes ? 'openid' THEN '[]'::jsonb
+      ELSE '["openid"]'::jsonb
+    END
+    || CASE
+      WHEN allowed_scopes ? 'profile' THEN '[]'::jsonb
+      ELSE '["profile"]'::jsonb
+    END
+    || CASE
+      WHEN allowed_scopes ? 'offline_access' THEN '[]'::jsonb
+      ELSE '["offline_access"]'::jsonb
+    END,
+  updated_at = NOW()
+WHERE token_endpoint_auth_method = 'none'
+  AND require_pkce = true
+  AND grant_types @> '["authorization_code"]'::jsonb
+  AND NOT (
+    allowed_scopes @> '["openid", "profile", "offline_access"]'::jsonb
+  );
+
+ALTER TABLE oauth_clients
+  DROP CONSTRAINT IF EXISTS oauth_clients_public_oidc_scopes;
+ALTER TABLE oauth_clients
+  ADD CONSTRAINT oauth_clients_public_oidc_scopes
+  CHECK (
+    token_endpoint_auth_method <> 'none'
+    OR require_pkce <> true
+    OR NOT (grant_types @> '["authorization_code"]'::jsonb)
+    OR allowed_scopes @> '["openid", "profile", "offline_access"]'::jsonb
+  );

--- a/lib/oauth/oauth-scopes.ts
+++ b/lib/oauth/oauth-scopes.ts
@@ -21,6 +21,27 @@ const OIDC_SCOPE_LABELS: Record<string, string> = {
 
 export const OIDC_SCOPES = Object.keys(OIDC_SCOPE_LABELS)
 
+/**
+ * Public authorization-code clients cannot silently omit these scopes. `openid`
+ * starts an OIDC flow, `profile` supplies the signed-in Atrium identity, and
+ * `offline_access` permits the refresh-token grant already registered for these
+ * clients.
+ */
+export const PUBLIC_CLIENT_REQUIRED_OIDC_SCOPES = [
+  "openid",
+  "profile",
+  "offline_access",
+] as const
+
+/**
+ * Return a stable, duplicate-free scope list with the public-client OIDC
+ * baseline first. This is enforced server-side; the admin UI is only a
+ * presentation of the same policy.
+ */
+export function withPublicClientRequiredScopes(scopes: readonly string[]): string[] {
+  return [...new Set([...PUBLIC_CLIENT_REQUIRED_OIDC_SCOPES, ...scopes])]
+}
+
 // ============================================
 // Combined Scopes (OIDC + MCP)
 // ============================================

--- a/tests/e2e/oauth-clients.functional.spec.ts
+++ b/tests/e2e/oauth-clients.functional.spec.ts
@@ -22,7 +22,7 @@ test.describe("OAuth client application profiles (#1289)", () => {
       "Requires the authenticated local E2E harness",
     )
 
-    test("registration UI exposes and explains all application types", async ({
+    test("registration UI exposes application types and public OIDC scopes", async ({
       page,
     }) => {
       await authenticateContext(
@@ -55,6 +55,15 @@ test.describe("OAuth client application profiles (#1289)", () => {
         "placeholder",
         /com\.example\.app:/
       )
+      for (const scope of ["openid", "profile", "offline_access"]) {
+        const scopeRow = page.getByText(scope, { exact: true }).locator("..")
+        await expect(scopeRow.getByRole("checkbox")).toBeChecked()
+        await expect(scopeRow.getByRole("checkbox")).toBeDisabled()
+        await expect(scopeRow).toContainText("required for public clients")
+      }
+      await expect(
+        page.getByText("email", { exact: true }).locator("..").getByRole("checkbox")
+      ).toBeEnabled()
     })
   })
 })

--- a/tests/unit/actions/oauth-client-actions.test.ts
+++ b/tests/unit/actions/oauth-client-actions.test.ts
@@ -95,6 +95,60 @@ describe('revokeOAuthClient (REV-COR-055)', () => {
     expect(res.data?.clientSecret).toBeUndefined()
   })
 
+  it('persists every required OIDC scope when a public caller omits them', async () => {
+    const createdAt = new Date('2026-07-24T12:00:00.000Z')
+    const createdRow = {
+      id: 10,
+      clientId: 'browser-client',
+      clientName: 'Atrium Capture Browser',
+      applicationType: 'browser_extension',
+      clientSecretHash: null,
+      redirectUris: ['https://abcdefghijklmnopabcdefghijklmnop.chromiumapp.org/atrium'],
+      allowedScopes: ['openid', 'profile', 'offline_access', 'content:create'],
+      grantTypes: ['authorization_code', 'refresh_token'],
+      responseTypes: ['code'],
+      tokenEndpointAuthMethod: 'none',
+      requirePkce: true,
+      accessTokenTtl: 900,
+      refreshTokenTtl: 86400,
+      isActive: true,
+      createdAt,
+      updatedAt: createdAt,
+    }
+    let insertedValues: Record<string, unknown> | undefined
+    type InsertDb = {
+      insert: (table: unknown) => {
+        values: (values: Record<string, unknown>) => {
+          returning: () => Promise<unknown[]>
+        }
+      }
+    }
+    mockExecuteQuery.mockImplementationOnce(async (...args: unknown[]) => {
+      const operation = args[0] as (db: InsertDb) => Promise<unknown[]>
+      return operation({
+        insert: () => ({
+          values: (values) => {
+            insertedValues = values
+            return {
+              returning: async () => [createdRow],
+            }
+          },
+        }),
+      })
+    })
+
+    const result = await createOAuthClient({
+      clientName: 'Atrium Capture Browser',
+      applicationType: 'browser_extension',
+      redirectUris: ['https://abcdefghijklmnopabcdefghijklmnop.chromiumapp.org/atrium'],
+      allowedScopes: ['content:create'],
+      tokenEndpointAuthMethod: 'none',
+    })
+
+    expect(result.isSuccess).toBe(true)
+    expect(insertedValues?.allowedScopes).toEqual(createdRow.allowedScopes)
+  })
+
   it('rejects native localhost callbacks before touching the database', async () => {
     const res = await createOAuthClient({
       clientName: 'Unsafe Desktop',

--- a/tests/unit/lib/oauth/oauth-scopes.test.ts
+++ b/tests/unit/lib/oauth/oauth-scopes.test.ts
@@ -6,7 +6,11 @@
  * returns the raw-string fallback rather than a Function or other inherited value.
  */
 
-import { getScopeLabel } from "@/lib/oauth/oauth-scopes"
+import {
+  getScopeLabel,
+  PUBLIC_CLIENT_REQUIRED_OIDC_SCOPES,
+  withPublicClientRequiredScopes,
+} from "@/lib/oauth/oauth-scopes"
 
 describe("getScopeLabel (REV-COR-637)", () => {
   it("returns the OIDC label for a known OIDC scope", () => {
@@ -35,5 +39,30 @@ describe("getScopeLabel (REV-COR-637)", () => {
     const label = getScopeLabel(scope)
     expect(typeof label).toBe("string")
     expect(label).toBe(scope)
+  })
+})
+
+describe("withPublicClientRequiredScopes", () => {
+  it("adds the OIDC baseline required by public authorization-code clients", () => {
+    expect(withPublicClientRequiredScopes(["content:read"])).toEqual([
+      "openid",
+      "profile",
+      "offline_access",
+      "content:read",
+    ])
+  })
+
+  it("preserves caller scopes without duplicating required scopes", () => {
+    const scopes = withPublicClientRequiredScopes([
+      "profile",
+      "content:create",
+      "openid",
+      "content:create",
+    ])
+
+    expect(scopes).toEqual([
+      ...PUBLIC_CLIENT_REQUIRED_OIDC_SCOPES,
+      "content:create",
+    ])
   })
 })

--- a/tests/unit/lib/tools/catalog.test.ts
+++ b/tests/unit/lib/tools/catalog.test.ts
@@ -435,10 +435,14 @@ describe("ToolCatalog", () => {
       // The REST execute route reads entry.isActive to deny when an admin disables
       // the tool (the MCP surface gates via dispatch()). get() must therefore return
       // the inactive entry rather than hiding it.
+      const manifestEntry = TOOL_MANIFEST.find(
+        (entry) => entry.identifier === "assistants.execute"
+      )
+      expect(manifestEntry).toBeDefined()
       dbRows = [
         {
           identifier: "assistants.execute",
-          version: "v1",
+          version: manifestEntry?.version ?? "v1",
           name: "execute_assistant",
           description: "x",
           inputSchema: { type: "object", properties: {} },

--- a/tests/unit/oauth-client-form-sheet.test.tsx
+++ b/tests/unit/oauth-client-form-sheet.test.tsx
@@ -1,0 +1,66 @@
+/** @jest-environment jsdom */
+
+import { render, screen, within } from "@testing-library/react"
+import type { ReactNode } from "react"
+import { ClientFormSheet } from "@/app/(protected)/admin/oauth-clients/_components/client-form-sheet"
+
+jest.mock("@/actions/oauth/oauth-client.actions", () => ({
+  createOAuthClient: jest.fn(),
+}))
+jest.mock("@/components/ui/button", () => ({
+  Button: ({ children }: { children: ReactNode }) => <button>{children}</button>,
+}))
+jest.mock("@/components/ui/checkbox", () => ({
+  Checkbox: ({
+    checked,
+    disabled,
+  }: {
+    checked?: boolean
+    disabled?: boolean
+  }) => (
+    <input type="checkbox" checked={checked} disabled={disabled} readOnly />
+  ),
+}))
+jest.mock("@/components/ui/input", () => ({
+  Input: () => <input />,
+}))
+jest.mock("@/components/ui/label", () => ({
+  Label: ({ children }: { children: ReactNode }) => <label>{children}</label>,
+}))
+jest.mock("@/components/ui/select", () => ({
+  Select: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  SelectContent: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  SelectItem: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  SelectTrigger: ({
+    children,
+    id,
+  }: {
+    children: ReactNode
+    id?: string
+  }) => <button id={id}>{children}</button>,
+  SelectValue: () => null,
+}))
+
+describe("OAuth client registration form", () => {
+  it("shows and locks the required OIDC scopes for a public client", () => {
+    render(<ClientFormSheet onSuccess={jest.fn()} />)
+
+    for (const scope of ["openid", "profile", "offline_access"]) {
+      const row = screen.getByText(scope, { exact: true }).closest("label")
+      expect(row).not.toBeNull()
+      expect(within(row as HTMLLabelElement).getByRole("checkbox")).toBeChecked()
+      expect(
+        within(row as HTMLLabelElement).getByRole("checkbox")
+      ).toBeDisabled()
+      expect(row).toHaveTextContent("required for public clients")
+    }
+
+    const emailRow = screen.getByText("email", { exact: true }).closest("label")
+    expect(emailRow).not.toBeNull()
+    expect(
+      within(emailRow as HTMLLabelElement).getByRole("checkbox")
+    ).toBeEnabled()
+  })
+})

--- a/tests/unit/oauth-public-client-scopes-migration.test.ts
+++ b/tests/unit/oauth-public-client-scopes-migration.test.ts
@@ -1,0 +1,27 @@
+import fs from "fs"
+import path from "path"
+
+const migrationPath = path.join(
+  process.cwd(),
+  "infra/database/schema/132-oauth-public-client-scopes.sql"
+)
+const migration = fs.readFileSync(migrationPath, "utf8")
+
+describe("public OAuth client scope migration", () => {
+  it("repairs secretless PKCE authorization-code clients in place", () => {
+    expect(migration).toContain("UPDATE oauth_clients")
+    expect(migration).toContain("token_endpoint_auth_method = 'none'")
+    expect(migration).toContain("require_pkce = true")
+    expect(migration).toContain(`grant_types @> '["authorization_code"]'::jsonb`)
+    for (const scope of ["openid", "profile", "offline_access"]) {
+      expect(migration).toContain(`allowed_scopes ? '${scope}'`)
+    }
+  })
+
+  it("adds a database invariant for all three required scopes", () => {
+    expect(migration).toContain("ADD CONSTRAINT oauth_clients_public_oidc_scopes")
+    expect(migration).toContain(
+      `allowed_scopes @> '["openid", "profile", "offline_access"]'::jsonb`
+    )
+  })
+})


### PR DESCRIPTION
## Summary

Promote the reviewed Atrium OAuth public-client fix from `dev` to `main`. This release repairs the production Atrium Capture registrations without changing their client IDs or redirects.

- require `openid`, `profile`, and `offline_access` for public PKCE authorization-code clients
- expose and lock required OIDC scopes in the admin registration UI
- enforce the invariant in the server action and database
- run migration 132 to update existing public clients in place
- include regression coverage and the stale catalog fixture correction found by CI

## Source review

PR #1324 merged to `dev` after all checks passed. Claude reviewed current head `64dcf26` and reported **Blocking findings: None**. CI, PostgreSQL lifecycle, CDK validation, CodeQL, and Claude review all passed.

## Deployment order

Deploy the production database stack/migrations (migration 132), then the production frontend stack. After deployment, verify both Atrium Capture clients contain the required OIDC scopes and rerun the live registration smoke gate.