### PR TITLE
feat(atrium): add secure collection management

### DIFF
--- a/actions/db/atrium/audit-log.ts
+++ b/actions/db/atrium/audit-log.ts
@@ -14,7 +14,7 @@
  * trail).
  */
 
-import { and, desc, eq, sql } from "drizzle-orm";
+import { and, desc, eq, or, sql } from "drizzle-orm";
 import { createLogger, generateRequestId, startTimer } from "@/lib/logger";
 import {
   createSuccess,
@@ -46,6 +46,8 @@ export interface ContentAuditFilter {
 export interface ContentAuditRowDTO {
   id: string;
   objectId: string | null;
+  collectionId: string | null;
+  collectionName: string | null;
   action: string;
   surface: string;
   actorKind: "human" | "agent";
@@ -92,14 +94,22 @@ function buildAuditWhere(filter: ContentAuditFilter) {
   const objectQuery = filter.objectId?.trim();
   if (objectQuery) {
     if (UUID_RE.test(objectQuery)) {
-      conditions.push(eq(contentAuditLogs.objectId, objectQuery));
+      conditions.push(
+        or(
+          eq(contentAuditLogs.objectId, objectQuery),
+          sql`${contentAuditLogs.details}->>'collectionId' = ${objectQuery}`
+        )
+      );
     } else {
       // Substring match against the uuid's text form. Escape LIKE wildcards
       // so a pasted `%`/`_` is treated literally (drizzle parameterizes the
       // value itself, so there is no injection surface here).
       const escaped = objectQuery.replace(/[\\%_]/g, (m) => `\\${m}`);
       conditions.push(
-        sql`${contentAuditLogs.objectId}::text ILIKE ${`%${escaped}%`}`
+        or(
+          sql`${contentAuditLogs.objectId}::text ILIKE ${`%${escaped}%`}`,
+          sql`${contentAuditLogs.details}->>'collectionId' ILIKE ${`%${escaped}%`}`
+        )
       );
     }
   }
@@ -155,6 +165,8 @@ export async function listContentAuditAction(
       rows: rows.map((row) => ({
         id: row.id,
         objectId: row.objectId,
+        collectionId: row.details?.collectionId ?? null,
+        collectionName: row.details?.collectionName ?? null,
         action: row.action,
         surface: row.surface,
         actorKind: row.actorKind,

--- a/actions/db/atrium/collection-management.ts
+++ b/actions/db/atrium/collection-management.ts
@@ -133,10 +133,13 @@ export async function updateCollectionAction(
         grants: input.grants?.length ?? undefined,
       }),
     });
+    // Authenticate and capability-gate before branching on attacker-controlled
+    // identifiers. Besides keeping logged-out responses consistently at 401,
+    // this prevents validation behavior from becoming an authorization oracle.
+    const requester = await authorizedRequester(requestId);
     if (!collectionId) {
       throw ErrorFactories.missingRequiredField("collectionId");
     }
-    const requester = await authorizedRequester(requestId);
     const parsed = updateCollectionBodySchema.safeParse(input);
     if (!parsed.success) {
       throw new ValidationError("Invalid collection update", {

--- a/actions/db/atrium/collection-management.ts
+++ b/actions/db/atrium/collection-management.ts
@@ -1,0 +1,169 @@
+"use server"
+
+/**
+ * Human-facing Atrium collection management actions (#1438).
+ *
+ * Authorization remains in the shared service: administrators may manage the
+ * district hierarchy, while every Atrium author may manage only their own
+ * owner-bound private hierarchy.
+ */
+
+import {
+  createLogger,
+  generateRequestId,
+  sanitizeForLogging,
+  startTimer,
+} from "@/lib/logger";
+import { createSuccess, ErrorFactories, handleError } from "@/lib/error-utils";
+import { getServerSession } from "@/lib/auth/server-session";
+import {
+  collectionManagementService,
+  ContentError,
+  ValidationError,
+} from "@/lib/content";
+import {
+  createCollectionBodySchema,
+  updateCollectionBodySchema,
+} from "@/lib/content/rest";
+import type {
+  CollectionDTO,
+  CreateCollectionInput,
+  UpdateCollectionInput,
+} from "@/lib/content";
+import type { ActionState } from "@/types";
+import { hasCapabilityAccess } from "@/utils/roles";
+import { getUserRequester } from "./requester";
+
+async function authorizedRequester(requestId: string) {
+  const session = await getServerSession();
+  const requester = await getUserRequester(requestId, session);
+  if (!(await hasCapabilityAccess("atrium-content", session!.sub))) {
+    throw ErrorFactories.authzToolAccessDenied("atrium-content");
+  }
+  return requester;
+}
+
+export async function listManageableCollectionsAction(
+  mode: "admin" | "private" = "admin"
+): Promise<
+  ActionState<CollectionDTO[]>
+> {
+  const requestId = generateRequestId();
+  const timer = startTimer("listManageableCollectionsAction");
+  const log = createLogger({
+    requestId,
+    action: "listManageableCollectionsAction",
+  });
+  try {
+    log.info("Action started: list manageable collections");
+    const requester = await authorizedRequester(requestId);
+    const collections =
+      mode === "private"
+        ? await collectionManagementService.listOwnedPrivate(requester)
+        : await collectionManagementService.listManageable(requester);
+    timer({ status: "success" });
+    log.info("Manageable collections loaded", { count: collections.length });
+    return createSuccess(collections, "Collections loaded");
+  } catch (error) {
+    timer({ status: "error" });
+    return handleError(error, "Failed to load collections", {
+      context: "listManageableCollectionsAction",
+      requestId,
+      operation: "listManageableCollectionsAction",
+    });
+  }
+}
+
+export async function createCollectionAction(
+  input: CreateCollectionInput
+): Promise<ActionState<CollectionDTO>> {
+  const requestId = generateRequestId();
+  const timer = startTimer("createCollectionAction");
+  const log = createLogger({ requestId, action: "createCollectionAction" });
+  try {
+    log.info("Action started: create collection", {
+      input: sanitizeForLogging({
+        ...input,
+        grants: input.grants?.length ?? 0,
+      }),
+    });
+    const requester = await authorizedRequester(requestId);
+    const parsed = createCollectionBodySchema.safeParse(input);
+    if (!parsed.success) {
+      throw new ValidationError("Invalid collection input", {
+        issues: parsed.error.issues,
+      });
+    }
+    const collection = await collectionManagementService.create(
+      requester,
+      parsed.data,
+      { surface: "ui", requestId }
+    );
+    timer({ status: "success" });
+    log.info("Collection created", { collectionId: collection.id });
+    return createSuccess(collection, "Collection created");
+  } catch (error) {
+    timer({ status: "error" });
+    return handleError(
+      error,
+      error instanceof ContentError
+        ? error.message
+        : "Failed to create collection",
+      {
+        context: "createCollectionAction",
+        requestId,
+        operation: "createCollectionAction",
+      }
+    );
+  }
+}
+
+export async function updateCollectionAction(
+  collectionId: string,
+  input: UpdateCollectionInput
+): Promise<ActionState<CollectionDTO>> {
+  const requestId = generateRequestId();
+  const timer = startTimer("updateCollectionAction");
+  const log = createLogger({ requestId, action: "updateCollectionAction" });
+  try {
+    log.info("Action started: update collection", {
+      collectionId: sanitizeForLogging(collectionId),
+      input: sanitizeForLogging({
+        ...input,
+        grants: input.grants?.length ?? undefined,
+      }),
+    });
+    if (!collectionId) {
+      throw ErrorFactories.missingRequiredField("collectionId");
+    }
+    const requester = await authorizedRequester(requestId);
+    const parsed = updateCollectionBodySchema.safeParse(input);
+    if (!parsed.success) {
+      throw new ValidationError("Invalid collection update", {
+        issues: parsed.error.issues,
+      });
+    }
+    const collection = await collectionManagementService.update(
+      requester,
+      collectionId,
+      parsed.data,
+      { surface: "ui", requestId }
+    );
+    timer({ status: "success" });
+    log.info("Collection updated", { collectionId: collection.id });
+    return createSuccess(collection, "Collection updated");
+  } catch (error) {
+    timer({ status: "error" });
+    return handleError(
+      error,
+      error instanceof ContentError
+        ? error.message
+        : "Failed to update collection",
+      {
+        context: "updateCollectionAction",
+        requestId,
+        operation: "updateCollectionAction",
+      }
+    );
+  }
+}

--- a/actions/db/atrium/comments.ts
+++ b/actions/db/atrium/comments.ts
@@ -180,6 +180,7 @@ async function resolveGatedObject(
   const viewable = await visibilityService.canView(requester, {
     id: obj.id,
     ownerUserId: obj.ownerUserId,
+    collectionId: obj.collectionId,
     visibilityLevel: obj.visibilityLevel,
   });
   // Mask existence: a non-viewable object 404s (never a 403) — the edit gate below

--- a/actions/db/atrium/get-visibility.ts
+++ b/actions/db/atrium/get-visibility.ts
@@ -59,6 +59,7 @@ export async function getVisibilityAction(
     const viewable = await visibilityService.canView(requester, {
       id: obj.id,
       ownerUserId: obj.ownerUserId,
+      collectionId: obj.collectionId,
       visibilityLevel: obj.visibilityLevel,
     });
     if (!viewable) throw new NotFoundError("Content not found", { idOrSlug });

--- a/actions/db/atrium/set-visibility.ts
+++ b/actions/db/atrium/set-visibility.ts
@@ -105,6 +105,7 @@ export async function setVisibilityAction(
     const viewable = await visibilityService.canView(requester, {
       id: obj.id,
       ownerUserId: obj.ownerUserId,
+      collectionId: obj.collectionId,
       visibilityLevel: obj.visibilityLevel,
     });
     if (!viewable) throw new NotFoundError("Content not found", { idOrSlug });

--- a/actions/db/atrium/snapshot-document.ts
+++ b/actions/db/atrium/snapshot-document.ts
@@ -81,6 +81,7 @@ export async function snapshotDocumentAction(
     const viewable = await visibilityService.canView(requester, {
       id: obj.id,
       ownerUserId: obj.ownerUserId,
+      collectionId: obj.collectionId,
       visibilityLevel: obj.visibilityLevel,
     });
     // Mask existence: a non-viewable object 404s rather than revealing — via a

--- a/actions/db/atrium/workspace-panel.ts
+++ b/actions/db/atrium/workspace-panel.ts
@@ -66,6 +66,7 @@ export async function loadWorkspacePanelAction(
     const viewable = await visibilityService.canView(requester, {
       id: obj.id,
       ownerUserId: obj.ownerUserId,
+      collectionId: obj.collectionId,
       visibilityLevel: obj.visibilityLevel,
     });
     // Existence-mask: a non-viewable object 404s exactly like an absent one.

--- a/app/(protected)/admin/atrium/page.tsx
+++ b/app/(protected)/admin/atrium/page.tsx
@@ -4,6 +4,7 @@ import { PageBranding } from "@/components/ui/page-branding"
 import { listPendingApprovalsAction } from "@/actions/db/atrium/approvals"
 import { listContentAuditAction } from "@/actions/db/atrium/audit-log"
 import { AtriumAdminTabs } from "@/components/atrium/admin/atrium-admin-tabs"
+import { listManageableCollectionsAction } from "@/actions/db/atrium/collection-management"
 
 /**
  * Atrium oversight (Epic #1059 completion) — the admin surface for the §26.4
@@ -17,9 +18,10 @@ export const metadata = adminPageMetadata("/admin/atrium")
 export default async function AtriumAdminPage() {
   await requireRole("administrator")
 
-  const [approvalsResult, auditResult] = await Promise.all([
+  const [approvalsResult, auditResult, collectionsResult] = await Promise.all([
     listPendingApprovalsAction(),
     listContentAuditAction({}),
+    listManageableCollectionsAction(),
   ])
 
   const approvals = approvalsResult.isSuccess ? (approvalsResult.data ?? []) : []
@@ -32,6 +34,12 @@ export default async function AtriumAdminPage() {
   const auditError = !auditResult.isSuccess
     ? (auditResult.message ?? "Failed to load the audit log")
     : null
+  const collections = collectionsResult.isSuccess
+    ? (collectionsResult.data ?? [])
+    : []
+  const collectionsError = !collectionsResult.isSuccess
+    ? (collectionsResult.message ?? "Failed to load collections")
+    : null
 
   return (
     <div className="p-6">
@@ -41,8 +49,8 @@ export default async function AtriumAdminPage() {
           Atrium Oversight
         </h1>
         <p className="text-sm text-muted-foreground mt-1">
-          Approve or deny public-publish requests and review the content audit
-          trail
+          Manage district collections, approve public-publish requests, and
+          review the content audit trail
         </p>
       </div>
 
@@ -51,6 +59,8 @@ export default async function AtriumAdminPage() {
         approvalsError={approvalsError}
         initialAudit={audit}
         auditError={auditError}
+        initialCollections={collections}
+        collectionsError={collectionsError}
       />
     </div>
   )

--- a/app/(protected)/atrium/[id]/edit/page.tsx
+++ b/app/(protected)/atrium/[id]/edit/page.tsx
@@ -51,6 +51,7 @@ export default async function AtriumEditPage({
   const viewable = await visibilityService.canView(req, {
     id: obj.id,
     ownerUserId: obj.ownerUserId,
+    collectionId: obj.collectionId,
     visibilityLevel: obj.visibilityLevel,
   });
   // Existence-mask: a non-viewable object must NOT return 403 — that leaks existence

--- a/app/(protected)/atrium/[id]/view/page.tsx
+++ b/app/(protected)/atrium/[id]/view/page.tsx
@@ -63,6 +63,7 @@ export default async function AtriumArtifactViewPage({
   const viewable = await visibilityService.canView(req, {
     id: obj.id,
     ownerUserId: obj.ownerUserId,
+    collectionId: obj.collectionId,
     visibilityLevel: obj.visibilityLevel,
   });
   if (!viewable) notFound();

--- a/app/(protected)/c/[slug]/page.tsx
+++ b/app/(protected)/c/[slug]/page.tsx
@@ -99,6 +99,7 @@ async function loadPublishedObject(slug: string): Promise<{
   id: string;
   kind: "document" | "artifact";
   ownerUserId: number;
+  collectionId: string | null;
   visibilityLevel: "private" | "group" | "internal" | "public";
   title: string;
   /** The object's collection name (via left join), for the reader meta line. */
@@ -117,6 +118,7 @@ async function loadPublishedObject(slug: string): Promise<{
           id: contentObjects.id,
           kind: contentObjects.kind,
           ownerUserId: contentObjects.ownerUserId,
+          collectionId: contentObjects.collectionId,
           visibilityLevel: contentObjects.visibilityLevel,
           title: contentObjects.title,
           // Left join → collection name (or null when the object is uncollected),
@@ -225,6 +227,7 @@ export default async function ReaderPage({
   const viewable = await visibilityService.canView(requester, {
     id: published.id,
     ownerUserId: published.ownerUserId,
+    collectionId: published.collectionId,
     visibilityLevel: published.visibilityLevel,
   });
   if (!viewable) {

--- a/app/(public)/p/[slug]/page.tsx
+++ b/app/(public)/p/[slug]/page.tsx
@@ -17,9 +17,10 @@
  * `canView(session)` here would leak non-public content to authenticated users
  * through the public URL (e.g. an `internal` object that was published to
  * `public_web` while its visibility stayed `internal`). `visibility_level ===
- * 'public'` is exactly the world-readable predicate (`canView` short-circuits to
- * `true` for `public` regardless of principal), so the strict check is both
- * simpler and strictly safer than a guest `canView`.
+ * 'public'` is the object-level world-readable predicate. A fixed anonymous
+ * requester is additionally checked against the object's collection so an
+ * archived or grant-restricted district collection cannot remain public through
+ * a stale `/p/` publication.
  *
  * ## Visibility gate (always 404, never 403)
  * No object for the slug, no live `public_web` publication, OR a non-`public`
@@ -55,7 +56,9 @@ import {
 import { s3Store } from "@/lib/content/storage/s3-store";
 import { versionService } from "@/lib/content/version-service";
 import { resolveDocumentParts } from "@/lib/content/embed-resolver";
+import { requesterMayViewCollection } from "@/lib/content/collection-access";
 import { extractDocumentHeadings } from "@/lib/content/render/headings";
+import type { Requester } from "@/lib/content/types";
 import { createLogger } from "@/lib/logger";
 import { ProvenanceFooter } from "@/components/atrium/ProvenanceFooter";
 import { ArtifactSandbox } from "@/components/atrium/ArtifactSandbox";
@@ -76,6 +79,14 @@ interface PublicReaderPageProps {
   params: Promise<{ slug: string }>;
 }
 
+const ANONYMOUS_REQUESTER: Requester = {
+  kind: "user",
+  userId: null,
+  roles: [],
+  groups: [],
+  isAdmin: false,
+};
+
 /**
  * Load the object + live `public_web` publication for a slug, but ONLY when the
  * object's visibility is `public`. Returns `null` otherwise (absent slug, no live
@@ -92,6 +103,7 @@ const loadPublicObject = cache(async (
   id: string;
   kind: "document" | "artifact";
   title: string;
+  collectionId: string | null;
   /** The object's collection name (via left join), for the reader meta line. */
   collectionName: string | null;
   /** Cover-gradient preset key + emoji icon (slice F) for the reader cover band. */
@@ -108,6 +120,7 @@ const loadPublicObject = cache(async (
           id: contentObjects.id,
           kind: contentObjects.kind,
           title: contentObjects.title,
+          collectionId: contentObjects.collectionId,
           visibilityLevel: contentObjects.visibilityLevel,
           // Left join → collection name (or null), for the reader meta. Rides on
           // the existing slug lookup — no extra query and no session read.
@@ -131,6 +144,14 @@ const loadPublicObject = cache(async (
   // A non-public object (even one published to public_web while its visibility
   // stayed internal/group) is treated as absent — 404, never 403.
   if (obj.visibilityLevel !== "public") return null;
+  if (
+    !(await requesterMayViewCollection(
+      ANONYMOUS_REQUESTER,
+      obj.collectionId
+    ))
+  ) {
+    return null;
+  }
 
   const [publication] = await executeQuery(
     (db) =>
@@ -156,6 +177,7 @@ const loadPublicObject = cache(async (
     id: obj.id,
     kind: obj.kind,
     title: obj.title,
+    collectionId: obj.collectionId,
     collectionName: obj.collectionName ?? null,
     coverGradient: obj.coverGradient,
     icon: obj.icon,

--- a/app/api/agent/atrium/route.ts
+++ b/app/api/agent/atrium/route.ts
@@ -22,42 +22,41 @@ type AtriumBody = {
   body?: Record<string, unknown>
 }
 
+const ALLOWED_PATHS: Record<AtriumBody["method"], readonly RegExp[]> = {
+  GET: [
+    /^$/,
+    /^\/collections$/,
+    new RegExp(`^/${IDENTIFIER}$`),
+    // Committed markdown source — the ONLY way an agent can read a document's
+    // body text (`GET /<id>` returns bodyLocation "proof" with no text).
+    new RegExp(`^/${IDENTIFIER}/source$`),
+    // Authored image assets (#1284): metadata list, plus a bounded
+    // base64 byte read so an agent can copy an image between objects.
+    new RegExp(`^/${IDENTIFIER}/assets$`),
+    new RegExp(`^/${IDENTIFIER}/assets/${IDENTIFIER}/bytes$`),
+  ],
+  POST: [
+    /^$/,
+    /^\/collections$/,
+    new RegExp(`^/${IDENTIFIER}/(?:versions|publish)$`),
+    new RegExp(`^/${IDENTIFIER}/assets$`),
+    new RegExp(`^/${IDENTIFIER}/assets/${IDENTIFIER}/complete$`),
+  ],
+  PATCH: [
+    new RegExp(`^/${IDENTIFIER}(?:/visibility)?$`),
+    new RegExp(`^/collections/${IDENTIFIER}$`),
+  ],
+  DELETE: [
+    new RegExp(`^/${IDENTIFIER}$`),
+    new RegExp(
+      `^/${IDENTIFIER}/publish/(?:intranet|public_web|schoology|google)$`
+    ),
+  ],
+}
+
 function isAllowedMethodPath(method: string, path: string): boolean {
-  if (method === "GET") {
-    return (
-      path === "" ||
-      new RegExp(`^/${IDENTIFIER}$`).test(path) ||
-      // Committed markdown source — the ONLY way an agent can read a document's
-      // body text (`GET /<id>` returns bodyLocation "proof" with no text).
-      new RegExp(`^/${IDENTIFIER}/source$`).test(path) ||
-      // Authored image assets (#1284): metadata list, plus a bounded
-      // base64 byte read so an agent can copy an image from one object to
-      // another (assets are per-object; a directive may only reference an
-      // asset owned by the object it is embedded in).
-      new RegExp(`^/${IDENTIFIER}/assets$`).test(path) ||
-      new RegExp(`^/${IDENTIFIER}/assets/${IDENTIFIER}/bytes$`).test(path)
-    )
-  }
-  if (method === "POST") {
-    return (
-      path === "" ||
-      new RegExp(`^/${IDENTIFIER}/(?:versions|publish)$`).test(path) ||
-      new RegExp(`^/${IDENTIFIER}/assets$`).test(path) ||
-      new RegExp(`^/${IDENTIFIER}/assets/${IDENTIFIER}/complete$`).test(path)
-    )
-  }
-  if (method === "PATCH") {
-    return new RegExp(`^/${IDENTIFIER}(?:/visibility)?$`).test(path)
-  }
-  if (method === "DELETE") {
-    return (
-      new RegExp(`^/${IDENTIFIER}$`).test(path) ||
-      new RegExp(
-        `^/${IDENTIFIER}/publish/(?:intranet|public_web|schoology|google)$`
-      ).test(path)
-    )
-  }
-  return false
+  const patterns = ALLOWED_PATHS[method as AtriumBody["method"]]
+  return patterns?.some((pattern) => pattern.test(path)) ?? false
 }
 
 /** A non-null, non-array object — the shape both `query` and `body` must have. */

--- a/app/api/content/[id]/agent-bridge/route.ts
+++ b/app/api/content/[id]/agent-bridge/route.ts
@@ -208,6 +208,7 @@ async function loadEditableObject(
   const viewable = await visibilityService.canView(req, {
     id: obj.id,
     ownerUserId: obj.ownerUserId,
+    collectionId: obj.collectionId,
     visibilityLevel: obj.visibilityLevel,
   });
   if (!viewable) return { error: NextResponse.json({ error: "Not found" }, { status: 404 }) };

--- a/app/api/content/[id]/collab/route.ts
+++ b/app/api/content/[id]/collab/route.ts
@@ -53,6 +53,7 @@ async function getHandler(
     const viewable = await visibilityService.canView(req, {
       id: obj.id,
       ownerUserId: obj.ownerUserId,
+      collectionId: obj.collectionId,
       visibilityLevel: obj.visibilityLevel,
     });
     if (!viewable) {

--- a/app/api/v1/content/[id]/route.ts
+++ b/app/api/v1/content/[id]/route.ts
@@ -100,7 +100,7 @@ export const PATCH = withApiAuth(async (request: NextRequest, auth, requestId, p
         ? undefined
         : patch.collectionId === null
           ? null
-          : await resolveCollectionId(patch.collectionId);
+          : await resolveCollectionId(req, patch.collectionId, "create");
     const updated = await contentService.update(req, id, {
       title: patch.title,
       tags: patch.tags,

--- a/app/api/v1/content/collections/[id]/route.ts
+++ b/app/api/v1/content/collections/[id]/route.ts
@@ -1,0 +1,65 @@
+/**
+ * Atrium collection mutation endpoint (#1438).
+ *
+ * PATCH covers rename, reorder, move, default policy changes, recursive archive,
+ * and recursive restore. The shared service enforces district admin authority
+ * and owner-bound private hierarchies.
+ */
+
+import { NextRequest } from "next/server";
+import {
+  createApiResponse,
+  createErrorResponse,
+  parseRequestBody,
+  requireScope,
+  withApiAuth,
+} from "@/lib/api";
+import { collectionManagementService } from "@/lib/content";
+import {
+  contentErrorToResponse,
+  resolveRestRequester,
+  updateCollectionBodySchema,
+} from "@/lib/content/rest";
+import { assertContentAuthoringCapability } from "@/lib/content/surface-helpers";
+
+export const PATCH = withApiAuth(
+  async (request: NextRequest, auth, requestId, params) => {
+    const scopeError = requireScope(auth, "content:update", requestId);
+    if (scopeError) return scopeError;
+    const id = params.id;
+    if (!id) {
+      return createErrorResponse(
+        requestId,
+        400,
+        "VALIDATION_ERROR",
+        "Missing collection id"
+      );
+    }
+
+    const parsedBody = await parseRequestBody(
+      request,
+      updateCollectionBodySchema,
+      requestId
+    );
+    if (parsedBody instanceof Response) return parsedBody;
+
+    const resolved = await resolveRestRequester(auth, requestId);
+    if ("response" in resolved) return resolved.response;
+
+    try {
+      await assertContentAuthoringCapability(auth);
+      const collection = await collectionManagementService.update(
+        resolved.req,
+        id,
+        parsedBody.data,
+        { surface: "rest", requestId }
+      );
+      return createApiResponse(
+        { data: collection, meta: { requestId } },
+        requestId
+      );
+    } catch (error) {
+      return contentErrorToResponse(error, requestId);
+    }
+  }
+);

--- a/app/api/v1/content/collections/[id]/route.ts
+++ b/app/api/v1/content/collections/[id]/route.ts
@@ -20,7 +20,6 @@ import {
   resolveRestRequester,
   updateCollectionBodySchema,
 } from "@/lib/content/rest";
-import { assertContentAuthoringCapability } from "@/lib/content/surface-helpers";
 
 export const PATCH = withApiAuth(
   async (request: NextRequest, auth, requestId, params) => {
@@ -47,7 +46,6 @@ export const PATCH = withApiAuth(
     if ("response" in resolved) return resolved.response;
 
     try {
-      await assertContentAuthoringCapability(auth);
       const collection = await collectionManagementService.update(
         resolved.req,
         id,

--- a/app/api/v1/content/collections/route.ts
+++ b/app/api/v1/content/collections/route.ts
@@ -9,12 +9,22 @@ import { z } from "zod";
 import {
   createApiResponse,
   createErrorResponse,
+  parseRequestBody,
   requireScope,
   withApiAuth,
 } from "@/lib/api";
 import { hasScope } from "@/lib/api-keys/key-service";
-import { collectionService, requesterFromApiAuth } from "@/lib/content";
-import { contentErrorToResponse } from "@/lib/content/rest";
+import {
+  collectionManagementService,
+  collectionService,
+  requesterFromApiAuth,
+} from "@/lib/content";
+import {
+  contentErrorToResponse,
+  createCollectionBodySchema,
+  resolveRestRequester,
+} from "@/lib/content/rest";
+import { assertContentAuthoringCapability } from "@/lib/content/surface-helpers";
 
 const querySchema = z.object({
   shape: z.enum(["tree", "flat"]).default("tree"),
@@ -53,6 +63,37 @@ export const GET = withApiAuth(async (request: NextRequest, auth, requestId) => 
         },
       },
       requestId
+    );
+  } catch (error) {
+    return contentErrorToResponse(error, requestId);
+  }
+});
+
+export const POST = withApiAuth(async (request: NextRequest, auth, requestId) => {
+  const scopeError = requireScope(auth, "content:create", requestId);
+  if (scopeError) return scopeError;
+
+  const parsedBody = await parseRequestBody(
+    request,
+    createCollectionBodySchema,
+    requestId
+  );
+  if (parsedBody instanceof Response) return parsedBody;
+
+  const resolved = await resolveRestRequester(auth, requestId);
+  if ("response" in resolved) return resolved.response;
+
+  try {
+    await assertContentAuthoringCapability(auth);
+    const collection = await collectionManagementService.create(
+      resolved.req,
+      parsedBody.data,
+      { surface: "rest", requestId }
+    );
+    return createApiResponse(
+      { data: collection, meta: { requestId } },
+      requestId,
+      201
     );
   } catch (error) {
     return contentErrorToResponse(error, requestId);

--- a/app/api/v1/content/collections/route.ts
+++ b/app/api/v1/content/collections/route.ts
@@ -24,7 +24,6 @@ import {
   createCollectionBodySchema,
   resolveRestRequester,
 } from "@/lib/content/rest";
-import { assertContentAuthoringCapability } from "@/lib/content/surface-helpers";
 
 const querySchema = z.object({
   shape: z.enum(["tree", "flat"]).default("tree"),
@@ -84,7 +83,6 @@ export const POST = withApiAuth(async (request: NextRequest, auth, requestId) =>
   if ("response" in resolved) return resolved.response;
 
   try {
-    await assertContentAuthoringCapability(auth);
     const collection = await collectionManagementService.create(
       resolved.req,
       parsedBody.data,

--- a/app/api/v1/content/export/okf/route.ts
+++ b/app/api/v1/content/export/okf/route.ts
@@ -59,7 +59,11 @@ export const POST = withApiAuth(async (request: NextRequest, auth, requestId) =>
     // slug/id — caught below and mapped consistently with every other content route.
     // The required overload guarantees a defined id for a zod-validated `.min(1)`
     // input, so no `undefined` narrowing is needed here.
-    const collectionId = await resolveCollectionId(input.collectionId);
+    const collectionId = await resolveCollectionId(
+      req,
+      input.collectionId,
+      "view"
+    );
     const result = await okfExportService.exportCollection(req, collectionId, {
       audience: input.audience,
       hasPublishPublicCapability,

--- a/app/api/v1/content/import/okf/route.ts
+++ b/app/api/v1/content/import/okf/route.ts
@@ -53,12 +53,16 @@ export const POST = withApiAuth(async (request: NextRequest, auth, requestId) =>
     // callers are gated by the content:create scope above.
     await assertContentAuthoringCapability(auth);
     const targetCollectionId = input.targetCollectionId
-      ? await resolveCollectionId(input.targetCollectionId)
+      ? await resolveCollectionId(req, input.targetCollectionId, "create")
       : undefined;
-    const result = await okfImportService.importBundle(req, {
-      files: input.files,
-      targetCollectionId,
-    });
+    const result = await okfImportService.importBundle(
+      req,
+      {
+        files: input.files,
+        targetCollectionId,
+      },
+      { surface: "rest", requestId }
+    );
     void recordContentAudit({
       req,
       action: "import_okf",

--- a/app/api/v1/content/route.ts
+++ b/app/api/v1/content/route.ts
@@ -109,7 +109,11 @@ export const GET = withApiAuth(async (request: NextRequest, auth, requestId) => 
 
   try {
     const req = await requesterFromApiAuth(auth);
-    const collectionId = await resolveCollectionId(parsed.data.collection);
+    const collectionId = await resolveCollectionId(
+      req,
+      parsed.data.collection,
+      "view"
+    );
     const items = await contentService.list(req, {
       kind: parsed.data.kind,
       collectionId,
@@ -159,7 +163,11 @@ export const POST = withApiAuth(async (request: NextRequest, auth, requestId) =>
     return {
       kind: input.kind,
       title: input.title,
-      collectionId: await resolveCollectionId(input.collectionId),
+      collectionId: await resolveCollectionId(
+        req,
+        input.collectionId,
+        "create"
+      ),
       // Decode before both the create path and recovery metadata comparison so
       // the two paths use the identical semantic service input.
       body: decodeContentBody(input.body, input.codeEncoding),

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -7,6 +7,7 @@
  *   - `content_objects.visibility_level = 'public'`  (the strict public gate)
  *   - a LIVE `public_web` publication                 (destination + status)
  *   - `content_objects.status = 'published'`
+ *   - the anonymous requester may enter the active containing collection
  *
  * Because every condition here is at least as strict as the page's own gate,
  * the sitemap can never name a URL the reader would 404 (which would both leak
@@ -28,9 +29,19 @@ import { and, eq } from "drizzle-orm";
 import { executeQuery } from "@/lib/db/drizzle-client";
 import { contentObjects, contentPublications } from "@/lib/db/schema";
 import { publicReaderLink } from "@/lib/content/surface-helpers";
+import { collectionAccessSnapshot } from "@/lib/content/collection-access";
+import type { Requester } from "@/lib/content/types";
 import { createLogger } from "@/lib/logger";
 
 export const dynamic = "force-dynamic";
+
+const ANONYMOUS_REQUESTER: Requester = {
+  kind: "user",
+  userId: null,
+  roles: [],
+  groups: [],
+  isAdmin: false,
+};
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const log = createLogger({ action: "atrium.sitemap" });
@@ -44,37 +55,47 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   }
 
   try {
-    const rows = await executeQuery(
-      (db) =>
-        db
-          .select({
-            slug: contentObjects.slug,
-            updatedAt: contentObjects.updatedAt,
-          })
-          .from(contentObjects)
-          .innerJoin(
-            contentPublications,
-            eq(contentPublications.objectId, contentObjects.id)
-          )
-          .where(
-            and(
-              // The /p/[slug] strict public gate, exactly:
-              eq(contentObjects.visibilityLevel, "public"),
-              eq(contentPublications.destination, "public_web"),
-              eq(contentPublications.status, "live"),
-              // Lifecycle subset guard (publish sets it; unpublish reverts it):
-              eq(contentObjects.status, "published")
+    const [rows, collectionAccess] = await Promise.all([
+      executeQuery(
+        (db) =>
+          db
+            .select({
+              slug: contentObjects.slug,
+              updatedAt: contentObjects.updatedAt,
+              collectionId: contentObjects.collectionId,
+            })
+            .from(contentObjects)
+            .innerJoin(
+              contentPublications,
+              eq(contentPublications.objectId, contentObjects.id)
             )
-          ),
-      "atrium.sitemap.publicObjects"
-    );
+            .where(
+              and(
+                // The /p/[slug] strict public gate, exactly:
+                eq(contentObjects.visibilityLevel, "public"),
+                eq(contentPublications.destination, "public_web"),
+                eq(contentPublications.status, "live"),
+                // Lifecycle subset guard (publish sets it; unpublish reverts it):
+                eq(contentObjects.status, "published")
+              )
+            ),
+        "atrium.sitemap.publicObjects"
+      ),
+      collectionAccessSnapshot(ANONYMOUS_REQUESTER),
+    ]);
 
-    return rows.map((row) => ({
-      // publicReaderLink is the SINGLE builder for /p/ URLs (the same one the
-      // publish adapter records as external_ref) — no second URL format here.
-      url: publicReaderLink(row.slug),
-      ...(row.updatedAt ? { lastModified: row.updatedAt } : {}),
-    }));
+    return rows
+      .filter(
+        (row) =>
+          row.collectionId == null ||
+          collectionAccess.allowedCollectionIds.has(row.collectionId)
+      )
+      .map((row) => ({
+        // publicReaderLink is the SINGLE builder for /p/ URLs (the same one the
+        // publish adapter records as external_ref) — no second URL format here.
+        url: publicReaderLink(row.slug),
+        ...(row.updatedAt ? { lastModified: row.updatedAt } : {}),
+      }));
   } catch (error) {
     // Fail soft: an unreachable DB must degrade to an empty sitemap, never a 500.
     log.warn("Failed to build sitemap; serving empty sitemap", {

--- a/components/atrium/CollectionManagementPanel.tsx
+++ b/components/atrium/CollectionManagementPanel.tsx
@@ -1,0 +1,656 @@
+"use client";
+
+/**
+ * Shared collection editor for the library's private-collection dialog and the
+ * administrator's district hierarchy panel (#1438).
+ */
+
+import { useEffect, useMemo, useState, useTransition } from "react";
+import { Archive, FolderPlus, RotateCcw, Save } from "lucide-react";
+import {
+  createCollectionAction,
+  listManageableCollectionsAction,
+  updateCollectionAction,
+} from "@/actions/db/atrium/collection-management";
+import {
+  listGrantOptionsAction,
+  type GrantOptions,
+} from "@/actions/db/atrium/list-grant-options";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import type {
+  CollectionDTO,
+  CollectionGrant,
+  VisibilityLevel,
+} from "@/lib/content";
+
+interface CollectionManagementPanelProps {
+  mode: "admin" | "private";
+  initialCollections?: CollectionDTO[];
+  initialError?: string | null;
+}
+
+interface EditorState {
+  id: string | null;
+  name: string;
+  parentId: string;
+  position: string;
+  defaultVisibilityLevel: VisibilityLevel;
+  inheritGrants: boolean;
+  grants: CollectionGrant[];
+}
+
+const EMPTY_EDITOR: EditorState = {
+  id: null,
+  name: "",
+  parentId: "",
+  position: "",
+  defaultVisibilityLevel: "internal",
+  inheritGrants: true,
+  grants: [],
+};
+
+function editorFor(row: CollectionDTO): EditorState {
+  return {
+    id: row.id,
+    name: row.name,
+    parentId: row.parentId ?? "",
+    position: String(row.position),
+    defaultVisibilityLevel: row.defaultVisibilityLevel,
+    inheritGrants: row.inheritGrants,
+    grants: row.grants,
+  };
+}
+
+function ordered(rows: CollectionDTO[]): CollectionDTO[] {
+  const compare = (left: CollectionDTO, right: CollectionDTO) =>
+    left.position - right.position || left.name.localeCompare(right.name);
+  const children = new Map<string | null, CollectionDTO[]>();
+  for (const row of rows) {
+    const siblings = children.get(row.parentId) ?? [];
+    siblings.push(row);
+    children.set(row.parentId, siblings);
+  }
+  for (const siblings of children.values()) siblings.sort(compare);
+
+  const result: CollectionDTO[] = [];
+  const seen = new Set<string>();
+  const visit = (row: CollectionDTO) => {
+    if (seen.has(row.id)) return;
+    seen.add(row.id);
+    result.push(row);
+    for (const child of children.get(row.id) ?? []) visit(child);
+  };
+  for (const root of children.get(null) ?? []) visit(root);
+  // Defensive fallback for legacy orphan/cycle rows: display each once.
+  for (const row of [...rows].sort(compare)) visit(row);
+  return result;
+}
+
+function announceTreeChange(): void {
+  window.dispatchEvent(new Event("atrium:collections-changed"));
+}
+
+function GrantEditor({
+  grants,
+  options,
+  disabled,
+  onChange,
+}: {
+  grants: CollectionGrant[];
+  options: GrantOptions;
+  disabled: boolean;
+  onChange: (grants: CollectionGrant[]) => void;
+}): React.JSX.Element {
+  function patch(index: number, grant: CollectionGrant): void {
+    onChange(grants.map((current, i) => (i === index ? grant : current)));
+  }
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center justify-between">
+        <Label>Role and group access</Label>
+        <Button
+          type="button"
+          size="sm"
+          variant="outline"
+          disabled={disabled}
+          onClick={() =>
+            onChange([
+              ...grants,
+              { access: "view", kind: "role", value: options.roles[0] ?? "" },
+            ])
+          }
+        >
+          Add grant
+        </Button>
+      </div>
+      {grants.length === 0 ? (
+        <p className="text-xs text-muted-foreground">
+          No grants: authenticated users retain legacy access.
+        </p>
+      ) : null}
+      {grants.map((grant, index) => {
+        const values =
+          grant.kind === "role"
+            ? options.roles
+            : grant.kind === "group"
+              ? options.groups.map((group) => group.email)
+              : [];
+        return (
+          <div
+            key={`${index}-${grant.access}-${grant.kind}`}
+            className="grid gap-2 sm:grid-cols-[110px_110px_1fr_auto]"
+          >
+            <select
+              aria-label={`Grant ${index + 1} access`}
+              className="h-9 rounded-md border bg-background px-2 text-sm"
+              value={grant.access}
+              disabled={disabled}
+              onChange={(event) =>
+                patch(index, {
+                  ...grant,
+                  access: event.target.value as CollectionGrant["access"],
+                })
+              }
+            >
+              <option value="view">View</option>
+              <option value="create">Create</option>
+            </select>
+            <select
+              aria-label={`Grant ${index + 1} kind`}
+              className="h-9 rounded-md border bg-background px-2 text-sm"
+              value={grant.kind}
+              disabled={disabled}
+              onChange={(event) => {
+                const kind = event.target.value as CollectionGrant["kind"];
+                patch(index, {
+                  access: grant.access,
+                  kind,
+                  value:
+                    kind === "role"
+                      ? options.roles[0] ?? ""
+                      : kind === "group"
+                        ? options.groups[0]?.email ?? ""
+                        : "",
+                });
+              }}
+            >
+              <option value="role">Role</option>
+              <option value="group">Group</option>
+              <option value="building">Building</option>
+              <option value="department">Department</option>
+              <option value="grade">Grade</option>
+              <option value="user">User ID</option>
+            </select>
+            {grant.kind === "role" || grant.kind === "group" ? (
+              <select
+                aria-label={`Grant ${index + 1} value`}
+                className="h-9 min-w-0 rounded-md border bg-background px-2 text-sm"
+                value={grant.value}
+                disabled={disabled}
+                onChange={(event) =>
+                  patch(index, { ...grant, value: event.target.value })
+                }
+              >
+                {!values.includes(grant.value) && grant.value ? (
+                  <option value={grant.value}>{grant.value}</option>
+                ) : null}
+                {values.map((value) => (
+                  <option key={value} value={value}>
+                    {value}
+                  </option>
+                ))}
+              </select>
+            ) : (
+              <Input
+                aria-label={`Grant ${index + 1} value`}
+                value={grant.value}
+                disabled={disabled}
+                onChange={(event) =>
+                  patch(index, { ...grant, value: event.target.value })
+                }
+              />
+            )}
+            <Button
+              type="button"
+              size="sm"
+              variant="ghost"
+              disabled={disabled}
+              onClick={() => onChange(grants.filter((_, i) => i !== index))}
+            >
+              Remove
+            </Button>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function CollectionList({
+  mode,
+  rows,
+  onNew,
+  onSelect,
+}: {
+  mode: CollectionManagementPanelProps["mode"];
+  rows: CollectionDTO[];
+  onNew: () => void;
+  onSelect: (row: CollectionDTO) => void;
+}): React.JSX.Element {
+  return (
+    <section className="space-y-3">
+      <div className="flex items-center justify-between">
+        <h3 className="font-medium">
+          {mode === "private" ? "My private collections" : "All collections"}
+        </h3>
+        <Button type="button" size="sm" variant="outline" onClick={onNew}>
+          <FolderPlus className="mr-1 h-4 w-4" />
+          New
+        </Button>
+      </div>
+      <div className="max-h-[480px] space-y-1 overflow-y-auto">
+        {rows.map((row) => (
+          <button
+            type="button"
+            key={row.id}
+            className="flex w-full items-start justify-between rounded-md border px-3 py-2 text-left hover:bg-muted/50"
+            onClick={() => onSelect(row)}
+          >
+            <span className="min-w-0">
+              <span className="block truncate text-sm font-medium">
+                {row.path.join(" / ")}
+              </span>
+              <span className="block text-xs text-muted-foreground">
+                {row.directContentCount} direct · {row.subtreeContentCount} subtree
+                {row.ownerName ? ` · ${row.ownerName}` : ""}
+              </span>
+            </span>
+            <span className="ml-2 flex gap-1">
+              <Badge variant="outline">{row.scope}</Badge>
+              {row.archivedAt ? (
+                <Badge variant="secondary">Archived</Badge>
+              ) : null}
+            </span>
+          </button>
+        ))}
+        {rows.length === 0 ? (
+          <p className="rounded-md border border-dashed p-4 text-sm text-muted-foreground">
+            No collections yet.
+          </p>
+        ) : null}
+      </div>
+    </section>
+  );
+}
+
+function CollectionBasics({
+  mode,
+  editor,
+  parentOptions,
+  readOnly,
+  onChange,
+}: {
+  mode: CollectionManagementPanelProps["mode"];
+  editor: EditorState;
+  parentOptions: CollectionDTO[];
+  readOnly: boolean;
+  onChange: (editor: EditorState) => void;
+}): React.JSX.Element {
+  return (
+    <>
+      <div className="space-y-2">
+        <Label htmlFor={`${mode}-collection-name`}>Name</Label>
+        <Input
+          id={`${mode}-collection-name`}
+          value={editor.name}
+          maxLength={200}
+          disabled={readOnly}
+          onChange={(event) =>
+            onChange({ ...editor, name: event.target.value })
+          }
+        />
+      </div>
+      <div className="grid gap-4 sm:grid-cols-2">
+        <div className="space-y-2">
+          <Label htmlFor={`${mode}-collection-parent`}>Parent</Label>
+          <select
+            id={`${mode}-collection-parent`}
+            className="h-9 w-full rounded-md border bg-background px-3 text-sm"
+            value={editor.parentId}
+            disabled={readOnly}
+            onChange={(event) =>
+              onChange({ ...editor, parentId: event.target.value })
+            }
+          >
+            <option value="">Top level</option>
+            {parentOptions.map((row) => (
+              <option key={row.id} value={row.id}>
+                {row.path.join(" / ")}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor={`${mode}-collection-position`}>Order</Label>
+          <Input
+            id={`${mode}-collection-position`}
+            type="number"
+            min={0}
+            value={editor.position}
+            disabled={readOnly}
+            onChange={(event) =>
+              onChange({ ...editor, position: event.target.value })
+            }
+          />
+        </div>
+      </div>
+    </>
+  );
+}
+
+function DistrictCollectionOptions({
+  editor,
+  grantOptions,
+  readOnly,
+  onChange,
+}: {
+  editor: EditorState;
+  grantOptions: GrantOptions;
+  readOnly: boolean;
+  onChange: (editor: EditorState) => void;
+}): React.JSX.Element {
+  return (
+    <>
+      <div className="space-y-2">
+        <Label htmlFor="district-default-visibility">
+          Default content visibility
+        </Label>
+        <select
+          id="district-default-visibility"
+          className="h-9 w-full rounded-md border bg-background px-3 text-sm"
+          value={editor.defaultVisibilityLevel}
+          disabled={readOnly}
+          onChange={(event) =>
+            onChange({
+              ...editor,
+              defaultVisibilityLevel: event.target.value as VisibilityLevel,
+            })
+          }
+        >
+          <option value="private">Private</option>
+          <option value="group">Group</option>
+          <option value="internal">Internal</option>
+          <option value="public">Public</option>
+        </select>
+      </div>
+      <div className="flex items-center gap-2">
+        <Checkbox
+          id="district-inherit-grants"
+          checked={editor.inheritGrants}
+          disabled={readOnly}
+          onCheckedChange={(checked) =>
+            onChange({ ...editor, inheritGrants: checked === true })
+          }
+        />
+        <Label htmlFor="district-inherit-grants">
+          Inherit view/create grants from parent
+        </Label>
+      </div>
+      <GrantEditor
+        grants={editor.grants}
+        options={grantOptions}
+        disabled={readOnly}
+        onChange={(grants) => onChange({ ...editor, grants })}
+      />
+    </>
+  );
+}
+
+function CollectionEditor({
+  mode,
+  editor,
+  grantOptions,
+  parentOptions,
+  selected,
+  readOnly,
+  error,
+  notice,
+  isPending,
+  onChange,
+  onSave,
+  onToggleArchived,
+}: {
+  mode: CollectionManagementPanelProps["mode"];
+  editor: EditorState;
+  grantOptions: GrantOptions;
+  parentOptions: CollectionDTO[];
+  selected: CollectionDTO | null;
+  readOnly: boolean;
+  error: string | null;
+  notice: string | null;
+  isPending: boolean;
+  onChange: (editor: EditorState) => void;
+  onSave: () => void;
+  onToggleArchived: (row: CollectionDTO) => void;
+}): React.JSX.Element {
+  return (
+    <section className="space-y-4 rounded-lg border p-4">
+      <div>
+        <h3 className="font-medium">
+          {editor.id ? "Collection settings" : "Create collection"}
+        </h3>
+        {readOnly ? (
+          <p className="text-xs text-muted-foreground">
+            Private collections are owner-bound and read-only to administrators.
+          </p>
+        ) : null}
+      </div>
+      <CollectionBasics
+        mode={mode}
+        editor={editor}
+        parentOptions={parentOptions}
+        readOnly={readOnly}
+        onChange={onChange}
+      />
+      {mode === "admin" ? (
+        <DistrictCollectionOptions
+          editor={editor}
+          grantOptions={grantOptions}
+          readOnly={readOnly}
+          onChange={onChange}
+        />
+      ) : (
+        <p className="text-xs text-muted-foreground">
+          Private collections and their contents are visible only to you.
+        </p>
+      )}
+      {error ? (
+        <p className="text-sm text-destructive" role="alert">
+          {error}
+        </p>
+      ) : null}
+      {notice ? (
+        <p className="text-sm text-emerald-700" role="status">
+          {notice}
+        </p>
+      ) : null}
+      <div className="flex flex-wrap justify-end gap-2">
+        {selected && !readOnly ? (
+          <Button
+            type="button"
+            variant="outline"
+            disabled={isPending}
+            onClick={() => onToggleArchived(selected)}
+          >
+            {selected.archivedAt ? (
+              <RotateCcw className="mr-1 h-4 w-4" />
+            ) : (
+              <Archive className="mr-1 h-4 w-4" />
+            )}
+            {selected.archivedAt ? "Restore subtree" : "Archive subtree"}
+          </Button>
+        ) : null}
+        <Button
+          type="button"
+          disabled={isPending || readOnly || !editor.name.trim()}
+          onClick={onSave}
+        >
+          <Save className="mr-1 h-4 w-4" />
+          {isPending ? "Saving…" : "Save"}
+        </Button>
+      </div>
+    </section>
+  );
+}
+
+export function CollectionManagementPanel({
+  mode,
+  initialCollections = [],
+  initialError = null,
+}: CollectionManagementPanelProps): React.JSX.Element {
+  const [collections, setCollections] = useState(initialCollections);
+  const [editor, setEditor] = useState<EditorState>(EMPTY_EDITOR);
+  const [grantOptions, setGrantOptions] = useState<GrantOptions>({
+    roles: [],
+    groups: [],
+  });
+  const [error, setError] = useState<string | null>(initialError);
+  const [notice, setNotice] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
+  const rows = useMemo(() => ordered(collections), [collections]);
+  const selected = editor.id
+    ? collections.find((row) => row.id === editor.id) ?? null
+    : null;
+  const readOnly = mode === "admin" && selected?.scope === "private";
+  const parentOptions = rows.filter(
+    (row) =>
+      row.id !== editor.id &&
+      !row.archivedAt &&
+      row.scope === (mode === "private" ? "private" : "district")
+  );
+
+  function refresh(selectId?: string): void {
+    startTransition(async () => {
+      const result = await listManageableCollectionsAction(mode);
+      if (!result.isSuccess) {
+        setError(result.message ?? "Failed to refresh collections");
+        return;
+      }
+      const next = result.data ?? [];
+      setCollections(next);
+      if (selectId) {
+        const row = next.find((item) => item.id === selectId);
+        if (row) setEditor(editorFor(row));
+      }
+      setError(null);
+    });
+  }
+
+  useEffect(() => {
+    if (initialCollections.length === 0) refresh();
+    if (mode === "admin") {
+      void listGrantOptionsAction().then((result) => {
+        if (result.isSuccess && result.data) setGrantOptions(result.data);
+      });
+    }
+    // Initial props are deliberately a one-time server snapshot.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [mode]);
+
+  function save(): void {
+    setError(null);
+    setNotice(null);
+    startTransition(async () => {
+      const position = editor.position.trim()
+        ? Number(editor.position)
+        : undefined;
+      const result = editor.id
+        ? await updateCollectionAction(editor.id, {
+            name: editor.name,
+            parentId: editor.parentId || null,
+            position,
+            ...(mode === "admin" && !readOnly
+              ? {
+                  defaultVisibilityLevel: editor.defaultVisibilityLevel,
+                  inheritGrants: editor.inheritGrants,
+                  grants: editor.grants,
+                }
+              : {}),
+          })
+        : await createCollectionAction({
+            name: editor.name,
+            scope: mode === "private" ? "private" : "district",
+            parentId: editor.parentId || null,
+            position,
+            ...(mode === "admin"
+              ? {
+                  defaultVisibilityLevel: editor.defaultVisibilityLevel,
+                  inheritGrants: editor.inheritGrants,
+                  grants: editor.grants,
+                }
+              : {}),
+          });
+      if (!result.isSuccess || !result.data) {
+        setError(result.message ?? "Failed to save collection");
+        return;
+      }
+      setNotice(editor.id ? "Collection updated" : "Collection created");
+      announceTreeChange();
+      refresh(result.data.id);
+    });
+  }
+
+  function toggleArchived(row: CollectionDTO): void {
+    setError(null);
+    setNotice(null);
+    startTransition(async () => {
+      const result = await updateCollectionAction(row.id, {
+        archived: !row.archivedAt,
+      });
+      if (!result.isSuccess) {
+        setError(result.message ?? "Failed to update collection");
+        return;
+      }
+      setNotice(row.archivedAt ? "Collection restored" : "Collection archived");
+      announceTreeChange();
+      refresh(row.id);
+    });
+  }
+
+  return (
+    <div className="grid gap-5 lg:grid-cols-[minmax(260px,0.8fr)_minmax(360px,1.2fr)]">
+      <CollectionList
+        mode={mode}
+        rows={rows}
+        onNew={() =>
+          setEditor({
+            ...EMPTY_EDITOR,
+            defaultVisibilityLevel:
+              mode === "private" ? "private" : "internal",
+            inheritGrants: mode !== "private",
+          })
+        }
+        onSelect={(row) => setEditor(editorFor(row))}
+      />
+      <CollectionEditor
+        mode={mode}
+        editor={editor}
+        grantOptions={grantOptions}
+        parentOptions={parentOptions}
+        selected={selected}
+        readOnly={readOnly}
+        error={error}
+        notice={notice}
+        isPending={isPending}
+        onChange={setEditor}
+        onSave={save}
+        onToggleArchived={toggleArchived}
+      />
+    </div>
+  );
+}

--- a/components/atrium/CollectionTree.tsx
+++ b/components/atrium/CollectionTree.tsx
@@ -158,6 +158,12 @@ export function CollectionTree({
     void load();
   }, [load]);
 
+  useEffect(() => {
+    const reload = () => void load();
+    window.addEventListener("atrium:collections-changed", reload);
+    return () => window.removeEventListener("atrium:collections-changed", reload);
+  }, [load]);
+
   return (
     <nav
       aria-label="Content sections"

--- a/components/atrium/LibraryView.tsx
+++ b/components/atrium/LibraryView.tsx
@@ -34,6 +34,7 @@ import { createLogger } from "@/lib/client-logger";
 import { LibraryList } from "./LibraryList";
 import { LibraryBulkBar } from "./LibraryBulkBar";
 import { CreateContentDialog } from "./CreateContentDialog";
+import { PrivateCollectionsDialog } from "./PrivateCollectionsDialog";
 
 const log = createLogger({ component: "LibraryView" });
 
@@ -184,6 +185,7 @@ function LibraryHeader({
           ⌘K
         </kbd>
       </div>
+      <PrivateCollectionsDialog />
       <button type="button" className="mer-btn" onClick={onNewArtifact}>
         <Sparkles className="h-4 w-4" aria-hidden="true" />
         New artifact

--- a/components/atrium/PrivateCollectionsDialog.tsx
+++ b/components/atrium/PrivateCollectionsDialog.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { FolderCog } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { CollectionManagementPanel } from "./CollectionManagementPanel";
+
+export function PrivateCollectionsDialog(): React.JSX.Element {
+  return (
+    <Dialog>
+      <DialogTrigger asChild>
+        <Button type="button" variant="outline">
+          <FolderCog className="mr-1 h-4 w-4" />
+          New private collection
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="max-h-[90vh] max-w-5xl overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>Manage private collections</DialogTitle>
+          <DialogDescription>
+            Create, nest, rename, move, reorder, archive, and restore collections
+            that remain bound to your account.
+          </DialogDescription>
+        </DialogHeader>
+        <CollectionManagementPanel mode="private" />
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/components/atrium/admin/atrium-admin-tabs.tsx
+++ b/components/atrium/admin/atrium-admin-tabs.tsx
@@ -9,14 +9,18 @@
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { ApprovalsQueue } from "./approvals-queue"
 import { AuditLogTable } from "./audit-log-table"
+import { CollectionManagementPanel } from "@/components/atrium/CollectionManagementPanel"
 import type { PendingApprovalDTO } from "@/actions/db/atrium/approvals"
 import type { ContentAuditPage } from "@/actions/db/atrium/audit-log"
+import type { CollectionDTO } from "@/lib/content"
 
 interface AtriumAdminTabsProps {
   initialApprovals: PendingApprovalDTO[]
   approvalsError: string | null
   initialAudit: ContentAuditPage
   auditError: string | null
+  initialCollections: CollectionDTO[]
+  collectionsError: string | null
 }
 
 export function AtriumAdminTabs({
@@ -24,6 +28,8 @@ export function AtriumAdminTabs({
   approvalsError,
   initialAudit,
   auditError,
+  initialCollections,
+  collectionsError,
 }: AtriumAdminTabsProps) {
   return (
     <Tabs defaultValue="approvals">
@@ -32,12 +38,20 @@ export function AtriumAdminTabs({
           Approvals
           {initialApprovals.length > 0 ? ` (${initialApprovals.length})` : ""}
         </TabsTrigger>
+        <TabsTrigger value="collections">Collections</TabsTrigger>
         <TabsTrigger value="audit">Audit</TabsTrigger>
       </TabsList>
       <TabsContent value="approvals">
         <ApprovalsQueue
           initialRequests={initialApprovals}
           initialError={approvalsError}
+        />
+      </TabsContent>
+      <TabsContent value="collections">
+        <CollectionManagementPanel
+          mode="admin"
+          initialCollections={initialCollections}
+          initialError={collectionsError}
         />
       </TabsContent>
       <TabsContent value="audit">

--- a/components/atrium/admin/audit-log-table.tsx
+++ b/components/atrium/admin/audit-log-table.tsx
@@ -43,6 +43,10 @@ const ACTIONS = [
   "unpublish",
   "export_okf",
   "import_okf",
+  "collection_create",
+  "collection_update",
+  "collection_archive",
+  "collection_restore",
 ] as const
 // `ui` is the in-app authoring surface — the source of the #1336
 // public-exposure notifications, so it must be filterable here.
@@ -149,8 +153,8 @@ function AuditFilters({
         className="w-[280px]"
         value={objectId}
         onChange={(e) => onObjectIdChange(e.target.value)}
-        placeholder="Object id (full or fragment)"
-        aria-label="Filter by object id"
+        placeholder="Object or collection id"
+        aria-label="Filter by object or collection id"
       />
 
       <Button size="sm" onClick={onApply} disabled={isPending}>
@@ -222,7 +226,7 @@ export function AuditLogTable({ initialData, initialError }: AuditLogTableProps)
               <TableHead>Action</TableHead>
               <TableHead>Surface</TableHead>
               <TableHead>Actor</TableHead>
-              <TableHead>Object</TableHead>
+              <TableHead>Object / collection</TableHead>
               <TableHead>Destination</TableHead>
               <TableHead>Outcome</TableHead>
               <TableHead>Error</TableHead>
@@ -251,8 +255,16 @@ export function AuditLogTable({ initialData, initialError }: AuditLogTableProps)
                 <TableCell>{actorOf(row)}</TableCell>
                 <TableCell>
                   <span className="font-mono text-xs">
-                    {row.objectId ?? "—"}
+                    {row.objectId ??
+                      row.collectionName ??
+                      row.collectionId ??
+                      "—"}
                   </span>
+                  {row.collectionName && row.collectionId ? (
+                    <span className="block font-mono text-[10px] text-muted-foreground">
+                      {row.collectionId}
+                    </span>
+                  ) : null}
                 </TableCell>
                 <TableCell>{row.destination ?? "—"}</TableCell>
                 <TableCell>

--- a/docs/API/v1/context-graph.md
+++ b/docs/API/v1/context-graph.md
@@ -1336,6 +1336,8 @@ through a secondary id/name lookup.
       "slug": "technology-guides",
       "parentId": null,
       "path": ["Technology Guides"],
+      "scope": "district",
+      "ownerUserId": null,
       "defaultVisibilityLevel": "internal",
       "visibleObjectCount": 42,
       "selectableForCreate": true,
@@ -1350,6 +1352,95 @@ through a secondary id/name lookup.
 failures are `401`/`403`. A slug/UUID selected from this response is passed to
 `POST /content` unchanged. If it is deleted before create, the existing typed
 `400 CONTENT_VALIDATION` collection-not-found response is returned.
+
+#### `POST /api/v1/content/collections`
+
+Creates a collection. Requires `content:create`; session callers must also have
+the `atrium-content` capability. `scope: "private"` creates an owner-bound
+hierarchy for the acting human. `scope: "district"` requires administrator
+authority.
+
+```json
+{
+  "name": "Human Resources",
+  "scope": "district",
+  "parentId": null,
+  "position": 2,
+  "defaultVisibilityLevel": "internal",
+  "inheritGrants": true,
+  "grants": [
+    { "access": "view", "kind": "role", "value": "staff" },
+    {
+      "access": "create",
+      "kind": "group",
+      "value": "hr-editors@psd401.net"
+    }
+  ]
+}
+```
+
+Grant `access` is independent: `view` controls collection/content discovery;
+`create` controls whether content may be placed there. Child collections inherit
+ancestor grants while `inheritGrants` is true. Zero effective grants preserve the
+legacy unrestricted district behavior. A `group` default uses effective
+collection `view` grants as the new object's group-visibility grants.
+
+Private collections are always `private`, never inherit or carry grants, and can
+nest only under private collections owned by the same user. An administrator can
+inspect private collection metadata/counts in the oversight UI but cannot enter,
+read, or mutate another user's private collection.
+
+**Response `201`**
+
+```json
+{
+  "data": {
+    "id": "c0ffee00-0000-4000-8000-000000000001",
+    "name": "Human Resources",
+    "slug": "human-resources",
+    "parentId": null,
+    "path": ["Human Resources"],
+    "scope": "district",
+    "ownerUserId": null,
+    "ownerName": null,
+    "defaultVisibilityLevel": "internal",
+    "inheritGrants": true,
+    "position": 2,
+    "archivedAt": null,
+    "directContentCount": 0,
+    "subtreeContentCount": 0,
+    "grants": [
+      { "access": "view", "kind": "role", "value": "staff" }
+    ],
+    "selectableForCreate": true
+  },
+  "meta": { "requestId": "req_abc123" }
+}
+```
+
+#### `PATCH /api/v1/content/collections/{id}`
+
+Requires `content:update`. Any subset of `name`, `parentId`, `position`,
+`defaultVisibilityLevel`, `inheritGrants`, `grants`, or `archived` may be sent.
+`parentId` + `position` implement move/reorder. `archived: true` archives the
+selected collection and its subtree; `false` restores the subtree. Content rows
+are retained.
+
+```json
+{ "parentId": "c0ffee00-0000-4000-8000-000000000001", "position": 0 }
+```
+
+Slugs remain stable on rename. Sibling names are case-insensitively unique within
+the district hierarchy or one private owner's hierarchy; different owners may
+use the same top-level name.
+Crossing district/private ownership boundaries, moving under a descendant,
+restoring under an archived parent, or conflicting concurrent hierarchy writes
+is rejected (`400`/`409`). The response uses the same management shape as create.
+
+Content counts have explicit semantics: `directContentCount` counts only rows
+filed directly in the collection; `subtreeContentCount` includes all descendants.
+Content selection in the library/API remains **direct collection only**; subtree
+counts do not change list filtering semantics.
 
 ---
 
@@ -2042,19 +2133,26 @@ Import an OKF bundle into content. Requires `content:create`.
 | Field | Type | Required | Constraints |
 |-------|------|----------|-------------|
 | `files` | array of `{ path, content }` | yes | ≥ 1 file |
-| `targetCollectionId` | string | no | Import the bundle root INTO this collection; a fresh root is created when omitted |
+| `targetCollectionId` | string | no | Import the bundle root INTO this selectable collection; a fresh owner-bound private root is created for human/delegated callers when omitted |
 
 **Provenance (§36.3):** imported objects are **agent-authored**
 (`actor_kind = 'agent'`, attributed to the seeded `atrium-importer` identity) and
 created **private + draft** — never fabricated human authorship, never pre-widened.
-The triggering caller is recorded in the audit trail.
+Object ownership and collection authorization remain bound to the triggering
+human/delegated caller, who is recorded in the audit trail.
+
+Reconstructed hierarchy uses the shared collection-management service. A
+human/delegated caller without a target gets a private hierarchy they own.
+Creating descendants beneath a district target requires administrator authority.
+Autonomous callers must supply an existing selectable target and cannot mint an
+ownerless/shared hierarchy.
 
 **Retry semantics (not transactional):** import is additive and not wrapped in a
 single transaction (`contentService.create` does its own tx + post-commit S3 IO
 per object). A run that fails partway leaves the already-created private/draft
-content in place, and a retry re-imports the whole bundle as **new** objects (no
-path/`sourceRef` dedup; slugs auto-suffix). For idempotency, import into a fresh
-`targetCollectionId` and, on failure, delete that partial collection before retrying.
+content in place. A blind retry can duplicate objects or meet a sibling-name
+conflict. For idempotency, use a fresh `targetCollectionId` and, on failure,
+archive the partial imported subtree before retrying into a new target.
 
 **Response `201`**
 

--- a/docs/API/v1/context-graph.md
+++ b/docs/API/v1/context-graph.md
@@ -1386,7 +1386,8 @@ Grant `access` is independent: `view` controls collection/content discovery;
 `create` controls whether content may be placed there. Child collections inherit
 ancestor grants while `inheritGrants` is true. Zero effective grants preserve the
 legacy unrestricted district behavior. A `group` default uses effective
-collection `view` grants as the new object's group-visibility grants.
+collection `view` grants as the new object's group-visibility grants and is
+rejected when no such grant exists.
 
 Private collections are always `private`, never inherit or carry grants, and can
 nest only under private collections owned by the same user. An administrator can
@@ -1438,7 +1439,9 @@ the district hierarchy or one private owner's hierarchy; different owners may
 use the same top-level name.
 Crossing district/private ownership boundaries, moving under a descendant,
 restoring under an archived parent, or conflicting concurrent hierarchy writes
-is rejected (`400`/`409`). The response uses the same management shape as create.
+is rejected (`400`/`409`). A resulting `group` default without any effective
+`view` grant is also rejected. The response uses the same management shape as
+create.
 
 Content counts have explicit semantics: `directContentCount` counts only rows
 filed directly in the collection; `subtreeContentCount` includes all descendants.

--- a/docs/API/v1/context-graph.md
+++ b/docs/API/v1/context-graph.md
@@ -1526,6 +1526,11 @@ initial version (v1) is snapshotted. Requires `content:create`.
 | `tags` | string[] | no | — |
 | `sourceRef` | object | no | Create-only typed provenance; see Capture provenance below |
 
+Collection placement is re-authorized inside the object write transaction under
+collection locks. The persisted default visibility and inherited grants are the
+locked current values; a concurrent archive or grant revocation cannot commit a
+stale create.
+
 **Capture provenance (#1290):** Atrium Capture may send
 `sourceRef: { type: "capture", provider, externalId, clientSurface, clientVersion,
 capturedAt, sourceOrigins? }`. `clientSurface` is `browser` or `mac`; identifiers
@@ -1659,6 +1664,10 @@ Requires `content:update`.
 | `tags` | string[] \| null | Replaces all tags; `null` clears them |
 | `collectionId` | string \| null | Collection slug or UUID; `null` clears the collection |
 | `status` | `draft` \| `published` \| `archived` | — |
+
+When `collectionId` changes, the target collection and its effective create
+grants are re-authorized under collection locks in the same transaction as the
+object update.
 
 **Example request:**
 

--- a/docs/API/v1/context-graph.md
+++ b/docs/API/v1/context-graph.md
@@ -1318,7 +1318,10 @@ applied or downgraded.
 Returns the same requester-visible hierarchy as `collectionService.tree(req)`.
 Requires `content:read`. Filtering and visible-object counts are permission-pushed
 on the server; a hidden collection is never loaded into the client or exposed
-through a secondary id/name lookup.
+through a secondary id/name lookup. If an accessible child exists below a denied
+ancestor, the denied node is omitted and the child is re-rooted beneath its
+nearest returned ancestor (or at the root); `parentId` and `path` reflect that
+permission-filtered projection.
 
 - `shape=tree` (default) retains nested `children`.
 - `shape=flat` walks that tree in stable Atrium position/name pre-order, omits
@@ -1355,9 +1358,9 @@ failures are `401`/`403`. A slug/UUID selected from this response is passed to
 
 #### `POST /api/v1/content/collections`
 
-Creates a collection. Requires `content:create`; session callers must also have
-the `atrium-content` capability. `scope: "private"` creates an owner-bound
-hierarchy for the acting human. `scope: "district"` requires administrator
+Creates a collection. Requires `content:create`; REST authorization remains
+scope-based. `scope: "private"` creates an owner-bound hierarchy for the acting
+human. `scope: "district"` requires administrator
 authority.
 
 ```json

--- a/docs/API/v1/openapi.yaml
+++ b/docs/API/v1/openapi.yaml
@@ -2087,6 +2087,9 @@ paths:
         Creates a document or artifact. Does NOT publish it. When `body` is
         supplied, an initial version (v1) is snapshotted. Mirrors the MCP
         `create_document` / `create_artifact` tools. Requires `content:create`.
+        Collection placement is re-authorized under collection locks in the
+        object write transaction, which also resolves the current default and
+        inherited grants.
 
         **Public create-as-private (§26.4, issue #1118):** creating directly at
         `visibility.level: "public"` (explicitly, or via a collection whose default
@@ -2376,7 +2379,9 @@ paths:
         Updates object metadata only — `title`, `tags`, `collectionId`, and
         `status`. Body changes go through the versions endpoint. `collectionId`
         accepts a slug or UUID; `null` clears the collection, `null` tags clears
-        all tags. Mirrors the MCP `update_content` tool. Requires `content:update`.
+        all tags. A collection move re-authorizes the target under collection
+        locks in the same transaction as the update. Mirrors the MCP
+        `update_content` tool. Requires `content:update`.
       security:
         - BearerAuth: []
       requestBody:

--- a/docs/API/v1/openapi.yaml
+++ b/docs/API/v1/openapi.yaml
@@ -2166,7 +2166,10 @@ paths:
         same stable pre-order without `children`, retaining each node's display
         `path`. When the caller also holds `content:create`,
         `selectableForCreate` is included so an external picker can select a
-        destination without hard-coded slugs or ids.
+        destination without hard-coded slugs or ids. If an accessible child is
+        below a denied ancestor, the denied node is omitted and the child is
+        re-rooted beneath its nearest returned ancestor (or at the root);
+        `parentId` and `path` reflect this permission-filtered projection.
       security:
         - BearerAuth: []
       parameters:
@@ -4650,6 +4653,7 @@ components:
           type: string
           format: uuid
           nullable: true
+          description: Nearest returned ancestor; null when no admitted ancestor is returned.
         path:
           type: array
           minItems: 1

--- a/docs/API/v1/openapi.yaml
+++ b/docs/API/v1/openapi.yaml
@@ -2204,6 +2204,119 @@ paths:
         "500":
           $ref: "#/components/responses/InternalError"
 
+    post:
+      operationId: createContentCollection
+      tags: [Content]
+      summary: Create an Atrium collection
+      description: |
+        Creates an owner-bound `private` collection for the calling human, or a
+        district/shared collection when the caller is an administrator. Requires
+        `content:create`. Private collections are always private, never inherit
+        grants, and may nest only under collections owned by the same user.
+      security:
+        - BearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateCollectionRequest"
+            examples:
+              private:
+                value:
+                  name: My Projects
+                  scope: private
+                  parentId: null
+              district:
+                value:
+                  name: Human Resources
+                  scope: district
+                  defaultVisibilityLevel: internal
+                  inheritGrants: true
+                  grants:
+                    - access: view
+                      kind: role
+                      value: staff
+                    - access: create
+                      kind: group
+                      value: hr-editors@psd401.net
+      responses:
+        "201":
+          description: Collection created.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CollectionManagementResponse"
+        "400":
+          $ref: "#/components/responses/ValidationError"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "409":
+          $ref: "#/components/responses/ContentConflict"
+        "429":
+          $ref: "#/components/responses/RateLimited"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /content/collections/{id}:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        description: Collection UUID returned by collection discovery or creation.
+        schema:
+          type: string
+          format: uuid
+    patch:
+      operationId: updateContentCollection
+      tags: [Content]
+      summary: Rename, reorder, move, archive, or restore an Atrium collection
+      description: |
+        Applies a partial collection update. `parentId` and `position` move/reorder
+        the collection; `archived=true|false` recursively archives/restores its
+        subtree without deleting content. Requires `content:update`. District
+        collections require administrator authority; private collections remain
+        owner-bound and cannot be managed or read by district administrators.
+      security:
+        - BearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UpdateCollectionRequest"
+            examples:
+              move:
+                value:
+                  parentId: c0ffee00-0000-4000-8000-000000000001
+                  position: 0
+              archiveSubtree:
+                value:
+                  archived: true
+      responses:
+        "200":
+          description: Updated collection.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CollectionManagementResponse"
+        "400":
+          $ref: "#/components/responses/ValidationError"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          $ref: "#/components/responses/ContentConflict"
+        "429":
+          $ref: "#/components/responses/RateLimited"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
   /content/{id}:
     parameters:
       - $ref: "#/components/parameters/contentIdPath"
@@ -3140,14 +3253,19 @@ paths:
         **Provenance:** imported objects are **agent-authored**
         (`actor_kind = 'agent'`, attributed to the seeded `atrium-importer`
         identity) and created **private + draft** — never fabricated human
-        authorship, never pre-widened. The triggering caller is recorded in the
-        audit trail.
+        authorship, never pre-widened. Ownership and collection authorization
+        remain bound to the triggering human/delegated caller.
+
+        Reconstructed hierarchy uses the shared collection-management service.
+        Without a target, human/delegated callers receive a private root they
+        own. Descendants beneath a district target require administrator
+        authority. Autonomous callers must supply an existing selectable target.
 
         **Retry semantics:** import is additive and NOT transactional. A run that
-        fails partway leaves the already-created private/draft content in place, and
-        a retry re-imports the whole bundle as new objects (no dedup). For
-        idempotency, import into a fresh `targetCollectionId` and delete that partial
-        collection before retrying.
+        fails partway leaves already-created private/draft content in place. A
+        blind retry can duplicate objects or meet a sibling-name conflict. For
+        idempotency, use a fresh target and archive the partial imported subtree
+        before retrying into a new target.
       security:
         - BearerAuth: []
       requestBody:
@@ -4516,6 +4634,8 @@ components:
         - slug
         - parentId
         - path
+        - scope
+        - ownerUserId
         - defaultVisibilityLevel
         - visibleObjectCount
       properties:
@@ -4535,6 +4655,13 @@ components:
           minItems: 1
           items:
             type: string
+        scope:
+          type: string
+          enum: [district, private]
+        ownerUserId:
+          type: integer
+          nullable: true
+          description: Present for owner-bound private collections.
         defaultVisibilityLevel:
           type: string
           enum: [private, group, internal, public]
@@ -4571,6 +4698,166 @@ components:
             count:
               type: integer
               minimum: 0
+
+    CollectionGrant:
+      type: object
+      additionalProperties: false
+      required: [access, kind, value]
+      properties:
+        access:
+          type: string
+          enum: [view, create]
+        kind:
+          type: string
+          enum: [role, building, department, grade, user, group]
+        value:
+          type: string
+          minLength: 1
+          maxLength: 255
+
+    CreateCollectionRequest:
+      type: object
+      additionalProperties: false
+      required: [name, scope]
+      properties:
+        name:
+          type: string
+          minLength: 1
+          maxLength: 200
+        scope:
+          type: string
+          enum: [district, private]
+        parentId:
+          type: string
+          format: uuid
+          nullable: true
+        position:
+          type: integer
+          minimum: 0
+        defaultVisibilityLevel:
+          type: string
+          enum: [private, group, internal, public]
+        inheritGrants:
+          type: boolean
+        grants:
+          type: array
+          maxItems: 200
+          items:
+            $ref: "#/components/schemas/CollectionGrant"
+
+    UpdateCollectionRequest:
+      type: object
+      additionalProperties: false
+      minProperties: 1
+      description: |
+        A collection cannot change between district and private ownership.
+      properties:
+        name:
+          type: string
+          minLength: 1
+          maxLength: 200
+        parentId:
+          type: string
+          format: uuid
+          nullable: true
+        position:
+          type: integer
+          minimum: 0
+        defaultVisibilityLevel:
+          type: string
+          enum: [private, group, internal, public]
+        inheritGrants:
+          type: boolean
+        grants:
+          type: array
+          maxItems: 200
+          items:
+            $ref: "#/components/schemas/CollectionGrant"
+        archived:
+          type: boolean
+
+    CollectionManagement:
+      type: object
+      additionalProperties: false
+      required:
+        - id
+        - name
+        - slug
+        - parentId
+        - path
+        - scope
+        - ownerUserId
+        - ownerName
+        - defaultVisibilityLevel
+        - inheritGrants
+        - position
+        - archivedAt
+        - directContentCount
+        - subtreeContentCount
+        - grants
+        - selectableForCreate
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+        slug:
+          type: string
+        parentId:
+          type: string
+          format: uuid
+          nullable: true
+        path:
+          type: array
+          items:
+            type: string
+        scope:
+          type: string
+          enum: [district, private]
+        ownerUserId:
+          type: integer
+          nullable: true
+        ownerName:
+          type: string
+          nullable: true
+        defaultVisibilityLevel:
+          type: string
+          enum: [private, group, internal, public]
+        inheritGrants:
+          type: boolean
+        position:
+          type: integer
+          minimum: 0
+        archivedAt:
+          type: string
+          format: date-time
+          nullable: true
+        directContentCount:
+          type: integer
+          minimum: 0
+        subtreeContentCount:
+          type: integer
+          minimum: 0
+        grants:
+          type: array
+          items:
+            $ref: "#/components/schemas/CollectionGrant"
+        selectableForCreate:
+          type: boolean
+
+    CollectionManagementResponse:
+      type: object
+      required: [data, meta]
+      properties:
+        data:
+          $ref: "#/components/schemas/CollectionManagement"
+        meta:
+          type: object
+          required: [requestId]
+          properties:
+            requestId:
+              type: string
 
     ContentObject:
       type: object
@@ -5335,7 +5622,7 @@ components:
             $ref: "#/components/schemas/OkfFile"
         targetCollectionId:
           type: string
-          description: Existing collection slug or id to import the bundle root INTO (a fresh root collection is created when omitted).
+          description: Existing selectable collection slug or id to import the bundle root INTO. When omitted, a human/delegated caller gets a fresh owner-bound private root; autonomous callers must supply a target.
 
     OkfImportResponse:
       type: object

--- a/docs/API/v1/openapi.yaml
+++ b/docs/API/v1/openapi.yaml
@@ -2215,7 +2215,8 @@ paths:
         Creates an owner-bound `private` collection for the calling human, or a
         district/shared collection when the caller is an administrator. Requires
         `content:create`. Private collections are always private, never inherit
-        grants, and may nest only under collections owned by the same user.
+        grants, and may nest only under collections owned by the same user. A
+        `group` default requires at least one effective `view` grant.
       security:
         - BearerAuth: []
       requestBody:
@@ -2281,7 +2282,8 @@ paths:
         the collection; `archived=true|false` recursively archives/restores its
         subtree without deleting content. Requires `content:update`. District
         collections require administrator authority; private collections remain
-        owner-bound and cannot be managed or read by district administrators.
+        owner-bound and cannot be managed or read by district administrators. A
+        resulting `group` default requires at least one effective `view` grant.
       security:
         - BearerAuth: []
       requestBody:

--- a/docs/README.md
+++ b/docs/README.md
@@ -213,6 +213,9 @@ Tool integration for Assistant Architect prompts.
 #### [features/atrium-agent-access.md](./features/atrium-agent-access.md)
 **Connecting agents to Atrium content** — how a local MCP client (Claude Code etc.) or the PSD AI Agents (OpenClaw) read/write Atrium documents: API-key setup, the MCP content tools + scope table, the version-based vs live-document distinction, delegated tokens, and the loopback binding hazard for the live bridge.
 
+#### [features/atrium-collection-management.md](./features/atrium-collection-management.md)
+**Atrium collection management** — district/shared and owner-bound private hierarchies, inherited view/create grants, lifecycle and conflict rules, explicit count/filter semantics, audit coverage, and the UI/REST/skill surfaces.
+
 #### [features/assistant-architect-json-import-spec.md](./features/assistant-architect-json-import-spec.md)
 **Complete JSON import specification** for generating valid assistant import files. Includes schema reference, field types, variable substitution, execution patterns, and comprehensive examples.
 

--- a/docs/features/atrium-agent-access.md
+++ b/docs/features/atrium-agent-access.md
@@ -100,9 +100,11 @@ Subcommands include `find`, `read`, `create-document`, `create-artifact`, `edit`
 `archive-collection`, and `restore-collection`. Collection mutations use the same
 owner/admin hierarchy service as the UI and REST API: every owner can manage only
 their private tree, while district collection management requires administrator
-authority. `list-collections` uses the management projection, so it includes
-active and archived manageable rows plus grants and direct/subtree counts; an
-owner can therefore rediscover the UUID required to restore an archived subtree.
+authority. `list-collections` combines active requester-visible collections
+(including accessible district/shared rows) with active and archived manageable
+rows. Manageable rows include grants and direct/subtree counts, so an owner can
+rediscover the UUID required to restore an archived subtree without losing
+district collection discovery.
 The agent
 works **version-based** (create-as-private, owner permission and capability
 gating) and acts as the **signed workspace owner** — a `user` requester. Writes

--- a/docs/features/atrium-agent-access.md
+++ b/docs/features/atrium-agent-access.md
@@ -100,7 +100,10 @@ Subcommands include `find`, `read`, `create-document`, `create-artifact`, `edit`
 `archive-collection`, and `restore-collection`. Collection mutations use the same
 owner/admin hierarchy service as the UI and REST API: every owner can manage only
 their private tree, while district collection management requires administrator
-authority. The agent
+authority. `list-collections` uses the management projection, so it includes
+active and archived manageable rows plus grants and direct/subtree counts; an
+owner can therefore rediscover the UUID required to restore an archived subtree.
+The agent
 works **version-based** (create-as-private, owner permission and capability
 gating) and acts as the **signed workspace owner** — a `user` requester. Writes
 are attributed to that owner; public publish/widen authority is never synthesized,

--- a/docs/features/atrium-agent-access.md
+++ b/docs/features/atrium-agent-access.md
@@ -59,7 +59,7 @@ Consequences for external agents:
    | `publish_content` | `content:publish_internal` | Public destinations additionally require the human/admin-held `content:publish_public` — the tool surfaces a structured `approval_required` signal instead of publishing |
    | `unpublish_content` | `content:publish_internal` | Taking down a **public** destination is gated the same as putting it up (§26.4) |
    | `export_okf` | `content:read` | `--audience public` additionally needs `content:publish_public` |
-   | `import_okf` | `content:create` | Imports land private + draft |
+   | `import_okf` | `content:create` | Imports land private + draft; hierarchy creation follows collection ownership/admin rules |
 
 **Safety invariants:** all agent-created objects start **private + draft**
 (create → widen, never create-public), and every write is permission-gated by the
@@ -94,8 +94,13 @@ whose signed invocation proof identifies the workspace owner. The broker resolve
 that email to an active `users` row and `requesterForUserId`, then invokes the
 shared content services directly. No reusable content key enters the workspace
 and the route never falls back to the shared service principal.
-Subcommands: `find`, `read`, `create-document`, `create-artifact`, `edit`
-(`--mode replace|append`), `set-visibility`, `publish`, `unpublish`. The agent
+Subcommands include `find`, `read`, `create-document`, `create-artifact`, `edit`
+(`--mode replace|append`), `set-visibility`, `publish`, `unpublish`, plus
+`list-collections`, `create-collection`, `edit-collection`, `move-collection`,
+`archive-collection`, and `restore-collection`. Collection mutations use the same
+owner/admin hierarchy service as the UI and REST API: every owner can manage only
+their private tree, while district collection management requires administrator
+authority. The agent
 works **version-based** (create-as-private, owner permission and capability
 gating) and acts as the **signed workspace owner** — a `user` requester. Writes
 are attributed to that owner; public publish/widen authority is never synthesized,

--- a/docs/features/atrium-collection-management.md
+++ b/docs/features/atrium-collection-management.md
@@ -78,6 +78,8 @@ object's group-visibility grants. Private collection content is always private.
   - `PATCH /api/v1/content/collections/{id}`
 - `psd-atrium`: `list-collections`, `create-collection`, `edit-collection`,
   `move-collection`, `archive-collection`, and `restore-collection`.
+  `list-collections` includes archived manageable rows and their grants and
+  direct/subtree counts so restore targets remain discoverable.
 
 Every mutation uses `collectionManagementService` and records
 `collection_create`, `collection_update`, `collection_archive`, or

--- a/docs/features/atrium-collection-management.md
+++ b/docs/features/atrium-collection-management.md
@@ -46,7 +46,9 @@ the existing Atrium grant kinds (`role`, `group`, `building`, `department`,
 `grade`, and `user`). District children inherit ancestor grants while
 `inherit_grants` is true; turning it off makes the child a new grant boundary.
 Matching is additive. Zero effective grants preserve the legacy unrestricted
-district behavior.
+district behavior. A `group` default is valid only when the collection has at
+least one effective `view` grant; create/update rejects configurations that
+would make every content creation attempt fail.
 
 Collection access is enforced in both point reads and permission-pushed content
 listing/count queries. An archived collection admits neither reads nor creates.

--- a/docs/features/atrium-collection-management.md
+++ b/docs/features/atrium-collection-management.md
@@ -78,8 +78,9 @@ object's group-visibility grants. Private collection content is always private.
   - `PATCH /api/v1/content/collections/{id}`
 - `psd-atrium`: `list-collections`, `create-collection`, `edit-collection`,
   `move-collection`, `archive-collection`, and `restore-collection`.
-  `list-collections` includes archived manageable rows and their grants and
-  direct/subtree counts so restore targets remain discoverable.
+  `list-collections` combines active requester-visible rows with archived
+  manageable rows and their grants and direct/subtree counts, so accessible
+  district collections and restore targets both remain discoverable.
 
 Every mutation uses `collectionManagementService` and records
 `collection_create`, `collection_update`, `collection_archive`, or

--- a/docs/features/atrium-collection-management.md
+++ b/docs/features/atrium-collection-management.md
@@ -1,0 +1,72 @@
+# Atrium collection management
+
+Issue #1438 adds one shared collection-management model across the Atrium UI,
+REST v1, and the owner-bound `psd-atrium` skill.
+
+## Authority and privacy
+
+- A row with `owner_user_id IS NULL` is a district/shared collection.
+  Administrators may create, rename, move, reorder, archive, restore, and set
+  its defaults/grants.
+- A row with `owner_user_id = users.id` is an owner-bound private collection.
+  Every Atrium author may manage their own private hierarchy. Private collections
+  are forced to `default_visibility_level = 'private'`,
+  `inherit_grants = false`, and carry no grants.
+- District administrators can inspect private collection metadata, owner, policy,
+  direct/subtree counts, and collection audit events. They cannot enter, read,
+  create in, or mutate another user's private collection. This is an additional
+  boundary around the existing object visibility rules.
+
+## Hierarchy and lifecycle
+
+Collections form a self-referential tree. A private collection can nest only
+under another collection with the same owner; district and private hierarchies
+never mix. Moves reject cycles, archived parents, and case-insensitive sibling
+name conflicts within the same district/private-owner hierarchy. Different
+private owners may use the same top-level name. Serializable mutation
+transactions prevent concurrent move or create operations from committing an
+invalid hierarchy.
+
+Renames retain the stable, globally unique slug. Private slugs use an owner
+namespace so another owner's hidden name cannot be inferred from a collision
+suffix. Reorder uses a non-negative `position`; ties remain deterministic by
+name. Archive and restore recurse over the selected subtree and retain every
+content row. A subtree can be restored only when its external parent is active.
+
+Counts and content filtering intentionally use different, explicit meanings:
+
+- `directContentCount`: objects filed directly in that collection.
+- `subtreeContentCount`: direct objects plus all descendants.
+- Library/API selection by `collectionId`: direct collection only.
+
+## Grants and defaults
+
+`content_collection_grants` distinguishes `view` from `create` access and uses
+the existing Atrium grant kinds (`role`, `group`, `building`, `department`,
+`grade`, and `user`). District children inherit ancestor grants while
+`inherit_grants` is true; turning it off makes the child a new grant boundary.
+Matching is additive. Zero effective grants preserve the legacy unrestricted
+district behavior.
+
+Collection access is enforced in both point reads and permission-pushed content
+listing/count queries. An archived collection admits neither reads nor creates.
+Slug/UUID resolution for list filters and content placement is requester-aware;
+an inaccessible private collection is reported exactly like an absent one.
+When a collection default is `group`, its effective `view` grants become the new
+object's group-visibility grants. Private collection content is always private.
+
+## Surfaces
+
+- Library: **New private collection** opens the owner-only hierarchy editor.
+- Admin → Atrium → **Collections** manages district collections and inspects all
+  collection metadata.
+- REST:
+  - `GET /api/v1/content/collections`
+  - `POST /api/v1/content/collections`
+  - `PATCH /api/v1/content/collections/{id}`
+- `psd-atrium`: `list-collections`, `create-collection`, `edit-collection`,
+  `move-collection`, `archive-collection`, and `restore-collection`.
+
+Every mutation uses `collectionManagementService` and records
+`collection_create`, `collection_update`, `collection_archive`, or
+`collection_restore` in `content_audit_logs`.

--- a/docs/features/atrium-collection-management.md
+++ b/docs/features/atrium-collection-management.md
@@ -52,6 +52,9 @@ Collection access is enforced in both point reads and permission-pushed content
 listing/count queries. An archived collection admits neither reads nor creates.
 Slug/UUID resolution for list filters and content placement is requester-aware;
 an inaccessible private collection is reported exactly like an absent one.
+If an accessible child cuts off inheritance beneath a denied ancestor,
+collection discovery omits the denied ancestor and re-roots the child at the
+nearest returned ancestor, so denied names, slugs, and ids are not exposed.
 When a collection default is `group`, its effective `view` grants become the new
 object's group-visibility grants. Private collection content is always private.
 

--- a/docs/features/atrium-collection-management.md
+++ b/docs/features/atrium-collection-management.md
@@ -11,7 +11,9 @@ REST v1, and the owner-bound `psd-atrium` skill.
 - A row with `owner_user_id = users.id` is an owner-bound private collection.
   Every Atrium author may manage their own private hierarchy. Private collections
   are forced to `default_visibility_level = 'private'`,
-  `inherit_grants = false`, and carry no grants.
+  `inherit_grants = false`, and carry no grants. Empty private collection trees
+  cascade away with a deleted owner account; content retains its independent
+  ownership foreign-key protections.
 - District administrators can inspect private collection metadata, owner, policy,
   direct/subtree counts, and collection audit events. They cannot enter, read,
   create in, or mutate another user's private collection. This is an additional
@@ -52,6 +54,11 @@ would make every content creation attempt fail.
 
 Collection access is enforced in both point reads and permission-pushed content
 listing/count queries. An archived collection admits neither reads nor creates.
+Content create/move performs a fast preflight, then re-resolves collection
+access, effective grants, and defaults under locks in the same transaction as
+the object write. Collection mutations take the conflicting lock before changing
+lifecycle, hierarchy, defaults, or grants, so a concurrent revocation cannot
+commit a stale placement.
 Slug/UUID resolution for list filters and content placement is requester-aware;
 an inaccessible private collection is reported exactly like an absent one.
 If an accessible child cuts off inheritance beneath a denied ancestor,

--- a/infra/agent-image/skills/psd-atrium/SKILL.md
+++ b/infra/agent-image/skills/psd-atrium/SKILL.md
@@ -97,6 +97,9 @@ node run.js restore-collection --id <uuid>
 ```
 
 - Use the collection UUID returned by `list-collections` for mutation commands.
+- `list-collections` returns both active and archived manageable collections,
+  including `archivedAt`, direct grants, `directContentCount`, and
+  `subtreeContentCount`; use it to rediscover a UUID before restoring a subtree.
 - `--parent root` moves to the top level.
 - `--grants none` clears direct grants. Grant entries are
   `view|create:role|group:<value>` (the API also accepts the other Atrium grant

--- a/infra/agent-image/skills/psd-atrium/SKILL.md
+++ b/infra/agent-image/skills/psd-atrium/SKILL.md
@@ -97,9 +97,11 @@ node run.js restore-collection --id <uuid>
 ```
 
 - Use the collection UUID returned by `list-collections` for mutation commands.
-- `list-collections` returns both active and archived manageable collections,
-  including `archivedAt`, direct grants, `directContentCount`, and
-  `subtreeContentCount`; use it to rediscover a UUID before restoring a subtree.
+- `list-collections` returns active collections you can enter (including
+  accessible district/shared collections) plus active and archived collections
+  you can manage. Manageable rows include `archivedAt`, direct grants,
+  `directContentCount`, and `subtreeContentCount`; use the command to rediscover
+  a UUID before restoring a subtree.
 - `--parent root` moves to the top level.
 - `--grants none` clears direct grants. Grant entries are
   `view|create:role|group:<value>` (the API also accepts the other Atrium grant

--- a/infra/agent-image/skills/psd-atrium/SKILL.md
+++ b/infra/agent-image/skills/psd-atrium/SKILL.md
@@ -76,6 +76,37 @@ item includes its canonical `url`.
 has open in the live editor may be **ahead** of this until a version is snapshotted
 — say so rather than presenting it as the current text.
 
+### Manage collections
+
+Every owner can create and manage an owner-bound private hierarchy. A private
+collection may be nested only below another collection owned by that same user;
+it cannot carry grants or widen its default visibility. Administrators can also
+manage the district/shared hierarchy and assign role/group `view` and `create`
+access independently.
+
+```bash
+node run.js list-collections
+node run.js create-collection --name "My projects" --scope private
+node run.js create-collection --name "HR" --scope district \
+  --parent root --default-visibility internal \
+  --grants view:role:staff,create:group:hr-editors@psd401.net
+node run.js edit-collection --id <uuid> --name "People Operations" --position 2
+node run.js move-collection --id <uuid> --parent <parent-uuid> --position 0
+node run.js archive-collection --id <uuid>
+node run.js restore-collection --id <uuid>
+```
+
+- Use the collection UUID returned by `list-collections` for mutation commands.
+- `--parent root` moves to the top level.
+- `--grants none` clears direct grants. Grant entries are
+  `view|create:role|group:<value>` (the API also accepts the other Atrium grant
+  kinds).
+- An archive/restore applies to the selected collection and its full subtree;
+  content is retained. Content counts include both `directContentCount` and
+  `subtreeContentCount`, so those meanings are never ambiguous.
+- Collection slugs stay stable across renames. Sibling names must be unique and
+  moving a collection below itself or a descendant is rejected.
+
 ### Images (authored assets)
 
 An image belongs to **one object**. Embedding it is a three-step flow, and the

--- a/infra/agent-image/skills/psd-atrium/run.js
+++ b/infra/agent-image/skills/psd-atrium/run.js
@@ -35,6 +35,14 @@
  *   node run.js delete --id <id>
  *   node run.js set-visibility --id <id> --level private|group|internal|public
  *                    [--grants role:staff,building:GHS]
+ *   node run.js list-collections
+ *   node run.js create-collection --name <name> [--scope private|district]
+ *                    [--parent <uuid|root>] [--position <n>]
+ *   node run.js edit-collection --id <uuid> [--name <name>] [--parent <uuid|root>]
+ *                    [--position <n>] [--default-visibility <level>]
+ *   node run.js move-collection --id <uuid> --parent <uuid|root> [--position <n>]
+ *   node run.js archive-collection --id <uuid>
+ *   node run.js restore-collection --id <uuid>
  *
  * Artifact code is HTML/JS/CSS (including <script>/<style>) and is FULLY
  * supported: run.js base64-encodes every write body automatically (codeEncoding:
@@ -85,6 +93,7 @@ const BODY_FORMATS = ['markdown', 'html', 'jsx'];
 const ARTIFACT_FORMATS = ['html', 'jsx'];
 const PUBLISH_DESTINATIONS = ['intranet', 'public_web', 'schoology', 'google', 'okf'];
 const UNPUBLISH_DESTINATIONS = ['intranet', 'public_web', 'schoology', 'google'];
+const COLLECTION_SCOPES = ['private', 'district'];
 
 function usage() {
   process.stdout.write(
@@ -117,6 +126,19 @@ function usage() {
       '                       while published — unpublish everywhere first)',
       '  set-visibility --id <id> --level private|group|internal|public',
       '                 [--grants role:staff,building:GHS]',
+      '',
+      'Collections (private for every owner; district requires administrator):',
+      '  list-collections',
+      '  create-collection --name <name> [--scope private|district]',
+      '                    [--parent <uuid|root>] [--position <n>]',
+      '                    [--default-visibility <level>] [--inherit-grants true|false]',
+      '                    [--grants view:role:staff,create:group:staff@example.org]',
+      '  edit-collection --id <uuid> [--name <name>] [--parent <uuid|root>]',
+      '                  [--position <n>] [--default-visibility <level>]',
+      '                  [--inherit-grants true|false] [--grants access:kind:value,...]',
+      '  move-collection --id <uuid> --parent <uuid|root> [--position <n>]',
+      '  archive-collection --id <uuid>',
+      '  restore-collection --id <uuid>',
       '',
       'Artifact code (HTML/JS/CSS, incl. <script>/<style>) is fully supported and',
       'sent base64-encoded automatically — you pass raw code, nothing to escape.',
@@ -161,6 +183,57 @@ function optStr(args, name, label) {
   if (v === undefined) return undefined;
   if (v === true) fail(`--${label} requires a value`);
   return v;
+}
+
+function optNonNegativeInt(args, name, label) {
+  const value = optStr(args, name, label);
+  if (value === undefined) return undefined;
+  if (!/^\d+$/.test(value)) fail(`--${label} must be a non-negative integer`);
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed)) fail(`--${label} is too large`);
+  return parsed;
+}
+
+function optBoolean(args, name, label) {
+  const value = optStr(args, name, label);
+  if (value === undefined) return undefined;
+  if (value !== 'true' && value !== 'false') {
+    fail(`--${label} must be true or false`);
+  }
+  return value === 'true';
+}
+
+function optCollectionParent(args, required = false) {
+  const value = required
+    ? requireStr(args, 'parent', 'parent')
+    : optStr(args, 'parent', 'parent');
+  if (value === undefined) return undefined;
+  return value === 'root' ? null : value;
+}
+
+function parseCollectionGrants(raw) {
+  if (raw === undefined) return undefined;
+  if (raw === true || raw === '') {
+    fail('--grants requires access:kind:value entries');
+  }
+  if (raw === 'none') return [];
+  return raw.split(',').map((entry) => {
+    const first = entry.indexOf(':');
+    const second = entry.indexOf(':', first + 1);
+    if (first <= 0 || second <= first + 1 || second === entry.length - 1) {
+      fail(`invalid collection grant "${entry}"; expected access:kind:value`);
+    }
+    const access = entry.slice(0, first);
+    const kind = entry.slice(first + 1, second);
+    const value = entry.slice(second + 1);
+    if (!['view', 'create'].includes(access)) {
+      fail(`collection grant access must be view or create: ${entry}`);
+    }
+    if (!['role', 'building', 'department', 'grade', 'user', 'group'].includes(kind)) {
+      fail(`invalid collection grant kind: ${entry}`);
+    }
+    return { access, kind, value };
+  });
 }
 
 /**
@@ -524,6 +597,79 @@ async function archiveObject(args) {
   emit({ ...payload, archived: true });
 }
 
+async function listCollections() {
+  const { payload } = await restFetch('GET', '/collections');
+  emit(payload);
+}
+
+async function createCollection(args) {
+  const body = {
+    name: requireStr(args, 'name', 'name'),
+    scope:
+      optEnum(args, 'scope', 'scope', COLLECTION_SCOPES) || 'private',
+    parentId: optCollectionParent(args),
+    position: optNonNegativeInt(args, 'position', 'position'),
+    defaultVisibilityLevel: optEnum(
+      args,
+      'default_visibility',
+      'default-visibility',
+      LEVELS
+    ),
+    inheritGrants: optBoolean(args, 'inherit_grants', 'inherit-grants'),
+    grants: parseCollectionGrants(args.grants),
+  };
+  const { payload } = await restFetch('POST', '/collections', { body });
+  emit(payload);
+}
+
+async function editCollection(args) {
+  const id = requireStr(args, 'id', 'id');
+  const body = {
+    name: optStr(args, 'name', 'name'),
+    parentId: optCollectionParent(args),
+    position: optNonNegativeInt(args, 'position', 'position'),
+    defaultVisibilityLevel: optEnum(
+      args,
+      'default_visibility',
+      'default-visibility',
+      LEVELS
+    ),
+    inheritGrants: optBoolean(args, 'inherit_grants', 'inherit-grants'),
+    grants: parseCollectionGrants(args.grants),
+  };
+  const { payload } = await restFetch(
+    'PATCH',
+    `/collections/${encodeURIComponent(id)}`,
+    { body }
+  );
+  emit(payload);
+}
+
+async function moveCollection(args) {
+  const id = requireStr(args, 'id', 'id');
+  const { payload } = await restFetch(
+    'PATCH',
+    `/collections/${encodeURIComponent(id)}`,
+    {
+      body: {
+        parentId: optCollectionParent(args, true),
+        position: optNonNegativeInt(args, 'position', 'position'),
+      },
+    }
+  );
+  emit(payload);
+}
+
+async function setCollectionArchived(args, archived) {
+  const id = requireStr(args, 'id', 'id');
+  const { payload } = await restFetch(
+    'PATCH',
+    `/collections/${encodeURIComponent(id)}`,
+    { body: { archived } }
+  );
+  emit(payload);
+}
+
 async function deleteObject(args) {
   const id = requireStr(args, 'id', 'id');
   const { payload } = await restFetch('DELETE', `/${encodeURIComponent(id)}`);
@@ -594,6 +740,12 @@ const COMMANDS = {
   'create-artifact': createArtifact,
   edit: editObject,
   archive: archiveObject,
+  'list-collections': listCollections,
+  'create-collection': createCollection,
+  'edit-collection': editCollection,
+  'move-collection': moveCollection,
+  'archive-collection': (args) => setCollectionArchived(args, true),
+  'restore-collection': (args) => setCollectionArchived(args, false),
   delete: deleteObject,
   'set-visibility': setVisibility,
   publish: publishObject,

--- a/infra/agent-image/skills/psd-atrium/run.test.js
+++ b/infra/agent-image/skills/psd-atrium/run.test.js
@@ -153,6 +153,110 @@ test('find rejects an invalid --kind (exit 1)', async () => {
   expect(code).toBe(1);
 });
 
+test('collection commands map to the fixed owner-bound broker surface', async () => {
+  await run('list-collections');
+  await run(
+    'create-collection',
+    '--name',
+    'HR',
+    '--scope',
+    'district',
+    '--parent',
+    'root',
+    '--position',
+    '2',
+    '--default-visibility',
+    'internal',
+    '--inherit-grants',
+    'true',
+    '--grants',
+    'view:role:staff,create:group:hr-editors@psd401.net'
+  );
+  await run(
+    'edit-collection',
+    '--id',
+    'collection-1',
+    '--name',
+    'People Operations',
+    '--grants',
+    'none'
+  );
+  await run(
+    'move-collection',
+    '--id',
+    'collection-1',
+    '--parent',
+    'collection-root',
+    '--position',
+    '0'
+  );
+  await run('archive-collection', '--id', 'collection-1');
+  await run('restore-collection', '--id', 'collection-1');
+
+  expect(restCalls.map(({ method, path }) => ({ method, path }))).toEqual([
+    { method: 'GET', path: '/collections' },
+    { method: 'POST', path: '/collections' },
+    { method: 'PATCH', path: '/collections/collection-1' },
+    { method: 'PATCH', path: '/collections/collection-1' },
+    { method: 'PATCH', path: '/collections/collection-1' },
+    { method: 'PATCH', path: '/collections/collection-1' },
+  ]);
+  expect(restCalls[1].opts.body).toEqual({
+    name: 'HR',
+    scope: 'district',
+    parentId: null,
+    position: 2,
+    defaultVisibilityLevel: 'internal',
+    inheritGrants: true,
+    grants: [
+      { access: 'view', kind: 'role', value: 'staff' },
+      {
+        access: 'create',
+        kind: 'group',
+        value: 'hr-editors@psd401.net',
+      },
+    ],
+  });
+  expect(restCalls[2].opts.body.grants).toEqual([]);
+  expect(restCalls[3].opts.body).toEqual({
+    parentId: 'collection-root',
+    position: 0,
+  });
+  expect(restCalls[4].opts.body).toEqual({ archived: true });
+  expect(restCalls[5].opts.body).toEqual({ archived: false });
+});
+
+test('collection commands reject malformed hierarchy flags locally', async () => {
+  let code;
+  try {
+    await run(
+      'create-collection',
+      '--name',
+      'Bad',
+      '--position',
+      '-1'
+    );
+  } catch (err) {
+    code = err.code;
+  }
+  expect(code).toBe(1);
+  expect(restCalls).toHaveLength(0);
+
+  try {
+    await run(
+      'create-collection',
+      '--name',
+      'Bad',
+      '--grants',
+      'role:staff'
+    );
+  } catch (err) {
+    code = err.code;
+  }
+  expect(code).toBe(1);
+  expect(restCalls).toHaveLength(0);
+});
+
 test('read GETs /<id> and surfaces the inline body', async () => {
   restResponder = () => ({
     approvalRequired: false,

--- a/infra/database/migrations.json
+++ b/infra/database/migrations.json
@@ -155,6 +155,7 @@
     "162-nexus-user-memories.sql",
     "163-assistant-execution-deadline.sql",
     "164-nexus-memory-extraction-model.sql",
-    "165-agent-scheduled-run-fire-idempotency.sql"
+    "165-agent-scheduled-run-fire-idempotency.sql",
+    "166-atrium-collection-management.sql"
   ]
 }

--- a/infra/database/schema/166-atrium-collection-management.sql
+++ b/infra/database/schema/166-atrium-collection-management.sql
@@ -51,6 +51,38 @@ CREATE INDEX IF NOT EXISTS idx_ccg_lookup
 
 -- The collection that originally motivated #1438. Stable slug, district/shared,
 -- internal-by-default, and idempotent across fresh and upgraded installations.
+WITH district_top_level AS MATERIALIZED (
+  SELECT position
+  FROM content_collections
+  WHERE parent_id IS NULL AND owner_user_id IS NULL
+),
+next_position AS (
+  SELECT
+    CASE
+      WHEN COALESCE(MAX(position), -1) < 2147483647
+        THEN COALESCE(MAX(position), -1) + 1
+      ELSE (
+        -- int4 max is already occupied: mirror the service's bounded gap
+        -- allocator instead of overflowing MAX(position) + 1.
+        SELECT candidate
+        FROM generate_series(
+          0,
+          (
+            SELECT LEAST(COUNT(*), 2147483647)::integer
+            FROM district_top_level
+          )
+        ) AS gap(candidate)
+        WHERE NOT EXISTS (
+          SELECT 1
+          FROM district_top_level existing
+          WHERE existing.position = gap.candidate
+        )
+        ORDER BY candidate
+        LIMIT 1
+      )
+    END AS position
+  FROM district_top_level
+)
 INSERT INTO content_collections (
   name,
   slug,
@@ -65,14 +97,8 @@ SELECT
   'internal',
   NULL,
   true,
-  COALESCE(
-    (
-      SELECT MAX(position) + 1
-      FROM content_collections
-      WHERE parent_id IS NULL AND owner_user_id IS NULL
-    ),
-    0
-  )
+  next_position.position
+FROM next_position
 WHERE NOT EXISTS (
   SELECT 1 FROM content_collections WHERE slug = 'psd-staff-intranet'
 );

--- a/infra/database/schema/166-atrium-collection-management.sql
+++ b/infra/database/schema/166-atrium-collection-management.sql
@@ -1,0 +1,85 @@
+-- ============================================================================
+-- 166 — Atrium collection management, ownership, grants, and lifecycle (#1438)
+--
+-- Additive/idempotent extension of migration 085's content_collections table.
+-- Existing collections remain district/shared (owner_user_id IS NULL), active,
+-- and grant-unrestricted, preserving their URLs and create behavior.
+--
+-- Private collections are identified by owner_user_id. The database backstop
+-- forces them to default to private visibility and disables grant inheritance.
+-- Collection grants are normalized and distinguish view from create access.
+-- Zero grants preserves the legacy unrestricted-collection behavior.
+-- ============================================================================
+
+ALTER TABLE content_collections
+  ADD COLUMN IF NOT EXISTS owner_user_id integer REFERENCES users(id) ON DELETE RESTRICT;
+ALTER TABLE content_collections
+  ADD COLUMN IF NOT EXISTS inherit_grants boolean NOT NULL DEFAULT true;
+ALTER TABLE content_collections
+  ADD COLUMN IF NOT EXISTS archived_at timestamp;
+
+CREATE INDEX IF NOT EXISTS idx_collection_owner
+  ON content_collections(owner_user_id);
+CREATE INDEX IF NOT EXISTS idx_collection_archived
+  ON content_collections(archived_at);
+
+ALTER TABLE content_collections
+  DROP CONSTRAINT IF EXISTS ck_collection_private_owner_policy;
+ALTER TABLE content_collections
+  ADD CONSTRAINT ck_collection_private_owner_policy
+  CHECK (
+    owner_user_id IS NULL
+    OR (default_visibility_level = 'private' AND inherit_grants = false)
+  );
+
+CREATE TABLE IF NOT EXISTS content_collection_grants (
+  id integer GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  collection_id uuid NOT NULL REFERENCES content_collections(id) ON DELETE CASCADE,
+  access varchar(16) NOT NULL,
+  grant_kind grant_kind NOT NULL,
+  grant_value varchar(255) NOT NULL,
+  CONSTRAINT ck_content_collection_grant_access
+    CHECK (access IN ('view', 'create')),
+  CONSTRAINT uq_content_collection_grant
+    UNIQUE (collection_id, access, grant_kind, grant_value)
+);
+
+CREATE INDEX IF NOT EXISTS idx_ccg_collection
+  ON content_collection_grants(collection_id);
+CREATE INDEX IF NOT EXISTS idx_ccg_lookup
+  ON content_collection_grants(access, grant_kind, grant_value);
+
+-- The collection that originally motivated #1438. Stable slug, district/shared,
+-- internal-by-default, and idempotent across fresh and upgraded installations.
+INSERT INTO content_collections (
+  name,
+  slug,
+  default_visibility_level,
+  owner_user_id,
+  inherit_grants,
+  position
+)
+SELECT
+  'PSD Staff Intranet',
+  'psd-staff-intranet',
+  'internal',
+  NULL,
+  true,
+  COALESCE(
+    (
+      SELECT MAX(position) + 1
+      FROM content_collections
+      WHERE parent_id IS NULL AND owner_user_id IS NULL
+    ),
+    0
+  )
+WHERE NOT EXISTS (
+  SELECT 1 FROM content_collections WHERE slug = 'psd-staff-intranet'
+);
+
+-- Manual rollback (only if application code has first stopped using the fields):
+-- DROP TABLE IF EXISTS content_collection_grants;
+-- ALTER TABLE content_collections DROP CONSTRAINT IF EXISTS ck_collection_private_owner_policy;
+-- ALTER TABLE content_collections DROP COLUMN IF EXISTS archived_at;
+-- ALTER TABLE content_collections DROP COLUMN IF EXISTS inherit_grants;
+-- ALTER TABLE content_collections DROP COLUMN IF EXISTS owner_user_id;

--- a/infra/database/schema/166-atrium-collection-management.sql
+++ b/infra/database/schema/166-atrium-collection-management.sql
@@ -12,7 +12,7 @@
 -- ============================================================================
 
 ALTER TABLE content_collections
-  ADD COLUMN IF NOT EXISTS owner_user_id integer REFERENCES users(id) ON DELETE RESTRICT;
+  ADD COLUMN IF NOT EXISTS owner_user_id integer REFERENCES users(id) ON DELETE CASCADE;
 ALTER TABLE content_collections
   ADD COLUMN IF NOT EXISTS inherit_grants boolean NOT NULL DEFAULT true;
 ALTER TABLE content_collections

--- a/lib/agent-workspace/atrium-owner-operation.ts
+++ b/lib/agent-workspace/atrium-owner-operation.ts
@@ -3,6 +3,8 @@ import {
   ApprovalRequiredError,
   ForbiddenError,
   contentAssetService,
+  collectionManagementService,
+  collectionService,
   contentService,
   contentSourceService,
   isContentError,
@@ -22,6 +24,10 @@ import {
   resolveCollectionId,
 } from "@/lib/content/surface-helpers"
 import { contentSourceRefSchema } from "@/lib/content/source-ref"
+import {
+  createCollectionBodySchema,
+  updateCollectionBodySchema,
+} from "@/lib/content/rest"
 import { getUserByEmail } from "@/lib/db/drizzle/users"
 
 const visibilitySchema = z
@@ -249,6 +255,22 @@ function recordAudit(
 /** Hands a branch's audit record back to the top-level catch. */
 type SetAudit = (audit: MutationAudit) => void
 
+async function executeSingleSegmentRead(
+  req: Requester,
+  segment: string,
+  requestId: string
+): Promise<AgentAtriumOperationResult> {
+  if (segment === "collections") {
+    const collections = await collectionService.discover(req, {
+      shape: "flat",
+      includeCreateSelection: true,
+    })
+    return success(collections, requestId)
+  }
+  const object = await contentService.get(req, segment)
+  return success({ ...object, url: contentDeepLink(object.slug) }, requestId)
+}
+
 /**
  * The READ half of the fixed surface.
  *
@@ -269,7 +291,11 @@ async function executeAtriumRead(
 
   if (segments.length === 0) {
     const query = listQuerySchema.parse(input.query ?? {})
-    const collectionId = await resolveCollectionId(query.collection)
+    const collectionId = await resolveCollectionId(
+      req,
+      query.collection,
+      "view"
+    )
     const items = await contentService.list(req, {
       kind: query.kind,
       collectionId,
@@ -288,11 +314,7 @@ async function executeAtriumRead(
   }
 
   if (segments.length === 1) {
-    const object = await contentService.get(req, segments[0])
-    return success(
-      { ...object, url: contentDeepLink(object.slug) },
-      input.requestId
-    )
+    return executeSingleSegmentRead(req, segments[0], input.requestId)
   }
 
   // Committed markdown source. `GET /<id>` deliberately omits a DOCUMENT's
@@ -373,7 +395,11 @@ async function executeContentWrite(
       {
         kind: body.kind,
         title: body.title,
-        collectionId: await resolveCollectionId(body.collectionId),
+        collectionId: await resolveCollectionId(
+          req,
+          body.collectionId,
+          "create"
+        ),
         body: decodeContentBody(body.body, body.codeEncoding),
         bodyFormat: body.bodyFormat,
         visibility: body.visibility,
@@ -414,6 +440,36 @@ async function executeContentWrite(
   return null
 }
 
+async function executeCollectionWrite(
+  req: Requester,
+  input: AgentAtriumOperationInput,
+  segments: string[]
+): Promise<AgentAtriumOperationResult | null> {
+  if (segments[0] !== "collections") return null
+
+  if (input.method === "POST" && segments.length === 1) {
+    const body = createCollectionBodySchema.parse(input.body ?? {})
+    const created = await collectionManagementService.create(req, body, {
+      surface: "rest",
+      requestId: input.requestId,
+    })
+    return success(created, input.requestId, 201)
+  }
+
+  if (input.method === "PATCH" && segments.length === 2) {
+    const body = updateCollectionBodySchema.parse(input.body ?? {})
+    const updated = await collectionManagementService.update(
+      req,
+      segments[1],
+      body,
+      { surface: "rest", requestId: input.requestId }
+    )
+    return success(updated, input.requestId)
+  }
+
+  return null
+}
+
 /**
  * Metadata writes: title/tags/collection/status, visibility level, and delete.
  * None of these carries a body — they change what an object IS or who may see
@@ -434,7 +490,7 @@ async function executeMetadataWrite(
         ? undefined
         : body.collectionId === null
           ? null
-          : await resolveCollectionId(body.collectionId)
+          : await resolveCollectionId(req, body.collectionId, "create")
     const updated = await contentService.update(req, segments[0], {
       title: body.title,
       tags: body.tags,
@@ -623,6 +679,7 @@ export async function executeOwnerAtriumOperation(
     })
 
     const written =
+      (await executeCollectionWrite(req, input, segments)) ??
       (await executeContentWrite(req, input, segments, setAudit)) ??
       (await executeMetadataWrite(req, input, segments, setAudit)) ??
       (await executeAssetWrite(req, input, segments, setAudit)) ??

--- a/lib/agent-workspace/atrium-owner-operation.ts
+++ b/lib/agent-workspace/atrium-owner-operation.ts
@@ -4,7 +4,6 @@ import {
   ForbiddenError,
   contentAssetService,
   collectionManagementService,
-  collectionService,
   contentService,
   contentSourceService,
   isContentError,
@@ -261,10 +260,11 @@ async function executeSingleSegmentRead(
   requestId: string
 ): Promise<AgentAtriumOperationResult> {
   if (segment === "collections") {
-    const collections = await collectionService.discover(req, {
-      shape: "flat",
-      includeCreateSelection: true,
-    })
+    // This command is the discovery surface for every collection mutation,
+    // including restore. Unlike the active-only picker projection, the
+    // management projection retains archived rows, UUIDs, grants, and counts.
+    // listManageable applies the owner/admin boundary before returning metadata.
+    const collections = await collectionManagementService.listManageable(req)
     return success(collections, requestId)
   }
   const object = await contentService.get(req, segment)

--- a/lib/agent-workspace/atrium-owner-operation.ts
+++ b/lib/agent-workspace/atrium-owner-operation.ts
@@ -4,6 +4,7 @@ import {
   ForbiddenError,
   contentAssetService,
   collectionManagementService,
+  collectionService,
   contentService,
   contentSourceService,
   isContentError,
@@ -260,12 +261,26 @@ async function executeSingleSegmentRead(
   requestId: string
 ): Promise<AgentAtriumOperationResult> {
   if (segment === "collections") {
-    // This command is the discovery surface for every collection mutation,
-    // including restore. Unlike the active-only picker projection, the
-    // management projection retains archived rows, UUIDs, grants, and counts.
-    // listManageable applies the owner/admin boundary before returning metadata.
-    const collections = await collectionManagementService.listManageable(req)
-    return success(collections, requestId)
+    // Active requester-visible rows retain district/shared collections the owner
+    // may read or create in. The management projection adds archived restore
+    // targets plus grants/counts, but intentionally excludes district rows a
+    // non-admin cannot manage. Merge both, preferring the richer management DTO
+    // for duplicate owned/admin-manageable rows.
+    const [visible, manageable] = await Promise.all([
+      collectionService.discover(req, {
+        shape: "flat",
+        includeCreateSelection: true,
+      }),
+      collectionManagementService.listManageable(req),
+    ])
+    const collectionsById = new Map<string, { id: string }>()
+    for (const collection of visible) {
+      collectionsById.set(collection.id, collection)
+    }
+    for (const collection of manageable) {
+      collectionsById.set(collection.id, collection)
+    }
+    return success([...collectionsById.values()], requestId)
   }
   const object = await contentService.get(req, segment)
   return success({ ...object, url: contentDeepLink(object.slug) }, requestId)

--- a/lib/content/audit.ts
+++ b/lib/content/audit.ts
@@ -34,7 +34,11 @@ export type ContentAuditAction =
   | "export_okf"
   | "import_okf"
   | "initiate_asset"
-  | "complete_asset";
+  | "complete_asset"
+  | "collection_create"
+  | "collection_update"
+  | "collection_archive"
+  | "collection_restore";
 
 /**
  * The surface the mutation arrived on. `ui` is a human acting through an in-app

--- a/lib/content/collection-access.ts
+++ b/lib/content/collection-access.ts
@@ -1,0 +1,269 @@
+/**
+ * Atrium collection access resolver (#1438).
+ *
+ * Collection ACLs are an additional boundary around object visibility:
+ * object visibility decides whether the requester may consume an object, while
+ * this module decides whether its containing collection admits that requester.
+ * Owner-bound private collections admit only their owner and never inherit
+ * grants. Administrators can inspect their metadata through the management
+ * service, but that district oversight never grants access to private contents.
+ * District/shared grants use
+ * "zero rows = unrestricted"; when rows exist, any matching role/group/org/user
+ * grant admits the requester. `inheritGrants=false` cuts off the ancestor walk.
+ */
+
+import { asc } from "drizzle-orm";
+import { executeQuery } from "@/lib/db/drizzle-client";
+import {
+  contentCollectionGrants,
+  contentCollections,
+} from "@/lib/db/schema";
+import { principalOf } from "./helpers";
+import type {
+  CollectionGrant,
+  CollectionGrantAccess,
+  Principal,
+  Requester,
+  VisibilityLevel,
+} from "./types";
+
+export interface CollectionAccessRow {
+  id: string;
+  name: string;
+  slug: string;
+  parentId: string | null;
+  ownerUserId: number | null;
+  defaultVisibilityLevel: VisibilityLevel;
+  inheritGrants: boolean;
+  position: number;
+  archivedAt: Date | null;
+}
+
+export interface CollectionAccessSnapshot {
+  collections: CollectionAccessRow[];
+  byId: Map<string, CollectionAccessRow>;
+  directGrants: Map<string, CollectionGrant[]>;
+  effectiveGrants: (
+    collectionId: string,
+    access: CollectionGrantAccess
+  ) => CollectionGrant[];
+  allowedCollectionIds: Set<string>;
+  selectableCollectionIds: Set<string>;
+}
+
+/** A human identity that can own an owner-bound private collection. */
+export function collectionOwnerUserId(req: Requester): number | null {
+  if (req.kind === "user") return req.userId;
+  if (req.kind === "agent-delegated") return req.actingForUserId;
+  return null;
+}
+
+export function principalMatchesCollectionGrant(
+  principal: Principal,
+  grant: CollectionGrant
+): boolean {
+  switch (grant.kind) {
+    case "role":
+      return principal.roles.includes(grant.value);
+    case "building":
+      return principal.building === grant.value;
+    case "department":
+      return principal.department === grant.value;
+    case "grade":
+      return (principal.gradeLevels ?? []).includes(grant.value);
+    case "user":
+      return (
+        principal.userId != null && String(principal.userId) === grant.value
+      );
+    case "group":
+      return principal.groups.includes(grant.value.toLowerCase());
+  }
+}
+
+async function loadRows(): Promise<{
+  collections: CollectionAccessRow[];
+  directGrants: Map<string, CollectionGrant[]>;
+}> {
+  const [collectionRows, grantRows] = await Promise.all([
+    executeQuery(
+      (db) =>
+        db
+          .select({
+            id: contentCollections.id,
+            name: contentCollections.name,
+            slug: contentCollections.slug,
+            parentId: contentCollections.parentId,
+            ownerUserId: contentCollections.ownerUserId,
+            defaultVisibilityLevel:
+              contentCollections.defaultVisibilityLevel,
+            inheritGrants: contentCollections.inheritGrants,
+            position: contentCollections.position,
+            archivedAt: contentCollections.archivedAt,
+          })
+          .from(contentCollections)
+          .orderBy(
+            asc(contentCollections.position),
+            asc(contentCollections.name)
+          ),
+      "collectionAccess.loadCollections"
+    ),
+    executeQuery(
+      (db) =>
+        db
+          .select({
+            collectionId: contentCollectionGrants.collectionId,
+            access: contentCollectionGrants.access,
+            kind: contentCollectionGrants.grantKind,
+            value: contentCollectionGrants.grantValue,
+          })
+          .from(contentCollectionGrants),
+      "collectionAccess.loadGrants"
+    ),
+  ]);
+
+  const directGrants = new Map<string, CollectionGrant[]>();
+  for (const row of grantRows) {
+    const grants = directGrants.get(row.collectionId) ?? [];
+    grants.push({
+      access: row.access,
+      kind: row.kind,
+      value: row.value,
+    });
+    directGrants.set(row.collectionId, grants);
+  }
+
+  return {
+    collections: collectionRows.map((row) => ({
+      ...row,
+      defaultVisibilityLevel: row.defaultVisibilityLevel as VisibilityLevel,
+    })),
+    directGrants,
+  };
+}
+
+function effectiveGrantResolver(
+  byId: Map<string, CollectionAccessRow>,
+  directGrants: Map<string, CollectionGrant[]>
+): CollectionAccessSnapshot["effectiveGrants"] {
+  const cache = new Map<string, CollectionGrant[]>();
+  return (collectionId, access) => {
+    const cacheKey = `${collectionId}:${access}`;
+    const cached = cache.get(cacheKey);
+    if (cached) return cached;
+
+    const result: CollectionGrant[] = [];
+    const seen = new Set<string>();
+    let cursor: string | null = collectionId;
+    while (cursor && !seen.has(cursor)) {
+      seen.add(cursor);
+      const row = byId.get(cursor);
+      if (!row || row.ownerUserId != null) break;
+      result.push(
+        ...(directGrants.get(cursor) ?? []).filter(
+          (grant) => grant.access === access
+        )
+      );
+      if (!row.inheritGrants) break;
+      cursor = row.parentId;
+    }
+
+    const deduped = [
+      ...new Map(
+        result.map((grant) => [
+          `${grant.access}:${grant.kind}:${grant.value}`,
+          grant,
+        ])
+      ).values(),
+    ];
+    cache.set(cacheKey, deduped);
+    return deduped;
+  };
+}
+
+/**
+ * Resolve active collection access for one requester.
+ *
+ * Archived collections are deliberately excluded from both sets: archiving a
+ * collection hides its contents without deleting them; restoring the collection
+ * makes the same objects reachable again. Management queries use the raw rows.
+ */
+export async function collectionAccessSnapshot(
+  req: Requester
+): Promise<CollectionAccessSnapshot> {
+  const { collections, directGrants } = await loadRows();
+  const byId = new Map(collections.map((row) => [row.id, row]));
+  const effectiveGrants = effectiveGrantResolver(byId, directGrants);
+  const principal = principalOf(req);
+  const ownerUserId = collectionOwnerUserId(req);
+  const allowedCollectionIds = new Set<string>();
+  const selectableCollectionIds = new Set<string>();
+
+  for (const collection of collections) {
+    if (collection.archivedAt) continue;
+
+    if (collection.ownerUserId != null) {
+      if (
+        (ownerUserId != null && collection.ownerUserId === ownerUserId)
+      ) {
+        allowedCollectionIds.add(collection.id);
+      }
+      if (
+        ownerUserId != null &&
+        collection.ownerUserId === ownerUserId
+      ) {
+        selectableCollectionIds.add(collection.id);
+      }
+      continue;
+    }
+
+    const viewGrants = effectiveGrants(collection.id, "view");
+    const createGrants = effectiveGrants(collection.id, "create");
+    if (
+      principal.isAdmin ||
+      viewGrants.length === 0 ||
+      viewGrants.some((grant) =>
+        principalMatchesCollectionGrant(principal, grant)
+      )
+    ) {
+      allowedCollectionIds.add(collection.id);
+    }
+    if (
+      principal.isAdmin ||
+      (createGrants.length === 0
+        ? principal.userId != null || principal.roles.length > 0
+        : createGrants.some((grant) =>
+            principalMatchesCollectionGrant(principal, grant)
+          ))
+    ) {
+      selectableCollectionIds.add(collection.id);
+    }
+  }
+
+  return {
+    collections,
+    byId,
+    directGrants,
+    effectiveGrants,
+    allowedCollectionIds,
+    selectableCollectionIds,
+  };
+}
+
+export async function requesterMayViewCollection(
+  req: Requester,
+  collectionId: string | null | undefined
+): Promise<boolean> {
+  if (!collectionId) return true;
+  return (await collectionAccessSnapshot(req)).allowedCollectionIds.has(
+    collectionId
+  );
+}
+
+export async function requesterMayCreateInCollection(
+  req: Requester,
+  collectionId: string
+): Promise<boolean> {
+  return (await collectionAccessSnapshot(req)).selectableCollectionIds.has(
+    collectionId
+  );
+}

--- a/lib/content/collection-access.ts
+++ b/lib/content/collection-access.ts
@@ -13,7 +13,10 @@
  */
 
 import { asc } from "drizzle-orm";
-import { executeQuery } from "@/lib/db/drizzle-client";
+import {
+  executeQuery,
+  type DbTransaction,
+} from "@/lib/db/drizzle-client";
 import {
   contentCollectionGrants,
   contentCollections,
@@ -141,6 +144,61 @@ async function loadRows(): Promise<{
   };
 }
 
+async function loadRowsInTx(tx: DbTransaction): Promise<{
+  collections: CollectionAccessRow[];
+  directGrants: Map<string, CollectionGrant[]>;
+}> {
+  // Collection-management mutations take FOR UPDATE locks on the same rows
+  // before changing lifecycle, hierarchy, defaults, or grants. Holding SHARE
+  // locks through the caller's content transaction therefore makes placement
+  // authorization and the object INSERT/UPDATE one serializable operation.
+  const collectionRows = await tx
+    .select({
+      id: contentCollections.id,
+      name: contentCollections.name,
+      slug: contentCollections.slug,
+      parentId: contentCollections.parentId,
+      ownerUserId: contentCollections.ownerUserId,
+      defaultVisibilityLevel: contentCollections.defaultVisibilityLevel,
+      inheritGrants: contentCollections.inheritGrants,
+      position: contentCollections.position,
+      archivedAt: contentCollections.archivedAt,
+    })
+    .from(contentCollections)
+    .orderBy(
+      asc(contentCollections.position),
+      asc(contentCollections.name)
+    )
+    .for("share");
+  const grantRows = await tx
+    .select({
+      collectionId: contentCollectionGrants.collectionId,
+      access: contentCollectionGrants.access,
+      kind: contentCollectionGrants.grantKind,
+      value: contentCollectionGrants.grantValue,
+    })
+    .from(contentCollectionGrants);
+
+  const directGrants = new Map<string, CollectionGrant[]>();
+  for (const row of grantRows) {
+    const grants = directGrants.get(row.collectionId) ?? [];
+    grants.push({
+      access: row.access,
+      kind: row.kind,
+      value: row.value,
+    });
+    directGrants.set(row.collectionId, grants);
+  }
+
+  return {
+    collections: collectionRows.map((row) => ({
+      ...row,
+      defaultVisibilityLevel: row.defaultVisibilityLevel as VisibilityLevel,
+    })),
+    directGrants,
+  };
+}
+
 function effectiveGrantResolver(
   byId: Map<string, CollectionAccessRow>,
   directGrants: Map<string, CollectionGrant[]>
@@ -191,6 +249,28 @@ export async function collectionAccessSnapshot(
   req: Requester
 ): Promise<CollectionAccessSnapshot> {
   const { collections, directGrants } = await loadRows();
+  return accessSnapshotFromRows(req, collections, directGrants);
+}
+
+/**
+ * Resolve collection access while holding collection SHARE locks until the
+ * caller's transaction commits. Content create/move paths use this variant so
+ * an archive, grant revocation, or default change cannot land between the
+ * authorization decision and the object write.
+ */
+export async function collectionAccessSnapshotInTx(
+  tx: DbTransaction,
+  req: Requester
+): Promise<CollectionAccessSnapshot> {
+  const { collections, directGrants } = await loadRowsInTx(tx);
+  return accessSnapshotFromRows(req, collections, directGrants);
+}
+
+function accessSnapshotFromRows(
+  req: Requester,
+  collections: CollectionAccessRow[],
+  directGrants: Map<string, CollectionGrant[]>
+): CollectionAccessSnapshot {
   const byId = new Map(collections.map((row) => [row.id, row]));
   const effectiveGrants = effectiveGrantResolver(byId, directGrants);
   const principal = principalOf(req);

--- a/lib/content/collection-management-service.ts
+++ b/lib/content/collection-management-service.ts
@@ -1,0 +1,813 @@
+/**
+ * Atrium collection mutation and management service (#1438).
+ *
+ * This is the single write path used by UI actions, REST, and the owner-bound
+ * psd-atrium broker. It enforces the district-vs-private authority split,
+ * owner-homogeneous private trees, cycle prevention, stable slugs, recursive
+ * archive/restore, and atomic grant replacement.
+ */
+
+import { count, eq, inArray } from "drizzle-orm";
+import {
+  executeQuery,
+  executeTransaction,
+  type DbTransaction,
+} from "@/lib/db/drizzle-client";
+import {
+  contentCollectionGrants,
+  contentCollections,
+  contentObjects,
+  users,
+} from "@/lib/db/schema";
+import {
+  assertCanCreate,
+  principalOf,
+  slugCandidate,
+  slugifyTitle,
+} from "./helpers";
+import {
+  collectionAccessSnapshot,
+  collectionOwnerUserId,
+  type CollectionAccessRow,
+} from "./collection-access";
+import { recordContentAudit, type ContentAuditSurface } from "./audit";
+import {
+  ConflictError,
+  ForbiddenError,
+  NotFoundError,
+  ValidationError,
+} from "./errors";
+import {
+  GRANT_KIND_SET,
+  GROUP_EMAIL_RE,
+  POSITIVE_INT_RE,
+  VISIBILITY_LEVEL_SET,
+} from "./validators";
+import type {
+  CollectionDTO,
+  CollectionGrant,
+  CollectionScope,
+  CreateCollectionInput,
+  Requester,
+  UpdateCollectionInput,
+  VisibilityLevel,
+} from "./types";
+
+const NAME_MAX_LENGTH = 200;
+const GRANT_VALUE_MAX_LENGTH = 255;
+const POSITION_MAX = 2_147_483_647;
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+interface MutationOptions {
+  surface?: ContentAuditSurface;
+  requestId?: string;
+}
+
+function normalizedName(name: string): string {
+  const value = name.trim();
+  if (!value) throw new ValidationError("Collection name is required");
+  if (value.length > NAME_MAX_LENGTH) {
+    throw new ValidationError(
+      `Collection name must be ${NAME_MAX_LENGTH} characters or fewer`
+    );
+  }
+  return value;
+}
+
+function normalizedPosition(position: number | undefined): number | undefined {
+  if (position === undefined) return undefined;
+  if (
+    !Number.isInteger(position) ||
+    position < 0 ||
+    position > POSITION_MAX
+  ) {
+    throw new ValidationError("Collection position must be a non-negative integer");
+  }
+  return position;
+}
+
+function assertCollectionId(collectionId: string): void {
+  if (!UUID_RE.test(collectionId)) {
+    throw new ValidationError("Collection id must be a valid UUID", {
+      collectionId,
+    });
+  }
+}
+
+function normalizeGrants(grants: CollectionGrant[]): CollectionGrant[] {
+  const normalized = grants.map((grant) => {
+    if (grant.access !== "view" && grant.access !== "create") {
+      throw new ValidationError("Invalid collection grant access", {
+        access: grant.access,
+      });
+    }
+    if (!GRANT_KIND_SET.has(grant.kind)) {
+      throw new ValidationError("Invalid collection grant kind", {
+        kind: grant.kind,
+      });
+    }
+    const value =
+      grant.kind === "group"
+        ? grant.value.trim().toLowerCase()
+        : grant.value.trim();
+    if (!value || value.length > GRANT_VALUE_MAX_LENGTH) {
+      throw new ValidationError("Invalid collection grant value", {
+        kind: grant.kind,
+      });
+    }
+    if (grant.kind === "user" && !POSITIVE_INT_RE.test(value)) {
+      throw new ValidationError(
+        "A user collection grant requires a positive-integer user id"
+      );
+    }
+    if (grant.kind === "group" && !GROUP_EMAIL_RE.test(value)) {
+      throw new ValidationError(
+        "A group collection grant requires a group email"
+      );
+    }
+    return { ...grant, value };
+  });
+
+  return [
+    ...new Map(
+      normalized.map((grant) => [
+        `${grant.access}:${grant.kind}:${grant.value}`,
+        grant,
+      ])
+    ).values(),
+  ];
+}
+
+function assertVisibilityLevel(level: VisibilityLevel): void {
+  if (!VISIBILITY_LEVEL_SET.has(level)) {
+    throw new ValidationError("Invalid collection default visibility", {
+      level,
+    });
+  }
+}
+
+function scopeOf(row: CollectionAccessRow): CollectionScope {
+  return row.ownerUserId == null ? "district" : "private";
+}
+
+function assertMayManage(req: Requester, row: CollectionAccessRow): void {
+  const principal = principalOf(req);
+  if (row.ownerUserId == null) {
+    if (!principal.isAdmin) {
+      throw new ForbiddenError(
+        "Administrator authority is required to manage district collections"
+      );
+    }
+    return;
+  }
+  if (collectionOwnerUserId(req) !== row.ownerUserId) {
+    if (!principal.isAdmin) {
+      throw new NotFoundError("Collection not found");
+    }
+    throw new ForbiddenError("You may manage only private collections you own");
+  }
+  if (req.kind !== "user" && !req.scopes.includes("content:update")) {
+    throw new ForbiddenError("content:update scope required");
+  }
+}
+
+function assertMayCreateScope(req: Requester, scope: CollectionScope): number | null {
+  assertCanCreate(req);
+  const principal = principalOf(req);
+  if (scope === "district") {
+    if (!principal.isAdmin) {
+      throw new ForbiddenError(
+        "Administrator authority is required to create district collections"
+      );
+    }
+    return null;
+  }
+  const ownerUserId = collectionOwnerUserId(req);
+  if (ownerUserId == null) {
+    throw new ForbiddenError(
+      "A human owner is required to create a private collection"
+    );
+  }
+  return ownerUserId;
+}
+
+function assertParent(
+  byId: Map<string, CollectionAccessRow>,
+  parentId: string | null,
+  scope: CollectionScope,
+  ownerUserId: number | null
+): CollectionAccessRow | null {
+  if (!parentId) return null;
+  const parent = byId.get(parentId);
+  if (!parent) throw new ValidationError("Parent collection not found", { parentId });
+  if (parent.archivedAt) {
+    throw new ValidationError("An archived collection cannot be a parent", {
+      parentId,
+    });
+  }
+  if (scopeOf(parent) !== scope) {
+    throw new ValidationError(
+      "Private and district collections cannot be mixed in one hierarchy"
+    );
+  }
+  if (scope === "private" && parent.ownerUserId !== ownerUserId) {
+    throw new ValidationError("Parent collection not found", { parentId });
+  }
+  return parent;
+}
+
+function assertNoCycle(
+  byId: Map<string, CollectionAccessRow>,
+  collectionId: string,
+  parentId: string | null
+): void {
+  const seen = new Set<string>([collectionId]);
+  let cursor = parentId;
+  while (cursor) {
+    if (seen.has(cursor)) {
+      throw new ValidationError("Collection hierarchy cannot contain a cycle", {
+        collectionId,
+        parentId,
+      });
+    }
+    seen.add(cursor);
+    cursor = byId.get(cursor)?.parentId ?? null;
+  }
+}
+
+function assertSiblingNameAvailable(
+  rows: CollectionAccessRow[],
+  name: string,
+  parentId: string | null,
+  ownerUserId: number | null,
+  ignoreId?: string
+): void {
+  const folded = name.toLowerCase();
+  const conflict = rows.some(
+    (row) =>
+      row.id !== ignoreId &&
+      row.parentId === parentId &&
+      row.ownerUserId === ownerUserId &&
+      row.name.toLowerCase() === folded
+  );
+  if (conflict) {
+    throw new ConflictError(
+      "A collection with this name already exists under the selected parent",
+      { name, parentId }
+    );
+  }
+}
+
+function nextSlug(
+  rows: CollectionAccessRow[],
+  name: string,
+  ownerUserId: number | null
+): string {
+  const nameSlug = slugifyTitle(name);
+  // Private slugs are owner-namespaced so another user's hidden collection name
+  // cannot be inferred from an otherwise surprising global collision suffix.
+  const base =
+    ownerUserId == null ? nameSlug : `private-${ownerUserId}-${nameSlug}`;
+  const taken = new Set(rows.map((row) => row.slug));
+  for (let attempt = 0; attempt <= taken.size; attempt++) {
+    const candidate = slugCandidate(base, attempt);
+    if (!taken.has(candidate)) return candidate;
+  }
+  throw new ConflictError("Could not allocate a collection slug", { base });
+}
+
+function nextPosition(
+  rows: CollectionAccessRow[],
+  parentId: string | null
+): number {
+  return (
+    rows
+      .filter((row) => row.parentId === parentId)
+      .reduce((highest, row) => Math.max(highest, row.position), -1) + 1
+  );
+}
+
+async function replaceGrants(
+  tx: DbTransaction,
+  collectionId: string,
+  grants: CollectionGrant[]
+): Promise<void> {
+  await tx
+    .delete(contentCollectionGrants)
+    .where(eq(contentCollectionGrants.collectionId, collectionId));
+  if (grants.length === 0) return;
+  await tx.insert(contentCollectionGrants).values(
+    grants.map((grant) => ({
+      collectionId,
+      access: grant.access,
+      grantKind: grant.kind,
+      grantValue: grant.value,
+    }))
+  );
+}
+
+function descendantIds(
+  rows: CollectionAccessRow[],
+  rootId: string
+): string[] {
+  const children = new Map<string, string[]>();
+  for (const row of rows) {
+    if (!row.parentId) continue;
+    const ids = children.get(row.parentId) ?? [];
+    ids.push(row.id);
+    children.set(row.parentId, ids);
+  }
+  const result: string[] = [];
+  const pending = [rootId];
+  const seen = new Set<string>();
+  while (pending.length > 0) {
+    const id = pending.pop();
+    if (!id || seen.has(id)) continue;
+    seen.add(id);
+    result.push(id);
+    pending.push(...(children.get(id) ?? []));
+  }
+  return result;
+}
+
+/**
+ * Pure hierarchy helpers exposed for focused regression tests. The mutation
+ * service remains the only production write surface.
+ */
+export const collectionManagementInternals = {
+  assertCollectionId,
+  assertMayCreateScope,
+  assertMayManage,
+  assertParent,
+  assertNoCycle,
+  assertSiblingNameAvailable,
+  descendantIds,
+  nextSlug,
+  normalizeGrants,
+};
+
+async function auditCollectionMutation(input: {
+  req: Requester;
+  action:
+    | "collection_create"
+    | "collection_update"
+    | "collection_archive"
+    | "collection_restore";
+  collectionId?: string;
+  collectionName?: string;
+  collectionScope?: CollectionScope;
+  parentId?: string | null;
+  outcome: "ok" | "error";
+  error?: unknown;
+  options?: MutationOptions;
+}): Promise<void> {
+  await recordContentAudit({
+    req: input.req,
+    action: input.action,
+    surface: input.options?.surface ?? "ui",
+    objectId: null,
+    outcome: input.outcome,
+    error:
+      input.error instanceof Error
+        ? input.error.message
+        : input.error
+          ? String(input.error)
+          : null,
+    details: {
+      collectionId: input.collectionId,
+      collectionName: input.collectionName,
+      collectionScope: input.collectionScope,
+      parentId: input.parentId ?? null,
+    },
+    requestId: input.options?.requestId ?? null,
+  });
+}
+
+async function managementDTOs(req: Requester): Promise<CollectionDTO[]> {
+  const access = await collectionAccessSnapshot(req);
+  const [contentCounts, ownerRows] = await Promise.all([
+    executeQuery(
+      (db) =>
+        db
+          .select({
+            collectionId: contentObjects.collectionId,
+            count: count(),
+          })
+          .from(contentObjects)
+          .groupBy(contentObjects.collectionId),
+      "collectionManagement.contentCounts"
+    ),
+    executeQuery(
+      (db) =>
+        db
+          .select({
+            id: users.id,
+            firstName: users.firstName,
+            lastName: users.lastName,
+            email: users.email,
+          })
+          .from(users),
+      "collectionManagement.ownerNames"
+    ),
+  ]);
+  const directCounts = new Map(
+    contentCounts
+      .filter((row) => row.collectionId != null)
+      .map((row) => [row.collectionId as string, Number(row.count)])
+  );
+  const ownerNames = new Map(
+    ownerRows.map((row) => {
+      const full = [row.firstName, row.lastName].filter(Boolean).join(" ").trim();
+      return [row.id, full || row.email || `User #${row.id}`];
+    })
+  );
+  const children = new Map<string | null, string[]>();
+  for (const row of access.collections) {
+    const ids = children.get(row.parentId) ?? [];
+    ids.push(row.id);
+    children.set(row.parentId, ids);
+  }
+  const subtreeCache = new Map<string, number>();
+  const subtreeCount = (id: string, active = new Set<string>()): number => {
+    const cached = subtreeCache.get(id);
+    if (cached != null) return cached;
+    if (active.has(id)) return directCounts.get(id) ?? 0;
+    const next = new Set(active);
+    next.add(id);
+    const value =
+      (directCounts.get(id) ?? 0) +
+      (children.get(id) ?? []).reduce(
+        (total, childId) => total + subtreeCount(childId, next),
+        0
+      );
+    subtreeCache.set(id, value);
+    return value;
+  };
+  const pathFor = (id: string): string[] => {
+    const path: string[] = [];
+    const seen = new Set<string>();
+    let cursor: string | null = id;
+    while (cursor && !seen.has(cursor)) {
+      seen.add(cursor);
+      const row = access.byId.get(cursor);
+      if (!row) break;
+      path.unshift(row.name);
+      cursor = row.parentId;
+    }
+    return path;
+  };
+
+  return access.collections.map((row) => ({
+    id: row.id,
+    name: row.name,
+    slug: row.slug,
+    parentId: row.parentId,
+    path: pathFor(row.id),
+    scope: scopeOf(row),
+    ownerUserId: row.ownerUserId,
+    ownerName:
+      row.ownerUserId == null ? null : ownerNames.get(row.ownerUserId) ?? null,
+    defaultVisibilityLevel: row.defaultVisibilityLevel,
+    inheritGrants: row.inheritGrants,
+    position: row.position,
+    archivedAt: row.archivedAt?.toISOString() ?? null,
+    directContentCount: directCounts.get(row.id) ?? 0,
+    subtreeContentCount: subtreeCount(row.id),
+    grants: access.directGrants.get(row.id) ?? [],
+    selectableForCreate: access.selectableCollectionIds.has(row.id),
+  }));
+}
+
+interface NormalizedCollectionUpdate {
+  name?: string;
+  position?: number;
+  grants?: CollectionGrant[];
+}
+
+interface CollectionUpdateAuditContext {
+  name?: string;
+  scope?: CollectionScope;
+  parentId?: string | null;
+}
+
+interface CollectionUpdateTxInput {
+  req: Requester;
+  collectionId: string;
+  input: UpdateCollectionInput;
+  normalized: NormalizedCollectionUpdate;
+  audit: CollectionUpdateAuditContext;
+}
+
+async function loadCollectionRows(
+  tx: DbTransaction
+): Promise<CollectionAccessRow[]> {
+  return (await tx
+    .select({
+      id: contentCollections.id,
+      name: contentCollections.name,
+      slug: contentCollections.slug,
+      parentId: contentCollections.parentId,
+      ownerUserId: contentCollections.ownerUserId,
+      defaultVisibilityLevel: contentCollections.defaultVisibilityLevel,
+      inheritGrants: contentCollections.inheritGrants,
+      position: contentCollections.position,
+      archivedAt: contentCollections.archivedAt,
+    })
+    .from(contentCollections)) as CollectionAccessRow[];
+}
+
+function assertRestorableBelowParent(
+  input: UpdateCollectionInput,
+  parentId: string | null,
+  byId: Map<string, CollectionAccessRow>
+): void {
+  if (input.archived === false && parentId && byId.get(parentId)?.archivedAt) {
+    throw new ValidationError(
+      "Restore the parent collection before restoring this collection"
+    );
+  }
+}
+
+function assertPrivateUpdate(
+  scope: CollectionScope,
+  input: UpdateCollectionInput,
+  grants: CollectionGrant[] | undefined
+): void {
+  if (
+    scope === "private" &&
+    ((input.defaultVisibilityLevel !== undefined &&
+      input.defaultVisibilityLevel !== "private") ||
+      input.inheritGrants === true ||
+      (grants !== undefined && grants.length > 0))
+  ) {
+    throw new ValidationError(
+      "Private collections must remain private and cannot inherit or carry grants"
+    );
+  }
+}
+
+function collectionUpdateValues(
+  input: UpdateCollectionInput,
+  normalized: NormalizedCollectionUpdate,
+  parentId: string | null
+): Partial<typeof contentCollections.$inferInsert> {
+  const values: Partial<typeof contentCollections.$inferInsert> = {
+    updatedAt: new Date(),
+  };
+  if (normalized.name !== undefined) values.name = normalized.name;
+  if (input.parentId !== undefined) values.parentId = parentId;
+  if (normalized.position !== undefined) values.position = normalized.position;
+  if (input.defaultVisibilityLevel !== undefined) {
+    values.defaultVisibilityLevel = input.defaultVisibilityLevel;
+  }
+  if (input.inheritGrants !== undefined) {
+    values.inheritGrants = input.inheritGrants;
+  }
+  return values;
+}
+
+async function applyArchiveState(
+  tx: DbTransaction,
+  rows: CollectionAccessRow[],
+  collectionId: string,
+  archived: boolean | undefined
+): Promise<void> {
+  if (archived === undefined) return;
+  await tx
+    .update(contentCollections)
+    .set({
+      archivedAt: archived ? new Date() : null,
+      updatedAt: new Date(),
+    })
+    .where(inArray(contentCollections.id, descendantIds(rows, collectionId)));
+}
+
+async function updateCollectionInTx(
+  tx: DbTransaction,
+  update: CollectionUpdateTxInput
+): Promise<void> {
+  const { req, collectionId, input, normalized, audit } = update;
+  const rows = await loadCollectionRows(tx);
+  const byId = new Map(rows.map((row) => [row.id, row]));
+  const existing = byId.get(collectionId);
+  if (!existing) {
+    throw new NotFoundError("Collection not found", { collectionId });
+  }
+  assertMayManage(req, existing);
+  const scope = scopeOf(existing);
+  const parentId =
+    input.parentId === undefined ? existing.parentId : input.parentId ?? null;
+  audit.name = normalized.name ?? existing.name;
+  audit.scope = scope;
+  audit.parentId = parentId;
+
+  assertParent(byId, parentId, scope, existing.ownerUserId);
+  assertNoCycle(byId, collectionId, parentId);
+  assertSiblingNameAvailable(
+    rows,
+    normalized.name ?? existing.name,
+    parentId,
+    existing.ownerUserId,
+    collectionId
+  );
+  assertRestorableBelowParent(input, parentId, byId);
+  assertPrivateUpdate(scope, input, normalized.grants);
+
+  await tx
+    .update(contentCollections)
+    .set(collectionUpdateValues(input, normalized, parentId))
+    .where(eq(contentCollections.id, collectionId));
+  if (normalized.grants !== undefined) {
+    await replaceGrants(tx, collectionId, normalized.grants);
+  }
+  await applyArchiveState(tx, rows, collectionId, input.archived);
+}
+
+export const collectionManagementService = {
+  async listManageable(req: Requester): Promise<CollectionDTO[]> {
+    const rows = await managementDTOs(req);
+    const principal = principalOf(req);
+    if (principal.isAdmin) return rows;
+    const ownerUserId = collectionOwnerUserId(req);
+    return rows.filter(
+      (row) => row.scope === "private" && row.ownerUserId === ownerUserId
+    );
+  },
+
+  async listOwnedPrivate(req: Requester): Promise<CollectionDTO[]> {
+    const ownerUserId = collectionOwnerUserId(req);
+    if (ownerUserId === null) {
+      throw new ForbiddenError(
+        "A signed-in user is required to manage private collections"
+      );
+    }
+    const rows = await managementDTOs(req);
+    return rows.filter(
+      (row) => row.scope === "private" && row.ownerUserId === ownerUserId
+    );
+  },
+
+  async create(
+    req: Requester,
+    input: CreateCollectionInput,
+    options: MutationOptions = {}
+  ): Promise<CollectionDTO> {
+    const name = normalizedName(input.name);
+    const position = normalizedPosition(input.position);
+    const ownerUserId = assertMayCreateScope(req, input.scope);
+    const level =
+      input.scope === "private"
+        ? "private"
+        : input.defaultVisibilityLevel ?? "internal";
+    assertVisibilityLevel(level);
+    const inheritGrants =
+      input.scope === "private" ? false : input.inheritGrants ?? true;
+    const grants = normalizeGrants(input.grants ?? []);
+    if (input.scope === "private" && grants.length > 0) {
+      throw new ValidationError("Private collections cannot carry access grants");
+    }
+
+    let createdId: string | undefined;
+    try {
+      createdId = await executeTransaction(async (tx) => {
+        const rows = (await tx
+          .select({
+            id: contentCollections.id,
+            name: contentCollections.name,
+            slug: contentCollections.slug,
+            parentId: contentCollections.parentId,
+            ownerUserId: contentCollections.ownerUserId,
+            defaultVisibilityLevel:
+              contentCollections.defaultVisibilityLevel,
+            inheritGrants: contentCollections.inheritGrants,
+            position: contentCollections.position,
+            archivedAt: contentCollections.archivedAt,
+          })
+          .from(contentCollections)) as CollectionAccessRow[];
+        const byId = new Map(rows.map((row) => [row.id, row]));
+        const parentId = input.parentId ?? null;
+        assertParent(byId, parentId, input.scope, ownerUserId);
+        assertSiblingNameAvailable(rows, name, parentId, ownerUserId);
+        const inserted = await tx
+          .insert(contentCollections)
+          .values({
+            name,
+            slug: nextSlug(rows, name, ownerUserId),
+            parentId,
+            ownerUserId,
+            defaultVisibilityLevel: level,
+            inheritGrants,
+            position: position ?? nextPosition(rows, parentId),
+          })
+          .returning({ id: contentCollections.id });
+        if (!inserted[0]) {
+          throw new ConflictError("Failed to create collection");
+        }
+        await replaceGrants(tx, inserted[0].id, grants);
+        return inserted[0].id;
+      }, "collectionManagement.create", { isolationLevel: "serializable" });
+      const created = (await managementDTOs(req)).find(
+        (row) => row.id === createdId
+      );
+      if (!created) throw new NotFoundError("Created collection not found");
+      await auditCollectionMutation({
+        req,
+        action: "collection_create",
+        collectionId: created.id,
+        collectionName: created.name,
+        collectionScope: created.scope,
+        parentId: created.parentId,
+        outcome: "ok",
+        options,
+      });
+      return created;
+    } catch (error) {
+      await auditCollectionMutation({
+        req,
+        action: "collection_create",
+        collectionId: createdId,
+        collectionName: name,
+        collectionScope: input.scope,
+        parentId: input.parentId ?? null,
+        outcome: "error",
+        error,
+        options,
+      });
+      throw error;
+    }
+  },
+
+  async update(
+    req: Requester,
+    collectionId: string,
+    input: UpdateCollectionInput,
+    options: MutationOptions = {}
+  ): Promise<CollectionDTO> {
+    assertCollectionId(collectionId);
+    if (Object.keys(input).length === 0) {
+      throw new ValidationError("Nothing to update");
+    }
+    const name = input.name === undefined ? undefined : normalizedName(input.name);
+    const position = normalizedPosition(input.position);
+    if (input.defaultVisibilityLevel) {
+      assertVisibilityLevel(input.defaultVisibilityLevel);
+    }
+    const grants =
+      input.grants === undefined ? undefined : normalizeGrants(input.grants);
+    const auditAction:
+      | "collection_update"
+      | "collection_archive"
+      | "collection_restore" =
+      input.archived === true
+        ? "collection_archive"
+        : input.archived === false
+          ? "collection_restore"
+          : "collection_update";
+    const audit: CollectionUpdateAuditContext = {};
+
+    try {
+      await executeTransaction(
+        (tx) =>
+          updateCollectionInTx(tx, {
+            req,
+            collectionId,
+            input,
+            normalized: { name, position, grants },
+            audit,
+          }),
+        "collectionManagement.update",
+        { isolationLevel: "serializable" }
+      );
+
+      const updated = (await managementDTOs(req)).find(
+        (row) => row.id === collectionId
+      );
+      if (!updated) throw new NotFoundError("Collection not found");
+      await auditCollectionMutation({
+        req,
+        action: auditAction,
+        collectionId,
+        collectionName: updated.name,
+        collectionScope: updated.scope,
+        parentId: updated.parentId,
+        outcome: "ok",
+        options,
+      });
+      return updated;
+    } catch (error) {
+      await auditCollectionMutation({
+        req,
+        action: auditAction,
+        collectionId,
+        collectionName: audit.name,
+        collectionScope: audit.scope,
+        parentId: audit.parentId,
+        outcome: "error",
+        error,
+        options,
+      });
+      throw error;
+    }
+  },
+};

--- a/lib/content/collection-management-service.ts
+++ b/lib/content/collection-management-service.ts
@@ -372,9 +372,13 @@ function nextSlug(
 
 function nextPosition(
   rows: CollectionAccessRow[],
-  parentId: string | null
+  parentId: string | null,
+  ownerUserId: number | null
 ): number {
-  const siblings = rows.filter((row) => row.parentId === parentId);
+  const siblings = rows.filter(
+    (row) =>
+      row.parentId === parentId && row.ownerUserId === ownerUserId
+  );
   const highest = siblings.reduce(
     (value, row) => Math.max(value, row.position),
     -1
@@ -622,7 +626,11 @@ async function loadCollectionRows(
       position: contentCollections.position,
       archivedAt: contentCollections.archivedAt,
     })
-    .from(contentCollections)) as CollectionAccessRow[];
+    .from(contentCollections)
+    // Content create/move holds SHARE locks on these rows while it authorizes
+    // placement. Taking UPDATE locks before any lifecycle/default/grant change
+    // closes the corresponding authorization/write race.
+    .for("update")) as CollectionAccessRow[];
 }
 
 async function loadDirectCollectionGrants(
@@ -836,7 +844,7 @@ export const collectionManagementService = {
             ownerUserId,
             defaultVisibilityLevel: level,
             inheritGrants,
-            position: position ?? nextPosition(rows, parentId),
+            position: position ?? nextPosition(rows, parentId, ownerUserId),
           })
           .returning({ id: contentCollections.id });
         if (!inserted[0]) {

--- a/lib/content/collection-management-service.ts
+++ b/lib/content/collection-management-service.ts
@@ -147,6 +147,94 @@ function assertVisibilityLevel(level: VisibilityLevel): void {
   }
 }
 
+interface GroupDefaultGrantCheck {
+  level: VisibilityLevel;
+  parentId: string | null;
+  inheritGrants: boolean;
+  ownGrants: CollectionGrant[];
+  byId: Map<string, CollectionAccessRow>;
+  directGrants: Map<string, CollectionGrant[]>;
+}
+
+function assertGroupDefaultHasEffectiveViewGrant(
+  check: GroupDefaultGrantCheck
+): void {
+  const {
+    level,
+    parentId,
+    inheritGrants,
+    ownGrants,
+    byId,
+    directGrants,
+  } = check;
+  if (level !== "group") return;
+  if (ownGrants.some((grant) => grant.access === "view")) return;
+
+  let cursor = inheritGrants ? parentId : null;
+  const seen = new Set<string>();
+  while (cursor && !seen.has(cursor)) {
+    seen.add(cursor);
+    const row = byId.get(cursor);
+    if (!row || row.ownerUserId != null) break;
+    if (
+      (directGrants.get(cursor) ?? []).some(
+        (grant) => grant.access === "view"
+      )
+    ) {
+      return;
+    }
+    if (!row.inheritGrants) break;
+    cursor = row.parentId;
+  }
+
+  throw new ValidationError(
+    "A group-default collection requires at least one effective view grant"
+  );
+}
+
+interface UpdatedSubtreeGrantCheck {
+  rows: CollectionAccessRow[];
+  collectionId: string;
+  parentId: string | null;
+  inheritGrants: boolean;
+  level: VisibilityLevel;
+  ownGrants: CollectionGrant[];
+  directGrants: Map<string, CollectionGrant[]>;
+}
+
+function assertUpdatedSubtreeGroupDefaults(
+  check: UpdatedSubtreeGrantCheck
+): void {
+  const existing = check.rows.find((row) => row.id === check.collectionId);
+  if (!existing) {
+    throw new NotFoundError("Collection not found", {
+      collectionId: check.collectionId,
+    });
+  }
+  const byId = new Map(check.rows.map((row) => [row.id, row]));
+  byId.set(check.collectionId, {
+    ...existing,
+    parentId: check.parentId,
+    inheritGrants: check.inheritGrants,
+    defaultVisibilityLevel: check.level,
+  });
+  const directGrants = new Map(check.directGrants);
+  directGrants.set(check.collectionId, check.ownGrants);
+
+  for (const collectionId of descendantIds(check.rows, check.collectionId)) {
+    const row = byId.get(collectionId);
+    if (!row) continue;
+    assertGroupDefaultHasEffectiveViewGrant({
+      level: row.defaultVisibilityLevel,
+      parentId: row.parentId,
+      inheritGrants: row.inheritGrants,
+      ownGrants: directGrants.get(collectionId) ?? [],
+      byId,
+      directGrants,
+    });
+  }
+}
+
 function scopeOf(row: CollectionAccessRow): CollectionScope {
   return row.ownerUserId == null ? "district" : "private";
 }
@@ -354,6 +442,8 @@ function descendantIds(
  */
 export const collectionManagementInternals = {
   assertCollectionId,
+  assertGroupDefaultHasEffectiveViewGrant,
+  assertUpdatedSubtreeGroupDefaults,
   assertMayCreateScope,
   assertMayManage,
   assertParent,
@@ -535,6 +625,30 @@ async function loadCollectionRows(
     .from(contentCollections)) as CollectionAccessRow[];
 }
 
+async function loadDirectCollectionGrants(
+  tx: DbTransaction
+): Promise<Map<string, CollectionGrant[]>> {
+  const rows = await tx
+    .select({
+      collectionId: contentCollectionGrants.collectionId,
+      access: contentCollectionGrants.access,
+      kind: contentCollectionGrants.grantKind,
+      value: contentCollectionGrants.grantValue,
+    })
+    .from(contentCollectionGrants);
+  const directGrants = new Map<string, CollectionGrant[]>();
+  for (const row of rows) {
+    const grants = directGrants.get(row.collectionId) ?? [];
+    grants.push({
+      access: row.access,
+      kind: row.kind,
+      value: row.value,
+    });
+    directGrants.set(row.collectionId, grants);
+  }
+  return directGrants;
+}
+
 function assertRestorableBelowParent(
   input: UpdateCollectionInput,
   parentId: string | null,
@@ -607,6 +721,7 @@ async function updateCollectionInTx(
 ): Promise<void> {
   const { req, collectionId, input, normalized, audit } = update;
   const rows = await loadCollectionRows(tx);
+  const directGrants = await loadDirectCollectionGrants(tx);
   const byId = new Map(rows.map((row) => [row.id, row]));
   const existing = byId.get(collectionId);
   if (!existing) {
@@ -631,6 +746,15 @@ async function updateCollectionInTx(
   );
   assertRestorableBelowParent(input, parentId, byId);
   assertPrivateUpdate(scope, input, normalized.grants);
+  assertUpdatedSubtreeGroupDefaults({
+    rows,
+    collectionId,
+    level: input.defaultVisibilityLevel ?? existing.defaultVisibilityLevel,
+    parentId,
+    inheritGrants: input.inheritGrants ?? existing.inheritGrants,
+    ownGrants: normalized.grants ?? directGrants.get(collectionId) ?? [],
+    directGrants,
+  });
 
   await tx
     .update(contentCollections)
@@ -689,24 +813,20 @@ export const collectionManagementService = {
     let createdId: string | undefined;
     try {
       createdId = await executeTransaction(async (tx) => {
-        const rows = (await tx
-          .select({
-            id: contentCollections.id,
-            name: contentCollections.name,
-            slug: contentCollections.slug,
-            parentId: contentCollections.parentId,
-            ownerUserId: contentCollections.ownerUserId,
-            defaultVisibilityLevel:
-              contentCollections.defaultVisibilityLevel,
-            inheritGrants: contentCollections.inheritGrants,
-            position: contentCollections.position,
-            archivedAt: contentCollections.archivedAt,
-          })
-          .from(contentCollections)) as CollectionAccessRow[];
+        const rows = await loadCollectionRows(tx);
+        const directGrants = await loadDirectCollectionGrants(tx);
         const byId = new Map(rows.map((row) => [row.id, row]));
         const parentId = input.parentId ?? null;
         assertParent(byId, parentId, input.scope, ownerUserId);
         assertSiblingNameAvailable(rows, name, parentId, ownerUserId);
+        assertGroupDefaultHasEffectiveViewGrant({
+          level,
+          parentId,
+          inheritGrants,
+          ownGrants: grants,
+          byId,
+          directGrants,
+        });
         const inserted = await tx
           .insert(contentCollections)
           .values({

--- a/lib/content/collection-management-service.ts
+++ b/lib/content/collection-management-service.ts
@@ -267,8 +267,13 @@ function nextSlug(
   const nameSlug = slugifyTitle(name);
   // Private slugs are owner-namespaced so another user's hidden collection name
   // cannot be inferred from an otherwise surprising global collision suffix.
-  const base =
+  const unboundedBase =
     ownerUserId == null ? nameSlug : `private-${ownerUserId}-${nameSlug}`;
+  // `slugifyTitle` bounds the name part, but a private owner prefix can push the
+  // combined value past content_collections.slug's varchar(200) limit.
+  const base = unboundedBase
+    .slice(0, NAME_MAX_LENGTH)
+    .replace(/-+$/g, "");
   const taken = new Set(rows.map((row) => row.slug));
   for (let attempt = 0; attempt <= taken.size; attempt++) {
     const candidate = slugCandidate(base, attempt);
@@ -281,11 +286,23 @@ function nextPosition(
   rows: CollectionAccessRow[],
   parentId: string | null
 ): number {
-  return (
-    rows
-      .filter((row) => row.parentId === parentId)
-      .reduce((highest, row) => Math.max(highest, row.position), -1) + 1
+  const siblings = rows.filter((row) => row.parentId === parentId);
+  const highest = siblings.reduce(
+    (value, row) => Math.max(value, row.position),
+    -1
   );
+  if (highest < POSITION_MAX) return highest + 1;
+
+  // An explicitly positioned sibling may already occupy PostgreSQL's int4 max.
+  // Reuse the first non-negative gap instead of overflowing to 2147483648.
+  const used = new Set(siblings.map((row) => row.position));
+  const fallbackLimit = Math.min(siblings.length, POSITION_MAX);
+  for (let candidate = 0; candidate <= fallbackLimit; candidate++) {
+    if (!used.has(candidate)) return candidate;
+  }
+  throw new ConflictError("Collection position space is exhausted", {
+    parentId,
+  });
 }
 
 async function replaceGrants(
@@ -343,6 +360,7 @@ export const collectionManagementInternals = {
   assertNoCycle,
   assertSiblingNameAvailable,
   descendantIds,
+  nextPosition,
   nextSlug,
   normalizeGrants,
 };

--- a/lib/content/collection-service.ts
+++ b/lib/content/collection-service.ts
@@ -11,7 +11,8 @@
  * object visibility. Owner-bound private collections are visible/selectable only
  * to their owner; administrator metadata oversight never grants content access.
  * Zero effective district grants preserve the original default-visibility model.
- * A visible object also keeps its connected ancestor path in the tree.
+ * A visible object also keeps its requester-admitted ancestor path in the tree;
+ * denied ancestors are omitted and accessible descendants are re-rooted.
  *
  * See docs/features/atrium-design-spec.md §21.
  */
@@ -150,32 +151,22 @@ function levelAdmitsPrincipal(
   return false;
 }
 
-/** Index collections by id and by parent id (the child lists), in one pass. */
-function indexCollections(collections: CollectionRow[]): {
-  byId: Map<string, CollectionRow>;
-  childrenOf: Map<string | null, CollectionRow[]>;
-} {
+/** Index collections by id in one pass. */
+function indexCollections(
+  collections: CollectionRow[]
+): Map<string, CollectionRow> {
   const byId = new Map<string, CollectionRow>();
-  const childrenOf = new Map<string | null, CollectionRow[]>();
   for (const c of collections) {
     byId.set(c.id, c);
-    const siblings = childrenOf.get(c.parentId) ?? [];
-    siblings.push(c);
-    childrenOf.set(c.parentId, siblings);
   }
-  return { byId, childrenOf };
+  return byId;
 }
 
 /**
  * The set of collection ids to KEEP: every directly-visible collection (its level
- * admits the principal OR it holds ≥1 visible object) plus every ANCESTOR of one,
- * so the tree stays connected.
- *
- * The ancestor walk stops as soon as it reaches a node already in `keep`: because
- * any node added to `keep` had its full ancestor chain added in the same walk,
- * hitting an already-kept node means every node above it is kept too. That
- * `!keep.has(cursorId)` terminator doubles as the cycle guard (a cycle revisits a
- * kept node and stops), so no per-iteration `seen` set is needed.
+ * admits the principal OR it holds ≥1 visible object) plus every requester-
+ * admitted ancestor. Denied ancestors are never added merely to preserve the
+ * canonical hierarchy; the returned tree compresses across those gaps instead.
  */
 function computeKeepSet(
   collections: CollectionRow[],
@@ -196,10 +187,16 @@ function computeKeepSet(
     const hasVisibleObject = (visibleCountByCollection.get(c.id) ?? 0) > 0;
     if (!levelOk && !(allowed && hasVisibleObject)) continue;
 
-    // Directly visible: mark it and every not-yet-kept ancestor KEEP.
+    // Directly visible: mark it and each admitted ancestor. Keep walking past a
+    // denied ancestor so an independently admitted grandparent can still provide
+    // context, but never add the denied row itself.
     let cursorId: string | null = c.id;
-    while (cursorId != null && byId.has(cursorId) && !keep.has(cursorId)) {
-      keep.add(cursorId);
+    const seen = new Set<string>();
+    while (cursorId != null && byId.has(cursorId) && !seen.has(cursorId)) {
+      seen.add(cursorId);
+      if (access.allowedCollectionIds.has(cursorId)) {
+        keep.add(cursorId);
+      }
       cursorId = byId.get(cursorId)?.parentId ?? null;
     }
   }
@@ -231,15 +228,15 @@ export const collectionService = {
   /**
    * Build the requester-visible collection tree (the reader sidebar / library
    * section tree). Returns only the collections the requester may enter, with the
-   * empty/forbidden subtrees pruned but every ANCESTOR of a visible node kept so
-   * the tree stays connected.
+   * empty/forbidden subtrees pruned. Requester-admitted ancestors of visible
+   * nodes are retained; denied ancestors are omitted and descendants re-rooted.
    *
    * Algorithm:
    *  1. Load all collections + the requester's visible objects (one permission-
    *     pushed `listVisible`).
    *  2. A collection is "directly visible" if its level admits the principal OR it
-   *     holds ≥1 visible object; mark it and its ancestors KEEP.
-   *  3. Assemble the kept collections into a parent/child forest.
+   *     holds ≥1 visible object; mark it and its admitted ancestors KEEP.
+   *  3. Assemble the kept collections into a forest, compressing denied gaps.
    */
   async tree(req: Requester): Promise<CollectionTreeNode[]> {
     const principal = principalOf(req);
@@ -268,7 +265,7 @@ export const collectionService = {
       .filter((row) => !row.archivedAt)
       .map((row) => ({ ...row, navItemId: navById.get(row.id) ?? null }));
 
-    const { byId, childrenOf } = indexCollections(collections);
+    const byId = indexCollections(collections);
     const keep = computeKeepSet(
       collections,
       byId,
@@ -277,16 +274,39 @@ export const collectionService = {
       access
     );
 
-    // Build the kept forest. A child is attached only when both it and its parent
-    // are kept; ancestor-propagation guarantees a kept node's parent is also kept.
+    // Project each kept node onto the nearest kept ancestor. This prevents a
+    // denied canonical parent's id/name/slug from leaking while keeping an
+    // independently admitted descendant reachable in both tree and flat shapes.
+    const visibleParentById = new Map<string, string | null>();
+    const visibleChildrenOf = new Map<string | null, CollectionRow[]>();
+    for (const collection of collections) {
+      if (!keep.has(collection.id)) continue;
+      let visibleParentId = collection.parentId;
+      const seen = new Set<string>([collection.id]);
+      while (
+        visibleParentId != null &&
+        !keep.has(visibleParentId) &&
+        !seen.has(visibleParentId)
+      ) {
+        seen.add(visibleParentId);
+        visibleParentId = byId.get(visibleParentId)?.parentId ?? null;
+      }
+      if (visibleParentId != null && seen.has(visibleParentId)) {
+        visibleParentId = null;
+      }
+      visibleParentById.set(collection.id, visibleParentId);
+      const siblings = visibleChildrenOf.get(visibleParentId) ?? [];
+      siblings.push(collection);
+      visibleChildrenOf.set(visibleParentId, siblings);
+    }
+
     const build = (parentId: string | null): CollectionTreeNode[] =>
-      (childrenOf.get(parentId) ?? [])
-        .filter((c) => keep.has(c.id))
+      (visibleChildrenOf.get(parentId) ?? [])
         .map((c) => ({
           id: c.id,
           name: c.name,
           slug: c.slug,
-          parentId: c.parentId,
+          parentId: visibleParentById.get(c.id) ?? null,
           scope: c.ownerUserId == null ? "district" : "private",
           ownerUserId: c.ownerUserId,
           defaultVisibilityLevel: c.defaultVisibilityLevel,

--- a/lib/content/collection-service.ts
+++ b/lib/content/collection-service.ts
@@ -6,50 +6,36 @@
  * sections a requester may enter — so a user never sees a section they cannot
  * enter (spec §21).
  *
- * ## Visibility model for a collection (no per-collection grant table exists)
- * Collections carry only `default_visibility_level` (there is no
- * `collection_visibility_grants` table — grants live on objects). A collection is
- * therefore "enterable" by a principal when EITHER:
- *  - the collection's `default_visibility_level` admits the principal at the
- *    LEVEL check (public → everyone; internal → any authenticated principal;
- *    private → admin only; group → cannot be satisfied at the collection level
- *    because collections carry no grants — see below), OR
- *  - the principal can view at least one content object placed in the collection
- *    (its subtree counts too). The visible-object counts are computed by the same
- *    permission-pushed visibility predicate (`buildVisibilitySql`) every other
- *    read path uses, via a per-collection `GROUP BY` aggregate bounded by
- *    collection count (not object count), so a `group`-scoped collection
- *    naturally becomes visible to exactly the principals who can see content
- *    inside it (via the objects' own grants).
- *
- * This keeps the two acceptance guarantees aligned:
- *  - "Published content appears in the collection tree" — a visible object lights
- *    up its collection (and all ancestors).
- *  - "Sidebar is filtered by visibility" — an empty/forbidden section the user
- *    cannot enter (no level access AND no visible object) is pruned entirely.
- *
- * An admin sees every collection (the level check short-circuits on `isAdmin`,
- * mirroring `visibilityService.canView`).
+ * Collection ACLs distinguish `view` and `create`, inherit through district
+ * parents until `inherit_grants=false`, and form an additional boundary around
+ * object visibility. Owner-bound private collections are visible/selectable only
+ * to their owner; administrator metadata oversight never grants content access.
+ * Zero effective district grants preserve the original default-visibility model.
+ * A visible object also keeps its connected ancestor path in the tree.
  *
  * See docs/features/atrium-design-spec.md §21.
  */
 
-import { asc, eq } from "drizzle-orm";
+import { eq } from "drizzle-orm";
 import { executeQuery } from "@/lib/db/drizzle-client";
 import { contentCollections } from "@/lib/db/schema";
 import { principalOf } from "./helpers";
 import { visibilityService } from "./visibility-service";
-import type { Principal, Requester, VisibilityLevel } from "./types";
+import {
+  collectionAccessSnapshot,
+  type CollectionAccessRow,
+  type CollectionAccessSnapshot,
+} from "./collection-access";
+import type {
+  CollectionScope,
+  Principal,
+  Requester,
+  VisibilityLevel,
+} from "./types";
 
 /** A collection row as loaded for the tree (timestamps not needed here). */
-interface CollectionRow {
-  id: string;
-  name: string;
-  slug: string;
-  parentId: string | null;
-  defaultVisibilityLevel: VisibilityLevel;
+interface CollectionRow extends CollectionAccessRow {
   navItemId: number | null;
-  position: number;
 }
 
 /** A node in the visibility-filtered collection tree returned to surfaces. */
@@ -58,9 +44,12 @@ export interface CollectionTreeNode {
   name: string;
   slug: string;
   parentId: string | null;
+  scope: CollectionScope;
+  ownerUserId: number | null;
   defaultVisibilityLevel: VisibilityLevel;
   navItemId: number | null;
   position: number;
+  selectableForCreate: boolean;
   /** Number of objects in THIS collection the requester can view (not subtree). */
   visibleObjectCount: number;
   children: CollectionTreeNode[];
@@ -73,6 +62,8 @@ export interface CollectionDiscoveryNode {
   slug: string;
   parentId: string | null;
   path: string[];
+  scope: CollectionScope;
+  ownerUserId: number | null;
   defaultVisibilityLevel: VisibilityLevel;
   visibleObjectCount: number;
   /**
@@ -102,9 +93,13 @@ function discoveryTree(
       slug: node.slug,
       parentId: node.parentId,
       path,
+      scope: node.scope,
+      ownerUserId: node.ownerUserId,
       defaultVisibilityLevel: node.defaultVisibilityLevel,
       visibleObjectCount: node.visibleObjectCount,
-      ...(includeCreateSelection ? { selectableForCreate: true } : {}),
+      ...(includeCreateSelection
+        ? { selectableForCreate: node.selectableForCreate }
+        : {}),
       children: discoveryTree(
         node.children,
         path,
@@ -130,16 +125,17 @@ function flattenDiscoveryTree(
 
 /**
  * Whether a principal may enter a collection based on its default visibility
- * LEVEL alone (no object/grant lookup). Mirrors the level rules in
- * `visibilityService.canView`, minus the owner branch (collections have no
- * owner) and the grant branches (collections have no grant table):
+ * LEVEL alone. This fallback is used only for grant-unrestricted district
+ * collections; private ownership and effective collection grants are resolved
+ * separately by `collectionAccessSnapshot`:
  *  - public   → everyone (incl. unauthenticated).
  *  - internal → any authenticated principal (a user id or a role).
  *  - private  → admin only.
  *  - group    → not satisfiable at the collection level (no collection grants);
  *               such a section surfaces only when it contains a visible object.
  *
- * Admin short-circuits to true for every level, matching `canView`.
+ * Admin short-circuits for district collections; owner-bound private rows never
+ * reach this fallback unless the requester is their owner.
  */
 function levelAdmitsPrincipal(
   principal: Principal,
@@ -152,30 +148,6 @@ function levelAdmitsPrincipal(
   }
   // private / group: not enterable on the level check alone for a non-admin.
   return false;
-}
-
-/** Load every collection ordered by (position, name) for a stable tree. */
-async function loadAllCollections(): Promise<CollectionRow[]> {
-  const rows = await executeQuery(
-    (db) =>
-      db
-        .select({
-          id: contentCollections.id,
-          name: contentCollections.name,
-          slug: contentCollections.slug,
-          parentId: contentCollections.parentId,
-          defaultVisibilityLevel: contentCollections.defaultVisibilityLevel,
-          navItemId: contentCollections.navItemId,
-          position: contentCollections.position,
-        })
-        .from(contentCollections)
-        .orderBy(asc(contentCollections.position), asc(contentCollections.name)),
-    "collection.loadAll"
-  );
-  return rows.map((r) => ({
-    ...r,
-    defaultVisibilityLevel: r.defaultVisibilityLevel as VisibilityLevel,
-  }));
 }
 
 /** Index collections by id and by parent id (the child lists), in one pass. */
@@ -209,13 +181,20 @@ function computeKeepSet(
   collections: CollectionRow[],
   byId: Map<string, CollectionRow>,
   principal: Principal,
-  visibleCountByCollection: Map<string, number>
+  visibleCountByCollection: Map<string, number>,
+  access: CollectionAccessSnapshot
 ): Set<string> {
   const keep = new Set<string>();
   for (const c of collections) {
-    const levelOk = levelAdmitsPrincipal(principal, c.defaultVisibilityLevel);
+    const allowed = access.allowedCollectionIds.has(c.id);
+    const hasViewAcl = access.effectiveGrants(c.id, "view").length > 0;
+    const levelOk =
+      allowed &&
+      (c.ownerUserId != null ||
+        hasViewAcl ||
+        levelAdmitsPrincipal(principal, c.defaultVisibilityLevel));
     const hasVisibleObject = (visibleCountByCollection.get(c.id) ?? 0) > 0;
-    if (!levelOk && !hasVisibleObject) continue;
+    if (!levelOk && !(allowed && hasVisibleObject)) continue;
 
     // Directly visible: mark it and every not-yet-kept ancestor KEEP.
     let cursorId: string | null = c.id;
@@ -264,8 +243,8 @@ export const collectionService = {
    */
   async tree(req: Requester): Promise<CollectionTreeNode[]> {
     const principal = principalOf(req);
-    const [collections, visibleCountByCollection] = await Promise.all([
-      loadAllCollections(),
+    const [access, visibleCountByCollection, navRows] = await Promise.all([
+      collectionAccessSnapshot(req),
       // Per-collection visible-object counts (permission-pushed, GROUP BY in SQL).
       // Excludes archived; published + draft both count toward "this section has
       // content I can see". Bounded by collection count, not object count, so a
@@ -273,14 +252,29 @@ export const collectionService = {
       // outside a capped list page (the reader sidebar is the same visibility, so
       // a non-author only ever counts published content they're entitled to).
       visibilityService.visibleCountsByCollection(req),
+      executeQuery(
+        (db) =>
+          db
+            .select({
+              id: contentCollections.id,
+              navItemId: contentCollections.navItemId,
+            })
+            .from(contentCollections),
+        "collection.loadNavItems"
+      ),
     ]);
+    const navById = new Map(navRows.map((row) => [row.id, row.navItemId]));
+    const collections: CollectionRow[] = access.collections
+      .filter((row) => !row.archivedAt)
+      .map((row) => ({ ...row, navItemId: navById.get(row.id) ?? null }));
 
     const { byId, childrenOf } = indexCollections(collections);
     const keep = computeKeepSet(
       collections,
       byId,
       principal,
-      visibleCountByCollection
+      visibleCountByCollection,
+      access
     );
 
     // Build the kept forest. A child is attached only when both it and its parent
@@ -293,9 +287,12 @@ export const collectionService = {
           name: c.name,
           slug: c.slug,
           parentId: c.parentId,
+          scope: c.ownerUserId == null ? "district" : "private",
+          ownerUserId: c.ownerUserId,
           defaultVisibilityLevel: c.defaultVisibilityLevel,
           navItemId: c.navItemId,
           position: c.position,
+          selectableForCreate: access.selectableCollectionIds.has(c.id),
           visibleObjectCount: visibleCountByCollection.get(c.id) ?? 0,
           children: build(c.id),
         }));

--- a/lib/content/content-service.ts
+++ b/lib/content/content-service.ts
@@ -50,6 +50,10 @@ import {
 import { snapshotInTx, versionService } from "./version-service";
 import { visibilityService } from "./visibility-service";
 import {
+  collectionAccessSnapshot,
+  requesterMayCreateInCollection,
+} from "./collection-access";
+import {
   ConflictError,
   ForbiddenError,
   NotFoundError,
@@ -170,22 +174,64 @@ async function uniqueSlug(tx: DbTransaction, title: string): Promise<string> {
  * decision that might itself branch into other I/O).
  */
 async function collectionDefaultOutsideTx(
+  req: Requester,
   collectionId: string | undefined
-): Promise<VisibilityLevel | null> {
+): Promise<{
+  level: VisibilityLevel;
+  ownerUserId: number | null;
+  grants: VisibilityGrant[];
+} | null> {
   if (!collectionId) return null;
-  const rows = await executeQuery(
-    (db) =>
-      db
-        .select({ level: contentCollections.defaultVisibilityLevel })
-        .from(contentCollections)
-        .where(eq(contentCollections.id, collectionId))
-        .limit(1),
-    "content.create.collectionDefault"
-  );
-  if (!rows[0]) {
+  const access = await collectionAccessSnapshot(req);
+  const collection = access.byId.get(collectionId);
+  if (!collection) {
     throw new ValidationError("Collection not found", { collectionId });
   }
-  return rows[0].level as VisibilityLevel;
+  if (
+    collection.archivedAt ||
+    !access.selectableCollectionIds.has(collectionId)
+  ) {
+    throw new ForbiddenError("Not permitted to create content in this collection", {
+      collectionId,
+    });
+  }
+  return {
+    level: collection.defaultVisibilityLevel,
+    ownerUserId: collection.ownerUserId,
+    grants: access
+      .effectiveGrants(collectionId, "view")
+      .map(({ kind, value }) => ({ kind, value })),
+  };
+}
+
+type CollectionDefault = NonNullable<
+  Awaited<ReturnType<typeof collectionDefaultOutsideTx>>
+>;
+
+function createVisibilityGrants(
+  input: CreateObjectInput,
+  collection: CollectionDefault | null
+): VisibilityGrant[] {
+  if (input.visibility?.grants) return input.visibility.grants;
+  if (input.visibility?.level == null && collection?.level === "group") {
+    return collection.grants;
+  }
+  return [];
+}
+
+function assertPrivateCollectionVisibility(
+  collection: CollectionDefault | null,
+  level: VisibilityLevel,
+  grants: VisibilityGrant[]
+): void {
+  if (
+    collection?.ownerUserId != null &&
+    (level !== "private" || grants.length > 0)
+  ) {
+    throw new ValidationError(
+      "Content in a private collection must remain private and cannot carry grants"
+    );
+  }
 }
 
 /**
@@ -194,11 +240,19 @@ async function collectionDefaultOutsideTx(
  * `collectionDefault` — so an invalid `collectionId` surfaces as a user-facing
  * 400 rather than a raw Postgres FK violation (SQLSTATE 23503).
  */
-async function assertCollectionExists(collectionId: string): Promise<void> {
+async function assertCollectionWritable(
+  req: Requester,
+  collectionId: string,
+  objectOwnerUserId: number
+): Promise<{ ownerUserId: number | null }> {
   const rows = await executeQuery(
     (db) =>
       db
-        .select({ id: contentCollections.id })
+        .select({
+          id: contentCollections.id,
+          ownerUserId: contentCollections.ownerUserId,
+          archivedAt: contentCollections.archivedAt,
+        })
         .from(contentCollections)
         .where(eq(contentCollections.id, collectionId))
         .limit(1),
@@ -207,6 +261,24 @@ async function assertCollectionExists(collectionId: string): Promise<void> {
   if (!rows[0]) {
     throw new ValidationError("Collection not found", { collectionId });
   }
+  if (
+    rows[0].archivedAt ||
+    !(await requesterMayCreateInCollection(req, collectionId))
+  ) {
+    throw new ForbiddenError("Not permitted to move content into this collection", {
+      collectionId,
+    });
+  }
+  if (
+    rows[0].ownerUserId != null &&
+    rows[0].ownerUserId !== objectOwnerUserId
+  ) {
+    throw new ForbiddenError(
+      "A private collection may contain only content owned by its collection owner",
+      { collectionId }
+    );
+  }
+  return { ownerUserId: rows[0].ownerUserId };
 }
 
 /**
@@ -319,7 +391,11 @@ async function resolveCreateVisibility(
   publicWidenRequested: boolean;
 }> {
   const explicitLevel = input.visibility?.level;
-  const grants = input.visibility?.grants ?? [];
+  // Resolve and authorize collection placement even when visibility is explicit.
+  // The former `explicit ?? collectionDefault()` skipped this lookup entirely for
+  // explicit visibility and could defer a bad id to an opaque FK error.
+  const collection = await collectionDefaultOutsideTx(req, input.collectionId);
+  const grants = createVisibilityGrants(input, collection);
 
   // A group object with no grants is invisible to everyone but the owner/admin
   // (equivalent to private without the semantics) — almost always a mistake.
@@ -333,24 +409,10 @@ async function resolveCreateVisibility(
     );
   }
 
-  let visibilityLevel: VisibilityLevel =
-    explicitLevel ??
-    (await collectionDefaultOutsideTx(input.collectionId)) ??
-    "private";
+  const visibilityLevel: VisibilityLevel =
+    explicitLevel ?? collection?.level ?? "private";
 
-  // A collection whose default is `group` can't be satisfied at create time:
-  // the create surface (library "New doc/artifact", the dialog takes only a
-  // title) authors no grants, and a grantless `group` is invisible to all but
-  // owner/admin. Rather than BLOCK creation from a group-default section
-  // (every seeded group collection would 400), fall back to `private`
-  // (owner-only) when the level was INHERITED from the collection default and
-  // no grants were supplied; the author then sets group visibility + grants
-  // via the Phase 3 visibility editor. An EXPLICIT grantless group still
-  // fails (the pre-transaction guard above + the assert below) — only the
-  // silent collection-default inheritance is softened here.
-  if (explicitLevel == null && visibilityLevel === "group" && grants.length === 0) {
-    visibilityLevel = "private";
-  }
+  assertPrivateCollectionVisibility(collection, visibilityLevel, grants);
 
   // Validate the RESOLVED level + grants BEFORE the transaction so an invalid
   // combination (e.g. an explicit `group` with no grants) fails without
@@ -371,6 +433,63 @@ async function resolveCreateVisibility(
   }
 
   return { visibilityLevel, grants, publicWidenRequested: false };
+}
+
+type ContentObjectSetValues = Partial<typeof contentObjects.$inferInsert>;
+
+function applyTitleAndTags(
+  patch: UpdatePatch,
+  setValues: ContentObjectSetValues
+): void {
+  if (patch.title !== undefined) {
+    if (!patch.title.trim()) throw new ValidationError("Title cannot be empty");
+    if (patch.title.trim().length > TITLE_MAX_LENGTH) {
+      throw new ValidationError(
+        `Title must be ${TITLE_MAX_LENGTH} characters or fewer`
+      );
+    }
+    setValues.title = patch.title;
+  }
+  if (patch.tags !== undefined) setValues.tags = patch.tags ?? [];
+}
+
+async function applyCollectionChange(
+  req: Requester,
+  existing: ContentObjectDTO,
+  patch: UpdatePatch,
+  setValues: ContentObjectSetValues
+): Promise<void> {
+  if (patch.collectionId === undefined) return;
+  if (patch.collectionId != null) {
+    const collection = await assertCollectionWritable(
+      req,
+      patch.collectionId,
+      existing.ownerUserId
+    );
+    if (
+      collection.ownerUserId != null &&
+      existing.visibilityLevel !== "private"
+    ) {
+      throw new ValidationError(
+        "Set content visibility to private before moving it into a private collection"
+      );
+    }
+  }
+  setValues.collectionId = patch.collectionId ?? null;
+}
+
+function applyStatusChange(
+  patch: UpdatePatch,
+  setValues: ContentObjectSetValues
+): void {
+  if (patch.status === undefined) return;
+  if (patch.status === "published") {
+    throw new ValidationError(
+      "Cannot set status to 'published' via update — use the publish endpoint/tool instead",
+      { status: patch.status }
+    );
+  }
+  setValues.status = patch.status;
 }
 
 export const contentService = {
@@ -460,7 +579,15 @@ export const contentService = {
   async create(
     req: Requester,
     input: CreateObjectInput,
-    opts: { hasPublishPublicCapability?: boolean } = {}
+    opts: {
+      hasPublishPublicCapability?: boolean;
+      /**
+       * Trusted internal workflows may attribute a write to a machine while
+       * keeping ownership/authorization bound to `req` (OKF import). Never map a
+       * client-supplied value into this option.
+       */
+      attributionRequester?: Requester;
+    } = {}
   ): Promise<ContentObjectWithVersion> {
     assertCanCreate(req);
     assertValidCreateInput(input);
@@ -472,11 +599,12 @@ export const contentService = {
     );
 
     const ownerUserId = ownerFor(req);
+    const attributionRequester = opts.attributionRequester ?? req;
     // Use the shared resolvers so object-level provenance matches version-level
     // (snapshotInTx uses the same helpers): actor === 'agent' iff an agent id is
     // recorded (autonomous only); delegated agents record as 'human'.
-    const createdByActor = actorKindOf(req);
-    const createdByAgentId = agentIdOf(req);
+    const createdByActor = actorKindOf(attributionRequester);
+    const createdByAgentId = agentIdOf(attributionRequester);
 
     // Resolve level + grants. An unauthorized public create is downgraded to
     // private here (create-as-private, §26.4); `publicWidenRequested` then drives
@@ -491,7 +619,11 @@ export const contentService = {
     // a pooled connection. Fail-closed: blocked or unscreenable content throws
     // ValidationError and nothing is created. The returned proof is asserted
     // inside `snapshotInTx` (issue #1118 item 3).
-    const screeningProof = await screenAgentBodyForWrite(req, input.body, null);
+    const screeningProof = await screenAgentBodyForWrite(
+      attributionRequester,
+      input.body,
+      null
+    );
 
     const { object, version, s3Writes } = await executeTransaction(
       async (tx) => {
@@ -559,7 +691,7 @@ export const contentService = {
         if (input.body !== undefined) {
           const snap = await snapshotInTx(
             tx,
-            req,
+            attributionRequester,
             { id: dto.id, kind: input.kind },
             { body: input.body, bodyFormat: input.bodyFormat },
             { proof: screeningProof }
@@ -733,51 +865,12 @@ export const contentService = {
 
     // Typed against the table's insert shape so a column-name typo is a compile
     // error (a `Record<string, unknown>` would silently no-op an unknown key).
-    const setValues: Partial<typeof contentObjects.$inferInsert> = {
+    const setValues: ContentObjectSetValues = {
       updatedAt: new Date(),
     };
-    if (patch.title !== undefined) {
-      if (!patch.title.trim()) throw new ValidationError("Title cannot be empty");
-      // Mirror create()'s varchar(500) guard so an over-long title is a typed
-      // 400, not a raw Postgres 22001 error.
-      if (patch.title.trim().length > TITLE_MAX_LENGTH) {
-        throw new ValidationError(
-          `Title must be ${TITLE_MAX_LENGTH} characters or fewer`
-        );
-      }
-      setValues.title = patch.title;
-    }
-    // Coerce to `[]` (never NULL) so updated rows match the `create()` invariant
-    // (tags is always an array). Downstream `.length`/`.filter()` callers would
-    // otherwise throw a TypeError on a null tags column.
-    if (patch.tags !== undefined) setValues.tags = patch.tags ?? [];
-    if (patch.collectionId !== undefined) {
-      // Validate existence so an invalid id is a typed 400, not a raw FK
-      // violation. A null clears the collection (no existence check needed).
-      if (patch.collectionId != null) {
-        await assertCollectionExists(patch.collectionId);
-      }
-      setValues.collectionId = patch.collectionId ?? null;
-    }
-    if (patch.status !== undefined) {
-      // "published" is NOT a plain metadata transition — it must go through
-      // `publishService.publish()`, which creates the `content_publications`
-      // row, calls the destination adapter, emits `content.published`, and
-      // enforces the §26.4 public-publish gate. Writing it directly here
-      // (content:update alone, no content:publish_internal/publish_public)
-      // would leave `status: "published"` with none of that: a caller could
-      // mark content "published" while it was never actually published
-      // anywhere, and — for a caller who otherwise couldn't pass the gate —
-      // outside the audited/gated flow entirely. "draft" and "archived"
-      // remain plain metadata transitions.
-      if (patch.status === "published") {
-        throw new ValidationError(
-          "Cannot set status to 'published' via update — use the publish endpoint/tool instead",
-          { status: patch.status }
-        );
-      }
-      setValues.status = patch.status;
-    }
+    applyTitleAndTags(patch, setValues);
+    await applyCollectionChange(req, existing, patch, setValues);
+    applyStatusChange(patch, setValues);
     // Slice-F presentation fields (cover gradient + emoji icon), validated at the
     // action boundary and merged as a typed partial (see presentationSetValues).
     Object.assign(setValues, presentationSetValues(patch));
@@ -1058,6 +1151,7 @@ async function assertViewable(
   const viewable = await visibilityService.canView(req, {
     id: obj.id,
     ownerUserId: obj.ownerUserId,
+    collectionId: obj.collectionId,
     visibilityLevel: obj.visibilityLevel,
   });
   if (!viewable) throw new NotFoundError("Content not found", { ref });

--- a/lib/content/content-service.ts
+++ b/lib/content/content-service.ts
@@ -20,7 +20,6 @@ import {
 } from "@/lib/db/drizzle-client";
 import {
   contentAuditLogs,
-  contentCollections,
   contentObjects,
   contentPublications,
   contentVersions,
@@ -51,7 +50,8 @@ import { snapshotInTx, versionService } from "./version-service";
 import { visibilityService } from "./visibility-service";
 import {
   collectionAccessSnapshot,
-  requesterMayCreateInCollection,
+  collectionAccessSnapshotInTx,
+  type CollectionAccessSnapshot,
 } from "./collection-access";
 import {
   ConflictError,
@@ -176,13 +176,26 @@ async function uniqueSlug(tx: DbTransaction, title: string): Promise<string> {
 async function collectionDefaultOutsideTx(
   req: Requester,
   collectionId: string | undefined
-): Promise<{
+): Promise<CollectionDefault | null> {
+  if (!collectionId) return null;
+  return collectionDefaultFromAccess(
+    await collectionAccessSnapshot(req),
+    collectionId,
+    "create content in"
+  );
+}
+
+interface CollectionDefault {
   level: VisibilityLevel;
   ownerUserId: number | null;
   grants: VisibilityGrant[];
-} | null> {
-  if (!collectionId) return null;
-  const access = await collectionAccessSnapshot(req);
+}
+
+function collectionDefaultFromAccess(
+  access: CollectionAccessSnapshot,
+  collectionId: string,
+  operation: "create content in" | "move content into"
+): CollectionDefault {
   const collection = access.byId.get(collectionId);
   if (!collection) {
     throw new ValidationError("Collection not found", { collectionId });
@@ -191,9 +204,10 @@ async function collectionDefaultOutsideTx(
     collection.archivedAt ||
     !access.selectableCollectionIds.has(collectionId)
   ) {
-    throw new ForbiddenError("Not permitted to create content in this collection", {
-      collectionId,
-    });
+    throw new ForbiddenError(
+      `Not permitted to ${operation} this collection`,
+      { collectionId }
+    );
   }
   return {
     level: collection.defaultVisibilityLevel,
@@ -204,9 +218,18 @@ async function collectionDefaultOutsideTx(
   };
 }
 
-type CollectionDefault = NonNullable<
-  Awaited<ReturnType<typeof collectionDefaultOutsideTx>>
->;
+async function collectionDefaultInTx(
+  tx: DbTransaction,
+  req: Requester,
+  collectionId: string | undefined
+): Promise<CollectionDefault | null> {
+  if (!collectionId) return null;
+  return collectionDefaultFromAccess(
+    await collectionAccessSnapshotInTx(tx, req),
+    collectionId,
+    "create content in"
+  );
+}
 
 function createVisibilityGrants(
   input: CreateObjectInput,
@@ -234,51 +257,27 @@ function assertPrivateCollectionVisibility(
   }
 }
 
-/**
- * Validate that a collection exists, throwing a typed `ValidationError` (400) on
- * miss. Used by `update()` — which (unlike `create()`) does not call
- * `collectionDefault` — so an invalid `collectionId` surfaces as a user-facing
- * 400 rather than a raw Postgres FK violation (SQLSTATE 23503).
- */
-async function assertCollectionWritable(
+async function assertCollectionWritableInTx(
+  tx: DbTransaction,
   req: Requester,
   collectionId: string,
   objectOwnerUserId: number
 ): Promise<{ ownerUserId: number | null }> {
-  const rows = await executeQuery(
-    (db) =>
-      db
-        .select({
-          id: contentCollections.id,
-          ownerUserId: contentCollections.ownerUserId,
-          archivedAt: contentCollections.archivedAt,
-        })
-        .from(contentCollections)
-        .where(eq(contentCollections.id, collectionId))
-        .limit(1),
-    "content.assertCollectionExists"
+  const collection = collectionDefaultFromAccess(
+    await collectionAccessSnapshotInTx(tx, req),
+    collectionId,
+    "move content into"
   );
-  if (!rows[0]) {
-    throw new ValidationError("Collection not found", { collectionId });
-  }
   if (
-    rows[0].archivedAt ||
-    !(await requesterMayCreateInCollection(req, collectionId))
-  ) {
-    throw new ForbiddenError("Not permitted to move content into this collection", {
-      collectionId,
-    });
-  }
-  if (
-    rows[0].ownerUserId != null &&
-    rows[0].ownerUserId !== objectOwnerUserId
+    collection.ownerUserId != null &&
+    collection.ownerUserId !== objectOwnerUserId
   ) {
     throw new ForbiddenError(
       "A private collection may contain only content owned by its collection owner",
       { collectionId }
     );
   }
-  return { ownerUserId: rows[0].ownerUserId };
+  return { ownerUserId: collection.ownerUserId };
 }
 
 /**
@@ -381,20 +380,17 @@ async function queuePublicWidenForCreate(
  * `publicWidenRequested` is true when an unauthorized public create was
  * downgraded to private — the caller queues a `visibility_widen` post-commit.
  */
-async function resolveCreateVisibility(
+function resolveCreateVisibilityForCollection(
   req: Requester,
   input: CreateObjectInput,
-  mayPublishPublic: boolean
-): Promise<{
+  mayPublishPublic: boolean,
+  collection: CollectionDefault | null
+): {
   visibilityLevel: VisibilityLevel;
   grants: VisibilityGrant[];
   publicWidenRequested: boolean;
-}> {
+} {
   const explicitLevel = input.visibility?.level;
-  // Resolve and authorize collection placement even when visibility is explicit.
-  // The former `explicit ?? collectionDefault()` skipped this lookup entirely for
-  // explicit visibility and could defer a bad id to an opaque FK error.
-  const collection = await collectionDefaultOutsideTx(req, input.collectionId);
   const grants = createVisibilityGrants(input, collection);
 
   // A group object with no grants is invisible to everyone but the owner/admin
@@ -435,6 +431,38 @@ async function resolveCreateVisibility(
   return { visibilityLevel, grants, publicWidenRequested: false };
 }
 
+async function resolveCreateVisibilityOutsideTx(
+  req: Requester,
+  input: CreateObjectInput,
+  mayPublishPublic: boolean
+): Promise<ReturnType<typeof resolveCreateVisibilityForCollection>> {
+  // Resolve and authorize collection placement even when visibility is explicit.
+  // This is a fast-fail before agent screening/external I/O; create re-resolves
+  // the same policy under collection locks inside its write transaction.
+  const collection = await collectionDefaultOutsideTx(req, input.collectionId);
+  return resolveCreateVisibilityForCollection(
+    req,
+    input,
+    mayPublishPublic,
+    collection
+  );
+}
+
+async function resolveCreateVisibilityInTx(
+  tx: DbTransaction,
+  req: Requester,
+  input: CreateObjectInput,
+  mayPublishPublic: boolean
+): Promise<ReturnType<typeof resolveCreateVisibilityForCollection>> {
+  const collection = await collectionDefaultInTx(tx, req, input.collectionId);
+  return resolveCreateVisibilityForCollection(
+    req,
+    input,
+    mayPublishPublic,
+    collection
+  );
+}
+
 type ContentObjectSetValues = Partial<typeof contentObjects.$inferInsert>;
 
 function applyTitleAndTags(
@@ -453,7 +481,8 @@ function applyTitleAndTags(
   if (patch.tags !== undefined) setValues.tags = patch.tags ?? [];
 }
 
-async function applyCollectionChange(
+async function applyCollectionChangeInTx(
+  tx: DbTransaction,
   req: Requester,
   existing: ContentObjectDTO,
   patch: UpdatePatch,
@@ -461,7 +490,8 @@ async function applyCollectionChange(
 ): Promise<void> {
   if (patch.collectionId === undefined) return;
   if (patch.collectionId != null) {
-    const collection = await assertCollectionWritable(
+    const collection = await assertCollectionWritableInTx(
+      tx,
       req,
       patch.collectionId,
       existing.ownerUserId
@@ -476,6 +506,33 @@ async function applyCollectionChange(
     }
   }
   setValues.collectionId = patch.collectionId ?? null;
+}
+
+async function updateWithCollectionChange(
+  req: Requester,
+  existingId: string,
+  patch: UpdatePatch,
+  setValues: ContentObjectSetValues
+): Promise<ObjectRowAsText[]> {
+  return executeTransaction(async (tx) => {
+    const lockedRows = await tx
+      .select(objectSelectFields)
+      .from(contentObjects)
+      .where(eq(contentObjects.id, existingId))
+      .for("update")
+      .limit(1);
+    if (!lockedRows[0]) {
+      throw new NotFoundError("Content not found", { id: existingId });
+    }
+    const locked = rowToObjectDTO(lockedRows[0] as ObjectRowAsText);
+    assertCanEdit(req, locked.ownerUserId);
+    await applyCollectionChangeInTx(tx, req, locked, patch, setValues);
+    return (await tx
+      .update(contentObjects)
+      .set(setValues)
+      .where(eq(contentObjects.id, existingId))
+      .returning(objectSelectFields)) as ObjectRowAsText[];
+  }, "content.updateCollection");
 }
 
 function applyStatusChange(
@@ -606,11 +663,10 @@ export const contentService = {
     const createdByActor = actorKindOf(attributionRequester);
     const createdByAgentId = agentIdOf(attributionRequester);
 
-    // Resolve level + grants. An unauthorized public create is downgraded to
-    // private here (create-as-private, §26.4); `publicWidenRequested` then drives
-    // the post-commit `visibility_widen` queue below.
-    const { visibilityLevel, grants, publicWidenRequested } =
-      await resolveCreateVisibility(req, input, mayPublishPublic);
+    // Fast-fail invalid/inaccessible collection placement before screening.
+    // The result is deliberately not trusted for the write: the collection,
+    // grants, and default are re-resolved under locks inside the transaction.
+    await resolveCreateVisibilityOutsideTx(req, input, mayPublishPublic);
 
     // §28.3 — agent-authored bodies (a document's markdown AND an artifact's
     // code) are guardrails/PII-screened BEFORE any write, mirroring the agent
@@ -625,85 +681,106 @@ export const contentService = {
       null
     );
 
-    const { object, version, s3Writes } = await executeTransaction(
-      async (tx) => {
-        const slug = await uniqueSlug(tx, input.title);
+    const { object, version, s3Writes, publicWidenRequested } =
+      await executeTransaction(
+        async (tx) => {
+          const { visibilityLevel, grants, publicWidenRequested } =
+            await resolveCreateVisibilityInTx(
+              tx,
+              req,
+              input,
+              mayPublishPublic
+            );
+          const slug = await uniqueSlug(tx, input.title);
 
-        // Translate a slug unique-violation that slips past uniqueSlug (a
-        // concurrent create racing the SELECT) into a typed ConflictError.
-        const inserted = await tx
-          .insert(contentObjects)
-          .values({
-            kind: input.kind,
-            title: input.title,
-            slug,
-            ownerUserId,
-            createdByActor,
-            createdByAgentId,
-            collectionId: input.collectionId ?? null,
-            visibilityLevel,
-            status: "draft",
-            // Typed JSONB must use the postgres.js cast pattern.
-            sourceRef: sql`${safeJsonbStringify(
-              input.sourceRef ?? { type: "none" }
-            )}::jsonb`,
-            tags: input.tags ?? [],
-          })
-          .returning(objectSelectFields)
-          .catch((e: unknown) => {
-            if (isUniqueViolation(e)) {
-              if (
-                uniqueConstraint(e) === "uq_content_capture_source" &&
-                input.sourceRef?.type === "capture"
-              ) {
+          // Translate a slug unique-violation that slips past uniqueSlug (a
+          // concurrent create racing the SELECT) into a typed ConflictError.
+          const inserted = await tx
+            .insert(contentObjects)
+            .values({
+              kind: input.kind,
+              title: input.title,
+              slug,
+              ownerUserId,
+              createdByActor,
+              createdByAgentId,
+              collectionId: input.collectionId ?? null,
+              visibilityLevel,
+              status: "draft",
+              // Typed JSONB must use the postgres.js cast pattern.
+              sourceRef: sql`${safeJsonbStringify(
+                input.sourceRef ?? { type: "none" }
+              )}::jsonb`,
+              tags: input.tags ?? [],
+            })
+            .returning(objectSelectFields)
+            .catch((e: unknown) => {
+              if (isUniqueViolation(e)) {
+                if (
+                  uniqueConstraint(e) === "uq_content_capture_source" &&
+                  input.sourceRef?.type === "capture"
+                ) {
+                  throw new ConflictError(
+                    "This capture session already created a content object",
+                    {
+                      provider: input.sourceRef.provider,
+                      externalId: input.sourceRef.externalId,
+                    }
+                  );
+                }
                 throw new ConflictError(
-                  "This capture session already created a content object",
-                  {
-                    provider: input.sourceRef.provider,
-                    externalId: input.sourceRef.externalId,
-                  }
+                  "A content object with this slug already exists",
+                  { slug }
                 );
               }
-              throw new ConflictError("A content object with this slug already exists", {
-                slug,
-              });
-            }
-            throw e;
-          });
+              throw e;
+            });
 
-        const row = inserted[0];
-        if (!row) {
-          throw new ConflictError("Failed to create content object", { slug });
-        }
+          const row = inserted[0];
+          if (!row) {
+            throw new ConflictError("Failed to create content object", {
+              slug,
+            });
+          }
 
-        // Reconcile grants against the RESOLVED level (enforces group-≥1-grant
-        // even when the level came from the collection default, and the
-        // non-group / private rules) — the same invariant `setLevelInTx` applies.
-        await visibilityService.applyGrantsForLevel(
-          tx,
-          row.id,
-          visibilityLevel,
-          grants
-        );
-
-        const dto = rowToObjectDTO(row as ObjectRowAsText);
-
-        if (input.body !== undefined) {
-          const snap = await snapshotInTx(
+          // Reconcile grants against the RESOLVED level (enforces group-≥1-grant
+          // even when the level came from the collection default, and the
+          // non-group / private rules) — the same invariant `setLevelInTx` applies.
+          await visibilityService.applyGrantsForLevel(
             tx,
-            attributionRequester,
-            { id: dto.id, kind: input.kind },
-            { body: input.body, bodyFormat: input.bodyFormat },
-            { proof: screeningProof }
+            row.id,
+            visibilityLevel,
+            grants
           );
-          // Reflect the new head id without a re-select.
-          dto.currentVersionId = snap.version.id;
-          return { object: dto, version: snap.version, s3Writes: snap.s3Writes };
-        }
-        return { object: dto, version: null, s3Writes: [] };
-      },
-      "content.create"
-    );
+
+          const dto = rowToObjectDTO(row as ObjectRowAsText);
+
+          if (input.body !== undefined) {
+            const snap = await snapshotInTx(
+              tx,
+              attributionRequester,
+              { id: dto.id, kind: input.kind },
+              { body: input.body, bodyFormat: input.bodyFormat },
+              { proof: screeningProof }
+            );
+            // Reflect the new head id without a re-select.
+            dto.currentVersionId = snap.version.id;
+            return {
+              object: dto,
+              version: snap.version,
+              s3Writes: snap.s3Writes,
+              publicWidenRequested,
+            };
+          }
+          return {
+            object: dto,
+            version: null,
+            s3Writes: [],
+            publicWidenRequested,
+          };
+        },
+        "content.create"
+      );
 
     // §26.4 create-as-private (issue #1118 item 2): the object was created private
     // because the caller lacked public-publish authority — queue a durable widen
@@ -869,21 +946,28 @@ export const contentService = {
       updatedAt: new Date(),
     };
     applyTitleAndTags(patch, setValues);
-    await applyCollectionChange(req, existing, patch, setValues);
     applyStatusChange(patch, setValues);
     // Slice-F presentation fields (cover gradient + emoji icon), validated at the
     // action boundary and merged as a typed partial (see presentationSetValues).
     Object.assign(setValues, presentationSetValues(patch));
 
-    const rows = await executeQuery(
-      (db) =>
-        db
-          .update(contentObjects)
-          .set(setValues)
-          .where(eq(contentObjects.id, existing.id))
-          .returning(objectSelectFields),
-      "content.update"
-    );
+    const rows =
+      patch.collectionId === undefined
+        ? await executeQuery(
+            (db) =>
+              db
+                .update(contentObjects)
+                .set(setValues)
+                .where(eq(contentObjects.id, existing.id))
+                .returning(objectSelectFields),
+            "content.update"
+          )
+        : await updateWithCollectionChange(
+            req,
+            existing.id,
+            patch,
+            setValues
+          );
     // Guard against a concurrent delete between load and update (TOCTOU): the
     // RETURNING yields no row, so surface a clean NotFoundError, not a TypeError.
     if (!rows[0]) throw new NotFoundError("Content not found", { id });

--- a/lib/content/embed-backlinks.ts
+++ b/lib/content/embed-backlinks.ts
@@ -14,6 +14,7 @@ import { executeQuery } from "@/lib/db/drizzle-client";
 import { contentEmbedLinks, contentObjects } from "@/lib/db/schema";
 import { visibilityService } from "./visibility-service";
 import { isArtifactId } from "./embed-directive";
+import { collectionAccessSnapshot } from "./collection-access";
 import type { Requester } from "./types";
 
 /** A document that embeds the artifact (viewer-visible, non-archived). */
@@ -56,15 +57,20 @@ export async function listEmbeddingDocuments(
     "atrium.embed.listEmbeddingDocuments"
   );
 
+  const candidates = rows.filter((row) => row.status !== "archived");
+  const collectionAccess = candidates.some(
+    (row) => row.collectionId != null
+  )
+    ? await collectionAccessSnapshot(requester)
+    : undefined;
   const out: EmbeddingDocument[] = [];
-  for (const r of rows) {
-    if (r.status === "archived") continue;
+  for (const r of candidates) {
     const viewable = await visibilityService.canView(requester, {
       id: r.id,
       ownerUserId: r.ownerUserId,
       collectionId: r.collectionId,
       visibilityLevel: r.visibilityLevel,
-    });
+    }, collectionAccess);
     if (viewable) out.push({ id: r.id, title: r.title, slug: r.slug });
   }
   return out;

--- a/lib/content/embed-backlinks.ts
+++ b/lib/content/embed-backlinks.ts
@@ -43,6 +43,7 @@ export async function listEmbeddingDocuments(
           title: contentObjects.title,
           slug: contentObjects.slug,
           ownerUserId: contentObjects.ownerUserId,
+          collectionId: contentObjects.collectionId,
           visibilityLevel: contentObjects.visibilityLevel,
           status: contentObjects.status,
         })
@@ -61,6 +62,7 @@ export async function listEmbeddingDocuments(
     const viewable = await visibilityService.canView(requester, {
       id: r.id,
       ownerUserId: r.ownerUserId,
+      collectionId: r.collectionId,
       visibilityLevel: r.visibilityLevel,
     });
     if (viewable) out.push({ id: r.id, title: r.title, slug: r.slug });

--- a/lib/content/embed-resolver.ts
+++ b/lib/content/embed-resolver.ts
@@ -38,11 +38,15 @@ import { contentObjects, contentPublications } from "@/lib/db/schema";
 import { createLogger } from "@/lib/logger";
 import { versionService } from "./version-service";
 import { visibilityService } from "./visibility-service";
-import { requesterMayViewCollection } from "./collection-access";
+import {
+  collectionAccessSnapshot,
+  requesterMayViewCollection,
+  type CollectionAccessSnapshot,
+} from "./collection-access";
 import { getArtifactSandboxRenderUrl } from "./artifact-sandbox-config";
 import { isArtifactId } from "./embed-directive";
 import { renderDocumentToParts } from "./render/document-parts";
-import type { Requester } from "./types";
+import type { Requester, VisibilityLevel } from "./types";
 
 const log = createLogger({ context: "atrium.embedResolver" });
 const ANONYMOUS_REQUESTER: Requester = {
@@ -74,11 +78,39 @@ export interface ResolveEmbedOptions {
   audience: EmbedAudience;
   /** Required for the `internal` audience (the session principal); ignored for `public`. */
   requester?: Requester;
+  /** Request-scoped reuse for documents containing multiple embedded artifacts. */
+  collectionAccess?: CollectionAccessSnapshot;
 }
 
 /** The masked/unavailable result — identical for absent, non-artifact, and hidden. */
 function unavailable(artifactId: string): ResolvedEmbed {
   return { artifactId, available: false, title: null, href: null, code: "", sandboxSrc: null };
+}
+
+interface EmbedVisibilityObject {
+  id: string;
+  ownerUserId: number;
+  collectionId: string | null;
+  visibilityLevel: VisibilityLevel;
+}
+
+async function canResolveEmbed(
+  obj: EmbedVisibilityObject,
+  opts: ResolveEmbedOptions,
+  collectionAccess?: CollectionAccessSnapshot
+): Promise<boolean> {
+  if (opts.audience === "internal") {
+    return (
+      opts.requester != null &&
+      visibilityService.canView(opts.requester, obj, collectionAccess)
+    );
+  }
+  if (obj.visibilityLevel !== "public") return false;
+  if (obj.collectionId == null) return true;
+  if (collectionAccess) {
+    return collectionAccess.allowedCollectionIds.has(obj.collectionId);
+  }
+  return requesterMayViewCollection(ANONYMOUS_REQUESTER, obj.collectionId);
 }
 
 /**
@@ -87,9 +119,10 @@ function unavailable(artifactId: string): ResolvedEmbed {
  * see. Only a viewable artifact loads its code (best-effort — a missing body
  * degrades to an empty live preview rather than surfacing a raw S3 error).
  */
-export async function resolveEmbedForReader(
+async function resolveEmbedForReaderWithAccess(
   artifactId: string,
-  opts: ResolveEmbedOptions
+  opts: ResolveEmbedOptions,
+  collectionAccess?: CollectionAccessSnapshot
 ): Promise<ResolvedEmbed> {
   // Validate the id shape before any DB lookup so a malformed/injected value never
   // becomes a query key.
@@ -117,20 +150,7 @@ export async function resolveEmbedForReader(
   if (!obj || obj.kind !== "artifact") return unavailable(artifactId);
 
   // Visibility gate — on the ARTIFACT's own visibility for THIS viewer.
-  const visible =
-    opts.audience === "public"
-      ? obj.visibilityLevel === "public" &&
-        (await requesterMayViewCollection(
-          ANONYMOUS_REQUESTER,
-          obj.collectionId
-        ))
-      : opts.requester != null &&
-        (await visibilityService.canView(opts.requester, {
-          id: obj.id,
-          ownerUserId: obj.ownerUserId,
-          collectionId: obj.collectionId,
-          visibilityLevel: obj.visibilityLevel,
-        }));
+  const visible = await canResolveEmbed(obj, opts, collectionAccess);
   if (!visible) return unavailable(artifactId);
 
   // The PUBLIC audience is held to the public reader's stricter contract: only an
@@ -185,6 +205,18 @@ export async function resolveEmbedForReader(
   };
 }
 
+export async function resolveEmbedForReader(
+  artifactId: string,
+  opts: ResolveEmbedOptions
+): Promise<ResolvedEmbed> {
+  // A caller cannot smuggle an authenticated snapshot into the public audience.
+  // Public document batches use the private helper below with an anonymous
+  // snapshot created inside this module.
+  const collectionAccess =
+    opts.audience === "internal" ? opts.collectionAccess : undefined;
+  return resolveEmbedForReaderWithAccess(artifactId, opts, collectionAccess);
+}
+
 /** A rendered document body segment: sanitized HTML or a resolved embed. */
 export type RenderedDocumentPart =
   | { kind: "html"; html: string }
@@ -201,11 +233,27 @@ export async function resolveDocumentParts(
   opts: ResolveEmbedOptions
 ): Promise<RenderedDocumentPart[]> {
   const parts = renderDocumentToParts(markdown);
+  const hasEmbed = parts.some((part) => part.kind === "embed");
+  const snapshotRequester =
+    opts.audience === "public" ? ANONYMOUS_REQUESTER : opts.requester;
+  const collectionAccess =
+    opts.audience === "internal" && opts.collectionAccess
+      ? opts.collectionAccess
+      : hasEmbed && snapshotRequester
+        ? await collectionAccessSnapshot(snapshotRequester)
+        : undefined;
   return Promise.all(
     parts.map(async (part): Promise<RenderedDocumentPart> =>
       part.kind === "html"
         ? { kind: "html", html: part.html }
-        : { kind: "embed", embed: await resolveEmbedForReader(part.artifactId, opts) }
+        : {
+            kind: "embed",
+            embed: await resolveEmbedForReaderWithAccess(
+              part.artifactId,
+              opts,
+              collectionAccess
+            ),
+          }
     )
   );
 }

--- a/lib/content/embed-resolver.ts
+++ b/lib/content/embed-resolver.ts
@@ -19,9 +19,10 @@
  *   uses. Expand links target `/c/<slug>`.
  * - `public` (the anonymous `/p/[slug]` reader) gates STRICTLY on
  *   `visibility_level === 'public'` AND a LIVE `public_web` publication, and
+ *   admits the fixed anonymous principal to the containing collection. It
  *   consults NO session — matching the public reader's own contract (a public
- *   surface must serve the same thing to everyone, and an unpublish must mask
- *   immediately). Expand links target `/p/<slug>`.
+ *   surface must serve the same thing to everyone, and an unpublish/archive must
+ *   mask immediately). Expand links target `/p/<slug>`.
  *
  * The resolved `code` is the artifact's CURRENT head for internal audiences (the
  * "live artifact" the mockup describes). The PUBLIC audience instead receives the
@@ -37,12 +38,20 @@ import { contentObjects, contentPublications } from "@/lib/db/schema";
 import { createLogger } from "@/lib/logger";
 import { versionService } from "./version-service";
 import { visibilityService } from "./visibility-service";
+import { requesterMayViewCollection } from "./collection-access";
 import { getArtifactSandboxRenderUrl } from "./artifact-sandbox-config";
 import { isArtifactId } from "./embed-directive";
 import { renderDocumentToParts } from "./render/document-parts";
 import type { Requester } from "./types";
 
 const log = createLogger({ context: "atrium.embedResolver" });
+const ANONYMOUS_REQUESTER: Requester = {
+  kind: "user",
+  userId: null,
+  roles: [],
+  groups: [],
+  isAdmin: false,
+};
 
 /** A resolved embed: either a live sandbox render or an unavailable placeholder. */
 export interface ResolvedEmbed {
@@ -93,6 +102,7 @@ export async function resolveEmbedForReader(
           id: contentObjects.id,
           kind: contentObjects.kind,
           ownerUserId: contentObjects.ownerUserId,
+          collectionId: contentObjects.collectionId,
           visibilityLevel: contentObjects.visibilityLevel,
           title: contentObjects.title,
           slug: contentObjects.slug,
@@ -109,11 +119,16 @@ export async function resolveEmbedForReader(
   // Visibility gate — on the ARTIFACT's own visibility for THIS viewer.
   const visible =
     opts.audience === "public"
-      ? obj.visibilityLevel === "public"
+      ? obj.visibilityLevel === "public" &&
+        (await requesterMayViewCollection(
+          ANONYMOUS_REQUESTER,
+          obj.collectionId
+        ))
       : opts.requester != null &&
         (await visibilityService.canView(opts.requester, {
           id: obj.id,
           ownerUserId: obj.ownerUserId,
+          collectionId: obj.collectionId,
           visibilityLevel: obj.visibilityLevel,
         }));
   if (!visible) return unavailable(artifactId);

--- a/lib/content/index.ts
+++ b/lib/content/index.ts
@@ -19,6 +19,13 @@ export {
 export { visibilityService } from "./visibility-service";
 export { collectionService } from "./collection-service";
 export type { CollectionTreeNode } from "./collection-service";
+export { collectionManagementService } from "./collection-management-service";
+export {
+  collectionAccessSnapshot,
+  collectionOwnerUserId,
+  requesterMayCreateInCollection,
+  requesterMayViewCollection,
+} from "./collection-access";
 export {
   cleanupExpiredContentAssets,
   contentAssetService,
@@ -122,6 +129,12 @@ export type {
   VisibilityGrant,
   GrantKind,
   VisibilityLevel,
+  CollectionScope,
+  CollectionGrantAccess,
+  CollectionGrant,
+  CreateCollectionInput,
+  UpdateCollectionInput,
+  CollectionDTO,
   ContentKind,
   BodyFormat,
   SnapshotInput,

--- a/lib/content/okf/import.ts
+++ b/lib/content/okf/import.ts
@@ -9,16 +9,18 @@
  *
  * ## Provenance: imported content is agent-authored (spec §36.3 / §11)
  * A machine transformed an external bundle into content; nobody typed it. So every
- * imported object + version is written as the seeded **`atrium-importer`** agent
- * identity (an `agent-autonomous` requester), stamping `actor_kind = 'agent'` and
- * `author_agent_id` — never fabricated human authorship. The human/agent that
- * TRIGGERED the import is still authorized at the surface (`content:create`) and
- * recorded in the audit row; only the content provenance is the importer agent.
+ * imported object + version is attributed to the seeded **`atrium-importer`**
+ * agent identity, stamping `actor_kind = 'agent'` and `author_agent_id` — never
+ * fabricated human authorship. Ownership and collection authorization remain
+ * bound to the human/delegated caller, so imported content can safely live in
+ * that caller's private hierarchy.
  *
  * ## Safe defaults
- * Imported objects are created **private + draft** (owner = the §26.5 system user):
- * inbound external content must not land pre-widened. A human/agent publishes or
- * widens it afterward through the normal gated paths.
+ * Imported objects are created **private + draft** and owned by the triggering
+ * human/delegated owner. Inbound external content must not land pre-widened. An
+ * autonomous caller may import into an existing selectable collection, but
+ * cannot mint an ownerless/shared hierarchy as a side door around collection
+ * administration.
  *
  * ## Retry / partial-failure semantics (NOT transactional)
  * Import is deliberately **additive and NOT wrapped in a single transaction**:
@@ -28,19 +30,27 @@
  * `OKF_IMPORT_MAX_FILES` creates would also pin a pooled connection far too long).
  * Consequently, if a run fails partway, the collections + objects already created
  * are **left in place** (they are valid private/draft content), and there is no
- * dedup on path/`sourceRef` — a client **retry re-imports the whole bundle as new
- * objects** (unique slugs are auto-suffixed). Callers that need idempotency should
- * import into a fresh `targetCollectionId` and treat a failed run as "delete the
- * partial target collection, then retry". Documented on the REST/MCP surfaces.
+ * dedup on path/`sourceRef`. A blind retry may duplicate objects or meet a
+ * sibling-name conflict. Callers that need idempotency should create/select a
+ * fresh target and treat a failed run as "archive the partial imported subtree,
+ * then retry into a new target". Documented on the REST/MCP surfaces.
  */
 
-import { executeQuery } from "@/lib/db/drizzle-client";
-import { contentCollections } from "@/lib/db/schema";
 import { createLogger } from "@/lib/logger";
 import { contentService } from "../content-service";
-import { assertCanCreate, slugCandidate, slugifyTitle } from "../helpers";
-import { ConflictError, ValidationError } from "../errors";
-import type { BodyFormat, Requester } from "../types";
+import { collectionManagementService } from "../collection-management-service";
+import {
+  collectionAccessSnapshot,
+  collectionOwnerUserId,
+} from "../collection-access";
+import { assertCanCreate } from "../helpers";
+import { ForbiddenError, ValidationError } from "../errors";
+import type {
+  BodyFormat,
+  CollectionScope,
+  Requester,
+} from "../types";
+import type { ContentAuditSurface } from "../audit";
 import { OKF_GENERATOR, OKF_INDEX_FILE, OKF_LOG_FILE, kindForOkfType, type OkfFile } from "./profile";
 import { parseConceptFile, parseFrontmatter } from "./frontmatter";
 
@@ -91,12 +101,6 @@ export interface OkfImportResult {
   objectCount: number;
 }
 
-const isUniqueViolation = (error: unknown): boolean =>
-  typeof error === "object" &&
-  error !== null &&
-  "code" in error &&
-  (error as { code?: string }).code === "23505";
-
 /**
  * The directory portion of a slash-path — everything before the last "/", or "" when
  * top-level. Works on a file path (`a/b.md` → `a`) AND on a directory key, where it
@@ -116,37 +120,56 @@ function baseOf(path: string): string {
   return idx === -1 ? path : path.slice(idx + 1);
 }
 
-/** Insert one collection, retrying with a `-N` slug suffix on a unique collision. */
+interface OkfImportOptions {
+  surface?: ContentAuditSurface;
+  requestId?: string;
+}
+
+/** Create one collection through the shared authority/audit write path. */
 async function createCollection(
+  req: Requester,
   name: string,
-  baseSlug: string,
-  parentId: string | null
+  parentId: string | null,
+  scope: CollectionScope,
+  options: OkfImportOptions
 ): Promise<string> {
-  const base = slugifyTitle(baseSlug || name);
-  for (let attempt = 0; attempt < 50; attempt++) {
-    const slug = slugCandidate(base, attempt);
-    try {
-      const rows = await executeQuery(
-        (db) =>
-          db
-            .insert(contentCollections)
-            .values({
-              name: name.slice(0, 200),
-              slug,
-              parentId,
-              // Inbound external content lands private-by-default (safe).
-              defaultVisibilityLevel: "private",
-            })
-            .returning({ id: contentCollections.id }),
-        "okf.import.createCollection"
-      );
-      if (rows[0]) return rows[0].id;
-    } catch (err) {
-      if (isUniqueViolation(err)) continue;
-      throw err;
-    }
+  const collection = await collectionManagementService.create(
+    req,
+    {
+      name: name.slice(0, 200),
+      scope,
+      parentId,
+      defaultVisibilityLevel: "private",
+      inheritGrants: scope === "district",
+    },
+    options
+  );
+  return collection.id;
+}
+
+async function importCollectionScope(
+  req: Requester,
+  targetCollectionId: string | undefined
+): Promise<CollectionScope> {
+  const access = await collectionAccessSnapshot(req);
+  const target = targetCollectionId
+    ? access.byId.get(targetCollectionId)
+    : undefined;
+  if (
+    targetCollectionId &&
+    (!target || !access.selectableCollectionIds.has(targetCollectionId))
+  ) {
+    throw new ValidationError("Target collection not found");
   }
-  throw new ConflictError("Could not allocate a unique collection slug", { base });
+  if (target) {
+    return target.ownerUserId == null ? "district" : "private";
+  }
+  if (collectionOwnerUserId(req) == null) {
+    throw new ForbiddenError(
+      "Autonomous imports require an existing selectable target collection"
+    );
+  }
+  return "private";
 }
 
 /** Parse the `title` frontmatter from an `index.md`, if present. */
@@ -165,12 +188,15 @@ function indexTitle(files: Map<string, OkfFile>, dir: string): string | undefine
  * when supplied, else to a freshly created root collection.
  */
 async function reconstructCollections(
+  req: Requester,
   dirs: Set<string>,
   fileMap: Map<string, OkfFile>,
-  targetCollectionId: string | undefined
+  targetCollectionId: string | undefined,
+  options: OkfImportOptions
 ): Promise<{ map: Map<string, string | null>; created: number }> {
   const map = new Map<string, string | null>();
   let created = 0;
+  const scope = await importCollectionScope(req, targetCollectionId);
 
   // Depth-sorted so a parent directory is always created before its children.
   const ordered = Array.from(dirs).sort(
@@ -183,7 +209,10 @@ async function reconstructCollections(
         map.set("", targetCollectionId);
       } else {
         const rootName = indexTitle(fileMap, "") ?? "Imported OKF bundle";
-        map.set("", await createCollection(rootName, rootName, null));
+        map.set(
+          "",
+          await createCollection(req, rootName, null, scope, options)
+        );
         created++;
       }
       continue;
@@ -191,7 +220,10 @@ async function reconstructCollections(
     const parentId = map.get(dirOf(dir)) ?? targetCollectionId ?? null;
     const segment = baseOf(dir);
     const name = indexTitle(fileMap, dir) ?? segment;
-    map.set(dir, await createCollection(name, segment, parentId));
+    map.set(
+      dir,
+      await createCollection(req, name, parentId, scope, options)
+    );
     created++;
   }
   return { map, created };
@@ -233,6 +265,7 @@ function conceptBodyForCreate(
 
 /** Create ONE imported object from a concept file, as the import agent. */
 async function importConcept(
+  callerReq: Requester,
   importReq: Requester,
   file: OkfFile,
   dirToCollection: Map<string, string | null>,
@@ -245,17 +278,21 @@ async function importConcept(
     dirToCollection.get(dirOf(file.path)) ?? targetCollectionId ?? undefined;
   const { body, bodyFormat } = conceptBodyForCreate(kind, concept.body);
 
-  const createdObject = await contentService.create(importReq, {
-    kind,
-    title,
-    collectionId,
-    body,
-    bodyFormat,
-    // Inbound content is private + draft; never pre-widened.
-    visibility: { level: "private" },
-    tags: concept.frontmatter.tags,
-    sourceRef: { type: "okf", generator: OKF_GENERATOR },
-  });
+  const createdObject = await contentService.create(
+    callerReq,
+    {
+      kind,
+      title,
+      collectionId,
+      body,
+      bodyFormat,
+      // Inbound content is private + draft; never pre-widened.
+      visibility: { level: "private" },
+      tags: concept.frontmatter.tags,
+      sourceRef: { type: "okf", generator: OKF_GENERATOR },
+    },
+    { attributionRequester: importReq }
+  );
   return {
     id: createdObject.id,
     slug: createdObject.slug,
@@ -271,7 +308,8 @@ export const okfImportService = {
    */
   async importBundle(
     callerReq: Requester,
-    input: OkfImportInput
+    input: OkfImportInput,
+    options: OkfImportOptions = {}
   ): Promise<OkfImportResult> {
     const log = createLogger({ action: "okf.import" });
     // Defense in depth: the surface already gated `content:create`, but re-assert so
@@ -305,16 +343,24 @@ export const okfImportService = {
       }
     }
     const { map: dirToCollection, created } = await reconstructCollections(
+      callerReq,
       dirs,
       fileMap,
-      input.targetCollectionId
+      input.targetCollectionId,
+      options
     );
 
     const importReq = importRequester();
     const objects: OkfImportedObject[] = [];
     for (const file of conceptFiles) {
       objects.push(
-        await importConcept(importReq, file, dirToCollection, input.targetCollectionId)
+        await importConcept(
+          callerReq,
+          importReq,
+          file,
+          dirToCollection,
+          input.targetCollectionId
+        )
       );
     }
 

--- a/lib/content/publish-service.ts
+++ b/lib/content/publish-service.ts
@@ -695,6 +695,7 @@ export const publishService = {
     const viewable = await visibilityService.canView(req, {
       id: objectId,
       ownerUserId: obj.ownerUserId,
+      collectionId: obj.collectionId,
       visibilityLevel: obj.visibilityLevel,
     });
     if (!viewable) {
@@ -807,6 +808,7 @@ export const publishService = {
     const viewable = await visibilityService.canView(req, {
       id: objectId,
       ownerUserId: obj.ownerUserId,
+      collectionId: obj.collectionId,
       visibilityLevel: obj.visibilityLevel,
     });
     if (!viewable) {
@@ -975,6 +977,7 @@ export const publishService = {
     const viewable = await visibilityService.canView(req, {
       id: objectId,
       ownerUserId: obj.ownerUserId,
+      collectionId: obj.collectionId,
       visibilityLevel: obj.visibilityLevel,
     });
     if (!viewable) {

--- a/lib/content/rest.ts
+++ b/lib/content/rest.ts
@@ -122,6 +122,33 @@ export const restGrantSchema = z.object({
   value: z.string(),
 });
 
+export const restCollectionGrantSchema = restGrantSchema.extend({
+  access: z.enum(["view", "create"]),
+});
+
+export const createCollectionBodySchema = z
+  .object({
+    name: z.string().min(1).max(200),
+    scope: z.enum(["district", "private"]),
+    parentId: z.string().uuid().nullable().optional(),
+    position: z.number().int().min(0).optional(),
+    defaultVisibilityLevel: z
+      .enum(["private", "group", "internal", "public"])
+      .optional(),
+    inheritGrants: z.boolean().optional(),
+    grants: z.array(restCollectionGrantSchema).max(200).optional(),
+  })
+  .strict();
+
+export const updateCollectionBodySchema = createCollectionBodySchema
+  .omit({ scope: true })
+  .partial()
+  .extend({ archived: z.boolean().optional() })
+  .strict()
+  .refine((value) => Object.keys(value).length > 0, {
+    message: "At least one collection field is required",
+  });
+
 export const restVisibilitySchema = z.object({
   level: z.enum(["private", "group", "internal", "public"]),
   grants: z.array(restGrantSchema).optional(),

--- a/lib/content/retrieval-service.ts
+++ b/lib/content/retrieval-service.ts
@@ -39,6 +39,7 @@ import { createLogger } from "@/lib/logger";
 import { contentService } from "./content-service";
 import { versionService } from "./version-service";
 import { visibilityService } from "./visibility-service";
+import { collectionAccessSnapshot } from "./collection-access";
 import { s3Store } from "./storage/s3-store";
 import { systemUserId } from "./helpers";
 import type { ContentObjectDTO, Requester, VisibilityLevel } from "./types";
@@ -402,11 +403,19 @@ async function search(
     candidates.push({ hit, obj });
   }
 
-  // The safety boundary: never return what the requester can't see. The per-hit
-  // checks are independent DB round trips (up to `limit` of them on the hot
-  // assistant-retrieval path), so run them CONCURRENTLY — `Promise.all` preserves
-  // input order, and the index-aligned filter below keeps the returned hits in
-  // the original vector-search (similarity) order, never completion order.
+  // Resolve the collection boundary ONCE for this search. Without this snapshot,
+  // every concurrent canView call reloads the entire collection/grant hierarchy
+  // and a ten-hit search can consume the configured connection pool.
+  const collectionAccess = candidates.some(
+    ({ obj }) => obj.collectionId != null
+  )
+    ? await collectionAccessSnapshot(req)
+    : undefined;
+
+  // The safety boundary: never return what the requester can't see. Object-level
+  // grant checks remain independent DB round trips, so run them concurrently.
+  // `Promise.all` preserves input order, and the index-aligned filter below keeps
+  // vector-search (similarity) order, never completion order.
   const visibility = await Promise.all(
     candidates.map(({ obj }) =>
       visibilityService.canView(req, {
@@ -414,7 +423,7 @@ async function search(
         ownerUserId: obj.ownerUserId,
         collectionId: obj.collectionId,
         visibilityLevel: obj.visibilityLevel,
-      })
+      }, collectionAccess)
     )
   );
   return candidates

--- a/lib/content/retrieval-service.ts
+++ b/lib/content/retrieval-service.ts
@@ -412,6 +412,7 @@ async function search(
       visibilityService.canView(req, {
         id: obj.id,
         ownerUserId: obj.ownerUserId,
+        collectionId: obj.collectionId,
         visibilityLevel: obj.visibilityLevel,
       })
     )
@@ -444,6 +445,7 @@ async function getContextDocument(
   const visible = await visibilityService.canView(req, {
     id: obj.id,
     ownerUserId: obj.ownerUserId,
+    collectionId: obj.collectionId,
     visibilityLevel: obj.visibilityLevel,
   });
   if (!visible) return null;

--- a/lib/content/surface-helpers.ts
+++ b/lib/content/surface-helpers.ts
@@ -10,7 +10,12 @@ import { eq } from "drizzle-orm";
 import { executeQuery } from "@/lib/db/drizzle-client";
 import { contentCollections } from "@/lib/db/schema";
 import { hasCapabilityAccess } from "@/utils/roles";
+import {
+  requesterMayCreateInCollection,
+  requesterMayViewCollection,
+} from "./collection-access";
 import { ForbiddenError, ValidationError } from "./errors";
+import type { Requester } from "./types";
 
 const UUID_RE =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
@@ -32,9 +37,11 @@ async function collectionIdByColumn(
 }
 
 /**
- * Resolve a `collection` argument (a slug OR a uuid) to a collection id, or
- * `undefined` when none is supplied. Throws a user-facing `ValidationError`
- * (→ 400) when it matches no collection.
+ * Resolve a `collection` argument (a slug OR a uuid) to a requester-admitted
+ * collection id, or `undefined` when none is supplied. Throws the same
+ * user-facing `ValidationError` (→ 400) when the collection is absent or the
+ * requester lacks the requested view/create access, so private names and ids
+ * cannot be confirmed through a filter or placement side channel.
  *
  * EXISTENCE is validated here — not deferred to the service. `contentService.create`
  * skips its own collection check when an explicit `visibility.level` is supplied
@@ -43,30 +50,53 @@ async function collectionIdByColumn(
  * uuid-shaped input is tried as an id first, then as a slug (a slug can itself be
  * uuid-shaped) — mirroring `loadByIdOrSlug`.
  *
- * Overloads: a REQUIRED (non-empty) argument always resolves to a `string` — the
- * function only returns `undefined` for a falsy input, and either resolves or
- * throws otherwise — so a caller passing a zod-validated `.min(1)` id needs no
- * `undefined` narrowing. Passing an optional/nullable value keeps the
+ * Overloads: a REQUIRED (non-empty) collection always resolves to a `string` —
+ * the function only returns `undefined` for a falsy input, and either resolves
+ * or throws otherwise — so a caller passing a zod-validated `.min(1)` id needs
+ * no `undefined` narrowing. Passing an optional/nullable value keeps the
  * `string | undefined` result.
  */
-export function resolveCollectionId(collection: string): Promise<string>;
+type CollectionResolutionAccess = "view" | "create";
+
 export function resolveCollectionId(
-  collection?: string | null
+  req: Requester,
+  collection: string,
+  access: CollectionResolutionAccess
+): Promise<string>;
+export function resolveCollectionId(
+  req: Requester,
+  collection: string | null | undefined,
+  access: CollectionResolutionAccess
 ): Promise<string | undefined>;
 export async function resolveCollectionId(
-  collection?: string | null
+  req: Requester,
+  collection: string | null | undefined,
+  access: CollectionResolutionAccess
 ): Promise<string | undefined> {
   if (!collection) return undefined;
+  let collectionId: string | undefined;
   if (UUID_RE.test(collection)) {
-    const byId = await collectionIdByColumn(contentCollections.id, collection);
-    if (byId) return byId;
+    collectionId = await collectionIdByColumn(
+      contentCollections.id,
+      collection
+    );
     // Fall through: the value may be a uuid-shaped slug rather than an id.
   }
-  const bySlug = await collectionIdByColumn(contentCollections.slug, collection);
-  if (!bySlug) {
+  if (!collectionId) {
+    collectionId = await collectionIdByColumn(
+      contentCollections.slug,
+      collection
+    );
+  }
+  const permitted =
+    collectionId != null &&
+    (access === "create"
+      ? await requesterMayCreateInCollection(req, collectionId)
+      : await requesterMayViewCollection(req, collectionId));
+  if (!collectionId || !permitted) {
     throw new ValidationError("Collection not found", { collection });
   }
-  return bySlug;
+  return collectionId;
 }
 
 // The two reader-link builders moved to the dependency-free `./reader-links`

--- a/lib/content/types.ts
+++ b/lib/content/types.ts
@@ -38,6 +38,54 @@ export interface VisibilityGrant {
 
 export type VisibilityLevel = "private" | "group" | "internal" | "public";
 
+export type CollectionScope = "district" | "private";
+export type CollectionGrantAccess = "view" | "create";
+
+export interface CollectionGrant {
+  access: CollectionGrantAccess;
+  kind: GrantKind;
+  value: string;
+}
+
+export interface CreateCollectionInput {
+  name: string;
+  scope: CollectionScope;
+  parentId?: string | null;
+  position?: number;
+  defaultVisibilityLevel?: VisibilityLevel;
+  inheritGrants?: boolean;
+  grants?: CollectionGrant[];
+}
+
+export interface UpdateCollectionInput {
+  name?: string;
+  parentId?: string | null;
+  position?: number;
+  defaultVisibilityLevel?: VisibilityLevel;
+  inheritGrants?: boolean;
+  grants?: CollectionGrant[];
+  archived?: boolean;
+}
+
+export interface CollectionDTO {
+  id: string;
+  name: string;
+  slug: string;
+  parentId: string | null;
+  path: string[];
+  scope: CollectionScope;
+  ownerUserId: number | null;
+  ownerName: string | null;
+  defaultVisibilityLevel: VisibilityLevel;
+  inheritGrants: boolean;
+  position: number;
+  archivedAt: string | null;
+  directContentCount: number;
+  subtreeContentCount: number;
+  grants: CollectionGrant[];
+  selectableForCreate: boolean;
+}
+
 export interface VisibilityInput {
   level: VisibilityLevel;
   /** Required (and only meaningful) when `level === "group"`. */

--- a/lib/content/version-service.ts
+++ b/lib/content/version-service.ts
@@ -742,6 +742,7 @@ export const versionService = {
         db
           .select({
             ownerUserId: contentObjects.ownerUserId,
+            collectionId: contentObjects.collectionId,
             visibilityLevel: contentObjects.visibilityLevel,
           })
           .from(contentObjects)
@@ -759,6 +760,7 @@ export const versionService = {
     const viewable = await visibilityService.canView(req, {
       id: objectId,
       ownerUserId: owner[0].ownerUserId,
+      collectionId: owner[0].collectionId,
       visibilityLevel: owner[0].visibilityLevel,
     });
     if (!viewable) {

--- a/lib/content/visibility-service.ts
+++ b/lib/content/visibility-service.ts
@@ -19,10 +19,15 @@ import {
   type DrizzleDB,
 } from "@/lib/db/drizzle-client";
 import {
+  contentCollections,
   contentObjects,
   contentVisibilityGrants,
   users,
 } from "@/lib/db/schema";
+import {
+  collectionAccessSnapshot,
+  requesterMayViewCollection,
+} from "./collection-access";
 import {
   canPublishPublic,
   principalOf,
@@ -221,10 +226,28 @@ function buildVisibilitySql(principal: Principal): SQL {
   )`;
 }
 
+/**
+ * Additional collection boundary for permission-pushed object queries.
+ * Unfiled objects are unaffected. Filed objects must be in an active collection
+ * admitted by the requester (private ownership and inherited ACLs included).
+ */
+function buildCollectionAccessSql(allowedCollectionIds: Set<string>): SQL {
+  const ids = [...allowedCollectionIds];
+  const admitted =
+    ids.length > 0
+      ? sql`${contentObjects.collectionId} IN (${sql.join(
+          ids.map((id) => sql`${id}`),
+          sql`, `
+        )})`
+      : sql`false`;
+  return sql`(${contentObjects.collectionId} IS NULL OR ${admitted})`;
+}
+
 /** A loaded object's fields `canView` needs (subset of the DTO). */
 export interface ViewableObject {
   id: string;
   ownerUserId: number;
+  collectionId: string | null;
   visibilityLevel: "private" | "group" | "internal" | "public";
 }
 
@@ -397,6 +420,23 @@ async function setLevelInTx(
   const level = visibility.level;
   assertWritableLevel(level, visibility.grants);
 
+  if (level !== "private") {
+    const collectionRows = await tx
+      .select({ ownerUserId: contentCollections.ownerUserId })
+      .from(contentObjects)
+      .leftJoin(
+        contentCollections,
+        eq(contentObjects.collectionId, contentCollections.id)
+      )
+      .where(eq(contentObjects.id, objectId))
+      .limit(1);
+    if (collectionRows[0]?.ownerUserId != null) {
+      throw new ValidationError(
+        "Content in a private collection must remain private"
+      );
+    }
+  }
+
   // Reconcile the persisted grant set with the target level — both inside the one
   // transaction so the level and its grant set are never observed apart.
   await reconcileGrantsInTx(tx, objectId, level, visibility.grants);
@@ -461,6 +501,9 @@ export const visibilityService = {
    * When you edit one, edit the other in the same commit.
    */
   async canView(req: Requester, obj: ViewableObject): Promise<boolean> {
+    if (!(await requesterMayViewCollection(req, obj.collectionId))) {
+      return false;
+    }
     if (obj.visibilityLevel === "public") return true;
 
     const principal = principalOf(req);
@@ -685,6 +728,9 @@ export const visibilityService = {
     const principal = principalOf(req);
     const o = contentObjects;
     const visiblePredicate = buildVisibilitySql(principal);
+    const collectionPredicate = buildCollectionAccessSql(
+      (await collectionAccessSnapshot(req)).allowedCollectionIds
+    );
     const rows = await executeQuery(
       (db: DrizzleDB) =>
         db
@@ -697,7 +743,8 @@ export const visibilityService = {
             and(
               sql`${o.status} <> 'archived'`,
               sql`${o.collectionId} IS NOT NULL`,
-              visiblePredicate
+              visiblePredicate,
+              collectionPredicate
             )
           )
           .groupBy(o.collectionId),
@@ -733,6 +780,9 @@ export const visibilityService = {
 
     const o = contentObjects;
     const visiblePredicate = buildVisibilitySql(principal);
+    const collectionPredicate = buildCollectionAccessSql(
+      (await collectionAccessSnapshot(req)).allowedCollectionIds
+    );
 
     const filters = [
       // archived objects are excluded unless explicitly requested.
@@ -740,6 +790,7 @@ export const visibilityService = {
         ? eq(o.status, filter.status)
         : sql`${o.status} <> 'archived'`,
       visiblePredicate,
+      collectionPredicate,
     ];
     if (filter.collectionId) filters.push(eq(o.collectionId, filter.collectionId));
     if (filter.kind) filters.push(eq(o.kind, filter.kind));

--- a/lib/content/visibility-service.ts
+++ b/lib/content/visibility-service.ts
@@ -27,6 +27,7 @@ import {
 import {
   collectionAccessSnapshot,
   requesterMayViewCollection,
+  type CollectionAccessSnapshot,
 } from "./collection-access";
 import {
   canPublishPublic,
@@ -500,8 +501,19 @@ export const visibilityService = {
    * disagree and leak (the mocked unit tests cannot catch a SQL-only divergence).
    * When you edit one, edit the other in the same commit.
    */
-  async canView(req: Requester, obj: ViewableObject): Promise<boolean> {
-    if (!(await requesterMayViewCollection(req, obj.collectionId))) {
+  async canView(
+    req: Requester,
+    obj: ViewableObject,
+    collectionAccess?: CollectionAccessSnapshot
+  ): Promise<boolean> {
+    // Batch callers pass one request-scoped snapshot so N concurrent object
+    // checks do not each reload the complete collection/grant hierarchy.
+    const collectionVisible =
+      obj.collectionId == null ||
+      (collectionAccess
+        ? collectionAccess.allowedCollectionIds.has(obj.collectionId)
+        : await requesterMayViewCollection(req, obj.collectionId));
+    if (!collectionVisible) {
       return false;
     }
     if (obj.visibilityLevel === "public") return true;

--- a/lib/db/schema/index.ts
+++ b/lib/db/schema/index.ts
@@ -203,6 +203,7 @@ export * from "./tables/oauth-consent-decisions";
 // Atrium Content Workspace (#1058, Epic #1059)
 // ============================================
 export * from "./tables/content-collections";
+export * from "./tables/content-collection-grants";
 export * from "./tables/content-objects";
 export * from "./tables/content-versions";
 export * from "./tables/content-visibility-grants";

--- a/lib/db/schema/tables/content-audit-logs.ts
+++ b/lib/db/schema/tables/content-audit-logs.ts
@@ -58,6 +58,11 @@ export interface ContentAuditDetails {
   publicExposure?: boolean;
   /** Short human-readable summary accompanying `publicExposure`. */
   note?: string;
+  /** Collection mutation identity (#1438); object_id stays null for these rows. */
+  collectionId?: string;
+  collectionName?: string;
+  collectionScope?: "district" | "private";
+  parentId?: string | null;
 }
 
 export const contentAuditLogs = pgTable("content_audit_logs", {

--- a/lib/db/schema/tables/content-collection-grants.ts
+++ b/lib/db/schema/tables/content-collection-grants.ts
@@ -1,0 +1,57 @@
+/**
+ * Collection-level access grants for Atrium.
+ *
+ * Issue #1438. A collection grant controls either entry/view access or whether
+ * content may be created in the collection. District/shared collections may
+ * inherit grants from their ancestors. Owner-bound private collections never
+ * carry or inherit grants.
+ */
+
+import {
+  check,
+  index,
+  integer,
+  pgTable,
+  unique,
+  uuid,
+  varchar,
+} from "drizzle-orm/pg-core";
+import { sql } from "drizzle-orm";
+import { grantKindEnum } from "../enums";
+import { contentCollections } from "./content-collections";
+
+export type CollectionGrantAccess = "view" | "create";
+
+export const contentCollectionGrants = pgTable(
+  "content_collection_grants",
+  {
+    id: integer("id").generatedAlwaysAsIdentity().primaryKey(),
+    collectionId: uuid("collection_id")
+      .references(() => contentCollections.id, { onDelete: "cascade" })
+      .notNull(),
+    access: varchar("access", { length: 16 })
+      .$type<CollectionGrantAccess>()
+      .notNull(),
+    grantKind: grantKindEnum("grant_kind").notNull(),
+    grantValue: varchar("grant_value", { length: 255 }).notNull(),
+  },
+  (t) => [
+    index("idx_ccg_collection").on(t.collectionId),
+    index("idx_ccg_lookup").on(t.access, t.grantKind, t.grantValue),
+    unique("uq_content_collection_grant").on(
+      t.collectionId,
+      t.access,
+      t.grantKind,
+      t.grantValue
+    ),
+    check(
+      "ck_content_collection_grant_access",
+      sql`${t.access} IN ('view', 'create')`
+    ),
+  ]
+);
+
+export type ContentCollectionGrantRow =
+  typeof contentCollectionGrants.$inferSelect;
+export type NewContentCollectionGrantRow =
+  typeof contentCollectionGrants.$inferInsert;

--- a/lib/db/schema/tables/content-collections.ts
+++ b/lib/db/schema/tables/content-collections.ts
@@ -52,7 +52,9 @@ export const contentCollections = pgTable(
      * both the service and the database check below.
      */
     ownerUserId: integer("owner_user_id").references(() => users.id, {
-      onDelete: "restrict",
+      // Empty private trees are organizational metadata and follow their owner
+      // on account deletion. Content retains its independent owner FK.
+      onDelete: "cascade",
     }),
     inheritGrants: boolean("inherit_grants").default(true).notNull(),
     archivedAt: timestamp("archived_at"),

--- a/lib/db/schema/tables/content-collections.ts
+++ b/lib/db/schema/tables/content-collections.ts
@@ -20,6 +20,8 @@
  */
 
 import {
+  boolean,
+  check,
   foreignKey,
   index,
   integer,
@@ -28,7 +30,9 @@ import {
   uuid,
   varchar,
 } from "drizzle-orm/pg-core";
+import { sql } from "drizzle-orm";
 import { navigationItems } from "./navigation-items";
+import { users } from "./users";
 import { visibilityLevelEnum } from "../enums";
 
 export const contentCollections = pgTable(
@@ -42,6 +46,16 @@ export const contentCollections = pgTable(
     defaultVisibilityLevel: visibilityLevelEnum("default_visibility_level")
       .default("internal")
       .notNull(),
+    /**
+     * NULL = district/shared collection. A user id = owner-bound private
+     * collection. Private collections are forced to private/no-inheritance by
+     * both the service and the database check below.
+     */
+    ownerUserId: integer("owner_user_id").references(() => users.id, {
+      onDelete: "restrict",
+    }),
+    inheritGrants: boolean("inherit_grants").default(true).notNull(),
+    archivedAt: timestamp("archived_at"),
     navItemId: integer("nav_item_id").references(() => navigationItems.id),
     position: integer("position").default(0).notNull(),
     createdAt: timestamp("created_at").defaultNow().notNull(),
@@ -49,6 +63,12 @@ export const contentCollections = pgTable(
   },
   (t) => [
     index("idx_collection_parent").on(t.parentId),
+    index("idx_collection_owner").on(t.ownerUserId),
+    index("idx_collection_archived").on(t.archivedAt),
+    check(
+      "ck_collection_private_owner_policy",
+      sql`${t.ownerUserId} IS NULL OR (${t.defaultVisibilityLevel} = 'private' AND ${t.inheritGrants} = false)`
+    ),
     foreignKey({
       columns: [t.parentId],
       foreignColumns: [t.id],

--- a/lib/mcp/content-tool-handlers.ts
+++ b/lib/mcp/content-tool-handlers.ts
@@ -206,7 +206,11 @@ async function createContent(
     // Decode a base64 (WAF-opaque) body BEFORE the service's §28.3 screening +
     // size caps — screening always sees the real, decoded content.
     const decodedBody = decodeContentBody(body.body, body.codeEncoding);
-    const collectionId = await resolveCollectionId(common.collection);
+    const collectionId = await resolveCollectionId(
+      req,
+      common.collection,
+      "create"
+    );
     const hasPublishPublicCapability = hasPublishPublicScope(context.scopes);
     const created = await contentService.create(
       req,
@@ -357,7 +361,11 @@ async function handleListContent(
   if ("result" in resolved) return resolved.result;
   const { req } = resolved;
   try {
-    const collectionId = await resolveCollectionId(parsed.data.collection);
+    const collectionId = await resolveCollectionId(
+      req,
+      parsed.data.collection,
+      "view"
+    );
     const items = await contentService.list(req, {
       kind: parsed.data.kind,
       collectionId,
@@ -409,7 +417,7 @@ async function handleUpdateContent(
         ? undefined
         : parsed.data.collection === null
           ? null
-          : await resolveCollectionId(parsed.data.collection);
+          : await resolveCollectionId(req, parsed.data.collection, "create");
     const updated = await contentService.update(req, parsed.data.id, {
       title: parsed.data.title,
       tags: parsed.data.tags,
@@ -674,7 +682,11 @@ async function handleExportOkf(
     // `resolveCollectionId` THROWS for an unresolvable id (caught by `fail` below →
     // structured error); its required overload guarantees a defined id for the
     // zod-validated `.min(1)` input, so no `undefined` narrowing is needed.
-    const collectionId = await resolveCollectionId(parsed.data.collectionId);
+    const collectionId = await resolveCollectionId(
+      req,
+      parsed.data.collectionId,
+      "view"
+    );
     const hasPublishPublicCapability = hasPublishPublicScope(context.scopes);
     const result = await okfExportService.exportCollection(req, collectionId, {
       audience: parsed.data.audience,
@@ -727,12 +739,20 @@ async function handleImportOkf(
     // capability (like create); sk-/agent callers are scope-gated at dispatch.
     await assertContentAuthoringCapability(context);
     const targetCollectionId = parsed.data.targetCollectionId
-      ? await resolveCollectionId(parsed.data.targetCollectionId)
+      ? await resolveCollectionId(
+          req,
+          parsed.data.targetCollectionId,
+          "create"
+        )
       : undefined;
-    const result = await okfImportService.importBundle(req, {
-      files: parsed.data.files,
-      targetCollectionId,
-    });
+    const result = await okfImportService.importBundle(
+      req,
+      {
+        files: parsed.data.files,
+        targetCollectionId,
+      },
+      { surface: "mcp", requestId: context.requestId }
+    );
     void recordContentAudit({
       req,
       action: "import_okf",

--- a/tests/e2e/atrium-collection-management.functional.spec.ts
+++ b/tests/e2e/atrium-collection-management.functional.spec.ts
@@ -1,0 +1,118 @@
+import { test, expect } from "./fixtures";
+import {
+  authenticateContext,
+  SEEDED_STAFF_EMAIL,
+  SEEDED_STAFF_SUB,
+} from "./helpers/session-auth";
+
+test.describe("Atrium collection management (authenticated)", () => {
+  test.skip(
+    process.env.PLAYWRIGHT_AUTH_ENABLED !== "true",
+    "Requires the authenticated local DB harness"
+  );
+
+  test("owner manages a private hierarchy and receives conflict feedback", async ({
+    browser,
+  }) => {
+    const context = await browser.newContext();
+    await authenticateContext(context, SEEDED_STAFF_EMAIL, SEEDED_STAFF_SUB);
+    const suffix = Date.now().toString(36);
+    const rootName = `E2E Private ${suffix}`;
+    const childName = `E2E Child ${suffix}`;
+    try {
+      const page = await context.newPage();
+      await page.goto("/atrium");
+      await page.getByRole("button", { name: "New private collection" }).click();
+      const dialog = page.getByRole("dialog", {
+        name: "Manage private collections",
+      });
+      await expect(dialog).toBeVisible();
+
+      await dialog.getByLabel("Name").fill(rootName);
+      await dialog.getByRole("button", { name: "Save" }).click();
+      await expect(dialog.getByRole("status")).toContainText(
+        "Collection created"
+      );
+      await expect(dialog.getByText("PSD Staff Intranet")).toHaveCount(0);
+
+      await dialog.getByRole("button", { name: "New" }).click();
+      await dialog.getByLabel("Name").fill(childName);
+      await dialog.getByLabel("Parent").selectOption({ label: rootName });
+      await dialog.getByRole("button", { name: "Save" }).click();
+      await expect(
+        dialog
+          .getByRole("button")
+          .filter({ hasText: `${rootName} / ${childName}` })
+      ).toBeVisible();
+
+      await dialog.getByRole("button", { name: "New" }).click();
+      await dialog.getByLabel("Name").fill(rootName);
+      await dialog.getByRole("button", { name: "Save" }).click();
+      await expect(dialog.getByRole("alert")).toContainText("already exists");
+
+      await dialog
+        .getByRole("button")
+        .filter({ hasText: rootName })
+        .first()
+        .click();
+      await dialog
+        .getByRole("button", { name: "Archive subtree" })
+        .click();
+      await expect(dialog.getByRole("status")).toContainText(
+        "Collection archived"
+      );
+      await dialog
+        .getByRole("button", { name: "Restore subtree" })
+        .click();
+      await expect(dialog.getByRole("status")).toContainText(
+        "Collection restored"
+      );
+    } finally {
+      await context.close();
+    }
+  });
+
+  test("administrator creates and archives a district collection", async ({
+    browser,
+  }) => {
+    const context = await browser.newContext();
+    await authenticateContext(context);
+    const name = `E2E District ${Date.now().toString(36)}`;
+    try {
+      const page = await context.newPage();
+      await page.goto("/admin/atrium");
+      await page.getByRole("tab", { name: "Collections" }).click();
+      await page.getByRole("button", { name: "New" }).click();
+      await page.getByLabel("Name").fill(name);
+      await page.getByRole("button", { name: "Save" }).click();
+      await expect(page.getByRole("status")).toContainText("Collection created");
+      await page
+        .getByRole("button")
+        .filter({ hasText: name })
+        .first()
+        .click();
+      await page.getByRole("button", { name: "Archive subtree" }).click();
+      await expect(page.getByRole("status")).toContainText(
+        "Collection archived"
+      );
+
+      await page.goto("/atrium");
+      await page
+        .getByRole("button", { name: "New private collection" })
+        .click();
+      const dialog = page.getByRole("dialog", {
+        name: "Manage private collections",
+      });
+      const privateName = `E2E Admin Private ${Date.now().toString(36)}`;
+      await dialog.getByLabel("Name").fill(privateName);
+      await dialog.getByRole("button", { name: "Save" }).click();
+      await expect(dialog.getByRole("status")).toContainText(
+        "Collection created"
+      );
+      await expect(dialog.getByText(name)).toHaveCount(0);
+      await expect(dialog.getByText("PSD Staff Intranet")).toHaveCount(0);
+    } finally {
+      await context.close();
+    }
+  });
+});

--- a/tests/e2e/atrium-collection-management.functional.spec.ts
+++ b/tests/e2e/atrium-collection-management.functional.spec.ts
@@ -14,6 +14,10 @@ test.describe("Atrium collection management (authenticated)", () => {
   test("owner manages a private hierarchy and receives conflict feedback", async ({
     browser,
   }) => {
+    // This workflow deliberately exercises five sequential server mutations.
+    // Give a cold local dev compiler the same headroom as other multi-step E2E
+    // flows; the production-build gate still runs this test with retries disabled.
+    test.slow();
     const context = await browser.newContext();
     await authenticateContext(context, SEEDED_STAFF_EMAIL, SEEDED_STAFF_SUB);
     const suffix = Date.now().toString(36);
@@ -75,6 +79,7 @@ test.describe("Atrium collection management (authenticated)", () => {
   test("administrator creates and archives a district collection", async ({
     browser,
   }) => {
+    test.slow();
     const context = await browser.newContext();
     await authenticateContext(context);
     const name = `E2E District ${Date.now().toString(36)}`;

--- a/tests/e2e/atrium-content-api.guard.spec.ts
+++ b/tests/e2e/atrium-content-api.guard.spec.ts
@@ -26,6 +26,18 @@ test.describe("Atrium content v1 endpoints — unauthenticated 401 (always-run)"
     ).toBe(401);
   });
 
+  test("collection mutations -> 401 before body parsing", async ({ request }) => {
+    const create = await request.post("/api/v1/content/collections", {
+      data: { name: "probe", scope: "private" },
+    });
+    const update = await request.patch(
+      `/api/v1/content/collections/${SOME_ID}`,
+      { data: { archived: true } }
+    );
+    expect(create.status()).toBe(401);
+    expect(update.status()).toBe(401);
+  });
+
   test("POST /api/v1/content -> 401 (auth before body parse)", async ({ request }) => {
     const res = await request.post("/api/v1/content", {
       data: { kind: "document", title: "probe" },

--- a/tests/e2e/global-setup.ts
+++ b/tests/e2e/global-setup.ts
@@ -57,6 +57,8 @@ const WARM_ROUTES = [
   // Heavy dynamic routes for the seeded fixture architect (assistant-architect-seed.sql).
   "/utilities/assistant-architect/9000/edit/prompts", // ReactFlow editor
   "/tools/assistant-architect/9000", // execution/streaming page
+  "/atrium",
+  "/admin/atrium",
   "/atrium/a7100000-0000-4000-8000-000000004040/edit",
   "/c/board-procedure-4040",
 ];

--- a/tests/smoke/atrium-group-visibility-list.smoke.ts
+++ b/tests/smoke/atrium-group-visibility-list.smoke.ts
@@ -66,6 +66,7 @@ const docs = toPgRows(
           id: contentObjects.id,
           slug: contentObjects.slug,
           ownerUserId: contentObjects.ownerUserId,
+          collectionId: contentObjects.collectionId,
           visibilityLevel: contentObjects.visibilityLevel,
         })
         .from(contentObjects)
@@ -76,6 +77,7 @@ const docs = toPgRows(
   id: string;
   slug: string;
   ownerUserId: number;
+  collectionId: string | null;
   visibilityLevel: "private" | "group" | "internal" | "public";
 }[];
 const activeDoc = docs.find((d) => d.slug === ACTIVE_SLUG);

--- a/tests/smoke/atrium-visibility-reference.smoke.ts
+++ b/tests/smoke/atrium-visibility-reference.smoke.ts
@@ -39,6 +39,7 @@ const rows = await executeQuery(
       .select({
         id: contentObjects.id,
         ownerUserId: contentObjects.ownerUserId,
+        collectionId: contentObjects.collectionId,
         visibilityLevel: contentObjects.visibilityLevel,
       })
       .from(contentObjects)

--- a/tests/unit/agent-atrium-owner-operation.test.ts
+++ b/tests/unit/agent-atrium-owner-operation.test.ts
@@ -15,7 +15,7 @@ const assetGetMock = jest.fn()
 const assetReadBytesMock = jest.fn()
 const assetInitiateMock = jest.fn()
 const assetCompleteMock = jest.fn()
-const collectionListMock = jest.fn()
+const collectionManageableListMock = jest.fn()
 const collectionCreateMock = jest.fn()
 const collectionUpdateMock = jest.fn()
 
@@ -79,11 +79,10 @@ jest.mock("@/lib/content", () => {
       delete: (...args: unknown[]) => contentDeleteMock(...args),
     },
     collectionManagementService: {
+      listManageable: (...args: unknown[]) =>
+        collectionManageableListMock(...args),
       create: (...args: unknown[]) => collectionCreateMock(...args),
       update: (...args: unknown[]) => collectionUpdateMock(...args),
-    },
-    collectionService: {
-      discover: (...args: unknown[]) => collectionListMock(...args),
     },
     contentSourceService: {
       read: (...args: unknown[]) => sourceReadMock(...args),
@@ -134,10 +133,16 @@ beforeEach(() => {
 })
 
 describe("signed-owner Atrium operations", () => {
-  it("lists the owner's visible collections without widening content access", async () => {
-    collectionListMock.mockResolvedValue([
-      { id: "f9999999-9999-4999-8999-999999999999", scope: "private" },
-    ])
+  it("keeps archived manageable collections discoverable without widening content access", async () => {
+    const archived = {
+      id: "f9999999-9999-4999-8999-999999999999",
+      scope: "private",
+      archivedAt: "2026-07-29T07:00:00.000Z",
+      directContentCount: 2,
+      subtreeContentCount: 5,
+      grants: [],
+    }
+    collectionManageableListMock.mockResolvedValue([archived])
     const result = await executeOwnerAtriumOperation({
       ownerEmail: "owner@psd401.net",
       requestId: "request-collections",
@@ -145,10 +150,11 @@ describe("signed-owner Atrium operations", () => {
       path: "/collections",
     })
     expect(result.httpStatus).toBe(200)
-    expect(collectionListMock).toHaveBeenCalledWith(requester, {
-      shape: "flat",
-      includeCreateSelection: true,
+    expect(result.payload).toEqual({
+      data: [archived],
+      meta: { requestId: "request-collections" },
     })
+    expect(collectionManageableListMock).toHaveBeenCalledWith(requester)
     expect(assertContentAuthoringCapabilityMock).not.toHaveBeenCalled()
   })
 

--- a/tests/unit/agent-atrium-owner-operation.test.ts
+++ b/tests/unit/agent-atrium-owner-operation.test.ts
@@ -15,6 +15,9 @@ const assetGetMock = jest.fn()
 const assetReadBytesMock = jest.fn()
 const assetInitiateMock = jest.fn()
 const assetCompleteMock = jest.fn()
+const collectionListMock = jest.fn()
+const collectionCreateMock = jest.fn()
+const collectionUpdateMock = jest.fn()
 
 jest.mock("@/lib/db/drizzle/users", () => ({
   getUserByEmail: (...args: unknown[]) => getUserByEmailMock(...args),
@@ -75,6 +78,13 @@ jest.mock("@/lib/content", () => {
       loadForEdit: jest.fn(),
       delete: (...args: unknown[]) => contentDeleteMock(...args),
     },
+    collectionManagementService: {
+      create: (...args: unknown[]) => collectionCreateMock(...args),
+      update: (...args: unknown[]) => collectionUpdateMock(...args),
+    },
+    collectionService: {
+      discover: (...args: unknown[]) => collectionListMock(...args),
+    },
     contentSourceService: {
       read: (...args: unknown[]) => sourceReadMock(...args),
     },
@@ -117,11 +127,66 @@ beforeEach(() => {
   })
   requesterForUserIdMock.mockResolvedValue(requester)
   assertContentAuthoringCapabilityMock.mockResolvedValue(undefined)
-  resolveCollectionIdMock.mockImplementation(async (value: unknown) => value)
+  resolveCollectionIdMock.mockImplementation(
+    async (_requester: unknown, value: unknown) => value
+  )
   auditMock.mockResolvedValue(undefined)
 })
 
 describe("signed-owner Atrium operations", () => {
+  it("lists the owner's visible collections without widening content access", async () => {
+    collectionListMock.mockResolvedValue([
+      { id: "f9999999-9999-4999-8999-999999999999", scope: "private" },
+    ])
+    const result = await executeOwnerAtriumOperation({
+      ownerEmail: "owner@psd401.net",
+      requestId: "request-collections",
+      method: "GET",
+      path: "/collections",
+    })
+    expect(result.httpStatus).toBe(200)
+    expect(collectionListMock).toHaveBeenCalledWith(requester, {
+      shape: "flat",
+      includeCreateSelection: true,
+    })
+    expect(assertContentAuthoringCapabilityMock).not.toHaveBeenCalled()
+  })
+
+  it("creates and moves collections through the shared owner-bound service", async () => {
+    const id = "f9999999-9999-4999-8999-999999999999"
+    collectionCreateMock.mockResolvedValue({ id, name: "Projects" })
+    collectionUpdateMock.mockResolvedValue({ id, name: "Projects", parentId: null })
+
+    const created = await executeOwnerAtriumOperation({
+      ownerEmail: "owner@psd401.net",
+      requestId: "request-create-collection",
+      method: "POST",
+      path: "/collections",
+      body: { name: "Projects", scope: "private" },
+    })
+    expect(created.httpStatus).toBe(201)
+    expect(collectionCreateMock).toHaveBeenCalledWith(
+      requester,
+      { name: "Projects", scope: "private" },
+      { surface: "rest", requestId: "request-create-collection" }
+    )
+
+    await executeOwnerAtriumOperation({
+      ownerEmail: "owner@psd401.net",
+      requestId: "request-move-collection",
+      method: "PATCH",
+      path: `/collections/${id}`,
+      body: { parentId: null, position: 0 },
+    })
+    expect(collectionUpdateMock).toHaveBeenCalledWith(
+      requester,
+      id,
+      { parentId: null, position: 0 },
+      { surface: "rest", requestId: "request-move-collection" }
+    )
+    expect(assertContentAuthoringCapabilityMock).toHaveBeenCalledTimes(2)
+  })
+
   it("resolves the signed email to the owner requester for reads", async () => {
     contentListMock.mockResolvedValue([
       { id: "content-1", slug: "staff-handbook" },

--- a/tests/unit/agent-atrium-owner-operation.test.ts
+++ b/tests/unit/agent-atrium-owner-operation.test.ts
@@ -15,6 +15,7 @@ const assetGetMock = jest.fn()
 const assetReadBytesMock = jest.fn()
 const assetInitiateMock = jest.fn()
 const assetCompleteMock = jest.fn()
+const collectionVisibleListMock = jest.fn()
 const collectionManageableListMock = jest.fn()
 const collectionCreateMock = jest.fn()
 const collectionUpdateMock = jest.fn()
@@ -84,6 +85,9 @@ jest.mock("@/lib/content", () => {
       create: (...args: unknown[]) => collectionCreateMock(...args),
       update: (...args: unknown[]) => collectionUpdateMock(...args),
     },
+    collectionService: {
+      discover: (...args: unknown[]) => collectionVisibleListMock(...args),
+    },
     contentSourceService: {
       read: (...args: unknown[]) => sourceReadMock(...args),
     },
@@ -134,6 +138,25 @@ beforeEach(() => {
 
 describe("signed-owner Atrium operations", () => {
   it("keeps archived manageable collections discoverable without widening content access", async () => {
+    const district = {
+      id: "d9999999-9999-4999-8999-999999999999",
+      scope: "district",
+      slug: "staff-intranet",
+      selectableForCreate: true,
+    }
+    const activePrivatePicker = {
+      id: "a9999999-9999-4999-8999-999999999999",
+      scope: "private",
+      slug: "active-private",
+      selectableForCreate: true,
+    }
+    const activePrivateManagement = {
+      ...activePrivatePicker,
+      archivedAt: null,
+      directContentCount: 1,
+      subtreeContentCount: 1,
+      grants: [],
+    }
     const archived = {
       id: "f9999999-9999-4999-8999-999999999999",
       scope: "private",
@@ -142,7 +165,14 @@ describe("signed-owner Atrium operations", () => {
       subtreeContentCount: 5,
       grants: [],
     }
-    collectionManageableListMock.mockResolvedValue([archived])
+    collectionVisibleListMock.mockResolvedValue([
+      district,
+      activePrivatePicker,
+    ])
+    collectionManageableListMock.mockResolvedValue([
+      activePrivateManagement,
+      archived,
+    ])
     const result = await executeOwnerAtriumOperation({
       ownerEmail: "owner@psd401.net",
       requestId: "request-collections",
@@ -151,8 +181,12 @@ describe("signed-owner Atrium operations", () => {
     })
     expect(result.httpStatus).toBe(200)
     expect(result.payload).toEqual({
-      data: [archived],
+      data: [district, activePrivateManagement, archived],
       meta: { requestId: "request-collections" },
+    })
+    expect(collectionVisibleListMock).toHaveBeenCalledWith(requester, {
+      shape: "flat",
+      includeCreateSelection: true,
     })
     expect(collectionManageableListMock).toHaveBeenCalledWith(requester)
     expect(assertContentAuthoringCapabilityMock).not.toHaveBeenCalled()

--- a/tests/unit/agent-atrium-route.test.ts
+++ b/tests/unit/agent-atrium-route.test.ts
@@ -101,6 +101,9 @@ describe("POST /api/agent/atrium", () => {
   })
 
   it.each([
+    ["GET", "/collections"],
+    ["POST", "/collections"],
+    ["PATCH", "/collections/f9999999-9999-4999-8999-999999999999"],
     ["GET", "/content-1/source"],
     ["GET", "/content-1/assets"],
     ["GET", "/content-1/assets/asset-1/bytes"],
@@ -128,6 +131,8 @@ describe("POST /api/agent/atrium", () => {
     ["POST", "/content-1/source"],
     ["DELETE", "/content-1/assets/asset-1"],
     ["PATCH", "/content-1/assets"],
+    ["DELETE", "/collections/content-1"],
+    ["PATCH", "/collections/content-1/archive"],
   ])("rejects operation %s %s outside the fixed API surface", async (method, path) => {
     const response = await POST(request({ method, path }))
     expect(response.status).toBe(400)

--- a/tests/unit/atrium-approvals-actions.test.ts
+++ b/tests/unit/atrium-approvals-actions.test.ts
@@ -351,6 +351,8 @@ describe("listContentAuditAction", () => {
       {
         id: "a-1",
         objectId: "obj-1",
+        collectionId: null,
+        collectionName: null,
         action: "publish",
         surface: "mcp",
         actorKind: "agent",
@@ -375,6 +377,8 @@ describe("listContentAuditAction", () => {
       {
         id: "a-1",
         objectId: "obj-1",
+        collectionId: null,
+        collectionName: null,
         action: "publish",
         surface: "mcp",
         actorKind: "agent",

--- a/tests/unit/atrium-collection-access.test.ts
+++ b/tests/unit/atrium-collection-access.test.ts
@@ -1,0 +1,179 @@
+/** @jest-environment node */
+
+const executeQueryMock = jest.fn();
+
+jest.mock("@/lib/db/drizzle-client", () => ({
+  executeQuery: (...args: unknown[]) => executeQueryMock(...args),
+}));
+jest.mock("@/lib/db/schema", () => ({
+  contentCollections: {
+    id: {},
+    name: {},
+    slug: {},
+    parentId: {},
+    ownerUserId: {},
+    defaultVisibilityLevel: {},
+    inheritGrants: {},
+    position: {},
+    archivedAt: {},
+  },
+  contentCollectionGrants: {
+    collectionId: {},
+    access: {},
+    grantKind: {},
+    grantValue: {},
+  },
+}));
+jest.mock("drizzle-orm", () => ({
+  asc: (value: unknown) => value,
+}));
+
+import { collectionAccessSnapshot } from "@/lib/content/collection-access";
+import type { Requester } from "@/lib/content/types";
+
+interface CollectionFixture {
+  id: string;
+  name: string;
+  slug: string;
+  parentId: string | null;
+  ownerUserId: number | null;
+  defaultVisibilityLevel: "private" | "group" | "internal" | "public";
+  inheritGrants: boolean;
+  position: number;
+  archivedAt: Date | null;
+}
+
+interface GrantFixture {
+  collectionId: string;
+  access: "view" | "create";
+  kind: "role" | "group";
+  value: string;
+}
+
+let collections: CollectionFixture[] = [];
+let grants: GrantFixture[] = [];
+
+const owner: Requester = {
+  kind: "user",
+  userId: 7,
+  roles: ["staff"],
+  groups: ["editors@psd401.net"],
+  isAdmin: false,
+};
+const outsider: Requester = {
+  kind: "user",
+  userId: 8,
+  roles: ["student"],
+  groups: [],
+  isAdmin: false,
+};
+const admin: Requester = {
+  kind: "user",
+  userId: 1,
+  roles: ["administrator"],
+  groups: [],
+  isAdmin: true,
+};
+
+function row(
+  id: string,
+  values: Partial<CollectionFixture> = {}
+): CollectionFixture {
+  return {
+    id,
+    name: id,
+    slug: id,
+    parentId: null,
+    ownerUserId: null,
+    defaultVisibilityLevel: "internal",
+    inheritGrants: true,
+    position: 0,
+    archivedAt: null,
+    ...values,
+  };
+}
+
+beforeEach(() => {
+  collections = [];
+  grants = [];
+  executeQueryMock.mockReset().mockImplementation(
+    async (_callback: unknown, context: string) =>
+      context === "collectionAccess.loadCollections" ? collections : grants
+  );
+});
+
+describe("Atrium collection access", () => {
+  it("keeps owner-bound private collections private even from administrators", async () => {
+    collections = [
+      row("private", {
+        ownerUserId: 7,
+        defaultVisibilityLevel: "private",
+        inheritGrants: false,
+      }),
+    ];
+
+    const ownerAccess = await collectionAccessSnapshot(owner);
+    expect(ownerAccess.allowedCollectionIds.has("private")).toBe(true);
+    expect(ownerAccess.selectableCollectionIds.has("private")).toBe(true);
+
+    const adminAccess = await collectionAccessSnapshot(admin);
+    expect(adminAccess.allowedCollectionIds.has("private")).toBe(false);
+    expect(adminAccess.selectableCollectionIds.has("private")).toBe(false);
+  });
+
+  it("inherits distinct view/create grants through a district hierarchy", async () => {
+    collections = [
+      row("root"),
+      row("child", { parentId: "root" }),
+    ];
+    grants = [
+      {
+        collectionId: "root",
+        access: "view",
+        kind: "role",
+        value: "staff",
+      },
+      {
+        collectionId: "root",
+        access: "create",
+        kind: "group",
+        value: "editors@psd401.net",
+      },
+    ];
+
+    const matching = await collectionAccessSnapshot(owner);
+    expect(matching.allowedCollectionIds.has("child")).toBe(true);
+    expect(matching.selectableCollectionIds.has("child")).toBe(true);
+
+    const denied = await collectionAccessSnapshot(outsider);
+    expect(denied.allowedCollectionIds.has("child")).toBe(false);
+    expect(denied.selectableCollectionIds.has("child")).toBe(false);
+  });
+
+  it("cuts off inheritance and preserves zero-grant legacy behavior", async () => {
+    collections = [
+      row("root"),
+      row("boundary", { parentId: "root", inheritGrants: false }),
+    ];
+    grants = [
+      {
+        collectionId: "root",
+        access: "view",
+        kind: "role",
+        value: "staff",
+      },
+    ];
+
+    const access = await collectionAccessSnapshot(outsider);
+    expect(access.allowedCollectionIds.has("root")).toBe(false);
+    expect(access.allowedCollectionIds.has("boundary")).toBe(true);
+    expect(access.selectableCollectionIds.has("boundary")).toBe(true);
+  });
+
+  it("excludes archived collections from both view and create sets", async () => {
+    collections = [row("archived", { archivedAt: new Date() })];
+    const access = await collectionAccessSnapshot(owner);
+    expect(access.allowedCollectionIds.has("archived")).toBe(false);
+    expect(access.selectableCollectionIds.has("archived")).toBe(false);
+  });
+});

--- a/tests/unit/atrium-collection-access.test.ts
+++ b/tests/unit/atrium-collection-access.test.ts
@@ -28,7 +28,10 @@ jest.mock("drizzle-orm", () => ({
   asc: (value: unknown) => value,
 }));
 
-import { collectionAccessSnapshot } from "@/lib/content/collection-access";
+import {
+  collectionAccessSnapshot,
+  collectionAccessSnapshotInTx,
+} from "@/lib/content/collection-access";
 import type { Requester } from "@/lib/content/types";
 
 interface CollectionFixture {
@@ -175,5 +178,27 @@ describe("Atrium collection access", () => {
     const access = await collectionAccessSnapshot(owner);
     expect(access.allowedCollectionIds.has("archived")).toBe(false);
     expect(access.selectableCollectionIds.has("archived")).toBe(false);
+  });
+
+  it("holds collection share locks for transaction-scoped authorization", async () => {
+    collections = [row("district")];
+    const forLock = jest.fn(async () => collections);
+    const orderBy = jest.fn(() => ({ for: forLock }));
+    const tx = {
+      select: jest
+        .fn()
+        .mockReturnValueOnce({
+          from: jest.fn(() => ({ orderBy })),
+        })
+        .mockReturnValueOnce({
+          from: jest.fn(async () => grants),
+        }),
+    };
+
+    const access = await collectionAccessSnapshotInTx(tx as never, owner);
+
+    expect(forLock).toHaveBeenCalledWith("share");
+    expect(access.selectableCollectionIds.has("district")).toBe(true);
+    expect(executeQueryMock).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/atrium-collection-item-route.test.ts
+++ b/tests/unit/atrium-collection-item-route.test.ts
@@ -1,0 +1,101 @@
+/** @jest-environment node */
+
+const requireScopeMock = jest.fn();
+const parseRequestBodyMock = jest.fn();
+const createApiResponseMock = jest.fn();
+const createErrorResponseMock = jest.fn();
+const updateMock = jest.fn();
+const resolveRestRequesterMock = jest.fn();
+const capabilityMock = jest.fn();
+
+jest.mock("@/lib/api", () => ({
+  withApiAuth: (handler: unknown) => handler,
+  requireScope: (...args: unknown[]) => requireScopeMock(...args),
+  parseRequestBody: (...args: unknown[]) => parseRequestBodyMock(...args),
+  createApiResponse: (...args: unknown[]) => createApiResponseMock(...args),
+  createErrorResponse: (...args: unknown[]) => createErrorResponseMock(...args),
+}));
+jest.mock("@/lib/content", () => ({
+  collectionManagementService: {
+    update: (...args: unknown[]) => updateMock(...args),
+  },
+}));
+jest.mock("@/lib/content/rest", () => ({
+  contentErrorToResponse: jest.fn(),
+  updateCollectionBodySchema: {},
+  resolveRestRequester: (...args: unknown[]) =>
+    resolveRestRequesterMock(...args),
+}));
+jest.mock("@/lib/content/surface-helpers", () => ({
+  assertContentAuthoringCapability: (...args: unknown[]) =>
+    capabilityMock(...args),
+}));
+
+import type { NextRequest } from "next/server";
+import { PATCH } from "@/app/api/v1/content/collections/[id]/route";
+
+const handler = PATCH as unknown as (
+  request: NextRequest,
+  auth: { scopes: string[] },
+  requestId: string,
+  params: { id?: string }
+) => Promise<unknown>;
+
+const requester = {
+  kind: "user",
+  userId: 7,
+  roles: ["staff"],
+  isAdmin: false,
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  requireScopeMock.mockReturnValue(null);
+  parseRequestBodyMock.mockResolvedValue({
+    data: { parentId: null, position: 1 },
+  });
+  resolveRestRequesterMock.mockResolvedValue({ req: requester });
+  capabilityMock.mockResolvedValue(undefined);
+  updateMock.mockResolvedValue({
+    id: "f9999999-9999-4999-8999-999999999999",
+    name: "Moved",
+  });
+});
+
+describe("PATCH /api/v1/content/collections/:id (#1438)", () => {
+  it("moves/updates through the shared collection service", async () => {
+    await handler(
+      {} as NextRequest,
+      { scopes: ["content:update"] },
+      "req-update",
+      { id: "f9999999-9999-4999-8999-999999999999" }
+    );
+
+    expect(updateMock).toHaveBeenCalledWith(
+      requester,
+      "f9999999-9999-4999-8999-999999999999",
+      { parentId: null, position: 1 },
+      { surface: "rest", requestId: "req-update" }
+    );
+    expect(createApiResponseMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          id: "f9999999-9999-4999-8999-999999999999",
+        }),
+      }),
+      "req-update"
+    );
+  });
+
+  it("rejects a missing id before body parsing", async () => {
+    createErrorResponseMock.mockReturnValue({ marker: "bad" });
+    await handler(
+      {} as NextRequest,
+      { scopes: ["content:update"] },
+      "req-missing",
+      {}
+    );
+    expect(parseRequestBodyMock).not.toHaveBeenCalled();
+    expect(updateMock).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/atrium-collection-item-route.test.ts
+++ b/tests/unit/atrium-collection-item-route.test.ts
@@ -55,7 +55,9 @@ beforeEach(() => {
     data: { parentId: null, position: 1 },
   });
   resolveRestRequesterMock.mockResolvedValue({ req: requester });
-  capabilityMock.mockResolvedValue(undefined);
+  capabilityMock.mockRejectedValue(
+    new Error("UI capability checks must not gate REST endpoints")
+  );
   updateMock.mockResolvedValue({
     id: "f9999999-9999-4999-8999-999999999999",
     name: "Moved",
@@ -63,14 +65,19 @@ beforeEach(() => {
 });
 
 describe("PATCH /api/v1/content/collections/:id (#1438)", () => {
-  it("moves/updates through the shared collection service", async () => {
+  it("uses the API scope without applying a UI capability gate", async () => {
     await handler(
       {} as NextRequest,
-      { scopes: ["content:update"] },
+      {
+        scopes: ["content:update"],
+        authType: "session",
+        cognitoSub: "cognito-sub",
+      } as { scopes: string[] },
       "req-update",
       { id: "f9999999-9999-4999-8999-999999999999" }
     );
 
+    expect(capabilityMock).not.toHaveBeenCalled();
     expect(updateMock).toHaveBeenCalledWith(
       requester,
       "f9999999-9999-4999-8999-999999999999",

--- a/tests/unit/atrium-collection-management-action-security.test.ts
+++ b/tests/unit/atrium-collection-management-action-security.test.ts
@@ -1,0 +1,73 @@
+/** @jest-environment node */
+
+const getUserRequesterMock = jest.fn(async () => ({
+  kind: "user" as const,
+  userId: 7,
+  roles: ["staff"],
+  isAdmin: false,
+}));
+jest.mock("@/actions/db/atrium/requester", () => ({
+  getUserRequester: (...args: unknown[]) =>
+    getUserRequesterMock(...(args as [])),
+}));
+
+jest.mock("@/lib/auth/server-session", () => ({
+  getServerSession: jest.fn(async () => ({ sub: "cognito-sub" })),
+}));
+
+const hasCapabilityAccessMock = jest.fn(async () => true);
+jest.mock("@/utils/roles", () => ({
+  hasCapabilityAccess: (...args: unknown[]) =>
+    hasCapabilityAccessMock(...(args as [])),
+}));
+
+const updateCollectionMock = jest.fn();
+jest.mock("@/lib/content", () => {
+  class MockContentError extends Error {}
+  class MockValidationError extends MockContentError {}
+
+  return {
+    collectionManagementService: {
+      create: jest.fn(),
+      listManageable: jest.fn(),
+      listOwnedPrivate: jest.fn(),
+      update: (...args: unknown[]) => updateCollectionMock(...args),
+    },
+    ContentError: MockContentError,
+    ValidationError: MockValidationError,
+  };
+});
+
+import { updateCollectionAction } from "@/actions/db/atrium/collection-management";
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  hasCapabilityAccessMock.mockResolvedValue(true);
+});
+
+describe("updateCollectionAction security gate ordering", () => {
+  it("authenticates before branching on a caller-controlled collection id", async () => {
+    getUserRequesterMock.mockRejectedValueOnce(new Error("authNoSession"));
+
+    const result = await updateCollectionAction("", {});
+
+    expect(result.isSuccess).toBe(false);
+    expect(getUserRequesterMock).toHaveBeenCalledTimes(1);
+    expect(hasCapabilityAccessMock).not.toHaveBeenCalled();
+    expect(updateCollectionMock).not.toHaveBeenCalled();
+  });
+
+  it("checks the Atrium capability before validating the collection id", async () => {
+    hasCapabilityAccessMock.mockResolvedValueOnce(false);
+
+    const result = await updateCollectionAction("", {});
+
+    expect(result.isSuccess).toBe(false);
+    expect(getUserRequesterMock).toHaveBeenCalledTimes(1);
+    expect(hasCapabilityAccessMock).toHaveBeenCalledWith(
+      "atrium-content",
+      "cognito-sub"
+    );
+    expect(updateCollectionMock).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/atrium-collection-management-migration.test.ts
+++ b/tests/unit/atrium-collection-management-migration.test.ts
@@ -35,5 +35,8 @@ describe("Atrium collection management migration", () => {
     expect(migration).toContain("UNIQUE (collection_id, access, grant_kind, grant_value)");
     expect(migration).toContain("'PSD Staff Intranet'");
     expect(migration).toContain("'psd-staff-intranet'");
+    expect(migration).toContain("2147483647");
+    expect(migration).toContain("generate_series(");
+    expect(migration).not.toContain("SELECT MAX(position) + 1");
   });
 });

--- a/tests/unit/atrium-collection-management-migration.test.ts
+++ b/tests/unit/atrium-collection-management-migration.test.ts
@@ -1,0 +1,36 @@
+import fs from "node:fs";
+import path from "node:path";
+
+const migrationName = "166-atrium-collection-management.sql";
+const migration = fs.readFileSync(
+  path.join(process.cwd(), "infra/database/schema", migrationName),
+  "utf8"
+);
+const manifest = JSON.parse(
+  fs.readFileSync(
+    path.join(process.cwd(), "infra/database/migrations.json"),
+    "utf8"
+  )
+) as { migrationFiles: string[] };
+
+describe("Atrium collection management migration", () => {
+  it("registers the additive migration and private-policy backstop", () => {
+    expect(manifest.migrationFiles).toContain(migrationName);
+    expect(migration).toContain("ADD COLUMN IF NOT EXISTS owner_user_id");
+    expect(migration).toContain("ADD COLUMN IF NOT EXISTS inherit_grants");
+    expect(migration).toContain("ADD COLUMN IF NOT EXISTS archived_at");
+    expect(migration).toMatch(
+      /owner_user_id IS NULL[\s\S]+default_visibility_level = 'private'[\s\S]+inherit_grants = false/
+    );
+  });
+
+  it("creates distinct view/create grants and seeds PSD Staff Intranet", () => {
+    expect(migration).toContain(
+      "CREATE TABLE IF NOT EXISTS content_collection_grants"
+    );
+    expect(migration).toContain("CHECK (access IN ('view', 'create'))");
+    expect(migration).toContain("UNIQUE (collection_id, access, grant_kind, grant_value)");
+    expect(migration).toContain("'PSD Staff Intranet'");
+    expect(migration).toContain("'psd-staff-intranet'");
+  });
+});

--- a/tests/unit/atrium-collection-management-migration.test.ts
+++ b/tests/unit/atrium-collection-management-migration.test.ts
@@ -17,6 +17,9 @@ describe("Atrium collection management migration", () => {
   it("registers the additive migration and private-policy backstop", () => {
     expect(manifest.migrationFiles).toContain(migrationName);
     expect(migration).toContain("ADD COLUMN IF NOT EXISTS owner_user_id");
+    expect(migration).toMatch(
+      /owner_user_id integer REFERENCES users\(id\) ON DELETE CASCADE/
+    );
     expect(migration).toContain("ADD COLUMN IF NOT EXISTS inherit_grants");
     expect(migration).toContain("ADD COLUMN IF NOT EXISTS archived_at");
     expect(migration).toMatch(

--- a/tests/unit/atrium-collection-management.test.ts
+++ b/tests/unit/atrium-collection-management.test.ts
@@ -1,0 +1,221 @@
+/** @jest-environment node */
+
+import { collectionManagementInternals } from "@/lib/content/collection-management-service";
+import type { Requester } from "@/lib/content/types";
+import type { CollectionAccessRow } from "@/lib/content/collection-access";
+
+const owner: Requester = {
+  kind: "user",
+  userId: 7,
+  roles: ["staff"],
+  isAdmin: false,
+};
+const other: Requester = {
+  kind: "user",
+  userId: 8,
+  roles: ["staff"],
+  isAdmin: false,
+};
+const admin: Requester = {
+  kind: "user",
+  userId: 1,
+  roles: ["administrator"],
+  isAdmin: true,
+};
+
+function row(
+  id: string,
+  values: Partial<CollectionAccessRow> = {}
+): CollectionAccessRow {
+  return {
+    id,
+    name: id,
+    slug: id,
+    parentId: null,
+    ownerUserId: null,
+    defaultVisibilityLevel: "internal",
+    inheritGrants: true,
+    position: 0,
+    archivedAt: null,
+    ...values,
+  };
+}
+
+describe("collection management hierarchy rules", () => {
+  it("rejects malformed collection ids before a UUID query can reach PostgreSQL", () => {
+    expect(() =>
+      collectionManagementInternals.assertCollectionId("not-a-uuid")
+    ).toThrow(/valid UUID/);
+    expect(() =>
+      collectionManagementInternals.assertCollectionId(
+        "f9999999-9999-4999-8999-999999999999"
+      )
+    ).not.toThrow();
+  });
+
+  it("separates district administration from private ownership", () => {
+    const district = row("district");
+    const privateRow = row("private", {
+      ownerUserId: 7,
+      defaultVisibilityLevel: "private",
+      inheritGrants: false,
+    });
+
+    expect(() =>
+      collectionManagementInternals.assertMayManage(admin, district)
+    ).not.toThrow();
+    expect(() =>
+      collectionManagementInternals.assertMayManage(owner, district)
+    ).toThrow(/Administrator authority/);
+    expect(() =>
+      collectionManagementInternals.assertMayManage(owner, privateRow)
+    ).not.toThrow();
+    expect(() =>
+      collectionManagementInternals.assertMayManage(admin, privateRow)
+    ).toThrow(/only private collections you own/);
+    expect(() =>
+      collectionManagementInternals.assertMayManage(other, privateRow)
+    ).toThrow(/Collection not found/);
+    expect(() =>
+      collectionManagementInternals.assertMayCreateScope(owner, "district")
+    ).toThrow(/Administrator authority/);
+    expect(
+      collectionManagementInternals.assertMayCreateScope(owner, "private")
+    ).toBe(7);
+    expect(
+      collectionManagementInternals.assertMayCreateScope(admin, "district")
+    ).toBeNull();
+  });
+
+  it("rejects cross-scope/cross-owner parents and hierarchy cycles", () => {
+    const district = row("district");
+    const privateRow = row("private", {
+      ownerUserId: 7,
+      defaultVisibilityLevel: "private",
+      inheritGrants: false,
+    });
+    const otherPrivate = row("other-private", {
+      ownerUserId: 8,
+      defaultVisibilityLevel: "private",
+      inheritGrants: false,
+    });
+    const child = row("child", { parentId: "district" });
+    const rows = new Map(
+      [district, privateRow, otherPrivate, child].map((item) => [item.id, item])
+    );
+
+    expect(() =>
+      collectionManagementInternals.assertParent(
+        rows,
+        "district",
+        "private",
+        7
+      )
+    ).toThrow(/cannot be mixed/);
+    expect(() =>
+      collectionManagementInternals.assertParent(
+        rows,
+        "other-private",
+        "private",
+        7
+      )
+    ).toThrow(/Parent collection not found/);
+    expect(() =>
+      collectionManagementInternals.assertNoCycle(rows, "district", "child")
+    ).toThrow(/cycle/);
+  });
+
+  it("detects name conflicts on move and walks archive subtrees once", () => {
+    const rows = [
+      row("root"),
+      row("first", { name: "Policies", parentId: "root" }),
+      row("second", { name: "Other", parentId: "root" }),
+      row("grandchild", { parentId: "first" }),
+    ];
+    expect(() =>
+      collectionManagementInternals.assertSiblingNameAvailable(
+        rows,
+        "POLICIES",
+        "root",
+        null,
+        "second"
+      )
+    ).toThrow(/already exists/);
+    expect(
+      collectionManagementInternals.descendantIds(rows, "root")
+    ).toEqual(expect.arrayContaining(["root", "first", "second", "grandchild"]));
+    expect(
+      new Set(collectionManagementInternals.descendantIds(rows, "root")).size
+    ).toBe(4);
+  });
+});
+
+describe("collection management naming and grants", () => {
+  it("scopes top-level name conflicts to district or the private owner", () => {
+    const rows = [
+      row("district", { name: "Projects" }),
+      row("owner-seven", { name: "Projects", ownerUserId: 7 }),
+      row("owner-eight", { name: "Other", ownerUserId: 8 }),
+    ];
+    expect(() =>
+      collectionManagementInternals.assertSiblingNameAvailable(
+        rows,
+        "Projects",
+        null,
+        8
+      )
+    ).not.toThrow();
+    expect(() =>
+      collectionManagementInternals.assertSiblingNameAvailable(
+        rows,
+        "Projects",
+        null,
+        7
+      )
+    ).toThrow(/already exists/);
+  });
+
+  it("namespaces private slugs so another owner's collision stays unobservable", () => {
+    const rows = [
+      row("owner-seven", {
+        name: "Projects",
+        slug: "private-7-projects",
+        ownerUserId: 7,
+      }),
+    ];
+    expect(
+      collectionManagementInternals.nextSlug(rows, "Projects", 8)
+    ).toBe("private-8-projects");
+    expect(
+      collectionManagementInternals.nextSlug(rows, "Projects", 7)
+    ).toBe("private-7-projects-1");
+  });
+
+  it("normalizes/deduplicates grants and rejects malformed group values", () => {
+    expect(
+      collectionManagementInternals.normalizeGrants([
+        {
+          access: "view",
+          kind: "group",
+          value: " STAFF@PSD401.NET ",
+        },
+        {
+          access: "view",
+          kind: "group",
+          value: "staff@psd401.net",
+        },
+      ])
+    ).toEqual([
+      {
+        access: "view",
+        kind: "group",
+        value: "staff@psd401.net",
+      },
+    ]);
+    expect(() =>
+      collectionManagementInternals.normalizeGrants([
+        { access: "create", kind: "group", value: "not-an-email" },
+      ])
+    ).toThrow(/group email/);
+  });
+});

--- a/tests/unit/atrium-collection-management.test.ts
+++ b/tests/unit/atrium-collection-management.test.ts
@@ -191,6 +191,29 @@ describe("collection management naming and grants", () => {
     ).toBe("private-7-projects-1");
   });
 
+  it("keeps owner-prefixed private slugs within the database column limit", () => {
+    const name = "a".repeat(200);
+    const first = collectionManagementInternals.nextSlug([], name, 7);
+    expect(first).toHaveLength(200);
+    expect(first.startsWith("private-7-")).toBe(true);
+
+    const collision = collectionManagementInternals.nextSlug(
+      [row("existing", { slug: first, ownerUserId: 7 })],
+      name,
+      7
+    );
+    expect(collision).toHaveLength(200);
+    expect(collision.endsWith("-1")).toBe(true);
+  });
+
+  it("allocates a safe position when a sibling already uses int4 max", () => {
+    const rows = [
+      row("max", { position: 2_147_483_647 }),
+      row("zero", { position: 0 }),
+    ];
+    expect(collectionManagementInternals.nextPosition(rows, null)).toBe(1);
+  });
+
   it("normalizes/deduplicates grants and rejects malformed group values", () => {
     expect(
       collectionManagementInternals.normalizeGrants([

--- a/tests/unit/atrium-collection-management.test.ts
+++ b/tests/unit/atrium-collection-management.test.ts
@@ -242,3 +242,141 @@ describe("collection management naming and grants", () => {
     ).toThrow(/group email/);
   });
 });
+
+describe("collection management group defaults", () => {
+  it("requires a direct or inherited effective view grant", () => {
+    const parent = row("parent");
+    const byId = new Map([[parent.id, parent]]);
+    const parentViewGrant = new Map([
+      [
+        parent.id,
+        [
+          {
+            access: "view" as const,
+            kind: "role" as const,
+            value: "staff",
+          },
+        ],
+      ],
+    ]);
+
+    expect(() =>
+      collectionManagementInternals.assertGroupDefaultHasEffectiveViewGrant(
+        {
+          level: "group",
+          parentId: null,
+          inheritGrants: true,
+          ownGrants: [],
+          byId,
+          directGrants: new Map(),
+        }
+      )
+    ).toThrow(/effective view grant/);
+    expect(() =>
+      collectionManagementInternals.assertGroupDefaultHasEffectiveViewGrant(
+        {
+          level: "group",
+          parentId: parent.id,
+          inheritGrants: true,
+          ownGrants: [],
+          byId,
+          directGrants: parentViewGrant,
+        }
+      )
+    ).not.toThrow();
+    expect(() =>
+      collectionManagementInternals.assertGroupDefaultHasEffectiveViewGrant(
+        {
+          level: "group",
+          parentId: parent.id,
+          inheritGrants: false,
+          ownGrants: [],
+          byId,
+          directGrants: parentViewGrant,
+        }
+      )
+    ).toThrow(/effective view grant/);
+    expect(() =>
+      collectionManagementInternals.assertGroupDefaultHasEffectiveViewGrant(
+        {
+          level: "group",
+          parentId: null,
+          inheritGrants: false,
+          ownGrants: [
+            { access: "create", kind: "role", value: "staff" },
+          ],
+          byId,
+          directGrants: new Map(),
+        }
+      )
+    ).toThrow(/effective view grant/);
+    expect(() =>
+      collectionManagementInternals.assertGroupDefaultHasEffectiveViewGrant(
+        {
+          level: "group",
+          parentId: null,
+          inheritGrants: false,
+          ownGrants: [{ access: "view", kind: "role", value: "staff" }],
+          byId,
+          directGrants: new Map(),
+        }
+      )
+    ).not.toThrow();
+  });
+
+  it("protects inherited group defaults throughout an updated subtree", () => {
+    const root = row("root");
+    const branch = row("branch", { parentId: root.id });
+    const groupChild = row("group-child", {
+      parentId: branch.id,
+      defaultVisibilityLevel: "group",
+    });
+    const rows = [root, branch, groupChild];
+    const rootViewGrant = new Map([
+      [
+        root.id,
+        [
+          {
+            access: "view" as const,
+            kind: "role" as const,
+            value: "staff",
+          },
+        ],
+      ],
+    ]);
+
+    expect(() =>
+      collectionManagementInternals.assertUpdatedSubtreeGroupDefaults({
+        rows,
+        collectionId: root.id,
+        parentId: null,
+        inheritGrants: true,
+        level: "internal",
+        ownGrants: [],
+        directGrants: rootViewGrant,
+      })
+    ).toThrow(/effective view grant/);
+    expect(() =>
+      collectionManagementInternals.assertUpdatedSubtreeGroupDefaults({
+        rows,
+        collectionId: branch.id,
+        parentId: root.id,
+        inheritGrants: false,
+        level: "internal",
+        ownGrants: [],
+        directGrants: rootViewGrant,
+      })
+    ).toThrow(/effective view grant/);
+    expect(() =>
+      collectionManagementInternals.assertUpdatedSubtreeGroupDefaults({
+        rows,
+        collectionId: branch.id,
+        parentId: root.id,
+        inheritGrants: true,
+        level: "internal",
+        ownGrants: [],
+        directGrants: rootViewGrant,
+      })
+    ).not.toThrow();
+  });
+});

--- a/tests/unit/atrium-collection-management.test.ts
+++ b/tests/unit/atrium-collection-management.test.ts
@@ -211,7 +211,22 @@ describe("collection management naming and grants", () => {
       row("max", { position: 2_147_483_647 }),
       row("zero", { position: 0 }),
     ];
-    expect(collectionManagementInternals.nextPosition(rows, null)).toBe(1);
+    expect(collectionManagementInternals.nextPosition(rows, null, null)).toBe(1);
+  });
+
+  it("allocates top-level positions only within the same owner hierarchy", () => {
+    const rows = [
+      row("district", { position: 4 }),
+      row("owner-seven-max", {
+        ownerUserId: 7,
+        position: 2_147_483_647,
+      }),
+      row("owner-eight", { ownerUserId: 8, position: 2 }),
+    ];
+
+    expect(collectionManagementInternals.nextPosition(rows, null, null)).toBe(5);
+    expect(collectionManagementInternals.nextPosition(rows, null, 7)).toBe(0);
+    expect(collectionManagementInternals.nextPosition(rows, null, 8)).toBe(3);
   });
 
   it("normalizes/deduplicates grants and rejects malformed group values", () => {

--- a/tests/unit/atrium-collection-tree.test.ts
+++ b/tests/unit/atrium-collection-tree.test.ts
@@ -31,6 +31,7 @@ let allCollections: Array<{
   archivedAt?: Date | null;
   navItemId: number | null;
   position: number;
+  viewAllowed?: boolean;
 }> = [];
 
 let visibleObjects: Array<{ collectionId: string | null }> = [];
@@ -85,8 +86,9 @@ jest.mock("@/lib/content/collection-access", () => ({
       collections
         .filter(
           (row) =>
-            row.ownerUserId == null ||
-            (req.kind === "user" && row.ownerUserId === req.userId)
+            row.viewAllowed !== false &&
+            (row.ownerUserId == null ||
+              (req.kind === "user" && row.ownerUserId === req.userId))
         )
         .map((row) => row.id)
     );
@@ -195,6 +197,45 @@ describe("collectionService.tree visibility filtering", () => {
     expect(tree).toHaveLength(1);
     expect(tree[0].id).toBe("root");
     expect(tree[0].children.map((c) => c.id)).toEqual(["child"]);
+  });
+
+  it("re-roots an admitted child without exposing a denied ancestor", async () => {
+    allCollections = [
+      {
+        id: "denied-root",
+        name: "Restricted Leadership",
+        slug: "restricted-leadership",
+        parentId: null,
+        defaultVisibilityLevel: "internal",
+        navItemId: null,
+        position: 0,
+        viewAllowed: false,
+      },
+      {
+        id: "admitted-child",
+        name: "Staff Handbook",
+        slug: "staff-handbook",
+        parentId: "denied-root",
+        defaultVisibilityLevel: "internal",
+        inheritGrants: false,
+        navItemId: null,
+        position: 0,
+      },
+    ];
+
+    const tree = await collectionService.tree(staff);
+
+    expect(tree).toHaveLength(1);
+    expect(tree[0]).toEqual(
+      expect.objectContaining({
+        id: "admitted-child",
+        name: "Staff Handbook",
+        parentId: null,
+      })
+    );
+    expect(JSON.stringify(tree)).not.toContain("denied-root");
+    expect(JSON.stringify(tree)).not.toContain("Restricted Leadership");
+    expect(JSON.stringify(tree)).not.toContain("restricted-leadership");
   });
 
   it("prunes an empty private subtree the requester cannot enter", async () => {

--- a/tests/unit/atrium-collection-tree.test.ts
+++ b/tests/unit/atrium-collection-tree.test.ts
@@ -26,6 +26,9 @@ let allCollections: Array<{
   slug: string;
   parentId: string | null;
   defaultVisibilityLevel: string;
+  ownerUserId?: number | null;
+  inheritGrants?: boolean;
+  archivedAt?: Date | null;
   navItemId: number | null;
   position: number;
 }> = [];
@@ -67,6 +70,40 @@ jest.mock("@/lib/content/visibility-service", () => ({
       return counts;
     }),
   },
+}));
+
+jest.mock("@/lib/content/collection-access", () => ({
+  collectionAccessSnapshot: jest.fn(
+    async (req: { kind: string; userId?: number | null }) => {
+    const collections = allCollections.map((row) => ({
+      ...row,
+      ownerUserId: row.ownerUserId ?? null,
+      inheritGrants: row.inheritGrants ?? true,
+      archivedAt: row.archivedAt ?? null,
+    }));
+    const allowedCollectionIds = new Set(
+      collections
+        .filter(
+          (row) =>
+            row.ownerUserId == null ||
+            (req.kind === "user" && row.ownerUserId === req.userId)
+        )
+        .map((row) => row.id)
+    );
+      return {
+        collections,
+        byId: new Map(collections.map((row) => [row.id, row])),
+        directGrants: new Map(),
+        effectiveGrants: () => [],
+        allowedCollectionIds,
+        selectableCollectionIds: new Set(
+          req.kind === "user" && req.userId != null
+            ? [...allowedCollectionIds]
+            : []
+        ),
+      };
+    }
+  ),
 }));
 
 import { collectionService } from "@/lib/content/collection-service";

--- a/tests/unit/atrium-collections-route.test.ts
+++ b/tests/unit/atrium-collections-route.test.ts
@@ -4,12 +4,17 @@ const mockCreateErrorResponse = jest.fn();
 const mockRequesterFromApiAuth = jest.fn();
 const mockDiscover = jest.fn();
 const mockHasScope = jest.fn();
+const mockParseRequestBody = jest.fn();
+const mockCreateCollection = jest.fn();
+const mockResolveRestRequester = jest.fn();
+const mockAssertContentAuthoringCapability = jest.fn();
 
 jest.mock("@/lib/api", () => ({
   withApiAuth: (handler: unknown) => handler,
   requireScope: (...args: unknown[]) => mockRequireScope(...args),
   createApiResponse: (...args: unknown[]) => mockCreateApiResponse(...args),
   createErrorResponse: (...args: unknown[]) => mockCreateErrorResponse(...args),
+  parseRequestBody: (...args: unknown[]) => mockParseRequestBody(...args),
 }));
 jest.mock("@/lib/api-keys/key-service", () => ({
   hasScope: (...args: unknown[]) => mockHasScope(...args),
@@ -18,21 +23,32 @@ jest.mock("@/lib/content", () => ({
   collectionService: {
     discover: (...args: unknown[]) => mockDiscover(...args),
   },
+  collectionManagementService: {
+    create: (...args: unknown[]) => mockCreateCollection(...args),
+  },
   requesterFromApiAuth: (...args: unknown[]) =>
     mockRequesterFromApiAuth(...args),
 }));
 jest.mock("@/lib/content/rest", () => ({
   contentErrorToResponse: jest.fn(),
+  createCollectionBodySchema: {},
+  resolveRestRequester: (...args: unknown[]) =>
+    mockResolveRestRequester(...args),
+}));
+jest.mock("@/lib/content/surface-helpers", () => ({
+  assertContentAuthoringCapability: (...args: unknown[]) =>
+    mockAssertContentAuthoringCapability(...args),
 }));
 
 import type { NextRequest } from "next/server";
-import { GET } from "@/app/api/v1/content/collections/route";
+import { GET, POST } from "@/app/api/v1/content/collections/route";
 
 const handler = GET as unknown as (
   request: NextRequest,
   auth: { scopes: string[] },
   requestId: string
 ) => Promise<unknown>;
+const postHandler = POST as unknown as typeof handler;
 const requester = {
   kind: "user",
   userId: 7,
@@ -57,6 +73,60 @@ beforeEach(() => {
     },
   ]);
   mockCreateApiResponse.mockReturnValue({ marker: "ok" });
+  mockParseRequestBody.mockResolvedValue({
+    data: { name: "My Projects", scope: "private" },
+  });
+  mockResolveRestRequester.mockResolvedValue({ req: requester });
+  mockCreateCollection.mockResolvedValue({
+    id: "collection-private",
+    name: "My Projects",
+    scope: "private",
+  });
+  mockAssertContentAuthoringCapability.mockResolvedValue(undefined);
+});
+
+describe("POST /api/v1/content/collections (#1438)", () => {
+  it("creates through the shared service with REST audit context", async () => {
+    await postHandler(
+      {
+        url: "https://app.test/api/v1/content/collections",
+      } as NextRequest,
+      { scopes: ["content:create"] },
+      "req-create"
+    );
+
+    expect(mockRequireScope).toHaveBeenCalledWith(
+      { scopes: ["content:create"] },
+      "content:create",
+      "req-create"
+    );
+    expect(mockAssertContentAuthoringCapability).toHaveBeenCalled();
+    expect(mockCreateCollection).toHaveBeenCalledWith(
+      requester,
+      { name: "My Projects", scope: "private" },
+      { surface: "rest", requestId: "req-create" }
+    );
+    expect(mockCreateApiResponse).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ id: "collection-private" }),
+      }),
+      "req-create",
+      201
+    );
+  });
+
+  it("returns the scope error before parsing the request body", async () => {
+    mockRequireScope.mockReturnValue({ marker: "scope-error" });
+    await postHandler(
+      {
+        url: "https://app.test/api/v1/content/collections",
+      } as NextRequest,
+      { scopes: [] },
+      "req-denied"
+    );
+    expect(mockParseRequestBody).not.toHaveBeenCalled();
+    expect(mockCreateCollection).not.toHaveBeenCalled();
+  });
 });
 
 describe("GET /api/v1/content/collections (#1286)", () => {

--- a/tests/unit/atrium-collections-route.test.ts
+++ b/tests/unit/atrium-collections-route.test.ts
@@ -82,25 +82,31 @@ beforeEach(() => {
     name: "My Projects",
     scope: "private",
   });
-  mockAssertContentAuthoringCapability.mockResolvedValue(undefined);
+  mockAssertContentAuthoringCapability.mockRejectedValue(
+    new Error("UI capability checks must not gate REST endpoints")
+  );
 });
 
 describe("POST /api/v1/content/collections (#1438)", () => {
-  it("creates through the shared service with REST audit context", async () => {
+  it("uses the API scope without applying a UI capability gate", async () => {
     await postHandler(
       {
         url: "https://app.test/api/v1/content/collections",
       } as NextRequest,
-      { scopes: ["content:create"] },
+      {
+        scopes: ["content:create"],
+        authType: "session",
+        cognitoSub: "cognito-sub",
+      } as { scopes: string[] },
       "req-create"
     );
 
     expect(mockRequireScope).toHaveBeenCalledWith(
-      { scopes: ["content:create"] },
+      expect.objectContaining({ scopes: ["content:create"] }),
       "content:create",
       "req-create"
     );
-    expect(mockAssertContentAuthoringCapability).toHaveBeenCalled();
+    expect(mockAssertContentAuthoringCapability).not.toHaveBeenCalled();
     expect(mockCreateCollection).toHaveBeenCalledWith(
       requester,
       { name: "My Projects", scope: "private" },

--- a/tests/unit/atrium-content-collection-atomicity.test.ts
+++ b/tests/unit/atrium-content-collection-atomicity.test.ts
@@ -1,0 +1,236 @@
+/** @jest-environment node */
+
+let mode: "create" | "update" = "create";
+let outsideRows: Array<Array<Record<string, unknown>>> = [];
+let insertedValues: Record<string, unknown> | null = null;
+let updatedValues: Record<string, unknown> | null = null;
+
+const collectionAccessSnapshotMock = jest.fn();
+const collectionAccessSnapshotInTxMock = jest.fn();
+jest.mock("@/lib/content/collection-access", () => ({
+  collectionAccessSnapshot: (...args: unknown[]) =>
+    collectionAccessSnapshotMock(...args),
+  collectionAccessSnapshotInTx: (...args: unknown[]) =>
+    collectionAccessSnapshotInTxMock(...args),
+}));
+
+const applyGrantsForLevelMock = jest.fn(
+  async (..._args: unknown[]) => undefined
+);
+jest.mock("@/lib/content/visibility-service", () => ({
+  visibilityService: {
+    canView: jest.fn(async () => true),
+    assertWritableLevel: jest.fn(),
+    applyGrantsForLevel: (...args: unknown[]) =>
+      applyGrantsForLevelMock(...args),
+  },
+}));
+
+const lockedObject = {
+  id: "11111111-1111-1111-1111-111111111111",
+  kind: "document",
+  title: "Existing",
+  slug: "existing",
+  ownerUserId: 7,
+  collectionId: null,
+  visibilityLevel: "private",
+  status: "draft",
+  tags: [],
+};
+
+const lockedLimitMock = jest.fn(async () => [lockedObject]);
+const lockedForMock = jest.fn(() => ({ limit: lockedLimitMock }));
+const selectWhereMock = jest.fn(() =>
+  mode === "create"
+    ? Promise.resolve([])
+    : { for: lockedForMock }
+);
+const selectFromMock = jest.fn(() => ({ where: selectWhereMock }));
+const insertReturningMock = jest.fn(async () => [
+  {
+    id: "22222222-2222-2222-2222-222222222222",
+    ...(insertedValues ?? {}),
+  },
+]);
+const insertValuesMock = jest.fn((values: Record<string, unknown>) => {
+  insertedValues = values;
+  return { returning: insertReturningMock };
+});
+const updateReturningMock = jest.fn(async () => [
+  { ...lockedObject, ...(updatedValues ?? {}) },
+]);
+const updateWhereMock = jest.fn(() => ({
+  returning: updateReturningMock,
+}));
+const updateSetMock = jest.fn((values: Record<string, unknown>) => {
+  updatedValues = values;
+  return { where: updateWhereMock };
+});
+const txStub = {
+  select: jest.fn(() => ({ from: selectFromMock })),
+  insert: jest.fn(() => ({
+    values: insertValuesMock,
+  })),
+  update: jest.fn(() => ({
+    set: updateSetMock,
+  })),
+};
+
+jest.mock("@/lib/db/drizzle-client", () => ({
+  executeQuery: jest.fn(async () => outsideRows.shift() ?? []),
+  executeTransaction: jest.fn(
+    async (callback: (tx: unknown) => Promise<unknown>) => callback(txStub)
+  ),
+}));
+jest.mock("@/lib/db/schema", () => ({
+  contentAuditLogs: {},
+  contentCollections: {},
+  contentObjects: { id: {}, slug: {} },
+  contentPublications: {},
+  contentVersions: {},
+  navigationItems: {},
+}));
+jest.mock("@/lib/db/json-utils", () => ({
+  safeJsonbStringify: (value: unknown) => JSON.stringify(value),
+}));
+jest.mock("drizzle-orm", () => ({
+  and: (...args: unknown[]) => args,
+  count: (value: unknown) => value,
+  eq: (...args: unknown[]) => args,
+  gte: (...args: unknown[]) => args,
+  isNull: (value: unknown) => value,
+  like: (...args: unknown[]) => args,
+  sql: Object.assign((..._args: unknown[]) => ({}), { join: () => ({}) }),
+}));
+jest.mock("@/lib/content/mappers", () => ({
+  objectSelectFields: {},
+  rowToObjectDTO: (row: Record<string, unknown>) => row,
+}));
+jest.mock("@/lib/content/version-service", () => ({
+  snapshotInTx: jest.fn(),
+  versionService: { flushSnapshotWrites: jest.fn(async () => undefined) },
+}));
+jest.mock("@/lib/content/agent-screening", () => ({
+  screenAgentBodyForWrite: jest.fn(async () => null),
+}));
+jest.mock("@/lib/content/events", () => ({
+  contentEvents: { emit: jest.fn(async () => undefined) },
+}));
+
+import { contentService } from "@/lib/content/content-service";
+import { ForbiddenError } from "@/lib/content/errors";
+import type {
+  CollectionGrant,
+  Requester,
+  VisibilityLevel,
+} from "@/lib/content/types";
+
+const requester: Requester = {
+  kind: "user",
+  userId: 7,
+  roles: ["staff"],
+  isAdmin: false,
+};
+const collectionId = "33333333-3333-3333-3333-333333333333";
+
+function accessSnapshot(input: {
+  level?: VisibilityLevel;
+  archived?: boolean;
+  selectable?: boolean;
+  grants?: CollectionGrant[];
+}) {
+  const collection = {
+    id: collectionId,
+    name: "Policies",
+    slug: "policies",
+    parentId: null,
+    ownerUserId: null,
+    defaultVisibilityLevel: input.level ?? "internal",
+    inheritGrants: true,
+    position: 0,
+    archivedAt: input.archived ? new Date() : null,
+  };
+  return {
+    collections: [collection],
+    byId: new Map([[collectionId, collection]]),
+    directGrants: new Map(),
+    effectiveGrants: jest.fn(() => input.grants ?? []),
+    allowedCollectionIds: new Set([collectionId]),
+    selectableCollectionIds: new Set(
+      input.selectable === false ? [] : [collectionId]
+    ),
+  };
+}
+
+beforeEach(() => {
+  mode = "create";
+  outsideRows = [];
+  insertedValues = null;
+  updatedValues = null;
+  jest.clearAllMocks();
+  collectionAccessSnapshotMock.mockResolvedValue(accessSnapshot({}));
+  collectionAccessSnapshotInTxMock.mockResolvedValue(accessSnapshot({}));
+});
+
+describe("content collection placement transaction boundary", () => {
+  it("rejects a create when access is revoked after preflight", async () => {
+    collectionAccessSnapshotInTxMock.mockResolvedValue(
+      accessSnapshot({ archived: true, selectable: false })
+    );
+
+    await expect(
+      contentService.create(requester, {
+        kind: "document",
+        title: "Policy",
+        collectionId,
+      })
+    ).rejects.toBeInstanceOf(ForbiddenError);
+
+    expect(collectionAccessSnapshotInTxMock).toHaveBeenCalledWith(
+      txStub,
+      requester
+    );
+    expect(txStub.insert).not.toHaveBeenCalled();
+  });
+
+  it("persists the locked current default and grants, not stale preflight values", async () => {
+    const viewGrant: CollectionGrant = {
+      access: "view",
+      kind: "role",
+      value: "staff",
+    };
+    collectionAccessSnapshotInTxMock.mockResolvedValue(
+      accessSnapshot({ level: "group", grants: [viewGrant] })
+    );
+
+    await contentService.create(requester, {
+      kind: "document",
+      title: "Policy",
+      collectionId,
+    });
+
+    expect(insertedValues?.visibilityLevel).toBe("group");
+    expect(applyGrantsForLevelMock.mock.calls[0][3]).toEqual([
+      { kind: "role", value: "staff" },
+    ]);
+  });
+
+  it("rejects a move when target access is revoked before the update", async () => {
+    mode = "update";
+    outsideRows = [[lockedObject]];
+    collectionAccessSnapshotInTxMock.mockResolvedValue(
+      accessSnapshot({ selectable: false })
+    );
+
+    await expect(
+      contentService.update(requester, lockedObject.id, { collectionId })
+    ).rejects.toBeInstanceOf(ForbiddenError);
+
+    expect(collectionAccessSnapshotInTxMock).toHaveBeenCalledWith(
+      txStub,
+      requester
+    );
+    expect(txStub.update).not.toHaveBeenCalled();
+    expect(updatedValues).toBeNull();
+  });
+});

--- a/tests/unit/atrium-embed-resolver.test.ts
+++ b/tests/unit/atrium-embed-resolver.test.ts
@@ -39,6 +39,10 @@ let canViewResult = false;
 jest.mock("@/lib/content/visibility-service", () => ({
   visibilityService: { canView: jest.fn(async () => canViewResult) },
 }));
+let mayViewCollection = true;
+jest.mock("@/lib/content/collection-access", () => ({
+  requesterMayViewCollection: jest.fn(async () => mayViewCollection),
+}));
 
 // A viewable artifact loads its current head code; default to a version + code so the
 // positive-control test can assert a live render. Overridden per test where needed.
@@ -87,6 +91,7 @@ beforeEach(() => {
   queuedRows = [];
   queuedPublicationRows = [{ publishedVersionId: "pv1" }];
   canViewResult = false;
+  mayViewCollection = true;
   currentVersion = { id: "v1" };
   publishedVersion = { id: "pv1" };
   artifactCode = "<h1>live</h1>";
@@ -163,6 +168,7 @@ describe("resolveEmbedForReader resolves a viewable artifact", () => {
     id: ARTIFACT_ID,
     kind: "artifact" as const,
     ownerUserId: 9,
+    collectionId: "public-collection",
     visibilityLevel: "public" as const,
     title: "Metrics",
     slug: "metrics",
@@ -185,6 +191,15 @@ describe("resolveEmbedForReader resolves a viewable artifact", () => {
     const res = await resolveEmbedForReader(ARTIFACT_ID, { audience: "public" });
     expect(res.available).toBe(true);
     expect(res.href).toBe("/p/metrics");
+  });
+
+  it("public: masks an artifact in a collection anonymous users cannot enter", async () => {
+    queuedRows = [artifactRow];
+    mayViewCollection = false;
+    const res = await resolveEmbedForReader(ARTIFACT_ID, {
+      audience: "public",
+    });
+    expect(res).toEqual(expectedMask(ARTIFACT_ID));
   });
 
   it("public: renders the PUBLISHED version, never the live head", async () => {

--- a/tests/unit/atrium-embed-resolver.test.ts
+++ b/tests/unit/atrium-embed-resolver.test.ts
@@ -40,8 +40,16 @@ jest.mock("@/lib/content/visibility-service", () => ({
   visibilityService: { canView: jest.fn(async () => canViewResult) },
 }));
 let mayViewCollection = true;
+const sharedCollectionAccess = {
+  allowedCollectionIds: new Set(["public-collection"]),
+};
+const collectionAccessSnapshotMock = jest.fn(
+  async () => sharedCollectionAccess
+);
 jest.mock("@/lib/content/collection-access", () => ({
   requesterMayViewCollection: jest.fn(async () => mayViewCollection),
+  collectionAccessSnapshot: (...args: unknown[]) =>
+    collectionAccessSnapshotMock(...(args as [])),
 }));
 
 // A viewable artifact loads its current head code; default to a version + code so the
@@ -72,11 +80,19 @@ jest.mock("@/lib/content/artifact-sandbox-config", () => ({
 }));
 // document-parts pulls the heavy unified/rehype render pipeline (ESM, not needed for
 // resolveEmbedForReader); stub it so the module loads cheaply under jest.
+let mockRenderedDocumentParts: Array<
+  | { kind: "html"; html: string }
+  | { kind: "embed"; artifactId: string }
+> = [];
 jest.mock("@/lib/content/render/document-parts", () => ({
-  renderDocumentToParts: () => [],
+  renderDocumentToParts: () => mockRenderedDocumentParts,
 }));
 
-import { resolveEmbedForReader, type ResolvedEmbed } from "@/lib/content/embed-resolver";
+import {
+  resolveDocumentParts,
+  resolveEmbedForReader,
+  type ResolvedEmbed,
+} from "@/lib/content/embed-resolver";
 import type { Requester } from "@/lib/content/types";
 
 const ARTIFACT_ID = "3f2504e0-4f89-41d3-9a0c-0305e82c3301";
@@ -95,6 +111,7 @@ beforeEach(() => {
   currentVersion = { id: "v1" };
   publishedVersion = { id: "pv1" };
   artifactCode = "<h1>live</h1>";
+  mockRenderedDocumentParts = [];
   jest.clearAllMocks();
 });
 
@@ -178,11 +195,17 @@ describe("resolveEmbedForReader resolves a viewable artifact", () => {
     queuedRows = [artifactRow];
     canViewResult = true;
     const res = await resolveEmbedForReader(ARTIFACT_ID, { audience: "internal", requester });
+    const { requesterMayViewCollection } = jest.requireMock(
+      "@/lib/content/collection-access"
+    ) as {
+      requesterMayViewCollection: jest.Mock;
+    };
     expect(res.available).toBe(true);
     expect(res.title).toBe("Metrics");
     expect(res.href).toBe("/c/metrics");
     expect(res.code).toBe("<h1>live</h1>");
     expect(res.sandboxSrc).toBe("https://sandbox.example");
+    expect(requesterMayViewCollection).not.toHaveBeenCalled();
   });
 
   it("public: a public artifact resolves with a /p/ href and consults NO session gate", async () => {
@@ -199,6 +222,17 @@ describe("resolveEmbedForReader resolves a viewable artifact", () => {
     const res = await resolveEmbedForReader(ARTIFACT_ID, {
       audience: "public",
     });
+    expect(res).toEqual(expectedMask(ARTIFACT_ID));
+  });
+
+  it("public: ignores a caller-supplied authenticated collection snapshot", async () => {
+    queuedRows = [artifactRow];
+    mayViewCollection = false;
+    const res = await resolveEmbedForReader(ARTIFACT_ID, {
+      audience: "public",
+      collectionAccess: sharedCollectionAccess as never,
+    });
+
     expect(res).toEqual(expectedMask(ARTIFACT_ID));
   });
 
@@ -248,5 +282,35 @@ describe("resolveEmbedForReader resolves a viewable artifact", () => {
     const res = await resolveEmbedForReader(ARTIFACT_ID, { audience: "internal", requester });
     expect(res.available).toBe(true);
     expect(res.code).toBe("");
+  });
+
+  it("shares one collection snapshot across every embed in a document", async () => {
+    queuedRows = [artifactRow];
+    canViewResult = true;
+    mockRenderedDocumentParts = [
+      { kind: "embed", artifactId: ARTIFACT_ID },
+      { kind: "embed", artifactId: ARTIFACT_ID },
+    ];
+
+    const parts = await resolveDocumentParts("unused", {
+      audience: "internal",
+      requester,
+    });
+    const { visibilityService } = jest.requireMock(
+      "@/lib/content/visibility-service"
+    ) as {
+      visibilityService: { canView: jest.Mock };
+    };
+
+    expect(parts).toHaveLength(2);
+    expect(collectionAccessSnapshotMock).toHaveBeenCalledTimes(1);
+    expect(collectionAccessSnapshotMock).toHaveBeenCalledWith(requester);
+    expect(visibilityService.canView).toHaveBeenCalledTimes(2);
+    expect(visibilityService.canView.mock.calls[0][2]).toBe(
+      sharedCollectionAccess
+    );
+    expect(visibilityService.canView.mock.calls[1][2]).toBe(
+      sharedCollectionAccess
+    );
   });
 });

--- a/tests/unit/atrium-list-visible-filters.test.ts
+++ b/tests/unit/atrium-list-visible-filters.test.ts
@@ -44,6 +44,11 @@ jest.mock("@/lib/db/drizzle-helpers", () => ({
   pgTimestampAsText: (c: unknown) => c,
   stripJsonQuotes: (v: unknown) => v,
 }));
+jest.mock("@/lib/content/collection-access", () => ({
+  collectionAccessSnapshot: jest.fn(async () => ({
+    allowedCollectionIds: new Set<string>(),
+  })),
+}));
 
 /** A captured sql`` invocation: raw template chunks + interpolated values. */
 interface CapturedSql {

--- a/tests/unit/atrium-okf-import.test.ts
+++ b/tests/unit/atrium-okf-import.test.ts
@@ -26,22 +26,35 @@ jest.mock("@/lib/content/content-service", () => ({
   },
 }));
 
-// executeQuery serves createCollection (nested dirs). The root-only tests pass a
-// targetCollectionId, so no fresh collection is created there.
-jest.mock("@/lib/db/drizzle-client", () => ({
-  executeQuery: jest.fn(async () => [{ id: "coll-new" }]),
+const mockCollectionCreate = jest.fn(async (..._args: unknown[]) => ({
+  id: "coll-new",
 }));
-
-jest.mock("@/lib/db/schema", () => ({
-  contentCollections: { id: "contentCollections.id" },
+jest.mock("@/lib/content/collection-management-service", () => ({
+  collectionManagementService: {
+    create: (...args: unknown[]) => mockCollectionCreate(...args),
+  },
+}));
+jest.mock("@/lib/content/collection-access", () => ({
+  collectionOwnerUserId: (req: { kind: string; userId?: number }) =>
+    req.kind === "user" ? req.userId ?? null : null,
+  collectionAccessSnapshot: jest.fn(async () => ({
+    byId: new Map([
+      [
+        "target-coll",
+        {
+          id: "target-coll",
+          ownerUserId: null,
+        },
+      ],
+    ]),
+    selectableCollectionIds: new Set(["target-coll"]),
+  })),
 }));
 
 import { contentService } from "@/lib/content/content-service";
-import { executeQuery } from "@/lib/db/drizzle-client";
 import { okfImportService, ATRIUM_IMPORT_AGENT_ID } from "@/lib/content/okf/import";
 
 const createMock = contentService.create as jest.Mock;
-const executeQueryMock = executeQuery as jest.Mock;
 import { buildConceptFile, type ConceptSource } from "@/lib/content/okf/serialize";
 import { serializeFrontmatter } from "@/lib/content/okf/frontmatter";
 import { OKF_INDEX_FILE } from "@/lib/content/okf/profile";
@@ -69,7 +82,7 @@ const docSource: ConceptSource = {
 describe("okfImportService.importBundle — provenance + safe defaults", () => {
   beforeEach(() => {
     createMock.mockClear();
-    executeQueryMock.mockClear();
+    mockCollectionCreate.mockClear();
   });
 
   it("reconstructs every ancestor collection for a nested concept path", async () => {
@@ -79,7 +92,12 @@ describe("okfImportService.importBundle — provenance + safe defaults", () => {
       files: [{ path: "math/algebra/equations.md", content: buildConceptFile(docSource) }],
     });
     // createCollection is issued for the root ("") + "math" + "math/algebra" = 3.
-    expect(executeQueryMock).toHaveBeenCalledTimes(3);
+    expect(mockCollectionCreate).toHaveBeenCalledTimes(3);
+    expect(mockCollectionCreate).toHaveBeenCalledWith(
+      userCaller,
+      expect.objectContaining({ scope: "private" }),
+      {}
+    );
     // The concept lands in the deepest reconstructed collection.
     const [, input] = createMock.mock.calls[0];
     expect(input.collectionId).toBe("coll-new");
@@ -95,11 +113,12 @@ describe("okfImportService.importBundle — provenance + safe defaults", () => {
     });
 
     expect(createMock).toHaveBeenCalledTimes(1);
-    const [req, input] = createMock.mock.calls[0];
-    // The WRITE identity is the importer agent — NOT the human caller.
-    expect((req as Requester).kind).toBe("agent-autonomous");
-    expect((req as { agentId: string }).agentId).toBe(ATRIUM_IMPORT_AGENT_ID);
-    expect((req as { kind: string }).kind).not.toBe("user");
+    const [req, input, options] = createMock.mock.calls[0];
+    // Ownership/authorization stays with the caller while provenance is the
+    // seeded importer agent.
+    expect(req).toBe(userCaller);
+    expect(options.attributionRequester.kind).toBe("agent-autonomous");
+    expect(options.attributionRequester.agentId).toBe(ATRIUM_IMPORT_AGENT_ID);
 
     // Mapped fields round-trip from the exporter's concept file.
     expect(input.kind).toBe("document");
@@ -194,5 +213,22 @@ describe("okfImportService.importBundle — provenance + safe defaults", () => {
       })
     ).rejects.toBeInstanceOf(ForbiddenError);
     expect(createMock).not.toHaveBeenCalled();
+  });
+
+  it("prevents autonomous callers from minting ownerless/shared hierarchy", async () => {
+    const autonomous: Requester = {
+      kind: "agent-autonomous",
+      agentId: "some-agent",
+      roleId: null,
+      roles: [],
+      scopes: ["content:create"],
+      agentLabel: "scoped-agent",
+    };
+    await expect(
+      okfImportService.importBundle(autonomous, {
+        files: [{ path: "a.md", content: buildConceptFile(docSource) }],
+      })
+    ).rejects.toBeInstanceOf(ForbiddenError);
+    expect(mockCollectionCreate).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/atrium-public-reader-page.test.tsx
+++ b/tests/unit/atrium-public-reader-page.test.tsx
@@ -4,9 +4,9 @@
  *
  * The public reader at `app/(public)/p/[slug]/page.tsx` is the anonymous, world-
  * readable surface. Its security contract is stricter than the internal reader:
- *   - it consults NO session/requester,
+ *   - it consults NO session-dependent requester,
  *   - it renders ONLY an object whose `visibility_level === 'public'` AND that has
- *     a LIVE `public_web` publication,
+ *     a LIVE `public_web` publication in a collection open to an anonymous user,
  *   - every other case (absent slug, non-public object, no live public_web
  *     publication, dangling version) resolves to `notFound()` (404) — NEVER 403,
  *     so a probe cannot distinguish "exists but not public" from "absent".
@@ -66,6 +66,11 @@ jest.mock("drizzle-orm", () => ({
 jest.mock("@/lib/content/visibility-service", () => ({
   visibilityService: { canView: jest.fn() },
 }));
+const requesterMayViewCollectionMock = jest.fn();
+jest.mock("@/lib/content/collection-access", () => ({
+  requesterMayViewCollection: (...args: unknown[]) =>
+    requesterMayViewCollectionMock(...args),
+}));
 
 const getByIdMock = jest.fn();
 const loadArtifactCodeMock = jest.fn();
@@ -114,12 +119,14 @@ const PUBLIC_OBJ = {
   id: "obj-1",
   kind: "document",
   title: "Public Doc",
+  collectionId: "collection-public",
   visibilityLevel: "public",
 };
 const INTERNAL_OBJ = {
   id: "obj-2",
   kind: "document",
   title: "Internal Doc",
+  collectionId: "collection-internal",
   visibilityLevel: "internal",
 };
 const PUBLICATION_ROW = { publishedVersionId: "ver-1" };
@@ -133,6 +140,7 @@ beforeEach(() => {
   getByIdMock.mockReset();
   getTextMock.mockReset();
   loadArtifactCodeMock.mockReset();
+  requesterMayViewCollectionMock.mockReset().mockResolvedValue(true);
   mockNotFound.mockClear();
 });
 
@@ -169,6 +177,20 @@ describe("Atrium public reader page — anonymous 404 masking", () => {
 
     expect(mockNotFound).toHaveBeenCalledTimes(1);
     expect(executeQueryMock).toHaveBeenCalledTimes(2);
+    expect(getByIdMock).not.toHaveBeenCalled();
+  });
+
+  it("404s public content in a collection the anonymous requester cannot enter", async () => {
+    executeQueryMock.mockResolvedValueOnce([PUBLIC_OBJ]);
+    requesterMayViewCollectionMock.mockResolvedValue(false);
+
+    await expect(render()).rejects.toBe(NOT_FOUND_SENTINEL);
+
+    expect(requesterMayViewCollectionMock).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: null, roles: [] }),
+      "collection-public"
+    );
+    expect(executeQueryMock).toHaveBeenCalledTimes(1);
     expect(getByIdMock).not.toHaveBeenCalled();
   });
 

--- a/tests/unit/atrium-public-visibility-gate.test.ts
+++ b/tests/unit/atrium-public-visibility-gate.test.ts
@@ -23,10 +23,9 @@
 // --- mocks (hoisted above imports by jest) ---
 
 let executeTransactionCalls = 0;
-// A queue of canned executeQuery results (e.g. the collection-default lookup);
-// each call shifts the next, falling back to [] — lets a test drive
-// `collectionDefaultOutsideTx` to a specific default_visibility_level.
-let executeQueryResults: unknown[] = [];
+// Canned rows for the collection access resolver. Label routing keeps its two
+// parallel reads deterministic.
+let collectionRowsResult: unknown[] = [];
 
 // A chainable tx proxy: awaited terminals `.limit()` / `.returning()` yield the
 // next queued result; every other builder method keeps the chain fluent. This
@@ -61,8 +60,11 @@ jest.mock("@/lib/db/drizzle-client", () => ({
       return cb(txProxy);
     }
   ),
-  executeQuery: jest.fn(async () => {
-    return executeQueryResults.length > 0 ? executeQueryResults.shift() : [];
+  executeQuery: jest.fn(async (_cb: unknown, label: string) => {
+    if (label === "collectionAccess.loadCollections") {
+      return collectionRowsResult;
+    }
+    return [];
   }),
 }));
 
@@ -142,7 +144,7 @@ beforeEach(() => {
   txUpdateCalls = 0;
   emitCalls = [];
   txResults = [];
-  executeQueryResults = [];
+  collectionRowsResult = [];
   // An autonomous agent owns content as the configured system user (§26.5). With
   // create-as-private (issue #1118), an autonomous public create now proceeds to
   // the write path (owner = system user) instead of short-circuiting at the old
@@ -193,7 +195,19 @@ describe("§26.4 create-as-private — contentService.create with visibility.lev
     // The seeded `public-site` collection has default_visibility_level = 'public',
     // so a create into it with NO explicit visibility resolves to "public" via the
     // collection default — the same create-as-private downgrade applies.
-    executeQueryResults = [[{ level: "public" }]]; // collection-default lookup -> public
+    collectionRowsResult = [
+      {
+        id: "col-public-site",
+        name: "Public site",
+        slug: "public-site",
+        parentId: null,
+        ownerUserId: null,
+        defaultVisibilityLevel: "public",
+        inheritGrants: true,
+        position: 0,
+        archivedAt: null,
+      },
+    ];
     await expect(
       contentService.create(staffUser, {
         kind: "document",

--- a/tests/unit/atrium-resolve-collection.test.ts
+++ b/tests/unit/atrium-resolve-collection.test.ts
@@ -12,6 +12,8 @@
  */
 
 let queue: Array<Array<{ id: string }>> = [];
+const requesterMayViewCollectionMock = jest.fn();
+const requesterMayCreateInCollectionMock = jest.fn();
 
 jest.mock("@/lib/db/drizzle-client", () => ({
   executeQuery: jest.fn(async () => queue.shift() ?? []),
@@ -22,6 +24,12 @@ jest.mock("@/lib/db/schema", () => ({
 }));
 
 jest.mock("drizzle-orm", () => ({ eq: (...a: unknown[]) => a }));
+jest.mock("@/lib/content/collection-access", () => ({
+  requesterMayViewCollection: (...args: unknown[]) =>
+    requesterMayViewCollectionMock(...args),
+  requesterMayCreateInCollection: (...args: unknown[]) =>
+    requesterMayCreateInCollectionMock(...args),
+}));
 
 const mockHasCapabilityAccess = jest.fn(async (..._args: unknown[]) => true);
 jest.mock("@/utils/roles", () => ({
@@ -36,45 +44,72 @@ import {
 import { ForbiddenError, ValidationError } from "@/lib/content/errors";
 
 const UUID = "11111111-1111-1111-1111-111111111111";
+const requester = {
+  kind: "user" as const,
+  userId: 7,
+  roles: ["staff"],
+  isAdmin: false,
+};
 
 beforeEach(() => {
   queue = [];
   jest.clearAllMocks();
   mockHasCapabilityAccess.mockResolvedValue(true);
+  requesterMayViewCollectionMock.mockResolvedValue(true);
+  requesterMayCreateInCollectionMock.mockResolvedValue(true);
 });
 
 describe("resolveCollectionId", () => {
   it("returns undefined when no collection is supplied", async () => {
-    expect(await resolveCollectionId(undefined)).toBeUndefined();
-    expect(await resolveCollectionId(null)).toBeUndefined();
-    expect(await resolveCollectionId("")).toBeUndefined();
+    expect(await resolveCollectionId(requester, undefined, "view")).toBeUndefined();
+    expect(await resolveCollectionId(requester, null, "view")).toBeUndefined();
+    expect(await resolveCollectionId(requester, "", "view")).toBeUndefined();
   });
 
   it("resolves a uuid that exists as an id", async () => {
     queue = [[{ id: UUID }]];
-    expect(await resolveCollectionId(UUID)).toBe(UUID);
+    expect(await resolveCollectionId(requester, UUID, "view")).toBe(UUID);
+    expect(requesterMayViewCollectionMock).toHaveBeenCalledWith(requester, UUID);
   });
 
   it("falls back to a slug lookup when a uuid-shaped value is not an id", async () => {
     // First call (id lookup) empty, second call (slug lookup) hits — a slug can
     // itself be uuid-shaped.
     queue = [[], [{ id: "c-2" }]];
-    expect(await resolveCollectionId(UUID)).toBe("c-2");
+    expect(await resolveCollectionId(requester, UUID, "view")).toBe("c-2");
   });
 
   it("throws ValidationError (not a raw FK 500) when a uuid matches nothing", async () => {
     queue = [[], []];
-    await expect(resolveCollectionId(UUID)).rejects.toThrow(ValidationError);
+    await expect(
+      resolveCollectionId(requester, UUID, "view")
+    ).rejects.toThrow(ValidationError);
   });
 
   it("resolves a slug that exists", async () => {
     queue = [[{ id: "c-3" }]];
-    expect(await resolveCollectionId("high-school")).toBe("c-3");
+    expect(
+      await resolveCollectionId(requester, "high-school", "create")
+    ).toBe("c-3");
+    expect(requesterMayCreateInCollectionMock).toHaveBeenCalledWith(
+      requester,
+      "c-3"
+    );
   });
 
   it("throws ValidationError when a slug matches nothing", async () => {
     queue = [[]];
-    await expect(resolveCollectionId("nope")).rejects.toThrow(ValidationError);
+    await expect(
+      resolveCollectionId(requester, "nope", "view")
+    ).rejects.toThrow(ValidationError);
+  });
+
+  it("masks an inaccessible private collection exactly like an absent one", async () => {
+    queue = [[{ id: "private-other-owner" }]];
+    requesterMayViewCollectionMock.mockResolvedValue(false);
+    await expect(
+      resolveCollectionId(requester, "private-slug", "view")
+    ).rejects.toThrow("Collection not found");
   });
 });
 

--- a/tests/unit/atrium-retrieval-permission-aware.test.ts
+++ b/tests/unit/atrium-retrieval-permission-aware.test.ts
@@ -78,6 +78,24 @@ jest.mock("@/lib/db/drizzle-client", () => ({
         return loadAssistantScopeResult;
       case "content.grantsFor":
         return grantsForResult;
+      case "collectionAccess.loadCollections":
+        return [
+          {
+            id: "col-hs-staff",
+            name: "High School Staff",
+            slug: "high-school-staff",
+            parentId: null,
+            ownerUserId: null,
+            defaultVisibilityLevel: "group",
+            inheritGrants: true,
+            position: 0,
+            archivedAt: null,
+          },
+        ];
+      case "collectionAccess.loadGrants":
+        // No collection-level rows preserves the legacy district-wide boundary;
+        // the object-level role/group grants below remain the predicate under test.
+        return [];
       default:
         return [];
     }

--- a/tests/unit/atrium-retrieval-permission-aware.test.ts
+++ b/tests/unit/atrium-retrieval-permission-aware.test.ts
@@ -174,6 +174,12 @@ import { s3Store } from "@/lib/content/storage/s3-store";
 import { visibilityService } from "@/lib/content/visibility-service";
 import type { Requester } from "@/lib/content/types";
 
+const executeQueryMock = (
+  jest.requireMock("@/lib/db/drizzle-client") as {
+    executeQuery: jest.Mock;
+  }
+).executeQuery;
+
 // The mocked s3Store.getText, retrieved from the mocked module so §16.3 tests
 // can assert it is (not) called without dereferencing it in a hoisted factory.
 const getTextMock = s3Store.getText as jest.Mock;
@@ -336,6 +342,14 @@ describe("§16.2 permission-aware search — the safety boundary", () => {
       // The draft hit was dropped by the cheap pre-filter — no canView DB call.
       const checkedIds = canViewSpy.mock.calls.map(([, obj]) => obj.id);
       expect(checkedIds).toEqual(["obj-1", "obj-3"]);
+      const snapshots = canViewSpy.mock.calls.map(([, , access]) => access);
+      expect(snapshots[0]).toBeDefined();
+      expect(snapshots[1]).toBe(snapshots[0]);
+      expect(
+        executeQueryMock.mock.calls.filter(
+          ([, label]) => label === "collectionAccess.loadCollections"
+        )
+      ).toHaveLength(1);
     } finally {
       canViewSpy.mockRestore();
     }

--- a/tests/unit/atrium-sitemap.test.ts
+++ b/tests/unit/atrium-sitemap.test.ts
@@ -1,11 +1,11 @@
 /**
  * Unit tests for app/sitemap.ts (Epic #1059 — Atrium public reader SEO).
  *
- * The security-relevant assertion is the QUERY GATE: the sitemap must filter on
- * exactly the /p/[slug] public-gate conditions (visibility_level='public' AND a
- * live public_web publication) plus the status='published' subset guard — so it
- * can never advertise a URL the public reader would 404 (existence leak +
- * crawler soft-404s).
+ * The security-relevant assertion is the complete gate: the query requires
+ * visibility_level='public', a live public_web publication, and published
+ * lifecycle; the result is then filtered through the anonymous collection
+ * snapshot. The sitemap therefore cannot advertise a URL the public reader
+ * would 404 (existence leak + crawler soft-404s).
  *
  * Also covered: the fail-soft contract (empty sitemap + log.warn on a DB error
  * or a missing ATRIUM_PUBLIC_BASE_URL — never a throw) and the entry mapping
@@ -26,6 +26,7 @@ jest.mock("@/lib/db/schema", () => ({
     id: "co.id",
     slug: "co.slug",
     updatedAt: "co.updated_at",
+    collectionId: "co.collection_id",
     visibilityLevel: "co.visibility_level",
     status: "co.status",
   },
@@ -45,6 +46,11 @@ jest.mock("drizzle-orm", () => ({
 // a deterministic absolute URL.
 jest.mock("@/lib/content/surface-helpers", () => ({
   publicReaderLink: (slug: string) => `https://app.test/p/${slug}`,
+}));
+const collectionAccessSnapshotMock = jest.fn();
+jest.mock("@/lib/content/collection-access", () => ({
+  collectionAccessSnapshot: (...args: unknown[]) =>
+    collectionAccessSnapshotMock(...args),
 }));
 
 const mockWarn = jest.fn();
@@ -93,6 +99,9 @@ const ORIGINAL_BASE = process.env.ATRIUM_PUBLIC_BASE_URL;
 beforeEach(() => {
   jest.clearAllMocks();
   process.env.ATRIUM_PUBLIC_BASE_URL = "https://app.test";
+  collectionAccessSnapshotMock.mockResolvedValue({
+    allowedCollectionIds: new Set(["visible-collection"]),
+  });
 });
 
 afterAll(() => {
@@ -128,8 +137,17 @@ describe("app/sitemap.ts — Atrium public reader sitemap", () => {
   it("maps rows to publicReaderLink URLs with lastModified", async () => {
     const updatedAt = new Date("2026-07-01T12:00:00Z");
     stubQuery([
-      { slug: "ai-guidelines", updatedAt },
-      { slug: "no-timestamp", updatedAt: null },
+      {
+        slug: "ai-guidelines",
+        updatedAt,
+        collectionId: "visible-collection",
+      },
+      { slug: "no-timestamp", updatedAt: null, collectionId: null },
+      {
+        slug: "hidden-collection-item",
+        updatedAt: null,
+        collectionId: "hidden-collection",
+      },
     ]);
 
     const entries = await sitemap();

--- a/tests/unit/atrium-visibility.test.ts
+++ b/tests/unit/atrium-visibility.test.ts
@@ -7,6 +7,7 @@
  */
 
 const executeQueryMock = jest.fn();
+const requesterMayViewCollectionMock = jest.fn(async () => true);
 jest.mock("@/lib/db/drizzle-client", () => ({
   executeQuery: (...args: unknown[]) => executeQueryMock(...args),
   // listVisible references these types only; provide inert stand-ins.
@@ -20,7 +21,8 @@ jest.mock("@/lib/db/schema", () => ({
   users: { id: {}, firstName: {}, lastName: {}, email: {} },
 }));
 jest.mock("@/lib/content/collection-access", () => ({
-  requesterMayViewCollection: jest.fn(async () => true),
+  requesterMayViewCollection: (...args: unknown[]) =>
+    requesterMayViewCollectionMock(...(args as [])),
   collectionAccessSnapshot: jest.fn(async () => ({
     allowedCollectionIds: new Set<string>(),
   })),
@@ -98,6 +100,8 @@ const roledAgent: Requester = {
 
 beforeEach(() => {
   executeQueryMock.mockReset();
+  requesterMayViewCollectionMock.mockClear();
+  requesterMayViewCollectionMock.mockResolvedValue(true);
 });
 
 describe("canView — public", () => {
@@ -106,6 +110,20 @@ describe("canView — public", () => {
     expect(await visibilityService.canView(staffUser, obj("public"))).toBe(true);
     // No grant lookup needed for public.
     expect(executeQueryMock).not.toHaveBeenCalled();
+  });
+
+  it("uses a supplied collection snapshot without reloading collection access", async () => {
+    const collectionAccess = {
+      allowedCollectionIds: new Set(["collection-1"]),
+    };
+    const visible = await visibilityService.canView(
+      staffUser,
+      { ...obj("public"), collectionId: "collection-1" },
+      collectionAccess as never
+    );
+
+    expect(visible).toBe(true);
+    expect(requesterMayViewCollectionMock).not.toHaveBeenCalled();
   });
 });
 

--- a/tests/unit/atrium-visibility.test.ts
+++ b/tests/unit/atrium-visibility.test.ts
@@ -14,9 +14,16 @@ jest.mock("@/lib/db/drizzle-client", () => ({
 }));
 jest.mock("@/lib/db/schema", () => ({
   contentObjects: {},
+  contentCollections: { id: {}, ownerUserId: {} },
   contentVisibilityGrants: {},
   // listVisible LEFT JOINs users to project the owner display name (#1052).
   users: { id: {}, firstName: {}, lastName: {}, email: {} },
+}));
+jest.mock("@/lib/content/collection-access", () => ({
+  requesterMayViewCollection: jest.fn(async () => true),
+  collectionAccessSnapshot: jest.fn(async () => ({
+    allowedCollectionIds: new Set<string>(),
+  })),
 }));
 jest.mock("@/lib/db/drizzle-helpers", () => ({
   pgTimestampAsText: (c: unknown) => c,
@@ -50,7 +57,7 @@ function obj(
   visibilityLevel: "private" | "group" | "internal" | "public",
   ownerUserId = OWNER_ID
 ) {
-  return { id: "obj-1", ownerUserId, visibilityLevel };
+  return { id: "obj-1", ownerUserId, collectionId: null, visibilityLevel };
 }
 
 const staffUser: Requester = {
@@ -406,6 +413,15 @@ describe("setLevelInTx — level + grant write semantics", () => {
     // (`clearNonUserGrantsInTx` → `and(eq(objectId), ne(kind, "user"))`).
     const deletes: unknown[] = [];
     const tx = {
+      select: () => ({
+        from: () => ({
+          leftJoin: () => ({
+            where: () => ({
+              limit: async () => [{ ownerUserId: null }],
+            }),
+          }),
+        }),
+      }),
       delete: () => ({
         where: async (clause: unknown) => {
           deletes.push(clause);


### PR DESCRIPTION
## Description

Implements Atrium collection management end-to-end for district/shared and owner-bound private hierarchies.

- Adds hierarchical create, rename, move, reorder, recursive archive, and recursive restore.
- Adds separate inherited `view` and `create` collection grants for district collections.
- Adds owner-bound private collections that remain private, carry no broad grants, and are invisible to other users.
- Enforces the collection boundary across object reads, lists, counts, writes, public readers, sitemap generation, embeds, OKF import, REST, MCP, and agent operations.
- Adds the administrator collection panel and the library's **New private collection** workflow.
- Adds REST and `psd-atrium` collection commands plus complete API/feature documentation.
- Combines active requester-visible collections (including accessible
  district/shared rows) with archived manageable rows in the owner-authorized
  `psd-atrium list-collections` command, preserving both normal discovery and
  recoverable restore targets across invocations.

Closes #1438

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update
- [ ] Bug fix
- [ ] Breaking change
- [ ] Infrastructure change (CDK/AWS)

## Security and authority model

- District hierarchy mutation requires administrator authority.
- Private hierarchy mutation is owner-only; administrators may inspect metadata but cannot read contents or mutate another user's private tree.
- Inaccessible collection identifiers are existence-masked.
- Private collection content is forced to private visibility and owner-homogeneous placement.
- Content create/move re-authorizes placement, current defaults, and inherited grants under collection locks in the same transaction as the object write.
- Collection ACLs are permission-pushed into list/filter/count queries so hidden collection content cannot leak through metadata or totals.
- Public reader, sitemap, and public embed paths use a fixed anonymous requester and reject archived or restricted collections.
- Human/delegated OKF imports retain caller ownership and authorization while preserving importer-agent provenance.
- Collection mutation actions authenticate and capability-gate before branching on caller-controlled identifiers.

## Database migration

Migration `166-atrium-collection-management.sql`:

- adds `owner_user_id`, `inherit_grants`, and `archived_at` to `content_collections`;
- adds normalized `content_collection_grants`;
- adds database checks/indexes and owner FK constraints;
- preserves existing collections as active district collections;
- idempotently seeds **PSD Staff Intranet**;
- uses an overflow-safe bounded gap allocator if the top-level position reaches
  the PostgreSQL `integer` maximum;
- is registered in `infra/database/migrations.json`.

Fresh initialization, strict replay, seed fixtures, real PostgreSQL visibility
smokes, and the `2147483647` position boundary were validated in isolated
pgvector containers.

## Testing

- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run test:ci` — 526 suites passed; 4,854 tests passed; 15 policy-skipped
- [x] `bun run test:skill:atrium` — 54 passed
- [x] `bun run openapi:check`
- [x] `bun run migration:list` — migration 166 registered
- [x] `bun run build`
- [x] CodeQL analysis and PR security check — passed; no open code-scanning alerts
- [x] Real-DB group visibility smoke — 9 checks passed
- [x] Real-DB reference visibility smoke — 2 checks passed
- [x] Production-build Playwright, `--workers=1 --retries=0` — 19/19 passed
- [x] Final-head isolated affected Playwright — all 20 distinct collection/API paths passed; one cold dev-hydration timeout after a successful create passed immediately on the focused warm retry
- [x] Repository pre-push Playwright suite — 300 passed, 40 policy-skipped; two first-attempt dev-harness flakes passed on retry. The collection test's cold-compiler timeout received explicit multi-step workflow headroom in the final commit and was then revalidated against the production build with retries disabled.

## Checklist

- [x] No `console.*` calls added to production/shared Next.js code
- [x] No `@/lib/logger` imports in client components
- [x] Types/interfaces follow project conventions; no `any`
- [x] Database fields use snake_case
- [x] TypeScript strict mode passes
- [x] Documentation and API references updated
- [x] New server actions return `ActionState<T>`
- [x] Business authority remains in the shared service layer
- [x] Database queries are parameterized through Drizzle
- [x] App builds and runs without module errors

## Screenshots

Not attached: the management views expose seeded local identities and collection metadata. Both staff-owner and administrator UI workflows are covered by authenticated browser tests.
