### PR TITLE
fix(agent-image): enable key-free web search

### DIFF
--- a/docs/operations/agent-image-build-gate.md
+++ b/docs/operations/agent-image-build-gate.md
@@ -1,7 +1,7 @@
 # Agent Image Build-Time Eval Gate (#1161)
 
 `infra/agent-image/build-and-push.sh` refuses to push an agent image that has
-not been proven to boot and answer. This page documents the gate's four checks,
+not been proven to boot and answer. This page documents the gate's five checks,
 how to satisfy the runtime half, and how to override it when you must.
 
 The gate exists because the image is an artifact optimised against an
@@ -9,17 +9,19 @@ evaluator, and three separate regressions reached production before it did:
 a dead-boot image (r10), a missing provider (r11), and a silently truncated
 `SOUL.md`. Every one of them is caught on a laptop by the checks below.
 
-## The four checks
+## The five checks
 
 | # | Check | Kind | Fails on |
 |---|-------|------|----------|
 | 1 | Instruction-budget (`check_bootstrap_budget.py`) | static | a bootstrap file that would be truncated at boot |
-| 2 | Config self-consistency (`check_config_consistency.py`) | static | bad `contextWindow` / `apiKey` hydration in `openclaw.json` |
-| 3 | Boot probe | runtime | no `BOOT_OK` within `PROBE_BOOT_TIMEOUT` (default 120s) |
-| 4 | Canary turn | runtime | `/invocations` does not answer `OK` |
+| 2 | Config self-consistency (`check_config_consistency.py`) | static | bad `contextWindow`, `apiKey` hydration, plugin compatibility, or web-search provider readiness in `openclaw.json` / `Dockerfile` |
+| 3 | Plugin-aware config validation | build | the complete config is invalid after the pinned custom plugins are installed |
+| 4 | Boot probe | runtime | no `BOOT_OK` within `PROBE_BOOT_TIMEOUT` (default 120s) |
+| 5 | Canary turn | runtime | `/invocations` does not answer `OK` |
 
-Static checks run before the build. The runtime checks run against the freshly
-built image, before `docker push`.
+Static checks run before the build. Plugin-aware validation runs inside the
+image after the official Bedrock and Parallel plugins are installed. The
+runtime checks run against the freshly built image, before `docker push`.
 
 ## Why the runtime half needs a signed context
 

--- a/docs/operations/agent-platform-setup.md
+++ b/docs/operations/agent-platform-setup.md
@@ -372,6 +372,33 @@ bunx cdk deploy AIStudio-AgentPlatformStack-Dev \
   --context baseDomain=yourdomain.com
 ```
 
+### Agent web search
+
+The agent image explicitly selects OpenClaw's official `parallel-free`
+provider for `web_search`. OpenClaw does not auto-detect key-free providers,
+so removing `tools.web.search.provider` leaves the tool visible but makes calls
+fail with `disabled or no provider available`.
+
+- Provider: `parallel-free`
+- API key: none
+- Endpoint: `https://search.parallel.ai/mcp` (fixed by the pinned official
+  `@openclaw/parallel-plugin`)
+- Image config: `infra/agent-image/openclaw.json`
+- Supply-chain pin and endpoint assertion: `infra/agent-image/Dockerfile`
+- Live regression: `web-search-available` in
+  `infra/agent-image/eval/suites/l2-live.yaml`
+
+Run the static contract before building:
+
+```bash
+python3 infra/agent-image/check_config_consistency.py
+python3 -m unittest infra/agent-image/test_check_config_consistency.py
+```
+
+The Docker build then performs fatal plugin-aware `openclaw config validate`.
+After deployment, run the L2 live suite or the `web-search-available` task
+against the immutable image digest to confirm live results and citations.
+
 ### Agent image supply-chain pins (SEC-009)
 
 Every third-party artifact baked into the agent base image is pinned and
@@ -384,6 +411,7 @@ the Dockerfile (the enforcement gate that keeps these from regressing).
 |----------|-----|--------------|
 | OpenClaw base | `ghcr.io/openclaw/openclaw@sha256:6a31d4…` (2026.7.1) | Immutable digest in `FROM` |
 | amazon-bedrock provider plugin | `2026.7.1` | `npm pack` pin; must stay ≥ the minimum in `check_config_consistency.py` or prompt caching silently turns off |
+| Parallel web-search plugin | `2026.7.1` | `npm pack` pin; config gate requires host compatibility, explicit load/enable, and the fixed `https://search.parallel.ai/mcp` endpoint |
 | bun | `1.2.12` | `bun-linux-aarch64.zip` SHA256 vs `BUN_SHA256` ARG |
 | uv | `0.7.9` | `uv-aarch64-unknown-linux-gnu.tar.gz` SHA256 vs `UV_SHA256` ARG |
 | Google Workspace CLI (`gws`) | `0.22.5` | `.tar.gz` SHA256 vs `GWS_SHA256` ARG |
@@ -563,6 +591,7 @@ intent text.
 | "Database not configured, skipping telemetry" | DATABASE_HOST not set | Check Lambda env vars in CloudWatch |
 | Mention in a space gets no room reply; Router logs `403 "This organization's administrator restricts this Chat app from performing this action"` | The app is intentionally allowed only for Staff at a child OU, and Google blocks its `chat.bot` identity in the shared space | Do not broaden the app to Students. Confirm `ChatPostPermissionDenied` telemetry and the private DM fallback described in step 1.7. The separate `agnt_...` Workspace user's ability to post is unrelated. |
 | Guardrail blocks everything | GUARDRAIL_FAIL_OPEN=false + guardrail misconfigured | Check guardrail rules in Bedrock console |
+| `web_search` reports `disabled or no provider available` | `parallel-free` is not selected or its pinned plugin is missing | Run `check_config_consistency.py`, rebuild the agent image, and run the `web-search-available` L2 task |
 | DLQ alarm firing | Messages failing after 3 retries | Check CloudWatch logs for Router Lambda errors |
 | Pub/Sub push fails to SQS | SQS requires signed requests | Add API Gateway → SQS proxy in front of the queue |
 | Migration 065 failed | PL/pgSQL not compatible with RDS Data API | Fixed — redeploy DatabaseStack to retry |

--- a/infra/agent-image/Dockerfile
+++ b/infra/agent-image/Dockerfile
@@ -252,21 +252,16 @@ RUN mkdir -p /home/node/.openclaw/memory
 #   it would have yielded. 60s is a ceiling, not a delay: fast calls return
 #   as before. Pair with psd-rules guidance to use SHORT yieldMs (≤10s) so
 #   long commands suspend early instead of racing this timeout.
+#
+#   tools.web.search.provider=parallel-free — the OpenClaw image exposes
+#   web_search even when no usable provider is configured, but executing it
+#   then fails with "disabled or no provider available". The official Parallel
+#   plugin supplies a key-free provider backed by its fixed Search MCP endpoint
+#   (https://search.parallel.ai/mcp). It is explicitly selected because
+#   key-free providers never win OpenClaw auto-detection. The plugin is pinned
+#   and installed below; no API key or secret belongs in this image.
 ARG OPENCLAW_CONFIG=openclaw.json
 COPY ${OPENCLAW_CONFIG} /home/node/.openclaw/openclaw.json
-# Build-time config sanity check (post-2026-07-02 config-risk hardening): surface
-# any openclaw.json schema/key errors at BUILD time instead of at runtime (a
-# rejected config would stop the gateway from starting = an outage). Non-fatal
-# for now — until we confirm `config validate` needs no live runtime env, we
-# only echo a marker on nonzero so a false-positive can't block the build. Read
-# the `[config-validate]` lines in the build log; harden to fatal once trusted.
-RUN HOME=/home/node openclaw config validate >/tmp/config-validate.log 2>&1; \
-    STATUS=$?; \
-    sed 's/^/[config-validate] /' /tmp/config-validate.log; \
-    rm -f /tmp/config-validate.log; \
-    if [ "$STATUS" -ne 0 ]; then \
-      echo "[config-validate] NONZERO EXIT — inspect openclaw.json before deploying"; \
-    fi
 # OpenClaw auto-injects SOUL.md as the system prompt every turn.
 # NOTE: Do NOT put HTML comments or TODO notes in this file — they are
 # visible to the LLM. Keep roadmap notes here in the Dockerfile instead.
@@ -321,8 +316,9 @@ COPY skills /opt/psd-skills
 # caused by adding the gws-wrapper COPY at 53). Absolute `cd` paths so the chain
 # is independent of prior CWD. Keep new skills in this RUN, not new RUNs.
 #
-# The tail of this RUN also vendors the @openclaw/amazon-bedrock-provider
-# plugin: it registers the "bedrock" memory-embedding adapter that
+# The tail of this RUN also vendors the @openclaw/amazon-bedrock-provider and
+# @openclaw/parallel-plugin plugins. The first registers the "bedrock"
+# memory-embedding adapter that
 # openclaw.json's memorySearch.provider names. The published OpenClaw base
 # image ships with NO bundled extensions (they're an opt-in OPENCLAW_EXTENSIONS
 # build arg of the upstream Dockerfile), so memory sync failed every cycle with
@@ -336,7 +332,7 @@ COPY skills /opt/psd-skills
 #
 # 2026.6.11 -> 2026.7.1 (2026-07-27) RESTORES PROMPT CACHING, which had been
 # silently off for every turn since #1384 moved chat to this provider. The
-# plugin only emits Bedrock Converse `cachePoint` blocks when
+# bedrock plugin only emits Bedrock Converse `cachePoint` blocks when
 # supportsBedrockPromptCaching() recognizes the model, and 2026.6.11's
 # allowlist predates Sonnet 5 — it matches only `-4-`, `claude-fable-5`,
 # `claude-3-7-sonnet` and `claude-3-5-haiku`, so `us.anthropic.claude-sonnet-5`
@@ -349,8 +345,19 @@ COPY skills /opt/psd-skills
 # that allowlist. Do not downgrade this plugin without also removing the
 # caching expectation — see check_config_consistency.py, which fails the build
 # if the two drift apart again.
+#
+# The Parallel plugin supplies the official `parallel-free` web-search provider
+# selected in openclaw.json. It requires no API key, but OpenClaw deliberately
+# does not auto-select key-free providers, and the base image does not bundle
+# this extension. Pin it to the host release, assert the fixed Search MCP
+# endpoint is present in the published artifact, then validate the complete
+# config only after both custom plugin paths exist. Config validation is fatal:
+# an invalid provider would otherwise boot successfully and fail only when a
+# user invokes web_search.
 ARG BEDROCK_PLUGIN_VERSION=2026.7.1
 ARG BEDROCK_PLUGIN_ASSERTION=claude-sonnet-5
+ARG PARALLEL_PLUGIN_VERSION=2026.7.1
+ARG PARALLEL_PLUGIN_ENDPOINT=https://search.parallel.ai/mcp
 RUN cd /opt/psd-skills/psd-schedules && npm install --omit=dev --no-audit --no-fund && \
     cd /opt/psd-skills/psd-credentials && npm install --omit=dev --no-audit --no-fund && \
     cd /opt/psd-skills/psd-skills-meta && npm install --omit=dev --no-audit --no-fund && \
@@ -366,7 +373,16 @@ RUN cd /opt/psd-skills/psd-schedules && npm install --omit=dev --no-audit --no-f
     rm "openclaw-amazon-bedrock-provider-${BEDROCK_PLUGIN_VERSION}.tgz" && \
     test -f /opt/openclaw-plugins/amazon-bedrock/openclaw.plugin.json && \
     grep -Fq -- "${BEDROCK_PLUGIN_ASSERTION}" \
-      /opt/openclaw-plugins/amazon-bedrock/dist/bedrock-options.js
+      /opt/openclaw-plugins/amazon-bedrock/dist/bedrock-options.js && \
+    cd /opt/openclaw-plugins && \
+    npm pack "@openclaw/parallel-plugin@${PARALLEL_PLUGIN_VERSION}" && \
+    tar -xzf "openclaw-parallel-plugin-${PARALLEL_PLUGIN_VERSION}.tgz" && \
+    mv package parallel && \
+    rm "openclaw-parallel-plugin-${PARALLEL_PLUGIN_VERSION}.tgz" && \
+    test -f /opt/openclaw-plugins/parallel/openclaw.plugin.json && \
+    grep -RFq -- "${PARALLEL_PLUGIN_ENDPOINT}" \
+      /opt/openclaw-plugins/parallel/dist && \
+    HOME=/home/node openclaw config validate
 # chat-card has zero npm deps. chat-chart's npm install is paired with the
 # matplotlib install above — both stay disabled until we figure out the
 # AgentCore overlay-mount failure. With both off the image boots cleanly

--- a/infra/agent-image/build-and-push.sh
+++ b/infra/agent-image/build-and-push.sh
@@ -154,17 +154,18 @@ echo ""
 # ---------------------------------------------------------------------------
 # Build-time eval gate (issue #1161). The image is an artifact optimized
 # against an evaluator: it must pass an automated gate BEFORE it is pushed, so
-# the build loop stops being "deploy and chat." Four checks —
+# the build loop stops being "deploy and chat." Five checks —
 #   1. instruction-budget gate   (static, no Docker)   — over-budget bootstrap
-#   2. config self-consistency   (static, no Docker)   — bad contextWindow / apiKey
-#   3. boot probe                (runtime, needs image) — dead-boot (no BOOT_OK)
-#   4. canary turn               (runtime, needs image) — non-answering agent
+#   2. config self-consistency   (static, no Docker)   — bad config/provider pins
+#   3. plugin-aware validation   (Docker build)        — invalid complete config
+#   4. boot probe                (runtime, needs image) — dead-boot (no BOOT_OK)
+#   5. canary turn               (runtime, needs image) — non-answering agent
 # Would have stopped r10 (dead-boot), r11 (missing provider), and the weeks-long
 # SOUL.md truncation on a laptop instead of in prod.
 #
 # Two separate bypasses, so an emergency doesn't disable more than it must:
 #   SKIP_PROBE_GATE=1   skips only the RUNTIME boot-probe + canary turn (checks
-#                       3-4) — reserved for a broken probe blocking releases.
+#                       4-5) — reserved for a broken probe blocking releases.
 #   SKIP_STATIC_GATE=1  skips the cheap STATIC checks (1-2). These are pure file
 #                       checks with no external dependency and essentially never
 #                       need bypassing — this exists only for a true emergency,

--- a/infra/agent-image/build-and-push.sh
+++ b/infra/agent-image/build-and-push.sh
@@ -63,6 +63,8 @@ PSD_RULES_BUILD_PATH="skills/psd-rules/SKILL.md"
 OPENCLAW_BASE_IMAGE=""
 BEDROCK_PLUGIN_VERSION=""
 BEDROCK_PLUGIN_ASSERTION=""
+PARALLEL_PLUGIN_VERSION=""
+PARALLEL_PLUGIN_ENDPOINT=""
 CID=""
 
 cleanup_build() {
@@ -116,6 +118,8 @@ if [ -n "${CANDIDATE_MANIFEST}" ]; then
   OPENCLAW_BASE_IMAGE="$(candidate_plan_value baseImage)"
   BEDROCK_PLUGIN_VERSION="$(candidate_plan_value bedrockPluginVersion)"
   BEDROCK_PLUGIN_ASSERTION="$(candidate_plan_value expectedPluginToken)"
+  PARALLEL_PLUGIN_VERSION="$(candidate_plan_value parallelPluginVersion)"
+  PARALLEL_PLUGIN_ENDPOINT="$(candidate_plan_value parallelPluginEndpoint)"
   CANDIDATE_METADATA="$(candidate_plan_value metadata)"
 fi
 
@@ -257,6 +261,8 @@ if [ -n "${CANDIDATE_ID}" ]; then
     --build-arg "OPENCLAW_BASE_IMAGE=${OPENCLAW_BASE_IMAGE}"
     --build-arg "BEDROCK_PLUGIN_VERSION=${BEDROCK_PLUGIN_VERSION}"
     --build-arg "BEDROCK_PLUGIN_ASSERTION=${BEDROCK_PLUGIN_ASSERTION}"
+    --build-arg "PARALLEL_PLUGIN_VERSION=${PARALLEL_PLUGIN_VERSION}"
+    --build-arg "PARALLEL_PLUGIN_ENDPOINT=${PARALLEL_PLUGIN_ENDPOINT}"
   )
 fi
 docker build "${DOCKER_BUILD_ARGS[@]}" "${SCRIPT_DIR}"

--- a/infra/agent-image/check_config_consistency.py
+++ b/infra/agent-image/check_config_consistency.py
@@ -2,7 +2,7 @@
 """
 Config self-consistency gate for the agent image (issue #1161).
 
-Four static asserts over openclaw.json + the Dockerfile, run on the host before
+Five static asserts over openclaw.json + the Dockerfile, run on the host before
 build (no Docker):
 
   1. contextWindow sanity — every declared model's contextWindow must be a
@@ -30,6 +30,12 @@ build (no Docker):
      `npm pack`, which downloads a tarball and runs no install, so that peer
      requirement is enforced NOWHERE else in the build. This check is the only
      thing standing between a mismatched host/plugin pair and production.
+
+  5. web-search readiness — web_search must select the key-free
+     `parallel-free` provider, the pinned official plugin must be loaded and
+     enabled, and the build must assert its fixed Search MCP endpoint. Without
+     an explicit provider, OpenClaw still exposes the tool but every call fails
+     at runtime with "disabled or no provider available".
 
 Exit 0 when consistent, 1 on any violation.
 """
@@ -95,6 +101,21 @@ _PLUGIN_PACK_ARG_RE = re.compile(
     r'npm pack ["\']?@openclaw/amazon-bedrock-provider@'
     r'\$\{BEDROCK_PLUGIN_VERSION\}["\']?'
 )
+_PARALLEL_PLUGIN_PACK_RE = re.compile(
+    r"npm pack @openclaw/parallel-plugin@([0-9A-Za-z.\-]+)"
+)
+_PARALLEL_PLUGIN_VERSION_ARG_RE = re.compile(
+    r"^ARG\s+PARALLEL_PLUGIN_VERSION=([0-9A-Za-z.\-]+)\s*$", re.MULTILINE,
+)
+_PARALLEL_PLUGIN_PACK_ARG_RE = re.compile(
+    r'npm pack ["\']?@openclaw/parallel-plugin@'
+    r'\$\{PARALLEL_PLUGIN_VERSION\}["\']?'
+)
+_PARALLEL_PLUGIN_ENDPOINT = "https://search.parallel.ai/mcp"
+_PARALLEL_PLUGIN_ENDPOINT_ARG_RE = re.compile(
+    r"^ARG\s+PARALLEL_PLUGIN_ENDPOINT=(\S+)\s*$", re.MULTILINE,
+)
+_PARALLEL_PLUGIN_LOAD_PATH = "/opt/openclaw-plugins/parallel"
 
 # The base image is pinned by immutable digest, with the human-readable tag
 # recorded directly above it. Parsing both lets us cross-check them AND compare
@@ -214,6 +235,132 @@ def parse_pinned_plugin_version(dockerfile_path: str) -> Tuple[Optional[str], Li
     return version, violations
 
 
+def parse_pinned_parallel_plugin_version(
+    dockerfile_path: str,
+) -> Tuple[Optional[str], List[str]]:
+    """Read and validate the pinned @openclaw/parallel-plugin artifact."""
+
+    try:
+        with open(dockerfile_path, "r", encoding="utf-8") as fh:
+            source = fh.read()
+    except OSError as exc:
+        return None, [f"cannot read Dockerfile {dockerfile_path}: {exc}"]
+
+    matches = _PARALLEL_PLUGIN_PACK_RE.findall(source)
+    argument_match = _PARALLEL_PLUGIN_VERSION_ARG_RE.search(source)
+    if argument_match and _PARALLEL_PLUGIN_PACK_ARG_RE.search(source):
+        matches.append(argument_match.group(1))
+    if not matches:
+        return None, [
+            "Dockerfile has no `npm pack @openclaw/parallel-plugin@<version>` "
+            "line — web_search has no verified provider artifact"
+        ]
+    if len(set(matches)) > 1:
+        return None, [
+            "Dockerfile pins conflicting parallel-plugin versions: "
+            + ", ".join(sorted(set(matches)))
+        ]
+
+    version = matches[0]
+    violations: List[str] = []
+    literal_filename = f"openclaw-parallel-plugin-{version}.tgz"
+    parameter_filename = "openclaw-parallel-plugin-${PARALLEL_PLUGIN_VERSION}.tgz"
+    if (
+        source.count(literal_filename) < 2
+        and source.count(parameter_filename) < 2
+    ):
+        violations.append(
+            f"Dockerfile pins parallel-plugin {version} but its tar/rm filenames "
+            "do not both reference the same version parameter"
+        )
+
+    endpoint_match = _PARALLEL_PLUGIN_ENDPOINT_ARG_RE.search(source)
+    endpoint = endpoint_match.group(1) if endpoint_match else None
+    if endpoint != _PARALLEL_PLUGIN_ENDPOINT:
+        violations.append(
+            "Dockerfile must pin the parallel-free endpoint as "
+            f"{_PARALLEL_PLUGIN_ENDPOINT!r}; found {endpoint!r}"
+        )
+    endpoint_assertion = re.search(
+        r'grep\s+-RFq\s+--\s+"\$\{PARALLEL_PLUGIN_ENDPOINT\}"\s*\\?\s*'
+        r"/opt/openclaw-plugins/parallel/dist",
+        source,
+    )
+    if not endpoint_assertion:
+        violations.append(
+            "Dockerfile does not assert the published parallel-plugin contains "
+            f"the expected endpoint {_PARALLEL_PLUGIN_ENDPOINT}"
+        )
+    return version, violations
+
+
+def check_web_search_provider(config: dict, dockerfile_path: str) -> List[str]:
+    """Fail closed unless the image has a usable, explicitly selected provider."""
+
+    violations: List[str] = []
+    tools = config.get("tools") or {}
+    web = tools.get("web") if isinstance(tools, dict) else None
+    search = web.get("search") if isinstance(web, dict) else None
+    if not isinstance(search, dict):
+        return [
+            "tools.web.search is missing — web_search would be exposed without "
+            "a usable provider"
+        ]
+    if search.get("enabled") is not True:
+        violations.append("tools.web.search.enabled must be true")
+    if search.get("provider") != "parallel-free":
+        violations.append(
+            "tools.web.search.provider must explicitly select 'parallel-free'; "
+            "key-free providers are never auto-detected"
+        )
+    if "apiKey" in search:
+        violations.append(
+            "tools.web.search must not contain an apiKey for key-free "
+            "parallel-free"
+        )
+
+    plugins = config.get("plugins") or {}
+    load = plugins.get("load") if isinstance(plugins, dict) else None
+    paths = load.get("paths") if isinstance(load, dict) else None
+    if (
+        not isinstance(paths, list)
+        or _PARALLEL_PLUGIN_LOAD_PATH not in paths
+    ):
+        violations.append(
+            f"plugins.load.paths must include {_PARALLEL_PLUGIN_LOAD_PATH!r}"
+        )
+    entries = plugins.get("entries") if isinstance(plugins, dict) else None
+    parallel = entries.get("parallel") if isinstance(entries, dict) else None
+    if not isinstance(parallel, dict) or parallel.get("enabled") is not True:
+        violations.append("plugins.entries.parallel.enabled must be true")
+    elif "config" in parallel:
+        violations.append(
+            "plugins.entries.parallel must not carry API-key configuration for "
+            "the key-free provider"
+        )
+
+    pinned, pin_violations = parse_pinned_parallel_plugin_version(dockerfile_path)
+    violations.extend(pin_violations)
+    try:
+        with open(dockerfile_path, "r", encoding="utf-8") as fh:
+            source = fh.read()
+    except OSError as exc:
+        return violations + [f"cannot read Dockerfile {dockerfile_path}: {exc}"]
+
+    host_match = _HOST_TAG_RE.search(source)
+    if not host_match:
+        violations.append(
+            "cannot verify parallel-plugin compatibility because the OpenClaw "
+            "host tag comment is missing"
+        )
+    elif pinned and _version_key(host_match.group(1)) < _version_key(pinned):
+        violations.append(
+            f"OpenClaw base image {host_match.group(1)} is older than "
+            f"parallel-plugin {pinned}"
+        )
+    return violations
+
+
 def resolve_ghcr_digest(tag: str) -> Tuple[Optional[str], Optional[str]]:
     """Ask ghcr what digest a tag actually resolves to. Returns (digest, error)."""
     import urllib.error
@@ -246,26 +393,34 @@ def resolve_ghcr_digest(tag: str) -> Tuple[Optional[str], Optional[str]]:
         return None, f"ghcr lookup for {tag} failed: {str(exc)[:200]}"
 
 
-def resolve_plugin_peer_requirement(version: str) -> Tuple[Optional[str], Optional[str]]:
+def resolve_plugin_peer_requirement(
+    package_name: str,
+    version: str,
+) -> Tuple[Optional[str], Optional[str]]:
     """Read the plugin's PUBLISHED peerDependencies.openclaw. Returns (spec, error).
 
     Uses the npm registry HTTP API directly so the gate needs no npm binary.
     """
     import urllib.error
+    import urllib.parse
     import urllib.request
 
     url = (
         "https://registry.npmjs.org/"
-        f"@openclaw%2Famazon-bedrock-provider/{version}"
+        f"{urllib.parse.quote(package_name, safe='')}/{version}"
     )
     try:
         with urllib.request.urlopen(url, timeout=15) as resp:
             payload = json.loads(resp.read().decode("utf-8"))
     except (urllib.error.URLError, OSError, ValueError) as exc:
-        return None, f"npm lookup for plugin {version} failed: {str(exc)[:200]}"
+        return None, (
+            f"npm lookup for {package_name}@{version} failed: {str(exc)[:200]}"
+        )
     spec = (payload.get("peerDependencies") or {}).get("openclaw")
     if not isinstance(spec, str) or not spec:
-        return None, f"plugin {version} declares no peerDependencies.openclaw"
+        return None, (
+            f"{package_name}@{version} declares no peerDependencies.openclaw"
+        )
     return spec, None
 
 
@@ -304,7 +459,10 @@ def check_upstream_pins(dockerfile_path: str) -> List[str]:
     host_argument_match = _HOST_IMAGE_ARG_RE.search(source)
     if not from_match and host_argument_match and _HOST_FROM_ARG_RE.search(source):
         from_match = host_argument_match
-    plugin_version, _ = parse_pinned_plugin_version(dockerfile_path)
+    bedrock_plugin_version, _ = parse_pinned_plugin_version(dockerfile_path)
+    parallel_plugin_version, _ = parse_pinned_parallel_plugin_version(
+        dockerfile_path
+    )
     if not tag_match or not from_match:
         return ["cannot verify upstream pins — Dockerfile tag/FROM lines unreadable"]
 
@@ -321,22 +479,31 @@ def check_upstream_pins(dockerfile_path: str) -> List[str]:
             f"version"
         )
 
-    if plugin_version:
-        spec, error = resolve_plugin_peer_requirement(plugin_version)
+    plugin_versions = (
+        ("@openclaw/amazon-bedrock-provider", bedrock_plugin_version),
+        ("@openclaw/parallel-plugin", parallel_plugin_version),
+    )
+    for package_name, plugin_version in plugin_versions:
+        if not plugin_version:
+            continue
+        spec, error = resolve_plugin_peer_requirement(
+            package_name,
+            plugin_version,
+        )
         if error:
             violations.append(error)
         else:
             minimum = re.match(r"^>=\s*([0-9A-Za-z.\-]+)$", spec.strip())
             if not minimum:
                 violations.append(
-                    f"plugin {plugin_version} declares peerDependencies.openclaw="
-                    f"{spec!r}, which this gate cannot interpret — check it by hand "
-                    f"against host {host_tag}"
+                    f"{package_name}@{plugin_version} declares "
+                    f"peerDependencies.openclaw={spec!r}, which this gate cannot "
+                    f"interpret — check it by hand against host {host_tag}"
                 )
             elif _version_key(host_tag) < _version_key(minimum.group(1)):
                 violations.append(
                     f"OpenClaw host {host_tag} does not satisfy the PUBLISHED "
-                    f"requirement of plugin {plugin_version} "
+                    f"requirement of {package_name}@{plugin_version} "
                     f"(peerDependencies.openclaw={spec!r})"
                 )
     return violations
@@ -571,6 +738,7 @@ def run_checks(
         + check_apikey_hydration(config, wrapper_path)
         + check_prompt_caching_reachable(config, dockerfile_path)
         + check_host_plugin_compatibility(dockerfile_path)
+        + check_web_search_provider(config, dockerfile_path)
     )
     if verify_upstream:
         violations += check_upstream_pins(dockerfile_path)
@@ -614,7 +782,8 @@ def main(argv: Optional[List[str]] = None) -> int:
 
     print(
         "OK — openclaw.json context windows + apiKey hydration paths + "
-        "prompt-caching reachability + host/plugin compatibility consistent."
+        "prompt-caching reachability + host/plugin compatibility + web-search "
+        "provider readiness consistent."
     )
     return 0
 

--- a/infra/agent-image/eval/README.md
+++ b/infra/agent-image/eval/README.md
@@ -371,7 +371,7 @@ Run the path-filtered/scheduled upstream release comparison locally with:
 python3 infra/agent-image/check_eval_coverage.py --verify-upstream
 ```
 
-The regression and capability manifests contain 50 tasks total. At least 25%
+The regression and capability manifests contain 51 tasks total. At least 25%
 are explicit negative cases: they prove that a route or side effect is not
 used, rather than treating non-invocation as an unobserved success.
 
@@ -383,7 +383,7 @@ Use the lowest hermeticity level that exercises the real skill boundary:
 |---|---|---|
 | L0 | No external network or live service | Local renderers/converters, bundled references, offline self-checks, and policy/clarification tasks |
 | L1 | All service traffic crosses the loopback broker and is fixture-backed or asserted absent | AI Studio, Atrium reads, Canva reads, credentials, data MCP, directory, email triage, Freshservice, GitHub, Plaud, schedules, skills catalog, workflow gateway, Workspace |
-| L2 | A required provider, AWS API, or out-of-band upload cannot be represented by the broker fixture contract | QuickChart, failure-report CloudWatch emission, HyperFrames Lambda, positive image generation/upload, keyless web research, records-safe model summarization, Polly/audio upload |
+| L2 | A required provider, AWS API, or out-of-band upload cannot be represented by the broker fixture contract | Native `web_search`, QuickChart, failure-report CloudWatch emission, HyperFrames Lambda, positive image generation/upload, keyless web research, records-safe model summarization, Polly/audio upload |
 
 Some skills support more than one level. `psd-html-artifact` is L0 when its
 `--audit-only` gate is evaluated, but a delivery task is L2 because the
@@ -413,6 +413,8 @@ The workflow uses `canary@build-gate.invalid`, the existing RFC 2606 disposable
 owner identity. Every live prompt is labeled `EVAL-1426` or synthetic. The
 subset is intentionally small:
 
+- native `web_search` verifies the configured key-free provider returns cited
+  results instead of a provider-unavailable error;
 - QuickChart and recent-source research use synthetic/public inputs;
 - summarization uses fabricated PII to verify exclusion;
 - TTS uploads only the phrase `EVAL 1426 synthetic audio canary`.

--- a/infra/agent-image/eval/candidates/README.md
+++ b/infra/agent-image/eval/candidates/README.md
@@ -43,10 +43,10 @@ rejects zero changes, an undeclared change, or changes to two or more axes.
   cost, cost sources, and IAM. The context budget may not exceed the selected
   model's documented context window.
 - `harness` pins the immutable OpenClaw base digest, human-readable host
-  version, Bedrock plugin version, and the token that must exist in the
-  vendored plugin. The generated pin contract is passed through
-  `check_config_consistency.py`; `npm pack` and both tarball references share
-  the same build argument.
+  version, Bedrock plugin version/assertion, and Parallel plugin
+  version/endpoint. The generated pin contract is passed through
+  `check_config_consistency.py`; each `npm pack` and its tarball references
+  share the same build argument.
 - `prompt` selects the SOUL preamble and rules skill. The candidate versions
   are passed as Docker build inputs and checked against the materialized
   config's bootstrap budgets.
@@ -140,8 +140,8 @@ The finalized JSON sidecar records:
 
 - candidate and baseline IDs, the varied axis, and both sides of that delta;
 - model ID, provider name/path/API/auth/base URL, and cache retention;
-- immutable base image, host/plugin pins, plugin assertion token, prompt
-  variant and source paths;
+- immutable base image, host/plugin pins, Bedrock assertion token, Parallel
+  endpoint, prompt variant, and source paths;
 - model costs, a source URL for every cost, complete provider source/IAM
   metadata, manifest SHA-256, and AI Studio source commit;
 - pushed ECR tag, immutable image digest, preparation time, and finalization

--- a/infra/agent-image/eval/candidates/candidate.py
+++ b/infra/agent-image/eval/candidates/candidate.py
@@ -68,6 +68,7 @@ IMAGE_RE = re.compile(
 )
 DIGEST_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
 SOURCE_COMMIT_RE = re.compile(r"^[0-9a-f]{40}$")
+PARALLEL_PLUGIN_ENDPOINT = "https://search.parallel.ai/mcp"
 
 
 def _utc_now() -> str:
@@ -427,17 +428,20 @@ def _compose_config(template: dict[str, object]) -> dict[str, object]:
 
 def _validate_harness(
     axis: object, label: str
-) -> tuple[str, str, str, str]:
+) -> tuple[str, str, str, str, str, str]:
     harness = _mapping(axis, label)
     if set(harness) != {
         "baseImage",
         "hostVersion",
         "bedrockPluginVersion",
         "expectedPluginToken",
+        "parallelPluginVersion",
+        "parallelPluginEndpoint",
     }:
         raise CandidateError(
             f"{label} must define baseImage, hostVersion, "
-            "bedrockPluginVersion, and expectedPluginToken"
+            "bedrockPluginVersion, expectedPluginToken, "
+            "parallelPluginVersion, and parallelPluginEndpoint"
         )
     base_image = _string(harness.get("baseImage"), f"{label}.baseImage")
     host_version = _string(harness.get("hostVersion"), f"{label}.hostVersion")
@@ -447,13 +451,37 @@ def _validate_harness(
     expected_token = _string(
         harness.get("expectedPluginToken"), f"{label}.expectedPluginToken"
     )
+    parallel_plugin_version = _string(
+        harness.get("parallelPluginVersion"),
+        f"{label}.parallelPluginVersion",
+    )
+    parallel_plugin_endpoint = _string(
+        harness.get("parallelPluginEndpoint"),
+        f"{label}.parallelPluginEndpoint",
+    )
     if not IMAGE_RE.fullmatch(base_image):
         raise CandidateError(f"{label}.baseImage must be an immutable OpenClaw digest")
-    if not PIN_RE.fullmatch(host_version) or not PIN_RE.fullmatch(plugin_version):
+    if (
+        not PIN_RE.fullmatch(host_version)
+        or not PIN_RE.fullmatch(plugin_version)
+        or not PIN_RE.fullmatch(parallel_plugin_version)
+    ):
         raise CandidateError(f"{label}: host/plugin versions are malformed")
     if not re.fullmatch(r"^[0-9A-Za-z._:-]+$", expected_token):
         raise CandidateError(f"{label}.expectedPluginToken is malformed")
-    return base_image, host_version, plugin_version, expected_token
+    if parallel_plugin_endpoint != PARALLEL_PLUGIN_ENDPOINT:
+        raise CandidateError(
+            f"{label}.parallelPluginEndpoint must be "
+            f"{PARALLEL_PLUGIN_ENDPOINT!r}"
+        )
+    return (
+        base_image,
+        host_version,
+        plugin_version,
+        expected_token,
+        parallel_plugin_version,
+        parallel_plugin_endpoint,
+    )
 
 
 def _validate_prompt(axis: object, label: str) -> tuple[str, Path, Path]:
@@ -564,6 +592,8 @@ def _render_pin_contract(
     host_version: str,
     plugin_version: str,
     expected_token: str,
+    parallel_plugin_version: str,
+    parallel_plugin_endpoint: str,
 ) -> str:
     source = CANONICAL_DOCKERFILE.read_text(encoding="utf-8")
     base_digest = base_image.rsplit("@", 1)[1]
@@ -588,6 +618,14 @@ def _render_pin_contract(
             r"^ARG BEDROCK_PLUGIN_ASSERTION=.*$",
             f"ARG BEDROCK_PLUGIN_ASSERTION={expected_token}",
         ),
+        (
+            r"^ARG PARALLEL_PLUGIN_VERSION=.*$",
+            f"ARG PARALLEL_PLUGIN_VERSION={parallel_plugin_version}",
+        ),
+        (
+            r"^ARG PARALLEL_PLUGIN_ENDPOINT=.*$",
+            f"ARG PARALLEL_PLUGIN_ENDPOINT={parallel_plugin_endpoint}",
+        ),
     )
     for pattern, replacement in replacements:
         source, count = re.subn(pattern, replacement, source, count=1, flags=re.MULTILINE)
@@ -611,9 +649,14 @@ def prepare(manifest_path: Path, output_dir: Path, source_commit: str) -> dict[s
     candidate_id = _string(manifest["_resolvedId"], "candidate id")
     baseline_id = _string(baseline["_resolvedId"], "baseline id")
     declared_axis = _string(manifest.get("declaredAxis"), "declaredAxis")
-    base_image, host_version, plugin_version, expected_token = _validate_harness(
-        axes["harness"], "axes.harness"
-    )
+    (
+        base_image,
+        host_version,
+        plugin_version,
+        expected_token,
+        parallel_plugin_version,
+        parallel_plugin_endpoint,
+    ) = _validate_harness(axes["harness"], "axes.harness")
     prompt_variant, soul_path, rules_path = _validate_prompt(
         axes["prompt"], "axes.prompt"
     )
@@ -631,7 +674,12 @@ def prepare(manifest_path: Path, output_dir: Path, source_commit: str) -> dict[s
     _atomic_json(config_path, _compose_config(template))
     dockerfile_path.write_text(
         _render_pin_contract(
-            base_image, host_version, plugin_version, expected_token
+            base_image,
+            host_version,
+            plugin_version,
+            expected_token,
+            parallel_plugin_version,
+            parallel_plugin_endpoint,
         ),
         encoding="utf-8",
     )
@@ -667,6 +715,8 @@ def prepare(manifest_path: Path, output_dir: Path, source_commit: str) -> dict[s
             "hostVersion": host_version,
             "bedrockPluginVersion": plugin_version,
             "expectedPluginToken": expected_token,
+            "parallelPluginVersion": parallel_plugin_version,
+            "parallelPluginEndpoint": parallel_plugin_endpoint,
         },
         "prompt": {
             "variant": prompt_variant,
@@ -702,6 +752,8 @@ def prepare(manifest_path: Path, output_dir: Path, source_commit: str) -> dict[s
         "baseImage": base_image,
         "bedrockPluginVersion": plugin_version,
         "expectedPluginToken": expected_token,
+        "parallelPluginVersion": parallel_plugin_version,
+        "parallelPluginEndpoint": parallel_plugin_endpoint,
         "metadata": str(metadata_path),
     }
     _atomic_json(output_dir / "plan.json", plan)

--- a/infra/agent-image/eval/candidates/manifests/baseline.json
+++ b/infra/agent-image/eval/candidates/manifests/baseline.json
@@ -11,7 +11,9 @@
       "baseImage": "ghcr.io/openclaw/openclaw@sha256:6a31d44b2944e7adcd2b582bf6fb463111264ebca97a0201795b799135bd102c",
       "hostVersion": "2026.7.1",
       "bedrockPluginVersion": "2026.7.1",
-      "expectedPluginToken": "claude-sonnet-5"
+      "expectedPluginToken": "claude-sonnet-5",
+      "parallelPluginVersion": "2026.7.1",
+      "parallelPluginEndpoint": "https://search.parallel.ai/mcp"
     },
     "prompt": {
       "variant": "default",

--- a/infra/agent-image/eval/candidates/manifests/glm-5-mantle-openai.json
+++ b/infra/agent-image/eval/candidates/manifests/glm-5-mantle-openai.json
@@ -11,7 +11,9 @@
       "baseImage": "ghcr.io/openclaw/openclaw@sha256:6a31d44b2944e7adcd2b582bf6fb463111264ebca97a0201795b799135bd102c",
       "hostVersion": "2026.7.1",
       "bedrockPluginVersion": "2026.7.1",
-      "expectedPluginToken": "claude-sonnet-5"
+      "expectedPluginToken": "claude-sonnet-5",
+      "parallelPluginVersion": "2026.7.1",
+      "parallelPluginEndpoint": "https://search.parallel.ai/mcp"
     },
     "prompt": {
       "variant": "default",

--- a/infra/agent-image/eval/candidates/manifests/glm-5-native.json
+++ b/infra/agent-image/eval/candidates/manifests/glm-5-native.json
@@ -11,7 +11,9 @@
       "baseImage": "ghcr.io/openclaw/openclaw@sha256:6a31d44b2944e7adcd2b582bf6fb463111264ebca97a0201795b799135bd102c",
       "hostVersion": "2026.7.1",
       "bedrockPluginVersion": "2026.7.1",
-      "expectedPluginToken": "claude-sonnet-5"
+      "expectedPluginToken": "claude-sonnet-5",
+      "parallelPluginVersion": "2026.7.1",
+      "parallelPluginEndpoint": "https://search.parallel.ai/mcp"
     },
     "prompt": {
       "variant": "default",

--- a/infra/agent-image/eval/candidates/manifests/kimi-k2-5.json
+++ b/infra/agent-image/eval/candidates/manifests/kimi-k2-5.json
@@ -11,7 +11,9 @@
       "baseImage": "ghcr.io/openclaw/openclaw@sha256:6a31d44b2944e7adcd2b582bf6fb463111264ebca97a0201795b799135bd102c",
       "hostVersion": "2026.7.1",
       "bedrockPluginVersion": "2026.7.1",
-      "expectedPluginToken": "claude-sonnet-5"
+      "expectedPluginToken": "claude-sonnet-5",
+      "parallelPluginVersion": "2026.7.1",
+      "parallelPluginEndpoint": "https://search.parallel.ai/mcp"
     },
     "prompt": {
       "variant": "default",

--- a/infra/agent-image/eval/candidates/manifests/openai-gpt-oss-120b.json
+++ b/infra/agent-image/eval/candidates/manifests/openai-gpt-oss-120b.json
@@ -11,7 +11,9 @@
       "baseImage": "ghcr.io/openclaw/openclaw@sha256:6a31d44b2944e7adcd2b582bf6fb463111264ebca97a0201795b799135bd102c",
       "hostVersion": "2026.7.1",
       "bedrockPluginVersion": "2026.7.1",
-      "expectedPluginToken": "claude-sonnet-5"
+      "expectedPluginToken": "claude-sonnet-5",
+      "parallelPluginVersion": "2026.7.1",
+      "parallelPluginEndpoint": "https://search.parallel.ai/mcp"
     },
     "prompt": {
       "variant": "default",

--- a/infra/agent-image/eval/candidates/manifests/qwen3-coder-next.json
+++ b/infra/agent-image/eval/candidates/manifests/qwen3-coder-next.json
@@ -11,7 +11,9 @@
       "baseImage": "ghcr.io/openclaw/openclaw@sha256:6a31d44b2944e7adcd2b582bf6fb463111264ebca97a0201795b799135bd102c",
       "hostVersion": "2026.7.1",
       "bedrockPluginVersion": "2026.7.1",
-      "expectedPluginToken": "claude-sonnet-5"
+      "expectedPluginToken": "claude-sonnet-5",
+      "parallelPluginVersion": "2026.7.1",
+      "parallelPluginEndpoint": "https://search.parallel.ai/mcp"
     },
     "prompt": {
       "variant": "default",

--- a/infra/agent-image/eval/candidates/manifests/sonnet-5-mantle-anthropic.json
+++ b/infra/agent-image/eval/candidates/manifests/sonnet-5-mantle-anthropic.json
@@ -11,7 +11,9 @@
       "baseImage": "ghcr.io/openclaw/openclaw@sha256:6a31d44b2944e7adcd2b582bf6fb463111264ebca97a0201795b799135bd102c",
       "hostVersion": "2026.7.1",
       "bedrockPluginVersion": "2026.7.1",
-      "expectedPluginToken": "claude-sonnet-5"
+      "expectedPluginToken": "claude-sonnet-5",
+      "parallelPluginVersion": "2026.7.1",
+      "parallelPluginEndpoint": "https://search.parallel.ai/mcp"
     },
     "prompt": {
       "variant": "default",

--- a/infra/agent-image/eval/suites/l2-live.yaml
+++ b/infra/agent-image/eval/suites/l2-live.yaml
@@ -3,9 +3,12 @@
 # known dev defect lands. TTS gates the fixed-operation credential boundary
 # from #1442. HyperFrames shares that boundary and is omitted from the weekly
 # subset to avoid a duplicate live render.
+# Native web search exercises the key-free provider configured in the agent
+# image and must return a cited result instead of a provider-unavailable error.
 # Failure reporting remains in the regression suite but requires a @psd401.net
 # actor for attribution, so the RFC 2606 canary owner cannot exercise it live.
 tasks:
+  - tasks/web-search-available.yaml
   - ../../skills/chat-chart/evals/synthetic-bar-chart.yaml
   - ../../skills/psd-last30days/evals/keyless-eval-reliability-brief.yaml
   - ../../skills/psd-summarize/evals/records-safe-projector-summary.yaml

--- a/infra/agent-image/eval/suites/regression.yaml
+++ b/infra/agent-image/eval/suites/regression.yaml
@@ -1,5 +1,6 @@
 # Stable contracts expected to remain at or near 100% pass^3.
 tasks:
+  - tasks/web-search-available.yaml
   - ../../skills/chat-chart/evals/synthetic-bar-chart.yaml
   - ../../skills/chat-card/evals/ticket-confirmation.yaml
   - ../../skills/chat-card/evals/single-sentence-plain-text.yaml

--- a/infra/agent-image/eval/suites/tasks/web-search-available.yaml
+++ b/infra/agent-image/eval/suites/tasks/web-search-available.yaml
@@ -1,0 +1,11 @@
+id: web-search-available
+skill: runner-core
+level: L2
+workspace: pure
+suite: regression
+prompt: "Use web_search to find current information from the Washington Office of Superintendent of Public Instruction about career and technical student organizations (CTSOs). Summarize one current fact and include at least one source URL."
+trials: 3
+graders:
+  - {"type":"tool_call_succeeded","tool":"web_search","args_pattern":"(?i)(Washington|OSPI|career|technical|CTSO)"}
+  - {"type":"output_match","pattern":"(?i)CTSO|career and technical student organization"}
+  - {"type":"output_match","pattern":"https?://"}

--- a/infra/agent-image/openclaw.json
+++ b/infra/agent-image/openclaw.json
@@ -55,6 +55,15 @@
     "codeMode": {
       "timeoutMs": 60000
     },
+    "web": {
+      "search": {
+        "enabled": true,
+        "provider": "parallel-free",
+        "maxResults": 5,
+        "timeoutSeconds": 30,
+        "cacheTtlMinutes": 15
+      }
+    },
     "deny": ["cron", "nodes", "gateway"]
   },
   "skills": {
@@ -68,7 +77,10 @@
   },
   "plugins": {
     "load": {
-      "paths": ["/opt/openclaw-plugins/amazon-bedrock"]
+      "paths": [
+        "/opt/openclaw-plugins/amazon-bedrock",
+        "/opt/openclaw-plugins/parallel"
+      ]
     },
     "entries": {
       "active-memory": {
@@ -81,6 +93,9 @@
             "enabled": false
           }
         }
+      },
+      "parallel": {
+        "enabled": true
       }
     }
   },

--- a/infra/agent-image/test_candidate_matrix.py
+++ b/infra/agent-image/test_candidate_matrix.py
@@ -104,6 +104,14 @@ class CandidateMatrixTests(unittest.TestCase):
             self.assertEqual(metadata["modelId"], "zai.glm-5")
             self.assertEqual(metadata["cacheRetention"], "none")
             self.assertEqual(metadata["contextTokens"], 180000)
+            self.assertEqual(
+                metadata["harness"]["parallelPluginVersion"],
+                "2026.7.1",
+            )
+            self.assertEqual(
+                metadata["harness"]["parallelPluginEndpoint"],
+                "https://search.parallel.ai/mcp",
+            )
             self.assertIsNone(metadata["imageDigest"])
             self.assertEqual(set(metadata["cost"]), set(metadata["costSources"]))
 
@@ -219,6 +227,65 @@ class CandidateMatrixTests(unittest.TestCase):
                 summary = candidate.validate(temporary_manifest)
 
                 self.assertEqual(summary["variedAxis"], declared_axis)
+
+    def test_harness_candidate_threads_parallel_plugin_contract(self):
+        baseline = json.loads(
+            (self.manifests_dir / "baseline.json").read_text(encoding="utf-8")
+        )
+        with tempfile.TemporaryDirectory(
+            dir=self.manifests_dir.parent, prefix=".candidate-contract-test."
+        ) as manifest_directory, tempfile.TemporaryDirectory(
+            dir=HERE, prefix=".candidate-test."
+        ) as output_directory:
+            source = json.loads(json.dumps(baseline))
+            source["id"] = "future-harness"
+            source["baseline"] = "../manifests/baseline.json"
+            source["declaredAxis"] = "harness"
+            source["axes"]["model"]["providerTemplate"] = (
+                "../providers/native-bedrock-sonnet-5.json"
+            )
+            source["axes"]["harness"].update(
+                {
+                    "baseImage": "ghcr.io/openclaw/openclaw@sha256:" + "f" * 64,
+                    "hostVersion": "2026.7.2",
+                    "parallelPluginVersion": "2026.7.2",
+                }
+            )
+            manifest_path = Path(manifest_directory) / "candidate.json"
+            manifest_path.write_text(json.dumps(source), encoding="utf-8")
+
+            plan = candidate.prepare(
+                manifest_path,
+                Path(output_directory),
+                "e" * 40,
+            )
+
+            rendered = Path(plan["dockerfile"]).read_text(encoding="utf-8")
+            self.assertIn("ARG PARALLEL_PLUGIN_VERSION=2026.7.2", rendered)
+            self.assertIn(
+                "ARG PARALLEL_PLUGIN_ENDPOINT=https://search.parallel.ai/mcp",
+                rendered,
+            )
+            self.assertEqual(plan["parallelPluginVersion"], "2026.7.2")
+            self.assertEqual(
+                plan["parallelPluginEndpoint"],
+                "https://search.parallel.ai/mcp",
+            )
+            metadata = json.loads(
+                Path(plan["metadata"]).read_text(encoding="utf-8")
+            )
+            self.assertEqual(
+                metadata["harness"]["parallelPluginVersion"],
+                "2026.7.2",
+            )
+            self.assertEqual(
+                consistency.run_checks(
+                    str(Path(output_directory) / "openclaw.json"),
+                    str(HERE / "agentcore_wrapper.py"),
+                    str(plan["dockerfile"]),
+                )[0],
+                [],
+            )
 
     def test_rejects_prompt_axis_without_materialized_byte_change(self):
         baseline = json.loads(
@@ -353,6 +420,11 @@ class CandidateMatrixTests(unittest.TestCase):
         self.assertIn(
             "ARG BEDROCK_PLUGIN_ASSERTION=claude-sonnet-5", dockerfile
         )
+        self.assertIn("ARG PARALLEL_PLUGIN_VERSION=2026.7.1", dockerfile)
+        self.assertIn(
+            "ARG PARALLEL_PLUGIN_ENDPOINT=https://search.parallel.ai/mcp",
+            dockerfile,
+        )
         self.assertIn(
             'grep -Fq -- "${BEDROCK_PLUGIN_ASSERTION}"', dockerfile
         )
@@ -365,6 +437,8 @@ class CandidateMatrixTests(unittest.TestCase):
             "OPENCLAW_BASE_IMAGE=",
             "BEDROCK_PLUGIN_VERSION=",
             "BEDROCK_PLUGIN_ASSERTION=",
+            "PARALLEL_PLUGIN_VERSION=",
+            "PARALLEL_PLUGIN_ENDPOINT=",
             "candidate.py\" finalize",
             '"grader":"output_match"',
         ):

--- a/infra/agent-image/test_check_config_consistency.py
+++ b/infra/agent-image/test_check_config_consistency.py
@@ -272,6 +272,126 @@ class PromptCachingReachabilityTests(unittest.TestCase):
         self.assertTrue(any("no `npm pack" in item for item in v))
 
 
+class WebSearchProviderTests(unittest.TestCase):
+    CONFIG = {
+        "tools": {
+            "web": {
+                "search": {
+                    "enabled": True,
+                    "provider": "parallel-free",
+                },
+            },
+        },
+        "plugins": {
+            "load": {
+                "paths": [
+                    "/opt/openclaw-plugins/amazon-bedrock",
+                    "/opt/openclaw-plugins/parallel",
+                ],
+            },
+            "entries": {
+                "parallel": {"enabled": True},
+            },
+        },
+    }
+
+    def _dockerfile(
+        self,
+        *,
+        host: str = "2026.7.1",
+        plugin: str = "2026.7.1",
+        endpoint: str = "https://search.parallel.ai/mcp",
+        assert_endpoint: bool = True,
+    ) -> str:
+        directory = tempfile.mkdtemp()
+        path = os.path.join(directory, "Dockerfile")
+        endpoint_assertion = (
+            '    grep -RFq -- "${PARALLEL_PLUGIN_ENDPOINT}" '
+            "/opt/openclaw-plugins/parallel/dist\n"
+            if assert_endpoint
+            else ""
+        )
+        with open(path, "w", encoding="utf-8") as fh:
+            fh.write(
+                f"#   ghcr.io/openclaw/openclaw:{host}\n"
+                f"#   index: {'sha256:' + '1' * 64}\n"
+                f"ARG PARALLEL_PLUGIN_VERSION={plugin}\n"
+                f"ARG PARALLEL_PLUGIN_ENDPOINT={endpoint}\n"
+                "RUN npm pack "
+                '"@openclaw/parallel-plugin@${PARALLEL_PLUGIN_VERSION}" && \\\n'
+                '    tar -xzf "openclaw-parallel-plugin-'
+                '${PARALLEL_PLUGIN_VERSION}.tgz" && \\\n'
+                '    rm "openclaw-parallel-plugin-'
+                '${PARALLEL_PLUGIN_VERSION}.tgz" && \\\n'
+                f"{endpoint_assertion}"
+            )
+        return path
+
+    def test_ready_key_free_provider_passes(self):
+        self.assertEqual(
+            ccc.check_web_search_provider(self.CONFIG, self._dockerfile()),
+            [],
+        )
+
+    def test_missing_search_config_fails_closed(self):
+        violations = ccc.check_web_search_provider({}, self._dockerfile())
+        self.assertEqual(len(violations), 1)
+        self.assertIn("tools.web.search is missing", violations[0])
+
+    def test_auto_detection_is_rejected_for_key_free_provider(self):
+        config = {
+            **self.CONFIG,
+            "tools": {"web": {"search": {"enabled": True}}},
+        }
+        violations = ccc.check_web_search_provider(config, self._dockerfile())
+        self.assertTrue(any("never auto-detected" in item for item in violations))
+
+    def test_key_configuration_is_rejected_for_key_free_provider(self):
+        config = {
+            **self.CONFIG,
+            "tools": {
+                "web": {
+                    "search": {
+                        "enabled": True,
+                        "provider": "parallel-free",
+                        "apiKey": "not-needed",
+                    },
+                },
+            },
+        }
+        violations = ccc.check_web_search_provider(config, self._dockerfile())
+        self.assertTrue(any("must not contain an apiKey" in item for item in violations))
+
+    def test_missing_plugin_load_path_is_rejected(self):
+        config = {
+            **self.CONFIG,
+            "plugins": {
+                "load": {"paths": ["/opt/openclaw-plugins/amazon-bedrock"]},
+                "entries": {"parallel": {"enabled": True}},
+            },
+        }
+        violations = ccc.check_web_search_provider(config, self._dockerfile())
+        self.assertTrue(any("plugins.load.paths" in item for item in violations))
+
+    def test_endpoint_drift_or_missing_build_assertion_is_rejected(self):
+        violations = ccc.check_web_search_provider(
+            self.CONFIG,
+            self._dockerfile(
+                endpoint="https://example.invalid/mcp",
+                assert_endpoint=False,
+            ),
+        )
+        self.assertTrue(any("must pin" in item for item in violations))
+        self.assertTrue(any("does not assert" in item for item in violations))
+
+    def test_plugin_newer_than_host_is_rejected(self):
+        violations = ccc.check_web_search_provider(
+            self.CONFIG,
+            self._dockerfile(host="2026.6.11"),
+        )
+        self.assertTrue(any("older than parallel-plugin" in item for item in violations))
+
+
 class HostPluginCompatibilityTests(unittest.TestCase):
     """`npm pack` never enforces peerDependencies — this gate is the only check.
 
@@ -377,6 +497,13 @@ class RealFilesTests(unittest.TestCase):
             ccc._version_key(version),
             ccc._version_key(ccc._CACHE_CAPABLE_PLUGIN_MIN["claude-sonnet-5"]),
         )
+
+    def test_repo_dockerfile_pins_the_web_search_plugin(self):
+        here = os.path.dirname(os.path.abspath(__file__))
+        version, violations = ccc.parse_pinned_parallel_plugin_version(
+            os.path.join(here, "Dockerfile"))
+        self.assertEqual(version, "2026.7.1")
+        self.assertEqual(violations, [])
 
 
 if __name__ == "__main__":

--- a/infra/agent-image/test_eval_runner.py
+++ b/infra/agent-image/test_eval_runner.py
@@ -137,7 +137,7 @@ class SuiteLoadingTests(unittest.TestCase):
             for task in suite_tasks
         ]
 
-        self.assertGreaterEqual(len(tasks), 50)
+        self.assertGreaterEqual(len(tasks), 51)
         self.assertEqual(len({task.id for task in tasks}), len(tasks))
         shipped_skills = {
             path.name
@@ -145,7 +145,13 @@ class SuiteLoadingTests(unittest.TestCase):
             if path.is_dir() and (path / "SKILL.md").is_file()
         }
         covered_skills = shipped_skills - {"psd-rules"}
-        self.assertEqual({task.skill for task in tasks}, covered_skills)
+        task_skills = {task.skill for task in tasks}
+        self.assertEqual(task_skills - {"runner-core"}, covered_skills)
+        self.assertIn(
+            "runner-core",
+            task_skills,
+            "platform-level runtime contracts belong to runner-core",
+        )
         self.assertEqual({task.trials for task in tasks}, {3})
         for suite, suite_tasks in tasks_by_suite.items():
             self.assertEqual({task.suite for task in suite_tasks}, {suite})
@@ -181,6 +187,14 @@ class SuiteLoadingTests(unittest.TestCase):
             path.resolve()
             for path in (AGENT_IMAGE_DIR / "skills").glob("*/evals/*.yaml")
         }
+        committed_task_paths.update(
+            path.resolve()
+            for path in (AGENT_IMAGE_DIR / "eval" / "suites" / "tasks").glob(
+                "*.yaml"
+            )
+            if runner._load_document(path).get("suite")
+            in {"regression", "capability"}
+        )
         self.assertEqual(suite_task_paths, committed_task_paths)
 
         negative_task_ids = {
@@ -458,7 +472,7 @@ class SuiteLoadingTests(unittest.TestCase):
             ),
         ]
 
-        self.assertEqual(len(l2_tasks), 4)
+        self.assertEqual(len(l2_tasks), 5)
         self.assertEqual({task.level for task in l2_tasks}, {"L2"})
         self.assertEqual({task.trials for task in l2_tasks}, {3})
         self.assertTrue(


### PR DESCRIPTION
## Description

Fixes the agent's exposed-but-unusable `web_search` tool by explicitly selecting OpenClaw's official key-free `parallel-free` provider and installing the matching pinned plugin in the agent image.

- pin and install `@openclaw/parallel-plugin@2026.7.1`
- fail closed on provider, plugin, endpoint, host compatibility, and complete-config drift
- add a three-trial live regression task to the regression and weekly L2 suites
- document the provider contract, release gate, and exact failure mode

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change
- [x] Documentation update
- [x] Infrastructure change (agent image only; no CDK resource/IAM changes)

## Acceptance Criteria

- [x] `web_search` has an explicitly selected usable provider
- [x] The provider requires no new API key or secret
- [x] Image build validates the complete plugin-aware OpenClaw configuration
- [x] The native tool returns current results with source URLs in three live trials
- [x] Provider and supply-chain drift fail before deployment

## Testing

- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run build`
- [x] `bun run test:ci` — 530 suites / 4,928 tests passed; repository skips only
- [x] `python3 -m unittest discover -s infra/agent-image -p 'test_*.py'` — 521 passed, 1 skipped
- [x] `python3 infra/agent-image/check_config_consistency.py --verify-upstream`
- [x] `python3 infra/agent-image/check_eval_coverage.py` — 30 covered, 45 explicit opt-outs
- [x] ARM64 `build-and-push.sh` static, plugin-aware config, boot, and signed canary gates
- [x] `web-search-available` live eval — pass^3 against immutable digest `sha256:9be433abf37c1a324bc53cf03b640fb2f51ed1237436b47662b33a8bb21a742c`
- [ ] Authenticated Playwright pre-push suite — isolated worktree has no `.env.local`/`AUTH_SECRET`; hook's documented one-push bypass used. No browser/UI behavior changed.

## Infrastructure / Risk

- No database migrations, API changes, new environment variables, IAM grants, or AWS resources.
- Runtime dependency is OpenClaw's official Parallel key-free provider at its fixed `https://search.parallel.ai/mcp` endpoint.
- Data handling: each explicit `web_search` query is sent to Parallel’s fixed third-party endpoint; the validation image was not deployed, so production rollout remains subject to the repository owner’s district data-sharing policy.
- The uniquely tagged validation image was pushed to dev ECR but was not deployed.

## Related Issues

Closes #1462


