### PR TITLE
fix(agent): remove the Freshservice capability gate that could never pass

### DIFF
--- a/app/api/agent/credentials/route.ts
+++ b/app/api/agent/credentials/route.ts
@@ -123,14 +123,22 @@ export async function POST(request: NextRequest) {
         )
       }
       case "freshservice": {
-        const granted = await broker.canAccessSkill(
-          invocation.ownerEmail,
-          "skill.freshservice",
-          undefined
-        )
-        if (!granted) {
-          return NextResponse.json({ error: "Forbidden" }, { status: 403 })
-        }
+        // NO capability gate — deliberately, and do not add one back.
+        //
+        // An earlier version of this case checked `skill.freshservice`, copied
+        // from the redrover case below. That identifier exists nowhere else in
+        // the codebase, so no role could ever hold it: every Freshservice call
+        // returned 403 forever, and the message ("access is not granted for
+        // this account") sent debugging toward account provisioning instead of
+        // toward the gate that had just been invented.
+        //
+        // The redrover gate is not a precedent to copy. Red Rover authenticates
+        // with a SHARED district credential (sharedCredentialJson), so who may
+        // borrow the district's account is a real question. Freshservice uses
+        // the caller's OWN per-user key (getUserOnly, scoped to
+        // invocation.ownerEmail) — the credential IS the authorization, and it
+        // grants exactly the access that person already has in Freshservice.
+        // A capability check adds no security here, only a way to be locked out.
         return NextResponse.json(
           await executeFreshserviceOperation({
             ownerEmail: invocation.ownerEmail,

--- a/tests/unit/lib/agent-credentials/freshservice-broker.test.ts
+++ b/tests/unit/lib/agent-credentials/freshservice-broker.test.ts
@@ -13,6 +13,10 @@
  * endpoints the skill never uses. These tests pin exactly what is reachable.
  */
 
+import fs from "node:fs"
+import path from "node:path"
+import { stripComments } from "../../../helpers/strip-ts-comments"
+
 const getUserOnly = jest.fn()
 const fetchMock = jest.fn()
 
@@ -223,6 +227,39 @@ describe("Freshservice broker behaviour", () => {
     expect(fetchMock.mock.calls[0][0]).toBe(
       "https://psd401.freshservice.com/api/v2/agents?email=someone%40psd401.net"
     )
+  })
+
+  it("is not gated behind a capability that cannot be granted", async () => {
+    // REGRESSION PIN. The route case briefly checked `skill.freshservice`,
+    // copied from the redrover case. That identifier existed nowhere else, so
+    // no role could hold it and every call 403'd forever — and the message
+    // ("access is not granted for this account") pointed debugging at account
+    // provisioning rather than at the gate that had just been invented.
+    //
+    // Red Rover is not a precedent: it uses a SHARED district credential, so
+    // gating who may borrow it is meaningful. Freshservice uses the caller's
+    // OWN per-user key, so the credential is already the authorization.
+    // Comment-stripped: the prose above the case explains WHY the gate was
+    // removed and names the identifier, so a raw substring check would fail on
+    // correct source.
+    const routeSource = stripComments(
+      fs.readFileSync(
+        path.join(process.cwd(), "app/api/agent/credentials/route.ts"),
+        "utf8",
+      ),
+    )
+    const freshserviceCase = routeSource.slice(
+      routeSource.indexOf('case "freshservice"'),
+      routeSource.indexOf('case "put"'),
+    )
+
+    // Guard the slice, so the assertions below cannot pass on an empty string.
+    expect(freshserviceCase).toContain("executeFreshserviceOperation")
+    expect(freshserviceCase).not.toContain("canAccessSkill")
+    expect(routeSource).not.toContain("skill.freshservice")
+
+    // The redrover case KEEPS its gate — it uses a shared district credential.
+    expect(routeSource).toContain("skill.redrover")
   })
 
   it("refuses to follow redirects", async () => {


### PR DESCRIPTION
Every Freshservice call returns 403 "access is not granted for this account".

**I added that gate in #1384 and it never worked.** It checks the capability `skill.freshservice`, which exists nowhere else in the codebase — no capabilities row, no migration, no manifest entry — so no role can hold it and `canAccessSkill` can only ever return false.

The message also misdirected the diagnosis: "access is not granted for this account" reads as account provisioning, so the agent reasonably concluded it was an infra config problem and filed a failure report. The API key got rotated trying to fix it — the one thing guaranteed not to help, since the 403 fires before the key is ever read.

## Why there should be no gate here

It was copied from the `redrover` case directly below it. That is not a precedent that transfers:

| | Credential | Gate |
|---|---|---|
| **Red Rover** | SHARED district credential (`sharedCredentialJson`) | `skill.redrover` does real work — who may borrow the district account is a genuine question. **Unchanged.** |
| **Freshservice** | the caller's OWN key (`getUserOnly`, scoped to `invocation.ownerEmail` from the signed context) | The credential *is* the authorization. It grants exactly the access that person already has, and the owner cannot be spoofed. |

The pre-#1384 code had no such check either — the skill fetched the user's key and called the API. This restores that authorization model while keeping the credential server-side, which was the actual point of the migration.

## Test

A regression pin asserts the freshservice case contains no `canAccessSkill` and that `skill.freshservice` appears nowhere in the route — while asserting `skill.redrover` **is** still present, so the fix cannot be over-applied to the case that legitimately needs its gate. Comment-stripped, since the prose above the case names the identifier it forbids.

**Mutation-verified:** re-adding the gate fails exactly that test and no other.

43 freshservice tests pass. Typecheck clean, lint 0 errors (497 baseline unchanged).

## Deploy

**Web tier only — no image rebuild.** The in-image skill already calls the broker correctly; the route was rejecting it.

Pushed with `SKIP_E2E=1`: the local suite's only failure is `atrium-meridian-editor.spec.ts`, which fails identically on clean `dev` and is unrelated to this change.