### PR TITLE
feat(db): add OneRoster core schema (#1309)

### DIFF
--- a/infra/database/migrations.json
+++ b/infra/database/migrations.json
@@ -132,6 +132,7 @@
     "135-atrium-asset-initiation-idempotency.sql",
     "136-google-content-connectors.sql",
     "137-nexus-conversation-retention.sql",
-    "138-atrium-capture-browser-registration.sql"
+    "138-atrium-capture-browser-registration.sql",
+    "141-oneroster-core.sql"
   ]
 }

--- a/infra/database/schema/141-oneroster-core.sql
+++ b/infra/database/schema/141-oneroster-core.sql
@@ -1,0 +1,269 @@
+-- Migration 141: OneRoster core schema (Epic #1308 / Issue #1309)
+--
+-- Mirrors the OneRoster 1.2 core rostering collections used by the ClassLink
+-- sync. Roster-to-roster references intentionally use sourced-id text columns
+-- plus indexes rather than foreign keys so collections can arrive independently.
+--
+-- This migration is additive and idempotent. It uses only plain statements
+-- because the migration runner cannot split PL/pgSQL DO blocks safely.
+
+-- ---------------------------------------------------------------------------
+-- Orgs
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS oneroster_orgs (
+  id                 uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  sourced_id         text NOT NULL,
+  name               text,
+  type               text,
+  identifier         text,
+  parent_sourced_id  text,
+  status             text CHECK (status IN ('active', 'tobedeleted')),
+  is_active          boolean NOT NULL DEFAULT true,
+  date_last_modified timestamptz,
+  last_synced_at     timestamptz,
+  created_at         timestamptz NOT NULL DEFAULT now(),
+  updated_at         timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_oneroster_orgs_sourced_id
+  ON oneroster_orgs (sourced_id);
+
+CREATE INDEX IF NOT EXISTS idx_oneroster_orgs_parent_sourced_id
+  ON oneroster_orgs (parent_sourced_id);
+
+DROP TRIGGER IF EXISTS update_oneroster_orgs_updated_at ON oneroster_orgs;
+CREATE TRIGGER update_oneroster_orgs_updated_at
+  BEFORE UPDATE ON oneroster_orgs
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+-- ---------------------------------------------------------------------------
+-- Academic sessions
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS oneroster_academic_sessions (
+  id                 uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  sourced_id         text NOT NULL,
+  title              text,
+  type               text,
+  start_date         date,
+  end_date           date,
+  parent_sourced_id  text,
+  school_year        text,
+  status             text CHECK (status IN ('active', 'tobedeleted')),
+  is_active          boolean NOT NULL DEFAULT true,
+  date_last_modified timestamptz,
+  last_synced_at     timestamptz,
+  created_at         timestamptz NOT NULL DEFAULT now(),
+  updated_at         timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_oneroster_academic_sessions_sourced_id
+  ON oneroster_academic_sessions (sourced_id);
+
+CREATE INDEX IF NOT EXISTS idx_oneroster_academic_sessions_parent_sourced_id
+  ON oneroster_academic_sessions (parent_sourced_id);
+
+DROP TRIGGER IF EXISTS update_oneroster_academic_sessions_updated_at
+  ON oneroster_academic_sessions;
+CREATE TRIGGER update_oneroster_academic_sessions_updated_at
+  BEFORE UPDATE ON oneroster_academic_sessions
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+-- ---------------------------------------------------------------------------
+-- Courses
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS oneroster_courses (
+  id                 uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  sourced_id         text NOT NULL,
+  title              text,
+  course_code        text,
+  org_sourced_id     text,
+  grades             text[],
+  status             text CHECK (status IN ('active', 'tobedeleted')),
+  is_active          boolean NOT NULL DEFAULT true,
+  date_last_modified timestamptz,
+  last_synced_at     timestamptz,
+  created_at         timestamptz NOT NULL DEFAULT now(),
+  updated_at         timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_oneroster_courses_sourced_id
+  ON oneroster_courses (sourced_id);
+
+CREATE INDEX IF NOT EXISTS idx_oneroster_courses_org_sourced_id
+  ON oneroster_courses (org_sourced_id);
+
+DROP TRIGGER IF EXISTS update_oneroster_courses_updated_at ON oneroster_courses;
+CREATE TRIGGER update_oneroster_courses_updated_at
+  BEFORE UPDATE ON oneroster_courses
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+-- ---------------------------------------------------------------------------
+-- Classes
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS oneroster_classes (
+  id                 uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  sourced_id         text NOT NULL,
+  title              text,
+  class_code         text,
+  class_type         text,
+  location           text,
+  course_sourced_id  text,
+  school_sourced_id  text,
+  grades             text[],
+  subjects           text[],
+  periods            text[],
+  status             text CHECK (status IN ('active', 'tobedeleted')),
+  is_active          boolean NOT NULL DEFAULT true,
+  date_last_modified timestamptz,
+  last_synced_at     timestamptz,
+  created_at         timestamptz NOT NULL DEFAULT now(),
+  updated_at         timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_oneroster_classes_sourced_id
+  ON oneroster_classes (sourced_id);
+
+CREATE INDEX IF NOT EXISTS idx_oneroster_classes_course_sourced_id
+  ON oneroster_classes (course_sourced_id);
+
+CREATE INDEX IF NOT EXISTS idx_oneroster_classes_school_sourced_id
+  ON oneroster_classes (school_sourced_id);
+
+DROP TRIGGER IF EXISTS update_oneroster_classes_updated_at ON oneroster_classes;
+CREATE TRIGGER update_oneroster_classes_updated_at
+  BEFORE UPDATE ON oneroster_classes
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+-- ---------------------------------------------------------------------------
+-- Class terms
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS oneroster_class_terms (
+  id                 uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  class_sourced_id   text NOT NULL,
+  term_sourced_id    text NOT NULL,
+  status             text CHECK (status IN ('active', 'tobedeleted')),
+  is_active          boolean NOT NULL DEFAULT true,
+  date_last_modified timestamptz,
+  last_synced_at     timestamptz,
+  created_at         timestamptz NOT NULL DEFAULT now(),
+  updated_at         timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_oneroster_class_terms_class_term
+  ON oneroster_class_terms (class_sourced_id, term_sourced_id);
+
+CREATE INDEX IF NOT EXISTS idx_oneroster_class_terms_term_sourced_id
+  ON oneroster_class_terms (term_sourced_id);
+
+DROP TRIGGER IF EXISTS update_oneroster_class_terms_updated_at
+  ON oneroster_class_terms;
+CREATE TRIGGER update_oneroster_class_terms_updated_at
+  BEFORE UPDATE ON oneroster_class_terms
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+-- ---------------------------------------------------------------------------
+-- Users
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS oneroster_users (
+  id                 uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  sourced_id         text NOT NULL,
+  email              text,
+  username           text,
+  given_name         text,
+  family_name        text,
+  role               text,
+  enabled_user       boolean,
+  grades             text[],
+  status             text CHECK (status IN ('active', 'tobedeleted')),
+  is_active          boolean NOT NULL DEFAULT true,
+  date_last_modified timestamptz,
+  last_synced_at     timestamptz,
+  created_at         timestamptz NOT NULL DEFAULT now(),
+  updated_at         timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_oneroster_users_sourced_id
+  ON oneroster_users (sourced_id);
+
+CREATE INDEX IF NOT EXISTS idx_oneroster_users_email
+  ON oneroster_users (lower(email));
+
+DROP TRIGGER IF EXISTS update_oneroster_users_updated_at ON oneroster_users;
+CREATE TRIGGER update_oneroster_users_updated_at
+  BEFORE UPDATE ON oneroster_users
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+-- ---------------------------------------------------------------------------
+-- User roles
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS oneroster_user_roles (
+  id                 uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_sourced_id    text NOT NULL,
+  role               text NOT NULL,
+  role_type          text NOT NULL,
+  org_sourced_id     text,
+  status             text CHECK (status IN ('active', 'tobedeleted')),
+  is_active          boolean NOT NULL DEFAULT true,
+  date_last_modified timestamptz,
+  last_synced_at     timestamptz,
+  created_at         timestamptz NOT NULL DEFAULT now(),
+  updated_at         timestamptz NOT NULL DEFAULT now()
+);
+
+-- PostgreSQL treats NULL values as distinct in ordinary unique indexes.
+-- Coalescing the nullable org id ensures only one org-less role tuple exists.
+CREATE UNIQUE INDEX IF NOT EXISTS uq_oneroster_user_roles_tuple
+  ON oneroster_user_roles (
+    user_sourced_id,
+    role,
+    role_type,
+    coalesce(org_sourced_id, '')
+  );
+
+CREATE INDEX IF NOT EXISTS idx_oneroster_user_roles_org_sourced_id
+  ON oneroster_user_roles (org_sourced_id);
+
+DROP TRIGGER IF EXISTS update_oneroster_user_roles_updated_at
+  ON oneroster_user_roles;
+CREATE TRIGGER update_oneroster_user_roles_updated_at
+  BEFORE UPDATE ON oneroster_user_roles
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+-- ---------------------------------------------------------------------------
+-- Enrollments
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS oneroster_enrollments (
+  id                 uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  sourced_id         text NOT NULL,
+  user_sourced_id    text,
+  class_sourced_id   text,
+  school_sourced_id  text,
+  role               text,
+  is_primary         boolean,
+  begin_date         date,
+  end_date           date,
+  status             text CHECK (status IN ('active', 'tobedeleted')),
+  is_active          boolean NOT NULL DEFAULT true,
+  date_last_modified timestamptz,
+  last_synced_at     timestamptz,
+  created_at         timestamptz NOT NULL DEFAULT now(),
+  updated_at         timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_oneroster_enrollments_sourced_id
+  ON oneroster_enrollments (sourced_id);
+
+CREATE INDEX IF NOT EXISTS idx_oneroster_enrollments_class_sourced_id
+  ON oneroster_enrollments (class_sourced_id);
+
+CREATE INDEX IF NOT EXISTS idx_oneroster_enrollments_user_sourced_id
+  ON oneroster_enrollments (user_sourced_id);
+
+CREATE INDEX IF NOT EXISTS idx_oneroster_enrollments_school_sourced_id
+  ON oneroster_enrollments (school_sourced_id);
+
+DROP TRIGGER IF EXISTS update_oneroster_enrollments_updated_at
+  ON oneroster_enrollments;
+CREATE TRIGGER update_oneroster_enrollments_updated_at
+  BEFORE UPDATE ON oneroster_enrollments
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();

--- a/infra/database/schema/141-oneroster-core.sql
+++ b/infra/database/schema/141-oneroster-core.sql
@@ -267,3 +267,16 @@ DROP TRIGGER IF EXISTS update_oneroster_enrollments_updated_at
 CREATE TRIGGER update_oneroster_enrollments_updated_at
   BEFORE UPDATE ON oneroster_enrollments
   FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+-- ===========================================================================
+-- ROLLBACK SQL (for manual rollback if needed)
+-- Drop dependents first so this remains safe if foreign keys are added later.
+-- ===========================================================================
+-- DROP TABLE IF EXISTS oneroster_enrollments;
+-- DROP TABLE IF EXISTS oneroster_user_roles;
+-- DROP TABLE IF EXISTS oneroster_users;
+-- DROP TABLE IF EXISTS oneroster_class_terms;
+-- DROP TABLE IF EXISTS oneroster_classes;
+-- DROP TABLE IF EXISTS oneroster_courses;
+-- DROP TABLE IF EXISTS oneroster_academic_sessions;
+-- DROP TABLE IF EXISTS oneroster_orgs;

--- a/lib/db/schema/index.ts
+++ b/lib/db/schema/index.ts
@@ -221,6 +221,18 @@ export * from "./tables/group-role-mappings";
 export * from "./tables/resource-access-grants";
 
 // ============================================
+// OneRoster Core Schema (Epic #1308 / Issue #1309)
+// ============================================
+export * from "./tables/oneroster-orgs";
+export * from "./tables/oneroster-academic-sessions";
+export * from "./tables/oneroster-courses";
+export * from "./tables/oneroster-classes";
+export * from "./tables/oneroster-class-terms";
+export * from "./tables/oneroster-users";
+export * from "./tables/oneroster-user-roles";
+export * from "./tables/oneroster-enrollments";
+
+// ============================================
 // Relations
 // ============================================
 export * from "./relations";

--- a/lib/db/schema/tables/oneroster-academic-sessions.ts
+++ b/lib/db/schema/tables/oneroster-academic-sessions.ts
@@ -1,0 +1,60 @@
+/**
+ * OneRoster academic sessions synced from ClassLink.
+ *
+ * See migration 141-oneroster-core.sql.
+ */
+
+import { sql } from "drizzle-orm";
+import {
+  boolean,
+  check,
+  date,
+  index,
+  pgTable,
+  text,
+  timestamp,
+  uniqueIndex,
+  uuid,
+} from "drizzle-orm/pg-core";
+import type { OneRosterStatus } from "./oneroster-orgs";
+
+export const onerosterAcademicSessions = pgTable(
+  "oneroster_academic_sessions",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    sourcedId: text("sourced_id").notNull(),
+    title: text("title"),
+    type: text("type"),
+    startDate: date("start_date"),
+    endDate: date("end_date"),
+    parentSourcedId: text("parent_sourced_id"),
+    schoolYear: text("school_year"),
+    status: text("status").$type<OneRosterStatus>(),
+    isActive: boolean("is_active").default(true).notNull(),
+    dateLastModified: timestamp("date_last_modified", { withTimezone: true }),
+    lastSyncedAt: timestamp("last_synced_at", { withTimezone: true }),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+  },
+  (table) => [
+    uniqueIndex("uq_oneroster_academic_sessions_sourced_id").on(
+      table.sourcedId
+    ),
+    index("idx_oneroster_academic_sessions_parent_sourced_id").on(
+      table.parentSourcedId
+    ),
+    check(
+      "oneroster_academic_sessions_status_check",
+      sql`${table.status} IN ('active', 'tobedeleted')`
+    ),
+  ]
+);
+
+export type OneRosterAcademicSessionRow =
+  typeof onerosterAcademicSessions.$inferSelect;
+export type NewOneRosterAcademicSessionRow =
+  typeof onerosterAcademicSessions.$inferInsert;

--- a/lib/db/schema/tables/oneroster-class-terms.ts
+++ b/lib/db/schema/tables/oneroster-class-terms.ts
@@ -1,0 +1,51 @@
+/**
+ * OneRoster class-to-term relationships synced from ClassLink.
+ *
+ * See migration 141-oneroster-core.sql.
+ */
+
+import { sql } from "drizzle-orm";
+import {
+  boolean,
+  check,
+  index,
+  pgTable,
+  text,
+  timestamp,
+  uniqueIndex,
+  uuid,
+} from "drizzle-orm/pg-core";
+import type { OneRosterStatus } from "./oneroster-orgs";
+
+export const onerosterClassTerms = pgTable(
+  "oneroster_class_terms",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    classSourcedId: text("class_sourced_id").notNull(),
+    termSourcedId: text("term_sourced_id").notNull(),
+    status: text("status").$type<OneRosterStatus>(),
+    isActive: boolean("is_active").default(true).notNull(),
+    dateLastModified: timestamp("date_last_modified", { withTimezone: true }),
+    lastSyncedAt: timestamp("last_synced_at", { withTimezone: true }),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+  },
+  (table) => [
+    uniqueIndex("uq_oneroster_class_terms_class_term").on(
+      table.classSourcedId,
+      table.termSourcedId
+    ),
+    index("idx_oneroster_class_terms_term_sourced_id").on(table.termSourcedId),
+    check(
+      "oneroster_class_terms_status_check",
+      sql`${table.status} IN ('active', 'tobedeleted')`
+    ),
+  ]
+);
+
+export type OneRosterClassTermRow = typeof onerosterClassTerms.$inferSelect;
+export type NewOneRosterClassTermRow = typeof onerosterClassTerms.$inferInsert;

--- a/lib/db/schema/tables/oneroster-classes.ts
+++ b/lib/db/schema/tables/oneroster-classes.ts
@@ -1,0 +1,57 @@
+/**
+ * OneRoster class sections synced from ClassLink.
+ *
+ * See migration 141-oneroster-core.sql.
+ */
+
+import { sql } from "drizzle-orm";
+import {
+  boolean,
+  check,
+  index,
+  pgTable,
+  text,
+  timestamp,
+  uniqueIndex,
+  uuid,
+} from "drizzle-orm/pg-core";
+import type { OneRosterStatus } from "./oneroster-orgs";
+
+export const onerosterClasses = pgTable(
+  "oneroster_classes",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    sourcedId: text("sourced_id").notNull(),
+    title: text("title"),
+    classCode: text("class_code"),
+    classType: text("class_type"),
+    location: text("location"),
+    courseSourcedId: text("course_sourced_id"),
+    schoolSourcedId: text("school_sourced_id"),
+    grades: text("grades").array(),
+    subjects: text("subjects").array(),
+    periods: text("periods").array(),
+    status: text("status").$type<OneRosterStatus>(),
+    isActive: boolean("is_active").default(true).notNull(),
+    dateLastModified: timestamp("date_last_modified", { withTimezone: true }),
+    lastSyncedAt: timestamp("last_synced_at", { withTimezone: true }),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+  },
+  (table) => [
+    uniqueIndex("uq_oneroster_classes_sourced_id").on(table.sourcedId),
+    index("idx_oneroster_classes_course_sourced_id").on(table.courseSourcedId),
+    index("idx_oneroster_classes_school_sourced_id").on(table.schoolSourcedId),
+    check(
+      "oneroster_classes_status_check",
+      sql`${table.status} IN ('active', 'tobedeleted')`
+    ),
+  ]
+);
+
+export type OneRosterClassRow = typeof onerosterClasses.$inferSelect;
+export type NewOneRosterClassRow = typeof onerosterClasses.$inferInsert;

--- a/lib/db/schema/tables/oneroster-courses.ts
+++ b/lib/db/schema/tables/oneroster-courses.ts
@@ -1,0 +1,51 @@
+/**
+ * OneRoster courses synced from ClassLink.
+ *
+ * See migration 141-oneroster-core.sql.
+ */
+
+import { sql } from "drizzle-orm";
+import {
+  boolean,
+  check,
+  index,
+  pgTable,
+  text,
+  timestamp,
+  uniqueIndex,
+  uuid,
+} from "drizzle-orm/pg-core";
+import type { OneRosterStatus } from "./oneroster-orgs";
+
+export const onerosterCourses = pgTable(
+  "oneroster_courses",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    sourcedId: text("sourced_id").notNull(),
+    title: text("title"),
+    courseCode: text("course_code"),
+    orgSourcedId: text("org_sourced_id"),
+    grades: text("grades").array(),
+    status: text("status").$type<OneRosterStatus>(),
+    isActive: boolean("is_active").default(true).notNull(),
+    dateLastModified: timestamp("date_last_modified", { withTimezone: true }),
+    lastSyncedAt: timestamp("last_synced_at", { withTimezone: true }),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+  },
+  (table) => [
+    uniqueIndex("uq_oneroster_courses_sourced_id").on(table.sourcedId),
+    index("idx_oneroster_courses_org_sourced_id").on(table.orgSourcedId),
+    check(
+      "oneroster_courses_status_check",
+      sql`${table.status} IN ('active', 'tobedeleted')`
+    ),
+  ]
+);
+
+export type OneRosterCourseRow = typeof onerosterCourses.$inferSelect;
+export type NewOneRosterCourseRow = typeof onerosterCourses.$inferInsert;

--- a/lib/db/schema/tables/oneroster-enrollments.ts
+++ b/lib/db/schema/tables/oneroster-enrollments.ts
@@ -1,0 +1,61 @@
+/**
+ * OneRoster class enrollments synced from ClassLink.
+ *
+ * See migration 141-oneroster-core.sql.
+ */
+
+import { sql } from "drizzle-orm";
+import {
+  boolean,
+  check,
+  date,
+  index,
+  pgTable,
+  text,
+  timestamp,
+  uniqueIndex,
+  uuid,
+} from "drizzle-orm/pg-core";
+import type { OneRosterStatus } from "./oneroster-orgs";
+
+export const onerosterEnrollments = pgTable(
+  "oneroster_enrollments",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    sourcedId: text("sourced_id").notNull(),
+    userSourcedId: text("user_sourced_id"),
+    classSourcedId: text("class_sourced_id"),
+    schoolSourcedId: text("school_sourced_id"),
+    role: text("role"),
+    isPrimary: boolean("is_primary"),
+    beginDate: date("begin_date"),
+    endDate: date("end_date"),
+    status: text("status").$type<OneRosterStatus>(),
+    isActive: boolean("is_active").default(true).notNull(),
+    dateLastModified: timestamp("date_last_modified", { withTimezone: true }),
+    lastSyncedAt: timestamp("last_synced_at", { withTimezone: true }),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+  },
+  (table) => [
+    uniqueIndex("uq_oneroster_enrollments_sourced_id").on(table.sourcedId),
+    index("idx_oneroster_enrollments_class_sourced_id").on(
+      table.classSourcedId
+    ),
+    index("idx_oneroster_enrollments_user_sourced_id").on(table.userSourcedId),
+    index("idx_oneroster_enrollments_school_sourced_id").on(
+      table.schoolSourcedId
+    ),
+    check(
+      "oneroster_enrollments_status_check",
+      sql`${table.status} IN ('active', 'tobedeleted')`
+    ),
+  ]
+);
+
+export type OneRosterEnrollmentRow = typeof onerosterEnrollments.$inferSelect;
+export type NewOneRosterEnrollmentRow = typeof onerosterEnrollments.$inferInsert;

--- a/lib/db/schema/tables/oneroster-orgs.ts
+++ b/lib/db/schema/tables/oneroster-orgs.ts
@@ -1,0 +1,53 @@
+/**
+ * OneRoster organizations synced from ClassLink.
+ *
+ * Sourced-id references are intentionally not foreign keys so collections can
+ * arrive independently. See migration 141-oneroster-core.sql.
+ */
+
+import { sql } from "drizzle-orm";
+import {
+  boolean,
+  check,
+  index,
+  pgTable,
+  text,
+  timestamp,
+  uniqueIndex,
+  uuid,
+} from "drizzle-orm/pg-core";
+
+export type OneRosterStatus = "active" | "tobedeleted";
+
+export const onerosterOrgs = pgTable(
+  "oneroster_orgs",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    sourcedId: text("sourced_id").notNull(),
+    name: text("name"),
+    type: text("type"),
+    identifier: text("identifier"),
+    parentSourcedId: text("parent_sourced_id"),
+    status: text("status").$type<OneRosterStatus>(),
+    isActive: boolean("is_active").default(true).notNull(),
+    dateLastModified: timestamp("date_last_modified", { withTimezone: true }),
+    lastSyncedAt: timestamp("last_synced_at", { withTimezone: true }),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+  },
+  (table) => [
+    uniqueIndex("uq_oneroster_orgs_sourced_id").on(table.sourcedId),
+    index("idx_oneroster_orgs_parent_sourced_id").on(table.parentSourcedId),
+    check(
+      "oneroster_orgs_status_check",
+      sql`${table.status} IN ('active', 'tobedeleted')`
+    ),
+  ]
+);
+
+export type OneRosterOrgRow = typeof onerosterOrgs.$inferSelect;
+export type NewOneRosterOrgRow = typeof onerosterOrgs.$inferInsert;

--- a/lib/db/schema/tables/oneroster-user-roles.ts
+++ b/lib/db/schema/tables/oneroster-user-roles.ts
@@ -1,0 +1,55 @@
+/**
+ * OneRoster 1.2 user roles normalized from each user's roles array.
+ *
+ * See migration 141-oneroster-core.sql.
+ */
+
+import { sql } from "drizzle-orm";
+import {
+  boolean,
+  check,
+  index,
+  pgTable,
+  text,
+  timestamp,
+  uniqueIndex,
+  uuid,
+} from "drizzle-orm/pg-core";
+import type { OneRosterStatus } from "./oneroster-orgs";
+
+export const onerosterUserRoles = pgTable(
+  "oneroster_user_roles",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    userSourcedId: text("user_sourced_id").notNull(),
+    role: text("role").notNull(),
+    roleType: text("role_type").notNull(),
+    orgSourcedId: text("org_sourced_id"),
+    status: text("status").$type<OneRosterStatus>(),
+    isActive: boolean("is_active").default(true).notNull(),
+    dateLastModified: timestamp("date_last_modified", { withTimezone: true }),
+    lastSyncedAt: timestamp("last_synced_at", { withTimezone: true }),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+  },
+  (table) => [
+    uniqueIndex("uq_oneroster_user_roles_tuple").on(
+      table.userSourcedId,
+      table.role,
+      table.roleType,
+      sql`coalesce(${table.orgSourcedId}, '')`
+    ),
+    index("idx_oneroster_user_roles_org_sourced_id").on(table.orgSourcedId),
+    check(
+      "oneroster_user_roles_status_check",
+      sql`${table.status} IN ('active', 'tobedeleted')`
+    ),
+  ]
+);
+
+export type OneRosterUserRoleRow = typeof onerosterUserRoles.$inferSelect;
+export type NewOneRosterUserRoleRow = typeof onerosterUserRoles.$inferInsert;

--- a/lib/db/schema/tables/oneroster-users.ts
+++ b/lib/db/schema/tables/oneroster-users.ts
@@ -1,0 +1,55 @@
+/**
+ * OneRoster users synced from ClassLink.
+ *
+ * The full OneRoster 1.2 roles array is normalized into
+ * `oneroster_user_roles`. See migration 141-oneroster-core.sql.
+ */
+
+import { sql } from "drizzle-orm";
+import {
+  boolean,
+  check,
+  index,
+  pgTable,
+  text,
+  timestamp,
+  uniqueIndex,
+  uuid,
+} from "drizzle-orm/pg-core";
+import type { OneRosterStatus } from "./oneroster-orgs";
+
+export const onerosterUsers = pgTable(
+  "oneroster_users",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    sourcedId: text("sourced_id").notNull(),
+    email: text("email"),
+    username: text("username"),
+    givenName: text("given_name"),
+    familyName: text("family_name"),
+    role: text("role"),
+    enabledUser: boolean("enabled_user"),
+    grades: text("grades").array(),
+    status: text("status").$type<OneRosterStatus>(),
+    isActive: boolean("is_active").default(true).notNull(),
+    dateLastModified: timestamp("date_last_modified", { withTimezone: true }),
+    lastSyncedAt: timestamp("last_synced_at", { withTimezone: true }),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+  },
+  (table) => [
+    uniqueIndex("uq_oneroster_users_sourced_id").on(table.sourcedId),
+    index("idx_oneroster_users_email").on(sql`lower(${table.email})`),
+    check(
+      "oneroster_users_status_check",
+      sql`${table.status} IN ('active', 'tobedeleted')`
+    ),
+  ]
+);
+
+export type OneRosterUserRow = typeof onerosterUsers.$inferSelect;
+export type NewOneRosterUserRow = typeof onerosterUsers.$inferInsert;

--- a/tests/unit/oneroster-core-migration.test.ts
+++ b/tests/unit/oneroster-core-migration.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Contract checks for the OneRoster core schema (Epic #1308 / Issue #1309).
+ *
+ * The sync relies on every collection having identical bookkeeping columns,
+ * sourced-id reference indexes without cross-collection foreign keys, and an
+ * updated_at trigger. Keep those invariants explicit as later roster work lands.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+
+const migrationName = "141-oneroster-core.sql";
+const migrationPath = path.join(
+  process.cwd(),
+  "infra/database/schema",
+  migrationName
+);
+const migration = fs.readFileSync(migrationPath, "utf8");
+
+const tableNames = [
+  "oneroster_orgs",
+  "oneroster_academic_sessions",
+  "oneroster_courses",
+  "oneroster_classes",
+  "oneroster_class_terms",
+  "oneroster_users",
+  "oneroster_user_roles",
+  "oneroster_enrollments",
+] as const;
+
+function tableBody(tableName: (typeof tableNames)[number]): string {
+  const match = migration.match(
+    new RegExp(
+      `CREATE TABLE IF NOT EXISTS ${tableName} \\(([\\s\\S]*?)\\n\\);`
+    )
+  );
+
+  if (!match?.[1]) {
+    throw new Error(`Missing CREATE TABLE for ${tableName}`);
+  }
+
+  return match[1].replace(/\s+/g, " ");
+}
+
+describe("OneRoster core migration", () => {
+  it("creates exactly the eight in-scope roster tables", () => {
+    const createdTables = [
+      ...migration.matchAll(/CREATE TABLE IF NOT EXISTS (oneroster_\w+)/g),
+    ].map((match) => match[1]);
+
+    expect(createdTables).toEqual(tableNames);
+    expect(migration).not.toContain("oneroster_demographics");
+  });
+
+  it.each(tableNames)(
+    "%s has sync bookkeeping and an updated_at trigger",
+    (tableName) => {
+      const body = tableBody(tableName);
+
+      expect(body).toContain(
+        "status text CHECK (status IN ('active', 'tobedeleted'))"
+      );
+      expect(body).toContain("is_active boolean NOT NULL DEFAULT true");
+      expect(body).toContain("date_last_modified timestamptz");
+      expect(body).toContain("last_synced_at timestamptz");
+      expect(body).toContain(
+        "created_at timestamptz NOT NULL DEFAULT now()"
+      );
+      expect(body).toContain(
+        "updated_at timestamptz NOT NULL DEFAULT now()"
+      );
+      expect(migration).toContain(
+        `CREATE TRIGGER update_${tableName}_updated_at`
+      );
+      expect(migration).toContain(
+        `BEFORE UPDATE ON ${tableName}\n  FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();`
+      );
+    }
+  );
+
+  it("uses indexes instead of foreign keys for roster sourced-id references", () => {
+    expect(migration).not.toMatch(/\bREFERENCES\s+oneroster_/i);
+
+    const requiredIndexes = [
+      "idx_oneroster_orgs_parent_sourced_id",
+      "idx_oneroster_academic_sessions_parent_sourced_id",
+      "idx_oneroster_courses_org_sourced_id",
+      "idx_oneroster_classes_course_sourced_id",
+      "idx_oneroster_classes_school_sourced_id",
+      "idx_oneroster_class_terms_term_sourced_id",
+      "idx_oneroster_user_roles_org_sourced_id",
+      "idx_oneroster_enrollments_class_sourced_id",
+      "idx_oneroster_enrollments_user_sourced_id",
+      "idx_oneroster_enrollments_school_sourced_id",
+    ];
+
+    for (const indexName of requiredIndexes) {
+      expect(migration).toContain(`CREATE INDEX IF NOT EXISTS ${indexName}`);
+    }
+  });
+
+  it("enforces entity and relationship uniqueness", () => {
+    const sourcedIdTables = [
+      "orgs",
+      "academic_sessions",
+      "courses",
+      "classes",
+      "users",
+      "enrollments",
+    ];
+
+    for (const tableName of sourcedIdTables) {
+      expect(migration).toContain(
+        `CREATE UNIQUE INDEX IF NOT EXISTS uq_oneroster_${tableName}_sourced_id`
+      );
+    }
+
+    expect(migration).toContain(
+      "CREATE UNIQUE INDEX IF NOT EXISTS uq_oneroster_class_terms_class_term"
+    );
+    expect(migration).toContain(
+      "CREATE UNIQUE INDEX IF NOT EXISTS uq_oneroster_user_roles_tuple"
+    );
+    expect(migration).toContain("coalesce(org_sourced_id, '')");
+  });
+
+  it("indexes the lowercase roster email join key", () => {
+    expect(migration).toMatch(
+      /CREATE INDEX IF NOT EXISTS idx_oneroster_users_email\s+ON oneroster_users \(lower\(email\)\);/
+    );
+  });
+
+  it("contains no executable DO blocks", () => {
+    expect(migration).not.toMatch(/^\s*DO\s+\$\$/m);
+  });
+
+  it("is registered in the migration manifest", () => {
+    const manifest = JSON.parse(
+      fs.readFileSync(
+        path.join(process.cwd(), "infra/database/migrations.json"),
+        "utf8"
+      )
+    ) as { migrationFiles: string[] };
+
+    expect(manifest.migrationFiles).toContain(migrationName);
+  });
+});

--- a/tests/unit/oneroster-core-migration.test.ts
+++ b/tests/unit/oneroster-core-migration.test.ts
@@ -134,6 +134,16 @@ describe("OneRoster core migration", () => {
     expect(migration).not.toMatch(/^\s*DO\s+\$\$/m);
   });
 
+  it("documents a complete manual rollback", () => {
+    expect(migration).toContain(
+      "-- ROLLBACK SQL (for manual rollback if needed)"
+    );
+
+    for (const tableName of tableNames) {
+      expect(migration).toContain(`-- DROP TABLE IF EXISTS ${tableName};`);
+    }
+  });
+
   it("is registered in the migration manifest", () => {
     const manifest = JSON.parse(
       fs.readFileSync(


### PR DESCRIPTION
## Summary

Completes the OneRoster core-schema foundation for Epic #1308:

- adds migration `141-oneroster-core.sql` with the eight in-scope OneRoster 1.2 tables:
  - `oneroster_orgs`
  - `oneroster_academic_sessions`
  - `oneroster_courses`
  - `oneroster_classes`
  - `oneroster_class_terms`
  - `oneroster_users`
  - `oneroster_user_roles`
  - `oneroster_enrollments`
- adds one matching Drizzle model per table and exports all eight from the schema index
- registers migration 141 in the migration manifest
- documents manual rollback SQL and adds a focused migration-contract test covering table scope, bookkeeping columns, triggers, sourced-reference indexes, uniqueness, lowercase email indexing, FK absence, rollback coverage, manifest registration, and SQL-splitter compatibility

This resumes the unverified handoff from `claude/bold-bardeen-upyl75` / `d78ab1c` rather than duplicating it. The implementation was reapplied onto current `dev` because the handoff's migration number 134 is now occupied. Migration 141 avoids both the unrelated local migration 139 work and migration 140 in open PR #1344.

## Acceptance criteria

- [x] All eight required tables are created and migration 141 is registered in `infra/database/migrations.json`
- [x] Every table has `status`, `is_active`, `date_last_modified`, `last_synced_at`, timestamps, and an `update_updated_at_column()` trigger
- [x] Required sourced-id and `lower(email)` indexes are present
- [x] No cross-collection OneRoster foreign keys are introduced
- [x] No executable `DO $$` blocks are present
- [x] Manual rollback SQL is documented for all eight additive tables
- [x] One Drizzle model exists per table and all eight are exported
- [x] A fresh local PostgreSQL reset applies the complete migration chain and migration 141
- [x] Full Jest CI suite, typecheck, build, manifest validation, and relevant lint checks pass
- [x] E2E: N/A — schema-only change with no user-facing surface

## Verification

- `bun run test -- tests/unit/oneroster-core-migration.test.ts tests/unit/db-migration-manifest.test.ts --runInBand`
  - 2 suites, 18 tests passed
- `bun run test:ci`
  - 361 suites passed; 3,567 tests passed; 3 suites / 26 tests skipped by existing configuration
- `bun run typecheck`
  - passed
- `bunx eslint lib/db/schema/index.ts lib/db/schema/tables/oneroster-*.ts --max-warnings 0 --no-warn-ignored`
  - passed with zero warnings
- `bun run lint`
  - exited successfully with 0 errors
  - current `dev` emits 407 warnings in untouched files; this PR adds none
- `bun run build`
  - passed; only existing Edge-runtime, dependency, and Browserslist warnings were emitted
- `bun run migration:list`
  - migration 141 registered and present; next available number reported as 142
- `bun run db:reset`
  - passed against an isolated PostgreSQL 16 + pgvector Compose volume/container so the main checkout's local database remained untouched
  - full initialization found 5 setup files and 125 migration files
  - migration log recorded `141-oneroster-core.sql:completed`
- strict idempotency rerun:
  - `psql -v ON_ERROR_STOP=1 -f infra/database/schema/141-oneroster-core.sql`
  - passed
- live PostgreSQL contract checks:
  - 8 roster tables
  - 8 updated-at triggers
  - 8 status checks
  - 0 OneRoster foreign keys
  - 27 indexes total (8 primary-key indexes + 19 explicit indexes)
  - duplicate sourced IDs rejected
  - duplicate org-less user-role tuples collapsed by the expression unique index
  - invalid status rejected
  - `updated_at` advances across transactions

## Migration and rollout

- Additive schema only; no existing table or data is modified.
- Roster references intentionally remain text sourced IDs with indexes rather than foreign keys so collection arrival order cannot break sync ingestion.
- Nothing reads these tables until #1310 lands.
- No demographics table is included.

## Risk and rollback

Risk is low: the tables are additive and currently unused. Migration 141 documents the manual drop order for all eight tables if rollback is required before #1310. Existing migrations are not modified.

Closes #1309
Part of #1308
