### PR TITLE
fix(agent): allow agent-owned Google Chat sends

### DIFF
--- a/app/api/agent/workspace-execute/route.ts
+++ b/app/api/agent/workspace-execute/route.ts
@@ -10,6 +10,7 @@ import {
   executeWorkspaceCommand,
   requiredWorkspaceScopeGap,
   validateEmailTaskWorkspaceCommand,
+  validateScheduledWorkspaceCommand,
   validateWorkspaceCommand,
   type WorkspaceCommand,
 } from "@/lib/agent-workspace/command-executor"
@@ -65,6 +66,8 @@ function validateCommandForMode(
   try {
     if (mode === "email-task") {
       validateEmailTaskWorkspaceCommand(command)
+    } else if (mode === "scheduled") {
+      validateScheduledWorkspaceCommand(command)
     } else {
       validateWorkspaceCommand(command)
     }

--- a/app/api/agent/workspace-execute/route.ts
+++ b/app/api/agent/workspace-execute/route.ts
@@ -8,6 +8,7 @@ import {
 import { getFreshAccessTokenForUser } from "@/lib/agent/workspace-token"
 import {
   executeWorkspaceCommand,
+  outboundMessageAudit,
   requiredWorkspaceScopeGap,
   validateEmailTaskWorkspaceCommand,
   validateWorkspaceCommand,
@@ -196,6 +197,7 @@ export async function POST(request: NextRequest) {
     const token = await workspaceAccessToken(body, context.ownerEmail)
     if (!token.ok) return token.response
     const result = await executeWorkspaceCommand(body, token.accessToken)
+    const outbound = outboundMessageAudit(body.argv)
     log.info(
       "Workspace command completed",
       sanitizeForLogging({
@@ -203,6 +205,12 @@ export async function POST(request: NextRequest) {
         ownerEmail: context.ownerEmail,
         scope: body.scope,
         operation: body.argv.slice(0, 4),
+        ...(outbound
+          ? {
+              outboundSpace: outbound.space,
+              outboundTextLength: outbound.textLength,
+            }
+          : {}),
       })
     )
     return NextResponse.json(result)

--- a/docs/README.md
+++ b/docs/README.md
@@ -181,6 +181,8 @@ AI integration patterns using Vercel AI SDK v6, provider factory implementation,
 
 **[Google Workspace content synchronization](./features/google-workspace-content-sync.md)** — PKCE OAuth and Picker selection across My Drive and user-accessible Shared Drives, durable cursor/version reconciliation, deployment-owned configuration, deletion grace, and operations.
 
+**[Agent-owned Google Workspace integration](./features/agent-workspace-integration.md)** — User and agent credential slots, DWD minting, automatic `agnt_` provisioning, Phase 1 safety boundaries, deployment, automated checks, live smoke tests, and troubleshooting.
+
 **[ClassLink OneRoster synchronization](./features/oneroster-classlink-sync.md)** — Nightly full-collection roster ingestion, OAuth1 and static-bearer Proxy configuration, fail-safe reconciliation invariants, metrics, alarms, rollout, and rollback.
 
 #### [features/navigation.md](./features/navigation.md)

--- a/docs/features/agent-workspace-integration.md
+++ b/docs/features/agent-workspace-integration.md
@@ -88,6 +88,18 @@ slot. The DWD assertion already carries `chat.messages`, which authorizes
 authentication and is not the credential mode used by the `agnt_*` identity.
 The skill still requires explicit user confirmation before posting.
 
+Two properties of that allowlist are worth stating plainly, because the
+confirmation requirement is a skill instruction rather than a code gate. The
+`workspace-execute` route accepts Chat sends in `scheduled` mode as well as
+`owner` mode, so a send can occur in a turn with no human present to confirm
+it. And the destination is bounded only by Chat membership — nothing ties the
+target space to the turn that triggered the send. The agent cannot widen that
+boundary itself: `chat spaces create`, `chat spaces setup` and
+`chat spaces members create` are all absent from the write allowlist, so the
+reachable set is the spaces the `agnt_*` identity already belongs to.
+Completed sends are logged with their resolved destination space and message
+length (never the body) so posts are auditable after the fact.
+
 ## Runtime error contract
 
 The skill emits a single JSON line on stdout (or a stderr message for exit 12)

--- a/docs/features/agent-workspace-integration.md
+++ b/docs/features/agent-workspace-integration.md
@@ -119,9 +119,12 @@ and a non-zero exit code when auth isn't ready:
 | 12 | (stderr) | both | Broker, policy, CLI, or Google failure; inspect the error text and request ID |
 | 13 | `phase1-forbidden` | both | A Phase-1 hard gate refused the command |
 | 14 | `account-provisioning` | agent | agnt_ account being auto-created — retry later, nothing to click |
+| 15 | `scope-upgrade-required` | user | Stored grant predates required Drive scopes — send the returned consent URL so the user can grant the additional permission |
 
-User-slot 10/11 payloads carry `consent_url`; `SOUL.md` instructs the agent to
-paste it verbatim into Chat and stop the turn. Exit 14 carries **no** URL.
+User-slot 10/11/15 payloads carry `consent_url`; `SOUL.md` instructs the agent
+to paste it verbatim into Chat and stop the turn. For exit 15, explain that one
+additional Drive permission is needed rather than saying authorization was
+missing or revoked. Exit 14 carries **no** URL.
 
 ## Deployment checklist
 

--- a/docs/features/agent-workspace-integration.md
+++ b/docs/features/agent-workspace-integration.md
@@ -3,8 +3,8 @@
 Per-user agents operate as their own Google Workspace identity
 (`agnt_<uniqname>@psd401.net`). Humans delegate to the agent the same way
 they would delegate to a real executive assistant. The agent's
-`psd-workspace` skill wraps the `gws` CLI and obtains per-session access
-tokens for two slots:
+`psd-workspace` submits tokenized `gws` commands to a trusted operation broker.
+The broker obtains credentials outside the model runtime for two slots:
 
 - **User slot (`--scope user`)** — the human's own identity. Still uses a
   per-user OAuth **consent** flow; the refresh token lives in Secrets Manager
@@ -12,30 +12,33 @@ tokens for two slots:
 - **Agent slot (`--scope agent`)** — the `agnt_*` identity. As of **#1232**
   there is **no consent flow and no stored refresh token**: a short-lived
   access token is minted on demand by a **domain-wide-delegation (DWD) token
-  broker** (`POST /api/agent/workspace-token`). Agent accounts are created
-  automatically via the OneSync sheet (**#1233**); interactive sign-in on
-  `agnt_*` accounts is blocked at the Google layer.
+  broker behind `POST /api/agent/workspace-execute`, then injected only into
+  the trusted `gws` child process. Agent accounts are created automatically via
+  the OneSync sheet (**#1233**); interactive sign-in on `agnt_*` accounts is
+  blocked at the Google layer.
   - **Confused-deputy isolation (#1232 hardening):** the DWD broker and the
     OneSync sheet writer do **not** run in the Next.js app. They run in a
     dedicated **mint Lambda** (`psd-agent-mint-{env}`) with its own least-
     privilege role, which is the **sole AWS principal the Google WIF provider
-    trusts**. The `/api/agent/workspace-token` and `/api/agent/account-request`
-    routes are thin proxies that reach the mint Lambda via an IAM-authed
+    trusts**. `/api/agent/workspace-execute` obtains its agent-slot token through
+    the mint boundary, and `/api/agent/account-request` is a thin provisioning
+    proxy; both reach the mint Lambda via IAM-authenticated
     `lambda:InvokeFunction`. So a frontend RCE/SSRF can at most *invoke* the mint
     Lambda — which always derives `agnt_<owner>` server-side — and can never
     reach the WIF credential to `signJwt(sub=<arbitrary human>)`. Blast radius of
     a frontend compromise: **any `agnt_` account** (agent-generated content), not
     any psd401.net mailbox. (When `AGENT_MINT_LAMBDA_NAME` is unset — local dev —
-    the routes run the broker in-process; there is no real WIF locally.)
+    the boundary runs in-process; there is no real WIF locally.)
 
 ## Components
 
 | Layer | Where | Purpose |
 |---|---|---|
 | DB | `psd_agent_workspace_tokens`, `psd_agent_workspace_consent_nonces` (migration 071) | Token manifest (user slot lifecycle; agent slot shows "Auto (DWD)") + one-time consent nonces |
-| API | `POST /api/agent/consent-link` | Agent→app, mints signed consent URLs (**user slot only** — agent_account is rejected, #1232) |
-| API | `POST /api/agent/workspace-token` | Agent→app; **thin proxy** to the mint Lambda; mints a ~1h agent-slot access token (#1232). 404 `account-not-provisioned` when the agnt_ account isn't made yet |
-| API | `POST /api/agent/account-request` | Router→app; **thin proxy** to the mint Lambda (probe + OneSync `agents` sheet append) to auto-provision the agnt_ account (#1233) |
+| API | `POST /api/agent/consent-link` | Owner-bound, router-signed request that mints a consent URL (**user slot only** — agent_account is rejected, #1232) |
+| API | `POST /api/agent/workspace-execute` | Owner-bound trusted operation broker. Validates the complete `gws` argv, obtains the selected slot's token outside the model runtime, executes `gws`, and returns bounded output. |
+| API | `POST /api/agent/workspace-token` | Retired raw-token endpoint. Authenticated callers receive 410 and must use `workspace-execute`; the model runtime never receives a reusable Google token. |
+| API | `POST /api/agent/account-request` | Owner-bound, router-signed **thin proxy** to the mint Lambda (existence probe + OneSync `agents` sheet append) that auto-provisions the agnt_ account (#1233) |
 | Lambda | `psd-agent-mint-{env}` (AgentPlatformStack, role `psd-agent-mint-execution-role-{env}`) | **#1232 isolation** — the sole WIF principal. Houses the DWD broker + provisioning-sheet writer; derives `agnt_<owner>` server-side. Role grants only `secretsmanager:GetSecretValue` on `psd-agent/{env}/*` + logs; the frontend holds only `lambda:InvokeFunction` on it. |
 | UI | `/agent-connect`, `/agent-connect/callback` | Public OAuth bootstrap (off-nav) |
 | Admin | "Workspace" tab in `/admin/agents` | Per-user status dashboard |
@@ -45,16 +48,18 @@ tokens for two slots:
 | Upstream skills | `gws-gmail`, `gws-calendar`, `gws-sheets`, … (cloned at image build, same tag as the binary) | Per-API guidance for the agent |
 | Rules | `infra/agent-image/skills/psd-rules/SKILL.md` | Tier 1 progressive-disclosure rules (think silently, never fabricate URLs/memory, no empty promises, Chat formatting) |
 | Formatter | `infra/agent-image/chat_format.py` | Markdown → Google Chat transform applied at the harness boundary |
-| Secrets | `psd-agent/{env}/google-oauth-client`, `psd-agent/{env}/internal-api-key`, `psd-agent/{env}/gcp-dwd-config` (#1232/#1233), `psd-agent/{env}/agent-gateway` (#1230/#1403), `psd-agent-creds/{env}/user/{email}/google-workspace-user` (user slot) | OAuth client, PSK, GCP DWD config JSON, dynamic workflow-gateway URL+token JSON, per-user refresh tokens. The agent slot no longer stores a refresh token (#1232). |
+| Invocation proof | `psd-agent/{env}/invocation-signing-key` | CDK-generated signing secret shared by the router and trusted web boundary. Every model-facing broker request is bound to the verified owner and invocation mode; caller-supplied owner selectors are rejected. |
+| Secrets | `psd-agent/{env}/google-oauth-client`, `psd-agent/{env}/gcp-dwd-config` (#1232/#1233), `psd-agent/{env}/agent-gateway` (#1230/#1403), `psd-agent-creds/{env}/user/{email}/google-workspace-user` (user slot) | OAuth client, GCP DWD config JSON, dynamic workflow-gateway URL+token JSON, and per-user refresh tokens. The agent slot no longer stores a refresh token (#1232). |
 | DWD config | `psd-agent/{env}/gcp-dwd-config` JSON: `{projectNumber, wifPoolId, wifProviderId, serviceAccountEmail, provisioningSheetId}` (Secrets Manager, IT-supplied; env-var overrides for local dev) | Keyless WIF → service-account impersonation for the broker + OneSync provisioning-sheet id. Read lazily (5-min cached); broker fails closed until populated. |
-| Cedar | `psd-agent-governance.cedar` | Allowlists for oauth2.googleapis.com + n8n gateway (`n8n.psd401.net/mcp/*`, #1230) + consent-link + workspace-token + account-request, secret.read on `psd-agent/*` |
+| Local broker | `infra/agent-image/mantle_proxy.py` + `skills/_shared/agent-broker.js` | Restricts callable `/api/agent/*` routes and forwards the router-signed invocation context; Workspace commands use `workspace-execute`, never the retired raw-token route. |
 
 ## Bootstrap flow — user slot (consent)
 
 1. User DMs agent with a request needing THEIR mailbox/calendar (`--scope user`).
-2. Skill checks Secrets Manager for a per-user refresh token; finds none.
-3. Skill POSTs `/api/agent/consent-link` (`kind:"user_account"`) with a
-   shared-secret Bearer.
+2. Skill submits the command to `/api/agent/workspace-execute`; the trusted
+   broker finds no usable per-user refresh token and returns `needs-auth`.
+3. Skill POSTs `/api/agent/consent-link` (`kind:"user_account"`) through the
+   owner-bound signed broker context.
 4. App signs a JWT (`AUTH_SECRET`, 24h exp, single-use nonce) and returns a URL.
 5. Skill emits `{status:"needs-auth",consent_url,...}` and exits 10.
 6. Agent pastes the URL verbatim into Chat; user clicks; `/agent-connect`
@@ -65,17 +70,20 @@ tokens for two slots:
    nothing and is retryable), writes the refresh token to
    `psd-agent-creds/{env}/user/{email}/google-workspace-user`, upserts the
    manifest row `active`, and consumes the nonce.
-9. User retries. Skill fetches the token, refreshes it, and execs `gws`.
+9. User retries. The trusted broker refreshes the user token and executes
+   `gws`; the model runtime receives command output, never the credential.
 
 ## Agent-slot flow — DWD broker (no consent)
 
 1. User asks the agent to act AS itself (`--scope agent`).
-2. Skill POSTs `/api/agent/workspace-token` (`{ownerEmail}`, PSK Bearer).
-3. The route (thin proxy) invokes the **mint Lambda**, which derives
+2. Skill submits the allowlisted argv to `/api/agent/workspace-execute` through
+   the owner-bound signed broker context.
+3. The trusted route invokes the **mint Lambda**, which derives
    `agnt_<owner-localpart>@psd401.net` server-side and mints a ~1h access token
-   via WIF → service-account signJwt → jwt-bearer exchange. Only the mint
-   Lambda's role can perform the WIF leg (the frontend cannot).
-4. If the agnt_ account doesn't exist yet, the mint Lambda returns 404
+   via WIF → service-account signJwt → jwt-bearer exchange. The route injects
+   the token only into its child `gws` process. Only the mint Lambda's role can
+   perform the WIF leg (the frontend and model runtime cannot).
+4. If the agnt_ account doesn't exist yet, the mint boundary returns
    `account-not-provisioned`; the skill emits `{status:"account-provisioning"}`
    exit 14 (the router has already kicked off auto-provisioning, #1233). No
    consent link — the user just retries in ~30 min.
@@ -108,7 +116,7 @@ and a non-zero exit code when auth isn't ready:
 |---|---|---|---|
 | 10 | `needs-auth` | user | No refresh token yet — consent URL in payload |
 | 11 | `token-revoked` | user | `invalid_grant` from Google — consent URL in payload |
-| 12 | (stderr) | agent | Transport error reaching the broker/Google (transient) |
+| 12 | (stderr) | both | Broker, policy, CLI, or Google failure; inspect the error text and request ID |
 | 13 | `phase1-forbidden` | both | A Phase-1 hard gate refused the command |
 | 14 | `account-provisioning` | agent | agnt_ account being auto-created — retry later, nothing to click |
 
@@ -126,11 +134,13 @@ paste it verbatim into Chat and stop the turn. Exit 14 carries **no** URL.
      --secret-id psd-agent/dev/google-oauth-client \
      --secret-string '{"client_id":"...","client_secret":"..."}'
    ```
-3. The internal API key is auto-generated by CDK. Capture it into the
-   Next.js app's `AGENT_INTERNAL_API_KEY` env var so the app can authenticate
-   incoming skill requests.
-4. Set `GOOGLE_WORKSPACE_CLIENT_ID` / `GOOGLE_WORKSPACE_CLIENT_SECRET` in the
-   Next.js environment (same values as step 2).
+3. The invocation-signing key is auto-generated by CDK. Router and frontend
+   receive its Secrets Manager ID automatically; do not copy it into the agent
+   image or a request body. For local development only, use the environment
+   override documented in `lib/agent-workspace/invocation-context.ts`.
+4. ECS loads the OAuth client lazily from
+   `GOOGLE_WORKSPACE_OAUTH_SECRET_ID`. Local development may instead set
+   `GOOGLE_WORKSPACE_CLIENT_ID` / `GOOGLE_WORKSPACE_CLIENT_SECRET`.
 5. **DWD broker + provisioning (#1232/#1233)** — IT provisions a Google service
    account with domain-wide delegation + a workload-identity-federation trust,
    then populate ONE Secrets Manager secret (no CDK context flags — aistudio is a
@@ -192,6 +202,168 @@ paste it verbatim into Chat and stop the turn. Exit 14 carries **no** URL.
      human's token). Dry-run by default; `--apply` to execute.
    - `scripts/agent-workspace/audit-user-slot-token-identity.ts` — audit
      user-slot tokens for identity mismatch (#1234) and purge the bad ones.
+
+## Operator runbook — run and verify the complete integration
+
+This is the start-to-finish checklist for Epic #912 and its DWD,
+auto-provisioning, Drive-access, and Chat-send follow-ups. The commands below
+match the current Phase 1 policy: Gmail writes stop at drafts, destructive
+operations remain blocked, user-slot file content creation is blocked, and
+interactive Chat sends use the agent slot.
+
+### 1. Run the automated contract
+
+From the repository root:
+
+```bash
+bun install --frozen-lockfile
+
+# Skill-side parsing, payload files, Phase 1 gates, and Chat-send pass-through
+bun run test:skill:workspace
+
+# Trusted broker, DWD minting, provisioning, OAuth identity, and route modes
+bunx jest --runInBand --runTestsByPath \
+  tests/unit/lib/agent-workspace/command-executor.test.ts \
+  tests/unit/lib/agent-workspace/command-executor-runtime.test.ts \
+  tests/unit/dwd-token-broker.test.ts \
+  tests/unit/agent-mint-client.test.ts \
+  tests/unit/agent-mint-lambda-handler.test.ts \
+  tests/unit/agent-provisioning-sheet.test.ts \
+  tests/unit/agent-account-request-route.test.ts \
+  tests/unit/agent-workspace-token-route.test.ts \
+  tests/unit/agent-consent-link-route.test.ts \
+  tests/unit/agent-workspace-callback-identity.test.ts \
+  tests/unit/agent-workspace-user-slot-scopes.test.ts \
+  tests/unit/agent-email-task-route.test.ts
+
+bun run lint
+bun run typecheck
+
+# In another shell: bun run db:up && bun run dev:local
+# Public consent-page and API-auth guards; no live Google grant required.
+PLAYWRIGHT_BASE_URL=http://localhost:3000 \
+  bunx playwright test tests/e2e/agent-workspace-connect.spec.ts
+```
+
+The full Google OAuth happy path, DWD exchange, OneSync account creation, and
+Chat delivery need dev credentials and are intentionally a live smoke test,
+not a hermetic CI test.
+
+### 2. Deploy the runnable pieces
+
+Follow the [Agent Platform Setup Guide](../operations/agent-platform-setup.md)
+for the GCP Chat app, AWS stacks, bridge, and image order. Follow the
+[Agent Image Build-Time Eval Gate](../operations/agent-image-build-gate.md)
+when building or promoting the image. The Workspace-specific order is:
+
+1. Complete the GCP OAuth, DWD, WIF, OU/app-policy, and OneSync setup in the
+   deployment checklist above. The WIF principal must be the mint Lambda role,
+   never the frontend role.
+2. Populate `google-oauth-client` and `gcp-dwd-config` without printing secret
+   values to logs. CDK creates the invocation-signing key; do not manually
+   retrieve or copy it.
+3. From `infra/`, run `bunx cdk synth` before any deploy, then deploy the
+   AgentPlatform and Frontend stacks for the target environment.
+4. From `infra/agent-image/`, run `./build-and-push.sh <immutable-tag>` and
+   redeploy the AgentPlatform stack with that image tag as described in the
+   setup guide.
+5. Run both one-off remediation scripts in dry-run mode, review their output,
+   then use their documented apply flags only for confirmed stale or
+   mismatched tokens.
+
+Safe configuration checks:
+
+```bash
+aws secretsmanager describe-secret \
+  --secret-id psd-agent/dev/gcp-dwd-config
+
+aws lambda get-function-configuration \
+  --function-name psd-agent-mint-dev \
+  --query '{State:State,LastUpdateStatus:LastUpdateStatus,Role:Role}'
+
+aws logs tail /aws/lambda/psd-agent-mint-dev --since 30m
+```
+
+These commands verify presence and runtime state without retrieving secret
+contents.
+
+### 3. Exercise the live flows in dev
+
+Use a staff pilot account and its `agnt_<uniqname>@psd401.net` identity.
+Confirm the Workspace tab under `/admin/agents` first shows the expected user
+slot and agent-slot state.
+
+The commands below run **inside the agent image during an active, signed
+invocation**; a standalone shell without invocation context is correctly
+rejected. In normal operation, send the equivalent request to the agent in
+Google Chat; the agent invokes the same entrypoint. For more examples and
+payload-file rules, see the bundled
+[`psd-workspace` skill contract](../../infra/agent-image/skills/psd-workspace/SKILL.md).
+
+```bash
+WORKSPACE_RUNNER=/opt/psd-skills/psd-workspace/run.js
+PILOT_EMAIL=someone@psd401.net
+
+# User-slot consent/read path. First run may return exit 10 with a consent URL.
+node "$WORKSPACE_RUNNER" --user "$PILOT_EMAIL" --scope user \
+  --command "gmail users messages list --params '{\"userId\":\"me\",\"q\":\"is:unread\",\"maxResults\":5}'"
+
+# User-slot safe writes.
+node "$WORKSPACE_RUNNER" --user "$PILOT_EMAIL" --scope user \
+  --command "gmail +draft --to someone@psd401.net --subject 'Workspace smoke test' --body 'Draft only'"
+node "$WORKSPACE_RUNNER" --user "$PILOT_EMAIL" --scope user \
+  --command "tasks tasks insert --params '{\"tasklist\":\"@default\"}' --json '{\"title\":\"Workspace smoke test\"}'"
+node "$WORKSPACE_RUNNER" --user "$PILOT_EMAIL" --scope user \
+  --command "drive files list --params '{\"pageSize\":5}'"
+
+# Agent-slot DWD path. A missing account returns exit 14 while OneSync creates it.
+node "$WORKSPACE_RUNNER" --user "$PILOT_EMAIL" --scope agent \
+  --command "drive files list --params '{\"pageSize\":5}'"
+
+# Chat send: use a disposable dev space and obtain explicit confirmation first.
+node "$WORKSPACE_RUNNER" --user "$PILOT_EMAIL" --scope agent \
+  --command "chat +send --space spaces/DEV_SPACE_ID --text 'Workspace smoke test'"
+```
+
+For the Chat-send regression, also exercise the raw
+`chat spaces messages create` form, verify the message appears in the
+designated space, and confirm the completion log records
+`outboundSpace`/`outboundTextLength` without the body. Re-run both forms with
+`--scope user` and verify the broker refuses them. Scheduled and email-task
+invocations must also refuse Chat writes; only an interactive owner invocation
+may post.
+
+Complete the remaining lifecycle checks:
+
+- **Provisioning:** use a staff pilot with no `agnt_` account. The first
+  interaction requests exactly one OneSync sheet row, returns exit 14 while
+  pending, and succeeds after OneSync creates the account. Numeric-prefix
+  student identities must never reach the sheet.
+- **Delegation:** delegate Gmail and Calendar to the `agnt_` identity using
+  Google settings, then verify the agent can read the delegated data. Without
+  delegation it should see only its own account.
+- **Revocation:** revoke the user-slot OAuth grant, retry a user-slot command,
+  and verify exit 11 supplies a new consent link without affecting the DWD
+  agent slot.
+- **Policy boundaries:** verify Gmail send, deletes, permission changes without
+  provenance, and user-owned document creation remain refused. Do not weaken a
+  gate to make a smoke test pass.
+
+### 4. Diagnose a failed run
+
+1. Map the skill exit code using the runtime error contract above.
+2. Check the router, frontend broker, and `/aws/lambda/psd-agent-mint-<env>`
+   logs with the shared request ID.
+3. Exit 12 with `Workspace operation is not allowed` is a trusted broker
+   allowlist rejection; exit 13 is a Phase 1 policy rejection. They are not
+   interchangeable.
+4. A Google error saying the organization restricts the **Chat app** belongs
+   to the router's `chat.bot` identity and Workspace app policy. It is separate
+   from the DWD-backed `agnt_` user identity; use the OU/app-policy checks in
+   the Agent Platform Setup Guide.
+5. After deployment, repeat the live smoke with at least two agent identities.
+   A single passing account does not prove the server-side derivation and
+   OneSync path work fleet-wide.
 
 ## Delegation (user-side)
 

--- a/docs/features/agent-workspace-integration.md
+++ b/docs/features/agent-workspace-integration.md
@@ -80,6 +80,14 @@ tokens for two slots:
    exit 14 (the router has already kicked off auto-provisioning, #1233). No
    consent link — the user just retries in ~30 min.
 
+Outbound Google Chat messages are agent-slot-only. The trusted executor
+allowlists both the `chat +send` helper and the raw
+`chat spaces messages create` method, while rejecting both on the human user
+slot. The DWD assertion already carries `chat.messages`, which authorizes
+`spaces.messages.create` with user authentication; `chat.bot` is for Chat-app
+authentication and is not the credential mode used by the `agnt_*` identity.
+The skill still requires explicit user confirmation before posting.
+
 ## Runtime error contract
 
 The skill emits a single JSON line on stdout (or a stderr message for exit 12)

--- a/docs/features/agent-workspace-integration.md
+++ b/docs/features/agent-workspace-integration.md
@@ -86,7 +86,10 @@ allowlists both the `chat +send` helper and the raw
 slot. The DWD assertion already carries `chat.messages`, which authorizes
 `spaces.messages.create` with user authentication; `chat.bot` is for Chat-app
 authentication and is not the credential mode used by the `agnt_*` identity.
-The skill still requires explicit user confirmation before posting.
+The skill still requires explicit user confirmation before posting, and the
+broker refuses Chat message creation from scheduled invocation mode, where no
+live confirmation can exist. Scheduled job output continues through the
+router's existing configured delivery path rather than calling `chat +send`.
 
 ## Runtime error contract
 

--- a/infra/agent-image/skills/psd-workspace/SKILL.md
+++ b/infra/agent-image/skills/psd-workspace/SKILL.md
@@ -152,6 +152,8 @@ node /opt/psd-skills/psd-workspace/run.js \
   --command "gmail +draft --to bill@psd401.net --subject 'Follow up' --body-file /tmp/draft-body.txt"
 
 # Chat message text (+send) uses --text-file (replaces --text)
+# Only send after the user explicitly confirms the message. Chat writes must
+# use the agent identity; the trusted broker rejects them on the human slot.
 node /opt/psd-skills/psd-workspace/run.js \
   --user hagelk@psd401.net --scope agent \
   --command "chat +send --space spaces/XXXX --text-file /tmp/chatmsg.txt"

--- a/infra/agent-image/skills/psd-workspace/SKILL.md
+++ b/infra/agent-image/skills/psd-workspace/SKILL.md
@@ -196,7 +196,7 @@ and style ranges immediately after, back-to-front.
 
 These cannot be bypassed by phrasing. The skill returns exit code 13 with `status: phase1-forbidden`:
 
-- **No sending mail.** `gmail.users.messages.send`, `gmail.users.drafts.send`, `+send`, `+reply`, `+reply-all`, `+forward` — all blocked. Drafts only.
+- **No sending mail.** `gmail.users.messages.send`, `gmail.users.drafts.send`, and the Gmail helper verbs `gmail +send`, `gmail +reply`, `gmail +reply-all`, `gmail +forward` — all blocked. Drafts only. These gates are Gmail-scoped: `chat +send` is a separate, allowed operation (agent slot only, see above) and is not covered by this boundary.
 - **No deletes.** Mail (delete/trash/batchDelete), events, calendars, Drive files, drive trash, tasks, tasklists.
 - **No permission changes.** `drive.permissions.create/update/delete` (except the explicit in-district shapes below).
 - **No file creation as the user.** `drive files create/copy`, `docs documents create`, `sheets spreadsheets create`, `slides presentations create` on `--scope user` are hard-blocked — a file created there is owned by the user's account (impersonation; no attribution trail). Create with `--scope agent`, then share explicitly. **One exception, added 2026-07-25 (#1305):** `drive files create` with `mimeType` exactly `application/vnd.google-apps.folder` is allowed, because a folder carries no content and creating one is organizing, not authoring. The mimeType is matched exactly — a shortcut, a Doc, or a lookalike mimeType still refuses — and any media/upload flag alongside it refuses too. Nothing else gets through, and no phrasing changes that.

--- a/infra/agent-image/skills/psd-workspace/SKILL.md
+++ b/infra/agent-image/skills/psd-workspace/SKILL.md
@@ -196,7 +196,7 @@ and style ranges immediately after, back-to-front.
 
 These cannot be bypassed by phrasing. The skill returns exit code 13 with `status: phase1-forbidden`:
 
-- **No sending mail.** `gmail.users.messages.send`, `gmail.users.drafts.send`, `+send`, `+reply`, `+reply-all`, `+forward` — all blocked. Drafts only.
+- **No sending mail.** `gmail.users.messages.send`, `gmail.users.drafts.send`, Gmail `+send`, `+reply`, `+reply-all`, `+forward` — all blocked. Drafts only.
 - **No deletes.** Mail (delete/trash/batchDelete), events, calendars, Drive files, drive trash, tasks, tasklists.
 - **No permission changes.** `drive.permissions.create/update/delete` (except the explicit in-district shapes below).
 - **No file creation as the user.** `drive files create/copy`, `docs documents create`, `sheets spreadsheets create`, `slides presentations create` on `--scope user` are hard-blocked — a file created there is owned by the user's account (impersonation; no attribution trail). Create with `--scope agent`, then share explicitly. **One exception, added 2026-07-25 (#1305):** `drive files create` with `mimeType` exactly `application/vnd.google-apps.folder` is allowed, because a folder carries no content and creating one is organizing, not authoring. The mimeType is matched exactly — a shortcut, a Doc, or a lookalike mimeType still refuses — and any media/upload flag alongside it refuses too. Nothing else gets through, and no phrasing changes that.

--- a/infra/agent-image/skills/psd-workspace/common.test.js
+++ b/infra/agent-image/skills/psd-workspace/common.test.js
@@ -299,6 +299,28 @@ describe('--text-file (chat +send message text)', () => {
   });
 });
 
+describe('Chat sends are broker-allowlisted, not Phase 1 forbidden', () => {
+  const AGENT_CTX = {
+    scope: 'agent_account',
+    ownerEmail: 'hagelk@psd401.net',
+  };
+
+  test('allows both the helper and raw create-message forms through the skill gate', () => {
+    expect(
+      enforcePhase1Gates(
+        'chat +send --space spaces/XXXX --text "Test summary"',
+        AGENT_CTX
+      )
+    ).toEqual({ allowed: true });
+    expect(
+      enforcePhase1Gates(
+        'chat spaces messages create --params \'{"parent":"spaces/XXXX"}\' --json \'{"text":"Test summary"}\'',
+        AGENT_CTX
+      )
+    ).toEqual({ allowed: true });
+  });
+});
+
 describe('quoted file paths (review finding 2)', () => {
   test('a quoted absolute path resolves like an unquoted one', () => {
     const payload = { a: 1 };

--- a/lib/agent-workspace/command-executor.ts
+++ b/lib/agent-workspace/command-executor.ts
@@ -73,6 +73,11 @@ const REQUIRES_AGENT_CREATED_PROVENANCE = new Set([
   "tasks tasks update",
 ])
 
+const CHAT_SEND_OPERATIONS = new Set([
+  "chat +send",
+  "chat spaces messages create",
+])
+
 const AGENT_ONLY_WRITES = new Set([
   "chat +send",
   "chat spaces messages create",
@@ -275,7 +280,15 @@ function validateWorkspaceMutation(
   tokens: string[]
 ): void {
   if (READ_ACTIONS.has(action)) {
-    if (tokens.slice(0, -1).some((token) => MUTATING_ACTIONS.has(token))) {
+    // A trailing read action must not smuggle an earlier mutation past the
+    // write allowlist. `+`-prefixed tokens are always helper verbs, never
+    // resources, so screening the whole class covers `+reply`, `+reply-all`
+    // and `+forward` without having to enumerate each new helper here.
+    if (
+      tokens
+        .slice(0, -1)
+        .some((token) => token.startsWith("+") || MUTATING_ACTIONS.has(token))
+    ) {
       throw new Error("Workspace read command contains a mutation operation")
     }
     return
@@ -315,6 +328,39 @@ export function validateWorkspaceCommand(command: WorkspaceCommand): void {
   validateWorkspaceArguments(argv)
   const { operation, action, tokens } = normalizedOperation(argv)
   validateWorkspaceMutation(argv, scope, operation, action, tokens)
+}
+
+export interface WorkspaceOutboundAudit {
+  space: string | null
+  textLength: number | null
+}
+
+/**
+ * Chat sends are the only allowlisted writes that put content outside the
+ * owner's own Workspace data, so the completion log has to record where the
+ * message went. `chat +send` carries the destination in `--space`, but the raw
+ * create-message form hides it inside `--params`, which the logged operation
+ * prefix never reaches. Message bodies are never returned — only their length.
+ */
+export function outboundMessageAudit(
+  argv: readonly string[]
+): WorkspaceOutboundAudit | null {
+  const operation = operationTokens(argv).join(" ")
+  if (!CHAT_SEND_OPERATIONS.has(operation)) return null
+  const params = parseObjectArgument(argv, "--params")
+  const payload = parseObjectArgument(argv, "--json")
+  const wrapped = payload?.resource ?? payload?.requestBody ?? payload
+  const body =
+    wrapped && typeof wrapped === "object" && !Array.isArray(wrapped)
+      ? (wrapped as Record<string, unknown>)
+      : null
+  const space =
+    argumentValue(argv, "--space") ??
+    (typeof params?.parent === "string" ? params.parent : null)
+  const text =
+    argumentValue(argv, "--text") ??
+    (typeof body?.text === "string" ? body.text : null)
+  return { space, textLength: text === null ? null : text.length }
 }
 
 export interface WorkspaceScopeGap {

--- a/lib/agent-workspace/command-executor.ts
+++ b/lib/agent-workspace/command-executor.ts
@@ -24,6 +24,7 @@ const READ_ACTIONS = new Set([
 ])
 
 const MUTATING_ACTIONS = new Set([
+  "+send",
   "batchdelete",
   "batchmodify",
   "batchupdate",
@@ -48,6 +49,8 @@ const MUTATING_ACTIONS = new Set([
 
 const ALLOWED_WRITES = new Set([
   "calendar events insert",
+  "chat +send",
+  "chat spaces messages create",
   "docs documents create",
   "drive files copy",
   "drive files create",
@@ -71,6 +74,8 @@ const REQUIRES_AGENT_CREATED_PROVENANCE = new Set([
 ])
 
 const AGENT_ONLY_WRITES = new Set([
+  "chat +send",
+  "chat spaces messages create",
   "docs documents create",
   "drive files copy",
   "drive files create",

--- a/lib/agent-workspace/command-executor.ts
+++ b/lib/agent-workspace/command-executor.ts
@@ -23,8 +23,9 @@ const READ_ACTIONS = new Set([
   "search",
 ])
 
+// Bare mutating verbs only. `+`-prefixed helper verbs are covered by the
+// prefix check in validateWorkspaceMutation and must not be enumerated here.
 const MUTATING_ACTIONS = new Set([
-  "+send",
   "batchdelete",
   "batchmodify",
   "batchupdate",
@@ -73,10 +74,12 @@ const REQUIRES_AGENT_CREATED_PROVENANCE = new Set([
   "tasks tasks update",
 ])
 
-const CHAT_SEND_OPERATIONS = new Set([
-  "chat +send",
-  "chat spaces messages create",
-])
+// Derived rather than enumerated: every allowlisted Chat write leaves the
+// owner's own Workspace data and therefore has to reach the audit log, so a
+// Chat operation cannot be added to ALLOWED_WRITES without being audited.
+const CHAT_SEND_OPERATIONS = new Set(
+  [...ALLOWED_WRITES].filter((operation) => operation.startsWith("chat "))
+)
 
 const AGENT_ONLY_WRITES = new Set([
   "chat +send",

--- a/lib/agent-workspace/command-executor.ts
+++ b/lib/agent-workspace/command-executor.ts
@@ -161,7 +161,7 @@ function parseObjectArgument(argv: readonly string[], flag: string): Record<stri
   }
 }
 
-function driveResource(argv: readonly string[]): Record<string, unknown> | null {
+function jsonResource(argv: readonly string[]): Record<string, unknown> | null {
   const payload = parseObjectArgument(argv, "--json")
   if (!payload) return null
   const wrapped = payload.resource ?? payload.requestBody ?? payload
@@ -184,7 +184,7 @@ function carriesDriveContent(argv: readonly string[]): boolean {
 }
 
 function validateUserDriveFolderCreate(argv: readonly string[]): void {
-  const resource = driveResource(argv)
+  const resource = jsonResource(argv)
   const mimeType =
     typeof resource?.mimeType === "string"
       ? resource.mimeType.trim().toLowerCase()
@@ -205,7 +205,7 @@ function validateUserDriveFolderCreate(argv: readonly string[]): void {
 }
 
 function validateUserDriveMetadataUpdate(argv: readonly string[]): void {
-  const resource = driveResource(argv)
+  const resource = jsonResource(argv)
   const keys = Object.keys(resource ?? {})
   if (
     !resource ||
@@ -335,6 +335,20 @@ export interface WorkspaceOutboundAudit {
   textLength: number | null
 }
 
+function chatDestinationSpace(argv: readonly string[]): string | null {
+  const explicit = argumentValue(argv, "--space")
+  if (explicit !== null) return explicit
+  const params = parseObjectArgument(argv, "--params")
+  return typeof params?.parent === "string" ? params.parent : null
+}
+
+function chatMessageText(argv: readonly string[]): string | null {
+  const explicit = argumentValue(argv, "--text")
+  if (explicit !== null) return explicit
+  const body = jsonResource(argv)
+  return typeof body?.text === "string" ? body.text : null
+}
+
 /**
  * Chat sends are the only allowlisted writes that put content outside the
  * owner's own Workspace data, so the completion log has to record where the
@@ -345,22 +359,12 @@ export interface WorkspaceOutboundAudit {
 export function outboundMessageAudit(
   argv: readonly string[]
 ): WorkspaceOutboundAudit | null {
-  const operation = operationTokens(argv).join(" ")
-  if (!CHAT_SEND_OPERATIONS.has(operation)) return null
-  const params = parseObjectArgument(argv, "--params")
-  const payload = parseObjectArgument(argv, "--json")
-  const wrapped = payload?.resource ?? payload?.requestBody ?? payload
-  const body =
-    wrapped && typeof wrapped === "object" && !Array.isArray(wrapped)
-      ? (wrapped as Record<string, unknown>)
-      : null
-  const space =
-    argumentValue(argv, "--space") ??
-    (typeof params?.parent === "string" ? params.parent : null)
-  const text =
-    argumentValue(argv, "--text") ??
-    (typeof body?.text === "string" ? body.text : null)
-  return { space, textLength: text === null ? null : text.length }
+  if (!CHAT_SEND_OPERATIONS.has(operationTokens(argv).join(" "))) return null
+  const text = chatMessageText(argv)
+  return {
+    space: chatDestinationSpace(argv),
+    textLength: text === null ? null : text.length,
+  }
 }
 
 export interface WorkspaceScopeGap {

--- a/lib/agent-workspace/command-executor.ts
+++ b/lib/agent-workspace/command-executor.ts
@@ -47,10 +47,14 @@ const MUTATING_ACTIONS = new Set([
   "watch",
 ])
 
-const ALLOWED_WRITES = new Set([
-  "calendar events insert",
+const CHAT_MESSAGE_CREATE_OPERATIONS = new Set([
   "chat +send",
   "chat spaces messages create",
+])
+
+const ALLOWED_WRITES = new Set([
+  "calendar events insert",
+  ...CHAT_MESSAGE_CREATE_OPERATIONS,
   "docs documents create",
   "drive files copy",
   "drive files create",
@@ -74,8 +78,7 @@ const REQUIRES_AGENT_CREATED_PROVENANCE = new Set([
 ])
 
 const AGENT_ONLY_WRITES = new Set([
-  "chat +send",
-  "chat spaces messages create",
+  ...CHAT_MESSAGE_CREATE_OPERATIONS,
   "docs documents create",
   "drive files copy",
   "drive files create",
@@ -362,6 +365,18 @@ export function validateEmailTaskWorkspaceCommand(
   const { operation } = normalizedOperation(command.argv)
   if (command.scope !== "user" || operation !== "tasks tasks insert") {
     throw new Error("Email tasks may only insert a user-owned Google task")
+  }
+}
+
+export function validateScheduledWorkspaceCommand(
+  command: WorkspaceCommand,
+): void {
+  validateWorkspaceCommand(command)
+  const { operation } = normalizedOperation(command.argv)
+  if (CHAT_MESSAGE_CREATE_OPERATIONS.has(operation)) {
+    throw new Error(
+      "Scheduled Workspace runs cannot post Google Chat messages without live user confirmation"
+    )
   }
 }
 

--- a/tests/unit/agent-email-task-route.test.ts
+++ b/tests/unit/agent-email-task-route.test.ts
@@ -5,7 +5,7 @@ import { beforeAll, beforeEach, describe, expect, it, jest } from "@jest/globals
 type Invocation = {
   ownerEmail: string
   actorEmail: string
-  mode: "owner" | "email-task"
+  mode: "owner" | "scheduled" | "email-task"
   sessionId: string
   nonce: string
 }
@@ -67,6 +67,42 @@ jest.mock("@/lib/logger", () => ({
 
 function request(body: unknown) {
   return { json: async () => body }
+}
+
+function defineScheduledChatConfinementTest(
+  workspacePost: () =>
+    typeof import("@/app/api/agent/workspace-execute/route").POST,
+): void {
+  it("blocks scheduled Chat sends before minting an agent token", async () => {
+    verifyContextMock.mockResolvedValue({
+      ownerEmail: "owner@example.com",
+      actorEmail: "owner@example.com",
+      mode: "scheduled",
+      sessionId: "scheduled-session",
+      nonce: "scheduled-nonce",
+    })
+
+    const response = await workspacePost()(
+      request({
+        scope: "agent",
+        argv: [
+          "chat",
+          "+send",
+          "--space",
+          "spaces/AAQA13FQZFA",
+          "--text",
+          "Automated update",
+        ],
+      }) as never,
+    )
+
+    expect(response.status).toBe(400)
+    await expect(response.json()).resolves.toMatchObject({
+      error: expect.stringMatching(/without live user confirmation/),
+    })
+    expect(mintAgentTokenMock).not.toHaveBeenCalled()
+    expect(executeWorkspaceCommandMock).not.toHaveBeenCalled()
+  })
 }
 
 describe("email-task route confinement", () => {
@@ -163,6 +199,8 @@ describe("email-task route confinement", () => {
     expect(executeWorkspaceCommandMock).toHaveBeenCalledTimes(1)
     expect(mintAgentTokenMock).not.toHaveBeenCalled()
   })
+
+  defineScheduledChatConfinementTest(() => workspacePost)
 
   it("requires a scope upgrade before executing a newly authorized Drive read", async () => {
     verifyContextMock.mockResolvedValue({

--- a/tests/unit/dwd-token-broker.test.ts
+++ b/tests/unit/dwd-token-broker.test.ts
@@ -116,6 +116,12 @@ describe("mintAgentWorkspaceToken", () => {
     process.env.GCP_DWD_SERVICE_ACCOUNT_EMAIL = SA
   })
 
+  it("requests the user-auth scope that permits Chat message creation", () => {
+    expect(AGENT_DWD_SCOPES).toContain(
+      "https://www.googleapis.com/auth/chat.messages"
+    )
+  })
+
   function fakeFetch(handlers: { sign?: () => unknown; token?: () => unknown }) {
     const calls: Array<{ url: string; init: RequestInit }> = []
     const impl = jest.fn(async (url: string, init: RequestInit) => {

--- a/tests/unit/lib/agent-workspace/command-executor-runtime.test.ts
+++ b/tests/unit/lib/agent-workspace/command-executor-runtime.test.ts
@@ -29,6 +29,42 @@ afterEach(async () => {
 })
 
 describe("trusted Workspace command runtime", () => {
+  it("executes an agent-owned Chat send through the trusted CLI boundary", async () => {
+    await validatedFsPromises.writeFile(
+      executable,
+      [
+        "#!/usr/bin/env node",
+        "process.stdout.write(JSON.stringify({",
+        "  argv: process.argv.slice(2),",
+        "  token: process.env.GOOGLE_WORKSPACE_CLI_TOKEN,",
+        "}))",
+      ].join("\n"),
+      { mode: 0o700 },
+    )
+
+    const argv = [
+      "chat",
+      "+send",
+      "--space",
+      "spaces/AAQA13FQZFA",
+      "--text",
+      "Test summary",
+    ]
+    const result = await executeWorkspaceCommand(
+      { scope: "agent", argv },
+      "agent-bound-access-token",
+    )
+    const execution = JSON.parse(result.stdout) as {
+      argv: string[]
+      token: string
+    }
+
+    expect(execution).toEqual({
+      argv,
+      token: "agent-bound-access-token",
+    })
+  })
+
   it("contains implicit binary downloads in a private disposable directory", async () => {
     await validatedFsPromises.writeFile(
       executable,

--- a/tests/unit/lib/agent-workspace/command-executor.test.ts
+++ b/tests/unit/lib/agent-workspace/command-executor.test.ts
@@ -480,6 +480,39 @@ const defineWorkspaceOutboundAuditSuite4 = () => {
       outboundMessageAudit(["chat", "+send", "--text", "orphan"])
     ).toEqual({ space: null, textLength: 6 })
   })
+
+  it.each([
+    ["helper", ["chat", "+send", "--space", "spaces/X", "--text", "hi"]],
+    [
+      "raw API",
+      ["chat", "spaces", "messages", "create", "--params", '{"parent":"s"}'],
+    ],
+  ])("audits every allowlisted Chat write via the %s form", (_name, argv) => {
+    expect(() => validateWorkspaceCommand({ scope: "agent", argv })).not.toThrow()
+    expect(outboundMessageAudit(argv)).not.toBeNull()
+  })
 };
 
 describe("Workspace outbound message audit", defineWorkspaceOutboundAuditSuite4)
+
+const defineEmailTaskChatRejectionSuite5 = () => {
+  it.each([
+    ["helper", ["chat", "+send", "--space", "spaces/X", "--text", "hi"]],
+    [
+      "raw API",
+      ["chat", "spaces", "messages", "create", "--params", '{"parent":"s"}'],
+    ],
+  ])("keeps sender-influenced email tasks from sending Chat via %s", (
+    _name,
+    argv
+  ) => {
+    expect(() =>
+      validateEmailTaskWorkspaceCommand({ scope: "agent", argv })
+    ).toThrow(/only insert a user-owned Google task/)
+    expect(() =>
+      validateEmailTaskWorkspaceCommand({ scope: "user", argv })
+    ).toThrow()
+  })
+};
+
+describe("Email-task mode excludes Chat sends", defineEmailTaskChatRejectionSuite5)

--- a/tests/unit/lib/agent-workspace/command-executor.test.ts
+++ b/tests/unit/lib/agent-workspace/command-executor.test.ts
@@ -267,6 +267,77 @@ function defineTrustedWorkspaceCommandPolicySuite1Part3() {it("rejects Gmail mod
       validateWorkspaceCommand({ scope: "agent", argv })
     ).not.toThrow()
   })
+
+  it.each([
+    [
+      "helper",
+      [
+        "chat",
+        "+send",
+        "--space",
+        "spaces/AAQA13FQZFA",
+        "--text",
+        "Test summary",
+      ],
+    ],
+    [
+      "raw API",
+      [
+        "chat",
+        "spaces",
+        "messages",
+        "create",
+        "--params",
+        '{"parent":"spaces/AAQA13FQZFA"}',
+        "--json",
+        '{"text":"Test summary"}',
+      ],
+    ],
+  ])("allows agent-owned Chat messages through the %s form", (_name, argv) => {
+    expect(() =>
+      validateWorkspaceCommand({ scope: "agent", argv })
+    ).not.toThrow()
+  })
+
+  it.each([
+    [
+      "helper",
+      [
+        "chat",
+        "+send",
+        "--space",
+        "spaces/AAQA13FQZFA",
+        "--text",
+        "No",
+      ],
+    ],
+    [
+      "raw API",
+      [
+        "chat",
+        "spaces",
+        "messages",
+        "create",
+        "--params",
+        '{"parent":"spaces/AAQA13FQZFA"}',
+        "--json",
+        '{"text":"No"}',
+      ],
+    ],
+  ])("keeps Chat message writes off the human user slot via %s", (_name, argv) => {
+    expect(() =>
+      validateWorkspaceCommand({ scope: "user", argv })
+    ).toThrow(/agent-owned Workspace account/)
+  })
+
+  it("does not let the Chat send helper hide before a read action", () => {
+    expect(() =>
+      validateWorkspaceCommand({
+        scope: "agent",
+        argv: ["chat", "+send", "list"],
+      })
+    ).toThrow(/contains a mutation/)
+  })
 }
 
 const defineTrustedWorkspaceCommandPolicySuite1 = () => {

--- a/tests/unit/lib/agent-workspace/command-executor.test.ts
+++ b/tests/unit/lib/agent-workspace/command-executor.test.ts
@@ -1,4 +1,5 @@
 import {
+  outboundMessageAudit,
   requiredWorkspaceScopeGap,
   validateEmailTaskWorkspaceCommand,
   validateWorkspaceCommand,
@@ -385,3 +386,100 @@ const defineWorkspaceUserSlotScopeUpgradesSuite2 = () => {
 };
 
 describe("Workspace user-slot scope upgrades", defineWorkspaceUserSlotScopeUpgradesSuite2)
+
+const defineWorkspaceHelperVerbSmugglingSuite3 = () => {
+  it.each([
+    ["gmail +reply", ["gmail", "+reply", "list"]],
+    ["gmail +reply-all", ["gmail", "+reply-all", "list"]],
+    ["gmail +forward", ["gmail", "+forward", "get"]],
+    ["gmail +send", ["gmail", "+send", "list"]],
+    ["chat +send", ["chat", "+send", "get"]],
+  ])(
+    "refuses %s hidden behind a trailing read action on the user slot",
+    (_name, argv) => {
+      expect(() =>
+        validateWorkspaceCommand({ scope: "user", argv })
+      ).toThrow(/contains a mutation/)
+      expect(() =>
+        validateWorkspaceCommand({ scope: "agent", argv })
+      ).toThrow(/contains a mutation/)
+    }
+  )
+
+  it("still allows ordinary read commands", () => {
+    expect(() =>
+      validateWorkspaceCommand({
+        scope: "user",
+        argv: ["gmail", "users", "messages", "list"],
+      })
+    ).not.toThrow()
+    expect(() =>
+      validateWorkspaceCommand({
+        scope: "agent",
+        argv: ["chat", "spaces", "list"],
+      })
+    ).not.toThrow()
+  })
+};
+
+describe("Workspace helper-verb read smuggling", defineWorkspaceHelperVerbSmugglingSuite3)
+
+const defineWorkspaceOutboundAuditSuite4 = () => {
+  it("records the destination and body length of a helper-form Chat send", () => {
+    expect(
+      outboundMessageAudit([
+        "chat",
+        "+send",
+        "--space",
+        "spaces/AAQA13FQZFA",
+        "--text",
+        "Daily digest",
+      ])
+    ).toEqual({ space: "spaces/AAQA13FQZFA", textLength: 12 })
+  })
+
+  it("recovers the destination the logged operation prefix cannot see", () => {
+    expect(
+      outboundMessageAudit([
+        "chat",
+        "spaces",
+        "messages",
+        "create",
+        "--params",
+        JSON.stringify({ parent: "spaces/AAQA13FQZFA" }),
+        "--json",
+        JSON.stringify({ text: "Daily digest" }),
+      ])
+    ).toEqual({ space: "spaces/AAQA13FQZFA", textLength: 12 })
+  })
+
+  it("unwraps a resource-wrapped raw payload", () => {
+    expect(
+      outboundMessageAudit([
+        "chat",
+        "spaces",
+        "messages",
+        "create",
+        "--params",
+        JSON.stringify({ parent: "spaces/AAQA13FQZFA" }),
+        "--json",
+        JSON.stringify({ resource: { text: "Hi" } }),
+      ])
+    ).toEqual({ space: "spaces/AAQA13FQZFA", textLength: 2 })
+  })
+
+  it("returns null for operations that do not leave the owner's Workspace", () => {
+    expect(
+      outboundMessageAudit(["gmail", "users", "drafts", "create"])
+    ).toBeNull()
+    expect(outboundMessageAudit(["chat", "spaces", "list"])).toBeNull()
+  })
+
+  it("reports a missing destination rather than inventing one", () => {
+    expect(
+      outboundMessageAudit(["chat", "+send", "--text", "orphan"])
+    ).toEqual({ space: null, textLength: 6 })
+  })
+};
+
+describe("Workspace outbound message audit", defineWorkspaceOutboundAuditSuite4)

--- a/tests/unit/lib/agent-workspace/command-executor.test.ts
+++ b/tests/unit/lib/agent-workspace/command-executor.test.ts
@@ -1,6 +1,7 @@
 import {
   requiredWorkspaceScopeGap,
   validateEmailTaskWorkspaceCommand,
+  validateScheduledWorkspaceCommand,
   validateWorkspaceCommand,
 } from "@/lib/agent-workspace/command-executor"
 
@@ -337,6 +338,34 @@ function defineTrustedWorkspaceCommandPolicySuite1Part3() {it("rejects Gmail mod
         argv: ["chat", "+send", "list"],
       })
     ).toThrow(/contains a mutation/)
+  })
+
+  it.each([
+    [
+      "helper",
+      [
+        "chat",
+        "+send",
+        "--space",
+        "spaces/AAQA13FQZFA",
+        "--text",
+        "No",
+      ],
+    ],
+    ["raw API", ["chat", "spaces", "messages", "create", "--json", "{}"]],
+  ])("blocks %s Chat sends from scheduled runs", (_name, argv) => {
+    expect(() =>
+      validateScheduledWorkspaceCommand({ scope: "agent", argv })
+    ).toThrow(/without live user confirmation/)
+  })
+
+  it("keeps scheduled Workspace reads available", () => {
+    expect(() =>
+      validateScheduledWorkspaceCommand({
+        scope: "agent",
+        argv: ["chat", "spaces", "messages", "list"],
+      })
+    ).not.toThrow()
   })
 }
 


### PR DESCRIPTION
## Description

Fixes the trusted Workspace broker rejection that prevented agent identities from posting Google Chat messages through either `chat +send` or raw `chat spaces messages create`.

Issue #1460 was reviewed as a duplicate report. Its additional Phase 1 acceptance detail is covered here; its router-side organization-policy failures are the separate #1449/#1451 path and are intentionally not folded into this broker fix.

## Type of Change

- [x] Bug fix (non-breaking change)
- [x] Documentation update
- [ ] Database migration
- [ ] Infrastructure/CDK change

## Implementation

- Allowlist both supported Chat message-create command forms at the trusted web boundary.
- Restrict every allowlisted Chat write to `--scope agent`; the human user slot remains blocked.
- Reject Chat writes from scheduled and email-task invocation modes, where no live user confirmation can exist.
- Fail closed on all `+`-prefixed helper mutations hidden before a trailing read verb, covering Gmail reply/forward helpers as well as Chat send.
- Audit successful outbound Chat messages with the resolved destination and text length while never logging the message body.
- Derive the Chat identity, audit, and scheduled-confirmation set from the trusted write allowlist so future Chat writes cannot silently bypass those controls.
- Add exact runtime and route regressions proving the helper reaches the trusted CLI with the agent-bound token only in an interactive owner invocation.
- Add a skill-gate regression proving neither Chat send form is a Phase 1 denial.
- Confirm with a regression guard and documentation that the existing DWD `chat.messages` scope already authorizes `spaces.messages.create` under user authentication; `chat.bot` is not required for this credential mode.

## Acceptance Criteria

- [x] `chat +send` is accepted for interactive agent identities.
- [x] Raw `chat spaces messages create` is accepted for interactive agent identities.
- [x] Both forms remain rejected for the human user slot.
- [x] Both forms remain rejected for scheduled and email-task invocations.
- [x] Both forms pass the Phase 1 skill gate rather than returning exit 13.
- [x] Existing mail-send, destructive-operation, and provenance gates remain unchanged.
- [x] Gmail helper mutations cannot be smuggled behind a trailing read verb.
- [x] Successful outbound Chat sends record destination and body length without recording body content.
- [x] The DWD grant contains the required Chat message scope.
- [x] Helper, raw, identity-boundary, mutation-smuggling, runtime, route-mode, Phase 1, audit, and DWD-scope regressions are covered.

## Validation

- [x] Focused Workspace broker/runtime/route Jest suite — 3 suites, 75 tests passed.
- [x] `bun test infra/agent-image/skills/psd-workspace/common.test.js` — 71 tests passed.
- [x] `bun run lint` — passed with zero warnings.
- [x] `bun run typecheck` — passed.
- [x] `bun run test:ci -- --runInBand` — 530 suites passed, 4,924 tests passed, 15 policy-skipped.
- [x] `bun run build` — production build passed; existing middleware-deprecation, Browserslist-age, and oidc-provider Node-version warnings only.
- [x] `bun run openapi:check` — generated catalog in sync.
- [x] `bun run capabilities:check` — generated catalog in sync.
- [x] `git diff --check` — passed.

The dedicated worktree has no `.env.local` or `AUTH_SECRET`, so the authenticated local Playwright pre-push hook cannot start. The hook-documented `SKIP_E2E=1` path was used for pushes. This is a backend broker-policy change with no browser UI acceptance path; trusted-boundary runtime and route regressions cover the reported pre-deploy failure, and hosted CI remains required.

## Risk, Rollback, and Deployment Verification

Risk is limited to a narrow allowlist expansion for two equivalent Chat create-message forms, constrained to the owner-derived agent identity and interactive owner invocation mode. Google Chat membership and Workspace policy continue to govern which existing spaces can receive messages; the agent cannot create spaces or add members through this broker. There are no migrations, new permissions, API v1 changes, environment variables, or cloud resources. Roll back by reverting these commits.

After deployment, rerun `chat +send` in `spaces/AAQA13FQZFA` with both `agnt_hagelk@psd401.net` and the affected Ashley Stolhand agent identity to confirm the broker reaches Google rather than returning the old local allowlist rejection.

## Screenshots

N/A — trusted backend command broker and agent skill documentation only.

Closes #1458
