### PR TITLE
fix: #1303 - enforce one agent_identities row per name

### DIFF
--- a/infra/database/migrations.json
+++ b/infra/database/migrations.json
@@ -132,6 +132,7 @@
     "135-atrium-asset-initiation-idempotency.sql",
     "136-google-content-connectors.sql",
     "137-nexus-conversation-retention.sql",
-    "138-atrium-capture-browser-registration.sql"
+    "138-atrium-capture-browser-registration.sql",
+    "140-agent-identities-name-unique.sql"
   ]
 }

--- a/infra/database/schema/140-agent-identities-name-unique.sql
+++ b/infra/database/schema/140-agent-identities-name-unique.sql
@@ -26,96 +26,115 @@
 -- single-rowed only because its deterministic id made the copy's id-conflict
 -- actually fire.
 --
--- Duplicate actor rows split attribution: six columns FK to agent_identities
--- (content_objects.created_by_agent_id, content_versions.author_agent_id,
--- content_audit_logs.agent_id, content_publish_requests.requested_by_agent_id,
--- atrium_doc_comments.author_agent_id, content_assets.uploader_agent_id), and
--- which duplicate a given code path resolves depends on which one its lookup
--- happened to return. (`scheduled_executions.agent_identity_id`, listed on
--- #1303, no longer exists — migration 133 dropped that table.)
+-- Six columns FK to agent_identities: content_objects.created_by_agent_id,
+-- content_versions.author_agent_id, content_audit_logs.agent_id,
+-- content_publish_requests.requested_by_agent_id,
+-- atrium_doc_comments.author_agent_id, content_assets.uploader_agent_id.
+-- (`scheduled_executions.agent_identity_id`, listed on #1303, no longer exists
+-- — migration 133 dropped that table.)
 --
--- WHAT THIS DOES, IN ONE STATEMENT.
---   1. Repoints every FK reference away from duplicate rows onto one canonical
---      row per name.
---   2. Deletes the now-unreferenced duplicates.
---   3. (Second statement) Adds a UNIQUE index on `name`, so no future seeding
---      path — migration, script, data copy, or application code — can create a
---      second row for a name regardless of what id it picks. This replaces
---      three racy read-then-write guards with one database-enforced invariant.
+-- ============================================================================
+-- WHY THIS MIGRATION DOES NOT DELETE ANYTHING
+-- ============================================================================
 --
--- WHY ONE STATEMENT, AND WHY `FOR UPDATE`. This is the correctness crux, so it
--- is spelled out. infra/database/lambda/db-init-handler.ts issues each
--- statement as its own RDS Data API ExecuteStatementCommand, and the Data API
--- gives no way to span a transaction across calls (a bare `BEGIN;` would not
--- persist). Written as seven statements — six repoints then a delete — the
--- migration has a window against a LIVE application: a request can resolve a
--- soon-to-be-deleted identity and insert an audit log, publish request, comment
--- or asset AFTER that table's repoint has already committed. Every one of those
--- FKs is `ON DELETE SET NULL`, so the delete would then SILENTLY erase the new
--- row's agent attribution instead of failing.
+-- The obvious shape — repoint the FKs onto a canonical row, then DELETE the
+-- duplicates — is NOT SAFE here, and two earlier drafts of this file got it
+-- wrong in two different ways. Both failures share one root cause: EVERY ONE of
+-- those six foreign keys is `ON DELETE SET NULL`, so a child row the repoint
+-- misses is not rejected — it is SILENTLY stripped of its agent attribution.
+-- That is exactly the class of silent failure this migration exists to prevent.
 --
--- So the repoints and the delete are a SINGLE statement built from
--- data-modifying CTEs. One statement is one transaction, which closes the
--- window for everything already committed at the statement's snapshot. The
--- remaining hazard — a writer that commits AFTER the snapshot but BEFORE the
--- delete reaches the parent row — is closed by `FOR UPDATE OF a` in the
--- `dupes` CTE: inserting a child row takes a FOR KEY SHARE lock on the parent,
--- which conflicts with FOR UPDATE, so any such writer BLOCKS until this
--- statement commits and then fails loudly on a foreign-key violation rather
--- than losing its attribution silently. `dupes` is declared MATERIALIZED so the
--- lock is genuinely taken before the dependent CTEs run, not inlined into each.
+-- Draft 1, seven separate statements (six repoints, then the delete):
+-- infra/database/lambda/db-init-handler.ts issues each statement as its own RDS
+-- Data API ExecuteStatementCommand and the Data API cannot span a transaction
+-- across calls, so each committed independently. Against a live application a
+-- request could insert a child row referencing a duplicate AFTER that table's
+-- repoint had committed; the delete then nulled it.
 --
--- No quiesce window is therefore required to deploy this.
+-- Draft 2, one statement of data-modifying CTEs plus `FOR UPDATE OF a`: closer,
+-- but still wrong on two counts.
+--   (a) A writer that took its `FOR KEY SHARE` lock just BEFORE this statement
+--       began commits while the delete waits on it. The statement's snapshot
+--       was already taken, so the repoint CTEs cannot see that newly committed
+--       child row, and the delete nulls it anyway.
+--   (b) PostgreSQL gives NO execution-order guarantee between sibling
+--       data-modifying CTEs and the main query, and explicitly documents that
+--       having the main query delete a parent whose FK action is ON DELETE SET
+--       NULL while a WITH sub-statement touches the same child rows leaves the
+--       outcome UNDEFINED. A passing test only proves the plan chosen that day.
+--
+-- Rather than try to out-lock a race whose safe form needs a transaction the
+-- runner cannot give us, this migration REMOVES THE DELETE. Duplicates are
+-- TOMBSTONED instead: renamed out of the way and deactivated.
+--
+--   * No row is ever deleted, so `ON DELETE SET NULL` never fires and NO child
+--     row can lose its attribution — no matter how the statements interleave
+--     with live traffic. The failure mode is designed out rather than guarded
+--     against.
+--   * A child row inserted concurrently, which the repoint therefore misses,
+--     still points at a row that EXISTS. Its attribution is stale, not lost,
+--     and it is trivially recoverable because the tombstone records exactly
+--     which identity it was.
+--   * Names become distinct, so the unique index can be created.
+--   * No quiesce window, no table lock, and no reliance on undefined ordering.
+--
+-- Tombstones are inert: `is_active = false`, and the name is mangled so no
+-- lookup by the real name can reach them. An operator can delete them later,
+-- deliberately and with no live traffic — which is when a delete is safe.
 --
 -- CANONICAL-ROW CHOICE (ORDER BY inside the DISTINCT ON), most significant first:
 --   a. `(id <> '0a710f00-0000-4000-a000-000000000f36')` ascending -> the row
---      whose id APPLICATION CODE PINS sorts first and can never be the one
---      deleted. lib/content/okf/import.ts exports that literal as
---      ATRIUM_IMPORT_AGENT_ID and writes it straight into
---      content_publish_requests.requested_by_agent_id without a lookup, so if
---      a duplicate `atrium-importer` ever outranked it every OKF import would
---      start failing on an FK violation. This is the only id any code pins;
---      the predicate is a no-op for every other name.
+--      whose id APPLICATION CODE PINS sorts first and can never be tombstoned.
+--      lib/content/okf/import.ts exports that literal as ATRIUM_IMPORT_AGENT_ID
+--      and writes it straight into
+--      content_publish_requests.requested_by_agent_id without a lookup. This is
+--      the only id any code pins; the predicate is a no-op for every other name.
 --   b. `(oauth_client_id IS NULL)` ascending -> rows BOUND to an OIDC client
---      sort first. Deleting a bound row would break that agent's
---      client-credentials authentication, so a bound row always wins over an
---      unbound one.
+--      sort first. Tombstoning a bound row would break that agent's
+--      client-credentials authentication.
 --   c. `created_at` ascending -> the oldest row wins. On prod that is the row
---      copied from dev, so dev and prod converge on the same identity rather
---      than diverging further.
+--      copied from dev, so dev and prod converge rather than diverging further.
 --   d. `id` ascending -> a total order, so the choice is deterministic even
 --      when (a)-(c) tie.
 --
--- FAIL-LOUD. If the dedupe somehow left a duplicate behind, CREATE UNIQUE INDEX
--- raises "could not create unique index ... is duplicated", which matches
--- neither the "already exists" nor the CREATE TYPE / ALTER TABLE special cases
--- in scripts/db/run-migrations.ts or infra/database/lambda/db-init-handler.ts.
--- The deploy fails instead of silently shipping an unenforced invariant.
+-- FAIL-LOUD. If the tombstone pass somehow left two rows sharing a name,
+-- CREATE UNIQUE INDEX raises "could not create unique index ... is duplicated",
+-- which matches neither the "already exists" nor the CREATE TYPE / ALTER TABLE
+-- special cases in scripts/db/run-migrations.ts or
+-- infra/database/lambda/db-init-handler.ts. The deploy fails rather than
+-- silently shipping an unenforced invariant.
 --
--- IDEMPOTENT. On an environment with no duplicates `dupes` is empty, so every
--- CTE touches zero rows and takes no locks, and the index is created once
--- (IF NOT EXISTS). Plain (non-CONCURRENT) CREATE UNIQUE INDEX: CONCURRENTLY is
--- rejected by the db-init validator, and this table holds single-digit rows.
+-- IDEMPOTENT. On an environment with no duplicates every statement matches zero
+-- rows and the index is created once (IF NOT EXISTS). The tombstone name embeds
+-- the row's own id and the `a.id <> c.id` guard is unchanged by it, so a second
+-- run cannot re-tombstone an already-tombstoned row. Plain (non-CONCURRENT)
+-- CREATE UNIQUE INDEX: CONCURRENTLY is rejected by the db-init validator, and
+-- this table holds single-digit rows.
 --
 -- Plain SQL statements only -- no PL/pgSQL anonymous blocks, which the db-init
 -- statement splitter cannot parse (it enters block mode only on
 -- CREATE TYPE/FUNCTION and DROP TYPE).
 
 -- ---------------------------------------------------------------------------
--- 1) Repoint every FK reference onto the canonical row, then delete the
---    duplicates -- atomically, and holding a lock that blocks new references.
+-- 1) Consolidate attribution: repoint every FK reference from a duplicate row
+--    onto the canonical row for that name.
+--
+--    Six plain UPDATEs on six DISTINCT tables, none of which fires a foreign
+--    key action, so the "sibling CTE ordering is unpredictable" caveat has
+--    nothing to bite on here — the sub-statements cannot interact. This pass is
+--    best-effort by design: anything it misses keeps a valid pointer to the
+--    tombstone, which is why step 2 must not delete.
 -- ---------------------------------------------------------------------------
 
 WITH canon AS (
   SELECT DISTINCT ON (name) name, id
   FROM agent_identities
   ORDER BY name, (id <> '0a710f00-0000-4000-a000-000000000f36'), (oauth_client_id IS NULL), created_at, id
-), dupes AS MATERIALIZED (
+), dupes AS (
   SELECT a.id AS dup_id, c.id AS keep_id
   FROM agent_identities a
   JOIN canon c ON c.name = a.name
   WHERE a.id <> c.id
-  FOR UPDATE OF a
 ), repoint_objects AS (
   UPDATE content_objects t
   SET created_by_agent_id = d.keep_id
@@ -146,19 +165,33 @@ WITH canon AS (
   FROM dupes d
   WHERE t.author_agent_id = d.dup_id
   RETURNING 1
-), repoint_assets AS (
-  UPDATE content_assets t
-  SET uploader_agent_id = d.keep_id
-  FROM dupes d
-  WHERE t.uploader_agent_id = d.dup_id
-  RETURNING 1
 )
-DELETE FROM agent_identities a
-USING dupes d
-WHERE a.id = d.dup_id;
+UPDATE content_assets t
+SET uploader_agent_id = d.keep_id
+FROM dupes d
+WHERE t.uploader_agent_id = d.dup_id;
 
 -- ---------------------------------------------------------------------------
--- 2) Enforce one row per name from here on.
+-- 2) Tombstone the duplicates: deactivate them and move their names aside so
+--    `name` becomes unique. NOT a delete — see the header. `left(name, 150)`
+--    keeps the result inside varchar(200): 150 + '#dup-' (5) + a 36-char uuid
+--    = 191.
+-- ---------------------------------------------------------------------------
+
+WITH canon AS (
+  SELECT DISTINCT ON (name) name, id
+  FROM agent_identities
+  ORDER BY name, (id <> '0a710f00-0000-4000-a000-000000000f36'), (oauth_client_id IS NULL), created_at, id
+)
+UPDATE agent_identities a
+SET name = left(a.name, 150) || '#dup-' || a.id,
+    is_active = false
+FROM canon c
+WHERE c.name = a.name
+  AND a.id <> c.id;
+
+-- ---------------------------------------------------------------------------
+-- 3) Enforce one row per name from here on.
 -- ---------------------------------------------------------------------------
 
 CREATE UNIQUE INDEX IF NOT EXISTS uq_agent_identities_name

--- a/infra/database/schema/140-agent-identities-name-unique.sql
+++ b/infra/database/schema/140-agent-identities-name-unique.sql
@@ -89,13 +89,22 @@
 --      and writes it straight into
 --      content_publish_requests.requested_by_agent_id without a lookup. This is
 --      the only id any code pins; the predicate is a no-op for every other name.
---   b. `(oauth_client_id IS NULL)` ascending -> rows BOUND to an OIDC client
---      sort first. Tombstoning a bound row would break that agent's
---      client-credentials authentication.
---   c. `created_at` ascending -> the oldest row wins. On prod that is the row
+--   b. `(NOT is_active)` ascending -> ACTIVE rows sort first. Runtime identity
+--      resolution requires is_active (lib/content/requester-from-auth.ts
+--      findAgentIdentity filters on it), so keeping an inactive row and
+--      tombstoning the active one would leave that agent with NO usable
+--      identity. Ranked above the binding test on purpose: an inactive row is
+--      already unusable at runtime whether or not it is bound to a client, so
+--      an active-but-unbound row is the better survivor of that pair.
+--   c. `(oauth_client_id IS NULL)` ascending -> among rows equal on (a)-(b),
+--      those BOUND to an OIDC client sort first. Tombstoning a bound row would
+--      break that agent's client-credentials authentication.
+--   d. `created_at` ascending -> the oldest row wins. On prod that is the row
 --      copied from dev, so dev and prod converge rather than diverging further.
---   d. `id` ascending -> a total order, so the choice is deterministic even
---      when (a)-(c) tie.
+--   e. `id` ascending -> a total order, so the choice is deterministic even
+--      when (a)-(d) tie.
+--
+--   `is_active` is NOT NULL (085), so (b) has no NULL-ordering subtlety.
 --
 -- FAIL-LOUD. If the tombstone pass somehow left two rows sharing a name,
 -- CREATE UNIQUE INDEX raises "could not create unique index ... is duplicated",
@@ -155,7 +164,7 @@ CREATE INDEX IF NOT EXISTS idx_content_assets_uploader_agent_id
 WITH canon AS (
   SELECT DISTINCT ON (name) name, id
   FROM agent_identities
-  ORDER BY name, (id <> '0a710f00-0000-4000-a000-000000000f36'), (oauth_client_id IS NULL), created_at, id
+  ORDER BY name, (id <> '0a710f00-0000-4000-a000-000000000f36'), (NOT is_active), (oauth_client_id IS NULL), created_at, id
 ), dupes AS (
   SELECT a.id AS dup_id, c.id AS keep_id
   FROM agent_identities a
@@ -207,7 +216,7 @@ WHERE t.uploader_agent_id = d.dup_id;
 WITH canon AS (
   SELECT DISTINCT ON (name) name, id
   FROM agent_identities
-  ORDER BY name, (id <> '0a710f00-0000-4000-a000-000000000f36'), (oauth_client_id IS NULL), created_at, id
+  ORDER BY name, (id <> '0a710f00-0000-4000-a000-000000000f36'), (NOT is_active), (oauth_client_id IS NULL), created_at, id
 )
 UPDATE agent_identities a
 SET name = left(a.name, 150) || '#dup-' || a.id,

--- a/infra/database/schema/140-agent-identities-name-unique.sql
+++ b/infra/database/schema/140-agent-identities-name-unique.sql
@@ -34,14 +34,38 @@
 -- happened to return. (`scheduled_executions.agent_identity_id`, listed on
 -- #1303, no longer exists — migration 133 dropped that table.)
 --
--- WHAT THIS DOES.
+-- WHAT THIS DOES, IN ONE STATEMENT.
 --   1. Repoints every FK reference away from duplicate rows onto one canonical
 --      row per name.
 --   2. Deletes the now-unreferenced duplicates.
---   3. Adds a UNIQUE index on `name`, so no future seeding path — migration,
---      script, data copy, or application code — can create a second row for a
---      name regardless of what id it picks. This replaces three racy
---      read-then-write guards with one database-enforced invariant.
+--   3. (Second statement) Adds a UNIQUE index on `name`, so no future seeding
+--      path — migration, script, data copy, or application code — can create a
+--      second row for a name regardless of what id it picks. This replaces
+--      three racy read-then-write guards with one database-enforced invariant.
+--
+-- WHY ONE STATEMENT, AND WHY `FOR UPDATE`. This is the correctness crux, so it
+-- is spelled out. infra/database/lambda/db-init-handler.ts issues each
+-- statement as its own RDS Data API ExecuteStatementCommand, and the Data API
+-- gives no way to span a transaction across calls (a bare `BEGIN;` would not
+-- persist). Written as seven statements — six repoints then a delete — the
+-- migration has a window against a LIVE application: a request can resolve a
+-- soon-to-be-deleted identity and insert an audit log, publish request, comment
+-- or asset AFTER that table's repoint has already committed. Every one of those
+-- FKs is `ON DELETE SET NULL`, so the delete would then SILENTLY erase the new
+-- row's agent attribution instead of failing.
+--
+-- So the repoints and the delete are a SINGLE statement built from
+-- data-modifying CTEs. One statement is one transaction, which closes the
+-- window for everything already committed at the statement's snapshot. The
+-- remaining hazard — a writer that commits AFTER the snapshot but BEFORE the
+-- delete reaches the parent row — is closed by `FOR UPDATE OF a` in the
+-- `dupes` CTE: inserting a child row takes a FOR KEY SHARE lock on the parent,
+-- which conflicts with FOR UPDATE, so any such writer BLOCKS until this
+-- statement commits and then fails loudly on a foreign-key violation rather
+-- than losing its attribution silently. `dupes` is declared MATERIALIZED so the
+-- lock is genuinely taken before the dependent CTEs run, not inlined into each.
+--
+-- No quiesce window is therefore required to deploy this.
 --
 -- CANONICAL-ROW CHOICE (ORDER BY inside the DISTINCT ON), most significant first:
 --   a. `(id <> '0a710f00-0000-4000-a000-000000000f36')` ascending -> the row
@@ -62,140 +86,79 @@
 --   d. `id` ascending -> a total order, so the choice is deterministic even
 --      when (a)-(c) tie.
 --
--- NOT ATOMIC, BY CONSTRUCTION. infra/database/lambda/db-init-handler.ts issues
--- each statement as its own RDS Data API ExecuteStatementCommand, so the
--- repoints, the delete and the index each commit separately (this is also why
--- the canonical rule is repeated per statement rather than staged in a TEMP
--- table — a temp table would not survive between calls). Every statement is
--- individually idempotent and they are ordered so a crash midway leaves the
--- database consistent: partially-repointed rows already point at the row the
--- next run will re-select as canonical.
---
--- FAIL-LOUD. If step 1/2 somehow left a duplicate behind, CREATE UNIQUE INDEX
+-- FAIL-LOUD. If the dedupe somehow left a duplicate behind, CREATE UNIQUE INDEX
 -- raises "could not create unique index ... is duplicated", which matches
 -- neither the "already exists" nor the CREATE TYPE / ALTER TABLE special cases
 -- in scripts/db/run-migrations.ts or infra/database/lambda/db-init-handler.ts.
 -- The deploy fails instead of silently shipping an unenforced invariant.
 --
--- IDEMPOTENT. On an environment with no duplicates the UPDATE/DELETE statements
--- match zero rows and the index is created once (IF NOT EXISTS). Plain
--- (non-CONCURRENT) CREATE UNIQUE INDEX: CONCURRENTLY is rejected by the db-init
--- validator, and this table holds single-digit rows.
+-- IDEMPOTENT. On an environment with no duplicates `dupes` is empty, so every
+-- CTE touches zero rows and takes no locks, and the index is created once
+-- (IF NOT EXISTS). Plain (non-CONCURRENT) CREATE UNIQUE INDEX: CONCURRENTLY is
+-- rejected by the db-init validator, and this table holds single-digit rows.
 --
 -- Plain SQL statements only -- no PL/pgSQL anonymous blocks, which the db-init
 -- statement splitter cannot parse (it enters block mode only on
 -- CREATE TYPE/FUNCTION and DROP TYPE).
 
 -- ---------------------------------------------------------------------------
--- 1) Repoint FK references from duplicate rows to the canonical row per name.
+-- 1) Repoint every FK reference onto the canonical row, then delete the
+--    duplicates -- atomically, and holding a lock that blocks new references.
 -- ---------------------------------------------------------------------------
 
 WITH canon AS (
   SELECT DISTINCT ON (name) name, id
   FROM agent_identities
   ORDER BY name, (id <> '0a710f00-0000-4000-a000-000000000f36'), (oauth_client_id IS NULL), created_at, id
-), dupes AS (
+), dupes AS MATERIALIZED (
   SELECT a.id AS dup_id, c.id AS keep_id
   FROM agent_identities a
   JOIN canon c ON c.name = a.name
   WHERE a.id <> c.id
-)
-UPDATE content_objects t
-SET created_by_agent_id = d.keep_id
-FROM dupes d
-WHERE t.created_by_agent_id = d.dup_id;
-
-WITH canon AS (
-  SELECT DISTINCT ON (name) name, id
-  FROM agent_identities
-  ORDER BY name, (id <> '0a710f00-0000-4000-a000-000000000f36'), (oauth_client_id IS NULL), created_at, id
-), dupes AS (
-  SELECT a.id AS dup_id, c.id AS keep_id
-  FROM agent_identities a
-  JOIN canon c ON c.name = a.name
-  WHERE a.id <> c.id
-)
-UPDATE content_versions t
-SET author_agent_id = d.keep_id
-FROM dupes d
-WHERE t.author_agent_id = d.dup_id;
-
-WITH canon AS (
-  SELECT DISTINCT ON (name) name, id
-  FROM agent_identities
-  ORDER BY name, (id <> '0a710f00-0000-4000-a000-000000000f36'), (oauth_client_id IS NULL), created_at, id
-), dupes AS (
-  SELECT a.id AS dup_id, c.id AS keep_id
-  FROM agent_identities a
-  JOIN canon c ON c.name = a.name
-  WHERE a.id <> c.id
-)
-UPDATE content_audit_logs t
-SET agent_id = d.keep_id
-FROM dupes d
-WHERE t.agent_id = d.dup_id;
-
-WITH canon AS (
-  SELECT DISTINCT ON (name) name, id
-  FROM agent_identities
-  ORDER BY name, (id <> '0a710f00-0000-4000-a000-000000000f36'), (oauth_client_id IS NULL), created_at, id
-), dupes AS (
-  SELECT a.id AS dup_id, c.id AS keep_id
-  FROM agent_identities a
-  JOIN canon c ON c.name = a.name
-  WHERE a.id <> c.id
-)
-UPDATE content_publish_requests t
-SET requested_by_agent_id = d.keep_id
-FROM dupes d
-WHERE t.requested_by_agent_id = d.dup_id;
-
-WITH canon AS (
-  SELECT DISTINCT ON (name) name, id
-  FROM agent_identities
-  ORDER BY name, (id <> '0a710f00-0000-4000-a000-000000000f36'), (oauth_client_id IS NULL), created_at, id
-), dupes AS (
-  SELECT a.id AS dup_id, c.id AS keep_id
-  FROM agent_identities a
-  JOIN canon c ON c.name = a.name
-  WHERE a.id <> c.id
-)
-UPDATE atrium_doc_comments t
-SET author_agent_id = d.keep_id
-FROM dupes d
-WHERE t.author_agent_id = d.dup_id;
-
-WITH canon AS (
-  SELECT DISTINCT ON (name) name, id
-  FROM agent_identities
-  ORDER BY name, (id <> '0a710f00-0000-4000-a000-000000000f36'), (oauth_client_id IS NULL), created_at, id
-), dupes AS (
-  SELECT a.id AS dup_id, c.id AS keep_id
-  FROM agent_identities a
-  JOIN canon c ON c.name = a.name
-  WHERE a.id <> c.id
-)
-UPDATE content_assets t
-SET uploader_agent_id = d.keep_id
-FROM dupes d
-WHERE t.uploader_agent_id = d.dup_id;
-
--- ---------------------------------------------------------------------------
--- 2) Delete the duplicates (now unreferenced by any FK).
--- ---------------------------------------------------------------------------
-
-WITH canon AS (
-  SELECT DISTINCT ON (name) name, id
-  FROM agent_identities
-  ORDER BY name, (id <> '0a710f00-0000-4000-a000-000000000f36'), (oauth_client_id IS NULL), created_at, id
+  FOR UPDATE OF a
+), repoint_objects AS (
+  UPDATE content_objects t
+  SET created_by_agent_id = d.keep_id
+  FROM dupes d
+  WHERE t.created_by_agent_id = d.dup_id
+  RETURNING 1
+), repoint_versions AS (
+  UPDATE content_versions t
+  SET author_agent_id = d.keep_id
+  FROM dupes d
+  WHERE t.author_agent_id = d.dup_id
+  RETURNING 1
+), repoint_audit AS (
+  UPDATE content_audit_logs t
+  SET agent_id = d.keep_id
+  FROM dupes d
+  WHERE t.agent_id = d.dup_id
+  RETURNING 1
+), repoint_publish_requests AS (
+  UPDATE content_publish_requests t
+  SET requested_by_agent_id = d.keep_id
+  FROM dupes d
+  WHERE t.requested_by_agent_id = d.dup_id
+  RETURNING 1
+), repoint_comments AS (
+  UPDATE atrium_doc_comments t
+  SET author_agent_id = d.keep_id
+  FROM dupes d
+  WHERE t.author_agent_id = d.dup_id
+  RETURNING 1
+), repoint_assets AS (
+  UPDATE content_assets t
+  SET uploader_agent_id = d.keep_id
+  FROM dupes d
+  WHERE t.uploader_agent_id = d.dup_id
+  RETURNING 1
 )
 DELETE FROM agent_identities a
-USING canon c
-WHERE c.name = a.name
-  AND a.id <> c.id;
+USING dupes d
+WHERE a.id = d.dup_id;
 
 -- ---------------------------------------------------------------------------
--- 3) Enforce one row per name from here on.
+-- 2) Enforce one row per name from here on.
 -- ---------------------------------------------------------------------------
 
 CREATE UNIQUE INDEX IF NOT EXISTS uq_agent_identities_name

--- a/infra/database/schema/140-agent-identities-name-unique.sql
+++ b/infra/database/schema/140-agent-identities-name-unique.sql
@@ -116,6 +116,32 @@
 -- CREATE TYPE/FUNCTION and DROP TYPE).
 
 -- ---------------------------------------------------------------------------
+-- 0) Index the repointed FK columns. Five of the six child tables never
+--    indexed their agent-identity FK (only content_publish_requests did:
+--    idx_cpr_requested_by_agent_id, migration 096). Without these the repoint
+--    UPDATEs below seq-scan each child table — a cost re-paid on every future
+--    fresh stand-up, since this file runs permanently, and content_audit_logs
+--    in particular is expected to grow large. They also serve ordinary
+--    attribution lookups by agent. Plain (non-CONCURRENT) CREATE INDEX for the
+--    same reason as the unique index in step 3.
+-- ---------------------------------------------------------------------------
+
+CREATE INDEX IF NOT EXISTS idx_content_created_by_agent_id
+  ON content_objects (created_by_agent_id);
+
+CREATE INDEX IF NOT EXISTS idx_version_author_agent_id
+  ON content_versions (author_agent_id);
+
+CREATE INDEX IF NOT EXISTS idx_content_audit_agent_id
+  ON content_audit_logs (agent_id);
+
+CREATE INDEX IF NOT EXISTS idx_adc_author_agent_id
+  ON atrium_doc_comments (author_agent_id);
+
+CREATE INDEX IF NOT EXISTS idx_content_assets_uploader_agent_id
+  ON content_assets (uploader_agent_id);
+
+-- ---------------------------------------------------------------------------
 -- 1) Consolidate attribution: repoint every FK reference from a duplicate row
 --    onto the canonical row for that name.
 --

--- a/infra/database/schema/140-agent-identities-name-unique.sql
+++ b/infra/database/schema/140-agent-identities-name-unique.sql
@@ -1,0 +1,202 @@
+-- ============================================================================
+-- 140: de-duplicate agent_identities by name + make `name` a unique key (#1303)
+-- ============================================================================
+--
+-- WHY. `agent_identities.name` is the logical key every seeding path keys on,
+-- but the table only ever had a surrogate `id uuid PRIMARY KEY DEFAULT
+-- gen_random_uuid()` and NO uniqueness on `name`. Three independent paths write
+-- these rows:
+--
+--   1. migration 085 (§10d) — INSERT ... SELECT ... WHERE NOT EXISTS (name = ?)
+--      for `ship-reporter`, `screentime-bot`, `tutorial-publisher`. It does NOT
+--      pin an id, so every FRESH environment mints different random uuids and
+--      stamps created_at = now() at deploy time.
+--   2. migration 095 (§2) — `atrium-importer`, guarded on a FIXED id
+--      ('0a710f00-0000-4000-a000-000000000f36'), not on name.
+--   3. scripts/seed-atrium-agents.ts — looks the identity up by name and
+--      updates in place, but its INSERT had no ON CONFLICT clause.
+--
+-- Each guard is a read-then-write (TOCTOU) check against a column with no
+-- constraint behind it, and guards 1 and 2 key on DIFFERENT columns. On the
+-- fresh prod stand-up (2026-07-24) migration 085 seeded three rows with fresh
+-- random uuids at deploy time, and the dev->prod data copy then inserted dev's
+-- rows for the SAME three names — its ON CONFLICT was on `id`, which could not
+-- fire because the uuids differed. Result: `ship-reporter`, `screentime-bot`
+-- and `tutorial-publisher` each existed twice. `atrium-importer` survived
+-- single-rowed only because its deterministic id made the copy's id-conflict
+-- actually fire.
+--
+-- Duplicate actor rows split attribution: six columns FK to agent_identities
+-- (content_objects.created_by_agent_id, content_versions.author_agent_id,
+-- content_audit_logs.agent_id, content_publish_requests.requested_by_agent_id,
+-- atrium_doc_comments.author_agent_id, content_assets.uploader_agent_id), and
+-- which duplicate a given code path resolves depends on which one its lookup
+-- happened to return. (`scheduled_executions.agent_identity_id`, listed on
+-- #1303, no longer exists — migration 133 dropped that table.)
+--
+-- WHAT THIS DOES.
+--   1. Repoints every FK reference away from duplicate rows onto one canonical
+--      row per name.
+--   2. Deletes the now-unreferenced duplicates.
+--   3. Adds a UNIQUE index on `name`, so no future seeding path — migration,
+--      script, data copy, or application code — can create a second row for a
+--      name regardless of what id it picks. This replaces three racy
+--      read-then-write guards with one database-enforced invariant.
+--
+-- CANONICAL-ROW CHOICE (ORDER BY inside the DISTINCT ON), most significant first:
+--   a. `(id <> '0a710f00-0000-4000-a000-000000000f36')` ascending -> the row
+--      whose id APPLICATION CODE PINS sorts first and can never be the one
+--      deleted. lib/content/okf/import.ts exports that literal as
+--      ATRIUM_IMPORT_AGENT_ID and writes it straight into
+--      content_publish_requests.requested_by_agent_id without a lookup, so if
+--      a duplicate `atrium-importer` ever outranked it every OKF import would
+--      start failing on an FK violation. This is the only id any code pins;
+--      the predicate is a no-op for every other name.
+--   b. `(oauth_client_id IS NULL)` ascending -> rows BOUND to an OIDC client
+--      sort first. Deleting a bound row would break that agent's
+--      client-credentials authentication, so a bound row always wins over an
+--      unbound one.
+--   c. `created_at` ascending -> the oldest row wins. On prod that is the row
+--      copied from dev, so dev and prod converge on the same identity rather
+--      than diverging further.
+--   d. `id` ascending -> a total order, so the choice is deterministic even
+--      when (a)-(c) tie.
+--
+-- NOT ATOMIC, BY CONSTRUCTION. infra/database/lambda/db-init-handler.ts issues
+-- each statement as its own RDS Data API ExecuteStatementCommand, so the
+-- repoints, the delete and the index each commit separately (this is also why
+-- the canonical rule is repeated per statement rather than staged in a TEMP
+-- table — a temp table would not survive between calls). Every statement is
+-- individually idempotent and they are ordered so a crash midway leaves the
+-- database consistent: partially-repointed rows already point at the row the
+-- next run will re-select as canonical.
+--
+-- FAIL-LOUD. If step 1/2 somehow left a duplicate behind, CREATE UNIQUE INDEX
+-- raises "could not create unique index ... is duplicated", which matches
+-- neither the "already exists" nor the CREATE TYPE / ALTER TABLE special cases
+-- in scripts/db/run-migrations.ts or infra/database/lambda/db-init-handler.ts.
+-- The deploy fails instead of silently shipping an unenforced invariant.
+--
+-- IDEMPOTENT. On an environment with no duplicates the UPDATE/DELETE statements
+-- match zero rows and the index is created once (IF NOT EXISTS). Plain
+-- (non-CONCURRENT) CREATE UNIQUE INDEX: CONCURRENTLY is rejected by the db-init
+-- validator, and this table holds single-digit rows.
+--
+-- Plain SQL statements only -- no PL/pgSQL anonymous blocks, which the db-init
+-- statement splitter cannot parse (it enters block mode only on
+-- CREATE TYPE/FUNCTION and DROP TYPE).
+
+-- ---------------------------------------------------------------------------
+-- 1) Repoint FK references from duplicate rows to the canonical row per name.
+-- ---------------------------------------------------------------------------
+
+WITH canon AS (
+  SELECT DISTINCT ON (name) name, id
+  FROM agent_identities
+  ORDER BY name, (id <> '0a710f00-0000-4000-a000-000000000f36'), (oauth_client_id IS NULL), created_at, id
+), dupes AS (
+  SELECT a.id AS dup_id, c.id AS keep_id
+  FROM agent_identities a
+  JOIN canon c ON c.name = a.name
+  WHERE a.id <> c.id
+)
+UPDATE content_objects t
+SET created_by_agent_id = d.keep_id
+FROM dupes d
+WHERE t.created_by_agent_id = d.dup_id;
+
+WITH canon AS (
+  SELECT DISTINCT ON (name) name, id
+  FROM agent_identities
+  ORDER BY name, (id <> '0a710f00-0000-4000-a000-000000000f36'), (oauth_client_id IS NULL), created_at, id
+), dupes AS (
+  SELECT a.id AS dup_id, c.id AS keep_id
+  FROM agent_identities a
+  JOIN canon c ON c.name = a.name
+  WHERE a.id <> c.id
+)
+UPDATE content_versions t
+SET author_agent_id = d.keep_id
+FROM dupes d
+WHERE t.author_agent_id = d.dup_id;
+
+WITH canon AS (
+  SELECT DISTINCT ON (name) name, id
+  FROM agent_identities
+  ORDER BY name, (id <> '0a710f00-0000-4000-a000-000000000f36'), (oauth_client_id IS NULL), created_at, id
+), dupes AS (
+  SELECT a.id AS dup_id, c.id AS keep_id
+  FROM agent_identities a
+  JOIN canon c ON c.name = a.name
+  WHERE a.id <> c.id
+)
+UPDATE content_audit_logs t
+SET agent_id = d.keep_id
+FROM dupes d
+WHERE t.agent_id = d.dup_id;
+
+WITH canon AS (
+  SELECT DISTINCT ON (name) name, id
+  FROM agent_identities
+  ORDER BY name, (id <> '0a710f00-0000-4000-a000-000000000f36'), (oauth_client_id IS NULL), created_at, id
+), dupes AS (
+  SELECT a.id AS dup_id, c.id AS keep_id
+  FROM agent_identities a
+  JOIN canon c ON c.name = a.name
+  WHERE a.id <> c.id
+)
+UPDATE content_publish_requests t
+SET requested_by_agent_id = d.keep_id
+FROM dupes d
+WHERE t.requested_by_agent_id = d.dup_id;
+
+WITH canon AS (
+  SELECT DISTINCT ON (name) name, id
+  FROM agent_identities
+  ORDER BY name, (id <> '0a710f00-0000-4000-a000-000000000f36'), (oauth_client_id IS NULL), created_at, id
+), dupes AS (
+  SELECT a.id AS dup_id, c.id AS keep_id
+  FROM agent_identities a
+  JOIN canon c ON c.name = a.name
+  WHERE a.id <> c.id
+)
+UPDATE atrium_doc_comments t
+SET author_agent_id = d.keep_id
+FROM dupes d
+WHERE t.author_agent_id = d.dup_id;
+
+WITH canon AS (
+  SELECT DISTINCT ON (name) name, id
+  FROM agent_identities
+  ORDER BY name, (id <> '0a710f00-0000-4000-a000-000000000f36'), (oauth_client_id IS NULL), created_at, id
+), dupes AS (
+  SELECT a.id AS dup_id, c.id AS keep_id
+  FROM agent_identities a
+  JOIN canon c ON c.name = a.name
+  WHERE a.id <> c.id
+)
+UPDATE content_assets t
+SET uploader_agent_id = d.keep_id
+FROM dupes d
+WHERE t.uploader_agent_id = d.dup_id;
+
+-- ---------------------------------------------------------------------------
+-- 2) Delete the duplicates (now unreferenced by any FK).
+-- ---------------------------------------------------------------------------
+
+WITH canon AS (
+  SELECT DISTINCT ON (name) name, id
+  FROM agent_identities
+  ORDER BY name, (id <> '0a710f00-0000-4000-a000-000000000f36'), (oauth_client_id IS NULL), created_at, id
+)
+DELETE FROM agent_identities a
+USING canon c
+WHERE c.name = a.name
+  AND a.id <> c.id;
+
+-- ---------------------------------------------------------------------------
+-- 3) Enforce one row per name from here on.
+-- ---------------------------------------------------------------------------
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_agent_identities_name
+  ON agent_identities (name);

--- a/lib/db/schema/tables/agent-identities.ts
+++ b/lib/db/schema/tables/agent-identities.ts
@@ -13,6 +13,12 @@
  * - `scopes` — content scopes the identity holds (e.g. `content:create`,
  *   `content:publish_internal`). Autonomous identities never hold
  *   `content:publish_public` — the public-publish gate (§26.4) enforces this.
+ * - `name` — the logical key every seeding path (migrations 085/095,
+ *   scripts/seed-atrium-agents.ts) matches on. UNIQUE since migration 140
+ *   (#1303): before that constraint existed, two seeding paths keyed on
+ *   different columns (085 on name, 095 on a fixed id) could each insert a row
+ *   for the same name on a fresh environment. Upsert on this column — never
+ *   read-then-insert.
  * - `oauth_client_id` — the OIDC client-credentials client used to authenticate.
  */
 
@@ -22,22 +28,32 @@ import {
   pgTable,
   text,
   timestamp,
+  uniqueIndex,
   uuid,
   varchar,
 } from "drizzle-orm/pg-core";
 import { roles } from "./roles";
 import { agentIdentityKindEnum } from "../enums";
 
-export const agentIdentities = pgTable("agent_identities", {
-  id: uuid("id").defaultRandom().primaryKey(),
-  name: varchar("name", { length: 200 }).notNull(),
-  kind: agentIdentityKindEnum("kind").notNull(),
-  roleId: integer("role_id").references(() => roles.id),
-  scopes: text("scopes").array().notNull(),
-  oauthClientId: varchar("oauth_client_id", { length: 255 }),
-  isActive: boolean("is_active").default(true).notNull(),
-  createdAt: timestamp("created_at").defaultNow().notNull(),
-});
+export const agentIdentities = pgTable(
+  "agent_identities",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    name: varchar("name", { length: 200 }).notNull(),
+    kind: agentIdentityKindEnum("kind").notNull(),
+    roleId: integer("role_id").references(() => roles.id),
+    scopes: text("scopes").array().notNull(),
+    oauthClientId: varchar("oauth_client_id", { length: 255 }),
+    isActive: boolean("is_active").default(true).notNull(),
+    createdAt: timestamp("created_at").defaultNow().notNull(),
+  },
+  (table) => [
+    // Migration 140 (#1303). One row per logical identity, enforced by the
+    // database so no seeding path can add a second row for a name. This index
+    // is also the ON CONFLICT arbiter every upsert-by-name must target.
+    uniqueIndex("uq_agent_identities_name").on(table.name),
+  ]
+);
 
 export type AgentIdentityRow = typeof agentIdentities.$inferSelect;
 export type NewAgentIdentityRow = typeof agentIdentities.$inferInsert;

--- a/scripts/seed-atrium-agents.ts
+++ b/scripts/seed-atrium-agents.ts
@@ -115,22 +115,32 @@ async function seedAgent(agent: SeedAgent, roleId: number | null): Promise<void>
         },
       });
 
-    // Upsert the identity and bind it to the client.
-    if (existing) {
-      await tx
-        .update(agentIdentities)
-        .set({ scopes: agent.scopes, kind: agent.kind, roleId, oauthClientId: clientId, isActive: true })
-        .where(eq(agentIdentities.id, existing.id));
-    } else {
-      await tx.insert(agentIdentities).values({
+    // Upsert the identity by NAME and bind it to the client. The earlier
+    // read-then-insert (#1303) had no conflict target, so a concurrent or
+    // independent seeding path — migration 085's own name-guarded INSERT, a
+    // cross-environment data copy keyed on `id` — could land a SECOND row for
+    // the same name. `uq_agent_identities_name` (migration 140) is the arbiter:
+    // one row per name, whatever id it happens to hold.
+    await tx
+      .insert(agentIdentities)
+      .values({
         name: agent.name,
         kind: agent.kind,
         roleId,
         scopes: agent.scopes,
         oauthClientId: clientId,
         isActive: true,
+      })
+      .onConflictDoUpdate({
+        target: agentIdentities.name,
+        set: {
+          kind: agent.kind,
+          roleId,
+          scopes: agent.scopes,
+          oauthClientId: clientId,
+          isActive: true,
+        },
       });
-    }
   }, "seedAtriumAgents.seed");
 
   log.info(`+ ${agent.name}: created client ${clientId}`);

--- a/tests/unit/agent-identities-name-unique-migration.test.ts
+++ b/tests/unit/agent-identities-name-unique-migration.test.ts
@@ -113,25 +113,43 @@ describe("migration 140 — agent_identities name uniqueness (#1303)", () => {
     expect(uncovered).toEqual([]);
   });
 
-  it("keeps duplicates deleted only after the repoint, and never the canonical row", () => {
-    const repointEnd = migration.lastIndexOf("SET uploader_agent_id");
-    const deleteAt = migration.indexOf("DELETE FROM agent_identities");
-    expect(repointEnd).toBeGreaterThan(-1);
-    expect(deleteAt).toBeGreaterThan(repointEnd);
-    expect(migration).toMatch(/DELETE\s+FROM\s+agent_identities\s+a\s+USING\s+canon\s+c/i);
-    expect(migration).toMatch(/WHERE\s+c\.name\s*=\s*a\.name\s*\n\s*AND\s+a\.id\s*<>\s*c\.id/i);
+  it("repoints and deletes in ONE statement so a live writer cannot lose attribution", () => {
+    // The migration runner issues each statement as its own RDS Data API call
+    // with no way to span a transaction. Split across statements, a request
+    // could insert a child row referencing a duplicate AFTER that table's
+    // repoint committed; every one of these FKs is ON DELETE SET NULL, so the
+    // delete would then silently erase the new row's agent attribution.
+    // Everything therefore rides in a single data-modifying-CTE statement.
+    const statements = migration
+      .replace(/--[^\n]*/g, "")
+      .split(";")
+      .map((s) => s.trim())
+      .filter(Boolean);
+    expect(statements).toHaveLength(2); // the dedupe, then the index
+
+    const dedupe = statements[0];
+    expect(dedupe).toMatch(/^WITH canon AS/i);
+    expect(dedupe).toMatch(/DELETE\s+FROM\s+agent_identities\s+a\s+USING\s+dupes\s+d\s+WHERE\s+a\.id\s*=\s*d\.dup_id/i);
+    expect(statements[1]).toMatch(/^CREATE UNIQUE INDEX/i);
   });
 
-  it("uses one canonical-row rule across every statement", () => {
+  it("locks the duplicate rows so concurrent FK writers block instead of losing rows", () => {
+    // Inserting a child row takes FOR KEY SHARE on the parent, which conflicts
+    // with FOR UPDATE — so a writer that would have raced the delete blocks
+    // and then fails loudly on an FK violation. MATERIALIZED is load-bearing:
+    // without it the CTE may be inlined into each dependent CTE rather than
+    // evaluated once up front, so the lock is not reliably taken first.
+    expect(migration).toMatch(/dupes AS MATERIALIZED \(/);
+    expect(migration).toMatch(/FOR UPDATE OF a/);
+  });
+
+  it("states the canonical-row rule exactly once", () => {
     const orderings = [
       ...migration.matchAll(
         /ORDER BY name, \(id <> '0a710f00-0000-4000-a000-000000000f36'\), \(oauth_client_id IS NULL\), created_at, id/g
       ),
     ];
-    // One per CTE: six repoint statements + the delete. The rule is repeated
-    // because the migration runner issues each statement as its own RDS Data
-    // API call, so a TEMP table holding the map would not survive between them.
-    expect(orderings).toHaveLength(7);
+    expect(orderings).toHaveLength(1);
   });
 
   it("never deletes an agent identity id that application code pins", () => {
@@ -148,10 +166,10 @@ describe("migration 140 — agent_identities name uniqueness (#1303)", () => {
     );
     expect(pinned).not.toBeNull();
     const id = pinned![1];
-    // Sorts first in every canonical-row ORDER BY, so it is always the keeper.
+    // Sorts first in the canonical-row ORDER BY, so it is always the keeper.
     const rules = [...migration.matchAll(/ORDER BY name, \(id <> '([0-9a-f-]{36})'\)/g)];
-    expect(rules).toHaveLength(7);
-    for (const rule of rules) expect(rule[1]).toBe(id);
+    expect(rules).toHaveLength(1);
+    expect(rules[0][1]).toBe(id);
   });
 
   it("uses no DO $$ block (the db-init statement splitter cannot parse them)", () => {

--- a/tests/unit/agent-identities-name-unique-migration.test.ts
+++ b/tests/unit/agent-identities-name-unique-migration.test.ts
@@ -9,10 +9,12 @@
  * plus a cross-environment data copy produced two rows per name.
  *
  * These tests pin the two halves of the fix that can silently rot:
- *   1. the migration repoints EVERY live FK column before deleting duplicates
- *      (a missed column would abort the deploy on an FK violation, or — worse
- *      with ON DELETE SET NULL — silently drop agent attribution), and
- *   2. the seed script upserts on `name` rather than read-then-insert.
+ *   1. the migration repoints EVERY live FK column (a missed column leaves
+ *      attribution split across the duplicate and its tombstone),
+ *   2. it NEVER deletes — every one of those FKs is ON DELETE SET NULL, and the
+ *      runner cannot span a transaction, so any delete races live writers and
+ *      loses their attribution SILENTLY. Duplicates are tombstoned instead, and
+ *   3. the seed script upserts on `name` rather than read-then-insert.
  */
 
 import fs from "node:fs";
@@ -21,6 +23,8 @@ import path from "node:path";
 const schemaDir = path.join(process.cwd(), "infra/database/schema");
 const migrationFile = "140-agent-identities-name-unique.sql";
 const migration = fs.readFileSync(path.join(schemaDir, migrationFile), "utf8");
+/** The migration with `--` comment lines removed — i.e. the SQL that runs. */
+const migrationSql = migration.replace(/--[^\n]*/g, "");
 
 const schemaFiles = fs
   .readdirSync(schemaDir)
@@ -85,7 +89,7 @@ describe("migration 140 — agent_identities name uniqueness (#1303)", () => {
     );
   });
 
-  it("repoints every live FK column onto the canonical row before deleting duplicates", () => {
+  it("repoints every live FK column onto the canonical row", () => {
     const { references, dropped } = collectAgentForeignKeys();
     const live = [...references].filter((ref) => !dropped.has(ref.split(".")[0])).sort();
 
@@ -113,46 +117,71 @@ describe("migration 140 — agent_identities name uniqueness (#1303)", () => {
     expect(uncovered).toEqual([]);
   });
 
-  it("repoints and deletes in ONE statement so a live writer cannot lose attribution", () => {
-    // The migration runner issues each statement as its own RDS Data API call
-    // with no way to span a transaction. Split across statements, a request
-    // could insert a child row referencing a duplicate AFTER that table's
-    // repoint committed; every one of these FKs is ON DELETE SET NULL, so the
-    // delete would then silently erase the new row's agent attribution.
-    // Everything therefore rides in a single data-modifying-CTE statement.
-    const statements = migration
-      .replace(/--[^\n]*/g, "")
+  it("NEVER deletes an agent identity — duplicates are tombstoned instead", () => {
+    // This is the load-bearing property of the whole migration, and it is not
+    // a stylistic choice. All six FKs are ON DELETE SET NULL, and the runner
+    // issues each statement as its own RDS Data API call with no way to span a
+    // transaction. Any delete therefore races live writers, and the race is
+    // LOSSY rather than loud: a child row the repoint missed gets its agent
+    // attribution silently stripped. PostgreSQL additionally documents the
+    // ordering between sibling data-modifying CTEs and a main-query DELETE
+    // whose FK action is SET NULL as UNDEFINED, so no single-statement
+    // formulation rescues it either. Removing the delete designs the failure
+    // mode out: a missed child row still points at a row that EXISTS.
+    // Asserted against the executable SQL, not the file: the header discusses
+    // DELETE and DROP TYPE at length explaining why neither appears.
+    expect(migrationSql).not.toMatch(/\bDELETE\s+FROM\b/i);
+    expect(migrationSql).not.toMatch(/\bDROP\b/i);
+    expect(migrationSql).not.toMatch(/\bTRUNCATE\b/i);
+  });
+
+  it("tombstones duplicates by renaming and deactivating them", () => {
+    const statements = migrationSql
       .split(";")
       .map((s) => s.trim())
       .filter(Boolean);
-    expect(statements).toHaveLength(2); // the dedupe, then the index
-
-    const dedupe = statements[0];
-    expect(dedupe).toMatch(/^WITH canon AS/i);
-    expect(dedupe).toMatch(/DELETE\s+FROM\s+agent_identities\s+a\s+USING\s+dupes\s+d\s+WHERE\s+a\.id\s*=\s*d\.dup_id/i);
-    expect(statements[1]).toMatch(/^CREATE UNIQUE INDEX/i);
+    // repoint, tombstone, index
+    expect(statements).toHaveLength(3);
+    expect(statements[0]).toMatch(/^WITH canon AS/i);
+    expect(statements[1]).toMatch(/UPDATE\s+agent_identities\s+a/i);
+    expect(statements[1]).toMatch(/is_active\s*=\s*false/i);
+    expect(statements[2]).toMatch(/^CREATE UNIQUE INDEX/i);
   });
 
-  it("locks the duplicate rows so concurrent FK writers block instead of losing rows", () => {
-    // Inserting a child row takes FOR KEY SHARE on the parent, which conflicts
-    // with FOR UPDATE — so a writer that would have raced the delete blocks
-    // and then fails loudly on an FK violation. MATERIALIZED is load-bearing:
-    // without it the CTE may be inlined into each dependent CTE rather than
-    // evaluated once up front, so the lock is not reliably taken first.
-    expect(migration).toMatch(/dupes AS MATERIALIZED \(/);
-    expect(migration).toMatch(/FOR UPDATE OF a/);
+  it("keeps a tombstoned name inside varchar(200)", () => {
+    // name is varchar(200). left(name,150) + '#dup-' (5) + a 36-char uuid = 191.
+    const truncation = migration.match(/left\(a\.name,\s*(\d+)\)/);
+    expect(truncation).not.toBeNull();
+    const keep = Number(truncation![1]);
+    const suffix = "#dup-".length + 36;
+    expect(keep + suffix).toBeLessThanOrEqual(200);
   });
 
-  it("states the canonical-row rule exactly once", () => {
+  it("every FK to agent_identities is ON DELETE SET NULL — the reason not to delete", () => {
+    // If a future FK is added WITHOUT ON DELETE SET NULL this test still holds,
+    // but if one of these is ever changed to CASCADE the stakes go up further,
+    // not down. Either way the no-delete rule above stays correct. This asserts
+    // the premise the header documents is actually true of the schema.
+    const audit = fs.readFileSync(
+      path.join(schemaDir, "090-atrium-content-audit.sql"),
+      "utf8"
+    );
+    expect(audit).toMatch(/agent_id\s+uuid\s+REFERENCES\s+agent_identities\(id\)\s+ON DELETE SET NULL/i);
+  });
+
+  it("states the canonical-row rule identically in every statement that needs it", () => {
     const orderings = [
       ...migration.matchAll(
         /ORDER BY name, \(id <> '0a710f00-0000-4000-a000-000000000f36'\), \(oauth_client_id IS NULL\), created_at, id/g
       ),
     ];
-    expect(orderings).toHaveLength(1);
+    // Once per statement that must pick a canonical row: the repoint and the
+    // tombstone. They MUST be byte-identical or the two passes could disagree
+    // about which row is canonical.
+    expect(orderings).toHaveLength(2);
   });
 
-  it("never deletes an agent identity id that application code pins", () => {
+  it("never tombstones an agent identity id that application code pins", () => {
     // lib/content/okf/import.ts writes ATRIUM_IMPORT_AGENT_ID into
     // content_publish_requests.requested_by_agent_id with no lookup. If the
     // dedupe ever picked a different `atrium-importer` row as canonical, every
@@ -168,8 +197,8 @@ describe("migration 140 — agent_identities name uniqueness (#1303)", () => {
     const id = pinned![1];
     // Sorts first in the canonical-row ORDER BY, so it is always the keeper.
     const rules = [...migration.matchAll(/ORDER BY name, \(id <> '([0-9a-f-]{36})'\)/g)];
-    expect(rules).toHaveLength(1);
-    expect(rules[0][1]).toBe(id);
+    expect(rules).toHaveLength(2);
+    for (const rule of rules) expect(rule[1]).toBe(id);
   });
 
   it("uses no DO $$ block (the db-init statement splitter cannot parse them)", () => {

--- a/tests/unit/agent-identities-name-unique-migration.test.ts
+++ b/tests/unit/agent-identities-name-unique-migration.test.ts
@@ -140,12 +140,37 @@ describe("migration 140 — agent_identities name uniqueness (#1303)", () => {
       .split(";")
       .map((s) => s.trim())
       .filter(Boolean);
-    // repoint, tombstone, index
-    expect(statements).toHaveLength(3);
-    expect(statements[0]).toMatch(/^WITH canon AS/i);
-    expect(statements[1]).toMatch(/UPDATE\s+agent_identities\s+a/i);
-    expect(statements[1]).toMatch(/is_active\s*=\s*false/i);
-    expect(statements[2]).toMatch(/^CREATE UNIQUE INDEX/i);
+    // five FK indexes, repoint, tombstone, unique index
+    expect(statements).toHaveLength(8);
+    for (const stmt of statements.slice(0, 5)) {
+      expect(stmt).toMatch(/^CREATE INDEX IF NOT EXISTS idx_/i);
+    }
+    expect(statements[5]).toMatch(/^WITH canon AS/i);
+    expect(statements[6]).toMatch(/UPDATE\s+agent_identities\s+a/i);
+    expect(statements[6]).toMatch(/is_active\s*=\s*false/i);
+    expect(statements[7]).toMatch(/^CREATE UNIQUE INDEX/i);
+  });
+
+  it("indexes every repointed FK column that lacked one", () => {
+    // content_publish_requests.requested_by_agent_id already has
+    // idx_cpr_requested_by_agent_id (096); the other five child tables never
+    // indexed their agent-identity FK, so the repoint UPDATEs would seq-scan
+    // them on every fresh stand-up.
+    const pairs: Array<[string, string]> = [
+      ["content_objects", "created_by_agent_id"],
+      ["content_versions", "author_agent_id"],
+      ["content_audit_logs", "agent_id"],
+      ["atrium_doc_comments", "author_agent_id"],
+      ["content_assets", "uploader_agent_id"],
+    ];
+    for (const [table, column] of pairs) {
+      expect(migrationSql).toMatch(
+        new RegExp(
+          `CREATE INDEX IF NOT EXISTS \\S+\\s+ON ${table}\\s*\\(${column}\\)`,
+          "i"
+        )
+      );
+    }
   });
 
   it("keeps a tombstoned name inside varchar(200)", () => {

--- a/tests/unit/agent-identities-name-unique-migration.test.ts
+++ b/tests/unit/agent-identities-name-unique-migration.test.ts
@@ -1,0 +1,189 @@
+/**
+ * Migration 140 — agent_identities name uniqueness (#1303).
+ *
+ * The bug: `agent_identities.name` is the logical key, but the table only had a
+ * random-uuid surrogate PK and no uniqueness on `name`. Migration 085 seeds
+ * three identities guarded on `name`, migration 095 seeds one guarded on a
+ * FIXED `id`, and scripts/seed-atrium-agents.ts read-then-inserted. Two guards
+ * keyed on different columns cannot see each other, so a fresh environment
+ * plus a cross-environment data copy produced two rows per name.
+ *
+ * These tests pin the two halves of the fix that can silently rot:
+ *   1. the migration repoints EVERY live FK column before deleting duplicates
+ *      (a missed column would abort the deploy on an FK violation, or — worse
+ *      with ON DELETE SET NULL — silently drop agent attribution), and
+ *   2. the seed script upserts on `name` rather than read-then-insert.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+
+const schemaDir = path.join(process.cwd(), "infra/database/schema");
+const migrationFile = "140-agent-identities-name-unique.sql";
+const migration = fs.readFileSync(path.join(schemaDir, migrationFile), "utf8");
+
+const schemaFiles = fs
+  .readdirSync(schemaDir)
+  .filter((f) => f.endsWith(".sql") && !f.endsWith("-rollback.sql"))
+  .sort();
+
+/**
+ * Every (table, column) in the schema history that foreign-keys to
+ * agent_identities, minus tables a later migration dropped. Both declaration
+ * forms are covered: inline `col uuid REFERENCES agent_identities(id)` inside a
+ * CREATE TABLE, and `ALTER TABLE t ADD CONSTRAINT ... FOREIGN KEY (col)
+ * REFERENCES agent_identities(id)`.
+ */
+function collectAgentForeignKeys(): { references: Set<string>; dropped: Set<string> } {
+  const references = new Set<string>();
+  const dropped = new Set<string>();
+
+  for (const file of schemaFiles) {
+    const sql = fs.readFileSync(path.join(schemaDir, file), "utf8");
+    // Strip line comments so commented-out DDL never counts as a declaration.
+    const code = sql.replace(/--[^\n]*/g, "");
+
+    for (const m of code.matchAll(/DROP\s+TABLE\s+(?:IF\s+EXISTS\s+)?([A-Za-z_][\w]*)/gi)) {
+      dropped.add(m[1].toLowerCase());
+    }
+
+    let currentTable: string | null = null;
+    for (const line of code.split("\n")) {
+      const create = line.match(/CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?([A-Za-z_][\w]*)/i);
+      if (create) currentTable = create[1].toLowerCase();
+      const alter = line.match(/ALTER\s+TABLE\s+(?:ONLY\s+)?([A-Za-z_][\w]*)/i);
+      if (alter) currentTable = alter[1].toLowerCase();
+
+      const inline = line.match(/^\s*([A-Za-z_][\w]*)\s+uuid\b[^,]*REFERENCES\s+agent_identities\s*\(/i);
+      if (inline && currentTable) {
+        references.add(`${currentTable}.${inline[1].toLowerCase()}`);
+        continue;
+      }
+      const explicit = line.match(
+        /FOREIGN\s+KEY\s*\(\s*([A-Za-z_][\w]*)\s*\)\s*REFERENCES\s+agent_identities\s*\(/i
+      );
+      if (explicit && currentTable) {
+        references.add(`${currentTable}.${explicit[1].toLowerCase()}`);
+      }
+    }
+  }
+
+  return { references, dropped };
+}
+
+describe("migration 140 — agent_identities name uniqueness (#1303)", () => {
+  it("is registered in the migration manifest", () => {
+    const manifest = JSON.parse(
+      fs.readFileSync(path.join(process.cwd(), "infra/database/migrations.json"), "utf8")
+    ) as { migrationFiles: string[] };
+    expect(manifest.migrationFiles).toContain(migrationFile);
+  });
+
+  it("creates the unique index that makes a second row per name impossible", () => {
+    expect(migration).toMatch(
+      /CREATE\s+UNIQUE\s+INDEX\s+IF\s+NOT\s+EXISTS\s+uq_agent_identities_name\s+ON\s+agent_identities\s*\(\s*name\s*\)/i
+    );
+  });
+
+  it("repoints every live FK column onto the canonical row before deleting duplicates", () => {
+    const { references, dropped } = collectAgentForeignKeys();
+    const live = [...references].filter((ref) => !dropped.has(ref.split(".")[0])).sort();
+
+    // Sanity: the parser must actually find the known referencing columns. If
+    // this drops to zero the coverage assertion below would pass vacuously.
+    expect(live).toEqual(
+      expect.arrayContaining([
+        "atrium_doc_comments.author_agent_id",
+        "content_assets.uploader_agent_id",
+        "content_audit_logs.agent_id",
+        "content_objects.created_by_agent_id",
+        "content_publish_requests.requested_by_agent_id",
+        "content_versions.author_agent_id",
+      ])
+    );
+
+    const uncovered = live.filter((ref) => {
+      const [table, column] = ref.split(".");
+      const update = new RegExp(
+        `UPDATE\\s+${table}\\s+\\w+\\s+SET\\s+${column}\\s*=\\s*d\\.keep_id`,
+        "i"
+      );
+      return !update.test(migration);
+    });
+    expect(uncovered).toEqual([]);
+  });
+
+  it("keeps duplicates deleted only after the repoint, and never the canonical row", () => {
+    const repointEnd = migration.lastIndexOf("SET uploader_agent_id");
+    const deleteAt = migration.indexOf("DELETE FROM agent_identities");
+    expect(repointEnd).toBeGreaterThan(-1);
+    expect(deleteAt).toBeGreaterThan(repointEnd);
+    expect(migration).toMatch(/DELETE\s+FROM\s+agent_identities\s+a\s+USING\s+canon\s+c/i);
+    expect(migration).toMatch(/WHERE\s+c\.name\s*=\s*a\.name\s*\n\s*AND\s+a\.id\s*<>\s*c\.id/i);
+  });
+
+  it("uses one canonical-row rule across every statement", () => {
+    const orderings = [
+      ...migration.matchAll(
+        /ORDER BY name, \(id <> '0a710f00-0000-4000-a000-000000000f36'\), \(oauth_client_id IS NULL\), created_at, id/g
+      ),
+    ];
+    // One per CTE: six repoint statements + the delete. The rule is repeated
+    // because the migration runner issues each statement as its own RDS Data
+    // API call, so a TEMP table holding the map would not survive between them.
+    expect(orderings).toHaveLength(7);
+  });
+
+  it("never deletes an agent identity id that application code pins", () => {
+    // lib/content/okf/import.ts writes ATRIUM_IMPORT_AGENT_ID into
+    // content_publish_requests.requested_by_agent_id with no lookup. If the
+    // dedupe ever picked a different `atrium-importer` row as canonical, every
+    // OKF import would fail on an FK violation.
+    const importer = fs.readFileSync(
+      path.join(process.cwd(), "lib/content/okf/import.ts"),
+      "utf8"
+    );
+    const pinned = importer.match(
+      /ATRIUM_IMPORT_AGENT_ID\s*=\s*"([0-9a-f-]{36})"/
+    );
+    expect(pinned).not.toBeNull();
+    const id = pinned![1];
+    // Sorts first in every canonical-row ORDER BY, so it is always the keeper.
+    const rules = [...migration.matchAll(/ORDER BY name, \(id <> '([0-9a-f-]{36})'\)/g)];
+    expect(rules).toHaveLength(7);
+    for (const rule of rules) expect(rule[1]).toBe(id);
+  });
+
+  it("uses no DO $$ block (the db-init statement splitter cannot parse them)", () => {
+    expect(migration).not.toContain("DO $$");
+  });
+});
+
+describe("scripts/seed-atrium-agents.ts idempotency (#1303)", () => {
+  const seed = fs.readFileSync(
+    path.join(process.cwd(), "scripts/seed-atrium-agents.ts"),
+    "utf8"
+  );
+
+  it("upserts the identity on name instead of read-then-insert", () => {
+    expect(seed).toMatch(/\.insert\(agentIdentities\)/);
+    expect(seed).toMatch(/target:\s*agentIdentities\.name/);
+  });
+
+  it("has no unguarded insert into agentIdentities", () => {
+    const inserts = [...seed.matchAll(/\.insert\(agentIdentities\)/g)];
+    expect(inserts).toHaveLength(1);
+    const after = seed.slice(inserts[0].index ?? 0);
+    expect(after).toMatch(/onConflictDoUpdate/);
+  });
+});
+
+describe("drizzle schema mirrors the constraint", () => {
+  it("declares uq_agent_identities_name on agent_identities.name", () => {
+    const table = fs.readFileSync(
+      path.join(process.cwd(), "lib/db/schema/tables/agent-identities.ts"),
+      "utf8"
+    );
+    expect(table).toMatch(/uniqueIndex\("uq_agent_identities_name"\)\.on\(table\.name\)/);
+  });
+});

--- a/tests/unit/agent-identities-name-unique-migration.test.ts
+++ b/tests/unit/agent-identities-name-unique-migration.test.ts
@@ -197,13 +197,29 @@ describe("migration 140 — agent_identities name uniqueness (#1303)", () => {
   it("states the canonical-row rule identically in every statement that needs it", () => {
     const orderings = [
       ...migration.matchAll(
-        /ORDER BY name, \(id <> '0a710f00-0000-4000-a000-000000000f36'\), \(oauth_client_id IS NULL\), created_at, id/g
+        /ORDER BY name, \(id <> '0a710f00-0000-4000-a000-000000000f36'\), \(NOT is_active\), \(oauth_client_id IS NULL\), created_at, id/g
       ),
     ];
     // Once per statement that must pick a canonical row: the repoint and the
     // tombstone. They MUST be byte-identical or the two passes could disagree
     // about which row is canonical.
     expect(orderings).toHaveLength(2);
+  });
+
+  it("prefers an ACTIVE row over an inactive one, above the binding test", () => {
+    // findAgentIdentity (lib/content/requester-from-auth.ts) filters on
+    // is_active, so a canonical row that is inactive leaves the agent with no
+    // resolvable identity. `(NOT is_active)` must therefore outrank
+    // `(oauth_client_id IS NULL)`: an inactive row is unusable at runtime
+    // whether or not it is bound, so an active-but-unbound row is the better
+    // survivor. The fixed-id pin still outranks both.
+    const order = migration.match(/ORDER BY name,[^\n]*/)![0];
+    const pinnedAt = order.indexOf("0a710f00");
+    const activeAt = order.indexOf("NOT is_active");
+    const boundAt = order.indexOf("oauth_client_id IS NULL");
+    expect(pinnedAt).toBeGreaterThan(-1);
+    expect(activeAt).toBeGreaterThan(pinnedAt);
+    expect(boundAt).toBeGreaterThan(activeAt);
   });
 
   it("never tombstones an agent identity id that application code pins", () => {


### PR DESCRIPTION
## Summary

Implements #1303. On the fresh prod stand-up (2026-07-24) `agent_identities` ended up with two rows each for `screentime-bot`, `ship-reporter` and `tutorial-publisher`.

## Root cause (corrects the issue's inference)

`agent_identities.name` is the logical key every seeding path matches on, but the table only ever carried a random-uuid surrogate PK and **no uniqueness on `name`**. Three paths write these rows and their guards key on *different columns*, so none can see the others:

| Path | Guard | Consequence |
|---|---|---|
| migration `085` §10d — the three bot identities | `WHERE NOT EXISTS (name = ?)`, **no id pinned** | Every fresh env mints new random uuids, `created_at` = deploy time |
| migration `095` §2 — `atrium-importer` | `WHERE NOT EXISTS (id = '0a710f00-…')` | Deterministic id, so a data copy's id-conflict actually fires |
| `scripts/seed-atrium-agents.ts` | read-then-insert | No `ON CONFLICT` at all |

The issue attributes the `00:13:15` rows to "the skill-initializer or a bootstrap". They are **migration 085 itself** running against an empty prod database — and the `00:13:19` `atrium-importer` row is migration 095, four statements later. The `2026-06-25` rows are the ones the dev→prod data copy brought over; its `ON CONFLICT (id)` could not fire for the three bots because their uuids differed, so it inserted second rows for names that already existed. `atrium-importer` stayed single-rowed purely because its id was deterministic.

Every guard is a TOCTOU read-then-write against an unconstrained column. Rather than fix three guards, this replaces them with one database-enforced invariant.

Also corrected from the issue: `scheduled_executions.agent_identity_id` no longer exists (migration 133 dropped that table), and `content_assets.uploader_agent_id` **is** a live FK the issue did not list.

## The migration never deletes anything — that is the design, not a detail

Two earlier drafts of the migration tried to repoint the FKs and then `DELETE` the duplicates. Codex correctly shot down both, and the reasons are worth recording because they rule out the whole approach under this runner:

- **All six FKs are `ON DELETE SET NULL`.** A child row the repoint misses is not *rejected* — it is silently stripped of its agent attribution. Exactly the failure class this migration exists to prevent.
- **`db-init-handler.ts` issues each statement as its own RDS Data API `ExecuteStatementCommand`**, and the Data API cannot span a transaction across calls (a bare `BEGIN;` does not persist). So a multi-statement repoint-then-delete races any live writer.
- **Folding it into one statement does not save it.** A writer that takes its `FOR KEY SHARE` lock *just before* the statement begins commits while the delete waits; the repoint CTEs, bound to the older snapshot, never see its row. And PostgreSQL explicitly documents the ordering between sibling data-modifying CTEs and a main-query `DELETE` whose FK action is `SET NULL` as **undefined** — a green test proves the plan chosen that day, not a property.

So duplicates are **tombstoned**: renamed to `left(name,150) || '#dup-' || id` and set `is_active = false`.

- No row is ever deleted, so `ON DELETE SET NULL` never fires and **no interleaving with live traffic can lose attribution**. The failure mode is designed out rather than guarded against — no lock, no quiesce window, no reliance on undefined ordering.
- A concurrently-inserted child row the repoint misses still points at a row that **exists**. Attribution is stale, not lost, and the tombstone records exactly which identity it was.
- Names become distinct, so `CREATE UNIQUE INDEX` still lands the invariant.
- Tombstones are inert (`is_active = false`, name mangled so no lookup by the real name reaches them). An operator can delete them later, deliberately, with no live traffic — which is when a delete is safe.

Three plain statements: repoint → tombstone → index.

## Changes

- **`infra/database/schema/140-agent-identities-name-unique.sql`** (new) — the above, plus `uq_agent_identities_name`.
  - Canonical row = **app-pinned id first**, then client-bound, then oldest `created_at`, then lowest id.
  - Fails the deploy loudly if a duplicate survives (the `CREATE UNIQUE INDEX` error matches none of the runners' skip cases).
  - Plain statements only — no PL/pgSQL blocks, which the db-init splitter cannot parse.
- **`lib/db/schema/tables/agent-identities.ts`** — Drizzle mirrors the constraint via `uniqueIndex("uq_agent_identities_name")`.
- **`scripts/seed-atrium-agents.ts`** — read-then-insert replaced with `.onConflictDoUpdate({ target: agentIdentities.name })`.
- **`tests/unit/agent-identities-name-unique-migration.test.ts`** (new) — parses the whole schema directory for columns FK-ing to `agent_identities`, subtracts tables later migrations dropped, and asserts the migration repoints every remaining one. Also asserts the executable SQL contains **no `DELETE`/`DROP`/`TRUNCATE`**, that the tombstone name cannot overflow `varchar(200)`, and that the canonical-row `ORDER BY` is byte-identical in both statements that pick a canonical row (they must agree, or the two passes could disagree about which row wins).

### The pinned-id rule is load-bearing

`lib/content/okf/import.ts` exports `ATRIUM_IMPORT_AGENT_ID = "0a710f00-0000-4000-a000-000000000f36"` and writes it into `content_publish_requests.requested_by_agent_id` **with no lookup**. Had a duplicate `atrium-importer` outranked it on `created_at` or client binding, every OKF import would have started failing on an FK violation. The canonical rule sorts that id first so it can never be the row tombstoned.

## Verification (all green before opening)

- Build (`next build --webpack`): ✅
- Lint (`eslint .`): ✅ 0 errors (407 pre-existing warnings, unchanged)
- Typecheck (`tsc --noEmit`): ✅
- Tests (full CI suite): ✅ 3566 passed / 361 suites
- Authenticated Playwright suite (pre-push gate): ✅

**Live PostgreSQL, inside rolled-back transactions (local DB left unchanged):**

1. **Codex's exact race** — ran the repoint, *then* inserted a `content_audit_logs` row referencing the duplicate, *then* ran the tombstone + index. Result: `attribution_kept = true`, resolving to `ship-reporter#dup-ff16f647-…`. Under the delete-based design that row's `agent_id` would have been silently nulled.
2. All four names duplicated, with an `atrium-importer` decoy that was ten years older **and** client-bound → 8 rows / 8 distinct names / 4 active, the app-pinned `0a710f00-…` still canonical, and `content_objects` repointed onto the winner.
3. Re-runs 2 and 3 → no-ops (0 rows, index skipped).
4. Post-migration duplicate `INSERT` → rejected: `duplicate key value violates unique constraint "uq_agent_identities_name"`.

## Evidence

_N/A — no UI surface._

## Note for the next fresh stand-up

A dev→prod data copy that runs *after* migrations and relies on `ON CONFLICT (id)` will now hit a unique violation on `name` instead of silently duplicating. That is intended — loud beats silent — but the copy step should conflict on `name` (or skip `agent_identities`, which the migrations seed anyway). No in-repo tooling does this copy; it was a one-off.

Closes #1303
