### PR TITLE
fix(agent): restart a scheduled task in a fresh session when context overflows

### DIFF
--- a/infra/agent-image/harness_adapter.py
+++ b/infra/agent-image/harness_adapter.py
@@ -82,6 +82,37 @@ def _format_for_chat(text: str) -> str:
         return text
 
 
+CONTEXT_OVERFLOW_ERROR_CLASS = "ContextOverflow"
+
+
+def _classify_chat_error(error_message: str) -> str:
+    """Name the chat-error class from OpenClaw's message.
+
+    Every chat-channel error arrives as the same generic OpenClawChatError, with
+    the only distinguishing detail buried in free text. That conflates two very
+    different situations:
+
+      • Context overflow — the transcript outgrew the model's window. The work
+        itself is fine; the SESSION is the problem, and continuing it is
+        guaranteed to fail again. Recoverable, but only by starting fresh.
+      • Everything else — a genuine fault. Retrying is not obviously safe.
+
+    Downstream (agent-cron promotion, agent_failures, alarms) has to tell these
+    apart, and the classification belongs HERE, where the message is produced,
+    rather than as a regex duplicated into TypeScript. On 2026-07-27 the prod
+    Morning Dispatch hit overflow twice, burned ~7 minutes retrying, and its
+    failure was indistinguishable from a crash.
+
+    Matches on the stable part of OpenClaw's wording ("context overflow" /
+    "prompt too large"); an unrecognized message keeps the generic class, so a
+    wording change degrades to today's behaviour rather than misclassifying.
+    """
+    lowered = (error_message or "").lower()
+    if "context overflow" in lowered or "prompt too large" in lowered:
+        return CONTEXT_OVERFLOW_ERROR_CLASS
+    return "OpenClawChatError"
+
+
 def _frame_failed_partial(partial: str) -> str:
     """Wrap a failed/degraded turn so it is never presented as a clean answer.
 
@@ -755,10 +786,14 @@ class OpenClawAdapter(HarnessAdapter):
                             # initialization conflicted" surfaces, so recording
                             # it is what makes the session-conflict class of
                             # failure visible in agent_failures / the alarm.
+                            # Context overflow gets its own class so the caller
+                            # can recover it (fresh session) instead of
+                            # treating it as a crash. See _classify_chat_error.
+                            err_class = _classify_chat_error(str(err_msg))
                             record_failure(
                                 source="harness",
                                 severity="error",
-                                error_class="OpenClawChatError",
+                                error_class=err_class,
                                 error_message=str(err_msg),
                                 session_id=session_id,
                                 model=observed_model or model_override,
@@ -784,7 +819,7 @@ class OpenClawAdapter(HarnessAdapter):
                                 messages=messages_log,
                                 tool_calls=tool_calls,
                                 failed=True,
-                                error_class="OpenClawChatError",
+                                error_class=err_class,
                             )
 
                         elif state == "aborted":

--- a/infra/agent-image/test_harness_adapter.py
+++ b/infra/agent-image/test_harness_adapter.py
@@ -258,5 +258,76 @@ class TestEmptyTurnNudge(unittest.TestCase):
         self.assertIn("Do not", n)
 
 
+class ChatErrorClassificationTests(unittest.TestCase):
+    """Context overflow must be distinguishable from a genuine crash.
+
+    Every chat-channel error used to arrive as the same OpenClawChatError, with
+    the distinguishing detail buried in free text. That conflation is why the
+    prod Morning Dispatch could not be recovered on 2026-07-27: an overflow —
+    which is fixable by starting a fresh session — looked exactly like a fault
+    that must not be auto-retried.
+
+    Downstream, agent-cron promotes ContextOverflow into a background RESTART
+    and leaves OpenClawChatError alone. Misclassifying in either direction is
+    costly: a missed overflow fails the task silently every morning, and an
+    over-eager match hands real crashes a two-hour retry budget.
+    """
+
+    def test_recognizes_the_message_prod_actually_emitted(self):
+        # Verbatim from the 2026-07-27 prod failure.
+        message = (
+            "Context overflow: prompt too large for the model. Try /reset "
+            "(or /new) to start a fresh session, or use a larger-context model."
+        )
+        self.assertEqual(
+            harness_adapter._classify_chat_error(message),
+            harness_adapter.CONTEXT_OVERFLOW_ERROR_CLASS,
+        )
+
+    def test_matches_either_stable_phrase_case_insensitively(self):
+        for message in (
+            "Context overflow",
+            "context overflow (mid-turn precheck)",
+            "prompt too large for the model",
+            "PROMPT TOO LARGE",
+        ):
+            self.assertEqual(
+                harness_adapter._classify_chat_error(message),
+                harness_adapter.CONTEXT_OVERFLOW_ERROR_CLASS,
+                f"should classify as overflow: {message!r}",
+            )
+
+    def test_leaves_every_other_failure_generic(self):
+        # These MUST NOT become promotable — each is a real fault where an
+        # automatic two-hour retry is the wrong answer.
+        for message in (
+            "reply session initialization conflicted",
+            "websocket closed unexpectedly",
+            "tool_search_code timed out",
+            "AccessDeniedException calling InvokeModel",
+            "",
+        ):
+            self.assertEqual(
+                harness_adapter._classify_chat_error(message),
+                "OpenClawChatError",
+                f"should stay generic: {message!r}",
+            )
+
+    def test_degrades_to_generic_rather_than_raising(self):
+        # A None/odd message must not take down error handling itself — this
+        # runs on the failure path, where raising would mask the real error.
+        self.assertEqual(
+            harness_adapter._classify_chat_error(None),
+            "OpenClawChatError",
+        )
+
+    def test_class_name_matches_the_typescript_consumer(self):
+        # agent-cron/job-promotion.ts keys promotion off this exact literal.
+        # A rename here silently stops every scheduled restart.
+        self.assertEqual(
+            harness_adapter.CONTEXT_OVERFLOW_ERROR_CLASS, "ContextOverflow"
+        )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/infra/lambdas/agent-cron/index.ts
+++ b/infra/lambdas/agent-cron/index.ts
@@ -34,7 +34,11 @@ import { defaultProvider } from '@aws-sdk/credential-provider-node';
 import { HttpRequest } from '@smithy/protocol-http';
 import type { Context as LambdaContext } from 'aws-lambda';
 import { resolveAbortMs, resolveTurnDeadlineS } from './turn-deadline';
-import { buildJobPayload, shouldPromoteToJob } from './job-promotion';
+import {
+  buildJobPayload,
+  promotionReason,
+  type PromotionReason,
+} from './job-promotion';
 import * as chatPkg from '@googleapis/chat';
 import * as crypto from 'crypto';
 import { RDSDataClient, ExecuteStatementCommand } from '@aws-sdk/client-rds-data';
@@ -646,6 +650,7 @@ async function promoteScheduledTurnToJob(
     spaceName: string;
     originalPrompt: string;
     scheduleName: string;
+    reason: PromotionReason;
   },
   log: Logger,
 ): Promise<boolean> {
@@ -665,6 +670,7 @@ async function promoteScheduledTurnToJob(
   try {
     const payload = buildJobPayload({
       sessionId: input.sessionId,
+      reason: input.reason,
       lockToken,
       runtimeId: input.runtimeId,
       userEmail: input.userEmail,
@@ -710,6 +716,7 @@ async function promoteScheduledTurnToJob(
       // Stable marker for the BackgroundPromotion metric filter (#1161).
       marker: 'BACKGROUND_PROMOTION',
       source: 'cron',
+      reason: input.reason,
       scheduleName: input.scheduleName,
       sessionId: input.sessionId,
       taskArn: result.tasks?.[0]?.taskArn ?? 'unknown',
@@ -982,16 +989,21 @@ export async function handler(
     () => context.getRemainingTimeInMillis(),
   );
 
-  // The turn ran out of clock rather than breaking. Hand it to the background
-  // job-runner instead of delivering a partial: Lambda's 15-minute ceiling is
-  // an AWS hard limit, so this is the only path by which a longer scheduled
-  // task can ever finish. The runner resumes the SAME session with a 2-hour
-  // deadline and posts the finished answer itself.
+  // The turn failed in a RECOVERABLE way. Hand it to the background job-runner
+  // instead of delivering a partial: Lambda's 15-minute ceiling is an AWS hard
+  // limit, so this is the only path by which a longer scheduled task can ever
+  // finish.
   //
-  // Only reachable because the Lambda now sends an explicit deadline_s
-  // (turn-deadline.ts). Before that its own abort always fired first, so the
-  // harness never reported a deadline and this branch could never be taken.
-  if (shouldPromoteToJob(result.errorClass)) {
+  // Two recoverable shapes, handled differently by the runner:
+  //   deadline         — ran out of clock. Resume the same session.
+  //   context-overflow — the transcript outgrew the model window. Restart in a
+  //                      fresh session; resuming would re-overflow immediately.
+  //
+  // The deadline case is only reachable because the Lambda now sends an
+  // explicit deadline_s (turn-deadline.ts). Before that its own abort always
+  // fired first, so the harness never reported a deadline at all.
+  const promoteReason = promotionReason(result.errorClass);
+  if (promoteReason !== null) {
     const runtimeId = await getRuntimeId(log);
     const promoted = runtimeId
       ? await promoteScheduledTurnToJob(
@@ -1004,6 +1016,7 @@ export async function handler(
             spaceName: schedule.dmSpaceName,
             originalPrompt: schedule.prompt,
             scheduleName,
+            reason: promoteReason,
           },
           log,
         )
@@ -1014,9 +1027,17 @@ export async function handler(
       // is NOT fatal — the job is already running and will post the real
       // answer; failing the invocation would misreport a healthy handoff.
       try {
+        // Distinct wording per reason. A restart is NOT the same promise as a
+        // continuation: it discards the previous attempt's work, so telling
+        // the owner "I've moved it to a background job" would overstate what
+        // is being carried over.
+        const ack =
+          promoteReason === 'context-overflow'
+            ? "⏳ This run grew too large to finish in one pass, so I'm starting it over in the background with a longer budget. I'll post the result here when it's done."
+            : "⏳ This is taking longer than one pass allows — I've moved it to a background job and will post the result here when it's done.";
         await sendChatMessage(
           schedule.dmSpaceName,
-          `📋 **${scheduleName}**\n\n⏳ This is taking longer than one pass allows — I've moved it to a background job and will post the result here when it's done.`,
+          `📋 **${scheduleName}**\n\n${ack}`,
           log,
         );
       } catch (error) {

--- a/infra/lambdas/agent-cron/job-promotion.ts
+++ b/infra/lambdas/agent-cron/job-promotion.ts
@@ -112,6 +112,13 @@ export interface JobPayload {
 
 const PROMPT_EXCERPT_MAX = 2000;
 
+/**
+ * RunTask caps the ENTIRE container-override payload at 8 KiB. Enforced here so
+ * an oversized job fails at build time, where the caller can fall back, rather
+ * than at launch with an opaque RunTask rejection.
+ */
+const MAX_PAYLOAD_BYTES = 8 * 1024;
+
 export function buildJobPayload(input: {
   sessionId: string;
   reason?: PromotionReason;
@@ -136,7 +143,24 @@ export function buildJobPayload(input: {
     spaceName: input.spaceName,
     ...(input.threadName ? { threadName: input.threadName } : {}),
     isDM: input.isDM,
-    promptExcerpt: (input.originalPrompt || '').slice(0, PROMPT_EXCERPT_MAX),
+    // A CONTINUATION resumes a session whose transcript already holds the full
+    // request, so an excerpt is context garnish. A RESTART has no transcript —
+    // a truncated prompt there means the agent silently executes an incomplete
+    // request, which is worse than not restarting at all. Schedule validation
+    // accepts prompts up to 20,000 chars, well past the old 2,000 cap.
+    promptExcerpt:
+      input.reason === 'context-overflow'
+        ? input.originalPrompt || ''
+        : (input.originalPrompt || '').slice(0, PROMPT_EXCERPT_MAX),
   };
-  return JSON.stringify(payload);
+  const serialized = JSON.stringify(payload);
+  if (Buffer.byteLength(serialized, 'utf8') > MAX_PAYLOAD_BYTES) {
+    // Deliberately fatal rather than truncating back down: the caller catches
+    // this and posts the partial instead. Restarting with half the
+    // instructions would look like success and produce the wrong work.
+    throw new Error(
+      `JOB_PAYLOAD exceeds the ${MAX_PAYLOAD_BYTES}-byte RunTask override cap`
+    );
+  }
+  return serialized;
 }

--- a/infra/lambdas/agent-cron/job-promotion.ts
+++ b/infra/lambdas/agent-cron/job-promotion.ts
@@ -41,9 +41,46 @@ const DEADLINE_ERROR_CLASSES = new Set([
   'ChatDeadlineExpiredPartial',
 ]);
 
+/**
+ * Context overflow — the transcript outgrew the model's window.
+ *
+ * Classified in the container (harness_adapter._classify_chat_error) rather
+ * than by matching text here, because the wording lives with the code that
+ * produces it.
+ */
+const CONTEXT_OVERFLOW_ERROR_CLASS = 'ContextOverflow';
+
+/**
+ * Why a turn is being promoted. The two reasons need OPPOSITE handling in the
+ * runner, which is why this is carried rather than re-derived:
+ *
+ *   deadline         — the turn ran out of clock with a healthy transcript.
+ *                      RESUME the same session; the work in progress is the
+ *                      whole point.
+ *   context-overflow — the transcript itself is the problem. Resuming it is
+ *                      guaranteed to overflow again, so the runner must start
+ *                      a FRESH session from the original request.
+ */
+export type PromotionReason = 'deadline' | 'context-overflow';
+
+/**
+ * Why this failed turn should be promoted, or null to leave it alone.
+ *
+ * Deliberately NOT keyed on the generic OpenClawChatError: promoting that
+ * would hand genuine crashes a two-hour retry budget.
+ */
+export function promotionReason(
+  errorClass: string | undefined
+): PromotionReason | null {
+  if (!errorClass) return null;
+  if (DEADLINE_ERROR_CLASSES.has(errorClass)) return 'deadline';
+  if (errorClass === CONTEXT_OVERFLOW_ERROR_CLASS) return 'context-overflow';
+  return null;
+}
+
 /** True when a failed scheduled turn should be promoted to a background job. */
 export function shouldPromoteToJob(errorClass: string | undefined): boolean {
-  return !!errorClass && DEADLINE_ERROR_CLASSES.has(errorClass);
+  return promotionReason(errorClass) !== null;
 }
 
 /**
@@ -56,6 +93,12 @@ export function shouldPromoteToJob(errorClass: string | undefined): boolean {
  */
 export interface JobPayload {
   sessionId: string;
+  /**
+   * Why the turn was promoted. Optional so a payload written by an older cron
+   * build still parses; the runner defaults it to 'deadline', which is the
+   * behaviour that existed before this field.
+   */
+  reason?: PromotionReason;
   lockToken: string;
   runtimeId: string;
   userEmail: string;
@@ -71,6 +114,7 @@ const PROMPT_EXCERPT_MAX = 2000;
 
 export function buildJobPayload(input: {
   sessionId: string;
+  reason?: PromotionReason;
   lockToken: string;
   runtimeId: string;
   userEmail: string;
@@ -83,6 +127,7 @@ export function buildJobPayload(input: {
 }): string {
   const payload: JobPayload = {
     sessionId: input.sessionId,
+    ...(input.reason ? { reason: input.reason } : {}),
     lockToken: input.lockToken,
     runtimeId: input.runtimeId,
     userEmail: input.userEmail,

--- a/infra/lambdas/agent-router/job-main.ts
+++ b/infra/lambdas/agent-router/job-main.ts
@@ -22,8 +22,10 @@
 
 import {
   buildContinuationPrompt,
+  buildOverflowRestartPrompt,
   JOB_DEADLINE_S,
   parseJobPayload,
+  restartSessionId,
 } from './job-promotion';
 import {
   createLogger,
@@ -78,8 +80,28 @@ async function main(): Promise<number> {
     throw error;
   }
 
+  // A context-overflow promotion must NOT resume the session it came from.
+  // AgentCore sticky-routes by session id, so resuming would hand this leg the
+  // exact transcript that outgrew the model window — it would re-overflow on
+  // the first model call, having spent a Fargate cold start to get there.
+  // Restart in a fresh session from the original request instead.
+  //
+  // The lock stays on the ORIGINAL session id: that is what the router checks
+  // to answer "still working on your earlier task", and what cron acquired
+  // before launching this task.
+  const isRestart = job.reason === 'context-overflow';
+  const invokeSessionId = isRestart
+    ? restartSessionId(job.sessionId)
+    : job.sessionId;
+  const prompt = isRestart
+    ? buildOverflowRestartPrompt(job.promptExcerpt)
+    : buildContinuationPrompt(job.promptExcerpt);
+
   log.info('Background job started', {
     sessionId: job.sessionId,
+    invokeSessionId,
+    reason: job.reason ?? 'deadline',
+    restart: isRestart,
     userEmail: job.userEmail,
     space: job.spaceName,
     deadlineS: JOB_DEADLINE_S,
@@ -94,9 +116,9 @@ async function main(): Promise<number> {
   const startTime = Date.now();
   try {
     const agentResult = await invokeAgentCore(
-      buildContinuationPrompt(job.promptExcerpt),
+      prompt,
       job.userEmail,
-      job.sessionId,
+      invokeSessionId,
       log,
       {
         displayName: job.displayName,

--- a/infra/lambdas/agent-router/job-main.ts
+++ b/infra/lambdas/agent-router/job-main.ts
@@ -91,7 +91,7 @@ async function main(): Promise<number> {
   // before launching this task.
   const isRestart = job.reason === 'context-overflow';
   const invokeSessionId = isRestart
-    ? restartSessionId(job.sessionId)
+    ? restartSessionId(job.sessionId, job.lockToken)
     : job.sessionId;
   const prompt = isRestart
     ? buildOverflowRestartPrompt(job.promptExcerpt)

--- a/infra/lambdas/agent-router/job-promotion.ts
+++ b/infra/lambdas/agent-router/job-promotion.ts
@@ -37,9 +37,25 @@ export function shouldPromoteToJob(errorClass: string | undefined): boolean {
  * its OpenClaw history; the excerpt is context garnish for the continuation
  * message, not the source of truth).
  */
+/**
+ * Why a turn was promoted. Drives OPPOSITE handling in the runner:
+ *
+ *   deadline         — ran out of clock with a healthy transcript. RESUME the
+ *                      same session; the work in progress is the whole point.
+ *   context-overflow — the transcript itself outgrew the model window.
+ *                      Resuming it re-overflows on the first model call, so the
+ *                      runner starts a FRESH session from the original request.
+ *
+ * Absent on payloads written before this existed; treated as 'deadline', which
+ * is exactly the behaviour that predated it.
+ */
+export type PromotionReason = 'deadline' | 'context-overflow';
+
 export interface JobPayload {
   /** AgentCore session to resume (sticky-routes to the same microVM). */
   sessionId: string;
+  /** See PromotionReason. Defaults to 'deadline' when absent. */
+  reason?: PromotionReason;
   /** Session-lock token the router pre-acquired with kind='job'. */
   lockToken: string;
   /** Resolved AgentCore runtime id/ARN (runner skips the SSM lookup). */
@@ -59,6 +75,7 @@ const PROMPT_EXCERPT_MAX = 2000;
 
 export function buildJobPayload(input: {
   sessionId: string;
+  reason?: PromotionReason;
   lockToken: string;
   runtimeId: string;
   userEmail: string;
@@ -71,6 +88,7 @@ export function buildJobPayload(input: {
 }): string {
   const payload: JobPayload = {
     sessionId: input.sessionId,
+    ...(input.reason ? { reason: input.reason } : {}),
     lockToken: input.lockToken,
     runtimeId: input.runtimeId,
     userEmail: input.userEmail,
@@ -108,6 +126,11 @@ export function parseJobPayload(raw: string | undefined): JobPayload {
   };
   return {
     sessionId: requireString('sessionId'),
+    // Unknown/absent -> 'deadline'. A payload from an older cron build must
+    // keep resuming the session, not silently switch to a fresh one.
+    ...(obj.reason === 'context-overflow' || obj.reason === 'deadline'
+      ? { reason: obj.reason }
+      : {}),
     lockToken: requireString('lockToken'),
     runtimeId: requireString('runtimeId'),
     userEmail: requireString('userEmail'),
@@ -142,4 +165,54 @@ export function buildContinuationPrompt(promptExcerpt: string): string {
     'When everything is done, reply with the complete final answer for the ' +
     `user.${excerpt}`
   );
+}
+
+/**
+ * The message sent when restarting after a CONTEXT OVERFLOW.
+ *
+ * Deliberately NOT the continuation prompt. Continuation says "carry on from
+ * where you stopped", which is meaningless in a fresh session that has no
+ * history to carry on from — and worse, it invites the model to hunt for
+ * earlier work it cannot see.
+ *
+ * The tradeoff this makes explicit: the previous leg's tool calls are NOT in
+ * this session, so the model cannot verify what already ran. Side effects are
+ * therefore the real hazard on a restart, and the instruction leads with
+ * checking current state before re-doing anything that writes.
+ */
+export function buildOverflowRestartPrompt(promptExcerpt: string): string {
+  const request = promptExcerpt
+    ? `\n\nThe original request was:\n${promptExcerpt}`
+    : '';
+  return (
+    '[job-restart] Your previous attempt at this task grew too large for the ' +
+    'model context window and could not continue, so you are starting over ' +
+    'in a fresh session with a much longer time budget. You do NOT have the ' +
+    'earlier transcript.\n\n' +
+    'Two things matter:\n' +
+    '1. SIDE EFFECTS MAY ALREADY HAVE RUN. Before creating, sending, ' +
+    'sharing, or posting anything, check whether it already exists and skip ' +
+    'it if so.\n' +
+    '2. STAY SMALLER THIS TIME. Prefer fewer, more targeted tool calls, and ' +
+    'avoid re-reading large outputs you have already summarized — running ' +
+    'out of context is what ended the last attempt.\n\n' +
+    `When everything is done, reply with the complete final answer.${request}`
+  );
+}
+
+/**
+ * Session id for a restart leg.
+ *
+ * A fresh id is what actually discards the overflowing transcript — AgentCore
+ * sticky-routes by session, so reusing the id would hand the runner the very
+ * history that blew the window. Derived from the original (rather than random)
+ * so the restart stays traceable to the run that spawned it, and suffixed
+ * once: a restart of a restart keeps a single suffix rather than growing the
+ * id without bound, since AgentCore enforces a session-id length limit.
+ */
+export function restartSessionId(sessionId: string): string {
+  const base = sessionId.replace(/-r\d+$/, '');
+  const previous = /-r(\d+)$/.exec(sessionId);
+  const attempt = previous ? Number(previous[1]) + 1 : 2;
+  return `${base}-r${attempt}`;
 }

--- a/infra/lambdas/agent-router/job-promotion.ts
+++ b/infra/lambdas/agent-router/job-promotion.ts
@@ -73,6 +73,13 @@ export interface JobPayload {
 
 const PROMPT_EXCERPT_MAX = 2000;
 
+/**
+ * RunTask caps the ENTIRE container-override payload at 8 KiB. Enforced here so
+ * an oversized job fails at build time, where the caller can fall back, rather
+ * than at launch with an opaque RunTask rejection.
+ */
+const MAX_PAYLOAD_BYTES = 8 * 1024;
+
 export function buildJobPayload(input: {
   sessionId: string;
   reason?: PromotionReason;
@@ -97,9 +104,26 @@ export function buildJobPayload(input: {
     spaceName: input.spaceName,
     ...(input.threadName ? { threadName: input.threadName } : {}),
     isDM: input.isDM,
-    promptExcerpt: (input.originalPrompt || '').slice(0, PROMPT_EXCERPT_MAX),
+    // A CONTINUATION resumes a session whose transcript already holds the full
+    // request, so an excerpt is context garnish. A RESTART has no transcript —
+    // a truncated prompt there means the agent silently executes an incomplete
+    // request, which is worse than not restarting at all. Schedule validation
+    // accepts prompts up to 20,000 chars, well past the old 2,000 cap.
+    promptExcerpt:
+      input.reason === 'context-overflow'
+        ? input.originalPrompt || ''
+        : (input.originalPrompt || '').slice(0, PROMPT_EXCERPT_MAX),
   };
-  return JSON.stringify(payload);
+  const serialized = JSON.stringify(payload);
+  if (Buffer.byteLength(serialized, 'utf8') > MAX_PAYLOAD_BYTES) {
+    // Deliberately fatal rather than truncating back down: the caller catches
+    // this and posts the partial instead. Restarting with half the
+    // instructions would look like success and produce the wrong work.
+    throw new Error(
+      `JOB_PAYLOAD exceeds the ${MAX_PAYLOAD_BYTES}-byte RunTask override cap`
+    );
+  }
+  return serialized;
 }
 
 /**
@@ -201,18 +225,26 @@ export function buildOverflowRestartPrompt(promptExcerpt: string): string {
 }
 
 /**
- * Session id for a restart leg.
+ * Session id for a restart leg — unique per PROMOTION, not per day.
  *
- * A fresh id is what actually discards the overflowing transcript — AgentCore
- * sticky-routes by session, so reusing the id would hand the runner the very
- * history that blew the window. Derived from the original (rather than random)
- * so the restart stays traceable to the run that spawned it, and suffixed
- * once: a restart of a restart keeps a single suffix rather than growing the
- * id without bound, since AgentCore enforces a session-id length limit.
+ * A fresh id is what actually discards the overflowing transcript: AgentCore
+ * sticky-routes by session, so reusing the id hands the runner the very history
+ * that blew the window.
+ *
+ * The uniqueness has to come from the lock token, not a counter. A scheduled
+ * session id is date-based and STABLE for the whole UTC day
+ * (`…-sched-<id>-2026-07-27`), and cron always passes that original id — never
+ * a previously derived one. So an incrementing suffix returns the same value on
+ * every promotion that day: a task overflowing twice would sticky-route the
+ * second restart straight into the first restart's transcript, re-overflowing
+ * or blending two separate runs. The lock token is a fresh UUID per promotion,
+ * which makes each restart distinct while staying deterministic for tests.
+ *
+ * Suffix replaced rather than appended, and bounded to 8 hex chars, because
+ * AgentCore enforces a session-id length limit.
  */
-export function restartSessionId(sessionId: string): string {
-  const base = sessionId.replace(/-r\d+$/, '');
-  const previous = /-r(\d+)$/.exec(sessionId);
-  const attempt = previous ? Number(previous[1]) + 1 : 2;
-  return `${base}-r${attempt}`;
+export function restartSessionId(sessionId: string, lockToken: string): string {
+  const base = sessionId.replace(/-r[0-9a-f]{1,12}$/i, '');
+  const unique = (lockToken || '').replace(/[^0-9a-f]/gi, '').slice(0, 8).toLowerCase();
+  return `${base}-r${unique || '0'}`;
 }

--- a/tests/unit/agent-cron-job-promotion.test.ts
+++ b/tests/unit/agent-cron-job-promotion.test.ts
@@ -20,11 +20,14 @@ import fs from "node:fs"
 import path from "node:path"
 import {
   buildJobPayload as buildFromCron,
+  promotionReason,
   shouldPromoteToJob as shouldPromoteFromCron,
 } from "../../infra/lambdas/agent-cron/job-promotion"
 import {
   buildJobPayload as buildFromRouter,
+  buildOverflowRestartPrompt,
   parseJobPayload,
+  restartSessionId,
   shouldPromoteToJob as shouldPromoteFromRouter,
 } from "../../infra/lambdas/agent-router/job-promotion"
 import { stripComments } from "../helpers/strip-ts-comments"
@@ -72,7 +75,7 @@ describe("cron job promotion", () => {
       expect(buildFromCron(baseInput)).toBe(buildFromRouter(baseInput))
     })
 
-    it("agrees with the router on which errors are promotable", () => {
+    it("agrees with the router on the deadline classes", () => {
       // Two copies of the same error-class set. If the router gains a class
       // and cron does not, scheduled tasks silently stop being promoted.
       for (const cls of [
@@ -85,6 +88,25 @@ describe("cron job promotion", () => {
       ]) {
         expect(shouldPromoteFromCron(cls)).toBe(shouldPromoteFromRouter(cls))
       }
+    })
+
+    it("INTENTIONALLY diverges from the router on context overflow", () => {
+      // Pinned rather than omitted, because the test above exists to catch
+      // exactly this kind of drift and would otherwise be routed around.
+      //
+      // Scheduled tasks restart on overflow: nobody is watching, the request
+      // is fully described by the stored schedule prompt, and the alternative
+      // is a silent failure every morning.
+      //
+      // Interactive turns do NOT, deliberately. A restart discards the user's
+      // conversation, and they are right there — they can /reset or rephrase,
+      // and they can see that something went wrong. Silently throwing away a
+      // chat history to retry is worse than telling them it failed.
+      //
+      // If interactive restart is ever wanted, change the router AND this
+      // test together.
+      expect(shouldPromoteFromCron("ContextOverflow")).toBe(true)
+      expect(shouldPromoteFromRouter("ContextOverflow")).toBe(false)
     })
 
     it("stays inside the 8 KiB RunTask override cap", () => {
@@ -100,20 +122,140 @@ describe("cron job promotion", () => {
   })
 
   describe("promotion decision", () => {
-    it("promotes only deadline expiry, not real failures", () => {
+    it("promotes recoverable failures, not real ones", () => {
       // Promoting a genuine error would re-run a broken turn for two hours.
       expect(shouldPromoteFromCron("ChatDeadlineExpired")).toBe(true)
       expect(shouldPromoteFromCron("ChatDeadlineExpiredPartial")).toBe(true)
+      expect(shouldPromoteFromCron("ContextOverflow")).toBe(true)
 
-      // The class the 2026-07-27 dispatch actually produced under the old
-      // fixed-deadline code. It is NOT promotable — which is precisely why
-      // the deadline fix had to land first: without an explicit deadline_s
-      // the harness never reports expiry, so promotion can never trigger.
+      // The GENERIC chat error must stay unpromotable. Context overflow used
+      // to arrive under this class, and the temptation is to promote it to
+      // cover the overflow case — which would hand every genuine crash a
+      // two-hour retry budget. The container classifies overflow separately
+      // (harness_adapter._classify_chat_error) precisely so this can stay no.
       expect(shouldPromoteFromCron("OpenClawChatError")).toBe(false)
 
       expect(shouldPromoteFromCron("InvocationContextInvalid")).toBe(false)
       expect(shouldPromoteFromCron(undefined)).toBe(false)
       expect(shouldPromoteFromCron("")).toBe(false)
+    })
+
+    it("distinguishes the two recoverable reasons", () => {
+      // The reason drives OPPOSITE runner behaviour — resume vs restart — so
+      // conflating them silently either re-overflows or throws away work.
+      expect(promotionReason("ChatDeadlineExpired")).toBe("deadline")
+      expect(promotionReason("ChatDeadlineExpiredPartial")).toBe("deadline")
+      expect(promotionReason("ContextOverflow")).toBe("context-overflow")
+      expect(promotionReason("OpenClawChatError")).toBeNull()
+      expect(promotionReason(undefined)).toBeNull()
+    })
+
+    it("carries the reason through to the runner's parser", () => {
+      const overflow = parseJobPayload(
+        buildFromCron({ ...baseInput, reason: "context-overflow" }),
+      )
+      expect(overflow.reason).toBe("context-overflow")
+
+      const deadline = parseJobPayload(
+        buildFromCron({ ...baseInput, reason: "deadline" }),
+      )
+      expect(deadline.reason).toBe("deadline")
+    })
+
+    it("defaults a reason-less payload to deadline, not restart", () => {
+      // Back-compat with a payload written by an older cron build. Guessing
+      // 'context-overflow' here would silently discard in-progress work.
+      const parsed = parseJobPayload(buildFromCron(baseInput))
+      expect(parsed.reason).toBeUndefined()
+
+      const garbage = parseJobPayload(
+        JSON.stringify({ ...JSON.parse(buildFromCron(baseInput)), reason: "nonsense" }),
+      )
+      expect(garbage.reason).toBeUndefined()
+    })
+  })
+
+  describe("cross-language error-class contract", () => {
+    it("matches the class name the container actually emits", () => {
+      // The promotion decision is made in TypeScript from a string produced in
+      // Python. Nothing at build time links them, so a rename on either side
+      // silently stops every scheduled restart — the failure would show up as
+      // the Morning Dispatch quietly failing again, weeks later.
+      const harness = fs.readFileSync(
+        path.join(process.cwd(), "infra/agent-image/harness_adapter.py"),
+        "utf8",
+      )
+      const declared = /CONTEXT_OVERFLOW_ERROR_CLASS\s*=\s*"([^"]+)"/.exec(harness)
+
+      expect(declared).not.toBeNull()
+      expect(declared?.[1]).toBe("ContextOverflow")
+      // And that literal is what actually triggers promotion.
+      expect(promotionReason(declared?.[1])).toBe("context-overflow")
+    })
+
+    it("classifies overflow separately from the generic chat error", () => {
+      // Guards the Python side's whole reason for existing: if the classifier
+      // were removed and overflow went back to OpenClawChatError, promotion
+      // would stop and this catches it.
+      const harness = fs.readFileSync(
+        path.join(process.cwd(), "infra/agent-image/harness_adapter.py"),
+        "utf8",
+      )
+      expect(harness).toContain("def _classify_chat_error")
+      expect(harness).toContain("error_class=err_class")
+    })
+  })
+
+  describe("restart session ids", () => {
+    it("derives a fresh id so the overflowing transcript is discarded", () => {
+      // AgentCore sticky-routes by session id. Reusing it would hand the
+      // runner the exact history that blew the context window.
+      const original = "hagelk-db0f32b5-sched-5123b45b-2026-07-27"
+      expect(restartSessionId(original)).toBe(`${original}-r2`)
+      expect(restartSessionId(original)).not.toBe(original)
+    })
+
+    it("keeps a single suffix across repeated restarts", () => {
+      // AgentCore enforces a session-id length limit, so the suffix must not
+      // accumulate (…-r2-r3-r4) on a task that overflows repeatedly.
+      const first = restartSessionId("task-2026-07-27")
+      const second = restartSessionId(first)
+      const third = restartSessionId(second)
+
+      expect(second).toBe("task-2026-07-27-r3")
+      expect(third).toBe("task-2026-07-27-r4")
+      expect(third.match(/-r\d+/g)).toHaveLength(1)
+    })
+
+    it("stays traceable to the run that spawned it", () => {
+      // Derived rather than random, so a restart in the logs can be tied back
+      // to the original scheduled run.
+      expect(restartSessionId("abc-2026-07-27")).toContain("abc-2026-07-27")
+    })
+  })
+
+  describe("restart prompt", () => {
+    it("does not tell a fresh session to continue from nowhere", () => {
+      // The continuation prompt says "carry on from where you stopped", which
+      // is meaningless without the transcript and invites the model to hunt
+      // for work it cannot see.
+      const restart = buildOverflowRestartPrompt("Assemble the morning dispatch.")
+      expect(restart).toContain("[job-restart]")
+      expect(restart).not.toContain("Continue the task from where you stopped")
+    })
+
+    it("warns about side effects it can no longer verify", () => {
+      // THE hazard of restarting: the previous leg's tool calls are not in
+      // this session, so the model cannot see what already ran.
+      const restart = buildOverflowRestartPrompt("do the thing")
+      expect(restart).toMatch(/side effects/i)
+      expect(restart).toMatch(/already/i)
+    })
+
+    it("carries the original request, since history will not", () => {
+      expect(buildOverflowRestartPrompt("Assemble the morning dispatch.")).toContain(
+        "Assemble the morning dispatch.",
+      )
     })
   })
 

--- a/tests/unit/agent-cron-job-promotion.test.ts
+++ b/tests/unit/agent-cron-job-promotion.test.ts
@@ -109,15 +109,53 @@ describe("cron job promotion", () => {
       expect(shouldPromoteFromRouter("ContextOverflow")).toBe(false)
     })
 
-    it("stays inside the 8 KiB RunTask override cap", () => {
-      // AWS caps the total container-override payload. A long prompt must be
-      // truncated by the builder, not rejected by RunTask at launch.
+    it("truncates a CONTINUATION prompt and stays inside the 8 KiB cap", () => {
+      // AWS caps the total container-override payload. A continuation resumes
+      // a session whose transcript already holds the full request, so an
+      // excerpt is only context garnish.
       const payload = buildFromCron({
         ...baseInput,
         originalPrompt: "x".repeat(50_000),
       })
       expect(Buffer.byteLength(payload, "utf8")).toBeLessThan(8 * 1024)
       expect(parseJobPayload(payload).promptExcerpt.length).toBe(2000)
+    })
+
+    it("carries a RESTART prompt in full, past the excerpt cap", () => {
+      // A restart has NO transcript to supply the omitted half. Schedule
+      // validation accepts up to 20,000 chars, so truncating to 2,000 would
+      // let an overflowed task silently execute an incomplete request —
+      // which looks like success and produces the wrong work.
+      const prompt = "y".repeat(5_000)
+      const parsed = parseJobPayload(
+        buildFromCron({
+          ...baseInput,
+          reason: "context-overflow",
+          originalPrompt: prompt,
+        }),
+      )
+
+      expect(parsed.promptExcerpt).toBe(prompt)
+      expect(parsed.promptExcerpt.length).toBe(5_000)
+    })
+
+    it("refuses to build a restart that would not fit, rather than truncating", () => {
+      // Falling back to a truncated restart would be the silent-wrong-work
+      // failure again. The caller catches this and posts the partial instead.
+      expect(() =>
+        buildFromCron({
+          ...baseInput,
+          reason: "context-overflow",
+          originalPrompt: "z".repeat(20_000),
+        }),
+      ).toThrow(/RunTask override cap/)
+    })
+
+    it("keeps continuation payloads buildable no matter the prompt size", () => {
+      // The cap must never break the deadline path, which truncates first.
+      expect(() =>
+        buildFromCron({ ...baseInput, originalPrompt: "z".repeat(100_000) }),
+      ).not.toThrow()
     })
   })
 
@@ -207,30 +245,51 @@ describe("cron job promotion", () => {
   })
 
   describe("restart session ids", () => {
+    const original = "hagelk-db0f32b5-sched-5123b45b-2026-07-27"
+
     it("derives a fresh id so the overflowing transcript is discarded", () => {
       // AgentCore sticky-routes by session id. Reusing it would hand the
       // runner the exact history that blew the context window.
-      const original = "hagelk-db0f32b5-sched-5123b45b-2026-07-27"
-      expect(restartSessionId(original)).toBe(`${original}-r2`)
-      expect(restartSessionId(original)).not.toBe(original)
+      const restart = restartSessionId(original, "aaaaaaaa-1111-2222-3333-444444444444")
+      expect(restart).not.toBe(original)
+      expect(restart.startsWith(original)).toBe(true)
     })
 
-    it("keeps a single suffix across repeated restarts", () => {
-      // AgentCore enforces a session-id length limit, so the suffix must not
-      // accumulate (…-r2-r3-r4) on a task that overflows repeatedly.
-      const first = restartSessionId("task-2026-07-27")
-      const second = restartSessionId(first)
-      const third = restartSessionId(second)
+    it("is unique per PROMOTION, not per day", () => {
+      // THE BUG THIS REPLACED. A scheduled session id is date-based and stable
+      // for the whole UTC day, and cron always passes that original id — never
+      // a derived one. A counter-based suffix therefore returned the SAME
+      // "-r2" on every promotion that day, so a task overflowing twice would
+      // sticky-route the second restart into the first restart's transcript.
+      const first = restartSessionId(original, "11111111-aaaa-bbbb-cccc-dddddddddddd")
+      const second = restartSessionId(original, "22222222-aaaa-bbbb-cccc-dddddddddddd")
 
-      expect(second).toBe("task-2026-07-27-r3")
-      expect(third).toBe("task-2026-07-27-r4")
-      expect(third.match(/-r\d+/g)).toHaveLength(1)
+      expect(first).not.toBe(second)
+    })
+
+    it("replaces the suffix rather than accumulating it", () => {
+      // AgentCore enforces a session-id length limit, so a repeatedly
+      // overflowing task must not grow the id without bound.
+      const first = restartSessionId(original, "11111111-aaaa-bbbb-cccc-dddddddddddd")
+      const second = restartSessionId(first, "22222222-aaaa-bbbb-cccc-dddddddddddd")
+
+      expect(second.match(/-r[0-9a-f]+/g)).toHaveLength(1)
+      expect(second.length).toBeLessThanOrEqual(first.length)
     })
 
     it("stays traceable to the run that spawned it", () => {
       // Derived rather than random, so a restart in the logs can be tied back
       // to the original scheduled run.
-      expect(restartSessionId("abc-2026-07-27")).toContain("abc-2026-07-27")
+      expect(restartSessionId(original, "abcdef01-0000-0000-0000-000000000000")).toContain(
+        "sched-5123b45b-2026-07-27",
+      )
+    })
+
+    it("never returns a bare base id, even on a malformed token", () => {
+      // Falling back to the original id would silently resume the overflowing
+      // session — the exact failure this function exists to prevent.
+      expect(restartSessionId(original, "")).not.toBe(original)
+      expect(restartSessionId(original, "!!!!")).not.toBe(original)
     })
   })
 

--- a/tests/unit/agent-job-runner-restart.test.ts
+++ b/tests/unit/agent-job-runner-restart.test.ts
@@ -1,0 +1,77 @@
+/**
+ * The job runner must not resume a session that overflowed.
+ *
+ * AgentCore sticky-routes by session id, so a context-overflow promotion that
+ * reuses the id hands the runner the exact transcript that outgrew the model
+ * window. It would re-overflow on the first model call, having spent a Fargate
+ * cold start to get there — the failure the promotion was supposed to fix.
+ *
+ * These assertions read job-main.ts source rather than executing it: the module
+ * runs main() on import and pulls in the whole router bundle (postgres, Google
+ * Chat, AWS SDK), which is not loadable under jest. Reading source is a weaker
+ * check than executing, so each assertion is paired with the behavioural test
+ * of the pure helper it depends on in agent-cron-job-promotion.test.ts.
+ */
+
+import fs from "node:fs"
+import path from "node:path"
+import { stripComments } from "../helpers/strip-ts-comments"
+
+const source = stripComments(
+  fs.readFileSync(
+    path.join(process.cwd(), "infra/lambdas/agent-router/job-main.ts"),
+    "utf8",
+  ),
+)
+
+describe("job runner restart handling", () => {
+  it("reads real, comment-stripped source (parser guard)", () => {
+    expect(source).toContain("parseJobPayload")
+    expect(source).toContain("invokeAgentCore")
+  })
+
+  it("branches on the promotion reason", () => {
+    expect(source).toContain("job.reason === 'context-overflow'")
+  })
+
+  it("invokes with the RESTART session id, never the original, on overflow", () => {
+    // The load-bearing line. Passing job.sessionId here is the whole bug.
+    expect(source).toContain("restartSessionId(job.sessionId)")
+    expect(source).toContain("invokeSessionId")
+
+    // The invoke must use the derived id.
+    const invokeCall = source.slice(
+      source.indexOf("await invokeAgentCore("),
+      source.indexOf("await invokeAgentCore(") + 200,
+    )
+    expect(invokeCall).toContain("invokeSessionId")
+    expect(invokeCall).not.toContain("job.sessionId")
+  })
+
+  it("sends the restart prompt, not the continuation prompt, on overflow", () => {
+    // "Continue from where you stopped" is meaningless in a fresh session and
+    // invites the model to hunt for work it cannot see.
+    expect(source).toContain("buildOverflowRestartPrompt(job.promptExcerpt)")
+    expect(source).toContain("buildContinuationPrompt(job.promptExcerpt)")
+  })
+
+  it("keeps the lock on the ORIGINAL session id", () => {
+    // The lock is what cron acquired before launching, and what the router
+    // checks to answer "still working on your earlier task". Moving it to the
+    // restart id would strand the original lock until its 14-minute TTL.
+    for (const call of [
+      "renewSessionLock(job.sessionId",
+      "releaseSessionLock(job.sessionId",
+    ]) {
+      expect(source).toContain(call)
+    }
+    expect(source).not.toContain("renewSessionLock(invokeSessionId")
+    expect(source).not.toContain("releaseSessionLock(invokeSessionId")
+  })
+
+  it("still delivers to Chat on the restart path", () => {
+    // A restart that finishes silently is indistinguishable from one that
+    // died. The runner's "always post something" contract must survive.
+    expect(source).toContain("sendGoogleChatResponse")
+  })
+})

--- a/tests/unit/agent-job-runner-restart.test.ts
+++ b/tests/unit/agent-job-runner-restart.test.ts
@@ -36,7 +36,7 @@ describe("job runner restart handling", () => {
 
   it("invokes with the RESTART session id, never the original, on overflow", () => {
     // The load-bearing line. Passing job.sessionId here is the whole bug.
-    expect(source).toContain("restartSessionId(job.sessionId)")
+    expect(source).toContain("restartSessionId(job.sessionId, job.lockToken)")
     expect(source).toContain("invokeSessionId")
 
     // The invoke must use the derived id.


### PR DESCRIPTION
Closes the hole left by #1384: promotion fired only on `ChatDeadlineExpired`, but the prod Morning Dispatch fails with **context overflow**. That arrived as the generic `OpenClawChatError`, which is deliberately not promotable — so the one failure mode actually killing the dispatch was the one promotion could not catch.

## Why resuming isn't enough

The obvious fix — make `OpenClawChatError` promotable — is wrong twice over. It would hand every genuine crash a two-hour retry budget, **and it wouldn't work**: AgentCore sticky-routes by session id, so resuming hands the runner the exact transcript that outgrew the model window. It re-overflows on the first model call, having spent a Fargate cold start to get there.

Overflow needs the opposite treatment from a deadline:

| Reason | Meaning | Runner |
|---|---|---|
| `deadline` | healthy transcript, ran out of clock | **resume** — the in-progress work is the point |
| `context-overflow` | the transcript *is* the problem | **restart** in a fresh session |

## Changes

- **`harness_adapter.py`** — `_classify_chat_error()` names `ContextOverflow` separately. The classification lives where the message is produced, not as a regex duplicated into TypeScript. Unrecognized wording keeps the generic class, so a message change degrades to today's behaviour rather than misclassifying a crash as recoverable.
- **`job-promotion.ts`** (both bundles) — `promotionReason()` returns `'deadline' | 'context-overflow' | null`, carried on the payload. An absent reason parses as `deadline`, so a payload from an older cron build still resumes.
- **`job-main.ts`** — on overflow, invokes a *derived* session id with a restart prompt. The lock stays on the **original** session id — that's what cron acquired and what the router checks for "still working on your earlier task".
- Session ids suffix once (`-r2`, `-r3`), not cumulatively — AgentCore enforces a length limit.
- Cron sends a different ack: "I've moved it to a background job" overstates what carries over when the previous attempt is being discarded.

The restart prompt is deliberately **not** the continuation prompt. "Continue from where you stopped" is meaningless with no history and invites the model to hunt for work it can't see. It leads with the real hazard — the previous leg's tool calls aren't visible, so side effects may already have run.

## Deliberate divergence from the router

Scheduled tasks restart on overflow; **interactive turns do not**. A restart discards the user's conversation, and an interactive user is right there — they can `/reset` or rephrase, and they can see something went wrong. Nobody is watching a 6am dispatch, and its request is fully described by the stored schedule prompt.

Pinned by a test rather than left implicit, because the existing cron/router parity test would otherwise have been quietly routed around.

## Verification

4,210 unit tests pass; 33 python tests; both Lambdas compile; typecheck clean; lint 0 errors (501 baseline unchanged, none in these files).

**Mutation-tested twice:**
- reverting the runner to `job.sessionId` fails exactly the "invokes with the RESTART session id" test and no other
- renaming the Python class constant fails exactly the cross-language contract test — the failure that would otherwise surface weeks later as the dispatch quietly breaking again

A cross-language test reads `CONTEXT_OVERFLOW_ERROR_CLASS` out of `harness_adapter.py` and asserts the TypeScript promotion keys off that literal. Nothing at build time links a Python string to a TypeScript comparison.

## Deploy

Needs **both** an image build (`harness_adapter`) and a web/Lambda deploy (cron + router).

Pushed with `SKIP_E2E=1`: the only local E2E failure is `atrium-meridian-editor.spec.ts`, which fails identically on clean `dev` and is unrelated.