### PR TITLE
fix(oauth): update Atrium Capture browser identity

### DIFF
--- a/docs/guides/oauth-integration.md
+++ b/docs/guides/oauth-integration.md
@@ -76,9 +76,11 @@ OAuth `state` before exchanging the code. The redirect URI must match the
 registered extension id and `/atrium` path exactly.
 
 Browser CORS trust is registered separately from redirect trust. The production
-Atrium Capture client `ae781263-20c0-4b0c-8a34-8be01ab72fb1` allows only the
-exact caller origin
-`chrome-extension://jldnpmcpimhabiphcglkbgmbffpoocpo` on token requests for
+Atrium Capture client `ae781263-20c0-4b0c-8a34-8be01ab72fb1` uses the exact
+callback
+`https://eomlblaiglafndhplfhilmdcaofhkkbj.chromiumapp.org/atrium` and allows
+only the exact caller origin
+`chrome-extension://eomlblaiglafndhplfhilmdcaofhkkbj` on token requests for
 `authorization_code` and `refresh_token`, and on revocation. Successful CORS
 handling echoes that exact origin; it never uses `*`. No origin is inferred from
 the Chromium HTTPS redirect URI.

--- a/infra/database/migrations.json
+++ b/infra/database/migrations.json
@@ -131,6 +131,7 @@
     "134-oauth-first-party-clients.sql",
     "135-atrium-asset-initiation-idempotency.sql",
     "136-google-content-connectors.sql",
-    "137-nexus-conversation-retention.sql"
+    "137-nexus-conversation-retention.sql",
+    "138-atrium-capture-browser-registration.sql"
   ]
 }

--- a/infra/database/schema/138-atrium-capture-browser-registration.sql
+++ b/infra/database/schema/138-atrium-capture-browser-registration.sql
@@ -1,0 +1,31 @@
+-- Migration 138: Replace the Atrium Capture browser-extension registration.
+--
+-- The Chrome Web Store build has a new permanent extension id. OAuth redirect
+-- registration and browser CORS trust are independent: this migration updates
+-- only the persisted callback, while lib/oauth/client-origin-policy.ts owns the
+-- exact chrome-extension:// origin allowlist.
+--
+-- The exact old callback and public-PKCE profile guard against overwriting an
+-- administrator-modified or unrelated client. Re-running after a successful
+-- update is an intentional no-op.
+--
+-- Rollback:
+-- UPDATE oauth_clients
+-- SET
+--   redirect_uris = '["https://jldnpmcpimhabiphcglkbgmbffpoocpo.chromiumapp.org/atrium"]'::jsonb,
+--   updated_at = NOW()
+-- WHERE client_id = 'ae781263-20c0-4b0c-8a34-8be01ab72fb1'
+--   AND redirect_uris = '["https://eomlblaiglafndhplfhilmdcaofhkkbj.chromiumapp.org/atrium"]'::jsonb;
+
+UPDATE oauth_clients
+SET
+  redirect_uris = '["https://eomlblaiglafndhplfhilmdcaofhkkbj.chromiumapp.org/atrium"]'::jsonb,
+  updated_at = NOW()
+WHERE client_id = 'ae781263-20c0-4b0c-8a34-8be01ab72fb1'
+  AND application_type = 'browser_extension'
+  AND token_endpoint_auth_method = 'none'
+  AND client_secret_hash IS NULL
+  AND require_pkce = true
+  AND is_first_party = true
+  AND is_active = true
+  AND redirect_uris = '["https://jldnpmcpimhabiphcglkbgmbffpoocpo.chromiumapp.org/atrium"]'::jsonb;

--- a/lib/oauth/client-origin-policy.ts
+++ b/lib/oauth/client-origin-policy.ts
@@ -10,7 +10,7 @@ export const ATRIUM_CAPTURE_BROWSER_CLIENT_ID =
   "ae781263-20c0-4b0c-8a34-8be01ab72fb1"
 
 export const ATRIUM_CAPTURE_EXTENSION_ORIGIN =
-  "chrome-extension://jldnpmcpimhabiphcglkbgmbffpoocpo"
+  "chrome-extension://eomlblaiglafndhplfhilmdcaofhkkbj"
 
 const ATRIUM_CAPTURE_TOKEN_GRANTS = new Set([
   "authorization_code",

--- a/scripts/test/oauth-public-client-flow.smoke.ts
+++ b/scripts/test/oauth-public-client-flow.smoke.ts
@@ -263,7 +263,7 @@ async function main(): Promise<void> {
   }
   const clientId = "ae781263-20c0-4b0c-8a34-8be01ab72fb1"
   const redirectUri =
-    "https://jldnpmcpimhabiphcglkbgmbffpoocpo.chromiumapp.org/atrium"
+    "https://eomlblaiglafndhplfhilmdcaofhkkbj.chromiumapp.org/atrium"
   const nativeClientId = "fbdaa815-1b0f-435b-805f-1732805720c1"
   const nativeRedirectUri =
     "org.psd401.atrium-capture:/oauth/callback"
@@ -724,8 +724,17 @@ async function main(): Promise<void> {
       authorizationUrl({
         clientId,
         redirectUri:
-          "https://jldnpmcpimhabiphcglkbgmbffpoocpo.chromiumapp.org/wrong",
+          "https://eomlblaiglafndhplfhilmdcaofhkkbj.chromiumapp.org/wrong",
         state: "callback-mismatch",
+      }),
+      "invalid_redirect_uri"
+    )
+    await assertAuthorizationRejected(
+      authorizationUrl({
+        clientId,
+        redirectUri:
+          "https://jldnpmcpimhabiphcglkbgmbffpoocpo.chromiumapp.org/atrium",
+        state: "retired-extension-callback",
       }),
       "invalid_redirect_uri"
     )

--- a/tests/unit/lib/oauth/client-origin-policy.test.ts
+++ b/tests/unit/lib/oauth/client-origin-policy.test.ts
@@ -45,6 +45,13 @@ describe("OAuth client browser-origin policy", () => {
       grantType: "authorization_code",
     },
     {
+      name: "retired extension",
+      clientId: ATRIUM_CAPTURE_BROWSER_CLIENT_ID,
+      origin: "chrome-extension://jldnpmcpimhabiphcglkbgmbffpoocpo",
+      route: "token",
+      grantType: "authorization_code",
+    },
+    {
       name: "origin suffix",
       clientId: ATRIUM_CAPTURE_BROWSER_CLIENT_ID,
       origin: `${ATRIUM_CAPTURE_EXTENSION_ORIGIN}.example`,
@@ -54,7 +61,7 @@ describe("OAuth client browser-origin policy", () => {
     {
       name: "redirect origin",
       clientId: ATRIUM_CAPTURE_BROWSER_CLIENT_ID,
-      origin: "https://jldnpmcpimhabiphcglkbgmbffpoocpo.chromiumapp.org",
+      origin: "https://eomlblaiglafndhplfhilmdcaofhkkbj.chromiumapp.org",
       route: "token",
       grantType: "authorization_code",
     },

--- a/tests/unit/oauth-browser-client-registration-migration.test.ts
+++ b/tests/unit/oauth-browser-client-registration-migration.test.ts
@@ -1,0 +1,31 @@
+import fs from "node:fs"
+import path from "node:path"
+
+const migrationPath = path.join(
+  process.cwd(),
+  "infra/database/schema/138-atrium-capture-browser-registration.sql"
+)
+const migration = fs.readFileSync(migrationPath, "utf8")
+
+describe("Atrium Capture browser registration migration", () => {
+  it("replaces the exact old callback for the existing browser client", () => {
+    expect(migration).toContain(
+      "ae781263-20c0-4b0c-8a34-8be01ab72fb1"
+    )
+    expect(migration).toContain(
+      "https://jldnpmcpimhabiphcglkbgmbffpoocpo.chromiumapp.org/atrium"
+    )
+    expect(migration).toContain(
+      "https://eomlblaiglafndhplfhilmdcaofhkkbj.chromiumapp.org/atrium"
+    )
+  })
+
+  it("requires the trusted public-PKCE browser profile", () => {
+    expect(migration).toContain("application_type = 'browser_extension'")
+    expect(migration).toContain("token_endpoint_auth_method = 'none'")
+    expect(migration).toContain("client_secret_hash IS NULL")
+    expect(migration).toContain("require_pkce = true")
+    expect(migration).toContain("is_first_party = true")
+    expect(migration).toContain("is_active = true")
+  })
+})


### PR DESCRIPTION
## Summary
- replace the Atrium Capture browser callback with `https://eomlblaiglafndhplfhilmdcaofhkkbj.chromiumapp.org/atrium`
- allow only the matching extension origin `chrome-extension://eomlblaiglafndhplfhilmdcaofhkkbj`
- add migration 138 to update the existing trusted public-PKCE browser client safely and idempotently
- update OAuth documentation and regression coverage, including rejection of the retired client identity

## Validation
- `bun run test:oauth-public-flow`
- focused OAuth origin and migration Jest suites (21 tests passed)
- `bun run migration:list`
- migration 138 applied twice against local PostgreSQL (UPDATE 1, then UPDATE 0) and verified
- `bun run typecheck`
- `bun run lint` (0 errors; existing warnings only)

## E2E note
The authenticated pre-push suite was explicitly skipped after its reused local server on port 3100 exited mid-run. Tests through the earlier Atrium coverage passed before the server loss; no OAuth-focused failure occurred.