### PR TITLE
feat(agent-image): add multi-provider candidate image matrix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,6 +76,7 @@ tests/e2e/.auth/
 
 # Agent-image build-time eval-gate probe artifacts (#1161)
 infra/agent-image/.build-probes/
+infra/agent-image/.candidate-builds/
 
 # Agent-image eval transcripts contain prompts, model output, tool details, and
 # broker request bodies. Only digest-named, transcript-free summaries and exact

--- a/.gitignore
+++ b/.gitignore
@@ -77,6 +77,7 @@ tests/e2e/.auth/
 # Agent-image build-time eval-gate probe artifacts (#1161)
 infra/agent-image/.build-probes/
 infra/agent-image/.candidate-builds/
+infra/agent-image/.candidate-staging.*/
 
 # Agent-image eval transcripts contain prompts, model output, tool details, and
 # broker request bodies. Only digest-named, transcript-free summaries and exact

--- a/docs/operations/agent-image-build-gate.md
+++ b/docs/operations/agent-image-build-gate.md
@@ -94,10 +94,12 @@ model/provider path, harness pin, prompt variant, cache mode, varied axis,
 source commit, and cited costs.
 
 Native candidates use the active AWS credential chain. Mantle candidates
-explicitly opt into the stack's `BedrockApiKeySecretArn`; the wrapper fetches
-and atomically inlines that API key before OpenClaw starts. The checked-in
-native production config contains no API-key placeholder, so this hydration is
-a strict no-op on the default build.
+explicitly opt into the stack's `BedrockApiKeySecretArn`; the root-owned
+loopback relay fetches and injects that API key only into the fixed AWS model
+request. OpenClaw receives a non-secret sentinel and cannot read either the
+bearer or secret ARN. The checked-in native production config contains no
+API-key placeholder, so this relay configuration is a strict no-op on the
+default build.
 
 See
 [`infra/agent-image/eval/candidates/README.md`](../../infra/agent-image/eval/candidates/README.md)
@@ -114,18 +116,18 @@ schema unchanged:
 
 ```bash
 python3 infra/agent-image/eval/runner.py \
-  --image <tag-or-digest> \
+  --image <immutable-ecr-uri@sha256:digest> \
   --candidate-metadata infra/agent-image/.candidate-builds/<tag>.json \
   --suite infra/agent-image/eval/suites/core.yaml \
   --trials 3 \
   --out /tmp/agent-eval-core.jsonl
 ```
 
-The finalized sidecar makes provider authentication fail closed: its
-tag/digest must match `--image`; native SigV4 candidates receive no provider
-secret; Mantle candidates resolve the environment stack's
-`BedrockApiKeySecretArn` and pass only that ARN to the short-lived eval
-container.
+The finalized sidecar makes provider authentication fail closed:
+`--image` must be its immutable digest (the matching mutable tag is rejected);
+native SigV4 candidates receive no provider secret; Mantle candidates resolve
+the environment stack's `BedrockApiKeySecretArn` and pass only that ARN to the
+short-lived eval container's root relay.
 
 Pure tasks share a booted container but receive a fresh AgentCore session UUID
 and freshly minted signed context on every trial. Workspace-mutating tasks get

--- a/docs/operations/agent-image-build-gate.md
+++ b/docs/operations/agent-image-build-gate.md
@@ -123,8 +123,10 @@ python3 infra/agent-image/eval/runner.py \
   --out /tmp/agent-eval-core.jsonl
 ```
 
-The finalized sidecar makes provider authentication fail closed:
-`--image` must be its immutable digest (the matching mutable tag is rejected);
+Every runner invocation requires an immutable `repository@sha256:...` image,
+including runs without candidate metadata. The finalized sidecar additionally
+makes provider authentication fail closed: `--image` must match its immutable
+digest (the matching mutable tag is rejected);
 native SigV4 candidates receive no provider secret; Mantle candidates resolve
 the environment stack's `BedrockApiKeySecretArn` and pass only that ARN to the
 short-lived eval container's root relay.

--- a/docs/operations/agent-image-build-gate.md
+++ b/docs/operations/agent-image-build-gate.md
@@ -115,10 +115,17 @@ schema unchanged:
 ```bash
 python3 infra/agent-image/eval/runner.py \
   --image <tag-or-digest> \
+  --candidate-metadata infra/agent-image/.candidate-builds/<tag>.json \
   --suite infra/agent-image/eval/suites/core.yaml \
   --trials 3 \
   --out /tmp/agent-eval-core.jsonl
 ```
+
+The finalized sidecar makes provider authentication fail closed: its
+tag/digest must match `--image`; native SigV4 candidates receive no provider
+secret; Mantle candidates resolve the environment stack's
+`BedrockApiKeySecretArn` and pass only that ARN to the short-lived eval
+container.
 
 Pure tasks share a booted container but receive a fresh AgentCore session UUID
 and freshly minted signed context on every trial. Workspace-mutating tasks get

--- a/docs/operations/agent-image-build-gate.md
+++ b/docs/operations/agent-image-build-gate.md
@@ -23,11 +23,12 @@ built image, before `docker push`.
 
 ## Why the runtime half needs a signed context
 
-Before PR #1353 the probe handed the container a Bedrock API key secret and let
-it call the model directly. It no longer can: **the image never receives a
-provider credential.** Model calls are brokered by the web tier at
-`APP_BASE_URL/api/agent/model-proxy`, which authorizes each request from two
-things the router Lambda normally supplies:
+Before PR #1353 the production probe handed the container a Bedrock API key
+secret and let it call the model directly. The default production image no
+longer does: **its native Bedrock provider receives no provider secret** and
+signs direct Bedrock calls with the probe/execution role. Privileged broker
+calls go through `APP_BASE_URL/api/agent/model-proxy`, which authorizes each
+request from two things the router Lambda normally supplies:
 
 - **`invocation_context`** — a short-lived HMAC-signed token binding
   actor / owner / mode / session / workspace-prefix / expiry
@@ -66,6 +67,43 @@ That is usually all you need. When `AGENT_PROBE_APP_BASE_URL` and
 
 Both steps need AWS credentials for the target environment. If either fails,
 the build **stops** — it does not push an unverified image.
+
+### Building a one-axis candidate
+
+Candidate manifests use the same command and all four gates:
+
+```bash
+cd infra/agent-image
+./build-and-push.sh \
+  --candidate eval/candidates/manifests/glm-5-native.json \
+  2026-07-29-glm-5-native
+```
+
+The candidate path validates that exactly one of model/provider, harness, or
+prompt differs from the committed baseline. The Dockerfile defaults are still
+the production Sonnet/native-SigV4 inputs; the selected config, immutable host
+digest, provider-plugin version/assertion, and prompt paths arrive only as
+candidate build arguments.
+
+Candidate canaries are deterministic graded turns: the prompt requests exactly
+`CANDIDATE_OK`, the extracted final result must fully match, and the probe
+artifact records `"grader":"output_match"` plus `grade_passed`. After push, the
+command resolves the ECR digest and writes
+`infra/agent-image/.candidate-builds/<tag>.json`, binding that digest to the
+model/provider path, harness pin, prompt variant, cache mode, varied axis,
+source commit, and cited costs.
+
+Native candidates use the active AWS credential chain. Mantle candidates
+explicitly opt into the stack's `BedrockApiKeySecretArn`; the wrapper fetches
+and atomically inlines that API key before OpenClaw starts. The checked-in
+native production config contains no API-key placeholder, so this hydration is
+a strict no-op on the default build.
+
+See
+[`infra/agent-image/eval/candidates/README.md`](../../infra/agent-image/eval/candidates/README.md)
+for the complete OpenAI/GLM/Kimi/Qwen/Claude matrix, provider API/auth/base URL
+contracts, IAM and cross-region ARN requirements, caching rules, and official
+cost sources.
 
 ## Running the repeated local eval
 
@@ -150,7 +188,7 @@ trusted-broker check.
 | `AGENT_PROBE_REQUEST_PROOF_KEY` | Derived request-proof key. Auto-minted alongside the token. |
 | `PROBE_BOOT_TIMEOUT` | Seconds to wait for `BOOT_OK` (default 120). |
 | `PROBE_CANARY_TIMEOUT` | Seconds to wait for the canary answer (default 120). |
-| `CANARY_MESSAGE` | Canary prompt (default `Reply with exactly: OK`). |
+| `CANARY_MESSAGE` | Canary prompt (default `Reply with exactly: OK`; candidate default `Reply with exactly: CANDIDATE_OK`). |
 | `PROBE_ARTIFACT_DIR` | Where probe result JSON is written (default `infra/agent-image/.build-probes`). |
 
 ### Bypasses
@@ -181,6 +219,8 @@ Each build writes `infra/agent-image/.build-probes/<tag>.json`:
 ```jsonc
 // verified
 {"tag":"2026-07-27-x","boot_ok":true,"boot_elapsed_s":24,"canary_ok":true,"canary_elapsed_s":11}
+// verified candidate
+{"tag":"2026-07-29-glm","candidate_id":"glm-5-native","boot_ok":true,"boot_elapsed_s":24,"canary_ok":true,"canary_elapsed_s":11,"grader":"output_match","grade_passed":true}
 // waived
 {"tag":"2026-07-27-x","skipped":true,"reason":"missing_signed_broker_context","allow_unverified":true}
 ```

--- a/infra/agent-image/.dockerignore
+++ b/infra/agent-image/.dockerignore
@@ -35,6 +35,7 @@ node_modules/
 
 # Build-time eval-gate probe artifacts (issue #1161) — trend data, not image content
 .build-probes/
+.candidate-builds/
 
 # Local-only test scratch
 test_*.py

--- a/infra/agent-image/Dockerfile
+++ b/infra/agent-image/Dockerfile
@@ -64,7 +64,8 @@
 # double-nesting fix by commit ancestry and (b) a clean end-to-end test that
 # includes the Morning Brief payload — a trivial "respond OK" prompt masks
 # session-completion regressions.
-FROM ghcr.io/openclaw/openclaw@sha256:6a31d44b2944e7adcd2b582bf6fb463111264ebca97a0201795b799135bd102c
+ARG OPENCLAW_BASE_IMAGE=ghcr.io/openclaw/openclaw@sha256:6a31d44b2944e7adcd2b582bf6fb463111264ebca97a0201795b799135bd102c
+FROM ${OPENCLAW_BASE_IMAGE}
 
 # Bind every pushed image to the exact clean AI Studio source revision used to
 # build it. The nightly evaluator reads this immutable config label instead of
@@ -251,7 +252,8 @@ RUN mkdir -p /home/node/.openclaw/memory
 #   it would have yielded. 60s is a ceiling, not a delay: fast calls return
 #   as before. Pair with psd-rules guidance to use SHORT yieldMs (≤10s) so
 #   long commands suspend early instead of racing this timeout.
-COPY openclaw.json /home/node/.openclaw/openclaw.json
+ARG OPENCLAW_CONFIG=openclaw.json
+COPY ${OPENCLAW_CONFIG} /home/node/.openclaw/openclaw.json
 # Build-time config sanity check (post-2026-07-02 config-risk hardening): surface
 # any openclaw.json schema/key errors at BUILD time instead of at runtime (a
 # rejected config would stop the gateway from starting = an outage). Non-fatal
@@ -278,8 +280,10 @@ RUN HOME=/home/node openclaw config validate >/tmp/config-validate.log 2>&1; \
 # At build time we strip psd-rules' YAML frontmatter and append the body
 # to SOUL.md so the rules ARE in the system prompt every turn. The
 # canonical edit point stays `skills/psd-rules/SKILL.md`.
-COPY SOUL.md /tmp/SOUL.preamble.md
-COPY skills/psd-rules/SKILL.md /tmp/psd-rules.SKILL.md
+ARG SOUL_PREAMBLE=SOUL.md
+ARG PSD_RULES_SKILL=skills/psd-rules/SKILL.md
+COPY ${SOUL_PREAMBLE} /tmp/SOUL.preamble.md
+COPY ${PSD_RULES_SKILL} /tmp/psd-rules.SKILL.md
 RUN awk 'BEGIN{f=0} /^---[[:space:]]*$/{f++; next} f>=2{print}' /tmp/psd-rules.SKILL.md > /tmp/psd-rules.body.md && \
     cat /tmp/SOUL.preamble.md > /home/node/.openclaw/SOUL.md && \
     printf '\n\n---\n\n# Operating Rules (from psd-rules)\n\n_The following rules are concatenated from `skills/psd-rules/SKILL.md` at container build time so they are guaranteed to appear in every turn\xe2\x80\x99s system prompt. Edit them in that file, not here._\n\n' >> /home/node/.openclaw/SOUL.md && \
@@ -345,6 +349,8 @@ COPY skills /opt/psd-skills
 # that allowlist. Do not downgrade this plugin without also removing the
 # caching expectation — see check_config_consistency.py, which fails the build
 # if the two drift apart again.
+ARG BEDROCK_PLUGIN_VERSION=2026.7.1
+ARG BEDROCK_PLUGIN_EXPECTED_TOKEN=claude-sonnet-5
 RUN cd /opt/psd-skills/psd-schedules && npm install --omit=dev --no-audit --no-fund && \
     cd /opt/psd-skills/psd-credentials && npm install --omit=dev --no-audit --no-fund && \
     cd /opt/psd-skills/psd-skills-meta && npm install --omit=dev --no-audit --no-fund && \
@@ -354,12 +360,13 @@ RUN cd /opt/psd-skills/psd-schedules && npm install --omit=dev --no-audit --no-f
     cd /opt/psd-skills/psd-failure-report && npm install --omit=dev --no-audit --no-fund && \
     cd /opt/psd-skills/psd-email-triage && npm install --omit=dev --no-audit --no-fund && \
     mkdir -p /opt/openclaw-plugins && cd /opt/openclaw-plugins && \
-    npm pack @openclaw/amazon-bedrock-provider@2026.7.1 && \
-    tar -xzf openclaw-amazon-bedrock-provider-2026.7.1.tgz && \
+    npm pack "@openclaw/amazon-bedrock-provider@${BEDROCK_PLUGIN_VERSION}" && \
+    tar -xzf "openclaw-amazon-bedrock-provider-${BEDROCK_PLUGIN_VERSION}.tgz" && \
     mv package amazon-bedrock && \
-    rm openclaw-amazon-bedrock-provider-2026.7.1.tgz && \
+    rm "openclaw-amazon-bedrock-provider-${BEDROCK_PLUGIN_VERSION}.tgz" && \
     test -f /opt/openclaw-plugins/amazon-bedrock/openclaw.plugin.json && \
-    grep -q "claude-sonnet-5" /opt/openclaw-plugins/amazon-bedrock/dist/bedrock-options.js
+    grep -Fq -- "${BEDROCK_PLUGIN_EXPECTED_TOKEN}" \
+      /opt/openclaw-plugins/amazon-bedrock/dist/bedrock-options.js
 # chat-card has zero npm deps. chat-chart's npm install is paired with the
 # matplotlib install above — both stay disabled until we figure out the
 # AgentCore overlay-mount failure. With both off the image boots cleanly

--- a/infra/agent-image/Dockerfile
+++ b/infra/agent-image/Dockerfile
@@ -350,7 +350,7 @@ COPY skills /opt/psd-skills
 # caching expectation — see check_config_consistency.py, which fails the build
 # if the two drift apart again.
 ARG BEDROCK_PLUGIN_VERSION=2026.7.1
-ARG BEDROCK_PLUGIN_EXPECTED_TOKEN=claude-sonnet-5
+ARG BEDROCK_PLUGIN_ASSERTION=claude-sonnet-5
 RUN cd /opt/psd-skills/psd-schedules && npm install --omit=dev --no-audit --no-fund && \
     cd /opt/psd-skills/psd-credentials && npm install --omit=dev --no-audit --no-fund && \
     cd /opt/psd-skills/psd-skills-meta && npm install --omit=dev --no-audit --no-fund && \
@@ -365,7 +365,7 @@ RUN cd /opt/psd-skills/psd-schedules && npm install --omit=dev --no-audit --no-f
     mv package amazon-bedrock && \
     rm "openclaw-amazon-bedrock-provider-${BEDROCK_PLUGIN_VERSION}.tgz" && \
     test -f /opt/openclaw-plugins/amazon-bedrock/openclaw.plugin.json && \
-    grep -Fq -- "${BEDROCK_PLUGIN_EXPECTED_TOKEN}" \
+    grep -Fq -- "${BEDROCK_PLUGIN_ASSERTION}" \
       /opt/openclaw-plugins/amazon-bedrock/dist/bedrock-options.js
 # chat-card has zero npm deps. chat-chart's npm install is paired with the
 # matplotlib install above — both stay disabled until we figure out the

--- a/infra/agent-image/agentcore_wrapper.py
+++ b/infra/agent-image/agentcore_wrapper.py
@@ -466,6 +466,7 @@ def _configure_candidate_mantle_relay(
     provider["baseUrl"] = CANDIDATE_MANTLE_RELAY_BASE_URL
     provider["apiKey"] = CANDIDATE_MANTLE_RELAY_API_KEY
     directory = os.path.dirname(config_path)
+    config_metadata = os.stat(config_path)
     descriptor, temporary_path = tempfile.mkstemp(
         prefix=".openclaw.candidate.", dir=directory
     )
@@ -475,7 +476,15 @@ def _configure_candidate_mantle_relay(
             output.write("\n")
             output.flush()
             os.fsync(output.fileno())
-        os.chmod(temporary_path, os.stat(config_path).st_mode & 0o777)
+            # The wrapper is root while OpenClaw runs as node. An atomic
+            # replacement must preserve the original node ownership as well as
+            # its mode or the gateway cannot read the rewritten config.
+            os.fchown(
+                output.fileno(),
+                config_metadata.st_uid,
+                config_metadata.st_gid,
+            )
+            os.fchmod(output.fileno(), config_metadata.st_mode & 0o777)
         os.replace(temporary_path, config_path)
     except Exception:
         try:

--- a/infra/agent-image/agentcore_wrapper.py
+++ b/infra/agent-image/agentcore_wrapper.py
@@ -30,6 +30,7 @@ import secrets
 import signal
 import subprocess
 import sys
+import tempfile
 import time
 from datetime import datetime
 from zoneinfo import ZoneInfo
@@ -52,15 +53,11 @@ from check_bootstrap_budget import check_runtime_bootstrap
 OPENCLAW_CONFIG_PATH = "/home/node/.openclaw/openclaw.json"
 OPENCLAW_WORKSPACE_DIR = "/home/node/.openclaw"
 
-# The model the agent platform runs on today — used as the last-resort model-id
-# fallback for telemetry when neither the proxy, harness, nor caller supplied
-# one. Must match the id the proxy records + an ai_models pricing row
-# (migration 092); a mismatch silently yields $0 cost. Single source of truth so
-# the two fallbacks below don't drift (issue #1083, review round 2).
-# Switched GLM-5 -> Claude Sonnet 5 for #1089. Bedrock Mantle's Anthropic
-# Messages endpoint echoes the bare `claude-sonnet-5` on the response (verified),
-# so that is the id the proxy records — use it here too so the fallback matches.
+# Emergency fallback only. Candidate images read their actual primary model
+# from openclaw.json so a GLM/Kimi/Qwen/OpenAI turn is never mislabeled Claude
+# merely because neither the proxy nor transcript returned a model id.
 DEFAULT_AGENT_MODEL_ID = "claude-sonnet-5"
+BEDROCK_BEARER_ENV = "AWS_BEARER_TOKEN_BEDROCK"
 
 adapter = OpenClawAdapter()
 
@@ -390,6 +387,132 @@ def start_mantle_proxy() -> None:
         time.sleep(0.5)
 
     raise RuntimeError("Mantle proxy did not become ready within 20s")
+
+
+def _configured_primary_model_id(
+    config_path: str = OPENCLAW_CONFIG_PATH,
+) -> str:
+    """Return the configured primary model id, with a safe legacy fallback."""
+    try:
+        with open(config_path, "r", encoding="utf-8") as config_file:
+            config = json.load(config_file)
+        primary = (
+            ((config.get("agents") or {}).get("defaults") or {}).get("model") or {}
+        ).get("primary")
+        if isinstance(primary, str) and "/" in primary:
+            _, model_id = primary.split("/", 1)
+            if model_id:
+                return model_id
+    except (OSError, ValueError):
+        pass
+    return DEFAULT_AGENT_MODEL_ID
+
+
+def _inline_configured_bearer_token(config_path: str, value: str) -> list[str]:
+    """Replace only the explicit Bedrock bearer placeholders, atomically."""
+    with open(config_path, "r", encoding="utf-8") as config_file:
+        config = json.load(config_file)
+    providers = (config.get("models") or {}).get("providers") or {}
+    hydrated: list[str] = []
+    for provider_name, provider in providers.items():
+        if (
+            isinstance(provider_name, str)
+            and isinstance(provider, dict)
+            and provider.get("apiKey") == f"env:{BEDROCK_BEARER_ENV}"
+        ):
+            provider["apiKey"] = value
+            hydrated.append(provider_name)
+    if not hydrated:
+        return []
+
+    directory = os.path.dirname(config_path)
+    descriptor, temporary_path = tempfile.mkstemp(
+        prefix=".openclaw.candidate.", dir=directory
+    )
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as output:
+            json.dump(config, output, indent=2)
+            output.write("\n")
+            output.flush()
+            os.fsync(output.fileno())
+        os.chmod(temporary_path, os.stat(config_path).st_mode & 0o777)
+        os.replace(temporary_path, config_path)
+    except Exception:
+        try:
+            os.unlink(temporary_path)
+        except OSError:
+            pass
+        raise
+    return hydrated
+
+
+def hydrate_configured_provider_api_keys(
+    config_path: str = OPENCLAW_CONFIG_PATH,
+) -> list[str]:
+    """Hydrate candidate Mantle providers; native SigV4 remains a strict no-op.
+
+    The checked-in production config has no apiKey and therefore performs no
+    secret read. A candidate that explicitly declares
+    ``env:AWS_BEARER_TOKEN_BEDROCK`` must receive either that environment value
+    or ``BEDROCK_API_KEY_SECRET_ARN``. Failure is fatal before BOOT_OK.
+    """
+    with open(config_path, "r", encoding="utf-8") as config_file:
+        config = json.load(config_file)
+    providers = (config.get("models") or {}).get("providers") or {}
+    targets = [
+        provider_name
+        for provider_name, provider in providers.items()
+        if (
+            isinstance(provider_name, str)
+            and isinstance(provider, dict)
+            and provider.get("apiKey") == f"env:{BEDROCK_BEARER_ENV}"
+        )
+    ]
+    if not targets:
+        return []
+
+    value = os.environ.get(BEDROCK_BEARER_ENV, "").strip()
+    secret_version = "environment"
+    if not value:
+        secret_arn = os.environ.get("BEDROCK_API_KEY_SECRET_ARN", "").strip()
+        if not secret_arn:
+            raise RuntimeError(
+                "token-auth provider configured but neither "
+                "AWS_BEARER_TOKEN_BEDROCK nor BEDROCK_API_KEY_SECRET_ARN is set"
+            )
+        import boto3
+
+        region = (
+            os.environ.get("AWS_REGION")
+            or os.environ.get("AWS_DEFAULT_REGION")
+            or "us-east-1"
+        )
+        saved_profile = os.environ.pop("AWS_PROFILE", None)
+        try:
+            secrets_client = boto3.client("secretsmanager", region_name=region)
+        finally:
+            if saved_profile is not None:
+                os.environ["AWS_PROFILE"] = saved_profile
+        response = secrets_client.get_secret_value(SecretId=secret_arn)
+        raw_value = response.get("SecretString")
+        if not isinstance(raw_value, str) or not raw_value.strip():
+            raise RuntimeError("Bedrock API-key secret has an empty SecretString")
+        value = raw_value.strip()
+        secret_version = str(response.get("VersionId", "unknown"))
+
+    # Keep the env value for OpenClaw discovery and inline it because all
+    # OpenClaw call paths do not consistently resolve env: placeholders.
+    os.environ["AWS_BEARER_TOKEN_BEDROCK"] = value
+    hydrated = _inline_configured_bearer_token(config_path, value)
+    if sorted(hydrated) != sorted(targets):
+        raise RuntimeError("provider apiKey hydration did not update every target")
+    logger.info(
+        "Hydrated Bedrock bearer for candidate provider(s)=%s version=%s",
+        ",".join(sorted(hydrated)),
+        secret_version,
+    )
+    return hydrated
+
 
 def resolve_model_call_count(proxy_model_calls: int, tool_call_count: int) -> int:
     """Resolve a per-turn model-call count from broker telemetry or events."""
@@ -727,6 +850,10 @@ def main():
             "Install via: pip install bedrock-agentcore"
         )
         sys.exit(1)
+
+    # Native production config is a no-op. Candidate Mantle configs fail
+    # closed here if their explicit bearer placeholder cannot be hydrated.
+    hydrate_configured_provider_api_keys()
 
     # Start the local request-shaping proxy before OpenClaw. It forwards only
     # to the owner-bound web broker and never receives a provider credential.
@@ -1116,7 +1243,11 @@ def main():
             metadata: dict = {
                 "session_id": session_id,
                 "user_id": user_email,
-                "model": proxy_model or model_override or DEFAULT_AGENT_MODEL_ID,
+                "model": (
+                    proxy_model
+                    or model_override
+                    or _configured_primary_model_id()
+                ),
                 "input_tokens": proxy_in,
                 "output_tokens": proxy_out,
                 # Cache tokens come only from the proxy delta (the harness has
@@ -1146,7 +1277,12 @@ def main():
                 # Real model id, in priority order: proxy-observed > harness-
                 # observed > caller override > the known default model. We
                 # never emit the literal "default" anymore (issue #1083).
-                "model": proxy_model or result.model or model_override or DEFAULT_AGENT_MODEL_ID,
+                "model": (
+                    proxy_model
+                    or result.model
+                    or model_override
+                    or _configured_primary_model_id()
+                ),
                 "input_tokens": input_tokens,
                 "output_tokens": output_tokens,
                 # Bedrock prompt-caching split (issue #1089). Same precedence as

--- a/infra/agent-image/agentcore_wrapper.py
+++ b/infra/agent-image/agentcore_wrapper.py
@@ -58,12 +58,20 @@ OPENCLAW_WORKSPACE_DIR = "/home/node/.openclaw"
 # merely because neither the proxy nor transcript returned a model id.
 DEFAULT_AGENT_MODEL_ID = "claude-sonnet-5"
 BEDROCK_BEARER_ENV = "AWS_BEARER_TOKEN_BEDROCK"
+CANDIDATE_MANTLE_RELAY_BASE_URL = (
+    "http://127.0.0.1:18791/candidate-mantle"
+)
+CANDIDATE_MANTLE_RELAY_API_KEY = "candidate-relay-managed"
+CANDIDATE_MANTLE_APIS = frozenset(
+    {"openai-completions", "anthropic-messages"}
+)
 
 adapter = OpenClawAdapter()
 
 # Credential-isolating logging proxy sitting between OpenClaw and the web broker.
 # Track the process so we can reap it on shutdown and log if it crashes.
 _mantle_proxy_process: subprocess.Popen | None = None
+_candidate_relay_environment: dict[str, str] = {}
 
 
 def _safe_header_value(value: str, limit: int = 100) -> str:
@@ -345,28 +353,34 @@ def _serialize_invocations(function):
     return serialized
 
 
-def start_mantle_proxy() -> None:
+def start_mantle_proxy(
+    candidate_relay_environment: dict[str, str] | None = None,
+) -> None:
     """
     Launch the root-owned model/direct-AWS relay on 127.0.0.1:18791 and block
     until /health returns 200. If it can't come up, exit — OpenClaw's
     openclaw.json points its baseUrl at the relay, so no relay means no model
     calls or direct-AWS skills.
     """
-    global _mantle_proxy_process
+    global _mantle_proxy_process, _candidate_relay_environment
     import urllib.request
     import urllib.error
 
     logger.info("Starting Mantle logging proxy on 127.0.0.1:18791")
+    if candidate_relay_environment is not None:
+        _candidate_relay_environment = dict(candidate_relay_environment)
+    proxy_environment = {
+        key: value
+        for key, value in os.environ.items()
+        if key not in ("AWS_BEARER_TOKEN_BEDROCK", "BEDROCK_API_KEY_SECRET_ARN")
+    }
+    proxy_environment.update(_candidate_relay_environment)
     _mantle_proxy_process = subprocess.Popen(
         [sys.executable, "/app/mantle_proxy.py"],
         stdout=sys.stdout,
         stderr=sys.stderr,
         stdin=subprocess.DEVNULL,
-        env={
-            key: value
-            for key, value in os.environ.items()
-            if key not in ("AWS_BEARER_TOKEN_BEDROCK", "BEDROCK_API_KEY_SECRET_ARN")
-        },
+        env=proxy_environment,
     )
     deadline = time.time() + 20
     while time.time() < deadline:
@@ -408,23 +422,49 @@ def _configured_primary_model_id(
     return DEFAULT_AGENT_MODEL_ID
 
 
-def _inline_configured_bearer_token(config_path: str, value: str) -> list[str]:
-    """Replace only the explicit Bedrock bearer placeholders, atomically."""
+def _configure_candidate_mantle_relay(
+    config_path: str,
+    value: str,
+) -> tuple[list[str], dict[str, str]]:
+    """Point one candidate provider at the root relay without persisting its key."""
     with open(config_path, "r", encoding="utf-8") as config_file:
         config = json.load(config_file)
     providers = (config.get("models") or {}).get("providers") or {}
-    hydrated: list[str] = []
-    for provider_name, provider in providers.items():
+    targets = [
+        (provider_name, provider)
+        for provider_name, provider in providers.items()
         if (
             isinstance(provider_name, str)
             and isinstance(provider, dict)
             and provider.get("apiKey") == f"env:{BEDROCK_BEARER_ENV}"
-        ):
-            provider["apiKey"] = value
-            hydrated.append(provider_name)
-    if not hydrated:
-        return []
+        )
+    ]
+    if not targets:
+        return [], {}
+    if len(targets) != 1:
+        raise RuntimeError(
+            "candidate Mantle relay requires exactly one token-auth provider"
+        )
 
+    provider_name, provider = targets[0]
+    provider_api = provider.get("api")
+    upstream_base_url = provider.get("baseUrl")
+    models = provider.get("models")
+    if (
+        provider.get("auth") != "api-key"
+        or provider_api not in CANDIDATE_MANTLE_APIS
+        or not isinstance(upstream_base_url, str)
+        or not upstream_base_url
+        or not isinstance(models, list)
+        or len(models) != 1
+        or not isinstance(models[0], dict)
+        or not isinstance(models[0].get("id"), str)
+        or not models[0]["id"]
+    ):
+        raise RuntimeError("candidate Mantle provider contract is malformed")
+
+    provider["baseUrl"] = CANDIDATE_MANTLE_RELAY_BASE_URL
+    provider["apiKey"] = CANDIDATE_MANTLE_RELAY_API_KEY
     directory = os.path.dirname(config_path)
     descriptor, temporary_path = tempfile.mkstemp(
         prefix=".openclaw.candidate.", dir=directory
@@ -443,18 +483,26 @@ def _inline_configured_bearer_token(config_path: str, value: str) -> list[str]:
         except OSError:
             pass
         raise
-    return hydrated
+    relay_environment = {
+        "CANDIDATE_MANTLE_API": provider_api,
+        "CANDIDATE_MANTLE_BASE_URL": upstream_base_url,
+        "CANDIDATE_MANTLE_BEARER_TOKEN": value,
+        "CANDIDATE_MANTLE_MODEL_ID": models[0]["id"],
+    }
+    return [provider_name], relay_environment
 
 
 def hydrate_configured_provider_api_keys(
     config_path: str = OPENCLAW_CONFIG_PATH,
-) -> list[str]:
-    """Hydrate candidate Mantle providers; native SigV4 remains a strict no-op.
+) -> dict[str, str]:
+    """Configure a root-only candidate relay; native SigV4 is a strict no-op.
 
     The checked-in production config has no apiKey and therefore performs no
     secret read. A candidate that explicitly declares
     ``env:AWS_BEARER_TOKEN_BEDROCK`` must receive either that environment value
-    or ``BEDROCK_API_KEY_SECRET_ARN``. Failure is fatal before BOOT_OK.
+    or ``BEDROCK_API_KEY_SECRET_ARN``. The bearer is passed only to the
+    root-owned relay; OpenClaw receives a non-secret sentinel and loopback URL.
+    Failure is fatal before BOOT_OK.
     """
     with open(config_path, "r", encoding="utf-8") as config_file:
         config = json.load(config_file)
@@ -469,7 +517,7 @@ def hydrate_configured_provider_api_keys(
         )
     ]
     if not targets:
-        return []
+        return {}
 
     value = os.environ.get(BEDROCK_BEARER_ENV, "").strip()
     secret_version = "environment"
@@ -500,18 +548,25 @@ def hydrate_configured_provider_api_keys(
         value = raw_value.strip()
         secret_version = str(response.get("VersionId", "unknown"))
 
-    # Keep the env value for OpenClaw discovery and inline it because all
-    # OpenClaw call paths do not consistently resolve env: placeholders.
-    os.environ["AWS_BEARER_TOKEN_BEDROCK"] = value
-    hydrated = _inline_configured_bearer_token(config_path, value)
+    try:
+        hydrated, relay_environment = _configure_candidate_mantle_relay(
+            config_path, value
+        )
+    finally:
+        # The node gateway inherits the wrapper environment. Remove both the
+        # bearer and its secret identifier before that process can start.
+        os.environ.pop(BEDROCK_BEARER_ENV, None)
+        os.environ.pop("BEDROCK_API_KEY_SECRET_ARN", None)
     if sorted(hydrated) != sorted(targets):
-        raise RuntimeError("provider apiKey hydration did not update every target")
+        raise RuntimeError(
+            "candidate relay configuration did not update every target"
+        )
     logger.info(
-        "Hydrated Bedrock bearer for candidate provider(s)=%s version=%s",
+        "Configured root-only candidate relay for provider(s)=%s version=%s",
         ",".join(sorted(hydrated)),
         secret_version,
     )
-    return hydrated
+    return relay_environment
 
 
 def resolve_model_call_count(proxy_model_calls: int, tool_call_count: int) -> int:
@@ -853,11 +908,11 @@ def main():
 
     # Native production config is a no-op. Candidate Mantle configs fail
     # closed here if their explicit bearer placeholder cannot be hydrated.
-    hydrate_configured_provider_api_keys()
+    candidate_relay_environment = hydrate_configured_provider_api_keys()
 
-    # Start the local request-shaping proxy before OpenClaw. It forwards only
-    # to the owner-bound web broker and never receives a provider credential.
-    start_mantle_proxy()
+    # Start the root-owned request relay before OpenClaw. A candidate Mantle
+    # bearer is passed only to this process, never to the node gateway.
+    start_mantle_proxy(candidate_relay_environment)
 
     # Step 2: start the OpenClaw gateway
     logger.info("Configuring OpenClaw adapter")

--- a/infra/agent-image/build-and-push.sh
+++ b/infra/agent-image/build-and-push.sh
@@ -62,7 +62,7 @@ SOUL_PREAMBLE_BUILD_PATH="SOUL.md"
 PSD_RULES_BUILD_PATH="skills/psd-rules/SKILL.md"
 OPENCLAW_BASE_IMAGE=""
 BEDROCK_PLUGIN_VERSION=""
-BEDROCK_PLUGIN_EXPECTED_TOKEN=""
+BEDROCK_PLUGIN_ASSERTION=""
 CID=""
 
 cleanup_build() {
@@ -115,7 +115,7 @@ if [ -n "${CANDIDATE_MANIFEST}" ]; then
   PSD_RULES_BUILD_PATH="$(candidate_plan_value psdRulesSkill)"
   OPENCLAW_BASE_IMAGE="$(candidate_plan_value baseImage)"
   BEDROCK_PLUGIN_VERSION="$(candidate_plan_value bedrockPluginVersion)"
-  BEDROCK_PLUGIN_EXPECTED_TOKEN="$(candidate_plan_value expectedPluginToken)"
+  BEDROCK_PLUGIN_ASSERTION="$(candidate_plan_value expectedPluginToken)"
   CANDIDATE_METADATA="$(candidate_plan_value metadata)"
 fi
 
@@ -255,7 +255,7 @@ if [ -n "${CANDIDATE_ID}" ]; then
     --build-arg "PSD_RULES_SKILL=${PSD_RULES_BUILD_PATH}"
     --build-arg "OPENCLAW_BASE_IMAGE=${OPENCLAW_BASE_IMAGE}"
     --build-arg "BEDROCK_PLUGIN_VERSION=${BEDROCK_PLUGIN_VERSION}"
-    --build-arg "BEDROCK_PLUGIN_EXPECTED_TOKEN=${BEDROCK_PLUGIN_EXPECTED_TOKEN}"
+    --build-arg "BEDROCK_PLUGIN_ASSERTION=${BEDROCK_PLUGIN_ASSERTION}"
   )
 fi
 docker build "${DOCKER_BUILD_ARGS[@]}" "${SCRIPT_DIR}"

--- a/infra/agent-image/build-and-push.sh
+++ b/infra/agent-image/build-and-push.sh
@@ -4,6 +4,7 @@
 # Usage:
 #   ./build-and-push.sh                    # Uses default tag: YYYY-MM-DD-initial
 #   ./build-and-push.sh my-custom-tag      # Uses custom tag
+#   ./build-and-push.sh --candidate eval/candidates/manifests/glm-5-native.json [tag]
 #
 # Prerequisites:
 #   - AWS CLI configured with appropriate credentials
@@ -21,6 +22,20 @@
 
 set -euo pipefail
 
+CANDIDATE_MANIFEST=""
+if [ "${1:-}" = "--candidate" ]; then
+  if [ -z "${2:-}" ]; then
+    echo "ERROR: --candidate requires a manifest path." >&2
+    exit 2
+  fi
+  CANDIDATE_MANIFEST="${2}"
+  shift 2
+fi
+if [ "$#" -gt 1 ]; then
+  echo "ERROR: unexpected extra arguments." >&2
+  exit 2
+fi
+
 ENVIRONMENT="${ENVIRONMENT:-dev}"
 # Capitalize first letter for stack name (portable — no bashisms or GNU sed)
 ENV_CAPITALIZED="$(echo "${ENVIRONMENT}" | awk '{print toupper(substr($0,1,1)) substr($0,2)}')"
@@ -29,6 +44,39 @@ REGION="${AWS_REGION:-us-east-1}"
 TAG="${1:-$(date +%Y-%m-%d)-initial}"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+if ! [[ "${TAG}" =~ ^[A-Za-z0-9._-]{1,128}$ ]]; then
+  echo "ERROR: image tag must contain only letters, digits, dot, underscore, or hyphen." >&2
+  exit 2
+fi
+
+BUILD_CONFIG="${SCRIPT_DIR}/openclaw.json"
+BUILD_DOCKERFILE="${SCRIPT_DIR}/Dockerfile"
+BOOTSTRAP_SOURCE_DIR="${SCRIPT_DIR}"
+CANDIDATE_STAGING=""
+CANDIDATE_METADATA=""
+CANDIDATE_ID=""
+CANDIDATE_PROVIDER_PATH=""
+CANDIDATE_REQUIRES_BEARER="false"
+OPENCLAW_CONFIG_BUILD_PATH="openclaw.json"
+SOUL_PREAMBLE_BUILD_PATH="SOUL.md"
+PSD_RULES_BUILD_PATH="skills/psd-rules/SKILL.md"
+OPENCLAW_BASE_IMAGE=""
+BEDROCK_PLUGIN_VERSION=""
+BEDROCK_PLUGIN_EXPECTED_TOKEN=""
+CID=""
+
+cleanup_build() {
+  if [ -n "${CID}" ]; then
+    docker rm -f "${CID}" >/dev/null 2>&1 || true
+  fi
+  rm -f "${SCRIPT_DIR}/skills/validated-fs.cjs"
+  case "${CANDIDATE_STAGING}" in
+    "${SCRIPT_DIR}"/.candidate-staging.*)
+      rm -rf -- "${CANDIDATE_STAGING}"
+      ;;
+  esac
+}
+trap cleanup_build EXIT
 
 SOURCE_COMMIT="$(git -C "${REPO_ROOT}" rev-parse HEAD)"
 if ! [[ "${SOURCE_COMMIT}" =~ ^[0-9a-f]{40}$ ]]; then
@@ -42,10 +90,42 @@ if [ -n "$(git -C "${REPO_ROOT}" status --porcelain --untracked-files=all -- \
   exit 1
 fi
 
+PYTHON="${PYTHON:-python3}"
+if [ -n "${CANDIDATE_MANIFEST}" ]; then
+  CANDIDATE_STAGING="$(mktemp -d "${SCRIPT_DIR}/.candidate-staging.XXXXXX")"
+  CANDIDATE_PLAN="${CANDIDATE_STAGING}/plan.json"
+  "${PYTHON}" "${SCRIPT_DIR}/eval/candidates/candidate.py" prepare \
+    --manifest "${CANDIDATE_MANIFEST}" \
+    --output-dir "${CANDIDATE_STAGING}" \
+    --source-commit "${SOURCE_COMMIT}" >/dev/null
+
+  candidate_plan_value() {
+    "${PYTHON}" -c \
+      'import json, sys; print(json.load(open(sys.argv[1], encoding="utf-8"))[sys.argv[2]])' \
+      "${CANDIDATE_PLAN}" "$1"
+  }
+  CANDIDATE_ID="$(candidate_plan_value candidateId)"
+  CANDIDATE_PROVIDER_PATH="$(candidate_plan_value providerPath)"
+  CANDIDATE_REQUIRES_BEARER="$(candidate_plan_value requiresBearerToken | tr '[:upper:]' '[:lower:]')"
+  OPENCLAW_CONFIG_BUILD_PATH="$(candidate_plan_value openclawConfig)"
+  BUILD_CONFIG="${SCRIPT_DIR}/${OPENCLAW_CONFIG_BUILD_PATH}"
+  BUILD_DOCKERFILE="$(candidate_plan_value dockerfile)"
+  BOOTSTRAP_SOURCE_DIR="${CANDIDATE_STAGING}"
+  SOUL_PREAMBLE_BUILD_PATH="$(candidate_plan_value soulPreamble)"
+  PSD_RULES_BUILD_PATH="$(candidate_plan_value psdRulesSkill)"
+  OPENCLAW_BASE_IMAGE="$(candidate_plan_value baseImage)"
+  BEDROCK_PLUGIN_VERSION="$(candidate_plan_value bedrockPluginVersion)"
+  BEDROCK_PLUGIN_EXPECTED_TOKEN="$(candidate_plan_value expectedPluginToken)"
+  CANDIDATE_METADATA="$(candidate_plan_value metadata)"
+fi
+
 echo "=== PSD Agent Image Build & Push ==="
 echo "Environment: ${ENVIRONMENT}"
 echo "Tag: ${TAG}"
 echo "Source commit: ${SOURCE_COMMIT}"
+if [ -n "${CANDIDATE_ID}" ]; then
+  echo "Candidate: ${CANDIDATE_ID} (${CANDIDATE_PROVIDER_PATH})"
+fi
 echo ""
 
 # Supply-chain enforcement gate (SEC-009): the agent image must ship no
@@ -93,8 +173,6 @@ echo ""
 #                       config-consistency gates that guard the #1138 class.
 # Static gates run fail-fast here (before the expensive ECR/build steps); the
 # runtime probe runs after the image is built, before push.
-PYTHON="${PYTHON:-python3}"
-
 if [ "${SKIP_STATIC_GATE:-0}" = "1" ]; then
   echo "WARNING: SKIP_STATIC_GATE=1 — static eval gates BYPASSED (emergency only)."
   echo ""
@@ -102,7 +180,9 @@ else
   echo "=== Build-time eval gate (1161): static checks ==="
 
   echo "1. Instruction-budget gate (bootstrap files vs openclaw.json limits)..."
-  if ! "${PYTHON}" "${SCRIPT_DIR}/check_bootstrap_budget.py" --source-dir "${SCRIPT_DIR}"; then
+  if ! "${PYTHON}" "${SCRIPT_DIR}/check_bootstrap_budget.py" \
+        --config "${BUILD_CONFIG}" \
+        --source-dir "${BOOTSTRAP_SOURCE_DIR}"; then
     echo "ERROR: instruction-budget gate FAILED — a bootstrap file would be" >&2
     echo "       silently truncated at boot. Trim it before building." >&2
     exit 1
@@ -117,8 +197,9 @@ else
   # never enforces peerDependencies.
   echo "2. Config self-consistency (contextWindow + apiKey hydration + pins)..."
   if ! "${PYTHON}" "${SCRIPT_DIR}/check_config_consistency.py" \
-        --config "${SCRIPT_DIR}/openclaw.json" \
+        --config "${BUILD_CONFIG}" \
         --wrapper "${SCRIPT_DIR}/agentcore_wrapper.py" \
+        --dockerfile "${BUILD_DOCKERFILE}" \
         --verify-upstream; then
     echo "ERROR: config self-consistency gate FAILED (see above)." >&2
     exit 1
@@ -161,20 +242,34 @@ echo "Building image (ARM64)..."
 # Staged (gitignored) rather than checked in twice, so it can never drift from
 # infra/validated-fs.cjs.
 cp "${SCRIPT_DIR}/../validated-fs.cjs" "${SCRIPT_DIR}/skills/validated-fs.cjs"
-docker build \
-  --platform linux/arm64 \
-  --build-arg "AISTUDIO_SOURCE_COMMIT=${SOURCE_COMMIT}" \
-  -t "${ECR_URI}:${TAG}" \
-  "${SCRIPT_DIR}"
+DOCKER_BUILD_ARGS=(
+  --platform linux/arm64
+  --build-arg "AISTUDIO_SOURCE_COMMIT=${SOURCE_COMMIT}"
+  -f "${SCRIPT_DIR}/Dockerfile"
+  -t "${ECR_URI}:${TAG}"
+)
+if [ -n "${CANDIDATE_ID}" ]; then
+  DOCKER_BUILD_ARGS+=(
+    --build-arg "OPENCLAW_CONFIG=${OPENCLAW_CONFIG_BUILD_PATH}"
+    --build-arg "SOUL_PREAMBLE=${SOUL_PREAMBLE_BUILD_PATH}"
+    --build-arg "PSD_RULES_SKILL=${PSD_RULES_BUILD_PATH}"
+    --build-arg "OPENCLAW_BASE_IMAGE=${OPENCLAW_BASE_IMAGE}"
+    --build-arg "BEDROCK_PLUGIN_VERSION=${BEDROCK_PLUGIN_VERSION}"
+    --build-arg "BEDROCK_PLUGIN_EXPECTED_TOKEN=${BEDROCK_PLUGIN_EXPECTED_TOKEN}"
+  )
+fi
+docker build "${DOCKER_BUILD_ARGS[@]}" "${SCRIPT_DIR}"
 rm -f "${SCRIPT_DIR}/skills/validated-fs.cjs"
 
 # ---------------------------------------------------------------------------
 # Build-time eval gate (issue #1161): runtime boot probe + signed canary turn.
-# The image never receives a provider credential. A canary can run only when
-# the caller supplies the trusted web origin plus a short-lived router-signed
-# invocation context AND its derived request-proof key — the web broker
-# (/api/agent/model-proxy) authorizes on all three, and agentcore_wrapper.py
-# refuses to install authority when either half of the pair is missing.
+# The default native-SigV4 image never receives a provider secret. A Mantle
+# candidate receives only the environment's secret ARN and resolves it inside
+# the short-lived probe container. Every canary also requires the trusted web
+# origin plus a short-lived router-signed invocation context AND its derived
+# request-proof key — the web broker (/api/agent/model-proxy) authorizes on all
+# three, and agentcore_wrapper.py refuses to install authority when either half
+# of the pair is missing.
 #
 # Both halves are minted by scripts/agent-workspace/mint-agent-probe-context.ts
 # (`bun run agent:probe-context`), which signs with the same HMAC key the router
@@ -279,23 +374,36 @@ except Exception:
   else
     PROBE_RAN="true"
     PROBE_TIMEOUT="${PROBE_BOOT_TIMEOUT:-120}"
-    CANARY_MESSAGE="${CANARY_MESSAGE:-Reply with exactly: OK}"
+    if [ -n "${CANDIDATE_ID}" ]; then
+      CANARY_MESSAGE="${CANARY_MESSAGE:-Reply with exactly: CANDIDATE_OK}"
+    else
+      CANARY_MESSAGE="${CANARY_MESSAGE:-Reply with exactly: OK}"
+    fi
     # The payload's user_email is identity metadata only — the broker derives
     # the real owner from the signed claims. Read it back OUT of the token so
     # the two can never disagree in logs, whoever minted the context.
     CANARY_OWNER_EMAIL=$("${PYTHON}" "${SCRIPT_DIR}/eval/probe.py" owner-email \
       "${PROBE_INVOCATION_CONTEXT}")
-    CID=""
-    # Always reap the probe container, even on failure/exit.
-    cleanup_probe() { [ -n "${CID}" ] && docker rm -f "${CID}" >/dev/null 2>&1 || true; }
-    trap cleanup_probe EXIT
-
     echo "Starting probe container against the signed web broker..."
     # Pass through host AWS creds. Build an array (rather than unquoted
     # ${VAR:+...} word-splitting) so the args are robust regardless of the
     # credential alphabet / IFS.
     PROBE_ENV_ARGS=(-e "ENVIRONMENT=${ENVIRONMENT}" -e "AWS_REGION=${REGION}"
       -e "BUILD_MARKER=${TAG}@probe" -e "APP_BASE_URL=${PROBE_APP_BASE_URL}")
+    if [ "${CANDIDATE_REQUIRES_BEARER}" = "true" ]; then
+      BEDROCK_API_KEY_SECRET_ARN=$(aws cloudformation describe-stacks \
+        --stack-name "${STACK_NAME}" \
+        --query "Stacks[0].Outputs[?OutputKey=='BedrockApiKeySecretArn'].OutputValue" \
+        --output text --region "${REGION}")
+      if [ -z "${BEDROCK_API_KEY_SECRET_ARN}" ] \
+         || [ "${BEDROCK_API_KEY_SECRET_ARN}" = "None" ]; then
+        echo "ERROR: candidate uses Mantle but BedrockApiKeySecretArn is unavailable." >&2
+        exit 1
+      fi
+      PROBE_ENV_ARGS+=(
+        -e "BEDROCK_API_KEY_SECRET_ARN=${BEDROCK_API_KEY_SECRET_ARN}"
+      )
+    fi
 
     # The agent signs its own Bedrock calls with SigV4 from the AgentCore
     # execution role, so the probe container needs REAL credentials or the
@@ -410,21 +518,41 @@ except Exception:
     # Match the extracted answer with a word-bounded, case-SENSITIVE 'OK' — a
     # bare `grep -qi ok` false-passes on strings that merely CONTAIN the
     # substring ("token", "broken", "ExpiredTokenException", "look").
-    if [ "${CANARY_STATUS}" -eq 0 ] \
-       && printf '%s' "${CANARY_ANSWER}" | grep -Eq '(^|[^A-Za-z])OK([^A-Za-z]|$)'; then
+    if [ -n "${CANDIDATE_ID}" ]; then
+      if [ "${CANARY_STATUS}" -eq 0 ] \
+         && printf '%s' "${CANARY_ANSWER}" | grep -Eq '^CANDIDATE_OK[[:space:]]*$'; then
+        CANARY_GRADED="true"
+      else
+        CANARY_GRADED="false"
+      fi
+    elif [ "${CANARY_STATUS}" -eq 0 ] \
+         && printf '%s' "${CANARY_ANSWER}" | grep -Eq '(^|[^A-Za-z])OK([^A-Za-z]|$)'; then
+      CANARY_GRADED="true"
+    else
+      CANARY_GRADED="false"
+    fi
+    if [ "${CANARY_GRADED}" = "true" ]; then
       echo "  Canary turn PASSED (answered in ${CANARY_ELAPSED}s)."
       CANARY_OK="true"
     else
-      echo "ERROR: canary turn failed (exit=${CANARY_STATUS}) or produced no 'OK' answer." >&2
+      echo "ERROR: canary turn failed (exit=${CANARY_STATUS}) or missed the expected output." >&2
       printf '%s\n' "${CANARY_OUT}" | tail -5 | sed 's/^/    [canary-raw] /' >&2
       CANARY_OK="false"
     fi
 
-    printf '{"tag":"%s","boot_ok":true,"boot_elapsed_s":%s,"canary_ok":%s,"canary_elapsed_s":%s}\n' \
-      "${TAG}" "${BOOT_ELAPSED}" "${CANARY_OK}" "${CANARY_ELAPSED}" > "${PROBE_ARTIFACT}"
+    if [ -n "${CANDIDATE_ID}" ]; then
+      printf '{"tag":"%s","candidate_id":"%s","boot_ok":true,"boot_elapsed_s":%s,"canary_ok":%s,"canary_elapsed_s":%s,"grader":"output_match","grade_passed":%s}\n' \
+        "${TAG}" "${CANDIDATE_ID}" "${BOOT_ELAPSED}" "${CANARY_OK}" \
+        "${CANARY_ELAPSED}" "${CANARY_GRADED}" > "${PROBE_ARTIFACT}"
+    else
+      printf '{"tag":"%s","boot_ok":true,"boot_elapsed_s":%s,"canary_ok":%s,"canary_elapsed_s":%s}\n' \
+        "${TAG}" "${BOOT_ELAPSED}" "${CANARY_OK}" "${CANARY_ELAPSED}" \
+        > "${PROBE_ARTIFACT}"
+    fi
     echo "  Probe artifact: ${PROBE_ARTIFACT}"
 
-    cleanup_probe; CID=""; trap - EXIT
+    docker rm -f "${CID}" >/dev/null 2>&1 || true
+    CID=""
     if [ "${CANARY_OK}" != "true" ]; then
       exit 1
     fi
@@ -454,6 +582,16 @@ DIGEST=$(aws ecr describe-images \
   --image-ids "imageTag=${TAG}" \
   --query 'imageDetails[0].imageDigest' \
   --output text)
+
+if [ -n "${CANDIDATE_ID}" ]; then
+  CANDIDATE_SIDECAR="${SCRIPT_DIR}/.candidate-builds/${TAG}.json"
+  "${PYTHON}" "${SCRIPT_DIR}/eval/candidates/candidate.py" finalize \
+    --metadata "${CANDIDATE_METADATA}" \
+    --out "${CANDIDATE_SIDECAR}" \
+    --image "${ECR_URI}:${TAG}" \
+    --digest "${DIGEST}" >/dev/null
+  echo "Candidate metadata: ${CANDIDATE_SIDECAR}"
+fi
 
 echo ""
 echo "=== Done ==="

--- a/infra/agent-image/check_config_consistency.py
+++ b/infra/agent-image/check_config_consistency.py
@@ -50,6 +50,7 @@ KNOWN_CONTEXT_WINDOWS: Dict[str, int] = {
     "anthropic.claude-sonnet-5": 200000,
     "us.anthropic.claude-sonnet-5": 200000,
     "claude-sonnet-5": 200000,
+    "zai.glm-5": 200000,
 }
 
 # Generic sanity band for models not in the known table (catches order-of-
@@ -87,6 +88,13 @@ _CACHE_CAPABLE_PLUGIN_MIN: Dict[str, str] = {
 _PLUGIN_PACK_RE = re.compile(
     r"npm pack @openclaw/amazon-bedrock-provider@([0-9A-Za-z.\-]+)"
 )
+_PLUGIN_VERSION_ARG_RE = re.compile(
+    r"^ARG\s+BEDROCK_PLUGIN_VERSION=([0-9A-Za-z.\-]+)\s*$", re.MULTILINE,
+)
+_PLUGIN_PACK_ARG_RE = re.compile(
+    r'npm pack ["\']?@openclaw/amazon-bedrock-provider@'
+    r'\$\{BEDROCK_PLUGIN_VERSION\}["\']?'
+)
 
 # The base image is pinned by immutable digest, with the human-readable tag
 # recorded directly above it. Parsing both lets us cross-check them AND compare
@@ -98,6 +106,14 @@ _HOST_TAG_RE = re.compile(
 )
 _HOST_FROM_RE = re.compile(
     r"^FROM\s+ghcr\.io/openclaw/openclaw@(sha256:[0-9a-f]{64})", re.MULTILINE,
+)
+_HOST_IMAGE_ARG_RE = re.compile(
+    r"^ARG\s+OPENCLAW_BASE_IMAGE="
+    r"ghcr\.io/openclaw/openclaw@(sha256:[0-9a-f]{64})\s*$",
+    re.MULTILINE,
+)
+_HOST_FROM_ARG_RE = re.compile(
+    r"^FROM\s+\$\{OPENCLAW_BASE_IMAGE\}\s*$", re.MULTILINE,
 )
 
 
@@ -166,6 +182,9 @@ def parse_pinned_plugin_version(dockerfile_path: str) -> Tuple[Optional[str], Li
         return None, [f"cannot read Dockerfile {dockerfile_path}: {exc}"]
 
     matches = _PLUGIN_PACK_RE.findall(source)
+    argument_match = _PLUGIN_VERSION_ARG_RE.search(source)
+    if argument_match and _PLUGIN_PACK_ARG_RE.search(source):
+        matches.append(argument_match.group(1))
     if not matches:
         return None, [
             "Dockerfile has no `npm pack @openclaw/amazon-bedrock-provider@<version>` "
@@ -178,17 +197,20 @@ def parse_pinned_plugin_version(dockerfile_path: str) -> Tuple[Optional[str], Li
         ]
     version = matches[0]
     violations: List[str] = []
-    # The same version appears in the tar/rm filenames right after npm pack; a
-    # copy-paste slip there fails the build deep in the RUN with a confusing
-    # "No such file" instead of a clear version mismatch.
-    for filename in (
-        f"openclaw-amazon-bedrock-provider-{version}.tgz",
+    # The tar/rm filenames must use the same literal version or the same
+    # parameter. A copy-paste slip otherwise fails deep in the RUN.
+    literal_filename = f"openclaw-amazon-bedrock-provider-{version}.tgz"
+    parameter_filename = (
+        "openclaw-amazon-bedrock-provider-${BEDROCK_PLUGIN_VERSION}.tgz"
+    )
+    if (
+        source.count(literal_filename) < 2
+        and source.count(parameter_filename) < 2
     ):
-        if source.count(filename) < 2:
-            violations.append(
-                f"Dockerfile pins plugin {version} but its tar/rm filenames do "
-                f"not both reference {filename}"
-            )
+        violations.append(
+            f"Dockerfile pins plugin {version} but its tar/rm filenames do "
+            "not both reference the same version parameter"
+        )
     return version, violations
 
 
@@ -279,6 +301,9 @@ def check_upstream_pins(dockerfile_path: str) -> List[str]:
 
     tag_match = _HOST_TAG_RE.search(source)
     from_match = _HOST_FROM_RE.search(source)
+    host_argument_match = _HOST_IMAGE_ARG_RE.search(source)
+    if not from_match and host_argument_match and _HOST_FROM_ARG_RE.search(source):
+        from_match = host_argument_match
     plugin_version, _ = parse_pinned_plugin_version(dockerfile_path)
     if not tag_match or not from_match:
         return ["cannot verify upstream pins — Dockerfile tag/FROM lines unreadable"]
@@ -351,6 +376,9 @@ def check_host_plugin_compatibility(dockerfile_path: str) -> List[str]:
 
     tag_match = _HOST_TAG_RE.search(source)
     from_match = _HOST_FROM_RE.search(source)
+    host_argument_match = _HOST_IMAGE_ARG_RE.search(source)
+    if not from_match and host_argument_match and _HOST_FROM_ARG_RE.search(source):
+        from_match = host_argument_match
     if not tag_match:
         return violations + [
             "Dockerfile has no `# ghcr.io/openclaw/openclaw:<tag>` + `# index: "

--- a/infra/agent-image/check_config_consistency.py
+++ b/infra/agent-image/check_config_consistency.py
@@ -10,9 +10,9 @@ build (no Docker):
      table it must match. A fat-fingered contextWindow (20_000 instead of
      200_000, or 2_000_000) silently changes pruning behavior and cost.
 
-  2. apiKey hydration path — every provider whose apiKey is an `env:VAR`
-     placeholder must have VAR actually hydrated in agentcore_wrapper.py. A
-     provider that points at an env var nothing sets boots with no credential
+  2. apiKey credential path — every provider whose apiKey is an `env:VAR`
+     placeholder must have VAR hydrated or confined to the root-owned relay in
+     agentcore_wrapper.py. An unresolved placeholder boots with no credential
      and every model call 401s (the r11-class "missing provider" failure).
 
   3. prompt-caching reachability — if openclaw.json asks for prompt caching
@@ -530,20 +530,31 @@ def check_apikey_hydration(config: dict, wrapper_path: str) -> List[str]:
         if not env_var:
             violations.append(f"{provider_name}: apiKey 'env:' has no variable name")
             continue
-        # The wrapper must actually SET this env var (hydration), i.e. contain an
-        # `os.environ["VAR"]` reference — not merely the bare name as a substring.
-        # A bare-name match false-passes when the var is a substring of another
-        # name (e.g. `TOKEN` inside `AWS_BEARER_TOKEN_BEDROCK`) or appears only in
-        # a comment, exactly the r11 "missing provider" class this gate exists to
-        # catch. Accept single- or double-quoted subscript.
+        # The wrapper must either hydrate this exact env var or route the
+        # Bedrock candidate placeholder through the root-only relay. Bare-name
+        # matches false-pass when a variable is only a substring/comment, so
+        # require the complete source contract for the relay path.
         hydration_markers = (
             f'os.environ["{env_var}"]',
             f"os.environ['{env_var}']",
         )
-        if not any(marker in wrapper_src for marker in hydration_markers):
+        candidate_relay_markers = (
+            f'BEDROCK_BEARER_ENV = "{env_var}"',
+            "os.environ.get(BEDROCK_BEARER_ENV",
+            "CANDIDATE_MANTLE_RELAY_API_KEY",
+            '"CANDIDATE_MANTLE_BEARER_TOKEN": value',
+            "os.environ.pop(BEDROCK_BEARER_ENV",
+        )
+        has_direct_hydration = any(
+            marker in wrapper_src for marker in hydration_markers
+        )
+        has_candidate_relay = env_var == "AWS_BEARER_TOKEN_BEDROCK" and all(
+            marker in wrapper_src for marker in candidate_relay_markers
+        )
+        if not has_direct_hydration and not has_candidate_relay:
             violations.append(
                 f"{provider_name}: apiKey env:{env_var} has no hydration path "
-                f'(os.environ["{env_var}"]) in {os.path.basename(wrapper_path)}'
+                f"or root-only relay in {os.path.basename(wrapper_path)}"
             )
     return violations
 

--- a/infra/agent-image/eval/README.md
+++ b/infra/agent-image/eval/README.md
@@ -11,7 +11,7 @@ From the repository root:
 
 ```bash
 python3 infra/agent-image/eval/runner.py \
-  --image <tag-or-digest> \
+  --image <immutable-ecr-uri@sha256:digest> \
   --candidate-metadata infra/agent-image/.candidate-builds/<tag>.json \
   --suite infra/agent-image/eval/suites/regression.yaml \
   --trials 3 \
@@ -50,14 +50,15 @@ When a post-mint credential check recycles the runtime, the runner discards
 that authority and remints it for the ready container before invoking.
 
 Candidate-matrix runs must pass the finalized `.candidate-builds/<tag>.json`
-sidecar. The runner rejects a sidecar whose tag/digest does not match
-`--image`. Native SigV4 metadata causes no provider-secret lookup. For Mantle
-OpenAI/Anthropic metadata, the runner resolves
+sidecar. The runner requires the sidecar's immutable digest as `--image` and
+rejects even its matching mutable tag. Native SigV4 metadata causes no
+provider-secret lookup. For Mantle OpenAI/Anthropic metadata, the runner resolves
 `BedrockApiKeySecretArn` from the selected environment's agent-platform stack
-and passes only that ARN into each short-lived container; the container reads
-the value with the same refreshed AWS credential chain. The caller therefore
-needs `secretsmanager:GetSecretValue` on that environment secret for Mantle
-evaluations.
+and passes only that ARN into each short-lived container. The root-owned relay
+reads the value with the same refreshed AWS credential chain and injects it
+only into the fixed AWS model request; the node gateway cannot read it. The
+caller therefore needs `secretsmanager:GetSecretValue` on that environment
+secret for Mantle evaluations.
 
 Owner-bound skill tasks must pass an eval-only address on the real PSD domain
 with `--owner-email` (or `AGENT_EVAL_OWNER_EMAIL`). The signed context makes

--- a/infra/agent-image/eval/README.md
+++ b/infra/agent-image/eval/README.md
@@ -60,6 +60,33 @@ JSONL output is created with owner-only (`0600`) permissions because complete
 metadata can contain prompts, messages, and tool details. Keep it in an
 issue-specific temporary path; do not commit run transcripts.
 
+## Build a reproducible candidate image
+
+The one-axis candidate matrix lives under `eval/candidates/`. From
+`infra/agent-image`, build and push a selected candidate with:
+
+```bash
+./build-and-push.sh \
+  --candidate eval/candidates/manifests/glm-5-native.json \
+  2026-07-29-glm-5-native
+```
+
+`candidate.py` compares the full model/provider, harness, and prompt axes to
+`manifests/baseline.json` and requires exactly the declared axis to differ. It
+then materializes the config and prompt, validates the effective host/plugin
+pins and cache behavior with the existing consistency gate, and leaves the
+Dockerfile's default Sonnet/native-SigV4 behavior unchanged.
+
+Before push, the candidate must boot and pass one exact-output graded turn.
+After push, `.candidate-builds/<tag>.json` binds the immutable digest to its
+model ID, provider path, harness and plugin pins, prompt variant, cache mode,
+axis delta, cost sources, and source commit. That local sidecar is comparison
+evidence, not a deployment instruction.
+
+See [`candidates/README.md`](./candidates/README.md) for the complete
+OpenAI/GLM/Kimi/Qwen/Claude manifest matrix and the verified native Bedrock,
+Mantle OpenAI-compatible, and Mantle Anthropic Messages contracts.
+
 ## Transcript-free summaries
 
 After both production suites finish, convert their JSONL records into the only
@@ -497,6 +524,7 @@ UV_CACHE_DIR=/tmp/issue-1426-uv-cache \
   infra/agent-image/test_mantle_proxy_logging.py \
   infra/agent-image/test_check_bootstrap_budget.py \
   infra/agent-image/test_check_config_consistency.py \
+  infra/agent-image/test_candidate_matrix.py \
   infra/agent-image/test_workspace_sync.py \
   infra/agent-image/test_chat_format.py \
   infra/agent-image/test_artifact_publisher.py \

--- a/infra/agent-image/eval/README.md
+++ b/infra/agent-image/eval/README.md
@@ -12,6 +12,7 @@ From the repository root:
 ```bash
 python3 infra/agent-image/eval/runner.py \
   --image <tag-or-digest> \
+  --candidate-metadata infra/agent-image/.candidate-builds/<tag>.json \
   --suite infra/agent-image/eval/suites/regression.yaml \
   --trials 3 \
   --out /tmp/issue-1426-regression.jsonl \
@@ -48,6 +49,16 @@ credential action's `aws-expiration` output.
 When a post-mint credential check recycles the runtime, the runner discards
 that authority and remints it for the ready container before invoking.
 
+Candidate-matrix runs must pass the finalized `.candidate-builds/<tag>.json`
+sidecar. The runner rejects a sidecar whose tag/digest does not match
+`--image`. Native SigV4 metadata causes no provider-secret lookup. For Mantle
+OpenAI/Anthropic metadata, the runner resolves
+`BedrockApiKeySecretArn` from the selected environment's agent-platform stack
+and passes only that ARN into each short-lived container; the container reads
+the value with the same refreshed AWS credential chain. The caller therefore
+needs `secretsmanager:GetSecretValue` on that environment secret for Mantle
+evaluations.
+
 Owner-bound skill tasks must pass an eval-only address on the real PSD domain
 with `--owner-email` (or `AGENT_EVAL_OWNER_EMAIL`). The signed context makes
 that address the trial's actor and owner, so the model exercises the same
@@ -81,7 +92,7 @@ Before push, the candidate must boot and pass one exact-output graded turn.
 After push, `.candidate-builds/<tag>.json` binds the immutable digest to its
 model ID, provider path, harness and plugin pins, prompt variant, cache mode,
 axis delta, cost sources, and source commit. That local sidecar is comparison
-evidence, not a deployment instruction.
+evidence and the runner's provider-auth contract, not a deployment instruction.
 
 See [`candidates/README.md`](./candidates/README.md) for the complete
 OpenAI/GLM/Kimi/Qwen/Claude manifest matrix and the verified native Bedrock,

--- a/infra/agent-image/eval/README.md
+++ b/infra/agent-image/eval/README.md
@@ -49,6 +49,9 @@ credential action's `aws-expiration` output.
 When a post-mint credential check recycles the runtime, the runner discards
 that authority and remints it for the ready container before invoking.
 
+Every run requires an immutable `repository@sha256:...` image reference, even
+when `--candidate-metadata` is omitted. Mutable local or ECR tags are rejected
+before Docker starts so results cannot be attributed to moving image bytes.
 Candidate-matrix runs must pass the finalized `.candidate-builds/<tag>.json`
 sidecar. The runner requires the sidecar's immutable digest as `--image` and
 rejects even its matching mutable tag. Native SigV4 metadata causes no

--- a/infra/agent-image/eval/candidates/README.md
+++ b/infra/agent-image/eval/candidates/README.md
@@ -84,7 +84,7 @@ and [supported cross-region profiles](https://docs.aws.amazon.com/bedrock/latest
 - Credential: `AWS_BEARER_TOKEN_BEDROCK`, loaded from the stack's
   `BedrockApiKeySecretArn` for the candidate probe and atomically inlined
   before OpenClaw starts.
-- IAM for the key-backed API: `bedrock-mantle:CallWithBearerToken` requires
+- IAM for the key-backed API: `bedrock:CallWithBearerToken` requires
   resource `*`; the probe principal also needs `secretsmanager:GetSecretValue`
   on that one environment secret. Model access should be constrained with a
   Bedrock project/API-key policy when this path is used beyond a local
@@ -100,7 +100,7 @@ and [Mantle IAM projects](https://docs.aws.amazon.com/bedrock/latest/userguide/s
 - `auth`: `api-key`
 - `baseUrl`: `https://bedrock-mantle.us-east-1.api.aws/anthropic`; OpenClaw
   appends `/v1/messages`.
-- Credential/IAM: the same API-key and `bedrock-mantle:CallWithBearerToken`
+- Credential/IAM: the same API-key and `bedrock:CallWithBearerToken`
   contract as the OpenAI-compatible path.
 
 Source: [Bedrock Mantle Messages API](https://docs.aws.amazon.com/bedrock/latest/userguide/inference-messages-api.html).
@@ -147,3 +147,19 @@ The finalized JSON sidecar records:
 `.candidate-builds/` is ignored because it is local build evidence. Copy the
 sidecar into the issue/PR evidence when reporting the candidate; do not commit
 credentials or eval transcripts.
+
+Pass the same finalized sidecar to repeated evaluations:
+
+```bash
+python3 infra/agent-image/eval/runner.py \
+  --image <immutable-ecr-uri@sha256:digest> \
+  --candidate-metadata infra/agent-image/.candidate-builds/<tag>.json \
+  --suite infra/agent-image/eval/suites/regression.yaml \
+  --out /tmp/candidate-regression.jsonl
+```
+
+The runner verifies that the sidecar tag/digest matches the image. Native
+SigV4 remains a no-secret path. For either Mantle path, it resolves the
+environment's `BedrockApiKeySecretArn` stack output and gives the container
+only that ARN; the container retrieves the key using the active, refreshed AWS
+credential chain.

--- a/infra/agent-image/eval/candidates/README.md
+++ b/infra/agent-image/eval/candidates/README.md
@@ -1,0 +1,149 @@
+# Candidate image matrix
+
+The candidate-image contract builds one comparison image while holding every
+axis but one equal to `manifests/baseline.json`. It is intentionally separate
+from deployment and promotion: producing an ECR digest does not change the
+AgentCore runtime.
+
+## One command
+
+Run from `infra/agent-image` with a clean Git checkout:
+
+```bash
+./build-and-push.sh \
+  --candidate eval/candidates/manifests/glm-5-native.json \
+  2026-07-29-glm-5-native
+```
+
+The command validates the manifest and its official-source metadata, runs the
+unchanged static gates against the materialized inputs, builds, boots, executes
+one real `/invocations` turn, grades the exact `CANDIDATE_OK` output, pushes,
+resolves the immutable digest, and writes the local sidecar
+`.candidate-builds/<tag>.json`.
+
+The committed matrix is:
+
+| Manifest | Model | Provider path | Cache |
+|---|---|---|---|
+| `glm-5-native.json` | Z.AI GLM-5 | native Bedrock Converse + SigV4 | `none` |
+| `glm-5-mantle-openai.json` | Z.AI GLM-5 | Mantle OpenAI-compatible | `none` |
+| `openai-gpt-oss-120b.json` | OpenAI GPT OSS 120B | Mantle OpenAI-compatible | `none` |
+| `kimi-k2-5.json` | Moonshot Kimi K2.5 | Mantle OpenAI-compatible | `none` |
+| `qwen3-coder-next.json` | Qwen3 Coder Next | Mantle OpenAI-compatible | `none` |
+| `sonnet-5-mantle-anthropic.json` | Claude Sonnet 5 | Mantle Anthropic Messages | `long` |
+
+## Axis contract
+
+Every manifest contains complete `model`, `harness`, and `prompt` axes plus a
+`declaredAxis`. `candidate.py` compares those objects to the baseline and
+rejects zero changes, an undeclared change, or changes to two or more axes.
+
+- `model` selects one provider template. A template includes the model,
+  transport, authentication, endpoint, safe agent context budget, cache mode,
+  cost, cost sources, and IAM. The context budget may not exceed the selected
+  model's documented context window.
+- `harness` pins the immutable OpenClaw base digest, human-readable host
+  version, Bedrock plugin version, and the token that must exist in the
+  vendored plugin. The generated pin contract is passed through
+  `check_config_consistency.py`; `npm pack` and both tarball references share
+  the same build argument.
+- `prompt` selects the SOUL preamble and rules skill. The candidate versions
+  are passed as Docker build inputs and checked against the materialized
+  config's bootstrap budgets.
+
+The baseline template must compose byte-for-byte to the checked-in
+`openclaw.json`. If production changes without a matching baseline update,
+every candidate validation fails loudly.
+
+## Provider contracts
+
+All entries below were re-verified against the linked AWS documentation on
+2026-07-29.
+
+### Native Bedrock SigV4
+
+- OpenClaw `api`: `bedrock-converse-stream`
+- `auth`: `aws-sdk`
+- `baseUrl`: `https://bedrock-runtime.us-east-1.amazonaws.com`
+- Runtime IAM: `bedrock:InvokeModel` and
+  `bedrock:InvokeModelWithResponseStream` on the selected foundation model.
+- For a cross-region inference profile, grant both the inference-profile ARN
+  and **every** destination-region foundation-model ARN. Organization SCPs
+  must permit all of those destination regions. The Sonnet template enumerates
+  us-east-1, us-east-2, and us-west-2 member ARN patterns.
+
+Sources: [Bedrock endpoints](https://docs.aws.amazon.com/bedrock/latest/userguide/endpoints.html),
+[inference-profile prerequisites](https://docs.aws.amazon.com/bedrock/latest/userguide/inference-profiles-prereq.html),
+and [supported cross-region profiles](https://docs.aws.amazon.com/bedrock/latest/userguide/inference-profiles-support.html).
+
+### Mantle OpenAI-compatible
+
+- OpenClaw `api`: `openai-completions`
+- `auth`: `api-key`
+- `baseUrl`: `https://bedrock-mantle.us-east-1.api.aws/v1`
+- Credential: `AWS_BEARER_TOKEN_BEDROCK`, loaded from the stack's
+  `BedrockApiKeySecretArn` for the candidate probe and atomically inlined
+  before OpenClaw starts.
+- IAM for the key-backed API: `bedrock-mantle:CallWithBearerToken` requires
+  resource `*`; the probe principal also needs `secretsmanager:GetSecretValue`
+  on that one environment secret. Model access should be constrained with a
+  Bedrock project/API-key policy when this path is used beyond a local
+  candidate.
+
+Sources: [Mantle APIs](https://docs.aws.amazon.com/bedrock/latest/userguide/bedrock-mantle.html),
+[API-key authentication](https://docs.aws.amazon.com/bedrock/latest/userguide/api-keys-use.html),
+and [Mantle IAM projects](https://docs.aws.amazon.com/bedrock/latest/userguide/security-iam-projects.html).
+
+### Mantle Anthropic Messages
+
+- OpenClaw `api`: `anthropic-messages`
+- `auth`: `api-key`
+- `baseUrl`: `https://bedrock-mantle.us-east-1.api.aws/anthropic`; OpenClaw
+  appends `/v1/messages`.
+- Credential/IAM: the same API-key and `bedrock-mantle:CallWithBearerToken`
+  contract as the OpenAI-compatible path.
+
+Source: [Bedrock Mantle Messages API](https://docs.aws.amazon.com/bedrock/latest/userguide/inference-messages-api.html).
+
+## Model limits, cost, and caching
+
+Costs are USD per one million tokens in US East standard/on-demand service.
+Every numeric cost field in a provider template has its own `costSources`
+entry, and validation fails if a field or source is missing.
+
+| Model | Context / max output | Input / output | Cache read / write |
+|---|---:|---:|---:|
+| Claude Sonnet 5 | operational 200K / 32K | $3 / $15 | $0.30 / $6 |
+| GLM-5 | 200K / 128K | $1 / $3.20 | $0 / $0 |
+| GPT OSS 120B | 128K / 16K | $0.15 / $0.60 | $0 / $0 |
+| Kimi K2.5 | 256K / 16K | $0.60 / $3 | $0 / $0 |
+| Qwen3 Coder Next | 256K / 16K | $0.50 / $1.20 | $0 / $0 |
+
+The baseline keeps the repository's deliberate 200K/32K operational cap for
+Claude even though the current model card advertises a larger service maximum.
+Non-Claude candidates must set `cacheRetention: none`; validation rejects any
+other value and the existing prompt-cache consistency gate remains in force.
+
+Sources: [Amazon Bedrock pricing](https://aws.amazon.com/bedrock/pricing/),
+[Claude Sonnet 5](https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-sonnet-5.html),
+[GLM-5](https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-zai-glm-5.html),
+[GPT OSS 120B](https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-openai-gpt-oss-120b.html),
+[Kimi K2.5](https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-moonshot-ai-kimi-k2-5.html),
+and [Qwen3 Coder Next](https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-qwen-qwen3-coder-next.html).
+
+## Sidecar fields
+
+The finalized JSON sidecar records:
+
+- candidate and baseline IDs, the varied axis, and both sides of that delta;
+- model ID, provider name/path/API/auth/base URL, and cache retention;
+- immutable base image, host/plugin pins, plugin assertion token, prompt
+  variant and source paths;
+- model costs, a source URL for every cost, complete provider source/IAM
+  metadata, manifest SHA-256, and AI Studio source commit;
+- pushed ECR tag, immutable image digest, preparation time, and finalization
+  time.
+
+`.candidate-builds/` is ignored because it is local build evidence. Copy the
+sidecar into the issue/PR evidence when reporting the candidate; do not commit
+credentials or eval transcripts.

--- a/infra/agent-image/eval/candidates/README.md
+++ b/infra/agent-image/eval/candidates/README.md
@@ -82,9 +82,11 @@ and [supported cross-region profiles](https://docs.aws.amazon.com/bedrock/latest
 - `auth`: `api-key`
 - `baseUrl`: `https://bedrock-mantle.us-east-1.api.aws/v1`
 - Credential: `AWS_BEARER_TOKEN_BEDROCK`, loaded from the stack's
-  `BedrockApiKeySecretArn` for the candidate probe and atomically inlined
-  before OpenClaw starts.
-- IAM for the key-backed API: `bedrock:CallWithBearerToken` requires
+  `BedrockApiKeySecretArn` for the candidate probe. The root-owned loopback
+  relay injects it into the fixed AWS request; the node gateway receives only
+  a non-secret sentinel and cannot read the bearer or secret ARN.
+- IAM for the key-backed Mantle API:
+  `bedrock-mantle:CallWithBearerToken` requires
   resource `*`; the probe principal also needs `secretsmanager:GetSecretValue`
   on that one environment secret. Model access should be constrained with a
   Bedrock project/API-key policy when this path is used beyond a local
@@ -92,7 +94,7 @@ and [supported cross-region profiles](https://docs.aws.amazon.com/bedrock/latest
 
 Sources: [Mantle APIs](https://docs.aws.amazon.com/bedrock/latest/userguide/bedrock-mantle.html),
 [API-key authentication](https://docs.aws.amazon.com/bedrock/latest/userguide/api-keys-use.html),
-and [Mantle IAM projects](https://docs.aws.amazon.com/bedrock/latest/userguide/security-iam-projects.html).
+and [API-key permissions](https://docs.aws.amazon.com/bedrock/latest/userguide/api-keys-permissions.html).
 
 ### Mantle Anthropic Messages
 
@@ -100,7 +102,8 @@ and [Mantle IAM projects](https://docs.aws.amazon.com/bedrock/latest/userguide/s
 - `auth`: `api-key`
 - `baseUrl`: `https://bedrock-mantle.us-east-1.api.aws/anthropic`; OpenClaw
   appends `/v1/messages`.
-- Credential/IAM: the same API-key and `bedrock:CallWithBearerToken`
+- Credential/IAM: the same root-relayed API key and
+  `bedrock-mantle:CallWithBearerToken`
   contract as the OpenAI-compatible path.
 
 Source: [Bedrock Mantle Messages API](https://docs.aws.amazon.com/bedrock/latest/userguide/inference-messages-api.html).
@@ -158,8 +161,9 @@ python3 infra/agent-image/eval/runner.py \
   --out /tmp/candidate-regression.jsonl
 ```
 
-The runner verifies that the sidecar tag/digest matches the image. Native
-SigV4 remains a no-secret path. For either Mantle path, it resolves the
+The runner requires `--image` in immutable `repository@sha256:...` form and
+verifies that digest against the sidecar; the mutable tag is evidence only.
+Native SigV4 remains a no-secret path. For either Mantle path, it resolves the
 environment's `BedrockApiKeySecretArn` stack output and gives the container
-only that ARN; the container retrieves the key using the active, refreshed AWS
-credential chain.
+only that ARN. The root-owned relay retrieves and injects the key using the
+active, refreshed AWS credential chain; the node gateway receives neither.

--- a/infra/agent-image/eval/candidates/candidate.py
+++ b/infra/agent-image/eval/candidates/candidate.py
@@ -34,6 +34,7 @@ AGENT_IMAGE_DIR = SCRIPT_PATH.parents[2]
 CANONICAL_CONFIG = AGENT_IMAGE_DIR / "openclaw.json"
 CANONICAL_DOCKERFILE = AGENT_IMAGE_DIR / "Dockerfile"
 AXES = ("model", "harness", "prompt")
+UNCHANGED_BOOTSTRAP_FILES = ("IDENTITY.md", "USER.md", "MEMORY.md")
 PROVIDER_PATH_CONTRACTS: Mapping[str, tuple[str, str, str]] = {
     "native-bedrock-sigv4": (
         "bedrock-converse-stream",
@@ -541,6 +542,11 @@ def prepare(manifest_path: Path, output_dir: Path, source_commit: str) -> dict[s
     shutil.copyfile(soul_path, soul_output)
     rules_output.parent.mkdir(parents=True, exist_ok=True)
     shutil.copyfile(rules_path, rules_output)
+    # The build still copies these non-prompt-axis bootstrap files from the
+    # canonical context. Mirror them into staging so the candidate budget gate
+    # measures the complete effective prompt instead of SOUL.md alone.
+    for filename in UNCHANGED_BOOTSTRAP_FILES:
+        shutil.copyfile(AGENT_IMAGE_DIR / filename, output_dir / filename)
 
     provider = _mapping(template["provider"], "provider")
     model = _mapping(provider["models"][0], "model")  # type: ignore[index]

--- a/infra/agent-image/eval/candidates/candidate.py
+++ b/infra/agent-image/eval/candidates/candidate.py
@@ -1,0 +1,678 @@
+#!/usr/bin/env python3
+"""Validate and materialize one-axis PSD Agent image candidates.
+
+The committed manifest is the reproducibility contract. ``prepare`` resolves
+its provider template, proves that exactly one axis differs from the committed
+baseline, and writes build inputs plus a metadata draft. ``finalize`` binds
+that draft to the pushed image digest.
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import hashlib
+import json
+import os
+import re
+import shutil
+import sys
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Mapping, Sequence
+from urllib.parse import urlparse
+
+
+class CandidateError(RuntimeError):
+    """A candidate contract is invalid or cannot be materialized safely."""
+
+
+SCRIPT_PATH = Path(__file__).resolve()
+CANDIDATES_DIR = SCRIPT_PATH.parent
+AGENT_IMAGE_DIR = SCRIPT_PATH.parents[2]
+CANONICAL_CONFIG = AGENT_IMAGE_DIR / "openclaw.json"
+CANONICAL_DOCKERFILE = AGENT_IMAGE_DIR / "Dockerfile"
+AXES = ("model", "harness", "prompt")
+PROVIDER_PATH_CONTRACTS: Mapping[str, tuple[str, str, str]] = {
+    "native-bedrock-sigv4": (
+        "bedrock-converse-stream",
+        "aws-sdk",
+        "https://bedrock-runtime.",
+    ),
+    "mantle-openai-compatible": (
+        "openai-completions",
+        "api-key",
+        "https://bedrock-mantle.",
+    ),
+    "mantle-anthropic-messages": (
+        "anthropic-messages",
+        "api-key",
+        "https://bedrock-mantle.",
+    ),
+}
+REQUIRED_SOURCE_FIELDS = ("api", "auth", "baseUrl", "iam", "model", "pricing")
+REQUIRED_COST_FIELDS = ("input", "output", "cacheRead", "cacheWrite")
+SAFE_ID_RE = re.compile(r"^[a-z0-9][a-z0-9-]{0,63}$")
+PIN_RE = re.compile(r"^[0-9A-Za-z.-]+$")
+IMAGE_RE = re.compile(
+    r"^ghcr\.io/openclaw/openclaw@sha256:[0-9a-f]{64}$"
+)
+DIGEST_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
+SOURCE_COMMIT_RE = re.compile(r"^[0-9a-f]{40}$")
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _load_json(path: Path, label: str) -> dict[str, object]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError) as error:
+        raise CandidateError(f"cannot read {label} {path}: {error}") from error
+    if not isinstance(value, dict):
+        raise CandidateError(f"{label} {path} must be a JSON object")
+    return value
+
+
+def _mapping(value: object, label: str) -> dict[str, object]:
+    if not isinstance(value, dict):
+        raise CandidateError(f"{label} must be an object")
+    return value
+
+
+def _string(value: object, label: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise CandidateError(f"{label} must be a non-empty string")
+    return value
+
+
+def _safe_relative_file(raw_path: object, label: str) -> Path:
+    value = _string(raw_path, label)
+    candidate = Path(value)
+    if candidate.is_absolute():
+        raise CandidateError(f"{label} must be relative to {AGENT_IMAGE_DIR}")
+    resolved = (AGENT_IMAGE_DIR / candidate).resolve()
+    try:
+        resolved.relative_to(AGENT_IMAGE_DIR)
+    except ValueError as error:
+        raise CandidateError(f"{label} escapes {AGENT_IMAGE_DIR}") from error
+    if not resolved.is_file():
+        raise CandidateError(f"{label} does not exist: {value}")
+    return resolved
+
+
+def _resolve_manifest_path(raw_path: object, manifest_path: Path, label: str) -> Path:
+    value = _string(raw_path, label)
+    candidate = Path(value)
+    if candidate.is_absolute():
+        raise CandidateError(f"{label} must be relative to its manifest")
+    resolved = (manifest_path.parent / candidate).resolve()
+    try:
+        resolved.relative_to(CANDIDATES_DIR)
+    except ValueError as error:
+        raise CandidateError(f"{label} escapes {CANDIDATES_DIR}") from error
+    if not resolved.is_file():
+        raise CandidateError(f"{label} does not exist: {value}")
+    return resolved
+
+
+def _validate_manifest(
+    manifest: dict[str, object],
+    manifest_path: Path,
+    *,
+    is_baseline: bool,
+) -> tuple[str, dict[str, object]]:
+    if manifest.get("schemaVersion") != 1:
+        raise CandidateError(f"{manifest_path}: schemaVersion must be 1")
+    candidate_id = _string(manifest.get("id"), f"{manifest_path}: id")
+    if not SAFE_ID_RE.fullmatch(candidate_id):
+        raise CandidateError(f"{manifest_path}: id must be lowercase kebab-case")
+    axes = _mapping(manifest.get("axes"), f"{manifest_path}: axes")
+    if set(axes) != set(AXES):
+        raise CandidateError(
+            f"{manifest_path}: axes must be exactly {', '.join(AXES)}"
+        )
+    declared = _string(
+        manifest.get("declaredAxis"), f"{manifest_path}: declaredAxis"
+    )
+    if is_baseline:
+        if declared != "baseline" or manifest.get("baseline") is not None:
+            raise CandidateError(
+                f"{manifest_path}: baseline must declare axis 'baseline' "
+                "and set baseline to null"
+            )
+    elif declared not in AXES:
+        raise CandidateError(
+            f"{manifest_path}: declaredAxis must be one of {', '.join(AXES)}"
+        )
+    return candidate_id, axes
+
+
+def _validate_source_url(value: object, label: str) -> str:
+    source = _string(value, label)
+    parsed = urlparse(source)
+    if parsed.scheme != "https":
+        raise CandidateError(f"{label} must be an HTTPS source URL")
+    hostname = parsed.hostname or ""
+    if hostname != "aws.amazon.com" and not hostname.endswith(".aws.amazon.com"):
+        raise CandidateError(f"{label} must cite an official AWS source")
+    return source
+
+
+def _provider_template(
+    axes: dict[str, object],
+    manifest_path: Path,
+) -> tuple[dict[str, object], Path]:
+    model_axis = _mapping(axes["model"], f"{manifest_path}: axes.model")
+    template_path = _resolve_manifest_path(
+        model_axis.get("providerTemplate"),
+        manifest_path,
+        f"{manifest_path}: axes.model.providerTemplate",
+    )
+    template = _load_json(template_path, "provider template")
+    if template.get("schemaVersion") != 1:
+        raise CandidateError(f"{template_path}: schemaVersion must be 1")
+    verified_at = _string(
+        template.get("verifiedAt"), f"{template_path}: verifiedAt"
+    )
+    if not re.fullmatch(r"20[0-9]{2}-[0-9]{2}-[0-9]{2}", verified_at):
+        raise CandidateError(f"{template_path}: verifiedAt must be YYYY-MM-DD")
+
+    provider_path = _string(
+        template.get("providerPath"), f"{template_path}: providerPath"
+    )
+    contract = PROVIDER_PATH_CONTRACTS.get(provider_path)
+    if contract is None:
+        raise CandidateError(
+            f"{template_path}: unsupported providerPath {provider_path!r}"
+        )
+    provider_name = _string(
+        template.get("providerName"), f"{template_path}: providerName"
+    )
+    provider = _mapping(
+        template.get("provider"), f"{template_path}: provider"
+    )
+    expected_api, expected_auth, base_prefix = contract
+    if provider.get("api") != expected_api:
+        raise CandidateError(
+            f"{template_path}: {provider_path} requires api={expected_api!r}"
+        )
+    if provider.get("auth") != expected_auth:
+        raise CandidateError(
+            f"{template_path}: {provider_path} requires auth={expected_auth!r}"
+        )
+    base_url = _string(provider.get("baseUrl"), f"{template_path}: baseUrl")
+    if not base_url.startswith(base_prefix):
+        raise CandidateError(
+            f"{template_path}: {provider_path} requires an AWS {base_prefix} baseUrl"
+        )
+    if provider_path == "mantle-openai-compatible" and not base_url.endswith("/v1"):
+        raise CandidateError(f"{template_path}: Mantle OpenAI baseUrl must end in /v1")
+    if (
+        provider_path == "mantle-anthropic-messages"
+        and not base_url.endswith("/anthropic")
+    ):
+        raise CandidateError(
+            f"{template_path}: Mantle Anthropic baseUrl must end in /anthropic"
+        )
+    if provider_path.startswith("mantle-") and provider.get("apiKey") != (
+        "env:AWS_BEARER_TOKEN_BEDROCK"
+    ):
+        raise CandidateError(
+            f"{template_path}: Mantle templates must hydrate "
+            "env:AWS_BEARER_TOKEN_BEDROCK"
+        )
+    if provider_path == "native-bedrock-sigv4" and "apiKey" in provider:
+        raise CandidateError(f"{template_path}: native SigV4 must not declare apiKey")
+
+    models = provider.get("models")
+    if not isinstance(models, list) or len(models) != 1 or not isinstance(models[0], dict):
+        raise CandidateError(f"{template_path}: provider must declare exactly one model")
+    model = models[0]
+    model_id = _string(model.get("id"), f"{template_path}: model.id")
+    if template.get("primaryModelId") != model_id:
+        raise CandidateError(f"{template_path}: primaryModelId must match model.id")
+    cost = _mapping(model.get("cost"), f"{template_path}: model.cost")
+    if set(cost) != set(REQUIRED_COST_FIELDS):
+        raise CandidateError(
+            f"{template_path}: model.cost must contain exactly "
+            + ", ".join(REQUIRED_COST_FIELDS)
+        )
+    for field, value in cost.items():
+        if isinstance(value, bool) or not isinstance(value, (int, float)) or value < 0:
+            raise CandidateError(
+                f"{template_path}: model.cost.{field} must be non-negative"
+            )
+    cost_sources = _mapping(
+        template.get("costSources"), f"{template_path}: costSources"
+    )
+    if set(cost_sources) != set(cost):
+        raise CandidateError(
+            f"{template_path}: every cost field must have one costSources entry"
+        )
+    for field, source in cost_sources.items():
+        _validate_source_url(source, f"{template_path}: costSources.{field}")
+
+    sources = _mapping(template.get("sources"), f"{template_path}: sources")
+    if set(sources) != set(REQUIRED_SOURCE_FIELDS):
+        raise CandidateError(
+            f"{template_path}: sources must be exactly "
+            + ", ".join(REQUIRED_SOURCE_FIELDS)
+        )
+    for field, source in sources.items():
+        _validate_source_url(source, f"{template_path}: sources.{field}")
+
+    cache_retention = _string(
+        template.get("cacheRetention"), f"{template_path}: cacheRetention"
+    )
+    if "claude" not in model_id.lower() and cache_retention != "none":
+        raise CandidateError(
+            f"{template_path}: non-Claude candidates must use cacheRetention=none"
+        )
+    context_tokens = template.get("contextTokens")
+    context_window = model.get("contextWindow")
+    if (
+        isinstance(context_tokens, bool)
+        or not isinstance(context_tokens, int)
+        or context_tokens <= 0
+        or not isinstance(context_window, int)
+        or context_tokens > context_window
+    ):
+        raise CandidateError(
+            f"{template_path}: contextTokens must be a positive integer no "
+            "larger than the model contextWindow"
+        )
+
+    iam = _mapping(template.get("iam"), f"{template_path}: iam")
+    actions = iam.get("actions")
+    resources = iam.get("resources")
+    if (
+        not isinstance(actions, list)
+        or not actions
+        or any(not isinstance(item, str) or not item for item in actions)
+        or not isinstance(resources, list)
+        or not resources
+        or any(not isinstance(item, str) or not item for item in resources)
+    ):
+        raise CandidateError(f"{template_path}: iam actions/resources must be lists")
+    inference_profile = iam.get("inferenceProfileId")
+    member_models = iam.get("crossRegionFoundationModelArns")
+    if inference_profile is not None and (
+        not isinstance(member_models, list)
+        or not member_models
+        or any(not isinstance(item, str) or not item for item in member_models)
+    ):
+        raise CandidateError(
+            f"{template_path}: cross-region profiles must enumerate every "
+            "destination foundation-model ARN pattern"
+        )
+
+    # Provider name is validated here even though composition uses the template
+    # field directly; this catches whitespace/slash values that would make the
+    # OpenClaw primary reference ambiguous.
+    if "/" in provider_name or provider_name.strip() != provider_name:
+        raise CandidateError(f"{template_path}: providerName is malformed")
+    return template, template_path
+
+
+def _load_contract(
+    manifest_path: Path,
+) -> tuple[
+    dict[str, object],
+    dict[str, object],
+    dict[str, object],
+    Path,
+    dict[str, object],
+]:
+    manifest_path = manifest_path.resolve()
+    try:
+        manifest_path.relative_to(CANDIDATES_DIR)
+    except ValueError as error:
+        raise CandidateError(
+            f"candidate manifest must live under {CANDIDATES_DIR}"
+        ) from error
+    manifest = _load_json(manifest_path, "candidate manifest")
+    candidate_id, axes = _validate_manifest(
+        manifest, manifest_path, is_baseline=False
+    )
+    baseline_path = _resolve_manifest_path(
+        manifest.get("baseline"), manifest_path, f"{manifest_path}: baseline"
+    )
+    baseline = _load_json(baseline_path, "baseline manifest")
+    baseline_id, baseline_axes = _validate_manifest(
+        baseline, baseline_path, is_baseline=True
+    )
+
+    changed_axes = [axis for axis in AXES if axes[axis] != baseline_axes[axis]]
+    declared_axis = _string(
+        manifest.get("declaredAxis"), f"{manifest_path}: declaredAxis"
+    )
+    if changed_axes != [declared_axis]:
+        rendered = ", ".join(changed_axes) if changed_axes else "none"
+        raise CandidateError(
+            f"{manifest_path}: declaredAxis={declared_axis!r}, but changed axes "
+            f"are {rendered}; candidates must vary exactly one axis"
+        )
+    template, template_path = _provider_template(axes, manifest_path)
+
+    # The baseline itself is executable documentation: it must continue to
+    # resolve to the checked-in production config, or comparisons have drifted.
+    baseline_template, _ = _provider_template(baseline_axes, baseline_path)
+    baseline_config = _compose_config(baseline_template)
+    canonical_config = _load_json(CANONICAL_CONFIG, "canonical OpenClaw config")
+    if baseline_config != canonical_config:
+        raise CandidateError(
+            f"{baseline_path}: composed baseline no longer matches "
+            f"{CANONICAL_CONFIG}"
+        )
+    manifest["_resolvedId"] = candidate_id
+    baseline["_resolvedId"] = baseline_id
+    return manifest, axes, baseline, template_path, template
+
+
+def _compose_config(template: dict[str, object]) -> dict[str, object]:
+    config = copy.deepcopy(_load_json(CANONICAL_CONFIG, "canonical config"))
+    provider_name = _string(template.get("providerName"), "providerName")
+    provider = copy.deepcopy(_mapping(template.get("provider"), "provider"))
+    model_id = _string(template.get("primaryModelId"), "primaryModelId")
+    cache_retention = _string(template.get("cacheRetention"), "cacheRetention")
+    models = _mapping(config["models"], "canonical models")
+    models["providers"] = {provider_name: provider}
+    agents = _mapping(config["agents"], "canonical agents")
+    defaults = _mapping(agents["defaults"], "canonical agents.defaults")
+    defaults["model"] = {"primary": f"{provider_name}/{model_id}"}
+    defaults["contextTokens"] = template["contextTokens"]
+    params = _mapping(defaults["params"], "canonical agents.defaults.params")
+    params["cacheRetention"] = cache_retention
+    return config
+
+
+def _validate_harness(
+    axis: object, label: str
+) -> tuple[str, str, str, str]:
+    harness = _mapping(axis, label)
+    if set(harness) != {
+        "baseImage",
+        "hostVersion",
+        "bedrockPluginVersion",
+        "expectedPluginToken",
+    }:
+        raise CandidateError(
+            f"{label} must define baseImage, hostVersion, "
+            "bedrockPluginVersion, and expectedPluginToken"
+        )
+    base_image = _string(harness.get("baseImage"), f"{label}.baseImage")
+    host_version = _string(harness.get("hostVersion"), f"{label}.hostVersion")
+    plugin_version = _string(
+        harness.get("bedrockPluginVersion"), f"{label}.bedrockPluginVersion"
+    )
+    expected_token = _string(
+        harness.get("expectedPluginToken"), f"{label}.expectedPluginToken"
+    )
+    if not IMAGE_RE.fullmatch(base_image):
+        raise CandidateError(f"{label}.baseImage must be an immutable OpenClaw digest")
+    if not PIN_RE.fullmatch(host_version) or not PIN_RE.fullmatch(plugin_version):
+        raise CandidateError(f"{label}: host/plugin versions are malformed")
+    if not re.fullmatch(r"^[0-9A-Za-z._:-]+$", expected_token):
+        raise CandidateError(f"{label}.expectedPluginToken is malformed")
+    return base_image, host_version, plugin_version, expected_token
+
+
+def _validate_prompt(axis: object, label: str) -> tuple[str, Path, Path]:
+    prompt = _mapping(axis, label)
+    if set(prompt) != {"variant", "soul", "rules"}:
+        raise CandidateError(f"{label} must define variant, soul, and rules")
+    variant = _string(prompt.get("variant"), f"{label}.variant")
+    if not SAFE_ID_RE.fullmatch(variant):
+        raise CandidateError(f"{label}.variant must be lowercase kebab-case")
+    soul = _safe_relative_file(prompt.get("soul"), f"{label}.soul")
+    rules = _safe_relative_file(prompt.get("rules"), f"{label}.rules")
+    return variant, soul, rules
+
+
+def _atomic_json(path: Path, value: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, temporary_name = tempfile.mkstemp(
+        prefix=f".{path.name}.", dir=path.parent
+    )
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as output:
+            json.dump(value, output, indent=2, sort_keys=True)
+            output.write("\n")
+            output.flush()
+            os.fsync(output.fileno())
+        os.replace(temporary_name, path)
+    except Exception:
+        try:
+            os.unlink(temporary_name)
+        except OSError:
+            pass
+        raise
+
+
+def _staging_build_path(path: Path) -> str:
+    try:
+        relative = path.resolve().relative_to(AGENT_IMAGE_DIR)
+    except ValueError as error:
+        raise CandidateError(
+            f"staging directory must be inside {AGENT_IMAGE_DIR}"
+        ) from error
+    return relative.as_posix()
+
+
+def _render_pin_contract(
+    base_image: str,
+    host_version: str,
+    plugin_version: str,
+    expected_token: str,
+) -> str:
+    source = CANONICAL_DOCKERFILE.read_text(encoding="utf-8")
+    base_digest = base_image.rsplit("@", 1)[1]
+    replacements = (
+        (
+            r"^#   ghcr\.io/openclaw/openclaw:[0-9A-Za-z.-]+\s*$",
+            f"#   ghcr.io/openclaw/openclaw:{host_version}",
+        ),
+        (
+            r"^#   index: sha256:[0-9a-f]{64}\s*$",
+            f"#   index: {base_digest}",
+        ),
+        (
+            r"^ARG OPENCLAW_BASE_IMAGE=.*$",
+            f"ARG OPENCLAW_BASE_IMAGE={base_image}",
+        ),
+        (
+            r"^ARG BEDROCK_PLUGIN_VERSION=.*$",
+            f"ARG BEDROCK_PLUGIN_VERSION={plugin_version}",
+        ),
+        (
+            r"^ARG BEDROCK_PLUGIN_EXPECTED_TOKEN=.*$",
+            f"ARG BEDROCK_PLUGIN_EXPECTED_TOKEN={expected_token}",
+        ),
+    )
+    for pattern, replacement in replacements:
+        source, count = re.subn(pattern, replacement, source, count=1, flags=re.MULTILINE)
+        if count != 1:
+            raise CandidateError(
+                f"{CANONICAL_DOCKERFILE}: missing parameter contract {pattern}"
+            )
+    return source
+
+
+def prepare(manifest_path: Path, output_dir: Path, source_commit: str) -> dict[str, object]:
+    if not SOURCE_COMMIT_RE.fullmatch(source_commit):
+        raise CandidateError("source commit must be a full lowercase Git SHA")
+    (
+        manifest,
+        axes,
+        baseline,
+        template_path,
+        template,
+    ) = _load_contract(manifest_path)
+    candidate_id = _string(manifest["_resolvedId"], "candidate id")
+    baseline_id = _string(baseline["_resolvedId"], "baseline id")
+    declared_axis = _string(manifest.get("declaredAxis"), "declaredAxis")
+    base_image, host_version, plugin_version, expected_token = _validate_harness(
+        axes["harness"], "axes.harness"
+    )
+    prompt_variant, soul_path, rules_path = _validate_prompt(
+        axes["prompt"], "axes.prompt"
+    )
+    output_dir = output_dir.resolve()
+    _staging_build_path(output_dir)
+    if output_dir.exists() and any(output_dir.iterdir()):
+        raise CandidateError(f"output directory is not empty: {output_dir}")
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    config_path = output_dir / "openclaw.json"
+    dockerfile_path = output_dir / "pin-contract.Dockerfile"
+    soul_output = output_dir / "SOUL.md"
+    rules_output = output_dir / "skills" / "psd-rules" / "SKILL.md"
+    metadata_path = output_dir / "metadata.json"
+    _atomic_json(config_path, _compose_config(template))
+    dockerfile_path.write_text(
+        _render_pin_contract(
+            base_image, host_version, plugin_version, expected_token
+        ),
+        encoding="utf-8",
+    )
+    shutil.copyfile(soul_path, soul_output)
+    rules_output.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copyfile(rules_path, rules_output)
+
+    provider = _mapping(template["provider"], "provider")
+    model = _mapping(provider["models"][0], "model")  # type: ignore[index]
+    manifest_bytes = manifest_path.resolve().read_bytes()
+    metadata: dict[str, object] = {
+        "schemaVersion": 1,
+        "candidateId": candidate_id,
+        "baselineId": baseline_id,
+        "variedAxis": declared_axis,
+        "axisDiff": {
+            "baseline": baseline["axes"][declared_axis],  # type: ignore[index]
+            "candidate": axes[declared_axis],
+        },
+        "modelId": model["id"],
+        "providerName": template["providerName"],
+        "providerPath": template["providerPath"],
+        "providerApi": provider["api"],
+        "providerAuth": provider["auth"],
+        "providerBaseUrl": provider["baseUrl"],
+        "harness": {
+            "baseImage": base_image,
+            "hostVersion": host_version,
+            "bedrockPluginVersion": plugin_version,
+            "expectedPluginToken": expected_token,
+        },
+        "prompt": {
+            "variant": prompt_variant,
+            "soul": axes["prompt"]["soul"],  # type: ignore[index]
+            "rules": axes["prompt"]["rules"],  # type: ignore[index]
+        },
+        "cacheRetention": template["cacheRetention"],
+        "contextTokens": template["contextTokens"],
+        "cost": model["cost"],
+        "costSources": template["costSources"],
+        "sources": template["sources"],
+        "sourcesVerifiedAt": template["verifiedAt"],
+        "iam": template["iam"],
+        "providerTemplate": str(template_path.relative_to(CANDIDATES_DIR)),
+        "manifest": str(manifest_path.resolve().relative_to(CANDIDATES_DIR)),
+        "manifestSha256": hashlib.sha256(manifest_bytes).hexdigest(),
+        "sourceCommit": source_commit,
+        "preparedAt": _utc_now(),
+        "image": None,
+        "imageDigest": None,
+        "finalizedAt": None,
+    }
+    _atomic_json(metadata_path, metadata)
+
+    plan = {
+        "candidateId": candidate_id,
+        "providerPath": template["providerPath"],
+        "requiresBearerToken": str(template["providerPath"]).startswith("mantle-"),
+        "openclawConfig": _staging_build_path(config_path),
+        "dockerfile": str(dockerfile_path),
+        "soulPreamble": _staging_build_path(soul_output),
+        "psdRulesSkill": _staging_build_path(rules_output),
+        "baseImage": base_image,
+        "bedrockPluginVersion": plugin_version,
+        "expectedPluginToken": expected_token,
+        "metadata": str(metadata_path),
+    }
+    _atomic_json(output_dir / "plan.json", plan)
+    return plan
+
+
+def finalize(metadata_path: Path, output_path: Path, image: str, digest: str) -> None:
+    if not image or any(character.isspace() for character in image):
+        raise CandidateError("image must be a non-empty reference without whitespace")
+    if not DIGEST_RE.fullmatch(digest):
+        raise CandidateError("digest must be sha256:<64 lowercase hex characters>")
+    metadata = _load_json(metadata_path.resolve(), "candidate metadata")
+    if metadata.get("image") is not None or metadata.get("imageDigest") is not None:
+        raise CandidateError("candidate metadata has already been finalized")
+    metadata["image"] = image
+    metadata["imageDigest"] = digest
+    metadata["finalizedAt"] = _utc_now()
+    _atomic_json(output_path.resolve(), metadata)
+
+
+def validate(manifest_path: Path) -> dict[str, object]:
+    manifest, axes, baseline, template_path, template = _load_contract(manifest_path)
+    _validate_harness(axes["harness"], "axes.harness")
+    _validate_prompt(axes["prompt"], "axes.prompt")
+    return {
+        "candidateId": manifest["_resolvedId"],
+        "baselineId": baseline["_resolvedId"],
+        "variedAxis": manifest["declaredAxis"],
+        "providerTemplate": str(template_path.relative_to(CANDIDATES_DIR)),
+        "providerPath": template["providerPath"],
+        "modelId": template["primaryModelId"],
+    }
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    validate_parser = subparsers.add_parser("validate")
+    validate_parser.add_argument("--manifest", required=True, type=Path)
+    prepare_parser = subparsers.add_parser("prepare")
+    prepare_parser.add_argument("--manifest", required=True, type=Path)
+    prepare_parser.add_argument("--output-dir", required=True, type=Path)
+    prepare_parser.add_argument("--source-commit", required=True)
+    finalize_parser = subparsers.add_parser("finalize")
+    finalize_parser.add_argument("--metadata", required=True, type=Path)
+    finalize_parser.add_argument("--out", required=True, type=Path)
+    finalize_parser.add_argument("--image", required=True)
+    finalize_parser.add_argument("--digest", required=True)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    try:
+        if args.command == "validate":
+            result = validate(args.manifest)
+            print(json.dumps(result, sort_keys=True))
+        elif args.command == "prepare":
+            result = prepare(args.manifest, args.output_dir, args.source_commit)
+            print(json.dumps(result, sort_keys=True))
+        else:
+            finalize(
+                args.metadata,
+                args.out,
+                args.image,
+                args.digest,
+            )
+            print(args.out)
+        return 0
+    except (CandidateError, OSError, ValueError) as error:
+        print(f"ERROR: {error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/infra/agent-image/eval/candidates/candidate.py
+++ b/infra/agent-image/eval/candidates/candidate.py
@@ -35,21 +35,28 @@ CANONICAL_CONFIG = AGENT_IMAGE_DIR / "openclaw.json"
 CANONICAL_DOCKERFILE = AGENT_IMAGE_DIR / "Dockerfile"
 AXES = ("model", "harness", "prompt")
 UNCHANGED_BOOTSTRAP_FILES = ("IDENTITY.md", "USER.md", "MEMORY.md")
-PROVIDER_PATH_CONTRACTS: Mapping[str, tuple[str, str, str]] = {
+PROVIDER_PATH_CONTRACTS: Mapping[
+    str, tuple[str, str, re.Pattern[str], str]
+] = {
     "native-bedrock-sigv4": (
         "bedrock-converse-stream",
         "aws-sdk",
-        "https://bedrock-runtime.",
+        re.compile(
+            r"bedrock-runtime\.[a-z0-9-]+\.amazonaws\.com(?:\.cn)?"
+        ),
+        "",
     ),
     "mantle-openai-compatible": (
         "openai-completions",
         "api-key",
-        "https://bedrock-mantle.",
+        re.compile(r"bedrock-mantle\.[a-z0-9-]+\.api\.aws"),
+        "/v1",
     ),
     "mantle-anthropic-messages": (
         "anthropic-messages",
         "api-key",
-        "https://bedrock-mantle.",
+        re.compile(r"bedrock-mantle\.[a-z0-9-]+\.api\.aws"),
+        "/anthropic",
     ),
 }
 REQUIRED_SOURCE_FIELDS = ("api", "auth", "baseUrl", "iam", "model", "pricing")
@@ -195,7 +202,7 @@ def _provider_template(
     provider = _mapping(
         template.get("provider"), f"{template_path}: provider"
     )
-    expected_api, expected_auth, base_prefix = contract
+    expected_api, expected_auth, hostname_pattern, expected_path = contract
     if provider.get("api") != expected_api:
         raise CandidateError(
             f"{template_path}: {provider_path} requires api={expected_api!r}"
@@ -205,18 +212,28 @@ def _provider_template(
             f"{template_path}: {provider_path} requires auth={expected_auth!r}"
         )
     base_url = _string(provider.get("baseUrl"), f"{template_path}: baseUrl")
-    if not base_url.startswith(base_prefix):
+    parsed_base_url = urlparse(base_url)
+    try:
+        port = parsed_base_url.port
+    except ValueError as error:
         raise CandidateError(
-            f"{template_path}: {provider_path} requires an AWS {base_prefix} baseUrl"
-        )
-    if provider_path == "mantle-openai-compatible" and not base_url.endswith("/v1"):
-        raise CandidateError(f"{template_path}: Mantle OpenAI baseUrl must end in /v1")
+            f"{template_path}: {provider_path} baseUrl has an invalid port"
+        ) from error
     if (
-        provider_path == "mantle-anthropic-messages"
-        and not base_url.endswith("/anthropic")
+        parsed_base_url.scheme != "https"
+        or parsed_base_url.hostname is None
+        or not hostname_pattern.fullmatch(parsed_base_url.hostname)
+        or parsed_base_url.username is not None
+        or parsed_base_url.password is not None
+        or port is not None
+        or parsed_base_url.path != expected_path
+        or parsed_base_url.params
+        or parsed_base_url.query
+        or parsed_base_url.fragment
     ):
         raise CandidateError(
-            f"{template_path}: Mantle Anthropic baseUrl must end in /anthropic"
+            f"{template_path}: {provider_path} requires an exact AWS endpoint "
+            "hostname and path without credentials, port, query, or fragment"
         )
     if provider_path.startswith("mantle-") and provider.get("apiKey") != (
         "env:AWS_BEARER_TOKEN_BEDROCK"
@@ -363,6 +380,15 @@ def _load_contract(
             f"{manifest_path}: declaredAxis={declared_axis!r}, but changed axes "
             f"are {rendered}; candidates must vary exactly one axis"
         )
+    if declared_axis == "prompt" and _materialized_prompt_bytes(
+        axes["prompt"], f"{manifest_path}: axes.prompt"
+    ) == _materialized_prompt_bytes(
+        baseline_axes["prompt"], f"{baseline_path}: axes.prompt"
+    ):
+        raise CandidateError(
+            f"{manifest_path}: prompt candidates must change materialized "
+            "SOUL or rules bytes"
+        )
     template, template_path = _provider_template(axes, manifest_path)
 
     # The baseline itself is executable documentation: it must continue to
@@ -439,6 +465,27 @@ def _validate_prompt(axis: object, label: str) -> tuple[str, Path, Path]:
     soul = _safe_relative_file(prompt.get("soul"), f"{label}.soul")
     rules = _safe_relative_file(prompt.get("rules"), f"{label}.rules")
     return variant, soul, rules
+
+
+def _materialized_prompt_bytes(
+    axis: object, label: str
+) -> tuple[bytes, bytes]:
+    """Return the prompt bytes that survive the Dockerfile materialization."""
+    _, soul, rules = _validate_prompt(axis, label)
+    frontmatter_delimiters = 0
+    rules_body: list[str] = []
+    for line in rules.read_text(encoding="utf-8").splitlines():
+        if re.fullmatch(r"---\s*", line):
+            frontmatter_delimiters += 1
+            continue
+        if frontmatter_delimiters >= 2:
+            rules_body.append(line)
+    rendered_rules = (
+        ("\n".join(rules_body) + "\n").encode("utf-8")
+        if rules_body
+        else b""
+    )
+    return soul.read_bytes(), rendered_rules
 
 
 def _validate_baseline_harness_and_prompt(

--- a/infra/agent-image/eval/candidates/candidate.py
+++ b/infra/agent-image/eval/candidates/candidate.py
@@ -488,8 +488,8 @@ def _render_pin_contract(
             f"ARG BEDROCK_PLUGIN_VERSION={plugin_version}",
         ),
         (
-            r"^ARG BEDROCK_PLUGIN_EXPECTED_TOKEN=.*$",
-            f"ARG BEDROCK_PLUGIN_EXPECTED_TOKEN={expected_token}",
+            r"^ARG BEDROCK_PLUGIN_ASSERTION=.*$",
+            f"ARG BEDROCK_PLUGIN_ASSERTION={expected_token}",
         ),
     )
     for pattern, replacement in replacements:

--- a/infra/agent-image/eval/candidates/candidate.py
+++ b/infra/agent-image/eval/candidates/candidate.py
@@ -298,6 +298,13 @@ def _provider_template(
         or any(not isinstance(item, str) or not item for item in resources)
     ):
         raise CandidateError(f"{template_path}: iam actions/resources must be lists")
+    if provider_path.startswith("mantle-") and (
+        "bedrock:CallWithBearerToken" not in actions or "*" not in resources
+    ):
+        raise CandidateError(
+            f"{template_path}: Mantle IAM must include "
+            "bedrock:CallWithBearerToken on Resource '*'"
+        )
     inference_profile = iam.get("inferenceProfileId")
     member_models = iam.get("crossRegionFoundationModelArns")
     if inference_profile is not None and (
@@ -368,6 +375,7 @@ def _load_contract(
             f"{baseline_path}: composed baseline no longer matches "
             f"{CANONICAL_CONFIG}"
         )
+    _validate_baseline_harness_and_prompt(baseline_axes, baseline_path)
     manifest["_resolvedId"] = candidate_id
     baseline["_resolvedId"] = baseline_id
     return manifest, axes, baseline, template_path, template
@@ -431,6 +439,46 @@ def _validate_prompt(axis: object, label: str) -> tuple[str, Path, Path]:
     soul = _safe_relative_file(prompt.get("soul"), f"{label}.soul")
     rules = _safe_relative_file(prompt.get("rules"), f"{label}.rules")
     return variant, soul, rules
+
+
+def _validate_baseline_harness_and_prompt(
+    axes: dict[str, object],
+    baseline_path: Path,
+) -> None:
+    """Prove the non-model baseline axes still match production defaults."""
+    harness = _validate_harness(
+        axes["harness"], f"{baseline_path}: axes.harness"
+    )
+    dockerfile = CANONICAL_DOCKERFILE.read_text(encoding="utf-8")
+    if _render_pin_contract(*harness) != dockerfile:
+        raise CandidateError(
+            f"{baseline_path}: baseline harness no longer matches the "
+            f"production defaults in {CANONICAL_DOCKERFILE}"
+        )
+
+    variant, soul_path, rules_path = _validate_prompt(
+        axes["prompt"], f"{baseline_path}: axes.prompt"
+    )
+    soul_relative = soul_path.relative_to(AGENT_IMAGE_DIR).as_posix()
+    rules_relative = rules_path.relative_to(AGENT_IMAGE_DIR).as_posix()
+    prompt_defaults_match = (
+        variant == "default"
+        and re.search(
+            rf"^ARG SOUL_PREAMBLE={re.escape(soul_relative)}\s*$",
+            dockerfile,
+            re.MULTILINE,
+        )
+        and re.search(
+            rf"^ARG PSD_RULES_SKILL={re.escape(rules_relative)}\s*$",
+            dockerfile,
+            re.MULTILINE,
+        )
+    )
+    if not prompt_defaults_match:
+        raise CandidateError(
+            f"{baseline_path}: baseline prompt no longer matches the "
+            f"production defaults in {CANONICAL_DOCKERFILE}"
+        )
 
 
 def _atomic_json(path: Path, value: object) -> None:

--- a/infra/agent-image/eval/candidates/candidate.py
+++ b/infra/agent-image/eval/candidates/candidate.py
@@ -316,11 +316,12 @@ def _provider_template(
     ):
         raise CandidateError(f"{template_path}: iam actions/resources must be lists")
     if provider_path.startswith("mantle-") and (
-        "bedrock:CallWithBearerToken" not in actions or "*" not in resources
+        "bedrock-mantle:CallWithBearerToken" not in actions
+        or "*" not in resources
     ):
         raise CandidateError(
             f"{template_path}: Mantle IAM must include "
-            "bedrock:CallWithBearerToken on Resource '*'"
+            "bedrock-mantle:CallWithBearerToken on Resource '*'"
         )
     inference_profile = iam.get("inferenceProfileId")
     member_models = iam.get("crossRegionFoundationModelArns")

--- a/infra/agent-image/eval/candidates/manifests/baseline.json
+++ b/infra/agent-image/eval/candidates/manifests/baseline.json
@@ -1,0 +1,22 @@
+{
+  "schemaVersion": 1,
+  "id": "baseline-sonnet-5-native",
+  "baseline": null,
+  "declaredAxis": "baseline",
+  "axes": {
+    "model": {
+      "providerTemplate": "../providers/native-bedrock-sonnet-5.json"
+    },
+    "harness": {
+      "baseImage": "ghcr.io/openclaw/openclaw@sha256:6a31d44b2944e7adcd2b582bf6fb463111264ebca97a0201795b799135bd102c",
+      "hostVersion": "2026.7.1",
+      "bedrockPluginVersion": "2026.7.1",
+      "expectedPluginToken": "claude-sonnet-5"
+    },
+    "prompt": {
+      "variant": "default",
+      "soul": "SOUL.md",
+      "rules": "skills/psd-rules/SKILL.md"
+    }
+  }
+}

--- a/infra/agent-image/eval/candidates/manifests/glm-5-mantle-openai.json
+++ b/infra/agent-image/eval/candidates/manifests/glm-5-mantle-openai.json
@@ -1,0 +1,22 @@
+{
+  "schemaVersion": 1,
+  "id": "glm-5-mantle-openai",
+  "baseline": "baseline.json",
+  "declaredAxis": "model",
+  "axes": {
+    "model": {
+      "providerTemplate": "../providers/mantle-openai-glm-5.json"
+    },
+    "harness": {
+      "baseImage": "ghcr.io/openclaw/openclaw@sha256:6a31d44b2944e7adcd2b582bf6fb463111264ebca97a0201795b799135bd102c",
+      "hostVersion": "2026.7.1",
+      "bedrockPluginVersion": "2026.7.1",
+      "expectedPluginToken": "claude-sonnet-5"
+    },
+    "prompt": {
+      "variant": "default",
+      "soul": "SOUL.md",
+      "rules": "skills/psd-rules/SKILL.md"
+    }
+  }
+}

--- a/infra/agent-image/eval/candidates/manifests/glm-5-native.json
+++ b/infra/agent-image/eval/candidates/manifests/glm-5-native.json
@@ -1,0 +1,22 @@
+{
+  "schemaVersion": 1,
+  "id": "glm-5-native",
+  "baseline": "baseline.json",
+  "declaredAxis": "model",
+  "axes": {
+    "model": {
+      "providerTemplate": "../providers/native-bedrock-glm-5.json"
+    },
+    "harness": {
+      "baseImage": "ghcr.io/openclaw/openclaw@sha256:6a31d44b2944e7adcd2b582bf6fb463111264ebca97a0201795b799135bd102c",
+      "hostVersion": "2026.7.1",
+      "bedrockPluginVersion": "2026.7.1",
+      "expectedPluginToken": "claude-sonnet-5"
+    },
+    "prompt": {
+      "variant": "default",
+      "soul": "SOUL.md",
+      "rules": "skills/psd-rules/SKILL.md"
+    }
+  }
+}

--- a/infra/agent-image/eval/candidates/manifests/kimi-k2-5.json
+++ b/infra/agent-image/eval/candidates/manifests/kimi-k2-5.json
@@ -1,0 +1,22 @@
+{
+  "schemaVersion": 1,
+  "id": "kimi-k2-5",
+  "baseline": "baseline.json",
+  "declaredAxis": "model",
+  "axes": {
+    "model": {
+      "providerTemplate": "../providers/mantle-openai-kimi-k2-5.json"
+    },
+    "harness": {
+      "baseImage": "ghcr.io/openclaw/openclaw@sha256:6a31d44b2944e7adcd2b582bf6fb463111264ebca97a0201795b799135bd102c",
+      "hostVersion": "2026.7.1",
+      "bedrockPluginVersion": "2026.7.1",
+      "expectedPluginToken": "claude-sonnet-5"
+    },
+    "prompt": {
+      "variant": "default",
+      "soul": "SOUL.md",
+      "rules": "skills/psd-rules/SKILL.md"
+    }
+  }
+}

--- a/infra/agent-image/eval/candidates/manifests/openai-gpt-oss-120b.json
+++ b/infra/agent-image/eval/candidates/manifests/openai-gpt-oss-120b.json
@@ -1,0 +1,22 @@
+{
+  "schemaVersion": 1,
+  "id": "openai-gpt-oss-120b",
+  "baseline": "baseline.json",
+  "declaredAxis": "model",
+  "axes": {
+    "model": {
+      "providerTemplate": "../providers/mantle-openai-gpt-oss-120b.json"
+    },
+    "harness": {
+      "baseImage": "ghcr.io/openclaw/openclaw@sha256:6a31d44b2944e7adcd2b582bf6fb463111264ebca97a0201795b799135bd102c",
+      "hostVersion": "2026.7.1",
+      "bedrockPluginVersion": "2026.7.1",
+      "expectedPluginToken": "claude-sonnet-5"
+    },
+    "prompt": {
+      "variant": "default",
+      "soul": "SOUL.md",
+      "rules": "skills/psd-rules/SKILL.md"
+    }
+  }
+}

--- a/infra/agent-image/eval/candidates/manifests/qwen3-coder-next.json
+++ b/infra/agent-image/eval/candidates/manifests/qwen3-coder-next.json
@@ -1,0 +1,22 @@
+{
+  "schemaVersion": 1,
+  "id": "qwen3-coder-next",
+  "baseline": "baseline.json",
+  "declaredAxis": "model",
+  "axes": {
+    "model": {
+      "providerTemplate": "../providers/mantle-openai-qwen3-coder-next.json"
+    },
+    "harness": {
+      "baseImage": "ghcr.io/openclaw/openclaw@sha256:6a31d44b2944e7adcd2b582bf6fb463111264ebca97a0201795b799135bd102c",
+      "hostVersion": "2026.7.1",
+      "bedrockPluginVersion": "2026.7.1",
+      "expectedPluginToken": "claude-sonnet-5"
+    },
+    "prompt": {
+      "variant": "default",
+      "soul": "SOUL.md",
+      "rules": "skills/psd-rules/SKILL.md"
+    }
+  }
+}

--- a/infra/agent-image/eval/candidates/manifests/sonnet-5-mantle-anthropic.json
+++ b/infra/agent-image/eval/candidates/manifests/sonnet-5-mantle-anthropic.json
@@ -1,0 +1,22 @@
+{
+  "schemaVersion": 1,
+  "id": "sonnet-5-mantle-anthropic",
+  "baseline": "baseline.json",
+  "declaredAxis": "model",
+  "axes": {
+    "model": {
+      "providerTemplate": "../providers/mantle-anthropic-sonnet-5.json"
+    },
+    "harness": {
+      "baseImage": "ghcr.io/openclaw/openclaw@sha256:6a31d44b2944e7adcd2b582bf6fb463111264ebca97a0201795b799135bd102c",
+      "hostVersion": "2026.7.1",
+      "bedrockPluginVersion": "2026.7.1",
+      "expectedPluginToken": "claude-sonnet-5"
+    },
+    "prompt": {
+      "variant": "default",
+      "soul": "SOUL.md",
+      "rules": "skills/psd-rules/SKILL.md"
+    }
+  }
+}

--- a/infra/agent-image/eval/candidates/providers/mantle-anthropic-sonnet-5.json
+++ b/infra/agent-image/eval/candidates/providers/mantle-anthropic-sonnet-5.json
@@ -40,13 +40,13 @@
     "api": "https://docs.aws.amazon.com/bedrock/latest/userguide/inference-messages-api.html",
     "auth": "https://docs.aws.amazon.com/bedrock/latest/userguide/api-keys-use.html",
     "baseUrl": "https://docs.aws.amazon.com/bedrock/latest/userguide/endpoints.html",
-    "iam": "https://docs.aws.amazon.com/bedrock/latest/userguide/security-iam-projects.html",
+    "iam": "https://docs.aws.amazon.com/bedrock/latest/userguide/api-keys-permissions.html",
     "model": "https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-sonnet-5.html",
     "pricing": "https://aws.amazon.com/bedrock/pricing/"
   },
   "iam": {
     "authMechanism": "Bedrock API key loaded from Secrets Manager and sent as x-api-key",
-    "actions": ["bedrock:CallWithBearerToken"],
+    "actions": ["bedrock-mantle:CallWithBearerToken"],
     "resources": ["*"],
     "inferenceProfileId": "us.anthropic.claude-sonnet-5",
     "crossRegionFoundationModelArns": [
@@ -54,6 +54,6 @@
       "arn:aws:bedrock:us-east-2::foundation-model/anthropic.claude-sonnet-5*",
       "arn:aws:bedrock:us-west-2::foundation-model/anthropic.claude-sonnet-5*"
     ],
-    "note": "The bearer-token call itself requires Resource '*'. The listed profile destinations document the equivalent SigV4 grant and the regions that organization SCPs must not deny."
+    "note": "bedrock-mantle:CallWithBearerToken requires Resource '*'. The listed profile destinations document the equivalent SigV4 grant and the regions that organization SCPs must not deny."
   }
 }

--- a/infra/agent-image/eval/candidates/providers/mantle-anthropic-sonnet-5.json
+++ b/infra/agent-image/eval/candidates/providers/mantle-anthropic-sonnet-5.json
@@ -1,0 +1,59 @@
+{
+  "schemaVersion": 1,
+  "verifiedAt": "2026-07-29",
+  "id": "mantle-anthropic-sonnet-5",
+  "providerPath": "mantle-anthropic-messages",
+  "providerName": "amazon-bedrock-mantle-anthropic",
+  "primaryModelId": "us.anthropic.claude-sonnet-5",
+  "cacheRetention": "long",
+  "contextTokens": 180000,
+  "provider": {
+    "baseUrl": "https://bedrock-mantle.us-east-1.api.aws/anthropic",
+    "api": "anthropic-messages",
+    "auth": "api-key",
+    "apiKey": "env:AWS_BEARER_TOKEN_BEDROCK",
+    "timeoutSeconds": 300,
+    "models": [
+      {
+        "id": "us.anthropic.claude-sonnet-5",
+        "name": "Claude Sonnet 5 (Bedrock Mantle Anthropic Messages)",
+        "reasoning": false,
+        "input": ["text"],
+        "contextWindow": 200000,
+        "maxTokens": 32768,
+        "cost": {
+          "input": 3,
+          "output": 15,
+          "cacheRead": 0.3,
+          "cacheWrite": 6
+        }
+      }
+    ]
+  },
+  "costSources": {
+    "input": "https://aws.amazon.com/bedrock/pricing/",
+    "output": "https://aws.amazon.com/bedrock/pricing/",
+    "cacheRead": "https://aws.amazon.com/bedrock/pricing/",
+    "cacheWrite": "https://aws.amazon.com/bedrock/pricing/"
+  },
+  "sources": {
+    "api": "https://docs.aws.amazon.com/bedrock/latest/userguide/inference-messages-api.html",
+    "auth": "https://docs.aws.amazon.com/bedrock/latest/userguide/api-keys-use.html",
+    "baseUrl": "https://docs.aws.amazon.com/bedrock/latest/userguide/endpoints.html",
+    "iam": "https://docs.aws.amazon.com/bedrock/latest/userguide/security-iam-projects.html",
+    "model": "https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-sonnet-5.html",
+    "pricing": "https://aws.amazon.com/bedrock/pricing/"
+  },
+  "iam": {
+    "authMechanism": "Bedrock API key loaded from Secrets Manager and sent as x-api-key",
+    "actions": ["bedrock-mantle:CallWithBearerToken"],
+    "resources": ["*"],
+    "inferenceProfileId": "us.anthropic.claude-sonnet-5",
+    "crossRegionFoundationModelArns": [
+      "arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-sonnet-5*",
+      "arn:aws:bedrock:us-east-2::foundation-model/anthropic.claude-sonnet-5*",
+      "arn:aws:bedrock:us-west-2::foundation-model/anthropic.claude-sonnet-5*"
+    ],
+    "note": "The bearer-token call itself requires Resource '*'. The listed profile destinations document the equivalent SigV4 grant and the regions that organization SCPs must not deny."
+  }
+}

--- a/infra/agent-image/eval/candidates/providers/mantle-anthropic-sonnet-5.json
+++ b/infra/agent-image/eval/candidates/providers/mantle-anthropic-sonnet-5.json
@@ -46,7 +46,7 @@
   },
   "iam": {
     "authMechanism": "Bedrock API key loaded from Secrets Manager and sent as x-api-key",
-    "actions": ["bedrock-mantle:CallWithBearerToken"],
+    "actions": ["bedrock:CallWithBearerToken"],
     "resources": ["*"],
     "inferenceProfileId": "us.anthropic.claude-sonnet-5",
     "crossRegionFoundationModelArns": [

--- a/infra/agent-image/eval/candidates/providers/mantle-openai-glm-5.json
+++ b/infra/agent-image/eval/candidates/providers/mantle-openai-glm-5.json
@@ -1,0 +1,55 @@
+{
+  "schemaVersion": 1,
+  "verifiedAt": "2026-07-29",
+  "id": "mantle-openai-glm-5",
+  "providerPath": "mantle-openai-compatible",
+  "providerName": "amazon-bedrock-mantle-openai",
+  "primaryModelId": "zai.glm-5",
+  "cacheRetention": "none",
+  "contextTokens": 180000,
+  "provider": {
+    "baseUrl": "https://bedrock-mantle.us-east-1.api.aws/v1",
+    "api": "openai-completions",
+    "auth": "api-key",
+    "apiKey": "env:AWS_BEARER_TOKEN_BEDROCK",
+    "timeoutSeconds": 300,
+    "models": [
+      {
+        "id": "zai.glm-5",
+        "name": "GLM-5 (Bedrock Mantle OpenAI-compatible)",
+        "reasoning": false,
+        "input": ["text"],
+        "contextWindow": 200000,
+        "maxTokens": 131072,
+        "cost": {
+          "input": 1,
+          "output": 3.2,
+          "cacheRead": 0,
+          "cacheWrite": 0
+        }
+      }
+    ]
+  },
+  "costSources": {
+    "input": "https://aws.amazon.com/bedrock/pricing/",
+    "output": "https://aws.amazon.com/bedrock/pricing/",
+    "cacheRead": "https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-zai-glm-5.html",
+    "cacheWrite": "https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-zai-glm-5.html"
+  },
+  "sources": {
+    "api": "https://docs.aws.amazon.com/bedrock/latest/userguide/bedrock-mantle.html",
+    "auth": "https://docs.aws.amazon.com/bedrock/latest/userguide/api-keys-use.html",
+    "baseUrl": "https://docs.aws.amazon.com/bedrock/latest/userguide/endpoints.html",
+    "iam": "https://docs.aws.amazon.com/bedrock/latest/userguide/security-iam-projects.html",
+    "model": "https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-zai-glm-5.html",
+    "pricing": "https://aws.amazon.com/bedrock/pricing/"
+  },
+  "iam": {
+    "authMechanism": "Bedrock API key loaded from Secrets Manager and sent as a Bearer token",
+    "actions": ["bedrock-mantle:CallWithBearerToken"],
+    "resources": ["*"],
+    "inferenceProfileId": null,
+    "crossRegionFoundationModelArns": [],
+    "note": "CallWithBearerToken requires Resource '*'. The secret reader additionally needs secretsmanager:GetSecretValue on the environment's Bedrock API-key secret."
+  }
+}

--- a/infra/agent-image/eval/candidates/providers/mantle-openai-glm-5.json
+++ b/infra/agent-image/eval/candidates/providers/mantle-openai-glm-5.json
@@ -46,7 +46,7 @@
   },
   "iam": {
     "authMechanism": "Bedrock API key loaded from Secrets Manager and sent as a Bearer token",
-    "actions": ["bedrock-mantle:CallWithBearerToken"],
+    "actions": ["bedrock:CallWithBearerToken"],
     "resources": ["*"],
     "inferenceProfileId": null,
     "crossRegionFoundationModelArns": [],

--- a/infra/agent-image/eval/candidates/providers/mantle-openai-glm-5.json
+++ b/infra/agent-image/eval/candidates/providers/mantle-openai-glm-5.json
@@ -40,16 +40,16 @@
     "api": "https://docs.aws.amazon.com/bedrock/latest/userguide/bedrock-mantle.html",
     "auth": "https://docs.aws.amazon.com/bedrock/latest/userguide/api-keys-use.html",
     "baseUrl": "https://docs.aws.amazon.com/bedrock/latest/userguide/endpoints.html",
-    "iam": "https://docs.aws.amazon.com/bedrock/latest/userguide/security-iam-projects.html",
+    "iam": "https://docs.aws.amazon.com/bedrock/latest/userguide/api-keys-permissions.html",
     "model": "https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-zai-glm-5.html",
     "pricing": "https://aws.amazon.com/bedrock/pricing/"
   },
   "iam": {
     "authMechanism": "Bedrock API key loaded from Secrets Manager and sent as a Bearer token",
-    "actions": ["bedrock:CallWithBearerToken"],
+    "actions": ["bedrock-mantle:CallWithBearerToken"],
     "resources": ["*"],
     "inferenceProfileId": null,
     "crossRegionFoundationModelArns": [],
-    "note": "CallWithBearerToken requires Resource '*'. The secret reader additionally needs secretsmanager:GetSecretValue on the environment's Bedrock API-key secret."
+    "note": "bedrock-mantle:CallWithBearerToken requires Resource '*'. The secret reader additionally needs secretsmanager:GetSecretValue on the environment's Bedrock API-key secret."
   }
 }

--- a/infra/agent-image/eval/candidates/providers/mantle-openai-gpt-oss-120b.json
+++ b/infra/agent-image/eval/candidates/providers/mantle-openai-gpt-oss-120b.json
@@ -1,0 +1,55 @@
+{
+  "schemaVersion": 1,
+  "verifiedAt": "2026-07-29",
+  "id": "mantle-openai-gpt-oss-120b",
+  "providerPath": "mantle-openai-compatible",
+  "providerName": "amazon-bedrock-mantle-openai",
+  "primaryModelId": "openai.gpt-oss-120b",
+  "cacheRetention": "none",
+  "contextTokens": 110000,
+  "provider": {
+    "baseUrl": "https://bedrock-mantle.us-east-1.api.aws/v1",
+    "api": "openai-completions",
+    "auth": "api-key",
+    "apiKey": "env:AWS_BEARER_TOKEN_BEDROCK",
+    "timeoutSeconds": 300,
+    "models": [
+      {
+        "id": "openai.gpt-oss-120b",
+        "name": "OpenAI GPT OSS 120B (Bedrock Mantle)",
+        "reasoning": false,
+        "input": ["text"],
+        "contextWindow": 128000,
+        "maxTokens": 16384,
+        "cost": {
+          "input": 0.15,
+          "output": 0.6,
+          "cacheRead": 0,
+          "cacheWrite": 0
+        }
+      }
+    ]
+  },
+  "costSources": {
+    "input": "https://aws.amazon.com/bedrock/pricing/",
+    "output": "https://aws.amazon.com/bedrock/pricing/",
+    "cacheRead": "https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-openai-gpt-oss-120b.html",
+    "cacheWrite": "https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-openai-gpt-oss-120b.html"
+  },
+  "sources": {
+    "api": "https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-openai-gpt-oss-120b.html",
+    "auth": "https://docs.aws.amazon.com/bedrock/latest/userguide/api-keys-use.html",
+    "baseUrl": "https://docs.aws.amazon.com/bedrock/latest/userguide/endpoints.html",
+    "iam": "https://docs.aws.amazon.com/bedrock/latest/userguide/security-iam-projects.html",
+    "model": "https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-openai-gpt-oss-120b.html",
+    "pricing": "https://aws.amazon.com/bedrock/pricing/"
+  },
+  "iam": {
+    "authMechanism": "Bedrock API key loaded from Secrets Manager and sent as a Bearer token",
+    "actions": ["bedrock-mantle:CallWithBearerToken"],
+    "resources": ["*"],
+    "inferenceProfileId": null,
+    "crossRegionFoundationModelArns": [],
+    "note": "CallWithBearerToken requires Resource '*'. The secret reader additionally needs secretsmanager:GetSecretValue on the environment's Bedrock API-key secret."
+  }
+}

--- a/infra/agent-image/eval/candidates/providers/mantle-openai-gpt-oss-120b.json
+++ b/infra/agent-image/eval/candidates/providers/mantle-openai-gpt-oss-120b.json
@@ -46,7 +46,7 @@
   },
   "iam": {
     "authMechanism": "Bedrock API key loaded from Secrets Manager and sent as a Bearer token",
-    "actions": ["bedrock-mantle:CallWithBearerToken"],
+    "actions": ["bedrock:CallWithBearerToken"],
     "resources": ["*"],
     "inferenceProfileId": null,
     "crossRegionFoundationModelArns": [],

--- a/infra/agent-image/eval/candidates/providers/mantle-openai-gpt-oss-120b.json
+++ b/infra/agent-image/eval/candidates/providers/mantle-openai-gpt-oss-120b.json
@@ -40,16 +40,16 @@
     "api": "https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-openai-gpt-oss-120b.html",
     "auth": "https://docs.aws.amazon.com/bedrock/latest/userguide/api-keys-use.html",
     "baseUrl": "https://docs.aws.amazon.com/bedrock/latest/userguide/endpoints.html",
-    "iam": "https://docs.aws.amazon.com/bedrock/latest/userguide/security-iam-projects.html",
+    "iam": "https://docs.aws.amazon.com/bedrock/latest/userguide/api-keys-permissions.html",
     "model": "https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-openai-gpt-oss-120b.html",
     "pricing": "https://aws.amazon.com/bedrock/pricing/"
   },
   "iam": {
     "authMechanism": "Bedrock API key loaded from Secrets Manager and sent as a Bearer token",
-    "actions": ["bedrock:CallWithBearerToken"],
+    "actions": ["bedrock-mantle:CallWithBearerToken"],
     "resources": ["*"],
     "inferenceProfileId": null,
     "crossRegionFoundationModelArns": [],
-    "note": "CallWithBearerToken requires Resource '*'. The secret reader additionally needs secretsmanager:GetSecretValue on the environment's Bedrock API-key secret."
+    "note": "bedrock-mantle:CallWithBearerToken requires Resource '*'. The secret reader additionally needs secretsmanager:GetSecretValue on the environment's Bedrock API-key secret."
   }
 }

--- a/infra/agent-image/eval/candidates/providers/mantle-openai-kimi-k2-5.json
+++ b/infra/agent-image/eval/candidates/providers/mantle-openai-kimi-k2-5.json
@@ -40,16 +40,16 @@
     "api": "https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-moonshot-ai-kimi-k2-5.html",
     "auth": "https://docs.aws.amazon.com/bedrock/latest/userguide/api-keys-use.html",
     "baseUrl": "https://docs.aws.amazon.com/bedrock/latest/userguide/endpoints.html",
-    "iam": "https://docs.aws.amazon.com/bedrock/latest/userguide/security-iam-projects.html",
+    "iam": "https://docs.aws.amazon.com/bedrock/latest/userguide/api-keys-permissions.html",
     "model": "https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-moonshot-ai-kimi-k2-5.html",
     "pricing": "https://aws.amazon.com/bedrock/pricing/"
   },
   "iam": {
     "authMechanism": "Bedrock API key loaded from Secrets Manager and sent as a Bearer token",
-    "actions": ["bedrock:CallWithBearerToken"],
+    "actions": ["bedrock-mantle:CallWithBearerToken"],
     "resources": ["*"],
     "inferenceProfileId": null,
     "crossRegionFoundationModelArns": [],
-    "note": "CallWithBearerToken requires Resource '*'. Kimi K2.5 uses its regional model ID and no cross-region inference profile."
+    "note": "bedrock-mantle:CallWithBearerToken requires Resource '*'. Kimi K2.5 uses its regional model ID and no cross-region inference profile."
   }
 }

--- a/infra/agent-image/eval/candidates/providers/mantle-openai-kimi-k2-5.json
+++ b/infra/agent-image/eval/candidates/providers/mantle-openai-kimi-k2-5.json
@@ -46,7 +46,7 @@
   },
   "iam": {
     "authMechanism": "Bedrock API key loaded from Secrets Manager and sent as a Bearer token",
-    "actions": ["bedrock-mantle:CallWithBearerToken"],
+    "actions": ["bedrock:CallWithBearerToken"],
     "resources": ["*"],
     "inferenceProfileId": null,
     "crossRegionFoundationModelArns": [],

--- a/infra/agent-image/eval/candidates/providers/mantle-openai-kimi-k2-5.json
+++ b/infra/agent-image/eval/candidates/providers/mantle-openai-kimi-k2-5.json
@@ -1,0 +1,55 @@
+{
+  "schemaVersion": 1,
+  "verifiedAt": "2026-07-29",
+  "id": "mantle-openai-kimi-k2-5",
+  "providerPath": "mantle-openai-compatible",
+  "providerName": "amazon-bedrock-mantle-openai",
+  "primaryModelId": "moonshotai.kimi-k2.5",
+  "cacheRetention": "none",
+  "contextTokens": 220000,
+  "provider": {
+    "baseUrl": "https://bedrock-mantle.us-east-1.api.aws/v1",
+    "api": "openai-completions",
+    "auth": "api-key",
+    "apiKey": "env:AWS_BEARER_TOKEN_BEDROCK",
+    "timeoutSeconds": 300,
+    "models": [
+      {
+        "id": "moonshotai.kimi-k2.5",
+        "name": "Kimi K2.5 (Bedrock Mantle)",
+        "reasoning": false,
+        "input": ["text"],
+        "contextWindow": 256000,
+        "maxTokens": 16384,
+        "cost": {
+          "input": 0.6,
+          "output": 3,
+          "cacheRead": 0,
+          "cacheWrite": 0
+        }
+      }
+    ]
+  },
+  "costSources": {
+    "input": "https://aws.amazon.com/bedrock/pricing/",
+    "output": "https://aws.amazon.com/bedrock/pricing/",
+    "cacheRead": "https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-moonshot-ai-kimi-k2-5.html",
+    "cacheWrite": "https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-moonshot-ai-kimi-k2-5.html"
+  },
+  "sources": {
+    "api": "https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-moonshot-ai-kimi-k2-5.html",
+    "auth": "https://docs.aws.amazon.com/bedrock/latest/userguide/api-keys-use.html",
+    "baseUrl": "https://docs.aws.amazon.com/bedrock/latest/userguide/endpoints.html",
+    "iam": "https://docs.aws.amazon.com/bedrock/latest/userguide/security-iam-projects.html",
+    "model": "https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-moonshot-ai-kimi-k2-5.html",
+    "pricing": "https://aws.amazon.com/bedrock/pricing/"
+  },
+  "iam": {
+    "authMechanism": "Bedrock API key loaded from Secrets Manager and sent as a Bearer token",
+    "actions": ["bedrock-mantle:CallWithBearerToken"],
+    "resources": ["*"],
+    "inferenceProfileId": null,
+    "crossRegionFoundationModelArns": [],
+    "note": "CallWithBearerToken requires Resource '*'. Kimi K2.5 uses its regional model ID and no cross-region inference profile."
+  }
+}

--- a/infra/agent-image/eval/candidates/providers/mantle-openai-qwen3-coder-next.json
+++ b/infra/agent-image/eval/candidates/providers/mantle-openai-qwen3-coder-next.json
@@ -40,16 +40,16 @@
     "api": "https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-qwen-qwen3-coder-next.html",
     "auth": "https://docs.aws.amazon.com/bedrock/latest/userguide/api-keys-use.html",
     "baseUrl": "https://docs.aws.amazon.com/bedrock/latest/userguide/endpoints.html",
-    "iam": "https://docs.aws.amazon.com/bedrock/latest/userguide/security-iam-projects.html",
+    "iam": "https://docs.aws.amazon.com/bedrock/latest/userguide/api-keys-permissions.html",
     "model": "https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-qwen-qwen3-coder-next.html",
     "pricing": "https://aws.amazon.com/bedrock/pricing/"
   },
   "iam": {
     "authMechanism": "Bedrock API key loaded from Secrets Manager and sent as a Bearer token",
-    "actions": ["bedrock:CallWithBearerToken"],
+    "actions": ["bedrock-mantle:CallWithBearerToken"],
     "resources": ["*"],
     "inferenceProfileId": null,
     "crossRegionFoundationModelArns": [],
-    "note": "CallWithBearerToken requires Resource '*'. Qwen3 Coder Next uses its regional model ID and no cross-region inference profile."
+    "note": "bedrock-mantle:CallWithBearerToken requires Resource '*'. Qwen3 Coder Next uses its regional model ID and no cross-region inference profile."
   }
 }

--- a/infra/agent-image/eval/candidates/providers/mantle-openai-qwen3-coder-next.json
+++ b/infra/agent-image/eval/candidates/providers/mantle-openai-qwen3-coder-next.json
@@ -46,7 +46,7 @@
   },
   "iam": {
     "authMechanism": "Bedrock API key loaded from Secrets Manager and sent as a Bearer token",
-    "actions": ["bedrock-mantle:CallWithBearerToken"],
+    "actions": ["bedrock:CallWithBearerToken"],
     "resources": ["*"],
     "inferenceProfileId": null,
     "crossRegionFoundationModelArns": [],

--- a/infra/agent-image/eval/candidates/providers/mantle-openai-qwen3-coder-next.json
+++ b/infra/agent-image/eval/candidates/providers/mantle-openai-qwen3-coder-next.json
@@ -1,0 +1,55 @@
+{
+  "schemaVersion": 1,
+  "verifiedAt": "2026-07-29",
+  "id": "mantle-openai-qwen3-coder-next",
+  "providerPath": "mantle-openai-compatible",
+  "providerName": "amazon-bedrock-mantle-openai",
+  "primaryModelId": "qwen.qwen3-coder-next",
+  "cacheRetention": "none",
+  "contextTokens": 220000,
+  "provider": {
+    "baseUrl": "https://bedrock-mantle.us-east-1.api.aws/v1",
+    "api": "openai-completions",
+    "auth": "api-key",
+    "apiKey": "env:AWS_BEARER_TOKEN_BEDROCK",
+    "timeoutSeconds": 300,
+    "models": [
+      {
+        "id": "qwen.qwen3-coder-next",
+        "name": "Qwen3 Coder Next (Bedrock Mantle)",
+        "reasoning": false,
+        "input": ["text"],
+        "contextWindow": 256000,
+        "maxTokens": 16384,
+        "cost": {
+          "input": 0.5,
+          "output": 1.2,
+          "cacheRead": 0,
+          "cacheWrite": 0
+        }
+      }
+    ]
+  },
+  "costSources": {
+    "input": "https://aws.amazon.com/bedrock/pricing/",
+    "output": "https://aws.amazon.com/bedrock/pricing/",
+    "cacheRead": "https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-qwen-qwen3-coder-next.html",
+    "cacheWrite": "https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-qwen-qwen3-coder-next.html"
+  },
+  "sources": {
+    "api": "https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-qwen-qwen3-coder-next.html",
+    "auth": "https://docs.aws.amazon.com/bedrock/latest/userguide/api-keys-use.html",
+    "baseUrl": "https://docs.aws.amazon.com/bedrock/latest/userguide/endpoints.html",
+    "iam": "https://docs.aws.amazon.com/bedrock/latest/userguide/security-iam-projects.html",
+    "model": "https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-qwen-qwen3-coder-next.html",
+    "pricing": "https://aws.amazon.com/bedrock/pricing/"
+  },
+  "iam": {
+    "authMechanism": "Bedrock API key loaded from Secrets Manager and sent as a Bearer token",
+    "actions": ["bedrock-mantle:CallWithBearerToken"],
+    "resources": ["*"],
+    "inferenceProfileId": null,
+    "crossRegionFoundationModelArns": [],
+    "note": "CallWithBearerToken requires Resource '*'. Qwen3 Coder Next uses its regional model ID and no cross-region inference profile."
+  }
+}

--- a/infra/agent-image/eval/candidates/providers/native-bedrock-glm-5.json
+++ b/infra/agent-image/eval/candidates/providers/native-bedrock-glm-5.json
@@ -1,0 +1,56 @@
+{
+  "schemaVersion": 1,
+  "verifiedAt": "2026-07-29",
+  "id": "native-bedrock-glm-5",
+  "providerPath": "native-bedrock-sigv4",
+  "providerName": "amazon-bedrock",
+  "primaryModelId": "zai.glm-5",
+  "cacheRetention": "none",
+  "contextTokens": 180000,
+  "provider": {
+    "baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
+    "api": "bedrock-converse-stream",
+    "auth": "aws-sdk",
+    "timeoutSeconds": 300,
+    "models": [
+      {
+        "id": "zai.glm-5",
+        "name": "GLM-5 (Bedrock, SigV4 via execution role)",
+        "reasoning": false,
+        "input": ["text"],
+        "contextWindow": 200000,
+        "maxTokens": 131072,
+        "cost": {
+          "input": 1,
+          "output": 3.2,
+          "cacheRead": 0,
+          "cacheWrite": 0
+        }
+      }
+    ]
+  },
+  "costSources": {
+    "input": "https://aws.amazon.com/bedrock/pricing/",
+    "output": "https://aws.amazon.com/bedrock/pricing/",
+    "cacheRead": "https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-zai-glm-5.html",
+    "cacheWrite": "https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-zai-glm-5.html"
+  },
+  "sources": {
+    "api": "https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-zai-glm-5.html",
+    "auth": "https://docs.aws.amazon.com/bedrock/latest/userguide/security-iam.html",
+    "baseUrl": "https://docs.aws.amazon.com/bedrock/latest/userguide/endpoints.html",
+    "iam": "https://docs.aws.amazon.com/bedrock/latest/userguide/security-iam-id-based-policy-examples.html",
+    "model": "https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-zai-glm-5.html",
+    "pricing": "https://aws.amazon.com/bedrock/pricing/"
+  },
+  "iam": {
+    "authMechanism": "AWS SigV4 execution-role credentials",
+    "actions": ["bedrock:InvokeModel", "bedrock:InvokeModelWithResponseStream"],
+    "resources": [
+      "arn:aws:bedrock:us-east-1::foundation-model/zai.glm-5"
+    ],
+    "inferenceProfileId": null,
+    "crossRegionFoundationModelArns": [],
+    "note": "GLM-5 is invoked as the regional foundation-model ID in us-east-1; no cross-region profile is used by this template."
+  }
+}

--- a/infra/agent-image/eval/candidates/providers/native-bedrock-sonnet-5.json
+++ b/infra/agent-image/eval/candidates/providers/native-bedrock-sonnet-5.json
@@ -1,0 +1,63 @@
+{
+  "schemaVersion": 1,
+  "verifiedAt": "2026-07-29",
+  "id": "native-bedrock-sonnet-5",
+  "providerPath": "native-bedrock-sigv4",
+  "providerName": "amazon-bedrock",
+  "primaryModelId": "us.anthropic.claude-sonnet-5",
+  "cacheRetention": "long",
+  "contextTokens": 180000,
+  "provider": {
+    "baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
+    "api": "bedrock-converse-stream",
+    "auth": "aws-sdk",
+    "timeoutSeconds": 300,
+    "models": [
+      {
+        "id": "us.anthropic.claude-sonnet-5",
+        "name": "Claude Sonnet 5 (Bedrock, SigV4 via execution role)",
+        "reasoning": false,
+        "input": ["text"],
+        "contextWindow": 200000,
+        "maxTokens": 32768,
+        "cost": {
+          "input": 3,
+          "output": 15,
+          "cacheRead": 0.3,
+          "cacheWrite": 6
+        }
+      }
+    ]
+  },
+  "costSources": {
+    "input": "https://aws.amazon.com/bedrock/pricing/",
+    "output": "https://aws.amazon.com/bedrock/pricing/",
+    "cacheRead": "https://aws.amazon.com/bedrock/pricing/",
+    "cacheWrite": "https://aws.amazon.com/bedrock/pricing/"
+  },
+  "sources": {
+    "api": "https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-sonnet-5.html",
+    "auth": "https://docs.aws.amazon.com/bedrock/latest/userguide/security-iam.html",
+    "baseUrl": "https://docs.aws.amazon.com/bedrock/latest/userguide/endpoints.html",
+    "iam": "https://docs.aws.amazon.com/bedrock/latest/userguide/inference-profiles-prereq.html",
+    "model": "https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-sonnet-5.html",
+    "pricing": "https://aws.amazon.com/bedrock/pricing/"
+  },
+  "iam": {
+    "authMechanism": "AWS SigV4 execution-role credentials",
+    "actions": ["bedrock:InvokeModel", "bedrock:InvokeModelWithResponseStream"],
+    "resources": [
+      "arn:aws:bedrock:*:<account-id>:inference-profile/us.anthropic.claude-sonnet-5*",
+      "arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-sonnet-5*",
+      "arn:aws:bedrock:us-east-2::foundation-model/anthropic.claude-sonnet-5*",
+      "arn:aws:bedrock:us-west-2::foundation-model/anthropic.claude-sonnet-5*"
+    ],
+    "inferenceProfileId": "us.anthropic.claude-sonnet-5",
+    "crossRegionFoundationModelArns": [
+      "arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-sonnet-5*",
+      "arn:aws:bedrock:us-east-2::foundation-model/anthropic.claude-sonnet-5*",
+      "arn:aws:bedrock:us-west-2::foundation-model/anthropic.claude-sonnet-5*"
+    ],
+    "note": "Grant the profile ARN and every destination-region foundation-model ARN; SCPs must also allow every destination region."
+  }
+}

--- a/infra/agent-image/eval/runner.py
+++ b/infra/agent-image/eval/runner.py
@@ -1409,9 +1409,11 @@ def _resolve_candidate_runtime_environment(
             f"candidate metadata {metadata_path} is not finalized"
         )
     repository = metadata_image.rsplit(":", 1)[0]
-    if image not in {metadata_image, f"{repository}@{image_digest}"}:
+    immutable_image = f"{repository}@{image_digest}"
+    if image != immutable_image:
         raise EvalRunnerError(
-            f"--image does not match finalized candidate metadata {metadata_path}"
+            f"--image must be the immutable digest from finalized candidate "
+            f"metadata {metadata_path}: {immutable_image}"
         )
     if provider_path not in MANTLE_CANDIDATE_PROVIDER_PATHS:
         return {}

--- a/infra/agent-image/eval/runner.py
+++ b/infra/agent-image/eval/runner.py
@@ -2,7 +2,7 @@
 """Run a repeated task suite against a local PSD Agent Docker image.
 
 Example:
-    python3 runner.py --image <tag-or-digest> --suite suites/core.yaml \
+    python3 runner.py --image <repository@sha256:digest> --suite suites/core.yaml \
         --trials 3 --out /tmp/issue-1425-run.jsonl \
         --name-prefix psd-agent-eval-issue-1425
 """
@@ -124,6 +124,7 @@ MANTLE_CANDIDATE_PROVIDER_PATHS = frozenset(
         "mantle-anthropic-messages",
     }
 )
+IMMUTABLE_IMAGE_RE = re.compile(r"^[^@\s]+@sha256:[0-9a-f]{64}$")
 
 
 class EvalRunnerError(RuntimeError):
@@ -1380,6 +1381,10 @@ def _resolve_candidate_runtime_environment(
     Mantle candidates receive only the secret ARN and resolve its value inside
     the short-lived container using the already-supplied AWS credentials.
     """
+    if not IMMUTABLE_IMAGE_RE.fullmatch(image):
+        raise EvalRunnerError(
+            "--image must be an immutable repository@sha256:<64 hex> reference"
+        )
     if metadata_path is None:
         return {}
     try:
@@ -1640,7 +1645,11 @@ def _open_output(path: Path, overwrite: bool) -> TextIO:
 
 def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--image", required=True, help="candidate image tag or digest")
+    parser.add_argument(
+        "--image",
+        required=True,
+        help="immutable repository@sha256:digest image reference",
+    )
     parser.add_argument(
         "--candidate-metadata",
         type=Path,

--- a/infra/agent-image/eval/runner.py
+++ b/infra/agent-image/eval/runner.py
@@ -111,6 +111,19 @@ DEPLOYED_RUNTIME_ENVIRONMENT_KEYS = (
     "HYPERFRAMES_RENDER_FUNCTION",
     "SUMMARIZE_MODEL_ID",
 )
+SUPPORTED_CANDIDATE_PROVIDER_PATHS = frozenset(
+    {
+        "native-bedrock-sigv4",
+        "mantle-openai-compatible",
+        "mantle-anthropic-messages",
+    }
+)
+MANTLE_CANDIDATE_PROVIDER_PATHS = frozenset(
+    {
+        "mantle-openai-compatible",
+        "mantle-anthropic-messages",
+    }
+)
 
 
 class EvalRunnerError(RuntimeError):
@@ -1353,6 +1366,86 @@ def _resolve_app_base_url(
     return resolved
 
 
+def _resolve_candidate_runtime_environment(
+    executor: CommandExecutor,
+    metadata_path: Path | None,
+    image: str,
+    environment: str,
+    region: str,
+) -> dict[str, str]:
+    """Resolve only the secret ARN required by a token-auth candidate.
+
+    Finalized candidate metadata is the authority for the provider path and
+    immutable image identity. Native SigV4 candidates remain a strict no-op;
+    Mantle candidates receive only the secret ARN and resolve its value inside
+    the short-lived container using the already-supplied AWS credentials.
+    """
+    if metadata_path is None:
+        return {}
+    try:
+        metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise EvalRunnerError(
+            f"cannot read candidate metadata {metadata_path}: {error}"
+        ) from error
+    if not isinstance(metadata, dict) or metadata.get("schemaVersion") != 1:
+        raise EvalRunnerError(
+            f"candidate metadata {metadata_path} must be a schemaVersion 1 object"
+        )
+    provider_path = metadata.get("providerPath")
+    if provider_path not in SUPPORTED_CANDIDATE_PROVIDER_PATHS:
+        raise EvalRunnerError(
+            f"candidate metadata {metadata_path} has unsupported providerPath"
+        )
+    metadata_image = metadata.get("image")
+    image_digest = metadata.get("imageDigest")
+    if (
+        not isinstance(metadata_image, str)
+        or not metadata_image
+        or not isinstance(image_digest, str)
+        or not re.fullmatch(r"sha256:[0-9a-f]{64}", image_digest)
+    ):
+        raise EvalRunnerError(
+            f"candidate metadata {metadata_path} is not finalized"
+        )
+    repository = metadata_image.rsplit(":", 1)[0]
+    if image not in {metadata_image, f"{repository}@{image_digest}"}:
+        raise EvalRunnerError(
+            f"--image does not match finalized candidate metadata {metadata_path}"
+        )
+    if provider_path not in MANTLE_CANDIDATE_PROVIDER_PATHS:
+        return {}
+    if metadata.get("providerAuth") != "api-key":
+        raise EvalRunnerError(
+            f"Mantle candidate metadata {metadata_path} must use api-key auth"
+        )
+
+    env_capitalized = environment[:1].upper() + environment[1:]
+    stack_name = f"AIStudio-AgentPlatformStack-{env_capitalized}"
+    result = executor.run(
+        [
+            "aws",
+            "cloudformation",
+            "describe-stacks",
+            "--stack-name",
+            stack_name,
+            "--query",
+            "Stacks[0].Outputs[?OutputKey=='BedrockApiKeySecretArn'].OutputValue",
+            "--output",
+            "text",
+            "--region",
+            region,
+        ],
+        timeout=30,
+    )
+    secret_arn = result.stdout.strip()
+    if not secret_arn or secret_arn == "None":
+        raise EvalRunnerError(
+            f"stack {stack_name} has no BedrockApiKeySecretArn output"
+        )
+    return {"BEDROCK_API_KEY_SECRET_ARN": secret_arn}
+
+
 def _resolve_deployed_runtime_environment(
     executor: CommandExecutor,
     runtime_id: str | None,
@@ -1546,6 +1639,14 @@ def _open_output(path: Path, overwrite: bool) -> TextIO:
 def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--image", required=True, help="candidate image tag or digest")
+    parser.add_argument(
+        "--candidate-metadata",
+        type=Path,
+        help=(
+            "finalized .candidate-builds sidecar for --image; required for "
+            "Mantle candidates so the runner can resolve their secret ARN"
+        ),
+    )
     parser.add_argument("--suite", required=True, type=Path)
     parser.add_argument("--trials", type=_trial_count)
     parser.add_argument("--out", required=True, type=Path)
@@ -1600,12 +1701,20 @@ def main(argv: list[str] | None = None) -> int:
             args.agent_runtime_id,
             args.region,
         )
+        candidate_runtime_environment = _resolve_candidate_runtime_environment(
+            executor,
+            args.candidate_metadata.resolve() if args.candidate_metadata else None,
+            args.image,
+            args.environment,
+            args.region,
+        )
         environment_values = {
             "ENVIRONMENT": args.environment,
             "AWS_REGION": args.region,
             "APP_BASE_URL": app_base_url,
             "BUILD_MARKER": f"eval:{args.image}",
             **deployed_runtime_environment,
+            **candidate_runtime_environment,
         }
         credential_provider = ActiveAwsCredentialProvider(executor)
         name_token = _docker_name_token(args.name_prefix, os.getpid())

--- a/infra/agent-image/harness_adapter.py
+++ b/infra/agent-image/harness_adapter.py
@@ -304,6 +304,9 @@ class OpenClawAdapter(HarnessAdapter):
                                 "AGENT_INVOCATION_SIGNING_SECRET_ID",
                                 "PSD_INVOCATION_CONTEXT_FILE",
                                 "PSD_INVOCATION_REQUEST_PROOF_KEY_FILE",
+                                "AWS_BEARER_TOKEN_BEDROCK",
+                                "BEDROCK_API_KEY_SECRET_ARN",
+                                "CANDIDATE_MANTLE_BEARER_TOKEN",
                             }
                         },
                         "HOME": "/home/node",

--- a/infra/agent-image/mantle_proxy.py
+++ b/infra/agent-image/mantle_proxy.py
@@ -213,6 +213,14 @@ def _resolve_candidate_mantle_request(
     return f"{base_url}/{relative_path}"
 
 
+def _candidate_mantle_authority_required(method: str, path: str) -> bool:
+    """Require turn authority for paid candidate inference, not startup discovery."""
+    return (
+        path.startswith(f"{CANDIDATE_MANTLE_PREFIX}/")
+        and method != "GET"
+    )
+
+
 def _read_authority() -> tuple[str, bytes]:
     """Read authority that is inaccessible to the model's node UID."""
     with open(INVOCATION_CONTEXT_PATH, "r", encoding="ascii") as handle:
@@ -745,8 +753,8 @@ async def finalization_gate_middleware(request, handler):
 # per-container = per-microVM = per-session and turns are serial, so no
 # concurrent turn can interleave its usage into another turn's delta window.
 #
-# Only the FINAL adopted upstream response (post-retry, post-rescue) is counted,
-# so a retried/degenerate first attempt does not double-count.
+# Every upstream response with usage is counted, including discarded retries,
+# because each model call is billable even when its response is not adopted.
 # ---------------------------------------------------------------------------
 _usage_lock = asyncio.Lock()
 _cumulative_input_tokens = 0
@@ -758,6 +766,40 @@ _cumulative_cache_read_tokens = 0
 _cumulative_cache_write_tokens = 0
 _last_model: Optional[str] = None
 _usage_events = 0  # count of upstream responses that carried a usage object
+
+
+class _UsageAccumulator:
+    """Sum billable usage across every upstream attempt for one proxy request."""
+
+    def __init__(self) -> None:
+        self.input_tokens = 0
+        self.output_tokens = 0
+        self.cache_read_tokens = 0
+        self.cache_write_tokens = 0
+        self.events = 0
+        self.model: Optional[str] = None
+
+    def add(
+        self,
+        usage_in: Optional[int],
+        usage_out: Optional[int],
+        cache_read: int,
+        cache_write: int,
+        model: Optional[str],
+    ) -> None:
+        has_usage = usage_in is not None or usage_out is not None
+        if isinstance(usage_in, int):
+            self.input_tokens += usage_in
+        if isinstance(usage_out, int):
+            self.output_tokens += usage_out
+        if has_usage:
+            if isinstance(cache_read, int):
+                self.cache_read_tokens += cache_read
+            if isinstance(cache_write, int):
+                self.cache_write_tokens += cache_write
+            self.events += 1
+        if model:
+            self.model = model
 
 
 def _extract_usage(
@@ -1722,6 +1764,14 @@ async def handle_proxy(request: web.Request) -> web.StreamResponse:
     if _read_workspace_flush_token() is not None:
         return web.json_response({"error": "Turn is finalizing"}, status=503)
     path = request.match_info.get("path", "")
+    if (
+        _candidate_mantle_authority_required(request.method, path)
+        and not _invocation_authority_is_available()
+    ):
+        return web.json_response(
+            {"error": "Invocation authority is unavailable"},
+            status=503,
+        )
     req_id = f"{int(time.time()*1000)}-{id(request) % 100000}"
     t0 = time.time()
 
@@ -2088,6 +2138,14 @@ async def handle_proxy(request: web.Request) -> web.StreamResponse:
         # First attempt.
         (status, headers, chunks, content, finish,
          usage_in, usage_out, cache_read, cache_write, resp_model) = await fetch_upstream("first")
+        attempt_usage = _UsageAccumulator()
+        attempt_usage.add(
+            usage_in,
+            usage_out,
+            cache_read,
+            cache_write,
+            resp_model,
+        )
         # The native Anthropic path (Sonnet 5) does not use the OpenAI-shaped
         # empty-relay/degeneracy retry+rescue — that was a GLM-5/Kimi workaround
         # and its detectors assume the OpenAI response shape. We forward the
@@ -2118,6 +2176,13 @@ async def handle_proxy(request: web.Request) -> web.StreamResponse:
              resp_model_r) = await fetch_upstream(
                 f"retry{retry_attempts}", body_override=retry_body
             )
+            attempt_usage.add(
+                usage_in_r,
+                usage_out_r,
+                cache_read_r,
+                cache_write_r,
+                resp_model_r,
+            )
             reason_r = is_retryable_failure(status_r, content_r, finish_r)
             # Always adopt the latest attempt's response body — if it succeeds
             # we use it directly; if it fails we still prefer it as the most
@@ -2125,25 +2190,6 @@ async def handle_proxy(request: web.Request) -> web.StreamResponse:
             status, headers, chunks, content, finish = (
                 status_r, headers_r, chunks_r, content_r, finish_r
             )
-            # Usage carry-forward: adopt the retry's usage ONLY when it actually
-            # reported usage — a retry whose response was differently-shaped (no
-            # `usage` object) must NOT discard the real, already-generated token
-            # count from the prior attempt (that would undercount cost). We take
-            # the latest NON-None value per field so the final billed usage is
-            # the freshest real number, not a null overwrite (review round 2).
-            if usage_in_r is not None:
-                usage_in = usage_in_r
-            if usage_out_r is not None:
-                usage_out = usage_out_r
-            # Cache tokens ride the same carry-forward rule: adopt the retry's
-            # split ONLY when the retry actually carried a usage object, so a
-            # usage-less retry response doesn't zero out the real cache numbers
-            # from the prior attempt.
-            if usage_in_r is not None or usage_out_r is not None:
-                cache_read = cache_read_r
-                cache_write = cache_write_r
-            if resp_model_r:
-                resp_model = resp_model_r
             if reason_r is None:
                 log.info(j("retry_succeeded", req_id=req_id,
                            attempt=retry_attempts,
@@ -2187,28 +2233,21 @@ async def handle_proxy(request: web.Request) -> web.StreamResponse:
                           synth_text_len=len(rescue_text),
                           retries_attempted=retry_attempts))
 
-        # Account the FINAL adopted response's usage into the cumulative
-        # counters so agentcore_wrapper's before/after `/usage` delta captures
-        # this turn's tokens. Rescue synthesis replaces the chunks but keeps the
-        # usage from the last real upstream attempt (usage_in/out unchanged),
-        # which is the right number to bill for the turn.
-        if usage_in is not None or usage_out is not None or resp_model:
+        # Account every paid attempt, including responses discarded by the
+        # retry/rescue policy. The before/after `/usage` delta must measure
+        # actual candidate cost rather than only the adopted response.
+        if attempt_usage.events or attempt_usage.model:
             global _cumulative_input_tokens, _cumulative_output_tokens
             global _cumulative_cache_read_tokens, _cumulative_cache_write_tokens
             global _last_model, _usage_events
             async with _usage_lock:
-                if isinstance(usage_in, int):
-                    _cumulative_input_tokens += usage_in
-                if isinstance(usage_out, int):
-                    _cumulative_output_tokens += usage_out
-                if isinstance(cache_read, int):
-                    _cumulative_cache_read_tokens += cache_read
-                if isinstance(cache_write, int):
-                    _cumulative_cache_write_tokens += cache_write
-                if resp_model:
-                    _last_model = resp_model
-                if usage_in is not None or usage_out is not None:
-                    _usage_events += 1
+                _cumulative_input_tokens += attempt_usage.input_tokens
+                _cumulative_output_tokens += attempt_usage.output_tokens
+                _cumulative_cache_read_tokens += attempt_usage.cache_read_tokens
+                _cumulative_cache_write_tokens += attempt_usage.cache_write_tokens
+                if attempt_usage.model:
+                    _last_model = attempt_usage.model
+                _usage_events += attempt_usage.events
 
         # Forward the (possibly retried) response to the client.
         resp = web.StreamResponse(status=status, headers=headers)

--- a/infra/agent-image/mantle_proxy.py
+++ b/infra/agent-image/mantle_proxy.py
@@ -28,6 +28,7 @@ import sys
 import time
 import uuid
 from typing import Optional
+from urllib.parse import urlparse
 
 from aiohttp import web, ClientSession, ClientTimeout
 
@@ -49,6 +50,30 @@ def j(msg: str, **kw) -> str:
 
 APP_BASE_URL = os.environ.get("APP_BASE_URL", "").rstrip("/")
 UPSTREAM = APP_BASE_URL + "/api/agent/model-proxy"
+CANDIDATE_MANTLE_API = os.environ.pop("CANDIDATE_MANTLE_API", "").strip()
+CANDIDATE_MANTLE_BASE_URL = os.environ.pop(
+    "CANDIDATE_MANTLE_BASE_URL", ""
+).strip()
+CANDIDATE_MANTLE_BEARER_TOKEN = os.environ.pop(
+    "CANDIDATE_MANTLE_BEARER_TOKEN", ""
+).strip()
+CANDIDATE_MANTLE_MODEL_ID = os.environ.pop(
+    "CANDIDATE_MANTLE_MODEL_ID", ""
+).strip()
+CANDIDATE_MANTLE_PREFIX = "candidate-mantle"
+CANDIDATE_MANTLE_OPERATIONS = {
+    "openai-completions": (
+        frozenset({("GET", "models"), ("POST", "chat/completions")}),
+        "/v1",
+    ),
+    "anthropic-messages": (
+        frozenset({("POST", "v1/messages")}),
+        "/anthropic",
+    ),
+}
+CANDIDATE_MANTLE_HOST_RE = re.compile(
+    r"bedrock-mantle\.[a-z0-9-]+\.api\.aws"
+)
 AUTHORITY_DIRECTORY = "/run/psd-agent-authority"
 INVOCATION_CONTEXT_PATH = f"{AUTHORITY_DIRECTORY}/invocation-context"
 REQUEST_PROOF_KEY_PATH = f"{AUTHORITY_DIRECTORY}/request-proof-key"
@@ -117,6 +142,75 @@ HYPERFRAMES_MAX_DIMENSION = 3_840
 POLLY_ENGINES = frozenset({"generative", "long-form", "neural", "standard"})
 POLLY_VOICE_RE = re.compile(r"^[A-Za-z][A-Za-z0-9_-]{0,63}$")
 EMAIL_RE = re.compile(r"^[^\s@/]+@[^\s@/]+\.[^\s@/]+$")
+
+
+def _candidate_mantle_configuration() -> tuple[str, str, str, str] | None:
+    """Validate the root-only direct-Mantle relay environment."""
+    values = (
+        CANDIDATE_MANTLE_API,
+        CANDIDATE_MANTLE_BASE_URL,
+        CANDIDATE_MANTLE_BEARER_TOKEN,
+        CANDIDATE_MANTLE_MODEL_ID,
+    )
+    if not any(values):
+        return None
+    if (
+        not all(values)
+        or CANDIDATE_MANTLE_API not in CANDIDATE_MANTLE_OPERATIONS
+    ):
+        raise RuntimeError("candidate Mantle relay configuration is incomplete")
+    _, expected_base_path = CANDIDATE_MANTLE_OPERATIONS[
+        CANDIDATE_MANTLE_API
+    ]
+    parsed = urlparse(CANDIDATE_MANTLE_BASE_URL)
+    try:
+        port = parsed.port
+    except ValueError as error:
+        raise RuntimeError("candidate Mantle base URL has an invalid port") from error
+    if (
+        parsed.scheme != "https"
+        or parsed.hostname is None
+        or not CANDIDATE_MANTLE_HOST_RE.fullmatch(parsed.hostname)
+        or parsed.username is not None
+        or parsed.password is not None
+        or port is not None
+        or parsed.path != expected_base_path
+        or parsed.params
+        or parsed.query
+        or parsed.fragment
+    ):
+        raise RuntimeError(
+            "candidate Mantle base URL is not an exact AWS endpoint"
+        )
+    return values
+
+
+def _resolve_candidate_mantle_request(
+    method: str,
+    path: str,
+    body: bytes | None,
+) -> str | None:
+    """Map one fixed model operation to the configured AWS endpoint."""
+    prefix = f"{CANDIDATE_MANTLE_PREFIX}/"
+    if not path.startswith(prefix):
+        return None
+    configuration = _candidate_mantle_configuration()
+    if configuration is None:
+        raise ValueError("candidate Mantle relay is disabled")
+    provider_api, base_url, _, model_id = configuration
+    allowed_operations, _ = CANDIDATE_MANTLE_OPERATIONS[provider_api]
+    relative_path = path[len(prefix) :]
+    if (method, relative_path) not in allowed_operations:
+        raise ValueError("unsupported candidate Mantle operation")
+    if method == "GET":
+        return f"{base_url}/{relative_path}"
+    try:
+        payload = json.loads(body) if body else None
+    except (TypeError, ValueError) as error:
+        raise ValueError("candidate Mantle request must be JSON") from error
+    if not isinstance(payload, dict) or payload.get("model") != model_id:
+        raise ValueError("candidate Mantle request model does not match")
+    return f"{base_url}/{relative_path}"
 
 
 def _read_authority() -> tuple[str, bytes]:
@@ -1628,13 +1722,25 @@ async def handle_proxy(request: web.Request) -> web.StreamResponse:
     if _read_workspace_flush_token() is not None:
         return web.json_response({"error": "Turn is finalizing"}, status=503)
     path = request.match_info.get("path", "")
-    url = f"{UPSTREAM}/{path}"
     req_id = f"{int(time.time()*1000)}-{id(request) % 100000}"
     t0 = time.time()
 
     req_body: Optional[bytes] = None
     if request.method in ("POST", "PUT", "PATCH"):
         req_body = await request.read()
+    try:
+        candidate_url = _resolve_candidate_mantle_request(
+            request.method, path, req_body
+        )
+    except (RuntimeError, ValueError) as error:
+        log.warning(
+            j("candidate_mantle_rejected", path=path, error=str(error)[:200])
+        )
+        return web.json_response(
+            {"error": "Unsupported candidate model operation"}, status=404
+        )
+    is_candidate_mantle = candidate_url is not None
+    url = candidate_url or f"{UPSTREAM}/{path}"
 
     # Log request summary + truncated body
     try:
@@ -1738,6 +1844,8 @@ async def handle_proxy(request: web.Request) -> web.StreamResponse:
             "x-agent-request-proof-signature",
         }:
             continue
+        if is_candidate_mantle and kl == "authorization":
+            continue
         fwd_headers[k] = v
 
     timeout = ClientTimeout(total=300, sock_read=300, sock_connect=30)
@@ -1769,11 +1877,18 @@ async def handle_proxy(request: web.Request) -> web.StreamResponse:
         `/usage` counters by the caller.
         """
         body_to_send = body_override if body_override is not None else req_body
-        proof_headers = _authority_headers(
-            request.method,
-            f"/api/agent/model-proxy/{path}",
-            body_to_send or b"",
-        )
+        if is_candidate_mantle:
+            proof_headers = {
+                "Authorization": (
+                    f"Bearer {CANDIDATE_MANTLE_BEARER_TOKEN}"
+                )
+            }
+        else:
+            proof_headers = _authority_headers(
+                request.method,
+                f"/api/agent/model-proxy/{path}",
+                body_to_send or b"",
+            )
         async with ClientSession(timeout=timeout) as session:
             async with session.request(
                 request.method,
@@ -2131,6 +2246,7 @@ async def handle_proxy(request: web.Request) -> web.StreamResponse:
 def main() -> None:
     if not UPSTREAM.startswith(("https://", "http://127.0.0.1", "http://localhost")):
         raise RuntimeError("APP_BASE_URL is not a trusted model broker URL")
+    candidate_mantle = _candidate_mantle_configuration() is not None
     app = web.Application(
         client_max_size=50 * 1024 * 1024,
         middlewares=[finalization_gate_middleware],
@@ -2145,7 +2261,15 @@ def main() -> None:
     app.router.add_post("/aws-skill/hyperframes/invoke", handle_hyperframes_invoke)
     app.router.add_route("*", "/agent-broker/{route:.*}", handle_agent_broker)
     app.router.add_route("*", "/{path:.*}", handle_proxy)
-    log.info(j("starting", host="127.0.0.1", port=18791, upstream=UPSTREAM))
+    log.info(
+        j(
+            "starting",
+            host="127.0.0.1",
+            port=18791,
+            upstream=UPSTREAM,
+            candidate_mantle=candidate_mantle,
+        )
+    )
     web.run_app(app, host="127.0.0.1", port=18791, access_log=None,
                 print=lambda *a, **k: None)
 

--- a/infra/agent-image/test_agentcore_wrapper.py
+++ b/infra/agent-image/test_agentcore_wrapper.py
@@ -41,6 +41,161 @@ for _m in _stubbed_by_us:
 _safe = agentcore_wrapper._safe_header_value
 
 
+class TestCandidateProviderHydration(unittest.TestCase):
+    def _config(self, directory, provider):
+        import json
+        from pathlib import Path
+
+        path = Path(directory) / "openclaw.json"
+        path.write_text(
+            json.dumps(
+                {
+                    "models": {"providers": {"candidate": provider}},
+                    "agents": {
+                        "defaults": {
+                            "model": {
+                                "primary": (
+                                    "candidate/"
+                                    + provider.get("models", [{"id": "model"}])[0]["id"]
+                                )
+                            }
+                        }
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+        return path
+
+    def test_native_sigv4_config_is_a_strict_noop(self):
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as directory:
+            path = self._config(
+                directory,
+                {"auth": "aws-sdk", "models": [{"id": "zai.glm-5"}]},
+            )
+            before = path.read_bytes()
+            with mock.patch.dict(
+                agentcore_wrapper.os.environ,
+                {},
+                clear=True,
+            ):
+                self.assertEqual(
+                    agentcore_wrapper.hydrate_configured_provider_api_keys(
+                        str(path)
+                    ),
+                    [],
+                )
+            self.assertEqual(path.read_bytes(), before)
+
+    def test_existing_bearer_is_inlined_for_any_named_provider(self):
+        import json
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as directory:
+            path = self._config(
+                directory,
+                {
+                    "auth": "api-key",
+                    "apiKey": "env:AWS_BEARER_TOKEN_BEDROCK",
+                    "models": [{"id": "qwen.qwen3-coder-next"}],
+                },
+            )
+            with mock.patch.dict(
+                agentcore_wrapper.os.environ,
+                {"AWS_BEARER_TOKEN_BEDROCK": "candidate-secret"},
+                clear=True,
+            ):
+                hydrated = (
+                    agentcore_wrapper.hydrate_configured_provider_api_keys(
+                        str(path)
+                    )
+                )
+            self.assertEqual(hydrated, ["candidate"])
+            config = json.loads(path.read_text(encoding="utf-8"))
+            self.assertEqual(
+                config["models"]["providers"]["candidate"]["apiKey"],
+                "candidate-secret",
+            )
+
+    def test_secret_arn_hydrates_when_bearer_env_is_absent(self):
+        import json
+        import tempfile
+
+        boto3 = mock.MagicMock()
+        boto3.client.return_value.get_secret_value.return_value = {
+            "SecretString": " fetched-secret ",
+            "VersionId": "version-1",
+        }
+        with tempfile.TemporaryDirectory() as directory:
+            path = self._config(
+                directory,
+                {
+                    "auth": "api-key",
+                    "apiKey": "env:AWS_BEARER_TOKEN_BEDROCK",
+                    "models": [{"id": "moonshotai.kimi-k2.5"}],
+                },
+            )
+            with mock.patch.dict(sys.modules, {"boto3": boto3}), mock.patch.dict(
+                agentcore_wrapper.os.environ,
+                {
+                    "BEDROCK_API_KEY_SECRET_ARN": "arn:aws:secretsmanager:example",
+                    "AWS_REGION": "us-east-1",
+                },
+                clear=True,
+            ):
+                hydrated = (
+                    agentcore_wrapper.hydrate_configured_provider_api_keys(
+                        str(path)
+                    )
+                )
+                self.assertEqual(
+                    agentcore_wrapper.os.environ[
+                        "AWS_BEARER_TOKEN_BEDROCK"
+                    ],
+                    "fetched-secret",
+                )
+            self.assertEqual(hydrated, ["candidate"])
+            config = json.loads(path.read_text(encoding="utf-8"))
+            self.assertEqual(
+                config["models"]["providers"]["candidate"]["apiKey"],
+                "fetched-secret",
+            )
+
+    def test_token_provider_without_credential_fails_before_boot(self):
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as directory:
+            path = self._config(
+                directory,
+                {
+                    "auth": "api-key",
+                    "apiKey": "env:AWS_BEARER_TOKEN_BEDROCK",
+                    "models": [{"id": "openai.gpt-oss-120b"}],
+                },
+            )
+            with mock.patch.dict(
+                agentcore_wrapper.os.environ,
+                {},
+                clear=True,
+            ), self.assertRaisesRegex(RuntimeError, "neither"):
+                agentcore_wrapper.hydrate_configured_provider_api_keys(str(path))
+
+    def test_telemetry_fallback_uses_configured_candidate_model(self):
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as directory:
+            path = self._config(
+                directory,
+                {"auth": "aws-sdk", "models": [{"id": "zai.glm-5"}]},
+            )
+            self.assertEqual(
+                agentcore_wrapper._configured_primary_model_id(str(path)),
+                "zai.glm-5",
+            )
+
+
 class TestInvocationContextInstaller(unittest.TestCase):
     def test_installs_authority_atomically_with_root_only_modes(self):
         import os

--- a/infra/agent-image/test_agentcore_wrapper.py
+++ b/infra/agent-image/test_agentcore_wrapper.py
@@ -110,11 +110,16 @@ class TestCandidateProviderHydration(unittest.TestCase):
                     "models": [{"id": "qwen.qwen3-coder-next"}],
                 },
             )
+            original_metadata = path.stat()
             with mock.patch.dict(
                 agentcore_wrapper.os.environ,
                 {"AWS_BEARER_TOKEN_BEDROCK": "candidate-secret"},
                 clear=True,
-            ):
+            ), mock.patch.object(
+                agentcore_wrapper.os,
+                "fchown",
+                wraps=agentcore_wrapper.os.fchown,
+            ) as fchown:
                 relay_environment = (
                     agentcore_wrapper.hydrate_configured_provider_api_keys(
                         str(path)
@@ -124,7 +129,19 @@ class TestCandidateProviderHydration(unittest.TestCase):
                     "AWS_BEARER_TOKEN_BEDROCK",
                     agentcore_wrapper.os.environ,
                 )
+            fchown.assert_called_once_with(
+                mock.ANY,
+                original_metadata.st_uid,
+                original_metadata.st_gid,
+            )
             config = json.loads(path.read_text(encoding="utf-8"))
+            rewritten_metadata = path.stat()
+            self.assertEqual(rewritten_metadata.st_uid, original_metadata.st_uid)
+            self.assertEqual(rewritten_metadata.st_gid, original_metadata.st_gid)
+            self.assertEqual(
+                rewritten_metadata.st_mode & 0o777,
+                original_metadata.st_mode & 0o777,
+            )
             self.assertEqual(
                 config["models"]["providers"]["candidate"]["apiKey"],
                 agentcore_wrapper.CANDIDATE_MANTLE_RELAY_API_KEY,

--- a/infra/agent-image/test_agentcore_wrapper.py
+++ b/infra/agent-image/test_agentcore_wrapper.py
@@ -46,6 +46,14 @@ class TestCandidateProviderHydration(unittest.TestCase):
         import json
         from pathlib import Path
 
+        provider = dict(provider)
+        if provider.get("apiKey") == "env:AWS_BEARER_TOKEN_BEDROCK":
+            provider.setdefault("api", "openai-completions")
+            provider.setdefault("auth", "api-key")
+            provider.setdefault(
+                "baseUrl",
+                "https://bedrock-mantle.us-east-1.api.aws/v1",
+            )
         path = Path(directory) / "openclaw.json"
         path.write_text(
             json.dumps(
@@ -85,11 +93,11 @@ class TestCandidateProviderHydration(unittest.TestCase):
                     agentcore_wrapper.hydrate_configured_provider_api_keys(
                         str(path)
                     ),
-                    [],
+                    {},
                 )
             self.assertEqual(path.read_bytes(), before)
 
-    def test_existing_bearer_is_inlined_for_any_named_provider(self):
+    def test_existing_bearer_is_confined_to_the_root_relay(self):
         import json
         import tempfile
 
@@ -107,19 +115,31 @@ class TestCandidateProviderHydration(unittest.TestCase):
                 {"AWS_BEARER_TOKEN_BEDROCK": "candidate-secret"},
                 clear=True,
             ):
-                hydrated = (
+                relay_environment = (
                     agentcore_wrapper.hydrate_configured_provider_api_keys(
                         str(path)
                     )
                 )
-            self.assertEqual(hydrated, ["candidate"])
+                self.assertNotIn(
+                    "AWS_BEARER_TOKEN_BEDROCK",
+                    agentcore_wrapper.os.environ,
+                )
             config = json.loads(path.read_text(encoding="utf-8"))
             self.assertEqual(
                 config["models"]["providers"]["candidate"]["apiKey"],
+                agentcore_wrapper.CANDIDATE_MANTLE_RELAY_API_KEY,
+            )
+            self.assertEqual(
+                config["models"]["providers"]["candidate"]["baseUrl"],
+                agentcore_wrapper.CANDIDATE_MANTLE_RELAY_BASE_URL,
+            )
+            self.assertNotIn("candidate-secret", path.read_text(encoding="utf-8"))
+            self.assertEqual(
+                relay_environment["CANDIDATE_MANTLE_BEARER_TOKEN"],
                 "candidate-secret",
             )
 
-    def test_secret_arn_hydrates_when_bearer_env_is_absent(self):
+    def test_secret_arn_configures_only_the_root_relay(self):
         import json
         import tempfile
 
@@ -145,22 +165,32 @@ class TestCandidateProviderHydration(unittest.TestCase):
                 },
                 clear=True,
             ):
-                hydrated = (
+                relay_environment = (
                     agentcore_wrapper.hydrate_configured_provider_api_keys(
                         str(path)
                     )
                 )
-                self.assertEqual(
-                    agentcore_wrapper.os.environ[
-                        "AWS_BEARER_TOKEN_BEDROCK"
-                    ],
-                    "fetched-secret",
+                self.assertNotIn(
+                    "AWS_BEARER_TOKEN_BEDROCK",
+                    agentcore_wrapper.os.environ,
                 )
-            self.assertEqual(hydrated, ["candidate"])
+                self.assertNotIn(
+                    "BEDROCK_API_KEY_SECRET_ARN",
+                    agentcore_wrapper.os.environ,
+                )
             config = json.loads(path.read_text(encoding="utf-8"))
             self.assertEqual(
                 config["models"]["providers"]["candidate"]["apiKey"],
+                agentcore_wrapper.CANDIDATE_MANTLE_RELAY_API_KEY,
+            )
+            self.assertNotIn("fetched-secret", path.read_text(encoding="utf-8"))
+            self.assertEqual(
+                relay_environment["CANDIDATE_MANTLE_BEARER_TOKEN"],
                 "fetched-secret",
+            )
+            self.assertEqual(
+                relay_environment["CANDIDATE_MANTLE_BASE_URL"],
+                "https://bedrock-mantle.us-east-1.api.aws/v1",
             )
 
     def test_token_provider_without_credential_fails_before_boot(self):
@@ -181,6 +211,49 @@ class TestCandidateProviderHydration(unittest.TestCase):
                 clear=True,
             ), self.assertRaisesRegex(RuntimeError, "neither"):
                 agentcore_wrapper.hydrate_configured_provider_api_keys(str(path))
+
+    def test_proxy_child_alone_receives_candidate_bearer(self):
+        process = mock.Mock()
+        process.poll.return_value = None
+        response = mock.MagicMock()
+        response.__enter__.return_value.status = 200
+        relay_environment = {
+            "CANDIDATE_MANTLE_API": "openai-completions",
+            "CANDIDATE_MANTLE_BASE_URL": (
+                "https://bedrock-mantle.us-east-1.api.aws/v1"
+            ),
+            "CANDIDATE_MANTLE_BEARER_TOKEN": "candidate-secret",
+            "CANDIDATE_MANTLE_MODEL_ID": "zai.glm-5",
+        }
+        with mock.patch.object(
+            agentcore_wrapper.subprocess,
+            "Popen",
+            return_value=process,
+        ) as popen, mock.patch(
+            "urllib.request.urlopen",
+            return_value=response,
+        ), mock.patch.dict(
+            agentcore_wrapper.os.environ,
+            {"APP_BASE_URL": "https://dev.example.invalid"},
+            clear=True,
+        ), mock.patch.object(
+            agentcore_wrapper,
+            "_mantle_proxy_process",
+            None,
+        ), mock.patch.object(
+            agentcore_wrapper,
+            "_candidate_relay_environment",
+            {},
+        ):
+            agentcore_wrapper.start_mantle_proxy(relay_environment)
+
+        child_environment = popen.call_args.kwargs["env"]
+        self.assertEqual(
+            child_environment["CANDIDATE_MANTLE_BEARER_TOKEN"],
+            "candidate-secret",
+        )
+        self.assertNotIn("AWS_BEARER_TOKEN_BEDROCK", child_environment)
+        self.assertNotIn("BEDROCK_API_KEY_SECRET_ARN", child_environment)
 
     def test_telemetry_fallback_uses_configured_candidate_model(self):
         import tempfile

--- a/infra/agent-image/test_candidate_matrix.py
+++ b/infra/agent-image/test_candidate_matrix.py
@@ -331,14 +331,14 @@ class CandidateMatrixTests(unittest.TestCase):
                 ):
                     candidate.validate(temporary_manifest)
 
-    def test_mantle_templates_use_the_bedrock_iam_service_prefix(self):
+    def test_mantle_templates_use_the_mantle_iam_service_prefix(self):
         providers_dir = self.manifests_dir.parent / "providers"
         for template_path in providers_dir.glob("mantle-*.json"):
             with self.subTest(template=template_path.name):
                 template = json.loads(template_path.read_text(encoding="utf-8"))
                 self.assertEqual(
                     template["iam"]["actions"],
-                    ["bedrock:CallWithBearerToken"],
+                    ["bedrock-mantle:CallWithBearerToken"],
                 )
                 self.assertEqual(template["iam"]["resources"], ["*"])
 

--- a/infra/agent-image/test_candidate_matrix.py
+++ b/infra/agent-image/test_candidate_matrix.py
@@ -172,6 +172,58 @@ class CandidateMatrixTests(unittest.TestCase):
 
                 self.assertEqual(summary["variedAxis"], declared_axis)
 
+    def test_rejects_baseline_harness_or_prompt_drift_from_production(self):
+        original_baseline = json.loads(
+            (self.manifests_dir / "baseline.json").read_text(encoding="utf-8")
+        )
+        original_candidate = json.loads(
+            (self.manifests_dir / "glm-5-native.json").read_text(encoding="utf-8")
+        )
+        for drifted_axis in ("harness", "prompt"):
+            with self.subTest(axis=drifted_axis), tempfile.TemporaryDirectory(
+                dir=self.manifests_dir.parent, prefix=".candidate-contract-test."
+            ) as directory:
+                baseline = json.loads(json.dumps(original_baseline))
+                source = json.loads(json.dumps(original_candidate))
+                baseline["axes"]["model"]["providerTemplate"] = (
+                    "../providers/native-bedrock-sonnet-5.json"
+                )
+                source["baseline"] = "baseline.json"
+                source["axes"]["model"]["providerTemplate"] = (
+                    "../providers/native-bedrock-glm-5.json"
+                )
+                if drifted_axis == "harness":
+                    baseline["axes"]["harness"]["hostVersion"] = "2099.1.1"
+                else:
+                    baseline["axes"]["prompt"]["variant"] = "stale-default"
+                source["axes"][drifted_axis] = baseline["axes"][drifted_axis]
+
+                directory_path = Path(directory)
+                (directory_path / "baseline.json").write_text(
+                    json.dumps(baseline), encoding="utf-8"
+                )
+                temporary_manifest = directory_path / "candidate.json"
+                temporary_manifest.write_text(
+                    json.dumps(source), encoding="utf-8"
+                )
+
+                with self.assertRaisesRegex(
+                    candidate.CandidateError,
+                    rf"baseline {drifted_axis} no longer matches",
+                ):
+                    candidate.validate(temporary_manifest)
+
+    def test_mantle_templates_use_the_bedrock_iam_service_prefix(self):
+        providers_dir = self.manifests_dir.parent / "providers"
+        for template_path in providers_dir.glob("mantle-*.json"):
+            with self.subTest(template=template_path.name):
+                template = json.loads(template_path.read_text(encoding="utf-8"))
+                self.assertEqual(
+                    template["iam"]["actions"],
+                    ["bedrock:CallWithBearerToken"],
+                )
+                self.assertEqual(template["iam"]["resources"], ["*"])
+
     def test_dockerfile_defaults_keep_production_pins_and_assertion(self):
         dockerfile = (HERE / "Dockerfile").read_text(encoding="utf-8")
         self.assertIn(

--- a/infra/agent-image/test_candidate_matrix.py
+++ b/infra/agent-image/test_candidate_matrix.py
@@ -176,10 +176,10 @@ class CandidateMatrixTests(unittest.TestCase):
         )
         self.assertIn("ARG BEDROCK_PLUGIN_VERSION=2026.7.1", dockerfile)
         self.assertIn(
-            "ARG BEDROCK_PLUGIN_EXPECTED_TOKEN=claude-sonnet-5", dockerfile
+            "ARG BEDROCK_PLUGIN_ASSERTION=claude-sonnet-5", dockerfile
         )
         self.assertIn(
-            'grep -Fq -- "${BEDROCK_PLUGIN_EXPECTED_TOKEN}"', dockerfile
+            'grep -Fq -- "${BEDROCK_PLUGIN_ASSERTION}"', dockerfile
         )
 
     def test_build_command_wires_manifest_inputs_and_digest_sidecar(self):
@@ -189,7 +189,7 @@ class CandidateMatrixTests(unittest.TestCase):
             "OPENCLAW_CONFIG=",
             "OPENCLAW_BASE_IMAGE=",
             "BEDROCK_PLUGIN_VERSION=",
-            "BEDROCK_PLUGIN_EXPECTED_TOKEN=",
+            "BEDROCK_PLUGIN_ASSERTION=",
             "candidate.py\" finalize",
             '"grader":"output_match"',
         ):

--- a/infra/agent-image/test_candidate_matrix.py
+++ b/infra/agent-image/test_candidate_matrix.py
@@ -12,6 +12,7 @@ HERE = Path(__file__).resolve().parent
 sys.path.insert(0, str(HERE))
 sys.path.insert(0, str(HERE / "eval" / "candidates"))
 
+import check_bootstrap_budget as budget  # noqa: E402
 import check_config_consistency as consistency  # noqa: E402
 import candidate  # noqa: E402
 
@@ -83,6 +84,10 @@ class CandidateMatrixTests(unittest.TestCase):
             self.assertFalse(plan["requiresBearerToken"])
             self.assertTrue(
                 (Path(directory) / "skills" / "psd-rules" / "SKILL.md").is_file()
+            )
+            self.assertEqual(
+                budget.effective_bootstrap_sizes(directory),
+                budget.effective_bootstrap_sizes(str(HERE)),
             )
             self.assertEqual(
                 consistency.run_checks(

--- a/infra/agent-image/test_candidate_matrix.py
+++ b/infra/agent-image/test_candidate_matrix.py
@@ -204,12 +204,91 @@ class CandidateMatrixTests(unittest.TestCase):
                     source["axes"]["harness"]["hostVersion"] = "2026.7.2"
                 else:
                     source["axes"]["prompt"]["variant"] = "alternate"
+                    alternate_soul = Path(directory) / "alternate-SOUL.md"
+                    alternate_soul.write_text(
+                        (HERE / "SOUL.md").read_text(encoding="utf-8")
+                        + "\nCandidate prompt delta.\n",
+                        encoding="utf-8",
+                    )
+                    source["axes"]["prompt"]["soul"] = (
+                        alternate_soul.relative_to(HERE).as_posix()
+                    )
                 temporary_manifest = Path(directory) / "candidate.json"
                 temporary_manifest.write_text(json.dumps(source), encoding="utf-8")
 
                 summary = candidate.validate(temporary_manifest)
 
                 self.assertEqual(summary["variedAxis"], declared_axis)
+
+    def test_rejects_prompt_axis_without_materialized_byte_change(self):
+        baseline = json.loads(
+            (self.manifests_dir / "baseline.json").read_text(encoding="utf-8")
+        )
+        for case in ("variant-only", "identical-file"):
+            with self.subTest(case=case), tempfile.TemporaryDirectory(
+                dir=self.manifests_dir.parent, prefix=".candidate-contract-test."
+            ) as directory:
+                source = json.loads(json.dumps(baseline))
+                source["id"] = f"prompt-{case}"
+                source["baseline"] = "../manifests/baseline.json"
+                source["declaredAxis"] = "prompt"
+                source["axes"]["model"]["providerTemplate"] = (
+                    "../providers/native-bedrock-sonnet-5.json"
+                )
+                if case == "variant-only":
+                    source["axes"]["prompt"]["variant"] = "alternate"
+                else:
+                    identical_soul = Path(directory) / "identical-SOUL.md"
+                    identical_soul.write_bytes((HERE / "SOUL.md").read_bytes())
+                    source["axes"]["prompt"]["soul"] = (
+                        identical_soul.relative_to(HERE).as_posix()
+                    )
+                temporary_manifest = Path(directory) / "candidate.json"
+                temporary_manifest.write_text(json.dumps(source), encoding="utf-8")
+
+                with self.assertRaisesRegex(
+                    candidate.CandidateError, "must change materialized"
+                ):
+                    candidate.validate(temporary_manifest)
+
+    def test_rejects_lookalike_aws_provider_hostnames(self):
+        providers_dir = self.manifests_dir.parent / "providers"
+        cases = (
+            (
+                "glm-5-mantle-openai.json",
+                "mantle-openai-glm-5.json",
+                "https://bedrock-mantle.us-east-1.api.aws.attacker.example/v1",
+            ),
+            (
+                "glm-5-native.json",
+                "native-bedrock-glm-5.json",
+                "https://bedrock-runtime.us-east-1.amazonaws.com.attacker.example",
+            ),
+        )
+        for manifest_name, provider_name, base_url in cases:
+            with self.subTest(provider=provider_name), tempfile.TemporaryDirectory(
+                dir=self.manifests_dir.parent, prefix=".candidate-contract-test."
+            ) as directory:
+                source = json.loads(
+                    (self.manifests_dir / manifest_name).read_text(encoding="utf-8")
+                )
+                provider = json.loads(
+                    (providers_dir / provider_name).read_text(encoding="utf-8")
+                )
+                source["baseline"] = "../manifests/baseline.json"
+                source["axes"]["model"]["providerTemplate"] = "provider.json"
+                provider["provider"]["baseUrl"] = base_url
+                directory_path = Path(directory)
+                (directory_path / "provider.json").write_text(
+                    json.dumps(provider), encoding="utf-8"
+                )
+                temporary_manifest = directory_path / "candidate.json"
+                temporary_manifest.write_text(json.dumps(source), encoding="utf-8")
+
+                with self.assertRaisesRegex(
+                    candidate.CandidateError, "exact AWS endpoint hostname"
+                ):
+                    candidate.validate(temporary_manifest)
 
     def test_rejects_baseline_harness_or_prompt_drift_from_production(self):
         original_baseline = json.loads(

--- a/infra/agent-image/test_candidate_matrix.py
+++ b/infra/agent-image/test_candidate_matrix.py
@@ -1,0 +1,200 @@
+"""Hermetic tests for the one-axis candidate-image matrix (#1423)."""
+
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(HERE))
+sys.path.insert(0, str(HERE / "eval" / "candidates"))
+
+import check_config_consistency as consistency  # noqa: E402
+import candidate  # noqa: E402
+
+
+class CandidateMatrixTests(unittest.TestCase):
+    manifests_dir = HERE / "eval" / "candidates" / "manifests"
+
+    def test_committed_matrix_covers_models_and_provider_paths(self):
+        manifest_paths = [
+            path
+            for path in sorted(self.manifests_dir.glob("*.json"))
+            if path.name != "baseline.json"
+        ]
+        summaries = [candidate.validate(path) for path in manifest_paths]
+        self.assertEqual(
+            {summary["candidateId"] for summary in summaries},
+            {
+                "glm-5-mantle-openai",
+                "glm-5-native",
+                "kimi-k2-5",
+                "openai-gpt-oss-120b",
+                "qwen3-coder-next",
+                "sonnet-5-mantle-anthropic",
+            },
+        )
+        for manifest_path in manifest_paths:
+            with self.subTest(manifest=manifest_path.name), tempfile.TemporaryDirectory(
+                dir=HERE, prefix=".candidate-test."
+            ) as directory:
+                plan = candidate.prepare(
+                    manifest_path,
+                    Path(directory),
+                    "d" * 40,
+                )
+                violations, _ = consistency.run_checks(
+                    str(Path(directory) / "openclaw.json"),
+                    str(HERE / "agentcore_wrapper.py"),
+                    str(plan["dockerfile"]),
+                )
+                self.assertEqual(violations, [])
+        self.assertEqual(
+            {summary["providerPath"] for summary in summaries},
+            {
+                "native-bedrock-sigv4",
+                "mantle-openai-compatible",
+                "mantle-anthropic-messages",
+            },
+        )
+
+    def test_glm_native_prepares_reproducible_build_inputs_and_metadata(self):
+        manifest = self.manifests_dir / "glm-5-native.json"
+        with tempfile.TemporaryDirectory(
+            dir=HERE, prefix=".candidate-test."
+        ) as directory:
+            plan = candidate.prepare(
+                manifest,
+                Path(directory),
+                "a" * 40,
+            )
+            config = json.loads(
+                (Path(directory) / "openclaw.json").read_text(encoding="utf-8")
+            )
+            provider = config["models"]["providers"]["amazon-bedrock"]
+            self.assertEqual(provider["models"][0]["id"], "zai.glm-5")
+            self.assertEqual(
+                config["agents"]["defaults"]["params"]["cacheRetention"], "none"
+            )
+            self.assertEqual(plan["providerPath"], "native-bedrock-sigv4")
+            self.assertFalse(plan["requiresBearerToken"])
+            self.assertTrue(
+                (Path(directory) / "skills" / "psd-rules" / "SKILL.md").is_file()
+            )
+            self.assertEqual(
+                consistency.run_checks(
+                    str(Path(directory) / "openclaw.json"),
+                    str(HERE / "agentcore_wrapper.py"),
+                    str(Path(directory) / "pin-contract.Dockerfile"),
+                )[0],
+                [],
+            )
+            metadata = json.loads(
+                Path(plan["metadata"]).read_text(encoding="utf-8")
+            )
+            self.assertEqual(metadata["variedAxis"], "model")
+            self.assertEqual(metadata["modelId"], "zai.glm-5")
+            self.assertEqual(metadata["cacheRetention"], "none")
+            self.assertEqual(metadata["contextTokens"], 180000)
+            self.assertIsNone(metadata["imageDigest"])
+            self.assertEqual(set(metadata["cost"]), set(metadata["costSources"]))
+
+    def test_finalize_binds_metadata_to_immutable_digest(self):
+        manifest = self.manifests_dir / "glm-5-native.json"
+        with tempfile.TemporaryDirectory(
+            dir=HERE, prefix=".candidate-test."
+        ) as directory:
+            output_dir = Path(directory)
+            plan = candidate.prepare(manifest, output_dir, "b" * 40)
+            finalized = output_dir / "final.json"
+            candidate.finalize(
+                Path(plan["metadata"]),
+                finalized,
+                "example.dkr.ecr.us-east-1.amazonaws.com/agent:test",
+                "sha256:" + "c" * 64,
+            )
+            metadata = json.loads(finalized.read_text(encoding="utf-8"))
+            self.assertEqual(metadata["imageDigest"], "sha256:" + "c" * 64)
+            self.assertTrue(metadata["finalizedAt"].endswith("Z"))
+
+    def test_rejects_candidate_that_changes_more_than_declared_axis(self):
+        source = json.loads(
+            (self.manifests_dir / "glm-5-native.json").read_text(encoding="utf-8")
+        )
+        source["axes"]["harness"]["hostVersion"] = "2099.1.1"
+        with tempfile.TemporaryDirectory(
+            dir=self.manifests_dir.parent, prefix=".candidate-contract-test."
+        ) as directory:
+            temporary_manifest = Path(directory) / "invalid.json"
+            # The temporary manifest lives one directory above manifests, so
+            # make its committed references relative to that location.
+            source["baseline"] = "../manifests/baseline.json"
+            source["axes"]["model"]["providerTemplate"] = (
+                "../providers/native-bedrock-glm-5.json"
+            )
+            temporary_manifest.write_text(json.dumps(source), encoding="utf-8")
+            with self.assertRaisesRegex(
+                candidate.CandidateError, "must vary exactly one axis"
+            ):
+                candidate.validate(temporary_manifest)
+
+    def test_accepts_harness_only_and_prompt_only_candidates(self):
+        baseline = json.loads(
+            (self.manifests_dir / "baseline.json").read_text(encoding="utf-8")
+        )
+        for declared_axis in ("harness", "prompt"):
+            with self.subTest(axis=declared_axis), tempfile.TemporaryDirectory(
+                dir=self.manifests_dir.parent, prefix=".candidate-contract-test."
+            ) as directory:
+                source = json.loads(json.dumps(baseline))
+                source["id"] = f"{declared_axis}-only"
+                source["baseline"] = "../manifests/baseline.json"
+                source["declaredAxis"] = declared_axis
+                source["axes"]["model"]["providerTemplate"] = (
+                    "../providers/native-bedrock-sonnet-5.json"
+                )
+                if declared_axis == "harness":
+                    source["axes"]["harness"]["hostVersion"] = "2026.7.2"
+                else:
+                    source["axes"]["prompt"]["variant"] = "alternate"
+                temporary_manifest = Path(directory) / "candidate.json"
+                temporary_manifest.write_text(json.dumps(source), encoding="utf-8")
+
+                summary = candidate.validate(temporary_manifest)
+
+                self.assertEqual(summary["variedAxis"], declared_axis)
+
+    def test_dockerfile_defaults_keep_production_pins_and_assertion(self):
+        dockerfile = (HERE / "Dockerfile").read_text(encoding="utf-8")
+        self.assertIn(
+            "ARG OPENCLAW_BASE_IMAGE=ghcr.io/openclaw/openclaw@sha256:"
+            "6a31d44b2944e7adcd2b582bf6fb463111264ebca97a0201795b799135bd102c",
+            dockerfile,
+        )
+        self.assertIn("ARG BEDROCK_PLUGIN_VERSION=2026.7.1", dockerfile)
+        self.assertIn(
+            "ARG BEDROCK_PLUGIN_EXPECTED_TOKEN=claude-sonnet-5", dockerfile
+        )
+        self.assertIn(
+            'grep -Fq -- "${BEDROCK_PLUGIN_EXPECTED_TOKEN}"', dockerfile
+        )
+
+    def test_build_command_wires_manifest_inputs_and_digest_sidecar(self):
+        script = (HERE / "build-and-push.sh").read_text(encoding="utf-8")
+        for token in (
+            "--candidate",
+            "OPENCLAW_CONFIG=",
+            "OPENCLAW_BASE_IMAGE=",
+            "BEDROCK_PLUGIN_VERSION=",
+            "BEDROCK_PLUGIN_EXPECTED_TOKEN=",
+            "candidate.py\" finalize",
+            '"grader":"output_match"',
+        ):
+            self.assertIn(token, script)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/infra/agent-image/test_candidate_matrix.py
+++ b/infra/agent-image/test_candidate_matrix.py
@@ -146,6 +146,45 @@ class CandidateMatrixTests(unittest.TestCase):
             ):
                 candidate.validate(temporary_manifest)
 
+    def test_rejects_candidate_paths_that_escape_the_candidate_tree(self):
+        baseline = json.loads(
+            (self.manifests_dir / "baseline.json").read_text(encoding="utf-8")
+        )
+        model_candidate = json.loads(
+            (self.manifests_dir / "glm-5-native.json").read_text(encoding="utf-8")
+        )
+        cases = (
+            (
+                "provider-template",
+                model_candidate,
+                ("model", "providerTemplate"),
+                "../../../../etc/passwd",
+            ),
+            (
+                "prompt-file",
+                baseline,
+                ("prompt", "soul"),
+                "../../../../etc/passwd",
+            ),
+        )
+        for name, original, path, escape in cases:
+            with self.subTest(case=name), tempfile.TemporaryDirectory(
+                dir=self.manifests_dir.parent, prefix=".candidate-contract-test."
+            ) as directory:
+                source = json.loads(json.dumps(original))
+                source["id"] = f"escape-{name}"
+                source["baseline"] = "../manifests/baseline.json"
+                source["declaredAxis"] = path[0]
+                source["axes"]["model"]["providerTemplate"] = (
+                    "../providers/native-bedrock-sonnet-5.json"
+                )
+                source["axes"][path[0]][path[1]] = escape
+                temporary_manifest = Path(directory) / "candidate.json"
+                temporary_manifest.write_text(json.dumps(source), encoding="utf-8")
+
+                with self.assertRaisesRegex(candidate.CandidateError, "escapes"):
+                    candidate.validate(temporary_manifest)
+
     def test_accepts_harness_only_and_prompt_only_candidates(self):
         baseline = json.loads(
             (self.manifests_dir / "baseline.json").read_text(encoding="utf-8")

--- a/infra/agent-image/test_check_config_consistency.py
+++ b/infra/agent-image/test_check_config_consistency.py
@@ -61,6 +61,18 @@ class ApiKeyHydrationTests(unittest.TestCase):
         wrapper = self._wrapper('os.environ["MY_TOKEN"] = value')
         self.assertEqual(ccc.check_apikey_hydration(cfg, wrapper), [])
 
+    def test_bedrock_placeholder_accepts_complete_root_relay_contract(self):
+        cfg = {"models": {"providers": {"mantle": {
+            "apiKey": "env:AWS_BEARER_TOKEN_BEDROCK"}}}}
+        wrapper = self._wrapper(
+            'BEDROCK_BEARER_ENV = "AWS_BEARER_TOKEN_BEDROCK"\n'
+            "value = os.environ.get(BEDROCK_BEARER_ENV, '')\n"
+            "CANDIDATE_MANTLE_RELAY_API_KEY = 'sentinel'\n"
+            'relay = {"CANDIDATE_MANTLE_BEARER_TOKEN": value}\n'
+            "os.environ.pop(BEDROCK_BEARER_ENV, None)\n"
+        )
+        self.assertEqual(ccc.check_apikey_hydration(cfg, wrapper), [])
+
     def test_unhydrated_env_var_flagged(self):
         cfg = {"models": {"providers": {"mantle": {"apiKey": "env:GHOST_TOKEN"}}}}
         wrapper = self._wrapper("nothing here sets it")

--- a/infra/agent-image/test_check_config_consistency.py
+++ b/infra/agent-image/test_check_config_consistency.py
@@ -26,6 +26,13 @@ class ContextWindowTests(unittest.TestCase):
         self.assertEqual(len(v), 1)
         self.assertIn("!= known value 200000", v[0])
 
+    def test_glm_5_known_window_and_wrong_window(self):
+        cfg = {"models": {"providers": {"p": {"models": [
+            {"id": "zai.glm-5", "contextWindow": 200000}]}}}}
+        self.assertEqual(ccc.check_context_windows(cfg), [])
+        cfg["models"]["providers"]["p"]["models"][0]["contextWindow"] = 203000
+        self.assertIn("!= known value 200000", ccc.check_context_windows(cfg)[0])
+
     def test_unknown_model_out_of_band_flagged(self):
         cfg = {"models": {"providers": {"p": {"models": [
             {"id": "mystery", "contextWindow": 5_000_000}]}}}}
@@ -329,6 +336,14 @@ class HostPluginCompatibilityTests(unittest.TestCase):
             ccc.check_host_plugin_compatibility(os.path.join(here, "Dockerfile")),
             [],
         )
+
+    def test_parameterized_repo_dockerfile_resolves_default_plugin_pin(self):
+        here = os.path.dirname(os.path.abspath(__file__))
+        version, violations = ccc.parse_pinned_plugin_version(
+            os.path.join(here, "Dockerfile")
+        )
+        self.assertEqual(version, "2026.7.1")
+        self.assertEqual(violations, [])
 
 
 class RealFilesTests(unittest.TestCase):

--- a/infra/agent-image/test_eval_runner.py
+++ b/infra/agent-image/test_eval_runner.py
@@ -2080,7 +2080,7 @@ class MainWiringTests(unittest.TestCase):
             environment = runner._resolve_candidate_runtime_environment(
                 executor,
                 metadata_path,
-                image,
+                f"{image.rsplit(':', 1)[0]}@{digest}",
                 "dev",
                 "us-east-1",
             )
@@ -2107,12 +2107,42 @@ class MainWiringTests(unittest.TestCase):
 
             with self.assertRaisesRegex(
                 runner.EvalRunnerError,
-                "--image does not match",
+                "--image must be the immutable digest",
             ):
                 runner._resolve_candidate_runtime_environment(
                     mock.Mock(),
                     metadata_path,
                     "example.invalid/agent:other",
+                    "dev",
+                    "us-east-1",
+                )
+
+    def test_candidate_metadata_rejects_its_matching_mutable_tag(self):
+        digest = "sha256:" + "d" * 64
+        image = "example.invalid/agent:mutable"
+        with tempfile.TemporaryDirectory() as directory:
+            metadata_path = Path(directory) / "candidate.json"
+            metadata_path.write_text(
+                json.dumps(
+                    {
+                        "schemaVersion": 1,
+                        "providerPath": "native-bedrock-sigv4",
+                        "providerAuth": "aws-sdk",
+                        "image": image,
+                        "imageDigest": digest,
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            with self.assertRaisesRegex(
+                runner.EvalRunnerError,
+                "--image must be the immutable digest",
+            ):
+                runner._resolve_candidate_runtime_environment(
+                    mock.Mock(),
+                    metadata_path,
+                    image,
                     "dev",
                     "us-east-1",
                 )

--- a/infra/agent-image/test_eval_runner.py
+++ b/infra/agent-image/test_eval_runner.py
@@ -2112,7 +2112,7 @@ class MainWiringTests(unittest.TestCase):
                 runner._resolve_candidate_runtime_environment(
                     mock.Mock(),
                     metadata_path,
-                    "example.invalid/agent:other",
+                    "example.invalid/agent@sha256:" + "e" * 64,
                     "dev",
                     "us-east-1",
                 )
@@ -2137,7 +2137,7 @@ class MainWiringTests(unittest.TestCase):
 
             with self.assertRaisesRegex(
                 runner.EvalRunnerError,
-                "--image must be the immutable digest",
+                "--image must be an immutable repository",
             ):
                 runner._resolve_candidate_runtime_environment(
                     mock.Mock(),
@@ -2146,6 +2146,33 @@ class MainWiringTests(unittest.TestCase):
                     "dev",
                     "us-east-1",
                 )
+
+    def test_image_is_immutable_even_without_candidate_metadata(self):
+        executor = mock.Mock()
+        digest_image = "example.invalid/agent@sha256:" + "f" * 64
+
+        self.assertEqual(
+            runner._resolve_candidate_runtime_environment(
+                executor,
+                None,
+                digest_image,
+                "dev",
+                "us-east-1",
+            ),
+            {},
+        )
+        with self.assertRaisesRegex(
+            runner.EvalRunnerError,
+            "--image must be an immutable repository",
+        ):
+            runner._resolve_candidate_runtime_environment(
+                executor,
+                None,
+                "example.invalid/agent:mutable",
+                "dev",
+                "us-east-1",
+            )
+        executor.run.assert_not_called()
 
     def test_main_passes_candidate_auth_environment_to_docker_factory(self):
         provider = mock.Mock()
@@ -2182,7 +2209,7 @@ class MainWiringTests(unittest.TestCase):
             status = runner.main(
                 [
                     "--image",
-                    "candidate@sha256:digest",
+                    "candidate@sha256:" + "0" * 64,
                     "--candidate-metadata",
                     str(metadata_path),
                     "--suite",
@@ -2277,7 +2304,7 @@ class MainWiringTests(unittest.TestCase):
             status = runner.main(
                 [
                     "--image",
-                    "candidate@sha256:digest",
+                    "candidate@sha256:" + "0" * 64,
                     "--suite",
                     "suite.yaml",
                     "--out",

--- a/infra/agent-image/test_eval_runner.py
+++ b/infra/agent-image/test_eval_runner.py
@@ -2014,6 +2014,164 @@ class DockerRuntimeTests(unittest.TestCase):
 
 
 class MainWiringTests(unittest.TestCase):
+    def test_mantle_candidate_metadata_resolves_only_the_secret_arn(self):
+        executor = mock.Mock()
+        executor.run.return_value = runner.CommandResult(
+            0,
+            "arn:aws:secretsmanager:us-east-1:123456789012:secret:bedrock\n",
+            "",
+        )
+        digest = "sha256:" + "a" * 64
+        image = "example.dkr.ecr.us-east-1.amazonaws.com/agent:test"
+        with tempfile.TemporaryDirectory() as directory:
+            metadata_path = Path(directory) / "candidate.json"
+            metadata_path.write_text(
+                json.dumps(
+                    {
+                        "schemaVersion": 1,
+                        "providerPath": "mantle-openai-compatible",
+                        "providerAuth": "api-key",
+                        "image": image,
+                        "imageDigest": digest,
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            environment = runner._resolve_candidate_runtime_environment(
+                executor,
+                metadata_path,
+                f"{image.rsplit(':', 1)[0]}@{digest}",
+                "dev",
+                "us-east-1",
+            )
+
+        self.assertEqual(
+            environment,
+            {
+                "BEDROCK_API_KEY_SECRET_ARN": (
+                    "arn:aws:secretsmanager:us-east-1:123456789012:secret:bedrock"
+                )
+            },
+        )
+        command = executor.run.call_args.args[0]
+        self.assertIn("BedrockApiKeySecretArn", " ".join(command))
+        self.assertNotIn("get-secret-value", command)
+
+    def test_native_candidate_metadata_never_resolves_a_secret(self):
+        executor = mock.Mock()
+        digest = "sha256:" + "b" * 64
+        image = "example.dkr.ecr.us-east-1.amazonaws.com/agent:native"
+        with tempfile.TemporaryDirectory() as directory:
+            metadata_path = Path(directory) / "candidate.json"
+            metadata_path.write_text(
+                json.dumps(
+                    {
+                        "schemaVersion": 1,
+                        "providerPath": "native-bedrock-sigv4",
+                        "providerAuth": "aws-sdk",
+                        "image": image,
+                        "imageDigest": digest,
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            environment = runner._resolve_candidate_runtime_environment(
+                executor,
+                metadata_path,
+                image,
+                "dev",
+                "us-east-1",
+            )
+
+        self.assertEqual(environment, {})
+        executor.run.assert_not_called()
+
+    def test_candidate_metadata_must_match_the_evaluated_image(self):
+        digest = "sha256:" + "c" * 64
+        with tempfile.TemporaryDirectory() as directory:
+            metadata_path = Path(directory) / "candidate.json"
+            metadata_path.write_text(
+                json.dumps(
+                    {
+                        "schemaVersion": 1,
+                        "providerPath": "mantle-anthropic-messages",
+                        "providerAuth": "api-key",
+                        "image": "example.invalid/agent:expected",
+                        "imageDigest": digest,
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            with self.assertRaisesRegex(
+                runner.EvalRunnerError,
+                "--image does not match",
+            ):
+                runner._resolve_candidate_runtime_environment(
+                    mock.Mock(),
+                    metadata_path,
+                    "example.invalid/agent:other",
+                    "dev",
+                    "us-east-1",
+                )
+
+    def test_main_passes_candidate_auth_environment_to_docker_factory(self):
+        provider = mock.Mock()
+        evaluation = mock.Mock()
+        evaluation.run.return_value = []
+        with tempfile.TemporaryDirectory() as directory, mock.patch.object(
+            runner,
+            "load_suite",
+            return_value=[],
+        ), mock.patch.object(
+            runner,
+            "_resolve_app_base_url",
+            return_value="https://dev.example.invalid",
+        ), mock.patch.object(
+            runner,
+            "_resolve_candidate_runtime_environment",
+            return_value={"BEDROCK_API_KEY_SECRET_ARN": "secret-arn"},
+        ) as candidate_environment, mock.patch.object(
+            runner,
+            "ActiveAwsCredentialProvider",
+            return_value=provider,
+        ), mock.patch.object(
+            runner,
+            "DockerRuntimeFactory",
+        ) as runtime_factory, mock.patch.object(
+            runner,
+            "ProbeContextMinter",
+        ), mock.patch.object(
+            runner,
+            "EvaluationRunner",
+            return_value=evaluation,
+        ):
+            metadata_path = Path(directory) / "candidate.json"
+            status = runner.main(
+                [
+                    "--image",
+                    "candidate@sha256:digest",
+                    "--candidate-metadata",
+                    str(metadata_path),
+                    "--suite",
+                    "suite.yaml",
+                    "--out",
+                    str(Path(directory) / "results.jsonl"),
+                ]
+            )
+
+        self.assertEqual(status, 0)
+        self.assertEqual(
+            runtime_factory.call_args.args[3]["BEDROCK_API_KEY_SECRET_ARN"],
+            "secret-arn",
+        )
+        self.assertEqual(
+            candidate_environment.call_args.args[1],
+            metadata_path.resolve(),
+        )
+
     def test_deployed_runtime_environment_is_allowlisted(self):
         executor = mock.Mock()
         executor.run.return_value = runner.CommandResult(

--- a/infra/agent-image/test_harness_adapter.py
+++ b/infra/agent-image/test_harness_adapter.py
@@ -124,7 +124,15 @@ class GatewayTokenTests(unittest.TestCase):
         # connect envelope reads (harness_adapter.py: `gateway_token =
         # self._gateway_token`), so launcher and client cannot diverge.
         a = harness_adapter.OpenClawAdapter()
-        with mock.patch.object(harness_adapter.subprocess, "Popen") as popen, \
+        with mock.patch.dict(
+                harness_adapter.os.environ,
+                {
+                    "AWS_BEARER_TOKEN_BEDROCK": "secret",
+                    "BEDROCK_API_KEY_SECRET_ARN": "secret-arn",
+                    "CANDIDATE_MANTLE_BEARER_TOKEN": "relay-secret",
+                },
+                clear=False,
+            ), mock.patch.object(harness_adapter.subprocess, "Popen") as popen, \
                 mock.patch.object(harness_adapter.OpenClawAdapter, "_wait_for_ready"), \
                 mock.patch.object(harness_adapter.time, "sleep"):
             a.configure({"gateway_port": 3100})
@@ -135,6 +143,10 @@ class GatewayTokenTests(unittest.TestCase):
         token_value = argv[argv.index("--token") + 1]
         self.assertEqual(token_value, a._gateway_token)
         self.assertNotEqual(token_value, OLD_LITERAL)
+        child_environment = popen.call_args.kwargs["env"]
+        self.assertNotIn("AWS_BEARER_TOKEN_BEDROCK", child_environment)
+        self.assertNotIn("BEDROCK_API_KEY_SECRET_ARN", child_environment)
+        self.assertNotIn("CANDIDATE_MANTLE_BEARER_TOKEN", child_environment)
 
 
 # Bound staticmethod for readability.

--- a/infra/agent-image/test_mantle_proxy.py
+++ b/infra/agent-image/test_mantle_proxy.py
@@ -67,6 +67,7 @@ from mantle_proxy import (  # noqa: E402
     HYPERFRAMES_RELAY_TIMEOUT_SECONDS,
     POLLY_TEXT_MAX_CHARS,
     _bind_hyperframes_owner,
+    _candidate_mantle_configuration,
     _decode_invocation_owner,
     _invoke_hyperframes,
     _new_lambda_client,
@@ -74,6 +75,7 @@ from mantle_proxy import (  # noqa: E402
     _resolve_invocation_owner,
     _read_bounded_agent_broker_response,
     _read_signed_identity_response,
+    _resolve_candidate_mantle_request,
     _resolve_agent_broker_route,
     _synthesize_polly,
     _validate_hyperframes_payload,
@@ -92,6 +94,77 @@ from mantle_proxy import (  # noqa: E402
     _parse_anthropic_stream,
     _parse_anthropic_response,
 )
+
+
+class TestCandidateMantleRelay(unittest.TestCase):
+    def _configuration(self, *, api="openai-completions", base_url=None):
+        if base_url is None:
+            base_url = (
+                "https://bedrock-mantle.us-east-1.api.aws/v1"
+                if api == "openai-completions"
+                else "https://bedrock-mantle.us-east-1.api.aws/anthropic"
+            )
+        return mock.patch.multiple(
+            mantle_proxy,
+            CANDIDATE_MANTLE_API=api,
+            CANDIDATE_MANTLE_BASE_URL=base_url,
+            CANDIDATE_MANTLE_BEARER_TOKEN="root-only-secret",
+            CANDIDATE_MANTLE_MODEL_ID="zai.glm-5",
+        )
+
+    def test_maps_only_the_configured_model_operation(self):
+        body = json.dumps({"model": "zai.glm-5", "messages": []}).encode()
+        with self._configuration():
+            self.assertEqual(
+                _resolve_candidate_mantle_request(
+                    "POST", "candidate-mantle/chat/completions", body
+                ),
+                (
+                    "https://bedrock-mantle.us-east-1.api.aws/v1"
+                    "/chat/completions"
+                ),
+            )
+            self.assertEqual(
+                _resolve_candidate_mantle_request(
+                    "GET", "candidate-mantle/models", None
+                ),
+                "https://bedrock-mantle.us-east-1.api.aws/v1/models",
+            )
+            with self.assertRaisesRegex(ValueError, "model does not match"):
+                _resolve_candidate_mantle_request(
+                    "POST",
+                    "candidate-mantle/chat/completions",
+                    json.dumps({"model": "other"}).encode(),
+                )
+            with self.assertRaisesRegex(ValueError, "unsupported"):
+                _resolve_candidate_mantle_request(
+                    "POST", "candidate-mantle/models", body
+                )
+
+    def test_maps_anthropic_messages_without_exposing_the_bearer(self):
+        body = json.dumps({"model": "zai.glm-5", "messages": []}).encode()
+        with self._configuration(api="anthropic-messages"):
+            configuration = _candidate_mantle_configuration()
+            self.assertIsNotNone(configuration)
+            upstream = _resolve_candidate_mantle_request(
+                "POST", "candidate-mantle/v1/messages", body
+            )
+            self.assertEqual(
+                upstream,
+                (
+                    "https://bedrock-mantle.us-east-1.api.aws/anthropic"
+                    "/v1/messages"
+                ),
+            )
+            self.assertNotIn("root-only-secret", upstream)
+
+    def test_rejects_lookalike_mantle_origin(self):
+        with self._configuration(
+            base_url=(
+                "https://bedrock-mantle.us-east-1.api.aws.attacker.example/v1"
+            )
+        ), self.assertRaisesRegex(RuntimeError, "exact AWS endpoint"):
+            _candidate_mantle_configuration()
 
 
 class _FakeAwsStream:

--- a/infra/agent-image/test_mantle_proxy.py
+++ b/infra/agent-image/test_mantle_proxy.py
@@ -33,8 +33,9 @@ if "aiohttp" not in sys.modules:
         """Minimal stand-in for aiohttp.web.json_response — records the payload
         so tests can assert on the /usage body."""
 
-        def __init__(self, payload):
+        def __init__(self, payload, status=200):
             self.payload = payload
+            self.status = status
 
     def _middleware(function):
         function.__middleware_version__ = 1
@@ -43,7 +44,9 @@ if "aiohttp" not in sys.modules:
     _aiohttp.web = types.SimpleNamespace(
         Request=object, Response=object, StreamResponse=object,
         Application=object,
-        json_response=lambda payload, *a, **k: _FakeJsonResponse(payload),
+        json_response=lambda payload, *a, **k: _FakeJsonResponse(
+            payload, status=k.get("status", 200)
+        ),
         run_app=lambda *a, **k: None,
         middleware=_middleware,
     )
@@ -76,8 +79,10 @@ from mantle_proxy import (  # noqa: E402
     _read_bounded_agent_broker_response,
     _read_signed_identity_response,
     _resolve_candidate_mantle_request,
+    _candidate_mantle_authority_required,
     _resolve_agent_broker_route,
     _synthesize_polly,
+    _UsageAccumulator,
     _validate_hyperframes_payload,
     _validate_polly_payload,
     _workspace_flush_request_allowed,
@@ -93,6 +98,7 @@ from mantle_proxy import (  # noqa: E402
     inject_anthropic_cache_breakpoints,
     _parse_anthropic_stream,
     _parse_anthropic_response,
+    handle_proxy,
 )
 
 
@@ -165,6 +171,56 @@ class TestCandidateMantleRelay(unittest.TestCase):
             )
         ), self.assertRaisesRegex(RuntimeError, "exact AWS endpoint"):
             _candidate_mantle_configuration()
+
+    def test_only_paid_candidate_operations_require_turn_authority(self):
+        self.assertTrue(
+            _candidate_mantle_authority_required(
+                "POST", "candidate-mantle/chat/completions"
+            )
+        )
+        self.assertFalse(
+            _candidate_mantle_authority_required(
+                "GET", "candidate-mantle/models"
+            )
+        )
+        self.assertFalse(
+            _candidate_mantle_authority_required(
+                "POST", "v1/chat/completions"
+            )
+        )
+
+    def test_candidate_inference_without_authority_fails_before_body_read(self):
+        class Request:
+            method = "POST"
+            match_info = {"path": "candidate-mantle/chat/completions"}
+
+            def __init__(self):
+                self.read_called = False
+
+            async def read(self):
+                self.read_called = True
+                return json.dumps(
+                    {"model": "zai.glm-5", "messages": []}
+                ).encode()
+
+        request = Request()
+        with self._configuration(), mock.patch.object(
+            mantle_proxy,
+            "_read_workspace_flush_token",
+            return_value=None,
+        ), mock.patch.object(
+            mantle_proxy,
+            "_invocation_authority_is_available",
+            return_value=False,
+        ):
+            response = asyncio.run(handle_proxy(request))
+
+        self.assertEqual(response.status, 503)
+        self.assertEqual(
+            response.payload,
+            {"error": "Invocation authority is unavailable"},
+        )
+        self.assertFalse(request.read_called)
 
 
 class _FakeAwsStream:
@@ -1084,6 +1140,19 @@ class TestUsageEndpoint(unittest.TestCase):
             final["cache_read_input_tokens"] - baseline["cache_read_input_tokens"],
             32000,
         )
+
+    def test_retry_accumulator_counts_every_paid_attempt(self):
+        usage = _UsageAccumulator()
+        usage.add(100, 10, 20, 5, "zai.glm-5")
+        usage.add(120, 12, 0, 0, "zai.glm-5")
+        usage.add(None, None, 0, 0, None)
+
+        self.assertEqual(usage.input_tokens, 220)
+        self.assertEqual(usage.output_tokens, 22)
+        self.assertEqual(usage.cache_read_tokens, 20)
+        self.assertEqual(usage.cache_write_tokens, 5)
+        self.assertEqual(usage.events, 2)
+        self.assertEqual(usage.model, "zai.glm-5")
 
 
 class TestAnthropicPathDetection(unittest.TestCase):

--- a/infra/lib/agent-platform-stack.ts
+++ b/infra/lib/agent-platform-stack.ts
@@ -4910,11 +4910,12 @@ export class AgentPlatformStack extends cdk.Stack {
       description: 'Router Lambda function ARN',
     });
 
-    // Bedrock API key secret ARN — consumed by build-and-push.sh (#1161) to run
-    // the build-time boot probe + canary turn with canary credentials.
+    // Bedrock API key secret ARN — consumed only when build-and-push.sh runs a
+    // token-authenticated Mantle candidate. The default native-SigV4 build
+    // probe does not read or receive this provider secret.
     new cdk.CfnOutput(this, 'BedrockApiKeySecretArn', {
       value: resources.bedrockApiKeySecret.secretArn,
-      description: 'Bedrock API key secret ARN (build-time canary probe credential)',
+      description: 'Bedrock API key secret ARN (Mantle candidate probe only)',
     });
 
     new cdk.CfnOutput(this, 'RouterQueueUrl', {


### PR DESCRIPTION
## Summary

- parameterize the OpenClaw base image, provider plugin assertion, config, and prompt inputs while preserving the production defaults
- add a validated one-axis candidate manifest contract and verified Bedrock templates for native SigV4, Mantle OpenAI-compatible, and Mantle Anthropic Messages paths
- add immutable build metadata, exact-output graded build canaries, and digest-only evaluation for every runner invocation
- confine candidate Mantle bearer credentials to a root-owned fixed-upstream relay; paid inference requires active turn authority and the node gateway receives only a loopback URL and non-secret sentinel
- account for every paid candidate retry so comparison cost cannot omit discarded model responses
- document model costs, API/auth/base URL contracts, IAM requirements, cross-region profile members, cache behavior, and the one-command workflow
- validate all baseline axes against production, count every effective bootstrap file, reject path traversal/lookalike hosts, and preserve node ownership across atomic candidate config rewrites

## Live candidate evidence

Primary no-secret candidate:

- candidate: `glm-5-native` (`zai.glm-5`, native Bedrock SigV4)
- source commit: `05b149de9cf116b712db0af7def0edf4a8eb3429`
- image: `390844780692.dkr.ecr.us-east-1.amazonaws.com/psd-agent-base-dev:2026-07-29-1423-glm5-native-r7`
- digest: `sha256:5069fa1c2c24dea35eb789ab8f131887b5ec54a2aadc8005e9f70916111f6f44`
- complete bootstrap budget: 30,380 / 80,000 characters across SOUL, IDENTITY, USER, and MEMORY
- boot probe: passed in 16s
- graded turn: exact `CANDIDATE_OK`, passed in 4s with `output_match`
- ECR image label and finalized sidecar both resolve to the same source commit and digest

No AgentCore deployment was performed.

## Validation

- `python3 -m unittest discover -s infra/agent-image -p "test_*.py"` — 512 passed, 1 skipped
- `bun run lint`
- `bun run typecheck`
- `bun run build`
- `cd infra && bunx cdk synth --quiet`
- candidate static instruction/config/upstream gates
- ARM64 Docker builds, local `BOOT_OK`, signed end-to-end turns, exact-output grades, ECR pushes, and immutable digest resolution on the final SHA
- browser E2E not run: this is an infrastructure/CLI workflow with no user-facing browser behavior

Closes #1423
