### PR TITLE
fix(atrium): stop post-archive editor bounce; de-flake archived-view E2E; add local E2E DB cleanup script

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -376,6 +376,7 @@ tree, and anti-patterns.
 - **Don't** return internal state getters from hooks when the caller also supplies `fn` — use `onFailure(count)` event callbacks
 - **Don't** read a ref mutated inside a hook's `.catch()` without `+1` — use `onFailure(count)` callback instead (callers see pre-mutation value)
 - **Don't** pass unstable adapter references to `useChatRuntime` — use ref-based getters with empty dep arrays to prevent runtime re-initialization and duplicate messages
+- **Don't** `router.push()` away from a page that may still have server actions in flight (e.g. mount-time fetch bursts) — a straggler resolving after the push rebases the App Router back onto its origin route, silently yanking the user back. For leave-the-page mutations (archive/delete → library), use a document navigation (`window.location.assign`) so page teardown cancels the stragglers (see `ContentSettings.tsx`)
 
 ## 📖 Documentation
 

--- a/components/atrium/ContentSettings.tsx
+++ b/components/atrium/ContentSettings.tsx
@@ -93,7 +93,14 @@ async function runUpdate(
     if (res.isSuccess) {
       setOpen(false);
       if (patch.status === "archived") {
-        router.push("/atrium");
+        // FULL document navigation, deliberately not router.push: the editor
+        // mounts a burst of server-action fetches (session, collection tree,
+        // versions, comments, …), and a client-side push that lands while one
+        // is still in flight gets rolled back when the straggler resolves —
+        // the App Router rebases onto the action's origin route and yanks the
+        // user back into the editor they just archived. A document navigation
+        // tears the editor down, so no straggler can rebase it.
+        window.location.assign("/atrium");
       } else {
         router.refresh();
       }
@@ -122,13 +129,12 @@ async function runUpdate(
 async function runDelete(
   objectId: string,
   ctx: {
-    router: ReturnType<typeof useRouter>;
     setDeleting: (v: boolean) => void;
     setError: (v: string | null) => void;
     setOpen: (v: boolean) => void;
   }
 ): Promise<void> {
-  const { router, setDeleting, setError, setOpen } = ctx;
+  const { setDeleting, setError, setOpen } = ctx;
   if (
     typeof window !== "undefined" &&
     !window.confirm(
@@ -145,7 +151,9 @@ async function runDelete(
     const res = await deleteContentAction(objectId);
     if (res.isSuccess) {
       setOpen(false);
-      router.push("/atrium");
+      // Full document navigation for the same straggling-server-action reason
+      // as the archive branch in `runUpdate` above.
+      window.location.assign("/atrium");
     } else {
       setError(res.message ?? "Could not delete this content");
       log.warn("deleteContentAction failed", { message: res.message });
@@ -429,8 +437,8 @@ export function ContentSettings({
   // Extracted to the module-level `runDelete` to keep this component under the
   // max-lines-per-function lint.
   const deleteContent = useCallback(
-    () => runDelete(objectId, { router, setDeleting, setError, setOpen }),
-    [objectId, router]
+    () => runDelete(objectId, { setDeleting, setError, setOpen }),
+    [objectId]
   );
 
   const busy = saving || deleting;

--- a/components/atrium/LibraryView.tsx
+++ b/components/atrium/LibraryView.tsx
@@ -306,6 +306,15 @@ function useLibraryPage(filter: ListFilter) {
   // means the end was reached, so "Load more" hides.
   const [hasMore, setHasMore] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  // The query/status the COMMITTED items were fetched with (undefined until the
+  // first fetch commits), set in the same state batch as `setItems` (so they can
+  // never describe a grid the view isn't showing). Rendered as `data-results-*`
+  // on the library section: the only deterministic "the grid now reflects THIS
+  // search + view" signal — `loading` flips inside a post-paint effect, leaving
+  // a window where the filters have changed but neither `loading` nor the items
+  // say so. E2E search pinning awaits these instead of racing the debounce.
+  const [settledQuery, setSettledQuery] = useState<string | undefined>(undefined);
+  const [settledStatus, setSettledStatus] = useState<string | undefined>(undefined);
   const reqSeqRef = useRef(0);
 
   const { collectionId, kind, owner, status, tag, query } = filter;
@@ -332,6 +341,8 @@ function useLibraryPage(filter: ListFilter) {
         if (res.isSuccess) {
           setItems((prev) => (append ? [...prev, ...res.data] : res.data));
           setHasMore(res.data.length === PAGE_SIZE);
+          setSettledQuery(query ?? "");
+          setSettledStatus(status ?? "");
         } else {
           setError(res.message ?? "Could not load content");
           log.warn("listContentAction failed", { message: res.message });
@@ -370,7 +381,17 @@ function useLibraryPage(filter: ListFilter) {
     void fetchPageRef.current(0);
   }, []);
 
-  return { items, loading, loadingMore, hasMore, error, fetchPage, refresh };
+  return {
+    items,
+    loading,
+    loadingMore,
+    hasMore,
+    error,
+    settledQuery,
+    settledStatus,
+    fetchPage,
+    refresh,
+  };
 }
 
 /**
@@ -466,8 +487,17 @@ export function LibraryView({
   const { kind, owner, status } = viewToFilter(view);
   const archivedView = view === "archived";
 
-  const { items, loading, loadingMore, hasMore, error, fetchPage, refresh } =
-    useLibraryPage({
+  const {
+    items,
+    loading,
+    loadingMore,
+    hasMore,
+    error,
+    settledQuery,
+    settledStatus,
+    fetchPage,
+    refresh,
+  } = useLibraryPage({
       collectionId: collectionId ?? undefined,
       kind,
       owner,
@@ -500,7 +530,14 @@ export function LibraryView({
 
   return (
     <div className="w-full px-5 py-6 md:px-8 md:py-8">
-      <section className="mx-auto min-w-0 max-w-6xl">
+      {/* `data-results-*`: which query/view the committed grid was fetched for
+          (absent until the first fetch commits) — see the settled-state note in
+          `useLibraryPage`. */}
+      <section
+        className="mx-auto min-w-0 max-w-6xl"
+        data-results-query={settledQuery}
+        data-results-status={settledStatus}
+      >
         <LibraryHeader
           search={search}
           onSearch={setSearch}

--- a/docs/guides/e2e-authenticated-testing.md
+++ b/docs/guides/e2e-authenticated-testing.md
@@ -106,3 +106,4 @@ Two non-obvious requirements (both encoded in the helper):
 | `401` despite matching secret | token missing `tokenLifetimeMs` / near expiry | use `mintSessionToken()` (sets a 12h lifetime) |
 | Empty navigation / page errors | local DB behind on migrations | run `scripts/db/run-migrations.ts` (step 1) |
 | `/api/auth/session` → `200 null` | cookie not reaching server | use `authenticateContext()` (addCookies), not raw fetch |
+| List/search specs degrade over weeks of runs | E2E probe rows accumulating in the shared local DB | `bun run db:cleanup:e2e` (dry run), then `-- --yes` to prune |

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "db:seed": "docker exec -i aistudio-postgres psql -U postgres -d aistudio < scripts/db/seed-local.sql",
     "db:studio": "DATABASE_URL='postgresql://postgres:postgres@localhost:5432/aistudio' DB_SSL=false bun run drizzle:studio",
     "db:psql": "docker exec -it aistudio-postgres psql -U postgres -d aistudio",
+    "db:cleanup:e2e": "DATABASE_URL='postgresql://postgres:postgres@localhost:5432/aistudio' bun scripts/db/cleanup-e2e-content.ts",
     "dev:docker": "docker compose -f docker-compose.dev.yml up",
     "dev:local": "DATABASE_URL='postgresql://postgres:postgres@localhost:5432/aistudio' DB_SSL=false IS_LOCAL_DEV=true bun run server.ts",
     "dev:voice": "DATABASE_URL='postgresql://postgres:postgres@localhost:5432/aistudio' DB_SSL=false IS_LOCAL_DEV=true bun run server.ts"

--- a/scripts/db/cleanup-e2e-content.ts
+++ b/scripts/db/cleanup-e2e-content.ts
@@ -58,13 +58,14 @@ const FIXTURE_ID_PREFIX = "a7100000-%";
 /**
  * Graph nodes created by the decision/graph E2E specs. Every node those specs
  * create carries an "E2E-<TAG>-<Date.now()>" token in its name (decision text
- * AND decidedBy actor names), so the anchored tag+timestamp shape is safe to
+ * AND decidedBy actor names) — plus the graph-admin spec's hyphen-less
+ * "E2EGRAPH<Date.now()>" form — so the anchored tag+timestamp shape is safe to
  * match on name alone across node types. Accumulation here breaks the semantic
  * search spec directly: each run adds a near-identical "zeppelin" decision, and
  * the fresh one must beat all its prior twins into the top-25 similarity
  * window — at ~100 twins it reliably loses (observed 2026-07-26).
  */
-const GRAPH_E2E_NAME_REGEX = "E2E-[A-Z]+-[0-9]{12,}";
+const GRAPH_E2E_NAME_REGEX = "(E2E-[A-Z]+-|E2EGRAPH)[0-9]{12,}";
 
 interface CandidateRow {
   id: string;
@@ -190,14 +191,54 @@ async function main(): Promise<void> {
     }
 
     if (candidates.length > 0) {
+      const ids = candidates.map((c) => c.id);
+
+      // Repository items the candidates were indexed into: captured BEFORE the
+      // content delete cascades away the content_index_links that reference
+      // them (repository_items itself does NOT hang off content_objects, so
+      // the cascade would orphan these rows and their chunks silently).
+      const linkedRepoItems = await sql<{ repository_item_id: number }[]>`
+        SELECT DISTINCT repository_item_id
+          FROM content_index_links
+         WHERE object_id IN ${sql(ids)}
+      `;
+
+      // Mirror contentService.delete: navigation_items.content_object_id is
+      // ON DELETE NO ACTION and unpublish only soft-hides the row, so debris
+      // from a published-then-abandoned probe would otherwise reject the whole
+      // batch delete with an FK violation.
+      await sql`
+        DELETE FROM navigation_items
+         WHERE content_object_id IN ${sql(ids)}
+      `;
+
       const deleted = await sql<{ id: string }[]>`
         DELETE FROM content_objects
-         WHERE id IN ${sql(candidates.map((c) => c.id))}
+         WHERE id IN ${sql(ids)}
          RETURNING id
       `;
       log.success(
         `Deleted ${deleted.length} content_objects rows (children removed via ON DELETE CASCADE).`
       );
+
+      // Now-unreferenced repository items from the captured set (an item still
+      // linked by any SURVIVING content is kept); chunks/versions cascade.
+      if (linkedRepoItems.length > 0) {
+        const orphaned = await sql<{ id: number }[]>`
+          DELETE FROM repository_items ri
+           WHERE ri.id IN ${sql(linkedRepoItems.map((r) => r.repository_item_id))}
+             AND NOT EXISTS (
+                   SELECT 1 FROM content_index_links l
+                    WHERE l.repository_item_id = ri.id
+                 )
+           RETURNING ri.id
+        `;
+        if (orphaned.length > 0) {
+          log.success(
+            `Deleted ${orphaned.length} orphaned repository_items rows (chunks/versions cascade).`
+          );
+        }
+      }
     }
 
     if (graphCandidates.length > 0) {

--- a/scripts/db/cleanup-e2e-content.ts
+++ b/scripts/db/cleanup-e2e-content.ts
@@ -38,14 +38,15 @@
  * Exit codes: 0 — success (including "nothing to delete"); 2 — refused or failed.
  */
 
-import postgres from "postgres";
+import postgres, { type TransactionSql } from "postgres";
 import { scriptLogger as log } from "./script-logger";
 
 const DATABASE_URL =
   process.env.DATABASE_URL ||
   "postgresql://postgres:postgres@localhost:5432/aistudio";
 
-const LOCAL_HOSTS = new Set(["localhost", "127.0.0.1", "::1", "[::1]"]);
+// new URL().hostname returns IPv6 hosts WITH brackets (WHATWG URL spec).
+const LOCAL_HOSTS = new Set(["localhost", "127.0.0.1", "[::1]"]);
 
 /** Title shapes the E2E specs generate. Keep in sync with tests/e2e/*.spec.ts. */
 const TITLE_PREFIXES = ["e2e %", "E2E %"] as const;
@@ -190,67 +191,80 @@ async function main(): Promise<void> {
       return;
     }
 
-    if (candidates.length > 0) {
-      const ids = candidates.map((c) => c.id);
+    // One transaction for the whole multi-statement sequence: a failure in any
+    // later delete rolls back the earlier ones instead of leaving a partial
+    // prune (e.g. nav rows gone but the content delete rejected).
+    //
+    // The cast bridges a postgres.js typings wart: TransactionSql extends
+    // Omit<Sql, ...>, and Omit drops Sql's CALL signatures, so the (runtime-
+    // callable) tx object types as non-callable. Sql is its supertype minus
+    // members this block never touches (begin/end/listen/...).
+    await sql.begin(async (t: TransactionSql) => {
+      const tx = t as unknown as typeof sql;
+      if (candidates.length > 0) {
+        const ids = candidates.map((c) => c.id);
 
-      // Repository items the candidates were indexed into: captured BEFORE the
-      // content delete cascades away the content_index_links that reference
-      // them (repository_items itself does NOT hang off content_objects, so
-      // the cascade would orphan these rows and their chunks silently).
-      const linkedRepoItems = await sql<{ repository_item_id: number }[]>`
-        SELECT DISTINCT repository_item_id
-          FROM content_index_links
-         WHERE object_id IN ${sql(ids)}
-      `;
-
-      // Mirror contentService.delete: navigation_items.content_object_id is
-      // ON DELETE NO ACTION and unpublish only soft-hides the row, so debris
-      // from a published-then-abandoned probe would otherwise reject the whole
-      // batch delete with an FK violation.
-      await sql`
-        DELETE FROM navigation_items
-         WHERE content_object_id IN ${sql(ids)}
-      `;
-
-      const deleted = await sql<{ id: string }[]>`
-        DELETE FROM content_objects
-         WHERE id IN ${sql(ids)}
-         RETURNING id
-      `;
-      log.success(
-        `Deleted ${deleted.length} content_objects rows (children removed via ON DELETE CASCADE).`
-      );
-
-      // Now-unreferenced repository items from the captured set (an item still
-      // linked by any SURVIVING content is kept); chunks/versions cascade.
-      if (linkedRepoItems.length > 0) {
-        const orphaned = await sql<{ id: number }[]>`
-          DELETE FROM repository_items ri
-           WHERE ri.id IN ${sql(linkedRepoItems.map((r) => r.repository_item_id))}
-             AND NOT EXISTS (
-                   SELECT 1 FROM content_index_links l
-                    WHERE l.repository_item_id = ri.id
-                 )
-           RETURNING ri.id
+        // Repository items the candidates were indexed into: captured BEFORE
+        // the content delete cascades away the content_index_links that
+        // reference them (repository_items itself does NOT hang off
+        // content_objects, so the cascade would orphan these rows and their
+        // chunks silently).
+        const linkedRepoItems = await tx<{ repository_item_id: number }[]>`
+          SELECT DISTINCT repository_item_id
+            FROM content_index_links
+           WHERE object_id IN ${tx(ids)}
         `;
-        if (orphaned.length > 0) {
-          log.success(
-            `Deleted ${orphaned.length} orphaned repository_items rows (chunks/versions cascade).`
-          );
+
+        // Mirror contentService.delete: navigation_items.content_object_id is
+        // ON DELETE NO ACTION and unpublish only soft-hides the row, so debris
+        // from a published-then-abandoned probe would otherwise reject the
+        // whole batch delete with an FK violation.
+        await tx`
+          DELETE FROM navigation_items
+           WHERE content_object_id IN ${tx(ids)}
+        `;
+
+        const deleted = await tx<{ id: string }[]>`
+          DELETE FROM content_objects
+           WHERE id IN ${tx(ids)}
+           RETURNING id
+        `;
+        log.success(
+          `Deleted ${deleted.length} content_objects rows (children removed via ON DELETE CASCADE).`
+        );
+
+        // Now-unreferenced repository items from the captured set (an item
+        // still linked by any SURVIVING content is kept); chunks/versions
+        // cascade.
+        if (linkedRepoItems.length > 0) {
+          const orphaned = await tx<{ id: number }[]>`
+            DELETE FROM repository_items ri
+             WHERE ri.id IN ${tx(linkedRepoItems.map((r) => r.repository_item_id))}
+               AND NOT EXISTS (
+                     SELECT 1 FROM content_index_links l
+                      WHERE l.repository_item_id = ri.id
+                   )
+             RETURNING ri.id
+          `;
+          if (orphaned.length > 0) {
+            log.success(
+              `Deleted ${orphaned.length} orphaned repository_items rows (chunks/versions cascade).`
+            );
+          }
         }
       }
-    }
 
-    if (graphCandidates.length > 0) {
-      const deletedGraph = await sql<{ id: string }[]>`
-        DELETE FROM graph_nodes
-         WHERE id IN ${sql(graphCandidates.map((g) => g.id))}
-         RETURNING id
-      `;
-      log.success(
-        `Deleted ${deletedGraph.length} graph_nodes rows (edges removed via ON DELETE CASCADE).`
-      );
-    }
+      if (graphCandidates.length > 0) {
+        const deletedGraph = await tx<{ id: string }[]>`
+          DELETE FROM graph_nodes
+           WHERE id IN ${tx(graphCandidates.map((g) => g.id))}
+           RETURNING id
+        `;
+        log.success(
+          `Deleted ${deletedGraph.length} graph_nodes rows (edges removed via ON DELETE CASCADE).`
+        );
+      }
+    });
   } finally {
     await sql.end();
   }

--- a/scripts/db/cleanup-e2e-content.ts
+++ b/scripts/db/cleanup-e2e-content.ts
@@ -55,6 +55,17 @@ const TOKENED_TITLE_REGEX =
 /** Seeded reference fixtures (tests/e2e/fixtures/*.sql) — never deleted. */
 const FIXTURE_ID_PREFIX = "a7100000-%";
 
+/**
+ * Graph nodes created by the decision/graph E2E specs. Every node those specs
+ * create carries an "E2E-<TAG>-<Date.now()>" token in its name (decision text
+ * AND decidedBy actor names), so the anchored tag+timestamp shape is safe to
+ * match on name alone across node types. Accumulation here breaks the semantic
+ * search spec directly: each run adds a near-identical "zeppelin" decision, and
+ * the fresh one must beat all its prior twins into the top-25 similarity
+ * window — at ~100 twins it reliably loses (observed 2026-07-26).
+ */
+const GRAPH_E2E_NAME_REGEX = "E2E-[A-Z]+-[0-9]{12,}";
+
 interface CandidateRow {
   id: string;
   title: string;
@@ -141,7 +152,14 @@ async function main(): Promise<void> {
        ORDER BY created_at
     `;
 
-    if (candidates.length === 0) {
+    const graphCandidates = await sql<{ id: string }[]>`
+      SELECT id
+        FROM graph_nodes
+       WHERE name ~ ${GRAPH_E2E_NAME_REGEX}
+         AND created_at < now() - make_interval(mins => ${minAgeMinutes})
+    `;
+
+    if (candidates.length === 0 && graphCandidates.length === 0) {
       log.success("Nothing to clean up — no E2E-pattern rows older than the age guard.");
       return;
     }
@@ -162,19 +180,36 @@ async function main(): Promise<void> {
       log.info(`  … and ${candidates.length - 15} more`);
     }
 
+    log.info(
+      `Matched ${graphCandidates.length} graph_nodes rows (E2E-tagged decision/graph fixtures)`
+    );
+
     if (!yes) {
       log.info("Dry run — nothing deleted. Re-run with --yes to delete these rows.");
       return;
     }
 
-    const deleted = await sql<{ id: string }[]>`
-      DELETE FROM content_objects
-       WHERE id IN ${sql(candidates.map((c) => c.id))}
-       RETURNING id
-    `;
-    log.success(
-      `Deleted ${deleted.length} content_objects rows (children removed via ON DELETE CASCADE).`
-    );
+    if (candidates.length > 0) {
+      const deleted = await sql<{ id: string }[]>`
+        DELETE FROM content_objects
+         WHERE id IN ${sql(candidates.map((c) => c.id))}
+         RETURNING id
+      `;
+      log.success(
+        `Deleted ${deleted.length} content_objects rows (children removed via ON DELETE CASCADE).`
+      );
+    }
+
+    if (graphCandidates.length > 0) {
+      const deletedGraph = await sql<{ id: string }[]>`
+        DELETE FROM graph_nodes
+         WHERE id IN ${sql(graphCandidates.map((g) => g.id))}
+         RETURNING id
+      `;
+      log.success(
+        `Deleted ${deletedGraph.length} graph_nodes rows (edges removed via ON DELETE CASCADE).`
+      );
+    }
   } finally {
     await sql.end();
   }

--- a/scripts/db/cleanup-e2e-content.ts
+++ b/scripts/db/cleanup-e2e-content.ts
@@ -1,0 +1,188 @@
+/**
+ * Prune accumulated E2E-created content rows from the LOCAL dev database.
+ *
+ * The authenticated Playwright suite (scripts/test/e2e-local.sh) creates probe
+ * documents/artifacts on every run ("e2e archived probe …", "Quarterly plan
+ * <token>", …). Specs delete their own fixtures on the happy path, but failed
+ * or interrupted runs leave rows behind, and the shared local database
+ * accumulates hundreds of them over time — which slows list views and widens
+ * timing races in the very specs the rows came from. CI is unaffected (it runs
+ * against a fresh database); this is local-only hygiene.
+ *
+ * Usage:
+ *   bun run db:cleanup:e2e                 # DRY RUN — lists what would be deleted
+ *   bun run db:cleanup:e2e -- --yes        # actually delete
+ *   bun run db:cleanup:e2e -- --yes --min-age-minutes 5
+ *
+ * Safety properties:
+ *   - LOCAL ONLY: refuses any DATABASE_URL whose host is not
+ *     localhost/127.0.0.1/::1 (Aurora and container-perspective URLs are
+ *     rejected with a hint). Writing to shared/AWS databases from scripts is
+ *     off-limits.
+ *   - DRY RUN by default; deletion requires the explicit --yes flag.
+ *   - AGE GUARD: only rows older than --min-age-minutes (default 60) are
+ *     touched, so a cleanup can never race a currently-running suite's live
+ *     probes.
+ *   - PATTERN-SCOPED: matches only the title shapes the specs generate —
+ *     "e2e …"/"E2E …" prefixes and the known "<Name> <run-token>" forms where
+ *     the token is runToken()'s 13+ digit timestamp+random suffix. Anchored so
+ *     a human's "Dashboard ideas" doc can never match.
+ *   - SEED-SAFE: the reference fixtures (tests/e2e/fixtures/*.sql) use fixed
+ *     UUIDs under the a7100000-… prefix and are excluded regardless of title
+ *     (none currently collide with the patterns; the exclusion is insurance).
+ *
+ * Deleting content_objects rows cascades to versions, comments, publications,
+ * visibility grants, assets, embed/index links, and doc state (all children
+ * declare ON DELETE CASCADE), so no orphan rows are left behind.
+ *
+ * Exit codes: 0 — success (including "nothing to delete"); 2 — refused or failed.
+ */
+
+import postgres from "postgres";
+import { scriptLogger as log } from "./script-logger";
+
+const DATABASE_URL =
+  process.env.DATABASE_URL ||
+  "postgresql://postgres:postgres@localhost:5432/aistudio";
+
+const LOCAL_HOSTS = new Set(["localhost", "127.0.0.1", "::1", "[::1]"]);
+
+/** Title shapes the E2E specs generate. Keep in sync with tests/e2e/*.spec.ts. */
+const TITLE_PREFIXES = ["e2e %", "E2E %"] as const;
+const TOKENED_TITLE_REGEX =
+  "^(Quarterly plan|Dashboard|Bulk probe [0-9]+|Comments probe|Cover probe|Sync probe|OAuth PKCE e2e) [0-9]{12,}$";
+
+/** Seeded reference fixtures (tests/e2e/fixtures/*.sql) — never deleted. */
+const FIXTURE_ID_PREFIX = "a7100000-%";
+
+interface CandidateRow {
+  id: string;
+  title: string;
+  status: string;
+  /**
+   * Selected as ::text — `created_at` is `timestamp without time zone` (UTC
+   * wall-clock), and letting the driver parse it into a JS Date re-interprets
+   * it in the machine's local zone, shifting every printed time by the UTC
+   * offset. The SQL age-guard comparison is unaffected (it never leaves the DB).
+   */
+  created_at: string;
+}
+
+function parseArgs(argv: string[]): { yes: boolean; minAgeMinutes: number } {
+  let yes = false;
+  let minAgeMinutes = 60;
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--yes") yes = true;
+    else if (a === "--min-age-minutes") {
+      const v = Number(argv[++i]);
+      if (!Number.isFinite(v) || v < 0) {
+        log.error(`--min-age-minutes requires a non-negative number, got: ${argv[i]}`);
+        process.exit(2);
+      }
+      minAgeMinutes = v;
+    } else if (a === "--help" || a === "-h") {
+      log.info(
+        "Usage: bun scripts/db/cleanup-e2e-content.ts [--yes] [--min-age-minutes N]"
+      );
+      process.exit(0);
+    } else {
+      log.error(`Unknown argument: ${a}`);
+      process.exit(2);
+    }
+  }
+  return { yes, minAgeMinutes };
+}
+
+async function main(): Promise<void> {
+  const { yes, minAgeMinutes } = parseArgs(process.argv.slice(2));
+
+  log.section("AI Studio — local E2E content cleanup");
+
+  let host: string;
+  try {
+    host = new URL(DATABASE_URL).hostname;
+  } catch {
+    log.error("DATABASE_URL is not a parseable URL — refusing.");
+    process.exit(2);
+  }
+  if (!LOCAL_HOSTS.has(host)) {
+    log.error(
+      `Refusing: DATABASE_URL host "${host}" is not local. This script only ` +
+        "prunes the local Docker postgres. If you meant the local DB, run with:\n" +
+        "  DATABASE_URL=postgresql://postgres:postgres@localhost:5432/aistudio bun run db:cleanup:e2e"
+    );
+    process.exit(2);
+  }
+
+  log.info("Database", { url: DATABASE_URL.replace(/:\/\/.*@/, "://*****@") });
+  log.info(yes ? "Mode: DELETE" : "Mode: DRY RUN (pass --yes to delete)", {
+    minAgeMinutes,
+  });
+
+  const sql = postgres(DATABASE_URL, {
+    ssl: false,
+    max: 1,
+    idle_timeout: 20,
+    connect_timeout: 10,
+  });
+
+  try {
+    const candidates = await sql<CandidateRow[]>`
+      SELECT id, title, status, created_at::text AS created_at
+        FROM content_objects
+       WHERE (
+               title LIKE ${TITLE_PREFIXES[0]}
+            OR title LIKE ${TITLE_PREFIXES[1]}
+            OR title ~ ${TOKENED_TITLE_REGEX}
+             )
+         AND id::text NOT LIKE ${FIXTURE_ID_PREFIX}
+         AND created_at < now() - make_interval(mins => ${minAgeMinutes})
+       ORDER BY created_at
+    `;
+
+    if (candidates.length === 0) {
+      log.success("Nothing to clean up — no E2E-pattern rows older than the age guard.");
+      return;
+    }
+
+    const byStatus = new Map<string, number>();
+    for (const c of candidates) {
+      byStatus.set(c.status, (byStatus.get(c.status) ?? 0) + 1);
+    }
+    log.info(`Matched ${candidates.length} content_objects rows`, {
+      byStatus: Object.fromEntries(byStatus),
+      oldestUtc: candidates[0]?.created_at,
+      newestUtc: candidates.at(-1)?.created_at,
+    });
+    for (const c of candidates.slice(0, 15)) {
+      log.info(`  ${c.created_at} UTC  [${c.status}]  ${c.title}`);
+    }
+    if (candidates.length > 15) {
+      log.info(`  … and ${candidates.length - 15} more`);
+    }
+
+    if (!yes) {
+      log.info("Dry run — nothing deleted. Re-run with --yes to delete these rows.");
+      return;
+    }
+
+    const deleted = await sql<{ id: string }[]>`
+      DELETE FROM content_objects
+       WHERE id IN ${sql(candidates.map((c) => c.id))}
+       RETURNING id
+    `;
+    log.success(
+      `Deleted ${deleted.length} content_objects rows (children removed via ON DELETE CASCADE).`
+    );
+  } finally {
+    await sql.end();
+  }
+}
+
+main().catch((e: unknown) => {
+  log.error("Cleanup failed", {
+    error: e instanceof Error ? e.message : String(e),
+  });
+  process.exit(2);
+});

--- a/tests/e2e/atrium-archived-view.functional.spec.ts
+++ b/tests/e2e/atrium-archived-view.functional.spec.ts
@@ -36,14 +36,38 @@ const SHOT_DIR = 'docs/verification/atrium-meridian'
  * is SERVER-side (#1336), so this scopes the query itself rather than filtering
  * an already-loaded page — which is what makes the assertion independent of how
  * much content the shared local database has accumulated.
+ *
+ * DETERMINISM: a bare `fill()` races the 300ms debounce → server-action round
+ * trip (the next assertion then runs against the PREVIOUS result set), and —
+ * right after a navigation — hydration, which can re-render the controlled
+ * input from empty React state and silently wipe the typed value, so the
+ * search never fires at all. So this awaits the library's `data-results-*`
+ * settle signal (stamped in the same React commit as the items it describes)
+ * until the committed grid is the one fetched for exactly this query in the
+ * expected view, retrying the fill inside `toPass` to recover a hydration
+ * wipe. Only then may callers assert card presence/absence — including
+ * `toHaveCount(0)`, which would otherwise false-pass against a stale grid.
  */
 async function pinToProbe(
   page: import('@playwright/test').Page,
-  title: string
+  title: string,
+  view: 'default' | 'archived'
 ) {
-  await page
-    .getByRole('textbox', { name: 'Search content by title or tag' })
-    .fill(title)
+  const box = page.getByRole('textbox', {
+    name: 'Search content by title or tag',
+  })
+  const results = page.locator('section[data-results-query]')
+  await expect(async () => {
+    await box.fill(title)
+    await expect(results).toHaveAttribute('data-results-query', title, {
+      timeout: 3000,
+    })
+    await expect(results).toHaveAttribute(
+      'data-results-status',
+      view === 'archived' ? 'archived' : '',
+      { timeout: 3000 }
+    )
+  }).toPass({ timeout: 30_000 })
 }
 
 /** The chips group's "Archived" filter button. */
@@ -53,11 +77,33 @@ function archivedChip(page: import('@playwright/test').Page) {
     .getByRole('button', { name: 'Archived', exact: true })
 }
 
+/**
+ * Activate the "Archived" view and wait until React confirms it. A bare
+ * `click()` right after a navigation can land on the server-rendered button
+ * before hydration attaches its handler — the click is then silently swallowed
+ * and the view never changes. Clicking again is idempotent (single-select
+ * chips), so retry until `aria-pressed` flips.
+ */
+async function openArchivedView(page: import('@playwright/test').Page) {
+  await expect(async () => {
+    await archivedChip(page).click()
+    await expect(archivedChip(page)).toHaveAttribute('aria-pressed', 'true', {
+      timeout: 1500,
+    })
+  }).toPass({ timeout: 30_000 })
+}
+
 test.describe('Atrium archived-content view (authenticated)', () => {
   test.skip(
     process.env.PLAYWRIGHT_AUTH_ENABLED !== 'true',
     'Requires an authenticated session — set PLAYWRIGHT_AUTH_ENABLED=true and run against the host :3100 dev server (see docs/guides/e2e-authenticated-testing.md)'
   )
+
+  // The lifecycle test below settles ~9 server-side search pins against a Next
+  // DEV server that compiles each action on first hit and slows further under
+  // the parallel full suite, so the default 60s per-test budget is too tight
+  // (same rationale as the sibling library-polish spec).
+  test.describe.configure({ timeout: 180_000 })
 
   test.beforeAll(() => {
     mkdirSync(SHOT_DIR, { recursive: true })
@@ -81,14 +127,18 @@ test.describe('Atrium archived-content view (authenticated)', () => {
       // results explains itself), so that is the state this asserts. The old
       // "Nothing archived" expectation only ever passed by racing the tag
       // debounce while the archive list happened to be empty.
-      await archivedChip(page).click()
-      await expect(archivedChip(page)).toHaveAttribute('aria-pressed', 'true')
-      await page
-        .getByRole('textbox', { name: 'Filter by tag' })
-        .fill('no-such-tag-zzz-e2e')
+      await openArchivedView(page)
 
+      // Retry the fill: like the search box in `pinToProbe`, a value typed
+      // before hydration can be wiped, and the zero-match state only renders
+      // once the debounced tag commits — so assert it inside the retry.
       const zeroMatch = page.getByTestId('library-search-empty')
-      await expect(zeroMatch).toBeVisible({ timeout: 15000 })
+      await expect(async () => {
+        await page
+          .getByRole('textbox', { name: 'Filter by tag' })
+          .fill('no-such-tag-zzz-e2e')
+        await expect(zeroMatch).toBeVisible({ timeout: 3000 })
+      }).toPass({ timeout: 30_000 })
       await expect(zeroMatch).toContainText('No matches for “no-such-tag-zzz-e2e”')
       // The create affordance is suppressed in the archived management view.
       await expect(
@@ -131,10 +181,10 @@ test.describe('Atrium archived-content view (authenticated)', () => {
 
       // It starts as a draft: visible in the default library, absent from Archived.
       await page.goto('/atrium')
-      await pinToProbe(page, title)
+      await pinToProbe(page, title, 'default')
       await expect(cardLink).toBeVisible({ timeout: 15000 })
-      await archivedChip(page).click()
-      await pinToProbe(page, title)
+      await openArchivedView(page)
+      await pinToProbe(page, title, 'archived')
       await expect(cardLink).toHaveCount(0)
 
       // Archive it from the editor's content-settings dialog.
@@ -147,10 +197,10 @@ test.describe('Atrium archived-content view (authenticated)', () => {
       await page.waitForURL('**/atrium', { timeout: 15000 })
 
       // Now it is GONE from the default view and present ONLY under Archived.
-      await pinToProbe(page, title)
+      await pinToProbe(page, title, 'default')
       await expect(cardLink).toHaveCount(0)
-      await archivedChip(page).click()
-      await pinToProbe(page, title)
+      await openArchivedView(page)
+      await pinToProbe(page, title, 'archived')
       await expect(cardLink).toBeVisible({ timeout: 15000 })
       // Muted treatment + ARCHIVED pill on the card.
       await expect(cardLink).toHaveClass(/mer-card-archived/)
@@ -176,10 +226,10 @@ test.describe('Atrium archived-content view (authenticated)', () => {
 
       // Back in the library it is visible in the default view again, absent from Archived.
       await page.goto('/atrium')
-      await pinToProbe(page, title)
+      await pinToProbe(page, title, 'default')
       await expect(cardLink).toBeVisible({ timeout: 15000 })
-      await archivedChip(page).click()
-      await pinToProbe(page, title)
+      await openArchivedView(page)
+      await pinToProbe(page, title, 'archived')
       await expect(cardLink).toHaveCount(0)
 
       // Archive it a second time, then Delete permanently from the editor.
@@ -188,8 +238,8 @@ test.describe('Atrium archived-content view (authenticated)', () => {
       await page.getByRole('button', { name: 'Archive', exact: true }).click()
       await page.waitForURL('**/atrium', { timeout: 15000 })
 
-      await archivedChip(page).click()
-      await pinToProbe(page, title)
+      await openArchivedView(page)
+      await pinToProbe(page, title, 'archived')
       await expect(cardLink).toBeVisible({ timeout: 15000 })
       await cardLink.click()
       await page.waitForURL(`**/atrium/${id}/edit`, { timeout: 15000 })
@@ -206,10 +256,10 @@ test.describe('Atrium archived-content view (authenticated)', () => {
       expect(editorResp?.status()).toBe(404)
 
       await page.goto('/atrium')
-      await pinToProbe(page, title)
+      await pinToProbe(page, title, 'default')
       await expect(cardLink).toHaveCount(0)
-      await archivedChip(page).click()
-      await pinToProbe(page, title)
+      await openArchivedView(page)
+      await pinToProbe(page, title, 'archived')
       await expect(cardLink).toHaveCount(0)
     } finally {
       await context.close()

--- a/tests/e2e/nexus/organization.spec.ts
+++ b/tests/e2e/nexus/organization.spec.ts
@@ -324,6 +324,14 @@ test.describe('Nexus Sidebar — Authenticated', () => {
   })
 
   test('new conversation URL resolves on /nexus', async ({ page }) => {
+    // Same live-model dependency as the two gated siblings above/below: the
+    // conversation id only appears once a streamed turn creates the row, so a
+    // keyless environment 500s the send and this can never pass. This was the
+    // only ungated sendMessage() test in the file.
+    test.skip(
+      process.env.E2E_RUN_EXTERNAL !== '1',
+      'Creating a conversation via chat needs a live model — set E2E_RUN_EXTERNAL=1'
+    )
     await gotoNexus(page)
 
     await sendMessage(page, 'Create conversation for direct URL navigation test')


### PR DESCRIPTION
## Summary

De-flakes `tests/e2e/atrium-archived-view.functional.spec.ts` (failed all 3 retries under the full local pre-push suite while passing in isolation) by fixing the **real app bug** the flake pointed at, plus making the spec's search pinning deterministic. Also adds the local E2E database cleanup script Kris requested.

## Root cause — a post-archive navigation bounce (app bug, not test bug)

Reproduced deterministically with an instrumented diagnostic (patched `history.pushState`/`replaceState` with stack capture + server-action POST logging):

1. The editor page fires a burst of server-action fetches on mount (session, collection tree, versions, comments, …).
2. Archive/Delete left the page via `router.push("/atrium")`. Any mount action still in flight resolves **after** the push…
3. …and the App Router rebases onto the straggler's origin route — the page is silently yanked **back into the editor that was just archived** (~0.5 s after arriving at the library, permanently). The `replaceState` stack shows the rebase comes from Next's router internals during an effect commit.

Under the parallel suite the dev server resolves those actions late → bounce on every attempt. In isolation they finish before the push → no bounce. That asymmetry was the entire "passes isolated, fails full-suite" signature, and it defeated both prior de-flake attempts (`d2674ab6`, `9022bd37`) because no amount of test-side waiting survives the page being taken away.

This is also a real user-facing bug: archive quickly on a slow connection and you're bounced back into the archived doc's editor.

## Changes

**`components/atrium/ContentSettings.tsx`** — archive and hard-delete now leave via `window.location.assign("/atrium")` (document navigation) instead of `router.push`. Page teardown cancels the stragglers, so nothing can rebase the router. Restore keeps `router.refresh()` (stays on the page); `runDelete` no longer needs the router. *Intentional trade-off:* this is a full document load, so client-side state (scroll position, in-memory sidebar state) is not preserved on archive/delete — accepted, since the bug it replaces silently bounced users back into the archived doc's editor.

**`components/atrium/LibraryView.tsx`** — `useLibraryPage` records `settledQuery`/`settledStatus` (the filter values the currently *committed* grid was fetched with, set in the same state batch as `setItems`), rendered as `data-results-query`/`data-results-status` on the library section. `loading` is not a valid settle signal — it flips in a post-paint effect, leaving a window where neither it nor the items reflect a just-changed filter.

**`tests/e2e/atrium-archived-view.functional.spec.ts`**
- `pinToProbe(page, title, view)` fills the search box then awaits the `data-results-*` settle signal for exactly that query + view inside `expect().toPass` (re-filling on retry). Closes both old races: the 300 ms debounce → server-action round trip (assertions ran against the previous result set; `toHaveCount(0)` could false-pass), and the post-navigation hydration wipe (React re-renders the controlled input from empty state, so the typed value — and the search — vanish).
- `openArchivedView()` retries the chip click until `aria-pressed` confirms React handled it (pre-hydration clicks are silently swallowed; single-select chips make re-clicks idempotent).
- The empty-state test's tag fill gets the same retry; the describe block adopts the sibling polish spec's 180 s budget as a companion to the fix, not a substitute.

**`tests/e2e/nexus/organization.spec.ts`** — gated `new conversation URL resolves on /nexus` behind `E2E_RUN_EXTERNAL=1`, matching its two siblings in the same file. It sends a real chat turn (the conversation id only exists once a streamed model response creates the row); in a keyless environment the send 500s (`OpenAI API key not configured`) and the test walled the pre-push suite for unrelated changes.

**`scripts/db/cleanup-e2e-content.ts` + `bun run db:cleanup:e2e`** (requested) — prunes E2E debris from the **local** dev DB, covering both accumulation sites:
- `content_objects` matching the specs' title shapes (`e2e %`/`E2E %` prefixes and anchored `<Name> <run-token>` forms). First run removed 603 + 73 rows dating back three days.
- `graph_nodes` carrying the decision specs' `E2E-<TAG>-<timestamp>` token — 1,001 accumulated nodes across five tags. This accumulation was actively breaking the semantic-search spec: every run adds a near-identical "zeppelin" decision, and the fresh one must beat ~99 prior twins into the top-25 similarity window (failed all retries before pruning; passes after).

Safety: dry-run by default, `--yes` to delete, 60-minute age guard (can't race a live suite), anchored patterns only, refuses non-localhost `DATABASE_URL`, seeded fixtures excluded by UUID prefix, deletes cascade via existing FKs. CI is unaffected (fresh DB). Worth running periodically — the graph specs never clean up after themselves (left as-is here; flagging only).

**`CLAUDE.md`** — documented the `router.push`-vs-straggling-server-actions pitfall in the React section.

## Verification

- Previously failing case: **10/10 green** with `--repeat-each=5` across 5 parallel workers.
- Full authenticated suite (`bun run test:e2e:local`): 275 passed / 33 skipped across multiple complete runs; the only failures were rotating known-flaky specs unrelated to this change (decision semantic search, repository upload, Meridian presence) that pass on rerun.
- `bun run lint`: 0 errors (touched files warning-free). `bun run typecheck`: clean.

## Environment note (no action in this PR)

Worktrees without their own `node_modules` resolve through the parent checkout's install; a stale nested `@codemirror/state@6.5.3` there (beside the pinned 6.7.0) made the atrium Code-tab spec crash with the duplicate-instance error on every fresh server — it looked like a dev regression but is environment cruft. A worktree-local `bun install --frozen-lockfile` fixes it; the main tree has since been reinstalled clean.
