### PR TITLE
fix(agent-image): restore the #1161 runtime eval gate, and stop it degrading silently

### DIFF
--- a/docs/operations/agent-image-build-gate.md
+++ b/docs/operations/agent-image-build-gate.md
@@ -1,0 +1,202 @@
+# Agent Image Build-Time Eval Gate (#1161)
+
+`infra/agent-image/build-and-push.sh` refuses to push an agent image that has
+not been proven to boot and answer. This page documents the gate's four checks,
+how to satisfy the runtime half, and how to override it when you must.
+
+The gate exists because the image is an artifact optimised against an
+evaluator, and three separate regressions reached production before it did:
+a dead-boot image (r10), a missing provider (r11), and a silently truncated
+`SOUL.md`. Every one of them is caught on a laptop by the checks below.
+
+## The four checks
+
+| # | Check | Kind | Fails on |
+|---|-------|------|----------|
+| 1 | Instruction-budget (`check_bootstrap_budget.py`) | static | a bootstrap file that would be truncated at boot |
+| 2 | Config self-consistency (`check_config_consistency.py`) | static | bad `contextWindow` / `apiKey` hydration in `openclaw.json` |
+| 3 | Boot probe | runtime | no `BOOT_OK` within `PROBE_BOOT_TIMEOUT` (default 120s) |
+| 4 | Canary turn | runtime | `/invocations` does not answer `OK` |
+
+Static checks run before the build. The runtime checks run against the freshly
+built image, before `docker push`.
+
+## Why the runtime half needs a signed context
+
+Before PR #1353 the probe handed the container a Bedrock API key secret and let
+it call the model directly. It no longer can: **the image never receives a
+provider credential.** Model calls are brokered by the web tier at
+`APP_BASE_URL/api/agent/model-proxy`, which authorizes each request from two
+things the router Lambda normally supplies:
+
+- **`invocation_context`** — a short-lived HMAC-signed token binding
+  actor / owner / mode / session / workspace-prefix / expiry
+  (`infra/lambdas/agent-router/invocation-context.ts`).
+- **`invocation_request_proof_key`** — a key derived from that token's nonce,
+  used to sign each individual broker request.
+
+Both are required. `agentcore_wrapper.py`'s `_install_invocation_authority()`
+rejects the turn if either is missing or malformed, and
+`verifyAgentInvocationContext()` (`lib/agent-workspace/invocation-context.ts`)
+re-verifies both at the broker.
+
+The signing key lives in Secrets Manager at
+`psd-agent/<env>/invocation-signing-key`. The AgentCore execution role is
+explicitly **denied** read access to it (`DenyInvocationSigningSecret` in
+`infra/lib/agent-platform-stack.ts`), which is the whole point: prompt-driven
+code inside the container cannot forge another owner. A developer's own AWS
+credentials *can* read it, which is what makes a local probe possible.
+
+## Running the gate
+
+### The short version
+
+```bash
+cd infra/agent-image
+./build-and-push.sh 2026-07-27-my-change
+```
+
+That is usually all you need. When `AGENT_PROBE_APP_BASE_URL` and
+`AGENT_PROBE_INVOCATION_CONTEXT` are unset, the script:
+
+1. reads the broker origin from the deployed router Lambda's `APP_BASE_URL`
+   (via the stack's `RouterLambdaArn` output), and
+2. mints a fresh 15-minute canary context by running
+   `scripts/agent-workspace/mint-agent-probe-context.ts`.
+
+Both steps need AWS credentials for the target environment. If either fails,
+the build **stops** — it does not push an unverified image.
+
+### Minting a context by hand
+
+Useful when building against an environment other than the one your default
+credentials point at, when you want a longer TTL, or when debugging a probe
+failure:
+
+```bash
+# From the repo root — loads both variables into the current shell
+eval "$(bun run --silent agent:probe-context)"
+
+# Then build
+cd infra/agent-image
+AGENT_PROBE_APP_BASE_URL=https://dev.<your-domain> ./build-and-push.sh my-tag
+```
+
+`bun run agent:probe-context` prints two shell exports and a summary line on
+stderr:
+
+```
+export AGENT_PROBE_INVOCATION_CONTEXT='v1.eyJ2ZXJzaW9u...'
+export AGENT_PROBE_REQUEST_PROOF_KEY='kQ7f...'
+```
+
+Options (pass after `--`):
+
+| Flag | Default | Notes |
+|------|---------|-------|
+| `--env <name>` | `$ENVIRONMENT` or `dev` | selects `psd-agent/<env>/invocation-signing-key` |
+| `--secret-id <id>` | derived from `--env` | full Secrets Manager id or ARN |
+| `--owner <email>` | `canary@build-gate.invalid` | must have a dotted domain — the verifier's `SAFE_EMAIL_RE` rejects bare hostnames |
+| `--session <id>` | `probe-<uuid>` | recorded in the token |
+| `--ttl <seconds>` | `900` | 30–7200; the verifier caps token lifetime at 2h |
+| `--mode <mode>` | `owner` | `owner` \| `consultation` \| `scheduled` |
+| `--json` | off | machine-readable output |
+
+`AGENT_INVOCATION_SIGNING_SECRET` short-circuits Secrets Manager entirely —
+handy against a local `bun run dev:local` broker whose `.env.local` sets the
+same value.
+
+The script signs by importing the router Lambda's own
+`createInvocationContextToken()` / `deriveInvocationRequestProofKey()`, so the
+token format cannot drift away from what production issues.
+
+### Choosing `AGENT_PROBE_APP_BASE_URL`
+
+The probe container calls the broker over the network, and `mantle_proxy.py`
+only trusts an origin that is `https://…`, `http://127.0.0.1…`, or
+`http://localhost…`. In practice that means the deployed environment's URL
+(`https://dev.<domain>` for dev). A host-run `bun run dev:local` on port 3000 is
+**not** reachable as `http://host.docker.internal:3000` — that origin fails the
+trusted-broker check.
+
+## Environment variables
+
+| Variable | Effect |
+|----------|--------|
+| `AGENT_PROBE_APP_BASE_URL` | Broker origin for the probe. Auto-discovered from the router Lambda when unset. |
+| `AGENT_PROBE_INVOCATION_CONTEXT` | Signed context token. Auto-minted when unset. |
+| `AGENT_PROBE_REQUEST_PROOF_KEY` | Derived request-proof key. Auto-minted alongside the token. |
+| `PROBE_BOOT_TIMEOUT` | Seconds to wait for `BOOT_OK` (default 120). |
+| `PROBE_CANARY_TIMEOUT` | Seconds to wait for the canary answer (default 120). |
+| `CANARY_MESSAGE` | Canary prompt (default `Reply with exactly: OK`). |
+| `PROBE_ARTIFACT_DIR` | Where probe result JSON is written (default `infra/agent-image/.build-probes`). |
+
+### Bypasses
+
+Three separate flags, deliberately not one, so an emergency disables no more
+than it must:
+
+| Flag | Disables | When |
+|------|----------|------|
+| `ALLOW_UNVERIFIED_IMAGE=1` | turns a *skipped* runtime probe from a hard failure into a warning | you cannot reach the broker (no credentials, environment not deployed) and accept an unverified image |
+| `SKIP_PROBE_GATE=1` | checks 3–4 entirely, even when they could run | the probe itself is broken and blocking a release |
+| `SKIP_STATIC_GATE=1` | checks 1–2 | true emergency only — these are pure file checks with no external dependency |
+| `REQUIRE_PROBE_GATE=1` | nothing; **outranks** `ALLOW_UNVERIFIED_IMAGE` | CI, so an opt-in inherited from the environment cannot weaken the pipeline |
+
+`ALLOW_UNVERIFIED_IMAGE=1` does not print "PASSED". It prints:
+
+```
+=== Eval gate WAIVED — static checks only; image NOT boot-verified ===
+```
+
+and records `"allow_unverified": true` in the probe artifact, so an unverified
+image is identifiable after the fact.
+
+## Probe artifacts
+
+Each build writes `infra/agent-image/.build-probes/<tag>.json`:
+
+```jsonc
+// verified
+{"tag":"2026-07-27-x","boot_ok":true,"boot_elapsed_s":24,"canary_ok":true,"canary_elapsed_s":11}
+// waived
+{"tag":"2026-07-27-x","skipped":true,"reason":"missing_signed_broker_context","allow_unverified":true}
+```
+
+These make canary latency trendable across builds, and make it possible to ask
+"was this ECR tag ever boot-verified?" after the fact.
+
+## Troubleshooting
+
+**`Could not read the invocation signing secret …`**
+Your credentials cannot read `psd-agent/<env>/invocation-signing-key`. Check the
+profile/region, or that the environment's `AgentPlatformStack` is deployed.
+
+**Canary answer is `I couldn't verify the identity for this request.`**
+`_install_invocation_authority()` rejected the pair. Either the token expired
+(mint a fresh one — the default TTL is 15 minutes and the build itself takes
+time), or only one of the two variables is set.
+
+**Canary fails with a 403 from the broker.**
+The token verified locally but the web tier rejected it: usually a signing-key
+mismatch (context minted for `dev`, `AGENT_PROBE_APP_BASE_URL` pointing at
+prod), or clock skew beyond 30s between your host and the broker.
+
+**`APP_BASE_URL is not a trusted model broker URL`** in the container logs.
+The origin is not `https://` / `127.0.0.1` / `localhost`. See
+[Choosing `AGENT_PROBE_APP_BASE_URL`](#choosing-agent_probe_app_base_url).
+
+**Dead boot — `container exited before logging BOOT_OK`.**
+A real image defect, which is what the gate is for. `docker logs` output is
+echoed above the error; the last 40 lines usually name the failing import or
+config key.
+
+## Related
+
+- [`docs/operations/agent-platform-setup.md`](./agent-platform-setup.md) — full
+  deploy sequence, including the supply-chain pin refresh (SEC-009).
+- `infra/agent-image/build-and-push.sh` — the gate itself.
+- `scripts/agent-workspace/mint-agent-probe-context.ts` — the context minter.
+- `infra/lambdas/agent-router/invocation-context.ts` — the token format
+  (source of truth).
+- `lib/agent-workspace/invocation-context.ts` — the verifier.

--- a/docs/operations/agent-platform-setup.md
+++ b/docs/operations/agent-platform-setup.md
@@ -112,6 +112,14 @@ cd infra/agent-image
 ENVIRONMENT=prod ./build-and-push.sh 2026-04-16-initial
 ```
 
+`build-and-push.sh` runs a build-time eval gate (#1161) and refuses to push an
+image it could not prove boots and answers a real turn. On a first deploy the
+web tier and router Lambda do not exist yet, so the runtime probe cannot run —
+pass `ALLOW_UNVERIFIED_IMAGE=1` for this bootstrap build only, and let the gate
+run normally on every build after it. See
+[Agent Image Build-Time Eval Gate](./agent-image-build-gate.md) for the checks,
+how the probe's signed broker context is minted, and the bypass flags.
+
 #### 2.4 Deploy AgentCore Runtime
 
 Re-deploy the stack with the image tag to create the AgentCore Runtime:
@@ -261,6 +269,8 @@ To update the agent (new model config, system prompt changes, etc.):
 ```bash
 cd infra/agent-image
 # Edit Dockerfile, openclaw.json, psd-system-prompt.md as needed
+# The eval gate boot-verifies the image before pushing — see
+# docs/operations/agent-image-build-gate.md
 ./build-and-push.sh 2026-04-17-update-models
 
 # Redeploy with new image tag

--- a/infra/agent-image/build-and-push.sh
+++ b/infra/agent-image/build-and-push.sh
@@ -11,6 +11,13 @@
 #   - CDK stacks deployed (ECR repository must exist)
 #
 # The script reads the ECR repository URI from CloudFormation outputs.
+#
+# Build-time eval gate (#1161): the image must prove it boots and answers a real
+# turn before it is pushed. The runtime half needs a signed broker context; this
+# script mints one automatically when your AWS credentials allow it. If it
+# cannot, the build FAILS rather than pushing an unverified image — override
+# with ALLOW_UNVERIFIED_IMAGE=1 only when you accept that.
+# Full reference: docs/operations/agent-image-build-gate.md
 
 set -euo pipefail
 
@@ -135,35 +142,128 @@ docker build \
 # ---------------------------------------------------------------------------
 # Build-time eval gate (issue #1161): runtime boot probe + signed canary turn.
 # The image never receives a provider credential. A canary can run only when
-# the caller supplies the trusted web origin and a short-lived router-signed
-# invocation context. Otherwise the probe is skipped unless REQUIRE_PROBE_GATE
-# makes that a hard failure.
+# the caller supplies the trusted web origin plus a short-lived router-signed
+# invocation context AND its derived request-proof key — the web broker
+# (/api/agent/model-proxy) authorizes on all three, and agentcore_wrapper.py
+# refuses to install authority when either half of the pair is missing.
+#
+# Both halves are minted by scripts/agent-workspace/mint-agent-probe-context.ts
+# (`bun run agent:probe-context`), which signs with the same HMAC key the router
+# Lambda uses. This script auto-mints when the vars are unset and credentials
+# allow it, so the gate runs by default instead of quietly degrading.
+#
+# A skipped runtime probe is a HARD FAILURE unless ALLOW_UNVERIFIED_IMAGE=1 is
+# passed explicitly: "static gates passed" is not "the image boots", and an
+# unverified image reaching ECR is exactly the outcome #1161 exists to prevent.
 if [ "${SKIP_PROBE_GATE:-0}" = "1" ]; then
   echo ""
   echo "WARNING: SKIP_PROBE_GATE=1 — runtime boot/canary probe BYPASSED."
+  echo "         This image is NOT boot-verified. See docs/operations/agent-image-build-gate.md"
 else
   echo ""
   echo "=== Build-time eval gate (1161): runtime boot probe + canary turn ==="
   PROBE_APP_BASE_URL="${AGENT_PROBE_APP_BASE_URL:-}"
   PROBE_INVOCATION_CONTEXT="${AGENT_PROBE_INVOCATION_CONTEXT:-}"
+  PROBE_REQUEST_PROOF_KEY="${AGENT_PROBE_REQUEST_PROOF_KEY:-}"
 
   PROBE_DIR="${PROBE_ARTIFACT_DIR:-${SCRIPT_DIR}/.build-probes}"
   mkdir -p "${PROBE_DIR}"
   PROBE_ARTIFACT="${PROBE_DIR}/${TAG}.json"
 
-  if [ -z "${PROBE_APP_BASE_URL}" ] || [ -z "${PROBE_INVOCATION_CONTEXT}" ]; then
-    MSG="runtime probe SKIPPED — set AGENT_PROBE_APP_BASE_URL and a short-lived AGENT_PROBE_INVOCATION_CONTEXT. Static gates still enforced."
-    echo "WARNING: ${MSG}"
-    printf '{"tag":"%s","skipped":true,"reason":"missing_signed_broker_context"}\n' "${TAG}" > "${PROBE_ARTIFACT}"
+  # Auto-discovery 1: the broker origin. The router Lambda already holds the
+  # exact APP_BASE_URL the deployed agent brokers through, so read it from
+  # there rather than making every developer hardcode the environment's domain.
+  if [ -z "${PROBE_APP_BASE_URL}" ]; then
+    ROUTER_LAMBDA_ARN=$(aws cloudformation describe-stacks \
+      --stack-name "${STACK_NAME}" \
+      --query "Stacks[0].Outputs[?OutputKey=='RouterLambdaArn'].OutputValue" \
+      --output text --region "${REGION}" 2>/dev/null || echo "")
+    if [ -n "${ROUTER_LAMBDA_ARN}" ] && [ "${ROUTER_LAMBDA_ARN}" != "None" ]; then
+      PROBE_APP_BASE_URL=$(aws lambda get-function-configuration \
+        --function-name "${ROUTER_LAMBDA_ARN}" \
+        --query 'Environment.Variables.APP_BASE_URL' \
+        --output text --region "${REGION}" 2>/dev/null || echo "")
+      [ "${PROBE_APP_BASE_URL}" = "None" ] && PROBE_APP_BASE_URL=""
+      [ -n "${PROBE_APP_BASE_URL}" ] && \
+        echo "  Broker origin (from router Lambda): ${PROBE_APP_BASE_URL}"
+    fi
+  fi
+
+  # Auto-discovery 2: the signed context pair. Needs credentials that can read
+  # psd-agent/<env>/invocation-signing-key — a developer has them, the AgentCore
+  # execution role deliberately does not.
+  if [ -z "${PROBE_INVOCATION_CONTEXT}" ] || [ -z "${PROBE_REQUEST_PROOF_KEY}" ]; then
+    REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+    MINT_SCRIPT="${REPO_ROOT}/scripts/agent-workspace/mint-agent-probe-context.ts"
+    if command -v bun >/dev/null 2>&1 && [ -r "${MINT_SCRIPT}" ]; then
+      echo "  Minting a probe invocation context (bun run agent:probe-context)..."
+      MINT_JSON=$(ENVIRONMENT="${ENVIRONMENT}" AWS_REGION="${REGION}" \
+        bun run "${MINT_SCRIPT}" --json 2>&1) && MINT_STATUS=0 || MINT_STATUS=$?
+      if [ "${MINT_STATUS}" -eq 0 ]; then
+        # Parse tolerantly and on ONE line each: a non-JSON stdout (a bun
+        # notice, say) must fall through to the actionable message below, not
+        # abort the build via `set -e` on a failed command substitution.
+        MINT_PAIR=$(printf '%s' "${MINT_JSON}" | "${PYTHON}" -c '
+import json, sys
+try:
+    minted = json.loads(sys.stdin.read())
+    print(minted["invocationContext"])
+    print(minted["requestProofKey"])
+except Exception:
+    print(); print()' || printf '\n\n')
+        PROBE_INVOCATION_CONTEXT=$(printf '%s\n' "${MINT_PAIR}" | sed -n 1p)
+        PROBE_REQUEST_PROOF_KEY=$(printf '%s\n' "${MINT_PAIR}" | sed -n 2p)
+        [ -n "${PROBE_INVOCATION_CONTEXT}" ] && echo "  Minted a fresh probe context."
+      else
+        echo "  Could not mint a probe context automatically:"
+        printf '%s\n' "${MINT_JSON}" | tail -5 | sed 's/^/    /'
+      fi
+    else
+      echo "  Skipping auto-mint (bun or ${MINT_SCRIPT} unavailable)."
+    fi
+  fi
+
+  if [ -z "${PROBE_APP_BASE_URL}" ] || [ -z "${PROBE_INVOCATION_CONTEXT}" ] \
+     || [ -z "${PROBE_REQUEST_PROOF_KEY}" ]; then
+    MSG="runtime probe SKIPPED — no signed broker context, so the image is NOT boot-verified."
+    echo "WARNING: ${MSG}" >&2
+    echo "  To run the gate (see docs/operations/agent-image-build-gate.md):" >&2
+    echo "    eval \"\$(bun run --silent agent:probe-context)\"" >&2
+    echo "    export AGENT_PROBE_APP_BASE_URL=https://dev.<your-domain>" >&2
+    echo "    ./build-and-push.sh ${TAG}" >&2
+    echo "  To push an unverified image anyway, opt in explicitly:" >&2
+    echo "    ALLOW_UNVERIFIED_IMAGE=1 ./build-and-push.sh ${TAG}" >&2
+    printf '{"tag":"%s","skipped":true,"reason":"missing_signed_broker_context","allow_unverified":%s}\n' \
+      "${TAG}" "$([ "${ALLOW_UNVERIFIED_IMAGE:-0}" = "1" ] && echo true || echo false)" \
+      > "${PROBE_ARTIFACT}"
+    # REQUIRE_PROBE_GATE=1 (CI) outranks ALLOW_UNVERIFIED_IMAGE, so an
+    # inherited opt-in in the environment cannot weaken a pipeline.
     if [ "${REQUIRE_PROBE_GATE:-0}" = "1" ]; then
       echo "ERROR: REQUIRE_PROBE_GATE=1 but ${MSG}" >&2
       exit 1
     fi
+    if [ "${ALLOW_UNVERIFIED_IMAGE:-0}" != "1" ]; then
+      echo "ERROR: refusing to push an unverified image. ${MSG}" >&2
+      exit 1
+    fi
+    echo "WARNING: ALLOW_UNVERIFIED_IMAGE=1 — pushing without boot verification." >&2
     PROBE_RAN="false"
   else
     PROBE_RAN="true"
     PROBE_TIMEOUT="${PROBE_BOOT_TIMEOUT:-120}"
     CANARY_MESSAGE="${CANARY_MESSAGE:-Reply with exactly: OK}"
+    # The payload's user_email is identity metadata only — the broker derives
+    # the real owner from the signed claims. Read it back OUT of the token so
+    # the two can never disagree in logs, whoever minted the context.
+    CANARY_OWNER_EMAIL=$(printf '%s' "${PROBE_INVOCATION_CONTEXT}" | "${PYTHON}" -c '
+import base64, json, sys
+fallback = "canary@build-gate.invalid"
+try:
+    segment = sys.stdin.read().strip().split(".")[1]
+    claims = json.loads(base64.urlsafe_b64decode(segment + "=" * (-len(segment) % 4)))
+    print(claims.get("ownerEmail") or fallback)
+except Exception:
+    print(fallback)')
     CID=""
     # Always reap the probe container, even on failure/exit.
     cleanup_probe() { [ -n "${CID}" ] && docker rm -f "${CID}" >/dev/null 2>&1 || true; }
@@ -237,9 +337,14 @@ else
     # false-pass on the echoed "Reply with exactly: OK".
     echo "Canary turn: '${CANARY_MESSAGE}' (via /invocations)..."
     CANARY_TIMEOUT="${PROBE_CANARY_TIMEOUT:-120}"
+    # Both halves of the authority pair are mandatory: agentcore_wrapper.py's
+    # _install_invocation_authority() rejects the turn outright when either the
+    # signed context or its derived request-proof key is missing or malformed,
+    # and the web broker verifies a per-request signature made with that key.
     CANARY_PAYLOAD=$("${PYTHON}" -c \
-      'import json, sys; print(json.dumps({"prompt": sys.argv[1], "user_email": "canary@build-gate", "invocation_context": sys.argv[2]}))' \
-      "${CANARY_MESSAGE}" "${PROBE_INVOCATION_CONTEXT}")
+      'import json, sys; print(json.dumps({"prompt": sys.argv[1], "user_email": sys.argv[2], "invocation_context": sys.argv[3], "invocation_request_proof_key": sys.argv[4]}))' \
+      "${CANARY_MESSAGE}" "${CANARY_OWNER_EMAIL}" \
+      "${PROBE_INVOCATION_CONTEXT}" "${PROBE_REQUEST_PROOF_KEY}")
     CANARY_START=$(date +%s)
     CANARY_OUT=$(docker exec "${CID}" curl -sS -f -m "${CANARY_TIMEOUT}" \
       -X POST "http://127.0.0.1:8080/invocations" \
@@ -287,7 +392,10 @@ print(answer)')
   if [ "${PROBE_RAN}" = "true" ]; then
     echo "=== Eval gate PASSED — image is boot-verified and answers ==="
   else
-    echo "=== Eval gate PASSED (static checks only — runtime probe skipped; image NOT boot-verified) ==="
+    # Deliberately NOT the word "PASSED": the only way to reach this line is an
+    # explicit ALLOW_UNVERIFIED_IMAGE=1, and the banner must read as the waiver
+    # it is rather than as a green build.
+    echo "=== Eval gate WAIVED — static checks only; image NOT boot-verified ==="
   fi
   echo ""
 fi

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "test:smoke:agents-projects": "DATABASE_URL='postgresql://postgres:postgres@localhost:5432/aistudio' DB_SSL=false bun --preload ./tests/smoke/server-only-preload.js tests/smoke/unified-content-agents-projects.smoke.ts",
     "test:smoke:unified-content-lambda-artifact": "bun run scripts/test/unified-content-lambda-artifact.smoke.ts",
     "test:smoke:embedding-lambda-artifact": "bun run scripts/test/embedding-lambda-artifact.smoke.ts",
+    "agent:probe-context": "bun run scripts/agent-workspace/mint-agent-probe-context.ts",
     "test:skill:workspace": "cd infra/agent-image/skills/psd-workspace && bun test common.test.js",
     "test:skill:directory": "cd infra/agent-image/skills/psd-directory && bun test run.test.js",
     "test:skill:schedules": "cd infra/agent-image/skills/psd-schedules && bun test",

--- a/scripts/agent-workspace/mint-agent-probe-context.ts
+++ b/scripts/agent-workspace/mint-agent-probe-context.ts
@@ -1,0 +1,240 @@
+/**
+ * Mint a short-lived invocation context for the agent-image build gate (#1161).
+ *
+ * `infra/agent-image/build-and-push.sh` boots the freshly-built image and drives
+ * one real turn through `/invocations` before pushing. Since PR #1353 the image
+ * holds no provider credential: the model call is brokered by the web tier at
+ * `APP_BASE_URL/api/agent/model-proxy`, which authorizes the caller from a
+ * router-signed invocation context plus a per-request proof signature. So the
+ * probe needs BOTH of these, and they must be issued by something that can read
+ * the HMAC signing secret — which the AgentCore execution role is explicitly
+ * denied (agent-platform-stack.ts, `DenyInvocationSigningSecret`).
+ *
+ * This script is that issuer, for a human at a laptop. It signs a canary-owned
+ * context exactly the way the router Lambda does — by importing the router's own
+ * implementation, so there is no second copy of the token format to drift.
+ *
+ * Run (from the repo root):
+ *   bun run agent:probe-context                    # shell exports, ready to eval
+ *   bun run agent:probe-context -- --json          # machine-readable
+ *   eval "$(bun run --silent agent:probe-context)" # load into the current shell
+ *
+ * Requires AWS credentials that can read
+ * `psd-agent/<env>/invocation-signing-key`, or `AGENT_INVOCATION_SIGNING_SECRET`
+ * set directly (useful against a local `bun run dev:local` broker).
+ *
+ * See docs/operations/agent-image-build-gate.md.
+ */
+
+import { randomUUID } from "node:crypto"
+import {
+  createInvocationContextToken,
+  deriveInvocationRequestProofKey,
+  type InvocationMode,
+} from "../../infra/lambdas/agent-router/invocation-context"
+
+/** The wrapper's own guards (agentcore_wrapper.py) — fail here, not at boot. */
+const INVOCATION_CONTEXT_RE = /^v1\.[\w-]{40,3500}\.[\w-]{43}$/
+const REQUEST_PROOF_KEY_RE = /^[\w-]{43}$/
+/** lib/agent-workspace/validation.ts SAFE_EMAIL_RE — the verifier rejects anything else. */
+const SAFE_EMAIL_RE = /^[\w%+.-]+@[\d.A-Za-z-]+\.[A-Za-z]{2,}$/
+
+/**
+ * `.invalid` is reserved by RFC 2606, so this can never collide with a real
+ * mailbox — but it still satisfies the verifier's email shape. The web tier
+ * meters model-proxy spend per ownerEmail, so probe turns bill to their own
+ * bucket instead of a staff member's.
+ */
+const DEFAULT_OWNER = "canary@build-gate.invalid"
+const DEFAULT_TTL_SECONDS = 900
+
+interface Options {
+  environment: string
+  secretId: string | undefined
+  owner: string
+  sessionId: string
+  ttlSeconds: number
+  mode: InvocationMode
+  json: boolean
+}
+
+const USAGE = `Mint a short-lived AgentCore probe invocation context (#1161 build gate).
+
+Usage:
+  bun run agent:probe-context [-- options]
+
+Options:
+  --env <name>       Environment whose signing key to use (default: $ENVIRONMENT or "dev")
+  --secret-id <id>   Override the Secrets Manager id / ARN
+  --owner <email>    Canary actor+owner email (default: ${DEFAULT_OWNER})
+  --session <id>     Session id recorded in the token (default: probe-<uuid>)
+  --ttl <seconds>    Token lifetime, 30-7200 (default: ${DEFAULT_TTL_SECONDS})
+  --mode <mode>      owner | consultation | scheduled (default: owner)
+  --json             Emit JSON instead of shell exports
+  -h, --help         Show this help
+
+Environment:
+  AGENT_INVOCATION_SIGNING_SECRET     Use this secret verbatim, skip Secrets Manager
+  AGENT_INVOCATION_SIGNING_SECRET_ID  Default for --secret-id
+  AWS_REGION                          Region for Secrets Manager (default: us-east-1)
+`
+
+function parseArgs(argv: readonly string[]): Options {
+  const options: Options = {
+    environment: process.env.ENVIRONMENT ?? "dev",
+    secretId: process.env.AGENT_INVOCATION_SIGNING_SECRET_ID,
+    owner: DEFAULT_OWNER,
+    sessionId: `probe-${randomUUID()}`,
+    ttlSeconds: DEFAULT_TTL_SECONDS,
+    mode: "owner",
+    json: false,
+  }
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const flag = argv[index]
+    const takeValue = (): string => {
+      const value = argv[index + 1]
+      if (value === undefined || value.startsWith("--")) {
+        throw new Error(`${flag} requires a value`)
+      }
+      index += 1
+      return value
+    }
+    switch (flag) {
+      case "--env":
+        options.environment = takeValue()
+        break
+      case "--secret-id":
+        options.secretId = takeValue()
+        break
+      case "--owner":
+        options.owner = takeValue()
+        break
+      case "--session":
+        options.sessionId = takeValue()
+        break
+      case "--ttl":
+        options.ttlSeconds = Number(takeValue())
+        break
+      case "--mode": {
+        const mode = takeValue()
+        if (mode !== "owner" && mode !== "consultation" && mode !== "scheduled") {
+          throw new Error(`--mode must be owner|consultation|scheduled, got "${mode}"`)
+        }
+        options.mode = mode
+        break
+      }
+      case "--json":
+        options.json = true
+        break
+      case "-h":
+      case "--help":
+        console.log(USAGE)
+        process.exit(0)
+        break
+      default:
+        throw new Error(`Unknown argument "${flag}"\n\n${USAGE}`)
+    }
+  }
+
+  if (!SAFE_EMAIL_RE.test(options.owner)) {
+    throw new Error(
+      `--owner "${options.owner}" is not a shape the verifier accepts ` +
+        `(lib/agent-workspace/validation.ts SAFE_EMAIL_RE) — it needs a dotted domain, ` +
+        `e.g. ${DEFAULT_OWNER}`
+    )
+  }
+  if (!Number.isInteger(options.ttlSeconds) || options.ttlSeconds < 30 || options.ttlSeconds > 7200) {
+    throw new Error(`--ttl must be an integer between 30 and 7200, got "${options.ttlSeconds}"`)
+  }
+  return options
+}
+
+async function resolveSigningSecret(options: Options): Promise<string> {
+  const direct = process.env.AGENT_INVOCATION_SIGNING_SECRET
+  if (direct) return direct
+
+  const secretId = options.secretId ?? `psd-agent/${options.environment}/invocation-signing-key`
+  // Imported lazily so the AGENT_INVOCATION_SIGNING_SECRET path — the one used
+  // against a local broker — needs nothing from node_modules.
+  const { GetSecretValueCommand, SecretsManagerClient } = await import(
+    "@aws-sdk/client-secrets-manager"
+  )
+  const client = new SecretsManagerClient({ region: process.env.AWS_REGION ?? "us-east-1" })
+  const secret = await client
+    .send(new GetSecretValueCommand({ SecretId: secretId }))
+    .then((result) => result.SecretString ?? "")
+    .catch((error: unknown) => {
+      throw new Error(
+        `Could not read the invocation signing secret "${secretId}": ` +
+          `${error instanceof Error ? error.message : String(error)}\n` +
+          `Check your AWS credentials/region, or set AGENT_INVOCATION_SIGNING_SECRET directly.`
+      )
+    })
+  if (Buffer.byteLength(secret, "utf8") < 32) {
+    throw new Error(`Signing secret "${secretId}" is missing or shorter than 32 bytes`)
+  }
+  return secret
+}
+
+async function main(): Promise<void> {
+  const options = parseArgs(process.argv.slice(2))
+  const secret = await resolveSigningSecret(options)
+
+  const token = createInvocationContextToken(
+    secret,
+    {
+      actorEmail: options.owner,
+      ownerEmail: options.owner,
+      mode: options.mode,
+      sessionId: options.sessionId,
+      // The probe payload sends no workspace_prefix, so the token must not
+      // claim one either — the wrapper binds the microVM to what it is given.
+      workspacePrefix: "",
+    },
+    { ttlSeconds: options.ttlSeconds }
+  )
+  const requestProofKey = deriveInvocationRequestProofKey(secret, token)
+
+  // Reject locally rather than letting the container reject at canary time,
+  // where the failure reads as "the image is broken".
+  if (!INVOCATION_CONTEXT_RE.test(token)) {
+    throw new Error("Minted token does not match the wrapper's accepted shape")
+  }
+  if (!REQUEST_PROOF_KEY_RE.test(requestProofKey)) {
+    throw new Error("Derived request proof key does not match the wrapper's accepted shape")
+  }
+
+  const expiresAt = new Date((Math.floor(Date.now() / 1000) + options.ttlSeconds) * 1000)
+
+  if (options.json) {
+    console.log(
+      JSON.stringify(
+        {
+          invocationContext: token,
+          requestProofKey,
+          ownerEmail: options.owner,
+          sessionId: options.sessionId,
+          mode: options.mode,
+          expiresAt: expiresAt.toISOString(),
+        },
+        null,
+        2
+      )
+    )
+    return
+  }
+
+  // stderr, so `eval "$(...)"` picks up only the exports.
+  process.stderr.write(
+    `Minted ${options.mode} context for ${options.owner} (${options.environment}), ` +
+      `expires ${expiresAt.toISOString()}\n`
+  )
+  console.log(`export AGENT_PROBE_INVOCATION_CONTEXT='${token}'`)
+  console.log(`export AGENT_PROBE_REQUEST_PROOF_KEY='${requestProofKey}'`)
+}
+
+main().catch((error: unknown) => {
+  process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`)
+  process.exit(1)
+})


### PR DESCRIPTION
## Description

Since PR #1353 the build-time eval gate's runtime half has been dead. Every local build printed `Eval gate PASSED (static checks only)` and pushed an image that had never been proven to boot — the exact outcome #1161 exists to prevent. `psd-agent-base-dev:2026-07-26-directory` is in ECR unverified as a result.

Three separate defects, all fixed here.

### 1. The canary could never have passed

#1353 moved the probe from a Bedrock API key to a proxy-signed invocation context, but the payload it builds sends only `invocation_context`. `agentcore_wrapper.py`'s `_install_invocation_authority()` requires **both** that and the derived `invocation_request_proof_key`, and deletes the authority files and returns `False` when either is missing. Even with both documented env vars set, the probe would have answered *"I couldn't verify the identity for this request."* — so the silent skip was not merely the common path, it was the only path that exited 0.

The hardcoded `canary@build-gate` was a second dead end: it fails the verifier's `SAFE_EMAIL_RE` (`lib/agent-workspace/validation.ts:16`) because it has no dotted domain.

The payload now carries the full authority pair, and the canary's `user_email` is decoded from the token's own claims so the two can never disagree.

### 2. There was no way to mint the context

Nothing in the repo — docs, scripts, or comments — explained how to produce one, so the only reachable path was the silent skip.

Adds `scripts/agent-workspace/mint-agent-probe-context.ts` (`bun run agent:probe-context`), which signs by *importing* the router Lambda's own `createInvocationContextToken` / `deriveInvocationRequestProofKey` rather than reimplementing the token format, so the two cannot drift.

Documentation alone would have left the friction that caused the skipping, so `build-and-push.sh` also auto-discovers both inputs: the broker origin from the deployed router Lambda's `APP_BASE_URL`, and a fresh 15-minute context via the minter. With dev credentials the gate simply runs, unprompted.

### 3. A skipped probe reported success

It printed `PASSED` and exited 0 — the same failure shape as the undeployed-CFN-output skip already noted for #1161. Now:

- a skip is a **hard failure** unless `ALLOW_UNVERIFIED_IMAGE=1` is passed explicitly
- the banner reads `WAIVED`, not `PASSED`
- the probe artifact records `allow_unverified`, so an unverified image is identifiable after the fact
- `REQUIRE_PROBE_GATE=1` outranks the waiver, so an inherited opt-in cannot weaken CI
- the warning names the exact commands to run instead of leaving the next person guessing

### Documentation

`docs/operations/agent-image-build-gate.md` covers the four checks, why the runtime half needs a signed pair, how to mint one, the trusted-origin constraint on `APP_BASE_URL` (`mantle_proxy.py` only accepts `https://` / `127.0.0.1` / `localhost`, so `host.docker.internal` will not work), the bypass matrix, and troubleshooting. Linked from the script header, from the skip warning itself, and from the platform setup guide.

## Verification

- The minted pair was checked against an independent Python reimplementation of the verifier — wrapper shape guards (`_INVOCATION_CONTEXT_RE`, `_REQUEST_PROOF_KEY_RE`), HMAC signature, `isValidClaims`, expiry window, and request-proof key derivation all pass.
- All four gate branches exercised end to end against stubbed `aws`/`docker`: fail-closed (exit 1), waived (exit 0, `WAIVED`), `REQUIRE_PROBE_GATE` override (exit 1), and full auto-discover/auto-mint (exit 0, `PASSED`). The canary payload was captured and confirmed to contain the proof key with a matching `user_email`.
- `bash -n` clean; the documented `eval "$(bun run --silent agent:probe-context)"` workflow was run as written.
- Re-verified after rebasing onto latest `dev`, including against the updated `agentcore_wrapper.py` from #1364 — the two-halves contract is unchanged.
- **Lint / test / typecheck:** these could not be run in the authoring environment (npm registry returns 403 through its proxy, so `node_modules` could not be installed). CI has since run them — `Test, Lint, and Type Check` passed, as did `Validate CDK Infrastructure`, `check-sdk-version`, `Unified Content PostgreSQL Lifecycle`, CodeQL, and `claude-review`.

## Checklist

- [x] No `console.*` calls in production/shared code; all server-side logging uses Winston logger (`@/lib/logger`) — the new file is a standalone CLI under `scripts/`, where `no-console` is explicitly disabled by `eslint.config.mjs` Rule 5
- [x] **No imports or usage of `@/lib/logger` in client components or client hooks**
- [x] Client code uses `console.error` only for actionable errors in development — n/a, no client code
- [x] Lint passes — verified by CI (`Test, Lint, and Type Check`)
- [x] All tests pass — verified by CI
- [x] Types/interfaces follow project conventions
- [x] No type assertions (`as any`) without justification — none used
- [x] Database field names use snake_case — n/a, no DB access
- [x] TypeScript strict mode errors resolved — verified by CI
- [x] Environment variables handled securely and `.env.example` updated if needed — the new vars are build-time only and documented in the ops guide; no secret is written to disk or echoed
- [x] Documentation updated
- [ ] Code reviewed and approved
- [x] App builds and runs without module errors — n/a, no application code changed

## Related Issues

- Fixes the runtime half of the build-time eval gate from #1161
- Regression introduced by #1353
- Found while building `psd-agent-base-dev:2026-07-26-directory` for #1239