### PR TITLE
fix(frontend): install the MUSL gws build — glibc binary cannot run on alpine (deploy blocker)

### DIFF
--- a/Dockerfile.graviton
+++ b/Dockerfile.graviton
@@ -84,10 +84,18 @@ RUN apk add --no-cache curl su-exec libc6-compat
 # AgentCore image has no raw binary or OAuth token; requests arrive here through
 # the owner-bound /api/agent/workspace-execute policy broker.
 ARG GWS_VERSION=0.22.5
-ARG GWS_SHA256=94490295d9580e1e88574e715a0a162991747d12d62f8c7b8dcc8268b6c1cea0
+# MUSL build, not gnu. This stage is node:22-alpine, so the glibc artifact
+# installs fine and then dies at first exec with
+# "Error relocating /usr/local/bin/gws: __res_init: symbol not found" —
+# gcompat does not implement glibc's resolver symbols. Because the RUN ends in
+# `gws --version`, that failure surfaces at BUILD time, which is the one good
+# thing about it. When bumping the version, take the digest from the MUSL
+# sidecar:
+#   curl -sL "https://github.com/googleworkspace/cli/releases/download/v<VER>/google-workspace-cli-aarch64-unknown-linux-musl.tar.gz.sha256"
+ARG GWS_SHA256=e700fe63524932b10ec2130b47ece90aa850e66005fe52ccfc4cf8767bf9919a
 RUN set -eux; \
     curl -fsSL -o /tmp/gws.tar.gz \
-      "https://github.com/googleworkspace/cli/releases/download/v${GWS_VERSION}/google-workspace-cli-aarch64-unknown-linux-gnu.tar.gz"; \
+      "https://github.com/googleworkspace/cli/releases/download/v${GWS_VERSION}/google-workspace-cli-aarch64-unknown-linux-musl.tar.gz"; \
     echo "${GWS_SHA256}  /tmp/gws.tar.gz" | sha256sum -c -; \
     tar -xzf /tmp/gws.tar.gz -C /tmp ./gws; \
     install -m 0755 /tmp/gws /usr/local/bin/gws; \


### PR DESCRIPTION
## `cdk deploy` fails before it reaches application code

`AIStudio-FrontendStack-ECS-Dev` cannot build its image on dev:

```
+ /usr/local/bin/gws --version
Error relocating /usr/local/bin/gws: __res_init: symbol not found
exit code: 127
```

## Cause

[PR #1353](https://github.com/psd401/aistudio/pull/1353) moved gws execution into the trusted web broker. That correctly requires the gws binary in the **frontend** image — the web task executes it now, so the model runtime never holds a token. But the install block was carried over from the agent image and kept its **glibc** artifact:

```
google-workspace-cli-aarch64-unknown-linux-gnu.tar.gz
```

That's right for the agent image, which is Debian-based. `Dockerfile.graviton`'s runner stage is `node:22-alpine` — **musl**. The binary downloads, the checksum verifies, and the very next line dies. `libc6-compat`/gcompat is installed but doesn't implement glibc's resolver symbols.

The one good thing: the RUN ends in `gws --version`, so this failed at **build** time rather than the first time the broker tried to execute a Workspace command in production.

## Fix

Upstream publishes a musl target for exactly this case. Switched to `-musl` with its published sidecar digest, and documented the musl sidecar as the source when bumping the version so the next bump can't silently reintroduce a glibc binary.

## Verification

Built a minimal `node:22-alpine` stage with the same apk packages and the same install block:

```
+ /usr/local/bin/gws --version
gws 0.22.5
#6 DONE 1.4s
```

The identical probe against the `-gnu` artifact is what produced the relocation error above, so this is a confirmed before/after — not just a plausible fix.

## Note

This is the second deploy-blocking gap from #1353's Dockerfile changes; [PR #1356](https://github.com/psd401/aistudio/pull/1356) fixed the first (a deleted `ARG GWS_VERSION` still referenced by a clone step). Both share a root cause worth naming: **no CI job builds either image**, so a broken Dockerfile merges green and is only discovered at deploy. A build-only smoke job for `Dockerfile.graviton` and `infra/agent-image/Dockerfile` would have caught both.