### PR TITLE
feat(roster): add administrator roster controls

### DIFF
--- a/actions/db/roster-admin-actions.ts
+++ b/actions/db/roster-admin-actions.ts
@@ -27,8 +27,9 @@ import {
 } from "@/lib/logger"
 import { revalidateSettingsCache } from "@/lib/settings-manager"
 import {
+  createOneRosterSettingsInputSchema,
+  getOneRosterDeploymentIdentity,
   getOneRosterSettings,
-  oneRosterSettingsInputSchema,
   ONEROSTER_SETTING_KEYS,
   type OneRosterSettings,
   type OneRosterSettingsInput,
@@ -128,7 +129,9 @@ export async function saveOneRosterSettingsAction(
 
   try {
     await requireAdminSession(log, "save OneRoster settings")
-    const parsed = oneRosterSettingsInputSchema.parse(input)
+    const parsed = createOneRosterSettingsInputSchema(
+      getOneRosterDeploymentIdentity()
+    ).parse(input)
     const now = new Date()
     const rows = [
       {

--- a/actions/db/roster-admin-actions.ts
+++ b/actions/db/roster-admin-actions.ts
@@ -1,0 +1,354 @@
+"use server"
+
+/**
+ * Administrator-only OneRoster settings, sync, and roster-browser actions.
+ *
+ * Roster rows are read-only here: the sync Lambda remains their sole writer.
+ * The settings action stores only non-secret configuration and a Secrets
+ * Manager ARN; ClassLink credentials never enter the application database.
+ */
+
+import { randomUUID } from "node:crypto"
+import { revalidatePath } from "next/cache"
+import { executeTransaction } from "@/lib/db/drizzle-client"
+import { settings } from "@/lib/db/schema"
+import { getUserIdByCognitoSubAsNumber } from "@/lib/db/drizzle"
+import { getServerSession } from "@/lib/auth/server-session"
+import { hasRole } from "@/utils/roles"
+import {
+  createSuccess,
+  ErrorFactories,
+  handleError,
+} from "@/lib/error-utils"
+import {
+  createLogger,
+  generateRequestId,
+  startTimer,
+} from "@/lib/logger"
+import { revalidateSettingsCache } from "@/lib/settings-manager"
+import {
+  getOneRosterSettings,
+  oneRosterSettingsInputSchema,
+  ONEROSTER_SETTING_KEYS,
+  type OneRosterSettings,
+  type OneRosterSettingsInput,
+} from "@/lib/roster/settings"
+import {
+  getOneRosterSyncOverview,
+  listRosterClasses,
+  listRosterSchools,
+  listRosterStudents,
+  type OneRosterSyncOverview,
+  type RosterClass,
+  type RosterSchool,
+  type RosterStudent,
+} from "@/lib/roster/queries"
+import {
+  getOneRosterSyncStatus,
+  writeOneRosterSyncStatus,
+  type OneRosterSyncStatus,
+} from "@/lib/roster/status"
+import { triggerOneRosterSyncNow } from "@/lib/roster/trigger"
+import type { ActionState } from "@/types"
+
+const ADMIN_ROSTERS_PATH = "/admin/rosters"
+
+export interface OneRosterAdminData {
+  settings: OneRosterSettings
+  overview: OneRosterSyncOverview
+  schools: RosterSchool[]
+  syncConfigured: boolean
+}
+
+async function requireAdminSession(
+  log: ReturnType<typeof createLogger>,
+  operation: string
+): Promise<string> {
+  const session = await getServerSession()
+  if (!session) {
+    log.warn(`Unauthorized ${operation} attempt`)
+    throw ErrorFactories.authNoSession()
+  }
+  if (!(await hasRole("administrator"))) {
+    log.warn(`Non-admin attempted ${operation}`, { userId: session.sub })
+    throw ErrorFactories.authzInsufficientPermissions("administrator")
+  }
+  return session.sub
+}
+
+function isConfigured(value: OneRosterSettings): boolean {
+  return Boolean(
+    value.baseUrl && value.authMode && value.credentialsSecretArn
+  )
+}
+
+export async function getOneRosterAdminDataAction(): Promise<
+  ActionState<OneRosterAdminData>
+> {
+  const requestId = generateRequestId()
+  const timer = startTimer("getOneRosterAdminDataAction")
+  const log = createLogger({ requestId, action: "getOneRosterAdminDataAction" })
+
+  try {
+    await requireAdminSession(log, "load OneRoster admin data")
+    const [rosterSettings, overview, schools] = await Promise.all([
+      getOneRosterSettings(),
+      getOneRosterSyncOverview(),
+      listRosterSchools(),
+    ])
+    timer({ status: "success" })
+    return createSuccess(
+      {
+        settings: rosterSettings,
+        overview,
+        schools,
+        syncConfigured: isConfigured(rosterSettings),
+      },
+      "OneRoster admin data loaded"
+    )
+  } catch (error) {
+    timer({ status: "error" })
+    return handleError(error, "Failed to load OneRoster data.", {
+      context: "getOneRosterAdminDataAction",
+      requestId,
+      operation: "getOneRosterAdminDataAction",
+    })
+  }
+}
+
+export async function saveOneRosterSettingsAction(
+  input: OneRosterSettingsInput
+): Promise<ActionState<OneRosterSettings>> {
+  const requestId = generateRequestId()
+  const timer = startTimer("saveOneRosterSettingsAction")
+  const log = createLogger({
+    requestId,
+    action: "saveOneRosterSettingsAction",
+  })
+
+  try {
+    await requireAdminSession(log, "save OneRoster settings")
+    const parsed = oneRosterSettingsInputSchema.parse(input)
+    const now = new Date()
+    const rows = [
+      {
+        key: ONEROSTER_SETTING_KEYS.enabled,
+        value: String(parsed.enabled),
+        description: "Enable scheduled ClassLink OneRoster synchronization",
+      },
+      {
+        key: ONEROSTER_SETTING_KEYS.baseUrl,
+        value: parsed.baseUrl,
+        description: "ClassLink Roster Server or OAuth2 Proxy base URL",
+      },
+      {
+        key: ONEROSTER_SETTING_KEYS.authMode,
+        value: parsed.authMode,
+        description: "ClassLink authentication mode: oauth1 or proxy",
+      },
+      {
+        key: ONEROSTER_SETTING_KEYS.credentialsSecretArn,
+        value: parsed.credentialsSecretArn,
+        description: "Secrets Manager ARN containing ClassLink credentials",
+      },
+      {
+        key: ONEROSTER_SETTING_KEYS.apiVersion,
+        value: parsed.apiVersion,
+        description: "OneRoster REST API path version",
+      },
+      {
+        key: ONEROSTER_SETTING_KEYS.pageSize,
+        value: String(parsed.pageSize),
+        description: "OneRoster bulk collection page size",
+      },
+    ] as const
+
+    await executeTransaction(
+      async tx => {
+        for (const row of rows) {
+          await tx
+            .insert(settings)
+            .values({
+              ...row,
+              category: "integrations",
+              isSecret:
+                row.key === ONEROSTER_SETTING_KEYS.credentialsSecretArn,
+              updatedAt: now,
+            })
+            .onConflictDoUpdate({
+              target: settings.key,
+              set: {
+                value: row.value,
+                description: row.description,
+                category: "integrations",
+                isSecret:
+                  row.key === ONEROSTER_SETTING_KEYS.credentialsSecretArn,
+                updatedAt: now,
+              },
+            })
+        }
+      },
+      "saveOneRosterSettingsAction"
+    )
+
+    await revalidateSettingsCache()
+    revalidatePath(ADMIN_ROSTERS_PATH)
+    const saved = await getOneRosterSettings()
+    log.info("OneRoster settings saved", {
+      enabled: saved.enabled,
+      authMode: saved.authMode,
+      apiVersion: saved.apiVersion,
+      pageSize: saved.pageSize,
+      configured: isConfigured(saved),
+    })
+    timer({ status: "success" })
+    return createSuccess(saved, "OneRoster settings saved")
+  } catch (error) {
+    timer({ status: "error" })
+    return handleError(error, "Failed to save OneRoster settings.", {
+      context: "saveOneRosterSettingsAction",
+      requestId,
+      operation: "saveOneRosterSettingsAction",
+    })
+  }
+}
+
+export async function triggerOneRosterSyncAction(): Promise<
+  ActionState<{ runId: string; dispatched: boolean }>
+> {
+  const requestId = generateRequestId()
+  const timer = startTimer("triggerOneRosterSyncAction")
+  const log = createLogger({ requestId, action: "triggerOneRosterSyncAction" })
+  const runId = randomUUID()
+  const startedAt = new Date().toISOString()
+
+  try {
+    const cognitoSub = await requireAdminSession(log, "trigger OneRoster sync")
+    const rosterSettings = await getOneRosterSettings()
+    if (!isConfigured(rosterSettings)) {
+      throw ErrorFactories.invalidInput(
+        "OneRoster settings",
+        "incomplete",
+        "Save a base URL, authentication mode, and credentials secret ARN first"
+      )
+    }
+
+    const queued: OneRosterSyncStatus = {
+      runId,
+      trigger: "manual",
+      state: "queued",
+      startedAt,
+      completedAt: null,
+      unchanged: false,
+      collections: [],
+      error: null,
+    }
+    await writeOneRosterSyncStatus(queued)
+
+    const dbUserId = await getUserIdByCognitoSubAsNumber(cognitoSub)
+    try {
+      await triggerOneRosterSyncNow(dbUserId, runId)
+    } catch (error) {
+      await writeOneRosterSyncStatus({
+        ...queued,
+        state: "failed",
+        completedAt: new Date().toISOString(),
+        error: "The OneRoster sync Lambda could not be invoked.",
+      })
+      throw error
+    }
+
+    log.info("OneRoster sync dispatched", {
+      userId: cognitoSub,
+      dbUserId,
+      runId,
+    })
+    timer({ status: "success" })
+    return createSuccess(
+      { runId, dispatched: true },
+      "OneRoster sync started"
+    )
+  } catch (error) {
+    timer({ status: "error" })
+    return handleError(error, "Failed to start OneRoster sync.", {
+      context: "triggerOneRosterSyncAction",
+      requestId,
+      operation: "triggerOneRosterSyncAction",
+    })
+  }
+}
+
+export async function getOneRosterSyncStatusAction(): Promise<
+  ActionState<OneRosterSyncStatus | null>
+> {
+  const requestId = generateRequestId()
+  const timer = startTimer("getOneRosterSyncStatusAction")
+  const log = createLogger({
+    requestId,
+    action: "getOneRosterSyncStatusAction",
+  })
+
+  try {
+    await requireAdminSession(log, "poll OneRoster sync status")
+    const status = await getOneRosterSyncStatus()
+    timer({ status: "success" })
+    return createSuccess(status, "OneRoster sync status loaded")
+  } catch (error) {
+    timer({ status: "error" })
+    return handleError(error, "Failed to load OneRoster sync status.", {
+      context: "getOneRosterSyncStatusAction",
+      requestId,
+      operation: "getOneRosterSyncStatusAction",
+    })
+  }
+}
+
+export async function listRosterClassesAction(
+  schoolSourcedId: string
+): Promise<ActionState<RosterClass[]>> {
+  const requestId = generateRequestId()
+  const timer = startTimer("listRosterClassesAction")
+  const log = createLogger({ requestId, action: "listRosterClassesAction" })
+
+  try {
+    await requireAdminSession(log, "list OneRoster classes")
+    if (!schoolSourcedId.trim()) {
+      throw ErrorFactories.missingRequiredField("schoolSourcedId")
+    }
+    const classes = await listRosterClasses(schoolSourcedId)
+    timer({ status: "success" })
+    return createSuccess(classes, "OneRoster classes loaded")
+  } catch (error) {
+    timer({ status: "error" })
+    return handleError(error, "Failed to load OneRoster classes.", {
+      context: "listRosterClassesAction",
+      requestId,
+      operation: "listRosterClassesAction",
+    })
+  }
+}
+
+export async function listRosterStudentsAction(
+  classSourcedId: string
+): Promise<ActionState<RosterStudent[]>> {
+  const requestId = generateRequestId()
+  const timer = startTimer("listRosterStudentsAction")
+  const log = createLogger({ requestId, action: "listRosterStudentsAction" })
+
+  try {
+    await requireAdminSession(log, "list OneRoster students")
+    if (!classSourcedId.trim()) {
+      throw ErrorFactories.missingRequiredField("classSourcedId")
+    }
+    const students = await listRosterStudents(classSourcedId)
+    timer({ status: "success" })
+    return createSuccess(students, "OneRoster students loaded")
+  } catch (error) {
+    timer({ status: "error" })
+    return handleError(error, "Failed to load OneRoster students.", {
+      context: "listRosterStudentsAction",
+      requestId,
+      operation: "listRosterStudentsAction",
+    })
+  }
+}

--- a/app/(protected)/admin/_lib/admin-pages.ts
+++ b/app/(protected)/admin/_lib/admin-pages.ts
@@ -14,6 +14,7 @@ import {
   Library,
   Plug,
   Settings,
+  School,
   ShieldCheck,
   Users,
   UsersRound,
@@ -69,6 +70,14 @@ export const ADMIN_SECTIONS: AdminSection[] = [
           "Google Directory group sync — selection rules, membership, and manual sync",
         icon: UsersRound,
         slug: "groups",
+      },
+      {
+        href: "/admin/rosters",
+        title: "Rosters",
+        description:
+          "ClassLink OneRoster settings, sync status, and read-only roster browser",
+        icon: School,
+        slug: "rosters",
       },
       {
         href: "/admin/oauth-clients",

--- a/app/(protected)/admin/rosters/_components/rosters-admin.tsx
+++ b/app/(protected)/admin/rosters/_components/rosters-admin.tsx
@@ -120,6 +120,40 @@ async function pollForRun(
   return null
 }
 
+function usePersistedRunMonitor(
+  runId: string | null,
+  router: ReturnType<typeof useRouter>,
+  syncInFlightRef: { current: boolean },
+  mountedRef: { current: boolean }
+) {
+  useEffect(() => {
+    if (!runId) return
+    let cancelled = false
+    syncInFlightRef.current = true
+
+    const monitorPersistedRun = async () => {
+      while (!cancelled && mountedRef.current) {
+        const status = await pollForRun(
+          runId,
+          () => mountedRef.current && !cancelled
+        )
+        if (cancelled || !mountedRef.current) return
+        if (status) {
+          syncInFlightRef.current = false
+          router.refresh()
+          return
+        }
+      }
+    }
+
+    void monitorPersistedRun()
+    return () => {
+      cancelled = true
+      syncInFlightRef.current = false
+    }
+  }, [mountedRef, router, runId, syncInFlightRef])
+}
+
 interface RostersAdminProps {
   initialData: OneRosterAdminData | null
   initialError: string | null
@@ -132,9 +166,14 @@ export function RostersAdmin({
   const router = useRouter()
   const { toast } = useToast()
   const [isPending, startTransition] = useTransition()
-  const [isSyncing, setIsSyncing] = useState(
-    initialData?.overview.status?.state === "queued" ||
-      initialData?.overview.status?.state === "running"
+  const [isManualSyncing, setIsManualSyncing] = useState(false)
+  const persistedStatus = initialData?.overview.status
+  const persistedRunId =
+    persistedStatus && !isTerminal(persistedStatus)
+      ? persistedStatus.runId
+      : null
+  const isSyncing = Boolean(
+    isManualSyncing || persistedRunId
   )
   const syncInFlightRef = useRef(false)
   const mountedRef = useRef(true)
@@ -145,6 +184,13 @@ export function RostersAdmin({
       mountedRef.current = false
     }
   }, [])
+
+  usePersistedRunMonitor(
+    persistedRunId,
+    router,
+    syncInFlightRef,
+    mountedRef
+  )
 
   if (!initialData) {
     return (
@@ -160,13 +206,13 @@ export function RostersAdmin({
   const handleSyncNow = async () => {
     if (syncInFlightRef.current) return
     syncInFlightRef.current = true
-    setIsSyncing(true)
+    setIsManualSyncing(true)
 
     const trigger = await triggerOneRosterSyncAction()
     if (!mountedRef.current) return
     if (!trigger.isSuccess) {
       syncInFlightRef.current = false
-      setIsSyncing(false)
+      setIsManualSyncing(false)
       toast({
         title: "Sync could not start",
         description: trigger.message,
@@ -185,7 +231,7 @@ export function RostersAdmin({
     )
     if (!mountedRef.current) return
     syncInFlightRef.current = false
-    setIsSyncing(false)
+    setIsManualSyncing(false)
 
     if (!status) {
       toast({
@@ -635,14 +681,19 @@ function RosterBrowser({ data }: { data: OneRosterAdminData }) {
   const [selectedClass, setSelectedClass] = useState<RosterClass | null>(null)
   const [loadingClasses, setLoadingClasses] = useState(false)
   const [loadingStudents, setLoadingStudents] = useState(false)
+  const schoolRequestRef = useRef(0)
+  const rosterRequestRef = useRef(0)
 
   const handleSchoolChange = async (value: string) => {
+    const requestId = ++schoolRequestRef.current
+    rosterRequestRef.current += 1
     setSchoolId(value)
     setClasses([])
     setStudents([])
     setSelectedClass(null)
     setLoadingClasses(true)
     const result = await listRosterClassesAction(value)
+    if (requestId !== schoolRequestRef.current) return
     setLoadingClasses(false)
     if (result.isSuccess) {
       setClasses(result.data)
@@ -656,10 +707,12 @@ function RosterBrowser({ data }: { data: OneRosterAdminData }) {
   }
 
   const handleViewRoster = async (rosterClass: RosterClass) => {
+    const requestId = ++rosterRequestRef.current
     setSelectedClass(rosterClass)
     setStudents([])
     setLoadingStudents(true)
     const result = await listRosterStudentsAction(rosterClass.sourcedId)
+    if (requestId !== rosterRequestRef.current) return
     setLoadingStudents(false)
     if (result.isSuccess) {
       setStudents(result.data)

--- a/app/(protected)/admin/rosters/_components/rosters-admin.tsx
+++ b/app/(protected)/admin/rosters/_components/rosters-admin.tsx
@@ -59,7 +59,10 @@ import type {
   OneRosterAuthMode,
   OneRosterApiVersion,
 } from "@/lib/roster/settings"
-import type { OneRosterSyncStatus } from "@/lib/roster/status"
+import {
+  isOneRosterSyncStatusActive,
+  type OneRosterSyncStatus,
+} from "@/lib/roster/status"
 
 type DateValue = Date | string | null
 
@@ -88,6 +91,12 @@ function collectionLabel(value: string): string {
 
 function statusLabel(status: OneRosterSyncStatus | null): string {
   if (!status) return "No run recorded"
+  if (
+    (status.state === "queued" || status.state === "running") &&
+    !isOneRosterSyncStatusActive(status)
+  ) {
+    return "Timed out"
+  }
   if (status.state === "succeeded" && status.unchanged) return "No changes"
   return status.state.charAt(0).toUpperCase() + status.state.slice(1)
 }
@@ -121,29 +130,35 @@ async function pollForRun(
 }
 
 function usePersistedRunMonitor(
-  runId: string | null,
+  status: OneRosterSyncStatus | null,
   router: ReturnType<typeof useRouter>,
   syncInFlightRef: { current: boolean },
   mountedRef: { current: boolean }
 ) {
   useEffect(() => {
-    if (!runId) return
+    if (!status || !isOneRosterSyncStatusActive(status)) return
     let cancelled = false
     syncInFlightRef.current = true
+    const shouldContinue = () =>
+      mountedRef.current &&
+      !cancelled &&
+      isOneRosterSyncStatusActive(status)
 
     const monitorPersistedRun = async () => {
-      while (!cancelled && mountedRef.current) {
-        const status = await pollForRun(
-          runId,
-          () => mountedRef.current && !cancelled
+      while (shouldContinue()) {
+        const terminalStatus = await pollForRun(
+          status.runId,
+          shouldContinue
         )
         if (cancelled || !mountedRef.current) return
-        if (status) {
+        if (terminalStatus) {
           syncInFlightRef.current = false
           router.refresh()
           return
         }
       }
+      syncInFlightRef.current = false
+      router.refresh()
     }
 
     void monitorPersistedRun()
@@ -151,7 +166,7 @@ function usePersistedRunMonitor(
       cancelled = true
       syncInFlightRef.current = false
     }
-  }, [mountedRef, router, runId, syncInFlightRef])
+  }, [mountedRef, router, status, syncInFlightRef])
 }
 
 interface RostersAdminProps {
@@ -168,12 +183,12 @@ export function RostersAdmin({
   const [isPending, startTransition] = useTransition()
   const [isManualSyncing, setIsManualSyncing] = useState(false)
   const persistedStatus = initialData?.overview.status
-  const persistedRunId =
-    persistedStatus && !isTerminal(persistedStatus)
-      ? persistedStatus.runId
+  const persistedRun =
+    persistedStatus && isOneRosterSyncStatusActive(persistedStatus)
+      ? persistedStatus
       : null
   const isSyncing = Boolean(
-    isManualSyncing || persistedRunId
+    isManualSyncing || persistedRun
   )
   const syncInFlightRef = useRef(false)
   const mountedRef = useRef(true)
@@ -186,7 +201,7 @@ export function RostersAdmin({
   }, [])
 
   usePersistedRunMonitor(
-    persistedRunId,
+    persistedRun,
     router,
     syncInFlightRef,
     mountedRef

--- a/app/(protected)/admin/rosters/_components/rosters-admin.tsx
+++ b/app/(protected)/admin/rosters/_components/rosters-admin.tsx
@@ -1,0 +1,906 @@
+"use client"
+
+import {
+  useEffect,
+  useRef,
+  useState,
+  useTransition,
+} from "react"
+import { useRouter } from "next/navigation"
+import { AlertCircle, RefreshCw, Save, Users } from "lucide-react"
+import { Alert, AlertDescription } from "@/components/ui/alert"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { Switch } from "@/components/ui/switch"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
+import {
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
+} from "@/components/ui/tabs"
+import { useToast } from "@/components/ui/use-toast"
+import {
+  getOneRosterSyncStatusAction,
+  listRosterClassesAction,
+  listRosterStudentsAction,
+  saveOneRosterSettingsAction,
+  triggerOneRosterSyncAction,
+  type OneRosterAdminData,
+} from "@/actions/db/roster-admin-actions"
+import type {
+  RosterClass,
+  RosterStudent,
+} from "@/lib/roster/queries"
+import type {
+  OneRosterAuthMode,
+  OneRosterApiVersion,
+} from "@/lib/roster/settings"
+import type { OneRosterSyncStatus } from "@/lib/roster/status"
+
+type DateValue = Date | string | null
+
+function formatDate(value: DateValue): string {
+  if (!value) return "Never"
+  const parsed = value instanceof Date ? value : new Date(value)
+  return Number.isNaN(parsed.getTime()) ? "Never" : parsed.toLocaleString()
+}
+
+function displayName(student: RosterStudent): string {
+  const name = [student.givenName, student.familyName].filter(Boolean).join(" ")
+  return name || student.email || student.userSourcedId || "Unknown student"
+}
+
+function collectionLabel(value: string): string {
+  const labels: Record<string, string> = {
+    orgs: "Organizations",
+    academicSessions: "Academic sessions",
+    courses: "Courses",
+    classes: "Classes",
+    users: "Users",
+    enrollments: "Enrollments",
+  }
+  return labels[value] ?? value
+}
+
+function statusLabel(status: OneRosterSyncStatus | null): string {
+  if (!status) return "No run recorded"
+  if (status.state === "succeeded" && status.unchanged) return "No changes"
+  return status.state.charAt(0).toUpperCase() + status.state.slice(1)
+}
+
+function isTerminal(status: OneRosterSyncStatus): boolean {
+  return (
+    status.state === "succeeded" ||
+    status.state === "failed" ||
+    status.state === "skipped"
+  )
+}
+
+const wait = (ms: number) =>
+  new Promise<void>(resolve => {
+    setTimeout(resolve, ms)
+  })
+
+async function pollForRun(
+  runId: string,
+  isMounted: () => boolean
+): Promise<OneRosterSyncStatus | null> {
+  const deadline = Date.now() + 180_000
+  while (isMounted() && Date.now() < deadline) {
+    await wait(3_000)
+    if (!isMounted()) return null
+    const result = await getOneRosterSyncStatusAction()
+    const status = result.isSuccess ? result.data : null
+    if (status?.runId === runId && isTerminal(status)) return status
+  }
+  return null
+}
+
+interface RostersAdminProps {
+  initialData: OneRosterAdminData | null
+  initialError: string | null
+}
+
+export function RostersAdmin({
+  initialData,
+  initialError,
+}: RostersAdminProps) {
+  const router = useRouter()
+  const { toast } = useToast()
+  const [isPending, startTransition] = useTransition()
+  const [isSyncing, setIsSyncing] = useState(
+    initialData?.overview.status?.state === "queued" ||
+      initialData?.overview.status?.state === "running"
+  )
+  const syncInFlightRef = useRef(false)
+  const mountedRef = useRef(true)
+
+  useEffect(() => {
+    mountedRef.current = true
+    return () => {
+      mountedRef.current = false
+    }
+  }, [])
+
+  if (!initialData) {
+    return (
+      <Alert variant="destructive" data-testid="rosters-load-error">
+        <AlertCircle className="h-4 w-4" />
+        <AlertDescription>
+          {initialError ?? "Failed to load OneRoster data."}
+        </AlertDescription>
+      </Alert>
+    )
+  }
+
+  const handleSyncNow = async () => {
+    if (syncInFlightRef.current) return
+    syncInFlightRef.current = true
+    setIsSyncing(true)
+
+    const trigger = await triggerOneRosterSyncAction()
+    if (!mountedRef.current) return
+    if (!trigger.isSuccess) {
+      syncInFlightRef.current = false
+      setIsSyncing(false)
+      toast({
+        title: "Sync could not start",
+        description: trigger.message,
+        variant: "destructive",
+      })
+      return
+    }
+
+    toast({
+      title: "Sync started",
+      description: "ClassLink collections are being refreshed.",
+    })
+    const status = await pollForRun(
+      trigger.data.runId,
+      () => mountedRef.current
+    )
+    if (!mountedRef.current) return
+    syncInFlightRef.current = false
+    setIsSyncing(false)
+
+    if (!status) {
+      toast({
+        title: "Sync still running",
+        description:
+          "The run is taking longer than expected. Refresh to see its latest status.",
+      })
+    } else if (status.state === "succeeded") {
+      toast({
+        title: status.unchanged ? "Roster already current" : "Sync complete",
+        description: status.unchanged
+          ? "ClassLink reported no roster changes."
+          : "The complete roster snapshot was refreshed.",
+      })
+    } else {
+      toast({
+        title: status.state === "skipped" ? "Sync skipped" : "Sync failed",
+        description:
+          status.error ??
+          "The previous roster snapshot was preserved. Review Lambda alarms and logs.",
+        variant: "destructive",
+      })
+    }
+    router.refresh()
+  }
+
+  return (
+    <div className="space-y-6" data-testid="rosters-admin">
+      {!initialData.syncConfigured && (
+        <Alert data-testid="rosters-not-configured">
+          <AlertCircle className="h-4 w-4" />
+          <AlertDescription>
+            Save the ClassLink base URL, documented authentication mode, and
+            scoped Secrets Manager ARN before running a sync.
+          </AlertDescription>
+        </Alert>
+      )}
+
+      <Tabs defaultValue="settings">
+        <TabsList>
+          <TabsTrigger value="settings" data-testid="tab-roster-settings">
+            Settings
+          </TabsTrigger>
+          <TabsTrigger value="sync" data-testid="tab-roster-sync">
+            Sync
+          </TabsTrigger>
+          <TabsTrigger value="browser" data-testid="tab-roster-browser">
+            Roster browser
+          </TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="settings">
+          <SettingsTab
+            settings={initialData.settings}
+            isPending={isPending}
+            startTransition={startTransition}
+          />
+        </TabsContent>
+
+        <TabsContent value="sync">
+          <SyncTab
+            data={initialData}
+            isPending={isPending}
+            isSyncing={isSyncing}
+            onSync={handleSyncNow}
+            onRefresh={() => startTransition(() => router.refresh())}
+          />
+        </TabsContent>
+
+        <TabsContent value="browser">
+          <RosterBrowser data={initialData} />
+        </TabsContent>
+      </Tabs>
+    </div>
+  )
+}
+
+interface SettingsTabProps {
+  settings: OneRosterAdminData["settings"]
+  isPending: boolean
+  startTransition: (callback: () => void) => void
+}
+
+function SettingsTab({
+  settings,
+  isPending,
+  startTransition,
+}: SettingsTabProps) {
+  const router = useRouter()
+  const { toast } = useToast()
+  const [enabled, setEnabled] = useState(settings.enabled)
+  const [baseUrl, setBaseUrl] = useState(settings.baseUrl ?? "")
+  const [authMode, setAuthMode] = useState<OneRosterAuthMode | "">(
+    settings.authMode ?? ""
+  )
+  const [secretArn, setSecretArn] = useState(
+    settings.credentialsSecretArn ?? ""
+  )
+  const [apiVersion, setApiVersion] = useState<OneRosterApiVersion>(
+    settings.apiVersion
+  )
+  const [pageSize, setPageSize] = useState(String(settings.pageSize))
+
+  const handleSave = () => {
+    if (!authMode) {
+      toast({
+        title: "Settings not saved",
+        description: "Select the documented ClassLink authentication mode.",
+        variant: "destructive",
+      })
+      return
+    }
+    startTransition(async () => {
+      const result = await saveOneRosterSettingsAction({
+        enabled,
+        baseUrl,
+        authMode,
+        credentialsSecretArn: secretArn,
+        apiVersion,
+        pageSize,
+      })
+      if (result.isSuccess) {
+        toast({ title: "Settings saved", description: result.message })
+        router.refresh()
+      } else {
+        toast({
+          title: "Settings not saved",
+          description: result.message,
+          variant: "destructive",
+        })
+      }
+    })
+  }
+
+  return (
+    <Card data-testid="roster-settings-form">
+      <CardHeader>
+        <CardTitle>ClassLink connection</CardTitle>
+        <CardDescription>
+          Credentials stay in Secrets Manager. This page stores only the
+          connection URL, documented auth mode, secret ARN, API path version,
+          page size, and schedule flag.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-5">
+        <div className="flex items-center justify-between rounded-md border p-4">
+          <div>
+            <Label htmlFor="roster-enabled">Nightly synchronization</Label>
+            <p className="text-sm text-muted-foreground">
+              Manual sync remains available while the schedule is disabled.
+            </p>
+          </div>
+          <Switch
+            id="roster-enabled"
+            checked={enabled}
+            onCheckedChange={setEnabled}
+            data-testid="roster-enabled"
+          />
+        </div>
+
+        <ConnectionSettingsFields
+          baseUrl={baseUrl}
+          setBaseUrl={setBaseUrl}
+          authMode={authMode}
+          setAuthMode={setAuthMode}
+          secretArn={secretArn}
+          setSecretArn={setSecretArn}
+          apiVersion={apiVersion}
+          setApiVersion={setApiVersion}
+          pageSize={pageSize}
+          setPageSize={setPageSize}
+        />
+
+        <div className="flex justify-end">
+          <Button
+            onClick={handleSave}
+            disabled={isPending}
+            data-testid="roster-settings-save"
+          >
+            <Save className="mr-2 h-4 w-4" />
+            {isPending ? "Saving…" : "Save settings"}
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}
+
+interface ConnectionSettingsFieldsProps {
+  baseUrl: string
+  setBaseUrl: (value: string) => void
+  authMode: OneRosterAuthMode | ""
+  setAuthMode: (value: OneRosterAuthMode) => void
+  secretArn: string
+  setSecretArn: (value: string) => void
+  apiVersion: OneRosterApiVersion
+  setApiVersion: (value: OneRosterApiVersion) => void
+  pageSize: string
+  setPageSize: (value: string) => void
+}
+
+function ConnectionSettingsFields({
+  baseUrl,
+  setBaseUrl,
+  authMode,
+  setAuthMode,
+  secretArn,
+  setSecretArn,
+  apiVersion,
+  setApiVersion,
+  pageSize,
+  setPageSize,
+}: ConnectionSettingsFieldsProps) {
+  return (
+    <div className="grid gap-5 md:grid-cols-2">
+      <div className="space-y-2 md:col-span-2">
+        <Label htmlFor="roster-base-url">ClassLink base URL</Label>
+        <Input
+          id="roster-base-url"
+          value={baseUrl}
+          onChange={event => setBaseUrl(event.target.value)}
+          placeholder="https://district.example.org"
+          autoComplete="off"
+          data-testid="roster-base-url"
+        />
+      </div>
+
+      <div className="space-y-2">
+        <Label>Authentication mode</Label>
+        <Select
+          value={authMode}
+          onValueChange={value => setAuthMode(value as OneRosterAuthMode)}
+        >
+          <SelectTrigger data-testid="roster-auth-mode">
+            <SelectValue placeholder="Select documented mode" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="oauth1">OAuth1 HMAC direct</SelectItem>
+            <SelectItem value="proxy">OAuth2 Proxy bearer</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+
+      <div className="space-y-2">
+        <Label>OneRoster API path</Label>
+        <Select
+          value={apiVersion}
+          onValueChange={value =>
+            setApiVersion(value as OneRosterApiVersion)
+          }
+        >
+          <SelectTrigger data-testid="roster-api-version">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="v1p1">v1p1 (default)</SelectItem>
+            <SelectItem value="v1p2">v1p2</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+
+      <div className="space-y-2 md:col-span-2">
+        <Label htmlFor="roster-secret-arn">Credentials secret ARN</Label>
+        <Input
+          id="roster-secret-arn"
+          value={secretArn}
+          onChange={event => setSecretArn(event.target.value)}
+          placeholder="arn:aws:secretsmanager:us-west-2:123456789012:secret:aistudio-dev-oneroster-..."
+          autoComplete="off"
+          data-testid="roster-secret-arn"
+        />
+        <p className="text-xs text-muted-foreground">
+          Must match the{" "}
+          <code>aistudio-{"{environment}"}-oneroster-*</code> secret family. The
+          credential value is never stored here.
+        </p>
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="roster-page-size">Bulk page size</Label>
+        <Input
+          id="roster-page-size"
+          type="number"
+          min={1}
+          max={10_000}
+          value={pageSize}
+          onChange={event => setPageSize(event.target.value)}
+          data-testid="roster-page-size"
+        />
+        <p className="text-xs text-muted-foreground">
+          ClassLink&apos;s recommended default is 10,000.
+        </p>
+      </div>
+    </div>
+  )
+}
+
+interface SyncTabProps {
+  data: OneRosterAdminData
+  isPending: boolean
+  isSyncing: boolean
+  onSync: () => void
+  onRefresh: () => void
+}
+
+function SyncTab({
+  data,
+  isPending,
+  isSyncing,
+  onSync,
+  onRefresh,
+}: SyncTabProps) {
+  const status = data.overview.status
+  const runCollections = new Map(
+    status?.collections.map(collection => [collection.name, collection])
+  )
+
+  return (
+    <div className="space-y-4">
+      <div className="grid gap-4 sm:grid-cols-3">
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-xs font-medium text-muted-foreground">
+              Last run
+            </CardTitle>
+          </CardHeader>
+          <CardContent data-testid="roster-last-run">
+            {formatDate(data.overview.lastRunAt)}
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-xs font-medium text-muted-foreground">
+              Status
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <Badge
+              variant={status?.state === "failed" ? "destructive" : "secondary"}
+              data-testid="roster-sync-status"
+            >
+              {statusLabel(status)}
+            </Badge>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-xs font-medium text-muted-foreground">
+              Schedule
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <Badge variant={data.settings.enabled ? "default" : "outline"}>
+              {data.settings.enabled ? "Nightly enabled" : "Disabled"}
+            </Badge>
+          </CardContent>
+        </Card>
+      </div>
+
+      {status?.error && (
+        <Alert variant="destructive" data-testid="roster-last-error">
+          <AlertCircle className="h-4 w-4" />
+          <AlertDescription>{status.error}</AlertDescription>
+        </Alert>
+      )}
+
+      <div className="flex justify-end gap-2">
+        <Button
+          variant="outline"
+          onClick={onRefresh}
+          disabled={isPending || isSyncing}
+          data-testid="roster-refresh"
+        >
+          <RefreshCw className="mr-2 h-4 w-4" />
+          Refresh
+        </Button>
+        <Button
+          onClick={onSync}
+          disabled={
+            isPending ||
+            isSyncing ||
+            !data.syncConfigured
+          }
+          data-testid="roster-sync-now"
+        >
+          <RefreshCw
+            className={`mr-2 h-4 w-4 ${isSyncing ? "animate-spin" : ""}`}
+          />
+          {isSyncing ? "Syncing…" : "Sync now"}
+        </Button>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Collection snapshot</CardTitle>
+          <CardDescription>
+            Live active/inactive totals plus counts from the last recorded run.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="p-0">
+          <Table data-testid="roster-collection-summary">
+            <TableHeader>
+              <TableRow>
+                <TableHead>Collection</TableHead>
+                <TableHead>Active</TableHead>
+                <TableHead>Inactive</TableHead>
+                <TableHead>Last run</TableHead>
+                <TableHead>Last synced</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {data.overview.collections.map(collection => {
+                const run = runCollections.get(collection.name)
+                return (
+                  <TableRow key={collection.name}>
+                    <TableCell className="font-medium">
+                      {collectionLabel(collection.name)}
+                    </TableCell>
+                    <TableCell>{collection.active}</TableCell>
+                    <TableCell>{collection.inactive}</TableCell>
+                    <TableCell>
+                      {run
+                        ? `${run.synced} synced · ${run.deactivated} deactivated${
+                            run.failed ? " · failed" : ""
+                          }`
+                        : "—"}
+                    </TableCell>
+                    <TableCell>
+                      {formatDate(collection.lastSyncedAt)}
+                    </TableCell>
+                  </TableRow>
+                )
+              })}
+            </TableBody>
+          </Table>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}
+
+function RosterBrowser({ data }: { data: OneRosterAdminData }) {
+  const { toast } = useToast()
+  const [schoolId, setSchoolId] = useState("")
+  const [classes, setClasses] = useState<RosterClass[]>([])
+  const [students, setStudents] = useState<RosterStudent[]>([])
+  const [selectedClass, setSelectedClass] = useState<RosterClass | null>(null)
+  const [loadingClasses, setLoadingClasses] = useState(false)
+  const [loadingStudents, setLoadingStudents] = useState(false)
+
+  const handleSchoolChange = async (value: string) => {
+    setSchoolId(value)
+    setClasses([])
+    setStudents([])
+    setSelectedClass(null)
+    setLoadingClasses(true)
+    const result = await listRosterClassesAction(value)
+    setLoadingClasses(false)
+    if (result.isSuccess) {
+      setClasses(result.data)
+    } else {
+      toast({
+        title: "Classes unavailable",
+        description: result.message,
+        variant: "destructive",
+      })
+    }
+  }
+
+  const handleViewRoster = async (rosterClass: RosterClass) => {
+    setSelectedClass(rosterClass)
+    setStudents([])
+    setLoadingStudents(true)
+    const result = await listRosterStudentsAction(rosterClass.sourcedId)
+    setLoadingStudents(false)
+    if (result.isSuccess) {
+      setStudents(result.data)
+    } else {
+      toast({
+        title: "Class roster unavailable",
+        description: result.message,
+        variant: "destructive",
+      })
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      <Card>
+        <CardHeader>
+          <CardTitle>Browse the synced roster</CardTitle>
+          <CardDescription>
+            Select a school, inspect its classes and teachers of record, then
+            open a read-only student roster.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="max-w-xl space-y-2">
+            <Label>School</Label>
+            <Select value={schoolId} onValueChange={handleSchoolChange}>
+              <SelectTrigger data-testid="roster-school-select">
+                <SelectValue placeholder="Select a school" />
+              </SelectTrigger>
+              <SelectContent>
+                {data.schools.map(school => (
+                  <SelectItem key={school.sourcedId} value={school.sourcedId}>
+                    {school.name ?? school.sourcedId}
+                    {school.isActive ? "" : " (inactive)"}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            {data.schools.length === 0 && (
+              <p
+                className="text-sm text-muted-foreground"
+                data-testid="roster-schools-empty"
+              >
+                No synced schools yet.
+              </p>
+            )}
+          </div>
+        </CardContent>
+      </Card>
+
+      {schoolId && (
+        <RosterClassesCard
+          classes={classes}
+          loading={loadingClasses}
+          onViewRoster={handleViewRoster}
+        />
+      )}
+
+      {selectedClass && (
+        <RosterStudentsCard
+          rosterClass={selectedClass}
+          students={students}
+          loading={loadingStudents}
+        />
+      )}
+    </div>
+  )
+}
+
+interface RosterClassesCardProps {
+  classes: RosterClass[]
+  loading: boolean
+  onViewRoster: (rosterClass: RosterClass) => void
+}
+
+function RosterClassesCard({
+  classes,
+  loading,
+  onViewRoster,
+}: RosterClassesCardProps) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Classes</CardTitle>
+      </CardHeader>
+      <CardContent className="p-0">
+        {loading ? (
+          <p className="p-6 text-sm text-muted-foreground">
+            Loading classes…
+          </p>
+        ) : classes.length === 0 ? (
+          <p className="p-6 text-sm text-muted-foreground">
+            No classes are linked to this school.
+          </p>
+        ) : (
+          <Table data-testid="roster-classes-table">
+            <TableHeader>
+              <TableRow>
+                <TableHead>Class</TableHead>
+                <TableHead>Term</TableHead>
+                <TableHead>Teacher of record</TableHead>
+                <TableHead>Students</TableHead>
+                <TableHead>Status</TableHead>
+                <TableHead className="text-right">Roster</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {classes.map(rosterClass => (
+                <TableRow
+                  key={rosterClass.sourcedId}
+                  data-testid={`roster-class-${rosterClass.sourcedId}`}
+                >
+                  <TableCell>
+                    <div className="font-medium">
+                      {rosterClass.title ?? rosterClass.sourcedId}
+                    </div>
+                    <div className="text-xs text-muted-foreground">
+                      {rosterClass.classCode ?? rosterClass.location ?? ""}
+                    </div>
+                  </TableCell>
+                  <TableCell>{rosterClass.terms.join(", ") || "—"}</TableCell>
+                  <TableCell>
+                    {rosterClass.teachers.join(", ") || "—"}
+                  </TableCell>
+                  <TableCell>{rosterClass.studentCount}</TableCell>
+                  <TableCell>
+                    <Badge
+                      variant={rosterClass.isActive ? "default" : "secondary"}
+                    >
+                      {rosterClass.isActive ? "Active" : "Inactive"}
+                    </Badge>
+                  </TableCell>
+                  <TableCell className="text-right">
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => onViewRoster(rosterClass)}
+                      data-testid={`view-roster-${rosterClass.sourcedId}`}
+                    >
+                      <Users className="mr-2 h-4 w-4" />
+                      View
+                    </Button>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        )}
+      </CardContent>
+    </Card>
+  )
+}
+
+interface RosterStudentsCardProps {
+  rosterClass: RosterClass
+  students: RosterStudent[]
+  loading: boolean
+}
+
+function RosterStudentsCard({
+  rosterClass,
+  students,
+  loading,
+}: RosterStudentsCardProps) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>
+          {rosterClass.title ?? rosterClass.sourcedId} roster
+        </CardTitle>
+        <CardDescription>
+          Student enrollment and user status are shown separately so
+          referential or deactivation drift is visible.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="p-0">
+        {loading ? (
+          <p className="p-6 text-sm text-muted-foreground">
+            Loading students…
+          </p>
+        ) : students.length === 0 ? (
+          <p className="p-6 text-sm text-muted-foreground">
+            No student enrollments are present for this class.
+          </p>
+        ) : (
+          <RosterStudentsTable students={students} />
+        )}
+      </CardContent>
+    </Card>
+  )
+}
+
+function RosterStudentsTable({
+  students,
+}: {
+  students: RosterStudent[]
+}) {
+  return (
+    <Table data-testid="roster-students-table">
+      <TableHeader>
+        <TableRow>
+          <TableHead>Student</TableHead>
+          <TableHead>Email</TableHead>
+          <TableHead>Primary</TableHead>
+          <TableHead>Enrollment</TableHead>
+          <TableHead>User</TableHead>
+          <TableHead>Last synced</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {students.map(student => (
+          <TableRow key={student.enrollmentSourcedId}>
+            <TableCell className="font-medium">
+              {displayName(student)}
+            </TableCell>
+            <TableCell>{student.email ?? "—"}</TableCell>
+            <TableCell>{student.isPrimary ? "Yes" : "No"}</TableCell>
+            <TableCell>
+              <Badge
+                variant={student.enrollmentActive ? "default" : "secondary"}
+              >
+                {student.enrollmentActive ? "Active" : "Inactive"}
+              </Badge>
+            </TableCell>
+            <TableCell>
+              <Badge
+                variant={
+                  student.userActive === false ? "secondary" : "default"
+                }
+              >
+                {student.userActive === null
+                  ? "Missing"
+                  : student.userActive
+                    ? "Active"
+                    : "Inactive"}
+              </Badge>
+            </TableCell>
+            <TableCell>{formatDate(student.lastSyncedAt)}</TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  )
+}

--- a/app/(protected)/admin/rosters/page.tsx
+++ b/app/(protected)/admin/rosters/page.tsx
@@ -1,0 +1,40 @@
+import { adminPageMetadata } from "../_lib/admin-pages"
+import { requireRole } from "@/lib/auth/role-helpers"
+import { PageBranding } from "@/components/ui/page-branding"
+import { getOneRosterAdminDataAction } from "@/actions/db/roster-admin-actions"
+import { RostersAdmin } from "./_components/rosters-admin"
+
+/**
+ * ClassLink OneRoster administrator control surface (Epic #1308 / #1311).
+ *
+ * The page and every backing server action are administrator-gated. Synced
+ * roster data is read-only here; only the isolated Lambda mutates it.
+ */
+export const dynamic = "force-dynamic"
+
+export const metadata = adminPageMetadata("/admin/rosters")
+
+export default async function RostersAdminPage() {
+  await requireRole("administrator")
+
+  const result = await getOneRosterAdminDataAction()
+  const data = result.isSuccess ? result.data : null
+  const error = !result.isSuccess
+    ? result.message ?? "Failed to load OneRoster data"
+    : null
+
+  return (
+    <div className="p-6">
+      <div className="mb-6">
+        <PageBranding />
+        <h1 className="text-2xl font-semibold text-foreground">Rosters</h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Configure ClassLink, run the nightly OneRoster import on demand, and
+          inspect the read-only school, class, and enrollment snapshot.
+        </p>
+      </div>
+
+      <RostersAdmin initialData={data} initialError={error} />
+    </div>
+  )
+}

--- a/docs/features/oneroster-classlink-sync.md
+++ b/docs/features/oneroster-classlink-sync.md
@@ -150,8 +150,10 @@ layers. It has three tabs:
 - **Sync** shows active/inactive totals and last-sync timestamps for all six
   collections. **Sync now** writes a unique queued run ID, invokes the same
   Lambda used by EventBridge, and polls `ONEROSTER_SYNC_STATUS` until that run
-  succeeds, fails, skips, or times out. A client-side in-flight ref prevents
-  two same-tick clicks from dispatching duplicate runs.
+  succeeds, fails, skips, or times out. Nonterminal status rows older than the
+  one-hour Lambda execution-and-retry window are shown as timed out and no
+  longer block a manual retry. A client-side in-flight ref prevents two
+  same-tick clicks from dispatching duplicate runs.
 - **Roster browser** lazily reads schools, their classes (including active term,
   teacher-of-record, and student count), and each class's student enrollments.
   It never edits sync-owned rows.

--- a/docs/features/oneroster-classlink-sync.md
+++ b/docs/features/oneroster-classlink-sync.md
@@ -1,9 +1,10 @@
 # ClassLink OneRoster synchronization
 
-Status: v1 ingestion foundation implemented by Epic
+Status: v1 ingestion foundation and administrator control surface implemented by Epic
 [#1308](https://github.com/psd401/aistudio/issues/1308), Issue
-[#1310](https://github.com/psd401/aistudio/issues/1310). The administrator UI,
-role mapping, room provisioning, and reporting are separate workstreams.
+[#1310](https://github.com/psd401/aistudio/issues/1310), and Issue
+[#1311](https://github.com/psd401/aistudio/issues/1311). Role mapping, room
+provisioning, and reporting are separate workstreams.
 
 ## Scope and data boundary
 
@@ -129,9 +130,36 @@ All values are database-first. The Next.js accessors in
 | `ONEROSTER_API_VERSION` | no | `v1p1` | `v1p1` or `v1p2`. |
 | `ONEROSTER_PAGE_SIZE` | no | `10000` | Integer from 1 through 10,000. |
 | `ONEROSTER_LAST_PERM_REV` | internal | none | Last fully applied ClassLink revision; do not edit during normal operation. |
+| `ONEROSTER_SYNC_STATUS` | internal | none | Sanitized queued/running/terminal status used by `/admin/rosters`; do not edit during normal operation. |
 
 Set the URL, auth mode, secret ARN, version, and page size before enabling the
 schedule. A missing or incomplete configuration safely skips the invocation.
+
+## Administrator control surface
+
+`/admin/rosters` is administrator-only at both the page and server-action
+layers. It has three tabs:
+
+- **Settings** stores the six operator-managed values above in one database
+  transaction. The base URL must use HTTPS, the auth mode is limited to
+  `oauth1` or `proxy`, the API path is limited to `v1p1` or `v1p2`, the page
+  size is 1–10,000, and the secret ARN must match the
+  `aistudio-{environment}-oneroster-*` family. There is intentionally no token
+  URL or generic client-credentials configuration.
+- **Sync** shows active/inactive totals and last-sync timestamps for all six
+  collections. **Sync now** writes a unique queued run ID, invokes the same
+  Lambda used by EventBridge, and polls `ONEROSTER_SYNC_STATUS` until that run
+  succeeds, fails, skips, or times out. A client-side in-flight ref prevents
+  two same-tick clicks from dispatching duplicate runs.
+- **Roster browser** lazily reads schools, their classes (including active term,
+  teacher-of-record, and student count), and each class's student enrollments.
+  It never edits sync-owned rows.
+
+The status value contains timestamps, state, collection counts, and a bounded
+sanitized error message only. It never contains credentials, response bodies,
+or roster records. Failure to write dashboard status does not fail an otherwise
+safe roster reconciliation; Lambda error and staleness alarms remain the
+fallback.
 
 ## Consistency and deletion invariants
 
@@ -198,13 +226,14 @@ Manual invocation uses an asynchronous event:
 ```json
 {
   "trigger": "manual",
-  "requestedByUserId": 123
+  "requestedByUserId": 123,
+  "runId": "3a67d19e-..."
 }
 ```
 
 Use `triggerOneRosterSyncNow()` from application code so the deterministic
-function name and audit payload stay consistent. The ECS task role has invoke
-permission only for that named function (alongside its existing explicit
+function name, run ID, and audit payload stay consistent. The ECS task role has
+invoke permission only for that named function (alongside its existing explicit
 Lambda grants).
 
 ## Verification
@@ -248,9 +277,15 @@ Roll out disabled:
    changed.
 5. Set `ROSTER_SYNC_ENABLED=true`.
 
-To stop ingestion, set `ROSTER_SYNC_ENABLED=false`. Existing roster rows remain
+To stop ingestion, set `ROSTER_SYNC_ENABLED=false` in `/admin/rosters`.
+Existing roster rows remain
 as the last-known-good snapshot. For a code rollback, deploy the previous
 Processing stack version; migration 141 and the `oneroster_*` tables are
 additive and may remain in place. Do not clear rows or the revision checkpoint
 as part of routine rollback. If a credential may be exposed, rotate it in
 ClassLink and Secrets Manager before re-enabling the integration.
+
+To remove only the administrator UI, remove its `ADMIN_SECTIONS` registry entry
+and route. The settings and last-known-good roster snapshot can remain. Older
+Lambda versions ignore `ONEROSTER_SYNC_STATUS`; removing that internal settings
+row is optional and must not be coupled to roster-row deletion.

--- a/docs/features/oneroster-classlink-sync.md
+++ b/docs/features/oneroster-classlink-sync.md
@@ -151,9 +151,11 @@ layers. It has three tabs:
   collections. **Sync now** writes a unique queued run ID, invokes the same
   Lambda used by EventBridge, and polls `ONEROSTER_SYNC_STATUS` until that run
   succeeds, fails, skips, or times out. Nonterminal status rows older than the
-  one-hour Lambda execution-and-retry window are shown as timed out and no
-  longer block a manual retry. A client-side in-flight ref prevents two
-  same-tick clicks from dispatching duplicate runs.
+  one-hour Lambda dispatch-and-execution window are shown as timed out and no
+  longer block a manual retry. Lambda's implicit asynchronous retries are
+  disabled so a persisted terminal failure is final; operators retry manually,
+  and the nightly schedule remains the unattended retry path. A client-side
+  in-flight ref prevents two same-tick clicks from dispatching duplicate runs.
 - **Roster browser** lazily reads schools, their classes (including active term,
   teacher-of-record, and student count), and each class's student enrollments.
   It never edits sync-owned rows.

--- a/docs/features/oneroster-classlink-sync.md
+++ b/docs/features/oneroster-classlink-sync.md
@@ -143,9 +143,10 @@ layers. It has three tabs:
 - **Settings** stores the six operator-managed values above in one database
   transaction. The base URL must use HTTPS, the auth mode is limited to
   `oauth1` or `proxy`, the API path is limited to `v1p1` or `v1p2`, the page
-  size is 1–10,000, and the secret ARN must match the
-  `aistudio-{environment}-oneroster-*` family. There is intentionally no token
-  URL or generic client-credentials configuration.
+  size is 1–10,000, and the secret ARN must match the current deployment's
+  environment, region, account, and `aistudio-{environment}-oneroster-*`
+  family. There is intentionally no token URL or generic client-credentials
+  configuration.
 - **Sync** shows active/inactive totals and last-sync timestamps for all six
   collections. **Sync now** writes a unique queued run ID, invokes the same
   Lambda used by EventBridge, and polls `ONEROSTER_SYNC_STATUS` until that run

--- a/infra/lambdas/oneroster-sync/config.ts
+++ b/infra/lambdas/oneroster-sync/config.ts
@@ -18,6 +18,8 @@ export const ONEROSTER_SETTING_KEYS = {
   pageSize: "ONEROSTER_PAGE_SIZE",
   /** Internal sync checkpoint; not an administrator-entered credential/config. */
   lastPermRev: "ONEROSTER_LAST_PERM_REV",
+  /** Internal run status consumed by the administrator dashboard poll. */
+  syncStatus: "ONEROSTER_SYNC_STATUS",
 } as const;
 
 export type OneRosterAuthMode = "oauth1" | "proxy";

--- a/infra/lambdas/oneroster-sync/db.integration.test.ts
+++ b/infra/lambdas/oneroster-sync/db.integration.test.ts
@@ -8,7 +8,7 @@
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "bun:test";
 import { readFileSync } from "node:fs";
 import postgres from "postgres";
-import { reconcileCollection } from "./db";
+import { reconcileCollection, writeSyncStatus } from "./db";
 import type { CollectionPullSuccess } from "./oneroster-client";
 
 const databaseUrl = process.env.ONEROSTER_DB_TEST_URL;
@@ -33,6 +33,16 @@ describeDatabase("OneRoster PostgreSQL reconciliation", () => {
     if (!sql) return;
     await sql.unsafe(`
       CREATE EXTENSION IF NOT EXISTS pgcrypto;
+      CREATE TABLE IF NOT EXISTS settings (
+        id serial PRIMARY KEY,
+        key varchar(255) NOT NULL UNIQUE,
+        value text,
+        description text,
+        category varchar(100),
+        is_secret boolean DEFAULT false,
+        created_at timestamp DEFAULT now(),
+        updated_at timestamp DEFAULT now()
+      );
       CREATE OR REPLACE FUNCTION update_updated_at_column()
       RETURNS TRIGGER AS $$
       BEGIN
@@ -61,6 +71,9 @@ describeDatabase("OneRoster PostgreSQL reconciliation", () => {
         oneroster_academic_sessions,
         oneroster_orgs
     `);
+    await sql`
+      DELETE FROM settings WHERE key = 'ONEROSTER_SYNC_STATUS'
+    `;
   });
 
   afterAll(async () => {
@@ -165,5 +178,36 @@ describeDatabase("OneRoster PostgreSQL reconciliation", () => {
         last_synced_at: expect.any(Date),
       })
     );
+  });
+
+  it("upserts the durable administrator sync status without marking it secret", async () => {
+    if (!sql) throw new Error("database connection was not initialized");
+    const status = {
+      runId: "integration-run",
+      trigger: "manual",
+      state: "succeeded",
+      startedAt: "2026-07-26T18:00:00.000Z",
+      completedAt: "2026-07-26T18:01:00.000Z",
+      unchanged: false,
+      collections: [],
+      error: null,
+    };
+
+    await writeSyncStatus(sql, status);
+    const [row] = await sql<
+      Array<{
+        value: string;
+        category: string | null;
+        is_secret: boolean | null;
+      }>
+    >`
+      SELECT value, category, is_secret
+        FROM settings
+       WHERE key = 'ONEROSTER_SYNC_STATUS'
+    `;
+
+    expect(JSON.parse(row.value)).toEqual(status);
+    expect(row.category).toBe("integrations");
+    expect(row.is_secret).toBe(false);
   });
 });

--- a/infra/lambdas/oneroster-sync/db.ts
+++ b/infra/lambdas/oneroster-sync/db.ts
@@ -30,6 +30,8 @@ import type { CollectionPullSuccess } from "./oneroster-client";
 const secretsClient = new SecretsManagerClient({});
 const UPSERT_CHUNK_SIZE = 4_000;
 const LAST_PERM_REV_SETTING_KEY = "ONEROSTER_LAST_PERM_REV";
+// Keep synchronized with lib/roster/settings.ts and config.ts.
+const SYNC_STATUS_SETTING_KEY = "ONEROSTER_SYNC_STATUS";
 
 let sqlSingleton: postgres.Sql | null = null;
 let initPromise: Promise<postgres.Sql> | null = null;
@@ -119,6 +121,34 @@ export async function writeLastPermRev(
     ON CONFLICT (key) DO UPDATE
       SET value = EXCLUDED.value,
           description = EXCLUDED.description,
+          updated_at = now()
+  `;
+}
+
+export async function writeSyncStatus(
+  sql: postgres.Sql,
+  status: unknown
+): Promise<void> {
+  await sql`
+    INSERT INTO settings (
+      key,
+      value,
+      description,
+      category,
+      is_secret
+    )
+    VALUES (
+      ${SYNC_STATUS_SETTING_KEY},
+      ${JSON.stringify(status)},
+      'Internal OneRoster sync run status for the administrator dashboard',
+      'integrations',
+      false
+    )
+    ON CONFLICT (key) DO UPDATE
+      SET value = EXCLUDED.value,
+          description = EXCLUDED.description,
+          category = EXCLUDED.category,
+          is_secret = false,
           updated_at = now()
   `;
 }

--- a/infra/lambdas/oneroster-sync/index.ts
+++ b/infra/lambdas/oneroster-sync/index.ts
@@ -75,6 +75,9 @@ interface PersistedSyncStatus {
   error: string | null;
 }
 
+const INCOMPLETE_SYNC_ERROR =
+  "OneRoster sync was incomplete; failed collections retain last-known-good rows";
+
 export async function handler(
   event: OneRosterSyncEvent = {}
 ): Promise<HandlerResult> {
@@ -155,9 +158,7 @@ export async function handler(
     await emitMetrics(result);
     metricsEmitted = true;
     if (!result.fullySuccessful) {
-      throw new Error(
-        "OneRoster sync was incomplete; failed collections retain last-known-good rows"
-      );
+      throw new Error(INCOMPLETE_SYNC_ERROR);
     }
     log.info("OneRoster sync completed", {
       unchanged: result.unchanged,
@@ -173,9 +174,14 @@ export async function handler(
     );
     return { status: "ok", result };
   } catch (error) {
+    const thrownErrorMessage = safeErrorMessage(error);
+    const collectionError = syncResult?.collections.find(
+      (collection) => collection.failed > 0
+    )?.error;
     const errorMessage =
-      syncResult?.collections.find((collection) => collection.failed > 0)
-        ?.error ?? safeErrorMessage(error);
+      thrownErrorMessage === INCOMPLETE_SYNC_ERROR && collectionError
+        ? collectionError
+        : thrownErrorMessage;
     log.error("OneRoster sync failed", { error: errorMessage, runId });
     if (!metricsEmitted) {
       await emitMetrics(null).catch(() => {});

--- a/infra/lambdas/oneroster-sync/index.ts
+++ b/infra/lambdas/oneroster-sync/index.ts
@@ -6,6 +6,7 @@
  * exception. Credentials are read from Secrets Manager and never logged.
  */
 
+import { randomUUID } from "node:crypto";
 import {
   CloudWatchClient,
   PutMetricDataCommand,
@@ -22,6 +23,7 @@ import {
   readLastPermRev,
   reconcileCollection,
   writeLastPermRev,
+  writeSyncStatus,
 } from "./db";
 import { OneRosterClient } from "./oneroster-client";
 import { runOneRosterSync, type OneRosterSyncResult } from "./sync";
@@ -45,6 +47,7 @@ const log = {
 interface OneRosterSyncEvent {
   trigger?: string;
   requestedByUserId?: number | null;
+  runId?: string;
 }
 
 interface HandlerResult {
@@ -53,25 +56,79 @@ interface HandlerResult {
   result?: OneRosterSyncResult;
 }
 
+type SyncState = "running" | "succeeded" | "failed" | "skipped";
+
+interface PersistedSyncStatus {
+  runId: string;
+  trigger: "manual" | "schedule";
+  state: SyncState;
+  startedAt: string;
+  completedAt: string | null;
+  unchanged: boolean;
+  collections: Array<{
+    name: string;
+    recordsTotal: number;
+    synced: number;
+    deactivated: number;
+    failed: number;
+  }>;
+  error: string | null;
+}
+
 export async function handler(
   event: OneRosterSyncEvent = {}
 ): Promise<HandlerResult> {
   const manual = event.trigger === "manual";
+  const trigger = manual ? "manual" : "schedule";
+  const runId = resolveRunId(event.runId);
+  const startedAt = new Date().toISOString();
   let metricsEmitted = false;
+  let syncResult: OneRosterSyncResult | null = null;
   log.info("OneRoster sync invoked", {
-    trigger: manual ? "manual" : "schedule",
+    trigger,
     requestedByUserId: event.requestedByUserId ?? null,
+    runId,
   });
 
   const sql = await getSql();
   try {
+    await writeStatusSafely(sql, {
+      runId,
+      trigger,
+      state: "running",
+      startedAt,
+      completedAt: null,
+      unchanged: false,
+      collections: [],
+      error: null,
+    });
     const config = await resolveConfig(sql);
     if (!config.baseUrl || !config.authMode || !config.credentialsSecretArn) {
       log.warn("OneRoster sync is not fully configured; skipping");
+      await writeStatusSafely(sql, {
+        runId,
+        trigger,
+        state: "skipped",
+        startedAt,
+        completedAt: new Date().toISOString(),
+        unchanged: false,
+        collections: [],
+        error: "OneRoster settings are incomplete.",
+      });
       return { status: "skipped", reason: "not-configured" };
     }
     if (!manual && !config.enabled) {
       log.info("Nightly OneRoster sync is disabled; skipping");
+      await writeStatusSafely(sql, {
+        runId,
+        trigger,
+        state: "skipped",
+        startedAt,
+        completedAt: new Date().toISOString(),
+        unchanged: false,
+        collections: [],
+        error: "Scheduled OneRoster synchronization is disabled.",
+      });
       return { status: "skipped", reason: "disabled" };
     }
 
@@ -93,6 +150,7 @@ export async function handler(
       writeLastPermRev: (permRev) => writeLastPermRev(sql, permRev),
       log,
     });
+    syncResult = result;
 
     await emitMetrics(result);
     metricsEmitted = true;
@@ -109,15 +167,77 @@ export async function handler(
         0
       ),
     });
+    await writeStatusSafely(
+      sql,
+      statusFromResult(runId, trigger, startedAt, "succeeded", result, null)
+    );
     return { status: "ok", result };
   } catch (error) {
-    log.error("OneRoster sync failed", { error: safeErrorMessage(error) });
+    const errorMessage =
+      syncResult?.collections.find((collection) => collection.failed > 0)
+        ?.error ?? safeErrorMessage(error);
+    log.error("OneRoster sync failed", { error: errorMessage, runId });
     if (!metricsEmitted) {
       await emitMetrics(null).catch(() => {});
     }
+    await writeStatusSafely(
+      sql,
+      statusFromResult(
+        runId,
+        trigger,
+        startedAt,
+        "failed",
+        syncResult,
+        errorMessage
+      )
+    );
     throw error;
   } finally {
     await closeSql().catch(() => {});
+  }
+}
+
+function statusFromResult(
+  runId: string,
+  trigger: "manual" | "schedule",
+  startedAt: string,
+  state: "succeeded" | "failed",
+  result: OneRosterSyncResult | null,
+  error: string | null
+): PersistedSyncStatus {
+  return {
+    runId,
+    trigger,
+    state,
+    startedAt,
+    completedAt: new Date().toISOString(),
+    unchanged: result?.unchanged ?? false,
+    collections:
+      result?.collections.map((collection) => ({
+        name: collection.name,
+        recordsTotal: collection.recordsTotal,
+        synced: collection.synced,
+        deactivated: collection.deactivated,
+        failed: collection.failed,
+      })) ?? [],
+    error: error ? safeErrorMessage(error) : null,
+  };
+}
+
+async function writeStatusSafely(
+  sql: Awaited<ReturnType<typeof getSql>>,
+  status: PersistedSyncStatus
+): Promise<void> {
+  try {
+    await writeSyncStatus(sql, status);
+  } catch (error) {
+    // Dashboard observability must never turn a safe roster reconciliation into
+    // a failed run. The Lambda error/staleness alarms remain the fallback.
+    log.warn("Failed to persist OneRoster sync status", {
+      runId: status.runId,
+      state: status.state,
+      error: safeErrorMessage(error),
+    });
   }
 }
 
@@ -220,5 +340,13 @@ async function emitMetrics(result: OneRosterSyncResult | null): Promise<void> {
 
 function safeErrorMessage(error: unknown): string {
   const message = error instanceof Error ? error.message : String(error);
-  return message.length > 500 ? `${message.slice(0, 500)}…` : message;
+  return message.length > 500 ? `${message.slice(0, 499)}…` : message;
+}
+
+function resolveRunId(value: unknown): string {
+  if (typeof value !== "string") return randomUUID();
+  const normalized = value.trim();
+  return normalized.length > 0 && normalized.length <= 100
+    ? normalized
+    : randomUUID();
 }

--- a/infra/lambdas/oneroster-sync/oneroster-client.ts
+++ b/infra/lambdas/oneroster-sync/oneroster-client.ts
@@ -375,7 +375,7 @@ function retryAfterMilliseconds(value: string | null): number | null {
 
 function safeErrorMessage(error: unknown): string {
   const message = error instanceof Error ? error.message : String(error);
-  return message.length > 500 ? `${message.slice(0, 500)}…` : message;
+  return message.length > 500 ? `${message.slice(0, 499)}…` : message;
 }
 
 async function defaultTransport(

--- a/infra/lambdas/oneroster-sync/sync.ts
+++ b/infra/lambdas/oneroster-sync/sync.ts
@@ -188,5 +188,5 @@ export async function runOneRosterSync(
 
 function safeErrorMessage(error: unknown): string {
   const message = error instanceof Error ? error.message : String(error);
-  return message.length > 500 ? `${message.slice(0, 500)}…` : message;
+  return message.length > 500 ? `${message.slice(0, 499)}…` : message;
 }

--- a/infra/lib/processing-stack.ts
+++ b/infra/lib/processing-stack.ts
@@ -911,6 +911,10 @@ export class ProcessingStack extends cdk.Stack {
         },
       ),
       timeout: cdk.Duration.minutes(15),
+      // A persisted failed status must be terminal. Implicit async retries can
+      // otherwise overlap with a new manual run between attempts.
+      retryAttempts: 0,
+      maxEventAge: cdk.Duration.minutes(30),
       memorySize: 1024,
       architecture: lambda.Architecture.ARM_64,
       vpc,

--- a/infra/test/unit/processing-stack-embedding-access.test.ts
+++ b/infra/test/unit/processing-stack-embedding-access.test.ts
@@ -148,6 +148,10 @@ describe('ProcessingStack embedding visual-artifact access', () => {
         { Key: 'ManagedBy', Value: 'cdk' },
       ]),
     });
+    template.hasResourceProperties('AWS::Lambda::EventInvokeConfig', {
+      MaximumRetryAttempts: 0,
+      MaximumEventAgeInSeconds: 1_800,
+    });
     template.hasResourceProperties('AWS::Events::Rule', {
       Description: 'Nightly ClassLink OneRoster full sync (#1310)',
       ScheduleExpression: 'cron(0 10 * * ? *)',

--- a/lib/roster/queries.ts
+++ b/lib/roster/queries.ts
@@ -1,0 +1,328 @@
+/**
+ * Read-only OneRoster accessors for the administrator roster browser.
+ *
+ * The sync Lambda exclusively owns roster writes. These queries expose bounded
+ * school/class/roster views and aggregate collection health without copying
+ * raw roster records into logs or application-owned tables.
+ */
+
+import { and, asc, desc, eq, sql } from "drizzle-orm";
+import { alias } from "drizzle-orm/pg-core";
+import { executeQuery } from "@/lib/db/drizzle-client";
+import {
+  onerosterAcademicSessions,
+  onerosterClasses,
+  onerosterClassTerms,
+  onerosterCourses,
+  onerosterEnrollments,
+  onerosterOrgs,
+  onerosterUsers,
+} from "@/lib/db/schema";
+import {
+  getOneRosterSyncStatus,
+  type OneRosterCollectionName,
+  type OneRosterSyncStatus,
+} from "./status";
+
+export interface RosterCollectionSummary {
+  name: OneRosterCollectionName;
+  total: number;
+  active: number;
+  inactive: number;
+  lastSyncedAt: Date | null;
+}
+
+export interface OneRosterSyncOverview {
+  collections: RosterCollectionSummary[];
+  lastRunAt: Date | null;
+  status: OneRosterSyncStatus | null;
+}
+
+export interface RosterSchool {
+  sourcedId: string;
+  name: string | null;
+  identifier: string | null;
+  isActive: boolean;
+  lastSyncedAt: Date | null;
+}
+
+export interface RosterClass {
+  sourcedId: string;
+  title: string | null;
+  classCode: string | null;
+  location: string | null;
+  isActive: boolean;
+  lastSyncedAt: Date | null;
+  terms: string[];
+  teachers: string[];
+  studentCount: number;
+}
+
+export interface RosterStudent {
+  enrollmentSourcedId: string;
+  userSourcedId: string | null;
+  email: string | null;
+  givenName: string | null;
+  familyName: string | null;
+  isPrimary: boolean | null;
+  enrollmentActive: boolean;
+  userActive: boolean | null;
+  lastSyncedAt: Date | null;
+}
+
+const aggregateSelection = <T extends {
+  isActive: unknown;
+  lastSyncedAt: unknown;
+}>(table: T) => ({
+  total: sql<number>`count(*)::int`,
+  active: sql<number>`count(*) filter (where ${table.isActive})::int`,
+  lastSyncedAt: sql<Date | null>`max(${table.lastSyncedAt})`,
+});
+
+export async function getOneRosterSyncOverview(): Promise<OneRosterSyncOverview> {
+  const [
+    orgRows,
+    sessionRows,
+    courseRows,
+    classRows,
+    userRows,
+    enrollmentRows,
+    status,
+  ] = await Promise.all([
+    executeQuery(
+      (db) => db.select(aggregateSelection(onerosterOrgs)).from(onerosterOrgs),
+      "getOneRosterSyncOverview:orgs"
+    ),
+    executeQuery(
+      (db) =>
+        db
+          .select(aggregateSelection(onerosterAcademicSessions))
+          .from(onerosterAcademicSessions),
+      "getOneRosterSyncOverview:academicSessions"
+    ),
+    executeQuery(
+      (db) =>
+        db.select(aggregateSelection(onerosterCourses)).from(onerosterCourses),
+      "getOneRosterSyncOverview:courses"
+    ),
+    executeQuery(
+      (db) =>
+        db.select(aggregateSelection(onerosterClasses)).from(onerosterClasses),
+      "getOneRosterSyncOverview:classes"
+    ),
+    executeQuery(
+      (db) => db.select(aggregateSelection(onerosterUsers)).from(onerosterUsers),
+      "getOneRosterSyncOverview:users"
+    ),
+    executeQuery(
+      (db) =>
+        db
+          .select(aggregateSelection(onerosterEnrollments))
+          .from(onerosterEnrollments),
+      "getOneRosterSyncOverview:enrollments"
+    ),
+    getOneRosterSyncStatus(),
+  ]);
+
+  const rows = [
+    ["orgs", orgRows[0]],
+    ["academicSessions", sessionRows[0]],
+    ["courses", courseRows[0]],
+    ["classes", classRows[0]],
+    ["users", userRows[0]],
+    ["enrollments", enrollmentRows[0]],
+  ] as const;
+  const collections = rows.map(([name, row]) => {
+    const total = row?.total ?? 0;
+    const active = row?.active ?? 0;
+    return {
+      name,
+      total,
+      active,
+      inactive: Math.max(0, total - active),
+      lastSyncedAt: row?.lastSyncedAt ?? null,
+    };
+  });
+  const completedAt = status?.completedAt ? new Date(status.completedAt) : null;
+  const tableLastRun = collections.reduce<Date | null>((latest, collection) => {
+    if (!collection.lastSyncedAt) return latest;
+    return !latest || collection.lastSyncedAt > latest
+      ? collection.lastSyncedAt
+      : latest;
+  }, null);
+
+  return {
+    collections,
+    lastRunAt:
+      completedAt && (!tableLastRun || completedAt > tableLastRun)
+        ? completedAt
+        : tableLastRun,
+    status,
+  };
+}
+
+export async function listRosterSchools(): Promise<RosterSchool[]> {
+  return executeQuery(
+    (db) =>
+      db
+        .select({
+          sourcedId: onerosterOrgs.sourcedId,
+          name: onerosterOrgs.name,
+          identifier: onerosterOrgs.identifier,
+          isActive: onerosterOrgs.isActive,
+          lastSyncedAt: onerosterOrgs.lastSyncedAt,
+        })
+        .from(onerosterOrgs)
+        .where(sql`lower(coalesce(${onerosterOrgs.type}, '')) = 'school'`)
+        .orderBy(desc(onerosterOrgs.isActive), asc(onerosterOrgs.name)),
+    "listRosterSchools"
+  );
+}
+
+export async function listRosterClasses(
+  schoolSourcedId: string
+): Promise<RosterClass[]> {
+  const teacherEnrollments = alias(
+    onerosterEnrollments,
+    "roster_teacher_enrollments"
+  );
+  const teacherUsers = alias(onerosterUsers, "roster_teacher_users");
+  const studentEnrollments = alias(
+    onerosterEnrollments,
+    "roster_student_enrollments"
+  );
+
+  return executeQuery(
+    (db) =>
+      db
+        .select({
+          sourcedId: onerosterClasses.sourcedId,
+          title: onerosterClasses.title,
+          classCode: onerosterClasses.classCode,
+          location: onerosterClasses.location,
+          isActive: onerosterClasses.isActive,
+          lastSyncedAt: onerosterClasses.lastSyncedAt,
+          terms: sql<string[]>`
+            coalesce(
+              array_agg(distinct ${onerosterAcademicSessions.title})
+                filter (
+                  where ${onerosterClassTerms.isActive}
+                    and ${onerosterAcademicSessions.isActive}
+                    and ${onerosterAcademicSessions.title} is not null
+                ),
+              '{}'::text[]
+            )
+          `,
+          teachers: sql<string[]>`
+            coalesce(
+              array_agg(
+                distinct trim(
+                  concat_ws(
+                    ' ',
+                    ${teacherUsers.givenName},
+                    ${teacherUsers.familyName}
+                  )
+                )
+              ) filter (
+                where ${teacherEnrollments.isActive}
+                  and ${teacherUsers.isActive}
+                  and lower(coalesce(${teacherEnrollments.role}, '')) = 'teacher'
+                  and (
+                    ${teacherUsers.givenName} is not null
+                    or ${teacherUsers.familyName} is not null
+                  )
+              ),
+              '{}'::text[]
+            )
+          `,
+          studentCount: sql<number>`
+            count(distinct ${studentEnrollments.userSourcedId})
+              filter (
+                where ${studentEnrollments.isActive}
+                  and lower(coalesce(${studentEnrollments.role}, '')) = 'student'
+              )::int
+          `,
+        })
+        .from(onerosterClasses)
+        .leftJoin(
+          onerosterClassTerms,
+          eq(
+            onerosterClassTerms.classSourcedId,
+            onerosterClasses.sourcedId
+          )
+        )
+        .leftJoin(
+          onerosterAcademicSessions,
+          eq(
+            onerosterAcademicSessions.sourcedId,
+            onerosterClassTerms.termSourcedId
+          )
+        )
+        .leftJoin(
+          teacherEnrollments,
+          and(
+            eq(
+              teacherEnrollments.classSourcedId,
+              onerosterClasses.sourcedId
+            ),
+            sql`lower(coalesce(${teacherEnrollments.role}, '')) = 'teacher'`
+          )
+        )
+        .leftJoin(
+          teacherUsers,
+          eq(teacherUsers.sourcedId, teacherEnrollments.userSourcedId)
+        )
+        .leftJoin(
+          studentEnrollments,
+          and(
+            eq(
+              studentEnrollments.classSourcedId,
+              onerosterClasses.sourcedId
+            ),
+            sql`lower(coalesce(${studentEnrollments.role}, '')) = 'student'`
+          )
+        )
+        .where(eq(onerosterClasses.schoolSourcedId, schoolSourcedId))
+        .groupBy(onerosterClasses.id)
+        .orderBy(desc(onerosterClasses.isActive), asc(onerosterClasses.title)),
+    "listRosterClasses"
+  );
+}
+
+export async function listRosterStudents(
+  classSourcedId: string
+): Promise<RosterStudent[]> {
+  return executeQuery(
+    (db) =>
+      db
+        .select({
+          enrollmentSourcedId: onerosterEnrollments.sourcedId,
+          userSourcedId: onerosterEnrollments.userSourcedId,
+          email: onerosterUsers.email,
+          givenName: onerosterUsers.givenName,
+          familyName: onerosterUsers.familyName,
+          isPrimary: onerosterEnrollments.isPrimary,
+          enrollmentActive: onerosterEnrollments.isActive,
+          userActive: onerosterUsers.isActive,
+          lastSyncedAt: onerosterEnrollments.lastSyncedAt,
+        })
+        .from(onerosterEnrollments)
+        .leftJoin(
+          onerosterUsers,
+          eq(onerosterUsers.sourcedId, onerosterEnrollments.userSourcedId)
+        )
+        .where(
+          and(
+            eq(onerosterEnrollments.classSourcedId, classSourcedId),
+            sql`lower(coalesce(${onerosterEnrollments.role}, '')) = 'student'`
+          )
+        )
+        .orderBy(
+          desc(onerosterEnrollments.isActive),
+          asc(onerosterUsers.familyName),
+          asc(onerosterUsers.givenName),
+          asc(onerosterUsers.email)
+        ),
+    "listRosterStudents"
+  );
+}

--- a/lib/roster/settings.ts
+++ b/lib/roster/settings.ts
@@ -33,8 +33,14 @@ export interface OneRosterSettings {
   pageSize: number;
 }
 
+export interface OneRosterDeploymentIdentity {
+  environment: string;
+  region: string | null;
+  accountId: string | null;
+}
+
 const secretArnPattern =
-  /^arn:(?:aws|aws-us-gov|aws-cn):secretsmanager:[a-z0-9-]+:\d{12}:secret:aistudio-[a-z0-9-]+-oneroster-[a-z0-9/_+=.@-]+$/i;
+  /^arn:(?:aws|aws-us-gov|aws-cn):secretsmanager:([a-z0-9-]+):(\d{12}):secret:aistudio-([a-z0-9-]+)-oneroster-[a-z0-9/_+=.@-]+$/i;
 
 export const oneRosterSettingsInputSchema = z.object({
   enabled: z.boolean(),
@@ -85,6 +91,46 @@ export const oneRosterSettingsInputSchema = z.object({
     .min(1, "Page size must be at least 1")
     .max(10_000, "Page size must not exceed 10,000"),
 }).strict();
+
+export function getOneRosterDeploymentIdentity(): OneRosterDeploymentIdentity {
+  return {
+    environment:
+      process.env.ENVIRONMENT ?? process.env.DEPLOY_ENVIRONMENT ?? "dev",
+    region: process.env.AWS_REGION ?? process.env.AWS_DEFAULT_REGION ?? null,
+    accountId: process.env.AWS_ACCOUNT_ID ?? null,
+  };
+}
+
+export function createOneRosterSettingsInputSchema(
+  deployment: OneRosterDeploymentIdentity
+) {
+  return oneRosterSettingsInputSchema.superRefine((value, context) => {
+    const match = secretArnPattern.exec(value.credentialsSecretArn);
+    if (!match) return;
+    const [, region, accountId, environment] = match;
+    const mismatches = [
+      environment.toLowerCase() !== deployment.environment.toLowerCase()
+        ? "environment"
+        : null,
+      deployment.region && region.toLowerCase() !== deployment.region.toLowerCase()
+        ? "region"
+        : null,
+      deployment.accountId && accountId !== deployment.accountId
+        ? "account"
+        : null,
+    ].filter((entry): entry is string => entry !== null);
+
+    if (mismatches.length > 0) {
+      context.addIssue({
+        code: "custom",
+        path: ["credentialsSecretArn"],
+        message: `Secret ARN must belong to this deployment's ${mismatches.join(
+          ", "
+        )}`,
+      });
+    }
+  });
+}
 
 export type OneRosterSettingsInput = z.input<
   typeof oneRosterSettingsInputSchema

--- a/lib/roster/settings.ts
+++ b/lib/roster/settings.ts
@@ -6,6 +6,7 @@
  */
 
 import { getSetting } from "@/lib/settings-manager";
+import { z } from "zod";
 
 export const ONEROSTER_SETTING_KEYS = {
   enabled: "ROSTER_SYNC_ENABLED",
@@ -16,6 +17,8 @@ export const ONEROSTER_SETTING_KEYS = {
   pageSize: "ONEROSTER_PAGE_SIZE",
   /** Lambda-owned revision checkpoint, exposed for key-parity checks only. */
   lastPermRev: "ONEROSTER_LAST_PERM_REV",
+  /** Lambda-owned run status used by the administrator sync-status poll. */
+  syncStatus: "ONEROSTER_SYNC_STATUS",
 } as const;
 
 export type OneRosterAuthMode = "oauth1" | "proxy";
@@ -29,6 +32,66 @@ export interface OneRosterSettings {
   apiVersion: OneRosterApiVersion;
   pageSize: number;
 }
+
+const secretArnPattern =
+  /^arn:(?:aws|aws-us-gov|aws-cn):secretsmanager:[a-z0-9-]+:\d{12}:secret:aistudio-[a-z0-9-]+-oneroster-[a-z0-9/_+=.@-]+$/i;
+
+export const oneRosterSettingsInputSchema = z.object({
+  enabled: z.boolean(),
+  baseUrl: z
+    .string()
+    .trim()
+    .min(1, "ClassLink base URL is required")
+    .transform((value, context) => {
+      try {
+        const parsed = new URL(value);
+        if (parsed.protocol !== "https:") {
+          context.addIssue({
+            code: "custom",
+            message: "ClassLink base URL must use HTTPS",
+          });
+          return z.NEVER;
+        }
+        if (parsed.username || parsed.password) {
+          context.addIssue({
+            code: "custom",
+            message: "ClassLink base URL must not contain credentials",
+          });
+          return z.NEVER;
+        }
+        parsed.hash = "";
+        parsed.search = "";
+        return parsed.toString().replace(/\/+$/, "");
+      } catch {
+        context.addIssue({
+          code: "custom",
+          message: "ClassLink base URL must be a valid URL",
+        });
+        return z.NEVER;
+      }
+    }),
+  authMode: z.enum(["oauth1", "proxy"]),
+  credentialsSecretArn: z
+    .string()
+    .trim()
+    .regex(
+      secretArnPattern,
+      "Secret ARN must match the aistudio-{environment}-oneroster-* family"
+    ),
+  apiVersion: z.enum(["v1p1", "v1p2"]),
+  pageSize: z.coerce
+    .number()
+    .int("Page size must be a whole number")
+    .min(1, "Page size must be at least 1")
+    .max(10_000, "Page size must not exceed 10,000"),
+}).strict();
+
+export type OneRosterSettingsInput = z.input<
+  typeof oneRosterSettingsInputSchema
+>;
+export type ParsedOneRosterSettingsInput = z.output<
+  typeof oneRosterSettingsInputSchema
+>;
 
 export async function getOneRosterSettings(): Promise<OneRosterSettings> {
   const [enabled, baseUrl, authMode, secretArn, apiVersion, pageSize] =

--- a/lib/roster/status.ts
+++ b/lib/roster/status.ts
@@ -46,9 +46,9 @@ export const oneRosterSyncStatusSchema = z.object({
 
 export type OneRosterSyncStatus = z.infer<typeof oneRosterSyncStatusSchema>;
 
-// Lambda async invocation can make the initial attempt plus two retries. With
-// the 15-minute function timeout and the default retry delays, one hour covers
-// the complete execution window while still recovering abandoned status rows.
+// CDK disables implicit async retries and caps queued event age at 30 minutes,
+// so one hour covers dispatch plus the 15-minute execution timeout with margin
+// while still recovering abandoned status rows.
 export const ONEROSTER_SYNC_ACTIVE_WINDOW_MS = 60 * 60 * 1000;
 
 export function isOneRosterSyncStatusActive(

--- a/lib/roster/status.ts
+++ b/lib/roster/status.ts
@@ -1,0 +1,101 @@
+/**
+ * Durable OneRoster sync status shared by the administrator UI.
+ *
+ * The isolated Lambda duplicates this serialized contract deliberately because
+ * its bundle cannot import Next.js application code. Keep the state names and
+ * collection fields synchronized with infra/lambdas/oneroster-sync/index.ts.
+ */
+
+import { z } from "zod";
+import { executeQuery } from "@/lib/db/drizzle-client";
+import { getSettingValue } from "@/lib/db/drizzle/settings";
+import { settings } from "@/lib/db/schema";
+import { ONEROSTER_SETTING_KEYS } from "./settings";
+
+export const oneRosterCollectionNameSchema = z.enum([
+  "orgs",
+  "academicSessions",
+  "courses",
+  "classes",
+  "users",
+  "enrollments",
+]);
+
+export type OneRosterCollectionName = z.infer<
+  typeof oneRosterCollectionNameSchema
+>;
+
+const collectionStatusSchema = z.object({
+  name: oneRosterCollectionNameSchema,
+  recordsTotal: z.number().int().nonnegative(),
+  synced: z.number().int().nonnegative(),
+  deactivated: z.number().int().nonnegative(),
+  failed: z.number().int().nonnegative(),
+});
+
+export const oneRosterSyncStatusSchema = z.object({
+  runId: z.string().min(1).max(100),
+  trigger: z.enum(["manual", "schedule"]),
+  state: z.enum(["queued", "running", "succeeded", "failed", "skipped"]),
+  startedAt: z.iso.datetime(),
+  completedAt: z.iso.datetime().nullable(),
+  unchanged: z.boolean(),
+  collections: z.array(collectionStatusSchema),
+  error: z.string().max(500).nullable(),
+});
+
+export type OneRosterSyncStatus = z.infer<typeof oneRosterSyncStatusSchema>;
+
+export function parseOneRosterSyncStatus(
+  value: string | null
+): OneRosterSyncStatus | null {
+  if (!value) return null;
+  try {
+    const parsed: unknown = JSON.parse(value);
+    const result = oneRosterSyncStatusSchema.safeParse(parsed);
+    return result.success ? result.data : null;
+  } catch {
+    return null;
+  }
+}
+
+export async function getOneRosterSyncStatus(): Promise<OneRosterSyncStatus | null> {
+  return parseOneRosterSyncStatus(
+    // Bypass settings-manager's five-minute cache: the Lambda updates this row
+    // out of process while the admin page polls every few seconds.
+    await getSettingValue(ONEROSTER_SETTING_KEYS.syncStatus)
+  );
+}
+
+export async function writeOneRosterSyncStatus(
+  status: OneRosterSyncStatus
+): Promise<void> {
+  const parsed = oneRosterSyncStatusSchema.parse(status);
+  const now = new Date();
+  await executeQuery(
+    (db) =>
+      db
+        .insert(settings)
+        .values({
+          key: ONEROSTER_SETTING_KEYS.syncStatus,
+          value: JSON.stringify(parsed),
+          description:
+            "Internal OneRoster sync run status for the administrator dashboard",
+          category: "integrations",
+          isSecret: false,
+          updatedAt: now,
+        })
+        .onConflictDoUpdate({
+          target: settings.key,
+          set: {
+            value: JSON.stringify(parsed),
+            description:
+              "Internal OneRoster sync run status for the administrator dashboard",
+            category: "integrations",
+            isSecret: false,
+            updatedAt: now,
+          },
+        }),
+    "writeOneRosterSyncStatus"
+  );
+}

--- a/lib/roster/status.ts
+++ b/lib/roster/status.ts
@@ -46,6 +46,24 @@ export const oneRosterSyncStatusSchema = z.object({
 
 export type OneRosterSyncStatus = z.infer<typeof oneRosterSyncStatusSchema>;
 
+// Lambda async invocation can make the initial attempt plus two retries. With
+// the 15-minute function timeout and the default retry delays, one hour covers
+// the complete execution window while still recovering abandoned status rows.
+export const ONEROSTER_SYNC_ACTIVE_WINDOW_MS = 60 * 60 * 1000;
+
+export function isOneRosterSyncStatusActive(
+  status: OneRosterSyncStatus,
+  now = Date.now()
+): boolean {
+  if (status.state !== "queued" && status.state !== "running") return false;
+  const startedAt = Date.parse(status.startedAt);
+  return (
+    Number.isFinite(startedAt) &&
+    startedAt <= now &&
+    now - startedAt <= ONEROSTER_SYNC_ACTIVE_WINDOW_MS
+  );
+}
+
 export function parseOneRosterSyncStatus(
   value: string | null
 ): OneRosterSyncStatus | null {

--- a/lib/roster/trigger.ts
+++ b/lib/roster/trigger.ts
@@ -22,7 +22,8 @@ export function getOneRosterSyncFunctionName(): string {
 }
 
 export async function triggerOneRosterSyncNow(
-  requestedByUserId: number | null
+  requestedByUserId: number | null,
+  runId?: string
 ): Promise<void> {
   const functionName = getOneRosterSyncFunctionName();
   await getLambdaClient().send(
@@ -30,7 +31,7 @@ export async function triggerOneRosterSyncNow(
       FunctionName: functionName,
       InvocationType: "Event",
       Payload: Buffer.from(
-        JSON.stringify({ trigger: "manual", requestedByUserId })
+        JSON.stringify({ trigger: "manual", requestedByUserId, runId })
       ),
     })
   );

--- a/tests/e2e/admin-rosters.functional.spec.ts
+++ b/tests/e2e/admin-rosters.functional.spec.ts
@@ -38,6 +38,12 @@ test.describe("Admin OneRoster page (#1311)", () => {
     const studentId = `e2e-student-${stamp}`;
     const teacherEnrollmentId = `e2e-teacher-enrollment-${stamp}`;
     const studentEnrollmentId = `e2e-student-enrollment-${stamp}`;
+    const deploymentRegion =
+      process.env.AWS_REGION ?? process.env.AWS_DEFAULT_REGION ?? "us-west-2";
+    const deploymentAccountId =
+      process.env.AWS_ACCOUNT_ID ?? "123456789012";
+    const deploymentEnvironment =
+      process.env.ENVIRONMENT ?? process.env.DEPLOY_ENVIRONMENT ?? "dev";
     const originalSettings = await sql<{
       key: string;
       value: string | null;
@@ -57,7 +63,7 @@ test.describe("Admin OneRoster page (#1311)", () => {
         ["ONEROSTER_AUTH_MODE", "oauth1"],
         [
           "ONEROSTER_CREDENTIALS_SECRET_ARN",
-          "arn:aws:secretsmanager:us-west-2:123456789012:secret:aistudio-dev-oneroster-e2e",
+          `arn:aws:secretsmanager:${deploymentRegion}:${deploymentAccountId}:secret:aistudio-${deploymentEnvironment}-oneroster-e2e`,
         ],
         ["ONEROSTER_API_VERSION", "v1p1"],
         ["ONEROSTER_PAGE_SIZE", "10000"],

--- a/tests/e2e/admin-rosters.functional.spec.ts
+++ b/tests/e2e/admin-rosters.functional.spec.ts
@@ -1,0 +1,253 @@
+import { mkdir } from "node:fs/promises";
+import { test, expect } from "./fixtures";
+import {
+  authenticateContext,
+  SEEDED_ADMIN_EMAIL,
+  SEEDED_ADMIN_SUB,
+} from "./helpers/session-auth";
+
+const settingKeys = [
+  "ROSTER_SYNC_ENABLED",
+  "ONEROSTER_BASE_URL",
+  "ONEROSTER_AUTH_MODE",
+  "ONEROSTER_CREDENTIALS_SECRET_ARN",
+  "ONEROSTER_API_VERSION",
+  "ONEROSTER_PAGE_SIZE",
+] as const;
+
+test.describe("Admin OneRoster page (#1311)", () => {
+  test.skip(
+    process.env.PLAYWRIGHT_AUTH_ENABLED !== "true",
+    "Requires authenticated session against the host :3100 dev server"
+  );
+
+  test("persists settings and browses seeded school, class, and student rows", async ({
+    page,
+  }, testInfo) => {
+    const postgres = (await import("postgres")).default;
+    const sql = postgres(
+      process.env.E2E_DATABASE_URL ??
+        "postgresql://postgres:postgres@localhost:5432/aistudio",
+      { ssl: process.env.E2E_DB_SSL === "true" }
+    );
+    const stamp = Date.now();
+    const schoolId = `e2e-school-${stamp}`;
+    const termId = `e2e-term-${stamp}`;
+    const classId = `e2e-class-${stamp}`;
+    const teacherId = `e2e-teacher-${stamp}`;
+    const studentId = `e2e-student-${stamp}`;
+    const teacherEnrollmentId = `e2e-teacher-enrollment-${stamp}`;
+    const studentEnrollmentId = `e2e-student-enrollment-${stamp}`;
+    const originalSettings = await sql<{
+      key: string;
+      value: string | null;
+      description: string | null;
+      category: string | null;
+      is_secret: boolean | null;
+    }[]>`
+      SELECT key, value, description, category, is_secret
+        FROM settings
+       WHERE key IN ${sql([...settingKeys])}
+    `;
+
+    try {
+      const settingValues = [
+        ["ROSTER_SYNC_ENABLED", "false"],
+        ["ONEROSTER_BASE_URL", "https://district.example.org"],
+        ["ONEROSTER_AUTH_MODE", "oauth1"],
+        [
+          "ONEROSTER_CREDENTIALS_SECRET_ARN",
+          "arn:aws:secretsmanager:us-west-2:123456789012:secret:aistudio-dev-oneroster-e2e",
+        ],
+        ["ONEROSTER_API_VERSION", "v1p1"],
+        ["ONEROSTER_PAGE_SIZE", "10000"],
+      ] as const;
+      for (const [key, value] of settingValues) {
+        await sql`
+          INSERT INTO settings (key, value, category, is_secret)
+          VALUES (
+            ${key},
+            ${value},
+            'integrations',
+            ${key === "ONEROSTER_CREDENTIALS_SECRET_ARN"}
+          )
+          ON CONFLICT (key) DO UPDATE
+            SET value = EXCLUDED.value,
+                category = EXCLUDED.category,
+                is_secret = EXCLUDED.is_secret,
+                updated_at = now()
+        `;
+      }
+
+      await sql`
+        INSERT INTO oneroster_orgs (
+          sourced_id, name, type, identifier, status, is_active, last_synced_at
+        )
+        VALUES (
+          ${schoolId}, 'E2E Cedar School', 'school', 'E2E-CEDAR',
+          'active', true, now()
+        )
+      `;
+      await sql`
+        INSERT INTO oneroster_academic_sessions (
+          sourced_id, title, type, status, is_active, last_synced_at
+        )
+        VALUES (
+          ${termId}, 'E2E Fall Term', 'term', 'active', true, now()
+        )
+      `;
+      await sql`
+        INSERT INTO oneroster_classes (
+          sourced_id, title, class_code, school_sourced_id, status,
+          is_active, last_synced_at
+        )
+        VALUES (
+          ${classId}, 'E2E Biology', 'BIO-E2E', ${schoolId}, 'active',
+          true, now()
+        )
+      `;
+      await sql`
+        INSERT INTO oneroster_class_terms (
+          class_sourced_id, term_sourced_id, status, is_active, last_synced_at
+        )
+        VALUES (${classId}, ${termId}, 'active', true, now())
+      `;
+      await sql`
+        INSERT INTO oneroster_users (
+          sourced_id, email, given_name, family_name, role, status,
+          is_active, last_synced_at
+        )
+        VALUES
+          (
+            ${teacherId}, ${`teacher-${stamp}@psd401.net`}, 'Taylor', 'Teacher',
+            'teacher', 'active', true, now()
+          ),
+          (
+            ${studentId}, ${`student-${stamp}@edtools.psd401.net`}, 'Sam', 'Student',
+            'student', 'active', true, now()
+          )
+      `;
+      await sql`
+        INSERT INTO oneroster_enrollments (
+          sourced_id, user_sourced_id, class_sourced_id, school_sourced_id,
+          role, is_primary, status, is_active, last_synced_at
+        )
+        VALUES
+          (
+            ${teacherEnrollmentId}, ${teacherId}, ${classId}, ${schoolId},
+            'teacher', true, 'active', true, now()
+          ),
+          (
+            ${studentEnrollmentId}, ${studentId}, ${classId}, ${schoolId},
+            'student', true, 'active', true, now()
+          )
+      `;
+
+      await authenticateContext(
+        page.context(),
+        SEEDED_ADMIN_EMAIL,
+        SEEDED_ADMIN_SUB
+      );
+      await page.goto("/admin/rosters");
+      await expect(
+        page.locator("h1").filter({ hasText: /^Rosters$/ })
+      ).toBeVisible({ timeout: 15_000 });
+      await expect(page.getByTestId("rosters-admin")).toBeVisible();
+
+      await expect(page.getByTestId("roster-base-url")).toHaveValue(
+        "https://district.example.org"
+      );
+      await page.getByTestId("roster-page-size").fill("4321");
+      await page.getByTestId("roster-settings-save").click();
+      await expect
+        .poll(
+          async () => {
+            const [row] = await sql<{ value: string | null }[]>`
+              SELECT value
+              FROM settings
+              WHERE key = 'ONEROSTER_PAGE_SIZE'
+            `;
+            return row?.value;
+          },
+          { timeout: 10_000 }
+        )
+        .toBe("4321");
+
+      await page.getByTestId("tab-roster-sync").click();
+      await expect(
+        page.getByTestId("roster-collection-summary")
+      ).toBeVisible();
+      await expect(page.getByText("Organizations", { exact: true })).toBeVisible();
+      await expect(page.getByTestId("roster-sync-now")).toBeEnabled();
+
+      await page.getByTestId("tab-roster-browser").click();
+      await page.getByTestId("roster-school-select").click();
+      await page.getByRole("option", { name: "E2E Cedar School" }).click();
+      await expect(page.getByTestId("roster-classes-table")).toBeVisible({
+        timeout: 10_000,
+      });
+      await expect(page.getByText("E2E Biology", { exact: true })).toBeVisible();
+      await expect(
+        page.getByText("Taylor Teacher", { exact: true })
+      ).toBeVisible();
+      await page.getByTestId(`view-roster-${classId}`).click();
+      await expect(page.getByTestId("roster-students-table")).toBeVisible({
+        timeout: 10_000,
+      });
+      await expect(page.getByText("Sam Student", { exact: true })).toBeVisible();
+
+      await mkdir(".verification", { recursive: true });
+      await page.screenshot({
+        path: `.verification/admin-rosters-${testInfo.project.name}.png`,
+        fullPage: true,
+      });
+    } finally {
+      await sql`
+        DELETE FROM oneroster_enrollments
+         WHERE sourced_id IN (${teacherEnrollmentId}, ${studentEnrollmentId})
+      `;
+      await sql`
+        DELETE FROM oneroster_users
+         WHERE sourced_id IN (${teacherId}, ${studentId})
+      `;
+      await sql`
+        DELETE FROM oneroster_class_terms
+         WHERE class_sourced_id = ${classId}
+      `;
+      await sql`
+        DELETE FROM oneroster_classes
+         WHERE sourced_id = ${classId}
+      `;
+      await sql`
+        DELETE FROM oneroster_academic_sessions
+         WHERE sourced_id = ${termId}
+      `;
+      await sql`
+        DELETE FROM oneroster_orgs
+         WHERE sourced_id = ${schoolId}
+      `;
+      await sql`
+        DELETE FROM settings
+         WHERE key IN ${sql([...settingKeys])}
+      `;
+      for (const row of originalSettings) {
+        await sql`
+          INSERT INTO settings (
+            key, value, description, category, is_secret
+          )
+          VALUES (
+            ${row.key}, ${row.value}, ${row.description}, ${row.category},
+            ${row.is_secret}
+          )
+          ON CONFLICT (key) DO UPDATE
+            SET value = EXCLUDED.value,
+                description = EXCLUDED.description,
+                category = EXCLUDED.category,
+                is_secret = EXCLUDED.is_secret,
+                updated_at = now()
+        `;
+      }
+      await sql.end();
+    }
+  });
+});

--- a/tests/e2e/admin-rosters.guard.spec.ts
+++ b/tests/e2e/admin-rosters.guard.spec.ts
@@ -1,0 +1,14 @@
+import { test, expect } from "./fixtures";
+
+test.describe("Admin rosters — route auth gate (always-run)", () => {
+  test("GET /admin/rosters unauthenticated redirects to sign-in", async ({
+    request,
+  }) => {
+    const response = await request.get("/admin/rosters", {
+      maxRedirects: 0,
+    });
+
+    expect(response.status()).toBe(307);
+    expect(response.headers()["location"]).toContain("/api/auth/signin");
+  });
+});

--- a/tests/unit/oneroster-admin-contract.test.ts
+++ b/tests/unit/oneroster-admin-contract.test.ts
@@ -38,6 +38,7 @@ describe("OneRoster administrator contracts", () => {
     expect(component).toContain("syncInFlightRef");
     expect(component).toContain("pollForRun");
     expect(component).toContain("monitorPersistedRun");
+    expect(component).toContain("isOneRosterSyncStatusActive");
     expect(component).not.toMatch(/token[_ -]?url/i);
   });
 

--- a/tests/unit/oneroster-admin-contract.test.ts
+++ b/tests/unit/oneroster-admin-contract.test.ts
@@ -37,7 +37,19 @@ describe("OneRoster administrator contracts", () => {
     expect(lambda).toContain('"failed"');
     expect(component).toContain("syncInFlightRef");
     expect(component).toContain("pollForRun");
+    expect(component).toContain("monitorPersistedRun");
     expect(component).not.toMatch(/token[_ -]?url/i);
+  });
+
+  it("discards stale school and class roster responses", () => {
+    const component = source(
+      "app/(protected)/admin/rosters/_components/rosters-admin.tsx"
+    );
+
+    expect(component).toContain("schoolRequestRef");
+    expect(component).toContain("rosterRequestRef");
+    expect(component).toContain("requestId !== schoolRequestRef.current");
+    expect(component).toContain("requestId !== rosterRequestRef.current");
   });
 
   it("keeps roster rows read-only in the application layer", () => {

--- a/tests/unit/oneroster-admin-contract.test.ts
+++ b/tests/unit/oneroster-admin-contract.test.ts
@@ -1,0 +1,51 @@
+/**
+ * Cross-surface contracts for the #1311 administrator UI.
+ *
+ * These source checks complement behavior/E2E coverage by pinning the isolated
+ * Lambda status writer and the admin-registry route, which cannot share imports.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { ALL_ADMIN_PAGES } from "@/app/(protected)/admin/_lib/admin-pages";
+
+function source(relativePath: string): string {
+  return fs.readFileSync(path.join(process.cwd(), relativePath), "utf8");
+}
+
+describe("OneRoster administrator contracts", () => {
+  it("registers /admin/rosters in the admin hub", () => {
+    expect(
+      ALL_ADMIN_PAGES.find((page) => page.href === "/admin/rosters")
+    ).toMatchObject({
+      title: "Rosters",
+      slug: "rosters",
+    });
+  });
+
+  it("persists and polls a shared run id without a token endpoint flow", () => {
+    const trigger = source("lib/roster/trigger.ts");
+    const lambda = source("infra/lambdas/oneroster-sync/index.ts");
+    const component = source(
+      "app/(protected)/admin/rosters/_components/rosters-admin.tsx"
+    );
+
+    expect(trigger).toContain("requestedByUserId, runId");
+    expect(lambda).toContain("writeStatusSafely");
+    expect(lambda).toContain('state: "running"');
+    expect(lambda).toContain('"succeeded"');
+    expect(lambda).toContain('"failed"');
+    expect(component).toContain("syncInFlightRef");
+    expect(component).toContain("pollForRun");
+    expect(component).not.toMatch(/token[_ -]?url/i);
+  });
+
+  it("keeps roster rows read-only in the application layer", () => {
+    const queries = source("lib/roster/queries.ts");
+    const actions = source("actions/db/roster-admin-actions.ts");
+
+    expect(queries).not.toMatch(/\.(?:insert|update|delete)\(oneroster/i);
+    expect(actions).not.toMatch(/\.(?:insert|update|delete)\(oneroster/i);
+    expect(actions).toContain('hasRole("administrator")');
+  });
+});

--- a/tests/unit/oneroster-admin-settings.test.ts
+++ b/tests/unit/oneroster-admin-settings.test.ts
@@ -1,0 +1,121 @@
+import {
+  oneRosterSettingsInputSchema,
+  ONEROSTER_SETTING_KEYS,
+} from "@/lib/roster/settings";
+import { parseOneRosterSyncStatus } from "@/lib/roster/status";
+
+const validInput = {
+  enabled: true,
+  baseUrl: "https://district.example.org/",
+  authMode: "oauth1" as const,
+  credentialsSecretArn:
+    "arn:aws:secretsmanager:us-west-2:123456789012:secret:aistudio-dev-oneroster-abc123",
+  apiVersion: "v1p1" as const,
+  pageSize: 10_000,
+};
+
+describe("OneRoster administrator settings", () => {
+  it("accepts the two documented auth modes and normalizes HTTPS URLs", () => {
+    const oauth1 = oneRosterSettingsInputSchema.parse(validInput);
+    const proxy = oneRosterSettingsInputSchema.parse({
+      ...validInput,
+      authMode: "proxy",
+      baseUrl:
+        "https://oneroster-proxy.apis.classlink.com/proxy/v1p0/application-id?ignored=true",
+    });
+
+    expect(oauth1.baseUrl).toBe("https://district.example.org");
+    expect(proxy.baseUrl).toBe(
+      "https://oneroster-proxy.apis.classlink.com/proxy/v1p0/application-id"
+    );
+  });
+
+  it("rejects unsafe URLs, generic token-flow fields, bad ARNs, and invalid page sizes", () => {
+    expect(() =>
+      oneRosterSettingsInputSchema.parse({
+        ...validInput,
+        baseUrl: "http://district.example.org",
+      })
+    ).toThrow();
+    expect(() =>
+      oneRosterSettingsInputSchema.parse({
+        ...validInput,
+        tokenUrl: "https://district.example.org/oauth/token",
+      })
+    ).toThrow();
+    expect(() =>
+      oneRosterSettingsInputSchema.parse({
+        ...validInput,
+        credentialsSecretArn:
+          "arn:aws:secretsmanager:us-west-2:123456789012:secret:other-secret",
+      })
+    ).toThrow();
+    expect(() =>
+      oneRosterSettingsInputSchema.parse({ ...validInput, pageSize: 10_001 })
+    ).toThrow();
+  });
+
+  it("includes the durable status key in the shared settings contract", () => {
+    expect(ONEROSTER_SETTING_KEYS.syncStatus).toBe("ONEROSTER_SYNC_STATUS");
+  });
+});
+
+describe("OneRoster sync status parsing", () => {
+  it("accepts the non-sensitive terminal run contract", () => {
+    const status = parseOneRosterSyncStatus(
+      JSON.stringify({
+        runId: "run-1",
+        trigger: "manual",
+        state: "failed",
+        startedAt: "2026-07-26T20:00:00.000Z",
+        completedAt: "2026-07-26T20:01:00.000Z",
+        unchanged: false,
+        collections: [
+          {
+            name: "users",
+            recordsTotal: 50,
+            synced: 0,
+            deactivated: 0,
+            failed: 1,
+          },
+        ],
+        error: "Users collection failed; last-known-good rows were preserved.",
+      })
+    );
+
+    expect(status?.state).toBe("failed");
+    expect(status?.collections[0]?.name).toBe("users");
+  });
+
+  it("fails closed for malformed or oversized status payloads", () => {
+    expect(parseOneRosterSyncStatus("not-json")).toBeNull();
+    expect(
+      parseOneRosterSyncStatus(
+        JSON.stringify({
+          runId: "run-1",
+          trigger: "manual",
+          state: "succeeded",
+          startedAt: "not-a-date",
+          completedAt: null,
+          unchanged: false,
+          collections: [],
+          error: null,
+        })
+      )
+    ).toBeNull();
+    expect(
+      parseOneRosterSyncStatus(
+        JSON.stringify({
+          runId: "run-1",
+          trigger: "manual",
+          state: "failed",
+          startedAt: "2026-07-26T20:00:00.000Z",
+          completedAt: "2026-07-26T20:01:00.000Z",
+          unchanged: false,
+          collections: [],
+          error: "x".repeat(501),
+        })
+      )
+    ).toBeNull();
+  });
+});

--- a/tests/unit/oneroster-admin-settings.test.ts
+++ b/tests/unit/oneroster-admin-settings.test.ts
@@ -1,4 +1,5 @@
 import {
+  createOneRosterSettingsInputSchema,
   oneRosterSettingsInputSchema,
   ONEROSTER_SETTING_KEYS,
 } from "@/lib/roster/settings";
@@ -53,6 +54,40 @@ describe("OneRoster administrator settings", () => {
     expect(() =>
       oneRosterSettingsInputSchema.parse({ ...validInput, pageSize: 10_001 })
     ).toThrow();
+  });
+
+  it("rejects secret ARNs outside the current deployment", () => {
+    const deploymentSchema = createOneRosterSettingsInputSchema({
+      environment: "dev",
+      region: "us-west-2",
+      accountId: "123456789012",
+    });
+
+    expect(() =>
+      deploymentSchema.parse({
+        ...validInput,
+        credentialsSecretArn:
+          "arn:aws:secretsmanager:us-west-2:123456789012:secret:aistudio-prod-oneroster-abc123",
+      })
+    ).toThrow(/environment/);
+    expect(() =>
+      deploymentSchema.parse({
+        ...validInput,
+        credentialsSecretArn:
+          "arn:aws:secretsmanager:us-east-1:123456789012:secret:aistudio-dev-oneroster-abc123",
+      })
+    ).toThrow(/region/);
+    expect(() =>
+      deploymentSchema.parse({
+        ...validInput,
+        credentialsSecretArn:
+          "arn:aws:secretsmanager:us-west-2:210987654321:secret:aistudio-dev-oneroster-abc123",
+      })
+    ).toThrow(/account/);
+    expect(deploymentSchema.parse(validInput)).toMatchObject({
+      ...validInput,
+      baseUrl: "https://district.example.org",
+    });
   });
 
   it("includes the durable status key in the shared settings contract", () => {

--- a/tests/unit/oneroster-admin-settings.test.ts
+++ b/tests/unit/oneroster-admin-settings.test.ts
@@ -3,7 +3,11 @@ import {
   oneRosterSettingsInputSchema,
   ONEROSTER_SETTING_KEYS,
 } from "@/lib/roster/settings";
-import { parseOneRosterSyncStatus } from "@/lib/roster/status";
+import {
+  isOneRosterSyncStatusActive,
+  ONEROSTER_SYNC_ACTIVE_WINDOW_MS,
+  parseOneRosterSyncStatus,
+} from "@/lib/roster/status";
 
 const validInput = {
   enabled: true,
@@ -152,5 +156,40 @@ describe("OneRoster sync status parsing", () => {
         })
       )
     ).toBeNull();
+  });
+
+  it("expires abandoned nonterminal runs after the retry window", () => {
+    const now = Date.parse("2026-07-26T21:00:00.000Z");
+    const activeStatus = parseOneRosterSyncStatus(
+      JSON.stringify({
+        runId: "run-active",
+        trigger: "manual",
+        state: "running",
+        startedAt: new Date(
+          now - ONEROSTER_SYNC_ACTIVE_WINDOW_MS + 1
+        ).toISOString(),
+        completedAt: null,
+        unchanged: false,
+        collections: [],
+        error: null,
+      })
+    );
+    const staleStatus = activeStatus
+      ? {
+          ...activeStatus,
+          runId: "run-stale",
+          startedAt: new Date(
+            now - ONEROSTER_SYNC_ACTIVE_WINDOW_MS - 1
+          ).toISOString(),
+        }
+      : null;
+
+    expect(activeStatus).not.toBeNull();
+    expect(activeStatus && isOneRosterSyncStatusActive(activeStatus, now)).toBe(
+      true
+    );
+    expect(staleStatus && isOneRosterSyncStatusActive(staleStatus, now)).toBe(
+      false
+    );
   });
 });

--- a/tests/unit/oneroster-sync-contract.test.ts
+++ b/tests/unit/oneroster-sync-contract.test.ts
@@ -28,6 +28,7 @@ describe("OneRoster sync cross-bundle contracts", () => {
       "ONEROSTER_API_VERSION",
       "ONEROSTER_PAGE_SIZE",
       "ONEROSTER_LAST_PERM_REV",
+      "ONEROSTER_SYNC_STATUS",
     ]) {
       expect(appSettings).toContain(key);
       expect(lambdaSettings).toContain(key);


### PR DESCRIPTION
## Summary

- add the administrator-only `/admin/rosters` control surface to the admin hub
- transactionally manage the six supported ClassLink settings without adding a generic OAuth2 token endpoint
- dispatch manual runs with a unique run ID and poll a bounded, non-sensitive Lambda status record
- provide read-only school → class/teacher → student roster browsing
- document configuration, security boundaries, operations, and rollback

## Source of truth and scope

Epic #1308 lists #1311 as the first workstream after the merged ingestion foundation (#1309 and #1310). No active or review-ready implementation of #1311 existed when this branch was created from current `dev`.

This PR implements only #1311. It does not add role mapping, room provisioning, or reporting.

## Security and data boundaries

- page and every server action require the `administrator` role
- credentials remain in Secrets Manager; the database stores only the scoped secret ARN
- the accepted auth modes remain the two documented modes: direct OAuth1 HMAC or the non-expiring OAuth2 Proxy bearer
- the settings schema rejects HTTP URLs, embedded URL credentials, unrecognized auth/API modes, unsafe secret names, extra token-flow fields, and page sizes outside 1–10,000
- sync status contains only run metadata, collection counts, and a bounded sanitized error
- application queries are read-only for every `oneroster_*` table; the isolated Lambda remains the sole roster writer

## Verification

- `bun run lint` — pass, 0 errors (repository baseline: 407 pre-existing warnings; changed application files add none)
- `bun run typecheck` — pass
- `bun run test:ci --runInBand` — 364 suites / 3,580 tests passed; 3 suites / 26 tests intentionally skipped
- `bun run build` — pass; `/admin/rosters` included in the production route manifest
- focused OneRoster/Jest contracts — 4 suites / 15 tests passed
- OneRoster Lambda `bun run build` — pass
- OneRoster Lambda `bun test` against a disposable PostgreSQL database — 24 tests passed, including collection rollback and durable status upsert
- `cd infra && bun run build` — pass, including 11 nested Lambda tests
- `cd infra && bunx cdk synth --quiet` — all dev/prod stacks synthesized; modified OneRoster asset bundled
- authenticated Playwright functional spec — pass against local PostgreSQL and seeded admin session
- unauthenticated Playwright route guard — pass
- visual inspection of the populated school/class/student browser — pass

## Rollback

Remove the `/admin/rosters` route and its `ADMIN_SECTIONS` entry, then deploy the prior application/Lambda version. Existing settings, migration 141, and the last-known-good roster snapshot can remain; no destructive data rollback is required.

Closes #1311
Part of #1308
