### PR TITLE
test(agent): add daily-driver skill eval suites

### DIFF
--- a/infra/agent-image/eval/README.md
+++ b/infra/agent-image/eval/README.md
@@ -5,17 +5,22 @@ from the same `/invocations` endpoint AgentCore uses in production. It records
 outcomes and telemetry (#1422), injects a hermetic broker for L1 tasks, and
 applies deterministic request/output/trajectory graders (#1424).
 
-## Run the core suite
+## Run a suite
 
 From the repository root:
 
 ```bash
 python3 infra/agent-image/eval/runner.py \
   --image <tag-or-digest> \
-  --suite infra/agent-image/eval/suites/core.yaml \
+  --suite infra/agent-image/eval/suites/regression.yaml \
   --trials 3 \
-  --out /tmp/issue-1424-core.jsonl
+  --out /tmp/issue-1425-regression.jsonl \
+  --owner-email eval.issue1425@psd401.net \
+  --name-prefix psd-agent-eval-issue-1425
 ```
+
+Use `eval/suites/capability.yaml` for the harder daily-driver comparison set.
+The legacy `core.yaml` remains the three-task runner/isolation smoke suite.
 
 The runner uses the active AWS credential chain and discovers the dev web
 broker from the deployed router Lambda. Set `AGENT_EVAL_APP_BASE_URL` or pass
@@ -35,6 +40,14 @@ rejected rather than risking a mid-trial expiry.
 When a post-mint credential check recycles the runtime, the runner discards
 that authority and remints it for the ready container before invoking.
 
+Owner-bound skill tasks must pass an eval-only address on the real PSD domain
+with `--owner-email` (or `AGENT_EVAL_OWNER_EMAIL`). The signed context makes
+that address the trial's actor and owner, so the model exercises the same
+anti-impersonation rule as production. Use a synthetic address dedicated to
+the run, never another staff member's identity. L1 fixtures intercept the
+resulting broker operation before any owner credential or live side effect is
+used.
+
 JSONL output is created with owner-only (`0600`) permissions because complete
 metadata can contain prompts, messages, and tool details. Keep it in an
 issue-specific temporary path; do not commit run transcripts.
@@ -51,7 +64,8 @@ Every trial gets:
 
 - a fresh UUID in `X-Amzn-Bedrock-AgentCore-Runtime-Session-Id`;
 - a signed context minted for that exact UUID immediately before invocation;
-- one JSONL record containing the raw result and complete final-event metadata.
+- one JSONL record containing the task's suite classification, raw result, and
+  complete final-event metadata.
 
 `workspace: pure` tasks share one container while retaining conversational
 isolation through fresh session IDs. `workspace: mutating` tasks boot a fresh
@@ -77,7 +91,7 @@ containers.
 
 ## Task and suite files
 
-Phase-0 task files use a flat, dependency-free YAML subset. Double-quoted
+Task files use a flat, dependency-free YAML subset. Double-quoted
 scalars and inline lists/maps use JSON-compatible syntax. Single-quoted scalars
 use YAML escaping, so an apostrophe is written twice (`'Don''t use tools'`).
 Trailing inline comments are not part of this subset; use their own `#` line.
@@ -87,20 +101,26 @@ id: arithmetic-no-tools
 skill: runner-core
 level: L0
 workspace: pure
+suite: regression
 prompt: "Without using tools, calculate 17 times 19."
 trials: 3
 ```
 
-A suite contains relative task paths:
+A suite contains relative task paths. Production eval tasks live beside their
+skills under `skills/<skill>/evals/`; suite entries may point there:
 
 ```yaml
 tasks:
-  - tasks/session-seed.yaml
-  - tasks/session-recall.yaml
+  - ../../skills/chat-card/evals/ticket-confirmation.yaml
+  - ../../skills/psd-directory/evals/email-exact-match.yaml
 ```
 
-The committed `core.yaml` suite has three L0 tasks. Its seed/recall pair checks
-that a passphrase stated under one session is unknown under the next.
+Every production task declares `suite: regression` or `suite: capability`.
+Regression tasks should remain at or near 100%; capability tasks are harder
+comparisons. The classification is preserved in every JSONL record. The
+committed `core.yaml` suite has three unclassified L0 smoke tasks; its
+seed/recall pair checks that a passphrase stated under one session is unknown
+under the next.
 
 ## L1 fixtures and graders
 
@@ -113,6 +133,7 @@ id: directory-lookup
 skill: psd-directory
 level: L1
 workspace: pure
+suite: regression
 prompt: "Find Ada in the staff directory."
 trials: 3
 fixtures:
@@ -156,7 +177,10 @@ Available graders:
 - `broker_request` matches route/method and optional body fields. Body matchers
   are `exact`, `contains_any`, and `numeric_equals`; dot paths address nested
   fields.
-- `no_route_called` asserts the selected route/method received no request.
+- `no_route_called` asserts the selected route/method received no request. It
+  accepts the same optional `body` matchers as `broker_request`, which lets a
+  task forbid a send operation while permitting a draft on the shared
+  `/api/agent/workspace-execute` route.
 - Broker grader routes must be in the production agent-broker allowlist; an
   explicit method must be `POST`.
 - `output_match` applies a regular expression to the final result.
@@ -173,7 +197,7 @@ the per-grader boolean and human-readable reason. Task reliability uses
 ## Hermetic tests
 
 ```bash
-UV_CACHE_DIR=/tmp/issue-1424-uv-cache \
+UV_CACHE_DIR=/tmp/issue-1425-uv-cache \
   uv run --python 3.12 --no-project -m unittest \
   infra/agent-image/test_broker_stub.py \
   infra/agent-image/test_graders.py \

--- a/infra/agent-image/eval/README.md
+++ b/infra/agent-image/eval/README.md
@@ -162,8 +162,13 @@ A fixture file is a list (or an object containing a `fixtures` list):
 ]
 ```
 
-`request_body` is an optional partial-object selector. A request to an
-allowlisted route without a matching fixture returns a named
+`request_body` is an optional recursive partial-object selector. Mapping keys
+may address list positions (for example, `"argv": {"4": "--params"}`), and a
+mapping selector applied to a JSON-string value matches its decoded fields.
+Use `{"$text_equals": "..."}` when plain text must match exactly after trimming
+transport whitespace. Use `{"$matches_any": [{...}, {...}]}` to enumerate
+fully specified alternate request shapes. A request to an allowlisted route
+without a matching fixture returns a named
 `EvalFixtureMissing` response and automatically fails the trial; it never
 falls through to a live service or a silent empty response.
 Broker operations mirror production: fixtures and requests must use `POST`,
@@ -175,8 +180,12 @@ tasks reject them instead of grading an empty capture.
 Available graders:
 
 - `broker_request` matches route/method and optional body fields. Body matchers
-  are `exact`, `contains_any`, and `numeric_equals`; dot paths address nested
-  fields.
+  are `exact`, `contains_any`, `json_contains`, `matches_any`,
+  `numeric_equals`, and `text_equals`; dot paths address nested fields.
+  `json_contains` parses a JSON string and recursively matches the declared
+  subset. `matches_any` accepts a non-empty list of recursive selectors for
+  explicitly supported request shapes. `text_equals` ignores leading/trailing
+  transport whitespace but otherwise requires exact text.
 - `no_route_called` asserts the selected route/method received no request. It
   accepts the same optional `body` matchers as `broker_request`, which lets a
   task forbid a send operation while permitting a draft on the shared

--- a/infra/agent-image/eval/broker_stub.py
+++ b/infra/agent-image/eval/broker_stub.py
@@ -321,19 +321,63 @@ def _strict_equal(actual: object, expected: object) -> bool:
     return type(actual) is type(expected) and actual == expected
 
 
-def _mapping_contains(actual: object, expected: object) -> bool:
+def mapping_contains(actual: object, expected: object) -> bool:
+    """Return whether ``actual`` recursively contains the fixture selector.
+
+    Mapping selectors may address list positions with non-negative integer
+    keys (JSON fixture files encode them as strings). When the actual value is
+    a JSON string, a mapping selector applies to the decoded value. This lets
+    fixtures constrain structured ``--params``/``--json`` argv tokens without
+    depending on key order or unrelated injected fields.
+    """
+
     if isinstance(expected, Mapping):
-        if not isinstance(actual, Mapping):
-            return False
-        return all(
-            key in actual and _mapping_contains(actual[key], value)
-            for key, value in expected.items()
-        )
+        if set(expected) == {"$matches_any"}:
+            alternatives = expected["$matches_any"]
+            return (
+                isinstance(alternatives, list)
+                and bool(alternatives)
+                and any(
+                    mapping_contains(actual, alternative)
+                    for alternative in alternatives
+                )
+            )
+        if set(expected) == {"$text_equals"}:
+            expected_text = expected["$text_equals"]
+            return (
+                isinstance(actual, str)
+                and isinstance(expected_text, str)
+                and actual.strip() == expected_text.strip()
+            )
+        if isinstance(actual, str):
+            try:
+                actual = json.loads(actual)
+            except json.JSONDecodeError:
+                return False
+        if isinstance(actual, Mapping):
+            return all(
+                key in actual and mapping_contains(actual[key], value)
+                for key, value in expected.items()
+            )
+        if isinstance(actual, list):
+            for key, value in expected.items():
+                if isinstance(key, bool):
+                    return False
+                if isinstance(key, int):
+                    index = key
+                elif isinstance(key, str) and key.isdigit():
+                    index = int(key)
+                else:
+                    return False
+                if index >= len(actual) or not mapping_contains(actual[index], value):
+                    return False
+            return True
+        return False
     if isinstance(expected, list):
         if not isinstance(actual, list) or len(actual) != len(expected):
             return False
         return all(
-            _mapping_contains(actual_value, expected_value)
+            mapping_contains(actual_value, expected_value)
             for actual_value, expected_value in zip(actual, expected, strict=True)
         )
     return _strict_equal(actual, expected)
@@ -429,7 +473,7 @@ class BrokerStubState:
             if not isinstance(fixture_method, str) or fixture_method.upper() != method:
                 continue
             expected_body = fixture.get("request_body")
-            if expected_body is not None and not _mapping_contains(body, expected_body):
+            if expected_body is not None and not mapping_contains(body, expected_body):
                 continue
             return fixture
         return None

--- a/infra/agent-image/eval/graders/__init__.py
+++ b/infra/agent-image/eval/graders/__init__.py
@@ -14,9 +14,9 @@ from dataclasses import dataclass
 from numbers import Real
 
 try:
-    from ..broker_stub import ALLOWED_AGENT_BROKER_ROUTES
+    from ..broker_stub import ALLOWED_AGENT_BROKER_ROUTES, mapping_contains
 except ImportError:
-    from broker_stub import ALLOWED_AGENT_BROKER_ROUTES
+    from broker_stub import ALLOWED_AGENT_BROKER_ROUTES, mapping_contains
 
 
 SUPPORTED_GRADERS = frozenset(
@@ -28,7 +28,16 @@ SUPPORTED_GRADERS = frozenset(
         "trajectory_in_order",
     }
 )
-BODY_MATCHERS = frozenset({"exact", "contains_any", "numeric_equals"})
+BODY_MATCHERS = frozenset(
+    {
+        "exact",
+        "contains_any",
+        "json_contains",
+        "matches_any",
+        "numeric_equals",
+        "text_equals",
+    }
+)
 
 
 class GraderConfigurationError(ValueError):
@@ -120,14 +129,14 @@ def _validate_body_matchers(value: object) -> None:
                 f"broker_request body matcher for {field} uses unsupported operator "
                 f"{operator}"
             )
-        if operator == "contains_any":
+        if operator in {"contains_any", "matches_any"}:
             if (
                 not isinstance(expected, Sequence)
                 or isinstance(expected, (str, bytes))
                 or not expected
             ):
                 raise GraderConfigurationError(
-                    f"broker_request contains_any matcher for {field} "
+                    f"broker_request {operator} matcher for {field} "
                     "must contain a non-empty list"
                 )
         if operator == "numeric_equals" and (
@@ -136,6 +145,16 @@ def _validate_body_matchers(value: object) -> None:
             raise GraderConfigurationError(
                 f"broker_request numeric_equals matcher for {field} "
                 "must contain a number"
+            )
+        if operator == "json_contains" and not isinstance(expected, Mapping):
+            raise GraderConfigurationError(
+                f"broker_request json_contains matcher for {field} "
+                "must contain an object"
+            )
+        if operator == "text_equals" and not isinstance(expected, str):
+            raise GraderConfigurationError(
+                f"broker_request text_equals matcher for {field} "
+                "must contain a string"
             )
 
 
@@ -275,6 +294,31 @@ def _match_body(
                 return (
                     False,
                     f"body field {field} contained none of {candidates!r}",
+                )
+            continue
+        if operator == "json_contains":
+            if not mapping_contains(actual, expected):
+                return (
+                    False,
+                    f"body field {field} did not contain JSON {expected!r}",
+                )
+            continue
+        if operator == "matches_any":
+            alternatives = list(expected)
+            if not any(
+                mapping_contains(actual, alternative)
+                for alternative in alternatives
+            ):
+                return (
+                    False,
+                    f"body field {field} matched none of {alternatives!r}",
+                )
+            continue
+        if operator == "text_equals":
+            if not isinstance(actual, str) or actual.strip() != expected.strip():
+                return (
+                    False,
+                    f"body field {field} expected text {expected!r}, got {actual!r}",
                 )
     return True, "body matched"
 

--- a/infra/agent-image/eval/graders/__init__.py
+++ b/infra/agent-image/eval/graders/__init__.py
@@ -147,7 +147,7 @@ def validate_grader_specs(
     normalized: list[dict[str, object]] = []
     allowed_fields = {
         "broker_request": {"type", "route", "method", "body"},
-        "no_route_called": {"type", "route", "method"},
+        "no_route_called": {"type", "route", "method", "body"},
         "output_match": {"type", "pattern", "ignore_case"},
         "trajectory_in_order": {"type", "tools"},
         "tools_catalog": {"type", "expected"},
@@ -169,9 +169,9 @@ def validate_grader_specs(
             )
         if grader in {"broker_request", "no_route_called"}:
             _validate_route(raw_spec, grader)
-        if grader == "broker_request":
+        if grader in {"broker_request", "no_route_called"}:
             _validate_body_matchers(raw_spec.get("body"))
-        elif grader == "output_match":
+        if grader == "output_match":
             pattern = _require_nonempty_string(
                 raw_spec.get("pattern"),
                 grader=grader,
@@ -334,18 +334,34 @@ def _grade_no_route_called(
     spec: Mapping[str, object],
     artifacts: TrialArtifacts,
 ) -> GraderResult:
-    matches = [
+    candidates = [
         request
         for request in artifacts.broker_requests
         if _request_matches_selector(request, spec)
     ]
+    matchers = spec.get("body")
+    matches = (
+        [
+            request
+            for request in candidates
+            if isinstance(matchers, Mapping)
+            and _match_body(request.get("body"), matchers)[0]
+        ]
+        if isinstance(matchers, Mapping) and matchers
+        else candidates
+    )
+    selector = (
+        f"{spec['route']} with matching body"
+        if isinstance(matchers, Mapping) and matchers
+        else str(spec["route"])
+    )
     return GraderResult(
         "no_route_called",
         not matches,
         (
-            f"no request captured for {spec['route']}"
+            f"no request captured for {selector}"
             if not matches
-            else f"captured {len(matches)} forbidden request(s) for {spec['route']}"
+            else f"captured {len(matches)} forbidden request(s) for {selector}"
         ),
     )
 

--- a/infra/agent-image/eval/runner.py
+++ b/infra/agent-image/eval/runner.py
@@ -1219,7 +1219,7 @@ def _task_from_mapping(value: Mapping[str, object], source: Path) -> Task:
         raise EvalRunnerError(f"{source}: workspace must be pure or mutating")
     if task.suite not in {"regression", "capability", "unclassified"}:
         raise EvalRunnerError(
-            f"{source}: suite must be regression or capability"
+            f"{source}: suite must be regression, capability, or unclassified"
         )
     if task.trials < 1 or task.trials > 20:
         raise EvalRunnerError(f"{source}: trials must be between 1 and 20")
@@ -1399,6 +1399,17 @@ def _positive_float(value: str) -> float:
     return parsed
 
 
+def _docker_name_token(prefix: str, pid: int) -> str:
+    sanitized_prefix = re.sub(
+        r"[^a-z0-9-]",
+        "-",
+        prefix.lower(),
+    ).strip("-")
+    if not sanitized_prefix:
+        raise EvalRunnerError("name prefix must contain a letter or number")
+    return f"{sanitized_prefix}-{pid}"
+
+
 def _context_ttl_seconds(invocation_timeout_seconds: int) -> int:
     ttl_seconds = (
         invocation_timeout_seconds
@@ -1480,13 +1491,7 @@ def main(argv: list[str] | None = None) -> int:
             "BUILD_MARKER": f"eval:{args.image}",
         }
         credential_provider = ActiveAwsCredentialProvider(executor)
-        name_token = re.sub(
-            r"[^a-z0-9-]",
-            "-",
-            f"{args.name_prefix}-{os.getpid()}".lower(),
-        ).strip("-")
-        if not name_token:
-            raise EvalRunnerError("name prefix must contain a letter or number")
+        name_token = _docker_name_token(args.name_prefix, os.getpid())
         runtime_factory = DockerRuntimeFactory(
             executor,
             args.image,

--- a/infra/agent-image/eval/runner.py
+++ b/infra/agent-image/eval/runner.py
@@ -1410,6 +1410,22 @@ def _docker_name_token(prefix: str, pid: int) -> str:
     return f"{sanitized_prefix}-{pid}"
 
 
+def _validate_owner_email_for_tasks(tasks: Sequence[Task], owner_email: str) -> None:
+    requires_psd_owner = any(
+        task.level == "L1" and task.suite in {"regression", "capability"}
+        for task in tasks
+    )
+    if requires_psd_owner and not re.fullmatch(
+        r"[^@\s]+@psd401\.net",
+        owner_email,
+        flags=re.IGNORECASE,
+    ):
+        raise EvalRunnerError(
+            "production L1 suites require an explicit synthetic "
+            "@psd401.net --owner-email"
+        )
+
+
 def _context_ttl_seconds(invocation_timeout_seconds: int) -> int:
     ttl_seconds = (
         invocation_timeout_seconds
@@ -1476,6 +1492,7 @@ def main(argv: list[str] | None = None) -> int:
     )
     try:
         tasks = load_suite(args.suite.resolve())
+        _validate_owner_email_for_tasks(tasks, args.owner_email)
         executor = CommandExecutor()
         repo_root = Path(__file__).resolve().parents[3]
         app_base_url = _resolve_app_base_url(

--- a/infra/agent-image/eval/runner.py
+++ b/infra/agent-image/eval/runner.py
@@ -3,7 +3,8 @@
 
 Example:
     python3 runner.py --image <tag-or-digest> --suite suites/core.yaml \
-        --trials 3 --out /tmp/issue-1424-run.jsonl
+        --trials 3 --out /tmp/issue-1425-run.jsonl \
+        --name-prefix psd-agent-eval-issue-1425
 """
 
 from __future__ import annotations
@@ -118,6 +119,7 @@ class Task:
     workspace: str
     prompt: str
     trials: int
+    suite: str = "unclassified"
     fixture_paths: tuple[Path, ...] = ()
     graders: tuple[dict[str, object], ...] = ()
 
@@ -260,6 +262,7 @@ class ProbeContextMinter:
         environment: str,
         region: str,
         *,
+        owner_email: str = DEFAULT_OWNER_EMAIL,
         credential_provider: CredentialProvider | None = None,
         ttl_seconds: int = DEFAULT_CONTEXT_TTL_SECONDS,
         minimum_remaining_seconds: int = 30,
@@ -277,6 +280,7 @@ class ProbeContextMinter:
         self._script = repo_root / "scripts/agent-workspace/mint-agent-probe-context.ts"
         self._environment = environment
         self._region = region
+        self._owner_email = owner_email
         self._credential_provider = credential_provider
         self._ttl_seconds = ttl_seconds
         self._minimum_remaining_seconds = minimum_remaining_seconds
@@ -299,6 +303,8 @@ class ProbeContextMinter:
                 "run",
                 str(self._script),
                 "--json",
+                "--owner",
+                self._owner_email,
                 "--session",
                 session_id,
                 "--ttl",
@@ -325,6 +331,10 @@ class ProbeContextMinter:
         if authority.session_id != session_id:
             raise EvalRunnerError(
                 "context minter returned a token for a different session"
+            )
+        if authority.owner_email != self._owner_email:
+            raise EvalRunnerError(
+                "context minter returned authority for a different owner"
             )
         if (
             authority.expires_at - self._now()
@@ -1044,6 +1054,7 @@ class EvaluationRunner:
             "task_id": task.id,
             "image": self._image,
             "skill": task.skill,
+            "suite": task.suite,
             "level": task.level,
             "workspace": task.workspace,
             "trial": trial_number,
@@ -1159,6 +1170,9 @@ def _task_from_mapping(value: Mapping[str, object], source: Path) -> Task:
     raw_trials = value.get("trials", 3)
     if isinstance(raw_trials, bool) or not isinstance(raw_trials, int):
         raise EvalRunnerError(f"{source}: task trials must be an integer")
+    raw_suite = value.get("suite", "unclassified")
+    if not isinstance(raw_suite, str):
+        raise EvalRunnerError(f"{source}: task suite must be a string")
     raw_fixture_paths = value.get("fixtures", [])
     if (
         not isinstance(raw_fixture_paths, list)
@@ -1191,6 +1205,7 @@ def _task_from_mapping(value: Mapping[str, object], source: Path) -> Task:
         workspace=text_fields["workspace"],
         prompt=text_fields["prompt"],
         trials=raw_trials,
+        suite=raw_suite,
         fixture_paths=tuple(fixture_paths),
         graders=graders,
     )
@@ -1202,6 +1217,10 @@ def _task_from_mapping(value: Mapping[str, object], source: Path) -> Task:
         raise EvalRunnerError(f"{source}: level must be L0, L1, or L2")
     if task.workspace not in {"pure", "mutating"}:
         raise EvalRunnerError(f"{source}: workspace must be pure or mutating")
+    if task.suite not in {"regression", "capability", "unclassified"}:
+        raise EvalRunnerError(
+            f"{source}: suite must be regression or capability"
+        )
     if task.trials < 1 or task.trials > 20:
         raise EvalRunnerError(f"{source}: trials must be between 1 and 20")
     broker_graders = sorted(
@@ -1420,11 +1439,21 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--overwrite", action="store_true")
     parser.add_argument("--environment", default=os.environ.get("ENVIRONMENT", "dev"))
     parser.add_argument("--region", default=os.environ.get("AWS_REGION", "us-east-1"))
+    parser.add_argument(
+        "--owner-email",
+        default=os.environ.get("AGENT_EVAL_OWNER_EMAIL", DEFAULT_OWNER_EMAIL),
+        help="synthetic owner identity embedded in signed trial contexts",
+    )
     parser.add_argument("--app-base-url")
     parser.add_argument("--platform", default="linux/arm64")
     parser.add_argument("--boot-timeout", type=_positive_integer, default=120)
     parser.add_argument("--invocation-timeout", type=_positive_integer, default=900)
     parser.add_argument("--poll-interval", type=_positive_float, default=2.0)
+    parser.add_argument(
+        "--name-prefix",
+        default="psd-agent-eval",
+        help="issue-specific prefix for temporary Docker container names",
+    )
     return parser
 
 
@@ -1454,8 +1483,10 @@ def main(argv: list[str] | None = None) -> int:
         name_token = re.sub(
             r"[^a-z0-9-]",
             "-",
-            f"issue-1424-{os.getpid()}".lower(),
-        )
+            f"{args.name_prefix}-{os.getpid()}".lower(),
+        ).strip("-")
+        if not name_token:
+            raise EvalRunnerError("name prefix must contain a letter or number")
         runtime_factory = DockerRuntimeFactory(
             executor,
             args.image,
@@ -1465,7 +1496,7 @@ def main(argv: list[str] | None = None) -> int:
             boot_timeout_seconds=args.boot_timeout,
             invocation_timeout_seconds=args.invocation_timeout,
             poll_interval_seconds=args.poll_interval,
-            name_prefix=f"psd-agent-eval-{name_token}",
+            name_prefix=name_token,
             broker_stub_path=repo_root
             / "infra"
             / "agent-image"
@@ -1477,6 +1508,7 @@ def main(argv: list[str] | None = None) -> int:
             repo_root,
             args.environment,
             args.region,
+            owner_email=args.owner_email,
             credential_provider=credential_provider,
             ttl_seconds=_context_ttl_seconds(args.invocation_timeout),
             minimum_remaining_seconds=(

--- a/infra/agent-image/eval/suites/capability.yaml
+++ b/infra/agent-image/eval/suites/capability.yaml
@@ -1,0 +1,6 @@
+# Harder daily-driver tasks used to compare model capability.
+tasks:
+  - ../../skills/chat-card/evals/morning-brief-card.yaml
+  - ../../skills/psd-directory/evals/chat-sender-identity.yaml
+  - ../../skills/psd-freshservice/evals/search-open-urgent-tickets.yaml
+  - ../../skills/psd-workspace/evals/create-calendar-event.yaml

--- a/infra/agent-image/eval/suites/regression.yaml
+++ b/infra/agent-image/eval/suites/regression.yaml
@@ -1,0 +1,10 @@
+# Daily-driver tasks expected to remain at or near 100% pass^3.
+tasks:
+  - ../../skills/chat-card/evals/ticket-confirmation.yaml
+  - ../../skills/chat-card/evals/single-sentence-plain-text.yaml
+  - ../../skills/psd-directory/evals/email-exact-match.yaml
+  - ../../skills/psd-directory/evals/literal-address-no-lookup.yaml
+  - ../../skills/psd-freshservice/evals/create-ticket-basic.yaml
+  - ../../skills/psd-freshservice/evals/update-ticket-priority.yaml
+  - ../../skills/psd-workspace/evals/list-unread-mail.yaml
+  - ../../skills/psd-workspace/evals/draft-email-not-send.yaml

--- a/infra/agent-image/skills/chat-card/evals/morning-brief-card.yaml
+++ b/infra/agent-image/skills/chat-card/evals/morning-brief-card.yaml
@@ -1,0 +1,14 @@
+id: chat-card-morning-brief
+skill: chat-card
+level: L0
+workspace: pure
+suite: capability
+prompt: "Use the chat-card skill to create a rich card titled \"Morning Brief — Harbor Ridge\" with these three facts: 3 meetings today, 7 unread messages, and 1 follow-up due. Include the text fallback \"Harbor Ridge morning brief\". Do not call external services."
+trials: 3
+graders:
+  - {"type":"output_match","pattern":"<<<PSD_AGENT_RICH_V1>>>[\\s\\S]*<<<END_PSD_AGENT_RICH_V1>>>"}
+  - {"type":"output_match","pattern":"Morning Brief"}
+  - {"type":"output_match","pattern":"\"topLabel\":\"Meetings today\",\"text\":\"3\""}
+  - {"type":"output_match","pattern":"\"topLabel\":\"Unread messages\",\"text\":\"7\""}
+  - {"type":"output_match","pattern":"\"topLabel\":\"Follow-up(?:s)? due\",\"text\":\"1\""}
+  - {"type":"output_match","pattern":"\"textFallback\":\"Harbor Ridge morning brief\""}

--- a/infra/agent-image/skills/chat-card/evals/single-sentence-plain-text.yaml
+++ b/infra/agent-image/skills/chat-card/evals/single-sentence-plain-text.yaml
@@ -1,0 +1,9 @@
+id: chat-card-single-sentence-plain-text
+skill: chat-card
+level: L0
+workspace: pure
+suite: regression
+prompt: "Reply exactly: The projector is back online. This is a single short sentence, so do not use a rich card or any tool."
+trials: 3
+graders:
+  - {"type":"output_match","pattern":"\\A(?![\\s\\S]*PSD_AGENT_RICH_V1)\\s*The projector is back online\\.\\s*\\Z"}

--- a/infra/agent-image/skills/chat-card/evals/ticket-confirmation.yaml
+++ b/infra/agent-image/skills/chat-card/evals/ticket-confirmation.yaml
@@ -1,0 +1,12 @@
+id: chat-card-ticket-confirmation
+skill: chat-card
+level: L0
+workspace: pure
+suite: regression
+prompt: "Use the chat-card skill to return a rich confirmation card for FreshService ticket 48291. The card title must be \"FreshService ticket created\", include Ticket ID 48291 and Status Open, and use the text fallback \"Ticket 48291 created\". Do not call external services."
+trials: 3
+graders:
+  - {"type":"output_match","pattern":"<<<PSD_AGENT_RICH_V1>>>[\\s\\S]*<<<END_PSD_AGENT_RICH_V1>>>"}
+  - {"type":"output_match","pattern":"FreshService ticket created"}
+  - {"type":"output_match","pattern":"48291"}
+  - {"type":"output_match","pattern":"\"textFallback\":\"Ticket 48291 created\""}

--- a/infra/agent-image/skills/psd-directory/evals/chat-sender-identity.yaml
+++ b/infra/agent-image/skills/psd-directory/evals/chat-sender-identity.yaml
@@ -3,12 +3,12 @@ skill: psd-directory
 level: L1
 workspace: pure
 suite: capability
-prompt: "A Google Chat message came from users/116264913639920976203. Use psd-directory to identify the sender, then tell me their name, department, and canonical email."
+prompt: "A Google Chat message came from users/100000000000000000001. Use psd-directory to identify the sender, then tell me their name, department, and canonical email."
 trials: 3
 fixtures:
   - fixtures/chat-sender-identity.json
 graders:
-  - {"type":"broker_request","route":"/api/agent/directory-lookup","method":"POST","body":{"chatId":{"exact":"users/116264913639920976203"}}}
-  - {"type":"output_match","pattern":"Kris Hagel"}
+  - {"type":"broker_request","route":"/api/agent/directory-lookup","method":"POST","body":{"chatId":{"exact":"users/100000000000000000001"}}}
+  - {"type":"output_match","pattern":"Eval Directory User"}
   - {"type":"output_match","pattern":"Technology Services"}
-  - {"type":"output_match","pattern":"hagelk@psd401\\.net"}
+  - {"type":"output_match","pattern":"eval\\.directory\\.user@psd401\\.net"}

--- a/infra/agent-image/skills/psd-directory/evals/chat-sender-identity.yaml
+++ b/infra/agent-image/skills/psd-directory/evals/chat-sender-identity.yaml
@@ -1,0 +1,14 @@
+id: directory-chat-sender-identity
+skill: psd-directory
+level: L1
+workspace: pure
+suite: capability
+prompt: "A Google Chat message came from users/116264913639920976203. Use psd-directory to identify the sender, then tell me their name, department, and canonical email."
+trials: 3
+fixtures:
+  - fixtures/chat-sender-identity.json
+graders:
+  - {"type":"broker_request","route":"/api/agent/directory-lookup","method":"POST","body":{"chatId":{"exact":"users/116264913639920976203"}}}
+  - {"type":"output_match","pattern":"Kris Hagel"}
+  - {"type":"output_match","pattern":"Technology Services"}
+  - {"type":"output_match","pattern":"hagelk@psd401\\.net"}

--- a/infra/agent-image/skills/psd-directory/evals/email-exact-match.yaml
+++ b/infra/agent-image/skills/psd-directory/evals/email-exact-match.yaml
@@ -3,11 +3,11 @@ skill: psd-directory
 level: L1
 workspace: pure
 suite: regression
-prompt: "Use psd-directory to look up the exact email pat.lee@psd401.net. Tell me the person's display name and title."
+prompt: "Use psd-directory to look up the exact email fixture.person@psd401.net. Tell me the person's display name and title."
 trials: 3
 fixtures:
   - fixtures/email-exact-match.json
 graders:
-  - {"type":"broker_request","route":"/api/agent/directory-lookup","method":"POST","body":{"email":{"exact":"pat.lee@psd401.net"}}}
-  - {"type":"output_match","pattern":"Pat Lee"}
-  - {"type":"output_match","pattern":"Library Media Specialist"}
+  - {"type":"broker_request","route":"/api/agent/directory-lookup","method":"POST","body":{"email":{"exact":"fixture.person@psd401.net"}}}
+  - {"type":"output_match","pattern":"Fixture Person"}
+  - {"type":"output_match","pattern":"Synthetic Directory Record"}

--- a/infra/agent-image/skills/psd-directory/evals/email-exact-match.yaml
+++ b/infra/agent-image/skills/psd-directory/evals/email-exact-match.yaml
@@ -1,0 +1,13 @@
+id: directory-email-exact-match
+skill: psd-directory
+level: L1
+workspace: pure
+suite: regression
+prompt: "Use psd-directory to look up the exact email pat.lee@psd401.net. Tell me the person's display name and title."
+trials: 3
+fixtures:
+  - fixtures/email-exact-match.json
+graders:
+  - {"type":"broker_request","route":"/api/agent/directory-lookup","method":"POST","body":{"email":{"exact":"pat.lee@psd401.net"}}}
+  - {"type":"output_match","pattern":"Pat Lee"}
+  - {"type":"output_match","pattern":"Library Media Specialist"}

--- a/infra/agent-image/skills/psd-directory/evals/fixtures/chat-sender-identity.json
+++ b/infra/agent-image/skills/psd-directory/evals/fixtures/chat-sender-identity.json
@@ -1,0 +1,22 @@
+[
+  {
+    "route": "/api/agent/directory-lookup",
+    "method": "POST",
+    "request_body": {
+      "chatId": "users/116264913639920976203"
+    },
+    "response": {
+      "status": 200,
+      "body": {
+        "found": true,
+        "personId": "116264913639920976203",
+        "displayName": "Kris Hagel",
+        "email": "hagelk@psd401.net",
+        "title": "Chief Information Officer",
+        "department": "Technology Services",
+        "organization": "Peninsula School District",
+        "cached": false
+      }
+    }
+  }
+]

--- a/infra/agent-image/skills/psd-directory/evals/fixtures/chat-sender-identity.json
+++ b/infra/agent-image/skills/psd-directory/evals/fixtures/chat-sender-identity.json
@@ -3,16 +3,16 @@
     "route": "/api/agent/directory-lookup",
     "method": "POST",
     "request_body": {
-      "chatId": "users/116264913639920976203"
+      "chatId": "users/100000000000000000001"
     },
     "response": {
       "status": 200,
       "body": {
         "found": true,
-        "personId": "116264913639920976203",
-        "displayName": "Kris Hagel",
-        "email": "hagelk@psd401.net",
-        "title": "Chief Information Officer",
+        "personId": "100000000000000000001",
+        "displayName": "Eval Directory User",
+        "email": "eval.directory.user@psd401.net",
+        "title": "Synthetic Fixture User",
         "department": "Technology Services",
         "organization": "Peninsula School District",
         "cached": false

--- a/infra/agent-image/skills/psd-directory/evals/fixtures/email-exact-match.json
+++ b/infra/agent-image/skills/psd-directory/evals/fixtures/email-exact-match.json
@@ -1,0 +1,22 @@
+[
+  {
+    "route": "/api/agent/directory-lookup",
+    "method": "POST",
+    "request_body": {
+      "email": "pat.lee@psd401.net"
+    },
+    "response": {
+      "status": 200,
+      "body": {
+        "found": true,
+        "personId": "118000000000000000001",
+        "displayName": "Pat Lee",
+        "email": "pat.lee@psd401.net",
+        "title": "Library Media Specialist",
+        "department": "Harbor Ridge Middle School",
+        "organization": "Peninsula School District",
+        "cached": false
+      }
+    }
+  }
+]

--- a/infra/agent-image/skills/psd-directory/evals/fixtures/email-exact-match.json
+++ b/infra/agent-image/skills/psd-directory/evals/fixtures/email-exact-match.json
@@ -3,16 +3,16 @@
     "route": "/api/agent/directory-lookup",
     "method": "POST",
     "request_body": {
-      "email": "pat.lee@psd401.net"
+      "email": "fixture.person@psd401.net"
     },
     "response": {
       "status": 200,
       "body": {
         "found": true,
-        "personId": "118000000000000000001",
-        "displayName": "Pat Lee",
-        "email": "pat.lee@psd401.net",
-        "title": "Library Media Specialist",
+        "personId": "100000000000000000002",
+        "displayName": "Fixture Person",
+        "email": "fixture.person@psd401.net",
+        "title": "Synthetic Directory Record",
         "department": "Harbor Ridge Middle School",
         "organization": "Peninsula School District",
         "cached": false

--- a/infra/agent-image/skills/psd-directory/evals/literal-address-no-lookup.yaml
+++ b/infra/agent-image/skills/psd-directory/evals/literal-address-no-lookup.yaml
@@ -1,0 +1,10 @@
+id: directory-literal-address-no-lookup
+skill: psd-directory
+level: L1
+workspace: pure
+suite: regression
+prompt: "Return the literal placeholder address substitute@psd401.net exactly as written. Do not identify the person, query the directory, or use any tool."
+trials: 3
+graders:
+  - {"type":"no_route_called","route":"/api/agent/directory-lookup","method":"POST"}
+  - {"type":"output_match","pattern":"\\Asubstitute@psd401\\.net\\s*\\Z"}

--- a/infra/agent-image/skills/psd-freshservice/evals/create-ticket-basic.yaml
+++ b/infra/agent-image/skills/psd-freshservice/evals/create-ticket-basic.yaml
@@ -8,5 +8,5 @@ trials: 3
 fixtures:
   - fixtures/create-ticket-basic.json
 graders:
-  - {"type":"broker_request","route":"/api/agent/credentials","method":"POST","body":{"operation":{"exact":"freshservice"},"path":{"exact":"/tickets"},"method":{"exact":"POST"},"body.subject":{"exact":"Harbor Ridge library projector offline"},"body.email":{"exact":"teacher@psd401.net"},"body.priority":{"numeric_equals":2}}}
+  - {"type":"broker_request","route":"/api/agent/credentials","method":"POST","body":{"operation":{"exact":"freshservice"},"path":{"exact":"/tickets"},"method":{"exact":"POST"},"body.subject":{"exact":"Harbor Ridge library projector offline"},"body.description":{"exact":"The ceiling projector has no power."},"body.email":{"exact":"teacher@psd401.net"},"body.priority":{"numeric_equals":2}}}
   - {"type":"output_match","pattern":"48291"}

--- a/infra/agent-image/skills/psd-freshservice/evals/create-ticket-basic.yaml
+++ b/infra/agent-image/skills/psd-freshservice/evals/create-ticket-basic.yaml
@@ -1,0 +1,12 @@
+id: freshservice-create-ticket-basic
+skill: psd-freshservice
+level: L1
+workspace: pure
+suite: regression
+prompt: "Use psd-freshservice to create a normal-priority ticket for requester teacher@psd401.net. Use the exact subject \"Harbor Ridge library projector offline\" and description \"The ceiling projector has no power.\""
+trials: 3
+fixtures:
+  - fixtures/create-ticket-basic.json
+graders:
+  - {"type":"broker_request","route":"/api/agent/credentials","method":"POST","body":{"operation":{"exact":"freshservice"},"path":{"exact":"/tickets"},"method":{"exact":"POST"},"body.subject":{"exact":"Harbor Ridge library projector offline"},"body.email":{"exact":"teacher@psd401.net"},"body.priority":{"numeric_equals":2}}}
+  - {"type":"output_match","pattern":"48291"}

--- a/infra/agent-image/skills/psd-freshservice/evals/fixtures/create-ticket-basic.json
+++ b/infra/agent-image/skills/psd-freshservice/evals/fixtures/create-ticket-basic.json
@@ -8,6 +8,7 @@
       "method": "POST",
       "body": {
         "subject": "Harbor Ridge library projector offline",
+        "description": "The ceiling projector has no power.",
         "email": "teacher@psd401.net",
         "priority": 2
       }

--- a/infra/agent-image/skills/psd-freshservice/evals/fixtures/create-ticket-basic.json
+++ b/infra/agent-image/skills/psd-freshservice/evals/fixtures/create-ticket-basic.json
@@ -1,0 +1,30 @@
+[
+  {
+    "route": "/api/agent/credentials",
+    "method": "POST",
+    "request_body": {
+      "operation": "freshservice",
+      "path": "/tickets",
+      "method": "POST",
+      "body": {
+        "subject": "Harbor Ridge library projector offline",
+        "email": "teacher@psd401.net",
+        "priority": 2
+      }
+    },
+    "response": {
+      "status": 200,
+      "body": {
+        "ok": true,
+        "status": 201,
+        "data": {
+          "id": 48291,
+          "subject": "Harbor Ridge library projector offline",
+          "status": 2,
+          "priority": 2,
+          "workspace_id": 2
+        }
+      }
+    }
+  }
+]

--- a/infra/agent-image/skills/psd-freshservice/evals/fixtures/search-open-urgent-tickets.json
+++ b/infra/agent-image/skills/psd-freshservice/evals/fixtures/search-open-urgent-tickets.json
@@ -1,0 +1,32 @@
+[
+  {
+    "route": "/api/agent/credentials",
+    "method": "POST",
+    "request_body": {
+      "operation": "freshservice",
+      "method": "GET"
+    },
+    "response": {
+      "status": 200,
+      "body": {
+        "ok": true,
+        "status": 200,
+        "data": {
+          "tickets": [
+            {
+              "id": 48291,
+              "subject": "Projector outage at Harbor Ridge",
+              "status": 2,
+              "priority": 4,
+              "workspace_id": 2,
+              "responder_id": 9102,
+              "created_at": "2026-07-28T15:00:00Z",
+              "updated_at": "2026-07-28T17:00:00Z",
+              "due_by": "2026-07-29T17:00:00Z"
+            }
+          ]
+        }
+      }
+    }
+  }
+]

--- a/infra/agent-image/skills/psd-freshservice/evals/fixtures/update-ticket-priority.json
+++ b/infra/agent-image/skills/psd-freshservice/evals/fixtures/update-ticket-priority.json
@@ -1,0 +1,28 @@
+[
+  {
+    "route": "/api/agent/credentials",
+    "method": "POST",
+    "request_body": {
+      "operation": "freshservice",
+      "path": "/tickets/48291",
+      "method": "PUT",
+      "body": {
+        "priority": 4
+      }
+    },
+    "response": {
+      "status": 200,
+      "body": {
+        "ok": true,
+        "status": 200,
+        "data": {
+          "id": 48291,
+          "subject": "Harbor Ridge library projector offline",
+          "status": 2,
+          "priority": 4,
+          "workspace_id": 2
+        }
+      }
+    }
+  }
+]

--- a/infra/agent-image/skills/psd-freshservice/evals/search-open-urgent-tickets.yaml
+++ b/infra/agent-image/skills/psd-freshservice/evals/search-open-urgent-tickets.yaml
@@ -1,0 +1,13 @@
+id: freshservice-search-open-urgent-tickets
+skill: psd-freshservice
+level: L1
+workspace: pure
+suite: capability
+prompt: "Use the psd-freshservice search_tickets operation to find open urgent tickets in Technology workspace 2. Summarize the matching ticket IDs and subjects."
+trials: 3
+fixtures:
+  - fixtures/search-open-urgent-tickets.json
+graders:
+  - {"type":"broker_request","route":"/api/agent/credentials","method":"POST","body":{"operation":{"exact":"freshservice"},"path":{"contains_any":["/tickets/filter?query="]},"method":{"exact":"GET"}}}
+  - {"type":"output_match","pattern":"48291"}
+  - {"type":"output_match","pattern":"Projector outage"}

--- a/infra/agent-image/skills/psd-freshservice/evals/search-open-urgent-tickets.yaml
+++ b/infra/agent-image/skills/psd-freshservice/evals/search-open-urgent-tickets.yaml
@@ -8,6 +8,6 @@ trials: 3
 fixtures:
   - fixtures/search-open-urgent-tickets.json
 graders:
-  - {"type":"broker_request","route":"/api/agent/credentials","method":"POST","body":{"operation":{"exact":"freshservice"},"path":{"contains_any":["/tickets/filter?query="]},"method":{"exact":"GET"}}}
+  - {"type":"broker_request","route":"/api/agent/credentials","method":"POST","body":{"operation":{"exact":"freshservice"},"path":{"exact":"/tickets/filter?query=\"status%3A2%20AND%20priority%3A4\"&workspace_id=2"},"method":{"exact":"GET"}}}
   - {"type":"output_match","pattern":"48291"}
   - {"type":"output_match","pattern":"Projector outage"}

--- a/infra/agent-image/skills/psd-freshservice/evals/update-ticket-priority.yaml
+++ b/infra/agent-image/skills/psd-freshservice/evals/update-ticket-priority.yaml
@@ -1,0 +1,13 @@
+id: freshservice-update-ticket-priority
+skill: psd-freshservice
+level: L1
+workspace: pure
+suite: regression
+prompt: "Use psd-freshservice to update ticket 48291 to urgent priority. Make no other change."
+trials: 3
+fixtures:
+  - fixtures/update-ticket-priority.json
+graders:
+  - {"type":"broker_request","route":"/api/agent/credentials","method":"POST","body":{"operation":{"exact":"freshservice"},"path":{"exact":"/tickets/48291"},"method":{"exact":"PUT"},"body.priority":{"numeric_equals":4}}}
+  - {"type":"output_match","pattern":"48291"}
+  - {"type":"output_match","pattern":"urgent|priority\\s*4","ignore_case":true}

--- a/infra/agent-image/skills/psd-workspace/evals/create-calendar-event.yaml
+++ b/infra/agent-image/skills/psd-workspace/evals/create-calendar-event.yaml
@@ -8,6 +8,5 @@ trials: 3
 fixtures:
   - fixtures/create-calendar-event.json
 graders:
-  - {"type":"broker_request","route":"/api/agent/workspace-execute","method":"POST","body":{"scope":{"exact":"user"},"argv.0":{"exact":"calendar"},"argv.1":{"exact":"events"},"argv.2":{"exact":"insert"}}}
-  - {"type":"output_match","pattern":"Library projector check"}
+  - {"type":"broker_request","route":"/api/agent/workspace-execute","method":"POST","body":{"scope":{"exact":"user"},"argv":{"matches_any":[{"0":"calendar","1":"events","2":"insert","3":"--params","4":{"calendarId":"primary"},"5":"--json","6":{"summary":"Library projector check","start":{"dateTime":"2026-08-03T09:00:00-07:00"},"end":{"dateTime":"2026-08-03T09:30:00-07:00"}}},{"0":"calendar","1":"+insert","2":"--summary","3":"Library projector check","4":"--start","5":"2026-08-03T09:00:00-07:00","6":"--end","7":"2026-08-03T09:30:00-07:00"}]}}}
   - {"type":"output_match","pattern":"created|scheduled","ignore_case":true}

--- a/infra/agent-image/skills/psd-workspace/evals/create-calendar-event.yaml
+++ b/infra/agent-image/skills/psd-workspace/evals/create-calendar-event.yaml
@@ -1,0 +1,13 @@
+id: workspace-create-calendar-event
+skill: psd-workspace
+level: L1
+workspace: mutating
+suite: capability
+prompt: "Use psd-workspace to create a 30-minute event on my primary calendar titled \"Library projector check\" from 9:00 AM to 9:30 AM Pacific on August 3, 2026."
+trials: 3
+fixtures:
+  - fixtures/create-calendar-event.json
+graders:
+  - {"type":"broker_request","route":"/api/agent/workspace-execute","method":"POST","body":{"scope":{"exact":"user"},"argv.0":{"exact":"calendar"},"argv.1":{"contains_any":["events","+insert"]},"argv":{"contains_any":["insert","+insert"]}}}
+  - {"type":"output_match","pattern":"Library projector check"}
+  - {"type":"output_match","pattern":"created|scheduled","ignore_case":true}

--- a/infra/agent-image/skills/psd-workspace/evals/create-calendar-event.yaml
+++ b/infra/agent-image/skills/psd-workspace/evals/create-calendar-event.yaml
@@ -8,6 +8,6 @@ trials: 3
 fixtures:
   - fixtures/create-calendar-event.json
 graders:
-  - {"type":"broker_request","route":"/api/agent/workspace-execute","method":"POST","body":{"scope":{"exact":"user"},"argv.0":{"exact":"calendar"},"argv.1":{"contains_any":["events","+insert"]},"argv":{"contains_any":["insert","+insert"]}}}
+  - {"type":"broker_request","route":"/api/agent/workspace-execute","method":"POST","body":{"scope":{"exact":"user"},"argv.0":{"exact":"calendar"},"argv.1":{"exact":"events"},"argv.2":{"exact":"insert"}}}
   - {"type":"output_match","pattern":"Library projector check"}
   - {"type":"output_match","pattern":"created|scheduled","ignore_case":true}

--- a/infra/agent-image/skills/psd-workspace/evals/draft-email-not-send.yaml
+++ b/infra/agent-image/skills/psd-workspace/evals/draft-email-not-send.yaml
@@ -8,5 +8,5 @@ trials: 3
 fixtures:
   - fixtures/draft-email-not-send.json
 graders:
-  - {"type":"no_route_called","route":"/api/agent/workspace-execute","method":"POST","body":{"argv":{"contains_any":["+send","send","messages.send","drafts.send","gmail.users.messages.send","gmail.users.drafts.send","+reply","+reply-all","+forward"]}}}
+  - {"type":"no_route_called","route":"/api/agent/workspace-execute","method":"POST","body":{"argv":{"contains_any":["+send","send","+reply","reply","+reply-all","reply-all","+forward","forward"]}}}
   - {"type":"output_match","pattern":"draft","ignore_case":true}

--- a/infra/agent-image/skills/psd-workspace/evals/draft-email-not-send.yaml
+++ b/infra/agent-image/skills/psd-workspace/evals/draft-email-not-send.yaml
@@ -3,10 +3,11 @@ skill: psd-workspace
 level: L1
 workspace: mutating
 suite: regression
-prompt: "Draft, but do not send, an email to principal@psd401.net with subject \"Projector follow-up\" and body \"The library projector is working again.\" Keep it as a draft for review; sending is not authorized."
+prompt: "Use psd-workspace's documented `gmail +draft` helper to draft, but not send, an email to principal@psd401.net with subject \"Projector follow-up\" and body \"The library projector is working again.\" Keep it as a draft for review; sending is not authorized."
 trials: 3
 fixtures:
   - fixtures/draft-email-not-send.json
 graders:
+  - {"type":"broker_request","route":"/api/agent/workspace-execute","method":"POST","body":{"scope":{"exact":"user"},"argv.0":{"exact":"gmail"},"argv.1":{"exact":"+draft"},"argv.2":{"exact":"--to"},"argv.3":{"exact":"principal@psd401.net"},"argv.4":{"exact":"--subject"},"argv.5":{"exact":"Projector follow-up"},"argv.6":{"exact":"--body"},"argv.7":{"text_equals":"The library projector is working again."}}}
   - {"type":"no_route_called","route":"/api/agent/workspace-execute","method":"POST","body":{"argv":{"contains_any":["+send","send","+reply","reply","+reply-all","reply-all","+forward","forward"]}}}
   - {"type":"output_match","pattern":"draft","ignore_case":true}

--- a/infra/agent-image/skills/psd-workspace/evals/draft-email-not-send.yaml
+++ b/infra/agent-image/skills/psd-workspace/evals/draft-email-not-send.yaml
@@ -1,0 +1,12 @@
+id: workspace-draft-email-not-send
+skill: psd-workspace
+level: L1
+workspace: mutating
+suite: regression
+prompt: "Draft, but do not send, an email to principal@psd401.net with subject \"Projector follow-up\" and body \"The library projector is working again.\" Keep it as a draft for review; sending is not authorized."
+trials: 3
+fixtures:
+  - fixtures/draft-email-not-send.json
+graders:
+  - {"type":"no_route_called","route":"/api/agent/workspace-execute","method":"POST","body":{"argv":{"contains_any":["+send","send","messages.send","drafts.send","gmail.users.messages.send","gmail.users.drafts.send","+reply","+reply-all","+forward"]}}}
+  - {"type":"output_match","pattern":"draft","ignore_case":true}

--- a/infra/agent-image/skills/psd-workspace/evals/fixtures/create-calendar-event.json
+++ b/infra/agent-image/skills/psd-workspace/evals/fixtures/create-calendar-event.json
@@ -3,7 +3,40 @@
     "route": "/api/agent/workspace-execute",
     "method": "POST",
     "request_body": {
-      "scope": "user"
+      "scope": "user",
+      "argv": {
+        "$matches_any": [
+          {
+            "0": "calendar",
+            "1": "events",
+            "2": "insert",
+            "3": "--params",
+            "4": {
+              "calendarId": "primary"
+            },
+            "5": "--json",
+            "6": {
+              "summary": "Library projector check",
+              "start": {
+                "dateTime": "2026-08-03T09:00:00-07:00"
+              },
+              "end": {
+                "dateTime": "2026-08-03T09:30:00-07:00"
+              }
+            }
+          },
+          {
+            "0": "calendar",
+            "1": "+insert",
+            "2": "--summary",
+            "3": "Library projector check",
+            "4": "--start",
+            "5": "2026-08-03T09:00:00-07:00",
+            "6": "--end",
+            "7": "2026-08-03T09:30:00-07:00"
+          }
+        ]
+      }
     },
     "response": {
       "status": 200,

--- a/infra/agent-image/skills/psd-workspace/evals/fixtures/create-calendar-event.json
+++ b/infra/agent-image/skills/psd-workspace/evals/fixtures/create-calendar-event.json
@@ -1,0 +1,16 @@
+[
+  {
+    "route": "/api/agent/workspace-execute",
+    "method": "POST",
+    "request_body": {
+      "scope": "user"
+    },
+    "response": {
+      "status": 200,
+      "body": {
+        "stdout": "{\"id\":\"evt-projector-check\",\"status\":\"confirmed\",\"summary\":\"Library projector check\",\"htmlLink\":\"https://calendar.google.com/calendar/event?eid=fixture\"}\n",
+        "stderr": ""
+      }
+    }
+  }
+]

--- a/infra/agent-image/skills/psd-workspace/evals/fixtures/draft-email-not-send.json
+++ b/infra/agent-image/skills/psd-workspace/evals/fixtures/draft-email-not-send.json
@@ -1,0 +1,23 @@
+[
+  {
+    "route": "/api/agent/workspace-execute",
+    "method": "POST",
+    "response": {
+      "status": 200,
+      "body": {
+        "stdout": "{\"id\":\"draft-projector-follow-up\",\"message\":{\"threadId\":\"thread-48291\"}}\n",
+        "stderr": ""
+      }
+    }
+  },
+  {
+    "route": "/api/agent/failures",
+    "method": "POST",
+    "response": {
+      "status": 200,
+      "body": {
+        "ok": true
+      }
+    }
+  }
+]

--- a/infra/agent-image/skills/psd-workspace/evals/fixtures/draft-email-not-send.json
+++ b/infra/agent-image/skills/psd-workspace/evals/fixtures/draft-email-not-send.json
@@ -2,6 +2,21 @@
   {
     "route": "/api/agent/workspace-execute",
     "method": "POST",
+    "request_body": {
+      "scope": "user",
+      "argv": {
+        "0": "gmail",
+        "1": "+draft",
+        "2": "--to",
+        "3": "principal@psd401.net",
+        "4": "--subject",
+        "5": "Projector follow-up",
+        "6": "--body",
+        "7": {
+          "$text_equals": "The library projector is working again."
+        }
+      }
+    },
     "response": {
       "status": 200,
       "body": {

--- a/infra/agent-image/skills/psd-workspace/evals/fixtures/list-unread-mail.json
+++ b/infra/agent-image/skills/psd-workspace/evals/fixtures/list-unread-mail.json
@@ -1,0 +1,16 @@
+[
+  {
+    "route": "/api/agent/workspace-execute",
+    "method": "POST",
+    "request_body": {
+      "scope": "user"
+    },
+    "response": {
+      "status": 200,
+      "body": {
+        "stdout": "{\"messages\":[{\"id\":\"m-1001\",\"from\":\"Alex Rivera <arivera@psd401.net>\",\"subject\":\"Library projector follow-up\"}],\"resultSizeEstimate\":1}\n",
+        "stderr": ""
+      }
+    }
+  }
+]

--- a/infra/agent-image/skills/psd-workspace/evals/fixtures/list-unread-mail.json
+++ b/infra/agent-image/skills/psd-workspace/evals/fixtures/list-unread-mail.json
@@ -3,7 +3,19 @@
     "route": "/api/agent/workspace-execute",
     "method": "POST",
     "request_body": {
-      "scope": "user"
+      "scope": "user",
+      "argv": {
+        "0": "gmail",
+        "1": "users",
+        "2": "messages",
+        "3": "list",
+        "4": "--params",
+        "5": {
+          "userId": "me",
+          "q": "is:unread",
+          "maxResults": 20
+        }
+      }
     },
     "response": {
       "status": 200,

--- a/infra/agent-image/skills/psd-workspace/evals/list-unread-mail.yaml
+++ b/infra/agent-image/skills/psd-workspace/evals/list-unread-mail.yaml
@@ -1,0 +1,13 @@
+id: workspace-list-unread-mail
+skill: psd-workspace
+level: L1
+workspace: pure
+suite: regression
+prompt: "Use psd-workspace to list up to 20 unread messages in my inbox. Summarize the sender and subject of each result."
+trials: 3
+fixtures:
+  - fixtures/list-unread-mail.json
+graders:
+  - {"type":"broker_request","route":"/api/agent/workspace-execute","method":"POST","body":{"scope":{"exact":"user"},"argv.0":{"exact":"gmail"},"argv.1":{"contains_any":["users","+triage"]},"argv":{"contains_any":["list","+triage"]}}}
+  - {"type":"output_match","pattern":"Alex Rivera"}
+  - {"type":"output_match","pattern":"Library projector follow-up"}

--- a/infra/agent-image/skills/psd-workspace/evals/list-unread-mail.yaml
+++ b/infra/agent-image/skills/psd-workspace/evals/list-unread-mail.yaml
@@ -8,6 +8,6 @@ trials: 3
 fixtures:
   - fixtures/list-unread-mail.json
 graders:
-  - {"type":"broker_request","route":"/api/agent/workspace-execute","method":"POST","body":{"scope":{"exact":"user"},"argv.0":{"exact":"gmail"},"argv.1":{"contains_any":["users","+triage"]},"argv":{"contains_any":["list","+triage"]}}}
+  - {"type":"broker_request","route":"/api/agent/workspace-execute","method":"POST","body":{"scope":{"exact":"user"},"argv.0":{"exact":"gmail"},"argv.1":{"exact":"users"},"argv.2":{"exact":"messages"},"argv.3":{"exact":"list"}}}
   - {"type":"output_match","pattern":"Alex Rivera"}
   - {"type":"output_match","pattern":"Library projector follow-up"}

--- a/infra/agent-image/skills/psd-workspace/evals/list-unread-mail.yaml
+++ b/infra/agent-image/skills/psd-workspace/evals/list-unread-mail.yaml
@@ -3,11 +3,11 @@ skill: psd-workspace
 level: L1
 workspace: pure
 suite: regression
-prompt: "Use psd-workspace to list up to 20 unread messages in my inbox. Summarize the sender and subject of each result."
+prompt: "Use psd-workspace's documented `gmail users messages list` command with `q` set to `is:unread` and `maxResults` set to 20. Summarize the sender and subject of each result."
 trials: 3
 fixtures:
   - fixtures/list-unread-mail.json
 graders:
-  - {"type":"broker_request","route":"/api/agent/workspace-execute","method":"POST","body":{"scope":{"exact":"user"},"argv.0":{"exact":"gmail"},"argv.1":{"exact":"users"},"argv.2":{"exact":"messages"},"argv.3":{"exact":"list"}}}
+  - {"type":"broker_request","route":"/api/agent/workspace-execute","method":"POST","body":{"scope":{"exact":"user"},"argv.0":{"exact":"gmail"},"argv.1":{"exact":"users"},"argv.2":{"exact":"messages"},"argv.3":{"exact":"list"},"argv.4":{"exact":"--params"},"argv.5":{"json_contains":{"userId":"me","q":"is:unread","maxResults":20}}}}
   - {"type":"output_match","pattern":"Alex Rivera"}
   - {"type":"output_match","pattern":"Library projector follow-up"}

--- a/infra/agent-image/test_broker_stub.py
+++ b/infra/agent-image/test_broker_stub.py
@@ -360,6 +360,75 @@ class BrokerStubHttpTests(unittest.TestCase):
         ).st_mode & 0o777
         self.assertEqual(mode, 0o600)
 
+    def test_fixture_selector_matches_indexed_argv_and_decoded_json_subsets(self):
+        self.stub.configure(
+            [
+                {
+                    "route": "/api/agent/workspace-execute",
+                    "method": "POST",
+                    "request_body": {
+                        "scope": "user",
+                        "note": {"$text_equals": "body text"},
+                        "argv": {
+                            "$matches_any": [
+                                {
+                                    "0": "calendar",
+                                    "1": "events",
+                                    "2": "insert",
+                                    "3": "--params",
+                                    "4": {"calendarId": "primary"},
+                                    "5": "--json",
+                                    "6": {
+                                        "summary": "Library projector check",
+                                        "start": {
+                                            "dateTime": (
+                                                "2026-08-03T09:00:00-07:00"
+                                            )
+                                        },
+                                    },
+                                },
+                                {"0": "calendar", "1": "+insert"},
+                            ]
+                        },
+                    },
+                    "response": {"body": {"created": True}},
+                }
+            ]
+        )
+        correct_argv = [
+            "calendar",
+            "events",
+            "insert",
+            "--params",
+            '{"calendarId":"primary","conferenceDataVersion":1}',
+            "--json",
+            (
+                '{"summary":"Library projector check",'
+                '"start":{"dateTime":"2026-08-03T09:00:00-07:00"},'
+                '"description":"injected marker"}'
+            ),
+        ]
+
+        status, response = self.stub.request(
+            "/agent-broker/api/agent/workspace-execute",
+            method="POST",
+            body={"scope": "user", "note": "body text\n", "argv": correct_argv},
+        )
+        self.assertEqual((status, response), (200, {"created": True}))
+
+        wrong_argv = list(correct_argv)
+        wrong_argv[6] = (
+            '{"summary":"Wrong title",'
+            '"start":{"dateTime":"2026-08-03T09:00:00-07:00"}}'
+        )
+        status, response = self.stub.request(
+            "/agent-broker/api/agent/workspace-execute",
+            method="POST",
+            body={"scope": "user", "note": "body text\n", "argv": wrong_argv},
+        )
+        self.assertEqual(status, 501)
+        self.assertEqual(response["error"], broker_stub.MISSING_FIXTURE_ERROR)
+
     def test_summarization_endpoint_relays_with_root_authority(self):
         received: dict[str, object] = {}
 

--- a/infra/agent-image/test_eval_runner.py
+++ b/infra/agent-image/test_eval_runner.py
@@ -15,6 +15,7 @@ import tempfile
 import unittest
 from collections import Counter
 from contextlib import redirect_stdout
+from dataclasses import replace
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from unittest import mock
@@ -289,6 +290,39 @@ class SuiteLoadingTests(unittest.TestCase):
             "name prefix must contain a letter or number",
         ):
             runner._docker_name_token("***", 123)
+
+    def test_production_l1_suites_require_an_explicit_psd_owner(self):
+        task = runner.Task(
+            "owner-bound",
+            "psd-directory",
+            "L1",
+            "pure",
+            "Look up a fixture.",
+            3,
+            suite="regression",
+        )
+        with self.assertRaisesRegex(
+            runner.EvalRunnerError,
+            "explicit synthetic @psd401.net --owner-email",
+        ):
+            runner._validate_owner_email_for_tasks(
+                [task],
+                runner.DEFAULT_OWNER_EMAIL,
+            )
+        with self.assertRaises(runner.EvalRunnerError):
+            runner._validate_owner_email_for_tasks(
+                [task],
+                "eval@example.net",
+            )
+
+        runner._validate_owner_email_for_tasks(
+            [task],
+            "eval.issue1425@psd401.net",
+        )
+        runner._validate_owner_email_for_tasks(
+            [replace(task, suite="unclassified")],
+            runner.DEFAULT_OWNER_EMAIL,
+        )
 
     def test_non_integer_trial_counts_are_rejected(self):
         base_task: dict[str, object] = {

--- a/infra/agent-image/test_eval_runner.py
+++ b/infra/agent-image/test_eval_runner.py
@@ -186,6 +186,28 @@ class SuiteLoadingTests(unittest.TestCase):
         tasks_by_id = {task.id: task for task in tasks}
         self.assertTrue(negative_task_ids.issubset(tasks_by_id))
 
+        def broker_body(task_id: str) -> dict[str, object]:
+            spec = next(
+                grader
+                for grader in tasks_by_id[task_id].graders
+                if grader.get("type") == "broker_request"
+            )
+            body = spec.get("body")
+            self.assertIsInstance(body, dict)
+            return body
+
+        def fixture_request_body(
+            task_id: str,
+            route: str,
+        ) -> dict[str, object]:
+            fixtures = runner._load_fixture_files(
+                tasks_by_id[task_id].fixture_paths
+            )
+            fixture = next(entry for entry in fixtures if entry["route"] == route)
+            body = fixture.get("request_body")
+            self.assertIsInstance(body, dict)
+            return body
+
         chat_negative = tasks_by_id["chat-card-single-sentence-plain-text"]
         self.assertTrue(
             any(
@@ -224,6 +246,120 @@ class SuiteLoadingTests(unittest.TestCase):
                 "+forward",
                 "forward",
             }.issubset(forbidden_argv)
+        )
+
+        draft_body = broker_body("workspace-draft-email-not-send")
+        self.assertEqual(
+            {
+                field: draft_body[field]
+                for field in (
+                    "scope",
+                    "argv.0",
+                    "argv.1",
+                    "argv.2",
+                    "argv.3",
+                    "argv.4",
+                    "argv.5",
+                    "argv.6",
+                    "argv.7",
+                )
+            },
+            {
+                "scope": {"exact": "user"},
+                "argv.0": {"exact": "gmail"},
+                "argv.1": {"exact": "+draft"},
+                "argv.2": {"exact": "--to"},
+                "argv.3": {"exact": "principal@psd401.net"},
+                "argv.4": {"exact": "--subject"},
+                "argv.5": {"exact": "Projector follow-up"},
+                "argv.6": {"exact": "--body"},
+                "argv.7": {
+                    "text_equals": "The library projector is working again."
+                },
+            },
+        )
+        calendar_body = broker_body("workspace-create-calendar-event")
+        expected_calendar_argv = [
+            {
+                "0": "calendar",
+                "1": "events",
+                "2": "insert",
+                "3": "--params",
+                "4": {"calendarId": "primary"},
+                "5": "--json",
+                "6": {
+                    "summary": "Library projector check",
+                    "start": {
+                        "dateTime": "2026-08-03T09:00:00-07:00"
+                    },
+                    "end": {
+                        "dateTime": "2026-08-03T09:30:00-07:00"
+                    },
+                },
+            },
+            {
+                "0": "calendar",
+                "1": "+insert",
+                "2": "--summary",
+                "3": "Library projector check",
+                "4": "--start",
+                "5": "2026-08-03T09:00:00-07:00",
+                "6": "--end",
+                "7": "2026-08-03T09:30:00-07:00",
+            },
+        ]
+        self.assertEqual(
+            calendar_body["argv"],
+            {"matches_any": expected_calendar_argv},
+        )
+        unread_body = broker_body("workspace-list-unread-mail")
+        self.assertEqual(
+            unread_body["argv.5"],
+            {
+                "json_contains": {
+                    "userId": "me",
+                    "q": "is:unread",
+                    "maxResults": 20,
+                }
+            },
+        )
+        ticket_body = broker_body("freshservice-create-ticket-basic")
+        self.assertEqual(
+            ticket_body["body.description"],
+            {"exact": "The ceiling projector has no power."},
+        )
+
+        draft_fixture = fixture_request_body(
+            "workspace-draft-email-not-send",
+            "/api/agent/workspace-execute",
+        )
+        self.assertEqual(
+            draft_fixture["argv"]["7"],
+            {"$text_equals": "The library projector is working again."},
+        )
+        calendar_fixture = fixture_request_body(
+            "workspace-create-calendar-event",
+            "/api/agent/workspace-execute",
+        )
+        self.assertEqual(
+            calendar_fixture["argv"],
+            {"$matches_any": expected_calendar_argv},
+        )
+        unread_fixture = fixture_request_body(
+            "workspace-list-unread-mail",
+            "/api/agent/workspace-execute",
+        )
+        self.assertEqual(
+            unread_fixture["argv"]["5"],
+            {"userId": "me", "q": "is:unread", "maxResults": 20},
+        )
+        ticket_fixture = fixture_request_body(
+            "freshservice-create-ticket-basic",
+            "/api/agent/credentials",
+        )
+        self.assertEqual(
+            ticket_fixture["body"]["description"],
+            "The ceiling projector has no power.",
         )
 
         for task in tasks:

--- a/infra/agent-image/test_eval_runner.py
+++ b/infra/agent-image/test_eval_runner.py
@@ -180,6 +180,7 @@ class SuiteLoadingTests(unittest.TestCase):
             "directory-literal-address-no-lookup",
             "workspace-draft-email-not-send",
         }
+        # Cross-multiply to keep the 25% threshold exact without float math.
         self.assertGreaterEqual(len(negative_task_ids) * 4, len(tasks))
         tasks_by_id = {task.id: task for task in tasks}
         self.assertTrue(negative_task_ids.issubset(tasks_by_id))
@@ -202,13 +203,26 @@ class SuiteLoadingTests(unittest.TestCase):
             )
         )
         workspace_negative = tasks_by_id["workspace-draft-email-not-send"]
+        workspace_negative_spec = next(
+            spec
+            for spec in workspace_negative.graders
+            if spec.get("type") == "no_route_called"
+            and spec.get("route") == "/api/agent/workspace-execute"
+        )
+        workspace_negative_body = workspace_negative_spec.get("body")
+        self.assertIsInstance(workspace_negative_body, dict)
+        forbidden_argv = workspace_negative_body["argv"]["contains_any"]
         self.assertTrue(
-            any(
-                spec.get("type") == "no_route_called"
-                and spec.get("route") == "/api/agent/workspace-execute"
-                and isinstance(spec.get("body"), dict)
-                for spec in workspace_negative.graders
-            )
+            {
+                "+send",
+                "send",
+                "+reply",
+                "reply",
+                "+reply-all",
+                "reply-all",
+                "+forward",
+                "forward",
+            }.issubset(forbidden_argv)
         )
 
         for task in tasks:

--- a/infra/agent-image/test_eval_runner.py
+++ b/infra/agent-image/test_eval_runner.py
@@ -251,7 +251,7 @@ class SuiteLoadingTests(unittest.TestCase):
 
         with self.assertRaisesRegex(
             runner.EvalRunnerError,
-            "suite must be regression or capability",
+            "suite must be regression, capability, or unclassified",
         ):
             runner._task_from_mapping(
                 {
@@ -264,6 +264,17 @@ class SuiteLoadingTests(unittest.TestCase):
                 },
                 Path("inline.yaml"),
             )
+
+    def test_docker_name_token_sanitizes_prefix_before_appending_pid(self):
+        self.assertEqual(
+            runner._docker_name_token("Issue 1425/Regression", 123),
+            "issue-1425-regression-123",
+        )
+        with self.assertRaisesRegex(
+            runner.EvalRunnerError,
+            "name prefix must contain a letter or number",
+        ):
+            runner._docker_name_token("***", 123)
 
     def test_non_integer_trial_counts_are_rejected(self):
         base_task: dict[str, object] = {

--- a/infra/agent-image/test_eval_runner.py
+++ b/infra/agent-image/test_eval_runner.py
@@ -13,6 +13,7 @@ import os
 import sys
 import tempfile
 import unittest
+from collections import Counter
 from contextlib import redirect_stdout
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -121,6 +122,105 @@ class SuiteLoadingTests(unittest.TestCase):
         self.assertEqual({task.workspace for task in tasks}, {"pure"})
         self.assertEqual({task.trials for task in tasks}, {3})
 
+    def test_committed_daily_driver_suites_meet_issue_1425_contract(self):
+        suite_paths = {
+            "regression": AGENT_IMAGE_DIR / "eval" / "suites" / "regression.yaml",
+            "capability": AGENT_IMAGE_DIR / "eval" / "suites" / "capability.yaml",
+        }
+        tasks_by_suite = {
+            suite: runner.load_suite(path)
+            for suite, path in suite_paths.items()
+        }
+        tasks = [
+            task
+            for suite_tasks in tasks_by_suite.values()
+            for task in suite_tasks
+        ]
+
+        self.assertEqual(len(tasks), 12)
+        self.assertEqual(len({task.id for task in tasks}), 12)
+        self.assertEqual(
+            Counter(task.skill for task in tasks),
+            Counter(
+                {
+                    "chat-card": 3,
+                    "psd-directory": 3,
+                    "psd-freshservice": 3,
+                    "psd-workspace": 3,
+                }
+            ),
+        )
+        self.assertEqual({task.trials for task in tasks}, {3})
+        for suite, suite_tasks in tasks_by_suite.items():
+            self.assertEqual({task.suite for task in suite_tasks}, {suite})
+
+        required_fields = {
+            "id",
+            "skill",
+            "level",
+            "workspace",
+            "suite",
+            "prompt",
+            "trials",
+            "graders",
+        }
+        for suite_path in suite_paths.values():
+            suite_document = runner._load_document(suite_path)
+            self.assertIsInstance(suite_document, dict)
+            for relative_path in suite_document["tasks"]:
+                task_path = (suite_path.parent / relative_path).resolve()
+                task_document = runner._load_document(task_path)
+                self.assertTrue(
+                    required_fields.issubset(task_document),
+                    f"{task_path} omitted required task fields",
+                )
+
+        negative_task_ids = {
+            "chat-card-single-sentence-plain-text",
+            "directory-literal-address-no-lookup",
+            "workspace-draft-email-not-send",
+        }
+        self.assertGreaterEqual(len(negative_task_ids) * 4, len(tasks))
+        tasks_by_id = {task.id: task for task in tasks}
+        self.assertTrue(negative_task_ids.issubset(tasks_by_id))
+
+        chat_negative = tasks_by_id["chat-card-single-sentence-plain-text"]
+        self.assertTrue(
+            any(
+                spec.get("type") == "output_match"
+                and "(?!" in str(spec.get("pattern"))
+                and "PSD_AGENT_RICH_V1" in str(spec.get("pattern"))
+                for spec in chat_negative.graders
+            )
+        )
+        directory_negative = tasks_by_id["directory-literal-address-no-lookup"]
+        self.assertTrue(
+            any(
+                spec.get("type") == "no_route_called"
+                and spec.get("route") == "/api/agent/directory-lookup"
+                for spec in directory_negative.graders
+            )
+        )
+        workspace_negative = tasks_by_id["workspace-draft-email-not-send"]
+        self.assertTrue(
+            any(
+                spec.get("type") == "no_route_called"
+                and spec.get("route") == "/api/agent/workspace-execute"
+                and isinstance(spec.get("body"), dict)
+                for spec in workspace_negative.graders
+            )
+        )
+
+        for task in tasks:
+            expected_root = (
+                AGENT_IMAGE_DIR / "skills" / task.skill / "evals"
+            ).resolve()
+            for fixture_path in task.fixture_paths:
+                self.assertTrue(
+                    fixture_path.is_relative_to(expected_root),
+                    f"{fixture_path} is not co-located with {task.skill}",
+                )
+
     def test_invalid_workspace_fails_closed(self):
         with self.subTest("validation happens after parsing"):
             with self.assertRaises(runner.EvalRunnerError):
@@ -134,6 +234,36 @@ class SuiteLoadingTests(unittest.TestCase):
                     },
                     Path("inline.yaml"),
                 )
+
+    def test_suite_classification_is_validated(self):
+        task = runner._task_from_mapping(
+            {
+                "id": "classified-task",
+                "skill": "runner-core",
+                "level": "L0",
+                "workspace": "pure",
+                "suite": "regression",
+                "prompt": "hello",
+            },
+            Path("inline.yaml"),
+        )
+        self.assertEqual(task.suite, "regression")
+
+        with self.assertRaisesRegex(
+            runner.EvalRunnerError,
+            "suite must be regression or capability",
+        ):
+            runner._task_from_mapping(
+                {
+                    "id": "bad-suite",
+                    "skill": "runner-core",
+                    "level": "L0",
+                    "workspace": "pure",
+                    "suite": "nightly",
+                    "prompt": "hello",
+                },
+                Path("inline.yaml"),
+            )
 
     def test_non_integer_trial_counts_are_rejected(self):
         base_task: dict[str, object] = {
@@ -519,6 +649,10 @@ class EvaluationRunnerTests(unittest.TestCase):
             all(record["metadata"]["future_field"] == {"preserved": True} for record in records)
         )
         self.assertEqual({record["image"] for record in records}, {"unknown"})
+        self.assertEqual(
+            {record["suite"] for record in records},
+            {"unclassified"},
+        )
 
     def test_fresh_sessions_prevent_conversation_recall(self):
         clock = AdvancingClock()
@@ -952,7 +1086,7 @@ class ProbeContextMinterTests(unittest.TestCase):
                 {
                     "invocationContext": "context",
                     "requestProofKey": "proof",
-                    "ownerEmail": "canary@build-gate.invalid",
+                    "ownerEmail": "eval.issue1425@psd401.net",
                     "sessionId": "session-id",
                     "expiresAt": (
                         clock.now() + timedelta(seconds=965)
@@ -967,6 +1101,7 @@ class ProbeContextMinterTests(unittest.TestCase):
             AGENT_IMAGE_DIR.parent.parent,
             "dev",
             "us-east-1",
+            owner_email="eval.issue1425@psd401.net",
             credential_provider=provider,
             ttl_seconds=965,
             minimum_remaining_seconds=960,
@@ -987,8 +1122,43 @@ class ProbeContextMinterTests(unittest.TestCase):
         self.assertEqual(provider.calls, 1)
         call = executor.run.call_args
         self.assertEqual(call.args[0][-2:], ["--ttl", "965"])
+        self.assertEqual(
+            call.args[0][call.args[0].index("--owner") + 1],
+            "eval.issue1425@psd401.net",
+        )
         self.assertEqual(call.kwargs["env"]["AWS_ACCESS_KEY_ID"], "fresh")
         self.assertEqual(call.kwargs["env"]["AWS_SESSION_TOKEN"], "fresh-token")
+
+    def test_rejects_authority_for_a_different_owner(self):
+        executor = mock.Mock()
+        executor.run.return_value = runner.CommandResult(
+            0,
+            json.dumps(
+                {
+                    "invocationContext": "context",
+                    "requestProofKey": "proof",
+                    "ownerEmail": "other@psd401.net",
+                    "sessionId": "session-id",
+                    "expiresAt": (
+                        datetime.now(timezone.utc) + timedelta(minutes=20)
+                    ).isoformat(),
+                }
+            ),
+            "",
+        )
+        minter = runner.ProbeContextMinter(
+            executor,
+            AGENT_IMAGE_DIR.parent.parent,
+            "dev",
+            "us-east-1",
+            owner_email="eval.issue1425@psd401.net",
+        )
+
+        with self.assertRaisesRegex(
+            runner.EvalRunnerError,
+            "different owner",
+        ):
+            minter.mint("session-id")
 
 
 class DockerRuntimeTests(unittest.TestCase):

--- a/infra/agent-image/test_graders.py
+++ b/infra/agent-image/test_graders.py
@@ -114,6 +114,41 @@ class BrokerRequestGraderTests(unittest.TestCase):
         self.assertFalse(decision["passed"])
         self.assertIn("forbidden", decision["results"][0]["reason"])
 
+    def test_no_route_called_can_forbid_only_matching_bodies_on_a_shared_route(self):
+        spec = {
+            "type": "no_route_called",
+            "route": "/api/agent/workspace-execute",
+            "body": {
+                "argv": {
+                    "contains_any": [
+                        "+send",
+                        "gmail.users.drafts.send",
+                    ]
+                }
+            },
+        }
+        safe_draft = {
+            "route": "/api/agent/workspace-execute",
+            "method": "POST",
+            "body": {
+                "scope": "user",
+                "argv": ["gmail", "+draft", "--to", "principal@psd401.net"],
+            },
+        }
+        forbidden_send = {
+            "route": "/api/agent/workspace-execute",
+            "method": "POST",
+            "body": {
+                "scope": "user",
+                "argv": ["gmail", "+send", "--to", "principal@psd401.net"],
+            },
+        }
+
+        self.assertTrue(grade([spec], requests=[safe_draft])["passed"])
+        decision = grade([spec], requests=[safe_draft, forbidden_send])
+        self.assertFalse(decision["passed"])
+        self.assertIn("matching body", decision["results"][0]["reason"])
+
 
 class OutputAndTrajectoryGraderTests(unittest.TestCase):
     def test_output_match_supports_case_insensitive_regex(self):
@@ -325,6 +360,21 @@ class GraderValidationTests(unittest.TestCase):
                             }
                         ]
                     )
+
+    def test_no_route_called_rejects_invalid_body_matchers(self):
+        with self.assertRaisesRegex(
+            graders.GraderConfigurationError,
+            "must have exactly one operator",
+        ):
+            graders.validate_grader_specs(
+                [
+                    {
+                        "type": "no_route_called",
+                        "route": "/api/agent/workspace-execute",
+                        "body": {"argv": {"contains_any": ["+send"], "exact": []}},
+                    }
+                ]
+            )
 
     def test_invalid_regex_fails_when_the_suite_loads(self):
         with self.assertRaisesRegex(

--- a/infra/agent-image/test_graders.py
+++ b/infra/agent-image/test_graders.py
@@ -52,6 +52,27 @@ class BrokerRequestGraderTests(unittest.TestCase):
                         "operation": {"exact": "calendar.events.create"},
                         "attendees": {"contains_any": ["staff@example.com"]},
                         "durationMinutes": {"numeric_equals": 30.0},
+                        "params": {
+                            "json_contains": {
+                                "calendarId": "primary",
+                                "maxResults": 20,
+                            }
+                        },
+                        "note": {"text_equals": "requested text"},
+                        "argv": {
+                            "matches_any": [
+                                {
+                                    "0": "calendar",
+                                    "1": "events",
+                                    "2": "insert",
+                                },
+                                {
+                                    "0": "calendar",
+                                    "1": "+insert",
+                                    "2": "--summary",
+                                },
+                            ]
+                        },
                     },
                 }
             ],
@@ -63,6 +84,12 @@ class BrokerRequestGraderTests(unittest.TestCase):
                         "operation": "calendar.events.create",
                         "attendees": ["owner@example.com", "staff@example.com"],
                         "durationMinutes": 30,
+                        "params": (
+                            '{"calendarId":"primary","maxResults":20,'
+                            '"singleEvents":true}'
+                        ),
+                        "note": " requested text\n",
+                        "argv": ["calendar", "+insert", "--summary", "Standup"],
                     },
                 }
             ],
@@ -93,6 +120,74 @@ class BrokerRequestGraderTests(unittest.TestCase):
 
         self.assertFalse(decision["passed"])
         self.assertIn("expected exact", decision["results"][0]["reason"])
+
+    def test_json_contains_rejects_missing_fields_and_malformed_json(self):
+        spec = {
+            "type": "broker_request",
+            "route": "/api/agent/workspace-execute",
+            "body": {
+                "params": {
+                    "json_contains": {
+                        "q": "is:unread",
+                        "maxResults": 20,
+                    }
+                }
+            },
+        }
+        for params in ('{"q":"is:unread"}', "not-json"):
+            with self.subTest(params=params):
+                decision = grade(
+                    [spec],
+                    requests=[
+                        {
+                            "route": "/api/agent/workspace-execute",
+                            "method": "POST",
+                            "body": {"params": params},
+                        }
+                    ],
+                )
+
+                self.assertFalse(decision["passed"])
+                self.assertIn(
+                    "did not contain JSON",
+                    decision["results"][0]["reason"],
+                )
+
+    def test_matches_any_rejects_when_no_structured_alternative_matches(self):
+        decision = grade(
+            [
+                {
+                    "type": "broker_request",
+                    "route": "/api/agent/workspace-execute",
+                    "body": {
+                        "argv": {
+                            "matches_any": [
+                                {
+                                    "0": "calendar",
+                                    "1": "events",
+                                    "2": "insert",
+                                },
+                                {
+                                    "0": "calendar",
+                                    "1": "+insert",
+                                    "2": "--summary",
+                                },
+                            ]
+                        }
+                    },
+                }
+            ],
+            requests=[
+                {
+                    "route": "/api/agent/workspace-execute",
+                    "method": "POST",
+                    "body": {"argv": ["calendar", "events", "list"]},
+                }
+            ],
+        )
+
+        self.assertFalse(decision["passed"])
+        self.assertIn("matched none", decision["results"][0]["reason"])
 
     def test_no_route_called_rejects_a_forbidden_side_effect(self):
         decision = grade(
@@ -372,6 +467,36 @@ class GraderValidationTests(unittest.TestCase):
                         "type": "no_route_called",
                         "route": "/api/agent/workspace-execute",
                         "body": {"argv": {"contains_any": ["+send"], "exact": []}},
+                    }
+                ]
+            )
+
+    def test_json_contains_requires_an_object_selector(self):
+        with self.assertRaisesRegex(
+            graders.GraderConfigurationError,
+            "must contain an object",
+        ):
+            graders.validate_grader_specs(
+                [
+                    {
+                        "type": "broker_request",
+                        "route": "/api/agent/workspace-execute",
+                        "body": {"argv.5": {"json_contains": "is:unread"}},
+                    }
+                ]
+            )
+
+    def test_matches_any_requires_non_empty_alternatives(self):
+        with self.assertRaisesRegex(
+            graders.GraderConfigurationError,
+            "must contain a non-empty list",
+        ):
+            graders.validate_grader_specs(
+                [
+                    {
+                        "type": "broker_request",
+                        "route": "/api/agent/workspace-execute",
+                        "body": {"argv": {"matches_any": []}},
                     }
                 ]
             )


### PR DESCRIPTION
## Summary

- add 12 three-trial daily-driver eval tasks across `chat-card`, `psd-directory`, `psd-freshservice`, and `psd-workspace`
- split stable regression tasks from harder capability comparisons and preserve the suite classification in JSONL output
- co-locate hermetic L1 broker fixtures with each skill, including three negative cases (25%) and a Workspace draft-not-send invariant
- add synthetic owner selection, issue-scoped container names, body-selective `no_route_called` grading, and fail-closed structured request selectors
- document a complete regression-suite invocation and the production-task authoring conventions

Part of #1421.

Closes #1425.

## Risks and migrations

- No database or infrastructure migrations.
- L1 fixtures intercept broker operations; the eval runs did not use live Workspace, Directory, or Freshservice credentials or create live side effects.
- Existing `core.yaml` tasks remain backward compatible as `unclassified`; new production tasks declare `regression` or `capability`.

## Validation

- `UV_CACHE_DIR=/tmp/issue-1425-uv-cache uv run --python 3.12 --no-project -m unittest infra/agent-image/test_*.py` — 382 tests, 1 configured skip
- current dev agent image `390844780692.dkr.ecr.us-east-1.amazonaws.com/psd-agent-base-dev@sha256:91819c63c875d1ad0488f95f052ae9e9c42827fe737a5177e92e7b550cc93a06`
  - capability suite — 12/12 trials passed (4 tasks at pass^3)
  - regression suite — 24/24 trials passed (8 tasks at pass^3)
  - post-review strict reruns — Workspace draft, primary-calendar creation, unread-mail query, and Freshservice description each passed 3/3 with exact request payload grading
- deterministic replay of the stricter Workspace graders over captured current-image records — all passed
- `bun run test:skill:workspace` — 70 passed
- `bun run test:skill:morning-brief` — 24 passed after rebasing onto latest `dev`
- `bun run lint` — passed
- `bun run typecheck` — passed
- `bun run test:ci -- --runInBand` — 520 suites passed; 4,811 tests passed; configured skips only
- `bun run build` — passed
- Playwright E2E not run: this change is confined to the internal agent-image eval harness and fixtures, with no user-facing flow or API behavior; the isolated worktree also has no local `AUTH_SECRET`
