### PR TITLE
feat(rooms): add teacher room management (#1313)

### DIFF
--- a/actions/db/rooms-actions.ts
+++ b/actions/db/rooms-actions.ts
@@ -1,0 +1,374 @@
+"use server";
+
+/**
+ * Capability-gated room management actions (Epic #1308 / Issue #1313).
+ *
+ * The server is authoritative for section ownership, assistant access, and
+ * creator/administrator mutation rights. Roster emails and individual students
+ * are never written to logs.
+ */
+
+import { revalidatePath } from "next/cache";
+import { z } from "zod";
+import { getServerSession } from "@/lib/auth/server-session";
+import { resolveUserId } from "@/lib/auth/resolve-user";
+import {
+  createSuccess,
+  ErrorFactories,
+  handleError,
+} from "@/lib/error-utils";
+import {
+  createLogger,
+  generateRequestId,
+  startTimer,
+} from "@/lib/logger";
+import {
+  accessibleActiveRosterStudentEmails,
+  accessibleApprovedAssistantIds,
+  getRoomActor,
+  getRoomAuthorizationSnapshot,
+  listAccessibleApprovedAssistants,
+  listRoomsForManagement,
+  listTeacherSections,
+  searchActiveRosterStudents,
+  type AccessibleAssistantOption,
+  type ManagedRoom,
+  type RosterStudentOption,
+  type TeacherSectionOption,
+} from "@/lib/rooms/queries";
+import {
+  createManagedRoom,
+  deactivateManagedRoom,
+  updateManagedRoom,
+  type RoomMutationActor,
+  type RoomMutationInput,
+} from "@/lib/rooms/mutations";
+import {
+  canManageRoom,
+  findUnauthorizedAssistantIds,
+  findUnauthorizedClassIds,
+} from "@/lib/rooms/validation";
+import { normalizeEmail } from "@/lib/groups/normalize";
+import { hasCapabilityAccess } from "@/utils/roles";
+import type { ActionState } from "@/types";
+
+const ROOMS_MANAGE_PATH = "/rooms/manage";
+const ROOM_NAME_MAX = 120;
+const MAX_ROOM_CLASSES = 50;
+const MAX_EXPLICIT_MEMBERS = 200;
+const MAX_ASSISTANTS = 100;
+const STUDENT_SEARCH_MAX = 200;
+
+const roomMutationSchema = z.object({
+  name: z.string().trim().min(1).max(ROOM_NAME_MAX),
+  classSourcedIds: z
+    .array(z.string().trim().min(1).max(512))
+    .max(MAX_ROOM_CLASSES),
+  memberEmails: z
+    .array(z.string().trim().email().max(320))
+    .max(MAX_EXPLICIT_MEMBERS),
+  assistantIds: z
+    .array(z.number().int().positive())
+    .max(MAX_ASSISTANTS),
+});
+
+const roomIdSchema = z.string().uuid();
+const studentSearchSchema = z
+  .string()
+  .trim()
+  .min(2)
+  .max(STUDENT_SEARCH_MAX);
+
+export interface RoomsManageData {
+  rooms: ManagedRoom[];
+  sections: TeacherSectionOption[];
+  assistants: AccessibleAssistantOption[];
+}
+
+interface RoomsActor extends RoomMutationActor {
+  email: string;
+}
+
+function parseRoomInput(input: unknown): RoomMutationInput {
+  const parsed = roomMutationSchema.safeParse(input);
+  if (!parsed.success) {
+    throw ErrorFactories.validationFailed(
+      parsed.error.issues.map((issue) => ({
+        field: issue.path.join(".") || "room",
+        message: issue.message,
+      }))
+    );
+  }
+  return {
+    name: parsed.data.name,
+    classSourcedIds: [
+      ...new Set(parsed.data.classSourcedIds.map((value) => value.trim())),
+    ],
+    memberEmails: [
+      ...new Set(
+        parsed.data.memberEmails.map((value) => normalizeEmail(value))
+      ),
+    ],
+    assistantIds: [...new Set(parsed.data.assistantIds)],
+  };
+}
+
+function parseRoomId(roomId: string): string {
+  const parsed = roomIdSchema.safeParse(roomId);
+  if (!parsed.success) {
+    throw ErrorFactories.authzResourceNotFound("room", "invalid");
+  }
+  return parsed.data;
+}
+
+async function requireRoomsActor(
+  requestId: string,
+  log: ReturnType<typeof createLogger>
+): Promise<RoomsActor> {
+  const session = await getServerSession();
+  if (!session) {
+    log.warn("Unauthenticated room-management request");
+    throw ErrorFactories.authNoSession();
+  }
+
+  const userId = await resolveUserId(session, requestId);
+  if (!(await hasCapabilityAccess("rooms-manage", session.sub))) {
+    log.warn("Room-management capability denied", { userId });
+    throw ErrorFactories.authzInsufficientPermissions("rooms-manage");
+  }
+
+  const actor = await getRoomActor(userId);
+  if (!actor) {
+    throw ErrorFactories.authzResourceNotFound("user", String(userId));
+  }
+  return {
+    userId,
+    email: actor.email,
+    isAdministrator: actor.isAdministrator,
+  };
+}
+
+async function validateAssignments(
+  actor: RoomsActor,
+  input: RoomMutationInput,
+  existingClassIds: string[]
+): Promise<void> {
+  const sections = await listTeacherSections(actor.email);
+  const teacherClassIds = new Set(
+    sections.map((section) => section.sourcedId)
+  );
+  const unauthorizedClasses = findUnauthorizedClassIds(
+    input.classSourcedIds,
+    existingClassIds,
+    teacherClassIds,
+    actor.isAdministrator
+  );
+  if (unauthorizedClasses.length > 0) {
+    // Preserve visibility-before-permission: do not reveal whether the supplied
+    // sourced ID belongs to another teacher.
+    throw ErrorFactories.authzResourceNotFound(
+      "OneRoster class",
+      unauthorizedClasses[0]
+    );
+  }
+
+  const accessibleIds = await accessibleApprovedAssistantIds(
+    actor.userId,
+    input.assistantIds
+  );
+  const unauthorizedAssistants = findUnauthorizedAssistantIds(
+    input.assistantIds,
+    accessibleIds
+  );
+  if (unauthorizedAssistants.length > 0) {
+    throw ErrorFactories.authzResourceNotFound(
+      "assistant",
+      String(unauthorizedAssistants[0])
+    );
+  }
+
+  const accessibleMemberEmails =
+    await accessibleActiveRosterStudentEmails(
+      actor.email,
+      actor.isAdministrator,
+      input.memberEmails
+    );
+  const unauthorizedMemberEmail = input.memberEmails.find(
+    (email) => !accessibleMemberEmails.has(email)
+  );
+  if (unauthorizedMemberEmail) {
+    throw ErrorFactories.authzResourceNotFound(
+      "OneRoster student",
+      unauthorizedMemberEmail
+    );
+  }
+}
+
+export async function getRoomsManageDataAction(): Promise<
+  ActionState<RoomsManageData>
+> {
+  const requestId = generateRequestId();
+  const timer = startTimer("getRoomsManageDataAction");
+  const log = createLogger({ requestId, action: "getRoomsManageDataAction" });
+  try {
+    const actor = await requireRoomsActor(requestId, log);
+    const [rooms, sections, assistants] = await Promise.all([
+      listRoomsForManagement(actor.userId),
+      listTeacherSections(actor.email),
+      listAccessibleApprovedAssistants(actor.userId),
+    ]);
+    timer({ status: "success" });
+    return createSuccess(
+      { rooms, sections, assistants },
+      "Room management data loaded"
+    );
+  } catch (error) {
+    timer({ status: "error" });
+    return handleError(error, "Failed to load room management.", {
+      context: "getRoomsManageDataAction",
+      requestId,
+      operation: "getRoomsManageDataAction",
+    });
+  }
+}
+
+export async function searchRoomStudentsAction(
+  search: unknown
+): Promise<ActionState<RosterStudentOption[]>> {
+  const requestId = generateRequestId();
+  const timer = startTimer("searchRoomStudentsAction");
+  const log = createLogger({ requestId, action: "searchRoomStudentsAction" });
+  try {
+    const actor = await requireRoomsActor(requestId, log);
+    const parsed = studentSearchSchema.safeParse(search);
+    if (!parsed.success) {
+      throw ErrorFactories.validationFailed([
+        { field: "search", message: "Enter between 2 and 200 characters." },
+      ]);
+    }
+    const students = await searchActiveRosterStudents(
+      parsed.data,
+      actor.email,
+      actor.isAdministrator
+    );
+    timer({ status: "success", count: students.length });
+    return createSuccess(students, "Student search complete");
+  } catch (error) {
+    timer({ status: "error" });
+    return handleError(error, "Failed to search roster students.", {
+      context: "searchRoomStudentsAction",
+      requestId,
+      operation: "searchRoomStudentsAction",
+    });
+  }
+}
+
+export async function createRoomAction(
+  input: RoomMutationInput
+): Promise<ActionState<{ roomId: string }>> {
+  const requestId = generateRequestId();
+  const timer = startTimer("createRoomAction");
+  const log = createLogger({ requestId, action: "createRoomAction" });
+  try {
+    const actor = await requireRoomsActor(requestId, log);
+    const parsed = parseRoomInput(input);
+    await validateAssignments(actor, parsed, []);
+    const roomId = await createManagedRoom(actor, parsed);
+    revalidatePath(ROOMS_MANAGE_PATH);
+    log.info("Room created", {
+      userId: actor.userId,
+      roomId,
+      classCount: parsed.classSourcedIds.length,
+      explicitMemberCount: parsed.memberEmails.length,
+      assistantCount: parsed.assistantIds.length,
+    });
+    timer({ status: "success" });
+    return createSuccess({ roomId }, "Room created");
+  } catch (error) {
+    timer({ status: "error" });
+    return handleError(error, "Failed to create room.", {
+      context: "createRoomAction",
+      requestId,
+      operation: "createRoomAction",
+    });
+  }
+}
+
+export async function updateRoomAction(
+  roomId: string,
+  input: RoomMutationInput
+): Promise<ActionState<{ roomId: string }>> {
+  const requestId = generateRequestId();
+  const timer = startTimer("updateRoomAction");
+  const log = createLogger({ requestId, action: "updateRoomAction" });
+  try {
+    const actor = await requireRoomsActor(requestId, log);
+    const id = parseRoomId(roomId);
+    const snapshot = await getRoomAuthorizationSnapshot(id);
+    if (
+      !snapshot ||
+      !canManageRoom(
+        actor.userId,
+        snapshot.createdBy,
+        actor.isAdministrator
+      )
+    ) {
+      throw ErrorFactories.authzResourceNotFound("room", id);
+    }
+    const parsed = parseRoomInput(input);
+    await validateAssignments(actor, parsed, snapshot.classSourcedIds);
+    await updateManagedRoom(id, actor, parsed);
+    revalidatePath(ROOMS_MANAGE_PATH);
+    log.info("Room updated", {
+      userId: actor.userId,
+      roomId: id,
+      classCount: parsed.classSourcedIds.length,
+      explicitMemberCount: parsed.memberEmails.length,
+      assistantCount: parsed.assistantIds.length,
+    });
+    timer({ status: "success" });
+    return createSuccess({ roomId: id }, "Room updated");
+  } catch (error) {
+    timer({ status: "error" });
+    return handleError(error, "Failed to update room.", {
+      context: "updateRoomAction",
+      requestId,
+      operation: "updateRoomAction",
+    });
+  }
+}
+
+export async function deleteRoomAction(
+  roomId: string
+): Promise<ActionState<{ roomId: string }>> {
+  const requestId = generateRequestId();
+  const timer = startTimer("deleteRoomAction");
+  const log = createLogger({ requestId, action: "deleteRoomAction" });
+  try {
+    const actor = await requireRoomsActor(requestId, log);
+    const id = parseRoomId(roomId);
+    const snapshot = await getRoomAuthorizationSnapshot(id);
+    if (
+      !snapshot ||
+      !canManageRoom(
+        actor.userId,
+        snapshot.createdBy,
+        actor.isAdministrator
+      )
+    ) {
+      throw ErrorFactories.authzResourceNotFound("room", id);
+    }
+    await deactivateManagedRoom(id, actor);
+    revalidatePath(ROOMS_MANAGE_PATH);
+    log.info("Room deactivated", { userId: actor.userId, roomId: id });
+    timer({ status: "success" });
+    return createSuccess({ roomId: id }, "Room deleted");
+  } catch (error) {
+    timer({ status: "error" });
+    return handleError(error, "Failed to delete room.", {
+      context: "deleteRoomAction",
+      requestId,
+      operation: "deleteRoomAction",
+    });
+  }
+}

--- a/actions/db/rooms-actions.ts
+++ b/actions/db/rooms-actions.ts
@@ -83,6 +83,7 @@ export interface RoomsManageData {
   rooms: ManagedRoom[];
   sections: TeacherSectionOption[];
   assistants: AccessibleAssistantOption[];
+  isAdministrator: boolean;
 }
 
 interface RoomsActor extends RoomMutationActor {
@@ -213,13 +214,13 @@ export async function getRoomsManageDataAction(): Promise<
   try {
     const actor = await requireRoomsActor(requestId, log);
     const [rooms, sections, assistants] = await Promise.all([
-      listRoomsForManagement(actor.userId),
+      listRoomsForManagement(actor.userId, actor.isAdministrator),
       listTeacherSections(actor.email),
       listAccessibleApprovedAssistants(actor.userId),
     ]);
     timer({ status: "success" });
     return createSuccess(
-      { rooms, sections, assistants },
+      { rooms, sections, assistants, isAdministrator: actor.isAdministrator },
       "Room management data loaded"
     );
   } catch (error) {

--- a/app/(protected)/rooms/manage/_components/room-assistant-picker.tsx
+++ b/app/(protected)/rooms/manage/_components/room-assistant-picker.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import type { AccessibleAssistantOption } from "@/lib/rooms/queries";
+
+interface RoomAssistantPickerProps {
+  assistants: AccessibleAssistantOption[];
+  selectedAssistantIds: number[];
+  onToggle: (assistantId: number) => void;
+}
+
+export function RoomAssistantPicker({
+  assistants,
+  selectedAssistantIds,
+  onToggle,
+}: RoomAssistantPickerProps) {
+  return (
+    <fieldset className="space-y-3">
+      <legend className="font-medium">Assigned assistants</legend>
+      <p className="text-xs text-muted-foreground">
+        Only approved assistants you can access are available.
+      </p>
+      {assistants.length === 0 ? (
+        <p className="rounded-md border p-3 text-sm text-muted-foreground">
+          No accessible approved assistants are available.
+        </p>
+      ) : (
+        <div className="max-h-56 space-y-2 overflow-y-auto rounded-md border p-3">
+          {assistants.map((assistant) => {
+            const inputId = `room-assistant-input-${assistant.id}`;
+            return (
+              <div
+                key={assistant.id}
+                className="flex items-start gap-3 rounded-md p-2 hover:bg-muted/60"
+              >
+                <input
+                  id={inputId}
+                  type="checkbox"
+                  className="mt-1 h-4 w-4"
+                  checked={selectedAssistantIds.includes(assistant.id)}
+                  data-testid={`room-assistant-${assistant.id}`}
+                  onChange={() => onToggle(assistant.id)}
+                />
+                <label htmlFor={inputId} className="cursor-pointer">
+                  <span className="block text-sm font-medium">
+                    {assistant.name}
+                  </span>
+                  {assistant.description && (
+                    <span className="block text-xs text-muted-foreground">
+                      {assistant.description}
+                    </span>
+                  )}
+                </label>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </fieldset>
+  );
+}

--- a/app/(protected)/rooms/manage/_components/room-editor.tsx
+++ b/app/(protected)/rooms/manage/_components/room-editor.tsx
@@ -1,0 +1,151 @@
+"use client";
+
+import type { FormEvent } from "react";
+import type { RoomMutationInput } from "@/lib/rooms/mutations";
+import type {
+  AccessibleAssistantOption,
+  RosterStudentOption,
+  TeacherSectionOption,
+} from "@/lib/rooms/queries";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Separator } from "@/components/ui/separator";
+import { RoomAssistantPicker } from "./room-assistant-picker";
+import { RoomSectionPicker } from "./room-section-picker";
+import { RoomStudentPicker } from "./room-student-picker";
+
+export interface RoomEditorFeedback {
+  kind: "success" | "error";
+  message: string;
+}
+
+interface RoomEditorProps {
+  editingRoomId: string | null;
+  draft: RoomMutationInput;
+  sections: TeacherSectionOption[];
+  assistants: AccessibleAssistantOption[];
+  studentSearch: string;
+  studentResults: RosterStudentOption[];
+  feedback: RoomEditorFeedback | null;
+  isSaving: boolean;
+  isSearching: boolean;
+  onDraftChange: (draft: RoomMutationInput) => void;
+  onStudentSearchChange: (value: string) => void;
+  onStudentSearch: () => void;
+  onAddStudent: (student: RosterStudentOption) => void;
+  onCancel: () => void;
+  onSubmit: (event: FormEvent<HTMLFormElement>) => void;
+}
+
+export function RoomEditor(props: RoomEditorProps) {
+  const updateDraft = (changes: Partial<RoomMutationInput>) =>
+    props.onDraftChange({ ...props.draft, ...changes });
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>
+          {props.editingRoomId ? "Edit room" : "Create a room"}
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <form className="space-y-6" onSubmit={props.onSubmit}>
+          <div className="space-y-2">
+            <Label htmlFor="room-name">Room name</Label>
+            <Input
+              id="room-name"
+              data-testid="room-name"
+              value={props.draft.name}
+              maxLength={120}
+              required
+              onChange={(event) => updateDraft({ name: event.target.value })}
+              placeholder="Period 2 Biology"
+            />
+          </div>
+          <Separator />
+          <RoomSectionPicker
+            sections={props.sections}
+            selectedSectionIds={props.draft.classSourcedIds}
+            onToggle={(sectionId) =>
+              updateDraft({
+                classSourcedIds: toggleValue(
+                  props.draft.classSourcedIds,
+                  sectionId
+                ),
+              })
+            }
+          />
+          <Separator />
+          <RoomStudentPicker
+            search={props.studentSearch}
+            results={props.studentResults}
+            memberEmails={props.draft.memberEmails}
+            isSearching={props.isSearching}
+            onSearchChange={props.onStudentSearchChange}
+            onSearch={props.onStudentSearch}
+            onAdd={props.onAddStudent}
+            onRemove={(email) =>
+              updateDraft({
+                memberEmails: props.draft.memberEmails.filter(
+                  (value) => value !== email
+                ),
+              })
+            }
+          />
+          <Separator />
+          <RoomAssistantPicker
+            assistants={props.assistants}
+            selectedAssistantIds={props.draft.assistantIds}
+            onToggle={(assistantId) =>
+              updateDraft({
+                assistantIds: toggleValue(
+                  props.draft.assistantIds,
+                  assistantId
+                ),
+              })
+            }
+          />
+          {props.feedback && (
+            <p
+              role="status"
+              className={
+                props.feedback.kind === "success"
+                  ? "text-sm text-emerald-700"
+                  : "text-sm text-destructive"
+              }
+              data-testid="room-feedback"
+            >
+              {props.feedback.message}
+            </p>
+          )}
+          <div className="flex justify-end gap-2">
+            {props.editingRoomId && (
+              <Button type="button" variant="outline" onClick={props.onCancel}>
+                Cancel
+              </Button>
+            )}
+            <Button
+              type="submit"
+              disabled={props.isSaving}
+              data-testid="room-save"
+            >
+              {props.isSaving
+                ? "Saving…"
+                : props.editingRoomId
+                  ? "Save changes"
+                  : "Create room"}
+            </Button>
+          </div>
+        </form>
+      </CardContent>
+    </Card>
+  );
+}
+
+function toggleValue<T>(values: T[], value: T): T[] {
+  return values.includes(value)
+    ? values.filter((candidate) => candidate !== value)
+    : [...values, value];
+}

--- a/app/(protected)/rooms/manage/_components/room-section-picker.tsx
+++ b/app/(protected)/rooms/manage/_components/room-section-picker.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import type { TeacherSectionOption } from "@/lib/rooms/queries";
+
+interface RoomSectionPickerProps {
+  sections: TeacherSectionOption[];
+  selectedSectionIds: string[];
+  onToggle: (sectionId: string) => void;
+}
+
+export function RoomSectionPicker({
+  sections,
+  selectedSectionIds,
+  onToggle,
+}: RoomSectionPickerProps) {
+  return (
+    <fieldset className="space-y-3">
+      <legend className="font-medium">Your ClassLink sections</legend>
+      <p className="text-xs text-muted-foreground">
+        Membership follows active student enrollments automatically.
+      </p>
+      {sections.length === 0 ? (
+        <p className="rounded-md border p-3 text-sm text-muted-foreground">
+          No active teacher sections match your email.
+        </p>
+      ) : (
+        <div className="max-h-56 space-y-2 overflow-y-auto rounded-md border p-3">
+          {sections.map((section) => {
+            const inputId = `room-section-input-${section.sourcedId}`;
+            return (
+              <div
+                key={section.sourcedId}
+                className="flex items-start gap-3 rounded-md p-2 hover:bg-muted/60"
+              >
+                <input
+                  id={inputId}
+                  type="checkbox"
+                  className="mt-1 h-4 w-4"
+                  data-testid={`room-section-${section.sourcedId}`}
+                  checked={selectedSectionIds.includes(section.sourcedId)}
+                  onChange={() => onToggle(section.sourcedId)}
+                />
+                <label htmlFor={inputId} className="cursor-pointer">
+                  <span className="block text-sm font-medium">
+                    {section.title ?? section.sourcedId}
+                  </span>
+                  <span className="block text-xs text-muted-foreground">
+                    {[section.classCode, section.schoolName]
+                      .filter(Boolean)
+                      .join(" · ")}{" "}
+                    · {section.studentCount} students
+                  </span>
+                </label>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </fieldset>
+  );
+}

--- a/app/(protected)/rooms/manage/_components/room-student-picker.tsx
+++ b/app/(protected)/rooms/manage/_components/room-student-picker.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import { Search, UserPlus, X } from "lucide-react";
+import type { RosterStudentOption } from "@/lib/rooms/queries";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+
+interface RoomStudentPickerProps {
+  search: string;
+  results: RosterStudentOption[];
+  memberEmails: string[];
+  isSearching: boolean;
+  onSearchChange: (value: string) => void;
+  onSearch: () => void;
+  onAdd: (student: RosterStudentOption) => void;
+  onRemove: (email: string) => void;
+}
+
+export function RoomStudentPicker({
+  search,
+  results,
+  memberEmails,
+  isSearching,
+  onSearchChange,
+  onSearch,
+  onAdd,
+  onRemove,
+}: RoomStudentPickerProps) {
+  return (
+    <fieldset className="space-y-3">
+      <legend className="font-medium">Individual students</legend>
+      <p className="text-xs text-muted-foreground">
+        Search the active roster. Explicit members are unioned with section
+        enrollment.
+      </p>
+      <div className="flex gap-2">
+        <Input
+          value={search}
+          data-testid="room-student-search"
+          onChange={(event) => onSearchChange(event.target.value)}
+          placeholder="Name or email"
+          minLength={2}
+        />
+        <Button
+          type="button"
+          variant="outline"
+          disabled={isSearching || search.trim().length < 2}
+          onClick={onSearch}
+          data-testid="room-student-search-button"
+        >
+          <Search className="mr-2 h-4 w-4" />
+          Search
+        </Button>
+      </div>
+      {results.length > 0 && (
+        <div className="max-h-40 space-y-1 overflow-y-auto rounded-md border p-2">
+          {results.map((student) => (
+            <button
+              key={student.email}
+              type="button"
+              className="flex w-full items-center justify-between rounded p-2 text-left text-sm hover:bg-muted"
+              onClick={() => onAdd(student)}
+              data-testid={`room-student-result-${student.email}`}
+            >
+              <span>
+                {[student.givenName, student.familyName]
+                  .filter(Boolean)
+                  .join(" ") || student.email}
+                <span className="ml-2 text-xs text-muted-foreground">
+                  {student.email}
+                </span>
+              </span>
+              <UserPlus className="h-4 w-4" />
+            </button>
+          ))}
+        </div>
+      )}
+      <div className="flex flex-wrap gap-2" data-testid="room-explicit-members">
+        {memberEmails.map((email) => (
+          <Badge key={email} variant="secondary">
+            {email}
+            <button
+              type="button"
+              className="ml-1"
+              aria-label={`Remove ${email}`}
+              onClick={() => onRemove(email)}
+            >
+              <X className="h-3 w-3" />
+            </button>
+          </Badge>
+        ))}
+      </div>
+    </fieldset>
+  );
+}

--- a/app/(protected)/rooms/manage/_components/rooms-list.tsx
+++ b/app/(protected)/rooms/manage/_components/rooms-list.tsx
@@ -12,6 +12,12 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 
 interface RoomsListProps {
   rooms: ManagedRoom[];
+  /**
+   * Administrators are served every owner's rooms, so the list is labelled
+   * "All rooms" and each card names its owner — without it, same-named rooms
+   * from different teachers are indistinguishable. Display only: the server
+   * re-derives management rights on every mutation.
+   */
   isAdministrator: boolean;
   sectionById: ReadonlyMap<string, TeacherSectionOption>;
   assistantById: ReadonlyMap<number, AccessibleAssistantOption>;
@@ -61,6 +67,14 @@ export function RoomsList({
               <div className="flex items-start justify-between gap-3">
                 <div>
                   <CardTitle className="text-base">{room.name}</CardTitle>
+                  {isAdministrator ? (
+                    <p
+                      className="mt-1 text-xs text-muted-foreground"
+                      data-testid={`room-owner-${room.id}`}
+                    >
+                      Owner: {room.createdByEmail ?? "unassigned"}
+                    </p>
+                  ) : null}
                   <p className="mt-1 text-xs text-muted-foreground">
                     {room.classSourcedIds.length} section
                     {room.classSourcedIds.length === 1 ? "" : "s"} ·{" "}

--- a/app/(protected)/rooms/manage/_components/rooms-list.tsx
+++ b/app/(protected)/rooms/manage/_components/rooms-list.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import { Pencil, Plus, Trash2 } from "lucide-react";
+import type {
+  AccessibleAssistantOption,
+  ManagedRoom,
+  TeacherSectionOption,
+} from "@/lib/rooms/queries";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+interface RoomsListProps {
+  rooms: ManagedRoom[];
+  sectionById: ReadonlyMap<string, TeacherSectionOption>;
+  assistantById: ReadonlyMap<number, AccessibleAssistantOption>;
+  deletingRoomId: string | null;
+  onCreate: () => void;
+  onEdit: (room: ManagedRoom) => void;
+  onDelete: (roomId: string) => void;
+}
+
+export function RoomsList({
+  rooms,
+  sectionById,
+  assistantById,
+  deletingRoomId,
+  onCreate,
+  onEdit,
+  onDelete,
+}: RoomsListProps) {
+  return (
+    <section className="space-y-4" aria-labelledby="my-rooms-heading">
+      <div className="flex items-center justify-between gap-3">
+        <div>
+          <h2 id="my-rooms-heading" className="text-lg font-semibold">
+            My rooms
+          </h2>
+          <p className="text-sm text-muted-foreground">
+            {rooms.length} active room{rooms.length === 1 ? "" : "s"}
+          </p>
+        </div>
+        <Button type="button" onClick={onCreate} data-testid="room-create-new">
+          <Plus className="mr-2 h-4 w-4" />
+          New room
+        </Button>
+      </div>
+
+      {rooms.length === 0 ? (
+        <Card>
+          <CardContent className="py-8 text-center text-sm text-muted-foreground">
+            No rooms yet. Create one from your synced ClassLink sections.
+          </CardContent>
+        </Card>
+      ) : (
+        rooms.map((room) => (
+          <Card key={room.id} data-testid={`room-card-${room.id}`}>
+            <CardHeader className="pb-3">
+              <div className="flex items-start justify-between gap-3">
+                <div>
+                  <CardTitle className="text-base">{room.name}</CardTitle>
+                  <p className="mt-1 text-xs text-muted-foreground">
+                    {room.classSourcedIds.length} section
+                    {room.classSourcedIds.length === 1 ? "" : "s"} ·{" "}
+                    {room.memberEmails.length} explicit student
+                    {room.memberEmails.length === 1 ? "" : "s"} ·{" "}
+                    {room.assistantIds.length} assistant
+                    {room.assistantIds.length === 1 ? "" : "s"}
+                  </p>
+                </div>
+                <div className="flex gap-1">
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon"
+                    aria-label={`Edit ${room.name}`}
+                    onClick={() => onEdit(room)}
+                  >
+                    <Pencil className="h-4 w-4" />
+                  </Button>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon"
+                    aria-label={`Delete ${room.name}`}
+                    disabled={deletingRoomId === room.id}
+                    onClick={() => onDelete(room.id)}
+                  >
+                    <Trash2 className="h-4 w-4" />
+                  </Button>
+                </div>
+              </div>
+            </CardHeader>
+            <CardContent className="space-y-2 text-sm">
+              {room.classSourcedIds.map((id) => (
+                <Badge key={id} variant="secondary">
+                  {sectionById.get(id)?.title ?? id}
+                </Badge>
+              ))}
+              {room.assistantIds.map((id) => (
+                <Badge key={id} variant="outline">
+                  {assistantById.get(id)?.name ?? `Assistant ${id}`}
+                </Badge>
+              ))}
+            </CardContent>
+          </Card>
+        ))
+      )}
+    </section>
+  );
+}

--- a/app/(protected)/rooms/manage/_components/rooms-list.tsx
+++ b/app/(protected)/rooms/manage/_components/rooms-list.tsx
@@ -12,6 +12,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 
 interface RoomsListProps {
   rooms: ManagedRoom[];
+  isAdministrator: boolean;
   sectionById: ReadonlyMap<string, TeacherSectionOption>;
   assistantById: ReadonlyMap<number, AccessibleAssistantOption>;
   deletingRoomId: string | null;
@@ -22,6 +23,7 @@ interface RoomsListProps {
 
 export function RoomsList({
   rooms,
+  isAdministrator,
   sectionById,
   assistantById,
   deletingRoomId,
@@ -34,7 +36,7 @@ export function RoomsList({
       <div className="flex items-center justify-between gap-3">
         <div>
           <h2 id="my-rooms-heading" className="text-lg font-semibold">
-            My rooms
+            {isAdministrator ? "All rooms" : "My rooms"}
           </h2>
           <p className="text-sm text-muted-foreground">
             {rooms.length} active room{rooms.length === 1 ? "" : "s"}

--- a/app/(protected)/rooms/manage/_components/rooms-manage-client.tsx
+++ b/app/(protected)/rooms/manage/_components/rooms-manage-client.tsx
@@ -142,6 +142,7 @@ export function RoomsManageClient({
     >
       <RoomsList
         rooms={initialData.rooms}
+        isAdministrator={initialData.isAdministrator}
         sectionById={sectionById}
         assistantById={assistantById}
         deletingRoomId={deletingRoomId}

--- a/app/(protected)/rooms/manage/_components/rooms-manage-client.tsx
+++ b/app/(protected)/rooms/manage/_components/rooms-manage-client.tsx
@@ -1,0 +1,171 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
+import {
+  createRoomAction,
+  deleteRoomAction,
+  searchRoomStudentsAction,
+  updateRoomAction,
+  type RoomsManageData,
+} from "@/actions/db/rooms-actions";
+import type { RoomMutationInput } from "@/lib/rooms/mutations";
+import type { ManagedRoom, RosterStudentOption } from "@/lib/rooms/queries";
+import { RoomEditor, type RoomEditorFeedback } from "./room-editor";
+import { RoomsList } from "./rooms-list";
+
+const emptyDraft = (): RoomMutationInput => ({
+  name: "",
+  classSourcedIds: [],
+  memberEmails: [],
+  assistantIds: [],
+});
+
+function roomToDraft(room: ManagedRoom): RoomMutationInput {
+  return {
+    name: room.name,
+    classSourcedIds: [...room.classSourcedIds],
+    memberEmails: [...room.memberEmails],
+    assistantIds: [...room.assistantIds],
+  };
+}
+
+export function RoomsManageClient({
+  initialData,
+}: {
+  initialData: RoomsManageData;
+}) {
+  const router = useRouter();
+  const [editingRoomId, setEditingRoomId] = useState<string | null>(null);
+  const [draft, setDraft] = useState<RoomMutationInput>(emptyDraft);
+  const [studentSearch, setStudentSearch] = useState("");
+  const [studentResults, setStudentResults] = useState<RosterStudentOption[]>([]);
+  const [feedback, setFeedback] = useState<RoomEditorFeedback | null>(null);
+  const [isSaving, setIsSaving] = useState(false);
+  const [isSearching, setIsSearching] = useState(false);
+  const [deletingRoomId, setDeletingRoomId] = useState<string | null>(null);
+  const sectionById = useMemo(
+    () =>
+      new Map(
+        initialData.sections.map((section) => [section.sourcedId, section])
+      ),
+    [initialData.sections]
+  );
+  const assistantById = useMemo(
+    () =>
+      new Map(
+        initialData.assistants.map((assistant) => [assistant.id, assistant])
+      ),
+    [initialData.assistants]
+  );
+
+  function resetEditor() {
+    setEditingRoomId(null);
+    setDraft(emptyDraft());
+    setStudentResults([]);
+    setStudentSearch("");
+    setFeedback(null);
+  }
+
+  function beginEdit(room: ManagedRoom) {
+    resetEditor();
+    setEditingRoomId(room.id);
+    setDraft(roomToDraft(room));
+  }
+
+  async function searchStudents() {
+    setIsSearching(true);
+    setFeedback(null);
+    const result = await searchRoomStudentsAction(studentSearch);
+    setIsSearching(false);
+    if (!result.isSuccess || !result.data) {
+      setStudentResults([]);
+      setFeedback({
+        kind: "error",
+        message: result.message ?? "Student search failed.",
+      });
+      return;
+    }
+    setStudentResults(result.data);
+  }
+
+  function addStudent(student: RosterStudentOption) {
+    if (!draft.memberEmails.includes(student.email)) {
+      setDraft((current) => ({
+        ...current,
+        memberEmails: [...current.memberEmails, student.email],
+      }));
+    }
+  }
+
+  async function saveRoom(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setIsSaving(true);
+    setFeedback(null);
+    const result = editingRoomId
+      ? await updateRoomAction(editingRoomId, draft)
+      : await createRoomAction(draft);
+    setIsSaving(false);
+    if (!result.isSuccess) {
+      setFeedback({
+        kind: "error",
+        message: result.message ?? "Room could not be saved.",
+      });
+      return;
+    }
+    resetEditor();
+    setFeedback({ kind: "success", message: result.message ?? "Room saved." });
+    router.refresh();
+  }
+
+  async function deleteRoom(roomId: string) {
+    setDeletingRoomId(roomId);
+    setFeedback(null);
+    const result = await deleteRoomAction(roomId);
+    setDeletingRoomId(null);
+    if (!result.isSuccess) {
+      setFeedback({
+        kind: "error",
+        message: result.message ?? "Room could not be deleted.",
+      });
+      return;
+    }
+    if (editingRoomId === roomId) resetEditor();
+    setFeedback({ kind: "success", message: result.message ?? "Room deleted." });
+    router.refresh();
+  }
+
+  return (
+    <div
+      className="grid gap-6 lg:grid-cols-[minmax(0,0.9fr)_minmax(0,1.1fr)]"
+      data-testid="rooms-manage"
+    >
+      <RoomsList
+        rooms={initialData.rooms}
+        sectionById={sectionById}
+        assistantById={assistantById}
+        deletingRoomId={deletingRoomId}
+        onCreate={resetEditor}
+        onEdit={beginEdit}
+        onDelete={deleteRoom}
+      />
+      <RoomEditor
+        editingRoomId={editingRoomId}
+        draft={draft}
+        sections={initialData.sections}
+        assistants={initialData.assistants}
+        studentSearch={studentSearch}
+        studentResults={studentResults}
+        feedback={feedback}
+        isSaving={isSaving}
+        isSearching={isSearching}
+        onDraftChange={setDraft}
+        onStudentSearchChange={setStudentSearch}
+        onStudentSearch={searchStudents}
+        onAddStudent={addStudent}
+        onCancel={resetEditor}
+        onSubmit={saveRoom}
+      />
+    </div>
+  );
+}

--- a/app/(protected)/rooms/manage/layout.tsx
+++ b/app/(protected)/rooms/manage/layout.tsx
@@ -1,0 +1,29 @@
+import { redirect } from "next/navigation";
+import { NavbarNested } from "@/components/navigation/navbar-nested";
+import { getServerSession } from "@/lib/auth/server-session";
+import { hasCapabilityAccess } from "@/utils/roles";
+
+export default async function RoomsManageLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const session = await getServerSession();
+  if (!session) {
+    redirect("/sign-in");
+  }
+  if (!(await hasCapabilityAccess("rooms-manage", session.sub))) {
+    redirect("/dashboard");
+  }
+
+  return (
+    <div className="flex min-h-screen">
+      <NavbarNested fullHeight />
+      <main className="min-w-0 flex-1 bg-white lg:pl-[68px]">
+        <div className="mx-auto max-w-7xl p-4 sm:p-6 md:p-8">
+          {children}
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/app/(protected)/rooms/manage/page.tsx
+++ b/app/(protected)/rooms/manage/page.tsx
@@ -1,0 +1,38 @@
+import { getRoomsManageDataAction } from "@/actions/db/rooms-actions";
+import { PageBranding } from "@/components/ui/page-branding";
+import { RoomsManageClient } from "./_components/rooms-manage-client";
+
+export const dynamic = "force-dynamic";
+
+export const metadata = {
+  title: "Manage Rooms | AI Studio",
+  description: "Compose roster sections and assistants into student rooms.",
+};
+
+export default async function RoomsManagePage() {
+  const result = await getRoomsManageDataAction();
+
+  return (
+    <div className="space-y-6" data-testid="rooms-manage-page">
+      <div>
+        <PageBranding />
+        <h1 className="text-2xl font-semibold text-foreground">Manage Rooms</h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Build rooms from your ClassLink sections, add individual students, and
+          assign assistants you can access.
+        </p>
+      </div>
+
+      {result.isSuccess && result.data ? (
+        <RoomsManageClient initialData={result.data} />
+      ) : (
+        <div
+          className="rounded-md border border-destructive/40 bg-destructive/5 p-4 text-sm text-destructive"
+          role="alert"
+        >
+          {result.message ?? "Failed to load room management."}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/docs/API/v1/generated/capability-catalog.json
+++ b/docs/API/v1/generated/capability-catalog.json
@@ -1,7 +1,7 @@
 {
   "summary": {
     "actions": 29,
-    "features": 9,
+    "features": 10,
     "scopes": 29,
     "agentInvocableActions": 22
   },
@@ -703,6 +703,16 @@
       "identifier": "model-compare",
       "name": "Model Compare",
       "description": "Compare AI model responses side-by-side.",
+      "defaultRoles": [
+        "administrator",
+        "staff"
+      ],
+      "humanDriven": true
+    },
+    {
+      "identifier": "rooms-manage",
+      "name": "Room Management",
+      "description": "Compose class rooms from roster sections and assign approved assistants.",
       "defaultRoles": [
         "administrator",
         "staff"

--- a/docs/features/oneroster-classlink-sync.md
+++ b/docs/features/oneroster-classlink-sync.md
@@ -5,8 +5,10 @@ Status: v1 ingestion foundation and administrator control surface implemented by
 [#1310](https://github.com/psd401/aistudio/issues/1310), and Issue
 [#1311](https://github.com/psd401/aistudio/issues/1311). Optional roster role
 reconciliation is implemented by Issue
-[#1312](https://github.com/psd401/aistudio/issues/1312). Room provisioning and
-reporting are separate workstreams.
+[#1312](https://github.com/psd401/aistudio/issues/1312). Teacher-managed room
+provisioning is implemented by Issue
+[#1313](https://github.com/psd401/aistudio/issues/1313). Student room access
+enforcement and reporting remain separate workstreams.
 
 ## Scope and data boundary
 
@@ -171,6 +173,49 @@ The pass runs only after all six roster collections are confirmed successful,
 including a successful unchanged-revision night. It does not run for manual
 syncs. Its own failure is logged and rolled back but does not fail or undo the
 good roster snapshot. Disable the flag to stop future role changes immediately.
+
+## Teacher-managed rooms
+
+Migration 157 adds application-owned `rooms`, `room_classes`, `room_members`,
+and `room_resources` tables. They do not change the ownership of sync data:
+
+- A room is owned by its creator and is soft-deleted with `is_active=false`.
+  Only that creator or an application administrator may update or delete it.
+- `room_classes.class_sourced_id` deliberately has no FK to the sync-owned
+  OneRoster tables. A ClassLink refresh or soft deletion cannot cascade into an
+  application-owned room.
+- Section membership is dynamic. `lib/rooms/membership.ts` resolves the union of
+  active students in linked active sections and explicit room-member emails.
+  It lowercases both sides of email comparisons.
+- Explicit students are stored by lowercased email, not by `users.id`, so a
+  teacher can compose a room before a student first signs in.
+- `room_resources` admits only `resource_type='assistant'` in v1. The resource
+  ID uses the same text representation as `resource_access_grants`.
+
+The teacher surface is `/rooms/manage`, gated at both the layout and server
+action layers by the `rooms-manage` human UI capability. The code-managed
+capability is initially granted to `staff` and `administrator`; it is not an
+API-key scope.
+
+The section picker is server-filtered to active teacher enrollments whose
+OneRoster user email matches the signed-in teacher with
+`lower(roster_email) = lower(application_email)`. A submitted class sourced ID
+that was not already on the room must be in that server-derived set. The
+individual-student search is limited to active students in the signed-in
+teacher's schools (administrators may search the full active roster), and every
+submitted explicit-member email is revalidated against that same server-side
+scope before it is stored. The
+assistant picker lists only approved assistants admitted by
+`filterAccessibleResourceIds`, and every create/update re-runs the same
+existence, approval, and access checks before writing. A crafted client cannot
+assign another teacher's section or an inaccessible assistant.
+
+Room mutations full-replace their class, explicit-member, and assistant link
+sets in one `executeTransaction` call. Ownership is rechecked while the room
+row is locked, and child rows cascade if a room is manually hard-deleted.
+Neither room management nor membership resolution writes users, roster rows,
+roles, capabilities, API scopes, resource grants, or administrator access.
+Student-facing assistant grant/restriction behavior remains owned by #1314.
 
 ## Administrator control surface
 
@@ -359,3 +404,9 @@ To remove only the administrator UI, remove its `ADMIN_SECTIONS` registry entry
 and route. The settings and last-known-good roster snapshot can remain. Older
 Lambda versions ignore `ONEROSTER_SYNC_STATUS`; removing that internal settings
 row is optional and must not be coupled to roster-row deletion.
+
+To roll back only teacher room management, revoke the `rooms-manage`
+capability or deploy the previous application version. The additive migration
+may remain. If the room data itself must be removed, migration 157 documents
+the child-first manual drop order; export or confirm that the room definitions
+are disposable before running those destructive statements.

--- a/infra/database/migrations.json
+++ b/infra/database/migrations.json
@@ -146,6 +146,7 @@
     "153-workspace-upload-reservations.sql",
     "154-workspace-upload-reservation-nullable-leases.sql",
     "155-unified-content-migration-retirement.sql",
-    "156-oneroster-user-role-source.sql"
+    "156-oneroster-user-role-source.sql",
+    "157-rooms.sql"
   ]
 }

--- a/infra/database/schema/157-rooms.sql
+++ b/infra/database/schema/157-rooms.sql
@@ -88,9 +88,77 @@ CREATE INDEX IF NOT EXISTS idx_room_resources_room_id
 CREATE INDEX IF NOT EXISTS idx_room_resources_resource
   ON room_resources (resource_type, resource_id);
 
+-- The manifest sync normally creates this capability at application boot. On a
+-- fresh database migrations run first, so create and grant it here only when it
+-- does not already exist. Existing districts keep their current role grants.
+WITH inserted_capability AS (
+  INSERT INTO capabilities (
+    identifier,
+    name,
+    description,
+    is_active,
+    source
+  )
+  SELECT
+    'rooms-manage',
+    'Room Management',
+    'Compose class rooms from roster sections and assign approved assistants.',
+    true,
+    'code'
+  WHERE NOT EXISTS (
+    SELECT 1 FROM capabilities WHERE identifier = 'rooms-manage'
+  )
+  RETURNING id
+)
+INSERT INTO role_capabilities (role_id, capability_id)
+SELECT roles.id, inserted_capability.id
+FROM inserted_capability
+JOIN roles ON roles.name IN ('administrator', 'staff')
+ON CONFLICT (role_id, capability_id) DO NOTHING;
+
+-- Keep room management discoverable under Instructional and gate the link with
+-- the same capability enforced by the route. Parent lookup avoids fixed IDs in
+-- deployed databases; a missing Instructional section safely yields a top-level
+-- link instead.
+INSERT INTO navigation_items (
+  label,
+  icon,
+  link,
+  parent_id,
+  capability_id,
+  requires_role,
+  position,
+  is_active,
+  type,
+  description
+)
+SELECT
+  'Rooms',
+  'IconUsersGroup',
+  '/rooms/manage',
+  (
+    SELECT id
+    FROM navigation_items
+    WHERE label = 'Instructional' AND type = 'section'
+    ORDER BY id
+    LIMIT 1
+  ),
+  capabilities.id,
+  NULL,
+  10,
+  true,
+  'link',
+  'Compose roster sections, individual students, and approved assistants'
+FROM capabilities
+WHERE capabilities.identifier = 'rooms-manage'
+  AND NOT EXISTS (
+    SELECT 1 FROM navigation_items WHERE link = '/rooms/manage'
+  );
+
 -- ============================================
 -- ROLLBACK SQL (for manual rollback if needed)
 -- ============================================
+-- DELETE FROM navigation_items WHERE link = '/rooms/manage';
 -- DROP TABLE IF EXISTS room_resources;
 -- DROP TABLE IF EXISTS room_members;
 -- DROP TABLE IF EXISTS room_classes;

--- a/infra/database/schema/157-rooms.sql
+++ b/infra/database/schema/157-rooms.sql
@@ -1,0 +1,97 @@
+-- Migration 157: Teacher-managed rooms (Epic #1308 / Issue #1313)
+--
+-- Rooms are application-owned containers that compose synced OneRoster class
+-- sections, explicit student email addresses, and assigned AI Studio resources.
+-- The OneRoster rows remain sync-owned and are referenced by sourced ID rather
+-- than foreign key so a roster refresh or soft deletion cannot destroy a room.
+--
+-- Child rows are full-replaced inside the room mutation transaction. As with
+-- group_members (migration 106), they therefore carry created_at only:
+-- updated_at would always equal created_at and would add meaningless triggers.
+--
+-- Additive and idempotent. No transaction control or dollar-quoted blocks are
+-- used because the migration runner owns the transaction and statement split.
+
+CREATE TABLE IF NOT EXISTS rooms (
+  id          uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  name        text NOT NULL CHECK (
+    char_length(btrim(name)) BETWEEN 1 AND 120
+  ),
+  created_by  integer REFERENCES users(id) ON DELETE SET NULL,
+  is_active   boolean NOT NULL DEFAULT true,
+  created_at  timestamptz NOT NULL DEFAULT now(),
+  updated_at  timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_rooms_created_by
+  ON rooms (created_by);
+
+CREATE INDEX IF NOT EXISTS idx_rooms_is_active
+  ON rooms (is_active);
+
+DROP TRIGGER IF EXISTS update_rooms_updated_at ON rooms;
+CREATE TRIGGER update_rooms_updated_at
+  BEFORE UPDATE ON rooms
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+CREATE TABLE IF NOT EXISTS room_classes (
+  id                uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  room_id           uuid NOT NULL REFERENCES rooms(id) ON DELETE CASCADE,
+  class_sourced_id  text NOT NULL CHECK (btrim(class_sourced_id) <> ''),
+  created_at        timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_room_class
+  ON room_classes (room_id, class_sourced_id);
+
+CREATE INDEX IF NOT EXISTS idx_room_classes_room_id
+  ON room_classes (room_id);
+
+CREATE INDEX IF NOT EXISTS idx_room_classes_class_sourced_id
+  ON room_classes (class_sourced_id);
+
+CREATE TABLE IF NOT EXISTS room_members (
+  id            uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  room_id       uuid NOT NULL REFERENCES rooms(id) ON DELETE CASCADE,
+  member_email  text NOT NULL CHECK (
+    member_email = lower(btrim(member_email))
+    AND member_email <> ''
+  ),
+  created_at    timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_room_member
+  ON room_members (room_id, lower(member_email));
+
+CREATE INDEX IF NOT EXISTS idx_room_members_room_id
+  ON room_members (room_id);
+
+CREATE INDEX IF NOT EXISTS idx_room_members_email
+  ON room_members (lower(member_email));
+
+CREATE TABLE IF NOT EXISTS room_resources (
+  id             uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  room_id        uuid NOT NULL REFERENCES rooms(id) ON DELETE CASCADE,
+  resource_type  text NOT NULL CHECK (resource_type = 'assistant'),
+  resource_id    text NOT NULL CHECK (
+    resource_id ~ '^[1-9][0-9]*$'
+  ),
+  created_at     timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_room_resource
+  ON room_resources (room_id, resource_type, resource_id);
+
+CREATE INDEX IF NOT EXISTS idx_room_resources_room_id
+  ON room_resources (room_id);
+
+CREATE INDEX IF NOT EXISTS idx_room_resources_resource
+  ON room_resources (resource_type, resource_id);
+
+-- ============================================
+-- ROLLBACK SQL (for manual rollback if needed)
+-- ============================================
+-- DROP TABLE IF EXISTS room_resources;
+-- DROP TABLE IF EXISTS room_members;
+-- DROP TABLE IF EXISTS room_classes;
+-- DROP TABLE IF EXISTS rooms;

--- a/lib/capabilities/manifest.ts
+++ b/lib/capabilities/manifest.ts
@@ -113,6 +113,13 @@ export const CAPABILITY_MANIFEST: readonly CapabilityManifestEntry[] = [
     defaultRoles: ["administrator", "staff"],
   },
   {
+    identifier: "rooms-manage",
+    name: "Room Management",
+    description:
+      "Compose class rooms from roster sections and assign approved assistants.",
+    defaultRoles: ["administrator", "staff"],
+  },
+  {
     identifier: "skill.redrover",
     name: "Agent skill: Red Rover",
     description:

--- a/lib/db/schema/index.ts
+++ b/lib/db/schema/index.ts
@@ -244,6 +244,14 @@ export * from "./tables/oneroster-user-roles";
 export * from "./tables/oneroster-enrollments";
 
 // ============================================
+// Teacher-managed Rooms (Epic #1308 / Issue #1313)
+// ============================================
+export * from "./tables/rooms";
+export * from "./tables/room-classes";
+export * from "./tables/room-members";
+export * from "./tables/room-resources";
+
+// ============================================
 // Relations
 // ============================================
 export * from "./relations";

--- a/lib/db/schema/tables/room-classes.ts
+++ b/lib/db/schema/tables/room-classes.ts
@@ -1,0 +1,38 @@
+/**
+ * OneRoster class sections linked to teacher-managed rooms.
+ *
+ * The sourced ID intentionally has no foreign key to the sync-owned roster
+ * tables. A roster refresh must never cascade into application-owned rooms.
+ */
+
+import {
+  index,
+  pgTable,
+  text,
+  timestamp,
+  uniqueIndex,
+  uuid,
+} from "drizzle-orm/pg-core";
+import { rooms } from "./rooms";
+
+export const roomClasses = pgTable(
+  "room_classes",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    roomId: uuid("room_id")
+      .references(() => rooms.id, { onDelete: "cascade" })
+      .notNull(),
+    classSourcedId: text("class_sourced_id").notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+  },
+  (table) => [
+    uniqueIndex("uq_room_class").on(table.roomId, table.classSourcedId),
+    index("idx_room_classes_room_id").on(table.roomId),
+    index("idx_room_classes_class_sourced_id").on(table.classSourcedId),
+  ]
+);
+
+export type RoomClassRow = typeof roomClasses.$inferSelect;
+export type NewRoomClassRow = typeof roomClasses.$inferInsert;

--- a/lib/db/schema/tables/room-members.ts
+++ b/lib/db/schema/tables/room-members.ts
@@ -1,0 +1,42 @@
+/**
+ * Explicit room members keyed by lowercased email.
+ *
+ * Email, rather than a users FK, preserves membership for students who have not
+ * signed in. Every authorization comparison still lowercases both sides.
+ */
+
+import { sql } from "drizzle-orm";
+import {
+  index,
+  pgTable,
+  text,
+  timestamp,
+  uniqueIndex,
+  uuid,
+} from "drizzle-orm/pg-core";
+import { rooms } from "./rooms";
+
+export const roomMembers = pgTable(
+  "room_members",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    roomId: uuid("room_id")
+      .references(() => rooms.id, { onDelete: "cascade" })
+      .notNull(),
+    memberEmail: text("member_email").notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+  },
+  (table) => [
+    uniqueIndex("uq_room_member").on(
+      table.roomId,
+      sql`lower(${table.memberEmail})`
+    ),
+    index("idx_room_members_room_id").on(table.roomId),
+    index("idx_room_members_email").on(sql`lower(${table.memberEmail})`),
+  ]
+);
+
+export type RoomMemberRow = typeof roomMembers.$inferSelect;
+export type NewRoomMemberRow = typeof roomMembers.$inferInsert;

--- a/lib/db/schema/tables/room-resources.ts
+++ b/lib/db/schema/tables/room-resources.ts
@@ -1,0 +1,52 @@
+/**
+ * AI Studio resources assigned to a room.
+ *
+ * Only Assistant Architect assistants are admitted in v1. The text resource ID
+ * mirrors resource_access_grants and leaves the column extensible for a later
+ * explicitly reviewed resource type.
+ */
+
+import {
+  index,
+  pgTable,
+  text,
+  timestamp,
+  uniqueIndex,
+  uuid,
+} from "drizzle-orm/pg-core";
+import { rooms } from "./rooms";
+
+export const ROOM_RESOURCE_TYPES = ["assistant"] as const;
+export type RoomResourceType = (typeof ROOM_RESOURCE_TYPES)[number];
+
+export const roomResources = pgTable(
+  "room_resources",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    roomId: uuid("room_id")
+      .references(() => rooms.id, { onDelete: "cascade" })
+      .notNull(),
+    resourceType: text("resource_type")
+      .$type<RoomResourceType>()
+      .notNull(),
+    resourceId: text("resource_id").notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+  },
+  (table) => [
+    uniqueIndex("uq_room_resource").on(
+      table.roomId,
+      table.resourceType,
+      table.resourceId
+    ),
+    index("idx_room_resources_room_id").on(table.roomId),
+    index("idx_room_resources_resource").on(
+      table.resourceType,
+      table.resourceId
+    ),
+  ]
+);
+
+export type RoomResourceRow = typeof roomResources.$inferSelect;
+export type NewRoomResourceRow = typeof roomResources.$inferInsert;

--- a/lib/db/schema/tables/rooms.ts
+++ b/lib/db/schema/tables/rooms.ts
@@ -1,0 +1,41 @@
+/**
+ * Teacher-managed rooms composed from OneRoster sections and explicit students.
+ *
+ * See migration 157-rooms.sql (Epic #1308 / Issue #1313).
+ */
+
+import {
+  boolean,
+  index,
+  integer,
+  pgTable,
+  text,
+  timestamp,
+  uuid,
+} from "drizzle-orm/pg-core";
+import { users } from "./users";
+
+export const rooms = pgTable(
+  "rooms",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    name: text("name").notNull(),
+    createdBy: integer("created_by").references(() => users.id, {
+      onDelete: "set null",
+    }),
+    isActive: boolean("is_active").default(true).notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+  },
+  (table) => [
+    index("idx_rooms_created_by").on(table.createdBy),
+    index("idx_rooms_is_active").on(table.isActive),
+  ]
+);
+
+export type RoomRow = typeof rooms.$inferSelect;
+export type NewRoomRow = typeof rooms.$inferInsert;

--- a/lib/rooms/membership.ts
+++ b/lib/rooms/membership.ts
@@ -1,0 +1,156 @@
+/**
+ * Canonical room-membership resolution (Epic #1308 / Issue #1313).
+ *
+ * Membership is the union of:
+ *  - active student enrollments in active OneRoster sections linked to a room
+ *  - explicit lowercased email rows in room_members
+ *
+ * Email remains a cross-system join key, so every comparison lowercases both
+ * sides even though normal writes already store lowercase values.
+ */
+
+import { and, eq, sql } from "drizzle-orm";
+import { executeQuery, toPgRows } from "@/lib/db/drizzle-client";
+import {
+  onerosterClasses,
+  onerosterEnrollments,
+  onerosterUsers,
+  roomClasses,
+  roomMembers,
+  rooms,
+} from "@/lib/db/schema";
+import { normalizeEmail } from "@/lib/groups/normalize";
+
+export function mergeRoomMembershipEmails(
+  sectionEmails: Array<string | null>,
+  explicitEmails: Array<string | null>
+): string[] {
+  const unique = new Set<string>();
+  for (const value of [...sectionEmails, ...explicitEmails]) {
+    const email = normalizeEmail(value);
+    if (email) unique.add(email);
+  }
+  return [...unique].sort((a, b) => a.localeCompare(b));
+}
+
+/**
+ * Return the room's current membership snapshot as normalized email addresses.
+ * The section half follows roster changes dynamically; no student rows are
+ * copied into application-owned tables.
+ */
+export async function resolveRoomMembershipEmails(
+  roomId: string
+): Promise<string[]> {
+  const [sectionRows, explicitRows] = await Promise.all([
+    executeQuery(
+      (db) =>
+        db
+          .select({ email: onerosterUsers.email })
+          .from(roomClasses)
+          .innerJoin(
+            rooms,
+            and(eq(rooms.id, roomClasses.roomId), eq(rooms.isActive, true))
+          )
+          .innerJoin(
+            onerosterClasses,
+            and(
+              eq(
+                onerosterClasses.sourcedId,
+                roomClasses.classSourcedId
+              ),
+              eq(onerosterClasses.isActive, true)
+            )
+          )
+          .innerJoin(
+            onerosterEnrollments,
+            and(
+              eq(
+                onerosterEnrollments.classSourcedId,
+                roomClasses.classSourcedId
+              ),
+              eq(onerosterEnrollments.isActive, true),
+              sql`lower(coalesce(${onerosterEnrollments.role}, '')) = 'student'`
+            )
+          )
+          .innerJoin(
+            onerosterUsers,
+            and(
+              eq(
+                onerosterUsers.sourcedId,
+                onerosterEnrollments.userSourcedId
+              ),
+              eq(onerosterUsers.isActive, true)
+            )
+          )
+          .where(eq(roomClasses.roomId, roomId)),
+      "resolveRoomMembershipEmails.sections"
+    ),
+    executeQuery(
+      (db) =>
+        db
+          .select({ email: roomMembers.memberEmail })
+          .from(roomMembers)
+          .innerJoin(
+            rooms,
+            and(eq(rooms.id, roomMembers.roomId), eq(rooms.isActive, true))
+          )
+          .where(eq(roomMembers.roomId, roomId)),
+      "resolveRoomMembershipEmails.explicit"
+    ),
+  ]);
+
+  return mergeRoomMembershipEmails(
+    sectionRows.map((row) => row.email),
+    explicitRows.map((row) => row.email)
+  );
+}
+
+/**
+ * Efficient authorization-shaped point check used by the student experience in
+ * the next workstream. Kept here so section and explicit-member semantics have
+ * one implementation.
+ */
+export async function isRoomMember(
+  roomId: string,
+  memberEmail: string
+): Promise<boolean> {
+  const email = normalizeEmail(memberEmail);
+  if (!email) return false;
+
+  const result = await executeQuery(
+    (db) =>
+      db.execute(sql`
+        SELECT (
+          EXISTS (
+            SELECT 1
+              FROM rooms r
+              JOIN room_members rm ON rm.room_id = r.id
+             WHERE r.id = ${roomId}
+               AND r.is_active = true
+               AND lower(rm.member_email) = lower(${email})
+          )
+          OR EXISTS (
+            SELECT 1
+              FROM rooms r
+              JOIN room_classes rc ON rc.room_id = r.id
+              JOIN oneroster_classes c
+                ON c.sourced_id = rc.class_sourced_id
+               AND c.is_active = true
+              JOIN oneroster_enrollments e
+                ON e.class_sourced_id = rc.class_sourced_id
+               AND e.is_active = true
+               AND lower(coalesce(e.role, '')) = 'student'
+              JOIN oneroster_users u
+                ON u.sourced_id = e.user_sourced_id
+               AND u.is_active = true
+             WHERE r.id = ${roomId}
+               AND r.is_active = true
+               AND lower(u.email) = lower(${email})
+          )
+        ) AS is_member
+      `),
+    "isRoomMember"
+  );
+  const [row] = toPgRows<{ is_member: boolean }>(result);
+  return row?.is_member === true;
+}

--- a/lib/rooms/mutations.ts
+++ b/lib/rooms/mutations.ts
@@ -1,0 +1,163 @@
+/**
+ * Transactional room mutations. Authorization snapshots are rechecked while
+ * the room row is locked so a non-owner cannot win a check/write race.
+ */
+
+import { and, eq } from "drizzle-orm";
+import {
+  executeTransaction,
+  type DbTransaction,
+} from "@/lib/db/drizzle-client";
+import {
+  roomClasses,
+  roomMembers,
+  roomResources,
+  rooms,
+} from "@/lib/db/schema";
+import { ErrorFactories } from "@/lib/error-utils";
+import { normalizeEmail } from "@/lib/groups/normalize";
+import { canManageRoom } from "./validation";
+
+export interface RoomMutationInput {
+  name: string;
+  classSourcedIds: string[];
+  memberEmails: string[];
+  assistantIds: number[];
+}
+
+export interface RoomMutationActor {
+  userId: number;
+  isAdministrator: boolean;
+}
+
+async function replaceRoomChildren(
+  tx: DbTransaction,
+  roomId: string,
+  input: RoomMutationInput
+): Promise<void> {
+  await tx.delete(roomClasses).where(eq(roomClasses.roomId, roomId));
+  if (input.classSourcedIds.length > 0) {
+    await tx.insert(roomClasses).values(
+      input.classSourcedIds.map((classSourcedId) => ({
+        roomId,
+        classSourcedId,
+      }))
+    );
+  }
+
+  await tx.delete(roomMembers).where(eq(roomMembers.roomId, roomId));
+  if (input.memberEmails.length > 0) {
+    await tx.insert(roomMembers).values(
+      input.memberEmails.map((memberEmail) => ({
+        roomId,
+        memberEmail: normalizeEmail(memberEmail),
+      }))
+    );
+  }
+
+  await tx.delete(roomResources).where(eq(roomResources.roomId, roomId));
+  if (input.assistantIds.length > 0) {
+    await tx.insert(roomResources).values(
+      input.assistantIds.map((assistantId) => ({
+        roomId,
+        resourceType: "assistant" as const,
+        resourceId: String(assistantId),
+      }))
+    );
+  }
+}
+
+export async function createManagedRoom(
+  actor: RoomMutationActor,
+  input: RoomMutationInput
+): Promise<string> {
+  return executeTransaction(
+    async (tx) => {
+      const [created] = await tx
+        .insert(rooms)
+        .values({
+          name: input.name.trim(),
+          createdBy: actor.userId,
+        })
+        .returning({ id: rooms.id });
+      if (!created) {
+        throw ErrorFactories.dbQueryFailed("create room");
+      }
+      await replaceRoomChildren(tx, created.id, input);
+      return created.id;
+    },
+    "createManagedRoom"
+  );
+}
+
+export async function updateManagedRoom(
+  roomId: string,
+  actor: RoomMutationActor,
+  input: RoomMutationInput
+): Promise<void> {
+  await executeTransaction(
+    async (tx) => {
+      const [existing] = await tx
+        .select({
+          id: rooms.id,
+          createdBy: rooms.createdBy,
+        })
+        .from(rooms)
+        .where(and(eq(rooms.id, roomId), eq(rooms.isActive, true)))
+        .for("update");
+      if (!existing) {
+        throw ErrorFactories.authzResourceNotFound("room", roomId);
+      }
+      if (
+        !canManageRoom(
+          actor.userId,
+          existing.createdBy,
+          actor.isAdministrator
+        )
+      ) {
+        throw ErrorFactories.authzResourceNotFound("room", roomId);
+      }
+      await tx
+        .update(rooms)
+        .set({ name: input.name.trim() })
+        .where(eq(rooms.id, roomId));
+      await replaceRoomChildren(tx, roomId, input);
+    },
+    "updateManagedRoom"
+  );
+}
+
+export async function deactivateManagedRoom(
+  roomId: string,
+  actor: RoomMutationActor
+): Promise<void> {
+  await executeTransaction(
+    async (tx) => {
+      const [existing] = await tx
+        .select({
+          id: rooms.id,
+          createdBy: rooms.createdBy,
+        })
+        .from(rooms)
+        .where(and(eq(rooms.id, roomId), eq(rooms.isActive, true)))
+        .for("update");
+      if (!existing) {
+        throw ErrorFactories.authzResourceNotFound("room", roomId);
+      }
+      if (
+        !canManageRoom(
+          actor.userId,
+          existing.createdBy,
+          actor.isAdministrator
+        )
+      ) {
+        throw ErrorFactories.authzResourceNotFound("room", roomId);
+      }
+      await tx
+        .update(rooms)
+        .set({ isActive: false })
+        .where(eq(rooms.id, roomId));
+    },
+    "deactivateManagedRoom"
+  );
+}

--- a/lib/rooms/queries.ts
+++ b/lib/rooms/queries.ts
@@ -279,7 +279,8 @@ export async function accessibleApprovedAssistantIds(
 }
 
 export async function listRoomsForManagement(
-  userId: number
+  userId: number,
+  isAdministrator: boolean
 ): Promise<ManagedRoom[]> {
   const roomRows = await executeQuery(
     (db) =>
@@ -292,7 +293,11 @@ export async function listRoomsForManagement(
           updatedAt: rooms.updatedAt,
         })
         .from(rooms)
-        .where(and(eq(rooms.createdBy, userId), eq(rooms.isActive, true)))
+        .where(
+          isAdministrator
+            ? eq(rooms.isActive, true)
+            : and(eq(rooms.createdBy, userId), eq(rooms.isActive, true))
+        )
         .orderBy(desc(rooms.updatedAt)),
     "listRoomsForManagement.rooms"
   );

--- a/lib/rooms/queries.ts
+++ b/lib/rooms/queries.ts
@@ -110,6 +110,25 @@ export async function listTeacherSections(
   return toPgRows<TeacherSectionOption>(result);
 }
 
+/**
+ * Escape LIKE metacharacters (`\`, `%`, `_`) in user-supplied search text so a
+ * query like "first_last" matches literally instead of treating `_` as a
+ * single-character wildcard. Postgres's default LIKE escape character is already
+ * backslash, so this needs NO explicit `ESCAPE` clause — matching the precedent
+ * in lib/content/visibility-service.ts.
+ *
+ * Do NOT add an explicit escape clause here with a single-backslash string.
+ * Inside a template literal the backslash is consumed escaping the closing
+ * quote, so what reaches Postgres is an escape clause with an EMPTY string,
+ * which per the Postgres docs selects no escape character at all. The
+ * backslashes inserted below then become literal characters the pattern has to
+ * match, and a search for `first_last` silently returns no rows. Verified
+ * against PostgreSQL 16. If an explicit clause is ever needed, the string must
+ * contain a doubled backslash in source.
+ *
+ * The pattern is a bound parameter regardless — this is pattern semantics, not
+ * injection protection.
+ */
 function escapeLikePattern(value: string): string {
   return value.replace(/[\\%_]/g, "\\$&");
 }
@@ -160,10 +179,10 @@ export async function searchActiveRosterStudents(
                )
           )
           AND (
-            lower(u.email) LIKE ${pattern} ESCAPE '\'
+            lower(u.email) LIKE ${pattern}
             OR lower(
               trim(concat_ws(' ', u.given_name, u.family_name))
-            ) LIKE ${pattern} ESCAPE '\'
+            ) LIKE ${pattern}
           )
         ORDER BY email
         LIMIT ${boundedLimit}

--- a/lib/rooms/queries.ts
+++ b/lib/rooms/queries.ts
@@ -14,6 +14,7 @@ import {
   roomMembers,
   roomResources,
   rooms,
+  users,
 } from "@/lib/db/schema";
 import { filterAccessibleResourceIds } from "@/lib/db/drizzle/resource-access";
 import { normalizeEmail } from "@/lib/groups/normalize";
@@ -42,12 +43,25 @@ export interface ManagedRoom {
   id: string;
   name: string;
   createdBy: number | null;
+  /**
+   * Owner email, or null for an orphaned room (creator deleted — `rooms.created_by`
+   * is ON DELETE SET NULL). Only meaningful to administrators, the only actors
+   * served rooms they did not create.
+   */
+  createdByEmail: string | null;
   createdAt: Date;
   updatedAt: Date;
   classSourcedIds: string[];
   memberEmails: string[];
   assistantIds: number[];
 }
+
+/**
+ * Upper bound on rows returned by `listRoomsForManagement`. Only reachable by
+ * administrators, whose list spans every owner in the district; a teacher's own
+ * rooms are far below it.
+ */
+export const MANAGED_ROOM_LIST_LIMIT = 500;
 
 export interface RoomAuthorizationSnapshot {
   createdBy: number | null;
@@ -278,6 +292,19 @@ export async function accessibleApprovedAssistantIds(
   );
 }
 
+/**
+ * Rooms the actor may manage: their own, or — for an administrator — every
+ * active room, so the administrator override in `canManageRoom` is reachable
+ * from the UI instead of only by knowing a room's UUID.
+ *
+ * The administrator result set is district-wide, so it is capped at
+ * `MANAGED_ROOM_LIST_LIMIT` (most recently updated first). The cap is load-
+ * bearing, not cosmetic: every returned id is spread into three `IN (...)`
+ * child-row queries below, so an uncapped list would grow the bind-parameter
+ * count and the payload serialized into the client component linearly with the
+ * number of rooms in the district. A searchable/paged administrator view is
+ * follow-up work.
+ */
 export async function listRoomsForManagement(
   userId: number,
   isAdministrator: boolean
@@ -289,16 +316,19 @@ export async function listRoomsForManagement(
           id: rooms.id,
           name: rooms.name,
           createdBy: rooms.createdBy,
+          createdByEmail: users.email,
           createdAt: rooms.createdAt,
           updatedAt: rooms.updatedAt,
         })
         .from(rooms)
+        .leftJoin(users, eq(users.id, rooms.createdBy))
         .where(
           isAdministrator
             ? eq(rooms.isActive, true)
             : and(eq(rooms.createdBy, userId), eq(rooms.isActive, true))
         )
-        .orderBy(desc(rooms.updatedAt)),
+        .orderBy(desc(rooms.updatedAt))
+        .limit(MANAGED_ROOM_LIST_LIMIT),
     "listRoomsForManagement.rooms"
   );
   if (roomRows.length === 0) return [];
@@ -347,6 +377,8 @@ export async function listRoomsForManagement(
 
   return roomRows.map((room) => ({
     ...room,
+    // Left join: null whenever the creator row is gone (created_by SET NULL).
+    createdByEmail: room.createdByEmail ?? null,
     classSourcedIds: classRows
       .filter((row) => row.roomId === room.id)
       .map((row) => row.classSourcedId),

--- a/lib/rooms/queries.ts
+++ b/lib/rooms/queries.ts
@@ -1,0 +1,418 @@
+/**
+ * Read accessors for teacher room management.
+ *
+ * Roster tables are read-only. Every teacher-section query lowercases both
+ * sides of the email join and every result is bounded to the room-management
+ * surface's needs.
+ */
+
+import { and, desc, eq, inArray, sql } from "drizzle-orm";
+import { executeQuery, toPgRows } from "@/lib/db/drizzle-client";
+import {
+  assistantArchitects,
+  roomClasses,
+  roomMembers,
+  roomResources,
+  rooms,
+} from "@/lib/db/schema";
+import { filterAccessibleResourceIds } from "@/lib/db/drizzle/resource-access";
+import { normalizeEmail } from "@/lib/groups/normalize";
+
+export interface TeacherSectionOption {
+  sourcedId: string;
+  title: string | null;
+  classCode: string | null;
+  schoolName: string | null;
+  studentCount: number;
+}
+
+export interface RosterStudentOption {
+  email: string;
+  givenName: string | null;
+  familyName: string | null;
+}
+
+export interface AccessibleAssistantOption {
+  id: number;
+  name: string;
+  description: string | null;
+}
+
+export interface ManagedRoom {
+  id: string;
+  name: string;
+  createdBy: number | null;
+  createdAt: Date;
+  updatedAt: Date;
+  classSourcedIds: string[];
+  memberEmails: string[];
+  assistantIds: number[];
+}
+
+export interface RoomAuthorizationSnapshot {
+  createdBy: number | null;
+  classSourcedIds: string[];
+}
+
+export async function listTeacherSections(
+  teacherEmail: string
+): Promise<TeacherSectionOption[]> {
+  const email = normalizeEmail(teacherEmail);
+  if (!email) return [];
+
+  const result = await executeQuery(
+    (db) =>
+      db.execute(sql`
+        SELECT DISTINCT
+          c.sourced_id AS "sourcedId",
+          c.title,
+          c.class_code AS "classCode",
+          school.name AS "schoolName",
+          (
+            SELECT count(DISTINCT student_e.user_sourced_id)::int
+              FROM oneroster_enrollments student_e
+             WHERE student_e.class_sourced_id = c.sourced_id
+               AND student_e.is_active = true
+               AND lower(coalesce(student_e.role, '')) = 'student'
+          ) AS "studentCount"
+        FROM oneroster_classes c
+        JOIN oneroster_enrollments teacher_e
+          ON teacher_e.class_sourced_id = c.sourced_id
+         AND teacher_e.is_active = true
+         AND lower(coalesce(teacher_e.role, '')) = 'teacher'
+        JOIN oneroster_users teacher_u
+          ON teacher_u.sourced_id = teacher_e.user_sourced_id
+         AND teacher_u.is_active = true
+        LEFT JOIN oneroster_orgs school
+          ON school.sourced_id = c.school_sourced_id
+         AND school.is_active = true
+        WHERE c.is_active = true
+          AND lower(teacher_u.email) = lower(${email})
+        ORDER BY c.title NULLS LAST, c.sourced_id
+      `),
+    "listTeacherSections"
+  );
+
+  return toPgRows<TeacherSectionOption>(result);
+}
+
+function escapeLikePattern(value: string): string {
+  return value.replace(/[\\%_]/g, "\\$&");
+}
+
+export async function searchActiveRosterStudents(
+  search: string,
+  teacherEmail: string,
+  isAdministrator: boolean,
+  limit = 25
+): Promise<RosterStudentOption[]> {
+  const normalized = search.trim().toLowerCase();
+  const normalizedTeacherEmail = normalizeEmail(teacherEmail);
+  if (normalized.length < 2) return [];
+  if (!isAdministrator && !normalizedTeacherEmail) return [];
+  const boundedLimit = Math.max(1, Math.min(limit, 25));
+  const pattern = `%${escapeLikePattern(normalized)}%`;
+
+  const result = await executeQuery(
+    (db) =>
+      db.execute(sql`
+        SELECT DISTINCT
+          lower(u.email) AS email,
+          u.given_name AS "givenName",
+          u.family_name AS "familyName"
+        FROM oneroster_users u
+        WHERE u.is_active = true
+          AND u.email IS NOT NULL
+          AND EXISTS (
+            SELECT 1
+              FROM oneroster_enrollments e
+             WHERE e.user_sourced_id = u.sourced_id
+               AND e.is_active = true
+               AND lower(coalesce(e.role, '')) = 'student'
+               AND (
+                 ${isAdministrator}
+                 OR EXISTS (
+                   SELECT 1
+                     FROM oneroster_enrollments teacher_e
+                     JOIN oneroster_users teacher_u
+                       ON teacher_u.sourced_id = teacher_e.user_sourced_id
+                      AND teacher_u.is_active = true
+                    WHERE teacher_e.is_active = true
+                      AND lower(coalesce(teacher_e.role, '')) = 'teacher'
+                      AND lower(teacher_u.email) = lower(${normalizedTeacherEmail})
+                      AND teacher_e.school_sourced_id IS NOT NULL
+                      AND teacher_e.school_sourced_id = e.school_sourced_id
+                 )
+               )
+          )
+          AND (
+            lower(u.email) LIKE ${pattern} ESCAPE '\'
+            OR lower(
+              trim(concat_ws(' ', u.given_name, u.family_name))
+            ) LIKE ${pattern} ESCAPE '\'
+          )
+        ORDER BY email
+        LIMIT ${boundedLimit}
+      `),
+    "searchActiveRosterStudents"
+  );
+
+  return toPgRows<RosterStudentOption>(result);
+}
+
+/**
+ * Resolve requested explicit members through the same server-owned roster
+ * boundary as the student picker. Administrators may select any active roster
+ * student; staff are limited to students enrolled in a school where they have
+ * an active teacher enrollment.
+ */
+export async function accessibleActiveRosterStudentEmails(
+  teacherEmail: string,
+  isAdministrator: boolean,
+  requestedEmails: string[]
+): Promise<Set<string>> {
+  const emails = [
+    ...new Set(requestedEmails.map(normalizeEmail).filter(Boolean)),
+  ];
+  if (emails.length === 0) return new Set<string>();
+  const normalizedTeacherEmail = normalizeEmail(teacherEmail);
+  if (!isAdministrator && !normalizedTeacherEmail) return new Set<string>();
+
+  const result = await executeQuery(
+    (db) =>
+      db.execute(sql`
+        SELECT DISTINCT lower(u.email) AS email
+          FROM oneroster_users u
+         WHERE u.is_active = true
+           AND u.email IS NOT NULL
+           AND lower(u.email) IN (
+             ${sql.join(
+               emails.map((email) => sql`${email}`),
+               sql`, `
+             )}
+           )
+           AND EXISTS (
+             SELECT 1
+               FROM oneroster_enrollments e
+              WHERE e.user_sourced_id = u.sourced_id
+                AND e.is_active = true
+                AND lower(coalesce(e.role, '')) = 'student'
+                AND (
+                  ${isAdministrator}
+                  OR EXISTS (
+                    SELECT 1
+                      FROM oneroster_enrollments teacher_e
+                      JOIN oneroster_users teacher_u
+                        ON teacher_u.sourced_id = teacher_e.user_sourced_id
+                       AND teacher_u.is_active = true
+                     WHERE teacher_e.is_active = true
+                       AND lower(coalesce(teacher_e.role, '')) = 'teacher'
+                       AND lower(teacher_u.email) = lower(${normalizedTeacherEmail})
+                       AND teacher_e.school_sourced_id IS NOT NULL
+                       AND teacher_e.school_sourced_id = e.school_sourced_id
+                  )
+                )
+           )
+      `),
+    "accessibleActiveRosterStudentEmails"
+  );
+
+  return new Set(
+    toPgRows<{ email: string }>(result).map((row) =>
+      normalizeEmail(row.email)
+    )
+  );
+}
+
+export async function listAccessibleApprovedAssistants(
+  userId: number
+): Promise<AccessibleAssistantOption[]> {
+  const candidates = await executeQuery(
+    (db) =>
+      db
+        .select({
+          id: assistantArchitects.id,
+          name: assistantArchitects.name,
+          description: assistantArchitects.description,
+        })
+        .from(assistantArchitects)
+        .where(eq(assistantArchitects.status, "approved"))
+        .orderBy(assistantArchitects.name),
+    "listAccessibleApprovedAssistants.candidates"
+  );
+  const accessible = await filterAccessibleResourceIds(
+    userId,
+    "assistant",
+    candidates.map((candidate) => candidate.id)
+  );
+  return candidates.filter((candidate) => accessible.has(String(candidate.id)));
+}
+
+export async function accessibleApprovedAssistantIds(
+  userId: number,
+  requestedIds: number[]
+): Promise<Set<number>> {
+  if (requestedIds.length === 0) return new Set<number>();
+  const approved = await executeQuery(
+    (db) =>
+      db
+        .select({ id: assistantArchitects.id })
+        .from(assistantArchitects)
+        .where(
+          and(
+            eq(assistantArchitects.status, "approved"),
+            inArray(assistantArchitects.id, requestedIds)
+          )
+        ),
+    "accessibleApprovedAssistantIds.approved"
+  );
+  const accessible = await filterAccessibleResourceIds(
+    userId,
+    "assistant",
+    approved.map((candidate) => candidate.id)
+  );
+  return new Set(
+    approved
+      .map((candidate) => candidate.id)
+      .filter((id) => accessible.has(String(id)))
+  );
+}
+
+export async function listRoomsForManagement(
+  userId: number
+): Promise<ManagedRoom[]> {
+  const roomRows = await executeQuery(
+    (db) =>
+      db
+        .select({
+          id: rooms.id,
+          name: rooms.name,
+          createdBy: rooms.createdBy,
+          createdAt: rooms.createdAt,
+          updatedAt: rooms.updatedAt,
+        })
+        .from(rooms)
+        .where(and(eq(rooms.createdBy, userId), eq(rooms.isActive, true)))
+        .orderBy(desc(rooms.updatedAt)),
+    "listRoomsForManagement.rooms"
+  );
+  if (roomRows.length === 0) return [];
+
+  const roomIds = roomRows.map((room) => room.id);
+  const [classRows, memberRows, resourceRows] = await Promise.all([
+    executeQuery(
+      (db) =>
+        db
+          .select({
+            roomId: roomClasses.roomId,
+            classSourcedId: roomClasses.classSourcedId,
+          })
+          .from(roomClasses)
+          .where(inArray(roomClasses.roomId, roomIds)),
+      "listRoomsForManagement.classes"
+    ),
+    executeQuery(
+      (db) =>
+        db
+          .select({
+            roomId: roomMembers.roomId,
+            memberEmail: roomMembers.memberEmail,
+          })
+          .from(roomMembers)
+          .where(inArray(roomMembers.roomId, roomIds)),
+      "listRoomsForManagement.members"
+    ),
+    executeQuery(
+      (db) =>
+        db
+          .select({
+            roomId: roomResources.roomId,
+            resourceId: roomResources.resourceId,
+          })
+          .from(roomResources)
+          .where(
+            and(
+              inArray(roomResources.roomId, roomIds),
+              eq(roomResources.resourceType, "assistant")
+            )
+          ),
+      "listRoomsForManagement.resources"
+    ),
+  ]);
+
+  return roomRows.map((room) => ({
+    ...room,
+    classSourcedIds: classRows
+      .filter((row) => row.roomId === room.id)
+      .map((row) => row.classSourcedId),
+    memberEmails: memberRows
+      .filter((row) => row.roomId === room.id)
+      .map((row) => normalizeEmail(row.memberEmail))
+      .sort((a, b) => a.localeCompare(b)),
+    assistantIds: resourceRows
+      .filter((row) => row.roomId === room.id)
+      .map((row) => Number(row.resourceId))
+      .filter((id) => Number.isSafeInteger(id) && id > 0),
+  }));
+}
+
+export async function getRoomAuthorizationSnapshot(
+  roomId: string
+): Promise<RoomAuthorizationSnapshot | null> {
+  const [roomRow, classRows] = await Promise.all([
+    executeQuery(
+      (db) =>
+        db
+          .select({ createdBy: rooms.createdBy })
+          .from(rooms)
+          .where(and(eq(rooms.id, roomId), eq(rooms.isActive, true)))
+          .limit(1),
+      "getRoomAuthorizationSnapshot.room"
+    ),
+    executeQuery(
+      (db) =>
+        db
+          .select({ classSourcedId: roomClasses.classSourcedId })
+          .from(roomClasses)
+          .where(eq(roomClasses.roomId, roomId)),
+      "getRoomAuthorizationSnapshot.classes"
+    ),
+  ]);
+  if (!roomRow[0]) return null;
+  return {
+    createdBy: roomRow[0].createdBy,
+    classSourcedIds: classRows.map((row) => row.classSourcedId),
+  };
+}
+
+export async function getRoomActor(
+  userId: number
+): Promise<{ email: string; isAdministrator: boolean } | null> {
+  const result = await executeQuery(
+    (db) =>
+      db.execute(sql`
+        SELECT
+          u.email,
+          EXISTS (
+            SELECT 1
+              FROM user_roles ur
+              JOIN roles r ON r.id = ur.role_id
+             WHERE ur.user_id = u.id
+               AND lower(r.name) = 'administrator'
+          ) AS "isAdministrator"
+        FROM users u
+        WHERE u.id = ${userId}
+        LIMIT 1
+      `),
+    "getRoomActor"
+  );
+  const [row] = toPgRows<{
+    email: string | null;
+    isAdministrator: boolean;
+  }>(result);
+  if (!row?.email) return null;
+  return {
+    email: row.email,
+    isAdministrator: row.isAdministrator === true,
+  };
+}

--- a/lib/rooms/validation.ts
+++ b/lib/rooms/validation.ts
@@ -1,0 +1,39 @@
+/**
+ * Pure authorization/assignment decisions shared by room server actions and
+ * focused unit tests. The action layer supplies fresh server-side data.
+ */
+
+export function canManageRoom(
+  actorUserId: number,
+  createdBy: number | null,
+  isAdministrator: boolean
+): boolean {
+  return isAdministrator || createdBy === actorUserId;
+}
+
+/**
+ * Existing links may be preserved by an administrator maintaining somebody
+ * else's room. Every newly added link must belong to the acting teacher.
+ */
+export function findUnauthorizedClassIds(
+  desiredClassIds: string[],
+  existingClassIds: string[],
+  teacherClassIds: ReadonlySet<string>,
+  isAdministrator: boolean
+): string[] {
+  const existing = new Set(existingClassIds);
+  return desiredClassIds.filter(
+    (classId) =>
+      !teacherClassIds.has(classId) &&
+      !(isAdministrator && existing.has(classId))
+  );
+}
+
+export function findUnauthorizedAssistantIds(
+  desiredAssistantIds: number[],
+  accessibleAssistantIds: ReadonlySet<number>
+): number[] {
+  return desiredAssistantIds.filter(
+    (assistantId) => !accessibleAssistantIds.has(assistantId)
+  );
+}

--- a/scripts/db/seed-local.sql
+++ b/scripts/db/seed-local.sql
@@ -104,7 +104,7 @@ ON CONFLICT (user_id, role_id) DO NOTHING;
 -- ============================================================================
 -- Capabilities (role-gated UI features; successor to the legacy tools table)
 -- ============================================================================
--- hasCapabilityAccess() reads from capabilities/role_capabilities. Seed ALL 8
+-- hasCapabilityAccess() reads from capabilities/role_capabilities. Seed all
 -- identifiers from CAPABILITY_MANIFEST (lib/capabilities/manifest.ts) so local
 -- test users keep access immediately on a freshly seeded DB — before the
 -- boot-time manifest sync has run:
@@ -113,6 +113,7 @@ ON CONFLICT (user_id, role_id) DO NOTHING;
 -- - knowledge-repositories: repositories, prompt library
 -- - decision-capture, voice-mode: Nexus features
 -- - atrium-content: Atrium content workspace (/atrium)
+-- - rooms-manage: teacher room composition (/rooms/manage)
 -- - internal-performance-monitoring, internal-system-administration: internal
 --   monitoring/admin APIs (would 403 for admin until first server boot otherwise)
 -- These are marked source='manual' here; the boot-time manifest sync flips
@@ -125,6 +126,7 @@ INSERT INTO capabilities (identifier, name, description, is_active, source) VALU
 ('decision-capture', 'Decision Capture', 'Extract and capture decisions from meeting transcripts into the context graph', true, 'manual'),
 ('voice-mode', 'Voice Mode', 'Real-time voice conversations in Nexus using AI speech providers', true, 'manual'),
 ('atrium-content', 'Atrium Content', 'Create and manage Atrium documents, artifacts, and collections', true, 'manual'),
+('rooms-manage', 'Room Management', 'Compose class rooms from roster sections and assign approved assistants', true, 'manual'),
 ('internal-performance-monitoring', 'Internal Performance Monitoring', 'Access internal performance monitoring dashboards and metrics.', true, 'manual'),
 ('internal-system-administration', 'Internal System Administration', 'Access internal system administration tooling and diagnostics.', true, 'manual')
 ON CONFLICT (identifier) DO UPDATE SET
@@ -139,16 +141,16 @@ SELECT r.id, c.id
 FROM roles r
 CROSS JOIN capabilities c
 WHERE r.name = 'administrator'
-  AND c.identifier IN ('assistant-architect', 'model-compare', 'knowledge-repositories', 'decision-capture', 'voice-mode', 'atrium-content', 'internal-performance-monitoring', 'internal-system-administration')
+  AND c.identifier IN ('assistant-architect', 'model-compare', 'knowledge-repositories', 'decision-capture', 'voice-mode', 'atrium-content', 'rooms-manage', 'internal-performance-monitoring', 'internal-system-administration')
 ON CONFLICT (role_id, capability_id) DO NOTHING;
 
--- Grant assistant-architect and model-compare to staff role
+-- Grant staff-facing capabilities to staff role
 INSERT INTO role_capabilities (role_id, capability_id)
 SELECT r.id, c.id
 FROM roles r
 CROSS JOIN capabilities c
 WHERE r.name = 'staff'
-  AND c.identifier IN ('assistant-architect', 'model-compare')
+  AND c.identifier IN ('assistant-architect', 'model-compare', 'rooms-manage')
 ON CONFLICT (role_id, capability_id) DO NOTHING;
 
 -- ============================================================================

--- a/scripts/db/seed-local.sql
+++ b/scripts/db/seed-local.sql
@@ -191,7 +191,8 @@ INSERT INTO navigation_items (id, label, icon, link, parent_id, capability_id, r
 (7, 'Assistant Architect', 'IconBraces', '/utilities/assistant-architect', 19, (SELECT id FROM capabilities WHERE identifier = 'assistant-architect'), NULL, 10, true, NULL, 'link'),
 (37, 'Model Compare', 'IconRobot', '/compare', 19, (SELECT id FROM capabilities WHERE identifier = 'model-compare'), NULL, 20, true, 'Compare AI model responses side-by-side', 'link'),
 (36, 'Repositories', 'IconBuildingBank', '/repositories', 19, (SELECT id FROM capabilities WHERE identifier = 'knowledge-repositories'), NULL, 30, true, '', 'link'),
-(47, 'Decision Capture', 'IconGitBranch', '/nexus/decision-capture', 19, (SELECT id FROM capabilities WHERE identifier = 'decision-capture'), NULL, 40, true, 'Extract decisions from meeting transcripts', 'link');
+(47, 'Decision Capture', 'IconGitBranch', '/nexus/decision-capture', 19, (SELECT id FROM capabilities WHERE identifier = 'decision-capture'), NULL, 40, true, 'Extract decisions from meeting transcripts', 'link'),
+(48, 'Rooms', 'IconUsersGroup', '/rooms/manage', 21, (SELECT id FROM capabilities WHERE identifier = 'rooms-manage'), NULL, 10, true, 'Compose roster sections, individual students, and approved assistants', 'link');
 
 -- Update sequence to max id + 1
 SELECT setval('navigation_items_id_seq', (SELECT MAX(id) FROM navigation_items));

--- a/tests/e2e/helpers/session-auth.ts
+++ b/tests/e2e/helpers/session-auth.ts
@@ -36,6 +36,8 @@ export const SEEDED_ADMIN_EMAIL = 'test@example.com'
 // cognito_sub of the seeded admin user (see scripts/db/seed-local.sql). Holds
 // every capability, so capability guards resolve to 200.
 export const SEEDED_ADMIN_SUB = 'e2e-test-user'
+export const SEEDED_STAFF_EMAIL = 'staff@example.com'
+export const SEEDED_STAFF_SUB = 'e2e-staff-user'
 // cognito_sub of the seeded student user. The student role is granted NO
 // role_capabilities, so capability guards resolve to 403 for this identity —
 // used to exercise the capability-denied path (Issue #928).

--- a/tests/e2e/rooms.guard.spec.ts
+++ b/tests/e2e/rooms.guard.spec.ts
@@ -1,0 +1,14 @@
+import { test, expect } from "./fixtures";
+
+test.describe("Rooms management — route auth gate (always-run)", () => {
+  test("GET /rooms/manage unauthenticated redirects to sign-in", async ({
+    request,
+  }) => {
+    const response = await request.get("/rooms/manage", {
+      maxRedirects: 0,
+    });
+
+    expect(response.status()).toBe(307);
+    expect(response.headers()["location"]).toContain("/api/auth/signin");
+  });
+});

--- a/tests/e2e/teacher-room-create.functional.spec.ts
+++ b/tests/e2e/teacher-room-create.functional.spec.ts
@@ -152,7 +152,15 @@ test.describe("Teacher room management (#1313)", () => {
         SEEDED_STAFF_EMAIL,
         SEEDED_STAFF_SUB
       );
-      await page.goto("/rooms/manage");
+      await page.goto("/dashboard");
+      const navigation = page.getByRole("navigation");
+      await navigation.hover();
+      await navigation
+        .getByRole("button", { name: "Instructional" })
+        .click();
+      const roomsLink = navigation.locator('a[href="/rooms/manage"]');
+      await expect(roomsLink).toBeVisible({ timeout: 15_000 });
+      await roomsLink.click();
       await expect(page.getByTestId("rooms-manage")).toBeVisible({
         timeout: 15_000,
       });
@@ -216,6 +224,13 @@ test.describe("Teacher room management (#1313)", () => {
               AND resource_id = ${String(assistant.id)}) AS resources
       `;
       expect(counts).toEqual({ classes: 1, members: 1, resources: 1 });
+
+      await authenticateContext(page.context());
+      await page.goto("/rooms/manage");
+      await expect(page.getByText("All rooms", { exact: true })).toBeVisible({
+        timeout: 15_000,
+      });
+      await expect(page.getByText(roomName, { exact: true })).toBeVisible();
 
       await mkdir(".verification", { recursive: true });
       await page.screenshot({

--- a/tests/e2e/teacher-room-create.functional.spec.ts
+++ b/tests/e2e/teacher-room-create.functional.spec.ts
@@ -1,0 +1,263 @@
+import { mkdir } from "node:fs/promises";
+import { test, expect } from "./fixtures";
+import {
+  authenticateContext,
+  SEEDED_STAFF_EMAIL,
+  SEEDED_STAFF_SUB,
+} from "./helpers/session-auth";
+
+test.describe("Teacher room management (#1313)", () => {
+  test.skip(
+    process.env.PLAYWRIGHT_AUTH_ENABLED !== "true",
+    "Requires authenticated session against the host dev server"
+  );
+
+  test("teacher composes a section, explicit student, and accessible assistant", async ({
+    page,
+  }, testInfo) => {
+    const postgres = (await import("postgres")).default;
+    const sql = postgres(
+      process.env.E2E_DATABASE_URL ??
+        "postgresql://postgres:postgres@localhost:5432/aistudio",
+      { ssl: process.env.E2E_DB_SSL === "true" }
+    );
+    const stamp = Date.now();
+    const schoolId = `room-e2e-school-${stamp}`;
+    const otherSchoolId = `room-e2e-other-school-${stamp}`;
+    const linkedClassId = `room-e2e-linked-${stamp}`;
+    const otherClassId = `room-e2e-other-${stamp}`;
+    const otherSchoolClassId = `room-e2e-other-school-class-${stamp}`;
+    const teacherRosterId = `room-e2e-teacher-${stamp}`;
+    const sectionStudentId = `room-e2e-section-student-${stamp}`;
+    const explicitStudentId = `room-e2e-explicit-student-${stamp}`;
+    const otherSchoolStudentId = `room-e2e-other-school-student-${stamp}`;
+    const teacherEnrollmentId = `room-e2e-teacher-enrollment-${stamp}`;
+    const sectionStudentEnrollmentId =
+      `room-e2e-section-student-enrollment-${stamp}`;
+    const explicitStudentEnrollmentId =
+      `room-e2e-explicit-student-enrollment-${stamp}`;
+    const otherSchoolStudentEnrollmentId =
+      `room-e2e-other-school-student-enrollment-${stamp}`;
+    const explicitStudentEmail =
+      `explicit-${stamp}@edtools.psd401.net`;
+    const otherSchoolStudentEmail =
+      `restricted-${stamp}@edtools.psd401.net`;
+    const roomName = `E2E Biology Room ${stamp}`;
+    let roomId: string | null = null;
+    let assistantId: number | null = null;
+
+    try {
+      const [staff] = await sql<{ id: number }[]>`
+        SELECT id FROM users WHERE cognito_sub = ${SEEDED_STAFF_SUB}
+      `;
+      if (!staff) throw new Error("Seeded staff user is missing");
+
+      await sql`
+        INSERT INTO oneroster_orgs (
+          sourced_id, name, type, status, is_active, last_synced_at
+        )
+        VALUES
+          (
+            ${schoolId}, 'E2E Room School', 'school', 'active', true, now()
+          ),
+          (
+            ${otherSchoolId}, 'E2E Other School', 'school', 'active', true,
+            now()
+          )
+      `;
+      await sql`
+        INSERT INTO oneroster_classes (
+          sourced_id, title, class_code, school_sourced_id, status,
+          is_active, last_synced_at
+        )
+        VALUES
+          (
+            ${linkedClassId}, 'E2E Biology Section', 'BIO-ROOM',
+            ${schoolId}, 'active', true, now()
+          ),
+          (
+            ${otherClassId}, 'E2E Other Section', 'OTHER-ROOM',
+            ${schoolId}, 'active', true, now()
+          ),
+          (
+            ${otherSchoolClassId}, 'E2E Restricted Section',
+            'RESTRICTED-ROOM', ${otherSchoolId}, 'active', true, now()
+          )
+      `;
+      await sql`
+        INSERT INTO oneroster_users (
+          sourced_id, email, given_name, family_name, role, status,
+          is_active, last_synced_at
+        )
+        VALUES
+          (
+            ${teacherRosterId}, 'STAFF@EXAMPLE.COM', 'Staff', 'Member',
+            'teacher', 'active', true, now()
+          ),
+          (
+            ${sectionStudentId},
+            ${`section-${stamp}@edtools.psd401.net`},
+            'Section', 'Student', 'student', 'active', true, now()
+          ),
+          (
+            ${explicitStudentId}, ${explicitStudentEmail},
+            'Explicit', 'Student', 'student', 'active', true, now()
+          ),
+          (
+            ${otherSchoolStudentId}, ${otherSchoolStudentEmail},
+            'Restricted', 'Student', 'student', 'active', true, now()
+          )
+      `;
+      await sql`
+        INSERT INTO oneroster_enrollments (
+          sourced_id, user_sourced_id, class_sourced_id, school_sourced_id,
+          role, status, is_active, last_synced_at
+        )
+        VALUES
+          (
+            ${teacherEnrollmentId}, ${teacherRosterId}, ${linkedClassId},
+            ${schoolId}, 'teacher', 'active', true, now()
+          ),
+          (
+            ${sectionStudentEnrollmentId}, ${sectionStudentId},
+            ${linkedClassId}, ${schoolId}, 'student', 'active', true, now()
+          ),
+          (
+            ${explicitStudentEnrollmentId}, ${explicitStudentId},
+            ${otherClassId}, ${schoolId}, 'student', 'active', true, now()
+          ),
+          (
+            ${otherSchoolStudentEnrollmentId}, ${otherSchoolStudentId},
+            ${otherSchoolClassId}, ${otherSchoolId}, 'student', 'active',
+            true, now()
+          )
+      `;
+      const [assistant] = await sql<{ id: number }[]>`
+        INSERT INTO assistant_architects (
+          name, description, status, user_id
+        )
+        VALUES (
+          ${`E2E Room Assistant ${stamp}`},
+          'Assistant assigned by the room-management functional test',
+          'approved',
+          ${staff.id}
+        )
+        RETURNING id
+      `;
+      if (!assistant) throw new Error("Assistant fixture was not created");
+      assistantId = assistant.id;
+
+      await authenticateContext(
+        page.context(),
+        SEEDED_STAFF_EMAIL,
+        SEEDED_STAFF_SUB
+      );
+      await page.goto("/rooms/manage");
+      await expect(page.getByTestId("rooms-manage")).toBeVisible({
+        timeout: 15_000,
+      });
+
+      await page.getByTestId("room-name").fill(roomName);
+      await page
+        .getByTestId(`room-section-${linkedClassId}`)
+        .check();
+      await page
+        .getByTestId("room-student-search")
+        .fill(`restricted-${stamp}`);
+      await page.getByTestId("room-student-search-button").click();
+      await expect(
+        page.getByTestId(
+          `room-student-result-${otherSchoolStudentEmail}`
+        )
+      ).toHaveCount(0);
+      await page
+        .getByTestId("room-student-search")
+        .fill(`explicit-${stamp}`);
+      await page.getByTestId("room-student-search-button").click();
+      await page
+        .getByTestId(`room-student-result-${explicitStudentEmail}`)
+        .click();
+      await page
+        .getByTestId(`room-assistant-${assistant.id}`)
+        .check();
+      await page.getByTestId("room-save").click();
+
+      await expect(page.getByTestId("room-feedback")).toContainText(
+        "Room created",
+        { timeout: 10_000 }
+      );
+      await expect(page.getByText(roomName, { exact: true })).toBeVisible({
+        timeout: 10_000,
+      });
+
+      const [createdRoom] = await sql<{ id: string }[]>`
+        SELECT id
+          FROM rooms
+         WHERE name = ${roomName}
+           AND created_by = ${staff.id}
+           AND is_active = true
+      `;
+      if (!createdRoom) throw new Error("Room was not persisted");
+      roomId = createdRoom.id;
+      const [counts] = await sql<{
+        classes: number;
+        members: number;
+        resources: number;
+      }[]>`
+        SELECT
+          (SELECT count(*)::int FROM room_classes
+            WHERE room_id = ${createdRoom.id}) AS classes,
+          (SELECT count(*)::int FROM room_members
+            WHERE room_id = ${createdRoom.id}
+              AND lower(member_email) = lower(${explicitStudentEmail})) AS members,
+          (SELECT count(*)::int FROM room_resources
+            WHERE room_id = ${createdRoom.id}
+              AND resource_type = 'assistant'
+              AND resource_id = ${String(assistant.id)}) AS resources
+      `;
+      expect(counts).toEqual({ classes: 1, members: 1, resources: 1 });
+
+      await mkdir(".verification", { recursive: true });
+      await page.screenshot({
+        path: `.verification/teacher-room-create-${testInfo.project.name}.png`,
+        fullPage: true,
+      });
+    } finally {
+      if (roomId) {
+        await sql`DELETE FROM rooms WHERE id = ${roomId}`;
+      }
+      if (assistantId) {
+        await sql`
+          DELETE FROM assistant_architects WHERE id = ${assistantId}
+        `;
+      }
+      await sql`
+        DELETE FROM oneroster_enrollments
+         WHERE sourced_id IN (
+           ${teacherEnrollmentId},
+           ${sectionStudentEnrollmentId},
+           ${explicitStudentEnrollmentId},
+           ${otherSchoolStudentEnrollmentId}
+         )
+      `;
+      await sql`
+        DELETE FROM oneroster_users
+         WHERE sourced_id IN (
+           ${teacherRosterId}, ${sectionStudentId}, ${explicitStudentId},
+           ${otherSchoolStudentId}
+         )
+      `;
+      await sql`
+        DELETE FROM oneroster_classes
+         WHERE sourced_id IN (
+           ${linkedClassId}, ${otherClassId}, ${otherSchoolClassId}
+         )
+      `;
+      await sql`
+        DELETE FROM oneroster_orgs
+         WHERE sourced_id IN (${schoolId}, ${otherSchoolId})
+      `;
+      await sql.end();
+    }
+  });
+});

--- a/tests/unit/actions/rooms-actions.test.ts
+++ b/tests/unit/actions/rooms-actions.test.ts
@@ -202,6 +202,37 @@ describe("room actions — server authorization", () => {
     expect(mockUpdateManagedRoom).toHaveBeenCalled();
   });
 
+  it("rejects every entry point when the rooms-manage capability is denied", async () => {
+    mockHasCapabilityAccess.mockResolvedValue(false);
+
+    const created = await createRoomAction({
+      name: "Biology",
+      classSourcedIds: ["owned-section"],
+      memberEmails: [],
+      assistantIds: [],
+    });
+    const loaded = await getRoomsManageDataAction();
+
+    expect(created.isSuccess).toBe(false);
+    expect(loaded.isSuccess).toBe(false);
+    expect(mockHasCapabilityAccess).toHaveBeenCalledWith(
+      "rooms-manage",
+      "teacher-sub"
+    );
+    // The gate must short-circuit before any room data is read or written.
+    expect(mockGetRoomActor).not.toHaveBeenCalled();
+    expect(mockListRoomsForManagement).not.toHaveBeenCalled();
+    expect(mockCreateManagedRoom).not.toHaveBeenCalled();
+  });
+
+  it("scopes the room list to the actor for a non-administrator", async () => {
+    const result = await getRoomsManageDataAction();
+
+    expect(result.isSuccess).toBe(true);
+    expect(mockListRoomsForManagement).toHaveBeenCalledWith(7, false);
+    expect(result.data?.isAdministrator).toBe(false);
+  });
+
   it("loads every active room for administrators", async () => {
     mockGetRoomActor.mockResolvedValue({
       email: "admin@example.com",

--- a/tests/unit/actions/rooms-actions.test.ts
+++ b/tests/unit/actions/rooms-actions.test.ts
@@ -6,6 +6,7 @@ const mockListTeacherSections = jest.fn();
 const mockAccessibleApprovedAssistantIds = jest.fn();
 const mockAccessibleActiveRosterStudentEmails = jest.fn();
 const mockGetRoomAuthorizationSnapshot = jest.fn();
+const mockListRoomsForManagement = jest.fn();
 const mockCreateManagedRoom = jest.fn();
 const mockUpdateManagedRoom = jest.fn();
 const mockDeactivateManagedRoom = jest.fn();
@@ -32,7 +33,8 @@ jest.mock("@/lib/rooms/queries", () => ({
   getRoomAuthorizationSnapshot: (...args: unknown[]) =>
     mockGetRoomAuthorizationSnapshot(...args),
   listAccessibleApprovedAssistants: jest.fn().mockResolvedValue([]),
-  listRoomsForManagement: jest.fn().mockResolvedValue([]),
+  listRoomsForManagement: (...args: unknown[]) =>
+    mockListRoomsForManagement(...args),
   searchActiveRosterStudents: jest.fn().mockResolvedValue([]),
 }));
 jest.mock("@/lib/rooms/mutations", () => ({
@@ -44,6 +46,7 @@ jest.mock("@/lib/rooms/mutations", () => ({
 
 import {
   createRoomAction,
+  getRoomsManageDataAction,
   updateRoomAction,
 } from "@/actions/db/rooms-actions";
 
@@ -75,6 +78,7 @@ describe("room actions — server authorization", () => {
     mockAccessibleActiveRosterStudentEmails.mockResolvedValue(
       new Set(["student@example.com"])
     );
+    mockListRoomsForManagement.mockResolvedValue([]);
     mockCreateManagedRoom.mockResolvedValue(roomId);
     mockUpdateManagedRoom.mockResolvedValue(undefined);
   });
@@ -196,5 +200,18 @@ describe("room actions — server authorization", () => {
 
     expect(result.isSuccess).toBe(true);
     expect(mockUpdateManagedRoom).toHaveBeenCalled();
+  });
+
+  it("loads every active room for administrators", async () => {
+    mockGetRoomActor.mockResolvedValue({
+      email: "admin@example.com",
+      isAdministrator: true,
+    });
+
+    const result = await getRoomsManageDataAction();
+
+    expect(result.isSuccess).toBe(true);
+    expect(mockListRoomsForManagement).toHaveBeenCalledWith(7, true);
+    expect(result.data?.isAdministrator).toBe(true);
   });
 });

--- a/tests/unit/actions/rooms-actions.test.ts
+++ b/tests/unit/actions/rooms-actions.test.ts
@@ -1,0 +1,200 @@
+const mockGetServerSession = jest.fn();
+const mockResolveUserId = jest.fn();
+const mockHasCapabilityAccess = jest.fn();
+const mockGetRoomActor = jest.fn();
+const mockListTeacherSections = jest.fn();
+const mockAccessibleApprovedAssistantIds = jest.fn();
+const mockAccessibleActiveRosterStudentEmails = jest.fn();
+const mockGetRoomAuthorizationSnapshot = jest.fn();
+const mockCreateManagedRoom = jest.fn();
+const mockUpdateManagedRoom = jest.fn();
+const mockDeactivateManagedRoom = jest.fn();
+
+jest.mock("next/cache", () => ({ revalidatePath: jest.fn() }));
+jest.mock("@/lib/auth/server-session", () => ({
+  getServerSession: (...args: unknown[]) => mockGetServerSession(...args),
+}));
+jest.mock("@/lib/auth/resolve-user", () => ({
+  resolveUserId: (...args: unknown[]) => mockResolveUserId(...args),
+}));
+jest.mock("@/utils/roles", () => ({
+  hasCapabilityAccess: (...args: unknown[]) =>
+    mockHasCapabilityAccess(...args),
+}));
+jest.mock("@/lib/rooms/queries", () => ({
+  getRoomActor: (...args: unknown[]) => mockGetRoomActor(...args),
+  listTeacherSections: (...args: unknown[]) =>
+    mockListTeacherSections(...args),
+  accessibleApprovedAssistantIds: (...args: unknown[]) =>
+    mockAccessibleApprovedAssistantIds(...args),
+  accessibleActiveRosterStudentEmails: (...args: unknown[]) =>
+    mockAccessibleActiveRosterStudentEmails(...args),
+  getRoomAuthorizationSnapshot: (...args: unknown[]) =>
+    mockGetRoomAuthorizationSnapshot(...args),
+  listAccessibleApprovedAssistants: jest.fn().mockResolvedValue([]),
+  listRoomsForManagement: jest.fn().mockResolvedValue([]),
+  searchActiveRosterStudents: jest.fn().mockResolvedValue([]),
+}));
+jest.mock("@/lib/rooms/mutations", () => ({
+  createManagedRoom: (...args: unknown[]) => mockCreateManagedRoom(...args),
+  updateManagedRoom: (...args: unknown[]) => mockUpdateManagedRoom(...args),
+  deactivateManagedRoom: (...args: unknown[]) =>
+    mockDeactivateManagedRoom(...args),
+}));
+
+import {
+  createRoomAction,
+  updateRoomAction,
+} from "@/actions/db/rooms-actions";
+
+const roomId = "b56adf63-75c2-4d92-9f6f-d6d69c90a2fb";
+
+describe("room actions — server authorization", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetServerSession.mockResolvedValue({
+      sub: "teacher-sub",
+      email: "teacher@example.com",
+    });
+    mockResolveUserId.mockResolvedValue(7);
+    mockHasCapabilityAccess.mockResolvedValue(true);
+    mockGetRoomActor.mockResolvedValue({
+      email: "teacher@example.com",
+      isAdministrator: false,
+    });
+    mockListTeacherSections.mockResolvedValue([
+      {
+        sourcedId: "owned-section",
+        title: "Owned",
+        classCode: null,
+        schoolName: null,
+        studentCount: 1,
+      },
+    ]);
+    mockAccessibleApprovedAssistantIds.mockResolvedValue(new Set<number>());
+    mockAccessibleActiveRosterStudentEmails.mockResolvedValue(
+      new Set(["student@example.com"])
+    );
+    mockCreateManagedRoom.mockResolvedValue(roomId);
+    mockUpdateManagedRoom.mockResolvedValue(undefined);
+  });
+
+  it("rejects a section that is not the signed-in teacher's own", async () => {
+    const result = await createRoomAction({
+      name: "Biology",
+      classSourcedIds: ["other-teacher-section"],
+      memberEmails: [],
+      assistantIds: [],
+    });
+
+    expect(result.isSuccess).toBe(false);
+    expect(mockCreateManagedRoom).not.toHaveBeenCalled();
+  });
+
+  it("rejects an assistant the teacher cannot access", async () => {
+    const result = await createRoomAction({
+      name: "Biology",
+      classSourcedIds: ["owned-section"],
+      memberEmails: [],
+      assistantIds: [42],
+    });
+
+    expect(result.isSuccess).toBe(false);
+    expect(mockAccessibleApprovedAssistantIds).toHaveBeenCalledWith(7, [42]);
+    expect(mockCreateManagedRoom).not.toHaveBeenCalled();
+  });
+
+  it("rejects an explicit member absent from the actor's active roster scope", async () => {
+    mockAccessibleActiveRosterStudentEmails.mockResolvedValue(
+      new Set<string>()
+    );
+
+    const result = await createRoomAction({
+      name: "Biology",
+      classSourcedIds: ["owned-section"],
+      memberEmails: ["outsider@example.com"],
+      assistantIds: [],
+    });
+
+    expect(result.isSuccess).toBe(false);
+    expect(mockAccessibleActiveRosterStudentEmails).toHaveBeenCalledWith(
+      "teacher@example.com",
+      false,
+      ["outsider@example.com"]
+    );
+    expect(mockCreateManagedRoom).not.toHaveBeenCalled();
+  });
+
+  it("allows an active roster student in the actor's scope", async () => {
+    const result = await createRoomAction({
+      name: "Biology",
+      classSourcedIds: ["owned-section"],
+      memberEmails: ["STUDENT@example.com"],
+      assistantIds: [],
+    });
+
+    expect(result.isSuccess).toBe(true);
+    expect(mockAccessibleActiveRosterStudentEmails).toHaveBeenCalledWith(
+      "teacher@example.com",
+      false,
+      ["student@example.com"]
+    );
+    expect(mockCreateManagedRoom).toHaveBeenCalled();
+  });
+
+  it("rejects a non-creator non-administrator before assignment checks", async () => {
+    mockGetRoomAuthorizationSnapshot.mockResolvedValue({
+      createdBy: 99,
+      classSourcedIds: [],
+    });
+
+    const result = await updateRoomAction(roomId, {
+      name: "Changed",
+      classSourcedIds: [],
+      memberEmails: [],
+      assistantIds: [],
+    });
+
+    expect(result.isSuccess).toBe(false);
+    expect(mockListTeacherSections).not.toHaveBeenCalled();
+    expect(mockUpdateManagedRoom).not.toHaveBeenCalled();
+  });
+
+  it("rejects an owner preserving a section they no longer teach", async () => {
+    mockGetRoomAuthorizationSnapshot.mockResolvedValue({
+      createdBy: 7,
+      classSourcedIds: ["former-section"],
+    });
+
+    const result = await updateRoomAction(roomId, {
+      name: "Changed",
+      classSourcedIds: ["former-section"],
+      memberEmails: [],
+      assistantIds: [],
+    });
+
+    expect(result.isSuccess).toBe(false);
+    expect(mockUpdateManagedRoom).not.toHaveBeenCalled();
+  });
+
+  it("allows an administrator to preserve existing section links", async () => {
+    mockGetRoomActor.mockResolvedValue({
+      email: "admin@example.com",
+      isAdministrator: true,
+    });
+    mockGetRoomAuthorizationSnapshot.mockResolvedValue({
+      createdBy: 99,
+      classSourcedIds: ["existing-section"],
+    });
+
+    const result = await updateRoomAction(roomId, {
+      name: "Maintained",
+      classSourcedIds: ["existing-section"],
+      memberEmails: [],
+      assistantIds: [],
+    });
+
+    expect(result.isSuccess).toBe(true);
+    expect(mockUpdateManagedRoom).toHaveBeenCalled();
+  });
+});

--- a/tests/unit/rooms-membership.test.ts
+++ b/tests/unit/rooms-membership.test.ts
@@ -1,0 +1,67 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+const mockExecuteQuery = jest.fn();
+
+jest.mock("@/lib/db/drizzle-client", () => ({
+  executeQuery: (...args: unknown[]) => mockExecuteQuery(...args),
+  toPgRows: <T>(rows: T[]): T[] => rows,
+}));
+
+import {
+  mergeRoomMembershipEmails,
+  resolveRoomMembershipEmails,
+} from "@/lib/rooms/membership";
+
+describe("room membership", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("unions section and explicit membership with lowercase deduplication", () => {
+    expect(
+      mergeRoomMembershipEmails(
+        ["Student@Example.com", "shared@example.com", null],
+        ["SHARED@example.com", "explicit@example.com", " "]
+      )
+    ).toEqual([
+      "explicit@example.com",
+      "shared@example.com",
+      "student@example.com",
+    ]);
+  });
+
+  it("resolves the dynamic section and explicit rows through one union", async () => {
+    mockExecuteQuery
+      .mockResolvedValueOnce([
+        { email: "SECTION@EXAMPLE.COM" },
+        { email: "shared@example.com" },
+      ])
+      .mockResolvedValueOnce([
+        { email: "explicit@example.com" },
+        { email: "SHARED@example.com" },
+      ]);
+
+    await expect(resolveRoomMembershipEmails("room-id")).resolves.toEqual([
+      "explicit@example.com",
+      "section@example.com",
+      "shared@example.com",
+    ]);
+    expect(mockExecuteQuery).toHaveBeenCalledTimes(2);
+  });
+
+  it("pins active-student and lowercase-email point-check semantics", () => {
+    const source = readFileSync(
+      path.resolve(__dirname, "../../lib/rooms/membership.ts"),
+      "utf8"
+    );
+    expect(source).toContain(
+      "lower(coalesce(${onerosterEnrollments.role}, '')) = 'student'"
+    );
+    expect(source).toContain("eq(onerosterEnrollments.isActive, true)");
+    expect(source).toContain(
+      "lower(rm.member_email) = lower(${email})"
+    );
+    expect(source).toContain("lower(u.email) = lower(${email})");
+  });
+});

--- a/tests/unit/rooms-migration.test.ts
+++ b/tests/unit/rooms-migration.test.ts
@@ -1,0 +1,91 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+const root = path.resolve(__dirname, "../..");
+const migrationPath = path.join(
+  root,
+  "infra/database/schema/157-rooms.sql"
+);
+const migration = readFileSync(migrationPath, "utf8");
+const manifest = JSON.parse(
+  readFileSync(
+    path.join(root, "infra/database/migrations.json"),
+    "utf8"
+  )
+) as { migrationFiles: string[] };
+
+describe("migration 157 — teacher-managed rooms", () => {
+  it("is registered after the current OneRoster role-source migration", () => {
+    expect(manifest.migrationFiles.slice(-2)).toEqual([
+      "156-oneroster-user-role-source.sql",
+      "157-rooms.sql",
+    ]);
+  });
+
+  it.each(["rooms", "room_classes", "room_members", "room_resources"])(
+    "creates %s additively",
+    (table) => {
+      expect(migration).toMatch(
+        new RegExp(`CREATE TABLE IF NOT EXISTS ${table} \\(`)
+      );
+    }
+  );
+
+  it("enforces ownership, source-key, email, and assistant constraints", () => {
+    expect(migration).toContain(
+      "created_by  integer REFERENCES users(id) ON DELETE SET NULL"
+    );
+    expect(migration).toContain(
+      "room_id           uuid NOT NULL REFERENCES rooms(id) ON DELETE CASCADE"
+    );
+    expect(migration).toContain(
+      "ON room_classes (room_id, class_sourced_id)"
+    );
+    expect(migration).toContain(
+      "ON room_members (room_id, lower(member_email))"
+    );
+    expect(migration).toContain(
+      "member_email = lower(btrim(member_email))"
+    );
+    expect(migration).toContain(
+      "resource_type  text NOT NULL CHECK (resource_type = 'assistant')"
+    );
+    expect(migration).toContain(
+      "ON room_resources (room_id, resource_type, resource_id)"
+    );
+  });
+
+  it("indexes every FK/source lookup and maintains rooms.updated_at", () => {
+    for (const indexName of [
+      "idx_rooms_created_by",
+      "idx_room_classes_room_id",
+      "idx_room_classes_class_sourced_id",
+      "idx_room_members_room_id",
+      "idx_room_members_email",
+      "idx_room_resources_room_id",
+      "idx_room_resources_resource",
+    ]) {
+      expect(migration).toContain(`CREATE INDEX IF NOT EXISTS ${indexName}`);
+    }
+    expect(migration).toContain(
+      "CREATE TRIGGER update_rooms_updated_at"
+    );
+    expect(migration).toContain(
+      "FOR EACH ROW EXECUTE FUNCTION update_updated_at_column()"
+    );
+  });
+
+  it("remains splitter-compatible, excludes demographics, and documents rollback", () => {
+    expect(migration).not.toMatch(/\bDO\s+\$\$/i);
+    expect(migration).not.toMatch(/^\s*(BEGIN|COMMIT|ROLLBACK)\s*;/im);
+    expect(migration).not.toMatch(/demographic/i);
+    for (const table of [
+      "room_resources",
+      "room_members",
+      "room_classes",
+      "rooms",
+    ]) {
+      expect(migration).toContain(`-- DROP TABLE IF EXISTS ${table};`);
+    }
+  });
+});

--- a/tests/unit/rooms-migration.test.ts
+++ b/tests/unit/rooms-migration.test.ts
@@ -75,6 +75,15 @@ describe("migration 157 — teacher-managed rooms", () => {
     );
   });
 
+  it("seeds capability-gated room navigation for fresh databases", () => {
+    expect(migration).toContain("'rooms-manage'");
+    expect(migration).toContain("JOIN roles ON roles.name IN ('administrator', 'staff')");
+    expect(migration).toContain("'Rooms'");
+    expect(migration).toContain("'IconUsersGroup'");
+    expect(migration).toContain("'/rooms/manage'");
+    expect(migration).toContain("capabilities.id");
+  });
+
   it("remains splitter-compatible, excludes demographics, and documents rollback", () => {
     expect(migration).not.toMatch(/\bDO\s+\$\$/i);
     expect(migration).not.toMatch(/^\s*(BEGIN|COMMIT|ROLLBACK)\s*;/im);

--- a/tests/unit/rooms-queries.test.ts
+++ b/tests/unit/rooms-queries.test.ts
@@ -1,0 +1,56 @@
+/** @jest-environment node */
+
+import type { SQL } from "drizzle-orm";
+import { PgDialect } from "drizzle-orm/pg-core";
+
+const mockExecuteQuery = jest.fn();
+
+jest.mock("@/lib/db/drizzle-client", () => ({
+  executeQuery: (...args: unknown[]) => mockExecuteQuery(...args),
+  toPgRows: (value: unknown) => value,
+}));
+
+import { searchActiveRosterStudents } from "@/lib/rooms/queries";
+
+const dialect = new PgDialect();
+
+describe("room roster queries", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("preserves literal LIKE metacharacters in student searches", async () => {
+    let capturedQuery: SQL | undefined;
+    mockExecuteQuery.mockImplementationOnce(
+      async (callback: unknown, label: unknown) => {
+        expect(label).toBe("searchActiveRosterStudents");
+        const execute = jest.fn((query: SQL) => {
+          capturedQuery = query;
+          return Promise.resolve([]);
+        });
+        return (
+          callback as (db: { execute: typeof execute }) => Promise<unknown>
+        )({ execute });
+      }
+    );
+
+    await expect(
+      searchActiveRosterStudents(
+        "First_Last%\\Term",
+        "teacher@example.com",
+        false
+      )
+    ).resolves.toEqual([]);
+
+    expect(capturedQuery).toBeDefined();
+    const compiled = dialect.sqlToQuery(capturedQuery!);
+    expect(compiled.sql).not.toContain("ESCAPE");
+    expect(compiled.params).toEqual([
+      false,
+      "teacher@example.com",
+      "%first\\_last\\%\\\\term%",
+      "%first\\_last\\%\\\\term%",
+      25,
+    ]);
+  });
+});

--- a/tests/unit/rooms-search-escaping.test.ts
+++ b/tests/unit/rooms-search-escaping.test.ts
@@ -1,0 +1,42 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+/**
+ * Regression guard for the roster student search's LIKE-pattern escaping.
+ *
+ * `searchActiveRosterStudents` escapes `\`, `%`, and `_` in user-supplied search
+ * text so they match literally. Postgres's default LIKE escape character is
+ * already backslash, so that escaping works only when NO explicit `ESCAPE`
+ * clause is present.
+ *
+ * The trap this pins: written inside a template literal, an `ESCAPE` clause
+ * followed by a single-backslash string does not survive to Postgres. The
+ * backslash is consumed escaping the closing quote, so the SQL actually sent is
+ * `ESCAPE ''` — which per the Postgres docs selects NO escape character. The
+ * backslashes the helper inserts then become literal characters the pattern has
+ * to match, and a search for `first_last` returns no rows at all. Verified
+ * against PostgreSQL 16: `'first_last@x.edu' LIKE '%first\_last%' ESCAPE ''` is
+ * false, while the same pattern with no ESCAPE clause is true.
+ */
+describe("roster student search — LIKE pattern escaping", () => {
+  const source = readFileSync(
+    path.resolve(__dirname, "../../lib/rooms/queries.ts"),
+    "utf8"
+  );
+
+  it("sends no ESCAPE clause, relying on Postgres's backslash default", () => {
+    // The cooked form the broken clause produces must never reach the SQL.
+    expect(source).not.toContain("ESCAPE ''");
+    // Guard the source form too, so the bug cannot be reintroduced verbatim.
+    expect(source).not.toMatch(/LIKE \$\{pattern\} ESCAPE/);
+    expect(source).toContain("lower(u.email) LIKE ${pattern}");
+    expect(source).toContain(") LIKE ${pattern}");
+  });
+
+  it("still escapes LIKE metacharacters in user-supplied search text", () => {
+    expect(source).toContain('return value.replace(/[\\\\%_]/g, "\\\\$&");');
+    expect(source).toContain(
+      "const pattern = `%${escapeLikePattern(normalized)}%`;"
+    );
+  });
+});

--- a/tests/unit/rooms-validation.test.ts
+++ b/tests/unit/rooms-validation.test.ts
@@ -1,0 +1,43 @@
+import {
+  canManageRoom,
+  findUnauthorizedAssistantIds,
+  findUnauthorizedClassIds,
+} from "@/lib/rooms/validation";
+
+describe("room server-side assignment decisions", () => {
+  it("rejects every section a non-admin teacher no longer owns", () => {
+    const owned = new Set(["teacher-section"]);
+    expect(
+      findUnauthorizedClassIds(
+        ["existing-admin-room-section", "teacher-section", "other-section"],
+        ["existing-admin-room-section"],
+        owned,
+        false
+      )
+    ).toEqual(["existing-admin-room-section", "other-section"]);
+  });
+
+  it("allows an administrator to preserve existing section links", () => {
+    expect(
+      findUnauthorizedClassIds(
+        ["existing-section", "new-section"],
+        ["existing-section"],
+        new Set(),
+        true
+      )
+    ).toEqual(["new-section"]);
+  });
+
+  it("rejects assistants absent from the fresh accessible-approved set", () => {
+    expect(
+      findUnauthorizedAssistantIds([10, 11, 12], new Set([10, 12]))
+    ).toEqual([11]);
+  });
+
+  it("permits only the creator or an administrator to mutate a room", () => {
+    expect(canManageRoom(7, 7, false)).toBe(true);
+    expect(canManageRoom(7, 8, true)).toBe(true);
+    expect(canManageRoom(7, 8, false)).toBe(false);
+    expect(canManageRoom(7, null, false)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- add migration 157 and typed Drizzle schemas for teacher-managed rooms, linked OneRoster sections, explicit members, and assistant resources
- add the `rooms-manage` staff/administrator UI capability and local seed wiring
- add `/rooms/manage` list/create/edit/delete flows with section, student, and assistant pickers
- enforce capability, creator/administrator ownership, current teacher-section authority, school-scoped student lookup, active explicit-member validation, and accessible approved-assistant checks on the server
- resolve membership as the lowercase-email union of active linked-section enrollments and explicit members
- replace room children atomically and recheck room ownership under a row lock

Closes #1313
Part of #1308

## Security review

A full Codex Security diff review covered all 22 changed source-like files. It found and fixed three issues before this PR was opened:

- forged `memberEmails` could bypass the active-roster picker
- ordinary staff room managers could search student names/emails outside their schools
- non-admin room owners could preserve a linked section after losing their teacher enrollment

Focused failing regressions reproduced each broken boundary before the fixes. Final patched-snapshot review has zero unresolved reportable findings. A narrow validation-to-commit revocation race was assessed and rejected for this issue because authorization is valid at check time and #1314 owns the first student-facing execution sink.

## Verification

- `bunx jest tests/unit/rooms-migration.test.ts tests/unit/rooms-membership.test.ts tests/unit/rooms-validation.test.ts tests/unit/actions/rooms-actions.test.ts --runInBand` — 22 passed
- `bun run test:ci -- --runInBand` — 427 suites passed, 3 skipped; 4,042 tests passed, 26 skipped
- authenticated Playwright `rooms.guard` + `teacher-room-create.functional` — 2/2 passed, zero retries
  - proves unauthenticated denial, cross-school student non-disclosure, same-school explicit student selection, accessible assistant assignment, and persisted room composition
- `bun run typecheck` — passed
- changed production file ESLint with `--max-warnings=0` — passed
- `bun run lint` — exit 0; 497 pre-existing warnings remain in unchanged files
- `bun run build` — passed; `/rooms/manage` included in the production route manifest
- cold PostgreSQL 16/pgvector initialization + local seed + migration 157 constraint/cascade/trigger/idempotency probes — passed
- `cd infra && bunx cdk synth` — passed with existing low-severity CDK warnings
- `git diff --check` — passed

## Rollback

Revoke `rooms-manage` to disable the teacher surface. Migration 157 is additive; its rollback statements are documented in reverse dependency order.
