### PR TITLE
fix(agent-platform): break CloudFormation cycle in schedule-target backfill role

### DIFF
--- a/infra/lib/agent-platform-stack.ts
+++ b/infra/lib/agent-platform-stack.ts
@@ -2339,6 +2339,29 @@ export class AgentPlatformStack extends cdk.Stack {
       actions: ['scheduler:ListSchedules'],
       resources: ['*'],
     }));
+    // Self-invocation for continuation paging. The ARN is FORMATTED from the
+    // known functionName rather than read off the Function construct: a
+    // `backfill.functionArn` reference emits Fn::GetAtt into the role's
+    // DefaultPolicy, while CDK also makes CfnFunction DependsOn that same
+    // DefaultPolicy (Function adds a node dependency on its role, which covers
+    // the role's child policy). That is a CloudFormation resource cycle —
+    // synth passes and the deploy fails with "Circular dependency between
+    // resources: [ScheduleTargetBackfillLambda, ScheduleTargetBackfillRole
+    // DefaultPolicy, ScheduleTargetBackfillLambdaEventInvokeConfig]".
+    // functionName is deterministic here, so the literal ARN is exact.
+    role.addToPolicy(new iam.PolicyStatement({
+      sid: 'ScheduleTargetBackfillContinue',
+      effect: iam.Effect.ALLOW,
+      actions: ['lambda:InvokeFunction'],
+      resources: [
+        this.formatArn({
+          service: 'lambda',
+          resource: 'function',
+          arnFormat: cdk.ArnFormat.COLON_RESOURCE_NAME,
+          resourceName: functionName,
+        }),
+      ],
+    }));
     const logGroup = new logs.LogGroup(
       this,
       'ScheduleTargetBackfillLogGroup',
@@ -2377,12 +2400,6 @@ export class AgentPlatformStack extends cdk.Stack {
     );
     cdk.Tags.of(backfill).add('Environment', environment);
     cdk.Tags.of(backfill).add('ManagedBy', 'cdk');
-    role.addToPolicy(new iam.PolicyStatement({
-      sid: 'ScheduleTargetBackfillContinue',
-      effect: iam.Effect.ALLOW,
-      actions: ['lambda:InvokeFunction'],
-      resources: [backfill.functionArn],
-    }));
 
     // The invocation deliberately lives in FrontendStackEcs. That stack
     // deploys after AgentPlatformStack and makes the trigger depend on the ECS

--- a/infra/test/agent-platform-resource-cycles.test.ts
+++ b/infra/test/agent-platform-resource-cycles.test.ts
@@ -1,0 +1,227 @@
+/**
+ * CloudFormation resource-cycle guard for AgentPlatformStack.
+ *
+ * A CDK stack can synthesize cleanly and still be rejected by CloudFormation at
+ * deploy time with "Circular dependency between resources". `cdk synth` does not
+ * detect intra-stack resource cycles, so nothing in the normal build catches
+ * them — the failure lands mid-deploy, after asset builds.
+ *
+ * The regression this guards: `ScheduleTargetBackfill` granted the migration
+ * Lambda permission to invoke ITSELF (continuation paging) by referencing
+ * `backfill.functionArn`. That emits `Fn::GetAtt` into the role's DefaultPolicy,
+ * while CDK independently makes the CfnFunction `DependsOn` that same
+ * DefaultPolicy (Function adds a node dependency on its role, which covers the
+ * role's child policy). Cycle:
+ *
+ *   ScheduleTargetBackfillLambda
+ *     -> DependsOn -> ScheduleTargetBackfillRoleDefaultPolicy
+ *     -> Fn::GetAtt -> ScheduleTargetBackfillLambda
+ *
+ * The fix formats the self-ARN from the deterministic functionName instead of
+ * reading it off the construct. This test asserts the whole template stays
+ * acyclic, so the same shape cannot return anywhere in the stack.
+ *
+ * Synth notes match infra/test/agent-platform-mcp-key.test.ts: the stack imports
+ * the shared VPC via `Vpc.fromLookup`, and the AgentCore runtime pins subnets to
+ * us-east-1b/1c, so the cached lookup is remapped under a test account. Asset
+ * bundling is disabled so the test never runs `bun install`/`tsc`.
+ */
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as cdk from 'aws-cdk-lib';
+import { Template } from 'aws-cdk-lib/assertions';
+import { AgentPlatformStack } from '../lib/agent-platform-stack';
+import { EnvironmentConfig } from '../lib/constructs';
+
+const TEST_ACCOUNT = '123456789012';
+const REGION = 'us-east-1';
+
+const REAL_VPC_KEY =
+  'vpc-provider:account=390844780692:filter.tag:Name=aistudio-dev-vpc:region=us-east-1:returnAsymmetricSubnets=true';
+
+function buildTemplate(environment: 'dev' | 'prod'): Template {
+  const cdkContext = JSON.parse(
+    fs.readFileSync(path.join(__dirname, '..', 'cdk.context.json'), 'utf8')
+  ) as Record<string, unknown>;
+
+  const testVpcKey =
+    `vpc-provider:account=${TEST_ACCOUNT}:filter.tag:Name=aistudio-${environment}-vpc` +
+    `:region=${REGION}:returnAsymmetricSubnets=true`;
+
+  const vpcBlob = JSON.parse(JSON.stringify(cdkContext[REAL_VPC_KEY])) as {
+    subnetGroups: Array<{ subnets: Array<{ availabilityZone: string }> }>;
+  };
+  for (const group of vpcBlob.subnetGroups) {
+    for (const subnet of group.subnets) {
+      if (subnet.availabilityZone === 'us-east-1a') subnet.availabilityZone = 'us-east-1c';
+    }
+  }
+
+  const app = new cdk.App({
+    context: {
+      ...cdkContext,
+      [testVpcKey]: vpcBlob,
+      'aws:cdk:bundling-stacks': [],
+      // The AgentCore runtime is image-gated; force it so the full resource
+      // graph — not a reduced one — is what gets checked for cycles.
+      agentImageTag: 'test-image-tag',
+    },
+  });
+
+  const stack = new AgentPlatformStack(
+    app,
+    `AIStudio-AgentPlatformStack-${environment}`,
+    {
+      environment,
+      config: EnvironmentConfig.get(environment),
+      databaseResourceArn: `arn:aws:rds:${REGION}:${TEST_ACCOUNT}:cluster:aistudio-${environment}`,
+      databaseSecretArn:
+        `arn:aws:secretsmanager:${REGION}:${TEST_ACCOUNT}:secret:aistudio-${environment}-db-AbCdEf`,
+      databaseHost: `aistudio-${environment}.cluster-abc.${REGION}.rds.amazonaws.com`,
+      databaseName: 'aistudio',
+      guardrailArn: `arn:aws:bedrock:${REGION}:${TEST_ACCOUNT}:guardrail/test`,
+      guardrailId: 'test-guardrail-id',
+      alertEmail: 'alerts@psd401.net',
+      appBaseUrl: `https://${environment}.aistudio.psd401.ai`,
+      env: { account: TEST_ACCOUNT, region: REGION },
+    }
+  );
+
+  return Template.fromStack(stack);
+}
+
+type ResourceBody = Record<string, unknown>;
+
+/**
+ * The resource names a single intrinsic points at, or null when the key is not
+ * a dependency-carrying intrinsic (so the caller keeps recursing into it).
+ */
+function targetsOfIntrinsic(key: string, value: unknown): string[] | null {
+  if (key === 'Ref') {
+    return typeof value === 'string' ? [value] : [];
+  }
+  if (key === 'Fn::GetAtt') {
+    const target = Array.isArray(value)
+      ? String(value[0])
+      : String(value).split('.')[0];
+    return [target];
+  }
+  if (key === 'DependsOn') {
+    return ([] as unknown[])
+      .concat(value)
+      .filter((dep): dep is string => typeof dep === 'string');
+  }
+  return null;
+}
+
+/**
+ * Every edge CloudFormation itself honours: explicit `DependsOn` plus the
+ * implicit ordering created by `Ref` and `Fn::GetAtt`.
+ */
+function dependenciesOf(body: unknown, known: Set<string>, into: Set<string>): Set<string> {
+  if (body === null || typeof body !== 'object') return into;
+  if (Array.isArray(body)) {
+    for (const item of body) dependenciesOf(item, known, into);
+    return into;
+  }
+  for (const [key, value] of Object.entries(body as ResourceBody)) {
+    const targets = targetsOfIntrinsic(key, value);
+    if (targets === null) {
+      dependenciesOf(value, known, into);
+      continue;
+    }
+    for (const target of targets) {
+      if (known.has(target)) into.add(target);
+    }
+  }
+  return into;
+}
+
+/** Returns each cycle as an ordered path, e.g. [A, B, A]. */
+function findResourceCycles(template: Template): string[][] {
+  const resources = template.toJSON().Resources as Record<string, ResourceBody>;
+  const names = new Set(Object.keys(resources));
+
+  const graph = new Map<string, string[]>();
+  for (const [name, body] of Object.entries(resources)) {
+    const deps = dependenciesOf(body, names, new Set<string>());
+    deps.delete(name);
+    graph.set(name, [...deps]);
+  }
+
+  const WHITE = 0, GREY = 1, BLACK = 2;
+  const color = new Map<string, number>([...names].map((n) => [n, WHITE]));
+  const cycles: string[][] = [];
+
+  for (const root of names) {
+    if (color.get(root) !== WHITE) continue;
+    const stack: Array<[string, string[]]> = [[root, [...(graph.get(root) ?? [])]]];
+    const trail: string[] = [root];
+    color.set(root, GREY);
+    while (stack.length > 0) {
+      const frame = stack[stack.length - 1];
+      const next = frame[1].shift();
+      if (next === undefined) {
+        color.set(frame[0], BLACK);
+        stack.pop();
+        trail.pop();
+        continue;
+      }
+      const state = color.get(next);
+      if (state === GREY) {
+        cycles.push([...trail.slice(trail.indexOf(next)), next]);
+      } else if (state === WHITE) {
+        color.set(next, GREY);
+        trail.push(next);
+        stack.push([next, [...(graph.get(next) ?? [])]]);
+      }
+    }
+  }
+
+  return cycles;
+}
+
+const defineAgentPlatformStackResourceCycleGuard = () => {
+  it.each(['dev', 'prod'] as const)(
+    'synthesizes %s with no CloudFormation resource cycles',
+    (environment) => {
+      const cycles = findResourceCycles(buildTemplate(environment));
+      expect(cycles.map((cycle) => cycle.join(' -> '))).toEqual([]);
+    }
+  );
+
+  it('grants the backfill Lambda self-invoke without referencing its own construct', () => {
+    const template = buildTemplate('dev');
+    const policies = template.findResources('AWS::IAM::Policy');
+    const selfInvoke = Object.values(policies)
+      .flatMap((policy) => {
+        const document = (
+          policy as {
+            Properties?: {
+              PolicyDocument?: { Statement?: Array<Record<string, unknown>> };
+            };
+          }
+        ).Properties?.PolicyDocument;
+        return document?.Statement ?? [];
+      })
+      .filter((statement) => statement.Sid === 'ScheduleTargetBackfillContinue');
+
+    expect(selfInvoke).toHaveLength(1);
+
+    // The ARN must be FORMATTED (a literal, or an Fn::Join over pseudo-params)
+    // and must NOT be an Fn::GetAtt on the function — the GetAtt form is
+    // precisely what reintroduces the deploy-time cycle. Assert on the shape,
+    // not on one rendering: whether `formatArn` collapses to a plain string or
+    // an Fn::Join depends on how the partition resolves at synth.
+    const serialized = JSON.stringify(selfInvoke[0].Resource);
+    expect(serialized).not.toContain('Fn::GetAtt');
+    expect(serialized).toContain(
+      `:lambda:${REGION}:${TEST_ACCOUNT}:function:psd-agent-schedule-target-backfill-dev`
+    );
+  });
+};
+
+describe(
+  'AgentPlatformStack — CloudFormation resource-cycle guard',
+  defineAgentPlatformStackResourceCycleGuard
+);


### PR DESCRIPTION
## Problem

The dev deploy of `AgentPlatformStack` fails:

```
Circular dependency between resources: [ScheduleTargetBackfillLambdaA13ED06D,
ScheduleTargetBackfillRoleDefaultPolicyD1BDAB8A,
ScheduleTargetBackfillLambdaEventInvokeConfigBE89BC36]
```

Present in **both the Dev and Prod** synthesized templates, so it blocks the prod deploy identically.

## Root cause

`createScheduleTargetBackfill()` granted the migration Lambda permission to invoke **itself** (continuation paging) with `resources: [backfill.functionArn]`. Reading the ARN off the construct emits `Fn::GetAtt` into the role's DefaultPolicy. Meanwhile aws-lambda's `Function` calls `resource.node.addDependency(this.role)`, and a Role's DefaultPolicy is a *child construct* of that Role — so the function also renders an explicit `DependsOn` onto the same policy:

```
ScheduleTargetBackfillLambda            → DependsOn → ScheduleTargetBackfillRoleDefaultPolicy
ScheduleTargetBackfillRoleDefaultPolicy → Fn::GetAtt → ScheduleTargetBackfillLambda
```

`EventInvokeConfig` (from `retryAttempts: 2`) appears in the reported set because it also orders after the function.

Introduced with the schedule-target backfill worker (#1415 / #1420).

## Why it reached a deploy

**`cdk synth` does not validate intra-stack resource cycles** — synthesis of the unfixed stack exits 0 and writes a template CloudFormation then rejects. Nothing in lint, typecheck, or the test suite caught it; the failure landed mid-deploy, after the ECS container asset had already been built.

## Fix

Format the self-invoke ARN from the deterministic `functionName` via `this.formatArn(...)` instead of referencing the construct. The grant is unchanged — it resolves to `arn:aws:lambda:<region>:<account>:function:psd-agent-schedule-target-backfill-<env>`, exactly the function the statement always targeted — but it carries no `Fn::GetAtt`, so the DefaultPolicy no longer orders after the function.

The statement moves up beside the sibling `ScheduleTargetBackfillReadGroup` grant, before the `Function` is constructed, so the ARN can't be sourced from the construct by accident. An inline comment records the failure mode verbatim.

The cross-stack invoke grant in `FrontendStackEcs.createScheduleTargetBackfillTrigger` is **untouched** — different stack, already depends on AgentPlatformStack, ordinary cross-stack export, no cycle.

## Regression guard

New `infra/test/agent-platform-resource-cycles.test.ts` synthesizes AgentPlatformStack for dev **and** prod and asserts the template graph is acyclic across `DependsOn` / `Ref` / `Fn::GetAtt` — a general guard, not pinned to this resource. Plus a targeted assertion that the backfill self-invoke `Resource` contains no `Fn::GetAtt`.

**Verified red against the reverted (buggy) source, green with the fix.** Useful detail: `Template.fromStack()` *does* raise `Template is undeployable, these resources have a dependency cycle`, so this test closes the detection gap `cdk synth` leaves open.

## Verification

| Check | Result |
|---|---|
| Cycle scan, all 34 synthesized templates | 1 before (Dev + Prod) → **0 after** |
| `agent-platform-resource-cycles.test.ts` | 3 passed (red without the fix) |
| `tests/unit/agent-schedule-target-backfill.test.ts` | 12 passed |
| Full unit suite | 456 suites / **4014 tests passed** |
| `bun run lint` | 0 errors, 0 warnings |
| `bun run typecheck` | clean |
| `cdk synth --all` | exit 0 |
| Authenticated Playwright E2E (pre-push) | **298 passed**, 1 flaky (`nexus-projects`, unrelated, retried green) |

No schema changes, no migrations. Rollback is a straight revert.
