### PR TITLE
fix(agent): model-proxy budget is observe-only — measure, log, never block the user

### DIFF
--- a/app/api/agent/model-proxy/[...path]/route.ts
+++ b/app/api/agent/model-proxy/[...path]/route.ts
@@ -130,10 +130,25 @@ export async function POST(
     units: 1,
     limits: MODEL_PROXY_CALL_LIMITS,
   })
+  // OBSERVE-ONLY (2026-07-27, Hagel). Admission still MEASURES every call so
+  // we accumulate real consumption data, but it must never reject a user's
+  // request. The limits added in #1353 were calibrated as if one model call
+  // per turn; an agentic turn makes many, each re-sending the whole context,
+  // so a single conversation could exhaust the hourly cap and the agent
+  // answered "I couldn't complete that" with nothing explaining why.
+  //
+  // We do not yet know what normal consumption looks like for this workload.
+  // Until we do, over-limit is a LOG LINE, not a 429 — the numbers are here
+  // to be read, and limits can be set from evidence later.
   if (!callAdmission.allowed) {
-    return NextResponse.json(
-      { error: "Model request capacity is exhausted" },
-      { status: 429, headers: { "Retry-After": "60" } },
+    log.warn(
+      "Model call rate over threshold (observe-only — request allowed)",
+      sanitizeForLogging({
+        requestId,
+        ownerEmail: context.ownerEmail,
+        reason: callAdmission.reason,
+        limit: "MODEL_PROXY_CALL_LIMITS",
+      }),
     )
   }
 
@@ -141,7 +156,7 @@ export async function POST(
   try {
     body = await readBoundedModelRequest(request)
   } catch (error) {
-    await releaseResourceAdmission(callAdmission.leaseId)
+    if (callAdmission.allowed) await releaseResourceAdmission(callAdmission.leaseId)
     if (error instanceof ModelRequestBodyError) {
       return NextResponse.json({ error: error.message }, { status: error.status })
     }
@@ -151,7 +166,7 @@ export async function POST(
   try {
     parsed = JSON.parse(new TextDecoder("utf-8", { fatal: true }).decode(body)) as ModelRequest
   } catch {
-    await releaseResourceAdmission(callAdmission.leaseId)
+    if (callAdmission.allowed) await releaseResourceAdmission(callAdmission.leaseId)
     return NextResponse.json({ error: "Model request must be JSON" }, { status: 400 })
   }
   if (
@@ -162,7 +177,7 @@ export async function POST(
     parsed.max_tokens < 1 ||
     parsed.max_tokens > MAX_OUTPUT_TOKENS
   ) {
-    await releaseResourceAdmission(callAdmission.leaseId)
+    if (callAdmission.allowed) await releaseResourceAdmission(callAdmission.leaseId)
     return NextResponse.json({ error: "Model or output limit is not allowed" }, { status: 400 })
   }
   // UTF-8 bytes are a conservative upper bound on input tokens. Admission uses
@@ -170,7 +185,7 @@ export async function POST(
   // string can escape accounting by changing the request shape.
   const inputTokenUpperBound = body.byteLength
   if (inputTokenUpperBound > MAX_INPUT_TOKEN_UPPER_BOUND) {
-    await releaseResourceAdmission(callAdmission.leaseId)
+    if (callAdmission.allowed) await releaseResourceAdmission(callAdmission.leaseId)
     return NextResponse.json(
       { error: "Model input exceeds the supported context budget" },
       { status: 413 },
@@ -207,26 +222,38 @@ export async function POST(
     units: reservedTokens,
     limits: MODEL_PROXY_TOKEN_LIMITS,
   })
-  const costAdmission = tokenAdmission.allowed
-    ? await acquireResourceAdmission({
-        kind: "model-proxy-cost-microcents",
-        ownerKey: context.ownerEmail,
-        contextKey,
-        idempotencyKey: `${context.nonce}:${bodyDigest}:cost`,
-        units: reservedCostMicrocents,
-        limits: MODEL_PROXY_COST_LIMITS,
-      })
-    : tokenAdmission
+  // Measured unconditionally — previously cost was only sampled when tokens
+  // were under limit, which blinded us to spend in exactly the situation
+  // worth observing.
+  const costAdmission = await acquireResourceAdmission({
+    kind: "model-proxy-cost-microcents",
+    ownerKey: context.ownerEmail,
+    contextKey,
+    idempotencyKey: `${context.nonce}:${bodyDigest}:cost`,
+    units: reservedCostMicrocents,
+    limits: MODEL_PROXY_COST_LIMITS,
+  })
   if (!tokenAdmission.allowed || !costAdmission.allowed) {
-    if (tokenAdmission.allowed) {
-      await releaseResourceAdmission(tokenAdmission.leaseId)
-    }
-    await releaseResourceAdmission(callAdmission.leaseId)
-    return NextResponse.json(
-      { error: "Model token or cost budget is exhausted" },
-      { status: 429, headers: { "Retry-After": "60" } },
+    // OBSERVE-ONLY — see the note above. Log the numbers; serve the request.
+    log.warn(
+      "Model token/cost over threshold (observe-only — request allowed)",
+      sanitizeForLogging({
+        requestId,
+        ownerEmail: context.ownerEmail,
+        reservedTokens,
+        reservedCostMicrocents,
+        tokenReason: tokenAdmission.allowed ? null : tokenAdmission.reason,
+        costReason: costAdmission.allowed ? null : costAdmission.reason,
+      }),
     )
   }
+
+  // Only granted leases can be released or settled; a denied admission has no
+  // leaseId. Collecting them here keeps the lifecycle correct now that a
+  // denial no longer short-circuits the request.
+  const activeLeaseIds = [callAdmission, tokenAdmission, costAdmission]
+    .filter((a) => a.allowed)
+    .map((a) => a.leaseId)
 
   const secretId =
     process.env.AGENT_BEDROCK_API_KEY_SECRET_ID ||
@@ -234,11 +261,7 @@ export async function POST(
   const apiKey = await getSecretString(secretId)
   if (!apiKey) {
     log.error("Model broker credential is not configured", { requestId })
-    await Promise.all([
-      releaseResourceAdmission(callAdmission.leaseId),
-      releaseResourceAdmission(tokenAdmission.leaseId),
-      releaseResourceAdmission(costAdmission.leaseId),
-    ])
+    await Promise.all(activeLeaseIds.map((id) => releaseResourceAdmission(id)))
     return NextResponse.json({ error: "Model broker is not configured" }, { status: 503 })
   }
 
@@ -259,11 +282,7 @@ export async function POST(
     // Once fetch has been dispatched, a transport error or caller abort is
     // ambiguous: the provider may already have accepted and billed the work.
     // Retain the conservative reservation instead of reopening quota.
-    await Promise.all([
-      finishResourceAdmission(callAdmission.leaseId),
-      finishResourceAdmission(tokenAdmission.leaseId),
-      finishResourceAdmission(costAdmission.leaseId),
-    ])
+    await Promise.all(activeLeaseIds.map((id) => finishResourceAdmission(id)))
     log.error(
       "Model broker upstream request failed",
       sanitizeForLogging({
@@ -298,9 +317,5 @@ export async function POST(
     const value = upstream.headers.get(name)
     if (value) headers.set(name, value)
   }
-  return responseWithAdmissionLifecycle(upstream, headers, [
-    callAdmission.leaseId,
-    tokenAdmission.leaseId,
-    costAdmission.leaseId,
-  ])
+  return responseWithAdmissionLifecycle(upstream, headers, activeLeaseIds)
 }

--- a/tests/unit/agent-model-proxy-route.test.ts
+++ b/tests/unit/agent-model-proxy-route.test.ts
@@ -266,6 +266,84 @@ describe("Agent model credential broker", () => {
     expect(forwarded.anthropic_version).toBe("bedrock-2099-01-01")
   })
 
+  it("serves the request when the token/cost budget is over threshold", async () => {
+    // OBSERVE-ONLY. These limits were added in #1353 calibrated as if one
+    // model call per turn; an agentic turn makes many, each re-sending the
+    // whole context, so a single conversation could exhaust the hourly cap and
+    // the user got "I couldn't complete that" with no explanation. Until we
+    // know what normal consumption looks like, over-limit must MEASURE, never
+    // reject.
+    // beforeEach queues mockResolvedValueOnce values that would otherwise
+    // take priority over this override and make the test vacuous.
+    acquireAdmissionMock.mockReset()
+    acquireAdmissionMock.mockImplementation((req: unknown) => {
+      const kind = (req as { kind: string }).kind
+      if (kind === "model-proxy-total-tokens" || kind === "model-proxy-cost-microcents") {
+        return Promise.resolve({ allowed: false, reason: "owner_hourly_units" })
+      }
+      return Promise.resolve({ allowed: true, leaseId: `lease-${kind}`, reservedUnits: 1 })
+    })
+
+    const response = await POST(
+      request({
+        model: "us.anthropic.claude-sonnet-5",
+        max_tokens: 1_024,
+        messages: [{ role: "user", content: "hello" }],
+      }) as never,
+      { params: Promise.resolve({ path: ["anthropic", "v1", "messages"] }) },
+    )
+
+    expect(response.status).toBe(200)
+    expect(fetchMock).toHaveBeenCalled()
+    // Only the granted lease may be settled — a denial carries no leaseId.
+    const settled = finishAdmissionMock.mock.calls.map((c) => c[0])
+    expect(settled).not.toContain(undefined)
+  })
+
+  it("serves the request when the call-rate limit is over threshold", async () => {
+    // beforeEach queues mockResolvedValueOnce values that would otherwise
+    // take priority over this override and make the test vacuous.
+    acquireAdmissionMock.mockReset()
+    acquireAdmissionMock.mockImplementation((req: unknown) => {
+      const kind = (req as { kind: string }).kind
+      if (kind === "model-proxy-call") {
+        return Promise.resolve({ allowed: false, reason: "owner_hourly_units" })
+      }
+      return Promise.resolve({ allowed: true, leaseId: `lease-${kind}`, reservedUnits: 1 })
+    })
+
+    const response = await POST(
+      request({
+        model: "us.anthropic.claude-sonnet-5",
+        max_tokens: 1_024,
+        messages: [{ role: "user", content: "hello" }],
+      }) as never,
+      { params: Promise.resolve({ path: ["anthropic", "v1", "messages"] }) },
+    )
+
+    expect(response.status).toBe(200)
+  })
+
+  it("never answers 429 for a budget or capacity threshold", async () => {
+    // The contract in one line: thresholds are telemetry, not a gate.
+    // beforeEach queues mockResolvedValueOnce values that would otherwise
+    // take priority over this override and make the test vacuous.
+    acquireAdmissionMock.mockReset()
+    acquireAdmissionMock.mockResolvedValue({ allowed: false, reason: "owner_hourly_units" })
+
+    const response = await POST(
+      request({
+        model: "us.anthropic.claude-sonnet-5",
+        max_tokens: 1_024,
+        messages: [{ role: "user", content: "hello" }],
+      }) as never,
+      { params: Promise.resolve({ path: ["anthropic", "v1", "messages"] }) },
+    )
+
+    expect(response.status).not.toBe(429)
+    expect(response.status).toBe(200)
+  })
+
   it("retains conservative reservations after an ambiguous dispatch failure", async () => {
     fetchMock.mockRejectedValueOnce(new Error("client aborted after dispatch"))
     const response = await POST(


### PR DESCRIPTION
## What was there

[#1353](https://github.com/psd401/aistudio/pull/1353) (`28939358`, "enforce durable resource admission") added **hardcoded per-owner caps** to the model broker — no env override, no note that they'd throttle normal use:

```
ownerHourlyUnits:  1,000,000 tokens    200,000,000 microcents  (= $2.00/hour)
```

and estimated input as:

```ts
const inputTokenUpperBound = body.byteLength   // BYTES counted as TOKENS
```

Bytes-as-tokens overcounts ~4x (a token averages ~4 characters). The per-token *prices* are correct for Sonnet ($3/M in, $15/M out) — the **count** is inflated.

With a 100KB prompt, one call reserves ~$0.43, so the owner cap allows **about four calls an hour**. An agentic turn isn't one call: every tool-use iteration re-sends the whole context and takes a fresh reservation. A single conversation could exhaust the hour.

What the user saw: *"I couldn't complete that — I hit a problem partway through,"* with nothing explaining why.

It also compounded the `anthropic_version` bug ([#1366](https://github.com/psd401/aistudio/pull/1366)) — every rejected upstream call still consumed its reservation, so the agent burned a $2/hour budget on requests Bedrock was never going to accept.

## What this does

Admission still **measures** every call — that data is worth keeping while the workload is unknown. Over-threshold is now a **log line, never a 429**.

- all three admissions (`call`, `total-tokens`, `cost-microcents`) are still acquired and settled
- **cost is now measured unconditionally** — it was previously only sampled when tokens were under limit, blinding us in exactly the case worth observing
- a denial carries no `leaseId`, so only **granted** leases are released/settled (`activeLeaseIds`), keeping the lifecycle correct now that a denial no longer short-circuits

Limits can be set later from evidence rather than guessed.

## Tests — 11 pass (+3)

- over-threshold token/cost still serves 200
- over-threshold call rate still serves 200
- a blanket denial never yields 429

**Worth recording how nearly these shipped vacuous.** `beforeEach` queues three `mockResolvedValueOnce` admissions, which take priority over a later `mockImplementation` — so my overrides never applied and all three passed against a route that *still blocked*. They now `mockReset()` first, and the negative control confirms it: reintroducing the 429 fails 2 of them.

## Not changed — same origin, different paths

Say the word and these go too:

| File | Gate |
|---|---|
| `app/api/agent/classified-evaluation/route.ts:177` | "Classified evaluation capacity is exhausted" |
| `app/api/nexus/chat/route.ts:725` | "Deep Research capacity or cost budget is currently exhausted" |