### PR TITLE
fix: observe-only admission for classified eval, skill scan, and Deep Research

### DIFF
--- a/app/api/agent/classified-evaluation/route.ts
+++ b/app/api/agent/classified-evaluation/route.ts
@@ -172,12 +172,19 @@ export async function POST(request: NextRequest) {
     units: 1,
     limits: CLASSIFIED_GATEWAY_LIMITS,
   })
+  // OBSERVE-ONLY (2026-07-27, Hagel): admission MEASURES but must never
+  // reject a user's request. The #1353 limits were set without data on
+  // what this workload actually consumes; over-threshold is telemetry
+  // until real numbers say otherwise.
   if (!admission.allowed) {
-    return NextResponse.json(
-      { error: "Classified evaluation capacity is exhausted" },
-      { status: 429, headers: { "Retry-After": "60" } },
-    )
+    log.warn("Classified gateway over threshold (observe-only — request allowed)", {
+      requestId,
+      reason: admission.reason,
+    })
   }
+  // A denied admission carries no leaseId, so settlement is conditional now
+  // that a denial no longer short-circuits the request.
+  const admissionLeaseId = admission.allowed ? admission.leaseId : null
 
   try {
     const result = await classifiedGatewayDependencies.execute(
@@ -219,13 +226,13 @@ export async function POST(request: NextRequest) {
     )
   } finally {
     try {
-      await finishResourceAdmission(admission.leaseId)
+      if (admissionLeaseId) await finishResourceAdmission(admissionLeaseId)
     } catch (finishError) {
       log.error(
         "Classified gateway admission settlement failed",
         sanitizeForLogging({
           requestId,
-          leaseId: admission.leaseId,
+          leaseId: admissionLeaseId,
           error:
             finishError instanceof Error
               ? finishError.message

--- a/app/api/nexus/chat/route.ts
+++ b/app/api/nexus/chat/route.ts
@@ -718,19 +718,16 @@ async function handleDeepResearch(params: {
   // persistence. A denied request must not leave durable chat state, and every
   // failure before the stream takes ownership must release the active lease.
   const reservation = await reserveDeepResearch(userId);
+  // OBSERVE-ONLY (2026-07-27, Hagel): the #1353 thresholds were set without
+  // data on real consumption, so crossing one is telemetry, not a refusal.
+  // A denial carries no leaseId, hence the nullable lease below.
   if (!reservation.allowed) {
-    timer({ status: 'rate_limited', reason: reservation.reason });
-    return new Response(
-      JSON.stringify({
-        error: 'Deep Research capacity or cost budget is currently exhausted. Try again later.',
-        requestId,
-      }),
-      {
-        status: 429,
-        headers: { 'Content-Type': 'application/json', 'Retry-After': '60' },
-      }
-    );
+    log.warn('Deep Research over threshold (observe-only — request allowed)', {
+      requestId,
+      reason: reservation.reason,
+    });
   }
+  const deepResearchLeaseId = reservation.allowed ? reservation.leaseId : null;
 
   // Conversation setup — same shape the standard flow uses, so the
   // conversation list, history, and resume work without special-casing.
@@ -746,7 +743,7 @@ async function handleDeepResearch(params: {
       log,
     });
     if ('error' in convSetup) {
-      await releaseDeepResearch(reservation.leaseId);
+      if (deepResearchLeaseId) await releaseDeepResearch(deepResearchLeaseId);
       return convSetup.error;
     }
     await persistLastUserMessage({
@@ -755,10 +752,10 @@ async function handleDeepResearch(params: {
       dbModelId,
     });
   } catch (error) {
-    await releaseDeepResearch(reservation.leaseId).catch(
+    if (deepResearchLeaseId) await releaseDeepResearch(deepResearchLeaseId).catch(
       (releaseError: unknown) => {
         log.error('Failed to release Deep Research pre-stream lease', {
-          leaseId: reservation.leaseId,
+          leaseId: deepResearchLeaseId,
           error:
             releaseError instanceof Error
               ? releaseError.message
@@ -876,9 +873,9 @@ async function handleDeepResearch(params: {
           }
           timer({ status: 'error', conversationId, errType });
         } finally {
-          await releaseDeepResearch(reservation.leaseId).catch((releaseError: unknown) => {
+          if (deepResearchLeaseId) await releaseDeepResearch(deepResearchLeaseId).catch((releaseError: unknown) => {
             log.error('Failed to release Deep Research concurrency lease', {
-              leaseId: reservation.leaseId,
+              leaseId: deepResearchLeaseId,
               error:
                 releaseError instanceof Error
                   ? releaseError.message

--- a/lib/skills/skill-publish-pipeline.ts
+++ b/lib/skills/skill-publish-pipeline.ts
@@ -207,13 +207,16 @@ export async function invokeSkillScan(
     units: 1,
     limits: SKILL_SCAN_LIMITS,
   })
+  // OBSERVE-ONLY (2026-07-27, Hagel): a scan-rate threshold must not silently
+  // refuse to publish a skill. Measure it, log it, carry on.
   if (!admission.allowed) {
-    log.warn("Skill scan admission rejected", {
+    log.warn("Skill scan over threshold (observe-only — scan proceeding)", {
       skillId: params.skillId,
       reason: admission.reason,
     })
-    return false
   }
+  // No leaseId on a denial; the scan still runs, it just is not lease-bound.
+  const scanLeaseId = admission.allowed ? admission.leaseId : null
 
   try {
     const client = getLambda()
@@ -226,7 +229,7 @@ export async function invokeSkillScan(
             skillId: params.skillId,
             ownerKey: params.ownerKey.toLowerCase(),
             version: params.version,
-            scanLeaseId: admission.leaseId,
+            scanLeaseId,
             idempotencyKey: params.idempotencyKey,
             s3Key: params.draftPrefix,
             destinationPrefix: params.destinationPrefix,
@@ -239,7 +242,7 @@ export async function invokeSkillScan(
     log.info("Dispatched skill-builder scan", { skillId: params.skillId })
     return true
   } catch (error) {
-    await releaseResourceAdmission(admission.leaseId)
+    if (scanLeaseId) await releaseResourceAdmission(scanLeaseId)
     log.error("Skill-builder invoke failed (non-fatal)", {
       skillId: params.skillId,
       error: error instanceof Error ? error.message : String(error),


### PR DESCRIPTION
Follows [#1367](https://github.com/psd401/aistudio/pull/1367) across the remaining user-facing gates from [#1353](https://github.com/psd401/aistudio/pull/1353).

## Converted — measure, log, serve the request

| File | Was |
|---|---|
| `app/api/agent/classified-evaluation/route.ts` | 429 "Classified evaluation capacity is exhausted" |
| `lib/skills/skill-publish-pipeline.ts` | returned `false` — silently refused to publish a skill |
| `app/api/nexus/chat/route.ts` | 429 "Deep Research capacity or cost budget is currently exhausted" |

In each case a denial carries no `leaseId`, so settlement had to become conditional now that a denial no longer short-circuits.

**TypeScript caught every one of those sites for free.** `ResourceAdmission` is a discriminated union, so removing the early return turned each `.leaseId` read into a compile error rather than a runtime surprise. Nullable lease locals (`admissionLeaseId`, `scanLeaseId`, `deepResearchLeaseId`) now guard the release/settle paths.

## ⚠️ Deliberately NOT converted — `lib/agent-workspace/storage-broker.ts`

Its three gates are a **different kind of limit**, and I didn't want to remove them on inference:

- `workspace-*-upload-bytes` / `-upload-objects` (lines 191, 202)
- `workspaceRetainedQuotaReason` (line 399)

These bound how much data an agent can **write and retain in S3** — not how fast it may ask a question. Making them observe-only means an agent loop can grow storage without bound, which is a spend and data-retention question rather than a rate-limit annoyance.

They're also structurally harder: the lease ids are persisted **positionally** into DB columns (`byteLeaseId`/`objectLeaseId`, [storage-broker.ts:412-413](lib/agent-workspace/storage-broker.ts#L412-L413)) through a `readonly [string, string]` tuple, so making them optional is a schema-touching change rather than a one-line edit.

Flagged for an explicit decision. Happy to do it — just want it to be a choice, not something done quietly at the end of a long night.

## Verified

- full suite: **411 suites / 3,973 tests pass**
- `tsc` clean — the sole remaining error (`agent-schedules-service`) is pre-existing and environment-only
- the three eslint warnings on touched files are pre-existing, confirmed by stashing