### PR TITLE
fix(test): anchor .claude/worktrees jest exclusion to rootDir

### DIFF
--- a/jest.config.ci.js
+++ b/jest.config.ci.js
@@ -47,9 +47,17 @@ const customJestConfig = {
   // CDK synthesis copies the application (including manual mocks) into many
   // asset folders. Exclude those generated modules from Jest's haste map so a
   // prior synth cannot create hundreds of false duplicate-mock warnings.
+  //
+  // .claude/worktrees/ holds full repo checkouts. A fresh CI checkout has none,
+  // so these entries are a no-op there, but `bun run test:ci` from a developer's
+  // repo root would otherwise crawl them all. These MUST stay anchored to
+  // <rootDir>: an unanchored '/.claude/worktrees/' also matches when rootDir
+  // *is* a worktree, so jest silently discovers zero tests and exits
+  // "No tests found" instead of failing a check.
   modulePathIgnorePatterns: [
     '<rootDir>/infra/cdk.out/',
     '<rootDir>/.next/',
+    '<rootDir>/.claude/worktrees/',
   ],
   testPathIgnorePatterns: [
     '/node_modules/',
@@ -57,6 +65,7 @@ const customJestConfig = {
     '/.next/',
     '/infra/',  // Infra has its own Jest config and CDK dependencies
     '/tests/performance/',  // EXCLUDE performance tests in CI
+    '<rootDir>/.claude/worktrees/',  // Nested worktrees only - see note above
     'mock-sse-factory.ts',  // Utility file, not a test file
   ]
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -39,6 +39,12 @@ const customJestConfig = {
   transformIgnorePatterns: [
     'node_modules/(?!(lucide-react|next-auth|@next-auth|nanoid)/)'
   ],
+  // Git worktrees under .claude/worktrees/ are full repo checkouts. Left
+  // unignored, a run from the repo root crawls every worktree and multiplies
+  // the discovered suite (~450 -> ~3600) with duplicate haste modules.
+  // These MUST stay anchored to <rootDir>: an unanchored '/.claude/worktrees/'
+  // also matches when rootDir *is* a worktree, so jest silently discovers zero
+  // tests and exits "No tests found" instead of failing a check.
   modulePathIgnorePatterns: [
     '<rootDir>/infra/cdk.out/',
     '<rootDir>/.next/',
@@ -50,7 +56,7 @@ const customJestConfig = {
     '/.next/',
     '/infra/', // Infra has its own Jest config
     '/infra/cdk.out/',
-    '/.claude/worktrees/',
+    '<rootDir>/.claude/worktrees/', // Nested worktrees only - see note above
     'mock-sse-factory.ts' // Utility file, not a test file
   ]
 };


### PR DESCRIPTION
## Problem

`jest.config.js` on `dev` carries `'/.claude/worktrees/'` in `testPathIgnorePatterns` (added in #1390). Entries in that array are regexes matched against **absolute** test paths, so when `rootDir` is itself a worktree under `.claude/worktrees/<branch>/`, every test path in the project contains the pattern and **all tests are ignored**:

```
cd .claude/worktrees/<branch> && bunx jest tests/unit
# -> "No tests found, exiting with code 1"
#    testPathIgnorePatterns: /.claude/worktrees/ - 0 matches
```

This is a silent-verification hazard rather than a normal failure: Jest reports *no tests found* instead of failing a check, so a run that executed nothing is indistinguishable from a run with nothing to do. Worktrees under `.claude/worktrees/` are where work is expected to happen, so the config disabled testing precisely where testing was needed.

The original intent is real and worth keeping — worktrees are full repo checkouts, and leaving them unignored multiplies the discovered suite:

| Config | From repo root |
|---|---|
| no worktrees exclusion, `jest.config.js` | 3636 suites |
| no worktrees exclusion, `jest.config.ci.js` | 3591 suites (3098 nested-worktree copies) |

## Fix

Anchor both exclusions to `<rootDir>`, which Jest substitutes in `testPathIgnorePatterns` and `modulePathIgnorePatterns` alike:

- from the repo root it resolves to `<repo>/.claude/worktrees/` and still excludes every worktree;
- from inside a worktree it resolves to `<worktree>/.claude/worktrees/`, which only excludes worktrees nested inside that worktree — normally nonexistent — so the worktree's own suite runs.

Both files gain a comment recording why the anchor is load-bearing, so a future cleanup doesn't simplify it back.

`jest.config.ci.js` previously carried no worktrees exclusion at all. CI checks out a fresh tree with no `.claude/worktrees/` directory, so the new entries are a **no-op in CI**; the benefit is local, where `bun run test:ci` from the repo root otherwise crawled every worktree.

## Verification

Discovery counts via `jest --listTests`:

| Run | Location | Suites |
|---|---|---|
| unanchored (current `dev`) | repo root | 448 |
| `<rootDir>`-anchored (this PR) | repo root | 448 — identical |
| unanchored (current `dev`) | worktree | **0** — the bug |
| `<rootDir>`-anchored (this PR) | worktree | 452 |

Nested-exclusion behaviour was confirmed against the real config file by planting a throwaway test at `.claude/worktrees/__nested_probe__/tests/unit/probe.test.ts` from inside a worktree: discovered when the worktrees entries are removed from both arrays, excluded with them present, while the worktree's own suites stayed visible. The probe was removed afterwards.

Full gate, executed **from inside a worktree** — the case that was broken:

- `bun run test:ci` → 444 passed, 3 skipped of 447; 4239 tests passed, 26 skipped; exit 0
- `bun run typecheck` → exit 0
- `scripts/test/e2e-local.sh` (pre-push hook, authenticated Playwright) → 291 passed, 34 skipped, 0 failed, 0 flaky; exit 0

## Note for reviewers

This replaces the line added by #1390 rather than adding a second entry. If anything rebases across this, the unanchored `'/.claude/worktrees/'` must not come back — a merge resolution that keeps both forms reintroduces the zero-test failure.

## Out of scope — two local-only E2E findings

Neither is caused by this change (the diff is two Jest config files, and nothing in the Playwright path reads them). Both surfaced while getting the pre-push gate green and are **local-only** — CI runs against a fresh database.

1. **`tests/e2e/nexus/organization.spec.ts` poisons its own well.** Line 183 pins a conversation on every run and never unpins it; line 224 then pages at `limit=100` against an `is_pinned DESC` ordering. Once accumulated pinned rows exceed 100, the freshly-created row sorts past the page and `expect(archivedInList2).toBeDefined()` fails — guaranteed at roughly run 101 on any long-lived local DB. The local database had 105 pinned conversations for `test@example.com`. Worse, line 260's `expect(archivedInList).toBeUndefined()` passes *vacuously* under the same truncation, so the assertion pair silently degrades. Cleared by unpinning; it will recur.

2. **`scripts/test/e2e-local.sh` writes to a hardcoded `/tmp/e2e-local-server.log`** shared by every worktree, so a concurrent run in another worktree overwrites the diagnostic you're reading. The fixed `:3100` port also races back-to-back runs: a suite started while the previous server is still shutting down gets 404s from the dying server and reports "dev server never became healthy", which reads as an app failure rather than a port conflict.

`bun run db:cleanup:e2e -- --yes` (235 content objects, 385 graph nodes) cut suite wall-clock from 15.5m to 6.3m, corroborating that accumulation was widening timing races.
