### PR TITLE
fix(e2e): green the local functional gate — stale 401 specs + unapplied-migration hardening

### DIFF
--- a/scripts/test/e2e-local.sh
+++ b/scripts/test/e2e-local.sh
@@ -247,6 +247,23 @@ else
   fi
 fi
 
+# --- Apply pending migrations to the LOCAL database --------------------------------
+# A migration merged to dev but never applied locally silently breaks every route
+# that touches the new table — e.g. the durable API rate limiter (migration 146)
+# fails CLOSED, so every /api/v1 request 429s and ~30 authed specs go red with no
+# obvious cause (2026-07-26 incident: gate red on pristine dev because migrations
+# 146-153 were unapplied). The runner is idempotent (skips completed files) and
+# targets ONLY the local DB, so this is a no-op costing ~2s on an up-to-date DB.
+if docker exec -i aistudio-postgres pg_isready -U postgres >/dev/null 2>&1; then
+  echo "e2e-local: applying pending local DB migrations…"
+  if ! DATABASE_URL="${E2E_DATABASE_URL:-postgresql://postgres:postgres@localhost:5432/aistudio}" \
+    DB_SSL="${E2E_DB_SSL:-false}" \
+    bun scripts/db/run-migrations.ts >/dev/null 2>&1; then
+    echo "❌ e2e-local: local DB migration run failed — run 'bun run db:migrate' for details"
+    exit 1
+  fi
+fi
+
 # --- Seed the LOCAL database idempotently -----------------------------------------
 # Allowed: local Docker postgres is fair game (Aurora is off-limits; only
 # data-destroying commands are forbidden). `docker exec … psql` matches `db:seed`.

--- a/tests/e2e/agent-workspace-connect.spec.ts
+++ b/tests/e2e/agent-workspace-connect.spec.ts
@@ -35,18 +35,22 @@ test.describe('Agent Connect — public pages', () => {
 })
 
 test.describe('Agent Consent Link API — auth gate', () => {
-  test('POST /api/agent/consent-link without Authorization returns 401', async ({ request }) => {
+  // Since the security remediation (53fd0968), this route authenticates via a
+  // router-signed invocation-context header instead of a shared-secret bearer,
+  // and answers 403 when the context is missing or unverifiable. Owner
+  // selectors in the body are rejected too, but auth is checked first.
+  test('POST /api/agent/consent-link without invocation context returns 403', async ({ request }) => {
     const resp = await request.post('/api/agent/consent-link', {
-      data: { ownerEmail: 'hagelk@psd401.net' },
+      data: { kind: 'user_account' },
     })
-    expect(resp.status()).toBe(401)
+    expect(resp.status()).toBe(403)
   })
 
-  test('POST /api/agent/consent-link with wrong bearer returns 401', async ({ request }) => {
+  test('POST /api/agent/consent-link with a stale bearer secret returns 403', async ({ request }) => {
     const resp = await request.post('/api/agent/consent-link', {
       headers: { Authorization: 'Bearer not-the-real-key' },
-      data: { ownerEmail: 'hagelk@psd401.net' },
+      data: { kind: 'user_account' },
     })
-    expect(resp.status()).toBe(401)
+    expect(resp.status()).toBe(403)
   })
 })


### PR DESCRIPTION
# fix(e2e): green the local functional gate — stale 401 specs + unapplied-migration hardening

## Problem

The pre-push e2e-local gate was RED on pristine dev (b4f8a021 and after): 33–34 functional specs failing across four clusters (agent-workspace-connect, atrium-*, decision-*, nexus-projects), blocking every push from every branch. These specs are session-mint gated (`PLAYWRIGHT_AUTH_ENABLED`) and never run in CI, which is how the breaking merges landed green.

## Root causes (per cluster)

### 1. agent-workspace-connect — stale spec (implementation change was intentional)

The security remediation (53fd0968, PR #1353) replaced the shared-secret Bearer auth on `POST /api/agent/consent-link` with a router-signed invocation context (`verifyAgentInvocationContext`), returning **403** where the old code returned **401**. The two auth-gate specs still expected 401.

**Fix:** updated `tests/e2e/agent-workspace-connect.spec.ts` to expect 403 and stopped sending `ownerEmail` (owner selectors are now rejected server-side).

### 2. atrium-*, decision-*, nexus-projects — environment: migrations 146–154 unapplied locally (NOT a code bug)

The same security remediation added durable, DB-backed rate limiting: `checkRateLimit()` in `lib/api/rate-limiter.ts` now runs a reservation transaction against `api_rate_limit_reservations` (migration 146) for **every** `withApiAuth` request — session auth included — and **fails closed** on DB error.

The local DB's `migration_log` stopped at `141-oneroster-core.sql`; migrations 146–153 (renumbered reservation/lease tables from the remediation) plus 154 were never applied. Result: every `/api/v1/*` and `/api/mcp` request 429'd. Evidence from the gate server log:

```
error: Rate limit check failed, denying request
  "authType": "session",
  "error": "Failed query: delete from \"api_rate_limit_reservations\" where ..."
```

(74 occurrences in one suite run.) Every failing atrium/decision/nexus spec drives a `withApiAuth` route.

**Fix (this PR):** `scripts/test/e2e-local.sh` now runs the idempotent local migration runner (`scripts/db/run-migrations.ts`) before seeding, failing fast with a clear message if it errors. A merged migration can no longer silently redden the gate; up-to-date DBs pay ~2s. Applied migrations 146–154 to the local DB as part of verification.

## Verification

- Baseline (pristine dev f7f3ea01, before fix): 250 passed / 33 unique specs failed / 2 flaky — reproducing the reported clusters.
- After (dev d1585090 + this branch, migrations applied): **285 passed / 0 failed / 0 flaky / 34 skipped** — twice (direct run 6.4m, then again in the pre-push hook 5.7m). 285 = 250 baseline + 33 formerly failing + 2 formerly flaky.
- `bun run lint`: 0 errors (476 pre-existing warnings, none in touched files). `bun run typecheck`: exit 0.

## Notes / follow-ups (not in this PR)

- `checkRateLimit` now rate-limits **session** principals at DEFAULT_RPM=60/min, though its docstring and the `withApiAuth` call-site comment both still say "API key only" (the pre-remediation code had an explicit session early-return). If extending to sessions was intentional, the comments should be updated; if not, the early-return should come back. Flagging rather than changing audit-driven behavior.
- `checkRateLimit` inserts `endpoint: "/api/mcp"` hardcoded for all routes.
