### PR TITLE
fix: restore Google Drive Picker selections

### DIFF
--- a/app/api/repositories/[repositoryId]/connectors/google/selections/route.ts
+++ b/app/api/repositories/[repositoryId]/connectors/google/selections/route.ts
@@ -62,7 +62,10 @@ async function replaceSelections(
           if (!file.shortcutDetails?.targetId) {
             throw new Error("Selected shortcut has no accessible target");
           }
-          file = await drive.getFile(file.shortcutDetails.targetId);
+          file = await drive.getFile(
+            file.shortcutDetails.targetId,
+            file.shortcutDetails.targetResourceKey,
+          );
         }
         return {
           externalId: file.id,

--- a/docs/features/google-workspace-content-sync.md
+++ b/docs/features/google-workspace-content-sync.md
@@ -157,8 +157,8 @@ versions. Do not remove migration 136 or delete connector records as a rollback.
 ## Verification
 
 - `tests/unit/lib/repositories/google-drive-client.test.ts` covers exact scope,
-  Drive metadata/cursor contracts, export mappings, and resumable Vids
-  operations.
+  valid Drive metadata/cursor field contracts, shortcut target resource-key
+  propagation, export mappings, and resumable Vids operations.
 - `tests/unit/lib/repositories/google-drive-oauth.test.ts` covers PKCE and
   fail-closed scope validation plus sanitized missing/malformed deployment
   configuration errors.

--- a/docs/plans/2026-07-21-unified-content-platform.md
+++ b/docs/plans/2026-07-21-unified-content-platform.md
@@ -1164,3 +1164,13 @@ lint (zero errors; 411 existing warnings), all 353 application Jest suites with
 with 406 tests, both production builds, full CDK synthesis, deploy-script
 preflight, the authenticated Repository Manager Playwright case, final diff
 checks, and a complete diff-scoped security review with no reportable findings.
+
+Live Dev verification then completed the real Google authorization flow and
+opened Picker against both personal and Shared Drive content. Selecting a source
+exposed an invalid Drive metadata field projection:
+`shortcutDetails.resourceKey` is not a Drive API v3 field; the provider contract
+uses `shortcutDetails.targetResourceKey`. The post-deployment hotfix corrects
+that field across metadata, change, and traversal requests and forwards the
+target resource key through `X-Goog-Drive-Resource-Keys` when resolving a
+link-shared shortcut. Focused client and selection-route tests now assert the
+exact provider field projection and resource-key propagation.

--- a/lib/repositories/google-drive/drive-client.ts
+++ b/lib/repositories/google-drive/drive-client.ts
@@ -21,14 +21,14 @@ const FILE_FIELDS = [
   "webViewLink",
   "iconLink",
   "owners(displayName)",
-  "shortcutDetails(targetId,targetMimeType,resourceKey)",
+  "shortcutDetails(targetId,targetMimeType,targetResourceKey)",
 ].join(",");
 
 const driveUserSchema = z.object({ displayName: z.string().optional() });
 const shortcutDetailsSchema = z.object({
   targetId: z.string(),
   targetMimeType: z.string(),
-  resourceKey: z.string().optional(),
+  targetResourceKey: z.string().optional(),
 });
 
 export const googleDriveFileSchema = z.object({
@@ -183,13 +183,25 @@ export class GoogleDriveClient {
     throw new GoogleDriveApiError(message, response.status, reason);
   }
 
-  async getFile(fileId: string): Promise<GoogleDriveFile> {
+  async getFile(
+    fileId: string,
+    resourceKey?: string,
+  ): Promise<GoogleDriveFile> {
     const url = new URL(
       `${DRIVE_API_BASE}/files/${encodeURIComponent(fileId)}`,
     );
     url.searchParams.set("supportsAllDrives", "true");
     url.searchParams.set("fields", FILE_FIELDS);
-    const response = await this.request(url);
+    const response = await this.request(
+      url,
+      resourceKey
+        ? {
+            headers: {
+              "X-Goog-Drive-Resource-Keys": `${fileId}/${resourceKey}`,
+            },
+          }
+        : undefined,
+    );
     return googleDriveFileSchema.parse(await response.json());
   }
 

--- a/tests/unit/lib/repositories/google-drive-client.test.ts
+++ b/tests/unit/lib/repositories/google-drive-client.test.ts
@@ -47,13 +47,45 @@ describe("GoogleDriveClient", () => {
 
     expect(file.id).toBe("file-1");
     const [url, init] = fetchMock.mock.calls[0] ?? [];
-    expect(String(url)).toContain("/drive/v3/files/file-1");
-    expect(String(url)).toContain("supportsAllDrives=true");
+    const requestUrl = new URL(String(url));
+    expect(requestUrl.pathname).toBe("/drive/v3/files/file-1");
+    expect(requestUrl.searchParams.get("supportsAllDrives")).toBe("true");
+    expect(requestUrl.searchParams.get("fields")).toContain(
+      "shortcutDetails(targetId,targetMimeType,targetResourceKey)",
+    );
+    expect(requestUrl.searchParams.get("fields")).not.toContain(
+      "shortcutDetails(targetId,targetMimeType,resourceKey)",
+    );
     expect(init?.headers).toEqual(
       expect.objectContaining({ Authorization: "Bearer access-token" }),
     );
     expect(GOOGLE_DRIVE_SCOPE).toBe(
       "https://www.googleapis.com/auth/drive.readonly",
+    );
+  });
+
+  test("uses a shortcut target resource key for link-shared metadata", async () => {
+    const fetchMock = jest
+      .fn<ReturnType<typeof fetch>, Parameters<typeof fetch>>()
+      .mockResolvedValue(
+        jsonResponse({
+          id: "target-file",
+          name: "Linked handbook",
+          mimeType: "application/vnd.google-apps.document",
+        }),
+      );
+    const client = new GoogleDriveClient("access-token", {
+      fetch: fetchMock,
+    });
+
+    await client.getFile("target-file", "target-resource-key");
+
+    expect(fetchMock.mock.calls[0]?.[1]?.headers).toEqual(
+      expect.objectContaining({
+        Authorization: "Bearer access-token",
+        "X-Goog-Drive-Resource-Keys":
+          "target-file/target-resource-key",
+      }),
     );
   });
 

--- a/tests/unit/lib/repositories/google-drive-selections-route.test.ts
+++ b/tests/unit/lib/repositories/google-drive-selections-route.test.ts
@@ -66,25 +66,54 @@ describe("Google Drive selection replacement route", () => {
   test("bounds provider fanout and applies the route-local request budget", async () => {
     let active = 0;
     let peak = 0;
-    getFile.mockImplementation(async (fileId: string) => {
-      active += 1;
-      peak = Math.max(peak, active);
-      await new Promise((resolve) => setTimeout(resolve, 2));
-      active -= 1;
-      return {
-        id: fileId,
-        name: fileId,
-        mimeType: "text/plain",
-      };
-    });
+    getFile.mockImplementation(
+      async (fileId: string, resourceKey?: string) => {
+        active += 1;
+        peak = Math.max(peak, active);
+        await new Promise((resolve) => setTimeout(resolve, 2));
+        active -= 1;
+        if (fileId === "shortcut-file") {
+          return {
+            id: fileId,
+            name: "Linked handbook",
+            mimeType: "application/vnd.google-apps.shortcut",
+            shortcutDetails: {
+              targetId: "target-file",
+              targetMimeType: "application/vnd.google-apps.document",
+              targetResourceKey: "target-resource-key",
+            },
+          };
+        }
+        if (fileId === "target-file") {
+          expect(resourceKey).toBe("target-resource-key");
+          return {
+            id: fileId,
+            name: "Handbook",
+            mimeType: "application/vnd.google-apps.document",
+          };
+        }
+        return {
+          id: fileId,
+          name: fileId,
+          mimeType: "text/plain",
+        };
+      },
+    );
 
     const response = await POST(
-      request(Array.from({ length: 20 }, (_, index) => `file-${index}`)),
+      request([
+        "shortcut-file",
+        ...Array.from({ length: 19 }, (_, index) => `file-${index}`),
+      ]),
       context,
     );
 
     expect(response.status).toBe(200);
     expect(peak).toBe(5);
+    expect(getFile).toHaveBeenCalledWith(
+      "target-file",
+      "target-resource-key",
+    );
     expect(replaceGoogleDriveSelections).toHaveBeenCalledTimes(1);
     getFile.mockResolvedValue({
       id: "file",


### PR DESCRIPTION
## Summary

Live Dev validation after #1337 completed Google OAuth and opened Picker, but
selecting a Drive item failed before persistence. CloudWatch correlated the
rejection to the Drive metadata lookup.

Google Drive API v3 exposes
`shortcutDetails.targetResourceKey`; the client requested the nonexistent
`shortcutDetails.resourceKey`, making the `files.get` field projection invalid
for every selected item.

This follow-up:

- requests the correct `targetResourceKey` metadata field across Drive queries;
- propagates a shortcut target resource key through
  `X-Goog-Drive-Resource-Keys` when resolving link-shared shortcut targets;
- adds exact request-contract and route-propagation regression tests;
- records the live Dev finding and verification boundary in the feature docs
  and durable implementation-plan ledger.

Follow-up to #1262. Part of #1261.

## Acceptance criteria

- [x] A selected Drive item uses a valid Drive API v3 metadata projection.
- [x] A Google shortcut resolves to its target under the signed-in user's
      existing read-only OAuth grant.
- [x] Link-shared shortcut targets receive the provider-returned target resource
      key in the documented request header.
- [x] Repository, connector-owner, input, rate, and bounded-concurrency controls
      remain unchanged.
- [x] No OAuth token or resource key is logged, persisted, queued, or returned.

## Verification

- `bunx jest --runInBand tests/unit/lib/repositories/google-drive-client.test.ts tests/unit/lib/repositories/google-drive-selections-route.test.ts`
  — 2 suites / 11 tests passed.
- `bun run test:ci --runInBand --forceExit`
  — 353 suites / 3,495 tests passed; 3 suites / 26 tests skipped.
- `bun run typecheck` — passed.
- `bun run lint` — passed with zero errors (409 existing warnings).
- `bun run build` — production build passed.
- Authenticated pre-push Playwright gate — 269 passed / 33
  suite-defined skips.
- Diff check — clean.
- Diff-scoped security review — both changed runtime files fully reviewed; no
  reportable findings.

The separate live-load performance suites require a running streaming load
target and are not part of `jest.config.ci.js`; the repository CI-configured
suite above passed completely.

## Rollout and risk

- No database migration or infrastructure change.
- No CDK synthesis is required for this application-only patch.
- After merge, redeploy the Dev frontend/ECS application.
- Repeat the live Picker selection using the existing test document, then
  confirm the selection persists, sync completes, the source is tracked, and
  retrieval returns the validation marker.
- Remaining risk is limited to that post-deployment provider round-trip; the
  exact provider contract and authorization boundaries are covered locally.
