### PR TITLE
feat: #1305 - user-slot Drive read + organize, folder-only create

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,16 @@ jobs:
         # Dedicated collab-token signing key (mirrors the smoke's own default).
         COLLAB_JWT_SECRET: ci-collab-secret-0123456789
     
+    # psd-workspace skill gate (Bun). infra/agent-image/skills/psd-workspace is
+    # plain CJS outside the Next.js/jest roots, so `test:ci` never saw it — the
+    # regex gate that is the ONLY barrier against the agent sending mail,
+    # deleting, or creating files as the user (#912 Phase 1, #1138, #1305) had
+    # no CI coverage at all. It does now.
+    - name: Run psd-workspace skill gate tests (Bun)
+      run: bun run test:skill:workspace
+      env:
+        CI: true
+
     # Optional: Upload test coverage if you generate it
     # - name: Upload coverage reports
     #   uses: codecov/codecov-action@v3

--- a/actions/agent-workspace.actions.ts
+++ b/actions/agent-workspace.actions.ts
@@ -44,8 +44,25 @@ const SCOPES_BY_KIND: Record<"user_account", string[]> = {
     // Tasks for to-do management.
     "https://www.googleapis.com/auth/tasks",
     // Drive scoped to files the app creates or the user explicitly opens
-    // with the app — narrowest possible Drive grant.
+    // with the app. On the user slot this is now used for exactly ONE write:
+    // creating a FOLDER (the skill gate refuses every other files.create).
     "https://www.googleapis.com/auth/drive.file",
+    // Read + organize the user's own Drive (#1305, approved 2026-07-25).
+    // drive.readonly => list/get/export any file the user can see.
+    // drive.metadata => rename, move (add/removeParents), star — metadata
+    // writes ONLY. Neither scope permits a content write or an upload, and
+    // permanent delete still requires `drive`/`drive.file` on the target, so
+    // deleting a file the agent did not create is impossible at the GOOGLE
+    // layer rather than merely refused by our regex gate. Creating a non-folder
+    // item in the user's Drive stays banned by the skill gate — the
+    // impersonation barrier from 2026-07-06/07 is unchanged.
+    //
+    // Adding these does NOT affect existing refresh tokens: a stored token
+    // keeps the scope set it was issued with, and users pick the new ones up
+    // lazily on their next consent click. The OAuth client is Internal, so
+    // there is no restricted-scope verification or CASA burden.
+    "https://www.googleapis.com/auth/drive.readonly",
+    "https://www.googleapis.com/auth/drive.metadata",
     // People API directory scope — enables resolving user IDs to names
     // for Chat senders and calendar attendees.
     "https://www.googleapis.com/auth/directory.readonly",

--- a/infra/agent-image/skills/psd-workspace/SKILL.md
+++ b/infra/agent-image/skills/psd-workspace/SKILL.md
@@ -13,36 +13,68 @@ Google Workspace access for the user's data, gated by Phase 1 boundaries (#912).
 
 Phase 1 introduces two parallel OAuth identities per user. The `--scope` flag selects which:
 
-- `--scope user` (**default**) — OAuth on the human user (e.g. `hagelk@psd401.net`). Scopes: `gmail.modify` (read + draft + send + archive/label, no permanent delete), `calendar`, `tasks`, `drive.file`. Use this for reading the user's mail, managing their tasks, writing to their calendar. **NEVER for creating Drive files/Docs/Sheets/Slides** — a file created on this slot is OWNED BY THE USER, which is impersonation (hard-blocked at the skill layer, 2026-07-07). Every document you produce is created with `--scope agent` and shared explicitly. Sending is gated by behavioral rules — always confirm before actually sending.
+- `--scope user` (**default**) — OAuth on the human user (e.g. `hagelk@psd401.net`). Scopes: `gmail.modify` (read + draft + send + archive/label, no permanent delete), `calendar`, `tasks`, `drive.file`, `drive.readonly`, `drive.metadata`. Use this for reading the user's mail, managing their tasks, writing to their calendar, and **reading and organizing their Drive** (see below). **NEVER for creating Drive files/Docs/Sheets/Slides** — a file created on this slot is OWNED BY THE USER, which is impersonation (hard-blocked at the skill layer, 2026-07-07). Folders are the single exception, because a folder has no content to author. Every *document* you produce is created with `--scope agent` and shared explicitly. Sending is gated by behavioral rules — always confirm before actually sending.
 - `--scope agent` — the agent identity (e.g. `agnt_hagelk@psd401.net`). Broad scopes. Use this for actions the agent takes *as itself* (the agent's own calendar, drafts owned by the agent, agent-owned Drive folder). **There is no consent step for this slot** (as of #1232): the skill mints a short-lived access token automatically from the token broker. If your agent account hasn't been created yet you'll get `status: "account-provisioning"` (exit 14) — it's being set up automatically; just tell the user to retry in ~30 minutes. **Never** show a consent link for the agent slot.
 
 If you omit `--scope`, the skill defaults to `user`. Phase 1 work is overwhelmingly on user data.
 
-## Reading a Drive file the user already has — the `drive.file` 404
+## Reading and organizing the user's Drive (`--scope user`)
 
-The **user** slot's `drive.file` scope only exposes files this OAuth client
-created or that the user explicitly opened through it. So `files.get` (or any
-read) on a **pre-existing** doc the user already owns returns Drive's
-`404 File not found`. **This is a scope limitation, not a sharing problem** —
-the user owns the file, and sharing it with their own account changes nothing.
+Since 2026-07-25 (#1305) the user slot holds `drive.readonly` +
+`drive.metadata` in addition to `drive.file`. On that slot you **can**:
 
-When you hit a 404 reading a Drive file or a Drive chip on the **user** slot:
+| Do this | How |
+|---|---|
+| List / search anything the user can see | `drive files list --params '{"q":"…"}'` |
+| Read or export a file | `drive files get` / `drive files export` |
+| Rename a file | `drive files update --params '{"fileId":"…"}' --json '{"name":"New name"}'` |
+| Move a file between folders | `drive files update --params '{"fileId":"…","addParents":"<new>","removeParents":"<old>"}' --json '{"name":"…"}'` |
+| Star / describe / recolour | `drive files update … --json '{"starred":true}'` |
+| **Create a folder** | `drive files create --json '{"name":"Budget 2026","mimeType":"application/vnd.google-apps.folder"}'` |
 
-1. **Retry with `--scope agent`.** Your agent identity is
-   `agnt_<caller-uniqname>@psd401.net` (for caller `hagelk@psd401.net` that is
-   `agnt_hagelk@psd401.net`). It can read anything shared with it.
-2. **If that still 404s,** the file simply hasn't been shared with your agent
-   account yet. Ask the user to **share it with your agent account** —
-   e.g. `agnt_hagelk@psd401.net` — Reader (view) access is enough.
+and you **cannot** — each refuses with a plain-language reason:
+
+| Not this | Blocked by |
+|---|---|
+| Create a doc/sheet/deck/file in the user's Drive | the skill gate (impersonation ban, 2026-07-07) |
+| Copy a file into the user's Drive | the skill gate — the copy would be owned by the user |
+| Change any file's **content** | **Google** — no granted scope permits a content write |
+| Trash a file (`{"trashed":true}`) | the skill gate, on both slots |
+| Permanently delete, or empty trash | **Google** — needs `drive`/`drive.file` on that file, which you do not have for anything you did not create |
+
+Note the asymmetry: content edits and permanent deletion are impossible at the
+**Google** layer, not merely refused by our regex. There is no phrasing that
+gets around them.
+
+Folders you create are exempt from the `[Agent] ` filename prefix — the user
+asked for "Budget 2026", so that is what they get. The invisible
+`appProperties.psdAgentCreated` marker is still applied.
+
+### "One more permission" — exit 15
+
+Users pick the new scopes up **lazily**, on their next consent click. A refresh
+token issued before 2026-07-25 still carries only the old scopes, so a Drive
+read or metadata update on that token exits **15** with
+`status: "scope-upgrade-required"` and a `consent_chat_hyperlink`. Handle it
+exactly like `needs-auth`: paste the hyperlink on its own line, then on a
+separate line say *"I need one more permission to read your Drive — click the
+link to grant it."* Do not retry until the user confirms. Everything the slot
+could already do (mail, calendar, tasks, folder creation) keeps working on the
+old token with no prompt.
+
+### If a read still 404s
+
+With `drive.readonly` a 404 now means the **user** genuinely cannot see that
+file — not a scope gap. Retry with `--scope agent` (your agent identity is
+`agnt_<caller-uniqname>@psd401.net`; for caller `hagelk@psd401.net` that is
+`agnt_hagelk@psd401.net`), which can read anything shared with it. If that
+also 404s, ask the user to **share it with your agent account** — Reader
+access is enough.
 
 **Never** tell the user to share the file with their **own** address
 (`hagelk@psd401.net`): they already own it, so that guidance sends them in
-circles. Name the **agent** account (`agnt_…`) every time.
-
-Do **not** describe a 404 as "the file doesn't exist" or "you need to share it
-with yourself." Say instead: *"I can't open that file with the access I have
-yet — share it with my agent account `agnt_<you>@psd401.net` (Reader is fine)
-and I'll read it."*
+circles. Name the **agent** account (`agnt_…`) every time. Do **not** describe
+a 404 as "the file doesn't exist" or "you need to share it with yourself."
 
 Chat message attachments arrive to you as an `[attachments: …]` header at the
 top of the turn. A Drive chip / Drive-file attachment carries a `driveFileId` —
@@ -165,7 +197,8 @@ These cannot be bypassed by phrasing. The skill returns exit code 13 with `statu
 - **No sending mail.** `gmail.users.messages.send`, `gmail.users.drafts.send`, `+send`, `+reply`, `+reply-all`, `+forward` — all blocked. Drafts only.
 - **No deletes.** Mail (delete/trash/batchDelete), events, calendars, Drive files, drive trash, tasks, tasklists.
 - **No permission changes.** `drive.permissions.create/update/delete` (except the explicit in-district shapes below).
-- **No file creation as the user.** `drive files create/copy`, `docs documents create`, `sheets spreadsheets create`, `slides presentations create` on `--scope user` are hard-blocked — a file created there is owned by the user's account (impersonation; no attribution trail). Create with `--scope agent`, then share explicitly. This has NO exception and no phrasing gets around it.
+- **No file creation as the user.** `drive files create/copy`, `docs documents create`, `sheets spreadsheets create`, `slides presentations create` on `--scope user` are hard-blocked — a file created there is owned by the user's account (impersonation; no attribution trail). Create with `--scope agent`, then share explicitly. **One exception, added 2026-07-25 (#1305):** `drive files create` with `mimeType` exactly `application/vnd.google-apps.folder` is allowed, because a folder carries no content and creating one is organizing, not authoring. The mimeType is matched exactly — a shortcut, a Doc, or a lookalike mimeType still refuses — and any media/upload flag alongside it refuses too. Nothing else gets through, and no phrasing changes that.
+- **User-slot `drive files update` is metadata-only.** Rename, move, star, describe and recolour are allowed; anything else — an unrecognised field, a media/upload flag, or `{"trashed":true}` — refuses the whole call. The allowlist is all-or-nothing: one unknown key poisons the payload.
 
 **Exception — explicit in-district shares of YOUR OWN files.** `drive.permissions.create` is permitted only on files the agent owns (`--scope agent`), only as `create` (never update/delete), and only in these explicit shapes:
 
@@ -225,6 +258,7 @@ health), not runtime availability.
 - **Transport error (exit 12):** `gws`-style stderr message — the skill couldn't reach the token broker or Google (network/5xx). This is transient: tell the user Workspace access is temporarily unavailable and to try again shortly. Do not paste a consent link (there isn't one).
 - **Phase 1 forbidden (exit 13):** stdout is `{"status":"phase1-forbidden","reason":"<short>","message":"<longer>"}`. The user asked you to do something Phase 1 disallows (send mail, delete, etc.). Tell them what you can do instead — usually "I'll draft it; reply 'send' if it's right." Do **not** retry with a workaround.
 - **Account provisioning (exit 14):** stdout is `{"status":"account-provisioning","kind":"agent_account","message":"..."}`. Only the **agent slot** produces this: your `agnt_` Workspace account is being created automatically. Tell the user their agent account is being set up and to try again in about 30 minutes. There is **NOTHING to click** — do not show a consent link, do not retry in the same turn.
+- **Scope upgrade required (exit 15):** stdout is `{"status":"scope-upgrade-required","consent_url":"...","consent_chat_hyperlink":"<url|label>","kind":"user_account","missing_scopes":[...],"message":"..."}`. Only the **user slot** produces this, and only for the Drive read/organize operations added in #1305: the user authorized you *before* that feature existed, so their stored token predates the scope. Same rule as exits 10/11 — paste `consent_chat_hyperlink` on its own line, no surrounding markdown, then on a separate line say *"I need one more permission to read your Drive — click the link to grant it."* Frame it as **one more permission**, not as "you never authorized me" (exit 10) or "your access was revoked" (exit 11). Do not retry until the user confirms they clicked it.
 - **gws failure (exit 2+):** `gws` stderr is surfaced. Report the error to the user; do not invent workarounds.
 
 ## My inbox vs your inbox

--- a/infra/agent-image/skills/psd-workspace/SKILL.md
+++ b/infra/agent-image/skills/psd-workspace/SKILL.md
@@ -39,7 +39,7 @@ and you **cannot** — each refuses with a plain-language reason:
 | Create a doc/sheet/deck/file in the user's Drive | the skill gate (impersonation ban, 2026-07-07) |
 | Copy a file into the user's Drive | the skill gate — the copy would be owned by the user |
 | Change any file's **content** | **Google** — no granted scope permits a content write |
-| Trash a file (`{"trashed":true}`) | the skill gate, on both slots |
+| Trash or untrash a file (any `trashed` field) | the skill gate, on both slots — judged on the **parsed** payload, so a JSON key escape does not get around it |
 | Permanently delete, or empty trash | **Google** — needs `drive`/`drive.file` on that file, which you do not have for anything you did not create |
 
 Note the asymmetry: content edits and permanent deletion are impossible at the

--- a/infra/agent-image/skills/psd-workspace/common.js
+++ b/infra/agent-image/skills/psd-workspace/common.js
@@ -526,7 +526,9 @@ const PHASE1_FORBIDDEN = [
   // across the user's whole Drive. Blocked on BOTH slots: Phase 1 policy is
   // "never destructive", and `trashed` is also absent from the
   // metadata-update allowlist, so two independent rules have to fail for a
-  // trash to get through.
+  // trash to get through. This raw-string form is a fast fail only — the
+  // authoritative check is detectDriveTrashedWrite on the PARSED payload,
+  // which a JSON key escape cannot dodge (codex P1, PR #1346).
   { pattern: /"trashed"\s*:\s*true/i,
     reason: 'trashing a Drive file (Phase 1: never destructive — ask the user to trash it themselves)' },
   { pattern: /\bdrive[\s.]+files[\s.]+untrash\b/i,
@@ -667,6 +669,37 @@ function isMetadataOnlyDriveUpdate(commandString, tokens) {
   const keys = Object.keys(resource);
   if (keys.length === 0) return false;
   return keys.every((key) => DRIVE_METADATA_FIELDS.has(key.toLowerCase()));
+}
+
+/**
+ * REFUSE any Drive files write whose PARSED payload carries a `trashed` key.
+ *
+ * The raw-string PHASE1_FORBIDDEN pattern ('"trashed": true') is kept as a
+ * fast fail, but it can be routed around with a JSON string escape in the
+ * key — `--json '{"tr\u0061shed":true}'` — which the raw-string regex never
+ * matches while gws's JSON.parse decodes it right back to `trashed` and
+ * executes the trash (codex P1, PR #1346). The user slot happens to survive
+ * that because isMetadataOnlyDriveUpdate judges decoded keys, but the agent
+ * slot skips the user-slot allowlists entirely, so the gate must also judge
+ * the DECODED resource — same dual extraction the allowlists use.
+ *
+ * ANY value is refused, not just `true`: `trashed:false` is an untrash, and
+ * `files.untrash` is already blocked ("the agent does not manage the trash").
+ * Covers update/patch (trash/untrash) and create/copy (pre-trashed spawn).
+ * A payload our parse cannot read is not judged here — extractDriveResource
+ * uses the same JSON.parse gws does, and the unparseable case dies in gws.
+ */
+function detectDriveTrashedWrite(commandString, tokens) {
+  const spaceJoined = tokens.join(' ').toLowerCase();
+  const dotJoined = tokens.join('.').toLowerCase();
+  const driveWriteRe = /\bdrive[\s.]+files[\s.]+(update|patch|create|copy)\b/i;
+  if (!driveWriteRe.test(spaceJoined) && !driveWriteRe.test(dotJoined)) return null;
+  const resource = extractDriveResource(commandString, tokens);
+  if (!resource) return null;
+  const hasTrashed = Object.keys(resource).some((k) => k.toLowerCase() === 'trashed');
+  return hasTrashed
+    ? 'trashing/untrashing a Drive file (Phase 1: never destructive — ask the user to manage the trash themselves)'
+    : null;
 }
 
 // gws gmail "helper" verbs that put a message on the wire. The `+`-prefixed
@@ -944,6 +977,14 @@ function enforcePhase1Gates(commandString, context) {
       }
       return { allowed: false, reason };
     }
+  }
+
+  // Trash travels as a body field, and the raw-string pattern above can be
+  // dodged with a JSON escape in the key — judge the DECODED payload too,
+  // on BOTH slots (codex P1, PR #1346).
+  const trashedReason = detectDriveTrashedWrite(commandString, tokens);
+  if (trashedReason) {
+    return { allowed: false, reason: trashedReason };
   }
 
   // Helper-form send/reply/forward (REV-COR-350) — `gws gmail +send`,

--- a/infra/agent-image/skills/psd-workspace/common.js
+++ b/infra/agent-image/skills/psd-workspace/common.js
@@ -446,9 +446,31 @@ function execGws(commandString, accessToken, payloads) {
 // isPermittedExplicitShare. Drafts/calendar/tasks on the user slot remain
 // allowed: they are marker-stamped, land in review surfaces (Drafts folder,
 // own calendar), and were explicitly designed as user-slot writes.
+//
+// Refined 2026-07-25 (#1305): the user slot now also holds drive.readonly +
+// drive.metadata so the agent can READ and ORGANIZE the user's Drive. The
+// impersonated-CREATION ban is untouched — with one deliberate exception,
+// creating a FOLDER, which is an organizing act and carries no content. See
+// isPermittedFolderCreate below.
 const USER_SCOPE_FORBIDDEN = [
-  { pattern: /\bdrive[\s.]+files[\s.]+(create|copy)\b/i,
-    reason: 'creating files owned by the user (create as the agent and share explicitly instead)' },
+  // `copy` is unconditional: a copy always produces a content-bearing file.
+  { pattern: /\bdrive[\s.]+files[\s.]+copy\b/i,
+    reason: 'copying a file into the user\'s Drive — the copy would be owned by the user (create as the agent and share explicitly instead)' },
+  // `create` has exactly ONE exception — mimeType application/vnd.google-apps.folder
+  // (isPermittedFolderCreate). Everything else still refuses here.
+  { pattern: /\bdrive[\s.]+files[\s.]+create\b/i,
+    exception: isPermittedFolderCreate,
+    reason: 'creating files owned by the user (only folders may be created on this slot; create documents as the agent and share explicitly instead)' },
+  // `update` is newly reachable across the user's whole Drive now that
+  // drive.metadata is granted, so it needs a gate it never needed under
+  // drive.file. Allowed ONLY for metadata-field writes
+  // (isMetadataOnlyDriveUpdate): rename, move, star. Content/media uploads and
+  // `trashed` are refused. Google also rejects content writes under
+  // readonly+metadata+file, so this is belt-and-suspenders — its real value is
+  // a comprehensible error instead of an opaque 403.
+  { pattern: /\bdrive[\s.]+files[\s.]+update\b/i,
+    exception: isMetadataOnlyDriveUpdate,
+    reason: 'writing file content or trashing in the user\'s Drive (this slot may only change metadata: rename, move, star, describe)' },
   { pattern: /\bdocs[\s.]+documents[\s.]+create\b/i,
     reason: 'creating a Google Doc owned by the user (create as the agent and share explicitly instead)' },
   { pattern: /\bsheets[\s.]+spreadsheets[\s.]+create\b/i,
@@ -496,10 +518,156 @@ const PHASE1_FORBIDDEN = [
   { pattern: /\btasks[\s.]+tasklists[\s.]+delete\b/i,
     reason: 'deleting tasklists (Phase 1: never destructive)' },
 
+  // Trashing a Drive file. `files.delete` and `emptyTrash` are blocked above,
+  // but trashing travels as a METADATA write — `files update {"trashed":true}`
+  // — so it does not match them. Before #1305 the user slot held only
+  // drive.file and Google refused this on any file the app had not created;
+  // now that drive.metadata is granted it would otherwise become reachable
+  // across the user's whole Drive. Blocked on BOTH slots: Phase 1 policy is
+  // "never destructive", and `trashed` is also absent from the
+  // metadata-update allowlist, so two independent rules have to fail for a
+  // trash to get through.
+  { pattern: /"trashed"\s*:\s*true/i,
+    reason: 'trashing a Drive file (Phase 1: never destructive — ask the user to trash it themselves)' },
+  { pattern: /\bdrive[\s.]+files[\s.]+untrash\b/i,
+    reason: 'untrashing a Drive file (Phase 1: the agent does not manage the trash)' },
+
   // Sharing externally / changing permissions on user data
   { pattern: /\bdrive[\s.]+permissions[\s.]+(create|update|delete)\b/i,
     reason: 'modifying Drive sharing permissions (Phase 1: no permission changes)' },
 ];
+
+// ============================================================================
+// User-slot Drive: read + organize (#1305)
+// ============================================================================
+//
+// The user slot gained drive.readonly + drive.metadata on 2026-07-25 so the
+// agent can read and ORGANIZE the user's Drive. Two narrow exceptions to
+// USER_SCOPE_FORBIDDEN implement "organize" without reopening impersonated
+// creation:
+//
+//   isPermittedFolderCreate   — files.create, folder mimeType ONLY
+//   isMetadataOnlyDriveUpdate — files.update, metadata fields ONLY
+//
+// Both are ALLOWLISTS. Anything they cannot positively prove is safe falls
+// through to the block, so a payload shape we did not anticipate is refused
+// rather than permitted.
+
+const DRIVE_FOLDER_MIME = 'application/vnd.google-apps.folder';
+
+// Fields on the Drive `files` resource that carry no content and are covered
+// by drive.metadata. `trashed` is deliberately absent (see PHASE1_FORBIDDEN),
+// and so is anything that could carry bytes.
+const DRIVE_METADATA_FIELDS = new Set([
+  'name',
+  'starred',
+  'description',
+  'foldercolorrgb',
+  'properties',
+  'appproperties',
+]);
+
+// Flags that would attach a body/media stream to a Drive call. `--json` and
+// `--json-file` are the metadata resource and are fine; `--params` carries
+// query parameters (fileId, addParents, removeParents, supportsAllDrives) and
+// is checked separately for uploadType.
+const DRIVE_CONTENT_FLAG = /^--(media|media-file|media-body|upload|upload-file|upload-type|content|content-file|data|data-file|body|body-file|text|text-file|file|source|source-file)$/i;
+
+/**
+ * Pull the JSON resource out of a gws command, using the SAME dual extraction
+ * as isPermittedExplicitShare: prefer the argv token that actually executes
+ * (REV-COR-346 — the gate must see what gws sees), and fall back to the
+ * brace-balanced raw-string scan for the payload-file flow, whose synthetic
+ * command inlines minified JSON unquoted and so mangles under splitCommand.
+ * Returns the parsed object, or null when there is no parseable payload.
+ */
+function extractDriveResource(commandString, tokens) {
+  let payload = null;
+  const tokenJson = extractJsonArgFromTokens(tokens);
+  if (tokenJson) {
+    try { payload = JSON.parse(tokenJson); } catch { payload = null; }
+  }
+  if (!payload) {
+    const rawJson = extractJsonArg(commandString);
+    if (!rawJson) return null;
+    try { payload = JSON.parse(rawJson); } catch { return null; }
+  }
+  const resource = payload.resource || payload.requestBody || payload;
+  return resource && typeof resource === 'object' && !Array.isArray(resource)
+    ? resource
+    : null;
+}
+
+/** True if any argv token would attach content/media to the call. */
+function carriesDriveContent(tokens) {
+  for (let i = 0; i < tokens.length; i++) {
+    if (DRIVE_CONTENT_FLAG.test(tokens[i])) return true;
+    // `--params '{"uploadType":"media"}'` is a resumable/multipart upload in
+    // query-parameter clothing. Checked ONLY in the --params value, not across
+    // every token: a file the user asked to rename to "uploadType notes.txt"
+    // is a rename, and refusing it would be a false positive.
+    if (tokens[i] === '--params' && /uploadtype/i.test(tokens[i + 1] || '')) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * ALLOW `drive files create` on the user slot for a FOLDER and nothing else.
+ *
+ * A folder holds no content, so creating one is an organizing act rather than
+ * impersonated authorship — it does not reintroduce the 2026-07-07 hole
+ * (#1138: "do not create documents as my account"). It rides the existing
+ * drive.file grant, which also means the agent keeps access to the folder it
+ * created so it can move files into it afterwards.
+ *
+ * ALL must hold: the command is files.create; a payload parses; its mimeType
+ * is EXACTLY the folder mimeType; and no token attaches content. A create with
+ * no parseable payload is refused — absence of proof is not proof of absence.
+ */
+function isPermittedFolderCreate(commandString, tokens) {
+  const spaceJoined = tokens.join(' ').toLowerCase();
+  const dotJoined = tokens.join('.').toLowerCase();
+  const createRe = /\bdrive[\s.]+files[\s.]+create\b/i;
+  if (!createRe.test(spaceJoined) && !createRe.test(dotJoined)) return false;
+  if (carriesDriveContent(tokens)) return false;
+
+  const resource = extractDriveResource(commandString, tokens);
+  if (!resource) return false;
+  const mimeType = typeof resource.mimeType === 'string'
+    ? resource.mimeType.trim().toLowerCase()
+    : '';
+  return mimeType === DRIVE_FOLDER_MIME;
+}
+
+/**
+ * ALLOW `drive files update` on the user slot when every field it writes is
+ * metadata: rename, move (addParents/removeParents ride --params, not the
+ * body), star, describe, recolour.
+ *
+ * Google enforces this too — neither drive.readonly nor drive.metadata permits
+ * a content write, so an upload against a file the agent did not create 403s
+ * regardless. The gate exists so the agent gets a comprehensible refusal
+ * instead of an opaque 403, and so `trashed` is refused by our own rule as
+ * well as by policy.
+ *
+ * An update with no parseable payload is refused: without a body we cannot
+ * prove the call is metadata-only.
+ */
+function isMetadataOnlyDriveUpdate(commandString, tokens) {
+  const spaceJoined = tokens.join(' ').toLowerCase();
+  const dotJoined = tokens.join('.').toLowerCase();
+  const updateRe = /\bdrive[\s.]+files[\s.]+update\b/i;
+  if (!updateRe.test(spaceJoined) && !updateRe.test(dotJoined)) return false;
+  if (carriesDriveContent(tokens)) return false;
+
+  const resource = extractDriveResource(commandString, tokens);
+  if (!resource) return false;
+  const keys = Object.keys(resource);
+  if (keys.length === 0) return false;
+  return keys.every((key) => DRIVE_METADATA_FIELDS.has(key.toLowerCase()));
+}
 
 // gws gmail "helper" verbs that put a message on the wire. The `+`-prefixed
 // forms are unambiguous (they never appear as a search-query value), so they
@@ -635,6 +803,90 @@ function isPermittedExplicitShare(commandString, tokens, context) {
   return false;
 }
 
+// ============================================================================
+// Lazy scope upgrades (#1305)
+// ============================================================================
+//
+// drive.readonly + drive.metadata were added to the user slot on 2026-07-25.
+// Existing refresh tokens keep the scope set they were ISSUED with — Google
+// does not retroactively widen them — so a user who has not re-consented since
+// then has a token that cannot perform the new Drive read/organize calls. There
+// is no forced migration; users upgrade lazily on their next consent click.
+//
+// WHY THIS IS A PRE-FLIGHT CHECK AND NOT 403 PARSING. The issue asked for
+// "missing-scope 403 detection". The skill CANNOT observe such a 403: execGws
+// spawns gws with stdio ['ignore', 'inherit', 'inherit'], so gws writes its
+// output straight to our stdout/stderr and the skill never sees a byte of it.
+// Intercepting would mean buffering every gws response, which would also break
+// the streaming behaviour the agent relies on. The token refresh response,
+// however, carries the GRANTED scope string — so the gap is detectable one step
+// earlier, before the call is even attempted. That is strictly better for the
+// user: a re-authorize link instead of a failed operation plus a link.
+//
+// The result is emitted through the SAME consent-link path as revoked-token
+// handling (run.js, invalid_grant -> exit 11), just with its own status and
+// exit code so a caller can tell "you never authorized me" from "your
+// authorization expired" from "you authorized me before this feature existed".
+
+const DRIVE_READ_SCOPE = 'https://www.googleapis.com/auth/drive.readonly';
+const DRIVE_METADATA_SCOPE = 'https://www.googleapis.com/auth/drive.metadata';
+
+// Commands that only work once the user has re-consented. Deliberately narrow:
+// only the operations #1305 introduced. Everything the slot could already do
+// keeps working on an old token with no prompt.
+const SCOPE_REQUIREMENTS = [
+  {
+    pattern: /\bdrive[\s.]+files[\s.]+(list|get|export)\b/i,
+    scope: DRIVE_READ_SCOPE,
+    capability: 'read files in your Drive',
+  },
+  {
+    pattern: /\bdrive[\s.]+(about|changes)[\s.]+/i,
+    scope: DRIVE_READ_SCOPE,
+    capability: 'read files in your Drive',
+  },
+  {
+    pattern: /\bdrive[\s.]+files[\s.]+update\b/i,
+    scope: DRIVE_METADATA_SCOPE,
+    capability: 'rename and move files in your Drive',
+  },
+];
+
+/**
+ * Given a gws command and the space-separated `scope` string Google returned
+ * with the access token, report which newly-required scopes are missing.
+ *
+ * Returns `null` when the command needs nothing new (the overwhelmingly common
+ * case, so the caller pays nothing), otherwise
+ * `{ scopes: [...], capability: '<human phrase>' }`.
+ *
+ * Fail-OPEN on an absent/unparseable scope string: Google always returns
+ * `scope` on a refresh, but if it ever did not, refusing every Drive call
+ * would be a self-inflicted outage. A genuinely missing scope still fails at
+ * Google with a 403 — the pre-flight is an improvement to the error, not the
+ * security boundary. The security boundaries are the OAuth grant itself and
+ * enforcePhase1Gates.
+ */
+function missingScopesForCommand(commandString, grantedScopeString) {
+  if (!commandString || typeof grantedScopeString !== 'string' || !grantedScopeString.trim()) {
+    return null;
+  }
+  const tokens = splitCommand(commandString);
+  const spaceJoined = tokens.join(' ').toLowerCase();
+  const dotJoined = tokens.join('.').toLowerCase();
+  const granted = new Set(grantedScopeString.split(/\s+/).filter(Boolean));
+
+  const missing = [];
+  let capability = null;
+  for (const req of SCOPE_REQUIREMENTS) {
+    if (!req.pattern.test(spaceJoined) && !req.pattern.test(dotJoined)) continue;
+    if (granted.has(req.scope)) continue;
+    if (!missing.includes(req.scope)) missing.push(req.scope);
+    if (!capability) capability = req.capability;
+  }
+  return missing.length ? { scopes: missing, capability } : null;
+}
+
 /**
  * Test the gws command against Phase 1 forbidden patterns. Returns
  * `{allowed: true}` if the command can proceed, or
@@ -668,8 +920,14 @@ function enforcePhase1Gates(commandString, context) {
   // apply the user-slot rules (run.js always passes a resolved scope; only
   // a buggy caller would omit it, and the agent slot is the privileged one).
   if (!context || context.scope !== 'agent_account') {
-    for (const { pattern, reason } of USER_SCOPE_FORBIDDEN) {
+    for (const { pattern, reason, exception } of USER_SCOPE_FORBIDDEN) {
       if (hits(pattern)) {
+        // #1305: `create` and `update` carry narrow allowlisted exceptions
+        // (folder-only create, metadata-only update). Every other entry has
+        // no `exception` and stays absolute.
+        if (exception && exception(commandString, tokens)) {
+          continue;
+        }
         return { allowed: false, reason };
       }
     }
@@ -766,7 +1024,17 @@ function injectMarkers(commandString) {
   // Drive files create: prefix filename + appProperties marker
   if (/\bdrive[\s.]+files[\s.]+create\b/i.test(commandString)) {
     return mutateJsonField(commandString, (obj) => {
-      if (obj.name && !obj.name.startsWith('[Agent] ')) {
+      // FOLDERS are exempt from the visible `[Agent] ` prefix (#1305). A folder
+      // is an organizing container the USER asked for by name — "file these
+      // under Budget 2026" must not produce "[Agent] Budget 2026" in their own
+      // Drive. The prefix exists to mark agent-AUTHORED artifacts; a folder
+      // has no content to author. The invisible appProperties marker below is
+      // still applied, so the audit trail is unchanged and the folder remains
+      // identifiable as agent-created.
+      const isFolder =
+        typeof obj.mimeType === 'string' &&
+        obj.mimeType.trim().toLowerCase() === DRIVE_FOLDER_MIME;
+      if (obj.name && !isFolder && !obj.name.startsWith('[Agent] ')) {
         obj.name = `[Agent] ${obj.name}`;
       }
       obj.appProperties = obj.appProperties || {};
@@ -910,5 +1178,12 @@ module.exports = {
   injectMarkers,
   resolvePayloadFiles,
   extractJsonArg,
+  missingScopesForCommand,
+  isPermittedFolderCreate,
+  isMetadataOnlyDriveUpdate,
   PHASE1_FORBIDDEN,
+  USER_SCOPE_FORBIDDEN,
+  DRIVE_FOLDER_MIME,
+  DRIVE_READ_SCOPE,
+  DRIVE_METADATA_SCOPE,
 };

--- a/infra/agent-image/skills/psd-workspace/common.js
+++ b/infra/agent-image/skills/psd-workspace/common.js
@@ -1024,6 +1024,20 @@ function injectMarkers(commandString) {
   // Drive files create: prefix filename + appProperties marker
   if (/\bdrive[\s.]+files[\s.]+create\b/i.test(commandString)) {
     return mutateJsonField(commandString, (obj) => {
+      // Mark the FILE RESOURCE, not the envelope. gws accepts the resource at
+      // top level or wrapped under `resource` / `requestBody`, and the gate
+      // (isPermittedFolderCreate / isMetadataOnlyDriveUpdate, via
+      // extractDriveResource) unwraps all three. Marking only the outer object
+      // meant a wrapped payload was ALLOWED through the gate but its actual
+      // folder/file resource got neither the appProperties marker nor the
+      // folder-name handling — the audit trail silently went missing for
+      // exactly the shapes the gate accepts. Unwrap identically here so the
+      // gate and the marker can never disagree about which object is the file.
+      const target =
+        (obj.resource && typeof obj.resource === 'object' && !Array.isArray(obj.resource) && obj.resource) ||
+        (obj.requestBody && typeof obj.requestBody === 'object' && !Array.isArray(obj.requestBody) && obj.requestBody) ||
+        obj;
+
       // FOLDERS are exempt from the visible `[Agent] ` prefix (#1305). A folder
       // is an organizing container the USER asked for by name — "file these
       // under Budget 2026" must not produce "[Agent] Budget 2026" in their own
@@ -1032,13 +1046,13 @@ function injectMarkers(commandString) {
       // still applied, so the audit trail is unchanged and the folder remains
       // identifiable as agent-created.
       const isFolder =
-        typeof obj.mimeType === 'string' &&
-        obj.mimeType.trim().toLowerCase() === DRIVE_FOLDER_MIME;
-      if (obj.name && !isFolder && !obj.name.startsWith('[Agent] ')) {
-        obj.name = `[Agent] ${obj.name}`;
+        typeof target.mimeType === 'string' &&
+        target.mimeType.trim().toLowerCase() === DRIVE_FOLDER_MIME;
+      if (target.name && !isFolder && !target.name.startsWith('[Agent] ')) {
+        target.name = `[Agent] ${target.name}`;
       }
-      obj.appProperties = obj.appProperties || {};
-      obj.appProperties.psdAgentCreated = 'true';
+      target.appProperties = target.appProperties || {};
+      target.appProperties.psdAgentCreated = 'true';
       return obj;
     });
   }

--- a/infra/agent-image/skills/psd-workspace/common.test.js
+++ b/infra/agent-image/skills/psd-workspace/common.test.js
@@ -630,3 +630,46 @@ describe('#1305 uploadType is caught in --params without false-refusing renames'
     ).toBe(true);
   });
 });
+
+describe('#1305 marker injection marks the nested resource, not the envelope', () => {
+  // gws accepts the file resource at top level or wrapped under `resource` /
+  // `requestBody`, and the gate unwraps all three. The marker must unwrap the
+  // same way or a wrapped payload sails through the gate with NO audit marker
+  // on the object Google actually creates.
+  const shapes = [
+    ['top level', (r) => r],
+    ['resource wrapper', (r) => ({ resource: r })],
+    ['requestBody wrapper', (r) => ({ requestBody: r })],
+  ];
+
+  for (const [label, wrap] of shapes) {
+    test(`${label}: a folder keeps its name and gets the marker on the resource`, () => {
+      const payload = wrap({ name: 'Budget 2026', mimeType: DRIVE_FOLDER_MIME });
+      const out = injectMarkers(`drive files create --json '${JSON.stringify(payload)}'`);
+      const parsed = JSON.parse(extractJsonArg(out));
+      const resource = parsed.resource || parsed.requestBody || parsed;
+      expect(resource.name).toBe('Budget 2026');
+      expect(resource.appProperties.psdAgentCreated).toBe('true');
+      // The envelope itself must NOT be marked when it is only an envelope.
+      if (parsed !== resource) expect(parsed.appProperties).toBeUndefined();
+    });
+
+    test(`${label}: a non-folder gets the [Agent] prefix on the resource`, () => {
+      const payload = wrap({ name: 'Report.pdf' });
+      const out = injectMarkers(`drive files create --json '${JSON.stringify(payload)}'`);
+      const parsed = JSON.parse(extractJsonArg(out));
+      const resource = parsed.resource || parsed.requestBody || parsed;
+      expect(resource.name).toBe('[Agent] Report.pdf');
+      expect(resource.appProperties.psdAgentCreated).toBe('true');
+    });
+
+    test(`${label}: the gate and the marker agree on what the resource is`, () => {
+      const USER_CTX = { scope: 'user_account', ownerEmail: 'hagelk@psd401.net' };
+      const folder = wrap({ name: 'Q3', mimeType: DRIVE_FOLDER_MIME });
+      const doc = wrap({ name: 'Q3', mimeType: 'application/vnd.google-apps.document' });
+      const cmd = (p) => `drive files create --json '${JSON.stringify(p)}'`;
+      expect(enforcePhase1Gates(cmd(folder), USER_CTX).allowed).toBe(true);
+      expect(enforcePhase1Gates(cmd(doc), USER_CTX).allowed).toBe(false);
+    });
+  }
+});

--- a/infra/agent-image/skills/psd-workspace/common.test.js
+++ b/infra/agent-image/skills/psd-workspace/common.test.js
@@ -495,6 +495,41 @@ describe('#1305 user-slot Drive: files.update is metadata-only', () => {
     ).toBe(false);
   });
 
+  test('a JSON-escaped `trashed` key cannot dodge the ban on either slot (codex P1)', () => {
+    // `{"tr\u0061shed":true}` never matches the raw-string PHASE1 pattern,
+    // but gws's JSON.parse decodes the key straight back to `trashed` and
+    // executes the trash. The gate must judge the DECODED payload. The raw
+    // command below carries the literal backslash-u escape, exactly as an
+    // adversarial model would emit it.
+    const AGENT_CTX = { scope: 'agent_account', ownerEmail: 'hagelk@psd401.net' };
+    const escaped = `drive files update --params '{"fileId":"f1"}' --json '{"tr\\u0061shed":true}'`;
+    const agentVerdict = enforcePhase1Gates(escaped, AGENT_CTX);
+    expect(agentVerdict.allowed).toBe(false);
+    expect(agentVerdict.reason).toContain('trash');
+    expect(enforcePhase1Gates(escaped, USER_CTX).allowed).toBe(false);
+  });
+
+  test('untrash smuggled as `trashed:false` in the body is refused on both slots', () => {
+    // `files.untrash` is blocked as a verb; the body form must not be a way
+    // around it — the agent does not manage the trash in either direction.
+    const AGENT_CTX = { scope: 'agent_account', ownerEmail: 'hagelk@psd401.net' };
+    const untrash = `drive files update --params '{"fileId":"f1"}' --json '{"trashed":false}'`;
+    expect(enforcePhase1Gates(untrash, AGENT_CTX).allowed).toBe(false);
+    expect(enforcePhase1Gates(untrash, USER_CTX).allowed).toBe(false);
+  });
+
+  test('a pre-trashed folder create is refused even though the mimeType is permitted', () => {
+    // isPermittedFolderCreate only proves mimeType; without the parsed-payload
+    // trash check a folder create carrying an escaped `trashed` key would ride
+    // the #1305 carve-out through USER_SCOPE_FORBIDDEN.
+    expect(
+      enforcePhase1Gates(
+        `drive files create --json '{"mimeType":"application/vnd.google-apps.folder","name":"x","tr\\u0061shed":true}'`,
+        USER_CTX
+      ).allowed
+    ).toBe(false);
+  });
+
   test('any field outside the metadata allowlist refuses the whole call', () => {
     // One unknown key poisons the payload — the allowlist is all-or-nothing.
     expect(update({ name: 'ok', contentHints: { indexableText: 'x' } }).allowed).toBe(false);

--- a/infra/agent-image/skills/psd-workspace/common.test.js
+++ b/infra/agent-image/skills/psd-workspace/common.test.js
@@ -360,3 +360,273 @@ describe('gmail helper send forms (REV-COR-350) — prefixes cannot dodge the an
     expect(enforcePhase1Gates('drive files list --query gmail send', USER_CTX).allowed).toBe(true);
   });
 });
+
+// ============================================================================
+// #1305 — user-slot Drive read + organize
+// ============================================================================
+//
+// The user slot gained drive.readonly + drive.metadata on 2026-07-25 so the
+// agent can read and ORGANIZE the user's Drive. These tests pin the boundary:
+// what "organize" newly permits, and that the impersonation and destruction
+// bans it sits next to are unchanged. Both carve-outs are ALLOWLISTS, so the
+// most important cases here are the ones that must still be REFUSED.
+
+const {
+  missingScopesForCommand,
+  DRIVE_FOLDER_MIME,
+  DRIVE_READ_SCOPE,
+  DRIVE_METADATA_SCOPE,
+} = require('./common');
+
+describe('#1305 user-slot Drive: folder creation is the ONLY permitted create', () => {
+  const USER_CTX = { scope: 'user_account', ownerEmail: 'hagelk@psd401.net' };
+  const create = (resource, extra = '') =>
+    enforcePhase1Gates(
+      `drive files create --json '${JSON.stringify(resource)}'${extra}`,
+      USER_CTX
+    );
+
+  test('creating a folder is allowed', () => {
+    expect(create({ name: 'Budget 2026', mimeType: DRIVE_FOLDER_MIME }).allowed).toBe(true);
+  });
+
+  test('creating a folder inside another folder is allowed', () => {
+    expect(
+      create({ name: 'Q3', mimeType: DRIVE_FOLDER_MIME, parents: ['abc123'] }).allowed
+    ).toBe(true);
+  });
+
+  test('the folder mimeType is matched exactly, not as a prefix or substring', () => {
+    // A shortcut, a Doc, and a lookalike must all still refuse.
+    for (const mimeType of [
+      'application/vnd.google-apps.document',
+      'application/vnd.google-apps.shortcut',
+      'application/vnd.google-apps.folder.evil',
+      'text/plain',
+      'application/vnd.google-apps.folderx',
+    ]) {
+      expect(create({ name: 'x', mimeType }).allowed).toBe(false);
+    }
+  });
+
+  test('a create with no mimeType is refused — absence of proof is not proof', () => {
+    expect(create({ name: 'notes.txt' }).allowed).toBe(false);
+  });
+
+  test('a create with no parseable payload at all is refused', () => {
+    expect(enforcePhase1Gates('drive files create', USER_CTX).allowed).toBe(false);
+    expect(
+      enforcePhase1Gates('drive files create --json not-json', USER_CTX).allowed
+    ).toBe(false);
+  });
+
+  test('a folder mimeType cannot smuggle content in alongside it', () => {
+    for (const flag of [
+      ' --media /tmp/payload.bin',
+      ' --upload-type multipart',
+      ' --media-file /tmp/x',
+      " --params '{\"uploadType\":\"resumable\"}'",
+    ]) {
+      expect(create({ name: 'x', mimeType: DRIVE_FOLDER_MIME }, flag).allowed).toBe(false);
+    }
+  });
+
+  test('copy stays banned even for a folder — the carve-out is create-only', () => {
+    expect(
+      enforcePhase1Gates(
+        `drive files copy --json '{"mimeType":"${DRIVE_FOLDER_MIME}"}'`,
+        USER_CTX
+      ).allowed
+    ).toBe(false);
+  });
+
+  test('docs/sheets/slides creation is untouched by the carve-out', () => {
+    for (const cmd of [
+      `docs documents create --json '{"title":"x","mimeType":"${DRIVE_FOLDER_MIME}"}'`,
+      `sheets spreadsheets create --json '{"mimeType":"${DRIVE_FOLDER_MIME}"}'`,
+      `slides presentations create --json '{"mimeType":"${DRIVE_FOLDER_MIME}"}'`,
+    ]) {
+      expect(enforcePhase1Gates(cmd, USER_CTX).allowed).toBe(false);
+    }
+  });
+});
+
+describe('#1305 user-slot Drive: files.update is metadata-only', () => {
+  const USER_CTX = { scope: 'user_account', ownerEmail: 'hagelk@psd401.net' };
+  const update = (resource, extra = '') =>
+    enforcePhase1Gates(
+      `drive files update --params '{"fileId":"f1"}' --json '${JSON.stringify(resource)}'${extra}`,
+      USER_CTX
+    );
+
+  test('rename, star, describe and recolour are allowed', () => {
+    expect(update({ name: 'Renamed.pdf' }).allowed).toBe(true);
+    expect(update({ starred: true }).allowed).toBe(true);
+    expect(update({ description: 'filed by the agent' }).allowed).toBe(true);
+    expect(update({ name: 'Q3', folderColorRgb: '#8f8f8f' }).allowed).toBe(true);
+  });
+
+  test('moving a file (addParents/removeParents ride --params) is allowed', () => {
+    expect(
+      enforcePhase1Gates(
+        `drive files update --params '{"fileId":"f1","addParents":"folder2","removeParents":"folder1"}' --json '{"name":"Q3 report"}'`,
+        USER_CTX
+      ).allowed
+    ).toBe(true);
+  });
+
+  test('TRASHING is refused — the destructive ban survives the new scopes', () => {
+    // drive.metadata makes `trashed` a metadata write, so this would otherwise
+    // have become reachable across the user's whole Drive.
+    expect(update({ trashed: true }).allowed).toBe(false);
+    expect(update({ name: 'x', trashed: true }).allowed).toBe(false);
+  });
+
+  test('trashing is refused on the AGENT slot too (Phase 1: never destructive)', () => {
+    const AGENT_CTX = { scope: 'agent_account', ownerEmail: 'hagelk@psd401.net' };
+    expect(
+      enforcePhase1Gates(
+        `drive files update --params '{"fileId":"f1"}' --json '{"trashed":true}'`,
+        AGENT_CTX
+      ).allowed
+    ).toBe(false);
+    expect(
+      enforcePhase1Gates(`drive files untrash --params '{"fileId":"f1"}'`, AGENT_CTX).allowed
+    ).toBe(false);
+  });
+
+  test('any field outside the metadata allowlist refuses the whole call', () => {
+    // One unknown key poisons the payload — the allowlist is all-or-nothing.
+    expect(update({ name: 'ok', contentHints: { indexableText: 'x' } }).allowed).toBe(false);
+    expect(update({ capabilities: { canEdit: true } }).allowed).toBe(false);
+    expect(update({ owners: [{ emailAddress: 'someone@psd401.net' }] }).allowed).toBe(false);
+  });
+
+  test('content/media flags refuse regardless of how benign the body looks', () => {
+    for (const flag of [
+      ' --media /tmp/new-content.docx',
+      ' --media-body /tmp/x',
+      ' --upload-type media',
+      ' --content-file /tmp/x',
+    ]) {
+      expect(update({ name: 'still just a rename' }, flag).allowed).toBe(false);
+    }
+  });
+
+  test('an update with an empty or unparseable body is refused', () => {
+    expect(update({}).allowed).toBe(false);
+    expect(
+      enforcePhase1Gates(
+        `drive files update --params '{"fileId":"f1"}'`,
+        USER_CTX
+      ).allowed
+    ).toBe(false);
+  });
+
+  test('permanent delete and emptyTrash remain blocked', () => {
+    expect(
+      enforcePhase1Gates(`drive files delete --params '{"fileId":"f1"}'`, USER_CTX).allowed
+    ).toBe(false);
+    expect(enforcePhase1Gates('drive files emptyTrash', USER_CTX).allowed).toBe(false);
+  });
+
+  test('reads are allowed and always were', () => {
+    expect(
+      enforcePhase1Gates(`drive files get --params '{"fileId":"f1"}'`, USER_CTX).allowed
+    ).toBe(true);
+    expect(
+      enforcePhase1Gates(`drive files export --params '{"fileId":"f1","mimeType":"text/markdown"}'`, USER_CTX).allowed
+    ).toBe(true);
+  });
+});
+
+describe('#1305 lazy scope upgrade detection', () => {
+  const OLD = [
+    'https://www.googleapis.com/auth/gmail.modify',
+    'https://www.googleapis.com/auth/calendar',
+    'https://www.googleapis.com/auth/tasks',
+    'https://www.googleapis.com/auth/drive.file',
+  ].join(' ');
+  const NEW = `${OLD} ${DRIVE_READ_SCOPE} ${DRIVE_METADATA_SCOPE}`;
+
+  test('a pre-#1305 token is flagged for the new Drive reads', () => {
+    const gap = missingScopesForCommand(`drive files list --params '{"q":"x"}'`, OLD);
+    expect(gap).not.toBeNull();
+    expect(gap.scopes).toEqual([DRIVE_READ_SCOPE]);
+    expect(gap.capability).toContain('read');
+  });
+
+  test('a pre-#1305 token is flagged for metadata updates', () => {
+    const gap = missingScopesForCommand(`drive files update --json '{"name":"x"}'`, OLD);
+    expect(gap.scopes).toEqual([DRIVE_METADATA_SCOPE]);
+  });
+
+  test('a re-consented token is never flagged', () => {
+    expect(missingScopesForCommand(`drive files list --params '{}'`, NEW)).toBeNull();
+    expect(missingScopesForCommand(`drive files update --json '{"name":"x"}'`, NEW)).toBeNull();
+  });
+
+  test('operations that predate #1305 never prompt, even on an old token', () => {
+    // No forced migration: everything the slot could already do keeps working.
+    for (const cmd of [
+      `gmail users messages list --query 'is:unread'`,
+      `calendar events insert --json '{"summary":"x"}'`,
+      `tasks tasks insert --json '{"title":"x"}'`,
+      `drive files create --json '{"mimeType":"${DRIVE_FOLDER_MIME}"}'`,
+    ]) {
+      expect(missingScopesForCommand(cmd, OLD)).toBeNull();
+    }
+  });
+
+  test('fails OPEN on a missing scope string rather than blocking every call', () => {
+    // Google always returns `scope` on a refresh; if it ever did not, refusing
+    // all Drive work would be a self-inflicted outage. Google still 403s a
+    // genuinely missing scope — this check only improves the error.
+    expect(missingScopesForCommand(`drive files list --params '{}'`, undefined)).toBeNull();
+    expect(missingScopesForCommand(`drive files list --params '{}'`, '')).toBeNull();
+  });
+
+  test('dot-form invocations are detected the same as space-form', () => {
+    expect(missingScopesForCommand('drive.files.list', OLD)).not.toBeNull();
+  });
+});
+
+describe('#1305 marker injection on folders', () => {
+  test('a folder keeps the name the user asked for, but still gets the audit marker', () => {
+    const out = injectMarkers(
+      `drive files create --json '{"name":"Budget 2026","mimeType":"${DRIVE_FOLDER_MIME}"}'`
+    );
+    const obj = JSON.parse(extractJsonArg(out));
+    expect(obj.name).toBe('Budget 2026');
+    expect(obj.appProperties.psdAgentCreated).toBe('true');
+  });
+
+  test('non-folder creations still get the visible [Agent] prefix', () => {
+    const out = injectMarkers(`drive files create --json '{"name":"Report.pdf"}'`);
+    const obj = JSON.parse(extractJsonArg(out));
+    expect(obj.name).toBe('[Agent] Report.pdf');
+    expect(obj.appProperties.psdAgentCreated).toBe('true');
+  });
+});
+
+describe('#1305 uploadType is caught in --params without false-refusing renames', () => {
+  const USER_CTX = { scope: 'user_account', ownerEmail: 'hagelk@psd401.net' };
+
+  test('uploadType in --params refuses (an upload in query-parameter clothing)', () => {
+    expect(
+      enforcePhase1Gates(
+        `drive files update --params '{"fileId":"f1","uploadType":"media"}' --json '{"name":"x"}'`,
+        USER_CTX
+      ).allowed
+    ).toBe(false);
+  });
+
+  test('a filename that merely contains "uploadType" is still a rename', () => {
+    expect(
+      enforcePhase1Gates(
+        `drive files update --params '{"fileId":"f1"}' --json '{"name":"uploadType notes.txt"}'`,
+        USER_CTX
+      ).allowed
+    ).toBe(true);
+  });
+});

--- a/infra/agent-image/skills/psd-workspace/run.js
+++ b/infra/agent-image/skills/psd-workspace/run.js
@@ -10,10 +10,15 @@
  *
  *   --scope user (default for Phase 1) →
  *     OAuth on the human user's identity (hagelk@psd401.net), scopes
- *     (gmail.modify, calendar, tasks, drive.file). gmail.modify covers
- *     read + draft + archive/label + (technically) send — sending is
- *     blocked by the skill's regex gate, not by the OAuth scope. Use for
- *     reading/writing the human's own data.
+ *     (gmail.modify, calendar, tasks, drive.file, drive.readonly,
+ *     drive.metadata). gmail.modify covers read + draft + archive/label +
+ *     (technically) send — sending is blocked by the skill's regex gate, not
+ *     by the OAuth scope. drive.readonly + drive.metadata (#1305) let the
+ *     agent READ and ORGANIZE the user's Drive: list/get/export anything,
+ *     rename/move/star, and create FOLDERS. Creating a non-folder item,
+ *     writing file content, trashing and deleting all remain impossible —
+ *     see the Phase 1 gate notes below. Use for reading/writing the human's
+ *     own data.
  *
  *   --scope agent →
  *     The agent account (agnt_hagelk@psd401.net), broad scopes. As of #1232
@@ -51,6 +56,9 @@
  *   12 transport error (broker/network failure)
  *   13 phase1-forbidden (Phase 1 hard gate refused the command)
  *   14 account-provisioning (agent slot; agnt_ account being auto-created)
+ *   15 scope-upgrade-required (user slot; the stored token predates a scope
+ *      this command needs — #1305. Distinct from 10/11 so the caller can say
+ *      "one more permission" rather than "you never authorized me")
  */
 
 'use strict';
@@ -70,6 +78,7 @@ const {
   injectMarkers,
   resolvePayloadFiles,
   extractJsonArg,
+  missingScopesForCommand,
 } = require('./common');
 
 async function main() {
@@ -243,6 +252,38 @@ async function main() {
     if (!access || !access.access_token) {
       fail('Token refresh returned no access_token');
     }
+
+    // Lazy scope upgrade (#1305). drive.readonly + drive.metadata joined the
+    // user slot on 2026-07-25; a refresh token issued before then still
+    // carries only the old scopes, and Google does not widen it retroactively.
+    // Check the GRANTED scope string that came back with this token rather
+    // than waiting for a 403 — execGws inherits stdio, so the skill never sees
+    // gws's output and could not detect the 403 anyway. Same consent-link
+    // pattern as the revoked-token path above, with its own status/exit code so
+    // "authorized before this feature existed" is distinguishable from
+    // "never authorized" (10) and "authorization revoked" (11).
+    const scopeGap = missingScopesForCommand(guardedCommand, access.scope);
+    if (scopeGap) {
+      let consentUrl;
+      try {
+        consentUrl = await mintConsentUrl(ownerEmail, scope);
+      } catch (e) {
+        fail(`Additional Google permission required but consent-link mint failed: ${e.message}`);
+      }
+      emit({
+        status: 'scope-upgrade-required',
+        consent_url: consentUrl,
+        consent_chat_hyperlink: `<${consentUrl}|Re-authorize Google Workspace>`,
+        kind: scope,
+        missing_scopes: scopeGap.scopes,
+        message:
+          'Paste consent_chat_hyperlink on its own line, no surrounding markdown. Then on a separate line: ' +
+          `"I need one more permission to ${scopeGap.capability} — click the link to grant it." ` +
+          'Do not retry until the user confirms they clicked it.',
+      });
+      process.exit(15);
+    }
+
     accessToken = access.access_token;
   }
 

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "test:smoke:google-content": "DATABASE_URL='postgresql://postgres:postgres@localhost:5432/aistudio' DB_SSL=false bun run tests/smoke/google-content-connectors.smoke.ts",
     "test:smoke:unified-content-lambda-artifact": "bun run scripts/test/unified-content-lambda-artifact.smoke.ts",
     "test:smoke:embedding-lambda-artifact": "bun run scripts/test/embedding-lambda-artifact.smoke.ts",
+    "test:skill:workspace": "cd infra/agent-image/skills/psd-workspace && bun test common.test.js",
     "test:smoke:atrium": "bun run test:smoke:atrium-render && bun run test:smoke:atrium-collab && bun run test:smoke:atrium-collab-token && bun run test:smoke:atrium-agent-bridge && bun run test:smoke:atrium-agent-read && bun run test:smoke:atrium-html-sanitize && bun run test:smoke:atrium-provenance-rail && bun run test:smoke:atrium-collab-schema && bun run test:smoke:atrium-suggestions-resolve && bun run test:smoke:atrium-suggestion-mode && bun run test:smoke:atrium-sandbox-config && bun run test:smoke:atrium-sandbox-host",
     "test:ci": "jest --config=jest.config.ci.js",
     "test:watch": "jest --watch",

--- a/tests/unit/agent-workspace-user-slot-scopes.test.ts
+++ b/tests/unit/agent-workspace-user-slot-scopes.test.ts
@@ -1,0 +1,116 @@
+/**
+ * User-slot OAuth consent scope set (#1305).
+ *
+ * `SCOPES_BY_KIND.user_account` in actions/agent-workspace.actions.ts is the
+ * list Google is asked for when a user clicks the consent link. It is the
+ * OUTER boundary of everything the agent can ever do on the user's behalf —
+ * the skill gate in infra/agent-image/skills/psd-workspace/common.js only ever
+ * narrows it. Nothing else in the codebase pins this list, so a silent edit
+ * would either break the Drive read/organize feature (scope dropped) or widen
+ * the blast radius without review (scope added).
+ *
+ * These are static assertions on the source: the module is a "use server" file
+ * whose import pulls in the whole auth/db stack, and the constant is not
+ * exported.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+
+const actionsSource = fs.readFileSync(
+  path.join(process.cwd(), "actions/agent-workspace.actions.ts"),
+  "utf8"
+);
+
+/** The scope string literals inside the SCOPES_BY_KIND.user_account array. */
+function userAccountScopes(): string[] {
+  const start = actionsSource.indexOf("const SCOPES_BY_KIND");
+  expect(start).toBeGreaterThan(-1);
+  const open = actionsSource.indexOf("user_account: [", start);
+  expect(open).toBeGreaterThan(-1);
+  const close = actionsSource.indexOf("],", open);
+  expect(close).toBeGreaterThan(open);
+  // Drop whole comment LINES first — the rationale comments in this block
+  // quote prose ("the way it is working right now is fine") that would
+  // otherwise read as a scope literal. Anchored to the start of the line on
+  // purpose: a naive /\/\/.*/ strip would also eat the `//` in every
+  // `https://…` scope URL.
+  const body = actionsSource
+    .slice(open, close)
+    .replace(/^[ \t]*\/\/[^\n]*$/gm, "");
+  return [...body.matchAll(/"([^"]+)"/g)]
+    .map((m) => m[1])
+    .filter((s) => s !== "user_account");
+}
+
+const DRIVE_READONLY = "https://www.googleapis.com/auth/drive.readonly";
+const DRIVE_METADATA = "https://www.googleapis.com/auth/drive.metadata";
+
+describe("user-slot consent scopes", () => {
+  it("is exactly the approved set — no more, no less", () => {
+    expect(userAccountScopes().sort()).toEqual(
+      [
+        "email",
+        "openid",
+        "profile",
+        "https://www.googleapis.com/auth/calendar",
+        "https://www.googleapis.com/auth/directory.readonly",
+        "https://www.googleapis.com/auth/drive.file",
+        DRIVE_METADATA,
+        DRIVE_READONLY,
+        "https://www.googleapis.com/auth/gmail.modify",
+        "https://www.googleapis.com/auth/tasks",
+      ].sort()
+    );
+  });
+
+  it("grants the two Drive scopes #1305 added", () => {
+    const scopes = userAccountScopes();
+    expect(scopes).toContain(DRIVE_READONLY);
+    expect(scopes).toContain(DRIVE_METADATA);
+  });
+
+  it("never requests full Drive — delete must stay impossible at the Google layer", () => {
+    // The whole point of readonly+metadata+file is that permanent delete needs
+    // `drive` (or `drive.file` on the target). Granting `drive` would make
+    // deletion depend on our regex gate, which #1305 explicitly rejected.
+    const scopes = userAccountScopes();
+    expect(scopes).not.toContain("https://www.googleapis.com/auth/drive");
+    expect(scopes).not.toContain("https://www.googleapis.com/auth/drive.appdata");
+  });
+
+  it("never requests contacts scopes (#1239: wrong scope for the directory)", () => {
+    const scopes = userAccountScopes();
+    for (const scope of scopes) {
+      expect(scope).not.toMatch(/\/contacts/);
+    }
+  });
+});
+
+describe("psd-workspace SKILL.md documents the new capability", () => {
+  const skill = fs.readFileSync(
+    path.join(
+      process.cwd(),
+      "infra/agent-image/skills/psd-workspace/SKILL.md"
+    ),
+    "utf8"
+  );
+
+  it("lists the new scopes in the --scope user description", () => {
+    // The model reads SKILL.md, not the source. If the scopes ship without the
+    // docs it will keep refusing Drive reads out of habit.
+    expect(skill).toContain("drive.readonly");
+    expect(skill).toContain("drive.metadata");
+  });
+
+  it("documents the folder-only create exception and the bans it sits beside", () => {
+    expect(skill).toContain("application/vnd.google-apps.folder");
+    expect(skill).toMatch(/trash/i);
+    expect(skill).toMatch(/metadata-only/i);
+  });
+
+  it("documents the exit-15 re-consent path", () => {
+    expect(skill).toContain("scope-upgrade-required");
+    expect(skill).toContain("exit 15");
+  });
+});


### PR DESCRIPTION
## Summary

Implements #1305. The user slot gains `drive.readonly` + `drive.metadata` so the agent can **read and organize** the user's own Drive, folder creation is carved out of the impersonation ban, and deletion is made **scope-impossible** rather than gate-blocked.

This refines — it does not reverse — the 2026-07-06/07 decision. The impersonated-*creation* ban stays; read + organize are now in scope; folders are explicitly allowed because a folder has no content to author.

## Enforcement is layered, and the layers are not interchangeable

| Operation | Allowed | Enforced by |
|---|---|---|
| Read / list / export any file | ✅ | `drive.readonly` |
| Rename, move, star, describe | ✅ | `drive.metadata` |
| Create a **folder** | ✅ | `drive.file` + a gate carve-out |
| Create any other item | ❌ | skill gate (impersonation barrier) |
| Copy a file | ❌ | skill gate |
| Modify file **content** | ❌ | **Google** — no granted scope permits it |
| Trash (`{"trashed":true}`) | ❌ | skill gate, on **both** slots |
| Permanent delete / `emptyTrash` | ❌ | **Google** — needs `drive`/`drive.file` on the target |

The two Google-enforced rows are the point. The rejected alternatives (full `drive` + regex-only gating; DWD impersonation of real users) all made deletion depend on our own regex, which the issue explicitly ruled out. A test asserts full `drive` is **never** requested, so that cannot regress quietly.

## Notable decisions

**Trash was a new hole, not an existing rule.** Trashing travels as a *metadata* write (`files update {"trashed":true}`), so it matched neither `files delete` nor `emptyTrash`. Under `drive.file` Google refused it on anything the app had not created; under `drive.metadata` it would have become reachable across the user's whole Drive. It is now blocked on both slots **and** absent from the metadata allowlist — two independent rules must fail for a trash to get through.

**"Missing-scope 403 detection" is implemented as a pre-flight check, not 403 parsing.** The skill *cannot* observe such a 403: `execGws` spawns `gws` with `stdio: ['ignore','inherit','inherit']`, so gws writes straight to our stdout/stderr and the skill never sees a byte of it. Intercepting would mean buffering every response and would break streaming. The token refresh response *does* carry the granted `scope` string, so the gap is detectable one step **earlier** — the user gets a re-authorize link instead of a failed operation plus a link. New exit **15** (`scope-upgrade-required`), distinct from 10 (never authorized) and 11 (revoked) so the agent can say "one more permission". Exit 12 was already taken by transport errors. The check fails **open** on an absent scope string — a genuinely missing scope still 403s at Google, and the security boundaries remain the OAuth grant and `enforcePhase1Gates`.

**Folders skip the `[Agent] ` filename prefix.** "File these under Budget 2026" must not produce `[Agent] Budget 2026` in the user's own Drive. The invisible `appProperties.psdAgentCreated` marker still applies, so the audit trail is unchanged.

**The gate tests never ran in CI.** `infra/agent-image/skills/psd-workspace` is plain CJS outside the jest roots, so the regex gate — the only barrier against the agent sending mail, deleting, or creating files as the user — had **zero** CI coverage. Added `test:skill:workspace` and a CI step. Verified it works from a clean checkout by removing the skill's local `node_modules` and confirming `@aws-sdk/client-secrets-manager` still resolves from the root install.

## Verification (all green before opening)

- Build (`next build --webpack`): ✅
- Lint (`eslint .`): ✅ 0 errors (407 pre-existing warnings, unchanged; touched files clean)
- Typecheck (`tsc --noEmit`): ✅
- Jest (full CI suite): ✅ 3560 passed / 361 suites
- psd-workspace gate suite: ✅ **61 passed** (27 new), weighted toward what must still be **refused** — lookalike folder mimeTypes (`…folder.evil`, `…folderx`), folder-create with a smuggled media flag, copy-a-folder, docs/sheets/slides carrying a folder mimeType, trash on both slots, unknown fields in an update, `uploadType` in `--params`, and empty/unparseable payloads.
- Authenticated Playwright suite (pre-push gate): ✅

## Evidence

_N/A — no UI surface. The change is the consent scope list, the skill gate, and skill documentation._

## ⚠️ Live probes still pending — these need YOU, Hagel

The issue's probe checklist requires a user token carrying the **new** scopes. That token cannot exist until this ships and a dev user re-consents, so none of these could be run here. After deploying to dev and re-consenting the test user via **PSD Agent Dev**:

- [ ] `drive.metadata` + `files.update {trashed:true}` — does **Google** reject it, or only our gate? **Believed: our gate is currently the load-bearing barrier.** `drive.metadata` is documented as "view and manage metadata", and `trashed` is a metadata field, so Google may well permit it. Treat the skill gate as the only thing stopping trash until this is confirmed.
- [ ] A folder created via `drive.file` is owned by the user and stays agent-visible/manageable afterwards (so the agent can move files into it).
- [ ] Content upload under `readonly`+`metadata`+`file` against a **non-app-created** file → expect Google 403.
- [ ] Export of Google-native formats (Docs/Sheets → md/csv) under `drive.readonly`.
- [ ] Shared-drive items (`supportsAllDrives`) on read + move paths. (`supportsAllDrives` rides `--params`, which the metadata allowlist does not restrict, so this is expected to work.)
- [ ] Moving a file the user cannot move (view-only shared item) → clean error surfaced.

Closes #1305
