### PR TITLE
feat(atrium): add since filters and reader links

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -150,10 +150,10 @@ SQL_LOGGING=false
 # public `/p/[slug]` reader). The `public_web` publish adapter records
 # `${ATRIUM_PUBLIC_BASE_URL}/p/{slug}` as the publication's external_ref, and the
 # REST/MCP surfaces return `${ATRIUM_PUBLIC_BASE_URL}/c/{slug}` as the deep link.
-# No trailing slash (it is stripped). When unset, links degrade to relative paths
-# (`/c/{slug}`, `/p/{slug}`) — valid same-origin, but set the absolute app origin
-# in deployed environments so shared/external links resolve. §33 #7 is resolved to
-# the authenticated-but-anonymous Next public route, so this is the app origin (no
+# No trailing slash (it is stripped). ECS injects the canonical app origin
+# automatically; set this only for local/non-CDK runtimes. When unset, links
+# degrade to relative paths (`/c/{slug}`, `/p/{slug}`). §33 #7 is resolved to the
+# authenticated-but-anonymous Next public route, so this is the app origin (no
 # separate CloudFront/S3 public distribution).
 # ATRIUM_PUBLIC_BASE_URL=https://aistudio.psd401.ai
 #

--- a/actions/db/atrium/list-content.ts
+++ b/actions/db/atrium/list-content.ts
@@ -28,6 +28,13 @@ import { contentService } from "@/lib/content";
 import type { ContentObjectDTO, ListFilter } from "@/lib/content";
 import type { ActionState } from "@/types";
 import { getOptionalRequester } from "./requester";
+import { z } from "zod";
+
+const listFilterSchema = z
+  .object({
+    since: z.string().datetime({ offset: true }).optional(),
+  })
+  .passthrough();
 
 export async function listContentAction(
   filter: ListFilter = {}
@@ -37,6 +44,7 @@ export async function listContentAction(
   const log = createLogger({ requestId, action: "listContentAction" });
 
   try {
+    listFilterSchema.parse(filter);
     log.info("Action started: list content", {
       filter: sanitizeForLogging(filter),
     });

--- a/app/api/agent/atrium/route.ts
+++ b/app/api/agent/atrium/route.ts
@@ -11,6 +11,7 @@ const ALLOWED_QUERY_KEYS = new Set([
   "collection",
   "tag",
   "query",
+  "since",
 ])
 const IDENTIFIER = "[A-Za-z0-9%._~-]{1,384}"
 

--- a/app/api/v1/content/[id]/publish/route.ts
+++ b/app/api/v1/content/[id]/publish/route.ts
@@ -121,6 +121,7 @@ export const POST = withApiAuth(async (request: NextRequest, auth, requestId, pa
               id,
               destination: input.destination,
               publishedVersionId: result.publishedVersionId,
+              readerUrl: result.readerUrl,
             },
             meta: { requestId },
           },

--- a/app/api/v1/content/route.ts
+++ b/app/api/v1/content/route.ts
@@ -51,6 +51,7 @@ const listQuerySchema = z.object({
   // Case-insensitive title search (service-side ILIKE); bounded at 200 chars —
   // same contract as the MCP list_content tool.
   query: z.string().min(1).max(200).optional(),
+  since: z.string().datetime({ offset: true }).optional(),
 });
 
 const createBodySchema = z.object({
@@ -115,6 +116,7 @@ export const GET = withApiAuth(async (request: NextRequest, auth, requestId) => 
       tag: parsed.data.tag,
       status: parsed.data.status,
       query: parsed.data.query,
+      since: parsed.data.since,
     });
     return createApiResponse(
       { data: items, meta: { requestId, count: items.length } },

--- a/docs/API/v1/context-graph.md
+++ b/docs/API/v1/context-graph.md
@@ -1111,13 +1111,17 @@ List content objects the caller may view (permission-filtered server-side). Requ
 | `tag` | string | Filter by a single tag (whole-tag match, case-insensitive) |
 | `status` | `draft` \| `published` \| `archived` | Filter by lifecycle status |
 | `query` | string (1–200 chars) | Case-insensitive substring search over the title **or any tag**. Unlike `tag` (whole-tag equality), this matches partial text anywhere in a tag; supplying both ANDs them |
+| `since` | ISO 8601 date-time | Return objects whose `updatedAt` is greater than or equal to this instant (inclusive) |
 
 **Example request:**
 
 ```bash
 curl -H "Authorization: Bearer sk-your-key" \
-  "https://your-domain/api/v1/content?kind=document&status=published&tag=policy&query=acceptable%20use"
+  "https://your-domain/api/v1/content?kind=document&status=published&tag=policy&query=acceptable%20use&since=2026-07-27T00%3A00%3A00Z"
 ```
+
+An invalid `since` value returns `400 VALIDATION_ERROR`; it is never ignored or
+interpreted client-side.
 
 **Response `200`** — `meta.count` is the number of items returned.
 
@@ -1638,11 +1642,16 @@ curl -X POST -H "Authorization: Bearer sk-your-key" \
   "data": {
     "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
     "destination": "intranet",
-    "publishedVersionId": "11111111-2222-4333-8444-555555555555"
+    "publishedVersionId": "11111111-2222-4333-8444-555555555555",
+    "readerUrl": "https://your-domain/c/ai-acceptable-use-policy"
   },
   "meta": { "requestId": "req_abc123" }
 }
 ```
+
+`readerUrl` is the publish service's canonical link. It is an absolute `/c/{slug}`
+or `/p/{slug}` URL for deployed Atrium readers and `null` for destinations that
+do not provide a reader URL.
 
 **Response `202`** (approval required — public publish without `content:publish_public`)
 

--- a/docs/API/v1/generated/capability-catalog.json
+++ b/docs/API/v1/generated/capability-catalog.json
@@ -261,7 +261,7 @@
     {
       "identifier": "content.list",
       "name": "list_content",
-      "description": "List content the caller may view. Filterable by kind, collection, tag, status, and title text.",
+      "description": "List content the caller may view. Filterable by kind, collection, tag, status, title text, and updated-at timestamp.",
       "surfaces": [
         "mcp",
         "internal"

--- a/docs/API/v1/openapi.yaml
+++ b/docs/API/v1/openapi.yaml
@@ -1691,6 +1691,15 @@ paths:
             type: string
             minLength: 1
             maxLength: 200
+        - name: since
+          in: query
+          description: >-
+            Return objects whose updatedAt is greater than or equal to this
+            ISO 8601 timestamp. Invalid timestamps return 400 VALIDATION_ERROR.
+          schema:
+            type: string
+            format: date-time
+          example: "2026-07-27T00:00:00Z"
       responses:
         "200":
           description: List of visible content objects
@@ -4603,7 +4612,7 @@ components:
       properties:
         data:
           type: object
-          required: [id, destination, publishedVersionId]
+          required: [id, destination, publishedVersionId, readerUrl]
           properties:
             id:
               type: string
@@ -4614,6 +4623,15 @@ components:
             publishedVersionId:
               type: string
               format: uuid
+            readerUrl:
+              type: string
+              format: uri-reference
+              nullable: true
+              description: >-
+                Canonical reader URL returned by the publish service. Deployed
+                intranet/public readers are absolute; destinations without a
+                reader URL return null.
+              example: "https://aistudio.example.edu/c/ai-acceptable-use-policy"
         meta:
           type: object
           required: [requestId]

--- a/infra/agent-image/skills/psd-atrium/SKILL.md
+++ b/infra/agent-image/skills/psd-atrium/SKILL.md
@@ -55,7 +55,7 @@ attributed to that owner, never to a shared service principal.
 
 ```bash
 # Find content you can view (permission-filtered). All filters optional.
-node run.js find --kind document --query "field trip" --status published
+node run.js find --kind document --query "field trip" --status published --since "2026-07-27T00:00:00Z"
 
 # Read one object + its last saved version.
 # Document TEXT is NOT returned here — it lives in the collaborative store, so
@@ -68,7 +68,9 @@ node run.js read-source --id <uuid-or-slug>
 ```
 
 `find` filters: `--kind document|artifact`, `--collection <slug|id>`, `--tag <t>`,
-`--status draft|published|archived`, `--query <title text>` (case-insensitive).
+`--status draft|published|archived`, `--query <title text>` (case-insensitive),
+`--since <ISO-8601 timestamp>` (inclusive `updatedAt` lower bound). Each returned
+item includes its canonical `url`.
 
 `read-source` returns the last **committed** version's source. A document someone
 has open in the live editor may be **ahead** of this until a version is snapshotted
@@ -199,7 +201,8 @@ node run.js unpublish --id <id> --destination intranet
 `content:publish_internal`. A **public** destination the key may not publish
 directly returns a structured **approval_required** result (HTTP 202) — this is a
 SUCCESS, not an error. **Relay its `message` verbatim** so the user knows the
-request was queued for a human/admin to approve.
+request was queued for a human/admin to approve. A completed publish includes
+`readerUrl` when the destination has a reader link.
 
 ### Change who can view it
 

--- a/infra/agent-image/skills/psd-atrium/run.js
+++ b/infra/agent-image/skills/psd-atrium/run.js
@@ -232,6 +232,7 @@ async function findObjects(args) {
     collection: optStr(args, 'collection', 'collection'),
     tag: optStr(args, 'tag', 'tag'),
     query: optStr(args, 'query', 'query'),
+    since: optStr(args, 'since', 'since'),
   };
   const { payload } = await restFetch('GET', '', { query });
   emit(payload);

--- a/infra/agent-image/skills/psd-atrium/run.test.js
+++ b/infra/agent-image/skills/psd-atrium/run.test.js
@@ -103,7 +103,31 @@ async function run(...argv) {
 }
 
 test('find issues GET / with the filter query', async () => {
-  await run('find', '--kind', 'document', '--status', 'published', '--query', 'trip', '--tag', 'science');
+  restResponder = () => ({
+    approvalRequired: false,
+    status: 200,
+    payload: [
+      {
+        id: 'obj-1',
+        slug: 'field-trip',
+        url: 'https://app.example/c/field-trip',
+      },
+    ],
+  });
+
+  await run(
+    'find',
+    '--kind',
+    'document',
+    '--status',
+    'published',
+    '--query',
+    'trip',
+    '--tag',
+    'science',
+    '--since',
+    '2026-07-27T00:00:00Z'
+  );
 
   expect(restCalls).toHaveLength(1);
   expect(restCalls[0].method).toBe('GET');
@@ -114,7 +138,9 @@ test('find issues GET / with the filter query', async () => {
     collection: undefined,
     tag: 'science',
     query: 'trip',
+    since: '2026-07-27T00:00:00Z',
   });
+  expect(emitted[0][0].url).toBe('https://app.example/c/field-trip');
 });
 
 test('find rejects an invalid --kind (exit 1)', async () => {
@@ -463,6 +489,25 @@ test('publish POSTs /<id>/publish with the destination (default intranet)', asyn
   await run('publish', '--id', 'obj-1');
   expect(restCalls[0]).toMatchObject({ method: 'POST', path: '/obj-1/publish' });
   expect(restCalls[0].opts.body).toEqual({ destination: 'intranet' });
+});
+
+test('publish emits readerUrl when the broker returns it', async () => {
+  restResponder = () => ({
+    approvalRequired: false,
+    status: 200,
+    payload: {
+      id: 'obj-1',
+      destination: 'intranet',
+      publishedVersionId: 'v7',
+      readerUrl: 'https://app.example/c/field-trip',
+    },
+  });
+
+  await run('publish', '--id', 'obj-1');
+
+  expect(emitted[0].readerUrl).toBe(
+    'https://app.example/c/field-trip'
+  );
 });
 
 test('publish relays an approval_required outcome', async () => {

--- a/infra/lib/constructs/ecs-service.ts
+++ b/infra/lib/constructs/ecs-service.ts
@@ -1050,6 +1050,10 @@ export class EcsServiceConstruct extends Construct {
       DOCUMENTS_BUCKET_NAME: documentsBucketName, // Legacy name for compatibility
       RDS_DATABASE_NAME: 'aistudio',
       AUTH_URL: props.authUrl,
+      // Canonical absolute origin for Atrium /c and /p reader links. Reuse the
+      // ECS service's authoritative auth origin so deployed links are never
+      // relative or dependent on a separately hand-managed value.
+      ATRIUM_PUBLIC_BASE_URL: props.authUrl,
       AUTH_COGNITO_CLIENT_ID: props.cognitoClientId,
       AUTH_COGNITO_ISSUER: props.cognitoIssuer,
       // Legacy RDS Data API variables (kept for backward compatibility during migration)

--- a/infra/test/unit/ecs-service-atrium-public-base-url.test.ts
+++ b/infra/test/unit/ecs-service-atrium-public-base-url.test.ts
@@ -1,0 +1,54 @@
+import * as cdk from "aws-cdk-lib";
+import * as ec2 from "aws-cdk-lib/aws-ec2";
+import { Match, Template } from "aws-cdk-lib/assertions";
+import { EcsServiceConstruct } from "../../lib/constructs/ecs-service";
+
+describe("ECS Service — Atrium public base URL", () => {
+  it("injects the canonical app origin into the frontend task", () => {
+    const app = new cdk.App();
+    const stack = new cdk.Stack(app, "TestStack", {
+      env: { account: "123456789012", region: "us-east-1" },
+    });
+    const vpc = new ec2.Vpc(stack, "TestVpc", { maxAzs: 2 });
+    const secretArn = (name: string) =>
+      `arn:aws:secretsmanager:us-east-1:123456789012:secret:aistudio-dev-${name}-AbCdEf`;
+    const appOrigin = "https://dev.aistudio.psd401.ai";
+
+    new EcsServiceConstruct(stack, "EcsService", {
+      vpc,
+      environment: "dev",
+      documentsBucketName: "aistudio-dev-documents",
+      agentWorkspaceBucketName: "aistudio-dev-agent-workspace",
+      atriumSandboxOrigin: "https://sandbox.example.com",
+      dockerImageSource: "fromEcrRepository",
+      authUrl: appOrigin,
+      cognitoClientId: "test-client-id",
+      cognitoIssuer:
+        "https://cognito-idp.us-east-1.amazonaws.com/us-east-1_testpool",
+      rdsResourceArn:
+        "arn:aws:rds:us-east-1:123456789012:cluster:aistudio-dev-cluster",
+      rdsSecretArn: secretArn("db"),
+      authSecretArn: secretArn("auth"),
+      collabJwtSecretArn: secretArn("collab-jwt"),
+      guardrailHashSecretArn: secretArn("guardrail-hash"),
+      oidcCookieSecretArn: secretArn("oidc-cookie"),
+      oidcSigningJwksSecretArn: secretArn("oidc-signing"),
+    });
+
+    Template.fromStack(stack).hasResourceProperties(
+      "AWS::ECS::TaskDefinition",
+      {
+        ContainerDefinitions: Match.arrayWith([
+          Match.objectLike({
+            Environment: Match.arrayWith([
+              {
+                Name: "ATRIUM_PUBLIC_BASE_URL",
+                Value: appOrigin,
+              },
+            ]),
+          }),
+        ]),
+      }
+    );
+  });
+});

--- a/lib/agent-workspace/atrium-owner-operation.ts
+++ b/lib/agent-workspace/atrium-owner-operation.ts
@@ -54,6 +54,7 @@ const listQuerySchema = z
     tag: z.string().min(1).max(100).optional(),
     status: z.enum(["draft", "published", "archived"]).optional(),
     query: z.string().min(1).max(200).optional(),
+    since: z.string().datetime({ offset: true }).optional(),
   })
   .strict()
 
@@ -275,8 +276,15 @@ async function executeAtriumRead(
       tag: query.tag,
       status: query.status,
       query: query.query,
+      since: query.since,
     })
-    return success(items, input.requestId)
+    return success(
+      items.map((item) => ({
+        ...item,
+        url: contentDeepLink(item.slug),
+      })),
+      input.requestId
+    )
   }
 
   if (segments.length === 1) {
@@ -554,6 +562,7 @@ async function executePublishWrite(
         id: segments[0],
         destination: body.destination,
         publishedVersionId: published.publishedVersionId,
+        readerUrl: published.readerUrl,
       },
       input.requestId
     )

--- a/lib/content/types.ts
+++ b/lib/content/types.ts
@@ -145,6 +145,8 @@ export interface ListFilter {
   collectionId?: string;
   kind?: ContentKind;
   tag?: string;
+  /** Return objects updated at or after this ISO 8601 timestamp. */
+  since?: string;
   /**
    * Case-insensitive substring search over the title OR any tag (#1336). The
    * service clamps it to 200 chars and LIKE-escapes `\`/`%`/`_`, so callers pass

--- a/lib/content/visibility-service.ts
+++ b/lib/content/visibility-service.ts
@@ -11,7 +11,7 @@
  * visibility widening (`setLevel`) lands with the publish service in Phase 5/7.
  */
 
-import { and, desc, eq, ilike, ne, sql, type SQL } from "drizzle-orm";
+import { and, desc, eq, gte, ilike, ne, sql, type SQL } from "drizzle-orm";
 import {
   executeQuery,
   executeTransaction,
@@ -743,6 +743,15 @@ export const visibilityService = {
     ];
     if (filter.collectionId) filters.push(eq(o.collectionId, filter.collectionId));
     if (filter.kind) filters.push(eq(o.kind, filter.kind));
+    if (filter.since) {
+      const since = new Date(filter.since);
+      if (Number.isNaN(since.getTime())) {
+        throw new ValidationError("Invalid since timestamp", {
+          since: filter.since,
+        });
+      }
+      filters.push(gte(o.updatedAt, since));
+    }
     if (filter.owner === "shared") {
       // "Shared with me": content the caller can see but does not own, that
       // reached them through an explicit grant (group/private) rather than the

--- a/lib/mcp/content-tool-handlers.ts
+++ b/lib/mcp/content-tool-handlers.ts
@@ -344,6 +344,7 @@ const listContentSchema = z.object({
   // Case-insensitive title search; the 200-char bound mirrors the REST
   // listQuerySchema so both surfaces reject oversized input at the boundary.
   query: z.string().min(1).max(200).optional(),
+  since: z.string().datetime({ offset: true }).optional(),
 });
 
 async function handleListContent(
@@ -363,6 +364,7 @@ async function handleListContent(
       tag: parsed.data.tag,
       status: parsed.data.status,
       query: parsed.data.query,
+      since: parsed.data.since,
     });
     return ok({
       items: items.map((o) => ({

--- a/lib/mcp/content-tools.ts
+++ b/lib/mcp/content-tools.ts
@@ -109,7 +109,7 @@ export const CONTENT_MCP_TOOLS: McpToolDefinition[] = [
   {
     name: "list_content",
     description:
-      "List content the caller may view. Filterable by kind, collection, tag, status, and title text.",
+      "List content the caller may view. Filterable by kind, collection, tag, status, title text, and updated-at timestamp.",
     inputSchema: {
       type: "object",
       properties: {
@@ -124,6 +124,12 @@ export const CONTENT_MCP_TOOLS: McpToolDefinition[] = [
         query: {
           type: "string",
           description: "Case-insensitive title search (max 200 characters)",
+        },
+        since: {
+          type: "string",
+          format: "date-time",
+          description:
+            "Return content updated at or after this ISO 8601 timestamp",
         },
       },
     },

--- a/lib/mcp/types.ts
+++ b/lib/mcp/types.ts
@@ -84,6 +84,7 @@ export interface McpToolDefinition {
 export interface McpToolProperty {
   type: string
   description: string
+  format?: string
   enum?: string[]
   items?: { type: string }
   default?: unknown

--- a/lib/tools/catalog/manifest.ts
+++ b/lib/tools/catalog/manifest.ts
@@ -266,6 +266,8 @@ const MCP_TOOL_CATALOG_MAP: Record<string, McpCatalogMapping> = {
     identifier: "content.list",
     requiredScope: "content:read",
     internalScopes: ["content:read"],
+    // v2: #1414 added the optional ISO 8601 `since` lower-bound filter.
+    version: "v2",
   },
   update_content: {
     identifier: "content.update",

--- a/lib/tools/catalog/manifest.ts
+++ b/lib/tools/catalog/manifest.ts
@@ -374,6 +374,53 @@ const MCP_MANIFEST_ENTRIES: ToolManifestEntry[] = MCP_TOOLS.map(
 );
 
 /**
+ * Frozen MCP contracts that must remain addressable after a newer version ships.
+ *
+ * Keep these as explicit snapshots instead of deriving them from `MCP_TOOLS`:
+ * deriving a legacy entry from the live registry would silently mutate the old
+ * contract the next time its current schema changes. The boot sync owns every
+ * `(identifier, version)` listed here, so retaining the row also prevents
+ * `deactivateOrphans()` from breaking callers pinned to the earlier version.
+ */
+const LEGACY_MCP_MANIFEST_ENTRIES: readonly ToolManifestEntry[] = [
+  {
+    identifier: "content.list",
+    version: "v1",
+    name: "list_content",
+    description:
+      "List content the caller may view. Filterable by kind, collection, tag, status, and title text.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        kind: {
+          type: "string",
+          enum: ["document", "artifact"],
+          description: "Filter by kind",
+        },
+        collection: {
+          type: "string",
+          description: "Collection slug or id",
+        },
+        tag: { type: "string", description: "Filter by tag" },
+        status: {
+          type: "string",
+          enum: ["draft", "published", "archived"],
+          description: "Filter by status",
+        },
+        query: {
+          type: "string",
+          description: "Case-insensitive title search (max 200 characters)",
+        },
+      },
+    },
+    surfaces: ["mcp", "internal"],
+    requiredScopes: ["content:read"],
+    surfaceScopes: { internal: ["content:read"] },
+    agentCallable: true,
+  },
+];
+
+/**
  * AI SDK tools exposed in chat / Nexus, projected from the single browser-safe
  * source of truth (`lib/tools/catalog/ai-sdk-tools.ts`). These are descriptor-only
  * catalog entries (no in-process MCP `handler`): the concrete tool implementations
@@ -435,6 +482,7 @@ const AGENT_TOOL_MANIFEST_ENTRIES: ToolManifestEntry[] = AGENT_TOOL_DESCRIPTORS.
  */
 export const TOOL_MANIFEST: readonly ToolManifestEntry[] = [
   ...MCP_MANIFEST_ENTRIES,
+  ...LEGACY_MCP_MANIFEST_ENTRIES,
   ...AI_SDK_MANIFEST_ENTRIES,
   ...AGENT_TOOL_MANIFEST_ENTRIES,
 ];

--- a/tests/unit/agent-atrium-owner-operation.test.ts
+++ b/tests/unit/agent-atrium-owner-operation.test.ts
@@ -123,19 +123,31 @@ beforeEach(() => {
 
 describe("signed-owner Atrium operations", () => {
   it("resolves the signed email to the owner requester for reads", async () => {
-    contentListMock.mockResolvedValue([{ id: "content-1" }])
+    contentListMock.mockResolvedValue([
+      { id: "content-1", slug: "staff-handbook" },
+    ])
     await expect(
       executeOwnerAtriumOperation({
         ownerEmail: "owner@psd401.net",
         requestId: "request-1",
         method: "GET",
         path: "",
-        query: { collection: "handbook", status: "draft" },
+        query: {
+          collection: "handbook",
+          status: "draft",
+          since: "2026-07-27T00:00:00Z",
+        },
       })
     ).resolves.toEqual({
       httpStatus: 200,
       payload: {
-        data: [{ id: "content-1" }],
+        data: [
+          {
+            id: "content-1",
+            slug: "staff-handbook",
+            url: "/c/staff-handbook",
+          },
+        ],
         meta: { requestId: "request-1" },
       },
     })
@@ -147,10 +159,31 @@ describe("signed-owner Atrium operations", () => {
       tag: undefined,
       status: "draft",
       query: undefined,
+      since: "2026-07-27T00:00:00Z",
     })
     expect(assertContentAuthoringCapabilityMock).not.toHaveBeenCalled()
   })
 
+  it("returns a 400 validation result for an invalid since value", async () => {
+    const result = await executeOwnerAtriumOperation({
+      ownerEmail: "owner@psd401.net",
+      requestId: "request-invalid-since",
+      method: "GET",
+      path: "",
+      query: { since: "yesterday-ish" },
+    })
+
+    expect(result.httpStatus).toBe(400)
+    expect(result.payload).toEqual(
+      expect.objectContaining({
+        error: expect.objectContaining({ code: "VALIDATION_ERROR" }),
+      })
+    )
+    expect(contentListMock).not.toHaveBeenCalled()
+  })
+})
+
+describe("signed-owner Atrium mutations", () => {
   it("attributes writes to the signed owner requester", async () => {
     contentCreateMock.mockResolvedValue({
       id: "content-1",
@@ -263,6 +296,34 @@ describe("signed-owner Atrium operations", () => {
     expect(auditMock).toHaveBeenCalledWith(
       expect.objectContaining({ outcome: "approval_required" })
     )
+  })
+
+  it("passes the publish readerUrl through to the broker response", async () => {
+    publishMock.mockResolvedValue({
+      publishedVersionId: "version-7",
+      readerUrl: "https://app.example/c/staff-handbook",
+    })
+
+    await expect(
+      executeOwnerAtriumOperation({
+        ownerEmail: "owner@psd401.net",
+        requestId: "request-publish-reader",
+        method: "POST",
+        path: "/content-1/publish",
+        body: { destination: "intranet" },
+      })
+    ).resolves.toEqual({
+      httpStatus: 200,
+      payload: {
+        data: {
+          id: "content-1",
+          destination: "intranet",
+          publishedVersionId: "version-7",
+          readerUrl: "https://app.example/c/staff-handbook",
+        },
+        meta: { requestId: "request-publish-reader" },
+      },
+    })
   })
 })
 

--- a/tests/unit/agent-atrium-route.test.ts
+++ b/tests/unit/agent-atrium-route.test.ts
@@ -145,4 +145,21 @@ describe("POST /api/agent/atrium", () => {
     expect(response.status).toBe(400)
     expect(executeOwnerAtriumOperationMock).not.toHaveBeenCalled()
   })
+
+  it("admits the since query field for owner-operation validation", async () => {
+    const response = await POST(
+      request({
+        method: "GET",
+        path: "",
+        query: { since: "2026-07-27T00:00:00Z" },
+      })
+    )
+
+    expect(response.status).toBe(200)
+    expect(executeOwnerAtriumOperationMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        query: { since: "2026-07-27T00:00:00Z" },
+      })
+    )
+  })
 })

--- a/tests/unit/atrium-content-code-encoding-routes.test.ts
+++ b/tests/unit/atrium-content-code-encoding-routes.test.ts
@@ -25,6 +25,7 @@ const mockCreateApiResponse = jest.fn();
 const mockResolveCollectionId = jest.fn();
 const mockParseContentIfMatch = jest.fn();
 const mockRunIdempotentMutation = jest.fn();
+const mockPublish = jest.fn();
 
 jest.mock("@/lib/api", () => ({
   withApiAuth: (handler: unknown) => handler,
@@ -42,6 +43,9 @@ jest.mock("@/lib/content", () => {
       create: (...a: unknown[]) => mockCreate(...a),
       recoverCaptureCreate: (...a: unknown[]) => mockRecoverCaptureCreate(...a),
       createVersion: (...a: unknown[]) => mockCreateVersion(...a),
+    },
+    publishService: {
+      publish: (...a: unknown[]) => mockPublish(...a),
     },
     versionService: { list: jest.fn() },
     hasPublishPublicScope: jest.fn(() => false),
@@ -76,6 +80,7 @@ jest.mock("@/lib/content/surface-helpers", () => ({
 import type { NextRequest } from "next/server";
 import { POST as CREATE } from "@/app/api/v1/content/route";
 import { POST as CREATE_VERSION } from "@/app/api/v1/content/[id]/versions/route";
+import { POST as PUBLISH } from "@/app/api/v1/content/[id]/publish/route";
 import { ValidationError } from "@/lib/content/errors";
 
 const REQ = { kind: "user", userId: 7, roles: ["staff"], isAdmin: false };
@@ -96,6 +101,7 @@ type VersionHandler = (
 
 const createHandler = CREATE as unknown as CreateHandler;
 const versionHandler = CREATE_VERSION as unknown as VersionHandler;
+const publishHandler = PUBLISH as unknown as VersionHandler;
 
 const request = {
   url: "https://app.test/api/v1/content",
@@ -118,10 +124,37 @@ beforeEach(() => {
   });
   mockCreate.mockResolvedValue({ id: "obj-1", slug: "art", visibilityLevel: "private" });
   mockCreateVersion.mockResolvedValue({ id: "obj-1", slug: "art", version: { id: "v2" } });
+  mockPublish.mockResolvedValue({
+    publishedVersionId: "v7",
+    readerUrl: "https://app.example/c/art",
+  });
   mockContentErrorToResponse.mockReturnValue({ __marker: "content-error" });
   mockCreateApiResponse.mockReturnValue({
     __marker: "ok",
     headers: { set: jest.fn() },
+  });
+});
+
+describe("POST /api/v1/content/:id/publish — readerUrl response", () => {
+  it("passes through the readerUrl returned by publishService", async () => {
+    mockParseRequestBody.mockResolvedValue({
+      data: { destination: "intranet" },
+    });
+
+    await publishHandler(request, AUTH, "req-publish", { id: "obj-1" });
+
+    expect(mockCreateApiResponse).toHaveBeenCalledWith(
+      {
+        data: {
+          id: "obj-1",
+          destination: "intranet",
+          publishedVersionId: "v7",
+          readerUrl: "https://app.example/c/art",
+        },
+        meta: { requestId: "req-publish" },
+      },
+      "req-publish"
+    );
   });
 });
 

--- a/tests/unit/atrium-list-content-action-since.test.ts
+++ b/tests/unit/atrium-list-content-action-since.test.ts
@@ -1,0 +1,76 @@
+const listMock = jest.fn();
+const requesterMock = jest.fn();
+const handleErrorMock = jest.fn();
+
+jest.mock("@/lib/logger", () => ({
+  createLogger: () => ({
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  }),
+  generateRequestId: () => "request-list-since",
+  startTimer: () => jest.fn(),
+  sanitizeForLogging: (value: unknown) => value,
+}));
+
+jest.mock("@/lib/error-utils", () => ({
+  createSuccess: (data: unknown, message: string) => ({
+    isSuccess: true,
+    data,
+    message,
+  }),
+  handleError: (...args: unknown[]) => handleErrorMock(...args),
+}));
+
+jest.mock("@/lib/content", () => ({
+  contentService: {
+    list: (...args: unknown[]) => listMock(...args),
+  },
+}));
+
+jest.mock("@/actions/db/atrium/requester", () => ({
+  getOptionalRequester: (...args: unknown[]) => requesterMock(...args),
+}));
+
+import { listContentAction } from "@/actions/db/atrium/list-content";
+
+const REQUESTER = {
+  kind: "user",
+  userId: 7,
+  roles: ["staff"],
+  isAdmin: false,
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  requesterMock.mockResolvedValue(REQUESTER);
+  listMock.mockResolvedValue([]);
+  handleErrorMock.mockReturnValue({
+    isSuccess: false,
+    message: "Failed to list content",
+  });
+});
+
+describe("listContentAction since validation", () => {
+  it("passes a valid ISO 8601 lower bound through to the service", async () => {
+    const since = "2026-07-27T12:34:56.789Z";
+
+    const result = await listContentAction({ since });
+
+    expect(result.isSuccess).toBe(true);
+    expect(listMock).toHaveBeenCalledWith(REQUESTER, { since });
+  });
+
+  it("rejects an invalid since before resolving the requester or listing", async () => {
+    const result = await listContentAction({ since: "not-a-timestamp" });
+
+    expect(result.isSuccess).toBe(false);
+    expect(requesterMock).not.toHaveBeenCalled();
+    expect(listMock).not.toHaveBeenCalled();
+    expect(handleErrorMock).toHaveBeenCalledWith(
+      expect.anything(),
+      "Failed to list content",
+      expect.objectContaining({ operation: "listContentAction" })
+    );
+  });
+});

--- a/tests/unit/atrium-list-visible-filters.test.ts
+++ b/tests/unit/atrium-list-visible-filters.test.ts
@@ -1,5 +1,5 @@
 /**
- * Unit tests for the listVisible tag + query filters (Epic #1059 completion).
+ * Unit tests for the listVisible tag + query + since filters.
  *
  *  - Tag filter: CASE-INSENSITIVE whole-tag equality via `lower() = lower()`
  *    over `unnest(tags)` (#1336 review) — tags are stored case-preserved, so
@@ -60,11 +60,16 @@ interface CapturedEq {
   op: "eq";
   a: unknown[];
 }
+interface CapturedGte {
+  op: "gte";
+  a: unknown[];
+}
 
 jest.mock("drizzle-orm", () => ({
   and: (...a: unknown[]) => a,
   desc: (a: unknown) => a,
   eq: (...a: unknown[]) => ({ op: "eq", a }),
+  gte: (...a: unknown[]) => ({ op: "gte", a }),
   ne: (...a: unknown[]) => ({ op: "ne", a }),
   ilike: (column: unknown, pattern: unknown) => ({ op: "ilike", column, pattern }),
   sql: Object.assign(
@@ -120,6 +125,8 @@ const isIlike = (f: unknown): f is CapturedIlike =>
   typeof f === "object" && f !== null && (f as { op?: string }).op === "ilike";
 const isEq = (f: unknown): f is CapturedEq =>
   typeof f === "object" && f !== null && (f as { op?: string }).op === "eq";
+const isGte = (f: unknown): f is CapturedGte =>
+  typeof f === "object" && f !== null && (f as { op?: string }).op === "gte";
 
 /** Find the `<status> <> 'archived'` default-exclusion guard, if present. */
 const archivedGuard = (filters: unknown[]): CapturedSql | undefined =>
@@ -222,6 +229,23 @@ describe("listVisible query filter (title OR tag ILIKE — #1336)", () => {
   it("adds no query filter when query is absent or empty", async () => {
     expect(queryFilter(await captureFilters({}))).toBeUndefined();
     expect(queryFilter(await captureFilters({ query: "" }))).toBeUndefined();
+  });
+});
+
+describe("listVisible since filter (#1414)", () => {
+  it("uses an inclusive updated_at >= timestamp predicate", async () => {
+    const since = "2026-07-27T12:34:56.789Z";
+    const filters = await captureFilters({ since });
+    const predicate = filters.find(isGte);
+
+    expect(predicate).toBeDefined();
+    expect(predicate!.a[0]).toBe("COL_updated_at");
+    expect(predicate!.a[1]).toBeInstanceOf(Date);
+    expect((predicate!.a[1] as Date).toISOString()).toBe(since);
+  });
+
+  it("adds no updated_at predicate when since is omitted", async () => {
+    expect((await captureFilters({})).find(isGte)).toBeUndefined();
   });
 });
 

--- a/tests/unit/atrium-mcp-content-tools.test.ts
+++ b/tests/unit/atrium-mcp-content-tools.test.ts
@@ -111,13 +111,35 @@ describe("Atrium MCP content tools registry", () => {
 
   it("list_content exposes an optional ISO date-time `since` property", () => {
     const tool = CONTENT_MCP_TOOLS.find((t) => t.name === "list_content");
-    const manifestEntry = TOOL_MANIFEST.find((t) => t.name === "list_content");
+    const manifestEntries = TOOL_MANIFEST.filter(
+      (entry) => entry.identifier === "content.list"
+    );
+    const v1 = manifestEntries.find((entry) => entry.version === "v1");
+    const v2 = manifestEntries.find((entry) => entry.version === "v2");
+
     expect(tool?.inputSchema.properties.since).toMatchObject({
       type: "string",
       format: "date-time",
     });
     expect(tool?.inputSchema.required ?? []).not.toContain("since");
-    expect(manifestEntry?.version).toBe("v2");
+    expect(v2?.inputSchema.properties.since).toEqual(
+      tool?.inputSchema.properties.since
+    );
+    expect(v1).toMatchObject({
+      name: "list_content",
+      description:
+        "List content the caller may view. Filterable by kind, collection, tag, status, and title text.",
+      surfaces: ["mcp", "internal"],
+      requiredScopes: ["content:read"],
+      surfaceScopes: { internal: ["content:read"] },
+    });
+    expect(Object.keys(v1?.inputSchema.properties ?? {})).toEqual([
+      "kind",
+      "collection",
+      "tag",
+      "status",
+      "query",
+    ]);
   });
 
   it("the body-carrying create/version tools expose an optional codeEncoding: base64", () => {

--- a/tests/unit/atrium-mcp-content-tools.test.ts
+++ b/tests/unit/atrium-mcp-content-tools.test.ts
@@ -109,6 +109,17 @@ describe("Atrium MCP content tools registry", () => {
     expect(tool?.inputSchema.required ?? []).not.toContain("query");
   });
 
+  it("list_content exposes an optional ISO date-time `since` property", () => {
+    const tool = CONTENT_MCP_TOOLS.find((t) => t.name === "list_content");
+    const manifestEntry = TOOL_MANIFEST.find((t) => t.name === "list_content");
+    expect(tool?.inputSchema.properties.since).toMatchObject({
+      type: "string",
+      format: "date-time",
+    });
+    expect(tool?.inputSchema.required ?? []).not.toContain("since");
+    expect(manifestEntry?.version).toBe("v2");
+  });
+
   it("the body-carrying create/version tools expose an optional codeEncoding: base64", () => {
     // WAF-opaque transit: an artifact whose code contains <script>/<style> must be
     // sendable base64-encoded so the edge WAF's CrossSiteScripting_BODY rule can't

--- a/tests/unit/atrium-mcp-unpublish-handler.test.ts
+++ b/tests/unit/atrium-mcp-unpublish-handler.test.ts
@@ -1,6 +1,6 @@
 /**
  * Behavior tests for the `unpublish_content` MCP tool handler and the
- * `list_content` `query` pass-through (Epic #1059 completion).
+ * `list_content` `query` + `since` pass-through.
  *
  * `unpublish_content` must mirror the REST DELETE
  * /api/v1/content/{id}/publish/{destination} semantics exactly:
@@ -290,6 +290,28 @@ describe("list_content `query` filter", () => {
 
   it("rejects a query over 200 chars at the zod boundary — service never called", async () => {
     const result = await handler({ query: "x".repeat(201) }, context());
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0]?.text).toContain("Validation failed");
+    expect(mockList).not.toHaveBeenCalled();
+  });
+
+  it("passes a valid ISO since lower bound through to contentService.list", async () => {
+    const since = "2026-07-27T12:34:56.789Z";
+    mockResolveCollectionId.mockResolvedValue(undefined);
+    mockList.mockResolvedValue([]);
+
+    const result = await handler({ since }, context());
+
+    expect(result.isError).toBeUndefined();
+    expect(mockList).toHaveBeenCalledWith(
+      REQ,
+      expect.objectContaining({ since })
+    );
+  });
+
+  it("rejects an invalid since at the zod boundary", async () => {
+    const result = await handler({ since: "not-a-timestamp" }, context());
 
     expect(result.isError).toBe(true);
     expect(result.content[0]?.text).toContain("Validation failed");

--- a/tests/unit/atrium-rest-content-list-query.test.ts
+++ b/tests/unit/atrium-rest-content-list-query.test.ts
@@ -1,5 +1,5 @@
 /**
- * GET /api/v1/content — `query` filter pass-through (Epic #1059 completion).
+ * GET /api/v1/content — `query` and `since` filter pass-through.
  *
  * The REST list endpoint exposes the same bounded title-search `query` the MCP
  * `list_content` tool does. These tests drive the real route handler (withApiAuth
@@ -122,6 +122,42 @@ describe("GET /api/v1/content — query filter", () => {
 
     expect(mockCreateErrorResponse).toHaveBeenCalledWith(
       "req-3",
+      400,
+      "VALIDATION_ERROR",
+      "Invalid query parameters",
+      expect.anything()
+    );
+    expect(mockList).not.toHaveBeenCalled();
+    expect(result).toEqual({ __marker: "error" });
+  });
+});
+
+describe("GET /api/v1/content — since filter", () => {
+  it("passes a valid ISO 8601 lower bound through to contentService.list", async () => {
+    const since = "2026-07-27T12:34:56.789Z";
+
+    const result = await handler(
+      request(`?since=${encodeURIComponent(since)}`),
+      AUTH,
+      "req-since"
+    );
+
+    expect(mockList).toHaveBeenCalledWith(
+      REQ,
+      expect.objectContaining({ since })
+    );
+    expect(result).toEqual({ __marker: "ok" });
+  });
+
+  it("rejects an invalid since with a 400 validation error", async () => {
+    const result = await handler(
+      request("?since=not-a-timestamp"),
+      AUTH,
+      "req-bad-since"
+    );
+
+    expect(mockCreateErrorResponse).toHaveBeenCalledWith(
+      "req-bad-since",
       400,
       "VALIDATION_ERROR",
       "Invalid query parameters",

--- a/tests/unit/lib/mcp/jsonrpc-catalog.test.ts
+++ b/tests/unit/lib/mcp/jsonrpc-catalog.test.ts
@@ -58,12 +58,14 @@ import type { McpToolContext } from "@/lib/mcp/types"
 import { TOOL_MANIFEST } from "@/lib/tools/catalog/manifest"
 import { toolCatalogInstance } from "@/lib/tools/catalog/catalog"
 
-// Derive the expected MCP tool count from the manifest so this test self-updates
-// when an MCP tool is added/removed, rather than asserting a hardcoded length.
-// (PR #1032 review finding #10.)
-const MCP_TOOL_COUNT = TOOL_MANIFEST.filter((t) =>
-  t.surfaces.includes("mcp")
-).length
+// Default tools/list collapses multiple versions to the latest entry for each
+// identifier. Count unique identifiers rather than raw manifest rows so a frozen
+// legacy version remains pinned-callable without being double-advertised.
+const MCP_TOOL_COUNT = new Set(
+  TOOL_MANIFEST.filter((tool) => tool.surfaces.includes("mcp")).map(
+    (tool) => tool.identifier
+  )
+).size
 
 function ctx(scopes: string[]): McpToolContext {
   return { userId: 1, cognitoSub: "sub", scopes, requestId: "req" }


### PR DESCRIPTION
## Summary

- add an optional inclusive ISO 8601 `since` lower-bound filter to Atrium content lists across REST, MCP, the owner broker, the server action, and the `psd-atrium find` skill command
- retain the frozen `content.list@v1` manifest contract for pinned callers while publishing the `since`-enabled schema as `content.list@v2`
- return canonical content URLs from owner-broker list results and publish `readerUrl` values from both the owner broker and REST API
- inject `ATRIUM_PUBLIC_BASE_URL` from the ECS service's canonical app origin and document the new list/publish contracts
- refresh the generated capability catalog and add unit coverage for validation, inclusive filtering, URLs, skill behavior, and synthesized ECS configuration

Closes #1414

## Validation

- `bun run lint`
- `bun run typecheck`
- `bun run capabilities:check`
- `bun run openapi:check`
- `bun run test:ci` — 4,417 passed, 15 skipped
- `bun run test:skill:atrium` — 52 passed
- `bun run test:smoke:atrium`
- focused Atrium Jest suites — 94 passed
- `bun run build`
- `cd infra && bun run build` — includes 17 Lambda tests
- `cd infra && bun test test/unit/ecs-service-atrium-public-base-url.test.ts`
- `cd infra && CDK_DEFAULT_ACCOUNT=123456789012 CDK_DEFAULT_REGION=us-east-1 bunx cdk synth --all --no-lookups --context baseDomain=example.com`

E2E is N/A for this API/agent-contract-only change, as specified by #1414; the affected surfaces are covered by unit, skill, smoke, build, and synthesis checks.

## Database / deployment notes

- no migration is required; migration `085_atrium.sql` already creates `idx_content_objects_updated` on `content_objects(updated_at DESC)`
- deployed ECS tasks receive `ATRIUM_PUBLIC_BASE_URL` from the same canonical origin used for `AUTH_URL`

## Risks

- callers that send a malformed `since` value now receive a validation error instead of having the value ignored
- `list_content` is published as catalog version `v2` because its input schema gained a new optional field; the original v1 contract remains code-owned and pinned-callable
