### PR TITLE
fix(e2e): pre-push gate — reuse only this worktree's server, serialize runs machine-wide

### DIFF
--- a/docs/guides/e2e-authenticated-testing.md
+++ b/docs/guides/e2e-authenticated-testing.md
@@ -39,7 +39,12 @@ mint it.
 For the complete local suite, prefer `bun run test:e2e:local`. The runner starts
 or reuses the host development server, seeds the test users and every committed
 authenticated fixture (including Atrium visibility/group content and resource
-grant rows), warms the routes, and then runs Playwright serially. This makes a
+grant rows), warms the routes, and then runs Playwright serially. A server on
+`:3100` is reused **only when it belongs to the same worktree** the runner is
+invoked from (the listener's cwd must match the repo root) — a healthy server
+from another worktree serves different code and a different `node_modules`, so
+the runner instead scans `E2E_PORT+1..+9` for a free port and starts its own,
+after syncing dependencies with `bun install --frozen-lockfile`. This makes a
 freshly reset local database sufficient without manually applying individual SQL
 files from `tests/e2e/fixtures/`. A runner-started server also sets
 `ATRIUM_LOCAL_STORAGE_DIR` to a port-scoped directory under `/tmp`, so Atrium

--- a/scripts/test/e2e-local.sh
+++ b/scripts/test/e2e-local.sh
@@ -100,8 +100,28 @@ trap 'exit 143' TERM
 while ! mkdir "$LOCK_DIR" 2>/dev/null; do
   holder_pid="$(cat "$LOCK_DIR/pid" 2>/dev/null)"
   if [ -n "$holder_pid" ] && ! kill -0 "$holder_pid" 2>/dev/null; then
-    echo "e2e-local: stale lock (pid $holder_pid is gone) — taking over."
-    rm -rf "$LOCK_DIR"
+    # Steal under a dedicated steal-token so the destructive rm is serialized:
+    # with a bare "check pid → rm → mkdir" steal, two waiters can both judge the
+    # lock stale and the second's rm deletes the FIRST's freshly-created lock —
+    # both then run concurrently, defeating the whole point. Only the waiter
+    # holding the token may rm, and it re-verifies staleness inside the token.
+    if mkdir "$LOCK_DIR.steal" 2>/dev/null; then
+      pid_now="$(cat "$LOCK_DIR/pid" 2>/dev/null)"
+      if [ "$pid_now" = "$holder_pid" ]; then
+        echo "e2e-local: stale lock (pid $holder_pid is gone) — taking over."
+        rm -rf "$LOCK_DIR"
+      elif [ -z "$pid_now" ] && [ -n "$(find "$LOCK_DIR" -maxdepth 0 -mmin +2 2>/dev/null)" ]; then
+        # No pid file: either a FRESH lock whose winner hasn't written yet
+        # (do not touch), or a creator that died between mkdir and the pid
+        # write. Only age distinguishes them — steal only the old one.
+        echo "e2e-local: stale lock (no pid recorded, dir is old) — taking over."
+        rm -rf "$LOCK_DIR"
+      fi
+      rmdir "$LOCK_DIR.steal" 2>/dev/null
+    elif [ -n "$(find "$LOCK_DIR.steal" -maxdepth 0 -mmin +2 2>/dev/null)" ]; then
+      # A stealer died inside the (milliseconds-wide) token window; reclaim.
+      rmdir "$LOCK_DIR.steal" 2>/dev/null
+    fi
     continue
   fi
   echo "e2e-local: another run (pid ${holder_pid:-unknown}, root: $(cat "$LOCK_DIR/root" 2>/dev/null || echo unknown)) is in progress — waiting 30s (bypass once with SKIP_E2E=1)…"
@@ -147,21 +167,31 @@ port_owner_cwd() {
   lsof -a -p "$pid" -d cwd -Fn 2>/dev/null | awk '/^n/ { print substr($0, 2); exit }'
 }
 
+# Two passes: prefer REUSING this worktree's own healthy server anywhere in the
+# range over starting a fresh one on a lower free port (a redundant boot wastes
+# a bun install + server start). Health probes carry --max-time: a server that
+# accepts TCP but never answers /api/healthz (the wedged-server shape from the
+# incident) must fail the probe fast, not stall the scan.
 REUSE=0
 CHOSEN_PORT=""
 for port in $(seq "$E2E_PORT" $((E2E_PORT + 9))); do
-  if curl -sf "http://localhost:${port}/api/healthz" >/dev/null 2>&1; then
-    owner="$(port_owner_cwd "$port")"
-    if [ -n "$owner" ] && [ "$owner" = "$ROOT_CANON" ]; then
-      REUSE=1; CHOSEN_PORT="$port"; break
-    fi
-    echo "e2e-local: :$port serves ${owner:-an unknown directory}, not this worktree — can't gate this push on it."
-  elif [ -n "$(lsof -nP -iTCP:"$port" -sTCP:LISTEN -t 2>/dev/null)" ]; then
-    echo "e2e-local: :$port is occupied by a non-healthy listener — skipping."
-  else
-    CHOSEN_PORT="$port"; break
+  if curl -sf --max-time 3 "http://localhost:${port}/api/healthz" >/dev/null 2>&1 &&
+     [ "$(port_owner_cwd "$port")" = "$ROOT_CANON" ]; then
+    REUSE=1; CHOSEN_PORT="$port"; break
   fi
 done
+if [ "$REUSE" != "1" ]; then
+  for port in $(seq "$E2E_PORT" $((E2E_PORT + 9))); do
+    if curl -sf --max-time 3 "http://localhost:${port}/api/healthz" >/dev/null 2>&1; then
+      owner="$(port_owner_cwd "$port")"
+      echo "e2e-local: :$port serves ${owner:-an unknown directory}, not this worktree — can't gate this push on it."
+    elif [ -n "$(lsof -nP -iTCP:"$port" -sTCP:LISTEN -t 2>/dev/null)" ]; then
+      echo "e2e-local: :$port is occupied by a non-healthy listener — skipping."
+    else
+      CHOSEN_PORT="$port"; break
+    fi
+  done
+fi
 if [ -z "$CHOSEN_PORT" ]; then
   echo "❌ e2e-local: no usable port in $E2E_PORT-$((E2E_PORT + 9)) (all owned by other worktrees/processes)."
   echo "   Stop one of those servers, or rerun with E2E_PORT=<free port>."
@@ -208,7 +238,7 @@ else
   echo -n "e2e-local: waiting for $BASE "
   ready=0
   for attempt in $(seq 1 90); do
-    curl -sf "$BASE/api/healthz" >/dev/null 2>&1 && { ready=1; echo "— ready"; break; }
+    curl -sf --max-time 3 "$BASE/api/healthz" >/dev/null 2>&1 && { ready=1; echo "— ready"; break; }
     echo -n "."; sleep 2
   done
   if [ "$ready" != "1" ]; then

--- a/scripts/test/e2e-local.sh
+++ b/scripts/test/e2e-local.sh
@@ -67,8 +67,14 @@ ROOT="$(git rev-parse --show-toplevel)"; cd "$ROOT" || exit 1
 # "<distDir>/types" to the tsconfig include), and the machine-wide run lock.
 STARTED_PID=""
 LOCK_ACQUIRED=0
+CLEANED=0
 LOCK_DIR="/tmp/aistudio-e2e-local.lock"
 on_exit() {
+  # One-shot: cleanup must run exactly once. By the time a second invocation
+  # could fire, a NEWER run may own the lock — releasing it again would strand
+  # that run unprotected.
+  [ "$CLEANED" = "1" ] && return 0
+  CLEANED=1
   if [ -n "$STARTED_PID" ]; then
     kill "$STARTED_PID" >/dev/null 2>&1
     git checkout -- tsconfig.json >/dev/null 2>&1
@@ -76,7 +82,13 @@ on_exit() {
   [ "$LOCK_ACQUIRED" = "1" ] && rm -rf "$LOCK_DIR"
   return 0
 }
-trap on_exit EXIT INT TERM
+trap on_exit EXIT
+# Signals must become a real exit, not just run the handler: bash RESUMES a
+# script after a trapped-signal handler returns, so a Ctrl-C during the lock
+# wait would keep waiting, and a mid-suite INT would release the lock while
+# this run kept going. exit fires the EXIT trap, so cleanup still runs once.
+trap 'exit 130' INT
+trap 'exit 143' TERM
 
 # --- One run at a time per machine --------------------------------------------------
 # Two concurrent e2e-local runs (e.g. pushes from two worktrees) share ONE local
@@ -117,6 +129,15 @@ fi
 # @codemirror/state crash no branch contained). Reuse only when the listener's
 # cwd is this worktree; when a foreigner owns the port, scan for a free one.
 ROOT_CANON="$(cd "$ROOT" && pwd -P)"
+
+# The ownership check depends on lsof. Without it every healthy server would
+# silently read as foreign (a pointless second server) and an occupied-but-dead
+# port would read as free (a 3-minute startup stall) — fail actionably instead.
+if ! command -v lsof >/dev/null 2>&1; then
+  echo "❌ e2e-local: lsof is required (it verifies which worktree owns the dev server on a port)."
+  echo "   Install lsof, or bypass this push with SKIP_E2E=1."
+  exit 1
+fi
 
 # cwd of the process listening on TCP <port> ('' when none / undetermined).
 port_owner_cwd() {

--- a/scripts/test/e2e-local.sh
+++ b/scripts/test/e2e-local.sh
@@ -62,6 +62,43 @@ if [ "${SKIP_E2E:-}" = "1" ]; then echo "e2e-local: SKIP_E2E=1 — skipping"; ex
 
 ROOT="$(git rev-parse --show-toplevel)"; cd "$ROOT" || exit 1
 
+# Single exit trap for everything this run owns: the started server, Next's
+# automatic tsconfig.json edit (running `next dev` with a custom distDir appends
+# "<distDir>/types" to the tsconfig include), and the machine-wide run lock.
+STARTED_PID=""
+LOCK_ACQUIRED=0
+LOCK_DIR="/tmp/aistudio-e2e-local.lock"
+on_exit() {
+  if [ -n "$STARTED_PID" ]; then
+    kill "$STARTED_PID" >/dev/null 2>&1
+    git checkout -- tsconfig.json >/dev/null 2>&1
+  fi
+  [ "$LOCK_ACQUIRED" = "1" ] && rm -rf "$LOCK_DIR"
+  return 0
+}
+trap on_exit EXIT INT TERM
+
+# --- One run at a time per machine --------------------------------------------------
+# Two concurrent e2e-local runs (e.g. pushes from two worktrees) share ONE local
+# postgres and one laptop: the younger suite re-seeds and mutates rows under the
+# older one, and the resource contention can wedge a dev server for good. On
+# 2026-07-26 a ~9-minute overlap left the younger server permanently hanging every
+# /api route (92 spurious failures over the following hour), while the identical
+# suite alone passed clean. Serialize instead: wait for the running instance.
+while ! mkdir "$LOCK_DIR" 2>/dev/null; do
+  holder_pid="$(cat "$LOCK_DIR/pid" 2>/dev/null)"
+  if [ -n "$holder_pid" ] && ! kill -0 "$holder_pid" 2>/dev/null; then
+    echo "e2e-local: stale lock (pid $holder_pid is gone) — taking over."
+    rm -rf "$LOCK_DIR"
+    continue
+  fi
+  echo "e2e-local: another run (pid ${holder_pid:-unknown}, root: $(cat "$LOCK_DIR/root" 2>/dev/null || echo unknown)) is in progress — waiting 30s (bypass once with SKIP_E2E=1)…"
+  sleep 30
+done
+LOCK_ACQUIRED=1
+echo "$$" > "$LOCK_DIR/pid"
+echo "$ROOT" > "$LOCK_DIR/root"
+
 E2E_PORT="${E2E_PORT:-3100}"
 
 # --- Local secrets (AUTH_SECRET + AUTH_COGNITO_* from .env.local) -----------------
@@ -113,7 +150,10 @@ E2E_PORT="$CHOSEN_PORT"
 BASE="http://localhost:${E2E_PORT}"
 
 # --- Reuse this worktree's dev server, or start our own ----------------------------
-STARTED_PID=""
+# Port-scoped log: two sequential runs on different ports (or a foreign server
+# also logging) must not clobber one file — a shared name produced an unreadable
+# interleaved log during the 2026-07-26 incident diagnosis.
+SERVER_LOG="/tmp/e2e-local-server-${E2E_PORT}.log"
 if [ "$REUSE" = "1" ]; then
   echo "e2e-local: reusing this worktree's dev server on :$E2E_PORT"
 else
@@ -142,16 +182,8 @@ else
   DATABASE_URL="${E2E_DATABASE_URL:-postgresql://postgres:postgres@localhost:5432/aistudio}" \
   ATRIUM_LOCAL_STORAGE_DIR="${E2E_ATRIUM_STORAGE_DIR:-/tmp/aistudio-atrium-e2e-${E2E_PORT}}" \
   DB_SSL="${E2E_DB_SSL:-false}" PORT="$E2E_PORT" HOSTNAME=127.0.0.1 \
-    bun run server.ts > /tmp/e2e-local-server.log 2>&1 &
-  STARTED_PID=$!
-  # On exit: stop our server and undo Next's automatic tsconfig.json edit (running
-  # `next dev` with a custom distDir appends "<distDir>/types" to tsconfig include).
-  cleanup() {
-    [ -n "$STARTED_PID" ] && kill "$STARTED_PID" >/dev/null 2>&1
-    git checkout -- tsconfig.json >/dev/null 2>&1
-    return 0
-  }
-  trap cleanup EXIT INT TERM
+    bun run server.ts > "$SERVER_LOG" 2>&1 &
+  STARTED_PID=$!   # the on_exit trap (set at the top) stops it and restores tsconfig.json
   echo -n "e2e-local: waiting for $BASE "
   ready=0
   for attempt in $(seq 1 90); do
@@ -159,8 +191,8 @@ else
     echo -n "."; sleep 2
   done
   if [ "$ready" != "1" ]; then
-    echo ""; echo "❌ e2e-local: dev server never became healthy. Last log lines:"
-    tail -20 /tmp/e2e-local-server.log; exit 1
+    echo ""; echo "❌ e2e-local: dev server never became healthy. Last log lines ($SERVER_LOG):"
+    tail -20 "$SERVER_LOG"; exit 1
   fi
 fi
 

--- a/scripts/test/e2e-local.sh
+++ b/scripts/test/e2e-local.sh
@@ -21,9 +21,15 @@
 #   check below would latch onto that container, which answers healthz fine but
 #   rejects the minted cookie (every authed spec dies on a /dashboard redirect).
 #   If a healthy server is already on :3100 (e.g. a prior harness run), it is
-#   reused; otherwise the runner starts its own — in an isolated build dir
+#   reused ONLY when it belongs to this worktree (the listener's cwd matches this
+#   repo root) — a healthy server from ANOTHER worktree/checkout serves different
+#   code and a different node_modules, so gating this push on it is meaningless
+#   at best (see the 2026-07-26 duplicate-@codemirror/state incident, where a
+#   foreign server failed code-tab-renders 3/3 on every branch that reused it).
+#   When a foreigner owns the port, the runner scans the next few ports for a
+#   free one instead. A runner-started server lives in an isolated build dir
 #   (.next-e2e via NEXT_DIST_DIR) so it never locks or pollutes your normal
-#   `.next` — and tears it down afterward.
+#   `.next` — and is torn down afterward.
 #
 #   Next dev lazily compiles each route on first hit and can fall over under parallel
 #   load, so the runner warms the heavy routes first and caps workers (E2E_WORKERS=2).
@@ -34,7 +40,10 @@
 #
 # KNOBS:
 #   SKIP_E2E=1         skip entirely for one push       (never runs in CI)
-#   E2E_PORT=3100      port for the dev server (avoid 3000: the Docker app owns it)
+#   E2E_PORT=3100      base port for the dev server (avoid 3000: the Docker app
+#                      owns it). A healthy server here is reused only if it is
+#                      THIS worktree's; otherwise E2E_PORT+1..+9 are scanned for
+#                      a free port
 #   E2E_DATABASE_URL   DB for a runner-started server (default: local Docker
 #                      postgres). Deliberately NOT plain DATABASE_URL — that is
 #                      sourced from .env.local and may be container-perspective.
@@ -54,7 +63,6 @@ if [ "${SKIP_E2E:-}" = "1" ]; then echo "e2e-local: SKIP_E2E=1 — skipping"; ex
 ROOT="$(git rev-parse --show-toplevel)"; cd "$ROOT" || exit 1
 
 E2E_PORT="${E2E_PORT:-3100}"
-BASE="http://localhost:${E2E_PORT}"
 
 # --- Local secrets (AUTH_SECRET + AUTH_COGNITO_* from .env.local) -----------------
 if [ -f .env.local ]; then set -a; . ./.env.local; set +a; fi
@@ -62,11 +70,65 @@ if [ -z "${AUTH_SECRET:-}" ]; then
   echo "❌ e2e-local: AUTH_SECRET not set (expected in .env.local). Aborting."; exit 1
 fi
 
-# --- Reuse a running dev server on :$E2E_PORT, or start our own --------------------
+# --- Pick a port whose server (if any) is OURS -------------------------------------
+# Reusing a healthy server is only valid when it serves THIS worktree. Worktrees
+# live inside the main checkout (.claude/worktrees/*), so several checkouts take
+# turns owning :3100 — and a foreign server gates this push against the WRONG
+# code, from a different node_modules (2026-07-26: a foreign server whose module
+# graph had fallen through to the main checkout's stale tree failed
+# code-tab-renders 3/3 on every branch that reused it, via a duplicate
+# @codemirror/state crash no branch contained). Reuse only when the listener's
+# cwd is this worktree; when a foreigner owns the port, scan for a free one.
+ROOT_CANON="$(cd "$ROOT" && pwd -P)"
+
+# cwd of the process listening on TCP <port> ('' when none / undetermined).
+port_owner_cwd() {
+  local pid
+  pid="$(lsof -nP -iTCP:"$1" -sTCP:LISTEN -t 2>/dev/null | head -1)"
+  [ -z "$pid" ] && return 0
+  lsof -a -p "$pid" -d cwd -Fn 2>/dev/null | awk '/^n/ { print substr($0, 2); exit }'
+}
+
+REUSE=0
+CHOSEN_PORT=""
+for port in $(seq "$E2E_PORT" $((E2E_PORT + 9))); do
+  if curl -sf "http://localhost:${port}/api/healthz" >/dev/null 2>&1; then
+    owner="$(port_owner_cwd "$port")"
+    if [ -n "$owner" ] && [ "$owner" = "$ROOT_CANON" ]; then
+      REUSE=1; CHOSEN_PORT="$port"; break
+    fi
+    echo "e2e-local: :$port serves ${owner:-an unknown directory}, not this worktree — can't gate this push on it."
+  elif [ -n "$(lsof -nP -iTCP:"$port" -sTCP:LISTEN -t 2>/dev/null)" ]; then
+    echo "e2e-local: :$port is occupied by a non-healthy listener — skipping."
+  else
+    CHOSEN_PORT="$port"; break
+  fi
+done
+if [ -z "$CHOSEN_PORT" ]; then
+  echo "❌ e2e-local: no usable port in $E2E_PORT-$((E2E_PORT + 9)) (all owned by other worktrees/processes)."
+  echo "   Stop one of those servers, or rerun with E2E_PORT=<free port>."
+  exit 1
+fi
+E2E_PORT="$CHOSEN_PORT"
+BASE="http://localhost:${E2E_PORT}"
+
+# --- Reuse this worktree's dev server, or start our own ----------------------------
 STARTED_PID=""
-if curl -sf "$BASE/api/healthz" >/dev/null 2>&1; then
-  echo "e2e-local: reusing the dev server already on :$E2E_PORT"
+if [ "$REUSE" = "1" ]; then
+  echo "e2e-local: reusing this worktree's dev server on :$E2E_PORT"
 else
+  # The server must start from a node_modules that matches bun.lock: an
+  # incomplete tree makes Node fall through to the parent checkout's
+  # node_modules (worktrees sit inside it), silently mixing two copies of
+  # packages — the duplicate-@codemirror/state class of crash above.
+  # --frozen-lockfile heals a merely incomplete tree and fails only when
+  # bun.lock itself no longer matches package.json.
+  echo "e2e-local: syncing node_modules (bun install --frozen-lockfile)…"
+  if ! bun install --frozen-lockfile >/dev/null 2>&1; then
+    echo "❌ e2e-local: node_modules cannot be synced — bun.lock does not match package.json."
+    echo "   Run 'bun install' (and commit the lockfile), or bypass once with SKIP_E2E=1."
+    exit 1
+  fi
   echo "e2e-local: starting a dev server on :$E2E_PORT (AUTH_URL pinned to it; isolated .next-e2e)…"
   # Pin the started server to the LOCAL Docker postgres, exactly like the
   # `dev:local` script does. .env.local was sourced above (for AUTH_SECRET) and


### PR DESCRIPTION
## Problem

On 2026-07-26 the pre-push E2E gate failed `code-tab-renders` (tests/e2e/atrium-artifact-fixes.spec.ts) 3/3 deterministically on two unrelated branches, blocking all pushes. Diagnosis showed **neither branch nor dev had a regression** — the gate itself had two machine-level flaws:

1. **Blind server reuse.** `scripts/test/e2e-local.sh` reused any healthy server on `:$E2E_PORT` (bare healthz probe). With several checkouts on one machine (main checkout + `.claude/worktrees/*`), the reused server can belong to a **different worktree** — gating the push against the wrong code and the wrong `node_modules`. In the incident, the foreign server's module graph had fallen through to the main checkout's stale dependency tree (worktrees resolve missing packages from the parent repo because they live inside it), loading two instances of `@codemirror/state` and reviving the exact "Unrecognized extension value in extension set" crash the spec guards (originally fixed in #1224). Playwright trace evidence: Turbopack chunks named for the foreign worktree, four distinct `@codemirror/view` chunks, and overlay stack frames pointing at `../../../node_modules/@codemirror/state/dist/index.js`.

2. **Concurrent runs on one machine.** Two overlapping e2e-local runs share a single local postgres and laptop. A ~9-minute overlap between two full-suite runs left the younger dev server permanently hanging **every** `/api` route-handler request (healthz fine, 0% CPU, zero postgres connections — requests queued behind leaked capacity), producing 92 spurious 1.0m-timeout failures, while the identical suite run alone on the same dev commit passed clean.

## Changes (`scripts/test/e2e-local.sh`)

- **Ownership check before reuse**: after healthz succeeds, an `lsof` cwd check requires the listener's working directory to equal this repo root. A healthy foreign server is skipped with an explicit message.
- **Port fallback**: when the base port is foreign-owned or occupied, scan `E2E_PORT+1..+9` for a free port and start our own server there (AUTH_URL, PLAYWRIGHT_BASE_URL, and the Atrium storage dir all follow the chosen port).
- **Dependency freshness**: before starting a server, `bun install --frozen-lockfile` — heals an incomplete tree (the fall-through trigger) and fails with an actionable message only when bun.lock no longer matches package.json.
- **Machine-wide run lock** (`/tmp/aistudio-e2e-local.lock`, atomic `mkdir`): a second run waits in 30s ticks, printing the holder's pid and repo root; a dead-pid lock is stolen. `SKIP_E2E=1` remains the bypass.
- **One consolidated `on_exit` trap** for server teardown, tsconfig.json restore, and lock release (previously only installed on the server-start path).
- **Port-scoped server log** (`/tmp/e2e-local-server-<port>.log`) — two servers writing one fixed path produced an unreadable interleaved log during diagnosis.
- `docs/guides/e2e-authenticated-testing.md` updated to document the ownership rule.

## Verification

- Unit: `lsof` cwd extraction matches the canonicalized repo root; waiter blocks on a live lock holder without stealing; stale (dead-pid) lock is taken over.
- Live foreign-server scenario: with another worktree's server on :3100, the runner printed the ownership rejection, synced deps, started its own server on :3101, and ran the artifact specs green.
- Full pre-push suite through the new gate on a clean machine: **275 passed, 2 flaky (passed on retry), 33 skipped, 0 failures (6.1m)**.

## Out of scope (flagged separately)

The dev server's API-path capacity leak under client-aborted requests (the mechanism behind flaw 2's wedge) is an app robustness bug in the custom server/proxy layer, tracked as a separate task.
