### PR TITLE
Agent eval comparison report and promotion enforcement

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,7 @@ jobs:
           infra/agent-image/test_graders.py \
           infra/agent-image/test_eval_runner.py \
           infra/agent-image/test_eval_summary.py \
+          infra/agent-image/test_report.py \
           infra/agent-image/test_tts_synthesize.py \
           infra/agent-image/skills/psd-last30days/scripts/test_last30days.py
 

--- a/.gitignore
+++ b/.gitignore
@@ -78,9 +78,9 @@ tests/e2e/.auth/
 infra/agent-image/.build-probes/
 
 # Agent-image eval transcripts contain prompts, model output, tool details, and
-# broker request bodies. Only digest-named, transcript-free summaries belong in
-# .eval-runs/; summarize.py also validates the Git index so `git add -f` cannot
-# bypass this guard in CI.
+# broker request bodies. Only digest-named, transcript-free summaries and exact
+# generated digest-pair comparison reports belong in .eval-runs/; summarize.py
+# also validates the Git index so `git add -f` cannot bypass this guard in CI.
 /.eval-runs/**/*.jsonl
 /.eval-runs/*.jsonl
 /.eval-runs/**/*transcript*

--- a/infra/agent-image/eval/README.md
+++ b/infra/agent-image/eval/README.md
@@ -129,8 +129,9 @@ itself records the full immutable ECR URI and digest.
 ## Compare two summaries
 
 `report.py` compares two schema-valid, digest-named summaries. It requires the
-same task IDs, skill ownership, suite classification, and trial count in both
-arms so a task-set change cannot masquerade as a model or harness improvement:
+same `eval_harness_commit`, task IDs, skill ownership, suite classification, and
+trial count in both arms so a harness or task-set change cannot masquerade as a
+model improvement:
 
 ```bash
 python3 infra/agent-image/eval/report.py \

--- a/infra/agent-image/eval/README.md
+++ b/infra/agent-image/eval/README.md
@@ -150,6 +150,11 @@ The promotion verdict implements the epic's three clauses independently:
 2. overall capability-suite `pass^3` strictly improves; and
 3. cost per task increases by no more than 20%.
 
+Clause (3) reconstructs unrounded Decimal costs from each arm's stored token
+totals and model price block. The six-decimal summary cost remains a display
+value only, so two tiny real costs that both round to zero cannot accidentally
+pass the promotion gate.
+
 Caching status is re-derived from each summary's observed
 `cache_read_input_tokens`, not from candidate configuration or the summary's
 status label. When only one arm observed cache reads, raw costs remain visible

--- a/infra/agent-image/eval/README.md
+++ b/infra/agent-image/eval/README.md
@@ -151,10 +151,11 @@ The promotion verdict implements the epic's three clauses independently:
 2. overall capability-suite `pass^3` strictly improves; and
 3. cost per task increases by no more than 20%.
 
-Clause (3) reconstructs unrounded Decimal costs from each arm's stored token
-totals and model price block. The six-decimal summary cost remains a display
-value only, so two tiny real costs that both round to zero cannot accidentally
-pass the promotion gate.
+Clause (3) and the report's total/per-task cost deltas reconstruct unrounded
+Decimal costs from each arm's stored token totals and model price block. The
+six-decimal summary cost remains a display value only, so two tiny real costs
+that both round to zero cannot accidentally pass the promotion gate or produce
+a contradictory `0.00%` report delta.
 
 Caching status is re-derived from each summary's observed
 `cache_read_input_tokens`, not from candidate configuration or the summary's

--- a/infra/agent-image/eval/README.md
+++ b/infra/agent-image/eval/README.md
@@ -126,6 +126,57 @@ python3 infra/agent-image/eval/summarize.py --check-repository
 Committed summary filenames use `sha256-<64 lowercase hex>.json`; the file
 itself records the full immutable ECR URI and digest.
 
+## Compare two summaries
+
+`report.py` compares two schema-valid, digest-named summaries. It requires the
+same task IDs, skill ownership, suite classification, and trial count in both
+arms so a task-set change cannot masquerade as a model or harness improvement:
+
+```bash
+python3 infra/agent-image/eval/report.py \
+  .eval-runs/sha256-<baseline-digest>.json \
+  .eval-runs/sha256-<candidate-digest>.json
+```
+
+The terminal report sorts the per-skill `pass^3` table by regression severity,
+then shows aggregate cost, duration, latency, model-call, nudge, and runtime
+failure-class deltas. Any task whose passed-trial count changed is shown as,
+for example, `2/3 (FAIL) -> 3/3 (PASS)`. The report does not invent confidence
+intervals from three trials.
+
+The promotion verdict implements the epic's three clauses independently:
+
+1. no skill's regression-suite `pass^3` rate drops below its baseline;
+2. overall capability-suite `pass^3` strictly improves; and
+3. cost per task increases by no more than 20%.
+
+Caching status is re-derived from each summary's observed
+`cache_read_input_tokens`, not from candidate configuration or the summary's
+status label. When only one arm observed cache reads, raw costs remain visible
+but their delta and clause (3) are marked `DECLINED`; the result can never be
+`PROMOTE`. A quality-clause failure still produces `REJECT`, while otherwise
+passing quality with an unavailable cost verdict produces `INDETERMINATE`.
+
+Render the same evidence as Markdown for a recorded comparison decision:
+
+```bash
+python3 infra/agent-image/eval/report.py \
+  .eval-runs/sha256-<baseline-digest>.json \
+  .eval-runs/sha256-<candidate-digest>.json \
+  --format markdown \
+  --out .eval-runs/comparison-sha256-<baseline-digest>-vs-sha256-<candidate-digest>.md
+```
+
+Markdown under `.eval-runs/` is accepted by the repository guard only with
+that digest-pair filename and only when its bytes exactly match a report
+regenerated from the two tracked summaries. Arbitrary Markdown, hand-edited
+reports, nested artifacts, and transcript-like files remain rejected.
+
+By default, reporting a rejected candidate succeeds so its evidence can be
+recorded. Add `--require-promotion` in an enforcement step to exit with status
+1 for `REJECT` or `INDETERMINATE`. Invalid or incomparable summaries exit with
+status 2.
+
 ## Nightly and on-demand runs
 
 `.github/workflows/agent-eval-nightly.yml` runs all 50 regression and capability
@@ -444,7 +495,8 @@ UV_CACHE_DIR=/tmp/issue-1426-uv-cache \
   infra/agent-image/test_broker_stub.py \
   infra/agent-image/test_graders.py \
   infra/agent-image/test_eval_runner.py \
-  infra/agent-image/test_eval_summary.py
+  infra/agent-image/test_eval_summary.py \
+  infra/agent-image/test_report.py
 ```
 
 The tests make no AWS, model, Docker, or external-network calls. Broker HTTP

--- a/infra/agent-image/eval/README.md
+++ b/infra/agent-image/eval/README.md
@@ -155,7 +155,9 @@ Clause (3) and the report's total/per-task cost deltas reconstruct unrounded
 Decimal costs from each arm's stored token totals and model price block. The
 six-decimal summary cost remains a display value only, so two tiny real costs
 that both round to zero cannot accidentally pass the promotion gate or produce
-a contradictory `0.00%` report delta.
+a contradictory `0.00%` report delta. Any exact increase above the 20% limit
+also carries an explicit `over 20% limit` marker, even if its two-decimal
+percentage display rounds to `20.00%`.
 
 Caching status is re-derived from each summary's observed
 `cache_read_input_tokens`, not from candidate configuration or the summary's

--- a/infra/agent-image/eval/report.py
+++ b/infra/agent-image/eval/report.py
@@ -330,6 +330,13 @@ def _format_percent(value: Decimal) -> str:
     return f"{value * Decimal(100):.2f}%"
 
 
+def _format_cost_change(value: Decimal) -> str:
+    formatted = _format_percent(value)
+    if value > MAX_COST_INCREASE:
+        return f"{formatted} (over 20% limit)"
+    return formatted
+
+
 def _format_points(value: Decimal) -> str:
     return f"{value * Decimal(100):+.2f} pp"
 
@@ -489,7 +496,7 @@ def _promotion_clauses(
             change_label = "undefined increase from a zero-cost baseline"
         else:
             cost_passed = cost_change <= MAX_COST_INCREASE
-            change_label = _format_percent(cost_change)
+            change_label = _format_cost_change(cost_change)
         cost_clause = ClauseResult(
             key="c",
             title="Cost per task increases by no more than 20%",
@@ -664,7 +671,7 @@ def _metric_rows(comparison: Comparison) -> list[list[str]]:
         elif change is None:
             delta = "undefined from zero baseline"
         else:
-            delta = _format_percent(change)
+            delta = _format_cost_change(change)
         rows.append(
             [
                 title,

--- a/infra/agent-image/eval/report.py
+++ b/infra/agent-image/eval/report.py
@@ -279,10 +279,10 @@ def _observed_caching_status(
     return "uncached" if cache_reads == 0 else "cached"
 
 
-def _scope_cost_per_task(
+def _scope_costs(
     summary: Mapping[str, object],
     label: str,
-) -> Decimal:
+) -> tuple[Decimal, Decimal]:
     telemetry = _telemetry(summary, label)
     tokens = _mapping(
         telemetry.get("tokens"),
@@ -317,7 +317,7 @@ def _scope_cost_per_task(
     )
     if task_count <= 0:
         raise EvalReportError(f"{label}.overall.task_count must be positive")
-    return total_cost / Decimal(task_count)
+    return total_cost, total_cost / Decimal(task_count)
 
 
 def _percent_change(baseline: Decimal, candidate: Decimal) -> Decimal | None:
@@ -469,8 +469,8 @@ def _promotion_clauses(
         ),
     )
 
-    baseline_cost = _scope_cost_per_task(baseline, "baseline")
-    candidate_cost = _scope_cost_per_task(candidate, "candidate")
+    _, baseline_cost = _scope_costs(baseline, "baseline")
+    _, candidate_cost = _scope_costs(candidate, "candidate")
     if baseline_caching_status != candidate_caching_status:
         cost_clause = ClauseResult(
             key="c",
@@ -628,9 +628,27 @@ def _metric_rows(comparison: Comparison) -> list[list[str]]:
         candidate_telemetry.get("cost"),
         "candidate.overall.telemetry.cost",
     )
-    for field, title in (
-        ("per_task_usd", "Cost / task"),
-        ("total_usd", "Cost total"),
+    baseline_total_exact, baseline_per_task_exact = _scope_costs(
+        comparison.baseline,
+        "baseline",
+    )
+    candidate_total_exact, candidate_per_task_exact = _scope_costs(
+        comparison.candidate,
+        "candidate",
+    )
+    for field, title, baseline_exact, candidate_exact in (
+        (
+            "per_task_usd",
+            "Cost / task",
+            baseline_per_task_exact,
+            candidate_per_task_exact,
+        ),
+        (
+            "total_usd",
+            "Cost total",
+            baseline_total_exact,
+            candidate_total_exact,
+        ),
     ):
         baseline_value = _decimal(
             baseline_cost.get(field),
@@ -640,7 +658,7 @@ def _metric_rows(comparison: Comparison) -> list[list[str]]:
             candidate_cost.get(field),
             f"candidate.overall.telemetry.cost.{field}",
         )
-        change = _percent_change(baseline_value, candidate_value)
+        change = _percent_change(baseline_exact, candidate_exact)
         if not caching_matches:
             delta = "declined: caching mismatch"
         elif change is None:

--- a/infra/agent-image/eval/report.py
+++ b/infra/agent-image/eval/report.py
@@ -232,6 +232,20 @@ def _validate_comparison_identity(
     baseline: Mapping[str, object],
     candidate: Mapping[str, object],
 ) -> None:
+    baseline_harness = _string(
+        baseline.get("eval_harness_commit"),
+        "baseline.eval_harness_commit",
+    )
+    candidate_harness = _string(
+        candidate.get("eval_harness_commit"),
+        "candidate.eval_harness_commit",
+    )
+    if baseline_harness != candidate_harness:
+        raise EvalReportError(
+            "summaries must use the same eval_harness_commit "
+            f"(baseline {baseline_harness}; candidate {candidate_harness})"
+        )
+
     baseline_tasks = _tasks(baseline, "baseline")
     candidate_tasks = _tasks(candidate, "candidate")
     if set(baseline_tasks) != set(candidate_tasks):

--- a/infra/agent-image/eval/report.py
+++ b/infra/agent-image/eval/report.py
@@ -20,6 +20,12 @@ import summarize
 
 
 MAX_COST_INCREASE = Decimal("0.20")
+TOKEN_PRICE_KEYS = {
+    "input_tokens": "input",
+    "output_tokens": "output",
+    "cache_read_input_tokens": "cacheRead",
+    "cache_write_input_tokens": "cacheWrite",
+}
 SAFE_REPORT_NAME_RE = re.compile(
     r"^comparison-(sha256-[0-9a-f]{64})-vs-(sha256-[0-9a-f]{64})\.md$"
 )
@@ -264,11 +270,40 @@ def _scope_cost_per_task(
     label: str,
 ) -> Decimal:
     telemetry = _telemetry(summary, label)
-    cost = _mapping(telemetry.get("cost"), f"{label}.overall.telemetry.cost")
-    return _decimal(
-        cost.get("per_task_usd"),
-        f"{label}.overall.telemetry.cost.per_task_usd",
+    tokens = _mapping(
+        telemetry.get("tokens"),
+        f"{label}.overall.telemetry.tokens",
     )
+    model = _mapping(summary.get("model"), f"{label}.model")
+    pricing = _mapping(
+        model.get("pricing_usd_per_million_tokens"),
+        f"{label}.model.pricing_usd_per_million_tokens",
+    )
+    total_cost = sum(
+        Decimal(
+            _integer(
+                tokens.get(token_field),
+                f"{label}.overall.telemetry.tokens.{token_field}",
+            )
+        )
+        * _decimal(
+            pricing.get(price_field),
+            (
+                f"{label}.model.pricing_usd_per_million_tokens."
+                f"{price_field}"
+            ),
+        )
+        / Decimal(1_000_000)
+        for token_field, price_field in TOKEN_PRICE_KEYS.items()
+    )
+    overall = _mapping(summary.get("overall"), f"{label}.overall")
+    task_count = _integer(
+        overall.get("task_count"),
+        f"{label}.overall.task_count",
+    )
+    if task_count <= 0:
+        raise EvalReportError(f"{label}.overall.task_count must be positive")
+    return total_cost / Decimal(task_count)
 
 
 def _percent_change(baseline: Decimal, candidate: Decimal) -> Decimal | None:

--- a/infra/agent-image/eval/report.py
+++ b/infra/agent-image/eval/report.py
@@ -1,0 +1,1076 @@
+#!/usr/bin/env python3
+"""Compare two committed agent-eval summaries and enforce promotion policy.
+
+The report consumes only transcript-free summary JSON. It deliberately does
+not accept trial JSONL, broker captures, or other raw eval artifacts.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import dataclass
+from decimal import Decimal
+from pathlib import Path
+from typing import Mapping, Sequence
+
+import summarize
+
+
+MAX_COST_INCREASE = Decimal("0.20")
+SAFE_REPORT_NAME_RE = re.compile(
+    r"^comparison-(sha256-[0-9a-f]{64})-vs-(sha256-[0-9a-f]{64})\.md$"
+)
+
+
+class EvalReportError(RuntimeError):
+    """Two eval summaries could not be compared safely."""
+
+
+@dataclass(frozen=True)
+class PassStats:
+    """pass^3 counts for a task scope."""
+
+    passed: int
+    total: int
+
+    @property
+    def rate(self) -> Decimal:
+        if self.total == 0:
+            return Decimal(0)
+        return Decimal(self.passed) / Decimal(self.total)
+
+
+@dataclass(frozen=True)
+class SkillDelta:
+    """Per-skill reliability before and after the candidate."""
+
+    skill: str
+    baseline_regression: PassStats | None
+    candidate_regression: PassStats | None
+    baseline_overall: PassStats
+    candidate_overall: PassStats
+
+    @property
+    def regression_delta(self) -> Decimal | None:
+        if (
+            self.baseline_regression is None
+            or self.candidate_regression is None
+        ):
+            return None
+        return self.candidate_regression.rate - self.baseline_regression.rate
+
+    @property
+    def overall_delta(self) -> Decimal:
+        return self.candidate_overall.rate - self.baseline_overall.rate
+
+
+@dataclass(frozen=True)
+class TaskChange:
+    """A changed task outcome with the available trial-level counts."""
+
+    task_id: str
+    skill: str
+    suite: str
+    baseline_passed: int
+    candidate_passed: int
+    trials: int
+
+
+@dataclass(frozen=True)
+class ClauseResult:
+    """One independently evaluated promotion clause."""
+
+    key: str
+    title: str
+    passed: bool | None
+    detail: str
+
+
+@dataclass(frozen=True)
+class Comparison:
+    """All values needed by terminal and Markdown renderers."""
+
+    baseline: Mapping[str, object]
+    candidate: Mapping[str, object]
+    skill_deltas: tuple[SkillDelta, ...]
+    task_changes: tuple[TaskChange, ...]
+    clauses: tuple[ClauseResult, ...]
+    baseline_caching_status: str
+    candidate_caching_status: str
+    verdict: str
+
+
+def _mapping(value: object, description: str) -> Mapping[str, object]:
+    if not isinstance(value, Mapping):
+        raise EvalReportError(f"{description} must be an object")
+    return value
+
+
+def _string(value: object, description: str) -> str:
+    if not isinstance(value, str) or not value:
+        raise EvalReportError(f"{description} must be a non-empty string")
+    return value
+
+
+def _integer(value: object, description: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise EvalReportError(f"{description} must be an integer")
+    return value
+
+
+def _decimal(value: object, description: str) -> Decimal:
+    if isinstance(value, bool) or not isinstance(value, (int, float, Decimal)):
+        raise EvalReportError(f"{description} must be numeric")
+    parsed = Decimal(str(value))
+    if not parsed.is_finite():
+        raise EvalReportError(f"{description} must be finite")
+    return parsed
+
+
+def _load_summary_bytes(
+    path: Path,
+    content: bytes,
+) -> Mapping[str, object]:
+    # The existing validator is intentionally reused so reporting cannot become
+    # a weaker ingestion path for forced-added transcripts or unknown fields.
+    validation_path = Path(".eval-runs") / path.name
+    try:
+        summarize.validate_committed_summary(validation_path, content)
+        value = json.loads(content)
+    except (json.JSONDecodeError, summarize.EvalSummaryError) as error:
+        raise EvalReportError(f"invalid run summary {path}: {error}") from error
+    return _mapping(value, f"{path} summary")
+
+
+def load_summary(path: Path) -> Mapping[str, object]:
+    """Load and fully validate one digest-named, transcript-free summary."""
+
+    try:
+        content = path.read_bytes()
+    except OSError as error:
+        raise EvalReportError(f"could not read {path}: {error}") from error
+    return _load_summary_bytes(path, content)
+
+
+def _tasks(summary: Mapping[str, object], label: str) -> Mapping[str, object]:
+    return _mapping(summary.get("tasks"), f"{label}.tasks")
+
+
+def _task(
+    tasks: Mapping[str, object],
+    task_id: str,
+    label: str,
+) -> Mapping[str, object]:
+    return _mapping(tasks.get(task_id), f"{label}.tasks.{task_id}")
+
+
+def _telemetry(
+    summary: Mapping[str, object],
+    label: str,
+) -> Mapping[str, object]:
+    overall = _mapping(summary.get("overall"), f"{label}.overall")
+    return _mapping(overall.get("telemetry"), f"{label}.overall.telemetry")
+
+
+def _suite(
+    summary: Mapping[str, object],
+    suite: str,
+    label: str,
+) -> Mapping[str, object]:
+    suites = _mapping(summary.get("suites"), f"{label}.suites")
+    if suite not in suites:
+        raise EvalReportError(f"{label} has no {suite!r} suite")
+    return _mapping(suites.get(suite), f"{label}.suites.{suite}")
+
+
+def _pass_stats(scope: Mapping[str, object], description: str) -> PassStats:
+    pass_three = _mapping(scope.get("pass^3"), f"{description}.pass^3")
+    return PassStats(
+        passed=_integer(
+            pass_three.get("passed_tasks"),
+            f"{description}.pass^3.passed_tasks",
+        ),
+        total=_integer(
+            pass_three.get("total_tasks"),
+            f"{description}.pass^3.total_tasks",
+        ),
+    )
+
+
+def _skill_pass_stats(
+    summary: Mapping[str, object],
+    skill: str,
+    *,
+    suite: str | None = None,
+) -> PassStats | None:
+    selected: list[Mapping[str, object]] = []
+    for task_id, value in _tasks(summary, "summary").items():
+        task = _mapping(value, f"summary.tasks.{task_id}")
+        if task.get("skill") != skill:
+            continue
+        if suite is not None and task.get("suite") != suite:
+            continue
+        selected.append(task)
+    if not selected:
+        return None
+    return PassStats(
+        passed=sum(task.get("pass^3") is True for task in selected),
+        total=len(selected),
+    )
+
+
+def _validate_comparison_identity(
+    baseline: Mapping[str, object],
+    candidate: Mapping[str, object],
+) -> None:
+    baseline_tasks = _tasks(baseline, "baseline")
+    candidate_tasks = _tasks(candidate, "candidate")
+    if set(baseline_tasks) != set(candidate_tasks):
+        missing = sorted(set(baseline_tasks) - set(candidate_tasks))
+        added = sorted(set(candidate_tasks) - set(baseline_tasks))
+        raise EvalReportError(
+            "summaries must contain the same task IDs "
+            f"(missing from candidate: {missing or 'none'}; "
+            f"candidate-only: {added or 'none'})"
+        )
+    for task_id in sorted(baseline_tasks):
+        baseline_task = _task(baseline_tasks, task_id, "baseline")
+        candidate_task = _task(candidate_tasks, task_id, "candidate")
+        for field in ("skill", "suite", "trials"):
+            if baseline_task.get(field) != candidate_task.get(field):
+                raise EvalReportError(
+                    f"task {task_id} changed {field} between summaries"
+                )
+
+
+def _observed_caching_status(
+    summary: Mapping[str, object],
+    label: str,
+) -> str:
+    telemetry = _telemetry(summary, label)
+    tokens = _mapping(telemetry.get("tokens"), f"{label}.overall.telemetry.tokens")
+    cache_reads = _integer(
+        tokens.get("cache_read_input_tokens"),
+        f"{label}.overall.telemetry.tokens.cache_read_input_tokens",
+    )
+    return "uncached" if cache_reads == 0 else "cached"
+
+
+def _scope_cost_per_task(
+    summary: Mapping[str, object],
+    label: str,
+) -> Decimal:
+    telemetry = _telemetry(summary, label)
+    cost = _mapping(telemetry.get("cost"), f"{label}.overall.telemetry.cost")
+    return _decimal(
+        cost.get("per_task_usd"),
+        f"{label}.overall.telemetry.cost.per_task_usd",
+    )
+
+
+def _percent_change(baseline: Decimal, candidate: Decimal) -> Decimal | None:
+    if baseline == 0:
+        return Decimal(0) if candidate == 0 else None
+    return (candidate - baseline) / baseline
+
+
+def _format_percent(value: Decimal) -> str:
+    return f"{value * Decimal(100):.2f}%"
+
+
+def _format_points(value: Decimal) -> str:
+    return f"{value * Decimal(100):+.2f} pp"
+
+
+def _build_skill_deltas(
+    baseline: Mapping[str, object],
+    candidate: Mapping[str, object],
+) -> tuple[SkillDelta, ...]:
+    skills = sorted(
+        {
+            _string(task.get("skill"), f"tasks.{task_id}.skill")
+            for task_id, value in _tasks(baseline, "baseline").items()
+            for task in [_mapping(value, f"baseline.tasks.{task_id}")]
+        }
+    )
+    rows: list[SkillDelta] = []
+    for skill in skills:
+        baseline_overall = _skill_pass_stats(baseline, skill)
+        candidate_overall = _skill_pass_stats(candidate, skill)
+        if baseline_overall is None or candidate_overall is None:
+            raise EvalReportError(f"skill {skill} is missing from one summary")
+        rows.append(
+            SkillDelta(
+                skill=skill,
+                baseline_regression=_skill_pass_stats(
+                    baseline,
+                    skill,
+                    suite="regression",
+                ),
+                candidate_regression=_skill_pass_stats(
+                    candidate,
+                    skill,
+                    suite="regression",
+                ),
+                baseline_overall=baseline_overall,
+                candidate_overall=candidate_overall,
+            )
+        )
+
+    def severity(row: SkillDelta) -> tuple[int, Decimal, Decimal, str]:
+        regression_delta = row.regression_delta
+        return (
+            0 if regression_delta is not None and regression_delta < 0 else 1,
+            regression_delta if regression_delta is not None else Decimal("Infinity"),
+            row.overall_delta,
+            row.skill,
+        )
+
+    return tuple(sorted(rows, key=severity))
+
+
+def _build_task_changes(
+    baseline: Mapping[str, object],
+    candidate: Mapping[str, object],
+) -> tuple[TaskChange, ...]:
+    baseline_tasks = _tasks(baseline, "baseline")
+    candidate_tasks = _tasks(candidate, "candidate")
+    changes: list[TaskChange] = []
+    for task_id in sorted(baseline_tasks):
+        baseline_task = _task(baseline_tasks, task_id, "baseline")
+        candidate_task = _task(candidate_tasks, task_id, "candidate")
+        baseline_passed = _integer(
+            baseline_task.get("passed_trials"),
+            f"baseline.tasks.{task_id}.passed_trials",
+        )
+        candidate_passed = _integer(
+            candidate_task.get("passed_trials"),
+            f"candidate.tasks.{task_id}.passed_trials",
+        )
+        if baseline_passed == candidate_passed:
+            continue
+        changes.append(
+            TaskChange(
+                task_id=task_id,
+                skill=_string(
+                    baseline_task.get("skill"),
+                    f"baseline.tasks.{task_id}.skill",
+                ),
+                suite=_string(
+                    baseline_task.get("suite"),
+                    f"baseline.tasks.{task_id}.suite",
+                ),
+                baseline_passed=baseline_passed,
+                candidate_passed=candidate_passed,
+                trials=_integer(
+                    baseline_task.get("trials"),
+                    f"baseline.tasks.{task_id}.trials",
+                ),
+            )
+        )
+    return tuple(changes)
+
+
+def _promotion_clauses(
+    baseline: Mapping[str, object],
+    candidate: Mapping[str, object],
+    skill_deltas: Sequence[SkillDelta],
+    baseline_caching_status: str,
+    candidate_caching_status: str,
+) -> tuple[ClauseResult, ...]:
+    regressions = [
+        row
+        for row in skill_deltas
+        if row.regression_delta is not None and row.regression_delta < 0
+    ]
+    if regressions:
+        regression_detail = "Regression-suite drops: " + ", ".join(
+            f"{row.skill} ({_format_points(row.regression_delta or Decimal(0))})"
+            for row in regressions
+        )
+    else:
+        regression_detail = "No skill's regression-suite pass^3 dropped."
+    regression_clause = ClauseResult(
+        key="a",
+        title="No per-skill regression-suite pass^3 drop",
+        passed=not regressions,
+        detail=regression_detail,
+    )
+
+    baseline_capability = _pass_stats(
+        _suite(baseline, "capability", "baseline"),
+        "baseline.suites.capability",
+    )
+    candidate_capability = _pass_stats(
+        _suite(candidate, "capability", "candidate"),
+        "candidate.suites.capability",
+    )
+    capability_improved = candidate_capability.rate > baseline_capability.rate
+    capability_clause = ClauseResult(
+        key="b",
+        title="Overall capability pass^3 improves",
+        passed=capability_improved,
+        detail=(
+            f"{_format_stats(baseline_capability)} -> "
+            f"{_format_stats(candidate_capability)} "
+            f"({_format_points(candidate_capability.rate - baseline_capability.rate)})"
+        ),
+    )
+
+    baseline_cost = _scope_cost_per_task(baseline, "baseline")
+    candidate_cost = _scope_cost_per_task(candidate, "candidate")
+    if baseline_caching_status != candidate_caching_status:
+        cost_clause = ClauseResult(
+            key="c",
+            title="Cost per task increases by no more than 20%",
+            passed=None,
+            detail=(
+                "Declined because observed caching differs "
+                f"(baseline {baseline_caching_status}, "
+                f"candidate {candidate_caching_status}); no cost verdict rendered."
+            ),
+        )
+    else:
+        cost_change = _percent_change(baseline_cost, candidate_cost)
+        if cost_change is None:
+            cost_passed = False
+            change_label = "undefined increase from a zero-cost baseline"
+        else:
+            cost_passed = cost_change <= MAX_COST_INCREASE
+            change_label = _format_percent(cost_change)
+        cost_clause = ClauseResult(
+            key="c",
+            title="Cost per task increases by no more than 20%",
+            passed=cost_passed,
+            detail=(
+                f"${baseline_cost:.6f} -> ${candidate_cost:.6f} "
+                f"({change_label})"
+            ),
+        )
+    return regression_clause, capability_clause, cost_clause
+
+
+def compare_summaries(
+    baseline: Mapping[str, object],
+    candidate: Mapping[str, object],
+) -> Comparison:
+    """Compare validated run summaries and evaluate the promotion rule."""
+
+    _validate_comparison_identity(baseline, candidate)
+    skill_deltas = _build_skill_deltas(baseline, candidate)
+    baseline_caching_status = _observed_caching_status(baseline, "baseline")
+    candidate_caching_status = _observed_caching_status(candidate, "candidate")
+    clauses = _promotion_clauses(
+        baseline,
+        candidate,
+        skill_deltas,
+        baseline_caching_status,
+        candidate_caching_status,
+    )
+    if any(clause.passed is False for clause in clauses):
+        verdict = "REJECT"
+    elif all(clause.passed is True for clause in clauses):
+        verdict = "PROMOTE"
+    else:
+        verdict = "INDETERMINATE"
+    return Comparison(
+        baseline=baseline,
+        candidate=candidate,
+        skill_deltas=skill_deltas,
+        task_changes=_build_task_changes(baseline, candidate),
+        clauses=clauses,
+        baseline_caching_status=baseline_caching_status,
+        candidate_caching_status=candidate_caching_status,
+        verdict=verdict,
+    )
+
+
+def committed_report_name(comparison: Comparison) -> str:
+    """Return the only accepted .eval-runs Markdown filename."""
+
+    baseline_digest = _string(
+        comparison.baseline.get("image_digest"),
+        "baseline.image_digest",
+    ).replace(":", "-")
+    candidate_digest = _string(
+        comparison.candidate.get("image_digest"),
+        "candidate.image_digest",
+    ).replace(":", "-")
+    return f"comparison-{baseline_digest}-vs-{candidate_digest}.md"
+
+
+def _format_stats(stats: PassStats | None) -> str:
+    if stats is None:
+        return "—"
+    return f"{stats.passed}/{stats.total} ({_format_percent(stats.rate)})"
+
+
+def _format_status(passed: bool | None) -> str:
+    if passed is True:
+        return "PASS"
+    if passed is False:
+        return "FAIL"
+    return "DECLINED"
+
+
+def _terminal_table(
+    headers: Sequence[str],
+    rows: Sequence[Sequence[str]],
+) -> list[str]:
+    widths = [
+        max([len(headers[index]), *(len(row[index]) for row in rows)])
+        for index in range(len(headers))
+    ]
+
+    def line(row: Sequence[str]) -> str:
+        return " | ".join(
+            value.ljust(widths[index]) for index, value in enumerate(row)
+        ).rstrip()
+
+    return [
+        line(headers),
+        "-+-".join("-" * width for width in widths),
+        *(line(row) for row in rows),
+    ]
+
+
+def _markdown_table(
+    headers: Sequence[str],
+    rows: Sequence[Sequence[str]],
+) -> list[str]:
+    def escape(value: str) -> str:
+        return value.replace("|", "\\|").replace("\n", " ")
+
+    return [
+        "| " + " | ".join(escape(value) for value in headers) + " |",
+        "| " + " | ".join("---" for _ in headers) + " |",
+        *(
+            "| " + " | ".join(escape(value) for value in row) + " |"
+            for row in rows
+        ),
+    ]
+
+
+def _summary_label(summary: Mapping[str, object], label: str) -> str:
+    model = _mapping(summary.get("model"), f"{label}.model")
+    return (
+        f"{_string(model.get('model_id'), f'{label}.model.model_id')} | "
+        f"{_string(summary.get('image_digest'), f'{label}.image_digest')}"
+    )
+
+
+def _metric_rows(comparison: Comparison) -> list[list[str]]:
+    baseline_telemetry = _telemetry(comparison.baseline, "baseline")
+    candidate_telemetry = _telemetry(comparison.candidate, "candidate")
+    caching_matches = (
+        comparison.baseline_caching_status
+        == comparison.candidate_caching_status
+    )
+    rows: list[list[str]] = []
+
+    baseline_cost = _mapping(
+        baseline_telemetry.get("cost"),
+        "baseline.overall.telemetry.cost",
+    )
+    candidate_cost = _mapping(
+        candidate_telemetry.get("cost"),
+        "candidate.overall.telemetry.cost",
+    )
+    for field, title in (
+        ("per_task_usd", "Cost / task"),
+        ("total_usd", "Cost total"),
+    ):
+        baseline_value = _decimal(
+            baseline_cost.get(field),
+            f"baseline.overall.telemetry.cost.{field}",
+        )
+        candidate_value = _decimal(
+            candidate_cost.get(field),
+            f"candidate.overall.telemetry.cost.{field}",
+        )
+        change = _percent_change(baseline_value, candidate_value)
+        if not caching_matches:
+            delta = "declined: caching mismatch"
+        elif change is None:
+            delta = "undefined from zero baseline"
+        else:
+            delta = _format_percent(change)
+        rows.append(
+            [
+                title,
+                f"${baseline_value:.6f}",
+                f"${candidate_value:.6f}",
+                delta,
+            ]
+        )
+
+    for field, title in (
+        ("duration_ms", "Duration mean"),
+        ("latency_ms", "Latency mean"),
+        ("model_call_count", "Model calls mean"),
+    ):
+        baseline_distribution = _mapping(
+            baseline_telemetry.get(field),
+            f"baseline.overall.telemetry.{field}",
+        )
+        candidate_distribution = _mapping(
+            candidate_telemetry.get(field),
+            f"candidate.overall.telemetry.{field}",
+        )
+        baseline_value = _decimal(
+            baseline_distribution.get("mean"),
+            f"baseline.overall.telemetry.{field}.mean",
+        )
+        candidate_value = _decimal(
+            candidate_distribution.get("mean"),
+            f"candidate.overall.telemetry.{field}.mean",
+        )
+        unit = " ms" if field != "model_call_count" else ""
+        rows.append(
+            [
+                title,
+                f"{baseline_value:.3f}{unit}",
+                f"{candidate_value:.3f}{unit}",
+                f"{candidate_value - baseline_value:+.3f}{unit}",
+            ]
+        )
+
+    baseline_model_calls = _mapping(
+        baseline_telemetry.get("model_call_count"),
+        "baseline.overall.telemetry.model_call_count",
+    )
+    candidate_model_calls = _mapping(
+        candidate_telemetry.get("model_call_count"),
+        "candidate.overall.telemetry.model_call_count",
+    )
+    baseline_model_call_total = _integer(
+        baseline_model_calls.get("total"),
+        "baseline.overall.telemetry.model_call_count.total",
+    )
+    candidate_model_call_total = _integer(
+        candidate_model_calls.get("total"),
+        "candidate.overall.telemetry.model_call_count.total",
+    )
+    rows.append(
+        [
+            "Model calls total",
+            str(baseline_model_call_total),
+            str(candidate_model_call_total),
+            f"{candidate_model_call_total - baseline_model_call_total:+d}",
+        ]
+    )
+
+    for field, title in (
+        ("duration_ms", "Duration p50 / p95"),
+        ("latency_ms", "Latency p50 / p95"),
+    ):
+        baseline_distribution = _mapping(
+            baseline_telemetry.get(field),
+            f"baseline.overall.telemetry.{field}",
+        )
+        candidate_distribution = _mapping(
+            candidate_telemetry.get(field),
+            f"candidate.overall.telemetry.{field}",
+        )
+        baseline_p50 = _integer(
+            baseline_distribution.get("p50"),
+            f"baseline.overall.telemetry.{field}.p50",
+        )
+        baseline_p95 = _integer(
+            baseline_distribution.get("p95"),
+            f"baseline.overall.telemetry.{field}.p95",
+        )
+        candidate_p50 = _integer(
+            candidate_distribution.get("p50"),
+            f"candidate.overall.telemetry.{field}.p50",
+        )
+        candidate_p95 = _integer(
+            candidate_distribution.get("p95"),
+            f"candidate.overall.telemetry.{field}.p95",
+        )
+        rows.append(
+            [
+                title,
+                f"{baseline_p50} / {baseline_p95} ms",
+                f"{candidate_p50} / {candidate_p95} ms",
+                f"{candidate_p50 - baseline_p50:+d} / "
+                f"{candidate_p95 - baseline_p95:+d} ms",
+            ]
+        )
+
+    for field, title in (("nudged", "Nudged rate"),):
+        baseline_rate = _decimal(
+            _mapping(
+                baseline_telemetry.get(field),
+                f"baseline.overall.telemetry.{field}",
+            ).get("rate"),
+            f"baseline.overall.telemetry.{field}.rate",
+        )
+        candidate_rate = _decimal(
+            _mapping(
+                candidate_telemetry.get(field),
+                f"candidate.overall.telemetry.{field}",
+            ).get("rate"),
+            f"candidate.overall.telemetry.{field}.rate",
+        )
+        rows.append(
+            [
+                title,
+                _format_percent(baseline_rate),
+                _format_percent(candidate_rate),
+                _format_points(candidate_rate - baseline_rate),
+            ]
+        )
+
+    baseline_failures = _mapping(
+        baseline_telemetry.get("failures"),
+        "baseline.overall.telemetry.failures",
+    )
+    candidate_failures = _mapping(
+        candidate_telemetry.get("failures"),
+        "candidate.overall.telemetry.failures",
+    )
+    baseline_failure_rate = _decimal(
+        baseline_failures.get("rate"),
+        "baseline.overall.telemetry.failures.rate",
+    )
+    candidate_failure_rate = _decimal(
+        candidate_failures.get("rate"),
+        "candidate.overall.telemetry.failures.rate",
+    )
+    rows.append(
+        [
+            "Runtime failure rate",
+            _format_percent(baseline_failure_rate),
+            _format_percent(candidate_failure_rate),
+            _format_points(candidate_failure_rate - baseline_failure_rate),
+        ]
+    )
+    return rows
+
+
+def _failure_rows(comparison: Comparison) -> list[list[str]]:
+    def counts(
+        summary: Mapping[str, object],
+        label: str,
+    ) -> Mapping[str, object]:
+        telemetry = _telemetry(summary, label)
+        failures = _mapping(
+            telemetry.get("failures"),
+            f"{label}.overall.telemetry.failures",
+        )
+        return _mapping(
+            failures.get("by_error_class"),
+            f"{label}.overall.telemetry.failures.by_error_class",
+        )
+
+    baseline_counts = counts(comparison.baseline, "baseline")
+    candidate_counts = counts(comparison.candidate, "candidate")
+    classes = sorted(set(baseline_counts) | set(candidate_counts))
+    if not classes:
+        return [["<none>", "0", "0", "0"]]
+    rows: list[list[str]] = []
+    for error_class in classes:
+        baseline_value = _integer(
+            baseline_counts.get(error_class, 0),
+            f"baseline failure class {error_class}",
+        )
+        candidate_value = _integer(
+            candidate_counts.get(error_class, 0),
+            f"candidate failure class {error_class}",
+        )
+        rows.append(
+            [
+                error_class,
+                str(baseline_value),
+                str(candidate_value),
+                f"{candidate_value - baseline_value:+d}",
+            ]
+        )
+    return rows
+
+
+def _skill_rows(comparison: Comparison) -> list[list[str]]:
+    return [
+        [
+            row.skill,
+            _format_stats(row.baseline_regression),
+            _format_stats(row.candidate_regression),
+            (
+                _format_points(row.regression_delta)
+                if row.regression_delta is not None
+                else "—"
+            ),
+            _format_stats(row.baseline_overall),
+            _format_stats(row.candidate_overall),
+            _format_points(row.overall_delta),
+        ]
+        for row in comparison.skill_deltas
+    ]
+
+
+def _task_change_rows(comparison: Comparison) -> list[list[str]]:
+    return [
+        [
+            change.task_id,
+            change.skill,
+            change.suite,
+            (
+                f"{change.baseline_passed}/{change.trials} "
+                f"({'PASS' if change.baseline_passed == change.trials else 'FAIL'})"
+            ),
+            (
+                f"{change.candidate_passed}/{change.trials} "
+                f"({'PASS' if change.candidate_passed == change.trials else 'FAIL'})"
+            ),
+        ]
+        for change in comparison.task_changes
+    ]
+
+
+def render_terminal(comparison: Comparison) -> str:
+    """Render a compact report for an interactive terminal."""
+
+    lines = [
+        "Agent eval comparison",
+        f"Verdict: {comparison.verdict}",
+        f"Baseline:  {_summary_label(comparison.baseline, 'baseline')}",
+        f"Candidate: {_summary_label(comparison.candidate, 'candidate')}",
+        (
+            "Observed caching: "
+            f"{comparison.baseline_caching_status} -> "
+            f"{comparison.candidate_caching_status}"
+        ),
+        "",
+        "Promotion rule",
+    ]
+    lines.extend(
+        f"[{_format_status(clause.passed)}] ({clause.key}) "
+        f"{clause.title}: {clause.detail}"
+        for clause in comparison.clauses
+    )
+    lines.extend(
+        [
+            "",
+            "Per-skill pass^3",
+            *_terminal_table(
+                (
+                    "Skill",
+                    "Regression base",
+                    "Regression cand",
+                    "Regression Δ",
+                    "Overall base",
+                    "Overall cand",
+                    "Overall Δ",
+                ),
+                _skill_rows(comparison),
+            ),
+            "",
+            "Operational telemetry",
+            *_terminal_table(
+                ("Metric", "Baseline", "Candidate", "Delta"),
+                _metric_rows(comparison),
+            ),
+            "",
+            "Runtime failure classes",
+            *_terminal_table(
+                ("Error class", "Baseline", "Candidate", "Delta"),
+                _failure_rows(comparison),
+            ),
+            "",
+            "Changed task trial outcomes",
+        ]
+    )
+    if comparison.task_changes:
+        lines.extend(
+            _terminal_table(
+                ("Task", "Skill", "Suite", "Baseline", "Candidate"),
+                _task_change_rows(comparison),
+            )
+        )
+    else:
+        lines.append("No task passed-trial counts changed.")
+    return "\n".join(lines) + "\n"
+
+
+def render_markdown(comparison: Comparison) -> str:
+    """Render a report suitable for committing beside run summaries."""
+
+    lines = [
+        "# Agent eval comparison",
+        "",
+        f"**Verdict: {comparison.verdict}**",
+        "",
+        f"- Baseline: `{_summary_label(comparison.baseline, 'baseline')}`",
+        f"- Candidate: `{_summary_label(comparison.candidate, 'candidate')}`",
+        (
+            "- Observed caching: "
+            f"`{comparison.baseline_caching_status}` → "
+            f"`{comparison.candidate_caching_status}`"
+        ),
+        "",
+        "## Promotion rule",
+        "",
+        *_markdown_table(
+            ("Clause", "Status", "Evidence"),
+            [
+                [
+                    f"({clause.key}) {clause.title}",
+                    _format_status(clause.passed),
+                    clause.detail,
+                ]
+                for clause in comparison.clauses
+            ],
+        ),
+        "",
+        "## Per-skill pass^3",
+        "",
+        *_markdown_table(
+            (
+                "Skill",
+                "Regression baseline",
+                "Regression candidate",
+                "Regression delta",
+                "Overall baseline",
+                "Overall candidate",
+                "Overall delta",
+            ),
+            _skill_rows(comparison),
+        ),
+        "",
+        "## Operational telemetry",
+        "",
+        *_markdown_table(
+            ("Metric", "Baseline", "Candidate", "Delta"),
+            _metric_rows(comparison),
+        ),
+        "",
+        "## Runtime failure classes",
+        "",
+        *_markdown_table(
+            ("Error class", "Baseline", "Candidate", "Delta"),
+            _failure_rows(comparison),
+        ),
+        "",
+        "## Changed task trial outcomes",
+        "",
+    ]
+    if comparison.task_changes:
+        lines.extend(
+            _markdown_table(
+                ("Task", "Skill", "Suite", "Baseline", "Candidate"),
+                _task_change_rows(comparison),
+            )
+        )
+    else:
+        lines.append("No task passed-trial counts changed.")
+    lines.extend(
+        [
+            "",
+            "_`pass^3` means all three trials passed. No confidence interval is "
+            "reported because three trials do not support that precision._",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def validate_committed_report(
+    path: Path,
+    content: bytes,
+    summary_blobs: Mapping[Path, bytes],
+) -> None:
+    """Require committed Markdown to be exactly reproducible from summaries."""
+
+    if path.parent != Path(".eval-runs"):
+        raise EvalReportError(f"{path} must be directly inside .eval-runs")
+    match = SAFE_REPORT_NAME_RE.fullmatch(path.name)
+    if match is None:
+        raise EvalReportError(
+            f"{path} must use the digest-pair comparison report filename"
+        )
+    baseline_path = Path(".eval-runs") / f"{match.group(1)}.json"
+    candidate_path = Path(".eval-runs") / f"{match.group(2)}.json"
+    missing = [
+        summary_path
+        for summary_path in (baseline_path, candidate_path)
+        if summary_path not in summary_blobs
+    ]
+    if missing:
+        raise EvalReportError(
+            f"{path} references untracked run summaries: "
+            + ", ".join(str(summary_path) for summary_path in missing)
+        )
+    comparison = compare_summaries(
+        _load_summary_bytes(baseline_path, summary_blobs[baseline_path]),
+        _load_summary_bytes(candidate_path, summary_blobs[candidate_path]),
+    )
+    if path.name != committed_report_name(comparison):
+        raise EvalReportError(f"{path} filename does not match its summaries")
+    if content != render_markdown(comparison).encode("utf-8"):
+        raise EvalReportError(
+            f"{path} does not exactly match the report regenerated "
+            "from its tracked summaries"
+        )
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Compare two transcript-free agent-eval run summaries.",
+    )
+    parser.add_argument("baseline", type=Path, help="baseline summary JSON")
+    parser.add_argument("candidate", type=Path, help="candidate summary JSON")
+    parser.add_argument(
+        "--format",
+        choices=("terminal", "markdown"),
+        default="terminal",
+        dest="output_format",
+        help="report rendering (default: terminal)",
+    )
+    parser.add_argument("--out", type=Path, help="write the report to this path")
+    parser.add_argument(
+        "--require-promotion",
+        action="store_true",
+        help="exit 1 unless every promotion clause passes",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    try:
+        comparison = compare_summaries(
+            load_summary(args.baseline),
+            load_summary(args.candidate),
+        )
+        rendered = (
+            render_markdown(comparison)
+            if args.output_format == "markdown"
+            else render_terminal(comparison)
+        )
+        if args.out is None:
+            sys.stdout.write(rendered)
+        else:
+            if (
+                args.output_format == "markdown"
+                and args.out.parent.name == ".eval-runs"
+                and args.out.name != committed_report_name(comparison)
+            ):
+                raise EvalReportError(
+                    "a report under .eval-runs must be named "
+                    f"{committed_report_name(comparison)}"
+                )
+            args.out.write_text(rendered, encoding="utf-8")
+    except (EvalReportError, OSError) as error:
+        print(f"eval report failed: {error}", file=sys.stderr)
+        return 2
+    if args.require_promotion and comparison.verdict != "PROMOTE":
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/infra/agent-image/eval/summarize.py
+++ b/infra/agent-image/eval/summarize.py
@@ -1437,6 +1437,7 @@ def check_repository(repo_root: Path) -> list[Path]:
         for value in result.stdout.split(b"\0")
         if value
     ]
+    indexed_blobs: dict[Path, bytes] = {}
     for relative_path in tracked:
         indexed_blob = subprocess.run(
             [
@@ -1457,7 +1458,23 @@ def check_repository(repo_root: Path) -> list[Path]:
             raise EvalSummaryError(
                 f"could not read staged {relative_path}: {detail}"
             )
-        validate_committed_summary(relative_path, indexed_blob.stdout)
+        indexed_blobs[relative_path] = indexed_blob.stdout
+    for relative_path, content in indexed_blobs.items():
+        if relative_path.suffix == ".md":
+            # Imported lazily to keep the summary writer independent from the
+            # comparison renderer during normal summary generation.
+            import report
+
+            try:
+                report.validate_committed_report(
+                    relative_path,
+                    content,
+                    indexed_blobs,
+                )
+            except report.EvalReportError as error:
+                raise EvalSummaryError(str(error)) from error
+        else:
+            validate_committed_summary(relative_path, content)
     return tracked
 
 

--- a/infra/agent-image/test_report.py
+++ b/infra/agent-image/test_report.py
@@ -404,6 +404,21 @@ class ReportRenderingTests(unittest.TestCase):
 
 
 class InputAndCliTests(unittest.TestCase):
+    def test_harness_commit_changes_are_rejected(self):
+        specs = {
+            "reg-a": ("skill-a", "regression", 3),
+            "cap-a": ("skill-a", "capability", 2),
+        }
+        baseline = build_summary(specs, digest_character="a")
+        candidate = build_summary(specs, digest_character="b")
+        candidate["eval_harness_commit"] = "e" * 40
+
+        with self.assertRaisesRegex(
+            eval_report.EvalReportError,
+            "same eval_harness_commit",
+        ):
+            eval_report.compare_summaries(baseline, candidate)
+
     def test_task_identity_changes_are_rejected(self):
         baseline = build_summary(
             {

--- a/infra/agent-image/test_report.py
+++ b/infra/agent-image/test_report.py
@@ -254,6 +254,10 @@ class PromotionRuleTests(unittest.TestCase):
 
         self.assertFalse(clause(comparison, "c").passed)
         self.assertIn("200.00%", clause(comparison, "c").detail)
+        self.assertEqual(
+            [row[3] for row in eval_report._metric_rows(comparison)[:2]],
+            ["200.00%", "200.00%"],
+        )
         self.assertEqual(comparison.verdict, "REJECT")
 
     def test_caching_mismatch_declines_cost_clause(self):

--- a/infra/agent-image/test_report.py
+++ b/infra/agent-image/test_report.py
@@ -1,0 +1,548 @@
+"""Hermetic tests for agent-eval comparison reporting.
+
+Run with:
+    uv run --python 3.12 --no-project -m unittest \
+      infra/agent-image/test_report.py
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from decimal import Decimal
+from pathlib import Path
+
+AGENT_IMAGE_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(AGENT_IMAGE_DIR / "eval"))
+
+import report as eval_report  # noqa: E402
+import summarize  # noqa: E402
+
+
+TaskSpecs = dict[str, tuple[str, str, int]]
+
+
+def pricing() -> dict[str, object]:
+    return {
+        "primary": "amazon-bedrock/synthetic-model",
+        "provider": "amazon-bedrock",
+        "model_id": "synthetic-model",
+        "pricing_usd_per_million_tokens": {
+            "input": Decimal("1"),
+            "output": Decimal("0"),
+            "cacheRead": Decimal("0"),
+            "cacheWrite": Decimal("0"),
+        },
+    }
+
+
+def build_summary(
+    specs: TaskSpecs,
+    *,
+    digest_character: str,
+    input_tokens: int = 1000,
+    cache_reads: int = 100,
+    duration_ms: int = 1000,
+    model_calls: int = 2,
+    nudged_tasks: frozenset[str] = frozenset(),
+    runtime_failures: dict[str, str] | None = None,
+) -> dict[str, object]:
+    digest = "sha256:" + (digest_character * 64)
+    image = (
+        "123456789012.dkr.ecr.us-east-1.amazonaws.com/agent@" + digest
+    )
+    failures = runtime_failures or {}
+    records: list[dict[str, object]] = []
+    sequence = 0
+    for task_id, (skill, suite, passed_trials) in specs.items():
+        for trial in range(1, 4):
+            sequence += 1
+            failed = task_id in failures and trial == 1
+            records.append(
+                {
+                    "task_id": task_id,
+                    "image": image,
+                    "skill": skill,
+                    "suite": suite,
+                    "level": "L1",
+                    "workspace": "pure",
+                    "trial": trial,
+                    "trials": 3,
+                    "prompt": "synthetic prompt",
+                    "session_id": (
+                        f"00000000-0000-4000-8000-{sequence:012d}"
+                    ),
+                    "result": "synthetic result",
+                    "metadata": {
+                        "input_tokens": input_tokens,
+                        "output_tokens": 0,
+                        "cache_read_input_tokens": cache_reads,
+                        "cache_write_input_tokens": 0,
+                        "model_call_count": model_calls,
+                        "duration_ms": duration_ms + trial,
+                        "latency_ms": duration_ms - 100 + trial,
+                        "nudged": task_id in nudged_tasks and trial == 1,
+                        "tool_calls": [],
+                        "failed": failed,
+                        "error_class": failures.get(task_id) if failed else None,
+                    },
+                    "broker_requests": [],
+                    "grade": {
+                        "passed": trial <= passed_trials,
+                        "reason": "synthetic",
+                        "results": [],
+                    },
+                    "run_started_at": "2026-07-29T00:00:00+00:00",
+                    "recorded_at": (
+                        f"2026-07-29T00:00:{sequence:02d}+00:00"
+                    ),
+                }
+            )
+    return summarize.summarize_records(
+        records,
+        pricing(),
+        expected_image=image,
+        source_commit="c" * 40,
+        source_commit_provenance="image-label",
+        eval_harness_commit="d" * 40,
+    )
+
+
+def write_summary(directory: Path, summary: dict[str, object]) -> Path:
+    digest = str(summary["image_digest"])
+    path = directory / f"{digest.replace(':', '-')}.json"
+    path.write_text(json.dumps(summary), encoding="utf-8")
+    return path
+
+
+def summary_index_path(summary: dict[str, object]) -> Path:
+    digest = str(summary["image_digest"])
+    return Path(".eval-runs") / f"{digest.replace(':', '-')}.json"
+
+
+def clause(
+    comparison: eval_report.Comparison,
+    key: str,
+) -> eval_report.ClauseResult:
+    return next(item for item in comparison.clauses if item.key == key)
+
+
+class PromotionRuleTests(unittest.TestCase):
+    def test_all_clauses_pass_at_exactly_twenty_percent_cost_increase(self):
+        baseline = build_summary(
+            {
+                "reg-a": ("skill-a", "regression", 3),
+                "cap-a": ("skill-a", "capability", 2),
+            },
+            digest_character="a",
+            input_tokens=1000,
+        )
+        candidate = build_summary(
+            {
+                "reg-a": ("skill-a", "regression", 3),
+                "cap-a": ("skill-a", "capability", 3),
+            },
+            digest_character="b",
+            input_tokens=1200,
+        )
+
+        comparison = eval_report.compare_summaries(baseline, candidate)
+
+        self.assertEqual(comparison.verdict, "PROMOTE")
+        self.assertTrue(all(item.passed is True for item in comparison.clauses))
+        self.assertIn("20.00%", clause(comparison, "c").detail)
+
+    def test_single_skill_regression_blocks_aggregate_improvement(self):
+        baseline = build_summary(
+            {
+                "reg-a": ("skill-a", "regression", 3),
+                "cap-a": ("skill-a", "capability", 2),
+                "cap-b": ("skill-b", "capability", 2),
+            },
+            digest_character="a",
+        )
+        candidate = build_summary(
+            {
+                "reg-a": ("skill-a", "regression", 2),
+                "cap-a": ("skill-a", "capability", 3),
+                "cap-b": ("skill-b", "capability", 3),
+            },
+            digest_character="b",
+        )
+
+        comparison = eval_report.compare_summaries(baseline, candidate)
+
+        self.assertEqual(comparison.verdict, "REJECT")
+        self.assertFalse(clause(comparison, "a").passed)
+        self.assertTrue(clause(comparison, "b").passed)
+        self.assertIn("skill-a", clause(comparison, "a").detail)
+
+    def test_capability_must_strictly_improve(self):
+        specs = {
+            "reg-a": ("skill-a", "regression", 3),
+            "cap-a": ("skill-a", "capability", 2),
+        }
+        baseline = build_summary(specs, digest_character="a")
+        candidate = build_summary(specs, digest_character="b")
+
+        comparison = eval_report.compare_summaries(baseline, candidate)
+
+        self.assertTrue(clause(comparison, "a").passed)
+        self.assertFalse(clause(comparison, "b").passed)
+        self.assertTrue(clause(comparison, "c").passed)
+        self.assertEqual(comparison.verdict, "REJECT")
+
+    def test_cost_increase_over_twenty_percent_rejects(self):
+        baseline = build_summary(
+            {
+                "reg-a": ("skill-a", "regression", 3),
+                "cap-a": ("skill-a", "capability", 2),
+            },
+            digest_character="a",
+            input_tokens=1000,
+        )
+        candidate = build_summary(
+            {
+                "reg-a": ("skill-a", "regression", 3),
+                "cap-a": ("skill-a", "capability", 3),
+            },
+            digest_character="b",
+            input_tokens=1201,
+        )
+
+        comparison = eval_report.compare_summaries(baseline, candidate)
+
+        self.assertTrue(clause(comparison, "a").passed)
+        self.assertTrue(clause(comparison, "b").passed)
+        self.assertFalse(clause(comparison, "c").passed)
+        self.assertEqual(comparison.verdict, "REJECT")
+
+    def test_caching_mismatch_declines_cost_clause(self):
+        baseline = build_summary(
+            {
+                "reg-a": ("skill-a", "regression", 3),
+                "cap-a": ("skill-a", "capability", 2),
+            },
+            digest_character="a",
+            cache_reads=100,
+        )
+        candidate = build_summary(
+            {
+                "reg-a": ("skill-a", "regression", 3),
+                "cap-a": ("skill-a", "capability", 3),
+            },
+            digest_character="b",
+            cache_reads=0,
+        )
+
+        comparison = eval_report.compare_summaries(baseline, candidate)
+        rendered = eval_report.render_terminal(comparison)
+
+        self.assertEqual(comparison.baseline_caching_status, "cached")
+        self.assertEqual(comparison.candidate_caching_status, "uncached")
+        self.assertIsNone(clause(comparison, "c").passed)
+        self.assertEqual(comparison.verdict, "INDETERMINATE")
+        self.assertIn("[DECLINED] (c)", rendered)
+        self.assertIn("declined: caching mismatch", rendered)
+
+    def test_zero_observed_cache_reads_are_derived_as_uncached(self):
+        baseline = build_summary(
+            {
+                "reg-a": ("skill-a", "regression", 3),
+                "cap-a": ("skill-a", "capability", 2),
+            },
+            digest_character="a",
+            cache_reads=0,
+        )
+        candidate = build_summary(
+            {
+                "reg-a": ("skill-a", "regression", 3),
+                "cap-a": ("skill-a", "capability", 3),
+            },
+            digest_character="b",
+            cache_reads=0,
+        )
+
+        comparison = eval_report.compare_summaries(baseline, candidate)
+
+        self.assertEqual(comparison.baseline_caching_status, "uncached")
+        self.assertEqual(comparison.candidate_caching_status, "uncached")
+        self.assertTrue(clause(comparison, "c").passed)
+
+
+class ReportRenderingTests(unittest.TestCase):
+    def test_changed_tasks_show_passed_trial_counts_in_both_formats(self):
+        baseline = build_summary(
+            {
+                "reg-a": ("skill-a", "regression", 3),
+                "cap-a": ("skill-a", "capability", 2),
+            },
+            digest_character="a",
+        )
+        candidate = build_summary(
+            {
+                "reg-a": ("skill-a", "regression", 3),
+                "cap-a": ("skill-a", "capability", 3),
+            },
+            digest_character="b",
+        )
+
+        comparison = eval_report.compare_summaries(baseline, candidate)
+
+        for rendered in (
+            eval_report.render_terminal(comparison),
+            eval_report.render_markdown(comparison),
+        ):
+            self.assertIn("cap-a", rendered)
+            self.assertIn("2/3 (FAIL)", rendered)
+            self.assertIn("3/3 (PASS)", rendered)
+
+    def test_report_includes_all_required_telemetry_and_failures(self):
+        specs = {
+            "reg-a": ("skill-a", "regression", 3),
+            "cap-a": ("skill-a", "capability", 2),
+        }
+        baseline = build_summary(
+            specs,
+            digest_character="a",
+            duration_ms=1000,
+            model_calls=2,
+            nudged_tasks=frozenset({"reg-a"}),
+            runtime_failures={"reg-a": "BaselineFailure"},
+        )
+        candidate = build_summary(
+            {
+                **specs,
+                "cap-a": ("skill-a", "capability", 3),
+            },
+            digest_character="b",
+            duration_ms=1200,
+            model_calls=4,
+            runtime_failures={"cap-a": "CandidateFailure"},
+        )
+
+        rendered = eval_report.render_markdown(
+            eval_report.compare_summaries(baseline, candidate)
+        )
+
+        for expected in (
+            "Per-skill pass^3",
+            "Cost / task",
+            "Duration mean",
+            "Latency mean",
+            "Model calls mean",
+            "Nudged rate",
+            "Runtime failure classes",
+            "BaselineFailure",
+            "CandidateFailure",
+        ):
+            self.assertIn(expected, rendered)
+
+    def test_regression_rows_are_sorted_by_most_severe_drop(self):
+        baseline_specs = {
+            "reg-a1": ("skill-a", "regression", 3),
+            "reg-a2": ("skill-a", "regression", 3),
+            "reg-b1": ("skill-b", "regression", 3),
+            "reg-b2": ("skill-b", "regression", 3),
+            "cap-a": ("skill-a", "capability", 2),
+        }
+        candidate_specs = {
+            **baseline_specs,
+            "reg-a1": ("skill-a", "regression", 2),
+            "reg-a2": ("skill-a", "regression", 2),
+            "reg-b1": ("skill-b", "regression", 2),
+            "cap-a": ("skill-a", "capability", 3),
+        }
+        comparison = eval_report.compare_summaries(
+            build_summary(baseline_specs, digest_character="a"),
+            build_summary(candidate_specs, digest_character="b"),
+        )
+
+        self.assertEqual(
+            [row.skill for row in comparison.skill_deltas[:2]],
+            ["skill-a", "skill-b"],
+        )
+
+
+class InputAndCliTests(unittest.TestCase):
+    def test_task_identity_changes_are_rejected(self):
+        baseline = build_summary(
+            {
+                "reg-a": ("skill-a", "regression", 3),
+                "cap-a": ("skill-a", "capability", 2),
+            },
+            digest_character="a",
+        )
+        candidate = build_summary(
+            {
+                "reg-a": ("renamed-skill", "regression", 3),
+                "cap-a": ("skill-a", "capability", 3),
+            },
+            digest_character="b",
+        )
+
+        with self.assertRaisesRegex(
+            eval_report.EvalReportError,
+            "changed skill",
+        ):
+            eval_report.compare_summaries(baseline, candidate)
+
+    def test_cli_writes_markdown_and_enforces_promotion(self):
+        baseline = build_summary(
+            {
+                "reg-a": ("skill-a", "regression", 3),
+                "cap-a": ("skill-a", "capability", 2),
+            },
+            digest_character="a",
+        )
+        candidate = build_summary(
+            {
+                "reg-a": ("skill-a", "regression", 3),
+                "cap-a": ("skill-a", "capability", 3),
+            },
+            digest_character="b",
+        )
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            baseline_path = write_summary(root, baseline)
+            candidate_path = write_summary(root, candidate)
+            output_path = root / "comparison.md"
+
+            exit_code = eval_report.main(
+                [
+                    str(baseline_path),
+                    str(candidate_path),
+                    "--format",
+                    "markdown",
+                    "--out",
+                    str(output_path),
+                    "--require-promotion",
+                ]
+            )
+
+            self.assertEqual(exit_code, 0)
+            self.assertIn("**Verdict: PROMOTE**", output_path.read_text())
+
+    def test_cli_requirement_fails_for_rejected_candidate(self):
+        specs = {
+            "reg-a": ("skill-a", "regression", 3),
+            "cap-a": ("skill-a", "capability", 2),
+        }
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            baseline_path = write_summary(
+                root,
+                build_summary(specs, digest_character="a"),
+            )
+            candidate_path = write_summary(
+                root,
+                build_summary(specs, digest_character="b"),
+            )
+
+            exit_code = eval_report.main(
+                [
+                    str(baseline_path),
+                    str(candidate_path),
+                    "--require-promotion",
+                    "--out",
+                    str(root / "report.txt"),
+                ]
+            )
+
+            self.assertEqual(exit_code, 1)
+
+    def test_loader_rejects_non_digest_named_summary(self):
+        summary = build_summary(
+            {
+                "reg-a": ("skill-a", "regression", 3),
+                "cap-a": ("skill-a", "capability", 2),
+            },
+            digest_character="a",
+        )
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            path = Path(temporary_directory) / "summary.json"
+            path.write_text(json.dumps(summary), encoding="utf-8")
+
+            with self.assertRaisesRegex(
+                eval_report.EvalReportError,
+                "digest-named",
+            ):
+                eval_report.load_summary(path)
+
+
+class CommittedReportGuardTests(unittest.TestCase):
+    def summaries(
+        self,
+    ) -> tuple[dict[str, object], dict[str, object]]:
+        baseline = build_summary(
+            {
+                "reg-a": ("skill-a", "regression", 3),
+                "cap-a": ("skill-a", "capability", 2),
+            },
+            digest_character="a",
+        )
+        candidate = build_summary(
+            {
+                "reg-a": ("skill-a", "regression", 3),
+                "cap-a": ("skill-a", "capability", 3),
+            },
+            digest_character="b",
+        )
+        return baseline, candidate
+
+    def test_exact_generated_markdown_is_accepted_and_tampering_is_rejected(
+        self,
+    ):
+        baseline, candidate = self.summaries()
+        comparison = eval_report.compare_summaries(baseline, candidate)
+        path = Path(".eval-runs") / eval_report.committed_report_name(comparison)
+        summary_blobs = {
+            summary_index_path(baseline): json.dumps(baseline).encode("utf-8"),
+            summary_index_path(candidate): json.dumps(candidate).encode("utf-8"),
+        }
+        content = eval_report.render_markdown(comparison).encode("utf-8")
+
+        eval_report.validate_committed_report(path, content, summary_blobs)
+        with self.assertRaisesRegex(
+            eval_report.EvalReportError,
+            "does not exactly match",
+        ):
+            eval_report.validate_committed_report(
+                path,
+                content + b"\nprivate note",
+                summary_blobs,
+            )
+
+    def test_repository_guard_accepts_reproducible_markdown_from_index(self):
+        baseline, candidate = self.summaries()
+        comparison = eval_report.compare_summaries(baseline, candidate)
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            repo = Path(temporary_directory)
+            subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+            artifact_dir = repo / ".eval-runs"
+            artifact_dir.mkdir()
+            write_summary(artifact_dir, baseline)
+            write_summary(artifact_dir, candidate)
+            report_path = (
+                artifact_dir / eval_report.committed_report_name(comparison)
+            )
+            report_path.write_text(
+                eval_report.render_markdown(comparison),
+                encoding="utf-8",
+            )
+            subprocess.run(
+                ["git", "add", ".eval-runs"],
+                cwd=repo,
+                check=True,
+            )
+
+            tracked = summarize.check_repository(repo)
+
+            self.assertEqual(len(tracked), 3)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/infra/agent-image/test_report.py
+++ b/infra/agent-image/test_report.py
@@ -203,7 +203,7 @@ class PromotionRuleTests(unittest.TestCase):
                 "cap-a": ("skill-a", "capability", 2),
             },
             digest_character="a",
-            input_tokens=1000,
+            input_tokens=25000,
         )
         candidate = build_summary(
             {
@@ -211,7 +211,7 @@ class PromotionRuleTests(unittest.TestCase):
                 "cap-a": ("skill-a", "capability", 3),
             },
             digest_character="b",
-            input_tokens=1201,
+            input_tokens=30001,
         )
 
         comparison = eval_report.compare_summaries(baseline, candidate)
@@ -219,6 +219,17 @@ class PromotionRuleTests(unittest.TestCase):
         self.assertTrue(clause(comparison, "a").passed)
         self.assertTrue(clause(comparison, "b").passed)
         self.assertFalse(clause(comparison, "c").passed)
+        self.assertIn(
+            "20.00% (over 20% limit)",
+            clause(comparison, "c").detail,
+        )
+        self.assertEqual(
+            [row[3] for row in eval_report._metric_rows(comparison)[:2]],
+            [
+                "20.00% (over 20% limit)",
+                "20.00% (over 20% limit)",
+            ],
+        )
         self.assertEqual(comparison.verdict, "REJECT")
 
     def test_cost_clause_uses_unrounded_tokens_and_prices(self):
@@ -256,7 +267,10 @@ class PromotionRuleTests(unittest.TestCase):
         self.assertIn("200.00%", clause(comparison, "c").detail)
         self.assertEqual(
             [row[3] for row in eval_report._metric_rows(comparison)[:2]],
-            ["200.00%", "200.00%"],
+            [
+                "200.00% (over 20% limit)",
+                "200.00% (over 20% limit)",
+            ],
         )
         self.assertEqual(comparison.verdict, "REJECT")
 

--- a/infra/agent-image/test_report.py
+++ b/infra/agent-image/test_report.py
@@ -25,13 +25,13 @@ import summarize  # noqa: E402
 TaskSpecs = dict[str, tuple[str, str, int]]
 
 
-def pricing() -> dict[str, object]:
+def pricing(*, input_price: Decimal = Decimal("1")) -> dict[str, object]:
     return {
         "primary": "amazon-bedrock/synthetic-model",
         "provider": "amazon-bedrock",
         "model_id": "synthetic-model",
         "pricing_usd_per_million_tokens": {
-            "input": Decimal("1"),
+            "input": input_price,
             "output": Decimal("0"),
             "cacheRead": Decimal("0"),
             "cacheWrite": Decimal("0"),
@@ -47,6 +47,7 @@ def build_summary(
     cache_reads: int = 100,
     duration_ms: int = 1000,
     model_calls: int = 2,
+    input_price: Decimal = Decimal("1"),
     nudged_tasks: frozenset[str] = frozenset(),
     runtime_failures: dict[str, str] | None = None,
 ) -> dict[str, object]:
@@ -103,7 +104,7 @@ def build_summary(
             )
     return summarize.summarize_records(
         records,
-        pricing(),
+        pricing(input_price=input_price),
         expected_image=image,
         source_commit="c" * 40,
         source_commit_provenance="image-label",
@@ -218,6 +219,41 @@ class PromotionRuleTests(unittest.TestCase):
         self.assertTrue(clause(comparison, "a").passed)
         self.assertTrue(clause(comparison, "b").passed)
         self.assertFalse(clause(comparison, "c").passed)
+        self.assertEqual(comparison.verdict, "REJECT")
+
+    def test_cost_clause_uses_unrounded_tokens_and_prices(self):
+        baseline = build_summary(
+            {
+                "reg-a": ("skill-a", "regression", 3),
+                "cap-a": ("skill-a", "capability", 2),
+            },
+            digest_character="a",
+            input_tokens=1,
+            input_price=Decimal("0.05"),
+        )
+        candidate = build_summary(
+            {
+                "reg-a": ("skill-a", "regression", 3),
+                "cap-a": ("skill-a", "capability", 3),
+            },
+            digest_character="b",
+            input_tokens=3,
+            input_price=Decimal("0.05"),
+        )
+
+        self.assertEqual(
+            baseline["overall"]["telemetry"]["cost"]["per_task_usd"],
+            0.0,
+        )
+        self.assertEqual(
+            candidate["overall"]["telemetry"]["cost"]["per_task_usd"],
+            0.0,
+        )
+
+        comparison = eval_report.compare_summaries(baseline, candidate)
+
+        self.assertFalse(clause(comparison, "c").passed)
+        self.assertIn("200.00%", clause(comparison, "c").detail)
         self.assertEqual(comparison.verdict, "REJECT")
 
     def test_caching_mismatch_declines_cost_clause(self):


### PR DESCRIPTION
## Summary
- add schema-validated baseline/candidate comparison reports with per-skill `pass^3`, cost, duration, latency, model-call, nudge, failure-class, and changed-trial deltas
- implement the three-clause promotion decision, including a per-skill regression floor and strict capability improvement
- derive caching from observed cache-read tokens and decline cross-cache cost verdicts
- render terminal and reproducible Markdown output, with `--require-promotion` enforcement
- admit committed Markdown only when it byte-for-byte regenerates from its two tracked safe summaries
- document the workflow and add the hermetic report suite to CI

## Risks and migrations
- No database or infrastructure migration.
- No production runtime path changes; this is local/CI eval tooling.
- The `.eval-runs` guard remains fail-closed for arbitrary Markdown and transcript-like artifacts.
- Browser E2E is not applicable to this hermetic Python CLI.

## Validation
- `UV_CACHE_DIR=/tmp/issue-1428-uv-cache uv run --python 3.12 --no-project -m unittest <exact CI agent-image suite>` — 516 passed, 1 skipped
- `CI=true bun run test:ci` — 530 suites passed; 4,900 tests passed; existing skips only
- `bun run lint` — passed with zero warnings
- `bun run typecheck` — passed
- `bun run openapi:check` — generated catalog in sync
- `bun run capabilities:check` — generated catalog in sync
- `python3 infra/agent-image/check_eval_coverage.py` — 30 covered, 45 opted out
- `python3 infra/agent-image/eval/summarize.py --check-repository` — passed
- `python3 -m py_compile infra/agent-image/eval/report.py infra/agent-image/eval/summarize.py infra/agent-image/test_report.py` — passed
- `bun run build` — passed; only existing Edge-runtime and browserslist warnings

Closes #1428
Part of #1421