### PR TITLE
fix(db): rewrite migration 136 trigger function so the db-init splitter can parse it

### DIFF
--- a/infra/database/schema/136-google-content-connectors.sql
+++ b/infra/database/schema/136-google-content-connectors.sql
@@ -208,19 +208,11 @@ FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
 -- A connector can be deleted indirectly when the administrator who configured
 -- it is removed. Preserve the repository item/version audit trail, but fail the
 -- item closed before connector/source cascades erase the reconciliation link.
-CREATE OR REPLACE FUNCTION mark_repository_connector_items_unavailable()
-RETURNS TRIGGER AS $$
-BEGIN
-  UPDATE repository_items
-  SET lifecycle_status = 'unavailable', updated_at = NOW()
-  WHERE id IN (
-    SELECT repository_item_id
-    FROM repository_connector_sources
-    WHERE connector_id = OLD.id
-  );
-  RETURN OLD;
-END;
-$$ LANGUAGE plpgsql;
+-- Single-line single-quote-style body (migration-134 pattern): the db-init
+-- Lambda's statement splitter closes a dollar-quoted function block at any
+-- interior line ending in ");" and ships an unterminated fragment to the RDS
+-- Data API, failing the migration.
+CREATE OR REPLACE FUNCTION mark_repository_connector_items_unavailable() RETURNS TRIGGER AS 'BEGIN UPDATE repository_items SET lifecycle_status = ''unavailable'', updated_at = NOW() WHERE id IN (SELECT repository_item_id FROM repository_connector_sources WHERE connector_id = OLD.id); RETURN OLD; END;' LANGUAGE plpgsql;
 
 DROP TRIGGER IF EXISTS trg_repository_connector_items_unavailable
   ON repository_connectors;


### PR DESCRIPTION
## Summary

Migration `136-google-content-connectors.sql` (from #1337) fails on every dev deploy, which blocks migration 137 (#1330 Nexus conversation retention) from ever running. This PR rewrites one function in 136 so the db-init Lambda's statement splitter can parse it. No semantic change.

## The failure

Both dev deploys today (16:39 and 19:13 UTC) failed in `db-init-dev` on:

```
▶️  Running migration: 136-google-content-connectors.sql
ERROR  SQL execution error for statement: CREATE OR REPLACE FUNCTION mark_repository_connector_items_unavailable()
ERROR  ❌ Database operation failed: Error: Migration 136-google-content-connectors.sql failed: Database returned SQL Exception
```

Downstream impact: 137 never runs → `nexus_conversations.is_saved` doesn't exist on dev → the deployed retention Lambda's dry-run fails with `column "is_saved" does not exist`. With `NEXUS_CONVERSATION_RETENTION_DAYS` now set on dev, the nightly 05:00 UTC sweep errors the same way (fail-closed before any deletion — no data at risk, but a nightly ERROR until this lands). Prod would hit the identical failure on its next deploy.

## Root cause

`splitSqlStatements` in `infra/database/lambda/db-init-handler.ts` is a line-based splitter that does not understand dollar-quoted PL/pgSQL bodies. It enters block mode at `CREATE OR REPLACE FUNCTION` and exits at the first line ending in `);`. The original function body contained:

```sql
  WHERE id IN (
    SELECT repository_item_id
    FROM repository_connector_sources
    WHERE connector_id = OLD.id
  );          -- ← splitter treats this as end-of-block
```

so the splitter cut the function mid-`$$`-quote and sent an unterminated fragment to the RDS Data API. This is the documented splitter limitation (see `docs/learnings` splitter entry); migration 065 worked around it by dropping its function entirely, and migration 134 by using the single-line single-quote form.

## Fix

Rewrite the function in the migration-134 pattern — single line, `AS 'BEGIN ... END;' LANGUAGE plpgsql`, interior quotes doubled. That form ends with `' LANGUAGE plpgsql;`, which is the one function terminator the splitter's block-exit condition explicitly recognizes. Migration 134 applied cleanly on dev with this exact pattern.

## Verification

- Replayed the exact `splitSqlStatements` logic over the edited file: **25 complete statements**, the function is its own single statement, zero unbalanced `$$`, and the trailing `DROP TRIGGER` / `CREATE TRIGGER` statements split correctly.
- Executed the rewritten `CREATE OR REPLACE FUNCTION` against local Postgres: `CREATE FUNCTION` succeeded; `pg_proc.prosrc` reads back with correct un-doubled quoting (`lifecycle_status = 'unavailable'`), byte-for-byte the same body logic as the original.
- `bun run lint`: 0 errors. `bun run typecheck`: clean.

## Re-run safety

Everything in 136 before the function already applied on dev and is `IF NOT EXISTS` / `DROP TRIGGER IF EXISTS` guarded — the migration runner's automatic retry of a failed migration is idempotent. 137 then runs; its settings seed is `ON CONFLICT (key) DO NOTHING`, so the admin-set retention value on dev is preserved.

## After merge

Redeploy dev (canonical command). Expected db-init log: `▶️ Running migration: 136...` succeeds, then `▶️ Running migration: 137...`. Then re-run the retention dry-run invoke for candidate counts.

Refs #1330. Fixes the deploy blocker introduced in #1337.
