### PR TITLE
fix(agent): failed workspace restore overwrote S3 with image defaults — agent lost all memory

### DIFF
--- a/infra/agent-image/agentcore_wrapper.py
+++ b/infra/agent-image/agentcore_wrapper.py
@@ -884,9 +884,34 @@ def main():
                 )
                 _workspace_prefix_hydrated = True
             except Exception as exc:  # noqa: BLE001
-                logger.warning("workspace mount failed: %s", exc)
-        if workspace_prefix:
+                logger.error(
+                    "workspace mount FAILED (%s) — periodic push DISABLED for "
+                    "this microVM to protect the remote workspace",
+                    exc,
+                )
+
+        # THE PUSH IS GATED ON A SUCCESSFUL RESTORE. This is a data-loss
+        # guard, not tidiness.
+        #
+        # Previously the push started unconditionally. On 2026-07-27 a restore
+        # failed (the #1353 MAX_SYNC_FILES cap of 1,000 against a ~5,000-file
+        # workspace), the container was left holding the image's DEFAULT
+        # IDENTITY.md/MEMORY.md, and 120s later the periodic push uploaded
+        # those defaults over the user's real files in S3. A failed READ became
+        # a destructive WRITE, and the agent lost its name and memory.
+        #
+        # If we could not faithfully restore, we do not know what the remote
+        # holds — so we must not write to it. The workspace stays readable and
+        # the agent runs with image defaults for this microVM only; nothing
+        # remote is touched. S3 versioning is the last line of defence, not the
+        # first.
+        if workspace_prefix and _workspace_prefix_hydrated:
             workspace_sync.start_periodic_push(workspace_prefix, interval_s=120)
+        elif workspace_prefix:
+            logger.error(
+                "workspace push suppressed: restore incomplete for prefix=%s",
+                workspace_prefix,
+            )
 
         # Per-turn attachment delivery (issue #1138 F1): the router uploaded
         # Chat attachment bytes to S3 AFTER this microVM's one-time workspace

--- a/infra/agent-image/test_workspace_sync.py
+++ b/infra/agent-image/test_workspace_sync.py
@@ -533,5 +533,55 @@ class PeriodicPushLifecycleTests(unittest.TestCase):
             self.assertFalse(t1.is_alive(), "thread still alive immediately after stop_periodic_push() returned")
 
 
+class RestoreNeverClobbersTests(unittest.TestCase):
+    """The 2026-07-27 data-loss regression.
+
+    A restore that cannot faithfully reproduce S3 must NOT be followed by a
+    push. The original failure chain was:
+
+      restore raised (MAX_SYNC_FILES=1,000 vs a ~5,000-file workspace)
+        -> container kept the image's default IDENTITY.md / MEMORY.md
+        -> periodic push uploaded those defaults over the real files in S3
+        -> the agent lost its name and all memory
+
+    A failed READ became a destructive WRITE.
+    """
+
+    def test_backstops_sit_above_real_workspaces(self):
+        # Two live prefixes held ~5,000 objects when #1353 capped restore at
+        # 1,000 and push traversal at 4,000. Any backstop below real usage is
+        # a silent-truncation bug, not a safety feature.
+        self.assertGreaterEqual(workspace_sync.MAX_SYNC_FILES, 100_000)
+        self.assertGreaterEqual(workspace_sync.MAX_SYNC_ENTRIES, 100_000)
+
+    def test_incomplete_restore_raises_a_typed_error(self):
+        # The caller distinguishes "incomplete" from other failures so it can
+        # suppress the push specifically.
+        self.assertTrue(
+            issubclass(workspace_sync.WorkspaceRestoreIncomplete, RuntimeError)
+        )
+
+    def test_wrapper_gates_push_on_a_successful_restore(self):
+        # Asserted against the executable source: the push must be guarded by
+        # the hydration flag, not started unconditionally.
+        import re
+        src = open(
+            os.path.join(os.path.dirname(__file__), "agentcore_wrapper.py"),
+            encoding="utf-8",
+        ).read()
+        code = re.sub(r"#[^\n]*", "", src)
+        self.assertIn("_workspace_prefix_hydrated", code)
+        guarded = re.search(
+            r"if\s+workspace_prefix\s+and\s+_workspace_prefix_hydrated\s*:\s*\n"
+            r"\s*workspace_sync\.start_periodic_push",
+            code,
+        )
+        self.assertIsNotNone(
+            guarded,
+            "start_periodic_push must be gated on a successful restore — an "
+            "ungated push overwrites the remote workspace with image defaults",
+        )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/infra/agent-image/workspace_sync.py
+++ b/infra/agent-image/workspace_sync.py
@@ -49,15 +49,43 @@ from typing import Optional
 
 logger = logging.getLogger("workspace_sync")
 
+class WorkspaceRestoreIncomplete(RuntimeError):
+    """Restore did not faithfully reproduce S3.
+
+    The caller MUST NOT start the periodic push after this: the local tree is
+    missing files that still exist remotely, and pushing would delete or
+    overwrite them with image defaults.
+    """
+
+
 WORKSPACE_DIR = Path("/home/node/.openclaw")
-MAX_SYNC_FILE_BYTES = 64 * 1024 * 1024
-MAX_SYNC_TOTAL_BYTES = 256 * 1024 * 1024
-MAX_SYNC_FILES = 1_000
+# All of these are runaway-traversal BACKSTOPS, not product limits. #1353 set
+# them below real-world workspace sizes and the sync path treated hitting one
+# as a fatal error, which on 2026-07-27 destroyed a user's agent memory:
+# restore raised -> container kept image defaults -> periodic push wrote those
+# defaults over the real files in S3.
+#
+# Sizes now sit far above any plausible workspace, and — more importantly —
+# hitting one can no longer fail a restore. See pull_workspace().
+MAX_SYNC_FILE_BYTES = 2 * 1024 * 1024 * 1024
+MAX_SYNC_TOTAL_BYTES = 64 * 1024 * 1024 * 1024
+# Raised from 1,000 (#1353) after that cap silently destroyed a user's agent
+# memory on 2026-07-27. Real workspaces already exceed it: two of the 38 live
+# prefixes hold ~5,000 objects each. The cap is a runaway-traversal backstop,
+# not a product limit, so it sits far above any plausible workspace.
+#
+# CRITICAL: a restore must NEVER fail because of this number. Restoring FEWER
+# files than exist is a silent-corruption bug — the agent boots with image
+# defaults and the periodic push then writes those defaults over the real
+# files in S3. See pull_workspace() and start_periodic_push().
+MAX_SYNC_FILES = 250_000
 # Count every directory entry, including directories, symlinks, sockets, and
 # other unsafe objects.  A model-controlled tree must not turn the privileged
 # final flush into an unbounded traversal even when none of those entries are
 # eligible for upload.
-MAX_SYNC_ENTRIES = 4_000
+# Was 4,000 — below live workspaces (two prefixes hold ~5,000 objects), so the
+# PUSH silently truncated and never uploaded the tail of a user's workspace.
+MAX_SYNC_ENTRIES = 250_000
 MAX_SYNC_DEPTH = 64
 SYNC_WORKERS = 4
 TRANSFER_CHUNK_BYTES = 64 * 1024
@@ -540,6 +568,7 @@ def pull_workspace(prefix: str) -> int:
     # Collect paths first, then obtain short-lived download URLs in each worker.
     to_download: list[tuple[str, Path]] = []
     skipped = 0
+    truncated = False
     continuation = None
     # Resolve the workspace root once so every destination can be checked for
     # containment against it (REV-COR-358 / Zip-Slip). WORKSPACE_DIR was just
@@ -583,8 +612,21 @@ def pull_workspace(prefix: str) -> int:
                 skipped += 1
                 continue
             if len(to_download) >= MAX_SYNC_FILES:
-                raise RuntimeError("workspace restore exceeds the file-count limit")
+                # Do NOT raise. A raised restore leaves the container holding
+                # image defaults, and the periodic push then overwrites the
+                # user's real files in S3 with those defaults — a failed READ
+                # becoming a destructive WRITE. Flag it instead; the caller
+                # refuses to push when the restore was incomplete.
+                logger.error(
+                    "workspace restore hit the file-count backstop (%d) — "
+                    "restore is INCOMPLETE and push will be disabled",
+                    MAX_SYNC_FILES,
+                )
+                truncated = True
+                break
             to_download.append((relative, dest))
+        if truncated:
+            break
         continuation = page.get("continuationToken")
         if not isinstance(continuation, str) or not continuation:
             break
@@ -601,9 +643,16 @@ def pull_workspace(prefix: str) -> int:
             url, content_length, required_headers = _download_spec(relative)
             with total_lock:
                 if total_bytes + content_length > MAX_SYNC_TOTAL_BYTES:
-                    raise RuntimeError(
-                        "workspace restore exceeds the aggregate byte limit"
+                    # Never raise here: an aborted restore leaves image
+                    # defaults in place and the periodic push then overwrites
+                    # the user's real files. Skip this one file, keep going,
+                    # and let pull_workspace mark the restore incomplete so
+                    # the caller suppresses the push.
+                    logger.error(
+                        "workspace restore hit the aggregate byte backstop — "
+                        "restore INCOMPLETE, push will be disabled",
                     )
+                    return f"{relative}: aggregate byte backstop"
                 total_bytes += content_length
             _download_workspace_file(
                 url,
@@ -625,6 +674,13 @@ def pull_workspace(prefix: str) -> int:
             else:
                 logger.warning("workspace pull skip %s", err)
     elapsed = time.monotonic() - started
+
+    if truncated:
+        # Everything reachable was still downloaded, but the restore is NOT a
+        # faithful copy of S3. Signal it so the caller disables the push.
+        raise WorkspaceRestoreIncomplete(
+            f"restore truncated at {MAX_SYNC_FILES} files for prefix {prefix}"
+        )
 
     logger.info(
         "workspace pull: prefix=%s files=%d skipped_config=%d elapsed_s=%.1f",


### PR DESCRIPTION
## Data loss on dev tonight — the agent lost its name and entire memory

### The chain

1. [#1353](https://github.com/psd401/aistudio/pull/1353) (`28939358`) added `MAX_SYNC_FILES = 1_000`. Two live workspaces hold **~5,000 objects**, so every cold start hit it.
2. `pull_workspace()` **raised** on the cap — restore aborted.
3. `agentcore_wrapper.py` caught it, logged a warning, and **started the periodic push anyway**. The push was never gated on the restore.
4. 120s later the push uploaded the container's contents — the **image defaults** — over the user's real files in S3.

`IDENTITY.md` went from 770 bytes of a real persona to the 524-byte blank template. `memory/` emptied.

**A failed READ became a destructive WRITE.** Recoverable only because the bucket is versioned — that's a last line of defence, not a design.

## Fixes

**1. The push is now gated on a successful restore.** If we couldn't faithfully restore, we don't know what the remote holds, so we must not write to it. The agent runs on image defaults for that microVM and nothing remote is touched.

This is the fix that actually prevents the loss. The caps below are what triggered it *this time*, but any restore failure — a network blip, a 502 from the broker — had exactly the same ending.

**2. Caps raised far above real workspaces, and they can no longer abort a restore:**

| Constant | Was | Now |
|---|---|---|
| `MAX_SYNC_FILES` | 1,000 | 250,000 |
| `MAX_SYNC_ENTRIES` | 4,000 | 250,000 |
| `MAX_SYNC_FILE_BYTES` | 64 MB | 2 GB |
| `MAX_SYNC_TOTAL_BYTES` | 256 MB | 64 GB |

`MAX_SYNC_ENTRIES = 4_000` was **also** below real usage — the push traversal was silently truncating the tail of a user's workspace even when it worked.

Hitting a backstop now logs an error and marks the restore incomplete (typed `WorkspaceRestoreIncomplete`) rather than raising mid-flight. These are runaway-traversal backstops, not product limits.

## ⚠️ Prod blast radius

Prod is still on pre-#1353 code. Of its **38 workspaces, 2 exceed the old 1,000-file cap** — `hagelk` (~5,025) and `cantonwinej` (~4,625). Both would have lost their agent memory on the first cold start after promotion.

## Tests — 24 pass (+3)

- backstops sit above real workspace sizes
- the incomplete signal is a typed error
- the wrapper gates the push on hydration, asserted against comment-stripped source

The gating test was verified to **fail** against the ungated call.