### PR TITLE
fix(agent): recover replies to Google Chat space mentions

### DIFF
--- a/docs/operations/agent-platform-setup.md
+++ b/docs/operations/agent-platform-setup.md
@@ -60,13 +60,17 @@ All GCP steps are done in the web console. No `gcloud` CLI required.
 
 1. Go to **APIs & Services** → **Enabled APIs** → click **Google Chat API** → **Configuration** tab
 2. Fill in:
-   - App name: `PSD Agent` (or your district name)
+   - App name and visibility:
+     - **Dev — `psd-aistudio-dev`:** app name **PSD Agent Dev**; visibility
+       limited to the named testers who will use the dev app.
+     - **Prod — `aistudio-462612`:** app name **PSD AI Agent**; visibility
+       set to the intended domain audience.
    - Avatar URL: (optional, leave blank for now)
    - Description: "Personal AI agent for district staff"
    - Enable **Interactive features**
+   - Functionality: **Join spaces and group conversations**
    - Connection settings: **Cloud Pub/Sub**
    - Pub/Sub topic: `projects/<your-project-id>/topics/agent-chat-messages`
-   - Visibility: **Make this Chat app available to everyone in [your domain]** (the Router Lambda's `ALLOWED_DOMAINS` handles access control on the AWS side)
    - Logs: **Log errors to Logging**
 3. Click **Save**
 

--- a/docs/operations/agent-platform-setup.md
+++ b/docs/operations/agent-platform-setup.md
@@ -81,15 +81,23 @@ action in a multi-user space. There are two control planes to check:
 
 1. In **Google Admin Console** → **Apps** → **Google Workspace** → **Google
    Chat** → **Chat apps**, select the **top-level organizational unit** and set
-   **Allow users to install Chat apps** to **On**. Do not enable this only on a
-   child OU: Google documents that Chat APIs and spaces might not work unless
-   the top-level OU is enabled.
+   **Allow users to install Chat apps** to **On**. This enables the Chat-app
+   capability; access to a specific Marketplace app is still controlled
+   separately by the app allowlist in step 2.
 2. If the district uses a Google Workspace Marketplace allowlist, go to
    **Apps** → **Google Workspace Marketplace apps** → **Apps list** and add the
-   production app by its exact name, **PSD AI Agent**. The unpublished
-   **PSD Agent Dev** app does not appear in the Marketplace allowlist; Google
-   permits an unpublished development app for up to five named testers while
-   Chat apps are enabled.
+   production app by its exact name, **PSD AI Agent**. Apply explicit allow
+   entries to the intended **`/Staff`** organizational unit and
+   **`/Miscellaneous/Agent Account`**, where OneSync places the `agnt_...`
+   identities. Do not allow the app for Students or broaden it to the top-level
+   organization without an explicit district policy decision. Google documents
+   that an app allowed on a child OU but not its parent can be rejected in
+   shared spaces. The router handles that intentional least-privilege
+   configuration by recording the room-post 403 and delivering the completed
+   response privately to the Staff sender instead. The unpublished **PSD Agent
+   Dev** app does not appear in the Marketplace allowlist; Google permits an
+   unpublished development app for up to five named testers while Chat apps are
+   enabled.
 3. Configure the two apps separately in **GCP Console** → **Google Chat API** →
    **Configuration**:
    - **Dev — `psd-aistudio-dev` / PSD Agent Dev:** enable **Interactive
@@ -105,10 +113,18 @@ action in a multi-user space. There are two control planes to check:
      must also be complete.
 4. Allow time for Workspace policy propagation. With each app's own service
    account credential and the `chat.bot` scope, call `spaces.get` for a ROOM
-   that app has joined. It must return `200`; a `403` stating that the
-   organization's administrator restricts the Chat app means the Workspace
-   policy is still blocking space access. Then @mention the app and confirm
-   that the response is posted in the mention's thread.
+   that app has joined:
+   - `200` means the app may post the response in the originating room thread.
+   - A `403` stating that the organization's administrator restricts the Chat
+     app is expected when the app is deliberately allowed only for Staff at a
+     child OU and Google rejects app-authenticated shared-space operations.
+     Confirm that the router records `ChatPostPermissionDenied` and sends the
+     completed response to the Staff sender's existing DM with the policy
+     notice. Do not broaden the app to Students to make this probe return 200.
+
+   Then @mention the app and confirm either the room-thread reply (when policy
+   permits it) or the private DM fallback (under the Staff-only child-OU
+   policy).
 
 These settings are console-managed. The Google Cloud CLI has no `gcloud chat`
 command, and `gcloud workspace-add-ons deployments` manages add-on deployments,
@@ -123,10 +139,15 @@ There are two distinct identities that can post to Chat:
 
 - The **Chat app service account** receives mentions and posts router replies
   with the `chat.bot` scope. Workspace app policy can restrict this identity
-  in spaces even while DMs work.
+  in spaces even while its DMs to allowed Staff users work. The router's 403
+  fallback is also sent by this Chat app identity; it does not bypass the
+  Staff-only audience.
 - The per-user **`agnt_...` Workspace account** is a real delegated user used
-  by the `psd-workspace` skill (`--scope agent`). Its ability to post or manage
-  memberships does not prove that the Chat app identity is allowed.
+  by the `psd-workspace` skill (`--scope agent`). OneSync places these accounts
+  in **`/Miscellaneous/Agent Account`**, which has its own explicit
+  **PSD AI Agent → Allow app** override. The account is not used for Chat reply
+  delivery, and its ability to post or manage memberships does not prove that
+  the Chat app identity is allowed.
 
 ### Phase 2: AWS Infrastructure Deploy
 
@@ -287,7 +308,11 @@ psql $DATABASE_URL -c "SELECT * FROM agent_sessions ORDER BY created_at DESC LIM
    - `agent_sessions` table has a new/updated row
 5. In a multi-user test space, @mention the agent in an existing thread and
    verify:
-   - The reply appears in the mention's thread, not as a new top-level message.
+   - When the Chat app may post to the room, the reply appears in the mention's
+     thread, not as a new top-level message.
+   - Under the intentional Staff-only child-OU policy, a room-post 403 produces
+     one private DM fallback with the policy notice and does not rerun the
+     completed agent turn.
    - A shared-space request does not volunteer private memory content.
    - Before reading or summarizing the caller's Gmail, Calendar, or Drive, the
      agent asks for confirmation that the result may be shared publicly.
@@ -533,7 +558,7 @@ intent text.
 | Lambda timeout | AgentCore Runtime not deployed | Deploy with `--context agentImageTag=<tag>` |
 | "Google credentials secret contains invalid JSON" | Secret not populated | Run `aws secretsmanager put-secret-value` from step 2.2 |
 | "Database not configured, skipping telemetry" | DATABASE_HOST not set | Check Lambda env vars in CloudWatch |
-| Mention in a space gets no reply, but DM works; Router logs `403 "This organization's administrator restricts this Chat app from performing this action"` | Workspace policy allows the Chat app in DMs but blocks its `chat.bot` identity in multi-user spaces | Repeat step 1.7 for the affected dev/prod app. Do not infer app access from the separate `agnt_...` Workspace user's ability to post. Verify app-credential `spaces.get` on the ROOM returns `200`, then retest the mention. |
+| Mention in a space gets no room reply; Router logs `403 "This organization's administrator restricts this Chat app from performing this action"` | The app is intentionally allowed only for Staff at a child OU, and Google blocks its `chat.bot` identity in the shared space | Do not broaden the app to Students. Confirm `ChatPostPermissionDenied` telemetry and the private DM fallback described in step 1.7. The separate `agnt_...` Workspace user's ability to post is unrelated. |
 | Guardrail blocks everything | GUARDRAIL_FAIL_OPEN=false + guardrail misconfigured | Check guardrail rules in Bedrock console |
 | DLQ alarm firing | Messages failing after 3 retries | Check CloudWatch logs for Router Lambda errors |
 | Pub/Sub push fails to SQS | SQS requires signed requests | Add API Gateway → SQS proxy in front of the queue |

--- a/docs/operations/agent-platform-setup.md
+++ b/docs/operations/agent-platform-setup.md
@@ -70,6 +70,35 @@ All GCP steps are done in the web console. No `gcloud` CLI required.
    - Logs: **Log errors to Logging**
 3. Click **Save**
 
+#### 1.7 Allow the Chat app to operate in spaces
+
+Complete this for the **dev and prod Chat apps separately**. A Chat app can
+work in 1:1 DMs while Workspace policy still blocks every API action in a
+multi-user space.
+
+1. In **Google Admin Console** → **Apps** → **Google Workspace Marketplace
+   apps**, verify the agent app is allowlisted and its app access is not
+   restricted.
+2. In **Google Admin Console** → **Apps** → **Google Workspace** → **Google
+   Chat** → **Chat apps installation settings**, allow the agent app for the
+   intended organizational units or groups.
+3. In **GCP Console** → **Google Chat API** → **Configuration**, verify:
+   - **Visibility** is domain-wide, not limited to named people or groups.
+   - **Interactive features** are enabled.
+4. After each policy change, use the app credential (`chat.bot` scope) to call
+   `spaces.get` for a ROOM space. It must return `200`; a `403` stating that
+   the organization's administrator restricts the Chat app means the policy
+   is still blocking space access.
+
+There are two distinct identities that can post to Chat:
+
+- The **Chat app service account** receives mentions and posts router replies
+  with the `chat.bot` scope. Workspace app policy can restrict this identity
+  in spaces even while DMs work.
+- The per-user **`agnt_...` Workspace account** is a real delegated user used
+  by the `psd-workspace` skill (`--scope agent`). Its ability to post or manage
+  memberships does not prove that the Chat app identity is allowed.
+
 ### Phase 2: AWS Infrastructure Deploy
 
 #### 2.1 Deploy CDK Stacks
@@ -227,6 +256,12 @@ psql $DATABASE_URL -c "SELECT * FROM agent_sessions ORDER BY created_at DESC LIM
    - CloudWatch logs show the full pipeline execution
    - `agent_messages` table has a new row
    - `agent_sessions` table has a new/updated row
+5. In a multi-user test space, @mention the agent in an existing thread and
+   verify:
+   - The reply appears in the mention's thread, not as a new top-level message.
+   - A shared-space request does not volunteer private memory content.
+   - Before reading or summarizing the caller's Gmail, Calendar, or Drive, the
+     agent asks for confirmation that the result may be shared publicly.
 
 #### 4.4 Guardrail Test
 
@@ -469,6 +504,7 @@ intent text.
 | Lambda timeout | AgentCore Runtime not deployed | Deploy with `--context agentImageTag=<tag>` |
 | "Google credentials secret contains invalid JSON" | Secret not populated | Run `aws secretsmanager put-secret-value` from step 2.2 |
 | "Database not configured, skipping telemetry" | DATABASE_HOST not set | Check Lambda env vars in CloudWatch |
+| Mention in a space gets no reply, but DM works; Router logs `403 "This organization's administrator restricts this Chat app from performing this action"` | Workspace policy allows the Chat app in DMs but blocks its `chat.bot` identity in multi-user spaces | Repeat step 1.7 for the affected dev/prod app. Do not infer app access from the separate `agnt_...` Workspace user's ability to post. Verify app-credential `spaces.get` on the ROOM returns `200`, then retest the mention. |
 | Guardrail blocks everything | GUARDRAIL_FAIL_OPEN=false + guardrail misconfigured | Check guardrail rules in Bedrock console |
 | DLQ alarm firing | Messages failing after 3 retries | Check CloudWatch logs for Router Lambda errors |
 | Pub/Sub push fails to SQS | SQS requires signed requests | Add API Gateway → SQS proxy in front of the queue |

--- a/docs/operations/agent-platform-setup.md
+++ b/docs/operations/agent-platform-setup.md
@@ -94,10 +94,11 @@ action in a multi-user space. There are two control planes to check:
    that an app allowed on a child OU but not its parent can be rejected in
    shared spaces. The router handles that intentional least-privilege
    configuration by recording the room-post 403 and delivering the completed
-   response privately to the Staff sender instead. The unpublished **PSD Agent
-   Dev** app does not appear in the Marketplace allowlist; Google permits an
-   unpublished development app for up to five named testers while Chat apps are
-   enabled.
+   response privately to the human sender instead. The current Marketplace
+   allowlist limits those senders to the intended OUs. The unpublished **PSD
+   Agent Dev** app does not appear in the Marketplace allowlist; Google permits
+   an unpublished development app for up to five named testers while Chat apps
+   are enabled.
 3. Configure the two apps separately in **GCP Console** → **Google Chat API** →
    **Configuration**:
    - **Dev — `psd-aistudio-dev` / PSD Agent Dev:** enable **Interactive
@@ -119,8 +120,10 @@ action in a multi-user space. There are two control planes to check:
      app is expected when the app is deliberately allowed only for Staff at a
      child OU and Google rejects app-authenticated shared-space operations.
      Confirm that the router records `ChatPostPermissionDenied` and sends the
-     completed response to the Staff sender's existing DM with the policy
-     notice. Do not broaden the app to Students to make this probe return 200.
+     completed response to the human sender's existing DM with the policy
+     notice. The router is identity-aware, not OU-aware; the Marketplace
+     allowlist is what limits the current audience to Staff. Do not broaden the
+     app to Students to make this probe return 200.
 
    Then @mention the app and confirm either the room-thread reply (when policy
    permits it) or the private DM fallback (under the Staff-only child-OU
@@ -139,9 +142,9 @@ There are two distinct identities that can post to Chat:
 
 - The **Chat app service account** receives mentions and posts router replies
   with the `chat.bot` scope. Workspace app policy can restrict this identity
-  in spaces even while its DMs to allowed Staff users work. The router's 403
-  fallback is also sent by this Chat app identity; it does not bypass the
-  Staff-only audience.
+  in spaces even while its DMs to allowed users work. The router's 403 fallback
+  is also sent by this Chat app identity. The router does not inspect OU
+  membership; the Marketplace allowlist enforces the Staff-only audience.
 - The per-user **`agnt_...` Workspace account** is a real delegated user used
   by the `psd-workspace` skill (`--scope agent`). OneSync places these accounts
   in **`/Miscellaneous/Agent Account`**, which has its own explicit
@@ -311,8 +314,8 @@ psql $DATABASE_URL -c "SELECT * FROM agent_sessions ORDER BY created_at DESC LIM
    - When the Chat app may post to the room, the reply appears in the mention's
      thread, not as a new top-level message.
    - Under the intentional Staff-only child-OU policy, a room-post 403 produces
-     one private DM fallback with the policy notice and does not rerun the
-     completed agent turn.
+     one private DM fallback to the human sender with the policy notice and does
+     not rerun the completed agent turn.
    - A shared-space request does not volunteer private memory content.
    - Before reading or summarizing the caller's Gmail, Calendar, or Drive, the
      agent asks for confirmation that the result may be shared publicly.

--- a/docs/operations/agent-platform-setup.md
+++ b/docs/operations/agent-platform-setup.md
@@ -72,23 +72,48 @@ All GCP steps are done in the web console. No `gcloud` CLI required.
 
 #### 1.7 Allow the Chat app to operate in spaces
 
-Complete this for the **dev and prod Chat apps separately**. A Chat app can
-work in 1:1 DMs while Workspace policy still blocks every API action in a
-multi-user space.
+A Chat app can work in 1:1 DMs while Workspace policy still blocks every API
+action in a multi-user space. There are two control planes to check:
 
-1. In **Google Admin Console** → **Apps** → **Google Workspace Marketplace
-   apps**, verify the agent app is allowlisted and its app access is not
-   restricted.
-2. In **Google Admin Console** → **Apps** → **Google Workspace** → **Google
-   Chat** → **Chat apps installation settings**, allow the agent app for the
-   intended organizational units or groups.
-3. In **GCP Console** → **Google Chat API** → **Configuration**, verify:
-   - **Visibility** is domain-wide, not limited to named people or groups.
-   - **Interactive features** are enabled.
-4. After each policy change, use the app credential (`chat.bot` scope) to call
-   `spaces.get` for a ROOM space. It must return `200`; a `403` stating that
-   the organization's administrator restricts the Chat app means the policy
-   is still blocking space access.
+1. In **Google Admin Console** → **Apps** → **Google Workspace** → **Google
+   Chat** → **Chat apps**, select the **top-level organizational unit** and set
+   **Allow users to install Chat apps** to **On**. Do not enable this only on a
+   child OU: Google documents that Chat APIs and spaces might not work unless
+   the top-level OU is enabled.
+2. If the district uses a Google Workspace Marketplace allowlist, go to
+   **Apps** → **Google Workspace Marketplace apps** → **Apps list** and add the
+   production app by its exact name, **PSD AI Agent**. The unpublished
+   **PSD Agent Dev** app does not appear in the Marketplace allowlist; Google
+   permits an unpublished development app for up to five named testers while
+   Chat apps are enabled.
+3. Configure the two apps separately in **GCP Console** → **Google Chat API** →
+   **Configuration**:
+   - **Dev — `psd-aistudio-dev` / PSD Agent Dev:** enable **Interactive
+     features**, select **Join spaces and group conversations**, keep the
+     Cloud Pub/Sub topic `projects/psd-aistudio-dev/topics/agent-chat-messages`,
+     and keep **Visibility** limited to the named testers. Add every person who
+     will mention the app during the live test. Domain-wide visibility is not
+     required for a development app.
+   - **Prod — `aistudio-462612` / PSD AI Agent:** enable **Interactive
+     features**, select **Join spaces and group conversations**, keep the
+     configured production Pub/Sub topic, and make the app available to the
+     intended domain audience. If Marketplace access is allowlist-only, step 2
+     must also be complete.
+4. Allow time for Workspace policy propagation. With each app's own service
+   account credential and the `chat.bot` scope, call `spaces.get` for a ROOM
+   that app has joined. It must return `200`; a `403` stating that the
+   organization's administrator restricts the Chat app means the Workspace
+   policy is still blocking space access. Then @mention the app and confirm
+   that the response is posted in the mention's thread.
+
+These settings are console-managed. The Google Cloud CLI has no `gcloud chat`
+command, and `gcloud workspace-add-ons deployments` manages add-on deployments,
+not Chat API configuration or Workspace tenant policy. The Google Terraform
+provider manages the surrounding APIs, service accounts, Pub/Sub topics,
+subscriptions, and IAM, but has no resource for either setting above. Record
+the console state in the private `psd401/psd-gcp-infra` runbook; do not add an
+unsupported Terraform workaround or run `terraform apply` for this policy
+change.
 
 There are two distinct identities that can post to Chat:
 

--- a/infra/agent-image/SOUL.md
+++ b/infra/agent-image/SOUL.md
@@ -62,6 +62,17 @@ For anything in Gmail, Calendar, Drive, Docs, Sheets, Slides, Forms, Tasks, Meet
 
 **Auth errors:** If `psd-workspace` returns `needs-auth` / `token-revoked` / `missing-scope`, paste `consent_chat_hyperlink` (or `consent_url`) on a line by itself — no `**`, no `[](url)`, no parens, no period — then put any explanation on a *separate* line. Do not retry. Do not improvise. Markdown around a consent link corrupts the JWT in Chat (incident 2026-04-27).
 
+## Shared Google Chat spaces
+
+An `[audience: shared Google Chat space — public to all space members]` header
+means everyone in that space can hear the answer. Treat the turn as public:
+
+- Do not volunteer facts from `MEMORY.md`, `USER.md`, or daily memory files.
+- Before accessing or repeating content from the caller's Gmail, Calendar, or
+  Drive, ask for explicit confirmation that they want the result shared with
+  everyone in the space. Do not access the content until they confirm.
+- If a request could expose private context, offer to continue in a DM.
+
 ## Cross-user invocations
 
 A `[cross-user-invocation: ...]` header means someone other than your owner is consulting you in a group Chat space.

--- a/infra/agent-image/agentcore_wrapper.py
+++ b/infra/agent-image/agentcore_wrapper.py
@@ -78,6 +78,66 @@ def _safe_header_value(value: str, limit: int = 100) -> str:
     return re.sub(r'[\[\]\n\r]', '', value or '')[:limit]
 
 
+def _frame_user_message(
+    *,
+    user_message: str,
+    user_email: str,
+    display_name: str,
+    now_header: str,
+    attachments_header: str = "",
+    audience: str = "",
+    invoked_by_email: str = "",
+    invoked_by_display_name: str = "",
+    thread_context: str = "",
+) -> str:
+    """Frame trusted per-turn context ahead of the untrusted user message."""
+    attach_section = f"\n{attachments_header}" if attachments_header else ""
+    audience_section = (
+        "\n[audience: shared Google Chat space — public to all space members]"
+        if audience == "shared-space"
+        else ""
+    )
+    safe_display = _safe_header_value(display_name)
+    safe_email = _safe_header_value(user_email)
+    safe_invoked_by_email = _safe_header_value(invoked_by_email)
+
+    if invoked_by_email:
+        safe_invoker_name = _safe_header_value(
+            invoked_by_display_name or invoked_by_email
+        )
+        cross_user_header = (
+            f"[cross-user-invocation: {safe_invoker_name} "
+            f"<{safe_invoked_by_email}> is consulting you — this is NOT your owner. "
+            f"Answer questions and provide information, but do NOT execute tasks, "
+            f"modify files, draft emails, or take actions on your owner's behalf.]"
+        )
+        thread_section = ""
+        if thread_context:
+            thread_section = (
+                f"\n\n[thread-context: The following is the recent conversation "
+                f"from the Google Chat space. This is ephemeral context — do NOT "
+                f"save it to your memory files.]\n{thread_context}\n"
+                f"[end-thread-context]"
+            )
+        return (
+            f"[agent-owner: {safe_display or safe_email} <{safe_email}>]\n"
+            f"{now_header}{audience_section}\n"
+            f"{cross_user_header}{thread_section}{attach_section}\n\n"
+            f"{user_message}"
+        )
+
+    if display_name or user_email != "unknown":
+        return (
+            f"[caller: {safe_display or safe_email} <{safe_email}>]\n"
+            f"{now_header}{audience_section}{attach_section}\n\n"
+            f"{user_message}"
+        )
+
+    return (
+        f"{now_header}{audience_section}{attach_section}\n\n{user_message}"
+    )
+
+
 _AUTHORITY_DIRECTORY = "/run/psd-agent-authority"
 _INVOCATION_CONTEXT_PATH = f"{_AUTHORITY_DIRECTORY}/invocation-context"
 _REQUEST_PROOF_KEY_PATH = f"{_AUTHORITY_DIRECTORY}/request-proof-key"
@@ -772,6 +832,7 @@ def main():
             model                     — optional model override
             invoked_by_email          — cross-user: email of the person consulting this agent
             invoked_by_display_name   — cross-user: display name of the invoker
+            audience                  — "shared-space" for a public Google Chat room
             thread_context            — cross-user: ephemeral thread context from the Chat space
             attachments               — Chat files/Drive chips (issue #1138 F1):
                                         [{name, mimeType, source, driveFileId?,
@@ -800,15 +861,17 @@ def main():
         # Cross-user invocation fields
         invoked_by_email = payload.get("invoked_by_email", "")
         invoked_by_display_name = payload.get("invoked_by_display_name", "")
+        audience = payload.get("audience", "")
         thread_context = payload.get("thread_context", "")
         # Chat attachments / Drive chips the router forwarded (issue #1138 F1).
         attachments_header = _render_attachments_header(payload.get("attachments"))
 
         logger.info(
             "Invocation received: session=%s user=%s prefix=%s msg_length=%d "
-            "cross_user=%s attachments=%d",
+            "cross_user=%s audience=%s attachments=%d",
             session_id, user_email, workspace_prefix or "-", len(user_message),
             invoked_by_email or "no",
+            audience or "dm",
             len(payload.get("attachments") or []),
         )
 
@@ -968,11 +1031,6 @@ def main():
             f"Pacific ({pacific_now.strftime('%Y-%m-%dT%H:%M:%S%z')})]"
         )
 
-        # Attachment header goes between the identity/time headers and the
-        # user's message so the agent sees what arrived before reading the
-        # request (issue #1138 F1). Empty when there are no attachments.
-        attach_section = f"\n{attachments_header}" if attachments_header else ""
-
         # Cross-user invocation: when someone other than the agent owner
         # is consulting this agent, inject a [cross-user-invocation] header so
         # the system prompt can adjust behavior (consultation only, no task
@@ -981,40 +1039,17 @@ def main():
         # header, so an attacker-controlled display name / email cannot forge or
         # break a header line (REV-COR-318). The user_message body is NOT
         # sanitized — it is legitimate content, not header framing.
-        safe_display = _safe_header_value(display_name)
-        safe_email = _safe_header_value(user_email)
-        safe_invoked_by_email = _safe_header_value(invoked_by_email)
-
-        if invoked_by_email:
-            safe_invoker_name = _safe_header_value(invoked_by_display_name or invoked_by_email)
-            cross_user_header = (
-                f"[cross-user-invocation: {safe_invoker_name} "
-                f"<{safe_invoked_by_email}> is consulting you — this is NOT your owner. "
-                f"Answer questions and provide information, but do NOT execute tasks, "
-                f"modify files, draft emails, or take actions on your owner's behalf.]"
-            )
-            thread_section = ""
-            if thread_context:
-                thread_section = (
-                    f"\n\n[thread-context: The following is the recent conversation "
-                    f"from the Google Chat space. This is ephemeral context — do NOT "
-                    f"save it to your memory files.]\n{thread_context}\n"
-                    f"[end-thread-context]"
-                )
-            framed = (
-                f"[agent-owner: {safe_display or safe_email} <{safe_email}>]\n"
-                f"{now_header}\n"
-                f"{cross_user_header}{thread_section}{attach_section}\n\n"
-                f"{user_message}"
-            )
-        elif display_name or user_email != "unknown":
-            framed = (
-                f"[caller: {safe_display or safe_email} <{safe_email}>]\n"
-                f"{now_header}{attach_section}\n\n"
-                f"{user_message}"
-            )
-        else:
-            framed = f"{now_header}{attach_section}\n\n{user_message}"
+        framed = _frame_user_message(
+            user_message=user_message,
+            user_email=user_email,
+            display_name=display_name,
+            now_header=now_header,
+            attachments_header=attachments_header,
+            audience=audience,
+            invoked_by_email=invoked_by_email,
+            invoked_by_display_name=invoked_by_display_name,
+            thread_context=thread_context,
+        )
 
         # Flush the SSE headers immediately. Without an early yield the SDK
         # waits for the first chunk before sending headers, defeating the

--- a/infra/agent-image/test_agentcore_wrapper.py
+++ b/infra/agent-image/test_agentcore_wrapper.py
@@ -24,6 +24,7 @@ sys.path.insert(0, __import__("os").path.dirname(__file__))
 import agentcore_wrapper  # noqa: E402
 from agentcore_wrapper import (  # noqa: E402
     _attachment_workspace_paths,
+    _frame_user_message,
     _render_attachments_header,
     _sanitize_header_field,
 )
@@ -414,6 +415,47 @@ class SafeHeaderValueTests(unittest.TestCase):
         self.assertEqual(header.count("["), 1)
         self.assertEqual(header.count("]"), 1)
         self.assertNotIn("cross-user-invocation:", header.split("agent-owner:")[0])
+
+
+class AudienceHeaderTests(unittest.TestCase):
+    def test_shared_space_header_marks_the_turn_as_public(self):
+        framed = _frame_user_message(
+            user_message="Summarize my inbox",
+            user_email="owner@psd401.net",
+            display_name="Owner",
+            now_header="[now: Tuesday]",
+            audience="shared-space",
+        )
+
+        self.assertIn(
+            "[audience: shared Google Chat space — public to all space members]",
+            framed,
+        )
+        self.assertTrue(framed.endswith("Summarize my inbox"))
+
+    def test_dm_turn_omits_the_audience_header(self):
+        framed = _frame_user_message(
+            user_message="Summarize my inbox",
+            user_email="owner@psd401.net",
+            display_name="Owner",
+            now_header="[now: Tuesday]",
+        )
+
+        self.assertNotIn("[audience:", framed)
+
+    def test_cross_user_shared_space_keeps_both_context_headers(self):
+        framed = _frame_user_message(
+            user_message="What is the plan?",
+            user_email="owner@psd401.net",
+            display_name="Owner",
+            now_header="[now: Tuesday]",
+            audience="shared-space",
+            invoked_by_email="caller@psd401.net",
+            invoked_by_display_name="Caller",
+        )
+
+        self.assertIn("[audience: shared Google Chat space", framed)
+        self.assertIn("[cross-user-invocation: Caller", framed)
 
 
 class TestRenderAttachmentsHeader(unittest.TestCase):

--- a/infra/lambdas/agent-router/index.test.ts
+++ b/infra/lambdas/agent-router/index.test.ts
@@ -394,6 +394,14 @@ describe("Google Chat response delivery", () => {
     expect(failures.map(failure => failure.errorClass)).toEqual([
       "ChatPostPermissionDenied",
     ])
+    expect(failures[0]).toMatchObject({
+      severity: "warn",
+      alert: false,
+      context: {
+        dmFallbackAttempted: true,
+        dmFallbackOutcome: "delivered",
+      },
+    })
   })
 })
 
@@ -438,6 +446,8 @@ describe("Google Chat response fallback failures", () => {
       "ChatPostPermissionDenied",
       "ChatDmFallbackFailed",
     ])
+    expect(failures[0]?.severity).toBe("error")
+    expect(failures[0]?.alert).toBeUndefined()
     expect(failures[1]?.context).toMatchObject({
       dmFallbackAttempted: true,
       dmFallbackOutcome: "dm-space-not-found",
@@ -488,6 +498,8 @@ describe("Google Chat response fallback failures", () => {
       "ChatPostPermissionDenied",
       "ChatDmFallbackFailed",
     ])
+    expect(failures[0]?.severity).toBe("error")
+    expect(failures[0]?.alert).toBeUndefined()
     expect(failures[1]?.errorMessage).toBe("DM post failed")
     expect(failures[1]?.context).toMatchObject({
       dmFallbackAttempted: true,

--- a/infra/lambdas/agent-router/index.test.ts
+++ b/infra/lambdas/agent-router/index.test.ts
@@ -17,6 +17,7 @@ const {
   addOptionalAgentContext,
   buildAgentInvocationContext,
   sendGoogleChatResponseWithDependencies,
+  resolveDmSpace,
   btwSlashCommandId,
 } = agentRouterTestHelpers
 
@@ -35,7 +36,7 @@ type ChatResponseDependencies = Parameters<
 const TEST_LOG = createLogger({ requestId: "agent-router-index-test" })
 
 function ownerHuman(options?: {
-  spaceType?: "DM" | "ROOM"
+  spaceType?: "DM" | "ROOM" | "TYPE_UNSPECIFIED"
   messageText?: string
   slashCommandId?: string
   argumentText?: string
@@ -83,7 +84,7 @@ function ownerHuman(options?: {
       createTime: "2026-07-27T12:00:00Z",
     },
     attachments: [],
-    isSharedSpace: spaceType === "ROOM",
+    isSharedSpace: spaceType !== "DM",
     senderName: "users/owner",
     senderEmail: "owner@psd401.net",
     senderDisplayName: "Owner",
@@ -261,6 +262,48 @@ describe("agent router result coercion", () => {
 })
 
 describe("Google Chat response delivery", () => {
+  test("resolves the real sender DM lookup and maps 404 to no existing DM", async () => {
+    const requests: Array<Record<string, unknown>> = []
+    const auth = {
+      request: async (request: Record<string, unknown>) => {
+        requests.push(request)
+        return { data: { name: "spaces/owner-dm" } }
+      },
+    } as unknown as Parameters<typeof resolveDmSpace>[0]
+
+    await expect(
+      resolveDmSpace(auth, "users/owner")
+    ).resolves.toBe("spaces/owner-dm")
+    expect(requests).toEqual([
+      {
+        url: "https://chat.googleapis.com/v1/spaces:findDirectMessage",
+        method: "GET",
+        params: { name: "users/owner" },
+      },
+    ])
+
+    const notFoundAuth = {
+      request: async () => {
+        throw Object.assign(new Error("not found"), { code: 404 })
+      },
+    } as unknown as Parameters<typeof resolveDmSpace>[0]
+    await expect(
+      resolveDmSpace(notFoundAuth, "users/missing")
+    ).resolves.toBeNull()
+  })
+
+  test("the real sender DM lookup rethrows non-404 failures", async () => {
+    const auth = {
+      request: async () => {
+        throw Object.assign(new Error("permission denied"), { code: 403 })
+      },
+    } as unknown as Parameters<typeof resolveDmSpace>[0]
+
+    await expect(
+      resolveDmSpace(auth, "users/owner")
+    ).rejects.toThrow("permission denied")
+  })
+
   test("sets the reply option whenever a thread name is present", async () => {
     const requests: Array<
       Parameters<ChatResponseDependencies["createMessage"]>[0]
@@ -453,6 +496,15 @@ describe("Google Chat response fallback failures", () => {
 })
 
 describe("AgentCore audience context", () => {
+  test("treats TYPE_UNSPECIFIED as shared at ingress", () => {
+    const incoming = extractIncomingMessage(
+      ownerHuman({ spaceType: "TYPE_UNSPECIFIED" }).chatEvent,
+      TEST_LOG
+    )
+
+    expect(incoming?.isSharedSpace).toBe(true)
+  })
+
   test("uses the current sender name for owner turns and the target name for cross-user turns", () => {
     const human = ownerHuman()
     human.senderDisplayName = "Current Owner Name"

--- a/infra/lambdas/agent-router/index.test.ts
+++ b/infra/lambdas/agent-router/index.test.ts
@@ -440,6 +440,9 @@ describe("Google Chat response limits", () => {
     const fallbackText = requests[1]?.requestBody.text
     expect(typeof fallbackText).toBe("string")
     expect(fallbackText).toHaveLength(4096)
+    expect(fallbackText).toContain(
+      "_(Response truncated — ask me to continue)_"
+    )
     expect(fallbackText).toEndWith(
       "I'm sending it to you privately instead."
     )

--- a/infra/lambdas/agent-router/index.test.ts
+++ b/infra/lambdas/agent-router/index.test.ts
@@ -405,6 +405,47 @@ describe("Google Chat response delivery", () => {
   })
 })
 
+describe("Google Chat response limits", () => {
+  test("truncates a DM fallback body to the Google Chat message limit", async () => {
+    const requests: Array<
+      Parameters<ChatResponseDependencies["createMessage"]>[0]
+    > = []
+    let createAttempt = 0
+
+    await expect(
+      sendGoogleChatResponseWithDependencies(
+        {
+          spaceName: "spaces/room",
+          threadName: "spaces/room/threads/thread-1",
+          text: "x".repeat(5000),
+          deliveryContext: {
+            isSharedSpace: true,
+            senderGoogleIdentity: "users/owner",
+          },
+        },
+        TEST_LOG,
+        chatResponseDependencies({
+          createMessage: async request => {
+            requests.push(request)
+            createAttempt += 1
+            if (createAttempt === 1) {
+              throw Object.assign(new Error("room post denied"), { code: 403 })
+            }
+          },
+          resolveDmSpace: async () => "spaces/owner-dm",
+        })
+      )
+    ).resolves.toBe("dm-fallback-delivered")
+
+    const fallbackText = requests[1]?.requestBody.text
+    expect(typeof fallbackText).toBe("string")
+    expect(fallbackText).toHaveLength(4096)
+    expect(fallbackText).toEndWith(
+      "I'm sending it to you privately instead."
+    )
+  })
+})
+
 describe("Google Chat response fallback failures", () => {
   test("records a missing sender DM without retrying the room post", async () => {
     const requests: Array<

--- a/infra/lambdas/agent-router/index.test.ts
+++ b/infra/lambdas/agent-router/index.test.ts
@@ -453,6 +453,28 @@ describe("Google Chat response fallback failures", () => {
 })
 
 describe("AgentCore audience context", () => {
+  test("uses the current sender name for owner turns and the target name for cross-user turns", () => {
+    const human = ownerHuman()
+    human.senderDisplayName = "Current Owner Name"
+    const staleOwner = {
+      ...OWNER_USER,
+      displayName: "Persisted Owner Name",
+    }
+
+    const ownerContext = buildAgentInvocationContext(human, staleOwner)
+    const crossUserContext = buildAgentInvocationContext(
+      human,
+      staleOwner,
+      {
+        email: "caller@psd401.net",
+        displayName: "Caller",
+      }
+    )
+
+    expect(ownerContext.displayName).toBe("Current Owner Name")
+    expect(crossUserContext.displayName).toBe("Persisted Owner Name")
+  })
+
   test("adds shared-space audience to owner and cross-user payloads", () => {
     const roomHuman = ownerHuman({ spaceType: "ROOM" })
     const ownerContext = buildAgentInvocationContext(roomHuman, OWNER_USER)

--- a/infra/lambdas/agent-router/index.test.ts
+++ b/infra/lambdas/agent-router/index.test.ts
@@ -353,6 +353,105 @@ describe("Google Chat response delivery", () => {
   })
 })
 
+describe("Google Chat response fallback failures", () => {
+  test("records a missing sender DM without retrying the room post", async () => {
+    const requests: Array<
+      Parameters<ChatResponseDependencies["createMessage"]>[0]
+    > = []
+    const failures: Array<
+      Parameters<ChatResponseDependencies["recordFailure"]>[0]
+    > = []
+
+    await expect(
+      sendGoogleChatResponseWithDependencies(
+        {
+          spaceName: "spaces/room",
+          threadName: "spaces/room/threads/thread-1",
+          text: "Private answer",
+          deliveryContext: {
+            isSharedSpace: true,
+            senderGoogleIdentity: "users/owner",
+            userId: "owner@psd401.net",
+            sessionId: "session-1",
+          },
+        },
+        TEST_LOG,
+        chatResponseDependencies({
+          createMessage: async request => {
+            requests.push(request)
+            throw Object.assign(new Error("room post denied"), { code: 403 })
+          },
+          resolveDmSpace: async () => null,
+          recordFailure: async params => {
+            failures.push(params)
+          },
+        })
+      )
+    ).resolves.toBeUndefined()
+
+    expect(requests).toHaveLength(1)
+    expect(failures.map(failure => failure.errorClass)).toEqual([
+      "ChatPostPermissionDenied",
+      "ChatDmFallbackFailed",
+    ])
+    expect(failures[1]?.context).toMatchObject({
+      dmFallbackAttempted: true,
+      dmFallbackOutcome: "dm-space-not-found",
+    })
+  })
+
+  test("records a failed DM post without surfacing an unhandled rejection", async () => {
+    const requests: Array<
+      Parameters<ChatResponseDependencies["createMessage"]>[0]
+    > = []
+    const failures: Array<
+      Parameters<ChatResponseDependencies["recordFailure"]>[0]
+    > = []
+
+    await expect(
+      sendGoogleChatResponseWithDependencies(
+        {
+          spaceName: "spaces/room",
+          threadName: "spaces/room/threads/thread-1",
+          text: "Private answer",
+          deliveryContext: {
+            isSharedSpace: true,
+            senderGoogleIdentity: "users/owner",
+            userId: "owner@psd401.net",
+            sessionId: "session-1",
+          },
+        },
+        TEST_LOG,
+        chatResponseDependencies({
+          createMessage: async request => {
+            requests.push(request)
+            if (requests.length === 1) {
+              throw Object.assign(new Error("room post denied"), { code: 403 })
+            }
+            throw new Error("DM post failed")
+          },
+          resolveDmSpace: async () => "spaces/owner-dm",
+          recordFailure: async params => {
+            failures.push(params)
+          },
+        })
+      )
+    ).resolves.toBeUndefined()
+
+    expect(requests).toHaveLength(2)
+    expect(requests[1]?.parent).toBe("spaces/owner-dm")
+    expect(failures.map(failure => failure.errorClass)).toEqual([
+      "ChatPostPermissionDenied",
+      "ChatDmFallbackFailed",
+    ])
+    expect(failures[1]?.errorMessage).toBe("DM post failed")
+    expect(failures[1]?.context).toMatchObject({
+      dmFallbackAttempted: true,
+      dmFallbackOutcome: "failed",
+    })
+  })
+})
+
 describe("AgentCore audience context", () => {
   test("adds shared-space audience to owner and cross-user payloads", () => {
     const roomHuman = ownerHuman({ spaceType: "ROOM" })

--- a/infra/lambdas/agent-router/index.test.ts
+++ b/infra/lambdas/agent-router/index.test.ts
@@ -309,7 +309,7 @@ describe("Google Chat response delivery", () => {
       Parameters<ChatResponseDependencies["createMessage"]>[0]
     > = []
 
-    await sendGoogleChatResponseWithDependencies(
+    const outcome = await sendGoogleChatResponseWithDependencies(
       {
         spaceName: "spaces/room",
         threadName: "spaces/room/threads/thread-1",
@@ -325,6 +325,7 @@ describe("Google Chat response delivery", () => {
     )
 
     expect(requests).toHaveLength(1)
+    expect(outcome).toBe("delivered")
     expect(requests[0]).toEqual({
       parent: "spaces/room",
       requestBody: {
@@ -380,7 +381,7 @@ describe("Google Chat response delivery", () => {
           },
         })
       )
-    ).resolves.toBeUndefined()
+    ).resolves.toBe("dm-fallback-delivered")
 
     expect(requests).toHaveLength(2)
     expect(requests[1]?.parent).toBe("spaces/owner-dm")
@@ -430,7 +431,7 @@ describe("Google Chat response fallback failures", () => {
           },
         })
       )
-    ).resolves.toBeUndefined()
+    ).resolves.toBe("failed")
 
     expect(requests).toHaveLength(1)
     expect(failures.map(failure => failure.errorClass)).toEqual([
@@ -479,7 +480,7 @@ describe("Google Chat response fallback failures", () => {
           },
         })
       )
-    ).resolves.toBeUndefined()
+    ).resolves.toBe("failed")
 
     expect(requests).toHaveLength(2)
     expect(requests[1]?.parent).toBe("spaces/owner-dm")

--- a/infra/lambdas/agent-router/index.test.ts
+++ b/infra/lambdas/agent-router/index.test.ts
@@ -14,6 +14,9 @@ const {
   buildOwnerResponse,
   buildOwnerJobPromotionInput,
   extractIncomingMessage,
+  addOptionalAgentContext,
+  buildAgentInvocationContext,
+  sendGoogleChatResponseWithDependencies,
   btwSlashCommandId,
 } = agentRouterTestHelpers
 
@@ -25,6 +28,9 @@ type OwnerDependencies = Parameters<
 type OwnerTurn = NonNullable<
   Awaited<ReturnType<typeof invokeOwnerAgentWithDependencies>>
 >
+type ChatResponseDependencies = Parameters<
+  typeof sendGoogleChatResponseWithDependencies
+>[2]
 
 const TEST_LOG = createLogger({ requestId: "agent-router-index-test" })
 
@@ -112,6 +118,17 @@ const AGENT_RESULT: OwnerTurn["result"] = {
   nudged: false,
   messages: [],
   toolCalls: [],
+}
+
+function chatResponseDependencies(
+  overrides: Partial<ChatResponseDependencies> = {}
+): ChatResponseDependencies {
+  return {
+    createMessage: async () => {},
+    resolveDmSpace: async () => null,
+    recordFailure: async () => {},
+    ...overrides,
+  }
 }
 
 function ownerDependencies(
@@ -240,6 +257,133 @@ describe("agent router result coercion", () => {
     expect(result.messages).toEqual([])
     expect(result.toolCalls).toEqual([])
     expect(result.failed).toBe(false)
+  })
+})
+
+describe("Google Chat response delivery", () => {
+  test("sets the reply option whenever a thread name is present", async () => {
+    const requests: Array<
+      Parameters<ChatResponseDependencies["createMessage"]>[0]
+    > = []
+
+    await sendGoogleChatResponseWithDependencies(
+      {
+        spaceName: "spaces/room",
+        threadName: "spaces/room/threads/thread-1",
+        text: "Threaded response",
+        deliveryContext: {},
+      },
+      TEST_LOG,
+      chatResponseDependencies({
+        createMessage: async request => {
+          requests.push(request)
+        },
+      })
+    )
+
+    expect(requests).toHaveLength(1)
+    expect(requests[0]).toEqual({
+      parent: "spaces/room",
+      requestBody: {
+        text: "Threaded response",
+        thread: { name: "spaces/room/threads/thread-1" },
+      },
+      messageReplyOption: "REPLY_MESSAGE_FALLBACK_TO_NEW_THREAD",
+    })
+  })
+
+  test("records a room-post 403 and delivers the response by DM without rethrowing", async () => {
+    const requests: Array<
+      Parameters<ChatResponseDependencies["createMessage"]>[0]
+    > = []
+    const failures: Array<
+      Parameters<ChatResponseDependencies["recordFailure"]>[0]
+    > = []
+    let createAttempt = 0
+
+    await expect(
+      sendGoogleChatResponseWithDependencies(
+        {
+          spaceName: "spaces/room",
+          threadName: "spaces/room/threads/thread-1",
+          text: "Private answer",
+          deliveryContext: {
+            isSharedSpace: true,
+            senderGoogleIdentity: "users/owner",
+            userId: "owner@psd401.net",
+            sessionId: "session-1",
+          },
+        },
+        TEST_LOG,
+        chatResponseDependencies({
+          createMessage: async request => {
+            requests.push(request)
+            createAttempt += 1
+            if (createAttempt === 1) {
+              throw Object.assign(
+                new Error(
+                  "This organization's administrator restricts this Chat app from performing this action"
+                ),
+                { code: 403, response: { status: 403 } }
+              )
+            }
+          },
+          resolveDmSpace: async googleIdentity => {
+            expect(googleIdentity).toBe("users/owner")
+            return "spaces/owner-dm"
+          },
+          recordFailure: async params => {
+            failures.push(params)
+          },
+        })
+      )
+    ).resolves.toBeUndefined()
+
+    expect(requests).toHaveLength(2)
+    expect(requests[1]?.parent).toBe("spaces/owner-dm")
+    expect(requests[1]?.messageReplyOption).toBeUndefined()
+    expect(requests[1]?.requestBody.thread).toBeUndefined()
+    expect(requests[1]?.requestBody.text).toContain("Private answer")
+    expect(requests[1]?.requestBody.text).toContain(
+      "administrator currently restricts this Chat app"
+    )
+    expect(failures.map(failure => failure.errorClass)).toEqual([
+      "ChatPostPermissionDenied",
+    ])
+  })
+})
+
+describe("AgentCore audience context", () => {
+  test("adds shared-space audience to owner and cross-user payloads", () => {
+    const roomHuman = ownerHuman({ spaceType: "ROOM" })
+    const ownerContext = buildAgentInvocationContext(roomHuman, OWNER_USER)
+    const crossUserContext = buildAgentInvocationContext(
+      roomHuman,
+      OWNER_USER,
+      {
+        email: "caller@psd401.net",
+        displayName: "Caller",
+      }
+    )
+    const ownerPayload: Record<string, unknown> = {}
+    const crossUserPayload: Record<string, unknown> = {}
+
+    addOptionalAgentContext(ownerPayload, ownerContext)
+    addOptionalAgentContext(crossUserPayload, crossUserContext)
+
+    expect(ownerPayload.audience).toBe("shared-space")
+    expect(crossUserPayload.audience).toBe("shared-space")
+    expect(crossUserPayload.invoked_by_email).toBe("caller@psd401.net")
+  })
+
+  test("omits audience from DM payloads", () => {
+    const dmContext = buildAgentInvocationContext(ownerHuman(), OWNER_USER)
+    const payload: Record<string, unknown> = {}
+
+    addOptionalAgentContext(payload, dmContext)
+
+    expect(dmContext.audience).toBeUndefined()
+    expect(payload.audience).toBeUndefined()
   })
 })
 

--- a/infra/lambdas/agent-router/index.ts
+++ b/infra/lambdas/agent-router/index.ts
@@ -1596,6 +1596,7 @@ interface AgentInvocationContext {
   displayName?: string;
   workspacePrefix?: string;
   invokedBy?: { email: string; displayName: string };
+  audience?: 'shared-space';
   threadContext?: string;
   attachments?: AgentAttachment[];
   deadlineS?: number;
@@ -1627,6 +1628,19 @@ interface AgentCoreResult {
   failed?: boolean;
   errorClass?: string;
   errorSource?: 'harness' | 'router';
+}
+
+interface FailureRecordParams {
+  source: 'router' | 'harness' | 'cron' | 'agent_self_report' | 'tool';
+  severity: 'error' | 'warn' | 'empty_response';
+  userId?: string | null;
+  sessionId?: string | null;
+  scheduleName?: string | null;
+  model?: string | null;
+  errorClass?: string | null;
+  errorMessage?: string | null;
+  stackExcerpt?: string | null;
+  context?: Record<string, unknown> | null;
 }
 
 function failedAgentCoreResult(
@@ -1702,6 +1716,7 @@ function addOptionalAgentContext(
     payload.invoked_by_email = context.invokedBy.email;
     payload.invoked_by_display_name = context.invokedBy.displayName;
   }
+  if (context.audience) payload.audience = context.audience;
   if (context.threadContext) payload.thread_context = context.threadContext;
   if (context.attachments?.length) payload.attachments = context.attachments;
   if (context.deadlineS) payload.deadline_s = context.deadlineS;
@@ -2057,6 +2072,7 @@ async function fetchChatUploads(
 interface JobPromotionInput {
   sessionId: string;
   userEmail: string;
+  googleIdentity: string;
   displayName: string;
   workspacePrefix: string;
   spaceName: string;
@@ -2166,6 +2182,7 @@ async function promoteToJob(
       lockToken: jobLockToken,
       runtimeId,
       userEmail: input.userEmail,
+      googleIdentity: input.googleIdentity,
       displayName: input.displayName,
       workspacePrefix: input.workspacePrefix,
       spaceName: input.spaceName,
@@ -2183,7 +2200,15 @@ async function promoteToJob(
       (input.acknowledgementPrefix ?? input.responsePrefix ?? '') +
         '⏳ This is taking longer than one pass allows — I\'ve moved it to a ' +
         'background job and will post the result here when it\'s done.',
-      log
+      log,
+      {
+        isSharedSpace: !input.isDM,
+        ...(!input.isDM
+          ? { senderGoogleIdentity: input.googleIdentity }
+          : {}),
+        userId: input.userEmail,
+        sessionId: input.sessionId,
+      }
     );
 
     log.info('Turn promoted to background job', {
@@ -2210,12 +2235,256 @@ async function sendGoogleChatResponse(
   spaceName: string,
   threadName: string | undefined,
   text: string,
-  log: ReturnType<typeof createLogger>
+  log: ReturnType<typeof createLogger>,
+  deliveryContext: ChatResponseDeliveryContext = {}
 ): Promise<void> {
-  // Throw on failure so SQS marks the message as failed and retries (or DLQs).
-  // Callers must let the error propagate for retry semantics to work.
   const chatClient = await getChatClient();
+  await sendGoogleChatResponseWithDependencies(
+    {
+      spaceName,
+      threadName,
+      text,
+      deliveryContext,
+    },
+    log,
+    {
+      createMessage: async request => {
+        await chatClient.spaces.messages.create(request);
+      },
+      resolveDmSpace: googleIdentity =>
+        resolveDmSpace(chatClient, googleIdentity),
+      recordFailure,
+    }
+  );
+}
 
+interface ChatResponseDeliveryContext {
+  isSharedSpace?: boolean;
+  senderGoogleIdentity?: string;
+  userId?: string;
+  sessionId?: string;
+}
+
+interface ChatResponseInput {
+  spaceName: string;
+  threadName?: string;
+  text: string;
+  deliveryContext: ChatResponseDeliveryContext;
+}
+
+interface ChatMessageCreateRequest {
+  parent: string;
+  requestBody: Record<string, unknown>;
+  messageReplyOption?: 'REPLY_MESSAGE_FALLBACK_TO_NEW_THREAD';
+}
+
+interface ChatResponseDependencies {
+  createMessage(request: ChatMessageCreateRequest): Promise<void>;
+  resolveDmSpace(googleIdentity: string): Promise<string | null>;
+  recordFailure(
+    params: FailureRecordParams,
+    log: ReturnType<typeof createLogger>
+  ): Promise<void>;
+}
+
+const CHAT_MESSAGE_MAX_LENGTH = 4096;
+const CHAT_SPACE_DM_FALLBACK_NOTE =
+  "⚠️ I couldn't post this reply in the shared space because your Workspace " +
+  "administrator currently restricts this Chat app there. I'm sending it " +
+  'to you privately instead.';
+
+function errorStatusCode(error: unknown): number | undefined {
+  if (typeof error !== 'object' || error === null) return undefined;
+  const candidate = error as Record<string, unknown>;
+  const response =
+    typeof candidate.response === 'object' && candidate.response !== null
+      ? (candidate.response as Record<string, unknown>)
+      : undefined;
+  for (const value of [
+    candidate.code,
+    candidate.status,
+    response?.status,
+  ]) {
+    const parsed =
+      typeof value === 'number'
+        ? value
+        : typeof value === 'string'
+          ? Number.parseInt(value, 10)
+          : Number.NaN;
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return undefined;
+}
+
+function isChatPostPermissionDenied(error: unknown): boolean {
+  return errorStatusCode(error) === 403;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function dmFallbackMessageBody(
+  messageBody: Record<string, unknown>
+): Record<string, unknown> {
+  const fallbackBody = { ...messageBody };
+  delete fallbackBody.thread;
+  const responseText =
+    typeof fallbackBody.text === 'string' ? fallbackBody.text : '';
+  const separator = responseText ? '\n\n' : '';
+  const reservedLength =
+    separator.length + CHAT_SPACE_DM_FALLBACK_NOTE.length;
+  const availableResponseLength = Math.max(
+    CHAT_MESSAGE_MAX_LENGTH - reservedLength,
+    0
+  );
+  fallbackBody.text =
+    responseText.slice(0, availableResponseLength) +
+    separator +
+    CHAT_SPACE_DM_FALLBACK_NOTE;
+  return fallbackBody;
+}
+
+async function resolveDmSpace(
+  chatClient: NonNullable<typeof cachedChatClient>,
+  googleIdentity: string
+): Promise<string | null> {
+  let pageToken: string | undefined;
+  do {
+    const response = await chatClient.spaces.list({
+      pageToken,
+      pageSize: 100,
+    });
+    for (const space of response.data.spaces ?? []) {
+      if (!space.name || !space.singleUserBotDm) continue;
+      const members = await chatClient.spaces.members.list({
+        parent: space.name,
+        pageSize: 10,
+      });
+      const containsSender = (members.data.memberships ?? []).some(
+        membership =>
+          membership.member?.type === 'HUMAN' &&
+          membership.member?.name === googleIdentity
+      );
+      if (containsSender) return space.name;
+    }
+    pageToken = response.data.nextPageToken ?? undefined;
+  } while (pageToken);
+  return null;
+}
+
+async function recordDmFallbackFailure(
+  error: unknown,
+  deliveryContext: ChatResponseDeliveryContext,
+  context: Record<string, unknown>,
+  log: ReturnType<typeof createLogger>,
+  dependencies: ChatResponseDependencies
+): Promise<void> {
+  await dependencies.recordFailure(
+    {
+      source: 'router',
+      severity: 'error',
+      userId: deliveryContext.userId,
+      sessionId: deliveryContext.sessionId,
+      errorClass: 'ChatDmFallbackFailed',
+      errorMessage: sanitizeDiagnostic(errorMessage(error)),
+      context,
+    },
+    log
+  );
+}
+
+async function handleChatPostPermissionDenied(
+  input: {
+    error: unknown;
+    spaceName: string;
+    threadName?: string;
+    messageBody: Record<string, unknown>;
+    deliveryContext: ChatResponseDeliveryContext;
+    log: ReturnType<typeof createLogger>;
+  },
+  dependencies: ChatResponseDependencies
+): Promise<void> {
+  const {
+    error,
+    spaceName,
+    threadName,
+    messageBody,
+    deliveryContext,
+    log,
+  } = input;
+  const failureContext = {
+    phase: 'google_chat_response',
+    spaceName,
+    ...(threadName ? { threadName } : {}),
+    dmFallbackAttempted: true,
+  };
+  await dependencies.recordFailure(
+    {
+      source: 'router',
+      severity: 'error',
+      userId: deliveryContext.userId,
+      sessionId: deliveryContext.sessionId,
+      errorClass: 'ChatPostPermissionDenied',
+      errorMessage: sanitizeDiagnostic(errorMessage(error)),
+      context: failureContext,
+    },
+    log
+  );
+
+  try {
+    const dmSpaceName = await dependencies.resolveDmSpace(
+      deliveryContext.senderGoogleIdentity ?? ''
+    );
+    if (!dmSpaceName) {
+      log.error('Shared-space Chat reply failed and sender DM was not found', {
+        space: spaceName,
+        errorClass: 'ChatPostPermissionDenied',
+      });
+      await recordDmFallbackFailure(
+        new Error('No existing Google Chat DM space found for sender'),
+        deliveryContext,
+        { ...failureContext, dmFallbackOutcome: 'dm-space-not-found' },
+        log,
+        dependencies
+      );
+      return;
+    }
+
+    await dependencies.createMessage({
+      parent: dmSpaceName,
+      requestBody: dmFallbackMessageBody(messageBody),
+    });
+    log.warn('Shared-space Chat reply delivered by DM fallback', {
+      space: spaceName,
+      dmSpace: dmSpaceName,
+      errorClass: 'ChatPostPermissionDenied',
+    });
+  } catch (fallbackError) {
+    log.error('Shared-space Chat reply and DM fallback both failed', {
+      space: spaceName,
+      error: sanitizeDiagnostic(errorMessage(fallbackError)),
+      errorClass: 'ChatDmFallbackFailed',
+    });
+    await recordDmFallbackFailure(
+      fallbackError,
+      deliveryContext,
+      { ...failureContext, dmFallbackOutcome: 'failed' },
+      log,
+      dependencies
+    );
+  }
+}
+
+function prepareGoogleChatMessage(
+  spaceName: string,
+  text: string,
+  log: ReturnType<typeof createLogger>
+): {
+  messageBody: Record<string, unknown>;
+  hasCards: boolean;
+  hasAccessoryWidgets: boolean;
+} {
   // Pull a rich-output envelope out of the agent reply, if one is present.
   // The envelope carries cardsV2 / accessoryWidgets the chat-card / chat-chart
   // skills produced. Remaining prose becomes the message's `text` field
@@ -2241,20 +2510,61 @@ async function sendGoogleChatResponse(
   } else {
     messageBody.text = remaining || text;
   }
-  if (threadName) {
-    messageBody.thread = { name: threadName };
-  }
+  return {
+    messageBody,
+    hasCards: Boolean(envelope?.cardsV2),
+    hasAccessoryWidgets: Boolean(envelope?.accessoryWidgets),
+  };
+}
 
-  await chatClient.spaces.messages.create({
+async function sendGoogleChatResponseWithDependencies(
+  input: ChatResponseInput,
+  log: ReturnType<typeof createLogger>,
+  dependencies: ChatResponseDependencies
+): Promise<void> {
+  const { spaceName, threadName, text, deliveryContext } = input;
+  const prepared = prepareGoogleChatMessage(spaceName, text, log);
+  const messageBody: Record<string, unknown> = {
+    ...prepared.messageBody,
+    ...(threadName ? { thread: { name: threadName } } : {}),
+  };
+  const createRequest: ChatMessageCreateRequest = {
     parent: spaceName,
     requestBody: messageBody,
-  });
+    ...(threadName
+      ? {
+          messageReplyOption:
+            'REPLY_MESSAGE_FALLBACK_TO_NEW_THREAD',
+        }
+      : {}),
+  };
+  try {
+    await dependencies.createMessage(createRequest);
+  } catch (error) {
+    const canFallbackToDm =
+      deliveryContext.isSharedSpace === true &&
+      Boolean(deliveryContext.senderGoogleIdentity) &&
+      isChatPostPermissionDenied(error);
+    if (!canFallbackToDm) throw error;
+    await handleChatPostPermissionDenied(
+      {
+        error,
+        spaceName,
+        threadName,
+        messageBody,
+        deliveryContext,
+        log,
+      },
+      dependencies
+    );
+    return;
+  }
 
   log.info('Response sent to Google Chat', {
     space: spaceName,
     responseLength: text.length,
-    hasCards: !!envelope?.cardsV2,
-    hasAccessoryWidgets: !!envelope?.accessoryWidgets,
+    hasCards: prepared.hasCards,
+    hasAccessoryWidgets: prepared.hasAccessoryWidgets,
   });
 }
 
@@ -2541,18 +2851,7 @@ async function writeScheduledRun(params: ScheduledRunWrite): Promise<void> {
  * original failure remains discoverable there.
  */
 async function recordFailure(
-  params: {
-    source: 'router' | 'harness' | 'cron' | 'agent_self_report' | 'tool';
-    severity: 'error' | 'warn' | 'empty_response';
-    userId?: string | null;
-    sessionId?: string | null;
-    scheduleName?: string | null;
-    model?: string | null;
-    errorClass?: string | null;
-    errorMessage?: string | null;
-    stackExcerpt?: string | null;
-    context?: Record<string, unknown> | null;
-  },
+  params: FailureRecordParams,
   log: ReturnType<typeof createLogger>
 ): Promise<void> {
   // Emit a structured CloudWatch line first so the metric filter ticks even
@@ -3037,11 +3336,20 @@ async function handleNonMessageEvent(
   const addedByEmail = chatEvent.message?.sender?.email;
   const addedByDomain = addedByEmail?.split('@')[1]?.toLowerCase();
   if (addedByDomain && ALLOWED_DOMAINS.includes(addedByDomain)) {
+    const isSharedSpace = chatEvent.space.type === 'ROOM';
+    const senderGoogleIdentity = chatEvent.message?.sender?.name;
     await sendGoogleChatResponse(
       chatEvent.space.name,
       undefined,
       "Hello! I'm your PSD AI Agent. Send me a message to get started.",
-      log
+      log,
+      {
+        isSharedSpace,
+        ...(isSharedSpace && senderGoogleIdentity
+          ? { senderGoogleIdentity }
+          : {}),
+        userId: addedByEmail,
+      }
     );
   } else {
     log.warn('ADDED_TO_SPACE from unverified domain, skipping welcome message', {
@@ -3203,6 +3511,38 @@ function createHumanMessage(incoming: IncomingMessage): HumanMessage {
   };
 }
 
+function humanChatDeliveryContext(
+  human: HumanMessage,
+  sessionId?: string
+): ChatResponseDeliveryContext {
+  return {
+    isSharedSpace: human.isSharedSpace,
+    ...(human.isSharedSpace
+      ? { senderGoogleIdentity: human.senderName }
+      : {}),
+    userId: human.senderEmail,
+    ...(sessionId ? { sessionId } : {}),
+  };
+}
+
+function buildAgentInvocationContext(
+  human: HumanMessage,
+  owner: Pick<AgentUser, 'displayName' | 'workspacePrefix'>,
+  invokedBy?: { email: string; displayName: string }
+): AgentInvocationContext {
+  return {
+    displayName: owner.displayName,
+    workspacePrefix: owner.workspacePrefix,
+    ...(invokedBy ? { invokedBy, threadContext: '' } : {}),
+    ...(human.isSharedSpace
+      ? { audience: 'shared-space' }
+      : {}),
+    ...(human.attachments.length > 0
+      ? { attachments: human.attachments }
+      : {}),
+  };
+}
+
 async function admitHumanMessage(
   human: HumanMessage,
   log: ReturnType<typeof createLogger>
@@ -3244,7 +3584,8 @@ async function admitHumanMessage(
     human.threadName,
     `Your message is too long (${human.messageText.length.toLocaleString()} characters). ` +
       `Please keep messages under ${MAX_MESSAGE_LENGTH.toLocaleString()} characters.`,
-    log
+    log,
+    humanChatDeliveryContext(human)
   );
   return false;
 }
@@ -3373,7 +3714,8 @@ async function invokeCrossUserAgent(
       human.spaceName,
       human.threadName,
       `[${ownerLabel}'s Agent] I'm currently busy processing another request. Please try again in a moment.`,
-      log
+      log,
+      humanChatDeliveryContext(human, sessionId)
     );
     return null;
   }
@@ -3382,18 +3724,14 @@ async function invokeCrossUserAgent(
     targetUser.email,
     sessionId,
     log,
-    {
-      displayName: targetUser.displayName,
-      workspacePrefix: targetUser.workspacePrefix,
-      invokedBy: {
+    buildAgentInvocationContext(
+      human,
+      targetUser,
+      {
         email: human.senderEmail,
         displayName: human.senderDisplayName,
-      },
-      threadContext: '',
-      ...(human.attachments.length > 0
-        ? { attachments: human.attachments }
-        : {}),
-    }
+      }
+    )
   ).finally(() => releaseSessionLock(sessionId, lockToken, log));
   return { result, sessionId };
 }
@@ -3497,7 +3835,8 @@ async function runCrossUserTurn(
       human.spaceName,
       human.threadName,
       emptyCrossUserQuestionHelp(invocation),
-      log
+      log,
+      humanChatDeliveryContext(human)
     );
     return;
   }
@@ -3518,7 +3857,8 @@ async function runCrossUserTurn(
     human.spaceName,
     human.threadName,
     buildCrossUserResponse(invocation, targetUser, turn.result, log),
-    log
+    log,
+    humanChatDeliveryContext(human, turn.sessionId)
   );
   await recordCrossUserResult(
     {
@@ -3548,7 +3888,8 @@ async function handleCrossUserInvocation(
       human.spaceName,
       human.threadName,
       crossUserUsageHelp(invocation),
-      log
+      log,
+      humanChatDeliveryContext(human)
     );
     return { handled: true, messageText: human.messageText };
   }
@@ -3568,7 +3909,8 @@ async function handleCrossUserInvocation(
       human.spaceName,
       human.threadName,
       'Agent not found. If you believe this is an error, contact your workspace admin.',
-      log
+      log,
+      humanChatDeliveryContext(human)
     );
     return { handled: true, messageText: human.messageText };
   }
@@ -3582,7 +3924,8 @@ async function handleCrossUserInvocation(
       human.spaceName,
       human.threadName,
       'Cross-user agent consultation is unavailable until the owner grants explicit access.',
-      log
+      log,
+      humanChatDeliveryContext(human)
     );
     return { handled: true, messageText: human.messageText };
   }
@@ -3599,7 +3942,8 @@ async function handleCrossUserInvocation(
       human.spaceName,
       human.threadName,
       help,
-      log
+      log,
+      humanChatDeliveryContext(human)
     );
     return { handled: true, messageText: human.messageText };
   }
@@ -3682,7 +4026,8 @@ async function invokeOwnerAgentWithDependencies(
       human.spaceName,
       human.threadName,
       'Usage: `/btw <question>`',
-      log
+      log,
+      humanChatDeliveryContext(human)
     );
     return null;
   }
@@ -3730,7 +4075,8 @@ async function invokeOwnerAgentWithDependencies(
         human.threadName,
         "I'm still working on your earlier task in the background — I'll post " +
           "the result here when it's done.",
-        log
+        log,
+        humanChatDeliveryContext(human, mainSessionId)
       );
       return null;
     }
@@ -3744,7 +4090,8 @@ async function invokeOwnerAgentWithDependencies(
       human.spaceName,
       human.threadName,
       OWNER_BUSY_RESPONSE,
-      log
+      log,
+      humanChatDeliveryContext(human, sessionId)
     );
     return null;
   }
@@ -3753,13 +4100,7 @@ async function invokeOwnerAgentWithDependencies(
     human.senderEmail,
     sessionId,
     log,
-    {
-      displayName: human.senderDisplayName,
-      workspacePrefix: user.workspacePrefix,
-      ...(human.attachments.length > 0
-        ? { attachments: human.attachments }
-        : {}),
-    }
+    buildAgentInvocationContext(human, user)
   ).finally(() =>
     dependencies.releaseSessionLock(sessionId, lockToken, log)
   );
@@ -3803,6 +4144,7 @@ function buildOwnerJobPromotionInput(
   return {
     sessionId: turn.sessionId,
     userEmail: human.senderEmail,
+    googleIdentity: human.senderName,
     displayName: human.senderDisplayName,
     workspacePrefix: user.workspacePrefix,
     spaceName: human.spaceName,
@@ -3954,7 +4296,8 @@ async function handleOwnerTurn(
     human.spaceName,
     human.threadName,
     buildOwnerResponse(human, turn.result, turn.responsePrefix),
-    log
+    log,
+    humanChatDeliveryContext(human, turn.sessionId)
   );
   await recordOwnerResult(human, prepared, turn, startTime, log);
 }
@@ -4001,6 +4344,9 @@ export const agentRouterTestHelpers = {
   buildOwnerResponse,
   buildOwnerJobPromotionInput,
   extractIncomingMessage,
+  addOptionalAgentContext,
+  buildAgentInvocationContext,
+  sendGoogleChatResponseWithDependencies,
   btwSlashCommandId: BTW_SLASH_COMMAND_ID,
 };
 

--- a/infra/lambdas/agent-router/index.ts
+++ b/infra/lambdas/agent-router/index.ts
@@ -73,6 +73,7 @@ import {
 } from './attachments';
 import {
   buildJobPayload,
+  jobChatDeliveryContext,
   shouldPromoteToJob,
 } from './job-promotion';
 import type { ScheduledRunWrite } from './scheduled-run-telemetry';
@@ -2220,14 +2221,7 @@ async function promoteToJob(
         '⏳ This is taking longer than one pass allows — I\'ve moved it to a ' +
         'background job and will post the result here when it\'s done.',
       log,
-      {
-        isSharedSpace: !input.isDM,
-        ...(!input.isDM
-          ? { senderGoogleIdentity: input.googleIdentity }
-          : {}),
-        userId: input.userEmail,
-        sessionId: input.sessionId,
-      }
+      jobChatDeliveryContext(input)
     );
 
     log.info('Turn promoted to background job', {
@@ -2442,6 +2436,7 @@ async function handleChatPostPermissionDenied(
     spaceName: string;
     threadName?: string;
     messageBody: Record<string, unknown>;
+    senderGoogleIdentity: string;
     deliveryContext: ChatResponseDeliveryContext;
     log: ReturnType<typeof createLogger>;
   },
@@ -2452,6 +2447,7 @@ async function handleChatPostPermissionDenied(
     spaceName,
     threadName,
     messageBody,
+    senderGoogleIdentity,
     deliveryContext,
     log,
   } = input;
@@ -2463,9 +2459,8 @@ async function handleChatPostPermissionDenied(
   };
 
   try {
-    const dmSpaceName = await dependencies.resolveDmSpace(
-      deliveryContext.senderGoogleIdentity ?? ''
-    );
+    const dmSpaceName =
+      await dependencies.resolveDmSpace(senderGoogleIdentity);
     if (!dmSpaceName) {
       log.error('Shared-space Chat reply failed and sender DM was not found', {
         space: spaceName,
@@ -2611,17 +2606,28 @@ async function sendGoogleChatResponseWithDependencies(
   try {
     await dependencies.createMessage(createRequest);
   } catch (error) {
-    const canFallbackToDm =
-      deliveryContext.isSharedSpace === true &&
-      Boolean(deliveryContext.senderGoogleIdentity) &&
-      isChatPostPermissionDenied(error);
-    if (!canFallbackToDm) throw error;
+    const senderGoogleIdentity =
+      deliveryContext.senderGoogleIdentity;
+    if (
+      deliveryContext.isSharedSpace !== true ||
+      !senderGoogleIdentity ||
+      !isChatPostPermissionDenied(error)
+    ) {
+      throw error;
+    }
+
+    // The AgentCore turn has already completed. A failed room+DM delivery is
+    // returned as an explicit outcome and recorded by the fallback handler
+    // instead of throwing back to SQS, because retrying the event would rerun
+    // a potentially side-effecting turn. Promoted jobs convert this outcome
+    // to exit code 3; interactive turns page through AGENT_FAILURE_RECORD.
     return handleChatPostPermissionDenied(
       {
         error,
         spaceName,
         threadName,
         messageBody,
+        senderGoogleIdentity,
         deliveryContext,
         log,
       },

--- a/infra/lambdas/agent-router/index.ts
+++ b/infra/lambdas/agent-router/index.ts
@@ -2254,10 +2254,10 @@ async function sendGoogleChatResponse(
   text: string,
   log: ReturnType<typeof createLogger>,
   deliveryContext: ChatResponseDeliveryContext = {}
-): Promise<void> {
+): Promise<ChatResponseDeliveryOutcome> {
   const chatClient = await getChatClient();
   const chatAuth = await getChatAuth();
-  await sendGoogleChatResponseWithDependencies(
+  return sendGoogleChatResponseWithDependencies(
     {
       spaceName,
       threadName,
@@ -2289,6 +2289,11 @@ interface ChatResponseInput {
   text: string;
   deliveryContext: ChatResponseDeliveryContext;
 }
+
+type ChatResponseDeliveryOutcome =
+  | 'delivered'
+  | 'dm-fallback-delivered'
+  | 'failed';
 
 interface ChatMessageCreateRequest {
   parent: string;
@@ -2413,7 +2418,7 @@ async function handleChatPostPermissionDenied(
     log: ReturnType<typeof createLogger>;
   },
   dependencies: ChatResponseDependencies
-): Promise<void> {
+): Promise<Exclude<ChatResponseDeliveryOutcome, 'delivered'>> {
   const {
     error,
     spaceName,
@@ -2457,7 +2462,7 @@ async function handleChatPostPermissionDenied(
         log,
         dependencies
       );
-      return;
+      return 'failed';
     }
 
     await dependencies.createMessage({
@@ -2469,6 +2474,7 @@ async function handleChatPostPermissionDenied(
       dmSpace: dmSpaceName,
       errorClass: 'ChatPostPermissionDenied',
     });
+    return 'dm-fallback-delivered';
   } catch (fallbackError) {
     log.error('Shared-space Chat reply and DM fallback both failed', {
       space: spaceName,
@@ -2482,6 +2488,7 @@ async function handleChatPostPermissionDenied(
       log,
       dependencies
     );
+    return 'failed';
   }
 }
 
@@ -2530,7 +2537,7 @@ async function sendGoogleChatResponseWithDependencies(
   input: ChatResponseInput,
   log: ReturnType<typeof createLogger>,
   dependencies: ChatResponseDependencies
-): Promise<void> {
+): Promise<ChatResponseDeliveryOutcome> {
   const { spaceName, threadName, text, deliveryContext } = input;
   const prepared = prepareGoogleChatMessage(spaceName, text, log);
   const messageBody: Record<string, unknown> = {
@@ -2555,7 +2562,7 @@ async function sendGoogleChatResponseWithDependencies(
       Boolean(deliveryContext.senderGoogleIdentity) &&
       isChatPostPermissionDenied(error);
     if (!canFallbackToDm) throw error;
-    await handleChatPostPermissionDenied(
+    return handleChatPostPermissionDenied(
       {
         error,
         spaceName,
@@ -2566,7 +2573,6 @@ async function sendGoogleChatResponseWithDependencies(
       },
       dependencies
     );
-    return;
   }
 
   log.info('Response sent to Google Chat', {
@@ -2575,6 +2581,7 @@ async function sendGoogleChatResponseWithDependencies(
     hasCards: prepared.hasCards,
     hasAccessoryWidgets: prepared.hasAccessoryWidgets,
   });
+  return 'delivered';
 }
 
 // ---------------------------------------------------------------------------

--- a/infra/lambdas/agent-router/index.ts
+++ b/infra/lambdas/agent-router/index.ts
@@ -3540,7 +3540,7 @@ function buildAgentInvocationContext(
   invokedBy?: { email: string; displayName: string }
 ): AgentInvocationContext {
   return {
-    displayName: owner.displayName,
+    displayName: invokedBy ? owner.displayName : human.senderDisplayName,
     workspacePrefix: owner.workspacePrefix,
     ...(invokedBy ? { invokedBy, threadContext: '' } : {}),
     ...(human.isSharedSpace

--- a/infra/lambdas/agent-router/index.ts
+++ b/infra/lambdas/agent-router/index.ts
@@ -2311,6 +2311,8 @@ const CHAT_SPACE_DM_FALLBACK_NOTE =
   "⚠️ I couldn't post this reply in the shared space because your Workspace " +
   "administrator currently restricts this Chat app there. I'm sending it " +
   'to you privately instead.';
+const CHAT_MESSAGE_TRUNCATION_SUFFIX =
+  '\n\n_(Response truncated — ask me to continue)_';
 
 function errorStatusCode(error: unknown): number | undefined {
   if (typeof error !== 'object' || error === null) return undefined;
@@ -2351,16 +2353,26 @@ function dmFallbackMessageBody(
   const responseText =
     typeof fallbackBody.text === 'string' ? fallbackBody.text : '';
   const separator = responseText ? '\n\n' : '';
-  const reservedLength =
-    separator.length + CHAT_SPACE_DM_FALLBACK_NOTE.length;
-  const availableResponseLength = Math.max(
-    CHAT_MESSAGE_MAX_LENGTH - reservedLength,
+  const policySuffix = separator + CHAT_SPACE_DM_FALLBACK_NOTE;
+  const availableUntruncatedLength = Math.max(
+    CHAT_MESSAGE_MAX_LENGTH - policySuffix.length,
+    0
+  );
+  if (responseText.length <= availableUntruncatedLength) {
+    fallbackBody.text = responseText + policySuffix;
+    return fallbackBody;
+  }
+
+  const availableTruncatedLength = Math.max(
+    CHAT_MESSAGE_MAX_LENGTH -
+      policySuffix.length -
+      CHAT_MESSAGE_TRUNCATION_SUFFIX.length,
     0
   );
   fallbackBody.text =
-    responseText.slice(0, availableResponseLength) +
-    separator +
-    CHAT_SPACE_DM_FALLBACK_NOTE;
+    responseText.slice(0, availableTruncatedLength) +
+    CHAT_MESSAGE_TRUNCATION_SUFFIX +
+    policySuffix;
   return fallbackBody;
 }
 

--- a/infra/lambdas/agent-router/index.ts
+++ b/infra/lambdas/agent-router/index.ts
@@ -559,6 +559,17 @@ const CREDENTIALS_TTL_MS = 10 * 60 * 1000; // 10 minutes
 
 // Cached Google Chat API client — reuses OAuth token across warm invocations.
 // Invalidated when credentials are refreshed (TTL expiry or parse error).
+function createGoogleChatAuth(
+  credentials: Record<string, unknown>
+) {
+  return new chatPkg.auth.GoogleAuth({
+    credentials,
+    scopes: ['https://www.googleapis.com/auth/chat.bot'],
+  });
+}
+
+type GoogleChatAuth = ReturnType<typeof createGoogleChatAuth>;
+let cachedChatAuth: GoogleChatAuth | null = null;
 let cachedChatClient: ReturnType<typeof chatPkg.chat> | null = null;
 
 // Cache SSM lookups at module scope to avoid redundant API calls on every invocation.
@@ -880,6 +891,7 @@ async function getGoogleCredentials(): Promise<string> {
   cachedGoogleCredentials = result.SecretString || '';
   credentialsCachedAt = Date.now();
   // Invalidate the Chat API client so it picks up fresh credentials
+  cachedChatAuth = null;
   cachedChatClient = null;
   return cachedGoogleCredentials;
 }
@@ -1944,7 +1956,7 @@ async function invokeAgentCore(
  * Cached across warm invocations to avoid an OAuth token round-trip; the
  * cache is invalidated when credentials refresh (TTL expiry or parse error).
  */
-async function getChatClient(): Promise<NonNullable<typeof cachedChatClient>> {
+async function getChatAuth(): Promise<GoogleChatAuth> {
   const credentialsJson = await getGoogleCredentials();
   let credentials: Record<string, unknown>;
   try {
@@ -1954,18 +1966,23 @@ async function getChatClient(): Promise<NonNullable<typeof cachedChatClient>> {
     // Secrets Manager in case the secret was recently updated/fixed.
     cachedGoogleCredentials = null;
     credentialsCachedAt = null;
+    cachedChatAuth = null;
     cachedChatClient = null;
     throw new Error('Google credentials secret contains invalid JSON');
   }
 
-  if (!cachedChatClient) {
-    const googleAuth = new chatPkg.auth.GoogleAuth({
-      credentials,
-      scopes: ['https://www.googleapis.com/auth/chat.bot'],
-    });
-    cachedChatClient = chatPkg.chat({ version: 'v1', auth: googleAuth });
+  if (!cachedChatAuth) {
+    cachedChatAuth = createGoogleChatAuth(credentials);
   }
 
+  return cachedChatAuth;
+}
+
+async function getChatClient(): Promise<NonNullable<typeof cachedChatClient>> {
+  const googleAuth = await getChatAuth();
+  if (!cachedChatClient) {
+    cachedChatClient = chatPkg.chat({ version: 'v1', auth: googleAuth });
+  }
   return cachedChatClient;
 }
 
@@ -2239,6 +2256,7 @@ async function sendGoogleChatResponse(
   deliveryContext: ChatResponseDeliveryContext = {}
 ): Promise<void> {
   const chatClient = await getChatClient();
+  const chatAuth = await getChatAuth();
   await sendGoogleChatResponseWithDependencies(
     {
       spaceName,
@@ -2252,7 +2270,7 @@ async function sendGoogleChatResponse(
         await chatClient.spaces.messages.create(request);
       },
       resolveDmSpace: googleIdentity =>
-        resolveDmSpace(chatClient, googleIdentity),
+        resolveDmSpace(chatAuth, googleIdentity),
       recordFailure,
     }
   );
@@ -2346,31 +2364,22 @@ function dmFallbackMessageBody(
 }
 
 async function resolveDmSpace(
-  chatClient: NonNullable<typeof cachedChatClient>,
+  chatAuth: GoogleChatAuth,
   googleIdentity: string
 ): Promise<string | null> {
-  let pageToken: string | undefined;
-  do {
-    const response = await chatClient.spaces.list({
-      pageToken,
-      pageSize: 100,
+  try {
+    const response = await chatAuth.request<{ name?: string }>({
+      url: 'https://chat.googleapis.com/v1/spaces:findDirectMessage',
+      method: 'GET',
+      params: {
+        name: googleIdentity,
+      },
     });
-    for (const space of response.data.spaces ?? []) {
-      if (!space.name || !space.singleUserBotDm) continue;
-      const members = await chatClient.spaces.members.list({
-        parent: space.name,
-        pageSize: 10,
-      });
-      const containsSender = (members.data.memberships ?? []).some(
-        membership =>
-          membership.member?.type === 'HUMAN' &&
-          membership.member?.name === googleIdentity
-      );
-      if (containsSender) return space.name;
-    }
-    pageToken = response.data.nextPageToken ?? undefined;
-  } while (pageToken);
-  return null;
+    return response.data.name ?? null;
+  } catch (error) {
+    if (errorStatusCode(error) === 404) return null;
+    throw error;
+  }
 }
 
 async function recordDmFallbackFailure(

--- a/infra/lambdas/agent-router/index.ts
+++ b/infra/lambdas/agent-router/index.ts
@@ -1645,6 +1645,8 @@ interface AgentCoreResult {
 interface FailureRecordParams {
   source: 'router' | 'harness' | 'cron' | 'agent_self_report' | 'tool';
   severity: 'error' | 'warn' | 'empty_response';
+  /** False persists a diagnostic without incrementing the failure pager. */
+  alert?: boolean;
   userId?: string | null;
   sessionId?: string | null;
   scheduleName?: string | null;
@@ -2408,6 +2410,32 @@ async function recordDmFallbackFailure(
   );
 }
 
+async function recordChatPostPermissionOutcome(
+  input: {
+    error: unknown;
+    deliveryContext: ChatResponseDeliveryContext;
+    context: Record<string, unknown>;
+    recovered: boolean;
+    log: ReturnType<typeof createLogger>;
+  },
+  dependencies: ChatResponseDependencies
+): Promise<void> {
+  const { error, deliveryContext, context, recovered, log } = input;
+  await dependencies.recordFailure(
+    {
+      source: 'router',
+      severity: recovered ? 'warn' : 'error',
+      ...(recovered ? { alert: false } : {}),
+      userId: deliveryContext.userId,
+      sessionId: deliveryContext.sessionId,
+      errorClass: 'ChatPostPermissionDenied',
+      errorMessage: sanitizeDiagnostic(errorMessage(error)),
+      context,
+    },
+    log
+  );
+}
+
 async function handleChatPostPermissionDenied(
   input: {
     error: unknown;
@@ -2433,18 +2461,6 @@ async function handleChatPostPermissionDenied(
     ...(threadName ? { threadName } : {}),
     dmFallbackAttempted: true,
   };
-  await dependencies.recordFailure(
-    {
-      source: 'router',
-      severity: 'error',
-      userId: deliveryContext.userId,
-      sessionId: deliveryContext.sessionId,
-      errorClass: 'ChatPostPermissionDenied',
-      errorMessage: sanitizeDiagnostic(errorMessage(error)),
-      context: failureContext,
-    },
-    log
-  );
 
   try {
     const dmSpaceName = await dependencies.resolveDmSpace(
@@ -2455,10 +2471,24 @@ async function handleChatPostPermissionDenied(
         space: spaceName,
         errorClass: 'ChatPostPermissionDenied',
       });
+      const outcomeContext = {
+        ...failureContext,
+        dmFallbackOutcome: 'dm-space-not-found',
+      };
+      await recordChatPostPermissionOutcome(
+        {
+          error,
+          deliveryContext,
+          context: outcomeContext,
+          recovered: false,
+          log,
+        },
+        dependencies
+      );
       await recordDmFallbackFailure(
         new Error('No existing Google Chat DM space found for sender'),
         deliveryContext,
-        { ...failureContext, dmFallbackOutcome: 'dm-space-not-found' },
+        outcomeContext,
         log,
         dependencies
       );
@@ -2469,6 +2499,16 @@ async function handleChatPostPermissionDenied(
       parent: dmSpaceName,
       requestBody: dmFallbackMessageBody(messageBody),
     });
+    await recordChatPostPermissionOutcome(
+      {
+        error,
+        deliveryContext,
+        context: { ...failureContext, dmFallbackOutcome: 'delivered' },
+        recovered: true,
+        log,
+      },
+      dependencies
+    );
     log.warn('Shared-space Chat reply delivered by DM fallback', {
       space: spaceName,
       dmSpace: dmSpaceName,
@@ -2481,10 +2521,24 @@ async function handleChatPostPermissionDenied(
       error: sanitizeDiagnostic(errorMessage(fallbackError)),
       errorClass: 'ChatDmFallbackFailed',
     });
+    const outcomeContext = {
+      ...failureContext,
+      dmFallbackOutcome: 'failed',
+    };
+    await recordChatPostPermissionOutcome(
+      {
+        error,
+        deliveryContext,
+        context: outcomeContext,
+        recovered: false,
+        log,
+      },
+      dependencies
+    );
     await recordDmFallbackFailure(
       fallbackError,
       deliveryContext,
-      { ...failureContext, dmFallbackOutcome: 'failed' },
+      outcomeContext,
       log,
       dependencies
     );
@@ -2870,16 +2924,22 @@ async function recordFailure(
   params: FailureRecordParams,
   log: ReturnType<typeof createLogger>
 ): Promise<void> {
-  // Emit a structured CloudWatch line first so the metric filter ticks even
-  // when the DB write fails. The string AGENT_FAILURE_RECORD is matched by a
-  // CloudWatch MetricFilter — keep it stable.
-  log.error('AGENT_FAILURE_RECORD', {
+  const logContext = {
     source: params.source,
     severity: params.severity,
     userId: params.userId ? sanitizeEmailForLog(params.userId) : null,
     sessionId: params.sessionId ?? null,
     errorClass: params.errorClass ?? null,
-  });
+  };
+  if (params.alert === false) {
+    // Persist recovered policy outcomes for diagnostics without ticking the
+    // AGENT_FAILURE_RECORD metric filter and production failure pager.
+    log.warn('AGENT_DIAGNOSTIC_RECORD', logContext);
+  } else {
+    // Emit a structured CloudWatch line first so the metric filter ticks even
+    // when the DB write fails. Keep AGENT_FAILURE_RECORD stable.
+    log.error('AGENT_FAILURE_RECORD', logContext);
+  }
   if (!DATABASE_HOST || !DATABASE_SECRET_ARN) {
     log.warn('Database not configured, skipping failure record');
     return;

--- a/infra/lambdas/agent-router/index.ts
+++ b/infra/lambdas/agent-router/index.ts
@@ -3345,7 +3345,7 @@ async function handleNonMessageEvent(
   const addedByEmail = chatEvent.message?.sender?.email;
   const addedByDomain = addedByEmail?.split('@')[1]?.toLowerCase();
   if (addedByDomain && ALLOWED_DOMAINS.includes(addedByDomain)) {
-    const isSharedSpace = chatEvent.space.type === 'ROOM';
+    const isSharedSpace = isSharedChatSpaceType(chatEvent.space.type);
     const senderGoogleIdentity = chatEvent.message?.sender?.name;
     await sendGoogleChatResponse(
       chatEvent.space.name,
@@ -3375,6 +3375,15 @@ interface IncomingMessage {
   rawText: string;
   attachments: AgentAttachment[];
   isSharedSpace: boolean;
+}
+
+function isSharedChatSpaceType(
+  spaceType: GoogleChatEvent['space']['type']
+): boolean {
+  // Treat unknown future/non-DM types as shared. This keeps privacy and
+  // delivery behavior fail-safe and matches the promoted-job `!isDM`
+  // classification.
+  return spaceType !== 'DM';
 }
 
 function extractIncomingMessage(
@@ -3415,7 +3424,7 @@ function extractIncomingMessage(
     message,
     rawText,
     attachments,
-    isSharedSpace: chatEvent.space.type === 'ROOM',
+    isSharedSpace: isSharedChatSpaceType(chatEvent.space.type),
   };
 }
 
@@ -4356,6 +4365,7 @@ export const agentRouterTestHelpers = {
   addOptionalAgentContext,
   buildAgentInvocationContext,
   sendGoogleChatResponseWithDependencies,
+  resolveDmSpace,
   btwSlashCommandId: BTW_SLASH_COMMAND_ID,
 };
 

--- a/infra/lambdas/agent-router/job-main.ts
+++ b/infra/lambdas/agent-router/job-main.ts
@@ -136,7 +136,11 @@ async function recordCompletedJobResult(
 
   if (deliveryFailed) {
     log.warn('Background job completed but no Chat response was delivered', {
-      marker: 'JOB_RUNNER_DELIVERY_FAILED',
+      // Keep this on the monitored job-runner failure marker so interactive
+      // promotions page through the existing JobRunnerFailures alarm too.
+      marker: 'JOB_RUNNER_FAILED_TURN',
+      failureKind: 'delivery',
+      deliveryMarker: 'JOB_RUNNER_DELIVERY_FAILED',
       sessionId: job.sessionId,
       latencyMs,
     });

--- a/infra/lambdas/agent-router/job-main.ts
+++ b/infra/lambdas/agent-router/job-main.ts
@@ -50,6 +50,17 @@ type JobPayload = ReturnType<typeof parseJobPayload>;
 type AgentResult = Awaited<ReturnType<typeof invokeAgentCore>>;
 type JobLogger = ReturnType<typeof createLogger>;
 
+function jobChatDeliveryContext(job: JobPayload) {
+  return {
+    isSharedSpace: !job.isDM,
+    ...(!job.isDM && job.googleIdentity
+      ? { senderGoogleIdentity: job.googleIdentity }
+      : {}),
+    userId: job.userEmail,
+    sessionId: job.sessionId,
+  };
+}
+
 /**
  * Best-effort lock release when JOB_PAYLOAD fails full validation (review,
  * #1147): the router pre-acquired the kind='job' lock BEFORE launching this
@@ -170,7 +181,8 @@ async function handleJobRunnerError(
       '⚠️ The background job hit an internal error and could not finish. ' +
         'Some steps may have already completed — ask me to check before ' +
         'retrying.',
-      log
+      log,
+      jobChatDeliveryContext(job)
     );
   } catch (sendError) {
     log.error('Failed to post job-error message to Chat', {
@@ -278,6 +290,7 @@ async function main(): Promise<number> {
       {
         displayName: job.displayName,
         workspacePrefix: job.workspacePrefix,
+        ...(!job.isDM ? { audience: 'shared-space' } : {}),
         deadlineS: JOB_DEADLINE_S,
         runtimeIdOverride: job.runtimeId,
       }
@@ -290,7 +303,8 @@ async function main(): Promise<number> {
       job.spaceName,
       job.threadName,
       formatJobChatResponse(job, agentResult.response),
-      log
+      log,
+      jobChatDeliveryContext(job)
     );
 
     const latencyMs =

--- a/infra/lambdas/agent-router/job-main.ts
+++ b/infra/lambdas/agent-router/job-main.ts
@@ -114,6 +114,22 @@ async function recordCompletedJobResult(
     },
     log
   );
+  if (agentResult.failed && agentResult.errorSource === 'router') {
+    await recordFailure(
+      {
+        source: 'router',
+        severity: 'error',
+        userId: job.userEmail,
+        sessionId: job.sessionId,
+        scheduleName: job.scheduleName,
+        model: agentResult.model,
+        errorClass: agentResult.errorClass ?? 'JobLegError',
+        errorMessage: agentResult.response,
+        context: scheduledFailureContext(job),
+      },
+      log
+    );
+  }
   await recordScheduledJobTerminal(
     job,
     {
@@ -124,7 +140,10 @@ async function recordCompletedJobResult(
       ...(deliveryFailed
         ? {
             errorMessage:
-              'Google Chat room post and private DM fallback both failed',
+              'Google Chat room post and private DM fallback both failed' +
+              (agentResult.failed
+                ? ` after agent error: ${agentResult.response}`
+                : ''),
           }
         : agentResult.failed
           ? { errorMessage: agentResult.response }
@@ -154,22 +173,6 @@ async function recordCompletedJobResult(
       outputTokens: agentResult.outputTokens,
     });
     return;
-  }
-  if (agentResult.errorSource === 'router') {
-    await recordFailure(
-      {
-        source: 'router',
-        severity: 'error',
-        userId: job.userEmail,
-        sessionId: job.sessionId,
-        scheduleName: job.scheduleName,
-        model: agentResult.model,
-        errorClass: agentResult.errorClass ?? 'JobLegError',
-        errorMessage: agentResult.response,
-        context: scheduledFailureContext(job),
-      },
-      log
-    );
   }
   log.warn('Background job finished with a failed turn', {
     marker: 'JOB_RUNNER_FAILED_TURN',

--- a/infra/lambdas/agent-router/job-main.ts
+++ b/infra/lambdas/agent-router/job-main.ts
@@ -22,6 +22,8 @@
 
 import {
   formatJobChatResponse,
+  jobAgentAudienceContext,
+  jobChatDeliveryContext,
   JOB_DEADLINE_S,
   parseJobPayload,
   resolveJobInvocation,
@@ -49,17 +51,6 @@ const RENEW_INTERVAL_MS = 5 * 60 * 1000;
 type JobPayload = ReturnType<typeof parseJobPayload>;
 type AgentResult = Awaited<ReturnType<typeof invokeAgentCore>>;
 type JobLogger = ReturnType<typeof createLogger>;
-
-function jobChatDeliveryContext(job: JobPayload) {
-  return {
-    isSharedSpace: !job.isDM,
-    ...(!job.isDM && job.googleIdentity
-      ? { senderGoogleIdentity: job.googleIdentity }
-      : {}),
-    userId: job.userEmail,
-    sessionId: job.sessionId,
-  };
-}
 
 /**
  * Best-effort lock release when JOB_PAYLOAD fails full validation (review,
@@ -290,7 +281,7 @@ async function main(): Promise<number> {
       {
         displayName: job.displayName,
         workspacePrefix: job.workspacePrefix,
-        ...(!job.isDM ? { audience: 'shared-space' } : {}),
+        ...jobAgentAudienceContext(job),
         deadlineS: JOB_DEADLINE_S,
         runtimeIdOverride: job.runtimeId,
       }

--- a/infra/lambdas/agent-router/job-main.ts
+++ b/infra/lambdas/agent-router/job-main.ts
@@ -86,12 +86,14 @@ function scheduledFailureContext(job: JobPayload) {
   };
 }
 
-async function recordDeliveredJobResult(
+async function recordCompletedJobResult(
   job: JobPayload,
   agentResult: AgentResult,
   latencyMs: number,
+  deliveryOutcome: Awaited<ReturnType<typeof sendGoogleChatResponse>>,
   log: JobLogger
 ): Promise<void> {
+  const deliveryFailed = deliveryOutcome === 'failed';
   await logTelemetry(
     {
       userId: job.userEmail,
@@ -115,17 +117,31 @@ async function recordDeliveredJobResult(
   await recordScheduledJobTerminal(
     job,
     {
-      status: agentResult.failed ? 'error' : 'success',
+      status: agentResult.failed || deliveryFailed ? 'error' : 'success',
       inputTokens: agentResult.inputTokens,
       outputTokens: agentResult.outputTokens,
       latencyMs,
-      ...(agentResult.failed
-        ? { errorMessage: agentResult.response }
+      ...(deliveryFailed
+        ? {
+            errorMessage:
+              'Google Chat room post and private DM fallback both failed',
+          }
+        : agentResult.failed
+          ? { errorMessage: agentResult.response }
         : {}),
     },
     writeScheduledRun,
     log
   );
+
+  if (deliveryFailed) {
+    log.warn('Background job completed but no Chat response was delivered', {
+      marker: 'JOB_RUNNER_DELIVERY_FAILED',
+      sessionId: job.sessionId,
+      latencyMs,
+    });
+    return;
+  }
 
   if (!agentResult.failed) {
     log.info('Background job completed', {
@@ -290,7 +306,7 @@ async function main(): Promise<number> {
     // Deliver exactly like the router's Step 6: truncate the raw response,
     // then prefix in shared spaces. A failed turn's response is already the
     // harness's failure frame — posting it satisfies "always post something".
-    await sendGoogleChatResponse(
+    const deliveryOutcome = await sendGoogleChatResponse(
       job.spaceName,
       job.threadName,
       formatJobChatResponse(job, agentResult.response),
@@ -300,11 +316,17 @@ async function main(): Promise<number> {
 
     const latencyMs =
       agentResult.latencyMs > 0 ? agentResult.latencyMs : Date.now() - startTime;
-    await recordDeliveredJobResult(job, agentResult, latencyMs, log);
+    await recordCompletedJobResult(
+      job,
+      agentResult,
+      latencyMs,
+      deliveryOutcome,
+      log
+    );
     // The ECS STOPPED-state supervisor uses the process exit code as its
     // authoritative terminal signal. A delivered agent failure is not a clean
     // job even though Chat delivery itself succeeded.
-    return agentResult.failed ? 2 : 0;
+    return deliveryOutcome === 'failed' ? 3 : agentResult.failed ? 2 : 0;
   } catch (error) {
     const exitCode = await handleJobRunnerError(job, error, startTime, log);
     return exitCode;

--- a/infra/lambdas/agent-router/job-promotion.test.ts
+++ b/infra/lambdas/agent-router/job-promotion.test.ts
@@ -35,6 +35,7 @@ const BASE = {
   lockToken: 'tok-1',
   runtimeId: 'psd_agent_dev-XYZ',
   userEmail: 'hagelk@psd401.net',
+  googleIdentity: 'users/123456789',
   displayName: 'Kris Hagel',
   workspacePrefix: 'hagelk-abc123',
   spaceName: 'spaces/AAA',
@@ -49,6 +50,7 @@ describe('buildJobPayload / parseJobPayload round-trip', () => {
     expect(parsed.lockToken).toBe(BASE.lockToken);
     expect(parsed.runtimeId).toBe(BASE.runtimeId);
     expect(parsed.userEmail).toBe(BASE.userEmail);
+    expect(parsed.googleIdentity).toBe(BASE.googleIdentity);
     expect(parsed.workspacePrefix).toBe(BASE.workspacePrefix);
     expect(parsed.spaceName).toBe(BASE.spaceName);
     expect(parsed.threadName).toBe('spaces/AAA/threads/t1');

--- a/infra/lambdas/agent-router/job-promotion.test.ts
+++ b/infra/lambdas/agent-router/job-promotion.test.ts
@@ -10,6 +10,8 @@ import {
   buildContinuationPrompt,
   buildJobPayload,
   formatJobChatResponse,
+  jobAgentAudienceContext,
+  jobChatDeliveryContext,
   JOB_DEADLINE_S,
   parseJobPayload,
   shouldPromoteToJob,
@@ -150,6 +152,43 @@ describe('formatJobChatResponse', () => {
         'room result'
       )
     ).toBe(`[${BASE.displayName}'s Agent] room result`);
+  });
+});
+
+describe('promoted-job Chat context', () => {
+  test('retains the sender identity and public audience for room delivery', () => {
+    const roomJob = {
+      isDM: false,
+      googleIdentity: BASE.googleIdentity,
+      userEmail: BASE.userEmail,
+      sessionId: BASE.sessionId,
+    };
+
+    expect(jobChatDeliveryContext(roomJob)).toEqual({
+      isSharedSpace: true,
+      senderGoogleIdentity: BASE.googleIdentity,
+      userId: BASE.userEmail,
+      sessionId: BASE.sessionId,
+    });
+    expect(jobAgentAudienceContext(roomJob)).toEqual({
+      audience: 'shared-space',
+    });
+  });
+
+  test('omits sender fallback and public audience for DM delivery', () => {
+    const dmJob = {
+      isDM: true,
+      googleIdentity: BASE.googleIdentity,
+      userEmail: BASE.userEmail,
+      sessionId: BASE.sessionId,
+    };
+
+    expect(jobChatDeliveryContext(dmJob)).toEqual({
+      isSharedSpace: false,
+      userId: BASE.userEmail,
+      sessionId: BASE.sessionId,
+    });
+    expect(jobAgentAudienceContext(dmJob)).toEqual({});
   });
 });
 

--- a/infra/lambdas/agent-router/job-promotion.ts
+++ b/infra/lambdas/agent-router/job-promotion.ts
@@ -88,6 +88,29 @@ export interface JobInvocation {
   restart: boolean;
 }
 
+export function jobChatDeliveryContext(
+  job: Pick<
+    JobPayload,
+    'isDM' | 'googleIdentity' | 'userEmail' | 'sessionId'
+  >
+) {
+  const isSharedSpace = !job.isDM;
+  return {
+    isSharedSpace,
+    ...(isSharedSpace && job.googleIdentity
+      ? { senderGoogleIdentity: job.googleIdentity }
+      : {}),
+    userId: job.userEmail,
+    sessionId: job.sessionId,
+  };
+}
+
+export function jobAgentAudienceContext(
+  job: Pick<JobPayload, 'isDM'>
+): { audience?: 'shared-space' } {
+  return job.isDM ? {} : { audience: 'shared-space' };
+}
+
 const JOB_RESPONSE_MAX_LENGTH = 4096;
 const JOB_TRUNCATION_SUFFIX =
   '\n\n_(Response truncated — ask me to continue)_';

--- a/infra/lambdas/agent-router/job-promotion.ts
+++ b/infra/lambdas/agent-router/job-promotion.ts
@@ -61,6 +61,8 @@ export interface JobPayload {
   /** Resolved AgentCore runtime id/ARN (runner skips the SSM lookup). */
   runtimeId: string;
   userEmail: string;
+  /** Google Chat users/{id}; enables shared-space reply fallback to DM. */
+  googleIdentity?: string;
   displayName: string;
   workspacePrefix: string;
   spaceName: string;
@@ -154,6 +156,7 @@ export function buildJobPayload(input: {
   lockToken: string;
   runtimeId: string;
   userEmail: string;
+  googleIdentity?: string;
   displayName: string;
   workspacePrefix: string;
   spaceName: string;
@@ -172,6 +175,9 @@ export function buildJobPayload(input: {
     lockToken: input.lockToken,
     runtimeId: input.runtimeId,
     userEmail: input.userEmail,
+    ...(input.googleIdentity
+      ? { googleIdentity: input.googleIdentity }
+      : {}),
     displayName: input.displayName,
     workspacePrefix: input.workspacePrefix,
     spaceName: input.spaceName,
@@ -258,6 +264,7 @@ export function parseJobPayload(raw: string | undefined): JobPayload {
   );
   const scheduledRunId = readScheduledRunId(obj);
   const fireKey = boundedOptionalString(obj, 'fireKey', 192);
+  const googleIdentity = boundedOptionalString(obj, 'googleIdentity', 256);
   return {
     sessionId: requireString('sessionId'),
     // Unknown/absent -> 'deadline'. A payload from an older cron build must
@@ -268,6 +275,7 @@ export function parseJobPayload(raw: string | undefined): JobPayload {
     lockToken: requireString('lockToken'),
     runtimeId: requireString('runtimeId'),
     userEmail: requireString('userEmail'),
+    googleIdentity,
     displayName: typeof obj.displayName === 'string' ? obj.displayName : '',
     workspacePrefix: requireString('workspacePrefix'),
     spaceName: requireString('spaceName'),

--- a/tests/unit/agent-job-runner-restart.test.ts
+++ b/tests/unit/agent-job-runner-restart.test.ts
@@ -101,6 +101,7 @@ describe("job runner restart handling", () => {
     expect(source).toContain(
       "return deliveryOutcome === 'failed' ? 3 : agentResult.failed ? 2 : 0",
     )
+    expect(source).toContain("marker: 'JOB_RUNNER_FAILED_TURN'")
     expect(source).toContain("JOB_RUNNER_DELIVERY_FAILED")
   })
 

--- a/tests/unit/agent-job-runner-restart.test.ts
+++ b/tests/unit/agent-job-runner-restart.test.ts
@@ -93,11 +93,18 @@ describe("job runner restart handling", () => {
     expect(source).toContain("recordScheduledJobTerminal(")
     expect(source).toContain("writeScheduledRun,")
     expect(source).toContain(
-      "status: agentResult.failed ? 'error' : 'success'",
+      "status: agentResult.failed || deliveryFailed ? 'error' : 'success'",
     )
   })
 
+  it("exits nonzero when both room and DM delivery fail", () => {
+    expect(source).toContain(
+      "return deliveryOutcome === 'failed' ? 3 : agentResult.failed ? 2 : 0",
+    )
+    expect(source).toContain("JOB_RUNNER_DELIVERY_FAILED")
+  })
+
   it("exits nonzero after delivering an agent failure for ECS supervision", () => {
-    expect(source).toContain("return agentResult.failed ? 2 : 0")
+    expect(source).toContain("agentResult.failed ? 2 : 0")
   })
 })

--- a/tests/unit/agent-job-runner-restart.test.ts
+++ b/tests/unit/agent-job-runner-restart.test.ts
@@ -101,8 +101,24 @@ describe("job runner restart handling", () => {
     expect(source).toContain(
       "return deliveryOutcome === 'failed' ? 3 : agentResult.failed ? 2 : 0",
     )
-    expect(source).toContain("marker: 'JOB_RUNNER_FAILED_TURN'")
-    expect(source).toContain("JOB_RUNNER_DELIVERY_FAILED")
+    const deliveryFailureBranch = source.slice(
+      source.indexOf("if (deliveryFailed)"),
+      source.indexOf("if (!agentResult.failed)"),
+    )
+    expect(deliveryFailureBranch).toContain(
+      "marker: 'JOB_RUNNER_FAILED_TURN'",
+    )
+    expect(deliveryFailureBranch).toContain("failureKind: 'delivery'")
+    expect(deliveryFailureBranch).toContain("JOB_RUNNER_DELIVERY_FAILED")
+  })
+
+  it("records a router invocation failure before handling delivery failure", () => {
+    const invocationFailure = source.indexOf(
+      "if (agentResult.failed && agentResult.errorSource === 'router')",
+    )
+    const deliveryFailure = source.indexOf("if (deliveryFailed)")
+    expect(invocationFailure).toBeGreaterThan(-1)
+    expect(deliveryFailure).toBeGreaterThan(invocationFailure)
   })
 
   it("exits nonzero after delivering an agent failure for ECS supervision", () => {


### PR DESCRIPTION
## Description

Fixes the Google Chat room reply path so mention responses stay in the originating thread, Workspace-policy 403s recover through the sender's existing DM without rerunning the completed agent turn, and the agent treats shared-space answers as public.

## Type of Change

- [x] Bug fix (non-breaking change)
- [x] Documentation update
- [ ] Database migration
- [ ] CDK resource change

## Implementation

- Add `REPLY_MESSAGE_FALLBACK_TO_NEW_THREAD` whenever Google Chat supplies a thread name.
- On a shared-space post 403, resolve the human sender's existing DM with the one-call `spaces:findDirectMessage` API and deliver the already-computed response there.
- Keep recovered 403s as non-alerting diagnostics; page on genuine room-plus-DM delivery failure.
- Return explicit Chat delivery outcomes. Promoted jobs record exhausted delivery as a terminal scheduled-run error, emit the existing monitored `JOB_RUNNER_FAILED_TURN` marker, and exit 3 without rerunning AgentCore.
- Preserve the underlying router invocation failure when agent execution and Chat delivery both fail.
- Keep long DM fallbacks at the 4,096-character Chat limit while preserving both the response-truncation marker and the Workspace policy notice.
- Preserve sender identity and shared-space audience through promoted jobs, with one shared `jobChatDeliveryContext` implementation.
- Add `audience: shared-space` to owner and cross-user AgentCore payloads and render a public-audience header in the per-turn frame.
- Preserve the current Chat sender display name for owner turns and the target owner's name for cross-user turns.
- Add system guidance against volunteering memory and require confirmation before reading Gmail, Calendar, or Drive content into a shared space.
- Treat every non-DM space type, including `TYPE_UNSPECIFIED`, as shared for privacy and fallback behavior.
- Document the verified Workspace policy and the exact dev/prod Google Chat API configuration.

## Validation

- [x] `bun test` in `infra/lambdas/agent-router/` — 75 passed, 216 expectations
- [x] `bun run build` in `infra/lambdas/agent-router/`
- [x] `python3 -m unittest test_agentcore_wrapper.py` in `infra/agent-image/` — 35 passed, 1 skipped
- [x] `bun run lint` — zero warnings
- [x] `bun run typecheck`
- [x] `bun run test:ci -- --runInBand` — 530 suites / 4,902 tests passed; 1 suite / 15 tests skipped by policy
- [x] Root `bun run build` — successful; existing Browserslist and `oidc-provider` runtime warnings only
- [x] `bun run build` in `infra/` — successful, including 17 agent-skill-builder Lambda tests
- [x] Final head `db4f314419`: all required PR CI, CodeQL, infrastructure, auth-artifact, and Claude checks green
- [x] Final Codex review on `db4f314419`: no major issues
- [x] Final requested Claude review on `db4f314419`: no remaining actionable findings
- [x] All seven review threads resolved

The isolated worktree has no `.env.local` / `AUTH_SECRET`, so the documented authenticated local Playwright pre-push hook was skipped with `SKIP_E2E=1`. This backend Google Chat → Pub/Sub → SQS change has no browser UI acceptance path; the repository's required PR CI equivalent is green on the final SHA.

## Live Google Admin and API verification

Verified on 2026-07-29:

- [x] Tenant Google Chat apps capability is **On** at the top-level organization.
- [x] Marketplace installation is allowlist-only.
- [x] The exact production app **PSD AI Agent** (application/project number `905669698724`) is explicitly allowed for `/Staff`.
- [x] `/Miscellaneous/Agent Account`, where OneSync places the `agnt_...` identities, has its own explicit **Allow app** override.
- [x] Students and the top-level organization are not granted the production app.
- [x] The known production room delivers Chat events to the application pipeline.
- [x] The production app credential reaches that room but receives `403 This organization's administrator restricts this Chat app from performing this action`.
- [x] Rechecking after the Agent Account OU override produced the same 403, confirming room posts use the separate Chat app service-account identity rather than the `agnt_...` delegated user.
- [x] The dev credential against the production room reaches membership validation and returns `403 This Chat app is not a member of this space`; a separate dev room is required for an end-to-end dev check.

Under the district's deliberate Staff-only child-OU policy, the production room-post 403 is an expected Workspace policy boundary. This PR handles it by privately delivering the completed answer to the human sender's existing DM. It does not expand access to Students.

No Google Admin or gcloud login is still needed for this PR. The required settings were already present. Workspace tenant app policy and Google Chat API Console configuration are console-managed; the existing GCP Terraform remains responsible for APIs, service accounts, Pub/Sub, subscriptions, and IAM.

## Post-deployment verification

- [ ] @mention the deployed app in the affected room and confirm either a reply in the originating thread or, when Workspace rejects the room post, one private DM fallback containing the policy notice.
- [ ] For an intentionally long reply, confirm the DM retains both the truncation marker and policy notice.
- [ ] Confirm a shared-space turn does not volunteer private memory and asks before exposing Gmail, Calendar, or Drive content.

These checks require the merged/deployed artifact and are not merge blockers.

## Risk and rollback

No migrations, new cloud resources, or expanded permissions. Threading is additive; DM fallback runs only for shared-space 403s with a known human sender; successful recovery does not page; exhausted delivery does page; and DM turns omit the public-audience marker. Roll back by reverting the PR commits. Workspace app policy is unchanged by this PR.

## Screenshots

N/A — backend Google Chat pipeline and system-context change.

Closes #1449
