### PR TITLE
fix: restore Freshservice filters and brokered GitHub operations

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,6 +10,22 @@
 
 set -e
 
+echo "[entrypoint] Preparing writable /tmp volume..."
+
+# ECS mounts the writable /tmp volume as root:root with mode 0755. The
+# application runs as nextjs, so leaving that default intact makes every
+# secure mkdtemp() call fail with EACCES even though the mount itself is
+# writable. Keep root ownership and apply the conventional sticky-bit mode:
+# all processes may create private entries, but may not remove one another's.
+if [ ! -d "/tmp" ]; then
+  echo "[entrypoint] ERROR: /tmp volume is not mounted"
+  exit 1
+fi
+if ! chmod 1777 /tmp; then
+  echo "[entrypoint] ERROR: Failed to make /tmp writable"
+  exit 1
+fi
+
 echo "[entrypoint] Setting correct ownership on /app/.next/cache volume..."
 
 # Ensure the cache directory exists and is owned by nextjs:nodejs

--- a/lib/agent-credentials/owner-operation-broker.ts
+++ b/lib/agent-credentials/owner-operation-broker.ts
@@ -786,11 +786,19 @@ const FRESHSERVICE_PRESET_FILTERS = new Set([
 ])
 
 function isAllowedFreshserviceQueryValue(
+  pathname: string,
   key: string,
   value: string
 ): boolean {
-  if (key === "filter") return FRESHSERVICE_PRESET_FILTERS.has(value)
-  if (key === "query") return FRESHSERVICE_FILTER_QUERY_CHARS.test(value)
+  if (key === "filter") {
+    return pathname === "/tickets" && FRESHSERVICE_PRESET_FILTERS.has(value)
+  }
+  if (key === "query") {
+    return (
+      pathname === "/tickets/filter" &&
+      FRESHSERVICE_FILTER_QUERY_CHARS.test(value)
+    )
+  }
   return FRESHSERVICE_VALUE_CHARS.test(value)
 }
 
@@ -825,7 +833,7 @@ function canonicalFreshservicePath(method: string, path: string): string | null 
 
   if (rawQuery.length === 0) return canonicalPath
 
-  const query = canonicalFreshserviceQuery(rawQuery)
+  const query = canonicalFreshserviceQuery(canonicalPath, rawQuery)
   if (query === null) return null
   return query.length > 0 ? `${canonicalPath}?${query}` : canonicalPath
 }
@@ -835,7 +843,10 @@ function canonicalFreshservicePath(method: string, path: string): string | null 
  * is unrecognized. Split out from the path canonicalizer to keep each half
  * under the complexity ceiling and independently readable.
  */
-function canonicalFreshserviceQuery(rawQuery: string): string | null {
+function canonicalFreshserviceQuery(
+  canonicalPath: string,
+  rawQuery: string
+): string | null {
   const rebuilt = new URLSearchParams()
   for (const pair of rawQuery.split("&")) {
     if (pair.length === 0) continue
@@ -849,7 +860,7 @@ function canonicalFreshserviceQuery(rawQuery: string): string | null {
     } catch {
       return null
     }
-    if (!isAllowedFreshserviceQueryValue(key, value)) return null
+    if (!isAllowedFreshserviceQueryValue(canonicalPath, key, value)) return null
     rebuilt.append(key, value)
   }
   return rebuilt.toString()

--- a/lib/agent-credentials/owner-operation-broker.ts
+++ b/lib/agent-credentials/owner-operation-broker.ts
@@ -1,4 +1,7 @@
-import { AgentCredentialBroker } from "@/lib/agent-credentials/broker";
+import {
+  AgentCredentialBroker,
+  AgentCredentialInputError,
+} from "@/lib/agent-credentials/broker";
 import { createLogger, sanitizeForLogging } from "@/lib/logger";
 
 const MCP_PROTOCOL_VERSION = "2025-06-18";
@@ -724,6 +727,11 @@ const FRESHSERVICE_ROUTES: ReadonlyArray<{
 }> = [
   { method: "GET", pattern: /^\/tickets$/, build: () => "/tickets" },
   { method: "POST", pattern: /^\/tickets$/, build: () => "/tickets" },
+  {
+    method: "GET",
+    pattern: /^\/tickets\/filter$/,
+    build: () => "/tickets/filter",
+  },
   { method: "GET", pattern: /^\/tickets\/(\d+)$/, build: (id) => `/tickets/${id}` },
   { method: "PUT", pattern: /^\/tickets\/(\d+)$/, build: (id) => `/tickets/${id}` },
   {
@@ -764,17 +772,35 @@ const FRESHSERVICE_QUERY_KEYS = new Set([
   "updated_since",
   "order_type",
   "workspace_id",
+  "filter",
   "query",
 ])
 const FRESHSERVICE_VALUE_CHARS = /^[A-Za-z0-9_.,:+@ -]*$/
+const FRESHSERVICE_FILTER_QUERY_CHARS = /^[A-Za-z0-9_.,:+@()'<>"= -]*$/
+const FRESHSERVICE_PRESET_FILTERS = new Set([
+  "new_and_my_open",
+  "watching",
+  "spam",
+  "deleted",
+  "archived",
+])
+
+function isAllowedFreshserviceQueryValue(
+  key: string,
+  value: string
+): boolean {
+  if (key === "filter") return FRESHSERVICE_PRESET_FILTERS.has(value)
+  if (key === "query") return FRESHSERVICE_FILTER_QUERY_CHARS.test(value)
+  return FRESHSERVICE_VALUE_CHARS.test(value)
+}
 
 /**
  * Canonicalize one request, or return null if it is not allowlisted.
  *
  * Returns a NEWLY BUILT path string: literal segments, numeric ids passed
  * through Number(), and a query re-serialized from an allowlisted key set with
- * a value charset that excludes "/", ":"-schemes and "@", so a query can
- * neither smuggle path segments nor an alternate host.
+ * a key-specific value grammar that excludes "/", so a query can neither
+ * smuggle path segments nor alter the fixed upstream host.
  *
  * Splitting the query off BEFORE matching also keeps every pattern a static
  * anchored literal. Folding an optional query group into each pattern is the
@@ -823,7 +849,7 @@ function canonicalFreshserviceQuery(rawQuery: string): string | null {
     } catch {
       return null
     }
-    if (!FRESHSERVICE_VALUE_CHARS.test(value)) return null
+    if (!isAllowedFreshserviceQueryValue(key, value)) return null
     rebuilt.append(key, value)
   }
   return rebuilt.toString()
@@ -849,7 +875,7 @@ function validatedFreshserviceRequest(
 ): { path: string; method: "GET" | "POST" | "PUT" } {
   const method = rawMethod === undefined ? "GET" : rawMethod
   if (method !== "GET" && method !== "POST" && method !== "PUT") {
-    throw new Error("Invalid Freshservice method")
+    throw new AgentCredentialInputError("Invalid Freshservice method")
   }
   if (
     typeof rawPath !== "string" ||
@@ -857,13 +883,15 @@ function validatedFreshserviceRequest(
     rawPath.length > 512 ||
     hasAsciiControl(rawPath)
   ) {
-    throw new Error("Invalid Freshservice path")
+    throw new AgentCredentialInputError("Invalid Freshservice path")
   }
   const canonical = canonicalFreshservicePath(method, rawPath)
   if (canonical === null) {
     // Named explicitly: an unlisted endpoint is a skill change that needs a
     // route added, not a transient failure the agent should retry.
-    throw new Error(`Freshservice route not allowed: ${method} ${rawPath}`)
+    throw new AgentCredentialInputError(
+      `Freshservice route not allowed: ${method} ${rawPath}`
+    )
   }
   // The REBUILT path, never rawPath — this is what keeps caller-supplied
   // characters out of the URL that gets fetched.

--- a/tests/unit/agent-credentials-route.test.ts
+++ b/tests/unit/agent-credentials-route.test.ts
@@ -19,6 +19,7 @@ const requestMock = jest.fn()
 const canAccessSkillMock = jest.fn()
 const brokerConstructorMock = jest.fn()
 const executeOpenAiImageOperationMock = jest.fn()
+const executeFreshserviceOperationMock = jest.fn()
 
 jest.mock("@/lib/agent-workspace/invocation-context", () => ({
   verifyAgentInvocationContext: jest.fn(
@@ -68,11 +69,13 @@ jest.mock("@/lib/agent-credentials/owner-operation-broker", () => ({
     executeOpenAiImageOperationMock(...args),
   executePlaudOperation: jest.fn(),
   executePsdDataOperation: jest.fn(),
-  executeFreshserviceOperation: jest.fn(),
+  executeFreshserviceOperation: (...args: unknown[]) =>
+    executeFreshserviceOperationMock(...args),
 }))
 
 import type { NextRequest } from "next/server"
 import { POST } from "@/app/api/agent/credentials/route"
+import { AgentCredentialInputError } from "@/lib/agent-credentials/broker"
 
 function request(body: unknown): NextRequest {
   return {
@@ -103,6 +106,11 @@ beforeEach(() => {
   canAccessSkillMock.mockReset().mockResolvedValue(true)
   executeOpenAiImageOperationMock.mockReset().mockResolvedValue({
     imageBase64: "aGVsbG8=",
+  })
+  executeFreshserviceOperationMock.mockReset().mockResolvedValue({
+    status: 200,
+    ok: true,
+    data: { tickets: [] },
   })
 })
 
@@ -246,6 +254,27 @@ describe("POST /api/agent/credentials", () => {
       quality: "high",
       background: "opaque",
       referenceDataUrl: null,
+    })
+  })
+
+  it("returns a specific input error for a rejected Freshservice route", async () => {
+    executeFreshserviceOperationMock.mockRejectedValueOnce(
+      new AgentCredentialInputError(
+        "Freshservice route not allowed: GET /solutions/articles"
+      )
+    )
+
+    const response = await POST(
+      request({
+        operation: "freshservice",
+        path: "/solutions/articles",
+        method: "GET",
+      })
+    )
+
+    expect(response.status).toBe(400)
+    expect(await response.json()).toEqual({
+      error: "Freshservice route not allowed: GET /solutions/articles",
     })
   })
 })

--- a/tests/unit/agent-credentials-route.test.ts
+++ b/tests/unit/agent-credentials-route.test.ts
@@ -256,7 +256,9 @@ describe("POST /api/agent/credentials", () => {
       referenceDataUrl: null,
     })
   })
+})
 
+describe("POST /api/agent/credentials Freshservice errors", () => {
   it("returns a specific input error for a rejected Freshservice route", async () => {
     executeFreshserviceOperationMock.mockRejectedValueOnce(
       new AgentCredentialInputError(

--- a/tests/unit/lib/agent-credentials/freshservice-broker.test.ts
+++ b/tests/unit/lib/agent-credentials/freshservice-broker.test.ts
@@ -20,9 +20,18 @@ import { stripComments } from "../../../helpers/strip-ts-comments"
 const getUserOnly = jest.fn()
 const fetchMock = jest.fn()
 
-jest.mock("@/lib/agent-credentials/broker", () => ({
-  AgentCredentialBroker: jest.fn().mockImplementation(() => ({ getUserOnly })),
-}))
+jest.mock("@/lib/agent-credentials/broker", () => {
+  class AgentCredentialInputError extends Error {
+    constructor(message: string) {
+      super(message)
+      this.name = "AgentCredentialInputError"
+    }
+  }
+  return {
+    AgentCredentialBroker: jest.fn().mockImplementation(() => ({ getUserOnly })),
+    AgentCredentialInputError,
+  }
+})
 
 import { executeFreshserviceOperation } from "@/lib/agent-credentials/owner-operation-broker"
 
@@ -72,6 +81,13 @@ describe("Freshservice broker allowlist", () => {
   it.each([
     ["GET", "/tickets"],
     ["GET", "/tickets?per_page=30&page=1"],
+    ["GET", "/tickets?filter=new_and_my_open&per_page=5"],
+    ["GET", "/tickets?workspace_id=2&filter=watching"],
+    ["GET", '/tickets/filter?query="status:2"&workspace_id=2'],
+    [
+      "GET",
+      '/tickets/filter?query="%28status%3A4%20OR%20status%3A5%29%20AND%20updated_at%3A%3E%272026-07-26%27%20AND%20updated_at%3A%3C%272026-07-30%27"&workspace_id=2&page=1&per_page=100',
+    ],
     ["POST", "/tickets"],
     ["GET", "/tickets/12345"],
     ["GET", "/tickets/12345?include=conversations,requester"],
@@ -98,6 +114,7 @@ describe("Freshservice broker allowlist", () => {
     ["GET", "/products"],
     // Method/path mismatches: read routes must not become write routes.
     ["PUT", "/tickets"],
+    ["POST", "/tickets/filter"],
     ["POST", "/workspaces"],
     ["PUT", "/agents/99"],
     // Traversal and smuggling.
@@ -113,9 +130,12 @@ describe("Freshservice broker allowlist", () => {
   })
 
   it("rejects a non-relative path outright", async () => {
-    await expect(call("https://evil.example/tickets", "GET")).rejects.toThrow(
-      "Invalid Freshservice path"
-    )
+    await expect(
+      call("https://evil.example/tickets", "GET")
+    ).rejects.toMatchObject({
+      name: "AgentCredentialInputError",
+      message: "Invalid Freshservice path",
+    })
     expect(fetchMock).not.toHaveBeenCalled()
   })
 
@@ -206,6 +226,16 @@ describe("Freshservice broker behaviour", () => {
     )
   })
 
+  it("canonicalizes the filter endpoint and its documented query grammar", async () => {
+    await call(
+      '/tickets/filter?query="priority%3A4%20AND%20created_at%3A%3E%272026-07-28%27"&workspace_id=2'
+    )
+
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      "https://psd401.freshservice.com/api/v2/tickets/filter?query=%22priority%3A4+AND+created_at%3A%3E%272026-07-28%27%22&workspace_id=2"
+    )
+  })
+
   it.each([
     // Unknown keys cannot ride along into the upstream request.
     "/tickets?evil=1",
@@ -213,6 +243,10 @@ describe("Freshservice broker behaviour", () => {
     "/tickets?include=a/b",
     // Malformed pairs are rejected rather than silently dropped.
     "/tickets?noequals",
+    // Preset filters are a closed Freshservice-defined list.
+    "/tickets?filter=all",
+    // Filter expressions may not smuggle path separators.
+    '/tickets/filter?query="status:2/admin"',
   ])("rejects query %s", async (path) => {
     await expect(call(path)).rejects.toThrow("not allowed")
     expect(fetchMock).not.toHaveBeenCalled()

--- a/tests/unit/lib/agent-credentials/freshservice-broker.test.ts
+++ b/tests/unit/lib/agent-credentials/freshservice-broker.test.ts
@@ -245,6 +245,9 @@ describe("Freshservice broker behaviour", () => {
     "/tickets?noequals",
     // Preset filters are a closed Freshservice-defined list.
     "/tickets?filter=all",
+    // The two filter-only keys cannot ride along on sibling endpoints.
+    '/agents?query="status:2"',
+    "/workspaces?filter=watching",
     // Filter expressions may not smuggle path separators.
     '/tickets/filter?query="status:2/admin"',
   ])("rejects query %s", async (path) => {

--- a/tests/unit/lib/agent-github-command-executor.test.ts
+++ b/tests/unit/lib/agent-github-command-executor.test.ts
@@ -86,6 +86,18 @@ function defineGitHubCommandBoundarySuite1Part1() {
     expect(env.GH_PROMPT_DISABLED).toBe("1")
   })
 
+  it("makes the ECS temp mount writable before dropping application privileges", () => {
+    const entrypoint = validatedFs.readFileSync(
+      join(process.cwd(), "entrypoint.sh"),
+      "utf8"
+    )
+    const prepareTmp = entrypoint.indexOf("if ! chmod 1777 /tmp; then")
+    const dropPrivileges = entrypoint.indexOf('exec su-exec nextjs "$@"')
+
+    expect(prepareTmp).toBeGreaterThan(-1)
+    expect(dropPrivileges).toBeGreaterThan(prepareTmp)
+  })
+
   it("redacts the injected token and recognizable GitHub tokens from output", () => {
     const token = "github_pat_abcdefghijklmnopqrstuvwxyz123456"
     const output = redactGitHubToken(


### PR DESCRIPTION
## Description

Restores the two agent-broker operation families reported in #1441:

- Freshservice now accepts the ticket filters the bundled skill actually emits:
  the documented preset `filter` query parameter and the read-only
  `/tickets/filter?query=...` endpoint. The broker still rebuilds every request
  below its fixed Freshservice HTTPS origin, restricts method/path pairs,
  validates decoded values per key, re-encodes with `URLSearchParams`, rejects
  redirects, and resolves only the verified owner's credential.
- ECS startup now gives the task-local `/tmp` bind mount conventional sticky
  writable permissions before dropping from root to `nextjs`. This lets
  brokered GitHub CLI operations create their existing private
  `gh-broker-*` directories without weakening the non-root application runtime.
- Invalid Freshservice routes now return the route's existing specific 400
  input-error response instead of a misleading generic credential-operation
  failure.

Sanitized CloudWatch evidence identified both production roots:

- GitHub operations failed before `gh` launched with
  `EACCES: permission denied, mkdtemp '/tmp/gh-broker-XXXXXX'`.
- Freshservice rejected the reported preset and expression forms at its route
  allowlist, while ordinary `/tickets` requests succeeded.

### Security and risk

- The new Freshservice route is GET-only and literal.
- Preset filters remain a closed Freshservice-defined set.
- Expression values are decoded once, constrained to the documented ASCII
  grammar, cannot contain `/`, and are re-encoded under the fixed upstream host.
- The preset `filter` key is accepted only on `/tickets`, and the richer
  expression `query` grammar is accepted only on `/tickets/filter`.
- Fetch remains `redirect: "error"` and request/response limits are unchanged.
- `/tmp` remains root-owned; mode `1777` supplies standard sticky-bit isolation.
  Per-invocation GitHub homes are still randomized, private, and cleaned up.
- A complete diff-focused Codex Security review covered every changed
  source-like file and produced zero reportable findings and no deferred work.

### Validation

- `bun run lint` — passed
- `bun run typecheck` — passed
- `bun run build` — passed
- `bun run test:ci -- --runInBand` — passed; 520 suites and 4,823 tests passed
  (1 suite / 15 tests skipped by repository policy)
- Focused broker/route suites — passed; 3 suites / 90 tests
- `sh -n entrypoint.sh` — passed
- `infra/bun run build` — passed, including the agent skill builder's 17 tests
- `CDK_DEFAULT_ACCOUNT=123456789012 CDK_DEFAULT_REGION=us-east-1 bunx cdk synth --all --no-lookups --context baseDomain=example.com` — passed
- Isolated container runtime check — passed: after the entrypoint's privilege
  drop, `nextjs` could create a private `/tmp/gh-broker-*` directory
- Diff-focused security scan — complete; 2/2 production files reviewed,
  0 findings, 0 deferred

The repository's authenticated pre-push Playwright suite could not run in this
dedicated worktree because it intentionally has no `.env.local` `AUTH_SECRET`
or shared seeded/provider environment. The documented one-push
`SKIP_E2E=1` hook bypass was used. This change has no browser UI path; its
affected broker/runtime behavior is covered by unit, full CI, infrastructure,
container, and security validation above.

### Migrations, documentation, and screenshots

- Database migrations: none
- `/api/v1` documentation: not applicable; no v1 endpoint changed
- User-facing documentation: none required
- Screenshots: not applicable; no UI changed

## Checklist

- [x] No `console.*` calls in production/shared code; all server-side logging uses Winston logger (`@/lib/logger`)
- [x] **No imports or usage of `@/lib/logger` in client components or client hooks**
- [x] Client code uses `console.error` only for actionable errors in development (never for routine info)
- [x] Lint passes (`npm run lint`)
- [x] All applicable tests pass (`npm test`)
- [x] Types/interfaces follow project conventions
- [x] No type assertions (`as any`) without justification
- [x] Database field names use snake_case (automatic camelCase transformation handled by data API adapter)
- [x] TypeScript strict mode errors resolved
- [x] Environment variables handled securely and `.env.example` updated if needed
- [x] Documentation updated (if needed)
- [ ] Code reviewed and approved
- [x] App builds and runs without module errors (e.g., no 'fs' errors in browser)

## Related Issues

Closes #1441
