### PR TITLE
feat(content): add agent repository access and Nexus Projects (#1266)

### DIFF
--- a/actions/agent-aistudio.actions.ts
+++ b/actions/agent-aistudio.actions.ts
@@ -157,13 +157,6 @@ export async function handleAistudioCallback(
   const timer = startTimer("handleAistudioCallback")
   const log = createLogger({ requestId, action: "handleAistudioCallback" })
   try {
-    if (!code) {
-      timer({ status: "error" })
-      return createSuccess({
-        success: false,
-        error: "Invalid authorization response. Ask your agent for a new link.",
-      })
-    }
     // Treat the server-side, single-use nonce record as the state validator.
     // A format check is not an authorization boundary: only an exact,
     // unconsumed, unexpired nonce issued by this application may proceed.

--- a/actions/agent-aistudio.actions.ts
+++ b/actions/agent-aistudio.actions.ts
@@ -1,0 +1,310 @@
+"use server"
+
+import { createHash } from "node:crypto"
+import { and, eq, isNull, sql } from "drizzle-orm"
+import { createLogger, generateRequestId, sanitizeForLogging, startTimer } from "@/lib/logger"
+import { createSuccess, handleError } from "@/lib/error-utils"
+import type { ActionState } from "@/types"
+import { executeQuery } from "@/lib/db/drizzle-client"
+import { psdAgentWorkspaceConsentNonces } from "@/lib/db/schema"
+import { verifyConsentToken } from "@/lib/agent-workspace/consent-token"
+import {
+  storeAistudioOAuthTokens,
+  type AistudioOAuthTokenData,
+} from "@/lib/agent-workspace/secrets-manager"
+import { getIssuerUrl } from "@/lib/oauth/issuer-config"
+import { getServerSession } from "@/lib/auth/server-session"
+import {
+  AISTUDIO_OPENCLAW_CLIENT_ID,
+  AISTUDIO_OPENCLAW_SCOPES,
+} from "@/lib/oauth/openclaw-client"
+
+function redirectUri(): string {
+  return `${getIssuerUrl()}/agent-connect-aistudio/callback`
+}
+
+function s256Challenge(verifier: string): string {
+  return createHash("sha256").update(verifier).digest("base64url")
+}
+
+async function isAuthenticatedOwner(ownerEmail: string): Promise<boolean> {
+  const session = await getServerSession()
+  return (
+    typeof session?.email === "string" &&
+    session.email.trim().toLowerCase() === ownerEmail.trim().toLowerCase()
+  )
+}
+
+export interface AistudioConsentVerifyResult {
+  valid: boolean
+  ownerEmail?: string
+  oauthUrl?: string
+  error?: string
+}
+
+export async function verifyAistudioConsentAndGetOAuthUrl(
+  token: string
+): Promise<ActionState<AistudioConsentVerifyResult>> {
+  const requestId = generateRequestId()
+  const timer = startTimer("verifyAistudioConsent")
+  const log = createLogger({ requestId, action: "verifyAistudioConsent" })
+  try {
+    const payload = await verifyConsentToken(token)
+    if (!payload || payload.kind !== "aistudio") {
+      timer({ status: "error" })
+      return createSuccess({
+        valid: false,
+        error: "This consent link is invalid or for a different connection.",
+      })
+    }
+    if (!(await isAuthenticatedOwner(payload.sub))) {
+      timer({ status: "error" })
+      return createSuccess({
+        valid: false,
+        error:
+          "Sign in as the AI Studio owner named in this link to connect OpenClaw.",
+      })
+    }
+    const oneHourAgo = new Date(Date.now() - 60 * 60 * 1000).toISOString()
+    const [row] = await executeQuery(
+      (db) =>
+        db
+          .select({
+            codeVerifier: psdAgentWorkspaceConsentNonces.codeVerifier,
+            ownerEmail: psdAgentWorkspaceConsentNonces.ownerEmail,
+          })
+          .from(psdAgentWorkspaceConsentNonces)
+          .where(
+            sql`${psdAgentWorkspaceConsentNonces.nonce} = ${payload.nonce}
+                AND ${psdAgentWorkspaceConsentNonces.tokenKind} = 'aistudio'
+                AND ${psdAgentWorkspaceConsentNonces.consumedAt} IS NULL
+                AND ${psdAgentWorkspaceConsentNonces.createdAt} > ${oneHourAgo}::timestamptz`
+          )
+          .limit(1),
+      "lookupAistudioConsentNonce"
+    )
+    if (
+      !row?.codeVerifier ||
+      row.ownerEmail.toLowerCase() !== payload.sub.toLowerCase()
+    ) {
+      timer({ status: "error" })
+      return createSuccess({
+        valid: false,
+        error:
+          "This link expired or was already used. Ask your agent for a new link.",
+      })
+    }
+    const params = new URLSearchParams({
+      client_id: AISTUDIO_OPENCLAW_CLIENT_ID,
+      redirect_uri: redirectUri(),
+      response_type: "code",
+      scope: AISTUDIO_OPENCLAW_SCOPES.join(" "),
+      state: payload.nonce,
+      code_challenge: s256Challenge(row.codeVerifier),
+      code_challenge_method: "S256",
+    })
+    timer({ status: "success" })
+    log.info(
+      "AI Studio consent verified",
+      sanitizeForLogging({ ownerEmail: payload.sub })
+    )
+    return createSuccess({
+      valid: true,
+      ownerEmail: payload.sub,
+      oauthUrl: `${getIssuerUrl()}/api/oauth/auth?${params.toString()}`,
+    })
+  } catch (error) {
+    timer({ status: "error" })
+    return handleError(error, "Failed to verify AI Studio consent link", {
+      context: "verifyAistudioConsent",
+      requestId,
+      operation: "verifyAistudioConsent",
+    })
+  }
+}
+
+export interface AistudioCallbackResult {
+  success: boolean
+  ownerEmail?: string
+  error?: string
+}
+
+interface TokenResponse {
+  access_token?: string
+  refresh_token?: string
+  token_type?: string
+  scope?: string
+  expires_in?: number
+  error?: string
+}
+
+async function readJsonObject(response: Response): Promise<Record<string, unknown>> {
+  try {
+    const value: unknown = await response.json()
+    return value && typeof value === "object"
+      ? (value as Record<string, unknown>)
+      : {}
+  } catch {
+    return {}
+  }
+}
+
+export async function handleAistudioCallback(
+  code: string,
+  state: string
+): Promise<ActionState<AistudioCallbackResult>> {
+  const requestId = generateRequestId()
+  const timer = startTimer("handleAistudioCallback")
+  const log = createLogger({ requestId, action: "handleAistudioCallback" })
+  try {
+    if (!/^[\da-f]{64}$/.test(state) || !code) {
+      timer({ status: "error" })
+      return createSuccess({
+        success: false,
+        error: "Invalid authorization response. Ask your agent for a new link.",
+      })
+    }
+    const oneHourAgo = new Date(Date.now() - 60 * 60 * 1000).toISOString()
+    const [row] = await executeQuery(
+      (db) =>
+        db
+          .select({
+            ownerEmail: psdAgentWorkspaceConsentNonces.ownerEmail,
+            tokenKind: psdAgentWorkspaceConsentNonces.tokenKind,
+            codeVerifier: psdAgentWorkspaceConsentNonces.codeVerifier,
+          })
+          .from(psdAgentWorkspaceConsentNonces)
+          .where(
+            sql`${psdAgentWorkspaceConsentNonces.nonce} = ${state}
+                AND ${psdAgentWorkspaceConsentNonces.consumedAt} IS NULL
+                AND ${psdAgentWorkspaceConsentNonces.createdAt} > ${oneHourAgo}::timestamptz`
+          )
+          .limit(1),
+      "lookupAistudioCallbackNonce"
+    )
+    if (!row || row.tokenKind !== "aistudio" || !row.codeVerifier) {
+      timer({ status: "error" })
+      return createSuccess({
+        success: false,
+        error:
+          "This connection link was already used or expired. Ask your agent for a new one.",
+      })
+    }
+    if (!(await isAuthenticatedOwner(row.ownerEmail))) {
+      timer({ status: "error" })
+      return createSuccess({
+        success: false,
+        error:
+          "This AI Studio consent link belongs to a different signed-in user.",
+      })
+    }
+
+    const tokenResponse = await fetch(`${getIssuerUrl()}/api/oauth/token`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+        Accept: "application/json",
+      },
+      body: new URLSearchParams({
+        grant_type: "authorization_code",
+        client_id: AISTUDIO_OPENCLAW_CLIENT_ID,
+        code,
+        redirect_uri: redirectUri(),
+        code_verifier: row.codeVerifier,
+      }).toString(),
+      signal: AbortSignal.timeout(15_000),
+    })
+    const tokenData = (await readJsonObject(tokenResponse)) as TokenResponse
+    if (
+      !tokenResponse.ok ||
+      typeof tokenData.access_token !== "string" ||
+      typeof tokenData.refresh_token !== "string" ||
+      typeof tokenData.expires_in !== "number"
+    ) {
+      log.warn("AI Studio authorization-code exchange failed", {
+        status: tokenResponse.status,
+        error: tokenData.error,
+      })
+      timer({ status: "error" })
+      return createSuccess({
+        success: false,
+        error: "AI Studio rejected the authorization. Please request a new link.",
+      })
+    }
+
+    const userinfoResponse = await fetch(
+      `${getIssuerUrl()}/api/oauth/userinfo`,
+      {
+        headers: {
+          Authorization: `Bearer ${tokenData.access_token}`,
+          Accept: "application/json",
+        },
+        signal: AbortSignal.timeout(10_000),
+      }
+    )
+    const userinfo = await readJsonObject(userinfoResponse)
+    const authorizedEmail =
+      typeof userinfo.email === "string" ? userinfo.email.toLowerCase() : null
+    if (
+      !userinfoResponse.ok ||
+      authorizedEmail !== row.ownerEmail.toLowerCase()
+    ) {
+      log.warn("AI Studio OAuth identity did not match consent owner", {
+        userinfoStatus: userinfoResponse.status,
+        hasEmail: authorizedEmail !== null,
+      })
+      timer({ status: "error" })
+      return createSuccess({
+        success: false,
+        error:
+          "The signed-in AI Studio account does not match this connection link.",
+      })
+    }
+
+    const obtainedAt = new Date()
+    const tokens: AistudioOAuthTokenData = {
+      access_token: tokenData.access_token,
+      refresh_token: tokenData.refresh_token,
+      token_type: "Bearer",
+      scope:
+        typeof tokenData.scope === "string"
+          ? tokenData.scope
+          : AISTUDIO_OPENCLAW_SCOPES.join(" "),
+      obtained_at: obtainedAt.toISOString(),
+      expires_at: new Date(
+        obtainedAt.getTime() + tokenData.expires_in * 1000
+      ).toISOString(),
+    }
+    await storeAistudioOAuthTokens(row.ownerEmail, tokens)
+    const consumed = await executeQuery(
+      (db) =>
+        db
+          .update(psdAgentWorkspaceConsentNonces)
+          .set({ consumedAt: new Date() })
+          .where(
+            and(
+              eq(psdAgentWorkspaceConsentNonces.nonce, state),
+              isNull(psdAgentWorkspaceConsentNonces.consumedAt)
+            )
+          )
+          .returning({ nonce: psdAgentWorkspaceConsentNonces.nonce }),
+      "consumeAistudioConsentNonce"
+    )
+    if (consumed.length !== 1) {
+      throw new Error("AI Studio consent nonce was consumed concurrently")
+    }
+    timer({ status: "success" })
+    log.info(
+      "AI Studio connected to OpenClaw",
+      sanitizeForLogging({ ownerEmail: row.ownerEmail })
+    )
+    return createSuccess({ success: true, ownerEmail: row.ownerEmail })
+  } catch (error) {
+    timer({ status: "error" })
+    return handleError(error, "Failed to complete AI Studio connection", {
+      context: "handleAistudioCallback",
+      requestId,
+      operation: "handleAistudioCallback",
+    })
+  }
+}

--- a/actions/agent-aistudio.actions.ts
+++ b/actions/agent-aistudio.actions.ts
@@ -157,13 +157,16 @@ export async function handleAistudioCallback(
   const timer = startTimer("handleAistudioCallback")
   const log = createLogger({ requestId, action: "handleAistudioCallback" })
   try {
-    if (!/^[\da-f]{64}$/.test(state) || !code) {
+    if (!code) {
       timer({ status: "error" })
       return createSuccess({
         success: false,
         error: "Invalid authorization response. Ask your agent for a new link.",
       })
     }
+    // Treat the server-side, single-use nonce record as the state validator.
+    // A format check is not an authorization boundary: only an exact,
+    // unconsumed, unexpired nonce issued by this application may proceed.
     const oneHourAgo = new Date(Date.now() - 60 * 60 * 1000).toISOString()
     const [row] = await executeQuery(
       (db) =>

--- a/actions/db/publish-skill.actions.ts
+++ b/actions/db/publish-skill.actions.ts
@@ -238,11 +238,11 @@ export async function publishAssistantArchitectAsSkillAction(
 
       await tx
         .delete(skillRepositoryBindings)
-        .where(eq(skillRepositoryBindings.skillId, resolvedId))
+        .where(eq(skillRepositoryBindings.skillId, resolved.id))
       if (repositoryIds.length > 0) {
         await tx.insert(skillRepositoryBindings).values(
           repositoryIds.map((repositoryId) => ({
-            skillId: resolvedId,
+            skillId: resolved.id,
             repositoryId,
           }))
         )

--- a/actions/db/publish-skill.actions.ts
+++ b/actions/db/publish-skill.actions.ts
@@ -9,6 +9,8 @@ import { executeTransaction } from "@/lib/db/drizzle-client"
 import { eq, and, sql } from "drizzle-orm"
 import { psdAgentSkills } from "@/lib/db/schema/tables/agent-skills"
 import { psdAgentSkillAudit } from "@/lib/db/schema/tables/agent-skill-audit"
+import { skillRepositoryBindings } from "@/lib/db/schema/tables/skill-repository-bindings"
+import { getAccessibleRepositoryIds } from "@/lib/db/drizzle"
 import { getAssistantArchitectByIdAction } from "@/actions/db/assistant-architect-actions"
 import {
   serializeAssistantToSkill,
@@ -117,6 +119,30 @@ export async function publishAssistantArchitectAsSkillAction(
       throw ErrorFactories.authzInsufficientPermissions("publish this assistant")
     }
 
+    const repositoryIds = [
+      ...new Set(
+        (architect.prompts ?? []).flatMap((prompt) =>
+          Array.isArray(prompt.repositoryIds)
+            ? prompt.repositoryIds.filter(
+                (id): id is number =>
+                  typeof id === "number" &&
+                  Number.isSafeInteger(id) &&
+                  id > 0
+              )
+            : []
+        )
+      ),
+    ]
+    const accessibleRepositoryIds = await getAccessibleRepositoryIds(
+      repositoryIds,
+      ownerUserId
+    )
+    if (accessibleRepositoryIds.length !== repositoryIds.length) {
+      throw ErrorFactories.authzInsufficientPermissions(
+        "publish one or more bound repositories"
+      )
+    }
+
     // 2. Serialize to SKILL.md.
     const serializerPrompts = (architect.prompts ?? []).map<SerializerPrompt>((p) => ({
       name: p.name,
@@ -210,6 +236,18 @@ export async function publishAssistantArchitectAsSkillAction(
         )
       }
 
+      await tx
+        .delete(skillRepositoryBindings)
+        .where(eq(skillRepositoryBindings.skillId, resolvedId))
+      if (repositoryIds.length > 0) {
+        await tx.insert(skillRepositoryBindings).values(
+          repositoryIds.map((repositoryId) => ({
+            skillId: resolvedId,
+            repositoryId,
+          }))
+        )
+      }
+
       await tx.insert(psdAgentSkillAudit).values({
         skillId: resolved.id,
         action: "published_from_architect",
@@ -218,6 +256,7 @@ export async function publishAssistantArchitectAsSkillAction(
           assistantId,
           slug: serialized.slug,
           allowedTools: serialized.allowedTools,
+          repositoryIds,
           s3Key: draftPrefix,
           // Record the promotion target so an admin can re-trigger the scan
           // Lambda without reconstructing the path from the draft prefix.

--- a/actions/nexus/projects.actions.ts
+++ b/actions/nexus/projects.actions.ts
@@ -1,0 +1,171 @@
+"use server";
+
+import { z } from "zod";
+import { getServerSession } from "@/lib/auth/server-session";
+import { getUserIdByCognitoSubAsNumber } from "@/lib/db/drizzle";
+import { createLogger, generateRequestId, startTimer } from "@/lib/logger";
+import {
+  createSuccess,
+  ErrorFactories,
+  handleError,
+} from "@/lib/error-utils";
+import type { ActionState } from "@/types";
+import {
+  addNexusProjectMember,
+  connectNexusProjectRepository,
+  createNexusProject,
+  createNexusProjectConversation,
+  disconnectNexusProjectRepository,
+  getNexusProject,
+  listNexusProjects,
+  removeNexusProjectMember,
+  updateNexusProject,
+} from "@/lib/nexus/projects/project-service";
+
+const projectIdSchema = z.string().uuid();
+const projectInputSchema = z.object({
+  name: z.string().trim().min(1).max(200),
+  instructions: z.string().trim().max(20_000).optional(),
+});
+
+async function authenticatedUserId() {
+  const session = await getServerSession();
+  if (!session) throw ErrorFactories.authNoSession();
+  const userId = await getUserIdByCognitoSubAsNumber(session.sub);
+  if (!userId) throw ErrorFactories.authNoSession();
+  return userId;
+}
+
+async function runProjectAction<T>(
+  operation: string,
+  callback: (userId: number) => Promise<T>
+): Promise<ActionState<T>> {
+  const requestId = generateRequestId();
+  const timer = startTimer(operation);
+  const log = createLogger({ requestId, action: operation });
+  try {
+    const userId = await authenticatedUserId();
+    const result = await callback(userId);
+    timer({ status: "success" });
+    log.info("Nexus project action completed", { userId });
+    return createSuccess(result, "Success");
+  } catch (error) {
+    timer({ status: "error" });
+    return handleError(error, "Nexus project request failed", {
+      context: operation,
+      requestId,
+      operation,
+    });
+  }
+}
+
+export async function createNexusProjectAction(
+  input: z.input<typeof projectInputSchema>
+) {
+  return runProjectAction("createNexusProjectAction", async (ownerId) => {
+    const parsed = projectInputSchema.parse(input);
+    return createNexusProject({ ownerId, ...parsed });
+  });
+}
+
+export async function listNexusProjectsAction() {
+  return runProjectAction("listNexusProjectsAction", listNexusProjects);
+}
+
+export async function getNexusProjectAction(projectId: string) {
+  return runProjectAction("getNexusProjectAction", async (userId) =>
+    getNexusProject(projectIdSchema.parse(projectId), userId)
+  );
+}
+
+export async function updateNexusProjectAction(input: {
+  projectId: string;
+  name: string;
+  instructions: string;
+}) {
+  return runProjectAction("updateNexusProjectAction", async (userId) => {
+    const projectId = projectIdSchema.parse(input.projectId);
+    const project = projectInputSchema.parse(input);
+    return updateNexusProject({
+      projectId,
+      userId,
+      name: project.name,
+      instructions: project.instructions ?? "",
+    });
+  });
+}
+
+export async function addNexusProjectMemberAction(input: {
+  projectId: string;
+  email: string;
+  role: "editor" | "viewer";
+}) {
+  return runProjectAction("addNexusProjectMemberAction", async (actorUserId) =>
+    addNexusProjectMember({
+      actorUserId,
+      projectId: projectIdSchema.parse(input.projectId),
+      email: z.string().email().max(255).parse(input.email),
+      role: z.enum(["editor", "viewer"]).parse(input.role),
+    })
+  );
+}
+
+export async function removeNexusProjectMemberAction(input: {
+  projectId: string;
+  memberUserId: number;
+}) {
+  return runProjectAction(
+    "removeNexusProjectMemberAction",
+    async (actorUserId) =>
+      removeNexusProjectMember({
+        actorUserId,
+        projectId: projectIdSchema.parse(input.projectId),
+        memberUserId: z.number().int().positive().parse(input.memberUserId),
+      })
+  );
+}
+
+export async function connectNexusProjectRepositoryAction(input: {
+  projectId: string;
+  repositoryId: number;
+}) {
+  return runProjectAction(
+    "connectNexusProjectRepositoryAction",
+    async (userId) =>
+      connectNexusProjectRepository({
+        userId,
+        projectId: projectIdSchema.parse(input.projectId),
+        repositoryId: z.number().int().positive().parse(input.repositoryId),
+      })
+  );
+}
+
+export async function disconnectNexusProjectRepositoryAction(input: {
+  projectId: string;
+  repositoryId: number;
+}) {
+  return runProjectAction(
+    "disconnectNexusProjectRepositoryAction",
+    async (userId) =>
+      disconnectNexusProjectRepository({
+        userId,
+        projectId: projectIdSchema.parse(input.projectId),
+        repositoryId: z.number().int().positive().parse(input.repositoryId),
+      })
+  );
+}
+
+export async function createNexusProjectConversationAction(input: {
+  projectId: string;
+  title?: string;
+}) {
+  return runProjectAction(
+    "createNexusProjectConversationAction",
+    async (userId) =>
+      createNexusProjectConversation({
+        userId,
+        projectId: projectIdSchema.parse(input.projectId),
+        title: z.string().trim().max(500).optional().parse(input.title),
+      })
+  );
+}

--- a/app/(protected)/nexus/_components/layout/nexus-sidebar.tsx
+++ b/app/(protected)/nexus/_components/layout/nexus-sidebar.tsx
@@ -5,6 +5,8 @@ import { Button } from '@/components/ui/button'
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@/components/ui/sheet'
 import { Drawer, DrawerContent, DrawerHeader, DrawerTitle } from '@/components/ui/drawer'
 import { Plus } from 'lucide-react'
+import { FolderKanban } from 'lucide-react'
+import Link from 'next/link'
 import { cn } from '@/lib/utils'
 import { navigateToNewConversation } from '@/lib/nexus/conversation-navigation'
 import type { SidebarMode } from '@/lib/hooks/use-sidebar-state'
@@ -69,6 +71,12 @@ export function NexusSidebar({
                 <Plus className="h-4 w-4" />
                 New Chat
               </Button>
+              <Button asChild variant="ghost" size="sm">
+                <Link href="/nexus/projects">
+                  <FolderKanban className="mr-1.5 h-4 w-4" />
+                  Projects
+                </Link>
+              </Button>
             </div>
           </DrawerHeader>
           <div className="flex-1 overflow-y-auto px-4 pb-4 pt-2">
@@ -95,6 +103,12 @@ export function NexusSidebar({
               >
                 <Plus className="h-4 w-4" />
                 New Chat
+              </Button>
+              <Button asChild variant="ghost" size="sm">
+                <Link href="/nexus/projects">
+                  <FolderKanban className="mr-1.5 h-4 w-4" />
+                  Projects
+                </Link>
               </Button>
             </div>
           </SheetHeader>
@@ -127,6 +141,14 @@ export function NexusSidebar({
             >
               <Plus className="h-4 w-4" />
               New Chat
+            </Button>
+          </div>
+          <div className="border-b px-3 py-2">
+            <Button asChild variant="ghost" size="sm" className="w-full justify-start">
+              <Link href="/nexus/projects">
+                <FolderKanban className="mr-2 h-4 w-4" />
+                Projects
+              </Link>
             </Button>
           </div>
 

--- a/app/(protected)/nexus/page.tsx
+++ b/app/(protected)/nexus/page.tsx
@@ -76,6 +76,8 @@ interface ConversationRuntimeProviderProps {
   routingMode: NexusExperienceMode
   modelFamily: NexusModelFamily
   skillId?: string
+  /** Nexus Project binding; server verifies membership and conversation linkage. */
+  projectId?: string
   /** The open workspace object id/slug (`?workspace=`); binds §1087 content tools server-side. */
   workspaceId?: string
   attachmentAdapter: AttachmentAdapter
@@ -100,6 +102,7 @@ function ConversationRuntimeProvider({
   routingMode,
   modelFamily,
   skillId,
+  projectId,
   workspaceId,
   attachmentAdapter,
   voiceAdapter,
@@ -348,6 +351,7 @@ function ConversationRuntimeProvider({
           enabledConnectors,
           // Bind the session to a skill so the server enforces its allowed-tools pin (#925).
           skillId,
+          projectId,
           // Bind the open workspace object so the server offers §1087 read/edit tools.
           workspaceId: workspaceIdRef.current || undefined,
           conversationId: conversationIdRef.current || undefined,
@@ -386,6 +390,7 @@ interface NexusRuntimeWrapperProps {
   onRoutingModeChange: (mode: NexusExperienceMode) => void
   onModelFamilyChange: (family: NexusModelFamily) => void
   skillId?: string
+  projectId?: string
   /** Open workspace object id/slug (`?workspace=`); passed to the runtime for §1087 tools. */
   workspaceId?: string
   attachmentAdapter: AttachmentAdapter
@@ -410,6 +415,7 @@ function NexusRuntimeWrapper({
   onRoutingModeChange,
   onModelFamilyChange,
   skillId,
+  projectId,
   workspaceId,
   attachmentAdapter,
   voiceAvailable,
@@ -492,6 +498,7 @@ function NexusRuntimeWrapper({
       routingMode={routingMode}
       modelFamily={modelFamily}
       skillId={skillId}
+      projectId={projectId}
       workspaceId={workspaceId}
       attachmentAdapter={attachmentAdapter}
       voiceAdapter={voiceAdapter}
@@ -616,6 +623,11 @@ function NexusPageContent() {
   // session is bound to the skill so the server enforces its allowed-tools pin.
   const urlSkillId = useMemo(() => {
     const raw = searchParams.get('skillId')
+    return raw && uuidSchema.safeParse(raw).success ? raw : undefined
+  }, [searchParams])
+
+  const urlProjectId = useMemo(() => {
+    const raw = searchParams.get('projectId')
     return raw && uuidSchema.safeParse(raw).success ? raw : undefined
   }, [searchParams])
 
@@ -1008,6 +1020,7 @@ function NexusPageContent() {
                           onRoutingModeChange={handleRoutingModeChange}
                           onModelFamilyChange={handleModelFamilyChange}
                           skillId={urlSkillId}
+                          projectId={urlProjectId}
                           workspaceId={urlWorkspaceId ?? undefined}
                           attachmentAdapter={attachmentAdapter}
                           voiceAvailable={voiceAvailability.available}

--- a/app/(protected)/nexus/projects/[id]/_components/project-detail-client.tsx
+++ b/app/(protected)/nexus/projects/[id]/_components/project-detail-client.tsx
@@ -1,0 +1,363 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useState, useTransition } from "react";
+import { Loader2, MessageSquarePlus, Trash2 } from "lucide-react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  addNexusProjectMemberAction,
+  connectNexusProjectRepositoryAction,
+  createNexusProjectConversationAction,
+  disconnectNexusProjectRepositoryAction,
+  removeNexusProjectMemberAction,
+  updateNexusProjectAction,
+} from "@/actions/nexus/projects.actions";
+
+interface ProjectDetail {
+  projectId: string;
+  name: string;
+  instructions: string;
+  role: "owner" | "editor" | "viewer";
+  projectRepositoryId: number;
+  projectRepository: { id: number; name: string; itemCount: number } | null;
+  members: Array<{
+    userId: number;
+    role: "owner" | "editor" | "viewer";
+    email: string | null;
+    firstName: string | null;
+    lastName: string | null;
+  }>;
+  connectedRepositories: Array<{
+    id: number;
+    name: string;
+    description: string | null;
+  }>;
+  conversations: Array<{
+    id: string;
+    title: string | null;
+    messageCount: number | null;
+  }>;
+}
+
+interface RepositoryOption {
+  id: number;
+  name: string;
+}
+
+export function ProjectDetailClient({
+  project,
+  repositoryOptions,
+}: {
+  project: ProjectDetail;
+  repositoryOptions: RepositoryOption[];
+}) {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+  const [name, setName] = useState(project.name);
+  const [instructions, setInstructions] = useState(project.instructions);
+  const [memberEmail, setMemberEmail] = useState("");
+  const [memberRole, setMemberRole] = useState<"editor" | "viewer">("viewer");
+  const [repositoryId, setRepositoryId] = useState("");
+  const canEdit = project.role === "owner" || project.role === "editor";
+
+  function run(
+    action: () => Promise<{ isSuccess: boolean; message: string }>,
+    successMessage: string
+  ) {
+    startTransition(async () => {
+      const result = await action();
+      if (!result.isSuccess) {
+        toast.error(result.message);
+        return;
+      }
+      toast.success(successMessage);
+      router.refresh();
+    });
+  }
+
+  function startChat() {
+    startTransition(async () => {
+      const result = await createNexusProjectConversationAction({
+        projectId: project.projectId,
+      });
+      if (!result.isSuccess) {
+        toast.error(result.message);
+        return;
+      }
+      router.push(
+        `/nexus?conversationId=${result.data.id}&projectId=${project.projectId}`
+      );
+    });
+  }
+
+  const connectedIds = new Set([
+    project.projectRepositoryId,
+    ...project.connectedRepositories.map((repository) => repository.id),
+  ]);
+
+  return (
+    <div className="mx-auto max-w-6xl space-y-6 p-6 md:p-10">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <Link href="/nexus/projects" className="text-sm text-primary">
+            ← All projects
+          </Link>
+          <h1 className="mt-2 text-3xl font-semibold tracking-tight">
+            {project.name}
+          </h1>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Your role: {project.role}
+          </p>
+        </div>
+        <Button onClick={startChat} disabled={isPending}>
+          <MessageSquarePlus className="mr-2 h-4 w-4" />
+          New project chat
+        </Button>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Project context</CardTitle>
+        </CardHeader>
+        <CardContent className="grid gap-4">
+          <Input
+            aria-label="Project name"
+            value={name}
+            maxLength={200}
+            disabled={!canEdit}
+            onChange={(event) => setName(event.target.value)}
+          />
+          <Textarea
+            aria-label="Project instructions"
+            value={instructions}
+            maxLength={20_000}
+            disabled={!canEdit}
+            onChange={(event) => setInstructions(event.target.value)}
+          />
+          {canEdit && (
+            <Button
+              className="w-fit"
+              disabled={isPending || name.trim().length === 0}
+              onClick={() =>
+                run(
+                  () =>
+                    updateNexusProjectAction({
+                      projectId: project.projectId,
+                      name,
+                      instructions,
+                    }),
+                  "Project updated"
+                )
+              }
+            >
+              Save context
+            </Button>
+          )}
+        </CardContent>
+      </Card>
+
+      <div className="grid gap-6 lg:grid-cols-2">
+        <Card>
+          <CardHeader>
+            <CardTitle>Repositories</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="rounded-md border p-3 text-sm">
+              <p className="font-medium">
+                {project.projectRepository?.name ?? "Project files"}
+              </p>
+              <p className="text-muted-foreground">
+                Private project repository ·{" "}
+                {project.projectRepository?.itemCount ?? 0} items
+              </p>
+            </div>
+            {project.connectedRepositories.map((repository) => (
+              <div
+                key={repository.id}
+                className="flex items-start justify-between gap-3 rounded-md border p-3"
+              >
+                <div>
+                  <p className="text-sm font-medium">{repository.name}</p>
+                  <p className="text-xs text-muted-foreground">
+                    {repository.description}
+                  </p>
+                </div>
+                {canEdit && (
+                  <Button
+                    size="icon"
+                    variant="ghost"
+                    aria-label={`Disconnect ${repository.name}`}
+                    disabled={isPending}
+                    onClick={() =>
+                      run(
+                        () =>
+                          disconnectNexusProjectRepositoryAction({
+                            projectId: project.projectId,
+                            repositoryId: repository.id,
+                          }),
+                        "Repository disconnected"
+                      )
+                    }
+                  >
+                    <Trash2 className="h-4 w-4" />
+                  </Button>
+                )}
+              </div>
+            ))}
+            {canEdit && (
+              <div className="flex gap-2">
+                <select
+                  aria-label="Repository to connect"
+                  className="h-10 flex-1 rounded-md border bg-background px-3 text-sm"
+                  value={repositoryId}
+                  onChange={(event) => setRepositoryId(event.target.value)}
+                >
+                  <option value="">Select a repository</option>
+                  {repositoryOptions
+                    .filter((repository) => !connectedIds.has(repository.id))
+                    .map((repository) => (
+                      <option key={repository.id} value={repository.id}>
+                        {repository.name}
+                      </option>
+                    ))}
+                </select>
+                <Button
+                  disabled={isPending || !repositoryId}
+                  onClick={() =>
+                    run(
+                      () =>
+                        connectNexusProjectRepositoryAction({
+                          projectId: project.projectId,
+                          repositoryId: Number(repositoryId),
+                        }),
+                      "Repository connected"
+                    )
+                  }
+                >
+                  Connect
+                </Button>
+              </div>
+            )}
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Members</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            {project.members.map((member) => (
+              <div
+                key={member.userId}
+                className="flex items-center justify-between gap-3 rounded-md border p-3"
+              >
+                <div>
+                  <p className="text-sm font-medium">
+                    {[member.firstName, member.lastName].filter(Boolean).join(" ") ||
+                      member.email}
+                  </p>
+                  <p className="text-xs text-muted-foreground">
+                    {member.email} · {member.role}
+                  </p>
+                </div>
+                {project.role === "owner" && member.role !== "owner" && (
+                  <Button
+                    size="icon"
+                    variant="ghost"
+                    aria-label={`Remove ${member.email ?? "member"}`}
+                    disabled={isPending}
+                    onClick={() =>
+                      run(
+                        () =>
+                          removeNexusProjectMemberAction({
+                            projectId: project.projectId,
+                            memberUserId: member.userId,
+                          }),
+                        "Member removed"
+                      )
+                    }
+                  >
+                    <Trash2 className="h-4 w-4" />
+                  </Button>
+                )}
+              </div>
+            ))}
+            {project.role === "owner" && (
+              <div className="grid gap-2 sm:grid-cols-[1fr_auto_auto]">
+                <Input
+                  aria-label="Member email"
+                  type="email"
+                  placeholder="colleague@psd401.net"
+                  value={memberEmail}
+                  onChange={(event) => setMemberEmail(event.target.value)}
+                />
+                <select
+                  aria-label="Member role"
+                  className="h-10 rounded-md border bg-background px-3 text-sm"
+                  value={memberRole}
+                  onChange={(event) =>
+                    setMemberRole(event.target.value as "editor" | "viewer")
+                  }
+                >
+                  <option value="viewer">Viewer</option>
+                  <option value="editor">Editor</option>
+                </select>
+                <Button
+                  disabled={isPending || !memberEmail}
+                  onClick={() =>
+                    run(
+                      () =>
+                        addNexusProjectMemberAction({
+                          projectId: project.projectId,
+                          email: memberEmail,
+                          role: memberRole,
+                        }),
+                      "Member added"
+                    )
+                  }
+                >
+                  Add
+                </Button>
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Your project chats</CardTitle>
+        </CardHeader>
+        <CardContent className="grid gap-2">
+          {project.conversations.map((conversation) => (
+            <Link
+              key={conversation.id}
+              href={`/nexus?conversationId=${conversation.id}&projectId=${project.projectId}`}
+              className="rounded-md border p-3 text-sm hover:border-primary/50"
+            >
+              {conversation.title ?? "Untitled chat"} ·{" "}
+              {conversation.messageCount ?? 0} messages
+            </Link>
+          ))}
+          {project.conversations.length === 0 && (
+            <p className="text-sm text-muted-foreground">
+              No chats yet. Start one to use the project instructions and
+              repositories.
+            </p>
+          )}
+        </CardContent>
+      </Card>
+
+      {isPending && (
+        <div className="fixed bottom-6 right-6 rounded-full border bg-background p-3 shadow">
+          <Loader2 className="h-5 w-5 animate-spin" />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/(protected)/nexus/projects/[id]/page.tsx
+++ b/app/(protected)/nexus/projects/[id]/page.tsx
@@ -1,0 +1,36 @@
+import { notFound, redirect } from "next/navigation";
+import { getServerSession } from "@/lib/auth/server-session";
+import { getUserIdByCognitoSubAsNumber } from "@/lib/db/drizzle";
+import { listRepositoryCatalog } from "@/lib/repositories/repository-catalog-service";
+import {
+  getNexusProject,
+  NexusProjectAccessError,
+} from "@/lib/nexus/projects/project-service";
+import { ProjectDetailClient } from "./_components/project-detail-client";
+
+export default async function NexusProjectDetailPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const session = await getServerSession();
+  if (!session) redirect("/sign-in");
+  const userId = await getUserIdByCognitoSubAsNumber(session.sub);
+  if (!userId) redirect("/sign-in");
+  const { id } = await params;
+  const [project, repositoryOptions] = await Promise.all([
+      getNexusProject(id, userId),
+      listRepositoryCatalog(session.sub),
+    ]).catch((error: unknown) => {
+    if (error instanceof NexusProjectAccessError) notFound();
+    throw error;
+  });
+  return (
+    <div className="h-full overflow-y-auto">
+      <ProjectDetailClient
+        project={project}
+        repositoryOptions={repositoryOptions}
+      />
+    </div>
+  );
+}

--- a/app/(protected)/nexus/projects/_components/projects-client.tsx
+++ b/app/(protected)/nexus/projects/_components/projects-client.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useState, useTransition } from "react";
+import { FolderKanban, Loader2, Plus } from "lucide-react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { createNexusProjectAction } from "@/actions/nexus/projects.actions";
+
+interface ProjectListItem {
+  id: string;
+  name: string;
+  instructions: string;
+  role: "owner" | "editor" | "viewer";
+  conversationCount: number;
+  updatedAt: Date;
+}
+
+export function ProjectsClient({ projects }: { projects: ProjectListItem[] }) {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+  const [name, setName] = useState("");
+  const [instructions, setInstructions] = useState("");
+
+  function createProject() {
+    startTransition(async () => {
+      const result = await createNexusProjectAction({ name, instructions });
+      if (!result.isSuccess) {
+        toast.error(result.message);
+        return;
+      }
+      setName("");
+      setInstructions("");
+      router.push(`/nexus/projects/${result.data.id}`);
+    });
+  }
+
+  return (
+    <div className="mx-auto max-w-6xl space-y-8 p-6 md:p-10">
+      <div>
+        <h1 className="text-3xl font-semibold tracking-tight">Nexus Projects</h1>
+        <p className="mt-2 text-muted-foreground">
+          Durable project instructions, shared repositories, members, and chats.
+        </p>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2 text-lg">
+            <Plus className="h-5 w-5" />
+            New project
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="grid gap-4">
+          <Input
+            aria-label="Project name"
+            placeholder="Project name"
+            maxLength={200}
+            value={name}
+            onChange={(event) => setName(event.target.value)}
+          />
+          <Textarea
+            aria-label="Project instructions"
+            placeholder="Instructions Nexus should apply to every project chat"
+            maxLength={20_000}
+            value={instructions}
+            onChange={(event) => setInstructions(event.target.value)}
+          />
+          <Button
+            className="w-fit"
+            disabled={isPending || name.trim().length === 0}
+            onClick={createProject}
+          >
+            {isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+            Create project
+          </Button>
+        </CardContent>
+      </Card>
+
+      <div className="grid gap-4 md:grid-cols-2">
+        {projects.map((project) => (
+          <Link key={project.id} href={`/nexus/projects/${project.id}`}>
+            <Card className="h-full transition-colors hover:border-primary/50">
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2 text-lg">
+                  <FolderKanban className="h-5 w-5 text-primary" />
+                  {project.name}
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-2 text-sm text-muted-foreground">
+                <p className="line-clamp-2">
+                  {project.instructions || "No project instructions yet."}
+                </p>
+                <p>
+                  {project.role} · {project.conversationCount} chat
+                  {project.conversationCount === 1 ? "" : "s"}
+                </p>
+              </CardContent>
+            </Card>
+          </Link>
+        ))}
+        {projects.length === 0 && (
+          <p className="text-sm text-muted-foreground">
+            Create your first project to establish a durable Nexus workspace.
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/(protected)/nexus/projects/page.tsx
+++ b/app/(protected)/nexus/projects/page.tsx
@@ -1,0 +1,18 @@
+import { redirect } from "next/navigation";
+import { getServerSession } from "@/lib/auth/server-session";
+import { getUserIdByCognitoSubAsNumber } from "@/lib/db/drizzle";
+import { listNexusProjects } from "@/lib/nexus/projects/project-service";
+import { ProjectsClient } from "./_components/projects-client";
+
+export default async function NexusProjectsPage() {
+  const session = await getServerSession();
+  if (!session) redirect("/sign-in");
+  const userId = await getUserIdByCognitoSubAsNumber(session.sub);
+  if (!userId) redirect("/sign-in");
+  const projects = await listNexusProjects(userId);
+  return (
+    <div className="h-full overflow-y-auto">
+      <ProjectsClient projects={projects} />
+    </div>
+  );
+}

--- a/app/agent-connect-aistudio/_components/aistudio-connect-client.tsx
+++ b/app/agent-connect-aistudio/_components/aistudio-connect-client.tsx
@@ -1,0 +1,66 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { useSearchParams } from "next/navigation"
+import { verifyAistudioConsentAndGetOAuthUrl } from "@/actions/agent-aistudio.actions"
+
+export function AistudioConnectClient() {
+  const searchParams = useSearchParams()
+  const token = searchParams.get("token")
+  const [oauthUrl, setOauthUrl] = useState<string | null>(null)
+  const [ownerEmail, setOwnerEmail] = useState<string | null>(null)
+  const [asyncError, setAsyncError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!token) return
+    let cancelled = false
+    void (async () => {
+      const result = await verifyAistudioConsentAndGetOAuthUrl(token)
+      if (cancelled) return
+      if (result.isSuccess && result.data.valid && result.data.oauthUrl) {
+        setOauthUrl(result.data.oauthUrl)
+        setOwnerEmail(result.data.ownerEmail ?? null)
+      } else {
+        setAsyncError(
+          (result.isSuccess && result.data.error) ||
+            (!result.isSuccess ? result.message : "") ||
+            "This connection link is invalid or expired."
+        )
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [token])
+
+  const error = token
+    ? asyncError
+    : "Missing connection token. Ask your agent for a new link."
+
+  return (
+    <div className="flex min-h-screen items-center justify-center p-4">
+      <div className="w-full max-w-md rounded-lg border bg-card p-8 shadow-sm">
+        <h1 className="mb-2 text-xl font-semibold">Connect AI Studio</h1>
+        {error ? (
+          <p className="text-destructive">{error}</p>
+        ) : oauthUrl ? (
+          <>
+            <p className="mb-6 text-muted-foreground">
+              Authorize OpenClaw to discover and search the AI Studio repositories
+              you can access{ownerEmail ? ` as ${ownerEmail}` : ""}. Access follows
+              your current repository permissions and can be revoked.
+            </p>
+            <a
+              href={oauthUrl}
+              className="inline-flex w-full items-center justify-center rounded-md bg-primary px-4 py-2 font-medium text-primary-foreground hover:bg-primary/90"
+            >
+              Continue to AI Studio
+            </a>
+          </>
+        ) : (
+          <p className="text-muted-foreground">Verifying your link...</p>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/app/agent-connect-aistudio/callback/_components/aistudio-callback-client.tsx
+++ b/app/agent-connect-aistudio/callback/_components/aistudio-callback-client.tsx
@@ -1,0 +1,67 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { useSearchParams } from "next/navigation"
+import {
+  handleAistudioCallback,
+  type AistudioCallbackResult,
+} from "@/actions/agent-aistudio.actions"
+
+export function AistudioCallbackClient() {
+  const searchParams = useSearchParams()
+  const code = searchParams.get("code")
+  const state = searchParams.get("state")
+  const oauthError = searchParams.get("error")
+  const parameterError = oauthError
+    ? `AI Studio reported: ${oauthError}. Ask your agent for a new link.`
+    : !code || !state
+      ? "Missing authorization response. Ask your agent for a new link."
+      : null
+  const [result, setResult] = useState<AistudioCallbackResult | null>(null)
+
+  useEffect(() => {
+    if (parameterError || !code || !state) return
+    let cancelled = false
+    void (async () => {
+      const response = await handleAistudioCallback(code, state)
+      if (cancelled) return
+      setResult(
+        response.isSuccess
+          ? response.data
+          : { success: false, error: response.message }
+      )
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [code, state, parameterError])
+
+  const error =
+    parameterError ?? (result && !result.success ? result.error : null)
+  return (
+    <div className="flex min-h-screen items-center justify-center p-4">
+      <div className="w-full max-w-md rounded-lg border bg-card p-8 text-center shadow-sm">
+        {!error && result === null && (
+          <p className="text-muted-foreground">Connecting AI Studio...</p>
+        )}
+        {result?.success && (
+          <>
+            <h1 className="mb-2 text-xl font-semibold">AI Studio connected</h1>
+            <p className="text-muted-foreground">
+              OpenClaw can now use your authorized repository catalog. You can
+              close this tab and return to chat.
+            </p>
+          </>
+        )}
+        {error && (
+          <>
+            <h1 className="mb-2 text-xl font-semibold">
+              Couldn&apos;t connect
+            </h1>
+            <p className="text-destructive">{error}</p>
+          </>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/app/agent-connect-aistudio/callback/page.tsx
+++ b/app/agent-connect-aistudio/callback/page.tsx
@@ -1,0 +1,18 @@
+import { Suspense } from "react"
+import { AistudioCallbackClient } from "./_components/aistudio-callback-client"
+
+export const dynamic = "force-dynamic"
+
+export default function AistudioCallbackPage() {
+  return (
+    <Suspense
+      fallback={
+        <div className="flex min-h-screen items-center justify-center">
+          <div className="text-lg text-muted-foreground">Connecting...</div>
+        </div>
+      }
+    >
+      <AistudioCallbackClient />
+    </Suspense>
+  )
+}

--- a/app/agent-connect-aistudio/page.tsx
+++ b/app/agent-connect-aistudio/page.tsx
@@ -1,0 +1,18 @@
+import { Suspense } from "react"
+import { AistudioConnectClient } from "./_components/aistudio-connect-client"
+
+export const dynamic = "force-dynamic"
+
+export default function AgentConnectAistudioPage() {
+  return (
+    <Suspense
+      fallback={
+        <div className="flex min-h-screen items-center justify-center">
+          <div className="text-lg text-muted-foreground">Verifying...</div>
+        </div>
+      }
+    >
+      <AistudioConnectClient />
+    </Suspense>
+  )
+}

--- a/app/api/agent/aistudio/route.ts
+++ b/app/api/agent/aistudio/route.ts
@@ -1,12 +1,25 @@
 import { NextRequest, NextResponse } from "next/server"
 import { verifyAgentInvocationContext } from "@/lib/agent-workspace/invocation-context"
-import { getSecretString } from "@/lib/agent-workspace/secrets-manager"
+import {
+  aistudioOAuthSecretId,
+  deleteAistudioOAuthSecret,
+  getSecretJson,
+  getSecretString,
+  storeAistudioOAuthTokens,
+  type AistudioOAuthTokenData,
+} from "@/lib/agent-workspace/secrets-manager"
 import { createLogger, generateRequestId, sanitizeForLogging } from "@/lib/logger"
+import { getIssuerUrl } from "@/lib/oauth/issuer-config"
+import { AISTUDIO_OPENCLAW_CLIENT_ID } from "@/lib/oauth/openclaw-client"
 
 const log = createLogger({ module: "agent-aistudio-broker" })
 const ALLOWED_METHODS = new Set(["tools/list", "tools/call"])
 const MAX_REQUEST_BYTES = 4 * 1024 * 1024
 const PERSONAL_KEY_NAME = "aistudio_personal_key"
+
+type AistudioBrokerBody =
+  | { operation: "disconnect" }
+  | { method: "tools/list" | "tools/call"; params: Record<string, unknown> }
 
 function environment(): string {
   return process.env.ENVIRONMENT ?? process.env.DEPLOY_ENVIRONMENT ?? "dev"
@@ -27,9 +40,12 @@ function mcpUrl(): URL {
 
 function isValidBody(
   value: unknown
-): value is { method: "tools/list" | "tools/call"; params: unknown } {
+): value is AistudioBrokerBody {
   if (!value || typeof value !== "object" || Array.isArray(value)) return false
   const body = value as Record<string, unknown>
+  if (body.operation === "disconnect") {
+    return Object.keys(body).length === 1
+  }
   if (Object.keys(body).some((key) => key !== "method" && key !== "params")) {
     return false
   }
@@ -54,12 +70,88 @@ function isValidBody(
       return false
     }
   }
-  return true
+  return body.params !== null
 }
 
-async function resolveKey(
+async function readJsonObject(response: Response): Promise<Record<string, unknown>> {
+  try {
+    const value: unknown = await response.json()
+    return value && typeof value === "object" && !Array.isArray(value)
+      ? (value as Record<string, unknown>)
+      : {}
+  } catch {
+    return {}
+  }
+}
+
+async function refreshOAuthRecord(
+  ownerEmail: string,
+  record: AistudioOAuthTokenData
+): Promise<AistudioOAuthTokenData | null> {
+  const response = await fetch(`${getIssuerUrl()}/api/oauth/token`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded",
+      Accept: "application/json",
+    },
+    body: new URLSearchParams({
+      grant_type: "refresh_token",
+      client_id: AISTUDIO_OPENCLAW_CLIENT_ID,
+      refresh_token: record.refresh_token,
+    }).toString(),
+    redirect: "error",
+    signal: AbortSignal.timeout(15_000),
+  })
+  const data = await readJsonObject(response)
+  if (
+    !response.ok ||
+    typeof data.access_token !== "string" ||
+    typeof data.refresh_token !== "string"
+  ) {
+    log.warn("Owner-bound AI Studio OAuth refresh was rejected", {
+      status: response.status,
+    })
+    return null
+  }
+  const obtainedAt = new Date()
+  const next: AistudioOAuthTokenData = {
+    access_token: data.access_token,
+    refresh_token: data.refresh_token,
+    token_type: "Bearer",
+    scope: typeof data.scope === "string" ? data.scope : record.scope,
+    obtained_at: obtainedAt.toISOString(),
+    expires_at: new Date(
+      obtainedAt.getTime() +
+        (typeof data.expires_in === "number" ? data.expires_in : 900) * 1000
+    ).toISOString(),
+  }
+  await storeAistudioOAuthTokens(ownerEmail, next)
+  return next
+}
+
+async function resolveOAuthToken(ownerEmail: string): Promise<string | null> {
+  const record = await getSecretJson<AistudioOAuthTokenData>(
+    aistudioOAuthSecretId(ownerEmail)
+  )
+  if (
+    !record ||
+    typeof record.access_token !== "string" ||
+    typeof record.refresh_token !== "string"
+  ) {
+    return null
+  }
+  const expiresAt = Date.parse(record.expires_at)
+  if (Number.isFinite(expiresAt) && expiresAt > Date.now() + 60_000) {
+    return record.access_token
+  }
+  return (await refreshOAuthRecord(ownerEmail, record))?.access_token ?? null
+}
+
+async function resolveCredential(
   ownerEmail: string
-): Promise<{ key: string; source: "personal" | "shared" } | null> {
+): Promise<{ key: string; source: "oauth" | "personal" | "shared" } | null> {
+  const oauth = await resolveOAuthToken(ownerEmail)
+  if (oauth) return { key: oauth, source: "oauth" }
   const personal = await getSecretString(
     `psd-agent-creds/${environment()}/user/${ownerEmail}/${PERSONAL_KEY_NAME}`
   )
@@ -68,6 +160,44 @@ async function resolveKey(
     `psd-agent/${environment()}/aistudio-mcp-api-key`
   )
   return shared ? { key: shared, source: "shared" } : null
+}
+
+async function disconnectOwner(ownerEmail: string): Promise<NextResponse> {
+  const tokens = await getSecretJson<AistudioOAuthTokenData>(
+    aistudioOAuthSecretId(ownerEmail)
+  )
+  if (!tokens?.refresh_token) {
+    return NextResponse.json({ disconnected: true, alreadyDisconnected: true })
+  }
+  const response = await fetch(`${getIssuerUrl()}/api/oauth/revocation`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded",
+      Accept: "application/json",
+    },
+    body: new URLSearchParams({
+      token: tokens.refresh_token,
+      token_type_hint: "refresh_token",
+      client_id: AISTUDIO_OPENCLAW_CLIENT_ID,
+    }).toString(),
+    redirect: "error",
+    signal: AbortSignal.timeout(10_000),
+  })
+  if (!response.ok) {
+    log.warn("Owner-bound AI Studio OAuth revocation failed", {
+      status: response.status,
+    })
+    return NextResponse.json(
+      { error: "AI Studio token revocation failed" },
+      { status: 502 }
+    )
+  }
+  await deleteAistudioOAuthSecret(ownerEmail)
+  log.info(
+    "Owner disconnected AI Studio from OpenClaw",
+    sanitizeForLogging({ ownerEmail })
+  )
+  return NextResponse.json({ disconnected: true })
 }
 
 export async function POST(request: NextRequest) {
@@ -90,7 +220,14 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: "Request is too large" }, { status: 413 })
   }
 
-  const credential = await resolveKey(context.ownerEmail)
+  if ("operation" in body) {
+    if (context.mode !== "owner") {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 })
+    }
+    return disconnectOwner(context.ownerEmail)
+  }
+
+  const credential = await resolveCredential(context.ownerEmail)
   if (!credential) {
     return NextResponse.json(
       { error: "AI Studio credential is not configured" },

--- a/app/api/agent/consent-link/route.ts
+++ b/app/api/agent/consent-link/route.ts
@@ -28,8 +28,14 @@ const log = createLogger({ module: "agent-consent-link" })
  * `agent_account` is RETIRED (#1232): Workspace operations now execute only
  * through the owner-bound operation broker. This route rejects the old slot.
  */
-type Kind = "user_account" | "cognito_data" | "plaud" | "canva"
-const ALLOWED_KINDS: Kind[] = ["user_account", "cognito_data", "plaud", "canva"]
+type Kind = "user_account" | "cognito_data" | "plaud" | "canva" | "aistudio"
+const ALLOWED_KINDS: Kind[] = [
+  "user_account",
+  "cognito_data",
+  "plaud",
+  "canva",
+  "aistudio",
+]
 
 /**
  * Map a consent kind to its public start page. cognito_data captures a
@@ -44,6 +50,8 @@ function resolveConsentPath(kind: Kind): string {
       return "/agent-connect-plaud"
     case "canva":
       return "/agent-connect-canva"
+    case "aistudio":
+      return "/agent-connect-aistudio"
     default:
       return "/agent-connect"
   }
@@ -142,7 +150,7 @@ export async function POST(request: NextRequest) {
       !(ALLOWED_KINDS as readonly string[]).includes(requestBody.kind))
   ) {
     return NextResponse.json(
-      { error: "kind must be 'user_account', 'cognito_data', 'plaud', or 'canva' if provided" },
+      { error: "kind must be 'user_account', 'cognito_data', 'plaud', 'canva', or 'aistudio' if provided" },
       { status: 400 }
     )
   }
@@ -177,7 +185,9 @@ export async function POST(request: NextRequest) {
   // base64url(32 bytes) = 43 chars, within RFC 7636's 43–128 range. Stored
   // server-side; only the S256 challenge ever leaves in a URL.
   const codeVerifier =
-    kind === "plaud" || kind === "canva" ? randomBytes(32).toString("base64url") : null
+    kind === "plaud" || kind === "canva" || kind === "aistudio"
+      ? randomBytes(32).toString("base64url")
+      : null
 
   await executeQuery(
     (db) =>

--- a/app/api/nexus/chat/chat-helpers.ts
+++ b/app/api/nexus/chat/chat-helpers.ts
@@ -84,8 +84,9 @@ export async function createConversation(params: {
   provider: string;
   modelId: string;
   title: string;
+  projectId?: string;
 }): Promise<{ conversationId: string } | { error: Response; requestId?: string }> {
-  const { userId, provider, modelId, title } = params;
+  const { userId, provider, modelId, title, projectId } = params;
 
   const sanitizedTitle = sanitizeTextForDatabase(title);
   const now = new Date();
@@ -94,6 +95,7 @@ export async function createConversation(params: {
     (db) => db.insert(nexusConversations)
       .values({
         userId,
+        projectId,
         provider,
         modelUsed: modelId,
         title: sanitizedTitle,

--- a/app/api/nexus/chat/route.ts
+++ b/app/api/nexus/chat/route.ts
@@ -19,7 +19,10 @@ import { userCanAccessResource } from '@/lib/db/drizzle/resource-access';
 import { getConnectorTools } from '@/lib/mcp/connector-service';
 import type { McpConnectorToolsResult } from '@/lib/mcp/connector-types';
 import { createUniversalTools } from '@/lib/tools/provider-native-tools';
-import { createNexusAttachmentTools } from '@/lib/nexus/attachment-repository-tool';
+import {
+  createNexusAttachmentTools,
+  createNexusRepositorySearchTools,
+} from '@/lib/nexus/attachment-repository-tool';
 import { prepareRepositoryAttachmentMessages } from '@/lib/nexus/repository-attachment-messages';
 import {
   resolveNexusAttachmentImageSources,
@@ -89,6 +92,10 @@ import {
   nexusModelFamilySchema,
   type NexusRoutingMetadata,
 } from '@/lib/nexus/model-router/types';
+import {
+  NexusProjectAccessError,
+  resolveNexusProjectChatContext,
+} from '@/lib/nexus/projects/project-service';
 
 // Allow streaming responses up to 30 minutes. Deep Research runs take 5–25
 // minutes; standard chat and image-gen finish well within this window.
@@ -248,6 +255,8 @@ async function executeStreaming(params: {
   workspacePromptFragment?: string;
   /** Owner-validated search over repositories attached to this conversation. */
   attachmentTools?: ToolSet;
+  /** Server-derived project and skill repository instructions. */
+  repositoryPromptFragment?: string;
   reasoningEffort: 'minimal' | 'low' | 'medium' | 'high';
   responseMode: 'standard' | 'flex' | 'priority';
   requestId: string;
@@ -263,32 +272,37 @@ async function executeStreaming(params: {
     conversationIdValue, conversationTitle, enabledTools, enabledConnectors,
     connectorToolResults, failedConnectorIds, skillInstructions, skillName,
     workspaceTools, workspacePromptFragment, attachmentTools,
+    repositoryPromptFragment,
     reasoningEffort, responseMode,
     requestId, dbModelId, log, timer, precomputedInputTokenMappings,
     inputTokenMappingSink, routingMetadata
   } = params;
 
-  const hasAttachmentTools =
+  const hasRepositoryTools =
     !!attachmentTools && Object.keys(attachmentTools).length > 0;
+  const hasAttachmentTools =
+    !!attachmentTools &&
+    Object.hasOwn(attachmentTools, "searchNexusAttachments");
   const systemPrompt = buildNexusSystemPrompt(
     skillInstructions,
     skillName,
     workspacePromptFragment,
-    hasAttachmentTools
+    hasAttachmentTools,
+    repositoryPromptFragment
   );
 
   const hasWorkspaceTools = !!workspaceTools && Object.keys(workspaceTools).length > 0;
   const multiStepToolsActive =
     connectorToolResults.length > 0 ||
     hasWorkspaceTools ||
-    hasAttachmentTools;
+    hasRepositoryTools;
 
   // Pre-merge adapter + connector + workspace tools (undefined when none active).
   const mergedTools = await buildMergedChatTools({
     enabledTools,
     connectorToolResults,
     workspaceTools: hasWorkspaceTools ? workspaceTools : undefined,
-    attachmentTools: hasAttachmentTools ? attachmentTools : undefined,
+    attachmentTools: hasRepositoryTools ? attachmentTools : undefined,
   });
 
   const streamRequest: StreamRequest = {
@@ -403,6 +417,7 @@ const ChatRequestSchema = z.object({
   // When the session is bound to a published skill ("use in chat"), the skill's
   // `allowed-tools` pin is enforced server-side over the client tool list (#925 AC#6).
   skillId: z.string().uuid().optional(),
+  projectId: z.string().uuid().optional(),
   // When a workspace document/artifact is open beside the chat (`?workspace=<id|slug>`),
   // the server binds read/edit tools for THAT object (Atrium §1087). Loose validation
   // only — the tool builder canView/canEdit-gates server-side; cap length like other params.
@@ -1136,12 +1151,22 @@ async function setupConversation(params: {
   modelId: string;
   requestId: string;
   log: ReturnType<typeof createLogger>;
+  projectId?: string;
 }): Promise<{
   conversationId: string;
   conversationTitle: string;
   created: boolean;
 } | { error: Response }> {
-  const { conversationIdValue, messages, userId, provider, modelId, requestId, log } = params;
+  const {
+    conversationIdValue,
+    messages,
+    userId,
+    provider,
+    modelId,
+    requestId,
+    log,
+    projectId,
+  } = params;
 
   let conversationId = conversationIdValue || '';
   let conversationTitle = 'New Conversation';
@@ -1149,7 +1174,13 @@ async function setupConversation(params: {
 
   if (!conversationId) {
     conversationTitle = generateConversationTitle(messages as UIMessage[]);
-    const convResult = await createConversation({ userId, provider, modelId, title: conversationTitle });
+    const convResult = await createConversation({
+      userId,
+      provider,
+      modelId,
+      title: conversationTitle,
+      projectId,
+    });
     if ('error' in convResult) return convResult;
     conversationId = convResult.conversationId;
     created = true;
@@ -1158,7 +1189,10 @@ async function setupConversation(params: {
     // Without this check any authenticated user can inject messages into any conversation.
     const owned = await executeQuery(
       (db) => db
-        .select({ id: nexusConversations.id })
+        .select({
+          id: nexusConversations.id,
+          projectId: nexusConversations.projectId,
+        })
         .from(nexusConversations)
         .where(and(
           eq(nexusConversations.id, conversationId),
@@ -1169,6 +1203,19 @@ async function setupConversation(params: {
     );
     if (!owned || owned.length === 0) {
       log.warn('Conversation ownership check failed — access denied', { conversationId, userId });
+      return {
+        error: new Response(
+          JSON.stringify({ error: 'Conversation not found or access denied', requestId }),
+          { status: 404, headers: { 'Content-Type': 'application/json' } }
+        )
+      };
+    }
+    if (owned[0]?.projectId !== (projectId ?? null)) {
+      log.warn('Conversation project binding check failed', {
+        conversationId,
+        userId,
+        requestedProjectId: projectId,
+      });
       return {
         error: new Response(
           JSON.stringify({ error: 'Conversation not found or access denied', requestId }),
@@ -1458,7 +1505,8 @@ function buildNexusSystemPrompt(
   skillInstructions: string | undefined,
   skillName: string | undefined,
   workspacePromptFragment?: string,
-  hasAttachmentTools = false
+  hasAttachmentTools = false,
+  repositoryPromptFragment?: string
 ): string {
   let prompt = NEXUS_BASE_SYSTEM_PROMPT;
   if (skillInstructions) {
@@ -1474,6 +1522,9 @@ function buildNexusSystemPrompt(
       "\n\n---\n\nThe user attached private repository content to this conversation. " +
       "Use searchNexusAttachments before making claims about those attachments. " +
       "Cite the returned source labels and never invent content that was not returned.";
+  }
+  if (repositoryPromptFragment) {
+    prompt += `\n\n---\n\n${repositoryPromptFragment}`;
   }
   return prompt;
 }
@@ -1530,6 +1581,7 @@ async function applySkillSessionBinding(args: {
    * opening a workspace (PR #1136 review, codex P2).
    */
   skillAllowedTools: string[];
+  skillRepositoryIds: number[];
 }> {
   const { connectorToolResults, skillId, log } = args;
   const boundSkill = await loadBoundSkill(skillId, log);
@@ -1540,6 +1592,7 @@ async function applySkillSessionBinding(args: {
       skillInstructions: undefined,
       skillName: undefined,
       skillAllowedTools: [],
+      skillRepositoryIds: [],
     };
   }
   const scopedEnabledTools = intersectSkillAllowedTools(
@@ -1566,6 +1619,7 @@ async function applySkillSessionBinding(args: {
     skillInstructions: boundSkill.instructions ?? undefined,
     skillName: boundSkill.name,
     skillAllowedTools: boundSkill.allowedTools,
+    skillRepositoryIds: boundSkill.repositoryIds,
   };
 }
 
@@ -1624,6 +1678,66 @@ async function bindWorkspaceToolsForChat(args: {
   };
 }
 
+async function resolveChatProjectBinding(input: {
+  requestedProjectId?: string;
+  conversationId?: string;
+  userId: number;
+  requestId: string;
+  log: ReturnType<typeof createLogger>;
+}): Promise<
+  | {
+      projectId: string;
+      name: string;
+      instructions: string;
+      repositoryIds: number[];
+    }
+  | null
+  | { error: Response }
+> {
+  let projectId = input.requestedProjectId;
+  if (!projectId && input.conversationId) {
+    const conversationId = input.conversationId;
+    const [conversation] = await executeQuery(
+      (db) =>
+        db
+          .select({ projectId: nexusConversations.projectId })
+          .from(nexusConversations)
+          .where(
+            and(
+              eq(nexusConversations.id, conversationId),
+              eq(nexusConversations.userId, input.userId)
+            )
+          )
+          .limit(1),
+      "resolveNexusConversationProject"
+    );
+    projectId = conversation?.projectId ?? undefined;
+  }
+  if (!projectId) return null;
+  try {
+    const context = await resolveNexusProjectChatContext({
+      projectId,
+      userId: input.userId,
+    });
+    return { projectId, ...context };
+  } catch (error) {
+    if (!(error instanceof NexusProjectAccessError)) throw error;
+    input.log.warn("Nexus project binding denied", {
+      userId: input.userId,
+      projectId,
+    });
+    return {
+      error: new Response(
+        JSON.stringify({
+          error: "Project not found or access denied",
+          requestId: input.requestId,
+        }),
+        { status: 404, headers: { "Content-Type": "application/json" } }
+      ),
+    };
+  }
+}
+
 /**
  * Nexus Chat API - Native Streaming with AI SDK v5
  */
@@ -1650,6 +1764,7 @@ export async function POST(req: Request) {
       enabledTools = [],
       enabledConnectors: manuallyEnabledConnectors = [],
       skillId,
+      projectId: requestedProjectId,
       workspaceId,
       nexusMode,
       modelFamily,
@@ -1682,6 +1797,17 @@ export async function POST(req: Request) {
       return canonicalInlineResult.error;
     }
     const messages = canonicalInlineResult.messages;
+
+    const projectBinding = await resolveChatProjectBinding({
+      requestedProjectId,
+      conversationId: conversationIdValue,
+      userId,
+      requestId,
+      log,
+    });
+    if (projectBinding && "error" in projectBinding) {
+      return projectBinding.error;
+    }
 
     // Resolve the current turn's opaque references before routing or creating a
     // conversation. Forged, expired, and foreign markers therefore leave no
@@ -1734,9 +1860,14 @@ export async function POST(req: Request) {
     const requiresAttachmentTools =
       preboundAttachmentRepositoryIds.length > 0 ||
       attachmentPreflight.requiresAttachmentTools;
-    const routingEnabledTools = requiresAttachmentTools
-      ? [...new Set([...enabledTools, 'searchNexusAttachments'])]
-      : enabledTools;
+    const routingEnabledTools = [
+      ...new Set([
+        ...enabledTools,
+        ...(requiresAttachmentTools ? ['searchNexusAttachments'] : []),
+        ...(projectBinding ? ['searchProjectRepositories'] : []),
+        ...(skillId ? ['searchSkillRepositories'] : []),
+      ]),
+    ];
 
     // 4. Classify and resolve the model. In shadow mode this records the proposed
     // route while continuing to execute the client's existing safe fallback.
@@ -1830,13 +1961,24 @@ export async function POST(req: Request) {
     // the only specialist path that explicitly binds inline-shadow references.
     if (
       isDeepResearchModel &&
-      attachmentPreflight.references.length > 0
+      (attachmentPreflight.references.length > 0 || projectBinding)
     ) {
       timer({ status: 'error', reason: 'deep_research_attachment_unsupported' });
       return new Response(
         JSON.stringify({
           error:
-            'Deep Research does not support attached repository content. Choose a chat model for this request.',
+            'Deep Research does not support repository-backed project content. Choose a chat model for this request.',
+          requestId,
+        }),
+        { status: 400, headers: { 'Content-Type': 'application/json' } }
+      );
+    }
+    if (isImageGenerationModel && projectBinding) {
+      timer({ status: 'error', reason: 'image_project_unsupported' });
+      return new Response(
+        JSON.stringify({
+          error:
+            'Image generation does not use project repository context. Choose a chat model for this request.',
           requestId,
         }),
         { status: 400, headers: { 'Content-Type': 'application/json' } }
@@ -1870,9 +2012,9 @@ export async function POST(req: Request) {
       messages:
         messagesWithParts as z.infer<
           typeof ChatRequestSchema
-        >['messages'],
+      >['messages'],
       userId, provider: modelConfig.provider,
-      modelId, requestId, log
+      modelId, requestId, log, projectId: projectBinding?.projectId
     });
     if ('error' in convSetup) return convSetup.error;
     const { conversationId, conversationTitle, created: conversationCreated } =
@@ -1904,17 +2046,29 @@ export async function POST(req: Request) {
         ownerId: userId,
         conversationId,
       });
-    const attachmentTokenMappingSink =
-      attachmentRepositoryIds.length > 0
+    const repositoryTokenMappingSink =
+      attachmentRepositoryIds.length > 0 || projectBinding || skillId
         ? createTokenMappingSink()
         : undefined;
-    const attachmentTools = attachmentTokenMappingSink
+    const attachmentTools = repositoryTokenMappingSink
       ? createNexusAttachmentTools({
           repositoryIds: attachmentRepositoryIds,
           userCognitoSub: session.sub,
-          tokenMappingSink: attachmentTokenMappingSink,
+          tokenMappingSink: repositoryTokenMappingSink,
         })
       : {};
+    const projectTools =
+      repositoryTokenMappingSink && projectBinding
+        ? createNexusRepositorySearchTools({
+            repositoryIds: projectBinding.repositoryIds,
+            userCognitoSub: session.sub,
+            tokenMappingSink: repositoryTokenMappingSink,
+            toolName: "searchProjectRepositories",
+            description:
+              `Search the repositories connected to the Nexus project "${projectBinding.name}". ` +
+              "Use this before making project-specific claims and cite returned sources.",
+          })
+        : {};
     const { lightweightMessages } = await processMessagesWithAttachments(
       conversationId,
       messagesWithParts
@@ -1948,8 +2102,31 @@ export async function POST(req: Request) {
       skillId,
       log,
     });
-    const { scopedEnabledTools, effectiveConnectorToolResults, skillInstructions, skillName, skillAllowedTools } = skillBinding;
+    const {
+      scopedEnabledTools,
+      effectiveConnectorToolResults,
+      skillInstructions,
+      skillName,
+      skillAllowedTools,
+      skillRepositoryIds,
+    } = skillBinding;
     assertAutomaticToolsAvailable(routing.automaticToolNames, scopedEnabledTools);
+    const skillRepositoryTools =
+      repositoryTokenMappingSink && skillRepositoryIds.length > 0
+        ? createNexusRepositorySearchTools({
+            repositoryIds: skillRepositoryIds,
+            userCognitoSub: session.sub,
+            tokenMappingSink: repositoryTokenMappingSink,
+            toolName: "searchSkillRepositories",
+            description:
+              "Search the repositories bound to the loaded skill. Use current results before following repository-dependent skill instructions and cite returned sources.",
+          })
+        : {};
+    const repositoryTools: ToolSet = {
+      ...attachmentTools,
+      ...projectTools,
+      ...skillRepositoryTools,
+    };
 
     // 8c. Bind workspace content tools when a document/artifact is open beside the
     // chat (Atrium §1087). Server-built + canView/canEdit-gated; a bad/unviewable
@@ -1982,7 +2159,17 @@ export async function POST(req: Request) {
       skillName,
       workspaceTools,
       workspacePromptFragment,
-      attachmentTools,
+      attachmentTools: repositoryTools,
+      repositoryPromptFragment: [
+        projectBinding
+          ? `You are working in the Nexus project "${projectBinding.name}". Follow these project instructions for this conversation:\n\n${projectBinding.instructions || "(No additional instructions.)"}\n\nUse searchProjectRepositories for project repository questions.`
+          : null,
+        skillRepositoryIds.length > 0
+          ? "The loaded skill has repository bindings. Use searchSkillRepositories before applying repository-dependent instructions."
+          : null,
+      ]
+        .filter((value): value is string => value !== null)
+        .join("\n\n---\n\n") || undefined,
       reasoningEffort: validation.data.reasoningEffort || 'medium',
       responseMode: validation.data.responseMode || 'standard',
       requestId,
@@ -1990,7 +2177,7 @@ export async function POST(req: Request) {
       log,
       timer,
       precomputedInputTokenMappings,
-      inputTokenMappingSink: attachmentTokenMappingSink,
+      inputTokenMappingSink: repositoryTokenMappingSink,
       routingMetadata: routing.metadata,
     });
     } catch (turnError) {

--- a/app/api/v1/repositories/[id]/route.ts
+++ b/app/api/v1/repositories/[id]/route.ts
@@ -1,0 +1,42 @@
+import { NextRequest } from "next/server";
+import {
+  createApiResponse,
+  createErrorResponse,
+  requireScope,
+  withApiAuth,
+} from "@/lib/api";
+import { describeRepository } from "@/lib/repositories/repository-catalog-service";
+
+export const GET = withApiAuth(
+  async (
+    _request: NextRequest,
+    auth,
+    requestId,
+    params
+  ) => {
+    const scopeError = requireScope(auth, "repositories:list", requestId);
+    if (scopeError) return scopeError;
+    const repositoryId = Number(params.id);
+    if (!Number.isSafeInteger(repositoryId) || repositoryId <= 0) {
+      return createErrorResponse(
+        requestId,
+        400,
+        "VALIDATION_ERROR",
+        "Invalid repository id"
+      );
+    }
+    const repository = await describeRepository(auth.cognitoSub, repositoryId);
+    if (!repository) {
+      return createErrorResponse(
+        requestId,
+        404,
+        "NOT_FOUND",
+        "Repository not found"
+      );
+    }
+    return createApiResponse(
+      { data: repository, meta: { requestId } },
+      requestId
+    );
+  }
+);

--- a/app/api/v1/repositories/[id]/source/route.ts
+++ b/app/api/v1/repositories/[id]/source/route.ts
@@ -1,0 +1,56 @@
+import { NextRequest } from "next/server";
+import { z } from "zod";
+import {
+  createApiResponse,
+  createErrorResponse,
+  requireScope,
+  withApiAuth,
+} from "@/lib/api";
+import { getRepositorySource } from "@/lib/repositories/repository-catalog-service";
+
+const querySchema = z.object({
+  itemId: z.coerce.number().int().positive(),
+  chunkId: z.coerce.number().int().positive().optional(),
+  limit: z.coerce.number().int().min(1).max(50).optional(),
+});
+
+export const GET = withApiAuth(
+  async (request: NextRequest, auth, requestId, params) => {
+    const scopeError = requireScope(auth, "repositories:read", requestId);
+    if (scopeError) return scopeError;
+    const repositoryId = Number(params.id);
+    const query = querySchema.safeParse(
+      Object.fromEntries(new URL(request.url).searchParams.entries())
+    );
+    if (
+      !Number.isSafeInteger(repositoryId) ||
+      repositoryId <= 0 ||
+      !query.success
+    ) {
+      return createErrorResponse(
+        requestId,
+        400,
+        "VALIDATION_ERROR",
+        "A valid repository id and itemId are required",
+        query.success ? undefined : query.error.issues
+      );
+    }
+    const segments = await getRepositorySource({
+      userId: auth.userId,
+      repositoryId,
+      ...query.data,
+    });
+    if (segments.length === 0) {
+      return createErrorResponse(
+        requestId,
+        404,
+        "NOT_FOUND",
+        "Repository source not found"
+      );
+    }
+    return createApiResponse(
+      { data: segments, meta: { requestId, count: segments.length } },
+      requestId
+    );
+  }
+);

--- a/app/api/v1/repositories/changes/route.ts
+++ b/app/api/v1/repositories/changes/route.ts
@@ -1,0 +1,73 @@
+import { NextRequest } from "next/server";
+import { z } from "zod";
+import {
+  createApiResponse,
+  createErrorResponse,
+  requireScope,
+  withApiAuth,
+} from "@/lib/api";
+import { createLogger } from "@/lib/logger";
+import { listRepositoryChanges } from "@/lib/repositories/repository-catalog-service";
+
+const querySchema = z.object({
+  repositoryIds: z
+    .string()
+    .min(1)
+    .transform((value) => value.split(",").map(Number))
+    .pipe(z.array(z.number().int().positive()).min(1).max(50)),
+  cursor: z.string().max(2048).optional(),
+  limit: z.coerce.number().int().min(1).max(100).optional(),
+});
+
+export const GET = withApiAuth(
+  async (request: NextRequest, auth, requestId) => {
+    const scopeError = requireScope(auth, "repositories:changes", requestId);
+    if (scopeError) return scopeError;
+    const parsed = querySchema.safeParse(
+      Object.fromEntries(new URL(request.url).searchParams.entries())
+    );
+    if (!parsed.success) {
+      return createErrorResponse(
+        requestId,
+        400,
+        "VALIDATION_ERROR",
+        "Invalid repository changes query",
+        parsed.error.issues
+      );
+    }
+    const log = createLogger({
+      requestId,
+      route: "api.v1.repositories.changes",
+    });
+    try {
+      const result = await listRepositoryChanges({
+        userId: auth.userId,
+        ...parsed.data,
+      });
+      return createApiResponse(
+        {
+          data: result.changes,
+          meta: { requestId, nextCursor: result.nextCursor },
+        },
+        requestId
+      );
+    } catch (error) {
+      const invalidCursor =
+        error instanceof Error &&
+        error.message === "Invalid repository changes cursor";
+      if (!invalidCursor) {
+        log.error("Failed to list repository changes", {
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+      return createErrorResponse(
+        requestId,
+        invalidCursor ? 400 : 500,
+        invalidCursor ? "VALIDATION_ERROR" : "INTERNAL_ERROR",
+        invalidCursor
+          ? "Invalid repository changes cursor"
+          : "Failed to list repository changes"
+      );
+    }
+  }
+);

--- a/app/api/v1/repositories/route.ts
+++ b/app/api/v1/repositories/route.ts
@@ -1,0 +1,62 @@
+import { NextRequest } from "next/server";
+import { z } from "zod";
+import {
+  createApiResponse,
+  createErrorResponse,
+  requireScope,
+  withApiAuth,
+} from "@/lib/api";
+import { createLogger } from "@/lib/logger";
+import { listRepositoryCatalog } from "@/lib/repositories/repository-catalog-service";
+
+const querySchema = z.object({
+  query: z.string().max(200).optional(),
+  limit: z.coerce.number().int().min(1).max(50).optional(),
+});
+
+export const GET = withApiAuth(
+  async (request: NextRequest, auth, requestId) => {
+    const scopeError = requireScope(auth, "repositories:list", requestId);
+    if (scopeError) return scopeError;
+    const parsed = querySchema.safeParse(
+      Object.fromEntries(new URL(request.url).searchParams.entries())
+    );
+    if (!parsed.success) {
+      return createErrorResponse(
+        requestId,
+        400,
+        "VALIDATION_ERROR",
+        "Invalid repository query parameters",
+        parsed.error.issues
+      );
+    }
+    const log = createLogger({
+      requestId,
+      route: "api.v1.repositories.list",
+    });
+    try {
+      const repositories = await listRepositoryCatalog(auth.cognitoSub, parsed.data);
+      log.info("Listed repository catalog", {
+        userId: auth.userId,
+        count: repositories.length,
+      });
+      return createApiResponse(
+        {
+          data: repositories,
+          meta: { requestId, count: repositories.length },
+        },
+        requestId
+      );
+    } catch (error) {
+      log.error("Failed to list repository catalog", {
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return createErrorResponse(
+        requestId,
+        500,
+        "INTERNAL_ERROR",
+        "Failed to list repositories"
+      );
+    }
+  }
+);

--- a/app/api/v1/repositories/search/route.ts
+++ b/app/api/v1/repositories/search/route.ts
@@ -1,0 +1,61 @@
+import { NextRequest } from "next/server";
+import { z } from "zod";
+import {
+  createApiResponse,
+  createErrorResponse,
+  parseRequestBody,
+  requireScope,
+  withApiAuth,
+} from "@/lib/api";
+import { createLogger } from "@/lib/logger";
+import { searchRepositoryCatalog } from "@/lib/repositories/repository-catalog-service";
+
+const bodySchema = z.object({
+  query: z.string().trim().min(1).max(2000),
+  repositoryIds: z.array(z.number().int().positive()).max(50).optional(),
+  mode: z.enum(["keyword", "vector", "hybrid"]).optional(),
+  modalities: z
+    .array(z.enum(["text", "image", "audio", "video", "table"]))
+    .max(5)
+    .optional(),
+  limit: z.number().int().min(1).max(50).optional(),
+  threshold: z.number().min(0).max(1).optional(),
+});
+
+export const POST = withApiAuth(
+  async (request: NextRequest, auth, requestId) => {
+    const scopeError = requireScope(auth, "repositories:search", requestId);
+    if (scopeError) return scopeError;
+    const parsed = await parseRequestBody(request, bodySchema, requestId);
+    if (parsed instanceof Response) return parsed;
+    const log = createLogger({
+      requestId,
+      route: "api.v1.repositories.search",
+    });
+    try {
+      const result = await searchRepositoryCatalog({
+        cognitoSub: auth.cognitoSub,
+        ...parsed.data,
+      });
+      log.info("Searched repository catalog", {
+        userId: auth.userId,
+        requestedRepositoryCount: parsed.data.repositoryIds?.length ?? 0,
+        returnedResults: result.results.length,
+      });
+      return createApiResponse(
+        { data: result.results, meta: { requestId, ...result.diagnostics } },
+        requestId
+      );
+    } catch (error) {
+      log.error("Failed to search repository catalog", {
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return createErrorResponse(
+        requestId,
+        500,
+        "INTERNAL_ERROR",
+        "Failed to search repositories"
+      );
+    }
+  }
+);

--- a/docs/API/v1/context-graph.md
+++ b/docs/API/v1/context-graph.md
@@ -31,6 +31,10 @@ All `/api/v1/graph/*` endpoints require authentication. Two modes are supported:
 |-------|--------|
 | `graph:read` | List nodes, get node, list edges, get connections |
 | `graph:write` | Create/update/delete nodes, create/delete edges |
+| `repositories:list` | List and describe repositories currently accessible to the principal |
+| `repositories:read` | Disclose current immutable source segments and citations |
+| `repositories:search` | Run retrieval v2 over currently authorized repositories |
+| `repositories:changes` | Poll the authorized repository item change feed |
 
 API keys are created in **Settings > API Keys**. Administrators receive all scopes; staff receives `graph:read` by default.
 
@@ -486,6 +490,101 @@ Delete a single edge. Requires `graph:write`.
 ```
 
 **Response `404`** — Edge not found.
+
+---
+
+### Repository catalog and retrieval — Issue #1266
+
+The repository API is the REST equivalent of the
+`repositories_list`, `repositories_describe`, `repositories_search`,
+`repositories_get_source`, and `repositories_list_changes` MCP tools. Each
+operation has its own API-key scope. Holding a scope never grants repository
+access: the executing user must also pass the live repository ACL, and
+source/search disclosure additionally enforces segment ACLs, current immutable
+item versions, and the active index generation.
+
+Inaccessible resources are omitted from lists/searches and masked as
+`404 NOT_FOUND` on direct reads. System-managed, ephemeral, expired, and
+non-active repositories are not part of the external catalog.
+
+#### `GET /api/v1/repositories`
+
+Requires `repositories:list`. Optional query parameters:
+
+| Name | Type | Description |
+|---|---|---|
+| `query` | string (max 200) | Case-insensitive name/description filter |
+| `limit` | integer (1-50) | Maximum entries; default 50 |
+
+```bash
+curl -H "Authorization: Bearer sk-your-key" \
+  "https://your-domain/api/v1/repositories?query=policy&limit=20"
+```
+
+Each entry includes `id`, `name`, `description`, `ownerName`, `visibility`,
+`itemCount`, `activeIndexGenerationId`, and update timestamps.
+
+#### `GET /api/v1/repositories/{id}`
+
+Requires `repositories:list`. Returns the same catalog projection for one
+currently accessible repository. Missing and inaccessible ids both return 404.
+
+#### `POST /api/v1/repositories/search`
+
+Requires `repositories:search`. Omit `repositoryIds` to search all accessible
+durable repositories.
+
+```json
+{
+  "query": "What is the current graduation policy?",
+  "repositoryIds": [42],
+  "mode": "hybrid",
+  "modalities": ["text", "table"],
+  "limit": 5,
+  "threshold": 0.2
+}
+```
+
+`mode` is `keyword`, `vector`, or `hybrid`; modalities are `text`, `image`,
+`audio`, `video`, or `table`. Results use retrieval v2 and include immutable
+source citations. Unauthorized requested ids produce no results from those
+repositories; they never disclose whether the id exists.
+
+#### `GET /api/v1/repositories/{id}/source`
+
+Requires `repositories:read`. `itemId` is required; `chunkId` and a 1-50
+`limit` are optional. This is the exact-source step after search:
+
+```bash
+curl -H "Authorization: Bearer sk-your-key" \
+  "https://your-domain/api/v1/repositories/42/source?itemId=87&chunkId=901"
+```
+
+The response contains `chunkId`, stable/current item and version identifiers,
+`versionNumber`, modality, content, context prefix, and exact source locator.
+The final SQL disclosure rechecks repository and segment access in the same
+statement. No accessible current segment returns 404.
+
+#### `GET /api/v1/repositories/changes`
+
+Requires `repositories:changes`. `repositoryIds` is a required comma-separated
+list of at most 50 ids. `limit` is 1-100; `cursor` is the opaque
+`meta.nextCursor` from the previous response.
+
+```bash
+curl -H "Authorization: Bearer sk-your-key" \
+  "https://your-domain/api/v1/repositories/changes?repositoryIds=42,51&limit=50"
+```
+
+Changes are ordered by `(updatedAt,itemId)`, which makes the cursor stable when
+timestamps tie. Each page rechecks current ACLs; access revocation therefore
+takes effect without rebuilding an agent. A malformed cursor returns
+`400 VALIDATION_ERROR`.
+
+Common errors are `400 VALIDATION_ERROR`, `401 UNAUTHORIZED`/`INVALID_TOKEN`,
+`403 INSUFFICIENT_SCOPE`, `404 NOT_FOUND`, `429 RATE_LIMIT_EXCEEDED`, and
+`500 INTERNAL_ERROR`. Every response retains the standard request-id and
+rate-limit headers described above.
 
 ---
 

--- a/docs/API/v1/generated/capability-catalog.json
+++ b/docs/API/v1/generated/capability-catalog.json
@@ -1,9 +1,9 @@
 {
   "summary": {
-    "actions": 24,
+    "actions": 29,
     "features": 9,
-    "scopes": 25,
-    "agentInvocableActions": 17
+    "scopes": 29,
+    "agentInvocableActions": 22
   },
   "actions": [
     {
@@ -493,6 +493,136 @@
       "agentInvocable": true
     },
     {
+      "identifier": "repositories.describe",
+      "name": "repositories_describe",
+      "description": "Describe one durable repository if the authenticated user can currently access it.",
+      "surfaces": [
+        "mcp",
+        "internal",
+        "rest"
+      ],
+      "requiredScopes": [
+        "repositories:list"
+      ],
+      "scopesBySurface": {
+        "mcp": [
+          "repositories:list"
+        ],
+        "internal": [
+          "repositories:list"
+        ],
+        "rest": [
+          "repositories:list"
+        ]
+      },
+      "destructive": false,
+      "agentInvocable": true
+    },
+    {
+      "identifier": "repositories.get_source",
+      "name": "repositories_get_source",
+      "description": "Get exact citation source segments from an authorized repository's active generation and current item version.",
+      "surfaces": [
+        "mcp",
+        "internal",
+        "rest"
+      ],
+      "requiredScopes": [
+        "repositories:read"
+      ],
+      "scopesBySurface": {
+        "mcp": [
+          "repositories:read"
+        ],
+        "internal": [
+          "repositories:read"
+        ],
+        "rest": [
+          "repositories:read"
+        ]
+      },
+      "destructive": false,
+      "agentInvocable": true
+    },
+    {
+      "identifier": "repositories.list",
+      "name": "repositories_list",
+      "description": "List durable repositories the authenticated user can currently access.",
+      "surfaces": [
+        "mcp",
+        "internal",
+        "rest"
+      ],
+      "requiredScopes": [
+        "repositories:list"
+      ],
+      "scopesBySurface": {
+        "mcp": [
+          "repositories:list"
+        ],
+        "internal": [
+          "repositories:list"
+        ],
+        "rest": [
+          "repositories:list"
+        ]
+      },
+      "destructive": false,
+      "agentInvocable": true
+    },
+    {
+      "identifier": "repositories.list_changes",
+      "name": "repositories_list_changes",
+      "description": "List item changes in authorized repositories using a stable opaque cursor.",
+      "surfaces": [
+        "mcp",
+        "internal",
+        "rest"
+      ],
+      "requiredScopes": [
+        "repositories:changes"
+      ],
+      "scopesBySurface": {
+        "mcp": [
+          "repositories:changes"
+        ],
+        "internal": [
+          "repositories:changes"
+        ],
+        "rest": [
+          "repositories:changes"
+        ]
+      },
+      "destructive": false,
+      "agentInvocable": true
+    },
+    {
+      "identifier": "repositories.search",
+      "name": "repositories_search",
+      "description": "Search one or more authorized repositories using the active retrieval generation and live repository and segment ACLs.",
+      "surfaces": [
+        "mcp",
+        "internal",
+        "rest"
+      ],
+      "requiredScopes": [
+        "repositories:search"
+      ],
+      "scopesBySurface": {
+        "mcp": [
+          "repositories:search"
+        ],
+        "internal": [
+          "repositories:search"
+        ],
+        "rest": [
+          "repositories:search"
+        ]
+      },
+      "destructive": false,
+      "agentInvocable": true
+    },
+    {
       "identifier": "web.fetch",
       "name": "web_fetch",
       "description": "Fetch a single public web page over HTTPS and return its readable text content (scripts, styles, and markup stripped). Use to read documentation, articles, or reference pages the user links to. Private/internal hosts are blocked.",
@@ -785,6 +915,38 @@
       "description": "Read the AI Studio capability catalog (actions, features, scopes)",
       "roles": [
         "student",
+        "staff",
+        "administrator"
+      ]
+    },
+    {
+      "scope": "repositories:changes",
+      "description": "Read authorized repository change feeds",
+      "roles": [
+        "staff",
+        "administrator"
+      ]
+    },
+    {
+      "scope": "repositories:list",
+      "description": "List and describe repositories the caller can access",
+      "roles": [
+        "staff",
+        "administrator"
+      ]
+    },
+    {
+      "scope": "repositories:read",
+      "description": "Read authorized repository source segments and citations",
+      "roles": [
+        "staff",
+        "administrator"
+      ]
+    },
+    {
+      "scope": "repositories:search",
+      "description": "Search authorized repositories",
+      "roles": [
         "staff",
         "administrator"
       ]

--- a/docs/API/v1/generated/tool-catalog.openapi.json
+++ b/docs/API/v1/generated/tool-catalog.openapi.json
@@ -94,6 +94,180 @@
           }
         }
       }
+    },
+    "/api/v1/repositories": {
+      "get": {
+        "operationId": "listRepositories",
+        "summary": "List accessible repositories",
+        "x-tool-identifier": "repositories.list",
+        "x-tool-version": "v1",
+        "security": [
+          {
+            "ApiKeyAuth": [
+              "repositories:list"
+            ]
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "401": {
+            "description": "Missing or invalid API credentials."
+          },
+          "403": {
+            "description": "Authenticated but missing a required scope."
+          },
+          "500": {
+            "description": "Internal error."
+          }
+        }
+      }
+    },
+    "/api/v1/repositories/{id}": {
+      "get": {
+        "operationId": "describeRepository",
+        "summary": "Describe an accessible repository",
+        "x-tool-identifier": "repositories.describe",
+        "x-tool-version": "v1",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": [
+              "repositories:list"
+            ]
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "401": {
+            "description": "Missing or invalid API credentials."
+          },
+          "403": {
+            "description": "Authenticated but missing a required scope."
+          },
+          "500": {
+            "description": "Internal error."
+          }
+        }
+      }
+    },
+    "/api/v1/repositories/{id}/source": {
+      "get": {
+        "operationId": "getRepositorySource",
+        "summary": "Get authorized repository source segments",
+        "x-tool-identifier": "repositories.get_source",
+        "x-tool-version": "v1",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": [
+              "repositories:read"
+            ]
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "401": {
+            "description": "Missing or invalid API credentials."
+          },
+          "403": {
+            "description": "Authenticated but missing a required scope."
+          },
+          "500": {
+            "description": "Internal error."
+          }
+        }
+      }
+    },
+    "/api/v1/repositories/changes": {
+      "get": {
+        "operationId": "listRepositoryChanges",
+        "summary": "List authorized repository changes",
+        "x-tool-identifier": "repositories.list_changes",
+        "x-tool-version": "v1",
+        "security": [
+          {
+            "ApiKeyAuth": [
+              "repositories:changes"
+            ]
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "401": {
+            "description": "Missing or invalid API credentials."
+          },
+          "403": {
+            "description": "Authenticated but missing a required scope."
+          },
+          "500": {
+            "description": "Internal error."
+          }
+        }
+      }
+    },
+    "/api/v1/repositories/search": {
+      "post": {
+        "operationId": "searchRepositories",
+        "summary": "Search accessible repositories",
+        "x-tool-identifier": "repositories.search",
+        "x-tool-version": "v1",
+        "security": [
+          {
+            "ApiKeyAuth": [
+              "repositories:search"
+            ]
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "description": "Validation error — malformed body or invalid inputs."
+          },
+          "401": {
+            "description": "Missing or invalid API credentials."
+          },
+          "403": {
+            "description": "Authenticated but missing a required scope."
+          },
+          "404": {
+            "description": "Resource not found, or the tool is disabled in the catalog."
+          },
+          "429": {
+            "description": "Concurrent-execution or rate limit exceeded."
+          },
+          "500": {
+            "description": "Internal error."
+          }
+        }
+      }
     }
   }
 }

--- a/docs/API/v1/openapi.yaml
+++ b/docs/API/v1/openapi.yaml
@@ -80,6 +80,8 @@ tags:
     description: High-level decision capture (creates nodes + edges in one call)
   - name: Assistants
     description: Assistant listing, execution, and multi-turn conversations
+  - name: Repositories
+    description: Permission-aware durable repository discovery, retrieval, source disclosure, and changes
   - name: Jobs
     description: Async job polling and cancellation
   - name: Voice
@@ -663,6 +665,341 @@ paths:
               $ref: "#/components/headers/X-RateLimit-Remaining"
             X-RateLimit-Reset:
               $ref: "#/components/headers/X-RateLimit-Reset"
+        "400":
+          $ref: "#/components/responses/ValidationError"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "429":
+          $ref: "#/components/responses/RateLimited"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  # ============================================
+  # Repositories
+  # ============================================
+
+  /repositories:
+    get:
+      operationId: listRepositories
+      tags: [Repositories]
+      summary: List accessible repositories
+      description: |
+        Lists active, unexpired, durable repositories the current principal can
+        access. System-managed repositories are never projected. Requires
+        `repositories:list`; repository ACLs are evaluated for every call.
+      security:
+        - BearerAuth: []
+        - SessionAuth: []
+      parameters:
+        - name: query
+          in: query
+          schema:
+            type: string
+            maxLength: 200
+          description: Case-insensitive name or description filter.
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 50
+            default: 50
+      responses:
+        "200":
+          description: Accessible repository catalog.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/RepositoryCatalogEntry"
+                  meta:
+                    type: object
+                    properties:
+                      requestId: { type: string }
+                      count: { type: integer }
+              example:
+                data:
+                  - id: 42
+                    name: District policies
+                    description: Current board and administrative policies
+                    ownerName: Policy Office
+                    visibility: private
+                    itemCount: 18
+                    activeIndexGenerationId: 11111111-2222-4333-8444-555555555555
+                    lastUpdated: "2026-07-26T18:00:00.000Z"
+                meta: { requestId: req_abc123, count: 1 }
+        "400":
+          $ref: "#/components/responses/ValidationError"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "429":
+          $ref: "#/components/responses/RateLimited"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /repositories/{id}:
+    get:
+      operationId: describeRepository
+      tags: [Repositories]
+      summary: Describe an accessible repository
+      description: |
+        Returns one catalog entry after a current ACL check. Requires
+        `repositories:list`; inaccessible and missing repositories both return
+        `404 NOT_FOUND`.
+      security:
+        - BearerAuth: []
+        - SessionAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            minimum: 1
+      responses:
+        "200":
+          description: Repository description.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    $ref: "#/components/schemas/RepositoryCatalogEntry"
+                  meta:
+                    type: object
+                    properties:
+                      requestId: { type: string }
+        "400":
+          $ref: "#/components/responses/ValidationError"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "429":
+          $ref: "#/components/responses/RateLimited"
+
+  /repositories/search:
+    post:
+      operationId: searchRepositories
+      tags: [Repositories]
+      summary: Search accessible repositories
+      description: |
+        Runs retrieval v2 against the requested repositories, or every
+        accessible durable repository when `repositoryIds` is omitted. Current
+        repository and segment ACLs, immutable item versions, and the active
+        index generation are enforced before disclosure. Requires
+        `repositories:search`.
+      security:
+        - BearerAuth: []
+        - SessionAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/RepositorySearchRequest"
+            example:
+              query: What is the current graduation policy?
+              repositoryIds: [42]
+              mode: hybrid
+              modalities: [text, table]
+              limit: 5
+      responses:
+        "200":
+          description: Ranked retrieval results with exact citations.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      type: object
+                      additionalProperties: true
+                  meta:
+                    type: object
+                    additionalProperties: true
+              example:
+                data:
+                  - repositoryId: 42
+                    itemId: 87
+                    itemVersionId: 33333333-4444-4555-8666-777777777777
+                    context: [{ content: "Students must...", citation: { page: 4 } }]
+                meta:
+                  requestId: req_abc123
+                  repositoriesRequested: 1
+                  repositoriesAuthorized: 1
+                  returnedResults: 1
+        "400":
+          $ref: "#/components/responses/ValidationError"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "429":
+          $ref: "#/components/responses/RateLimited"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /repositories/{id}/source:
+    get:
+      operationId: getRepositorySource
+      tags: [Repositories]
+      summary: Get authorized source segments
+      description: |
+        Returns exact source segments only from the item's current immutable
+        version and the repository's active index generation. Repository and
+        segment ACLs are re-evaluated in the disclosure query. Requires
+        `repositories:read`; inaccessible and missing sources both return
+        `404 NOT_FOUND`.
+      security:
+        - BearerAuth: []
+        - SessionAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            minimum: 1
+        - name: itemId
+          in: query
+          required: true
+          schema:
+            type: integer
+            minimum: 1
+        - name: chunkId
+          in: query
+          schema:
+            type: integer
+            minimum: 1
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 50
+            default: 20
+      responses:
+        "200":
+          description: Current authorized source segments.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/RepositorySourceSegment"
+                  meta:
+                    type: object
+                    properties:
+                      requestId: { type: string }
+                      count: { type: integer }
+              example:
+                data:
+                  - chunkId: 901
+                    itemId: 87
+                    itemStableId: 55555555-6666-4777-8888-999999999999
+                    itemName: Graduation policy
+                    itemVersionId: 33333333-4444-4555-8666-777777777777
+                    versionNumber: 4
+                    chunkIndex: 8
+                    modality: text
+                    content: Students must...
+                    contextPrefix: Page 4
+                    sourceLocator: { page: 4 }
+                meta: { requestId: req_abc123, count: 1 }
+        "400":
+          $ref: "#/components/responses/ValidationError"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "429":
+          $ref: "#/components/responses/RateLimited"
+
+  /repositories/changes:
+    get:
+      operationId: listRepositoryChanges
+      tags: [Repositories]
+      summary: List authorized repository changes
+      description: |
+        Lists changed repository items in stable `(updatedAt,itemId)` order.
+        Pass the opaque `nextCursor` unchanged to resume. Current repository
+        ACLs are evaluated in the change query, so revocation takes effect
+        without rebuilding or restarting an agent. Requires
+        `repositories:changes`.
+      security:
+        - BearerAuth: []
+        - SessionAuth: []
+      parameters:
+        - name: repositoryIds
+          in: query
+          required: true
+          description: Comma-separated repository ids (maximum 50).
+          schema:
+            type: string
+            example: 42,51
+        - name: cursor
+          in: query
+          description: Opaque cursor returned in the previous response.
+          schema:
+            type: string
+            maxLength: 2048
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+            default: 50
+      responses:
+        "200":
+          description: Authorized change page.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/RepositoryChange"
+                  meta:
+                    type: object
+                    properties:
+                      requestId: { type: string }
+                      nextCursor:
+                        type: [string, "null"]
+              example:
+                data:
+                  - repositoryId: 42
+                    repositoryName: District policies
+                    itemId: 87
+                    itemStableId: 55555555-6666-4777-8888-999999999999
+                    itemName: Graduation policy
+                    lifecycleStatus: active
+                    currentVersionId: 33333333-4444-4555-8666-777777777777
+                    updatedAt: "2026-07-26T18:00:00.000Z"
+                meta:
+                  requestId: req_abc123
+                  nextCursor: eyJ1cGRhdGVkQXQiOi...
         "400":
           $ref: "#/components/responses/ValidationError"
         "401":
@@ -2795,6 +3132,100 @@ components:
 
   # ---- Schemas ----
   schemas:
+    # -- Repository catalog --
+    RepositoryCatalogEntry:
+      type: object
+      required: [id, name, visibility, itemCount]
+      properties:
+        id: { type: integer }
+        name: { type: string }
+        description: { type: [string, "null"] }
+        ownerName: { type: [string, "null"] }
+        visibility:
+          type: string
+          enum: [public, private]
+        itemCount: { type: integer }
+        activeIndexGenerationId: { type: [string, "null"], format: uuid }
+        lastUpdated: { type: [string, "null"], format: date-time }
+        createdAt: { type: [string, "null"], format: date-time }
+        updatedAt: { type: [string, "null"], format: date-time }
+
+    RepositorySearchRequest:
+      type: object
+      required: [query]
+      properties:
+        query:
+          type: string
+          minLength: 1
+          maxLength: 2000
+        repositoryIds:
+          type: array
+          maxItems: 50
+          items: { type: integer, minimum: 1 }
+        mode:
+          type: string
+          enum: [keyword, vector, hybrid]
+          default: hybrid
+        modalities:
+          type: array
+          maxItems: 5
+          items:
+            type: string
+            enum: [text, image, audio, video, table]
+        limit:
+          type: integer
+          minimum: 1
+          maximum: 50
+          default: 10
+        threshold:
+          type: number
+          minimum: 0
+          maximum: 1
+
+    RepositorySourceSegment:
+      type: object
+      required:
+        - chunkId
+        - itemId
+        - itemStableId
+        - itemName
+        - itemVersionId
+        - versionNumber
+        - chunkIndex
+        - modality
+        - content
+        - contextPrefix
+        - sourceLocator
+      properties:
+        chunkId: { type: integer }
+        itemId: { type: integer }
+        itemStableId: { type: string, format: uuid }
+        itemName: { type: string }
+        itemVersionId: { type: string, format: uuid }
+        versionNumber: { type: integer }
+        chunkIndex: { type: integer }
+        modality:
+          type: string
+          enum: [text, image, audio, video, table]
+        content: { type: string }
+        contextPrefix: { type: string }
+        sourceLocator:
+          type: object
+          additionalProperties: true
+
+    RepositoryChange:
+      type: object
+      properties:
+        repositoryId: { type: integer }
+        repositoryName: { type: string }
+        activeIndexGenerationId: { type: [string, "null"], format: uuid }
+        itemId: { type: integer }
+        itemStableId: { type: string, format: uuid }
+        itemName: { type: string }
+        lifecycleStatus: { type: string }
+        currentVersionId: { type: [string, "null"], format: uuid }
+        updatedAt: { type: [string, "null"], format: date-time }
+
     # -- Assistants --
     AssistantListItem:
       type: object

--- a/docs/README.md
+++ b/docs/README.md
@@ -174,6 +174,8 @@ AI integration patterns using Vercel AI SDK v6, provider factory implementation,
 
 **[Unified repository product integration](./features/unified-repository-product-integration.md)** — Authoritative Repository Manager source/ACL/version UI, Assistant Architect repository-only knowledge, Nexus private ephemeral attachments, promotion, retention, and rollback boundaries.
 
+**[Unified content agents and Projects](./features/unified-content-agents-and-projects.md)** — Repository catalog MCP/REST scopes, per-user OpenClaw PKCE OAuth, live skill repository bindings, and durable Nexus Project membership/repository/chat boundaries.
+
 **[Google Workspace content synchronization](./features/google-workspace-content-sync.md)** — PKCE OAuth and Picker selection across My Drive and user-accessible Shared Drives, durable cursor/version reconciliation, deployment-owned configuration, deletion grace, and operations.
 
 **[ClassLink OneRoster synchronization](./features/oneroster-classlink-sync.md)** — Nightly full-collection roster ingestion, OAuth1 and static-bearer Proxy configuration, fail-safe reconciliation invariants, metrics, alarms, rollout, and rollback.

--- a/docs/features/atrium-agent-access.md
+++ b/docs/features/atrium-agent-access.md
@@ -73,18 +73,20 @@ mint the key to an accountable staff/service identity. True agent-identity write
 
 ## Path 2 — PSD AI Agents (OpenClaw on AgentCore)
 
-**Today:** the deployed `psd-aistudio` skill
-(`infra/agent-image/skills/psd-aistudio/`) is **discovery-only**. It calls the
-`describe_capabilities` meta-tool over `/api/mcp` with a `platform:read`-scoped
-key (from `AISTUDIO_MCP_API_KEY` or Secrets Manager via
-`AISTUDIO_MCP_API_KEY_SECRET_ID`) so the agent always knows what AI Studio can
-do — it deliberately does not execute content actions. That `platform:read` key
-is **zero-touch provisioned** exactly like the content key (see below) — the two
-were previously conflated; the MCP key now has its own secret + service user.
+The deployed `psd-aistudio` skill
+(`infra/agent-image/skills/psd-aistudio/`) discovers platform capabilities and,
+after per-user AI Studio OAuth consent, lists, describes, searches, reads exact
+sources from, and polls changes in the repositories that user can access. The
+credential priority is delegated OAuth, the legacy per-user personal API key,
+then the shared `platform:read` discovery key. The shared key remains
+**discovery-only** and is zero-touch provisioned exactly like the content key
+(see below); it has its own secret and service user. Repository commands never
+borrow the shared identity's content access and instead prompt the user to run
+`psd-aistudio connect`.
 
 **Gotcha:** `AGENT_INTERNAL_API_KEY` is a pre-shared key for the internal agent
 endpoints — it is **not scope-aware and cannot authenticate to `/api/mcp`**.
-Content access needs its own `sk-` key.
+Content/repository access needs a scoped `sk-` key or the per-user OAuth grant.
 
 **The `psd-atrium` skill** (`infra/agent-image/skills/psd-atrium/`) gives the
 agents Atrium abilities. It calls the fixed `/api/agent/atrium` broker surface,
@@ -140,9 +142,10 @@ The `psd-aistudio` discovery skill's `platform:read` key is provisioned by the
 
 **The only remaining human steps:**
 
-1. **`cdk deploy`** — applies the current migrations and provisions the
-   `psd-aistudio` discovery key. Atrium workspace operations use signed-owner
-   broker authority rather than the legacy content service key.
+1. **`cdk deploy`** — applies the current migrations, including migration 139
+   for repository OAuth and Nexus Projects, and provisions the `psd-aistudio`
+   discovery key. Atrium workspace operations use signed-owner broker authority
+   rather than the legacy content service key.
 2. **Rebuild + redeploy the agent image** — the agent discovers the skill only
    after `infra/agent-image` is rebuilt and the AgentCore runtime redeployed.
 
@@ -191,6 +194,7 @@ Boot-log check: `Local: http://localhost:3000` = healthy;
 | 401 from `/api/mcp` using `AGENT_INTERNAL_API_KEY` | Wrong credential class — mint an `sk-` key (see gotcha above) |
 | `psd-atrium` exits 11 (unauthorized / not configured) | The signed invocation proof is missing/invalid, or its owner no longer resolves to an active Atrium requester. Check the agent broker proof configuration and the owner's user/capability records. |
 | `psd-aistudio` exits 11 (no credential configured) | The `platform:read` MCP key isn't in the secret. It is auto-provisioned by the `AistudioMcpKeyProvisioner` custom resource on `cdk deploy` — check its CloudWatch logs (`/aws/lambda/psd-agent-aistudio-mcp-key-bootstrap-<env>`); confirm migration 108 applied. A re-deploy re-mints. (`AISTUDIO_MCP_API_KEY` may be set directly for local/dev.) |
+| A `psd-aistudio repositories-*` command reports insufficient scope | Run `psd-aistudio connect --user <email>` and complete the one-time AI Studio consent. The shared discovery key intentionally has no repository scopes. |
 | `psd-atrium publish` returns `approval_required` | Public destination without `content:publish_public` — expected; relay the message so the user knows it's queued |
 | 403 `INSUFFICIENT_SCOPE` on a content tool | Key lacks the scope in the table above |
 | `publish_content` returns `approval_required` | Public destination — needs human/admin `content:publish_public`; internal destinations publish directly |

--- a/docs/features/nexus-conversation-architecture.md
+++ b/docs/features/nexus-conversation-architecture.md
@@ -1,6 +1,6 @@
 # Nexus Conversation Architecture
 
-**Last Updated:** January 2025
+**Last Updated:** July 2026
 **Critical:** Read this before modifying conversation handling code
 
 ## Table of Contents
@@ -453,6 +453,29 @@ With cutover flags off, initiation returns `mode: "legacy"` before creating
 repository state and the established attachment processor remains the rollback
 path. See
 [Unified Repository Product Integration](./unified-repository-product-integration.md).
+
+---
+
+## Nexus Projects
+
+Project chats use the same stable runtime and conversation ownership rules.
+`/nexus/projects/{id}` creates the conversation server-side, then navigates to
+`/nexus?conversationId={conversationId}&projectId={projectId}`. The transport
+includes `projectId` in each request body; a resumed conversation may recover
+its persisted project id when the query parameter is absent.
+
+The server never trusts the URL binding. Before attachment preflight, routing,
+or message persistence it verifies both current project membership and that an
+existing conversation is owned by the caller and bound to the same project.
+Every turn reloads project instructions and filters connected repository ids
+through the executing member's current ACL. The private project repository is
+available through the member-specific grant created with membership. Project
+and skill searches use separate bounded tools and pass retrieved content through
+the same content-safety/PII mapping used by attachment retrieval.
+
+Image-generation and Deep Research paths reject project context because those
+special handlers cannot honor the required repository tool contract. See
+[Unified Content: Agents, Skills, and Nexus Projects](./unified-content-agents-and-projects.md).
 
 ---
 

--- a/docs/features/skill-publishing.md
+++ b/docs/features/skill-publishing.md
@@ -43,7 +43,9 @@ The body documents the assistant: `# name`, `## Inputs` (field table),
 2. The serialized folder uploads to S3 under
    `skills/user/{email}/drafts/{slug}/` and a `psd_agent_skills` row is written
    with `scope: 'draft'`, `scan_status: 'pending'` (republish bumps `version`
-   in place while still a draft).
+   in place while still a draft). Prompt repository ids are re-authorized and
+   replace `skill_repository_bindings` in the same transaction as the skill and
+   audit rows.
 3. The **agent-skill-builder Lambda** is invoked async
    (`lib/skills/skill-publish-pipeline.ts`): it downloads the folder, scans it
    (secrets / PII / npm audit / SKILL.md lint, including malformed
@@ -64,7 +66,7 @@ The body documents the assistant: `# name`, `## Inputs` (field table),
 
 | Surface | Mechanism |
 |---------|-----------|
-| **Nexus chat** | Session binding, not a callable tool: `/skills/{id}` → "Use in chat" passes `skillId`; the chat route re-validates approval server-side, intersects the session's built-in tools with `allowed-tools`, drops MCP connector tools unless a pin explicitly namespaces them (`connector:{name}` or `connector:{serverId}:{name}` — a bare pin never admits an external tool, which could otherwise shadow the pinned built-in), and injects the SKILL.md instructions into the system prompt. An unknown/unapproved id neither loosens tools nor injects anything. |
+| **Nexus chat** | Session binding, not a callable tool: `/skills/{id}` → "Use in chat" passes `skillId`; the chat route re-validates approval server-side, intersects the session's built-in tools with `allowed-tools`, drops MCP connector tools unless a pin explicitly namespaces them (`connector:{name}` or `connector:{serverId}:{name}` — a bare pin never admits an external tool, which could otherwise shadow the pinned built-in), injects the SKILL.md instructions, and supplies `searchSkillRepositories` for current prompt-bound repositories. Repository bindings and the executing user's ACL are re-read every turn, so revocation or updated content takes effect without republishing. An unknown/unapproved id neither loosens tools nor injects anything. |
 | **Agentic assistants / MCP** | The `skill.{slug}` catalog tool is invocable; dispatch resolves `handlerRef: skill:{id}` via `lib/skills/skill-tool-executor.ts`, which re-checks approval (uncached) and returns the SKILL.md document as the tool result (progressive disclosure — a skill is an instruction folder, not a function). |
 
 ## Export for Claude Code / Claude Desktop

--- a/docs/features/unified-content-agents-and-projects.md
+++ b/docs/features/unified-content-agents-and-projects.md
@@ -1,0 +1,130 @@
+# Unified Content: Agents, Skills, and Nexus Projects
+
+Issue [#1266](https://github.com/psd401/aistudio/issues/1266), part of Epic
+[#1261](https://github.com/psd401/aistudio/issues/1261). This workstream exposes
+the unified repository platform to OpenClaw, published skills, and durable Nexus
+Projects without creating another content or authorization model.
+
+## Repository catalog contract
+
+Five read-only operations share one implementation across MCP, internal tool
+dispatch, REST, and the OpenClaw `psd-aistudio` skill:
+
+| Operation | API-key scope | Purpose |
+|---|---|---|
+| `repositories_list` | `repositories:list` | Discover active durable repositories |
+| `repositories_describe` | `repositories:list` | Inspect one accessible repository |
+| `repositories_search` | `repositories:search` | Run retrieval v2 |
+| `repositories_get_source` | `repositories:read` | Read exact current source segments |
+| `repositories_list_changes` | `repositories:changes` | Poll changed items with an opaque cursor |
+
+The REST paths are documented in
+[`docs/API/v1/context-graph.md`](../API/v1/context-graph.md). Scope checks and
+repository authorization are separate: a key or OAuth grant authorizes an
+operation, while current repository/role/user ACLs authorize each resource.
+Search reuses retrieval v2. Exact-source disclosure independently requires the
+repository's active generation, the item's current immutable version, a live
+repository ACL, and a live segment ACL in one SQL statement. The change feed
+orders by `(updatedAt,itemId)` and reapplies live ACLs on every page.
+
+System-managed, ephemeral, expired, and inactive repositories never enter this
+catalog. Direct reads mask inaccessible ids as not found.
+
+## OpenClaw delegated authorization
+
+The first-party `PSD OpenClaw` OAuth client is a public/native client: it has no
+client secret, requires authorization code plus S256 PKCE, and permits only the
+registered localhost/dev/production callbacks. Its exact grant is:
+
+```text
+openid profile email offline_access platform:read
+repositories:list repositories:read repositories:search repositories:changes
+```
+
+The user asks OpenClaw to connect AI Studio. The model-facing skill calls the
+local owner-bound broker with `kind: aistudio`; it never supplies an owner
+selector or receives signing material. The router adds a replay-bound signed
+invocation proof, and AI Studio derives the immutable owner from that proof.
+AI Studio persists a one-hour, one-time nonce and the PKCE verifier, then
+returns a signed URL. Both the consent page and callback require a live AI
+Studio session for that same owner. The callback exchanges the code, calls
+OIDC userinfo, and requires the provider identity to equal the nonce owner
+before storing anything. A successful callback stores the
+access/rotating-refresh bundle in:
+
+```text
+psd-agent-creds/{environment}/user/{email}/aistudio_oauth
+```
+
+The nonce is consumed only after storage succeeds. The trusted AI Studio broker
+prefers a current OAuth access token, refreshes before expiry, and persists a
+rotated refresh token before use. Provider tokens and API keys never enter the
+model runtime. During rollout the broker may fall back to the existing per-user
+`aistudio_personal_key`, then to the shared discovery-only key. Repository
+commands that lack the new scopes tell the user to run `connect`.
+
+`disconnect` uses the same owner-bound broker and is forbidden for scheduled
+invocations. The server revokes the refresh token first and deletes the secret
+only after successful revocation. A missing secret is an idempotent success; a
+provider revocation failure preserves the credential so the operation can be
+retried.
+
+## Published-skill repository bindings
+
+Assistant Architect prompt repository ids are normalized and re-authorized at
+publish time. Draft registration replaces `skill_repository_bindings` in the
+same transaction as the skill row and audit event, so a failed republish cannot
+leave mismatched instructions and repositories.
+
+Approved Nexus skill sessions load repository bindings on every turn. The
+server supplies a bounded `searchSkillRepositories` tool; retrieval rechecks the
+executing user's current ACL and active generation. Changing repository
+content, revoking access, or republishing the skill takes effect without
+rebuilding the exported skill or restarting a chat. A skill binding never lends
+the publisher's access to another user.
+
+## Nexus Projects
+
+`/nexus/projects` creates durable project workspaces with:
+
+- project name and persistent instructions;
+- a dedicated private durable repository owned by the project owner;
+- explicit owner/editor/viewer membership;
+- optional links to other repositories;
+- user-owned project conversations.
+
+Adding a member creates a distinct `repository_access` row for the private
+project repository and stores that exact grant id with the membership. Removing
+the member deletes only that grant, preserving any independent/manual access the
+user already held. Only owners manage membership; owners and editors edit
+context and repository links; viewers read and chat.
+
+Linking a repository does not widen access. The editor connecting it must have
+current access, each member sees only connected repositories they can currently
+access, and every chat turn filters links through the executing member's live
+ACL. Project membership is rechecked on every turn. Project conversations remain
+owned by the person who created them and must match the server-bound project id.
+Image-generation and deep-research models reject project context because they
+cannot honor the required repository tool contract.
+
+## Migration and rollout
+
+Migration `139-unified-content-agents-projects.sql` is additive:
+
+- widens consent nonces with `aistudio`;
+- registers the first-party public PKCE client;
+- creates skill repository bindings and Nexus Project tables;
+- adds nullable `nexus_conversations.project_id`.
+
+Deploy the migration before the application and agent image. Existing
+conversations remain valid with a null project id, and existing OpenClaw
+personal/shared credentials continue to work during OAuth rollout. Rollback can
+remove the OAuth client and new tables/column; it does not rewrite canonical
+repository content.
+
+Operational logs contain request/user/resource counts but never source text,
+authorization codes, refresh tokens, signed consent tokens, or PKCE verifiers.
+The relevant local gates are the real PostgreSQL agents/projects smoke, focused
+OAuth/catalog/project unit tests, OpenClaw skill tests, authenticated Nexus
+Projects Playwright flow, full application regression, production build, and
+CDK synthesis.

--- a/docs/plans/2026-07-21-unified-content-platform.md
+++ b/docs/plans/2026-07-21-unified-content-platform.md
@@ -366,17 +366,16 @@ scheduled dev-environment suite validates the real services.
 
 ## Worktree and branch model
 
-The active Google synchronization branch is
-`codex/unified-content-google-sync` in the main checkout:
+The active Agents and Projects branch is
+`codex/unified-content-agents-projects` in the main checkout:
 
 ```text
 /Users/hagelk/non-ic-code/aistudio
 ```
 
-The main checkout stays on `dev`, so other agents or projects can use separate
-branches/worktrees without touching this work. PRs target `dev`. Each workstream
-may split into its own `codex/` branch after the foundation contracts merge; no
-two worktrees should edit the same migration or contract file concurrently.
+The branch was created from current `origin/dev`, and its PR targets `dev`.
+Other agents or projects should use separate branches/worktrees; no two
+worktrees should edit the same migration or contract file concurrently.
 
 ## Progress ledger
 
@@ -393,7 +392,7 @@ two worktrees should edit the same migration or contract file concurrently.
 - [x] Retrieval v2 and visual search
 - [x] Google Workspace sync
 - [x] Universal product UI migration
-- [ ] OpenClaw and Projects integration
+- [x] OpenClaw and Projects integration
 - [ ] Backfill, cutover, and legacy retirement
 
 Update this checklist and the linked GitHub issues at every delivery boundary.
@@ -1174,3 +1173,75 @@ that field across metadata, change, and traversal requests and forwards the
 target resource key through `X-Goog-Drive-Resource-Keys` when resolving a
 link-shared shortcut. Focused client and selection-route tests now assert the
 exact provider field projection and resource-key propagation.
+
+### Agents and Projects checkpoint (2026-07-26)
+
+Issue #1266 was selected because this ledger names OpenClaw and Projects as the
+first unchecked workstream and explicitly sequences backfill/cutover work
+afterward in #1267. The epic, all linked workstreams, current open and merged
+pull requests, ADR-007, repository guidance, and relevant feature/API
+documentation were inspected before selection; no active pull request
+overlapped this work.
+
+Implemented on `codex/unified-content-agents-projects`, ready for dev review:
+
+- Five catalog-backed operations list, describe, search, disclose exact source,
+  and stream repository changes through the shared internal catalog, MCP, and
+  documented v1 REST surfaces. Granular API scopes authorize each operation;
+  current durable-repository, item, role/user, and segment ACLs authorize every
+  resource. Search and source resolve only the current immutable item version
+  in the repository's active generation.
+- OpenClaw uses an owner-bound AI Studio authorization-code flow with S256 PKCE,
+  one-time state, an exact same-owner AI Studio session, exact registered
+  scopes, short-lived access tokens, rotating refresh tokens, identity
+  verification, revocation, and per-user Secrets Manager storage. The
+  model-facing psd-aistudio skill sends no owner selector and sees no provider
+  token or signing material; the router-signed invocation context (landed in
+  prerequisite PR #1353) is the sole credential-owner authority. The trusted
+  broker refreshes grants and provides repository list, describe, search,
+  source, and change commands; a manually stored personal key remains a
+  compatibility fallback.
+- Published Assistant Architect skills persist normalized repository bindings.
+  Nexus reloads those bindings, checks the executing user's current ACLs, and
+  searches the active generation on every turn, so repository publication and
+  revocation take effect without republishing the skill.
+- Nexus Projects provide a private durable project repository, connected
+  durable repositories, owner/editor/viewer membership, exact member grants,
+  project instructions, and durable user-owned project conversations. Project
+  and conversation bindings are server-derived, and every chat turn filters
+  connected repositories against the executing member's current access.
+- Additive migration 139 introduces the first-party native OAuth client,
+  `aistudio` consent nonces, skill bindings, project/membership/repository
+  records, and a nullable project reference on existing conversations. Existing
+  chats remain backward-compatible, and deployment/rollback ordering is
+  documented.
+
+Verification at this checkpoint passed whole-repository typecheck and lint,
+the production Next.js build, OpenAPI generation/drift checking, 365 application
+Jest suites with 3,584 tests passing (3 suites/26 tests skipped), all 43
+infrastructure suites with 406 tests, the infrastructure build and all-stack
+dev/prod CDK synthesis, and all 51 OpenClaw adapter tests. The real PostgreSQL
+migration/authorization smoke passed schema replay, current-generation source
+disclosure, skill binding, project membership/grant/revocation, durable chat,
+OAuth-client, and cleanup checks. Seven focused Playwright cases passed,
+including authenticated project persistence and member removal plus a real
+staff-scoped API key exercising REST, MCP, the live change feed, exact
+repository ACL exclusion, UI revocation, and post-revocation denial.
+
+The 2026-07-26 dev deployment was checked before delivery. CloudFormation
+reported the database stack and migration custom resource `UPDATE_COMPLETE`;
+the migration Lambda and live `migration_log` showed only the already-merged
+`141-oneroster-core.sql` running successfully. Neither migration 139 nor its
+tables were present in dev. The runner tracks completion by exact filename
+rather than by a highest numeric watermark, so deploying 139 after 141 remains
+supported; the PostgreSQL smoke replayed that exact manifest order. A refreshed
+parallel-work audit found only the expected manifest overlap with open PR
+#1344, whose migration 140 deliberately reserved its number around this
+in-flight migration and has no schema dependency on it.
+
+Rollout is migration-first: deploy migration 139 before the application and
+agent image. The new OAuth client is public/PKCE-only and limited to the three
+registered callback origins; production token storage continues to use the
+existing `psd-agent-creds/<environment>/user/*` encrypted secret boundary. No
+legacy route or table is removed here; inventory, backfill, cutover, and legacy
+retirement remain exclusively in #1267.

--- a/infra/agent-image/skills/psd-aistudio/SKILL.md
+++ b/infra/agent-image/skills/psd-aistudio/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: psd-aistudio
-summary: Live view of what AI Studio can do (discovery) PLUS the ability to act in AI Studio as the caller — execute assistants and read/capture decisions — when the caller has stored their own AI Studio API key. Projected from the app's own registries via the /api/mcp endpoint.
-description: Use this to know what AI Studio can currently do (describe_capabilities) and to act in AI Studio on the caller's behalf — list/execute assistants, search/capture decisions, read the decision graph — over the existing /api/mcp endpoint. Discovery works on a shared read-only key; actions require the caller's own AI Studio API key (per-user override), and every action's scope is enforced server-side by that key. Never rely on a static list; the catalog reflects the deployed code.
+summary: Discover and act in AI Studio as the caller, including catalog-backed repository list, describe, search, source, and change operations. Uses a one-click delegated OAuth connection, with legacy per-user API keys retained only for compatibility.
+description: Use this to read AI Studio's live capability catalog and repository catalog, execute assistants, and work with decisions. Prefer the caller-bound OAuth connection; current scopes and repository/item/segment ACLs are enforced server-side on every request.
 allowed-tools: Bash(node:*)
 ---
 
@@ -15,23 +15,31 @@ Two things in one skill, over AI Studio's existing `/api/mcp` endpoint:
 2. **Action** — do things in AI Studio **as the caller**: list/execute assistants,
    search/capture decisions, read the decision graph. Each action maps 1:1 to an
    MCP tool call; **what you're allowed to do is enforced server-side by the
-   caller's own API key**, not by this skill.
+   signed invocation owner's OAuth grant or API key**, not by this skill.
 
-## Key model — shared default, per-user override (district-wide)
+## Authorization model — delegated OAuth first
 
-Every subcommand takes an optional `--user <caller-email>` (from the harness
-`[caller: Name <email>]` line — pass it verbatim). Key resolution:
+Every subcommand accepts a legacy optional `--user <caller-email>` hint from
+the harness `[caller: Name <email>]` line. It is never an identity selector and
+never crosses the broker boundary. The local router signs the immutable
+workspace owner into a replay-bound request proof; AI Studio derives the
+credential path only from that signed context. Credential resolution:
 
-- **Default = the shared, read-only `platform:read` key.** Pre-provisioned,
-  zero-touch. It can **discover** (capabilities/list) but not act. A caller with
-  no personal key still works, limited to discovery.
-- **Override = the caller's own AI Studio API key**, if they've stored one at
-  `aistudio_personal_key`. When present it **replaces** the shared key for that
-  caller, unlocking exactly whatever that key is scoped for — nothing more,
-  nothing less. Any user, district-wide: each caller resolves *their own* key by
-  *their own* email.
+- **Preferred: owner-bound OAuth.** `connect` produces a one-click AI Studio
+  Authorization Code + S256 PKCE link. Access/refresh tokens are stored in the
+  owner's encrypted per-user slot, refresh tokens rotate automatically, and
+  `disconnect` revokes the current invocation owner's grant.
+- **Compatibility: owner's existing `aistudio_personal_key`.** Used only when
+  no usable OAuth connection exists.
+- **Discovery fallback: shared `platform:read` key.** It can discover
+  capabilities but cannot read repositories or perform user actions.
 
-Store a personal key once (the value never appears in chat, logs, or files —
+```bash
+node /opt/psd-skills/psd-aistudio/run.js connect --user <caller-email>
+node /opt/psd-skills/psd-aistudio/run.js disconnect --user <caller-email>
+```
+
+Legacy API-key compatibility remains available (the value never appears in chat, logs, or files —
 though, like any CLI argument, `--value` is briefly visible in the machine's
 process list while `put.js` runs; same caveat psd-credentials documents):
 
@@ -40,9 +48,11 @@ node /opt/psd-skills/psd-credentials/put.js \
   --name aistudio_personal_key --value <the caller's sk- key>
 ```
 
-The skill prints which key it used (`personal` vs `shared`) to **stderr only** —
-never the value. If an action comes back insufficient-scope on the shared key,
-tell the user to store their own key (above).
+The broker returns only which credential class it used (`oauth`, `personal`, or
+`shared`) — never the value. Provider tokens, API keys, Authorization headers,
+and Secrets Manager access remain outside the model-facing skill. If an action
+comes back insufficient-scope on the shared key, tell the user to store their
+own key (above).
 
 > This skill is a **thin passthrough**. It does not decide which scopes are
 > admin-only — it hands the resolved key to `/api/mcp` and the server enforces the
@@ -161,6 +171,27 @@ node /opt/psd-skills/psd-aistudio/run.js get-decision-graph --user <email> --nod
 ```
 
 Returns the node plus its edges.
+
+## Repository subcommands
+
+All repository operations use the catalog-backed MCP tools and the caller's
+current delegated identity. Scope authorization is followed by live repository
+and segment ACL checks; searches and source reads use the repository's active
+index generation, so updates take effect without reconnecting.
+
+```bash
+node /opt/psd-skills/psd-aistudio/run.js repositories-list --user <email> [--query <text>]
+node /opt/psd-skills/psd-aistudio/run.js repositories-describe --user <email> --repository-id 42
+node /opt/psd-skills/psd-aistudio/run.js repositories-search --user <email> \
+  --query "graduation requirements" [--repository-ids 42,51] [--mode hybrid]
+node /opt/psd-skills/psd-aistudio/run.js repositories-source --user <email> \
+  --repository-id 42 --item-id 900 [--chunk-id 1234]
+node /opt/psd-skills/psd-aistudio/run.js repositories-changes --user <email> \
+  --repository-ids 42,51 [--cursor <opaque-cursor>]
+```
+
+Scopes are deliberately granular: `repositories:list`, `repositories:read`,
+`repositories:search`, and `repositories:changes`.
 
 ## Failure modes (surfaced cleanly, never retried)
 

--- a/infra/agent-image/skills/psd-aistudio/common.js
+++ b/infra/agent-image/skills/psd-aistudio/common.js
@@ -61,6 +61,34 @@ function parseArgs(argv) {
 }
 
 /**
+ * Mint the one-click OAuth link through the signed invocation broker. The
+ * legacy callerEmail argument is intentionally ignored: the server derives the
+ * immutable owner from the router-signed context.
+ */
+async function mintConsentUrl(callerEmail) {
+  void callerEmail;
+  const result = await _internals.requestAgentBroker(
+    '/api/agent/consent-link',
+    { kind: 'aistudio' }
+  );
+  if (!result || typeof result.url !== 'string') {
+    throw new Error('Connection-link broker returned an invalid success payload');
+  }
+  return result.url;
+}
+
+/**
+ * Revoke the current invocation owner's delegated grant. No model-selected
+ * owner crosses the broker boundary.
+ */
+async function disconnectOAuth(callerEmail) {
+  void callerEmail;
+  return _internals.requestAgentBroker('/api/agent/aistudio', {
+    operation: 'disconnect',
+  });
+}
+
+/**
  * Low-level MCP call through the owner-bound broker. The model runtime never
  * receives either the owner's personal key or the platform fallback key.
  * Handles terminal transport failures uniformly
@@ -97,14 +125,20 @@ async function callMcpRaw(method, params, callerEmail, timeoutMs = MCP_FETCH_TIM
 
   const httpStatus = Number(brokerResult.httpStatus);
   const keySource =
-    brokerResult.keySource === 'personal' ? 'personal' : 'shared';
+    brokerResult.keySource === 'oauth'
+      ? 'oauth'
+      : brokerResult.keySource === 'personal'
+        ? 'personal'
+        : 'shared';
   const data = brokerResult.payload;
   if (httpStatus === 401) {
     emit({
       status: 'unauthorized',
       message:
         'AI Studio MCP rejected the API key (401). ' +
-        (keySource === 'personal'
+        (keySource === 'oauth'
+          ? 'Your delegated connection expired or was revoked — run connect again.'
+          : keySource === 'personal'
           ? 'Your stored AI Studio key is invalid or revoked — re-store a current ' +
             'key with psd-credentials put --name aistudio_personal_key.'
           : 'The shared key must be a valid sk- key holding at least platform:read.'),
@@ -234,6 +268,8 @@ module.exports = {
   fail,
   emit,
   parseArgs,
+  mintConsentUrl,
+  disconnectOAuth,
   callMcpRaw,
   callMcp,
   callTool,

--- a/infra/agent-image/skills/psd-aistudio/common.test.js
+++ b/infra/agent-image/skills/psd-aistudio/common.test.js
@@ -79,6 +79,46 @@ test('forwards only the MCP operation to the fixed owner-bound broker', async ()
   expect(serializedCall).not.toContain('Authorization');
 });
 
+test('mints consent without forwarding a model-selected owner', async () => {
+  brokerMock.mockResolvedValue({
+    url: 'https://app.example/agent-connect-aistudio?token=signed',
+  });
+
+  await expect(
+    common.mintConsentUrl('victim@psd401.net')
+  ).resolves.toContain('/agent-connect-aistudio');
+  expect(brokerMock).toHaveBeenCalledWith(
+    '/api/agent/consent-link',
+    { kind: 'aistudio' }
+  );
+  expect(JSON.stringify(brokerMock.mock.calls[0])).not.toContain('victim');
+});
+
+test('disconnects only through the owner-bound broker', async () => {
+  brokerMock.mockResolvedValue({ disconnected: true });
+
+  await expect(
+    common.disconnectOAuth('victim@psd401.net')
+  ).resolves.toEqual({ disconnected: true });
+  expect(brokerMock).toHaveBeenCalledWith('/api/agent/aistudio', {
+    operation: 'disconnect',
+  });
+  expect(JSON.stringify(brokerMock.mock.calls[0])).not.toContain('victim');
+});
+
+test('preserves the OAuth credential source returned by the broker', async () => {
+  brokerMock.mockResolvedValue({
+    httpStatus: 200,
+    keySource: 'oauth',
+    payload: { jsonrpc: '2.0', id: 'test', result: { ok: true } },
+  });
+
+  await expect(
+    common.callMcpRaw('tools/list', {}, 'victim@psd401.net')
+  ).resolves.toEqual({ result: { ok: true }, keySource: 'oauth' });
+  expect(JSON.stringify(brokerMock.mock.calls[0])).not.toContain('victim');
+});
+
 test.each([
   [401, 11, 'unauthorized'],
   [429, 14, 'rate-limited'],

--- a/infra/agent-image/skills/psd-aistudio/run.js
+++ b/infra/agent-image/skills/psd-aistudio/run.js
@@ -8,18 +8,17 @@
  *     capabilities  live capability catalog (describe_capabilities)
  *     list          raw MCP tools/list (scope-filtered to the resolved key)
  *
- *   ACTION (#1223) — each maps 1:1 to an MCP tools/call and runs as the CALLER:
+ *   ACTION (#1223) — each maps 1:1 to an MCP tools/call and runs as the OWNER:
  *     list-assistants   / execute-assistant
  *     search-decisions  / capture-decision / get-decision-graph
  *
- * KEY MODEL (#1223): every subcommand accepts an optional `--user <caller-email>`
- * (from the harness `[caller: Name <email>]` line). When that caller has stored
- * their OWN AI Studio API key (`psd-credentials put --name
- * aistudio_personal_key`) it OVERRIDES the shared key, so the agent can do exactly what that key is scoped
- * for — enforced server-side. With no `--user` / no stored key, the shared,
- * read-only platform:read key is used (discovery works; action subcommands come
- * back insufficient-scope with a hint to store a personal key). Scope is NEVER
- * hardcoded here — this is a thin passthrough.
+ * IDENTITY MODEL: every operation crosses the local owner-bound broker. The
+ * router signs the immutable workspace owner into a replay-bound request proof;
+ * AI Studio derives the credential path only from that proof. `--user` remains
+ * accepted for CLI compatibility and display-oriented harnesses, but it never
+ * selects an owner or credential and is never forwarded to the broker. Provider
+ * tokens and API keys stay in the trusted web tier. Scope and resource ACLs are
+ * enforced server-side.
  *
  * Usage:
  *   node run.js capabilities [--section actions|features|scopes|all]
@@ -44,7 +43,15 @@
 
 'use strict';
 
-const { fail, emit, parseArgs, callMcp, callTool } = require('./common');
+const {
+  fail,
+  emit,
+  parseArgs,
+  callMcp,
+  callTool,
+  mintConsentUrl,
+  disconnectOAuth,
+} = require('./common');
 
 const SECTIONS = ['actions', 'features', 'scopes', 'all'];
 const SURFACES = ['mcp', 'ai_sdk', 'rest', 'internal'];
@@ -54,9 +61,14 @@ function usage() {
     [
       'Usage: node run.js <subcommand> [...]',
       '',
-      'Every subcommand accepts an optional --user <caller-email>. When that caller',
-      'has stored their own AI Studio API key it overrides the shared read-only key,',
-      'unlocking exactly what that key is scoped for (enforced server-side).',
+      'Every subcommand accepts an optional legacy --user <caller-email> hint.',
+      'It never selects an identity; the signed invocation owner is authoritative.',
+      'When that owner has connected AI Studio with OAuth, that grant is used first.',
+      'A legacy stored API key remains supported as a compatibility fallback.',
+      '',
+      'Connection:',
+      '  connect --user <email>       Mint a one-click delegated OAuth link.',
+      '  disconnect --user <email>    Revoke the delegated grant.',
       '',
       'Discovery (shared platform:read key is enough):',
       '  capabilities [--section actions|features|scopes|all]',
@@ -81,6 +93,14 @@ function usage() {
       '                    [--conditions a,b] [--alternatives a,b] [--related-to uuid,uuid]',
       '                    [--agent-id <t>]   (admin-only: needs mcp:capture_decision)',
       '  get-decision-graph [--user <email>] --node-id <uuid>',
+      '',
+      'Repositories (delegated OAuth or a key with repository scopes):',
+      '  repositories-list [--query <text>] [--limit N]',
+      '  repositories-describe --repository-id N',
+      '  repositories-search --query <text> [--repository-ids 1,2] [--mode keyword|vector|hybrid]',
+      '                      [--modalities text,image,audio,video,table] [--limit N]',
+      '  repositories-source --repository-id N --item-id N [--chunk-id N] [--limit N]',
+      '  repositories-changes --repository-ids 1,2 [--cursor C] [--limit N]',
       '',
     ].join('\n')
   );
@@ -127,9 +147,36 @@ function parseList(value, label) {
   return items.length ? items : undefined;
 }
 
+function parseIntegerList(value, label) {
+  const values = parseList(value, label);
+  if (values === undefined) return undefined;
+  const numbers = values.map(Number);
+  if (numbers.some((number) => !Number.isSafeInteger(number) || number <= 0)) {
+    fail(`--${label} must be a comma-separated list of positive integers`);
+  }
+  return numbers;
+}
+
+function requiredScopeForTool(toolName) {
+  const repositoryScopes = {
+    repositories_list: 'repositories:list',
+    repositories_describe: 'repositories:list',
+    repositories_search: 'repositories:search',
+    repositories_get_source: 'repositories:read',
+    repositories_list_changes: 'repositories:changes',
+  };
+  return repositoryScopes[toolName] || `mcp:${toolName}`;
+}
+
 /** The remediation hint for an insufficient-scope failure — different when the
  *  caller is already on a personal key (re-mint) vs the shared key (store one). */
 function scopeHint(keySource, scope) {
+  if (keySource === 'oauth') {
+    return (
+      `Your delegated AI Studio connection lacks ${scope}. Disconnect and run ` +
+      '`connect --user <your-email>` to authorize the current scope set.'
+    );
+  }
   if (keySource === 'personal') {
     return (
       `Your stored AI Studio key lacks ${scope}. Mint a NEW key that includes ` +
@@ -163,7 +210,9 @@ function surfaceToolError(res, toolName) {
       tool: toolName,
       http_status: res.httpStatus,
       jsonrpc_error: res.jsonrpcError,
-      ...(insufficient && { hint: scopeHint(res.keySource, `mcp:${toolName}`) }),
+      ...(insufficient && {
+        hint: scopeHint(res.keySource, requiredScopeForTool(toolName)),
+      }),
     });
     process.exit(12);
   }
@@ -200,10 +249,31 @@ async function main() {
     process.exit(0);
   }
 
-  // Optional caller email — present on every subcommand. Absent → shared key.
+  // Legacy compatibility hint only. common.js intentionally ignores it; the
+  // signed invocation context is the sole credential-owner authority.
   const email = optStr(args, 'user', 'user');
 
   switch (subcommand) {
+    case 'connect': {
+      const ownerEmail = requireStr(args, 'user', 'user');
+      const url = await mintConsentUrl(ownerEmail);
+      emit({
+        status: 'needs-auth',
+        kind: 'aistudio',
+        consent_url: url,
+        consent_chat_hyperlink: `<${url}|Connect AI Studio>`,
+        message:
+          'Paste consent_chat_hyperlink on its own line, without surrounding markdown.',
+      });
+      return;
+    }
+
+    case 'disconnect': {
+      const ownerEmail = requireStr(args, 'user', 'user');
+      emit(await disconnectOAuth(ownerEmail));
+      return;
+    }
+
     case 'capabilities': {
       const toolArgs = {};
       if (args.section !== undefined) {
@@ -355,6 +425,90 @@ async function main() {
     case 'get-decision-graph': {
       const nodeId = requireStr(args, 'node_id', 'node-id');
       await runToolAndEmit('get_decision_graph', { nodeId }, email);
+      return;
+    }
+
+    case 'repositories-list': {
+      const toolArgs = {};
+      const query = optStr(args, 'query', 'query');
+      const limit = optInt(args, 'limit', 'limit');
+      if (query !== undefined) toolArgs.query = query;
+      if (limit !== undefined) toolArgs.limit = limit;
+      await runToolAndEmit('repositories_list', toolArgs, email);
+      return;
+    }
+
+    case 'repositories-describe': {
+      const repositoryId = optInt(
+        args,
+        'repository_id',
+        'repository-id'
+      );
+      if (repositoryId === undefined) {
+        fail('--repository-id is required');
+      }
+      await runToolAndEmit(
+        'repositories_describe',
+        { repositoryId },
+        email
+      );
+      return;
+    }
+
+    case 'repositories-search': {
+      const query = requireStr(args, 'query', 'query');
+      const toolArgs = { query };
+      const repositoryIds = parseIntegerList(
+        args.repository_ids,
+        'repository-ids'
+      );
+      const mode = optStr(args, 'mode', 'mode');
+      const modalities = parseList(args.modalities, 'modalities');
+      const limit = optInt(args, 'limit', 'limit');
+      if (repositoryIds !== undefined) toolArgs.repositoryIds = repositoryIds;
+      if (mode !== undefined) {
+        if (!['keyword', 'vector', 'hybrid'].includes(mode)) {
+          fail('--mode must be keyword, vector, or hybrid');
+        }
+        toolArgs.mode = mode;
+      }
+      if (modalities !== undefined) toolArgs.modalities = modalities;
+      if (limit !== undefined) toolArgs.limit = limit;
+      await runToolAndEmit('repositories_search', toolArgs, email);
+      return;
+    }
+
+    case 'repositories-source': {
+      const repositoryId = optInt(
+        args,
+        'repository_id',
+        'repository-id'
+      );
+      const itemId = optInt(args, 'item_id', 'item-id');
+      if (repositoryId === undefined || itemId === undefined) {
+        fail('--repository-id and --item-id are required');
+      }
+      const toolArgs = { repositoryId, itemId };
+      const chunkId = optInt(args, 'chunk_id', 'chunk-id');
+      const limit = optInt(args, 'limit', 'limit');
+      if (chunkId !== undefined) toolArgs.chunkId = chunkId;
+      if (limit !== undefined) toolArgs.limit = limit;
+      await runToolAndEmit('repositories_get_source', toolArgs, email);
+      return;
+    }
+
+    case 'repositories-changes': {
+      const repositoryIds = parseIntegerList(
+        args.repository_ids,
+        'repository-ids'
+      );
+      if (!repositoryIds) fail('--repository-ids is required');
+      const toolArgs = { repositoryIds };
+      const cursor = optStr(args, 'cursor', 'cursor');
+      const limit = optInt(args, 'limit', 'limit');
+      if (cursor !== undefined) toolArgs.cursor = cursor;
+      if (limit !== undefined) toolArgs.limit = limit;
+      await runToolAndEmit('repositories_list_changes', toolArgs, email);
       return;
     }
 

--- a/infra/agent-image/skills/psd-aistudio/run.test.js
+++ b/infra/agent-image/skills/psd-aistudio/run.test.js
@@ -355,6 +355,102 @@ test('get-decision-graph requires --node-id (exit 1)', async () => {
   expect(code).toBe(1);
 });
 
+test('repositories-list maps filters to repositories_list', async () => {
+  await run(
+    'repositories-list',
+    '--user',
+    'a@b.co',
+    '--query',
+    'policy',
+    '--limit',
+    '7'
+  );
+  expect(toolCalls[0]).toEqual({
+    toolName: 'repositories_list',
+    toolArgs: { query: 'policy', limit: 7 },
+    callerEmail: 'a@b.co',
+  });
+});
+
+test('repositories-search maps ids, mode, modalities, and limit', async () => {
+  await run(
+    'repositories-search',
+    '--user',
+    'a@b.co',
+    '--query',
+    'graduation',
+    '--repository-ids',
+    '4,9',
+    '--mode',
+    'hybrid',
+    '--modalities',
+    'text,table',
+    '--limit',
+    '8'
+  );
+  expect(toolCalls[0]).toEqual({
+    toolName: 'repositories_search',
+    toolArgs: {
+      query: 'graduation',
+      repositoryIds: [4, 9],
+      mode: 'hybrid',
+      modalities: ['text', 'table'],
+      limit: 8,
+    },
+    callerEmail: 'a@b.co',
+  });
+});
+
+test('repositories-source and changes use numeric ids and cursor', async () => {
+  await run(
+    'repositories-source',
+    '--repository-id',
+    '4',
+    '--item-id',
+    '11',
+    '--chunk-id',
+    '22'
+  );
+  expect(toolCalls[0].toolName).toBe('repositories_get_source');
+  expect(toolCalls[0].toolArgs).toEqual({
+    repositoryId: 4,
+    itemId: 11,
+    chunkId: 22,
+  });
+
+  await run(
+    'repositories-changes',
+    '--repository-ids',
+    '4,9',
+    '--cursor',
+    'opaque',
+    '--limit',
+    '5'
+  );
+  expect(toolCalls[1].toolName).toBe('repositories_list_changes');
+  expect(toolCalls[1].toolArgs).toEqual({
+    repositoryIds: [4, 9],
+    cursor: 'opaque',
+    limit: 5,
+  });
+});
+
+test('repository ids reject non-positive and non-integer values', async () => {
+  let code;
+  try {
+    await run(
+      'repositories-search',
+      '--query',
+      'x',
+      '--repository-ids',
+      '1,nope'
+    );
+  } catch (error) {
+    code = error.code;
+  }
+  expect(code).toBe(1);
+});
+
 // ── generic ────────────────────────────────────────────────────────────────────
 
 test('an action subcommand surfaces a tool-level isError (non-execute) as tool-error, exit 12', async () => {

--- a/infra/database/migrations.json
+++ b/infra/database/migrations.json
@@ -133,6 +133,7 @@
     "136-google-content-connectors.sql",
     "137-nexus-conversation-retention.sql",
     "138-atrium-capture-browser-registration.sql",
+    "139-unified-content-agents-projects.sql",
     "140-agent-identities-name-unique.sql",
     "141-oneroster-core.sql",
     "146-api-rate-limit-reservations.sql",

--- a/infra/database/schema/139-unified-content-agents-projects.sql
+++ b/infra/database/schema/139-unified-content-agents-projects.sql
@@ -1,0 +1,150 @@
+-- Migration 139: Unified content integrations for agents, skills, and Nexus Projects.
+-- Epic #1261, workstream #1266.
+--
+-- Additive only:
+--   * repository catalog scopes and a first-party public PKCE client for OpenClaw
+--   * durable skill-to-repository bindings
+--   * Nexus Projects, membership, connected repositories, and project chats
+-- Existing Nexus conversations remain valid with project_id NULL.
+--
+-- Rollback:
+-- DELETE FROM oauth_clients
+--  WHERE client_id = '7e8646f4-4091-4a34-a6b9-0d3721e8a126'
+--    AND client_name = 'PSD OpenClaw';
+-- ALTER TABLE psd_agent_workspace_consent_nonces
+--   DROP CONSTRAINT IF EXISTS psd_agent_workspace_consent_nonces_token_kind_check;
+-- ALTER TABLE psd_agent_workspace_consent_nonces
+--   ADD CONSTRAINT psd_agent_workspace_consent_nonces_token_kind_check
+--   CHECK (token_kind IN ('agent_account', 'user_account', 'cognito_data', 'plaud', 'canva'));
+-- ALTER TABLE nexus_conversations DROP COLUMN IF EXISTS project_id;
+-- DROP TABLE IF EXISTS nexus_project_repositories;
+-- DROP TABLE IF EXISTS nexus_project_members;
+-- DROP TABLE IF EXISTS nexus_projects;
+-- DROP TABLE IF EXISTS skill_repository_bindings;
+
+ALTER TABLE psd_agent_workspace_consent_nonces
+  DROP CONSTRAINT IF EXISTS psd_agent_workspace_consent_nonces_token_kind_check;
+ALTER TABLE psd_agent_workspace_consent_nonces
+  ADD CONSTRAINT psd_agent_workspace_consent_nonces_token_kind_check
+  CHECK (token_kind IN (
+    'agent_account',
+    'user_account',
+    'cognito_data',
+    'plaud',
+    'canva',
+    'aistudio'
+  ));
+
+INSERT INTO oauth_clients (
+  client_id,
+  client_name,
+  application_type,
+  client_secret_hash,
+  redirect_uris,
+  allowed_scopes,
+  grant_types,
+  response_types,
+  token_endpoint_auth_method,
+  require_pkce,
+  access_token_ttl,
+  refresh_token_ttl,
+  is_active,
+  is_first_party
+)
+VALUES (
+  '7e8646f4-4091-4a34-a6b9-0d3721e8a126',
+  'PSD OpenClaw',
+  'native',
+  NULL,
+  '[
+    "http://localhost:3000/agent-connect-aistudio/callback",
+    "https://dev.aistudio.psd401.ai/agent-connect-aistudio/callback",
+    "https://aistudio.psd401.ai/agent-connect-aistudio/callback"
+  ]'::jsonb,
+  '[
+    "openid",
+    "profile",
+    "email",
+    "offline_access",
+    "platform:read",
+    "repositories:list",
+    "repositories:read",
+    "repositories:search",
+    "repositories:changes"
+  ]'::jsonb,
+  '["authorization_code", "refresh_token"]'::jsonb,
+  '["code"]'::jsonb,
+  'none',
+  true,
+  900,
+  2592000,
+  true,
+  true
+)
+ON CONFLICT (client_id) DO NOTHING;
+
+CREATE TABLE IF NOT EXISTS skill_repository_bindings (
+  skill_id uuid NOT NULL REFERENCES psd_agent_skills(id) ON DELETE CASCADE,
+  repository_id integer NOT NULL REFERENCES knowledge_repositories(id) ON DELETE CASCADE,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (skill_id, repository_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_skill_repository_bindings_repository
+  ON skill_repository_bindings (repository_id, skill_id);
+
+CREATE TABLE IF NOT EXISTS nexus_projects (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  owner_id integer NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  name varchar(200) NOT NULL,
+  instructions text NOT NULL DEFAULT '',
+  project_repository_id integer NOT NULL UNIQUE
+    REFERENCES knowledge_repositories(id) ON DELETE RESTRICT,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT chk_nexus_projects_name_not_blank CHECK (btrim(name) <> '')
+);
+
+CREATE INDEX IF NOT EXISTS idx_nexus_projects_owner_updated
+  ON nexus_projects (owner_id, updated_at DESC);
+
+DROP TRIGGER IF EXISTS trg_nexus_projects_updated_at ON nexus_projects;
+CREATE TRIGGER trg_nexus_projects_updated_at
+  BEFORE UPDATE ON nexus_projects
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+CREATE TABLE IF NOT EXISTS nexus_project_members (
+  project_id uuid NOT NULL REFERENCES nexus_projects(id) ON DELETE CASCADE,
+  user_id integer NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  role varchar(16) NOT NULL DEFAULT 'viewer',
+  repository_access_id integer REFERENCES repository_access(id) ON DELETE SET NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (project_id, user_id),
+  CONSTRAINT chk_nexus_project_member_role
+    CHECK (role IN ('owner', 'editor', 'viewer'))
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_nexus_project_owner_member
+  ON nexus_project_members (project_id)
+  WHERE role = 'owner';
+CREATE INDEX IF NOT EXISTS idx_nexus_project_members_user
+  ON nexus_project_members (user_id, project_id);
+
+CREATE TABLE IF NOT EXISTS nexus_project_repositories (
+  project_id uuid NOT NULL REFERENCES nexus_projects(id) ON DELETE CASCADE,
+  repository_id integer NOT NULL REFERENCES knowledge_repositories(id) ON DELETE CASCADE,
+  connected_by integer REFERENCES users(id) ON DELETE SET NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (project_id, repository_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_nexus_project_repositories_repository
+  ON nexus_project_repositories (repository_id, project_id);
+
+ALTER TABLE nexus_conversations
+  ADD COLUMN IF NOT EXISTS project_id uuid
+  REFERENCES nexus_projects(id) ON DELETE SET NULL;
+
+CREATE INDEX IF NOT EXISTS idx_nexus_conversations_project_user_updated
+  ON nexus_conversations (project_id, user_id, updated_at DESC)
+  WHERE project_id IS NOT NULL;

--- a/lib/agent-workspace/consent-token.ts
+++ b/lib/agent-workspace/consent-token.ts
@@ -28,7 +28,13 @@ const log = createLogger({ module: "consent-token" })
  *                     PKCE). Captured by /agent-connect-canva, stored at
  *                     psd-agent-creds/{env}/user/{email}/canva.
  */
-export type ConsentTokenKind = "agent_account" | "user_account" | "cognito_data" | "plaud" | "canva"
+export type ConsentTokenKind =
+  | "agent_account"
+  | "user_account"
+  | "cognito_data"
+  | "plaud"
+  | "canva"
+  | "aistudio"
 
 export interface ConsentTokenPayload {
   /** Human user email (e.g. hagelk@psd401.net) */
@@ -134,7 +140,8 @@ export async function verifyConsentToken(token: string): Promise<ConsentTokenPay
       kind === "user_account" ||
       kind === "cognito_data" ||
       kind === "plaud" ||
-      kind === "canva"
+      kind === "canva" ||
+      kind === "aistudio"
     ) {
       resolvedKind = kind
     } else if (kind !== undefined) {

--- a/lib/agent-workspace/secrets-manager.ts
+++ b/lib/agent-workspace/secrets-manager.ts
@@ -163,6 +163,107 @@ export interface CanvaTokenData {
   obtained_at: string
 }
 
+export interface AistudioOAuthTokenData {
+  access_token: string
+  refresh_token: string
+  token_type: "Bearer"
+  scope: string
+  expires_at: string
+  obtained_at: string
+}
+
+export function aistudioOAuthSecretId(ownerEmail: string): string {
+  if (!SAFE_EMAIL_RE.test(ownerEmail)) {
+    throw new Error(`Invalid ownerEmail for Secrets Manager path: ${ownerEmail}`)
+  }
+  const environment =
+    process.env.ENVIRONMENT ?? process.env.DEPLOY_ENVIRONMENT ?? "dev"
+  return `psd-agent-creds/${environment}/user/${ownerEmail}/aistudio_oauth`
+}
+
+export async function storeAistudioOAuthTokens(
+  ownerEmail: string,
+  tokenData: AistudioOAuthTokenData
+): Promise<string | null> {
+  const secretId = aistudioOAuthSecretId(ownerEmail)
+  const environment =
+    process.env.ENVIRONMENT ?? process.env.DEPLOY_ENVIRONMENT ?? "dev"
+  if (process.env.NODE_ENV === "development") {
+    log.info("Local dev mode — skipping AI Studio OAuth secret write", {
+      secretId,
+    })
+    return null
+  }
+  const {
+    PutSecretValueCommand,
+    CreateSecretCommand,
+    DescribeSecretCommand,
+    ResourceNotFoundException,
+  } = await import("@aws-sdk/client-secrets-manager")
+  const client = await getSecretsManagerClient()
+  const secretString = JSON.stringify(tokenData)
+  try {
+    const response = await client.send(
+      new PutSecretValueCommand({ SecretId: secretId, SecretString: secretString })
+    )
+    return response.ARN ?? (await describeArn(secretId, DescribeSecretCommand))
+  } catch (error) {
+    if (!(error instanceof ResourceNotFoundException)) throw error
+    try {
+      const response = await client.send(
+        new CreateSecretCommand({
+          Name: secretId,
+          SecretString: secretString,
+          Description: `AI Studio OAuth tokens for ${ownerEmail}`,
+          Tags: [
+            { Key: "Environment", Value: environment },
+            { Key: "ManagedBy", Value: "aistudio" },
+            { Key: "OwnerEmail", Value: ownerEmail },
+          ],
+        })
+      )
+      return response.ARN ?? (await describeArn(secretId, DescribeSecretCommand))
+    } catch (createError) {
+      if (
+        createError instanceof Error &&
+        createError.name === "ResourceExistsException"
+      ) {
+        const response = await client.send(
+          new PutSecretValueCommand({
+            SecretId: secretId,
+            SecretString: secretString,
+          })
+        )
+        return response.ARN ?? (await describeArn(secretId, DescribeSecretCommand))
+      }
+      throw createError
+    }
+  }
+}
+
+export async function deleteAistudioOAuthSecret(
+  ownerEmail: string
+): Promise<boolean> {
+  const secretId = aistudioOAuthSecretId(ownerEmail)
+  if (process.env.NODE_ENV === "development") return false
+  const { DeleteSecretCommand, ResourceNotFoundException } = await import(
+    "@aws-sdk/client-secrets-manager"
+  )
+  const client = await getSecretsManagerClient()
+  try {
+    await client.send(
+      new DeleteSecretCommand({
+        SecretId: secretId,
+        ForceDeleteWithoutRecovery: true,
+      })
+    )
+    return true
+  } catch (error) {
+    if (error instanceof ResourceNotFoundException) return false
+    throw error
+  }
+}
+
 export function canvaSecretId(ownerEmail: string): string {
   if (!SAFE_EMAIL_RE.test(ownerEmail)) {
     throw new Error(`Invalid ownerEmail for Secrets Manager path: ${ownerEmail}`)

--- a/lib/agent-workspace/secrets-manager.ts
+++ b/lib/agent-workspace/secrets-manager.ts
@@ -206,6 +206,7 @@ export async function storeAistudioOAuthTokens(
     const response = await client.send(
       new PutSecretValueCommand({ SecretId: secretId, SecretString: secretString })
     )
+    _secretCache.delete(secretId)
     return response.ARN ?? (await describeArn(secretId, DescribeSecretCommand))
   } catch (error) {
     if (!(error instanceof ResourceNotFoundException)) throw error
@@ -222,6 +223,7 @@ export async function storeAistudioOAuthTokens(
           ],
         })
       )
+      _secretCache.delete(secretId)
       return response.ARN ?? (await describeArn(secretId, DescribeSecretCommand))
     } catch (createError) {
       if (
@@ -234,6 +236,7 @@ export async function storeAistudioOAuthTokens(
             SecretString: secretString,
           })
         )
+        _secretCache.delete(secretId)
         return response.ARN ?? (await describeArn(secretId, DescribeSecretCommand))
       }
       throw createError
@@ -245,7 +248,10 @@ export async function deleteAistudioOAuthSecret(
   ownerEmail: string
 ): Promise<boolean> {
   const secretId = aistudioOAuthSecretId(ownerEmail)
-  if (process.env.NODE_ENV === "development") return false
+  if (process.env.NODE_ENV === "development") {
+    _secretCache.delete(secretId)
+    return false
+  }
   const { DeleteSecretCommand, ResourceNotFoundException } = await import(
     "@aws-sdk/client-secrets-manager"
   )
@@ -257,9 +263,13 @@ export async function deleteAistudioOAuthSecret(
         ForceDeleteWithoutRecovery: true,
       })
     )
+    _secretCache.delete(secretId)
     return true
   } catch (error) {
-    if (error instanceof ResourceNotFoundException) return false
+    if (error instanceof ResourceNotFoundException) {
+      _secretCache.delete(secretId)
+      return false
+    }
     throw error
   }
 }

--- a/lib/api-keys/scopes.ts
+++ b/lib/api-keys/scopes.ts
@@ -28,6 +28,10 @@ export const API_SCOPES = {
   // the platform can do via the `describe_capabilities` MCP meta-tool. It exposes
   // no user data, only the shape of the app.
   "platform:read": "Read the AI Studio capability catalog (actions, features, scopes)",
+  "repositories:list": "List and describe repositories the caller can access",
+  "repositories:read": "Read authorized repository source segments and citations",
+  "repositories:search": "Search authorized repositories",
+  "repositories:changes": "Read authorized repository change feeds",
   "documents:read": "Read documents and attachments",
   "documents:write": "Upload and manage documents",
   "graph:read": "Read context graph nodes and edges",
@@ -83,6 +87,10 @@ export const ROLE_SCOPES: Record<string, ApiScope[]> = {
     "models:read",
     "tools:read",
     "platform:read",
+    "repositories:list",
+    "repositories:read",
+    "repositories:search",
+    "repositories:changes",
     "documents:read",
     "graph:read",
     "mcp:search_decisions",

--- a/lib/api/rate-limiter.ts
+++ b/lib/api/rate-limiter.ts
@@ -18,7 +18,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { executeQuery, executeTransaction } from "@/lib/db/drizzle-client";
 import { apiKeyUsage, apiKeys, apiRateLimitReservations } from "@/lib/db/schema";
-import { eq, count, lt, sql } from "drizzle-orm";
+import { and, count, eq, gte, lt, sql } from "drizzle-orm";
 import { createLogger } from "@/lib/logger";
 import type { ApiAuthContext } from "./auth-middleware";
 import { createErrorResponse } from "./auth-middleware";
@@ -53,8 +53,7 @@ const WINDOW_MS = 60 * 1000; // 1 minute sliding window
  * Returns a RateLimitResult indicating whether the request is allowed.
  * Only applies to api_key auth — session auth is not rate-limited here.
  *
- * Uses a simple count-based sliding window:
- * COUNT(*) FROM api_key_usage WHERE api_key_id = ? AND request_at > NOW() - 1 min
+ * Uses a count-based sliding window over durable pre-dispatch reservations.
  */
 export async function checkRateLimit(
   auth: ApiAuthContext
@@ -95,8 +94,10 @@ export async function checkRateLimit(
           .select({ value: count() })
           .from(apiRateLimitReservations)
           .where(
-            sql`${apiRateLimitReservations.principalHash} = ${principalHash}
-                AND ${apiRateLimitReservations.requestAt} >= ${windowStart}`
+            and(
+              eq(apiRateLimitReservations.principalHash, principalHash),
+              gte(apiRateLimitReservations.requestAt, windowStart)
+            )
           );
         const used = usage?.value ?? 0;
         if (used < rpm) {

--- a/lib/db/schema/index.ts
+++ b/lib/db/schema/index.ts
@@ -62,6 +62,7 @@ export * from "./tables/agentic-cost-reservations";
 export * from "./tables/resource-admission-leases";
 export * from "./tables/workspace-upload-reservations";
 export * from "./tables/nexus-repository-bindings";
+export * from "./tables/nexus-projects";
 
 // ============================================
 // Nexus MCP (Model Context Protocol)
@@ -91,6 +92,7 @@ export * from "./tables/repository-upload-sessions";
 export * from "./tables/repository-processing-jobs";
 export * from "./tables/repository-artifacts";
 export * from "./tables/repository-index-generations";
+export * from "./tables/skill-repository-bindings";
 
 // ============================================
 // Prompt Library

--- a/lib/db/schema/tables/agent-workspace-consent-nonces.ts
+++ b/lib/db/schema/tables/agent-workspace-consent-nonces.ts
@@ -35,10 +35,17 @@ export const psdAgentWorkspaceConsentNonces = pgTable("psd_agent_workspace_conse
   //  - 'canva'         = Canva Connect OAuth refresh-token capture (confidential
   //                      client, PKCE). Migration 101 widens the CHECK constraint.
   tokenKind: varchar("token_kind", { length: 16 })
-    .$type<"agent_account" | "user_account" | "cognito_data" | "plaud" | "canva">()
+    .$type<
+      | "agent_account"
+      | "user_account"
+      | "cognito_data"
+      | "plaud"
+      | "canva"
+      | "aistudio"
+    >()
     .notNull()
     .default("agent_account"),
-  // PKCE (S256) code_verifier for the PKCE kinds ('plaud', 'canva') — generated
+  // PKCE (S256) code_verifier for the PKCE kinds ('plaud', 'canva', 'aistudio') — generated
   // at mint time, read back at the callback to exchange the auth code. Never
   // placed in a URL (only the S256 challenge is). Null for the non-PKCE kinds.
   codeVerifier: varchar("code_verifier", { length: 128 }),

--- a/lib/db/schema/tables/nexus-conversations.ts
+++ b/lib/db/schema/tables/nexus-conversations.ts
@@ -16,6 +16,7 @@ import {
 import type { NexusConversationMetadata } from "@/lib/db/types/jsonb";
 import { users } from "./users";
 import { nexusFolders } from "./nexus-folders";
+import { nexusProjects } from "./nexus-projects";
 
 export const nexusConversations = pgTable(
   "nexus_conversations",
@@ -30,6 +31,9 @@ export const nexusConversations = pgTable(
     title: varchar("title", { length: 500 }),
     modelUsed: varchar("model_used", { length: 100 }),
     folderId: uuid("folder_id").references(() => nexusFolders.id),
+    projectId: uuid("project_id").references(() => nexusProjects.id, {
+      onDelete: "set null",
+    }),
     messageCount: integer("message_count").default(0),
     totalTokens: integer("total_tokens").default(0),
     lastMessageAt: timestamp("last_message_at").defaultNow(),

--- a/lib/db/schema/tables/nexus-projects.ts
+++ b/lib/db/schema/tables/nexus-projects.ts
@@ -1,0 +1,98 @@
+import {
+  index,
+  integer,
+  pgTable,
+  primaryKey,
+  text,
+  timestamp,
+  uniqueIndex,
+  uuid,
+  varchar,
+} from "drizzle-orm/pg-core";
+import { sql } from "drizzle-orm";
+import { users } from "./users";
+import { knowledgeRepositories } from "./knowledge-repositories";
+import { repositoryAccess } from "./repository-access";
+
+export const NEXUS_PROJECT_MEMBER_ROLES = [
+  "owner",
+  "editor",
+  "viewer",
+] as const;
+export type NexusProjectMemberRole =
+  (typeof NEXUS_PROJECT_MEMBER_ROLES)[number];
+
+export const nexusProjects = pgTable(
+  "nexus_projects",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    ownerId: integer("owner_id")
+      .references(() => users.id, { onDelete: "cascade" })
+      .notNull(),
+    name: varchar("name", { length: 200 }).notNull(),
+    instructions: text("instructions").notNull().default(""),
+    projectRepositoryId: integer("project_repository_id")
+      .references(() => knowledgeRepositories.id, { onDelete: "restrict" })
+      .notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).defaultNow().notNull(),
+  },
+  (table) => [
+    uniqueIndex("uq_nexus_projects_repository").on(table.projectRepositoryId),
+    index("idx_nexus_projects_owner_updated").on(table.ownerId, table.updatedAt),
+  ]
+);
+
+export const nexusProjectMembers = pgTable(
+  "nexus_project_members",
+  {
+    projectId: uuid("project_id")
+      .references(() => nexusProjects.id, { onDelete: "cascade" })
+      .notNull(),
+    userId: integer("user_id")
+      .references(() => users.id, { onDelete: "cascade" })
+      .notNull(),
+    role: varchar("role", { length: 16 })
+      .$type<NexusProjectMemberRole>()
+      .notNull()
+      .default("viewer"),
+    repositoryAccessId: integer("repository_access_id").references(
+      () => repositoryAccess.id,
+      { onDelete: "set null" }
+    ),
+    createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
+  },
+  (table) => [
+    primaryKey({ columns: [table.projectId, table.userId] }),
+    uniqueIndex("uq_nexus_project_owner_member")
+      .on(table.projectId)
+      .where(sql`${table.role} = 'owner'`),
+    index("idx_nexus_project_members_user").on(table.userId, table.projectId),
+  ]
+);
+
+export const nexusProjectRepositories = pgTable(
+  "nexus_project_repositories",
+  {
+    projectId: uuid("project_id")
+      .references(() => nexusProjects.id, { onDelete: "cascade" })
+      .notNull(),
+    repositoryId: integer("repository_id")
+      .references(() => knowledgeRepositories.id, { onDelete: "cascade" })
+      .notNull(),
+    connectedBy: integer("connected_by").references(() => users.id, {
+      onDelete: "set null",
+    }),
+    createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
+  },
+  (table) => [
+    primaryKey({ columns: [table.projectId, table.repositoryId] }),
+    index("idx_nexus_project_repositories_repository").on(
+      table.repositoryId,
+      table.projectId
+    ),
+  ]
+);
+
+export type NexusProject = typeof nexusProjects.$inferSelect;
+export type NexusProjectMember = typeof nexusProjectMembers.$inferSelect;

--- a/lib/db/schema/tables/skill-repository-bindings.ts
+++ b/lib/db/schema/tables/skill-repository-bindings.ts
@@ -1,0 +1,26 @@
+import { integer, pgTable, primaryKey, timestamp, uuid, index } from "drizzle-orm/pg-core";
+import { psdAgentSkills } from "./agent-skills";
+import { knowledgeRepositories } from "./knowledge-repositories";
+
+export const skillRepositoryBindings = pgTable(
+  "skill_repository_bindings",
+  {
+    skillId: uuid("skill_id")
+      .references(() => psdAgentSkills.id, { onDelete: "cascade" })
+      .notNull(),
+    repositoryId: integer("repository_id")
+      .references(() => knowledgeRepositories.id, { onDelete: "cascade" })
+      .notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
+  },
+  (table) => [
+    primaryKey({ columns: [table.skillId, table.repositoryId] }),
+    index("idx_skill_repository_bindings_repository").on(
+      table.repositoryId,
+      table.skillId
+    ),
+  ]
+);
+
+export type SkillRepositoryBinding =
+  typeof skillRepositoryBindings.$inferSelect;

--- a/lib/mcp/tool-handlers.ts
+++ b/lib/mcp/tool-handlers.ts
@@ -38,6 +38,17 @@ import {
   type CapabilityCatalogSection,
 } from "@/lib/capabilities/capability-catalog"
 import type { ToolSurface } from "@/lib/tools/catalog/types"
+import {
+  describeRepository,
+  getRepositorySource,
+  listRepositoryCatalog,
+  listRepositoryChanges,
+  searchRepositoryCatalog,
+} from "@/lib/repositories/repository-catalog-service"
+import type {
+  RetrievalMode,
+  RetrievalModality,
+} from "@/lib/repositories/retrieval-v2/types"
 
 // ============================================
 // Handler Map
@@ -50,6 +61,11 @@ export const TOOL_HANDLERS: Record<string, McpToolHandler> = {
   execute_assistant: handleExecuteAssistant,
   list_assistants: handleListAssistants,
   get_decision_graph: handleGetDecisionGraph,
+  repositories_list: handleRepositoriesList,
+  repositories_describe: handleRepositoriesDescribe,
+  repositories_search: handleRepositoriesSearch,
+  repositories_get_source: handleRepositoriesGetSource,
+  repositories_list_changes: handleRepositoriesListChanges,
   // Agent platform tools (#926): image gen, web fetch, document gen. Exposed on
   // the `internal` surface only (see lib/tools/catalog/manifest.ts) so they are
   // callable from the agentic Assistant Architect runtime but not the external
@@ -58,6 +74,147 @@ export const TOOL_HANDLERS: Record<string, McpToolHandler> = {
   // Atrium content tools (Phase 5, Issue #1055): create/get/list/update/version/
   // visibility/publish over the §11–§15 services.
   ...CONTENT_TOOL_HANDLERS,
+}
+
+function positiveInteger(value: unknown): number | null {
+  return typeof value === "number" &&
+    Number.isSafeInteger(value) &&
+    value > 0
+    ? value
+    : null
+}
+
+function positiveIntegerArray(value: unknown): number[] {
+  return Array.isArray(value)
+    ? value
+        .map(positiveInteger)
+        .filter((item): item is number => item != null)
+    : []
+}
+
+function jsonResult(value: unknown): McpToolResult {
+  return { content: [{ type: "text", text: JSON.stringify(value) }] }
+}
+
+async function handleRepositoriesList(
+  args: Record<string, unknown>,
+  context: { cognitoSub: string }
+): Promise<McpToolResult> {
+  return jsonResult({
+    repositories: await listRepositoryCatalog(context.cognitoSub, {
+      query: typeof args.query === "string" ? args.query : undefined,
+      limit: typeof args.limit === "number" ? args.limit : undefined,
+    }),
+  })
+}
+
+async function handleRepositoriesDescribe(
+  args: Record<string, unknown>,
+  context: { cognitoSub: string }
+): Promise<McpToolResult> {
+  const repositoryId = positiveInteger(args.repositoryId)
+  if (!repositoryId) {
+    return {
+      content: [{ type: "text", text: "Invalid repositoryId" }],
+      isError: true,
+    }
+  }
+  const repository = await describeRepository(context.cognitoSub, repositoryId)
+  return repository
+    ? jsonResult({ repository })
+    : {
+        content: [{ type: "text", text: "Repository not found" }],
+        isError: true,
+      }
+}
+
+async function handleRepositoriesSearch(
+  args: Record<string, unknown>,
+  context: { cognitoSub: string }
+): Promise<McpToolResult> {
+  const query = typeof args.query === "string" ? args.query.trim() : ""
+  if (!query) {
+    return {
+      content: [{ type: "text", text: "query is required" }],
+      isError: true,
+    }
+  }
+  const allowedModes: RetrievalMode[] = ["keyword", "vector", "hybrid"]
+  const allowedModalities: RetrievalModality[] = [
+    "text",
+    "image",
+    "audio",
+    "video",
+    "table",
+  ]
+  const mode =
+    typeof args.mode === "string" &&
+    allowedModes.includes(args.mode as RetrievalMode)
+      ? (args.mode as RetrievalMode)
+      : undefined
+  const modalities = Array.isArray(args.modalities)
+    ? args.modalities.filter(
+        (value): value is RetrievalModality =>
+          typeof value === "string" &&
+          allowedModalities.includes(value as RetrievalModality)
+      )
+    : undefined
+  return jsonResult(
+    await searchRepositoryCatalog({
+      cognitoSub: context.cognitoSub,
+      query,
+      repositoryIds: positiveIntegerArray(args.repositoryIds),
+      mode,
+      modalities,
+      limit: typeof args.limit === "number" ? args.limit : undefined,
+    })
+  )
+}
+
+async function handleRepositoriesGetSource(
+  args: Record<string, unknown>,
+  context: { userId: number }
+): Promise<McpToolResult> {
+  const repositoryId = positiveInteger(args.repositoryId)
+  const itemId = positiveInteger(args.itemId)
+  if (!repositoryId || !itemId) {
+    return {
+      content: [
+        { type: "text", text: "Valid repositoryId and itemId are required" },
+      ],
+      isError: true,
+    }
+  }
+  return jsonResult({
+    segments: await getRepositorySource({
+      userId: context.userId,
+      repositoryId,
+      itemId,
+      chunkId: positiveInteger(args.chunkId) ?? undefined,
+      limit: typeof args.limit === "number" ? args.limit : undefined,
+    }),
+  })
+}
+
+async function handleRepositoriesListChanges(
+  args: Record<string, unknown>,
+  context: { userId: number }
+): Promise<McpToolResult> {
+  const repositoryIds = positiveIntegerArray(args.repositoryIds)
+  if (repositoryIds.length === 0) {
+    return {
+      content: [{ type: "text", text: "repositoryIds is required" }],
+      isError: true,
+    }
+  }
+  return jsonResult(
+    await listRepositoryChanges({
+      userId: context.userId,
+      repositoryIds,
+      cursor: typeof args.cursor === "string" ? args.cursor : undefined,
+      limit: typeof args.limit === "number" ? args.limit : undefined,
+    })
+  )
 }
 
 // ============================================

--- a/lib/mcp/tool-registry.ts
+++ b/lib/mcp/tool-registry.ts
@@ -240,6 +240,120 @@ Example:
       },
     },
   },
+  {
+    name: "repositories_list",
+    description:
+      "List durable repositories the authenticated user can currently access.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        query: {
+          type: "string",
+          description: "Optional case-insensitive name or description filter.",
+        },
+        limit: {
+          type: "number",
+          description: "Maximum repositories to return (1-50, default 50).",
+          default: 50,
+        },
+      },
+    },
+  },
+  {
+    name: "repositories_describe",
+    description:
+      "Describe one durable repository if the authenticated user can currently access it.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        repositoryId: {
+          type: "number",
+          description: "Repository numeric id.",
+        },
+      },
+      required: ["repositoryId"],
+    },
+  },
+  {
+    name: "repositories_search",
+    description:
+      "Search one or more authorized repositories using the active retrieval generation and live repository and segment ACLs.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        query: { type: "string", description: "Search query." },
+        repositoryIds: {
+          type: "array",
+          items: { type: "number" },
+          description:
+            "Repository ids to search. Omit to search every accessible durable repository.",
+        },
+        mode: {
+          type: "string",
+          enum: ["keyword", "vector", "hybrid"],
+          description: "Retrieval mode (default hybrid).",
+        },
+        modalities: {
+          type: "array",
+          items: { type: "string" },
+          description: "Optional text, image, audio, video, or table filters.",
+        },
+        limit: {
+          type: "number",
+          description: "Maximum results (1-50, default 10).",
+          default: 10,
+        },
+      },
+      required: ["query"],
+    },
+  },
+  {
+    name: "repositories_get_source",
+    description:
+      "Get exact citation source segments from an authorized repository's active generation and current item version.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        repositoryId: { type: "number", description: "Repository numeric id." },
+        itemId: { type: "number", description: "Repository item numeric id." },
+        chunkId: {
+          type: "number",
+          description: "Optional exact source chunk id.",
+        },
+        limit: {
+          type: "number",
+          description: "Maximum source segments (1-50, default 20).",
+          default: 20,
+        },
+      },
+      required: ["repositoryId", "itemId"],
+    },
+  },
+  {
+    name: "repositories_list_changes",
+    description:
+      "List item changes in authorized repositories using a stable opaque cursor.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        repositoryIds: {
+          type: "array",
+          items: { type: "number" },
+          description: "One or more repository ids.",
+        },
+        cursor: {
+          type: "string",
+          description: "Opaque cursor returned by the previous call.",
+        },
+        limit: {
+          type: "number",
+          description: "Maximum changes (1-100, default 50).",
+          default: 50,
+        },
+      },
+      required: ["repositoryIds"],
+    },
+  },
   // Atrium content tools (Phase 5, Issue #1055) — listed so scoped callers
   // discover them via tools/list.
   ...CONTENT_MCP_TOOLS,

--- a/lib/nexus/attachment-repository-tool.ts
+++ b/lib/nexus/attachment-repository-tool.ts
@@ -15,6 +15,12 @@ interface CreateNexusAttachmentToolsInput {
   tokenMappingSink: TokenMappingSink;
 }
 
+interface CreateNexusRepositorySearchToolsInput
+  extends CreateNexusAttachmentToolsInput {
+  toolName: string;
+  description: string;
+}
+
 class NexusAttachmentSafetyUnavailableError extends Error {
   constructor() {
     super("Attachment search results could not be safety-checked");
@@ -67,6 +73,17 @@ async function protectRetrievedChunk(input: {
 export function createNexusAttachmentTools(
   input: CreateNexusAttachmentToolsInput
 ): ToolSet {
+  return createNexusRepositorySearchTools({
+    ...input,
+    toolName: "searchNexusAttachments",
+    description:
+      "Search the documents attached to this Nexus conversation. Use this before answering questions about attachments and cite the returned source labels.",
+  });
+}
+
+export function createNexusRepositorySearchTools(
+  input: CreateNexusRepositorySearchToolsInput
+): ToolSet {
   const repositoryIds = [...new Set(input.repositoryIds)].filter(
     (id) => Number.isSafeInteger(id) && id > 0
   );
@@ -77,9 +94,8 @@ export function createNexusAttachmentTools(
   });
 
   return {
-    searchNexusAttachments: tool({
-      description:
-        "Search the documents attached to this Nexus conversation. Use this before answering questions about attachments and cite the returned source labels.",
+    [input.toolName]: tool({
+      description: input.description,
       inputSchema: z.object({
         query: z.string().trim().min(1).max(4_000),
         limit: z.number().int().min(1).max(10).optional().default(5),

--- a/lib/nexus/projects/project-service.ts
+++ b/lib/nexus/projects/project-service.ts
@@ -1,0 +1,508 @@
+import "server-only";
+
+import { and, desc, eq, inArray, ne, sql } from "drizzle-orm";
+import { getAccessibleRepositoryIds } from "@/lib/db/drizzle";
+import {
+  executeQuery,
+  executeTransaction,
+} from "@/lib/db/drizzle-client";
+import {
+  knowledgeRepositories,
+  nexusConversations,
+  nexusProjectMembers,
+  nexusProjectRepositories,
+  nexusProjects,
+  repositoryAccess,
+  users,
+  type NexusProjectMemberRole,
+} from "@/lib/db/schema";
+
+export class NexusProjectAccessError extends Error {
+  constructor(message = "Project not found") {
+    super(message);
+    this.name = "NexusProjectAccessError";
+  }
+}
+
+async function requireMembership(projectId: string, userId: number) {
+  const [membership] = await executeQuery(
+    (db) =>
+      db
+        .select({
+          projectId: nexusProjects.id,
+          ownerId: nexusProjects.ownerId,
+          projectRepositoryId: nexusProjects.projectRepositoryId,
+          role: nexusProjectMembers.role,
+          name: nexusProjects.name,
+          instructions: nexusProjects.instructions,
+        })
+        .from(nexusProjects)
+        .innerJoin(
+          nexusProjectMembers,
+          and(
+            eq(nexusProjectMembers.projectId, nexusProjects.id),
+            eq(nexusProjectMembers.userId, userId)
+          )
+        )
+        .where(eq(nexusProjects.id, projectId))
+        .limit(1),
+    "requireNexusProjectMembership"
+  );
+  if (!membership) throw new NexusProjectAccessError();
+  return membership;
+}
+
+function assertCanEdit(role: NexusProjectMemberRole) {
+  if (role !== "owner" && role !== "editor") {
+    throw new NexusProjectAccessError();
+  }
+}
+
+function assertOwner(role: NexusProjectMemberRole) {
+  if (role !== "owner") throw new NexusProjectAccessError();
+}
+
+export async function createNexusProject(input: {
+  ownerId: number;
+  name: string;
+  instructions?: string;
+}) {
+  const name = input.name.trim();
+  const instructions = input.instructions?.trim() ?? "";
+  return executeTransaction(
+    async (tx) => {
+      const [repository] = await tx
+        .insert(knowledgeRepositories)
+        .values({
+          name: `${name} — Project files`,
+          description: `Private working repository for the Nexus project "${name}".`,
+          ownerId: input.ownerId,
+          isPublic: false,
+          repositoryKind: "durable",
+          lifecycleStatus: "active",
+          metadata: {
+            nexusProjectManaged: true,
+          },
+        })
+        .returning({ id: knowledgeRepositories.id });
+      if (!repository) throw new Error("Failed to create project repository");
+      const [project] = await tx
+        .insert(nexusProjects)
+        .values({
+          ownerId: input.ownerId,
+          name,
+          instructions,
+          projectRepositoryId: repository.id,
+        })
+        .returning();
+      if (!project) throw new Error("Failed to create Nexus project");
+      await tx.insert(nexusProjectMembers).values({
+        projectId: project.id,
+        userId: input.ownerId,
+        role: "owner",
+      });
+      return project;
+    },
+    "createNexusProject"
+  );
+}
+
+export async function listNexusProjects(userId: number) {
+  return executeQuery(
+    (db) =>
+      db
+        .select({
+          id: nexusProjects.id,
+          name: nexusProjects.name,
+          instructions: nexusProjects.instructions,
+          ownerId: nexusProjects.ownerId,
+          ownerEmail: users.email,
+          role: nexusProjectMembers.role,
+          projectRepositoryId: nexusProjects.projectRepositoryId,
+          updatedAt: nexusProjects.updatedAt,
+          conversationCount: sql<number>`(
+            SELECT count(*)::int
+            FROM nexus_conversations conversation
+            WHERE conversation.project_id = ${nexusProjects.id}
+              AND conversation.user_id = ${userId}
+          )`,
+        })
+        .from(nexusProjects)
+        .innerJoin(
+          nexusProjectMembers,
+          and(
+            eq(nexusProjectMembers.projectId, nexusProjects.id),
+            eq(nexusProjectMembers.userId, userId)
+          )
+        )
+        .innerJoin(users, eq(users.id, nexusProjects.ownerId))
+        .orderBy(desc(nexusProjects.updatedAt)),
+    "listNexusProjects"
+  );
+}
+
+export async function getNexusProject(projectId: string, userId: number) {
+  const membership = await requireMembership(projectId, userId);
+  const repositoryBindings = await executeQuery(
+    (db) =>
+      db
+        .select({ repositoryId: nexusProjectRepositories.repositoryId })
+        .from(nexusProjectRepositories)
+        .where(eq(nexusProjectRepositories.projectId, projectId)),
+    "getNexusProjectRepositoryBindings"
+  );
+  const accessibleConnectedRepositoryIds = await getAccessibleRepositoryIds(
+    repositoryBindings.map((binding) => binding.repositoryId),
+    userId
+  );
+  const [members, connectedRepositories, conversations, projectRepository] =
+    await Promise.all([
+      executeQuery(
+        (db) =>
+          db
+            .select({
+              userId: nexusProjectMembers.userId,
+              role: nexusProjectMembers.role,
+              email: users.email,
+              firstName: users.firstName,
+              lastName: users.lastName,
+            })
+            .from(nexusProjectMembers)
+            .innerJoin(users, eq(users.id, nexusProjectMembers.userId))
+            .where(eq(nexusProjectMembers.projectId, projectId))
+            .orderBy(users.email),
+        "getNexusProjectMembers"
+      ),
+      executeQuery(
+        (db) =>
+          db
+            .select({
+              id: knowledgeRepositories.id,
+              name: knowledgeRepositories.name,
+              description: knowledgeRepositories.description,
+              activeIndexGenerationId:
+                knowledgeRepositories.activeIndexGenerationId,
+            })
+            .from(nexusProjectRepositories)
+            .innerJoin(
+              knowledgeRepositories,
+              eq(
+                knowledgeRepositories.id,
+                nexusProjectRepositories.repositoryId
+              )
+            )
+            .where(
+              and(
+                eq(nexusProjectRepositories.projectId, projectId),
+                inArray(
+                  nexusProjectRepositories.repositoryId,
+                  accessibleConnectedRepositoryIds
+                )
+              )
+            )
+            .orderBy(knowledgeRepositories.name),
+        "getNexusProjectConnectedRepositories"
+      ),
+      executeQuery(
+        (db) =>
+          db
+            .select({
+              id: nexusConversations.id,
+              title: nexusConversations.title,
+              provider: nexusConversations.provider,
+              messageCount: nexusConversations.messageCount,
+              updatedAt: nexusConversations.updatedAt,
+            })
+            .from(nexusConversations)
+            .where(
+              and(
+                eq(nexusConversations.projectId, projectId),
+                eq(nexusConversations.userId, userId)
+              )
+            )
+            .orderBy(desc(nexusConversations.updatedAt)),
+        "getNexusProjectConversations"
+      ),
+      executeQuery(
+        (db) =>
+          db
+            .select({
+              id: knowledgeRepositories.id,
+              name: knowledgeRepositories.name,
+              itemCount: sql<number>`(
+                SELECT count(*)::int
+                FROM repository_items item
+                WHERE item.repository_id = ${knowledgeRepositories.id}
+              )`,
+            })
+            .from(knowledgeRepositories)
+            .where(
+              eq(
+                knowledgeRepositories.id,
+                membership.projectRepositoryId
+              )
+            )
+            .limit(1),
+        "getNexusProjectRepository"
+      ),
+    ]);
+  return {
+    ...membership,
+    members,
+    connectedRepositories,
+    conversations,
+    projectRepository: projectRepository[0] ?? null,
+  };
+}
+
+export async function updateNexusProject(input: {
+  projectId: string;
+  userId: number;
+  name: string;
+  instructions: string;
+}) {
+  const membership = await requireMembership(input.projectId, input.userId);
+  assertCanEdit(membership.role);
+  const [updated] = await executeQuery(
+    (db) =>
+      db
+        .update(nexusProjects)
+        .set({
+          name: input.name.trim(),
+          instructions: input.instructions.trim(),
+          updatedAt: new Date(),
+        })
+        .where(eq(nexusProjects.id, input.projectId))
+        .returning(),
+    "updateNexusProject"
+  );
+  return updated;
+}
+
+export async function addNexusProjectMember(input: {
+  projectId: string;
+  actorUserId: number;
+  email: string;
+  role: Exclude<NexusProjectMemberRole, "owner">;
+}) {
+  const membership = await requireMembership(input.projectId, input.actorUserId);
+  assertOwner(membership.role);
+  return executeTransaction(
+    async (tx) => {
+      const [target] = await tx
+        .select({ id: users.id })
+        .from(users)
+        .where(eq(sql`lower(${users.email})`, input.email.trim().toLowerCase()))
+        .limit(1);
+      if (!target) throw new Error("User not found");
+      if (target.id === membership.ownerId) {
+        throw new Error("The project owner is already a member");
+      }
+      const [grant] = await tx
+        .insert(repositoryAccess)
+        .values({
+          repositoryId: membership.projectRepositoryId,
+          userId: target.id,
+        })
+        .returning({ id: repositoryAccess.id });
+      if (!grant) throw new Error("Failed to grant project repository access");
+      await tx.insert(nexusProjectMembers).values({
+        projectId: input.projectId,
+        userId: target.id,
+        role: input.role,
+        repositoryAccessId: grant.id,
+      });
+      return { userId: target.id, role: input.role };
+    },
+    "addNexusProjectMember"
+  );
+}
+
+export async function removeNexusProjectMember(input: {
+  projectId: string;
+  actorUserId: number;
+  memberUserId: number;
+}) {
+  const membership = await requireMembership(input.projectId, input.actorUserId);
+  assertOwner(membership.role);
+  if (input.memberUserId === membership.ownerId) {
+    throw new Error("The project owner cannot be removed");
+  }
+  return executeTransaction(
+    async (tx) => {
+      const [removed] = await tx
+        .delete(nexusProjectMembers)
+        .where(
+          and(
+            eq(nexusProjectMembers.projectId, input.projectId),
+            eq(nexusProjectMembers.userId, input.memberUserId),
+            ne(nexusProjectMembers.role, "owner")
+          )
+        )
+        .returning({
+          repositoryAccessId: nexusProjectMembers.repositoryAccessId,
+        });
+      if (!removed) throw new NexusProjectAccessError();
+      if (removed.repositoryAccessId) {
+        await tx
+          .delete(repositoryAccess)
+          .where(eq(repositoryAccess.id, removed.repositoryAccessId));
+      }
+      return true;
+    },
+    "removeNexusProjectMember"
+  );
+}
+
+export async function connectNexusProjectRepository(input: {
+  projectId: string;
+  userId: number;
+  repositoryId: number;
+}) {
+  const membership = await requireMembership(input.projectId, input.userId);
+  assertCanEdit(membership.role);
+  if (input.repositoryId === membership.projectRepositoryId) {
+    throw new Error("The project repository is already connected");
+  }
+  const accessible = await getAccessibleRepositoryIds(
+    [input.repositoryId],
+    input.userId
+  );
+  if (accessible.length !== 1) throw new NexusProjectAccessError();
+  const [durableRepository] = await executeQuery(
+    (db) =>
+      db
+        .select({ id: knowledgeRepositories.id })
+        .from(knowledgeRepositories)
+        .where(
+          and(
+            eq(knowledgeRepositories.id, input.repositoryId),
+            eq(knowledgeRepositories.repositoryKind, "durable")
+          )
+        )
+        .limit(1),
+    "validateNexusProjectConnectedRepository"
+  );
+  if (!durableRepository) {
+    throw new Error("Only durable repositories can be connected to a project");
+  }
+  await executeQuery(
+    (db) =>
+      db
+        .insert(nexusProjectRepositories)
+        .values({
+          projectId: input.projectId,
+          repositoryId: input.repositoryId,
+          connectedBy: input.userId,
+        })
+        .onConflictDoNothing(),
+    "connectNexusProjectRepository"
+  );
+}
+
+export async function disconnectNexusProjectRepository(input: {
+  projectId: string;
+  userId: number;
+  repositoryId: number;
+}) {
+  const membership = await requireMembership(input.projectId, input.userId);
+  assertCanEdit(membership.role);
+  await executeQuery(
+    (db) =>
+      db
+        .delete(nexusProjectRepositories)
+        .where(
+          and(
+            eq(nexusProjectRepositories.projectId, input.projectId),
+            eq(nexusProjectRepositories.repositoryId, input.repositoryId)
+          )
+        ),
+    "disconnectNexusProjectRepository"
+  );
+}
+
+export async function createNexusProjectConversation(input: {
+  projectId: string;
+  userId: number;
+  title?: string;
+}) {
+  await requireMembership(input.projectId, input.userId);
+  const [conversation] = await executeQuery(
+    (db) =>
+      db
+        .insert(nexusConversations)
+        .values({
+          userId: input.userId,
+          projectId: input.projectId,
+          provider: "nexus",
+          title: input.title?.trim() || "New project chat",
+          messageCount: 0,
+          totalTokens: 0,
+          metadata: {},
+        })
+        .returning({
+          id: nexusConversations.id,
+          title: nexusConversations.title,
+        }),
+    "createNexusProjectConversation"
+  );
+  if (!conversation) throw new Error("Failed to create project conversation");
+  return conversation;
+}
+
+/**
+ * Resolve project instructions and repositories for a chat turn. Connected
+ * repositories are filtered against the executing member's current access on
+ * every call; membership removal and repository revocation therefore take
+ * effect without republishing or recreating the chat.
+ */
+export async function resolveNexusProjectChatContext(input: {
+  projectId: string;
+  userId: number;
+}) {
+  const membership = await requireMembership(input.projectId, input.userId);
+  const connected = await executeQuery(
+    (db) =>
+      db
+        .select({ repositoryId: nexusProjectRepositories.repositoryId })
+        .from(nexusProjectRepositories)
+        .where(eq(nexusProjectRepositories.projectId, input.projectId)),
+    "resolveNexusProjectRepositories"
+  );
+  const connectedIds = await getAccessibleRepositoryIds(
+    connected.map((row) => row.repositoryId),
+    input.userId
+  );
+  return {
+    name: membership.name,
+    instructions: membership.instructions,
+    repositoryIds: [
+      membership.projectRepositoryId,
+      ...connectedIds.filter((id) => id !== membership.projectRepositoryId),
+    ],
+  };
+}
+
+export async function assertConversationProject(input: {
+  conversationId: string;
+  projectId: string;
+  userId: number;
+}) {
+  const [conversation] = await executeQuery(
+    (db) =>
+      db
+        .select({ projectId: nexusConversations.projectId })
+        .from(nexusConversations)
+        .where(
+          and(
+            eq(nexusConversations.id, input.conversationId),
+            eq(nexusConversations.userId, input.userId)
+          )
+        )
+        .limit(1),
+    "assertConversationProject"
+  );
+  if (!conversation || conversation.projectId !== input.projectId) {
+    throw new NexusProjectAccessError();
+  }
+}

--- a/lib/oauth/oauth-scopes.ts
+++ b/lib/oauth/oauth-scopes.ts
@@ -63,6 +63,10 @@ const PLATFORM_SCOPES = Object.keys(API_SCOPES).filter((s) =>
   s.startsWith("platform:")
 )
 
+const REPOSITORY_SCOPES = Object.keys(API_SCOPES).filter((s) =>
+  s.startsWith("repositories:")
+)
+
 /**
  * Scopes granted for the AI Studio API resource server. Standard OIDC scopes
  * must remain in the OIDC grant portion and must not be duplicated as API
@@ -72,6 +76,7 @@ export const RESOURCE_SERVER_SCOPES = [
   ...MCP_SCOPES,
   ...CONTENT_SCOPES,
   ...PLATFORM_SCOPES,
+  ...REPOSITORY_SCOPES,
 ]
 
 /**

--- a/lib/oauth/openclaw-client.ts
+++ b/lib/oauth/openclaw-client.ts
@@ -1,0 +1,14 @@
+export const AISTUDIO_OPENCLAW_CLIENT_ID =
+  "7e8646f4-4091-4a34-a6b9-0d3721e8a126"
+
+export const AISTUDIO_OPENCLAW_SCOPES = [
+  "openid",
+  "profile",
+  "email",
+  "offline_access",
+  "platform:read",
+  "repositories:list",
+  "repositories:read",
+  "repositories:search",
+  "repositories:changes",
+] as const

--- a/lib/repositories/repository-catalog-service.ts
+++ b/lib/repositories/repository-catalog-service.ts
@@ -1,0 +1,403 @@
+import "server-only";
+
+import { and, asc, eq, gt, inArray, or, sql } from "drizzle-orm";
+import { getUserAccessibleRepositories } from "@/lib/db/drizzle";
+import {
+  executeQuery,
+  toPgRows,
+} from "@/lib/db/drizzle-client";
+import {
+  knowledgeRepositories,
+  repositoryItems,
+} from "@/lib/db/schema";
+import { retrieveRepositoryContent } from "./retrieval-v2/service";
+import type {
+  RetrievalMode,
+  RetrievalModality,
+} from "./retrieval-v2/types";
+
+const MAX_REPOSITORIES = 50;
+const MAX_RESULTS = 50;
+const MAX_SOURCE_SEGMENTS = 50;
+const MAX_CHANGES = 100;
+
+export interface RepositoryCatalogEntry {
+  id: number;
+  name: string;
+  description: string | null;
+  ownerName: string | null;
+  visibility: "public" | "private";
+  itemCount: number;
+  activeIndexGenerationId: string | null;
+  lastUpdated: string | null;
+  createdAt: string | null;
+  updatedAt: string | null;
+}
+
+export interface RepositorySourceSegment {
+  chunkId: number;
+  itemId: number;
+  itemStableId: string;
+  itemName: string;
+  itemVersionId: string;
+  versionNumber: number;
+  chunkIndex: number;
+  modality: string;
+  content: string;
+  contextPrefix: string;
+  sourceLocator: Record<string, unknown>;
+}
+
+interface SourceRow {
+  chunk_id: number;
+  item_id: number;
+  item_stable_id: string;
+  item_name: string;
+  item_version_id: string;
+  version_number: number;
+  chunk_index: number;
+  modality: string;
+  content: string;
+  context_prefix: string;
+  source_locator: Record<string, unknown>;
+}
+
+interface ChangeCursor {
+  updatedAt: string;
+  itemId: number;
+}
+
+function toIso(value: Date | string | null): string | null {
+  if (value == null) return null;
+  const date = value instanceof Date ? value : new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date.toISOString();
+}
+
+function clamp(value: number | undefined, fallback: number, maximum: number) {
+  if (value == null || !Number.isFinite(value)) return fallback;
+  return Math.min(Math.max(1, Math.floor(value)), maximum);
+}
+
+function mapCatalogEntry(
+  repository: Awaited<ReturnType<typeof getUserAccessibleRepositories>>[number]
+): RepositoryCatalogEntry {
+  return {
+    id: repository.id,
+    name: repository.name,
+    description: repository.description,
+    ownerName: repository.ownerName,
+    visibility: repository.isPublic ? "public" : "private",
+    itemCount: Number(repository.itemCount),
+    activeIndexGenerationId: repository.activeIndexGenerationId,
+    lastUpdated: toIso(repository.lastUpdated),
+    createdAt: toIso(repository.createdAt),
+    updatedAt: toIso(repository.updatedAt),
+  };
+}
+
+export async function listRepositoryCatalog(
+  cognitoSub: string,
+  options: { query?: string; limit?: number } = {}
+): Promise<RepositoryCatalogEntry[]> {
+  const query = options.query?.trim().toLocaleLowerCase();
+  const limit = clamp(options.limit, MAX_REPOSITORIES, MAX_REPOSITORIES);
+  const repositories = await getUserAccessibleRepositories(cognitoSub);
+  return repositories
+    .filter((repository) => {
+      if (!query) return true;
+      return (
+        repository.name.toLocaleLowerCase().includes(query) ||
+        repository.description?.toLocaleLowerCase().includes(query) === true
+      );
+    })
+    .slice(0, limit)
+    .map(mapCatalogEntry);
+}
+
+export async function describeRepository(
+  cognitoSub: string,
+  repositoryId: number
+): Promise<RepositoryCatalogEntry | null> {
+  const repositories = await getUserAccessibleRepositories(cognitoSub);
+  const repository = repositories.find((row) => row.id === repositoryId);
+  return repository ? mapCatalogEntry(repository) : null;
+}
+
+export async function searchRepositoryCatalog(input: {
+  cognitoSub: string;
+  query: string;
+  repositoryIds?: number[];
+  mode?: RetrievalMode;
+  modalities?: RetrievalModality[];
+  limit?: number;
+  threshold?: number;
+}) {
+  const requestedIds =
+    input.repositoryIds?.filter(
+      (id) => Number.isSafeInteger(id) && id > 0
+    ) ?? [];
+  const repositoryIds =
+    requestedIds.length > 0
+      ? requestedIds.slice(0, MAX_REPOSITORIES)
+      : (await listRepositoryCatalog(input.cognitoSub)).map(
+          (repository) => repository.id
+        );
+  return retrieveRepositoryContent({
+    query: input.query,
+    repositoryIds,
+    userCognitoSub: input.cognitoSub,
+    mode: input.mode,
+    modalities: input.modalities,
+    limit: clamp(input.limit, 10, MAX_RESULTS),
+    threshold: input.threshold,
+  });
+}
+
+/**
+ * Return exact source segments only from the repository's currently active
+ * generation and the item's current immutable version. Repository and segment
+ * ACLs are re-evaluated in this disclosure statement so revocation cannot race
+ * an earlier list/describe call.
+ */
+export async function getRepositorySource(input: {
+  userId: number;
+  repositoryId: number;
+  itemId: number;
+  chunkId?: number;
+  limit?: number;
+}): Promise<RepositorySourceSegment[]> {
+  const limit = clamp(input.limit, 20, MAX_SOURCE_SEGMENTS);
+  const chunkPredicate =
+    input.chunkId == null
+      ? sql`TRUE`
+      : sql`chunk.id = ${input.chunkId}`;
+  const result = await executeQuery(
+    (db) =>
+      db.execute(sql`
+        SELECT
+          chunk.id AS chunk_id,
+          item.id AS item_id,
+          item.stable_id::text AS item_stable_id,
+          item.name AS item_name,
+          version.id::text AS item_version_id,
+          version.version_number,
+          chunk.chunk_index,
+          chunk.modality,
+          chunk.content,
+          chunk.context_prefix,
+          chunk.source_locator
+        FROM knowledge_repositories repository
+        JOIN repository_items item
+          ON item.repository_id = repository.id
+        JOIN repository_item_versions version
+          ON version.id = item.current_version_id
+        JOIN repository_item_chunks chunk
+          ON chunk.item_id = item.id
+         AND chunk.item_version_id = version.id
+         AND chunk.index_generation_id = repository.active_index_generation_id
+        WHERE repository.id = ${input.repositoryId}
+          AND item.id = ${input.itemId}
+          AND ${chunkPredicate}
+          AND repository.repository_kind = 'durable'
+          AND (repository.metadata ->> 'systemManaged')
+            IS DISTINCT FROM 'true'
+          AND repository.lifecycle_status = 'active'
+          AND (repository.expires_at IS NULL OR repository.expires_at > now())
+          AND item.lifecycle_status = 'active'
+          AND (item.expires_at IS NULL OR item.expires_at > now())
+          AND (
+            repository.is_public = true
+            OR repository.owner_id = ${input.userId}
+            OR EXISTS (
+              SELECT 1
+              FROM repository_access repository_acl
+              WHERE repository_acl.repository_id = repository.id
+                AND (
+                  repository_acl.user_id = ${input.userId}
+                  OR EXISTS (
+                    SELECT 1
+                    FROM user_roles membership
+                    WHERE membership.user_id = ${input.userId}
+                      AND membership.role_id = repository_acl.role_id
+                  )
+                )
+            )
+          )
+          AND (
+            NOT (
+              chunk.access_scope ? 'userIds'
+              OR chunk.access_scope ? 'roleIds'
+            )
+            OR (
+              jsonb_typeof(chunk.access_scope -> 'userIds') = 'array'
+              AND chunk.access_scope -> 'userIds'
+                @> to_jsonb(ARRAY[${input.userId}]::integer[])
+            )
+            OR (
+              jsonb_typeof(chunk.access_scope -> 'roleIds') = 'array'
+              AND EXISTS (
+                SELECT 1
+                FROM jsonb_array_elements(chunk.access_scope -> 'roleIds') role_value
+                JOIN user_roles membership
+                  ON membership.user_id = ${input.userId}
+                 AND role_value = to_jsonb(membership.role_id)
+              )
+            )
+          )
+        ORDER BY chunk.chunk_index ASC, chunk.id ASC
+        LIMIT ${limit}
+      `),
+    "getRepositoryCatalogSource"
+  );
+  return toPgRows<SourceRow>(result).map((row) => ({
+    chunkId: row.chunk_id,
+    itemId: row.item_id,
+    itemStableId: row.item_stable_id,
+    itemName: row.item_name,
+    itemVersionId: row.item_version_id,
+    versionNumber: row.version_number,
+    chunkIndex: row.chunk_index,
+    modality: row.modality,
+    content: row.content,
+    contextPrefix: row.context_prefix,
+    sourceLocator: row.source_locator,
+  }));
+}
+
+function decodeChangeCursor(cursor: string | undefined): ChangeCursor | null {
+  if (!cursor) return null;
+  try {
+    const decoded: unknown = JSON.parse(
+      Buffer.from(cursor, "base64url").toString("utf8")
+    );
+    if (
+      !decoded ||
+      typeof decoded !== "object" ||
+      !("updatedAt" in decoded) ||
+      !("itemId" in decoded)
+    ) {
+      return null;
+    }
+    const updatedAt = Reflect.get(decoded, "updatedAt");
+    const itemId = Reflect.get(decoded, "itemId");
+    if (
+      typeof updatedAt !== "string" ||
+      Number.isNaN(new Date(updatedAt).getTime()) ||
+      typeof itemId !== "number" ||
+      !Number.isSafeInteger(itemId)
+    ) {
+      return null;
+    }
+    return { updatedAt, itemId };
+  } catch {
+    return null;
+  }
+}
+
+function encodeChangeCursor(cursor: ChangeCursor): string {
+  return Buffer.from(JSON.stringify(cursor), "utf8").toString("base64url");
+}
+
+export async function listRepositoryChanges(input: {
+  userId: number;
+  repositoryIds?: number[];
+  cursor?: string;
+  limit?: number;
+}) {
+  const requestedIds =
+    input.repositoryIds?.filter(
+      (id) => Number.isSafeInteger(id) && id > 0
+    ) ?? [];
+  const repositoryIds = requestedIds.slice(0, MAX_REPOSITORIES);
+  if (repositoryIds.length === 0) {
+    return { changes: [], nextCursor: null };
+  }
+
+  const cursor = decodeChangeCursor(input.cursor);
+  if (input.cursor && !cursor) {
+    throw new Error("Invalid repository changes cursor");
+  }
+  const limit = clamp(input.limit, 50, MAX_CHANGES);
+  const cursorPredicate = cursor
+    ? or(
+        gt(repositoryItems.updatedAt, new Date(cursor.updatedAt)),
+        and(
+          eq(repositoryItems.updatedAt, new Date(cursor.updatedAt)),
+          gt(repositoryItems.id, cursor.itemId)
+        )
+      )
+    : undefined;
+  const rows = await executeQuery(
+    (db) =>
+      db
+        .select({
+          repositoryId: knowledgeRepositories.id,
+          repositoryName: knowledgeRepositories.name,
+          activeIndexGenerationId:
+            knowledgeRepositories.activeIndexGenerationId,
+          itemId: repositoryItems.id,
+          itemStableId: repositoryItems.stableId,
+          itemName: repositoryItems.name,
+          lifecycleStatus: repositoryItems.lifecycleStatus,
+          currentVersionId: repositoryItems.currentVersionId,
+          updatedAt: repositoryItems.updatedAt,
+        })
+        .from(repositoryItems)
+        .innerJoin(
+          knowledgeRepositories,
+          eq(knowledgeRepositories.id, repositoryItems.repositoryId)
+        )
+        .where(
+          and(
+            inArray(repositoryItems.repositoryId, repositoryIds),
+            eq(knowledgeRepositories.repositoryKind, "durable"),
+            eq(knowledgeRepositories.lifecycleStatus, "active"),
+            sql`(
+              (${knowledgeRepositories.metadata} ->> 'systemManaged')
+                IS DISTINCT FROM 'true'
+              AND (
+                ${knowledgeRepositories.expiresAt} IS NULL
+                OR ${knowledgeRepositories.expiresAt} > now()
+              )
+            )`,
+            or(
+              eq(knowledgeRepositories.isPublic, true),
+              eq(knowledgeRepositories.ownerId, input.userId),
+              sql`EXISTS (
+                SELECT 1
+                FROM repository_access repository_acl
+                WHERE repository_acl.repository_id = ${knowledgeRepositories.id}
+                  AND (
+                    repository_acl.user_id = ${input.userId}
+                    OR EXISTS (
+                      SELECT 1
+                      FROM user_roles membership
+                      WHERE membership.user_id = ${input.userId}
+                        AND membership.role_id = repository_acl.role_id
+                    )
+                  )
+              )`
+            ),
+            cursorPredicate
+          )
+        )
+        .orderBy(asc(repositoryItems.updatedAt), asc(repositoryItems.id))
+        .limit(limit + 1),
+    "listRepositoryCatalogChanges"
+  );
+  const page = rows.slice(0, limit);
+  const last = page.at(-1);
+  return {
+    changes: page.map((row) => ({
+      ...row,
+      updatedAt: toIso(row.updatedAt),
+    })),
+    nextCursor:
+      rows.length > limit && last?.updatedAt
+        ? encodeChangeCursor({
+            updatedAt: toIso(last.updatedAt) ?? new Date(0).toISOString(),
+            itemId: last.itemId,
+          })
+        : null,
+  };
+}

--- a/lib/skills/skill-tool-enforcement.ts
+++ b/lib/skills/skill-tool-enforcement.ts
@@ -19,6 +19,7 @@
 import { and, eq } from "drizzle-orm";
 import { executeQuery } from "@/lib/db/drizzle-client";
 import { psdAgentSkills } from "@/lib/db/schema/tables/agent-skills";
+import { skillRepositoryBindings } from "@/lib/db/schema/tables/skill-repository-bindings";
 import { parseToolRef } from "@/lib/tools/catalog/version-resolver";
 
 /**
@@ -121,6 +122,8 @@ export interface ApprovedSkillSession {
   allowedTools: string[];
   /** S3 prefix of the promoted skill folder (SKILL.md lives under it). */
   s3Key: string;
+  /** Canonical repositories bound when the skill was published. */
+  repositoryIds: number[];
 }
 
 /**
@@ -170,10 +173,19 @@ export async function getApprovedSkillSession(
   );
   const row = rows[0];
   if (!row) return null;
+  const repositoryRows = await executeQuery(
+    (db) =>
+      db
+        .select({ repositoryId: skillRepositoryBindings.repositoryId })
+        .from(skillRepositoryBindings)
+        .where(eq(skillRepositoryBindings.skillId, skillId)),
+    "skillEnforcement.repositories"
+  );
   return {
     name: row.name,
     allowedTools: Array.isArray(row.allowedTools) ? row.allowedTools : [],
     s3Key: row.s3Key,
+    repositoryIds: repositoryRows.map((binding) => binding.repositoryId),
   };
 }
 

--- a/lib/tools/catalog/manifest.ts
+++ b/lib/tools/catalog/manifest.ts
@@ -101,6 +101,76 @@ const MCP_TOOL_CATALOG_MAP: Record<string, McpCatalogMapping> = {
     requiredScope: "platform:read",
     internalScopes: ["platform:read"],
   },
+  repositories_list: {
+    identifier: "repositories.list",
+    requiredScope: "repositories:list",
+    internalScopes: ["repositories:list"],
+    rest: {
+      scopes: ["repositories:list"],
+      binding: {
+        method: "get",
+        path: "/api/v1/repositories",
+        summary: "List accessible repositories",
+        operationId: "listRepositories",
+      },
+    },
+  },
+  repositories_describe: {
+    identifier: "repositories.describe",
+    requiredScope: "repositories:list",
+    internalScopes: ["repositories:list"],
+    rest: {
+      scopes: ["repositories:list"],
+      binding: {
+        method: "get",
+        path: "/api/v1/repositories/{id}",
+        summary: "Describe an accessible repository",
+        operationId: "describeRepository",
+      },
+    },
+  },
+  repositories_search: {
+    identifier: "repositories.search",
+    requiredScope: "repositories:search",
+    internalScopes: ["repositories:search"],
+    rest: {
+      scopes: ["repositories:search"],
+      binding: {
+        method: "post",
+        path: "/api/v1/repositories/search",
+        summary: "Search accessible repositories",
+        operationId: "searchRepositories",
+      },
+    },
+  },
+  repositories_get_source: {
+    identifier: "repositories.get_source",
+    requiredScope: "repositories:read",
+    internalScopes: ["repositories:read"],
+    rest: {
+      scopes: ["repositories:read"],
+      binding: {
+        method: "get",
+        path: "/api/v1/repositories/{id}/source",
+        summary: "Get authorized repository source segments",
+        operationId: "getRepositorySource",
+      },
+    },
+  },
+  repositories_list_changes: {
+    identifier: "repositories.list_changes",
+    requiredScope: "repositories:changes",
+    internalScopes: ["repositories:changes"],
+    rest: {
+      scopes: ["repositories:changes"],
+      binding: {
+        method: "get",
+        path: "/api/v1/repositories/changes",
+        summary: "List authorized repository changes",
+        operationId: "listRepositoryChanges",
+      },
+    },
+  },
   search_decisions: {
     identifier: "decisions.search",
     requiredScope: "mcp:search_decisions",

--- a/middleware.ts
+++ b/middleware.ts
@@ -21,17 +21,18 @@ const PUBLIC_PATHS = [
   "/api/oauth", // OAuth2/OIDC endpoints handle their own auth (#686)
   "/.well-known", // OIDC discovery document (#686)
   "/auth/error",
-  // Agent Workspace OAuth bootstrap (#912) — all three endpoints authenticate
-  // via signed tokens in the URL or a Bearer shared-secret from the agent
-  // runtime. A PSD session is not required (and would be impossible on the
-  // first visit, since consent happens outside the PSD web session).
+  // Agent Workspace bootstrap (#912). API calls verify router-signed invocation
+  // context. The original Google Workspace flow remains link-authenticated;
+  // provider-specific reusable grants are deliberately excluded below and
+  // require a same-owner AI Studio session.
   "/api/agent", // Agent endpoints verify router-signed invocation context
   "/agent-connect", // Consent page and OAuth callback — signed JWT in URL
-  // Canva and Plaud intentionally are NOT public. Their external OAuth grants
-  // are stored in a local owner's reusable credential slot, so both the start
-  // and callback must carry a live AI Studio session whose email matches that
-  // immutable owner. A signed link alone proves integrity, not who opened it.
-  // The Cognito data flow remains separate and has its own identity semantics.
+  // Canva, Plaud, and AI Studio intentionally are NOT public. Their external
+  // OAuth grants are stored in a local owner's reusable credential slot, so
+  // both the start and callback must carry a live AI Studio session whose email
+  // matches that immutable owner. A signed link alone proves integrity, not who
+  // opened it. The Cognito data flow remains separate and has its own identity
+  // semantics.
   "/agent-connect-data",
   // Atrium public reader (#1057): /p/[slug] is the anonymous public_web reader
   // route (spec §20). It is world-readable by design — the page itself gates

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "test:smoke:nexus-ephemeral": "DATABASE_URL='postgresql://postgres:postgres@localhost:5432/aistudio' DB_SSL=false bun run tests/smoke/nexus-ephemeral-repositories.smoke.ts",
     "test:smoke:repository-upload-quota": "DATABASE_URL='postgresql://postgres:postgres@localhost:5432/aistudio' DB_SSL=false bun run tests/smoke/repository-upload-quota.smoke.ts",
     "test:smoke:google-content": "DATABASE_URL='postgresql://postgres:postgres@localhost:5432/aistudio' DB_SSL=false bun run tests/smoke/google-content-connectors.smoke.ts",
+    "test:smoke:agents-projects": "DATABASE_URL='postgresql://postgres:postgres@localhost:5432/aistudio' DB_SSL=false bun --preload ./tests/smoke/server-only-preload.js tests/smoke/unified-content-agents-projects.smoke.ts",
     "test:smoke:unified-content-lambda-artifact": "bun run scripts/test/unified-content-lambda-artifact.smoke.ts",
     "test:smoke:embedding-lambda-artifact": "bun run scripts/test/embedding-lambda-artifact.smoke.ts",
     "test:skill:workspace": "cd infra/agent-image/skills/psd-workspace && bun test common.test.js",

--- a/tests/e2e/aistudio-agent-connect.spec.ts
+++ b/tests/e2e/aistudio-agent-connect.spec.ts
@@ -1,0 +1,43 @@
+import { expect, test } from "./fixtures";
+
+test.describe("Agent Connect (AI Studio) authenticated pages", () => {
+  test("missing consent token requires an AI Studio session", async ({ page }) => {
+    const response = await page.goto("/agent-connect-aistudio");
+    expect(response).not.toBeNull();
+    await expect(page).toHaveURL(/\/auth\/signin/);
+  });
+
+  test("a signed-link-shaped request cannot bypass session auth", async ({
+    page,
+  }) => {
+    const response = await page.goto(
+      "/agent-connect-aistudio?token=not-a-signed-token"
+    );
+    expect(response).not.toBeNull();
+    await expect(page).toHaveURL(/\/auth\/signin/);
+  });
+
+  test("callback requires the same authenticated AI Studio session", async ({
+    page,
+  }) => {
+    const response = await page.goto("/agent-connect-aistudio/callback");
+    expect(response).not.toBeNull();
+    await expect(page).toHaveURL(/\/auth\/signin/);
+  });
+});
+
+test.describe("Agent Connect (AI Studio) API guards", () => {
+  test("consent and disconnect operations reject missing invocation proof", async ({
+    request,
+  }) => {
+    const consent = await request.post("/api/agent/consent-link", {
+      data: { kind: "aistudio" },
+    });
+    expect(consent.status()).toBe(403);
+
+    const disconnect = await request.post("/api/agent/aistudio", {
+      data: { operation: "disconnect" },
+    });
+    expect(disconnect.status()).toBe(403);
+  });
+});

--- a/tests/e2e/nexus-projects.functional.spec.ts
+++ b/tests/e2e/nexus-projects.functional.spec.ts
@@ -1,0 +1,230 @@
+import { expect, test } from "./fixtures";
+import {
+  authenticateContext,
+  SEEDED_ADMIN_EMAIL,
+  SEEDED_ADMIN_SUB,
+} from "./helpers/session-auth";
+
+const STAFF_EMAIL = "staff@example.com";
+const STAFF_SUB = "e2e-staff-user";
+const SHARED_REPOSITORY = "E2E Unified Content Repository";
+const OWNER_ONLY_REPOSITORY = "E2E Owner Only Repository";
+
+function rpc(method: string, params?: Record<string, unknown>, id = 1) {
+  return { jsonrpc: "2.0", method, id, ...(params ? { params } : {}) };
+}
+
+test.describe("Nexus Projects (authenticated)", () => {
+  test.skip(
+    process.env.PLAYWRIGHT_AUTH_ENABLED !== "true",
+    "Requires the authenticated local E2E server and seeded users"
+  );
+
+  test("persists project context, membership, private files, and project chats", async ({
+    page,
+  }) => {
+    test.setTimeout(120_000);
+    await authenticateContext(
+      page.context(),
+      SEEDED_ADMIN_EMAIL,
+      SEEDED_ADMIN_SUB
+    );
+
+    const suffix = Date.now();
+    const projectName = `E2E Nexus project ${suffix}`;
+    const originalInstructions = "Use the current approved project sources.";
+    const updatedInstructions =
+      "Use the current approved project sources and cite each policy.";
+
+    await page.goto("/nexus/projects");
+    await page.getByLabel("Project name").fill(projectName);
+    await page.getByLabel("Project instructions").fill(originalInstructions);
+    await page.getByRole("button", { name: "Create project" }).click();
+
+    await expect(page).toHaveURL(/\/nexus\/projects\/[0-9a-f-]+$/, {
+      timeout: 30_000,
+    });
+    const projectId = page.url().split("/").at(-1);
+    expect(projectId).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+    );
+
+    await expect(
+      page.getByRole("heading", { name: projectName })
+    ).toBeVisible();
+    await expect(page.getByText("Private project repository")).toBeVisible();
+    await page
+      .getByLabel("Project instructions")
+      .fill(updatedInstructions);
+    await page.getByRole("button", { name: "Save context" }).click();
+    await expect(page.getByText("Project updated")).toBeVisible();
+
+    await page.getByLabel("Member email").fill(STAFF_EMAIL);
+    await page.getByLabel("Member role").selectOption("editor");
+    await page.getByRole("button", { name: "Add", exact: true }).click();
+    await expect(page.getByText(`${STAFF_EMAIL} · editor`)).toBeVisible();
+
+    await authenticateContext(page.context(), STAFF_EMAIL, STAFF_SUB);
+    await page.reload();
+    await expect(page.getByText("Your role: editor")).toBeVisible();
+    await expect(page.getByLabel("Member email")).toHaveCount(0);
+    await expect(page.getByLabel("Project instructions")).toHaveValue(
+      updatedInstructions
+    );
+
+    await page.getByRole("button", { name: "New project chat" }).click();
+    await expect(page).toHaveURL(
+      new RegExp(
+        `/nexus\\?conversationId=[0-9a-f-]+&projectId=${projectId}$`
+      ),
+      { timeout: 30_000 }
+    );
+
+    await authenticateContext(
+      page.context(),
+      SEEDED_ADMIN_EMAIL,
+      SEEDED_ADMIN_SUB
+    );
+    await page.goto(`/nexus/projects/${projectId}`);
+    await page
+      .getByRole("button", { name: `Remove ${STAFF_EMAIL}` })
+      .click();
+    await expect(page.getByText("Member removed")).toBeVisible();
+    await expect(page.getByText(`${STAFF_EMAIL} · editor`)).toHaveCount(0);
+
+    await authenticateContext(page.context(), STAFF_EMAIL, STAFF_SUB);
+    const removedMemberResponse = await page.goto(
+      `/nexus/projects/${projectId}`
+    );
+    expect(removedMemberResponse?.status()).toBe(404);
+  });
+
+  test("queries only live authorized repositories over REST and MCP with a revocable scoped key", async ({
+    page,
+  }) => {
+    test.setTimeout(120_000);
+    await authenticateContext(page.context(), STAFF_EMAIL, STAFF_SUB);
+    await page.goto("/settings");
+    await page.getByRole("tab", { name: "API Keys" }).click();
+
+    const keyName = `E2E repository catalog ${Date.now()}`;
+    let rawKey: string | null = null;
+    const keyRow = () =>
+      page
+        .getByText(keyName, { exact: true })
+        .locator("xpath=ancestor::div[contains(@class,'rounded-lg')][1]");
+
+    try {
+      await page.getByRole("button", { name: "Generate Key" }).click();
+      const createDialog = page.getByRole("dialog", {
+        name: "Generate API Key",
+      });
+      await createDialog.getByLabel("Key Name").fill(keyName);
+      for (const scope of [
+        "repositories:list",
+        "repositories:read",
+        "repositories:search",
+        "repositories:changes",
+      ]) {
+        await createDialog
+          .getByRole("checkbox", { name: new RegExp(`^${scope}`) })
+          .click();
+      }
+      await createDialog.getByRole("button", { name: "Create Key" }).click();
+
+      const createdDialog = page.getByRole("alertdialog", {
+        name: "Save Your API Key",
+      });
+      rawKey = (await createdDialog.locator("code").textContent())?.trim() ?? null;
+      expect(rawKey).toMatch(/^sk-[\da-f]{64}$/);
+      await createdDialog
+        .getByRole("button", { name: "I've saved my key" })
+        .click();
+
+      const authHeaders = { Authorization: `Bearer ${rawKey}` };
+      const listResponse = await page.request.get(
+        `/api/v1/repositories?query=${encodeURIComponent("E2E")}`,
+        { headers: authHeaders }
+      );
+      expect(listResponse.status()).toBe(200);
+      const listBody = (await listResponse.json()) as {
+        data: Array<{ id: number; name: string }>;
+      };
+      expect(listBody.data.map((repository) => repository.name)).toContain(
+        SHARED_REPOSITORY
+      );
+      expect(listBody.data.map((repository) => repository.name)).not.toContain(
+        OWNER_ONLY_REPOSITORY
+      );
+      const sharedRepository = listBody.data.find(
+        (repository) => repository.name === SHARED_REPOSITORY
+      );
+      expect(sharedRepository).toBeDefined();
+
+      const mcpResponse = await page.request.post("/api/mcp", {
+        headers: authHeaders,
+        data: rpc("tools/call", {
+          name: "repositories_list",
+          arguments: { query: "E2E" },
+        }),
+      });
+      expect(mcpResponse.status()).toBe(200);
+      const mcpBody = (await mcpResponse.json()) as {
+        result?: { content?: Array<{ text?: string }> };
+      };
+      const mcpCatalog = JSON.parse(
+        mcpBody.result?.content?.[0]?.text ?? "{}"
+      ) as { repositories?: Array<{ name: string }> };
+      expect(
+        mcpCatalog.repositories?.map((repository) => repository.name)
+      ).toContain(SHARED_REPOSITORY);
+      expect(
+        mcpCatalog.repositories?.map((repository) => repository.name)
+      ).not.toContain(OWNER_ONLY_REPOSITORY);
+
+      const changesResponse = await page.request.get(
+        `/api/v1/repositories/changes?repositoryIds=${sharedRepository?.id}`,
+        { headers: authHeaders }
+      );
+      expect(changesResponse.status()).toBe(200);
+      const changesBody = (await changesResponse.json()) as {
+        data: Array<{ repositoryId: number; itemName: string }>;
+      };
+      expect(changesBody.data.length).toBeGreaterThan(0);
+      expect(
+        changesBody.data.every(
+          (change) => change.repositoryId === sharedRepository?.id
+        )
+      ).toBe(true);
+    } finally {
+      if (rawKey) {
+        await expect(keyRow()).toBeVisible();
+        await keyRow().getByRole("button", { name: "Revoke" }).click();
+        await page
+          .getByRole("alertdialog", { name: "Revoke API Key?" })
+          .getByRole("button", { name: "Revoke Key" })
+          .click();
+        await expect(keyRow()).toContainText("Revoked");
+
+        const revokedResponse = await page.request.get("/api/v1/repositories", {
+          headers: { Authorization: `Bearer ${rawKey}` },
+        });
+        expect(revokedResponse.status()).toBe(401);
+      }
+    }
+  });
+});
+
+test.describe("Repository catalog API guards", () => {
+  test("rejects catalog requests without an API credential", async ({
+    request,
+  }) => {
+    const list = await request.get("/api/v1/repositories");
+    expect(list.status()).toBe(401);
+
+    const search = await request.post("/api/v1/repositories/search", {
+      data: { query: "policy" },
+    });
+    expect(search.status()).toBe(401);
+  });
+});

--- a/tests/smoke/server-only-preload.js
+++ b/tests/smoke/server-only-preload.js
@@ -1,0 +1,7 @@
+/**
+ * Next.js resolves `server-only` as a poison-package marker. Standalone Bun
+ * smoke scripts need a no-op module so they can load the same server services.
+ */
+import { mock } from "bun:test";
+
+mock.module("server-only", () => ({}));

--- a/tests/smoke/unified-content-agents-projects.smoke.ts
+++ b/tests/smoke/unified-content-agents-projects.smoke.ts
@@ -1,0 +1,306 @@
+/**
+ * Real PostgreSQL smoke for Epic #1261 workstream #1266.
+ *
+ * Proves project/member/repository/chat transactions and immediate ACL
+ * revocation. OAuth protocol behavior is covered by unit/route tests; this
+ * smoke verifies the client and nonce schema created by migration 139.
+ */
+
+import assert from "node:assert/strict";
+import { randomUUID } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { and, eq, sql } from "drizzle-orm";
+import { closeDatabase, executeQuery } from "@/lib/db/drizzle-client";
+import {
+  knowledgeRepositories,
+  nexusConversations,
+  nexusProjectMembers,
+  nexusProjects,
+  oauthClients,
+  psdAgentWorkspaceConsentNonces,
+  users,
+} from "@/lib/db/schema";
+import { getAccessibleRepositoryIds } from "@/lib/db/drizzle";
+import {
+  NexusProjectAccessError,
+  addNexusProjectMember,
+  connectNexusProjectRepository,
+  createNexusProject,
+  createNexusProjectConversation,
+  getNexusProject,
+  removeNexusProjectMember,
+  resolveNexusProjectChatContext,
+} from "@/lib/nexus/projects/project-service";
+
+const migration = readFileSync(
+  resolve(
+    process.cwd(),
+    "infra/database/schema/139-unified-content-agents-projects.sql"
+  ),
+  "utf8"
+);
+for (const [index, statement] of migration
+  .split(/;\s*(?:\r?\n|$)/)
+  .map((entry) => entry.trim())
+  .filter(Boolean)
+  .entries()) {
+  await executeQuery(
+    (db) => db.execute(sql.raw(statement)),
+    `smoke.agentsProjects.ensureSchema.${index + 1}`
+  );
+}
+
+const fixture = randomUUID();
+const [owner] = await executeQuery(
+  (db) =>
+    db
+      .select({ id: users.id })
+      .from(users)
+      .where(eq(users.cognitoSub, "e2e-test-user"))
+      .limit(1),
+  "smoke.agentsProjects.owner"
+);
+assert.ok(owner, "standard local seed is missing e2e-test-user");
+
+const [member] = await executeQuery(
+  (db) =>
+    db
+      .insert(users)
+      .values({
+        cognitoSub: `agents-projects-member-${fixture}`,
+        email: `agents-projects-member-${fixture}@example.invalid`,
+      })
+      .returning({ id: users.id, email: users.email }),
+  "smoke.agentsProjects.member"
+);
+assert.ok(member?.email);
+const memberEmail = member.email;
+
+const [connectedRepository] = await executeQuery(
+  (db) =>
+    db
+      .insert(knowledgeRepositories)
+      .values({
+        name: `Connected repository ${fixture}`,
+        ownerId: owner.id,
+        isPublic: false,
+        repositoryKind: "durable",
+      })
+      .returning({ id: knowledgeRepositories.id }),
+  "smoke.agentsProjects.connectedRepository"
+);
+assert.ok(connectedRepository);
+
+const [ephemeralRepository] = await executeQuery(
+  (db) =>
+    db
+      .insert(knowledgeRepositories)
+      .values({
+        name: `Ephemeral repository ${fixture}`,
+        ownerId: owner.id,
+        isPublic: false,
+        repositoryKind: "ephemeral",
+        retentionDays: 30,
+        expiresAt: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000),
+      })
+      .returning({ id: knowledgeRepositories.id }),
+  "smoke.agentsProjects.ephemeralRepository"
+);
+assert.ok(ephemeralRepository);
+
+let projectId: string | null = null;
+let projectRepositoryId: number | null = null;
+let consentNonce: string | null = null;
+try {
+  const project = await createNexusProject({
+    ownerId: owner.id,
+    name: `Project smoke ${fixture}`,
+    instructions: "Use the current approved policy.",
+  });
+  projectId = project.id;
+  projectRepositoryId = project.projectRepositoryId;
+
+  const [ownerMembership] = await executeQuery(
+    (db) =>
+      db
+        .select()
+        .from(nexusProjectMembers)
+        .where(
+          and(
+            eq(nexusProjectMembers.projectId, project.id),
+            eq(nexusProjectMembers.userId, owner.id)
+          )
+        ),
+    "smoke.agentsProjects.ownerMembership"
+  );
+  assert.equal(ownerMembership?.role, "owner");
+
+  await addNexusProjectMember({
+    projectId: project.id,
+    actorUserId: owner.id,
+    email: memberEmail,
+    role: "editor",
+  });
+  assert.deepEqual(
+    await getAccessibleRepositoryIds([project.projectRepositoryId], member.id),
+    [project.projectRepositoryId],
+    "project membership must grant the dedicated repository"
+  );
+
+  await assert.rejects(
+    connectNexusProjectRepository({
+      projectId: project.id,
+      userId: owner.id,
+      repositoryId: ephemeralRepository.id,
+    }),
+    /Only durable repositories/
+  );
+
+  await connectNexusProjectRepository({
+    projectId: project.id,
+    userId: owner.id,
+    repositoryId: connectedRepository.id,
+  });
+  const ownerContext = await resolveNexusProjectChatContext({
+    projectId: project.id,
+    userId: owner.id,
+  });
+  assert.deepEqual(ownerContext.repositoryIds.sort((a, b) => a - b), [
+    connectedRepository.id,
+    project.projectRepositoryId,
+  ].sort((a, b) => a - b));
+
+  const memberContext = await resolveNexusProjectChatContext({
+    projectId: project.id,
+    userId: member.id,
+  });
+  assert.deepEqual(
+    memberContext.repositoryIds,
+    [project.projectRepositoryId],
+    "a connected repository must not widen access for a project member"
+  );
+
+  const conversation = await createNexusProjectConversation({
+    projectId: project.id,
+    userId: member.id,
+  });
+  const [persistedConversation] = await executeQuery(
+    (db) =>
+      db
+        .select({
+          userId: nexusConversations.userId,
+          projectId: nexusConversations.projectId,
+        })
+        .from(nexusConversations)
+        .where(eq(nexusConversations.id, conversation.id)),
+    "smoke.agentsProjects.conversation"
+  );
+  assert.deepEqual(persistedConversation, {
+    userId: member.id,
+    projectId: project.id,
+  });
+
+  await removeNexusProjectMember({
+    projectId: project.id,
+    actorUserId: owner.id,
+    memberUserId: member.id,
+  });
+  assert.deepEqual(
+    await getAccessibleRepositoryIds([project.projectRepositoryId], member.id),
+    [],
+    "membership removal must revoke the exact project repository grant"
+  );
+  await assert.rejects(
+    getNexusProject(project.id, member.id),
+    NexusProjectAccessError
+  );
+
+  const [oauthClient] = await executeQuery(
+    (db) =>
+      db
+        .select({
+          applicationType: oauthClients.applicationType,
+          requirePkce: oauthClients.requirePkce,
+          isFirstParty: oauthClients.isFirstParty,
+        })
+        .from(oauthClients)
+        .where(
+          eq(
+            oauthClients.clientId,
+            "7e8646f4-4091-4a34-a6b9-0d3721e8a126"
+          )
+        ),
+    "smoke.agentsProjects.oauthClient"
+  );
+  assert.deepEqual(oauthClient, {
+    applicationType: "native",
+    requirePkce: true,
+    isFirstParty: true,
+  });
+
+  const createdConsentNonce =
+    randomUUID().replaceAll("-", "") + randomUUID().replaceAll("-", "");
+  consentNonce = createdConsentNonce;
+  await executeQuery(
+    (db) =>
+      db.insert(psdAgentWorkspaceConsentNonces).values({
+        nonce: createdConsentNonce,
+        ownerEmail: memberEmail,
+        agentEmail: `agnt_${memberEmail}`,
+        tokenKind: "aistudio",
+        codeVerifier: "a".repeat(43),
+      }),
+    "smoke.agentsProjects.aistudioNonce"
+  );
+} finally {
+  if (projectId) {
+    const cleanupProjectId = projectId;
+    await executeQuery(
+      (db) =>
+        db.delete(nexusProjects).where(eq(nexusProjects.id, cleanupProjectId)),
+      "smoke.agentsProjects.cleanupProject"
+    );
+  }
+  if (projectRepositoryId) {
+    const cleanupRepositoryId = projectRepositoryId;
+    await executeQuery(
+      (db) =>
+        db
+          .delete(knowledgeRepositories)
+          .where(eq(knowledgeRepositories.id, cleanupRepositoryId)),
+      "smoke.agentsProjects.cleanupProjectRepository"
+    );
+  }
+  if (consentNonce) {
+    const cleanupNonce = consentNonce;
+    await executeQuery(
+      (db) =>
+        db
+          .delete(psdAgentWorkspaceConsentNonces)
+          .where(eq(psdAgentWorkspaceConsentNonces.nonce, cleanupNonce)),
+      "smoke.agentsProjects.cleanupNonce"
+    );
+  }
+  await executeQuery(
+    (db) =>
+      db
+        .delete(knowledgeRepositories)
+        .where(eq(knowledgeRepositories.id, connectedRepository.id)),
+    "smoke.agentsProjects.cleanupConnectedRepository"
+  );
+  await executeQuery(
+    (db) =>
+      db
+        .delete(knowledgeRepositories)
+        .where(eq(knowledgeRepositories.id, ephemeralRepository.id)),
+    "smoke.agentsProjects.cleanupEphemeralRepository"
+  );
+  await executeQuery(
+    (db) => db.delete(users).where(eq(users.id, member.id)),
+    "smoke.agentsProjects.cleanupMember"
+  );
+  await closeDatabase();
+}
+
+process.stdout.write("Unified content agents/projects smoke passed.\n");

--- a/tests/unit/actions/publish-skill-repositories.test.ts
+++ b/tests/unit/actions/publish-skill-repositories.test.ts
@@ -1,0 +1,170 @@
+const mockGetCurrentUser = jest.fn();
+const mockHasCapability = jest.fn();
+const mockGetArchitect = jest.fn();
+const mockAccessibleRepositoryIds = jest.fn();
+const mockUploadDraft = jest.fn();
+const mockInvokeScan = jest.fn();
+const mockExecuteTransaction = jest.fn();
+
+jest.mock("@/lib/logger", () => ({
+  createLogger: () => ({
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  }),
+  sanitizeForLogging: (value: unknown) => value,
+  generateRequestId: () => "publish-skill-request",
+  getLogContext: () => ({}),
+  startTimer: () => () => undefined,
+}));
+
+jest.mock("@/actions/db/get-current-user-action", () => ({
+  getCurrentUserAction: (...args: unknown[]) => mockGetCurrentUser(...args),
+}));
+jest.mock("@/utils/roles", () => ({
+  hasCapabilityAccess: (...args: unknown[]) => mockHasCapability(...args),
+}));
+jest.mock("@/actions/db/assistant-architect-actions", () => ({
+  getAssistantArchitectByIdAction: (...args: unknown[]) =>
+    mockGetArchitect(...args),
+}));
+jest.mock("@/lib/db/drizzle", () => ({
+  getAccessibleRepositoryIds: (...args: unknown[]) =>
+    mockAccessibleRepositoryIds(...args),
+}));
+jest.mock("@/lib/db/drizzle-client", () => ({
+  executeTransaction: (...args: unknown[]) => mockExecuteTransaction(...args),
+}));
+jest.mock("@/lib/skills/skill-publish-pipeline", () => ({
+  uploadSkillDraft: (...args: unknown[]) => mockUploadDraft(...args),
+  invokeSkillScan: (...args: unknown[]) => mockInvokeScan(...args),
+}));
+jest.mock("@/lib/db/schema/tables/agent-skills", () => ({
+  psdAgentSkills: "skills-table",
+}));
+jest.mock("@/lib/db/schema/tables/agent-skill-audit", () => ({
+  psdAgentSkillAudit: "audit-table",
+}));
+jest.mock("@/lib/db/schema/tables/skill-repository-bindings", () => ({
+  skillRepositoryBindings: "bindings-table",
+}));
+jest.mock("drizzle-orm", () => ({
+  eq: (...values: unknown[]) => ({ eq: values }),
+  and: (...values: unknown[]) => ({ and: values }),
+  sql: (strings: TemplateStringsArray, ...values: unknown[]) => ({
+    strings: [...strings],
+    values,
+  }),
+}));
+
+import { publishAssistantArchitectAsSkillAction } from "@/actions/db/publish-skill.actions";
+
+const skillId = "11111111-2222-4333-8444-555555555555";
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockGetCurrentUser.mockResolvedValue({
+    isSuccess: true,
+    data: { user: { id: 7, email: "owner@psd401.net" } },
+  });
+  mockHasCapability.mockResolvedValue(true);
+  mockGetArchitect.mockResolvedValue({
+    isSuccess: true,
+    data: {
+      id: 31,
+      userId: 7,
+      name: "Policy helper",
+      description: "Answers policy questions",
+      inputFields: [],
+      prompts: [
+        {
+          name: "Answer",
+          content: "Answer from the repositories.",
+          systemContext: null,
+          position: 0,
+          enabledTools: [],
+          repositoryIds: [41, 41, 87],
+        },
+      ],
+    },
+  });
+  mockAccessibleRepositoryIds.mockResolvedValue([41, 87]);
+  mockUploadDraft.mockResolvedValue({
+    draftPrefix: "skills/drafts/policy-helper/",
+    destinationPrefix: "skills/shared/policy-helper/",
+  });
+  mockInvokeScan.mockResolvedValue(true);
+});
+
+describe("publish skill repository bindings", () => {
+  it("normalizes, authorizes, and transactionally replaces prompt repository bindings", async () => {
+    const insertedBindings: unknown[] = [];
+    const auditValues: unknown[] = [];
+    let deletedBindings = false;
+    mockExecuteTransaction.mockImplementation(
+      async (callback: (tx: unknown) => Promise<unknown>) => {
+        const tx = {
+          insert(table: unknown) {
+            if (table === "skills-table") {
+              return {
+                values: () => ({
+                  onConflictDoUpdate: () => ({
+                    returning: async () => [{ id: skillId }],
+                  }),
+                }),
+              };
+            }
+            if (table === "bindings-table") {
+              return {
+                values: async (values: unknown[]) => {
+                  insertedBindings.push(...values);
+                },
+              };
+            }
+            return {
+              values: async (values: unknown) => {
+                auditValues.push(values);
+              },
+            };
+          },
+          delete(table: unknown) {
+            expect(table).toBe("bindings-table");
+            return {
+              where: async () => {
+                deletedBindings = true;
+              },
+            };
+          },
+        };
+        return callback(tx);
+      }
+    );
+
+    const result = await publishAssistantArchitectAsSkillAction("31");
+
+    expect(result.isSuccess).toBe(true);
+    expect(mockAccessibleRepositoryIds).toHaveBeenCalledWith([41, 87], 7);
+    expect(deletedBindings).toBe(true);
+    expect(insertedBindings).toEqual([
+      { skillId, repositoryId: 41 },
+      { skillId, repositoryId: 87 },
+    ]);
+    expect(auditValues).toEqual([
+      expect.objectContaining({
+        skillId,
+        details: expect.objectContaining({ repositoryIds: [41, 87] }),
+      }),
+    ]);
+  });
+
+  it("fails before upload or persistence when the publisher lost repository access", async () => {
+    mockAccessibleRepositoryIds.mockResolvedValue([41]);
+
+    const result = await publishAssistantArchitectAsSkillAction("31");
+
+    expect(result.isSuccess).toBe(false);
+    expect(mockUploadDraft).not.toHaveBeenCalled();
+    expect(mockExecuteTransaction).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/agent-aistudio-oauth.test.ts
+++ b/tests/unit/agent-aistudio-oauth.test.ts
@@ -263,4 +263,18 @@ describe("AI Studio OAuth callback", () => {
     expect(mockExecutedLabels).toEqual(["lookupAistudioCallbackNonce"]);
     expect(global.fetch).not.toHaveBeenCalled();
   });
+
+  it("lets the fixed OAuth issuer reject an invalid authorization code", async () => {
+    global.fetch = jest
+      .fn()
+      .mockResolvedValueOnce(
+        jsonResponse({ error: "invalid_grant" }, 400)
+      ) as unknown as typeof fetch;
+
+    const result = await handleAistudioCallback("", mockNonce);
+
+    expect(result.data).toMatchObject({ success: false });
+    expect(mockStoreTokens).not.toHaveBeenCalled();
+    expect(mockExecutedLabels).toEqual(["lookupAistudioCallbackNonce"]);
+  });
 });

--- a/tests/unit/agent-aistudio-oauth.test.ts
+++ b/tests/unit/agent-aistudio-oauth.test.ts
@@ -255,10 +255,12 @@ describe("AI Studio OAuth callback", () => {
     }
   );
 
-  it("rejects malformed state before querying or exchanging a code", async () => {
+  it("rejects unknown state through the single-use nonce lookup", async () => {
+    mockNonceAvailable = false;
+
     const result = await handleAistudioCallback("authorization-code", "bad");
     expect(result.data).toMatchObject({ success: false });
-    expect(mockExecutedLabels).toEqual([]);
+    expect(mockExecutedLabels).toEqual(["lookupAistudioCallbackNonce"]);
     expect(global.fetch).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/agent-aistudio-oauth.test.ts
+++ b/tests/unit/agent-aistudio-oauth.test.ts
@@ -1,0 +1,264 @@
+import { createHash } from "node:crypto";
+
+const mockCodeVerifier = "v".repeat(43);
+const mockOwnerEmail = "owner@psd401.net";
+const mockNonce = "a".repeat(64);
+let mockExecutedLabels: string[] = [];
+let mockNonceAvailable = true;
+let mockSessionEmail: string | null = mockOwnerEmail;
+
+const mockVerifyConsentToken = jest.fn();
+const mockStoreTokens = jest.fn();
+
+jest.mock("@/lib/auth/server-session", () => ({
+  getServerSession: jest.fn(async () =>
+    mockSessionEmail ? { email: mockSessionEmail } : null
+  ),
+}));
+
+jest.mock("@/lib/logger", () => ({
+  createLogger: () => ({
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  }),
+  sanitizeForLogging: (value: unknown) => value,
+  generateRequestId: () => "request-aistudio-test",
+  startTimer: () => () => undefined,
+}));
+
+jest.mock("@/lib/db/drizzle-client", () => ({
+  executeQuery: jest.fn(async (_callback: unknown, label: string) => {
+    mockExecutedLabels.push(label);
+    if (label === "lookupAistudioConsentNonce") {
+      return mockNonceAvailable
+        ? [{ codeVerifier: mockCodeVerifier, ownerEmail: mockOwnerEmail }]
+        : [];
+    }
+    if (label === "lookupAistudioCallbackNonce") {
+      return mockNonceAvailable
+        ? [
+            {
+              ownerEmail: mockOwnerEmail,
+              tokenKind: "aistudio",
+              codeVerifier: mockCodeVerifier,
+            },
+          ]
+        : [];
+    }
+    if (label === "consumeAistudioConsentNonce") {
+      return [{ nonce: mockNonce }];
+    }
+    return [];
+  }),
+}));
+
+jest.mock("@/lib/db/schema", () => ({
+  psdAgentWorkspaceConsentNonces: {},
+}));
+
+jest.mock("@/lib/agent-workspace/consent-token", () => ({
+  verifyConsentToken: (...args: unknown[]) =>
+    mockVerifyConsentToken(...args),
+}));
+
+jest.mock("@/lib/agent-workspace/secrets-manager", () => ({
+  storeAistudioOAuthTokens: (...args: unknown[]) => mockStoreTokens(...args),
+}));
+
+jest.mock("@/lib/oauth/issuer-config", () => ({
+  getIssuerUrl: () => "https://issuer.example",
+}));
+
+import {
+  handleAistudioCallback,
+  verifyAistudioConsentAndGetOAuthUrl,
+} from "@/actions/agent-aistudio.actions";
+import {
+  AISTUDIO_OPENCLAW_CLIENT_ID,
+  AISTUDIO_OPENCLAW_SCOPES,
+} from "@/lib/oauth/openclaw-client";
+
+function jsonResponse(body: Record<string, unknown>, status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  } as unknown as Response;
+}
+
+beforeEach(() => {
+  mockExecutedLabels = [];
+  mockNonceAvailable = true;
+  mockSessionEmail = mockOwnerEmail;
+  mockVerifyConsentToken.mockReset();
+  mockStoreTokens.mockReset();
+  mockStoreTokens.mockResolvedValue(undefined);
+  global.fetch = jest.fn();
+});
+
+describe("AI Studio OAuth consent", () => {
+  it("builds a public-client authorization URL with exact scopes and S256 PKCE", async () => {
+    mockVerifyConsentToken.mockResolvedValue({
+      sub: mockOwnerEmail,
+      kind: "aistudio",
+      nonce: mockNonce,
+    });
+
+    const result = await verifyAistudioConsentAndGetOAuthUrl("signed-token");
+    expect(result.isSuccess).toBe(true);
+    expect(result.data?.valid).toBe(true);
+
+    const oauthUrl = new URL(result.data?.oauthUrl ?? "");
+    expect(`${oauthUrl.origin}${oauthUrl.pathname}`).toBe(
+      "https://issuer.example/api/oauth/auth"
+    );
+    expect(oauthUrl.searchParams.get("client_id")).toBe(
+      AISTUDIO_OPENCLAW_CLIENT_ID
+    );
+    expect(oauthUrl.searchParams.get("state")).toBe(mockNonce);
+    expect(oauthUrl.searchParams.get("scope")).toBe(
+      AISTUDIO_OPENCLAW_SCOPES.join(" ")
+    );
+    expect(oauthUrl.searchParams.get("code_challenge_method")).toBe("S256");
+    expect(oauthUrl.searchParams.get("code_challenge")).toBe(
+      createHash("sha256").update(mockCodeVerifier).digest("base64url")
+    );
+  });
+
+  it("rejects an expired or consumed nonce", async () => {
+    mockVerifyConsentToken.mockResolvedValue({
+      sub: mockOwnerEmail,
+      kind: "aistudio",
+      nonce: mockNonce,
+    });
+    mockNonceAvailable = false;
+
+    const result = await verifyAistudioConsentAndGetOAuthUrl("signed-token");
+    expect(result.data).toMatchObject({ valid: false });
+    expect(result.data?.error).toMatch(/expired|already used/i);
+  });
+
+  it("rejects a signed token whose owner does not match the nonce owner", async () => {
+    mockVerifyConsentToken.mockResolvedValue({
+      sub: "different-owner@psd401.net",
+      kind: "aistudio",
+      nonce: mockNonce,
+    });
+    mockSessionEmail = "different-owner@psd401.net";
+
+    const result = await verifyAistudioConsentAndGetOAuthUrl("signed-token");
+    expect(result.data).toMatchObject({ valid: false });
+    expect(result.data?.oauthUrl).toBeUndefined();
+  });
+
+  it.each([null, "attacker@psd401.net"])(
+    "rejects a consent link when the live session is %s",
+    async (sessionEmail) => {
+      mockSessionEmail = sessionEmail;
+      mockVerifyConsentToken.mockResolvedValue({
+        sub: mockOwnerEmail,
+        kind: "aistudio",
+        nonce: mockNonce,
+      });
+
+      const result =
+        await verifyAistudioConsentAndGetOAuthUrl("signed-token");
+
+      expect(result.data).toMatchObject({ valid: false });
+      expect(result.data?.oauthUrl).toBeUndefined();
+      expect(mockExecutedLabels).toEqual([]);
+    }
+  );
+});
+
+describe("AI Studio OAuth callback", () => {
+  it("stores rotating OAuth tokens and consumes the nonce for the same identity", async () => {
+    const fetchMock = jest
+      .fn()
+      .mockResolvedValueOnce(
+        jsonResponse({
+          access_token: "access-token",
+          refresh_token: "refresh-token",
+          token_type: "Bearer",
+          scope: AISTUDIO_OPENCLAW_SCOPES.join(" "),
+          expires_in: 900,
+        })
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({ sub: "user-1", email: mockOwnerEmail })
+      );
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const result = await handleAistudioCallback("authorization-code", mockNonce);
+
+    expect(result.data).toEqual({
+      success: true,
+      ownerEmail: mockOwnerEmail,
+    });
+    expect(mockStoreTokens).toHaveBeenCalledWith(
+      mockOwnerEmail,
+      expect.objectContaining({
+        access_token: "access-token",
+        refresh_token: "refresh-token",
+        token_type: "Bearer",
+      })
+    );
+    expect(mockExecutedLabels).toContain("consumeAistudioConsentNonce");
+
+    const tokenRequest = fetchMock.mock.calls[0];
+    expect(tokenRequest[0]).toBe("https://issuer.example/api/oauth/token");
+    expect(String(tokenRequest[1]?.body)).toContain(
+      `client_id=${AISTUDIO_OPENCLAW_CLIENT_ID}`
+    );
+    expect(String(tokenRequest[1]?.body)).toContain(
+      `code_verifier=${mockCodeVerifier}`
+    );
+  });
+
+  it("does not store tokens or consume the nonce when userinfo identifies another user", async () => {
+    global.fetch = jest
+      .fn()
+      .mockResolvedValueOnce(
+        jsonResponse({
+          access_token: "access-token",
+          refresh_token: "refresh-token",
+          expires_in: 900,
+        })
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({ email: "someone-else@psd401.net" })
+      ) as unknown as typeof fetch;
+
+    const result = await handleAistudioCallback("authorization-code", mockNonce);
+
+    expect(result.data).toMatchObject({ success: false });
+    expect(mockStoreTokens).not.toHaveBeenCalled();
+    expect(mockExecutedLabels).not.toContain("consumeAistudioConsentNonce");
+  });
+
+  it.each([null, "attacker@psd401.net"])(
+    "rejects the callback when the live session is %s",
+    async (sessionEmail) => {
+      mockSessionEmail = sessionEmail;
+
+      const result = await handleAistudioCallback(
+        "authorization-code",
+        mockNonce
+      );
+
+      expect(result.data).toMatchObject({ success: false });
+      expect(mockStoreTokens).not.toHaveBeenCalled();
+      expect(mockExecutedLabels).toEqual(["lookupAistudioCallbackNonce"]);
+      expect(global.fetch).not.toHaveBeenCalled();
+    }
+  );
+
+  it("rejects malformed state before querying or exchanging a code", async () => {
+    const result = await handleAistudioCallback("authorization-code", "bad");
+    expect(result.data).toMatchObject({ success: false });
+    expect(mockExecutedLabels).toEqual([]);
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/agent-aistudio-route.test.ts
+++ b/tests/unit/agent-aistudio-route.test.ts
@@ -10,13 +10,23 @@ let context:
   mode: "owner",
 }
 
+const getSecretJsonMock = jest.fn()
 const getSecretStringMock = jest.fn()
+const storeAistudioOAuthTokensMock = jest.fn()
+const deleteAistudioOAuthSecretMock = jest.fn()
 
 jest.mock("@/lib/agent-workspace/invocation-context", () => ({
   verifyAgentInvocationContext: jest.fn(async () => context),
 }))
 jest.mock("@/lib/agent-workspace/secrets-manager", () => ({
+  aistudioOAuthSecretId: (ownerEmail: string) =>
+    `psd-agent-creds/test/user/${ownerEmail}/aistudio_oauth`,
+  deleteAistudioOAuthSecret: (...args: unknown[]) =>
+    deleteAistudioOAuthSecretMock(...args),
+  getSecretJson: (...args: unknown[]) => getSecretJsonMock(...args),
   getSecretString: (...args: unknown[]) => getSecretStringMock(...args),
+  storeAistudioOAuthTokens: (...args: unknown[]) =>
+    storeAistudioOAuthTokensMock(...args),
 }))
 jest.mock("@/lib/logger", () => ({
   createLogger: () => ({
@@ -40,6 +50,17 @@ function request(body: unknown): NextRequest {
 }
 
 const originalFetch = globalThis.fetch
+const originalAuthUrl = process.env.AUTH_URL
+
+function jsonResponse(body: Record<string, unknown>, status = 200): Response {
+  const serialized = JSON.stringify(body)
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+    text: async () => serialized,
+  } as unknown as Response
+}
 
 beforeEach(() => {
   context = {
@@ -48,23 +69,28 @@ beforeEach(() => {
     mode: "owner",
   }
   process.env.APP_BASE_URL = "https://app.example"
+  process.env.AUTH_URL = "https://app.example"
   process.env.ENVIRONMENT = "test"
+  getSecretJsonMock.mockReset().mockResolvedValue(null)
   getSecretStringMock.mockReset().mockResolvedValue("personal-key")
+  storeAistudioOAuthTokensMock.mockReset().mockResolvedValue(undefined)
+  deleteAistudioOAuthSecretMock.mockReset().mockResolvedValue(true)
   globalThis.fetch = jest.fn(async () =>
-    ({
-      status: 200,
-      text: async () =>
-        JSON.stringify({
-          jsonrpc: "2.0",
-          id: "upstream",
-          result: { ok: true },
-        }),
-    }) as Response
+    jsonResponse({
+      jsonrpc: "2.0",
+      id: "upstream",
+      result: { ok: true },
+    })
   ) as typeof fetch
 })
 
 afterAll(() => {
   globalThis.fetch = originalFetch
+  if (originalAuthUrl === undefined) {
+    delete process.env.AUTH_URL
+  } else {
+    process.env.AUTH_URL = originalAuthUrl
+  }
 })
 
 describe("POST /api/agent/aistudio", () => {
@@ -89,6 +115,7 @@ describe("POST /api/agent/aistudio", () => {
         )
       ).status
     ).toBe(400)
+    expect(getSecretJsonMock).not.toHaveBeenCalled()
     expect(getSecretStringMock).not.toHaveBeenCalled()
   })
 
@@ -125,6 +152,130 @@ describe("POST /api/agent/aistudio", () => {
     expect(await response.json()).toEqual(
       expect.objectContaining({ keySource: "shared", httpStatus: 200 })
     )
+  })
+
+  it("uses the signed owner's current OAuth access token without exposing it", async () => {
+    getSecretJsonMock.mockResolvedValue({
+      access_token: "owner-oauth-token",
+      refresh_token: "owner-refresh-token",
+      token_type: "Bearer",
+      scope: "repositories:list",
+      obtained_at: new Date().toISOString(),
+      expires_at: new Date(Date.now() + 15 * 60_000).toISOString(),
+    })
+
+    const response = await POST(request({ method: "tools/list", params: {} }))
+
+    expect(response.status).toBe(200)
+    expect(getSecretJsonMock).toHaveBeenCalledWith(
+      "psd-agent-creds/test/user/owner@psd401.net/aistudio_oauth"
+    )
+    expect(getSecretStringMock).not.toHaveBeenCalled()
+    const fetchCall = (globalThis.fetch as jest.Mock).mock.calls[0]
+    expect(fetchCall[1].headers.Authorization).toBe(
+      "Bearer owner-oauth-token"
+    )
+    const payload = await response.json()
+    expect(payload).toEqual(
+      expect.objectContaining({ keySource: "oauth", httpStatus: 200 })
+    )
+    expect(JSON.stringify(payload)).not.toContain("owner-oauth-token")
+    expect(JSON.stringify(payload)).not.toContain("owner-refresh-token")
+  })
+
+  it("refreshes and persists a rotating OAuth grant before using it", async () => {
+    getSecretJsonMock.mockResolvedValue({
+      access_token: "expired-oauth-token",
+      refresh_token: "old-refresh-token",
+      token_type: "Bearer",
+      scope: "repositories:list",
+      obtained_at: new Date(Date.now() - 30 * 60_000).toISOString(),
+      expires_at: new Date(Date.now() - 60_000).toISOString(),
+    })
+    globalThis.fetch = jest
+      .fn()
+      .mockResolvedValueOnce(
+        jsonResponse({
+          access_token: "fresh-oauth-token",
+          refresh_token: "new-refresh-token",
+          expires_in: 900,
+          scope: "repositories:list repositories:search",
+        })
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({
+          jsonrpc: "2.0",
+          id: "upstream",
+          result: { ok: true },
+        })
+      ) as typeof fetch
+
+    const response = await POST(request({ method: "tools/list", params: {} }))
+
+    expect(response.status).toBe(200)
+    const refreshCall = (globalThis.fetch as jest.Mock).mock.calls[0]
+    expect(String(refreshCall[0])).toBe(
+      "https://app.example/api/oauth/token"
+    )
+    expect(String(refreshCall[1].body)).toContain(
+      "refresh_token=old-refresh-token"
+    )
+    expect(refreshCall[1].redirect).toBe("error")
+    expect(storeAistudioOAuthTokensMock).toHaveBeenCalledWith(
+      "owner@psd401.net",
+      expect.objectContaining({
+        access_token: "fresh-oauth-token",
+        refresh_token: "new-refresh-token",
+      })
+    )
+    const mcpCall = (globalThis.fetch as jest.Mock).mock.calls[1]
+    expect(mcpCall[1].headers.Authorization).toBe("Bearer fresh-oauth-token")
+  })
+
+  it("revokes and removes only the signed owner's OAuth grant", async () => {
+    getSecretJsonMock.mockResolvedValue({
+      access_token: "owner-oauth-token",
+      refresh_token: "owner-refresh-token",
+      token_type: "Bearer",
+      scope: "repositories:list",
+      obtained_at: new Date().toISOString(),
+      expires_at: new Date(Date.now() + 15 * 60_000).toISOString(),
+    })
+    globalThis.fetch = jest.fn(async () => jsonResponse({})) as typeof fetch
+
+    const response = await POST(request({ operation: "disconnect" }))
+
+    expect(response.status).toBe(200)
+    const responseBody = await response.json()
+    expect(responseBody).toEqual({ disconnected: true })
+    expect(getSecretJsonMock).toHaveBeenCalledWith(
+      "psd-agent-creds/test/user/owner@psd401.net/aistudio_oauth"
+    )
+    const revokeCall = (globalThis.fetch as jest.Mock).mock.calls[0]
+    expect(String(revokeCall[0])).toBe(
+      "https://app.example/api/oauth/revocation"
+    )
+    expect(String(revokeCall[1].body)).toContain(
+      "token=owner-refresh-token"
+    )
+    expect(deleteAistudioOAuthSecretMock).toHaveBeenCalledWith(
+      "owner@psd401.net"
+    )
+    expect(JSON.stringify(responseBody)).not.toContain("owner-refresh-token")
+  })
+
+  it("rejects scheduled disconnects before reading the owner secret", async () => {
+    context = {
+      ownerEmail: "owner@psd401.net",
+      actorEmail: "scheduler@psd401.net",
+      mode: "scheduled",
+    }
+
+    const response = await POST(request({ operation: "disconnect" }))
+
+    expect(response.status).toBe(403)
+    expect(getSecretJsonMock).not.toHaveBeenCalled()
+    expect(deleteAistudioOAuthSecretMock).not.toHaveBeenCalled()
   })
 
   it("rejects malformed tool calls before reading credentials", async () => {

--- a/tests/unit/agent-aistudio-secret-cache.test.ts
+++ b/tests/unit/agent-aistudio-secret-cache.test.ts
@@ -1,0 +1,129 @@
+/** @jest-environment node */
+
+const mockSecretsSend = jest.fn()
+
+jest.mock("@aws-sdk/client-secrets-manager", () => ({
+  CreateSecretCommand: jest.fn((input: unknown) => ({
+    command: "create",
+    input,
+  })),
+  DeleteSecretCommand: jest.fn((input: unknown) => ({
+    command: "delete",
+    input,
+  })),
+  DescribeSecretCommand: jest.fn((input: unknown) => ({
+    command: "describe",
+    input,
+  })),
+  GetSecretValueCommand: jest.fn((input: unknown) => ({
+    command: "get",
+    input,
+  })),
+  PutSecretValueCommand: jest.fn((input: unknown) => ({
+    command: "put",
+    input,
+  })),
+  ResourceNotFoundException: class ResourceNotFoundException extends Error {},
+  SecretsManagerClient: jest.fn(() => ({ send: mockSecretsSend })),
+}))
+
+import {
+  aistudioOAuthSecretId,
+  deleteAistudioOAuthSecret,
+  getSecretJson,
+  storeAistudioOAuthTokens,
+  type AistudioOAuthTokenData,
+} from "@/lib/agent-workspace/secrets-manager"
+
+interface MockCommand {
+  command: "create" | "delete" | "describe" | "get" | "put"
+  input: {
+    SecretId?: string
+    SecretString?: string
+  }
+}
+
+function tokenData(accessToken: string): AistudioOAuthTokenData {
+  return {
+    access_token: accessToken,
+    refresh_token: `${accessToken}-refresh`,
+    token_type: "Bearer",
+    scope: "mcp",
+    expires_at: "2026-07-26T23:00:00.000Z",
+    obtained_at: "2026-07-26T22:00:00.000Z",
+  }
+}
+
+describe("AI Studio OAuth secret cache invalidation", () => {
+  const originalNodeEnv = process.env.NODE_ENV
+  let storedSecret: string | null
+
+  beforeEach(() => {
+    Object.defineProperty(process.env, "NODE_ENV", {
+      configurable: true,
+      value: "test",
+    })
+    storedSecret = JSON.stringify(tokenData("old-access-token"))
+    mockSecretsSend.mockReset().mockImplementation((rawCommand: MockCommand) => {
+      const command = rawCommand
+      if (command.command === "get") {
+        return Promise.resolve({ SecretString: storedSecret ?? undefined })
+      }
+      if (command.command === "put") {
+        storedSecret = command.input.SecretString ?? null
+        return Promise.resolve({ ARN: "arn:aws:secretsmanager:test:aistudio" })
+      }
+      if (command.command === "delete") {
+        storedSecret = null
+        return Promise.resolve({})
+      }
+      return Promise.resolve({ ARN: "arn:aws:secretsmanager:test:aistudio" })
+    })
+  })
+
+  afterEach(() => {
+    Object.defineProperty(process.env, "NODE_ENV", {
+      configurable: true,
+      value: originalNodeEnv,
+    })
+  })
+
+  it("does not serve a stale token after rotating the stored secret", async () => {
+    const ownerEmail = "cache-rotate@example.com"
+    const secretId = aistudioOAuthSecretId(ownerEmail)
+
+    await expect(
+      getSecretJson<AistudioOAuthTokenData>(secretId)
+    ).resolves.toMatchObject({ access_token: "old-access-token" })
+
+    await storeAistudioOAuthTokens(ownerEmail, tokenData("new-access-token"))
+
+    await expect(
+      getSecretJson<AistudioOAuthTokenData>(secretId)
+    ).resolves.toMatchObject({ access_token: "new-access-token" })
+    expect(
+      mockSecretsSend.mock.calls.filter(
+        ([command]) => (command as MockCommand).command === "get"
+      )
+    ).toHaveLength(2)
+  })
+
+  it("does not serve a cached token after disconnect deletes the secret", async () => {
+    const ownerEmail = "cache-delete@example.com"
+    const secretId = aistudioOAuthSecretId(ownerEmail)
+
+    await expect(
+      getSecretJson<AistudioOAuthTokenData>(secretId)
+    ).resolves.toMatchObject({ access_token: "old-access-token" })
+
+    await expect(deleteAistudioOAuthSecret(ownerEmail)).resolves.toBe(true)
+    await expect(
+      getSecretJson<AistudioOAuthTokenData>(secretId)
+    ).resolves.toBeNull()
+    expect(
+      mockSecretsSend.mock.calls.filter(
+        ([command]) => (command as MockCommand).command === "get"
+      )
+    ).toHaveLength(2)
+  })
+})

--- a/tests/unit/lib/api/rate-limiter.test.ts
+++ b/tests/unit/lib/api/rate-limiter.test.ts
@@ -57,8 +57,10 @@ jest.mock("@/lib/db/schema", () => ({
 }))
 
 jest.mock("drizzle-orm", () => ({
+  and: jest.fn(),
   eq: jest.fn(),
   count: jest.fn(),
+  gte: jest.fn(),
   lt: jest.fn(),
   sql: jest.fn((parts: TemplateStringsArray) => parts.join("?")),
 }))
@@ -168,6 +170,14 @@ describe("Rate Limiter", () => {
       expect(result.allowed).toBe(true)
       expect(result.limit).toBe(60)
       expect(result.remaining).toBe(29) // 60 - 30 - 1 (current)
+      // The typed operator applies the timestamp column encoder. A raw SQL
+      // interpolation passes Date directly to postgres.js and fails closed.
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const { gte } = require("drizzle-orm") as { gte: jest.Mock }
+      expect(gte).toHaveBeenCalledWith(
+        "request_at",
+        expect.any(Date)
+      )
     })
 
     it("should deny requests exceeding limit", async () => {

--- a/tests/unit/lib/nexus/attachment-repository-tool.test.ts
+++ b/tests/unit/lib/nexus/attachment-repository-tool.test.ts
@@ -23,7 +23,10 @@ jest.mock("ai", () => ({
   tool: (definition: unknown) => definition,
 }));
 
-import { createNexusAttachmentTools } from "@/lib/nexus/attachment-repository-tool";
+import {
+  createNexusAttachmentTools,
+  createNexusRepositorySearchTools,
+} from "@/lib/nexus/attachment-repository-tool";
 import { createTokenMappingSink } from "@/lib/safety/token-mapping-sink";
 import { ContentSafetyBlockedError } from "@/lib/streaming/types";
 
@@ -98,6 +101,29 @@ describe("Nexus attachment repository tool", () => {
       userCognitoSub: "executing-user",
       mode: "hybrid",
       limit: 3,
+    });
+  });
+
+  it("supports server-named project and skill repository tools with the same safety boundary", async () => {
+    const tools = createNexusRepositorySearchTools({
+      repositoryIds: [7],
+      userCognitoSub: "executing-user",
+      tokenMappingSink: createTokenMappingSink(),
+      toolName: "searchProjectRepositories",
+      description: "Search project repositories",
+    });
+    const search = tools.searchProjectRepositories as unknown as SearchTool;
+
+    await expect(search.execute({ query: "attendance" })).resolves.toMatchObject({
+      success: true,
+      results: [{ content: "Budgeted source" }],
+    });
+    expect(mockRetrieveRepositoryContent).toHaveBeenCalledWith({
+      query: "attendance",
+      repositoryIds: [7],
+      userCognitoSub: "executing-user",
+      mode: "hybrid",
+      limit: 5,
     });
   });
 

--- a/tests/unit/lib/repositories/repository-catalog-service.test.ts
+++ b/tests/unit/lib/repositories/repository-catalog-service.test.ts
@@ -1,0 +1,184 @@
+/** @jest-environment node */
+
+import { PgDialect } from "drizzle-orm/pg-core";
+import type { SQL } from "drizzle-orm";
+
+jest.mock("server-only", () => ({}));
+
+const mockAccessibleRepositories = jest.fn();
+const mockAccessibleIds = jest.fn();
+const mockRetrieve = jest.fn();
+const mockExecuteQuery = jest.fn();
+
+jest.mock("@/lib/db/drizzle", () => ({
+  getUserAccessibleRepositories: (...args: unknown[]) =>
+    mockAccessibleRepositories(...args),
+  getAccessibleRepositoryIds: (...args: unknown[]) =>
+    mockAccessibleIds(...args),
+}));
+jest.mock("@/lib/db/drizzle-client", () => ({
+  executeQuery: (...args: unknown[]) => mockExecuteQuery(...args),
+  toPgRows: (value: unknown) => value,
+}));
+jest.mock("@/lib/repositories/retrieval-v2/service", () => ({
+  retrieveRepositoryContent: (...args: unknown[]) => mockRetrieve(...args),
+}));
+
+import {
+  describeRepository,
+  getRepositorySource,
+  listRepositoryCatalog,
+  searchRepositoryCatalog,
+} from "@/lib/repositories/repository-catalog-service";
+
+const accessibleRows = [
+  {
+    id: 4,
+    name: "District Policies",
+    description: "Board and administrative policy",
+    ownerId: 2,
+    ownerName: "Policy Office",
+    isPublic: false,
+    repositoryKind: "durable" as const,
+    lifecycleStatus: "active" as const,
+    retentionDays: null,
+    expiresAt: null,
+    activeIndexGenerationId: "generation-4",
+    metadata: {},
+    createdAt: new Date("2026-01-01T00:00:00Z"),
+    updatedAt: new Date("2026-02-01T00:00:00Z"),
+    itemCount: 3,
+    lastUpdated: new Date("2026-02-02T00:00:00Z"),
+  },
+  {
+    id: 9,
+    name: "Curriculum",
+    description: null,
+    ownerId: 3,
+    ownerName: null,
+    isPublic: true,
+    repositoryKind: "durable" as const,
+    lifecycleStatus: "active" as const,
+    retentionDays: null,
+    expiresAt: null,
+    activeIndexGenerationId: null,
+    metadata: {},
+    createdAt: null,
+    updatedAt: null,
+    itemCount: 0,
+    lastUpdated: null,
+  },
+];
+
+describe("repository catalog service", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockAccessibleRepositories.mockResolvedValue(accessibleRows);
+  });
+
+  it("lists and describes only the repositories returned by the live ACL query", async () => {
+    await expect(
+      listRepositoryCatalog("caller-sub", { query: "policy" })
+    ).resolves.toEqual([
+      {
+        id: 4,
+        name: "District Policies",
+        description: "Board and administrative policy",
+        ownerName: "Policy Office",
+        visibility: "private",
+        itemCount: 3,
+        activeIndexGenerationId: "generation-4",
+        lastUpdated: "2026-02-02T00:00:00.000Z",
+        createdAt: "2026-01-01T00:00:00.000Z",
+        updatedAt: "2026-02-01T00:00:00.000Z",
+      },
+    ]);
+    await expect(describeRepository("caller-sub", 9)).resolves.toMatchObject({
+      id: 9,
+      visibility: "public",
+    });
+    await expect(describeRepository("caller-sub", 99)).resolves.toBeNull();
+    expect(mockAccessibleRepositories).toHaveBeenCalledWith("caller-sub");
+  });
+
+  it("uses retrieval v2 with current accessible repositories when ids are omitted", async () => {
+    mockRetrieve.mockResolvedValue({ results: [], diagnostics: {} });
+    await searchRepositoryCatalog({
+      cognitoSub: "caller-sub",
+      query: "graduation",
+      mode: "hybrid",
+      limit: 5,
+    });
+    expect(mockRetrieve).toHaveBeenCalledWith({
+      query: "graduation",
+      repositoryIds: [4, 9],
+      userCognitoSub: "caller-sub",
+      mode: "hybrid",
+      modalities: undefined,
+      limit: 5,
+      threshold: undefined,
+    });
+  });
+
+  it("source disclosure pins the active generation/current version and rechecks both ACL layers", async () => {
+    let compiledSql = "";
+    mockExecuteQuery.mockImplementation(
+      async (
+        callback: (db: {
+          execute(query: SQL): Array<Record<string, unknown>>;
+        }) => unknown
+      ) =>
+        callback({
+          execute(query) {
+            compiledSql = new PgDialect().sqlToQuery(query).sql;
+            return [
+              {
+                chunk_id: 12,
+                item_id: 8,
+                item_stable_id: "stable",
+                item_name: "Handbook",
+                item_version_id: "version",
+                version_number: 3,
+                chunk_index: 2,
+                modality: "text",
+                content: "Allowed content",
+                context_prefix: "Page 3",
+                source_locator: { page: 3 },
+              },
+            ];
+          },
+        })
+    );
+
+    await expect(
+      getRepositorySource({
+        userId: 42,
+        repositoryId: 4,
+        itemId: 8,
+        chunkId: 12,
+      })
+    ).resolves.toEqual([
+      {
+        chunkId: 12,
+        itemId: 8,
+        itemStableId: "stable",
+        itemName: "Handbook",
+        itemVersionId: "version",
+        versionNumber: 3,
+        chunkIndex: 2,
+        modality: "text",
+        content: "Allowed content",
+        contextPrefix: "Page 3",
+        sourceLocator: { page: 3 },
+      },
+    ]);
+    expect(compiledSql).toContain(
+      "chunk.index_generation_id = repository.active_index_generation_id"
+    );
+    expect(compiledSql).toContain("version.id = item.current_version_id");
+    expect(compiledSql).toContain("repository.metadata ->> 'systemManaged'");
+    expect(compiledSql).toContain("FROM repository_access repository_acl");
+    expect(compiledSql).toContain("chunk.access_scope");
+    expect(compiledSql).toContain("FROM user_roles membership");
+  });
+});

--- a/tests/unit/lib/skills/skill-tool-executor.test.ts
+++ b/tests/unit/lib/skills/skill-tool-executor.test.ts
@@ -15,6 +15,9 @@ jest.mock("@/lib/db/drizzle-client", () => ({
 jest.mock("@/lib/db/schema/tables/agent-skills", () => ({
   psdAgentSkills: {},
 }))
+jest.mock("@/lib/db/schema/tables/skill-repository-bindings", () => ({
+  skillRepositoryBindings: {},
+}))
 jest.mock("drizzle-orm", () => ({
   and: (...a: unknown[]) => a,
   eq: (...a: unknown[]) => a,

--- a/tests/unit/skill-tool-enforcement.test.ts
+++ b/tests/unit/skill-tool-enforcement.test.ts
@@ -14,6 +14,9 @@ jest.mock("@/lib/db/drizzle-client", () => ({
 jest.mock("@/lib/db/schema/tables/agent-skills", () => ({
   psdAgentSkills: {},
 }))
+jest.mock("@/lib/db/schema/tables/skill-repository-bindings", () => ({
+  skillRepositoryBindings: {},
+}))
 jest.mock("drizzle-orm", () => ({
   and: (...a: unknown[]) => a,
   eq: (...a: unknown[]) => a,
@@ -139,13 +142,15 @@ describe("getApprovedSkillAllowedTools (DB path)", () => {
 
   it("returns the skill's allowed-tools when approved", async () => {
     // The underlying getApprovedSkillSession query now also selects name/s3Key.
-    executeQueryMock.mockResolvedValue([
-      {
-        name: "weather-helper",
-        allowedTools: ["webSearch", "imageGen"],
-        s3Key: "skills/shared/weather-helper/",
-      },
-    ])
+    executeQueryMock
+      .mockResolvedValueOnce([
+        {
+          name: "weather-helper",
+          allowedTools: ["webSearch", "imageGen"],
+          s3Key: "skills/shared/weather-helper/",
+        },
+      ])
+      .mockResolvedValueOnce([{ repositoryId: 41 }])
     await expect(getApprovedSkillAllowedTools("11111111-2222-4333-8444-555555555555")).resolves.toEqual([
       "webSearch",
       "imageGen",
@@ -155,9 +160,11 @@ describe("getApprovedSkillAllowedTools (DB path)", () => {
   it("returns an empty array (no pin) when allowedTools is null in the row", async () => {
     // An approved skill that pins nothing stores null/non-array; the accessor
     // normalizes to [] so callers keep all available tools (no pin), NOT null.
-    executeQueryMock.mockResolvedValue([
-      { name: "no-pin", allowedTools: null, s3Key: "skills/shared/no-pin/" },
-    ])
+    executeQueryMock
+      .mockResolvedValueOnce([
+        { name: "no-pin", allowedTools: null, s3Key: "skills/shared/no-pin/" },
+      ])
+      .mockResolvedValueOnce([])
     await expect(getApprovedSkillAllowedTools("11111111-2222-4333-8444-555555555555")).resolves.toEqual([])
   })
 })
@@ -167,18 +174,24 @@ describe("getApprovedSkillSession (epic #922 completion audit)", () => {
     executeQueryMock.mockReset()
   })
 
-  it("returns name, allowedTools, and s3Key for an approved skill", async () => {
-    executeQueryMock.mockResolvedValue([
-      {
-        name: "weather-helper",
-        allowedTools: ["documents.create@v1"],
-        s3Key: "skills/shared/weather-helper/",
-      },
-    ])
+  it("returns instructions, tool pins, and live repository bindings for an approved skill", async () => {
+    executeQueryMock
+      .mockResolvedValueOnce([
+        {
+          name: "weather-helper",
+          allowedTools: ["documents.create@v1"],
+          s3Key: "skills/shared/weather-helper/",
+        },
+      ])
+      .mockResolvedValueOnce([
+        { repositoryId: 41 },
+        { repositoryId: 87 },
+      ])
     await expect(getApprovedSkillSession("11111111-2222-4333-8444-555555555555")).resolves.toEqual({
       name: "weather-helper",
       allowedTools: ["documents.create@v1"],
       s3Key: "skills/shared/weather-helper/",
+      repositoryIds: [41, 87],
     })
   })
 
@@ -190,13 +203,16 @@ describe("getApprovedSkillSession (epic #922 completion audit)", () => {
   })
 
   it("normalizes a null allowedTools column to an empty pin", async () => {
-    executeQueryMock.mockResolvedValue([
-      { name: "no-pin", allowedTools: null, s3Key: "skills/shared/no-pin/" },
-    ])
+    executeQueryMock
+      .mockResolvedValueOnce([
+        { name: "no-pin", allowedTools: null, s3Key: "skills/shared/no-pin/" },
+      ])
+      .mockResolvedValueOnce([])
     await expect(getApprovedSkillSession("11111111-2222-4333-8444-555555555555")).resolves.toEqual({
       name: "no-pin",
       allowedTools: [],
       s3Key: "skills/shared/no-pin/",
+      repositoryIds: [],
     })
   })
 })


### PR DESCRIPTION
Closes #1266
Part of #1261

## Why this issue

The durable plan and epic identify OpenClaw/agent repository access and Nexus Projects as the first incomplete, unblocked workstream after the unified-content foundation and security prerequisite. No open or merged PR already implemented #1266; #1267 remains the later migration/cutover workstream.

## What changed

- adds catalog-backed repository list, describe, search, exact-source, and change operations across MCP, internal catalog dispatch, and scoped `/api/v1` REST routes
- enforces current repository, item, active-generation, and segment ACLs at retrieval/disclosure time with granular `repositories:*` scopes
- adds owner-bound AI Studio delegated OAuth for OpenClaw using a protected same-owner browser session, one-time state/nonce, S256 PKCE, fixed public client metadata, rotating refresh tokens, revocation, and server-only Secrets Manager storage
- keeps model-selected user input out of the credential boundary; the router-signed invocation owner is authoritative and no token/API key is returned to the model runtime
- extends `psd-aistudio` with repository discovery/search/source/change commands while preserving manual personal-key compatibility
- persists skill-to-repository bindings and resolves the current active repository generation at execution time
- adds Nexus Projects with a private durable repository, connected repositories, owner/editor/viewer membership, instructions, and durable user-owned project chats
- adds additive migration `139-unified-content-agents-projects.sql`, Drizzle schema, REST/OpenAPI documentation, feature documentation, and the durable-plan delivery ledger
- invalidates the local OAuth secret cache after token rotation and disconnect so revoked/stale credentials cannot remain usable in-process
- fixes the durable API limiter’s timestamp predicate so postgres.js encodes the sliding-window boundary instead of failing closed with a false first-request 429

## Verification

- `bun run typecheck`
- `bun run lint` — 0 errors (existing warnings only, including parallel worktrees)
- `bunx jest --config=jest.config.ci.js --runInBand --modulePathIgnorePatterns '<rootDir>/infra/cdk.out/' '<rootDir>/.next/' '<rootDir>/.claude/worktrees/'` — 409 suites, 3,930 tests passed
- focused durable rate-limiter regression suite — 18 passed
- direct durable rate-limit reservation against PostgreSQL — first request allowed and reservation committed
- focused AI Studio OAuth/route/cache tests — 20 passed
- focused unified-content feature suites — 69 passed
- OpenClaw `psd-aistudio` tests — 36 passed
- `bun run test:smoke:agents-projects` against PostgreSQL — migration replay, OAuth client, project/member/repository ACL, conversation, revocation, and cleanup lifecycle passed
- authenticated/guard Playwright delivery set against an isolated fully migrated PostgreSQL lane — 7 passed (AI Studio session/invocation guards; Nexus project context, membership, private files, and chat; scoped REST/MCP repository catalog; change listing; key revocation; unauthenticated rejection)
- `bun run openapi:check`
- `bun run capabilities:check`
- `cd infra && bun run build`
- `cd infra && bunx cdk synth --all --no-lookups --context baseDomain=example.com`
- Codex Security diff scan — 47/47 source-file receipts, canonical contract valid, no reportable findings

## Migration and rollout

- migration 139 is additive and idempotent; migrations 001–005 are unchanged
- existing Nexus conversations remain valid with `project_id = NULL`
- new tables/FKs/indexes and the `nexus_projects.updated_at` trigger are created without backfilling existing content
- migration 139 passed both the isolated full-manifest replay and GitHub’s Unified Content PostgreSQL Lifecycle job on the prior head; the current head reruns that job
- the first-party OpenClaw public client uses Authorization Code + PKCE and exact registered redirects/scopes; no client secret is introduced
- rollback SQL is documented in the migration header
- no legacy repository cutover or deletion is included; that remains #1267

## Remaining risks / known baseline

- the application production build currently fails on `origin/dev` because the unrelated roster admin client imports server-only Winston/Postgres/AWS modules. This branch does not touch that surface; typecheck, lint, tests, migration validation, and CDK synth pass.
- deployment still requires the normal database migration Lambda and frontend rollout; no protected environment was mutated from this branch.
