### PR TITLE
chore(release): promote Atrium OAuth fix to production

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,6 +120,11 @@ jobs:
       env:
         CI: true
 
+    - name: Run OAuth client trust audit smoke
+      run: bun run test:smoke:oauth-client-trust-audit
+      env:
+        CI: true
+
     - name: Run Nexus ephemeral-repository lifecycle smoke
       run: bun run test:smoke:nexus-ephemeral
       env:

--- a/actions/oauth/consent.actions.ts
+++ b/actions/oauth/consent.actions.ts
@@ -41,8 +41,7 @@ interface ConsentResult {
 
 async function processConsent(
   interactionUid: string,
-  approved: boolean,
-  grantedScopes: string[] = []
+  approved: boolean
 ): Promise<ActionState<ConsentResult>> {
   const actionName = approved ? "approveConsent" : "denyConsent"
   const requestId = generateRequestId()
@@ -55,7 +54,7 @@ async function processConsent(
       throw ErrorFactories.authNoSession()
     }
 
-    log.info(`Processing consent ${approved ? "approval" : "denial"}`, { interactionUid })
+    log.info(`Processing consent ${approved ? "approval" : "denial"}`)
 
     const userId = await getUserIdByCognitoSubAsNumber(session.sub)
     if (!userId) {
@@ -71,18 +70,23 @@ async function processConsent(
             uid: interactionUid,
             userId,
             approved,
-            scopes: grantedScopes,
+            // The completion route derives grant scopes from oidc-provider's
+            // signed interaction state, never from browser-supplied values.
+            scopes: [],
             expiresAt: new Date(Date.now() + 5 * 60 * 1000),
           }),
       "storeConsentDecision"
     )
 
     const issuer = getIssuerUrl()
-    const path = approved ? "login" : "abort"
-    const redirectTo = `${issuer}/api/oauth/interaction/${interactionUid}/${path}`
+    const path = approved ? "consent" : "abort"
+    const redirectTo =
+      `${issuer}/oauth/authorize/interaction/${interactionUid}/${path}`
 
     timer({ status: "success" })
-    log.info(`Consent ${approved ? "approved" : "denied"}`, { interactionUid, userId })
+    log.info(`Consent ${approved ? "approved" : "denied"}`, {
+      userId,
+    })
 
     return createSuccess(
       { redirectTo },
@@ -103,10 +107,9 @@ async function processConsent(
 // ============================================
 
 export async function approveConsent(
-  interactionUid: string,
-  grantedScopes: string[]
+  interactionUid: string
 ): Promise<ActionState<ConsentResult>> {
-  return processConsent(interactionUid, true, grantedScopes)
+  return processConsent(interactionUid, true)
 }
 
 export async function denyConsent(

--- a/actions/oauth/oauth-client.actions.ts
+++ b/actions/oauth/oauth-client.actions.ts
@@ -43,6 +43,7 @@ export interface OAuthClientRow {
   accessTokenTtl: number
   refreshTokenTtl: number
   isActive: boolean
+  isFirstParty: boolean
   createdAt: Date
   updatedAt: Date
 }
@@ -130,6 +131,7 @@ export async function listOAuthClients(): Promise<ActionState<OAuthClientRow[]>>
             accessTokenTtl: oauthClients.accessTokenTtl,
             refreshTokenTtl: oauthClients.refreshTokenTtl,
             isActive: oauthClients.isActive,
+            isFirstParty: oauthClients.isFirstParty,
             createdAt: oauthClients.createdAt,
             updatedAt: oauthClients.updatedAt,
           })
@@ -257,6 +259,7 @@ export async function createOAuthClient(
           accessTokenTtl: created.accessTokenTtl,
           refreshTokenTtl: created.refreshTokenTtl,
           isActive: created.isActive,
+          isFirstParty: created.isFirstParty,
           createdAt: created.createdAt,
           updatedAt: created.updatedAt,
         },

--- a/app/(protected)/admin/oauth-clients/_components/oauth-clients-page-client.tsx
+++ b/app/(protected)/admin/oauth-clients/_components/oauth-clients-page-client.tsx
@@ -123,6 +123,7 @@ export function OAuthClientsPageClient({ initialClients }: Props) {
                 <TableHead>Client ID</TableHead>
                 <TableHead>Type</TableHead>
                 <TableHead>Auth Method</TableHead>
+                <TableHead>Trust</TableHead>
                 <TableHead>Status</TableHead>
                 <TableHead>Scopes</TableHead>
                 <TableHead className="w-24">Actions</TableHead>
@@ -153,6 +154,13 @@ export function OAuthClientsPageClient({ initialClients }: Props) {
                       {client.tokenEndpointAuthMethod === "none"
                         ? "Public (PKCE)"
                         : "Confidential"}
+                    </Badge>
+                  </TableCell>
+                  <TableCell>
+                    <Badge
+                      variant={client.isFirstParty ? "default" : "outline"}
+                    >
+                      {client.isFirstParty ? "First-party" : "Standard"}
                     </Badge>
                   </TableCell>
                   <TableCell>

--- a/app/(protected)/oauth/authorize/_components/consent-form.tsx
+++ b/app/(protected)/oauth/authorize/_components/consent-form.tsx
@@ -13,10 +13,9 @@ import { approveConsent, denyConsent } from "@/actions/oauth/consent.actions"
 
 interface ConsentFormProps {
   uid: string
-  scopes: string[]
 }
 
-export function ConsentForm({ uid, scopes }: ConsentFormProps) {
+export function ConsentForm({ uid }: ConsentFormProps) {
   const router = useRouter()
   const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
@@ -25,7 +24,7 @@ export function ConsentForm({ uid, scopes }: ConsentFormProps) {
     setIsLoading(true)
     setError(null)
     try {
-      const result = await approveConsent(uid, scopes)
+      const result = await approveConsent(uid)
       if (result.isSuccess && result.data?.redirectTo) {
         router.push(result.data.redirectTo)
       } else {

--- a/app/(protected)/oauth/authorize/interaction/[uid]/[action]/route.ts
+++ b/app/(protected)/oauth/authorize/interaction/[uid]/[action]/route.ts
@@ -1,0 +1,273 @@
+/**
+ * Complete custom oidc-provider login and consent interactions.
+ *
+ * All interaction state is read and completed through oidc-provider's public
+ * interactionDetails/interactionFinished APIs. The browser-provided uid is
+ * only an expected identifier; the signed interaction cookie is authoritative.
+ */
+
+import { NextRequest } from "next/server"
+import type { Grant, Interaction, Provider } from "oidc-provider"
+import { getOidcProvider } from "@/lib/oauth/oidc-provider-config"
+import { invokeNodeHttpHandler } from "@/lib/oauth/node-http-adapter"
+import { getServerSession } from "@/lib/auth/server-session"
+import { getUserIdByCognitoSubAsNumber } from "@/lib/db/drizzle/utils"
+import { consumeConsentDecision } from "@/lib/oauth/consent-decisions"
+import { createLogger, generateRequestId } from "@/lib/logger"
+
+export const runtime = "nodejs"
+
+type OidcProvider = InstanceType<typeof Provider>
+
+interface RouteContext {
+  params: Promise<{
+    uid: string
+    action: string
+  }>
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0
+    ? value
+    : undefined
+}
+
+function asStringArray(value: unknown): string[] {
+  return Array.isArray(value) &&
+    value.every((item) => typeof item === "string")
+    ? value
+    : []
+}
+
+function registeredScopes(providerClientScope: string | undefined): Set<string> {
+  return new Set((providerClientScope ?? "").split(" ").filter(Boolean))
+}
+
+function assertRegisteredScopes(
+  scopes: string[],
+  registered: Set<string>
+): void {
+  if (scopes.some((scope) => !registered.has(scope))) {
+    throw new Error("OAuth consent contained an unregistered scope")
+  }
+}
+
+function requiredInteractionAccount(
+  interaction: Interaction,
+  decisionUserId: number
+): string {
+  const accountId = interaction.session?.accountId
+  if (!accountId || accountId !== String(decisionUserId)) {
+    throw new Error("OAuth consent principal mismatch")
+  }
+  return accountId
+}
+
+async function consentGrant(
+  provider: OidcProvider,
+  interaction: Interaction,
+  accountId: string
+): Promise<Grant> {
+  const clientId = asString(interaction.params.client_id)
+  if (!clientId) throw new Error("OAuth interaction is missing client_id")
+
+  const client = await provider.Client.find(clientId)
+  if (!client) throw new Error("OAuth client is inactive or unavailable")
+
+  const registered = registeredScopes(client.scope)
+  let grant = interaction.grantId
+    ? await provider.Grant.find(interaction.grantId)
+    : undefined
+  if (
+    grant &&
+    (grant.accountId !== accountId || grant.clientId !== clientId)
+  ) {
+    throw new Error("OAuth grant principal mismatch")
+  }
+  grant ??= new provider.Grant({ accountId, clientId })
+
+  const details = interaction.prompt.details
+  const oidcScopes = asStringArray(details.missingOIDCScope)
+  assertRegisteredScopes(oidcScopes, registered)
+  if (oidcScopes.length > 0) {
+    grant.addOIDCScope(oidcScopes.join(" "))
+  }
+
+  const oidcClaims = asStringArray(details.missingOIDCClaims)
+  if (oidcClaims.length > 0) {
+    grant.addOIDCClaims(oidcClaims)
+  }
+
+  const missingResources = details.missingResourceScopes
+  if (
+    missingResources &&
+    typeof missingResources === "object" &&
+    !Array.isArray(missingResources)
+  ) {
+    for (const [resource, value] of Object.entries(missingResources)) {
+      const scopes = asStringArray(value)
+      assertRegisteredScopes(scopes, registered)
+      if (scopes.length > 0) {
+        grant.addResourceScope(resource, scopes.join(" "))
+      }
+    }
+  }
+
+  await grant.save()
+  return grant
+}
+
+async function finishLogin(
+  provider: OidcProvider,
+  interaction: Interaction,
+  request: import("node:http").IncomingMessage,
+  response: import("node:http").ServerResponse
+): Promise<void> {
+  if (interaction.prompt.name !== "login") {
+    throw new Error("OAuth interaction is not awaiting login")
+  }
+
+  const session = await getServerSession()
+  const userId = session?.sub
+    ? await getUserIdByCognitoSubAsNumber(session.sub)
+    : null
+  if (!userId) {
+    const callbackUrl = `/oauth/authorize?uid=${encodeURIComponent(
+      interaction.uid
+    )}`
+    response.statusCode = 303
+    response.setHeader(
+      "Location",
+      `/api/auth/signin?callbackUrl=${encodeURIComponent(callbackUrl)}`
+    )
+    response.end()
+    return
+  }
+
+  await provider.interactionFinished(
+    request,
+    response,
+    {
+      login: {
+        accountId: String(userId),
+      },
+    },
+    { mergeWithLastSubmission: false }
+  )
+}
+
+async function finishConsentDecision(
+  provider: OidcProvider,
+  interaction: Interaction,
+  action: "consent" | "abort",
+  request: import("node:http").IncomingMessage,
+  response: import("node:http").ServerResponse
+): Promise<void> {
+  if (interaction.prompt.name !== "consent") {
+    throw new Error("OAuth interaction is not awaiting consent")
+  }
+
+  const decision = await consumeConsentDecision(interaction.uid)
+  if (!decision || decision.approved !== (action === "consent")) {
+    throw new Error("OAuth consent decision is missing or inconsistent")
+  }
+
+  const session = await getServerSession()
+  const currentUserId = session?.sub
+    ? await getUserIdByCognitoSubAsNumber(session.sub)
+    : null
+  if (!currentUserId || currentUserId !== decision.userId) {
+    throw new Error("OAuth consent session principal mismatch")
+  }
+
+  const accountId = requiredInteractionAccount(
+    interaction,
+    decision.userId
+  )
+  if (!decision.approved) {
+    await provider.interactionFinished(
+      request,
+      response,
+      {
+        error: "access_denied",
+        error_description: "End-User denied authorization",
+      },
+      { mergeWithLastSubmission: false }
+    )
+    return
+  }
+
+  const grant = await consentGrant(provider, interaction, accountId)
+  await provider.interactionFinished(
+    request,
+    response,
+    { consent: { grantId: grant.jti } },
+    { mergeWithLastSubmission: true }
+  )
+}
+
+export async function GET(
+  request: NextRequest,
+  context: RouteContext
+): Promise<Response> {
+  const requestId = generateRequestId()
+  const log = createLogger({
+    requestId,
+    action: "oauth.interaction.complete",
+  })
+
+  try {
+    const { uid, action } = await context.params
+    if (
+      action !== "login" &&
+      action !== "consent" &&
+      action !== "abort"
+    ) {
+      return Response.json(
+        { error: "invalid_interaction_action" },
+        { status: 404 }
+      )
+    }
+
+    const provider = await getOidcProvider()
+    const url = new URL(request.url)
+    return await invokeNodeHttpHandler(
+      request,
+      url.pathname + url.search,
+      async (nodeRequest, nodeResponse) => {
+        const interaction = await provider.interactionDetails(
+          nodeRequest,
+          nodeResponse
+        )
+        if (interaction.uid !== uid) {
+          throw new Error("OAuth interaction identifier mismatch")
+        }
+
+        if (action === "login") {
+          await finishLogin(
+            provider,
+            interaction,
+            nodeRequest,
+            nodeResponse
+          )
+          return
+        }
+        await finishConsentDecision(
+          provider,
+          interaction,
+          action,
+          nodeRequest,
+          nodeResponse
+        )
+      }
+    )
+  } catch (error) {
+    log.warn("OAuth interaction could not be completed", {
+      error: error instanceof Error ? error.message : String(error),
+    })
+    return Response.json(
+      { error: "invalid_or_expired_interaction" },
+      { status: 400 }
+    )
+  }
+}

--- a/app/(protected)/oauth/authorize/page.tsx
+++ b/app/(protected)/oauth/authorize/page.tsx
@@ -5,8 +5,10 @@
  */
 
 import { redirect } from "next/navigation"
+import { headers } from "next/headers"
 import { ConsentForm } from "./_components/consent-form"
 import { getScopeLabel } from "@/lib/oauth/oauth-scopes"
+import { getOAuthInteractionSummary } from "@/lib/oauth/interaction-service"
 
 interface OAuthAuthorizePageProps {
   searchParams: Promise<{ uid?: string }>
@@ -22,26 +24,10 @@ export default async function OAuthAuthorizePage({
     redirect("/")
   }
 
-  // Fetch interaction details from oidc-provider
-  let interaction: {
-    prompt: { name: string; details?: Record<string, unknown> }
-    params: Record<string, unknown>
-  } | null = null
-
-  try {
-    const { getOidcProvider } = await import("@/lib/oauth/oidc-provider-config")
-    const provider = await getOidcProvider()
-    const details = await provider.Interaction.find(uid)
-
-    if (details) {
-      interaction = {
-        prompt: details.prompt as { name: string; details?: Record<string, unknown> },
-        params: details.params as Record<string, unknown>,
-      }
-    }
-  } catch {
-    // Interaction may have expired
-  }
+  const interaction = await getOAuthInteractionSummary(
+    uid,
+    new Headers(await headers())
+  ).catch(() => undefined)
 
   if (!interaction) {
     return (
@@ -56,21 +42,40 @@ export default async function OAuthAuthorizePage({
     )
   }
 
-  const clientId = interaction.params.client_id as string
-  const requestedScopes = ((interaction.params.scope as string) ?? "openid").split(" ")
+  if (interaction.promptName === "login") {
+    redirect(
+      `/oauth/authorize/interaction/${encodeURIComponent(uid)}/login`
+    )
+  }
+
+  if (interaction.promptName !== "consent") {
+    return (
+      <div className="flex min-h-screen items-center justify-center">
+        <div className="max-w-md p-6 text-center">
+          <h1 className="text-xl font-semibold text-gray-900">
+            Authorization Cannot Continue
+          </h1>
+          <p className="mt-2 text-sm text-muted-foreground">
+            This authorization request requires an unsupported interaction.
+          </p>
+        </div>
+      </div>
+    )
+  }
 
   return (
     <div className="flex min-h-screen items-center justify-center bg-gray-50">
       <div className="w-full max-w-md rounded-lg border bg-white p-8 shadow-sm">
         <h1 className="text-xl font-semibold text-gray-900">Authorize Application</h1>
         <p className="mt-2 text-sm text-muted-foreground">
-          <strong>{clientId}</strong> is requesting access to your AI Studio account.
+          <strong>{interaction.clientName}</strong> is requesting access to
+          your AI Studio account.
         </p>
 
         <div className="mt-6">
           <h2 className="text-sm font-medium text-gray-700">Requested permissions:</h2>
           <ul className="mt-2 space-y-1">
-            {requestedScopes.map((scope) => (
+            {interaction.requestedScopes.map((scope) => (
               <li
                 key={scope}
                 className="flex items-center gap-2 text-sm text-gray-600"
@@ -82,7 +87,7 @@ export default async function OAuthAuthorizePage({
           </ul>
         </div>
 
-        <ConsentForm uid={uid} scopes={requestedScopes} />
+        <ConsentForm uid={uid} />
       </div>
     </div>
   )

--- a/app/api/oauth/[...oidc]/route.ts
+++ b/app/api/oauth/[...oidc]/route.ts
@@ -13,10 +13,9 @@
  */
 
 import { NextRequest } from "next/server"
-import { IncomingMessage, ServerResponse } from "node:http"
-import { Socket } from "node:net"
 import { getOidcProvider } from "@/lib/oauth/oidc-provider-config"
 import { createLogger, generateRequestId } from "@/lib/logger"
+import { invokeNodeHttpHandler } from "@/lib/oauth/node-http-adapter"
 
 export const runtime = "nodejs"
 
@@ -35,98 +34,11 @@ async function handleOidcRequest(request: NextRequest): Promise<Response> {
     const url = new URL(request.url)
     // Strip /api/oauth prefix to get the path oidc-provider expects
     const oidcPath = url.pathname.replace(/^\/api\/oauth/, "") || "/"
-
-    // Build a minimal Node.js IncomingMessage
-    const socket = new Socket()
-    const nodeReq = new IncomingMessage(socket)
-    nodeReq.method = request.method
-    nodeReq.url = oidcPath + url.search
-
-    // Copy headers
-    for (const [key, value] of request.headers.entries()) {
-      nodeReq.headers[key.toLowerCase()] = value
-    }
-
-    // For POST requests, we need to push the body into the request stream
-    if (request.method === "POST" || request.method === "PUT" || request.method === "PATCH") {
-      const bodyText = await request.text()
-      nodeReq.push(bodyText)
-      nodeReq.push(null) // Signal end of stream
-    } else {
-      nodeReq.push(null) // No body
-    }
-
-    // Build a ServerResponse that captures the output
-    const nodeRes = new ServerResponse(nodeReq)
-
-    return new Promise<Response>((resolve) => {
-      const chunks: Buffer[] = []
-      let statusCode = 200
-      const responseHeaders: Record<string, string> = {}
-
-      // Override writeHead to capture status and headers
-      const originalWriteHead = nodeRes.writeHead.bind(nodeRes)
-      nodeRes.writeHead = function (
-        status: number,
-        ...args: unknown[]
-      ): ServerResponse<IncomingMessage> {
-        statusCode = status
-
-        // Headers can be in different positions depending on overload
-        const hdrs = (typeof args[0] === "object" && args[0] !== null && !Array.isArray(args[0]))
-          ? args[0] as Record<string, string | string[]>
-          : (typeof args[1] === "object" && args[1] !== null && !Array.isArray(args[1]))
-            ? args[1] as Record<string, string | string[]>
-            : {}
-
-        for (const [k, v] of Object.entries(hdrs)) {
-          responseHeaders[k.toLowerCase()] = Array.isArray(v) ? v.join(", ") : String(v)
-        }
-
-        return originalWriteHead(status, ...args as [string])
-      }
-
-      // Override write to capture body chunks
-      nodeRes.write = function (chunk: unknown): boolean {
-        if (Buffer.isBuffer(chunk)) chunks.push(chunk)
-        else if (typeof chunk === "string") chunks.push(Buffer.from(chunk))
-        return true
-      } as typeof nodeRes.write
-
-      // Override end to resolve the promise
-      nodeRes.end = function (chunk?: unknown): ServerResponse<IncomingMessage> {
-        if (chunk) {
-          if (Buffer.isBuffer(chunk)) chunks.push(chunk)
-          else if (typeof chunk === "string") chunks.push(Buffer.from(chunk))
-        }
-
-        // Also capture headers set via setHeader()
-        const headerNames = nodeRes.getHeaderNames()
-        for (const name of headerNames) {
-          const val = nodeRes.getHeader(name)
-          if (val !== undefined) {
-            responseHeaders[name.toLowerCase()] = Array.isArray(val) ? val.join(", ") : String(val)
-          }
-        }
-
-        statusCode = statusCode || nodeRes.statusCode
-
-        const body = Buffer.concat(chunks)
-        resolve(
-          new Response(body.length > 0 ? body : null, {
-            status: statusCode,
-            headers: responseHeaders,
-          })
-        )
-
-        // Cleanup
-        socket.destroy()
-
-        return nodeRes
-      } as typeof nodeRes.end
-
-      callback(nodeReq, nodeRes)
-    })
+    return invokeNodeHttpHandler(
+      request,
+      oidcPath + url.search,
+      callback
+    )
   } catch (error) {
     log.error("OIDC route error", {
       error: error instanceof Error ? error.message : String(error),

--- a/app/auth/[uid]/route.ts
+++ b/app/auth/[uid]/route.ts
@@ -1,0 +1,45 @@
+/**
+ * Mount oidc-provider's internally generated authorization resume URL.
+ *
+ * The public provider endpoints enter through `/api/oauth/*`, but the issuer
+ * remains the site origin so oidc-provider correctly returns `/auth/:uid`.
+ * This route forwards that exact provider URL without constructing or
+ * rewriting an interaction destination.
+ */
+
+import type { NextRequest } from "next/server"
+import { getOidcProvider } from "@/lib/oauth/oidc-provider-config"
+import { invokeNodeHttpHandler } from "@/lib/oauth/node-http-adapter"
+import { isOidcProviderResumePath } from "@/lib/oauth/resume-path"
+import { createLogger, generateRequestId } from "@/lib/logger"
+
+export const runtime = "nodejs"
+
+export async function GET(request: NextRequest): Promise<Response> {
+  const log = createLogger({
+    requestId: generateRequestId(),
+    action: "oauth.authorization.resume",
+  })
+
+  try {
+    const url = new URL(request.url)
+    if (!isOidcProviderResumePath(url.pathname)) {
+      return Response.json({ error: "not_found" }, { status: 404 })
+    }
+
+    const provider = await getOidcProvider()
+    return await invokeNodeHttpHandler(
+      request,
+      url.pathname + url.search,
+      provider.callback()
+    )
+  } catch (error) {
+    log.warn("OAuth authorization could not be resumed", {
+      error: error instanceof Error ? error.message : String(error),
+    })
+    return Response.json(
+      { error: "invalid_or_expired_interaction" },
+      { status: 400 }
+    )
+  }
+}

--- a/docs/features/oauth-provider.md
+++ b/docs/features/oauth-provider.md
@@ -25,14 +25,41 @@ Returns the standard OpenID Connect discovery document with all endpoint URLs.
 | Introspection | `/api/oauth/introspection` | Validate tokens |
 | Revocation | `/api/oauth/revocation` | Revoke tokens |
 
+oidc-provider's signed, single-use interaction continuation uses the internal
+`/auth/:uid` route. Middleware exposes only the provider's exact
+43-character URL-safe UID shape, not the surrounding `/auth/*` tree.
+
 ## Auth Code Flow with PKCE
 
 1. Client generates `code_verifier` and `code_challenge` (S256)
 2. Client redirects user to `/api/oauth/auth?client_id=...&code_challenge=...&redirect_uri=...`
-3. User sees consent screen at `/oauth/authorize`
-4. User approves → redirect back with `code`
-5. Client exchanges code + `code_verifier` at `/api/oauth/token`
-6. Receives JWT access token + refresh token
+3. AI Studio completes the provider's login prompt with the authenticated
+   district user
+4. Explicitly trusted first-party clients return immediately; standard clients
+   see the consent screen at `/oauth/authorize`
+5. When required, the user approves → redirect back with `code`
+6. Client exchanges code + `code_verifier` at `/api/oauth/token`
+7. Client receives a JWT access token + rotating refresh token
+
+The App Router bridge preserves oidc-provider's status, exact `Location`,
+response body, and individual `Set-Cookie` headers. Custom login and consent
+completion use oidc-provider's public interaction APIs; no resume URL is
+constructed by application code.
+
+## First-party clients
+
+`oauth_clients.is_first_party` is an explicit, default-false trust decision.
+It is never inferred from a client name, application type, redirect URI, or
+requested scopes. Migration 134 marks only the existing Atrium Capture browser
+extension and Mac client IDs as first-party, and only when their exact redirect
+and public S256 PKCE registration still match the expected production profile.
+
+First-party authorization still requires a valid district user session. Once
+an account is known, `loadExistingGrant` reuses or creates a provider grant
+containing only requested scopes present in that client's registered
+allowlist. OIDC scopes are stored in the OIDC grant portion; `content:*` scopes
+are stored under the AI Studio resource server. Standard clients continue
+through explicit consent.
 
 ## Security
 
@@ -44,6 +71,10 @@ Returns the standard OpenID Connect discovery document with all endpoint URLs.
 - **Durability**: provider sessions, interactions, grants, codes, and tokens persist in PostgreSQL across ECS tasks/restarts
 - **Application types**: web, browser extension, and native
 - **Public clients**: browser extensions and native apps have no secret and always use S256 PKCE
+- **First-party trust**: explicit default-deny client metadata; does not bypass
+  login, redirect validation, scope allowlists, active-client checks, or PKCE
+- **Consent integrity**: grant scopes come from signed provider interaction
+  state, never browser-submitted scope lists
 - Client secrets hashed with Argon2id
 
 ## JWT Claims
@@ -71,6 +102,11 @@ OAuth clients are managed at `/admin/oauth-clients`:
   `offline_access`; the admin form displays these as required, and the database
   enforces the same invariant
 - Revoke clients (deactivates all issued tokens)
+- View whether a client has the privileged `First-party` trust designation
+
+First-party trust changes are written to `oauth_client_trust_audit`. Migration
+backfills have an explicit source, and later database changes are captured by
+the trust audit rule.
 
 Redirect URI validation is application-aware:
 
@@ -91,6 +127,7 @@ writes cannot bypass the registration policy.
 | Table | Purpose |
 |-------|---------|
 | `oauth_clients` | Registered applications |
+| `oauth_client_trust_audit` | Append-only first-party trust changes |
 | `oauth_authorization_codes` | Short-lived auth codes |
 | `oauth_access_tokens` | Issued JWT metadata |
 | `oauth_refresh_tokens` | Refresh token rotation |
@@ -116,13 +153,18 @@ authenticateRequest() → token starts with "sk-"?
 |------|---------|
 | `lib/oauth/oidc-provider-config.ts` | Provider initialization |
 | `lib/oauth/drizzle-adapter.ts` | Database adapter for oidc-provider |
+| `lib/oauth/first-party-grants.ts` | Explicit first-party grant and interaction policy |
+| `lib/oauth/node-http-adapter.ts` | Node/Web request-response bridge |
+| `lib/oauth/interaction-service.ts` | Read-only public interaction API adapter |
 | `lib/oauth/redirect-uri-policy.ts` | Application-aware redirect security policy |
 | `lib/oauth/jwt-signer.ts` | JWT signing factory (KMS or local) |
 | `lib/oauth/kms-jwt-service.ts` | AWS KMS signing implementation |
 | `lib/oauth/jwks-cache.ts` | JWKS key caching for verification |
 | `app/api/oauth/[...oidc]/route.ts` | OIDC endpoint routing |
+| `app/auth/[uid]/route.ts` | Provider-generated authorization resume routing |
 | `app/.well-known/openid-configuration/route.ts` | Discovery document |
 | `app/(protected)/oauth/authorize/page.tsx` | Consent UI |
+| `app/(protected)/oauth/authorize/interaction/[uid]/[action]/route.ts` | Login/consent completion |
 | `actions/oauth/consent.actions.ts` | Consent server actions |
 | `actions/oauth/oauth-client.actions.ts` | Client CRUD actions |
 

--- a/infra/database/migrations.json
+++ b/infra/database/migrations.json
@@ -127,6 +127,7 @@
     "130-oauth-application-types.sql",
     "131-admin-hub-nav-cleanup.sql",
     "132-oauth-public-client-scopes.sql",
-    "133-decommission-scheduled-executions.sql"
+    "133-decommission-scheduled-executions.sql",
+    "134-oauth-first-party-clients.sql"
   ]
 }

--- a/infra/database/schema/134-oauth-first-party-clients.sql
+++ b/infra/database/schema/134-oauth-first-party-clients.sql
@@ -1,0 +1,134 @@
+-- =====================================================
+-- Migration: 134-oauth-first-party-clients.sql
+-- Description: Explicit, audited first-party trust for Atrium Capture clients
+-- Dependencies: 053-oauth-provider-tables.sql,
+--               130-oauth-application-types.sql,
+--               132-oauth-public-client-scopes.sql
+--
+-- Trust is never inferred from names, callbacks, application type, or scopes.
+-- This migration backfills only the two production client IDs, and only while
+-- each row still matches its expected public PKCE security profile and exact
+-- redirect. Existing IDs, callbacks, grants, and secrets are not recreated.
+--
+-- Rollback:
+-- DROP RULE IF EXISTS oauth_client_trust_audit_insert ON oauth_clients;
+-- DROP RULE IF EXISTS oauth_client_trust_audit_update ON oauth_clients;
+-- DROP TABLE IF EXISTS oauth_client_trust_audit;
+-- ALTER TABLE oauth_clients DROP CONSTRAINT IF EXISTS
+--   oauth_clients_first_party_security;
+-- ALTER TABLE oauth_clients DROP COLUMN IF EXISTS is_first_party;
+-- =====================================================
+
+ALTER TABLE oauth_clients
+  ADD COLUMN IF NOT EXISTS is_first_party BOOLEAN NOT NULL DEFAULT false;
+
+ALTER TABLE oauth_clients
+  DROP CONSTRAINT IF EXISTS oauth_clients_first_party_security;
+ALTER TABLE oauth_clients
+  ADD CONSTRAINT oauth_clients_first_party_security
+  CHECK (
+    is_first_party = false
+    OR (
+      token_endpoint_auth_method = 'none'
+      AND client_secret_hash IS NULL
+      AND require_pkce = true
+      AND grant_types @> '["authorization_code"]'::jsonb
+    )
+  );
+
+CREATE TABLE IF NOT EXISTS oauth_client_trust_audit (
+  id SERIAL PRIMARY KEY,
+  client_id VARCHAR(255) NOT NULL,
+  previous_is_first_party BOOLEAN NOT NULL,
+  new_is_first_party BOOLEAN NOT NULL,
+  changed_by INTEGER REFERENCES users(id) ON DELETE SET NULL,
+  change_source VARCHAR(128) NOT NULL,
+  changed_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_oauth_client_trust_audit_client
+  ON oauth_client_trust_audit (client_id, changed_at DESC);
+
+-- Remove prior audit rules before the idempotent backfill. PostgreSQL does not
+-- permit an UPDATE inside a data-modifying CTE when that table already has a
+-- DO ALSO rule; both rules are recreated after the backfill below.
+DROP RULE IF EXISTS oauth_client_trust_audit_insert ON oauth_clients;
+DROP RULE IF EXISTS oauth_client_trust_audit_update ON oauth_clients;
+
+WITH trusted_clients AS (
+  UPDATE oauth_clients
+  SET
+    is_first_party = true,
+    updated_at = NOW()
+  WHERE is_first_party = false
+    AND token_endpoint_auth_method = 'none'
+    AND client_secret_hash IS NULL
+    AND require_pkce = true
+    AND is_active = true
+    AND (
+      (
+        client_id = 'ae781263-20c0-4b0c-8a34-8be01ab72fb1'
+        AND application_type = 'browser_extension'
+        AND redirect_uris = '["https://jldnpmcpimhabiphcglkbgmbffpoocpo.chromiumapp.org/atrium"]'::jsonb
+      )
+      OR
+      (
+        client_id = 'fbdaa815-1b0f-435b-805f-1732805720c1'
+        AND application_type = 'native'
+        AND redirect_uris = '["org.psd401.atrium-capture:/oauth/callback"]'::jsonb
+      )
+    )
+  RETURNING client_id
+)
+INSERT INTO oauth_client_trust_audit (
+  client_id,
+  previous_is_first_party,
+  new_is_first_party,
+  changed_by,
+  change_source
+)
+SELECT
+  client_id,
+  false,
+  true,
+  NULL,
+  'migration-134-exact-atrium-capture-backfill'
+FROM trusted_clients;
+
+CREATE OR REPLACE RULE oauth_client_trust_audit_update AS
+  ON UPDATE TO oauth_clients
+  WHERE NEW.is_first_party IS DISTINCT FROM OLD.is_first_party
+  DO ALSO
+    INSERT INTO oauth_client_trust_audit (
+      client_id,
+      previous_is_first_party,
+      new_is_first_party,
+      changed_by,
+      change_source
+    )
+    VALUES (
+      NEW.client_id,
+      OLD.is_first_party,
+      NEW.is_first_party,
+      NULL,
+      'database-rule'
+    );
+
+CREATE OR REPLACE RULE oauth_client_trust_audit_insert AS
+  ON INSERT TO oauth_clients
+  WHERE NEW.is_first_party = true
+  DO ALSO
+    INSERT INTO oauth_client_trust_audit (
+      client_id,
+      previous_is_first_party,
+      new_is_first_party,
+      changed_by,
+      change_source
+    )
+    VALUES (
+      NEW.client_id,
+      false,
+      true,
+      NEW.created_by,
+      'database-rule-insert'
+    );

--- a/infra/database/schema/134-oauth-first-party-clients.sql
+++ b/infra/database/schema/134-oauth-first-party-clients.sql
@@ -11,6 +11,11 @@
 -- redirect. Existing IDs, callbacks, grants, and secrets are not recreated.
 --
 -- Rollback:
+-- DROP TRIGGER IF EXISTS trg_oauth_client_trust_audit_insert ON oauth_clients;
+-- DROP TRIGGER IF EXISTS trg_oauth_client_trust_audit_update ON oauth_clients;
+-- DROP FUNCTION IF EXISTS audit_oauth_client_first_party_insert();
+-- DROP FUNCTION IF EXISTS audit_oauth_client_first_party_update();
+-- DROP FUNCTION IF EXISTS audit_oauth_client_first_party_trust();
 -- DROP RULE IF EXISTS oauth_client_trust_audit_insert ON oauth_clients;
 -- DROP RULE IF EXISTS oauth_client_trust_audit_update ON oauth_clients;
 -- DROP TABLE IF EXISTS oauth_client_trust_audit;
@@ -49,11 +54,18 @@ CREATE TABLE IF NOT EXISTS oauth_client_trust_audit (
 CREATE INDEX IF NOT EXISTS idx_oauth_client_trust_audit_client
   ON oauth_client_trust_audit (client_id, changed_at DESC);
 
--- Remove prior audit rules before the idempotent backfill. PostgreSQL does not
--- permit an UPDATE inside a data-modifying CTE when that table already has a
--- DO ALSO rule; both rules are recreated after the backfill below.
+-- Remove audit hooks before the idempotent backfill so the migration writes one
+-- explicit audit row per exact-ID promotion. The rule drops clean up an earlier
+-- migration-134 implementation: PostgreSQL rewrite rules make every
+-- INSERT ... ON CONFLICT against oauth_clients fail, even when their predicate
+-- is false. Row-level triggers preserve existing OAuth client upsert paths.
 DROP RULE IF EXISTS oauth_client_trust_audit_insert ON oauth_clients;
 DROP RULE IF EXISTS oauth_client_trust_audit_update ON oauth_clients;
+DROP TRIGGER IF EXISTS trg_oauth_client_trust_audit_insert ON oauth_clients;
+DROP TRIGGER IF EXISTS trg_oauth_client_trust_audit_update ON oauth_clients;
+DROP FUNCTION IF EXISTS audit_oauth_client_first_party_insert();
+DROP FUNCTION IF EXISTS audit_oauth_client_first_party_update();
+DROP FUNCTION IF EXISTS audit_oauth_client_first_party_trust();
 
 WITH trusted_clients AS (
   UPDATE oauth_clients
@@ -95,40 +107,22 @@ SELECT
   'migration-134-exact-atrium-capture-backfill'
 FROM trusted_clients;
 
-CREATE OR REPLACE RULE oauth_client_trust_audit_update AS
-  ON UPDATE TO oauth_clients
-  WHERE NEW.is_first_party IS DISTINCT FROM OLD.is_first_party
-  DO ALSO
-    INSERT INTO oauth_client_trust_audit (
-      client_id,
-      previous_is_first_party,
-      new_is_first_party,
-      changed_by,
-      change_source
-    )
-    VALUES (
-      NEW.client_id,
-      OLD.is_first_party,
-      NEW.is_first_party,
-      NULL,
-      'database-rule'
-    );
+-- Keep each trigger function on one line. The production RDS Data API
+-- migration splitter ends PL/pgSQL blocks on a line ending in
+-- "' LANGUAGE plpgsql;" and otherwise mistakes inner semicolons for statement
+-- boundaries.
+CREATE OR REPLACE FUNCTION audit_oauth_client_first_party_insert() RETURNS TRIGGER AS 'BEGIN INSERT INTO oauth_client_trust_audit (client_id, previous_is_first_party, new_is_first_party, changed_by, change_source) VALUES (NEW.client_id, false, true, NEW.created_by, ''database-trigger-insert''); RETURN NEW; END;' LANGUAGE plpgsql;
 
-CREATE OR REPLACE RULE oauth_client_trust_audit_insert AS
-  ON INSERT TO oauth_clients
-  WHERE NEW.is_first_party = true
-  DO ALSO
-    INSERT INTO oauth_client_trust_audit (
-      client_id,
-      previous_is_first_party,
-      new_is_first_party,
-      changed_by,
-      change_source
-    )
-    VALUES (
-      NEW.client_id,
-      false,
-      true,
-      NEW.created_by,
-      'database-rule-insert'
-    );
+CREATE OR REPLACE FUNCTION audit_oauth_client_first_party_update() RETURNS TRIGGER AS 'BEGIN INSERT INTO oauth_client_trust_audit (client_id, previous_is_first_party, new_is_first_party, changed_by, change_source) VALUES (NEW.client_id, OLD.is_first_party, NEW.is_first_party, NULL, ''database-trigger-update''); RETURN NEW; END;' LANGUAGE plpgsql;
+
+CREATE TRIGGER trg_oauth_client_trust_audit_insert
+  AFTER INSERT ON oauth_clients
+  FOR EACH ROW
+  WHEN (NEW.is_first_party = true)
+  EXECUTE FUNCTION audit_oauth_client_first_party_insert();
+
+CREATE TRIGGER trg_oauth_client_trust_audit_update
+  AFTER UPDATE OF is_first_party ON oauth_clients
+  FOR EACH ROW
+  WHEN (NEW.is_first_party IS DISTINCT FROM OLD.is_first_party)
+  EXECUTE FUNCTION audit_oauth_client_first_party_update();

--- a/lib/auth/sign-in-callback.ts
+++ b/lib/auth/sign-in-callback.ts
@@ -1,0 +1,12 @@
+/**
+ * Preserve the complete in-app destination across authentication.
+ *
+ * OAuth interaction UIDs live in the query string; dropping `search` abandons
+ * the provider interaction after district sign-in.
+ */
+export function inAppSignInCallbackUrl(url: {
+  pathname: string
+  search: string
+}): string {
+  return url.pathname + url.search
+}

--- a/lib/db/schema/index.ts
+++ b/lib/db/schema/index.ts
@@ -177,6 +177,7 @@ export * from "./tables/api-key-usage";
 // OAuth2/OIDC Provider (#686)
 // ============================================
 export * from "./tables/oauth-clients";
+export * from "./tables/oauth-client-trust-audit";
 export * from "./tables/oauth-authorization-codes";
 export * from "./tables/oauth-access-tokens";
 export * from "./tables/oauth-refresh-tokens";

--- a/lib/db/schema/tables/oauth-client-trust-audit.ts
+++ b/lib/db/schema/tables/oauth-client-trust-audit.ts
@@ -1,0 +1,40 @@
+/**
+ * Append-only audit trail for OAuth first-party trust changes.
+ */
+
+import {
+  boolean,
+  index,
+  integer,
+  pgTable,
+  serial,
+  timestamp,
+  varchar,
+} from "drizzle-orm/pg-core"
+import { users } from "./users"
+
+export const oauthClientTrustAudit = pgTable(
+  "oauth_client_trust_audit",
+  {
+    id: serial("id").primaryKey(),
+    clientId: varchar("client_id", { length: 255 }).notNull(),
+    previousIsFirstParty: boolean("previous_is_first_party").notNull(),
+    newIsFirstParty: boolean("new_is_first_party").notNull(),
+    changedBy: integer("changed_by").references(() => users.id, {
+      onDelete: "set null",
+    }),
+    changeSource: varchar("change_source", { length: 128 }).notNull(),
+    changedAt: timestamp("changed_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (table) => [
+    index("idx_oauth_client_trust_audit_client").on(
+      table.clientId,
+      table.changedAt
+    ),
+  ]
+)
+
+export type OAuthClientTrustAuditRow =
+  typeof oauthClientTrustAudit.$inferSelect

--- a/lib/db/schema/tables/oauth-clients.ts
+++ b/lib/db/schema/tables/oauth-clients.ts
@@ -35,6 +35,7 @@ export const oauthClients = pgTable("oauth_clients", {
   accessTokenTtl: integer("access_token_ttl").notNull().default(900),
   refreshTokenTtl: integer("refresh_token_ttl").notNull().default(86400),
   isActive: boolean("is_active").notNull().default(true),
+  isFirstParty: boolean("is_first_party").notNull().default(false),
   createdBy: integer("created_by").references(() => users.id, { onDelete: "set null" }),
   createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
   updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),

--- a/lib/oauth/drizzle-adapter.ts
+++ b/lib/oauth/drizzle-adapter.ts
@@ -407,6 +407,7 @@ class DrizzleAdapter implements Adapter {
             allowedScopes: oauthClients.allowedScopes,
             tokenEndpointAuthMethod: oauthClients.tokenEndpointAuthMethod,
             requirePkce: oauthClients.requirePkce,
+            isFirstParty: oauthClients.isFirstParty,
           })
           .from(oauthClients)
           .where(and(eq(oauthClients.clientId, clientId), eq(oauthClients.isActive, true)))
@@ -467,6 +468,7 @@ class DrizzleAdapter implements Adapter {
       response_types: asStringArray(client.responseTypes) as ("code" | "id_token" | "none")[],
       scope: asStringArray(client.allowedScopes).join(" "),
       token_endpoint_auth_method: client.tokenEndpointAuthMethod as "none" | "client_secret_post" | "client_secret_basic",
+      is_first_party: client.isFirstParty,
     }
   }
 

--- a/lib/oauth/first-party-grants.ts
+++ b/lib/oauth/first-party-grants.ts
@@ -1,0 +1,202 @@
+/**
+ * Explicit first-party OAuth grant policy.
+ *
+ * Trust comes only from the persisted `is_first_party` client metadata flag.
+ * Names, application type, redirect shape, and requested scopes never imply
+ * first-party status.
+ */
+
+import type {
+  Client,
+  Configuration,
+  Grant,
+  KoaContextWithOIDC,
+} from "oidc-provider"
+import { interactionPolicy } from "oidc-provider"
+import { OIDC_SCOPES } from "./oauth-scopes"
+
+const OIDC_SCOPE_SET = new Set(OIDC_SCOPES)
+
+interface FirstPartyScopePartition {
+  oidcScopes: string[]
+  contentScopes: string[]
+}
+
+function splitScopes(value: unknown): string[] {
+  if (typeof value !== "string") return []
+  return value.split(" ").filter(Boolean)
+}
+
+export function isExplicitFirstPartyClient(
+  client: Client | undefined
+): boolean {
+  return client?.metadata().is_first_party === true
+}
+
+/**
+ * Intersect the request with the client's registered scope allowlist, then
+ * partition the scopes into the grant sections oidc-provider consumes.
+ */
+export function partitionRegisteredFirstPartyScopes(
+  requestedScope: unknown,
+  registeredScope: unknown
+): FirstPartyScopePartition {
+  const registered = new Set(splitScopes(registeredScope))
+  const requested = splitScopes(requestedScope).filter((scope) =>
+    registered.has(scope)
+  )
+
+  return {
+    oidcScopes: requested.filter((scope) => OIDC_SCOPE_SET.has(scope)),
+    contentScopes: requested.filter((scope) => scope.startsWith("content:")),
+  }
+}
+
+async function findExistingGrant(
+  ctx: KoaContextWithOIDC
+): Promise<Grant | undefined> {
+  const client = ctx.oidc.client
+  if (!client) return undefined
+
+  const resultGrantId = ctx.oidc.result?.consent?.grantId
+  const sessionGrantId = ctx.oidc.session?.grantIdFor(client.clientId)
+  const grantId = resultGrantId ?? sessionGrantId
+  return grantId
+    ? ctx.oidc.provider.Grant.find(grantId)
+    : undefined
+}
+
+export function createFirstPartyLoadExistingGrant(
+  resourceServer: string
+): NonNullable<Configuration["loadExistingGrant"]> {
+  return async (ctx) => {
+    const client = ctx.oidc.client
+    const existingGrant = await findExistingGrant(ctx)
+
+    if (!client || !isExplicitFirstPartyClient(client)) {
+      return existingGrant
+    }
+
+    const accountId = ctx.oidc.account?.accountId
+    if (!accountId) {
+      // Preserve the login prompt. A first-party designation is not an identity.
+      return existingGrant
+    }
+
+    if (
+      existingGrant &&
+      (existingGrant.accountId !== accountId ||
+        existingGrant.clientId !== client.clientId)
+    ) {
+      throw new Error("Existing OAuth grant principal mismatch")
+    }
+
+    const grant =
+      existingGrant ??
+      new ctx.oidc.provider.Grant({
+        accountId,
+        clientId: client.clientId,
+      })
+    const scopes = partitionRegisteredFirstPartyScopes(
+      ctx.oidc.params?.scope,
+      client.scope
+    )
+
+    if (scopes.oidcScopes.length > 0) {
+      grant.addOIDCScope(scopes.oidcScopes.join(" "))
+    }
+    if (scopes.contentScopes.length > 0) {
+      grant.addResourceScope(
+        resourceServer,
+        scopes.contentScopes.join(" ")
+      )
+    }
+
+    await grant.save()
+    return grant
+  }
+}
+
+/**
+ * Keep the provider's default login and consent policy. The sole exception is
+ * the default "native clients always re-consent" check for an explicitly
+ * trusted client; loadExistingGrant still has to satisfy every requested scope.
+ */
+export function createOAuthInteractionPolicy(): interactionPolicy.DefaultPolicy {
+  const policy = interactionPolicy.base()
+  const consentPrompt = policy.get("consent")
+  const oidcScopeCheckIndex =
+    consentPrompt?.checks.findIndex(
+      (check) => check.reason === "op_scopes_missing"
+    ) ?? -1
+  const nativeCheckIndex =
+    consentPrompt?.checks.findIndex(
+      (check) => check.reason === "native_client_prompt"
+    ) ?? -1
+
+  if (
+    !consentPrompt ||
+    nativeCheckIndex < 0 ||
+    oidcScopeCheckIndex < 0
+  ) {
+    throw new Error("oidc-provider consent policy has an unexpected shape")
+  }
+
+  // `scopes` must continue to advertise and validate API scopes against each
+  // client's allowlist. oidc-provider consequently includes those configured
+  // values in requestParamOIDCScopes even though they belong to the resource
+  // server. Narrow only this consent check to actual OIDC scopes; the default
+  // rs_scopes_missing check still handles content/API scopes.
+  const missingOidcScopes = new WeakMap<
+    KoaContextWithOIDC,
+    string[]
+  >()
+  consentPrompt.checks.remove("op_scopes_missing")
+  consentPrompt.checks.add(
+    new interactionPolicy.Check(
+      "op_scopes_missing",
+      "requested OIDC scopes not granted",
+      (ctx) => {
+        const oidc = ctx.oidc as typeof ctx.oidc & {
+          grant: Grant
+          requestParamOIDCScopes: Set<string>
+        }
+        const encountered = new Set(
+          oidc.grant.getOIDCScopeEncountered().split(" ")
+        )
+        const missing = [...oidc.requestParamOIDCScopes].filter(
+          (scope) =>
+            OIDC_SCOPE_SET.has(scope) && !encountered.has(scope)
+        )
+        if (missing.length === 0) {
+          missingOidcScopes.delete(ctx)
+          return interactionPolicy.Check.NO_NEED_TO_PROMPT
+        }
+        missingOidcScopes.set(ctx, missing)
+        return interactionPolicy.Check.REQUEST_PROMPT
+      },
+      (ctx) => {
+        const missing = missingOidcScopes.get(ctx)
+        return missing ? { missingOIDCScope: missing } : {}
+      }
+    ),
+    oidcScopeCheckIndex
+  )
+
+  consentPrompt.checks.remove("native_client_prompt")
+  consentPrompt.checks.add(
+    new interactionPolicy.Check(
+      "native_client_prompt",
+      "untrusted native clients require End-User interaction",
+      "interaction_required",
+      (ctx) =>
+        !isExplicitFirstPartyClient(ctx.oidc.client) &&
+        ctx.oidc.client?.applicationType === "native" &&
+        ctx.oidc.params?.response_type !== "none" &&
+        !ctx.oidc.result?.consent
+    ),
+    nativeCheckIndex
+  )
+
+  return policy
+}

--- a/lib/oauth/interaction-service.ts
+++ b/lib/oauth/interaction-service.ts
@@ -1,0 +1,70 @@
+/**
+ * Read-only access to oidc-provider interactions through its public API.
+ */
+
+import "server-only"
+
+import { getOidcProvider } from "./oidc-provider-config"
+import { getIssuerUrl } from "./issuer-config"
+import { createNodeHttpContext } from "./node-http-adapter"
+
+export interface OAuthInteractionSummary {
+  uid: string
+  promptName: string
+  promptDetails: Record<string, unknown>
+  clientId: string
+  clientName: string
+  requestedScopes: string[]
+}
+
+function stringParam(
+  params: Record<string, unknown>,
+  name: string
+): string {
+  const value = params[name]
+  return typeof value === "string" ? value : ""
+}
+
+export async function getOAuthInteractionSummary(
+  uid: string,
+  requestHeaders: Headers
+): Promise<OAuthInteractionSummary | undefined> {
+  const issuer = getIssuerUrl()
+  const webRequest = new Request(
+    `${issuer}/oauth/authorize/interaction/${encodeURIComponent(uid)}/details`,
+    { headers: requestHeaders }
+  )
+  const context = await createNodeHttpContext(
+    webRequest,
+    `/interaction/${encodeURIComponent(uid)}`
+  )
+
+  try {
+    const provider = await getOidcProvider()
+    const interaction = await provider.interactionDetails(
+      context.request,
+      context.response
+    )
+    if (interaction.uid !== uid) return undefined
+
+    const params = interaction.params as Record<string, unknown>
+    const clientId = stringParam(params, "client_id")
+    const client = clientId
+      ? await provider.Client.find(clientId)
+      : undefined
+    if (!client) return undefined
+
+    return {
+      uid,
+      promptName: interaction.prompt.name,
+      promptDetails: interaction.prompt.details,
+      clientId,
+      clientName: client.clientName ?? clientId,
+      requestedScopes: stringParam(params, "scope")
+        .split(" ")
+        .filter(Boolean),
+    }
+  } finally {
+    context.close()
+  }
+}

--- a/lib/oauth/node-http-adapter.ts
+++ b/lib/oauth/node-http-adapter.ts
@@ -1,0 +1,201 @@
+/**
+ * Bridge a Web Request/Response to a Node.js request handler.
+ *
+ * oidc-provider exposes a Node handler and its public interaction APIs accept
+ * IncomingMessage/ServerResponse. Next App Router exposes Web Request/Response,
+ * so both the provider catch-all and custom interaction routes use this bridge.
+ */
+
+import { IncomingMessage, ServerResponse } from "node:http"
+import { Socket } from "node:net"
+
+export type NodeHttpHandler = (
+  request: IncomingMessage,
+  response: ServerResponse<IncomingMessage>
+) => void | Promise<void>
+
+export interface NodeHttpContext {
+  request: IncomingMessage
+  response: ServerResponse<IncomingMessage>
+  close: () => void
+}
+
+function appendNodeHeader(
+  headers: Headers,
+  name: string,
+  value: number | string | string[]
+): void {
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      headers.append(name, item)
+    }
+    return
+  }
+  headers.set(name, String(value))
+}
+
+function responseMayHaveBody(method: string, status: number): boolean {
+  return (
+    method !== "HEAD" &&
+    status !== 204 &&
+    status !== 205 &&
+    status !== 304 &&
+    (status < 100 || status >= 200)
+  )
+}
+
+function toBuffer(
+  chunk: string | Uint8Array,
+  encoding?: BufferEncoding
+): Buffer {
+  return typeof chunk === "string"
+    ? Buffer.from(chunk, encoding)
+    : Buffer.from(chunk)
+}
+
+/**
+ * Invoke a Node handler and return its completed response as a Web Response.
+ *
+ * Resolution waits for both `response.end()` and the handler promise. This is
+ * important for Koa/oidc-provider: resolving at `end()` while ignoring a later
+ * callback rejection creates an unhandled rejection and can hide a failed
+ * authorization request behind a partial response.
+ */
+export async function invokeNodeHttpHandler(
+  request: Request,
+  path: string,
+  handler: NodeHttpHandler
+): Promise<Response> {
+  const context = await createNodeHttpContext(request, path)
+  const { request: nodeRequest, response: nodeResponse } = context
+
+  return new Promise<Response>((resolve, reject) => {
+    const chunks: Buffer[] = []
+    let handlerCompleted = false
+    let responseEnded = false
+    let settled = false
+
+    const cleanup = () => {
+      context.close()
+    }
+
+    const rejectOnce = (error: unknown) => {
+      if (settled) return
+      settled = true
+      cleanup()
+      reject(error)
+    }
+
+    const resolveWhenComplete = () => {
+      if (settled || !handlerCompleted || !responseEnded) return
+
+      const headers = new Headers()
+      for (const [name, value] of Object.entries(nodeResponse.getHeaders())) {
+        if (value !== undefined) {
+          appendNodeHeader(headers, name, value)
+        }
+      }
+
+      const status = nodeResponse.statusCode
+      const body = Buffer.concat(chunks)
+      settled = true
+      cleanup()
+      resolve(
+        new Response(
+          responseMayHaveBody(request.method, status) && body.length > 0
+            ? body
+            : null,
+          { status, headers }
+        )
+      )
+    }
+
+    nodeResponse.write = ((
+      chunk: string | Uint8Array,
+      encodingOrCallback?: BufferEncoding | (() => void),
+      callback?: () => void
+    ): boolean => {
+      const encoding =
+        typeof encodingOrCallback === "string"
+          ? encodingOrCallback
+          : undefined
+      chunks.push(toBuffer(chunk, encoding))
+      if (typeof encodingOrCallback === "function") {
+        encodingOrCallback()
+      }
+      callback?.()
+      return true
+    }) as typeof nodeResponse.write
+
+    nodeResponse.end = ((
+      chunk?: string | Uint8Array | (() => void),
+      encodingOrCallback?: BufferEncoding | (() => void),
+      callback?: () => void
+    ): ServerResponse<IncomingMessage> => {
+      if (typeof chunk === "string" || chunk instanceof Uint8Array) {
+        const encoding =
+          typeof encodingOrCallback === "string"
+            ? encodingOrCallback
+            : undefined
+        chunks.push(toBuffer(chunk, encoding))
+      }
+      if (typeof chunk === "function") {
+        chunk()
+      }
+      if (typeof encodingOrCallback === "function") {
+        encodingOrCallback()
+      }
+      callback?.()
+      responseEnded = true
+      resolveWhenComplete()
+      return nodeResponse
+    }) as typeof nodeResponse.end
+
+    try {
+      Promise.resolve(handler(nodeRequest, nodeResponse)).then(
+        () => {
+          handlerCompleted = true
+          resolveWhenComplete()
+        },
+        rejectOnce
+      )
+    } catch (error) {
+      rejectOnce(error)
+    }
+  })
+}
+
+/**
+ * Build a Node request/response pair for oidc-provider public APIs that do not
+ * themselves emit a response (for example `interactionDetails`).
+ */
+export async function createNodeHttpContext(
+  request: Request,
+  path: string
+): Promise<NodeHttpContext> {
+  const socket = new Socket()
+  const nodeRequest = new IncomingMessage(socket)
+  nodeRequest.method = request.method
+  nodeRequest.url = path
+
+  for (const [name, value] of request.headers.entries()) {
+    nodeRequest.headers[name.toLowerCase()] = value
+    nodeRequest.rawHeaders.push(name, value)
+  }
+
+  if (
+    request.method === "POST" ||
+    request.method === "PUT" ||
+    request.method === "PATCH"
+  ) {
+    nodeRequest.push(Buffer.from(await request.arrayBuffer()))
+  }
+  nodeRequest.push(null)
+
+  const nodeResponse = new ServerResponse(nodeRequest)
+  return {
+    request: nodeRequest,
+    response: nodeResponse,
+    close: () => socket.destroy(),
+  }
+}

--- a/lib/oauth/oauth-scopes.ts
+++ b/lib/oauth/oauth-scopes.ts
@@ -64,14 +64,23 @@ const PLATFORM_SCOPES = Object.keys(API_SCOPES).filter((s) =>
 )
 
 /**
+ * Scopes granted for the AI Studio API resource server. Standard OIDC scopes
+ * must remain in the OIDC grant portion and must not be duplicated as API
+ * resource scopes.
+ */
+export const RESOURCE_SERVER_SCOPES = [
+  ...MCP_SCOPES,
+  ...CONTENT_SCOPES,
+  ...PLATFORM_SCOPES,
+]
+
+/**
  * All scopes the OAuth provider supports (standard OIDC + MCP + Atrium content +
  * platform capability catalog).
  */
 export const ALL_OAUTH_SCOPES = [
   ...OIDC_SCOPES,
-  ...MCP_SCOPES,
-  ...CONTENT_SCOPES,
-  ...PLATFORM_SCOPES,
+  ...RESOURCE_SERVER_SCOPES,
 ]
 
 /**

--- a/lib/oauth/oidc-provider-config.ts
+++ b/lib/oauth/oidc-provider-config.ts
@@ -12,8 +12,15 @@ import {
   type OidcSigningKeySet,
 } from "./oidc-signing-key-store"
 import { getIssuerUrl } from "./issuer-config"
-import { ALL_OAUTH_SCOPES } from "./oauth-scopes"
+import {
+  ALL_OAUTH_SCOPES,
+  RESOURCE_SERVER_SCOPES,
+} from "./oauth-scopes"
 import { getOidcCookieSecret } from "./oidc-cookie-secret"
+import {
+  createFirstPartyLoadExistingGrant,
+  createOAuthInteractionPolicy,
+} from "./first-party-grants"
 import { createLogger } from "@/lib/logger"
 
 // ============================================
@@ -130,6 +137,13 @@ export async function getOidcProvider(
     // ==========================================
     // Dynamic client registration is not enabled;
     // clients are managed via admin UI and adapter.
+    extraClientMetadata: {
+      properties: ["is_first_party"],
+    },
+
+    // First-party clients receive only their explicitly registered, requested
+    // scopes and only after the provider has an authenticated account.
+    loadExistingGrant: createFirstPartyLoadExistingGrant(issuer),
 
     // ==========================================
     // JWKS — signing keys
@@ -158,7 +172,7 @@ export async function getOidcProvider(
         defaultResource: async () => issuer,
         useGrantedResource: async () => true,
         getResourceServerInfo: async () => ({
-          scope: ALL_OAUTH_SCOPES.join(" "),
+          scope: RESOURCE_SERVER_SCOPES.join(" "),
           audience: issuer,
           accessTokenTTL: 900,
           accessTokenFormat: "jwt" as const,
@@ -251,6 +265,7 @@ export async function getOidcProvider(
     // Interactions — custom consent UI
     // ==========================================
     interactions: {
+      policy: createOAuthInteractionPolicy(),
       url: (_ctx, interaction) => {
         return `/oauth/authorize?uid=${interaction.uid}`
       },

--- a/lib/oauth/resume-path.ts
+++ b/lib/oauth/resume-path.ts
@@ -1,0 +1,10 @@
+/**
+ * oidc-provider uses 43-character nanoid values for interaction resume routes.
+ * Keep the middleware exception narrower than the surrounding `/auth/*` tree.
+ */
+
+const OIDC_RESUME_PATH = /^\/auth\/[A-Za-z0-9_-]{43}$/
+
+export function isOidcProviderResumePath(pathname: string): boolean {
+  return OIDC_RESUME_PATH.test(pathname)
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,6 +1,8 @@
 import { authMiddleware } from "@/auth";
 import { NextResponse } from "next/server";
 import { getArtifactSandboxOrigin } from "@/lib/content/artifact-sandbox-config";
+import { inAppSignInCallbackUrl } from "@/lib/auth/sign-in-callback";
+import { isOidcProviderResumePath } from "@/lib/oauth/resume-path";
 
 // Public paths that don't require authentication
 const PUBLIC_PATHS = [
@@ -94,7 +96,7 @@ export default authMiddleware((req) => {
   // Check if path is public
   const isPublicPath = PUBLIC_PATHS.some(path => 
     nextUrl.pathname === path || nextUrl.pathname.startsWith(path + "/")
-  );
+  ) || isOidcProviderResumePath(nextUrl.pathname);
 
   // Create response with security headers
   let response: NextResponse;
@@ -128,7 +130,8 @@ export default authMiddleware((req) => {
   }
   // Redirect unauthenticated users to sign-in for non-API routes
   else if (!isLoggedIn) {
-    response = NextResponse.redirect(new URL(`/api/auth/signin?callbackUrl=${encodeURIComponent(nextUrl.pathname)}`, nextUrl));
+    const callbackUrl = inAppSignInCallbackUrl(nextUrl);
+    response = NextResponse.redirect(new URL(`/api/auth/signin?callbackUrl=${encodeURIComponent(callbackUrl)}`, nextUrl));
   }
   else {
     response = NextResponse.next();

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "packageManager": "bun@1.2.23",
   "scripts": {
     "test:oauth-public-flow": "tsx scripts/test/oauth-public-client-flow.smoke.ts",
-    "test:smoke:oauth-client-trust-audit": "tsx tests/smoke/oauth-client-trust-audit.smoke.ts",
+    "test:smoke:oauth-client-trust-audit": "bun run tests/smoke/oauth-client-trust-audit.smoke.ts",
     "prepare": "git rev-parse --is-inside-work-tree >/dev/null 2>&1 && git config core.hooksPath .githooks || true",
     "test:e2e:local": "bash scripts/test/e2e-local.sh",
     "dev": "next dev",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "packageManager": "bun@1.2.23",
   "scripts": {
     "test:oauth-public-flow": "tsx scripts/test/oauth-public-client-flow.smoke.ts",
+    "test:smoke:oauth-client-trust-audit": "tsx tests/smoke/oauth-client-trust-audit.smoke.ts",
     "prepare": "git rev-parse --is-inside-work-tree >/dev/null 2>&1 && git config core.hooksPath .githooks || true",
     "test:e2e:local": "bash scripts/test/e2e-local.sh",
     "dev": "next dev",

--- a/scripts/test/oauth-public-client-flow.smoke.ts
+++ b/scripts/test/oauth-public-client-flow.smoke.ts
@@ -2,23 +2,35 @@
  * Protocol smoke test for the public OAuth/OIDC contract (Issue #1285).
  *
  * It runs the repository's real oidc-provider version with a deterministic
- * in-memory adapter and exercises security behavior at HTTP boundaries: S256
- * PKCE, verifier/redirect mismatch, code replay, RS256 access JWTs, refresh
- * rotation/replay, expiry, revocation, and native loopback port matching.
+ * in-memory adapter and exercises the browser-visible authorization
+ * interaction lifecycle plus token security at HTTP boundaries: first-party
+ * login without consent, third-party consent, S256 PKCE, redirect mismatch,
+ * code replay, RS256 access JWTs, refresh rotation/replay, expiry, revocation,
+ * and native redirect matching.
  *
  * Run: bun run test:oauth-public-flow
  */
 
 import assert from "node:assert/strict"
 import { createHash, generateKeyPairSync } from "node:crypto"
-import { createServer, type Server } from "node:http"
+import {
+  createServer,
+  type IncomingMessage,
+  type Server,
+  type ServerResponse,
+} from "node:http"
 import type { AddressInfo } from "node:net"
 import Provider, {
   type Adapter,
   type AdapterPayload,
+  type Interaction,
 } from "oidc-provider"
 import { decodeJwt, decodeProtectedHeader } from "jose"
 import { scriptLogger as log } from "../db/script-logger"
+import {
+  createFirstPartyLoadExistingGrant,
+  createOAuthInteractionPolicy,
+} from "../../lib/oauth/first-party-grants"
 
 interface Stored {
   payload: AdapterPayload
@@ -116,8 +128,85 @@ interface OAuthError {
   error_description?: string
 }
 
+interface AuthorizationResult {
+  callback: URL
+  prompts: string[]
+}
+
+class CookieJar {
+  private readonly values = new Map<
+    string,
+    { value: string; path: string }
+  >()
+
+  capture(response: Response, requestUrl: string): void {
+    const requestPath = new URL(requestUrl).pathname
+    const lastSlash = requestPath.lastIndexOf("/")
+    const defaultPath =
+      lastSlash <= 0 ? "/" : requestPath.slice(0, lastSlash)
+
+    for (const cookie of response.headers.getSetCookie()) {
+      const pair = cookie.split(";", 1)[0]
+      const separator = pair.indexOf("=")
+      if (separator <= 0) continue
+      const name = pair.slice(0, separator)
+      const value = pair.slice(separator + 1)
+      const path =
+        cookie.match(/(?:^|;)\s*path=([^;]+)/i)?.[1] ?? defaultPath
+      if (
+        value.length === 0 ||
+        /(?:^|;)\s*max-age=0(?:;|$)/i.test(cookie)
+      ) {
+        this.values.delete(name)
+      } else {
+        this.values.set(name, { value, path })
+      }
+    }
+  }
+
+  header(requestUrl: string): string | undefined {
+    const requestPath = new URL(requestUrl).pathname
+    const cookies = [...this.values].filter(([, cookie]) => {
+      return (
+        requestPath === cookie.path ||
+        requestPath.startsWith(
+          cookie.path.endsWith("/") ? cookie.path : `${cookie.path}/`
+        )
+      )
+    })
+    if (cookies.length === 0) return undefined
+    return cookies
+      .map(([name, cookie]) => `${name}=${cookie.value}`)
+      .join("; ")
+  }
+}
+
 function pkce(verifier: string): string {
   return createHash("sha256").update(verifier).digest("base64url")
+}
+
+function isRedirect(status: number): boolean {
+  return status >= 300 && status < 400
+}
+
+function stringArray(value: unknown): string[] {
+  return Array.isArray(value) &&
+    value.every((item) => typeof item === "string")
+    ? value
+    : []
+}
+
+async function fetchWithCookies(
+  url: string,
+  jar: CookieJar
+): Promise<Response> {
+  const cookie = jar.header(url)
+  const response = await fetch(url, {
+    redirect: "manual",
+    headers: cookie ? { cookie } : undefined,
+  })
+  jar.capture(response, url)
+  return response
 }
 
 async function postForm<T>(
@@ -162,11 +251,19 @@ async function main(): Promise<void> {
     alg: "RS256",
     use: "sig",
   }
-  const clientId = "atrium-chrome-extension"
+  const clientId = "ae781263-20c0-4b0c-8a34-8be01ab72fb1"
   const redirectUri =
-    "https://abcdefghijklmnopabcdefghijklmnop.chromiumapp.org/atrium"
-  const nativeClientId = "atrium-native"
-  const nativeRedirectUri = "http://127.0.0.1/oauth/callback"
+    "https://jldnpmcpimhabiphcglkbgmbffpoocpo.chromiumapp.org/atrium"
+  const nativeClientId = "fbdaa815-1b0f-435b-805f-1732805720c1"
+  const nativeRedirectUri =
+    "org.psd401.atrium-capture:/oauth/callback"
+  const thirdPartyClientId = "third-party-browser"
+  const thirdPartyRedirectUri =
+    "https://third-party.example/oauth/callback"
+  const loopbackClientId = "native-loopback-smoke"
+  const loopbackRedirectUri = "http://127.0.0.1/oauth/callback"
+  const registeredScopes =
+    "openid profile offline_access content:read content:create content:update content:publish_internal"
   const verifier = "a".repeat(64)
 
   const holder = createServer()
@@ -184,6 +281,8 @@ async function main(): Promise<void> {
         redirect_uris: [redirectUri],
         response_types: ["code"],
         grant_types: ["authorization_code", "refresh_token"],
+        scope: registeredScopes,
+        is_first_party: true,
       },
       {
         client_id: nativeClientId,
@@ -193,8 +292,36 @@ async function main(): Promise<void> {
         redirect_uris: [nativeRedirectUri],
         response_types: ["code"],
         grant_types: ["authorization_code", "refresh_token"],
+        scope: registeredScopes,
+        is_first_party: true,
+      },
+      {
+        client_id: thirdPartyClientId,
+        client_name: "Third-party browser",
+        application_type: "web",
+        token_endpoint_auth_method: "none",
+        redirect_uris: [thirdPartyRedirectUri],
+        response_types: ["code"],
+        grant_types: ["authorization_code", "refresh_token"],
+        scope: registeredScopes,
+        is_first_party: false,
+      },
+      {
+        client_id: loopbackClientId,
+        client_name: "Native loopback smoke client",
+        application_type: "native",
+        token_endpoint_auth_method: "none",
+        redirect_uris: [loopbackRedirectUri],
+        response_types: ["code"],
+        grant_types: ["authorization_code", "refresh_token"],
+        scope: registeredScopes,
+        is_first_party: false,
       },
     ],
+    extraClientMetadata: {
+      properties: ["is_first_party"],
+    },
+    loadExistingGrant: createFirstPartyLoadExistingGrant(origin),
     jwks: { keys: [signingJwk] },
     pkce: { required: () => true },
     responseTypes: ["code"],
@@ -206,6 +333,7 @@ async function main(): Promise<void> {
       "content:create",
       "content:update",
       "content:publish_internal",
+      "content:not_registered",
     ],
     issueRefreshToken: () => true,
     rotateRefreshToken: true,
@@ -248,9 +376,130 @@ async function main(): Promise<void> {
         name: "Smoke User",
       }),
     }),
+    interactions: {
+      policy: createOAuthInteractionPolicy(),
+      url: (_ctx, interaction) =>
+        `/oauth/authorize?uid=${interaction.uid}`,
+    },
     cookies: { keys: ["smoke-cookie-key"] },
   })
-  const server = createServer(provider.callback())
+  const observedPrompts: Array<{
+    clientId: string
+    name: string
+    details: Record<string, unknown>
+  }> = []
+  const providerCallback = provider.callback()
+
+  async function finishInteraction(
+    request: IncomingMessage,
+    response: ServerResponse,
+    interaction: Interaction
+  ): Promise<void> {
+    const rawClientId = interaction.params.client_id
+    if (typeof rawClientId !== "string") {
+      throw new TypeError("interaction client_id must be a string")
+    }
+    const clientIdParam = rawClientId
+
+    if (interaction.prompt.name === "login") {
+      await provider.interactionFinished(
+        request,
+        response,
+        { login: { accountId: "1" } },
+        { mergeWithLastSubmission: false }
+      )
+      return
+    }
+
+    assert.equal(interaction.prompt.name, "consent")
+    const accountId = interaction.session?.accountId
+    assert(accountId)
+    let grant = interaction.grantId
+      ? await provider.Grant.find(interaction.grantId)
+      : undefined
+    grant ??= new provider.Grant({
+      accountId,
+      clientId: clientIdParam,
+    })
+
+    const details = interaction.prompt.details
+    const oidcScopes = stringArray(details.missingOIDCScope)
+    if (oidcScopes.length > 0) {
+      grant.addOIDCScope(oidcScopes.join(" "))
+    }
+    const oidcClaims = stringArray(details.missingOIDCClaims)
+    if (oidcClaims.length > 0) {
+      grant.addOIDCClaims(oidcClaims)
+    }
+    const resources = details.missingResourceScopes
+    if (
+      resources &&
+      typeof resources === "object" &&
+      !Array.isArray(resources)
+    ) {
+      for (const [resource, value] of Object.entries(resources)) {
+        const scopes = stringArray(value)
+        if (scopes.length > 0) {
+          grant.addResourceScope(resource, scopes.join(" "))
+        }
+      }
+    }
+
+    await provider.interactionFinished(
+      request,
+      response,
+      { consent: { grantId: await grant.save() } },
+      { mergeWithLastSubmission: true }
+    )
+  }
+
+  async function handleRequest(
+    request: IncomingMessage,
+    response: ServerResponse
+  ): Promise<void> {
+    const path = new URL(request.url ?? "/", origin).pathname
+    if (path === "/oauth/authorize") {
+      const interaction = await provider.interactionDetails(
+        request,
+        response
+      )
+      const rawClientId = interaction.params.client_id
+      if (typeof rawClientId !== "string") {
+        throw new TypeError("interaction client_id must be a string")
+      }
+      observedPrompts.push({
+        clientId: rawClientId,
+        name: interaction.prompt.name,
+        details: interaction.prompt.details,
+      })
+      response.statusCode = 303
+      response.setHeader(
+        "Location",
+        `/oauth/authorize/interaction/${interaction.uid}/${interaction.prompt.name}`
+      )
+      response.end()
+      return
+    }
+    if (path.startsWith("/oauth/authorize/interaction/")) {
+      const interaction = await provider.interactionDetails(
+        request,
+        response
+      )
+      await finishInteraction(request, response, interaction)
+      return
+    }
+    providerCallback(request, response)
+  }
+
+  const server = createServer((request, response) => {
+    void handleRequest(request, response).catch((error) => {
+      log.error("OAuth smoke HTTP handler failed", {
+        error: error instanceof Error ? error.message : String(error),
+      })
+      if (!response.headersSent) response.statusCode = 500
+      if (!response.writableEnded) response.end()
+    })
+  })
   await new Promise<void>((resolve, reject) => {
     server.once("error", reject)
     const port = Number(new URL(origin).port)
@@ -262,6 +511,10 @@ async function main(): Promise<void> {
   const client = foundClient
   const nativeClient = await provider.Client.find(nativeClientId)
   if (!nativeClient) throw new Error("Smoke native OAuth client not found")
+  const loopbackClient = await provider.Client.find(loopbackClientId)
+  if (!loopbackClient) {
+    throw new Error("Smoke loopback OAuth client not found")
+  }
 
   async function authorizationCode(
     expire = false
@@ -293,19 +546,222 @@ async function main(): Promise<void> {
     return value
   }
 
+  function authorizationUrl(options: {
+    clientId: string
+    redirectUri: string
+    state: string
+    scope?: string
+    includeChallenge?: boolean
+    challengeMethod?: string
+  }): string {
+    const params = new URLSearchParams({
+      client_id: options.clientId,
+      redirect_uri: options.redirectUri,
+      response_type: "code",
+      scope: options.scope ?? registeredScopes,
+      state: options.state,
+      resource: origin,
+    })
+    if (options.includeChallenge !== false) {
+      params.set("code_challenge", pkce(verifier))
+      params.set(
+        "code_challenge_method",
+        options.challengeMethod ?? "S256"
+      )
+    }
+    return `${origin}/auth?${params.toString()}`
+  }
+
+  async function authorize(options: {
+    clientId: string
+    redirectUri: string
+    state: string
+    jar: CookieJar
+  }): Promise<AuthorizationResult> {
+    let current = authorizationUrl(options)
+    const promptStart = observedPrompts.length
+
+    for (let redirectCount = 0; redirectCount < 10; redirectCount += 1) {
+      const response = await fetchWithCookies(current, options.jar)
+      assert(
+        isRedirect(response.status),
+        `authorization expected redirect, got ${response.status}: ${await response.text()}`
+      )
+      const location = response.headers.get("location")
+      assert(location, "authorization redirect missing Location")
+      const next = new URL(location, current)
+      if (next.href.startsWith(options.redirectUri)) {
+        return {
+          callback: next,
+          prompts: observedPrompts
+            .slice(promptStart)
+            .map((prompt) => prompt.name),
+        }
+      }
+      assert.equal(
+        next.origin,
+        origin,
+        `unexpected authorization redirect: ${next.href}`
+      )
+      current = next.href
+    }
+
+    throw new Error("authorization redirect limit exceeded")
+  }
+
+  async function assertAuthorizationRejected(
+    url: string,
+    expectedError: string
+  ): Promise<void> {
+    const response = await fetchWithCookies(url, new CookieJar())
+    if (isRedirect(response.status)) {
+      const location = response.headers.get("location")
+      assert(location, "OAuth error redirect missing Location")
+      const error = new URL(location, url).searchParams.get("error")
+      assert.equal(error, expectedError)
+      return
+    }
+
+    assert(
+      response.status >= 400,
+      `OAuth rejection returned unexpected HTTP ${response.status}`
+    )
+    const body = await response.text()
+    assert(
+      body.includes(expectedError),
+      `OAuth rejection did not include ${expectedError}: ${body}`
+    )
+  }
+
   try {
+    const browserSession = new CookieJar()
+    const signedOutBrowser = await authorize({
+      clientId,
+      redirectUri,
+      state: "browser-signed-out",
+      jar: browserSession,
+    })
+    assert.equal(
+      signedOutBrowser.callback.searchParams.get("state"),
+      "browser-signed-out"
+    )
+    assert(signedOutBrowser.callback.searchParams.get("code"))
+    assert.deepEqual(
+      signedOutBrowser.prompts,
+      ["login"],
+      JSON.stringify(observedPrompts, null, 2)
+    )
+
+    const signedInBrowser = await authorize({
+      clientId,
+      redirectUri,
+      state: "browser-signed-in",
+      jar: browserSession,
+    })
+    assert.equal(
+      signedInBrowser.callback.searchParams.get("state"),
+      "browser-signed-in"
+    )
+    assert(signedInBrowser.callback.searchParams.get("code"))
+    assert.deepEqual(signedInBrowser.prompts, [])
+
+    const nativeFirstParty = await authorize({
+      clientId: nativeClientId,
+      redirectUri: nativeRedirectUri,
+      state: "native-first-party",
+      jar: new CookieJar(),
+    })
+    assert.equal(
+      nativeFirstParty.callback.searchParams.get("state"),
+      "native-first-party"
+    )
+    assert(nativeFirstParty.callback.searchParams.get("code"))
+    assert.deepEqual(nativeFirstParty.prompts, ["login"])
+
+    const thirdParty = await authorize({
+      clientId: thirdPartyClientId,
+      redirectUri: thirdPartyRedirectUri,
+      state: "third-party",
+      jar: new CookieJar(),
+    })
+    assert.equal(
+      thirdParty.callback.searchParams.get("state"),
+      "third-party"
+    )
+    assert(thirdParty.callback.searchParams.get("code"))
+    assert.deepEqual(thirdParty.prompts, ["login", "consent"])
+
+    await assertAuthorizationRejected(
+      authorizationUrl({
+        clientId,
+        redirectUri,
+        state: "unregistered-scope",
+        scope: "openid content:not_registered",
+      }),
+      "invalid_scope"
+    )
+    await assertAuthorizationRejected(
+      authorizationUrl({
+        clientId,
+        redirectUri:
+          "https://jldnpmcpimhabiphcglkbgmbffpoocpo.chromiumapp.org/wrong",
+        state: "callback-mismatch",
+      }),
+      "invalid_redirect_uri"
+    )
+    await assertAuthorizationRejected(
+      authorizationUrl({
+        clientId,
+        redirectUri,
+        state: "missing-pkce",
+        includeChallenge: false,
+      }),
+      "invalid_request"
+    )
+    await assertAuthorizationRejected(
+      authorizationUrl({
+        clientId,
+        redirectUri,
+        state: "plain-pkce",
+        challengeMethod: "plain",
+      }),
+      "invalid_request"
+    )
+    await assertAuthorizationRejected(
+      authorizationUrl({
+        clientId: "inactive-or-unknown-client",
+        redirectUri,
+        state: "inactive-client",
+      }),
+      "invalid_client"
+    )
+
+    assert.equal(
+      nativeClient.redirectUriAllowed(nativeRedirectUri),
+      true
+    )
     assert.equal(
       nativeClient.redirectUriAllowed(
+        "org.psd401.atrium-capture:/oauth/wrong"
+      ),
+      false
+    )
+    assert.equal(
+      loopbackClient.redirectUriAllowed(
         "http://127.0.0.1:49152/oauth/callback"
       ),
       true
     )
     assert.equal(
-      nativeClient.redirectUriAllowed("http://localhost:49152/oauth/callback"),
+      loopbackClient.redirectUriAllowed(
+        "http://localhost:49152/oauth/callback"
+      ),
       false
     )
     assert.equal(
-      nativeClient.redirectUriAllowed("http://127.0.0.1:49152/wrong"),
+      loopbackClient.redirectUriAllowed(
+        "http://127.0.0.1:49152/wrong"
+      ),
       false
     )
 
@@ -427,6 +883,15 @@ async function main(): Promise<void> {
 
     log.info("OAuth public-client protocol smoke passed", {
       checks: [
+        "first_party_signed_out_login_only",
+        "first_party_signed_in_no_prompt",
+        "first_party_native_login_only",
+        "third_party_consent",
+        "unregistered_scope_rejected",
+        "authorization_redirect_mismatch",
+        "missing_pkce_rejected",
+        "non_s256_pkce_rejected",
+        "inactive_client_rejected",
         "wrong_verifier",
         "redirect_mismatch",
         "expired_code",
@@ -435,6 +900,7 @@ async function main(): Promise<void> {
         "refresh_rotation",
         "refresh_replay",
         "revocation",
+        "native_custom_scheme_exact_match",
         "native_loopback_variable_port",
       ],
     })

--- a/tests/e2e/oauth-clients.functional.spec.ts
+++ b/tests/e2e/oauth-clients.functional.spec.ts
@@ -16,6 +16,17 @@ test.describe("OAuth client application profiles (#1289)", () => {
     expect(response.headers().location).toContain("/api/auth/signin")
   })
 
+  test("OAuth interaction completion requires a district session", async ({
+    request,
+  }) => {
+    const response = await request.get(
+      "/oauth/authorize/interaction/not-a-real-interaction/login",
+      { maxRedirects: 0 }
+    )
+    expect(response.status()).toBe(307)
+    expect(response.headers().location).toContain("/api/auth/signin")
+  })
+
   test.describe("authenticated administration", () => {
     test.skip(
       process.env.PLAYWRIGHT_AUTH_ENABLED !== "true",
@@ -64,6 +75,23 @@ test.describe("OAuth client application profiles (#1289)", () => {
       await expect(
         page.getByText("email", { exact: true }).locator("..").getByRole("checkbox")
       ).toBeEnabled()
+    })
+
+    test("invalid provider interactions show the safe expired state", async ({
+      page,
+    }) => {
+      await authenticateContext(
+        page.context(),
+        SEEDED_ADMIN_EMAIL,
+        SEEDED_ADMIN_SUB
+      )
+      await page.goto("/oauth/authorize?uid=not-a-real-interaction")
+      await expect(
+        page.getByRole("heading", { name: "Authorization Expired" })
+      ).toBeVisible()
+      await expect(page).toHaveURL(
+        /\/oauth\/authorize\?uid=not-a-real-interaction/
+      )
     })
   })
 })

--- a/tests/smoke/oauth-client-trust-audit.smoke.ts
+++ b/tests/smoke/oauth-client-trust-audit.smoke.ts
@@ -1,0 +1,212 @@
+/**
+ * OAuth client first-party trust real-database smoke.
+ *
+ * Proves migration 134's audit triggers remain compatible with the existing
+ * INSERT ... ON CONFLICT credential-rotation path and record each privileged
+ * trust change exactly once. All fixtures run inside a rolled-back transaction.
+ *
+ * Run:
+ *   DATABASE_URL='postgresql://postgres:postgres@localhost:5432/aistudio' DB_SSL=false \
+ *     bun run test:smoke:oauth-client-trust-audit
+ */
+
+import assert from "node:assert/strict";
+import postgres from "postgres";
+import { scriptLogger as log } from "../../scripts/db/script-logger";
+
+async function main(): Promise<void> {
+  const databaseUrl =
+    process.env.DATABASE_URL ??
+    "postgresql://postgres:postgres@localhost:5432/aistudio";
+  const sslEnabled = process.env.DB_SSL !== "false";
+  const sql = postgres(databaseUrl, {
+    ssl: sslEnabled ? "require" : false,
+    max: 1,
+    idle_timeout: 20,
+    connect_timeout: 10,
+  });
+
+  let transactionStarted = false;
+
+  try {
+    await sql`BEGIN`;
+    transactionStarted = true;
+
+    await sql`
+    INSERT INTO oauth_clients (
+      client_id,
+      client_name,
+      client_secret_hash,
+      redirect_uris,
+      allowed_scopes,
+      grant_types,
+      response_types,
+      token_endpoint_auth_method,
+      require_pkce,
+      is_active
+    )
+    VALUES (
+      'oauth-trust-audit-smoke-confidential',
+      'OAuth trust audit confidential upsert smoke',
+      'test-only-not-a-secret',
+      '[]'::jsonb,
+      '[]'::jsonb,
+      '["client_credentials"]'::jsonb,
+      '[]'::jsonb,
+      'client_secret_basic',
+      false,
+      true
+    )
+    ON CONFLICT (client_id) DO UPDATE
+    SET allowed_scopes = EXCLUDED.allowed_scopes
+  `;
+
+    await sql`
+    INSERT INTO oauth_clients (
+      client_id,
+      client_name,
+      client_secret_hash,
+      redirect_uris,
+      allowed_scopes,
+      grant_types,
+      response_types,
+      token_endpoint_auth_method,
+      require_pkce,
+      is_active
+    )
+    VALUES (
+      'oauth-trust-audit-smoke-confidential',
+      'OAuth trust audit confidential upsert smoke',
+      'test-only-not-a-secret',
+      '[]'::jsonb,
+      '[]'::jsonb,
+      '["client_credentials"]'::jsonb,
+      '[]'::jsonb,
+      'client_secret_basic',
+      false,
+      true
+    )
+    ON CONFLICT (client_id) DO UPDATE
+    SET allowed_scopes = EXCLUDED.allowed_scopes
+  `;
+
+    await sql`
+    INSERT INTO oauth_clients (
+      client_id,
+      client_name,
+      redirect_uris,
+      allowed_scopes,
+      grant_types,
+      response_types,
+      token_endpoint_auth_method,
+      require_pkce,
+      is_active,
+      is_first_party
+    )
+    VALUES (
+      'oauth-trust-audit-smoke-first-party',
+      'OAuth trust audit first-party upsert smoke',
+      '["https://smoke.invalid/callback"]'::jsonb,
+      '["openid", "profile", "offline_access"]'::jsonb,
+      '["authorization_code"]'::jsonb,
+      '["code"]'::jsonb,
+      'none',
+      true,
+      true,
+      false
+    )
+    ON CONFLICT (client_id) DO UPDATE
+    SET is_first_party = EXCLUDED.is_first_party
+  `;
+
+    for (const isFirstParty of [true, true]) {
+      await sql`
+      INSERT INTO oauth_clients (
+        client_id,
+        client_name,
+        redirect_uris,
+        allowed_scopes,
+        grant_types,
+        response_types,
+        token_endpoint_auth_method,
+        require_pkce,
+        is_active,
+        is_first_party
+      )
+      VALUES (
+        'oauth-trust-audit-smoke-first-party',
+        'OAuth trust audit first-party upsert smoke',
+        '["https://smoke.invalid/callback"]'::jsonb,
+        '["openid", "profile", "offline_access"]'::jsonb,
+        '["authorization_code"]'::jsonb,
+        '["code"]'::jsonb,
+        'none',
+        true,
+        true,
+        ${isFirstParty}
+      )
+      ON CONFLICT (client_id) DO UPDATE
+      SET is_first_party = EXCLUDED.is_first_party
+    `;
+    }
+
+    const [result] = await sql<
+      {
+        confidentialUpsertRows: number;
+        confidentialAuditRows: number;
+        firstPartyAuditRows: number;
+        legacyAuditRules: number;
+      }[]
+    >`
+    SELECT
+      (
+        SELECT COUNT(*)::integer
+        FROM oauth_clients
+        WHERE client_id = 'oauth-trust-audit-smoke-confidential'
+      ) AS "confidentialUpsertRows",
+      (
+        SELECT COUNT(*)::integer
+        FROM oauth_client_trust_audit
+        WHERE client_id = 'oauth-trust-audit-smoke-confidential'
+      ) AS "confidentialAuditRows",
+      (
+        SELECT COUNT(*)::integer
+        FROM oauth_client_trust_audit
+        WHERE client_id = 'oauth-trust-audit-smoke-first-party'
+          AND previous_is_first_party = false
+          AND new_is_first_party = true
+          AND change_source = 'database-trigger-update'
+      ) AS "firstPartyAuditRows",
+      (
+        SELECT COUNT(*)::integer
+        FROM pg_rewrite
+        WHERE rulename IN (
+          'oauth_client_trust_audit_insert',
+          'oauth_client_trust_audit_update'
+        )
+      ) AS "legacyAuditRules"
+  `;
+
+    assert.deepEqual(result, {
+      confidentialUpsertRows: 1,
+      confidentialAuditRows: 0,
+      firstPartyAuditRows: 1,
+      legacyAuditRules: 0,
+    });
+    log.success(
+      "OAuth client upserts remain usable and first-party trust changes are audited once",
+    );
+  } finally {
+    if (transactionStarted) {
+      await sql`ROLLBACK`;
+    }
+    await sql.end();
+  }
+}
+
+main().catch((error: unknown) => {
+  log.error("OAuth client trust audit smoke failed", {
+    error: error instanceof Error ? error.message : String(error),
+  });
+  process.exitCode = 1;
+});

--- a/tests/unit/actions/oauth-client-actions.test.ts
+++ b/tests/unit/actions/oauth-client-actions.test.ts
@@ -28,6 +28,7 @@ jest.mock('@/lib/db/schema', () => ({
     accessTokenTtl: 'access_token_ttl',
     refreshTokenTtl: 'refresh_token_ttl',
     isActive: 'is_active',
+    isFirstParty: 'is_first_party',
     createdAt: 'created_at',
     updatedAt: 'updated_at',
   },
@@ -78,6 +79,7 @@ describe('revokeOAuthClient (REV-COR-055)', () => {
       accessTokenTtl: 900,
       refreshTokenTtl: 86400,
       isActive: true,
+      isFirstParty: false,
       createdAt,
       updatedAt: createdAt,
     }])
@@ -112,6 +114,7 @@ describe('revokeOAuthClient (REV-COR-055)', () => {
       accessTokenTtl: 900,
       refreshTokenTtl: 86400,
       isActive: true,
+      isFirstParty: false,
       createdAt,
       updatedAt: createdAt,
     }

--- a/tests/unit/lib/auth/sign-in-callback.test.ts
+++ b/tests/unit/lib/auth/sign-in-callback.test.ts
@@ -1,0 +1,21 @@
+import { inAppSignInCallbackUrl } from "@/lib/auth/sign-in-callback"
+
+describe("in-app sign-in callback", () => {
+  it("preserves the OAuth interaction uid query parameter", () => {
+    expect(
+      inAppSignInCallbackUrl({
+        pathname: "/oauth/authorize",
+        search: "?uid=interaction-123",
+      })
+    ).toBe("/oauth/authorize?uid=interaction-123")
+  })
+
+  it("does not add a query delimiter when there is no search", () => {
+    expect(
+      inAppSignInCallbackUrl({
+        pathname: "/dashboard",
+        search: "",
+      })
+    ).toBe("/dashboard")
+  })
+})

--- a/tests/unit/lib/oauth/drizzle-adapter.test.ts
+++ b/tests/unit/lib/oauth/drizzle-adapter.test.ts
@@ -40,6 +40,7 @@ jest.mock("@/lib/db/schema", () => ({
     tokenEndpointAuthMethod: "token_endpoint_auth_method",
     requirePkce: "require_pkce",
     isActive: "is_active",
+    isFirstParty: "is_first_party",
   },
   oauthAuthorizationCodes: {
     id: "id",
@@ -188,6 +189,7 @@ describe("Drizzle OIDC adapter production durability (#1285)", () => {
         allowedScopes: ["openid", "content:read"],
         tokenEndpointAuthMethod: "none",
         requirePkce: true,
+        isFirstParty: true,
       },
     ])
 
@@ -199,6 +201,7 @@ describe("Drizzle OIDC adapter production durability (#1285)", () => {
         client_secret: undefined,
         redirect_uris: ["http://127.0.0.1/oauth/callback"],
         token_endpoint_auth_method: "none",
+        is_first_party: true,
       })
     )
   })
@@ -216,6 +219,7 @@ describe("Drizzle OIDC adapter production durability (#1285)", () => {
         allowedScopes: ["openid"],
         tokenEndpointAuthMethod: "client_secret_post",
         requirePkce: false,
+        isFirstParty: false,
       },
     ])
 

--- a/tests/unit/lib/oauth/first-party-grants.test.ts
+++ b/tests/unit/lib/oauth/first-party-grants.test.ts
@@ -1,0 +1,290 @@
+import type {
+  Client,
+  Configuration,
+  KoaContextWithOIDC,
+} from "oidc-provider"
+
+jest.mock("oidc-provider", () => {
+  type CheckFunction = (context: KoaContextWithOIDC) => boolean
+  type DetailsFunction = (
+    context: KoaContextWithOIDC
+  ) => Record<string, unknown>
+
+  class Check {
+    static readonly REQUEST_PROMPT = true
+    static readonly NO_NEED_TO_PROMPT = false
+
+    readonly error: string | undefined
+    readonly check: CheckFunction
+    readonly details: DetailsFunction
+
+    constructor(
+      readonly reason: string,
+      readonly description: string,
+      errorOrCheck: string | CheckFunction,
+      checkOrDetails?: CheckFunction | DetailsFunction,
+      details: DetailsFunction = () => ({})
+    ) {
+      if (typeof errorOrCheck === "function") {
+        this.error = undefined
+        this.check = errorOrCheck
+        this.details =
+          (checkOrDetails as DetailsFunction | undefined) ?? (() => ({}))
+      } else {
+        this.error = errorOrCheck
+        this.check = checkOrDetails as CheckFunction
+        this.details = details
+      }
+    }
+  }
+
+  class Checks extends Array<Check> {
+    get(reason: string) {
+      return this.find((check) => check.reason === reason)
+    }
+
+    remove(reason: string) {
+      const index = this.findIndex((check) => check.reason === reason)
+      if (index >= 0) this.splice(index, 1)
+    }
+
+    add(check: Check, index = this.length) {
+      this.splice(index, 0, check)
+    }
+  }
+
+  class Prompt {
+    readonly checks: Checks
+
+    constructor(readonly name: string, ...checks: Check[]) {
+      this.checks = new Checks(...checks)
+    }
+  }
+
+  function base() {
+    const nativeCheck = new Check(
+      "native_client_prompt",
+      "native",
+      "interaction_required",
+      () => true
+    )
+    const oidcScopeCheck = new Check(
+      "op_scopes_missing",
+      "scopes",
+      () => true
+    )
+    const prompts = [
+      new Prompt("login"),
+      new Prompt("consent", nativeCheck, oidcScopeCheck),
+    ]
+    return Object.assign(prompts, {
+      get: (name: string) =>
+        prompts.find((prompt) => prompt.name === name),
+      remove: jest.fn(),
+      clear: jest.fn(),
+      add: jest.fn(),
+    })
+  }
+
+  return {
+    interactionPolicy: {
+      Check,
+      base,
+    },
+  }
+})
+
+import {
+  createFirstPartyLoadExistingGrant,
+  createOAuthInteractionPolicy,
+  partitionRegisteredFirstPartyScopes,
+} from "@/lib/oauth/first-party-grants"
+
+type LoadExistingGrant = NonNullable<Configuration["loadExistingGrant"]>
+type LoadContext = Parameters<LoadExistingGrant>[0]
+
+class MockGrant {
+  static existing: MockGrant | undefined
+  static created = 0
+
+  readonly jti = "grant-1"
+  readonly accountId: string
+  readonly clientId: string
+  readonly addOIDCScope = jest.fn()
+  readonly addResourceScope = jest.fn()
+  readonly save = jest.fn(async () => this.jti)
+
+  constructor(properties: { accountId: string; clientId: string }) {
+    this.accountId = properties.accountId
+    this.clientId = properties.clientId
+    MockGrant.created += 1
+  }
+
+  static find = jest.fn(async () => MockGrant.existing)
+}
+
+function mockClient(isFirstParty: boolean, scope: string): Client {
+  const metadata = {
+    client_id: "atrium-client",
+    is_first_party: isFirstParty,
+  }
+  return {
+    clientId: "atrium-client",
+    scope,
+    applicationType: "native",
+    metadata: () => metadata,
+  } as unknown as Client
+}
+
+function loadContext(options: {
+  isFirstParty: boolean
+  requestedScope: string
+  registeredScope: string
+  accountId?: string
+}): LoadContext {
+  const client = mockClient(
+    options.isFirstParty,
+    options.registeredScope
+  )
+  return {
+    oidc: {
+      client,
+      account: options.accountId
+        ? { accountId: options.accountId }
+        : undefined,
+      params: { scope: options.requestedScope },
+      provider: {
+        Grant: MockGrant,
+      },
+    },
+  } as unknown as LoadContext
+}
+
+describe("first-party OAuth grants", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    MockGrant.created = 0
+    MockGrant.existing = undefined
+  })
+
+  it("does not create a grant before an authenticated account exists", async () => {
+    const load = createFirstPartyLoadExistingGrant(
+      "https://aistudio.example/api/oauth"
+    )
+
+    await expect(
+      load(
+        loadContext({
+          isFirstParty: true,
+          requestedScope: "openid content:read",
+          registeredScope: "openid content:read",
+        })
+      )
+    ).resolves.toBeUndefined()
+    expect(MockGrant.created).toBe(0)
+  })
+
+  it("grants only requested scopes present in the client allowlist", async () => {
+    const load = createFirstPartyLoadExistingGrant(
+      "https://aistudio.example/api/oauth"
+    )
+
+    const grant = (await load(
+      loadContext({
+        isFirstParty: true,
+        accountId: "42",
+        requestedScope:
+          "openid profile offline_access content:read content:update",
+        registeredScope:
+          "openid profile offline_access content:read",
+      })
+    )) as unknown as MockGrant
+
+    expect(grant.addOIDCScope).toHaveBeenCalledWith(
+      "openid profile offline_access"
+    )
+    expect(grant.addResourceScope).toHaveBeenCalledWith(
+      "https://aistudio.example/api/oauth",
+      "content:read"
+    )
+    expect(grant.addResourceScope).not.toHaveBeenCalledWith(
+      expect.anything(),
+      expect.stringContaining("content:update")
+    )
+    expect(grant.save).toHaveBeenCalledTimes(1)
+  })
+
+  it("does not pre-authorize an untrusted client", async () => {
+    const load = createFirstPartyLoadExistingGrant(
+      "https://aistudio.example/api/oauth"
+    )
+
+    await expect(
+      load(
+        loadContext({
+          isFirstParty: false,
+          accountId: "42",
+          requestedScope: "openid content:read",
+          registeredScope: "openid content:read",
+        })
+      )
+    ).resolves.toBeUndefined()
+    expect(MockGrant.created).toBe(0)
+  })
+
+  it("exempts only explicitly trusted native clients from repeat consent", async () => {
+    const policy = createOAuthInteractionPolicy()
+    const nativeCheck = policy
+      .get("consent")
+      ?.checks.get("native_client_prompt")
+    expect(nativeCheck).toBeDefined()
+
+    const context = (isFirstParty: boolean) =>
+      ({
+        oidc: {
+          client: mockClient(isFirstParty, "openid"),
+          params: { response_type: "code" },
+        },
+      }) as unknown as KoaContextWithOIDC
+
+    expect(nativeCheck?.check(context(true))).toBe(false)
+    expect(nativeCheck?.check(context(false))).toBe(true)
+  })
+
+  it("keeps resource scopes out of the OIDC missing-scope check", () => {
+    const check = createOAuthInteractionPolicy()
+      .get("consent")
+      ?.checks.get("op_scopes_missing")
+    expect(check).toBeDefined()
+
+    const context = {
+      oidc: {
+        grant: {
+          getOIDCScopeEncountered: () => "openid",
+        },
+        requestParamOIDCScopes: new Set([
+          "openid",
+          "profile",
+          "content:read",
+        ]),
+      },
+    } as unknown as KoaContextWithOIDC
+
+    expect(check?.check(context)).toBe(true)
+    expect(check?.details(context)).toEqual({
+      missingOIDCScope: ["profile"],
+    })
+  })
+
+  it("partitions no unregistered scope into either grant section", () => {
+    expect(
+      partitionRegisteredFirstPartyScopes(
+        "openid content:read content:update",
+        "openid content:read"
+      )
+    ).toEqual({
+      oidcScopes: ["openid"],
+      contentScopes: ["content:read"],
+    })
+  })
+})

--- a/tests/unit/lib/oauth/node-http-adapter.test.ts
+++ b/tests/unit/lib/oauth/node-http-adapter.test.ts
@@ -1,0 +1,89 @@
+/** @jest-environment node */
+
+import {
+  Headers as UndiciHeaders,
+  Request as UndiciRequest,
+  Response as UndiciResponse,
+} from "undici"
+import { invokeNodeHttpHandler } from "@/lib/oauth/node-http-adapter"
+
+Object.assign(globalThis, {
+  Headers: UndiciHeaders,
+  Request: UndiciRequest,
+  Response: UndiciResponse,
+})
+
+describe("OIDC Node/Web response adapter", () => {
+  it("uses statusCode set without writeHead and preserves the body", async () => {
+    const response = await invokeNodeHttpHandler(
+      new Request("https://aistudio.example/api/oauth/auth"),
+      "/auth",
+      (_request, nodeResponse) => {
+        nodeResponse.statusCode = 303
+        nodeResponse.end("Redirecting…")
+      }
+    )
+
+    expect(response.status).toBe(303)
+    expect(await response.text()).toBe("Redirecting…")
+  })
+
+  it("uses an explicit writeHead status", async () => {
+    const response = await invokeNodeHttpHandler(
+      new Request("https://aistudio.example/api/oauth/auth"),
+      "/auth",
+      (_request, nodeResponse) => {
+        nodeResponse.writeHead(307)
+        nodeResponse.end()
+      }
+    )
+
+    expect(response.status).toBe(307)
+  })
+
+  it("forwards Location exactly", async () => {
+    const location =
+      "/oauth/authorize?uid=abc%2F123&return=https%3A%2F%2Fclient.example"
+    const response = await invokeNodeHttpHandler(
+      new Request("https://aistudio.example/api/oauth/auth"),
+      "/auth",
+      (_request, nodeResponse) => {
+        nodeResponse.statusCode = 303
+        nodeResponse.setHeader("Location", location)
+        nodeResponse.end()
+      }
+    )
+
+    expect(response.headers.get("location")).toBe(location)
+  })
+
+  it("preserves multiple Set-Cookie headers separately", async () => {
+    const cookies = [
+      "_interaction=one; Path=/api/oauth; HttpOnly; Secure",
+      "_session=two; Path=/api/oauth; HttpOnly; Secure",
+    ]
+    const response = await invokeNodeHttpHandler(
+      new Request("https://aistudio.example/api/oauth/auth"),
+      "/auth",
+      (_request, nodeResponse) => {
+        nodeResponse.statusCode = 303
+        nodeResponse.setHeader("Set-Cookie", cookies)
+        nodeResponse.end()
+      }
+    )
+
+    expect(response.headers.getSetCookie()).toEqual(cookies)
+  })
+
+  it("rejects when the Node callback promise rejects", async () => {
+    await expect(
+      invokeNodeHttpHandler(
+        new Request("https://aistudio.example/api/oauth/auth"),
+        "/auth",
+        async () => {
+          throw new Error("provider failed")
+        }
+      )
+    ).rejects.toThrow("provider failed")
+  })
+})

--- a/tests/unit/lib/oauth/oauth-scopes.test.ts
+++ b/tests/unit/lib/oauth/oauth-scopes.test.ts
@@ -9,6 +9,7 @@
 import {
   getScopeLabel,
   PUBLIC_CLIENT_REQUIRED_OIDC_SCOPES,
+  RESOURCE_SERVER_SCOPES,
   withPublicClientRequiredScopes,
 } from "@/lib/oauth/oauth-scopes"
 
@@ -64,5 +65,25 @@ describe("withPublicClientRequiredScopes", () => {
       ...PUBLIC_CLIENT_REQUIRED_OIDC_SCOPES,
       "content:create",
     ])
+  })
+})
+
+describe("RESOURCE_SERVER_SCOPES", () => {
+  it("contains API scopes without duplicating OIDC scopes into the resource grant", () => {
+    expect(RESOURCE_SERVER_SCOPES).toEqual(
+      expect.arrayContaining([
+        "mcp:search_decisions",
+        "content:read",
+        "content:publish_internal",
+        "platform:read",
+      ])
+    )
+    expect(RESOURCE_SERVER_SCOPES).not.toEqual(
+      expect.arrayContaining([
+        "openid",
+        "profile",
+        "offline_access",
+      ])
+    )
   })
 })

--- a/tests/unit/lib/oauth/resume-path.test.ts
+++ b/tests/unit/lib/oauth/resume-path.test.ts
@@ -1,0 +1,28 @@
+import { isOidcProviderResumePath } from "@/lib/oauth/resume-path"
+
+describe("OIDC provider resume path", () => {
+  it("allows only the provider's exact 43-character URL-safe uid shape", () => {
+    expect(
+      isOidcProviderResumePath(`/auth/${"a".repeat(43)}`)
+    ).toBe(true)
+    expect(
+      isOidcProviderResumePath(`/auth/${"A_-".repeat(14)}A`)
+    ).toBe(true)
+  })
+
+  it("does not make the surrounding auth tree public", () => {
+    expect(isOidcProviderResumePath("/auth/error")).toBe(false)
+    expect(
+      isOidcProviderResumePath(`/auth/${"a".repeat(42)}`)
+    ).toBe(false)
+    expect(
+      isOidcProviderResumePath(`/auth/${"a".repeat(44)}`)
+    ).toBe(false)
+    expect(
+      isOidcProviderResumePath(`/auth/${"a".repeat(42)}!`)
+    ).toBe(false)
+    expect(
+      isOidcProviderResumePath(`/auth/${"a".repeat(43)}/extra`)
+    ).toBe(false)
+  })
+})

--- a/tests/unit/oauth-authorization-route.test.ts
+++ b/tests/unit/oauth-authorization-route.test.ts
@@ -1,0 +1,64 @@
+/** @jest-environment node */
+
+import type { NextRequest } from "next/server"
+import {
+  Headers as UndiciHeaders,
+  Request as UndiciRequest,
+  Response as UndiciResponse,
+} from "undici"
+
+Object.assign(globalThis, {
+  Headers: UndiciHeaders,
+  Request: UndiciRequest,
+  Response: UndiciResponse,
+})
+
+const providerCallback = jest.fn(
+  (
+    _request: import("node:http").IncomingMessage,
+    response: import("node:http").ServerResponse
+  ) => {
+    response.statusCode = 303
+    response.setHeader("Location", "/oauth/authorize?uid=interaction-123")
+    response.setHeader("Set-Cookie", [
+      "_interaction=one; Path=/api/oauth; HttpOnly",
+      "_session=two; Path=/api/oauth; HttpOnly",
+    ])
+    response.end("Redirecting…")
+  }
+)
+
+jest.mock("@/lib/oauth/oidc-provider-config", () => ({
+  getOidcProvider: jest.fn(async () => ({
+    callback: () => providerCallback,
+  })),
+}))
+
+jest.mock("@/lib/logger", () => ({
+  generateRequestId: () => "request-id",
+  createLogger: () => ({
+    error: jest.fn(),
+  }),
+}))
+
+import { GET } from "@/app/api/oauth/[...oidc]/route"
+
+describe("OAuth authorization route", () => {
+  it("returns the provider's real redirect and separate cookies", async () => {
+    const response = await GET(
+      new UndiciRequest(
+        "https://aistudio.example/api/oauth/auth?client_id=atrium"
+      ) as unknown as NextRequest
+    )
+
+    expect(response.status).toBe(303)
+    expect(response.headers.get("location")).toBe(
+      "/oauth/authorize?uid=interaction-123"
+    )
+    expect(response.headers.getSetCookie()).toEqual([
+      "_interaction=one; Path=/api/oauth; HttpOnly",
+      "_session=two; Path=/api/oauth; HttpOnly",
+    ])
+    expect(await response.text()).toBe("Redirecting…")
+  })
+})

--- a/tests/unit/oauth-clients-admin-trust.test.tsx
+++ b/tests/unit/oauth-clients-admin-trust.test.tsx
@@ -1,0 +1,115 @@
+/** @jest-environment jsdom */
+
+import { render, screen } from "@testing-library/react"
+import type { ReactNode } from "react"
+import { OAuthClientsPageClient } from "@/app/(protected)/admin/oauth-clients/_components/oauth-clients-page-client"
+import type { OAuthClientRow } from "@/actions/oauth/oauth-client.actions"
+
+jest.mock("@/actions/oauth/oauth-client.actions", () => ({
+  listOAuthClients: jest.fn(),
+  revokeOAuthClient: jest.fn(),
+}))
+jest.mock("@/components/ui/button", () => ({
+  Button: ({ children }: { children: ReactNode }) => (
+    <button type="button">{children}</button>
+  ),
+}))
+jest.mock("@/components/ui/badge", () => ({
+  Badge: ({ children }: { children: ReactNode }) => <span>{children}</span>,
+}))
+jest.mock("@/components/ui/table", () => ({
+  Table: ({ children }: { children: ReactNode }) => (
+    <table>{children}</table>
+  ),
+  TableBody: ({ children }: { children: ReactNode }) => (
+    <tbody>{children}</tbody>
+  ),
+  TableCell: ({ children }: { children: ReactNode }) => <td>{children}</td>,
+  TableHead: ({ children }: { children: ReactNode }) => <th>{children}</th>,
+  TableHeader: ({ children }: { children: ReactNode }) => (
+    <thead>{children}</thead>
+  ),
+  TableRow: ({ children }: { children: ReactNode }) => <tr>{children}</tr>,
+}))
+jest.mock("lucide-react", () => ({
+  Plus: () => <span aria-hidden="true">+</span>,
+  Ban: () => <span aria-hidden="true">×</span>,
+}))
+jest.mock(
+  "@/app/(protected)/admin/oauth-clients/_components/client-form-sheet",
+  () => ({
+    ClientFormSheet: () => null,
+  })
+)
+jest.mock("@/components/ui/sheet", () => {
+  const Wrapper = ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  )
+  return {
+    Sheet: Wrapper,
+    SheetContent: Wrapper,
+    SheetDescription: Wrapper,
+    SheetHeader: Wrapper,
+    SheetTitle: Wrapper,
+    SheetTrigger: Wrapper,
+  }
+})
+jest.mock("@/components/ui/alert-dialog", () => {
+  const Wrapper = ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  )
+  return {
+    AlertDialog: Wrapper,
+    AlertDialogAction: Wrapper,
+    AlertDialogCancel: Wrapper,
+    AlertDialogContent: Wrapper,
+    AlertDialogDescription: Wrapper,
+    AlertDialogFooter: Wrapper,
+    AlertDialogHeader: Wrapper,
+    AlertDialogTitle: Wrapper,
+    AlertDialogTrigger: Wrapper,
+  }
+})
+
+function client(
+  id: number,
+  clientName: string,
+  isFirstParty: boolean
+): OAuthClientRow {
+  const now = new Date("2026-07-24T12:00:00.000Z")
+  return {
+    id,
+    clientId: `client-${id}`,
+    clientName,
+    applicationType: "native",
+    redirectUris: ["org.example:/oauth/callback"],
+    allowedScopes: ["openid"],
+    grantTypes: ["authorization_code", "refresh_token"],
+    tokenEndpointAuthMethod: "none",
+    requirePkce: true,
+    accessTokenTtl: 900,
+    refreshTokenTtl: 86400,
+    isActive: true,
+    isFirstParty,
+    createdAt: now,
+    updatedAt: now,
+  }
+}
+
+describe("OAuth client trust administration", () => {
+  it("makes privileged first-party state visible in the admin list", () => {
+    render(
+      <OAuthClientsPageClient
+        initialClients={[
+          client(1, "Atrium Capture Mac", true),
+          client(2, "External App", false),
+        ]}
+      />
+    )
+
+    expect(screen.getByText("Atrium Capture Mac")).toBeInTheDocument()
+    expect(screen.getByText("First-party")).toBeInTheDocument()
+    expect(screen.getByText("External App")).toBeInTheDocument()
+    expect(screen.getByText("Standard")).toBeInTheDocument()
+  })
+})

--- a/tests/unit/oauth-first-party-migration.test.ts
+++ b/tests/unit/oauth-first-party-migration.test.ts
@@ -1,0 +1,58 @@
+import fs from "node:fs"
+import path from "node:path"
+
+const migrationPath = path.join(
+  process.cwd(),
+  "infra/database/schema/134-oauth-first-party-clients.sql"
+)
+const migration = fs.readFileSync(migrationPath, "utf8")
+
+describe("first-party OAuth client migration", () => {
+  it("adds a default-deny trust flag and public-client security invariant", () => {
+    expect(migration).toContain(
+      "is_first_party BOOLEAN NOT NULL DEFAULT false"
+    )
+    expect(migration).toContain(
+      "ADD CONSTRAINT oauth_clients_first_party_security"
+    )
+    expect(migration).toContain("token_endpoint_auth_method = 'none'")
+    expect(migration).toContain("client_secret_hash IS NULL")
+    expect(migration).toContain("require_pkce = true")
+  })
+
+  it("backfills only the two exact Atrium Capture client registrations", () => {
+    expect(migration).toContain(
+      "ae781263-20c0-4b0c-8a34-8be01ab72fb1"
+    )
+    expect(migration).toContain(
+      "fbdaa815-1b0f-435b-805f-1732805720c1"
+    )
+    expect(migration).toContain(
+      "https://jldnpmcpimhabiphcglkbgmbffpoocpo.chromiumapp.org/atrium"
+    )
+    expect(migration).toContain(
+      "org.psd401.atrium-capture:/oauth/callback"
+    )
+    expect(migration).not.toContain("client_name =")
+  })
+
+  it("writes the backfill audit and installs a future-change audit rule", () => {
+    expect(migration).toContain("oauth_client_trust_audit")
+    expect(migration).toContain(
+      "migration-134-exact-atrium-capture-backfill"
+    )
+    expect(migration).toContain(
+      "CREATE OR REPLACE RULE oauth_client_trust_audit_update"
+    )
+    expect(migration).toContain(
+      "CREATE OR REPLACE RULE oauth_client_trust_audit_insert"
+    )
+    expect(migration).toContain(
+      "DROP RULE IF EXISTS oauth_client_trust_audit_update"
+    )
+    expect(migration).toContain(
+      "NEW.is_first_party IS DISTINCT FROM OLD.is_first_party"
+    )
+    expect(migration).not.toContain("CREATE FUNCTION")
+  })
+})

--- a/tests/unit/oauth-first-party-migration.test.ts
+++ b/tests/unit/oauth-first-party-migration.test.ts
@@ -36,23 +36,31 @@ describe("first-party OAuth client migration", () => {
     expect(migration).not.toContain("client_name =")
   })
 
-  it("writes the backfill audit and installs a future-change audit rule", () => {
+  it("writes the backfill audit and installs upsert-safe audit triggers", () => {
     expect(migration).toContain("oauth_client_trust_audit")
     expect(migration).toContain(
       "migration-134-exact-atrium-capture-backfill"
     )
     expect(migration).toContain(
-      "CREATE OR REPLACE RULE oauth_client_trust_audit_update"
+      "CREATE OR REPLACE FUNCTION audit_oauth_client_first_party_insert()"
     )
     expect(migration).toContain(
-      "CREATE OR REPLACE RULE oauth_client_trust_audit_insert"
+      "CREATE OR REPLACE FUNCTION audit_oauth_client_first_party_update()"
+    )
+    expect(migration).toContain(
+      "CREATE TRIGGER trg_oauth_client_trust_audit_insert"
+    )
+    expect(migration).toContain(
+      "CREATE TRIGGER trg_oauth_client_trust_audit_update"
+    )
+    expect(migration).toContain(
+      "WHEN (NEW.is_first_party IS DISTINCT FROM OLD.is_first_party)"
     )
     expect(migration).toContain(
       "DROP RULE IF EXISTS oauth_client_trust_audit_update"
     )
-    expect(migration).toContain(
-      "NEW.is_first_party IS DISTINCT FROM OLD.is_first_party"
+    expect(migration).not.toContain(
+      "CREATE OR REPLACE RULE oauth_client_trust_audit"
     )
-    expect(migration).not.toContain("CREATE FUNCTION")
   })
 })

--- a/tests/unit/oauth-interaction-route.test.ts
+++ b/tests/unit/oauth-interaction-route.test.ts
@@ -1,0 +1,281 @@
+/** @jest-environment node */
+
+import type { ServerResponse } from "node:http"
+import type { NextRequest } from "next/server"
+import {
+  Headers as UndiciHeaders,
+  Request as UndiciRequest,
+  Response as UndiciResponse,
+} from "undici"
+
+Object.assign(globalThis, {
+  Headers: UndiciHeaders,
+  Request: UndiciRequest,
+  Response: UndiciResponse,
+})
+
+const mockInteractionDetails = jest.fn()
+const mockInteractionFinished = jest.fn(
+  async (...args: unknown[]): Promise<void> => {
+    const response = args[1] as ServerResponse
+    response.statusCode = 303
+    response.setHeader(
+      "Location",
+      "/api/oauth/auth/resume/provider-returned"
+    )
+    response.end()
+  }
+)
+const mockClientFind = jest.fn()
+
+class TestGrant {
+  static find = jest.fn()
+  readonly jti = "grant-created"
+  readonly accountId: string
+  readonly clientId: string
+  readonly addOIDCScope = jest.fn()
+  readonly addOIDCClaims = jest.fn()
+  readonly addResourceScope = jest.fn()
+  readonly save = jest.fn(async () => this.jti)
+
+  constructor(properties: { accountId: string; clientId: string }) {
+    this.accountId = properties.accountId
+    this.clientId = properties.clientId
+  }
+}
+
+const mockProvider = {
+  interactionDetails: mockInteractionDetails,
+  interactionFinished: mockInteractionFinished,
+  Client: { find: mockClientFind },
+  Grant: TestGrant,
+}
+
+jest.mock("server-only", () => ({}))
+jest.mock("@/lib/oauth/oidc-provider-config", () => ({
+  getOidcProvider: jest.fn(async () => mockProvider),
+}))
+jest.mock("@/lib/auth/server-session", () => ({
+  getServerSession: jest.fn(),
+}))
+jest.mock("@/lib/db/drizzle/utils", () => ({
+  getUserIdByCognitoSubAsNumber: jest.fn(),
+}))
+jest.mock("@/lib/oauth/consent-decisions", () => ({
+  consumeConsentDecision: jest.fn(),
+}))
+jest.mock("@/lib/logger", () => ({
+  generateRequestId: () => "request-id",
+  createLogger: () => ({
+    warn: jest.fn(),
+  }),
+}))
+
+import { getServerSession } from "@/lib/auth/server-session"
+import { getUserIdByCognitoSubAsNumber } from "@/lib/db/drizzle/utils"
+import { consumeConsentDecision } from "@/lib/oauth/consent-decisions"
+import { GET } from "@/app/(protected)/oauth/authorize/interaction/[uid]/[action]/route"
+
+const mockGetServerSession = jest.mocked(getServerSession)
+const mockGetUserId = jest.mocked(getUserIdByCognitoSubAsNumber)
+const mockConsumeDecision = jest.mocked(consumeConsentDecision)
+
+function request(action: string): NextRequest {
+  return new UndiciRequest(
+    `https://aistudio.example/oauth/authorize/interaction/interaction-1/${action}?account_id=999`,
+    { headers: { cookie: "_interaction=signed-cookie" } }
+  ) as unknown as NextRequest
+}
+
+function context(action: string) {
+  return {
+    params: Promise.resolve({
+      uid: "interaction-1",
+      action,
+    }),
+  }
+}
+
+describe("OAuth interaction completion route", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockGetServerSession.mockResolvedValue({ sub: "cognito-user" })
+    mockGetUserId.mockResolvedValue(42)
+    mockClientFind.mockResolvedValue({
+      clientId: "third-party-client",
+      scope: "openid profile content:read",
+    })
+    TestGrant.find.mockResolvedValue(undefined)
+  })
+
+  it("uses the authenticated server account for login, never a client value", async () => {
+    mockInteractionDetails.mockResolvedValue({
+      uid: "interaction-1",
+      prompt: { name: "login", details: {} },
+      params: { client_id: "atrium-client" },
+    })
+
+    const response = await GET(request("login"), context("login"))
+
+    expect(response.status).toBe(303)
+    expect(response.headers.get("location")).toBe(
+      "/api/oauth/auth/resume/provider-returned"
+    )
+    expect(mockInteractionFinished).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      { login: { accountId: "42" } },
+      { mergeWithLastSubmission: false }
+    )
+  })
+
+  it("sends a signed-out user through district login with the uid intact", async () => {
+    mockGetServerSession.mockResolvedValue(null)
+    mockInteractionDetails.mockResolvedValue({
+      uid: "interaction-1",
+      prompt: { name: "login", details: {} },
+      params: { client_id: "atrium-client" },
+    })
+
+    const response = await GET(request("login"), context("login"))
+
+    expect(response.status).toBe(303)
+    expect(response.headers.get("location")).toBe(
+      "/api/auth/signin?callbackUrl=%2Foauth%2Fauthorize%3Fuid%3Dinteraction-1"
+    )
+    expect(mockInteractionFinished).not.toHaveBeenCalled()
+  })
+
+  it("creates an untrusted-client consent grant from provider state", async () => {
+    mockInteractionDetails.mockResolvedValue({
+      uid: "interaction-1",
+      grantId: undefined,
+      session: { accountId: "42" },
+      prompt: {
+        name: "consent",
+        details: {
+          missingOIDCScope: ["openid", "profile"],
+          missingResourceScopes: {
+            "https://aistudio.example/api/oauth": ["content:read"],
+          },
+        },
+      },
+      params: { client_id: "third-party-client" },
+    })
+    mockConsumeDecision.mockResolvedValue({
+      approved: true,
+      userId: 42,
+      scopes: [],
+      createdAt: Date.now(),
+    })
+
+    const response = await GET(
+      request("consent"),
+      context("consent")
+    )
+
+    expect(response.status).toBe(303)
+    const result = mockInteractionFinished.mock.calls.at(-1)?.[2]
+    expect(result).toEqual({
+      consent: { grantId: "grant-created" },
+    })
+  })
+
+  it("fails closed when consent contains a scope absent from allowedScopes", async () => {
+    mockInteractionDetails.mockResolvedValue({
+      uid: "interaction-1",
+      session: { accountId: "42" },
+      prompt: {
+        name: "consent",
+        details: {
+          missingResourceScopes: {
+            "https://aistudio.example/api/oauth": ["content:update"],
+          },
+        },
+      },
+      params: { client_id: "third-party-client" },
+    })
+    mockConsumeDecision.mockResolvedValue({
+      approved: true,
+      userId: 42,
+      scopes: [],
+      createdAt: Date.now(),
+    })
+
+    const response = await GET(
+      request("consent"),
+      context("consent")
+    )
+
+    expect(response.status).toBe(400)
+    expect(mockInteractionFinished).not.toHaveBeenCalled()
+  })
+
+  it("fails closed when the client is inactive or unavailable", async () => {
+    mockClientFind.mockResolvedValue(undefined)
+    mockInteractionDetails.mockResolvedValue({
+      uid: "interaction-1",
+      session: { accountId: "42" },
+      prompt: {
+        name: "consent",
+        details: { missingOIDCScope: ["openid"] },
+      },
+      params: { client_id: "inactive-client" },
+    })
+    mockConsumeDecision.mockResolvedValue({
+      approved: true,
+      userId: 42,
+      scopes: [],
+      createdAt: Date.now(),
+    })
+
+    const response = await GET(
+      request("consent"),
+      context("consent")
+    )
+
+    expect(response.status).toBe(400)
+    expect(mockInteractionFinished).not.toHaveBeenCalled()
+  })
+
+  it("preserves denial through oidc-provider's public completion API", async () => {
+    mockInteractionDetails.mockResolvedValue({
+      uid: "interaction-1",
+      session: { accountId: "42" },
+      prompt: { name: "consent", details: {} },
+      params: { client_id: "third-party-client" },
+    })
+    mockConsumeDecision.mockResolvedValue({
+      approved: false,
+      userId: 42,
+      scopes: [],
+      createdAt: Date.now(),
+    })
+
+    const response = await GET(request("abort"), context("abort"))
+
+    expect(response.status).toBe(303)
+    expect(mockInteractionFinished).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      {
+        error: "access_denied",
+        error_description: "End-User denied authorization",
+      },
+      { mergeWithLastSubmission: false }
+    )
+  })
+
+  it("rejects a route uid that does not match the signed interaction", async () => {
+    mockInteractionDetails.mockResolvedValue({
+      uid: "different-interaction",
+      prompt: { name: "login", details: {} },
+      params: { client_id: "atrium-client" },
+    })
+
+    const response = await GET(request("login"), context("login"))
+
+    expect(response.status).toBe(400)
+    expect(mockInteractionFinished).not.toHaveBeenCalled()
+  })
+})

--- a/tests/unit/oauth-resume-route.test.ts
+++ b/tests/unit/oauth-resume-route.test.ts
@@ -1,0 +1,70 @@
+/** @jest-environment node */
+
+import type { NextRequest } from "next/server"
+import {
+  Headers as UndiciHeaders,
+  Request as UndiciRequest,
+  Response as UndiciResponse,
+} from "undici"
+
+Object.assign(globalThis, {
+  Headers: UndiciHeaders,
+  Request: UndiciRequest,
+  Response: UndiciResponse,
+})
+
+const resumeUid = "r".repeat(43)
+const providerCallback = jest.fn(
+  (
+    request: import("node:http").IncomingMessage,
+    response: import("node:http").ServerResponse
+  ) => {
+    expect(request.url).toBe(`/auth/${resumeUid}`)
+    response.statusCode = 303
+    response.setHeader(
+      "Location",
+      "org.psd401.atrium-capture:/oauth/callback?code=code&state=state"
+    )
+    response.end()
+  }
+)
+
+jest.mock("@/lib/oauth/oidc-provider-config", () => ({
+  getOidcProvider: jest.fn(async () => ({
+    callback: () => providerCallback,
+  })),
+}))
+jest.mock("@/lib/logger", () => ({
+  generateRequestId: () => "request-id",
+  createLogger: () => ({
+    warn: jest.fn(),
+  }),
+}))
+
+import { GET } from "@/app/auth/[uid]/route"
+
+describe("OIDC provider resume route", () => {
+  it("forwards the exact provider resume path and callback redirect", async () => {
+    const response = await GET(
+      new UndiciRequest(
+        `https://aistudio.example/auth/${resumeUid}`
+      ) as unknown as NextRequest
+    )
+
+    expect(response.status).toBe(303)
+    expect(response.headers.get("location")).toBe(
+      "org.psd401.atrium-capture:/oauth/callback?code=code&state=state"
+    )
+  })
+
+  it("rejects paths that are not provider resume identifiers", async () => {
+    const response = await GET(
+      new UndiciRequest(
+        "https://aistudio.example/auth/not-a-provider-uid"
+      ) as unknown as NextRequest
+    )
+
+    expect(response.status).toBe(404)
+    expect(providerCallback).toHaveBeenCalledTimes(1)
+  })
+})


### PR DESCRIPTION
## Summary

Promote the deployed and validated dev OAuth authorization fix to main for production deployment.

Includes:
- correct oidc-provider HTTP redirect/cookie forwarding
- explicit audited first-party trust for the existing Atrium Capture browser and Mac clients
- login-only first-party authorization with normal third-party consent preserved
- server-authenticated interaction completion, exact callback validation, and S256 PKCE enforcement
- migration 134 and real PostgreSQL upsert/audit regression coverage

Source implementation: #1327
Dev merge commit: d4d6fb8775a78269f448900dc4c9a8b059db16db

## Validation

- dev deployment completed
- PR #1327 CI, PostgreSQL lifecycle, CDK validation, CodeQL, SDK guard, and Claude review passed
- OAuth Jest: 90 tests passed
- OAuth public-client protocol smoke passed
- production build passed
- local pre-push Playwright: 266 passed, 33 intentionally skipped
