### PR TITLE
fix(agent-image): restore GWS_VERSION pin — agent image is unbuildable on dev

### DIFF
--- a/infra/agent-image/Dockerfile
+++ b/infra/agent-image/Dockerfile
@@ -72,6 +72,13 @@ RUN apt-get update && \
 # Pin versions for supply-chain safety. Update these as needed.
 ARG BUN_VERSION=1.2.12
 ARG UV_VERSION=0.7.9
+# gws tag for the upstream gws-* SKILL.md docs clone further down. The gws
+# BINARY is no longer installed in this image — #1353 moved gws execution to
+# the trusted web broker so the model runtime never holds a Google token — but
+# the per-API SKILL.md guidance is still copied in, and its clone needs a
+# pinned tag. Declared here with the other version pins so the reference at
+# the clone step cannot go out of scope again.
+ARG GWS_VERSION=0.22.5
 
 # bun (JS/TS runtime) and uv (Python package manager) install from their
 # official GitHub release artifacts with SHA256 verification — NOT via
@@ -364,8 +371,11 @@ RUN cd /opt/psd-skills/psd-schedules && npm install --omit=dev --no-audit --no-f
 
 # Upstream gws-* skills (#912) — per-API SKILL.md guidance for Gmail, Drive,
 # Docs, Sheets, Slides, Forms, Tasks, Calendar, Chat, Meet, Contacts, etc.
-# Pinned to the same tag as the gws binary above so skill instructions never
-# drift from the CLI surface actually installed.
+# Pinned via ARG GWS_VERSION (declared with the other version pins near the top
+# of this stage) so the guidance never drifts from the CLI surface the web
+# broker actually executes. NOTE: the gws binary itself is no longer installed
+# here — #1353 moved execution to the trusted web broker — so this clone is the
+# only remaining gws artifact in the image, and it ships documentation only.
 #
 # git is required for the shallow clone. apt-get already added
 # ca-certificates+curl above; git is not in the base image.


### PR DESCRIPTION
## The agent image cannot be built on dev right now

This blocks **every** agent image build and deploy, not just one feature.

[PR #1353](https://github.com/psd401/aistudio/pull/1353) (security: remediate all 38 audit findings — 88 files, 6191 deletions) correctly moved gws execution to the trusted web broker so the model runtime never holds a Google token, and deleted the gws **binary** install accordingly.

But it also deleted `ARG GWS_VERSION=0.22.5` while leaving the step that still references it:

```dockerfile
git clone --depth 1 --branch "v${GWS_VERSION}" \
  https://github.com/googleworkspace/cli /tmp/gws-repo
```

`${GWS_VERSION}` now expands to empty, so the clone asks for branch `v`:

```
warning: Could not find remote branch v to clone.
fatal: Remote branch v not found in upstream origin
ERROR: ... exit code: 128
```

## The fix

Restores the pin **next to the other version ARGs** rather than beside the clone, so the reference can't fall out of scope again.

This reintroduces **no binary download and no supply-chain surface** — the clone ships the upstream `gws-*` SKILL.md guidance only. Those per-API docs are still needed: the broker executes the same CLI surface server-side, so the model still has to know the command syntax. Tag `v0.22.5` confirmed present upstream via `git ls-remote`.

Also corrects the adjacent comment, which still read "pinned to the same tag as the gws binary above" — that binary is gone, and stale wording like that is exactly what makes an orphaned reference easy to miss.

## Verification

Built the image locally. The step that previously died now runs `git clone --depth 1 --branch "v0.22.5"` and proceeds past it.

## Why CI didn't catch this

No workflow builds the agent image, so a broken Dockerfile merges green. Worth considering a build-only smoke job — happy to file that separately if you want it.