### PR TITLE
fix(infra): a missing --context flag silently deleted Chat ingress (dev outage; prod was next)

### DIFF
--- a/infra/cdk.json
+++ b/infra/cdk.json
@@ -91,6 +91,21 @@
     "@aws-cdk/aws-stepfunctions:useDistributedMapResultWriterV2": true,
     "@aws-cdk/s3-notifications:addS3TrustKeyPolicyForSnsSubscriptions": true,
     "@aws-cdk/aws-ec2:requirePrivateSubnetsForEgressOnlyInternetGateway": true,
-    "@aws-cdk/aws-s3:publicAccessBlockedByDefault": true
+    "@aws-cdk/aws-s3:publicAccessBlockedByDefault": true,
+    "chatIngress": {
+      "_comment": "Google Chat Pub/Sub ingress identifiers per environment. NOT secrets. These gate creation of the /chat route, its integration, the JWT authorizer and the Lambda invoke permission \u2014 they live here so a deploy that forgets a --context flag cannot silently delete live ingress (incident 2026-07-27). --context flags still override. Values come from psd401/psd-gcp-infra (chat-ingress.tf = prod, chat-dev-clone.tf = dev); the subject is the service account's numeric uniqueId from `gcloud iam service-accounts describe`.",
+      "dev": {
+        "gcpPubsubAudience": "https://twdwqcb822.execute-api.us-east-1.amazonaws.com/chat",
+        "gcpPubsubServiceAccountEmail": "psd-agent-chat-dev@psd-aistudio-dev.iam.gserviceaccount.com",
+        "gcpPubsubServiceAccountSubject": "113223227650359591172",
+        "gcpPubsubSubscription": "projects/psd-aistudio-dev/subscriptions/agent-chat-to-aws-bridge"
+      },
+      "prod": {
+        "gcpPubsubAudience": "https://hhjh4gssm6.execute-api.us-east-1.amazonaws.com/chat",
+        "gcpPubsubServiceAccountEmail": "psd-agent-chat@aistudio-462612.iam.gserviceaccount.com",
+        "gcpPubsubServiceAccountSubject": "105465329886887805514",
+        "gcpPubsubSubscription": "projects/aistudio-462612/subscriptions/agent-chat-to-aws-bridge"
+      }
+    }
   }
 }

--- a/infra/lib/agent-platform-stack.ts
+++ b/infra/lib/agent-platform-stack.ts
@@ -2909,16 +2909,61 @@ export class AgentPlatformStack extends cdk.Stack {
     // push subscription is configured to call). Setting this to the API URL
     // itself is the simplest correct value.
 
-    const gcpPubsubAudience = this.node.tryGetContext('gcpPubsubAudience') as string | undefined;
-    const gcpPubsubServiceAccountEmail = this.node.tryGetContext(
-      'gcpPubsubServiceAccountEmail',
-    ) as string | undefined;
-    const gcpPubsubServiceAccountSubject = this.node.tryGetContext(
-      'gcpPubsubServiceAccountSubject',
-    ) as string | undefined;
-    const gcpPubsubSubscription = this.node.tryGetContext(
-      'gcpPubsubSubscription',
-    ) as string | undefined;
+    // Resolution order: --context flag, then the per-environment defaults in
+    // cdk.json (chatIngress.<env>). The defaults exist because these four
+    // values GATE THE ROUTE'S EXISTENCE — see the guard below — so relying on
+    // an operator to remember four CLI flags means one forgotten flag deletes
+    // live ingress. They are identifiers, not secrets: an endpoint URL, a
+    // service-account email, that account's numeric OIDC subject, and a
+    // subscription path.
+    const chatIngressDefaults =
+      (this.node.tryGetContext('chatIngress') as
+        | Record<string, Record<string, string>>
+        | undefined)?.[environment] ?? {};
+    const fromContext = (key: string): string | undefined =>
+      (this.node.tryGetContext(key) as string | undefined) ?? chatIngressDefaults[key];
+
+    const gcpPubsubAudience = fromContext('gcpPubsubAudience');
+    const gcpPubsubServiceAccountEmail = fromContext('gcpPubsubServiceAccountEmail');
+    const gcpPubsubServiceAccountSubject = fromContext('gcpPubsubServiceAccountSubject');
+    const gcpPubsubSubscription = fromContext('gcpPubsubSubscription');
+
+    // FAIL LOUDLY ON A PARTIAL CONFIG.
+    //
+    // Every one of these four values is required before the /chat route,
+    // its integration, the JWT authorizer, and the Lambda invoke permission
+    // are synthesized. If some are present and others are not, the operator
+    // clearly INTENDS Chat ingress but is missing a value — and silently
+    // skipping the block would make CloudFormation DELETE those four live
+    // resources while reporting a successful deploy.
+    //
+    // That is not hypothetical. On 2026-07-27 a deploy carrying only
+    // `gcpPubsubAudience` (the documented flag at the time) deleted dev's
+    // route, integration, authorizer and Lambda permission. Google Pub/Sub
+    // kept POSTing into a routeless API — ~665 requests, all 5xx, ZERO Lambda
+    // invocations, so nothing appeared in any Lambda log and the agent simply
+    // went silent. Throwing here turns that into a failed deploy that names
+    // the missing values.
+    const chatIngressValues = {
+      gcpPubsubAudience,
+      gcpPubsubServiceAccountEmail,
+      gcpPubsubServiceAccountSubject,
+      gcpPubsubSubscription,
+    };
+    const missingChatIngress = Object.entries(chatIngressValues)
+      .filter(([, v]) => !v)
+      .map(([k]) => k);
+    if (missingChatIngress.length > 0 && missingChatIngress.length < 4) {
+      throw new Error(
+        `Google Chat ingress is partially configured for "${environment}": missing ` +
+          `${missingChatIngress.join(', ')}. Deploying now would DELETE the live ` +
+          `/chat route, its integration, the JWT authorizer and the Lambda invoke ` +
+          `permission, and the agent would stop receiving messages with no error ` +
+          `in any Lambda log. Add the missing --context values, or add them under ` +
+          `chatIngress.${environment} in infra/cdk.json. To intentionally stand up ` +
+          `an environment with NO Chat ingress, omit all four.`,
+      );
+    }
 
     const bridgeLogGroup = new logs.LogGroup(this, 'ChatBridgeLogGroup', {
       logGroupName: `/aws/lambda/psd-agent-chat-bridge-${environment}`,


### PR DESCRIPTION
## The dev agent went deaf tonight, with nothing in any log

Nothing appeared in any Lambda log because **the Lambda was never invoked**.

[PR #1353](https://github.com/psd401/aistudio/pull/1353) tightened the guard around the `/chat` route from one required context value to four:

```ts
if (gcpPubsubAudience && gcpPubsubServiceAccountEmail
    && gcpPubsubServiceAccountSubject && gcpPubsubSubscription) { ... }
```

The documented deploy command passes only `gcpPubsubAudience`, and wasn't updated. So a **correct, unchanged deploy command** made the guard false, CDK omitted the block, and CloudFormation deleted four live resources while reporting success:

```
DELETE_COMPLETE  ChatBridgeApiPOSTchatChatBridgeIntegrationPermission
DELETE_COMPLETE  ChatBridgeApiPOSTchat
DELETE_COMPLETE  ChatBridgeApiPOSTchatChatBridgeIntegration
DELETE_COMPLETE  ChatBridgeApiChatBridgeJwtAuthorizer
```

Google Pub/Sub then POSTed into a routeless API **~665 times in 3 hours, all 5xx, zero Lambda invocations**. Same shape as the documented `agentImageTag` trap: a missing `--context` flag destroying live infrastructure silently.

## ⚠️ Production was next

Prod's bridge Lambda still has only `ROUTER_QUEUE_URL` in its environment — it's running **pre-#1353 code** and works only because it hasn't been promoted. The first prod deploy after that promotion, with the same command, would have deleted **production** Chat ingress exactly as silently.

## Two changes

**1. Per-environment defaults in `infra/cdk.json`** under `chatIngress.<env>`. These are identifiers, not secrets — endpoint URL, SA email, that account's numeric OIDC subject, subscription path. Sourced from `psd401/psd-gcp-infra` (`chat-ingress.tf` = prod, `chat-dev-clone.tf` = dev) plus `gcloud iam service-accounts describe --format='value(uniqueId)'`. `--context` flags still override.

Config that gates the existence of live resources shouldn't depend on operator memory.

**2. A synth-time throw on a partial config.** Some values present and others absent means the operator *intends* ingress but is missing one — the case that must never silently proceed. All four absent still succeeds, so a genuinely new environment can be stood up without ingress.

## Verified by synth, three cases

| Case | Result |
|---|---|
| Hagel's exact unchanged command | Route, Integration, Authorizer, Lambda Permission all synthesized; env vars populated. **Restores dev instead of deleting it.** |
| Partial config | Throws, naming the three missing values and what would have been deleted |
| All four absent | exit 0, no ingress — new-environment path intact |
| **Prod, no chat flags** | Route + authorizer present, prod values correct — **landmine defused** |

## Follow-up worth filing

This is the fourth deploy-only failure this weekend that CI couldn't see. A synth-diff check in CI — flagging when a PR's synthesized template *deletes* resources that exist in the deployed stack — would have caught this one before it ran.