### PR TITLE
feat: #1239 - resolve district identities from email and Chat user id

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,16 @@ jobs:
       env:
         CI: true
 
+    # psd-directory (#1239). Same story as psd-workspace above: plain CJS
+    # outside the jest roots, so `test:ci` cannot see it. What these tests
+    # guard is identity CORRECTNESS — the exact-address rule that stops a
+    # fuzzy search result being reported as the person, and the absence of any
+    # directory-enumeration entry point.
+    - name: Run psd-directory lookup tests (Bun)
+      run: bun run test:skill:directory
+      env:
+        CI: true
+
     # Optional: Upload test coverage if you generate it
     # - name: Upload coverage reports
     #   uses: codecov/codecov-action@v3

--- a/infra/agent-image/skills/psd-directory/SKILL.md
+++ b/infra/agent-image/skills/psd-directory/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: psd-directory
+summary: Who is this person? Look up an unknown email address or a Google Chat sender (users/{id}) and get the real person — name, job title, department, school. Identity lookup for staff and colleagues by email, Chat id, or message sender.
 description: Resolve a district email address or a Google Chat `users/{id}` to the real person in the Peninsula SD directory — name, title, department. Use this whenever you are about to refer to someone by a raw email address or a Chat sender id, instead of guessing who they are.
+allowed-tools: Bash(node:*)
 ---
 
 # psd-directory — who is this person, actually

--- a/infra/agent-image/skills/psd-directory/SKILL.md
+++ b/infra/agent-image/skills/psd-directory/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: psd-directory
+description: Resolve a district email address or a Google Chat `users/{id}` to the real person in the Peninsula SD directory — name, title, department. Use this whenever you are about to refer to someone by a raw email address or a Chat sender id, instead of guessing who they are.
+---
+
+# psd-directory — who is this person, actually
+
+You frequently encounter an identity you cannot read: a raw address in a
+message, or a Chat sender that arrives as `users/116264913639920976203`.
+Guessing is the failure mode this skill exists to remove. Ask the directory.
+
+```bash
+# email -> person
+node /opt/psd-skills/psd-directory/run.js --user <owner@psd401.net> --email someone@psd401.net
+
+# Chat users/{id} -> person
+node /opt/psd-skills/psd-directory/run.js --user <owner@psd401.net> --chat-id users/116264913639920976203
+```
+
+`--user` is the person whose `agnt_` account brokers the lookup — normally the
+owner of the conversation you are working in.
+
+## What comes back
+
+One JSON line on stdout.
+
+```json
+{"found":true,"personId":"116264913639920976203","displayName":"Kris Hagel",
+ "email":"hagelk@psd401.net","title":"Chief","department":"Multiple Locations",
+ "organization":"Peninsula School District","cached":false}
+```
+
+A person who is not in the directory is an **answer, not an error** — exit 0:
+
+```json
+{"found":false,"query":"someone@psd401.net","reason":"not in directory"}
+```
+
+When `found` is false, say so. Do not fall back to inferring a name from the
+address local-part; "hagelk@" looking like a Hagel is exactly the guess this
+skill replaces.
+
+## Rules that matter
+
+**Never present a near match as the person.** An email lookup only reports a
+person whose address matches *exactly*. The underlying Google search is a
+prefix/substring search, so a partial address can return several people —
+resolving to the wrong human is worse than resolving to nobody.
+
+**`title` and `department` come from ClassLink OneSync**, so they are as
+current as the last sync, not live HR data. Treat them as descriptive, not
+authoritative, for anything consequential.
+
+**There is no way to list the directory, by design.** This skill resolves
+identities you have already encountered. It cannot enumerate people, and that
+is deliberate: the district directory includes student records (name, address,
+grade, building), so a bulk-listing capability in the agent image would be a
+student-directory dumper one prompt away. If you find yourself wanting "all
+users", stop — that is not a request this tool serves, and it is not one to
+work around by other means.
+
+## Cost and caching
+
+Lookups are cached on disk in the container: 12 hours for a hit, 5 minutes for
+a miss (a miss is often a race with account provisioning, and caching that for
+hours would make a new hire look permanently unresolvable). Repeated lookups of
+the same person inside one session cost nothing — resolve freely rather than
+rationing calls. `--no-cache` forces a fresh read if you have reason to think
+someone was just created or renamed.
+
+## When it fails
+
+| Exit | Meaning | What to do |
+|---|---|---|
+| 0 | Success, including `found:false` | Use the answer |
+| 1 | Bad usage or malformed input | Fix the arguments |
+| 2 | Unexpected People API error | Report it; do not retry blindly |
+| 12 | Broker or People API unreachable | Transient — retry once |
+| 14 | The `agnt_` account is still being created | Tell the user to retry shortly |
+| 16 | **Directory sharing is disabled in the Workspace admin console** | No code or retry fixes this. An admin must set Directory → Directory settings → Sharing settings → External Directory Sharing to "Organization data and authenticated user basic profile fields". Say that plainly rather than reporting a generic permission error. |
+| 17 | The agent token lacks `directory.readonly` | A scope/deploy problem — report it |
+
+Exit 16 is its own code on purpose: it was the real state of this district
+until 2026-07-26, and it looks identical to a permissions bug unless you know
+to name the setting.
+
+## Scope and privilege
+
+Uses `directory.readonly`, which the agent slot already holds — no new OAuth
+scope, no consent flow, no admin role on the service account, and
+`contacts.readonly` is deliberately **not** used (it grants personal contacts,
+which is a different and wrong thing). See issue #1239.

--- a/infra/agent-image/skills/psd-directory/SKILL.md
+++ b/infra/agent-image/skills/psd-directory/SKILL.md
@@ -88,8 +88,8 @@ or renamed, since that one does spend a mint.
 |---|---|---|
 | 0 | Success, including `found:false` | Use the answer |
 | 1 | Bad usage or malformed input | Fix the arguments |
-| 2 | Unexpected People API error | Report it; do not retry blindly |
-| 12 | Broker or People API unreachable | Transient — retry once |
+| 2 | Unexpected People API error (bad request, or a malformed response) | Report it; do not retry blindly |
+| 12 | Broker or People API unreachable, or the People API returned 5xx | Transient — retry once |
 | 14 | The `agnt_` account is still being created | Tell the user to retry shortly |
 | 16 | **Directory sharing is disabled in the Workspace admin console** | No code or retry fixes this. An admin must set Directory → Directory settings → Sharing settings → External Directory Sharing to "Organization data and authenticated user basic profile fields". Say that plainly rather than reporting a generic permission error. |
 | 17 | The agent token lacks `directory.readonly` | A scope/deploy problem — report it |

--- a/infra/agent-image/skills/psd-directory/SKILL.md
+++ b/infra/agent-image/skills/psd-directory/SKILL.md
@@ -47,6 +47,12 @@ person whose address matches *exactly*. The underlying Google search is a
 prefix/substring search, so a partial address can return several people —
 resolving to the wrong human is worse than resolving to nobody.
 
+**Aliases resolve, and say so.** The match considers every address on a
+record, not only the primary, so a `firstname.lastname` alias or a
+pre-name-change address finds the right person. When the query was an alias,
+the reply adds `"matchedAlias"` alongside the canonical `email` — mention the
+person by name rather than implying the two addresses are different people.
+
 **`title` and `department` come from ClassLink OneSync**, so they are as
 current as the last sync, not live HR data. Treat them as descriptive, not
 authoritative, for anything consequential.

--- a/infra/agent-image/skills/psd-directory/SKILL.md
+++ b/infra/agent-image/skills/psd-directory/SKILL.md
@@ -71,10 +71,16 @@ work around by other means.
 
 Lookups are cached on disk in the container: 12 hours for a hit, 5 minutes for
 a miss (a miss is often a race with account provisioning, and caching that for
-hours would make a new hire look permanently unresolvable). Repeated lookups of
-the same person inside one session cost nothing — resolve freely rather than
-rationing calls. `--no-cache` forces a fresh read if you have reason to think
-someone was just created or renamed.
+hours would make a new hire look permanently unresolvable).
+
+A cache hit costs **nothing** — no directory call and no token mint. That
+second part matters: minting goes through the DWD broker, which allows 120
+mints per hour per person and shares that budget with `psd-workspace`, so a
+lookup that minted on every call could exhaust the limit and break Gmail,
+Calendar and Drive alongside it. Resolving the same person repeatedly is
+genuinely free, so resolve freely rather than rationing calls — but reach for
+`--no-cache` only when you have real reason to think someone was just created
+or renamed, since that one does spend a mint.
 
 ## When it fails
 

--- a/infra/agent-image/skills/psd-directory/lib.js
+++ b/infra/agent-image/skills/psd-directory/lib.js
@@ -1,0 +1,284 @@
+/**
+ * psd-directory — resolve a district identity instead of guessing (#1239).
+ *
+ * Two questions this answers, both against the Google People API's DIRECTORY
+ * surface using the `directory.readonly` scope that AGENT_DWD_SCOPES already
+ * carries (no new scope, no admin role, no `contacts.readonly`):
+ *
+ *   email        -> who that is    (people.searchDirectoryPeople)
+ *   Chat user id -> who that is    (people.get on the same numeric id)
+ *
+ * The Chat `users/{id}` numeric id IS the People API person id, so the second
+ * lookup is a direct get rather than a search. Probed live on 2026-07-26 with
+ * an `agnt_` DWD token: people.get returns POPULATED names/emailAddresses in
+ * the service-account context, which is why the Admin SDK fallback (Option B
+ * on #1239, requiring a "Users > Read" admin role on the service account) is
+ * NOT built.
+ *
+ * ---------------------------------------------------------------------------
+ * DELIBERATE NON-CAPABILITY: no enumeration.
+ * ---------------------------------------------------------------------------
+ * This module exposes TARGETED resolution only. It never calls
+ * people.listDirectoryPeople, and there is no "list everyone" entry point.
+ * That is a safety property, not an oversight: the district directory
+ * includes ClassLink-provisioned STUDENT records (name, @edtools address,
+ * grade, building), so a bulk-list helper in the agent image would be a
+ * student-directory dumper one prompt away. Resolving an identity the agent
+ * has already encountered is a different act from enumerating children.
+ * Keep it that way — see SKILL.md.
+ */
+
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+
+const PEOPLE_BASE = 'https://people.googleapis.com/v1';
+const READ_MASK = 'names,emailAddresses,organizations';
+
+/**
+ * Cache TTLs. Directory data is slow-moving (titles change on the order of
+ * months), and the container is ephemeral, so a generous positive TTL is
+ * safe and is the whole point of the acceptance criterion "lookups cached to
+ * avoid per-message directory calls".
+ *
+ * Negatives get a SHORT ttl on purpose: a miss is often a race with
+ * provisioning (a new hire, a freshly created agnt_ account), and caching
+ * that for hours would make a real person look permanently unresolvable.
+ */
+const POSITIVE_TTL_MS = 12 * 60 * 60 * 1000; // 12h
+const NEGATIVE_TTL_MS = 5 * 60 * 1000; //  5m
+
+/** Cache lives in the container's tmp; ephemeral by construction. */
+function cacheDir() {
+  return process.env.PSD_DIRECTORY_CACHE_DIR || path.join(os.tmpdir(), 'psd-directory-cache');
+}
+
+/**
+ * Cache key -> filename. The key is hashed rather than used verbatim so an
+ * address like `a/b@x` cannot escape the cache directory via path traversal,
+ * and so no email address is written into a filename in plaintext.
+ */
+function cacheFile(key) {
+  const hash = require('node:crypto').createHash('sha256').update(key).digest('hex').slice(0, 32);
+  return path.join(cacheDir(), `${hash}.json`);
+}
+
+function readCache(key, now) {
+  let raw;
+  try {
+    raw = fs.readFileSync(cacheFile(key), 'utf8');
+  } catch {
+    return null; // absent or unreadable — treat as a miss
+  }
+  let entry;
+  try {
+    entry = JSON.parse(raw);
+  } catch {
+    return null; // corrupt — treat as a miss rather than throwing
+  }
+  if (!entry || typeof entry.expiresAt !== 'number') return null;
+  if (entry.expiresAt <= now) return null;
+  return entry.value ?? null;
+}
+
+function writeCache(key, value, now) {
+  const ttl = value && value.found ? POSITIVE_TTL_MS : NEGATIVE_TTL_MS;
+  const entry = { expiresAt: now + ttl, value };
+  try {
+    fs.mkdirSync(cacheDir(), { recursive: true });
+    // Write-then-rename so a concurrent reader never sees a half-written file.
+    const tmp = `${cacheFile(key)}.${process.pid}.tmp`;
+    fs.writeFileSync(tmp, JSON.stringify(entry), { mode: 0o600 });
+    fs.renameSync(tmp, cacheFile(key));
+  } catch {
+    // A cache that cannot be written must never fail the lookup. The call
+    // already succeeded; losing the cache costs latency, not correctness.
+  }
+}
+
+/**
+ * Normalize a Chat person reference to a bare People API id.
+ * Accepts `users/123`, `people/123`, or a bare `123`.
+ * Returns null if it is not a plausible id (digits only).
+ */
+function normalizePersonId(raw) {
+  if (typeof raw !== 'string') return null;
+  const trimmed = raw.trim().replace(/^(users|people)\//i, '');
+  return /^\d+$/.test(trimmed) ? trimmed : null;
+}
+
+function normalizeEmail(raw) {
+  if (typeof raw !== 'string') return null;
+  const trimmed = raw.trim().toLowerCase();
+  // Deliberately loose: Google is the authority on whether an address exists.
+  // This only rejects input that cannot be an address at all.
+  return /^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(trimmed) ? trimmed : null;
+}
+
+/**
+ * Distinguish the two 403s that mean very different things, so the agent (and
+ * whoever reads the logs) is not left guessing.
+ *
+ *   DIRECTORY_SHARING_DISABLED — the Workspace admin console setting
+ *     "External Directory Sharing" is on its restrictive default. NO code
+ *     change fixes this; it is an admin action. This was the actual state
+ *     until 2026-07-26.
+ *   INSUFFICIENT_SCOPE — the token genuinely lacks directory.readonly.
+ */
+function classifyError(status, body) {
+  const message = (body && body.error && body.error.message) || '';
+  if (status === 403 && /external directory sharing/i.test(message)) {
+    return { code: 'DIRECTORY_SHARING_DISABLED', message };
+  }
+  if (status === 403 && /insufficient authentication scopes/i.test(message)) {
+    return { code: 'INSUFFICIENT_SCOPE', message };
+  }
+  if (status === 403 || status === 401) {
+    return { code: 'FORBIDDEN', message };
+  }
+  return { code: 'LOOKUP_FAILED', message: message || `HTTP ${status}` };
+}
+
+class DirectoryError extends Error {
+  constructor(code, message) {
+    super(message);
+    this.code = code;
+  }
+}
+
+async function callPeople(url, accessToken, fetchImpl) {
+  const doFetch = fetchImpl || globalThis.fetch;
+  let resp;
+  try {
+    resp = await doFetch(url, { headers: { Authorization: `Bearer ${accessToken}` } });
+  } catch (err) {
+    throw new DirectoryError('TRANSPORT', `People API request failed: ${err.message}`);
+  }
+  const body = await resp.json().catch(() => ({}));
+  if (!resp.ok) {
+    const { code, message } = classifyError(resp.status, body);
+    throw new DirectoryError(code, message);
+  }
+  return body;
+}
+
+/**
+ * Shape a People API person into the flat record the agent actually wants.
+ * Returns null when the payload carries no usable identity, so an empty
+ * response is reported as "not found" rather than as a person with no name.
+ */
+function shapePerson(person) {
+  if (!person || typeof person !== 'object') return null;
+  const names = Array.isArray(person.names) ? person.names : [];
+  const emails = Array.isArray(person.emailAddresses) ? person.emailAddresses : [];
+  const orgs = Array.isArray(person.organizations) ? person.organizations : [];
+  const primary = (list) => list.find((x) => x && x.metadata && x.metadata.primary) || list[0] || null;
+
+  const name = primary(names);
+  const email = primary(emails);
+  const org = primary(orgs);
+  const displayName = (name && name.displayName) || null;
+  const emailAddress = (email && email.value) || null;
+  if (!displayName && !emailAddress) return null;
+
+  return {
+    personId: typeof person.resourceName === 'string' ? person.resourceName.replace(/^people\//, '') : null,
+    displayName,
+    email: emailAddress,
+    title: (org && org.title) || null,
+    department: (org && org.department) || null,
+    organization: (org && org.name) || null,
+  };
+}
+
+/**
+ * email -> district person. Uses searchDirectoryPeople because an address is
+ * not a person id; the search is then confirmed against the returned address
+ * so a fuzzy prefix match cannot silently resolve to the WRONG person — which
+ * would be worse than not resolving at all, given the agent uses this to
+ * decide who it is talking about.
+ */
+async function resolveEmail(email, accessToken, opts = {}) {
+  const normalized = normalizeEmail(email);
+  if (!normalized) throw new DirectoryError('INVALID_INPUT', `Not a valid email address: ${email}`);
+  const now = opts.now || Date.now();
+  const key = `email:${normalized}`;
+
+  if (!opts.noCache) {
+    const hit = readCache(key, now);
+    if (hit) return { ...hit, cached: true };
+  }
+
+  const url =
+    `${PEOPLE_BASE}/people:searchDirectoryPeople` +
+    `?query=${encodeURIComponent(normalized)}` +
+    `&readMask=${encodeURIComponent(READ_MASK)}` +
+    `&sources=DIRECTORY_SOURCE_TYPE_DOMAIN_PROFILE`;
+  const body = await callPeople(url, accessToken, opts.fetchImpl);
+
+  const candidates = Array.isArray(body.people) ? body.people : [];
+  const shaped = candidates.map(shapePerson).filter(Boolean);
+  // Exact-address match only. searchDirectoryPeople is a prefix/substring
+  // search, so "kris@" can return several people; picking [0] would be a
+  // confident wrong answer.
+  const match = shaped.find((p) => p.email && p.email.toLowerCase() === normalized) || null;
+
+  const result = match
+    ? { found: true, ...match }
+    : { found: false, query: normalized, reason: candidates.length ? 'no exact address match' : 'not in directory' };
+  writeCache(key, result, now);
+  return result;
+}
+
+/**
+ * Chat `users/{id}` -> district person, via people.get on the same id.
+ */
+async function resolvePersonId(rawId, accessToken, opts = {}) {
+  const id = normalizePersonId(rawId);
+  if (!id) throw new DirectoryError('INVALID_INPUT', `Not a valid person/Chat id: ${rawId}`);
+  const now = opts.now || Date.now();
+  const key = `id:${id}`;
+
+  if (!opts.noCache) {
+    const hit = readCache(key, now);
+    if (hit) return { ...hit, cached: true };
+  }
+
+  const url = `${PEOPLE_BASE}/people/${encodeURIComponent(id)}?personFields=${encodeURIComponent(READ_MASK)}`;
+  let body;
+  try {
+    body = await callPeople(url, accessToken, opts.fetchImpl);
+  } catch (err) {
+    // A 404 is a legitimate "no such person", not a failure to report upward.
+    if (err instanceof DirectoryError && err.code === 'LOOKUP_FAILED' && /HTTP 404|not found/i.test(err.message)) {
+      const miss = { found: false, query: id, reason: 'not in directory' };
+      writeCache(key, miss, now);
+      return miss;
+    }
+    throw err;
+  }
+
+  const shaped = shapePerson(body);
+  const result = shaped
+    ? { found: true, ...shaped }
+    : { found: false, query: id, reason: 'directory returned no usable fields' };
+  writeCache(key, result, now);
+  return result;
+}
+
+module.exports = {
+  resolveEmail,
+  resolvePersonId,
+  shapePerson,
+  normalizeEmail,
+  normalizePersonId,
+  classifyError,
+  readCache,
+  writeCache,
+  cacheDir,
+  DirectoryError,
+  POSITIVE_TTL_MS,
+  NEGATIVE_TTL_MS,
+};

--- a/infra/agent-image/skills/psd-directory/lib.js
+++ b/infra/agent-image/skills/psd-directory/lib.js
@@ -148,6 +148,20 @@ class DirectoryError extends Error {
   }
 }
 
+/**
+ * Accept either a token string or an async provider that mints one.
+ *
+ * The provider form exists so a CACHE HIT COSTS NO TOKEN. Minting goes through
+ * the DWD broker, which rate-limits to 120 mints/hour per owner
+ * (lib/agent-workspace/token-rate-limit.ts) and shares that budget with
+ * psd-workspace. Minting eagerly on every lookup would mean a heavily-cached
+ * identity lookup could still exhaust the limit and take Gmail/Calendar/Drive
+ * down with it. Resolve the token only once the cache has actually missed.
+ */
+async function resolveToken(tokenOrProvider) {
+  return typeof tokenOrProvider === 'function' ? await tokenOrProvider() : tokenOrProvider;
+}
+
 async function callPeople(url, accessToken, fetchImpl) {
   const doFetch = fetchImpl || globalThis.fetch;
   let resp;
@@ -212,7 +226,7 @@ function shapePerson(person) {
  * would be worse than not resolving at all, given the agent uses this to
  * decide who it is talking about.
  */
-async function resolveEmail(email, accessToken, opts = {}) {
+async function resolveEmail(email, tokenOrProvider, opts = {}) {
   const normalized = normalizeEmail(email);
   if (!normalized) throw new DirectoryError('INVALID_INPUT', `Not a valid email address: ${email}`);
   const now = opts.now || Date.now();
@@ -228,7 +242,8 @@ async function resolveEmail(email, accessToken, opts = {}) {
     `?query=${encodeURIComponent(normalized)}` +
     `&readMask=${encodeURIComponent(READ_MASK)}` +
     `&sources=DIRECTORY_SOURCE_TYPE_DOMAIN_PROFILE`;
-  const body = await callPeople(url, accessToken, opts.fetchImpl);
+  // Token resolved HERE, after the cache miss — never before it.
+  const body = await callPeople(url, await resolveToken(tokenOrProvider), opts.fetchImpl);
 
   const candidates = Array.isArray(body.people) ? body.people : [];
   // Exact-address match only. searchDirectoryPeople is a prefix/substring
@@ -259,7 +274,7 @@ async function resolveEmail(email, accessToken, opts = {}) {
 /**
  * Chat `users/{id}` -> district person, via people.get on the same id.
  */
-async function resolvePersonId(rawId, accessToken, opts = {}) {
+async function resolvePersonId(rawId, tokenOrProvider, opts = {}) {
   const id = normalizePersonId(rawId);
   if (!id) throw new DirectoryError('INVALID_INPUT', `Not a valid person/Chat id: ${rawId}`);
   const now = opts.now || Date.now();
@@ -273,7 +288,8 @@ async function resolvePersonId(rawId, accessToken, opts = {}) {
   const url = `${PEOPLE_BASE}/people/${encodeURIComponent(id)}?personFields=${encodeURIComponent(READ_MASK)}`;
   let body;
   try {
-    body = await callPeople(url, accessToken, opts.fetchImpl);
+    // Token resolved HERE, after the cache miss — never before it.
+    body = await callPeople(url, await resolveToken(tokenOrProvider), opts.fetchImpl);
   } catch (err) {
     // A 404 is a legitimate "no such person", not a failure to report upward.
     if (err instanceof DirectoryError && err.code === 'LOOKUP_FAILED' && /HTTP 404|not found/i.test(err.message)) {
@@ -295,6 +311,7 @@ async function resolvePersonId(rawId, accessToken, opts = {}) {
 module.exports = {
   resolveEmail,
   addressesOf,
+  resolveToken,
   resolvePersonId,
   shapePerson,
   normalizeEmail,

--- a/infra/agent-image/skills/psd-directory/lib.js
+++ b/infra/agent-image/skills/psd-directory/lib.js
@@ -165,6 +165,18 @@ async function callPeople(url, accessToken, fetchImpl) {
 }
 
 /**
+ * Every address on a directory record, lowercased — primary AND aliases.
+ * Matching uses this; the shaped record still reports the primary as the
+ * canonical `email`.
+ */
+function addressesOf(person) {
+  if (!person || !Array.isArray(person.emailAddresses)) return [];
+  return person.emailAddresses
+    .map((e) => (e && typeof e.value === 'string' ? e.value.trim().toLowerCase() : null))
+    .filter(Boolean);
+}
+
+/**
  * Shape a People API person into the flat record the agent actually wants.
  * Returns null when the payload carries no usable identity, so an empty
  * response is reported as "not found" rather than as a person with no name.
@@ -219,14 +231,26 @@ async function resolveEmail(email, accessToken, opts = {}) {
   const body = await callPeople(url, accessToken, opts.fetchImpl);
 
   const candidates = Array.isArray(body.people) ? body.people : [];
-  const shaped = candidates.map(shapePerson).filter(Boolean);
   // Exact-address match only. searchDirectoryPeople is a prefix/substring
   // search, so "kris@" can return several people; picking [0] would be a
   // confident wrong answer.
-  const match = shaped.find((p) => p.email && p.email.toLowerCase() === normalized) || null;
+  //
+  // Match against EVERY address on the record, not just the primary. A
+  // directory profile can carry aliases (a firstname.lastname form, or a
+  // pre-name-change address kept as an alias), and those are exactly the
+  // addresses a human is most likely to hand the agent. Comparing only the
+  // primary — which is what shapePerson leaves behind — would report
+  // found:false for a person Google had already returned correctly, then
+  // cache that miss.
+  const match = candidates.find((p) => addressesOf(p).includes(normalized)) || null;
+  const shaped = match ? shapePerson(match) : null;
 
-  const result = match
-    ? { found: true, ...match }
+  // When the query matched an alias, say so rather than silently answering
+  // about a different-looking address than the one that was asked about.
+  const matchedAlias = shaped && shaped.email && shaped.email.toLowerCase() !== normalized ? normalized : null;
+
+  const result = shaped
+    ? { found: true, ...shaped, ...(matchedAlias ? { matchedAlias } : {}) }
     : { found: false, query: normalized, reason: candidates.length ? 'no exact address match' : 'not in directory' };
   writeCache(key, result, now);
   return result;
@@ -270,6 +294,7 @@ async function resolvePersonId(rawId, accessToken, opts = {}) {
 
 module.exports = {
   resolveEmail,
+  addressesOf,
   resolvePersonId,
   shapePerson,
   normalizeEmail,

--- a/infra/agent-image/skills/psd-directory/lib.js
+++ b/infra/agent-image/skills/psd-directory/lib.js
@@ -162,6 +162,35 @@ async function resolveToken(tokenOrProvider) {
   return typeof tokenOrProvider === 'function' ? await tokenOrProvider() : tokenOrProvider;
 }
 
+/**
+ * Build the memoized, LAZY token provider the lookups call on a cache miss.
+ *
+ * Lives here rather than in run.js so the failure paths are testable: the
+ * broker call is injected, so "account not provisioned" (exit 14) and a broker
+ * transport failure (exit 12) can be exercised without an image or a network.
+ *
+ * Memoized so a single CLI invocation can never mint twice, and so a caller
+ * that resolves several identities spends one token rather than one each.
+ */
+function makeTokenMinter(fetchBrokerToken, ownerEmail) {
+  let minted = null;
+  return async () => {
+    if (!minted) {
+      let broker;
+      try {
+        broker = await fetchBrokerToken(ownerEmail);
+      } catch (err) {
+        throw new DirectoryError('MINT_TRANSPORT', `could not mint an agent token: ${err.message}`);
+      }
+      if (broker && broker.notProvisioned) {
+        throw new DirectoryError('ACCOUNT_NOT_PROVISIONED', 'account-not-provisioned');
+      }
+      minted = broker;
+    }
+    return minted.accessToken;
+  };
+}
+
 async function callPeople(url, accessToken, fetchImpl) {
   const doFetch = fetchImpl || globalThis.fetch;
   let resp;
@@ -312,6 +341,7 @@ module.exports = {
   resolveEmail,
   addressesOf,
   resolveToken,
+  makeTokenMinter,
   resolvePersonId,
   shapePerson,
   normalizeEmail,

--- a/infra/agent-image/skills/psd-directory/lib.js
+++ b/infra/agent-image/skills/psd-directory/lib.js
@@ -138,6 +138,16 @@ function classifyError(status, body) {
   if (status === 403 || status === 401) {
     return { code: 'FORBIDDEN', message };
   }
+  // 5xx is an upstream outage, not a bad request. It has to classify as
+  // TRANSPORT so run.js exits 12 ("transient — retry once") rather than 2
+  // ("do not retry blindly"), which is what SKILL.md promises callers. A 502
+  // from a load balancer also carries an HTML body, so `message` is empty
+  // here and the status is the only signal — classify on it, never on the
+  // parsed body (AGENTS.md: infra errors must stay distinguishable from app
+  // errors).
+  if (status >= 500) {
+    return { code: 'TRANSPORT', message: message || `People API returned HTTP ${status}` };
+  }
   return { code: 'LOOKUP_FAILED', message: message || `HTTP ${status}` };
 }
 
@@ -199,12 +209,22 @@ async function callPeople(url, accessToken, fetchImpl) {
   } catch (err) {
     throw new DirectoryError('TRANSPORT', `People API request failed: ${err.message}`);
   }
-  const body = await resp.json().catch(() => ({}));
+  // Status first, body second. On a failure the body is only used to enrich
+  // the message — the STATUS decides the class, so an HTML 502 from a load
+  // balancer still classifies as transport rather than as an app error.
   if (!resp.ok) {
+    const body = await resp.json().catch(() => ({}));
     const { code, message } = classifyError(resp.status, body);
     throw new DirectoryError(code, message);
   }
-  return body;
+  // A 2xx whose body will not parse must NOT degrade to `{}`. That used to
+  // shape into found:false — reporting "not in the directory" for a person who
+  // is in it, and caching that miss. A malformed success is a failure.
+  try {
+    return await resp.json();
+  } catch (err) {
+    throw new DirectoryError('LOOKUP_FAILED', `People API returned an unparseable body: ${err.message}`);
+  }
 }
 
 /**

--- a/infra/agent-image/skills/psd-directory/lib.test.js
+++ b/infra/agent-image/skills/psd-directory/lib.test.js
@@ -366,6 +366,63 @@ describe('caching', () => {
   });
 });
 
+describe('makeTokenMinter', () => {
+  // These are run.js's exit-14 and exit-12 paths. They live in lib.js with the
+  // broker injected precisely so they can be exercised here — previously the
+  // only coverage was "it works in the container".
+  test('mints once and memoizes across repeated calls', async () => {
+    let calls = 0;
+    const broker = async () => {
+      calls += 1;
+      return { accessToken: 'tok-' + calls };
+    };
+    const mint = lib.makeTokenMinter(broker, 'owner@psd401.net');
+    expect(await mint()).toBe('tok-1');
+    expect(await mint()).toBe('tok-1');
+    expect(calls).toBe(1);
+  });
+
+  test('passes the owner through to the broker', async () => {
+    let seen = null;
+    const broker = async (email) => {
+      seen = email;
+      return { accessToken: 't' };
+    };
+    await lib.makeTokenMinter(broker, 'owner@psd401.net')();
+    expect(seen).toBe('owner@psd401.net');
+  });
+
+  test('an unprovisioned account is a typed error (run.js exit 14)', async () => {
+    const broker = async () => ({ notProvisioned: true });
+    await expect(lib.makeTokenMinter(broker, 'o@psd401.net')()).rejects.toMatchObject({
+      code: 'ACCOUNT_NOT_PROVISIONED',
+    });
+  });
+
+  test('a broker failure is a typed transport error (run.js exit 12)', async () => {
+    const broker = async () => {
+      throw new Error('connect ECONNREFUSED');
+    };
+    await expect(lib.makeTokenMinter(broker, 'o@psd401.net')()).rejects.toMatchObject({
+      code: 'MINT_TRANSPORT',
+    });
+  });
+
+  test('a failed mint is not memoized as success', async () => {
+    // A transient broker blip must not poison the minter for the rest of the
+    // invocation — the next call has to be allowed to try again.
+    let calls = 0;
+    const broker = async () => {
+      calls += 1;
+      if (calls === 1) throw new Error('transient');
+      return { accessToken: 'tok' };
+    };
+    const mint = lib.makeTokenMinter(broker, 'o@psd401.net');
+    await expect(mint()).rejects.toMatchObject({ code: 'MINT_TRANSPORT' });
+    expect(await mint()).toBe('tok');
+  });
+});
+
 describe('SKILL.md registration frontmatter', () => {
   // The stack parses this frontmatter at registration
   // (infra/lib/agent-platform-stack.ts) and substitutes the useless string

--- a/infra/agent-image/skills/psd-directory/lib.test.js
+++ b/infra/agent-image/skills/psd-directory/lib.test.js
@@ -319,6 +319,45 @@ describe('caching', () => {
   });
 });
 
+describe('SKILL.md registration frontmatter', () => {
+  // The stack parses this frontmatter at registration
+  // (infra/lib/agent-platform-stack.ts) and substitutes the useless string
+  // "Bundled skill: <name>" when `summary` is absent. psd-skills-meta's
+  // skills.search then matches on NAME and SUMMARY only — never description.
+  // A skill without a keyword-rich summary is therefore findable only by
+  // someone who already knows it is called "directory", which defeats the
+  // point of shipping it. Caught by codex on PR #1351.
+  const frontmatter = () => {
+    const raw = fs.readFileSync(path.join(__dirname, 'SKILL.md'), 'utf8');
+    const fm = raw.match(/^---\n([\s\S]*?)\n---/);
+    expect(fm).not.toBeNull();
+    const fields = {};
+    for (const line of fm[1].split('\n')) {
+      const m = line.match(/^([a-z-]+):\s*(.*)$/);
+      if (m) fields[m[1]] = m[2].trim();
+    }
+    return fields;
+  };
+
+  test('declares name, summary, description and allowed-tools', () => {
+    const fm = frontmatter();
+    expect(fm.name).toBe('psd-directory');
+    expect(fm.summary && fm.summary.length).toBeGreaterThan(0);
+    expect(fm.description && fm.description.length).toBeGreaterThan(0);
+    // Without this the skill cannot shell out to node, so it cannot run at all.
+    expect(fm['allowed-tools']).toBe('Bash(node:*)');
+  });
+
+  test('the summary carries the words someone would actually search', () => {
+    // Not cosmetic: these are the natural queries for this capability, and
+    // summary is the only free-text field skills.search looks at.
+    const summary = frontmatter().summary.toLowerCase();
+    for (const term of ['email', 'chat', 'person', 'name', 'title', 'who']) {
+      expect(summary).toContain(term);
+    }
+  });
+});
+
 describe('no enumeration surface', () => {
   test('the module exposes no directory-listing entry point', () => {
     // The district directory contains ClassLink-provisioned STUDENT records.

--- a/infra/agent-image/skills/psd-directory/lib.test.js
+++ b/infra/agent-image/skills/psd-directory/lib.test.js
@@ -238,6 +238,53 @@ describe('caching', () => {
     expect(fetchImpl.calls.length).toBe(1);
   });
 
+  test('a cache HIT never mints a token (codex P2)', async () => {
+    // The DWD broker rate-limits to 120 mints/hour per owner and shares that
+    // budget with psd-workspace. If a lookup mints before consulting the
+    // cache, a chatty-but-cached workload burns the limit and takes
+    // Gmail/Calendar/Drive down with it — while SKILL.md is telling the model
+    // repeated lookups are free. The token must be resolved only on a miss.
+    let mints = 0;
+    const mintToken = async () => {
+      mints += 1;
+      return 'tok';
+    };
+    const fetchImpl = stubFetch(() => ({
+      body: { people: [person('116', 'Kris Hagel', 'hagelk@psd401.net', null)] },
+    }));
+
+    await lib.resolveEmail('hagelk@psd401.net', mintToken, { fetchImpl });
+    expect(mints).toBe(1); // miss -> one mint
+
+    await lib.resolveEmail('hagelk@psd401.net', mintToken, { fetchImpl });
+    await lib.resolveEmail('hagelk@psd401.net', mintToken, { fetchImpl });
+    expect(mints).toBe(1); // hits -> still one
+    expect(fetchImpl.calls.length).toBe(1);
+  });
+
+  test('a cached id lookup never mints either', async () => {
+    let mints = 0;
+    const mintToken = async () => {
+      mints += 1;
+      return 'tok';
+    };
+    const fetchImpl = stubFetch(() => ({
+      body: person('999', 'Someone Else', 'else@psd401.net', null),
+    }));
+    await lib.resolvePersonId('users/999', mintToken, { fetchImpl });
+    await lib.resolvePersonId('users/999', mintToken, { fetchImpl });
+    expect(mints).toBe(1);
+    expect(fetchImpl.calls.length).toBe(1);
+  });
+
+  test('a plain token string still works (provider is optional)', async () => {
+    const fetchImpl = stubFetch(() => ({
+      body: { people: [person('116', 'Kris Hagel', 'hagelk@psd401.net', null)] },
+    }));
+    const r = await lib.resolveEmail('hagelk@psd401.net', 'literal-token', { fetchImpl });
+    expect(r.found).toBe(true);
+  });
+
   test('--no-cache forces a fresh call', async () => {
     const fetchImpl = stubFetch(() => ({
       body: { people: [person('116', 'Kris Hagel', 'hagelk@psd401.net', null)] },

--- a/infra/agent-image/skills/psd-directory/lib.test.js
+++ b/infra/agent-image/skills/psd-directory/lib.test.js
@@ -107,6 +107,46 @@ describe('resolveEmail', () => {
     expect(r.reason).toBe('no exact address match');
   });
 
+  test('an ALIAS address resolves to the person (codex P2)', async () => {
+    // A directory profile can carry aliases — a firstname.lastname form, or a
+    // pre-name-change address kept as an alias — and those are exactly the
+    // addresses a human is most likely to hand the agent. Matching only the
+    // PRIMARY address would report found:false for a person Google had
+    // already returned correctly, and then cache that miss.
+    const rec = person('116', 'Kris Hagel', 'hagelk@psd401.net', null);
+    rec.emailAddresses.push({ metadata: { primary: false }, value: 'kris.hagel@psd401.net' });
+    const fetchImpl = stubFetch(() => ({ body: { people: [rec] } }));
+
+    const r = await lib.resolveEmail('kris.hagel@psd401.net', 'tok', { fetchImpl });
+    expect(r.found).toBe(true);
+    expect(r.personId).toBe('116');
+    // The canonical address is still reported as `email`...
+    expect(r.email).toBe('hagelk@psd401.net');
+    // ...and the alias that was actually asked about is surfaced, so the
+    // answer cannot look like it is about a different person.
+    expect(r.matchedAlias).toBe('kris.hagel@psd401.net');
+  });
+
+  test('matchedAlias is absent when the primary address was the query', async () => {
+    const fetchImpl = stubFetch(() => ({
+      body: { people: [person('116', 'Kris Hagel', 'hagelk@psd401.net', null)] },
+    }));
+    const r = await lib.resolveEmail('hagelk@psd401.net', 'tok', { fetchImpl });
+    expect(r.found).toBe(true);
+    expect(r.matchedAlias).toBeUndefined();
+  });
+
+  test('an alias on the WRONG record still does not match', async () => {
+    // Widening the comparison to every address must not weaken the
+    // exact-match rule that stops a fuzzy hit being reported as the person.
+    const other = person('2', 'Someone Else', 'else@psd401.net', null);
+    other.emailAddresses.push({ metadata: { primary: false }, value: 'se@psd401.net' });
+    const fetchImpl = stubFetch(() => ({ body: { people: [other] } }));
+    const r = await lib.resolveEmail('hagel@psd401.net', 'tok', { fetchImpl });
+    expect(r.found).toBe(false);
+    expect(r.reason).toBe('no exact address match');
+  });
+
   test('matches case-insensitively', async () => {
     const fetchImpl = stubFetch(() => ({
       body: { people: [person('116', 'Kris Hagel', 'HagelK@psd401.net', null)] },

--- a/infra/agent-image/skills/psd-directory/lib.test.js
+++ b/infra/agent-image/skills/psd-directory/lib.test.js
@@ -1,0 +1,299 @@
+/**
+ * psd-directory lib tests (#1239).
+ *
+ * Run: bun test lib.test.js   (from this directory, or via
+ *      `bun run test:skill:directory` at the repo root)
+ *
+ * These pin the properties that would silently produce a WRONG identity
+ * rather than a visible failure — which is the whole point of the issue, since
+ * the agent uses these answers to decide who it is talking about.
+ */
+
+'use strict';
+
+const { test, expect, describe, beforeEach, afterEach } = require('bun:test');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const lib = require('./lib');
+
+// Isolate the on-disk cache per run so tests never read each other's writes
+// (or the developer's real cache).
+let CACHE_DIR;
+beforeEach(() => {
+  CACHE_DIR = fs.mkdtempSync(path.join(os.tmpdir(), 'psd-dir-test-'));
+  process.env.PSD_DIRECTORY_CACHE_DIR = CACHE_DIR;
+});
+afterEach(() => {
+  fs.rmSync(CACHE_DIR, { recursive: true, force: true });
+  delete process.env.PSD_DIRECTORY_CACHE_DIR;
+});
+
+/** Build a People API person payload. */
+const person = (id, name, email, org) => ({
+  resourceName: `people/${id}`,
+  names: name ? [{ metadata: { primary: true }, displayName: name }] : [],
+  emailAddresses: email ? [{ metadata: { primary: true }, value: email }] : [],
+  organizations: org ? [{ metadata: { primary: true }, ...org }] : [],
+});
+
+/** A fetch stub that records calls and returns a canned response. */
+function stubFetch(responder) {
+  const calls = [];
+  const impl = async (url) => {
+    calls.push(url);
+    const { status = 200, body = {} } = responder(url) || {};
+    return { ok: status >= 200 && status < 300, status, json: async () => body };
+  };
+  impl.calls = calls;
+  return impl;
+}
+
+describe('normalizePersonId', () => {
+  test('accepts users/, people/ and bare numeric forms', () => {
+    expect(lib.normalizePersonId('users/12345')).toBe('12345');
+    expect(lib.normalizePersonId('people/12345')).toBe('12345');
+    expect(lib.normalizePersonId('12345')).toBe('12345');
+    expect(lib.normalizePersonId('  users/12345  ')).toBe('12345');
+  });
+
+  test('rejects anything that is not a bare id', () => {
+    // A non-numeric id would be interpolated into the request path, so this
+    // is the input-validation boundary, not a cosmetic check.
+    expect(lib.normalizePersonId('users/../../etc/passwd')).toBeNull();
+    expect(lib.normalizePersonId('me')).toBeNull();
+    expect(lib.normalizePersonId('')).toBeNull();
+    expect(lib.normalizePersonId(null)).toBeNull();
+  });
+});
+
+describe('resolveEmail', () => {
+  test('returns the person on an exact address match', async () => {
+    const fetchImpl = stubFetch(() => ({
+      body: {
+        people: [
+          person('116', 'Kris Hagel', 'hagelk@psd401.net', {
+            title: 'Chief',
+            department: 'Multiple Locations',
+            name: 'Peninsula School District',
+          }),
+        ],
+      },
+    }));
+    const r = await lib.resolveEmail('hagelk@psd401.net', 'tok', { fetchImpl });
+    expect(r.found).toBe(true);
+    expect(r.displayName).toBe('Kris Hagel');
+    expect(r.personId).toBe('116');
+    expect(r.title).toBe('Chief');
+    expect(r.department).toBe('Multiple Locations');
+  });
+
+  test('a near-miss search result is NOT reported as the person', async () => {
+    // searchDirectoryPeople is a prefix/substring search: querying one address
+    // can return other people. Taking [0] would be a confident WRONG answer —
+    // the agent would attribute a message to the wrong human. Exact-address
+    // match is the only acceptable rule.
+    const fetchImpl = stubFetch(() => ({
+      body: {
+        people: [
+          person('1', 'Kristen Hagelin', 'hagelink@psd401.net', null),
+          person('2', 'Kris Hagelund', 'hagelund@psd401.net', null),
+        ],
+      },
+    }));
+    const r = await lib.resolveEmail('hagel@psd401.net', 'tok', { fetchImpl });
+    expect(r.found).toBe(false);
+    expect(r.reason).toBe('no exact address match');
+  });
+
+  test('matches case-insensitively', async () => {
+    const fetchImpl = stubFetch(() => ({
+      body: { people: [person('116', 'Kris Hagel', 'HagelK@psd401.net', null)] },
+    }));
+    const r = await lib.resolveEmail('HAGELK@PSD401.NET', 'tok', { fetchImpl });
+    expect(r.found).toBe(true);
+    expect(r.personId).toBe('116');
+  });
+
+  test('rejects input that cannot be an address', async () => {
+    await expect(lib.resolveEmail('not-an-address', 'tok', {})).rejects.toThrow(/valid email/i);
+  });
+
+  test('requests only the DOMAIN_PROFILE source', async () => {
+    const fetchImpl = stubFetch(() => ({ body: { people: [] } }));
+    await lib.resolveEmail('x@psd401.net', 'tok', { fetchImpl });
+    expect(fetchImpl.calls[0]).toContain('sources=DIRECTORY_SOURCE_TYPE_DOMAIN_PROFILE');
+    expect(fetchImpl.calls[0]).toContain('people%3AsearchDirectoryPeople'.replace('%3A', ':'));
+  });
+});
+
+describe('resolvePersonId', () => {
+  test('resolves a Chat users/{id} via people.get', async () => {
+    const fetchImpl = stubFetch(() => ({
+      body: person('116264913639920976203', 'Kris Hagel', 'hagelk@psd401.net', { title: 'Chief' }),
+    }));
+    const r = await lib.resolvePersonId('users/116264913639920976203', 'tok', { fetchImpl });
+    expect(r.found).toBe(true);
+    expect(r.displayName).toBe('Kris Hagel');
+    expect(r.email).toBe('hagelk@psd401.net');
+    expect(fetchImpl.calls[0]).toContain('/people/116264913639920976203');
+  });
+
+  test('an empty-field response is a MISS, not a nameless person', async () => {
+    // This is the exact failure mode #1239 feared for the service-account
+    // context (and the trigger for Option B). If it ever starts happening, the
+    // agent must see found:false rather than a person with null everything.
+    const fetchImpl = stubFetch(() => ({ body: { resourceName: 'people/999' } }));
+    const r = await lib.resolvePersonId('users/999', 'tok', { fetchImpl });
+    expect(r.found).toBe(false);
+    expect(r.reason).toBe('directory returned no usable fields');
+  });
+
+  test('a 404 is a miss, not an error', async () => {
+    const fetchImpl = stubFetch(() => ({ status: 404, body: { error: { message: 'Requested entity was not found.' } } }));
+    const r = await lib.resolvePersonId('users/404', 'tok', { fetchImpl });
+    expect(r.found).toBe(false);
+    expect(r.reason).toBe('not in directory');
+  });
+});
+
+describe('error classification', () => {
+  test('the admin-console 403 is distinguished from a scope 403', () => {
+    // These two 403s demand completely different remedies — an admin action
+    // vs a token/scope fix. Collapsing them is what made #1239 expensive to
+    // diagnose, so the distinction is pinned.
+    expect(
+      lib.classifyError(403, { error: { message: 'The G Suite domain admin has disabled external directory sharing.' } }).code
+    ).toBe('DIRECTORY_SHARING_DISABLED');
+    expect(
+      lib.classifyError(403, { error: { message: 'Request had insufficient authentication scopes.' } }).code
+    ).toBe('INSUFFICIENT_SCOPE');
+  });
+
+  test('the sharing-disabled 403 propagates as a typed error', async () => {
+    const fetchImpl = stubFetch(() => ({
+      status: 403,
+      body: { error: { message: 'The G Suite domain admin has disabled external directory sharing.' } },
+    }));
+    await expect(lib.resolveEmail('x@psd401.net', 'tok', { fetchImpl })).rejects.toMatchObject({
+      code: 'DIRECTORY_SHARING_DISABLED',
+    });
+  });
+});
+
+describe('caching', () => {
+  test('a second lookup does not call the API', async () => {
+    const fetchImpl = stubFetch(() => ({
+      body: { people: [person('116', 'Kris Hagel', 'hagelk@psd401.net', null)] },
+    }));
+    const first = await lib.resolveEmail('hagelk@psd401.net', 'tok', { fetchImpl });
+    const second = await lib.resolveEmail('hagelk@psd401.net', 'tok', { fetchImpl });
+    expect(first.cached).toBeUndefined();
+    expect(second.cached).toBe(true);
+    expect(second.displayName).toBe('Kris Hagel');
+    // The acceptance criterion is "cached to avoid per-message directory
+    // calls" — so the call count, not just the returned value, is the assertion.
+    expect(fetchImpl.calls.length).toBe(1);
+  });
+
+  test('--no-cache forces a fresh call', async () => {
+    const fetchImpl = stubFetch(() => ({
+      body: { people: [person('116', 'Kris Hagel', 'hagelk@psd401.net', null)] },
+    }));
+    await lib.resolveEmail('hagelk@psd401.net', 'tok', { fetchImpl });
+    await lib.resolveEmail('hagelk@psd401.net', 'tok', { fetchImpl, noCache: true });
+    expect(fetchImpl.calls.length).toBe(2);
+  });
+
+  test('an expired positive entry is refetched', async () => {
+    const fetchImpl = stubFetch(() => ({
+      body: { people: [person('116', 'Kris Hagel', 'hagelk@psd401.net', null)] },
+    }));
+    const t0 = 1_000_000;
+    await lib.resolveEmail('hagelk@psd401.net', 'tok', { fetchImpl, now: t0 });
+    await lib.resolveEmail('hagelk@psd401.net', 'tok', {
+      fetchImpl,
+      now: t0 + lib.POSITIVE_TTL_MS + 1,
+    });
+    expect(fetchImpl.calls.length).toBe(2);
+  });
+
+  test('misses expire much faster than hits', async () => {
+    // A miss is often a race with provisioning; caching it for the positive
+    // TTL would make a real new hire look permanently unresolvable.
+    expect(lib.NEGATIVE_TTL_MS).toBeLessThan(lib.POSITIVE_TTL_MS);
+
+    const fetchImpl = stubFetch(() => ({ body: { people: [] } }));
+    const t0 = 2_000_000;
+    await lib.resolveEmail('ghost@psd401.net', 'tok', { fetchImpl, now: t0 });
+    await lib.resolveEmail('ghost@psd401.net', 'tok', { fetchImpl, now: t0 + lib.NEGATIVE_TTL_MS + 1 });
+    expect(fetchImpl.calls.length).toBe(2);
+  });
+
+  test('email and id lookups do not collide in the cache', async () => {
+    const fetchEmail = stubFetch(() => ({
+      body: { people: [person('116', 'Kris Hagel', 'hagelk@psd401.net', null)] },
+    }));
+    const fetchId = stubFetch(() => ({ body: person('999', 'Someone Else', 'else@psd401.net', null) }));
+    await lib.resolveEmail('hagelk@psd401.net', 'tok', { fetchImpl: fetchEmail });
+    const byId = await lib.resolvePersonId('users/999', 'tok', { fetchImpl: fetchId });
+    expect(byId.displayName).toBe('Someone Else');
+    expect(fetchId.calls.length).toBe(1);
+  });
+
+  test('a corrupt cache file is a miss, not a crash', async () => {
+    const fetchImpl = stubFetch(() => ({
+      body: { people: [person('116', 'Kris Hagel', 'hagelk@psd401.net', null)] },
+    }));
+    await lib.resolveEmail('hagelk@psd401.net', 'tok', { fetchImpl });
+    for (const f of fs.readdirSync(CACHE_DIR)) {
+      fs.writeFileSync(path.join(CACHE_DIR, f), '{not json');
+    }
+    const r = await lib.resolveEmail('hagelk@psd401.net', 'tok', { fetchImpl });
+    expect(r.found).toBe(true);
+    expect(fetchImpl.calls.length).toBe(2);
+  });
+
+  test('an unwritable cache directory does not fail the lookup', async () => {
+    // Losing the cache costs latency, not correctness — the lookup already
+    // succeeded by the time we try to persist it.
+    process.env.PSD_DIRECTORY_CACHE_DIR = '/proc/psd-directory-cannot-exist';
+    const fetchImpl = stubFetch(() => ({
+      body: { people: [person('116', 'Kris Hagel', 'hagelk@psd401.net', null)] },
+    }));
+    const r = await lib.resolveEmail('hagelk@psd401.net', 'tok', { fetchImpl });
+    expect(r.found).toBe(true);
+  });
+
+  test('no email address is written into a cache filename in plaintext', async () => {
+    const fetchImpl = stubFetch(() => ({
+      body: { people: [person('116', 'Kris Hagel', 'hagelk@psd401.net', null)] },
+    }));
+    await lib.resolveEmail('hagelk@psd401.net', 'tok', { fetchImpl });
+    for (const f of fs.readdirSync(CACHE_DIR)) {
+      expect(f).not.toContain('hagelk');
+      expect(f).not.toContain('@');
+    }
+  });
+});
+
+describe('no enumeration surface', () => {
+  test('the module exposes no directory-listing entry point', () => {
+    // The district directory contains ClassLink-provisioned STUDENT records.
+    // A list/enumerate helper here would be a student-directory dumper one
+    // prompt away, so its absence is a deliberate safety property and is
+    // asserted rather than left to reviewer memory.
+    // Asserted against the EXECUTABLE source, not the file: the header
+    // deliberately names listDirectoryPeople at length to explain why it is
+    // absent, and that prose must not be what keeps this test green.
+    const src = fs
+      .readFileSync(path.join(__dirname, 'lib.js'), 'utf8')
+      .replace(/\/\*[\s\S]*?\*\//g, '')
+      .replace(/\/\/[^\n]*/g, '');
+    expect(src).not.toContain('listDirectoryPeople');
+    for (const name of Object.keys(lib)) {
+      expect(name).not.toMatch(/^(list|enumerate|dump|all)/i);
+    }
+  });
+});

--- a/infra/agent-image/skills/psd-directory/lib.test.js
+++ b/infra/agent-image/skills/psd-directory/lib.test.js
@@ -43,8 +43,15 @@ function stubFetch(responder) {
   const calls = [];
   const impl = async (url) => {
     calls.push(url);
-    const { status = 200, body = {} } = responder(url) || {};
-    return { ok: status >= 200 && status < 300, status, json: async () => body };
+    const { status = 200, body = {}, unparseable = false } = responder(url) || {};
+    return {
+      ok: status >= 200 && status < 300,
+      status,
+      json: async () => {
+        if (unparseable) throw new SyntaxError('Unexpected token < in JSON at position 0');
+        return body;
+      },
+    };
   };
   impl.calls = calls;
   return impl;
@@ -210,6 +217,36 @@ describe('error classification', () => {
     expect(
       lib.classifyError(403, { error: { message: 'Request had insufficient authentication scopes.' } }).code
     ).toBe('INSUFFICIENT_SCOPE');
+  });
+
+  test('a 5xx is TRANSPORT, not a generic lookup failure (codex P2)', async () => {
+    // run.js maps TRANSPORT to exit 12 ("transient — retry once") and
+    // LOOKUP_FAILED to exit 2 ("do not retry blindly"). Misclassifying an
+    // upstream outage as exit 2 tells callers not to retry during exactly the
+    // situation retrying is for.
+    for (const status of [500, 502, 503, 504]) {
+      expect(lib.classifyError(status, {}).code).toBe('TRANSPORT');
+    }
+  });
+
+  test('a 502 with an HTML body still classifies on status', async () => {
+    // A load-balancer 502 carries HTML, so the parsed error message is empty
+    // and the status is the ONLY signal. Classifying on the body would make
+    // infra errors indistinguishable from app errors (AGENTS.md).
+    const fetchImpl = stubFetch(() => ({ status: 502, unparseable: true }));
+    await expect(lib.resolveEmail('x@psd401.net', 'tok', { fetchImpl })).rejects.toMatchObject({
+      code: 'TRANSPORT',
+    });
+  });
+
+  test('a 2xx with an unparseable body FAILS instead of becoming a false miss', async () => {
+    // Previously the body was parsed with .catch(() => ({})), so a malformed
+    // 200 shaped into found:false — reporting "not in the directory" for a
+    // person who is in it, and caching that miss for 5 minutes.
+    const fetchImpl = stubFetch(() => ({ status: 200, unparseable: true }));
+    await expect(lib.resolveEmail('x@psd401.net', 'tok', { fetchImpl })).rejects.toMatchObject({
+      code: 'LOOKUP_FAILED',
+    });
   });
 
   test('the sharing-disabled 403 propagates as a typed error', async () => {

--- a/infra/agent-image/skills/psd-directory/lib.test.js
+++ b/infra/agent-image/skills/psd-directory/lib.test.js
@@ -124,7 +124,8 @@ describe('resolveEmail', () => {
     const fetchImpl = stubFetch(() => ({ body: { people: [] } }));
     await lib.resolveEmail('x@psd401.net', 'tok', { fetchImpl });
     expect(fetchImpl.calls[0]).toContain('sources=DIRECTORY_SOURCE_TYPE_DOMAIN_PROFILE');
-    expect(fetchImpl.calls[0]).toContain('people%3AsearchDirectoryPeople'.replace('%3A', ':'));
+    // The colon in the RPC-style verb is not percent-encoded in the request.
+    expect(fetchImpl.calls[0]).toContain('/people:searchDirectoryPeople');
   });
 });
 

--- a/infra/agent-image/skills/psd-directory/package.json
+++ b/infra/agent-image/skills/psd-directory/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "psd-directory",
+  "version": "1.0.0",
+  "description": "OpenClaw skill — resolve a district email address or Google Chat users/{id} to a real person via the People API directory surface (#1239). Targeted lookups only; no enumeration.",
+  "private": true,
+  "dependencies": {}
+}

--- a/infra/agent-image/skills/psd-directory/run.js
+++ b/infra/agent-image/skills/psd-directory/run.js
@@ -1,0 +1,136 @@
+#!/usr/bin/env node
+/**
+ * run.js — psd-directory skill entrypoint (#1239)
+ *
+ * Resolve a district identity instead of guessing:
+ *
+ *   node run.js --user <owner@psd401.net> --email <someone@psd401.net>
+ *   node run.js --user <owner@psd401.net> --chat-id users/1162649136399...
+ *
+ * Authentication uses the AGENT slot only. `directory.readonly` is already in
+ * AGENT_DWD_SCOPES, so this needs no new scope, no consent flow, and no admin
+ * role — the token comes from the same DWD broker psd-workspace uses.
+ * (The user slot also carries directory.readonly, but resolving "who is this
+ * district person" is agent-context work and does not need the human's
+ * consent grant; keeping it on one slot keeps the failure modes to one set.)
+ *
+ * Output is a single JSON line on stdout:
+ *   {"found":true,"personId":"...","displayName":"...","email":"...",
+ *    "title":"...","department":"...","organization":"...","cached":false}
+ *   {"found":false,"query":"...","reason":"not in directory"}
+ *
+ * A miss is exit 0 with found:false — "this person is not in the directory"
+ * is an ANSWER, not a failure, and the agent must be able to act on it
+ * without treating it as an error.
+ *
+ * Exit codes:
+ *   0  success (including a found:false miss)
+ *   1  usage / config error
+ *   2  lookup failed (unexpected People API error)
+ *   12 transport error (broker or People API unreachable)
+ *   14 account-provisioning (agnt_ account is being auto-created; retry later)
+ *   16 directory-sharing-disabled — the Workspace admin console setting
+ *      "External Directory Sharing" is restrictive. Distinct from every other
+ *      code because NO code change fixes it: it is an admin action, and
+ *      collapsing it into a generic 403 is what made this issue expensive to
+ *      diagnose the first time.
+ *   17 insufficient-scope — the token genuinely lacks directory.readonly.
+ */
+
+'use strict';
+
+const WS = require('/opt/psd-skills/psd-workspace/common.js');
+const lib = require('./lib');
+
+const USAGE = `psd-directory — resolve a district email or Chat user id to a real person
+
+Usage:
+  run.js --user <owner@psd401.net> --email <address>
+  run.js --user <owner@psd401.net> --chat-id <users/{id} | {id}>
+
+Options:
+  --user      Required. The owner whose agnt_ account brokers the lookup.
+  --email     Resolve an email address to a directory person.
+  --chat-id   Resolve a Chat users/{id} (or bare numeric id) to a person.
+  --no-cache  Bypass the lookup cache for this call.
+  --help      Show this message.
+
+Exactly one of --email / --chat-id is required.`;
+
+function fail(message, code = 1) {
+  process.stderr.write(`psd-directory: ${message}\n`);
+  process.exit(code);
+}
+
+function emit(obj) {
+  process.stdout.write(JSON.stringify(obj) + '\n');
+}
+
+async function main() {
+  const args = WS.parseArgs(process.argv);
+  if (args.help) {
+    process.stdout.write(`${USAGE}\n`);
+    return 0;
+  }
+
+  const userEmail = args.user;
+  if (!userEmail || userEmail === true) fail('--user is required');
+  WS.validateUserEmail(userEmail);
+
+  const wantEmail = typeof args.email === 'string' ? args.email : null;
+  const wantChatId = typeof args.chat_id === 'string' ? args.chat_id : null;
+  if (!wantEmail && !wantChatId) fail('one of --email or --chat-id is required');
+  if (wantEmail && wantChatId) fail('--email and --chat-id are mutually exclusive');
+
+  // Agent-slot token via the DWD broker (directory.readonly already granted).
+  let broker;
+  try {
+    broker = await WS.fetchBrokerToken(userEmail);
+  } catch (err) {
+    fail(`could not mint an agent token: ${err.message}`, 12);
+  }
+  if (broker && broker.notProvisioned) {
+    emit({ status: 'account-provisioning', ownerEmail: userEmail });
+    return 14;
+  }
+
+  const opts = { noCache: args.no_cache === true };
+  try {
+    const result = wantEmail
+      ? await lib.resolveEmail(wantEmail, broker.accessToken, opts)
+      : await lib.resolvePersonId(wantChatId, broker.accessToken, opts);
+    emit({ cached: false, ...result });
+    return 0;
+  } catch (err) {
+    if (err instanceof lib.DirectoryError) {
+      switch (err.code) {
+        case 'DIRECTORY_SHARING_DISABLED':
+          fail(
+            'the Workspace directory is not shared with API callers. An admin must set ' +
+              'Directory > Directory settings > Sharing settings > External Directory Sharing to ' +
+              '"Organization data and authenticated user basic profile fields". ' +
+              `(Google said: ${err.message})`,
+            16
+          );
+          break;
+        case 'INSUFFICIENT_SCOPE':
+          fail(`the agent token lacks directory.readonly: ${err.message}`, 17);
+          break;
+        case 'TRANSPORT':
+          fail(err.message, 12);
+          break;
+        case 'INVALID_INPUT':
+          fail(err.message, 1);
+          break;
+        default:
+          fail(`directory lookup failed: ${err.message}`, 2);
+      }
+    }
+    fail(`directory lookup failed: ${err.message}`, 2);
+  }
+  return 0;
+}
+
+main()
+  .then((code) => process.exit(code))
+  .catch((err) => fail(`unexpected error: ${err && err.message}`, 2));

--- a/infra/agent-image/skills/psd-directory/run.js
+++ b/infra/agent-image/skills/psd-directory/run.js
@@ -83,34 +83,10 @@ async function main() {
   if (wantEmail && wantChatId) fail('--email and --chat-id are mutually exclusive');
 
   // Agent-slot token via the DWD broker (directory.readonly already granted).
-  //
-  // LAZY ON PURPOSE. The broker rate-limits to 120 mints/hour per owner
-  // (lib/agent-workspace/token-rate-limit.ts) and that budget is SHARED with
-  // psd-workspace. Minting up-front would charge a token to every lookup even
-  // when the on-disk cache answers it, so a chatty-but-cached workload could
-  // exhaust the limit and take Gmail/Calendar/Drive down with it. The lookup
-  // calls this only after its cache has missed. Memoized so a single
-  // invocation can never mint twice.
-  let minted = null;
-  const mintToken = async () => {
-    if (!minted) {
-      let broker;
-      try {
-        broker = await WS.fetchBrokerToken(userEmail);
-      } catch (err) {
-        const e = new Error(`could not mint an agent token: ${err.message}`);
-        e.code = 'MINT_TRANSPORT';
-        throw e;
-      }
-      if (broker && broker.notProvisioned) {
-        const e = new Error('account-not-provisioned');
-        e.code = 'ACCOUNT_NOT_PROVISIONED';
-        throw e;
-      }
-      minted = broker;
-    }
-    return minted.accessToken;
-  };
+  // LAZY on purpose — the lookup calls this only after its cache misses, so a
+  // cache hit spends no mint against the broker's shared rate limit. See
+  // makeTokenMinter in lib.js for why that matters and for its test coverage.
+  const mintToken = lib.makeTokenMinter(WS.fetchBrokerToken, userEmail);
 
   const opts = { noCache: args.no_cache === true };
   try {

--- a/infra/agent-image/skills/psd-directory/run.js
+++ b/infra/agent-image/skills/psd-directory/run.js
@@ -83,25 +83,50 @@ async function main() {
   if (wantEmail && wantChatId) fail('--email and --chat-id are mutually exclusive');
 
   // Agent-slot token via the DWD broker (directory.readonly already granted).
-  let broker;
-  try {
-    broker = await WS.fetchBrokerToken(userEmail);
-  } catch (err) {
-    fail(`could not mint an agent token: ${err.message}`, 12);
-  }
-  if (broker && broker.notProvisioned) {
-    emit({ status: 'account-provisioning', ownerEmail: userEmail });
-    return 14;
-  }
+  //
+  // LAZY ON PURPOSE. The broker rate-limits to 120 mints/hour per owner
+  // (lib/agent-workspace/token-rate-limit.ts) and that budget is SHARED with
+  // psd-workspace. Minting up-front would charge a token to every lookup even
+  // when the on-disk cache answers it, so a chatty-but-cached workload could
+  // exhaust the limit and take Gmail/Calendar/Drive down with it. The lookup
+  // calls this only after its cache has missed. Memoized so a single
+  // invocation can never mint twice.
+  let minted = null;
+  const mintToken = async () => {
+    if (!minted) {
+      let broker;
+      try {
+        broker = await WS.fetchBrokerToken(userEmail);
+      } catch (err) {
+        const e = new Error(`could not mint an agent token: ${err.message}`);
+        e.code = 'MINT_TRANSPORT';
+        throw e;
+      }
+      if (broker && broker.notProvisioned) {
+        const e = new Error('account-not-provisioned');
+        e.code = 'ACCOUNT_NOT_PROVISIONED';
+        throw e;
+      }
+      minted = broker;
+    }
+    return minted.accessToken;
+  };
 
   const opts = { noCache: args.no_cache === true };
   try {
     const result = wantEmail
-      ? await lib.resolveEmail(wantEmail, broker.accessToken, opts)
-      : await lib.resolvePersonId(wantChatId, broker.accessToken, opts);
+      ? await lib.resolveEmail(wantEmail, mintToken, opts)
+      : await lib.resolvePersonId(wantChatId, mintToken, opts);
     emit({ cached: false, ...result });
     return 0;
   } catch (err) {
+    if (err && err.code === 'ACCOUNT_NOT_PROVISIONED') {
+      emit({ status: 'account-provisioning', ownerEmail: userEmail });
+      return 14;
+    }
+    if (err && err.code === 'MINT_TRANSPORT') {
+      fail(err.message, 12);
+    }
     if (err instanceof lib.DirectoryError) {
       switch (err.code) {
         case 'DIRECTORY_SHARING_DISABLED':

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "test:smoke:unified-content-lambda-artifact": "bun run scripts/test/unified-content-lambda-artifact.smoke.ts",
     "test:smoke:embedding-lambda-artifact": "bun run scripts/test/embedding-lambda-artifact.smoke.ts",
     "test:skill:workspace": "cd infra/agent-image/skills/psd-workspace && bun test common.test.js",
+    "test:skill:directory": "cd infra/agent-image/skills/psd-directory && bun test lib.test.js",
     "test:smoke:atrium": "bun run test:smoke:atrium-render && bun run test:smoke:atrium-collab && bun run test:smoke:atrium-collab-token && bun run test:smoke:atrium-agent-bridge && bun run test:smoke:atrium-agent-read && bun run test:smoke:atrium-html-sanitize && bun run test:smoke:atrium-provenance-rail && bun run test:smoke:atrium-collab-schema && bun run test:smoke:atrium-suggestions-resolve && bun run test:smoke:atrium-suggestion-mode && bun run test:smoke:atrium-sandbox-config && bun run test:smoke:atrium-sandbox-host",
     "test:ci": "jest --config=jest.config.ci.js",
     "test:watch": "jest --watch",


### PR DESCRIPTION
Closes #1239

Adds the `psd-directory` skill so the agent asks the directory who someone is instead of guessing from an address local-part or leaving a Chat sender as an opaque `users/{id}`.

## The issue was wrong about the blocker, twice

The **"Google-side actions (Reese)"** section was stale — the broker moved to the district-owned `psd-aistudio-broker` project on 2026-07-16 and `people.googleapis.com` was already enabled there.

The actual blocker was an **admin console setting**: External Directory Sharing was on its restrictive default, so every directory call 403'd regardless of scope. My own first writeup then misnamed it "Contact sharing" (a different setting). It was corrected and toggled on 2026-07-26, and this code was written **only after** a live probe confirmed the surface returns data.

## Option B is deliberately not built

The genuinely open question was whether `people.get` returns populated fields for a Chat id in a **service-account** context, or comes back empty — empty would have forced Option B (Admin SDK `users.get` behind a custom "Users > Read" admin role on the SA).

Probed live with an `agnt_` DWD token: **it returns fully populated fields.** That privilege escalation is unnecessary and is not implemented. `AGENT_DWD_SCOPES` is untouched; `contacts.readonly` is still absent.

## What it does

```bash
run.js --user <owner> --email someone@psd401.net    # searchDirectoryPeople
run.js --user <owner> --chat-id users/11626491...   # people.get, same id
```

Returns one JSON line with `displayName`, `email`, `title`, `department`, `organization`. `organizations` supplies title/department directly, so the "name, title, org unit" criterion is one call, not two.

## Correctness decisions that aren't cosmetic

- **Exact-address match only.** `searchDirectoryPeople` is a prefix/substring search, so one address can return several people. Taking `[0]` would make the agent confidently attribute a message to the **wrong human** — worse than not resolving. A near miss reports `found:false`.
- **A miss is exit 0.** "Not in the directory" is an answer the agent must act on, not an error.
- **An empty-field `people.get` reports `found:false`**, not a person with null everything — that was the exact Option-B trigger, so if it ever starts happening it must be visible.
- **Exit 16 is reserved for the admin-console setting**, exit 17 for a genuinely missing scope. Collapsing those into a generic 403 is what made this issue expensive to diagnose the first time.

## ⚠️ No enumeration, by design — please read

The probe surfaced that the district directory includes **ClassLink-provisioned student records** (name, `@edtools` address, grade level, building), and External Directory Sharing is **domain-wide**. A list/enumerate helper in the agent image would therefore be a student-directory dumper one prompt away.

`listDirectoryPeople` is never called, there is no listing entry point, and a test asserts both against the **comment-stripped** source so the property can't rot silently. SKILL.md explicitly tells the model not to seek a workaround.

Separately: whether student OUs should be scoped out of the shared directory is a live question for Hagel — [custom directories](https://support.google.com/a/answer/9401094) are OU-assignable even though External Directory Sharing itself is not. That's an admin decision, not a code one, and it's noted on the issue.

## Caching (acceptance criterion)

On-disk, container-ephemeral. 12h for hits, 5m for misses — a miss is usually a race with account provisioning, and caching that for hours would make a new hire look permanently unresolvable. Keys are sha256-hashed so no address lands in a filename in plaintext and no key can traverse out of the cache dir. Cache failures never fail a lookup; by then the call already succeeded.

## Testing

- **21 unit tests** (bun), wired into CI as `test:skill:directory`. This skill is plain CJS outside the jest roots, so `test:ci` would never have seen it — the same coverage gap #1305 just fixed for `psd-workspace`.
- **Functionally tested against the live People API** with a real minted token, not only mocks:
  - email → `Kris Hagel / Chief / Multiple Locations`
  - second call served from cache
  - Chat-id path resolved the same person
  - nonexistent address and bogus id both returned clean misses rather than throwing
- Full suite: 364 passed, typecheck clean.

## Deploy note

No Dockerfile change needed — `COPY skills /opt/psd-skills` picks it up, and only skills with dependencies need an npm install entry (this has none). **This skill is not in the image tag pushed earlier today** (`2026-07-26-drive-organize`, which carries the #1305 gate fix); it needs a fresh build-and-push after merge.