### PR TITLE
ci: skip claude-review for dependabot-triggered runs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,12 +12,14 @@ on:
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
-    
+    # Dependabot-triggered runs read from the separate "Dependabot secrets"
+    # store, which does not contain CLAUDE_CODE_OAUTH_TOKEN — the action then
+    # fails env validation and blocks every dependabot PR. Skip those runs (a
+    # skipped check does not fail the PR). To enable reviews on dependabot
+    # PRs instead: add CLAUDE_CODE_OAUTH_TOKEN under Settings → Secrets →
+    # Dependabot and remove this condition (allowed_bots below already
+    # permits the actor).
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
Follow-up to #1391. `allowed_bots` lets the action accept the dependabot actor, but dependabot-triggered runs read the separate **Dependabot secrets** store, which lacks `CLAUDE_CODE_OAUTH_TOKEN` — so the action now fails env validation instead, still blocking every dependabot PR (verified on the re-run for #1382).

Skip the job for the dependabot actor — a skipped check does not fail the PR. To enable Claude reviews on dependabot PRs later: add `CLAUDE_CODE_OAUTH_TOKEN` under Settings → Secrets and variables → Dependabot, then remove the condition (`allowed_bots` already permits the actor). Adding that secret needs the token value, so it's a human follow-up.

E2E note: CI-YAML-only change; app tree is identical to dev@092ed2e5, whose full local suite ran green (287/0/0) an hour ago. Pushed with SKIP_E2E=1 on that basis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)