### PR TITLE
fix(waf): per-IP rate rule was blocking the agent's own API calls (4,849 blocks in one window)

### DIFF
--- a/infra/lib/frontend-stack-ecs.ts
+++ b/infra/lib/frontend-stack-ecs.ts
@@ -390,7 +390,22 @@ export class FrontendStackEcs extends cdk.Stack {
       defaultAction: { allow: {} },
       description: `WAF for AIStudio ${environment} environment`,
       rules: [
-        // Rate limiting rule
+        // Per-IP rate limiting for BROWSER traffic.
+        //
+        // scopeDownStatement excludes /api/agent/* — server-to-server calls
+        // from the agent runtime. Those arrive from a handful of NAT egress
+        // IPs, so a per-IP browser budget counts an entire fleet as one
+        // client. #1353 routed every agent LLM call through
+        // /api/agent/model-proxy, and an agentic turn makes many calls per
+        // user message; on 2026-07-27 that produced 4,849 blocked requests in
+        // a single 5-minute window and the dev agent could not answer at all.
+        // The rule itself (added #306, 2025-10-03) is unchanged and still
+        // correct for the browser traffic it was written for.
+        //
+        // Excluding this prefix does not remove authentication: /api/agent/*
+        // is gated by a proxy-signed invocation context
+        // (verifyAgentInvocationContext) and, in the deployed runtime, by the
+        // Cedar egress allowlist. The WAF was never what protected it.
         {
           name: 'RateLimitRule',
           priority: 1,
@@ -398,6 +413,20 @@ export class FrontendStackEcs extends cdk.Stack {
             rateBasedStatement: {
               limit: 2000, // 2000 requests per 5 minutes per IP
               aggregateKeyType: 'IP',
+              scopeDownStatement: {
+                notStatement: {
+                  statement: {
+                    byteMatchStatement: {
+                      fieldToMatch: { uriPath: {} },
+                      positionalConstraint: 'STARTS_WITH',
+                      searchString: '/api/agent/',
+                      textTransformations: [
+                        { priority: 0, type: 'NONE' },
+                      ],
+                    },
+                  },
+                },
+              },
             },
           },
           action: {

--- a/tests/unit/waf-agent-api-scope-down.test.ts
+++ b/tests/unit/waf-agent-api-scope-down.test.ts
@@ -1,0 +1,69 @@
+/**
+ * The WAF per-IP rate rule must not count agent server-to-server traffic.
+ *
+ * `RateLimitRule` (added in #306, 2025-10-03) blocks at 2,000 requests per
+ * 5 minutes per IP. That is correct for browsers, which arrive from many
+ * distinct addresses.
+ *
+ * #1353 routed every agent LLM call through /api/agent/model-proxy. Those
+ * requests leave the AgentCore runtime through a handful of NAT egress IPs,
+ * so a per-IP browser budget counts an entire agent fleet as ONE client — and
+ * a single agentic turn makes many model calls. On 2026-07-27 that produced
+ * 4,849 WAF-blocked requests in one 5-minute window and the dev agent could
+ * not answer at all. The agent surfaced it as:
+ *
+ *   {"error": "Too many requests. Please try again later."}
+ *
+ * which is the WAF's custom response body, not application code — so nothing
+ * in the app logs explained it.
+ *
+ * The fix is a scopeDownStatement excluding /api/agent/*. That path is
+ * authenticated by a proxy-signed invocation context and, in the deployed
+ * runtime, restricted by the Cedar egress allowlist; the WAF was never what
+ * protected it.
+ *
+ * This test reads the CDK source because CI does not run the infra jest
+ * suite, so an assertion placed there would never execute.
+ */
+
+import fs from "node:fs"
+import path from "node:path"
+
+const source = fs
+  .readFileSync(
+    path.join(process.cwd(), "infra/lib/frontend-stack-ecs.ts"),
+    "utf8",
+  )
+  // Assert against executable source: the rationale above is also written in
+  // comments beside the rule, and prose must not be what keeps this green.
+  .replace(/\/\*[\s\S]*?\*\//g, "")
+  .replace(/\/\/[^\n]*/g, "")
+
+describe("WAF rate limiting vs the agent API", () => {
+  it("still rate-limits by IP", () => {
+    // Guard the parser: if the rule were renamed or removed, every assertion
+    // below would pass vacuously.
+    expect(source).toContain("RateLimitRule")
+    expect(source).toContain("rateBasedStatement")
+    expect(source).toContain("aggregateKeyType: 'IP'")
+  })
+
+  it("excludes /api/agent/ from the per-IP budget", () => {
+    expect(source).toContain("scopeDownStatement")
+    expect(source).toContain("notStatement")
+    expect(source).toContain("searchString: '/api/agent/'")
+    expect(source).toContain("positionalConstraint: 'STARTS_WITH'")
+  })
+
+  it("keeps the exclusion inside the rate rule, not a separate allow", () => {
+    // A top-level allow rule for /api/agent/ would also stop the blocking,
+    // but it would bypass the managed rule sets too. The exclusion has to be
+    // scoped to the rate statement alone.
+    const rateIdx = source.indexOf("rateBasedStatement")
+    const scopeIdx = source.indexOf("scopeDownStatement")
+    const managedIdx = source.indexOf("AWSManagedRulesCommonRuleSet")
+    expect(rateIdx).toBeGreaterThan(-1)
+    expect(scopeIdx).toBeGreaterThan(rateIdx)
+    expect(managedIdx).toBeGreaterThan(scopeIdx)
+  })
+})


### PR DESCRIPTION
## The dev agent couldn't complete a turn

```
⚠️ API rate limit reached. Please try again later.
rawError={"error": "Too many requests. Please try again later."}
```

That string isn't application code — it's the **WAF's custom response body** (`RateLimitBody` in `frontend-stack-ecs.ts`). Which is exactly why **nothing in the app logs explained it**: the request never reached the route.

CloudWatch `AWS/WAFV2 BlockedRequests` for `RateLimitRule`: **4,849 blocked in a single 5-minute window.**

## Why now

`RateLimitRule` is unchanged since [#306](https://github.com/psd401/aistudio/pull/306) (2025-10-03): **2,000 requests / 5 min, aggregated per IP**. That's a sensible budget for *browsers*, which arrive from many distinct addresses.

[#1353](https://github.com/psd401/aistudio/pull/1353) routed every agent LLM call through `/api/agent/model-proxy`. Those leave the AgentCore runtime through **a handful of NAT egress IPs** — so a per-IP browser budget now counts an entire agent fleet as one client, and a single agentic turn makes many model calls, each re-sending context.

The limit is old and correct. The traffic pattern through it is one day old.

## Fix

A `scopeDownStatement` on the rate rule excluding `/api/agent/*`. Rate limiting is **unchanged for every other path**.

This doesn't remove authentication from that prefix — `/api/agent/*` is gated by a proxy-signed invocation context (`verifyAgentInvocationContext`) and, in the deployed runtime, by the Cedar egress allowlist. The WAF was never what protected it.

**Deliberately not done:** raising the global limit. That would weaken the rule for real browser traffic to accommodate a fleet it was never meant to measure.

## Tests — 3

- the rule still rate-limits by IP
- `/api/agent/` is excluded
- the exclusion lives **inside the rate statement**, not as a top-level allow — a blanket allow would also stop the blocking, but would bypass the managed rule sets with it

Verified to **fail** with the scope-down removed (2 of 3).

Placed in `tests/unit` rather than `infra/test` because **CI doesn't run the infra jest suite**, so an assertion there would never execute. Asserted against comment-stripped source so the rationale beside the rule can't keep it green.