### PR TITLE
feat(agent-eval): add hermetic broker stub and graders

### DIFF
--- a/infra/agent-image/eval/README.md
+++ b/infra/agent-image/eval/README.md
@@ -136,6 +136,8 @@ A fixture file is a list (or an object containing a `fixtures` list):
 allowlisted route without a matching fixture returns a named
 `EvalFixtureMissing` response and automatically fails the trial; it never
 falls through to a live service or a silent empty response.
+Broker operations mirror production: fixtures and requests must use `POST`,
+and request bodies must be JSON objects.
 
 Available graders:
 
@@ -146,8 +148,8 @@ Available graders:
 - `output_match` applies a regular expression to the final result.
 - `trajectory_in_order` requires relative tool order while allowing extra
   intervening steps.
-- `tools_catalog` checks the per-turn `tools.catalog` diagnostic for every
-  expected entry.
+- `tools_catalog` checks the per-turn compact, complete `tools.catalog` name
+  diagnostic for every expected entry.
 
 Each JSONL record includes `broker_requests` plus a `grade` object containing
 the per-grader boolean and human-readable reason. Task reliability uses

--- a/infra/agent-image/eval/README.md
+++ b/infra/agent-image/eval/README.md
@@ -62,9 +62,10 @@ read-only bind mount of `eval/broker_stub.py`. The candidate image is not
 modified. A second, runner-owned `0700` bind mount carries only the active
 trial's fixtures and `0600` request capture. The stub implements the same 16
 fixed `/api/agent/*` routes as `agent-broker.js` and `mantle_proxy.py`, plus the
-health, usage, and finalization endpoints the wrapper needs. L0 and L2 tasks
-retain the image's real proxy; pure live and stubbed tasks use separate
-containers.
+health, usage, and finalization endpoints the wrapper needs. Finalization
+drains already-active broker requests and rejects new work before acknowledging
+the boundary, so captures cannot spill across trials. L0 and L2 tasks retain
+the image's real proxy; pure live and stubbed tasks use separate containers.
 
 ## Task and suite files
 

--- a/infra/agent-image/eval/README.md
+++ b/infra/agent-image/eval/README.md
@@ -1,9 +1,9 @@
 # Local agent-image eval runner
 
 `runner.py` boots a candidate image locally and records repeated task results
-from the same `/invocations` endpoint AgentCore uses in production. Phase 0
-(#1422) records outcomes and telemetry; deterministic graders are added by
-#1424.
+from the same `/invocations` endpoint AgentCore uses in production. It records
+outcomes and telemetry (#1422), injects a hermetic broker for L1 tasks, and
+applies deterministic request/output/trajectory graders (#1424).
 
 ## Run the core suite
 
@@ -14,7 +14,7 @@ python3 infra/agent-image/eval/runner.py \
   --image <tag-or-digest> \
   --suite infra/agent-image/eval/suites/core.yaml \
   --trials 3 \
-  --out /tmp/issue-1422-core.jsonl
+  --out /tmp/issue-1424-core.jsonl
 ```
 
 The runner uses the active AWS credential chain and discovers the dev web
@@ -57,6 +57,15 @@ Every trial gets:
 isolation through fresh session IDs. `workspace: mutating` tasks boot a fresh
 container for every trial so local files and memory cannot leak.
 
+`level: L1` tasks replace the image's `/app/mantle_proxy.py` at runtime with a
+read-only bind mount of `eval/broker_stub.py`. The candidate image is not
+modified. A second, runner-owned `0700` bind mount carries only the active
+trial's fixtures and `0600` request capture. The stub implements the same 16
+fixed `/api/agent/*` routes as `agent-broker.js` and `mantle_proxy.py`, plus the
+health, usage, and finalization endpoints the wrapper needs. L0 and L2 tasks
+retain the image's real proxy; pure live and stubbed tasks use separate
+containers.
+
 ## Task and suite files
 
 Phase-0 task files use a flat, dependency-free YAML subset. Double-quoted
@@ -84,13 +93,76 @@ tasks:
 The committed `core.yaml` suite has three L0 tasks. Its seed/recall pair checks
 that a passphrase stated under one session is unknown under the next.
 
+## L1 fixtures and graders
+
+An L1 task names one or more relative JSON fixture files and at least one
+grader. Graders use inline JSON objects so the runner's dependency-free YAML
+subset stays unambiguous:
+
+```yaml
+id: directory-lookup
+skill: psd-directory
+level: L1
+workspace: pure
+prompt: "Find Ada in the staff directory."
+trials: 3
+fixtures:
+  - fixtures/directory-lookup.json
+graders:
+  - {"type":"broker_request","route":"/api/agent/directory-lookup","method":"POST","body":{"query":{"exact":"Ada"}}}
+  - {"type":"no_route_called","route":"/api/agent/email-triage"}
+  - {"type":"trajectory_in_order","tools":["skills.search","directory.lookup"]}
+  - {"type":"tools_catalog","expected":["skills.search","directory.lookup"]}
+  - {"type":"output_match","pattern":"Ada","ignore_case":true}
+```
+
+A fixture file is a list (or an object containing a `fixtures` list):
+
+```json
+[
+  {
+    "route": "/api/agent/directory-lookup",
+    "method": "POST",
+    "request_body": {"query": "Ada"},
+    "response": {
+      "status": 200,
+      "body": {"people": [{"name": "Ada Lovelace"}]}
+    }
+  }
+]
+```
+
+`request_body` is an optional partial-object selector. A request to an
+allowlisted route without a matching fixture returns a named
+`EvalFixtureMissing` response and automatically fails the trial; it never
+falls through to a live service or a silent empty response.
+
+Available graders:
+
+- `broker_request` matches route/method and optional body fields. Body matchers
+  are `exact`, `contains_any`, and `numeric_equals`; dot paths address nested
+  fields.
+- `no_route_called` asserts the selected route/method received no request.
+- `output_match` applies a regular expression to the final result.
+- `trajectory_in_order` requires relative tool order while allowing extra
+  intervening steps.
+- `tools_catalog` checks the per-turn `tools.catalog` diagnostic for every
+  expected entry.
+
+Each JSONL record includes `broker_requests` plus a `grade` object containing
+the per-grader boolean and human-readable reason. Task reliability uses
+`pass^k`: all `k` trials must pass. Two successes out of three is a failed
+`pass^3`.
+
 ## Hermetic tests
 
 ```bash
-UV_CACHE_DIR=/tmp/issue-1422-uv-cache \
+UV_CACHE_DIR=/tmp/issue-1424-uv-cache \
   uv run --python 3.12 --no-project -m unittest \
+  infra/agent-image/test_broker_stub.py \
+  infra/agent-image/test_graders.py \
   infra/agent-image/test_eval_runner.py
 ```
 
-The tests use fake runtimes only: they make no network, AWS, model, or Docker
-calls.
+The tests make no AWS, model, Docker, or external-network calls. Broker HTTP
+tests bind only an ephemeral loopback port.

--- a/infra/agent-image/eval/README.md
+++ b/infra/agent-image/eval/README.md
@@ -66,9 +66,11 @@ or forge grader inputs even when its numeric UID matches the host runner. The
 stub implements the same 16 fixed `/api/agent/*` routes as `agent-broker.js` and
 `mantle_proxy.py`, plus the health, usage, and finalization endpoints the wrapper
 needs. Finalization drains already-active broker requests and rejects new work
-before acknowledging the boundary, so captures cannot spill across trials. L0
-and L2 tasks retain the image's real proxy; pure live and stubbed tasks use
-separate containers.
+before acknowledging the boundary. The wrapper's end transition leaves the
+stub closed through runner capture collection; installing the next trial uses
+a separate root-only token to reopen it, so delayed work cannot spill across
+trials. L0 and L2 tasks retain the image's real proxy; pure live and stubbed
+tasks use separate containers.
 
 ## Task and suite files
 

--- a/infra/agent-image/eval/README.md
+++ b/infra/agent-image/eval/README.md
@@ -59,13 +59,16 @@ container for every trial so local files and memory cannot leak.
 
 `level: L1` tasks replace the image's `/app/mantle_proxy.py` at runtime with a
 read-only bind mount of `eval/broker_stub.py`. The candidate image is not
-modified. A second, runner-owned `0700` bind mount carries only the active
-trial's fixtures and `0600` request capture. The stub implements the same 16
-fixed `/api/agent/*` routes as `agent-broker.js` and `mantle_proxy.py`, plus the
-health, usage, and finalization endpoints the wrapper needs. Finalization
-drains already-active broker requests and rejects new work before acknowledging
-the boundary, so captures cannot spill across trials. L0 and L2 tasks retain
-the image's real proxy; pure live and stubbed tasks use separate containers.
+modified. A root-owned `0700` in-container tmpfs carries only the active trial's
+fixtures and `0600` request capture; the runner installs and collects that state
+through root-only Docker execs, so the image's `node` user cannot read fixtures
+or forge grader inputs even when its numeric UID matches the host runner. The
+stub implements the same 16 fixed `/api/agent/*` routes as `agent-broker.js` and
+`mantle_proxy.py`, plus the health, usage, and finalization endpoints the wrapper
+needs. Finalization drains already-active broker requests and rejects new work
+before acknowledging the boundary, so captures cannot spill across trials. L0
+and L2 tasks retain the image's real proxy; pure live and stubbed tasks use
+separate containers.
 
 ## Task and suite files
 

--- a/infra/agent-image/eval/README.md
+++ b/infra/agent-image/eval/README.md
@@ -65,12 +65,15 @@ through root-only Docker execs, so the image's `node` user cannot read fixtures
 or forge grader inputs even when its numeric UID matches the host runner. The
 stub implements the same 16 fixed `/api/agent/*` routes as `agent-broker.js` and
 `mantle_proxy.py`, plus the health, usage, and finalization endpoints the wrapper
-needs. Finalization drains already-active broker requests and rejects new work
-before acknowledging the boundary. The wrapper's end transition leaves the
-stub closed through runner capture collection; installing the next trial uses
-a separate root-only token to reopen it, so delayed work cannot spill across
-trials. L0 and L2 tasks retain the image's real proxy; pure live and stubbed
-tasks use separate containers.
+needs. It also preserves the fixed `/anthropic/v1/messages` loopback endpoint
+used by `psd-summarize`, relaying only that model path to the trusted web tier
+with root-held invocation authority. Finalization drains already-active broker
+and summarization requests and rejects new work before acknowledging the
+boundary. The wrapper's end transition leaves the stub closed through runner
+capture collection; installing the next trial uses a separate root-only token
+to reopen it, so delayed work cannot spill across trials. L0 and L2 tasks
+retain the image's real proxy; pure live and stubbed tasks use separate
+containers.
 
 ## Task and suite files
 
@@ -143,7 +146,8 @@ allowlisted route without a matching fixture returns a named
 `EvalFixtureMissing` response and automatically fails the trial; it never
 falls through to a live service or a silent empty response.
 Broker operations mirror production: fixtures and requests must use `POST`,
-and request bodies must be JSON objects. Fixture files plus the
+request bodies must be JSON objects, and fixture responses must use a final
+HTTP status in the range 200-599. Fixture files plus the
 `broker_request` and `no_route_called` graders require `level: L1`; live L0/L2
 tasks reject them instead of grading an empty capture.
 

--- a/infra/agent-image/eval/README.md
+++ b/infra/agent-image/eval/README.md
@@ -141,7 +141,9 @@ allowlisted route without a matching fixture returns a named
 `EvalFixtureMissing` response and automatically fails the trial; it never
 falls through to a live service or a silent empty response.
 Broker operations mirror production: fixtures and requests must use `POST`,
-and request bodies must be JSON objects.
+and request bodies must be JSON objects. Fixture files plus the
+`broker_request` and `no_route_called` graders require `level: L1`; live L0/L2
+tasks reject them instead of grading an empty capture.
 
 Available graders:
 

--- a/infra/agent-image/eval/README.md
+++ b/infra/agent-image/eval/README.md
@@ -153,6 +153,8 @@ Available graders:
   are `exact`, `contains_any`, and `numeric_equals`; dot paths address nested
   fields.
 - `no_route_called` asserts the selected route/method received no request.
+- Broker grader routes must be in the production agent-broker allowlist; an
+  explicit method must be `POST`.
 - `output_match` applies a regular expression to the final result.
 - `trajectory_in_order` requires relative tool order while allowing extra
   intervening steps.

--- a/infra/agent-image/eval/broker_stub.py
+++ b/infra/agent-image/eval/broker_stub.py
@@ -28,6 +28,8 @@ TRIAL_CONFIG_FILENAME = "trial.json"
 CAPTURE_FILENAME = "capture.jsonl"
 MAX_REQUEST_BYTES = 50 * 1024 * 1024
 MISSING_FIXTURE_ERROR = "EvalFixtureMissing"
+UNSUPPORTED_METHOD_ERROR = "EvalUnsupportedAgentMethod"
+INVALID_REQUEST_BODY_ERROR = "EvalInvalidRequestBody"
 
 ALLOWED_AGENT_BROKER_ROUTES = frozenset(
     {
@@ -255,8 +257,23 @@ class BrokerStubRequestHandler(BaseHTTPRequestHandler):
             trial = self.server.state.load_trial()
             trial_id = trial.get("trial_id")
             task_id = trial.get("task_id")
+            request_error: str | None = None
+            response_status = HTTPStatus.NOT_FOUND
             if route not in ALLOWED_AGENT_BROKER_ROUTES:
-                error = f"EvalUnsupportedAgentRoute: {self.command} {route}"
+                request_error = (
+                    f"EvalUnsupportedAgentRoute: {self.command} {route}"
+                )
+            elif self.command != "POST":
+                request_error = (
+                    f"{UNSUPPORTED_METHOD_ERROR}: {self.command} {route}"
+                )
+            elif not isinstance(body, Mapping):
+                request_error = (
+                    f"{INVALID_REQUEST_BODY_ERROR}: POST {route} "
+                    "requires a JSON object"
+                )
+                response_status = HTTPStatus.BAD_REQUEST
+            if request_error is not None:
                 self.server.state.capture(
                     {
                         "trial_id": trial_id,
@@ -268,12 +285,16 @@ class BrokerStubRequestHandler(BaseHTTPRequestHandler):
                             for key, value in self.headers.items()
                         },
                         "body": body,
-                        "stub_error": error,
+                        "stub_error": request_error,
                     }
                 )
                 self._send_json(
-                    HTTPStatus.NOT_FOUND,
-                    {"error": "EvalUnsupportedAgentRoute", "route": route},
+                    response_status,
+                    {
+                        "error": request_error.split(":", 1)[0],
+                        "message": request_error,
+                        "route": route,
+                    },
                 )
                 return
             fixture = self.server.state.find_fixture(

--- a/infra/agent-image/eval/broker_stub.py
+++ b/infra/agent-image/eval/broker_stub.py
@@ -9,6 +9,9 @@ through a root-owned in-container tmpfs.
 
 from __future__ import annotations
 
+import base64
+import binascii
+import hashlib
 import hmac
 import json
 import logging
@@ -34,9 +37,16 @@ DEFAULT_CONTROL_DIRECTORY = "/run/psd-agent-eval-broker"
 DEFAULT_WORKSPACE_FLUSH_TOKEN_PATH = (
     "/run/psd-agent-authority/workspace-flush-token"
 )
+DEFAULT_INVOCATION_CONTEXT_PATH = (
+    "/run/psd-agent-authority/invocation-context"
+)
+DEFAULT_REQUEST_PROOF_KEY_PATH = (
+    "/run/psd-agent-authority/request-proof-key"
+)
 TRIAL_CONFIG_FILENAME = "trial.json"
 CAPTURE_FILENAME = "capture.jsonl"
 MAX_REQUEST_BYTES = 50 * 1024 * 1024
+MAX_MODEL_RESPONSE_BYTES = 50 * 1024 * 1024
 FINALIZATION_DRAIN_TIMEOUT_SECONDS = 120
 MISSING_FIXTURE_ERROR = "EvalFixtureMissing"
 UNSUPPORTED_METHOD_ERROR = "EvalUnsupportedAgentMethod"
@@ -47,6 +57,8 @@ RUNNER_READ_CAPTURES_COMMAND = "--runner-read-captures"
 RUNNER_CONTROL_TOKEN_FILENAME = "runner-control-token"
 RUNNER_CONTROL_HEADER = "X-Agent-Eval-Runner-Control"
 RUNNER_OPEN_TRIAL_PATH = "/internal/eval-trial/open"
+MODEL_MESSAGES_PATH = "/anthropic/v1/messages"
+MODEL_PROXY_ROUTE = "/api/agent/model-proxy/anthropic/v1/messages"
 
 ALLOWED_AGENT_BROKER_ROUTES = frozenset(
     {
@@ -72,6 +84,83 @@ ALLOWED_AGENT_BROKER_ROUTES = frozenset(
 
 class BrokerStubConfigurationError(RuntimeError):
     """The runner supplied an invalid or unreadable trial fixture."""
+
+
+def _trusted_app_base_url(value: str) -> bool:
+    return value.startswith(
+        ("https://", "http://127.0.0.1", "http://localhost")
+    )
+
+
+def _read_invocation_authority(
+    invocation_context_path: Path,
+    request_proof_key_path: Path,
+) -> tuple[str, bytes]:
+    context = invocation_context_path.read_text(encoding="ascii").strip()
+    encoded_key = request_proof_key_path.read_text(encoding="ascii").strip()
+    padded_key = encoded_key + ("=" * (-len(encoded_key) % 4))
+    try:
+        proof_key = base64.urlsafe_b64decode(padded_key)
+    except (ValueError, binascii.Error) as error:
+        raise BrokerStubConfigurationError(
+            "invocation request proof key is malformed"
+        ) from error
+    if not context or len(proof_key) != 32:
+        raise BrokerStubConfigurationError(
+            "invocation authority is malformed"
+        )
+    return context, proof_key
+
+
+def _authority_headers(
+    method: str,
+    route: str,
+    body: bytes,
+    *,
+    invocation_context_path: Path,
+    request_proof_key_path: Path,
+) -> dict[str, str]:
+    context, proof_key = _read_invocation_authority(
+        invocation_context_path,
+        request_proof_key_path,
+    )
+    timestamp = str(int(time.time()))
+    nonce = str(uuid.uuid4())
+    body_sha256 = hashlib.sha256(body).hexdigest()
+    canonical = "\n".join(
+        [
+            "v1",
+            timestamp,
+            nonce,
+            method.upper(),
+            route,
+            body_sha256,
+        ]
+    ).encode("utf-8")
+    signature = base64.urlsafe_b64encode(
+        hmac.new(proof_key, canonical, hashlib.sha256).digest()
+    ).rstrip(b"=").decode("ascii")
+    return {
+        "X-Agent-Invocation-Context": context,
+        "X-Agent-Request-Proof-Version": "v1",
+        "X-Agent-Request-Proof-Timestamp": timestamp,
+        "X-Agent-Request-Proof-Nonce": nonce,
+        "X-Agent-Request-Proof-Body-Sha256": body_sha256,
+        "X-Agent-Request-Proof-Signature": signature,
+    }
+
+
+class _NoRedirectHandler(urllib_request.HTTPRedirectHandler):
+    def redirect_request(
+        self,
+        request: urllib_request.Request,
+        file_pointer: object,
+        code: int,
+        message: str,
+        headers: object,
+        new_url: str,
+    ) -> None:
+        return None
 
 
 def _ensure_runner_control_token(control_directory: Path) -> str:
@@ -258,12 +347,33 @@ class BrokerStubState:
         control_directory: Path,
         *,
         workspace_flush_token_path: Path | None = None,
+        invocation_context_path: Path | None = None,
+        request_proof_key_path: Path | None = None,
+        model_upstream_base_url: str | None = None,
     ) -> None:
         self.control_directory = control_directory
         self.workspace_flush_token_path = (
             workspace_flush_token_path
             or Path(DEFAULT_WORKSPACE_FLUSH_TOKEN_PATH)
         )
+        self.invocation_context_path = (
+            invocation_context_path
+            or Path(DEFAULT_INVOCATION_CONTEXT_PATH)
+        )
+        self.request_proof_key_path = (
+            request_proof_key_path
+            or Path(DEFAULT_REQUEST_PROOF_KEY_PATH)
+        )
+        configured_upstream = (
+            os.environ.get("APP_BASE_URL", "")
+            if model_upstream_base_url is None
+            else model_upstream_base_url
+        ).rstrip("/")
+        if not _trusted_app_base_url(configured_upstream):
+            raise BrokerStubConfigurationError(
+                "APP_BASE_URL is not a trusted model broker URL"
+            )
+        self.model_upstream_base_url = configured_upstream
         self._runner_control_token = _ensure_runner_control_token(
             control_directory
         )
@@ -363,6 +473,54 @@ class BrokerStubState:
             )
         )
 
+    def forward_model_request(
+        self,
+        body: bytes,
+        *,
+        content_type: str,
+        accept: str,
+    ) -> tuple[int, str, bytes]:
+        """Relay the one loopback model endpoint used by psd-summarize."""
+
+        headers = {
+            "Content-Type": content_type,
+            "Accept": accept,
+            **_authority_headers(
+                "POST",
+                MODEL_PROXY_ROUTE,
+                body,
+                invocation_context_path=self.invocation_context_path,
+                request_proof_key_path=self.request_proof_key_path,
+            ),
+        }
+        request = urllib_request.Request(
+            f"{self.model_upstream_base_url}{MODEL_PROXY_ROUTE}",
+            data=body,
+            method="POST",
+            headers=headers,
+        )
+        opener = urllib_request.build_opener(_NoRedirectHandler())
+        try:
+            response = opener.open(request, timeout=300)
+        except urllib_error.HTTPError as error:
+            response = error
+        try:
+            response_body = response.read(MAX_MODEL_RESPONSE_BYTES + 1)
+            if len(response_body) > MAX_MODEL_RESPONSE_BYTES:
+                raise BrokerStubConfigurationError(
+                    "model broker response exceeds eval stub limit"
+                )
+            return (
+                response.status,
+                response.headers.get(
+                    "Content-Type",
+                    "application/octet-stream",
+                ),
+                response_body,
+            )
+        finally:
+            response.close()
+
     def enter_request(
         self,
         *,
@@ -457,13 +615,21 @@ class BrokerStubRequestHandler(BaseHTTPRequestHandler):
 
     def _send_json(self, status: int, body: object) -> None:
         serialized = json.dumps(body, separators=(",", ":")).encode("utf-8")
+        self._send_body(status, serialized, "application/json")
+
+    def _send_body(
+        self,
+        status: int,
+        body: bytes,
+        content_type: str,
+    ) -> None:
         self.send_response(status)
-        self.send_header("Content-Type", "application/json")
-        self.send_header("Content-Length", str(len(serialized)))
+        self.send_header("Content-Type", content_type)
+        self.send_header("Content-Length", str(len(body)))
         self.send_header("Cache-Control", "no-store")
         self.send_header("Connection", "close")
         self.end_headers()
-        self.wfile.write(serialized)
+        self.wfile.write(body)
 
     def _read_body(self) -> tuple[bytes, object]:
         raw_length = self.headers.get("Content-Length", "0")
@@ -640,7 +806,7 @@ class BrokerStubRequestHandler(BaseHTTPRequestHandler):
             if (
                 isinstance(status, bool)
                 or not isinstance(status, int)
-                or status < 100
+                or status < 200
                 or status > 599
             ):
                 raise BrokerStubConfigurationError(
@@ -669,6 +835,37 @@ class BrokerStubRequestHandler(BaseHTTPRequestHandler):
             self._send_json(
                 HTTPStatus.INTERNAL_SERVER_ERROR,
                 {"error": MISSING_FIXTURE_ERROR, "message": message},
+            )
+
+    def _handle_model_proxy(self) -> None:
+        try:
+            body, _ = self._read_body()
+            status, content_type, response_body = (
+                self.server.state.forward_model_request(
+                    body,
+                    content_type=self.headers.get(
+                        "Content-Type",
+                        "application/json",
+                    ),
+                    accept=self.headers.get("Accept", "application/json"),
+                )
+            )
+            self._send_body(status, response_body, content_type)
+        except BrokerStubConfigurationError as error:
+            self._send_json(
+                HTTPStatus.BAD_GATEWAY,
+                {
+                    "error": "EvalModelProxyUnavailable",
+                    "message": str(error),
+                },
+            )
+        except (OSError, urllib_error.URLError) as error:
+            self._send_json(
+                HTTPStatus.BAD_GATEWAY,
+                {
+                    "error": "EvalModelProxyUnavailable",
+                    "message": str(error),
+                },
             )
 
     def _capture_finalization_rejection(self, route: str) -> None:
@@ -721,6 +918,25 @@ class BrokerStubRequestHandler(BaseHTTPRequestHandler):
             finally:
                 self.server.state.leave_request()
             return
+        if path == MODEL_MESSAGES_PATH:
+            if self.command != "POST":
+                self._send_json(
+                    HTTPStatus.METHOD_NOT_ALLOWED,
+                    {"error": "EvalModelMethodNotAllowed"},
+                )
+                return
+            entered, _ = self.server.state.enter_request()
+            if not entered:
+                self._send_json(
+                    HTTPStatus.SERVICE_UNAVAILABLE,
+                    {"error": FINALIZING_ERROR},
+                )
+                return
+            try:
+                self._handle_model_proxy()
+            finally:
+                self.server.state.leave_request()
+            return
         self._send_json(
             HTTPStatus.NOT_FOUND,
             {"error": "EvalUnsupportedPath"},
@@ -739,6 +955,9 @@ def create_server(
     host: str = "127.0.0.1",
     port: int = 18791,
     workspace_flush_token_path: Path | None = None,
+    invocation_context_path: Path | None = None,
+    request_proof_key_path: Path | None = None,
+    model_upstream_base_url: str | None = None,
 ) -> BrokerStubServer:
     control_directory.mkdir(parents=True, exist_ok=True, mode=0o700)
     os.chmod(control_directory, 0o700)
@@ -747,6 +966,9 @@ def create_server(
         BrokerStubState(
             control_directory,
             workspace_flush_token_path=workspace_flush_token_path,
+            invocation_context_path=invocation_context_path,
+            request_proof_key_path=request_proof_key_path,
+            model_upstream_base_url=model_upstream_base_url,
         ),
     )
 

--- a/infra/agent-image/eval/broker_stub.py
+++ b/infra/agent-image/eval/broker_stub.py
@@ -13,6 +13,7 @@ import hmac
 import json
 import logging
 import os
+import secrets
 import sys
 import threading
 import time
@@ -22,6 +23,8 @@ from http import HTTPStatus
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from typing import ClassVar
+from urllib import error as urllib_error
+from urllib import request as urllib_request
 from urllib.parse import urlsplit
 
 
@@ -41,6 +44,9 @@ INVALID_REQUEST_BODY_ERROR = "EvalInvalidRequestBody"
 FINALIZING_ERROR = "EvalFinalizationInProgress"
 RUNNER_WRITE_TRIAL_COMMAND = "--runner-write-trial"
 RUNNER_READ_CAPTURES_COMMAND = "--runner-read-captures"
+RUNNER_CONTROL_TOKEN_FILENAME = "runner-control-token"
+RUNNER_CONTROL_HEADER = "X-Agent-Eval-Runner-Control"
+RUNNER_OPEN_TRIAL_PATH = "/internal/eval-trial/open"
 
 ALLOWED_AGENT_BROKER_ROUTES = frozenset(
     {
@@ -66,6 +72,71 @@ ALLOWED_AGENT_BROKER_ROUTES = frozenset(
 
 class BrokerStubConfigurationError(RuntimeError):
     """The runner supplied an invalid or unreadable trial fixture."""
+
+
+def _ensure_runner_control_token(control_directory: Path) -> str:
+    """Create or reuse the root-only token for runner-owned gate transitions."""
+
+    path = control_directory / RUNNER_CONTROL_TOKEN_FILENAME
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+    flags |= getattr(os, "O_NOFOLLOW", 0)
+    try:
+        descriptor = os.open(path, flags, 0o600)
+    except FileExistsError:
+        read_flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+        descriptor = os.open(path, read_flags)
+        os.fchmod(descriptor, 0o600)
+        with os.fdopen(descriptor, "r", encoding="ascii") as handle:
+            token = handle.read().strip()
+    else:
+        token = secrets.token_urlsafe(32)
+        with os.fdopen(descriptor, "w", encoding="ascii") as handle:
+            os.fchmod(handle.fileno(), 0o600)
+            handle.write(token)
+            handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+    if len(token) != 43:
+        raise BrokerStubConfigurationError(
+            "runner control token is malformed"
+        )
+    return token
+
+
+def activate_installed_trial(
+    control_directory: Path,
+    *,
+    host: str = "127.0.0.1",
+    port: int = 18791,
+) -> None:
+    """Open the in-process gate only after root installed the next trial."""
+
+    token_path = control_directory / RUNNER_CONTROL_TOKEN_FILENAME
+    flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+    descriptor = os.open(token_path, flags)
+    with os.fdopen(descriptor, "r", encoding="ascii") as handle:
+        token = handle.read().strip()
+    request = urllib_request.Request(
+        f"http://{host}:{port}{RUNNER_OPEN_TRIAL_PATH}",
+        data=b"",
+        method="POST",
+        headers={RUNNER_CONTROL_HEADER: token},
+    )
+    try:
+        with urllib_request.urlopen(request, timeout=5) as response:
+            if response.status != HTTPStatus.OK:
+                raise BrokerStubConfigurationError(
+                    f"runner gate open returned {response.status}"
+                )
+    except urllib_error.HTTPError as error:
+        error.read(500)
+        raise BrokerStubConfigurationError(
+            f"runner gate open returned {error.code}"
+        ) from error
+    except urllib_error.URLError as error:
+        raise BrokerStubConfigurationError(
+            f"runner gate open failed: {error.reason}"
+        ) from error
 
 
 def install_trial_configuration(
@@ -140,6 +211,23 @@ def collect_trial_captures(control_directory: Path) -> bytes:
     return serialized
 
 
+def install_and_activate_trial(
+    control_directory: Path,
+    serialized: bytes,
+    *,
+    host: str = "127.0.0.1",
+    port: int = 18791,
+) -> None:
+    """Install the next trial and then cross its authenticated gate boundary."""
+
+    install_trial_configuration(control_directory, serialized)
+    activate_installed_trial(
+        control_directory,
+        host=host,
+        port=port,
+    )
+
+
 def _strict_equal(actual: object, expected: object) -> bool:
     return type(actual) is type(expected) and actual == expected
 
@@ -163,7 +251,7 @@ def _mapping_contains(actual: object, expected: object) -> bool:
 
 
 class BrokerStubState:
-    """Read active fixtures and append captures under a runner-owned directory."""
+    """Read fixtures and append captures under a root-owned directory."""
 
     def __init__(
         self,
@@ -176,9 +264,12 @@ class BrokerStubState:
             workspace_flush_token_path
             or Path(DEFAULT_WORKSPACE_FLUSH_TOKEN_PATH)
         )
+        self._runner_control_token = _ensure_runner_control_token(
+            control_directory
+        )
         self._capture_lock = threading.Lock()
         self._finalization_condition = threading.Condition()
-        self._finalization_state = "open"
+        self._finalization_state = "closed"
         self._active_requests = 0
 
     @property
@@ -263,14 +354,28 @@ class BrokerStubState:
             and hmac.compare_digest(supplied_token, expected_token)
         )
 
-    def enter_request(self, *, final_flush: bool = False) -> bool:
+    def valid_runner_control_token(self, supplied_token: str | None) -> bool:
+        return (
+            isinstance(supplied_token, str)
+            and hmac.compare_digest(
+                supplied_token,
+                self._runner_control_token,
+            )
+        )
+
+    def enter_request(
+        self,
+        *,
+        final_flush: bool = False,
+    ) -> tuple[bool, str]:
         with self._finalization_condition:
-            if self._finalization_state == "draining":
-                return False
-            if self._finalization_state == "flushing" and not final_flush:
-                return False
+            state = self._finalization_state
+            if state in {"draining", "closed"}:
+                return False, state
+            if state == "flushing" and not final_flush:
+                return False, state
             self._active_requests += 1
-            return True
+            return True, state
 
     def leave_request(self) -> None:
         with self._finalization_condition:
@@ -297,8 +402,18 @@ class BrokerStubState:
 
     def end_finalization(self) -> None:
         with self._finalization_condition:
-            self._finalization_state = "open"
+            self._finalization_state = "closed"
             self._finalization_condition.notify_all()
+
+    def activate_trial(self) -> bool:
+        with self._finalization_condition:
+            if (
+                self._finalization_state != "closed"
+                or self._active_requests
+            ):
+                return False
+            self._finalization_state = "open"
+            return True
 
     @property
     def finalization_state(self) -> str:
@@ -333,6 +448,7 @@ class BrokerStubRequestHandler(BaseHTTPRequestHandler):
             "/usage",
             "/internal/finalization/begin",
             "/internal/finalization/end",
+            RUNNER_OPEN_TRIAL_PATH,
         }
     )
 
@@ -381,6 +497,21 @@ class BrokerStubRequestHandler(BaseHTTPRequestHandler):
                     "model": None,
                 },
             )
+            return True
+        if path == RUNNER_OPEN_TRIAL_PATH and self.command == "POST":
+            self._read_body()
+            if not self.server.state.valid_runner_control_token(
+                self.headers.get(RUNNER_CONTROL_HEADER)
+            ):
+                self._send_json(HTTPStatus.NOT_FOUND, {"error": "NotFound"})
+                return True
+            if not self.server.state.activate_trial():
+                self._send_json(
+                    HTTPStatus.CONFLICT,
+                    {"error": "EvalTrialGateStateInvalid"},
+                )
+                return True
+            self._send_json(HTTPStatus.OK, {"trial_open": True})
             return True
         if path == "/internal/finalization/begin" and self.command == "POST":
             self._read_body()
@@ -574,8 +705,12 @@ class BrokerStubRequestHandler(BaseHTTPRequestHandler):
                     self.headers.get("X-Agent-Workspace-Flush")
                 )
             )
-            if not self.server.state.enter_request(final_flush=final_flush):
-                self._capture_finalization_rejection(route)
+            entered, rejected_state = self.server.state.enter_request(
+                final_flush=final_flush
+            )
+            if not entered:
+                if rejected_state != "closed":
+                    self._capture_finalization_rejection(route)
                 self._send_json(
                     HTTPStatus.SERVICE_UNAVAILABLE,
                     {"error": FINALIZING_ERROR},
@@ -622,7 +757,10 @@ def main(arguments: list[str] | None = None) -> None:
         os.environ.get(CONTROL_DIRECTORY_ENV, DEFAULT_CONTROL_DIRECTORY)
     )
     if requested == [RUNNER_WRITE_TRIAL_COMMAND]:
-        install_trial_configuration(control_directory, sys.stdin.buffer.read())
+        install_and_activate_trial(
+            control_directory,
+            sys.stdin.buffer.read(),
+        )
         return
     if requested == [RUNNER_READ_CAPTURES_COMMAND]:
         sys.stdout.buffer.write(collect_trial_captures(control_directory))

--- a/infra/agent-image/eval/broker_stub.py
+++ b/infra/agent-image/eval/broker_stub.py
@@ -4,7 +4,7 @@
 The eval runner bind-mounts this file over ``/app/mantle_proxy.py`` in L1
 candidate containers. The existing wrapper therefore starts it on
 127.0.0.1:18791 without modifying the image. Trial fixtures and captures move
-through a separate runner-owned bind mount.
+through a root-owned in-container tmpfs.
 """
 
 from __future__ import annotations
@@ -13,8 +13,10 @@ import hmac
 import json
 import logging
 import os
+import sys
 import threading
 import time
+import uuid
 from collections.abc import Mapping
 from http import HTTPStatus
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
@@ -37,6 +39,8 @@ MISSING_FIXTURE_ERROR = "EvalFixtureMissing"
 UNSUPPORTED_METHOD_ERROR = "EvalUnsupportedAgentMethod"
 INVALID_REQUEST_BODY_ERROR = "EvalInvalidRequestBody"
 FINALIZING_ERROR = "EvalFinalizationInProgress"
+RUNNER_WRITE_TRIAL_COMMAND = "--runner-write-trial"
+RUNNER_READ_CAPTURES_COMMAND = "--runner-read-captures"
 
 ALLOWED_AGENT_BROKER_ROUTES = frozenset(
     {
@@ -62,6 +66,78 @@ ALLOWED_AGENT_BROKER_ROUTES = frozenset(
 
 class BrokerStubConfigurationError(RuntimeError):
     """The runner supplied an invalid or unreadable trial fixture."""
+
+
+def install_trial_configuration(
+    control_directory: Path,
+    serialized: bytes,
+) -> None:
+    """Atomically install trial state inside the root-owned control tmpfs."""
+
+    try:
+        configuration = json.loads(serialized)
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise BrokerStubConfigurationError(
+            "runner trial configuration is not valid JSON"
+        ) from error
+    if not isinstance(configuration, Mapping):
+        raise BrokerStubConfigurationError(
+            "runner trial configuration must be an object"
+        )
+    control_directory.mkdir(parents=True, exist_ok=True, mode=0o700)
+    os.chmod(control_directory, 0o700)
+
+    capture_path = control_directory / CAPTURE_FILENAME
+    capture_flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC
+    capture_flags |= getattr(os, "O_NOFOLLOW", 0)
+    capture_descriptor = os.open(capture_path, capture_flags, 0o600)
+    try:
+        os.fchmod(capture_descriptor, 0o600)
+    finally:
+        os.close(capture_descriptor)
+
+    temporary_path = control_directory / (
+        f".{TRIAL_CONFIG_FILENAME}.{uuid.uuid4().hex}.tmp"
+    )
+    trial_flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+    trial_flags |= getattr(os, "O_NOFOLLOW", 0)
+    trial_descriptor = os.open(temporary_path, trial_flags, 0o600)
+    try:
+        os.fchmod(trial_descriptor, 0o600)
+        with os.fdopen(trial_descriptor, "wb") as handle:
+            handle.write(serialized)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary_path, control_directory / TRIAL_CONFIG_FILENAME)
+    except Exception:
+        try:
+            os.close(trial_descriptor)
+        except OSError:
+            pass
+        try:
+            temporary_path.unlink()
+        except OSError:
+            pass
+        raise
+
+
+def collect_trial_captures(control_directory: Path) -> bytes:
+    """Read the capture and remove the no-longer-active trial config."""
+
+    capture_path = control_directory / CAPTURE_FILENAME
+    flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+    try:
+        descriptor = os.open(capture_path, flags)
+    except FileNotFoundError:
+        serialized = b""
+    else:
+        with os.fdopen(descriptor, "rb") as handle:
+            serialized = handle.read()
+    try:
+        (control_directory / TRIAL_CONFIG_FILENAME).unlink()
+    except FileNotFoundError:
+        pass
+    return serialized
 
 
 def _strict_equal(actual: object, expected: object) -> bool:
@@ -540,13 +616,23 @@ def create_server(
     )
 
 
-def main() -> None:
+def main(arguments: list[str] | None = None) -> None:
+    requested = list(sys.argv[1:] if arguments is None else arguments)
+    control_directory = Path(
+        os.environ.get(CONTROL_DIRECTORY_ENV, DEFAULT_CONTROL_DIRECTORY)
+    )
+    if requested == [RUNNER_WRITE_TRIAL_COMMAND]:
+        install_trial_configuration(control_directory, sys.stdin.buffer.read())
+        return
+    if requested == [RUNNER_READ_CAPTURES_COMMAND]:
+        sys.stdout.buffer.write(collect_trial_captures(control_directory))
+        return
+    if requested:
+        raise SystemExit("unsupported eval broker stub command")
+
     logging.basicConfig(
         level=logging.INFO,
         format="%(asctime)s %(levelname)s %(message)s",
-    )
-    control_directory = Path(
-        os.environ.get(CONTROL_DIRECTORY_ENV, DEFAULT_CONTROL_DIRECTORY)
     )
     server = create_server(control_directory)
     LOGGER.info(

--- a/infra/agent-image/eval/broker_stub.py
+++ b/infra/agent-image/eval/broker_stub.py
@@ -9,10 +9,12 @@ through a separate runner-owned bind mount.
 
 from __future__ import annotations
 
+import hmac
 import json
 import logging
 import os
 import threading
+import time
 from collections.abc import Mapping
 from http import HTTPStatus
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
@@ -24,12 +26,17 @@ from urllib.parse import urlsplit
 LOGGER = logging.getLogger("agent_eval_broker_stub")
 CONTROL_DIRECTORY_ENV = "AGENT_EVAL_BROKER_CONTROL_DIR"
 DEFAULT_CONTROL_DIRECTORY = "/run/psd-agent-eval-broker"
+DEFAULT_WORKSPACE_FLUSH_TOKEN_PATH = (
+    "/run/psd-agent-authority/workspace-flush-token"
+)
 TRIAL_CONFIG_FILENAME = "trial.json"
 CAPTURE_FILENAME = "capture.jsonl"
 MAX_REQUEST_BYTES = 50 * 1024 * 1024
+FINALIZATION_DRAIN_TIMEOUT_SECONDS = 120
 MISSING_FIXTURE_ERROR = "EvalFixtureMissing"
 UNSUPPORTED_METHOD_ERROR = "EvalUnsupportedAgentMethod"
 INVALID_REQUEST_BODY_ERROR = "EvalInvalidRequestBody"
+FINALIZING_ERROR = "EvalFinalizationInProgress"
 
 ALLOWED_AGENT_BROKER_ROUTES = frozenset(
     {
@@ -82,9 +89,21 @@ def _mapping_contains(actual: object, expected: object) -> bool:
 class BrokerStubState:
     """Read active fixtures and append captures under a runner-owned directory."""
 
-    def __init__(self, control_directory: Path) -> None:
+    def __init__(
+        self,
+        control_directory: Path,
+        *,
+        workspace_flush_token_path: Path | None = None,
+    ) -> None:
         self.control_directory = control_directory
+        self.workspace_flush_token_path = (
+            workspace_flush_token_path
+            or Path(DEFAULT_WORKSPACE_FLUSH_TOKEN_PATH)
+        )
         self._capture_lock = threading.Lock()
+        self._finalization_condition = threading.Condition()
+        self._finalization_state = "open"
+        self._active_requests = 0
 
     @property
     def trial_config_path(self) -> Path:
@@ -154,6 +173,61 @@ class BrokerStubState:
                 except OSError:
                     pass
                 raise
+
+    def valid_flush_token(self, supplied_token: str | None) -> bool:
+        try:
+            expected_token = self.workspace_flush_token_path.read_text(
+                encoding="ascii"
+            ).strip()
+        except OSError:
+            return False
+        return (
+            isinstance(supplied_token, str)
+            and bool(expected_token)
+            and hmac.compare_digest(supplied_token, expected_token)
+        )
+
+    def enter_request(self, *, final_flush: bool = False) -> bool:
+        with self._finalization_condition:
+            if self._finalization_state == "draining":
+                return False
+            if self._finalization_state == "flushing" and not final_flush:
+                return False
+            self._active_requests += 1
+            return True
+
+    def leave_request(self) -> None:
+        with self._finalization_condition:
+            if self._active_requests <= 0:
+                raise RuntimeError("finalization gate request count underflow")
+            self._active_requests -= 1
+            if self._active_requests == 0:
+                self._finalization_condition.notify_all()
+
+    def begin_finalization(
+        self,
+        timeout_seconds: float = FINALIZATION_DRAIN_TIMEOUT_SECONDS,
+    ) -> bool:
+        deadline = time.monotonic() + timeout_seconds
+        with self._finalization_condition:
+            self._finalization_state = "draining"
+            while self._active_requests:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    return False
+                self._finalization_condition.wait(timeout=remaining)
+            self._finalization_state = "flushing"
+            return True
+
+    def end_finalization(self) -> None:
+        with self._finalization_condition:
+            self._finalization_state = "open"
+            self._finalization_condition.notify_all()
+
+    @property
+    def finalization_state(self) -> str:
+        with self._finalization_condition:
+            return self._finalization_state
 
 
 class BrokerStubServer(ThreadingHTTPServer):
@@ -234,10 +308,27 @@ class BrokerStubRequestHandler(BaseHTTPRequestHandler):
             return True
         if path == "/internal/finalization/begin" and self.command == "POST":
             self._read_body()
+            if not self.server.state.valid_flush_token(
+                self.headers.get("X-Agent-Workspace-Flush")
+            ):
+                self._send_json(HTTPStatus.NOT_FOUND, {"error": "NotFound"})
+                return True
+            if not self.server.state.begin_finalization():
+                self._send_json(
+                    HTTPStatus.SERVICE_UNAVAILABLE,
+                    {"error": "PrivilegedRequestDrainTimedOut"},
+                )
+                return True
             self._send_json(HTTPStatus.OK, {"finalizing": True})
             return True
         if path == "/internal/finalization/end" and self.command == "POST":
             self._read_body()
+            if not self.server.state.valid_flush_token(
+                self.headers.get("X-Agent-Workspace-Flush")
+            ):
+                self._send_json(HTTPStatus.NOT_FOUND, {"error": "NotFound"})
+                return True
+            self.server.state.end_finalization()
             self._send_json(HTTPStatus.OK, {"finalizing": False})
             return True
         if path in self.CONTROL_ENDPOINTS:
@@ -373,12 +464,51 @@ class BrokerStubRequestHandler(BaseHTTPRequestHandler):
                 {"error": MISSING_FIXTURE_ERROR, "message": message},
             )
 
+    def _capture_finalization_rejection(self, route: str) -> None:
+        try:
+            trial = self.server.state.load_trial()
+            self.server.state.capture(
+                {
+                    "trial_id": trial.get("trial_id"),
+                    "task_id": trial.get("task_id"),
+                    "route": route,
+                    "method": self.command,
+                    "headers": {
+                        key.lower(): value
+                        for key, value in self.headers.items()
+                    },
+                    "body": None,
+                    "stub_error": (
+                        f"{FINALIZING_ERROR}: rejected {self.command} {route}"
+                    ),
+                }
+            )
+        except (BrokerStubConfigurationError, OSError):
+            pass
+
     def _handle(self) -> None:
         path = urlsplit(self.path).path
         if self._handle_control(path):
             return
         if path.startswith("/agent-broker/"):
-            self._handle_agent_broker(path)
+            route = path[len("/agent-broker") :]
+            final_flush = (
+                route == "/api/agent/workspace-storage"
+                and self.server.state.valid_flush_token(
+                    self.headers.get("X-Agent-Workspace-Flush")
+                )
+            )
+            if not self.server.state.enter_request(final_flush=final_flush):
+                self._capture_finalization_rejection(route)
+                self._send_json(
+                    HTTPStatus.SERVICE_UNAVAILABLE,
+                    {"error": FINALIZING_ERROR},
+                )
+                return
+            try:
+                self._handle_agent_broker(path)
+            finally:
+                self.server.state.leave_request()
             return
         self._send_json(
             HTTPStatus.NOT_FOUND,
@@ -397,10 +527,17 @@ def create_server(
     *,
     host: str = "127.0.0.1",
     port: int = 18791,
+    workspace_flush_token_path: Path | None = None,
 ) -> BrokerStubServer:
     control_directory.mkdir(parents=True, exist_ok=True, mode=0o700)
     os.chmod(control_directory, 0o700)
-    return BrokerStubServer((host, port), BrokerStubState(control_directory))
+    return BrokerStubServer(
+        (host, port),
+        BrokerStubState(
+            control_directory,
+            workspace_flush_token_path=workspace_flush_token_path,
+        ),
+    )
 
 
 def main() -> None:

--- a/infra/agent-image/eval/broker_stub.py
+++ b/infra/agent-image/eval/broker_stub.py
@@ -613,6 +613,11 @@ class BrokerStubRequestHandler(BaseHTTPRequestHandler):
     def log_message(self, format_string: str, *arguments: object) -> None:
         LOGGER.debug(format_string, *arguments)
 
+    def __getattr__(self, name: str) -> object:
+        if name.startswith("do_"):
+            return self._handle
+        raise AttributeError(name)
+
     def _send_json(self, status: int, body: object) -> None:
         serialized = json.dumps(body, separators=(",", ":")).encode("utf-8")
         self._send_body(status, serialized, "application/json")

--- a/infra/agent-image/eval/broker_stub.py
+++ b/infra/agent-image/eval/broker_stub.py
@@ -1,0 +1,405 @@
+#!/usr/bin/env python3
+"""Hermetic agent-broker fixture server for local eval trials.
+
+The eval runner bind-mounts this file over ``/app/mantle_proxy.py`` in L1
+candidate containers. The existing wrapper therefore starts it on
+127.0.0.1:18791 without modifying the image. Trial fixtures and captures move
+through a separate runner-owned bind mount.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import threading
+from collections.abc import Mapping
+from http import HTTPStatus
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import ClassVar
+from urllib.parse import urlsplit
+
+
+LOGGER = logging.getLogger("agent_eval_broker_stub")
+CONTROL_DIRECTORY_ENV = "AGENT_EVAL_BROKER_CONTROL_DIR"
+DEFAULT_CONTROL_DIRECTORY = "/run/psd-agent-eval-broker"
+TRIAL_CONFIG_FILENAME = "trial.json"
+CAPTURE_FILENAME = "capture.jsonl"
+MAX_REQUEST_BYTES = 50 * 1024 * 1024
+MISSING_FIXTURE_ERROR = "EvalFixtureMissing"
+
+ALLOWED_AGENT_BROKER_ROUTES = frozenset(
+    {
+        "/api/agent/account-request",
+        "/api/agent/aistudio",
+        "/api/agent/atrium",
+        "/api/agent/canva",
+        "/api/agent/classified-evaluation",
+        "/api/agent/workflow-gateway",
+        "/api/agent/consent-link",
+        "/api/agent/credentials",
+        "/api/agent/directory-lookup",
+        "/api/agent/email-triage",
+        "/api/agent/failures",
+        "/api/agent/github-execute",
+        "/api/agent/schedules",
+        "/api/agent/skills",
+        "/api/agent/workspace-execute",
+        "/api/agent/workspace-storage",
+    }
+)
+
+
+class BrokerStubConfigurationError(RuntimeError):
+    """The runner supplied an invalid or unreadable trial fixture."""
+
+
+def _strict_equal(actual: object, expected: object) -> bool:
+    return type(actual) is type(expected) and actual == expected
+
+
+def _mapping_contains(actual: object, expected: object) -> bool:
+    if isinstance(expected, Mapping):
+        if not isinstance(actual, Mapping):
+            return False
+        return all(
+            key in actual and _mapping_contains(actual[key], value)
+            for key, value in expected.items()
+        )
+    if isinstance(expected, list):
+        if not isinstance(actual, list) or len(actual) != len(expected):
+            return False
+        return all(
+            _mapping_contains(actual_value, expected_value)
+            for actual_value, expected_value in zip(actual, expected, strict=True)
+        )
+    return _strict_equal(actual, expected)
+
+
+class BrokerStubState:
+    """Read active fixtures and append captures under a runner-owned directory."""
+
+    def __init__(self, control_directory: Path) -> None:
+        self.control_directory = control_directory
+        self._capture_lock = threading.Lock()
+
+    @property
+    def trial_config_path(self) -> Path:
+        return self.control_directory / TRIAL_CONFIG_FILENAME
+
+    @property
+    def capture_path(self) -> Path:
+        return self.control_directory / CAPTURE_FILENAME
+
+    def load_trial(self) -> Mapping[str, object]:
+        try:
+            raw = self.trial_config_path.read_text(encoding="utf-8")
+            trial = json.loads(raw)
+        except (OSError, json.JSONDecodeError) as error:
+            raise BrokerStubConfigurationError(
+                f"{MISSING_FIXTURE_ERROR}: active trial configuration is unavailable"
+            ) from error
+        if not isinstance(trial, Mapping):
+            raise BrokerStubConfigurationError(
+                f"{MISSING_FIXTURE_ERROR}: active trial configuration is not an object"
+            )
+        fixtures = trial.get("fixtures")
+        if not isinstance(fixtures, list):
+            raise BrokerStubConfigurationError(
+                f"{MISSING_FIXTURE_ERROR}: active trial fixtures are not a list"
+            )
+        return trial
+
+    def find_fixture(
+        self,
+        trial: Mapping[str, object],
+        *,
+        route: str,
+        method: str,
+        body: object,
+    ) -> Mapping[str, object] | None:
+        fixtures = trial["fixtures"]
+        if not isinstance(fixtures, list):
+            return None
+        for fixture in fixtures:
+            if not isinstance(fixture, Mapping):
+                continue
+            if fixture.get("route") != route:
+                continue
+            fixture_method = fixture.get("method", "POST")
+            if not isinstance(fixture_method, str) or fixture_method.upper() != method:
+                continue
+            expected_body = fixture.get("request_body")
+            if expected_body is not None and not _mapping_contains(body, expected_body):
+                continue
+            return fixture
+        return None
+
+    def capture(self, record: Mapping[str, object]) -> None:
+        serialized = json.dumps(record, separators=(",", ":")) + "\n"
+        flags = os.O_WRONLY | os.O_CREAT | os.O_APPEND
+        flags |= getattr(os, "O_NOFOLLOW", 0)
+        with self._capture_lock:
+            descriptor = os.open(self.capture_path, flags, 0o600)
+            try:
+                os.fchmod(descriptor, 0o600)
+                with os.fdopen(descriptor, "a", encoding="utf-8") as handle:
+                    handle.write(serialized)
+            except Exception:
+                try:
+                    os.close(descriptor)
+                except OSError:
+                    pass
+                raise
+
+
+class BrokerStubServer(ThreadingHTTPServer):
+    """Threaded loopback server carrying its isolated trial state."""
+
+    daemon_threads = True
+
+    def __init__(
+        self,
+        server_address: tuple[str, int],
+        state: BrokerStubState,
+    ) -> None:
+        self.state = state
+        super().__init__(server_address, BrokerStubRequestHandler)
+
+
+class BrokerStubRequestHandler(BaseHTTPRequestHandler):
+    """Serve control endpoints and the fixed agent-broker allowlist."""
+
+    server: BrokerStubServer
+    protocol_version = "HTTP/1.1"
+    server_version = "AgentEvalBrokerStub/1"
+    sys_version = ""
+    CONTROL_ENDPOINTS: ClassVar[frozenset[str]] = frozenset(
+        {
+            "/health",
+            "/usage",
+            "/internal/finalization/begin",
+            "/internal/finalization/end",
+        }
+    )
+
+    def log_message(self, format_string: str, *arguments: object) -> None:
+        LOGGER.debug(format_string, *arguments)
+
+    def _send_json(self, status: int, body: object) -> None:
+        serialized = json.dumps(body, separators=(",", ":")).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(serialized)))
+        self.send_header("Cache-Control", "no-store")
+        self.send_header("Connection", "close")
+        self.end_headers()
+        self.wfile.write(serialized)
+
+    def _read_body(self) -> tuple[bytes, object]:
+        raw_length = self.headers.get("Content-Length", "0")
+        try:
+            length = int(raw_length)
+        except ValueError as error:
+            raise BrokerStubConfigurationError("invalid Content-Length") from error
+        if length < 0 or length > MAX_REQUEST_BYTES:
+            raise BrokerStubConfigurationError("request body exceeds eval stub limit")
+        raw = self.rfile.read(length)
+        if not raw:
+            return raw, None
+        try:
+            return raw, json.loads(raw)
+        except (UnicodeDecodeError, json.JSONDecodeError):
+            return raw, raw.decode("utf-8", errors="replace")
+
+    def _handle_control(self, path: str) -> bool:
+        if path == "/health" and self.command == "GET":
+            self._send_json(HTTPStatus.OK, {"ok": True, "mode": "eval-stub"})
+            return True
+        if path == "/usage" and self.command == "GET":
+            self._send_json(
+                HTTPStatus.OK,
+                {
+                    "input_tokens": 0,
+                    "output_tokens": 0,
+                    "cache_read_input_tokens": 0,
+                    "cache_write_input_tokens": 0,
+                    "usage_events": 0,
+                    "model": None,
+                },
+            )
+            return True
+        if path == "/internal/finalization/begin" and self.command == "POST":
+            self._read_body()
+            self._send_json(HTTPStatus.OK, {"finalizing": True})
+            return True
+        if path == "/internal/finalization/end" and self.command == "POST":
+            self._read_body()
+            self._send_json(HTTPStatus.OK, {"finalizing": False})
+            return True
+        if path in self.CONTROL_ENDPOINTS:
+            self._send_json(
+                HTTPStatus.METHOD_NOT_ALLOWED,
+                {"error": "EvalControlMethodNotAllowed"},
+            )
+            return True
+        return False
+
+    def _handle_agent_broker(self, path: str) -> None:
+        prefix = "/agent-broker"
+        route = path[len(prefix) :]
+        body: object = None
+        try:
+            _, body = self._read_body()
+            trial = self.server.state.load_trial()
+            trial_id = trial.get("trial_id")
+            task_id = trial.get("task_id")
+            if route not in ALLOWED_AGENT_BROKER_ROUTES:
+                error = f"EvalUnsupportedAgentRoute: {self.command} {route}"
+                self.server.state.capture(
+                    {
+                        "trial_id": trial_id,
+                        "task_id": task_id,
+                        "route": route,
+                        "method": self.command,
+                        "headers": {
+                            key.lower(): value
+                            for key, value in self.headers.items()
+                        },
+                        "body": body,
+                        "stub_error": error,
+                    }
+                )
+                self._send_json(
+                    HTTPStatus.NOT_FOUND,
+                    {"error": "EvalUnsupportedAgentRoute", "route": route},
+                )
+                return
+            fixture = self.server.state.find_fixture(
+                trial,
+                route=route,
+                method=self.command,
+                body=body,
+            )
+            error: str | None = None
+            if fixture is None:
+                error = (
+                    f"{MISSING_FIXTURE_ERROR}: no fixture for "
+                    f"{self.command} {route}"
+                )
+            self.server.state.capture(
+                {
+                    "trial_id": trial_id,
+                    "task_id": task_id,
+                    "route": route,
+                    "method": self.command,
+                    "headers": {
+                        key.lower(): value
+                        for key, value in self.headers.items()
+                    },
+                    "body": body,
+                    "stub_error": error,
+                }
+            )
+            if fixture is None:
+                self._send_json(
+                    HTTPStatus.NOT_IMPLEMENTED,
+                    {
+                        "error": MISSING_FIXTURE_ERROR,
+                        "message": error,
+                        "route": route,
+                    },
+                )
+                return
+            response = fixture.get("response", {})
+            if not isinstance(response, Mapping):
+                raise BrokerStubConfigurationError(
+                    f"fixture response for {route} is not an object"
+                )
+            status = response.get("status", HTTPStatus.OK)
+            if (
+                isinstance(status, bool)
+                or not isinstance(status, int)
+                or status < 100
+                or status > 599
+            ):
+                raise BrokerStubConfigurationError(
+                    f"fixture response status for {route} is invalid"
+                )
+            self._send_json(status, response.get("body", {}))
+        except BrokerStubConfigurationError as error:
+            message = str(error)
+            try:
+                self.server.state.capture(
+                    {
+                        "trial_id": None,
+                        "task_id": None,
+                        "route": route,
+                        "method": self.command,
+                        "headers": {
+                            key.lower(): value
+                            for key, value in self.headers.items()
+                        },
+                        "body": body,
+                        "stub_error": message,
+                    }
+                )
+            except OSError:
+                pass
+            self._send_json(
+                HTTPStatus.INTERNAL_SERVER_ERROR,
+                {"error": MISSING_FIXTURE_ERROR, "message": message},
+            )
+
+    def _handle(self) -> None:
+        path = urlsplit(self.path).path
+        if self._handle_control(path):
+            return
+        if path.startswith("/agent-broker/"):
+            self._handle_agent_broker(path)
+            return
+        self._send_json(
+            HTTPStatus.NOT_FOUND,
+            {"error": "EvalUnsupportedPath"},
+        )
+
+    do_GET = _handle
+    do_POST = _handle
+    do_PUT = _handle
+    do_PATCH = _handle
+    do_DELETE = _handle
+
+
+def create_server(
+    control_directory: Path,
+    *,
+    host: str = "127.0.0.1",
+    port: int = 18791,
+) -> BrokerStubServer:
+    control_directory.mkdir(parents=True, exist_ok=True, mode=0o700)
+    os.chmod(control_directory, 0o700)
+    return BrokerStubServer((host, port), BrokerStubState(control_directory))
+
+
+def main() -> None:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(message)s",
+    )
+    control_directory = Path(
+        os.environ.get(CONTROL_DIRECTORY_ENV, DEFAULT_CONTROL_DIRECTORY)
+    )
+    server = create_server(control_directory)
+    LOGGER.info(
+        "starting eval broker stub on 127.0.0.1:18791 with %d routes",
+        len(ALLOWED_AGENT_BROKER_ROUTES),
+    )
+    try:
+        server.serve_forever()
+    finally:
+        server.server_close()
+
+
+if __name__ == "__main__":
+    main()

--- a/infra/agent-image/eval/graders/__init__.py
+++ b/infra/agent-image/eval/graders/__init__.py
@@ -468,10 +468,25 @@ def grade_trial(
 ) -> dict[str, object]:
     """Run every configured grader and preserve human-readable reasons."""
 
-    grader_results: list[GraderResult] = [
+    grader_results: list[GraderResult] = []
+    if metadata.get("failed") is True:
+        error_class = metadata.get("error_class")
+        detail = (
+            str(error_class)
+            if isinstance(error_class, str) and error_class
+            else "unknown runtime error"
+        )
+        grader_results.append(
+            GraderResult(
+                "invocation",
+                False,
+                f"invocation metadata reported failure: {detail}",
+            )
+        )
+    grader_results.extend(
         GraderResult("broker_stub", False, error)
         for error in artifacts.broker_errors
-    ]
+    )
     for spec in specs:
         grader = str(spec["type"])
         if grader == "broker_request":

--- a/infra/agent-image/eval/graders/__init__.py
+++ b/infra/agent-image/eval/graders/__init__.py
@@ -418,19 +418,37 @@ def _parse_tools_catalog_names(log_text: str) -> set[str]:
 
     def collect(value: object) -> None:
         if isinstance(value, Mapping):
+            compact_names = value.get("names")
+            if isinstance(compact_names, list):
+                observed.update(
+                    item
+                    for item in compact_names
+                    if isinstance(item, str) and item
+                )
+                return
             name = value.get("name")
             if isinstance(name, str) and name:
                 observed.add(name)
-            for nested in value.values():
-                if isinstance(nested, (Mapping, list)):
-                    collect(nested)
+                return
+            for group in value.values():
+                if isinstance(group, list):
+                    collect(group)
+                elif isinstance(group, Mapping):
+                    group_tools = group.get("tools")
+                    if isinstance(group_tools, list):
+                        collect(group_tools)
+                    else:
+                        group_name = group.get("name")
+                        if isinstance(group_name, str) and group_name:
+                            observed.add(group_name)
             return
         if isinstance(value, list):
-            for nested in value:
-                if isinstance(nested, str) and nested:
-                    observed.add(nested)
-                else:
-                    collect(nested)
+            for entry in value:
+                if not isinstance(entry, Mapping):
+                    continue
+                name = entry.get("name")
+                if isinstance(name, str) and name:
+                    observed.add(name)
 
     marker = "tools.catalog ok:"
     for line in log_text.splitlines():

--- a/infra/agent-image/eval/graders/__init__.py
+++ b/infra/agent-image/eval/graders/__init__.py
@@ -1,0 +1,550 @@
+"""Deterministic graders for local agent-image evaluations.
+
+The graders deliberately operate on recorded outputs, telemetry, and broker
+requests. They never call a model or a live service.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from collections import defaultdict
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from numbers import Real
+
+
+SUPPORTED_GRADERS = frozenset(
+    {
+        "broker_request",
+        "no_route_called",
+        "output_match",
+        "tools_catalog",
+        "trajectory_in_order",
+    }
+)
+BODY_MATCHERS = frozenset({"exact", "contains_any", "numeric_equals"})
+
+
+class GraderConfigurationError(ValueError):
+    """A grader declaration is malformed or unsupported."""
+
+
+@dataclass(frozen=True)
+class TrialArtifacts:
+    """Non-model artifacts collected while one trial ran."""
+
+    broker_requests: tuple[Mapping[str, object], ...] = ()
+    broker_errors: tuple[str, ...] = ()
+    tools_catalog_log: str = ""
+
+
+@dataclass(frozen=True)
+class GraderResult:
+    """One deterministic grading decision."""
+
+    grader: str
+    passed: bool
+    reason: str
+
+    def to_mapping(self) -> dict[str, object]:
+        return {
+            "grader": self.grader,
+            "passed": self.passed,
+            "reason": self.reason,
+        }
+
+
+def _require_nonempty_string(
+    value: object,
+    *,
+    grader: str,
+    field: str,
+) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise GraderConfigurationError(
+            f"{grader} grader field {field} must be a non-empty string"
+        )
+    return value
+
+
+def _validate_route(spec: Mapping[str, object], grader: str) -> None:
+    route = _require_nonempty_string(
+        spec.get("route"),
+        grader=grader,
+        field="route",
+    )
+    if not route.startswith("/api/agent/"):
+        raise GraderConfigurationError(
+            f"{grader} grader route must start with /api/agent/"
+        )
+    method = spec.get("method")
+    if method is not None:
+        _require_nonempty_string(method, grader=grader, field="method")
+
+
+def _validate_body_matchers(value: object) -> None:
+    if value is None:
+        return
+    if not isinstance(value, Mapping):
+        raise GraderConfigurationError(
+            "broker_request grader body must be a field-to-matcher mapping"
+        )
+    for field, matcher in value.items():
+        if not isinstance(field, str) or not field:
+            raise GraderConfigurationError(
+                "broker_request grader body field paths must be non-empty strings"
+            )
+        if not isinstance(matcher, Mapping) or len(matcher) != 1:
+            raise GraderConfigurationError(
+                f"broker_request body matcher for {field} "
+                "must have exactly one operator"
+            )
+        operator, expected = next(iter(matcher.items()))
+        if operator not in BODY_MATCHERS:
+            raise GraderConfigurationError(
+                f"broker_request body matcher for {field} uses unsupported operator "
+                f"{operator}"
+            )
+        if operator == "contains_any":
+            if (
+                not isinstance(expected, Sequence)
+                or isinstance(expected, (str, bytes))
+                or not expected
+            ):
+                raise GraderConfigurationError(
+                    f"broker_request contains_any matcher for {field} "
+                    "must contain a non-empty list"
+                )
+        if operator == "numeric_equals" and (
+            isinstance(expected, bool) or not isinstance(expected, Real)
+        ):
+            raise GraderConfigurationError(
+                f"broker_request numeric_equals matcher for {field} "
+                "must contain a number"
+            )
+
+
+def validate_grader_specs(
+    specs: Sequence[Mapping[str, object]],
+) -> tuple[dict[str, object], ...]:
+    """Validate and normalize task grader declarations."""
+
+    normalized: list[dict[str, object]] = []
+    allowed_fields = {
+        "broker_request": {"type", "route", "method", "body"},
+        "no_route_called": {"type", "route", "method"},
+        "output_match": {"type", "pattern", "ignore_case"},
+        "trajectory_in_order": {"type", "tools"},
+        "tools_catalog": {"type", "expected"},
+    }
+    for raw_spec in specs:
+        if not isinstance(raw_spec, Mapping):
+            raise GraderConfigurationError("grader entries must be mappings")
+        grader = _require_nonempty_string(
+            raw_spec.get("type"),
+            grader="task",
+            field="type",
+        )
+        if grader not in SUPPORTED_GRADERS:
+            raise GraderConfigurationError(f"unsupported grader type: {grader}")
+        unknown = sorted(set(raw_spec).difference(allowed_fields[grader]))
+        if unknown:
+            raise GraderConfigurationError(
+                f"{grader} grader has unsupported fields: {', '.join(unknown)}"
+            )
+        if grader in {"broker_request", "no_route_called"}:
+            _validate_route(raw_spec, grader)
+        if grader == "broker_request":
+            _validate_body_matchers(raw_spec.get("body"))
+        elif grader == "output_match":
+            pattern = _require_nonempty_string(
+                raw_spec.get("pattern"),
+                grader=grader,
+                field="pattern",
+            )
+            try:
+                re.compile(pattern)
+            except re.error as error:
+                raise GraderConfigurationError(
+                    f"output_match grader pattern is invalid: {error}"
+                ) from error
+            ignore_case = raw_spec.get("ignore_case", False)
+            if not isinstance(ignore_case, bool):
+                raise GraderConfigurationError(
+                    "output_match grader ignore_case must be a boolean"
+                )
+        elif grader in {"trajectory_in_order", "tools_catalog"}:
+            field = "tools" if grader == "trajectory_in_order" else "expected"
+            entries = raw_spec.get(field)
+            if (
+                not isinstance(entries, Sequence)
+                or isinstance(entries, (str, bytes))
+                or not entries
+                or any(not isinstance(entry, str) or not entry for entry in entries)
+            ):
+                raise GraderConfigurationError(
+                    f"{grader} grader field {field} must be a non-empty string list"
+                )
+        normalized.append(dict(raw_spec))
+    return tuple(normalized)
+
+
+def _strict_equal(actual: object, expected: object) -> bool:
+    return type(actual) is type(expected) and actual == expected
+
+
+def _resolve_field(body: object, field: str) -> tuple[bool, object]:
+    if field == "$":
+        return True, body
+    current = body
+    for component in field.split("."):
+        if isinstance(current, Mapping) and component in current:
+            current = current[component]
+            continue
+        if isinstance(current, Sequence) and not isinstance(current, (str, bytes)):
+            try:
+                index = int(component)
+                current = current[index]
+                continue
+            except (ValueError, IndexError):
+                pass
+        return False, None
+    return True, current
+
+
+def _match_body(
+    body: object,
+    matchers: Mapping[str, object],
+) -> tuple[bool, str]:
+    for field, matcher_object in matchers.items():
+        matcher = matcher_object
+        if not isinstance(matcher, Mapping):
+            return False, f"invalid matcher for {field}"
+        found, actual = _resolve_field(body, field)
+        if not found:
+            return False, f"body field {field} was absent"
+        operator, expected = next(iter(matcher.items()))
+        if operator == "exact":
+            if not _strict_equal(actual, expected):
+                return (
+                    False,
+                    f"body field {field} expected exact {expected!r}, got {actual!r}",
+                )
+            continue
+        if operator == "numeric_equals":
+            if (
+                isinstance(actual, bool)
+                or not isinstance(actual, Real)
+                or actual != expected
+            ):
+                return (
+                    False,
+                    f"body field {field} expected numeric {expected!r}, got {actual!r}",
+                )
+            continue
+        if operator == "contains_any":
+            candidates = list(expected)
+            if isinstance(actual, str):
+                matched = any(
+                    isinstance(candidate, str) and candidate in actual
+                    for candidate in candidates
+                )
+            elif isinstance(actual, Sequence) and not isinstance(actual, (str, bytes)):
+                matched = any(
+                    any(_strict_equal(item, candidate) for item in actual)
+                    for candidate in candidates
+                )
+            else:
+                matched = False
+            if not matched:
+                return (
+                    False,
+                    f"body field {field} contained none of {candidates!r}",
+                )
+    return True, "body matched"
+
+
+def _request_matches_selector(
+    request: Mapping[str, object],
+    spec: Mapping[str, object],
+) -> bool:
+    if request.get("route") != spec.get("route"):
+        return False
+    method = spec.get("method")
+    return method is None or request.get("method") == str(method).upper()
+
+
+def _grade_broker_request(
+    spec: Mapping[str, object],
+    artifacts: TrialArtifacts,
+) -> GraderResult:
+    candidates = [
+        request
+        for request in artifacts.broker_requests
+        if _request_matches_selector(request, spec)
+    ]
+    if not candidates:
+        method = str(spec.get("method") or "any method").upper()
+        return GraderResult(
+            "broker_request",
+            False,
+            f"no {method} request captured for {spec['route']}",
+        )
+    matchers = spec.get("body")
+    if not isinstance(matchers, Mapping) or not matchers:
+        return GraderResult(
+            "broker_request",
+            True,
+            f"captured {len(candidates)} matching request(s) for {spec['route']}",
+        )
+    failures: list[str] = []
+    for candidate in candidates:
+        matched, reason = _match_body(candidate.get("body"), matchers)
+        if matched:
+            return GraderResult(
+                "broker_request",
+                True,
+                f"captured request for {spec['route']} with matching body",
+            )
+        failures.append(reason)
+    return GraderResult(
+        "broker_request",
+        False,
+        f"{len(candidates)} request(s) hit {spec['route']}, but "
+        + "; ".join(failures[:3]),
+    )
+
+
+def _grade_no_route_called(
+    spec: Mapping[str, object],
+    artifacts: TrialArtifacts,
+) -> GraderResult:
+    matches = [
+        request
+        for request in artifacts.broker_requests
+        if _request_matches_selector(request, spec)
+    ]
+    return GraderResult(
+        "no_route_called",
+        not matches,
+        (
+            f"no request captured for {spec['route']}"
+            if not matches
+            else f"captured {len(matches)} forbidden request(s) for {spec['route']}"
+        ),
+    )
+
+
+def _grade_output_match(
+    spec: Mapping[str, object],
+    result: str,
+) -> GraderResult:
+    flags = re.IGNORECASE if spec.get("ignore_case") else 0
+    matched = re.search(str(spec["pattern"]), result, flags=flags) is not None
+    return GraderResult(
+        "output_match",
+        matched,
+        (
+            f"output matched /{spec['pattern']}/"
+            if matched
+            else f"output did not match /{spec['pattern']}/"
+        ),
+    )
+
+
+def _tool_name(call: object) -> str | None:
+    if isinstance(call, str):
+        return call
+    if not isinstance(call, Mapping):
+        return None
+    for field in ("name", "tool", "tool_name"):
+        value = call.get(field)
+        if isinstance(value, str) and value:
+            return value
+    return None
+
+
+def _grade_trajectory(
+    spec: Mapping[str, object],
+    metadata: Mapping[str, object],
+) -> GraderResult:
+    raw_calls = metadata.get("tool_calls")
+    calls = (
+        [_tool_name(call) for call in raw_calls]
+        if isinstance(raw_calls, Sequence) and not isinstance(raw_calls, (str, bytes))
+        else []
+    )
+    observed = [call for call in calls if call is not None]
+    expected = list(spec["tools"])
+    position = 0
+    for name in observed:
+        if position < len(expected) and name == expected[position]:
+            position += 1
+    passed = position == len(expected)
+    return GraderResult(
+        "trajectory_in_order",
+        passed,
+        (
+            f"observed expected relative order {expected!r}"
+            if passed
+            else f"expected relative order {expected!r}; observed {observed!r}"
+        ),
+    )
+
+
+def _grade_tools_catalog(
+    spec: Mapping[str, object],
+    artifacts: TrialArtifacts,
+) -> GraderResult:
+    expected = list(spec["expected"])
+    observed = _parse_tools_catalog_names(artifacts.tools_catalog_log)
+    missing = [name for name in expected if name not in observed]
+    return GraderResult(
+        "tools_catalog",
+        not missing,
+        (
+            f"catalog contained all {len(expected)} expected entries"
+            if not missing
+            else "catalog was missing: " + ", ".join(missing)
+        ),
+    )
+
+
+def _parse_tools_catalog_names(log_text: str) -> set[str]:
+    """Extract exact tool names from complete or length-truncated diagnostics."""
+
+    observed: set[str] = set()
+
+    def collect(value: object) -> None:
+        if isinstance(value, Mapping):
+            name = value.get("name")
+            if isinstance(name, str) and name:
+                observed.add(name)
+            for nested in value.values():
+                if isinstance(nested, (Mapping, list)):
+                    collect(nested)
+            return
+        if isinstance(value, list):
+            for nested in value:
+                if isinstance(nested, str) and nested:
+                    observed.add(nested)
+                else:
+                    collect(nested)
+
+    marker = "tools.catalog ok:"
+    for line in log_text.splitlines():
+        marker_position = line.find(marker)
+        if marker_position < 0:
+            continue
+        payload = line[marker_position + len(marker) :].strip()
+        try:
+            collect(json.loads(payload))
+            continue
+        except json.JSONDecodeError:
+            pass
+        # harness_adapter.py intentionally caps this diagnostic at 1500
+        # characters. Extract only explicit JSON `name` fields when that cap
+        # cuts a catalog off mid-document.
+        for match in re.finditer(
+            r'"name"\s*:\s*("(?:\\.|[^"\\])*")',
+            payload,
+        ):
+            try:
+                name = json.loads(match.group(1))
+            except json.JSONDecodeError:
+                continue
+            if isinstance(name, str) and name:
+                observed.add(name)
+    return observed
+
+
+def grade_trial(
+    specs: Sequence[Mapping[str, object]],
+    *,
+    result: str,
+    metadata: Mapping[str, object],
+    artifacts: TrialArtifacts,
+) -> dict[str, object]:
+    """Run every configured grader and preserve human-readable reasons."""
+
+    grader_results: list[GraderResult] = [
+        GraderResult("broker_stub", False, error)
+        for error in artifacts.broker_errors
+    ]
+    for spec in specs:
+        grader = str(spec["type"])
+        if grader == "broker_request":
+            grader_results.append(_grade_broker_request(spec, artifacts))
+        elif grader == "no_route_called":
+            grader_results.append(_grade_no_route_called(spec, artifacts))
+        elif grader == "output_match":
+            grader_results.append(_grade_output_match(spec, result))
+        elif grader == "trajectory_in_order":
+            grader_results.append(_grade_trajectory(spec, metadata))
+        elif grader == "tools_catalog":
+            grader_results.append(_grade_tools_catalog(spec, artifacts))
+        else:  # pragma: no cover - validate_grader_specs prevents this.
+            grader_results.append(
+                GraderResult(grader, False, f"unsupported grader type: {grader}")
+            )
+    if not grader_results:
+        return {
+            "passed": None,
+            "reason": "no graders configured",
+            "results": [],
+        }
+    failures = [item for item in grader_results if not item.passed]
+    return {
+        "passed": not failures,
+        "reason": (
+            f"all {len(grader_results)} graders passed"
+            if not failures
+            else f"{len(failures)} of {len(grader_results)} graders failed"
+        ),
+        "results": [item.to_mapping() for item in grader_results],
+    }
+
+
+def aggregate_pass_k(
+    records: Sequence[Mapping[str, object]],
+) -> list[dict[str, object]]:
+    """Aggregate trial grades using reliability semantics: all k must pass."""
+
+    grouped: dict[str, list[Mapping[str, object]]] = defaultdict(list)
+    for record in records:
+        task_id = record.get("task_id")
+        if not isinstance(task_id, str) or not task_id:
+            raise ValueError("trial record is missing task_id")
+        grouped[task_id].append(record)
+
+    summaries: list[dict[str, object]] = []
+    for task_id, task_records in grouped.items():
+        declared_trials = [record.get("trials") for record in task_records]
+        if any(
+            isinstance(value, bool) or not isinstance(value, int)
+            for value in declared_trials
+        ) or len(set(declared_trials)) != 1:
+            raise ValueError(f"task {task_id} has inconsistent trial counts")
+        expected_trials = declared_trials[0]
+        decisions = [
+            (
+                record.get("grade", {}).get("passed")
+                if isinstance(record.get("grade"), Mapping)
+                else None
+            )
+            for record in task_records
+        ]
+        passed_trials = sum(decision is True for decision in decisions)
+        summaries.append(
+            {
+                "task_id": task_id,
+                "trials": expected_trials,
+                "passed_trials": passed_trials,
+                "pass^k": (
+                    len(task_records) == expected_trials
+                    and passed_trials == expected_trials
+                ),
+            }
+        )
+    return summaries

--- a/infra/agent-image/eval/graders/__init__.py
+++ b/infra/agent-image/eval/graders/__init__.py
@@ -13,6 +13,11 @@ from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from numbers import Real
 
+try:
+    from ..broker_stub import ALLOWED_AGENT_BROKER_ROUTES
+except ImportError:
+    from broker_stub import ALLOWED_AGENT_BROKER_ROUTES
+
 
 SUPPORTED_GRADERS = frozenset(
     {
@@ -74,13 +79,22 @@ def _validate_route(spec: Mapping[str, object], grader: str) -> None:
         grader=grader,
         field="route",
     )
-    if not route.startswith("/api/agent/"):
+    if route not in ALLOWED_AGENT_BROKER_ROUTES:
         raise GraderConfigurationError(
-            f"{grader} grader route must start with /api/agent/"
+            f"{grader} grader route is not an allowed agent broker route: "
+            f"{route}"
         )
     method = spec.get("method")
     if method is not None:
-        _require_nonempty_string(method, grader=grader, field="method")
+        validated_method = _require_nonempty_string(
+            method,
+            grader=grader,
+            field="method",
+        )
+        if validated_method.upper() != "POST":
+            raise GraderConfigurationError(
+                f"{grader} grader method must be POST"
+            )
 
 
 def _validate_body_matchers(value: object) -> None:

--- a/infra/agent-image/eval/graders/__init__.py
+++ b/infra/agent-image/eval/graders/__init__.py
@@ -412,7 +412,7 @@ def _grade_tools_catalog(
 
 
 def _parse_tools_catalog_names(log_text: str) -> set[str]:
-    """Extract exact tool names from complete or length-truncated diagnostics."""
+    """Extract exact names from the compact catalog or legacy diagnostics."""
 
     observed: set[str] = set()
 
@@ -443,9 +443,9 @@ def _parse_tools_catalog_names(log_text: str) -> set[str]:
             continue
         except json.JSONDecodeError:
             pass
-        # harness_adapter.py intentionally caps this diagnostic at 1500
-        # characters. Extract only explicit JSON `name` fields when that cap
-        # cuts a catalog off mid-document.
+        # Older candidate images capped the complete catalog diagnostic at
+        # 1500 characters. Preserve best-effort compatibility with their
+        # explicit JSON `name` fields; current images log every name compactly.
         for match in re.finditer(
             r'"name"\s*:\s*("(?:\\.|[^"\\])*")',
             payload,

--- a/infra/agent-image/eval/runner.py
+++ b/infra/agent-image/eval/runner.py
@@ -14,10 +14,8 @@ import logging
 import math
 import os
 import re
-import shutil
 import subprocess
 import sys
-import tempfile
 import time
 import uuid
 from collections.abc import Callable, Mapping, Sequence
@@ -29,9 +27,10 @@ from typing import Protocol, TextIO
 if __package__:
     from .broker_stub import (
         ALLOWED_AGENT_BROKER_ROUTES,
-        CAPTURE_FILENAME,
         CONTROL_DIRECTORY_ENV,
-        TRIAL_CONFIG_FILENAME,
+        DEFAULT_CONTROL_DIRECTORY,
+        RUNNER_READ_CAPTURES_COMMAND,
+        RUNNER_WRITE_TRIAL_COMMAND,
     )
     from .graders import (
         GraderConfigurationError,
@@ -48,9 +47,10 @@ if __package__:
 else:
     from broker_stub import (
         ALLOWED_AGENT_BROKER_ROUTES,
-        CAPTURE_FILENAME,
         CONTROL_DIRECTORY_ENV,
-        TRIAL_CONFIG_FILENAME,
+        DEFAULT_CONTROL_DIRECTORY,
+        RUNNER_READ_CAPTURES_COMMAND,
+        RUNNER_WRITE_TRIAL_COMMAND,
     )
     from graders import (
         GraderConfigurationError,
@@ -96,6 +96,11 @@ REQUIRED_METADATA_FIELDS = frozenset(
         "session_id",
     }
 )
+BROKER_CONTROL_TMPFS_OPTIONS = (
+    f"{DEFAULT_CONTROL_DIRECTORY}:"
+    "rw,noexec,nosuid,nodev,size=268435456,mode=0700,uid=0,gid=0"
+)
+BROKER_STUB_CONTAINER_PATH = "/app/mantle_proxy.py"
 
 
 class EvalRunnerError(RuntimeError):
@@ -405,70 +410,21 @@ def _load_fixture_files(paths: Sequence[Path]) -> list[dict[str, object]]:
     return fixtures
 
 
-def _open_owner_only(path: Path, flags: int) -> int:
-    descriptor = os.open(
-        path,
-        flags | getattr(os, "O_NOFOLLOW", 0),
-        0o600,
-    )
-    os.fchmod(descriptor, 0o600)
-    return descriptor
+def _parse_captures(serialized: str) -> tuple[Mapping[str, object], ...]:
+    """Validate captures copied from the root-only in-container control tmpfs."""
 
-
-def _write_trial_configuration(
-    control_directory: Path,
-    value: Mapping[str, object],
-) -> None:
-    temporary_path = control_directory / (
-        f".{TRIAL_CONFIG_FILENAME}.{uuid.uuid4().hex}.tmp"
-    )
-    descriptor = _open_owner_only(
-        temporary_path,
-        os.O_WRONLY | os.O_CREAT | os.O_EXCL,
-    )
-    try:
-        with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
-            json.dump(value, handle, separators=(",", ":"))
-            handle.flush()
-            os.fsync(handle.fileno())
-        os.replace(temporary_path, control_directory / TRIAL_CONFIG_FILENAME)
-    except Exception:
-        try:
-            temporary_path.unlink()
-        except OSError:
-            pass
-        raise
-
-
-def _reset_capture(control_directory: Path) -> None:
-    descriptor = _open_owner_only(
-        control_directory / CAPTURE_FILENAME,
-        os.O_WRONLY | os.O_CREAT | os.O_TRUNC,
-    )
-    os.close(descriptor)
-
-
-def _read_captures(control_directory: Path) -> tuple[Mapping[str, object], ...]:
-    path = control_directory / CAPTURE_FILENAME
-    try:
-        lines = path.read_text(encoding="utf-8").splitlines()
-    except FileNotFoundError:
-        return ()
-    except OSError as error:
-        raise EvalRunnerError(
-            f"could not read broker capture {path}: {error}"
-        ) from error
+    lines = serialized.splitlines()
     captures: list[Mapping[str, object]] = []
     for line_number, line in enumerate(lines, start=1):
         try:
             record = json.loads(line)
         except json.JSONDecodeError as error:
             raise EvalRunnerError(
-                f"broker capture {path}:{line_number} is malformed"
+                f"broker capture line {line_number} is malformed"
             ) from error
         if not isinstance(record, Mapping):
             raise EvalRunnerError(
-                f"broker capture {path}:{line_number} is not an object"
+                f"broker capture line {line_number} is not an object"
             )
         captures.append(record)
     return tuple(captures)
@@ -510,7 +466,6 @@ class DockerRuntime:
         self._now = now or (lambda: datetime.now(timezone.utc))
         self._container_id: str | None = None
         self._active_credentials: AwsCredentials | None = None
-        self._broker_control_directory: Path | None = None
         self._trial_log_since: datetime | None = None
         self._capture_tools_catalog = False
         self._trial_active = False
@@ -596,14 +551,6 @@ class DockerRuntime:
                 or not self._broker_stub_path.is_file()
             ):
                 raise EvalRunnerError("eval broker stub source is unavailable")
-            if self._broker_control_directory is not None:
-                raise EvalRunnerError("eval broker control directory was not cleaned")
-            self._broker_control_directory = Path(
-                tempfile.mkdtemp(
-                    prefix=f"issue-1424-broker-{os.getpid()}-",
-                )
-            )
-            os.chmod(self._broker_control_directory, 0o700)
         arguments = [
             "docker",
             "run",
@@ -614,22 +561,16 @@ class DockerRuntime:
             self._name,
         ]
         if self._use_broker_stub:
-            if self._broker_control_directory is None:
-                raise EvalRunnerError("eval broker control directory was not created")
             arguments.extend(
                 [
                     "--mount",
                     (
                         "type=bind,"
                         f"src={self._broker_stub_path.resolve()},"
-                        "dst=/app/mantle_proxy.py,readonly"
+                        f"dst={BROKER_STUB_CONTAINER_PATH},readonly"
                     ),
-                    "--mount",
-                    (
-                        "type=bind,"
-                        f"src={self._broker_control_directory.resolve()},"
-                        "dst=/run/psd-agent-eval-broker"
-                    ),
+                    "--tmpfs",
+                    BROKER_CONTROL_TMPFS_OPTIONS,
                 ]
             )
         environment_values = {
@@ -637,9 +578,7 @@ class DockerRuntime:
             **self._active_credentials.environment,
         }
         if self._use_broker_stub:
-            environment_values[CONTROL_DIRECTORY_ENV] = (
-                "/run/psd-agent-eval-broker"
-            )
+            environment_values[CONTROL_DIRECTORY_ENV] = DEFAULT_CONTROL_DIRECTORY
         for key, value in sorted(environment_values.items()):
             arguments.extend(["-e", f"{key}={value}"])
         arguments.append(self._image)
@@ -775,6 +714,40 @@ class DockerRuntime:
         except ProbeProtocolError as error:
             raise EvalRunnerError(f"invalid invocation response: {error}") from error
 
+    def _write_broker_trial(self, value: Mapping[str, object]) -> None:
+        serialized = json.dumps(value, separators=(",", ":"))
+        self._executor.run(
+            [
+                "docker",
+                "exec",
+                "--user",
+                "0:0",
+                "--interactive",
+                self.container_id,
+                "python3",
+                BROKER_STUB_CONTAINER_PATH,
+                RUNNER_WRITE_TRIAL_COMMAND,
+            ],
+            input_text=serialized,
+            timeout=60,
+        )
+
+    def _read_broker_captures(self) -> tuple[Mapping[str, object], ...]:
+        result = self._executor.run(
+            [
+                "docker",
+                "exec",
+                "--user",
+                "0:0",
+                self.container_id,
+                "python3",
+                BROKER_STUB_CONTAINER_PATH,
+                RUNNER_READ_CAPTURES_COMMAND,
+            ],
+            timeout=60,
+        )
+        return _parse_captures(result.stdout)
+
     def begin_trial(
         self,
         task: Task,
@@ -792,12 +765,8 @@ class DockerRuntime:
                 raise EvalRunnerError("L1 task started without the eval broker stub")
             self._trial_active = True
             return
-        if self._broker_control_directory is None:
-            raise EvalRunnerError("eval broker control directory is unavailable")
         fixtures = _load_fixture_files(task.fixture_paths)
-        _reset_capture(self._broker_control_directory)
-        _write_trial_configuration(
-            self._broker_control_directory,
+        self._write_broker_trial(
             {
                 "task_id": task.id,
                 "trial_id": f"{task.id}:{trial_number}:{session_id}",
@@ -812,18 +781,7 @@ class DockerRuntime:
         try:
             captures: tuple[Mapping[str, object], ...] = ()
             if self._use_broker_stub:
-                if self._broker_control_directory is None:
-                    raise EvalRunnerError(
-                        "eval broker control directory is unavailable"
-                    )
-                captures = _read_captures(self._broker_control_directory)
-                try:
-                    (
-                        self._broker_control_directory
-                        / TRIAL_CONFIG_FILENAME
-                    ).unlink()
-                except FileNotFoundError:
-                    pass
+                captures = self._read_broker_captures()
             broker_errors = tuple(
                 str(capture["stub_error"])
                 for capture in captures
@@ -891,17 +849,6 @@ class DockerRuntime:
                     "failed to remove candidate container %s: %s",
                     container_id,
                     detail[-500:] or f"docker rm exited {result.returncode}",
-                )
-        if self._broker_control_directory is not None and removed:
-            control_directory = self._broker_control_directory
-            self._broker_control_directory = None
-            try:
-                shutil.rmtree(control_directory)
-            except OSError as error:
-                LOGGER.warning(
-                    "failed to remove eval broker control directory %s: %s",
-                    control_directory,
-                    error,
                 )
         self._trial_active = False
         self._trial_log_since = None

--- a/infra/agent-image/eval/runner.py
+++ b/infra/agent-image/eval/runner.py
@@ -3,7 +3,7 @@
 
 Example:
     python3 runner.py --image <tag-or-digest> --suite suites/core.yaml \
-        --trials 3 --out /tmp/issue-1422-run.jsonl
+        --trials 3 --out /tmp/issue-1424-run.jsonl
 """
 
 from __future__ import annotations
@@ -14,8 +14,10 @@ import logging
 import math
 import os
 import re
+import shutil
 import subprocess
 import sys
+import tempfile
 import time
 import uuid
 from collections.abc import Callable, Mapping, Sequence
@@ -25,12 +27,38 @@ from pathlib import Path
 from typing import Protocol, TextIO
 
 if __package__:
+    from .broker_stub import (
+        ALLOWED_AGENT_BROKER_ROUTES,
+        CAPTURE_FILENAME,
+        CONTROL_DIRECTORY_ENV,
+        TRIAL_CONFIG_FILENAME,
+    )
+    from .graders import (
+        GraderConfigurationError,
+        TrialArtifacts,
+        aggregate_pass_k,
+        grade_trial,
+        validate_grader_specs,
+    )
     from .probe import (
         ProbeProtocolError,
         build_invocation_payload,
         extract_last_result_event,
     )
 else:
+    from broker_stub import (
+        ALLOWED_AGENT_BROKER_ROUTES,
+        CAPTURE_FILENAME,
+        CONTROL_DIRECTORY_ENV,
+        TRIAL_CONFIG_FILENAME,
+    )
+    from graders import (
+        GraderConfigurationError,
+        TrialArtifacts,
+        aggregate_pass_k,
+        grade_trial,
+        validate_grader_specs,
+    )
     from probe import (
         ProbeProtocolError,
         build_invocation_payload,
@@ -82,6 +110,8 @@ class Task:
     workspace: str
     prompt: str
     trials: int
+    fixture_paths: tuple[Path, ...] = ()
+    graders: tuple[dict[str, object], ...] = ()
 
 
 @dataclass(frozen=True)
@@ -180,9 +210,20 @@ class Runtime(Protocol):
     def stop(self) -> None:
         """Remove only this runner-owned container."""
 
+    def begin_trial(
+        self,
+        task: Task,
+        trial_number: int,
+        session_id: str,
+    ) -> None:
+        """Install fixture/capture state immediately before invocation."""
+
+    def end_trial(self) -> TrialArtifacts:
+        """Collect the active trial's broker requests and diagnostic artifacts."""
+
 
 class RuntimeFactory(Protocol):
-    def create(self) -> Runtime:
+    def create(self, task: Task) -> Runtime:
         """Create an unstarted, independently owned runtime."""
 
 
@@ -287,6 +328,147 @@ class ProbeContextMinter:
         return authority
 
 
+def _load_fixture_files(paths: Sequence[Path]) -> list[dict[str, object]]:
+    """Load and validate JSON fixtures before exposing them to the container."""
+
+    fixtures: list[dict[str, object]] = []
+    allowed_fields = {"route", "method", "request_body", "response"}
+    for path in paths:
+        try:
+            document = json.loads(path.read_text(encoding="utf-8"))
+        except OSError as error:
+            raise EvalRunnerError(
+                f"could not read fixture file {path}: {error}"
+            ) from error
+        except json.JSONDecodeError as error:
+            raise EvalRunnerError(f"fixture file {path} is not valid JSON") from error
+        if isinstance(document, Mapping):
+            entries = document.get("fixtures")
+        else:
+            entries = document
+        if not isinstance(entries, list):
+            raise EvalRunnerError(
+                f"{path}: fixture file must be a list or contain a fixtures list"
+            )
+        for index, entry in enumerate(entries, start=1):
+            if not isinstance(entry, Mapping):
+                raise EvalRunnerError(f"{path}: fixture {index} must be an object")
+            unknown = sorted(set(entry).difference(allowed_fields))
+            if unknown:
+                raise EvalRunnerError(
+                    f"{path}: fixture {index} has unsupported fields: "
+                    + ", ".join(unknown)
+                )
+            route = entry.get("route")
+            if not isinstance(route, str) or route not in ALLOWED_AGENT_BROKER_ROUTES:
+                raise EvalRunnerError(
+                    f"{path}: fixture {index} route is not in the "
+                    "agent-broker allowlist"
+                )
+            method = entry.get("method", "POST")
+            if not isinstance(method, str) or not method:
+                raise EvalRunnerError(
+                    f"{path}: fixture {index} method must be a non-empty string"
+                )
+            response = entry.get("response", {})
+            if not isinstance(response, Mapping):
+                raise EvalRunnerError(
+                    f"{path}: fixture {index} response must be an object"
+                )
+            response_unknown = sorted(
+                set(response).difference({"status", "body"})
+            )
+            if response_unknown:
+                raise EvalRunnerError(
+                    f"{path}: fixture {index} response has unsupported fields: "
+                    + ", ".join(response_unknown)
+                )
+            status = response.get("status", 200)
+            if (
+                isinstance(status, bool)
+                or not isinstance(status, int)
+                or status < 100
+                or status > 599
+            ):
+                raise EvalRunnerError(
+                    f"{path}: fixture {index} response status must be 100-599"
+                )
+            normalized = dict(entry)
+            normalized["method"] = method.upper()
+            normalized["response"] = dict(response)
+            fixtures.append(normalized)
+    return fixtures
+
+
+def _open_owner_only(path: Path, flags: int) -> int:
+    descriptor = os.open(
+        path,
+        flags | getattr(os, "O_NOFOLLOW", 0),
+        0o600,
+    )
+    os.fchmod(descriptor, 0o600)
+    return descriptor
+
+
+def _write_trial_configuration(
+    control_directory: Path,
+    value: Mapping[str, object],
+) -> None:
+    temporary_path = control_directory / (
+        f".{TRIAL_CONFIG_FILENAME}.{uuid.uuid4().hex}.tmp"
+    )
+    descriptor = _open_owner_only(
+        temporary_path,
+        os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+    )
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+            json.dump(value, handle, separators=(",", ":"))
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary_path, control_directory / TRIAL_CONFIG_FILENAME)
+    except Exception:
+        try:
+            temporary_path.unlink()
+        except OSError:
+            pass
+        raise
+
+
+def _reset_capture(control_directory: Path) -> None:
+    descriptor = _open_owner_only(
+        control_directory / CAPTURE_FILENAME,
+        os.O_WRONLY | os.O_CREAT | os.O_TRUNC,
+    )
+    os.close(descriptor)
+
+
+def _read_captures(control_directory: Path) -> tuple[Mapping[str, object], ...]:
+    path = control_directory / CAPTURE_FILENAME
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except FileNotFoundError:
+        return ()
+    except OSError as error:
+        raise EvalRunnerError(
+            f"could not read broker capture {path}: {error}"
+        ) from error
+    captures: list[Mapping[str, object]] = []
+    for line_number, line in enumerate(lines, start=1):
+        try:
+            record = json.loads(line)
+        except json.JSONDecodeError as error:
+            raise EvalRunnerError(
+                f"broker capture {path}:{line_number} is malformed"
+            ) from error
+        if not isinstance(record, Mapping):
+            raise EvalRunnerError(
+                f"broker capture {path}:{line_number} is not an object"
+            )
+        captures.append(record)
+    return tuple(captures)
+
+
 class DockerRuntime:
     def __init__(
         self,
@@ -300,6 +482,8 @@ class DockerRuntime:
         invocation_timeout_seconds: int,
         poll_interval_seconds: float,
         name_prefix: str,
+        broker_stub_path: Path | None = None,
+        use_broker_stub: bool = False,
         monotonic: Callable[[], float] = time.monotonic,
         sleep: Callable[[float], None] = time.sleep,
         now: Callable[[], datetime] | None = None,
@@ -313,12 +497,18 @@ class DockerRuntime:
         self._invocation_timeout_seconds = invocation_timeout_seconds
         self._poll_interval_seconds = poll_interval_seconds
         self._name_prefix = name_prefix
+        self._broker_stub_path = broker_stub_path
+        self._use_broker_stub = use_broker_stub
         self._name = self._new_name()
         self._monotonic = monotonic
         self._sleep = sleep
         self._now = now or (lambda: datetime.now(timezone.utc))
         self._container_id: str | None = None
         self._active_credentials: AwsCredentials | None = None
+        self._broker_control_directory: Path | None = None
+        self._trial_log_since: datetime | None = None
+        self._capture_tools_catalog = False
+        self._trial_active = False
 
     def _new_name(self) -> str:
         return f"{self._name_prefix}-{uuid.uuid4().hex[:10]}"
@@ -395,6 +585,20 @@ class DockerRuntime:
             raise EvalRunnerError("container was already started")
         if self._active_credentials is None:
             raise EvalRunnerError("AWS credentials were not prepared")
+        if self._use_broker_stub:
+            if (
+                self._broker_stub_path is None
+                or not self._broker_stub_path.is_file()
+            ):
+                raise EvalRunnerError("eval broker stub source is unavailable")
+            if self._broker_control_directory is not None:
+                raise EvalRunnerError("eval broker control directory was not cleaned")
+            self._broker_control_directory = Path(
+                tempfile.mkdtemp(
+                    prefix=f"issue-1424-broker-{os.getpid()}-",
+                )
+            )
+            os.chmod(self._broker_control_directory, 0o700)
         arguments = [
             "docker",
             "run",
@@ -404,10 +608,33 @@ class DockerRuntime:
             "--name",
             self._name,
         ]
+        if self._use_broker_stub:
+            if self._broker_control_directory is None:
+                raise EvalRunnerError("eval broker control directory was not created")
+            arguments.extend(
+                [
+                    "--mount",
+                    (
+                        "type=bind,"
+                        f"src={self._broker_stub_path.resolve()},"
+                        "dst=/app/mantle_proxy.py,readonly"
+                    ),
+                    "--mount",
+                    (
+                        "type=bind,"
+                        f"src={self._broker_control_directory.resolve()},"
+                        "dst=/run/psd-agent-eval-broker"
+                    ),
+                ]
+            )
         environment_values = {
             **self._environment_values,
             **self._active_credentials.environment,
         }
+        if self._use_broker_stub:
+            environment_values[CONTROL_DIRECTORY_ENV] = (
+                "/run/psd-agent-eval-broker"
+            )
         for key, value in sorted(environment_values.items()):
             arguments.extend(["-e", f"{key}={value}"])
         arguments.append(self._image)
@@ -490,7 +717,9 @@ class DockerRuntime:
                     remaining_seconds,
                 )
             )
-        raise EvalRunnerError("container logged BOOT_OK but listener never became ready")
+        raise EvalRunnerError(
+            "container logged BOOT_OK but listener never became ready"
+        )
 
     def invoke(
         self,
@@ -541,6 +770,92 @@ class DockerRuntime:
         except ProbeProtocolError as error:
             raise EvalRunnerError(f"invalid invocation response: {error}") from error
 
+    def begin_trial(
+        self,
+        task: Task,
+        trial_number: int,
+        session_id: str,
+    ) -> None:
+        if self._trial_active:
+            raise EvalRunnerError("a broker capture trial is already active")
+        self._trial_log_since = self._now()
+        self._capture_tools_catalog = any(
+            spec.get("type") == "tools_catalog" for spec in task.graders
+        )
+        if not self._use_broker_stub:
+            if task.level == "L1":
+                raise EvalRunnerError("L1 task started without the eval broker stub")
+            self._trial_active = True
+            return
+        if self._broker_control_directory is None:
+            raise EvalRunnerError("eval broker control directory is unavailable")
+        fixtures = _load_fixture_files(task.fixture_paths)
+        _reset_capture(self._broker_control_directory)
+        _write_trial_configuration(
+            self._broker_control_directory,
+            {
+                "task_id": task.id,
+                "trial_id": f"{task.id}:{trial_number}:{session_id}",
+                "fixtures": fixtures,
+            },
+        )
+        self._trial_active = True
+
+    def end_trial(self) -> TrialArtifacts:
+        if not self._trial_active:
+            raise EvalRunnerError("no broker capture trial is active")
+        try:
+            captures: tuple[Mapping[str, object], ...] = ()
+            if self._use_broker_stub:
+                if self._broker_control_directory is None:
+                    raise EvalRunnerError(
+                        "eval broker control directory is unavailable"
+                    )
+                captures = _read_captures(self._broker_control_directory)
+                try:
+                    (
+                        self._broker_control_directory
+                        / TRIAL_CONFIG_FILENAME
+                    ).unlink()
+                except FileNotFoundError:
+                    pass
+            broker_errors = tuple(
+                str(capture["stub_error"])
+                for capture in captures
+                if capture.get("stub_error")
+            )
+            catalog_log = ""
+            if (
+                self._capture_tools_catalog
+                and self._trial_log_since is not None
+                and self._container_id is not None
+            ):
+                logs = self._executor.run(
+                    [
+                        "docker",
+                        "logs",
+                        "--since",
+                        self._trial_log_since.isoformat(),
+                        self.container_id,
+                    ],
+                    check=False,
+                    timeout=15,
+                )
+                catalog_log = "\n".join(
+                    line
+                    for line in f"{logs.stdout}\n{logs.stderr}".splitlines()
+                    if "tools.catalog " in line
+                )
+            return TrialArtifacts(
+                broker_requests=captures,
+                broker_errors=broker_errors,
+                tools_catalog_log=catalog_log,
+            )
+        finally:
+            self._trial_active = False
+            self._trial_log_since = None
+            self._capture_tools_catalog = False
+
     def _log_tail(self) -> None:
         if self._container_id is None:
             return
@@ -554,22 +869,38 @@ class DockerRuntime:
             LOGGER.error("candidate container log tail:\n%s", detail)
 
     def stop(self) -> None:
-        if self._container_id is None:
-            return
-        container_id = self._container_id
-        self._container_id = None
-        result = self._executor.run(
-            ["docker", "rm", "-f", container_id],
-            check=False,
-            timeout=30,
-        )
-        if result.returncode != 0:
-            detail = (result.stderr or result.stdout).strip()
-            LOGGER.warning(
-                "failed to remove candidate container %s: %s",
-                container_id,
-                detail[-500:] or f"docker rm exited {result.returncode}",
+        removed = True
+        if self._container_id is not None:
+            container_id = self._container_id
+            result = self._executor.run(
+                ["docker", "rm", "-f", container_id],
+                check=False,
+                timeout=30,
             )
+            removed = result.returncode == 0
+            if removed:
+                self._container_id = None
+            else:
+                detail = (result.stderr or result.stdout).strip()
+                LOGGER.warning(
+                    "failed to remove candidate container %s: %s",
+                    container_id,
+                    detail[-500:] or f"docker rm exited {result.returncode}",
+                )
+        if self._broker_control_directory is not None and removed:
+            control_directory = self._broker_control_directory
+            self._broker_control_directory = None
+            try:
+                shutil.rmtree(control_directory)
+            except OSError as error:
+                LOGGER.warning(
+                    "failed to remove eval broker control directory %s: %s",
+                    control_directory,
+                    error,
+                )
+        self._trial_active = False
+        self._trial_log_since = None
+        self._capture_tools_catalog = False
 
 
 class DockerRuntimeFactory:
@@ -585,6 +916,7 @@ class DockerRuntimeFactory:
         invocation_timeout_seconds: int,
         poll_interval_seconds: float,
         name_prefix: str,
+        broker_stub_path: Path,
     ) -> None:
         self._executor = executor
         self._image = image
@@ -595,8 +927,9 @@ class DockerRuntimeFactory:
         self._invocation_timeout_seconds = invocation_timeout_seconds
         self._poll_interval_seconds = poll_interval_seconds
         self._name_prefix = name_prefix
+        self._broker_stub_path = broker_stub_path
 
-    def create(self) -> DockerRuntime:
+    def create(self, task: Task) -> DockerRuntime:
         return DockerRuntime(
             self._executor,
             self._image,
@@ -607,6 +940,8 @@ class DockerRuntimeFactory:
             invocation_timeout_seconds=self._invocation_timeout_seconds,
             poll_interval_seconds=self._poll_interval_seconds,
             name_prefix=self._name_prefix,
+            broker_stub_path=self._broker_stub_path,
+            use_broker_stub=task.level == "L1",
         )
 
 
@@ -634,7 +969,7 @@ class EvaluationRunner:
         trials_override: int | None = None,
     ) -> list[dict[str, object]]:
         records: list[dict[str, object]] = []
-        pure_runtime: Runtime | None = None
+        pure_runtimes: dict[str, Runtime] = {}
         try:
             for task in tasks:
                 trial_count = (
@@ -644,12 +979,15 @@ class EvaluationRunner:
                     raise EvalRunnerError("trial count must be positive")
                 for trial_number in range(1, trial_count + 1):
                     owns_runtime = task.workspace == "mutating"
+                    runtime_mode = "stubbed" if task.level == "L1" else "live"
                     if owns_runtime:
-                        runtime = self._runtime_factory.create()
+                        runtime = self._runtime_factory.create(task)
                     else:
-                        if pure_runtime is None:
-                            pure_runtime = self._runtime_factory.create()
-                        runtime = pure_runtime
+                        if runtime_mode not in pure_runtimes:
+                            pure_runtimes[runtime_mode] = (
+                                self._runtime_factory.create(task)
+                            )
+                        runtime = pure_runtimes[runtime_mode]
                     try:
                         # Re-resolve the active credential chain before every
                         # trial. Pure runtimes remain shared while credentials
@@ -676,13 +1014,18 @@ class EvaluationRunner:
                                 "runtime kept restarting while invocation "
                                 "authority was minted"
                             )
-                        event = runtime.invoke(task, session_id, authority)
+                        runtime.begin_trial(task, trial_number, session_id)
+                        try:
+                            event = runtime.invoke(task, session_id, authority)
+                        finally:
+                            artifacts = runtime.end_trial()
                         record = self._make_record(
                             task,
                             trial_number,
                             trial_count,
                             session_id,
                             event,
+                            artifacts,
                         )
                         output.write(json.dumps(record, separators=(",", ":")) + "\n")
                         output.flush()
@@ -691,8 +1034,8 @@ class EvaluationRunner:
                         if owns_runtime:
                             runtime.stop()
         finally:
-            if pure_runtime is not None:
-                pure_runtime.stop()
+            for runtime in pure_runtimes.values():
+                runtime.stop()
         return records
 
     def _make_record(
@@ -702,6 +1045,7 @@ class EvaluationRunner:
         trial_count: int,
         session_id: str,
         event: Mapping[str, object],
+        artifacts: TrialArtifacts,
     ) -> dict[str, object]:
         result = event.get("result")
         metadata = event.get("metadata")
@@ -726,6 +1070,12 @@ class EvaluationRunner:
                 f"task {task.id} trial {trial_number} hit runner isolation error "
                 f"{error_class}"
             )
+        grade = grade_trial(
+            task.graders,
+            result="" if result is None else str(result),
+            metadata=metadata,
+            artifacts=artifacts,
+        )
         return {
             "task_id": task.id,
             "image": self._image,
@@ -740,6 +1090,8 @@ class EvaluationRunner:
             # Preserve the complete final-event metadata object. Later grader
             # issues can consume new telemetry without changing this runner.
             "metadata": metadata,
+            "broker_requests": list(artifacts.broker_requests),
+            "grade": grade,
             "recorded_at": self._now().isoformat(),
         }
 
@@ -790,22 +1142,25 @@ def _load_document(path: Path) -> object:
     try:
         text = path.read_text(encoding="utf-8")
     except OSError as error:
-        raise EvalRunnerError(f"could not read suite/task file {path}: {error}") from error
+        raise EvalRunnerError(
+            f"could not read suite/task file {path}: {error}"
+        ) from error
     try:
         return json.loads(text)
     except json.JSONDecodeError:
         pass
 
-    # Issue #1422's task contract is intentionally flat. Supporting that small
-    # YAML subset here keeps the runner dependency-free; nested grader YAML is
-    # introduced by #1424 and can extend the loader with its schema.
+    # The task contract stays dependency-free: grader objects use inline
+    # JSON-compatible mappings inside top-level YAML lists.
     document: dict[str, object] = {}
     active_list: list[object] | None = None
     for line_number, raw_line in enumerate(text.splitlines(), start=1):
         if not raw_line.strip() or raw_line.lstrip().startswith("#"):
             continue
         if "\t" in raw_line[: len(raw_line) - len(raw_line.lstrip())]:
-            raise EvalRunnerError(f"{path}:{line_number}: tabs are not valid indentation")
+            raise EvalRunnerError(
+                f"{path}:{line_number}: tabs are not valid indentation"
+            )
         indent = len(raw_line) - len(raw_line.lstrip())
         content = raw_line.strip()
         if indent == 0:
@@ -840,6 +1195,31 @@ def _task_from_mapping(value: Mapping[str, object], source: Path) -> Task:
     raw_trials = value.get("trials", 3)
     if isinstance(raw_trials, bool) or not isinstance(raw_trials, int):
         raise EvalRunnerError(f"{source}: task trials must be an integer")
+    raw_fixture_paths = value.get("fixtures", [])
+    if (
+        not isinstance(raw_fixture_paths, list)
+        or any(not isinstance(path, str) or not path for path in raw_fixture_paths)
+    ):
+        raise EvalRunnerError(f"{source}: task fixtures must be a string list")
+    fixture_paths: list[Path] = []
+    for raw_path in raw_fixture_paths:
+        candidate = Path(raw_path)
+        if candidate.is_absolute():
+            raise EvalRunnerError(f"{source}: fixture paths must be relative")
+        resolved = (source.parent / candidate).resolve()
+        if not resolved.is_file():
+            raise EvalRunnerError(f"{source}: fixture file does not exist: {raw_path}")
+        fixture_paths.append(resolved)
+    raw_graders = value.get("graders", [])
+    if (
+        not isinstance(raw_graders, list)
+        or any(not isinstance(spec, Mapping) for spec in raw_graders)
+    ):
+        raise EvalRunnerError(f"{source}: task graders must be a mapping list")
+    try:
+        graders = validate_grader_specs(raw_graders)
+    except GraderConfigurationError as error:
+        raise EvalRunnerError(f"{source}: {error}") from error
     task = Task(
         id=text_fields["id"],
         skill=text_fields["skill"],
@@ -847,6 +1227,8 @@ def _task_from_mapping(value: Mapping[str, object], source: Path) -> Task:
         workspace=text_fields["workspace"],
         prompt=text_fields["prompt"],
         trials=raw_trials,
+        fixture_paths=tuple(fixture_paths),
+        graders=graders,
     )
     if not task.id or not re.fullmatch(r"[a-z0-9][a-z0-9-]*", task.id):
         raise EvalRunnerError(f"{source}: task id must be lowercase kebab-case")
@@ -858,6 +1240,8 @@ def _task_from_mapping(value: Mapping[str, object], source: Path) -> Task:
         raise EvalRunnerError(f"{source}: workspace must be pure or mutating")
     if task.trials < 1 or task.trials > 20:
         raise EvalRunnerError(f"{source}: trials must be between 1 and 20")
+    if task.level == "L1" and not task.graders:
+        raise EvalRunnerError(f"{source}: L1 tasks must configure at least one grader")
     return task
 
 
@@ -879,7 +1263,9 @@ def load_suite(path: Path) -> list[Task]:
                 tasks.append(_task_from_mapping(entry, path))
                 continue
             if not isinstance(entry, str):
-                raise EvalRunnerError(f"{path}: suite task entries must be paths or mappings")
+                raise EvalRunnerError(
+                    f"{path}: suite task entries must be paths or mappings"
+                )
             task_path = (path.parent / entry).resolve()
             task_document = _load_document(task_path)
             if not isinstance(task_document, dict):
@@ -1087,7 +1473,11 @@ def main(argv: list[str] | None = None) -> int:
             "BUILD_MARKER": f"eval:{args.image}",
         }
         credential_provider = ActiveAwsCredentialProvider(executor)
-        name_token = re.sub(r"[^a-z0-9-]", "-", f"issue-1422-{os.getpid()}".lower())
+        name_token = re.sub(
+            r"[^a-z0-9-]",
+            "-",
+            f"issue-1424-{os.getpid()}".lower(),
+        )
         runtime_factory = DockerRuntimeFactory(
             executor,
             args.image,
@@ -1098,6 +1488,11 @@ def main(argv: list[str] | None = None) -> int:
             invocation_timeout_seconds=args.invocation_timeout,
             poll_interval_seconds=args.poll_interval,
             name_prefix=f"psd-agent-eval-{name_token}",
+            broker_stub_path=repo_root
+            / "infra"
+            / "agent-image"
+            / "eval"
+            / "broker_stub.py",
         )
         minter = ProbeContextMinter(
             executor,
@@ -1115,6 +1510,21 @@ def main(argv: list[str] | None = None) -> int:
         args.out.parent.mkdir(parents=True, exist_ok=True)
         with _open_output(args.out, args.overwrite) as output:
             records = runner.run(tasks, output, trials_override=args.trials)
+        graded_records = [
+            record
+            for record in records
+            if isinstance(record.get("grade"), Mapping)
+            and isinstance(record["grade"].get("passed"), bool)
+        ]
+        for summary in aggregate_pass_k(graded_records):
+            LOGGER.info(
+                "task %s pass^%s=%s (%s/%s trials)",
+                summary["task_id"],
+                summary["trials"],
+                summary["pass^k"],
+                summary["passed_trials"],
+                summary["trials"],
+            )
         LOGGER.info("wrote %d trial records to %s", len(records), args.out)
         return 0
     except (EvalRunnerError, OSError) as error:

--- a/infra/agent-image/eval/runner.py
+++ b/infra/agent-image/eval/runner.py
@@ -400,11 +400,11 @@ def _load_fixture_files(paths: Sequence[Path]) -> list[dict[str, object]]:
             if (
                 isinstance(status, bool)
                 or not isinstance(status, int)
-                or status < 100
+                or status < 200
                 or status > 599
             ):
                 raise EvalRunnerError(
-                    f"{path}: fixture {index} response status must be 100-599"
+                    f"{path}: fixture {index} response status must be 200-599"
                 )
             normalized = dict(entry)
             normalized["method"] = "POST"
@@ -972,7 +972,16 @@ class EvaluationRunner:
                         runtime.begin_trial(task, trial_number, session_id)
                         try:
                             event = runtime.invoke(task, session_id, authority)
-                        finally:
+                        except BaseException as invocation_error:
+                            try:
+                                runtime.end_trial()
+                            except Exception as cleanup_error:
+                                invocation_error.add_note(
+                                    "trial artifact collection also failed: "
+                                    f"{cleanup_error}"
+                                )
+                            raise
+                        else:
                             artifacts = runtime.end_trial()
                         record = self._make_record(
                             task,

--- a/infra/agent-image/eval/runner.py
+++ b/infra/agent-image/eval/runner.py
@@ -96,6 +96,9 @@ REQUIRED_METADATA_FIELDS = frozenset(
         "session_id",
     }
 )
+BROKER_CAPTURE_GRADER_TYPES = frozenset(
+    {"broker_request", "no_route_called"}
+)
 BROKER_CONTROL_TMPFS_OPTIONS = (
     f"{DEFAULT_CONTROL_DIRECTORY}:"
     "rw,noexec,nosuid,nodev,size=268435456,mode=0700,uid=0,gid=0"
@@ -1192,6 +1195,20 @@ def _task_from_mapping(value: Mapping[str, object], source: Path) -> Task:
         raise EvalRunnerError(f"{source}: workspace must be pure or mutating")
     if task.trials < 1 or task.trials > 20:
         raise EvalRunnerError(f"{source}: trials must be between 1 and 20")
+    broker_graders = sorted(
+        {
+            str(spec["type"])
+            for spec in task.graders
+            if spec.get("type") in BROKER_CAPTURE_GRADER_TYPES
+        }
+    )
+    if task.level != "L1" and broker_graders:
+        raise EvalRunnerError(
+            f"{source}: broker graders require level L1: "
+            + ", ".join(broker_graders)
+        )
+    if task.level != "L1" and task.fixture_paths:
+        raise EvalRunnerError(f"{source}: fixtures require level L1")
     if task.level == "L1" and not task.graders:
         raise EvalRunnerError(f"{source}: L1 tasks must configure at least one grader")
     return task

--- a/infra/agent-image/eval/runner.py
+++ b/infra/agent-image/eval/runner.py
@@ -366,9 +366,14 @@ def _load_fixture_files(paths: Sequence[Path]) -> list[dict[str, object]]:
                     "agent-broker allowlist"
                 )
             method = entry.get("method", "POST")
-            if not isinstance(method, str) or not method:
+            if not isinstance(method, str) or method.upper() != "POST":
                 raise EvalRunnerError(
-                    f"{path}: fixture {index} method must be a non-empty string"
+                    f"{path}: fixture {index} method must be POST"
+                )
+            request_body = entry.get("request_body")
+            if request_body is not None and not isinstance(request_body, Mapping):
+                raise EvalRunnerError(
+                    f"{path}: fixture {index} request_body must be an object"
                 )
             response = entry.get("response", {})
             if not isinstance(response, Mapping):
@@ -394,7 +399,7 @@ def _load_fixture_files(paths: Sequence[Path]) -> list[dict[str, object]]:
                     f"{path}: fixture {index} response status must be 100-599"
                 )
             normalized = dict(entry)
-            normalized["method"] = method.upper()
+            normalized["method"] = "POST"
             normalized["response"] = dict(response)
             fixtures.append(normalized)
     return fixtures

--- a/infra/agent-image/harness_adapter.py
+++ b/infra/agent-image/harness_adapter.py
@@ -40,6 +40,35 @@ def _is_safe_path_component(value: str) -> bool:
     return bool(_SAFE_PATH_ID.match(value or "")) and value not in {".", ".."}
 
 
+def _catalog_tool_names(catalog: object) -> List[str]:
+    """Return every exact tool name from the gateway catalog, in source order."""
+
+    names: List[str] = []
+    seen: set[str] = set()
+
+    def collect(value: object) -> None:
+        if isinstance(value, dict):
+            name = value.get("name")
+            if isinstance(name, str) and name and name not in seen:
+                seen.add(name)
+                names.append(name)
+            for nested in value.values():
+                if isinstance(nested, (dict, list, tuple)):
+                    collect(nested)
+            return
+        if isinstance(value, (list, tuple)):
+            for nested in value:
+                if isinstance(nested, str):
+                    if nested and nested not in seen:
+                        seen.add(nested)
+                        names.append(nested)
+                else:
+                    collect(nested)
+
+    collect(catalog)
+    return names
+
+
 @dataclasses.dataclass
 class TurnResult:
     """Structured result of a single agent turn.
@@ -653,9 +682,13 @@ class OpenClawAdapter(HarnessAdapter):
                             if msg_c.get("ok"):
                                 payload = msg_c.get("payload", {})
                                 tools = payload.get("tools") or payload.get("grouped") or payload
+                                names = _catalog_tool_names(tools)
                                 logger.info(
                                     "tools.catalog ok: %s",
-                                    json.dumps(tools)[:1500],
+                                    json.dumps(
+                                        {"names": names},
+                                        separators=(",", ":"),
+                                    ),
                                 )
                             else:
                                 logger.warning(

--- a/infra/agent-image/harness_adapter.py
+++ b/infra/agent-image/harness_adapter.py
@@ -41,31 +41,35 @@ def _is_safe_path_component(value: str) -> bool:
 
 
 def _catalog_tool_names(catalog: object) -> List[str]:
-    """Return every exact tool name from the gateway catalog, in source order."""
+    """Return explicit catalog-entry names without traversing their schemas."""
 
     names: List[str] = []
     seen: set[str] = set()
 
-    def collect(value: object) -> None:
-        if isinstance(value, dict):
-            name = value.get("name")
-            if isinstance(name, str) and name and name not in seen:
-                seen.add(name)
-                names.append(name)
-            for nested in value.values():
-                if isinstance(nested, (dict, list, tuple)):
-                    collect(nested)
-            return
-        if isinstance(value, (list, tuple)):
-            for nested in value:
-                if isinstance(nested, str):
-                    if nested and nested not in seen:
-                        seen.add(nested)
-                        names.append(nested)
-                else:
-                    collect(nested)
+    entries: List[object] = []
+    if isinstance(catalog, (list, tuple)):
+        entries.extend(catalog)
+    elif isinstance(catalog, dict):
+        if isinstance(catalog.get("name"), str):
+            entries.append(catalog)
+        else:
+            for group in catalog.values():
+                if isinstance(group, (list, tuple)):
+                    entries.extend(group)
+                elif isinstance(group, dict):
+                    group_tools = group.get("tools")
+                    if isinstance(group_tools, (list, tuple)):
+                        entries.extend(group_tools)
+                    elif isinstance(group.get("name"), str):
+                        entries.append(group)
 
-    collect(catalog)
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        name = entry.get("name")
+        if isinstance(name, str) and name and name not in seen:
+            seen.add(name)
+            names.append(name)
     return names
 
 

--- a/infra/agent-image/test_broker_stub.py
+++ b/infra/agent-image/test_broker_stub.py
@@ -259,6 +259,62 @@ class BrokerStubHttpTests(unittest.TestCase):
         self.assertEqual(capture["body"], {"url": "https://example.com"})
         self.assertIn("EvalUnsupportedAgentRoute", capture["stub_error"])
 
+    def test_non_post_method_is_rejected_even_when_a_fixture_would_match(self):
+        self.stub.configure(
+            [
+                {
+                    "route": "/api/agent/directory-lookup",
+                    "method": "GET",
+                    "response": {"body": {"people": []}},
+                }
+            ]
+        )
+
+        status, response = self.stub.request(
+            "/agent-broker/api/agent/directory-lookup",
+            method="GET",
+        )
+
+        self.assertEqual(status, 404)
+        self.assertEqual(
+            response["error"],
+            broker_stub.UNSUPPORTED_METHOD_ERROR,
+        )
+        [capture] = self.stub.captures()
+        self.assertIn(
+            broker_stub.UNSUPPORTED_METHOD_ERROR,
+            capture["stub_error"],
+        )
+
+    def test_non_object_json_bodies_are_rejected_and_captured(self):
+        for body in ("not-an-object", ["Ada"]):
+            with self.subTest(body=body):
+                self.stub.configure(
+                    [
+                        {
+                            "route": "/api/agent/directory-lookup",
+                            "response": {"body": {"people": []}},
+                        }
+                    ]
+                )
+                status, response = self.stub.request(
+                    "/agent-broker/api/agent/directory-lookup",
+                    method="POST",
+                    body=body,
+                )
+
+                self.assertEqual(status, 400)
+                self.assertEqual(
+                    response["error"],
+                    broker_stub.INVALID_REQUEST_BODY_ERROR,
+                )
+                [capture] = self.stub.captures()
+                self.assertEqual(capture["body"], body)
+                self.assertIn(
+                    broker_stub.INVALID_REQUEST_BODY_ERROR,
+                    capture["stub_error"],
+                )
+
     def test_unavailable_trial_config_preserves_the_request_body_in_capture(self):
         self.stub.configure([])
         (

--- a/infra/agent-image/test_broker_stub.py
+++ b/infra/agent-image/test_broker_stub.py
@@ -547,6 +547,28 @@ class BrokerStubHttpTests(unittest.TestCase):
             capture["stub_error"],
         )
 
+    def test_standard_and_custom_http_methods_are_rejected_and_captured(self):
+        for method in ("OPTIONS", "BREW"):
+            with self.subTest(method=method):
+                self.stub.configure([])
+
+                status, response = self.stub.request(
+                    "/agent-broker/api/agent/directory-lookup",
+                    method=method,
+                )
+
+                self.assertEqual(status, 404)
+                self.assertEqual(
+                    response["error"],
+                    broker_stub.UNSUPPORTED_METHOD_ERROR,
+                )
+                [capture] = self.stub.captures()
+                self.assertEqual(capture["method"], method)
+                self.assertIn(
+                    broker_stub.UNSUPPORTED_METHOD_ERROR,
+                    capture["stub_error"],
+                )
+
     def test_non_object_json_bodies_are_rejected_and_captured(self):
         for body in ("not-an-object", ["Ada"]):
             with self.subTest(body=body):

--- a/infra/agent-image/test_broker_stub.py
+++ b/infra/agent-image/test_broker_stub.py
@@ -87,23 +87,24 @@ class RunningStub:
         return f"http://{host}:{port}"
 
     def configure(self, fixtures: list[dict[str, object]]) -> None:
-        path = self.control_directory / broker_stub.TRIAL_CONFIG_FILENAME
-        temporary = path.with_suffix(".tmp")
-        temporary.write_text(
-            json.dumps(
-                {
-                    "task_id": "stub-test",
-                    "trial_id": "stub-test:1:session",
-                    "fixtures": fixtures,
-                }
-            ),
-            encoding="utf-8",
+        serialized = json.dumps(
+            {
+                "task_id": "stub-test",
+                "trial_id": "stub-test:1:session",
+                "fixtures": fixtures,
+            }
+        ).encode("utf-8")
+        if self.server.state.finalization_state == "closed":
+            broker_stub.install_and_activate_trial(
+                self.control_directory,
+                serialized,
+                port=self.server.server_address[1],
+            )
+            return
+        broker_stub.install_trial_configuration(
+            self.control_directory,
+            serialized,
         )
-        os.chmod(temporary, 0o600)
-        os.replace(temporary, path)
-        capture = self.control_directory / broker_stub.CAPTURE_FILENAME
-        capture.write_text("", encoding="utf-8")
-        os.chmod(capture, 0o600)
 
     def request(
         self,
@@ -162,6 +163,29 @@ class BrokerRouteParityTests(unittest.TestCase):
 
 
 class BrokerControlStorageTests(unittest.TestCase):
+    def test_runner_control_token_survives_a_proxy_restart(self):
+        with tempfile.TemporaryDirectory(
+            prefix="issue-1424-control-test-"
+        ) as directory:
+            control_directory = Path(directory)
+            first = broker_stub._ensure_runner_control_token(
+                control_directory
+            )
+            second = broker_stub._ensure_runner_control_token(
+                control_directory
+            )
+
+            self.assertEqual(first, second)
+            self.assertEqual(len(first), 43)
+            self.assertEqual(
+                (
+                    control_directory
+                    / broker_stub.RUNNER_CONTROL_TOKEN_FILENAME
+                ).stat().st_mode
+                & 0o777,
+                0o600,
+            )
+
     def test_runner_commands_install_and_collect_owner_only_state(self):
         with tempfile.TemporaryDirectory(
             prefix="issue-1424-control-test-"
@@ -219,6 +243,28 @@ class BrokerStubHttpTests(unittest.TestCase):
 
     def tearDown(self) -> None:
         self.stub.close()
+
+    def test_runner_gate_rejects_an_untrusted_transition(self):
+        status, response = self.stub.request(
+            broker_stub.RUNNER_OPEN_TRIAL_PATH,
+            method="POST",
+            headers={broker_stub.RUNNER_CONTROL_HEADER: "not-the-token"},
+        )
+
+        self.assertEqual(status, 404)
+        self.assertEqual(response, {"error": "NotFound"})
+        self.assertEqual(
+            self.stub.server.state.finalization_state,
+            "closed",
+        )
+        self.assertEqual(
+            (
+                self.stub.control_directory
+                / broker_stub.RUNNER_CONTROL_TOKEN_FILENAME
+            ).stat().st_mode
+            & 0o777,
+            0o600,
+        )
 
     def test_replays_every_allowlisted_route_and_captures_each_request(self):
         fixtures = [
@@ -531,6 +577,36 @@ class BrokerStubHttpTests(unittest.TestCase):
             headers={"X-Agent-Workspace-Flush": self.stub.flush_token},
         )
         self.assertEqual((end_status, end), (200, {"finalizing": False}))
+        self.assertEqual(
+            self.stub.server.state.finalization_state,
+            "closed",
+        )
+        capture_count = len(self.stub.captures())
+
+        late_status, late = self.stub.request(
+            "/agent-broker/api/agent/directory-lookup",
+            method="POST",
+            body={"query": "Late"},
+        )
+        self.assertEqual(late_status, 503)
+        self.assertEqual(late["error"], broker_stub.FINALIZING_ERROR)
+        self.assertEqual(len(self.stub.captures()), capture_count)
+
+        self.stub.configure(
+            [
+                {
+                    "route": "/api/agent/directory-lookup",
+                    "response": {"body": {"people": ["new-trial"]}},
+                }
+            ]
+        )
+        next_status, next_response = self.stub.request(
+            "/agent-broker/api/agent/directory-lookup",
+            method="POST",
+            body={"query": "Next"},
+        )
+        self.assertEqual(next_status, 200)
+        self.assertEqual(next_response, {"people": ["new-trial"]})
 
 
 if __name__ == "__main__":

--- a/infra/agent-image/test_broker_stub.py
+++ b/infra/agent-image/test_broker_stub.py
@@ -8,6 +8,9 @@ Run:
 from __future__ import annotations
 
 import ast
+import base64
+import hashlib
+import hmac
 import json
 import os
 import re
@@ -18,6 +21,7 @@ import time
 import unittest
 import urllib.error
 import urllib.request
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 
 
@@ -61,7 +65,11 @@ def _javascript_allowlist(path: Path) -> set[str]:
 
 
 class RunningStub:
-    def __init__(self) -> None:
+    def __init__(
+        self,
+        *,
+        model_upstream_base_url: str = "http://127.0.0.1:9",
+    ) -> None:
         self.temporary_directory = tempfile.TemporaryDirectory(
             prefix="issue-1424-broker-test-"
         )
@@ -70,10 +78,29 @@ class RunningStub:
         self.flush_token_path = self.control_directory / "workspace-flush-token"
         self.flush_token_path.write_text(self.flush_token, encoding="ascii")
         os.chmod(self.flush_token_path, 0o600)
+        self.invocation_context = "signed-invocation-context"
+        self.invocation_context_path = (
+            self.control_directory / "invocation-context"
+        )
+        self.invocation_context_path.write_text(
+            self.invocation_context,
+            encoding="ascii",
+        )
+        self.request_proof_key = b"r" * 32
+        encoded_proof_key = base64.urlsafe_b64encode(
+            self.request_proof_key
+        ).rstrip(b"=")
+        self.request_proof_key_path = (
+            self.control_directory / "request-proof-key"
+        )
+        self.request_proof_key_path.write_bytes(encoded_proof_key)
         self.server = broker_stub.create_server(
             self.control_directory,
             port=0,
             workspace_flush_token_path=self.flush_token_path,
+            invocation_context_path=self.invocation_context_path,
+            request_proof_key_path=self.request_proof_key_path,
+            model_upstream_base_url=model_upstream_base_url,
         )
         self.thread = threading.Thread(
             target=self.server.serve_forever,
@@ -332,6 +359,133 @@ class BrokerStubHttpTests(unittest.TestCase):
             self.stub.control_directory / broker_stub.CAPTURE_FILENAME
         ).st_mode & 0o777
         self.assertEqual(mode, 0o600)
+
+    def test_summarization_endpoint_relays_with_root_authority(self):
+        received: dict[str, object] = {}
+
+        class ModelBrokerHandler(BaseHTTPRequestHandler):
+            def log_message(
+                self,
+                format_string: str,
+                *arguments: object,
+            ) -> None:
+                return
+
+            def do_POST(self) -> None:
+                length = int(self.headers.get("Content-Length", "0"))
+                raw_body = self.rfile.read(length)
+                received.update(
+                    {
+                        "path": self.path,
+                        "body": raw_body,
+                        "headers": dict(self.headers.items()),
+                    }
+                )
+                response = json.dumps(
+                    {
+                        "content": [
+                            {"type": "text", "text": "Safe summary"}
+                        ]
+                    }
+                ).encode("utf-8")
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(response)))
+                self.end_headers()
+                self.wfile.write(response)
+
+        upstream = ThreadingHTTPServer(("127.0.0.1", 0), ModelBrokerHandler)
+        upstream_thread = threading.Thread(
+            target=upstream.serve_forever,
+            daemon=True,
+        )
+        upstream_thread.start()
+        self.stub.close()
+        self.stub = RunningStub(
+            model_upstream_base_url=(
+                f"http://127.0.0.1:{upstream.server_address[1]}"
+            )
+        )
+        try:
+            self.stub.configure([])
+            status, response = self.stub.request(
+                broker_stub.MODEL_MESSAGES_PATH,
+                method="POST",
+                body={
+                    "model": "anthropic.claude-haiku-4-5",
+                    "messages": [{"role": "user", "content": "Summarize"}],
+                },
+            )
+        finally:
+            upstream.shutdown()
+            upstream.server_close()
+            upstream_thread.join(timeout=2)
+
+        self.assertEqual(status, 200)
+        self.assertEqual(
+            response,
+            {
+                "content": [
+                    {"type": "text", "text": "Safe summary"}
+                ]
+            },
+        )
+        self.assertEqual(received["path"], broker_stub.MODEL_PROXY_ROUTE)
+        raw_body = received["body"]
+        self.assertIsInstance(raw_body, bytes)
+        headers = {
+            key.lower(): value
+            for key, value in received["headers"].items()
+        }
+        self.assertEqual(
+            headers["x-agent-invocation-context"],
+            self.stub.invocation_context,
+        )
+        self.assertEqual(
+            headers["x-agent-request-proof-body-sha256"],
+            hashlib.sha256(raw_body).hexdigest(),
+        )
+        canonical = "\n".join(
+            [
+                "v1",
+                headers["x-agent-request-proof-timestamp"],
+                headers["x-agent-request-proof-nonce"],
+                "POST",
+                broker_stub.MODEL_PROXY_ROUTE,
+                headers["x-agent-request-proof-body-sha256"],
+            ]
+        ).encode("utf-8")
+        expected_signature = base64.urlsafe_b64encode(
+            hmac.new(
+                self.stub.request_proof_key,
+                canonical,
+                hashlib.sha256,
+            ).digest()
+        ).rstrip(b"=").decode("ascii")
+        self.assertEqual(
+            headers["x-agent-request-proof-signature"],
+            expected_signature,
+        )
+        self.assertEqual(self.stub.captures(), [])
+
+    def test_informational_fixture_status_is_rejected(self):
+        self.stub.configure(
+            [
+                {
+                    "route": "/api/agent/directory-lookup",
+                    "response": {"status": 199, "body": {}},
+                }
+            ]
+        )
+
+        status, response = self.stub.request(
+            "/agent-broker/api/agent/directory-lookup",
+            method="POST",
+            body={"query": "Ada"},
+        )
+
+        self.assertEqual(status, 500)
+        self.assertIn("status", response["message"])
 
     def test_missing_fixture_is_loud_and_named_in_response_and_capture(self):
         self.stub.configure([])

--- a/infra/agent-image/test_broker_stub.py
+++ b/infra/agent-image/test_broker_stub.py
@@ -1,0 +1,306 @@
+"""Hermetic tests for the issue #1424 in-container broker stub.
+
+Run:
+    uv run --python 3.12 --no-project -m unittest \
+      infra/agent-image/test_broker_stub.py
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+import os
+import re
+import sys
+import tempfile
+import threading
+import unittest
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+
+AGENT_IMAGE_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(AGENT_IMAGE_DIR / "eval"))
+
+import broker_stub  # noqa: E402
+
+
+def _python_allowlist(path: Path, variable: str) -> set[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    for node in tree.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        if not any(
+            isinstance(target, ast.Name) and target.id == variable
+            for target in node.targets
+        ):
+            continue
+        value = node.value
+        if (
+            isinstance(value, ast.Call)
+            and isinstance(value.func, ast.Name)
+            and value.func.id == "frozenset"
+            and len(value.args) == 1
+        ):
+            return set(ast.literal_eval(value.args[0]))
+    raise AssertionError(f"{variable} was not found in {path}")
+
+
+def _javascript_allowlist(path: Path) -> set[str]:
+    source = path.read_text(encoding="utf-8")
+    match = re.search(
+        r"const ALLOWED_ROUTES = new Set\(\[(.*?)\]\);",
+        source,
+        flags=re.DOTALL,
+    )
+    if match is None:
+        raise AssertionError(f"ALLOWED_ROUTES was not found in {path}")
+    return set(re.findall(r"'(/api/agent/[^']+)'", match.group(1)))
+
+
+class RunningStub:
+    def __init__(self) -> None:
+        self.temporary_directory = tempfile.TemporaryDirectory(
+            prefix="issue-1424-broker-test-"
+        )
+        self.control_directory = Path(self.temporary_directory.name)
+        self.server = broker_stub.create_server(
+            self.control_directory,
+            port=0,
+        )
+        self.thread = threading.Thread(
+            target=self.server.serve_forever,
+            daemon=True,
+        )
+        self.thread.start()
+
+    @property
+    def base_url(self) -> str:
+        host, port = self.server.server_address
+        return f"http://{host}:{port}"
+
+    def configure(self, fixtures: list[dict[str, object]]) -> None:
+        path = self.control_directory / broker_stub.TRIAL_CONFIG_FILENAME
+        temporary = path.with_suffix(".tmp")
+        temporary.write_text(
+            json.dumps(
+                {
+                    "task_id": "stub-test",
+                    "trial_id": "stub-test:1:session",
+                    "fixtures": fixtures,
+                }
+            ),
+            encoding="utf-8",
+        )
+        os.chmod(temporary, 0o600)
+        os.replace(temporary, path)
+        capture = self.control_directory / broker_stub.CAPTURE_FILENAME
+        capture.write_text("", encoding="utf-8")
+        os.chmod(capture, 0o600)
+
+    def request(
+        self,
+        path: str,
+        *,
+        method: str = "GET",
+        body: object | None = None,
+    ) -> tuple[int, object]:
+        data = None if body is None else json.dumps(body).encode("utf-8")
+        request = urllib.request.Request(
+            self.base_url + path,
+            data=data,
+            method=method,
+            headers={"Content-Type": "application/json"},
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=2) as response:
+                return response.status, json.loads(response.read())
+        except urllib.error.HTTPError as error:
+            return error.code, json.loads(error.read())
+
+    def captures(self) -> list[dict[str, object]]:
+        capture = self.control_directory / broker_stub.CAPTURE_FILENAME
+        return [
+            json.loads(line)
+            for line in capture.read_text(encoding="utf-8").splitlines()
+            if line
+        ]
+
+    def close(self) -> None:
+        self.server.shutdown()
+        self.server.server_close()
+        self.thread.join(timeout=2)
+        self.temporary_directory.cleanup()
+
+
+class BrokerRouteParityTests(unittest.TestCase):
+    def test_stub_matches_both_production_allowlists_exactly(self):
+        javascript_routes = _javascript_allowlist(
+            AGENT_IMAGE_DIR / "skills" / "_shared" / "agent-broker.js"
+        )
+        proxy_routes = _python_allowlist(
+            AGENT_IMAGE_DIR / "mantle_proxy.py",
+            "ALLOWED_AGENT_BROKER_ROUTES",
+        )
+
+        self.assertEqual(len(javascript_routes), 16)
+        self.assertEqual(proxy_routes, javascript_routes)
+        self.assertEqual(
+            broker_stub.ALLOWED_AGENT_BROKER_ROUTES,
+            javascript_routes,
+        )
+
+
+class BrokerStubHttpTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.stub = RunningStub()
+
+    def tearDown(self) -> None:
+        self.stub.close()
+
+    def test_replays_every_allowlisted_route_and_captures_each_request(self):
+        fixtures = [
+            {
+                "route": route,
+                "method": "POST",
+                "response": {
+                    "status": 200,
+                    "body": {"fixture": route},
+                },
+            }
+            for route in sorted(broker_stub.ALLOWED_AGENT_BROKER_ROUTES)
+        ]
+        self.stub.configure(fixtures)
+
+        for route in sorted(broker_stub.ALLOWED_AGENT_BROKER_ROUTES):
+            status, response = self.stub.request(
+                f"/agent-broker{route}",
+                method="POST",
+                body={"route": route},
+            )
+            self.assertEqual(status, 200)
+            self.assertEqual(response, {"fixture": route})
+
+        captures = self.stub.captures()
+        self.assertEqual(len(captures), 16)
+        self.assertEqual(
+            {capture["route"] for capture in captures},
+            broker_stub.ALLOWED_AGENT_BROKER_ROUTES,
+        )
+
+    def test_fixture_response_and_complete_request_capture(self):
+        self.stub.configure(
+            [
+                {
+                    "route": "/api/agent/directory-lookup",
+                    "method": "POST",
+                    "request_body": {"query": "Ada"},
+                    "response": {
+                        "status": 201,
+                        "body": {"people": [{"name": "Ada Lovelace"}]},
+                    },
+                }
+            ]
+        )
+
+        status, response = self.stub.request(
+            "/agent-broker/api/agent/directory-lookup",
+            method="POST",
+            body={"query": "Ada", "limit": 5},
+        )
+
+        self.assertEqual(status, 201)
+        self.assertEqual(response["people"][0]["name"], "Ada Lovelace")
+        capture = self.stub.captures()[0]
+        self.assertEqual(capture["route"], "/api/agent/directory-lookup")
+        self.assertEqual(capture["method"], "POST")
+        self.assertEqual(capture["body"], {"query": "Ada", "limit": 5})
+        self.assertEqual(
+            capture["headers"]["content-type"],
+            "application/json",
+        )
+        self.assertIsNone(capture["stub_error"])
+        mode = os.stat(
+            self.stub.control_directory / broker_stub.CAPTURE_FILENAME
+        ).st_mode & 0o777
+        self.assertEqual(mode, 0o600)
+
+    def test_missing_fixture_is_loud_and_named_in_response_and_capture(self):
+        self.stub.configure([])
+
+        status, response = self.stub.request(
+            "/agent-broker/api/agent/workspace-execute",
+            method="POST",
+            body={"operation": "calendar.events.create"},
+        )
+
+        self.assertEqual(status, 501)
+        self.assertEqual(response["error"], broker_stub.MISSING_FIXTURE_ERROR)
+        capture = self.stub.captures()[0]
+        self.assertIn(
+            broker_stub.MISSING_FIXTURE_ERROR,
+            capture["stub_error"],
+        )
+
+    def test_unallowlisted_route_is_rejected_and_captured_loudly(self):
+        self.stub.configure([])
+
+        status, response = self.stub.request(
+            "/agent-broker/api/agent/arbitrary-proxy",
+            method="POST",
+            body={"url": "https://example.com"},
+        )
+
+        self.assertEqual(status, 404)
+        self.assertEqual(response["error"], "EvalUnsupportedAgentRoute")
+        [capture] = self.stub.captures()
+        self.assertEqual(capture["route"], "/api/agent/arbitrary-proxy")
+        self.assertEqual(capture["body"], {"url": "https://example.com"})
+        self.assertIn("EvalUnsupportedAgentRoute", capture["stub_error"])
+
+    def test_unavailable_trial_config_preserves_the_request_body_in_capture(self):
+        self.stub.configure([])
+        (
+            self.stub.control_directory / broker_stub.TRIAL_CONFIG_FILENAME
+        ).unlink()
+
+        status, response = self.stub.request(
+            "/agent-broker/api/agent/directory-lookup",
+            method="POST",
+            body={"query": "Ada"},
+        )
+
+        self.assertEqual(status, 500)
+        self.assertEqual(response["error"], broker_stub.MISSING_FIXTURE_ERROR)
+        [capture] = self.stub.captures()
+        self.assertEqual(capture["body"], {"query": "Ada"})
+        self.assertIn(
+            broker_stub.MISSING_FIXTURE_ERROR,
+            capture["stub_error"],
+        )
+
+    def test_wrapper_control_endpoints_remain_healthy(self):
+        self.stub.configure([])
+
+        health_status, health = self.stub.request("/health")
+        usage_status, usage = self.stub.request("/usage")
+        begin_status, begin = self.stub.request(
+            "/internal/finalization/begin",
+            method="POST",
+        )
+        end_status, end = self.stub.request(
+            "/internal/finalization/end",
+            method="POST",
+        )
+
+        self.assertEqual(health_status, 200)
+        self.assertEqual(health, {"ok": True, "mode": "eval-stub"})
+        self.assertEqual(usage_status, 200)
+        self.assertEqual(usage["usage_events"], 0)
+        self.assertEqual((begin_status, begin), (200, {"finalizing": True}))
+        self.assertEqual((end_status, end), (200, {"finalizing": False}))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/infra/agent-image/test_broker_stub.py
+++ b/infra/agent-image/test_broker_stub.py
@@ -161,6 +161,58 @@ class BrokerRouteParityTests(unittest.TestCase):
         )
 
 
+class BrokerControlStorageTests(unittest.TestCase):
+    def test_runner_commands_install_and_collect_owner_only_state(self):
+        with tempfile.TemporaryDirectory(
+            prefix="issue-1424-control-test-"
+        ) as directory:
+            control_directory = Path(directory) / "control"
+            serialized = json.dumps(
+                {
+                    "task_id": "control-test",
+                    "trial_id": "control-test:1:session",
+                    "fixtures": [],
+                }
+            ).encode("utf-8")
+
+            broker_stub.install_trial_configuration(
+                control_directory,
+                serialized,
+            )
+            trial_path = (
+                control_directory / broker_stub.TRIAL_CONFIG_FILENAME
+            )
+            capture_path = control_directory / broker_stub.CAPTURE_FILENAME
+            self.assertEqual(
+                control_directory.stat().st_mode & 0o777,
+                0o700,
+            )
+            self.assertEqual(trial_path.stat().st_mode & 0o777, 0o600)
+            self.assertEqual(capture_path.stat().st_mode & 0o777, 0o600)
+            capture_path.write_bytes(b'{"route":"/api/agent/skills"}\n')
+
+            captured = broker_stub.collect_trial_captures(control_directory)
+
+            self.assertEqual(
+                captured,
+                b'{"route":"/api/agent/skills"}\n',
+            )
+            self.assertFalse(trial_path.exists())
+
+    def test_runner_write_rejects_non_object_configuration(self):
+        with tempfile.TemporaryDirectory(
+            prefix="issue-1424-control-test-"
+        ) as directory:
+            with self.assertRaisesRegex(
+                broker_stub.BrokerStubConfigurationError,
+                "must be an object",
+            ):
+                broker_stub.install_trial_configuration(
+                    Path(directory),
+                    b"[]",
+                )
+
+
 class BrokerStubHttpTests(unittest.TestCase):
     def setUp(self) -> None:
         self.stub = RunningStub()

--- a/infra/agent-image/test_broker_stub.py
+++ b/infra/agent-image/test_broker_stub.py
@@ -14,6 +14,7 @@ import re
 import sys
 import tempfile
 import threading
+import time
 import unittest
 import urllib.error
 import urllib.request
@@ -65,9 +66,14 @@ class RunningStub:
             prefix="issue-1424-broker-test-"
         )
         self.control_directory = Path(self.temporary_directory.name)
+        self.flush_token = "f" * 43
+        self.flush_token_path = self.control_directory / "workspace-flush-token"
+        self.flush_token_path.write_text(self.flush_token, encoding="ascii")
+        os.chmod(self.flush_token_path, 0o600)
         self.server = broker_stub.create_server(
             self.control_directory,
             port=0,
+            workspace_flush_token_path=self.flush_token_path,
         )
         self.thread = threading.Thread(
             target=self.server.serve_forever,
@@ -105,13 +111,16 @@ class RunningStub:
         *,
         method: str = "GET",
         body: object | None = None,
+        headers: dict[str, str] | None = None,
     ) -> tuple[int, object]:
         data = None if body is None else json.dumps(body).encode("utf-8")
+        request_headers = {"Content-Type": "application/json"}
+        request_headers.update(headers or {})
         request = urllib.request.Request(
             self.base_url + path,
             data=data,
             method=method,
-            headers={"Content-Type": "application/json"},
+            headers=request_headers,
         )
         try:
             with urllib.request.urlopen(request, timeout=2) as response:
@@ -344,10 +353,12 @@ class BrokerStubHttpTests(unittest.TestCase):
         begin_status, begin = self.stub.request(
             "/internal/finalization/begin",
             method="POST",
+            headers={"X-Agent-Workspace-Flush": self.stub.flush_token},
         )
         end_status, end = self.stub.request(
             "/internal/finalization/end",
             method="POST",
+            headers={"X-Agent-Workspace-Flush": self.stub.flush_token},
         )
 
         self.assertEqual(health_status, 200)
@@ -355,6 +366,118 @@ class BrokerStubHttpTests(unittest.TestCase):
         self.assertEqual(usage_status, 200)
         self.assertEqual(usage["usage_events"], 0)
         self.assertEqual((begin_status, begin), (200, {"finalizing": True}))
+        self.assertEqual((end_status, end), (200, {"finalizing": False}))
+
+    def test_finalization_drains_in_flight_request_and_rejects_new_work(self):
+        self.stub.configure(
+            [
+                {
+                    "route": "/api/agent/directory-lookup",
+                    "response": {"body": {"people": []}},
+                },
+                {
+                    "route": "/api/agent/workspace-storage",
+                    "request_body": {"operation": "upload"},
+                    "response": {"body": {"stored": True}},
+                }
+            ]
+        )
+        entered_fixture = threading.Event()
+        release_fixture = threading.Event()
+        original_find_fixture = self.stub.server.state.find_fixture
+
+        def blocking_find_fixture(*args, **kwargs):
+            entered_fixture.set()
+            if not release_fixture.wait(timeout=2):
+                raise AssertionError("test did not release the in-flight request")
+            return original_find_fixture(*args, **kwargs)
+
+        self.stub.server.state.find_fixture = blocking_find_fixture
+        results: dict[str, tuple[int, object]] = {}
+
+        in_flight = threading.Thread(
+            target=lambda: results.setdefault(
+                "in_flight",
+                self.stub.request(
+                    "/agent-broker/api/agent/directory-lookup",
+                    method="POST",
+                    body={"query": "Ada"},
+                ),
+            ),
+            daemon=True,
+        )
+        in_flight.start()
+        self.assertTrue(entered_fixture.wait(timeout=1))
+
+        begin = threading.Thread(
+            target=lambda: results.setdefault(
+                "begin",
+                self.stub.request(
+                    "/internal/finalization/begin",
+                    method="POST",
+                    headers={
+                        "X-Agent-Workspace-Flush": self.stub.flush_token,
+                    },
+                ),
+            ),
+            daemon=True,
+        )
+        begin.start()
+        deadline = time.monotonic() + 1
+        while (
+            self.stub.server.state.finalization_state != "draining"
+            and time.monotonic() < deadline
+        ):
+            time.sleep(0.005)
+        self.assertEqual(
+            self.stub.server.state.finalization_state,
+            "draining",
+        )
+        self.assertTrue(begin.is_alive())
+
+        rejected_status, rejected = self.stub.request(
+            "/agent-broker/api/agent/directory-lookup",
+            method="POST",
+            body={"query": "Grace"},
+        )
+        self.assertEqual(rejected_status, 503)
+        self.assertEqual(rejected["error"], broker_stub.FINALIZING_ERROR)
+
+        release_fixture.set()
+        in_flight.join(timeout=1)
+        begin.join(timeout=1)
+        self.assertFalse(in_flight.is_alive())
+        self.assertFalse(begin.is_alive())
+        self.assertEqual(results["in_flight"][0], 200)
+        self.assertEqual(results["begin"], (200, {"finalizing": True}))
+        self.assertTrue(
+            any(
+                capture["body"] == {"query": "Ada"}
+                for capture in self.stub.captures()
+            )
+        )
+
+        rejected_status, rejected = self.stub.request(
+            "/agent-broker/api/agent/directory-lookup",
+            method="POST",
+            body={"query": "Katherine"},
+        )
+        self.assertEqual(rejected_status, 503)
+        self.assertEqual(rejected["error"], broker_stub.FINALIZING_ERROR)
+
+        flush_status, flush = self.stub.request(
+            "/agent-broker/api/agent/workspace-storage",
+            method="POST",
+            body={"operation": "upload"},
+            headers={"X-Agent-Workspace-Flush": self.stub.flush_token},
+        )
+        self.assertEqual((flush_status, flush), (200, {"stored": True}))
+
+        end_status, end = self.stub.request(
+            "/internal/finalization/end",
+            method="POST",
+            headers={"X-Agent-Workspace-Flush": self.stub.flush_token},
+        )
         self.assertEqual((end_status, end), (200, {"finalizing": False}))
 
 

--- a/infra/agent-image/test_eval_runner.py
+++ b/infra/agent-image/test_eval_runner.py
@@ -206,6 +206,69 @@ class SuiteLoadingTests(unittest.TestCase):
 
         self.assertEqual(task.prompt, "Don't use tools")
 
+    def test_l1_task_loads_fixture_paths_and_inline_graders(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            fixture = root / "directory.json"
+            fixture.write_text(
+                json.dumps(
+                    [
+                        {
+                            "route": "/api/agent/directory-lookup",
+                            "response": {"body": {"people": []}},
+                        }
+                    ]
+                ),
+                encoding="utf-8",
+            )
+            task_path = root / "task.yaml"
+            task_path.write_text(
+                "\n".join(
+                    [
+                        "id: directory-lookup",
+                        "skill: psd-directory",
+                        "level: L1",
+                        "workspace: pure",
+                        'prompt: "Find Ada."',
+                        "fixtures:",
+                        "  - directory.json",
+                        "graders:",
+                        (
+                            '  - {"type":"broker_request",'
+                            '"route":"/api/agent/directory-lookup"}'
+                        ),
+                    ]
+                ),
+                encoding="utf-8",
+            )
+
+            [task] = runner.load_suite(task_path)
+
+            self.assertEqual(task.fixture_paths, (fixture.resolve(),))
+            self.assertEqual(task.graders[0]["type"], "broker_request")
+
+    def test_l1_task_without_a_grader_fails_closed(self):
+        with tempfile.TemporaryDirectory() as directory:
+            task_path = Path(directory) / "task.yaml"
+            task_path.write_text(
+                "\n".join(
+                    [
+                        "id: ungraded",
+                        "skill: psd-directory",
+                        "level: L1",
+                        "workspace: pure",
+                        'prompt: "Find Ada."',
+                    ]
+                ),
+                encoding="utf-8",
+            )
+
+            with self.assertRaisesRegex(
+                runner.EvalRunnerError,
+                "L1 tasks must configure",
+            ):
+                runner.load_suite(task_path)
+
     def test_python_adjacent_string_syntax_is_not_accepted_as_yaml(self):
         with tempfile.TemporaryDirectory() as directory:
             task_path = Path(directory) / "adjacent-strings.yaml"
@@ -266,6 +329,7 @@ class FakeRuntime:
         self.stopped = False
         self.invocations: list[tuple[str, str]] = []
         self.memory: dict[str, str] = {}
+        self.trial_active = False
 
     def prepare(self) -> bool:
         restarted = not self.started
@@ -304,6 +368,15 @@ class FakeRuntime:
             "metadata": metadata(session_id, future_field={"preserved": True}),
         }
 
+    def begin_trial(self, task, trial_number, session_id) -> None:
+        self.trial_active = True
+
+    def end_trial(self) -> runner.TrialArtifacts:
+        if not self.trial_active:
+            raise AssertionError("trial lifecycle violated")
+        self.trial_active = False
+        return runner.TrialArtifacts()
+
     def stop(self) -> None:
         self.stopped = True
 
@@ -313,7 +386,7 @@ class FakeRuntimeFactory:
         self.clock = clock
         self.runtimes: list[FakeRuntime] = []
 
-    def create(self) -> FakeRuntime:
+    def create(self, task: runner.Task) -> FakeRuntime:
         runtime = FakeRuntime(self.clock)
         self.runtimes.append(runtime)
         return runtime
@@ -401,7 +474,7 @@ class EvaluationRunnerTests(unittest.TestCase):
                 return super().invoke(task, session_id, authority)
 
         class OrderedFactory:
-            def create(self):
+            def create(self, task):
                 return OrderedRuntime(clock)
 
         class OrderedMinter(FakeMinter):
@@ -436,7 +509,7 @@ class EvaluationRunnerTests(unittest.TestCase):
                 return super().invoke(task, session_id, authority)
 
         class RestartingFactory:
-            def create(self):
+            def create(self, task):
                 return RestartingRuntime()
 
         class RecordingMinter(FakeMinter):
@@ -493,7 +566,7 @@ class EvaluationRunnerTests(unittest.TestCase):
                 return {"result": "answer", "metadata": incomplete}
 
         class IncompleteFactory:
-            def create(self):
+            def create(self, task):
                 return IncompleteRuntime(clock)
 
         with self.assertRaisesRegex(runner.EvalRunnerError, "latency_ms"):
@@ -513,7 +586,7 @@ class EvaluationRunnerTests(unittest.TestCase):
                 return {"result": "answer", "metadata": incomplete}
 
         class MissingSessionFactory:
-            def create(self):
+            def create(self, task):
                 return MissingSessionRuntime(clock)
 
         with self.assertRaisesRegex(runner.EvalRunnerError, "session_id"):
@@ -538,7 +611,7 @@ class EvaluationRunnerTests(unittest.TestCase):
                 }
 
         class RejectedFactory:
-            def create(self):
+            def create(self, task):
                 return RejectedRuntime(clock)
 
         with self.assertRaisesRegex(
@@ -557,6 +630,64 @@ class EvaluationRunnerTests(unittest.TestCase):
             with runner._open_output(path, overwrite=False) as output:
                 output.write("{}\n")
             self.assertEqual(os.stat(path).st_mode & 0o777, 0o600)
+
+    def test_trial_artifacts_are_graded_and_preserved_in_the_record(self):
+        clock = AdvancingClock()
+
+        class CapturingRuntime(FakeRuntime):
+            def end_trial(self):
+                super().end_trial()
+                return runner.TrialArtifacts(
+                    broker_requests=(
+                        {
+                            "route": "/api/agent/directory-lookup",
+                            "method": "POST",
+                            "body": {"query": "Ada"},
+                            "stub_error": None,
+                        },
+                    ),
+                    tools_catalog_log=(
+                        'tools.catalog ok: [{"name":"skills.search"}]'
+                    ),
+                )
+
+        class CapturingFactory:
+            def create(self, task):
+                return CapturingRuntime(clock)
+
+        task = runner.Task(
+            id="graded-task",
+            skill="psd-directory",
+            level="L1",
+            workspace="pure",
+            prompt="Find Ada.",
+            trials=1,
+            graders=runner.validate_grader_specs(
+                [
+                    {
+                        "type": "broker_request",
+                        "route": "/api/agent/directory-lookup",
+                        "body": {"query": {"exact": "Ada"}},
+                    },
+                    {
+                        "type": "tools_catalog",
+                        "expected": ["skills.search"],
+                    },
+                ]
+            ),
+        )
+
+        records = runner.EvaluationRunner(
+            CapturingFactory(),
+            FakeMinter(clock),
+            now=clock.now,
+        ).run([task], io.StringIO())
+
+        self.assertTrue(records[0]["grade"]["passed"])
+        self.assertEqual(
+            records[0]["broker_requests"][0]["route"],
+            "/api/agent/directory-lookup",
+        )
 
 
 class RecordingExecutor:
@@ -618,6 +749,21 @@ class MissingResultExecutor(RecordingExecutor):
         result = super().run(arguments, **options)
         if "http://127.0.0.1:8080/invocations" in tuple(arguments):
             return runner.CommandResult(0, 'data: {"type":"start"}\n', "")
+        return result
+
+
+class CatalogExecutor(RecordingExecutor):
+    def run(self, arguments, **options):
+        result = super().run(arguments, **options)
+        if tuple(arguments)[:3] == ("docker", "logs", "--since"):
+            return runner.CommandResult(
+                0,
+                (
+                    'tools.catalog ok: [{"name":"skills.search"},'
+                    '{"name":"directory.lookup"}]'
+                ),
+                "",
+            )
         return result
 
 
@@ -803,6 +949,141 @@ class DockerRuntimeTests(unittest.TestCase):
         self.assertIn(
             f"X-Amzn-Bedrock-AgentCore-Runtime-Session-Id: {session_id}",
             invocation_call,
+        )
+
+    def test_l1_runtime_bind_mounts_stub_and_collects_per_trial_capture(self):
+        executor = RecordingExecutor()
+        with tempfile.TemporaryDirectory() as directory:
+            fixture_path = Path(directory) / "fixture.json"
+            fixture_path.write_text(
+                json.dumps(
+                    [
+                        {
+                            "route": "/api/agent/directory-lookup",
+                            "response": {"body": {"people": []}},
+                        }
+                    ]
+                ),
+                encoding="utf-8",
+            )
+            runtime = runner.DockerRuntime(
+                executor,
+                "candidate@sha256:digest",
+                "linux/arm64",
+                {"APP_BASE_URL": "https://dev.example.invalid"},
+                SequenceCredentialProvider([aws_credentials()]),
+                boot_timeout_seconds=120,
+                invocation_timeout_seconds=900,
+                poll_interval_seconds=0,
+                name_prefix="psd-agent-eval-issue-1424-test",
+                broker_stub_path=(
+                    AGENT_IMAGE_DIR / "eval" / "broker_stub.py"
+                ),
+                use_broker_stub=True,
+            )
+            runtime.prepare()
+            task = runner.Task(
+                id="directory-lookup",
+                skill="psd-directory",
+                level="L1",
+                workspace="pure",
+                prompt="Find Ada.",
+                trials=1,
+                fixture_paths=(fixture_path,),
+                graders=runner.validate_grader_specs(
+                    [
+                        {
+                            "type": "broker_request",
+                            "route": "/api/agent/directory-lookup",
+                        }
+                    ]
+                ),
+            )
+            session_id = "a" * 36
+            runtime.begin_trial(task, 1, session_id)
+            control_directory = runtime._broker_control_directory
+            self.assertIsNotNone(control_directory)
+            trial = json.loads(
+                (
+                    control_directory / runner.TRIAL_CONFIG_FILENAME
+                ).read_text(encoding="utf-8")
+            )
+            self.assertEqual(
+                trial["fixtures"][0]["route"],
+                "/api/agent/directory-lookup",
+            )
+            (
+                control_directory / runner.CAPTURE_FILENAME
+            ).write_text(
+                json.dumps(
+                    {
+                        "route": "/api/agent/directory-lookup",
+                        "method": "POST",
+                        "body": {"query": "Ada"},
+                        "stub_error": None,
+                    }
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+
+            artifacts = runtime.end_trial()
+            runtime.stop()
+
+        docker_run = next(
+            call for call in executor.calls if call[:2] == ("docker", "run")
+        )
+        joined = "\n".join(docker_run)
+        self.assertIn("dst=/app/mantle_proxy.py,readonly", joined)
+        self.assertIn("dst=/run/psd-agent-eval-broker", joined)
+        self.assertIn(
+            "AGENT_EVAL_BROKER_CONTROL_DIR=/run/psd-agent-eval-broker",
+            docker_run,
+        )
+        self.assertEqual(
+            artifacts.broker_requests[0]["route"],
+            "/api/agent/directory-lookup",
+        )
+        self.assertFalse(control_directory.exists())
+
+    def test_runtime_collects_tools_catalog_diagnostic_for_its_trial(self):
+        executor = CatalogExecutor()
+        runtime = runner.DockerRuntime(
+            executor,
+            "candidate@sha256:digest",
+            "linux/arm64",
+            {"APP_BASE_URL": "https://dev.example.invalid"},
+            SequenceCredentialProvider([aws_credentials()]),
+            boot_timeout_seconds=120,
+            invocation_timeout_seconds=900,
+            poll_interval_seconds=0,
+            name_prefix="psd-agent-eval-issue-1424-test",
+        )
+        runtime.prepare()
+        task = runner.Task(
+            id="catalog-task",
+            skill="runner-core",
+            level="L0",
+            workspace="pure",
+            prompt="hello",
+            trials=1,
+            graders=runner.validate_grader_specs(
+                [
+                    {
+                        "type": "tools_catalog",
+                        "expected": ["skills.search", "directory.lookup"],
+                    }
+                ]
+            ),
+        )
+
+        runtime.begin_trial(task, 1, "a" * 36)
+        artifacts = runtime.end_trial()
+        runtime.stop()
+
+        self.assertIn('"skills.search"', artifacts.tools_catalog_log)
+        self.assertTrue(
+            any(call[:3] == ("docker", "logs", "--since") for call in executor.calls)
         )
 
     def test_missing_result_is_reported_as_a_runner_error(self):

--- a/infra/agent-image/test_eval_runner.py
+++ b/infra/agent-image/test_eval_runner.py
@@ -718,11 +718,19 @@ class EvaluationRunnerTests(unittest.TestCase):
 class RecordingExecutor:
     def __init__(self) -> None:
         self.calls: list[tuple[str, ...]] = []
+        self.broker_trial_config: dict[str, object] | None = None
+        self.broker_capture = ""
 
     def run(self, arguments, **options):
-        del options
         call = tuple(arguments)
         self.calls.append(call)
+        if call[-1:] == (runner.RUNNER_WRITE_TRIAL_COMMAND,):
+            self.broker_trial_config = json.loads(options["input_text"])
+            self.broker_capture = ""
+            return runner.CommandResult(0, "", "")
+        if call[-1:] == (runner.RUNNER_READ_CAPTURES_COMMAND,):
+            self.broker_trial_config = None
+            return runner.CommandResult(0, self.broker_capture, "")
         if call[:2] == ("docker", "run"):
             return runner.CommandResult(0, "container-123\n", "")
         if call[:2] == ("docker", "logs"):
@@ -976,7 +984,7 @@ class DockerRuntimeTests(unittest.TestCase):
             invocation_call,
         )
 
-    def test_l1_runtime_bind_mounts_stub_and_collects_per_trial_capture(self):
+    def test_l1_runtime_uses_root_tmpfs_and_collects_per_trial_capture(self):
         executor = RecordingExecutor()
         with tempfile.TemporaryDirectory() as directory:
             fixture_path = Path(directory) / "fixture.json"
@@ -1026,20 +1034,13 @@ class DockerRuntimeTests(unittest.TestCase):
             )
             session_id = "a" * 36
             runtime.begin_trial(task, 1, session_id)
-            control_directory = runtime._broker_control_directory
-            self.assertIsNotNone(control_directory)
-            trial = json.loads(
-                (
-                    control_directory / runner.TRIAL_CONFIG_FILENAME
-                ).read_text(encoding="utf-8")
-            )
+            trial = executor.broker_trial_config
+            self.assertIsNotNone(trial)
             self.assertEqual(
                 trial["fixtures"][0]["route"],
                 "/api/agent/directory-lookup",
             )
-            (
-                control_directory / runner.CAPTURE_FILENAME
-            ).write_text(
+            executor.broker_capture = (
                 json.dumps(
                     {
                         "route": "/api/agent/directory-lookup",
@@ -1048,8 +1049,7 @@ class DockerRuntimeTests(unittest.TestCase):
                         "stub_error": None,
                     }
                 )
-                + "\n",
-                encoding="utf-8",
+                + "\n"
             )
 
             artifacts = runtime.end_trial()
@@ -1060,7 +1060,11 @@ class DockerRuntimeTests(unittest.TestCase):
         )
         joined = "\n".join(docker_run)
         self.assertIn("dst=/app/mantle_proxy.py,readonly", joined)
-        self.assertIn("dst=/run/psd-agent-eval-broker", joined)
+        self.assertIn("--tmpfs", docker_run)
+        self.assertIn(runner.BROKER_CONTROL_TMPFS_OPTIONS, docker_run)
+        self.assertIn("mode=0700,uid=0,gid=0", joined)
+        self.assertNotIn("dst=/run/psd-agent-eval-broker", joined)
+        self.assertEqual(docker_run.count("--mount"), 1)
         self.assertIn(
             "AGENT_EVAL_BROKER_CONTROL_DIR=/run/psd-agent-eval-broker",
             docker_run,
@@ -1069,7 +1073,24 @@ class DockerRuntimeTests(unittest.TestCase):
             artifacts.broker_requests[0]["route"],
             "/api/agent/directory-lookup",
         )
-        self.assertFalse(control_directory.exists())
+        broker_execs = [
+            call
+            for call in executor.calls
+            if call[:2] == ("docker", "exec")
+            and call[-1]
+            in {
+                runner.RUNNER_WRITE_TRIAL_COMMAND,
+                runner.RUNNER_READ_CAPTURES_COMMAND,
+            }
+        ]
+        self.assertEqual(len(broker_execs), 2)
+        self.assertTrue(
+            all(
+                ("--user", "0:0") == call[2:4]
+                for call in broker_execs
+            )
+        )
+        self.assertIsNone(executor.broker_trial_config)
 
     def test_runtime_collects_tools_catalog_diagnostic_for_its_trial(self):
         executor = CatalogExecutor()

--- a/infra/agent-image/test_eval_runner.py
+++ b/infra/agent-image/test_eval_runner.py
@@ -342,6 +342,27 @@ class SuiteLoadingTests(unittest.TestCase):
                     with self.assertRaises(runner.EvalRunnerError):
                         runner._load_fixture_files((path,))
 
+    def test_fixture_loading_rejects_informational_response_status(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "informational.json"
+            path.write_text(
+                json.dumps(
+                    [
+                        {
+                            "route": "/api/agent/directory-lookup",
+                            "response": {"status": 199, "body": {}},
+                        }
+                    ]
+                ),
+                encoding="utf-8",
+            )
+
+            with self.assertRaisesRegex(
+                runner.EvalRunnerError,
+                "status must be 200-599",
+            ):
+                runner._load_fixture_files((path,))
+
     def test_python_adjacent_string_syntax_is_not_accepted_as_yaml(self):
         with tempfile.TemporaryDirectory() as directory:
             task_path = Path(directory) / "adjacent-strings.yaml"
@@ -648,6 +669,39 @@ class EvaluationRunnerTests(unittest.TestCase):
                 FakeMinter(clock),
                 now=clock.now,
             ).run(self.tasks[:1], io.StringIO(), trials_override=1)
+
+    def test_artifact_failure_does_not_mask_invocation_failure(self):
+        clock = AdvancingClock()
+
+        class DoubleFailureRuntime(FakeRuntime):
+            def invoke(self, task, session_id, authority):
+                raise runner.EvalRunnerError("primary invocation failure")
+
+            def end_trial(self):
+                super().end_trial()
+                raise runner.EvalRunnerError("secondary artifact failure")
+
+        class DoubleFailureFactory:
+            def create(self, task):
+                return DoubleFailureRuntime(clock)
+
+        with self.assertRaisesRegex(
+            runner.EvalRunnerError,
+            "primary invocation failure",
+        ) as raised:
+            runner.EvaluationRunner(
+                DoubleFailureFactory(),
+                FakeMinter(clock),
+                now=clock.now,
+            ).run(self.tasks[:1], io.StringIO(), trials_override=1)
+
+        self.assertEqual(
+            raised.exception.__notes__,
+            [
+                "trial artifact collection also failed: "
+                "secondary artifact failure"
+            ],
+        )
 
     def test_missing_metadata_session_is_never_synthesized(self):
         clock = AdvancingClock()

--- a/infra/agent-image/test_eval_runner.py
+++ b/infra/agent-image/test_eval_runner.py
@@ -269,6 +269,31 @@ class SuiteLoadingTests(unittest.TestCase):
             ):
                 runner.load_suite(task_path)
 
+    def test_fixture_loading_rejects_non_post_methods_and_scalar_selectors(self):
+        invalid_fixtures = (
+            {
+                "route": "/api/agent/directory-lookup",
+                "method": "GET",
+                "response": {"body": {}},
+            },
+            {
+                "route": "/api/agent/directory-lookup",
+                "request_body": "Ada",
+                "response": {"body": {}},
+            },
+        )
+        for index, fixture in enumerate(invalid_fixtures):
+            with self.subTest(fixture=fixture):
+                with tempfile.TemporaryDirectory() as directory:
+                    path = Path(directory) / f"invalid-{index}.json"
+                    path.write_text(
+                        json.dumps([fixture]),
+                        encoding="utf-8",
+                    )
+
+                    with self.assertRaises(runner.EvalRunnerError):
+                        runner._load_fixture_files((path,))
+
     def test_python_adjacent_string_syntax_is_not_accepted_as_yaml(self):
         with tempfile.TemporaryDirectory() as directory:
             task_path = Path(directory) / "adjacent-strings.yaml"

--- a/infra/agent-image/test_eval_runner.py
+++ b/infra/agent-image/test_eval_runner.py
@@ -269,6 +269,54 @@ class SuiteLoadingTests(unittest.TestCase):
             ):
                 runner.load_suite(task_path)
 
+    def test_live_tasks_reject_broker_capture_graders(self):
+        for level in ("L0", "L2"):
+            for grader_type in ("broker_request", "no_route_called"):
+                with self.subTest(level=level, grader=grader_type):
+                    with self.assertRaisesRegex(
+                        runner.EvalRunnerError,
+                        "broker graders require level L1",
+                    ):
+                        runner._task_from_mapping(
+                            {
+                                "id": "invalid-live-grader",
+                                "skill": "runner-core",
+                                "level": level,
+                                "workspace": "pure",
+                                "prompt": "hello",
+                                "graders": [
+                                    {
+                                        "type": grader_type,
+                                        "route": (
+                                            "/api/agent/directory-lookup"
+                                        ),
+                                    }
+                                ],
+                            },
+                            Path("inline.yaml"),
+                        )
+
+    def test_live_tasks_reject_ignored_fixture_files(self):
+        with tempfile.TemporaryDirectory() as directory:
+            fixture_path = Path(directory) / "fixture.json"
+            fixture_path.write_text("[]", encoding="utf-8")
+
+            with self.assertRaisesRegex(
+                runner.EvalRunnerError,
+                "fixtures require level L1",
+            ):
+                runner._task_from_mapping(
+                    {
+                        "id": "invalid-live-fixture",
+                        "skill": "runner-core",
+                        "level": "L0",
+                        "workspace": "pure",
+                        "prompt": "hello",
+                        "fixtures": [fixture_path.name],
+                    },
+                    Path(directory) / "task.yaml",
+                )
+
     def test_fixture_loading_rejects_non_post_methods_and_scalar_selectors(self):
         invalid_fixtures = (
             {

--- a/infra/agent-image/test_graders.py
+++ b/infra/agent-image/test_graders.py
@@ -222,6 +222,29 @@ class OutputAndTrajectoryGraderTests(unittest.TestCase):
 
 
 class ReliabilityAggregationTests(unittest.TestCase):
+    def test_failed_invocation_cannot_pass_a_negative_route_grader(self):
+        decision = grade(
+            [
+                {
+                    "type": "no_route_called",
+                    "route": "/api/agent/email-triage",
+                }
+            ],
+            metadata={
+                "tool_calls": [],
+                "failed": True,
+                "error_class": "AgentDeadlineExceeded",
+            },
+        )
+
+        self.assertFalse(decision["passed"])
+        self.assertEqual(decision["results"][0]["grader"], "invocation")
+        self.assertIn(
+            "AgentDeadlineExceeded",
+            decision["results"][0]["reason"],
+        )
+        self.assertTrue(decision["results"][1]["passed"])
+
     def test_pass_k_fails_when_only_two_of_three_trials_pass(self):
         records = [
             {

--- a/infra/agent-image/test_graders.py
+++ b/infra/agent-image/test_graders.py
@@ -1,0 +1,275 @@
+"""Hermetic tests for the issue #1424 deterministic eval graders.
+
+Run:
+    uv run --python 3.12 --no-project -m unittest \
+      infra/agent-image/test_graders.py
+"""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+
+AGENT_IMAGE_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(AGENT_IMAGE_DIR / "eval"))
+
+import graders  # noqa: E402
+
+
+def grade(
+    specs,
+    *,
+    result="done",
+    metadata=None,
+    requests=(),
+    errors=(),
+    catalog="",
+):
+    validated = graders.validate_grader_specs(specs)
+    return graders.grade_trial(
+        validated,
+        result=result,
+        metadata=metadata or {"tool_calls": []},
+        artifacts=graders.TrialArtifacts(
+            broker_requests=tuple(requests),
+            broker_errors=tuple(errors),
+            tools_catalog_log=catalog,
+        ),
+    )
+
+
+class BrokerRequestGraderTests(unittest.TestCase):
+    def test_method_and_all_body_matcher_types(self):
+        decision = grade(
+            [
+                {
+                    "type": "broker_request",
+                    "route": "/api/agent/workspace-execute",
+                    "method": "POST",
+                    "body": {
+                        "operation": {"exact": "calendar.events.create"},
+                        "attendees": {"contains_any": ["staff@example.com"]},
+                        "durationMinutes": {"numeric_equals": 30.0},
+                    },
+                }
+            ],
+            requests=[
+                {
+                    "route": "/api/agent/workspace-execute",
+                    "method": "POST",
+                    "body": {
+                        "operation": "calendar.events.create",
+                        "attendees": ["owner@example.com", "staff@example.com"],
+                        "durationMinutes": 30,
+                    },
+                }
+            ],
+        )
+
+        self.assertTrue(decision["passed"])
+        self.assertIn("matching body", decision["results"][0]["reason"])
+
+    def test_nested_field_mismatch_has_human_readable_reason(self):
+        decision = grade(
+            [
+                {
+                    "type": "broker_request",
+                    "route": "/api/agent/failures",
+                    "body": {
+                        "failure.severity": {"exact": "critical"},
+                    },
+                }
+            ],
+            requests=[
+                {
+                    "route": "/api/agent/failures",
+                    "method": "POST",
+                    "body": {"failure": {"severity": "warning"}},
+                }
+            ],
+        )
+
+        self.assertFalse(decision["passed"])
+        self.assertIn("expected exact", decision["results"][0]["reason"])
+
+    def test_no_route_called_rejects_a_forbidden_side_effect(self):
+        decision = grade(
+            [
+                {
+                    "type": "no_route_called",
+                    "route": "/api/agent/email-triage",
+                }
+            ],
+            requests=[
+                {
+                    "route": "/api/agent/email-triage",
+                    "method": "POST",
+                    "body": {},
+                }
+            ],
+        )
+
+        self.assertFalse(decision["passed"])
+        self.assertIn("forbidden", decision["results"][0]["reason"])
+
+
+class OutputAndTrajectoryGraderTests(unittest.TestCase):
+    def test_output_match_supports_case_insensitive_regex(self):
+        decision = grade(
+            [
+                {
+                    "type": "output_match",
+                    "pattern": r"ticket\s+#\d+",
+                    "ignore_case": True,
+                }
+            ],
+            result="Created Ticket #418.",
+        )
+
+        self.assertTrue(decision["passed"])
+
+    def test_trajectory_requires_relative_order_but_allows_extra_steps(self):
+        decision = grade(
+            [
+                {
+                    "type": "trajectory_in_order",
+                    "tools": ["skills.search", "skills.load", "workspace.execute"],
+                }
+            ],
+            metadata={
+                "tool_calls": [
+                    {"name": "skills.search"},
+                    {"name": "read"},
+                    {"name": "skills.load"},
+                    {"name": "think"},
+                    {"name": "workspace.execute"},
+                ]
+            },
+        )
+
+        self.assertTrue(decision["passed"])
+        self.assertEqual(
+            len(decision["results"]),
+            1,
+            "extra tools are allowed instead of enforcing an exact sequence",
+        )
+
+    def test_trajectory_rejects_expected_tools_in_the_wrong_order(self):
+        decision = grade(
+            [
+                {
+                    "type": "trajectory_in_order",
+                    "tools": ["skills.search", "skills.load"],
+                }
+            ],
+            metadata={
+                "tool_calls": [
+                    {"name": "skills.load"},
+                    {"name": "skills.search"},
+                ]
+            },
+        )
+
+        self.assertFalse(decision["passed"])
+
+    def test_tools_catalog_requires_every_expected_entry(self):
+        decision = grade(
+            [
+                {
+                    "type": "tools_catalog",
+                    "expected": ["skills.search", "workspace.execute"],
+                }
+            ],
+            catalog='tools.catalog ok: [{"name":"skills.search"},{"name":"read"}]',
+        )
+
+        self.assertFalse(decision["passed"])
+        self.assertIn("workspace.execute", decision["results"][0]["reason"])
+
+    def test_tools_catalog_matches_name_fields_not_description_text(self):
+        decision = grade(
+            [
+                {
+                    "type": "tools_catalog",
+                    "expected": ["workspace.execute"],
+                }
+            ],
+            catalog=(
+                'tools.catalog ok: [{"name":"read",'
+                '"description":"use workspace.execute when needed"}]'
+            ),
+        )
+
+        self.assertFalse(decision["passed"])
+
+    def test_tools_catalog_handles_a_truncated_catalog_line(self):
+        decision = grade(
+            [
+                {
+                    "type": "tools_catalog",
+                    "expected": ["skills.search", "workspace.execute"],
+                }
+            ],
+            catalog=(
+                'tools.catalog ok: [{"name":"skills.search"},'
+                '{"name":"workspace.execute"},{"name":"truncated'
+            ),
+        )
+
+        self.assertTrue(decision["passed"])
+
+
+class ReliabilityAggregationTests(unittest.TestCase):
+    def test_pass_k_fails_when_only_two_of_three_trials_pass(self):
+        records = [
+            {
+                "task_id": "three-trial-task",
+                "trial": trial,
+                "trials": 3,
+                "grade": {"passed": trial != 2},
+            }
+            for trial in range(1, 4)
+        ]
+
+        summary = graders.aggregate_pass_k(records)
+
+        self.assertEqual(summary[0]["passed_trials"], 2)
+        self.assertFalse(summary[0]["pass^k"])
+
+    def test_missing_fixture_is_an_automatic_named_failure(self):
+        decision = grade(
+            [],
+            errors=(
+                "EvalFixtureMissing: no fixture for POST /api/agent/aistudio",
+            ),
+        )
+
+        self.assertFalse(decision["passed"])
+        self.assertEqual(decision["results"][0]["grader"], "broker_stub")
+        self.assertIn("EvalFixtureMissing", decision["results"][0]["reason"])
+
+
+class GraderValidationTests(unittest.TestCase):
+    def test_invalid_regex_fails_when_the_suite_loads(self):
+        with self.assertRaisesRegex(
+            graders.GraderConfigurationError,
+            "pattern is invalid",
+        ):
+            graders.validate_grader_specs(
+                [{"type": "output_match", "pattern": "["}]
+            )
+
+    def test_unknown_grader_fails_closed(self):
+        with self.assertRaisesRegex(
+            graders.GraderConfigurationError,
+            "unsupported grader",
+        ):
+            graders.validate_grader_specs(
+                [{"type": "model_judge", "prompt": "be generous"}]
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/infra/agent-image/test_graders.py
+++ b/infra/agent-image/test_graders.py
@@ -293,6 +293,39 @@ class ReliabilityAggregationTests(unittest.TestCase):
 
 
 class GraderValidationTests(unittest.TestCase):
+    def test_broker_graders_reject_routes_outside_the_allowlist(self):
+        for grader_type in ("broker_request", "no_route_called"):
+            with self.subTest(grader=grader_type):
+                with self.assertRaisesRegex(
+                    graders.GraderConfigurationError,
+                    "not an allowed agent broker route",
+                ):
+                    graders.validate_grader_specs(
+                        [
+                            {
+                                "type": grader_type,
+                                "route": "/api/agent/email-traige",
+                            }
+                        ]
+                    )
+
+    def test_broker_graders_reject_non_post_methods(self):
+        for grader_type in ("broker_request", "no_route_called"):
+            with self.subTest(grader=grader_type):
+                with self.assertRaisesRegex(
+                    graders.GraderConfigurationError,
+                    "method must be POST",
+                ):
+                    graders.validate_grader_specs(
+                        [
+                            {
+                                "type": grader_type,
+                                "route": "/api/agent/email-triage",
+                                "method": "GET",
+                            }
+                        ]
+                    )
+
     def test_invalid_regex_fails_when_the_suite_loads(self):
         with self.assertRaisesRegex(
             graders.GraderConfigurationError,

--- a/infra/agent-image/test_graders.py
+++ b/infra/agent-image/test_graders.py
@@ -220,6 +220,24 @@ class OutputAndTrajectoryGraderTests(unittest.TestCase):
 
         self.assertTrue(decision["passed"])
 
+    def test_tools_catalog_ignores_schema_strings_that_look_like_tools(self):
+        decision = grade(
+            [
+                {
+                    "type": "tools_catalog",
+                    "expected": ["workspace.execute"],
+                }
+            ],
+            catalog=(
+                'tools.catalog ok: [{"name":"read","inputSchema":'
+                '{"required":["workspace.execute"],'
+                '"properties":{"choice":{'
+                '"name":"workspace.execute"}}}}]'
+            ),
+        )
+
+        self.assertFalse(decision["passed"])
+
 
 class ReliabilityAggregationTests(unittest.TestCase):
     def test_failed_invocation_cannot_pass_a_negative_route_grader(self):

--- a/infra/agent-image/test_harness_adapter.py
+++ b/infra/agent-image/test_harness_adapter.py
@@ -37,6 +37,45 @@ extract_text = OpenClawAdapter._extract_text
 OLD_LITERAL = "psd-agent-internal-gateway-token"
 
 
+class CatalogDiagnosticTests(unittest.TestCase):
+    def test_compacts_every_name_without_the_old_diagnostic_truncation(self):
+        tools = [
+            {
+                "name": f"tool.{index:02d}",
+                "description": "x" * 100,
+            }
+            for index in range(40)
+        ]
+
+        names = harness_adapter._catalog_tool_names(tools)
+        compact = json.dumps({"names": names}, separators=(",", ":"))
+
+        self.assertGreater(len(json.dumps(tools)), 1500)
+        self.assertLess(len(compact), 1500)
+        self.assertEqual(names[0], "tool.00")
+        self.assertEqual(names[-1], "tool.39")
+        self.assertEqual(len(names), 40)
+
+    def test_reads_names_from_grouped_catalogs_and_deduplicates(self):
+        names = harness_adapter._catalog_tool_names(
+            {
+                "workspace": [
+                    {"name": "workspace.execute"},
+                    {"name": "skills.search"},
+                ],
+                "core": [
+                    {"name": "skills.search"},
+                    {"name": "read"},
+                ],
+            }
+        )
+
+        self.assertEqual(
+            names,
+            ["workspace.execute", "skills.search", "read"],
+        )
+
+
 class GatewayTokenTests(unittest.TestCase):
     def test_token_generated_and_nonempty(self):
         a = harness_adapter.OpenClawAdapter()

--- a/infra/agent-image/test_harness_adapter.py
+++ b/infra/agent-image/test_harness_adapter.py
@@ -75,6 +75,26 @@ class CatalogDiagnosticTests(unittest.TestCase):
             ["workspace.execute", "skills.search", "read"],
         )
 
+    def test_ignores_strings_and_name_fields_nested_inside_tool_schemas(self):
+        names = harness_adapter._catalog_tool_names(
+            [
+                {
+                    "name": "actual.tool",
+                    "inputSchema": {
+                        "required": ["phantom.required"],
+                        "properties": {
+                            "choice": {
+                                "enum": ["phantom.enum"],
+                                "name": "phantom.nested-name",
+                            }
+                        },
+                    },
+                }
+            ]
+        )
+
+        self.assertEqual(names, ["actual.tool"])
+
 
 class GatewayTokenTests(unittest.TestCase):
     def test_token_generated_and_nonempty(self):


### PR DESCRIPTION
## Summary

- inject a hermetic, per-trial broker fixture server into L1 candidate containers without modifying the image
- capture every broker request and fail trials loudly when fixtures are missing or unsupported routes are attempted
- preserve the fixed `psd-summarize` loopback model endpoint with root-signed relay authority while stubbing broker routes
- add deterministic request, negative-route, output, trajectory, tools-catalog, and `pass^k` graders
- document the L1 fixture/grader contract and cover lifecycle, allowlist parity, isolation, grading, and cleanup behavior

## Risk and migrations

- No database migrations or public API changes.
- L1 broker stubbing is local-eval-only; L0/L2 tasks retain the candidate image real proxy.
- `harness_adapter.py`, which is bundled into the production image, now logs a compact complete tool-name list instead of a truncated raw catalog/schema prefix. Repository search confirms only the eval harness consumes the `tools.catalog ok:` marker; model and tool serving behavior is unchanged.
- Stub control files are root-owned (`0700` directory, `0600` files) and unavailable to the model-facing `node` user.
- The model relay accepts only `/anthropic/v1/messages`, signs the exact body with root-held invocation authority, and participates in the same finalization drain as broker traffic.

## Validation

- `uv run --python 3.12 --no-project -m unittest discover -s infra/agent-image -p "test_*.py"` — 370 passed, 1 skipped
- `uv run --python 3.12 --no-project -m unittest infra/agent-image/test_broker_stub.py infra/agent-image/test_graders.py infra/agent-image/test_eval_runner.py` — 83 passed
- `CI=true bun run test:ci -- --runInBand` — 502 suites passed, 4,656 tests passed, 15 skipped
- `bun run lint`
- `bun run typecheck`
- `bun run openapi:check`
- `bun run capabilities:check`
- `bun run build`
- Playwright E2E not applicable: this change is confined to agent-image eval infrastructure and has no user-facing application behavior.

Closes #1424
Part of #1421