### PR TITLE
fix(content): complete unified migration readiness (#1267)

### DIFF
--- a/app/(protected)/admin/repositories/_components/migration-control-panel.tsx
+++ b/app/(protected)/admin/repositories/_components/migration-control-panel.tsx
@@ -188,6 +188,7 @@ export function MigrationControlPanel() {
         <div className="flex flex-wrap gap-2">
           <Badge variant="secondary">{metrics.migrated ?? 0} migrated</Badge>
           <Badge variant="secondary">{metrics.verified ?? 0} verified</Badge>
+          <Badge variant="outline">{metrics.excluded ?? 0} excluded</Badge>
           <Badge
             variant={
               (metrics.mismatched ?? 0) > 0 ? "destructive" : "secondary"

--- a/docs/features/google-workspace-content-sync.md
+++ b/docs/features/google-workspace-content-sync.md
@@ -91,7 +91,11 @@ deleted, a database cleanup trigger marks its retained repository items
 unavailable before connector/source cascades remove the reconciliation link.
 
 Google Docs, Sheets, Slides, and Drawings export to DOCX, XLSX, PPTX, and PDF.
-Drive blobs retain their supported MIME type. Google Vids and other Drive
+Drive blobs retain their supported MIME type except vendor text subtypes, which
+are processed as `text/plain` while their original MIME type remains in source
+and version metadata. This keeps files such as `text/x-python` inside the
+canonical text allowlist without changing their bytes or external identity.
+Google Vids and other Drive
 long-running downloads persist the operation name and resume later instead of
 holding a Lambda invocation open. Unsupported native types remain visible with
 an `unsupported` source status instead of silently disappearing.
@@ -191,3 +195,12 @@ After deployment, complete a labeled live matrix for create, edit, move into and
 out of a selected folder, delete/restore, Shared Drive permission loss/restore,
 notification loss followed by scheduled cursor resume, and one native export of
 each supported Workspace type.
+
+The 2026-07-27 dev readiness run verified the deployed personal OAuth connector,
+Picker selection, a 241-source initial reconciliation, and a later incremental
+sync with no queue or Lambda failure. It also classified five exported Google
+Docs with zero Word text characters as visible terminal “no searchable text”
+sources and repaired a `text/x-python` source through the canonical text
+compatibility path. This is operational evidence, not a substitute for the
+create/edit/move/delete/permission-loss matrix above; that matrix requires
+authorized mutations to external Drive content and remains a rollout gate.

--- a/docs/operations/unified-content-migration-retirement.md
+++ b/docs/operations/unified-content-migration-retirement.md
@@ -9,7 +9,10 @@ rollback drills, the recovery window, and irreversible legacy retirement.
 ## Safety contract
 
 - Deploy migration `155-unified-content-migration-retirement.sql` before the
-  application or worker.
+  application or worker. Deploy migrations
+  `159-unified-content-concurrency-recovery.sql` and
+  `160-unified-content-migration-source-eligibility.sql` before resuming a
+  backfill that was interrupted by database connection exhaustion.
 - Keep every new setting at its default until the dry run and backfill evidence
   are reviewed.
 - Never approve a reconciliation mismatch without comparing the immutable
@@ -77,7 +80,10 @@ must not contain source text, credentials, raw URLs, or signed URLs.
    left in an intermediate state.
 4. Run reconciliation. Each mapping compares:
    - source and canonical object SHA-256 when source bytes exist;
-   - ordered normalized extraction count and SHA-256;
+   - the complete canonical-text artifact SHA-256;
+   - extraction record counts as segmentation telemetry, not a parity
+     predicate, because the canonical tokenizer intentionally resegments
+     legacy extracts;
    - canonical processing completion.
 5. Reprocess retryable failures. Mark a source unrecoverable only when the
    original bytes and recoverable job input are genuinely absent.
@@ -86,6 +92,28 @@ must not contain source text, credentials, raw URLs, or signed URLs.
    original mismatch evidence.
 7. Do not continue while any failure, unrecoverable source, or unapproved
    mismatch remains.
+
+The migration worker has bounded database pressure. In dev the embedding
+generator reserves five concurrent invocations and its SQS mapping has the same
+maximum; production uses ten. The unified-content worker reserves one
+invocation for scheduled maintenance in addition to its SQS maximum, so
+outbox recovery and bounded migration batches cannot be starved by queue load.
+Migration publication sets a four-minute PostgreSQL statement timeout inside a
+270-second application transaction deadline for large repositories.
+
+If a pre-cap deployment exhausted Aurora connections, migration 159 fences only
+the exact incomplete generation and failed inspect rows carrying the known
+connection-establishment errors. The scheduled worker releases that marker
+after the old Lambda runtime has drained. It never re-arms arbitrary processing
+failures.
+
+Repository connector sources explicitly classified `unsupported`, and
+canonical targets created by the migration itself, are excluded from migration
+inventory without deleting their audit rows. A missing legacy S3 object is
+recoverable only when ordered legacy segments are present; the worker writes a
+deterministic text source and records `recoveredFromLegacySegments`. Access
+denials, network errors, and a source with neither bytes nor segments remain
+fail-closed.
 
 Repository items that already had a canonical version are shadow-audited
 without replacing that version. Newly created migration repositories, items,
@@ -227,3 +255,26 @@ If a problem is found after finalization, stop new ingestion with the
 product-specific setting, preserve evidence, and use the standard Aurora/S3
 restore process. Do not recreate empty compatibility tables or re-enable old
 workers against a partially restored database.
+
+## Dev readiness evidence (2026-07-27)
+
+The dev backfill and reconciliation discovered 45 eligible legacy sources.
+Forty-four migrated and verified, three unsupported connector records were
+explicitly excluded, and no failed or unapproved mismatch remained. Nine
+Assistant Architect PDF rows retained byte-identical immutable PDF hashes but
+had expected legacy-markdown versus `pdf-text-v2` plain-text extraction drift;
+an administrator approval recorded the processor evidence, both hashes, time,
+and reason without deleting the mismatch history. A final reconciliation run
+completed with `verified=44`, `mismatched=0`, and `failed=0`.
+
+The rollback drill temporarily selected the legacy chunks for one verified
+Repository item, proved the legacy read source existed, restored the exact
+canonical version in the same transaction, and recorded
+`snapshot.rollbackDrill=true`.
+
+Retirement is not approved. One Nexus document is genuinely unrecoverable
+because both its legacy object and chunks are absent. Retrieval shadowing and
+all three product cutovers remain disabled, so the required observation and
+seven-day quiet windows have not started. Restore or formally disposition the
+missing source, complete the live shadow/cutover matrix, and let the full
+recovery window elapse before enabling retirement or running the finalizer.

--- a/docs/operations/unified-content-migration-retirement.md
+++ b/docs/operations/unified-content-migration-retirement.md
@@ -102,10 +102,12 @@ Migration publication sets a four-minute PostgreSQL statement timeout inside a
 270-second application transaction deadline for large repositories.
 
 If a pre-cap deployment exhausted Aurora connections, migration 159 fences only
-the exact incomplete generation and failed inspect rows carrying the known
-connection-establishment errors. The scheduled worker releases that marker
-after the old Lambda runtime has drained. It never re-arms arbitrary processing
-failures.
+the exact exhausted generation and failed inspect rows carrying the known
+connection-establishment errors. This includes a generation whose vectors were
+fully written but whose final activation transaction failed. The scheduled
+worker releases that marker after the old Lambda runtime has drained, and the
+bounded recovery path either fills missing vectors or performs activation only.
+It never re-arms arbitrary processing failures.
 
 Repository connector sources explicitly classified `unsupported`, and
 canonical targets created by the migration itself, are excluded from migration
@@ -115,10 +117,19 @@ deterministic text source and records `recoveredFromLegacySegments`. Access
 denials, network errors, and a source with neither bytes nor segments remain
 fail-closed.
 
+The route gate and irreversible finalizer use the same inventory and metric
+denominators as the operator dashboard: excluded connector sources are reported
+separately, not counted as discovered work requiring verification, and never
+make a destructive retirement gate easier to satisfy for a supported source.
+
 Repository items that already had a canonical version are shadow-audited
 without replacing that version. Newly created migration repositories, items,
 versions, jobs, and S3 objects are recorded separately so rollback never
-deletes preexisting canonical data.
+deletes preexisting canonical data. Replaying a pre-hash canonical publication
+first verifies the immutable item, processor, payload locator, and any existing
+inline bytes. Object-backed producers send the expected SHA-256 checksum to S3,
+then the transaction conditionally backfills a missing canonical-text hash
+before returning the existing generation.
 
 ## 3. Shadow retrieval and product cutover
 
@@ -153,7 +164,9 @@ backfill. The drill verifies the deletion plan and records
 `snapshot.rollbackDrill=true`; it does not delete canonical data. A full
 rollback, if needed, fences processing jobs, deletes only migration-created
 canonical objects/rows, preserves preexisting canonical versions, and marks
-the mappings rolled back.
+the mappings rolled back. Explicitly excluded sources are retained as audit
+evidence, skipped because they created no canonical data, and reported in the
+completed rollback metrics instead of preventing the run from finishing.
 
 After a successful drill:
 

--- a/docs/plans/2026-07-21-unified-content-platform.md
+++ b/docs/plans/2026-07-21-unified-content-platform.md
@@ -1345,6 +1345,28 @@ missing-object recovery, explicit eligibility, complete artifact hashing,
 per-run reconciliation bookkeeping, and Google text normalization address
 those defects with unit, PostgreSQL smoke, and CDK assertions.
 
+A requested full Claude review of the review-ready diff then found three
+additional recovery defects before merge: migration 159 omitted generations
+that had written every vector but failed during atomic activation; replaying a
+preexisting object-backed canonical artifact did not backfill its missing
+SHA-256; and full rollback counted explicitly excluded sources as unfinished
+while never selecting them. The corrected implementation fences and releases
+activation-only failures, conditionally backfills only null artifact hashes,
+and completes rollback with excluded-source metrics. The real PostgreSQL smoke
+now applies migrations 159 and 160 twice, exercises the activation-only handoff,
+replays a legacy object-backed artifact, and completes an excluded-only rollback
+without invoking object storage.
+
+The follow-up security pass found that the first SHA repair bound a digest only
+to an artifact row, not its immutable payload coordinates, and that the route
+gate/finalizer still counted explicitly excluded connectors in their
+verification denominator. Publication replay now rejects item, processor,
+object-key, inline-text, or existing-hash drift; object-backed writes carry an
+S3 SHA-256 checksum; and both retirement entry points share the dashboard's
+fail-closed exclusion rules. PostgreSQL smoke covers mismatched object-key
+rejection before hash repair, while unit guards keep both retirement queries
+aligned.
+
 Live dev evidence now records 45 eligible sources, 44 migrated and verified,
 zero failed or unapproved mismatches, three explicitly excluded unsupported
 connector rows, and one genuinely missing Nexus source. A reversible rollback

--- a/docs/plans/2026-07-21-unified-content-platform.md
+++ b/docs/plans/2026-07-21-unified-content-platform.md
@@ -1313,3 +1313,49 @@ retirement frontend templates before the Processing and DocumentProcessing
 templates; and run the irreversible database finalizer only after the
 post-deployment checks. Until that boundary, disabling a single product flag
 restores its legacy read path without deleting canonical evidence.
+
+### Epic readiness audit continuation (2026-07-27)
+
+The post-merge audit selected #1267 again as the next actionable workstream
+because this plan explicitly makes live migration, shadowing, rollback, and
+retirement the next dependency. PR #1350 addressed only #1297's expired
+edge-session refresh proof; it did not satisfy the unified-content rollout
+gates.
+
+The dev execution exposed and corrected issues that pre-production tests did
+not model:
+
+- embedding concurrency could exhaust Aurora connection establishment, and SQS
+  load could consume every unified-worker reservation before scheduled recovery
+  ran;
+- a failed backfill lost retry-run metrics, large repository publication used
+  the default transaction deadline, and genuinely missing legacy S3 objects had
+  no deterministic segment fallback;
+- connector sources already classified unsupported and migration-created
+  canonical targets could re-enter inventory;
+- reconciliation omitted `section` segments, treated intentional canonical
+  resegmentation as a count mismatch, and stopped after the first batch of
+  previously mismatched rows;
+- Google vendor text MIME types could be accepted by Drive sync but rejected by
+  the canonical processor.
+
+Migrations 159 and 160, bounded Lambda/SQS concurrency, a reserved maintenance
+slot, exact retry metrics, extended publication deadlines, deterministic
+missing-object recovery, explicit eligibility, complete artifact hashing,
+per-run reconciliation bookkeeping, and Google text normalization address
+those defects with unit, PostgreSQL smoke, and CDK assertions.
+
+Live dev evidence now records 45 eligible sources, 44 migrated and verified,
+zero failed or unapproved mismatches, three explicitly excluded unsupported
+connector rows, and one genuinely missing Nexus source. A reversible rollback
+drill passed and restored the exact current version transactionally. The Google
+infrastructure and connector are deployed and incremental sync succeeds; the
+external mutation matrix remains outstanding.
+
+The epic is not ready for retirement. The missing Nexus source needs restore or
+an explicit product-data disposition; retrieval shadowing and the three
+independent product cutovers still require authenticated observation; the full
+quiet/recovery window must then elapse; and Cohere Embed v4/Rerank 3.5 remain
+blocked on an AWS Marketplace subscription that the current principal is not
+authorized to accept. #1263 and #1267 must remain open until those external and
+time-based gates have durable evidence.

--- a/infra/database/migrations.json
+++ b/infra/database/migrations.json
@@ -148,6 +148,8 @@
     "155-unified-content-migration-retirement.sql",
     "156-oneroster-user-role-source.sql",
     "157-rooms.sql",
-    "158-student-rooms-navigation.sql"
+    "158-student-rooms-navigation.sql",
+    "159-unified-content-concurrency-recovery.sql",
+    "160-unified-content-migration-source-eligibility.sql"
   ]
 }

--- a/infra/database/schema/159-unified-content-concurrency-recovery.sql
+++ b/infra/database/schema/159-unified-content-concurrency-recovery.sql
@@ -54,18 +54,13 @@ WHERE generation.status = 'failed'
   AND generation.embedding_recovery_attempts >= 3
   AND generation.error_message ILIKE
     'Failed query:%FROM repository_index_generations%'
+  -- A connection timeout can exhaust the retry budget after every vector was
+  -- written but before atomic activation. Fence any owned generation with the
+  -- known failure signature, not only generations with missing vectors.
   AND EXISTS (
     SELECT 1
     FROM repository_item_chunks chunk
     WHERE chunk.index_generation_id = generation.id
-      AND (
-        chunk.embedding IS NULL
-        OR (
-          generation.visual_embedding_model IS NOT NULL
-          AND chunk.modality IN ('image', 'video')
-          AND chunk.visual_embedding IS NULL
-        )
-      )
   )
   AND NOT EXISTS (
     SELECT 1

--- a/infra/database/schema/159-unified-content-concurrency-recovery.sql
+++ b/infra/database/schema/159-unified-content-concurrency-recovery.sql
@@ -1,0 +1,82 @@
+-- Migration 159: recover Unified Content work exhausted by an unbounded
+-- embedding-worker connection storm.
+--
+-- The pre-fix SQS event source had no concurrency limit. During a repository
+-- backfill it reached hundreds of concurrent VPC Lambdas, so Aurora connection
+-- establishment timed out before processing or embedding queries could run.
+-- Quarantine only the known transient signatures. The replacement scheduled
+-- worker releases these rows after its 20-minute old-runtime drain window;
+-- ordinary workers cannot claim them before that boundary.
+
+UPDATE repository_processing_jobs job
+SET status = 'cancelled',
+    attempt = 0,
+    max_attempts = 5,
+    available_at = 'infinity'::timestamptz,
+    lease_owner = NULL,
+    lease_expires_at = NULL,
+    last_error_code = 'POST_DEPLOY_RECOVERY_QUARANTINED',
+    last_error_message = 'Awaiting the bounded embedding concurrency runtime',
+    post_deploy_recovery = 'embedding-concurrency-v1',
+    metrics = '{"postDeployRecovery":"embedding-concurrency-v1"}'::jsonb,
+    started_at = NULL,
+    finished_at = now(),
+    updated_at = now()
+WHERE job.stage = 'inspect'
+  AND job.status = 'failed'
+  AND job.last_error_code = 'RETRY_BUDGET_EXHAUSTED'
+  AND job.last_error_message ILIKE 'Failed query:%repository_index_generations%'
+  AND EXISTS (
+    SELECT 1
+    FROM repository_item_versions version
+    JOIN repository_items item
+      ON item.current_version_id = version.id
+    WHERE version.id = job.item_version_id
+      AND item.lifecycle_status = 'active'
+      AND version.storage_status <> 'blocked'
+      AND version.inspection_status <> 'blocked'
+      AND version.object_key ~ (
+        '^repositories/' || item.repository_id::text ||
+        '/[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89aAbB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}/[^/]+$'
+      )
+  );
+
+-- Exhausted generations remain failed and keep their DLQ evidence visible.
+-- The timestamp plus max attempt count is the durable old-worker fence.
+UPDATE repository_index_generations generation
+SET embedding_recovery_queued_at = now(),
+    embedding_recovery_attempts = 3,
+    error_message = concat(
+      'embedding-concurrency-v1: ',
+      COALESCE(generation.error_message, 'database connection timeout')
+    )
+WHERE generation.status = 'failed'
+  AND generation.embedding_recovery_attempts >= 3
+  AND generation.error_message ILIKE
+    'Failed query:%FROM repository_index_generations%'
+  AND EXISTS (
+    SELECT 1
+    FROM repository_item_chunks chunk
+    WHERE chunk.index_generation_id = generation.id
+      AND (
+        chunk.embedding IS NULL
+        OR (
+          generation.visual_embedding_model IS NOT NULL
+          AND chunk.modality IN ('image', 'video')
+          AND chunk.visual_embedding IS NULL
+        )
+      )
+  )
+  AND NOT EXISTS (
+    SELECT 1
+    FROM repository_index_generations newer_generation
+    WHERE newer_generation.repository_id = generation.repository_id
+      AND newer_generation.status IN ('building', 'active', 'failed')
+      AND (
+        newer_generation.created_at > generation.created_at
+        OR (
+          newer_generation.created_at = generation.created_at
+          AND newer_generation.id > generation.id
+        )
+      )
+  );

--- a/infra/database/schema/160-unified-content-migration-source-eligibility.sql
+++ b/infra/database/schema/160-unified-content-migration-source-eligibility.sql
@@ -1,0 +1,52 @@
+-- Migration 160: keep intentionally unsupported connector sources out of the
+-- legacy-content retirement denominator without erasing their audit evidence.
+--
+-- Google Drive discovery records unsupported MIME types so operators can see
+-- them, but those rows have no canonical version by design. Migration 155
+-- originally treated every active document row as recoverable legacy content,
+-- which mislabeled unsupported connector discoveries as source loss and made
+-- retirement impossible. `excluded` is an explicit, durable non-migration
+-- disposition; it is never used for a source that created canonical data.
+
+ALTER TABLE repository_migration_items
+  DROP CONSTRAINT IF EXISTS repository_migration_items_status_check;
+
+ALTER TABLE repository_migration_items
+  ADD CONSTRAINT repository_migration_items_status_check
+  CHECK (
+    status IN (
+      'pending',
+      'migrating',
+      'migrated',
+      'verified',
+      'mismatch',
+      'failed',
+      'unrecoverable',
+      'excluded',
+      'rolled_back'
+    )
+  );
+
+UPDATE repository_migration_items migration
+SET status = 'excluded',
+    last_error_code = 'MIGRATION_SOURCE_EXCLUDED',
+    last_error_message =
+      'Connector source is intentionally unsupported and has no canonical version',
+    metadata = migration.metadata || jsonb_build_object(
+      'exclusionReason', 'unsupported_connector_source',
+      'excludedAt', now()
+    ),
+    verified_at = NULL,
+    updated_at = now()
+FROM repository_connector_sources connector_source
+WHERE migration.source_kind = 'repository_item'
+  AND connector_source.repository_item_id = migration.source_id
+  AND connector_source.status = 'unsupported'
+  AND migration.status IN (
+    'pending',
+    'migrating',
+    'failed',
+    'unrecoverable'
+  )
+  AND migration.canonical_version_id IS NULL
+  AND migration.canonical_object_key IS NULL;

--- a/infra/jest.config.js
+++ b/infra/jest.config.js
@@ -8,6 +8,12 @@ module.exports = {
       // `tsc` emits ignored JavaScript beside the TypeScript source. Resolve
       // TypeScript first so a prior build cannot make Jest exercise stale code.
       moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
+      // CDK local bundling installs Lambda dependencies in-place. Pin this
+      // package to the infra workspace copy so Jest mocks it consistently
+      // before and after a synth has populated nested node_modules folders.
+      moduleNameMapper: {
+        '^@aws-sdk/client-sqs$': '<rootDir>/../node_modules/@aws-sdk/client-sqs'
+      },
       transform: {
         '^.+\\.tsx?$': 'ts-jest'
       }

--- a/infra/lambdas/unified-content-processor/index.ts
+++ b/infra/lambdas/unified-content-processor/index.ts
@@ -110,7 +110,10 @@ import {
   type ContentProcessingMessage,
 } from "./contract";
 import { CONTENT_SWEEP_REDISPATCHABLE_STATUSES } from "../../../lib/repositories/content-platform/job-state";
-import { releasePostDeployRecoveryJobs } from "../../../lib/repositories/content-platform/post-deploy-recovery";
+import {
+  releasePostDeployEmbeddingGenerations,
+  releasePostDeployRecoveryJobs,
+} from "../../../lib/repositories/content-platform/post-deploy-recovery";
 import {
   claimRepositoryProcessingJob,
   reconcileRepositoryProcessingDlqMessage,
@@ -984,9 +987,16 @@ async function storeCanonicalText(
   itemVersionId: string,
   canonicalText: string,
   processorVersion: string,
-): Promise<{ canonicalText?: string; canonicalTextObjectKey?: string }> {
+): Promise<{
+  canonicalText?: string;
+  canonicalTextObjectKey?: string;
+  canonicalTextSha256: string;
+}> {
+  const canonicalTextSha256 = createHash("sha256")
+    .update(canonicalText)
+    .digest("hex");
   if (canonicalText.length <= MAX_INLINE_ARTIFACT_CHARACTERS) {
-    return { canonicalText };
+    return { canonicalText, canonicalTextSha256 };
   }
   const objectKey = canonicalTextArtifactObjectKey(repositoryId, itemVersionId, processorVersion);
   await s3.send(
@@ -997,7 +1007,7 @@ async function storeCanonicalText(
       ContentType: "text/markdown; charset=utf-8",
     }),
   );
-  return { canonicalTextObjectKey: objectKey };
+  return { canonicalTextObjectKey: objectKey, canonicalTextSha256 };
 }
 
 async function processMessage(message: ContentProcessingMessage, workerId: string): Promise<void> {
@@ -1339,6 +1349,7 @@ async function processMessage(message: ContentProcessingMessage, workerId: strin
       canonicalText = extracted.canonicalText;
       processorVersion = extracted.processorVersion;
       processorName = "aistudio-text";
+      detectedContentType = extracted.detectedContentType;
       artifactMetadata = extracted.metadata;
     } else {
       const prepared = await prepareRepositoryImage(source, declaredContentType);
@@ -1661,10 +1672,18 @@ export async function handler(
           name: "post-deploy-recovery",
           run: async () => {
             const released = await releasePostDeployRecoveryJobs();
+            const releasedGenerations =
+              await releasePostDeployEmbeddingGenerations();
             if (released.length > 0) {
               log.info("Released post-deployment unified content recovery jobs", {
                 count: released.length,
               });
+            }
+            if (releasedGenerations.length > 0) {
+              log.info(
+                "Released post-deployment embedding recovery generations",
+                { count: releasedGenerations.length }
+              );
             }
           },
         },

--- a/infra/lambdas/unified-content-processor/index.ts
+++ b/infra/lambdas/unified-content-processor/index.ts
@@ -1005,6 +1005,9 @@ async function storeCanonicalText(
       Key: objectKey,
       Body: canonicalText,
       ContentType: "text/markdown; charset=utf-8",
+      ChecksumSHA256: Buffer.from(canonicalTextSha256, "hex").toString(
+        "base64",
+      ),
     }),
   );
   return { canonicalTextObjectKey: objectKey, canonicalTextSha256 };

--- a/infra/lib/constructs/processing/unified-content-processing.ts
+++ b/infra/lib/constructs/processing/unified-content-processing.ts
@@ -316,6 +316,17 @@ export class UnifiedContentProcessing extends Construct {
                     actions: ["s3:GetObject", "s3:GetObjectVersion"],
                     resources: [`${props.documentsBucket.bucketArn}/*`],
                   }),
+                  new iam.PolicyStatement({
+                    // S3 reports a missing legacy object as AccessDenied unless
+                    // the caller can list the bucket. The migration needs that
+                    // distinction so reconciliation can classify genuinely
+                    // absent source bytes as unrecoverable. Historical keys
+                    // predate the repositories/ prefix, so this temporary
+                    // retirement-gated grant cannot be prefix-restricted.
+                    sid: "LegacyContentMigrationDiscovery",
+                    actions: ["s3:ListBucket"],
+                    resources: [props.documentsBucket.bucketArn],
+                  }),
                 ]
               : []),
             new iam.PolicyStatement({
@@ -393,6 +404,12 @@ export class UnifiedContentProcessing extends Construct {
       },
     );
 
+    const workerReservedConcurrency = props.environment === "prod" ? 10 : 3;
+    // EventBridge invokes this same function every minute for durable job
+    // recovery, migration, reconciliation, and retention. Leave one reserved
+    // execution outside the SQS poller's ceiling so a sustained content queue
+    // cannot starve recurring maintenance.
+    const workerQueueMaxConcurrency = workerReservedConcurrency - 1;
     this.worker = new lambdaNodejs.NodejsFunction(this, "Worker", {
       functionName,
       runtime: lambda.Runtime.NODEJS_20_X,
@@ -404,7 +421,7 @@ export class UnifiedContentProcessing extends Construct {
       handler: "handler",
       timeout: cdk.Duration.minutes(15),
       memorySize: 3008,
-      reservedConcurrentExecutions: props.environment === "prod" ? 10 : 3,
+      reservedConcurrentExecutions: workerReservedConcurrency,
       vpc: props.vpc,
       vpcSubnets: { subnetType: ec2.SubnetType.PRIVATE_WITH_EGRESS },
       securityGroups: [workerSecurityGroup],
@@ -481,7 +498,7 @@ export class UnifiedContentProcessing extends Construct {
     this.worker.addEventSource(
       new lambdaEventSources.SqsEventSource(this.queue, {
         batchSize: 1,
-        maxConcurrency: props.environment === "prod" ? 10 : 3,
+        maxConcurrency: workerQueueMaxConcurrency,
         reportBatchItemFailures: true,
       }),
     );

--- a/infra/lib/processing-stack.ts
+++ b/infra/lib/processing-stack.ts
@@ -476,6 +476,13 @@ export class ProcessingStack extends cdk.Stack {
       },
     );
 
+    // Each invocation opens one direct Aurora connection. An unbounded SQS
+    // event source scaled past 400 concurrent dev invocations during the
+    // Unified Content backfill, exhausting connection establishment before
+    // any embedding work could start. Keep Lambda reservation and poller
+    // scaling identical so throttled receives do not churn invisibly.
+    const embeddingGeneratorMaxConcurrency =
+      props.environment === "prod" ? 10 : 5;
     const embeddingGenerator = new lambda.Function(this, "EmbeddingGenerator", {
       runtime: lambda.Runtime.NODEJS_20_X,
       handler: "index.handler",
@@ -535,6 +542,7 @@ export class ProcessingStack extends cdk.Stack {
       ),
       timeout: cdk.Duration.minutes(5),
       memorySize: 1024, // 1GB
+      reservedConcurrentExecutions: embeddingGeneratorMaxConcurrency,
       vpc,
       vpcSubnets: { subnetType: ec2.SubnetType.PRIVATE_WITH_EGRESS },
       securityGroups: [embeddingGeneratorSg],
@@ -741,6 +749,7 @@ export class ProcessingStack extends cdk.Stack {
       new lambdaEventSources.SqsEventSource(this.embeddingQueue, {
         batchSize: 1, // Process one item at a time to avoid rate limits
         maxBatchingWindow: cdk.Duration.seconds(5),
+        maxConcurrency: embeddingGeneratorMaxConcurrency,
       }),
     );
 

--- a/infra/test/unit/legacy-content-retirement.test.ts
+++ b/infra/test/unit/legacy-content-retirement.test.ts
@@ -103,6 +103,9 @@ describe("legacy content infrastructure retirement", () => {
     expect(JSON.stringify(template.Resources)).not.toContain(
       "LegacyContentMigrationRead",
     );
+    expect(JSON.stringify(template.Resources)).not.toContain(
+      "LegacyContentMigrationDiscovery",
+    );
   });
 
   it("keeps the document stack deployable while removing every v2 legacy resource", () => {

--- a/infra/test/unit/processing-stack-embedding-access.test.ts
+++ b/infra/test/unit/processing-stack-embedding-access.test.ts
@@ -107,6 +107,21 @@ describe('ProcessingStack embedding visual-artifact access', () => {
     });
   });
 
+  it('bounds embedding concurrency at the Lambda and SQS poller boundaries', () => {
+    template.hasResourceProperties('AWS::Lambda::Function', {
+      ReservedConcurrentExecutions: 5,
+      Role: Match.anyValue(),
+      VpcConfig: Match.objectLike({
+        SecurityGroupIds: Match.anyValue(),
+        SubnetIds: Match.anyValue(),
+      }),
+    });
+    template.hasResourceProperties('AWS::Lambda::EventSourceMapping', {
+      BatchSize: 1,
+      ScalingConfig: { MaximumConcurrency: 5 },
+    });
+  });
+
   it('routes group-sync alarms through the shared monitoring topic', () => {
     const alarms = Object.values(
       template.findResources('AWS::CloudWatch::Alarm'),

--- a/infra/test/unit/unified-content-processing.test.ts
+++ b/infra/test/unit/unified-content-processing.test.ts
@@ -146,7 +146,7 @@ const defineUnifiedContentProcessingSuite1 = () => {
     template.hasResourceProperties("AWS::Lambda::EventSourceMapping", {
       BatchSize: 1,
       FunctionResponseTypes: ["ReportBatchItemFailures"],
-      ScalingConfig: { MaximumConcurrency: 3 },
+      ScalingConfig: { MaximumConcurrency: 2 },
     });
     template.hasResourceProperties("AWS::Events::Rule", {
       ScheduleExpression: "rate(1 minute)",
@@ -253,6 +253,20 @@ const defineUnifiedContentProcessingSuite1 = () => {
     expect(migrationRead?.Action).not.toEqual(
       expect.arrayContaining(["s3:PutObject", "s3:DeleteObject"]),
     );
+    const migrationDiscovery = statements.find(
+      (statement) => statement.Sid === "LegacyContentMigrationDiscovery",
+    );
+    expect(migrationDiscovery).toMatchObject({
+      Effect: "Allow",
+      Action: "s3:ListBucket",
+    });
+    expect(JSON.stringify(migrationDiscovery)).not.toContain(
+      "s3:ListBucketVersions",
+    );
+    expect(JSON.stringify(migrationDiscovery?.Resource)).toContain(
+      ":s3:::aistudio-dev-documents",
+    );
+    expect(migrationDiscovery?.Condition).toBeUndefined();
   });
 
   test("publishes a tagged operational dashboard and namespace-scoped metrics", () => {

--- a/lib/db/schema/tables/repository-migration-items.ts
+++ b/lib/db/schema/tables/repository-migration-items.ts
@@ -28,6 +28,7 @@ export type RepositoryMigrationItemStatus =
   | "mismatch"
   | "failed"
   | "unrecoverable"
+  | "excluded"
   | "rolled_back";
 
 export interface RepositoryMigrationItemMetadata {
@@ -42,6 +43,9 @@ export interface RepositoryMigrationItemMetadata {
   approvedMismatchReason?: string;
   rollbackPrepared?: boolean;
   rollbackObjectKeys?: string[];
+  exclusionReason?: string;
+  excludedAt?: string;
+  lastReconciledRunId?: string;
 }
 
 export const repositoryMigrationItems = pgTable(

--- a/lib/db/schema/tables/repository-migration-runs.ts
+++ b/lib/db/schema/tables/repository-migration-runs.ts
@@ -47,6 +47,7 @@ export interface RepositoryMigrationMetrics {
   mismatched?: number;
   failed?: number;
   unrecoverable?: number;
+  excluded?: number;
   rolledBack?: number;
 }
 

--- a/lib/db/schema/tables/repository-processing-jobs.ts
+++ b/lib/db/schema/tables/repository-processing-jobs.ts
@@ -36,7 +36,8 @@ export interface RepositoryProcessingMetrics {
   /** Transitional deployment handoff mirrored in the durable marker column. */
   postDeployRecovery?:
     | "unified-content-runtime-v2"
-    | "unified-content-artifact-v3";
+    | "unified-content-artifact-v3"
+    | "embedding-concurrency-v1";
   /** Current managed-service wait, used to enforce or observe its deadline. */
   waitReason?:
     | "CONTENT_PLATFORM_DISABLED"
@@ -119,7 +120,9 @@ export const repositoryProcessingJobs = pgTable(
     lastErrorMessage: text("last_error_message"),
     /** Durable across stale worker writes; only the replacement runtime clears it. */
     postDeployRecovery: varchar("post_deploy_recovery", { length: 64 }).$type<
-      "unified-content-runtime-v2" | "unified-content-artifact-v3"
+      | "unified-content-runtime-v2"
+      | "unified-content-artifact-v3"
+      | "embedding-concurrency-v1"
     >(),
     metrics: jsonb("metrics")
       .$type<RepositoryProcessingMetrics>()

--- a/lib/repositories/content-platform/legacy-retirement.ts
+++ b/lib/repositories/content-platform/legacy-retirement.ts
@@ -98,6 +98,7 @@ export async function isLegacyContentRetirementActive(): Promise<boolean> {
           (
             SELECT COUNT(*)::integer
             FROM repository_migration_items
+            WHERE status <> 'excluded'
           ) AS discovered,
           (
             SELECT COUNT(*)::integer
@@ -180,6 +181,15 @@ export async function isLegacyContentRetirementActive(): Promise<boolean> {
             WHERE item.lifecycle_status = 'active'
               AND repository.lifecycle_status = 'active'
               AND item.type IN ('document', 'text', 'url')
+              AND NOT (
+                COALESCE(item.metadata, '{}'::jsonb) ? 'migrationSourceKind'
+              )
+              AND NOT EXISTS (
+                SELECT 1
+                FROM repository_connector_sources connector_source
+                WHERE connector_source.repository_item_id = item.id
+                  AND connector_source.status = 'unsupported'
+              )
               AND (
                 item.current_version_id IS NULL
                 OR EXISTS (

--- a/lib/repositories/content-platform/migration-control-service.ts
+++ b/lib/repositories/content-platform/migration-control-service.ts
@@ -147,6 +147,15 @@ export async function getRepositoryMigrationInventory(): Promise<
         WHERE item.lifecycle_status = 'active'
           AND repository.lifecycle_status = 'active'
           AND item.type IN ('document', 'text', 'url')
+          AND NOT (
+            COALESCE(item.metadata, '{}'::jsonb) ? 'migrationSourceKind'
+          )
+          AND NOT EXISTS (
+            SELECT 1
+            FROM repository_connector_sources connector_source
+            WHERE connector_source.repository_item_id = item.id
+              AND connector_source.status = 'unsupported'
+          )
           AND (
             item.current_version_id IS NULL
             OR EXISTS (
@@ -210,6 +219,7 @@ export async function getRepositoryMigrationInventory(): Promise<
           COUNT(*)::integer AS tracked,
           COUNT(*) FILTER (WHERE status = 'verified')::integer AS verified
         FROM repository_migration_items
+        WHERE status <> 'excluded'
         GROUP BY source_kind
       `),
     );
@@ -632,17 +642,20 @@ function migrationMetricsFromRows(
   const counts = Object.fromEntries(
     rows.map((row) => [row.status, numberFromDatabase(row.count)]),
   ) as Partial<Record<RepositoryMigrationItemStatus, number>>;
+  const excluded = counts.excluded ?? 0;
   return {
-    discovered: Object.values(counts).reduce(
-      (total, value) => total + (value ?? 0),
-      0,
-    ),
+    discovered:
+      Object.values(counts).reduce(
+        (total, value) => total + (value ?? 0),
+        0,
+      ) - excluded,
     migrated:
       (counts.migrated ?? 0) + (counts.verified ?? 0) + (counts.mismatch ?? 0),
     verified: counts.verified ?? 0,
     mismatched: counts.mismatch ?? 0,
     failed: counts.failed ?? 0,
     unrecoverable: counts.unrecoverable ?? 0,
+    excluded,
     rolledBack: counts.rolled_back ?? 0,
   };
 }

--- a/lib/repositories/content-platform/migration-reconciliation.ts
+++ b/lib/repositories/content-platform/migration-reconciliation.ts
@@ -99,12 +99,10 @@ export function reconcileMigrationEvidence(
   if (evidence.canonicalContent.recordCount === 0) {
     reasons.push("canonical extraction produced no content records");
   }
-  if (
-    evidence.sourceContent.recordCount > 0 &&
-    evidence.sourceContent.recordCount !== evidence.canonicalContent.recordCount
-  ) {
-    reasons.push("extracted record count differs");
-  }
+  // Record counts remain useful rollout telemetry, but they cannot be a parity
+  // predicate: canonical processing intentionally resegments legacy extracts
+  // under the current tokenizer/section contract. Full normalized text hashes
+  // prove content parity independently of those chunk boundaries.
   if (
     evidence.sourceContent.sha256 &&
     evidence.sourceContent.sha256 !== evidence.canonicalContent.sha256

--- a/lib/repositories/content-platform/migration-runner.ts
+++ b/lib/repositories/content-platform/migration-runner.ts
@@ -1548,32 +1548,40 @@ async function processRollbackBatch(
           SELECT COUNT(*)::integer AS count
           FROM repository_migration_items
           WHERE origin_run_id = ${parentRunId}::uuid
-            AND status <> 'rolled_back'
+            AND status NOT IN ('rolled_back', 'excluded')
         `),
         "contentMigration.rollbackRemaining",
       ),
     )[0]?.count ?? 0;
   if (remaining === 0) {
-    const total =
-      toPgRows<{ count: number }>(
+    const totals =
+      toPgRows<{ rolled_back: number; excluded: number }>(
         await executeQuery(
           (db) =>
             db.execute(sql`
-            SELECT COUNT(*)::integer AS count
+            SELECT
+              COUNT(*) FILTER (
+                WHERE status = 'rolled_back'
+              )::integer AS rolled_back,
+              COUNT(*) FILTER (
+                WHERE status = 'excluded'
+              )::integer AS excluded
             FROM repository_migration_items
             WHERE origin_run_id = ${parentRunId}::uuid
-              AND status = 'rolled_back'
           `),
           "contentMigration.rollbackTotal",
         ),
-      )[0]?.count ?? rolledBack;
+      )[0];
     await executeQuery(
       (db) =>
         db
           .update(repositoryMigrationRuns)
           .set({
             status: "rolled_back",
-            metrics: { rolledBack: total },
+            metrics: {
+              rolledBack: totals?.rolled_back ?? rolledBack,
+              excluded: totals?.excluded ?? 0,
+            },
             finishedAt: new Date(),
             updatedAt: new Date(),
           })

--- a/lib/repositories/content-platform/migration-runner.ts
+++ b/lib/repositories/content-platform/migration-runner.ts
@@ -269,6 +269,15 @@ async function loadNextCandidate(
               AND item.lifecycle_status = 'active'
               AND repository.lifecycle_status = 'active'
               AND item.type IN ('document', 'text', 'url')
+              AND NOT (
+                COALESCE(item.metadata, '{}'::jsonb) ? 'migrationSourceKind'
+              )
+              AND NOT EXISTS (
+                SELECT 1
+                FROM repository_connector_sources connector_source
+                WHERE connector_source.repository_item_id = item.id
+                  AND connector_source.status = 'unsupported'
+              )
               AND (
                 item.current_version_id IS NULL
                 OR EXISTS (
@@ -646,6 +655,33 @@ function textCandidateBody(candidate: RepositoryCandidate): Uint8Array | null {
   return null;
 }
 
+export function isMissingMigrationSourceObject(error: unknown): boolean {
+  if (!error || typeof error !== "object") return false;
+  const candidate = error as {
+    name?: unknown;
+    Code?: unknown;
+    code?: unknown;
+    $metadata?: { httpStatusCode?: unknown };
+  };
+  const errorCode = [candidate.name, candidate.Code, candidate.code].find(
+    (value): value is string => typeof value === "string"
+  );
+  return (
+    ["NoSuchKey", "NotFound", "NoSuchBucket"].includes(errorCode ?? "") ||
+    candidate.$metadata?.httpStatusCode === 404
+  );
+}
+
+export function buildLegacyMigrationFallbackBody(
+  legacySegments: string[]
+): Uint8Array | null {
+  const content = legacySegments
+    .map((segment) => segment.trim())
+    .filter((segment) => segment.length > 0)
+    .join("\n");
+  return content ? Buffer.from(content, "utf8") : null;
+}
+
 async function migrateCandidate(
   run: RepositoryMigrationRunRow,
   candidate: MigrationCandidate,
@@ -731,6 +767,7 @@ async function migrateCandidate(
 
     let stored: MigrationStoredObject;
     let declaredContentType: string;
+    let sourceObjectBytesAvailable = true;
     let comparisonSegments = candidate.legacySegments;
     let textBody =
       candidate.sourceKind === "repository_item"
@@ -782,11 +819,36 @@ async function migrateCandidate(
         candidate.sourceKind === "repository_item"
           ? (stringValue(metadata, "contentType") ?? "application/octet-stream")
           : candidate.contentType || "application/octet-stream";
-      stored = await storage.inspectAndCopyObject({
-        sourceKey: candidate.source,
-        targetKey,
-      });
-      declaredContentType = stored.contentType ?? declaredContentType;
+      try {
+        stored = await storage.inspectAndCopyObject({
+          sourceKey: candidate.source,
+          targetKey,
+        });
+        declaredContentType = stored.contentType ?? declaredContentType;
+      } catch (error) {
+        if (!isMissingMigrationSourceObject(error)) throw error;
+        const fallbackBody = buildLegacyMigrationFallbackBody(
+          candidate.legacySegments
+        );
+        if (!fallbackBody) {
+          throw new UnrecoverableMigrationSourceError(
+            "Legacy source object and extracted content are unavailable"
+          );
+        }
+        sourceObjectBytesAvailable = false;
+        comparisonSegments = candidate.legacySegments;
+        declaredContentType = "text/plain";
+        stored = await storage.putObject({
+          targetKey,
+          body: fallbackBody,
+          contentType: declaredContentType,
+          metadata: {
+            migrationSourceKind: candidate.sourceKind,
+            migrationSourceId: candidate.sourceId.toString(),
+            recoveredFromLegacySegments: "true",
+          },
+        });
+      }
     }
 
     const registration = await registerCanonicalUpload({
@@ -822,9 +884,17 @@ async function migrateCandidate(
           canonicalObjectKey: targetKey,
           sourceRecordCount: sourceContent.recordCount,
           sourceContentSha256: sourceContent.sha256,
-          sourceObjectSha256: stored.sha256,
+          sourceObjectSha256: sourceObjectBytesAvailable
+            ? stored.sha256
+            : null,
           canonicalObjectSha256: stored.sha256,
           status: "migrated",
+          metadata: {
+            ...reserved.migration.metadata,
+            ...(sourceObjectBytesAvailable
+              ? {}
+              : { recoveredFromLegacySegments: true }),
+          },
           lastErrorCode: null,
           lastErrorMessage: null,
           migratedAt: new Date(),
@@ -855,7 +925,7 @@ async function migrateCandidate(
   }
 }
 
-async function updateRunCursor(
+export async function updateRepositoryMigrationRunCursor(
   runId: string,
   sourceKind: RepositoryMigrationSourceKind,
   sourceId: number,
@@ -865,15 +935,29 @@ async function updateRunCursor(
       db.execute(sql`
         UPDATE repository_migration_runs
         SET cursor = cursor || jsonb_build_object(
-              ${sourceKind},
+              ${sourceKind}::text,
               GREATEST(
-                COALESCE((cursor->>${sourceKind})::bigint, 0),
+                COALESCE((cursor->>${sourceKind}::text)::bigint, 0),
                 ${sourceId}
               )
             ),
             updated_at = NOW()
         WHERE id = ${runId}::uuid
-        RETURNING *
+        RETURNING
+          id,
+          mode,
+          status,
+          requested_by AS "requestedBy",
+          source_kinds AS "sourceKinds",
+          cursor,
+          snapshot,
+          metrics,
+          recovery_window_ends_at AS "recoveryWindowEndsAt",
+          error_message AS "errorMessage",
+          started_at AS "startedAt",
+          finished_at AS "finishedAt",
+          created_at AS "createdAt",
+          updated_at AS "updatedAt"
       `),
     "contentMigration.advanceCursor",
   );
@@ -900,9 +984,8 @@ async function updateRunCursor(
   };
 }
 
-async function metricsForRun(
+export async function getRepositoryMigrationRunMetrics(
   runId: string | null,
-  useOriginRun = false,
 ): Promise<RepositoryMigrationMetrics> {
   const rows = toPgRows<{ status: string; count: number }>(
     await executeQuery(
@@ -912,11 +995,7 @@ async function metricsForRun(
           FROM repository_migration_items
           ${
             runId
-              ? sql`WHERE ${
-                  useOriginRun
-                    ? sql`origin_run_id = ${runId}::uuid`
-                    : sql`run_id = ${runId}::uuid`
-                }`
+              ? sql`WHERE run_id = ${runId}::uuid`
               : sql``
           }
           GROUP BY status
@@ -925,17 +1004,18 @@ async function metricsForRun(
     ),
   );
   const counts = Object.fromEntries(rows.map((row) => [row.status, row.count]));
+  const excluded = counts.excluded ?? 0;
   return {
-    discovered: Object.values(counts).reduce(
-      (total, count) => total + count,
-      0,
-    ),
+    discovered:
+      Object.values(counts).reduce((total, count) => total + count, 0) -
+      excluded,
     migrated:
       (counts.migrated ?? 0) + (counts.verified ?? 0) + (counts.mismatch ?? 0),
     verified: counts.verified ?? 0,
     mismatched: counts.mismatch ?? 0,
     failed: counts.failed ?? 0,
     unrecoverable: counts.unrecoverable ?? 0,
+    excluded,
     rolledBack: counts.rolled_back ?? 0,
   };
 }
@@ -943,7 +1023,11 @@ async function metricsForRun(
 async function finishBackfillRun(
   run: RepositoryMigrationRunRow,
 ): Promise<void> {
-  const metrics = await metricsForRun(run.id, true);
+  // A retry preserves origin_run_id so rollback still belongs to the original
+  // backfill, but its operational result belongs to the retry run that
+  // currently owns the item. Count run_id here so one-source retries retain
+  // accurate discovered/migrated/error evidence.
+  const metrics = await getRepositoryMigrationRunMetrics(run.id);
   const recoveryDaysRow = toPgRows<{ value: string | null }>(
     await executeQuery(
       (db) =>
@@ -997,7 +1081,7 @@ async function processBackfillBatch(
     ) {
       const candidate = await loadNextCandidate(run, sourceKind);
       if (!candidate) {
-        run = await updateRunCursor(
+        run = await updateRepositoryMigrationRunCursor(
           run.id,
           sourceKind,
           run.snapshot.maximumIds?.[sourceKind] ?? 0,
@@ -1005,7 +1089,11 @@ async function processBackfillBatch(
         break;
       }
       await migrateCandidate(run, candidate, storage);
-      run = await updateRunCursor(run.id, sourceKind, candidate.sourceId);
+      run = await updateRepositoryMigrationRunCursor(
+        run.id,
+        sourceKind,
+        candidate.sourceId
+      );
       processed += 1;
     }
     if (processed >= MIGRATION_BATCH_SIZE) break;
@@ -1030,6 +1118,10 @@ async function reconcileNextBatch(
           and(
             inArray(repositoryMigrationItems.status, ["migrated", "mismatch"]),
             sql`${repositoryMigrationItems.canonicalVersionId} IS NOT NULL`,
+            sql`COALESCE(
+              ${repositoryMigrationItems.metadata} ->> 'lastReconciledRunId',
+              ''
+            ) <> ${run.id}`,
           ),
         )
         .orderBy(repositoryMigrationItems.updatedAt)
@@ -1057,19 +1149,35 @@ async function reconcileNextBatch(
       const evidence = toPgRows<{
         processing_status: string | null;
         object_sha256: string | null;
-        canonical_segments: string[];
+        canonical_record_count: number;
+        canonical_text_sha256: string | null;
       }>(
         await tx.execute(sql`
           SELECT
             version.processing_status,
             version.sha256 AS object_sha256,
-            ARRAY(
-              SELECT chunk.content
+            (
+              SELECT COUNT(*)::integer
               FROM repository_item_chunks chunk
               WHERE chunk.item_version_id = version.id
-                AND chunk.segment_level = 'chunk'
-              ORDER BY chunk.chunk_index, chunk.id
-            ) AS canonical_segments
+            ) AS canonical_record_count,
+            (
+              SELECT COALESCE(
+                artifact.sha256,
+                CASE
+                  WHEN artifact.text_inline IS NOT NULL
+                  THEN encode(
+                    sha256(convert_to(artifact.text_inline, 'UTF8')),
+                    'hex'
+                  )
+                END
+              )
+              FROM repository_artifacts artifact
+              WHERE artifact.item_version_id = version.id
+                AND artifact.kind = 'canonical_text'
+              ORDER BY artifact.created_at DESC
+              LIMIT 1
+            ) AS canonical_text_sha256
           FROM repository_item_versions version
           WHERE version.id = ${migration.canonicalVersionId}::uuid
           LIMIT 1
@@ -1081,9 +1189,10 @@ async function reconcileNextBatch(
       ) {
         return "pending" as const;
       }
-      const canonicalContent = buildMigrationContentEvidence(
-        evidence?.canonical_segments ?? [],
-      );
+      const canonicalContent = {
+        recordCount: evidence?.canonical_record_count ?? 0,
+        sha256: evidence?.canonical_text_sha256 ?? null,
+      };
       const approvedMismatch =
         typeof migration.metadata.approvedMismatchAt === "string";
       const decision = reconcileMigrationEvidence({
@@ -1113,6 +1222,10 @@ async function reconcileNextBatch(
               ? decision.reasons.join("; ").slice(0, 4_000)
               : null,
           verifiedAt: decision.status === "verified" ? new Date() : null,
+          metadata: {
+            ...migration.metadata,
+            lastReconciledRunId: run.id,
+          },
           updatedAt: new Date(),
         })
         .where(eq(repositoryMigrationItems.id, migration.id));
@@ -1127,13 +1240,15 @@ async function reconcileNextBatch(
           db.execute(sql`
           SELECT COUNT(*)::integer AS count
           FROM repository_migration_items
-          WHERE status = 'migrated'
+          WHERE status IN ('migrated', 'mismatch')
+            AND canonical_version_id IS NOT NULL
+            AND COALESCE(metadata ->> 'lastReconciledRunId', '') <> ${run.id}
         `),
         "contentMigration.remainingReconciliation",
       ),
     )[0]?.count ?? 0;
   if (remaining === 0 && pending === 0) {
-    const metrics = await metricsForRun(null);
+    const metrics = await getRepositoryMigrationRunMetrics(null);
     await executeQuery(
       (db) =>
         db

--- a/lib/repositories/content-platform/migration-runner.ts
+++ b/lib/repositories/content-platform/migration-runner.ts
@@ -836,7 +836,6 @@ async function migrateCandidate(
           );
         }
         sourceObjectBytesAvailable = false;
-        comparisonSegments = candidate.legacySegments;
         declaredContentType = "text/plain";
         stored = await storage.putObject({
           targetKey,

--- a/lib/repositories/content-platform/post-deploy-recovery.ts
+++ b/lib/repositories/content-platform/post-deploy-recovery.ts
@@ -163,11 +163,11 @@ export async function releasePostDeployRecoveryJobs(
 
 /**
  * Rearm exhausted embedding generations only after the previous unbounded
- * embedding worker has drained. Migration 157 fences known connection-storm
+ * embedding worker has drained. Migration 159 fences known connection-storm
  * failures with the maximum attempt count and a timestamp; old workers cannot
  * claim them. The replacement scheduler clears that fence after the same
  * 20-minute handoff used by processing jobs, then the normal bounded recovery
- * path redispatches only missing vectors.
+ * path redispatches missing vectors or an activation-only generation.
  */
 export async function releasePostDeployEmbeddingGenerations(
   options: ReleasePostDeployRecoveryOptions = {}
@@ -193,14 +193,6 @@ export async function releasePostDeployEmbeddingGenerations(
               SELECT 1
               FROM repository_item_chunks chunk
               WHERE chunk.index_generation_id = generation.id
-                AND (
-                  chunk.embedding IS NULL
-                  OR (
-                    generation.visual_embedding_model IS NOT NULL
-                    AND chunk.modality IN ('image', 'video')
-                    AND chunk.visual_embedding IS NULL
-                  )
-                )
             )
             AND NOT EXISTS (
               SELECT 1

--- a/lib/repositories/content-platform/post-deploy-recovery.ts
+++ b/lib/repositories/content-platform/post-deploy-recovery.ts
@@ -13,13 +13,20 @@ export const POST_DEPLOY_RECOVERY_MARKER =
   "unified-content-runtime-v2" as const;
 export const POST_DEPLOY_ARTIFACT_RECOVERY_MARKER =
   "unified-content-artifact-v3" as const;
+export const POST_DEPLOY_EMBEDDING_CONCURRENCY_MARKER =
+  "embedding-concurrency-v1" as const;
 export const POST_DEPLOY_RECOVERY_BATCH_SIZE = 25;
+export const POST_DEPLOY_EMBEDDING_RECOVERY_BATCH_SIZE = 10;
 /** Let every invocation of the previous 15-minute Lambda runtime drain first. */
 export const POST_DEPLOY_RECOVERY_GRACE_MINUTES = 20;
 
 export interface ReleasedPostDeployRecoveryJob {
   id: string;
   itemVersionId: string;
+}
+
+export interface ReleasedPostDeployEmbeddingGeneration {
+  id: string;
 }
 
 export interface ReleasePostDeployRecoveryOptions {
@@ -61,7 +68,8 @@ export async function releasePostDeployRecoveryJobs(
             AND job.status IN ('cancelled', 'failed', 'pending', 'queued', 'running')
             AND job.post_deploy_recovery IN (
               ${POST_DEPLOY_RECOVERY_MARKER},
-              ${POST_DEPLOY_ARTIFACT_RECOVERY_MARKER}
+              ${POST_DEPLOY_ARTIFACT_RECOVERY_MARKER},
+              ${POST_DEPLOY_EMBEDDING_CONCURRENCY_MARKER}
             )
             AND job.updated_at <= ${eligibleBefore}::timestamptz
             AND item.lifecycle_status = 'active'
@@ -151,4 +159,81 @@ export async function releasePostDeployRecoveryJobs(
     },
     "contentPlatform.releasePostDeployRecoveryJobs"
   );
+}
+
+/**
+ * Rearm exhausted embedding generations only after the previous unbounded
+ * embedding worker has drained. Migration 157 fences known connection-storm
+ * failures with the maximum attempt count and a timestamp; old workers cannot
+ * claim them. The replacement scheduler clears that fence after the same
+ * 20-minute handoff used by processing jobs, then the normal bounded recovery
+ * path redispatches only missing vectors.
+ */
+export async function releasePostDeployEmbeddingGenerations(
+  options: ReleasePostDeployRecoveryOptions = {}
+): Promise<ReleasedPostDeployEmbeddingGeneration[]> {
+  const graceMinutes =
+    options.graceMinutes ?? POST_DEPLOY_RECOVERY_GRACE_MINUTES;
+  const eligibleBefore = new Date(
+    (options.now ?? new Date()).getTime() - graceMinutes * 60_000
+  ).toISOString();
+  const markerPrefix = `${POST_DEPLOY_EMBEDDING_CONCURRENCY_MARKER}:`;
+  const released = await executeTransaction(
+    (tx) =>
+      tx.execute(sql`
+        WITH selected AS (
+          SELECT generation.id
+          FROM repository_index_generations generation
+          WHERE generation.status = 'failed'
+            AND generation.embedding_recovery_attempts >= 3
+            AND generation.embedding_recovery_queued_at
+              <= ${eligibleBefore}::timestamptz
+            AND generation.error_message LIKE ${`${markerPrefix}%`}
+            AND EXISTS (
+              SELECT 1
+              FROM repository_item_chunks chunk
+              WHERE chunk.index_generation_id = generation.id
+                AND (
+                  chunk.embedding IS NULL
+                  OR (
+                    generation.visual_embedding_model IS NOT NULL
+                    AND chunk.modality IN ('image', 'video')
+                    AND chunk.visual_embedding IS NULL
+                  )
+                )
+            )
+            AND NOT EXISTS (
+              SELECT 1
+              FROM repository_index_generations newer_generation
+              WHERE newer_generation.repository_id = generation.repository_id
+                AND newer_generation.status IN ('building', 'active', 'failed')
+                AND (
+                  newer_generation.created_at > generation.created_at
+                  OR (
+                    newer_generation.created_at = generation.created_at
+                    AND newer_generation.id > generation.id
+                  )
+                )
+            )
+          ORDER BY generation.embedding_recovery_queued_at, generation.id
+          FOR UPDATE OF generation SKIP LOCKED
+          LIMIT ${POST_DEPLOY_EMBEDDING_RECOVERY_BATCH_SIZE}
+        )
+        UPDATE repository_index_generations generation
+        SET embedding_recovery_attempts = 0,
+            embedding_recovery_queued_at = NULL,
+            error_message = concat(
+              'Released after bounded embedding worker deployment; previous error: ',
+              substring(
+                generation.error_message
+                FROM ${markerPrefix.length + 1}
+              )
+            )
+        FROM selected
+        WHERE generation.id = selected.id
+        RETURNING generation.id
+      `),
+    "contentPlatform.releasePostDeployEmbeddingGenerations"
+  );
+  return toPgRows<{ id: string }>(released);
 }

--- a/lib/repositories/content-platform/publication-service.ts
+++ b/lib/repositories/content-platform/publication-service.ts
@@ -4,6 +4,7 @@ import {
   desc,
   eq,
   inArray,
+  isNull,
   ne,
   sql,
   type SQLWrapper,
@@ -115,6 +116,60 @@ export type PublishPdfVersionResult = PublishDocumentVersionResult;
 export const MAX_INLINE_ARTIFACT_CHARACTERS = 1_000_000;
 export const REPOSITORY_PUBLICATION_STATEMENT_TIMEOUT_MS = 240_000;
 export const REPOSITORY_PUBLICATION_TRANSACTION_DEADLINE_MS = 270_000;
+
+interface ExistingCanonicalArtifact {
+  id: string;
+  itemVersionId: string;
+  kind: RepositoryArtifactKind;
+  objectKey: string | null;
+  textInline: string | null;
+  processorName: string;
+  processorVersion: string;
+  sha256: string | null;
+}
+
+function assertCanonicalArtifactReplayBinding(
+  input: PublishDocumentVersionInput,
+  artifact: ExistingCanonicalArtifact,
+  canonicalTextSha256: string,
+): void {
+  if (
+    artifact.itemVersionId !== input.itemVersionId ||
+    artifact.kind !== "canonical_text" ||
+    artifact.processorName !== input.processorName ||
+    artifact.processorVersion !== input.processorVersion
+  ) {
+    throw new Error(
+      "Existing canonical artifact coordinates do not match the replay",
+    );
+  }
+  if (artifact.objectKey !== (input.canonicalTextObjectKey ?? null)) {
+    throw new Error(
+      "Existing canonical artifact object key does not match the replay",
+    );
+  }
+  if (
+    artifact.textInline !== null &&
+    artifact.textInline !== (input.canonicalText ?? null)
+  ) {
+    throw new Error(
+      "Existing canonical artifact inline text does not match the replay",
+    );
+  }
+  if (artifact.objectKey === null && artifact.textInline === null) {
+    throw new Error("Existing canonical artifact has no bound payload");
+  }
+  const storedSha256 =
+    artifact.sha256 ??
+    (artifact.textInline
+      ? createHash("sha256").update(artifact.textInline).digest("hex")
+      : null);
+  if (storedSha256 && storedSha256 !== canonicalTextSha256) {
+    throw new Error(
+      "Existing canonical artifact SHA-256 does not match the replay",
+    );
+  }
+}
 
 /**
  * Repository publication copies the previous immutable generation before
@@ -240,6 +295,14 @@ export async function publishDocumentVersion(
 ): Promise<PublishDocumentVersionResult> {
   validatePublicationInput(input);
   const key = artifactKey(input);
+  const canonicalTextSha256 =
+    input.canonicalTextSha256 ??
+    (input.canonicalText
+      ? createHash("sha256").update(input.canonicalText).digest("hex")
+      : undefined);
+  if (!canonicalTextSha256) {
+    throw new Error("Canonical text SHA-256 is required");
+  }
 
   return executeTransaction(
     async (tx) => {
@@ -334,10 +397,41 @@ export async function publishDocumentVersion(
         buildingGeneration?.id ?? context.activeGenerationId;
 
       const [existingArtifact] = await tx
-        .select({ id: repositoryArtifacts.id })
+        .select({
+          id: repositoryArtifacts.id,
+          itemVersionId: repositoryArtifacts.itemVersionId,
+          kind: repositoryArtifacts.kind,
+          objectKey: repositoryArtifacts.objectKey,
+          textInline: repositoryArtifacts.textInline,
+          processorName: repositoryArtifacts.processorName,
+          processorVersion: repositoryArtifacts.processorVersion,
+          sha256: repositoryArtifacts.sha256,
+        })
         .from(repositoryArtifacts)
         .where(eq(repositoryArtifacts.artifactKey, key))
         .limit(1);
+      if (existingArtifact) {
+        assertCanonicalArtifactReplayBinding(
+          input,
+          existingArtifact,
+          canonicalTextSha256,
+        );
+      }
+      if (
+        existingArtifact &&
+        existingArtifact.sha256 === null &&
+        canonicalTextSha256
+      ) {
+        await tx
+          .update(repositoryArtifacts)
+          .set({ sha256: canonicalTextSha256 })
+          .where(
+            and(
+              eq(repositoryArtifacts.id, existingArtifact.id),
+              isNull(repositoryArtifacts.sha256)
+            )
+          );
+      }
 
       if (
         existingArtifact &&
@@ -388,13 +482,7 @@ export async function publishDocumentVersion(
               kind: "canonical_text",
               mediaType: "text/markdown",
               objectKey: input.canonicalTextObjectKey,
-              sha256:
-                input.canonicalTextSha256 ??
-                (input.canonicalText
-                  ? createHash("sha256")
-                      .update(input.canonicalText)
-                      .digest("hex")
-                  : undefined),
+              sha256: canonicalTextSha256,
               textInline:
                 input.canonicalText &&
                 input.canonicalText.length <= MAX_INLINE_ARTIFACT_CHARACTERS

--- a/lib/repositories/content-platform/publication-service.ts
+++ b/lib/repositories/content-platform/publication-service.ts
@@ -1,4 +1,13 @@
-import { and, desc, eq, inArray, ne, sql } from "drizzle-orm";
+import { createHash } from "node:crypto";
+import {
+  and,
+  desc,
+  eq,
+  inArray,
+  ne,
+  sql,
+  type SQLWrapper,
+} from "drizzle-orm";
 import { executeTransaction } from "@/lib/db/drizzle-client";
 import {
   knowledgeRepositories,
@@ -53,6 +62,7 @@ export interface PublishDocumentVersionInput {
   malwareScanRequired: boolean;
   canonicalText?: string;
   canonicalTextObjectKey?: string;
+  canonicalTextSha256?: string;
   segments: PublishableSegment[];
   artifactMetadata?: Record<string, unknown>;
   additionalArtifacts?: PublishableArtifact[];
@@ -103,6 +113,29 @@ export function isPublicationTargetActive(
 export type PublishPdfVersionResult = PublishDocumentVersionResult;
 
 export const MAX_INLINE_ARTIFACT_CHARACTERS = 1_000_000;
+export const REPOSITORY_PUBLICATION_STATEMENT_TIMEOUT_MS = 240_000;
+export const REPOSITORY_PUBLICATION_TRANSACTION_DEADLINE_MS = 270_000;
+
+/**
+ * Repository publication copies the previous immutable generation before
+ * swapping in one changed item. Large repositories can legitimately exceed
+ * the dev pool's global 60-second statement limit while copying vectors.
+ * Keep the override local to this transaction and below both the transaction
+ * deadline and the 15-minute worker timeout.
+ */
+export async function configureRepositoryPublicationTransaction(
+  tx: {
+    execute(query: string | SQLWrapper): PromiseLike<unknown>;
+  }
+): Promise<void> {
+  await tx.execute(sql`
+    SELECT set_config(
+      'statement_timeout',
+      ${REPOSITORY_PUBLICATION_STATEMENT_TIMEOUT_MS.toString()},
+      true
+    )
+  `);
+}
 
 function artifactKey(input: PublishDocumentVersionInput): string {
   return `${input.itemVersionId}:canonical_text:${input.processorVersion}`;
@@ -123,6 +156,19 @@ function validatePublicationInput(input: PublishDocumentVersionInput): void {
   }
   if (!input.canonicalText && !input.canonicalTextObjectKey) {
     throw new Error("Canonical text or its object key is required");
+  }
+  if (
+    input.canonicalTextSha256 &&
+    !/^[0-9a-f]{64}$/.test(input.canonicalTextSha256)
+  ) {
+    throw new Error("Canonical text SHA-256 must be lowercase hex");
+  }
+  if (
+    input.canonicalTextObjectKey &&
+    !input.canonicalText &&
+    !input.canonicalTextSha256
+  ) {
+    throw new Error("Object-backed canonical text requires a SHA-256");
   }
   if (
     input.canonicalText &&
@@ -197,6 +243,7 @@ export async function publishDocumentVersion(
 
   return executeTransaction(
     async (tx) => {
+      await configureRepositoryPublicationTransaction(tx);
       const [coordinates] = await tx
         .select({
           itemId: repositoryItemVersions.itemId,
@@ -341,6 +388,13 @@ export async function publishDocumentVersion(
               kind: "canonical_text",
               mediaType: "text/markdown",
               objectKey: input.canonicalTextObjectKey,
+              sha256:
+                input.canonicalTextSha256 ??
+                (input.canonicalText
+                  ? createHash("sha256")
+                      .update(input.canonicalText)
+                      .digest("hex")
+                  : undefined),
               textInline:
                 input.canonicalText &&
                 input.canonicalText.length <= MAX_INLINE_ARTIFACT_CHARACTERS
@@ -550,7 +604,10 @@ export async function publishDocumentVersion(
       };
     },
     "contentPlatform.publishDocumentVersion",
-    { isolationLevel: "serializable" }
+    {
+      isolationLevel: "serializable",
+      deadlineMs: REPOSITORY_PUBLICATION_TRANSACTION_DEADLINE_MS,
+    }
   );
 }
 

--- a/lib/repositories/content-platform/status-service.ts
+++ b/lib/repositories/content-platform/status-service.ts
@@ -38,6 +38,7 @@ interface CanonicalStatusRow {
   postDeployRecovery:
     | "unified-content-runtime-v2"
     | "unified-content-artifact-v3"
+    | "embedding-concurrency-v1"
     | null;
   active: boolean;
   buildingGeneration: boolean;

--- a/lib/repositories/content-platform/text-processing.ts
+++ b/lib/repositories/content-platform/text-processing.ts
@@ -15,6 +15,12 @@ export const TEXT_CONTENT_TYPES = [
 
 export type CanonicalTextContentType = (typeof TEXT_CONTENT_TYPES)[number];
 
+const TEXT_CONTENT_TYPE_ALIASES: Readonly<
+  Record<string, CanonicalTextContentType>
+> = {
+  "text/x-python": "text/plain",
+};
+
 export interface CanonicalTextSegment {
   content: string;
   contentHash: string;
@@ -45,8 +51,11 @@ interface TextSection {
 
 export function isCanonicalTextContentType(
   contentType: string
-): contentType is CanonicalTextContentType {
-  return (TEXT_CONTENT_TYPES as readonly string[]).includes(contentType);
+): boolean {
+  return (
+    (TEXT_CONTENT_TYPES as readonly string[]).includes(contentType) ||
+    TEXT_CONTENT_TYPE_ALIASES[contentType] !== undefined
+  );
 }
 
 function normalizeText(source: Uint8Array): string {
@@ -104,9 +113,12 @@ export function extractCanonicalTextDocument(
   if (!isCanonicalTextContentType(contentType)) {
     throw new Error("Unsupported canonical text content type");
   }
+  const canonicalContentType =
+    TEXT_CONTENT_TYPE_ALIASES[contentType] ??
+    (contentType as CanonicalTextContentType);
   const canonicalText = normalizeText(source);
   const sections =
-    contentType === "text/markdown"
+    canonicalContentType === "text/markdown"
       ? markdownSections(canonicalText)
       : [{ heading: null, content: canonicalText }];
   const label = sourceLabel(fileName);
@@ -138,7 +150,7 @@ export function extractCanonicalTextDocument(
 
   return {
     canonicalText,
-    detectedContentType: contentType,
+    detectedContentType: canonicalContentType,
     processorVersion: TEXT_PROCESSOR_VERSION,
     segments,
     metadata: {

--- a/lib/repositories/google-drive/formats.ts
+++ b/lib/repositories/google-drive/formats.ts
@@ -85,8 +85,19 @@ export function resolveGoogleDriveExportFormat(
     matches(sourceMimeType),
   );
   if (!mapping) return null;
+  const contentType =
+    mapping.type === "text" &&
+    sourceMimeType !== "text/markdown" &&
+    sourceMimeType !== "text/csv"
+      ? "text/plain"
+      : sourceMimeType;
   return {
-    contentType: sourceMimeType,
+    // The canonical text processor deliberately has a narrow media-type
+    // contract. Drive uses many vendor text subtypes (for example
+    // text/x-python); their original MIME type remains in connector/version
+    // metadata while the byte-identical UTF-8 source is processed as plain
+    // text.
+    contentType,
     extension: "",
     method: "blob",
     repositoryItemType: mapping.type,

--- a/scripts/db/finalize-unified-content-retirement.ts
+++ b/scripts/db/finalize-unified-content-retirement.ts
@@ -119,6 +119,7 @@ async function readSnapshot(
       (
         SELECT COUNT(*)::integer
         FROM repository_migration_items
+        WHERE status <> 'excluded'
       ) AS discovered,
       (
         SELECT COUNT(*)::integer
@@ -246,6 +247,15 @@ async function readSnapshot(
         WHERE item.lifecycle_status = 'active'
           AND repository.lifecycle_status = 'active'
           AND item.type IN ('document', 'text', 'url')
+          AND NOT (
+            COALESCE(item.metadata, '{}'::jsonb) ? 'migrationSourceKind'
+          )
+          AND NOT EXISTS (
+            SELECT 1
+            FROM repository_connector_sources connector_source
+            WHERE connector_source.repository_item_id = item.id
+              AND connector_source.status = 'unsupported'
+          )
           AND (
             item.current_version_id IS NULL
             OR EXISTS (

--- a/tests/smoke/unified-content-foundation.smoke.ts
+++ b/tests/smoke/unified-content-foundation.smoke.ts
@@ -30,6 +30,7 @@ import {
   repositoryItemChunks,
   repositoryItems,
   repositoryItemVersions,
+  repositoryMigrationItems,
   repositoryMigrationRuns,
   repositoryProcessingJobs,
   repositoryUploadSessions,
@@ -60,6 +61,7 @@ import {
   publishDocumentVersion,
   publishPdfVersion,
   POST_DEPLOY_RECOVERY_MARKER,
+  processNextRepositoryMigrationBatch,
   recordRepositoryProcessingFailure,
   recordRepositorySecurityBlock,
   reconcileRepositoryProcessingDlqMessage,
@@ -72,7 +74,9 @@ import {
   retryCanonicalRepositoryItem,
   segmentPdfPages,
   sourceRevisionForObjectKey,
+  startRepositoryRollbackRun,
   updateRepositoryMigrationRunCursor,
+  type RepositoryMigrationStorage,
   type RepositoryUploadStorage,
 } from "@/lib/repositories/content-platform";
 import { keywordSearch } from "@/lib/repositories/search-service";
@@ -119,6 +123,17 @@ const embeddingConcurrencyRecoveryStatements =
     .split(/;\s*(?:\r?\n|$)/)
     .map((statement) => statement.trim())
     .filter((statement) => statement.length > 0);
+const migrationSourceEligibilitySql = readFileSync(
+  resolve(
+    process.cwd(),
+    "infra/database/schema/160-unified-content-migration-source-eligibility.sql"
+  ),
+  "utf8"
+);
+const migrationSourceEligibilityStatements = migrationSourceEligibilitySql
+  .split(/;\s*(?:\r?\n|$)/)
+  .map((statement) => statement.trim())
+  .filter((statement) => statement.length > 0);
 
 async function applyPostDeployHandoff(context: string): Promise<void> {
   for (const [index, statement] of postDeployHandoffStatements.entries()) {
@@ -152,12 +167,30 @@ async function applyEmbeddingConcurrencyRecovery(
   }
 }
 
+async function applyMigrationSourceEligibility(context: string): Promise<void> {
+  for (const [
+    index,
+    statement,
+  ] of migrationSourceEligibilityStatements.entries()) {
+    await executeQuery(
+      (db) => db.execute(sql.raw(statement)),
+      `${context}.${index + 1}`
+    );
+  }
+}
+
 // The deployment always migrates the database before the application or worker
 // loads the expanded Drizzle schema. Reproduce that order in the standalone
 // smoke, whose local database may predate this branch.
 await applyPostDeployHandoff("smoke.unifiedContent.ensurePostDeploySchema");
 await applyArtifactStateRecovery(
   "smoke.unifiedContent.ensureArtifactRecoverySchema"
+);
+await applyMigrationSourceEligibility(
+  "smoke.unifiedContent.ensureMigrationSourceEligibility"
+);
+await applyMigrationSourceEligibility(
+  "smoke.unifiedContent.reapplyMigrationSourceEligibility"
 );
 const font = await pdf.embedFont(StandardFonts.Helvetica);
 for (const text of [
@@ -271,6 +304,103 @@ try {
           .delete(repositoryMigrationRuns)
           .where(eq(repositoryMigrationRuns.id, cursorRun.id)),
       "smoke.unifiedContent.cleanupCursorRun"
+    );
+  }
+
+  const [excludedRollbackParent] = await executeQuery(
+    (db) =>
+      db
+        .insert(repositoryMigrationRuns)
+        .values({
+          mode: "backfill",
+          status: "completed_with_errors",
+          requestedBy: owner.id,
+          sourceKinds: ["assistant_pdf_job"],
+          snapshot: {
+            counts: { assistant_pdf_job: 1 },
+            maximumIds: { assistant_pdf_job: 1 },
+          },
+          metrics: { discovered: 1, excluded: 1 },
+          recoveryWindowEndsAt: new Date(Date.now() + 60_000),
+          startedAt: new Date(),
+          finishedAt: new Date(),
+        })
+        .returning({ id: repositoryMigrationRuns.id }),
+    "smoke.unifiedContent.createExcludedRollbackParent"
+  );
+  assert.ok(excludedRollbackParent);
+  let excludedRollbackRunId: string | null = null;
+  try {
+    await executeQuery(
+      (db) =>
+        db.insert(repositoryMigrationItems).values({
+          runId: excludedRollbackParent.id,
+          originRunId: excludedRollbackParent.id,
+          sourceKind: "assistant_pdf_job",
+          sourceId: Date.now(),
+          ownerId: owner.id,
+          status: "excluded",
+          lastErrorCode: "MIGRATION_SOURCE_EXCLUDED",
+          metadata: {
+            exclusionReason: "unsupported_connector_source",
+            excludedAt: new Date().toISOString(),
+          },
+        }),
+      "smoke.unifiedContent.createExcludedRollbackItem"
+    );
+    const excludedRollbackRun = await startRepositoryRollbackRun({
+      parentRunId: excludedRollbackParent.id,
+      requestedBy: owner.id,
+    });
+    excludedRollbackRunId = excludedRollbackRun.id;
+    const rollbackStorage: RepositoryMigrationStorage = {
+      inspectAndCopyObject: async () => {
+        throw new Error("Excluded rollback must not inspect source objects");
+      },
+      putObject: async () => {
+        throw new Error("Excluded rollback must not create source objects");
+      },
+      deleteObject: async () => {
+        throw new Error("Excluded rollback must not delete source objects");
+      },
+    };
+    assert.deepEqual(
+      await processNextRepositoryMigrationBatch(rollbackStorage),
+      { runId: excludedRollbackRun.id, mode: "rollback" }
+    );
+    const [completedExcludedRollback] = await executeQuery(
+      (db) =>
+        db
+          .select({
+            status: repositoryMigrationRuns.status,
+            metrics: repositoryMigrationRuns.metrics,
+          })
+          .from(repositoryMigrationRuns)
+          .where(eq(repositoryMigrationRuns.id, excludedRollbackRun.id))
+          .limit(1),
+      "smoke.unifiedContent.readExcludedRollback"
+    );
+    assert.deepEqual(completedExcludedRollback, {
+      status: "rolled_back",
+      metrics: { rolledBack: 0, excluded: 1 },
+    });
+  } finally {
+    const rollbackRunId = excludedRollbackRunId;
+    if (rollbackRunId) {
+      await executeQuery(
+        (db) =>
+          db
+            .delete(repositoryMigrationRuns)
+            .where(eq(repositoryMigrationRuns.id, rollbackRunId)),
+        "smoke.unifiedContent.cleanupExcludedRollbackRun"
+      );
+    }
+    await executeQuery(
+      (db) =>
+        db
+          .delete(repositoryMigrationRuns)
+          .where(eq(repositoryMigrationRuns.id, excludedRollbackParent.id)),
+      "smoke.unifiedContent.cleanupExcludedRollbackParent"
     );
   }
 
@@ -1938,6 +2068,79 @@ try {
     canonicalTextArtifact?.sha256,
     createHash("sha256").update(textExtraction.canonicalText).digest("hex")
   );
+  const canonicalTextSha256 = createHash("sha256")
+    .update(textExtraction.canonicalText)
+    .digest("hex");
+  const canonicalTextObjectKey =
+    `repositories/${repository.id}/artifacts/${textRegistration.version.id}/canonical-text.md`;
+  await executeQuery(
+    (db) =>
+      db
+        .update(repositoryArtifacts)
+        .set({
+          objectKey: canonicalTextObjectKey,
+          textInline: null,
+          sha256: null,
+        })
+        .where(eq(repositoryArtifacts.id, textPublication.artifactId)),
+    "smoke.unifiedContent.createLegacyObjectBackedArtifact"
+  );
+  await assert.rejects(
+    publishDocumentVersion({
+      itemVersionId: textRegistration.version.id,
+      processorVersion: textExtraction.processorVersion,
+      processorName: "aistudio-text",
+      detectedContentType: textExtraction.detectedContentType,
+      inspectionStatus: "clean",
+      malwareScanRequired: true,
+      canonicalTextObjectKey: `${canonicalTextObjectKey}.mismatched`,
+      canonicalTextSha256,
+      segments: textExtraction.segments,
+      artifactMetadata: textExtraction.metadata,
+    }),
+    /object key does not match the replay/
+  );
+  const [rejectedReplayArtifact] = await executeQuery(
+    (db) =>
+      db
+        .select({ sha256: repositoryArtifacts.sha256 })
+        .from(repositoryArtifacts)
+        .where(eq(repositoryArtifacts.id, textPublication.artifactId))
+        .limit(1),
+    "smoke.unifiedContent.readRejectedLegacyArtifactReplay"
+  );
+  assert.equal(rejectedReplayArtifact?.sha256, null);
+  const legacyArtifactReplay = await publishDocumentVersion({
+    itemVersionId: textRegistration.version.id,
+    processorVersion: textExtraction.processorVersion,
+    processorName: "aistudio-text",
+    detectedContentType: textExtraction.detectedContentType,
+    inspectionStatus: "clean",
+    malwareScanRequired: true,
+    canonicalTextObjectKey,
+    canonicalTextSha256,
+    segments: textExtraction.segments,
+    artifactMetadata: textExtraction.metadata,
+  });
+  assert.equal(legacyArtifactReplay.replayed, true);
+  const [backfilledLegacyArtifact] = await executeQuery(
+    (db) =>
+      db
+        .select({
+          objectKey: repositoryArtifacts.objectKey,
+          textInline: repositoryArtifacts.textInline,
+          sha256: repositoryArtifacts.sha256,
+        })
+        .from(repositoryArtifacts)
+        .where(eq(repositoryArtifacts.id, textPublication.artifactId))
+        .limit(1),
+    "smoke.unifiedContent.readBackfilledLegacyArtifact"
+  );
+  assert.deepEqual(backfilledLegacyArtifact, {
+    objectKey: canonicalTextObjectKey,
+    textInline: null,
+    sha256: canonicalTextSha256,
+  });
   const canonicalTextResults = await retrieveRepositoryContent({
     query: "MOONLIT-HARBOR-SMOKE",
     repositoryIds: [repository.id],
@@ -2270,8 +2473,20 @@ try {
       }),
     "smoke.unifiedContent.createConnectionStormChunk"
   );
+  await executeQuery(
+    (db) =>
+      db.execute(sql`
+        UPDATE repository_item_chunks
+        SET embedding = ${smokeVector}::vector
+        WHERE index_generation_id = ${connectionStormGeneration.id}::uuid
+      `),
+    "smoke.unifiedContent.completeConnectionStormEmbeddings"
+  );
   await applyEmbeddingConcurrencyRecovery(
     "smoke.unifiedContent.applyEmbeddingConcurrencyRecovery"
+  );
+  await applyEmbeddingConcurrencyRecovery(
+    "smoke.unifiedContent.reapplyEmbeddingConcurrencyRecovery"
   );
   const [fencedConnectionStormGeneration] = await executeQuery(
     (db) =>
@@ -2328,6 +2543,7 @@ try {
   assert.ok(rearmedConnectionStormGeneration);
   assert.equal(rearmedConnectionStormGeneration.recoveryAttempt, 1);
   assert.equal(rearmedConnectionStormGeneration.previousStatus, "failed");
+  assert.equal(rearmedConnectionStormGeneration.activationOnly, true);
 
   const [activeLegacyItem] = await executeQuery(
     (db) =>

--- a/tests/smoke/unified-content-foundation.smoke.ts
+++ b/tests/smoke/unified-content-foundation.smoke.ts
@@ -12,6 +12,7 @@
  */
 
 import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { eq, sql, type SQL } from "drizzle-orm";
@@ -29,6 +30,7 @@ import {
   repositoryItemChunks,
   repositoryItems,
   repositoryItemVersions,
+  repositoryMigrationRuns,
   repositoryProcessingJobs,
   repositoryUploadSessions,
   users,
@@ -54,6 +56,7 @@ import {
   OFFICE_CONTENT_TYPES,
   IMAGE_PROCESSOR_VERSION,
   POST_DEPLOY_ARTIFACT_RECOVERY_MARKER,
+  POST_DEPLOY_EMBEDDING_CONCURRENCY_MARKER,
   publishDocumentVersion,
   publishPdfVersion,
   POST_DEPLOY_RECOVERY_MARKER,
@@ -61,12 +64,15 @@ import {
   recordRepositorySecurityBlock,
   reconcileRepositoryProcessingDlqMessage,
   releaseIncompleteEmbeddingGenerationClaim,
+  releasePostDeployEmbeddingGenerations,
   releasePostDeployRecoveryJobs,
   getCanonicalRepositoryItemStatuses,
+  getRepositoryMigrationInventory,
   registerCanonicalUpload,
   retryCanonicalRepositoryItem,
   segmentPdfPages,
   sourceRevisionForObjectKey,
+  updateRepositoryMigrationRunCursor,
   type RepositoryUploadStorage,
 } from "@/lib/repositories/content-platform";
 import { keywordSearch } from "@/lib/repositories/search-service";
@@ -101,6 +107,18 @@ const artifactStateRecoveryStatements = artifactStateRecoverySql
   .split(/;\s*(?:\r?\n|$)/)
   .map((statement) => statement.trim())
   .filter((statement) => statement.length > 0);
+const embeddingConcurrencyRecoverySql = readFileSync(
+  resolve(
+    process.cwd(),
+    "infra/database/schema/159-unified-content-concurrency-recovery.sql"
+  ),
+  "utf8"
+);
+const embeddingConcurrencyRecoveryStatements =
+  embeddingConcurrencyRecoverySql
+    .split(/;\s*(?:\r?\n|$)/)
+    .map((statement) => statement.trim())
+    .filter((statement) => statement.length > 0);
 
 async function applyPostDeployHandoff(context: string): Promise<void> {
   for (const [index, statement] of postDeployHandoffStatements.entries()) {
@@ -113,6 +131,20 @@ async function applyPostDeployHandoff(context: string): Promise<void> {
 
 async function applyArtifactStateRecovery(context: string): Promise<void> {
   for (const [index, statement] of artifactStateRecoveryStatements.entries()) {
+    await executeQuery(
+      (db) => db.execute(sql.raw(statement)),
+      `${context}.${index + 1}`
+    );
+  }
+}
+
+async function applyEmbeddingConcurrencyRecovery(
+  context: string
+): Promise<void> {
+  for (const [
+    index,
+    statement,
+  ] of embeddingConcurrencyRecoveryStatements.entries()) {
     await executeQuery(
       (db) => db.execute(sql.raw(statement)),
       `${context}.${index + 1}`
@@ -170,6 +202,78 @@ const [repository] = await executeQuery(
 assert.ok(repository);
 
 try {
+  const repositoryInventoryBefore = (
+    await getRepositoryMigrationInventory()
+  ).find((entry) => entry.sourceKind === "repository_item");
+  assert.ok(repositoryInventoryBefore);
+  await executeQuery(
+    (db) =>
+      db.insert(repositoryItems).values({
+        repositoryId: repository.id,
+        type: "document",
+        name: "Migration-created canonical target",
+        source: "legacy/missing-source.pdf",
+        metadata: {
+          migrationSourceKind: "nexus_document",
+          migrationSourceId: 999_999,
+        },
+      }),
+    "smoke.unifiedContent.createMigrationTargetInventoryExclusion"
+  );
+  const repositoryInventoryAfter = (
+    await getRepositoryMigrationInventory()
+  ).find((entry) => entry.sourceKind === "repository_item");
+  assert.equal(
+    repositoryInventoryAfter?.discovered,
+    repositoryInventoryBefore.discovered
+  );
+
+  const [cursorRun] = await executeQuery(
+    (db) =>
+      db
+        .insert(repositoryMigrationRuns)
+        .values({
+          mode: "backfill",
+          status: "running",
+          requestedBy: owner.id,
+          sourceKinds: ["repository_item"],
+          cursor: {},
+          snapshot: {
+            counts: { repository_item: 1 },
+            maximumIds: { repository_item: 8 },
+          },
+          metrics: { discovered: 1 },
+        })
+        .returning({ id: repositoryMigrationRuns.id }),
+    "smoke.unifiedContent.createCursorRun"
+  );
+  assert.ok(cursorRun);
+  try {
+    const advanced = await updateRepositoryMigrationRunCursor(
+      cursorRun.id,
+      "repository_item",
+      8
+    );
+    assert.equal(advanced.cursor.repository_item, 8);
+    assert.deepEqual(advanced.sourceKinds, ["repository_item"]);
+    assert.equal(advanced.snapshot.maximumIds?.repository_item, 8);
+    assert.equal(advanced.metrics.discovered, 1);
+    const monotonic = await updateRepositoryMigrationRunCursor(
+      cursorRun.id,
+      "repository_item",
+      5
+    );
+    assert.equal(monotonic.cursor.repository_item, 8);
+  } finally {
+    await executeQuery(
+      (db) =>
+        db
+          .delete(repositoryMigrationRuns)
+          .where(eq(repositoryMigrationRuns.id, cursorRun.id)),
+      "smoke.unifiedContent.cleanupCursorRun"
+    );
+  }
+
   const uploadStorage: RepositoryUploadStorage = {
     createSingleUpload: async () => ({ uploadUrl: "https://smoke.invalid/upload" }),
     createMultipartUpload: async () => {
@@ -1821,6 +1925,19 @@ try {
     segments: textExtraction.segments,
     artifactMetadata: textExtraction.metadata,
   });
+  const [canonicalTextArtifact] = await executeQuery(
+    (db) =>
+      db
+        .select({ sha256: repositoryArtifacts.sha256 })
+        .from(repositoryArtifacts)
+        .where(eq(repositoryArtifacts.id, textPublication.artifactId))
+        .limit(1),
+    "smoke.unifiedContent.canonicalTextHash"
+  );
+  assert.equal(
+    canonicalTextArtifact?.sha256,
+    createHash("sha256").update(textExtraction.canonicalText).digest("hex")
+  );
   const canonicalTextResults = await retrieveRepositoryContent({
     query: "MOONLIT-HARBOR-SMOKE",
     repositoryIds: [repository.id],
@@ -2112,6 +2229,106 @@ try {
     replayedActivation?.embedded_item_count,
     activation?.embedded_item_count
   );
+
+  const [connectionStormGeneration] = await executeQuery(
+    (db) =>
+      db
+        .insert(repositoryIndexGenerations)
+        .values({
+          repositoryId: repository.id,
+          status: "failed",
+          embeddingModel: "amazon-bedrock:amazon.titan-embed-text-v1",
+          embeddingDimensions: 1536,
+          segmentationVersion: "retrieval-v2",
+          processorVersion: "connection-storm-smoke-v1",
+          sourceVersionCount: 1,
+          segmentCount: 1,
+          embeddingRecoveryAttempts: 3,
+          errorMessage:
+            "Failed query: SELECT status FROM repository_index_generations",
+        })
+        .returning({ id: repositoryIndexGenerations.id }),
+    "smoke.unifiedContent.createConnectionStormGeneration"
+  );
+  assert.ok(connectionStormGeneration);
+  await executeQuery(
+    (db) =>
+      db.insert(repositoryItemChunks).values({
+        itemId: item.id,
+        itemVersionId: first.version.id,
+        indexGenerationId: connectionStormGeneration.id,
+        content: "Connection storm recovery test content.",
+        chunkIndex: 0,
+        metadata: {},
+        modality: "text",
+        contentHash: "e".repeat(64),
+        sourceLocator: { headingPath: ["Recovery"] },
+        contextPrefix: "Recovery",
+        segmentLevel: "section",
+        accessScope: {},
+        tokens: 6,
+      }),
+    "smoke.unifiedContent.createConnectionStormChunk"
+  );
+  await applyEmbeddingConcurrencyRecovery(
+    "smoke.unifiedContent.applyEmbeddingConcurrencyRecovery"
+  );
+  const [fencedConnectionStormGeneration] = await executeQuery(
+    (db) =>
+      db
+        .select({
+          status: repositoryIndexGenerations.status,
+          recoveryQueuedAt:
+            repositoryIndexGenerations.embeddingRecoveryQueuedAt,
+          recoveryAttempts:
+            repositoryIndexGenerations.embeddingRecoveryAttempts,
+          errorMessage: repositoryIndexGenerations.errorMessage,
+        })
+        .from(repositoryIndexGenerations)
+        .where(
+          eq(repositoryIndexGenerations.id, connectionStormGeneration.id)
+        )
+        .limit(1),
+    "smoke.unifiedContent.readFencedConnectionStormGeneration"
+  );
+  assert.equal(fencedConnectionStormGeneration?.status, "failed");
+  assert.ok(fencedConnectionStormGeneration?.recoveryQueuedAt);
+  assert.equal(fencedConnectionStormGeneration?.recoveryAttempts, 3);
+  assert.equal(
+    fencedConnectionStormGeneration?.errorMessage?.startsWith(
+      `${POST_DEPLOY_EMBEDDING_CONCURRENCY_MARKER}:`
+    ),
+    true
+  );
+  assert.equal(
+    (
+      await claimIncompleteEmbeddingGenerations({
+        now: new Date(Date.now() + 60_000),
+        intervalMinutes: 0,
+      })
+    ).some(
+      (generation) => generation.id === connectionStormGeneration.id
+    ),
+    false
+  );
+  assert.deepEqual(await releasePostDeployEmbeddingGenerations(), []);
+  assert.deepEqual(
+    await releasePostDeployEmbeddingGenerations({
+      graceMinutes: 0,
+      now: new Date(Date.now() + 60_000),
+    }),
+    [{ id: connectionStormGeneration.id }]
+  );
+  const rearmedConnectionStormGeneration = (
+    await claimIncompleteEmbeddingGenerations({
+      now: new Date(Date.now() + 2 * 60_000),
+      intervalMinutes: 0,
+    })
+  ).find((generation) => generation.id === connectionStormGeneration.id);
+  assert.ok(rearmedConnectionStormGeneration);
+  assert.equal(rearmedConnectionStormGeneration.recoveryAttempt, 1);
+  assert.equal(rearmedConnectionStormGeneration.previousStatus, "failed");
+
   const [activeLegacyItem] = await executeQuery(
     (db) =>
       db

--- a/tests/unit/lib/repositories/content-migration-reconciliation.test.ts
+++ b/tests/unit/lib/repositories/content-migration-reconciliation.test.ts
@@ -181,6 +181,15 @@ describe("unified content migration reconciliation", () => {
         ...readyInput,
         migrationMetrics: {
           ...readyInput.migrationMetrics,
+          excluded: 3,
+        },
+      }),
+    ).toEqual({ ready: true, blockers: [] });
+    expect(
+      assessContentRetirementReadiness({
+        ...readyInput,
+        migrationMetrics: {
+          ...readyInput.migrationMetrics,
           mismatched: 1,
           verified: 2,
         },

--- a/tests/unit/lib/repositories/content-migration-reconciliation.test.ts
+++ b/tests/unit/lib/repositories/content-migration-reconciliation.test.ts
@@ -1,5 +1,7 @@
 /** @jest-environment node */
 
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import {
   assessContentRetirementReadiness,
   buildMigrationContentEvidence,
@@ -7,9 +9,41 @@ import {
   isMigrationOwnedCanonicalVersion,
   reconcileMigrationEvidence,
 } from "@/lib/repositories/content-platform/migration-reconciliation";
-import { deterministicMigrationSourceId } from "@/lib/repositories/content-platform/migration-runner";
+import {
+  buildLegacyMigrationFallbackBody,
+  deterministicMigrationSourceId,
+  isMissingMigrationSourceObject,
+} from "@/lib/repositories/content-platform/migration-runner";
 
 describe("unified content migration reconciliation", () => {
+  it("recognizes only definitive S3 missing-object responses", () => {
+    expect(
+      isMissingMigrationSourceObject({
+        name: "NoSuchKey",
+        $metadata: { httpStatusCode: 404 },
+      }),
+    ).toBe(true);
+    expect(
+      isMissingMigrationSourceObject({
+        name: "AccessDenied",
+        $metadata: { httpStatusCode: 403 },
+      }),
+    ).toBe(false);
+    expect(
+      isMissingMigrationSourceObject(new Error("network timeout")),
+    ).toBe(false);
+  });
+
+  it("reconstructs a deterministic text source only from non-empty legacy segments", () => {
+    expect(
+      new TextDecoder().decode(
+        buildLegacyMigrationFallbackBody([" first ", "", "second\n"]) ??
+          undefined,
+      ),
+    ).toBe("first\nsecond");
+    expect(buildLegacyMigrationFallbackBody([" ", "\n"])).toBeNull();
+  });
+
   it("builds stable normalized evidence and deterministic source ids", () => {
     expect(
       buildMigrationContentEvidence(["alpha  \r\nbeta", "", "gamma"]),
@@ -50,9 +84,40 @@ describe("unified content migration reconciliation", () => {
       expect.arrayContaining([
         "canonical processing is failed",
         "source object SHA-256 differs",
-        "extracted record count differs",
         "extracted content SHA-256 differs",
       ]),
+    );
+  });
+
+  it("allows canonical resegmentation when full normalized text is unchanged", () => {
+    expect(
+      reconcileMigrationEvidence({
+        sourceObjectSha256: null,
+        canonicalObjectSha256: "a".repeat(64),
+        sourceContent: { recordCount: 3, sha256: "b".repeat(64) },
+        canonicalContent: { recordCount: 17, sha256: "b".repeat(64) },
+        processingStatus: "completed",
+        approvedMismatch: false,
+      }),
+    ).toEqual({ status: "verified", reasons: [] });
+  });
+
+  it("revisits each mismatch once per reconciliation run before finishing", () => {
+    const runnerSource = readFileSync(
+      join(
+        process.cwd(),
+        "lib/repositories/content-platform/migration-runner.ts",
+      ),
+      "utf8",
+    );
+    expect(runnerSource).toContain(
+      "${repositoryMigrationItems.metadata} ->> 'lastReconciledRunId'",
+    );
+    expect(runnerSource).toContain(
+      "lastReconciledRunId: run.id",
+    );
+    expect(runnerSource).toContain(
+      "WHERE status IN ('migrated', 'mismatch')",
     );
   });
 

--- a/tests/unit/lib/repositories/content-migration-run-metrics.test.ts
+++ b/tests/unit/lib/repositories/content-migration-run-metrics.test.ts
@@ -1,0 +1,69 @@
+/** @jest-environment node */
+
+import { beforeAll, beforeEach, describe, expect, it, jest } from "@jest/globals";
+import type { SQL } from "drizzle-orm";
+import { PgDialect } from "drizzle-orm/pg-core";
+
+const mockExecuteQuery = jest.fn();
+const mockToPgRows = jest.fn((result: unknown) => result);
+
+jest.mock("@/lib/db/drizzle-client", () => ({
+  executeQuery: mockExecuteQuery,
+  executeTransaction: jest.fn(),
+  toPgRows: mockToPgRows,
+}));
+
+let getRepositoryMigrationRunMetrics: typeof import("@/lib/repositories/content-platform/migration-runner").getRepositoryMigrationRunMetrics;
+
+describe("repository migration run metrics", () => {
+  beforeAll(async () => {
+    ({ getRepositoryMigrationRunMetrics } = await import(
+      "@/lib/repositories/content-platform/migration-runner"
+    ));
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("attributes retried items to the run that currently owns them", async () => {
+    const runId = "738a9787-27e9-40a4-815d-cf34e4311812";
+    let capturedQuery: SQL | undefined;
+    mockExecuteQuery.mockImplementationOnce(
+      async (...args: unknown[]) => {
+        const [callback, context] = args;
+        expect(context).toBe("contentMigration.runMetrics");
+        return (
+          callback as (db: {
+            execute(query: SQL): Promise<unknown>;
+          }) => Promise<unknown>
+        )({
+          execute: async (query) => {
+            capturedQuery = query;
+            return [
+              { status: "migrated", count: 1 },
+              { status: "unrecoverable", count: 2 },
+              { status: "excluded", count: 3 },
+            ];
+          },
+        });
+      },
+    );
+
+    await expect(getRepositoryMigrationRunMetrics(runId)).resolves.toEqual({
+      discovered: 3,
+      migrated: 1,
+      verified: 0,
+      mismatched: 0,
+      failed: 0,
+      unrecoverable: 2,
+      excluded: 3,
+      rolledBack: 0,
+    });
+    expect(capturedQuery).toBeDefined();
+    const compiled = new PgDialect().sqlToQuery(capturedQuery!);
+    expect(compiled.sql).toContain("WHERE run_id = $1::uuid");
+    expect(compiled.sql).not.toContain("origin_run_id");
+    expect(compiled.params).toEqual([runId]);
+  });
+});

--- a/tests/unit/lib/repositories/content-platform-publication-timeout.test.ts
+++ b/tests/unit/lib/repositories/content-platform-publication-timeout.test.ts
@@ -1,0 +1,32 @@
+/** @jest-environment node */
+
+import { describe, expect, it, jest } from "@jest/globals";
+import type { SQL } from "drizzle-orm";
+import { PgDialect } from "drizzle-orm/pg-core";
+import {
+  configureRepositoryPublicationTransaction,
+  REPOSITORY_PUBLICATION_STATEMENT_TIMEOUT_MS,
+  REPOSITORY_PUBLICATION_TRANSACTION_DEADLINE_MS,
+} from "@/lib/repositories/content-platform/publication-service";
+
+describe("repository publication timeout boundary", () => {
+  it("extends only the current transaction below its caller deadline", async () => {
+    const execute = jest.fn<(query: SQL) => Promise<unknown>>(
+      async () => [],
+    );
+
+    await configureRepositoryPublicationTransaction({ execute });
+
+    expect(execute).toHaveBeenCalledTimes(1);
+    const compiled = new PgDialect().sqlToQuery(
+      execute.mock.calls[0]![0],
+    );
+    expect(compiled.sql).toContain("set_config");
+    expect(compiled.params).toEqual(["240000"]);
+    expect(REPOSITORY_PUBLICATION_STATEMENT_TIMEOUT_MS).toBe(240_000);
+    expect(REPOSITORY_PUBLICATION_TRANSACTION_DEADLINE_MS).toBe(270_000);
+    expect(REPOSITORY_PUBLICATION_TRANSACTION_DEADLINE_MS).toBeGreaterThan(
+      REPOSITORY_PUBLICATION_STATEMENT_TIMEOUT_MS,
+    );
+  });
+});

--- a/tests/unit/lib/repositories/content-platform-status.test.ts
+++ b/tests/unit/lib/repositories/content-platform-status.test.ts
@@ -116,21 +116,27 @@ describe("canonical repository item status", () => {
   });
 
   it("keeps post-deployment recovery quarantined and disables manual retry", () => {
-    expect(
-      resolveCanonicalItemStatus(
-        statusRow({
-          versionStatus: "cancelled",
-          jobStatus: "cancelled",
-          jobError: "Awaiting the replacement runtime",
-          postDeployRecovery: "unified-content-runtime-v2",
-        })
-      )
-    ).toEqual({
-      itemId: 7,
-      processingStatus: "retrying",
-      processingError: null,
-      canRetry: false,
-    });
+    for (const postDeployRecovery of [
+      "unified-content-runtime-v2",
+      "unified-content-artifact-v3",
+      "embedding-concurrency-v1",
+    ] as const) {
+      expect(
+        resolveCanonicalItemStatus(
+          statusRow({
+            versionStatus: "cancelled",
+            jobStatus: "cancelled",
+            jobError: "Awaiting the replacement runtime",
+            postDeployRecovery,
+          })
+        )
+      ).toEqual({
+        itemId: 7,
+        processingStatus: "retrying",
+        processingError: null,
+        canRetry: false,
+      });
+    }
   });
 
   it("shows pending work with a consumed attempt as retrying", () => {

--- a/tests/unit/lib/repositories/content-platform-text-processing.test.ts
+++ b/tests/unit/lib/repositories/content-platform-text-processing.test.ts
@@ -1,5 +1,7 @@
 /** @jest-environment node */
 
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import {
   extractCanonicalTextDocument,
   isCanonicalTextContentType,
@@ -46,7 +48,15 @@ describe("canonical text processing", () => {
     expect(isCanonicalTextContentType("text/plain")).toBe(true);
     expect(isCanonicalTextContentType("text/markdown")).toBe(true);
     expect(isCanonicalTextContentType("text/csv")).toBe(true);
+    expect(isCanonicalTextContentType("text/x-python")).toBe(true);
     expect(isCanonicalTextContentType("application/zip")).toBe(false);
+    expect(
+      extractCanonicalTextDocument(
+        Buffer.from("print('canonical')"),
+        "text/x-python",
+        "example.py",
+      ).detectedContentType,
+    ).toBe("text/plain");
     expect(() =>
       extractCanonicalTextDocument(
         Uint8Array.from([0xff, 0xfe, 0xfd]),
@@ -56,5 +66,18 @@ describe("canonical text processing", () => {
     expect(() =>
       extractCanonicalTextDocument(Buffer.from("safe\0binary"), "text/plain")
     ).toThrow("binary null bytes");
+  });
+
+  it("publishes the normalized text MIME type from the worker", () => {
+    const workerSource = readFileSync(
+      join(
+        process.cwd(),
+        "infra/lambdas/unified-content-processor/index.ts",
+      ),
+      "utf8",
+    );
+    expect(workerSource).toContain(
+      "detectedContentType = extracted.detectedContentType;",
+    );
   });
 });

--- a/tests/unit/lib/repositories/google-drive-client.test.ts
+++ b/tests/unit/lib/repositories/google-drive-client.test.ts
@@ -195,6 +195,21 @@ describe("Google Drive canonical format mapping", () => {
     ).toBeNull();
   });
 
+  test("normalizes Drive vendor text types to the canonical text contract", () => {
+    expect(resolveGoogleDriveExportFormat("text/x-python")).toEqual({
+      contentType: "text/plain",
+      extension: "",
+      method: "blob",
+      repositoryItemType: "text",
+    });
+    expect(resolveGoogleDriveExportFormat("text/markdown")?.contentType).toBe(
+      "text/markdown",
+    );
+    expect(resolveGoogleDriveExportFormat("text/csv")?.contentType).toBe(
+      "text/csv",
+    );
+  });
+
   test("sanitizes exported source names", () => {
     const format = resolveGoogleDriveExportFormat(
       "application/vnd.google-apps.document",

--- a/tests/unit/rooms-migration.test.ts
+++ b/tests/unit/rooms-migration.test.ts
@@ -16,10 +16,11 @@ const manifest = JSON.parse(
 
 describe("migration 157 — teacher-managed rooms", () => {
   it("is registered after the current OneRoster role-source migration", () => {
-    expect(manifest.migrationFiles.slice(-3, -1)).toEqual([
+    const roleSourceIndex = manifest.migrationFiles.indexOf(
       "156-oneroster-user-role-source.sql",
-      "157-rooms.sql",
-    ]);
+    );
+    expect(roleSourceIndex).toBeGreaterThanOrEqual(0);
+    expect(manifest.migrationFiles[roleSourceIndex + 1]).toBe("157-rooms.sql");
   });
 
   it.each(["rooms", "room_classes", "room_members", "room_resources"])(

--- a/tests/unit/scripts/unified-content-publication-replay-integrity.test.ts
+++ b/tests/unit/scripts/unified-content-publication-replay-integrity.test.ts
@@ -1,0 +1,45 @@
+/** @jest-environment node */
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const publicationSource = readFileSync(
+  resolve(
+    process.cwd(),
+    "lib/repositories/content-platform/publication-service.ts",
+  ),
+  "utf8",
+);
+const workerSource = readFileSync(
+  resolve(
+    process.cwd(),
+    "infra/lambdas/unified-content-processor/index.ts",
+  ),
+  "utf8",
+);
+
+describe("unified content publication replay integrity", () => {
+  it("binds an existing artifact replay to immutable payload coordinates", () => {
+    expect(publicationSource).toContain(
+      "assertCanonicalArtifactReplayBinding",
+    );
+    expect(publicationSource).toContain(
+      "artifact.itemVersionId !== input.itemVersionId",
+    );
+    expect(publicationSource).toContain(
+      "artifact.objectKey !== (input.canonicalTextObjectKey ?? null)",
+    );
+    expect(publicationSource).toContain(
+      "artifact.textInline !== (input.canonicalText ?? null)",
+    );
+    expect(publicationSource).toContain(
+      "storedSha256 !== canonicalTextSha256",
+    );
+  });
+
+  it("has S3 verify the object-backed canonical-text digest", () => {
+    expect(workerSource).toContain(
+      'ChecksumSHA256: Buffer.from(canonicalTextSha256, "hex").toString(',
+    );
+  });
+});

--- a/tests/unit/scripts/unified-content-retirement-exclusion.test.ts
+++ b/tests/unit/scripts/unified-content-retirement-exclusion.test.ts
@@ -1,0 +1,28 @@
+/** @jest-environment node */
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const retirementGateSources = [
+  "lib/repositories/content-platform/legacy-retirement.ts",
+  "scripts/db/finalize-unified-content-retirement.ts",
+].map((path) => ({
+  path,
+  source: readFileSync(resolve(process.cwd(), path), "utf8"),
+}));
+
+describe.each(retirementGateSources)(
+  "unified content retirement exclusions in $path",
+  ({ source }) => {
+    it("keeps excluded connector sources out of the verification denominator", () => {
+      expect(source).toContain("WHERE status <> 'excluded'");
+      expect(source).toContain(
+        "COALESCE(item.metadata, '{}'::jsonb) ? 'migrationSourceKind'",
+      );
+      expect(source).toContain(
+        "FROM repository_connector_sources connector_source",
+      );
+      expect(source).toContain("connector_source.status = 'unsupported'");
+    });
+  },
+);

--- a/tests/unit/scripts/unified-content-runtime-recovery-migration.test.ts
+++ b/tests/unit/scripts/unified-content-runtime-recovery-migration.test.ts
@@ -135,3 +135,46 @@ describe("unified-content artifact and embedding recovery migration", () => {
     );
   });
 });
+
+describe("unified-content embedding concurrency recovery migration", () => {
+  const migration = readFileSync(
+    resolve(
+      process.cwd(),
+      "infra/database/schema/159-unified-content-concurrency-recovery.sql"
+    ),
+    "utf8"
+  );
+
+  it("quarantines only the known transient query failures for the replacement worker", () => {
+    expect(migration).toContain(
+      "job.last_error_code = 'RETRY_BUDGET_EXHAUSTED'"
+    );
+    expect(migration).toContain(
+      "job.last_error_message ILIKE 'Failed query:%repository_index_generations%'"
+    );
+    expect(migration).toContain(
+      "post_deploy_recovery = 'embedding-concurrency-v1'"
+    );
+    expect(migration).toContain("SET status = 'cancelled'");
+    expect(migration).toContain("available_at = 'infinity'::timestamptz");
+    expect(migration).not.toContain("No searchable text was extracted");
+  });
+
+  it("never revives blocked, noncanonical, or inactive versions", () => {
+    expect(migration).toContain("item.current_version_id = version.id");
+    expect(migration).toContain("item.lifecycle_status = 'active'");
+    expect(migration).toContain("version.storage_status <> 'blocked'");
+    expect(migration).toContain("version.inspection_status <> 'blocked'");
+    expect(migration).toContain("version.object_key ~ (");
+  });
+
+  it("fences only the latest incomplete failed generation until the bounded worker drains", () => {
+    expect(migration).toContain("embedding_recovery_queued_at = now()");
+    expect(migration).toContain("embedding_recovery_attempts = 3");
+    expect(migration).toContain(
+      "'embedding-concurrency-v1: '"
+    );
+    expect(migration).toContain("chunk.embedding IS NULL");
+    expect(migration).toContain("newer_generation.status IN ('building', 'active', 'failed')");
+  });
+});

--- a/tests/unit/scripts/unified-content-runtime-recovery-migration.test.ts
+++ b/tests/unit/scripts/unified-content-runtime-recovery-migration.test.ts
@@ -168,13 +168,16 @@ describe("unified-content embedding concurrency recovery migration", () => {
     expect(migration).toContain("version.object_key ~ (");
   });
 
-  it("fences only the latest incomplete failed generation until the bounded worker drains", () => {
+  it("fences the latest failed generation even when only activation remains", () => {
     expect(migration).toContain("embedding_recovery_queued_at = now()");
     expect(migration).toContain("embedding_recovery_attempts = 3");
     expect(migration).toContain(
       "'embedding-concurrency-v1: '"
     );
-    expect(migration).toContain("chunk.embedding IS NULL");
+    expect(migration).toContain(
+      "WHERE chunk.index_generation_id = generation.id"
+    );
+    expect(migration).not.toContain("chunk.embedding IS NULL");
     expect(migration).toContain("newer_generation.status IN ('building', 'active', 'failed')");
   });
 });

--- a/tests/unit/student-rooms-navigation-migration.test.ts
+++ b/tests/unit/student-rooms-navigation-migration.test.ts
@@ -18,10 +18,11 @@ const manifest = JSON.parse(
 
 describe("migration 158 — student room navigation", () => {
   it("is the registered migration immediately after rooms", () => {
-    expect(manifest.migrationFiles.slice(-2)).toEqual([
-      "157-rooms.sql",
-      "158-student-rooms-navigation.sql",
-    ]);
+    const roomsIndex = manifest.migrationFiles.indexOf("157-rooms.sql");
+    expect(roomsIndex).toBeGreaterThanOrEqual(0);
+    expect(manifest.migrationFiles[roomsIndex + 1]).toBe(
+      "158-student-rooms-navigation.sql"
+    );
   });
 
   it("adds a student-only read route without a management capability", () => {

--- a/tests/unit/unified-content-migration-schema.test.ts
+++ b/tests/unit/unified-content-migration-schema.test.ts
@@ -32,3 +32,66 @@ describe("migration 155 unified content retirement safety", () => {
     expect(migration).not.toMatch(/\bTRUNCATE\b/i);
   });
 });
+
+describe("migration 160 unified content source eligibility", () => {
+  const migrationPath = path.join(
+    process.cwd(),
+    "infra/database/schema/160-unified-content-migration-source-eligibility.sql",
+  );
+  const migration = fs.readFileSync(migrationPath, "utf8");
+  const migrationRunner = fs.readFileSync(
+    path.join(
+      process.cwd(),
+      "lib/repositories/content-platform/migration-runner.ts",
+    ),
+    "utf8",
+  );
+  const migrationControl = fs.readFileSync(
+    path.join(
+      process.cwd(),
+      "lib/repositories/content-platform/migration-control-service.ts",
+    ),
+    "utf8",
+  );
+  const manifest = JSON.parse(
+    fs.readFileSync(
+      path.join(process.cwd(), "infra/database/migrations.json"),
+      "utf8",
+    ),
+  ) as { migrationFiles: string[] };
+
+  it("records unsupported connector discoveries without hiding migrated data", () => {
+    expect(manifest.migrationFiles).toContain(
+      "160-unified-content-migration-source-eligibility.sql",
+    );
+    expect(migration).toContain("'excluded'");
+    expect(migration).toContain(
+      "connector_source.status = 'unsupported'",
+    );
+    expect(migration).toContain(
+      "migration.canonical_version_id IS NULL",
+    );
+    expect(migration).toContain(
+      "migration.canonical_object_key IS NULL",
+    );
+    expect(migration).toContain(
+      "'exclusionReason', 'unsupported_connector_source'",
+    );
+    expect(migration).not.toMatch(/\bDELETE\b/i);
+    expect(migration).not.toMatch(/\bTRUNCATE\b/i);
+  });
+
+  it("excludes unsupported connector discoveries from inventory and backfill", () => {
+    for (const source of [migrationRunner, migrationControl]) {
+      expect(source).toContain(
+        "FROM repository_connector_sources connector_source",
+      );
+      expect(source).toContain(
+        "connector_source.status = 'unsupported'",
+      );
+      expect(source).toContain(
+        "COALESCE(item.metadata, '{}'::jsonb) ? 'migrationSourceKind'",
+      );
+    }
+  });
+});


### PR DESCRIPTION
## Selected issue and rationale

Relates to #1267.
Epic: #1261.
Remaining model-entitlement gate: #1263.

The durable implementation plan explicitly identifies staged migration,
reconciliation, rollback, cutover, and retirement as the next dependency after
the already-merged workstreams. Issue #1267 is therefore the earliest
incomplete, unblocked delivery item. PR #1350 addressed #1297's authenticated
E2E coverage; it did not implement this migration/retirement readiness work.

## Acceptance criteria

- Bound canonical-processing and embedding concurrency to protect Aurora, while
  reserving one unified-worker slot for recurring maintenance.
- Recover only the known pre-cap exhausted work with generation, lifecycle,
  namespace, retry, age, ownership, and newest-generation fences.
- Make inventory, backfill, reconciliation, rollback, and retirement evidence
  resumable and auditable.
- Compare full canonical content hashes rather than counts or prefixes.
- Preserve recoverable legacy S3 content, explicitly classify only permanently
  unsupported connector discoveries, and keep supported failures fail-closed.
- Bind canonical-artifact replay to exact publication coordinates and preserve
  end-to-end SHA-256 integrity from the S3 write through database publication.
- Normalize vendor text MIME types without losing original source metadata.
- Exercise the affected paths with unit, real-PostgreSQL smoke, infrastructure,
  artifact, authenticated E2E, active-mode synth, and retirement-mode synth
  checks.
- Synchronize the runbook and durable implementation-plan ledger with live dev
  evidence and remaining rollout gates.

## Implementation

- Adds migrations 159 and 160 for narrowly fenced post-deploy recovery and
  auditable unsupported-source exclusion. They are additive and idempotent; the
  final rebase preserved the newly merged rooms migration 158 and updated both
  rooms tests to assert adjacency instead of assuming they remain last.
- Recovers activation-only generations whose vectors are already complete but
  whose lifecycle still failed, without weakening marker, retry, age, ownership,
  or newest-generation fences.
- Caps embedding worker/SQS concurrency and leaves a maintenance slot in the
  unified worker's reserved concurrency.
- Adds missing-object legacy S3 recovery, persisted detected MIME types,
  bounded publication timeouts, run-scoped reconciliation, full SHA-256
  comparison, cursor/metrics persistence, and a scheduled recovery marker.
- Binds canonical replay to item/version/processor/object/inline coordinates,
  performs concurrency-safe null-only legacy hash repair, and supplies
  `ChecksumSHA256` on the canonical S3 write before publication.
- Allows rollback runs containing auditable `excluded` records to complete
  without object-storage calls, while reporting both rolled-back and excluded
  totals.
- Makes the route gate, finalizer, and dashboard use the same supported-source
  eligibility and excludes explicitly unsupported sources from the verification
  denominator without weakening any independent retirement blocker.
- Normalizes Google Drive vendor text subtypes to canonical `text/plain` while
  retaining their original MIME metadata.
- Adds recurring regression coverage for concurrency/IAM, migration SQL,
  activation-only recovery, publication replay integrity, source eligibility,
  recovery, metrics, rollback exclusions, publication timeouts, full-hash
  reconciliation, MIME aliases, and retirement templates.
- Updates the Google sync guide, migration/retirement runbook, and durable plan
  progress ledger.

## Verification

- `bun run lint` — pass (508 warnings, 0 errors)
- `bun run typecheck` — pass
- `bun run test:ci -- --runInBand` — 448 suites / 4,256 tests passed; 3 suites /
  26 tests skipped
- Final focused Jest — 4 suites / 23 tests passed
- `bun run test:smoke:unified-content` — pass against real local PostgreSQL,
  including migration 159 twice, migration 160 twice, activation-only
  release/reclaim, excluded-only rollback with no storage calls, and
  mismatched/valid canonical replay
- `bun run build` — pass on Next.js 16.2.12 (91 static pages)
- Infra `bun run build` — pass, including unified worker typecheck and Lambda
  tests
- Active dev/prod database + processing synth — pass
- Retirement-mode dev/prod processing synth — pass
- Unified-content and embedding Lambda artifact smokes — pass
- Authenticated Playwright migration suite — 13 tests passed on commit
  `287717bd`; later commits do not modify UI or authentication routes
- Final GitHub CI on `e1ca777f` — all seven available checks passed, including
  the PostgreSQL lifecycle, production auth artifact, CDK validation, CodeQL,
  and automated Claude review
- Canonical Codex Security branch-diff scan of exact final snapshot
  `codex-security-snapshot/v1:sha256:f02d673df0307068c4588e8e77674eab29d69c9fe6b87a6f2f6add5353588984`
  — complete coverage, no deferred files, 0 reportable findings
- Explicit full Claude review found three original defects; all were fixed.
  A fresh final-head, file-by-file re-review verified all three fixes plus both
  follow-up security corrections against real PostgreSQL smoke coverage, found
  no remaining requested issue, and **approved** `e1ca777f`:
  https://github.com/psd401/aistudio/pull/1394#issuecomment-5096904364

## Live dev evidence

- Corrected reconciliation run
  `075d5a78-8408-4154-9170-f9849bd9eb1`: discovered 45, migrated 44, verified
  44, mismatched 0, failed 0, excluded 3, unrecoverable 1.
- Rollback drill `03a91ae7-...`: canonical item 37 restored to legacy record 1
  with rollback evidence preserved.
- Google sync initial reconciliation discovered 241 sources. Scheduled/manual
  sync completed with no batch failures; existing `text/x-python` content was
  reprocessed successfully into seven embedded chunks.
- Current unified and embedding queues and DLQs are empty.
- The branch templates set the final concurrency limits. The currently deployed
  stack has drifted back to uncapped embedding concurrency, so merge/deploy is a
  required rollout action before enabling any product cutover.

## Migration and rollout

1. Deploy migrations 159 and 160 and the processing stack together.
2. Verify reserved/event-source concurrency and all four queue depths.
3. Re-run initial reconciliation and the authorized Google
   create/edit/move/delete/permission-loss matrix.
4. Restore or explicitly disposition the single genuinely missing legacy Nexus
   object.
5. Enable shadow reads, observe the required quiet window, then stage product
   cutovers individually.
6. Run a fresh rollback drill and recovery window before enabling the
   irreversible retirement context/finalizer.

No destructive retirement action is included in this PR.

## Remaining risks / external gates

- One legacy Nexus PDF is absent from both object storage and chunks; restoration
  or an explicit product-data disposition is required.
- The Google live mutation matrix needs authorized Drive write activity; the
  configured connector is read-only.
- Cohere Embed v4 / Rerank 3.5 invocation remains blocked by an AWS Marketplace
  subscription/entitlement decision tracked in #1263.
- Shadow observations, product cutovers, and the seven-day quiet/recovery window
  have intentionally not started while those gates remain.
