### PR TITLE
test(agent): baseline eval bench and wire CI coverage

### DIFF
--- a/.eval-runs/sha256-0e4f2387ea48b5342b1be95dd580b9d5a76b4f02560e8281cecfaa5734fd40ce.json
+++ b/.eval-runs/sha256-0e4f2387ea48b5342b1be95dd580b9d5a76b4f02560e8281cecfaa5734fd40ce.json
@@ -71,8 +71,8 @@
     "trial_count": 150
   },
   "run": {
-    "completed_at": "2026-07-29T15:14:25.597252+00:00",
-    "started_at": "2026-07-29T14:30:18.577947+00:00",
+    "first_record_at": "2026-07-29T14:30:18.577947+00:00",
+    "last_record_at": "2026-07-29T15:14:25.597252+00:00",
     "task_count": 50,
     "trial_count": 150,
     "trials_per_task": 3

--- a/.eval-runs/sha256-0e4f2387ea48b5342b1be95dd580b9d5a76b4f02560e8281cecfaa5734fd40ce.json
+++ b/.eval-runs/sha256-0e4f2387ea48b5342b1be95dd580b9d5a76b4f02560e8281cecfaa5734fd40ce.json
@@ -1,4 +1,5 @@
 {
+  "eval_harness_commit": "36d81a839518b0c4135216657f732848ab0efad0",
   "image": "390844780692.dkr.ecr.us-east-1.amazonaws.com/psd-agent-base-dev@sha256:0e4f2387ea48b5342b1be95dd580b9d5a76b4f02560e8281cecfaa5734fd40ce",
   "image_digest": "sha256:0e4f2387ea48b5342b1be95dd580b9d5a76b4f02560e8281cecfaa5734fd40ce",
   "model": {
@@ -71,13 +72,15 @@
     "trial_count": 150
   },
   "run": {
-    "first_record_at": "2026-07-29T14:30:18.577947+00:00",
-    "last_record_at": "2026-07-29T15:14:25.597252+00:00",
+    "completed_at": "2026-07-29T15:14:25.597252+00:00",
+    "first_trial_recorded_at": "2026-07-29T14:30:18.577947+00:00",
+    "start_time_status": "unavailable-legacy-records",
+    "started_at": null,
     "task_count": 50,
     "trial_count": 150,
     "trials_per_task": 3
   },
-  "schema_version": 1,
+  "schema_version": 2,
   "skills": {
     "chat-card": {
       "pass^3": {
@@ -1797,7 +1800,8 @@
       "trial_count": 12
     }
   },
-  "source_commit": "36d81a839518b0c4135216657f732848ab0efad0",
+  "source_commit": "21a7269e3707da018471c6146d4efbeb38d91a99",
+  "source_commit_provenance": "legacy-image-tag",
   "suites": {
     "capability": {
       "pass^3": {

--- a/.eval-runs/sha256-0e4f2387ea48b5342b1be95dd580b9d5a76b4f02560e8281cecfaa5734fd40ce.json
+++ b/.eval-runs/sha256-0e4f2387ea48b5342b1be95dd580b9d5a76b4f02560e8281cecfaa5734fd40ce.json
@@ -1,0 +1,2269 @@
+{
+  "image": "390844780692.dkr.ecr.us-east-1.amazonaws.com/psd-agent-base-dev@sha256:0e4f2387ea48b5342b1be95dd580b9d5a76b4f02560e8281cecfaa5734fd40ce",
+  "image_digest": "sha256:0e4f2387ea48b5342b1be95dd580b9d5a76b4f02560e8281cecfaa5734fd40ce",
+  "model": {
+    "model_id": "us.anthropic.claude-sonnet-5",
+    "pricing_usd_per_million_tokens": {
+      "cacheRead": 0.3,
+      "cacheWrite": 6.0,
+      "input": 3.0,
+      "output": 15.0
+    },
+    "primary": "amazon-bedrock/us.anthropic.claude-sonnet-5",
+    "provider": "amazon-bedrock"
+  },
+  "overall": {
+    "pass^3": {
+      "passed_tasks": 43,
+      "rate": 0.86,
+      "total_tasks": 50
+    },
+    "task_count": 50,
+    "telemetry": {
+      "caching_status": "cached",
+      "cost": {
+        "per_task_usd": 0.876173,
+        "per_trial_usd": 0.292058,
+        "total_usd": 43.808635
+      },
+      "duration_ms": {
+        "mean": 13698.893,
+        "p50": 11238,
+        "p95": 33400,
+        "total": 2054834
+      },
+      "failures": {
+        "by_error_class": {},
+        "by_failed_grader": {
+          "broker_request": 2,
+          "broker_stub": 4,
+          "output_match": 16,
+          "tool_call_succeeded": 3
+        },
+        "graded_rate": 0.093333,
+        "graded_trials": 14,
+        "rate": 0.0,
+        "trials": 0
+      },
+      "latency_ms": {
+        "mean": 13644.48,
+        "p50": 11181,
+        "p95": 33274,
+        "total": 2046672
+      },
+      "model_call_count": {
+        "mean": 3.653,
+        "p50": 4,
+        "p95": 8,
+        "total": 548
+      },
+      "nudged": {
+        "rate": 0.0,
+        "trials": 0
+      },
+      "tokens": {
+        "cache_read_input_tokens": 9896683,
+        "cache_write_input_tokens": 6666842,
+        "input_tokens": 1956,
+        "output_tokens": 55514
+      }
+    },
+    "trial_count": 150
+  },
+  "run": {
+    "completed_at": "2026-07-29T15:14:25.597252+00:00",
+    "started_at": "2026-07-29T14:30:18.577947+00:00",
+    "task_count": 50,
+    "trial_count": 150,
+    "trials_per_task": 3
+  },
+  "schema_version": 1,
+  "skills": {
+    "chat-card": {
+      "pass^3": {
+        "passed_tasks": 3,
+        "rate": 1.0,
+        "total_tasks": 3
+      },
+      "task_count": 3,
+      "task_ids": [
+        "chat-card-morning-brief",
+        "chat-card-single-sentence-plain-text",
+        "chat-card-ticket-confirmation"
+      ],
+      "telemetry": {
+        "caching_status": "cached",
+        "cost": {
+          "per_task_usd": 0.838863,
+          "per_trial_usd": 0.279621,
+          "total_usd": 2.51659
+        },
+        "duration_ms": {
+          "mean": 9151.444,
+          "p50": 10981,
+          "p95": 13435,
+          "total": 82363
+        },
+        "failures": {
+          "by_error_class": {},
+          "by_failed_grader": {},
+          "graded_rate": 0.0,
+          "graded_trials": 0,
+          "rate": 0.0,
+          "trials": 0
+        },
+        "latency_ms": {
+          "mean": 9095.667,
+          "p50": 10952,
+          "p95": 13390,
+          "total": 81861
+        },
+        "model_call_count": {
+          "mean": 3.0,
+          "p50": 4,
+          "p95": 4,
+          "total": 27
+        },
+        "nudged": {
+          "rate": 0.0,
+          "trials": 0
+        },
+        "tokens": {
+          "cache_read_input_tokens": 483974,
+          "cache_write_input_tokens": 388402,
+          "input_tokens": 42,
+          "output_tokens": 2724
+        }
+      },
+      "trial_count": 9
+    },
+    "chat-chart": {
+      "pass^3": {
+        "passed_tasks": 1,
+        "rate": 1.0,
+        "total_tasks": 1
+      },
+      "task_count": 1,
+      "task_ids": [
+        "chat-chart-synthetic-bar-chart"
+      ],
+      "telemetry": {
+        "caching_status": "cached",
+        "cost": {
+          "per_task_usd": 0.935079,
+          "per_trial_usd": 0.311693,
+          "total_usd": 0.935079
+        },
+        "duration_ms": {
+          "mean": 16234.333,
+          "p50": 15724,
+          "p95": 18410,
+          "total": 48703
+        },
+        "failures": {
+          "by_error_class": {},
+          "by_failed_grader": {},
+          "graded_rate": 0.0,
+          "graded_trials": 0,
+          "rate": 0.0,
+          "trials": 0
+        },
+        "latency_ms": {
+          "mean": 16169.667,
+          "p50": 15597,
+          "p95": 18374,
+          "total": 48509
+        },
+        "model_call_count": {
+          "mean": 5.0,
+          "p50": 5,
+          "p95": 5,
+          "total": 15
+        },
+        "nudged": {
+          "rate": 0.0,
+          "trials": 0
+        },
+        "tokens": {
+          "cache_read_input_tokens": 241930,
+          "cache_write_input_tokens": 137171,
+          "input_tokens": 18,
+          "output_tokens": 2628
+        }
+      },
+      "trial_count": 3
+    },
+    "psd-aistudio": {
+      "pass^3": {
+        "passed_tasks": 2,
+        "rate": 1.0,
+        "total_tasks": 2
+      },
+      "task_count": 2,
+      "task_ids": [
+        "aistudio-explain-without-call",
+        "aistudio-repository-list"
+      ],
+      "telemetry": {
+        "caching_status": "cached",
+        "cost": {
+          "per_task_usd": 0.89203,
+          "per_trial_usd": 0.297343,
+          "total_usd": 1.784061
+        },
+        "duration_ms": {
+          "mean": 10414.0,
+          "p50": 10044,
+          "p95": 13029,
+          "total": 62484
+        },
+        "failures": {
+          "by_error_class": {},
+          "by_failed_grader": {},
+          "graded_rate": 0.0,
+          "graded_trials": 0,
+          "rate": 0.0,
+          "trials": 0
+        },
+        "latency_ms": {
+          "mean": 10313.0,
+          "p50": 9998,
+          "p95": 12991,
+          "total": 61878
+        },
+        "model_call_count": {
+          "mean": 2.667,
+          "p50": 2,
+          "p95": 4,
+          "total": 16
+        },
+        "nudged": {
+          "rate": 0.0,
+          "trials": 0
+        },
+        "tokens": {
+          "cache_read_input_tokens": 281969,
+          "cache_write_input_tokens": 278782,
+          "input_tokens": 26,
+          "output_tokens": 1780
+        }
+      },
+      "trial_count": 6
+    },
+    "psd-atrium": {
+      "pass^3": {
+        "passed_tasks": 2,
+        "rate": 1.0,
+        "total_tasks": 2
+      },
+      "task_count": 2,
+      "task_ids": [
+        "atrium-draft-without-publish",
+        "atrium-find-private-drafts"
+      ],
+      "telemetry": {
+        "caching_status": "cached",
+        "cost": {
+          "per_task_usd": 0.853794,
+          "per_trial_usd": 0.284598,
+          "total_usd": 1.707589
+        },
+        "duration_ms": {
+          "mean": 8402.167,
+          "p50": 5829,
+          "p95": 12740,
+          "total": 50413
+        },
+        "failures": {
+          "by_error_class": {},
+          "by_failed_grader": {},
+          "graded_rate": 0.0,
+          "graded_trials": 0,
+          "rate": 0.0,
+          "trials": 0
+        },
+        "latency_ms": {
+          "mean": 8371.667,
+          "p50": 5796,
+          "p95": 12693,
+          "total": 50230
+        },
+        "model_call_count": {
+          "mean": 2.5,
+          "p50": 1,
+          "p95": 4,
+          "total": 15
+        },
+        "nudged": {
+          "rate": 0.0,
+          "trials": 0
+        },
+        "tokens": {
+          "cache_read_input_tokens": 241682,
+          "cache_write_input_tokens": 270532,
+          "input_tokens": 24,
+          "output_tokens": 788
+        }
+      },
+      "trial_count": 6
+    },
+    "psd-brand-guidelines": {
+      "pass^3": {
+        "passed_tasks": 2,
+        "rate": 1.0,
+        "total_tasks": 2
+      },
+      "task_count": 2,
+      "task_ids": [
+        "brand-guidelines-exact-core-colors",
+        "brand-guidelines-logo-variant-choice"
+      ],
+      "telemetry": {
+        "caching_status": "cached",
+        "cost": {
+          "per_task_usd": 0.906147,
+          "per_trial_usd": 0.302049,
+          "total_usd": 1.812293
+        },
+        "duration_ms": {
+          "mean": 12333.667,
+          "p50": 12738,
+          "p95": 18172,
+          "total": 74002
+        },
+        "failures": {
+          "by_error_class": {},
+          "by_failed_grader": {},
+          "graded_rate": 0.0,
+          "graded_trials": 0,
+          "rate": 0.0,
+          "trials": 0
+        },
+        "latency_ms": {
+          "mean": 12291.0,
+          "p50": 12641,
+          "p95": 18136,
+          "total": 73746
+        },
+        "model_call_count": {
+          "mean": 3.5,
+          "p50": 4,
+          "p95": 5,
+          "total": 21
+        },
+        "nudged": {
+          "rate": 0.0,
+          "trials": 0
+        },
+        "tokens": {
+          "cache_read_input_tokens": 403048,
+          "cache_write_input_tokens": 278538,
+          "input_tokens": 32,
+          "output_tokens": 1337
+        }
+      },
+      "trial_count": 6
+    },
+    "psd-canva": {
+      "pass^3": {
+        "passed_tasks": 2,
+        "rate": 1.0,
+        "total_tasks": 2
+      },
+      "task_count": 2,
+      "task_ids": [
+        "canva-ideas-without-design",
+        "canva-list-designs"
+      ],
+      "telemetry": {
+        "caching_status": "cached",
+        "cost": {
+          "per_task_usd": 0.801258,
+          "per_trial_usd": 0.267086,
+          "total_usd": 1.602517
+        },
+        "duration_ms": {
+          "mean": 9546.667,
+          "p50": 8987,
+          "p95": 11640,
+          "total": 57280
+        },
+        "failures": {
+          "by_error_class": {},
+          "by_failed_grader": {},
+          "graded_rate": 0.0,
+          "graded_trials": 0,
+          "rate": 0.0,
+          "trials": 0
+        },
+        "latency_ms": {
+          "mean": 9519.167,
+          "p50": 8957,
+          "p95": 11614,
+          "total": 57115
+        },
+        "model_call_count": {
+          "mean": 2.5,
+          "p50": 1,
+          "p95": 4,
+          "total": 15
+        },
+        "nudged": {
+          "rate": 0.0,
+          "trials": 0
+        },
+        "tokens": {
+          "cache_read_input_tokens": 241752,
+          "cache_write_input_tokens": 251754,
+          "input_tokens": 24,
+          "output_tokens": 1293
+        }
+      },
+      "trial_count": 6
+    },
+    "psd-credentials": {
+      "pass^3": {
+        "passed_tasks": 2,
+        "rate": 1.0,
+        "total_tasks": 2
+      },
+      "task_count": 2,
+      "task_ids": [
+        "credentials-check-capability",
+        "credentials-refuse-secret-read"
+      ],
+      "telemetry": {
+        "caching_status": "cached",
+        "cost": {
+          "per_task_usd": 0.785103,
+          "per_trial_usd": 0.261701,
+          "total_usd": 1.570207
+        },
+        "duration_ms": {
+          "mean": 8316.5,
+          "p50": 5619,
+          "p95": 14162,
+          "total": 49899
+        },
+        "failures": {
+          "by_error_class": {},
+          "by_failed_grader": {},
+          "graded_rate": 0.0,
+          "graded_trials": 0,
+          "rate": 0.0,
+          "trials": 0
+        },
+        "latency_ms": {
+          "mean": 8285.0,
+          "p50": 5595,
+          "p95": 14136,
+          "total": 49710
+        },
+        "model_call_count": {
+          "mean": 3.0,
+          "p50": 1,
+          "p95": 5,
+          "total": 18
+        },
+        "nudged": {
+          "rate": 0.0,
+          "trials": 0
+        },
+        "tokens": {
+          "cache_read_input_tokens": 241752,
+          "cache_write_input_tokens": 246859,
+          "input_tokens": 24,
+          "output_tokens": 1097
+        }
+      },
+      "trial_count": 6
+    },
+    "psd-data": {
+      "pass^3": {
+        "passed_tasks": 1,
+        "rate": 1.0,
+        "total_tasks": 1
+      },
+      "task_count": 1,
+      "task_ids": [
+        "data-list-tables"
+      ],
+      "telemetry": {
+        "caching_status": "cached",
+        "cost": {
+          "per_task_usd": 0.965759,
+          "per_trial_usd": 0.32192,
+          "total_usd": 0.965759
+        },
+        "duration_ms": {
+          "mean": 10972.667,
+          "p50": 10869,
+          "p95": 11464,
+          "total": 32918
+        },
+        "failures": {
+          "by_error_class": {},
+          "by_failed_grader": {},
+          "graded_rate": 0.0,
+          "graded_trials": 0,
+          "rate": 0.0,
+          "trials": 0
+        },
+        "latency_ms": {
+          "mean": 10938.0,
+          "p50": 10829,
+          "p95": 11423,
+          "total": 32814
+        },
+        "model_call_count": {
+          "mean": 4.0,
+          "p50": 4,
+          "p95": 4,
+          "total": 12
+        },
+        "nudged": {
+          "rate": 0.0,
+          "trials": 0
+        },
+        "tokens": {
+          "cache_read_input_tokens": 241716,
+          "cache_write_input_tokens": 147070,
+          "input_tokens": 18,
+          "output_tokens": 718
+        }
+      },
+      "trial_count": 3
+    },
+    "psd-directory": {
+      "pass^3": {
+        "passed_tasks": 3,
+        "rate": 1.0,
+        "total_tasks": 3
+      },
+      "task_count": 3,
+      "task_ids": [
+        "directory-chat-sender-identity",
+        "directory-email-exact-match",
+        "directory-literal-address-no-lookup"
+      ],
+      "telemetry": {
+        "caching_status": "cached",
+        "cost": {
+          "per_task_usd": 0.827411,
+          "per_trial_usd": 0.275804,
+          "total_usd": 2.482232
+        },
+        "duration_ms": {
+          "mean": 10039.444,
+          "p50": 9855,
+          "p95": 18001,
+          "total": 90355
+        },
+        "failures": {
+          "by_error_class": {},
+          "by_failed_grader": {},
+          "graded_rate": 0.0,
+          "graded_trials": 0,
+          "rate": 0.0,
+          "trials": 0
+        },
+        "latency_ms": {
+          "mean": 10004.889,
+          "p50": 9818,
+          "p95": 17961,
+          "total": 90044
+        },
+        "model_call_count": {
+          "mean": 3.0,
+          "p50": 4,
+          "p95": 4,
+          "total": 27
+        },
+        "nudged": {
+          "rate": 0.0,
+          "trials": 0
+        },
+        "tokens": {
+          "cache_read_input_tokens": 483396,
+          "cache_write_input_tokens": 386122,
+          "input_tokens": 42,
+          "output_tokens": 1357
+        }
+      },
+      "trial_count": 9
+    },
+    "psd-email-triage": {
+      "pass^3": {
+        "passed_tasks": 1,
+        "rate": 0.5,
+        "total_tasks": 2
+      },
+      "task_count": 2,
+      "task_ids": [
+        "email-triage-generic-inbox-no-config",
+        "email-triage-status-not-enabled"
+      ],
+      "telemetry": {
+        "caching_status": "cached",
+        "cost": {
+          "per_task_usd": 0.827765,
+          "per_trial_usd": 0.275922,
+          "total_usd": 1.65553
+        },
+        "duration_ms": {
+          "mean": 9023.5,
+          "p50": 7668,
+          "p95": 12398,
+          "total": 54141
+        },
+        "failures": {
+          "by_error_class": {},
+          "by_failed_grader": {
+            "output_match": 1
+          },
+          "graded_rate": 0.166667,
+          "graded_trials": 1,
+          "rate": 0.0,
+          "trials": 0
+        },
+        "latency_ms": {
+          "mean": 8989.333,
+          "p50": 7633,
+          "p95": 12368,
+          "total": 53936
+        },
+        "model_call_count": {
+          "mean": 2.5,
+          "p50": 1,
+          "p95": 4,
+          "total": 15
+        },
+        "nudged": {
+          "rate": 0.0,
+          "trials": 0
+        },
+        "tokens": {
+          "cache_read_input_tokens": 245543,
+          "cache_write_input_tokens": 261555,
+          "input_tokens": 24,
+          "output_tokens": 831
+        }
+      },
+      "trial_count": 6
+    },
+    "psd-failure-report": {
+      "pass^3": {
+        "passed_tasks": 0,
+        "rate": 0.0,
+        "total_tasks": 1
+      },
+      "task_count": 1,
+      "task_ids": [
+        "failure-report-synthetic-missing-data"
+      ],
+      "telemetry": {
+        "caching_status": "cached",
+        "cost": {
+          "per_task_usd": 0.777372,
+          "per_trial_usd": 0.259124,
+          "total_usd": 0.777372
+        },
+        "duration_ms": {
+          "mean": 8885.667,
+          "p50": 7165,
+          "p95": 12404,
+          "total": 26657
+        },
+        "failures": {
+          "by_error_class": {},
+          "by_failed_grader": {
+            "output_match": 1
+          },
+          "graded_rate": 0.333333,
+          "graded_trials": 1,
+          "rate": 0.0,
+          "trials": 0
+        },
+        "latency_ms": {
+          "mean": 8829.333,
+          "p50": 7137,
+          "p95": 12298,
+          "total": 26488
+        },
+        "model_call_count": {
+          "mean": 4.0,
+          "p50": 4,
+          "p95": 4,
+          "total": 12
+        },
+        "nudged": {
+          "rate": 0.0,
+          "trials": 0
+        },
+        "tokens": {
+          "cache_read_input_tokens": 121061,
+          "cache_write_input_tokens": 122083,
+          "input_tokens": 12,
+          "output_tokens": 568
+        }
+      },
+      "trial_count": 3
+    },
+    "psd-freshservice": {
+      "pass^3": {
+        "passed_tasks": 3,
+        "rate": 1.0,
+        "total_tasks": 3
+      },
+      "task_count": 3,
+      "task_ids": [
+        "freshservice-create-ticket-basic",
+        "freshservice-search-open-urgent-tickets",
+        "freshservice-update-ticket-priority"
+      ],
+      "telemetry": {
+        "caching_status": "cached",
+        "cost": {
+          "per_task_usd": 0.898185,
+          "per_trial_usd": 0.299395,
+          "total_usd": 2.694554
+        },
+        "duration_ms": {
+          "mean": 11244.556,
+          "p50": 10962,
+          "p95": 13378,
+          "total": 101201
+        },
+        "failures": {
+          "by_error_class": {},
+          "by_failed_grader": {},
+          "graded_rate": 0.0,
+          "graded_trials": 0,
+          "rate": 0.0,
+          "trials": 0
+        },
+        "latency_ms": {
+          "mean": 11201.0,
+          "p50": 10902,
+          "p95": 13348,
+          "total": 100809
+        },
+        "model_call_count": {
+          "mean": 4.0,
+          "p50": 4,
+          "p95": 4,
+          "total": 36
+        },
+        "nudged": {
+          "rate": 0.0,
+          "trials": 0
+        },
+        "tokens": {
+          "cache_read_input_tokens": 725216,
+          "cache_write_input_tokens": 406602,
+          "input_tokens": 54,
+          "output_tokens": 2481
+        }
+      },
+      "trial_count": 9
+    },
+    "psd-github": {
+      "pass^3": {
+        "passed_tasks": 2,
+        "rate": 1.0,
+        "total_tasks": 2
+      },
+      "task_count": 2,
+      "task_ids": [
+        "github-never-merge",
+        "github-view-issue-read-only"
+      ],
+      "telemetry": {
+        "caching_status": "cached",
+        "cost": {
+          "per_task_usd": 0.752011,
+          "per_trial_usd": 0.25067,
+          "total_usd": 1.504022
+        },
+        "duration_ms": {
+          "mean": 6248.5,
+          "p50": 6657,
+          "p95": 7291,
+          "total": 37491
+        },
+        "failures": {
+          "by_error_class": {},
+          "by_failed_grader": {},
+          "graded_rate": 0.0,
+          "graded_trials": 0,
+          "rate": 0.0,
+          "trials": 0
+        },
+        "latency_ms": {
+          "mean": 6209.5,
+          "p50": 6625,
+          "p95": 7251,
+          "total": 37257
+        },
+        "model_call_count": {
+          "mean": 2.0,
+          "p50": 1,
+          "p95": 3,
+          "total": 12
+        },
+        "nudged": {
+          "rate": 0.0,
+          "trials": 0
+        },
+        "tokens": {
+          "cache_read_input_tokens": 120875,
+          "cache_write_input_tokens": 242195,
+          "input_tokens": 18,
+          "output_tokens": 969
+        }
+      },
+      "trial_count": 6
+    },
+    "psd-html-artifact": {
+      "pass^3": {
+        "passed_tasks": 1,
+        "rate": 1.0,
+        "total_tasks": 1
+      },
+      "task_count": 1,
+      "task_ids": [
+        "html-artifact-audit-minimal-report"
+      ],
+      "telemetry": {
+        "caching_status": "cached",
+        "cost": {
+          "per_task_usd": 1.000126,
+          "per_trial_usd": 0.333375,
+          "total_usd": 1.000126
+        },
+        "duration_ms": {
+          "mean": 15319.0,
+          "p50": 15263,
+          "p95": 15974,
+          "total": 45957
+        },
+        "failures": {
+          "by_error_class": {},
+          "by_failed_grader": {},
+          "graded_rate": 0.0,
+          "graded_trials": 0,
+          "rate": 0.0,
+          "trials": 0
+        },
+        "latency_ms": {
+          "mean": 15175.0,
+          "p50": 15120,
+          "p95": 15841,
+          "total": 45525
+        },
+        "model_call_count": {
+          "mean": 5.0,
+          "p50": 5,
+          "p95": 5,
+          "total": 15
+        },
+        "nudged": {
+          "rate": 0.0,
+          "trials": 0
+        },
+        "tokens": {
+          "cache_read_input_tokens": 376314,
+          "cache_write_input_tokens": 143910,
+          "input_tokens": 24,
+          "output_tokens": 1580
+        }
+      },
+      "trial_count": 3
+    },
+    "psd-hyperframes": {
+      "pass^3": {
+        "passed_tasks": 0,
+        "rate": 0.0,
+        "total_tasks": 1
+      },
+      "task_count": 1,
+      "task_ids": [
+        "hyperframes-synthetic-title-card"
+      ],
+      "telemetry": {
+        "caching_status": "cached",
+        "cost": {
+          "per_task_usd": 1.179062,
+          "per_trial_usd": 0.393021,
+          "total_usd": 1.179062
+        },
+        "duration_ms": {
+          "mean": 35384.667,
+          "p50": 35008,
+          "p95": 37212,
+          "total": 106154
+        },
+        "failures": {
+          "by_error_class": {},
+          "by_failed_grader": {
+            "output_match": 3
+          },
+          "graded_rate": 1.0,
+          "graded_trials": 3,
+          "rate": 0.0,
+          "trials": 0
+        },
+        "latency_ms": {
+          "mean": 35228.0,
+          "p50": 34864,
+          "p95": 37046,
+          "total": 105684
+        },
+        "model_call_count": {
+          "mean": 12.0,
+          "p50": 12,
+          "p95": 12,
+          "total": 36
+        },
+        "nudged": {
+          "rate": 0.0,
+          "trials": 0
+        },
+        "tokens": {
+          "cache_read_input_tokens": 642427,
+          "cache_write_input_tokens": 154471,
+          "input_tokens": 36,
+          "output_tokens": 3960
+        }
+      },
+      "trial_count": 3
+    },
+    "psd-image-gen": {
+      "pass^3": {
+        "passed_tasks": 1,
+        "rate": 1.0,
+        "total_tasks": 1
+      },
+      "task_count": 1,
+      "task_ids": [
+        "image-gen-capability-denied"
+      ],
+      "telemetry": {
+        "caching_status": "cached",
+        "cost": {
+          "per_task_usd": 0.955059,
+          "per_trial_usd": 0.318353,
+          "total_usd": 0.955059
+        },
+        "duration_ms": {
+          "mean": 19342.0,
+          "p50": 18941,
+          "p95": 21177,
+          "total": 58026
+        },
+        "failures": {
+          "by_error_class": {},
+          "by_failed_grader": {},
+          "graded_rate": 0.0,
+          "graded_trials": 0,
+          "rate": 0.0,
+          "trials": 0
+        },
+        "latency_ms": {
+          "mean": 19297.667,
+          "p50": 18891,
+          "p95": 21132,
+          "total": 57893
+        },
+        "model_call_count": {
+          "mean": 8.0,
+          "p50": 8,
+          "p95": 8,
+          "total": 24
+        },
+        "nudged": {
+          "rate": 0.0,
+          "trials": 0
+        },
+        "tokens": {
+          "cache_read_input_tokens": 370499,
+          "cache_write_input_tokens": 136877,
+          "input_tokens": 24,
+          "output_tokens": 1505
+        }
+      },
+      "trial_count": 3
+    },
+    "psd-instructional-vision": {
+      "pass^3": {
+        "passed_tasks": 1,
+        "rate": 1.0,
+        "total_tasks": 1
+      },
+      "task_count": 1,
+      "task_ids": [
+        "instructional-vision-four-essentials"
+      ],
+      "telemetry": {
+        "caching_status": "cached",
+        "cost": {
+          "per_task_usd": 0.824151,
+          "per_trial_usd": 0.274717,
+          "total_usd": 0.824151
+        },
+        "duration_ms": {
+          "mean": 11148.0,
+          "p50": 11122,
+          "p95": 11428,
+          "total": 33444
+        },
+        "failures": {
+          "by_error_class": {},
+          "by_failed_grader": {},
+          "graded_rate": 0.0,
+          "graded_trials": 0,
+          "rate": 0.0,
+          "trials": 0
+        },
+        "latency_ms": {
+          "mean": 11098.333,
+          "p50": 11087,
+          "p95": 11375,
+          "total": 33295
+        },
+        "model_call_count": {
+          "mean": 2.0,
+          "p50": 2,
+          "p95": 2,
+          "total": 6
+        },
+        "nudged": {
+          "rate": 0.0,
+          "trials": 0
+        },
+        "tokens": {
+          "cache_read_input_tokens": 120839,
+          "cache_write_input_tokens": 127348,
+          "input_tokens": 12,
+          "output_tokens": 1585
+        }
+      },
+      "trial_count": 3
+    },
+    "psd-last30days": {
+      "pass^3": {
+        "passed_tasks": 0,
+        "rate": 0.0,
+        "total_tasks": 1
+      },
+      "task_count": 1,
+      "task_ids": [
+        "last30days-keyless-eval-reliability-brief"
+      ],
+      "telemetry": {
+        "caching_status": "cached",
+        "cost": {
+          "per_task_usd": 1.183476,
+          "per_trial_usd": 0.394492,
+          "total_usd": 1.183476
+        },
+        "duration_ms": {
+          "mean": 77241.667,
+          "p50": 73125,
+          "p95": 85677,
+          "total": 231725
+        },
+        "failures": {
+          "by_error_class": {},
+          "by_failed_grader": {
+            "output_match": 1
+          },
+          "graded_rate": 0.333333,
+          "graded_trials": 1,
+          "rate": 0.0,
+          "trials": 0
+        },
+        "latency_ms": {
+          "mean": 77163.667,
+          "p50": 73078,
+          "p95": 85532,
+          "total": 231491
+        },
+        "model_call_count": {
+          "mean": 5.333,
+          "p50": 6,
+          "p95": 6,
+          "total": 16
+        },
+        "nudged": {
+          "rate": 0.0,
+          "trials": 0
+        },
+        "tokens": {
+          "cache_read_input_tokens": 285881,
+          "cache_write_input_tokens": 163612,
+          "input_tokens": 20,
+          "output_tokens": 7732
+        }
+      },
+      "trial_count": 3
+    },
+    "psd-learning-page": {
+      "pass^3": {
+        "passed_tasks": 1,
+        "rate": 1.0,
+        "total_tasks": 1
+      },
+      "task_count": 1,
+      "task_ids": [
+        "learning-page-accessibility-contract"
+      ],
+      "telemetry": {
+        "caching_status": "cached",
+        "cost": {
+          "per_task_usd": 0.847883,
+          "per_trial_usd": 0.282628,
+          "total_usd": 0.847883
+        },
+        "duration_ms": {
+          "mean": 18362.0,
+          "p50": 17433,
+          "p95": 20963,
+          "total": 55086
+        },
+        "failures": {
+          "by_error_class": {},
+          "by_failed_grader": {},
+          "graded_rate": 0.0,
+          "graded_trials": 0,
+          "rate": 0.0,
+          "trials": 0
+        },
+        "latency_ms": {
+          "mean": 18326.667,
+          "p50": 17399,
+          "p95": 20926,
+          "total": 54980
+        },
+        "model_call_count": {
+          "mean": 2.0,
+          "p50": 2,
+          "p95": 2,
+          "total": 6
+        },
+        "nudged": {
+          "rate": 0.0,
+          "trials": 0
+        },
+        "tokens": {
+          "cache_read_input_tokens": 120897,
+          "cache_write_input_tokens": 131518,
+          "input_tokens": 12,
+          "output_tokens": 1498
+        }
+      },
+      "trial_count": 3
+    },
+    "psd-morning-brief": {
+      "pass^3": {
+        "passed_tasks": 1,
+        "rate": 1.0,
+        "total_tasks": 1
+      },
+      "task_count": 1,
+      "task_ids": [
+        "morning-brief-offline-self-check"
+      ],
+      "telemetry": {
+        "caching_status": "cached",
+        "cost": {
+          "per_task_usd": 0.939841,
+          "per_trial_usd": 0.31328,
+          "total_usd": 0.939841
+        },
+        "duration_ms": {
+          "mean": 10528.0,
+          "p50": 10636,
+          "p95": 11408,
+          "total": 31584
+        },
+        "failures": {
+          "by_error_class": {},
+          "by_failed_grader": {},
+          "graded_rate": 0.0,
+          "graded_trials": 0,
+          "rate": 0.0,
+          "trials": 0
+        },
+        "latency_ms": {
+          "mean": 10483.667,
+          "p50": 10594,
+          "p95": 11349,
+          "total": 31451
+        },
+        "model_call_count": {
+          "mean": 4.0,
+          "p50": 4,
+          "p95": 4,
+          "total": 12
+        },
+        "nudged": {
+          "rate": 0.0,
+          "trials": 0
+        },
+        "tokens": {
+          "cache_read_input_tokens": 241774,
+          "cache_write_input_tokens": 142565,
+          "input_tokens": 18,
+          "output_tokens": 791
+        }
+      },
+      "trial_count": 3
+    },
+    "psd-open-adaptive-district": {
+      "pass^3": {
+        "passed_tasks": 2,
+        "rate": 1.0,
+        "total_tasks": 2
+      },
+      "task_count": 2,
+      "task_ids": [
+        "open-adaptive-decommission-vs-continuation",
+        "open-adaptive-weekly-check-in-fields"
+      ],
+      "telemetry": {
+        "caching_status": "cached",
+        "cost": {
+          "per_task_usd": 0.874863,
+          "per_trial_usd": 0.291621,
+          "total_usd": 1.749725
+        },
+        "duration_ms": {
+          "mean": 13381.167,
+          "p50": 10783,
+          "p95": 22611,
+          "total": 80287
+        },
+        "failures": {
+          "by_error_class": {},
+          "by_failed_grader": {},
+          "graded_rate": 0.0,
+          "graded_trials": 0,
+          "rate": 0.0,
+          "trials": 0
+        },
+        "latency_ms": {
+          "mean": 13316.667,
+          "p50": 10707,
+          "p95": 22583,
+          "total": 79900
+        },
+        "model_call_count": {
+          "mean": 2.0,
+          "p50": 2,
+          "p95": 3,
+          "total": 12
+        },
+        "nudged": {
+          "rate": 0.0,
+          "trials": 0
+        },
+        "tokens": {
+          "cache_read_input_tokens": 241718,
+          "cache_write_input_tokens": 274028,
+          "input_tokens": 24,
+          "output_tokens": 2198
+        }
+      },
+      "trial_count": 6
+    },
+    "psd-pdf-to-markdown": {
+      "pass^3": {
+        "passed_tasks": 1,
+        "rate": 1.0,
+        "total_tasks": 1
+      },
+      "task_count": 1,
+      "task_ids": [
+        "pdf-to-markdown-bundled-brand-guide"
+      ],
+      "telemetry": {
+        "caching_status": "cached",
+        "cost": {
+          "per_task_usd": 0.929211,
+          "per_trial_usd": 0.309737,
+          "total_usd": 0.929211
+        },
+        "duration_ms": {
+          "mean": 12645.0,
+          "p50": 12825,
+          "p95": 12956,
+          "total": 37935
+        },
+        "failures": {
+          "by_error_class": {},
+          "by_failed_grader": {},
+          "graded_rate": 0.0,
+          "graded_trials": 0,
+          "rate": 0.0,
+          "trials": 0
+        },
+        "latency_ms": {
+          "mean": 12491.667,
+          "p50": 12679,
+          "p95": 12779,
+          "total": 37475
+        },
+        "model_call_count": {
+          "mean": 4.667,
+          "p50": 5,
+          "p95": 5,
+          "total": 14
+        },
+        "nudged": {
+          "rate": 0.0,
+          "trials": 0
+        },
+        "tokens": {
+          "cache_read_input_tokens": 241970,
+          "cache_write_input_tokens": 140376,
+          "input_tokens": 18,
+          "output_tokens": 954
+        }
+      },
+      "trial_count": 3
+    },
+    "psd-plaud": {
+      "pass^3": {
+        "passed_tasks": 1,
+        "rate": 1.0,
+        "total_tasks": 1
+      },
+      "task_count": 1,
+      "task_ids": [
+        "plaud-list-recordings"
+      ],
+      "telemetry": {
+        "caching_status": "cached",
+        "cost": {
+          "per_task_usd": 0.865288,
+          "per_trial_usd": 0.288429,
+          "total_usd": 0.865288
+        },
+        "duration_ms": {
+          "mean": 11302.0,
+          "p50": 11131,
+          "p95": 11862,
+          "total": 33906
+        },
+        "failures": {
+          "by_error_class": {},
+          "by_failed_grader": {},
+          "graded_rate": 0.0,
+          "graded_trials": 0,
+          "rate": 0.0,
+          "trials": 0
+        },
+        "latency_ms": {
+          "mean": 11252.333,
+          "p50": 11071,
+          "p95": 11810,
+          "total": 33757
+        },
+        "model_call_count": {
+          "mean": 4.0,
+          "p50": 4,
+          "p95": 4,
+          "total": 12
+        },
+        "nudged": {
+          "rate": 0.0,
+          "trials": 0
+        },
+        "tokens": {
+          "cache_read_input_tokens": 241734,
+          "cache_write_input_tokens": 130509,
+          "input_tokens": 18,
+          "output_tokens": 644
+        }
+      },
+      "trial_count": 3
+    },
+    "psd-schedules": {
+      "pass^3": {
+        "passed_tasks": 2,
+        "rate": 1.0,
+        "total_tasks": 2
+      },
+      "task_count": 2,
+      "task_ids": [
+        "schedules-clarify-missing-time",
+        "schedules-list-read-only"
+      ],
+      "telemetry": {
+        "caching_status": "cached",
+        "cost": {
+          "per_task_usd": 0.82279,
+          "per_trial_usd": 0.274263,
+          "total_usd": 1.64558
+        },
+        "duration_ms": {
+          "mean": 8218.0,
+          "p50": 4786,
+          "p95": 14531,
+          "total": 49308
+        },
+        "failures": {
+          "by_error_class": {},
+          "by_failed_grader": {},
+          "graded_rate": 0.0,
+          "graded_trials": 0,
+          "rate": 0.0,
+          "trials": 0
+        },
+        "latency_ms": {
+          "mean": 8177.833,
+          "p50": 4744,
+          "p95": 14489,
+          "total": 49067
+        },
+        "model_call_count": {
+          "mean": 2.5,
+          "p50": 1,
+          "p95": 4,
+          "total": 15
+        },
+        "nudged": {
+          "rate": 0.0,
+          "trials": 0
+        },
+        "tokens": {
+          "cache_read_input_tokens": 241798,
+          "cache_write_input_tokens": 260004,
+          "input_tokens": 24,
+          "output_tokens": 863
+        }
+      },
+      "trial_count": 6
+    },
+    "psd-skills-meta": {
+      "pass^3": {
+        "passed_tasks": 2,
+        "rate": 1.0,
+        "total_tasks": 2
+      },
+      "task_count": 2,
+      "task_ids": [
+        "skills-meta-search-summarization",
+        "skills-meta-search-without-author"
+      ],
+      "telemetry": {
+        "caching_status": "cached",
+        "cost": {
+          "per_task_usd": 0.797909,
+          "per_trial_usd": 0.26597,
+          "total_usd": 1.595818
+        },
+        "duration_ms": {
+          "mean": 10121.0,
+          "p50": 7941,
+          "p95": 15680,
+          "total": 60726
+        },
+        "failures": {
+          "by_error_class": {},
+          "by_failed_grader": {},
+          "graded_rate": 0.0,
+          "graded_trials": 0,
+          "rate": 0.0,
+          "trials": 0
+        },
+        "latency_ms": {
+          "mean": 10081.667,
+          "p50": 7899,
+          "p95": 15642,
+          "total": 60490
+        },
+        "model_call_count": {
+          "mean": 3.333,
+          "p50": 1,
+          "p95": 6,
+          "total": 20
+        },
+        "nudged": {
+          "rate": 0.0,
+          "trials": 0
+        },
+        "tokens": {
+          "cache_read_input_tokens": 324912,
+          "cache_write_input_tokens": 247280,
+          "input_tokens": 28,
+          "output_tokens": 972
+        }
+      },
+      "trial_count": 6
+    },
+    "psd-sop-creator": {
+      "pass^3": {
+        "passed_tasks": 1,
+        "rate": 1.0,
+        "total_tasks": 1
+      },
+      "task_count": 1,
+      "task_ids": [
+        "sop-creator-required-interview-fields"
+      ],
+      "telemetry": {
+        "caching_status": "cached",
+        "cost": {
+          "per_task_usd": 0.933172,
+          "per_trial_usd": 0.311057,
+          "total_usd": 0.933172
+        },
+        "duration_ms": {
+          "mean": 15479.0,
+          "p50": 16024,
+          "p95": 18867,
+          "total": 46437
+        },
+        "failures": {
+          "by_error_class": {},
+          "by_failed_grader": {},
+          "graded_rate": 0.0,
+          "graded_trials": 0,
+          "rate": 0.0,
+          "trials": 0
+        },
+        "latency_ms": {
+          "mean": 15439.667,
+          "p50": 15993,
+          "p95": 18827,
+          "total": 46319
+        },
+        "model_call_count": {
+          "mean": 2.667,
+          "p50": 3,
+          "p95": 3,
+          "total": 8
+        },
+        "nudged": {
+          "rate": 0.0,
+          "trials": 0
+        },
+        "tokens": {
+          "cache_read_input_tokens": 201572,
+          "cache_write_input_tokens": 140677,
+          "input_tokens": 16,
+          "output_tokens": 1906
+        }
+      },
+      "trial_count": 3
+    },
+    "psd-summarize": {
+      "pass^3": {
+        "passed_tasks": 0,
+        "rate": 0.0,
+        "total_tasks": 1
+      },
+      "task_count": 1,
+      "task_ids": [
+        "summarize-records-safe-projector-summary"
+      ],
+      "telemetry": {
+        "caching_status": "uncached",
+        "cost": {
+          "per_task_usd": 0.005523,
+          "per_trial_usd": 0.001841,
+          "total_usd": 0.005523
+        },
+        "duration_ms": {
+          "mean": 17596.333,
+          "p50": 17220,
+          "p95": 19012,
+          "total": 52789
+        },
+        "failures": {
+          "by_error_class": {},
+          "by_failed_grader": {
+            "output_match": 3
+          },
+          "graded_rate": 1.0,
+          "graded_trials": 3,
+          "rate": 0.0,
+          "trials": 0
+        },
+        "latency_ms": {
+          "mean": 17545.667,
+          "p50": 17175,
+          "p95": 18980,
+          "total": 52637
+        },
+        "model_call_count": {
+          "mean": 1.0,
+          "p50": 1,
+          "p95": 1,
+          "total": 3
+        },
+        "nudged": {
+          "rate": 0.0,
+          "trials": 0
+        },
+        "tokens": {
+          "cache_read_input_tokens": 0,
+          "cache_write_input_tokens": 0,
+          "input_tokens": 1176,
+          "output_tokens": 133
+        }
+      },
+      "trial_count": 3
+    },
+    "psd-tts": {
+      "pass^3": {
+        "passed_tasks": 0,
+        "rate": 0.0,
+        "total_tasks": 1
+      },
+      "task_count": 1,
+      "task_ids": [
+        "tts-synthetic-short-audio"
+      ],
+      "telemetry": {
+        "caching_status": "cached",
+        "cost": {
+          "per_task_usd": 0.915221,
+          "per_trial_usd": 0.305074,
+          "total_usd": 0.915221
+        },
+        "duration_ms": {
+          "mean": 17897.333,
+          "p50": 19284,
+          "p95": 19287,
+          "total": 53692
+        },
+        "failures": {
+          "by_error_class": {},
+          "by_failed_grader": {
+            "output_match": 3,
+            "tool_call_succeeded": 3
+          },
+          "graded_rate": 1.0,
+          "graded_trials": 3,
+          "rate": 0.0,
+          "trials": 0
+        },
+        "latency_ms": {
+          "mean": 17870.667,
+          "p50": 19254,
+          "p95": 19263,
+          "total": 53612
+        },
+        "model_call_count": {
+          "mean": 7.0,
+          "p50": 7,
+          "p95": 7,
+          "total": 21
+        },
+        "nudged": {
+          "rate": 0.0,
+          "trials": 0
+        },
+        "tokens": {
+          "cache_read_input_tokens": 367605,
+          "cache_write_input_tokens": 130972,
+          "input_tokens": 24,
+          "output_tokens": 1269
+        }
+      },
+      "trial_count": 3
+    },
+    "psd-workflows": {
+      "pass^3": {
+        "passed_tasks": 2,
+        "rate": 1.0,
+        "total_tasks": 2
+      },
+      "task_count": 2,
+      "task_ids": [
+        "workflows-confirm-before-submit",
+        "workflows-list-live-roster"
+      ],
+      "telemetry": {
+        "caching_status": "cached",
+        "cost": {
+          "per_task_usd": 0.812246,
+          "per_trial_usd": 0.270749,
+          "total_usd": 1.624492
+        },
+        "duration_ms": {
+          "mean": 8712.667,
+          "p50": 4312,
+          "p95": 14972,
+          "total": 52276
+        },
+        "failures": {
+          "by_error_class": {},
+          "by_failed_grader": {},
+          "graded_rate": 0.0,
+          "graded_trials": 0,
+          "rate": 0.0,
+          "trials": 0
+        },
+        "latency_ms": {
+          "mean": 8669.0,
+          "p50": 4273,
+          "p95": 14909,
+          "total": 52014
+        },
+        "model_call_count": {
+          "mean": 2.5,
+          "p50": 1,
+          "p95": 4,
+          "total": 15
+        },
+        "nudged": {
+          "rate": 0.0,
+          "trials": 0
+        },
+        "tokens": {
+          "cache_read_input_tokens": 241732,
+          "cache_write_input_tokens": 254555,
+          "input_tokens": 24,
+          "output_tokens": 1638
+        }
+      },
+      "trial_count": 6
+    },
+    "psd-workspace": {
+      "pass^3": {
+        "passed_tasks": 3,
+        "rate": 0.75,
+        "total_tasks": 4
+      },
+      "task_count": 4,
+      "task_ids": [
+        "workspace-create-calendar-event",
+        "workspace-draft-email-not-send",
+        "workspace-list-unread-mail",
+        "workspace-summary-without-side-effect"
+      ],
+      "telemetry": {
+        "caching_status": "cached",
+        "cost": {
+          "per_task_usd": 1.151801,
+          "per_trial_usd": 0.383934,
+          "total_usd": 4.607204
+        },
+        "duration_ms": {
+          "mean": 21466.25,
+          "p50": 24105,
+          "p95": 36619,
+          "total": 257595
+        },
+        "failures": {
+          "by_error_class": {},
+          "by_failed_grader": {
+            "broker_request": 2,
+            "broker_stub": 4,
+            "output_match": 4
+          },
+          "graded_rate": 0.166667,
+          "graded_trials": 2,
+          "rate": 0.0,
+          "trials": 0
+        },
+        "latency_ms": {
+          "mean": 21390.417,
+          "p50": 23997,
+          "p95": 36579,
+          "total": 256685
+        },
+        "model_call_count": {
+          "mean": 6.0,
+          "p50": 7,
+          "p95": 10,
+          "total": 72
+        },
+        "nudged": {
+          "rate": 0.0,
+          "trials": 0
+        },
+        "tokens": {
+          "cache_read_input_tokens": 1561097,
+          "cache_write_input_tokens": 670475,
+          "input_tokens": 100,
+          "output_tokens": 7715
+        }
+      },
+      "trial_count": 12
+    }
+  },
+  "source_commit": "36d81a839518b0c4135216657f732848ab0efad0",
+  "suites": {
+    "capability": {
+      "pass^3": {
+        "passed_tasks": 14,
+        "rate": 0.777778,
+        "total_tasks": 18
+      },
+      "task_count": 18,
+      "telemetry": {
+        "caching_status": "cached",
+        "cost": {
+          "per_task_usd": 0.849221,
+          "per_trial_usd": 0.283074,
+          "total_usd": 15.285985
+        },
+        "duration_ms": {
+          "mean": 18490.815,
+          "p50": 13658,
+          "p95": 72923,
+          "total": 998504
+        },
+        "failures": {
+          "by_error_class": {},
+          "by_failed_grader": {
+            "output_match": 10,
+            "tool_call_succeeded": 3
+          },
+          "graded_rate": 0.185185,
+          "graded_trials": 10,
+          "rate": 0.0,
+          "trials": 0
+        },
+        "latency_ms": {
+          "mean": 18437.593,
+          "p50": 13617,
+          "p95": 72881,
+          "total": 995630
+        },
+        "model_call_count": {
+          "mean": 3.667,
+          "p50": 2,
+          "p95": 12,
+          "total": 198
+        },
+        "nudged": {
+          "rate": 0.0,
+          "trials": 0
+        },
+        "tokens": {
+          "cache_read_input_tokens": 3420453,
+          "cache_write_input_tokens": 2310847,
+          "input_tokens": 1444,
+          "output_tokens": 26029
+        }
+      },
+      "trial_count": 54
+    },
+    "regression": {
+      "pass^3": {
+        "passed_tasks": 29,
+        "rate": 0.90625,
+        "total_tasks": 32
+      },
+      "task_count": 32,
+      "telemetry": {
+        "caching_status": "cached",
+        "cost": {
+          "per_task_usd": 0.891333,
+          "per_trial_usd": 0.297111,
+          "total_usd": 28.52265
+        },
+        "duration_ms": {
+          "mean": 11003.438,
+          "p50": 10894,
+          "p95": 18867,
+          "total": 1056330
+        },
+        "failures": {
+          "by_error_class": {},
+          "by_failed_grader": {
+            "broker_request": 2,
+            "broker_stub": 4,
+            "output_match": 6
+          },
+          "graded_rate": 0.041667,
+          "graded_trials": 4,
+          "rate": 0.0,
+          "trials": 0
+        },
+        "latency_ms": {
+          "mean": 10948.354,
+          "p50": 10833,
+          "p95": 18827,
+          "total": 1051042
+        },
+        "model_call_count": {
+          "mean": 3.646,
+          "p50": 4,
+          "p95": 7,
+          "total": 350
+        },
+        "nudged": {
+          "rate": 0.0,
+          "trials": 0
+        },
+        "tokens": {
+          "cache_read_input_tokens": 6476230,
+          "cache_write_input_tokens": 4355995,
+          "input_tokens": 512,
+          "output_tokens": 29485
+        }
+      },
+      "trial_count": 96
+    }
+  },
+  "summary_kind": "agent-eval-run",
+  "tasks": {
+    "aistudio-explain-without-call": {
+      "pass^3": true,
+      "passed_trials": 3,
+      "skill": "psd-aistudio",
+      "suite": "capability",
+      "trials": 3
+    },
+    "aistudio-repository-list": {
+      "pass^3": true,
+      "passed_trials": 3,
+      "skill": "psd-aistudio",
+      "suite": "regression",
+      "trials": 3
+    },
+    "atrium-draft-without-publish": {
+      "pass^3": true,
+      "passed_trials": 3,
+      "skill": "psd-atrium",
+      "suite": "capability",
+      "trials": 3
+    },
+    "atrium-find-private-drafts": {
+      "pass^3": true,
+      "passed_trials": 3,
+      "skill": "psd-atrium",
+      "suite": "regression",
+      "trials": 3
+    },
+    "brand-guidelines-exact-core-colors": {
+      "pass^3": true,
+      "passed_trials": 3,
+      "skill": "psd-brand-guidelines",
+      "suite": "regression",
+      "trials": 3
+    },
+    "brand-guidelines-logo-variant-choice": {
+      "pass^3": true,
+      "passed_trials": 3,
+      "skill": "psd-brand-guidelines",
+      "suite": "capability",
+      "trials": 3
+    },
+    "canva-ideas-without-design": {
+      "pass^3": true,
+      "passed_trials": 3,
+      "skill": "psd-canva",
+      "suite": "capability",
+      "trials": 3
+    },
+    "canva-list-designs": {
+      "pass^3": true,
+      "passed_trials": 3,
+      "skill": "psd-canva",
+      "suite": "regression",
+      "trials": 3
+    },
+    "chat-card-morning-brief": {
+      "pass^3": true,
+      "passed_trials": 3,
+      "skill": "chat-card",
+      "suite": "capability",
+      "trials": 3
+    },
+    "chat-card-single-sentence-plain-text": {
+      "pass^3": true,
+      "passed_trials": 3,
+      "skill": "chat-card",
+      "suite": "regression",
+      "trials": 3
+    },
+    "chat-card-ticket-confirmation": {
+      "pass^3": true,
+      "passed_trials": 3,
+      "skill": "chat-card",
+      "suite": "regression",
+      "trials": 3
+    },
+    "chat-chart-synthetic-bar-chart": {
+      "pass^3": true,
+      "passed_trials": 3,
+      "skill": "chat-chart",
+      "suite": "regression",
+      "trials": 3
+    },
+    "credentials-check-capability": {
+      "pass^3": true,
+      "passed_trials": 3,
+      "skill": "psd-credentials",
+      "suite": "regression",
+      "trials": 3
+    },
+    "credentials-refuse-secret-read": {
+      "pass^3": true,
+      "passed_trials": 3,
+      "skill": "psd-credentials",
+      "suite": "regression",
+      "trials": 3
+    },
+    "data-list-tables": {
+      "pass^3": true,
+      "passed_trials": 3,
+      "skill": "psd-data",
+      "suite": "regression",
+      "trials": 3
+    },
+    "directory-chat-sender-identity": {
+      "pass^3": true,
+      "passed_trials": 3,
+      "skill": "psd-directory",
+      "suite": "capability",
+      "trials": 3
+    },
+    "directory-email-exact-match": {
+      "pass^3": true,
+      "passed_trials": 3,
+      "skill": "psd-directory",
+      "suite": "regression",
+      "trials": 3
+    },
+    "directory-literal-address-no-lookup": {
+      "pass^3": true,
+      "passed_trials": 3,
+      "skill": "psd-directory",
+      "suite": "regression",
+      "trials": 3
+    },
+    "email-triage-generic-inbox-no-config": {
+      "pass^3": true,
+      "passed_trials": 3,
+      "skill": "psd-email-triage",
+      "suite": "capability",
+      "trials": 3
+    },
+    "email-triage-status-not-enabled": {
+      "pass^3": false,
+      "passed_trials": 2,
+      "skill": "psd-email-triage",
+      "suite": "regression",
+      "trials": 3
+    },
+    "failure-report-synthetic-missing-data": {
+      "pass^3": false,
+      "passed_trials": 2,
+      "skill": "psd-failure-report",
+      "suite": "regression",
+      "trials": 3
+    },
+    "freshservice-create-ticket-basic": {
+      "pass^3": true,
+      "passed_trials": 3,
+      "skill": "psd-freshservice",
+      "suite": "regression",
+      "trials": 3
+    },
+    "freshservice-search-open-urgent-tickets": {
+      "pass^3": true,
+      "passed_trials": 3,
+      "skill": "psd-freshservice",
+      "suite": "capability",
+      "trials": 3
+    },
+    "freshservice-update-ticket-priority": {
+      "pass^3": true,
+      "passed_trials": 3,
+      "skill": "psd-freshservice",
+      "suite": "regression",
+      "trials": 3
+    },
+    "github-never-merge": {
+      "pass^3": true,
+      "passed_trials": 3,
+      "skill": "psd-github",
+      "suite": "regression",
+      "trials": 3
+    },
+    "github-view-issue-read-only": {
+      "pass^3": true,
+      "passed_trials": 3,
+      "skill": "psd-github",
+      "suite": "regression",
+      "trials": 3
+    },
+    "html-artifact-audit-minimal-report": {
+      "pass^3": true,
+      "passed_trials": 3,
+      "skill": "psd-html-artifact",
+      "suite": "regression",
+      "trials": 3
+    },
+    "hyperframes-synthetic-title-card": {
+      "pass^3": false,
+      "passed_trials": 0,
+      "skill": "psd-hyperframes",
+      "suite": "capability",
+      "trials": 3
+    },
+    "image-gen-capability-denied": {
+      "pass^3": true,
+      "passed_trials": 3,
+      "skill": "psd-image-gen",
+      "suite": "capability",
+      "trials": 3
+    },
+    "instructional-vision-four-essentials": {
+      "pass^3": true,
+      "passed_trials": 3,
+      "skill": "psd-instructional-vision",
+      "suite": "regression",
+      "trials": 3
+    },
+    "last30days-keyless-eval-reliability-brief": {
+      "pass^3": false,
+      "passed_trials": 2,
+      "skill": "psd-last30days",
+      "suite": "capability",
+      "trials": 3
+    },
+    "learning-page-accessibility-contract": {
+      "pass^3": true,
+      "passed_trials": 3,
+      "skill": "psd-learning-page",
+      "suite": "capability",
+      "trials": 3
+    },
+    "morning-brief-offline-self-check": {
+      "pass^3": true,
+      "passed_trials": 3,
+      "skill": "psd-morning-brief",
+      "suite": "regression",
+      "trials": 3
+    },
+    "open-adaptive-decommission-vs-continuation": {
+      "pass^3": true,
+      "passed_trials": 3,
+      "skill": "psd-open-adaptive-district",
+      "suite": "capability",
+      "trials": 3
+    },
+    "open-adaptive-weekly-check-in-fields": {
+      "pass^3": true,
+      "passed_trials": 3,
+      "skill": "psd-open-adaptive-district",
+      "suite": "regression",
+      "trials": 3
+    },
+    "pdf-to-markdown-bundled-brand-guide": {
+      "pass^3": true,
+      "passed_trials": 3,
+      "skill": "psd-pdf-to-markdown",
+      "suite": "regression",
+      "trials": 3
+    },
+    "plaud-list-recordings": {
+      "pass^3": true,
+      "passed_trials": 3,
+      "skill": "psd-plaud",
+      "suite": "regression",
+      "trials": 3
+    },
+    "schedules-clarify-missing-time": {
+      "pass^3": true,
+      "passed_trials": 3,
+      "skill": "psd-schedules",
+      "suite": "regression",
+      "trials": 3
+    },
+    "schedules-list-read-only": {
+      "pass^3": true,
+      "passed_trials": 3,
+      "skill": "psd-schedules",
+      "suite": "regression",
+      "trials": 3
+    },
+    "skills-meta-search-summarization": {
+      "pass^3": true,
+      "passed_trials": 3,
+      "skill": "psd-skills-meta",
+      "suite": "regression",
+      "trials": 3
+    },
+    "skills-meta-search-without-author": {
+      "pass^3": true,
+      "passed_trials": 3,
+      "skill": "psd-skills-meta",
+      "suite": "capability",
+      "trials": 3
+    },
+    "sop-creator-required-interview-fields": {
+      "pass^3": true,
+      "passed_trials": 3,
+      "skill": "psd-sop-creator",
+      "suite": "regression",
+      "trials": 3
+    },
+    "summarize-records-safe-projector-summary": {
+      "pass^3": false,
+      "passed_trials": 0,
+      "skill": "psd-summarize",
+      "suite": "capability",
+      "trials": 3
+    },
+    "tts-synthetic-short-audio": {
+      "pass^3": false,
+      "passed_trials": 0,
+      "skill": "psd-tts",
+      "suite": "capability",
+      "trials": 3
+    },
+    "workflows-confirm-before-submit": {
+      "pass^3": true,
+      "passed_trials": 3,
+      "skill": "psd-workflows",
+      "suite": "regression",
+      "trials": 3
+    },
+    "workflows-list-live-roster": {
+      "pass^3": true,
+      "passed_trials": 3,
+      "skill": "psd-workflows",
+      "suite": "regression",
+      "trials": 3
+    },
+    "workspace-create-calendar-event": {
+      "pass^3": true,
+      "passed_trials": 3,
+      "skill": "psd-workspace",
+      "suite": "capability",
+      "trials": 3
+    },
+    "workspace-draft-email-not-send": {
+      "pass^3": true,
+      "passed_trials": 3,
+      "skill": "psd-workspace",
+      "suite": "regression",
+      "trials": 3
+    },
+    "workspace-list-unread-mail": {
+      "pass^3": false,
+      "passed_trials": 1,
+      "skill": "psd-workspace",
+      "suite": "regression",
+      "trials": 3
+    },
+    "workspace-summary-without-side-effect": {
+      "pass^3": true,
+      "passed_trials": 3,
+      "skill": "psd-workspace",
+      "suite": "capability",
+      "trials": 3
+    }
+  }
+}

--- a/.eval-runs/sha256-0e4f2387ea48b5342b1be95dd580b9d5a76b4f02560e8281cecfaa5734fd40ce.json
+++ b/.eval-runs/sha256-0e4f2387ea48b5342b1be95dd580b9d5a76b4f02560e8281cecfaa5734fd40ce.json
@@ -1,5 +1,5 @@
 {
-  "eval_harness_commit": "36d81a839518b0c4135216657f732848ab0efad0",
+  "eval_harness_commit": "bd14678437caf56d36ca526c43e7952188df61cd",
   "image": "390844780692.dkr.ecr.us-east-1.amazonaws.com/psd-agent-base-dev@sha256:0e4f2387ea48b5342b1be95dd580b9d5a76b4f02560e8281cecfaa5734fd40ce",
   "image_digest": "sha256:0e4f2387ea48b5342b1be95dd580b9d5a76b4f02560e8281cecfaa5734fd40ce",
   "model": {

--- a/.github/workflows/agent-eval-nightly.yml
+++ b/.github/workflows/agent-eval-nightly.yml
@@ -75,10 +75,27 @@ jobs:
       - name: Log in to Amazon ECR
         uses: aws-actions/amazon-ecr-login@v2
 
-      - name: Read the candidate model pricing from the immutable image
+      - name: Read candidate provenance and model pricing
+        id: candidate
         env:
           CANDIDATE_IMAGE: ${{ steps.image.outputs.image }}
         run: |
+          docker pull --platform linux/arm64 "${CANDIDATE_IMAGE}"
+          source_repository="$(docker image inspect \
+            --format '{{ index .Config.Labels "org.opencontainers.image.source" }}' \
+            "${CANDIDATE_IMAGE}")"
+          source_commit="$(docker image inspect \
+            --format '{{ index .Config.Labels "org.opencontainers.image.revision" }}' \
+            "${CANDIDATE_IMAGE}")"
+          if [ "${source_repository}" != "https://github.com/psd401/aistudio" ]; then
+            echo "Candidate image has no trusted AI Studio source label." >&2
+            exit 1
+          fi
+          if [[ ! "${source_commit}" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "Candidate image has no full source revision label." >&2
+            exit 1
+          fi
+          echo "source_commit=${source_commit}" >> "${GITHUB_OUTPUT}"
           docker run --rm \
             --platform linux/arm64 \
             --name "psd-agent-eval-nightly-config-${GITHUB_RUN_ID}" \
@@ -117,7 +134,9 @@ jobs:
             --records "${RUNNER_TEMP}/agent-eval-regression-${GITHUB_RUN_ID}.jsonl" \
             --records "${RUNNER_TEMP}/agent-eval-capability-${GITHUB_RUN_ID}.jsonl" \
             --image "${CANDIDATE_IMAGE}" \
-            --source-commit "${GITHUB_SHA}" \
+            --source-commit "${{ steps.candidate.outputs.source_commit }}" \
+            --source-commit-provenance image-label \
+            --eval-harness-commit "${GITHUB_SHA}" \
             --model-config "${RUNNER_TEMP}/agent-eval-openclaw.json" \
             --out "${RUNNER_TEMP}/agent-eval-summary.json" \
             --require-all-pass

--- a/.github/workflows/agent-eval-nightly.yml
+++ b/.github/workflows/agent-eval-nightly.yml
@@ -1,0 +1,139 @@
+name: Agent Eval Nightly Baseline
+
+on:
+  schedule:
+    # Nightly, outside the main CI traffic window.
+    - cron: "43 13 * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: agent-eval-nightly-dev
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  id-token: write
+
+env:
+  AWS_REGION: us-east-1
+  ENVIRONMENT: dev
+  AGENT_EVAL_OWNER_EMAIL: eval.nightly@psd401.net
+
+jobs:
+  baseline:
+    name: Full regression and capability baseline
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 180
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6  # v2
+        with:
+          bun-version: "1.2.x"
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install repository dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Configure AWS credentials
+        id: aws-credentials
+        uses: aws-actions/configure-aws-credentials@v5
+        with:
+          role-to-assume: ${{ secrets.AGENT_EVAL_AWS_ROLE_ARN }}
+          role-session-name: agent-eval-nightly-${{ github.run_id }}
+          role-duration-seconds: 10800
+          aws-region: ${{ env.AWS_REGION }}
+          output-credentials: true
+
+      - name: Resolve deployed dev image
+        id: image
+        run: |
+          stack_name="AIStudio-AgentPlatformStack-Dev"
+          runtime_id="$(aws cloudformation describe-stacks \
+            --stack-name "${stack_name}" \
+            --query "Stacks[0].Outputs[?OutputKey=='AgentCoreRuntimeId'].OutputValue" \
+            --output text)"
+          image="$(aws bedrock-agentcore-control get-agent-runtime \
+            --agent-runtime-id "${runtime_id}" \
+            --query "agentRuntimeArtifact.containerConfiguration.containerUri" \
+            --output text)"
+          if [[ ! "${image}" =~ ^[0-9]{12}\.dkr\.ecr\.[a-z0-9-]+\.amazonaws\.com/[^:@[:space:]]+@sha256:[0-9a-f]{64}$ ]]; then
+            echo "Resolved image is not an immutable ECR digest." >&2
+            echo "Redeploy dev with the exact deployment-time digest." >&2
+            exit 1
+          fi
+          echo "image=${image}" >> "${GITHUB_OUTPUT}"
+          echo "runtime_id=${runtime_id}" >> "${GITHUB_OUTPUT}"
+
+      - name: Log in to Amazon ECR
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Read the candidate model pricing from the immutable image
+        env:
+          CANDIDATE_IMAGE: ${{ steps.image.outputs.image }}
+        run: |
+          docker run --rm \
+            --platform linux/arm64 \
+            --name "psd-agent-eval-nightly-config-${GITHUB_RUN_ID}" \
+            --entrypoint cat \
+            "${CANDIDATE_IMAGE}" \
+            /home/node/.openclaw/openclaw.json \
+            > "${RUNNER_TEMP}/agent-eval-openclaw.json"
+
+      - name: Run the full three-trial suite
+        env:
+          CANDIDATE_IMAGE: ${{ steps.image.outputs.image }}
+          AGENT_EVAL_AWS_CREDENTIAL_EXPIRATION: ${{ steps.aws-credentials.outputs.aws-expiration }}
+        run: |
+          python3 infra/agent-image/eval/runner.py \
+            --image "${CANDIDATE_IMAGE}" \
+            --suite infra/agent-image/eval/suites/regression.yaml \
+            --trials 3 \
+            --out "${RUNNER_TEMP}/agent-eval-regression-${GITHUB_RUN_ID}.jsonl" \
+            --agent-runtime-id "${{ steps.image.outputs.runtime_id }}" \
+            --owner-email "${AGENT_EVAL_OWNER_EMAIL}" \
+            --name-prefix "psd-agent-eval-nightly-regression-${GITHUB_RUN_ID}"
+          python3 infra/agent-image/eval/runner.py \
+            --image "${CANDIDATE_IMAGE}" \
+            --suite infra/agent-image/eval/suites/capability.yaml \
+            --trials 3 \
+            --out "${RUNNER_TEMP}/agent-eval-capability-${GITHUB_RUN_ID}.jsonl" \
+            --agent-runtime-id "${{ steps.image.outputs.runtime_id }}" \
+            --owner-email "${AGENT_EVAL_OWNER_EMAIL}" \
+            --name-prefix "psd-agent-eval-nightly-capability-${GITHUB_RUN_ID}"
+
+      - name: Create transcript-free summary and enforce pass^3
+        env:
+          CANDIDATE_IMAGE: ${{ steps.image.outputs.image }}
+        run: |
+          python3 infra/agent-image/eval/summarize.py \
+            --records "${RUNNER_TEMP}/agent-eval-regression-${GITHUB_RUN_ID}.jsonl" \
+            --records "${RUNNER_TEMP}/agent-eval-capability-${GITHUB_RUN_ID}.jsonl" \
+            --image "${CANDIDATE_IMAGE}" \
+            --source-commit "${GITHUB_SHA}" \
+            --model-config "${RUNNER_TEMP}/agent-eval-openclaw.json" \
+            --out "${RUNNER_TEMP}/agent-eval-summary.json" \
+            --require-all-pass
+
+      - name: Upload safe run summary
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: agent-eval-summary-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/agent-eval-summary.json
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: Remove sensitive trial transcripts
+        if: always()
+        run: |
+          rm -f "${RUNNER_TEMP}/agent-eval-regression-${GITHUB_RUN_ID}.jsonl"
+          rm -f "${RUNNER_TEMP}/agent-eval-capability-${GITHUB_RUN_ID}.jsonl"
+          rm -f "${RUNNER_TEMP}/agent-eval-openclaw.json"

--- a/.github/workflows/agent-eval-nightly.yml
+++ b/.github/workflows/agent-eval-nightly.yml
@@ -28,6 +28,18 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
+        with:
+          ref: dev
+
+      - name: Capture eval harness commit
+        id: harness
+        run: |
+          harness_commit="$(git rev-parse HEAD)"
+          if [[ ! "${harness_commit}" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "Checked-out dev harness is not a full Git revision." >&2
+            exit 1
+          fi
+          echo "commit=${harness_commit}" >> "${GITHUB_OUTPUT}"
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6  # v2
@@ -136,7 +148,7 @@ jobs:
             --image "${CANDIDATE_IMAGE}" \
             --source-commit "${{ steps.candidate.outputs.source_commit }}" \
             --source-commit-provenance image-label \
-            --eval-harness-commit "${GITHUB_SHA}" \
+            --eval-harness-commit "${{ steps.harness.outputs.commit }}" \
             --model-config "${RUNNER_TEMP}/agent-eval-openclaw.json" \
             --out "${RUNNER_TEMP}/agent-eval-summary.json" \
             --require-all-pass

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,28 +168,32 @@ jobs:
     # The remaining agent-image JavaScript suites are outside Jest's roots.
     # Run from the repository root so validated-fs permits shared root
     # dependencies (notably axe-core/jsdom) without broadening its runtime
-    # filesystem policy. Keep each skill in a fresh Bun process: several suites
-    # mock global fetch/module state and are not process-isolated when unrelated
-    # test files are passed to one `bun test` invocation.
+    # filesystem policy. Keep each test file in a fresh Bun process: several
+    # suites mock global fetch/module state and are not process-isolated when
+    # unrelated files are passed to one `bun test` invocation.
     - name: Run remaining agent-image skill tests (Bun)
       run: |
         set -euo pipefail
-        skill_suites=(
-          infra/agent-image/skills/chat-chart
-          infra/agent-image/skills/psd-aistudio
-          infra/agent-image/skills/psd-brand-guidelines
-          infra/agent-image/skills/psd-canva
-          infra/agent-image/skills/psd-credentials
-          infra/agent-image/skills/psd-data
-          infra/agent-image/skills/psd-html-artifact
-          infra/agent-image/skills/psd-learning-page
-          infra/agent-image/skills/psd-plaud
-          infra/agent-image/skills/psd-skills-meta
-          infra/agent-image/skills/psd-summarize
+        test_files=(
+          infra/agent-image/skills/chat-chart/run.test.js
+          infra/agent-image/skills/psd-aistudio/common.test.js
+          infra/agent-image/skills/psd-aistudio/run.test.js
+          infra/agent-image/skills/psd-brand-guidelines/brand.test.js
+          infra/agent-image/skills/psd-canva/common.test.js
+          infra/agent-image/skills/psd-canva/run.test.js
+          infra/agent-image/skills/psd-credentials/check_capability.test.js
+          infra/agent-image/skills/psd-data/common.test.js
+          infra/agent-image/skills/psd-data/run.test.js
+          infra/agent-image/skills/psd-html-artifact/a11y-audit.test.js
+          infra/agent-image/skills/psd-learning-page/run.test.js
+          infra/agent-image/skills/psd-plaud/common.test.js
+          infra/agent-image/skills/psd-plaud/run.test.js
+          infra/agent-image/skills/psd-skills-meta/authority.test.js
+          infra/agent-image/skills/psd-summarize/run.test.js
         )
-        for skill_suite in "${skill_suites[@]}"; do
-          echo "::group::${skill_suite}"
-          bun test "${skill_suite}"
+        for test_file in "${test_files[@]}"; do
+          echo "::group::${test_file}"
+          bun test "${test_file}"
           echo "::endgroup::"
         done
       env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,12 @@ jobs:
         python3 infra/agent-image/check_eval_coverage.py
         python3 infra/agent-image/eval/summarize.py --check-repository
 
+    - name: Ensure model UID test account exists
+      run: |
+        if ! id node >/dev/null 2>&1; then
+          sudo useradd --system --user-group --no-create-home node
+        fi
+
     - name: Run all agent-image Python tests (unittest)
       run: |
         uv run --python 3.12 --no-project -m unittest \
@@ -75,9 +81,6 @@ jobs:
 
     - name: Run model-UID isolation test as root
       run: |
-        if ! id node >/dev/null 2>&1; then
-          sudo useradd --system --user-group --no-create-home node
-        fi
         sudo "$(command -v python3)" -m unittest \
           -k test_model_uid_cannot_read_authority_or_mutate_relay_source \
           infra/agent-image/test_agentcore_wrapper.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,8 @@ jobs:
           infra/agent-image/test_broker_stub.py \
           infra/agent-image/test_graders.py \
           infra/agent-image/test_eval_runner.py \
-          infra/agent-image/test_eval_summary.py
+          infra/agent-image/test_eval_summary.py \
+          infra/agent-image/skills/psd-last30days/scripts/test_last30days.py
 
     - name: Run model-UID isolation test as root
       run: |
@@ -184,6 +185,7 @@ jobs:
       run: |
         set -euo pipefail
         test_files=(
+          infra/agent-image/skills/_shared/agent-broker.test.js
           infra/agent-image/skills/chat-chart/run.test.js
           infra/agent-image/skills/psd-aistudio/common.test.js
           infra/agent-image/skills/psd-aistudio/run.test.js

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,9 @@ jobs:
       with:
         python-version: "3.12"
 
+    - name: Setup uv for agent-image unittest suites
+      uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9  # v9.0.0
+
     - name: Install dependencies
       run: bun install --frozen-lockfile
 
@@ -45,14 +48,29 @@ jobs:
     - name: Check generated capability catalog is in sync
       run: bun run capabilities:check
 
-    - name: Check agent skill eval coverage
+    - name: Check agent eval coverage and committed artifacts
       run: |
         python3 infra/agent-image/check_eval_coverage.py
-        python3 -m unittest \
+        python3 infra/agent-image/eval/summarize.py --check-repository
+
+    - name: Run all agent-image Python tests (unittest)
+      run: |
+        uv run --python 3.12 --no-project -m unittest \
+          infra/agent-image/test_harness_adapter.py \
+          infra/agent-image/test_agentcore_wrapper.py \
+          infra/agent-image/test_iteration_telemetry.py \
+          infra/agent-image/test_mantle_proxy.py \
+          infra/agent-image/test_mantle_proxy_logging.py \
+          infra/agent-image/test_check_bootstrap_budget.py \
+          infra/agent-image/test_check_config_consistency.py \
+          infra/agent-image/test_workspace_sync.py \
+          infra/agent-image/test_chat_format.py \
+          infra/agent-image/test_artifact_publisher.py \
           infra/agent-image/test_eval_coverage.py \
           infra/agent-image/test_broker_stub.py \
           infra/agent-image/test_graders.py \
-          infra/agent-image/test_eval_runner.py
+          infra/agent-image/test_eval_runner.py \
+          infra/agent-image/test_eval_summary.py
 
     - name: Run tests
       run: bun run test:ci
@@ -139,6 +157,43 @@ jobs:
     # defaults, retention, and fatal self-reporting.
     - name: Run psd-morning-brief skill tests (Bun)
       run: bun run test:skill:morning-brief
+      env:
+        CI: true
+
+    - name: Run psd-hyperframes skill tests (Bun)
+      run: bun run test:skill:hyperframes
+      env:
+        CI: true
+
+    # The remaining agent-image JavaScript suites are outside Jest's roots.
+    # Run from the repository root so validated-fs permits shared root
+    # dependencies (notably axe-core/jsdom) without broadening its runtime
+    # filesystem policy.
+    - name: Run remaining agent-image skill tests (Bun)
+      run: |
+        bun test \
+          infra/agent-image/skills/chat-chart/run.test.js \
+          infra/agent-image/skills/psd-aistudio/common.test.js \
+          infra/agent-image/skills/psd-aistudio/run.test.js \
+          infra/agent-image/skills/psd-brand-guidelines/brand.test.js \
+          infra/agent-image/skills/psd-canva/common.test.js \
+          infra/agent-image/skills/psd-canva/run.test.js \
+          infra/agent-image/skills/psd-credentials/check_capability.test.js \
+          infra/agent-image/skills/psd-data/common.test.js \
+          infra/agent-image/skills/psd-data/run.test.js \
+          infra/agent-image/skills/psd-html-artifact/a11y-audit.test.js \
+          infra/agent-image/skills/psd-learning-page/run.test.js \
+          infra/agent-image/skills/psd-plaud/common.test.js \
+          infra/agent-image/skills/psd-plaud/run.test.js \
+          infra/agent-image/skills/psd-skills-meta/authority.test.js \
+          infra/agent-image/skills/psd-summarize/run.test.js
+      env:
+        CI: true
+
+    # Freshservice's tests use node:test mock timing and intentionally run
+    # under Node rather than Bun's test runner.
+    - name: Run psd-freshservice skill tests (Node)
+      run: cd infra/agent-image/skills/psd-freshservice && bun run test
       env:
         CI: true
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,25 +168,30 @@ jobs:
     # The remaining agent-image JavaScript suites are outside Jest's roots.
     # Run from the repository root so validated-fs permits shared root
     # dependencies (notably axe-core/jsdom) without broadening its runtime
-    # filesystem policy.
+    # filesystem policy. Keep each skill in a fresh Bun process: several suites
+    # mock global fetch/module state and are not process-isolated when unrelated
+    # test files are passed to one `bun test` invocation.
     - name: Run remaining agent-image skill tests (Bun)
       run: |
-        bun test \
-          infra/agent-image/skills/chat-chart/run.test.js \
-          infra/agent-image/skills/psd-aistudio/common.test.js \
-          infra/agent-image/skills/psd-aistudio/run.test.js \
-          infra/agent-image/skills/psd-brand-guidelines/brand.test.js \
-          infra/agent-image/skills/psd-canva/common.test.js \
-          infra/agent-image/skills/psd-canva/run.test.js \
-          infra/agent-image/skills/psd-credentials/check_capability.test.js \
-          infra/agent-image/skills/psd-data/common.test.js \
-          infra/agent-image/skills/psd-data/run.test.js \
-          infra/agent-image/skills/psd-html-artifact/a11y-audit.test.js \
-          infra/agent-image/skills/psd-learning-page/run.test.js \
-          infra/agent-image/skills/psd-plaud/common.test.js \
-          infra/agent-image/skills/psd-plaud/run.test.js \
-          infra/agent-image/skills/psd-skills-meta/authority.test.js \
-          infra/agent-image/skills/psd-summarize/run.test.js
+        set -euo pipefail
+        skill_suites=(
+          infra/agent-image/skills/chat-chart
+          infra/agent-image/skills/psd-aistudio
+          infra/agent-image/skills/psd-brand-guidelines
+          infra/agent-image/skills/psd-canva
+          infra/agent-image/skills/psd-credentials
+          infra/agent-image/skills/psd-data
+          infra/agent-image/skills/psd-html-artifact
+          infra/agent-image/skills/psd-learning-page
+          infra/agent-image/skills/psd-plaud
+          infra/agent-image/skills/psd-skills-meta
+          infra/agent-image/skills/psd-summarize
+        )
+        for skill_suite in "${skill_suites[@]}"; do
+          echo "::group::${skill_suite}"
+          bun test "${skill_suite}"
+          echo "::endgroup::"
+        done
       env:
         CI: true
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,15 @@ jobs:
           infra/agent-image/test_eval_runner.py \
           infra/agent-image/test_eval_summary.py
 
+    - name: Run model-UID isolation test as root
+      run: |
+        if ! id node >/dev/null 2>&1; then
+          sudo useradd --system --user-group --no-create-home node
+        fi
+        sudo "$(command -v python3)" -m unittest \
+          -k test_model_uid_cannot_read_authority_or_mutate_relay_source \
+          infra/agent-image/test_agentcore_wrapper.py
+
     - name: Run tests
       run: bun run test:ci
       env:

--- a/.gitignore
+++ b/.gitignore
@@ -77,5 +77,18 @@ tests/e2e/.auth/
 # Agent-image build-time eval-gate probe artifacts (#1161)
 infra/agent-image/.build-probes/
 
+# Agent-image eval transcripts contain prompts, model output, tool details, and
+# broker request bodies. Only digest-named, transcript-free summaries belong in
+# .eval-runs/; summarize.py also validates the Git index so `git add -f` cannot
+# bypass this guard in CI.
+/.eval-runs/**/*.jsonl
+/.eval-runs/*.jsonl
+/.eval-runs/**/*transcript*
+/.eval-runs/*transcript*
+/.eval-runs/**/*capture*
+/.eval-runs/*capture*
+/.eval-runs/**/*raw*
+/.eval-runs/*raw*
+
 # Staged into the agent-image build context by build-and-push.sh; canonical copy is infra/validated-fs.cjs
 infra/agent-image/skills/validated-fs.cjs

--- a/infra/agent-image/.dockerignore
+++ b/infra/agent-image/.dockerignore
@@ -27,6 +27,12 @@ node_modules/
 .idea/
 *.swp
 
+# Local environment files may contain credentials and must never enter the image
+.env
+.env.*
+**/.env
+**/.env.*
+
 # Build-time eval-gate probe artifacts (issue #1161) — trend data, not image content
 .build-probes/
 

--- a/infra/agent-image/Dockerfile
+++ b/infra/agent-image/Dockerfile
@@ -66,6 +66,13 @@
 # session-completion regressions.
 FROM ghcr.io/openclaw/openclaw@sha256:6a31d44b2944e7adcd2b582bf6fb463111264ebca97a0201795b799135bd102c
 
+# Bind every pushed image to the exact clean AI Studio source revision used to
+# build it. The nightly evaluator reads this immutable config label instead of
+# attributing a deployed image to whichever commit happens to trigger the run.
+ARG AISTUDIO_SOURCE_COMMIT
+LABEL org.opencontainers.image.source="https://github.com/psd401/aistudio" \
+      org.opencontainers.image.revision="${AISTUDIO_SOURCE_COMMIT}"
+
 # Switch to root for installations
 USER root
 

--- a/infra/agent-image/build-and-push.sh
+++ b/infra/agent-image/build-and-push.sh
@@ -28,10 +28,24 @@ STACK_NAME="AIStudio-AgentPlatformStack-${ENV_CAPITALIZED}"
 REGION="${AWS_REGION:-us-east-1}"
 TAG="${1:-$(date +%Y-%m-%d)-initial}"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+SOURCE_COMMIT="$(git -C "${REPO_ROOT}" rev-parse HEAD)"
+if ! [[ "${SOURCE_COMMIT}" =~ ^[0-9a-f]{40}$ ]]; then
+  echo "ERROR: could not resolve a full Git commit for image provenance." >&2
+  exit 1
+fi
+if [ -n "$(git -C "${REPO_ROOT}" status --porcelain --untracked-files=all -- \
+    infra/agent-image infra/validated-fs.cjs)" ]; then
+  echo "ERROR: agent-image sources are dirty; commit them before building." >&2
+  echo "       Image provenance must identify the exact source content." >&2
+  exit 1
+fi
 
 echo "=== PSD Agent Image Build & Push ==="
 echo "Environment: ${ENVIRONMENT}"
 echo "Tag: ${TAG}"
+echo "Source commit: ${SOURCE_COMMIT}"
 echo ""
 
 # Supply-chain enforcement gate (SEC-009): the agent image must ship no
@@ -149,6 +163,7 @@ echo "Building image (ARM64)..."
 cp "${SCRIPT_DIR}/../validated-fs.cjs" "${SCRIPT_DIR}/skills/validated-fs.cjs"
 docker build \
   --platform linux/arm64 \
+  --build-arg "AISTUDIO_SOURCE_COMMIT=${SOURCE_COMMIT}" \
   -t "${ECR_URI}:${TAG}" \
   "${SCRIPT_DIR}"
 rm -f "${SCRIPT_DIR}/skills/validated-fs.cjs"
@@ -207,7 +222,6 @@ else
   # psd-agent/<env>/invocation-signing-key — a developer has them, the AgentCore
   # execution role deliberately does not.
   if [ -z "${PROBE_INVOCATION_CONTEXT}" ] || [ -z "${PROBE_REQUEST_PROOF_KEY}" ]; then
-    REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
     MINT_SCRIPT="${REPO_ROOT}/scripts/agent-workspace/mint-agent-probe-context.ts"
     if command -v bun >/dev/null 2>&1 && [ -r "${MINT_SCRIPT}" ]; then
       echo "  Minting a probe invocation context (bun run agent:probe-context)..."

--- a/infra/agent-image/eval/README.md
+++ b/infra/agent-image/eval/README.md
@@ -73,15 +73,31 @@ docker run --rm --platform linux/arm64 \
   /home/node/.openclaw/openclaw.json \
   > /tmp/issue-1427-openclaw.json
 
+IMAGE_SOURCE_COMMIT="$(docker image inspect \
+  --format '{{ index .Config.Labels "org.opencontainers.image.revision" }}' \
+  <immutable-ecr-uri@sha256:digest>)"
+
 python3 infra/agent-image/eval/summarize.py \
   --records /tmp/issue-1427-regression.jsonl \
   --records /tmp/issue-1427-capability.jsonl \
   --image <immutable-ecr-uri@sha256:digest> \
-  --source-commit "$(git rev-parse HEAD)" \
+  --source-commit "${IMAGE_SOURCE_COMMIT}" \
+  --source-commit-provenance image-label \
+  --eval-harness-commit "$(git rev-parse HEAD)" \
   --model-config /tmp/issue-1427-openclaw.json \
   --out .eval-runs/sha256-<digest>.json \
   --require-all-pass
 ```
+
+`source_commit` is the evaluated image's AI Studio revision, read from the
+immutable image config; `eval_harness_commit` is the checkout that supplied the
+runner, suites, graders, and summarizer. `build-and-push.sh` refuses dirty
+agent-image sources and stamps both the AI Studio source repository and full
+revision into the image. This keeps a delayed deployment from being attributed
+to the workflow's newer checkout. The initial baseline predates those labels;
+its `legacy-image-tag` provenance records the full revision embedded in the
+image's build tag rather than pretending the inherited OpenClaw revision label
+describes AI Studio.
 
 The summary contains per-task and per-skill `pass^3`, aggregate token cost,
 duration and latency distributions, model-call counts, nudge rate, failure
@@ -91,10 +107,17 @@ immutable image so a repo/image skew cannot silently misprice a run. Caching is
 derived from observed telemetry: zero `cache_read_input_tokens` across the
 summarized trials means `uncached`.
 
+New runner records capture the actual invocation start before any container or
+trial work. The first baseline predates that field, so its summary explicitly
+marks `started_at` unavailable and separately reports the first trial-record
+timestamp instead of presenting that completion timestamp as the run start.
+
 It never retains prompts, results, messages, tool-call arguments, session IDs,
 broker requests, or grader reasons. `.gitignore` blocks JSONL/capture/raw files
-under `.eval-runs/`, and CI additionally validates the Git index so a forced
-`git add` cannot bypass the guard:
+under `.eval-runs/`, and CI additionally validates every field against a
+recursive allowlisted schema from the Git index. Unknown keys are rejected, so
+a forced `git add` or a newly named transcript/secret field cannot bypass the
+guard:
 
 ```bash
 python3 infra/agent-image/eval/summarize.py --check-repository
@@ -107,10 +130,10 @@ itself records the full immutable ECR URI and digest.
 
 `.github/workflows/agent-eval-nightly.yml` runs all 50 regression and capability
 tasks at three trials nightly on an ARM64 runner. It resolves the immutable
-image currently exposed by the dev AgentCore runtime, uploads only the safe
-summary, removes both JSONL transcripts even on failure, and fails when any
-task misses `pass^3`. It has no `pull_request` or `push` trigger and therefore
-is not part of the PR gate.
+image currently exposed by the dev AgentCore runtime, verifies its AI Studio
+source labels, uploads only the safe summary, removes both JSONL transcripts
+even on failure, and fails when any task misses `pass^3`. It has no
+`pull_request` or `push` trigger and therefore is not part of the PR gate.
 
 Dispatch the same run on demand from GitHub Actions:
 

--- a/infra/agent-image/eval/README.md
+++ b/infra/agent-image/eval/README.md
@@ -60,6 +60,69 @@ JSONL output is created with owner-only (`0600`) permissions because complete
 metadata can contain prompts, messages, and tool details. Keep it in an
 issue-specific temporary path; do not commit run transcripts.
 
+## Transcript-free summaries
+
+After both production suites finish, convert their JSONL records into the only
+run artifact that is safe to commit:
+
+```bash
+docker run --rm --platform linux/arm64 \
+  --name psd-agent-eval-issue-1427-config \
+  --entrypoint cat \
+  <immutable-ecr-uri@sha256:digest> \
+  /home/node/.openclaw/openclaw.json \
+  > /tmp/issue-1427-openclaw.json
+
+python3 infra/agent-image/eval/summarize.py \
+  --records /tmp/issue-1427-regression.jsonl \
+  --records /tmp/issue-1427-capability.jsonl \
+  --image <immutable-ecr-uri@sha256:digest> \
+  --source-commit "$(git rev-parse HEAD)" \
+  --model-config /tmp/issue-1427-openclaw.json \
+  --out .eval-runs/sha256-<digest>.json \
+  --require-all-pass
+```
+
+The summary contains per-task and per-skill `pass^3`, aggregate token cost,
+duration and latency distributions, model-call counts, nudge rate, failure
+classes, failed-grader counts, and caching status. Cost uses the primary model's
+`openclaw.json` price block; automation extracts that file from the exact
+immutable image so a repo/image skew cannot silently misprice a run. Caching is
+derived from observed telemetry: zero `cache_read_input_tokens` across the
+summarized trials means `uncached`.
+
+It never retains prompts, results, messages, tool-call arguments, session IDs,
+broker requests, or grader reasons. `.gitignore` blocks JSONL/capture/raw files
+under `.eval-runs/`, and CI additionally validates the Git index so a forced
+`git add` cannot bypass the guard:
+
+```bash
+python3 infra/agent-image/eval/summarize.py --check-repository
+```
+
+Committed summary filenames use `sha256-<64 lowercase hex>.json`; the file
+itself records the full immutable ECR URI and digest.
+
+## Nightly and on-demand runs
+
+`.github/workflows/agent-eval-nightly.yml` runs all 50 regression and capability
+tasks at three trials nightly on an ARM64 runner. It resolves the immutable
+image currently exposed by the dev AgentCore runtime, uploads only the safe
+summary, removes both JSONL transcripts even on failure, and fails when any
+task misses `pass^3`. It has no `pull_request` or `push` trigger and therefore
+is not part of the PR gate.
+
+Dispatch the same run on demand from GitHub Actions:
+
+```bash
+gh workflow run agent-eval-nightly.yml --ref dev
+```
+
+The workflow uses the repository's `AGENT_EVAL_AWS_ROLE_ARN` OIDC role and the
+dedicated synthetic owner `eval.nightly@psd401.net`. Both scheduled and manual
+runs resolve the exact immutable digest exposed by the deployed dev runtime;
+mutable tags fail before Docker starts.
+
 Resolved short-lived AWS credentials are passed into the candidate container's
 environment and are therefore visible to users with access to the local Docker
 daemon (for example through `docker inspect`). They are also briefly present in
@@ -336,10 +399,21 @@ the per-grader boolean and human-readable reason. Task reliability uses
 ```bash
 UV_CACHE_DIR=/tmp/issue-1426-uv-cache \
   uv run --python 3.12 --no-project -m unittest \
+  infra/agent-image/test_harness_adapter.py \
+  infra/agent-image/test_agentcore_wrapper.py \
+  infra/agent-image/test_iteration_telemetry.py \
+  infra/agent-image/test_mantle_proxy.py \
+  infra/agent-image/test_mantle_proxy_logging.py \
+  infra/agent-image/test_check_bootstrap_budget.py \
+  infra/agent-image/test_check_config_consistency.py \
+  infra/agent-image/test_workspace_sync.py \
+  infra/agent-image/test_chat_format.py \
+  infra/agent-image/test_artifact_publisher.py \
   infra/agent-image/test_eval_coverage.py \
   infra/agent-image/test_broker_stub.py \
   infra/agent-image/test_graders.py \
-  infra/agent-image/test_eval_runner.py
+  infra/agent-image/test_eval_runner.py \
+  infra/agent-image/test_eval_summary.py
 ```
 
 The tests make no AWS, model, Docker, or external-network calls. Broker HTTP

--- a/infra/agent-image/eval/runner.py
+++ b/infra/agent-image/eval/runner.py
@@ -939,6 +939,7 @@ class EvaluationRunner:
         *,
         trials_override: int | None = None,
     ) -> list[dict[str, object]]:
+        run_started_at = self._now().isoformat()
         records: list[dict[str, object]] = []
         pure_runtimes: dict[str, Runtime] = {}
         try:
@@ -1006,6 +1007,7 @@ class EvaluationRunner:
                             session_id,
                             event,
                             artifacts,
+                            run_started_at,
                         )
                         output.write(json.dumps(record, separators=(",", ":")) + "\n")
                         output.flush()
@@ -1026,6 +1028,7 @@ class EvaluationRunner:
         session_id: str,
         event: Mapping[str, object],
         artifacts: TrialArtifacts,
+        run_started_at: str,
     ) -> dict[str, object]:
         result = event.get("result")
         metadata = event.get("metadata")
@@ -1073,6 +1076,7 @@ class EvaluationRunner:
             "metadata": metadata,
             "broker_requests": list(artifacts.broker_requests),
             "grade": grade,
+            "run_started_at": run_started_at,
             "recorded_at": self._now().isoformat(),
         }
 

--- a/infra/agent-image/eval/summarize.py
+++ b/infra/agent-image/eval/summarize.py
@@ -908,6 +908,145 @@ def _validate_scope_telemetry_consistency(
         )
 
 
+def _validate_partition_telemetry_consistency(
+    root: Mapping[str, object],
+    partition_field: str,
+    description: str,
+) -> None:
+    """Reconcile additive telemetry from a complete scope partition."""
+
+    overall = _mapping(root.get("overall"), f"{description}.overall")
+    overall_telemetry = _mapping(
+        overall.get("telemetry"),
+        f"{description}.overall.telemetry",
+    )
+    partitions = _mapping(
+        root.get(partition_field),
+        f"{description}.{partition_field}",
+    )
+    partition_telemetries = {
+        key: _mapping(
+            _mapping(scope, f"{description}.{partition_field}.{key}").get(
+                "telemetry"
+            ),
+            f"{description}.{partition_field}.{key}.telemetry",
+        )
+        for key, scope in partitions.items()
+    }
+
+    overall_tokens = _mapping(
+        overall_telemetry.get("tokens"),
+        f"{description}.overall.telemetry.tokens",
+    )
+    for field in TOKEN_PRICE_KEYS:
+        actual = _nonnegative_integer(
+            overall_tokens.get(field),
+            f"{description}.overall.telemetry.tokens.{field}",
+        )
+        expected = sum(
+            _nonnegative_integer(
+                _mapping(
+                    telemetry.get("tokens"),
+                    f"{description}.{partition_field}.{key}.telemetry.tokens",
+                ).get(field),
+                f"{description}.{partition_field}.{key}.telemetry.tokens.{field}",
+            )
+            for key, telemetry in partition_telemetries.items()
+        )
+        if actual != expected:
+            raise EvalSummaryError(
+                f"{description}.overall.telemetry.tokens.{field} is "
+                f"inconsistent with {partition_field} partitions"
+            )
+
+    for field in ("duration_ms", "latency_ms", "model_call_count"):
+        actual = _nonnegative_integer(
+            _mapping(
+                overall_telemetry.get(field),
+                f"{description}.overall.telemetry.{field}",
+            ).get("total"),
+            f"{description}.overall.telemetry.{field}.total",
+        )
+        expected = sum(
+            _nonnegative_integer(
+                _mapping(
+                    telemetry.get(field),
+                    f"{description}.{partition_field}.{key}.telemetry.{field}",
+                ).get("total"),
+                f"{description}.{partition_field}.{key}.telemetry."
+                f"{field}.total",
+            )
+            for key, telemetry in partition_telemetries.items()
+        )
+        if actual != expected:
+            raise EvalSummaryError(
+                f"{description}.overall.telemetry.{field}.total is "
+                f"inconsistent with {partition_field} partitions"
+            )
+
+    additive_counters = (
+        ("nudged", "trials"),
+        ("failures", "trials"),
+        ("failures", "graded_trials"),
+    )
+    for group, field in additive_counters:
+        actual = _nonnegative_integer(
+            _mapping(
+                overall_telemetry.get(group),
+                f"{description}.overall.telemetry.{group}",
+            ).get(field),
+            f"{description}.overall.telemetry.{group}.{field}",
+        )
+        expected = sum(
+            _nonnegative_integer(
+                _mapping(
+                    telemetry.get(group),
+                    f"{description}.{partition_field}.{key}.telemetry.{group}",
+                ).get(field),
+                f"{description}.{partition_field}.{key}.telemetry."
+                f"{group}.{field}",
+            )
+            for key, telemetry in partition_telemetries.items()
+        )
+        if actual != expected:
+            raise EvalSummaryError(
+                f"{description}.overall.telemetry.{group}.{field} is "
+                f"inconsistent with {partition_field} partitions"
+            )
+
+    overall_failures = _mapping(
+        overall_telemetry.get("failures"),
+        f"{description}.overall.telemetry.failures",
+    )
+    for field in ("by_error_class", "by_failed_grader"):
+        actual_mapping = _mapping(
+            overall_failures.get(field),
+            f"{description}.overall.telemetry.failures.{field}",
+        )
+        actual = Counter(
+            {str(key): int(count) for key, count in actual_mapping.items()}
+        )
+        expected: Counter[str] = Counter()
+        for key, telemetry in partition_telemetries.items():
+            failures = _mapping(
+                telemetry.get("failures"),
+                f"{description}.{partition_field}.{key}.telemetry.failures",
+            )
+            counters = _mapping(
+                failures.get(field),
+                f"{description}.{partition_field}.{key}.telemetry."
+                f"failures.{field}",
+            )
+            expected.update(
+                {str(counter): int(count) for counter, count in counters.items()}
+            )
+        if actual != expected:
+            raise EvalSummaryError(
+                f"{description}.overall.telemetry.failures.{field} is "
+                f"inconsistent with {partition_field} partitions"
+            )
+
+
 def _validate_scope(
     value: object,
     description: str,
@@ -1209,6 +1348,12 @@ def _validate_summary_schema(root: Mapping[str, object], description: str) -> No
             validated_tasks,
             f"{description}.skills.{skill}",
             pricing,
+        )
+    for partition_field in ("suites", "skills"):
+        _validate_partition_telemetry_consistency(
+            root,
+            partition_field,
+            description,
         )
 
 

--- a/infra/agent-image/eval/summarize.py
+++ b/infra/agent-image/eval/summarize.py
@@ -727,6 +727,187 @@ def _validate_telemetry(value: object, description: str) -> None:
         )
 
 
+def _validate_derived_rate(
+    value: object,
+    numerator: int,
+    denominator: int,
+    description: str,
+) -> None:
+    actual = _finite_decimal(value, description)
+    expected = Decimal(str(_rate(numerator, denominator)))
+    if actual != expected:
+        raise EvalSummaryError(f"{description} is inconsistent with its scope")
+
+
+def _validate_scope_telemetry_consistency(
+    value: object,
+    description: str,
+    *,
+    task_count: int,
+    trial_count: int,
+    pricing: Mapping[str, object],
+) -> None:
+    """Validate telemetry fields that are derived from a scope's counters."""
+
+    scope = _mapping(value, description)
+    telemetry = _mapping(scope.get("telemetry"), f"{description}.telemetry")
+    tokens = _mapping(telemetry.get("tokens"), f"{description}.telemetry.tokens")
+    token_counts = {
+        field: _nonnegative_integer(
+            tokens.get(field),
+            f"{description}.telemetry.tokens.{field}",
+        )
+        for field in TOKEN_PRICE_KEYS
+    }
+    prices = {
+        field: _finite_decimal(
+            pricing.get(field),
+            f"model pricing {field}",
+        )
+        for field in TOKEN_PRICE_KEYS.values()
+    }
+    unrounded_cost = sum(
+        Decimal(token_counts[token_field]) * prices[price_field]
+        / Decimal(1_000_000)
+        for token_field, price_field in TOKEN_PRICE_KEYS.items()
+    )
+    expected_costs = {
+        "total_usd": Decimal(str(_rounded_usd(unrounded_cost))),
+        "per_trial_usd": Decimal(
+            str(_rounded_usd(unrounded_cost / Decimal(trial_count)))
+        ),
+        "per_task_usd": Decimal(
+            str(_rounded_usd(unrounded_cost / Decimal(task_count)))
+        ),
+    }
+    cost = _mapping(telemetry.get("cost"), f"{description}.telemetry.cost")
+    for field, expected in expected_costs.items():
+        actual = _finite_decimal(
+            cost.get(field),
+            f"{description}.telemetry.cost.{field}",
+        )
+        if actual != expected:
+            raise EvalSummaryError(
+                f"{description}.telemetry.cost.{field} is inconsistent "
+                "with tokens and model pricing"
+            )
+
+    for field in ("duration_ms", "latency_ms", "model_call_count"):
+        distribution = _mapping(
+            telemetry.get(field),
+            f"{description}.telemetry.{field}",
+        )
+        total = _nonnegative_integer(
+            distribution.get("total"),
+            f"{description}.telemetry.{field}.total",
+        )
+        expected_mean = Decimal(str(round(total / trial_count, 3)))
+        actual_mean = _finite_decimal(
+            distribution.get("mean"),
+            f"{description}.telemetry.{field}.mean",
+        )
+        if actual_mean != expected_mean:
+            raise EvalSummaryError(
+                f"{description}.telemetry.{field}.mean is inconsistent "
+                "with total and trial_count"
+            )
+        p50 = _nonnegative_integer(
+            distribution.get("p50"),
+            f"{description}.telemetry.{field}.p50",
+        )
+        p95 = _nonnegative_integer(
+            distribution.get("p95"),
+            f"{description}.telemetry.{field}.p95",
+        )
+        if p50 > p95 or p95 > total:
+            raise EvalSummaryError(
+                f"{description}.telemetry.{field} percentiles are "
+                "inconsistent with total"
+            )
+
+    nudged = _mapping(telemetry.get("nudged"), f"{description}.telemetry.nudged")
+    nudged_trials = _nonnegative_integer(
+        nudged.get("trials"),
+        f"{description}.telemetry.nudged.trials",
+    )
+    if nudged_trials > trial_count:
+        raise EvalSummaryError(
+            f"{description}.telemetry.nudged.trials exceeds trial_count"
+        )
+    _validate_derived_rate(
+        nudged.get("rate"),
+        nudged_trials,
+        trial_count,
+        f"{description}.telemetry.nudged.rate",
+    )
+
+    failures = _mapping(
+        telemetry.get("failures"),
+        f"{description}.telemetry.failures",
+    )
+    failed_trials = _nonnegative_integer(
+        failures.get("trials"),
+        f"{description}.telemetry.failures.trials",
+    )
+    if failed_trials > trial_count:
+        raise EvalSummaryError(
+            f"{description}.telemetry.failures.trials exceeds trial_count"
+        )
+    _validate_derived_rate(
+        failures.get("rate"),
+        failed_trials,
+        trial_count,
+        f"{description}.telemetry.failures.rate",
+    )
+    error_classes = _mapping(
+        failures.get("by_error_class"),
+        f"{description}.telemetry.failures.by_error_class",
+    )
+    if sum(int(count) for count in error_classes.values()) != failed_trials:
+        raise EvalSummaryError(
+            f"{description}.telemetry.failures.by_error_class is inconsistent "
+            "with failed trials"
+        )
+
+    graded_trials = _nonnegative_integer(
+        failures.get("graded_trials"),
+        f"{description}.telemetry.failures.graded_trials",
+    )
+    if graded_trials > trial_count:
+        raise EvalSummaryError(
+            f"{description}.telemetry.failures.graded_trials exceeds trial_count"
+        )
+    _validate_derived_rate(
+        failures.get("graded_rate"),
+        graded_trials,
+        trial_count,
+        f"{description}.telemetry.failures.graded_rate",
+    )
+    failed_graders = _mapping(
+        failures.get("by_failed_grader"),
+        f"{description}.telemetry.failures.by_failed_grader",
+    )
+    failed_grader_count = sum(int(count) for count in failed_graders.values())
+    if (graded_trials == 0 and failed_grader_count != 0) or (
+        graded_trials > 0 and failed_grader_count < graded_trials
+    ):
+        raise EvalSummaryError(
+            f"{description}.telemetry.failures.by_failed_grader is inconsistent "
+            "with graded failed trials"
+        )
+
+    expected_caching_status = (
+        "uncached"
+        if token_counts["cache_read_input_tokens"] == 0
+        else "cached"
+    )
+    if telemetry.get("caching_status") != expected_caching_status:
+        raise EvalSummaryError(
+            f"{description}.telemetry.caching_status is inconsistent "
+            "with cache-read tokens"
+        )
+
+
 def _validate_scope(
     value: object,
     description: str,
@@ -755,6 +936,7 @@ def _validate_scope_consistency(
     task_ids: Sequence[str],
     tasks: Mapping[str, Mapping[str, object]],
     description: str,
+    pricing: Mapping[str, object],
 ) -> None:
     """Ensure a scope's pass^3 headline is derived from its task summaries."""
 
@@ -770,6 +952,8 @@ def _validate_scope_consistency(
     expected_passed_tasks = sum(
         tasks[task_id].get("pass^3") is True for task_id in task_ids
     )
+    if expected_task_count == 0 or expected_trial_count == 0:
+        raise EvalSummaryError(f"{description} must contain evaluated tasks")
     if scope.get("task_count") != expected_task_count:
         raise EvalSummaryError(
             f"{description}.task_count is inconsistent with tasks"
@@ -797,6 +981,13 @@ def _validate_scope_consistency(
         raise EvalSummaryError(
             f"{description}.pass^3.rate is inconsistent with tasks"
         )
+    _validate_scope_telemetry_consistency(
+        scope,
+        description,
+        task_count=expected_task_count,
+        trial_count=expected_trial_count,
+        pricing=pricing,
+    )
 
 
 def _validate_summary_schema(root: Mapping[str, object], description: str) -> None:
@@ -964,6 +1155,7 @@ def _validate_summary_schema(root: Mapping[str, object], description: str) -> No
         task_ids,
         validated_tasks,
         f"{description}.overall",
+        pricing,
     )
 
     suites = _mapping(root.get("suites"), f"{description}.suites")
@@ -987,6 +1179,7 @@ def _validate_summary_schema(root: Mapping[str, object], description: str) -> No
             suite_task_ids,
             validated_tasks,
             f"{description}.suites.{suite}",
+            pricing,
         )
 
     skills = _mapping(root.get("skills"), f"{description}.skills")
@@ -1015,6 +1208,7 @@ def _validate_summary_schema(root: Mapping[str, object], description: str) -> No
             skill_task_ids,
             validated_tasks,
             f"{description}.skills.{skill}",
+            pricing,
         )
 
 

--- a/infra/agent-image/eval/summarize.py
+++ b/infra/agent-image/eval/summarize.py
@@ -54,10 +54,121 @@ TELEMETRY_INTEGER_FIELDS = (
     "latency_ms",
 )
 USD_QUANTUM = Decimal("0.000001")
+MAX_SUMMARY_KEY_LENGTH = 200
 
 
 class EvalSummaryError(RuntimeError):
     """Trial records could not be converted into a trustworthy summary."""
+
+
+class _MapOf:
+    """An object with free-form string keys whose values share one shape."""
+
+    __slots__ = ("value",)
+
+    def __init__(self, value: object) -> None:
+        self.value = value
+
+
+class _ListOf:
+    """An array whose items share one shape."""
+
+    __slots__ = ("item",)
+
+    def __init__(self, item: object) -> None:
+        self.item = item
+
+
+class _Nullable:
+    """A field that may be null before it is bound for a committed summary."""
+
+    __slots__ = ("inner",)
+
+    def __init__(self, inner: object) -> None:
+        self.inner = inner
+
+
+_STRING = "string"
+_INTEGER = "integer"
+_NUMBER = "number"
+_BOOLEAN = "boolean"
+
+_DISTRIBUTION_SCHEMA = {
+    "total": _NUMBER,
+    "mean": _NUMBER,
+    "p50": _NUMBER,
+    "p95": _NUMBER,
+}
+_TELEMETRY_SCHEMA = {
+    "tokens": {field: _INTEGER for field in TOKEN_PRICE_KEYS},
+    "cost": {
+        "total_usd": _NUMBER,
+        "per_trial_usd": _NUMBER,
+        "per_task_usd": _NUMBER,
+    },
+    "duration_ms": _DISTRIBUTION_SCHEMA,
+    "latency_ms": _DISTRIBUTION_SCHEMA,
+    "model_call_count": _DISTRIBUTION_SCHEMA,
+    "nudged": {"trials": _INTEGER, "rate": _NUMBER},
+    "failures": {
+        "trials": _INTEGER,
+        "rate": _NUMBER,
+        "by_error_class": _MapOf(_INTEGER),
+        "graded_trials": _INTEGER,
+        "graded_rate": _NUMBER,
+        "by_failed_grader": _MapOf(_INTEGER),
+    },
+    "caching_status": _STRING,
+}
+_SCOPE_SCHEMA = {
+    "task_count": _INTEGER,
+    "trial_count": _INTEGER,
+    "pass^3": {
+        "passed_tasks": _INTEGER,
+        "total_tasks": _INTEGER,
+        "rate": _NUMBER,
+    },
+    "telemetry": _TELEMETRY_SCHEMA,
+}
+# The complete, closed shape of a committed run summary. Anything not named
+# here — including a differently cased or newly invented key — is rejected, so
+# transcript text cannot ride along under a name the denylist never anticipated.
+SUMMARY_SCHEMA = {
+    "schema_version": _INTEGER,
+    "summary_kind": _STRING,
+    "image": _STRING,
+    "image_digest": _STRING,
+    # Null only for uncommitted, ad-hoc runs; validate_committed_summary()
+    # separately requires a full Git object ID before an artifact may land.
+    "source_commit": _Nullable(_STRING),
+    "run": {
+        "first_record_at": _STRING,
+        "last_record_at": _STRING,
+        "task_count": _INTEGER,
+        "trial_count": _INTEGER,
+        "trials_per_task": _INTEGER,
+    },
+    "model": {
+        "primary": _STRING,
+        "provider": _STRING,
+        "model_id": _STRING,
+        "pricing_usd_per_million_tokens": {
+            price_key: _NUMBER for price_key in TOKEN_PRICE_KEYS.values()
+        },
+    },
+    "overall": _SCOPE_SCHEMA,
+    "suites": _MapOf(_SCOPE_SCHEMA),
+    "skills": _MapOf({**_SCOPE_SCHEMA, "task_ids": _ListOf(_STRING)}),
+    "tasks": _MapOf(
+        {
+            "skill": _STRING,
+            "suite": _STRING,
+            "trials": _INTEGER,
+            "passed_trials": _INTEGER,
+            "pass^3": _BOOLEAN,
+        }
+    ),
+}
 
 
 def _mapping(value: object, description: str) -> Mapping[str, object]:
@@ -489,8 +600,12 @@ def summarize_records(
         "image_digest": digest,
         "source_commit": source_commit,
         "run": {
-            "started_at": min(recorded_times).isoformat(),
-            "completed_at": max(recorded_times).isoformat(),
+            # Both bounds come from `recorded_at`, which runner.py stamps only
+            # after a trial has been graded — so these are the first and last
+            # *completion* times, not container start or run end. Named for what
+            # they are so elapsed-time math is not silently wrong.
+            "first_record_at": min(recorded_times).isoformat(),
+            "last_record_at": max(recorded_times).isoformat(),
             "task_count": len(task_summaries),
             "trial_count": len(records),
             "trials_per_task": 3,
@@ -515,6 +630,7 @@ def summarize_records(
         "tasks": task_summaries,
     }
     _assert_no_transcript_fields(summary)
+    _assert_summary_schema(summary, SUMMARY_SCHEMA)
     return summary
 
 
@@ -529,6 +645,68 @@ def _assert_no_transcript_fields(value: object, path: str = "$") -> None:
     elif isinstance(value, list):
         for index, child in enumerate(value):
             _assert_no_transcript_fields(child, f"{path}[{index}]")
+
+
+def _assert_summary_key(key: object, path: str) -> str:
+    if not isinstance(key, str) or not key:
+        raise EvalSummaryError(f"summary {path} keys must be non-empty strings")
+    if len(key) > MAX_SUMMARY_KEY_LENGTH or key.strip() != key or "\n" in key:
+        raise EvalSummaryError(f"summary {path}.{key[:40]!r} is not a plain identifier")
+    return key
+
+
+def _assert_summary_scalar(value: object, spec: str, path: str) -> None:
+    if spec == _BOOLEAN:
+        if not isinstance(value, bool):
+            raise EvalSummaryError(f"summary {path} must be a boolean")
+        return
+    if isinstance(value, bool):
+        raise EvalSummaryError(f"summary {path} must not be a boolean")
+    if spec == _STRING:
+        _nonempty_string(value, f"summary {path}")
+        return
+    if spec == _INTEGER:
+        _nonnegative_integer(value, f"summary {path}")
+        return
+    _finite_decimal(value, f"summary {path}")
+
+
+def _assert_summary_schema(value: object, spec: object, path: str = "$") -> None:
+    """Reject anything the committed summary schema does not explicitly allow."""
+
+    if isinstance(spec, _Nullable):
+        if value is None:
+            return
+        _assert_summary_schema(value, spec.inner, path)
+        return
+    if isinstance(spec, _MapOf):
+        mapping = _mapping(value, f"summary {path}")
+        for key, child in mapping.items():
+            _assert_summary_key(key, path)
+            _assert_summary_schema(child, spec.value, f"{path}.{key}")
+        return
+    if isinstance(spec, _ListOf):
+        if not isinstance(value, list):
+            raise EvalSummaryError(f"summary {path} must be an array")
+        for index, child in enumerate(value):
+            _assert_summary_schema(child, spec.item, f"{path}[{index}]")
+        return
+    if isinstance(spec, Mapping):
+        mapping = _mapping(value, f"summary {path}")
+        unexpected = sorted(str(key) for key in set(mapping) - set(spec))
+        if unexpected:
+            raise EvalSummaryError(
+                f"summary {path} contains unexpected field(s): {', '.join(unexpected)}"
+            )
+        missing = sorted(set(spec) - set(mapping))
+        if missing:
+            raise EvalSummaryError(
+                f"summary {path} is missing required field(s): {', '.join(missing)}"
+            )
+        for key, child_spec in spec.items():
+            _assert_summary_schema(mapping[key], child_spec, f"{path}.{key}")
+        return
+    _assert_summary_scalar(value, spec, path)
 
 
 def validate_committed_summary(path: Path, content: bytes) -> None:
@@ -563,6 +741,7 @@ def validate_committed_summary(path: Path, content: bytes) -> None:
     if not isinstance(source_commit, str) or GIT_OID_RE.fullmatch(source_commit) is None:
         raise EvalSummaryError(f"{path} source_commit must be a full Git object ID")
     _assert_no_transcript_fields(root)
+    _assert_summary_schema(root, SUMMARY_SCHEMA)
 
 
 def check_repository(repo_root: Path) -> list[Path]:

--- a/infra/agent-image/eval/summarize.py
+++ b/infra/agent-image/eval/summarize.py
@@ -1081,11 +1081,26 @@ def check_repository(repo_root: Path) -> list[Path]:
         if value
     ]
     for relative_path in tracked:
-        try:
-            content = (repo_root / relative_path).read_bytes()
-        except OSError as error:
-            raise EvalSummaryError(f"could not read {relative_path}: {error}") from error
-        validate_committed_summary(relative_path, content)
+        indexed_blob = subprocess.run(
+            [
+                "git",
+                "cat-file",
+                "blob",
+                f":{relative_path.as_posix()}",
+            ],
+            cwd=repo_root,
+            check=False,
+            capture_output=True,
+        )
+        if indexed_blob.returncode != 0:
+            detail = indexed_blob.stderr.decode(
+                "utf-8",
+                errors="replace",
+            ).strip()
+            raise EvalSummaryError(
+                f"could not read staged {relative_path}: {detail}"
+            )
+        validate_committed_summary(relative_path, indexed_blob.stdout)
     return tracked
 
 

--- a/infra/agent-image/eval/summarize.py
+++ b/infra/agent-image/eval/summarize.py
@@ -22,7 +22,10 @@ from pathlib import Path
 
 SCHEMA_VERSION = 2
 SUMMARY_KIND = "agent-eval-run"
-IMMUTABLE_DIGEST_RE = re.compile(r"(?:^|@)(sha256:[0-9a-f]{64})$")
+IMMUTABLE_ECR_IMAGE_RE = re.compile(
+    r"^[0-9]{12}\.dkr\.ecr\.[a-z0-9-]+\.amazonaws\.com(?:\.cn)?/"
+    r"[a-z0-9]+(?:[._/-][a-z0-9]+)*@(?P<digest>sha256:[0-9a-f]{64})$"
+)
 SAFE_SUMMARY_NAME_RE = re.compile(r"^sha256-[0-9a-f]{64}\.json$")
 GIT_OID_RE = re.compile(r"^(?:[0-9a-f]{40}|[0-9a-f]{64})$")
 SAFE_IDENTIFIER_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:/@+-]{0,255}$")
@@ -100,12 +103,12 @@ def _finite_decimal(value: object, description: str) -> Decimal:
 
 
 def _digest_from_image(image: str) -> str:
-    match = IMMUTABLE_DIGEST_RE.search(image)
+    match = IMMUTABLE_ECR_IMAGE_RE.fullmatch(image)
     if match is None:
         raise EvalSummaryError(
-            "trial image must be an immutable sha256 digest, not a mutable tag"
+            "trial image must be a complete immutable ECR sha256 URI"
         )
-    return match.group(1)
+    return match.group("digest")
 
 
 def _timestamp(value: object, description: str) -> datetime:
@@ -747,6 +750,55 @@ def _validate_scope(
             _safe_identifier(task_id, f"{description}.task_ids[{index}]")
 
 
+def _validate_scope_consistency(
+    value: object,
+    task_ids: Sequence[str],
+    tasks: Mapping[str, Mapping[str, object]],
+    description: str,
+) -> None:
+    """Ensure a scope's pass^3 headline is derived from its task summaries."""
+
+    scope = _mapping(value, description)
+    expected_task_count = len(task_ids)
+    expected_trial_count = sum(
+        _positive_integer(
+            tasks[task_id].get("trials"),
+            f"{description} task {task_id} trials",
+        )
+        for task_id in task_ids
+    )
+    expected_passed_tasks = sum(
+        tasks[task_id].get("pass^3") is True for task_id in task_ids
+    )
+    if scope.get("task_count") != expected_task_count:
+        raise EvalSummaryError(
+            f"{description}.task_count is inconsistent with tasks"
+        )
+    if scope.get("trial_count") != expected_trial_count:
+        raise EvalSummaryError(
+            f"{description}.trial_count is inconsistent with tasks"
+        )
+
+    pass_three = _mapping(scope.get("pass^3"), f"{description}.pass^3")
+    if pass_three.get("passed_tasks") != expected_passed_tasks:
+        raise EvalSummaryError(
+            f"{description}.pass^3.passed_tasks is inconsistent with tasks"
+        )
+    if pass_three.get("total_tasks") != expected_task_count:
+        raise EvalSummaryError(
+            f"{description}.pass^3.total_tasks is inconsistent with tasks"
+        )
+    expected_rate = Decimal(str(_rate(expected_passed_tasks, expected_task_count)))
+    actual_rate = _finite_decimal(
+        pass_three.get("rate"),
+        f"{description}.pass^3.rate",
+    )
+    if actual_rate != expected_rate:
+        raise EvalSummaryError(
+            f"{description}.pass^3.rate is inconsistent with tasks"
+        )
+
+
 def _validate_summary_schema(root: Mapping[str, object], description: str) -> None:
     """Validate the complete allowlisted committed-summary schema."""
 
@@ -848,6 +900,7 @@ def _validate_summary_schema(root: Mapping[str, object], description: str) -> No
                 includes_task_ids=includes_task_ids,
             )
     tasks = _mapping(root.get("tasks"), f"{description}.tasks")
+    validated_tasks: dict[str, Mapping[str, object]] = {}
     for task_id, task_value in tasks.items():
         _safe_identifier(task_id, f"{description}.tasks key")
         task = _mapping(task_value, f"{description}.tasks.{task_id}")
@@ -874,6 +927,95 @@ def _validate_summary_schema(root: Mapping[str, object], description: str) -> No
             raise EvalSummaryError(
                 f"{description}.tasks.{task_id}.pass^3 must be a boolean"
             )
+        if trials != 3:
+            raise EvalSummaryError(
+                f"{description}.tasks.{task_id}.trials must be three for pass^3"
+            )
+        if task.get("pass^3") is not (passed_trials == trials):
+            raise EvalSummaryError(
+                f"{description}.tasks.{task_id}.pass^3 is inconsistent "
+                "with passed_trials"
+            )
+        validated_tasks[task_id] = task
+
+    task_ids = sorted(validated_tasks)
+    if run.get("trials_per_task") != 3:
+        raise EvalSummaryError(
+            f"{description}.run.trials_per_task must be three for pass^3"
+        )
+    if run.get("task_count") != len(task_ids):
+        raise EvalSummaryError(
+            f"{description}.run.task_count is inconsistent with tasks"
+        )
+    expected_trial_count = sum(
+        _positive_integer(
+            task.get("trials"),
+            f"{description}.tasks.{task_id}.trials",
+        )
+        for task_id, task in validated_tasks.items()
+    )
+    if run.get("trial_count") != expected_trial_count:
+        raise EvalSummaryError(
+            f"{description}.run.trial_count is inconsistent with tasks"
+        )
+
+    _validate_scope_consistency(
+        root.get("overall"),
+        task_ids,
+        validated_tasks,
+        f"{description}.overall",
+    )
+
+    suites = _mapping(root.get("suites"), f"{description}.suites")
+    expected_suites = {
+        _safe_identifier(
+            task.get("suite"),
+            f"{description}.tasks.{task_id}.suite",
+        )
+        for task_id, task in validated_tasks.items()
+    }
+    if set(suites) != expected_suites:
+        raise EvalSummaryError(f"{description}.suites is inconsistent with tasks")
+    for suite, scope in suites.items():
+        suite_task_ids = sorted(
+            task_id
+            for task_id, task in validated_tasks.items()
+            if task.get("suite") == suite
+        )
+        _validate_scope_consistency(
+            scope,
+            suite_task_ids,
+            validated_tasks,
+            f"{description}.suites.{suite}",
+        )
+
+    skills = _mapping(root.get("skills"), f"{description}.skills")
+    expected_skills = {
+        _safe_identifier(
+            task.get("skill"),
+            f"{description}.tasks.{task_id}.skill",
+        )
+        for task_id, task in validated_tasks.items()
+    }
+    if set(skills) != expected_skills:
+        raise EvalSummaryError(f"{description}.skills is inconsistent with tasks")
+    for skill, scope_value in skills.items():
+        skill_task_ids = sorted(
+            task_id
+            for task_id, task in validated_tasks.items()
+            if task.get("skill") == skill
+        )
+        scope = _mapping(scope_value, f"{description}.skills.{skill}")
+        if scope.get("task_ids") != skill_task_ids:
+            raise EvalSummaryError(
+                f"{description}.skills.{skill}.task_ids is inconsistent with tasks"
+            )
+        _validate_scope_consistency(
+            scope,
+            skill_task_ids,
+            validated_tasks,
+            f"{description}.skills.{skill}",
+        )
 
 
 def validate_committed_summary(path: Path, content: bytes) -> None:

--- a/infra/agent-image/eval/summarize.py
+++ b/infra/agent-image/eval/summarize.py
@@ -745,6 +745,7 @@ def _validate_scope_telemetry_consistency(
     *,
     task_count: int,
     trial_count: int,
+    expected_graded_trials: int,
     pricing: Mapping[str, object],
 ) -> None:
     """Validate telemetry fields that are derived from a scope's counters."""
@@ -876,6 +877,11 @@ def _validate_scope_telemetry_consistency(
     if graded_trials > trial_count:
         raise EvalSummaryError(
             f"{description}.telemetry.failures.graded_trials exceeds trial_count"
+        )
+    if graded_trials != expected_graded_trials:
+        raise EvalSummaryError(
+            f"{description}.telemetry.failures.graded_trials is inconsistent "
+            "with task passed-trial counts"
         )
     _validate_derived_rate(
         failures.get("graded_rate"),
@@ -1088,6 +1094,17 @@ def _validate_scope_consistency(
         )
         for task_id in task_ids
     )
+    expected_graded_trials = sum(
+        _positive_integer(
+            tasks[task_id].get("trials"),
+            f"{description} task {task_id} trials",
+        )
+        - _nonnegative_integer(
+            tasks[task_id].get("passed_trials"),
+            f"{description} task {task_id} passed_trials",
+        )
+        for task_id in task_ids
+    )
     expected_passed_tasks = sum(
         tasks[task_id].get("pass^3") is True for task_id in task_ids
     )
@@ -1125,6 +1142,7 @@ def _validate_scope_consistency(
         description,
         task_count=expected_task_count,
         trial_count=expected_trial_count,
+        expected_graded_trials=expected_graded_trials,
         pricing=pricing,
     )
 

--- a/infra/agent-image/eval/summarize.py
+++ b/infra/agent-image/eval/summarize.py
@@ -20,11 +20,13 @@ from datetime import datetime
 from decimal import Decimal, InvalidOperation, ROUND_HALF_UP
 from pathlib import Path
 
-SCHEMA_VERSION = 1
+SCHEMA_VERSION = 2
 SUMMARY_KIND = "agent-eval-run"
 IMMUTABLE_DIGEST_RE = re.compile(r"(?:^|@)(sha256:[0-9a-f]{64})$")
 SAFE_SUMMARY_NAME_RE = re.compile(r"^sha256-[0-9a-f]{64}\.json$")
 GIT_OID_RE = re.compile(r"^(?:[0-9a-f]{40}|[0-9a-f]{64})$")
+SAFE_IDENTIFIER_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:/@+-]{0,255}$")
+SOURCE_COMMIT_PROVENANCE = frozenset({"image-label", "legacy-image-tag"})
 FORBIDDEN_SUMMARY_KEYS = frozenset(
     {
         "broker_requests",
@@ -54,121 +56,10 @@ TELEMETRY_INTEGER_FIELDS = (
     "latency_ms",
 )
 USD_QUANTUM = Decimal("0.000001")
-MAX_SUMMARY_KEY_LENGTH = 200
 
 
 class EvalSummaryError(RuntimeError):
     """Trial records could not be converted into a trustworthy summary."""
-
-
-class _MapOf:
-    """An object with free-form string keys whose values share one shape."""
-
-    __slots__ = ("value",)
-
-    def __init__(self, value: object) -> None:
-        self.value = value
-
-
-class _ListOf:
-    """An array whose items share one shape."""
-
-    __slots__ = ("item",)
-
-    def __init__(self, item: object) -> None:
-        self.item = item
-
-
-class _Nullable:
-    """A field that may be null before it is bound for a committed summary."""
-
-    __slots__ = ("inner",)
-
-    def __init__(self, inner: object) -> None:
-        self.inner = inner
-
-
-_STRING = "string"
-_INTEGER = "integer"
-_NUMBER = "number"
-_BOOLEAN = "boolean"
-
-_DISTRIBUTION_SCHEMA = {
-    "total": _NUMBER,
-    "mean": _NUMBER,
-    "p50": _NUMBER,
-    "p95": _NUMBER,
-}
-_TELEMETRY_SCHEMA = {
-    "tokens": {field: _INTEGER for field in TOKEN_PRICE_KEYS},
-    "cost": {
-        "total_usd": _NUMBER,
-        "per_trial_usd": _NUMBER,
-        "per_task_usd": _NUMBER,
-    },
-    "duration_ms": _DISTRIBUTION_SCHEMA,
-    "latency_ms": _DISTRIBUTION_SCHEMA,
-    "model_call_count": _DISTRIBUTION_SCHEMA,
-    "nudged": {"trials": _INTEGER, "rate": _NUMBER},
-    "failures": {
-        "trials": _INTEGER,
-        "rate": _NUMBER,
-        "by_error_class": _MapOf(_INTEGER),
-        "graded_trials": _INTEGER,
-        "graded_rate": _NUMBER,
-        "by_failed_grader": _MapOf(_INTEGER),
-    },
-    "caching_status": _STRING,
-}
-_SCOPE_SCHEMA = {
-    "task_count": _INTEGER,
-    "trial_count": _INTEGER,
-    "pass^3": {
-        "passed_tasks": _INTEGER,
-        "total_tasks": _INTEGER,
-        "rate": _NUMBER,
-    },
-    "telemetry": _TELEMETRY_SCHEMA,
-}
-# The complete, closed shape of a committed run summary. Anything not named
-# here — including a differently cased or newly invented key — is rejected, so
-# transcript text cannot ride along under a name the denylist never anticipated.
-SUMMARY_SCHEMA = {
-    "schema_version": _INTEGER,
-    "summary_kind": _STRING,
-    "image": _STRING,
-    "image_digest": _STRING,
-    # Null only for uncommitted, ad-hoc runs; validate_committed_summary()
-    # separately requires a full Git object ID before an artifact may land.
-    "source_commit": _Nullable(_STRING),
-    "run": {
-        "first_record_at": _STRING,
-        "last_record_at": _STRING,
-        "task_count": _INTEGER,
-        "trial_count": _INTEGER,
-        "trials_per_task": _INTEGER,
-    },
-    "model": {
-        "primary": _STRING,
-        "provider": _STRING,
-        "model_id": _STRING,
-        "pricing_usd_per_million_tokens": {
-            price_key: _NUMBER for price_key in TOKEN_PRICE_KEYS.values()
-        },
-    },
-    "overall": _SCOPE_SCHEMA,
-    "suites": _MapOf(_SCOPE_SCHEMA),
-    "skills": _MapOf({**_SCOPE_SCHEMA, "task_ids": _ListOf(_STRING)}),
-    "tasks": _MapOf(
-        {
-            "skill": _STRING,
-            "suite": _STRING,
-            "trials": _INTEGER,
-            "passed_trials": _INTEGER,
-            "pass^3": _BOOLEAN,
-        }
-    ),
-}
 
 
 def _mapping(value: object, description: str) -> Mapping[str, object]:
@@ -314,7 +205,7 @@ def load_model_pricing(path: Path) -> dict[str, object]:
 def _validate_record(
     record: Mapping[str, object],
     index: int,
-) -> tuple[str, str, str, int, int, str, datetime]:
+) -> tuple[str, str, str, int, int, str, datetime, datetime | None]:
     label = f"trial record {index}"
     task_id = _nonempty_string(record.get("task_id"), f"{label} task_id")
     skill = _nonempty_string(record.get("skill"), f"{label} skill")
@@ -329,6 +220,14 @@ def _validate_record(
         record.get("recorded_at"),
         f"{label} recorded_at",
     )
+    raw_run_started_at = record.get("run_started_at")
+    run_started_at = (
+        None
+        if raw_run_started_at is None
+        else _timestamp(raw_run_started_at, f"{label} run_started_at")
+    )
+    if run_started_at is not None and run_started_at > recorded_at:
+        raise EvalSummaryError(f"{label} run_started_at is after recorded_at")
     grade = _mapping(record.get("grade"), f"{label} grade")
     if not isinstance(grade.get("passed"), bool):
         raise EvalSummaryError(f"{label} grade.passed must be a boolean")
@@ -341,7 +240,7 @@ def _validate_record(
     error_class = metadata.get("error_class")
     if error_class is not None and not isinstance(error_class, str):
         raise EvalSummaryError(f"{label} metadata.error_class must be a string or null")
-    return task_id, skill, suite, trial, trials, image, recorded_at
+    return task_id, skill, suite, trial, trials, image, recorded_at, run_started_at
 
 
 def _rounded_usd(value: Decimal) -> float:
@@ -495,6 +394,8 @@ def summarize_records(
     *,
     expected_image: str | None = None,
     source_commit: str | None = None,
+    source_commit_provenance: str | None = None,
+    eval_harness_commit: str | None = None,
 ) -> dict[str, object]:
     """Validate complete trials and return a transcript-free run summary."""
 
@@ -502,17 +403,35 @@ def summarize_records(
         raise EvalSummaryError("cannot summarize zero records")
     if source_commit is not None and GIT_OID_RE.fullmatch(source_commit) is None:
         raise EvalSummaryError("source_commit must be a full Git object ID")
+    if (
+        source_commit_provenance is not None
+        and source_commit_provenance not in SOURCE_COMMIT_PROVENANCE
+    ):
+        raise EvalSummaryError("source_commit_provenance is invalid")
+    if (
+        eval_harness_commit is not None
+        and GIT_OID_RE.fullmatch(eval_harness_commit) is None
+    ):
+        raise EvalSummaryError("eval_harness_commit must be a full Git object ID")
     seen_trials: set[tuple[str, int]] = set()
     grouped_tasks: dict[str, list[Mapping[str, object]]] = defaultdict(list)
     task_identity: dict[str, tuple[str, str, int]] = {}
     images: set[str] = set()
     digests: set[str] = set()
     recorded_times: list[datetime] = []
+    run_started_times: list[datetime] = []
+    missing_run_started_at = False
     for index, record in enumerate(records, start=1):
-        task_id, skill, suite, trial, trials, image, recorded_at = _validate_record(
-            record,
-            index,
-        )
+        (
+            task_id,
+            skill,
+            suite,
+            trial,
+            trials,
+            image,
+            recorded_at,
+            run_started_at,
+        ) = _validate_record(record, index)
         key = (task_id, trial)
         if key in seen_trials:
             raise EvalSummaryError(f"duplicate trial record for {task_id} trial {trial}")
@@ -525,6 +444,10 @@ def summarize_records(
         images.add(image)
         digests.add(_digest_from_image(image))
         recorded_times.append(recorded_at)
+        if run_started_at is None:
+            missing_run_started_at = True
+        else:
+            run_started_times.append(run_started_at)
     if len(images) != 1 or len(digests) != 1:
         raise EvalSummaryError("all trial records must use the same immutable image")
     image = next(iter(images))
@@ -599,13 +522,21 @@ def summarize_records(
         "image": image,
         "image_digest": digest,
         "source_commit": source_commit,
+        "source_commit_provenance": source_commit_provenance,
+        "eval_harness_commit": eval_harness_commit,
         "run": {
-            # Both bounds come from `recorded_at`, which runner.py stamps only
-            # after a trial has been graded — so these are the first and last
-            # *completion* times, not container start or run end. Named for what
-            # they are so elapsed-time math is not silently wrong.
-            "first_record_at": min(recorded_times).isoformat(),
-            "last_record_at": max(recorded_times).isoformat(),
+            "started_at": (
+                None
+                if missing_run_started_at
+                else min(run_started_times).isoformat()
+            ),
+            "start_time_status": (
+                "unavailable-legacy-records"
+                if missing_run_started_at
+                else "captured"
+            ),
+            "first_trial_recorded_at": min(recorded_times).isoformat(),
+            "completed_at": max(recorded_times).isoformat(),
             "task_count": len(task_summaries),
             "trial_count": len(records),
             "trials_per_task": 3,
@@ -630,7 +561,7 @@ def summarize_records(
         "tasks": task_summaries,
     }
     _assert_no_transcript_fields(summary)
-    _assert_summary_schema(summary, SUMMARY_SCHEMA)
+    _validate_summary_schema(summary, "summary")
     return summary
 
 
@@ -647,66 +578,302 @@ def _assert_no_transcript_fields(value: object, path: str = "$") -> None:
             _assert_no_transcript_fields(child, f"{path}[{index}]")
 
 
-def _assert_summary_key(key: object, path: str) -> str:
-    if not isinstance(key, str) or not key:
-        raise EvalSummaryError(f"summary {path} keys must be non-empty strings")
-    if len(key) > MAX_SUMMARY_KEY_LENGTH or key.strip() != key or "\n" in key:
-        raise EvalSummaryError(f"summary {path}.{key[:40]!r} is not a plain identifier")
-    return key
-
-
-def _assert_summary_scalar(value: object, spec: str, path: str) -> None:
-    if spec == _BOOLEAN:
-        if not isinstance(value, bool):
-            raise EvalSummaryError(f"summary {path} must be a boolean")
-        return
-    if isinstance(value, bool):
-        raise EvalSummaryError(f"summary {path} must not be a boolean")
-    if spec == _STRING:
-        _nonempty_string(value, f"summary {path}")
-        return
-    if spec == _INTEGER:
-        _nonnegative_integer(value, f"summary {path}")
-        return
-    _finite_decimal(value, f"summary {path}")
-
-
-def _assert_summary_schema(value: object, spec: object, path: str = "$") -> None:
-    """Reject anything the committed summary schema does not explicitly allow."""
-
-    if isinstance(spec, _Nullable):
-        if value is None:
-            return
-        _assert_summary_schema(value, spec.inner, path)
-        return
-    if isinstance(spec, _MapOf):
-        mapping = _mapping(value, f"summary {path}")
-        for key, child in mapping.items():
-            _assert_summary_key(key, path)
-            _assert_summary_schema(child, spec.value, f"{path}.{key}")
-        return
-    if isinstance(spec, _ListOf):
-        if not isinstance(value, list):
-            raise EvalSummaryError(f"summary {path} must be an array")
-        for index, child in enumerate(value):
-            _assert_summary_schema(child, spec.item, f"{path}[{index}]")
-        return
-    if isinstance(spec, Mapping):
-        mapping = _mapping(value, f"summary {path}")
-        unexpected = sorted(str(key) for key in set(mapping) - set(spec))
+def _exact_keys(
+    value: Mapping[str, object],
+    expected: set[str],
+    description: str,
+) -> None:
+    actual = set(value)
+    if actual != expected:
+        unexpected = sorted(actual - expected)
+        missing = sorted(expected - actual)
+        details = []
         if unexpected:
-            raise EvalSummaryError(
-                f"summary {path} contains unexpected field(s): {', '.join(unexpected)}"
-            )
-        missing = sorted(set(spec) - set(mapping))
+            details.append(f"unexpected fields: {', '.join(unexpected)}")
         if missing:
-            raise EvalSummaryError(
-                f"summary {path} is missing required field(s): {', '.join(missing)}"
+            details.append(f"missing fields: {', '.join(missing)}")
+        raise EvalSummaryError(f"{description} has {'; '.join(details)}")
+
+
+def _safe_identifier(value: object, description: str) -> str:
+    parsed = _nonempty_string(value, description)
+    if SAFE_IDENTIFIER_RE.fullmatch(parsed) is None:
+        raise EvalSummaryError(f"{description} is not a safe identifier")
+    return parsed
+
+
+def _rate_value(value: object, description: str) -> None:
+    parsed = _finite_decimal(value, description)
+    if parsed > 1:
+        raise EvalSummaryError(f"{description} must be between zero and one")
+
+
+def _validate_counter_map(value: object, description: str) -> None:
+    counters = _mapping(value, description)
+    for key, count in counters.items():
+        _safe_identifier(key, f"{description} key")
+        _nonnegative_integer(count, f"{description}.{key}")
+
+
+def _validate_pass_three(value: object, description: str) -> None:
+    pass_three = _mapping(value, description)
+    _exact_keys(
+        pass_three,
+        {"passed_tasks", "total_tasks", "rate"},
+        description,
+    )
+    passed = _nonnegative_integer(
+        pass_three.get("passed_tasks"),
+        f"{description}.passed_tasks",
+    )
+    total = _nonnegative_integer(
+        pass_three.get("total_tasks"),
+        f"{description}.total_tasks",
+    )
+    if passed > total:
+        raise EvalSummaryError(f"{description}.passed_tasks exceeds total_tasks")
+    _rate_value(pass_three.get("rate"), f"{description}.rate")
+
+
+def _validate_distribution(value: object, description: str) -> None:
+    distribution = _mapping(value, description)
+    _exact_keys(distribution, {"total", "mean", "p50", "p95"}, description)
+    _nonnegative_integer(distribution.get("total"), f"{description}.total")
+    _finite_decimal(distribution.get("mean"), f"{description}.mean")
+    _nonnegative_integer(distribution.get("p50"), f"{description}.p50")
+    _nonnegative_integer(distribution.get("p95"), f"{description}.p95")
+
+
+def _validate_telemetry(value: object, description: str) -> None:
+    telemetry = _mapping(value, description)
+    _exact_keys(
+        telemetry,
+        {
+            "tokens",
+            "cost",
+            "duration_ms",
+            "latency_ms",
+            "model_call_count",
+            "nudged",
+            "failures",
+            "caching_status",
+        },
+        description,
+    )
+    tokens = _mapping(telemetry.get("tokens"), f"{description}.tokens")
+    _exact_keys(tokens, set(TOKEN_PRICE_KEYS), f"{description}.tokens")
+    for field in TOKEN_PRICE_KEYS:
+        _nonnegative_integer(
+            tokens.get(field),
+            f"{description}.tokens.{field}",
+        )
+    cost = _mapping(telemetry.get("cost"), f"{description}.cost")
+    _exact_keys(
+        cost,
+        {"total_usd", "per_trial_usd", "per_task_usd"},
+        f"{description}.cost",
+    )
+    for field in ("total_usd", "per_trial_usd", "per_task_usd"):
+        _finite_decimal(cost.get(field), f"{description}.cost.{field}")
+    for field in ("duration_ms", "latency_ms", "model_call_count"):
+        _validate_distribution(
+            telemetry.get(field),
+            f"{description}.{field}",
+        )
+    nudged = _mapping(telemetry.get("nudged"), f"{description}.nudged")
+    _exact_keys(nudged, {"trials", "rate"}, f"{description}.nudged")
+    _nonnegative_integer(nudged.get("trials"), f"{description}.nudged.trials")
+    _rate_value(nudged.get("rate"), f"{description}.nudged.rate")
+    failures = _mapping(telemetry.get("failures"), f"{description}.failures")
+    _exact_keys(
+        failures,
+        {
+            "trials",
+            "rate",
+            "by_error_class",
+            "graded_trials",
+            "graded_rate",
+            "by_failed_grader",
+        },
+        f"{description}.failures",
+    )
+    _nonnegative_integer(
+        failures.get("trials"),
+        f"{description}.failures.trials",
+    )
+    _rate_value(failures.get("rate"), f"{description}.failures.rate")
+    _nonnegative_integer(
+        failures.get("graded_trials"),
+        f"{description}.failures.graded_trials",
+    )
+    _rate_value(
+        failures.get("graded_rate"),
+        f"{description}.failures.graded_rate",
+    )
+    _validate_counter_map(
+        failures.get("by_error_class"),
+        f"{description}.failures.by_error_class",
+    )
+    _validate_counter_map(
+        failures.get("by_failed_grader"),
+        f"{description}.failures.by_failed_grader",
+    )
+    if telemetry.get("caching_status") not in {"cached", "uncached"}:
+        raise EvalSummaryError(
+            f"{description}.caching_status must be cached or uncached"
+        )
+
+
+def _validate_scope(
+    value: object,
+    description: str,
+    *,
+    includes_task_ids: bool = False,
+) -> None:
+    scope = _mapping(value, description)
+    expected = {"task_count", "trial_count", "pass^3", "telemetry"}
+    if includes_task_ids:
+        expected.add("task_ids")
+    _exact_keys(scope, expected, description)
+    _nonnegative_integer(scope.get("task_count"), f"{description}.task_count")
+    _nonnegative_integer(scope.get("trial_count"), f"{description}.trial_count")
+    _validate_pass_three(scope.get("pass^3"), f"{description}.pass^3")
+    _validate_telemetry(scope.get("telemetry"), f"{description}.telemetry")
+    if includes_task_ids:
+        task_ids = scope.get("task_ids")
+        if not isinstance(task_ids, list):
+            raise EvalSummaryError(f"{description}.task_ids must be a list")
+        for index, task_id in enumerate(task_ids):
+            _safe_identifier(task_id, f"{description}.task_ids[{index}]")
+
+
+def _validate_summary_schema(root: Mapping[str, object], description: str) -> None:
+    """Validate the complete allowlisted committed-summary schema."""
+
+    _exact_keys(
+        root,
+        {
+            "schema_version",
+            "summary_kind",
+            "image",
+            "image_digest",
+            "source_commit",
+            "source_commit_provenance",
+            "eval_harness_commit",
+            "run",
+            "model",
+            "overall",
+            "suites",
+            "skills",
+            "tasks",
+        },
+        description,
+    )
+    run = _mapping(root.get("run"), f"{description}.run")
+    _exact_keys(
+        run,
+        {
+            "started_at",
+            "start_time_status",
+            "first_trial_recorded_at",
+            "completed_at",
+            "task_count",
+            "trial_count",
+            "trials_per_task",
+        },
+        f"{description}.run",
+    )
+    status = run.get("start_time_status")
+    if status not in {"captured", "unavailable-legacy-records"}:
+        raise EvalSummaryError(f"{description}.run has invalid start_time_status")
+    started_at = run.get("started_at")
+    if status == "captured":
+        started = _timestamp(started_at, f"{description}.run.started_at")
+    elif started_at is not None:
+        raise EvalSummaryError(
+            f"{description}.run.started_at must be null for legacy records"
+        )
+    else:
+        started = None
+    first_recorded = _timestamp(
+        run.get("first_trial_recorded_at"),
+        f"{description}.run.first_trial_recorded_at",
+    )
+    completed = _timestamp(
+        run.get("completed_at"),
+        f"{description}.run.completed_at",
+    )
+    if started is not None and started > first_recorded:
+        raise EvalSummaryError(f"{description}.run started after its first trial")
+    if first_recorded > completed:
+        raise EvalSummaryError(f"{description}.run completed before its first trial")
+    _nonnegative_integer(run.get("task_count"), f"{description}.run.task_count")
+    _nonnegative_integer(run.get("trial_count"), f"{description}.run.trial_count")
+    _positive_integer(
+        run.get("trials_per_task"),
+        f"{description}.run.trials_per_task",
+    )
+
+    model = _mapping(root.get("model"), f"{description}.model")
+    _exact_keys(
+        model,
+        {"primary", "provider", "model_id", "pricing_usd_per_million_tokens"},
+        f"{description}.model",
+    )
+    for field in ("primary", "provider", "model_id"):
+        _safe_identifier(model.get(field), f"{description}.model.{field}")
+    pricing = _mapping(
+        model.get("pricing_usd_per_million_tokens"),
+        f"{description}.model.pricing_usd_per_million_tokens",
+    )
+    _exact_keys(
+        pricing,
+        set(TOKEN_PRICE_KEYS.values()),
+        f"{description}.model.pricing_usd_per_million_tokens",
+    )
+    for field in TOKEN_PRICE_KEYS.values():
+        _finite_decimal(
+            pricing.get(field),
+            f"{description}.model.pricing_usd_per_million_tokens.{field}",
+        )
+
+    _validate_scope(root.get("overall"), f"{description}.overall")
+    for field, includes_task_ids in (("suites", False), ("skills", True)):
+        scopes = _mapping(root.get(field), f"{description}.{field}")
+        for key, scope in scopes.items():
+            _safe_identifier(key, f"{description}.{field} key")
+            _validate_scope(
+                scope,
+                f"{description}.{field}.{key}",
+                includes_task_ids=includes_task_ids,
             )
-        for key, child_spec in spec.items():
-            _assert_summary_schema(mapping[key], child_spec, f"{path}.{key}")
-        return
-    _assert_summary_scalar(value, spec, path)
+    tasks = _mapping(root.get("tasks"), f"{description}.tasks")
+    for task_id, task_value in tasks.items():
+        _safe_identifier(task_id, f"{description}.tasks key")
+        task = _mapping(task_value, f"{description}.tasks.{task_id}")
+        _exact_keys(
+            task,
+            {"skill", "suite", "trials", "passed_trials", "pass^3"},
+            f"{description}.tasks.{task_id}",
+        )
+        _safe_identifier(task.get("skill"), f"{description}.tasks.{task_id}.skill")
+        _safe_identifier(task.get("suite"), f"{description}.tasks.{task_id}.suite")
+        trials = _positive_integer(
+            task.get("trials"),
+            f"{description}.tasks.{task_id}.trials",
+        )
+        passed_trials = _nonnegative_integer(
+            task.get("passed_trials"),
+            f"{description}.tasks.{task_id}.passed_trials",
+        )
+        if passed_trials > trials:
+            raise EvalSummaryError(
+                f"{description}.tasks.{task_id}.passed_trials exceeds trials"
+            )
+        if not isinstance(task.get("pass^3"), bool):
+            raise EvalSummaryError(
+                f"{description}.tasks.{task_id}.pass^3 must be a boolean"
+            )
 
 
 def validate_committed_summary(path: Path, content: bytes) -> None:
@@ -740,8 +907,18 @@ def validate_committed_summary(path: Path, content: bytes) -> None:
     source_commit = root.get("source_commit")
     if not isinstance(source_commit, str) or GIT_OID_RE.fullmatch(source_commit) is None:
         raise EvalSummaryError(f"{path} source_commit must be a full Git object ID")
+    eval_harness_commit = root.get("eval_harness_commit")
+    if (
+        not isinstance(eval_harness_commit, str)
+        or GIT_OID_RE.fullmatch(eval_harness_commit) is None
+    ):
+        raise EvalSummaryError(
+            f"{path} eval_harness_commit must be a full Git object ID"
+        )
+    if root.get("source_commit_provenance") not in SOURCE_COMMIT_PROVENANCE:
+        raise EvalSummaryError(f"{path} has invalid source_commit_provenance")
     _assert_no_transcript_fields(root)
-    _assert_summary_schema(root, SUMMARY_SCHEMA)
+    _validate_summary_schema(root, f"{path} summary")
 
 
 def check_repository(repo_root: Path) -> list[Path]:
@@ -795,6 +972,11 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--image")
     parser.add_argument("--source-commit")
     parser.add_argument(
+        "--source-commit-provenance",
+        choices=sorted(SOURCE_COMMIT_PROVENANCE),
+    )
+    parser.add_argument("--eval-harness-commit")
+    parser.add_argument(
         "--model-config",
         type=Path,
         default=Path(__file__).resolve().parents[1] / "openclaw.json",
@@ -819,12 +1001,22 @@ def main(argv: list[str] | None = None) -> int:
             raise EvalSummaryError("--image is required with --records")
         if args.source_commit is None:
             raise EvalSummaryError("--source-commit is required with --records")
+        if args.source_commit_provenance is None:
+            raise EvalSummaryError(
+                "--source-commit-provenance is required with --records"
+            )
+        if args.eval_harness_commit is None:
+            raise EvalSummaryError(
+                "--eval-harness-commit is required with --records"
+            )
         records = load_records(args.records)
         summary = summarize_records(
             records,
             load_model_pricing(args.model_config),
             expected_image=args.image,
             source_commit=args.source_commit,
+            source_commit_provenance=args.source_commit_provenance,
+            eval_harness_commit=args.eval_harness_commit,
         )
         write_summary(args.out, summary)
         print(

--- a/infra/agent-image/eval/summarize.py
+++ b/infra/agent-image/eval/summarize.py
@@ -1,0 +1,669 @@
+#!/usr/bin/env python3
+"""Create a safe, committed summary from agent-eval JSONL trial records.
+
+The input JSONL is a sensitive transcript. The output intentionally contains
+only aggregate grades and telemetry, never prompts, results, broker requests,
+session identifiers, messages, or tool-call arguments.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+import re
+import subprocess
+from collections import Counter, defaultdict
+from collections.abc import Mapping, Sequence
+from datetime import datetime
+from decimal import Decimal, InvalidOperation, ROUND_HALF_UP
+from pathlib import Path
+
+SCHEMA_VERSION = 1
+SUMMARY_KIND = "agent-eval-run"
+IMMUTABLE_DIGEST_RE = re.compile(r"(?:^|@)(sha256:[0-9a-f]{64})$")
+SAFE_SUMMARY_NAME_RE = re.compile(r"^sha256-[0-9a-f]{64}\.json$")
+GIT_OID_RE = re.compile(r"^(?:[0-9a-f]{40}|[0-9a-f]{64})$")
+FORBIDDEN_SUMMARY_KEYS = frozenset(
+    {
+        "broker_requests",
+        "messages",
+        "metadata",
+        "prompt",
+        "request_body",
+        "result",
+        "session_id",
+        "tool_calls",
+    }
+)
+TRANSCRIPT_NAME_TOKENS = ("capture", "raw", "transcript")
+TOKEN_PRICE_KEYS = {
+    "input_tokens": "input",
+    "output_tokens": "output",
+    "cache_read_input_tokens": "cacheRead",
+    "cache_write_input_tokens": "cacheWrite",
+}
+TELEMETRY_INTEGER_FIELDS = (
+    "input_tokens",
+    "output_tokens",
+    "cache_read_input_tokens",
+    "cache_write_input_tokens",
+    "model_call_count",
+    "duration_ms",
+    "latency_ms",
+)
+USD_QUANTUM = Decimal("0.000001")
+
+
+class EvalSummaryError(RuntimeError):
+    """Trial records could not be converted into a trustworthy summary."""
+
+
+def _mapping(value: object, description: str) -> Mapping[str, object]:
+    if not isinstance(value, Mapping):
+        raise EvalSummaryError(f"{description} must be an object")
+    return value
+
+
+def _nonempty_string(value: object, description: str) -> str:
+    if not isinstance(value, str) or not value:
+        raise EvalSummaryError(f"{description} must be a non-empty string")
+    return value
+
+
+def _nonnegative_integer(value: object, description: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise EvalSummaryError(f"{description} must be a non-negative integer")
+    return value
+
+
+def _positive_integer(value: object, description: str) -> int:
+    parsed = _nonnegative_integer(value, description)
+    if parsed == 0:
+        raise EvalSummaryError(f"{description} must be positive")
+    return parsed
+
+
+def _finite_decimal(value: object, description: str) -> Decimal:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise EvalSummaryError(f"{description} must be a number")
+    try:
+        parsed = Decimal(str(value))
+    except InvalidOperation as error:
+        raise EvalSummaryError(f"{description} must be a number") from error
+    if not parsed.is_finite() or parsed < 0:
+        raise EvalSummaryError(f"{description} must be finite and non-negative")
+    return parsed
+
+
+def _digest_from_image(image: str) -> str:
+    match = IMMUTABLE_DIGEST_RE.search(image)
+    if match is None:
+        raise EvalSummaryError(
+            "trial image must be an immutable sha256 digest, not a mutable tag"
+        )
+    return match.group(1)
+
+
+def _timestamp(value: object, description: str) -> datetime:
+    raw = _nonempty_string(value, description)
+    try:
+        parsed = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+    except ValueError as error:
+        raise EvalSummaryError(f"{description} must be an ISO 8601 timestamp") from error
+    if parsed.tzinfo is None:
+        raise EvalSummaryError(f"{description} must include a timezone")
+    return parsed
+
+
+def load_records(paths: Sequence[Path]) -> list[dict[str, object]]:
+    """Load JSONL records without retaining blank lines or non-object values."""
+
+    if not paths:
+        raise EvalSummaryError("at least one --records path is required")
+    records: list[dict[str, object]] = []
+    for path in paths:
+        try:
+            lines = path.read_text(encoding="utf-8").splitlines()
+        except OSError as error:
+            raise EvalSummaryError(f"could not read trial records {path}: {error}") from error
+        for line_number, line in enumerate(lines, start=1):
+            if not line.strip():
+                continue
+            try:
+                record = json.loads(line)
+            except json.JSONDecodeError as error:
+                raise EvalSummaryError(
+                    f"{path}:{line_number} is not valid JSON: {error}"
+                ) from error
+            if not isinstance(record, dict):
+                raise EvalSummaryError(f"{path}:{line_number} must contain an object")
+            records.append(record)
+    if not records:
+        raise EvalSummaryError("trial record inputs were empty")
+    return records
+
+
+def load_model_pricing(path: Path) -> dict[str, object]:
+    """Resolve the primary model and its declared per-million-token prices."""
+
+    try:
+        config = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise EvalSummaryError(f"could not read model config {path}: {error}") from error
+    root = _mapping(config, "model config")
+    agents = _mapping(root.get("agents"), "model config agents")
+    defaults = _mapping(agents.get("defaults"), "model config agents.defaults")
+    model_defaults = _mapping(
+        defaults.get("model"),
+        "model config agents.defaults.model",
+    )
+    primary = _nonempty_string(
+        model_defaults.get("primary"),
+        "model config primary model",
+    )
+    if "/" not in primary:
+        raise EvalSummaryError("primary model must use provider/model form")
+    provider_name, model_id = primary.split("/", 1)
+    models = _mapping(root.get("models"), "model config models")
+    providers = _mapping(models.get("providers"), "model config providers")
+    provider = _mapping(
+        providers.get(provider_name),
+        f"model config provider {provider_name}",
+    )
+    declared_models = provider.get("models")
+    if not isinstance(declared_models, list):
+        raise EvalSummaryError(f"provider {provider_name} models must be a list")
+    selected: Mapping[str, object] | None = None
+    for candidate in declared_models:
+        if isinstance(candidate, Mapping) and candidate.get("id") == model_id:
+            selected = candidate
+            break
+    if selected is None:
+        raise EvalSummaryError(
+            f"primary model {model_id} is not declared under {provider_name}"
+        )
+    cost = _mapping(selected.get("cost"), f"model {model_id} cost")
+    prices = {
+        price_key: _finite_decimal(
+            cost.get(price_key),
+            f"model {model_id} cost.{price_key}",
+        )
+        for price_key in TOKEN_PRICE_KEYS.values()
+    }
+    return {
+        "primary": primary,
+        "provider": provider_name,
+        "model_id": model_id,
+        "pricing_usd_per_million_tokens": prices,
+    }
+
+
+def _validate_record(
+    record: Mapping[str, object],
+    index: int,
+) -> tuple[str, str, str, int, int, str, datetime]:
+    label = f"trial record {index}"
+    task_id = _nonempty_string(record.get("task_id"), f"{label} task_id")
+    skill = _nonempty_string(record.get("skill"), f"{label} skill")
+    suite = _nonempty_string(record.get("suite"), f"{label} suite")
+    trial = _positive_integer(record.get("trial"), f"{label} trial")
+    trials = _positive_integer(record.get("trials"), f"{label} trials")
+    if trial > trials:
+        raise EvalSummaryError(f"{label} trial exceeds its declared trial count")
+    image = _nonempty_string(record.get("image"), f"{label} image")
+    digest = _digest_from_image(image)
+    recorded_at = _timestamp(
+        record.get("recorded_at"),
+        f"{label} recorded_at",
+    )
+    grade = _mapping(record.get("grade"), f"{label} grade")
+    if not isinstance(grade.get("passed"), bool):
+        raise EvalSummaryError(f"{label} grade.passed must be a boolean")
+    metadata = _mapping(record.get("metadata"), f"{label} metadata")
+    for field in TELEMETRY_INTEGER_FIELDS:
+        _nonnegative_integer(metadata.get(field), f"{label} metadata.{field}")
+    for field in ("nudged", "failed"):
+        if not isinstance(metadata.get(field), bool):
+            raise EvalSummaryError(f"{label} metadata.{field} must be a boolean")
+    error_class = metadata.get("error_class")
+    if error_class is not None and not isinstance(error_class, str):
+        raise EvalSummaryError(f"{label} metadata.error_class must be a string or null")
+    return task_id, skill, suite, trial, trials, image, recorded_at
+
+
+def _rounded_usd(value: Decimal) -> float:
+    return float(value.quantize(USD_QUANTUM, rounding=ROUND_HALF_UP))
+
+
+def _rate(numerator: int, denominator: int) -> float:
+    return round(numerator / denominator, 6) if denominator else 0.0
+
+
+def _percentile(values: Sequence[int], percentile: float) -> int:
+    ordered = sorted(values)
+    rank = max(1, math.ceil(percentile * len(ordered)))
+    return ordered[rank - 1]
+
+
+def _distribution(values: Sequence[int]) -> dict[str, int | float]:
+    if not values:
+        raise EvalSummaryError("cannot summarize an empty telemetry distribution")
+    return {
+        "total": sum(values),
+        "mean": round(sum(values) / len(values), 3),
+        "p50": _percentile(values, 0.50),
+        "p95": _percentile(values, 0.95),
+    }
+
+
+def _telemetry_summary(
+    records: Sequence[Mapping[str, object]],
+    prices: Mapping[str, Decimal],
+) -> dict[str, object]:
+    tokens = {field: 0 for field in TOKEN_PRICE_KEYS}
+    durations: list[int] = []
+    latencies: list[int] = []
+    model_calls: list[int] = []
+    nudged_count = 0
+    failed_count = 0
+    graded_failure_count = 0
+    failure_classes: Counter[str] = Counter()
+    failed_graders: Counter[str] = Counter()
+    for index, record in enumerate(records, start=1):
+        metadata = _mapping(record.get("metadata"), f"trial record {index} metadata")
+        for field in TOKEN_PRICE_KEYS:
+            tokens[field] += _nonnegative_integer(
+                metadata.get(field),
+                f"trial record {index} metadata.{field}",
+            )
+        durations.append(
+            _nonnegative_integer(
+                metadata.get("duration_ms"),
+                f"trial record {index} metadata.duration_ms",
+            )
+        )
+        latencies.append(
+            _nonnegative_integer(
+                metadata.get("latency_ms"),
+                f"trial record {index} metadata.latency_ms",
+            )
+        )
+        model_calls.append(
+            _nonnegative_integer(
+                metadata.get("model_call_count"),
+                f"trial record {index} metadata.model_call_count",
+            )
+        )
+        if metadata.get("nudged") is True:
+            nudged_count += 1
+        if metadata.get("failed") is True:
+            failed_count += 1
+            error_class = metadata.get("error_class")
+            failure_classes[
+                error_class if isinstance(error_class, str) and error_class else "unknown"
+            ] += 1
+        grade = _mapping(record.get("grade"), f"trial record {index} grade")
+        if grade.get("passed") is False:
+            graded_failure_count += 1
+            recorded_failed_grader = False
+            grader_results = grade.get("results")
+            if isinstance(grader_results, list):
+                for grader_result in grader_results:
+                    if (
+                        isinstance(grader_result, Mapping)
+                        and grader_result.get("passed") is False
+                    ):
+                        grader = grader_result.get("grader")
+                        failed_graders[
+                            grader if isinstance(grader, str) and grader else "unknown"
+                        ] += 1
+                        recorded_failed_grader = True
+            if not recorded_failed_grader:
+                failed_graders["unknown"] += 1
+    cost = sum(
+        Decimal(tokens[token_field]) * prices[price_key] / Decimal(1_000_000)
+        for token_field, price_key in TOKEN_PRICE_KEYS.items()
+    )
+    task_count = len({_nonempty_string(record.get("task_id"), "task_id") for record in records})
+    return {
+        "tokens": tokens,
+        "cost": {
+            "total_usd": _rounded_usd(cost),
+            "per_trial_usd": _rounded_usd(cost / Decimal(len(records))),
+            "per_task_usd": _rounded_usd(cost / Decimal(task_count)),
+        },
+        "duration_ms": _distribution(durations),
+        "latency_ms": _distribution(latencies),
+        "model_call_count": _distribution(model_calls),
+        "nudged": {
+            "trials": nudged_count,
+            "rate": _rate(nudged_count, len(records)),
+        },
+        "failures": {
+            "trials": failed_count,
+            "rate": _rate(failed_count, len(records)),
+            "by_error_class": dict(sorted(failure_classes.items())),
+            "graded_trials": graded_failure_count,
+            "graded_rate": _rate(graded_failure_count, len(records)),
+            "by_failed_grader": dict(sorted(failed_graders.items())),
+        },
+        "caching_status": (
+            "uncached" if tokens["cache_read_input_tokens"] == 0 else "cached"
+        ),
+    }
+
+
+def _scope_summary(
+    records: Sequence[Mapping[str, object]],
+    task_summaries: Mapping[str, Mapping[str, object]],
+    prices: Mapping[str, Decimal],
+) -> dict[str, object]:
+    task_ids = sorted(
+        {_nonempty_string(record.get("task_id"), "task_id") for record in records}
+    )
+    passed_tasks = sum(
+        task_summaries[task_id].get("pass^3") is True for task_id in task_ids
+    )
+    return {
+        "task_count": len(task_ids),
+        "trial_count": len(records),
+        "pass^3": {
+            "passed_tasks": passed_tasks,
+            "total_tasks": len(task_ids),
+            "rate": _rate(passed_tasks, len(task_ids)),
+        },
+        "telemetry": _telemetry_summary(records, prices),
+    }
+
+
+def summarize_records(
+    records: Sequence[Mapping[str, object]],
+    model_pricing: Mapping[str, object],
+    *,
+    expected_image: str | None = None,
+    source_commit: str | None = None,
+) -> dict[str, object]:
+    """Validate complete trials and return a transcript-free run summary."""
+
+    if not records:
+        raise EvalSummaryError("cannot summarize zero records")
+    if source_commit is not None and GIT_OID_RE.fullmatch(source_commit) is None:
+        raise EvalSummaryError("source_commit must be a full Git object ID")
+    seen_trials: set[tuple[str, int]] = set()
+    grouped_tasks: dict[str, list[Mapping[str, object]]] = defaultdict(list)
+    task_identity: dict[str, tuple[str, str, int]] = {}
+    images: set[str] = set()
+    digests: set[str] = set()
+    recorded_times: list[datetime] = []
+    for index, record in enumerate(records, start=1):
+        task_id, skill, suite, trial, trials, image, recorded_at = _validate_record(
+            record,
+            index,
+        )
+        key = (task_id, trial)
+        if key in seen_trials:
+            raise EvalSummaryError(f"duplicate trial record for {task_id} trial {trial}")
+        seen_trials.add(key)
+        identity = (skill, suite, trials)
+        if task_id in task_identity and task_identity[task_id] != identity:
+            raise EvalSummaryError(f"task {task_id} changed skill, suite, or trial count")
+        task_identity[task_id] = identity
+        grouped_tasks[task_id].append(record)
+        images.add(image)
+        digests.add(_digest_from_image(image))
+        recorded_times.append(recorded_at)
+    if len(images) != 1 or len(digests) != 1:
+        raise EvalSummaryError("all trial records must use the same immutable image")
+    image = next(iter(images))
+    digest = next(iter(digests))
+    if expected_image is not None and (
+        _digest_from_image(expected_image) != digest or expected_image != image
+    ):
+        raise EvalSummaryError("trial image does not match --image")
+
+    task_summaries: dict[str, dict[str, object]] = {}
+    for task_id in sorted(grouped_tasks):
+        task_records = grouped_tasks[task_id]
+        skill, suite, trials = task_identity[task_id]
+        if trials != 3:
+            raise EvalSummaryError(
+                f"task {task_id} declared {trials} trials; committed summaries require pass^3"
+            )
+        observed_trials = sorted(
+            _positive_integer(record.get("trial"), f"task {task_id} trial")
+            for record in task_records
+        )
+        if observed_trials != [1, 2, 3]:
+            raise EvalSummaryError(
+                f"task {task_id} does not contain exactly trials 1, 2, and 3"
+            )
+        passed_trials = sum(
+            _mapping(record.get("grade"), f"task {task_id} grade").get("passed")
+            is True
+            for record in task_records
+        )
+        task_summaries[task_id] = {
+            "skill": skill,
+            "suite": suite,
+            "trials": trials,
+            "passed_trials": passed_trials,
+            "pass^3": passed_trials == trials,
+        }
+
+    prices_object = _mapping(
+        model_pricing.get("pricing_usd_per_million_tokens"),
+        "model pricing",
+    )
+    prices = {
+        key: (
+            value
+            if isinstance(value, Decimal)
+            else _finite_decimal(value, f"model pricing {key}")
+        )
+        for key, value in prices_object.items()
+    }
+    if set(prices) != set(TOKEN_PRICE_KEYS.values()):
+        raise EvalSummaryError("model pricing is missing one or more token categories")
+
+    suite_records: dict[str, list[Mapping[str, object]]] = defaultdict(list)
+    skill_records: dict[str, list[Mapping[str, object]]] = defaultdict(list)
+    for record in records:
+        task_id = _nonempty_string(record.get("task_id"), "task_id")
+        skill, suite, _ = task_identity[task_id]
+        suite_records[suite].append(record)
+        skill_records[skill].append(record)
+    safe_model_pricing = {
+        "primary": model_pricing["primary"],
+        "provider": model_pricing["provider"],
+        "model_id": model_pricing["model_id"],
+        "pricing_usd_per_million_tokens": {
+            key: float(value) for key, value in prices.items()
+        },
+    }
+    summary = {
+        "schema_version": SCHEMA_VERSION,
+        "summary_kind": SUMMARY_KIND,
+        "image": image,
+        "image_digest": digest,
+        "source_commit": source_commit,
+        "run": {
+            "started_at": min(recorded_times).isoformat(),
+            "completed_at": max(recorded_times).isoformat(),
+            "task_count": len(task_summaries),
+            "trial_count": len(records),
+            "trials_per_task": 3,
+        },
+        "model": safe_model_pricing,
+        "overall": _scope_summary(records, task_summaries, prices),
+        "suites": {
+            suite: _scope_summary(suite_records[suite], task_summaries, prices)
+            for suite in sorted(suite_records)
+        },
+        "skills": {
+            skill: {
+                **_scope_summary(skill_records[skill], task_summaries, prices),
+                "task_ids": sorted(
+                    task_id
+                    for task_id, task_summary in task_summaries.items()
+                    if task_summary["skill"] == skill
+                ),
+            }
+            for skill in sorted(skill_records)
+        },
+        "tasks": task_summaries,
+    }
+    _assert_no_transcript_fields(summary)
+    return summary
+
+
+def _assert_no_transcript_fields(value: object, path: str = "$") -> None:
+    if isinstance(value, Mapping):
+        for key, child in value.items():
+            if key in FORBIDDEN_SUMMARY_KEYS:
+                raise EvalSummaryError(
+                    f"summary contains forbidden transcript field {path}.{key}"
+                )
+            _assert_no_transcript_fields(child, f"{path}.{key}")
+    elif isinstance(value, list):
+        for index, child in enumerate(value):
+            _assert_no_transcript_fields(child, f"{path}[{index}]")
+
+
+def validate_committed_summary(path: Path, content: bytes) -> None:
+    """Reject committed eval artifacts that are not safe, digest-named summaries."""
+
+    lowered_name = path.name.lower()
+    if path.suffix == ".jsonl" or any(
+        token in lowered_name for token in TRANSCRIPT_NAME_TOKENS
+    ):
+        raise EvalSummaryError(f"{path} looks like a trial transcript")
+    if path.parent != Path(".eval-runs"):
+        raise EvalSummaryError(f"{path} must be directly inside .eval-runs")
+    if path.suffix != ".json" or SAFE_SUMMARY_NAME_RE.fullmatch(path.name) is None:
+        raise EvalSummaryError(f"{path} must be a digest-named summary JSON")
+    try:
+        value = json.loads(content)
+    except json.JSONDecodeError as error:
+        raise EvalSummaryError(f"{path} is not valid JSON: {error}") from error
+    root = _mapping(value, f"{path} summary")
+    if root.get("schema_version") != SCHEMA_VERSION:
+        raise EvalSummaryError(f"{path} has an unsupported schema version")
+    if root.get("summary_kind") != SUMMARY_KIND:
+        raise EvalSummaryError(f"{path} is not an agent eval run summary")
+    image = _nonempty_string(root.get("image"), f"{path} image")
+    digest = _digest_from_image(image)
+    if root.get("image_digest") != digest:
+        raise EvalSummaryError(f"{path} image digest does not match its image")
+    expected_name = f"{digest.replace(':', '-')}.json"
+    if path.name != expected_name:
+        raise EvalSummaryError(f"{path} filename does not match its image digest")
+    source_commit = root.get("source_commit")
+    if not isinstance(source_commit, str) or GIT_OID_RE.fullmatch(source_commit) is None:
+        raise EvalSummaryError(f"{path} source_commit must be a full Git object ID")
+    _assert_no_transcript_fields(root)
+
+
+def check_repository(repo_root: Path) -> list[Path]:
+    """Validate every tracked artifact under .eval-runs/."""
+
+    result = subprocess.run(
+        ["git", "ls-files", "-z", "--", ".eval-runs"],
+        cwd=repo_root,
+        check=False,
+        capture_output=True,
+    )
+    if result.returncode != 0:
+        detail = result.stderr.decode("utf-8", errors="replace").strip()
+        raise EvalSummaryError(f"git ls-files failed: {detail}")
+    tracked = [
+        Path(value.decode("utf-8"))
+        for value in result.stdout.split(b"\0")
+        if value
+    ]
+    for relative_path in tracked:
+        try:
+            content = (repo_root / relative_path).read_bytes()
+        except OSError as error:
+            raise EvalSummaryError(f"could not read {relative_path}: {error}") from error
+        validate_committed_summary(relative_path, content)
+    return tracked
+
+
+def write_summary(path: Path, summary: Mapping[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0)
+    descriptor = os.open(path, flags, 0o644)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as output:
+            json.dump(summary, output, indent=2, sort_keys=True)
+            output.write("\n")
+    except BaseException:
+        try:
+            path.unlink()
+        except OSError:
+            pass
+        raise
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    mode = parser.add_mutually_exclusive_group(required=True)
+    mode.add_argument("--records", action="append", type=Path)
+    mode.add_argument("--check-repository", action="store_true")
+    parser.add_argument("--out", type=Path)
+    parser.add_argument("--image")
+    parser.add_argument("--source-commit")
+    parser.add_argument(
+        "--model-config",
+        type=Path,
+        default=Path(__file__).resolve().parents[1] / "openclaw.json",
+    )
+    parser.add_argument("--require-all-pass", action="store_true")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    try:
+        if args.check_repository:
+            if args.out is not None:
+                raise EvalSummaryError("--out is not valid with --check-repository")
+            repo_root = Path(__file__).resolve().parents[3]
+            tracked = check_repository(repo_root)
+            print(f"validated {len(tracked)} committed eval artifact(s)")
+            return 0
+        if args.out is None:
+            raise EvalSummaryError("--out is required with --records")
+        if args.image is None:
+            raise EvalSummaryError("--image is required with --records")
+        if args.source_commit is None:
+            raise EvalSummaryError("--source-commit is required with --records")
+        records = load_records(args.records)
+        summary = summarize_records(
+            records,
+            load_model_pricing(args.model_config),
+            expected_image=args.image,
+            source_commit=args.source_commit,
+        )
+        write_summary(args.out, summary)
+        print(
+            f"wrote transcript-free summary for {summary['run']['task_count']} "
+            f"tasks to {args.out}"
+        )
+        pass_three = _mapping(summary["overall"], "overall").get("pass^3")
+        if args.require_all_pass and (
+            not isinstance(pass_three, Mapping)
+            or pass_three.get("passed_tasks") != pass_three.get("total_tasks")
+        ):
+            print("one or more tasks failed pass^3")
+            return 1
+        return 0
+    except (EvalSummaryError, OSError) as error:
+        print(f"error: {error}", file=os.sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/infra/agent-image/skills/psd-last30days/scripts/test_last30days.py
+++ b/infra/agent-image/skills/psd-last30days/scripts/test_last30days.py
@@ -19,6 +19,7 @@ import json
 import os
 import sys
 import time
+import types
 import unittest
 from unittest import mock
 
@@ -459,11 +460,16 @@ class GatherTests(unittest.TestCase):
 
 
 class UploadTests(unittest.TestCase):
-    def test_missing_bucket_raises_misconfigured(self):
-        with mock.patch.dict(os.environ, {}, clear=True):
+    def test_publisher_failure_raises_upstream_error(self):
+        publisher = types.ModuleType("artifact_publisher")
+        publisher.publish_artifact = mock.Mock(
+            side_effect=RuntimeError("broker unavailable"),
+        )
+        with mock.patch.dict(sys.modules, {"artifact_publisher": publisher}):
             with self.assertRaises(last30days.UploadError) as ctx:
                 last30days.upload_html("<html></html>", "a@psd401.net")
-        self.assertEqual(ctx.exception.code, "misconfigured")
+        self.assertEqual(ctx.exception.code, "upstream_error")
+        self.assertIn("broker unavailable", ctx.exception.message)
 
 
 if __name__ == "__main__":

--- a/infra/agent-image/test_eval_runner.py
+++ b/infra/agent-image/test_eval_runner.py
@@ -968,6 +968,13 @@ class EvaluationRunnerTests(unittest.TestCase):
             {record["suite"] for record in records},
             {"unclassified"},
         )
+        self.assertEqual(len({record["run_started_at"] for record in records}), 1)
+        self.assertTrue(
+            all(
+                record["run_started_at"] <= record["recorded_at"]
+                for record in records
+            )
+        )
 
     def test_fresh_sessions_prevent_conversation_recall(self):
         clock = AdvancingClock()

--- a/infra/agent-image/test_eval_summary.py
+++ b/infra/agent-image/test_eval_summary.py
@@ -655,6 +655,20 @@ class CommittedArtifactGuardTests(unittest.TestCase):
 
 
 class EvalAutomationContractTests(unittest.TestCase):
+    def test_image_context_excludes_local_environment_files(self):
+        dockerignore = (AGENT_IMAGE_DIR / ".dockerignore").read_text(
+            encoding="utf-8"
+        )
+
+        patterns = {
+            line.strip()
+            for line in dockerignore.splitlines()
+            if line.strip() and not line.lstrip().startswith("#")
+        }
+        self.assertTrue(
+            {".env", ".env.*", "**/.env", "**/.env.*"}.issubset(patterns)
+        )
+
     def test_ci_creates_model_uid_before_agent_image_python_suites(self):
         workflow = (
             AGENT_IMAGE_DIR.parent.parent / ".github" / "workflows" / "ci.yml"

--- a/infra/agent-image/test_eval_summary.py
+++ b/infra/agent-image/test_eval_summary.py
@@ -84,6 +84,7 @@ def trial_record(
             "reason": "sensitive grader reason",
             "results": [],
         },
+        "run_started_at": "2026-07-28T23:59:59+00:00",
         "recorded_at": f"2026-07-29T00:00:0{trial}+00:00",
     }
 
@@ -130,12 +131,22 @@ class SummaryAggregationTests(unittest.TestCase):
             pricing(),
             expected_image=IMAGE,
             source_commit="b" * 40,
+            source_commit_provenance="image-label",
+            eval_harness_commit="c" * 40,
         )
 
-        self.assertEqual(summary["schema_version"], 1)
+        self.assertEqual(summary["schema_version"], 2)
         self.assertEqual(summary["summary_kind"], "agent-eval-run")
         self.assertEqual(summary["image_digest"], IMAGE_DIGEST)
         self.assertEqual(summary["source_commit"], "b" * 40)
+        self.assertEqual(summary["source_commit_provenance"], "image-label")
+        self.assertEqual(summary["eval_harness_commit"], "c" * 40)
+        self.assertEqual(summary["run"]["started_at"], "2026-07-28T23:59:59+00:00")
+        self.assertEqual(summary["run"]["start_time_status"], "captured")
+        self.assertEqual(
+            summary["run"]["first_trial_recorded_at"],
+            "2026-07-29T00:00:01+00:00",
+        )
         self.assertEqual(summary["run"]["task_count"], 2)
         self.assertEqual(summary["run"]["trial_count"], 6)
         self.assertTrue(summary["tasks"]["task-a"]["pass^3"])
@@ -231,6 +242,23 @@ class SummaryAggregationTests(unittest.TestCase):
         with self.assertRaisesRegex(summarize.EvalSummaryError, "ISO 8601"):
             summarize.summarize_records(records, pricing())
 
+    def test_legacy_records_report_missing_start_instead_of_guessing(self):
+        records = complete_records()
+        for record in records:
+            record.pop("run_started_at")
+
+        summary = summarize.summarize_records(records, pricing())
+
+        self.assertIsNone(summary["run"]["started_at"])
+        self.assertEqual(
+            summary["run"]["start_time_status"],
+            "unavailable-legacy-records",
+        )
+        self.assertEqual(
+            summary["run"]["first_trial_recorded_at"],
+            "2026-07-29T00:00:01+00:00",
+        )
+
 
 class ModelPricingTests(unittest.TestCase):
     def test_primary_model_pricing_is_loaded_from_openclaw_config(self):
@@ -290,6 +318,8 @@ class CommittedArtifactGuardTests(unittest.TestCase):
             complete_records(),
             pricing(),
             source_commit="b" * 40,
+            source_commit_provenance="image-label",
+            eval_harness_commit="c" * 40,
         )
         return json.dumps(summary).encode("utf-8")
 
@@ -370,30 +400,33 @@ class CommittedArtifactGuardTests(unittest.TestCase):
 
     def test_summary_missing_a_required_field_is_rejected(self):
         value = json.loads(self.safe_summary_bytes())
-        del value["run"]["first_record_at"]
+        del value["run"]["first_trial_recorded_at"]
 
-        self.assert_rejected(value, "missing required field")
+        self.assert_rejected(value, "missing fields")
 
     def test_summary_field_of_the_wrong_type_is_rejected(self):
         value = json.loads(self.safe_summary_bytes())
         value["overall"]["telemetry"]["caching_status"] = {"prompt": "private"}
 
-        self.assert_rejected(value, r"\$\.overall\.telemetry\.caching_status")
+        self.assert_rejected(value, r"overall\.telemetry\.caching_status")
 
     def test_transcript_smuggled_as_a_free_form_key_is_rejected(self):
         value = json.loads(self.safe_summary_bytes())
         failures = value["overall"]["telemetry"]["failures"]
         failures["by_error_class"] = {"x" * 400: 1}
 
-        self.assert_rejected(value, "not a plain identifier")
+        self.assert_rejected(value, "not a safe identifier")
 
-    def test_run_bounds_are_named_for_the_record_times_they_derive_from(self):
+    def test_run_bounds_distinguish_start_from_trial_record_times(self):
         value = json.loads(self.safe_summary_bytes())
 
-        self.assertIn("first_record_at", value["run"])
-        self.assertIn("last_record_at", value["run"])
-        self.assertNotIn("started_at", value["run"])
-        self.assertNotIn("completed_at", value["run"])
+        self.assertIn("started_at", value["run"])
+        self.assertIn("first_trial_recorded_at", value["run"])
+        self.assertIn("completed_at", value["run"])
+        self.assertLessEqual(
+            value["run"]["started_at"],
+            value["run"]["first_trial_recorded_at"],
+        )
 
     def test_filename_must_match_the_summarized_image_digest(self):
         with self.assertRaisesRegex(summarize.EvalSummaryError, "filename"):
@@ -424,6 +457,45 @@ class CommittedArtifactGuardTests(unittest.TestCase):
                 summarize.check_repository(repo)
 
 
+class EvalAutomationContractTests(unittest.TestCase):
+    def test_image_build_stamps_clean_aistudio_source_revision(self):
+        dockerfile = (AGENT_IMAGE_DIR / "Dockerfile").read_text(encoding="utf-8")
+        build_script = (AGENT_IMAGE_DIR / "build-and-push.sh").read_text(
+            encoding="utf-8"
+        )
+
+        self.assertIn("ARG AISTUDIO_SOURCE_COMMIT", dockerfile)
+        self.assertIn(
+            'org.opencontainers.image.source="https://github.com/psd401/aistudio"',
+            dockerfile,
+        )
+        self.assertIn(
+            'org.opencontainers.image.revision="${AISTUDIO_SOURCE_COMMIT}"',
+            dockerfile,
+        )
+        self.assertIn("status --porcelain --untracked-files=all", build_script)
+        self.assertIn(
+            '--build-arg "AISTUDIO_SOURCE_COMMIT=${SOURCE_COMMIT}"',
+            build_script,
+        )
+
+    def test_nightly_binds_image_and_harness_commits_separately(self):
+        workflow = (
+            AGENT_IMAGE_DIR.parent.parent
+            / ".github"
+            / "workflows"
+            / "agent-eval-nightly.yml"
+        ).read_text(encoding="utf-8")
+
+        self.assertIn("org.opencontainers.image.revision", workflow)
+        self.assertIn(
+            "--source-commit \"${{ steps.candidate.outputs.source_commit }}\"",
+            workflow,
+        )
+        self.assertIn('--eval-harness-commit "${GITHUB_SHA}"', workflow)
+        self.assertNotIn('--source-commit "${GITHUB_SHA}"', workflow)
+
+
 class SummaryCliTests(unittest.TestCase):
     def test_cli_writes_safe_summary_and_can_enforce_pass_three(self):
         with tempfile.TemporaryDirectory() as directory:
@@ -446,6 +518,10 @@ class SummaryCliTests(unittest.TestCase):
                         IMAGE,
                         "--source-commit",
                         "b" * 40,
+                        "--source-commit-provenance",
+                        "image-label",
+                        "--eval-harness-commit",
+                        "c" * 40,
                         "--model-config",
                         str(AGENT_IMAGE_DIR / "openclaw.json"),
                         "--require-all-pass",

--- a/infra/agent-image/test_eval_summary.py
+++ b/infra/agent-image/test_eval_summary.py
@@ -435,6 +435,34 @@ class CommittedArtifactGuardTests(unittest.TestCase):
                 self.safe_summary_bytes(),
             )
 
+    def test_image_with_sensitive_prefix_before_digest_is_rejected(self):
+        value = json.loads(self.safe_summary_bytes())
+        value["image"] = f"private prompt\n@{IMAGE_DIGEST}"
+
+        self.assert_rejected(value, "complete immutable ECR sha256 URI")
+
+    def test_task_pass_three_must_match_passed_trial_count(self):
+        value = json.loads(self.safe_summary_bytes())
+        value["tasks"]["task-a"]["pass^3"] = False
+
+        self.assert_rejected(value, r"task-a\.pass\^3 is inconsistent")
+
+    def test_scope_pass_three_must_match_its_tasks(self):
+        value = json.loads(self.safe_summary_bytes())
+        value["overall"]["pass^3"]["passed_tasks"] = 2
+        value["overall"]["pass^3"]["rate"] = 1.0
+
+        self.assert_rejected(
+            value,
+            r"overall\.pass\^3\.passed_tasks is inconsistent",
+        )
+
+    def test_skill_membership_must_match_task_summaries(self):
+        value = json.loads(self.safe_summary_bytes())
+        value["skills"]["skill-a"]["task_ids"] = ["task-a"]
+
+        self.assert_rejected(value, r"task_ids is inconsistent")
+
     def test_repository_check_reads_the_git_index_not_only_gitignore(self):
         with tempfile.TemporaryDirectory() as directory:
             repo = Path(directory)

--- a/infra/agent-image/test_eval_summary.py
+++ b/infra/agent-image/test_eval_summary.py
@@ -457,6 +457,60 @@ class CommittedArtifactGuardTests(unittest.TestCase):
             r"overall\.pass\^3\.passed_tasks is inconsistent",
         )
 
+    def test_scope_telemetry_must_match_counts_rates_and_pricing(self):
+        mutations = (
+            (
+                ("overall", "telemetry", "failures", "trials"),
+                7,
+                r"failures\.trials exceeds trial_count",
+            ),
+            (
+                ("overall", "telemetry", "failures", "rate"),
+                0.5,
+                r"failures\.rate is inconsistent",
+            ),
+            (
+                ("overall", "telemetry", "failures", "by_error_class"),
+                {"ModelFailure": 2},
+                r"by_error_class is inconsistent",
+            ),
+            (
+                ("overall", "telemetry", "tokens", "input_tokens"),
+                6001,
+                r"cost\.total_usd is inconsistent",
+            ),
+            (
+                ("overall", "telemetry", "cost", "total_usd"),
+                0,
+                r"cost\.total_usd is inconsistent",
+            ),
+            (
+                ("overall", "telemetry", "duration_ms", "mean"),
+                1,
+                r"duration_ms\.mean is inconsistent",
+            ),
+            (
+                ("overall", "telemetry", "nudged", "trials"),
+                7,
+                r"nudged\.trials exceeds trial_count",
+            ),
+            (
+                ("overall", "telemetry", "caching_status"),
+                "uncached",
+                r"caching_status is inconsistent",
+            ),
+        )
+
+        for path, replacement, pattern in mutations:
+            with self.subTest(path=".".join(path)):
+                value = json.loads(self.safe_summary_bytes())
+                target = value
+                for field in path[:-1]:
+                    target = target[field]
+                target[path[-1]] = replacement
+
+                self.assert_rejected(value, pattern)
+
     def test_skill_membership_must_match_task_summaries(self):
         value = json.loads(self.safe_summary_bytes())
         value["skills"]["skill-a"]["task_ids"] = ["task-a"]

--- a/infra/agent-image/test_eval_summary.py
+++ b/infra/agent-image/test_eval_summary.py
@@ -484,6 +484,34 @@ class CommittedArtifactGuardTests(unittest.TestCase):
             with self.assertRaisesRegex(summarize.EvalSummaryError, "transcript"):
                 summarize.check_repository(repo)
 
+    def test_repository_check_validates_index_blob_not_working_tree_copy(self):
+        with tempfile.TemporaryDirectory() as directory:
+            repo = Path(directory)
+            subprocess.run(
+                ["git", "init", "-q"],
+                cwd=repo,
+                check=True,
+            )
+            artifact_dir = repo / ".eval-runs"
+            artifact_dir.mkdir()
+            artifact = artifact_dir / f"{IMAGE_DIGEST.replace(':', '-')}.json"
+            safe_content = self.safe_summary_bytes()
+            unsafe_value = json.loads(safe_content)
+            unsafe_value["prompt"] = "private staged prompt"
+            artifact.write_text(json.dumps(unsafe_value), encoding="utf-8")
+            subprocess.run(
+                ["git", "add", "-f", artifact.relative_to(repo)],
+                cwd=repo,
+                check=True,
+            )
+            artifact.write_bytes(safe_content)
+
+            with self.assertRaisesRegex(
+                summarize.EvalSummaryError,
+                "forbidden transcript field",
+            ):
+                summarize.check_repository(repo)
+
 
 class EvalAutomationContractTests(unittest.TestCase):
     def test_image_build_stamps_clean_aistudio_source_revision(self):

--- a/infra/agent-image/test_eval_summary.py
+++ b/infra/agent-image/test_eval_summary.py
@@ -333,6 +333,68 @@ class CommittedArtifactGuardTests(unittest.TestCase):
                 json.dumps(value).encode("utf-8"),
             )
 
+    def assert_rejected(self, value: dict, pattern: str) -> None:
+        with self.assertRaisesRegex(summarize.EvalSummaryError, pattern):
+            summarize.validate_committed_summary(
+                Path(".eval-runs") / f"{IMAGE_DIGEST.replace(':', '-')}.json",
+                json.dumps(value).encode("utf-8"),
+            )
+
+    def test_transcript_under_an_unlisted_key_is_rejected(self):
+        for container, key in (
+            (("skills", "skill-a"), "notes"),
+            (("skills", "skill-a"), "grader_reason"),
+            (("tasks", "task-a"), "output"),
+            ((), "completion"),
+        ):
+            with self.subTest(key=key):
+                value = json.loads(self.safe_summary_bytes())
+                target = value
+                for step in container:
+                    target = target[step]
+                target[key] = "the model said something private"
+
+                self.assert_rejected(value, f"unexpected field.*{key}")
+
+    def test_differently_cased_transcript_key_is_rejected(self):
+        value = json.loads(self.safe_summary_bytes())
+        value["Prompt"] = "private"
+
+        self.assert_rejected(value, "unexpected field")
+
+    def test_secret_smuggled_beside_the_model_pricing_is_rejected(self):
+        value = json.loads(self.safe_summary_bytes())
+        value["model"]["api_key"] = "sk-not-a-real-key"
+
+        self.assert_rejected(value, "unexpected field")
+
+    def test_summary_missing_a_required_field_is_rejected(self):
+        value = json.loads(self.safe_summary_bytes())
+        del value["run"]["first_record_at"]
+
+        self.assert_rejected(value, "missing required field")
+
+    def test_summary_field_of_the_wrong_type_is_rejected(self):
+        value = json.loads(self.safe_summary_bytes())
+        value["overall"]["telemetry"]["caching_status"] = {"prompt": "private"}
+
+        self.assert_rejected(value, r"\$\.overall\.telemetry\.caching_status")
+
+    def test_transcript_smuggled_as_a_free_form_key_is_rejected(self):
+        value = json.loads(self.safe_summary_bytes())
+        failures = value["overall"]["telemetry"]["failures"]
+        failures["by_error_class"] = {"x" * 400: 1}
+
+        self.assert_rejected(value, "not a plain identifier")
+
+    def test_run_bounds_are_named_for_the_record_times_they_derive_from(self):
+        value = json.loads(self.safe_summary_bytes())
+
+        self.assertIn("first_record_at", value["run"])
+        self.assertIn("last_record_at", value["run"])
+        self.assertNotIn("started_at", value["run"])
+        self.assertNotIn("completed_at", value["run"])
+
     def test_filename_must_match_the_summarized_image_digest(self):
         with self.assertRaisesRegex(summarize.EvalSummaryError, "filename"):
             summarize.validate_committed_summary(

--- a/infra/agent-image/test_eval_summary.py
+++ b/infra/agent-image/test_eval_summary.py
@@ -1,0 +1,400 @@
+"""Hermetic tests for transcript-free agent-eval run summaries.
+
+Run with:
+    uv run --python 3.12 --no-project -m unittest \
+      infra/agent-image/test_eval_summary.py
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+from decimal import Decimal
+from io import StringIO
+from pathlib import Path
+
+AGENT_IMAGE_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(AGENT_IMAGE_DIR / "eval"))
+
+import summarize  # noqa: E402
+
+IMAGE_DIGEST = "sha256:" + ("a" * 64)
+IMAGE = f"123456789012.dkr.ecr.us-east-1.amazonaws.com/agent@{IMAGE_DIGEST}"
+
+
+def pricing() -> dict[str, object]:
+    return {
+        "primary": "amazon-bedrock/example-model",
+        "provider": "amazon-bedrock",
+        "model_id": "example-model",
+        "pricing_usd_per_million_tokens": {
+            "input": Decimal("3"),
+            "output": Decimal("15"),
+            "cacheRead": Decimal("0.3"),
+            "cacheWrite": Decimal("6"),
+        },
+    }
+
+
+def trial_record(
+    task_id: str,
+    skill: str,
+    suite: str,
+    trial: int,
+    *,
+    passed: bool = True,
+    cache_reads: int = 100,
+    failed: bool = False,
+    error_class: str | None = None,
+    image: str = IMAGE,
+) -> dict[str, object]:
+    return {
+        "task_id": task_id,
+        "image": image,
+        "skill": skill,
+        "suite": suite,
+        "level": "L1",
+        "workspace": "pure",
+        "trial": trial,
+        "trials": 3,
+        "prompt": "sensitive prompt that must not survive",
+        "session_id": f"00000000-0000-4000-8000-{trial:012d}",
+        "result": "sensitive result that must not survive",
+        "metadata": {
+            "input_tokens": 1000,
+            "output_tokens": 200,
+            "cache_read_input_tokens": cache_reads,
+            "cache_write_input_tokens": 50,
+            "model_call_count": trial,
+            "duration_ms": trial * 1000,
+            "latency_ms": trial * 900,
+            "nudged": trial == 3,
+            "tool_calls": [{"name": "secret", "args": {"value": "private"}}],
+            "failed": failed,
+            "error_class": error_class,
+            "session_id": f"00000000-0000-4000-8000-{trial:012d}",
+        },
+        "broker_requests": [{"body": {"private": True}}],
+        "grade": {
+            "passed": passed,
+            "reason": "sensitive grader reason",
+            "results": [],
+        },
+        "recorded_at": f"2026-07-29T00:00:0{trial}+00:00",
+    }
+
+
+def complete_records(*, cache_reads: int = 100) -> list[dict[str, object]]:
+    records = [
+        trial_record(
+            "task-a",
+            "skill-a",
+            "regression",
+            trial,
+            cache_reads=cache_reads,
+        )
+        for trial in range(1, 4)
+    ]
+    records.extend(
+        trial_record(
+            "task-b",
+            "skill-a",
+            "capability",
+            trial,
+            passed=trial != 2,
+            cache_reads=cache_reads,
+            failed=trial == 2,
+            error_class="ModelFailure" if trial == 2 else None,
+        )
+        for trial in range(1, 4)
+    )
+    return records
+
+
+class SummaryAggregationTests(unittest.TestCase):
+    def test_aggregates_pass_three_cost_latency_and_failure_telemetry(self):
+        records = complete_records()
+        records[-2]["grade"]["results"] = [
+            {
+                "grader": "output_match",
+                "passed": False,
+                "reason": "sensitive grader reason",
+            }
+        ]
+        summary = summarize.summarize_records(
+            records,
+            pricing(),
+            expected_image=IMAGE,
+            source_commit="b" * 40,
+        )
+
+        self.assertEqual(summary["schema_version"], 1)
+        self.assertEqual(summary["summary_kind"], "agent-eval-run")
+        self.assertEqual(summary["image_digest"], IMAGE_DIGEST)
+        self.assertEqual(summary["source_commit"], "b" * 40)
+        self.assertEqual(summary["run"]["task_count"], 2)
+        self.assertEqual(summary["run"]["trial_count"], 6)
+        self.assertTrue(summary["tasks"]["task-a"]["pass^3"])
+        self.assertFalse(summary["tasks"]["task-b"]["pass^3"])
+        self.assertEqual(
+            summary["overall"]["pass^3"],
+            {"passed_tasks": 1, "total_tasks": 2, "rate": 0.5},
+        )
+        self.assertEqual(summary["skills"]["skill-a"]["task_count"], 2)
+        telemetry = summary["overall"]["telemetry"]
+        self.assertEqual(telemetry["tokens"]["input_tokens"], 6000)
+        self.assertEqual(telemetry["cost"]["total_usd"], 0.03798)
+        self.assertEqual(telemetry["duration_ms"]["p50"], 2000)
+        self.assertEqual(telemetry["duration_ms"]["p95"], 3000)
+        self.assertEqual(telemetry["model_call_count"]["total"], 12)
+        self.assertEqual(telemetry["nudged"], {"trials": 2, "rate": 0.333333})
+        self.assertEqual(
+            telemetry["failures"]["by_error_class"],
+            {"ModelFailure": 1},
+        )
+        self.assertEqual(telemetry["failures"]["graded_trials"], 1)
+        self.assertEqual(
+            telemetry["failures"]["by_failed_grader"],
+            {"output_match": 1},
+        )
+        self.assertEqual(telemetry["caching_status"], "cached")
+
+    def test_zero_cache_reads_are_derived_as_uncached(self):
+        summary = summarize.summarize_records(
+            complete_records(cache_reads=0),
+            pricing(),
+        )
+
+        self.assertEqual(
+            summary["overall"]["telemetry"]["caching_status"],
+            "uncached",
+        )
+        self.assertEqual(
+            summary["skills"]["skill-a"]["telemetry"]["caching_status"],
+            "uncached",
+        )
+
+    def test_summary_contains_no_trial_transcript_fields_or_values(self):
+        summary = summarize.summarize_records(complete_records(), pricing())
+        encoded = json.dumps(summary)
+
+        for forbidden in summarize.FORBIDDEN_SUMMARY_KEYS:
+            self.assertNotIn(f'"{forbidden}"', encoded)
+        self.assertNotIn("sensitive prompt", encoded)
+        self.assertNotIn("sensitive result", encoded)
+        self.assertNotIn("sensitive grader reason", encoded)
+        self.assertNotIn("private", encoded)
+
+    def test_mixed_images_are_rejected(self):
+        records = complete_records()
+        records[-1] = {
+            **records[-1],
+            "image": "123456789012.dkr.ecr.us-east-1.amazonaws.com/agent@sha256:"
+            + ("c" * 64),
+        }
+
+        with self.assertRaisesRegex(
+            summarize.EvalSummaryError,
+            "same immutable image",
+        ):
+            summarize.summarize_records(records, pricing())
+
+    def test_missing_trial_is_rejected_instead_of_inflating_pass_three(self):
+        records = [
+            record
+            for record in complete_records()
+            if not (record["task_id"] == "task-a" and record["trial"] == 2)
+        ]
+
+        with self.assertRaisesRegex(
+            summarize.EvalSummaryError,
+            "exactly trials 1, 2, and 3",
+        ):
+            summarize.summarize_records(records, pricing())
+
+    def test_mutable_image_tag_is_rejected(self):
+        records = [
+            {**record, "image": "agent:latest"} for record in complete_records()
+        ]
+
+        with self.assertRaisesRegex(summarize.EvalSummaryError, "immutable"):
+            summarize.summarize_records(records, pricing())
+
+    def test_recorded_time_must_be_timezone_aware_iso_8601(self):
+        records = complete_records()
+        records[0] = {**records[0], "recorded_at": "yesterday"}
+
+        with self.assertRaisesRegex(summarize.EvalSummaryError, "ISO 8601"):
+            summarize.summarize_records(records, pricing())
+
+
+class ModelPricingTests(unittest.TestCase):
+    def test_primary_model_pricing_is_loaded_from_openclaw_config(self):
+        loaded = summarize.load_model_pricing(AGENT_IMAGE_DIR / "openclaw.json")
+
+        self.assertEqual(
+            loaded["primary"],
+            "amazon-bedrock/us.anthropic.claude-sonnet-5",
+        )
+        self.assertEqual(
+            loaded["pricing_usd_per_million_tokens"]["cacheRead"],
+            Decimal("0.3"),
+        )
+
+    def test_missing_cost_category_is_rejected(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "openclaw.json"
+            path.write_text(
+                json.dumps(
+                    {
+                        "agents": {
+                            "defaults": {
+                                "model": {"primary": "provider/model"}
+                            }
+                        },
+                        "models": {
+                            "providers": {
+                                "provider": {
+                                    "models": [
+                                        {
+                                            "id": "model",
+                                            "cost": {
+                                                "input": 1,
+                                                "output": 2,
+                                                "cacheRead": 0.1,
+                                            },
+                                        }
+                                    ]
+                                }
+                            }
+                        },
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            with self.assertRaisesRegex(
+                summarize.EvalSummaryError,
+                "cacheWrite",
+            ):
+                summarize.load_model_pricing(path)
+
+
+class CommittedArtifactGuardTests(unittest.TestCase):
+    def safe_summary_bytes(self) -> bytes:
+        summary = summarize.summarize_records(
+            complete_records(),
+            pricing(),
+            source_commit="b" * 40,
+        )
+        return json.dumps(summary).encode("utf-8")
+
+    def test_digest_named_summary_is_accepted(self):
+        summarize.validate_committed_summary(
+            Path(".eval-runs") / f"{IMAGE_DIGEST.replace(':', '-')}.json",
+            self.safe_summary_bytes(),
+        )
+
+    def test_jsonl_transcript_is_rejected_even_if_forced_into_git(self):
+        with self.assertRaisesRegex(summarize.EvalSummaryError, "transcript"):
+            summarize.validate_committed_summary(
+                Path(".eval-runs") / "forced.jsonl",
+                b'{"prompt":"private"}\n',
+            )
+
+    def test_markdown_and_nested_artifacts_are_rejected(self):
+        with self.assertRaisesRegex(summarize.EvalSummaryError, "digest-named"):
+            summarize.validate_committed_summary(
+                Path(".eval-runs") / "notes.md",
+                b"private trial output",
+            )
+        with self.assertRaisesRegex(summarize.EvalSummaryError, "directly inside"):
+            summarize.validate_committed_summary(
+                Path(".eval-runs")
+                / "nested"
+                / f"{IMAGE_DIGEST.replace(':', '-')}.json",
+                self.safe_summary_bytes(),
+            )
+
+    def test_summary_with_a_forbidden_nested_field_is_rejected(self):
+        value = json.loads(self.safe_summary_bytes())
+        value["skills"]["skill-a"]["metadata"] = {"messages": ["private"]}
+
+        with self.assertRaisesRegex(
+            summarize.EvalSummaryError,
+            "forbidden transcript field",
+        ):
+            summarize.validate_committed_summary(
+                Path(".eval-runs") / f"{IMAGE_DIGEST.replace(':', '-')}.json",
+                json.dumps(value).encode("utf-8"),
+            )
+
+    def test_filename_must_match_the_summarized_image_digest(self):
+        with self.assertRaisesRegex(summarize.EvalSummaryError, "filename"):
+            summarize.validate_committed_summary(
+                Path(".eval-runs") / f"sha256-{'c' * 64}.json",
+                self.safe_summary_bytes(),
+            )
+
+    def test_repository_check_reads_the_git_index_not_only_gitignore(self):
+        with tempfile.TemporaryDirectory() as directory:
+            repo = Path(directory)
+            subprocess.run(
+                ["git", "init", "-q"],
+                cwd=repo,
+                check=True,
+            )
+            artifact_dir = repo / ".eval-runs"
+            artifact_dir.mkdir()
+            transcript = artifact_dir / "forced.jsonl"
+            transcript.write_text('{"prompt":"private"}\n', encoding="utf-8")
+            subprocess.run(
+                ["git", "add", "-f", ".eval-runs/forced.jsonl"],
+                cwd=repo,
+                check=True,
+            )
+
+            with self.assertRaisesRegex(summarize.EvalSummaryError, "transcript"):
+                summarize.check_repository(repo)
+
+
+class SummaryCliTests(unittest.TestCase):
+    def test_cli_writes_safe_summary_and_can_enforce_pass_three(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            records_path = root / "run.jsonl"
+            records_path.write_text(
+                "".join(json.dumps(record) + "\n" for record in complete_records()),
+                encoding="utf-8",
+            )
+            output = root / "summary.json"
+
+            with redirect_stdout(StringIO()):
+                result = summarize.main(
+                    [
+                        "--records",
+                        str(records_path),
+                        "--out",
+                        str(output),
+                        "--image",
+                        IMAGE,
+                        "--source-commit",
+                        "b" * 40,
+                        "--model-config",
+                        str(AGENT_IMAGE_DIR / "openclaw.json"),
+                        "--require-all-pass",
+                    ]
+                )
+
+            self.assertEqual(result, 1)
+            self.assertTrue(output.is_file())
+            value = json.loads(output.read_text(encoding="utf-8"))
+            self.assertEqual(value["overall"]["pass^3"]["passed_tasks"], 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/infra/agent-image/test_eval_summary.py
+++ b/infra/agent-image/test_eval_summary.py
@@ -708,8 +708,14 @@ class EvalAutomationContractTests(unittest.TestCase):
             "--source-commit \"${{ steps.candidate.outputs.source_commit }}\"",
             workflow,
         )
-        self.assertIn('--eval-harness-commit "${GITHUB_SHA}"', workflow)
+        self.assertIn("uses: actions/checkout@v7\n        with:\n          ref: dev", workflow)
+        self.assertIn('harness_commit="$(git rev-parse HEAD)"', workflow)
+        self.assertIn(
+            '--eval-harness-commit "${{ steps.harness.outputs.commit }}"',
+            workflow,
+        )
         self.assertNotIn('--source-commit "${GITHUB_SHA}"', workflow)
+        self.assertNotIn('--eval-harness-commit "${GITHUB_SHA}"', workflow)
 
 
 class SummaryCliTests(unittest.TestCase):

--- a/infra/agent-image/test_eval_summary.py
+++ b/infra/agent-image/test_eval_summary.py
@@ -457,6 +457,23 @@ class CommittedArtifactGuardTests(unittest.TestCase):
             r"overall\.pass\^3\.passed_tasks is inconsistent",
         )
 
+    def test_graded_failures_must_match_failed_task_trials(self):
+        value = json.loads(self.safe_summary_bytes())
+        value["tasks"]["task-b"]["passed_trials"] = 3
+        value["tasks"]["task-b"]["pass^3"] = True
+        for scope in (
+            value["overall"],
+            value["suites"]["capability"],
+            value["skills"]["skill-a"],
+        ):
+            scope["pass^3"]["passed_tasks"] = scope["pass^3"]["total_tasks"]
+            scope["pass^3"]["rate"] = 1.0
+
+        self.assert_rejected(
+            value,
+            r"graded_trials is inconsistent with task passed-trial counts",
+        )
+
     def test_scope_telemetry_must_match_counts_rates_and_pricing(self):
         mutations = (
             (

--- a/infra/agent-image/test_eval_summary.py
+++ b/infra/agent-image/test_eval_summary.py
@@ -655,6 +655,25 @@ class CommittedArtifactGuardTests(unittest.TestCase):
 
 
 class EvalAutomationContractTests(unittest.TestCase):
+    def test_ci_creates_model_uid_before_agent_image_python_suites(self):
+        workflow = (
+            AGENT_IMAGE_DIR.parent.parent / ".github" / "workflows" / "ci.yml"
+        ).read_text(encoding="utf-8")
+
+        account_setup = workflow.index(
+            "- name: Ensure model UID test account exists"
+        )
+        python_suites = workflow.index(
+            "- name: Run all agent-image Python tests (unittest)"
+        )
+        root_isolation = workflow.index(
+            "- name: Run model-UID isolation test as root"
+        )
+
+        self.assertLess(account_setup, python_suites)
+        self.assertLess(python_suites, root_isolation)
+        self.assertEqual(workflow.count("sudo useradd --system"), 1)
+
     def test_image_build_stamps_clean_aistudio_source_revision(self):
         dockerfile = (AGENT_IMAGE_DIR / "Dockerfile").read_text(encoding="utf-8")
         build_script = (AGENT_IMAGE_DIR / "build-and-push.sh").read_text(

--- a/infra/agent-image/test_eval_summary.py
+++ b/infra/agent-image/test_eval_summary.py
@@ -511,6 +511,93 @@ class CommittedArtifactGuardTests(unittest.TestCase):
 
                 self.assert_rejected(value, pattern)
 
+    def test_scope_telemetry_partitions_must_reconcile_with_overall(self):
+        def mutate_suite_tokens(value):
+            telemetry = value["suites"]["regression"]["telemetry"]
+            telemetry["tokens"]["output_tokens"] = 1600
+            telemetry["cost"] = {
+                "total_usd": 0.03399,
+                "per_trial_usd": 0.01133,
+                "per_task_usd": 0.03399,
+            }
+
+        def mutate_suite_duration(value):
+            duration = value["suites"]["regression"]["telemetry"]["duration_ms"]
+            duration["total"] = 6003
+            duration["mean"] = 2001
+
+        def mutate_suite_model_calls(value):
+            calls = value["suites"]["regression"]["telemetry"][
+                "model_call_count"
+            ]
+            calls["total"] = 9
+            calls["mean"] = 3
+
+        def mutate_suite_nudges(value):
+            nudged = value["suites"]["regression"]["telemetry"]["nudged"]
+            nudged["trials"] = 2
+            nudged["rate"] = 0.666667
+
+        def mutate_suite_failures(value):
+            failures = value["suites"]["regression"]["telemetry"]["failures"]
+            failures["trials"] = 1
+            failures["rate"] = 0.333333
+            failures["by_error_class"] = {"SyntheticFailure": 1}
+
+        def mutate_suite_failed_graders(value):
+            failures = value["suites"]["capability"]["telemetry"]["failures"]
+            failures["by_failed_grader"] = {"unknown": 2}
+
+        def mutate_skill_duration(value):
+            duration = value["skills"]["skill-a"]["telemetry"]["duration_ms"]
+            duration["total"] = 12006
+            duration["mean"] = 2001
+
+        mutations = (
+            (
+                "suite tokens",
+                mutate_suite_tokens,
+                r"tokens\.output_tokens.*suites partitions",
+            ),
+            (
+                "suite duration",
+                mutate_suite_duration,
+                r"duration_ms\.total.*suites partitions",
+            ),
+            (
+                "suite model calls",
+                mutate_suite_model_calls,
+                r"model_call_count\.total.*suites partitions",
+            ),
+            (
+                "suite nudges",
+                mutate_suite_nudges,
+                r"nudged\.trials.*suites partitions",
+            ),
+            (
+                "suite failures",
+                mutate_suite_failures,
+                r"failures\.trials.*suites partitions",
+            ),
+            (
+                "suite failed graders",
+                mutate_suite_failed_graders,
+                r"by_failed_grader.*suites partitions",
+            ),
+            (
+                "skill duration",
+                mutate_skill_duration,
+                r"duration_ms\.total.*skills partitions",
+            ),
+        )
+
+        for name, mutate, pattern in mutations:
+            with self.subTest(name=name):
+                value = json.loads(self.safe_summary_bytes())
+                mutate(value)
+
+                self.assert_rejected(value, pattern)
+
     def test_skill_membership_must_match_task_summaries(self):
         value = json.loads(self.safe_summary_bytes())
         value["skills"]["skill-a"]["task_ids"] = ["task-a"]


### PR DESCRIPTION
## Summary

- record the full three-trial baseline for the immutable dev AgentCore image as a digest-named, transcript-free summary
- add a recursive closed-schema generator and Git-index artifact guard so unknown prompt, output, broker, secret, and session fields cannot enter `.eval-runs`
- cross-check committed telemetry counters, rates, distributions, caching status, and token-derived costs against each summary scope, then reconcile every additive metric across the suite and skill partitions
- bind future run summaries to clean AI Studio OCI image provenance, record the eval-harness commit separately, and capture an honest run-start timestamp
- schedule the full regression + capability bench nightly from pinned `dev` with manual dispatch, exact-image pricing, safe artifact upload, and transcript cleanup; no PR or push trigger
- wire every orphaned agent-image Python and skill suite into CI, including portable model-account setup and a dedicated root-capable model-UID isolation check
- exclude local `.env` variants recursively from the agent-image build context so ignored credentials cannot enter runtime layers

## Baseline

- Image: `psd-agent-base-dev@sha256:0e4f2387ea48b5342b1be95dd580b9d5a76b4f02560e8281cecfaa5734fd40ce` (dev runtime v61, reverified after completion)
- Image source: `21a7269e3707da018471c6146d4efbeb38d91a99` from the legacy build tag; eval harness: `bd14678437caf56d36ca526c43e7952188df61cd` (first prior commit containing the exact schema-v2 summarizer plus runner, suites, and graders)
- 50 tasks / 150 trials at three trials per task
- Overall pass^3: 43/50 (regression 29/32; capability 14/18)
- Empirical caching: cached (`cache_read_input_tokens` > 0)
- Model calls: 548; nudged trials: 0; execution failures: 0
- Aggregate model cost: $43.808635; p50/p95 latency: 11,181 ms / 33,274 ms
- Seven measured task misses are retained only as safe per-task counts and failed-grader classes. The historical image reproduced the direct-AWS TTS credential defect, which was subsequently fixed on `dev` by #1450.
- Both raw JSONL transcripts and the extracted image config were removed after summary generation and were never tracked or uploaded.
- Because the original runner did not capture run start, this legacy summary reports `started_at: null` and labels the first post-grade record timestamp honestly. Future runs capture the real runner start.

## Risk and migrations

- The nightly job performs live model calls against the shipping dev image; the measured baseline cost above is a representative recurring-run risk.
- The scheduled workflow is intentionally not a PR gate. A failed pass^3 run still uploads only the safe summary for diagnosis.
- New image builds must come from clean agent-image sources and stamp full AI Studio OCI source labels; nightly evaluation fails closed if those labels are absent.
- No database or infrastructure migration.

## Validation

- all 17 agent-image Python test files: 501 passed, 1 skipped on the non-root host; the skipped model-UID boundary passed separately in the root-capable shipping container
- updated direct-AWS HyperFrames suite: 49 passed
- remaining 16 Bun skill test files: 179 passed; Freshservice Node suite: 12 passed
- `CI=true bun run test:ci`: 530 suites / 4,900 tests passed; 1 suite / 15 tests skipped
- `bun run lint`
- `bun run typecheck`
- `bun run build`
- `bun run openapi:check`
- `bun run capabilities:check`
- eval coverage check + staged repository artifact guard
- workflow YAML parse + shell syntax + diff checks
- E2E not applicable: CI/eval tooling only, with no user-facing route or behavior; the local pre-push hook was intentionally bypassed because this isolated worktree has no `AUTH_SECRET`

Closes #1427
Part of #1421
