### PR TITLE
feat(db): raise nexus retention sweep batch limit to 500 per run

### DIFF
--- a/infra/lib/database-stack.ts
+++ b/infra/lib/database-stack.ts
@@ -536,7 +536,7 @@ export class DatabaseStack extends cdk.Stack {
           // Per-run cap. Bounds the blast radius of a misconfigured retention
           // window: the first night after enabling can delete at most this
           // many conversations, and the backlog drains over subsequent runs.
-          SWEEP_BATCH_LIMIT: '200',
+          SWEEP_BATCH_LIMIT: '500',
         },
       });
       cdk.Tags.of(retentionLambda).add('Environment', props.environment);


### PR DESCRIPTION
## Summary
Raises `SWEEP_BATCH_LIMIT` on `psd-nexus-conversation-retention-<env>` from **200 → 500** conversations per nightly run — one env-var line in `infra/lib/database-stack.ts`. Requested by @psd401 ahead of the prod rollout of #1330 so the initial backlog drains faster once retention is enabled.

## Sizing evidence
First live dev run (2026-07-26 05:00 UTC): 200 text-only conversations deleted in **11.4s**, 91MB/512MB memory, against a 900s timeout. 500 leaves ample headroom even for conversations carrying S3 attachment/repository sweeps.

## Scope
- CDK env var only. The handler's in-code fallback (200) is intentionally untouched; unit tests pass explicit `batchLimit` values and don't pin the deployed setting.
- Verified: `cdk synth AIStudio-DatabaseStack-Dev` renders `SWEEP_BATCH_LIMIT: "500"`; lint 0 errors; typecheck clean.

Refs #1330.