### PR TITLE
fix: unblock deploy — client-bundle leak in roster admin + invalid S3 lifecycle rule

### DIFF
--- a/app/(protected)/admin/rosters/_components/rosters-admin.tsx
+++ b/app/(protected)/admin/rosters/_components/rosters-admin.tsx
@@ -59,10 +59,13 @@ import type {
   OneRosterAuthMode,
   OneRosterApiVersion,
 } from "@/lib/roster/settings"
+// status-shared, NOT status: this is a client component, and status.ts imports
+// the Drizzle client (-> logger -> winston -> fs/net), which webpack cannot
+// bundle for the browser.
 import {
   isOneRosterSyncStatusActive,
   type OneRosterSyncStatus,
-} from "@/lib/roster/status"
+} from "@/lib/roster/status-shared"
 
 type DateValue = Date | string | null
 

--- a/infra/lib/agent-platform-stack.ts
+++ b/infra/lib/agent-platform-stack.ts
@@ -235,6 +235,19 @@ export class AgentPlatformStack extends cdk.Stack {
           id: 'cleanup-private-workspace-versions',
           tagFilters: { Scope: 'private' },
           noncurrentVersionExpiration: cdk.Duration.days(30),
+          // NO abortIncompleteMultipartUploadAfter here. S3 rejects the
+          // combination outright — "AbortIncompleteMultipartUpload cannot be
+          // specified with Tags" — because an in-flight multipart upload has
+          // no object tags yet (tags are applied on completion), so a
+          // tag-filtered rule could never match one. CloudFormation surfaces
+          // this as an InvalidRequest that fails the whole stack update.
+        },
+        {
+          // Bucket-wide abort of abandoned multipart uploads, with no prefix
+          // or tag filter so it is a legal home for the action the rule above
+          // cannot carry. Keeps the cleanup intent that the tag-filtered rule
+          // was reaching for.
+          id: 'abort-abandoned-multipart-uploads',
           abortIncompleteMultipartUploadAfter: cdk.Duration.days(1),
         },
       ],

--- a/lib/roster/status-shared.ts
+++ b/lib/roster/status-shared.ts
@@ -1,0 +1,85 @@
+/**
+ * OneRoster sync status — the CLIENT-SAFE half.
+ *
+ * Split out of status.ts because the admin UI is a "use client" component and
+ * needs `isOneRosterSyncStatusActive`. Importing that from status.ts pulls the
+ * whole module into the browser bundle, and status.ts imports the Drizzle
+ * client, which imports the logger, which imports winston — so `next build`
+ * fails with "Can't resolve 'fs'", "Can't resolve 'net'", and unhandled
+ * `node:` schemes. A VALUE import is what does it; the `import type` lines
+ * beside it are erased and were never the problem.
+ *
+ * Everything here is pure: schemas, a constant, and two functions that touch
+ * no I/O. Anything needing the database belongs in status.ts.
+ *
+ * The isolated Lambda duplicates this serialized contract deliberately because
+ * its bundle cannot import Next.js application code. Keep the state names and
+ * collection fields synchronized with infra/lambdas/oneroster-sync/index.ts.
+ */
+
+import { z } from "zod";
+
+export const oneRosterCollectionNameSchema = z.enum([
+  "orgs",
+  "academicSessions",
+  "courses",
+  "classes",
+  "users",
+  "enrollments",
+]);
+
+export type OneRosterCollectionName = z.infer<
+  typeof oneRosterCollectionNameSchema
+>;
+
+const collectionStatusSchema = z.object({
+  name: oneRosterCollectionNameSchema,
+  recordsTotal: z.number().int().nonnegative(),
+  synced: z.number().int().nonnegative(),
+  deactivated: z.number().int().nonnegative(),
+  failed: z.number().int().nonnegative(),
+});
+
+export const oneRosterSyncStatusSchema = z.object({
+  runId: z.string().min(1).max(100),
+  trigger: z.enum(["manual", "schedule"]),
+  state: z.enum(["queued", "running", "succeeded", "failed", "skipped"]),
+  startedAt: z.iso.datetime(),
+  completedAt: z.iso.datetime().nullable(),
+  unchanged: z.boolean(),
+  collections: z.array(collectionStatusSchema),
+  error: z.string().max(500).nullable(),
+});
+
+export type OneRosterSyncStatus = z.infer<typeof oneRosterSyncStatusSchema>;
+
+// CDK disables implicit async retries and caps queued event age at 30 minutes,
+// so one hour covers dispatch plus the 15-minute execution timeout with margin
+// while still recovering abandoned status rows.
+export const ONEROSTER_SYNC_ACTIVE_WINDOW_MS = 60 * 60 * 1000;
+
+export function isOneRosterSyncStatusActive(
+  status: OneRosterSyncStatus,
+  now = Date.now()
+): boolean {
+  if (status.state !== "queued" && status.state !== "running") return false;
+  const startedAt = Date.parse(status.startedAt);
+  return (
+    Number.isFinite(startedAt) &&
+    startedAt <= now &&
+    now - startedAt <= ONEROSTER_SYNC_ACTIVE_WINDOW_MS
+  );
+}
+
+export function parseOneRosterSyncStatus(
+  value: string | null
+): OneRosterSyncStatus | null {
+  if (!value) return null;
+  try {
+    const parsed: unknown = JSON.parse(value);
+    const result = oneRosterSyncStatusSchema.safeParse(parsed);
+    return result.success ? result.data : null;
+  } catch {
+    return null;
+  }
+}

--- a/lib/roster/status.ts
+++ b/lib/roster/status.ts
@@ -1,81 +1,33 @@
 /**
- * Durable OneRoster sync status shared by the administrator UI.
+ * Durable OneRoster sync status — the SERVER half.
  *
- * The isolated Lambda duplicates this serialized contract deliberately because
- * its bundle cannot import Next.js application code. Keep the state names and
- * collection fields synchronized with infra/lambdas/oneroster-sync/index.ts.
+ * The pure schema/predicate half lives in ./status-shared so the admin UI can
+ * import it without dragging the Drizzle client (and therefore winston, fs and
+ * net) into the browser bundle. Server callers can keep importing everything
+ * from here; the shared surface is re-exported below.
  */
 
-import { z } from "zod";
 import { executeQuery } from "@/lib/db/drizzle-client";
 import { getSettingValue } from "@/lib/db/drizzle/settings";
 import { settings } from "@/lib/db/schema";
 import { ONEROSTER_SETTING_KEYS } from "./settings";
+import {
+  oneRosterSyncStatusSchema,
+  parseOneRosterSyncStatus,
+  type OneRosterSyncStatus,
+} from "./status-shared";
 
-export const oneRosterCollectionNameSchema = z.enum([
-  "orgs",
-  "academicSessions",
-  "courses",
-  "classes",
-  "users",
-  "enrollments",
-]);
-
-export type OneRosterCollectionName = z.infer<
-  typeof oneRosterCollectionNameSchema
->;
-
-const collectionStatusSchema = z.object({
-  name: oneRosterCollectionNameSchema,
-  recordsTotal: z.number().int().nonnegative(),
-  synced: z.number().int().nonnegative(),
-  deactivated: z.number().int().nonnegative(),
-  failed: z.number().int().nonnegative(),
-});
-
-export const oneRosterSyncStatusSchema = z.object({
-  runId: z.string().min(1).max(100),
-  trigger: z.enum(["manual", "schedule"]),
-  state: z.enum(["queued", "running", "succeeded", "failed", "skipped"]),
-  startedAt: z.iso.datetime(),
-  completedAt: z.iso.datetime().nullable(),
-  unchanged: z.boolean(),
-  collections: z.array(collectionStatusSchema),
-  error: z.string().max(500).nullable(),
-});
-
-export type OneRosterSyncStatus = z.infer<typeof oneRosterSyncStatusSchema>;
-
-// CDK disables implicit async retries and caps queued event age at 30 minutes,
-// so one hour covers dispatch plus the 15-minute execution timeout with margin
-// while still recovering abandoned status rows.
-export const ONEROSTER_SYNC_ACTIVE_WINDOW_MS = 60 * 60 * 1000;
-
-export function isOneRosterSyncStatusActive(
-  status: OneRosterSyncStatus,
-  now = Date.now()
-): boolean {
-  if (status.state !== "queued" && status.state !== "running") return false;
-  const startedAt = Date.parse(status.startedAt);
-  return (
-    Number.isFinite(startedAt) &&
-    startedAt <= now &&
-    now - startedAt <= ONEROSTER_SYNC_ACTIVE_WINDOW_MS
-  );
-}
-
-export function parseOneRosterSyncStatus(
-  value: string | null
-): OneRosterSyncStatus | null {
-  if (!value) return null;
-  try {
-    const parsed: unknown = JSON.parse(value);
-    const result = oneRosterSyncStatusSchema.safeParse(parsed);
-    return result.success ? result.data : null;
-  } catch {
-    return null;
-  }
-}
+export {
+  ONEROSTER_SYNC_ACTIVE_WINDOW_MS,
+  isOneRosterSyncStatusActive,
+  oneRosterCollectionNameSchema,
+  oneRosterSyncStatusSchema,
+  parseOneRosterSyncStatus,
+} from "./status-shared";
+export type {
+  OneRosterCollectionName,
+  OneRosterSyncStatus,
+} from "./status-shared";
 
 export async function getOneRosterSyncStatus(): Promise<OneRosterSyncStatus | null> {
   return parseOneRosterSyncStatus(


### PR DESCRIPTION
Two independent deploy blockers on dev. Both landed today; neither is catchable by CI as it currently stands.

## 1. Frontend image cannot build — server code in the client bundle

`next build` fails with `Can't resolve 'fs'`, `Can't resolve 'net'`, and `UnhandledSchemeError` on `node:async_hooks` / `node:crypto`:

```
app/(protected)/admin/rosters/_components/rosters-admin.tsx   ("use client")
  -> lib/roster/status.ts
  -> lib/db/drizzle-client.ts
  -> lib/logger.ts
  -> winston -> fs / tail-file
```

The component's two `import type` lines are erased at compile and were never the problem. The **value** import of `isOneRosterSyncStatusActive` is what drags all of `status.ts` — and therefore the Drizzle client — into the browser bundle.

**Fix:** split the pure half (zod schemas, the window constant, `isOneRosterSyncStatusActive`, `parseOneRosterSyncStatus` — no I/O) into `lib/roster/status-shared.ts`. `status.ts` keeps the DB functions and re-exports the shared surface, so every existing server-side import works unchanged. The client component imports from `status-shared`.

## 2. AgentPlatformStack update fails — illegal S3 lifecycle rule

```
Resource handler returned message: "AbortIncompleteMultipartUpload cannot be specified with Tags."
AWS::S3::Bucket AgentWorkspaceBucket6FB249E8
```

`cleanup-private-workspace-versions` carried both `tagFilters: { Scope: 'private' }` and `abortIncompleteMultipartUploadAfter`. S3 forbids that pairing: an in-flight multipart upload has no object tags yet (tags apply on completion), so a tag-filtered rule could never match one.

**Fix:** drop the action from the tag-filtered rule, add a separate unfiltered `abort-abandoned-multipart-uploads` rule that is a legal home for it and preserves the cleanup intent.

## Verification — both reproduced and re-run, not reasoned about

| Check | Result |
|---|---|
| `next build --webpack` | `✓ Compiled successfully in 58s`, exit 0 |
| Original error classes | `fs`, `net`, `UnhandledSchemeError`, `Failed to compile` — all **0** |
| `cdk synth AgentPlatformStack-Dev` | exit 0; tag-filtered rule has no abort action, separate unfiltered rule carries it |
| `tsc --noEmit` | clean |
| `oneroster-admin-settings.test.ts` | 7/7 — imports `isOneRosterSyncStatusActive`, resolves via the re-export |

## The pattern worth fixing separately

This is the **third** deploy blocker today that CI could not see ([#1356](https://github.com/psd401/aistudio/pull/1356) deleted ARG, [#1360](https://github.com/psd401/aistudio/pull/1360) glibc-on-musl, now this). Root cause is consistent: **no CI job runs a production `next build` or builds either Dockerfile**, so this whole class merges green and surfaces only when someone deploys.

A build-only smoke job — `next build --webpack` plus a docker build of `Dockerfile.graviton` and `infra/agent-image/Dockerfile` — would have caught all three. Worth filing.

## Local repro note

`bun install` may be needed first: `@aws-sdk/client-scheduler` is declared in `package.json` but missing from a stale `node_modules`, which masks itself as an unrelated build failure. The Docker build does a frozen-lockfile install and is unaffected.