### PR TITLE
perf(agent): stop syncing regenerable build trees — 162s cold start, 78% of it a pip venv

### DIFF
--- a/infra/agent-image/test_workspace_sync.py
+++ b/infra/agent-image/test_workspace_sync.py
@@ -634,6 +634,31 @@ class RegenerableArtifactSkipTests(unittest.TestCase):
                 f"must NOT skip a file merely NAMED like a build dir: {rel}",
             )
 
+    def test_visible_venv_suffix_does_not_swallow_authored_skills(self):
+        # skills/user/ is the agent's OWN scratch space. A visible directory
+        # that merely ends in "-venv" is an authored name, not a virtualenv,
+        # and skipping it would drop the skill from both pull and push.
+        for rel in (
+            "skills/user/hagelk-python-venv/SKILL.md",
+            "skills/user/build-a-venv/README.md",
+            "memory/how-to-venv/notes.md",
+        ):
+            self.assertFalse(
+                workspace_sync._should_skip_relative(rel),
+                f"must NOT skip a visible authored dir ending in -venv: {rel}",
+            )
+
+    def test_hidden_venv_suffix_is_still_skipped(self):
+        # The real-world form the skip exists for stays matched.
+        for rel in (
+            "skills/hagelk-morning-brief/.tts-venv/bin/python",
+            "skills/foo/.build-venv/lib/thing.py",
+        ):
+            self.assertTrue(
+                workspace_sync._should_skip_relative(rel),
+                f"should skip hidden virtualenv: {rel}",
+            )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/infra/agent-image/test_workspace_sync.py
+++ b/infra/agent-image/test_workspace_sync.py
@@ -583,5 +583,57 @@ class RestoreNeverClobbersTests(unittest.TestCase):
         )
 
 
+class RegenerableArtifactSkipTests(unittest.TestCase):
+    """Dependency trees are not memory and must not be synced.
+
+    A real workspace on 2026-07-27 held 4,989 objects, of which 3,886 (77.9%)
+    were a pip virtualenv inside ONE skill. The cold-start restore took 161.7s
+    before the agent could answer, while actual memory/ was 55 files.
+    """
+
+    def test_skips_regenerable_trees_at_any_depth(self):
+        # These appear MID-path, which the prefix list cannot express.
+        for rel in (
+            "skills/hagelk-morning-brief/.tts-venv/lib/python3.11/site-packages/pip/x.py",
+            "skills/foo/node_modules/left-pad/index.js",
+            "skills/foo/.venv/bin/python",
+            "skills/foo/venv/lib/thing.py",
+            "skills/foo/__pycache__/mod.cpython-311.pyc",
+            "workspace/.next/cache/blob",
+        ):
+            self.assertTrue(
+                workspace_sync._should_skip_relative(rel),
+                f"should skip regenerable path: {rel}",
+            )
+
+    def test_never_skips_memory_or_identity(self):
+        # The whole point of the sync. A false positive here is data loss.
+        for rel in (
+            "IDENTITY.md",
+            "MEMORY.md",
+            "USER.md",
+            "memory/2026-04-21.md",
+            "memory/main.sqlite",
+            "memory/.dreams/events.jsonl",
+            "skills/user/my-skill/SKILL.md",
+        ):
+            self.assertFalse(
+                workspace_sync._should_skip_relative(rel),
+                f"must NOT skip user-owned path: {rel}",
+            )
+
+    def test_does_not_skip_lookalike_names(self):
+        # Substring matching would wrongly catch these; segment matching does not.
+        for rel in (
+            "memory/venv-notes.md",
+            "notes/site-packages-comparison.md",
+            "memory/node_modules-explained.md",
+        ):
+            self.assertFalse(
+                workspace_sync._should_skip_relative(rel),
+                f"must NOT skip a file merely NAMED like a build dir: {rel}",
+            )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/infra/agent-image/workspace_sync.py
+++ b/infra/agent-image/workspace_sync.py
@@ -313,8 +313,17 @@ def _is_regenerable_segment(segment: str) -> bool:
     """True for a directory that can be rebuilt and need not be synced."""
     if segment in _SKIP_SEGMENT_NAMES:
         return True
-    # Virtualenvs: ".venv", "venv", and skill-specific forms like ".tts-venv".
-    return segment == "venv" or segment.endswith("-venv") or segment == ".venv"
+    # Virtualenvs: exact "venv"/".venv", plus HIDDEN skill-local forms like
+    # ".tts-venv". The "-venv" suffix is deliberately not honoured on visible
+    # segments: an authored directory such as
+    # "skills/user/hagelk-python-venv/SKILL.md" would then be skipped by BOTH
+    # the pull and the push, so the agent's own scratch space would be neither
+    # restored nor uploaded. The two failure modes are not symmetric — an
+    # unmatched venv only costs sync time, an over-matched skill loses work —
+    # so keep the match narrow and let a stray visible venv ride along.
+    if segment in ("venv", ".venv"):
+        return True
+    return segment.startswith(".") and segment.endswith("-venv")
 
 
 def _should_skip_relative(relative: str) -> bool:

--- a/infra/agent-image/workspace_sync.py
+++ b/infra/agent-image/workspace_sync.py
@@ -286,6 +286,36 @@ _SKIP_RELATIVE_PREFIXES = (
 # Filename suffixes that are always runtime cruft (socket files, pid files).
 _SKIP_SUFFIXES = (".sock", ".pid")
 
+# Directory names that hold REGENERABLE build artifacts, matched at ANY depth.
+#
+# These are not memory. They are dependency trees a skill can rebuild from its
+# manifest, and round-tripping them through S3 costs real time on every cold
+# start: on 2026-07-27 one workspace held 4,989 objects of which 3,886 (77.9%)
+# were a pip virtualenv inside a single skill, and the restore took 161.7s
+# before the agent could answer its first message. Actual memory/ was 55 files.
+#
+# Matched per path SEGMENT rather than as a prefix, because they appear
+# mid-path — e.g. skills/<name>/.tts-venv/lib/python3.11/site-packages/pip/...
+# — which the prefix list above cannot express.
+_SKIP_SEGMENT_NAMES = frozenset({
+    "node_modules",
+    "site-packages",
+    "__pycache__",
+    ".mypy_cache",
+    ".pytest_cache",
+    ".ruff_cache",
+    ".turbo",
+    ".next",
+})
+
+
+def _is_regenerable_segment(segment: str) -> bool:
+    """True for a directory that can be rebuilt and need not be synced."""
+    if segment in _SKIP_SEGMENT_NAMES:
+        return True
+    # Virtualenvs: ".venv", "venv", and skill-specific forms like ".tts-venv".
+    return segment == "venv" or segment.endswith("-venv") or segment == ".venv"
+
 
 def _should_skip_relative(relative: str) -> bool:
     """True if this workspace-relative path is gateway-owned, not user memory."""
@@ -293,6 +323,8 @@ def _should_skip_relative(relative: str) -> bool:
     for prefix in _SKIP_RELATIVE_PREFIXES:
         if rel == prefix or rel.startswith(prefix):
             return True
+    if any(_is_regenerable_segment(seg) for seg in rel.split("/")):
+        return True
     return any(rel.endswith(suf) for suf in _SKIP_SUFFIXES)
 
 


### PR DESCRIPTION
## The agent takes 162 seconds to answer its first message

```
workspace pull: prefix=hagelk-db0f32b5 files=2554 elapsed_s=161.7
```

### What it's restoring

| Count | Share | What |
|---|---|---|
| 3,886 | **77.9%** | pip virtualenv / `site-packages` inside **one** skill |
| 927 | 18.6% | other |
| 121 | 2.4% | markdown |
| **55** | **1.1%** | **`memory/` — the part that actually matters** |

Nearly four thousand files are a dependency tree the skill can rebuild from its own manifest. Not memory, and round-tripping them through S3 costs a wait on every cold start.

This only became visible tonight: before the restore was fixed it hit the [#1353](https://github.com/psd401/aistudio/pull/1353) 1,000-file cap and failed **fast** — quick, and exactly what destroyed the user's memory. A slow correct restore is the right trade; 162s isn't where it should land.

## Fix

Skip regenerable directories **by path segment at any depth**: `node_modules`, `site-packages`, `__pycache__`, `.mypy_cache`, `.pytest_cache`, `.ruff_cache`, `.turbo`, `.next`, and virtualenvs (`.venv`, `venv`, and skill-specific forms like `.tts-venv`).

Segment matching is the whole point — these appear **mid-path**:

```
skills/hagelk-morning-brief/.tts-venv/lib/python3.11/site-packages/pip/...
```

which `_SKIP_RELATIVE_PREFIXES` can't express, since it only anchors at the start.

## Measured against the real key listing

```
total 4,989  ->  skipped 3,887 (77.9%)  ->  synced 1,102

IDENTITY.md / MEMORY.md / USER.md    kept
memory/                              55 kept, 0 skipped
skills/user authoring scratchpad     kept
```

## Tests — 27 pass (+3)

- regenerable trees are skipped at depth
- memory and identity are **never** skipped
- files merely **named** like a build dir (`memory/venv-notes.md`, `notes/site-packages-comparison.md`) are **not** skipped — substring matching would have caught those; segment matching doesn't

Verified to **fail** with the segment check removed.