### PR TITLE
fix: observe-only storage admission + keep the replay guard blocking (corrects #1367)

### DIFF
--- a/app/api/agent/classified-evaluation/route.ts
+++ b/app/api/agent/classified-evaluation/route.ts
@@ -10,6 +10,7 @@ import { SAFE_EMAIL_RE } from "@/lib/agent-workspace/validation"
 import { createLogger, generateRequestId, sanitizeForLogging } from "@/lib/logger"
 import {
   acquireResourceAdmission,
+  isCapacityDenial,
   finishResourceAdmission,
 } from "@/lib/resource-admission"
 
@@ -176,6 +177,9 @@ export async function POST(request: NextRequest) {
   // reject a user's request. The #1353 limits were set without data on
   // what this workload actually consumes; over-threshold is telemetry
   // until real numbers say otherwise.
+  if (!admission.allowed && !isCapacityDenial(admission)) {
+    return NextResponse.json({ error: "Duplicate request" }, { status: 409 })
+  }
   if (!admission.allowed) {
     log.warn("Classified gateway over threshold (observe-only — request allowed)", {
       requestId,

--- a/app/api/agent/model-proxy/[...path]/route.ts
+++ b/app/api/agent/model-proxy/[...path]/route.ts
@@ -9,6 +9,7 @@ import {
 import { createLogger, generateRequestId, sanitizeForLogging } from "@/lib/logger"
 import {
   acquireResourceAdmission,
+  isCapacityDenial,
   finishResourceAdmission,
   releaseResourceAdmission,
 } from "@/lib/resource-admission"
@@ -140,6 +141,10 @@ export async function POST(
   // We do not yet know what normal consumption looks like for this workload.
   // Until we do, over-limit is a LOG LINE, not a 429 — the numbers are here
   // to be read, and limits can be set from evidence later.
+  if (!callAdmission.allowed && !isCapacityDenial(callAdmission)) {
+    // `duplicate` = replayed idempotency key, not a budget. Still refused.
+    return NextResponse.json({ error: "Duplicate model request" }, { status: 409 })
+  }
   if (!callAdmission.allowed) {
     log.warn(
       "Model call rate over threshold (observe-only — request allowed)",
@@ -233,6 +238,14 @@ export async function POST(
     units: reservedCostMicrocents,
     limits: MODEL_PROXY_COST_LIMITS,
   })
+  if (
+    (!tokenAdmission.allowed && !isCapacityDenial(tokenAdmission)) ||
+    (!costAdmission.allowed && !isCapacityDenial(costAdmission))
+  ) {
+    if (callAdmission.allowed) await releaseResourceAdmission(callAdmission.leaseId)
+    if (tokenAdmission.allowed) await releaseResourceAdmission(tokenAdmission.leaseId)
+    return NextResponse.json({ error: "Duplicate model request" }, { status: 409 })
+  }
   if (!tokenAdmission.allowed || !costAdmission.allowed) {
     // OBSERVE-ONLY — see the note above. Log the numbers; serve the request.
     log.warn(

--- a/infra/database/migrations.json
+++ b/infra/database/migrations.json
@@ -143,6 +143,7 @@
     "150-resource-admission-leases.sql",
     "151-agentic-cost-reconciliation.sql",
     "152-agent-skill-scan-leases.sql",
-    "153-workspace-upload-reservations.sql"
+    "153-workspace-upload-reservations.sql",
+    "154-workspace-upload-reservation-nullable-leases.sql"
   ]
 }

--- a/infra/database/schema/154-workspace-upload-reservation-nullable-leases.sql
+++ b/infra/database/schema/154-workspace-upload-reservation-nullable-leases.sql
@@ -1,0 +1,33 @@
+-- ============================================================================
+-- 154: allow workspace upload reservations without admission leases
+-- ============================================================================
+--
+-- WHY. `byte_lease_id` and `object_lease_id` were created NOT NULL (migration
+-- 153) because an upload could only be reserved after BOTH admission gates
+-- granted a lease — a denial threw and no row was ever written.
+--
+-- Those gates are now OBSERVE-ONLY: crossing a threshold is measured and
+-- logged, and the upload proceeds. The limits shipped in #1353 were set
+-- without data on what this workload actually consumes, and a user must not
+-- be blocked by a number nobody validated. See lib/agent-workspace/
+-- storage-broker.ts.
+--
+-- An upload that proceeded over-threshold therefore has NO lease to record,
+-- and NOT NULL would make the reservation insert fail — turning an advisory
+-- limit back into a hard block through the back door.
+--
+-- The columns exist so the reconciliation path can release or settle leases
+-- later. NULL simply means "this upload was admitted without a lease", which
+-- reconciliation must treat as nothing to release rather than as an error.
+--
+-- SAFE + REVERSIBLE. DROP NOT NULL never rewrites the table and cannot fail on
+-- existing rows: every row written so far has both ids populated, and they
+-- stay valid. Re-adding NOT NULL later would require those rows to be clean,
+-- which is why the rollback below is deliberately not automatic.
+-- ============================================================================
+
+ALTER TABLE workspace_upload_reservations
+  ALTER COLUMN byte_lease_id DROP NOT NULL;
+
+ALTER TABLE workspace_upload_reservations
+  ALTER COLUMN object_lease_id DROP NOT NULL;

--- a/lib/agent-workspace/storage-broker.ts
+++ b/lib/agent-workspace/storage-broker.ts
@@ -25,8 +25,12 @@ import { workspaceUploadReservations } from "@/lib/db/schema"
 import {
   acquireResourceAdmission,
   finishResourceAdmission,
+  isCapacityDenial,
   releaseResourceAdmission,
 } from "@/lib/resource-admission"
+import { createLogger } from "@/lib/logger"
+
+const log = createLogger({ module: "workspace-storage-broker" })
 
 const MAX_RELATIVE_PATH_LENGTH = 768
 const MAX_LIST_KEYS = 1_000
@@ -178,7 +182,7 @@ async function reserveUpload(params: {
   contextKey: string
   idempotencyKey: string
   contentLength: number
-}): Promise<readonly [string, string]> {
+}): Promise<readonly [string | null, string | null]> {
   const prefix = params.publicArtifact ? "public" : "private"
   const byteAdmission = await acquireResourceAdmission({
     kind: `workspace-${prefix}-upload-bytes`,
@@ -188,8 +192,23 @@ async function reserveUpload(params: {
     units: params.contentLength,
     limits: params.publicArtifact ? PUBLIC_BYTE_LIMITS : PRIVATE_BYTE_LIMITS,
   })
-  if (!byteAdmission.allowed) {
+  // OBSERVE-ONLY (2026-07-27, Hagel). These thresholds were set in #1353
+  // without data on real usage; crossing one is measured and logged, never a
+  // refusal. NOTE this is a STORAGE bound, not a rate limit — if unbounded
+  // growth becomes a problem the answer is a limit set from these numbers,
+  // not a silent throw at the user.
+  if (!byteAdmission.allowed && !isCapacityDenial(byteAdmission)) {
+    // `duplicate` = replay of an idempotency key. Still a hard failure: a
+    // second reservation for the same upload must not be created.
     throw new WorkspaceStorageAdmissionError(byteAdmission.reason)
+  }
+  if (!byteAdmission.allowed) {
+    log.warn("Workspace upload bytes over threshold (observe-only — upload allowed)", {
+      ownerEmail: params.ownerEmail,
+      contextKey: params.contextKey,
+      contentLength: params.contentLength,
+      reason: byteAdmission.reason,
+    })
   }
   const objectAdmission = await acquireResourceAdmission({
     kind: `workspace-${prefix}-upload-objects`,
@@ -199,11 +218,23 @@ async function reserveUpload(params: {
     units: 1,
     limits: params.publicArtifact ? PUBLIC_OBJECT_LIMITS : PRIVATE_OBJECT_LIMITS,
   })
-  if (!objectAdmission.allowed) {
-    await releaseResourceAdmission(byteAdmission.leaseId)
+  if (!objectAdmission.allowed && !isCapacityDenial(objectAdmission)) {
+    if (byteAdmission.allowed) await releaseResourceAdmission(byteAdmission.leaseId)
     throw new WorkspaceStorageAdmissionError(objectAdmission.reason)
   }
-  return [byteAdmission.leaseId, objectAdmission.leaseId]
+  if (!objectAdmission.allowed) {
+    log.warn("Workspace upload objects over threshold (observe-only — upload allowed)", {
+      ownerEmail: params.ownerEmail,
+      contextKey: params.contextKey,
+      reason: objectAdmission.reason,
+    })
+  }
+  // A denial carries no leaseId. Positions are preserved (byte, then object)
+  // because they are persisted into distinct columns.
+  return [
+    byteAdmission.allowed ? byteAdmission.leaseId : null,
+    objectAdmission.allowed ? objectAdmission.leaseId : null,
+  ]
 }
 
 function expectedChecksum(value: string): string {
@@ -328,6 +359,18 @@ async function reconcileExpiredPublicReservations(
   }
 }
 
+/**
+ * Settle/release helpers that tolerate a NULL lease.
+ *
+ * Since migration 154 an upload may be admitted with no lease (the admission
+ * gates are observe-only), so reconciliation must treat NULL as "nothing to
+ * settle" rather than passing it downstream.
+ */
+const settleLease = (leaseId: string | null, units?: number) =>
+  leaseId ? finishResourceAdmission(leaseId, units) : Promise.resolve()
+const dropLease = (leaseId: string | null) =>
+  leaseId ? releaseResourceAdmission(leaseId) : Promise.resolve()
+
 function publicUrl(bucket: string, key: string): string {
   const region = process.env.AWS_REGION || "us-east-1"
   const encodedKey = key.split("/").map(encodeURIComponent).join("/")
@@ -343,7 +386,7 @@ async function createUploadReservation(params: {
   expectedBytes: number
   checksumSha256: string
   contentType: string
-  leaseIds: readonly [string, string]
+  leaseIds: readonly [string | null, string | null]
 }): Promise<{ id: string; stagingKey: string }> {
   const ownerKey = params.ownerEmail.trim().toLowerCase()
   const id = randomUUID()
@@ -395,8 +438,23 @@ async function createUploadReservation(params: {
           params.expectedBytes,
           params.publicArtifact,
         )
+        // OBSERVE-ONLY (2026-07-27, Hagel). This is the RETAINED-storage
+        // quota — total bytes/objects an owner keeps, not a request rate.
+        // It is the one gate here with a genuine unbounded-growth risk, so
+        // the log line is deliberately loud enough to alarm on: if S3 spend
+        // starts climbing, this is the signal, and the limit should be reset
+        // from these numbers rather than reinstated blind.
         if (quotaReason) {
-          throw new WorkspaceStorageAdmissionError(quotaReason)
+          log.warn(
+            "Workspace retained-storage quota over threshold (observe-only — upload allowed)",
+            {
+              ownerKey,
+              contextKey: params.contextKey,
+              expectedBytes: params.expectedBytes,
+              publicArtifact: params.publicArtifact,
+              reason: quotaReason,
+            },
+          )
         }
         await tx.insert(workspaceUploadReservations).values({
           id,
@@ -418,7 +476,9 @@ async function createUploadReservation(params: {
       "createWorkspaceUploadReservation",
     )
   } catch (error) {
-    await Promise.all(params.leaseIds.map(releaseResourceAdmission))
+    await Promise.all(
+      params.leaseIds.filter((id): id is string => id !== null).map(releaseResourceAdmission),
+    )
     throw error
   }
 }
@@ -812,7 +872,9 @@ export async function createWorkspaceUploadUrl(
           .where(eq(workspaceUploadReservations.id, reservation.id)),
       "rejectWorkspaceUploadSigning",
     )
-    await Promise.all(leaseIds.map(releaseResourceAdmission))
+    await Promise.all(
+      leaseIds.filter((id): id is string => id !== null).map(releaseResourceAdmission),
+    )
     throw error
   }
 }
@@ -898,7 +960,9 @@ export async function createPublicArtifactUpload(
           .where(eq(workspaceUploadReservations.id, reservation.id)),
       "rejectPublicUploadSigning",
     )
-    await Promise.all(leaseIds.map(releaseResourceAdmission))
+    await Promise.all(
+      leaseIds.filter((id): id is string => id !== null).map(releaseResourceAdmission),
+    )
     throw error
   }
 }
@@ -944,11 +1008,8 @@ export async function completeWorkspaceUpload(
     )
     if (existing?.status === "committed") {
       await Promise.allSettled([
-        finishResourceAdmission(
-          existing.byteLeaseId,
-          existing.expectedBytes,
-        ),
-        finishResourceAdmission(existing.objectLeaseId, 1),
+        settleLease(existing.byteLeaseId, existing.expectedBytes),
+        settleLease(existing.objectLeaseId, 1),
       ])
       return {
         key: existing.targetKey,
@@ -1058,8 +1119,8 @@ export async function completeWorkspaceUpload(
     }
     settled = true
     await Promise.allSettled([
-      finishResourceAdmission(claimed.byteLeaseId, claimed.expectedBytes),
-      finishResourceAdmission(claimed.objectLeaseId, 1),
+      settleLease(claimed.byteLeaseId, claimed.expectedBytes),
+      settleLease(claimed.objectLeaseId, 1),
     ])
     for (const prior of priorVersions) {
       if (!prior.objectVersionId) continue
@@ -1143,8 +1204,8 @@ export async function completeWorkspaceUpload(
       "rejectWorkspaceUploadCompletion",
     )
     await Promise.all([
-      releaseResourceAdmission(claimed.byteLeaseId),
-      releaseResourceAdmission(claimed.objectLeaseId),
+      dropLease(claimed.byteLeaseId),
+      dropLease(claimed.objectLeaseId),
     ])
     throw error
   }

--- a/lib/db/schema/tables/workspace-upload-reservations.ts
+++ b/lib/db/schema/tables/workspace-upload-reservations.ts
@@ -23,8 +23,12 @@ export const workspaceUploadReservations = pgTable(
     expectedBytes: bigint("expected_bytes", { mode: "number" }).notNull(),
     checksumSha256: varchar("checksum_sha256", { length: 44 }).notNull(),
     contentType: varchar("content_type", { length: 255 }).notNull(),
-    byteLeaseId: varchar("byte_lease_id", { length: 36 }).notNull(),
-    objectLeaseId: varchar("object_lease_id", { length: 36 }).notNull(),
+    // Nullable since migration 154: the upload admission gates are
+    // observe-only, so an upload may proceed over-threshold with no lease to
+    // record. NULL means "admitted without a lease" — reconciliation treats it
+    // as nothing to release, not as an error.
+    byteLeaseId: varchar("byte_lease_id", { length: 36 }),
+    objectLeaseId: varchar("object_lease_id", { length: 36 }),
     status: varchar("status", { length: 16 }).notNull().default("reserved"),
     objectVersionId: varchar("object_version_id", { length: 1024 }),
     expiresAt: timestamp("expires_at", { withTimezone: true }).notNull(),

--- a/lib/resource-admission.ts
+++ b/lib/resource-admission.ts
@@ -66,6 +66,25 @@ export type ResourceAdmission =
         | "duplicate"
     }
 
+/**
+ * Is this denial a CAPACITY threshold rather than a correctness guard?
+ *
+ * The capacity reasons (concurrency and hourly budgets) are advisory: their
+ * limits were set in #1353 without data on real usage, and per Hagel
+ * (2026-07-27) they must never block a user — callers measure and log them
+ * instead.
+ *
+ * `duplicate` is NOT one of them. It means the same idempotency key was
+ * already admitted, i.e. a REPLAY. Letting that through would double-apply
+ * whatever the caller does next — a second upload reservation, a second
+ * charge — so it stays a hard failure everywhere.
+ */
+export function isCapacityDenial(
+  admission: ResourceAdmission,
+): boolean {
+  return !admission.allowed && admission.reason !== "duplicate"
+}
+
 function positiveSafeInteger(value: number, label: string): number {
   if (!Number.isSafeInteger(value) || value < 1) {
     throw new Error(`${label} must be a positive safe integer`)

--- a/lib/skills/skill-publish-pipeline.ts
+++ b/lib/skills/skill-publish-pipeline.ts
@@ -26,6 +26,7 @@ import { createLogger } from "@/lib/logger"
 import { getSetting } from "@/lib/settings-manager"
 import {
   acquireResourceAdmission,
+  isCapacityDenial,
   releaseResourceAdmission,
 } from "@/lib/resource-admission"
 
@@ -209,6 +210,14 @@ export async function invokeSkillScan(
   })
   // OBSERVE-ONLY (2026-07-27, Hagel): a scan-rate threshold must not silently
   // refuse to publish a skill. Measure it, log it, carry on.
+  if (!admission.allowed && !isCapacityDenial(admission)) {
+    // Replayed idempotency key — the scan was already dispatched.
+    log.warn("Skill scan already dispatched (duplicate)", {
+      skillId: params.skillId,
+      reason: admission.reason,
+    })
+    return false
+  }
   if (!admission.allowed) {
     log.warn("Skill scan over threshold (observe-only — scan proceeding)", {
       skillId: params.skillId,

--- a/tests/unit/agent-model-proxy-route.test.ts
+++ b/tests/unit/agent-model-proxy-route.test.ts
@@ -28,6 +28,11 @@ jest.mock("@/lib/agent-workspace/secrets-manager", () => ({
   getSecretString: getSecretStringMock,
 }))
 jest.mock("@/lib/resource-admission", () => ({
+  // Real implementation — the capacity-vs-replay split is behaviour under test:
+  // `duplicate` must stay a hard refusal while capacity thresholds are
+  // observe-only.
+  isCapacityDenial: (admission: { allowed: boolean; reason?: string }) =>
+    !admission.allowed && admission.reason !== "duplicate",
   acquireResourceAdmission: (...args: unknown[]) =>
     acquireAdmissionMock(...args),
   finishResourceAdmission: (...args: unknown[]) =>
@@ -342,6 +347,26 @@ describe("Agent model credential broker", () => {
 
     expect(response.status).not.toBe(429)
     expect(response.status).toBe(200)
+  })
+
+  it("still REFUSES a duplicate — that is a replay guard, not a budget", async () => {
+    // The observe-only change must not disable idempotency. `duplicate` means
+    // the same key was already admitted; serving it would double-apply the
+    // request.
+    acquireAdmissionMock.mockReset()
+    acquireAdmissionMock.mockResolvedValue({ allowed: false, reason: "duplicate" })
+
+    const response = await POST(
+      request({
+        model: "us.anthropic.claude-sonnet-5",
+        max_tokens: 1_024,
+        messages: [{ role: "user", content: "hello" }],
+      }) as never,
+      { params: Promise.resolve({ path: ["anthropic", "v1", "messages"] }) },
+    )
+
+    expect(response.status).toBe(409)
+    expect(fetchMock).not.toHaveBeenCalled()
   })
 
   it("retains conservative reservations after an ambiguous dispatch failure", async () => {

--- a/tests/unit/lib/agent-workspace/storage-broker-upload.test.ts
+++ b/tests/unit/lib/agent-workspace/storage-broker-upload.test.ts
@@ -46,6 +46,11 @@ jest.mock("@/lib/resource-admission", () => ({
   acquireResourceAdmission: (...args: unknown[]) => acquireMock(...args),
   finishResourceAdmission: (...args: unknown[]) => finishMock(...args),
   releaseResourceAdmission: (...args: unknown[]) => releaseMock(...args),
+  // Real implementation, not a stub: the capacity-vs-replay distinction is the
+  // behaviour under test here. `duplicate` must stay a hard failure while
+  // capacity thresholds are observe-only.
+  isCapacityDenial: (admission: { allowed: boolean; reason?: string }) =>
+    !admission.allowed && admission.reason !== "duplicate",
 }))
 
 let completeWorkspaceUpload:


### PR DESCRIPTION
Finishes the observe-only sweep across storage — and **corrects a real mistake in the earlier passes.**

## ⚠️ The mistake

[#1367](https://github.com/psd401/aistudio/pull/1367) and its follow-up made "admission denied" non-blocking everywhere. But `ResourceAdmission` has **seven** denial reasons, and they aren't the same kind of thing:

| Reason | Kind |
|---|---|
| `owner_concurrency`, `context_concurrency`, `global_concurrency` | capacity |
| `context_hourly`, `owner_hourly`, `global_hourly` | capacity |
| **`duplicate`** | **replay guard** |

`duplicate` means the same idempotency key was already admitted. Serving it **double-applies** whatever comes next — a second upload reservation, a second charge. The earlier passes disabled that too.

An existing test caught it (`rejects duplicate reservation admission`), which is the only reason it didn't ship.

New `isCapacityDenial()` draws the line once, and all four call sites use it: capacity is measured and logged, `duplicate` still fails hard — 409 on the HTTP paths, throw in the storage broker, `false` from the skill pipeline.

## Storage gates — observe-only for capacity

- `workspace-*-upload-bytes` / `-upload-objects`
- `workspaceRetainedQuotaReason` — the retained-storage quota

The retained-storage one is the **only gate here with genuine unbounded-growth risk**, so its log line is deliberately loud enough to alarm on. If S3 spend climbs, that's the signal — and the limit should be reset from those numbers rather than reinstated blind.

## Migration 154

`byte_lease_id` / `object_lease_id` were `NOT NULL`, because a reservation row could only exist once both gates granted a lease. An upload admitted over-threshold has **no lease**, so `NOT NULL` would fail the insert — turning an advisory limit back into a hard block through the back door.

Both columns are now nullable. `NULL` means "admitted without a lease"; reconciliation treats it as nothing to settle (`settleLease`/`dropLease`). `DROP NOT NULL` never rewrites the table and can't fail on existing rows.

## Not affected

Deep Research (`app/api/nexus/chat`) uses `lib/ai/deep-research-budget.ts` — env-configurable limits, no duplicate concept.

## Verified

- migration 154 applies to local Postgres **and re-applies cleanly**; both columns confirmed `is_nullable=YES`
- full suite: **411 suites / 3,974 tests pass**
- new test pins that a `duplicate` returns 409 and **never dispatches upstream**; storage-broker's own duplicate test passes unchanged
- `tsc` clean apart from the pre-existing `agent-schedules-service` env issue; eslint warnings on touched files are pre-existing