### PR TITLE
fix(agent-skills): make psd-schedules discoverable via skills.search

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,21 @@ jobs:
       env:
         CI: true
 
+    # psd-schedules (Bun). Same reason as above: plain CJS outside the jest
+    # roots. Runs the whole directory, which covers two suites:
+    #   - skill-frontmatter: DISCOVERABILITY. agent-platform-stack.ts
+    #     substitutes "Bundled skill: <name>" when the frontmatter has no
+    #     `summary`, and psd-skills-meta's skills.search matches on name +
+    #     summary only. Without a summary the scheduling skill is reachable
+    #     only by searching the literal word "schedules", so "remind me",
+    #     "cron" and "follow up" all silently return nothing.
+    #   - authority: the request-authority binding added in 38c18aec, which
+    #     shipped with no runner and so had never actually executed in CI.
+    - name: Run psd-schedules skill tests (Bun)
+      run: bun run test:skill:schedules
+      env:
+        CI: true
+
     # Optional: Upload test coverage if you generate it
     # - name: Upload coverage reports
     #   uses: codecov/codecov-action@v3

--- a/infra/agent-image/skills/psd-schedules/SKILL.md
+++ b/infra/agent-image/skills/psd-schedules/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: psd-schedules
+summary: Schedule agent work to run later — recurring cron or rate jobs, and one-shot at() reminders. Use when the user says remind me, wants a daily brief, morning brief, or weekly brief, needs a cron job, or when you promise to follow up later.
 description: Schedule an agent task to run later using Amazon EventBridge Scheduler — either a recurring cron/rate, OR a ONE-SHOT follow-up at a specific time. Use this for morning briefs, weekly summaries, reminders, cron jobs, AND ALSO for any "I'll get back to you in N minutes" promise you make to the user. Do NOT use OpenClaw's built-in cron subsystem; it is disabled in this deployment.
 allowed-tools: Bash(node:*)
 ---

--- a/infra/agent-image/skills/psd-schedules/skill-frontmatter.test.js
+++ b/infra/agent-image/skills/psd-schedules/skill-frontmatter.test.js
@@ -1,0 +1,129 @@
+/**
+ * psd-schedules SKILL.md registration tests.
+ *
+ * Run: bun test skill-frontmatter.test.js   (from this directory, or via
+ *      `bun run test:skill:schedules` at the repo root)
+ *
+ * These guard DISCOVERABILITY, which for this skill is a correctness property
+ * rather than polish. Two mechanisms have to line up:
+ *
+ *   1. infra/lib/agent-platform-stack.ts parses this frontmatter at deploy
+ *      time and registers `summary || `Bundled skill: ${name}``. A missing
+ *      summary is therefore not an empty column — it is a placeholder that
+ *      contains no searchable words.
+ *   2. psd-skills-meta/common.js implements skills.search as
+ *      `WHERE name ILIKE '%q%' OR summary ILIKE '%q%'` — NAME and SUMMARY
+ *      only, never description.
+ *
+ * Net effect when the summary is absent: the agent can reach the scheduling
+ * skill only by searching the literal string "schedules". "remind me", "cron",
+ * "recurring", "daily brief", "follow up" all return zero rows even though the
+ * description covers exactly those cases. That is the bug these tests pin.
+ */
+
+'use strict';
+
+const { test, expect, describe } = require('bun:test');
+const fs = require('node:fs');
+const path = require('node:path');
+
+/**
+ * Parse SKILL.md frontmatter with the SAME regexes agent-platform-stack.ts
+ * uses. Deliberately not a general YAML parser: what matters is what the
+ * registration path actually extracts, not what a stricter parser could.
+ */
+function parseFrontmatterAsStackDoes() {
+  const raw = fs.readFileSync(path.join(__dirname, 'SKILL.md'), 'utf8');
+  const fm = raw.match(/^---\n([\s\S]*?)\n---/);
+  expect(fm).not.toBeNull();
+
+  const fields = { name: '', summary: '', description: '' };
+  for (const line of fm[1].split('\n')) {
+    const m = line.match(/^(name|summary|description):\s*(.*)$/);
+    if (!m) continue;
+    fields[m[1]] = m[2].trim();
+  }
+  return fields;
+}
+
+// What the stack would UPSERT into psd_agent_skills.summary.
+function registeredSummary(fields) {
+  return fields.summary || `Bundled skill: ${fields.name}`;
+}
+
+describe('SKILL.md registration frontmatter', () => {
+  test('declares name, summary and description', () => {
+    const fm = parseFrontmatterAsStackDoes();
+    expect(fm.name).toBe('psd-schedules');
+    expect(fm.summary.length).toBeGreaterThan(0);
+    expect(fm.description.length).toBeGreaterThan(0);
+  });
+
+  test('registers a real summary, not the "Bundled skill:" placeholder', () => {
+    const fm = parseFrontmatterAsStackDoes();
+    expect(registeredSummary(fm)).not.toBe('Bundled skill: psd-schedules');
+  });
+
+  test('summary is a single line the stack can parse', () => {
+    // The stack splits frontmatter on '\n' and matches per line, so a wrapped
+    // summary would silently register only its first physical line.
+    const raw = fs.readFileSync(path.join(__dirname, 'SKILL.md'), 'utf8');
+    const summaryLines = raw
+      .match(/^---\n([\s\S]*?)\n---/)[1]
+      .split('\n')
+      .filter((l) => l.startsWith('summary:'));
+    expect(summaryLines).toHaveLength(1);
+    // A bare ': ' would make the line ambiguous to the YAML readers that also
+    // consume this file, so keep the value colon-free.
+    expect(summaryLines[0].slice('summary:'.length)).not.toContain(': ');
+  });
+});
+
+describe('skills.search discoverability', () => {
+  // Simulates `name ILIKE '%q%' OR summary ILIKE '%q%'`. ILIKE is
+  // case-insensitive substring matching, so lowercased .includes() is the
+  // faithful equivalent for these ASCII terms.
+  const searchable = () => {
+    const fm = parseFrontmatterAsStackDoes();
+    return `${fm.name} ${registeredSummary(fm)}`.toLowerCase();
+  };
+
+  // The queries an agent would actually type when it needs to defer work.
+  // Not cosmetic: summary is the only free-text field skills.search reads.
+  //
+  // Multi-word entries are here deliberately. ILIKE '%q%' matches ONE
+  // contiguous substring, not a bag of words, so "daily brief" only hits if
+  // that exact phrase appears — "daily or weekly brief" would not match it.
+  const QUERY_TERMS = [
+    'remind',
+    'remind me',
+    'reminder',
+    'cron',
+    'cron job',
+    'recurring',
+    'schedule',
+    'later',
+    'follow up',
+    'daily',
+    'daily brief',
+    'morning brief',
+    'weekly',
+    'weekly brief',
+    'brief',
+  ];
+
+  for (const term of QUERY_TERMS) {
+    test(`a search for "${term}" finds this skill`, () => {
+      expect(searchable()).toContain(term);
+    });
+  }
+
+  test('description text is NOT what makes those queries match', () => {
+    // Guards against a future edit that "fixes" discoverability by enriching
+    // the description — which skills.search never reads.
+    const fm = parseFrontmatterAsStackDoes();
+    const withoutSummary = `${fm.name} Bundled skill: ${fm.name}`.toLowerCase();
+    const stillFound = QUERY_TERMS.filter((t) => withoutSummary.includes(t));
+    expect(stillFound).toEqual(['schedule']);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "test:smoke:embedding-lambda-artifact": "bun run scripts/test/embedding-lambda-artifact.smoke.ts",
     "test:skill:workspace": "cd infra/agent-image/skills/psd-workspace && bun test common.test.js",
     "test:skill:directory": "cd infra/agent-image/skills/psd-directory && bun test lib.test.js",
+    "test:skill:schedules": "cd infra/agent-image/skills/psd-schedules && bun test",
     "test:smoke:atrium": "bun run test:smoke:atrium-render && bun run test:smoke:atrium-collab && bun run test:smoke:atrium-collab-token && bun run test:smoke:atrium-agent-bridge && bun run test:smoke:atrium-agent-read && bun run test:smoke:atrium-html-sanitize && bun run test:smoke:atrium-provenance-rail && bun run test:smoke:atrium-collab-schema && bun run test:smoke:atrium-suggestions-resolve && bun run test:smoke:atrium-suggestion-mode && bun run test:smoke:atrium-sandbox-config && bun run test:smoke:atrium-sandbox-host",
     "test:ci": "jest --config=jest.config.ci.js",
     "test:watch": "jest --watch",


### PR DESCRIPTION
## Problem

`psd-schedules` was the only executable bundled skill in `infra/agent-image/skills/` whose `SKILL.md` frontmatter declared no `summary:` — audited all 29 registered skills (`psd-rules` already had one). That single omission made the scheduling capability effectively unreachable by search.

Two mechanisms have to line up, and **neither reads `description`**:

1. **Registration** — `infra/lib/agent-platform-stack.ts:3997` walks the skills dir at deploy time and UPSERTs ``summary: summary || `Bundled skill: ${name}` ``. A missing summary is not an empty column; it registers the placeholder `"Bundled skill: psd-schedules"`, which contains no searchable words.
2. **Search** — `infra/agent-image/skills/psd-skills-meta/common.js` `searchSkills()` issues `WHERE name ILIKE '%q%' OR summary ILIKE '%q%'` — name and summary **only**.

Net effect: the agent could find the scheduling skill only by searching the literal word "schedules". `remind me`, `cron`, `recurring`, `daily brief`, `later`, `follow up` all returned zero rows — even though the description covers exactly those cases, and the skill explicitly instructs the agent to schedule an `at()` follow-up whenever it promises to get back to the user. A capability the agent cannot find is a capability it does not have.

## Changes

**`SKILL.md`** — add a single-line, keyword-rich `summary:` following the sibling pattern (`psd-workspace`, `psd-email-triage`, `psd-canva`). 237 chars; the column is `TEXT` with no cap (`070-agent-skills-platform.sql:43`) and `psd-atrium` already ships 332. Colon-free so the line stays unambiguous to the YAML readers that also consume this frontmatter.

Multi-word phrases are literal, not incidental: `ILIKE '%q%'` matches **one contiguous substring**, not a bag of words. An earlier draft reading "daily or weekly brief" passed every single-word check but still missed both `daily brief` and `remind me`; the wording was changed to make those phrases contiguous.

**`skill-frontmatter.test.js`** (new) — mirrors the `SKILL.md registration frontmatter` describe block from `psd-directory/lib.test.js` (#1351). Parses with the **same regexes the stack uses** rather than a general YAML parser — what matters is what the registration path actually extracts. Asserts the registered value isn't the placeholder, that the summary is exactly one physical line (the stack matches per-line, so a wrapped summary would silently register only its first line), and that each candidate query substring-matches `name + ' ' + summary`. A control test pins that the **description is not** what makes those queries match, so a future edit can't "fix" discoverability by enriching a field `skills.search` never reads.

**`package.json` / `ci.yml`** — wire it in as `test:skill:schedules`, following the `test:skill:workspace` precedent. These skills are plain CJS outside the Next.js and jest roots, so `test:ci` cannot see them; without an explicit step the test would never run.

The script runs `bun test` over the whole directory rather than naming my file. That picks up **`authority.test.js`** as well — the request-authority binding added in 38c18aec, which shipped with no runner and had therefore never executed in CI. It passes (4 tests, no env or network needed), so this gives an existing security suite its first real coverage at no cost.

## Verification

- **19 tests pass.** Confirmed non-tautological: with the summary line removed, 12 of 14 failed (before the phrase terms were added).
- **Simulated the full registration + search path against the real files**: 29 skills registered, **0 placeholder summaries**, and all 13 candidate queries now return `psd-schedules`:

| query | before | after |
|---|---|---|
| `remind me` / `remind` / `reminder` | miss | **hit** |
| `cron` / `recurring` | miss | **hit** |
| `later` / `follow up` | miss | **hit** |
| `daily` / `daily brief` / `morning brief` | miss | **hit** |
| `weekly` / `weekly brief` / `brief` | miss | **hit** |
| `schedule` | hit (name) | hit |

- Frontmatter re-parses as valid YAML (4 keys, summary a 237-char string); `ci.yml` and `package.json` parse clean.
- `bun run lint`: **0 errors** (407 pre-existing warnings, none in touched files — `infra/**` is eslint-ignored and no TypeScript changed). `bun run typecheck`: clean.

No TypeScript or infrastructure logic changed — the stack's parser and the `skills.search` query are untouched.

## Notes

- **Takes effect on next deploy**, not on merge: registration happens when the bundled-skill initializer custom resource runs. The changed `sourceHash` will bump the row.
- Found while working #1239 (#1351) and deliberately left out of that PR as out of scope.
- **Rebased onto `dev` after #1351 and #1353 merged.** Both touched the same region: #1351 added its `psd-directory` CI step in the exact spot, and #1353 rewrote `psd-schedules` itself. Conflicts were additive-only (both CI steps and both scripts kept); the diff against `dev` is now exactly one added script line, one summary line, one new test file, and one CI step.
- **#1353's rewrite does not invalidate the summary.** It changed the *identity model* — the broker now derives owner and Chat destination from the signed invocation, so `--user` is gone — but the capability surface is unchanged: still `cron()`, `rate()`, `at()`, still one-shot follow-ups. The summary describes what the skill does, not how identity is passed.
- Re-verified post-rebase against the new baseline: 23 tests pass in `psd-schedules` (19 mine + 4 authority), and `test:skill:directory` (37) and `test:skill:workspace` (70) still pass.
- `psd-directory/lib.test.js` (the pattern this mirrors) is now on `dev`.
