### PR TITLE
feat: add OneRoster promotion readiness report

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,6 +175,11 @@ jobs:
       env:
         CI: true
 
+    - name: Run OneRoster email-match report smoke
+      run: bun run test:smoke:roster-email-match
+      env:
+        CI: true
+
   # Production-build regression for #1297. Source-level import tests cannot
   # prove how Next/Webpack packages middleware, so exercise the compiled bundle
   # with Next's real Edge sandbox and a signed expired session on every PR/push.

--- a/docs/features/oneroster-classlink-sync.md
+++ b/docs/features/oneroster-classlink-sync.md
@@ -1,16 +1,10 @@
 # ClassLink OneRoster synchronization
 
-Status: v1 ingestion foundation and administrator control surface implemented by Epic
-[#1308](https://github.com/psd401/aistudio/issues/1308), Issue
-[#1310](https://github.com/psd401/aistudio/issues/1310), and Issue
-[#1311](https://github.com/psd401/aistudio/issues/1311). Optional roster role
-reconciliation is implemented by Issue
-[#1312](https://github.com/psd401/aistudio/issues/1312). Teacher-managed room
-provisioning is implemented by Issue
-[#1313](https://github.com/psd401/aistudio/issues/1313). Student room access and
-assistant enforcement are implemented by Issue
-[#1314](https://github.com/psd401/aistudio/issues/1314). Reporting remains a
-separate workstream.
+Status: v1 ingestion, administrator controls, optional role reconciliation,
+teacher-managed rooms, student enforcement, and promotion reporting are
+implemented by Epic [#1308](https://github.com/psd401/aistudio/issues/1308) and
+its linked workstreams, including reporting Issue
+[#1315](https://github.com/psd401/aistudio/issues/1315).
 
 ## Scope and data boundary
 
@@ -175,6 +169,63 @@ The pass runs only after all six roster collections are confirmed successful,
 including a successful unchanged-revision night. It does not run for manual
 syncs. Its own failure is logged and rolled back but does not fail or undo the
 good roster snapshot. Disable the flag to stop future role changes immediately.
+
+## Roster email-match readiness report
+
+After a complete manual sync, run the read-only promotion report against the
+target database:
+
+Provide `DATABASE_URL` through the approved environment/secret-injection
+mechanism rather than typing credentials into shell history, then run:
+
+```bash
+DB_SSL=true bun run scripts/db/report-roster-email-match.ts
+```
+
+The report uses a single-connection `postgres.js` client and issues only
+`SELECT` statements. It reports:
+
+- the active OneRoster-user match rate against `users` with
+  `lower(oneroster_users.email) = lower(users.email)`, split between the
+  `@edtools.psd401.net` student domain and `@psd401.net` staff domain;
+- a bounded, identifier-redacted sample of unmatched roster email domains and
+  primary roles;
+- case-insensitive duplicate active roster emails; and
+- active enrollments that reference a missing or inactive roster user or class.
+
+Exit `0` means there are active roster users and the report found no unmatched
+emails, unexpected/missing domains, duplicate roster emails, or referential
+drift. Exit `1` means findings need an operator decision. Exit `2` means the
+report itself failed and its output is not valid promotion evidence.
+
+### Promotion decision rule
+
+Application users are provisioned lazily, so a roster-wide match rate below
+100% can consist entirely of people who have never signed in. Treat the
+percentage as a readiness signal, not an automatic deletion or remediation
+instruction:
+
+- **Investigate** either student or staff match rate below **95%**, or a drop of
+  more than **5 percentage points** from the accepted dev/manual-sync baseline.
+  Before proceeding, confirm sampled unmatched people are expected
+  never-signed-in users rather than a domain, casing, whitespace, or sync
+  defect. Record only aggregate counts and the explanation in delivery
+  evidence.
+- **Block role-sync and room-enforcement promotion** if any unexpected/missing
+  email domain, duplicate roster email, or active-enrollment referential drift
+  remains. Correct the upstream/configuration problem, run another confirmed
+  complete sync, and rerun the report.
+- A sub-95% cohort may proceed only with an explicit, documented operator
+  exception showing that the gap is expected lazy provisioning and that the
+  sampled domains/roles align with the district roster. Never weaken the
+  lowercase join or manufacture application users to improve the number.
+
+Sample emails and sourced IDs are redacted by default. If an identifier-level
+investigation is necessary, rerun from a private, non-captured operator session
+with `ROSTER_REPORT_INCLUDE_PII=true`. That opt-in output contains student or
+staff identifiers and is FERPA-sensitive: do not paste it into issues, pull
+requests, CI artifacts, or shared logs. Promotion evidence should contain only
+aggregate counts, exit code, investigation result, and any approved exception.
 
 ## Teacher-managed rooms
 
@@ -408,21 +459,45 @@ no-op/change behavior, retries, deletion normalization, empty/error
 preservation, transaction isolation at the sync boundary, changed fields, and
 checkpoint behavior.
 
-## Rollout and rollback
+## Production promotion checklist
 
-Roll out disabled:
+Promote with ingestion and authorization flags disabled:
 
-1. Deploy the Processing stack and confirm the Lambda, nightly rule, alarms,
-   IAM policy, VPC configuration, and log group.
-2. Create the scoped credential secret and populate the non-secret settings.
-3. Run a manual sync. Compare per-collection totals with ClassLink and inspect a
-   sample of lowercased emails and sourced-ID relationships.
-4. Confirm no application roles, rooms, assistants, or demographics data
-   changed.
-5. Set `ROSTER_SYNC_ENABLED=true`.
-6. Review the roster-to-user email match and role distribution before setting
-   `ROSTER_ROLE_SYNC_ENABLED=true`. Keep the role flag disabled if either needs
-   investigation.
+1. Deploy the application and Processing stack. Confirm migrations 141, 156,
+   157, and 158 are applied; the Lambda, disabled-until-configured nightly rule,
+   alarms, IAM policy, VPC configuration, and log group exist; and rollback
+   owners are identified.
+2. Create the production credential secret with the
+   `aistudio-prod-oneroster-*` name pattern, `Environment=prod` and
+   `ManagedBy=manual` tags, and exactly the credential shape for the selected
+   `oauth1` or `proxy` mode. Keep all secret values out of settings, shell
+   history, logs, issues, and pull requests.
+3. While `ROSTER_SYNC_ENABLED=false` and
+   `ROSTER_ROLE_SYNC_ENABLED=false`, set the five manual-sync configuration
+   rows: `ONEROSTER_BASE_URL`, `ONEROSTER_AUTH_MODE`,
+   `ONEROSTER_CREDENTIALS_SECRET_ARN`, `ONEROSTER_API_VERSION`, and
+   `ONEROSTER_PAGE_SIZE`.
+4. Run one manual sync from `/admin/rosters`. Require a terminal success for all
+   six collections, stable `x-perm-rev`, plausible ClassLink-comparable totals,
+   and no Lambda failure alarm. An empty, partial, inconsistent, or failed pull
+   is not promotion evidence and must not be followed by absence deactivation.
+5. Confirm the manual run did not change application roles, rooms, assistants,
+   capabilities, API-key scopes, or demographics. Inspect lowercased email and
+   sourced-ID relationships without exporting unnecessary roster data.
+6. Run `scripts/db/report-roster-email-match.ts` against production. Apply the
+   decision rule above; retain only aggregate counts, exit code, and the
+   documented investigation/exception as evidence.
+7. Set `ROSTER_SYNC_ENABLED=true`, observe the first scheduled success and both
+   alarms, and verify the revision checkpoint advances only after a complete
+   run.
+8. Enable `ROSTER_ROLE_SYNC_ENABLED=true` only after the report decision is
+   accepted and the fixed student/staff mapping is approved. Before teachers
+   create active rooms, confirm the same accepted roster snapshot is still
+   current. Keep either authorization path disabled/unpopulated if its evidence
+   needs investigation.
+
+No live ClassLink credential test is implied by CI or the mocked protocol suite.
+The production manual sync in step 4 is the credentialed validation boundary.
 
 To stop ingestion, set `ROSTER_SYNC_ENABLED=false` in `/admin/rosters`.
 Existing roster rows remain

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "test:smoke:nexus-ephemeral": "DATABASE_URL='postgresql://postgres:postgres@localhost:5432/aistudio' DB_SSL=false bun run tests/smoke/nexus-ephemeral-repositories.smoke.ts",
     "test:smoke:repository-upload-quota": "DATABASE_URL='postgresql://postgres:postgres@localhost:5432/aistudio' DB_SSL=false bun run tests/smoke/repository-upload-quota.smoke.ts",
     "test:smoke:google-content": "DATABASE_URL='postgresql://postgres:postgres@localhost:5432/aistudio' DB_SSL=false bun run tests/smoke/google-content-connectors.smoke.ts",
+    "test:smoke:roster-email-match": "bun run tests/smoke/roster-email-match-report.smoke.ts",
     "test:smoke:agents-projects": "DATABASE_URL='postgresql://postgres:postgres@localhost:5432/aistudio' DB_SSL=false bun --preload ./tests/smoke/server-only-preload.js tests/smoke/unified-content-agents-projects.smoke.ts",
     "test:smoke:unified-content-lambda-artifact": "bun run scripts/test/unified-content-lambda-artifact.smoke.ts",
     "test:smoke:embedding-lambda-artifact": "bun run scripts/test/embedding-lambda-artifact.smoke.ts",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "test:smoke:nexus-ephemeral": "DATABASE_URL='postgresql://postgres:postgres@localhost:5432/aistudio' DB_SSL=false bun run tests/smoke/nexus-ephemeral-repositories.smoke.ts",
     "test:smoke:repository-upload-quota": "DATABASE_URL='postgresql://postgres:postgres@localhost:5432/aistudio' DB_SSL=false bun run tests/smoke/repository-upload-quota.smoke.ts",
     "test:smoke:google-content": "DATABASE_URL='postgresql://postgres:postgres@localhost:5432/aistudio' DB_SSL=false bun run tests/smoke/google-content-connectors.smoke.ts",
-    "test:smoke:roster-email-match": "bun run tests/smoke/roster-email-match-report.smoke.ts",
+    "test:smoke:roster-email-match": "DATABASE_URL='postgresql://postgres:postgres@localhost:5432/aistudio' DB_SSL=false bun run tests/smoke/roster-email-match-report.smoke.ts",
     "test:smoke:agents-projects": "DATABASE_URL='postgresql://postgres:postgres@localhost:5432/aistudio' DB_SSL=false bun --preload ./tests/smoke/server-only-preload.js tests/smoke/unified-content-agents-projects.smoke.ts",
     "test:smoke:unified-content-lambda-artifact": "bun run scripts/test/unified-content-lambda-artifact.smoke.ts",
     "test:smoke:embedding-lambda-artifact": "bun run scripts/test/embedding-lambda-artifact.smoke.ts",

--- a/scripts/db/report-roster-email-match.ts
+++ b/scripts/db/report-roster-email-match.ts
@@ -1,0 +1,415 @@
+/**
+ * OneRoster email-match and referential-drift report (Epic #1308 / Issue #1315).
+ *
+ * Run this read-only readiness check after a complete manual OneRoster sync and
+ * before enabling roster-driven roles or creating production rooms:
+ *
+ *   DATABASE_URL=postgres://... DB_SSL=true \
+ *     bun run scripts/db/report-roster-email-match.ts
+ *
+ * Sample identifiers are redacted by default. Set
+ * ROSTER_REPORT_INCLUDE_PII=true only for a private, non-captured operator
+ * session when exact identifiers are required for investigation.
+ *
+ * Exit codes:
+ *   0 — active roster rows all match application users and no integrity hazards
+ *       were found.
+ *   1 — findings were found; review the counts/samples and the decision rule in
+ *       docs/features/oneroster-classlink-sync.md before promotion.
+ *   2 — the script itself failed (connection/query error).
+ *
+ * READ-ONLY: every statement in this file is SELECT-only.
+ */
+
+import postgres from "postgres";
+import { scriptLogger as log } from "./script-logger";
+
+const DATABASE_URL =
+  process.env.DATABASE_URL ||
+  "postgresql://postgres:postgres@localhost:5432/aistudio";
+const sslEnabled = process.env.DB_SSL !== "false";
+const includeSensitiveSamples =
+  process.env.ROSTER_REPORT_INCLUDE_PII === "true";
+const SAMPLE_LIMIT = 25;
+
+type EmailCohort =
+  | "student_domain"
+  | "staff_domain"
+  | "other_domain"
+  | "missing_email";
+
+interface MatchCohortRow {
+  cohort: EmailCohort;
+  total: number;
+  matched: number;
+}
+
+interface UnmatchedRosterUserRow {
+  email: string | null;
+  role: string;
+}
+
+interface DuplicateSummaryRow {
+  duplicate_email_groups: number;
+  roster_rows: number;
+}
+
+interface DuplicateSampleRow {
+  email: string;
+  roster_rows: number;
+  roles: string[];
+}
+
+interface ReferentialDriftSummaryRow {
+  affected_enrollments: number;
+  missing_users: number;
+  inactive_users: number;
+  missing_classes: number;
+  inactive_classes: number;
+}
+
+interface ReferentialDriftSampleRow {
+  enrollment_sourced_id: string;
+  user_sourced_id: string | null;
+  class_sourced_id: string | null;
+  role: string;
+  missing_user: boolean;
+  inactive_user: boolean;
+  missing_class: boolean;
+  inactive_class: boolean;
+}
+
+function ratePercent(matched: number, total: number): number | null {
+  if (total === 0) {
+    return null;
+  }
+  return Number(((matched / total) * 100).toFixed(2));
+}
+
+function cohortLabel(cohort: EmailCohort): string {
+  switch (cohort) {
+    case "student_domain":
+      return "Student domain (@edtools.psd401.net)";
+    case "staff_domain":
+      return "Staff domain (@psd401.net)";
+    case "other_domain":
+      return "Unexpected domain";
+    case "missing_email":
+      return "Missing email";
+  }
+}
+
+function formatEmailSample(email: string | null): string {
+  if (email === null) {
+    return "(missing)";
+  }
+  if (includeSensitiveSamples) {
+    return email;
+  }
+
+  const separatorIndex = email.lastIndexOf("@");
+  if (separatorIndex === -1) {
+    return "[redacted]";
+  }
+  return `[redacted]${email.slice(separatorIndex)}`;
+}
+
+function formatIdentifierSample(identifier: string | null): string {
+  if (identifier === null) {
+    return "(missing)";
+  }
+  return includeSensitiveSamples ? identifier : "[redacted]";
+}
+
+async function main(): Promise<void> {
+  log.section("AI Studio - OneRoster Email-Match Report (#1315)");
+  log.info("Database", { url: DATABASE_URL.replace(/:\/\/.*@/, "://*****@") });
+  log.info("Sample limit", { rowsPerSection: SAMPLE_LIMIT });
+  log.info("Sensitive sample identifiers", {
+    included: includeSensitiveSamples,
+  });
+  if (includeSensitiveSamples) {
+    log.warn(
+      "Raw roster identifiers are enabled. Keep this terminal private and do not capture or share its output."
+    );
+  }
+
+  const sql = postgres(DATABASE_URL, {
+    ssl: sslEnabled ? "require" : false,
+    max: 1,
+    idle_timeout: 20,
+    connect_timeout: 10,
+  });
+
+  try {
+    const cohorts = await sql<MatchCohortRow[]>`
+      WITH active_roster_users AS (
+        SELECT lower(nullif(btrim(email), '')) AS normalized_email,
+               CASE
+                 WHEN nullif(btrim(email), '') IS NULL THEN 'missing_email'
+                 WHEN split_part(lower(btrim(email)), '@', 2) =
+                      'edtools.psd401.net' THEN 'student_domain'
+                 WHEN split_part(lower(btrim(email)), '@', 2) =
+                      'psd401.net' THEN 'staff_domain'
+                 ELSE 'other_domain'
+               END AS cohort
+          FROM oneroster_users
+         WHERE is_active = true
+      )
+      SELECT cohort,
+             count(*)::int AS total,
+             count(*) FILTER (
+               WHERE normalized_email IS NOT NULL
+                 AND EXISTS (
+                   SELECT 1
+                     FROM users
+                    WHERE lower(users.email) = normalized_email
+                 )
+             )::int AS matched
+        FROM active_roster_users
+       GROUP BY cohort
+    `;
+
+    const cohortByName = new Map<EmailCohort, MatchCohortRow>(
+      cohorts.map((row) => [row.cohort, row])
+    );
+    const orderedCohorts: EmailCohort[] = [
+      "student_domain",
+      "staff_domain",
+      "other_domain",
+      "missing_email",
+    ];
+    const totals = cohorts.reduce(
+      (summary, row) => ({
+        total: summary.total + row.total,
+        matched: summary.matched + row.matched,
+      }),
+      { total: 0, matched: 0 }
+    );
+    const unmatchedCount = totals.total - totals.matched;
+    const unexpectedDomainCount =
+      (cohortByName.get("other_domain")?.total ?? 0) +
+      (cohortByName.get("missing_email")?.total ?? 0);
+
+    log.section("Active roster email match rate");
+    log.info("Overall", {
+      activeRosterUsers: totals.total,
+      matchedApplicationUsers: totals.matched,
+      unmatchedRosterUsers: unmatchedCount,
+      matchRatePercent: ratePercent(totals.matched, totals.total),
+    });
+    for (const cohort of orderedCohorts) {
+      const row = cohortByName.get(cohort) ?? {
+        cohort,
+        total: 0,
+        matched: 0,
+      };
+      log.info(cohortLabel(cohort), {
+        activeRosterUsers: row.total,
+        matchedApplicationUsers: row.matched,
+        unmatchedRosterUsers: row.total - row.matched,
+        matchRatePercent: ratePercent(row.matched, row.total),
+      });
+    }
+
+    const unmatchedSamples = await sql<UnmatchedRosterUserRow[]>`
+      SELECT lower(nullif(btrim(ou.email), '')) AS email,
+             coalesce(nullif(btrim(ou.role), ''), 'unknown') AS role
+        FROM oneroster_users ou
+       WHERE ou.is_active = true
+         AND (
+           nullif(btrim(ou.email), '') IS NULL
+           OR NOT EXISTS (
+             SELECT 1
+               FROM users u
+              WHERE lower(u.email) = lower(btrim(ou.email))
+           )
+         )
+       ORDER BY lower(ou.email) NULLS LAST, ou.sourced_id
+       LIMIT ${SAMPLE_LIMIT}
+    `;
+
+    log.section("Unmatched active roster users (bounded sample)");
+    if (unmatchedSamples.length === 0) {
+      log.success("No unmatched active roster users.");
+    } else {
+      log.warn("Sample coverage", {
+        showing: unmatchedSamples.length,
+        totalUnmatched: unmatchedCount,
+      });
+      for (const row of unmatchedSamples) {
+        log.warn("Unmatched roster user", {
+          email: formatEmailSample(row.email),
+          role: row.role,
+        });
+      }
+    }
+
+    const [duplicateSummary] = await sql<DuplicateSummaryRow[]>`
+      WITH duplicate_emails AS (
+        SELECT lower(btrim(email)) AS email,
+               count(*)::int AS roster_rows
+          FROM oneroster_users
+         WHERE is_active = true
+           AND nullif(btrim(email), '') IS NOT NULL
+         GROUP BY lower(btrim(email))
+        HAVING count(*) > 1
+      )
+      SELECT count(*)::int AS duplicate_email_groups,
+             coalesce(sum(roster_rows), 0)::int AS roster_rows
+        FROM duplicate_emails
+    `;
+    const duplicateSamples = await sql<DuplicateSampleRow[]>`
+      SELECT lower(btrim(email)) AS email,
+             count(*)::int AS roster_rows,
+             array_agg(
+               DISTINCT coalesce(nullif(btrim(role), ''), 'unknown')
+               ORDER BY coalesce(nullif(btrim(role), ''), 'unknown')
+             ) AS roles
+        FROM oneroster_users
+       WHERE is_active = true
+         AND nullif(btrim(email), '') IS NOT NULL
+       GROUP BY lower(btrim(email))
+      HAVING count(*) > 1
+       ORDER BY count(*) DESC, lower(btrim(email))
+       LIMIT ${SAMPLE_LIMIT}
+    `;
+    const duplicateEmailGroups =
+      duplicateSummary?.duplicate_email_groups ?? 0;
+
+    log.section("Duplicate active roster emails");
+    log.info("Summary", {
+      duplicateEmailGroups,
+      affectedRosterRows: duplicateSummary?.roster_rows ?? 0,
+      sampleLimit: SAMPLE_LIMIT,
+    });
+    if (duplicateSamples.length === 0) {
+      log.success("No active roster rows share a case-insensitive email.");
+    } else {
+      for (const row of duplicateSamples) {
+        log.warn("Duplicate roster email", {
+          email: formatEmailSample(row.email),
+          rosterRows: row.roster_rows,
+          roles: row.roles,
+        });
+      }
+    }
+
+    const [driftSummary] = await sql<ReferentialDriftSummaryRow[]>`
+      WITH enrollment_references AS (
+        SELECT e.sourced_id,
+               (u.sourced_id IS NULL) AS missing_user,
+               (u.sourced_id IS NOT NULL AND u.is_active = false)
+                 AS inactive_user,
+               (c.sourced_id IS NULL) AS missing_class,
+               (c.sourced_id IS NOT NULL AND c.is_active = false)
+                 AS inactive_class
+          FROM oneroster_enrollments e
+          LEFT JOIN oneroster_users u
+            ON u.sourced_id = e.user_sourced_id
+          LEFT JOIN oneroster_classes c
+            ON c.sourced_id = e.class_sourced_id
+         WHERE e.is_active = true
+      )
+      SELECT count(*) FILTER (
+               WHERE missing_user OR inactive_user
+                  OR missing_class OR inactive_class
+             )::int AS affected_enrollments,
+             count(*) FILTER (WHERE missing_user)::int AS missing_users,
+             count(*) FILTER (WHERE inactive_user)::int AS inactive_users,
+             count(*) FILTER (WHERE missing_class)::int AS missing_classes,
+             count(*) FILTER (WHERE inactive_class)::int AS inactive_classes
+        FROM enrollment_references
+    `;
+    const driftSamples = await sql<ReferentialDriftSampleRow[]>`
+      SELECT e.sourced_id AS enrollment_sourced_id,
+             e.user_sourced_id,
+             e.class_sourced_id,
+             coalesce(nullif(btrim(e.role), ''), 'unknown') AS role,
+             (u.sourced_id IS NULL) AS missing_user,
+             (u.sourced_id IS NOT NULL AND u.is_active = false)
+               AS inactive_user,
+             (c.sourced_id IS NULL) AS missing_class,
+             (c.sourced_id IS NOT NULL AND c.is_active = false)
+               AS inactive_class
+        FROM oneroster_enrollments e
+        LEFT JOIN oneroster_users u
+          ON u.sourced_id = e.user_sourced_id
+        LEFT JOIN oneroster_classes c
+          ON c.sourced_id = e.class_sourced_id
+       WHERE e.is_active = true
+         AND (
+           u.sourced_id IS NULL
+           OR u.is_active = false
+           OR c.sourced_id IS NULL
+           OR c.is_active = false
+         )
+       ORDER BY e.sourced_id
+       LIMIT ${SAMPLE_LIMIT}
+    `;
+    const affectedEnrollments = driftSummary?.affected_enrollments ?? 0;
+
+    log.section("Active enrollment referential drift");
+    log.info("Summary", {
+      affectedEnrollments,
+      missingUsers: driftSummary?.missing_users ?? 0,
+      inactiveUsers: driftSummary?.inactive_users ?? 0,
+      missingClasses: driftSummary?.missing_classes ?? 0,
+      inactiveClasses: driftSummary?.inactive_classes ?? 0,
+      sampleLimit: SAMPLE_LIMIT,
+    });
+    if (driftSamples.length === 0) {
+      log.success(
+        "All active enrollments reference active roster users and classes."
+      );
+    } else {
+      for (const row of driftSamples) {
+        log.warn("Enrollment referential drift", {
+          enrollmentSourcedId: formatIdentifierSample(
+            row.enrollment_sourced_id
+          ),
+          userSourcedId: formatIdentifierSample(row.user_sourced_id),
+          classSourcedId: formatIdentifierSample(row.class_sourced_id),
+          role: row.role,
+          missingUser: row.missing_user,
+          inactiveUser: row.inactive_user,
+          missingClass: row.missing_class,
+          inactiveClass: row.inactive_class,
+        });
+      }
+    }
+
+    const hasFindings =
+      totals.total === 0 ||
+      unmatchedCount > 0 ||
+      unexpectedDomainCount > 0 ||
+      duplicateEmailGroups > 0 ||
+      affectedEnrollments > 0;
+
+    log.section("Promotion result");
+    if (hasFindings) {
+      log.fail(
+        "Roster data-quality findings require review before enabling production flags."
+      );
+      log.info(
+        "Apply the decision rule in docs/features/oneroster-classlink-sync.md; " +
+          "document expected never-signed-in users without copying raw email samples."
+      );
+      process.exitCode = 1;
+    } else {
+      log.success(
+        "No roster email-match, domain, duplicate, or referential-drift findings."
+      );
+      process.exitCode = 0;
+    }
+  } finally {
+    await sql.end();
+  }
+}
+
+main().catch((error) => {
+  log.error("OneRoster email-match report failed to run", {
+    error: error instanceof Error ? error.message : String(error),
+  });
+  process.exitCode = 2;
+});

--- a/tests/smoke/roster-email-match-report.smoke.ts
+++ b/tests/smoke/roster-email-match-report.smoke.ts
@@ -1,0 +1,212 @@
+/**
+ * Real-PostgreSQL CLI smoke for Issue #1315.
+ *
+ * Creates a disposable database and proves all three operator-facing outcomes:
+ * clean data exits 0, representative findings exit 1, and a connection failure
+ * exits 2. The report process performs no writes; only this fixture owns the
+ * temporary database and rows.
+ */
+
+import assert from "node:assert/strict";
+import { spawnSync, type SpawnSyncReturns } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import postgres from "postgres";
+import { scriptLogger as log } from "../../scripts/db/script-logger";
+
+const repositoryRoot = fileURLToPath(new URL("../..", import.meta.url));
+const sourceDatabaseUrl =
+  process.env.DATABASE_URL ||
+  "postgresql://postgres:postgres@localhost:5432/aistudio";
+const sslEnabled = process.env.DB_SSL !== "false";
+const databaseName = `aistudio_roster_report_${process.pid}_${Date.now()}`;
+
+function databaseUrl(database: string): string {
+  const url = new URL(sourceDatabaseUrl);
+  url.pathname = `/${database}`;
+  return url.toString();
+}
+
+function runReport(
+  url: string,
+  includeSensitiveSamples = false
+): SpawnSyncReturns<string> {
+  return spawnSync(
+    process.execPath,
+    ["run", "scripts/db/report-roster-email-match.ts"],
+    {
+      cwd: repositoryRoot,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        DATABASE_URL: url,
+        DB_SSL: process.env.DB_SSL ?? "false",
+        ROSTER_REPORT_INCLUDE_PII: includeSensitiveSamples ? "true" : "false",
+      },
+    }
+  );
+}
+
+function combinedOutput(result: SpawnSyncReturns<string>): string {
+  return `${result.stdout ?? ""}\n${result.stderr ?? ""}`;
+}
+
+const adminSql = postgres(databaseUrl("postgres"), {
+  ssl: sslEnabled ? "require" : false,
+  max: 1,
+});
+
+log.section("OneRoster email-match report PostgreSQL smoke");
+await adminSql`CREATE DATABASE ${adminSql(databaseName)}`;
+
+const fixtureUrl = databaseUrl(databaseName);
+const fixtureSql = postgres(fixtureUrl, {
+  ssl: sslEnabled ? "require" : false,
+  max: 1,
+});
+
+try {
+  await fixtureSql`
+    CREATE TABLE users (
+      id serial PRIMARY KEY,
+      email text
+    )
+  `;
+  await fixtureSql`
+    CREATE TABLE oneroster_users (
+      sourced_id text PRIMARY KEY,
+      email text,
+      role text,
+      is_active boolean NOT NULL DEFAULT true
+    )
+  `;
+  await fixtureSql`
+    CREATE TABLE oneroster_classes (
+      sourced_id text PRIMARY KEY,
+      is_active boolean NOT NULL DEFAULT true
+    )
+  `;
+  await fixtureSql`
+    CREATE TABLE oneroster_enrollments (
+      sourced_id text PRIMARY KEY,
+      user_sourced_id text,
+      class_sourced_id text,
+      role text,
+      is_active boolean NOT NULL DEFAULT true
+    )
+  `;
+
+  await fixtureSql`
+    INSERT INTO users (email)
+    VALUES ('STUDENT@edtools.psd401.net'), ('teacher@psd401.net')
+  `;
+  await fixtureSql`
+    INSERT INTO oneroster_users (sourced_id, email, role)
+    VALUES
+      ('student-1', 'student@edtools.psd401.net', 'student'),
+      ('teacher-1', 'TEACHER@psd401.net', 'teacher')
+  `;
+  await fixtureSql`
+    INSERT INTO oneroster_classes (sourced_id)
+    VALUES ('class-1')
+  `;
+  await fixtureSql`
+    INSERT INTO oneroster_enrollments (
+      sourced_id,
+      user_sourced_id,
+      class_sourced_id,
+      role
+    )
+    VALUES ('enrollment-1', 'student-1', 'class-1', 'student')
+  `;
+
+  const cleanResult = runReport(fixtureUrl);
+  const cleanOutput = combinedOutput(cleanResult);
+  assert.equal(cleanResult.status, 0, cleanOutput);
+  assert.match(cleanOutput, /Student domain \(@edtools\.psd401\.net\)/);
+  assert.match(cleanOutput, /Staff domain \(@psd401\.net\)/);
+  assert.match(
+    cleanOutput,
+    /No roster email-match, domain, duplicate, or referential-drift findings/
+  );
+
+  await fixtureSql`
+    INSERT INTO oneroster_users (sourced_id, email, role)
+    VALUES
+      ('unmatched-1', 'unmatched@edtools.psd401.net', 'student'),
+      ('duplicate-1', 'duplicate@psd401.net', 'teacher'),
+      ('duplicate-2', 'DUPLICATE@psd401.net', 'aide'),
+      ('unexpected-domain-1', 'domain-drift@example.test', 'student')
+  `;
+  await fixtureSql`
+    INSERT INTO oneroster_enrollments (
+      sourced_id,
+      user_sourced_id,
+      class_sourced_id,
+      role
+    )
+    VALUES
+      ('enrollment-missing-both', 'missing-user', 'missing-class', 'student')
+  `;
+
+  const [beforeFindingsRun] = await fixtureSql<
+    { users: number; roster_users: number; enrollments: number }[]
+  >`
+    SELECT (SELECT count(*)::int FROM users) AS users,
+           (SELECT count(*)::int FROM oneroster_users) AS roster_users,
+           (SELECT count(*)::int FROM oneroster_enrollments) AS enrollments
+  `;
+  const findingsResult = runReport(fixtureUrl);
+  const findingsOutput = combinedOutput(findingsResult);
+  assert.equal(findingsResult.status, 1, findingsOutput);
+  assert.match(findingsOutput, /\[redacted\]@edtools\.psd401\.net/);
+  assert.match(findingsOutput, /Duplicate roster email/);
+  assert.match(findingsOutput, /\[redacted\]@psd401\.net/);
+  assert.match(findingsOutput, /Enrollment referential drift/);
+  assert.match(findingsOutput, /enrollmentSourcedId.*\[redacted\]/);
+  assert.doesNotMatch(findingsOutput, /unmatched@edtools\.psd401\.net/);
+  assert.doesNotMatch(findingsOutput, /duplicate@psd401\.net/);
+  assert.doesNotMatch(findingsOutput, /enrollment-missing-both/);
+  assert.match(findingsOutput, /Roster data-quality findings require review/);
+
+  const sensitiveFindingsResult = runReport(fixtureUrl, true);
+  const sensitiveFindingsOutput = combinedOutput(sensitiveFindingsResult);
+  assert.equal(sensitiveFindingsResult.status, 1, sensitiveFindingsOutput);
+  assert.match(
+    sensitiveFindingsOutput,
+    /Raw roster identifiers are enabled/
+  );
+  assert.match(
+    sensitiveFindingsOutput,
+    /unmatched@edtools\.psd401\.net/
+  );
+  assert.match(sensitiveFindingsOutput, /duplicate@psd401\.net/);
+  assert.match(sensitiveFindingsOutput, /enrollment-missing-both/);
+
+  const [afterFindingsRun] = await fixtureSql<
+    { users: number; roster_users: number; enrollments: number }[]
+  >`
+    SELECT (SELECT count(*)::int FROM users) AS users,
+           (SELECT count(*)::int FROM oneroster_users) AS roster_users,
+           (SELECT count(*)::int FROM oneroster_enrollments) AS enrollments
+  `;
+  assert.deepEqual(
+    afterFindingsRun,
+    beforeFindingsRun,
+    "the report must not mutate application or roster rows"
+  );
+
+  const failureResult = runReport(
+    databaseUrl(`${databaseName}_does_not_exist`)
+  );
+  const failureOutput = combinedOutput(failureResult);
+  assert.equal(failureResult.status, 2, failureOutput);
+  assert.match(failureOutput, /OneRoster email-match report failed to run/);
+
+  log.success(
+    "Clean, redacted and opt-in findings, failure, output, and read-only checks passed."
+  );
+} finally {
+  await fixtureSql.end();
+  await adminSql`DROP DATABASE IF EXISTS ${adminSql(databaseName)} WITH (FORCE)`;
+  await adminSql.end();
+}


### PR DESCRIPTION
## Summary

- add the read-only `scripts/db/report-roster-email-match.ts` promotion report
  for active roster/application email matches, duplicate roster emails, and
  active-enrollment referential drift
- redact email local parts and all sourced IDs by default; exact identifiers
  require the explicit `ROSTER_REPORT_INCLUDE_PII=true` operator opt-in
- add a disposable real-PostgreSQL CLI smoke to CI and document the promotion
  decision rule plus the production rollout/rollback checklist

## Workstream selection

Epic #1308 lists #1315 as its next incomplete workstream. Its prerequisite
#1310 is merged, #1309-#1314 are merged, and the source-of-truth audit found no
open PR, active branch, or competing implementation for #1315. This PR contains
only that workstream.

## Acceptance criteria

- [x] standalone `bun run` script uses `DATABASE_URL` with the local-Docker
  fallback, postgres.js `max: 1`, and `scriptLogger`
- [x] all report statements are static, parameterized `SELECT` queries
- [x] exit `0` = clean, `1` = findings/operator decision, `2` = report failure
- [x] reports overall and student/staff cohort match rates, bounded unmatched
  samples, case-insensitive duplicate email groups, and enrollment reference
  drift
- [x] samples are identifier-redacted by default; a private operator can opt in
  to exact identifiers without changing promotion evidence requirements
- [x] runbook contains a concrete 95% / 5-point investigation rule, blocking
  integrity conditions, expected lazy-provisioning exception, and ordered
  production promotion checklist
- [x] CI runs the real CLI against a generated disposable PostgreSQL database

## Verification

- `bun run test:smoke:roster-email-match`
  - clean exit `0`
  - redacted findings exit `1`
  - explicit synthetic identifier opt-in exit `1`
  - connection failure exit `2`
  - before/after row counts prove the report makes no writes
- `bun run typecheck`
- `bun run lint` — exits `0`; changed files add no warnings (the unchanged
  repository baseline is 504 warnings)
- `bun run test:ci` — 444 suites passed, 3 skipped; 4,239 tests passed, 26
  skipped
- `bun run build`
- `bun run openapi:check`
- `bun run capabilities:check`
- `git diff --check`
- final-head GitHub checks — test/lint/typecheck, PostgreSQL lifecycle,
  production artifact, CDK validation, CodeQL, SDK guard, and Claude review all
  passed
- Codex Security immutable branch-diff review at `edd41c54` — zero reportable
  findings

E2E is N/A for this read-only operator script and documentation change. There
are no schema, migration, API v1, Lambda, CDK, or IAM changes.

## Operational notes

- CI uses fabricated roster values only and does not validate live ClassLink
  credentials.
- The runbook requires an approved secret-injection method for `DATABASE_URL`;
  promotion evidence contains aggregates only.
- The credentialed validation boundary remains the production manual sync,
  followed by this report while ingestion and role-sync flags are disabled.

## Risk and rollback

Risk is low: the new production-facing behavior is a manual SELECT-only report.
Rollback is removal of the report, package/CI wiring, and runbook additions; no
database state or deployed infrastructure requires reversal.

Closes #1315
Epic #1308
