### PR TITLE
fix: provision Google Drive OAuth configuration in deployment

### DIFF
--- a/app/api/repositories/[repositoryId]/connectors/google/authorize/route.ts
+++ b/app/api/repositories/[repositoryId]/connectors/google/authorize/route.ts
@@ -75,14 +75,14 @@ export async function GET(
       },
     );
     timer({ status: "success" });
-    log.info("Personal Google Drive authorization started", {
+    log.info("Google Drive authorization started", {
       repositoryId,
       userId: manager.userId,
     });
     return NextResponse.redirect(authorizationUrl);
   } catch (error) {
     timer({ status: "error" });
-    log.warn("Personal Google Drive authorization rejected");
+    log.warn("Google Drive authorization rejected");
     return repositoryConnectorErrorResponse(error);
   }
 }

--- a/app/api/repositories/[repositoryId]/connectors/google/route.ts
+++ b/app/api/repositories/[repositoryId]/connectors/google/route.ts
@@ -1,79 +1,37 @@
-import { z } from "zod";
-import {
-  assertGoogleContentSyncEnabled,
-  listGoogleDriveConnectors,
-  requestGoogleDriveSync,
-  upsertSharedDriveConnector,
-} from "@/lib/repositories/google-drive/connector-service";
+import { listGoogleDriveConnectors } from "@/lib/repositories/google-drive/connector-service";
 import {
   repositoryConnectorErrorResponse,
   requireRepositoryConnectorManager,
-  requireSharedDriveConnectorAdministrator,
 } from "@/lib/repositories/google-drive/route-access";
 import { createLogger, generateRequestId, startTimer } from "@/lib/logger";
-import { checkUserRole } from "@/lib/db/drizzle";
-
-const sharedDriveSchema = z.object({
-  sharedDriveId: z.string().trim().min(1).max(256),
-  displayName: z.string().trim().min(1).max(255),
-});
 
 export async function GET(
   _request: Request,
   context: { params: Promise<{ repositoryId: string }> },
 ): Promise<Response> {
-  const timer = startTimer("googleContent.connectors.list");
-  try {
-    const repositoryId = Number((await context.params).repositoryId);
-    const manager = await requireRepositoryConnectorManager(repositoryId);
-    const [connectors, canConfigureSharedDrives] = await Promise.all([
-      listGoogleDriveConnectors(repositoryId, manager.userId),
-      checkUserRole(manager.userId, "administrator"),
-    ]);
-    timer({ status: "success", connectorCount: connectors.length });
-    return Response.json({ connectors, canConfigureSharedDrives });
-  } catch (error) {
-    timer({ status: "error" });
-    return repositoryConnectorErrorResponse(error);
-  }
-}
-
-export async function POST(
-  request: Request,
-  context: { params: Promise<{ repositoryId: string }> },
-): Promise<Response> {
   const requestId = generateRequestId();
-  const timer = startTimer("googleContent.connectors.sharedDrive.create");
+  const timer = startTimer("googleContent.connectors.list");
   const log = createLogger({
     requestId,
-    action: "googleContent.connectors.sharedDrive.create",
+    action: "googleContent.connectors.list",
   });
   try {
     const repositoryId = Number((await context.params).repositoryId);
     const manager = await requireRepositoryConnectorManager(repositoryId);
-    await requireSharedDriveConnectorAdministrator(manager);
-    await assertGoogleContentSyncEnabled();
-    const input = sharedDriveSchema.parse(await request.json());
-    const connectorId = await upsertSharedDriveConnector({
+    const connectors = await listGoogleDriveConnectors(
       repositoryId,
-      userId: manager.userId,
-      sharedDriveId: input.sharedDriveId,
-      displayName: input.displayName,
-    });
-    await requestGoogleDriveSync({
-      connectorId,
-      trigger: "initial",
-    }).catch(() => {});
-    timer({ status: "success" });
-    log.info("Shared Drive connector configured", {
+      manager.userId,
+    );
+    timer({ status: "success", connectorCount: connectors.length });
+    log.info("Google Drive connectors listed", {
       repositoryId,
-      connectorId,
+      connectorCount: connectors.length,
       userId: manager.userId,
     });
-    return Response.json({ connectorId }, { status: 201 });
+    return Response.json({ connectors });
   } catch (error) {
     timer({ status: "error" });
-    log.warn("Shared Drive connector configuration rejected");
+    log.warn("Google Drive connector list rejected");
     return repositoryConnectorErrorResponse(error);
   }
 }

--- a/app/api/repositories/connectors/google/callback/route.ts
+++ b/app/api/repositories/connectors/google/callback/route.ts
@@ -137,7 +137,7 @@ export async function GET(request: Request): Promise<Response> {
       // worker will recover a transient SQS dispatch failure.
     });
     timer({ status: "success" });
-    log.info("Personal Google Drive connector authorized", {
+    log.info("Google Drive connector authorized", {
       repositoryId,
       connectorId,
       userId: manager.userId,
@@ -145,7 +145,7 @@ export async function GET(request: Request): Promise<Response> {
     return NextResponse.redirect(completionUrl(repositoryId, "connected"));
   } catch {
     timer({ status: "error" });
-    log.warn("Personal Google Drive callback rejected", { repositoryId });
+    log.warn("Google Drive callback rejected", { repositoryId });
     return NextResponse.redirect(completionUrl(repositoryId, "failed"));
   }
 }

--- a/components/features/repositories/google-drive-connector-panel.tsx
+++ b/components/features/repositories/google-drive-connector-panel.tsx
@@ -12,8 +12,6 @@ import {
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
 import { useToast } from "@/components/ui/use-toast";
 import type { GoogleDriveConnectorView } from "@/lib/repositories/google-drive/connector-service";
 
@@ -132,12 +130,8 @@ export function GoogleDriveConnectorPanel({
   const { toast } = useToast();
   const [connectors, setConnectors] = useState<GoogleDriveConnectorView[]>([]);
   const [isLoading, setIsLoading] = useState(true);
-  const [canConfigureSharedDrives, setCanConfigureSharedDrives] =
-    useState(false);
   const [pendingAction, setPendingAction] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
-  const [sharedDriveId, setSharedDriveId] = useState("");
-  const [sharedDriveName, setSharedDriveName] = useState("");
 
   const loadConnectors = useCallback(async () => {
     setIsLoading(true);
@@ -149,14 +143,12 @@ export function GoogleDriveConnectorPanel({
       );
       const payload = (await response.json()) as {
         connectors?: GoogleDriveConnectorView[];
-        canConfigureSharedDrives?: boolean;
         error?: string;
       };
       if (!response.ok) {
         throw new Error(payload.error || "Failed to load Drive connections");
       }
       setConnectors(payload.connectors ?? []);
-      setCanConfigureSharedDrives(payload.canConfigureSharedDrives === true);
     } catch (loadError) {
       setError(
         loadError instanceof Error
@@ -270,42 +262,6 @@ export function GoogleDriveConnectorPanel({
     }
   }
 
-  async function addSharedDrive() {
-    setPendingAction("shared-drive");
-    try {
-      const response = await postJson(
-        `/api/repositories/${repositoryId}/connectors/google`,
-        {
-          sharedDriveId,
-          displayName: sharedDriveName,
-        },
-      );
-      const result = (await response.json()) as { error?: string };
-      if (!response.ok) {
-        throw new Error(result.error || "Failed to connect Shared Drive");
-      }
-      setSharedDriveId("");
-      setSharedDriveName("");
-      toast({
-        title: "Shared Drive queued",
-        description:
-          "The fixed sync identity will verify access and begin reconciliation.",
-      });
-      await loadConnectors();
-    } catch (sharedDriveError) {
-      toast({
-        title: "Shared Drive connection failed",
-        description:
-          sharedDriveError instanceof Error
-            ? sharedDriveError.message
-            : "Failed to connect Shared Drive",
-        variant: "destructive",
-      });
-    } finally {
-      setPendingAction(null);
-    }
-  }
-
   async function syncConnector(connectorId: string) {
     setPendingAction(`sync:${connectorId}`);
     try {
@@ -393,10 +349,10 @@ export function GoogleDriveConnectorPanel({
       <div className="rounded-md border p-4">
         <div className="flex items-start justify-between gap-3">
           <div>
-            <h3 className="font-medium">Personal Google Drive</h3>
+            <h3 className="font-medium">Google Drive</h3>
             <p className="text-sm text-muted-foreground">
-              Connect with read-only access, then explicitly choose files or
-              folders to keep synchronized.
+              Connect with read-only access, then choose files or folders from
+              My Drive or Shared Drives that you can already access.
             </p>
           </div>
           {personalConnector ? (
@@ -425,56 +381,6 @@ export function GoogleDriveConnectorPanel({
           )}
         </div>
       </div>
-
-      {canConfigureSharedDrives && (
-        <div className="rounded-md border p-4">
-          <h3 className="font-medium">Shared Drive</h3>
-          <p className="mb-3 text-sm text-muted-foreground">
-            Add{" "}
-            <code className="break-all text-xs">
-              unified-content-sync@psd-aistudio-broker.iam.gserviceaccount.com
-            </code>{" "}
-            as a Viewer, then enter the Shared Drive ID below. No
-            service-account key or domain-wide delegation is used.
-          </p>
-          <div className="grid gap-3 sm:grid-cols-2">
-            <div className="space-y-1">
-              <Label htmlFor="shared-drive-name">Display name</Label>
-              <Input
-                id="shared-drive-name"
-                value={sharedDriveName}
-                onChange={(event) => setSharedDriveName(event.target.value)}
-                placeholder="Curriculum Shared Drive"
-              />
-            </div>
-            <div className="space-y-1">
-              <Label htmlFor="shared-drive-id">Shared Drive ID</Label>
-              <Input
-                id="shared-drive-id"
-                value={sharedDriveId}
-                onChange={(event) => setSharedDriveId(event.target.value)}
-                placeholder="0AExampleDriveId"
-              />
-            </div>
-          </div>
-          <Button
-            type="button"
-            variant="outline"
-            className="mt-3"
-            disabled={
-              pendingAction !== null ||
-              !sharedDriveId.trim() ||
-              !sharedDriveName.trim()
-            }
-            onClick={() => void addSharedDrive()}
-          >
-            {pendingAction === "shared-drive" && (
-              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-            )}
-            Connect Shared Drive
-          </Button>
-        </div>
-      )}
 
       {connectors.length > 0 && (
         <div className="space-y-2">

--- a/docs/README.md
+++ b/docs/README.md
@@ -174,7 +174,7 @@ AI integration patterns using Vercel AI SDK v6, provider factory implementation,
 
 **[Unified repository product integration](./features/unified-repository-product-integration.md)** — Authoritative Repository Manager source/ACL/version UI, Assistant Architect repository-only knowledge, Nexus private ephemeral attachments, promotion, retention, and rollback boundaries.
 
-**[Google Workspace content synchronization](./features/google-workspace-content-sync.md)** — Personal PKCE OAuth, Picker selection, keyless Shared Drive WIF, durable cursor/version reconciliation, deletion grace, deployment, and operations.
+**[Google Workspace content synchronization](./features/google-workspace-content-sync.md)** — PKCE OAuth and Picker selection across My Drive and user-accessible Shared Drives, durable cursor/version reconciliation, deployment-owned configuration, deletion grace, and operations.
 
 #### [features/navigation.md](./features/navigation.md)
 Dynamic navigation system with role-based menu items.

--- a/docs/features/google-workspace-content-sync.md
+++ b/docs/features/google-workspace-content-sync.md
@@ -22,31 +22,19 @@ existing AES-256-GCM token DEK and stored separately from connector/source
 metadata. Picker access tokens are short lived, returned only to the connector
 owner, sent with `Cache-Control: no-store`, and never logged.
 
-Shared Drives use the fixed keyless identity delivered by
-`psd401/psd-gcp-infra#1`:
-
-| Contract               | Value                                                                                    |
-| ---------------------- | ---------------------------------------------------------------------------------------- |
-| Service account        | `unified-content-sync@psd-aistudio-broker.iam.gserviceaccount.com`                       |
-| GCP project number     | `1022506104054`                                                                          |
-| Workload Identity Pool | `aws-agent-broker`                                                                       |
-| Provider               | `content-sync`                                                                           |
-| Trusted AWS roles      | `unified-content-sync-execution-role-dev` and `unified-content-sync-execution-role-prod` |
-
-The worker uses ambient Lambda credentials for AWS-to-GCP federation and service
-account impersonation. It has no service-account key and no domain-wide
-delegation. A Shared Drive administrator must add the service account as a
-Viewer before an AI Studio administrator configures the Drive ID in Repository
-Manager. Because WIF uses a shared application identity, Shared Drive creation
-is restricted to the AI Studio `administrator` role; this prevents a repository
-owner from using that identity to read a Drive they cannot access directly.
+The same user OAuth and Picker flow covers both My Drive and Shared Drives. A
+user may select only files, folders, and drives that Google reports as
+accessible to that user. AI Studio never asks a customer to grant access to an
+AI Studio service account or paste a Shared Drive ID. `supportsAllDrives` and
+`includeItemsFromAllDrives` are set on the Drive API calls used after selection.
 
 A repository owner or administrator with the `knowledge-repositories` UI
-capability may configure personal OAuth, choose personal sources, retry, and
-disconnect. Shared Drive setup additionally requires the `administrator` role
-and is hidden from other managers. The repository management check is repeated
-on list, Picker, selection, retry, and disconnect routes. This is a human UI
-capability boundary, not an API key scope.
+capability may connect Google Drive, select accessible sources, retry, and
+disconnect. The repository management check is repeated on list, Picker,
+selection, retry, and disconnect routes. This is a human UI capability
+boundary, not an API key scope. The worker retains read support for legacy WIF
+connector records during migration, but Repository Manager no longer creates
+that connector type.
 
 ## Synchronization model
 
@@ -113,27 +101,37 @@ an `unsupported` source status instead of silently disappearing.
 Deploy in this order:
 
 1. apply additive migration `136-google-content-connectors.sql`;
-2. deploy the Processing stack (queue, DLQ, isolated worker/WIF role, schedule,
+2. deploy the Auth stack so it creates the complete
+   `aistudio/{environment}/google-content-oauth` secret;
+3. deploy the Processing stack (queue, DLQ, isolated worker role, schedule,
    alarms, and queue exports);
-3. deploy the Frontend stack so ECS receives
+4. deploy the Frontend stack so ECS receives
    `GOOGLE_CONTENT_SYNC_QUEUE_URL`; and
-4. enable `CONTENT_PLATFORM_ENABLED` and
+5. enable `CONTENT_PLATFORM_ENABLED` and
    `GOOGLE_CONTENT_SYNC_ENABLED` for the intended environment.
 
 The scheduled next-run delay is controlled by
 `GOOGLE_CONTENT_SYNC_INTERVAL_MINUTES`; deferred long-running downloads retry
 after one minute.
 
-Create `aistudio/{environment}/google-content-oauth` in Secrets Manager with:
+`AuthStack` creates and retains
+`aistudio/{environment}/google-content-oauth` with this runtime contract:
 
 ```json
 {
   "clientId": "google-oauth-client-id",
   "clientSecret": "google-oauth-client-secret",
   "pickerApiKey": "browser-key-restricted-to-the-ai-studio-origin",
-  "appId": "1022506104054"
+  "appId": "google-cloud-project-number-derived-from-client-id"
 }
 ```
+
+Deployment supplies the existing `GoogleClientId` and the browser-restricted
+`GooglePickerApiKey` CloudFormation parameters. The existing
+`aistudio-{environment}-google-oauth` secret remains the source of the client
+secret. CloudFormation assembles the content secret; operators must not create
+or edit it manually. `infra/deploy-dev.sh` requires `GOOGLE_PICKER_API_KEY` and
+passes both parameters to the Auth stack.
 
 Register this exact callback for each environment:
 
@@ -143,8 +141,8 @@ https://<ai-studio-origin>/api/repositories/connectors/google/callback
 
 Restrict the Picker browser key to the corresponding HTTPS origin and Google
 Picker/Drive APIs. The OAuth client, consent screen, domain verification, and
-callback registration are administrator-controlled console steps; no secret
-value belongs in CDK, source control, a connector row, or a worker message.
+callback registration remain Google Cloud configuration; no credential value
+belongs in source control, a connector row, or a worker message.
 
 The worker alarms on Lambda errors, messages older than 30 minutes, and any DLQ
 record. Repository Manager shows connector status, last success, last error,
@@ -162,9 +160,10 @@ versions. Do not remove migration 136 or delete connector records as a rollback.
   Drive metadata/cursor contracts, export mappings, and resumable Vids
   operations.
 - `tests/unit/lib/repositories/google-drive-oauth.test.ts` covers PKCE and
-  fail-closed scope validation.
-- `tests/unit/lib/repositories/google-drive-route-access.test.ts` proves the
-  common WIF identity can only be configured by an AI Studio administrator.
+  fail-closed scope validation plus sanitized missing/malformed deployment
+  configuration errors.
+- `tests/unit/lib/repositories/google-drive-route-access.test.ts` covers the
+  capability/repository authorization boundary and sanitized 503 response.
 - `tests/unit/lib/repositories/google-drive-selections-route.test.ts` and
   `google-drive-bounded-concurrency.test.ts` prove per-user throttling, bounded
   provider fanout, and stable selection ordering.
@@ -177,9 +176,12 @@ versions. Do not remove migration 136 or delete connector records as a rollback.
   creator-deletion cleanup.
 - `infra/lambdas/google-content-sync/__tests__/safety.test.ts` proves metadata,
   response, and in-flight byte limits plus finite snapshot budgets.
-- `infra/test/unit/google-content-sync.test.ts` synthesizes the exact WIF role,
-  least-privilege object/queue policies, scheduled queue dispatch, queue/DLQ,
-  and alarms.
+- `infra/test/unit/google-content-oauth-secret.test.ts` proves the Auth stack
+  requires the Picker key and creates the retained, complete runtime secret
+  from deployment-owned inputs.
+- `infra/test/unit/google-content-sync.test.ts` synthesizes the isolated worker
+  role, exact OAuth secret grant, least-privilege object/queue policies,
+  scheduled queue dispatch, queue/DLQ, and alarms.
 - `tests/e2e/unified-content-product-migration.functional.spec.ts` covers
   unauthenticated route guards, public token-authenticated webhook reachability,
   and the authenticated personal/Shared Drive Repository Manager UI without

--- a/docs/features/unified-repository-product-integration.md
+++ b/docs/features/unified-repository-product-integration.md
@@ -19,8 +19,8 @@ preselected destination. The source modal currently supports:
 - canonical direct-to-S3 single or multipart file upload;
 - URL sources through the repository URL processor;
 - inline text with a canonical immutable-version shadow write; and
-- personal Google Drive file/folder selection and keyless Shared Drive
-  synchronization through the connector boundary in
+- Google Drive file/folder selection from My Drive or user-accessible Shared
+  Drives through the same OAuth Picker connector boundary in
   [#1262](google-workspace-content-sync.md).
 
 The canonical browser helper uploads bytes directly to a signed object-storage

--- a/docs/plans/2026-07-21-unified-content-platform.md
+++ b/docs/plans/2026-07-21-unified-content-platform.md
@@ -1132,3 +1132,35 @@ deployment runbook records migration-first ordering, OAuth secret
 shape/callback registration, flags, rollback, alarms, and the labeled live
 create/edit/move/delete/access-loss/notification-resume matrix required after
 dev deployment.
+
+#### Deployment remediation checkpoint (2026-07-25)
+
+Dev verification exposed two delivery defects after the original #1262 merge:
+the application depended on an operator-created
+`aistudio/dev/google-content-oauth` secret that the CDK deployment did not
+create, and Repository Manager presented Shared Drive WIF as a separate setup
+that required customers to grant an AI Studio service account access. Both
+contradicted the intended deployable, user-authorized connector boundary.
+
+The remediation moves the complete Google content OAuth secret into AuthStack.
+Deployment now requires the browser-restricted Picker key alongside the
+existing Google client ID, reads the client secret from the existing
+environment OAuth secret, derives Picker's app ID from the client ID's owning
+Google Cloud project, and creates the exact retained secret consumed by the web
+app and worker. ProcessingStack depends on AuthStack and grants the worker only
+that exact secret ARN. Missing or malformed runtime configuration returns a
+sanitized service-unavailable response without leaking AWS provider details.
+
+Repository Manager now exposes one Google Drive OAuth/Picker flow for My Drive
+and Shared Drives already accessible to the connecting user. The service-account
+email/Drive-ID form and its POST route were removed. Legacy WIF connector rows
+remain readable by the worker for backward compatibility, but no new WIF
+connector can be created through the product. Focused OAuth and CDK regression
+tests cover sanitized failure handling, required deployment inputs, secret
+shape, retention, app-ID derivation, exact IAM scope, and the updated
+authenticated UI. The remediation gate passed whole-repository typecheck and
+lint (zero errors; 411 existing warnings), all 353 application Jest suites with
+3,494 tests passing (3 suites/26 tests skipped), all 43 infrastructure suites
+with 406 tests, both production builds, full CDK synthesis, deploy-script
+preflight, the authenticated Repository Manager Playwright case, final diff
+checks, and a complete diff-scoped security review with no reportable findings.

--- a/infra/DEPLOYMENT_COMMANDS.md
+++ b/infra/DEPLOYMENT_COMMANDS.md
@@ -4,13 +4,13 @@
 
 ### Parameters Required by Each Stack:
 
-| Stack | GoogleClientId | baseDomain | Notes |
-|-------|---------------|------------|-------|
-| DatabaseStack | ❌ | ❌ | No parameters needed |
-| AuthStack | ✅ | ✅ (indirect) | Needs GoogleClientId parameter, baseDomain used for callback URLs |
-| StorageStack | ❌ | ❌ | No parameters needed |
-| ProcessingStack | ❌ | ❌ | No parameters needed |
-| FrontendStack | ❌ | ✅ | Only created when baseDomain is provided |
+| Stack | GoogleClientId | GooglePickerApiKey | baseDomain | Notes |
+|-------|---------------|--------------------|------------|-------|
+| DatabaseStack | ❌ | ❌ | ❌ | No parameters needed |
+| AuthStack | ✅ | ✅ | ✅ (indirect) | Creates the application OAuth/Picker secret; baseDomain is used for callback URLs |
+| StorageStack | ❌ | ❌ | ❌ | No parameters needed |
+| ProcessingStack | ❌ | ❌ | ❌ | Depends on the AuthStack content OAuth secret |
+| FrontendStack | ❌ | ❌ | ✅ | Only created when baseDomain is provided |
 
 ## Full Deployment Commands
 
@@ -19,10 +19,12 @@
 # With all required parameters
 bunx cdk deploy --all \
   --parameters AIStudio-AuthStack-Dev:GoogleClientId=YOUR_GOOGLE_CLIENT_ID \
+  --parameters AIStudio-AuthStack-Dev:GooglePickerApiKey=YOUR_RESTRICTED_PICKER_KEY \
   --context baseDomain=aistudio.psd401.ai
 
 # Or use the helper script
-./deploy-dev.sh YOUR_GOOGLE_CLIENT_ID aistudio.psd401.ai
+GOOGLE_PICKER_API_KEY=YOUR_RESTRICTED_PICKER_KEY \
+  ./deploy-dev.sh YOUR_GOOGLE_CLIENT_ID aistudio.psd401.ai
 ```
 
 ### Deploy All Stacks (Prod Environment)
@@ -32,8 +34,9 @@ bunx cdk deploy \
   AIStudio-AuthStack-Prod \
   AIStudio-StorageStack-Prod \
   AIStudio-ProcessingStack-Prod \
-  AIStudio-FrontendStack-Prod \
+  AIStudio-FrontendStack-ECS-Prod \
   --parameters AIStudio-AuthStack-Prod:GoogleClientId=YOUR_PROD_GOOGLE_CLIENT_ID \
+  --parameters AIStudio-AuthStack-Prod:GooglePickerApiKey=YOUR_PROD_RESTRICTED_PICKER_KEY \
   --context baseDomain=aistudio.psd401.ai
 ```
 
@@ -48,17 +51,19 @@ bunx cdk deploy AIStudio-DatabaseStack-Dev --exclusively
 bunx cdk deploy AIStudio-DatabaseStack-Prod --exclusively
 ```
 
-### AuthStack (Requires GoogleClientId)
+### AuthStack (Requires GoogleClientId and GooglePickerApiKey)
 ```bash
 # Dev
 bunx cdk deploy AIStudio-AuthStack-Dev \
   --parameters AIStudio-AuthStack-Dev:GoogleClientId=YOUR_GOOGLE_CLIENT_ID \
+  --parameters AIStudio-AuthStack-Dev:GooglePickerApiKey=YOUR_RESTRICTED_PICKER_KEY \
   --context baseDomain=aistudio.psd401.ai \
   --exclusively
 
 # Prod
 bunx cdk deploy AIStudio-AuthStack-Prod \
   --parameters AIStudio-AuthStack-Prod:GoogleClientId=YOUR_PROD_GOOGLE_CLIENT_ID \
+  --parameters AIStudio-AuthStack-Prod:GooglePickerApiKey=YOUR_PROD_RESTRICTED_PICKER_KEY \
   --context baseDomain=aistudio.psd401.ai \
   --exclusively
 ```
@@ -91,12 +96,12 @@ focused ProcessingStack deployment never creates or removes subscriptions.
 ### FrontendStack (Requires baseDomain)
 ```bash
 # Dev
-bunx cdk deploy AIStudio-FrontendStack-Dev \
+bunx cdk deploy AIStudio-FrontendStack-ECS-Dev \
   --context baseDomain=aistudio.psd401.ai \
   --exclusively
 
 # Prod
-bunx cdk deploy AIStudio-FrontendStack-Prod \
+bunx cdk deploy AIStudio-FrontendStack-ECS-Prod \
   --context baseDomain=aistudio.psd401.ai \
   --exclusively
 ```
@@ -109,23 +114,30 @@ bunx cdk deploy AIStudio-FrontendStack-Prod \
 - Different IDs for dev/prod environments
 - Stored in Secrets Manager as `aistudio-dev-google-oauth` and `aistudio-prod-google-oauth`
 
-### 2. Base Domain
+### 2. Google Picker API Key
+- Required for AuthStack only
+- Use a browser key restricted to the environment's exact HTTPS origin and the Google Picker/Drive APIs
+- Passed as a NoEcho CloudFormation parameter; never commit it or place it in a shell script
+- AuthStack combines it with the existing client ID/client secret in the retained `aistudio/{environment}/google-content-oauth` secret
+
+### 3. Base Domain
 - Required when deploying FrontendStack
 - Used by AuthStack for callback URLs (passed via context)
 - If not provided, FrontendStack won't be created
 
-### 3. First Deployment After SSM Changes
+### 4. First Deployment After OAuth Deployment Changes
 ```bash
 # Deploy all at once to ensure SSM parameters are created
 bunx cdk deploy --all \
   --parameters AIStudio-AuthStack-Dev:GoogleClientId=YOUR_GOOGLE_CLIENT_ID \
+  --parameters AIStudio-AuthStack-Dev:GooglePickerApiKey=YOUR_RESTRICTED_PICKER_KEY \
   --context baseDomain=aistudio.psd401.ai
 ```
 
-### 4. Deployment Order (if deploying individually)
+### 5. Deployment Order (if deploying individually)
 1. DatabaseStack & StorageStack (can be parallel, no dependencies)
-2. AuthStack (no dependencies, but needs GoogleClientId)
-3. ProcessingStack (depends on SSM from Database & Storage)
+2. AuthStack (needs GoogleClientId and GooglePickerApiKey)
+3. ProcessingStack (depends on Database, Storage, and the AuthStack content OAuth secret)
 4. FrontendStack (depends on SSM from Storage, needs baseDomain)
 
 ## Quick Reference
@@ -134,17 +146,19 @@ bunx cdk deploy --all \
 
 ```bash
 # Deploy everything (dev)
-./deploy-dev.sh YOUR_GOOGLE_CLIENT_ID aistudio.psd401.ai
+GOOGLE_PICKER_API_KEY=YOUR_RESTRICTED_PICKER_KEY \
+  ./deploy-dev.sh YOUR_GOOGLE_CLIENT_ID aistudio.psd401.ai
 
 # Update just the database
 bunx cdk deploy AIStudio-DatabaseStack-Dev --exclusively
 
 # Update just the frontend
-bunx cdk deploy AIStudio-FrontendStack-Dev --context baseDomain=aistudio.psd401.ai --exclusively
+bunx cdk deploy AIStudio-FrontendStack-ECS-Dev --context baseDomain=aistudio.psd401.ai --exclusively
 
 # Update auth (if Google OAuth changes)
 bunx cdk deploy AIStudio-AuthStack-Dev \
   --parameters AIStudio-AuthStack-Dev:GoogleClientId=NEW_GOOGLE_CLIENT_ID \
+  --parameters AIStudio-AuthStack-Dev:GooglePickerApiKey=YOUR_RESTRICTED_PICKER_KEY \
   --context baseDomain=aistudio.psd401.ai \
   --exclusively
 ```

--- a/infra/DEPLOYMENT_SAFETY_CHECKLIST.md
+++ b/infra/DEPLOYMENT_SAFETY_CHECKLIST.md
@@ -16,10 +16,16 @@ Based on the test output:
 
 3. **ProcessingStack-Dev**:
    - ✅ Adds SSM parameter lookups (backward compatible)
+   - ✅ Reads the exact deployment-owned Google content OAuth secret ARN
    - ✅ IAM policy update (normal)
    - ❌ No resources deleted
 
-4. **FrontendStack-Dev**:
+4. **AuthStack-Dev**:
+   - ✅ Creates and retains `aistudio/dev/google-content-oauth`
+   - ✅ Requires the browser-restricted Picker API key at deploy time
+   - ❌ Does not require a manually created content OAuth secret
+
+5. **FrontendStack-Dev**:
    - ✅ Adds SSM parameter lookup (backward compatible)
    - ✅ IAM role update to reference SSM parameter
    - ❌ No resources deleted
@@ -27,7 +33,7 @@ Based on the test output:
 ### ✅ Safety Guarantees
 
 1. **No Breaking Changes**:
-   - All changes are additive (new SSM parameters)
+   - Infrastructure changes are additive (new SSM parameters and retained secret)
    - Existing CloudFormation exports remain
    - Props made optional for backward compatibility
 
@@ -38,32 +44,37 @@ Based on the test output:
 
 3. **Application Continuity**:
    - Running applications continue to work
-   - No environment variable changes
+   - No manually populated application secret
    - No database or storage changes
 
 ## Deployment Steps
 
 ### Option 1: Safe Full Deployment (Recommended)
 ```bash
-# Deploy all stacks together to ensure SSM parameters are created
-bunx cdk deploy --all --context baseDomain=aistudio.psd401.ai
+# Deploy all stacks together to ensure parameters and the OAuth secret are created
+GOOGLE_PICKER_API_KEY=YOUR_RESTRICTED_PICKER_KEY \
+  ./deploy-dev.sh YOUR_GOOGLE_CLIENT_ID aistudio.psd401.ai
 
 # This will:
 # 1. Create SSM parameters in Database and Storage stacks
-# 2. Update Processing and Frontend stacks to use them
-# 3. Maintain all existing functionality
+# 2. Create the complete Google content OAuth secret in AuthStack
+# 3. Update Processing and Frontend stacks to use those resources
+# 4. Maintain all existing functionality
 ```
 
 ### Option 2: Staged Deployment (More Control)
 ```bash
-# 1. Deploy stacks that create SSM parameters first
-bunx cdk deploy AIStudio-DatabaseStack-Dev AIStudio-StorageStack-Dev --context baseDomain=aistudio.psd401.ai
+# 1. Deploy stacks that create shared parameters and the OAuth secret first
+bunx cdk deploy AIStudio-DatabaseStack-Dev AIStudio-StorageStack-Dev AIStudio-AuthStack-Dev \
+  --parameters AIStudio-AuthStack-Dev:GoogleClientId=YOUR_GOOGLE_CLIENT_ID \
+  --parameters AIStudio-AuthStack-Dev:GooglePickerApiKey=YOUR_RESTRICTED_PICKER_KEY \
+  --context baseDomain=aistudio.psd401.ai
 
 # 2. Verify SSM parameters were created
 aws ssm get-parameters-by-path --path '/aistudio/dev' --recursive
 
 # 3. Deploy stacks that consume SSM parameters
-bunx cdk deploy AIStudio-ProcessingStack-Dev AIStudio-FrontendStack-Dev \
+bunx cdk deploy AIStudio-ProcessingStack-Dev AIStudio-FrontendStack-ECS-Dev \
   --context baseDomain=aistudio.psd401.ai
 ```
 
@@ -96,7 +107,18 @@ aws amplify get-app --app-id $(aws amplify list-apps --query 'apps[?name==`aistu
 aws lambda list-functions --query 'Functions[?starts_with(FunctionName, `AIStudio-ProcessingStack-Dev`)].FunctionName'
 ```
 
-### 3. Test Independent Stack Deployment
+### 3. Verify Deployment-Owned OAuth Configuration
+```bash
+aws secretsmanager describe-secret \
+  --secret-id aistudio/dev/google-content-oauth \
+  --query '{Name:Name,Arn:ARN,Tags:Tags}'
+```
+
+Do not print the secret value. Verify Google Drive connect reaches the Google
+consent screen, and Picker displays both My Drive and Shared Drives accessible
+to the signed-in user.
+
+### 4. Test Independent Stack Deployment
 ```bash
 # After initial deployment, test updating a single stack
 bunx cdk deploy AIStudio-DatabaseStack-Dev --exclusively --context baseDomain=aistudio.psd401.ai
@@ -131,6 +153,7 @@ bunx cdk deploy AIStudio-DatabaseStack-Dev --exclusively --context baseDomain=ai
 
 ✅ All stacks show UPDATE_COMPLETE status
 ✅ SSM parameters exist in Parameter Store  
+✅ `aistudio/dev/google-content-oauth` exists and is tagged as CDK-managed
 ✅ Application remains accessible
 ✅ No CloudFormation rollbacks
 ✅ Future deployments can use --exclusively flag

--- a/infra/README.md
+++ b/infra/README.md
@@ -92,33 +92,47 @@ Deploy stacks in dependency order:
 
 ```bash
 cd infra
+export GOOGLE_CLIENT_ID=YOUR_GOOGLE_CLIENT_ID
+export GOOGLE_PICKER_API_KEY=YOUR_BROWSER_RESTRICTED_PICKER_KEY
 
 # 1. Database (creates VPC + Aurora)
 bunx cdk deploy AIStudio-DatabaseStack-Dev
 
-# 2. Auth (creates Cognito)
-bunx cdk deploy AIStudio-AuthStack-Dev
+# 2. Auth (creates Cognito and the Google content OAuth/Picker secret)
+bunx cdk deploy AIStudio-AuthStack-Dev \
+  --parameters AIStudio-AuthStack-Dev:GoogleClientId=$GOOGLE_CLIENT_ID \
+  --parameters AIStudio-AuthStack-Dev:GooglePickerApiKey=$GOOGLE_PICKER_API_KEY
 
 # 3. Storage (creates S3 buckets)
 bunx cdk deploy AIStudio-StorageStack-Dev
 
-# 4. Document Processing (creates Lambdas)
+# 4. Processing (creates Google content sync and other processing workers)
+bunx cdk deploy AIStudio-ProcessingStack-Dev
+
+# 5. Document Processing (creates Lambdas)
 bunx cdk deploy AIStudio-DocumentProcessingStack-Dev
 
-# 5. Frontend (creates ECS + ALB)
-bunx cdk deploy AIStudio-FrontendStack-Dev
+# 6. Frontend (creates ECS + ALB)
+bunx cdk deploy AIStudio-FrontendStack-ECS-Dev
 
-# 6. Scheduling (creates EventBridge)
+# 7. Scheduling (creates EventBridge)
 bunx cdk deploy AIStudio-SchedulingStack-Dev
 
-# 7. Monitoring (creates CloudWatch dashboards)
+# 8. Monitoring (creates CloudWatch dashboards)
 bunx cdk deploy AIStudio-MonitoringStack-Dev
 ```
 
 **Or deploy all at once:**
 ```bash
-bunx cdk deploy --all --require-approval never
+bunx cdk deploy --all \
+  --parameters AIStudio-AuthStack-Dev:GoogleClientId=$GOOGLE_CLIENT_ID \
+  --parameters AIStudio-AuthStack-Dev:GooglePickerApiKey=$GOOGLE_PICKER_API_KEY \
+  --require-approval never
 ```
+
+The Picker key must be restricted to the environment's exact browser origin
+and the Google Picker/Drive APIs. AuthStack assembles the retained
+`aistudio/dev/google-content-oauth` secret; do not create it manually.
 
 ### Subsequent Deployments
 
@@ -126,13 +140,13 @@ Deploy only changed stacks:
 
 ```bash
 # Check what changed
-bunx cdk diff AIStudio-FrontendStack-Dev
+bunx cdk diff AIStudio-FrontendStack-ECS-Dev
 
 # Deploy single stack
-bunx cdk deploy AIStudio-FrontendStack-Dev
+bunx cdk deploy AIStudio-FrontendStack-ECS-Dev
 
 # Deploy multiple specific stacks
-bunx cdk deploy AIStudio-FrontendStack-Dev AIStudio-DatabaseStack-Dev
+bunx cdk deploy AIStudio-FrontendStack-ECS-Dev AIStudio-DatabaseStack-Dev
 ```
 
 ## CDK Commands

--- a/infra/bin/infra.ts
+++ b/infra/bin/infra.ts
@@ -240,11 +240,13 @@ Object.entries(standardTags).forEach(([key, value]) => cdk.Tags.of(devAgentPlatf
 
 const devProcessingStack = new ProcessingStack(app, 'AIStudio-ProcessingStack-Dev', {
   environment: 'dev',
+  googleContentOAuthSecretArn: devAuthStack.googleContentOAuthSecret.secretArn,
   appBaseUrl: baseDomain ? `https://dev.${baseDomain}` : undefined,
   env: { account: process.env.CDK_DEFAULT_ACCOUNT, region: process.env.CDK_DEFAULT_REGION },
 });
 devProcessingStack.addDependency(devDbStack); // Reads database SSM parameters and uses the shared VPC
 devProcessingStack.addDependency(devStorageStack); // Reads the documents bucket SSM parameter
+devProcessingStack.addDependency(devAuthStack); // Owns Google content OAuth configuration
 cdk.Tags.of(devProcessingStack).add('Environment', 'Dev');
 Object.entries(standardTags).forEach(([key, value]) => cdk.Tags.of(devProcessingStack).add(key, value));
 
@@ -362,11 +364,13 @@ Object.entries(standardTags).forEach(([key, value]) => cdk.Tags.of(prodAgentPlat
 
 const prodProcessingStack = new ProcessingStack(app, 'AIStudio-ProcessingStack-Prod', {
   environment: 'prod',
+  googleContentOAuthSecretArn: prodAuthStack.googleContentOAuthSecret.secretArn,
   appBaseUrl: baseDomain ? `https://${baseDomain}` : undefined,
   env: { account: process.env.CDK_DEFAULT_ACCOUNT, region: process.env.CDK_DEFAULT_REGION },
 });
 prodProcessingStack.addDependency(prodDbStack); // Reads database SSM parameters and uses the shared VPC
 prodProcessingStack.addDependency(prodStorageStack); // Reads the documents bucket SSM parameter
+prodProcessingStack.addDependency(prodAuthStack); // Owns Google content OAuth configuration
 cdk.Tags.of(prodProcessingStack).add('Environment', 'Prod');
 Object.entries(standardTags).forEach(([key, value]) => cdk.Tags.of(prodProcessingStack).add(key, value));
 

--- a/infra/deploy-dev.sh
+++ b/infra/deploy-dev.sh
@@ -5,8 +5,14 @@ set -e
 
 # Check if Google Client ID is provided
 if [ -z "$1" ]; then
-    echo "Usage: ./deploy-dev.sh <GOOGLE_CLIENT_ID> [BASE_DOMAIN]"
-    echo "Example: ./deploy-dev.sh 905669698724-xxx.apps.googleusercontent.com aistudio.psd401.ai"
+    echo "Usage: GOOGLE_PICKER_API_KEY=<restricted-key> ./deploy-dev.sh <GOOGLE_CLIENT_ID> [BASE_DOMAIN]"
+    echo "Example: GOOGLE_PICKER_API_KEY=... ./deploy-dev.sh 905669698724-xxx.apps.googleusercontent.com aistudio.psd401.ai"
+    exit 1
+fi
+
+if [ -z "$GOOGLE_PICKER_API_KEY" ]; then
+    echo "GOOGLE_PICKER_API_KEY is required."
+    echo "Use a browser key restricted to the dev origin and Google Picker/Drive APIs."
     exit 1
 fi
 
@@ -23,7 +29,8 @@ bunx cdk deploy \
   AIStudio-AuthStack-Dev \
   AIStudio-StorageStack-Dev \
   AIStudio-ProcessingStack-Dev \
-  AIStudio-FrontendStack-Dev \
+  AIStudio-FrontendStack-ECS-Dev \
   --parameters AIStudio-AuthStack-Dev:GoogleClientId=$GOOGLE_CLIENT_ID \
+  --parameters AIStudio-AuthStack-Dev:GooglePickerApiKey=$GOOGLE_PICKER_API_KEY \
   --context baseDomain=$BASE_DOMAIN \
   --require-approval never

--- a/infra/lib/auth-stack.ts
+++ b/infra/lib/auth-stack.ts
@@ -11,6 +11,8 @@ export interface AuthStackProps extends cdk.StackProps {
 }
 
 export class AuthStack extends cdk.Stack {
+  public readonly googleContentOAuthSecret: secretsmanager.Secret;
+
   constructor(scope: Construct, id: string, props: AuthStackProps) {
     super(scope, id, props);
 
@@ -19,6 +21,33 @@ export class AuthStack extends cdk.Stack {
       description: `Google OAuth Client ID for ${props.environment}`,
     });
     const googleClientId = googleClientIdParam.valueAsString;
+    const googlePickerApiKeyParam = new cdk.CfnParameter(this, 'GooglePickerApiKey', {
+      type: 'String',
+      noEcho: true,
+      minLength: 1,
+      description: `Browser-restricted Google Picker API key for ${props.environment}`,
+    });
+
+    // Reuse the Google OAuth web client already required by this stack and
+    // assemble the content connector's complete runtime contract in
+    // CloudFormation. The application must never depend on an operator-created
+    // Secrets Manager object. A web client id encodes its owning Google Cloud
+    // project number before the first "-"; Picker requires that value as appId.
+    this.googleContentOAuthSecret = new secretsmanager.Secret(this, 'GoogleContentOAuthSecret', {
+      secretName: `aistudio/${props.environment}/google-content-oauth`,
+      description: 'Deployment-managed Google OAuth and Picker configuration for repository synchronization',
+      secretObjectValue: {
+        clientId: cdk.SecretValue.unsafePlainText(googleClientId),
+        clientSecret: props.googleClientSecret,
+        pickerApiKey: cdk.SecretValue.unsafePlainText(googlePickerApiKeyParam.valueAsString),
+        appId: cdk.SecretValue.unsafePlainText(
+          cdk.Fn.select(0, cdk.Fn.split('-', googleClientId))
+        ),
+      },
+      removalPolicy: cdk.RemovalPolicy.RETAIN,
+    });
+    cdk.Tags.of(this.googleContentOAuthSecret).add('Environment', props.environment);
+    cdk.Tags.of(this.googleContentOAuthSecret).add('ManagedBy', 'cdk');
 
     // Cognito User Pool
     const userPool = new cognito.UserPool(this, 'UserPool', {
@@ -126,6 +155,11 @@ export class AuthStack extends cdk.Stack {
       value: authSecret.secretArn,
       description: 'NextAuth secret ARN',
       exportName: `${props.environment}-AuthSecretArn`,
+    });
+    new cdk.CfnOutput(this, 'GoogleContentOAuthSecretArn', {
+      value: this.googleContentOAuthSecret.secretArn,
+      description: 'Deployment-managed Google content OAuth configuration secret ARN',
+      exportName: `${props.environment}-GoogleContentOAuthSecretArn`,
     });
   }
 }

--- a/infra/lib/constructs/processing/google-content-sync.ts
+++ b/infra/lib/constructs/processing/google-content-sync.ts
@@ -20,6 +20,7 @@ export interface GoogleContentSyncProps {
   documentsBucket: s3.IBucket;
   databaseHost: string;
   databaseSecretArn: string;
+  googleContentOAuthSecretArn: string;
   contentProcessingQueue: sqs.IQueue;
   vpc: ec2.IVpc;
   appBaseUrl?: string;
@@ -95,8 +96,7 @@ export class GoogleContentSync extends Construct {
                 props.databaseSecretArn,
                 `arn:${stack.partition}:secretsmanager:${stack.region}:` +
                   `${stack.account}:secret:aistudio/${props.environment}/mcp/token-encryption-key-*`,
-                `arn:${stack.partition}:secretsmanager:${stack.region}:` +
-                  `${stack.account}:secret:aistudio/${props.environment}/google-content-oauth-*`,
+                props.googleContentOAuthSecretArn,
               ],
             }),
             new iam.PolicyStatement({
@@ -159,7 +159,7 @@ export class GoogleContentSync extends Construct {
         DATABASE_PORT: "5432",
         ENVIRONMENT: props.environment,
         APP_BASE_URL: props.appBaseUrl ?? "",
-        GOOGLE_CONTENT_OAUTH_SECRET_ID: `aistudio/${props.environment}/google-content-oauth`,
+        GOOGLE_CONTENT_OAUTH_SECRET_ID: props.googleContentOAuthSecretArn,
       },
       bundling: {
         format: lambdaNodejs.OutputFormat.ESM,

--- a/infra/lib/processing-stack.ts
+++ b/infra/lib/processing-stack.ts
@@ -27,6 +27,7 @@ export interface ProcessingStackProps extends cdk.StackProps {
   documentsBucketName?: string; // Optional for backward compatibility
   databaseResourceArn?: string; // Optional for backward compatibility
   databaseSecretArn?: string; // Optional for backward compatibility
+  googleContentOAuthSecretArn: string;
   appBaseUrl?: string;
 }
 export class ProcessingStack extends cdk.Stack {
@@ -128,6 +129,7 @@ export class ProcessingStack extends cdk.Stack {
       documentsBucket,
       databaseHost,
       databaseSecretArn,
+      googleContentOAuthSecretArn: props.googleContentOAuthSecretArn,
       contentProcessingQueue: this.contentProcessingQueue,
       vpc,
       appBaseUrl: props.appBaseUrl,

--- a/infra/test-deployment.sh
+++ b/infra/test-deployment.sh
@@ -42,10 +42,11 @@ echo ""
 # 2. Check what will change in each stack
 echo "2️⃣ Checking changes for each stack..."
 STACKS=(
+    "AIStudio-AuthStack-Dev"
     "AIStudio-DatabaseStack-Dev"
     "AIStudio-StorageStack-Dev"
     "AIStudio-ProcessingStack-Dev"
-    "AIStudio-FrontendStack-Dev"
+    "AIStudio-FrontendStack-ECS-Dev"
 )
 
 for STACK in "${STACKS[@]}"; do
@@ -64,10 +65,10 @@ echo ""
 # 4. Test deployment order simulation
 echo "4️⃣ Simulating deployment order (dry run)..."
 echo "   Order for initial deployment:"
-echo "   1. AuthStack (no dependencies)"
+echo "   1. AuthStack (creates the deployment-owned Google content OAuth secret)"
 echo "   2. DatabaseStack (no dependencies)"
 echo "   3. StorageStack (no dependencies)"
-echo "   4. ProcessingStack (depends on SSM from Database & Storage)"
+echo "   4. ProcessingStack (depends on SSM from Database & Storage and AuthStack)"
 echo "   5. FrontendStack (depends on SSM from Storage)"
 echo ""
 
@@ -81,14 +82,14 @@ echo ""
 # 6. Deployment commands
 echo "6️⃣ Deployment commands to run:"
 echo ""
-echo "   First deployment (all stacks together to create SSM parameters):"
-echo "   bunx cdk deploy --all --context baseDomain=$BASEDOMAIN"
+echo "   First deployment (all stacks together to create SSM parameters and OAuth secret):"
+echo "   GOOGLE_PICKER_API_KEY=<restricted-key> ./deploy-dev.sh <google-client-id> $BASEDOMAIN"
 echo ""
 echo "   Future deployments (individual stacks):"
 echo "   bunx cdk deploy AIStudio-DatabaseStack-Dev --exclusively --context baseDomain=$BASEDOMAIN"
 echo "   bunx cdk deploy AIStudio-StorageStack-Dev --exclusively --context baseDomain=$BASEDOMAIN"
 echo "   bunx cdk deploy AIStudio-ProcessingStack-Dev --exclusively --context baseDomain=$BASEDOMAIN"
-echo "   bunx cdk deploy AIStudio-FrontendStack-Dev --exclusively --context baseDomain=$BASEDOMAIN"
+echo "   bunx cdk deploy AIStudio-FrontendStack-ECS-Dev --exclusively --context baseDomain=$BASEDOMAIN"
 echo ""
 
 # 7. Post-deployment verification
@@ -99,7 +100,7 @@ echo ""
 echo "✅ Pre-deployment tests completed successfully!"
 echo ""
 echo "⚠️  IMPORTANT: For the first deployment after this change:"
-echo "   1. Deploy all stacks together: bunx cdk deploy --all --context baseDomain=$BASEDOMAIN"
-echo "   2. This creates SSM parameters while maintaining existing exports"
+echo "   1. Deploy all stacks with deploy-dev.sh and its required OAuth/Picker inputs"
+echo "   2. This creates SSM parameters and the Google content OAuth secret"
 echo "   3. Future deployments can use --exclusively for individual stacks"
 echo ""

--- a/infra/test/unit/google-content-oauth-secret.test.ts
+++ b/infra/test/unit/google-content-oauth-secret.test.ts
@@ -1,0 +1,54 @@
+import * as cdk from "aws-cdk-lib";
+import { Template } from "aws-cdk-lib/assertions";
+import { AuthStack } from "../../lib/auth-stack";
+
+function synthesize(): Template {
+  const app = new cdk.App();
+  const stack = new AuthStack(app, "GoogleContentOAuthTest", {
+    environment: "dev",
+    googleClientSecret: cdk.SecretValue.secretsManager(
+      "aistudio-dev-google-oauth",
+      { jsonField: "clientSecret" },
+    ),
+    callbackUrls: ["https://dev.example.test/api/auth/callback/cognito"],
+    logoutUrls: ["https://dev.example.test"],
+    env: { account: "123456789012", region: "us-east-1" },
+  });
+  return Template.fromStack(stack);
+}
+
+describe("Google content OAuth deployment contract", () => {
+  const template = synthesize();
+
+  test("requires the browser-restricted Picker key as a deployment parameter", () => {
+    template.hasParameter("GooglePickerApiKey", {
+      Type: "String",
+      NoEcho: true,
+      MinLength: 1,
+    });
+  });
+
+  test("creates and retains the complete runtime configuration secret", () => {
+    const resources = template.findResources("AWS::SecretsManager::Secret", {
+      Properties: {
+        Name: "aistudio/dev/google-content-oauth",
+      },
+    });
+    expect(Object.keys(resources)).toHaveLength(1);
+    const [logicalId, resource] = Object.entries(resources)[0] ?? [];
+    expect(logicalId).toBeDefined();
+    expect(resource).toBeDefined();
+    expect(resource?.DeletionPolicy).toBe("Retain");
+    expect(resource?.UpdateReplacePolicy).toBe("Retain");
+
+    const secretString = JSON.stringify(resource?.Properties?.SecretString);
+    for (const field of ["clientId", "clientSecret", "pickerApiKey", "appId"]) {
+      expect(secretString).toContain(`\\"${field}\\"`);
+    }
+    expect(secretString).toContain("GoogleClientId");
+    expect(secretString).toContain("GooglePickerApiKey");
+    expect(secretString).toContain("aistudio-dev-google-oauth");
+    expect(secretString).toContain("clientSecret");
+    expect(secretString).toContain("Fn::Split");
+  });
+});

--- a/infra/test/unit/google-content-sync.test.ts
+++ b/infra/test/unit/google-content-sync.test.ts
@@ -26,6 +26,8 @@ function synthesize(): Template {
     databaseHost: "database.example.test",
     databaseSecretArn:
       "arn:aws:secretsmanager:us-east-1:123456789012:secret:aistudio-dev-db-AbCdEf",
+    googleContentOAuthSecretArn:
+      "arn:aws:secretsmanager:us-east-1:123456789012:secret:aistudio/dev/google-content-oauth-AbCdEf",
     contentProcessingQueue: processingQueue,
     vpc,
     appBaseUrl: "https://dev.aistudio.example.test",
@@ -86,6 +88,7 @@ describe("GoogleContentSync", () => {
     expect(policies).toContain("sqs:SendMessage");
     expect(policies).toContain("GoogleContentSyncQueue");
     expect(policies).toContain("aistudio/dev/mcp/token-encryption-key-");
+    expect(policies).toContain("aistudio/dev/google-content-oauth-AbCdEf");
     expect(policies).not.toContain("iam:CreateAccessKey");
   });
 

--- a/infra/test/unit/processing-stack-embedding-access.test.ts
+++ b/infra/test/unit/processing-stack-embedding-access.test.ts
@@ -41,6 +41,8 @@ function synthesizeProcessingStack(): Template {
       'arn:aws:rds:us-east-1:123456789012:cluster:aistudio-dev',
     databaseSecretArn:
       'arn:aws:secretsmanager:us-east-1:123456789012:secret:aistudio-dev',
+    googleContentOAuthSecretArn:
+      'arn:aws:secretsmanager:us-east-1:123456789012:secret:aistudio/dev/google-content-oauth-AbCdEf',
   });
   return Template.fromStack(stack);
 }

--- a/lib/repositories/google-drive/connector-service.ts
+++ b/lib/repositories/google-drive/connector-service.ts
@@ -157,7 +157,7 @@ export async function upsertPersonalGoogleDriveConnector(input: {
       await tx
         .update(repositoryConnectors)
         .set({
-          displayName: input.displayName?.trim() || "Personal Google Drive",
+          displayName: input.displayName?.trim() || "Google Drive",
           status: selection ? "pending" : "paused",
           nextSyncAt: new Date(),
           lastErrorCode: null,
@@ -189,89 +189,13 @@ export async function upsertPersonalGoogleDriveConnector(input: {
         authMode: "personal_oauth",
         createdBy: input.userId,
         credentialId: credential.id,
-        displayName: input.displayName?.trim() || "Personal Google Drive",
+        displayName: input.displayName?.trim() || "Google Drive",
         status: "paused",
       })
       .returning({ id: repositoryConnectors.id });
     if (!connector) throw new Error("Failed to create Google Drive connector");
     return connector.id;
   }, "googleDrive.upsertPersonalConnector");
-}
-
-export async function upsertSharedDriveConnector(input: {
-  repositoryId: number;
-  userId: number;
-  sharedDriveId: string;
-  displayName: string;
-}): Promise<string> {
-  validateRepositoryId(input.repositoryId);
-  const sharedDriveId = input.sharedDriveId.trim();
-  const displayName = input.displayName.trim();
-  if (!sharedDriveId || sharedDriveId.length > 256) {
-    throw new Error("A valid Shared Drive id is required");
-  }
-  if (!displayName || displayName.length > 255) {
-    throw new Error("A Shared Drive name is required");
-  }
-
-  return executeTransaction(async (tx) => {
-    const [repository] = await tx
-      .select({ id: knowledgeRepositories.id })
-      .from(knowledgeRepositories)
-      .where(eq(knowledgeRepositories.id, input.repositoryId))
-      .limit(1)
-      .for("update");
-    if (!repository) throw new Error("Repository not found");
-
-    const [existing] = await tx
-      .select({ id: repositoryConnectors.id })
-      .from(repositoryConnectors)
-      .where(
-        and(
-          eq(repositoryConnectors.repositoryId, input.repositoryId),
-          eq(repositoryConnectors.provider, "google_drive"),
-          eq(repositoryConnectors.authMode, "shared_drive_wif"),
-          eq(repositoryConnectors.sharedDriveId, sharedDriveId),
-        ),
-      )
-      .limit(1);
-    if (existing) {
-      await tx
-        .update(repositoryConnectors)
-        .set({
-          displayName,
-          status: "pending",
-          nextSyncAt: new Date(),
-          updatedAt: new Date(),
-        })
-        .where(eq(repositoryConnectors.id, existing.id));
-      return existing.id;
-    }
-
-    const [connector] = await tx
-      .insert(repositoryConnectors)
-      .values({
-        repositoryId: input.repositoryId,
-        provider: "google_drive",
-        authMode: "shared_drive_wif",
-        createdBy: input.userId,
-        credentialId: null,
-        displayName,
-        sharedDriveId,
-        status: "pending",
-      })
-      .returning({ id: repositoryConnectors.id });
-    if (!connector) throw new Error("Failed to create Shared Drive connector");
-
-    await tx.insert(repositoryConnectorSelections).values({
-      connectorId: connector.id,
-      externalId: sharedDriveId,
-      selectionKind: "drive",
-      displayName,
-      includeDescendants: true,
-    });
-    return connector.id;
-  }, "googleDrive.upsertSharedDriveConnector");
 }
 
 export async function replaceGoogleDriveSelections(input: {

--- a/lib/repositories/google-drive/oauth.ts
+++ b/lib/repositories/google-drive/oauth.ts
@@ -9,6 +9,8 @@ import { GOOGLE_DRIVE_SCOPE } from "./formats";
 
 const GOOGLE_TOKEN_ENDPOINT = "https://oauth2.googleapis.com/token";
 const GOOGLE_REVOKE_ENDPOINT = "https://oauth2.googleapis.com/revoke";
+const GOOGLE_CONTENT_CONFIGURATION_ERROR =
+  "Google Drive is not configured for this environment";
 
 const googleContentSecretSchema = z.object({
   clientId: z.string().min(1),
@@ -88,17 +90,23 @@ export async function loadGoogleContentOAuthConfig(): Promise<GoogleContentOAuth
     return cachedConfig.value;
   }
 
-  const result = await getSecretsClient().send(
-    new GetSecretValueCommand({ SecretId: secretId() }),
-  );
-  if (!result.SecretString) {
-    throw new Error("Google content OAuth is not configured");
+  try {
+    const result = await getSecretsClient().send(
+      new GetSecretValueCommand({ SecretId: secretId() }),
+    );
+    if (!result.SecretString) {
+      throw new Error(GOOGLE_CONTENT_CONFIGURATION_ERROR);
+    }
+    const config = googleContentSecretSchema.parse(
+      JSON.parse(result.SecretString) as unknown,
+    );
+    cachedConfig = { value: config, expiresAt: Date.now() + 5 * 60_000 };
+    return config;
+  } catch {
+    // AWS SDK errors include provider and resource details that are useful only
+    // to operators. Keep the public route response stable and non-disclosing.
+    throw new Error(GOOGLE_CONTENT_CONFIGURATION_ERROR);
   }
-  const config = googleContentSecretSchema.parse(
-    JSON.parse(result.SecretString) as unknown,
-  );
-  cachedConfig = { value: config, expiresAt: Date.now() + 5 * 60_000 };
-  return config;
 }
 
 export function generateGooglePkce(): {

--- a/lib/repositories/google-drive/route-access.ts
+++ b/lib/repositories/google-drive/route-access.ts
@@ -6,7 +6,6 @@ import {
   canModifyRepository,
   getUserIdFromSession,
 } from "@/actions/repositories/repository-permissions";
-import { checkUserRole } from "@/lib/db/drizzle";
 import { hasCapabilityAccess } from "@/utils/roles";
 
 export interface RepositoryConnectorManager {
@@ -31,20 +30,6 @@ export async function requireRepositoryConnectorManager(
     throw new Error("Forbidden");
   }
   return { userId, cognitoSub: session.sub };
-}
-
-/**
- * The shared WIF service account can read every Drive explicitly granted to
- * that common identity. Restrict choosing a Shared Drive id to application
- * administrators so repository ownership cannot be used as a confused-deputy
- * bridge into another team's Drive.
- */
-export async function requireSharedDriveConnectorAdministrator(
-  manager: RepositoryConnectorManager,
-): Promise<void> {
-  if (!(await checkUserRole(manager.userId, "administrator"))) {
-    throw new Error("Forbidden");
-  }
 }
 
 export function repositoryConnectorErrorResponse(error: unknown): Response {

--- a/tests/e2e/unified-content-product-migration.functional.spec.ts
+++ b/tests/e2e/unified-content-product-migration.functional.spec.ts
@@ -166,7 +166,6 @@ test.describe("Unified content product migration (authenticated)", () => {
           contentType: "application/json",
           body: JSON.stringify({
             connectors: [],
-            canConfigureSharedDrives: true,
           }),
         });
       },
@@ -191,20 +190,19 @@ test.describe("Unified content product migration (authenticated)", () => {
     ).toBeVisible();
     await sourceDialog.getByRole("tab", { name: "Google Drive" }).click();
     await expect(
-      sourceDialog.getByRole("heading", { name: "Personal Google Drive" }),
+      sourceDialog.getByRole("heading", { name: "Google Drive" }),
     ).toBeVisible();
     await expect(
       sourceDialog.getByRole("button", { name: "Connect Google Drive" }),
     ).toBeVisible();
     await expect(
-      sourceDialog.getByRole("heading", { name: "Shared Drive" }),
-    ).toBeVisible();
-    await expect(
       sourceDialog.getByText(
-        "unified-content-sync@psd-aistudio-broker.iam.gserviceaccount.com",
-        { exact: true },
+        "Connect with read-only access, then choose files or folders from My Drive or Shared Drives that you can already access.",
       ),
     ).toBeVisible();
+    await expect(sourceDialog.getByText(/unified-content-sync@/)).toHaveCount(
+      0,
+    );
   });
 
   test("staff can manage repositories and bind an explicitly shared repository in Assistant Architect", async ({

--- a/tests/unit/lib/repositories/google-drive-oauth.test.ts
+++ b/tests/unit/lib/repositories/google-drive-oauth.test.ts
@@ -1,9 +1,17 @@
 /** @jest-environment node */
 
+const mockSecretsSend = jest.fn();
+
+jest.mock("@aws-sdk/client-secrets-manager", () => ({
+  GetSecretValueCommand: jest.fn((input: unknown) => input),
+  SecretsManagerClient: jest.fn(() => ({ send: mockSecretsSend })),
+}));
+
 import {
   __resetGoogleOAuthConfigForTests,
   exchangeGoogleAuthorizationCode,
   generateGooglePkce,
+  loadGoogleContentOAuthConfig,
 } from "@/lib/repositories/google-drive/oauth";
 import { GOOGLE_DRIVE_SCOPE } from "@/lib/repositories/google-drive/formats";
 import { GOOGLE_CONTENT_WIF_CONFIG } from "@/lib/repositories/google-drive/wif";
@@ -18,6 +26,7 @@ function tokenResponse(body: unknown): Response {
 
 describe("Google content OAuth", () => {
   beforeEach(() => {
+    mockSecretsSend.mockReset();
     process.env.GOOGLE_CONTENT_OAUTH_CLIENT_ID = "client-id";
     process.env.GOOGLE_CONTENT_OAUTH_CLIENT_SECRET = "client-secret";
     process.env.GOOGLE_CONTENT_PICKER_API_KEY = "picker-key";
@@ -88,6 +97,36 @@ describe("Google content OAuth", () => {
         fetch: fetchMock,
       }),
     ).rejects.toThrow("unexpected scope");
+  });
+
+  test("sanitizes a missing deployment-managed secret", async () => {
+    delete process.env.GOOGLE_CONTENT_OAUTH_CLIENT_ID;
+    delete process.env.GOOGLE_CONTENT_OAUTH_CLIENT_SECRET;
+    delete process.env.GOOGLE_CONTENT_PICKER_API_KEY;
+    delete process.env.GOOGLE_CONTENT_PICKER_APP_ID;
+    __resetGoogleOAuthConfigForTests();
+    mockSecretsSend.mockRejectedValue(
+      new Error("Secrets Manager can't find the specified secret"),
+    );
+
+    await expect(loadGoogleContentOAuthConfig()).rejects.toThrow(
+      "Google Drive is not configured for this environment",
+    );
+  });
+
+  test("sanitizes malformed deployment configuration", async () => {
+    delete process.env.GOOGLE_CONTENT_OAUTH_CLIENT_ID;
+    delete process.env.GOOGLE_CONTENT_OAUTH_CLIENT_SECRET;
+    delete process.env.GOOGLE_CONTENT_PICKER_API_KEY;
+    delete process.env.GOOGLE_CONTENT_PICKER_APP_ID;
+    __resetGoogleOAuthConfigForTests();
+    mockSecretsSend.mockResolvedValue({
+      SecretString: JSON.stringify({ clientId: "incomplete" }),
+    });
+
+    await expect(loadGoogleContentOAuthConfig()).rejects.toThrow(
+      "Google Drive is not configured for this environment",
+    );
   });
 });
 

--- a/tests/unit/lib/repositories/google-drive-route-access.test.ts
+++ b/tests/unit/lib/repositories/google-drive-route-access.test.ts
@@ -2,52 +2,80 @@
 
 jest.mock("server-only", () => ({}));
 
-const checkUserRole = jest.fn();
+const getServerSession = jest.fn();
+const assertNotSystemManagedRepository = jest.fn();
+const canModifyRepository = jest.fn();
+const getUserIdFromSession = jest.fn();
+const hasCapabilityAccess = jest.fn();
 
-jest.mock("@/lib/db/drizzle", () => ({
-  checkUserRole: (...args: unknown[]) => checkUserRole(...args),
-}));
 jest.mock("@/lib/auth/server-session", () => ({
-  getServerSession: jest.fn(),
+  getServerSession: (...args: unknown[]) => getServerSession(...args),
 }));
 jest.mock("@/lib/repositories/repository-access-guard", () => ({
-  assertNotSystemManagedRepository: jest.fn(),
+  assertNotSystemManagedRepository: (...args: unknown[]) =>
+    assertNotSystemManagedRepository(...args),
 }));
 jest.mock("@/actions/repositories/repository-permissions", () => ({
-  canModifyRepository: jest.fn(),
-  getUserIdFromSession: jest.fn(),
+  canModifyRepository: (...args: unknown[]) => canModifyRepository(...args),
+  getUserIdFromSession: (...args: unknown[]) =>
+    getUserIdFromSession(...args),
 }));
 jest.mock("@/utils/roles", () => ({
-  hasCapabilityAccess: jest.fn(),
+  hasCapabilityAccess: (...args: unknown[]) => hasCapabilityAccess(...args),
 }));
 
-import { requireSharedDriveConnectorAdministrator } from "@/lib/repositories/google-drive/route-access";
+import {
+  repositoryConnectorErrorResponse,
+  requireRepositoryConnectorManager,
+} from "@/lib/repositories/google-drive/route-access";
 
-describe("shared Drive connector authority", () => {
+describe("Google Drive connector route access", () => {
+  beforeAll(() => {
+    Object.assign(Response, {
+      json: (body: unknown, init?: ResponseInit) =>
+        new Response(JSON.stringify(body), {
+          ...init,
+          headers: { "Content-Type": "application/json", ...init?.headers },
+        }),
+    });
+  });
+
   beforeEach(() => {
-    checkUserRole.mockReset();
+    getServerSession.mockReset().mockResolvedValue({ sub: "manager-sub" });
+    assertNotSystemManagedRepository.mockReset().mockResolvedValue(undefined);
+    canModifyRepository.mockReset().mockResolvedValue(true);
+    getUserIdFromSession.mockReset().mockResolvedValue(42);
+    hasCapabilityAccess.mockReset().mockResolvedValue(true);
   });
 
-  test("accepts an application administrator", async () => {
-    checkUserRole.mockResolvedValue(true);
+  test("requires both the UI capability and repository management access", async () => {
+    await expect(requireRepositoryConnectorManager(7)).resolves.toEqual({
+      userId: 42,
+      cognitoSub: "manager-sub",
+    });
+    expect(hasCapabilityAccess).toHaveBeenCalledWith("knowledge-repositories");
+    expect(assertNotSystemManagedRepository).toHaveBeenCalledWith(7);
+    expect(canModifyRepository).toHaveBeenCalledWith(7, 42);
 
-    await expect(
-      requireSharedDriveConnectorAdministrator({
-        userId: 42,
-        cognitoSub: "admin-sub",
-      }),
-    ).resolves.toBeUndefined();
-    expect(checkUserRole).toHaveBeenCalledWith(42, "administrator");
+    canModifyRepository.mockResolvedValue(false);
+    await expect(requireRepositoryConnectorManager(7)).rejects.toThrow(
+      "Forbidden",
+    );
   });
 
-  test("rejects a non-administrator repository owner", async () => {
-    checkUserRole.mockResolvedValue(false);
+  test("maps deployment configuration failures to a sanitized 503", async () => {
+    const response = repositoryConnectorErrorResponse(
+      new Error("Google Drive is not configured for this environment"),
+    );
 
-    await expect(
-      requireSharedDriveConnectorAdministrator({
-        userId: 43,
-        cognitoSub: "owner-sub",
-      }),
-    ).rejects.toThrow("Forbidden");
+    expect(response.status).toBe(503);
+    const responseBody = await Promise.resolve(response.json());
+    const parsedBody =
+      typeof responseBody === "string"
+        ? (JSON.parse(responseBody) as unknown)
+        : responseBody;
+    expect(parsedBody).toEqual({
+      error: "Google Drive is not configured for this environment",
+    });
   });
 });


### PR DESCRIPTION
## Summary

Remediates the Google Drive deployment and product-flow defects found during dev verification of #1262:

- makes `AIStudio-AuthStack-{Environment}` create and retain the complete `aistudio/{environment}/google-content-oauth` secret;
- composes that secret from the existing Google OAuth client ID/client secret plus a required, NoEcho, browser-restricted Picker API key;
- passes the exact secret ARN to `ProcessingStack` and scopes the sync worker's Secrets Manager access to that ARN;
- returns a sanitized 503 configuration error instead of raw AWS Secrets Manager details;
- uses one user-authorized OAuth/Picker flow for My Drive and Shared Drives the user can already access;
- removes the customer-facing service-account email/Shared Drive ID form and its POST endpoint;
- preserves worker support for legacy WIF connector rows without allowing the product to create new ones.

Refs #1262  
Refs #1261

## Acceptance criteria

- [x] A normal deployment owns the complete Google Drive OAuth runtime secret; operators do not manually create it.
- [x] My Drive and accessible Shared Drives use the signed-in user's read-only Google OAuth grant.
- [x] Repository Manager never asks a customer to grant access to an AI Studio service account.
- [x] Missing or malformed deployment configuration does not leak AWS/provider internals.
- [x] Worker IAM is restricted to the exact environment-specific OAuth secret.
- [x] Existing legacy WIF records remain readable for backward compatibility.

## Verification

- `bun run typecheck`
- `bunx eslint . --ignore-pattern '.claude/worktrees/**'` — 0 errors; 411 pre-existing warnings
- application Jest CI suite — 353 suites passed, 3 skipped; 3,494 tests passed, 26 skipped
- infrastructure Jest suite — 43 suites, 406 tests passed
- focused OAuth/route tests — 2 suites, 8 tests passed
- focused CDK OAuth/sync tests — 3 suites, 10 tests passed
- `bun run build`
- `cd infra && bun run build`
- `cd infra && bunx cdk synth --all --quiet --context baseDomain=aistudio.psd401.ai`
- authenticated focused Repository Manager Playwright case — passed
- pre-push full authenticated Playwright gate — 266 passed, 33 expected skips
- deploy-script missing-key preflight — failed closed with actionable guidance
- `git diff --check`
- Codex Security diff scan — complete coverage of 13/13 source-like files; no reportable findings

## Rollout

No database migration is required.

For dev, obtain a Google Picker browser key restricted to `https://dev.aistudio.psd401.ai` and the required Google Picker/Drive APIs, then deploy using:

```bash
cd infra
GOOGLE_PICKER_API_KEY='<restricted-key>' \
  ./deploy-dev.sh '905669698724-aur4qhs2ackbg4avmvj6ef1m837lav3t.apps.googleusercontent.com' \
  aistudio.psd401.ai
```

The existing `aistudio-dev-google-oauth` secret remains the source of `clientSecret`. AuthStack creates `aistudio/dev/google-content-oauth`; ProcessingStack and Frontend then consume it. The secret has a retain policy.

After deployment, verify the OAuth callback is registered as:

```text
https://dev.aistudio.psd401.ai/api/repositories/connectors/google/callback
```

Then test connection, Picker selection from My Drive and a Shared Drive already visible to the user, initial sync, edit/move/delete reconciliation, permission loss/restore, and scheduled recovery.

## Remaining risks

- Google Cloud still owns OAuth consent-screen approval, callback registration, and browser-key origin/API restrictions; CDK cannot create those cross-cloud resources.
- Live Google OAuth and Drive synchronization require the dev deployment and real Google credentials, so they remain post-deploy verification.
