### PR TITLE
fix(verify): remove sunset gemini-code-assist bot from reviewers

### DIFF
--- a/.psd/verify.json
+++ b/.psd/verify.json
@@ -18,7 +18,7 @@
     "atrium-share-grants"
   ],
   "strictness": "block",
-  "reviewers": ["chatgpt-codex-connector[bot]", "gemini-code-assist[bot]", "copilot-pull-request-reviewer[bot]"],
+  "reviewers": ["chatgpt-codex-connector[bot]", "copilot-pull-request-reviewer[bot]"],
   "commit_learnings": true,
   "auto_worktree": true,
   "screenshot_dir": ".verification",


### PR DESCRIPTION
## Summary
- Remove `gemini-code-assist[bot]` from the `reviewers` array in `.psd/verify.json`, leaving `chatgpt-codex-connector[bot]` and `copilot-pull-request-reviewer[bot]`.

## Why
The consumer version of Gemini Code Assist on GitHub has been sunset. On PR #1399 the bot posted that all code review activity has officially ceased — it will never submit a review again. Any workflow that waits for every login in `reviewers` to post a review therefore burned its full timeout on every PR before giving up.

## Repo sweep
Searched the whole repo for other references to the reviewer:
- `.psd/verify.json` was the **only operational reference**.
- The remaining `gemini-code-assist` mentions are historical code comments and test names in `infra/agent-image/` crediting past review feedback (provenance notes) — intentionally left in place.
- All other "gemini" hits refer to Gemini AI **models** (provider adapters, local seed data), unrelated to the review bot.

## Verification
- JSON parses; `reviewers` now `["chatgpt-codex-connector[bot]", "copilot-pull-request-reviewer[bot]"]`.
- Pre-push authed E2E gate: 290 passed, 1 flaky (passed on retry), 34 skipped.
