### PR TITLE
fix(agent): preserve entrypoint signature — every invocation was failing with 'No response from agent.'

### DIFF
--- a/infra/agent-image/agentcore_wrapper.py
+++ b/infra/agent-image/agentcore_wrapper.py
@@ -308,6 +308,20 @@ async def _finalize_invocation_authority() -> None:
 
 def _serialize_invocations(function):
     """Hold one owner's authority and revoke it before the terminal result."""
+
+    # functools.wraps is LOAD-BEARING, not cosmetic. BedrockAgentCoreApp
+    # decides whether to pass `context` to the entrypoint by inspecting its
+    # signature. Without wraps, inspect.signature() sees this wrapper's
+    # (*args, **kwargs) instead of the real (payload, context), so the SDK
+    # calls it with payload ONLY and every invocation dies with:
+    #
+    #   TypeError: agent_invocation() missing 1 required positional
+    #             argument: 'context'
+    #
+    # The container still boots and reports BOOT_OK — the failure only shows
+    # up when a turn is actually invoked, which is why it reached dev
+    # (2026-07-27) and surfaced to users as "No response from agent."
+    @functools.wraps(function)
     async def serialized(*args, **kwargs):
         finalized = False
         async with _invocation_lock:

--- a/infra/agent-image/test_agentcore_wrapper.py
+++ b/infra/agent-image/test_agentcore_wrapper.py
@@ -9,6 +9,8 @@ The Docker-only deps (harness_adapter, workspace_sync, the AgentCore SDK) are
 stubbed in sys.modules so the pure helper can be imported and tested.
 """
 
+import asyncio
+import inspect
 import sys
 import unittest
 from unittest import mock
@@ -168,6 +170,55 @@ class TestInvocationContextInstaller(unittest.TestCase):
                 preexec_fn=drop_to_node,
             )
             self.assertEqual(probe.returncode, 0)
+
+
+class TestSerializedInvocationSignature(unittest.TestCase):
+    """The decorator must not hide the entrypoint's real signature.
+
+    BedrockAgentCoreApp inspects the entrypoint to decide whether to pass
+    `context`. If _serialize_invocations returns a bare (*args, **kwargs)
+    wrapper, the SDK sees no `context` parameter, calls the handler with
+    `payload` only, and EVERY invocation dies with
+
+        TypeError: agent_invocation() missing 1 required positional
+                  argument: 'context'
+
+    The container still boots and logs BOOT_OK, so nothing catches this until
+    a real turn is invoked — it reached dev on 2026-07-27 and surfaced to
+    users as "No response from agent." (incident: the build-time canary turn,
+    which would have caught it, had been skipped).
+    """
+
+    def test_preserves_payload_and_context_parameters(self):
+        async def entrypoint(payload, context):
+            yield {"result": payload}
+
+        wrapped = agentcore_wrapper._serialize_invocations(entrypoint)
+        params = list(inspect.signature(wrapped).parameters)
+        self.assertEqual(
+            params,
+            ["payload", "context"],
+            "the SDK introspects this signature to decide whether to pass "
+            "`context`; (*args, **kwargs) here means context is never passed",
+        )
+
+    def test_wrapper_still_forwards_both_arguments(self):
+        seen = {}
+
+        async def entrypoint(payload, context):
+            seen["payload"] = payload
+            seen["context"] = context
+            yield {"result": "ok"}
+
+        wrapped = agentcore_wrapper._serialize_invocations(entrypoint)
+
+        async def drive():
+            return [e async for e in wrapped({"p": 1}, "ctx")]
+
+        events = asyncio.run(drive())
+        self.assertEqual(seen["payload"], {"p": 1})
+        self.assertEqual(seen["context"], "ctx")
+        self.assertEqual(events, [{"result": "ok"}])
 
 
 class TestSerializedInvocationCleanup(unittest.IsolatedAsyncioTestCase):


### PR DESCRIPTION
## Every dev agent turn was failing

Users saw **"No response from agent."** in Chat. The runtime logged:

```
TypeError: main.<locals>.agent_invocation() missing 1 required positional argument: 'context'
  File "/app/agentcore_wrapper.py", line 315, in serialized
    async for event in function(*args, **kwargs)
```

## Cause

[PR #1353](https://github.com/psd401/aistudio/pull/1353) (`38c18aec`) added the `_serialize_invocations` decorator **without `functools.wraps`**.

`BedrockAgentCoreApp` decides whether to pass `context` to the entrypoint by **inspecting its signature**. Unwrapped, `inspect.signature()` reports the wrapper's `(*args, **kwargs)` instead of the real `(payload, context)` — so the SDK called the handler with `payload` only, and every turn raised before producing a result. The router then fell back to its default string ([agent-router/index.ts:1719](infra/lambdas/agent-router/index.ts:1719)), which is the text that reached Chat.

Verified the mechanism directly rather than inferring it:

```
WITHOUT functools.wraps: signature=['args','kwargs']     -> context NOT passed
WITH    functools.wraps: signature=['payload','context'] -> context passed
```

## Fix

One line — `@functools.wraps(function)` on the wrapper (`functools` was already imported). The comment marks it load-bearing so a future tidy-up doesn't strip it.

## ⚠️ Why nothing caught this

The container **boots fine and logs `BOOT_OK`** — only a real invocation fails. The build-time eval gate's **canary turn** exists to catch precisely this, but it silently skipped: the runtime probe now requires `AGENT_PROBE_INVOCATION_CONTEXT`, which is undocumented, so `build-and-push.sh` printed *"image NOT boot-verified"* and pushed anyway, exiting 0.

Had the canary run, this would have failed the build instead of reaching users. That undocumented probe requirement is already filed separately, and this incident is the argument for making the skip a loud opt-in rather than a warning.

## Tests

`test_agentcore_wrapper.py`, +2 → **31 pass**:
- the decorator preserves `['payload', 'context']`
- the wrapper still forwards **both** arguments and yields events

Verified to **fail** against the unwrapped decorator (1 failure) and pass with it.

## Deploy note

This changes the agent image, so it needs a fresh `build-and-push` + deploy — the `2026-07-26-directory` image in ECR contains the bug.