### PR TITLE
feat(oneroster): reconcile roster-managed roles

### DIFF
--- a/actions/admin/user-management.actions.ts
+++ b/actions/admin/user-management.actions.ts
@@ -579,8 +579,9 @@ export async function updateUser(
 
         // Delete+insert lives in the shared helper — this logic was
         // copy-pasted across three call sites and drifted once already
-        // (#1222 review). Managed (source='group-sync') rows stay invisible
-        // to this editor: never deleted, never re-inserted as 'manual'.
+        // (#1222 review). Managed (source='group-sync' or 'oneroster') rows
+        // stay invisible to this editor: never deleted, never re-inserted as
+        // 'manual'.
         const submittedRoleIds = roleList.map((role) => role.id)
         await syncManualUserRoles(tx, userId, submittedRoleIds)
 

--- a/docs/features/oneroster-classlink-sync.md
+++ b/docs/features/oneroster-classlink-sync.md
@@ -3,8 +3,10 @@
 Status: v1 ingestion foundation and administrator control surface implemented by Epic
 [#1308](https://github.com/psd401/aistudio/issues/1308), Issue
 [#1310](https://github.com/psd401/aistudio/issues/1310), and Issue
-[#1311](https://github.com/psd401/aistudio/issues/1311). Role mapping, room
-provisioning, and reporting are separate workstreams.
+[#1311](https://github.com/psd401/aistudio/issues/1311). Optional roster role
+reconciliation is implemented by Issue
+[#1312](https://github.com/psd401/aistudio/issues/1312). Room provisioning and
+reporting are separate workstreams.
 
 ## Scope and data boundary
 
@@ -19,11 +21,14 @@ terms and OneRoster user roles into their relationship tables.
 - Demographics, metadata, resources, and other unnecessary student data are
   neither requested nor persisted.
 - Roster email is normalized to lowercase for the later cross-system user join.
-- This Lambda never writes application users, application role grants,
-  capabilities, API-key scopes, rooms, or assistants. In particular, ingestion
-  cannot grant or revoke the administrator role.
-- The Lambda modifies only the dedicated OneRoster tables and its internal
-  `ONEROSTER_LAST_PERM_REV` setting.
+- Collection ingestion never writes application users, role grants,
+  capabilities, API-key scopes, rooms, or assistants. A separate, default-off
+  post-sync pass may write source-owned `student` and `staff` role grants as
+  described below; it cannot grant or revoke the administrator role.
+- Collection reconciliation modifies only the dedicated OneRoster tables and
+  internal sync settings. The optional role pass additionally modifies
+  `user_roles.source='oneroster'` rows and bumps `users.role_version` for users
+  whose grants changed.
 
 The implementation follows ClassLink's guidance to pull the bulk collections
 with a 10,000-record page size and verify `x-count` and `x-total-count`.
@@ -124,6 +129,7 @@ All values are database-first. The Next.js accessors in
 | Key | Required | Default | Meaning |
 | --- | --- | --- | --- |
 | `ROSTER_SYNC_ENABLED` | yes for scheduled runs | `false` | Exact value `true` enables the nightly rule's work. Manual invocation can run while disabled. |
+| `ROSTER_ROLE_SYNC_ENABLED` | no | `false` | Exact value `true` enables the best-effort application-role pass after a fully successful scheduled sync. Manual sync never changes roles. |
 | `ONEROSTER_BASE_URL` | yes | none | HTTPS direct-server origin or application-specific proxy prefix. |
 | `ONEROSTER_AUTH_MODE` | yes | none | `oauth1` or `proxy`. |
 | `ONEROSTER_CREDENTIALS_SECRET_ARN` | yes | none | Full ARN of the scoped secret described above. |
@@ -134,6 +140,34 @@ All values are database-first. The Next.js accessors in
 
 Set the URL, auth mode, secret ARN, version, and page size before enabling the
 schedule. A missing or incomplete configuration safely skips the invocation.
+
+## Optional roster-driven application roles
+
+`ROSTER_ROLE_SYNC_ENABLED` is deliberately default-off. When its exact value is
+`true`, a fully successful **scheduled** roster sync runs one additional
+transaction:
+
+- Active OneRoster `student` roles map to AI Studio `student`.
+- Active OneRoster `teacher`, `aide`, `proctor`, and `administrator` roles map
+  to AI Studio `staff`. Recognized vendor staff/administrator spellings also
+  map to `staff`; family roles and unknown values fail closed and grant nothing.
+- Roster email joins application users with
+  `lower(users.email) = lower(oneroster_users.email)`. Roster people who have
+  never signed in are skipped without error.
+- New grants use `user_roles.source='oneroster'`. The transaction removes only
+  stale `oneroster` rows; `manual` and `group-sync` rows are invisible to it.
+- A mapped role already held from another source is left under that source.
+  `users.role_version` increments once for each user whose rows actually
+  changed, and does not churn on a no-op.
+- The application `administrator` role is not a possible mapping and is
+  structurally excluded from deletion. This path therefore cannot invoke the
+  last-administrator case. Any future change that could remove administrator
+  must use the shared `LAST_ADMIN_GUARD_LOCK_KEY` advisory-lock discipline.
+
+The pass runs only after all six roster collections are confirmed successful,
+including a successful unchanged-revision night. It does not run for manual
+syncs. Its own failure is logged and rolled back but does not fail or undo the
+good roster snapshot. Disable the flag to stop future role changes immediately.
 
 ## Administrator control surface
 
@@ -216,6 +250,9 @@ CloudWatch namespace: `AIStudio/RosterSync`
 - Collection metrics: `RecordsSynced`, `CollectionsFailed`,
   `RecordsDeactivated`, `RecordsTotal` (`Environment` and `Collection`
   dimensions).
+- Role metrics, emitted only when the optional pass succeeds:
+  `RolesGranted`, `RolesRevoked`, `RoleUsersChanged` (`Environment`
+  dimension).
 - `psd-oneroster-sync-failure-{environment}` alarms on any errored invocation
   during a day.
 - `psd-oneroster-sync-staleness-{environment}` alarms after approximately 48
@@ -278,9 +315,12 @@ Roll out disabled:
 2. Create the scoped credential secret and populate the non-secret settings.
 3. Run a manual sync. Compare per-collection totals with ClassLink and inspect a
    sample of lowercased emails and sourced-ID relationships.
-4. Confirm no `users`, application role, room, assistant, or demographics data
+4. Confirm no application roles, rooms, assistants, or demographics data
    changed.
 5. Set `ROSTER_SYNC_ENABLED=true`.
+6. Review the roster-to-user email match and role distribution before setting
+   `ROSTER_ROLE_SYNC_ENABLED=true`. Keep the role flag disabled if either needs
+   investigation.
 
 To stop ingestion, set `ROSTER_SYNC_ENABLED=false` in `/admin/rosters`.
 Existing roster rows remain
@@ -289,6 +329,28 @@ Processing stack version; migration 141 and the `oneroster_*` tables are
 additive and may remain in place. Do not clear rows or the revision checkpoint
 as part of routine rollback. If a credential may be exposed, rotate it in
 ClassLink and Secrets Manager before re-enabling the integration.
+
+To stop authorization reconciliation without stopping collection ingestion,
+set `ROSTER_ROLE_SYNC_ENABLED=false`. Existing `oneroster` grants remain as the
+last successfully reconciled state. If rollback requires removing them, first
+disable the flag, then run:
+
+```sql
+WITH deleted AS (
+  DELETE FROM user_roles
+   WHERE source = 'oneroster'
+  RETURNING user_id
+)
+UPDATE users
+   SET role_version = coalesce(role_version, 0) + 1,
+       updated_at = now()
+ WHERE id IN (SELECT DISTINCT user_id FROM deleted);
+```
+
+That statement is intentionally source-scoped and leaves manual, group-sync,
+and administrator grants unchanged. The version bump invalidates cached role
+state for every affected user. It changes authorization immediately; use the
+normal production change and audit process.
 
 To remove only the administrator UI, remove its `ADMIN_SECTIONS` registry entry
 and route. The settings and last-known-good roster snapshot can remain. Older

--- a/docs/features/oneroster-classlink-sync.md
+++ b/docs/features/oneroster-classlink-sync.md
@@ -157,8 +157,11 @@ transaction:
 - New grants use `user_roles.source='oneroster'`. The transaction removes only
   stale `oneroster` rows; `manual` and `group-sync` rows are invisible to it.
 - A mapped role already held from another source is left under that source.
-  `users.role_version` increments once for each user whose rows actually
-  changed, and does not churn on a no-op.
+  Because `(user_id, role_id)` is unique, if that owner's eligibility later
+  disappears while the other provider still computes the role, the current
+  owner atomically transfers its own row to the surviving provider instead of
+  dropping access. Provenance-only transfers do not bump `role_version`;
+  effective grant/revoke changes increment it once per affected user.
 - The application `administrator` role is not a possible mapping and is
   structurally excluded from deletion. This path therefore cannot invoke the
   last-administrator case. Any future change that could remove administrator

--- a/infra/database/migrations.json
+++ b/infra/database/migrations.json
@@ -145,6 +145,7 @@
     "152-agent-skill-scan-leases.sql",
     "153-workspace-upload-reservations.sql",
     "154-workspace-upload-reservation-nullable-leases.sql",
-    "155-unified-content-migration-retirement.sql"
+    "155-unified-content-migration-retirement.sql",
+    "156-oneroster-user-role-source.sql"
   ]
 }

--- a/infra/database/schema/156-oneroster-user-role-source.sql
+++ b/infra/database/schema/156-oneroster-user-role-source.sql
@@ -1,0 +1,34 @@
+-- Migration 156: Admit OneRoster-managed application role grants (Epic #1308 / #1312)
+--
+-- The existing user_roles.source constraint owns source isolation for manual
+-- assignments and Google group reconciliation. OneRoster reconciliation gets
+-- its own source so it can revoke only the rows it previously granted.
+
+ALTER TABLE user_roles
+  DROP CONSTRAINT IF EXISTS user_roles_source_check;
+
+ALTER TABLE user_roles
+  ADD CONSTRAINT user_roles_source_check
+  CHECK (source IN ('manual', 'group-sync', 'oneroster'));
+
+COMMENT ON COLUMN user_roles.source IS
+  'Grant owner: manual, group-sync, or oneroster. Reconcilers may mutate only their own source.';
+
+-- ============================================================
+-- ROLLBACK SQL (manual; disable ROSTER_ROLE_SYNC_ENABLED first)
+-- ============================================================
+-- WITH deleted AS (
+--   DELETE FROM user_roles
+--    WHERE source = 'oneroster'
+--   RETURNING user_id
+-- )
+-- UPDATE users
+--    SET role_version = coalesce(role_version, 0) + 1,
+--        updated_at = now()
+--  WHERE id IN (SELECT DISTINCT user_id FROM deleted);
+-- ALTER TABLE user_roles DROP CONSTRAINT IF EXISTS user_roles_source_check;
+-- ALTER TABLE user_roles
+--   ADD CONSTRAINT user_roles_source_check
+--   CHECK (source IN ('manual', 'group-sync'));
+-- COMMENT ON COLUMN user_roles.source IS
+--   'Grant owner: manual or group-sync. Reconcilers may mutate only their own source.';

--- a/infra/lambdas/group-sync/db.ts
+++ b/infra/lambdas/group-sync/db.ts
@@ -34,6 +34,19 @@ function requireEnv(name: string): string {
  */
 const LAST_ADMIN_GUARD_LOCK_KEY = 925_001;
 
+// Keep synchronized with the fixed v1 mapping in oneroster-sync/db.ts. The
+// Lambdas are packaged independently, so this small allowlist is duplicated.
+const STAFF_ONEROSTER_ROLE_NAMES = [
+  "teacher",
+  "aide",
+  "proctor",
+  "administrator",
+  "staff",
+  "districtadministrator",
+  "siteadministrator",
+  "systemadministrator",
+] as const;
+
 let _sql: postgres.Sql | null = null;
 let _initPromise: Promise<postgres.Sql> | null = null;
 
@@ -214,7 +227,9 @@ export interface RoleReconcileResult {
  *   - computed = (user, role) for every ACTIVE group→role mapping the user is a
  *     transitive member of (matched by lowercased email);
  *   - add computed roles the user lacks in ANY source, tagged 'group-sync';
- *   - remove only 'group-sync' rows no longer computed — 'manual' rows are never
+ *   - when a stale group-owned row is still computed by OneRoster, transfer
+ *     ownership to 'oneroster' atomically instead of dropping effective access;
+ *   - remove only remaining stale 'group-sync' rows — 'manual' rows are never
  *     eligible, so a hand-assigned role always survives;
  *   - bump role_version once per changed user (no churn on a no-op).
  *
@@ -312,8 +327,63 @@ export async function reconcileManagedRoles(
       RETURNING user_id
     `;
 
+    // user_roles is unique on (user_id, role_id), so overlapping providers
+    // cannot persist two provenance rows. Before removing a stale group-owned
+    // row, atomically hand it to OneRoster when the active roster still
+    // computes the same effective role. This closes the gap where one
+    // reconciler could delete the only row before the other runs.
+    await tx`
+      UPDATE user_roles managed
+         SET source = 'oneroster',
+             updated_at = now()
+        FROM users application_user,
+             roles application_role
+       WHERE managed.source = 'group-sync'
+         AND managed.user_id = application_user.id
+         AND managed.role_id = application_role.id
+         AND lower(application_role.name) IN ('student', 'staff')
+         AND NOT EXISTS (
+           SELECT 1
+             FROM _computed_roles computed
+            WHERE computed.user_id = managed.user_id
+              AND computed.role_id = managed.role_id
+         )
+         AND EXISTS (
+           SELECT 1
+             FROM oneroster_users roster_user
+             JOIN oneroster_user_roles roster_role
+               ON roster_role.user_sourced_id = roster_user.sourced_id
+              AND roster_role.is_active = true
+            WHERE roster_user.is_active = true
+              AND coalesce(roster_user.enabled_user, true) = true
+              AND lower(roster_user.email) = lower(application_user.email)
+              AND (
+                (
+                  lower(application_role.name) = 'student'
+                  AND regexp_replace(
+                    lower(trim(roster_role.role)),
+                    '[^a-z0-9]+',
+                    '',
+                    'g'
+                  ) = 'student'
+                )
+                OR
+                (
+                  lower(application_role.name) = 'staff'
+                  AND regexp_replace(
+                    lower(trim(roster_role.role)),
+                    '[^a-z0-9]+',
+                    '',
+                    'g'
+                  ) = ANY(${[...STAFF_ONEROSTER_ROLE_NAMES]}::text[])
+                )
+              )
+         )
+    `;
+
     // Remove group-sync rows no longer computed. Manual rows are never matched;
-    // the administrator role is excluded entirely when the guard tripped.
+    // rows transferred to OneRoster above are no longer matched; the
+    // administrator role is excluded entirely when the guard tripped.
     const removed = await tx<{ user_id: number }[]>`
       DELETE FROM user_roles ur
        WHERE ur.source = 'group-sync'

--- a/infra/lambdas/oneroster-sync/config.ts
+++ b/infra/lambdas/oneroster-sync/config.ts
@@ -11,6 +11,8 @@ import { isRecord } from "./normalize";
 
 export const ONEROSTER_SETTING_KEYS = {
   enabled: "ROSTER_SYNC_ENABLED",
+  /** Opt-in authorization pass; scheduled syncs only, default disabled. */
+  roleSyncEnabled: "ROSTER_ROLE_SYNC_ENABLED",
   baseUrl: "ONEROSTER_BASE_URL",
   authMode: "ONEROSTER_AUTH_MODE",
   credentialsSecretArn: "ONEROSTER_CREDENTIALS_SECRET_ARN",
@@ -27,6 +29,7 @@ export type OneRosterApiVersion = "v1p1" | "v1p2";
 
 export interface OneRosterConfig {
   enabled: boolean;
+  roleSyncEnabled: boolean;
   baseUrl: string | null;
   authMode: OneRosterAuthMode | null;
   credentialsSecretArn: string | null;
@@ -35,9 +38,18 @@ export interface OneRosterConfig {
 }
 
 export async function resolveConfig(sql: postgres.Sql): Promise<OneRosterConfig> {
-  const [enabled, baseUrl, authMode, credentialsSecretArn, apiVersion, pageSize] =
+  const [
+    enabled,
+    roleSyncEnabled,
+    baseUrl,
+    authMode,
+    credentialsSecretArn,
+    apiVersion,
+    pageSize,
+  ] =
     await Promise.all([
       getSettingValue(sql, ONEROSTER_SETTING_KEYS.enabled),
+      getSettingValue(sql, ONEROSTER_SETTING_KEYS.roleSyncEnabled),
       getSettingValue(sql, ONEROSTER_SETTING_KEYS.baseUrl),
       getSettingValue(sql, ONEROSTER_SETTING_KEYS.authMode),
       getSettingValue(sql, ONEROSTER_SETTING_KEYS.credentialsSecretArn),
@@ -51,6 +63,7 @@ export async function resolveConfig(sql: postgres.Sql): Promise<OneRosterConfig>
 
   return {
     enabled: enabled?.toLowerCase() === "true",
+    roleSyncEnabled: roleSyncEnabled?.toLowerCase() === "true",
     baseUrl: baseUrl ? normalizeBaseUrl(baseUrl) : null,
     authMode: parsedMode,
     credentialsSecretArn: credentialsSecretArn || null,

--- a/infra/lambdas/oneroster-sync/db.integration.test.ts
+++ b/infra/lambdas/oneroster-sync/db.integration.test.ts
@@ -21,6 +21,20 @@ const sql = databaseUrl
   ? postgres(databaseUrl, { max: 1 })
   : null;
 
+async function reconcileGoogleGroupRoles(
+  database: postgres.Sql
+): Promise<{
+  added: number;
+  removed: number;
+  usersChanged: number;
+  adminRoleProtected: boolean;
+}> {
+  process.env.DATABASE_HOST ??= "integration.invalid";
+  process.env.DATABASE_SECRET_ARN ??= "integration-secret";
+  const { reconcileManagedRoles } = await import("../group-sync/db");
+  return reconcileManagedRoles(database);
+}
+
 function orgs(
   records: Array<Record<string, unknown>>
 ): CollectionPullSuccess {
@@ -70,6 +84,30 @@ describeDatabase("OneRoster PostgreSQL reconciliation", () => {
         created_at timestamp DEFAULT now(),
         updated_at timestamp DEFAULT now()
       );
+      CREATE TABLE IF NOT EXISTS groups (
+        id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+        group_email text NOT NULL,
+        name text,
+        source text NOT NULL DEFAULT 'manual',
+        is_active boolean NOT NULL DEFAULT true,
+        created_at timestamptz NOT NULL DEFAULT now(),
+        updated_at timestamptz NOT NULL DEFAULT now()
+      );
+      CREATE UNIQUE INDEX IF NOT EXISTS uq_groups_group_email
+        ON groups (lower(group_email));
+      CREATE TABLE IF NOT EXISTS group_members (
+        id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+        group_id uuid NOT NULL REFERENCES groups(id) ON DELETE CASCADE,
+        member_email text NOT NULL,
+        created_at timestamptz NOT NULL DEFAULT now()
+      );
+      CREATE TABLE IF NOT EXISTS group_role_mappings (
+        id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+        group_email text NOT NULL,
+        role_id integer NOT NULL REFERENCES roles(id) ON DELETE CASCADE,
+        created_at timestamptz NOT NULL DEFAULT now(),
+        updated_at timestamptz NOT NULL DEFAULT now()
+      );
       CREATE OR REPLACE FUNCTION update_updated_at_column()
       RETURNS TRIGGER AS $$
       BEGIN
@@ -92,6 +130,14 @@ describeDatabase("OneRoster PostgreSQL reconciliation", () => {
 
   beforeEach(async () => {
     if (!sql) return;
+    await sql`
+      DELETE FROM group_role_mappings
+       WHERE lower(group_email) LIKE ${"%@oneroster-role.test"}
+    `;
+    await sql`
+      DELETE FROM groups
+       WHERE lower(group_email) LIKE ${"%@oneroster-role.test"}
+    `;
     await sql.unsafe(`
       TRUNCATE TABLE
         oneroster_enrollments,
@@ -264,7 +310,7 @@ describeDatabase("OneRoster PostgreSQL reconciliation", () => {
     expect(row.is_secret).toBe(false);
   });
 
-  it("reconciles lowercased roster roles while preserving other sources and administrator", async () => {
+  it("reconciles lowercased roles and transfers overlapping provider ownership atomically", async () => {
     if (!sql) throw new Error("database connection was not initialized");
     const roleRows = await sql<Array<{ id: number; name: string }>>`
       SELECT id, lower(name) AS name
@@ -339,12 +385,37 @@ describeDatabase("OneRoster PostgreSQL reconciliation", () => {
       )
       VALUES
         ('roster-mixed', 'student', 'primary', 'active', true),
+        ('roster-mixed', 'teacher', 'secondary', 'active', true),
         ('roster-staff', 'administrator', 'primary', 'active', true),
         ('roster-unchanged', 'student', 'primary', 'active', true),
         ('roster-unmatched', 'teacher', 'primary', 'active', true)
     `;
+    const [studentGroup] = await sql<Array<{ id: string }>>`
+      INSERT INTO groups (
+        group_email,
+        name,
+        source,
+        is_active
+      )
+      VALUES (
+        'roster-student@oneroster-role.test',
+        'Roster overlap student group',
+        'manual',
+        true
+      )
+      RETURNING id
+    `;
+    await sql`
+      INSERT INTO group_members (group_id, member_email)
+      VALUES (${studentGroup.id}, 'staff@oneroster-role.test')
+    `;
+    await sql`
+      INSERT INTO group_role_mappings (group_email, role_id)
+      VALUES ('roster-student@oneroster-role.test', ${studentRoleId})
+    `;
 
     const result = await reconcileOneRosterRoles(sql);
+    const groupResult = await reconcileGoogleGroupRoles(sql);
     const grants = await sql<
       Array<{ email: string; role: string; source: string }>
     >`
@@ -364,7 +435,13 @@ describeDatabase("OneRoster PostgreSQL reconciliation", () => {
        ORDER BY email
     `;
 
-    expect(result).toEqual({ granted: 2, revoked: 2, usersChanged: 3 });
+    expect(result).toEqual({ granted: 2, revoked: 1, usersChanged: 3 });
+    expect(groupResult).toEqual({
+      added: 0,
+      removed: 0,
+      usersChanged: 0,
+      adminRoleProtected: false,
+    });
     expect(grants).toEqual([
       {
         email: "mixed.case@oneroster-role.test",
@@ -374,7 +451,7 @@ describeDatabase("OneRoster PostgreSQL reconciliation", () => {
       {
         email: "mixed.case@oneroster-role.test",
         role: "staff",
-        source: "group-sync",
+        source: "oneroster",
       },
       {
         email: "mixed.case@oneroster-role.test",
@@ -390,6 +467,11 @@ describeDatabase("OneRoster PostgreSQL reconciliation", () => {
         email: "staff@oneroster-role.test",
         role: "staff",
         source: "oneroster",
+      },
+      {
+        email: "staff@oneroster-role.test",
+        role: "student",
+        source: "group-sync",
       },
       {
         email: "unchanged@oneroster-role.test",

--- a/infra/lambdas/oneroster-sync/db.integration.test.ts
+++ b/infra/lambdas/oneroster-sync/db.integration.test.ts
@@ -8,7 +8,11 @@
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "bun:test";
 import { readFileSync } from "node:fs";
 import postgres from "postgres";
-import { reconcileCollection, writeSyncStatus } from "./db";
+import {
+  reconcileCollection,
+  reconcileOneRosterRoles,
+  writeSyncStatus,
+} from "./db";
 import type { CollectionPullSuccess } from "./oneroster-client";
 
 const databaseUrl = process.env.ONEROSTER_DB_TEST_URL;
@@ -33,6 +37,29 @@ describeDatabase("OneRoster PostgreSQL reconciliation", () => {
     if (!sql) return;
     await sql.unsafe(`
       CREATE EXTENSION IF NOT EXISTS pgcrypto;
+      CREATE TABLE IF NOT EXISTS users (
+        id serial PRIMARY KEY,
+        email varchar(255),
+        role_version integer DEFAULT 1,
+        updated_at timestamp DEFAULT now() NOT NULL
+      );
+      CREATE TABLE IF NOT EXISTS roles (
+        id serial PRIMARY KEY,
+        name varchar(100) NOT NULL,
+        description text,
+        is_system boolean DEFAULT false,
+        created_at timestamp DEFAULT now(),
+        updated_at timestamp DEFAULT now()
+      );
+      CREATE TABLE IF NOT EXISTS user_roles (
+        id serial PRIMARY KEY,
+        user_id integer,
+        role_id integer,
+        source varchar(20) NOT NULL DEFAULT 'manual',
+        created_at timestamp DEFAULT now(),
+        updated_at timestamptz DEFAULT now(),
+        UNIQUE (user_id, role_id)
+      );
       CREATE TABLE IF NOT EXISTS settings (
         id serial PRIMARY KEY,
         key varchar(255) NOT NULL UNIQUE,
@@ -56,6 +83,11 @@ describeDatabase("OneRoster PostgreSQL reconciliation", () => {
       import.meta.url
     );
     await sql.unsafe(readFileSync(migrationUrl, "utf8"));
+    const roleSourceMigrationUrl = new URL(
+      "../../database/schema/156-oneroster-user-role-source.sql",
+      import.meta.url
+    );
+    await sql.unsafe(readFileSync(roleSourceMigrationUrl, "utf8"));
   });
 
   beforeEach(async () => {
@@ -74,6 +106,27 @@ describeDatabase("OneRoster PostgreSQL reconciliation", () => {
     await sql`
       DELETE FROM settings WHERE key = 'ONEROSTER_SYNC_STATUS'
     `;
+    await sql`
+      DELETE FROM user_roles
+       WHERE user_id IN (
+         SELECT id
+           FROM users
+          WHERE lower(email) LIKE ${"%@oneroster-role.test"}
+       )
+    `;
+    await sql`
+      DELETE FROM users
+       WHERE lower(email) LIKE ${"%@oneroster-role.test"}
+    `;
+    for (const roleName of ["student", "staff", "administrator"]) {
+      await sql`
+        INSERT INTO roles (name, description, is_system)
+        SELECT ${roleName}, ${`Integration ${roleName}`}, true
+         WHERE NOT EXISTS (
+           SELECT 1 FROM roles WHERE lower(name) = lower(${roleName})
+         )
+      `;
+    }
   });
 
   afterAll(async () => {
@@ -209,5 +262,147 @@ describeDatabase("OneRoster PostgreSQL reconciliation", () => {
     expect(JSON.parse(row.value)).toEqual(status);
     expect(row.category).toBe("integrations");
     expect(row.is_secret).toBe(false);
+  });
+
+  it("reconciles lowercased roster roles while preserving other sources and administrator", async () => {
+    if (!sql) throw new Error("database connection was not initialized");
+    const roleRows = await sql<Array<{ id: number; name: string }>>`
+      SELECT id, lower(name) AS name
+        FROM roles
+       WHERE lower(name) = ANY(${["student", "staff", "administrator"]}::text[])
+    `;
+    const roleIds = new Map(roleRows.map((role) => [role.name, role.id]));
+    const studentRoleId = roleIds.get("student");
+    const staffRoleId = roleIds.get("staff");
+    const administratorRoleId = roleIds.get("administrator");
+    if (!studentRoleId || !staffRoleId || !administratorRoleId) {
+      throw new Error("required integration roles were not initialized");
+    }
+
+    const [mixedCaseUser] = await sql<Array<{ id: number }>>`
+      INSERT INTO users (email, role_version)
+      VALUES ('Mixed.Case@ONEROSTER-ROLE.TEST', 10)
+      RETURNING id
+    `;
+    const [staffUser] = await sql<Array<{ id: number }>>`
+      INSERT INTO users (email, role_version)
+      VALUES ('staff@oneroster-role.test', 20)
+      RETURNING id
+    `;
+    const [removedUser] = await sql<Array<{ id: number }>>`
+      INSERT INTO users (email, role_version)
+      VALUES ('removed@oneroster-role.test', 30)
+      RETURNING id
+    `;
+    const [unchangedUser] = await sql<Array<{ id: number }>>`
+      INSERT INTO users (email, role_version)
+      VALUES ('unchanged@oneroster-role.test', 40)
+      RETURNING id
+    `;
+    const [protectedAdminUser] = await sql<Array<{ id: number }>>`
+      INSERT INTO users (email, role_version)
+      VALUES ('protected-admin@oneroster-role.test', 50)
+      RETURNING id
+    `;
+
+    await sql`
+      INSERT INTO user_roles (user_id, role_id, source)
+      VALUES
+        (${mixedCaseUser.id}, ${administratorRoleId}, 'manual'),
+        (${mixedCaseUser.id}, ${staffRoleId}, 'group-sync'),
+        (${staffUser.id}, ${studentRoleId}, 'oneroster'),
+        (${removedUser.id}, ${staffRoleId}, 'oneroster'),
+        (${unchangedUser.id}, ${studentRoleId}, 'oneroster'),
+        (${protectedAdminUser.id}, ${administratorRoleId}, 'oneroster')
+    `;
+    await sql`
+      INSERT INTO oneroster_users (
+        sourced_id,
+        email,
+        enabled_user,
+        status,
+        is_active
+      )
+      VALUES
+        ('roster-mixed', 'mixed.case@oneroster-role.test', true, 'active', true),
+        ('roster-staff', 'staff@oneroster-role.test', true, 'active', true),
+        ('roster-unchanged', 'unchanged@oneroster-role.test', true, 'active', true),
+        ('roster-unmatched', 'not-signed-in@oneroster-role.test', true, 'active', true)
+    `;
+    await sql`
+      INSERT INTO oneroster_user_roles (
+        user_sourced_id,
+        role,
+        role_type,
+        status,
+        is_active
+      )
+      VALUES
+        ('roster-mixed', 'student', 'primary', 'active', true),
+        ('roster-staff', 'administrator', 'primary', 'active', true),
+        ('roster-unchanged', 'student', 'primary', 'active', true),
+        ('roster-unmatched', 'teacher', 'primary', 'active', true)
+    `;
+
+    const result = await reconcileOneRosterRoles(sql);
+    const grants = await sql<
+      Array<{ email: string; role: string; source: string }>
+    >`
+      SELECT lower(application_user.email) AS email,
+             lower(application_role.name) AS role,
+             managed.source
+        FROM user_roles managed
+        JOIN users application_user ON application_user.id = managed.user_id
+        JOIN roles application_role ON application_role.id = managed.role_id
+       WHERE lower(application_user.email) LIKE ${"%@oneroster-role.test"}
+       ORDER BY email, role
+    `;
+    const versions = await sql<Array<{ email: string; role_version: number }>>`
+      SELECT lower(email) AS email, role_version
+        FROM users
+       WHERE lower(email) LIKE ${"%@oneroster-role.test"}
+       ORDER BY email
+    `;
+
+    expect(result).toEqual({ granted: 2, revoked: 2, usersChanged: 3 });
+    expect(grants).toEqual([
+      {
+        email: "mixed.case@oneroster-role.test",
+        role: "administrator",
+        source: "manual",
+      },
+      {
+        email: "mixed.case@oneroster-role.test",
+        role: "staff",
+        source: "group-sync",
+      },
+      {
+        email: "mixed.case@oneroster-role.test",
+        role: "student",
+        source: "oneroster",
+      },
+      {
+        email: "protected-admin@oneroster-role.test",
+        role: "administrator",
+        source: "oneroster",
+      },
+      {
+        email: "staff@oneroster-role.test",
+        role: "staff",
+        source: "oneroster",
+      },
+      {
+        email: "unchanged@oneroster-role.test",
+        role: "student",
+        source: "oneroster",
+      },
+    ]);
+    expect(versions).toEqual([
+      { email: "mixed.case@oneroster-role.test", role_version: 11 },
+      { email: "protected-admin@oneroster-role.test", role_version: 50 },
+      { email: "removed@oneroster-role.test", role_version: 31 },
+      { email: "staff@oneroster-role.test", role_version: 21 },
+      { email: "unchanged@oneroster-role.test", role_version: 40 },
+    ]);
   });
 });

--- a/infra/lambdas/oneroster-sync/db.ts
+++ b/infra/lambdas/oneroster-sync/db.ts
@@ -33,6 +33,28 @@ const LAST_PERM_REV_SETTING_KEY = "ONEROSTER_LAST_PERM_REV";
 // Keep synchronized with lib/roster/settings.ts and config.ts.
 const SYNC_STATUS_SETTING_KEY = "ONEROSTER_SYNC_STATUS";
 
+/**
+ * OneRoster roles that represent district staff in the fixed v1 mapping.
+ *
+ * The first four values are the OneRoster-defined staff-shaped roles called
+ * out by #1312. The remaining normalized values accommodate common
+ * vendor-specific staff/administrator spellings without treating family roles
+ * (parent, guardian, relative) or unknown input as staff authorization.
+ */
+const STAFF_ONEROSTER_ROLE_NAMES = [
+  "teacher",
+  "aide",
+  "proctor",
+  "administrator",
+  "staff",
+  "districtadministrator",
+  "siteadministrator",
+  "systemadministrator",
+] as const;
+const STAFF_ONEROSTER_ROLES = new Set<string>(
+  STAFF_ONEROSTER_ROLE_NAMES
+);
+
 let sqlSingleton: postgres.Sql | null = null;
 let initPromise: Promise<postgres.Sql> | null = null;
 
@@ -151,6 +173,161 @@ export async function writeSyncStatus(
           is_secret = false,
           updated_at = now()
   `;
+}
+
+export type MappedApplicationRole = "student" | "staff";
+
+/**
+ * Fixed, fail-closed OneRoster → AI Studio role mapping (#1312).
+ *
+ * Application administrator is deliberately not a possible return value.
+ */
+export function mapOneRosterRoleToApplicationRole(
+  role: string | null
+): MappedApplicationRole | null {
+  const normalized = role
+    ?.trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "");
+  if (!normalized) return null;
+  if (normalized === "student") return "student";
+  return STAFF_ONEROSTER_ROLES.has(normalized) ? "staff" : null;
+}
+
+export interface RoleReconcileResult {
+  /** OneRoster-owned user_roles rows inserted. */
+  granted: number;
+  /** OneRoster-owned user_roles rows removed. */
+  revoked: number;
+  /** Distinct users whose role_version was bumped. */
+  usersChanged: number;
+}
+
+/**
+ * Reconcile active roster roles into application roles in one transaction.
+ *
+ * Source ownership is the safety boundary:
+ *   - computed student/staff roles are inserted as source='oneroster' only
+ *     when the user does not already hold that role from any source;
+ *   - only stale source='oneroster' rows are removable;
+ *   - application administrator is excluded from both the mapping and delete.
+ *
+ * The administrator exclusion is structural, so this path cannot revoke admin
+ * access and does not need LAST_ADMIN_GUARD_LOCK_KEY. Any future expansion that
+ * can remove administrator must use the shared advisory-lock discipline.
+ */
+export async function reconcileOneRosterRoles(
+  sql: postgres.Sql
+): Promise<RoleReconcileResult> {
+  return sql.begin(async (tx) => {
+    const requiredRoles = await tx<{ name: string }[]>`
+      SELECT lower(name) AS name
+        FROM roles
+       WHERE lower(name) = ANY(${["student", "staff"]}::text[])
+    `;
+    const availableRoles = new Set(requiredRoles.map((role) => role.name));
+    const missingRoles = ["student", "staff"].filter(
+      (role) => !availableRoles.has(role)
+    );
+    if (missingRoles.length > 0) {
+      throw new Error(
+        `Required application roles are missing: ${missingRoles.join(", ")}`
+      );
+    }
+
+    await tx`
+      CREATE TEMP TABLE _computed_oneroster_roles ON COMMIT DROP AS
+      WITH mapped_roster_roles AS (
+        SELECT DISTINCT
+               application_user.id AS user_id,
+               CASE
+                 WHEN regexp_replace(
+                   lower(trim(roster_role.role)),
+                   '[^a-z0-9]+',
+                   '',
+                   'g'
+                 ) = 'student'
+                   THEN 'student'
+                 WHEN regexp_replace(
+                   lower(trim(roster_role.role)),
+                   '[^a-z0-9]+',
+                   '',
+                   'g'
+                 ) = ANY(${[...STAFF_ONEROSTER_ROLE_NAMES]}::text[])
+                   THEN 'staff'
+                 ELSE NULL
+               END AS application_role_name
+          FROM oneroster_users roster_user
+          JOIN oneroster_user_roles roster_role
+            ON roster_role.user_sourced_id = roster_user.sourced_id
+           AND roster_role.is_active = true
+          JOIN users application_user
+            ON lower(application_user.email) = lower(roster_user.email)
+         WHERE roster_user.is_active = true
+           AND coalesce(roster_user.enabled_user, true) = true
+           AND roster_user.email IS NOT NULL
+      )
+      SELECT mapped.user_id, application_role.id AS role_id
+        FROM mapped_roster_roles mapped
+        JOIN roles application_role
+          ON lower(application_role.name) = mapped.application_role_name
+       WHERE mapped.application_role_name IS NOT NULL
+    `;
+    await tx`ANALYZE _computed_oneroster_roles`;
+
+    const granted = await tx<{ user_id: number }[]>`
+      INSERT INTO user_roles (user_id, role_id, source)
+      SELECT computed.user_id, computed.role_id, 'oneroster'
+        FROM _computed_oneroster_roles computed
+       WHERE NOT EXISTS (
+         SELECT 1
+           FROM user_roles existing
+          WHERE existing.user_id = computed.user_id
+            AND existing.role_id = computed.role_id
+       )
+      ON CONFLICT (user_id, role_id) DO NOTHING
+      RETURNING user_id
+    `;
+
+    const revoked = await tx<{ user_id: number }[]>`
+      DELETE FROM user_roles managed
+       WHERE managed.source = 'oneroster'
+         AND NOT EXISTS (
+           SELECT 1
+             FROM _computed_oneroster_roles computed
+            WHERE computed.user_id = managed.user_id
+              AND computed.role_id = managed.role_id
+         )
+         AND NOT EXISTS (
+           SELECT 1
+             FROM roles protected_role
+            WHERE protected_role.id = managed.role_id
+              AND lower(protected_role.name) = 'administrator'
+         )
+      RETURNING managed.user_id
+    `;
+
+    const changedUserIds = [
+      ...new Set([
+        ...granted.map((row) => row.user_id),
+        ...revoked.map((row) => row.user_id),
+      ]),
+    ];
+    if (changedUserIds.length > 0) {
+      await tx`
+        UPDATE users
+           SET role_version = coalesce(role_version, 0) + 1,
+               updated_at = now()
+         WHERE id = ANY(${changedUserIds}::int[])
+      `;
+    }
+
+    return {
+      granted: granted.length,
+      revoked: revoked.length,
+      usersChanged: changedUserIds.length,
+    };
+  });
 }
 
 export async function reconcileCollection(

--- a/infra/lambdas/oneroster-sync/db.ts
+++ b/infra/lambdas/oneroster-sync/db.ts
@@ -209,7 +209,9 @@ export interface RoleReconcileResult {
  * Source ownership is the safety boundary:
  *   - computed student/staff roles are inserted as source='oneroster' only
  *     when the user does not already hold that role from any source;
- *   - only stale source='oneroster' rows are removable;
+ *   - stale OneRoster-owned rows still granted by Google groups are handed to
+ *     source='group-sync' atomically before any remaining stale rows are removed;
+ *   - only remaining stale source='oneroster' rows are removable;
  *   - application administrator is excluded from both the mapping and delete.
  *
  * The administrator exclusion is structural, so this path cannot revoke admin
@@ -287,6 +289,42 @@ export async function reconcileOneRosterRoles(
        )
       ON CONFLICT (user_id, role_id) DO NOTHING
       RETURNING user_id
+    `;
+
+    // user_roles is unique on (user_id, role_id), so an overlapping group grant
+    // may be represented by this OneRoster-owned row. Hand off provenance
+    // before deletion when the active group graph still computes the role.
+    await tx`
+      UPDATE user_roles managed
+         SET source = 'group-sync',
+             updated_at = now()
+        FROM users application_user
+       WHERE managed.source = 'oneroster'
+         AND managed.user_id = application_user.id
+         AND NOT EXISTS (
+           SELECT 1
+             FROM _computed_oneroster_roles computed
+            WHERE computed.user_id = managed.user_id
+              AND computed.role_id = managed.role_id
+         )
+         AND EXISTS (
+           SELECT 1
+             FROM group_role_mappings mapping
+             JOIN groups synced_group
+               ON lower(synced_group.group_email) = lower(mapping.group_email)
+              AND synced_group.is_active = true
+             JOIN group_members membership
+               ON membership.group_id = synced_group.id
+            WHERE mapping.role_id = managed.role_id
+              AND lower(membership.member_email) =
+                  lower(application_user.email)
+         )
+         AND NOT EXISTS (
+           SELECT 1
+             FROM roles protected_role
+            WHERE protected_role.id = managed.role_id
+              AND lower(protected_role.name) = 'administrator'
+         )
     `;
 
     const revoked = await tx<{ user_id: number }[]>`

--- a/infra/lambdas/oneroster-sync/index.ts
+++ b/infra/lambdas/oneroster-sync/index.ts
@@ -22,10 +22,16 @@ import {
   getSql,
   readLastPermRev,
   reconcileCollection,
+  reconcileOneRosterRoles,
   writeLastPermRev,
   writeSyncStatus,
+  type RoleReconcileResult,
 } from "./db";
 import { OneRosterClient } from "./oneroster-client";
+import {
+  roleReconcileMetrics,
+  runPostSyncRoleReconciliation,
+} from "./role-reconciliation";
 import { runOneRosterSync, type OneRosterSyncResult } from "./sync";
 
 const METRIC_NAMESPACE = "AIStudio/RosterSync";
@@ -155,11 +161,26 @@ export async function handler(
     });
     syncResult = result;
 
-    await emitMetrics(result);
-    metricsEmitted = true;
     if (!result.fullySuccessful) {
+      await emitMetrics(result, null);
+      metricsEmitted = true;
       throw new Error(INCOMPLETE_SYNC_ERROR);
     }
+
+    const roleReconcile = await runPostSyncRoleReconciliation(
+      {
+        trigger,
+        enabled: config.roleSyncEnabled,
+        fullySuccessful: result.fullySuccessful,
+      },
+      {
+        reconcile: () => reconcileOneRosterRoles(sql),
+        log,
+      }
+    );
+    await emitMetrics(result, roleReconcile);
+    metricsEmitted = true;
+
     log.info("OneRoster sync completed", {
       unchanged: result.unchanged,
       restartCount: result.restartCount,
@@ -184,7 +205,7 @@ export async function handler(
         : thrownErrorMessage;
     log.error("OneRoster sync failed", { error: errorMessage, runId });
     if (!metricsEmitted) {
-      await emitMetrics(null).catch(() => {});
+      await emitMetrics(null, null).catch(() => {});
     }
     await writeStatusSafely(
       sql,
@@ -257,7 +278,10 @@ async function loadSecret(secretArn: string): Promise<string> {
   return response.SecretString;
 }
 
-async function emitMetrics(result: OneRosterSyncResult | null): Promise<void> {
+async function emitMetrics(
+  result: OneRosterSyncResult | null,
+  roleReconcile: RoleReconcileResult | null
+): Promise<void> {
   const environmentDimension = [{ Name: "Environment", Value: ENVIRONMENT }];
   const metrics: MetricDatum[] = result
     ? [
@@ -327,6 +351,17 @@ async function emitMetrics(result: OneRosterSyncResult | null): Promise<void> {
           Dimensions: dimensions,
         }
       );
+    }
+  }
+
+  if (roleReconcile) {
+    for (const metric of roleReconcileMetrics(roleReconcile)) {
+      metrics.push({
+        MetricName: metric.name,
+        Value: metric.value,
+        Unit: "Count",
+        Dimensions: environmentDimension,
+      });
     }
   }
 

--- a/infra/lambdas/oneroster-sync/package.json
+++ b/infra/lambdas/oneroster-sync/package.json
@@ -11,11 +11,11 @@
   "dependencies": {
     "@aws-sdk/client-cloudwatch": "^3.0.0",
     "@aws-sdk/client-secrets-manager": "^3.0.0",
-    "postgres": "^3.4.0"
+    "postgres": "3.4.7"
   },
   "devDependencies": {
     "@types/aws-lambda": "^8.10.145",
     "@types/node": "^20.0.0",
-    "typescript": "^5.0.0"
+    "typescript": "5.9.3"
   }
 }

--- a/infra/lambdas/oneroster-sync/role-reconciliation.test.ts
+++ b/infra/lambdas/oneroster-sync/role-reconciliation.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "bun:test";
+import { mapOneRosterRoleToApplicationRole } from "./db";
+import {
+  roleReconcileMetrics,
+  runPostSyncRoleReconciliation,
+  type PostSyncRoleReconcileInput,
+} from "./role-reconciliation";
+
+describe("fixed OneRoster role mapping", () => {
+  it("maps student and staff-shaped roles without ever mapping administrator", () => {
+    expect(mapOneRosterRoleToApplicationRole("student")).toBe("student");
+    expect(mapOneRosterRoleToApplicationRole(" Teacher ")).toBe("staff");
+    expect(mapOneRosterRoleToApplicationRole("aide")).toBe("staff");
+    expect(mapOneRosterRoleToApplicationRole("proctor")).toBe("staff");
+    expect(mapOneRosterRoleToApplicationRole("administrator")).toBe("staff");
+    expect(mapOneRosterRoleToApplicationRole("district-administrator")).toBe(
+      "staff"
+    );
+    expect(mapOneRosterRoleToApplicationRole("parent")).toBeNull();
+    expect(mapOneRosterRoleToApplicationRole("guardian")).toBeNull();
+    expect(mapOneRosterRoleToApplicationRole("relative")).toBeNull();
+    expect(mapOneRosterRoleToApplicationRole("unknown")).toBeNull();
+    expect(mapOneRosterRoleToApplicationRole(null)).toBeNull();
+  });
+});
+
+describe("post-sync role reconciliation policy", () => {
+  const eligible: PostSyncRoleReconcileInput = {
+    trigger: "schedule",
+    enabled: true,
+    fullySuccessful: true,
+  };
+
+  it("runs only after a fully successful scheduled sync with the flag enabled", async () => {
+    let calls = 0;
+    const result = await runPostSyncRoleReconciliation(eligible, {
+      reconcile: async () => {
+        calls += 1;
+        return { granted: 2, revoked: 1, usersChanged: 3 };
+      },
+      log: { info: () => {}, error: () => {} },
+    });
+
+    expect(calls).toBe(1);
+    expect(result).toEqual({ granted: 2, revoked: 1, usersChanged: 3 });
+
+    for (const input of [
+      { ...eligible, trigger: "manual" as const },
+      { ...eligible, enabled: false },
+      { ...eligible, fullySuccessful: false },
+    ]) {
+      const skipped = await runPostSyncRoleReconciliation(input, {
+        reconcile: async () => {
+          calls += 1;
+          return { granted: 0, revoked: 0, usersChanged: 0 };
+        },
+        log: { info: () => {}, error: () => {} },
+      });
+      expect(skipped).toBeNull();
+    }
+    expect(calls).toBe(1);
+  });
+
+  it("contains a role failure without failing a successful roster sync", async () => {
+    const errors: Array<Record<string, unknown> | undefined> = [];
+    const result = await runPostSyncRoleReconciliation(eligible, {
+      reconcile: async () => {
+        throw new Error("role transaction rolled back");
+      },
+      log: {
+        info: () => {},
+        error: (_message, metadata) => errors.push(metadata),
+      },
+    });
+
+    expect(result).toBeNull();
+    expect(errors).toEqual([
+      { error: "role transaction rolled back" },
+    ]);
+  });
+
+  it("publishes granted, revoked, and changed-user metric values", () => {
+    expect(
+      roleReconcileMetrics({
+        granted: 4,
+        revoked: 2,
+        usersChanged: 5,
+      })
+    ).toEqual([
+      { name: "RolesGranted", value: 4 },
+      { name: "RolesRevoked", value: 2 },
+      { name: "RoleUsersChanged", value: 5 },
+    ]);
+  });
+});

--- a/infra/lambdas/oneroster-sync/role-reconciliation.ts
+++ b/infra/lambdas/oneroster-sync/role-reconciliation.ts
@@ -1,0 +1,73 @@
+/**
+ * Post-sync role-reconciliation policy for the isolated OneRoster Lambda.
+ *
+ * Keeping the gate and best-effort boundary separate from the AWS handler makes
+ * the authorization behavior deterministic and unit-testable: only a fully
+ * successful scheduled pull may reconcile, the setting is opt-in, and a role
+ * failure never changes a successful roster-sync result into a failed run.
+ */
+
+import type { RoleReconcileResult } from "./db";
+
+export interface RoleReconcileLog {
+  info(message: string, metadata?: Record<string, unknown>): void;
+  error(message: string, metadata?: Record<string, unknown>): void;
+}
+
+export interface PostSyncRoleReconcileInput {
+  trigger: "manual" | "schedule";
+  enabled: boolean;
+  fullySuccessful: boolean;
+}
+
+export interface PostSyncRoleReconcilePorts {
+  reconcile(): Promise<RoleReconcileResult>;
+  log: RoleReconcileLog;
+}
+
+export async function runPostSyncRoleReconciliation(
+  input: PostSyncRoleReconcileInput,
+  ports: PostSyncRoleReconcilePorts
+): Promise<RoleReconcileResult | null> {
+  if (
+    input.trigger !== "schedule" ||
+    !input.enabled ||
+    !input.fullySuccessful
+  ) {
+    return null;
+  }
+
+  try {
+    const result = await ports.reconcile();
+    ports.log.info("OneRoster role reconciliation completed", { ...result });
+    return result;
+  } catch (error) {
+    ports.log.error(
+      "OneRoster role reconciliation failed (roster sync still succeeded)",
+      {
+        error: safeErrorMessage(error),
+      }
+    );
+    return null;
+  }
+}
+
+export interface RoleReconcileMetric {
+  name: "RolesGranted" | "RolesRevoked" | "RoleUsersChanged";
+  value: number;
+}
+
+export function roleReconcileMetrics(
+  result: RoleReconcileResult
+): RoleReconcileMetric[] {
+  return [
+    { name: "RolesGranted", value: result.granted },
+    { name: "RolesRevoked", value: result.revoked },
+    { name: "RoleUsersChanged", value: result.usersChanged },
+  ];
+}
+
+function safeErrorMessage(error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error);
+  return message.length > 500 ? `${message.slice(0, 499)}…` : message;
+}

--- a/lib/db/drizzle/user-roles.ts
+++ b/lib/db/drizzle/user-roles.ts
@@ -10,7 +10,16 @@
  * @see https://orm.drizzle.team/docs/transactions
  */
 
-import { eq, ne, inArray, notInArray, and, sql } from "drizzle-orm";
+import {
+  eq,
+  ne,
+  inArray,
+  notInArray,
+  and,
+  or,
+  isNull,
+  sql,
+} from "drizzle-orm";
 import { executeQuery, type DbTransaction } from "@/lib/db/drizzle-client";
 import {
   users,
@@ -19,6 +28,8 @@ import {
   groups,
   groupMembers,
   groupRoleMappings,
+  onerosterUsers,
+  onerosterUserRoles,
   type UserRoleSource,
 } from "@/lib/db/schema";
 import { createLogger, generateRequestId, startTimer } from "@/lib/logger";
@@ -38,6 +49,20 @@ import { ErrorFactories } from "@/lib/error-utils";
  * last-admin count against both reconcilers too (#1222 round 4).
  */
 export const LAST_ADMIN_GUARD_LOCK_KEY = 925_001;
+
+// Keep synchronized with the fixed v1 mapping in
+// infra/lambdas/oneroster-sync/db.ts. The app and Lambda bundles cannot share
+// runtime imports across their packaging boundary.
+const STAFF_ONEROSTER_ROLE_NAMES = [
+  "teacher",
+  "aide",
+  "proctor",
+  "administrator",
+  "staff",
+  "districtadministrator",
+  "siteadministrator",
+  "systemadministrator",
+] as const;
 
 export interface ManualRoleSyncResult {
   deletedRoleIds: number[];
@@ -419,6 +444,31 @@ export interface ManagedRoleDiff {
   changed: boolean;
 }
 
+export interface ManagedRoleRemovalPartition {
+  /** Stale group-owned roles whose effective grant remains roster-computed. */
+  toTransfer: number[];
+  /** Stale group-owned roles no longer computed by either provider. */
+  toRemove: number[];
+}
+
+export function partitionManagedRoleRemovals(
+  groupOwnedRoleIds: Iterable<number>,
+  rosterComputedRoleIds: Iterable<number>
+): ManagedRoleRemovalPartition {
+  const rosterComputed = new Set(rosterComputedRoleIds);
+  const toTransfer: number[] = [];
+  const toRemove: number[] = [];
+
+  for (const roleId of groupOwnedRoleIds) {
+    if (rosterComputed.has(roleId)) {
+      toTransfer.push(roleId);
+    } else {
+      toRemove.push(roleId);
+    }
+  }
+  return { toTransfer, toRemove };
+}
+
 /**
  * Pure reconciliation core — no I/O, exhaustively unit-testable. Given the roles
  * a user SHOULD hold from group mappings (`computedRoleIds`) and their current
@@ -471,6 +521,76 @@ export function applyLastAdminGuard(
     toRemove: toRemove.filter((id) => id !== adminRoleId),
     adminProtected: true,
   };
+}
+
+async function transferOverlappingGroupRolesToOneRoster(
+  tx: DbTransaction,
+  userId: number,
+  normalizedEmail: string,
+  groupOwnedRoleIds: number[]
+): Promise<number[]> {
+  if (groupOwnedRoleIds.length === 0) return [];
+
+  const normalizedRosterRole = sql<string>`regexp_replace(
+    lower(trim(${onerosterUserRoles.role})),
+    '[^a-z0-9]+',
+    '',
+    'g'
+  )`;
+  const rosterComputedRows = await tx
+    .selectDistinct({ roleId: roles.id })
+    .from(onerosterUsers)
+    .innerJoin(
+      onerosterUserRoles,
+      and(
+        eq(onerosterUserRoles.userSourcedId, onerosterUsers.sourcedId),
+        eq(onerosterUserRoles.isActive, true)
+      )
+    )
+    .innerJoin(
+      roles,
+      or(
+        and(
+          eq(sql`lower(${roles.name})`, "student"),
+          eq(normalizedRosterRole, "student")
+        ),
+        and(
+          eq(sql`lower(${roles.name})`, "staff"),
+          inArray(normalizedRosterRole, [...STAFF_ONEROSTER_ROLE_NAMES])
+        )
+      )
+    )
+    .where(
+      and(
+        eq(sql`lower(${onerosterUsers.email})`, normalizedEmail),
+        eq(onerosterUsers.isActive, true),
+        or(
+          eq(onerosterUsers.enabledUser, true),
+          isNull(onerosterUsers.enabledUser)
+        )
+      )
+    );
+  const partition = partitionManagedRoleRemovals(
+    groupOwnedRoleIds,
+    rosterComputedRows.map((row) => row.roleId)
+  );
+
+  if (partition.toTransfer.length > 0) {
+    await tx
+      .update(userRoles)
+      .set({
+        source: "oneroster",
+        updatedAt: new Date(),
+      })
+      .where(
+        and(
+          eq(userRoles.userId, userId),
+          eq(userRoles.source, "group-sync"),
+          inArray(userRoles.roleId, partition.toTransfer)
+        )
+      );
+  }
+  return partition.toRemove;
 }
 
 /**
@@ -556,11 +676,17 @@ export async function reconcileUserManagedRoles(
 
           if (!diff.changed) return diff;
 
+          let toRemove = await transferOverlappingGroupRolesToOneRoster(
+            tx,
+            userId,
+            normalizedEmail,
+            diff.toRemove
+          );
+
           // Last-administrator lockout guard: an automated revocation must never
           // zero out the system's administrators (there would be no in-app
           // recovery — every admin surface, including the mapping UI itself, is
           // admin-gated). Mirrors actions/admin/user-management.actions.ts.
-          let toRemove = diff.toRemove;
           if (toRemove.length > 0) {
             const [adminRole] = await tx
               .select({ id: roles.id })

--- a/lib/db/drizzle/user-roles.ts
+++ b/lib/db/drizzle/user-roles.ts
@@ -49,10 +49,10 @@ export interface ManualRoleSyncResult {
  * Shared delete+insert body for the three source-aware "replace a user's
  * MANUAL roles" writers (this file's `updateUserRoles`, the legacy
  * `lib/db/user-roles.ts#updateUserRoles`, and the admin `updateUser` action).
- * Managed (source='group-sync') rows are invisible: never deleted
- * (reconciliation would silently re-add them next pass) and never
- * re-inserted as manual (would exempt them from auto-revocation forever).
- * This editor owns manual rows only. Callers keep their own role_version
+ * Managed (`source='group-sync'` or `source='oneroster'`) rows are invisible:
+ * never deleted (their reconciler would silently re-add them next pass) and
+ * never re-inserted as manual (which would exempt them from auto-revocation
+ * forever). This editor owns manual rows only. Callers keep their role_version
  * bump / last-admin-removal checks — this only performs the write (#1222
  * review: the logic was copy-pasted three times, drifting once already).
  */
@@ -426,8 +426,8 @@ export interface ManagedRoleDiff {
  *
  * A role the user already holds (in ANY source) is never re-added, so a manual
  * grant that also happens to be mapped stays manual and survives mapping removal.
- * Only group-sync rows are eligible for removal; manual rows are invisible to the
- * remove set by construction.
+ * Only group-sync rows are eligible for removal; manual and OneRoster rows are
+ * invisible to the remove set by construction.
  */
 export function computeManagedRoleDiff(
   computedRoleIds: Iterable<number>,

--- a/lib/db/schema/tables/user-roles.ts
+++ b/lib/db/schema/tables/user-roles.ts
@@ -11,11 +11,13 @@ import { roles } from "./roles";
 /**
  * How a user_roles row was granted (Epic #1202, Phase 1 / #1204).
  * 'manual'     — an admin assigned the role by hand (also the value for every
- *                pre-group-sync row). Reconciliation NEVER touches these.
+ *                pre-managed-sync row). Reconciliation NEVER touches these.
  * 'group-sync' — reconciliation granted it from a group→role mapping; it is the
- *                only source reconciliation ever adds or removes.
+ *                only source Google group reconciliation adds or removes.
+ * 'oneroster'  — nightly roster reconciliation granted it from an active
+ *                OneRoster role; only that reconciler adds or removes it.
  */
-export type UserRoleSource = "manual" | "group-sync";
+export type UserRoleSource = "manual" | "group-sync" | "oneroster";
 
 export const userRoles = pgTable("user_roles", {
   id: serial("id").primaryKey(),
@@ -31,5 +33,8 @@ export const userRoles = pgTable("user_roles", {
   userRoleUnique: unique().on(table.userId, table.roleId),
   // Mirrors the inline CHECK in migration 109 so the Drizzle schema stays the
   // faithful source of truth (same convention as capabilities_source_check).
-  sourceCheck: check("user_roles_source_check", sql`${table.source} IN ('manual', 'group-sync')`),
+  sourceCheck: check(
+    "user_roles_source_check",
+    sql`${table.source} IN ('manual', 'group-sync', 'oneroster')`
+  ),
 }));

--- a/lib/db/schema/tables/user-roles.ts
+++ b/lib/db/schema/tables/user-roles.ts
@@ -13,9 +13,11 @@ import { roles } from "./roles";
  * 'manual'     — an admin assigned the role by hand (also the value for every
  *                pre-managed-sync row). Reconciliation NEVER touches these.
  * 'group-sync' — reconciliation granted it from a group→role mapping; it is the
- *                only source Google group reconciliation adds or removes.
+ *                source Google group reconciliation owns while eligible.
  * 'oneroster'  — nightly roster reconciliation granted it from an active
- *                OneRoster role; only that reconciler adds or removes it.
+ *                OneRoster role; that reconciler owns it while eligible.
+ * When both providers compute the same unique (user, role), the current owner
+ * transfers its own row to the surviving provider before revocation.
  */
 export type UserRoleSource = "manual" | "group-sync" | "oneroster";
 

--- a/lib/db/user-roles.ts
+++ b/lib/db/user-roles.ts
@@ -109,10 +109,10 @@ export async function updateUserRoles(userId: number, roleNames: string[]): Prom
     }
 
     // Execute transaction to update user roles atomically.
-    // Managed (source='group-sync') rows are INVISIBLE to this editor (#1204):
-    // never deleted (reconciliation would re-add them next pass — a silent
-    // no-op revocation) and never re-inserted as 'manual' (which would exempt
-    // them from auto-revocation forever). This editor owns manual rows only.
+    // Managed (source='group-sync' or 'oneroster') rows are INVISIBLE to this
+    // editor: never deleted (their reconciler would re-add them next pass — a
+    // silent no-op revocation) and never re-inserted as 'manual' (which would
+    // exempt them from auto-revocation forever). This editor owns manual rows.
     await executeTransaction(
       async (tx) => {
         const submittedIds = roleResult.map(role => role.id);

--- a/lib/roster/settings.ts
+++ b/lib/roster/settings.ts
@@ -10,6 +10,8 @@ import { z } from "zod";
 
 export const ONEROSTER_SETTING_KEYS = {
   enabled: "ROSTER_SYNC_ENABLED",
+  /** Opt-in authorization pass; scheduled syncs only, default disabled. */
+  roleSyncEnabled: "ROSTER_ROLE_SYNC_ENABLED",
   baseUrl: "ONEROSTER_BASE_URL",
   authMode: "ONEROSTER_AUTH_MODE",
   credentialsSecretArn: "ONEROSTER_CREDENTIALS_SECRET_ARN",
@@ -26,6 +28,7 @@ export type OneRosterApiVersion = "v1p1" | "v1p2";
 
 export interface OneRosterSettings {
   enabled: boolean;
+  roleSyncEnabled: boolean;
   baseUrl: string | null;
   authMode: OneRosterAuthMode | null;
   credentialsSecretArn: string | null;
@@ -140,9 +143,18 @@ export type ParsedOneRosterSettingsInput = z.output<
 >;
 
 export async function getOneRosterSettings(): Promise<OneRosterSettings> {
-  const [enabled, baseUrl, authMode, secretArn, apiVersion, pageSize] =
+  const [
+    enabled,
+    roleSyncEnabled,
+    baseUrl,
+    authMode,
+    secretArn,
+    apiVersion,
+    pageSize,
+  ] =
     await Promise.all([
       getSetting(ONEROSTER_SETTING_KEYS.enabled),
+      getSetting(ONEROSTER_SETTING_KEYS.roleSyncEnabled),
       getSetting(ONEROSTER_SETTING_KEYS.baseUrl),
       getSetting(ONEROSTER_SETTING_KEYS.authMode),
       getSetting(ONEROSTER_SETTING_KEYS.credentialsSecretArn),
@@ -153,6 +165,8 @@ export async function getOneRosterSettings(): Promise<OneRosterSettings> {
 
   return {
     enabled: enabled?.trim().toLowerCase() === "true",
+    roleSyncEnabled:
+      roleSyncEnabled?.trim().toLowerCase() === "true",
     baseUrl: baseUrl?.trim() || null,
     authMode: parseAuthMode(authMode),
     credentialsSecretArn: secretArn?.trim() || null,

--- a/tests/unit/managed-role-reconciliation.test.ts
+++ b/tests/unit/managed-role-reconciliation.test.ts
@@ -11,6 +11,7 @@
 import {
   computeManagedRoleDiff,
   applyLastAdminGuard,
+  partitionManagedRoleRemovals,
   type ExistingUserRole,
 } from "@/lib/db/drizzle/user-roles";
 
@@ -95,6 +96,15 @@ describe("computeManagedRoleDiff", () => {
   it("treats an empty computed set with no managed rows as a no-op", () => {
     const diff = computeManagedRoleDiff([], []);
     expect(diff).toEqual({ toAdd: [], toRemove: [], changed: false });
+  });
+});
+
+describe("partitionManagedRoleRemovals", () => {
+  it("transfers overlapping roster grants and removes only unowned roles", () => {
+    expect(partitionManagedRoleRemovals([2, 5, 7], [5, 9])).toEqual({
+      toTransfer: [5],
+      toRemove: [2, 7],
+    });
   });
 });
 

--- a/tests/unit/managed-role-reconciliation.test.ts
+++ b/tests/unit/managed-role-reconciliation.test.ts
@@ -16,6 +16,10 @@ import {
 
 const manual = (roleId: number): ExistingUserRole => ({ roleId, source: "manual" });
 const managed = (roleId: number): ExistingUserRole => ({ roleId, source: "group-sync" });
+const rosterManaged = (roleId: number): ExistingUserRole => ({
+  roleId,
+  source: "oneroster",
+});
 
 describe("computeManagedRoleDiff", () => {
   it("grants a mapped role the user does not yet hold (add path)", () => {
@@ -59,6 +63,14 @@ describe("computeManagedRoleDiff", () => {
     // Manual role 2 persists; group-sync role 5 (no longer computed) is removed.
     const diff = computeManagedRoleDiff([], [manual(2), managed(5)]);
     expect(diff).toEqual({ toAdd: [], toRemove: [5], changed: true });
+  });
+
+  it("leaves OneRoster-owned rows untouched while reconciling group-sync rows", () => {
+    const diff = computeManagedRoleDiff([], [
+      rosterManaged(5),
+      managed(7),
+    ]);
+    expect(diff).toEqual({ toAdd: [], toRemove: [7], changed: true });
   });
 
   it("does not re-add a mapped role already held manually, but still revokes a stale managed role", () => {

--- a/tests/unit/oneroster-admin-settings.test.ts
+++ b/tests/unit/oneroster-admin-settings.test.ts
@@ -96,6 +96,9 @@ describe("OneRoster administrator settings", () => {
 
   it("includes the durable status key in the shared settings contract", () => {
     expect(ONEROSTER_SETTING_KEYS.syncStatus).toBe("ONEROSTER_SYNC_STATUS");
+    expect(ONEROSTER_SETTING_KEYS.roleSyncEnabled).toBe(
+      "ROSTER_ROLE_SYNC_ENABLED"
+    );
   });
 });
 

--- a/tests/unit/oneroster-role-source-migration.test.ts
+++ b/tests/unit/oneroster-role-source-migration.test.ts
@@ -1,0 +1,42 @@
+import fs from "node:fs";
+import path from "node:path";
+
+const migrationFile = "156-oneroster-user-role-source.sql";
+const migration = fs.readFileSync(
+  path.join(process.cwd(), "infra/database/schema", migrationFile),
+  "utf8"
+);
+
+describe("OneRoster user-role source migration", () => {
+  it("widens the source constraint without changing the default owner", () => {
+    expect(migration).toContain(
+      "CHECK (source IN ('manual', 'group-sync', 'oneroster'))"
+    );
+    expect(migration).toContain(
+      "DROP CONSTRAINT IF EXISTS user_roles_source_check"
+    );
+    expect(migration).not.toMatch(/ALTER COLUMN source SET DEFAULT 'oneroster'/i);
+  });
+
+  it("is splitter-safe and documents a source-scoped rollback", () => {
+    expect(migration).not.toMatch(/\bDO\s+\$\$/i);
+    expect(migration).not.toMatch(/\b(?:BEGIN|COMMIT|ROLLBACK)\s*;/i);
+    expect(migration).toContain(
+      "WHERE source = 'oneroster'"
+    );
+    expect(migration).toContain(
+      "SET role_version = coalesce(role_version, 0) + 1"
+    );
+  });
+
+  it("is registered in the authoritative migration manifest", () => {
+    const manifest = JSON.parse(
+      fs.readFileSync(
+        path.join(process.cwd(), "infra/database/migrations.json"),
+        "utf8"
+      )
+    ) as { migrationFiles: string[] };
+
+    expect(manifest.migrationFiles).toContain(migrationFile);
+  });
+});

--- a/tests/unit/oneroster-sync-contract.test.ts
+++ b/tests/unit/oneroster-sync-contract.test.ts
@@ -22,6 +22,7 @@ describe("OneRoster sync cross-bundle contracts", () => {
   it("keeps all shared database-first setting keys synchronized", () => {
     for (const key of [
       "ROSTER_SYNC_ENABLED",
+      "ROSTER_ROLE_SYNC_ENABLED",
       "ONEROSTER_BASE_URL",
       "ONEROSTER_AUTH_MODE",
       "ONEROSTER_CREDENTIALS_SECRET_ARN",
@@ -43,10 +44,21 @@ describe("OneRoster sync cross-bundle contracts", () => {
     );
   });
 
-  it("chunks writes below 5,000 rows and limits mutation SQL to roster tables", () => {
+  it("chunks collection writes below 5,000 rows", () => {
     expect(db).toContain("const UPSERT_CHUNK_SIZE = 4_000");
-    expect(db).not.toMatch(/\b(?:INSERT INTO|UPDATE|DELETE FROM)\s+users\b/i);
-    expect(db).not.toMatch(/\b(?:INSERT INTO|UPDATE|DELETE FROM)\s+user_roles\b/i);
+  });
+
+  it("source-scopes role writes and structurally excludes administrator", () => {
+    expect(db).toContain(
+      "SELECT computed.user_id, computed.role_id, 'oneroster'"
+    );
+    expect(db).toContain("WHERE managed.source = 'oneroster'");
+    expect(db).toContain(
+      "lower(protected_role.name) = 'administrator'"
+    );
+    expect(db).not.toContain(
+      "SELECT computed.user_id, computed.role_id, 'administrator'"
+    );
   });
 
   it("applies absence deactivation only inside collection transactions", () => {

--- a/tests/unit/oneroster-sync-contract.test.ts
+++ b/tests/unit/oneroster-sync-contract.test.ts
@@ -18,6 +18,8 @@ describe("OneRoster sync cross-bundle contracts", () => {
     "infra/lambdas/oneroster-sync/config.ts"
   );
   const db = source("infra/lambdas/oneroster-sync/db.ts");
+  const groupDb = source("infra/lambdas/group-sync/db.ts");
+  const appGroupReconciler = source("lib/db/drizzle/user-roles.ts");
 
   it("keeps all shared database-first setting keys synchronized", () => {
     for (const key of [
@@ -59,6 +61,26 @@ describe("OneRoster sync cross-bundle contracts", () => {
     expect(db).not.toContain(
       "SELECT computed.user_id, computed.role_id, 'administrator'"
     );
+  });
+
+  it("hands overlapping unique rows to the surviving managed provider", () => {
+    expect(db).toContain("SET source = 'group-sync'");
+    expect(groupDb).toContain("SET source = 'oneroster'");
+    expect(appGroupReconciler).toContain('source: "oneroster"');
+
+    for (const roleName of [
+      "teacher",
+      "aide",
+      "proctor",
+      "administrator",
+      "districtadministrator",
+      "siteadministrator",
+      "systemadministrator",
+    ]) {
+      expect(db).toContain(roleName);
+      expect(groupDb).toContain(roleName);
+      expect(appGroupReconciler).toContain(roleName);
+    }
   });
 
   it("applies absence deactivation only inside collection transactions", () => {


### PR DESCRIPTION
## Summary

Closes #1312. Part of #1308.

Adds a default-off, nightly-only OneRoster application-role reconciliation pass after a fully successful roster pull.

- Maps active OneRoster `student` to AI Studio `student`.
- Maps active staff-shaped roles (`teacher`, `aide`, `proctor`, `administrator`, and recognized vendor spellings) to AI Studio `staff`.
- Joins roster records to existing application users with `lower(email)` on both sides; people who have never signed in are skipped.
- Inserts new grants as `user_roles.source='oneroster'` and deletes only stale rows owned by that source.
- Preserves overlapping group/roster grants despite the unique `(user_id, role_id)` row: when the current provider becomes stale and the other still computes the same role, ownership transfers atomically instead of dropping access.
- Never maps to or deletes the AI Studio `administrator` role.
- Bumps `users.role_version` exactly once per changed user.
- Runs in one transaction and is contained by a best-effort boundary, so a role-pass failure cannot turn a good roster sync into a failed run.
- Emits `RolesGranted`, `RolesRevoked`, and `RoleUsersChanged` under `AIStudio/RosterSync`.

## Refined acceptance criteria

- [x] Migration 156 admits `source='oneroster'`, preserves the `manual` default, is registered after the newly merged migration 155 in `infra/database/migrations.json`, and has a source-scoped rollback.
- [x] Mapping is fixed and fail-closed; family and unknown role values grant nothing.
- [x] AI Studio `administrator` is structurally impossible to grant and structurally excluded from deletion.
- [x] Reconciliation is enabled only by exact `ROSTER_ROLE_SYNC_ENABLED='true'`, after a fully successful scheduled sync; manual syncs never reconcile roles.
- [x] A role transaction failure is logged and rolled back without failing the roster snapshot.
- [x] Unmatched roster people are skipped; the email join lowercases both sides.
- [x] Coexistence coverage proves manual grants remain isolated and overlapping OneRoster/group-sync grants hand off atomically in both directions without an effective revoke.
- [x] No-op runs do not churn `role_version`.
- [x] Operational metrics, default-off rollout, and cache-safe rollback are documented.
- [x] E2E is N/A because this is a background-only path with no UI or API surface.

## Schema and migration

`156-oneroster-user-role-source.sql` replaces the existing source constraint with:

```sql
CHECK (source IN ('manual', 'group-sync', 'oneroster'))
```

The column default remains `manual`. The migration contains no transaction control or dollar-quoted blocks, so it is compatible with the repository migration splitter. Before `dev` advanced, the same SQL was applied through the complete then-current chain in a fresh disposable pgvector/PostgreSQL database and reapplied twice successfully. The final rebase renumbered it from 155 to 156 behind the newly merged unified-content migration; manifest/contract tests validate the final order, and the PR PostgreSQL lifecycle runs the authoritative 001→156 chain.

Rollback:

1. Set `ROSTER_ROLE_SYNC_ENABLED=false`.
2. Delete only `source='oneroster'` rows with the documented CTE.
3. Bump `role_version` for every affected user in that same statement.
4. Restore the prior two-value source constraint if rolling back application code/migration state.

## ClassLink and configuration implications

- No new ClassLink API scopes, credentials, Secrets Manager entries, network rules, or IAM permissions are required.
- `ROSTER_ROLE_SYNC_ENABLED` is database-first and defaults to false when absent.
- Existing roster collection synchronization remains controlled independently by `ROSTER_SYNC_ENABLED`.
- Roll out collection sync first, review email-match coverage and role distribution, then explicitly enable the role flag.
- Manual roster runs remain observation/validation tools and never change application roles.

## Security and authorization analysis

- The roster value never becomes a role identifier directly; normalized input is compared only with a fixed allowlist.
- The application administrator role is not a mapping result and is separately excluded from the delete predicate, so this path cannot grant or revoke administrator.
- Source ownership is the authorization boundary: each reconciler deletes only rows it currently owns. A stale managed owner may transfer its own row to the other provider only after proving that provider still computes the identical effective role; `manual` rows remain invisible.
- Provenance-only handoffs do not bump `role_version` or grant/revoke metrics because effective authorization is unchanged.
- All writes and `role_version` invalidations occur in one database transaction.
- A missing required application role causes rollback rather than a partial authorization state.
- Existing users are matched by the database-enforced case-insensitive email identity; unmatched roster people are not provisioned.
- Credentials remain loaded from Secrets Manager and are never added to logs.
- No API endpoint or capability/scope authorization contract changes.

## Validation

- `bun run lint` — exits 0; current `dev` baseline remains 476 warnings and this PR adds no new OneRoster warning. The repository-wide “zero lint warnings” checkbox is intentionally not claimed.
- `bun run typecheck` — passed.
- `bun run test:ci` — 415 suites / 3,995 tests passed; 3 suites / 26 tests skipped by existing gates.
- `bun run build` — production Next.js build passed.
- `bun test` in `infra/lambdas/oneroster-sync` — unit suite passed; PostgreSQL tests are separately gated.
- `bun run build` in `infra/lambdas/oneroster-sync` — passed with pinned TypeScript 5.9.3 and postgres 3.4.7.
- `ONEROSTER_DB_TEST_URL=... bun test db.integration.test.ts` — 5 tests passed against both the local database and a fresh disposable database, including both managed-provider ownership handoff directions and exact `role_version` behavior.
- `bun run build` in `infra` — CDK TypeScript/unified-content typechecks and nested Lambda tests passed.
- `bun run test -- --runInBand` in `infra` — 46 suites / 429 tests passed.
- `bunx cdk synth` in `infra` — all dev and prod stacks synthesized, including the production OneRoster bundle.
- `git diff --check` — passed.

The local authenticated Playwright hook was bypassed with its documented `SKIP_E2E=1` mechanism because the isolated worktree has no `AUTH_SECRET` and this workstream has no UI surface.

## Rollout and observability

1. Deploy migration and Lambda while leaving `ROSTER_ROLE_SYNC_ENABLED=false`.
2. Confirm ordinary scheduled roster sync health and compare roster/application email coverage.
3. Enable the role flag.
4. Monitor `RolesGranted`, `RolesRevoked`, and `RoleUsersChanged` in `AIStudio/RosterSync`, plus the existing sync failure/staleness alarms.
5. Disable the role flag immediately if results need investigation; the last successful role state remains stable.

## Known limitations and risks

- A brand-new user keeps the heuristic default role until the next successful nightly pass.
- The mapping is intentionally fixed in v1; admin-configurable mapping and OneRoster-triggered login-time reconciliation remain out of scope.
- Role reconciliation is best-effort by design. A failure preserves the good roster snapshot and is visible in structured logs, but role-change metrics are emitted only after a successful role transaction.
- Authorization writes are medium risk; mitigations are the default-off flag, source isolation, fixed mapping, administrator exclusion, transactional writes, cache invalidation, and staged rollout.
