### PR TITLE
feat(agent-platform): add psd-morning-brief platform skill

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,6 +119,15 @@ jobs:
       env:
         CI: true
 
+    # psd-morning-brief (#1413). The three-stage CLI is plain CJS outside
+    # Jest's roots. This suite pins signed-owner authority boundaries, modular
+    # source omission, custom desks, private Atrium-only delivery, podcast
+    # defaults, retention, and fatal self-reporting.
+    - name: Run psd-morning-brief skill tests (Bun)
+      run: bun run test:skill:morning-brief
+      env:
+        CI: true
+
     # Optional: Upload test coverage if you generate it
     # - name: Upload coverage reports
     #   uses: codecov/codecov-action@v3

--- a/infra/agent-image/Dockerfile
+++ b/infra/agent-image/Dockerfile
@@ -403,6 +403,9 @@ RUN cd /opt/psd-skills/psd-schedules && npm install --omit=dev --no-audit --no-f
 # Its PDF path passes --extract-images to psd-pdf-to-markdown; that flag needs no
 # new Python dependency either (pymupdf4llm is already in /opt/agentcore-venv and
 # writes images itself), so the consolidated venv RUN above is untouched.
+# psd-morning-brief (#1413) is pure JS with ZERO npm deps. It composes brokered
+# platform skills and APIs, renders its private Atrium newspaper locally, and is
+# installed by `COPY skills` above — NO npm install, NO new RUN, NO new layer.
 
 # Upstream gws-* skills (#912) — per-API SKILL.md guidance for Gmail, Drive,
 # Docs, Sheets, Slides, Forms, Tasks, Calendar, Chat, Meet, Contacts, etc.

--- a/infra/agent-image/skills/psd-morning-brief/SKILL.md
+++ b/infra/agent-image/skills/psd-morning-brief/SKILL.md
@@ -1,0 +1,260 @@
+---
+name: psd-morning-brief
+summary: Opt-in personalized daily newspaper and podcast delivered privately through Atrium and the owner’s scheduled Chat response.
+description: Build or configure a personalized daily morning brief with calendar, inbox, Chat, service-desk, leave, Atrium, weather, news, and custom sections. Use when someone asks for a recurring daily brief, newspaper, or podcast.
+allowed-tools: Bash(node:*)
+---
+
+# psd-morning-brief
+
+An opt-in, owner-bound three-step pipeline:
+
+1. `--data-only` gathers only sources available to the signed owner and writes a
+   snapshot.
+2. The invoking agent curates that snapshot, gathers custom-section material,
+   and writes synthesis JSON.
+3. `--compose` creates a **private Atrium artifact**, generates the podcast, and
+   returns the exact links for the scheduled Chat response.
+
+The skill never publishes to an intranet or public Atrium destination. Creating
+the artifact is the delivery operation. Its date-stamped title produces a unique
+per-owner daily slug, and the owner-bound broker returns the absolute
+`contentDeepLink`.
+
+## Identity and security boundary
+
+Pass `--user <caller-email>` verbatim from the `[caller: Name <email>]` header.
+The value supports legacy composed tools that still validate a caller hint; it
+is not sent as an owner selector to any broker. Every broker operation derives
+the owner exclusively from the signed invocation context.
+
+Never pass an owner id, alternate user, DM-space id, or workspace prefix.
+`--owner-email`, `--user-email`, `--user-id`, `--owner-id`,
+`--dm-space-name`, and `--workspace-prefix` are rejected.
+
+All name resolution uses `psd-directory`. Do not infer a name from an email
+local-part or maintain a local name mapping.
+
+## Run the pipeline
+
+### Step 1 — gather
+
+```bash
+node /opt/psd-skills/psd-morning-brief/run.js \
+  --user <caller-email> \
+  --data-only
+```
+
+The JSON result contains:
+
+- `dataFile`: the private temporary snapshot path;
+- `synthesisRequest`: the exact task, available section ids, custom-section
+  instructions/sources, output shape, and curation rules;
+- `omittedSections`: unavailable or unconfigured sources. Omission is expected,
+  not an error.
+
+Only section ids in `synthesisRequest.availableSections` may appear in the
+synthesis. A source the owner cannot access is absent from both the newspaper
+and the synthesis request.
+
+### Step 2 — synthesize
+
+Read `dataFile`, follow `synthesisRequest`, and write a JSON file matching
+`outputShape`. Required editorial work:
+
+- connect related facts across sections instead of dumping source output;
+- curate the most useful items;
+- make an explicit `act-now | review | defer | archive` decision for every
+  inbox item;
+- gather every custom section from its declared `sources`;
+- use only directory-resolved person names from `snapshot.people`;
+- write a complete, natural spoken `podcastScript`.
+
+Write JSON only. Keep source URLs unchanged.
+
+### Step 3 — compose and deliver
+
+```bash
+node /opt/psd-skills/psd-morning-brief/run.js \
+  --user <caller-email> \
+  --compose \
+  --data-file <dataFile> \
+  --synthesis-file <synthesis.json>
+```
+
+On success, return `deliveryMessage` verbatim in the scheduled response. It
+contains the private Atrium URL and, when enabled, the podcast URL, each on its
+own line so Google Chat renders them correctly.
+
+`--compose` is intentionally strict:
+
+- Atrium must confirm `visibilityLevel: "private"`;
+- the Atrium URL must be absolute;
+- missing `atrium-content` capability is a hard error;
+- there is no S3, intranet, or public-publish fallback;
+- podcast generation runs by default and must succeed unless the owner disabled
+  it in config.
+
+The skill self-reports a fatal run through the same owner-bound failure broker
+used by `psd-failure-report` before returning its error. It calls that broker
+directly so no model-supplied owner selector is forwarded.
+
+## Legacy/debug mode
+
+```bash
+node /opt/psd-skills/psd-morning-brief/run.js \
+  --user <caller-email> \
+  --both
+```
+
+`--both` gathers, deterministically summarizes, composes, and delivers without
+the invoking-agent synthesis step. It is useful for smoke tests and debugging,
+but the scheduled production prompt should always use the three-step pipeline.
+
+Offline-safe self-check:
+
+```bash
+node /opt/psd-skills/psd-morning-brief/run.js --test
+```
+
+## Agent-guided setup interview
+
+Do not create a schedule until the owner has opted in. Interview them in one
+short conversation:
+
+1. Confirm delivery cadence, days, time, and IANA timezone.
+2. Detect or ask which sources they have: Calendar/Gmail, Chat spaces,
+   Freshservice, PSD data, and Atrium. Explain that inaccessible sections
+   quietly omit themselves.
+3. Propose the core sections that fit their connections.
+4. Capture specific Chat spaces by resource id plus a friendly title.
+5. Build “my people” one person at a time using an email or Chat id; resolve
+   each with `psd-directory` before saving it.
+6. Capture weather location/coordinates and news topics.
+7. Ask whether they want custom sections. Each is
+   `{ "title", "instructions", "sources" }`; no skill fork is needed.
+8. Explain that the podcast is on by default and confirm whether they want to
+   disable it.
+9. Summarize the proposed config, get confirmation, write it, then create the
+   schedule.
+
+Config lives at:
+
+```text
+/home/node/.openclaw/skills/psd-morning-brief/state/config.json
+```
+
+Example:
+
+```json
+{
+  "timezone": "America/Los_Angeles",
+  "retainDays": 30,
+  "enabledSections": [
+    "calendar",
+    "inbox",
+    "chat",
+    "freshservice",
+    "staff_leave",
+    "atrium",
+    "weather",
+    "news"
+  ],
+  "chat": {
+    "spaces": [
+      { "id": "spaces/EXAMPLE", "title": "Leadership team" }
+    ]
+  },
+  "weather": {
+    "label": "Gig Harbor",
+    "latitude": 47.3293,
+    "longitude": -122.5801
+  },
+  "news": {
+    "topics": ["K-12 education", "AI in education"],
+    "days": 7,
+    "limit": 5,
+    "sources": "web,hackernews,arxiv"
+  },
+  "people": [
+    { "email": "colleague@psd401.net", "note": "Direct collaborator" }
+  ],
+  "customSections": [
+    {
+      "title": "Current initiatives",
+      "instructions": "Summarize material changes and decisions needed today.",
+      "sources": ["psd-data", "psd-plaud"]
+    }
+  ],
+  "podcast": {
+    "enabled": true,
+    "voice": "Ruth",
+    "engine": "long-form"
+  }
+}
+```
+
+With no config file, the skill uses safe defaults: every core section is
+enabled but self-omits when unavailable, district-area weather and education
+news topics are used, podcast is enabled, and retention is 30 days.
+
+## Canonical schedule setup
+
+Use a staggered minute derived for the owner; do not put everyone at `:00`.
+For example, `17 6 * * 1-5` means 6:17 AM weekdays.
+
+The schedule prompt must be:
+
+```text
+Create my morning brief using psd-morning-brief’s production three-step
+pipeline. Read the exact owner email from the [caller: ...] header and pass it
+verbatim as --user. First run --data-only. Read its dataFile and
+synthesisRequest. Gather every custom section from its declared sources, then
+write synthesis JSON with cross-section curation, a decision for every inbox
+item, and a complete podcastScript. Run --compose with the returned dataFile
+and your synthesis file. Reply with the command’s deliveryMessage verbatim. If
+any step cannot complete, ensure the failure is self-reported before replying.
+```
+
+Create the schedule through the owner-bound scheduling skill:
+
+```bash
+node /opt/psd-skills/psd-schedules/create.js \
+  --name "Morning brief" \
+  --prompt "<canonical prompt above>" \
+  --cron "17 6 * * 1-5" \
+  --timezone "America/Los_Angeles"
+```
+
+Do not pass a user, owner, DM-space, or workspace-prefix argument to
+`psd-schedules`; it derives all of them from the signed context.
+
+## Section behavior
+
+- Calendar and inbox use the owner’s user-account Workspace slot.
+- Chat highlights use only configured spaces available to the agent account.
+- Freshservice calls the fixed owner-bound broker; provider credentials never
+  enter this process.
+- Staff leave dynamically discovers the caller-visible absence/vacancy table
+  through `psd-data`, inspects its schema, and queries today through server-side
+  row-level security. Optional `staffLeave.table` and
+  `staffLeave.dateColumn` disambiguate unusual warehouse schemas.
+- Atrium uses the server-side `since` filter and absolute list-item URLs.
+- Weather uses Open-Meteo and configured coordinates.
+- News uses `psd-last30days` once per configured topic.
+- Custom sections are gathered during synthesis with whatever skills/MCPs the
+  owner can access.
+
+Every included section renders a clean empty state. An unavailable section is
+omitted instead of rendered as an error.
+
+## Retention and cost
+
+The skill records only artifact ids that it created in the owner’s state
+ledger. On each successful run it permanently deletes its own ledger-tracked
+briefs older than `retainDays` through the owner-bound Atrium delete operation.
+It never searches and deletes by title or by another owner’s content.
+
+Podcast audio uses Polly long-form by default and is public-by-link under the
+same artifact-delivery model as `psd-tts`. Disabling it is a per-owner config
+choice.

--- a/infra/agent-image/skills/psd-morning-brief/newspaper.js
+++ b/infra/agent-image/skills/psd-morning-brief/newspaper.js
@@ -1,0 +1,312 @@
+'use strict';
+
+const DEFAULT_EMPTY_MESSAGES = Object.freeze({
+  calendar: 'Nothing is scheduled for today.',
+  inbox: 'No inbox items need attention.',
+  chat: 'No new highlights were found in the configured spaces.',
+  freshservice: 'No open tickets or pending approvals were found.',
+  staff_leave: 'No staff leave items were returned for today.',
+  atrium: 'No Atrium items changed in the selected window.',
+  weather: 'No weather observations were returned.',
+  news: 'No recent stories were returned for the configured topics.',
+});
+
+function escapeHtml(value) {
+  return String(value ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function safeUrl(value) {
+  if (typeof value !== 'string' || value.length > 4_096) return null;
+  try {
+    const parsed = new URL(value);
+    return parsed.protocol === 'https:' || parsed.protocol === 'http:'
+      ? parsed.toString()
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+function asArray(value) {
+  return Array.isArray(value) ? value : [];
+}
+
+function plainText(value, fallback = '') {
+  if (typeof value === 'string') return value.trim();
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return String(value);
+  }
+  return fallback;
+}
+
+function compactObject(value, depth = 0) {
+  if (depth > 2 || value == null) return '';
+  if (Array.isArray(value)) {
+    return value
+      .slice(0, 5)
+      .map((item) => compactObject(item, depth + 1))
+      .filter(Boolean)
+      .join(' · ');
+  }
+  if (typeof value === 'object') {
+    return Object.entries(value)
+      .slice(0, 8)
+      .map(([key, item]) => {
+        const rendered = compactObject(item, depth + 1);
+        return rendered ? `${key}: ${rendered}` : '';
+      })
+      .filter(Boolean)
+      .join(' · ');
+  }
+  return plainText(value);
+}
+
+function firstText(item, keys, fallback = '') {
+  for (const key of keys) {
+    const value = plainText(item[key]);
+    if (value) return value;
+  }
+  return fallback;
+}
+
+function normalizedItem(item, index) {
+  if (typeof item === 'string') {
+    return { headline: item, body: '', meta: '', url: null };
+  }
+  if (!item || typeof item !== 'object' || Array.isArray(item)) {
+    return {
+      headline: `Item ${index + 1}`,
+      body: plainText(item),
+      meta: '',
+      url: null,
+    };
+  }
+  const headline = firstText(
+    item,
+    ['headline', 'title', 'subject', 'name'],
+    `Item ${index + 1}`,
+  );
+  const body = firstText(item, [
+    'body',
+    'summary',
+    'description',
+    'detail',
+  ]);
+  const meta = firstText(item, ['meta', 'time', 'date', 'updatedAt']);
+  return {
+    headline,
+    body: body || compactObject(item),
+    meta,
+    url: safeUrl(item.url || item.link),
+  };
+}
+
+function synthesisSectionMap(synthesis) {
+  const map = Object.create(null);
+  for (const section of asArray(synthesis && synthesis.sections)) {
+    if (
+      section &&
+      typeof section === 'object' &&
+      typeof section.id === 'string' &&
+      section.id
+    ) {
+      map[section.id] = section;
+    }
+  }
+  return map;
+}
+
+function rawSectionItems(section) {
+  if (section && section.custom === true) return [];
+  const data = section && section.data;
+  if (Array.isArray(data)) return data;
+  if (!data || typeof data !== 'object') return [];
+  for (const key of [
+    'items',
+    'events',
+    'messages',
+    'emails',
+    'tickets',
+    'approvals',
+    'absences',
+    'stories',
+    'results',
+  ]) {
+    if (Array.isArray(data[key])) return data[key];
+  }
+  if (Object.keys(data).length > 0) return [data];
+  return [];
+}
+
+function sectionView(raw, synthesized) {
+  const synthesizedItems = asArray(synthesized && synthesized.items);
+  const rawItems = rawSectionItems(raw);
+  return {
+    id: raw.id,
+    title:
+      plainText(synthesized && synthesized.title) ||
+      plainText(raw.title) ||
+      raw.id,
+    summary: plainText(synthesized && synthesized.summary),
+    items: (synthesizedItems.length > 0 ? synthesizedItems : rawItems)
+      .slice(0, 12)
+      .map(normalizedItem),
+    emptyMessage:
+      plainText(synthesized && synthesized.emptyMessage) ||
+      plainText(raw.emptyMessage) ||
+      DEFAULT_EMPTY_MESSAGES[raw.id] ||
+      'Nothing to report in this section.',
+    custom: raw.custom === true,
+  };
+}
+
+function renderItem(item) {
+  const headline = item.url
+    ? `<a href="${escapeHtml(item.url)}">${escapeHtml(item.headline)}</a>`
+    : escapeHtml(item.headline);
+  return [
+    '<article class="item">',
+    `<h3>${headline}</h3>`,
+    item.meta ? `<p class="meta">${escapeHtml(item.meta)}</p>` : '',
+    item.body ? `<p>${escapeHtml(item.body)}</p>` : '',
+    '</article>',
+  ].join('');
+}
+
+function renderSection(section) {
+  const body =
+    section.items.length > 0
+      ? section.items.map(renderItem).join('')
+      : `<p class="empty">${escapeHtml(section.emptyMessage)}</p>`;
+  return [
+    `<section class="section${section.custom ? ' custom' : ''}" id="${escapeHtml(section.id)}">`,
+    '<div class="section-heading">',
+    `<p class="kicker">${section.custom ? 'Custom desk' : 'Daily desk'}</p>`,
+    `<h2>${escapeHtml(section.title)}</h2>`,
+    '</div>',
+    section.summary ? `<p class="summary">${escapeHtml(section.summary)}</p>` : '',
+    body,
+    '</section>',
+  ].join('');
+}
+
+function renderPeople(people) {
+  const entries = asArray(people).filter(
+    (person) => person && typeof person === 'object',
+  );
+  if (entries.length === 0) return '';
+  return [
+    '<aside class="people"><p class="kicker">My people</p><ul>',
+    ...entries.map((person) => {
+      const name =
+        plainText(person.displayName) ||
+        plainText(person.email) ||
+        plainText(person.chatId) ||
+        'Unresolved person';
+      const detail = [plainText(person.title), plainText(person.department)]
+        .filter(Boolean)
+        .join(' · ');
+      return `<li><strong>${escapeHtml(name)}</strong>${detail ? `<span>${escapeHtml(detail)}</span>` : ''}</li>`;
+    }),
+    '</ul></aside>',
+  ].join('');
+}
+
+function renderPodcast(podcast) {
+  if (!podcast || podcast.enabled === false) return '';
+  const url = safeUrl(podcast.url);
+  if (!url) {
+    return '<aside class="podcast"><p class="kicker">Podcast edition</p><p>Audio was disabled or unavailable for this run.</p></aside>';
+  }
+  return [
+    '<aside class="podcast">',
+    '<p class="kicker">Podcast edition</p>',
+    '<h2>Listen to today’s brief</h2>',
+    `<audio controls preload="none" src="${escapeHtml(url)}">`,
+    `<a href="${escapeHtml(url)}">Download the MP3</a>`,
+    '</audio>',
+    '</aside>',
+  ].join('');
+}
+
+function newspaperView(snapshot, synthesis) {
+  const safeSnapshot =
+    snapshot && typeof snapshot === 'object' ? snapshot : {};
+  const safeSynthesis =
+    synthesis && typeof synthesis === 'object' ? synthesis : {};
+  const synthesized = synthesisSectionMap(safeSynthesis);
+  const lead =
+    safeSynthesis.leadStory &&
+    typeof safeSynthesis.leadStory === 'object'
+      ? safeSynthesis.leadStory
+      : {};
+  const title =
+    plainText(safeSnapshot.title) ||
+    `Morning Brief — ${plainText(safeSnapshot.localDate)}`;
+  return {
+    sections: asArray(safeSnapshot.sections).map((raw) =>
+      sectionView(raw, synthesized[raw.id]),
+    ),
+    leadHeadline:
+      plainText(lead.headline) ||
+      plainText(safeSynthesis.headline) ||
+      'Your day, at a glance',
+    leadSummary:
+      plainText(lead.summary) ||
+      plainText(safeSynthesis.subheadline) ||
+      'A concise morning read assembled from the sources available to you.',
+    title,
+    date: plainText(safeSnapshot.displayDate) || title,
+    generatedAt: plainText(safeSnapshot.generatedAt),
+    people: safeSnapshot.people,
+  };
+}
+
+function renderNewspaper({ snapshot, synthesis, podcast = null }) {
+  const view = newspaperView(snapshot, synthesis);
+
+  return `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>${escapeHtml(view.title)}</title>
+<style>
+:root{--ink:#17202a;--paper:#f8f3e8;--rule:#b79d74;--accent:#7d2131;--muted:#615b52}
+*{box-sizing:border-box}body{margin:0;background:#d9d3c7;color:var(--ink);font-family:Georgia,"Times New Roman",serif;line-height:1.45}
+main{width:min(1120px,calc(100% - 24px));margin:18px auto;background:var(--paper);box-shadow:0 16px 48px #332d2440;padding:clamp(20px,4vw,54px)}
+a{color:var(--accent);text-decoration-thickness:1px;text-underline-offset:3px}
+.masthead{text-align:center;border-block:4px double var(--ink);padding:18px 0 13px}.masthead h1{font-size:clamp(2.35rem,8vw,5.8rem);line-height:.9;margin:0;letter-spacing:-.055em}
+.dateline{display:flex;justify-content:space-between;gap:20px;margin-top:12px;font-size:.78rem;letter-spacing:.12em;text-transform:uppercase}.kicker{font:700 .72rem/1.2 Arial,sans-serif;letter-spacing:.16em;text-transform:uppercase;color:var(--accent);margin:0 0 7px}
+.lead{padding:28px 0;border-bottom:1px solid var(--rule);display:grid;grid-template-columns:minmax(0,2fr) minmax(220px,1fr);gap:30px}.lead h2{font-size:clamp(2rem,5vw,4rem);line-height:1;margin:0 0 14px;letter-spacing:-.035em}.lead p{font-size:1.13rem;margin:0;color:var(--muted)}
+.people,.podcast{border-left:5px solid var(--accent);background:#eee5d4;padding:18px}.people ul{list-style:none;padding:0;margin:0}.people li{padding:8px 0;border-bottom:1px solid #b79d7460}.people li:last-child{border:0}.people span{display:block;color:var(--muted);font-size:.86rem}
+.podcast{margin:24px 0}.podcast h2{margin:0 0 12px}.podcast audio{width:100%}
+.sections{columns:2 340px;column-gap:34px}.section{break-inside:avoid;padding:25px 0;border-bottom:1px solid var(--rule)}.section.custom{border-top:5px solid var(--accent);padding-top:18px}.section-heading h2{font-size:1.9rem;line-height:1.05;margin:0}.summary{font-style:italic;color:var(--muted)}
+.item{padding:13px 0;border-top:1px solid #b79d7460}.item h3{font-size:1.08rem;line-height:1.25;margin:0}.item p{margin:6px 0 0}.meta{font:700 .7rem/1.2 Arial,sans-serif!important;letter-spacing:.06em;text-transform:uppercase;color:var(--muted)}.empty{color:var(--muted);font-style:italic}
+footer{border-top:4px double var(--ink);margin-top:28px;padding-top:13px;text-align:center;font-size:.78rem;color:var(--muted)}
+@media(max-width:720px){main{margin:0;width:100%;padding:20px}.lead{grid-template-columns:1fr}.dateline{display:block}.dateline span{display:block;margin-top:5px}.sections{columns:1}}
+@media print{body{background:white}main{box-shadow:none;margin:0;width:100%}.podcast audio{display:none}}
+</style>
+</head>
+<body><main>
+<header class="masthead"><p class="kicker">Personal daily edition</p><h1>Morning Brief</h1><div class="dateline"><span>${escapeHtml(view.date)}</span><span>Private edition</span></div></header>
+<section class="lead"><div><p class="kicker">Lead story</p><h2>${escapeHtml(view.leadHeadline)}</h2><p>${escapeHtml(view.leadSummary)}</p></div>${renderPeople(view.people)}</section>
+${renderPodcast(podcast)}
+<div class="sections">${view.sections.map(renderSection).join('')}</div>
+<footer>Prepared from sources available to this account${view.generatedAt ? ` · Generated ${escapeHtml(view.generatedAt)}` : ''}</footer>
+</main></body></html>`;
+}
+
+module.exports = {
+  DEFAULT_EMPTY_MESSAGES,
+  compactObject,
+  escapeHtml,
+  renderNewspaper,
+  safeUrl,
+  sectionView,
+};

--- a/infra/agent-image/skills/psd-morning-brief/package.json
+++ b/infra/agent-image/skills/psd-morning-brief/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "psd-morning-brief",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Owner-bound, opt-in daily morning brief pipeline for the PSD agent platform.",
+  "main": "run.js",
+  "scripts": {
+    "test": "bun test"
+  }
+}

--- a/infra/agent-image/skills/psd-morning-brief/run.js
+++ b/infra/agent-image/skills/psd-morning-brief/run.js
@@ -1,0 +1,2373 @@
+#!/usr/bin/env node
+
+'use strict';
+
+const os = require('node:os');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+const { validatedFs } = require('../../../validated-fs.cjs');
+const { requestAgentBroker } = require('../_shared/agent-broker');
+const {
+  DEFAULT_EMPTY_MESSAGES,
+  compactObject,
+  renderNewspaper,
+  safeUrl,
+} = require('./newspaper');
+
+const SKILL_ID = 'psd-morning-brief';
+const SKILLS_DIR = process.env.PSD_SKILLS_DIR || '/opt/psd-skills';
+const VENV_PYTHON =
+  process.env.PSD_VENV_PYTHON || '/opt/agentcore-venv/bin/python3';
+const DEFAULT_OPENCLAW_HOME =
+  process.env.OPENCLAW_HOME || '/home/node/.openclaw';
+const MAX_EXTERNAL_BUFFER = 64 * 1024 * 1024;
+const BRIEF_TAG = 'psd-morning-brief';
+const CORE_SECTION_IDS = Object.freeze([
+  'calendar',
+  'inbox',
+  'chat',
+  'freshservice',
+  'staff_leave',
+  'atrium',
+  'weather',
+  'news',
+]);
+
+const DEFAULT_CONFIG = Object.freeze({
+  timezone: 'America/Los_Angeles',
+  retainDays: 30,
+  enabledSections: CORE_SECTION_IDS,
+  calendar: { maxResults: 30 },
+  inbox: { maxResults: 12, query: 'newer_than:1d -in:spam -in:trash' },
+  chat: { spaces: [], maxResults: 40 },
+  freshservice: { maxTickets: 30 },
+  staffLeave: {},
+  atrium: { sinceHours: 24 },
+  weather: {
+    label: 'Gig Harbor',
+    latitude: 47.3293,
+    longitude: -122.5801,
+  },
+  news: {
+    topics: ['K-12 education', 'artificial intelligence in education'],
+    days: 7,
+    limit: 5,
+    sources: 'web,hackernews,arxiv',
+  },
+  people: [],
+  customSections: [],
+  podcast: { enabled: true, voice: 'Ruth', engine: 'long-form' },
+  leadWeights: {
+    calendar: 4,
+    inbox: 5,
+    chat: 3,
+    freshservice: 5,
+    staff_leave: 4,
+    atrium: 2,
+    weather: 1,
+    news: 2,
+  },
+});
+
+class BriefError extends Error {
+  constructor(message, code = 'brief_failed', phase = 'run') {
+    super(message);
+    this.name = 'BriefError';
+    this.code = code;
+    this.phase = phase;
+  }
+}
+
+class SourceUnavailableError extends Error {
+  constructor(message, source, cause = null) {
+    super(message);
+    this.name = 'SourceUnavailableError';
+    this.source = source;
+    this.cause = cause;
+  }
+}
+
+function emit(value) {
+  process.stdout.write(`${JSON.stringify(value, null, 2)}\n`);
+}
+
+function parseArgs(argv) {
+  const args = Object.create(null);
+  for (let index = 2; index < argv.length; index += 1) {
+    const token = argv[index];
+    if (token === '--help' || token === '-h') {
+      args.help = true;
+      continue;
+    }
+    if (!token.startsWith('--')) {
+      throw new BriefError(
+        `Unexpected positional argument: ${token}`,
+        'bad_args',
+        'arguments',
+      );
+    }
+    const key = token.slice(2).replace(/-/g, '_');
+    const next = argv[index + 1];
+    if (next === undefined || next.startsWith('--')) {
+      args[key] = true;
+    } else {
+      args[key] = next;
+      index += 1;
+    }
+  }
+  return args;
+}
+
+function validateUserEmail(email) {
+  if (typeof email !== 'string' || email.length > 254 || /\s|\//.test(email)) {
+    return false;
+  }
+  const at = email.indexOf('@');
+  if (at <= 0 || at !== email.lastIndexOf('@')) return false;
+  const domain = email.slice(at + 1);
+  return domain.includes('.') && !domain.startsWith('.') && !domain.endsWith('.');
+}
+
+function rejectAuthorityArgs(args) {
+  for (const key of [
+    'owner_email',
+    'user_email',
+    'user_id',
+    'owner_id',
+    'dm_space_name',
+    'workspace_prefix',
+  ]) {
+    if (Object.prototype.hasOwnProperty.call(args, key)) {
+      throw new BriefError(
+        `--${key.replace(/_/g, '-')} is not accepted; owner authority comes from the signed invocation context`,
+        'bad_args',
+        'arguments',
+      );
+    }
+  }
+}
+
+function stateDir() {
+  return (
+    process.env.PSD_MORNING_BRIEF_STATE_DIR ||
+    path.join(
+      DEFAULT_OPENCLAW_HOME,
+      'skills',
+      SKILL_ID,
+      'state',
+    )
+  );
+}
+
+function readJsonFile(filePath, label) {
+  try {
+    return JSON.parse(validatedFs.readFileSync(filePath, 'utf8'));
+  } catch (error) {
+    throw new BriefError(
+      `${label} is not readable JSON: ${error instanceof Error ? error.message : String(error)}`,
+      'bad_args',
+      'input',
+    );
+  }
+}
+
+function asObject(value) {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? value
+    : Object.create(null);
+}
+
+function boundedString(value, fallback, maxLength = 500) {
+  return typeof value === 'string' && value.trim()
+    ? value.trim().slice(0, maxLength)
+    : fallback;
+}
+
+function boundedNumber(value, fallback, min, max) {
+  const parsed = Number(value);
+  return Number.isFinite(parsed)
+    ? Math.max(min, Math.min(max, parsed))
+    : fallback;
+}
+
+function valueOr(value, fallback) {
+  return value || fallback;
+}
+
+function uniqueStrings(value, fallback = [], maxItems = 20, maxLength = 300) {
+  const source = Array.isArray(value) ? value : fallback;
+  return [
+    ...new Set(
+      source
+        .filter((item) => typeof item === 'string')
+        .map((item) => item.trim().slice(0, maxLength))
+        .filter(Boolean),
+    ),
+  ].slice(0, maxItems);
+}
+
+function normalizeSpaces(value) {
+  return (Array.isArray(value) ? value : [])
+    .filter((entry) => entry && typeof entry === 'object')
+    .map((entry) => ({
+      id: boundedString(entry.id || entry.space, '', 200),
+      title: boundedString(entry.title || entry.name, 'Chat space', 200),
+    }))
+    .filter((entry) => /^spaces\/[A-Za-z0-9_-]+$/.test(entry.id))
+    .slice(0, 20);
+}
+
+function customSectionId(entry, index) {
+  const explicit = boundedString(entry.id, '', 80)
+    .toLowerCase()
+    .replace(/[^a-z0-9_-]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+  if (explicit) return `custom-${explicit}`;
+  const title = boundedString(entry.title, `section-${index + 1}`, 80)
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+  return `custom-${title || index + 1}`;
+}
+
+function normalizeCustomSections(value) {
+  const seen = new Set();
+  const normalized = [];
+  for (const [index, raw] of (Array.isArray(value) ? value : []).entries()) {
+    if (!raw || typeof raw !== 'object') continue;
+    const title = boundedString(raw.title, '', 160);
+    const instructions = boundedString(raw.instructions, '', 2_000);
+    const sources = uniqueStrings(raw.sources, [], 12, 300);
+    if (!title || !instructions || sources.length === 0) continue;
+    let id = customSectionId(raw, index);
+    let suffix = 2;
+    while (seen.has(id)) {
+      id = `${customSectionId(raw, index)}-${suffix}`;
+      suffix += 1;
+    }
+    seen.add(id);
+    normalized.push({ id, title, instructions, sources });
+  }
+  return normalized.slice(0, 12);
+}
+
+function normalizePeople(value) {
+  return (Array.isArray(value) ? value : [])
+    .filter((entry) => entry && typeof entry === 'object')
+    .map((entry) => ({
+      email: boundedString(entry.email, '', 254).toLowerCase(),
+      chatId: boundedString(entry.chatId || entry.chat_id, '', 200),
+      note: boundedString(entry.note, '', 500),
+    }))
+    .filter(
+      (entry) =>
+        validateUserEmail(entry.email) ||
+        /^(?:users\/)?\d{6,30}$/.test(entry.chatId),
+    )
+    .slice(0, 50);
+}
+
+function normalizeLeadWeights(value) {
+  const source = asObject(value);
+  const result = Object.create(null);
+  for (const id of CORE_SECTION_IDS) {
+    result[id] = boundedNumber(
+      source[id],
+      DEFAULT_CONFIG.leadWeights[id],
+      0,
+      20,
+    );
+  }
+  return result;
+}
+
+function normalizedEnabledSections(input) {
+  const camelCase = Object.prototype.hasOwnProperty.call(
+    input,
+    'enabledSections',
+  );
+  const hasSetting =
+    camelCase ||
+    Object.prototype.hasOwnProperty.call(input, 'enabled_sections');
+  const enabled = uniqueStrings(
+    camelCase ? input.enabledSections : input.enabled_sections,
+    CORE_SECTION_IDS,
+    CORE_SECTION_IDS.length,
+    80,
+  ).filter((id) => CORE_SECTION_IDS.includes(id));
+  return hasSetting ? enabled : [...CORE_SECTION_IDS];
+}
+
+function normalizeConfig(raw = {}) {
+  const input = asObject(raw);
+  const calendar = asObject(input.calendar);
+  const inbox = asObject(input.inbox);
+  const chat = asObject(input.chat);
+  const freshservice = asObject(input.freshservice);
+  const staffLeave = asObject(input.staffLeave || input.staff_leave);
+  const atrium = asObject(input.atrium);
+  const weather = asObject(input.weather);
+  const news = asObject(input.news);
+  const podcast = asObject(input.podcast);
+
+  return {
+    timezone: boundedString(
+      input.timezone,
+      DEFAULT_CONFIG.timezone,
+      100,
+    ),
+    retainDays: Math.round(
+      boundedNumber(
+        input.retainDays || input.retain_days,
+        DEFAULT_CONFIG.retainDays,
+        1,
+        365,
+      ),
+    ),
+    enabledSections: normalizedEnabledSections(input),
+    calendar: {
+      maxResults: Math.round(
+        boundedNumber(
+          calendar.maxResults || calendar.max_results,
+          DEFAULT_CONFIG.calendar.maxResults,
+          1,
+          100,
+        ),
+      ),
+    },
+    inbox: {
+      maxResults: Math.round(
+        boundedNumber(
+          inbox.maxResults || inbox.max_results,
+          DEFAULT_CONFIG.inbox.maxResults,
+          1,
+          50,
+        ),
+      ),
+      query: boundedString(
+        inbox.query,
+        DEFAULT_CONFIG.inbox.query,
+        500,
+      ),
+    },
+    chat: {
+      spaces: normalizeSpaces(chat.spaces),
+      maxResults: Math.round(
+        boundedNumber(
+          chat.maxResults || chat.max_results,
+          DEFAULT_CONFIG.chat.maxResults,
+          1,
+          100,
+        ),
+      ),
+    },
+    freshservice: {
+      maxTickets: Math.round(
+        boundedNumber(
+          freshservice.maxTickets || freshservice.max_tickets,
+          DEFAULT_CONFIG.freshservice.maxTickets,
+          1,
+          100,
+        ),
+      ),
+    },
+    staffLeave: {
+      table: boundedString(staffLeave.table, '', 200),
+      dateColumn: boundedString(
+        staffLeave.dateColumn || staffLeave.date_column,
+        '',
+        200,
+      ),
+    },
+    atrium: {
+      sinceHours: boundedNumber(
+        atrium.sinceHours || atrium.since_hours,
+        DEFAULT_CONFIG.atrium.sinceHours,
+        1,
+        720,
+      ),
+    },
+    weather: {
+      label: boundedString(
+        weather.label,
+        DEFAULT_CONFIG.weather.label,
+        160,
+      ),
+      latitude: boundedNumber(
+        weather.latitude,
+        DEFAULT_CONFIG.weather.latitude,
+        -90,
+        90,
+      ),
+      longitude: boundedNumber(
+        weather.longitude,
+        DEFAULT_CONFIG.weather.longitude,
+        -180,
+        180,
+      ),
+    },
+    news: {
+      topics: uniqueStrings(
+        news.topics,
+        DEFAULT_CONFIG.news.topics,
+        5,
+        300,
+      ),
+      days: Math.round(
+        boundedNumber(news.days, DEFAULT_CONFIG.news.days, 1, 30),
+      ),
+      limit: Math.round(
+        boundedNumber(news.limit, DEFAULT_CONFIG.news.limit, 1, 10),
+      ),
+      sources: boundedString(
+        news.sources,
+        DEFAULT_CONFIG.news.sources,
+        200,
+      ),
+    },
+    people: normalizePeople(input.people),
+    customSections: normalizeCustomSections(
+      input.customSections || input.custom_sections,
+    ),
+    podcast: {
+      enabled: podcast.enabled !== false,
+      voice: boundedString(
+        podcast.voice,
+        DEFAULT_CONFIG.podcast.voice,
+        80,
+      ),
+      engine: ['generative', 'neural', 'long-form', 'standard'].includes(
+        podcast.engine,
+      )
+        ? podcast.engine
+        : DEFAULT_CONFIG.podcast.engine,
+    },
+    leadWeights: normalizeLeadWeights(
+      input.leadWeights || input.lead_weights,
+    ),
+  };
+}
+
+function loadConfig(configPath = path.join(stateDir(), 'config.json')) {
+  if (!validatedFs.existsSync(configPath)) {
+    return { config: normalizeConfig(), configPath, usedDefaults: true };
+  }
+  return {
+    config: normalizeConfig(readJsonFile(configPath, 'config.json')),
+    configPath,
+    usedDefaults: false,
+  };
+}
+
+function localDateParts(now, timezone) {
+  let formatter;
+  try {
+    formatter = new Intl.DateTimeFormat('en-CA', {
+      timeZone: timezone,
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+    });
+  } catch {
+    throw new BriefError(
+      `Invalid IANA timezone in config: ${timezone}`,
+      'bad_config',
+      'config',
+    );
+  }
+  const values = Object.fromEntries(
+    formatter.formatToParts(now).map((part) => [part.type, part.value]),
+  );
+  const localDate = `${values.year}-${values.month}-${values.day}`;
+  const displayDate = new Intl.DateTimeFormat('en-US', {
+    timeZone: timezone,
+    weekday: 'long',
+    month: 'long',
+    day: 'numeric',
+    year: 'numeric',
+  }).format(now);
+  return { localDate, displayDate };
+}
+
+function zonedDateTimeIso(parts, timezone) {
+  const target = Date.UTC(
+    parts.year,
+    parts.month - 1,
+    parts.day,
+    parts.hour || 0,
+    parts.minute || 0,
+    parts.second || 0,
+  );
+  const formatter = new Intl.DateTimeFormat('en-CA', {
+    timeZone: timezone,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    hourCycle: 'h23',
+  });
+  let candidate = target;
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    const values = Object.fromEntries(
+      formatter
+        .formatToParts(new Date(candidate))
+        .map((part) => [part.type, part.value]),
+    );
+    const represented = Date.UTC(
+      Number(values.year),
+      Number(values.month) - 1,
+      Number(values.day),
+      Number(values.hour),
+      Number(values.minute),
+      Number(values.second),
+    );
+    const correction = target - represented;
+    candidate += correction;
+    if (correction === 0) break;
+  }
+  return new Date(candidate).toISOString();
+}
+
+function dayWindow(localDate, timezone) {
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(localDate);
+  if (!match) {
+    throw new BriefError(
+      `Invalid local date: ${localDate}`,
+      'bad_config',
+      'config',
+    );
+  }
+  const start = {
+    year: Number(match[1]),
+    month: Number(match[2]),
+    day: Number(match[3]),
+  };
+  const startDate = new Date(
+    Date.UTC(start.year, start.month - 1, start.day),
+  );
+  if (
+    startDate.getUTCFullYear() !== start.year ||
+    startDate.getUTCMonth() !== start.month - 1 ||
+    startDate.getUTCDate() !== start.day
+  ) {
+    throw new BriefError(
+      `Invalid local date: ${localDate}`,
+      'bad_config',
+      'config',
+    );
+  }
+  const nextDate = new Date(startDate.getTime() + 24 * 60 * 60 * 1_000);
+  const next = {
+    year: nextDate.getUTCFullYear(),
+    month: nextDate.getUTCMonth() + 1,
+    day: nextDate.getUTCDate(),
+  };
+  return {
+    timeMin: zonedDateTimeIso(start, timezone),
+    timeMax: zonedDateTimeIso(next, timezone),
+  };
+}
+
+function lastJson(stdout) {
+  const text = String(stdout || '').trim();
+  if (!text) return null;
+  try {
+    return JSON.parse(text);
+  } catch {
+    const lines = text.split('\n');
+    for (let index = 0; index < lines.length; index += 1) {
+      const suffix = lines.slice(index).join('\n').trim();
+      if (!suffix || !['{', '['].includes(suffix[0])) continue;
+      try {
+        return JSON.parse(suffix);
+      } catch {
+        // Try the next suffix.
+      }
+    }
+  }
+  return null;
+}
+
+function defaultRunExternal(spec) {
+  const entries = {
+    'freshservice-tickets': {
+      command: 'node',
+      base: [
+        path.join(
+          SKILLS_DIR,
+          'psd-freshservice',
+          'list_tickets.js',
+        ),
+      ],
+    },
+    'freshservice-approvals': {
+      command: 'node',
+      base: [
+        path.join(
+          SKILLS_DIR,
+          'psd-freshservice',
+          'get_approvals.js',
+        ),
+      ],
+    },
+    'psd-data': {
+      command: 'node',
+      base: [path.join(SKILLS_DIR, 'psd-data', 'run.js')],
+    },
+    news: {
+      command: VENV_PYTHON,
+      base: [
+        path.join(
+          SKILLS_DIR,
+          'psd-last30days',
+          'scripts',
+          'last30days.py',
+        ),
+      ],
+    },
+    tts: {
+      command: VENV_PYTHON,
+      base: [
+        path.join(
+          SKILLS_DIR,
+          'psd-tts',
+          'scripts',
+          'synthesize.py',
+        ),
+      ],
+    },
+  };
+  const entry = entries[spec.skill];
+  if (!entry) {
+    throw new BriefError(
+      `Unknown external skill: ${spec.skill}`,
+      'internal_error',
+      'external',
+    );
+  }
+  const result = spawnSync(entry.command, [...entry.base, ...spec.args], {
+    input: spec.input,
+    encoding: 'utf8',
+    maxBuffer: MAX_EXTERNAL_BUFFER,
+    timeout: spec.timeoutMs || 120_000,
+  });
+  return {
+    code: result.status == null ? 1 : result.status,
+    stdout: result.stdout || '',
+    stderr: result.stderr || (result.error ? result.error.message : ''),
+  };
+}
+
+function externalJson(runExternal, spec, source) {
+  const result = runExternal(spec);
+  const parsed = lastJson(result.stdout);
+  if (result.code !== 0) {
+    const detail =
+      compactObject(parsed) ||
+      String(result.stderr || '').trim().slice(0, 1_000) ||
+      `${source} exited ${result.code}`;
+    throw new SourceUnavailableError(detail, source);
+  }
+  if (parsed === null) {
+    throw new SourceUnavailableError(
+      `${source} returned non-JSON output`,
+      source,
+    );
+  }
+  return parsed;
+}
+
+function unwrapAtrium(result) {
+  const status = Number(result && result.httpStatus);
+  const payload = result && result.payload;
+  if (status < 200 || status >= 300) {
+    const message =
+      payload && payload.error && payload.error.message
+        ? payload.error.message
+        : `Atrium returned HTTP ${status || 'unknown'}`;
+    const error = new SourceUnavailableError(message, 'psd-atrium');
+    error.status = status;
+    error.responseBody = payload;
+    throw error;
+  }
+  return payload && payload.data !== undefined ? payload.data : payload;
+}
+
+function isUnavailableError(error) {
+  if (error instanceof SourceUnavailableError) return true;
+  const status = Number(error && error.status);
+  const responseStatus =
+    error &&
+    error.responseBody &&
+    typeof error.responseBody.status === 'string'
+      ? error.responseBody.status
+      : '';
+  return (
+    [401, 403, 404, 409].includes(status) ||
+    /auth|forbidden|permission|provision|credential|scope/i.test(
+      `${responseStatus} ${error && error.message ? error.message : ''}`,
+    )
+  );
+}
+
+function parseWorkspaceStdout(result, source) {
+  const parsed = lastJson(result && result.stdout);
+  if (parsed === null) {
+    throw new SourceUnavailableError(
+      `${source} returned non-JSON output`,
+      source,
+    );
+  }
+  return parsed;
+}
+
+async function workspaceJson(broker, scope, argv, source) {
+  try {
+    const result = await broker('/api/agent/workspace-execute', {
+      scope,
+      argv,
+    });
+    return parseWorkspaceStdout(result, source);
+  } catch (error) {
+    throw new SourceUnavailableError(
+      error instanceof Error ? error.message : String(error),
+      source,
+      error,
+    );
+  }
+}
+
+function headerValue(message, name) {
+  const headers =
+    message &&
+    message.payload &&
+    Array.isArray(message.payload.headers)
+      ? message.payload.headers
+      : [];
+  const found = headers.find(
+    (header) =>
+      header &&
+      typeof header.name === 'string' &&
+      header.name.toLowerCase() === name.toLowerCase(),
+  );
+  return found && typeof found.value === 'string' ? found.value : '';
+}
+
+function calendarAdapter() {
+  return {
+    id: 'calendar',
+    title: "Today's calendar",
+    async available() {
+      return true;
+    },
+    async fetch(context) {
+      const window = dayWindow(
+        context.localDate,
+        context.config.timezone,
+      );
+      const result = await workspaceJson(
+        context.broker,
+        'user',
+        [
+          'calendar',
+          'events',
+          'list',
+          '--params',
+          JSON.stringify({
+            calendarId: 'primary',
+            timeMin: window.timeMin,
+            timeMax: window.timeMax,
+            singleEvents: true,
+            orderBy: 'startTime',
+            maxResults: context.config.calendar.maxResults,
+          }),
+        ],
+        'psd-workspace calendar',
+      );
+      const events = Array.isArray(result.items) ? result.items : [];
+      return {
+        events: events.map((event) => ({
+          title: boundedString(event.summary, 'Untitled event', 500),
+          start:
+            event.start && (event.start.dateTime || event.start.date)
+              ? event.start.dateTime || event.start.date
+              : '',
+          end:
+            event.end && (event.end.dateTime || event.end.date)
+              ? event.end.dateTime || event.end.date
+              : '',
+          location: boundedString(event.location, '', 500),
+          url: safeUrl(event.htmlLink),
+        })),
+      };
+    },
+  };
+}
+
+function inboxAdapter() {
+  return {
+    id: 'inbox',
+    title: 'Inbox triage',
+    async available() {
+      return true;
+    },
+    async fetch(context) {
+      const result = await workspaceJson(
+        context.broker,
+        'user',
+        [
+          'gmail',
+          'users',
+          'messages',
+          'list',
+          '--params',
+          JSON.stringify({
+            userId: 'me',
+            q: context.config.inbox.query,
+            maxResults: context.config.inbox.maxResults,
+          }),
+        ],
+        'psd-workspace inbox',
+      );
+      const refs = Array.isArray(result.messages) ? result.messages : [];
+      const emails = [];
+      for (let index = 0; index < refs.length; index += 4) {
+        const batch = refs.slice(index, index + 4);
+        const resolved = await Promise.all(
+          batch.map((ref) =>
+            workspaceJson(
+              context.broker,
+              'user',
+              [
+                'gmail',
+                'users',
+                'messages',
+                'get',
+                '--params',
+                JSON.stringify({
+                  userId: 'me',
+                  id: ref.id,
+                  format: 'metadata',
+                  metadataHeaders: ['From', 'Subject', 'Date'],
+                }),
+              ],
+              'psd-workspace inbox item',
+            ),
+          ),
+        );
+        for (const message of resolved) {
+          emails.push({
+            id: boundedString(message.id, '', 200),
+            threadId: boundedString(message.threadId, '', 200),
+            from: headerValue(message, 'From'),
+            subject: headerValue(message, 'Subject') || '(no subject)',
+            date: headerValue(message, 'Date'),
+            snippet: boundedString(message.snippet, '', 1_000),
+            labelIds: uniqueStrings(message.labelIds, [], 30, 100),
+          });
+        }
+      }
+      return { emails };
+    },
+  };
+}
+
+function chatAdapter() {
+  return {
+    id: 'chat',
+    title: 'Chat-space highlights',
+    async available(context) {
+      return context.config.chat.spaces.length > 0;
+    },
+    async fetch(context) {
+      const spaces = [];
+      for (const configured of context.config.chat.spaces) {
+        const result = await workspaceJson(
+          context.broker,
+          'agent',
+          [
+            'chat',
+            'spaces',
+            'messages',
+            'list',
+            '--params',
+            JSON.stringify({
+              parent: configured.id,
+              pageSize: context.config.chat.maxResults,
+              orderBy: 'createTime desc',
+            }),
+          ],
+          'psd-workspace chat',
+        );
+        spaces.push({
+          id: configured.id,
+          title: configured.title,
+          messages: (Array.isArray(result.messages) ? result.messages : []).map(
+            (message) => ({
+              text: boundedString(message.text, '', 2_000),
+              createTime: boundedString(message.createTime, '', 100),
+              senderChatId: boundedString(
+                message.sender && message.sender.name,
+                '',
+                200,
+              ),
+            }),
+          ),
+        });
+      }
+      return {
+        spaces,
+        messages: spaces.flatMap((space) =>
+          space.messages.map((message) => ({
+            ...message,
+            space: space.title,
+          })),
+        ),
+      };
+    },
+  };
+}
+
+function freshserviceAdapter() {
+  return {
+    id: 'freshservice',
+    title: 'Freshservice tickets & approvals',
+    async available(context) {
+      return validateUserEmail(context.user);
+    },
+    async fetch(context) {
+      const options = {
+        filter: 'new_and_my_open',
+        per_page: context.config.freshservice.maxTickets,
+        order_type: 'desc',
+      };
+      const tickets = externalJson(
+        context.runExternal,
+        {
+          skill: 'freshservice-tickets',
+          args: [
+            '--user',
+            context.user,
+            '--options',
+            JSON.stringify(options),
+          ],
+        },
+        'psd-freshservice tickets',
+      );
+      const approvals = externalJson(
+        context.runExternal,
+        {
+          skill: 'freshservice-approvals',
+          args: ['--user', context.user, '--status', 'requested'],
+        },
+        'psd-freshservice approvals',
+      );
+      return {
+        tickets: Array.isArray(tickets.tickets) ? tickets.tickets : [],
+        approvals: Array.isArray(approvals.approvals)
+          ? approvals.approvals
+          : [],
+      };
+    },
+  };
+}
+
+function recursivelyParseJson(value) {
+  if (typeof value !== 'string') return value;
+  const trimmed = value.trim();
+  if (!trimmed || !['{', '['].includes(trimmed[0])) return value;
+  try {
+    return JSON.parse(trimmed);
+  } catch {
+    return value;
+  }
+}
+
+function collectStructuredStrings(value, output = []) {
+  const parsed = recursivelyParseJson(value);
+  if (typeof parsed === 'string') {
+    output.push(parsed);
+    return output;
+  }
+  if (Array.isArray(parsed)) {
+    for (const item of parsed) collectStructuredStrings(item, output);
+    return output;
+  }
+  if (parsed && typeof parsed === 'object') {
+    for (const [key, item] of Object.entries(parsed)) {
+      output.push(key);
+      collectStructuredStrings(item, output);
+    }
+  }
+  return output;
+}
+
+function sqlIdentifier(value) {
+  const raw = boundedString(value, '', 200);
+  if (
+    !raw ||
+    !raw
+      .split('.')
+      .every((part) => /^[A-Za-z_][A-Za-z0-9_$]*$/.test(part))
+  ) {
+    return null;
+  }
+  return raw
+    .split('.')
+    .map((part) => `"${part}"`)
+    .join('.');
+}
+
+function findWarehouseTable(catalog, configured) {
+  if (sqlIdentifier(configured)) return configured;
+  return (
+    collectStructuredStrings(catalog).find(
+      (value) =>
+        /absence|vacanc|red.?rover|staff.?leave/i.test(value) &&
+        sqlIdentifier(value),
+    ) || null
+  );
+}
+
+function findDateColumn(schema, configured) {
+  if (sqlIdentifier(configured)) return configured;
+  const candidates = collectStructuredStrings(schema).filter(sqlIdentifier);
+  return (
+    candidates.find((value) =>
+      /^(absence_?date|start_?date|start_?time|date)$/i.test(value),
+    ) ||
+    candidates.find((value) => /date|start/i.test(value)) ||
+    null
+  );
+}
+
+function findLargestObjectArray(value, best = []) {
+  const parsed = recursivelyParseJson(value);
+  if (Array.isArray(parsed)) {
+    const objects = parsed.filter(
+      (item) => item && typeof item === 'object' && !Array.isArray(item),
+    );
+    let winner = objects.length > best.length ? objects : best;
+    for (const item of parsed) {
+      winner = findLargestObjectArray(item, winner);
+    }
+    return winner;
+  }
+  if (parsed && typeof parsed === 'object') {
+    let winner = best;
+    for (const item of Object.values(parsed)) {
+      winner = findLargestObjectArray(item, winner);
+    }
+    return winner;
+  }
+  return best;
+}
+
+function staffLeaveAdapter() {
+  return {
+    id: 'staff_leave',
+    title: 'Staff leave',
+    async available() {
+      return true;
+    },
+    async fetch(context) {
+      const catalog = externalJson(
+        context.runExternal,
+        {
+          skill: 'psd-data',
+          args: ['tables', '--detailed'],
+          timeoutMs: 60_000,
+        },
+        'psd-data table discovery',
+      );
+      const table = findWarehouseTable(
+        catalog,
+        context.config.staffLeave.table,
+      );
+      if (!table) {
+        return {
+          records: [],
+          note:
+            'No accessible warehouse table describing absences or vacancies was discovered.',
+        };
+      }
+      const schema = externalJson(
+        context.runExternal,
+        {
+          skill: 'psd-data',
+          args: ['schema', '--table', JSON.stringify([table])],
+          timeoutMs: 60_000,
+        },
+        'psd-data absence schema',
+      );
+      const dateColumn = findDateColumn(
+        schema,
+        context.config.staffLeave.dateColumn,
+      );
+      const tableSql = sqlIdentifier(table);
+      const dateSql = sqlIdentifier(dateColumn);
+      if (!tableSql || !dateSql) {
+        return {
+          table,
+          records: [],
+          note:
+            'The absence table is accessible, but no safe date column could be inferred. Configure staffLeave.dateColumn.',
+        };
+      }
+      const sql =
+        `SELECT * FROM ${tableSql} ` +
+        `WHERE CAST(${dateSql} AS DATE) = '${context.localDate}' ` +
+        `ORDER BY ${dateSql} LIMIT 100`;
+      const queried = externalJson(
+        context.runExternal,
+        {
+          skill: 'psd-data',
+          args: [
+            'query',
+            '--reason',
+            `Daily staff leave section for ${context.localDate}`,
+            '--sql',
+            sql,
+            '--limit',
+            '100',
+          ],
+          timeoutMs: 90_000,
+        },
+        'psd-data staff leave query',
+      );
+      return {
+        table,
+        dateColumn,
+        records: findLargestObjectArray(queried).slice(0, 100),
+      };
+    },
+  };
+}
+
+function atriumAdapter() {
+  return {
+    id: 'atrium',
+    title: 'Atrium digest',
+    async available() {
+      return true;
+    },
+    async fetch(context) {
+      const since = new Date(
+        context.now.getTime() -
+          context.config.atrium.sinceHours * 60 * 60 * 1_000,
+      ).toISOString();
+      let result;
+      try {
+        result = await context.broker('/api/agent/atrium', {
+          method: 'GET',
+          path: '',
+          query: { since },
+        });
+      } catch (error) {
+        throw new SourceUnavailableError(
+          error instanceof Error ? error.message : String(error),
+          'psd-atrium',
+          error,
+        );
+      }
+      const items = unwrapAtrium(result);
+      return {
+        since,
+        items: (Array.isArray(items) ? items : []).map((item) => ({
+          id: item.id,
+          title: boundedString(item.title, 'Untitled', 500),
+          kind: boundedString(item.kind, '', 40),
+          status: boundedString(item.status, '', 40),
+          updatedAt: boundedString(item.updatedAt, '', 100),
+          url: safeUrl(item.url),
+        })),
+      };
+    },
+  };
+}
+
+function weatherCodeLabel(code) {
+  const labels = {
+    0: 'Clear',
+    1: 'Mostly clear',
+    2: 'Partly cloudy',
+    3: 'Overcast',
+    45: 'Fog',
+    48: 'Freezing fog',
+    51: 'Light drizzle',
+    53: 'Drizzle',
+    55: 'Heavy drizzle',
+    61: 'Light rain',
+    63: 'Rain',
+    65: 'Heavy rain',
+    71: 'Light snow',
+    73: 'Snow',
+    75: 'Heavy snow',
+    80: 'Rain showers',
+    81: 'Rain showers',
+    82: 'Heavy showers',
+    95: 'Thunderstorms',
+  };
+  return labels[code] || `Weather code ${code}`;
+}
+
+function weatherAdapter() {
+  return {
+    id: 'weather',
+    title: 'Weather',
+    async available(context) {
+      return (
+        Number.isFinite(context.config.weather.latitude) &&
+        Number.isFinite(context.config.weather.longitude)
+      );
+    },
+    async fetch(context) {
+      const params = new URLSearchParams({
+        latitude: String(context.config.weather.latitude),
+        longitude: String(context.config.weather.longitude),
+        timezone: context.config.timezone,
+        forecast_days: '1',
+        current:
+          'temperature_2m,apparent_temperature,precipitation,weather_code,wind_speed_10m',
+        daily:
+          'temperature_2m_max,temperature_2m_min,precipitation_probability_max,weather_code',
+      });
+      let response;
+      try {
+        response = await context.fetch(
+          `https://api.open-meteo.com/v1/forecast?${params.toString()}`,
+          { signal: AbortSignal.timeout(15_000) },
+        );
+      } catch (error) {
+        throw new SourceUnavailableError(
+          `Open-Meteo request failed: ${error instanceof Error ? error.message : String(error)}`,
+          'weather',
+          error,
+        );
+      }
+      if (!response.ok) {
+        throw new SourceUnavailableError(
+          `Open-Meteo returned HTTP ${response.status}`,
+          'weather',
+        );
+      }
+      const data = await response.json();
+      const current = asObject(data.current);
+      const daily = asObject(data.daily);
+      return {
+        location: context.config.weather.label,
+        condition: weatherCodeLabel(
+          Number(current.weather_code ?? daily.weather_code?.[0]),
+        ),
+        temperature: current.temperature_2m,
+        apparentTemperature: current.apparent_temperature,
+        precipitation: current.precipitation,
+        windSpeed: current.wind_speed_10m,
+        high: Array.isArray(daily.temperature_2m_max)
+          ? daily.temperature_2m_max[0]
+          : null,
+        low: Array.isArray(daily.temperature_2m_min)
+          ? daily.temperature_2m_min[0]
+          : null,
+        precipitationProbability: Array.isArray(
+          daily.precipitation_probability_max,
+        )
+          ? daily.precipitation_probability_max[0]
+          : null,
+        units: data.current_units || {},
+      };
+    },
+  };
+}
+
+function newsAdapter() {
+  return {
+    id: 'news',
+    title: 'News & emerging topics',
+    async available(context) {
+      return context.config.news.topics.length > 0;
+    },
+    async fetch(context) {
+      const topics = [];
+      for (const topic of context.config.news.topics) {
+        try {
+          const result = externalJson(
+            context.runExternal,
+            {
+              skill: 'news',
+              args: [
+                '--topic',
+                topic,
+                '--format',
+                'md',
+                '--days',
+                String(context.config.news.days),
+                '--limit',
+                String(context.config.news.limit),
+                '--sources',
+                context.config.news.sources,
+              ],
+              timeoutMs: 90_000,
+            },
+            'psd-last30days',
+          );
+          topics.push({
+            topic,
+            totalItems: result.total_items || 0,
+            counts: result.counts || {},
+            warnings: Array.isArray(result.warnings) ? result.warnings : [],
+            sourceBrief: boundedString(
+              result.brief_markdown,
+              '',
+              20_000,
+            ),
+          });
+        } catch (error) {
+          topics.push({
+            topic,
+            totalItems: 0,
+            warnings: [
+              error instanceof Error ? error.message : String(error),
+            ],
+            sourceBrief: '',
+          });
+        }
+      }
+      if (topics.every((topic) => !topic.sourceBrief)) {
+        throw new SourceUnavailableError(
+          'No configured news topic returned source material',
+          'psd-last30days',
+        );
+      }
+      return { topics };
+    },
+  };
+}
+
+function createSectionRegistry() {
+  return [
+    calendarAdapter(),
+    inboxAdapter(),
+    chatAdapter(),
+    freshserviceAdapter(),
+    staffLeaveAdapter(),
+    atriumAdapter(),
+    weatherAdapter(),
+    newsAdapter(),
+  ];
+}
+
+function sectionHasItems(id, data) {
+  const object = asObject(data);
+  const keysBySection = {
+    calendar: ['events'],
+    inbox: ['emails'],
+    chat: ['messages'],
+    freshservice: ['tickets', 'approvals'],
+    staff_leave: ['records'],
+    atrium: ['items'],
+    news: ['topics'],
+  };
+  const keys = keysBySection[id] || [];
+  if (keys.some((key) => Array.isArray(object[key]) && object[key].length > 0)) {
+    return true;
+  }
+  if (id === 'weather') {
+    return Boolean(object.condition || object.temperature !== undefined);
+  }
+  return false;
+}
+
+async function resolvePeople(context) {
+  const results = [];
+  for (const person of context.config.people) {
+    const payload = person.email
+      ? { email: person.email }
+      : { chatId: person.chatId };
+    try {
+      const resolved = await context.broker(
+        '/api/agent/directory-lookup',
+        payload,
+      );
+      results.push({
+        ...resolved,
+        note: person.note,
+        query: person.email || person.chatId,
+      });
+    } catch (error) {
+      results.push({
+        found: false,
+        email: person.email || undefined,
+        chatId: person.chatId || undefined,
+        note: person.note,
+        reason:
+          error instanceof Error
+            ? `Directory lookup unavailable: ${error.message}`
+            : 'Directory lookup unavailable',
+      });
+    }
+  }
+  return results;
+}
+
+function customSnapshotSections(config) {
+  return config.customSections.map((section) => ({
+    id: section.id,
+    title: section.title,
+    custom: true,
+    status: 'awaiting-synthesis',
+    emptyMessage: 'No material was gathered for this custom section.',
+    data: {
+      instructions: section.instructions,
+      sources: section.sources,
+    },
+  }));
+}
+
+async function gatherCoreSection(adapter, context) {
+  let available;
+  try {
+    available = await adapter.available(context);
+  } catch (error) {
+    return {
+      omitted: {
+        id: adapter.id,
+        reason:
+          error instanceof Error
+            ? `availability check failed: ${error.message}`
+            : 'availability check failed',
+      },
+    };
+  }
+  if (!available) {
+    return {
+      omitted: {
+        id: adapter.id,
+        reason: 'source not configured or not available to this user',
+      },
+    };
+  }
+  try {
+    const data = await adapter.fetch(context);
+    return {
+      section: {
+        id: adapter.id,
+        title: adapter.title,
+        custom: false,
+        status: sectionHasItems(adapter.id, data) ? 'ok' : 'empty',
+        emptyMessage: DEFAULT_EMPTY_MESSAGES[adapter.id],
+        data,
+      },
+    };
+  } catch (error) {
+    if (!isUnavailableError(error)) throw error;
+    return {
+      omitted: {
+        id: adapter.id,
+        reason:
+          error instanceof Error
+            ? `source unavailable: ${error.message}`
+            : 'source unavailable',
+      },
+    };
+  }
+}
+
+async function gatherSnapshot(options = {}, deps = {}) {
+  const now = valueOr(options.now, new Date());
+  const config = valueOr(options.config, normalizeConfig());
+  const broker = valueOr(deps.broker, requestAgentBroker);
+  const context = {
+    user: options.user,
+    config,
+    now,
+    ...localDateParts(now, config.timezone),
+    broker,
+    runExternal: valueOr(deps.runExternal, defaultRunExternal),
+    fetch: valueOr(deps.fetch, globalThis.fetch),
+  };
+  const sections = [];
+  const omittedSections = [];
+  const registry = valueOr(deps.registry, createSectionRegistry());
+  const enabledAdapters = [];
+  for (const adapter of registry) {
+    if (!config.enabledSections.includes(adapter.id)) {
+      omittedSections.push({ id: adapter.id, reason: 'disabled in config' });
+      continue;
+    }
+    enabledAdapters.push(adapter);
+  }
+  const gathered = await Promise.all(
+    enabledAdapters.map((adapter) =>
+      gatherCoreSection(adapter, context),
+    ),
+  );
+  for (const result of gathered) {
+    if (result.section) sections.push(result.section);
+    if (result.omitted) omittedSections.push(result.omitted);
+  }
+  const custom = customSnapshotSections(config);
+  if (sections.length === 0 && custom.length === 0) {
+    throw new BriefError(
+      'No enabled morning-brief section is available for this user',
+      'no_sources',
+      'data',
+    );
+  }
+  const date = localDateParts(now, config.timezone);
+  return {
+    schemaVersion: 1,
+    generatedAt: now.toISOString(),
+    localDate: date.localDate,
+    displayDate: date.displayDate,
+    timezone: config.timezone,
+    title: `Morning Brief — ${date.localDate}`,
+    people: await resolvePeople(context),
+    sections: [...sections, ...custom],
+    omittedSections,
+  };
+}
+
+function makeSynthesisRequest(snapshot) {
+  const sections = snapshot.sections.map((section) => ({
+    id: section.id,
+    title: section.title,
+    custom: section.custom === true,
+    status: section.status,
+    ...(section.custom
+      ? {
+          instructions: section.data.instructions,
+          sources: section.data.sources,
+        }
+      : {
+          dataPath: `sections[id=${section.id}].data`,
+        }),
+  }));
+  return {
+    task:
+      'Read the data snapshot, gather every custom section from its listed sources, and write the synthesis JSON. Cross-connect related topics, curate rather than dump, make an explicit decision for every inbox item, and write a complete spoken podcast script.',
+    dataFile: null,
+    availableSections: sections,
+    outputShape: {
+      headline: 'string',
+      subheadline: 'string',
+      leadStory: {
+        sectionId: 'one available section id',
+        headline: 'string',
+        summary: 'string',
+      },
+      sections: [
+        {
+          id: 'available section id',
+          title: 'string',
+          summary: 'string',
+          emptyMessage: 'string when no data',
+          items: [
+            {
+              headline: 'string',
+              body: 'string',
+              meta: 'string',
+              url: 'optional absolute URL',
+            },
+          ],
+        },
+      ],
+      inboxDecisions: [
+        {
+          messageId: 'snapshot inbox message id',
+          decision: 'act-now | review | defer | archive',
+          rationale: 'string',
+        },
+      ],
+      podcastScript: 'complete natural-language narration for the full edition',
+    },
+    rules: [
+      'Use only section ids in availableSections; unavailable core sections were deliberately omitted.',
+      'Custom sections are first-class: gather their sources and include them in sections.',
+      'Do not infer a person name from an email or Chat id; use only directory-resolved names in snapshot.people.',
+      'Keep URLs exactly as supplied by sources.',
+      'Return JSON only.',
+    ],
+  };
+}
+
+function writeSnapshot(snapshot, request, outputDir) {
+  const directory = outputDir
+    ? path.resolve(outputDir)
+    : validatedFs.mkdtempSync(
+        path.join(os.tmpdir(), 'psd-morning-brief-'),
+      );
+  validatedFs.mkdirSync(directory, { recursive: true, mode: 0o700 });
+  const dataFile = path.join(directory, 'data.json');
+  validatedFs.writeFileSync(
+    dataFile,
+    `${JSON.stringify(snapshot, null, 2)}\n`,
+    {
+      encoding: 'utf8',
+      mode: 0o600,
+    },
+  );
+  return {
+    dataFile,
+    synthesisRequest: { ...request, dataFile },
+  };
+}
+
+function extractSectionItems(section) {
+  const data = asObject(section.data);
+  for (const key of [
+    'events',
+    'emails',
+    'messages',
+    'tickets',
+    'approvals',
+    'records',
+    'items',
+    'topics',
+  ]) {
+    if (Array.isArray(data[key])) return data[key];
+  }
+  return Object.keys(data).length > 0 ? [data] : [];
+}
+
+function urgencyScore(value) {
+  const text = compactObject(value).toLowerCase();
+  const matches = text.match(
+    /\b(urgent|overdue|unfilled|approval|deadline|critical|action required|high priority)\b/g,
+  );
+  return matches ? Math.min(12, matches.length * 2) : 0;
+}
+
+function computeLeadStory(snapshot, leadWeights = DEFAULT_CONFIG.leadWeights) {
+  const candidates = snapshot.sections
+    .filter((section) => section.custom !== true)
+    .map((section) => {
+      const items = extractSectionItems(section);
+      const score =
+        Number(leadWeights[section.id] || 0) +
+        Math.min(items.length, 10) +
+        urgencyScore(items);
+      return { section, items, score };
+    })
+    .sort(
+      (left, right) =>
+        right.score - left.score ||
+        left.section.id.localeCompare(right.section.id),
+    );
+  const best = candidates[0];
+  if (!best) {
+    return {
+      sectionId: snapshot.sections[0] ? snapshot.sections[0].id : 'brief',
+      headline: 'Your day, at a glance',
+      summary: 'Today’s available sources are collected below.',
+    };
+  }
+  return {
+    sectionId: best.section.id,
+    headline: best.section.title,
+    summary:
+      best.items.length > 0
+        ? `${best.items.length} item${best.items.length === 1 ? '' : 's'} surfaced in this section.`
+        : best.section.emptyMessage || 'Nothing urgent surfaced.',
+  };
+}
+
+function deterministicSynthesis(snapshot, config) {
+  const leadStory = computeLeadStory(snapshot, config.leadWeights);
+  const sections = snapshot.sections.map((section) => ({
+    id: section.id,
+    title: section.title,
+    summary:
+      section.status === 'empty'
+        ? section.emptyMessage
+        : `${extractSectionItems(section).length || 1} source item${extractSectionItems(section).length === 1 ? '' : 's'} collected.`,
+    emptyMessage: section.emptyMessage,
+    items: extractSectionItems(section).slice(0, 10).map((item, index) => ({
+      headline:
+        boundedString(
+          item &&
+            (item.title ||
+              item.subject ||
+              item.summary ||
+              item.topic ||
+              item.name),
+          `Item ${index + 1}`,
+          500,
+        ),
+      body: compactObject(item).slice(0, 1_500),
+      url: safeUrl(item && (item.url || item.link)) || undefined,
+    })),
+  }));
+  const spokenSections = sections
+    .map((section) => {
+      const itemText = section.items
+        .slice(0, 4)
+        .map((item) => `${item.headline}. ${item.body}`)
+        .join(' ');
+      return `${section.title}. ${section.summary}. ${itemText}`.trim();
+    })
+    .join('\n\n');
+  return {
+    headline: leadStory.headline,
+    subheadline: leadStory.summary,
+    leadStory,
+    sections,
+    inboxDecisions: snapshot.sections
+      .filter((section) => section.id === 'inbox')
+      .flatMap((section) => {
+        const data = asObject(section.data);
+        return Array.isArray(data.emails) ? data.emails : [];
+      })
+      .filter((email) => email && typeof email.id === 'string' && email.id)
+      .map((email) => ({
+        messageId: email.id,
+        decision: 'review',
+        rationale: 'Review this message in the inbox.',
+      })),
+    podcastScript:
+      `Good morning. This is your morning brief for ${snapshot.displayDate}. ` +
+      `${spokenSections} That concludes today's brief.`,
+  };
+}
+
+function validateSynthesis(raw, snapshot, config) {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+    throw new BriefError(
+      'synthesis file must contain a JSON object',
+      'bad_synthesis',
+      'synthesis',
+    );
+  }
+  const allowedIds = new Set(snapshot.sections.map((section) => section.id));
+  const sections = Array.isArray(raw.sections)
+    ? raw.sections
+        .filter(
+          (section) =>
+            section &&
+            typeof section === 'object' &&
+            typeof section.id === 'string' &&
+            allowedIds.has(section.id),
+        )
+        .map((section) => ({
+          id: section.id,
+          title: boundedString(section.title, '', 300),
+          summary: boundedString(section.summary, '', 3_000),
+          emptyMessage: boundedString(section.emptyMessage, '', 1_000),
+          items: (Array.isArray(section.items) ? section.items : [])
+            .slice(0, 30)
+            .map((item) => ({
+              headline: boundedString(
+                item && (item.headline || item.title),
+                'Untitled',
+                500,
+              ),
+              body: boundedString(
+                item && (item.body || item.summary),
+                '',
+                4_000,
+              ),
+              meta: boundedString(item && item.meta, '', 500),
+              url: safeUrl(item && (item.url || item.link)) || undefined,
+            })),
+        }))
+    : [];
+  const synthesizedIds = new Set(sections.map((section) => section.id));
+  const missingCustom = snapshot.sections
+    .filter(
+      (section) =>
+        section.custom === true && !synthesizedIds.has(section.id),
+    )
+    .map((section) => section.id);
+  if (missingCustom.length > 0) {
+    throw new BriefError(
+      `synthesis is missing configured custom section(s): ${missingCustom.join(', ')}`,
+      'bad_synthesis',
+      'synthesis',
+    );
+  }
+  const inboxMessageIds = new Set(
+    snapshot.sections
+      .filter((section) => section.id === 'inbox')
+      .flatMap((section) => {
+        const data = asObject(section.data);
+        return Array.isArray(data.emails) ? data.emails : [];
+      })
+      .filter((email) => email && typeof email.id === 'string' && email.id)
+      .map((email) => email.id),
+  );
+  const allowedInboxDecisions = new Set([
+    'act-now',
+    'review',
+    'defer',
+    'archive',
+  ]);
+  const inboxDecisions = (
+    Array.isArray(raw.inboxDecisions) ? raw.inboxDecisions : []
+  )
+    .filter(
+      (decision) =>
+        decision &&
+        typeof decision === 'object' &&
+        inboxMessageIds.has(decision.messageId) &&
+        allowedInboxDecisions.has(decision.decision),
+    )
+    .slice(0, 100)
+    .map((decision) => ({
+      messageId: decision.messageId,
+      decision: decision.decision,
+      rationale: boundedString(decision.rationale, '', 1_000),
+    }));
+  const decidedMessageIds = new Set(
+    inboxDecisions.map((decision) => decision.messageId),
+  );
+  const missingInboxDecisions = [...inboxMessageIds].filter(
+    (messageId) => !decidedMessageIds.has(messageId),
+  );
+  if (missingInboxDecisions.length > 0) {
+    throw new BriefError(
+      `synthesis must make a valid decision for every inbox item; missing: ${missingInboxDecisions.join(', ')}`,
+      'bad_synthesis',
+      'synthesis',
+    );
+  }
+  if (
+    typeof raw.podcastScript === 'string' &&
+    raw.podcastScript.trim().length > 200_000
+  ) {
+    throw new BriefError(
+      'synthesis podcastScript exceeds the 200000 character limit',
+      'bad_synthesis',
+      'synthesis',
+    );
+  }
+  const podcastScript = boundedString(raw.podcastScript, '', 200_000);
+  if (config.podcast.enabled && !podcastScript) {
+    throw new BriefError(
+      'synthesis must include a complete podcastScript while podcast delivery is enabled',
+      'bad_synthesis',
+      'synthesis',
+    );
+  }
+  const lead = asObject(raw.leadStory);
+  return {
+    headline: boundedString(raw.headline, 'Your day, at a glance', 500),
+    subheadline: boundedString(raw.subheadline, '', 2_000),
+    leadStory: {
+      sectionId: allowedIds.has(lead.sectionId)
+        ? lead.sectionId
+        : computeLeadStory(snapshot, config.leadWeights).sectionId,
+      headline: boundedString(lead.headline, '', 500),
+      summary: boundedString(lead.summary, '', 2_000),
+    },
+    sections,
+    inboxDecisions,
+    podcastScript,
+  };
+}
+
+function synthesizePodcast(synthesis, user, config, runExternal) {
+  if (!config.podcast.enabled) {
+    return { enabled: false, url: null };
+  }
+  const result = externalJson(
+    runExternal,
+    {
+      skill: 'tts',
+      args: [
+        '--user',
+        user,
+        '--voice',
+        config.podcast.voice,
+        '--engine',
+        config.podcast.engine,
+      ],
+      input: synthesis.podcastScript,
+      timeoutMs: 900_000,
+    },
+    'psd-tts',
+  );
+  const url = safeUrl(result.url);
+  if (!url) {
+    throw new BriefError(
+      'psd-tts returned no absolute audio URL',
+      'podcast_failed',
+      'podcast',
+    );
+  }
+  return {
+    enabled: true,
+    url,
+    voice: result.voice || config.podcast.voice,
+    engine: result.engine || config.podcast.engine,
+    characters: result.characters,
+  };
+}
+
+async function createPrivateAtriumArtifact(
+  snapshot,
+  html,
+  broker = requestAgentBroker,
+) {
+  let result;
+  try {
+    result = await broker('/api/agent/atrium', {
+      method: 'POST',
+      path: '',
+      body: {
+        kind: 'artifact',
+        title: snapshot.title,
+        body: Buffer.from(html, 'utf8').toString('base64'),
+        bodyFormat: 'html',
+        codeEncoding: 'base64',
+        visibility: { level: 'private' },
+        tags: [BRIEF_TAG, `morning-brief:${snapshot.localDate}`],
+      },
+    });
+  } catch (error) {
+    throw new BriefError(
+      `Atrium create failed: ${error instanceof Error ? error.message : String(error)}`,
+      'atrium_delivery_failed',
+      'atrium',
+    );
+  }
+  let created;
+  try {
+    created = unwrapAtrium(result);
+  } catch (error) {
+    throw new BriefError(
+      `Atrium create failed: ${error instanceof Error ? error.message : String(error)}`,
+      'atrium_delivery_failed',
+      'atrium',
+    );
+  }
+  if (
+    !created ||
+    !created.id ||
+    created.visibilityLevel !== 'private'
+  ) {
+    throw new BriefError(
+      'Atrium did not confirm a private artifact; no fallback delivery is allowed',
+      'atrium_delivery_failed',
+      'atrium',
+    );
+  }
+  if (!safeUrl(created.url)) {
+    throw new BriefError(
+      'Atrium returned a relative or missing contentDeepLink; the DM requires an absolute URL',
+      'atrium_delivery_failed',
+      'atrium',
+    );
+  }
+  return created;
+}
+
+function ledgerPath() {
+  return path.join(stateDir(), 'briefs.json');
+}
+
+function readLedger() {
+  const filePath = ledgerPath();
+  if (!validatedFs.existsSync(filePath)) return [];
+  const parsed = readJsonFile(filePath, 'brief retention ledger');
+  return Array.isArray(parsed) ? parsed : [];
+}
+
+function writeLedger(entries) {
+  validatedFs.mkdirSync(stateDir(), { recursive: true, mode: 0o700 });
+  validatedFs.writeFileSync(
+    ledgerPath(),
+    `${JSON.stringify(entries.slice(-400), null, 2)}\n`,
+    { encoding: 'utf8', mode: 0o600 },
+  );
+}
+
+async function applyRetention(
+  created,
+  snapshot,
+  config,
+  broker = requestAgentBroker,
+) {
+  const cutoff =
+    new Date(snapshot.generatedAt).getTime() -
+    config.retainDays * 24 * 60 * 60 * 1_000;
+  const existing = readLedger();
+  const keep = [];
+  const deleted = [];
+  const warnings = [];
+  for (const entry of existing) {
+    const createdAt = Date.parse(entry.createdAt);
+    if (!entry.id || !Number.isFinite(createdAt) || createdAt >= cutoff) {
+      keep.push(entry);
+      continue;
+    }
+    try {
+      const result = await broker('/api/agent/atrium', {
+        method: 'DELETE',
+        path: `/${encodeURIComponent(String(entry.id))}`,
+      });
+      unwrapAtrium(result);
+      deleted.push(entry.id);
+    } catch (error) {
+      keep.push(entry);
+      warnings.push(
+        `Could not delete retained brief ${entry.id}: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+    }
+  }
+  keep.push({
+    id: created.id,
+    slug: created.slug || null,
+    createdAt: snapshot.generatedAt,
+    localDate: snapshot.localDate,
+  });
+  writeLedger(keep);
+  return { deleted, warnings };
+}
+
+function deliveryMessage(snapshot, created, podcast) {
+  const lines = [
+    `Your private ${snapshot.title} is ready:`,
+    created.url,
+  ];
+  if (podcast.enabled && podcast.url) {
+    lines.push('', 'Podcast edition:', podcast.url);
+  }
+  return lines.join('\n');
+}
+
+async function composeBrief(options, deps = {}) {
+  const config = options.config || normalizeConfig();
+  const snapshot = options.snapshot;
+  const synthesis = validateSynthesis(options.synthesis, snapshot, config);
+  const runExternal = deps.runExternal || defaultRunExternal;
+  const broker = deps.broker || requestAgentBroker;
+  const podcast = synthesizePodcast(
+    synthesis,
+    options.user,
+    config,
+    runExternal,
+  );
+  const html = renderNewspaper({ snapshot, synthesis, podcast });
+  const created = await createPrivateAtriumArtifact(snapshot, html, broker);
+  const retention = await applyRetention(
+    created,
+    snapshot,
+    config,
+    broker,
+  );
+  return {
+    status: 'ok',
+    mode: options.mode || 'compose',
+    artifact: {
+      id: created.id,
+      slug: created.slug,
+      title: created.title,
+      visibility: created.visibilityLevel,
+      url: created.url,
+    },
+    podcast,
+    retention,
+    deliveryMessage: deliveryMessage(snapshot, created, podcast),
+  };
+}
+
+async function reportFailure(error, deps = {}) {
+  const broker = deps.broker || requestAgentBroker;
+  const code =
+    error && typeof error.code === 'string'
+      ? error.code
+      : 'morning_brief_failed';
+  const phase =
+    error && typeof error.phase === 'string' ? error.phase : 'unknown';
+  const message =
+    error instanceof Error ? error.message : String(error || 'Unknown error');
+  process.stderr.write(
+    `AGENT_FAILURE_RECORD ${JSON.stringify({
+      source: 'agent_self_report',
+      severity: 'error',
+      error_class: code,
+      error_message: message.slice(0, 4_000),
+      context: { skill: SKILL_ID, phase },
+    })}\n`,
+  );
+  try {
+    // This is the owner-bound persistence route used by
+    // psd-failure-report/report.js. Calling it directly avoids forwarding a
+    // model-supplied --user hint through a composed skill; the signed broker
+    // context remains the only authority.
+    return await broker('/api/agent/failures', {
+      source: 'agent_self_report',
+      severity: 'error',
+      errorClass: code.slice(0, 128),
+      errorMessage: message.slice(0, 4_000),
+      context: {
+        skill: SKILL_ID,
+        phase,
+        self_reported: true,
+      },
+    });
+  } catch (reportError) {
+    process.stderr.write(
+      `${SKILL_ID}: failure self-report could not be delivered: ${
+        reportError instanceof Error
+          ? reportError.message
+          : String(reportError)
+      }\n`,
+    );
+    return { logged: false };
+  }
+}
+
+function requireUser(args) {
+  if (!validateUserEmail(args.user)) {
+    throw new BriefError(
+      '--user <caller-email> is required and must come verbatim from the [caller: ...] header',
+      'bad_args',
+      'arguments',
+    );
+  }
+  return args.user.toLowerCase();
+}
+
+function selfCheck() {
+  const config = normalizeConfig();
+  const snapshot = {
+    schemaVersion: 1,
+    generatedAt: '2026-07-29T14:00:00.000Z',
+    localDate: '2026-07-29',
+    displayDate: 'Wednesday, July 29, 2026',
+    title: 'Morning Brief — 2026-07-29',
+    people: [],
+    omittedSections: [],
+    sections: [
+      {
+        id: 'calendar',
+        title: "Today's calendar",
+        status: 'empty',
+        emptyMessage: DEFAULT_EMPTY_MESSAGES.calendar,
+        data: { events: [] },
+      },
+      {
+        id: 'custom-focus',
+        title: 'Strategic focus',
+        custom: true,
+        status: 'awaiting-synthesis',
+        emptyMessage: 'No custom material was gathered.',
+        data: {
+          instructions: 'Summarize the current strategic focus.',
+          sources: ['psd-data'],
+        },
+      },
+    ],
+  };
+  const request = makeSynthesisRequest(snapshot);
+  const synthesis = deterministicSynthesis(snapshot, config);
+  const html = renderNewspaper({
+    snapshot,
+    synthesis,
+    podcast: { enabled: false },
+  });
+  const checks = {
+    registry:
+      createSectionRegistry().map((adapter) => adapter.id).join(',') ===
+      CORE_SECTION_IDS.join(','),
+    defaults: config.podcast.enabled && config.retainDays === 30,
+    customSection: request.availableSections.some(
+      (section) => section.id === 'custom-focus' && section.custom,
+    ),
+    emptyState: html.includes(DEFAULT_EMPTY_MESSAGES.calendar),
+    newspaper: html.startsWith('<!doctype html>') && html.includes('Private edition'),
+  };
+  if (Object.values(checks).some((passed) => !passed)) {
+    throw new BriefError(
+      `Offline self-check failed: ${JSON.stringify(checks)}`,
+      'self_test_failed',
+      'test',
+    );
+  }
+  return { status: 'ok', mode: 'test', offline: true, checks };
+}
+
+function printHelp() {
+  process.stdout.write(
+    [
+      'psd-morning-brief — private daily newspaper + podcast',
+      '',
+      'Usage:',
+      '  run.js --user <caller-email> --data-only [--config <path>] [--out-dir <path>]',
+      '  run.js --user <caller-email> --compose --data-file <path> --synthesis-file <path> [--config <path>]',
+      '  run.js --user <caller-email> --both [--config <path>]',
+      '  run.js --test',
+      '',
+      'Identity comes from the [caller: ...] header and the signed broker context.',
+      'Never pass owner selectors, DM-space ids, or workspace prefixes.',
+    ].join('\n') + '\n',
+  );
+}
+
+function emitResult(deps, result) {
+  valueOr(deps.emit, emit)(result);
+}
+
+async function main(argv = process.argv, deps = {}) {
+  const args = parseArgs(argv);
+  rejectAuthorityArgs(args);
+  if (args.help) {
+    printHelp();
+    return { status: 'ok', mode: 'help' };
+  }
+  const selectedModes = ['data_only', 'compose', 'both', 'test'].filter(
+    (mode) => args[mode] === true,
+  );
+  if (selectedModes.length !== 1) {
+    throw new BriefError(
+      'Choose exactly one mode: --data-only, --compose, --both, or --test',
+      'bad_args',
+      'arguments',
+    );
+  }
+  if (args.test === true) {
+    const result = selfCheck();
+    emitResult(deps, result);
+    return result;
+  }
+  const user = requireUser(args);
+  const loaded = loadConfig(
+    typeof args.config === 'string'
+      ? path.resolve(args.config)
+      : path.join(stateDir(), 'config.json'),
+  );
+  const config = loaded.config;
+
+  if (args.data_only === true) {
+    const snapshot = await gatherSnapshot(
+      { user, config, now: valueOr(deps.now, new Date()) },
+      deps,
+    );
+    const written = writeSnapshot(
+      snapshot,
+      makeSynthesisRequest(snapshot),
+      typeof args.out_dir === 'string' ? args.out_dir : undefined,
+    );
+    const result = {
+      status: 'ok',
+      mode: 'data-only',
+      usedDefaultConfig: loaded.usedDefaults,
+      omittedSections: snapshot.omittedSections,
+      ...written,
+    };
+    emitResult(deps, result);
+    return result;
+  }
+
+  if (args.compose === true) {
+    if (
+      typeof args.data_file !== 'string' ||
+      typeof args.synthesis_file !== 'string'
+    ) {
+      throw new BriefError(
+        '--compose requires --data-file and --synthesis-file',
+        'bad_args',
+        'arguments',
+      );
+    }
+    const result = await composeBrief(
+      {
+        user,
+        config,
+        snapshot: readJsonFile(
+          path.resolve(args.data_file),
+          'data snapshot',
+        ),
+        synthesis: readJsonFile(
+          path.resolve(args.synthesis_file),
+          'synthesis file',
+        ),
+        mode: 'compose',
+      },
+      deps,
+    );
+    emitResult(deps, result);
+    return result;
+  }
+
+  if (args.both === true) {
+    const snapshot = await gatherSnapshot(
+      { user, config, now: valueOr(deps.now, new Date()) },
+      deps,
+    );
+    const result = await composeBrief(
+      {
+        user,
+        config,
+        snapshot,
+        synthesis: deterministicSynthesis(snapshot, config),
+        mode: 'both',
+      },
+      deps,
+    );
+    emitResult(deps, result);
+    return result;
+  }
+
+  throw new BriefError(
+    'Choose exactly one mode: --data-only, --compose, --both, or --test',
+    'bad_args',
+    'arguments',
+  );
+}
+
+if (require.main === module) {
+  main(process.argv, {}).catch(async (error) => {
+    await reportFailure(error);
+    emit({
+      status: 'error',
+      error:
+        error && typeof error.code === 'string'
+          ? error.code
+          : 'morning_brief_failed',
+      phase:
+        error && typeof error.phase === 'string' ? error.phase : 'unknown',
+      message: error instanceof Error ? error.message : String(error),
+      selfReported: true,
+    });
+    process.exitCode = 1;
+  });
+}
+
+module.exports = {
+  BRIEF_TAG,
+  BriefError,
+  CORE_SECTION_IDS,
+  DEFAULT_CONFIG,
+  SourceUnavailableError,
+  applyRetention,
+  collectStructuredStrings,
+  composeBrief,
+  computeLeadStory,
+  createPrivateAtriumArtifact,
+  createSectionRegistry,
+  deterministicSynthesis,
+  dayWindow,
+  findDateColumn,
+  findLargestObjectArray,
+  findWarehouseTable,
+  gatherSnapshot,
+  isUnavailableError,
+  lastJson,
+  loadConfig,
+  main,
+  makeSynthesisRequest,
+  normalizeConfig,
+  parseArgs,
+  reportFailure,
+  selfCheck,
+  sqlIdentifier,
+  validateSynthesis,
+  validateUserEmail,
+  writeSnapshot,
+};

--- a/infra/agent-image/skills/psd-morning-brief/run.test.js
+++ b/infra/agent-image/skills/psd-morning-brief/run.test.js
@@ -1,0 +1,725 @@
+'use strict';
+
+const { afterEach, describe, expect, test } = require('bun:test');
+const os = require('node:os');
+const path = require('node:path');
+const { validatedFs } = require('../../../validated-fs.cjs');
+
+const {
+  BriefError,
+  applyRetention,
+  composeBrief,
+  computeLeadStory,
+  createPrivateAtriumArtifact,
+  dayWindow,
+  deterministicSynthesis,
+  gatherSnapshot,
+  main,
+  makeSynthesisRequest,
+  normalizeConfig,
+  reportFailure,
+  selfCheck,
+  validateSynthesis,
+  writeSnapshot,
+} = require('./run');
+const {
+  DEFAULT_EMPTY_MESSAGES,
+  escapeHtml,
+  renderNewspaper,
+  safeUrl,
+} = require('./newspaper');
+
+const scratch = [];
+
+function makeTempDir() {
+  const dir = validatedFs.mkdtempSync(
+    path.join(os.tmpdir(), 'brief-test-'),
+  );
+  scratch.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  delete process.env.PSD_MORNING_BRIEF_STATE_DIR;
+  for (const dir of scratch.splice(0)) {
+    validatedFs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function snapshotFixture() {
+  return {
+    schemaVersion: 1,
+    generatedAt: '2026-07-29T14:00:00.000Z',
+    localDate: '2026-07-29',
+    displayDate: 'Wednesday, July 29, 2026',
+    timezone: 'America/Los_Angeles',
+    title: 'Morning Brief — 2026-07-29',
+    people: [],
+    omittedSections: [],
+    sections: [
+      {
+        id: 'calendar',
+        title: "Today's calendar",
+        status: 'ok',
+        emptyMessage: DEFAULT_EMPTY_MESSAGES.calendar,
+        data: {
+          events: [
+            {
+              title: 'Planning meeting',
+              start: '2026-07-29T09:00:00-07:00',
+            },
+          ],
+        },
+      },
+      {
+        id: 'custom-focus',
+        title: 'Strategic focus',
+        custom: true,
+        status: 'awaiting-synthesis',
+        emptyMessage: 'No strategic update was gathered.',
+        data: {
+          instructions: 'Summarize changes.',
+          sources: ['psd-data'],
+        },
+      },
+    ],
+  };
+}
+
+function synthesisFixture() {
+  return {
+    headline: 'A focused day ahead',
+    subheadline: 'One scheduled decision anchors the day.',
+    leadStory: {
+      sectionId: 'calendar',
+      headline: 'Planning meeting leads the agenda',
+      summary: 'Prepare the decision packet before 9:00.',
+    },
+    sections: [
+      {
+        id: 'calendar',
+        title: "Today's calendar",
+        summary: 'One meeting.',
+        items: [
+          {
+            headline: 'Planning meeting',
+            body: 'Review the decision packet.',
+          },
+        ],
+      },
+      {
+        id: 'custom-focus',
+        title: 'Strategic focus',
+        summary: 'The custom desk is current.',
+        items: [{ headline: 'Initiative update', body: 'On track.' }],
+      },
+    ],
+    inboxDecisions: [],
+    podcastScript:
+      'Good morning. Here is the complete spoken edition for today.',
+  };
+}
+
+describe('configuration and self-check', () => {
+  test('no config input produces complete safe defaults', () => {
+    const config = normalizeConfig();
+    expect(config.enabledSections).toHaveLength(8);
+    expect(config.podcast.enabled).toBe(true);
+    expect(config.retainDays).toBe(30);
+    expect(config.news.topics.length).toBeGreaterThan(0);
+  });
+
+  test('custom sections are normalized into first-class stable ids', () => {
+    const config = normalizeConfig({
+      customSections: [
+        {
+          title: 'Project pulse',
+          instructions: 'Gather decisions and blockers.',
+          sources: ['psd-data', 'psd-plaud'],
+        },
+      ],
+    });
+    expect(config.customSections).toEqual([
+      {
+        id: 'custom-project-pulse',
+        title: 'Project pulse',
+        instructions: 'Gather decisions and blockers.',
+        sources: ['psd-data', 'psd-plaud'],
+      },
+    ]);
+  });
+
+  test('an explicit empty enabled-section list supports custom-only briefs', () => {
+    expect(normalizeConfig({ enabledSections: [] }).enabledSections).toEqual(
+      [],
+    );
+  });
+
+  test('calendar bounds follow the configured timezone across DST', () => {
+    expect(dayWindow('2026-07-29', 'America/Los_Angeles')).toEqual({
+      timeMin: '2026-07-29T07:00:00.000Z',
+      timeMax: '2026-07-30T07:00:00.000Z',
+    });
+    expect(dayWindow('2026-01-29', 'America/Los_Angeles')).toEqual({
+      timeMin: '2026-01-29T08:00:00.000Z',
+      timeMax: '2026-01-30T08:00:00.000Z',
+    });
+  });
+
+  test('--test self-check is offline and passes', () => {
+    expect(selfCheck()).toMatchObject({
+      status: 'ok',
+      mode: 'test',
+      offline: true,
+    });
+  });
+
+  test('authority selector flags are rejected', async () => {
+    await expect(
+      main(
+        [
+          'node',
+          'run.js',
+          '--owner-email',
+          'alternate@example.net',
+          '--data-only',
+        ],
+        {},
+      ),
+    ).rejects.toMatchObject({
+      code: 'bad_args',
+      phase: 'arguments',
+    });
+  });
+
+  test('ambiguous mode combinations are rejected', async () => {
+    await expect(
+      main(
+        [
+          'node',
+          'run.js',
+          '--user',
+          'owner@example.net',
+          '--data-only',
+          '--both',
+        ],
+        {},
+      ),
+    ).rejects.toMatchObject({
+      code: 'bad_args',
+      phase: 'arguments',
+    });
+  });
+
+  test('no config file still completes a private newspaper run', async () => {
+    const dir = makeTempDir();
+    process.env.PSD_MORNING_BRIEF_STATE_DIR = dir;
+    const emitted = [];
+    const result = await main(
+      [
+        'node',
+        'run.js',
+        '--user',
+        'owner@example.net',
+        '--both',
+      ],
+      {
+        now: new Date('2026-07-29T14:00:00.000Z'),
+        emit: (value) => emitted.push(value),
+        registry: [
+          {
+            id: 'calendar',
+            title: "Today's calendar",
+            available: async () => true,
+            fetch: async () => ({ events: [] }),
+          },
+        ],
+        runExternal: () => ({
+          code: 0,
+          stdout: JSON.stringify({
+            status: 'ok',
+            url: 'https://example.net/audio/default.mp3',
+            voice: 'Ruth',
+            engine: 'long-form',
+          }),
+          stderr: '',
+        }),
+        broker: async () => ({
+          httpStatus: 201,
+          payload: {
+            data: {
+              id: 'default-brief',
+              slug: 'morning-brief-2026-07-29',
+              title: 'Morning Brief — 2026-07-29',
+              visibilityLevel: 'private',
+              url: 'https://example.net/c/morning-brief-2026-07-29',
+            },
+          },
+        }),
+      },
+    );
+    expect(result.artifact.visibility).toBe('private');
+    expect(result.podcast.enabled).toBe(true);
+    expect(result.deliveryMessage).toContain(
+      'https://example.net/c/morning-brief-2026-07-29',
+    );
+    expect(emitted).toEqual([result]);
+  });
+});
+
+describe('section availability and synthesis request', () => {
+  test('unavailable core sections are omitted from snapshot and request', async () => {
+    const registry = [
+      {
+        id: 'calendar',
+        title: 'Calendar',
+        available: async () => true,
+        fetch: async () => ({ events: [] }),
+      },
+      {
+        id: 'inbox',
+        title: 'Inbox',
+        available: async () => false,
+        fetch: async () => {
+          throw new Error('must not run');
+        },
+      },
+    ];
+    const config = normalizeConfig({
+      enabledSections: ['calendar', 'inbox'],
+      customSections: [
+        {
+          title: 'Project pulse',
+          instructions: 'Gather changes.',
+          sources: ['psd-data'],
+        },
+      ],
+      people: [],
+    });
+    const snapshot = await gatherSnapshot(
+      {
+        user: 'owner@example.net',
+        config,
+        now: new Date('2026-07-29T14:00:00.000Z'),
+      },
+      {
+        registry,
+        broker: async () => {
+          throw new Error('unexpected broker call');
+        },
+      },
+    );
+    expect(snapshot.sections.map((section) => section.id)).toEqual([
+      'calendar',
+      'custom-project-pulse',
+    ]);
+    expect(snapshot.omittedSections).toContainEqual(
+      expect.objectContaining({ id: 'inbox' }),
+    );
+    expect(
+      makeSynthesisRequest(snapshot).availableSections.map(
+        (section) => section.id,
+      ),
+    ).not.toContain('inbox');
+  });
+
+  test('configured people are resolved only through the directory broker', async () => {
+    const calls = [];
+    const snapshot = await gatherSnapshot(
+      {
+        user: 'owner@example.net',
+        config: normalizeConfig({
+          enabledSections: ['calendar'],
+          people: [{ email: 'person@example.net', note: 'Collaborator' }],
+        }),
+        now: new Date('2026-07-29T14:00:00.000Z'),
+      },
+      {
+        registry: [
+          {
+            id: 'calendar',
+            title: 'Calendar',
+            available: async () => true,
+            fetch: async () => ({ events: [] }),
+          },
+        ],
+        broker: async (route, payload) => {
+          calls.push({ route, payload });
+          return {
+            found: true,
+            displayName: 'Directory Person',
+            email: payload.email,
+          };
+        },
+      },
+    );
+    expect(calls).toEqual([
+      {
+        route: '/api/agent/directory-lookup',
+        payload: { email: 'person@example.net' },
+      },
+    ]);
+    expect(snapshot.people[0].displayName).toBe('Directory Person');
+  });
+
+  test('snapshot writer returns a usable data path', () => {
+    const dir = makeTempDir();
+    const snapshot = snapshotFixture();
+    const result = writeSnapshot(
+      snapshot,
+      makeSynthesisRequest(snapshot),
+      dir,
+    );
+    expect(result.dataFile).toBe(path.join(dir, 'data.json'));
+    expect(
+      JSON.parse(validatedFs.readFileSync(result.dataFile, 'utf8')).title,
+    ).toBe(snapshot.title);
+    expect(result.synthesisRequest.dataFile).toBe(result.dataFile);
+  });
+});
+
+describe('synthesis and newspaper', () => {
+  test('podcast-enabled synthesis requires a complete script', () => {
+    const snapshot = snapshotFixture();
+    expect(() =>
+      validateSynthesis(
+        { ...synthesisFixture(), podcastScript: '' },
+        snapshot,
+        normalizeConfig(),
+      ),
+    ).toThrow(BriefError);
+  });
+
+  test('configured custom sections cannot be silently dropped', () => {
+    const snapshot = snapshotFixture();
+    const missingCustom = {
+      ...synthesisFixture(),
+      sections: synthesisFixture().sections.filter(
+        (section) => section.id !== 'custom-focus',
+      ),
+    };
+    expect(() =>
+      validateSynthesis(
+        missingCustom,
+        snapshot,
+        normalizeConfig(),
+      ),
+    ).toThrow(/missing configured custom section/);
+  });
+
+  test('every gathered inbox item receives a valid decision', () => {
+    const snapshot = snapshotFixture();
+    snapshot.sections.push({
+      id: 'inbox',
+      title: 'Inbox triage',
+      status: 'ok',
+      data: { emails: [{ id: 'message-1', subject: 'A decision' }] },
+    });
+    expect(() =>
+      validateSynthesis(
+        synthesisFixture(),
+        snapshot,
+        normalizeConfig(),
+      ),
+    ).toThrow(/decision for every inbox item/);
+    const deterministic = deterministicSynthesis(
+      snapshot,
+      normalizeConfig(),
+    );
+    expect(
+      validateSynthesis(deterministic, snapshot, normalizeConfig())
+        .inboxDecisions,
+    ).toEqual([
+      {
+        messageId: 'message-1',
+        decision: 'review',
+        rationale: 'Review this message in the inbox.',
+      },
+    ]);
+  });
+
+  test('custom source instructions are not rendered as fallback content', () => {
+    const snapshot = snapshotFixture();
+    const html = renderNewspaper({
+      snapshot,
+      synthesis: {
+        ...synthesisFixture(),
+        sections: [],
+      },
+      podcast: { enabled: false },
+    });
+    expect(html).not.toContain('Summarize changes.');
+  });
+
+  test('custom sections render as newspaper desks and empty core states are clean', () => {
+    const snapshot = snapshotFixture();
+    snapshot.sections[0] = {
+      ...snapshot.sections[0],
+      status: 'empty',
+      data: { events: [] },
+    };
+    const synthesis = {
+      ...synthesisFixture(),
+      sections: synthesisFixture().sections.filter(
+        (section) => section.id === 'custom-focus',
+      ),
+    };
+    const html = renderNewspaper({
+      snapshot,
+      synthesis,
+      podcast: { enabled: false },
+    });
+    expect(html).toContain('Custom desk');
+    expect(html).toContain('Strategic focus');
+    expect(html).toContain(DEFAULT_EMPTY_MESSAGES.calendar);
+  });
+
+  test('HTML and unsafe URLs are escaped instead of executed', () => {
+    expect(escapeHtml('<script>alert(1)</script>')).toBe(
+      '&lt;script&gt;alert(1)&lt;/script&gt;',
+    );
+    expect(safeUrl('javascript:alert(1)')).toBeNull();
+  });
+
+  test('lead story scoring generalizes across enabled sections', () => {
+    const snapshot = snapshotFixture();
+    snapshot.sections.push({
+      id: 'freshservice',
+      title: 'Service desk',
+      data: {
+        tickets: [
+          { subject: 'Critical overdue approval' },
+          { subject: 'Urgent incident' },
+        ],
+      },
+    });
+    expect(
+      computeLeadStory(snapshot, {
+        calendar: 1,
+        freshservice: 6,
+      }).sectionId,
+    ).toBe('freshservice');
+  });
+});
+
+describe('Atrium delivery and podcast', () => {
+  test('Atrium create is explicit private create with no authority selector or publish', async () => {
+    const calls = [];
+    const created = await createPrivateAtriumArtifact(
+      snapshotFixture(),
+      '<!doctype html><p>brief</p>',
+      async (route, payload) => {
+        calls.push({ route, payload });
+        return {
+          httpStatus: 201,
+          payload: {
+            data: {
+              id: 'brief-id',
+              slug: 'morning-brief-2026-07-29',
+              title: 'Morning Brief — 2026-07-29',
+              visibilityLevel: 'private',
+              url: 'https://example.net/c/morning-brief-2026-07-29',
+            },
+          },
+        };
+      },
+    );
+    expect(created.id).toBe('brief-id');
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toMatchObject({
+      route: '/api/agent/atrium',
+      payload: {
+        method: 'POST',
+        path: '',
+        body: {
+          kind: 'artifact',
+          bodyFormat: 'html',
+          codeEncoding: 'base64',
+          visibility: { level: 'private' },
+        },
+      },
+    });
+    expect(JSON.stringify(calls[0].payload)).not.toMatch(
+      /ownerEmail|userEmail|userId|publish/,
+    );
+  });
+
+  test('missing Atrium capability is a hard failure with no fallback', async () => {
+    await expect(
+      createPrivateAtriumArtifact(
+        snapshotFixture(),
+        '<!doctype html>',
+        async () => ({
+          httpStatus: 403,
+          payload: {
+            error: {
+              code: 'FORBIDDEN',
+              message: 'Atrium authoring capability is required',
+            },
+          },
+        }),
+      ),
+    ).rejects.toMatchObject({
+      code: 'atrium_delivery_failed',
+      phase: 'atrium',
+    });
+  });
+
+  test('compose generates podcast by default and returns both DM links', async () => {
+    const dir = makeTempDir();
+    process.env.PSD_MORNING_BRIEF_STATE_DIR = dir;
+    const externalCalls = [];
+    const brokerCalls = [];
+    const result = await composeBrief(
+      {
+        user: 'owner@example.net',
+        config: normalizeConfig(),
+        snapshot: snapshotFixture(),
+        synthesis: synthesisFixture(),
+      },
+      {
+        runExternal: (spec) => {
+          externalCalls.push(spec);
+          return {
+            code: 0,
+            stdout: JSON.stringify({
+              status: 'ok',
+              url: 'https://example.net/audio/today.mp3',
+              voice: 'Ruth',
+              engine: 'long-form',
+            }),
+            stderr: '',
+          };
+        },
+        broker: async (route, payload) => {
+          brokerCalls.push({ route, payload });
+          return {
+            httpStatus: 201,
+            payload: {
+              data: {
+                id: 'brief-id',
+                slug: 'morning-brief-2026-07-29',
+                title: 'Morning Brief — 2026-07-29',
+                visibilityLevel: 'private',
+                url: 'https://example.net/c/morning-brief-2026-07-29',
+              },
+            },
+          };
+        },
+      },
+    );
+    expect(externalCalls[0]).toMatchObject({
+      skill: 'tts',
+      args: expect.arrayContaining(['--engine', 'long-form']),
+    });
+    expect(result.deliveryMessage).toContain(
+      'https://example.net/c/morning-brief-2026-07-29',
+    );
+    expect(result.deliveryMessage).toContain(
+      'https://example.net/audio/today.mp3',
+    );
+    expect(brokerCalls).toHaveLength(1);
+  });
+
+  test('per-user config can disable podcast generation', async () => {
+    const dir = makeTempDir();
+    process.env.PSD_MORNING_BRIEF_STATE_DIR = dir;
+    const config = normalizeConfig({ podcast: { enabled: false } });
+    const result = await composeBrief(
+      {
+        user: 'owner@example.net',
+        config,
+        snapshot: snapshotFixture(),
+        synthesis: { ...synthesisFixture(), podcastScript: '' },
+      },
+      {
+        runExternal: () => {
+          throw new Error('TTS must not run');
+        },
+        broker: async () => ({
+          httpStatus: 201,
+          payload: {
+            data: {
+              id: 'brief-id',
+              slug: 'brief',
+              title: 'Morning Brief — 2026-07-29',
+              visibilityLevel: 'private',
+              url: 'https://example.net/c/brief',
+            },
+          },
+        }),
+      },
+    );
+    expect(result.podcast.enabled).toBe(false);
+    expect(result.deliveryMessage).not.toContain('.mp3');
+  });
+
+});
+
+describe('retention and failures', () => {
+  test('retention deletes only ledger-tracked briefs older than retainDays', async () => {
+    const dir = makeTempDir();
+    process.env.PSD_MORNING_BRIEF_STATE_DIR = dir;
+    validatedFs.writeFileSync(
+      path.join(dir, 'briefs.json'),
+      JSON.stringify([
+        {
+          id: 'old-owned',
+          createdAt: '2026-06-01T12:00:00.000Z',
+          localDate: '2026-06-01',
+        },
+        {
+          id: 'recent-owned',
+          createdAt: '2026-07-28T12:00:00.000Z',
+          localDate: '2026-07-28',
+        },
+      ]),
+    );
+    const calls = [];
+    const retention = await applyRetention(
+      { id: 'today', slug: 'today' },
+      snapshotFixture(),
+      normalizeConfig({ retainDays: 30 }),
+      async (route, payload) => {
+        calls.push({ route, payload });
+        return { httpStatus: 200, payload: { data: { deleted: true } } };
+      },
+    );
+    expect(calls).toEqual([
+      {
+        route: '/api/agent/atrium',
+        payload: { method: 'DELETE', path: '/old-owned' },
+      },
+    ]);
+    expect(retention.deleted).toEqual(['old-owned']);
+    const ledger = JSON.parse(
+      validatedFs.readFileSync(path.join(dir, 'briefs.json'), 'utf8'),
+    );
+    expect(ledger.map((entry) => entry.id)).toEqual([
+      'recent-owned',
+      'today',
+    ]);
+  });
+
+  test('fatal failure reporting contains no model-supplied owner selector', async () => {
+    const calls = [];
+    await reportFailure(
+      new BriefError('Delivery failed', 'delivery_failed', 'atrium'),
+      {
+        broker: async (route, payload) => {
+          calls.push({ route, payload });
+          return { logged: true };
+        },
+      },
+    );
+    expect(calls).toHaveLength(1);
+    expect(calls[0].route).toBe('/api/agent/failures');
+    expect(calls[0].payload.context).toMatchObject({
+      skill: 'psd-morning-brief',
+      phase: 'atrium',
+    });
+    expect(JSON.stringify(calls[0].payload)).not.toMatch(
+      /ownerEmail|userEmail|userId/,
+    );
+  });
+});

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "test:skill:hyperframes": "cd infra/agent-image/skills/psd-hyperframes && bun test",
     "test:skill:atrium": "cd infra/agent-image/skills/psd-atrium && bun test",
     "test:skill:sop-creator": "cd infra/agent-image/skills/psd-sop-creator && bun test",
+    "test:skill:morning-brief": "cd infra/agent-image/skills/psd-morning-brief && bun test",
     "test:smoke:atrium": "bun run test:smoke:atrium-render && bun run test:smoke:atrium-collab && bun run test:smoke:atrium-collab-token && bun run test:smoke:atrium-agent-bridge && bun run test:smoke:atrium-agent-read && bun run test:smoke:atrium-html-sanitize && bun run test:smoke:atrium-provenance-rail && bun run test:smoke:atrium-collab-schema && bun run test:smoke:atrium-suggestions-resolve && bun run test:smoke:atrium-suggestion-mode && bun run test:smoke:atrium-sandbox-config && bun run test:smoke:atrium-sandbox-host",
     "test:ci": "jest --config=jest.config.ci.js",
     "test:watch": "jest --watch",


### PR DESCRIPTION
## Description

Closes #1413.

Adds the opt-in `psd-morning-brief` platform skill for all agent-platform users. The implementation keeps the three-step gather → agent synthesis → compose contract, uses modular access-aware source adapters, renders a private newspaper, creates a private Atrium artifact, generates a podcast by default, expires only ledger-tracked artifacts, resolves configured people through `psd-directory`, and self-reports fatal failures through the signed owner-bound failure broker.

The skill includes agent-guided setup and staggered scheduling guidance, sane defaults when no config exists, deterministic `--both`/offline `--test` paths, and a CI-wired Bun suite.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update
- [ ] Infrastructure change (CDK/AWS)

## Testing

- [x] `bun run lint` — zero warnings
- [x] `bun run typecheck`
- [x] `bun run test:skill:morning-brief` — 24 passed
- [x] `bun run test:ci -- --runInBand` — 517 suites / 4,790 tests passed
- [x] `bun run build`
- [x] `node infra/agent-image/skills/psd-morning-brief/run.js --test`
- [x] Forbidden-constant grep returns zero matches
- [ ] Deployed-dev run for a non-personal test user — required manual follow-up before merge

The unfiltered `bun run test` also launches live performance suites against `localhost:3000`; those were not treated as an offline gate. The canonical `test:ci` configuration explicitly excludes them and passed completely.

## Checklist

- [x] No `console.*` calls in the new production code
- [x] No `any` types or unjustified type assertions
- [x] Tests added and wired into CI
- [x] Documentation updated
- [x] No database migrations, API v1 changes, new environment variables, AWS resources, or permissions
- [x] Production build completes
- [ ] Final automated reviewer passes complete

## Risk and Rollback

Risk is additive and isolated to the bundled agent image. Main risks are source latency, daily artifact volume, and podcast cost; concurrent section gathering, 30-day exact-ID retention, stagger guidance, and per-user podcast disablement bound them.

Rollback is to remove the skill directory and rebuild the agent image. Existing private artifacts remain owner-controlled and require no schema rollback.

## Screenshots

N/A — agent-image CLI skill with no web UI surface.