### PR TITLE
feat(roster): add fail-safe ClassLink OneRoster sync (#1310)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -176,6 +176,8 @@ AI integration patterns using Vercel AI SDK v6, provider factory implementation,
 
 **[Google Workspace content synchronization](./features/google-workspace-content-sync.md)** — PKCE OAuth and Picker selection across My Drive and user-accessible Shared Drives, durable cursor/version reconciliation, deployment-owned configuration, deletion grace, and operations.
 
+**[ClassLink OneRoster synchronization](./features/oneroster-classlink-sync.md)** — Nightly full-collection roster ingestion, OAuth1 and static-bearer Proxy configuration, fail-safe reconciliation invariants, metrics, alarms, rollout, and rollback.
+
 #### [features/navigation.md](./features/navigation.md)
 Dynamic navigation system with role-based menu items.
 

--- a/docs/features/oneroster-classlink-sync.md
+++ b/docs/features/oneroster-classlink-sync.md
@@ -1,0 +1,256 @@
+# ClassLink OneRoster synchronization
+
+Status: v1 ingestion foundation implemented by Epic
+[#1308](https://github.com/psd401/aistudio/issues/1308), Issue
+[#1310](https://github.com/psd401/aistudio/issues/1310). The administrator UI,
+role mapping, room provisioning, and reporting are separate workstreams.
+
+## Scope and data boundary
+
+The nightly Lambda imports one tenant's complete `orgs`,
+`academicSessions`, `courses`, `classes`, `users`, and `enrollments`
+collections into the dedicated `oneroster_*` tables. It also normalizes class
+terms and OneRoster user roles into their relationship tables.
+
+- The stored model follows the OneRoster 1.2 schema introduced by migration
+  141. API requests default to the widely deployed OneRoster 1.1 REST path;
+  `v1p2` is reserved behind `ONEROSTER_API_VERSION`.
+- Demographics, metadata, resources, and other unnecessary student data are
+  neither requested nor persisted.
+- Roster email is normalized to lowercase for the later cross-system user join.
+- This Lambda never writes application users, application role grants,
+  capabilities, API-key scopes, rooms, or assistants. In particular, ingestion
+  cannot grant or revoke the administrator role.
+- The Lambda modifies only the dedicated OneRoster tables and its internal
+  `ONEROSTER_LAST_PERM_REV` setting.
+
+The implementation follows ClassLink's guidance to pull the bulk collections
+with a 10,000-record page size and verify `x-count` and `x-total-count`.
+[ClassLink's current best-practices article](https://help.classlink.com/articles/Knowledge/rs-data-best-practices)
+is the protocol source of truth.
+
+## Architecture
+
+`ProcessingStack` deploys `psd-oneroster-sync-{environment}` as an isolated
+Node.js 20 ARM64 Lambda in private subnets with NAT egress:
+
+1. EventBridge invokes it nightly at 10:00 UTC. A future admin action can invoke
+   the same function asynchronously through `lib/roster/trigger.ts`.
+2. Runtime configuration is read from the `settings` table. Credentials are
+   read from a separately managed Secrets Manager secret.
+3. The HTTP client stages each complete collection in memory, using only the
+   requested fields.
+4. Each collection reconciles in its own PostgreSQL transaction. Upserts and
+   absence-driven deactivation commit together.
+5. The persistent `x-perm-rev` checkpoint advances only after all six
+   collections apply successfully.
+
+Reserved concurrency is one so manual and scheduled full snapshots cannot race.
+Database writes are chunked at 4,000 rows, below the required 5,000-row maximum.
+
+## Authentication modes
+
+`ONEROSTER_AUTH_MODE` has exactly two valid values. There is no generic OAuth2
+client-credentials flow or token endpoint.
+
+### Direct OAuth1 (`oauth1`)
+
+The Lambda signs each complete request URL, including `fields`, `limit`, and
+`offset`, with OAuth1 HMAC-SHA1. The secret JSON shape is:
+
+```json
+{
+  "consumerKey": "...",
+  "consumerSecret": "..."
+}
+```
+
+Set `ONEROSTER_BASE_URL` to the district Roster Server origin supplied by
+ClassLink, without `/ims/oneroster/...`.
+
+### ClassLink OAuth2 Proxy (`proxy`)
+
+The Lambda sends the static, non-expiring Partner Portal access token as a
+Bearer token. The secret JSON shape is:
+
+```json
+{
+  "bearerToken": "..."
+}
+```
+
+Set `ONEROSTER_BASE_URL` to the application-specific proxy prefix, for example:
+
+```text
+https://oneroster-proxy.apis.classlink.com/proxy/v1p0/{applicationId}
+```
+
+Use the hostname and application ID currently shown by ClassLink rather than
+copying the example literally. The Lambda appends the selected OneRoster API
+path. ClassLink documents both the Partner Portal credential workflow and the
+static Bearer behavior in
+[Accessing Roster Server Data](https://help.classlink.com/articles/Knowledge/pp-access-rs-data);
+its published API definition exposes the application-prefixed
+[proxy collection routes](https://oneroster-proxy.apis.classlink.com/docs/index.html).
+
+### Obtain credentials
+
+For either mode:
+
+1. Sign in to the ClassLink Partner Portal and choose **Clients** →
+   **View By Tenant**.
+2. Open the PSD tenant, select the connected application, and select the key
+   icon.
+3. For OAuth1, capture the district endpoint, key, and secret. For proxy mode,
+   capture the application ID, proxy host, and access token.
+4. Put the corresponding JSON object in an AWS secret named with the deployment
+   pattern `aistudio-{environment}-oneroster-*`. Tag it
+   `Environment={environment}` and `ManagedBy=manual`. Do not place credentials
+   in the settings table, source control, shell history, or logs.
+5. Store that secret's full ARN in
+   `ONEROSTER_CREDENTIALS_SECRET_ARN`.
+
+The Lambda IAM role can read only the Aurora credential secret and the
+environment-specific `aistudio-{environment}-oneroster-*` secret family; the
+credential read also requires the matching `Environment` resource tag.
+
+## Settings
+
+All values are database-first. The Next.js accessors in
+`lib/roster/settings.ts` and the isolated Lambda keys in
+`infra/lambdas/oneroster-sync/config.ts` must remain synchronized.
+
+| Key | Required | Default | Meaning |
+| --- | --- | --- | --- |
+| `ROSTER_SYNC_ENABLED` | yes for scheduled runs | `false` | Exact value `true` enables the nightly rule's work. Manual invocation can run while disabled. |
+| `ONEROSTER_BASE_URL` | yes | none | HTTPS direct-server origin or application-specific proxy prefix. |
+| `ONEROSTER_AUTH_MODE` | yes | none | `oauth1` or `proxy`. |
+| `ONEROSTER_CREDENTIALS_SECRET_ARN` | yes | none | Full ARN of the scoped secret described above. |
+| `ONEROSTER_API_VERSION` | no | `v1p1` | `v1p1` or `v1p2`. |
+| `ONEROSTER_PAGE_SIZE` | no | `10000` | Integer from 1 through 10,000. |
+| `ONEROSTER_LAST_PERM_REV` | internal | none | Last fully applied ClassLink revision; do not edit during normal operation. |
+
+Set the URL, auth mode, secret ARN, version, and page size before enabling the
+schedule. A missing or incomplete configuration safely skips the invocation.
+
+## Consistency and deletion invariants
+
+These are operational safety contracts, not best-effort behaviors:
+
+- Absence deactivation happens only after a complete, internally consistent,
+  non-empty collection pull.
+- An upstream error, invalid response, premature page ending, inconsistent
+  count, unexpectedly empty collection, or DB failure preserves that
+  collection's last-known-good rows.
+- `status: tobedeleted` is deactivated explicitly. Records absent from a
+  confirmed-complete collection are then deactivated in the same transaction.
+- A changed `x-perm-rev` anywhere in the batch discards every staged collection
+  and restarts from the beginning. The retry is bounded at three full attempts.
+- If the first collection returns the last fully applied persistent revision,
+  the run is a successful no-op.
+- A partial run does not advance the revision checkpoint, even when other
+  collections succeeded.
+
+ClassLink documents `x-perm-rev` as a batch-wide persistent consistency signal
+and recommends discarding already pulled data if it changes. The same guidance
+notes that delta-only syncs can miss purged records, which is why this
+implementation intentionally performs full nightly pulls.
+
+The integration does not currently send OneRoster `filter` expressions. If a
+future change adds them, ClassLink's non-parenthesized Boolean grouping must be
+tested explicitly: operations are split into `AND` groups separated by `OR`
+operators.
+
+## Retries and failure behavior
+
+HTTP 429 and 502 responses retry with capped exponential backoff starting at one
+second, up to one second of jitter, a maximum 32-second base delay, and at most
+five retries. A valid `Retry-After` delay wins when it is longer. Other
+non-success responses fail the collection without logging the response body.
+This follows ClassLink's
+[429/502 guidance](https://help.classlink.com/articles/Knowledge/oneroster-api-request-limits).
+
+A partial run publishes collection metrics and then throws. This preserves the
+per-collection data that succeeded while ensuring Lambda's built-in `Errors`
+metric and alarms reflect the incomplete snapshot.
+
+## Monitoring and operation
+
+CloudWatch namespace: `AIStudio/RosterSync`
+
+- Run metrics: `SyncRunSucceeded`, `SyncRunFailed`, `RevisionRestarts`
+  (`Environment` dimension).
+- Collection metrics: `RecordsSynced`, `CollectionsFailed`,
+  `RecordsDeactivated`, `RecordsTotal` (`Environment` and `Collection`
+  dimensions).
+- `psd-oneroster-sync-failure-{environment}` alarms on any errored invocation
+  during a day.
+- `psd-oneroster-sync-staleness-{environment}` alarms after approximately 48
+  hours without a successful run, including missing metrics.
+- Both alarms route to the shared
+  `aistudio-{environment}-monitoring-alarms` topic.
+- Logs are in `/aws/lambda/psd-oneroster-sync-{environment}`. Structured log
+  records contain collection names and counts, never credentials or raw roster
+  records.
+
+Manual invocation uses an asynchronous event:
+
+```json
+{
+  "trigger": "manual",
+  "requestedByUserId": 123
+}
+```
+
+Use `triggerOneRosterSyncNow()` from application code so the deterministic
+function name and audit payload stay consistent. The ECS task role has invoke
+permission only for that named function (alongside its existing explicit
+Lambda grants).
+
+## Verification
+
+The integration requires no live PSD credential for normal CI:
+
+```bash
+cd infra/lambdas/oneroster-sync
+bun install --frozen-lockfile
+bun test
+bun run build
+
+# Optional local PostgreSQL transaction/rollback coverage
+ONEROSTER_DB_TEST_URL=postgresql://... bun test db.integration.test.ts
+
+cd ../../..
+bun run lint
+bun run typecheck
+bun run build
+
+cd infra
+bun test -- --runInBand
+bunx cdk synth
+```
+
+The mocked HTTP suite covers both auth modes, bulk paging and headers, revision
+no-op/change behavior, retries, deletion normalization, empty/error
+preservation, transaction isolation at the sync boundary, changed fields, and
+checkpoint behavior.
+
+## Rollout and rollback
+
+Roll out disabled:
+
+1. Deploy the Processing stack and confirm the Lambda, nightly rule, alarms,
+   IAM policy, VPC configuration, and log group.
+2. Create the scoped credential secret and populate the non-secret settings.
+3. Run a manual sync. Compare per-collection totals with ClassLink and inspect a
+   sample of lowercased emails and sourced-ID relationships.
+4. Confirm no `users`, application role, room, assistant, or demographics data
+   changed.
+5. Set `ROSTER_SYNC_ENABLED=true`.
+
+To stop ingestion, set `ROSTER_SYNC_ENABLED=false`. Existing roster rows remain
+as the last-known-good snapshot. For a code rollback, deploy the previous
+Processing stack version; migration 141 and the `oneroster_*` tables are
+additive and may remain in place. Do not clear rows or the revision checkpoint
+as part of routine rollback. If a credential may be exposed, rotate it in
+ClassLink and Secrets Manager before re-enabling the integration.

--- a/infra/lambdas/oneroster-sync/config.ts
+++ b/infra/lambdas/oneroster-sync/config.ts
@@ -1,0 +1,127 @@
+/**
+ * Database-first configuration for the isolated OneRoster sync Lambda.
+ *
+ * Keep key names synchronized with lib/roster/settings.ts. Credentials remain
+ * in Secrets Manager; the settings table stores only the secret ARN.
+ */
+
+import type postgres from "postgres";
+import { getSettingValue } from "./db";
+import { isRecord } from "./normalize";
+
+export const ONEROSTER_SETTING_KEYS = {
+  enabled: "ROSTER_SYNC_ENABLED",
+  baseUrl: "ONEROSTER_BASE_URL",
+  authMode: "ONEROSTER_AUTH_MODE",
+  credentialsSecretArn: "ONEROSTER_CREDENTIALS_SECRET_ARN",
+  apiVersion: "ONEROSTER_API_VERSION",
+  pageSize: "ONEROSTER_PAGE_SIZE",
+  /** Internal sync checkpoint; not an administrator-entered credential/config. */
+  lastPermRev: "ONEROSTER_LAST_PERM_REV",
+} as const;
+
+export type OneRosterAuthMode = "oauth1" | "proxy";
+export type OneRosterApiVersion = "v1p1" | "v1p2";
+
+export interface OneRosterConfig {
+  enabled: boolean;
+  baseUrl: string | null;
+  authMode: OneRosterAuthMode | null;
+  credentialsSecretArn: string | null;
+  apiVersion: OneRosterApiVersion;
+  pageSize: number;
+}
+
+export async function resolveConfig(sql: postgres.Sql): Promise<OneRosterConfig> {
+  const [enabled, baseUrl, authMode, credentialsSecretArn, apiVersion, pageSize] =
+    await Promise.all([
+      getSettingValue(sql, ONEROSTER_SETTING_KEYS.enabled),
+      getSettingValue(sql, ONEROSTER_SETTING_KEYS.baseUrl),
+      getSettingValue(sql, ONEROSTER_SETTING_KEYS.authMode),
+      getSettingValue(sql, ONEROSTER_SETTING_KEYS.credentialsSecretArn),
+      getSettingValue(sql, ONEROSTER_SETTING_KEYS.apiVersion),
+      getSettingValue(sql, ONEROSTER_SETTING_KEYS.pageSize),
+    ]);
+
+  const parsedMode = parseAuthMode(authMode);
+  const parsedVersion = parseApiVersion(apiVersion);
+  const parsedPageSize = Number.parseInt(pageSize ?? "", 10);
+
+  return {
+    enabled: enabled?.toLowerCase() === "true",
+    baseUrl: baseUrl ? normalizeBaseUrl(baseUrl) : null,
+    authMode: parsedMode,
+    credentialsSecretArn: credentialsSecretArn || null,
+    apiVersion: parsedVersion,
+    pageSize:
+      Number.isInteger(parsedPageSize) &&
+      parsedPageSize > 0 &&
+      parsedPageSize <= 10_000
+        ? parsedPageSize
+        : 10_000,
+  };
+}
+
+function normalizeBaseUrl(value: string): string {
+  const parsed = new URL(value);
+  if (parsed.protocol !== "https:") {
+    throw new Error("ONEROSTER_BASE_URL must use https");
+  }
+  parsed.hash = "";
+  parsed.search = "";
+  return parsed.toString().replace(/\/+$/, "");
+}
+
+function parseAuthMode(value: string | null): OneRosterAuthMode | null {
+  const normalized = value?.toLowerCase();
+  if (!normalized) return null;
+  if (normalized === "oauth1" || normalized === "proxy") return normalized;
+  throw new Error("ONEROSTER_AUTH_MODE must be oauth1 or proxy");
+}
+
+function parseApiVersion(value: string | null): OneRosterApiVersion {
+  const normalized = value?.toLowerCase();
+  if (!normalized || normalized === "v1p1") return "v1p1";
+  if (normalized === "v1p2") return "v1p2";
+  throw new Error("ONEROSTER_API_VERSION must be v1p1 or v1p2");
+}
+
+export interface OAuth1Credentials {
+  mode: "oauth1";
+  consumerKey: string;
+  consumerSecret: string;
+}
+
+export interface ProxyCredentials {
+  mode: "proxy";
+  bearerToken: string;
+}
+
+export type OneRosterCredentials = OAuth1Credentials | ProxyCredentials;
+
+export function parseCredentials(
+  raw: string,
+  mode: OneRosterAuthMode
+): OneRosterCredentials {
+  const value: unknown = JSON.parse(raw);
+  if (!isRecord(value)) {
+    throw new Error("OneRoster credentials secret must contain a JSON object");
+  }
+  const parsed = value;
+  if (mode === "oauth1") {
+    const consumerKey = parsed.consumerKey;
+    const consumerSecret = parsed.consumerSecret;
+    if (typeof consumerKey !== "string" || !consumerKey) {
+      throw new Error("OneRoster OAuth1 secret is missing consumerKey");
+    }
+    if (typeof consumerSecret !== "string" || !consumerSecret) {
+      throw new Error("OneRoster OAuth1 secret is missing consumerSecret");
+    }
+    return { mode, consumerKey, consumerSecret };
+  }
+  const bearerToken = parsed.bearerToken;
+  if (typeof bearerToken !== "string" || !bearerToken) {
+    throw new Error("OneRoster proxy secret is missing bearerToken");
+  }
+  return { mode, bearerToken };
+}

--- a/infra/lambdas/oneroster-sync/db.integration.test.ts
+++ b/infra/lambdas/oneroster-sync/db.integration.test.ts
@@ -1,0 +1,169 @@
+/**
+ * PostgreSQL integration coverage for the collection transaction boundary.
+ *
+ * CI environments without PostgreSQL skip this suite. Run it locally with:
+ * ONEROSTER_DB_TEST_URL=postgresql://... bun test db.integration.test.ts
+ */
+
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+import postgres from "postgres";
+import { reconcileCollection } from "./db";
+import type { CollectionPullSuccess } from "./oneroster-client";
+
+const databaseUrl = process.env.ONEROSTER_DB_TEST_URL;
+const describeDatabase = databaseUrl ? describe : describe.skip;
+const sql = databaseUrl
+  ? postgres(databaseUrl, { max: 1 })
+  : null;
+
+function orgs(
+  records: Array<Record<string, unknown>>
+): CollectionPullSuccess {
+  return {
+    name: "orgs",
+    records,
+    permRev: "integration-rev",
+    complete: true,
+  };
+}
+
+describeDatabase("OneRoster PostgreSQL reconciliation", () => {
+  beforeAll(async () => {
+    if (!sql) return;
+    await sql.unsafe(`
+      CREATE EXTENSION IF NOT EXISTS pgcrypto;
+      CREATE OR REPLACE FUNCTION update_updated_at_column()
+      RETURNS TRIGGER AS $$
+      BEGIN
+        NEW.updated_at = now();
+        RETURN NEW;
+      END;
+      $$ LANGUAGE plpgsql;
+    `);
+    const migrationUrl = new URL(
+      "../../database/schema/141-oneroster-core.sql",
+      import.meta.url
+    );
+    await sql.unsafe(readFileSync(migrationUrl, "utf8"));
+  });
+
+  beforeEach(async () => {
+    if (!sql) return;
+    await sql.unsafe(`
+      TRUNCATE TABLE
+        oneroster_enrollments,
+        oneroster_user_roles,
+        oneroster_users,
+        oneroster_class_terms,
+        oneroster_classes,
+        oneroster_courses,
+        oneroster_academic_sessions,
+        oneroster_orgs
+    `);
+  });
+
+  afterAll(async () => {
+    if (sql) await sql.end({ timeout: 5 });
+  });
+
+  it("upserts changed fields and deactivates only rows absent from a complete snapshot", async () => {
+    if (!sql) throw new Error("database connection was not initialized");
+    await reconcileCollection(
+      sql,
+      orgs([
+        { sourcedId: "org-1", name: "Original" },
+        { sourcedId: "org-2", name: "Will be absent" },
+      ])
+    );
+
+    const result = await reconcileCollection(
+      sql,
+      orgs([{ sourcedId: "org-1", name: "Changed" }])
+    );
+    const rows = await sql<
+      Array<{ sourced_id: string; name: string; is_active: boolean }>
+    >`
+      SELECT sourced_id, name, is_active
+        FROM oneroster_orgs
+       ORDER BY sourced_id
+    `;
+
+    expect(result).toEqual({ synced: 1, deactivated: 1 });
+    expect(rows).toEqual([
+      { sourced_id: "org-1", name: "Changed", is_active: true },
+      { sourced_id: "org-2", name: "Will be absent", is_active: false },
+    ]);
+  });
+
+  it("rolls back both upserts and absence deactivation when a collection write fails", async () => {
+    if (!sql) throw new Error("database connection was not initialized");
+    await reconcileCollection(
+      sql,
+      orgs([
+        { sourcedId: "org-1", name: "Last known good" },
+        { sourcedId: "org-2", name: "Still active" },
+      ])
+    );
+
+    await expect(
+      reconcileCollection(
+        sql,
+        orgs([
+          { sourcedId: "org-1", name: "First duplicate" },
+          { sourcedId: "org-1", name: "Second duplicate" },
+        ])
+      )
+    ).rejects.toThrow();
+    const rows = await sql<
+      Array<{ sourced_id: string; name: string; is_active: boolean }>
+    >`
+      SELECT sourced_id, name, is_active
+        FROM oneroster_orgs
+       ORDER BY sourced_id
+    `;
+
+    expect(rows).toEqual([
+      { sourced_id: "org-1", name: "Last known good", is_active: true },
+      { sourced_id: "org-2", name: "Still active", is_active: true },
+    ]);
+  });
+
+  it("persists explicit to-be-deleted state and insert sync timestamps", async () => {
+    if (!sql) throw new Error("database connection was not initialized");
+    await reconcileCollection(
+      sql,
+      orgs([{ sourcedId: "org-1", name: "Active" }])
+    );
+    const result = await reconcileCollection(
+      sql,
+      orgs([
+        {
+          sourcedId: "org-1",
+          name: "Deleted",
+          status: "to-be-deleted",
+        },
+      ])
+    );
+    const [row] = await sql<
+      Array<{
+        status: string;
+        is_active: boolean;
+        last_synced_at: Date | null;
+      }>
+    >`
+      SELECT status, is_active, last_synced_at
+        FROM oneroster_orgs
+       WHERE sourced_id = 'org-1'
+    `;
+
+    expect(result.deactivated).toBe(1);
+    expect(row).toEqual(
+      expect.objectContaining({
+        status: "tobedeleted",
+        is_active: false,
+        last_synced_at: expect.any(Date),
+      })
+    );
+  });
+});

--- a/infra/lambdas/oneroster-sync/db.ts
+++ b/infra/lambdas/oneroster-sync/db.ts
@@ -1,0 +1,634 @@
+/**
+ * postgres.js data layer for the isolated OneRoster sync Lambda.
+ *
+ * Every collection reconciles in its own transaction. Upserts and
+ * absence-driven deactivation therefore commit together; malformed input or a
+ * DB error rolls the collection back and preserves its last-known-good rows.
+ * Bulk inserts are chunked below PostgreSQL's bind-parameter ceiling.
+ */
+
+import { GetSecretValueCommand, SecretsManagerClient } from "@aws-sdk/client-secrets-manager";
+import postgres from "postgres";
+import {
+  normalizeAcademicSession,
+  normalizeClass,
+  normalizeCourse,
+  normalizeEnrollment,
+  normalizeOrg,
+  normalizeUser,
+  type NormalizedAcademicSession,
+  type NormalizedClass,
+  type NormalizedClassTerm,
+  type NormalizedCourse,
+  type NormalizedEnrollment,
+  type NormalizedOrg,
+  type NormalizedUser,
+  type NormalizedUserRole,
+} from "./normalize";
+import type { CollectionPullSuccess } from "./oneroster-client";
+
+const secretsClient = new SecretsManagerClient({});
+const UPSERT_CHUNK_SIZE = 4_000;
+const LAST_PERM_REV_SETTING_KEY = "ONEROSTER_LAST_PERM_REV";
+
+let sqlSingleton: postgres.Sql | null = null;
+let initPromise: Promise<postgres.Sql> | null = null;
+
+function requireEnv(name: string): string {
+  const value = process.env[name];
+  if (!value) throw new Error(`${name} env var is required`);
+  return value;
+}
+
+async function resolveCredentials(): Promise<{
+  username: string;
+  password: string;
+}> {
+  const response = await secretsClient.send(
+    new GetSecretValueCommand({
+      SecretId: requireEnv("DATABASE_SECRET_ARN"),
+    })
+  );
+  if (!response.SecretString) {
+    throw new Error("DATABASE_SECRET_ARN payload is empty");
+  }
+  const parsed = JSON.parse(response.SecretString) as Record<string, unknown>;
+  if (typeof parsed.username !== "string" || !parsed.username) {
+    throw new Error("DATABASE_SECRET_ARN payload is missing username");
+  }
+  if (typeof parsed.password !== "string" || !parsed.password) {
+    throw new Error("DATABASE_SECRET_ARN payload is missing password");
+  }
+  return { username: parsed.username, password: parsed.password };
+}
+
+export async function getSql(): Promise<postgres.Sql> {
+  if (!initPromise) {
+    initPromise = (async () => {
+      const credentials = await resolveCredentials();
+      sqlSingleton = postgres({
+        host: requireEnv("DATABASE_HOST"),
+        port: Number.parseInt(process.env.DATABASE_PORT ?? "5432", 10),
+        database: process.env.DATABASE_NAME ?? "aistudio",
+        username: credentials.username,
+        password: credentials.password,
+        ssl: "require",
+        max: 2,
+        idle_timeout: 20,
+        connect_timeout: 10,
+      });
+      return sqlSingleton;
+    })();
+  }
+  return initPromise;
+}
+
+export async function closeSql(): Promise<void> {
+  const sql = sqlSingleton;
+  sqlSingleton = null;
+  initPromise = null;
+  if (sql) await sql.end({ timeout: 5 });
+}
+
+export async function getSettingValue(
+  sql: postgres.Sql,
+  key: string
+): Promise<string | null> {
+  const rows = await sql<{ value: string | null }[]>`
+    SELECT value FROM settings WHERE key = ${key} LIMIT 1
+  `;
+  const value = rows[0]?.value?.trim();
+  return value || null;
+}
+
+export async function readLastPermRev(sql: postgres.Sql): Promise<string | null> {
+  return getSettingValue(sql, LAST_PERM_REV_SETTING_KEY);
+}
+
+export async function writeLastPermRev(
+  sql: postgres.Sql,
+  permRev: string
+): Promise<void> {
+  await sql`
+    INSERT INTO settings (key, value, description)
+    VALUES (
+      ${LAST_PERM_REV_SETTING_KEY},
+      ${permRev},
+      'Internal checkpoint: x-perm-rev from the last fully successful OneRoster sync'
+    )
+    ON CONFLICT (key) DO UPDATE
+      SET value = EXCLUDED.value,
+          description = EXCLUDED.description,
+          updated_at = now()
+  `;
+}
+
+export async function reconcileCollection(
+  sql: postgres.Sql,
+  collection: CollectionPullSuccess
+): Promise<{ synced: number; deactivated: number }> {
+  switch (collection.name) {
+    case "orgs":
+      return reconcileOrgs(sql, collection.records.map(normalizeOrg));
+    case "academicSessions":
+      return reconcileAcademicSessions(
+        sql,
+        collection.records.map(normalizeAcademicSession)
+      );
+    case "courses":
+      return reconcileCourses(sql, collection.records.map(normalizeCourse));
+    case "classes": {
+      const normalized = collection.records.map(normalizeClass);
+      return reconcileClasses(
+        sql,
+        normalized.map((entry) => entry.entity),
+        normalized.flatMap((entry) => entry.terms)
+      );
+    }
+    case "users": {
+      const normalized = collection.records.map(normalizeUser);
+      return reconcileUsers(
+        sql,
+        normalized.map((entry) => entry.entity),
+        normalized.flatMap((entry) => entry.roles)
+      );
+    }
+    case "enrollments":
+      return reconcileEnrollments(
+        sql,
+        collection.records.map(normalizeEnrollment)
+      );
+  }
+}
+
+async function reconcileOrgs(
+  sql: postgres.Sql,
+  rows: NormalizedOrg[]
+): Promise<{ synced: number; deactivated: number }> {
+  return sql.begin(async (tx) => {
+    const explicit = await deactivateExplicit(
+      tx,
+      "oneroster_orgs",
+      rows
+    );
+    for (const chunk of chunks(rows)) {
+      await tx`
+        INSERT INTO oneroster_orgs ${tx(
+          withSyncTime(chunk),
+          "sourced_id",
+          "name",
+          "type",
+          "identifier",
+          "parent_sourced_id",
+          "status",
+          "is_active",
+          "date_last_modified",
+          "last_synced_at"
+        )}
+        ON CONFLICT (sourced_id) DO UPDATE SET
+          name = EXCLUDED.name,
+          type = EXCLUDED.type,
+          identifier = EXCLUDED.identifier,
+          parent_sourced_id = EXCLUDED.parent_sourced_id,
+          status = EXCLUDED.status,
+          is_active = EXCLUDED.is_active,
+          date_last_modified = EXCLUDED.date_last_modified,
+          last_synced_at = now()
+      `;
+    }
+    const absent = await deactivateAbsent(tx, "oneroster_orgs", rows);
+    return {
+      synced: rows.length,
+      deactivated: explicit + absent,
+    };
+  });
+}
+
+async function reconcileAcademicSessions(
+  sql: postgres.Sql,
+  rows: NormalizedAcademicSession[]
+): Promise<{ synced: number; deactivated: number }> {
+  return sql.begin(async (tx) => {
+    const explicit = await deactivateExplicit(
+      tx,
+      "oneroster_academic_sessions",
+      rows
+    );
+    for (const chunk of chunks(rows)) {
+      await tx`
+        INSERT INTO oneroster_academic_sessions ${tx(
+          withSyncTime(chunk),
+          "sourced_id",
+          "title",
+          "type",
+          "start_date",
+          "end_date",
+          "parent_sourced_id",
+          "school_year",
+          "status",
+          "is_active",
+          "date_last_modified",
+          "last_synced_at"
+        )}
+        ON CONFLICT (sourced_id) DO UPDATE SET
+          title = EXCLUDED.title,
+          type = EXCLUDED.type,
+          start_date = EXCLUDED.start_date,
+          end_date = EXCLUDED.end_date,
+          parent_sourced_id = EXCLUDED.parent_sourced_id,
+          school_year = EXCLUDED.school_year,
+          status = EXCLUDED.status,
+          is_active = EXCLUDED.is_active,
+          date_last_modified = EXCLUDED.date_last_modified,
+          last_synced_at = now()
+      `;
+    }
+    const absent = await deactivateAbsent(
+      tx,
+      "oneroster_academic_sessions",
+      rows
+    );
+    return { synced: rows.length, deactivated: explicit + absent };
+  });
+}
+
+async function reconcileCourses(
+  sql: postgres.Sql,
+  rows: NormalizedCourse[]
+): Promise<{ synced: number; deactivated: number }> {
+  return sql.begin(async (tx) => {
+    const explicit = await deactivateExplicit(tx, "oneroster_courses", rows);
+    for (const chunk of chunks(rows)) {
+      await tx`
+        INSERT INTO oneroster_courses ${tx(
+          withSyncTime(chunk),
+          "sourced_id",
+          "title",
+          "course_code",
+          "org_sourced_id",
+          "grades",
+          "status",
+          "is_active",
+          "date_last_modified",
+          "last_synced_at"
+        )}
+        ON CONFLICT (sourced_id) DO UPDATE SET
+          title = EXCLUDED.title,
+          course_code = EXCLUDED.course_code,
+          org_sourced_id = EXCLUDED.org_sourced_id,
+          grades = EXCLUDED.grades,
+          status = EXCLUDED.status,
+          is_active = EXCLUDED.is_active,
+          date_last_modified = EXCLUDED.date_last_modified,
+          last_synced_at = now()
+      `;
+    }
+    const absent = await deactivateAbsent(tx, "oneroster_courses", rows);
+    return { synced: rows.length, deactivated: explicit + absent };
+  });
+}
+
+async function reconcileClasses(
+  sql: postgres.Sql,
+  rows: NormalizedClass[],
+  terms: NormalizedClassTerm[]
+): Promise<{ synced: number; deactivated: number }> {
+  return sql.begin(async (tx) => {
+    const explicit = await deactivateExplicit(tx, "oneroster_classes", rows);
+    for (const chunk of chunks(rows)) {
+      await tx`
+        INSERT INTO oneroster_classes ${tx(
+          withSyncTime(chunk),
+          "sourced_id",
+          "title",
+          "class_code",
+          "class_type",
+          "location",
+          "course_sourced_id",
+          "school_sourced_id",
+          "grades",
+          "subjects",
+          "periods",
+          "status",
+          "is_active",
+          "date_last_modified",
+          "last_synced_at"
+        )}
+        ON CONFLICT (sourced_id) DO UPDATE SET
+          title = EXCLUDED.title,
+          class_code = EXCLUDED.class_code,
+          class_type = EXCLUDED.class_type,
+          location = EXCLUDED.location,
+          course_sourced_id = EXCLUDED.course_sourced_id,
+          school_sourced_id = EXCLUDED.school_sourced_id,
+          grades = EXCLUDED.grades,
+          subjects = EXCLUDED.subjects,
+          periods = EXCLUDED.periods,
+          status = EXCLUDED.status,
+          is_active = EXCLUDED.is_active,
+          date_last_modified = EXCLUDED.date_last_modified,
+          last_synced_at = now()
+      `;
+    }
+    const absent = await deactivateAbsent(tx, "oneroster_classes", rows);
+    const termDeactivated = await reconcileClassTerms(tx, terms);
+    return {
+      synced: rows.length,
+      deactivated: explicit + absent + termDeactivated,
+    };
+  });
+}
+
+async function reconcileClassTerms(
+  tx: postgres.TransactionSql,
+  rows: NormalizedClassTerm[]
+): Promise<number> {
+  await tx`
+    CREATE TEMP TABLE _seen_oneroster_class_terms (
+      class_sourced_id text NOT NULL,
+      term_sourced_id text NOT NULL,
+      status text NOT NULL,
+      is_active boolean NOT NULL,
+      date_last_modified timestamptz
+    ) ON COMMIT DROP
+  `;
+  for (const chunk of chunks(rows)) {
+    await tx`
+      INSERT INTO _seen_oneroster_class_terms ${tx(
+        chunk,
+        "class_sourced_id",
+        "term_sourced_id",
+        "status",
+        "is_active",
+        "date_last_modified"
+      )}
+    `;
+  }
+  const deactivated = await tx<{ id: string }[]>`
+    UPDATE oneroster_class_terms target
+       SET is_active = false
+     WHERE target.is_active = true
+       AND NOT EXISTS (
+         SELECT 1
+           FROM _seen_oneroster_class_terms seen
+          WHERE seen.class_sourced_id = target.class_sourced_id
+            AND seen.term_sourced_id = target.term_sourced_id
+            AND seen.is_active = true
+       )
+    RETURNING target.id
+  `;
+  await tx`
+    INSERT INTO oneroster_class_terms (
+      class_sourced_id,
+      term_sourced_id,
+      status,
+      is_active,
+      date_last_modified,
+      last_synced_at
+    )
+    SELECT class_sourced_id, term_sourced_id, status, is_active,
+           date_last_modified, now()
+      FROM _seen_oneroster_class_terms
+    ON CONFLICT (class_sourced_id, term_sourced_id) DO UPDATE SET
+      status = EXCLUDED.status,
+      is_active = EXCLUDED.is_active,
+      date_last_modified = EXCLUDED.date_last_modified,
+      last_synced_at = now()
+  `;
+  return deactivated.length;
+}
+
+async function reconcileUsers(
+  sql: postgres.Sql,
+  rows: NormalizedUser[],
+  roles: NormalizedUserRole[]
+): Promise<{ synced: number; deactivated: number }> {
+  return sql.begin(async (tx) => {
+    const explicit = await deactivateExplicit(tx, "oneroster_users", rows);
+    for (const chunk of chunks(rows)) {
+      await tx`
+        INSERT INTO oneroster_users ${tx(
+          withSyncTime(chunk),
+          "sourced_id",
+          "email",
+          "username",
+          "given_name",
+          "family_name",
+          "role",
+          "enabled_user",
+          "grades",
+          "status",
+          "is_active",
+          "date_last_modified",
+          "last_synced_at"
+        )}
+        ON CONFLICT (sourced_id) DO UPDATE SET
+          email = EXCLUDED.email,
+          username = EXCLUDED.username,
+          given_name = EXCLUDED.given_name,
+          family_name = EXCLUDED.family_name,
+          role = EXCLUDED.role,
+          enabled_user = EXCLUDED.enabled_user,
+          grades = EXCLUDED.grades,
+          status = EXCLUDED.status,
+          is_active = EXCLUDED.is_active,
+          date_last_modified = EXCLUDED.date_last_modified,
+          last_synced_at = now()
+      `;
+    }
+    const absent = await deactivateAbsent(tx, "oneroster_users", rows);
+    const roleDeactivated = await reconcileUserRoles(tx, roles);
+    return {
+      synced: rows.length,
+      deactivated: explicit + absent + roleDeactivated,
+    };
+  });
+}
+
+async function reconcileUserRoles(
+  tx: postgres.TransactionSql,
+  rows: NormalizedUserRole[]
+): Promise<number> {
+  await tx`
+    CREATE TEMP TABLE _seen_oneroster_user_roles (
+      user_sourced_id text NOT NULL,
+      role text NOT NULL,
+      role_type text NOT NULL,
+      org_sourced_id text,
+      status text NOT NULL,
+      is_active boolean NOT NULL,
+      date_last_modified timestamptz
+    ) ON COMMIT DROP
+  `;
+  for (const chunk of chunks(rows)) {
+    await tx`
+      INSERT INTO _seen_oneroster_user_roles ${tx(
+        chunk,
+        "user_sourced_id",
+        "role",
+        "role_type",
+        "org_sourced_id",
+        "status",
+        "is_active",
+        "date_last_modified"
+      )}
+    `;
+  }
+  const deactivated = await tx<{ id: string }[]>`
+    UPDATE oneroster_user_roles target
+       SET is_active = false
+     WHERE target.is_active = true
+       AND NOT EXISTS (
+         SELECT 1
+           FROM _seen_oneroster_user_roles seen
+          WHERE seen.user_sourced_id = target.user_sourced_id
+            AND seen.role = target.role
+            AND seen.role_type = target.role_type
+            AND coalesce(seen.org_sourced_id, '') =
+                coalesce(target.org_sourced_id, '')
+            AND seen.is_active = true
+       )
+    RETURNING target.id
+  `;
+  await tx`
+    INSERT INTO oneroster_user_roles (
+      user_sourced_id,
+      role,
+      role_type,
+      org_sourced_id,
+      status,
+      is_active,
+      date_last_modified,
+      last_synced_at
+    )
+    SELECT user_sourced_id, role, role_type, org_sourced_id, status, is_active,
+           date_last_modified, now()
+      FROM _seen_oneroster_user_roles
+    ON CONFLICT (
+      user_sourced_id,
+      role,
+      role_type,
+      (coalesce(org_sourced_id, ''))
+    ) DO UPDATE SET
+      status = EXCLUDED.status,
+      is_active = EXCLUDED.is_active,
+      date_last_modified = EXCLUDED.date_last_modified,
+      last_synced_at = now()
+  `;
+  return deactivated.length;
+}
+
+async function reconcileEnrollments(
+  sql: postgres.Sql,
+  rows: NormalizedEnrollment[]
+): Promise<{ synced: number; deactivated: number }> {
+  return sql.begin(async (tx) => {
+    const explicit = await deactivateExplicit(
+      tx,
+      "oneroster_enrollments",
+      rows
+    );
+    for (const chunk of chunks(rows)) {
+      await tx`
+        INSERT INTO oneroster_enrollments ${tx(
+          withSyncTime(chunk),
+          "sourced_id",
+          "user_sourced_id",
+          "class_sourced_id",
+          "school_sourced_id",
+          "role",
+          "is_primary",
+          "begin_date",
+          "end_date",
+          "status",
+          "is_active",
+          "date_last_modified",
+          "last_synced_at"
+        )}
+        ON CONFLICT (sourced_id) DO UPDATE SET
+          user_sourced_id = EXCLUDED.user_sourced_id,
+          class_sourced_id = EXCLUDED.class_sourced_id,
+          school_sourced_id = EXCLUDED.school_sourced_id,
+          role = EXCLUDED.role,
+          is_primary = EXCLUDED.is_primary,
+          begin_date = EXCLUDED.begin_date,
+          end_date = EXCLUDED.end_date,
+          status = EXCLUDED.status,
+          is_active = EXCLUDED.is_active,
+          date_last_modified = EXCLUDED.date_last_modified,
+          last_synced_at = now()
+      `;
+    }
+    const absent = await deactivateAbsent(
+      tx,
+      "oneroster_enrollments",
+      rows
+    );
+    return { synced: rows.length, deactivated: explicit + absent };
+  });
+}
+
+type SourcedRow = {
+  sourced_id: string;
+  status: "active" | "tobedeleted";
+};
+
+type EntityTable =
+  | "oneroster_orgs"
+  | "oneroster_academic_sessions"
+  | "oneroster_courses"
+  | "oneroster_classes"
+  | "oneroster_users"
+  | "oneroster_enrollments";
+
+async function deactivateExplicit(
+  tx: postgres.TransactionSql,
+  table: EntityTable,
+  rows: SourcedRow[]
+): Promise<number> {
+  const ids = rows
+    .filter((row) => row.status === "tobedeleted")
+    .map((row) => row.sourced_id);
+  if (ids.length === 0) return 0;
+  const updated = await tx.unsafe<{ id: string }[]>(
+    `UPDATE ${table}
+        SET is_active = false
+      WHERE is_active = true
+        AND sourced_id = ANY($1::text[])
+      RETURNING id`,
+    [ids]
+  );
+  return updated.length;
+}
+
+async function deactivateAbsent(
+  tx: postgres.TransactionSql,
+  table: EntityTable,
+  rows: SourcedRow[]
+): Promise<number> {
+  const ids = rows.map((row) => row.sourced_id);
+  const updated = await tx.unsafe<{ id: string }[]>(
+    `UPDATE ${table}
+        SET is_active = false
+      WHERE is_active = true
+        AND sourced_id <> ALL($1::text[])
+      RETURNING id`,
+    [ids]
+  );
+  return updated.length;
+}
+
+function chunks<T>(rows: T[]): T[][] {
+  const output: T[][] = [];
+  for (let index = 0; index < rows.length; index += UPSERT_CHUNK_SIZE) {
+    output.push(rows.slice(index, index + UPSERT_CHUNK_SIZE));
+  }
+  return output;
+}
+
+function withSyncTime<T extends object>(
+  rows: T[]
+): Array<T & { last_synced_at: Date }> {
+  const syncedAt = new Date();
+  return rows.map((row) => ({ ...row, last_synced_at: syncedAt }));
+}

--- a/infra/lambdas/oneroster-sync/index.ts
+++ b/infra/lambdas/oneroster-sync/index.ts
@@ -1,0 +1,224 @@
+/**
+ * Nightly and manually-invoked ClassLink OneRoster sync Lambda.
+ *
+ * This is an isolated bundle and cannot import the Next.js logger. Structured
+ * console output is therefore permitted by the repository's standalone-script
+ * exception. Credentials are read from Secrets Manager and never logged.
+ */
+
+import {
+  CloudWatchClient,
+  PutMetricDataCommand,
+  type MetricDatum,
+} from "@aws-sdk/client-cloudwatch";
+import {
+  GetSecretValueCommand,
+  SecretsManagerClient,
+} from "@aws-sdk/client-secrets-manager";
+import { parseCredentials, resolveConfig } from "./config";
+import {
+  closeSql,
+  getSql,
+  readLastPermRev,
+  reconcileCollection,
+  writeLastPermRev,
+} from "./db";
+import { OneRosterClient } from "./oneroster-client";
+import { runOneRosterSync, type OneRosterSyncResult } from "./sync";
+
+const METRIC_NAMESPACE = "AIStudio/RosterSync";
+const ENVIRONMENT = process.env.ENVIRONMENT ?? "dev";
+const secrets = new SecretsManagerClient({});
+const cloudwatch = new CloudWatchClient({});
+
+/* eslint-disable no-console */
+const log = {
+  info: (message: string, metadata?: Record<string, unknown>) =>
+    console.log(JSON.stringify({ level: "info", message, ...metadata })),
+  warn: (message: string, metadata?: Record<string, unknown>) =>
+    console.warn(JSON.stringify({ level: "warn", message, ...metadata })),
+  error: (message: string, metadata?: Record<string, unknown>) =>
+    console.error(JSON.stringify({ level: "error", message, ...metadata })),
+};
+/* eslint-enable no-console */
+
+interface OneRosterSyncEvent {
+  trigger?: string;
+  requestedByUserId?: number | null;
+}
+
+interface HandlerResult {
+  status: "ok" | "skipped";
+  reason?: string;
+  result?: OneRosterSyncResult;
+}
+
+export async function handler(
+  event: OneRosterSyncEvent = {}
+): Promise<HandlerResult> {
+  const manual = event.trigger === "manual";
+  let metricsEmitted = false;
+  log.info("OneRoster sync invoked", {
+    trigger: manual ? "manual" : "schedule",
+    requestedByUserId: event.requestedByUserId ?? null,
+  });
+
+  const sql = await getSql();
+  try {
+    const config = await resolveConfig(sql);
+    if (!config.baseUrl || !config.authMode || !config.credentialsSecretArn) {
+      log.warn("OneRoster sync is not fully configured; skipping");
+      return { status: "skipped", reason: "not-configured" };
+    }
+    if (!manual && !config.enabled) {
+      log.info("Nightly OneRoster sync is disabled; skipping");
+      return { status: "skipped", reason: "disabled" };
+    }
+
+    const credentials = parseCredentials(
+      await loadSecret(config.credentialsSecretArn),
+      config.authMode
+    );
+    const client = new OneRosterClient({
+      baseUrl: config.baseUrl,
+      apiVersion: config.apiVersion,
+      pageSize: config.pageSize,
+      credentials,
+    });
+    const result = await runOneRosterSync({
+      readLastPermRev: () => readLastPermRev(sql),
+      pullRoster: (previousPermRev) => client.pullAll(previousPermRev),
+      reconcileCollection: (collection) =>
+        reconcileCollection(sql, collection),
+      writeLastPermRev: (permRev) => writeLastPermRev(sql, permRev),
+      log,
+    });
+
+    await emitMetrics(result);
+    metricsEmitted = true;
+    if (!result.fullySuccessful) {
+      throw new Error(
+        "OneRoster sync was incomplete; failed collections retain last-known-good rows"
+      );
+    }
+    log.info("OneRoster sync completed", {
+      unchanged: result.unchanged,
+      restartCount: result.restartCount,
+      recordsSynced: result.collections.reduce(
+        (total, collection) => total + collection.synced,
+        0
+      ),
+    });
+    return { status: "ok", result };
+  } catch (error) {
+    log.error("OneRoster sync failed", { error: safeErrorMessage(error) });
+    if (!metricsEmitted) {
+      await emitMetrics(null).catch(() => {});
+    }
+    throw error;
+  } finally {
+    await closeSql().catch(() => {});
+  }
+}
+
+async function loadSecret(secretArn: string): Promise<string> {
+  const response = await secrets.send(
+    new GetSecretValueCommand({ SecretId: secretArn })
+  );
+  if (!response.SecretString) {
+    throw new Error("OneRoster credentials secret has no SecretString");
+  }
+  return response.SecretString;
+}
+
+async function emitMetrics(result: OneRosterSyncResult | null): Promise<void> {
+  const environmentDimension = [{ Name: "Environment", Value: ENVIRONMENT }];
+  const metrics: MetricDatum[] = result
+    ? [
+        {
+          MetricName: "SyncRunFailed",
+          Value: result.fullySuccessful ? 0 : 1,
+          Unit: "Count",
+          Dimensions: environmentDimension,
+        },
+        {
+          MetricName: "SyncRunSucceeded",
+          Value: result.fullySuccessful ? 1 : 0,
+          Unit: "Count",
+          Dimensions: environmentDimension,
+        },
+        {
+          MetricName: "RevisionRestarts",
+          Value: result.restartCount,
+          Unit: "Count",
+          Dimensions: environmentDimension,
+        },
+      ]
+    : [
+        {
+          MetricName: "SyncRunFailed",
+          Value: 1,
+          Unit: "Count",
+          Dimensions: environmentDimension,
+        },
+        {
+          MetricName: "SyncRunSucceeded",
+          Value: 0,
+          Unit: "Count",
+          Dimensions: environmentDimension,
+        },
+      ];
+
+  if (result) {
+    for (const collection of result.collections) {
+      const dimensions = [
+        ...environmentDimension,
+        { Name: "Collection", Value: collection.name },
+      ];
+      metrics.push(
+        {
+          MetricName: "RecordsSynced",
+          Value: collection.synced,
+          Unit: "Count",
+          Dimensions: dimensions,
+        },
+        {
+          MetricName: "CollectionsFailed",
+          Value: collection.failed,
+          Unit: "Count",
+          Dimensions: dimensions,
+        },
+        {
+          MetricName: "RecordsDeactivated",
+          Value: collection.deactivated,
+          Unit: "Count",
+          Dimensions: dimensions,
+        },
+        {
+          MetricName: "RecordsTotal",
+          Value: collection.recordsTotal,
+          Unit: "Count",
+          Dimensions: dimensions,
+        }
+      );
+    }
+  }
+
+  try {
+    await cloudwatch.send(
+      new PutMetricDataCommand({
+        Namespace: METRIC_NAMESPACE,
+        MetricData: metrics,
+      })
+    );
+  } catch (error) {
+    log.warn("Failed to publish OneRoster metrics", {
+      error: safeErrorMessage(error),
+    });
+  }
+}
+
+function safeErrorMessage(error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error);
+  return message.length > 500 ? `${message.slice(0, 500)}…` : message;
+}

--- a/infra/lambdas/oneroster-sync/normalize.test.ts
+++ b/infra/lambdas/oneroster-sync/normalize.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from "bun:test";
+import {
+  normalizeClass,
+  normalizeEnrollment,
+  normalizeStatus,
+  normalizeUser,
+} from "./normalize";
+import { parseCredentials } from "./config";
+
+describe("OneRoster normalization", () => {
+  it("normalizes deletion markers and the cross-system email join key", () => {
+    const normalized = normalizeUser({
+      sourcedId: "user-1",
+      status: "to-be-deleted",
+      email: " STUDENT@Example.COM ",
+      username: "student",
+      givenName: "New",
+      familyName: "Name",
+      enabledUser: "false",
+      grades: ["10"],
+      roles: [
+        {
+          role: "student",
+          roleType: "primary",
+          org: { sourcedId: "school-1" },
+        },
+      ],
+      demographics: { birthDate: "2000-01-01" },
+    });
+
+    expect(normalizeStatus("TO_BE_DELETED")).toBe("tobedeleted");
+    expect(normalized.entity).toMatchObject({
+      sourced_id: "user-1",
+      email: "student@example.com",
+      given_name: "New",
+      family_name: "Name",
+      enabled_user: false,
+      is_active: false,
+    });
+    expect(normalized.entity).not.toHaveProperty("demographics");
+    expect(normalized.roles).toEqual([
+      expect.objectContaining({
+        user_sourced_id: "user-1",
+        role: "student",
+        org_sourced_id: "school-1",
+        is_active: false,
+      }),
+    ]);
+  });
+
+  it("maps changed class and enrollment fields into persisted column names", () => {
+    const normalizedClass = normalizeClass({
+      sourcedId: "class-1",
+      title: "Changed title",
+      classCode: "ALG-2",
+      classType: "scheduled",
+      location: "Room 4",
+      course: { sourcedId: "course-1" },
+      school: { sourcedId: "school-1" },
+      terms: [{ sourcedId: "term-1" }, { sourcedId: "term-1" }],
+      subjects: ["Mathematics"],
+      periods: ["2"],
+    });
+    const enrollment = normalizeEnrollment({
+      sourcedId: "enrollment-1",
+      user: { sourcedId: "user-1" },
+      class: { sourcedId: "class-1" },
+      school: { sourcedId: "school-1" },
+      role: "student",
+      primary: true,
+      beginDate: "2026-08-01",
+    });
+
+    expect(normalizedClass.entity).toMatchObject({
+      title: "Changed title",
+      class_code: "ALG-2",
+      location: "Room 4",
+      course_sourced_id: "course-1",
+    });
+    expect(normalizedClass.terms).toHaveLength(1);
+    expect(enrollment).toMatchObject({
+      user_sourced_id: "user-1",
+      class_sourced_id: "class-1",
+      is_primary: true,
+      begin_date: "2026-08-01",
+    });
+  });
+});
+
+describe("ClassLink credential parsing", () => {
+  it("accepts only direct OAuth1 or static proxy bearer shapes", () => {
+    expect(
+      parseCredentials(
+        JSON.stringify({ consumerKey: "key", consumerSecret: "secret" }),
+        "oauth1"
+      )
+    ).toEqual({
+      mode: "oauth1",
+      consumerKey: "key",
+      consumerSecret: "secret",
+    });
+    expect(
+      parseCredentials(JSON.stringify({ bearerToken: "token" }), "proxy")
+    ).toEqual({ mode: "proxy", bearerToken: "token" });
+    expect(() =>
+      parseCredentials(
+        JSON.stringify({
+          clientId: "id",
+          clientSecret: "secret",
+          tokenUrl: "https://example/token",
+        }),
+        "proxy"
+      )
+    ).toThrow("bearerToken");
+    expect(() => parseCredentials("null", "oauth1")).toThrow("JSON object");
+  });
+});

--- a/infra/lambdas/oneroster-sync/normalize.ts
+++ b/infra/lambdas/oneroster-sync/normalize.ts
@@ -1,0 +1,350 @@
+/**
+ * OneRoster response normalization for the isolated sync Lambda.
+ *
+ * The upstream is untrusted JSON. These helpers narrow values without `any`,
+ * preserve only the v1 roster fields, and lowercase the cross-system email key.
+ * Demographics are deliberately absent from this module and the client.
+ */
+
+export type JsonRecord = Record<string, unknown>;
+export type OneRosterStatus = "active" | "tobedeleted";
+
+export function isRecord(value: unknown): value is JsonRecord {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function optionalString(value: unknown): string | null {
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+export function requiredString(value: unknown, field: string): string {
+  const normalized = optionalString(value);
+  if (!normalized) {
+    throw new Error(`OneRoster record is missing required ${field}`);
+  }
+  return normalized;
+}
+
+export function optionalBoolean(value: unknown): boolean | null {
+  if (typeof value === "boolean") return value;
+  if (typeof value === "string") {
+    if (value.toLowerCase() === "true") return true;
+    if (value.toLowerCase() === "false") return false;
+  }
+  return null;
+}
+
+export function stringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value
+    .map(optionalString)
+    .filter((entry): entry is string => entry !== null);
+}
+
+export function sourcedIdFromRef(value: unknown): string | null {
+  return isRecord(value) ? optionalString(value.sourcedId) : null;
+}
+
+export function firstSourcedId(value: unknown): string | null {
+  if (!Array.isArray(value)) return sourcedIdFromRef(value);
+  for (const entry of value) {
+    const sourcedId = sourcedIdFromRef(entry);
+    if (sourcedId) return sourcedId;
+  }
+  return null;
+}
+
+export function normalizeEmail(value: unknown): string | null {
+  const email = optionalString(value);
+  return email ? email.toLowerCase() : null;
+}
+
+export function normalizeStatus(value: unknown): OneRosterStatus {
+  const compact = optionalString(value)?.replaceAll(/[-_\s]/g, "").toLowerCase();
+  return compact === "tobedeleted" ? "tobedeleted" : "active";
+}
+
+export function dateValue(value: unknown): string | null {
+  const raw = optionalString(value);
+  if (!raw) return null;
+  const parsed = new Date(raw);
+  if (Number.isNaN(parsed.getTime())) {
+    throw new Error("OneRoster record contains an invalid date value");
+  }
+  return raw;
+}
+
+export function dateTimeValue(value: unknown): string | null {
+  return dateValue(value);
+}
+
+export interface NormalizedOrg {
+  sourced_id: string;
+  name: string | null;
+  type: string | null;
+  identifier: string | null;
+  parent_sourced_id: string | null;
+  status: OneRosterStatus;
+  is_active: boolean;
+  date_last_modified: string | null;
+}
+
+export function normalizeOrg(record: JsonRecord): NormalizedOrg {
+  const status = normalizeStatus(record.status);
+  return {
+    sourced_id: requiredString(record.sourcedId, "sourcedId"),
+    name: optionalString(record.name),
+    type: optionalString(record.type),
+    identifier: optionalString(record.identifier),
+    parent_sourced_id: sourcedIdFromRef(record.parent),
+    status,
+    is_active: status !== "tobedeleted",
+    date_last_modified: dateTimeValue(record.dateLastModified),
+  };
+}
+
+export interface NormalizedAcademicSession {
+  sourced_id: string;
+  title: string | null;
+  type: string | null;
+  start_date: string | null;
+  end_date: string | null;
+  parent_sourced_id: string | null;
+  school_year: string | null;
+  status: OneRosterStatus;
+  is_active: boolean;
+  date_last_modified: string | null;
+}
+
+export function normalizeAcademicSession(
+  record: JsonRecord
+): NormalizedAcademicSession {
+  const status = normalizeStatus(record.status);
+  return {
+    sourced_id: requiredString(record.sourcedId, "sourcedId"),
+    title: optionalString(record.title),
+    type: optionalString(record.type),
+    start_date: dateValue(record.startDate),
+    end_date: dateValue(record.endDate),
+    parent_sourced_id: sourcedIdFromRef(record.parent),
+    school_year: optionalString(record.schoolYear),
+    status,
+    is_active: status !== "tobedeleted",
+    date_last_modified: dateTimeValue(record.dateLastModified),
+  };
+}
+
+export interface NormalizedCourse {
+  sourced_id: string;
+  title: string | null;
+  course_code: string | null;
+  org_sourced_id: string | null;
+  grades: string[];
+  status: OneRosterStatus;
+  is_active: boolean;
+  date_last_modified: string | null;
+}
+
+export function normalizeCourse(record: JsonRecord): NormalizedCourse {
+  const status = normalizeStatus(record.status);
+  return {
+    sourced_id: requiredString(record.sourcedId, "sourcedId"),
+    title: optionalString(record.title),
+    course_code: optionalString(record.courseCode),
+    org_sourced_id: firstSourcedId(record.orgs ?? record.org),
+    grades: stringArray(record.grades),
+    status,
+    is_active: status !== "tobedeleted",
+    date_last_modified: dateTimeValue(record.dateLastModified),
+  };
+}
+
+export interface NormalizedClass {
+  sourced_id: string;
+  title: string | null;
+  class_code: string | null;
+  class_type: string | null;
+  location: string | null;
+  course_sourced_id: string | null;
+  school_sourced_id: string | null;
+  grades: string[];
+  subjects: string[];
+  periods: string[];
+  status: OneRosterStatus;
+  is_active: boolean;
+  date_last_modified: string | null;
+}
+
+export interface NormalizedClassTerm {
+  class_sourced_id: string;
+  term_sourced_id: string;
+  status: OneRosterStatus;
+  is_active: boolean;
+  date_last_modified: string | null;
+}
+
+export function normalizeClass(record: JsonRecord): {
+  entity: NormalizedClass;
+  terms: NormalizedClassTerm[];
+} {
+  const sourcedId = requiredString(record.sourcedId, "sourcedId");
+  const status = normalizeStatus(record.status);
+  const dateLastModified = dateTimeValue(record.dateLastModified);
+  const termIds = Array.isArray(record.terms)
+    ? record.terms
+        .map(sourcedIdFromRef)
+        .filter((entry): entry is string => entry !== null)
+    : [];
+  return {
+    entity: {
+      sourced_id: sourcedId,
+      title: optionalString(record.title),
+      class_code: optionalString(record.classCode),
+      class_type: optionalString(record.classType),
+      location: optionalString(record.location),
+      course_sourced_id: sourcedIdFromRef(record.course),
+      school_sourced_id: sourcedIdFromRef(record.school),
+      grades: stringArray(record.grades),
+      subjects: stringArray(record.subjects),
+      periods: stringArray(record.periods),
+      status,
+      is_active: status !== "tobedeleted",
+      date_last_modified: dateLastModified,
+    },
+    terms: [...new Set(termIds)].map((termId) => ({
+      class_sourced_id: sourcedId,
+      term_sourced_id: termId,
+      status,
+      is_active: status !== "tobedeleted",
+      date_last_modified: dateLastModified,
+    })),
+  };
+}
+
+export interface NormalizedUser {
+  sourced_id: string;
+  email: string | null;
+  username: string | null;
+  given_name: string | null;
+  family_name: string | null;
+  role: string | null;
+  enabled_user: boolean | null;
+  grades: string[];
+  status: OneRosterStatus;
+  is_active: boolean;
+  date_last_modified: string | null;
+}
+
+export interface NormalizedUserRole {
+  user_sourced_id: string;
+  role: string;
+  role_type: string;
+  org_sourced_id: string | null;
+  status: OneRosterStatus;
+  is_active: boolean;
+  date_last_modified: string | null;
+}
+
+export function normalizeUser(record: JsonRecord): {
+  entity: NormalizedUser;
+  roles: NormalizedUserRole[];
+} {
+  const sourcedId = requiredString(record.sourcedId, "sourcedId");
+  const status = normalizeStatus(record.status);
+  const dateLastModified = dateTimeValue(record.dateLastModified);
+  const roles: NormalizedUserRole[] = [];
+  if (Array.isArray(record.roles)) {
+    for (const rawRole of record.roles) {
+      if (!isRecord(rawRole)) continue;
+      const role = optionalString(rawRole.role);
+      if (!role) continue;
+      roles.push({
+        user_sourced_id: sourcedId,
+        role,
+        role_type: optionalString(rawRole.roleType) ?? "primary",
+        org_sourced_id: sourcedIdFromRef(rawRole.org),
+        status,
+        is_active: status !== "tobedeleted",
+        date_last_modified: dateLastModified,
+      });
+    }
+  }
+  const legacyRole = optionalString(record.role);
+  if (roles.length === 0 && legacyRole) {
+    roles.push({
+      user_sourced_id: sourcedId,
+      role: legacyRole,
+      role_type: "primary",
+      org_sourced_id: firstSourcedId(record.orgs),
+      status,
+      is_active: status !== "tobedeleted",
+      date_last_modified: dateLastModified,
+    });
+  }
+  const primaryRole =
+    roles.find((entry) => entry.role_type.toLowerCase() === "primary")?.role ??
+    roles[0]?.role ??
+    legacyRole;
+  return {
+    entity: {
+      sourced_id: sourcedId,
+      email: normalizeEmail(record.email),
+      username: optionalString(record.username),
+      given_name: optionalString(record.givenName),
+      family_name: optionalString(record.familyName),
+      role: primaryRole,
+      enabled_user: optionalBoolean(record.enabledUser),
+      grades: stringArray(record.grades),
+      status,
+      is_active: status !== "tobedeleted",
+      date_last_modified: dateLastModified,
+    },
+    roles: dedupeUserRoles(roles),
+  };
+}
+
+function dedupeUserRoles(roles: NormalizedUserRole[]): NormalizedUserRole[] {
+  const seen = new Set<string>();
+  return roles.filter((entry) => {
+    const key = [
+      entry.user_sourced_id,
+      entry.role.toLowerCase(),
+      entry.role_type.toLowerCase(),
+      entry.org_sourced_id?.toLowerCase() ?? "",
+    ].join("\u0000");
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
+export interface NormalizedEnrollment {
+  sourced_id: string;
+  user_sourced_id: string | null;
+  class_sourced_id: string | null;
+  school_sourced_id: string | null;
+  role: string | null;
+  is_primary: boolean | null;
+  begin_date: string | null;
+  end_date: string | null;
+  status: OneRosterStatus;
+  is_active: boolean;
+  date_last_modified: string | null;
+}
+
+export function normalizeEnrollment(record: JsonRecord): NormalizedEnrollment {
+  const status = normalizeStatus(record.status);
+  return {
+    sourced_id: requiredString(record.sourcedId, "sourcedId"),
+    user_sourced_id: sourcedIdFromRef(record.user),
+    class_sourced_id: sourcedIdFromRef(record.class),
+    school_sourced_id: sourcedIdFromRef(record.school),
+    role: optionalString(record.role),
+    is_primary: optionalBoolean(record.primary),
+    begin_date: dateValue(record.beginDate),
+    end_date: dateValue(record.endDate),
+    status,
+    is_active: status !== "tobedeleted",
+    date_last_modified: dateTimeValue(record.dateLastModified),
+  };
+}

--- a/infra/lambdas/oneroster-sync/oneroster-client.test.ts
+++ b/infra/lambdas/oneroster-sync/oneroster-client.test.ts
@@ -1,0 +1,286 @@
+import { describe, expect, it } from "bun:test";
+import {
+  buildOAuth1Header,
+  OneRosterClient,
+  RevisionChangedError,
+  type HttpResponse,
+  type HttpTransport,
+} from "./oneroster-client";
+
+class TestHeaders {
+  private readonly values: Map<string, string>;
+
+  constructor(values: Record<string, string> = {}) {
+    this.values = new Map(
+      Object.entries(values).map(([key, value]) => [
+        key.toLowerCase(),
+        value,
+      ])
+    );
+  }
+
+  get(name: string): string | null {
+    return this.values.get(name.toLowerCase()) ?? null;
+  }
+}
+
+function response(
+  status: number,
+  body: unknown,
+  headers: Record<string, string> = {}
+): HttpResponse {
+  const responseHeaders =
+    status >= 200 && status < 300
+      ? { "x-perm-rev": "rev-1", ...headers }
+      : headers;
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    headers: new TestHeaders(responseHeaders),
+    json: async () => body,
+  };
+}
+
+function proxyClient(
+  transport: HttpTransport,
+  overrides: {
+    pageSize?: number;
+    sleep?: (milliseconds: number) => Promise<void>;
+    random?: () => number;
+  } = {}
+): OneRosterClient {
+  return new OneRosterClient({
+    baseUrl: "https://district.example",
+    apiVersion: "v1p1",
+    pageSize: overrides.pageSize ?? 10_000,
+    credentials: { mode: "proxy", bearerToken: "static-token" },
+    transport,
+    sleep: overrides.sleep,
+    random: overrides.random,
+  });
+}
+
+describe("OneRosterClient authentication", () => {
+  it("signs the complete OAuth1 URL query with HMAC-SHA1", () => {
+    const base = {
+      method: "GET" as const,
+      consumerKey: "consumer",
+      consumerSecret: "secret",
+      timestamp: 1_700_000_000,
+      nonce: "fixed-nonce",
+    };
+    const first = buildOAuth1Header({
+      ...base,
+      url: "https://district.example/ims/oneroster/v1p1/users?limit=10000&offset=0",
+    });
+    const second = buildOAuth1Header({
+      ...base,
+      url: "https://district.example/ims/oneroster/v1p1/users?limit=10000&offset=10000",
+    });
+
+    expect(first).toContain('oauth_consumer_key="consumer"');
+    expect(first).toContain('oauth_signature_method="HMAC-SHA1"');
+    expect(first).not.toEqual(second);
+  });
+
+  it("uses the configured non-expiring proxy bearer token directly", async () => {
+    let authorization = "";
+    const client = proxyClient(async (_url, init) => {
+      authorization = init.headers.Authorization ?? "";
+      return response(200, { orgs: [] }, { "x-total-count": "0" });
+    });
+
+    await client.fetchCollection("orgs", null);
+
+    expect(authorization).toBe("Bearer static-token");
+  });
+});
+
+describe("OneRosterClient paging and consistency", () => {
+  it("pages bulk collections using limit, offset, fields, x-count, and x-total-count", async () => {
+    const urls: string[] = [];
+    const client = proxyClient(
+      async (rawUrl) => {
+        urls.push(rawUrl);
+        const offset = new URL(rawUrl).searchParams.get("offset");
+        return offset === "0"
+          ? response(
+              200,
+              { users: [{ sourcedId: "u1" }, { sourcedId: "u2" }] },
+              {
+                "x-count": "2",
+                "x-total-count": "3",
+                "x-perm-rev": "rev-1",
+              }
+            )
+          : response(
+              200,
+              { users: [{ sourcedId: "u3" }] },
+              {
+                "x-count": "1",
+                "x-total-count": "3",
+                "x-perm-rev": "rev-1",
+              }
+            );
+      },
+      { pageSize: 2 }
+    );
+
+    const result = await client.fetchCollection("users", null);
+
+    expect(result.records.map((record) => record.sourcedId)).toEqual([
+      "u1",
+      "u2",
+      "u3",
+    ]);
+    expect(urls).toHaveLength(2);
+    expect(new URL(urls[0] ?? "").searchParams.get("limit")).toBe("2");
+    expect(new URL(urls[1] ?? "").searchParams.get("offset")).toBe("2");
+    expect(new URL(urls[0] ?? "").searchParams.get("fields")).toContain(
+      "email"
+    );
+  });
+
+  it("uses an empty page only as the fallback terminator when totals are absent", async () => {
+    let requests = 0;
+    const client = proxyClient(
+      async () => {
+        requests += 1;
+        return requests === 1
+          ? response(200, { orgs: [{ sourcedId: "o1" }, { sourcedId: "o2" }] })
+          : response(200, { orgs: [] });
+      },
+      { pageSize: 2 }
+    );
+
+    const result = await client.fetchCollection("orgs", null);
+
+    expect(result.records).toHaveLength(2);
+    expect(requests).toBe(2);
+  });
+
+  it("rejects a premature empty page, inconsistent count, and excess total", async () => {
+    const premature = proxyClient(async () =>
+      response(200, { courses: [] }, { "x-total-count": "1" })
+    );
+    const badCount = proxyClient(async () =>
+      response(
+        200,
+        { courses: [{ sourcedId: "c1" }] },
+        { "x-count": "2" }
+      )
+    );
+    const excess = proxyClient(async () =>
+      response(
+        200,
+        { courses: [{ sourcedId: "c1" }, { sourcedId: "c2" }] },
+        { "x-total-count": "1" }
+      )
+    );
+
+    await expect(premature.fetchCollection("courses", null)).rejects.toThrow(
+      "before x-total-count"
+    );
+    await expect(badCount.fetchCollection("courses", null)).rejects.toThrow(
+      "inconsistent x-count"
+    );
+    await expect(excess.fetchCollection("courses", null)).rejects.toThrow(
+      "more records"
+    );
+  });
+
+  it("aborts staged data when x-perm-rev changes between pages", async () => {
+    let requests = 0;
+    const client = proxyClient(
+      async () => {
+        requests += 1;
+        return response(
+          200,
+          requests === 1
+            ? { classes: [{ sourcedId: "c1" }] }
+            : { classes: [{ sourcedId: "c2" }] },
+          {
+            "x-total-count": "2",
+            "x-perm-rev": requests === 1 ? "rev-1" : "rev-2",
+          }
+        );
+      },
+      { pageSize: 1 }
+    );
+
+    await expect(
+      client.fetchCollection("classes", null)
+    ).rejects.toBeInstanceOf(RevisionChangedError);
+  });
+
+  it("rejects a successful page without the consistency revision", async () => {
+    const client = proxyClient(async () => ({
+      ok: true,
+      status: 200,
+      headers: new TestHeaders(),
+      json: async () => ({ orgs: [{ sourcedId: "o1" }] }),
+    }));
+
+    await expect(client.fetchCollection("orgs", null)).rejects.toThrow(
+      "missing x-perm-rev"
+    );
+  });
+
+  it("short-circuits the full pull when the persistent revision is unchanged", async () => {
+    let requests = 0;
+    const client = proxyClient(async () => {
+      requests += 1;
+      return response(
+        200,
+        { orgs: [{ sourcedId: "o1" }] },
+        { "x-total-count": "1", "x-perm-rev": "same-rev" }
+      );
+    });
+
+    const result = await client.pullAll("same-rev");
+
+    expect(result.unchanged).toBe(true);
+    expect(requests).toBe(1);
+  });
+});
+
+describe("OneRosterClient transient retries", () => {
+  it("retries 429 and 502 with Retry-After and capped exponential backoff", async () => {
+    const delays: number[] = [];
+    let requests = 0;
+    const client = proxyClient(
+      async () => {
+        requests += 1;
+        if (requests === 1) {
+          return response(429, null, { "retry-after": "3" });
+        }
+        if (requests === 2) return response(502, null);
+        return response(200, { enrollments: [] }, { "x-total-count": "0" });
+      },
+      {
+        sleep: async (milliseconds) => {
+          delays.push(milliseconds);
+        },
+        random: () => 0,
+      }
+    );
+
+    await client.fetchCollection("enrollments", null);
+
+    expect(requests).toBe(3);
+    expect(delays).toEqual([3_000, 2_000]);
+  });
+
+  it("does not retry non-transient HTTP errors", async () => {
+    let requests = 0;
+    const client = proxyClient(async () => {
+      requests += 1;
+      return response(401, null);
+    });
+
+    await expect(client.fetchCollection("users", null)).rejects.toThrow(
+      "HTTP 401"
+    );
+    expect(requests).toBe(1);
+  });
+});

--- a/infra/lambdas/oneroster-sync/oneroster-client.ts
+++ b/infra/lambdas/oneroster-sync/oneroster-client.ts
@@ -1,0 +1,386 @@
+/**
+ * ClassLink OneRoster HTTP client.
+ *
+ * Implements only ClassLink's documented server-to-server modes:
+ *   - OAuth1 HMAC-SHA1 direct to a district Roster Server.
+ *   - Static bearer access through the ClassLink OAuth2 Proxy.
+ * There is intentionally no token endpoint or generic OAuth2 client-credentials
+ * flow. All query parameters are included in the OAuth1 signature base string.
+ */
+
+import { createHmac, randomBytes } from "node:crypto";
+import type {
+  OneRosterApiVersion,
+  OneRosterCredentials,
+} from "./config";
+import { isRecord, type JsonRecord } from "./normalize";
+
+export const COLLECTIONS = [
+  "orgs",
+  "academicSessions",
+  "courses",
+  "classes",
+  "users",
+  "enrollments",
+] as const;
+
+export type CollectionName = (typeof COLLECTIONS)[number];
+
+const COLLECTION_FIELDS: Record<CollectionName, string> = {
+  orgs:
+    "sourcedId,status,dateLastModified,name,type,identifier,parent",
+  academicSessions:
+    "sourcedId,status,dateLastModified,title,type,startDate,endDate,parent,schoolYear",
+  courses:
+    "sourcedId,status,dateLastModified,title,courseCode,orgs,org,grades",
+  classes:
+    "sourcedId,status,dateLastModified,title,classCode,classType,location,course,school,terms,grades,subjects,periods",
+  users:
+    "sourcedId,status,dateLastModified,email,username,givenName,familyName,role,roles,orgs,enabledUser,grades",
+  enrollments:
+    "sourcedId,status,dateLastModified,user,class,school,role,primary,beginDate,endDate",
+};
+
+export interface ResponseHeaders {
+  get(name: string): string | null;
+}
+
+export interface HttpResponse {
+  ok: boolean;
+  status: number;
+  headers: ResponseHeaders;
+  json(): Promise<unknown>;
+}
+
+export type HttpTransport = (
+  url: string,
+  init: { method: "GET"; headers: Record<string, string> }
+) => Promise<HttpResponse>;
+
+export interface OneRosterClientOptions {
+  baseUrl: string;
+  apiVersion: OneRosterApiVersion;
+  pageSize: number;
+  credentials: OneRosterCredentials;
+  transport?: HttpTransport;
+  sleep?: (milliseconds: number) => Promise<void>;
+  random?: () => number;
+  nowSeconds?: () => number;
+  nonce?: () => string;
+  maxRequestRetries?: number;
+}
+
+export interface CollectionPullSuccess {
+  name: CollectionName;
+  records: JsonRecord[];
+  permRev: string | null;
+  complete: true;
+}
+
+export interface CollectionPullFailure {
+  name: CollectionName;
+  error: string;
+}
+
+export type CollectionPullResult =
+  | CollectionPullSuccess
+  | CollectionPullFailure;
+
+export interface RosterPull {
+  unchanged: boolean;
+  permRev: string | null;
+  collections: CollectionPullResult[];
+}
+
+export class RevisionChangedError extends Error {
+  constructor() {
+    super("x-perm-rev changed during the OneRoster pull");
+    this.name = "RevisionChangedError";
+  }
+}
+
+export class OneRosterClient {
+  private readonly baseUrl: string;
+  private readonly apiVersion: OneRosterApiVersion;
+  private readonly pageSize: number;
+  private readonly credentials: OneRosterCredentials;
+  private readonly transport: HttpTransport;
+  private readonly sleep: (milliseconds: number) => Promise<void>;
+  private readonly random: () => number;
+  private readonly nowSeconds: () => number;
+  private readonly nonce: () => string;
+  private readonly maxRequestRetries: number;
+
+  constructor(options: OneRosterClientOptions) {
+    this.baseUrl = options.baseUrl.replace(/\/+$/, "");
+    this.apiVersion = options.apiVersion;
+    this.pageSize = options.pageSize;
+    this.credentials = options.credentials;
+    this.transport = options.transport ?? defaultTransport;
+    this.sleep =
+      options.sleep ??
+      ((milliseconds) =>
+        new Promise((resolve) => setTimeout(resolve, milliseconds)));
+    this.random = options.random ?? Math.random;
+    this.nowSeconds =
+      options.nowSeconds ?? (() => Math.floor(Date.now() / 1_000));
+    this.nonce =
+      options.nonce ?? (() => randomBytes(16).toString("hex"));
+    this.maxRequestRetries = options.maxRequestRetries ?? 5;
+  }
+
+  /**
+   * Pull every v1 collection in dependency order. Collection failures are
+   * isolated so their last-known-good rows survive while later collections can
+   * still refresh. A revision change is different: all staged data is stale, so
+   * it escapes for the bounded whole-pull restart in sync.ts.
+   */
+  async pullAll(previousPermRev: string | null): Promise<RosterPull> {
+    const results: CollectionPullResult[] = [];
+    let batchPermRev: string | null = null;
+
+    for (const name of COLLECTIONS) {
+      try {
+        const collection = await this.fetchCollection(name, batchPermRev);
+        batchPermRev ??= collection.permRev;
+        if (
+          results.length === 0 &&
+          previousPermRev &&
+          collection.permRev === previousPermRev
+        ) {
+          return {
+            unchanged: true,
+            permRev: collection.permRev,
+            collections: [],
+          };
+        }
+        results.push(collection);
+      } catch (error) {
+        if (error instanceof RevisionChangedError) throw error;
+        results.push({ name, error: safeErrorMessage(error) });
+      }
+    }
+
+    if (!results.some((result) => "records" in result)) {
+      throw new Error("Every OneRoster collection failed");
+    }
+    return {
+      unchanged: false,
+      permRev: batchPermRev,
+      collections: results,
+    };
+  }
+
+  async fetchCollection(
+    name: CollectionName,
+    expectedPermRev: string | null
+  ): Promise<CollectionPullSuccess> {
+    const records: JsonRecord[] = [];
+    let offset = 0;
+    let totalCount: number | null = null;
+    let permRev = expectedPermRev;
+
+    while (true) {
+      const url = this.collectionUrl(name, offset);
+      const response = await this.request(url);
+      const pagePermRev = cleanHeader(response.headers.get("x-perm-rev"));
+      if (!pagePermRev) {
+        throw new Error(`${name} response is missing x-perm-rev`);
+      }
+      if (permRev && pagePermRev !== permRev) {
+        throw new RevisionChangedError();
+      }
+      permRev ??= pagePermRev;
+
+      const page = extractRecords(await response.json(), name);
+      const xCount = parseCountHeader(response.headers.get("x-count"), "x-count");
+      if (xCount !== null && xCount !== page.length) {
+        throw new Error(`${name} returned an inconsistent x-count header`);
+      }
+      const pageTotal = parseCountHeader(
+        response.headers.get("x-total-count"),
+        "x-total-count"
+      );
+      if (
+        totalCount !== null &&
+        pageTotal !== null &&
+        pageTotal !== totalCount
+      ) {
+        throw new Error(`${name} changed x-total-count during paging`);
+      }
+      totalCount ??= pageTotal;
+
+      if (page.length === 0) {
+        if (totalCount !== null && records.length < totalCount) {
+          throw new Error(`${name} paging ended before x-total-count was reached`);
+        }
+        break;
+      }
+
+      records.push(...page);
+      if (totalCount !== null && records.length > totalCount) {
+        throw new Error(`${name} returned more records than x-total-count`);
+      }
+      if (totalCount !== null && records.length >= totalCount) break;
+      if (totalCount === null && page.length < this.pageSize) break;
+      offset += this.pageSize;
+    }
+
+    return { name, records, permRev, complete: true };
+  }
+
+  private collectionUrl(name: CollectionName, offset: number): string {
+    const path =
+      this.apiVersion === "v1p2"
+        ? `/ims/oneroster/rostering/v1p2/${name}`
+        : `/ims/oneroster/v1p1/${name}`;
+    const url = new URL(`${this.baseUrl}${path}`);
+    url.searchParams.set("limit", String(this.pageSize));
+    url.searchParams.set("offset", String(offset));
+    url.searchParams.set("fields", COLLECTION_FIELDS[name]);
+    return url.toString();
+  }
+
+  private async request(url: string): Promise<HttpResponse> {
+    for (let attempt = 0; ; attempt += 1) {
+      const headers: Record<string, string> = {
+        Accept: "application/json",
+      };
+      if (this.credentials.mode === "proxy") {
+        headers.Authorization = `Bearer ${this.credentials.bearerToken}`;
+      } else {
+        headers.Authorization = buildOAuth1Header({
+          method: "GET",
+          url,
+          consumerKey: this.credentials.consumerKey,
+          consumerSecret: this.credentials.consumerSecret,
+          timestamp: this.nowSeconds(),
+          nonce: this.nonce(),
+        });
+      }
+
+      const response = await this.transport(url, { method: "GET", headers });
+      if (response.ok) return response;
+      const retryable = response.status === 429 || response.status === 502;
+      if (!retryable || attempt >= this.maxRequestRetries) {
+        throw new Error(`OneRoster request failed with HTTP ${response.status}`);
+      }
+      const exponential = Math.min(32_000, 1_000 * 2 ** attempt);
+      const jitter = Math.floor(this.random() * 1_000);
+      const retryAfter = retryAfterMilliseconds(
+        response.headers.get("retry-after")
+      );
+      await this.sleep(Math.max(exponential + jitter, retryAfter ?? 0));
+    }
+  }
+}
+
+interface OAuth1HeaderInput {
+  method: "GET";
+  url: string;
+  consumerKey: string;
+  consumerSecret: string;
+  timestamp: number;
+  nonce: string;
+}
+
+export function buildOAuth1Header(input: OAuth1HeaderInput): string {
+  const url = new URL(input.url);
+  const oauth = new Map<string, string>([
+    ["oauth_consumer_key", input.consumerKey],
+    ["oauth_nonce", input.nonce],
+    ["oauth_signature_method", "HMAC-SHA1"],
+    ["oauth_timestamp", String(input.timestamp)],
+    ["oauth_version", "1.0"],
+  ]);
+  const parameters: [string, string][] = [];
+  for (const [key, value] of url.searchParams.entries()) {
+    parameters.push([key, value]);
+  }
+  for (const entry of oauth.entries()) parameters.push(entry);
+  parameters.sort(([leftKey, leftValue], [rightKey, rightValue]) => {
+    const keyOrder = oauthEncode(leftKey).localeCompare(oauthEncode(rightKey));
+    return keyOrder || oauthEncode(leftValue).localeCompare(oauthEncode(rightValue));
+  });
+  const normalized = parameters
+    .map(([key, value]) => `${oauthEncode(key)}=${oauthEncode(value)}`)
+    .join("&");
+  const baseUrl = `${url.protocol}//${url.host}${url.pathname}`;
+  const signatureBase = [
+    input.method,
+    oauthEncode(baseUrl),
+    oauthEncode(normalized),
+  ].join("&");
+  const signingKey = `${oauthEncode(input.consumerSecret)}&`;
+  const signature = createHmac("sha1", signingKey)
+    .update(signatureBase)
+    .digest("base64");
+  oauth.set("oauth_signature", signature);
+  return (
+    "OAuth " +
+    [...oauth.entries()]
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([key, value]) => `${oauthEncode(key)}="${oauthEncode(value)}"`)
+      .join(", ")
+  );
+}
+
+function oauthEncode(value: string): string {
+  return encodeURIComponent(value).replace(
+    /[!'()*]/g,
+    (character) =>
+      `%${character.charCodeAt(0).toString(16).toUpperCase()}`
+  );
+}
+
+function extractRecords(value: unknown, name: CollectionName): JsonRecord[] {
+  const raw =
+    Array.isArray(value)
+      ? value
+      : isRecord(value) && Array.isArray(value[name])
+        ? value[name]
+        : null;
+  if (!raw) {
+    throw new Error(`${name} response is missing its collection array`);
+  }
+  if (!raw.every(isRecord)) {
+    throw new Error(`${name} response contains a non-object record`);
+  }
+  return raw;
+}
+
+function parseCountHeader(value: string | null, name: string): number | null {
+  if (value === null || value.trim() === "") return null;
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isInteger(parsed) || parsed < 0) {
+    throw new Error(`OneRoster returned an invalid ${name} header`);
+  }
+  return parsed;
+}
+
+function cleanHeader(value: string | null): string | null {
+  const normalized = value?.trim();
+  return normalized || null;
+}
+
+function retryAfterMilliseconds(value: string | null): number | null {
+  if (!value) return null;
+  const seconds = Number(value);
+  if (Number.isFinite(seconds) && seconds >= 0) {
+    return Math.ceil(seconds * 1_000);
+  }
+  const date = Date.parse(value);
+  return Number.isNaN(date) ? null : Math.max(0, date - Date.now());
+}
+
+function safeErrorMessage(error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error);
+  return message.length > 500 ? `${message.slice(0, 500)}…` : message;
+}
+
+async function defaultTransport(
+  url: string,
+  init: { method: "GET"; headers: Record<string, string> }
+): Promise<HttpResponse> {
+  return fetch(url, init);
+}

--- a/infra/lambdas/oneroster-sync/package.json
+++ b/infra/lambdas/oneroster-sync/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "oneroster-sync",
+  "version": "1.0.0",
+  "description": "Nightly ClassLink OneRoster full sync (Epic #1308 / Issue #1310).",
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "tsc",
+    "prebuild": "rm -rf dist",
+    "test": "bun test"
+  },
+  "dependencies": {
+    "@aws-sdk/client-cloudwatch": "^3.0.0",
+    "@aws-sdk/client-secrets-manager": "^3.0.0",
+    "postgres": "^3.4.0"
+  },
+  "devDependencies": {
+    "@types/aws-lambda": "^8.10.145",
+    "@types/node": "^20.0.0",
+    "typescript": "^5.0.0"
+  }
+}

--- a/infra/lambdas/oneroster-sync/sync.test.ts
+++ b/infra/lambdas/oneroster-sync/sync.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, it } from "bun:test";
+import {
+  COLLECTIONS,
+  RevisionChangedError,
+  type CollectionName,
+  type RosterPull,
+} from "./oneroster-client";
+import { runOneRosterSync, type OneRosterSyncPorts } from "./sync";
+
+function completePull(): RosterPull {
+  return {
+    unchanged: false,
+    permRev: "rev-2",
+    collections: COLLECTIONS.map((name) => ({
+      name,
+      records: [{ sourcedId: `${name}-1`, title: "Changed" }],
+      permRev: "rev-2",
+      complete: true as const,
+    })),
+  };
+}
+
+function testPorts(
+  overrides: Partial<OneRosterSyncPorts> = {}
+): OneRosterSyncPorts & {
+  reconciled: CollectionName[];
+  checkpoints: string[];
+} {
+  const reconciled: CollectionName[] = [];
+  const checkpoints: string[] = [];
+  return {
+    reconciled,
+    checkpoints,
+    readLastPermRev: async () => "rev-1",
+    pullRoster: async () => completePull(),
+    reconcileCollection: async (collection) => {
+      reconciled.push(collection.name);
+      return { synced: collection.records.length, deactivated: 2 };
+    },
+    writeLastPermRev: async (permRev) => {
+      checkpoints.push(permRev);
+    },
+    log: {
+      info: () => {},
+      warn: () => {},
+      error: () => {},
+    },
+    ...overrides,
+  };
+}
+
+describe("runOneRosterSync fail-safety", () => {
+  it("reconciles complete collections, reports absence deactivations, and checkpoints", async () => {
+    const ports = testPorts();
+
+    const result = await runOneRosterSync(ports);
+
+    expect(result.fullySuccessful).toBe(true);
+    expect(ports.reconciled).toEqual([...COLLECTIONS]);
+    expect(result.collections.every((entry) => entry.deactivated === 2)).toBe(
+      true
+    );
+    expect(ports.checkpoints).toEqual(["rev-2"]);
+  });
+
+  it("preserves last-known-good rows for an errored collection", async () => {
+    const pull = completePull();
+    pull.collections = pull.collections.map((collection) =>
+      collection.name === "users"
+        ? { name: "users", error: "upstream failed" }
+        : collection
+    );
+    const ports = testPorts({ pullRoster: async () => pull });
+
+    const result = await runOneRosterSync(ports);
+
+    expect(result.fullySuccessful).toBe(false);
+    expect(ports.reconciled).not.toContain("users");
+    expect(result.collections.find((entry) => entry.name === "users")).toEqual(
+      expect.objectContaining({ failed: 1, deactivated: 0 })
+    );
+    expect(ports.checkpoints).toEqual([]);
+  });
+
+  it("does not reconcile or deactivate an unexpectedly empty collection", async () => {
+    const pull = completePull();
+    pull.collections = pull.collections.map((collection) =>
+      collection.name === "enrollments"
+        ? { ...collection, records: [] }
+        : collection
+    );
+    const ports = testPorts({ pullRoster: async () => pull });
+
+    const result = await runOneRosterSync(ports);
+
+    expect(ports.reconciled).not.toContain("enrollments");
+    expect(
+      result.collections.find((entry) => entry.name === "enrollments")
+    ).toEqual(expect.objectContaining({ failed: 1, deactivated: 0 }));
+    expect(ports.checkpoints).toEqual([]);
+  });
+
+  it("isolates a collection transaction failure and does not checkpoint", async () => {
+    const ports = testPorts({
+      reconcileCollection: async (collection) => {
+        if (collection.name === "classes") {
+          throw new Error("transaction rolled back");
+        }
+        return { synced: 1, deactivated: 0 };
+      },
+    });
+
+    const result = await runOneRosterSync(ports);
+
+    expect(result.fullySuccessful).toBe(false);
+    expect(result.collections.find((entry) => entry.name === "classes")).toEqual(
+      expect.objectContaining({
+        failed: 1,
+        deactivated: 0,
+        error: "transaction rolled back",
+      })
+    );
+    expect(ports.checkpoints).toEqual([]);
+  });
+
+  it("discards staged data and performs a bounded full restart on revision change", async () => {
+    let attempts = 0;
+    const ports = testPorts({
+      pullRoster: async () => {
+        attempts += 1;
+        if (attempts < 3) throw new RevisionChangedError();
+        return completePull();
+      },
+    });
+
+    const result = await runOneRosterSync(ports);
+
+    expect(attempts).toBe(3);
+    expect(result.restartCount).toBe(2);
+    expect(result.fullySuccessful).toBe(true);
+  });
+
+  it("fails after the third revision change without touching the database", async () => {
+    const ports = testPorts({
+      pullRoster: async () => {
+        throw new RevisionChangedError();
+      },
+    });
+
+    await expect(runOneRosterSync(ports)).rejects.toBeInstanceOf(
+      RevisionChangedError
+    );
+    expect(ports.reconciled).toEqual([]);
+    expect(ports.checkpoints).toEqual([]);
+  });
+
+  it("treats an unchanged persistent revision as a successful no-op", async () => {
+    const ports = testPorts({
+      pullRoster: async () => ({
+        unchanged: true,
+        permRev: "rev-1",
+        collections: [],
+      }),
+    });
+
+    const result = await runOneRosterSync(ports);
+
+    expect(result.unchanged).toBe(true);
+    expect(result.fullySuccessful).toBe(true);
+    expect(ports.reconciled).toEqual([]);
+    expect(ports.checkpoints).toEqual([]);
+    expect(result.collections).toHaveLength(6);
+  });
+});

--- a/infra/lambdas/oneroster-sync/sync.ts
+++ b/infra/lambdas/oneroster-sync/sync.ts
@@ -1,0 +1,192 @@
+/**
+ * Dependency-injected OneRoster reconciliation core.
+ *
+ * The HTTP client stages a complete in-memory snapshot before this module writes
+ * anything. A mid-pull x-perm-rev change discards that snapshot and restarts the
+ * whole pull. Collection failures and unexpectedly empty collections never call
+ * the DB reconciler, preserving their last-known-good rows.
+ */
+
+import {
+  COLLECTIONS,
+  RevisionChangedError,
+  type CollectionName,
+  type CollectionPullSuccess,
+  type RosterPull,
+} from "./oneroster-client";
+
+export interface CollectionRunResult {
+  name: CollectionName;
+  synced: number;
+  failed: number;
+  deactivated: number;
+  recordsTotal: number;
+  error?: string;
+}
+
+export interface OneRosterSyncResult {
+  unchanged: boolean;
+  fullySuccessful: boolean;
+  permRev: string | null;
+  restartCount: number;
+  collections: CollectionRunResult[];
+}
+
+export interface OneRosterSyncPorts {
+  readLastPermRev(): Promise<string | null>;
+  pullRoster(previousPermRev: string | null): Promise<RosterPull>;
+  reconcileCollection(
+    collection: CollectionPullSuccess
+  ): Promise<{ synced: number; deactivated: number }>;
+  writeLastPermRev(permRev: string): Promise<void>;
+  log: {
+    info(message: string, metadata?: Record<string, unknown>): void;
+    warn(message: string, metadata?: Record<string, unknown>): void;
+    error(message: string, metadata?: Record<string, unknown>): void;
+  };
+}
+
+const MAX_WHOLE_PULL_ATTEMPTS = 3;
+
+export async function runOneRosterSync(
+  ports: OneRosterSyncPorts
+): Promise<OneRosterSyncResult> {
+  const previousPermRev = await ports.readLastPermRev();
+  let pull: RosterPull | null = null;
+  let restartCount = 0;
+
+  for (let attempt = 1; attempt <= MAX_WHOLE_PULL_ATTEMPTS; attempt += 1) {
+    try {
+      pull = await ports.pullRoster(previousPermRev);
+      break;
+    } catch (error) {
+      if (
+        !(error instanceof RevisionChangedError) ||
+        attempt === MAX_WHOLE_PULL_ATTEMPTS
+      ) {
+        throw error;
+      }
+      restartCount += 1;
+      ports.log.warn(
+        "OneRoster revision changed during pull; discarding staged data and restarting",
+        { attempt }
+      );
+    }
+  }
+
+  if (!pull) {
+    throw new Error("OneRoster pull did not produce a snapshot");
+  }
+  if (pull.unchanged) {
+    ports.log.info("OneRoster revision unchanged; skipping full reconciliation");
+    return {
+      unchanged: true,
+      fullySuccessful: true,
+      permRev: pull.permRev,
+      restartCount,
+      collections: COLLECTIONS.map((name) => ({
+        name,
+        synced: 0,
+        failed: 0,
+        deactivated: 0,
+        recordsTotal: 0,
+      })),
+    };
+  }
+
+  const byName = new Map(pull.collections.map((entry) => [entry.name, entry]));
+  const collectionResults: CollectionRunResult[] = [];
+
+  for (const name of COLLECTIONS) {
+    const collection = byName.get(name);
+    if (!collection || !("records" in collection)) {
+      const error =
+        collection && "error" in collection
+          ? collection.error
+          : "collection was not returned";
+      ports.log.error("OneRoster collection pull failed; preserving last-known-good rows", {
+        collection: name,
+        error,
+      });
+      collectionResults.push({
+        name,
+        synced: 0,
+        failed: 1,
+        deactivated: 0,
+        recordsTotal: 0,
+        error,
+      });
+      continue;
+    }
+
+    if (collection.records.length === 0) {
+      const error = "collection returned zero records; reconciliation skipped";
+      ports.log.warn(
+        "OneRoster collection was empty; preserving last-known-good rows",
+        { collection: name }
+      );
+      collectionResults.push({
+        name,
+        synced: 0,
+        failed: 1,
+        deactivated: 0,
+        recordsTotal: 0,
+        error,
+      });
+      continue;
+    }
+
+    try {
+      const reconciled = await ports.reconcileCollection(collection);
+      collectionResults.push({
+        name,
+        synced: reconciled.synced,
+        failed: 0,
+        deactivated: reconciled.deactivated,
+        recordsTotal: collection.records.length,
+      });
+      ports.log.info("OneRoster collection reconciled", {
+        collection: name,
+        records: collection.records.length,
+        deactivated: reconciled.deactivated,
+      });
+    } catch (error) {
+      const message = safeErrorMessage(error);
+      ports.log.error(
+        "OneRoster collection reconciliation failed; transaction rolled back",
+        { collection: name, error: message }
+      );
+      collectionResults.push({
+        name,
+        synced: 0,
+        failed: 1,
+        deactivated: 0,
+        recordsTotal: collection.records.length,
+        error: message,
+      });
+    }
+  }
+
+  const fullySuccessful = collectionResults.every(
+    (collection) => collection.failed === 0
+  );
+  // The checkpoint represents a fully-applied snapshot. Never advance it after
+  // a partial/empty/DB-failed run or the next night could incorrectly no-op and
+  // strand the failed collection at its old state.
+  if (fullySuccessful && pull.permRev) {
+    await ports.writeLastPermRev(pull.permRev);
+  }
+
+  return {
+    unchanged: false,
+    fullySuccessful,
+    permRev: pull.permRev,
+    restartCount,
+    collections: collectionResults,
+  };
+}
+
+function safeErrorMessage(error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error);
+  return message.length > 500 ? `${message.slice(0, 500)}…` : message;
+}

--- a/infra/lambdas/oneroster-sync/tsconfig.json
+++ b/infra/lambdas/oneroster-sync/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "lib": ["ES2022"],
+    "outDir": "./dist",
+    "rootDir": "./",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "moduleResolution": "node",
+    "declaration": false,
+    "sourceMap": true,
+    "types": ["node"]
+  },
+  "include": ["*.ts"],
+  "exclude": ["node_modules", "dist", "*.test.ts"]
+}

--- a/infra/lib/constructs/ecs-service.ts
+++ b/infra/lib/constructs/ecs-service.ts
@@ -473,6 +473,8 @@ export class EcsServiceConstruct extends Construct {
                 `arn:aws:lambda:${cdk.Stack.of(this).region}:${cdk.Stack.of(this).account}:function:psd-agent-skill-builder-${environment}`,
                 // #1203: admin "Sync now" async-invokes the hourly group-sync Lambda
                 `arn:aws:lambda:${cdk.Stack.of(this).region}:${cdk.Stack.of(this).account}:function:psd-group-sync-${environment}`,
+                // #1310: admin "Sync now" invokes the nightly OneRoster Lambda.
+                `arn:aws:lambda:${cdk.Stack.of(this).region}:${cdk.Stack.of(this).account}:function:psd-oneroster-sync-${environment}`,
                 // #1232 confused-deputy isolation: the /api/agent/workspace-token
                 // and /api/agent/account-request routes invoke the isolated mint
                 // Lambda instead of running WIF/signJwt in-process. INVOKE-ONLY —

--- a/infra/lib/processing-stack.ts
+++ b/infra/lib/processing-stack.ts
@@ -781,6 +781,218 @@ export class ProcessingStack extends cdk.Stack {
     groupSyncFailureAlarm.addAlarmAction(alarmAction);
     groupSyncStalenessAlarm.addAlarmAction(alarmAction);
 
+    // =====================================================================
+    // ClassLink OneRoster Sync Lambda (Epic #1308 / Issue #1310)
+    // =====================================================================
+    // A complete nightly pull stages all six v1 roster collections before
+    // reconciling them. The Lambda owns only the oneroster_* tables and uses
+    // one transaction per collection so upstream or DB failures retain each
+    // collection's last-known-good snapshot.
+    const oneRosterSecretArnPattern =
+      `arn:aws:secretsmanager:${this.region}:${this.account}:secret:aistudio-${props.environment}-oneroster-*`;
+    const oneRosterRole = ServiceRoleFactory.createLambdaRole(
+      this,
+      'OneRosterSyncRole',
+      {
+        functionName: `psd-oneroster-sync-${props.environment}`,
+        environment: props.environment,
+        region: this.region,
+        account: this.account,
+        vpcEnabled: false,
+        additionalPolicies: [
+          new iam.PolicyDocument({
+            statements: [
+              new iam.PolicyStatement({
+                sid: 'AuroraSecretAccess',
+                effect: iam.Effect.ALLOW,
+                actions: ['secretsmanager:GetSecretValue'],
+                resources: [databaseSecretArn],
+              }),
+              new iam.PolicyStatement({
+                sid: 'OneRosterCredentialSecretAccess',
+                effect: iam.Effect.ALLOW,
+                actions: ['secretsmanager:GetSecretValue'],
+                resources: [oneRosterSecretArnPattern],
+                conditions: {
+                  StringEquals: {
+                    'aws:ResourceTag/Environment': props.environment,
+                  },
+                },
+              }),
+              new iam.PolicyStatement({
+                sid: 'OneRosterSyncMetrics',
+                effect: iam.Effect.ALLOW,
+                actions: ['cloudwatch:PutMetricData'],
+                resources: ['*'],
+                conditions: {
+                  StringEquals: {
+                    'cloudwatch:namespace': 'AIStudio/RosterSync',
+                  },
+                },
+              }),
+            ],
+          }),
+        ],
+      },
+    );
+    oneRosterRole.addManagedPolicy(
+      iam.ManagedPolicy.fromAwsManagedPolicyName(
+        'service-role/AWSLambdaVPCAccessExecutionRole',
+      ),
+    );
+
+    const oneRosterSg = new ec2.SecurityGroup(this, 'OneRosterSyncSg', {
+      vpc,
+      description:
+        'Security group for the OneRoster sync Lambda (Aurora + ClassLink egress)',
+      allowAllOutbound: true,
+    });
+    cdk.Tags.of(oneRosterSg).add('Environment', props.environment);
+    cdk.Tags.of(oneRosterSg).add('ManagedBy', 'cdk');
+
+    const oneRosterLambda = new lambda.Function(this, 'OneRosterSync', {
+      functionName: `psd-oneroster-sync-${props.environment}`,
+      // Manual and scheduled full snapshots must never race each other.
+      reservedConcurrentExecutions: 1,
+      runtime: lambda.Runtime.NODEJS_20_X,
+      handler: 'index.handler',
+      code: lambda.Code.fromAsset(
+        path.join(__dirname, '../lambdas/oneroster-sync'),
+        {
+          assetHashType: cdk.AssetHashType.SOURCE,
+          bundling: {
+            image: lambda.Runtime.NODEJS_20_X.bundlingImage,
+            local: {
+              tryBundle(outputDir: string): boolean {
+                try {
+                  const inputDir = path.join(
+                    __dirname,
+                    '..',
+                    'lambdas',
+                    'oneroster-sync',
+                  );
+                  execSync('bun install && bunx tsc', {
+                    cwd: inputDir,
+                    stdio: 'inherit',
+                  });
+                  execSync(`cp -r dist/* ${outputDir}/`, {
+                    cwd: inputDir,
+                    stdio: 'inherit',
+                  });
+                  execSync(`cp package.json bun.lock ${outputDir}/`, {
+                    cwd: inputDir,
+                    stdio: 'inherit',
+                  });
+                  execSync('bun install --production --frozen-lockfile', {
+                    cwd: outputDir,
+                    stdio: 'inherit',
+                  });
+                  return true;
+                } catch (error) {
+                  process.stderr.write(
+                    `OneRoster local bundling failed, falling back to Docker: ${error}\n`,
+                  );
+                  return false;
+                }
+              },
+            },
+            command: [
+              'bash',
+              '-c',
+              [
+                'npm install',
+                'npm run build',
+                'cp -r dist/* /asset-output/',
+                'cp package.json /asset-output/',
+                'cd /asset-output && npm install --production',
+              ].join(' && '),
+            ],
+          },
+        },
+      ),
+      timeout: cdk.Duration.minutes(15),
+      memorySize: 1024,
+      architecture: lambda.Architecture.ARM_64,
+      vpc,
+      vpcSubnets: { subnetType: ec2.SubnetType.PRIVATE_WITH_EGRESS },
+      securityGroups: [oneRosterSg],
+      environment: {
+        NODE_OPTIONS: '--enable-source-maps',
+        DATABASE_HOST: databaseHost,
+        DATABASE_SECRET_ARN: databaseSecretArn,
+        DATABASE_NAME: 'aistudio',
+        DATABASE_PORT: '5432',
+        ENVIRONMENT: props.environment,
+      },
+      role: oneRosterRole,
+    });
+    cdk.Tags.of(oneRosterLambda).add('Environment', props.environment);
+    cdk.Tags.of(oneRosterLambda).add('ManagedBy', 'cdk');
+
+    const oneRosterSchedule = new events.Rule(
+      this,
+      'OneRosterNightlySchedule',
+      {
+        description: 'Nightly ClassLink OneRoster full sync (#1310)',
+        schedule: events.Schedule.cron({ minute: '0', hour: '10' }),
+        targets: [new eventsTargets.LambdaFunction(oneRosterLambda)],
+      },
+    );
+    cdk.Tags.of(oneRosterSchedule).add('Environment', props.environment);
+    cdk.Tags.of(oneRosterSchedule).add('ManagedBy', 'cdk');
+
+    const oneRosterFailureAlarm = new cloudwatch.Alarm(
+      this,
+      'OneRosterSyncFailureAlarm',
+      {
+        alarmName: `psd-oneroster-sync-failure-${props.environment}`,
+        alarmDescription:
+          'The ClassLink OneRoster sync errored; failed collections retain their last-known-good rows.',
+        metric: oneRosterLambda.metricErrors({
+          period: cdk.Duration.days(1),
+          statistic: 'Sum',
+        }),
+        threshold: 1,
+        evaluationPeriods: 1,
+        comparisonOperator:
+          cloudwatch.ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+        treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
+      },
+    );
+    cdk.Tags.of(oneRosterFailureAlarm).add('Environment', props.environment);
+    cdk.Tags.of(oneRosterFailureAlarm).add('ManagedBy', 'cdk');
+    const oneRosterStalenessAlarm = new cloudwatch.Alarm(
+      this,
+      'OneRosterSyncStalenessAlarm',
+      {
+        alarmName: `psd-oneroster-sync-staleness-${props.environment}`,
+        alarmDescription:
+          'No successful ClassLink OneRoster sync in approximately 48 hours.',
+        metric: new cloudwatch.Metric({
+          namespace: 'AIStudio/RosterSync',
+          metricName: 'SyncRunSucceeded',
+          dimensionsMap: { Environment: props.environment },
+          period: cdk.Duration.days(1),
+          statistic: 'Sum',
+        }),
+        threshold: 1,
+        evaluationPeriods: 2,
+        datapointsToAlarm: 2,
+        comparisonOperator: cloudwatch.ComparisonOperator.LESS_THAN_THRESHOLD,
+        treatMissingData: cloudwatch.TreatMissingData.BREACHING,
+      },
+    );
+    cdk.Tags.of(oneRosterStalenessAlarm).add('Environment', props.environment);
+    cdk.Tags.of(oneRosterStalenessAlarm).add('ManagedBy', 'cdk');
+    oneRosterFailureAlarm.addAlarmAction(alarmAction);
+    oneRosterStalenessAlarm.addAlarmAction(alarmAction);
+
+    new cdk.CfnOutput(this, 'OneRosterSyncFunctionName', {
+      value: oneRosterLambda.functionName,
+      description: 'Name of the ClassLink OneRoster sync Lambda function',
+      exportName: `${props.environment}-OneRosterSyncFunctionName`,
+    });
+
     // Outputs
     new cdk.CfnOutput(this, 'GroupSyncFunctionName', {
       value: groupSyncLambda.functionName,

--- a/infra/test/unit/processing-stack-embedding-access.test.ts
+++ b/infra/test/unit/processing-stack-embedding-access.test.ts
@@ -1,5 +1,5 @@
 import * as cdk from 'aws-cdk-lib';
-import { Template } from 'aws-cdk-lib/assertions';
+import { Match, Template } from 'aws-cdk-lib/assertions';
 import { ProcessingStack } from '../../lib/processing-stack';
 
 interface PolicyStatement {
@@ -130,5 +130,72 @@ describe('ProcessingStack embedding visual-artifact access', () => {
     expect(JSON.stringify(topics)).not.toContain('psd-group-sync-alarms-dev');
     const subscriptions = template.findResources('AWS::SNS::Subscription');
     expect(JSON.stringify(subscriptions)).not.toContain('"Protocol":"email"');
+  });
+
+  it('provisions a singleton nightly OneRoster sync with failure and staleness alarms', () => {
+    template.hasResourceProperties('AWS::Lambda::Function', {
+      FunctionName: 'psd-oneroster-sync-dev',
+      ReservedConcurrentExecutions: 1,
+      Timeout: 900,
+      MemorySize: 1024,
+      Architectures: ['arm64'],
+      VpcConfig: {
+        SecurityGroupIds: Match.anyValue(),
+        SubnetIds: Match.anyValue(),
+      },
+      Tags: Match.arrayWith([
+        { Key: 'Environment', Value: 'dev' },
+        { Key: 'ManagedBy', Value: 'cdk' },
+      ]),
+    });
+    template.hasResourceProperties('AWS::Events::Rule', {
+      Description: 'Nightly ClassLink OneRoster full sync (#1310)',
+      ScheduleExpression: 'cron(0 10 * * ? *)',
+      State: 'ENABLED',
+    });
+    template.hasResourceProperties('AWS::CloudWatch::Alarm', {
+      AlarmName: 'psd-oneroster-sync-failure-dev',
+      Threshold: 1,
+      TreatMissingData: 'notBreaching',
+    });
+    template.hasResourceProperties('AWS::CloudWatch::Alarm', {
+      AlarmName: 'psd-oneroster-sync-staleness-dev',
+      Threshold: 1,
+      EvaluationPeriods: 2,
+      DatapointsToAlarm: 2,
+      TreatMissingData: 'breaching',
+    });
+  });
+
+  it('scopes OneRoster secret reads and conditions metric publication', () => {
+    const secretStatement = statements.find(
+      (candidate) => candidate.Sid === 'OneRosterCredentialSecretAccess',
+    );
+    expect(secretStatement).toMatchObject({
+      Effect: 'Allow',
+      Action: 'secretsmanager:GetSecretValue',
+      Condition: {
+        StringEquals: {
+          'aws:ResourceTag/Environment': 'dev',
+        },
+      },
+    });
+    expect(JSON.stringify(secretStatement?.Resource)).toContain(
+      ':secret:aistudio-dev-oneroster-*',
+    );
+
+    const metricsStatement = statements.find(
+      (candidate) => candidate.Sid === 'OneRosterSyncMetrics',
+    );
+    expect(metricsStatement).toMatchObject({
+      Effect: 'Allow',
+      Action: 'cloudwatch:PutMetricData',
+      Resource: '*',
+      Condition: {
+        StringEquals: {
+          'cloudwatch:namespace': 'AIStudio/RosterSync',
+        },
+      },
+    });
   });
 });

--- a/lib/roster/settings.ts
+++ b/lib/roster/settings.ts
@@ -1,0 +1,69 @@
+/**
+ * Database-first OneRoster settings shared by future admin surfaces.
+ *
+ * The isolated sync Lambda reads these same keys directly from PostgreSQL.
+ * Credentials stay in Secrets Manager; only the secret ARN is stored here.
+ */
+
+import { getSetting } from "@/lib/settings-manager";
+
+export const ONEROSTER_SETTING_KEYS = {
+  enabled: "ROSTER_SYNC_ENABLED",
+  baseUrl: "ONEROSTER_BASE_URL",
+  authMode: "ONEROSTER_AUTH_MODE",
+  credentialsSecretArn: "ONEROSTER_CREDENTIALS_SECRET_ARN",
+  apiVersion: "ONEROSTER_API_VERSION",
+  pageSize: "ONEROSTER_PAGE_SIZE",
+  /** Lambda-owned revision checkpoint, exposed for key-parity checks only. */
+  lastPermRev: "ONEROSTER_LAST_PERM_REV",
+} as const;
+
+export type OneRosterAuthMode = "oauth1" | "proxy";
+export type OneRosterApiVersion = "v1p1" | "v1p2";
+
+export interface OneRosterSettings {
+  enabled: boolean;
+  baseUrl: string | null;
+  authMode: OneRosterAuthMode | null;
+  credentialsSecretArn: string | null;
+  apiVersion: OneRosterApiVersion;
+  pageSize: number;
+}
+
+export async function getOneRosterSettings(): Promise<OneRosterSettings> {
+  const [enabled, baseUrl, authMode, secretArn, apiVersion, pageSize] =
+    await Promise.all([
+      getSetting(ONEROSTER_SETTING_KEYS.enabled),
+      getSetting(ONEROSTER_SETTING_KEYS.baseUrl),
+      getSetting(ONEROSTER_SETTING_KEYS.authMode),
+      getSetting(ONEROSTER_SETTING_KEYS.credentialsSecretArn),
+      getSetting(ONEROSTER_SETTING_KEYS.apiVersion),
+      getSetting(ONEROSTER_SETTING_KEYS.pageSize),
+    ]);
+  const parsedPageSize = Number.parseInt(pageSize ?? "", 10);
+
+  return {
+    enabled: enabled?.trim().toLowerCase() === "true",
+    baseUrl: baseUrl?.trim() || null,
+    authMode: parseAuthMode(authMode),
+    credentialsSecretArn: secretArn?.trim() || null,
+    apiVersion: parseApiVersion(apiVersion),
+    pageSize:
+      Number.isInteger(parsedPageSize) &&
+      parsedPageSize > 0 &&
+      parsedPageSize <= 10_000
+        ? parsedPageSize
+        : 10_000,
+  };
+}
+
+function parseAuthMode(value: string | null): OneRosterAuthMode | null {
+  const normalized = value?.trim().toLowerCase();
+  return normalized === "oauth1" || normalized === "proxy"
+    ? normalized
+    : null;
+}
+
+function parseApiVersion(value: string | null): OneRosterApiVersion {
+  return value?.trim().toLowerCase() === "v1p2" ? "v1p2" : "v1p1";
+}

--- a/lib/roster/trigger.ts
+++ b/lib/roster/trigger.ts
@@ -1,0 +1,41 @@
+/**
+ * Asynchronously invokes the same OneRoster Lambda used by the nightly rule.
+ */
+
+import { InvokeCommand, LambdaClient } from "@aws-sdk/client-lambda";
+import { createLogger } from "@/lib/logger";
+
+const log = createLogger({ service: "oneroster-sync-trigger" });
+const REGION =
+  process.env.AWS_REGION || process.env.AWS_DEFAULT_REGION || "us-east-1";
+const ENVIRONMENT = process.env.ENVIRONMENT || "dev";
+
+let lambdaClient: LambdaClient | null = null;
+
+function getLambdaClient(): LambdaClient {
+  lambdaClient ??= new LambdaClient({ region: REGION });
+  return lambdaClient;
+}
+
+export function getOneRosterSyncFunctionName(): string {
+  return `psd-oneroster-sync-${ENVIRONMENT}`;
+}
+
+export async function triggerOneRosterSyncNow(
+  requestedByUserId: number | null
+): Promise<void> {
+  const functionName = getOneRosterSyncFunctionName();
+  await getLambdaClient().send(
+    new InvokeCommand({
+      FunctionName: functionName,
+      InvocationType: "Event",
+      Payload: Buffer.from(
+        JSON.stringify({ trigger: "manual", requestedByUserId })
+      ),
+    })
+  );
+  log.info("Dispatched manual OneRoster sync", {
+    functionName,
+    requestedByUserId,
+  });
+}

--- a/tests/unit/oneroster-sync-contract.test.ts
+++ b/tests/unit/oneroster-sync-contract.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Cross-bundle contract checks for the OneRoster sync (#1310).
+ *
+ * The Lambda is intentionally isolated from Next.js, so these checks prevent
+ * its duplicated setting names and deterministic invocation ARN from drifting.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+
+function source(relativePath: string): string {
+  return fs.readFileSync(path.join(process.cwd(), relativePath), "utf8");
+}
+
+describe("OneRoster sync cross-bundle contracts", () => {
+  const appSettings = source("lib/roster/settings.ts");
+  const lambdaSettings = source(
+    "infra/lambdas/oneroster-sync/config.ts"
+  );
+  const db = source("infra/lambdas/oneroster-sync/db.ts");
+
+  it("keeps all shared database-first setting keys synchronized", () => {
+    for (const key of [
+      "ROSTER_SYNC_ENABLED",
+      "ONEROSTER_BASE_URL",
+      "ONEROSTER_AUTH_MODE",
+      "ONEROSTER_CREDENTIALS_SECRET_ARN",
+      "ONEROSTER_API_VERSION",
+      "ONEROSTER_PAGE_SIZE",
+      "ONEROSTER_LAST_PERM_REV",
+    ]) {
+      expect(appSettings).toContain(key);
+      expect(lambdaSettings).toContain(key);
+    }
+  });
+
+  it("grants ECS invoke access to the deterministic OneRoster function only", () => {
+    const ecsService = source("infra/lib/constructs/ecs-service.ts");
+
+    expect(ecsService).toContain(
+      "function:psd-oneroster-sync-${environment}"
+    );
+  });
+
+  it("chunks writes below 5,000 rows and limits mutation SQL to roster tables", () => {
+    expect(db).toContain("const UPSERT_CHUNK_SIZE = 4_000");
+    expect(db).not.toMatch(/\b(?:INSERT INTO|UPDATE|DELETE FROM)\s+users\b/i);
+    expect(db).not.toMatch(/\b(?:INSERT INTO|UPDATE|DELETE FROM)\s+user_roles\b/i);
+  });
+
+  it("applies absence deactivation only inside collection transactions", () => {
+    expect(db).toContain("return sql.begin(async (tx) =>");
+    expect(db).toContain(
+      "const absent = await deactivateAbsent(tx, \"oneroster_orgs\", rows)"
+    );
+    expect(db).toContain("sourced_id <> ALL($1::text[])");
+    expect(db).toContain("last_synced_at");
+  });
+});


### PR DESCRIPTION
## Issue and epic

Closes #1310

Part of #1308. This is the next dependency after merged schema workstream #1309; it does not begin any downstream UI, role-mapping, room, or reporting workstream.

## Refined acceptance criteria

- [x] Provide a self-contained `infra/lambdas/oneroster-sync` Node.js bundle.
- [x] Support only the epic-approved ClassLink modes selected by `ONEROSTER_AUTH_MODE`: direct OAuth1 HMAC-SHA1 and static-bearer OAuth2 Proxy. Do not implement a token endpoint or generic client-credentials flow.
- [x] Pull the complete v1 `orgs`, `academicSessions`, `courses`, `classes`, `users`, and `enrollments` collections using field minimization and a configurable page size defaulting to 10,000.
- [x] Validate `x-count`, `x-total-count`, empty-page termination, and a required stable `x-perm-rev`; no-op on the last fully applied revision and perform at most three whole-pull restarts on a mid-batch revision change.
- [x] Retry 429/502 with `Retry-After`, capped exponential backoff, jitter, and a bounded retry count.
- [x] Reconcile each confirmed-complete, non-empty collection transactionally in chunks below 5,000 rows. Preserve last-known-good rows on pull, validation, empty-result, or DB failure.
- [x] Normalize explicit `tobedeleted` state and perform absence-driven deactivation only inside the complete collection transaction.
- [x] Lowercase roster email, exclude demographics, and keep ingestion isolated from application users, grants, administrators, rooms, assistants, capabilities, and scopes.
- [x] Deploy a singleton VPC Lambda with a nightly EventBridge rule, deterministic manual-invoke path, environment-scoped and tag-conditioned credential secret access, namespace-conditioned metrics, shared-topic failure/staleness alarms, and required resource tags.
- [x] Keep application/Lambda setting keys synchronized and document credential setup, safety invariants, monitoring, rollout, and rollback.

## Implementation

- Added a dependency-injected ClassLink client with complete OAuth1 query signing, static Proxy bearer auth, bulk paging, consistency headers, field minimization, transient retries, and safe error messages.
- Added normalizers for the six in-scope collections plus class-term and user-role relationships. Demographics and metadata never enter the persistence shape.
- Added postgres.js reconciliation following the existing isolated group-sync Lambda pattern. Each collection uses one transaction for upserts plus explicit/absence deactivation; the persistent revision checkpoint advances only after all six collections apply successfully.
- Added structured Lambda logging and `AIStudio/RosterSync` run/collection metrics without credential or raw-roster logging.
- Added `ProcessingStack` infrastructure through `ServiceRoleFactory`, private-subnet/NAT networking, reserved concurrency 1, a 10:00 UTC nightly rule, scoped secret/IAM conditions, alarms, outputs, and ECS invoke permission.
- Added database-first settings accessors, an async manual trigger, a cross-bundle settings/invoke contract test, CDK assertions, and the ClassLink operations runbook.

## Verification

- `cd infra/lambdas/oneroster-sync && bun test` — 20 passed; PostgreSQL-only cases skipped without `ONEROSTER_DB_TEST_URL`.
- `ONEROSTER_DB_TEST_URL=postgresql://... bun test db.integration.test.ts` against a disposable PostgreSQL 16 container — 3 passed, including absence deactivation, changed-field upsert, explicit deletion, insert timestamps, and transaction rollback preserving last-known-good rows.
- `cd infra/lambdas/oneroster-sync && bun run build` — passed.
- `bun run test:ci --runInBand` — 362 suites passed, 3 skipped; 3,572 tests passed, 26 skipped.
- `cd infra && bun run test -- --runInBand test/unit/processing-stack-embedding-access.test.ts` — 6 passed; locally bundled the OneRoster artifact.
- `cd infra && bun run build` — passed, including infrastructure TypeScript, unified-content typecheck, and 11 isolated skill-builder tests.
- `cd infra && bunx cdk synth` — all dev/prod stacks synthesized successfully. Existing unrelated advisory warnings remain; no OneRoster role validation warning was emitted.
- `bun run typecheck` — passed.
- `bun run build` — passed. Existing unrelated Edge Runtime, middleware-deprecation, and browsers-data warnings remain.
- `bun run lint` — exited successfully with 0 errors. The repository currently emits 407 warnings in pre-existing untouched code; the affected application/test files emit 0 warnings.
- `git diff --check` — passed.

Authenticated Playwright E2E is not applicable: this issue adds no UI or authorization flow. The repository pre-push hook was intentionally bypassed with its documented `SKIP_E2E=1` option rather than copying `.env.local` credentials into the isolated worktree.

## Security and privacy

- Credentials exist only in an environment-named Secrets Manager secret; the settings table stores its ARN.
- Secret access is restricted by ARN family and matching `Environment` resource tag. CloudWatch writes are restricted to `AIStudio/RosterSync`.
- Logs and errors omit secret values, response bodies, and roster records.
- Requested/stored fields exclude demographics and other unnecessary FERPA-sensitive data.
- The Lambda writes only `oneroster_*` tables and its internal revision setting. It cannot grant/revoke roles or affect the last-administrator invariant.
- OAuth1 covers all URL query parameters. Proxy mode uses the ClassLink static bearer directly and has no refresh/token flow.

## Configuration and rollout

1. Deploy the Processing stack with roster sync disabled.
2. Obtain direct OAuth1 credentials or the application ID/static Proxy token from ClassLink Partner Portal.
3. Create and tag `aistudio-{environment}-oneroster-*`, then configure the non-secret database settings documented in `docs/features/oneroster-classlink-sync.md`.
4. Run a manual sync and compare per-collection totals/sample relationships with ClassLink.
5. Set `ROSTER_SYNC_ENABLED=true`.

The API defaults to `v1p1`; `v1p2` is reserved behind `ONEROSTER_API_VERSION`. The page size defaults to 10,000.

## Rollback

Set `ROSTER_SYNC_ENABLED=false` to stop scheduled work while retaining the last-known-good roster snapshot. A code rollback redeploys the prior Processing stack. Migration 141 is additive and can remain; routine rollback must not clear roster rows or `ONEROSTER_LAST_PERM_REV`. Rotate the ClassLink credential before re-enabling if exposure is suspected.

## Known limitations / remaining epic work

- No live PSD credential test was performed; protocol coverage uses deterministic mocked HTTP.
- #1311 (admin configuration UI), #1312 (optional role mapping), #1313/#1314 (rooms/authorization), and #1315 (reporting) remain separate and blocked until this PR merges according to the epic dependency policy.
- Full snapshots are deliberately staged in memory and remain subject to the Lambda's 15-minute/1,024 MiB envelope; CloudWatch failure and staleness alarms surface districts that exceed it.
