### PR TITLE
fix(agent): send anthropic_version — Bedrock requires it in the body (dev agent cannot complete any turn)

### DIFF
--- a/app/api/agent/model-proxy/[...path]/route.ts
+++ b/app/api/agent/model-proxy/[...path]/route.ts
@@ -17,6 +17,14 @@ export const runtime = "nodejs"
 
 const log = createLogger({ module: "agent-model-proxy" })
 const UPSTREAM = "https://bedrock-runtime.us-east-1.amazonaws.com/anthropic/v1/messages"
+// Bedrock's Anthropic-compatible endpoint requires `anthropic_version` as a
+// BODY field. The native Anthropic API instead takes an `anthropic-version`
+// HEADER, which is what an Anthropic-Messages client sends — so a client that
+// is correct against api.anthropic.com is rejected here with
+// `{"type":"invalid_request_error","message":"anthropic_version: Field required"}`
+// on EVERY call. The proxy forwards the body verbatim, so it has to supply the
+// field itself.
+const BEDROCK_ANTHROPIC_VERSION = "bedrock-2023-05-31"
 const ALLOWED_MODELS = new Set(["us.anthropic.claude-sonnet-5"])
 const MAX_INPUT_TOKEN_UPPER_BOUND = 200_000
 const MAX_OUTPUT_TOKENS = 32_768
@@ -51,6 +59,7 @@ const SONNET_INPUT_COST_MICROCENTS_PER_TOKEN = 300
 const SONNET_OUTPUT_COST_MICROCENTS_PER_TOKEN = 1_500
 
 type ModelRequest = {
+  anthropic_version?: unknown
   model?: unknown
   max_tokens?: unknown
 }
@@ -167,6 +176,23 @@ export async function POST(
       { status: 413 },
     )
   }
+  // Forward the RE-SERIALIZED, validated object rather than the raw bytes,
+  // with `anthropic_version` supplied when the client omitted it. An explicit
+  // client value is preserved rather than overwritten.
+  //
+  // Re-serializing also closes a validate-vs-forward gap: the checks above run
+  // on `parsed`, so forwarding the original bytes would let any parser
+  // disagreement (duplicate keys, for instance, where JSON.parse keeps the
+  // last and another parser may keep the first) send upstream something other
+  // than what was actually validated.
+  const forwardBody = new TextEncoder().encode(
+    JSON.stringify(
+      parsed.anthropic_version === undefined
+        ? { ...parsed, anthropic_version: BEDROCK_ANTHROPIC_VERSION }
+        : parsed,
+    ),
+  )
+
   const bodyDigest = createHash("sha256").update(body).digest("hex")
   const reservedTokens = inputTokenUpperBound + parsed.max_tokens
   const reservedCostMicrocents =
@@ -225,7 +251,7 @@ export async function POST(
         Accept: request.headers.get("accept") || "application/json",
         "x-api-key": apiKey,
       },
-      body: Buffer.from(body),
+      body: Buffer.from(forwardBody),
       redirect: "error",
       signal: request.signal,
     })

--- a/tests/unit/agent-model-proxy-route.test.ts
+++ b/tests/unit/agent-model-proxy-route.test.ts
@@ -216,6 +216,56 @@ describe("Agent model credential broker", () => {
     )
   })
 
+  /** The JSON actually dispatched upstream, as a string. */
+  const forwardedBody = (): string => {
+    const call = fetchMock.mock.calls[0]
+    if (!call) throw new Error("fetch was never called")
+    const init = call[1] as { body?: unknown } | undefined
+    if (!init?.body) throw new Error("fetch was called without a body")
+    return Buffer.from(init.body as Buffer).toString("utf8")
+  }
+
+  it("supplies anthropic_version, which Bedrock requires in the BODY", async () => {
+    // Bedrock's Anthropic-compatible endpoint requires `anthropic_version` as
+    // a body field. The native Anthropic API instead uses an
+    // `anthropic-version` HEADER, so an Anthropic-Messages client that is
+    // correct against api.anthropic.com omits the body field and Bedrock
+    // rejects EVERY call with:
+    //   {"type":"invalid_request_error","message":"anthropic_version: Field required"}
+    // That is what took the dev agent down on 2026-07-27 — this proxy path was
+    // one day old and had never completed a single successful turn.
+    await POST(
+      request({
+        model: "us.anthropic.claude-sonnet-5",
+        max_tokens: 1_024,
+        messages: [{ role: "user", content: "hello" }],
+      }) as never,
+      { params: Promise.resolve({ path: ["anthropic", "v1", "messages"] }) },
+    )
+
+    const forwarded = JSON.parse(forwardedBody())
+    expect(forwarded.anthropic_version).toBe("bedrock-2023-05-31")
+    // The rest of the request must survive untouched.
+    expect(forwarded.model).toBe("us.anthropic.claude-sonnet-5")
+    expect(forwarded.max_tokens).toBe(1_024)
+    expect(forwarded.messages).toEqual([{ role: "user", content: "hello" }])
+  })
+
+  it("does not overwrite an anthropic_version the client already set", async () => {
+    await POST(
+      request({
+        model: "us.anthropic.claude-sonnet-5",
+        max_tokens: 1_024,
+        anthropic_version: "bedrock-2099-01-01",
+        messages: [{ role: "user", content: "hello" }],
+      }) as never,
+      { params: Promise.resolve({ path: ["anthropic", "v1", "messages"] }) },
+    )
+
+    const forwarded = JSON.parse(forwardedBody())
+    expect(forwarded.anthropic_version).toBe("bedrock-2099-01-01")
+  })
+
   it("retains conservative reservations after an ambiguous dispatch failure", async () => {
     fetchMock.mockRejectedValueOnce(new Error("client aborted after dispatch"))
     const response = await POST(


### PR DESCRIPTION
## The dev agent cannot complete a single turn

Chat shows *"I couldn't complete that — I hit a problem partway through."* The runtime logs:

```
error=LLM request failed: provider rejected the request schema or tool payload.
rawError={"type":"invalid_request_error","message":"anthropic_version: Field required"}
```

## Cause

The model broker forwards to **Bedrock's Anthropic-compatible endpoint**:

```
https://bedrock-runtime.us-east-1.amazonaws.com/anthropic/v1/messages
```

That endpoint requires `anthropic_version` as a **body field**. The native Anthropic API instead takes an `anthropic-version` **header** — so a client that's correct against `api.anthropic.com` omits the body field and Bedrock rejects every call. The proxy forwarded the body verbatim, and `anthropic_version` appeared **nowhere in the repository**.

## Why prod is unaffected

**This path is one day old and has never worked.**

| What | When |
|---|---|
| Route created | `53fd0968` — 2026-07-26 09:26 |
| Agent proxy repointed at it | `38c18aec` — 2026-07-26 10:08 |

Both from [#1353](https://github.com/psd401/aistudio/pull/1353). Prod runs `2026-07-23-prod-cutover`, which predates both, and its proxy dispatches straight to Bedrock — prod never executes this code. Prod isn't working *despite* the bug; it hasn't inherited it yet. **It will on the next promotion.**

## Fix

Supply `anthropic_version: "bedrock-2023-05-31"` when the client omits it; an explicit client value is preserved.

The forwarded payload is now the **re-serialized validated object** rather than raw bytes. That also closes a validate-vs-forward gap: model and `max_tokens` are checked against the *parsed* object, so forwarding original bytes let any parser disagreement (duplicate keys — `JSON.parse` keeps the last, another parser may keep the first) send upstream something other than what was validated.

## The second error in the logs

`"Model token or cost budget is exhausted"` is **this route's own guard** ([route.ts:200](app/api/agent/model-proxy/[...path]/route.ts:200)) — an app-side limit, not an AWS cap. It's downstream of this bug: every rejected call still consumes its conservative reservation, so a retry loop against a request Bedrock can never accept drains the hourly budget. Worth re-checking after this lands rather than tuning limits blind.

## Tests — 8 pass (+2)

- `anthropic_version` is supplied and the rest of the request survives untouched
- an explicit client value is not overwritten

The first was verified to **fail** when forwarding the raw body (1 failed / 7 passed).

## Why nothing caught it

The build-time **canary turn** — which exercises a real invocation — has been silently skipping since it started requiring the undocumented `AGENT_PROBE_INVOCATION_CONTEXT`. A canary would have hit this on the very first call. That's now two user-facing bugs in one night that the canary was designed to catch.

## Note

The two eslint warnings on `POST` (177 lines, complexity 27) are **pre-existing** — verified by stashing this change. Refactoring a security-critical broker path is deliberately out of scope here.