### PR TITLE
fix(agent): broker direct AWS skill operations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
         bun-version: "1.2.x"
 
     - name: Setup Python for agent eval gates
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6
       with:
         python-version: "3.12"
 
@@ -139,6 +139,19 @@ jobs:
     # defaults, retention, and fatal self-reporting.
     - name: Run psd-morning-brief skill tests (Bun)
       run: bun run test:skill:morning-brief
+      env:
+        CI: true
+
+    # Direct-AWS credential boundary (#1442). OpenClaw strips inherited AWS
+    # credentials from model-launched exec subprocesses; these tests prove TTS
+    # and HyperFrames use only the root-owned fixed-operation relay and that the
+    # relay constrains both AWS targets and payloads.
+    - name: Run direct-AWS skill relay tests
+      run: |
+        python3 -m unittest \
+          infra/agent-image/test_mantle_proxy.py \
+          infra/agent-image/test_tts_synthesize.py
+        bun run test:skill:hyperframes
       env:
         CI: true
 

--- a/app/api/agent/invocation-identity/route.ts
+++ b/app/api/agent/invocation-identity/route.ts
@@ -1,0 +1,26 @@
+/**
+ * Root-relay-only owner resolution for direct AWS skill operations.
+ *
+ * The AgentCore execution role intentionally cannot read the invocation signing
+ * secret, so the root relay asks this trusted web boundary to verify the
+ * installed context before it injects an owner into a downstream AWS request.
+ * The model-facing skill cannot select or override the returned identity.
+ */
+
+import { NextRequest, NextResponse } from "next/server"
+import { verifyAgentInvocationContext } from "@/lib/agent-workspace/invocation-context"
+import { createLogger, generateRequestId } from "@/lib/logger"
+
+const log = createLogger({ module: "agent-invocation-identity" })
+
+export async function POST(request: NextRequest) {
+  const requestId = generateRequestId()
+  const invocation = await verifyAgentInvocationContext(request, {
+    allowedModes: ["owner", "consultation", "scheduled", "email-task"],
+  })
+  if (!invocation) {
+    log.warn("Invocation identity verification failed", { requestId })
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 })
+  }
+  return NextResponse.json({ ownerEmail: invocation.ownerEmail })
+}

--- a/docs/operations/agent-platform-setup.md
+++ b/docs/operations/agent-platform-setup.md
@@ -376,12 +376,15 @@ the relay resolves `ownerEmail` through the signed
 verification. During a staggered rollout to an older web tier, it authenticates
 the installed token and proof through the existing model broker's fixed
 unsupported-path response before decoding the owner claim; any 403 or
-unexpected response fails closed. Finalization gives active privileged requests
-a 795-second drain ceiling (above the 780-second render relay ceiling) while
-retaining a separate 120-second workspace-flush budget, so a proxy restart
-cannot orphan an accepted Lambda render. Keep future direct-AWS skills behind
-the same kind of fixed-operation boundary; do not add AWS credential keys to
-OpenClaw's exec allowlist.
+unexpected response fails closed. Owner resolution has one 30-second total
+budget across the dedicated and compatibility routes. The model-facing render
+client then allows 825 seconds for owner resolution, Lambda connection, its
+780-second response budget, and transport margin. Finalization gives active
+privileged requests a matching 830-second drain ceiling while retaining a
+separate 120-second workspace-flush budget, so a proxy restart cannot orphan
+an accepted Lambda render. Keep future direct-AWS skills behind the same kind
+of fixed-operation boundary; do not add AWS credential keys to OpenClaw's exec
+allowlist.
 
 ## Rich Chat output — cards, charts, button callbacks
 

--- a/docs/operations/agent-platform-setup.md
+++ b/docs/operations/agent-platform-setup.md
@@ -370,9 +370,18 @@ loopback relay in `mantle_proxy.py`. The relay inherits the AgentCore execution-
 role credential chain, validates bounded operation-specific payloads, and can
 only call Polly `SynthesizeSpeech` or the configured HyperFrames Lambda. It
 returns synthesized audio or the Lambda result, never credential values or a
-caller-selected AWS target. Keep future direct-AWS skills behind the same kind
-of fixed-operation boundary; do not add AWS credential keys to OpenClaw's exec
-allowlist.
+caller-selected AWS target. HyperFrames also rejects a model-supplied owner:
+the relay resolves `ownerEmail` through the signed
+`/api/agent/invocation-identity` web boundary and injects it only after
+verification. During a staggered rollout to an older web tier, it authenticates
+the installed token and proof through the existing model broker's fixed
+unsupported-path response before decoding the owner claim; any 403 or
+unexpected response fails closed. Finalization gives active privileged requests
+a 795-second drain ceiling (above the 780-second render relay ceiling) while
+retaining a separate 120-second workspace-flush budget, so a proxy restart
+cannot orphan an accepted Lambda render. Keep future direct-AWS skills behind
+the same kind of fixed-operation boundary; do not add AWS credential keys to
+OpenClaw's exec allowlist.
 
 ## Rich Chat output — cards, charts, button callbacks
 

--- a/docs/operations/agent-platform-setup.md
+++ b/docs/operations/agent-platform-setup.md
@@ -355,6 +355,25 @@ Then update the `FROM` digest and the header block in `infra/agent-image/Dockerf
 and **always** finish with the Morning Brief smoke test (below) — a trivial
 "respond OK" prompt masks session-completion regressions.
 
+### Direct-AWS skill credential boundary
+
+The pinned OpenClaw release sanitizes the environment for every model-launched
+`exec` subprocess. In particular, it removes inherited `AWS_ACCESS_KEY_ID`,
+`AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN`, and the ECS/AgentCore container-
+credential URI variables. This is intentional: forwarding those values would
+let arbitrary model-authored commands print or reuse the execution-role
+credentials.
+
+`psd-tts` and `psd-hyperframes` therefore do not instantiate AWS SDK clients in
+the model-facing subprocess. They call two fixed endpoints on the root-owned
+loopback relay in `mantle_proxy.py`. The relay inherits the AgentCore execution-
+role credential chain, validates bounded operation-specific payloads, and can
+only call Polly `SynthesizeSpeech` or the configured HyperFrames Lambda. It
+returns synthesized audio or the Lambda result, never credential values or a
+caller-selected AWS target. Keep future direct-AWS skills behind the same kind
+of fixed-operation boundary; do not add AWS credential keys to OpenClaw's exec
+allowlist.
+
 ## Rich Chat output — cards, charts, button callbacks
 
 Phase 1 of native Chat interactivity (#TBD) added two skills and one shared

--- a/infra/agent-image/Dockerfile
+++ b/infra/agent-image/Dockerfile
@@ -346,7 +346,6 @@ RUN cd /opt/psd-skills/psd-schedules && npm install --omit=dev --no-audit --no-f
     cd /opt/psd-skills/psd-html-artifact && npm install --omit=dev --no-audit --no-fund && \
     cd /opt/psd-skills/psd-failure-report && npm install --omit=dev --no-audit --no-fund && \
     cd /opt/psd-skills/psd-email-triage && npm install --omit=dev --no-audit --no-fund && \
-    cd /opt/psd-skills/psd-hyperframes && npm install --omit=dev --no-audit --no-fund && \
     mkdir -p /opt/openclaw-plugins && cd /opt/openclaw-plugins && \
     npm pack @openclaw/amazon-bedrock-provider@2026.7.1 && \
     tar -xzf openclaw-amazon-bedrock-provider-2026.7.1.tgz && \
@@ -370,13 +369,13 @@ RUN cd /opt/psd-skills/psd-schedules && npm install --omit=dev --no-audit --no-f
 # psd-freshservice has zero npm dependencies (native fetch + child_process only).
 # psd-brand-guidelines has zero npm dependencies (config + static assets only).
 # psd-github has zero npm dependencies (wraps /usr/local/bin/gh).
-# psd-hyperframes (#1175) has ONE pure-JS dep (@aws-sdk/client-lambda) and NO
-# native renderer deps: Chromium/FFmpeg/Puppeteer live ONLY in the separate
-# hyperframes-render Lambda (infra/hyperframes-render/), never in this image —
-# the AgentCore Firecracker overlay-mount snapshotter cannot carry that native
-# stack (same reason matplotlib/pymupdf4llm were removed). The skill just shells
-# an InvokeFunction call. Its npm install joins the SINGLE RUN above, adding NO
-# new Docker layer (stays under the Firecracker 54-layer ceiling).
+# psd-hyperframes (#1175, #1442) has NO npm deps and NO native renderer deps:
+# Chromium/FFmpeg/Puppeteer live ONLY in the separate hyperframes-render Lambda
+# (infra/hyperframes-render/), never in this image. The model-facing script sends
+# a bounded request to the root-owned loopback relay, which invokes the one
+# configured Lambda with the AgentCore role. This is necessary because OpenClaw
+# strips inherited AWS credentials from every model-launched exec subprocess;
+# the relay never returns reusable credential material to the model UID.
 # psd-last30days (#1174) is pure Python (stdlib urllib + xml.etree only) with an
 # optional boto3 S3 upload — boto3 is already in /opt/agentcore-venv, so it needs
 # NO new pip dependency and NO npm install. It is installed solely by the

--- a/infra/agent-image/agentcore_wrapper.py
+++ b/infra/agent-image/agentcore_wrapper.py
@@ -4,7 +4,7 @@ contract.
 
 Flow on container start:
   1. Log BUILD_MARKER so CloudWatch proves which image is running
-  2. Start a credential-isolating local model proxy
+  2. Start a credential-isolating local model/direct-AWS relay
   3. Start the OpenClaw gateway pointed only at that loopback proxy
   4. Register the agent_invocation entrypoint with BedrockAgentCoreApp
   5. Route incoming payloads through the harness adapter via WebSocket
@@ -345,9 +345,10 @@ def _serialize_invocations(function):
 
 def start_mantle_proxy() -> None:
     """
-    Launch the Mantle logging proxy on 127.0.0.1:18791 and block until
-    /health returns 200. If it can't come up, exit — OpenClaw's openclaw.json
-    points its baseUrl at the proxy, so no proxy means no model calls.
+    Launch the root-owned model/direct-AWS relay on 127.0.0.1:18791 and block
+    until /health returns 200. If it can't come up, exit — OpenClaw's
+    openclaw.json points its baseUrl at the relay, so no relay means no model
+    calls or direct-AWS skills.
     """
     global _mantle_proxy_process
     import urllib.request

--- a/infra/agent-image/agentcore_wrapper.py
+++ b/infra/agent-image/agentcore_wrapper.py
@@ -88,6 +88,10 @@ _INVOCATION_CONTEXT_RE = re.compile(
 _REQUEST_PROOF_KEY_RE = re.compile(r"^[A-Za-z0-9_-]{43}$")
 _invocation_lock = asyncio.Lock()
 FINAL_WORKSPACE_FLUSH_SECONDS = 120
+# HyperFrames may legitimately hold a synchronous relay request for 780s.
+# Finalization must keep the gate closed and wait longer than that ceiling
+# instead of restarting the proxy and orphaning an accepted Lambda render.
+PROXY_FINALIZATION_DRAIN_SECONDS = 795
 
 
 def _install_invocation_authority(token, request_proof_key) -> bool:
@@ -175,7 +179,7 @@ def _set_proxy_finalization(action: str, token: str) -> None:
         method="POST",
         headers={"X-Agent-Workspace-Flush": token},
     )
-    timeout = FINAL_WORKSPACE_FLUSH_SECONDS + 5 if action == "begin" else 5
+    timeout = PROXY_FINALIZATION_DRAIN_SECONDS + 5 if action == "begin" else 5
     try:
         with urllib.request.urlopen(request, timeout=timeout) as response:
             if response.status != 200:

--- a/infra/agent-image/agentcore_wrapper.py
+++ b/infra/agent-image/agentcore_wrapper.py
@@ -88,10 +88,11 @@ _INVOCATION_CONTEXT_RE = re.compile(
 _REQUEST_PROOF_KEY_RE = re.compile(r"^[A-Za-z0-9_-]{43}$")
 _invocation_lock = asyncio.Lock()
 FINAL_WORKSPACE_FLUSH_SECONDS = 120
-# HyperFrames may legitimately hold a synchronous relay request for 780s.
-# Finalization must keep the gate closed and wait longer than that ceiling
-# instead of restarting the proxy and orphaning an accepted Lambda render.
-PROXY_FINALIZATION_DRAIN_SECONDS = 795
+# HyperFrames may legitimately spend 30s resolving owner authority, 10s
+# connecting to Lambda, 780s waiting for its response, and 5s on local
+# transport. Finalization must outlive that 825s relay ceiling instead of
+# restarting the proxy and orphaning an accepted Lambda render.
+PROXY_FINALIZATION_DRAIN_SECONDS = 830
 
 
 def _install_invocation_authority(token, request_proof_key) -> bool:

--- a/infra/agent-image/eval/README.md
+++ b/infra/agent-image/eval/README.md
@@ -68,6 +68,13 @@ tools while the container starts. Run evals only on a trusted workstation. The
 runner removes its containers on completion and logs a warning if Docker cannot
 remove one.
 
+OpenClaw 2026.7.1 deliberately removes inherited AWS access-key and container-
+credential variables from model-launched `exec` subprocesses. Direct-AWS skills
+therefore use the image's root-owned fixed-operation relay: the relay inherits
+the candidate container's credential chain, while the skill process receives
+only the requested Polly audio or HyperFrames result and never reusable
+credential material. The TTS and HyperFrames L2 tasks cover this exact boundary.
+
 Every trial gets:
 
 - a fresh UUID in `X-Amzn-Bedrock-AgentCore-Runtime-Session-Id`;
@@ -231,10 +238,11 @@ role able to read the deployed runtime and ECR image, pull that image, discover
 the dev broker, mint signed probe authority, and perform the listed L2 calls.
 The role must permit a three-hour session, matching the workflow's requested
 duration.
-Until #1440 and #1442 are fixed, the retained Summarize and TTS canaries are
-expected to fail and should be treated as known defect signals, not workflow
-misconfiguration. HyperFrames exercises the same #1442 direct-AWS credential
-boundary and is omitted from the weekly subset to avoid a duplicate alert.
+Until #1440 is fixed, the retained Summarize canary is expected to fail and
+should be treated as a known defect signal, not workflow misconfiguration. TTS
+now gates the fixed-operation credential boundary from #1442. HyperFrames
+exercises the same boundary and is omitted from the weekly subset to avoid a
+duplicate live side effect.
 The workflow never uploads or commits JSONL transcripts. It prints only task
 IDs and failure reasons, then deletes the owner-only run file even on failure.
 

--- a/infra/agent-image/eval/suites/l2-live.yaml
+++ b/infra/agent-image/eval/suites/l2-live.yaml
@@ -1,7 +1,8 @@
 # Weekly live-dev fixture-drift subset. Every prompt uses synthetic test data.
-# Summarize (#1440) and TTS (#1442) are intentionally retained as fail-closed
-# signals until their known dev defects land. HyperFrames shares #1442's direct
-# AWS credential boundary and is omitted to avoid duplicating the same alert.
+# Summarize (#1440) is intentionally retained as a fail-closed signal until its
+# known dev defect lands. TTS gates the fixed-operation credential boundary
+# from #1442. HyperFrames shares that boundary and is omitted from the weekly
+# subset to avoid a duplicate live render.
 # Failure reporting remains in the regression suite but requires a @psd401.net
 # actor for attribution, so the RFC 2606 canary owner cannot exercise it live.
 tasks:

--- a/infra/agent-image/mantle_proxy.py
+++ b/infra/agent-image/mantle_proxy.py
@@ -91,16 +91,25 @@ HYPERFRAMES_INVOKE_PAYLOAD_MAX_BYTES = 6 * 1024 * 1024
 HYPERFRAMES_OWNER_BINDING_RESERVE_BYTES = 512
 HYPERFRAMES_HTTP_REQUEST_MAX_BYTES = HYPERFRAMES_INVOKE_PAYLOAD_MAX_BYTES
 HYPERFRAMES_RESPONSE_MAX_BYTES = 8 * 1024 * 1024
-# 13 minutes leaves 60 seconds under the interactive turn's 840-second budget.
-# The render process itself is capped at 720 seconds, leaving another minute
-# for Lambda cleanup/upload/response. Both the AWS client and Node relay client
-# use this value so neither disconnects while a supported render is still live.
-HYPERFRAMES_RELAY_TIMEOUT_SECONDS = 780
+# The renderer is capped at 720s. The Lambda read budget leaves another minute
+# for cleanup/upload/response. Owner resolution, Lambda connection, and the
+# response wait are separate sequential phases, so the model-facing relay
+# timeout must cover all three plus a small transport margin.
+HYPERFRAMES_IDENTITY_TIMEOUT_SECONDS = 30
+HYPERFRAMES_LAMBDA_CONNECT_TIMEOUT_SECONDS = 10
+HYPERFRAMES_LAMBDA_READ_TIMEOUT_SECONDS = 780
+HYPERFRAMES_RELAY_TRANSPORT_MARGIN_SECONDS = 5
+HYPERFRAMES_RELAY_TIMEOUT_SECONDS = (
+    HYPERFRAMES_IDENTITY_TIMEOUT_SECONDS
+    + HYPERFRAMES_LAMBDA_CONNECT_TIMEOUT_SECONDS
+    + HYPERFRAMES_LAMBDA_READ_TIMEOUT_SECONDS
+    + HYPERFRAMES_RELAY_TRANSPORT_MARGIN_SECONDS
+)
 # Finalization must never restart this proxy while an accepted synchronous
 # render can still be running in Lambda. Keep a small transport margin above
 # the relay ceiling; workspace flushing retains its separate 120-second budget
 # in agentcore_wrapper.py.
-FINALIZATION_DRAIN_TIMEOUT_SECONDS = HYPERFRAMES_RELAY_TIMEOUT_SECONDS + 15
+FINALIZATION_DRAIN_TIMEOUT_SECONDS = HYPERFRAMES_RELAY_TIMEOUT_SECONDS + 5
 HYPERFRAMES_MAX_DURATION_SECONDS = 180
 HYPERFRAMES_MAX_FRAMES = 3_600
 HYPERFRAMES_MIN_DIMENSION = 16
@@ -262,8 +271,8 @@ def _new_lambda_client():
         "lambda",
         region_name=AWS_REGION,
         config=Config(
-            connect_timeout=10,
-            read_timeout=HYPERFRAMES_RELAY_TIMEOUT_SECONDS,
+            connect_timeout=HYPERFRAMES_LAMBDA_CONNECT_TIMEOUT_SECONDS,
+            read_timeout=HYPERFRAMES_LAMBDA_READ_TIMEOUT_SECONDS,
             # Retrying a timed-out synchronous invoke can start the same costly
             # render twice. The caller can make an explicit retry after a
             # definitive failure; the transport itself stays single-attempt.
@@ -354,7 +363,18 @@ def _authority_headers(method: str, route: str, body: bytes) -> dict:
 
 
 async def _resolve_invocation_owner() -> str:
-    """Resolve the signed turn owner in the trusted web tier before AWS work."""
+    """Resolve one signed owner within a total budget across both web routes."""
+    try:
+        return await asyncio.wait_for(
+            _resolve_invocation_owner_within_budget(),
+            timeout=HYPERFRAMES_IDENTITY_TIMEOUT_SECONDS,
+        )
+    except asyncio.TimeoutError as exc:
+        raise RuntimeError("Invocation identity verification timed out") from exc
+
+
+async def _resolve_invocation_owner_within_budget() -> str:
+    """Use the dedicated route or one authenticated old-tier compatibility probe."""
     status, response_body = await _post_signed_identity_request(
         INVOCATION_IDENTITY_ROUTE,
         skip_not_found_body=True,
@@ -402,7 +422,11 @@ async def _post_signed_identity_request(
         "Content-Type": "application/json",
         **_authority_headers("POST", route, body),
     }
-    timeout = ClientTimeout(total=30, sock_read=30, sock_connect=10)
+    timeout = ClientTimeout(
+        total=HYPERFRAMES_IDENTITY_TIMEOUT_SECONDS,
+        sock_read=HYPERFRAMES_IDENTITY_TIMEOUT_SECONDS,
+        sock_connect=10,
+    )
     async with ClientSession(timeout=timeout) as session:
         async with session.post(
             f"{APP_BASE_URL}{route}",

--- a/infra/agent-image/mantle_proxy.py
+++ b/infra/agent-image/mantle_proxy.py
@@ -53,7 +53,14 @@ AUTHORITY_DIRECTORY = "/run/psd-agent-authority"
 INVOCATION_CONTEXT_PATH = f"{AUTHORITY_DIRECTORY}/invocation-context"
 REQUEST_PROOF_KEY_PATH = f"{AUTHORITY_DIRECTORY}/request-proof-key"
 WORKSPACE_FLUSH_TOKEN_PATH = f"{AUTHORITY_DIRECTORY}/workspace-flush-token"
-FINALIZATION_DRAIN_TIMEOUT_SECONDS = 120
+INVOCATION_IDENTITY_ROUTE = "/api/agent/invocation-identity"
+# Rolling-deploy compatibility: the existing model-broker route authenticates
+# all four invocation modes before rejecting an unsupported subpath. An exact
+# authenticated 404 therefore proves the installed token/key pair before this
+# relay decodes its root-only owner claim on an older web tier.
+INVOCATION_AUTHORITY_PROBE_ROUTE = (
+    "/api/agent/model-proxy/invocation-identity-probe"
+)
 ALLOWED_AGENT_BROKER_ROUTES = frozenset({
     "/api/agent/account-request",
     "/api/agent/aistudio",
@@ -81,6 +88,7 @@ HYPERFRAMES_REQUEST_MAX_BYTES = 4 * 1024 * 1024
 # body at that same exact ceiling, then check the compact serialized payload
 # independently: JSON escaping can make a <=4 MiB composition exceed 6 MiB.
 HYPERFRAMES_INVOKE_PAYLOAD_MAX_BYTES = 6 * 1024 * 1024
+HYPERFRAMES_OWNER_BINDING_RESERVE_BYTES = 512
 HYPERFRAMES_HTTP_REQUEST_MAX_BYTES = HYPERFRAMES_INVOKE_PAYLOAD_MAX_BYTES
 HYPERFRAMES_RESPONSE_MAX_BYTES = 8 * 1024 * 1024
 # 13 minutes leaves 60 seconds under the interactive turn's 840-second budget.
@@ -88,6 +96,11 @@ HYPERFRAMES_RESPONSE_MAX_BYTES = 8 * 1024 * 1024
 # for Lambda cleanup/upload/response. Both the AWS client and Node relay client
 # use this value so neither disconnects while a supported render is still live.
 HYPERFRAMES_RELAY_TIMEOUT_SECONDS = 780
+# Finalization must never restart this proxy while an accepted synchronous
+# render can still be running in Lambda. Keep a small transport margin above
+# the relay ceiling; workspace flushing retains its separate 120-second budget
+# in agentcore_wrapper.py.
+FINALIZATION_DRAIN_TIMEOUT_SECONDS = HYPERFRAMES_RELAY_TIMEOUT_SECONDS + 15
 HYPERFRAMES_MAX_DURATION_SECONDS = 180
 HYPERFRAMES_MAX_FRAMES = 3_600
 HYPERFRAMES_MIN_DIMENSION = 16
@@ -183,7 +196,6 @@ def _validate_hyperframes_payload(payload: object) -> dict:
         "fps",
         "width",
         "height",
-        "userEmail",
         "dryRun",
     }
     if set(payload) - allowed:
@@ -230,16 +242,15 @@ def _validate_hyperframes_payload(payload: object) -> dict:
         ):
             raise ValueError("invalid HyperFrames dimensions")
 
-    email = payload.get("userEmail")
-    if (
-        not isinstance(email, str)
-        or len(email) > 320
-        or not EMAIL_RE.fullmatch(email)
-    ):
-        raise ValueError("invalid HyperFrames user")
     if "dryRun" in payload and not isinstance(payload["dryRun"], bool):
         raise ValueError("invalid HyperFrames dry-run flag")
-    _serialize_hyperframes_payload(payload)
+    _serialize_hyperframes_payload(
+        payload,
+        max_bytes=(
+            HYPERFRAMES_INVOKE_PAYLOAD_MAX_BYTES
+            - HYPERFRAMES_OWNER_BINDING_RESERVE_BYTES
+        ),
+    )
     return payload
 
 
@@ -261,16 +272,34 @@ def _new_lambda_client():
     )
 
 
-def _serialize_hyperframes_payload(payload: dict) -> bytes:
+def _serialize_hyperframes_payload(
+    payload: dict,
+    *,
+    max_bytes: int = HYPERFRAMES_INVOKE_PAYLOAD_MAX_BYTES,
+) -> bytes:
     """Serialize exactly once within Lambda's synchronous invoke body limit."""
     body = json.dumps(
         payload,
         ensure_ascii=False,
         separators=(",", ":"),
     ).encode("utf-8")
-    if len(body) > HYPERFRAMES_INVOKE_PAYLOAD_MAX_BYTES:
+    if len(body) > max_bytes:
         raise ValueError("HyperFrames serialized payload exceeds the configured limit")
     return body
+
+
+def _bind_hyperframes_owner(payload: dict, owner_email: str) -> dict:
+    """Inject only the web-verified owner into the downstream Lambda payload."""
+    if (
+        not isinstance(owner_email, str)
+        or len(owner_email) > 320
+        or owner_email != owner_email.lower()
+        or not EMAIL_RE.fullmatch(owner_email)
+    ):
+        raise RuntimeError("HyperFrames invocation owner is invalid")
+    owner_bound_payload = {**payload, "userEmail": owner_email}
+    _serialize_hyperframes_payload(owner_bound_payload)
+    return owner_bound_payload
 
 
 def _invoke_hyperframes(payload: dict) -> dict:
@@ -322,6 +351,124 @@ def _authority_headers(method: str, route: str, body: bytes) -> dict:
         "X-Agent-Request-Proof-Body-Sha256": body_sha256,
         "X-Agent-Request-Proof-Signature": signature,
     }
+
+
+async def _resolve_invocation_owner() -> str:
+    """Resolve the signed turn owner in the trusted web tier before AWS work."""
+    status, response_body = await _post_signed_identity_request(
+        INVOCATION_IDENTITY_ROUTE,
+        skip_not_found_body=True,
+    )
+    if status == 200:
+        try:
+            result = json.loads(response_body)
+        except (TypeError, ValueError) as exc:
+            raise RuntimeError("Invocation identity response is invalid") from exc
+        return _validate_invocation_owner(
+            result.get("ownerEmail") if isinstance(result, dict) else None
+        )
+    if status != 404:
+        raise RuntimeError("Invocation identity verification failed")
+
+    # During a staggered rollout, the new web route may not exist yet. The
+    # already-deployed model broker validates the same signed context/proof
+    # before returning this exact unsupported-path response. Only after that
+    # cryptographic verification do we decode the owner from the root-only
+    # installed token.
+    probe_status, probe_body = await _post_signed_identity_request(
+        INVOCATION_AUTHORITY_PROBE_ROUTE
+    )
+    try:
+        probe_result = json.loads(probe_body)
+    except (TypeError, ValueError) as exc:
+        raise RuntimeError("Invocation authority probe is invalid") from exc
+    if (
+        probe_status != 404
+        or probe_result != {"error": "Unsupported model endpoint"}
+    ):
+        raise RuntimeError("Invocation authority verification failed")
+    context, _proof_key = _read_authority()
+    return _decode_invocation_owner(context)
+
+
+async def _post_signed_identity_request(
+    route: str,
+    *,
+    skip_not_found_body: bool = False,
+) -> tuple[int, bytes]:
+    """POST one bounded root-signed identity request to the trusted web tier."""
+    body = b"{}"
+    headers = {
+        "Content-Type": "application/json",
+        **_authority_headers("POST", route, body),
+    }
+    timeout = ClientTimeout(total=30, sock_read=30, sock_connect=10)
+    async with ClientSession(timeout=timeout) as session:
+        async with session.post(
+            f"{APP_BASE_URL}{route}",
+            data=body,
+            headers=headers,
+            allow_redirects=False,
+        ) as upstream:
+            return await _read_signed_identity_response(
+                upstream,
+                skip_not_found_body=skip_not_found_body,
+            )
+
+
+async def _read_signed_identity_response(
+    response,
+    *,
+    skip_not_found_body: bool,
+) -> tuple[int, bytes]:
+    """Bound responses, except an unused framework 404 body during rollout."""
+    if skip_not_found_body and response.status == 404:
+        response.close()
+        return response.status, b""
+    response_body = await _read_bounded_agent_broker_response(
+        response,
+        max_bytes=4 * 1024,
+    )
+    return response.status, response_body
+
+
+def _validate_invocation_owner(owner_email: object) -> str:
+    """Return one normalized owner suitable for the fixed Lambda namespace."""
+    if (
+        not isinstance(owner_email, str)
+        or len(owner_email) > 320
+        or owner_email != owner_email.lower()
+        or not EMAIL_RE.fullmatch(owner_email)
+    ):
+        raise RuntimeError("Invocation identity response is invalid")
+    return owner_email
+
+
+def _decode_invocation_owner(context: str) -> str:
+    """Decode claims only after the trusted web tier authenticated the token."""
+    try:
+        version, encoded_claims, _signature = context.split(".")
+        if version != "v1":
+            raise ValueError("unsupported invocation context")
+        padded = encoded_claims + ("=" * (-len(encoded_claims) % 4))
+        claims = json.loads(base64.urlsafe_b64decode(padded))
+    except (TypeError, ValueError, UnicodeDecodeError) as exc:
+        raise RuntimeError("Invocation identity response is invalid") from exc
+    if (
+        not isinstance(claims, dict)
+        or claims.get("version") != 1
+        or claims.get("audience") != "psd-agent-internal"
+    ):
+        raise RuntimeError("Invocation identity response is invalid")
+    return _validate_invocation_owner(claims.get("ownerEmail"))
+
+
+async def _owner_bound_hyperframes_payload(payload: dict) -> dict:
+    """Replace all model identity input with the freshly verified turn owner."""
+    return _bind_hyperframes_owner(
+        payload,
+        await _resolve_invocation_owner(),
+    )
 
 
 def _read_workspace_flush_token() -> str | None:
@@ -1349,7 +1496,8 @@ async def handle_hyperframes_invoke(request: web.Request) -> web.Response:
     except ValueError:
         return web.json_response({"error": "Invalid HyperFrames request"}, status=400)
     try:
-        result = await asyncio.to_thread(_invoke_hyperframes, payload)
+        owner_bound_payload = await _owner_bound_hyperframes_payload(payload)
+        result = await asyncio.to_thread(_invoke_hyperframes, owner_bound_payload)
     except Exception as exc:  # noqa: BLE001
         log.warning(j("hyperframes_invoke_failed", error=type(exc).__name__))
         return web.json_response({"error": "HyperFrames invocation failed"}, status=502)

--- a/infra/agent-image/mantle_proxy.py
+++ b/infra/agent-image/mantle_proxy.py
@@ -77,8 +77,17 @@ POLLY_TEXT_MAX_CHARS = 3_000
 POLLY_HTTP_REQUEST_MAX_BYTES = 16 * 1024
 POLLY_AUDIO_MAX_BYTES = 16 * 1024 * 1024
 HYPERFRAMES_REQUEST_MAX_BYTES = 4 * 1024 * 1024
-HYPERFRAMES_HTTP_REQUEST_MAX_BYTES = 6 * 1024 * 1024
+# Lambda's synchronous Invoke payload is capped at 6 MiB. Keep the loopback
+# body at that same exact ceiling, then check the compact serialized payload
+# independently: JSON escaping can make a <=4 MiB composition exceed 6 MiB.
+HYPERFRAMES_INVOKE_PAYLOAD_MAX_BYTES = 6 * 1024 * 1024
+HYPERFRAMES_HTTP_REQUEST_MAX_BYTES = HYPERFRAMES_INVOKE_PAYLOAD_MAX_BYTES
 HYPERFRAMES_RESPONSE_MAX_BYTES = 8 * 1024 * 1024
+# 13 minutes leaves 60 seconds under the interactive turn's 840-second budget.
+# The render process itself is capped at 720 seconds, leaving another minute
+# for Lambda cleanup/upload/response. Both the AWS client and Node relay client
+# use this value so neither disconnects while a supported render is still live.
+HYPERFRAMES_RELAY_TIMEOUT_SECONDS = 780
 HYPERFRAMES_MAX_DURATION_SECONDS = 180
 HYPERFRAMES_MAX_FRAMES = 3_600
 HYPERFRAMES_MIN_DIMENSION = 16
@@ -230,13 +239,38 @@ def _validate_hyperframes_payload(payload: object) -> dict:
         raise ValueError("invalid HyperFrames user")
     if "dryRun" in payload and not isinstance(payload["dryRun"], bool):
         raise ValueError("invalid HyperFrames dry-run flag")
+    _serialize_hyperframes_payload(payload)
     return payload
 
 
 def _new_lambda_client():
     import boto3
+    from botocore.config import Config
 
-    return boto3.client("lambda", region_name=AWS_REGION)
+    return boto3.client(
+        "lambda",
+        region_name=AWS_REGION,
+        config=Config(
+            connect_timeout=10,
+            read_timeout=HYPERFRAMES_RELAY_TIMEOUT_SECONDS,
+            # Retrying a timed-out synchronous invoke can start the same costly
+            # render twice. The caller can make an explicit retry after a
+            # definitive failure; the transport itself stays single-attempt.
+            retries={"total_max_attempts": 1, "mode": "standard"},
+        ),
+    )
+
+
+def _serialize_hyperframes_payload(payload: dict) -> bytes:
+    """Serialize exactly once within Lambda's synchronous invoke body limit."""
+    body = json.dumps(
+        payload,
+        ensure_ascii=False,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    if len(body) > HYPERFRAMES_INVOKE_PAYLOAD_MAX_BYTES:
+        raise ValueError("HyperFrames serialized payload exceeds the configured limit")
+    return body
 
 
 def _invoke_hyperframes(payload: dict) -> dict:
@@ -247,7 +281,7 @@ def _invoke_hyperframes(payload: dict) -> dict:
     response = _new_lambda_client().invoke(
         FunctionName=function_name,
         InvocationType="RequestResponse",
-        Payload=json.dumps(payload, separators=(",", ":")).encode("utf-8"),
+        Payload=_serialize_hyperframes_payload(payload),
     )
     stream = response.get("Payload")
     if stream is None:

--- a/infra/agent-image/mantle_proxy.py
+++ b/infra/agent-image/mantle_proxy.py
@@ -1,14 +1,14 @@
 #!/usr/bin/env python3
 """
-Transparent logging proxy for the owner-bound AI Studio model broker.
+Root-owned loopback relay for the AI Studio agent runtime.
 
-Why: we need ground-truth visibility into what OpenClaw actually sends to
-Mantle. OpenClaw's logs don't include request bodies, and the "!"-loop
-degeneracy we see isn't reproducible via direct curl calls with the same
-apparent payload. This proxy sits on 127.0.0.1:18791, logs request +
-response to stdout (CloudWatch), and forwards byte-for-byte to the trusted web
-tier. The web tier holds the provider credential and enforces the signed owner
-context plus a model/output allowlist.
+The primary path logs what OpenClaw sends to the owner-bound model broker and
+forwards it to the trusted web tier. Fixed agent-broker routes attach root-only
+invocation authority. Two direct-AWS endpoints also perform bounded Polly and
+HyperFrames operations with the root process's AgentCore execution-role
+credential chain. OpenClaw strips that chain from model-launched subprocesses,
+and these endpoints never return reusable credentials or accept arbitrary AWS
+targets.
 
 If this process dies, OpenClaw's requests also fail — so the entrypoint
 should (a) verify the proxy's /health before starting the gateway and
@@ -21,6 +21,7 @@ import hashlib
 import hmac
 import json
 import logging
+import math
 import os
 import re
 import sys
@@ -71,6 +72,20 @@ ALLOWED_AGENT_BROKER_ROUTES = frozenset({
     "/api/agent/workspace-execute",
     "/api/agent/workspace-storage",
 })
+AWS_REGION = os.environ.get("AWS_REGION", "us-east-1")
+POLLY_TEXT_MAX_CHARS = 3_000
+POLLY_HTTP_REQUEST_MAX_BYTES = 16 * 1024
+POLLY_AUDIO_MAX_BYTES = 16 * 1024 * 1024
+HYPERFRAMES_REQUEST_MAX_BYTES = 4 * 1024 * 1024
+HYPERFRAMES_HTTP_REQUEST_MAX_BYTES = 6 * 1024 * 1024
+HYPERFRAMES_RESPONSE_MAX_BYTES = 8 * 1024 * 1024
+HYPERFRAMES_MAX_DURATION_SECONDS = 180
+HYPERFRAMES_MAX_FRAMES = 3_600
+HYPERFRAMES_MIN_DIMENSION = 16
+HYPERFRAMES_MAX_DIMENSION = 3_840
+POLLY_ENGINES = frozenset({"generative", "long-form", "neural", "standard"})
+POLLY_VOICE_RE = re.compile(r"^[A-Za-z][A-Za-z0-9_-]{0,63}$")
+EMAIL_RE = re.compile(r"^[^\s@/]+@[^\s@/]+\.[^\s@/]+$")
 
 
 def _read_authority() -> tuple[str, bytes]:
@@ -81,6 +96,172 @@ def _read_authority() -> tuple[str, bytes]:
         encoded_key = handle.read().strip()
     padded = encoded_key + ("=" * (-len(encoded_key) % 4))
     return context, base64.urlsafe_b64decode(padded)
+
+
+def _invocation_authority_is_available() -> bool:
+    """Require an active, root-readable turn before privileged AWS work."""
+    try:
+        context, proof_key = _read_authority()
+    except (OSError, ValueError):
+        return False
+    return bool(context) and len(proof_key) == 32
+
+
+def _read_bounded_aws_stream(stream, max_bytes: int) -> bytes:
+    """Read and close an AWS StreamingBody without allowing memory exhaustion."""
+    body = bytearray()
+    try:
+        while True:
+            remaining = max_bytes - len(body)
+            chunk = stream.read(min(64 * 1024, remaining + 1))
+            if not chunk:
+                break
+            body.extend(chunk)
+            if len(body) > max_bytes:
+                raise ValueError("AWS response exceeds the configured limit")
+    finally:
+        close = getattr(stream, "close", None)
+        if callable(close):
+            close()
+    return bytes(body)
+
+
+def _validate_polly_payload(payload: object) -> dict:
+    """Validate the only Polly operation exposed to the model-facing UID."""
+    if not isinstance(payload, dict) or set(payload) != {"text", "voice", "engine"}:
+        raise ValueError("invalid Polly request")
+    text = payload.get("text")
+    voice = payload.get("voice")
+    engine = payload.get("engine")
+    if not isinstance(text, str) or not text.strip() or len(text) > POLLY_TEXT_MAX_CHARS:
+        raise ValueError("invalid Polly text")
+    if not isinstance(voice, str) or not POLLY_VOICE_RE.fullmatch(voice):
+        raise ValueError("invalid Polly voice")
+    if engine not in POLLY_ENGINES:
+        raise ValueError("invalid Polly engine")
+    return {"text": text, "voice": voice, "engine": engine}
+
+
+def _new_polly_client():
+    import boto3
+
+    return boto3.client("polly", region_name=AWS_REGION)
+
+
+def _synthesize_polly(payload: dict) -> bytes:
+    """Call Polly with the root relay's ambient AgentCore role credentials."""
+    response = _new_polly_client().synthesize_speech(
+        Text=payload["text"],
+        OutputFormat="mp3",
+        VoiceId=payload["voice"],
+        Engine=payload["engine"],
+    )
+    stream = response.get("AudioStream")
+    if stream is None:
+        raise RuntimeError("Polly returned no audio")
+    return _read_bounded_aws_stream(stream, POLLY_AUDIO_MAX_BYTES)
+
+
+def _validate_hyperframes_payload(payload: object) -> dict:
+    """Constrain the fixed Lambda relay independently of the skill and Lambda."""
+    if not isinstance(payload, dict):
+        raise ValueError("invalid HyperFrames request")
+    allowed = {
+        "html",
+        "css",
+        "js",
+        "durationSeconds",
+        "fps",
+        "width",
+        "height",
+        "userEmail",
+        "dryRun",
+    }
+    if set(payload) - allowed:
+        raise ValueError("invalid HyperFrames fields")
+
+    html = payload.get("html")
+    css = payload.get("css")
+    javascript = payload.get("js")
+    if not isinstance(html, str) or not html.strip():
+        raise ValueError("invalid HyperFrames HTML")
+    if css is not None and not isinstance(css, str):
+        raise ValueError("invalid HyperFrames CSS")
+    if javascript is not None and not isinstance(javascript, str):
+        raise ValueError("invalid HyperFrames JavaScript")
+    composition_bytes = sum(
+        len(value.encode("utf-8"))
+        for value in (html, css, javascript)
+        if isinstance(value, str)
+    )
+    if composition_bytes > HYPERFRAMES_REQUEST_MAX_BYTES:
+        raise ValueError("HyperFrames composition exceeds the configured limit")
+
+    duration = payload.get("durationSeconds")
+    fps = payload.get("fps")
+    width = payload.get("width")
+    height = payload.get("height")
+    if (
+        isinstance(duration, bool)
+        or not isinstance(duration, (int, float))
+        or not math.isfinite(duration)
+        or duration <= 0
+        or duration > HYPERFRAMES_MAX_DURATION_SECONDS
+    ):
+        raise ValueError("invalid HyperFrames duration")
+    if isinstance(fps, bool) or not isinstance(fps, int) or not 1 <= fps <= 60:
+        raise ValueError("invalid HyperFrames fps")
+    if math.ceil(duration * fps) > HYPERFRAMES_MAX_FRAMES:
+        raise ValueError("HyperFrames frame budget exceeded")
+    for value in (width, height):
+        if (
+            isinstance(value, bool)
+            or not isinstance(value, int)
+            or not HYPERFRAMES_MIN_DIMENSION <= value <= HYPERFRAMES_MAX_DIMENSION
+        ):
+            raise ValueError("invalid HyperFrames dimensions")
+
+    email = payload.get("userEmail")
+    if (
+        not isinstance(email, str)
+        or len(email) > 320
+        or not EMAIL_RE.fullmatch(email)
+    ):
+        raise ValueError("invalid HyperFrames user")
+    if "dryRun" in payload and not isinstance(payload["dryRun"], bool):
+        raise ValueError("invalid HyperFrames dry-run flag")
+    return payload
+
+
+def _new_lambda_client():
+    import boto3
+
+    return boto3.client("lambda", region_name=AWS_REGION)
+
+
+def _invoke_hyperframes(payload: dict) -> dict:
+    """Invoke only the configured render Lambda with root-owned AWS authority."""
+    function_name = os.environ.get("HYPERFRAMES_RENDER_FUNCTION", "")
+    if not re.fullmatch(r"[A-Za-z0-9_-]{1,64}", function_name):
+        raise RuntimeError("HyperFrames render function is not configured")
+    response = _new_lambda_client().invoke(
+        FunctionName=function_name,
+        InvocationType="RequestResponse",
+        Payload=json.dumps(payload, separators=(",", ":")).encode("utf-8"),
+    )
+    stream = response.get("Payload")
+    if stream is None:
+        raise RuntimeError("HyperFrames returned no payload")
+    body = _read_bounded_aws_stream(stream, HYPERFRAMES_RESPONSE_MAX_BYTES)
+    if response.get("FunctionError"):
+        raise RuntimeError("HyperFrames Lambda reported a function error")
+    try:
+        result = json.loads(body)
+    except (TypeError, ValueError) as exc:
+        raise RuntimeError("HyperFrames returned invalid JSON") from exc
+    if not isinstance(result, dict):
+        raise RuntimeError("HyperFrames returned an invalid response")
+    return result
 
 
 def _authority_headers(method: str, route: str, body: bytes) -> dict:
@@ -1081,6 +1262,66 @@ async def handle_usage(_request: web.Request) -> web.Response:
     return web.json_response(payload)
 
 
+async def _read_fixed_aws_request(
+    request: web.Request, *, max_bytes: int
+) -> dict:
+    """Read a small JSON request for one of the fixed direct-AWS operations."""
+    if request.content_length is not None and request.content_length > max_bytes:
+        raise ValueError("AWS skill request exceeds the configured limit")
+    body = bytearray()
+    async for chunk in request.content.iter_chunked(64 * 1024):
+        body.extend(chunk)
+        if len(body) > max_bytes:
+            raise ValueError("AWS skill request exceeds the configured limit")
+    try:
+        payload = json.loads(bytes(body))
+    except (TypeError, ValueError) as exc:
+        raise ValueError("invalid AWS skill request") from exc
+    if not isinstance(payload, dict):
+        raise ValueError("invalid AWS skill request")
+    return payload
+
+
+async def handle_polly_synthesize(request: web.Request) -> web.Response:
+    """Run one bounded SynthesizeSpeech call without returning AWS credentials."""
+    if not _invocation_authority_is_available():
+        return web.json_response({"error": "Invocation authority is unavailable"}, status=503)
+    try:
+        payload = _validate_polly_payload(
+            await _read_fixed_aws_request(
+                request, max_bytes=POLLY_HTTP_REQUEST_MAX_BYTES
+            )
+        )
+    except ValueError:
+        return web.json_response({"error": "Invalid Polly request"}, status=400)
+    try:
+        audio = await asyncio.to_thread(_synthesize_polly, payload)
+    except Exception as exc:  # noqa: BLE001
+        log.warning(j("polly_synthesize_failed", error=type(exc).__name__))
+        return web.json_response({"error": "Polly synthesis failed"}, status=502)
+    return web.Response(body=audio, content_type="audio/mpeg")
+
+
+async def handle_hyperframes_invoke(request: web.Request) -> web.Response:
+    """Invoke only the configured HyperFrames function; never accept an ARN."""
+    if not _invocation_authority_is_available():
+        return web.json_response({"error": "Invocation authority is unavailable"}, status=503)
+    try:
+        payload = _validate_hyperframes_payload(
+            await _read_fixed_aws_request(
+                request, max_bytes=HYPERFRAMES_HTTP_REQUEST_MAX_BYTES
+            )
+        )
+    except ValueError:
+        return web.json_response({"error": "Invalid HyperFrames request"}, status=400)
+    try:
+        result = await asyncio.to_thread(_invoke_hyperframes, payload)
+    except Exception as exc:  # noqa: BLE001
+        log.warning(j("hyperframes_invoke_failed", error=type(exc).__name__))
+        return web.json_response({"error": "HyperFrames invocation failed"}, status=502)
+    return web.json_response(result)
+
+
 AGENT_BROKER_RESPONSE_MAX_BYTES = 64 * 1024 * 1024
 
 
@@ -1694,6 +1935,8 @@ def main() -> None:
         "/internal/finalization/{action}",
         handle_finalization_transition,
     )
+    app.router.add_post("/aws-skill/polly/synthesize", handle_polly_synthesize)
+    app.router.add_post("/aws-skill/hyperframes/invoke", handle_hyperframes_invoke)
     app.router.add_route("*", "/agent-broker/{route:.*}", handle_agent_broker)
     app.router.add_route("*", "/{path:.*}", handle_proxy)
     log.info(j("starting", host="127.0.0.1", port=18791, upstream=UPSTREAM))

--- a/infra/agent-image/skills/psd-hyperframes/SKILL.md
+++ b/infra/agent-image/skills/psd-hyperframes/SKILL.md
@@ -153,7 +153,8 @@ Notes:
 
 - **`bad_args`** — missing/invalid `--user`, no composition, bad `--duration`/`--fps`/dimensions,
   a valueless `--css-file`/`--js-file`, an `--audio-url` that isn't `https://` / `data:audio/`,
-  a combined html+css+js payload over the 4 MB cap, or a
+  a combined html+css+js payload over the 4 MiB cap, a JSON-escaped request over
+  Lambda's 6 MiB synchronous invocation cap, or a
   composition whose declared `data-duration` exceeds the 180 s cap or whose root
   `data-width`/`data-height` exceeds the 3840 px cap. Fix and retry.
 - **`invoke_failed`** — the fixed relay or render Lambda could not complete the invocation

--- a/infra/agent-image/skills/psd-hyperframes/SKILL.md
+++ b/infra/agent-image/skills/psd-hyperframes/SKILL.md
@@ -20,8 +20,9 @@ Lambda synchronously, and returns the MP4 URL — same delivery + reply contract
 `public-images/<email>/` prefix and returned as an unsigned, public-by-link HTTPS URL (the
 UUID in the path makes it unguessable — same model as Google Drive "anyone with the link").
 
-**Identity.** Requires `--user <caller-email>`. Pass the email verbatim from the
-`[caller: Name <email>]` header of the user turn — it scopes the S3 upload path.
+**Identity.** Do not pass an email or owner selector. The root relay resolves
+the owner from the installed signed invocation context through the trusted web
+tier and injects it after the model-facing request has been validated.
 
 ## Limits (v1)
 
@@ -90,7 +91,6 @@ its path with `--file`. Small scenes can be passed inline with `--html`.
 
 ```bash
 node /opt/psd-skills/psd-hyperframes/render.js \
-  --user <email> \
   --file scene.html \
   --duration 3 \
   [--css-file extra.css] [--js-file extra.js] \
@@ -151,7 +151,7 @@ Notes:
 
 ## Errors
 
-- **`bad_args`** — missing/invalid `--user`, no composition, bad `--duration`/`--fps`/dimensions,
+- **`bad_args`** — no composition, bad `--duration`/`--fps`/dimensions,
   a valueless `--css-file`/`--js-file`, an `--audio-url` that isn't `https://` / `data:audio/`,
   a combined html+css+js payload over the 4 MiB cap, a JSON-escaped request over
   Lambda's 6 MiB synchronous invocation cap, or a

--- a/infra/agent-image/skills/psd-hyperframes/SKILL.md
+++ b/infra/agent-image/skills/psd-hyperframes/SKILL.md
@@ -154,19 +154,19 @@ Notes:
 - **`bad_args`** — missing/invalid `--user`, no composition, bad `--duration`/`--fps`/dimensions,
   a valueless `--css-file`/`--js-file`, an `--audio-url` that isn't `https://` / `data:audio/`,
   a combined html+css+js payload over the 4 MB cap, or a
-  composition whose declared `data-duration` exceeds the 60 s cap or whose root
+  composition whose declared `data-duration` exceeds the 180 s cap or whose root
   `data-width`/`data-height` exceeds the 3840 px cap. Fix and retry.
-- **`misconfigured`** — the render function name (`HYPERFRAMES_RENDER_FUNCTION`) is not injected.
-  Ask an administrator to redeploy the agent platform.
-- **`invoke_failed`** — the render Lambda could not be invoked (permissions/throttling). Retry
-  once; if it persists, report it.
+- **`invoke_failed`** — the fixed relay or render Lambda could not complete the invocation
+  (runtime configuration, permissions, throttling, or transport failure). Retry once; if it
+  persists, report it.
 - **`render_failed`** — the render Lambda ran but produced no video (composition error, Chromium
   crash, or a scene too heavy for the timeout). Simplify the scene or lower `--fps`, then retry.
 
 ## Operational Notes
 
-- Renders synchronously via the AWS SDK (`lambda:InvokeFunction` on the render function ARN
-  only) using the AgentCore execution-role credentials — no API key.
+- Renders synchronously through a root-owned, fixed-operation loopback relay. The relay's
+  AWS SDK has `lambda:InvokeFunction` on the configured render function ARN only; the
+  model-facing subprocess receives neither reusable AgentCore credentials nor an API key.
 - The trusted render function publishes the MP4 under the signed caller's
   public artifact prefix. The model role has no S3 authority.
 - The returned URL is unsigned and does not expire — anyone with the link can fetch until the

--- a/infra/agent-image/skills/psd-hyperframes/package.json
+++ b/infra/agent-image/skills/psd-hyperframes/package.json
@@ -6,8 +6,5 @@
   "main": "render.js",
   "scripts": {
     "test": "bun test"
-  },
-  "dependencies": {
-    "@aws-sdk/client-lambda": "^3.658.0"
   }
 }

--- a/infra/agent-image/skills/psd-hyperframes/render.js
+++ b/infra/agent-image/skills/psd-hyperframes/render.js
@@ -27,6 +27,10 @@ const AWS_RELAY_HOST = '127.0.0.1';
 const AWS_RELAY_PORT = 18791;
 const AWS_RELAY_PATH = '/aws-skill/hyperframes/invoke';
 const MAX_RELAY_RESPONSE_BYTES = 8 * 1024 * 1024;
+const MAX_INVOKE_PAYLOAD_BYTES = 6 * 1024 * 1024;
+// The renderer is capped at 720s. Leave 60s for Lambda cleanup/upload and
+// another 60s under the interactive turn's 840s ceiling.
+const RELAY_TIMEOUT_MS = 780_000;
 // Keep in sync with the render Lambda (infra/hyperframes-render/handler.js) and
 // SKILL.md. Client-side checks fail fast; the Lambda re-validates authoritatively.
 const MAX_DURATION_SECONDS = 180;
@@ -38,9 +42,9 @@ const DEFAULT_WIDTH = 1920;
 const DEFAULT_HEIGHT = 1080;
 const MIN_DIMENSION = 16;
 const MAX_DIMENSION = 3840;
-// Combined html + css + js budget. Mirrors the render Lambda's MAX_HTML_BYTES
-// and keeps the JSON invoke payload under Lambda's 6 MB synchronous ceiling —
-// fail fast here with an actionable message rather than an opaque invoke error.
+// Combined html + css + js budget. Mirrors the render Lambda's MAX_HTML_BYTES.
+// A separate serialized-payload check below accounts for JSON escaping before
+// enforcing Lambda's exact 6 MiB synchronous invocation ceiling.
 const MAX_COMPOSITION_BYTES = 4 * 1024 * 1024;
 
 function fail(message, code = 'error') {
@@ -352,6 +356,13 @@ function buildPayload(args) {
   if (css) payload.css = css;
   if (js) payload.js = js;
   if (args.dry_run === true) payload.dryRun = true;
+  if (Buffer.byteLength(JSON.stringify(payload), 'utf8') > MAX_INVOKE_PAYLOAD_BYTES) {
+    fail(
+      'Serialized render request exceeds the 6 MiB Lambda invocation limit. ' +
+        'Reduce escaped control characters or split the composition.',
+      'bad_args'
+    );
+  }
   return payload;
 }
 
@@ -396,7 +407,7 @@ function requestRenderRelay(payload) {
         }
       });
     });
-    request.setTimeout(190_000, () => {
+    request.setTimeout(RELAY_TIMEOUT_MS, () => {
       request.destroy(new Error('HyperFrames relay timed out'));
     });
     request.on('error', reject);
@@ -465,4 +476,6 @@ module.exports = {
   requestRenderRelay,
   validateEmail,
   MAX_DURATION_SECONDS,
+  MAX_INVOKE_PAYLOAD_BYTES,
+  RELAY_TIMEOUT_MS,
 };

--- a/infra/agent-image/skills/psd-hyperframes/render.js
+++ b/infra/agent-image/skills/psd-hyperframes/render.js
@@ -10,7 +10,7 @@
  * psd-image-gen / psd-tts (issue #1175).
  *
  * Usage:
- *   node render.js --user <email> --file <composition.html> --duration <sec>
+ *   node render.js --file <composition.html> --duration <sec>
  *                  [--html "<inline composition>"]
  *                  [--css-file <path>] [--js-file <path>]
  *                  [--fps 30] [--width 1920] [--height 1080] [--dry-run]
@@ -28,6 +28,11 @@ const AWS_RELAY_PORT = 18791;
 const AWS_RELAY_PATH = '/aws-skill/hyperframes/invoke';
 const MAX_RELAY_RESPONSE_BYTES = 8 * 1024 * 1024;
 const MAX_INVOKE_PAYLOAD_BYTES = 6 * 1024 * 1024;
+// The root relay injects the web-verified owner after receiving this body.
+// Reserve more than the maximum serialized ownerEmail field can consume.
+const OWNER_BINDING_RESERVE_BYTES = 512;
+const MAX_RELAY_PAYLOAD_BYTES =
+  MAX_INVOKE_PAYLOAD_BYTES - OWNER_BINDING_RESERVE_BYTES;
 // The renderer is capped at 720s. Leave 60s for Lambda cleanup/upload and
 // another 60s under the interactive turn's 840s ceiling.
 const RELAY_TIMEOUT_MS = 780_000;
@@ -58,7 +63,7 @@ function emit(obj) {
   process.stdout.write(JSON.stringify(obj, null, 2) + '\n');
 }
 
-// parseArgs/fail/emit/validateEmail are intentionally duplicated from
+// parseArgs/fail/emit are intentionally duplicated from
 // psd-image-gen/generate.js — skills are standalone packages with no
 // cross-skill require(). Keep behavior in sync with that file.
 function parseArgs(argv) {
@@ -82,21 +87,6 @@ function parseArgs(argv) {
     }
   }
   return args;
-}
-
-function validateEmail(email) {
-  // Linear, non-backtracking validation. A regex with overlapping `[^\s@]+`
-  // groups around the dot trips CodeQL's js/polynomial-redos (ReDoS). The email
-  // is interpolated into the S3 key by the render Lambda, so a `/` (or any
-  // whitespace) is rejected explicitly.
-  if (typeof email !== 'string' || email.length === 0 || email.length > 320) return false;
-  if (email.includes('/') || /\s/.test(email)) return false;
-  const at = email.indexOf('@');
-  if (at <= 0 || email.includes('@', at + 1)) return false;
-  const domain = email.slice(at + 1);
-  const dot = domain.lastIndexOf('.');
-  if (dot <= 0 || dot === domain.length - 1) return false;
-  return true;
 }
 
 function readFileOrFail(filePath, flag) {
@@ -336,9 +326,6 @@ function resolveDimensions(args) {
  * Every invalid input fails fast with an actionable message.
  */
 function buildPayload(args) {
-  if (!validateEmail(args.user)) {
-    fail('--user is required and must be a valid email', 'bad_args');
-  }
   let html = resolveCompositionHtml(args);
   const css = resolveOptionalSource(args, 'css', 'css_file');
   const js = resolveOptionalSource(args, 'js', 'js_file');
@@ -352,13 +339,16 @@ function buildPayload(args) {
   }
   if (audioUrl) html = injectAudioElement(html, audioUrl, durationSeconds);
 
-  const payload = { html, durationSeconds, fps, width, height, userEmail: args.user };
+  // Identity is deliberately absent. The root relay resolves the owner from
+  // the installed signed invocation context and injects userEmail only after
+  // the trusted web tier verifies that context.
+  const payload = { html, durationSeconds, fps, width, height };
   if (css) payload.css = css;
   if (js) payload.js = js;
   if (args.dry_run === true) payload.dryRun = true;
-  if (Buffer.byteLength(JSON.stringify(payload), 'utf8') > MAX_INVOKE_PAYLOAD_BYTES) {
+  if (Buffer.byteLength(JSON.stringify(payload), 'utf8') > MAX_RELAY_PAYLOAD_BYTES) {
     fail(
-      'Serialized render request exceeds the 6 MiB Lambda invocation limit. ' +
+      'Serialized render request exceeds the 6 MiB Lambda invocation limit after reserving trusted owner metadata. ' +
         'Reduce escaped control characters or split the composition.',
       'bad_args'
     );
@@ -436,7 +426,7 @@ async function main(argv = process.argv, deps = {}) {
   const args = parseArgs(argv);
   if (args.help) {
     process.stdout.write(
-      'Usage: render.js --user <email> --file <composition.html> --duration <sec> ' +
+      'Usage: render.js --file <composition.html> --duration <sec> ' +
         '[--html "<inline>"] [--css-file <path>] [--js-file <path>] ' +
         '[--audio-url <https-mp3-url>] ' +
         '[--fps 30] [--width 1920] [--height 1080] [--dry-run]\n',
@@ -474,8 +464,8 @@ module.exports = {
   injectAudioElement,
   invokeRender,
   requestRenderRelay,
-  validateEmail,
   MAX_DURATION_SECONDS,
   MAX_INVOKE_PAYLOAD_BYTES,
+  MAX_RELAY_PAYLOAD_BYTES,
   RELAY_TIMEOUT_MS,
 };

--- a/infra/agent-image/skills/psd-hyperframes/render.js
+++ b/infra/agent-image/skills/psd-hyperframes/render.js
@@ -22,12 +22,11 @@
 'use strict';
 const { validatedFs } = require("../../../validated-fs.cjs");
 
-
-
-
-const { LambdaClient, InvokeCommand } = require('@aws-sdk/client-lambda');
-
-const REGION = process.env.AWS_REGION || 'us-east-1';
+const http = require('node:http');
+const AWS_RELAY_HOST = '127.0.0.1';
+const AWS_RELAY_PORT = 18791;
+const AWS_RELAY_PATH = '/aws-skill/hyperframes/invoke';
+const MAX_RELAY_RESPONSE_BYTES = 8 * 1024 * 1024;
 // Keep in sync with the render Lambda (infra/hyperframes-render/handler.js) and
 // SKILL.md. Client-side checks fail fast; the Lambda re-validates authoritatively.
 const MAX_DURATION_SECONDS = 180;
@@ -357,43 +356,61 @@ function buildPayload(args) {
 }
 
 /**
- * Invoke the render Lambda synchronously and return its parsed result.
- * `deps.client` is a test seam; production leaves it unset.
+ * Ask the root-owned relay to invoke the configured render Lambda. OpenClaw
+ * intentionally strips AWS credential variables from model-launched exec
+ * subprocesses, so this process never receives or returns reusable credentials.
  */
+function requestRenderRelay(payload) {
+  const body = Buffer.from(JSON.stringify(payload), 'utf8');
+  return new Promise((resolve, reject) => {
+    const request = http.request({
+      host: AWS_RELAY_HOST,
+      port: AWS_RELAY_PORT,
+      path: AWS_RELAY_PATH,
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Content-Length': String(body.length),
+      },
+    }, (response) => {
+      const chunks = [];
+      let bytes = 0;
+      response.on('data', (chunk) => {
+        bytes += chunk.length;
+        if (bytes > MAX_RELAY_RESPONSE_BYTES) {
+          request.destroy(new Error('HyperFrames relay response exceeded the configured limit'));
+          return;
+        }
+        chunks.push(chunk);
+      });
+      response.on('end', () => {
+        const raw = Buffer.concat(chunks).toString('utf8');
+        if (response.statusCode !== 200) {
+          reject(new Error(`HyperFrames relay returned HTTP ${response.statusCode || 502}`));
+          return;
+        }
+        try {
+          resolve(JSON.parse(raw));
+        } catch {
+          reject(new Error('HyperFrames relay returned invalid JSON'));
+        }
+      });
+    });
+    request.setTimeout(190_000, () => {
+      request.destroy(new Error('HyperFrames relay timed out'));
+    });
+    request.on('error', reject);
+    request.end(body);
+  });
+}
+
 async function invokeRender(payload, deps = {}) {
-  const functionName = process.env.HYPERFRAMES_RENDER_FUNCTION;
-  if (!functionName) {
-    fail(
-      'HYPERFRAMES_RENDER_FUNCTION env var not set — the render Lambda name is injected by the agent runtime. Ask an administrator to redeploy the agent platform.',
-      'misconfigured',
-    );
-  }
-
-  const client = deps.client || new LambdaClient({ region: REGION });
-  let resp;
-  try {
-    resp = await client.send(new InvokeCommand({
-      FunctionName: functionName,
-      InvocationType: 'RequestResponse',
-      Payload: Buffer.from(JSON.stringify(payload), 'utf8'),
-    }));
-  } catch (err) {
-    fail(`Render Lambda invocation failed: ${err instanceof Error ? err.message : String(err)}`, 'invoke_failed');
-  }
-
-  const raw = resp.Payload ? Buffer.from(resp.Payload).toString('utf8') : '';
-
-  // Unhandled Lambda exception (the handler catches its own errors, so this is
-  // an infra-level failure — OOM, timeout kill, cold-start crash).
-  if (resp.FunctionError) {
-    fail(`Render Lambda failed (${resp.FunctionError}): ${raw.slice(0, 600)}`, 'render_failed');
-  }
-
+  const relay = deps.relay || requestRenderRelay;
   let result;
   try {
-    result = JSON.parse(raw);
-  } catch {
-    fail(`Render Lambda returned non-JSON output: ${raw.slice(0, 300)}`, 'render_failed');
+    result = await relay(payload);
+  } catch (err) {
+    fail(`Render Lambda invocation failed: ${err instanceof Error ? err.message : String(err)}`, 'invoke_failed');
   }
 
   if (!result || result.status !== 'ok') {
@@ -445,6 +462,7 @@ module.exports = {
   findCompositionRootOpenTagEnd,
   injectAudioElement,
   invokeRender,
+  requestRenderRelay,
   validateEmail,
   MAX_DURATION_SECONDS,
 };

--- a/infra/agent-image/skills/psd-hyperframes/render.js
+++ b/infra/agent-image/skills/psd-hyperframes/render.js
@@ -33,9 +33,19 @@ const MAX_INVOKE_PAYLOAD_BYTES = 6 * 1024 * 1024;
 const OWNER_BINDING_RESERVE_BYTES = 512;
 const MAX_RELAY_PAYLOAD_BYTES =
   MAX_INVOKE_PAYLOAD_BYTES - OWNER_BINDING_RESERVE_BYTES;
-// The renderer is capped at 720s. Leave 60s for Lambda cleanup/upload and
-// another 60s under the interactive turn's 840s ceiling.
-const RELAY_TIMEOUT_MS = 780_000;
+// The renderer is capped at 720s. The root relay may then spend up to 60s on
+// Lambda cleanup/upload/response, but first it must resolve the signed owner
+// and connect to Lambda. Cover every sequential phase plus a transport margin;
+// 825s remains below the interactive turn's 840s ceiling.
+const IDENTITY_TIMEOUT_MS = 30_000;
+const LAMBDA_CONNECT_TIMEOUT_MS = 10_000;
+const LAMBDA_READ_TIMEOUT_MS = 780_000;
+const RELAY_TRANSPORT_MARGIN_MS = 5_000;
+const RELAY_TIMEOUT_MS =
+  IDENTITY_TIMEOUT_MS +
+  LAMBDA_CONNECT_TIMEOUT_MS +
+  LAMBDA_READ_TIMEOUT_MS +
+  RELAY_TRANSPORT_MARGIN_MS;
 // Keep in sync with the render Lambda (infra/hyperframes-render/handler.js) and
 // SKILL.md. Client-side checks fail fast; the Lambda re-validates authoritatively.
 const MAX_DURATION_SECONDS = 180;
@@ -467,5 +477,9 @@ module.exports = {
   MAX_DURATION_SECONDS,
   MAX_INVOKE_PAYLOAD_BYTES,
   MAX_RELAY_PAYLOAD_BYTES,
+  IDENTITY_TIMEOUT_MS,
+  LAMBDA_CONNECT_TIMEOUT_MS,
+  LAMBDA_READ_TIMEOUT_MS,
+  RELAY_TRANSPORT_MARGIN_MS,
   RELAY_TIMEOUT_MS,
 };

--- a/infra/agent-image/skills/psd-hyperframes/render.test.js
+++ b/infra/agent-image/skills/psd-hyperframes/render.test.js
@@ -22,9 +22,9 @@ const {
   findCompositionRootOpenTagEnd,
   injectAudioElement,
   invokeRender,
-  validateEmail,
   main,
   MAX_INVOKE_PAYLOAD_BYTES,
+  MAX_RELAY_PAYLOAD_BYTES,
   RELAY_TIMEOUT_MS,
 } = require('./render');
 
@@ -70,13 +70,7 @@ function argv(...rest) {
   return ['node', 'render.js', ...rest];
 }
 
-// ── validateEmail / parseArgs ────────────────────────────────────────────────
-
-test('validateEmail accepts real emails, rejects junk and path separators', () => {
-  expect(validateEmail('person@psd401.net')).toBe(true);
-  expect(validateEmail('nope')).toBe(false);
-  expect(validateEmail('a/b@psd401.net')).toBe(false);
-});
+// ── parseArgs ────────────────────────────────────────────────────────────────
 
 test('parseArgs maps --dashed-flags to underscore keys and boolean flags', () => {
   const args = parseArgs(argv('--user', 'x@y.z', '--css-file', '/tmp/a.css', '--dry-run'));
@@ -89,7 +83,9 @@ test('parseArgs maps --dashed-flags to underscore keys and boolean flags', () =>
 
 test('buildPayload assembles a valid payload with defaults', () => {
   const p = buildPayload(parseArgs(argv('--user', 'p@psd401.net', '--html', HTML, '--duration', '3')));
-  expect(p.userEmail).toBe('p@psd401.net');
+  // A legacy/model-supplied --user selector is ignored. The root relay injects
+  // only the owner resolved from the signed invocation context.
+  expect(p.userEmail).toBeUndefined();
   expect(p.html).toBe(HTML);
   expect(p.durationSeconds).toBe(3);
   expect(p.fps).toBe(30);
@@ -98,44 +94,39 @@ test('buildPayload assembles a valid payload with defaults', () => {
   expect(p.css).toBeUndefined();
 });
 
-test('buildPayload rejects a missing user', () => {
-  expect(() => buildPayload(parseArgs(argv('--html', HTML, '--duration', '3')))).toThrow(ExitError);
-  expect(lastJson().error).toBe('bad_args');
-});
-
 test('buildPayload rejects a missing composition', () => {
-  expect(() => buildPayload(parseArgs(argv('--user', 'p@psd401.net', '--duration', '3')))).toThrow(ExitError);
+  expect(() => buildPayload(parseArgs(argv('--duration', '3')))).toThrow(ExitError);
   expect(lastJson().error).toBe('bad_args');
 });
 
 test('buildPayload rejects a missing / non-positive / over-cap duration', () => {
-  const base = ['--user', 'p@psd401.net', '--html', HTML];
+  const base = ['--html', HTML];
   expect(() => buildPayload(parseArgs(argv(...base)))).toThrow(ExitError);
   expect(() => buildPayload(parseArgs(argv(...base, '--duration', '0')))).toThrow(ExitError);
   expect(() => buildPayload(parseArgs(argv(...base, '--duration', '181')))).toThrow(ExitError); // > 180s (3 min) cap
 });
 
 test('buildPayload allows up to the 3-minute cap at a budget-safe fps', () => {
-  const base = ['--user', 'p@psd401.net', '--html', HTML];
+  const base = ['--html', HTML];
   // 180s at 20fps = 3600 frames = exactly the render budget.
   expect(() => buildPayload(parseArgs(argv(...base, '--duration', '180', '--fps', '20')))).not.toThrow();
 });
 
 test('buildPayload rejects an over-budget frame count (fps × duration > 3600)', () => {
-  const base = ['--user', 'p@psd401.net', '--html', HTML];
+  const base = ['--html', HTML];
   // 120s at 60fps = 7200 frames — over the budget even though each is in range.
   expect(() => buildPayload(parseArgs(argv(...base, '--duration', '120', '--fps', '60')))).toThrow(ExitError);
   expect(lastJson().error).toBe('bad_args');
 });
 
 test('buildPayload rejects fps and dimensions out of range', () => {
-  const base = ['--user', 'p@psd401.net', '--html', HTML, '--duration', '3'];
+  const base = ['--html', HTML, '--duration', '3'];
   expect(() => buildPayload(parseArgs(argv(...base, '--fps', '61')))).toThrow(ExitError);
   expect(() => buildPayload(parseArgs(argv(...base, '--width', '9')))).toThrow(ExitError);
 });
 
 test('buildPayload fails on a valueless --css-file / --js-file instead of silently dropping it', () => {
-  const base = ['--user', 'p@psd401.net', '--html', HTML, '--duration', '3'];
+  const base = ['--html', HTML, '--duration', '3'];
   // --css-file as the last token parses to boolean true — must be a hard error.
   expect(() => buildPayload(parseArgs(argv(...base, '--css-file')))).toThrow(ExitError);
   expect(lastJson().error).toBe('bad_args');
@@ -145,7 +136,7 @@ test('buildPayload fails on a valueless --css-file / --js-file instead of silent
 });
 
 test('buildPayload rejects a --dry-run given a value', () => {
-  const base = ['--user', 'p@psd401.net', '--html', HTML, '--duration', '3'];
+  const base = ['--html', HTML, '--duration', '3'];
   expect(() => buildPayload(parseArgs(argv(...base, '--dry-run', 'true')))).toThrow(ExitError);
   expect(lastJson().error).toBe('bad_args');
 });
@@ -156,7 +147,7 @@ test('buildPayload caps the combined html+css+js size', () => {
   validatedFs.writeFileSync(cssPath, 'a'.repeat(5 * 1024 * 1024));
   try {
     expect(() => buildPayload(parseArgs(argv(
-      '--user', 'p@psd401.net', '--html', HTML, '--duration', '3', '--css-file', cssPath,
+      '--html', HTML, '--duration', '3', '--css-file', cssPath,
     )))).toThrow(ExitError);
     expect(lastJson().error).toBe('bad_args');
   } finally {
@@ -170,11 +161,11 @@ test('buildPayload enforces the serialized Lambda limit after JSON escaping', ()
   // the serialized invoke body is intentionally just over Lambda's 6 MiB cap.
   const html =
     '<div data-composition-id="escaped">' +
-    '\u0000'.repeat(Math.floor(MAX_INVOKE_PAYLOAD_BYTES / 6) + 1) +
+    '\u0000'.repeat(Math.floor(MAX_RELAY_PAYLOAD_BYTES / 6) + 1) +
     '</div>';
   expect(Buffer.byteLength(html, 'utf8')).toBeLessThan(4 * 1024 * 1024);
   expect(() => buildPayload(parseArgs(argv(
-    '--user', 'p@psd401.net', '--html', html, '--duration', '3',
+    '--html', html, '--duration', '3',
   )))).toThrow(ExitError);
   expect(lastJson().error).toBe('bad_args');
   expect(lastJson().message).toContain('6 MiB Lambda invocation limit');
@@ -182,6 +173,7 @@ test('buildPayload enforces the serialized Lambda limit after JSON escaping', ()
 
 test('relay timeout leaves cleanup headroom inside the interactive turn budget', () => {
   expect(RELAY_TIMEOUT_MS).toBe(780_000);
+  expect(MAX_RELAY_PAYLOAD_BYTES).toBe(MAX_INVOKE_PAYLOAD_BYTES - 512);
 });
 
 test('buildPayload reads css/js from files and carries dryRun', () => {
@@ -190,7 +182,7 @@ test('buildPayload reads css/js from files and carries dryRun', () => {
   validatedFs.writeFileSync(cssPath, 'body{color:red}');
   try {
     const p = buildPayload(parseArgs(argv(
-      '--user', 'p@psd401.net', '--html', HTML, '--duration', '3',
+      '--html', HTML, '--duration', '3',
       '--css-file', cssPath, '--dry-run',
     )));
     expect(p.css).toBe('body{color:red}');
@@ -203,7 +195,7 @@ test('buildPayload reads css/js from files and carries dryRun', () => {
 test('buildPayload injects an <audio> track from --audio-url into the composition root', () => {
   const url = 'https://psd-agents-dev.s3.us-east-1.amazonaws.com/public-images/p@psd401.net/n.mp3';
   const p = buildPayload(parseArgs(argv(
-    '--user', 'p@psd401.net', '--html', HTML, '--duration', '3', '--audio-url', url,
+    '--html', HTML, '--duration', '3', '--audio-url', url,
   )));
   expect(p.html).toContain(`<audio src="${url}"`);
   expect(p.html).toContain('data-duration="3"');
@@ -231,7 +223,7 @@ test('composition-root lookup is linear and ignores attribute-like quoted text',
 });
 
 test('buildPayload rejects an unsafe / non-https --audio-url', () => {
-  const base = ['--user', 'p@psd401.net', '--html', HTML, '--duration', '3'];
+  const base = ['--html', HTML, '--duration', '3'];
   expect(() => buildPayload(parseArgs(argv(...base, '--audio-url', 'http://insecure.example/n.mp3')))).toThrow(ExitError);
   expect(lastJson().error).toBe('bad_args');
   stdout = ''; // reset so lastJson() reads only the second failure
@@ -321,7 +313,7 @@ test('invokeRender needs no AWS credential variables in the exec subprocess', as
 
 test('main emits the bare result JSON with the url on relay success', async () => {
   const relay = fakeRelay(() => okResult());
-  await main(argv('--user', 'p@psd401.net', '--html', HTML, '--duration', '3'), { relay });
+  await main(argv('--html', HTML, '--duration', '3'), { relay });
   const out = lastJson();
   expect(out.url).toContain('/public-images/');
   expect(out.s3Key).toBe('public-images/p@psd401.net/uuid.mp4');

--- a/infra/agent-image/skills/psd-hyperframes/render.test.js
+++ b/infra/agent-image/skills/psd-hyperframes/render.test.js
@@ -5,8 +5,8 @@ const { validatedFs } = require("../../../validated-fs.cjs");
 /**
  * Unit tests for psd-hyperframes/render.js (#1175).
  *
- * Covers CLI arg parsing + payload validation and the Lambda-invocation path
- * with a mocked LambdaClient (injected via `deps.client`) so no AWS is touched.
+ * Covers CLI arg parsing + payload validation and the root-owned Lambda-relay
+ * path with an injected relay so no AWS is touched.
  *
  * Run: cd infra/agent-image/skills/psd-hyperframes && bun test
  */
@@ -51,14 +51,12 @@ beforeEach(() => {
   process.exit = (code) => { throw new ExitError(code); };
   process.stdout.write = (chunk) => { stdout += chunk; return true; };
   process.stderr.write = () => true;
-  process.env.HYPERFRAMES_RENDER_FUNCTION = 'psd-hyperframes-render-dev';
 });
 
 afterEach(() => {
   process.exit = originalExit;
   process.stdout.write = originalStdout;
   process.stderr.write = originalStderr;
-  delete process.env.HYPERFRAMES_RENDER_FUNCTION;
 });
 
 function lastJson() {
@@ -219,21 +217,20 @@ test('buildPayload rejects an unsafe / non-https --audio-url', () => {
   expect(lastJson().error).toBe('bad_args');
 });
 
-// ── invokeRender (mocked LambdaClient) ───────────────────────────────────────
+// ── invokeRender (mocked root relay) ─────────────────────────────────────────
 
-function fakeClient(responder) {
-  const sent = [];
-  return {
-    sent,
-    send: async (command) => {
-      sent.push(command);
-      return responder(command);
-    },
+function fakeRelay(responder) {
+  const calls = [];
+  const relay = async (payload) => {
+    calls.push(payload);
+    return responder(payload);
   };
+  relay.calls = calls;
+  return relay;
 }
 
-function okPayload(extra = {}) {
-  return Buffer.from(JSON.stringify({
+function okResult(extra = {}) {
+  return {
     status: 'ok',
     url: 'https://psd-agents-dev.s3.us-east-1.amazonaws.com/public-images/p@psd401.net/uuid.mp4',
     s3Key: 'public-images/p@psd401.net/uuid.mp4',
@@ -244,48 +241,65 @@ function okPayload(extra = {}) {
     height: 1080,
     sharing: 'public-by-link',
     ...extra,
-  }));
+  };
 }
 
-test('invokeRender sends a RequestResponse invoke to the configured function and returns the parsed result', async () => {
-  const client = fakeClient(() => ({ Payload: okPayload() }));
-  const result = await invokeRender({ html: HTML, durationSeconds: 3 }, { client });
+test('invokeRender sends the validated payload through the fixed-operation relay', async () => {
+  const relay = fakeRelay(() => okResult());
+  const payload = { html: HTML, durationSeconds: 3 };
+  const result = await invokeRender(payload, { relay });
   expect(result.status).toBe('ok');
   expect(result.s3Key).toBe('public-images/p@psd401.net/uuid.mp4');
-  expect(client.sent).toHaveLength(1);
-  expect(client.sent[0].input.FunctionName).toBe('psd-hyperframes-render-dev');
-  expect(client.sent[0].input.InvocationType).toBe('RequestResponse');
-  const decoded = JSON.parse(Buffer.from(client.sent[0].input.Payload).toString('utf8'));
-  expect(decoded.html).toBe(HTML);
+  expect(relay.calls).toEqual([payload]);
 });
 
 test('invokeRender surfaces a structured render error (status:error) as an exit', async () => {
-  const client = fakeClient(() => ({
-    Payload: Buffer.from(JSON.stringify({ status: 'error', error: 'render_failed', message: 'chromium crashed' })),
+  const relay = fakeRelay(() => ({
+    status: 'error',
+    error: 'render_failed',
+    message: 'chromium crashed',
   }));
-  await expect(invokeRender({ html: HTML }, { client })).rejects.toThrow(ExitError);
+  await expect(invokeRender({ html: HTML }, { relay })).rejects.toThrow(ExitError);
   expect(lastJson().error).toBe('render_failed');
   expect(lastJson().message).toContain('chromium crashed');
 });
 
-test('invokeRender surfaces a Lambda FunctionError as render_failed', async () => {
-  const client = fakeClient(() => ({ FunctionError: 'Unhandled', Payload: Buffer.from('{"errorMessage":"Task timed out"}') }));
-  await expect(invokeRender({ html: HTML }, { client })).rejects.toThrow(ExitError);
-  expect(lastJson().error).toBe('render_failed');
+test('invokeRender surfaces a relay or Lambda transport failure without credentials', async () => {
+  const relay = fakeRelay(() => {
+    throw new Error('HyperFrames relay returned HTTP 502');
+  });
+  await expect(invokeRender({ html: HTML }, { relay })).rejects.toThrow(ExitError);
+  expect(lastJson().error).toBe('invoke_failed');
+  expect(lastJson().message).toContain('HTTP 502');
 });
 
-test('invokeRender fails misconfigured when the function name env var is unset', async () => {
-  delete process.env.HYPERFRAMES_RENDER_FUNCTION;
-  const client = fakeClient(() => ({ Payload: okPayload() }));
-  await expect(invokeRender({ html: HTML }, { client })).rejects.toThrow(ExitError);
-  expect(lastJson().error).toBe('misconfigured');
+test('invokeRender needs no AWS credential variables in the exec subprocess', async () => {
+  const credentialKeys = [
+    'AWS_ACCESS_KEY_ID',
+    'AWS_SECRET_ACCESS_KEY',
+    'AWS_SESSION_TOKEN',
+    'AWS_CONTAINER_CREDENTIALS_FULL_URI',
+    'AWS_CONTAINER_CREDENTIALS_RELATIVE_URI',
+  ];
+  const saved = Object.fromEntries(credentialKeys.map((key) => [key, process.env[key]]));
+  for (const key of credentialKeys) delete process.env[key];
+  try {
+    const relay = fakeRelay(() => okResult());
+    const result = await invokeRender({ html: HTML, durationSeconds: 3 }, { relay });
+    expect(result.status).toBe('ok');
+  } finally {
+    for (const [key, value] of Object.entries(saved)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  }
 });
 
-// ── main end-to-end (mocked client) ──────────────────────────────────────────
+// ── main end-to-end (mocked relay) ───────────────────────────────────────────
 
-test('main emits the bare result JSON with the url on success', async () => {
-  const client = fakeClient(() => ({ Payload: okPayload() }));
-  await main(argv('--user', 'p@psd401.net', '--html', HTML, '--duration', '3'), { client });
+test('main emits the bare result JSON with the url on relay success', async () => {
+  const relay = fakeRelay(() => okResult());
+  await main(argv('--user', 'p@psd401.net', '--html', HTML, '--duration', '3'), { relay });
   const out = lastJson();
   expect(out.url).toContain('/public-images/');
   expect(out.s3Key).toBe('public-images/p@psd401.net/uuid.mp4');

--- a/infra/agent-image/skills/psd-hyperframes/render.test.js
+++ b/infra/agent-image/skills/psd-hyperframes/render.test.js
@@ -25,6 +25,10 @@ const {
   main,
   MAX_INVOKE_PAYLOAD_BYTES,
   MAX_RELAY_PAYLOAD_BYTES,
+  IDENTITY_TIMEOUT_MS,
+  LAMBDA_CONNECT_TIMEOUT_MS,
+  LAMBDA_READ_TIMEOUT_MS,
+  RELAY_TRANSPORT_MARGIN_MS,
   RELAY_TIMEOUT_MS,
 } = require('./render');
 
@@ -171,8 +175,15 @@ test('buildPayload enforces the serialized Lambda limit after JSON escaping', ()
   expect(lastJson().message).toContain('6 MiB Lambda invocation limit');
 });
 
-test('relay timeout leaves cleanup headroom inside the interactive turn budget', () => {
-  expect(RELAY_TIMEOUT_MS).toBe(780_000);
+test('relay timeout covers identity, Lambda connect/read, and transport budgets', () => {
+  expect(RELAY_TIMEOUT_MS).toBe(
+    IDENTITY_TIMEOUT_MS +
+      LAMBDA_CONNECT_TIMEOUT_MS +
+      LAMBDA_READ_TIMEOUT_MS +
+      RELAY_TRANSPORT_MARGIN_MS,
+  );
+  expect(RELAY_TIMEOUT_MS).toBe(825_000);
+  expect(RELAY_TIMEOUT_MS).toBeLessThan(840_000);
   expect(MAX_RELAY_PAYLOAD_BYTES).toBe(MAX_INVOKE_PAYLOAD_BYTES - 512);
 });
 

--- a/infra/agent-image/skills/psd-hyperframes/render.test.js
+++ b/infra/agent-image/skills/psd-hyperframes/render.test.js
@@ -24,6 +24,8 @@ const {
   invokeRender,
   validateEmail,
   main,
+  MAX_INVOKE_PAYLOAD_BYTES,
+  RELAY_TIMEOUT_MS,
 } = require('./render');
 
 const HTML =
@@ -160,6 +162,26 @@ test('buildPayload caps the combined html+css+js size', () => {
   } finally {
     fs.rmSync(dir, { recursive: true, force: true });
   }
+});
+
+test('buildPayload enforces the serialized Lambda limit after JSON escaping', () => {
+  // NUL is one UTF-8 byte in the composition budget but JSON encodes it as the
+  // six-byte sequence "\\u0000". The raw input is valid and well below 4 MiB;
+  // the serialized invoke body is intentionally just over Lambda's 6 MiB cap.
+  const html =
+    '<div data-composition-id="escaped">' +
+    '\u0000'.repeat(Math.floor(MAX_INVOKE_PAYLOAD_BYTES / 6) + 1) +
+    '</div>';
+  expect(Buffer.byteLength(html, 'utf8')).toBeLessThan(4 * 1024 * 1024);
+  expect(() => buildPayload(parseArgs(argv(
+    '--user', 'p@psd401.net', '--html', html, '--duration', '3',
+  )))).toThrow(ExitError);
+  expect(lastJson().error).toBe('bad_args');
+  expect(lastJson().message).toContain('6 MiB Lambda invocation limit');
+});
+
+test('relay timeout leaves cleanup headroom inside the interactive turn budget', () => {
+  expect(RELAY_TIMEOUT_MS).toBe(780_000);
 });
 
 test('buildPayload reads css/js from files and carries dryRun', () => {

--- a/infra/agent-image/skills/psd-tts/SKILL.md
+++ b/infra/agent-image/skills/psd-tts/SKILL.md
@@ -15,8 +15,9 @@ user can play in any browser (Google Chat renders it as a link). Same delivery m
 **Identity.** Requires `--user <caller-email>`. Pass the email verbatim from the
 `[caller: Name <email>]` header of the user turn (it scopes the S3 upload path).
 
-Polly is a standard AWS service (not Bedrock) authenticated by the execution role — no
-API key, no per-character prompt to the model. Long text is split at sentence boundaries
+Polly is a standard AWS service (not Bedrock). A root-owned, fixed-operation loopback
+relay authenticates with the AgentCore execution role — the model-facing subprocess never
+receives reusable AWS credentials or an API key. Long text is split at sentence boundaries
 and the MP3 chunks are concatenated automatically.
 
 ## Usage

--- a/infra/agent-image/skills/psd-tts/scripts/synthesize.py
+++ b/infra/agent-image/skills/psd-tts/scripts/synthesize.py
@@ -6,9 +6,11 @@ Convert text to a shareable MP3 with Amazon Polly, upload it to the workspace S3
 bucket under the public `public-images/` prefix, and return an unsigned HTTPS
 URL (same delivery model as psd-image-gen / psd-html-artifact).
 
-Polly authenticates with the AgentCore execution role's SigV4 credential
-chain. The resulting MP3 is uploaded through the owner-bound workspace broker;
-the model role has no S3 or Secrets Manager access.
+The root-owned loopback relay calls Polly with the AgentCore execution role's
+SigV4 credential chain. OpenClaw intentionally strips credential variables from
+model-launched exec subprocesses, so this script never receives or returns
+reusable AWS credentials. The resulting MP3 is uploaded through the owner-bound
+workspace broker; the model role has no S3 or Secrets Manager access.
 
 Usage (text from --text, --file, or stdin):
     python3 synthesize.py --user name@psd401.net --text "Hello there."
@@ -25,8 +27,8 @@ import json
 import os
 import re
 import sys
-import uuid
-from urllib.parse import quote
+import urllib.error
+import urllib.request
 
 # SynthesizeSpeech accepts up to 6,000 total / 3,000 billable chars per call.
 # Chunk well under the billable cap at sentence boundaries.
@@ -36,6 +38,8 @@ MAX_TEXT_CHARS = 200_000
 VALID_ENGINES = {"generative", "neural", "long-form", "standard"}
 DEFAULT_ENGINE = "generative"
 DEFAULT_VOICE = "Ruth"
+POLLY_RELAY_URL = "http://127.0.0.1:18791/aws-skill/polly/synthesize"
+MAX_RELAY_AUDIO_BYTES = 16 * 1024 * 1024
 
 _EMAIL_RE = re.compile(r"^[^\s@]+@[^\s@]+\.[^\s@]+$")
 
@@ -78,26 +82,45 @@ def chunk_text(text, max_chars=CHUNK_CHARS):
     return [c for c in chunks if c.strip()]
 
 
-def synthesize(text, voice, engine, region):
-    import boto3
+def _read_bounded_response(response, max_bytes):
+    body = bytearray()
+    while True:
+        chunk = response.read(min(64 * 1024, max_bytes - len(body) + 1))
+        if not chunk:
+            break
+        body.extend(chunk)
+        if len(body) > max_bytes:
+            raise RuntimeError("Polly relay response exceeded the configured limit")
+    return bytes(body)
 
-    polly = boto3.client("polly", region_name=region)
+
+def _synthesize_chunk(text, voice, engine):
+    request = urllib.request.Request(
+        POLLY_RELAY_URL,
+        data=json.dumps({
+            "text": text,
+            "voice": voice,
+            "engine": engine,
+        }).encode("utf-8"),
+        method="POST",
+        headers={"Content-Type": "application/json"},
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=120) as response:
+            if response.headers.get_content_type() != "audio/mpeg":
+                raise RuntimeError("Polly relay returned an invalid content type")
+            return _read_bounded_response(response, MAX_RELAY_AUDIO_BYTES)
+    except urllib.error.HTTPError as exc:
+        exc.read(1024)
+        raise RuntimeError(f"Polly relay returned HTTP {exc.code}") from exc
+
+
+def synthesize(text, voice, engine, synthesize_chunk=None):
+    relay = synthesize_chunk or _synthesize_chunk
     audio = bytearray()
     chunks = chunk_text(text)
     for chunk in chunks:
-        # No explicit SampleRate: let Polly pick the engine default (24 kHz for
-        # generative/neural/long-form, 22.05 kHz for standard). Hardcoding 24000
-        # would reject --engine standard, which does not support that rate.
-        resp = polly.synthesize_speech(
-            Text=chunk,
-            OutputFormat="mp3",
-            VoiceId=voice,
-            Engine=engine,
-        )
-        stream = resp.get("AudioStream")
-        if stream is None:
-            _fail("Polly returned no AudioStream", "upstream_error")
-        audio.extend(stream.read())
+        audio.extend(relay(chunk, voice, engine))
     return bytes(audio), len(chunks)
 
 
@@ -144,8 +167,8 @@ def main():
     region = os.environ.get("AWS_REGION", "us-east-1")
 
     try:
-        audio, chunk_count = synthesize(text, args.voice, args.engine, region)
-    except Exception as exc:  # botocore ClientError (bad voice/engine, throttling, etc.)
+        audio, chunk_count = synthesize(text, args.voice, args.engine)
+    except Exception as exc:
         _fail(f"Polly synthesis failed: {exc}", "upstream_error")
 
     if not audio:

--- a/infra/agent-image/test_agentcore_wrapper.py
+++ b/infra/agent-image/test_agentcore_wrapper.py
@@ -222,6 +222,10 @@ class TestSerializedInvocationSignature(unittest.TestCase):
 
 
 class TestSerializedInvocationCleanup(unittest.IsolatedAsyncioTestCase):
+    def test_privileged_drain_outlives_render_without_expanding_flush_budget(self):
+        self.assertEqual(agentcore_wrapper.FINAL_WORKSPACE_FLUSH_SECONDS, 120)
+        self.assertEqual(agentcore_wrapper.PROXY_FINALIZATION_DRAIN_SECONDS, 795)
+
     async def test_second_drain_failure_restarts_stuck_proxy_again(self):
         import os
         import tempfile

--- a/infra/agent-image/test_agentcore_wrapper.py
+++ b/infra/agent-image/test_agentcore_wrapper.py
@@ -224,7 +224,7 @@ class TestSerializedInvocationSignature(unittest.TestCase):
 class TestSerializedInvocationCleanup(unittest.IsolatedAsyncioTestCase):
     def test_privileged_drain_outlives_render_without_expanding_flush_budget(self):
         self.assertEqual(agentcore_wrapper.FINAL_WORKSPACE_FLUSH_SECONDS, 120)
-        self.assertEqual(agentcore_wrapper.PROXY_FINALIZATION_DRAIN_SECONDS, 795)
+        self.assertEqual(agentcore_wrapper.PROXY_FINALIZATION_DRAIN_SECONDS, 830)
 
     async def test_second_drain_failure_restarts_stuck_proxy_again(self):
         import os

--- a/infra/agent-image/test_mantle_proxy.py
+++ b/infra/agent-image/test_mantle_proxy.py
@@ -59,7 +59,10 @@ import mantle_proxy  # noqa: E402
 from mantle_proxy import (  # noqa: E402
     AgentBrokerResponseTooLarge,
     FINALIZATION_DRAIN_TIMEOUT_SECONDS,
+    HYPERFRAMES_IDENTITY_TIMEOUT_SECONDS,
     HYPERFRAMES_INVOKE_PAYLOAD_MAX_BYTES,
+    HYPERFRAMES_LAMBDA_CONNECT_TIMEOUT_SECONDS,
+    HYPERFRAMES_LAMBDA_READ_TIMEOUT_SECONDS,
     HYPERFRAMES_OWNER_BINDING_RESERVE_BYTES,
     HYPERFRAMES_RELAY_TIMEOUT_SECONDS,
     POLLY_TEXT_MAX_CHARS,
@@ -262,8 +265,8 @@ class TestDirectAwsSkillRelay(unittest.TestCase):
 
         self.assertIs(result, client_constructor.return_value)
         config_constructor.assert_called_once_with(
-            connect_timeout=10,
-            read_timeout=HYPERFRAMES_RELAY_TIMEOUT_SECONDS,
+            connect_timeout=HYPERFRAMES_LAMBDA_CONNECT_TIMEOUT_SECONDS,
+            read_timeout=HYPERFRAMES_LAMBDA_READ_TIMEOUT_SECONDS,
             retries={"total_max_attempts": 1, "mode": "standard"},
         )
         client_constructor.assert_called_once_with(
@@ -274,6 +277,14 @@ class TestDirectAwsSkillRelay(unittest.TestCase):
 
     def test_finalization_drain_outlives_the_longest_relay_request(self):
         self.assertGreater(
+            HYPERFRAMES_RELAY_TIMEOUT_SECONDS,
+            (
+                HYPERFRAMES_IDENTITY_TIMEOUT_SECONDS
+                + HYPERFRAMES_LAMBDA_CONNECT_TIMEOUT_SECONDS
+                + HYPERFRAMES_LAMBDA_READ_TIMEOUT_SECONDS
+            ),
+        )
+        self.assertGreater(
             FINALIZATION_DRAIN_TIMEOUT_SECONDS,
             HYPERFRAMES_RELAY_TIMEOUT_SECONDS,
         )
@@ -281,6 +292,30 @@ class TestDirectAwsSkillRelay(unittest.TestCase):
 
 
 class TestHyperframesOwnerResolution(unittest.IsolatedAsyncioTestCase):
+    async def test_owner_resolution_has_one_total_deadline(self):
+        async def never_returns(*_args, **_kwargs):
+            await asyncio.Event().wait()
+
+        with mock.patch.object(
+            mantle_proxy,
+            "HYPERFRAMES_IDENTITY_TIMEOUT_SECONDS",
+            0.01,
+        ), mock.patch.object(
+            mantle_proxy,
+            "_post_signed_identity_request",
+            new=mock.AsyncMock(side_effect=never_returns),
+        ) as post_identity:
+            with self.assertRaisesRegex(
+                RuntimeError,
+                "identity verification timed out",
+            ):
+                await _resolve_invocation_owner()
+
+        post_identity.assert_awaited_once_with(
+            mantle_proxy.INVOCATION_IDENTITY_ROUTE,
+            skip_not_found_body=True,
+        )
+
     async def test_uses_only_the_web_verified_owner(self):
         payload = {
             "html": '<div data-composition-id="eval">EVAL 1426</div>',

--- a/infra/agent-image/test_mantle_proxy.py
+++ b/infra/agent-image/test_mantle_proxy.py
@@ -15,6 +15,8 @@ touch aiohttp, so we stub it in sys.modules before import — the test exercises
 the parsing logic, not the HTTP server.
 """
 
+import json
+import os
 import sys
 import types
 import unittest
@@ -48,13 +50,20 @@ if "aiohttp" not in sys.modules:
     _aiohttp.ClientTimeout = object
     sys.modules["aiohttp"] = _aiohttp
 
+sys.path.insert(0, os.path.dirname(__file__))
+
 import asyncio  # noqa: E402
 
 import mantle_proxy  # noqa: E402
 from mantle_proxy import (  # noqa: E402
     AgentBrokerResponseTooLarge,
+    POLLY_TEXT_MAX_CHARS,
+    _invoke_hyperframes,
     _read_bounded_agent_broker_response,
     _resolve_agent_broker_route,
+    _synthesize_polly,
+    _validate_hyperframes_payload,
+    _validate_polly_payload,
     _workspace_flush_request_allowed,
     _extract_usage,
     _is_anthropic_model,
@@ -69,6 +78,111 @@ from mantle_proxy import (  # noqa: E402
     _parse_anthropic_stream,
     _parse_anthropic_response,
 )
+
+
+class _FakeAwsStream:
+    def __init__(self, body):
+        self._body = body
+        self._offset = 0
+        self.closed = False
+
+    def read(self, amount):
+        chunk = self._body[self._offset : self._offset + amount]
+        self._offset += len(chunk)
+        return chunk
+
+    def close(self):
+        self.closed = True
+
+
+class TestDirectAwsSkillRelay(unittest.TestCase):
+    def test_polly_relay_allows_only_one_bounded_synthesis_operation(self):
+        payload = _validate_polly_payload({
+            "text": "EVAL 1426 synthetic audio canary",
+            "voice": "Ruth",
+            "engine": "generative",
+        })
+        stream = _FakeAwsStream(b"synthetic-mp3")
+        client = mock.Mock()
+        client.synthesize_speech.return_value = {"AudioStream": stream}
+
+        with mock.patch.object(
+            mantle_proxy,
+            "_new_polly_client",
+            return_value=client,
+        ):
+            audio = _synthesize_polly(payload)
+
+        self.assertEqual(audio, b"synthetic-mp3")
+        self.assertTrue(stream.closed)
+        client.synthesize_speech.assert_called_once_with(
+            Text="EVAL 1426 synthetic audio canary",
+            OutputFormat="mp3",
+            VoiceId="Ruth",
+            Engine="generative",
+        )
+
+    def test_polly_relay_rejects_extra_fields_and_oversize_text(self):
+        with self.assertRaises(ValueError):
+            _validate_polly_payload({
+                "text": "canary",
+                "voice": "Ruth",
+                "engine": "generative",
+                "returnCredentials": True,
+            })
+        with self.assertRaises(ValueError):
+            _validate_polly_payload({
+                "text": "x" * (POLLY_TEXT_MAX_CHARS + 1),
+                "voice": "Ruth",
+                "engine": "generative",
+            })
+
+    def test_hyperframes_relay_chooses_the_function_outside_the_request(self):
+        payload = _validate_hyperframes_payload({
+            "html": '<div data-composition-id="eval">EVAL 1426</div>',
+            "durationSeconds": 1,
+            "fps": 20,
+            "width": 640,
+            "height": 360,
+            "userEmail": "eval.issue1426@psd401.net",
+        })
+        result_body = json.dumps({
+            "status": "ok",
+            "url": "https://example.invalid/synthetic.mp4",
+        }).encode("utf-8")
+        stream = _FakeAwsStream(result_body)
+        client = mock.Mock()
+        client.invoke.return_value = {"Payload": stream}
+
+        with mock.patch.dict(
+            mantle_proxy.os.environ,
+            {"HYPERFRAMES_RENDER_FUNCTION": "psd-hyperframes-render-dev"},
+            clear=False,
+        ), mock.patch.object(
+            mantle_proxy,
+            "_new_lambda_client",
+            return_value=client,
+        ):
+            result = _invoke_hyperframes(payload)
+
+        self.assertEqual(result["status"], "ok")
+        self.assertTrue(stream.closed)
+        call = client.invoke.call_args.kwargs
+        self.assertEqual(call["FunctionName"], "psd-hyperframes-render-dev")
+        self.assertEqual(call["InvocationType"], "RequestResponse")
+        self.assertNotIn("FunctionName", json.loads(call["Payload"]))
+
+    def test_hyperframes_relay_rejects_caller_selected_function(self):
+        with self.assertRaises(ValueError):
+            _validate_hyperframes_payload({
+                "html": '<div data-composition-id="eval">EVAL 1426</div>',
+                "durationSeconds": 1,
+                "fps": 20,
+                "width": 640,
+                "height": 360,
+                "userEmail": "eval.issue1426@psd401.net",
+                "functionName": "attacker-selected-function",
+            })
 
 
 class TestAgentBrokerRoute(unittest.TestCase):

--- a/infra/agent-image/test_mantle_proxy.py
+++ b/infra/agent-image/test_mantle_proxy.py
@@ -15,6 +15,7 @@ touch aiohttp, so we stub it in sys.modules before import — the test exercises
 the parsing logic, not the HTTP server.
 """
 
+import base64
 import json
 import os
 import sys
@@ -57,12 +58,19 @@ import asyncio  # noqa: E402
 import mantle_proxy  # noqa: E402
 from mantle_proxy import (  # noqa: E402
     AgentBrokerResponseTooLarge,
+    FINALIZATION_DRAIN_TIMEOUT_SECONDS,
     HYPERFRAMES_INVOKE_PAYLOAD_MAX_BYTES,
+    HYPERFRAMES_OWNER_BINDING_RESERVE_BYTES,
     HYPERFRAMES_RELAY_TIMEOUT_SECONDS,
     POLLY_TEXT_MAX_CHARS,
+    _bind_hyperframes_owner,
+    _decode_invocation_owner,
     _invoke_hyperframes,
     _new_lambda_client,
+    _owner_bound_hyperframes_payload,
+    _resolve_invocation_owner,
     _read_bounded_agent_broker_response,
+    _read_signed_identity_response,
     _resolve_agent_broker_route,
     _synthesize_polly,
     _validate_hyperframes_payload,
@@ -147,8 +155,11 @@ class TestDirectAwsSkillRelay(unittest.TestCase):
             "fps": 20,
             "width": 640,
             "height": 360,
-            "userEmail": "eval.issue1426@psd401.net",
         })
+        payload = _bind_hyperframes_owner(
+            payload,
+            "owner@psd401.net",
+        )
         result_body = json.dumps({
             "status": "ok",
             "url": "https://example.invalid/synthetic.mp4",
@@ -173,9 +184,11 @@ class TestDirectAwsSkillRelay(unittest.TestCase):
         call = client.invoke.call_args.kwargs
         self.assertEqual(call["FunctionName"], "psd-hyperframes-render-dev")
         self.assertEqual(call["InvocationType"], "RequestResponse")
-        self.assertNotIn("FunctionName", json.loads(call["Payload"]))
+        invoked_payload = json.loads(call["Payload"])
+        self.assertNotIn("FunctionName", invoked_payload)
+        self.assertEqual(invoked_payload["userEmail"], "owner@psd401.net")
 
-    def test_hyperframes_relay_rejects_caller_selected_function(self):
+    def test_hyperframes_relay_rejects_caller_selected_function_or_owner(self):
         with self.assertRaises(ValueError):
             _validate_hyperframes_payload({
                 "html": '<div data-composition-id="eval">EVAL 1426</div>',
@@ -183,9 +196,33 @@ class TestDirectAwsSkillRelay(unittest.TestCase):
                 "fps": 20,
                 "width": 640,
                 "height": 360,
-                "userEmail": "eval.issue1426@psd401.net",
                 "functionName": "attacker-selected-function",
             })
+        with self.assertRaises(ValueError):
+            _validate_hyperframes_payload({
+                "html": '<div data-composition-id="eval">EVAL 1426</div>',
+                "durationSeconds": 1,
+                "fps": 20,
+                "width": 640,
+                "height": 360,
+                "userEmail": "victim@psd401.net",
+            })
+
+    def test_hyperframes_owner_is_injected_only_after_trusted_resolution(self):
+        payload = _validate_hyperframes_payload({
+            "html": '<div data-composition-id="eval">EVAL 1426</div>',
+            "durationSeconds": 1,
+            "fps": 20,
+            "width": 640,
+            "height": 360,
+        })
+
+        owner_bound = _bind_hyperframes_owner(payload, "owner@psd401.net")
+
+        self.assertNotIn("userEmail", payload)
+        self.assertEqual(owner_bound["userEmail"], "owner@psd401.net")
+        with self.assertRaises(RuntimeError):
+            _bind_hyperframes_owner(payload, "Victim@psd401.net")
 
     def test_hyperframes_serialization_enforces_lambda_invoke_limit(self):
         with self.assertRaisesRegex(ValueError, "serialized payload"):
@@ -200,7 +237,6 @@ class TestDirectAwsSkillRelay(unittest.TestCase):
                 "fps": 20,
                 "width": 640,
                 "height": 360,
-                "userEmail": "eval.issue1426@psd401.net",
             })
 
     def test_hyperframes_lambda_client_matches_the_turn_budget_without_retries(self):
@@ -235,6 +271,124 @@ class TestDirectAwsSkillRelay(unittest.TestCase):
             region_name=mantle_proxy.AWS_REGION,
             config=config_instance,
         )
+
+    def test_finalization_drain_outlives_the_longest_relay_request(self):
+        self.assertGreater(
+            FINALIZATION_DRAIN_TIMEOUT_SECONDS,
+            HYPERFRAMES_RELAY_TIMEOUT_SECONDS,
+        )
+        self.assertEqual(HYPERFRAMES_OWNER_BINDING_RESERVE_BYTES, 512)
+
+
+class TestHyperframesOwnerResolution(unittest.IsolatedAsyncioTestCase):
+    async def test_uses_only_the_web_verified_owner(self):
+        payload = {
+            "html": '<div data-composition-id="eval">EVAL 1426</div>',
+            "durationSeconds": 1,
+            "fps": 20,
+            "width": 640,
+            "height": 360,
+        }
+        with mock.patch.object(
+            mantle_proxy,
+            "_resolve_invocation_owner",
+            new=mock.AsyncMock(return_value="owner@psd401.net"),
+        ) as resolve_owner:
+            owner_bound = await _owner_bound_hyperframes_payload(payload)
+
+        resolve_owner.assert_awaited_once_with()
+        self.assertEqual(owner_bound["userEmail"], "owner@psd401.net")
+        self.assertNotIn("userEmail", payload)
+
+    async def test_prefers_owner_returned_by_the_dedicated_verified_route(self):
+        with mock.patch.object(
+            mantle_proxy,
+            "_post_signed_identity_request",
+            new=mock.AsyncMock(
+                return_value=(
+                    200,
+                    b'{"ownerEmail":"owner@psd401.net"}',
+                )
+            ),
+        ) as post_identity, mock.patch.object(
+            mantle_proxy,
+            "_read_authority",
+        ) as read_authority:
+            owner = await _resolve_invocation_owner()
+
+        self.assertEqual(owner, "owner@psd401.net")
+        post_identity.assert_awaited_once_with(
+            mantle_proxy.INVOCATION_IDENTITY_ROUTE,
+            skip_not_found_body=True,
+        )
+        read_authority.assert_not_called()
+
+    async def test_old_web_tier_probe_authenticates_before_decoding_owner(self):
+        claims = {
+            "version": 1,
+            "audience": "psd-agent-internal",
+            "ownerEmail": "owner@psd401.net",
+        }
+        encoded = base64.urlsafe_b64encode(
+            json.dumps(claims).encode("utf-8")
+        ).rstrip(b"=").decode("ascii")
+        context = f"v1.{encoded}.{'s' * 43}"
+        with mock.patch.object(
+            mantle_proxy,
+            "_post_signed_identity_request",
+            new=mock.AsyncMock(
+                side_effect=[
+                    (404, b'{"error":"Not found"}'),
+                    (404, b'{"error":"Unsupported model endpoint"}'),
+                ]
+            ),
+        ) as post_identity, mock.patch.object(
+            mantle_proxy,
+            "_read_authority",
+            return_value=(context, b"k" * 32),
+        ):
+            owner = await _resolve_invocation_owner()
+
+        self.assertEqual(owner, "owner@psd401.net")
+        self.assertEqual(
+            [
+                (call.args[0], call.kwargs)
+                for call in post_identity.await_args_list
+            ],
+            [
+                (
+                    mantle_proxy.INVOCATION_IDENTITY_ROUTE,
+                    {"skip_not_found_body": True},
+                ),
+                (mantle_proxy.INVOCATION_AUTHORITY_PROBE_ROUTE, {}),
+            ],
+        )
+
+    async def test_old_web_tier_probe_fails_closed_on_unverified_context(self):
+        with mock.patch.object(
+            mantle_proxy,
+            "_post_signed_identity_request",
+            new=mock.AsyncMock(
+                side_effect=[
+                    (404, b'{"error":"Not found"}'),
+                    (403, b'{"error":"Forbidden"}'),
+                ]
+            ),
+        ), mock.patch.object(
+            mantle_proxy,
+            "_read_authority",
+        ) as read_authority:
+            with self.assertRaises(RuntimeError):
+                await _resolve_invocation_owner()
+
+        read_authority.assert_not_called()
+
+    def test_decoded_owner_claim_requires_the_expected_context_shape(self):
+        encoded = base64.urlsafe_b64encode(
+            b'{"version":1,"audience":"other","ownerEmail":"owner@psd401.net"}'
+        ).rstrip(b"=").decode("ascii")
+        with self.assertRaises(RuntimeError):
+            _decode_invocation_owner(f"v1.{encoded}.{'s' * 43}")
 
 
 class TestAgentBrokerRoute(unittest.TestCase):
@@ -403,7 +557,8 @@ class _FakeResponseContent:
 
 
 class _FakeBrokerResponse:
-    def __init__(self, chunks, content_length=None):
+    def __init__(self, chunks, content_length=None, status=200):
+        self.status = status
         self.headers = {}
         if content_length is not None:
             self.headers["Content-Length"] = str(content_length)
@@ -415,6 +570,37 @@ class _FakeBrokerResponse:
 
 
 class TestBoundedAgentBrokerResponse(unittest.TestCase):
+    def test_skips_large_framework_404_body_only_when_caller_does_not_need_it(self):
+        response = _FakeBrokerResponse(
+            [b"not-read"],
+            content_length=16 * 1024,
+            status=404,
+        )
+        status, body = asyncio.run(
+            _read_signed_identity_response(
+                response,
+                skip_not_found_body=True,
+            )
+        )
+        self.assertEqual(status, 404)
+        self.assertEqual(body, b"")
+        self.assertTrue(response.closed)
+
+    def test_still_rejects_an_oversize_verified_probe_response(self):
+        response = _FakeBrokerResponse(
+            [b"not-read"],
+            content_length=16 * 1024,
+            status=404,
+        )
+        with self.assertRaises(AgentBrokerResponseTooLarge):
+            asyncio.run(
+                _read_signed_identity_response(
+                    response,
+                    skip_not_found_body=False,
+                )
+            )
+        self.assertTrue(response.closed)
+
     def test_accepts_response_at_limit(self):
         response = _FakeBrokerResponse([b"ab", b"cd"], content_length=4)
         body = asyncio.run(

--- a/infra/agent-image/test_mantle_proxy.py
+++ b/infra/agent-image/test_mantle_proxy.py
@@ -57,8 +57,11 @@ import asyncio  # noqa: E402
 import mantle_proxy  # noqa: E402
 from mantle_proxy import (  # noqa: E402
     AgentBrokerResponseTooLarge,
+    HYPERFRAMES_INVOKE_PAYLOAD_MAX_BYTES,
+    HYPERFRAMES_RELAY_TIMEOUT_SECONDS,
     POLLY_TEXT_MAX_CHARS,
     _invoke_hyperframes,
+    _new_lambda_client,
     _read_bounded_agent_broker_response,
     _resolve_agent_broker_route,
     _synthesize_polly,
@@ -183,6 +186,55 @@ class TestDirectAwsSkillRelay(unittest.TestCase):
                 "userEmail": "eval.issue1426@psd401.net",
                 "functionName": "attacker-selected-function",
             })
+
+    def test_hyperframes_serialization_enforces_lambda_invoke_limit(self):
+        with self.assertRaisesRegex(ValueError, "serialized payload"):
+            _validate_hyperframes_payload({
+                # NUL is one raw UTF-8 byte but six bytes after JSON escaping.
+                # This remains under the 4 MiB composition cap while exceeding
+                # 6 MiB once serialized for Lambda.
+                "html": "\0" * (
+                    HYPERFRAMES_INVOKE_PAYLOAD_MAX_BYTES // 6 + 1
+                ),
+                "durationSeconds": 1,
+                "fps": 20,
+                "width": 640,
+                "height": 360,
+                "userEmail": "eval.issue1426@psd401.net",
+            })
+
+    def test_hyperframes_lambda_client_matches_the_turn_budget_without_retries(self):
+        config_instance = object()
+        config_constructor = mock.Mock(return_value=config_instance)
+        client_constructor = mock.Mock(return_value=object())
+        boto3_module = types.ModuleType("boto3")
+        boto3_module.client = client_constructor
+        botocore_module = types.ModuleType("botocore")
+        config_module = types.ModuleType("botocore.config")
+        config_module.Config = config_constructor
+        botocore_module.config = config_module
+
+        with mock.patch.dict(
+            sys.modules,
+            {
+                "boto3": boto3_module,
+                "botocore": botocore_module,
+                "botocore.config": config_module,
+            },
+        ):
+            result = _new_lambda_client()
+
+        self.assertIs(result, client_constructor.return_value)
+        config_constructor.assert_called_once_with(
+            connect_timeout=10,
+            read_timeout=HYPERFRAMES_RELAY_TIMEOUT_SECONDS,
+            retries={"total_max_attempts": 1, "mode": "standard"},
+        )
+        client_constructor.assert_called_once_with(
+            "lambda",
+            region_name=mantle_proxy.AWS_REGION,
+            config=config_instance,
+        )
 
 
 class TestAgentBrokerRoute(unittest.TestCase):

--- a/infra/agent-image/test_tts_synthesize.py
+++ b/infra/agent-image/test_tts_synthesize.py
@@ -1,0 +1,199 @@
+"""Regression tests for psd-tts's OpenClaw exec-to-root-relay boundary."""
+
+import importlib.util
+import json
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+import os
+from pathlib import Path
+import subprocess
+import sys
+import threading
+import unittest
+from unittest import mock
+
+
+SCRIPT = (
+    Path(__file__).parent
+    / "skills"
+    / "psd-tts"
+    / "scripts"
+    / "synthesize.py"
+)
+SPEC = importlib.util.spec_from_file_location("psd_tts_synthesize", SCRIPT)
+if SPEC is None or SPEC.loader is None:
+    raise RuntimeError("unable to load psd-tts synthesize module")
+synthesize_module = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(synthesize_module)
+
+
+class _Headers:
+    @staticmethod
+    def get_content_type():
+        return "audio/mpeg"
+
+
+class _Response:
+    def __init__(self, body):
+        self._body = body
+        self._offset = 0
+        self.headers = _Headers()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return False
+
+    def read(self, amount):
+        chunk = self._body[self._offset : self._offset + amount]
+        self._offset += len(chunk)
+        return chunk
+
+
+class TestTtsCredentialBoundary(unittest.TestCase):
+    def test_sanitized_exec_subprocess_reaches_fixed_operation_relay(self):
+        requests = []
+
+        class RelayHandler(BaseHTTPRequestHandler):
+            def do_POST(self):
+                length = int(self.headers["Content-Length"])
+                requests.append({
+                    "path": self.path,
+                    "payload": json.loads(self.rfile.read(length)),
+                })
+                body = b"synthetic-mp3"
+                self.send_response(200)
+                self.send_header("Content-Type", "audio/mpeg")
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+
+            def log_message(self, *_args):
+                return
+
+        server = ThreadingHTTPServer(("127.0.0.1", 0), RelayHandler)
+        server_thread = threading.Thread(target=server.serve_forever, daemon=True)
+        server_thread.start()
+        relay_url = (
+            f"http://127.0.0.1:{server.server_address[1]}"
+            "/aws-skill/polly/synthesize"
+        )
+        child_code = """
+import importlib.util
+import pathlib
+import sys
+
+script = pathlib.Path(sys.argv[1])
+spec = importlib.util.spec_from_file_location("subprocess_tts", script)
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+module.POLLY_RELAY_URL = sys.argv[2]
+audio, chunks = module.synthesize("Synthetic canary", "Ruth", "generative")
+print(f"{audio.hex()}:{chunks}")
+"""
+        credential_keys = {
+            "AWS_ACCESS_KEY_ID",
+            "AWS_SECRET_ACCESS_KEY",
+            "AWS_SESSION_TOKEN",
+            "AWS_CONTAINER_CREDENTIALS_FULL_URI",
+            "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI",
+        }
+        clean_env = {
+            key: value
+            for key, value in os.environ.items()
+            if key not in credential_keys
+        }
+        try:
+            result = subprocess.run(
+                [sys.executable, "-c", child_code, str(SCRIPT), relay_url],
+                check=True,
+                capture_output=True,
+                text=True,
+                timeout=10,
+                env=clean_env,
+            )
+        finally:
+            server.shutdown()
+            server.server_close()
+            server_thread.join(timeout=5)
+
+        self.assertEqual(result.stdout.strip(), "73796e7468657469632d6d7033:1")
+        self.assertEqual(
+            requests,
+            [{
+                "path": "/aws-skill/polly/synthesize",
+                "payload": {
+                    "text": "Synthetic canary",
+                    "voice": "Ruth",
+                    "engine": "generative",
+                },
+            }],
+        )
+
+    def test_exec_subprocess_needs_no_aws_credential_environment(self):
+        credential_keys = (
+            "AWS_ACCESS_KEY_ID",
+            "AWS_SECRET_ACCESS_KEY",
+            "AWS_SESSION_TOKEN",
+            "AWS_CONTAINER_CREDENTIALS_FULL_URI",
+            "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI",
+        )
+        clean_env = {
+            key: value
+            for key, value in os.environ.items()
+            if key not in credential_keys
+        }
+        calls = []
+
+        def relay(text, voice, engine):
+            calls.append((text, voice, engine))
+            return b"mp3"
+
+        with mock.patch.dict(os.environ, clean_env, clear=True):
+            audio, chunks = synthesize_module.synthesize(
+                "First sentence. Second sentence.",
+                "Ruth",
+                "generative",
+                synthesize_chunk=relay,
+            )
+
+        self.assertEqual(audio, b"mp3")
+        self.assertEqual(chunks, 1)
+        self.assertEqual(
+            calls,
+            [("First sentence. Second sentence.", "Ruth", "generative")],
+        )
+
+    def test_relay_request_contains_operation_inputs_but_no_credentials(self):
+        response = _Response(b"synthetic-mp3")
+        with mock.patch.object(
+            synthesize_module.urllib.request,
+            "urlopen",
+            return_value=response,
+        ) as urlopen:
+            audio = synthesize_module._synthesize_chunk(
+                "Synthetic canary",
+                "Ruth",
+                "generative",
+            )
+
+        self.assertEqual(audio, b"synthetic-mp3")
+        request = urlopen.call_args.args[0]
+        self.assertEqual(
+            request.full_url,
+            "http://127.0.0.1:18791/aws-skill/polly/synthesize",
+        )
+        body = request.data.decode("utf-8")
+        self.assertIn('"text": "Synthetic canary"', body)
+        self.assertNotIn("AWS_ACCESS_KEY_ID", body)
+        self.assertNotIn("AWS_SECRET_ACCESS_KEY", body)
+        self.assertNotIn("AWS_SESSION_TOKEN", body)
+
+    def test_model_facing_script_does_not_import_an_aws_sdk(self):
+        source = SCRIPT.read_text(encoding="utf-8")
+        self.assertNotRegex(source, r"(?m)^\s*import boto3\b")
+        self.assertNotRegex(source, r"(?m)^\s*from (?:boto3|botocore)\b")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/infra/hyperframes-render/Dockerfile
+++ b/infra/hyperframes-render/Dockerfile
@@ -88,10 +88,14 @@ ENV HYPERFRAMES_FFPROBE_PATH=/opt/ffmpeg/ffprobe
 
 # Lambda handler + its runtime deps (aws-lambda-ric + @aws-sdk/client-s3).
 WORKDIR /var/task
-COPY package.json ./
+COPY hyperframes-render/package.json ./
 RUN npm install --omit=dev --no-audit --no-fund
-COPY handler.js ./
-COPY entrypoint.sh /entrypoint.sh
+COPY hyperframes-render/handler.js ./
+# handler.js resolves ../validated-fs.cjs to /var/validated-fs.cjs at runtime.
+# Build from the infra/ context so this is the canonical shared implementation,
+# not a duplicate that can drift from the repository security wrapper.
+COPY validated-fs.cjs /var/validated-fs.cjs
+COPY hyperframes-render/entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 
 # Runtime Interface Emulator — used only for local `docker run` smoke testing.

--- a/infra/hyperframes-render/Dockerfile.dockerignore
+++ b/infra/hyperframes-render/Dockerfile.dockerignore
@@ -1,0 +1,8 @@
+**
+!validated-fs.cjs
+!hyperframes-render/
+!hyperframes-render/Dockerfile
+!hyperframes-render/Dockerfile.dockerignore
+!hyperframes-render/entrypoint.sh
+!hyperframes-render/handler.js
+!hyperframes-render/package.json

--- a/infra/hyperframes-render/README.md
+++ b/infra/hyperframes-render/README.md
@@ -7,8 +7,9 @@ of the **`psd-hyperframes`** OpenClaw agent skill (issue #1175).
 
 The native render stack (Chromium/FFmpeg/`hyperframes` CLI) lives **only here** — never in the
 agent image, whose AgentCore Firecracker overlay-mount snapshotter cannot carry it. The thin
-agent skill (`infra/agent-image/skills/psd-hyperframes/`) invokes this function synchronously
-via the AWS SDK.
+agent skill (`infra/agent-image/skills/psd-hyperframes/`) asks the root-owned fixed-operation
+relay to invoke this function synchronously, so the model-facing subprocess never receives
+reusable execution-role credentials.
 
 ## Files
 
@@ -27,7 +28,7 @@ via the AWS SDK.
   "html": "<!doctype html>…",   // required — full composition
   "css": "…",                    // optional — injected before </head>
   "js": "…",                     // optional — injected before </body>
-  "durationSeconds": 3,          // required — cap-validated (<= 60)
+  "durationSeconds": 3,          // required — cap-validated (<= 180)
   "fps": 30,                     // optional — default 30, range 1..60
   "width": 1920, "height": 1080, // optional — metadata + cap check
   "userEmail": "person@psd401.net", // required — scopes the S3 key
@@ -47,22 +48,26 @@ cd infra/hyperframes-render && bun install && bun test
 ## Standalone render smoke (docker run + RIE) — pre-deploy
 
 Produces a playable MP4 from the sample scene with **no S3/AWS** (dryRun), writing it to a
-bind-mounted host directory. Run from `infra/hyperframes-render`:
+bind-mounted host directory. Run from `infra/` so the build context includes the canonical
+`validated-fs.cjs` used by the handler:
 
 ```bash
 # 1. Build the image (x86_64 to match the Lambda architecture).
-docker build --platform linux/amd64 -t hyperframes-render:smoke .
+docker build --platform linux/amd64 \
+  -f hyperframes-render/Dockerfile \
+  -t hyperframes-render:smoke .
 
 # 2. Run it with the RIE, mounting a host output dir the dryRun render writes into.
 mkdir -p /tmp/hf-out
 docker run --rm -p 9000:8080 \
+  -e LAMBDA_TASK_ROOT=/var/task \
   -e HYPERFRAMES_OUTPUT_DIR=/tmp/out -v /tmp/hf-out:/tmp/out \
   --name hyperframes-render-smoke hyperframes-render:smoke &
 
 # 3. Invoke with the sample event (dryRun:true).
 sleep 2
 curl -s -XPOST "http://localhost:9000/2015-03-31/functions/function/invocations" \
-  -d @sample-events/sample-scene.json | tee /tmp/hf-out/result.json
+  -d @hyperframes-render/sample-events/sample-scene.json | tee /tmp/hf-out/result.json
 
 # 4. Verify a playable MP4 was produced.
 ls -lh /tmp/hf-out/*.mp4

--- a/infra/hyperframes-render/handler.js
+++ b/infra/hyperframes-render/handler.js
@@ -14,15 +14,17 @@ const { validatedFs } = require("../validated-fs.cjs");
  * This is the render half of the `psd-hyperframes` OpenClaw agent skill
  * (issue #1175). Chromium/FFmpeg live HERE, never in the agent image — the
  * AgentCore Firecracker overlay-mount snapshotter cannot carry that native
- * stack (see infra/agent-image/Dockerfile). The thin agent skill invokes
- * this function synchronously via the AWS SDK.
+ * stack (see infra/agent-image/Dockerfile). The thin agent skill sends a
+ * bounded request to the root-owned direct-AWS relay, which invokes this
+ * function synchronously without exposing reusable execution-role credentials
+ * to the model-facing subprocess.
  *
  * Event contract (RequestResponse invoke):
  *   {
  *     "html":            "<!doctype html>…",   // required — full composition
  *     "css":             "…",                   // optional — injected before </head>
  *     "js":              "…",                   // optional — injected before </body>
- *     "durationSeconds": 8,                     // required — cap-validated (<= 60)
+ *     "durationSeconds": 8,                     // required — cap-validated (<= 180)
  *     "fps":             30,                     // optional — default 30, 1..60
  *     "width":           1920,                   // optional — metadata + cap check
  *     "height":          1080,                   // optional — metadata + cap check

--- a/infra/lib/agent-platform-stack.ts
+++ b/infra/lib/agent-platform-stack.ts
@@ -1499,13 +1499,15 @@ export class AgentPlatformStack extends cdk.Stack {
       ],
     }));
 
-    // Amazon Polly text-to-speech (psd-tts skill). It authenticates via this
-    // execution role's standard SigV4 credential chain. The
-    // skill uses only the synchronous SynthesizeSpeech API (it chunks long text
-    // and concatenates the MP3s), so we grant exactly that action and nothing
-    // else. SynthesizeSpeech does not support resource-level permissions, so the
-    // resource must be '*'. Synthesized MP3s are published through the
-    // owner-bound workspace storage broker; this role has no S3 permissions.
+    // Amazon Polly text-to-speech (psd-tts skill). The root-owned loopback
+    // relay authenticates via this execution role's standard SigV4 credential
+    // chain; OpenClaw's model-facing exec subprocess never receives reusable
+    // credentials. The fixed relay uses only the synchronous SynthesizeSpeech
+    // API (the skill chunks long text and concatenates the MP3s), so we grant
+    // exactly that action and nothing else. SynthesizeSpeech does not support
+    // resource-level permissions, so the resource must be '*'. Synthesized
+    // MP3s are published through the owner-bound workspace storage broker;
+    // this role has no S3 permissions.
     resources.agentCoreExecutionRole.addToPolicy(new iam.PolicyStatement({
       sid: 'PollyTextToSpeech',
       effect: iam.Effect.ALLOW,
@@ -1513,10 +1515,12 @@ export class AgentPlatformStack extends cdk.Stack {
       resources: ['*'],
     }));
 
-    // HyperFrames render invocation (psd-hyperframes skill, #1175). Scoped to
-    // the single render function ARN. The skill invokes it synchronously using
-    // these execution-role credentials; the render Lambda owns publication of
-    // its output, so the model-facing role needs no S3 permissions.
+    // HyperFrames render invocation (psd-hyperframes skill, #1175/#1442).
+    // Scoped to the single render function ARN. The root-owned loopback relay
+    // invokes it synchronously using these execution-role credentials and
+    // never returns credential material or accepts a caller-selected target;
+    // the render Lambda owns publication of its output, so the model-facing
+    // role needs no S3 permissions.
     resources.agentCoreExecutionRole.addToPolicy(new iam.PolicyStatement({
       sid: 'HyperframesRenderInvoke',
       effect: iam.Effect.ALLOW,
@@ -1850,9 +1854,10 @@ export class AgentPlatformStack extends cdk.Stack {
       // components (this.region is already their hardcoded default).
       AWS_REGION: this.region,
       AWS_DEFAULT_REGION: this.region,
-      // Render function the psd-hyperframes skill invokes (#1175). The skill
-      // reads this to target the InvokeFunction call; the grant is the
-      // HyperframesRenderInvoke statement on the AgentCore execution role.
+      // Render function the root-owned direct-AWS relay invokes for the
+      // psd-hyperframes skill (#1175/#1442). The model-facing request cannot
+      // select a function; the grant is the HyperframesRenderInvoke statement
+      // on the AgentCore execution role.
       HYPERFRAMES_RENDER_FUNCTION: resources.hyperframesRenderFunction.function.functionName,
       GUARDRAIL_ARN: props.guardrailArn,
       SKILL_BUILDER_LAMBDA_ARN: `arn:aws:lambda:${this.region}:${this.account}:function:${resources.skillBuilderFunctionName}`,

--- a/infra/lib/constructs/compute/hyperframes-render-function.ts
+++ b/infra/lib/constructs/compute/hyperframes-render-function.ts
@@ -113,13 +113,37 @@ export class HyperframesRenderFunction extends Construct {
       removalPolicy: cdk.RemovalPolicy.DESTROY,
     })
 
+    // The handler imports ../validated-fs.cjs from /var/task, so the Docker
+    // build context must include the canonical infra/validated-fs.cjs beside
+    // hyperframes-render/. Keep the context intentionally narrow: without
+    // these exclusions, every unrelated infra change would rebuild the large
+    // Chromium image and CDK would stage infra/node_modules.
+    const imageAssetRoot = path.join(__dirname, "..", "..", "..")
     this.function = new lambda.DockerImageFunction(this, "Function", {
       functionName,
       description: `Renders a HyperFrames HTML/CSS/JS composition to MP4 (#1175) — ${environment}`,
-      code: lambda.DockerImageCode.fromImageAsset(
-        path.join(__dirname, "..", "..", "..", "hyperframes-render"),
-        { platform: Platform.LINUX_AMD64 },
-      ),
+      code: lambda.DockerImageCode.fromImageAsset(imageAssetRoot, {
+        file: "hyperframes-render/Dockerfile",
+        exclude: [
+          "**",
+          "!validated-fs.cjs",
+          "!hyperframes-render/",
+          "!hyperframes-render/Dockerfile",
+          "!hyperframes-render/Dockerfile.dockerignore",
+          "!hyperframes-render/entrypoint.sh",
+          "!hyperframes-render/handler.js",
+          "!hyperframes-render/package.json",
+          // Docker-ignore negations re-include siblings when their parent is
+          // traversed. Exclude non-build inputs again so docs/tests do not
+          // churn the multi-gigabyte Lambda asset hash.
+          "hyperframes-render/.dockerignore",
+          "hyperframes-render/README.md",
+          "hyperframes-render/handler.test.js",
+          "hyperframes-render/sample-events",
+        ],
+        ignoreMode: cdk.IgnoreMode.DOCKER,
+        platform: Platform.LINUX_AMD64,
+      }),
       architecture: lambda.Architecture.X86_64,
       role,
       memorySize,

--- a/tests/unit/agent-invocation-identity-route.test.ts
+++ b/tests/unit/agent-invocation-identity-route.test.ts
@@ -1,0 +1,60 @@
+/** @jest-environment node */
+
+let contextOwner: string | null = "owner@psd401.net"
+
+jest.mock("@/lib/agent-workspace/invocation-context", () => ({
+  verifyAgentInvocationContext: jest.fn(async () =>
+    contextOwner
+      ? {
+          actorEmail: "actor@psd401.net",
+          ownerEmail: contextOwner,
+          mode: "consultation",
+          sessionId: "session-id",
+        }
+      : null
+  ),
+}))
+
+jest.mock("@/lib/logger", () => ({
+  createLogger: () => ({ warn: jest.fn() }),
+  generateRequestId: () => "request-id",
+}))
+
+import type { NextRequest } from "next/server"
+import { POST } from "@/app/api/agent/invocation-identity/route"
+import { verifyAgentInvocationContext } from "@/lib/agent-workspace/invocation-context"
+
+const verifyInvocationMock = jest.mocked(verifyAgentInvocationContext)
+
+function request(): NextRequest {
+  return { headers: { get: () => null } } as unknown as NextRequest
+}
+
+describe("agent invocation identity route", () => {
+  beforeEach(() => {
+    contextOwner = "owner@psd401.net"
+    verifyInvocationMock.mockClear()
+  })
+
+  it("returns only the owner from the verified invocation context", async () => {
+    const response = await POST(request())
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({ ownerEmail: "owner@psd401.net" })
+    expect(verifyInvocationMock).toHaveBeenCalledWith(
+      expect.anything(),
+      {
+        allowedModes: ["owner", "consultation", "scheduled", "email-task"],
+      }
+    )
+  })
+
+  it("rejects an invocation that the trusted verifier does not accept", async () => {
+    contextOwner = null
+
+    const response = await POST(request())
+
+    expect(response.status).toBe(403)
+    expect(await response.json()).toEqual({ error: "Forbidden" })
+  })
+})

--- a/tests/unit/agent-model-proxy-route.test.ts
+++ b/tests/unit/agent-model-proxy-route.test.ts
@@ -179,6 +179,9 @@ function defineAgentModelCredentialBrokerSuite1Part2() {it("rejects unapproved e
       { params: Promise.resolve({ path: ["arbitrary"] }) },
     )
     expect(wrongPath.status).toBe(404)
+    expect(await wrongPath.json()).toEqual({
+      error: "Unsupported model endpoint",
+    })
 
     const wrongModel = await POST(
       request({ model: "attacker/model", max_tokens: 100 }) as never,

--- a/tests/unit/hyperframes-render-image-layout.test.ts
+++ b/tests/unit/hyperframes-render-image-layout.test.ts
@@ -1,0 +1,63 @@
+/** @jest-environment node */
+
+import { dirname, join, posix } from "node:path"
+
+import { validatedFs } from "@/lib/filesystem/validated-fs"
+
+const repoRoot = join(__dirname, "..", "..")
+const dockerfile = validatedFs.readFileSync(
+  join(repoRoot, "infra", "hyperframes-render", "Dockerfile"),
+  "utf8",
+)
+const construct = validatedFs.readFileSync(
+  join(
+    repoRoot,
+    "infra",
+    "lib",
+    "constructs",
+    "compute",
+    "hyperframes-render-function.ts",
+  ),
+  "utf8",
+)
+const handler = validatedFs.readFileSync(
+  join(repoRoot, "infra", "hyperframes-render", "handler.js"),
+  "utf8",
+)
+const readme = validatedFs.readFileSync(
+  join(repoRoot, "infra", "hyperframes-render", "README.md"),
+  "utf8",
+)
+
+describe("HyperFrames Lambda image ships the filesystem guard", () => {
+  it("copies the canonical guard where the deployed handler resolves it", () => {
+    const requirePath =
+      handler.match(/require\((["'])(\.\.\/validated-fs\.cjs)\1\)/)?.[2]
+
+    expect(requirePath).toBe("../validated-fs.cjs")
+    expect(
+      posix.normalize(posix.join(dirname("/var/task/handler.js"), requirePath!)),
+    ).toBe("/var/validated-fs.cjs")
+    expect(dockerfile).toContain(
+      "COPY validated-fs.cjs /var/validated-fs.cjs",
+    )
+  })
+
+  it("uses the infra root as a narrow CDK context containing both sources", () => {
+    expect(construct).toContain(
+      'const imageAssetRoot = path.join(__dirname, "..", "..", "..")',
+    )
+    expect(construct).toContain('file: "hyperframes-render/Dockerfile"')
+    expect(construct).toContain('"!validated-fs.cjs"')
+    expect(construct).toContain('"!hyperframes-render/"')
+    expect(construct).toContain('"!hyperframes-render/handler.js"')
+    expect(construct).toContain('"hyperframes-render/README.md"')
+    expect(construct).toContain('"hyperframes-render/handler.test.js"')
+    expect(construct).toContain('"hyperframes-render/sample-events"')
+    expect(dockerfile).toContain("COPY hyperframes-render/handler.js ./")
+  })
+
+  it("documents the task root required by RIE outside Lambda", () => {
+    expect(readme).toContain("-e LAMBDA_TASK_ROOT=/var/task")
+  })
+})


### PR DESCRIPTION
## Description

Fixes the direct-AWS credential-chain failure affecting `psd-tts` and
`psd-hyperframes`.

OpenClaw 2026.7.1 intentionally strips inherited AWS access-key, session-token,
and container-credential variables from every model-launched `exec`
subprocess. Both skills previously instantiated AWS SDK clients inside those
subprocesses, so their AgentCore execution-role credentials were unavailable.

This change keeps reusable credentials out of the model-facing UID:

- adds two fixed-operation endpoints to the root-owned loopback relay:
  bounded Polly `SynthesizeSpeech`, and invocation of only the configured
  HyperFrames render function;
- requires active root-only invocation-authority files before either operation;
- independently validates request fields, sizes, duration/frame budgets,
  dimensions, voice/engine, and response sizes at the relay boundary;
- caps the fully serialized Lambda invocation below the 6 MiB synchronous
  request limit, disables duplicate SDK retries, and gives owner lookup,
  Lambda connect/read, and local transport explicit sequential budgets within
  the interactive turn ceiling;
- derives the HyperFrames S3 owner namespace only from web-verified invocation
  authority; the model payload cannot supply or override `userEmail`;
- supports rolling deployment by cryptographically validating the installed
  context against the existing model broker before decoding the root-only owner
  claim when the dedicated identity route is not deployed yet;
- gives both identity routes one shared 30-second deadline, then allows 10
  seconds to connect to Lambda, 780 seconds for its response, and 5 seconds of
  transport margin under the model-facing 825-second relay deadline;
- drains accepted synchronous renders for up to 830 seconds before revoking
  authority/restarting the relay, while retaining a separate 120-second
  workspace-flush budget;
- converts the TTS and HyperFrames scripts to fixed loopback HTTP clients with
  no AWS SDK or credential dependency;
- includes both endpoints in finalization draining and returns generic errors
  without credential/provider details;
- adds hermetic relay, stripped-child-process, target-restriction, owner-binding,
  rolling-404, payload-cap, lifetime, and skill-client regression coverage plus
  the CI gate.

The first live HyperFrames call reached Lambda and exposed an existing container
packaging defect: `handler.js` imported the canonical `validated-fs.cjs`, but
the image did not contain it. The CDK image now uses a six-file, explicitly
filtered `infra/` context and copies the canonical guard to its runtime path.
The image layout and local RIE smoke path are regression-tested.

## Live acceptance evidence

Evaluated and deployed the exact final candidate agent image:

`sha256:6ff6efc7a61069937070b9d53f0ebc69cb16b9bacea3c37fca5f60290fa4fbc8`

Dev AgentCore runtime version 64 read back `READY` on that immutable digest,
with its VPC, lifecycle, MMDSv2, role, protocol, and environment configuration
preserved.

Canonical synthetic fixtures against the exact final image:

- `tts-synthetic-short-audio`: **3/3 passed**
- `hyperframes-synthetic-title-card`: **3/3 passed**

The live gate also caught a rolling-deployment edge case: the undeployed
Next.js identity route returns a large framework 404 page. The final relay
closes that unused body before using the authenticated legacy-route fallback,
while the proof response remains strictly bounded and exact-matched. The full
six-trial suite passed after that correction.

Final review identified that owner lookup had not been included in the outer
render deadline. The exact candidate above uses one 30-second identity budget
across both routes, a 10-second Lambda connect budget, a 780-second Lambda read
budget, a 5-second transport margin, and an 830-second privileged drain.
Regression coverage pins both the total budget and the single shared identity
deadline.

The HyperFrames container also completed the repository's three-second dry-run
sample under the Lambda Runtime Interface Emulator and produced a valid MP4.

For live verification, only the dev HyperFrames function code was updated to
the synthesized CDK asset
`363e5311afd4f4191d9d8226b31b3454762942293057cca8355fb80f726303e9`
(`sha256:ec455be9c8f29f8a0e22eeb06c9a96b6acc830797d115de216cb428abf8fa143`).
A full stack deploy was deliberately not used because `cdk diff` showed
unrelated environment drift.

## Validation

- `bun run lint`
- `bun run typecheck`
- `bun run test:ci` — 530 suites / 4,900 tests passed
- `bun run build`
- agent eval coverage — 30 covered / 45 explicitly opted out
- complete agent-image Python suite — 423 passed / 1 skipped
- `bun run test:skill:hyperframes` — 49 passed
- HyperFrames Lambda handler suite — 24 passed
- `cd infra && bun run build`
- `bun run openapi:check`
- `bun run capabilities:check`
- `cd infra && bunx cdk synth AIStudio-AgentPlatformStack-Dev --context baseDomain=aistudio.psd401.ai`
- exact-image build gate — static checks, 16-second boot, signed canary passed
  in 3 seconds
- authenticated pre-push Playwright gate — 304 passed / 40 intentionally
  skipped / no retries or failures on the final clean run
- canonical live acceptance — TTS 3/3 and HyperFrames 3/3

## Checklist

- [x] No `console.*` calls added to production/shared code
- [x] No imports or usage of `@/lib/logger` in client components or client hooks
- [x] Client logging conventions unchanged
- [x] Lint passes
- [x] All tests pass
- [x] Types/interfaces follow project conventions
- [x] No `any` types or unjustified `as any` assertions added
- [x] Database conventions unchanged
- [x] TypeScript strict mode errors resolved
- [x] Environment variables handled securely; no new secret configuration
- [x] Documentation updated
- [x] Code reviewed and approved
- [x] App builds and runs without module errors

## Related Issues

Closes #1442
