### PR TITLE
ci: allow dependabot in claude-review + fix local E2E gate reliability

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -36,6 +36,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          allowed_bots: "dependabot"
           prompt: |
             Please review this pull request and provide feedback on:
             - Code quality and best practices

--- a/lib/api/rate-limiter.ts
+++ b/lib/api/rate-limiter.ts
@@ -40,7 +40,19 @@ export interface RateLimitResult {
 // Constants
 // ============================================
 
-const DEFAULT_RPM = 60;
+// Default requests-per-minute for principals without a per-key configuration
+// (session auth, OAuth clients, api keys with no rateLimitRpm row). Overridable
+// via API_RATE_LIMIT_DEFAULT_RPM for environments whose traffic shape is not
+// production-like: the local E2E harness (scripts/test/e2e-local.sh) drives one
+// shared test user far harder than any human, and a warm dev server runs the
+// suite fast enough to trip the production budget. Unset/invalid → 60.
+const DEFAULT_RPM = (() => {
+  const parsed = Number.parseInt(
+    process.env.API_RATE_LIMIT_DEFAULT_RPM ?? "",
+    10
+  );
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 60;
+})();
 const WINDOW_MS = 60 * 1000; // 1 minute sliding window
 
 // ============================================

--- a/scripts/test/e2e-local.sh
+++ b/scripts/test/e2e-local.sh
@@ -229,9 +229,14 @@ else
   # leaving the started server unable to reach the DB at all (every query fails
   # from boot; authed specs die on a /dashboard redirect at ~15s each). Use
   # E2E_DATABASE_URL / E2E_DB_SSL to point the suite at a non-default DB.
+  # API_RATE_LIMIT_DEFAULT_RPM: the suite funnels every /api/v1 call through ONE
+  # test user; a warm server runs it fast enough to trip the production 60-RPM
+  # sliding window (decision-* specs 429 and fail). Raise the budget for the
+  # E2E server only — production keeps the code default.
   AUTH_URL="$BASE" NEXT_DIST_DIR=.next-e2e \
   DATABASE_URL="${E2E_DATABASE_URL:-postgresql://postgres:postgres@localhost:5432/aistudio}" \
   ATRIUM_LOCAL_STORAGE_DIR="${E2E_ATRIUM_STORAGE_DIR:-/tmp/aistudio-atrium-e2e-${E2E_PORT}}" \
+  API_RATE_LIMIT_DEFAULT_RPM="${E2E_API_RATE_LIMIT_RPM:-600}" \
   DB_SSL="${E2E_DB_SSL:-false}" PORT="$E2E_PORT" HOSTNAME=127.0.0.1 \
     bun run server.ts > "$SERVER_LOG" 2>&1 &
   STARTED_PID=$!   # the on_exit trap (set at the top) stops it and restores tsconfig.json

--- a/tests/e2e/atrium-comments-suggestions.spec.ts
+++ b/tests/e2e/atrium-comments-suggestions.spec.ts
@@ -56,18 +56,33 @@ test.describe("Atrium comments + track-changes (authenticated)", () => {
       // selection from its end.
       const markerParagraph = pm.locator("p").filter({ hasText: marker }).last();
       await expect(markerParagraph).toBeVisible();
-      await markerParagraph.click();
-      await page.keyboard.press("End");
-      await page.keyboard.down("Shift");
-      for (let i = 0; i < "comment-me here".length; i++) {
-        await page.keyboard.press("ArrowLeft");
-      }
-      await page.keyboard.up("Shift");
       const sidebar = page.getByTestId("comment-sidebar");
       const composer = sidebar.getByLabel("New comment");
-      await expect(composer).toBeEnabled({ timeout: 15000 }); // enabled by the selection
-      await composer.fill("Please clarify this line.");
-      await sidebar.getByRole("button", { name: "Add comment" }).click();
+      // Since the #1336 B3 rail redesign the comment rail is COLLAPSED by
+      // default on a document with no open threads (it only auto-opens when
+      // threads already exist). The composer stays mounted but hidden, so any
+      // fill would stall on visibility. Open the rail like a user would.
+      await page.getByTestId("comments-toggle").click();
+      await expect(composer).toBeVisible({ timeout: 15000 });
+      // The editor can rebase a freshly-typed line a beat after typing (the
+      // save/attribution cycle lands as a transaction), which collapses the
+      // selection and flips the selection-gated composer back to disabled
+      // between an enabled-check and the fill — the fill then stalls forever.
+      // Make selection → fill → submit one atomic, retryable unit instead.
+      await expect(async () => {
+        await markerParagraph.click();
+        await page.keyboard.press("End");
+        await page.keyboard.down("Shift");
+        for (let i = 0; i < "comment-me here".length; i++) {
+          await page.keyboard.press("ArrowLeft");
+        }
+        await page.keyboard.up("Shift");
+        await expect(composer).toBeEnabled({ timeout: 5000 }); // enabled by the selection
+        await composer.fill("Please clarify this line.", { timeout: 5000 });
+        await sidebar
+          .getByRole("button", { name: "Add comment" })
+          .click({ timeout: 5000 });
+      }).toPass({ timeout: 45000 });
       // The thread appears in the sidebar and the span carries the comment mark.
       await expect(page.getByTestId("comment-thread").first()).toBeVisible({ timeout: 30000 });
       await expect(pm.locator("span.atrium-comment").first()).toBeVisible({ timeout: 30000 });

--- a/tests/e2e/fixtures/atrium-editor-seed.sql
+++ b/tests/e2e/fixtures/atrium-editor-seed.sql
@@ -24,6 +24,17 @@
 
 -- 1. The editor document -----------------------------------------------------
 
+-- Reset the editor doc's accumulated collaborative state so every run starts
+-- from the pristine baseline. The specs that drive this doc (editor-rail,
+-- comments/track-changes) APPEND lines and comment/suggestion marks on every
+-- run — and the collab server persists them — so without this reset the Y.Doc
+-- accumulates stale marks across runs until the comments spec wedges (the
+-- comment composer's selection-driven enablement flaps and Fill times out).
+-- The collab server re-initializes doc state on first connect, which is the
+-- baseline these specs were written against.
+DELETE FROM atrium_doc_comments WHERE object_id = 'a7100000-0000-4000-8000-000000006060';
+DELETE FROM atrium_doc_state    WHERE object_id = 'a7100000-0000-4000-8000-000000006060';
+
 INSERT INTO content_objects (
   id, kind, title, slug, owner_user_id, created_by_actor, visibility_level, status
 )


### PR DESCRIPTION
## Summary

Unblocks the `pr-fix-stuck` dependabot backlog (16 PRs) at its two roots, plus three local-E2E-gate reliability fixes discovered while re-establishing a green baseline.

### 1. claude-review fails on every bot PR
`anthropics/claude-code-action` rejects workflows initiated by non-human actors by default (`Workflow initiated by non-human actor: dependabot (type: Bot)`). Adds `allowed_bots: "dependabot"` so dependabot PRs get reviewed instead of failing outright.

### 2. Atrium editor fixture accumulates state across E2E runs
`atrium-editor-seed.sql` now resets the fixture doc's collab state (`atrium_doc_state`) and comment threads (`atrium_doc_comments`) each run, matching its stated 'resets the baseline' contract.

### 3. Comments spec vs. the collapsed-by-default rail (#1336 B3)
The comment rail is collapsed (hidden, still mounted) on docs with no open threads, so the spec's `toBeEnabled` check passed while `fill()` stalled forever on visibility. **The spec only ever passed when leftover threads from a prior run auto-opened the rail** — which fix 2 correctly eliminates. The spec now opens the rail via `comments-toggle` like a real user, and makes select→fill→submit atomic + retryable (the save/attribution cycle can collapse a fresh selection a beat after typing).

### 4. API rate limiter vs. warm-server suite speed
The durable /api/v1 limiter's fixed 60-RPM sliding window trips when the suite runs fast (warm server: 3.6–4.2 min), 429-failing the `decision-*` specs. `API_RATE_LIMIT_DEFAULT_RPM` env override (unset/invalid → 60, production unchanged; per-key `rateLimitRpm` still wins); `e2e-local.sh` sets 600 for its started server.

## Verification
- Full local authenticated E2E suite (pre-push hook): **287 passed, 0 failed, 0 flaky, 34 skipped (3.6m)**
- `bun run lint`: 0 errors · `bun run typecheck`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)