### PR TITLE
fix(agent): recover aborted context-overflow turns

### DIFF
--- a/infra/agent-image/harness_adapter.py
+++ b/infra/agent-image/harness_adapter.py
@@ -1121,17 +1121,6 @@ class OpenClawAdapter(HarnessAdapter):
                             )
 
                         elif state == "aborted":
-                            # A delayed abort event from the defensive
-                            # pre-send chat.abort belongs to the old run. It
-                            # must not terminate the new chat we just started.
-                            event_run_id = payload.get("runId")
-                            if event_run_id and event_run_id != chat_id:
-                                logger.info(
-                                    "ignoring stale chat abort: run_id=%s current_run_id=%s",
-                                    str(event_run_id)[:100],
-                                    chat_id,
-                                )
-                                continue
                             chat_aborted = True
                             stop_reason = payload.get("stopReason")
                             if isinstance(stop_reason, str) and stop_reason:
@@ -1258,7 +1247,11 @@ class OpenClawAdapter(HarnessAdapter):
                 nudged=nudged,
             )
 
-        if chat_aborted:
+        # A lifecycle error is terminal unless OpenClaw subsequently emits a
+        # successful final event. Usually chat follows it with `aborted`, but
+        # preserve the real cause even if that channel event never arrives and
+        # the receive loop instead runs to its deadline.
+        if chat_aborted or (not got_final and last_lifecycle_error):
             if not response_text and agent_assistant_accum:
                 response_text = agent_assistant_accum
             error_message = (
@@ -1270,9 +1263,13 @@ class OpenClawAdapter(HarnessAdapter):
                 if last_lifecycle_error
                 else "OpenClawChatAborted"
             )
+            terminal_phase = (
+                "chat_aborted" if chat_aborted else "lifecycle_error"
+            )
             logger.error(
-                "chat aborted before final: error_class=%s stop_reason=%s "
-                "elapsed_s=%d deadline_s=%d event_counts=%s",
+                "chat failed before final: phase=%s error_class=%s "
+                "stop_reason=%s elapsed_s=%d deadline_s=%d event_counts=%s",
+                terminal_phase,
                 error_class,
                 abort_stop_reason or "unknown",
                 latency_ms // 1000,
@@ -1287,7 +1284,7 @@ class OpenClawAdapter(HarnessAdapter):
                 session_id=session_id,
                 model=observed_model or model_override,
                 context={
-                    "phase": "chat_aborted",
+                    "phase": terminal_phase,
                     "last_state": last_state,
                     "stop_reason": abort_stop_reason,
                     "elapsed_s": latency_ms // 1000,

--- a/infra/agent-image/harness_adapter.py
+++ b/infra/agent-image/harness_adapter.py
@@ -818,6 +818,14 @@ class OpenClawAdapter(HarnessAdapter):
                 last_state: Optional[str] = None
                 last_payload_sample: str = ""
                 raw_event_samples: list = []
+                # OpenClaw reports the real reason for an aborted chat on the
+                # agent lifecycle stream before the chat channel emits only
+                # `{state: "aborted", stopReason: "stop"}`. Preserve the
+                # lifecycle error so an overflow is not mislabeled as a turn
+                # deadline (issue #1461).
+                last_lifecycle_error: Optional[str] = None
+                chat_aborted = False
+                abort_stop_reason: Optional[str] = None
                 # Accumulator for streaming assistant deltas that arrive via
                 # the agent event channel (OpenClaw >= 2026.4 routes streaming
                 # content through `event:agent` with stream="assistant"; the
@@ -914,6 +922,15 @@ class OpenClawAdapter(HarnessAdapter):
                                     tokens_in = max(tokens_in, ti)
                                 if isinstance(to, int):
                                     tokens_out = max(tokens_out, to)
+                        if stream == "lifecycle" and isinstance(data, dict):
+                            phase = data.get("phase")
+                            lifecycle_error = data.get("error")
+                            if (
+                                phase in {"error", "finishing"}
+                                and isinstance(lifecycle_error, str)
+                                and lifecycle_error.strip()
+                            ):
+                                last_lifecycle_error = lifecycle_error.strip()
                         if stream == "assistant" and isinstance(data, dict):
                             # OpenClaw protocol v4 streams assistant text as
                             # `deltaText` (the incremental piece) alongside
@@ -1104,6 +1121,21 @@ class OpenClawAdapter(HarnessAdapter):
                             )
 
                         elif state == "aborted":
+                            # A delayed abort event from the defensive
+                            # pre-send chat.abort belongs to the old run. It
+                            # must not terminate the new chat we just started.
+                            event_run_id = payload.get("runId")
+                            if event_run_id and event_run_id != chat_id:
+                                logger.info(
+                                    "ignoring stale chat abort: run_id=%s current_run_id=%s",
+                                    str(event_run_id)[:100],
+                                    chat_id,
+                                )
+                                continue
+                            chat_aborted = True
+                            stop_reason = payload.get("stopReason")
+                            if isinstance(stop_reason, str) and stop_reason:
+                                abort_stop_reason = stop_reason
                             logger.warning("chat aborted: payload=%s", json.dumps(payload)[:500])
                             break
 
@@ -1226,6 +1258,50 @@ class OpenClawAdapter(HarnessAdapter):
                 nudged=nudged,
             )
 
+        if chat_aborted:
+            if not response_text and agent_assistant_accum:
+                response_text = agent_assistant_accum
+            error_message = (
+                last_lifecycle_error
+                or f"chat aborted (stopReason={abort_stop_reason or 'unknown'})"
+            )
+            error_class = (
+                _classify_chat_error(last_lifecycle_error)
+                if last_lifecycle_error
+                else "OpenClawChatAborted"
+            )
+            logger.error(
+                "chat aborted before final: error_class=%s stop_reason=%s "
+                "elapsed_s=%d deadline_s=%d event_counts=%s",
+                error_class,
+                abort_stop_reason or "unknown",
+                latency_ms // 1000,
+                deadline_s,
+                json.dumps(event_counts),
+            )
+            record_failure(
+                source="harness",
+                severity="error",
+                error_class=error_class,
+                error_message=error_message,
+                session_id=session_id,
+                model=observed_model or model_override,
+                context={
+                    "phase": "chat_aborted",
+                    "last_state": last_state,
+                    "stop_reason": abort_stop_reason,
+                    "elapsed_s": latency_ms // 1000,
+                    "deadline_s": deadline_s,
+                    "event_counts": event_counts,
+                    "first_events": first_event_types,
+                },
+            )
+            return _result(
+                _frame_failed_partial(_format_for_chat(response_text.strip())),
+                failed=True,
+                error_class=error_class,
+            )
+
         if not got_final:
             if not response_text and agent_assistant_accum:
                 response_text = agent_assistant_accum
@@ -1255,6 +1331,8 @@ class OpenClawAdapter(HarnessAdapter):
                     context={
                         "phase": "deadline",
                         "last_state": last_state,
+                        "elapsed_s": latency_ms // 1000,
+                        "deadline_s": deadline_s,
                         "event_counts": event_counts,
                         "first_events": first_event_types,
                     },
@@ -1280,6 +1358,8 @@ class OpenClawAdapter(HarnessAdapter):
                 context={
                     "phase": "deadline",
                     "last_state": last_state,
+                    "elapsed_s": latency_ms // 1000,
+                    "deadline_s": deadline_s,
                     "event_counts": event_counts,
                     "first_events": first_event_types,
                 },

--- a/infra/agent-image/test_harness_adapter.py
+++ b/infra/agent-image/test_harness_adapter.py
@@ -292,8 +292,9 @@ class TestChatDeadlineRegression(unittest.TestCase):
     def _message(**fields):
         return json.dumps(fields)
 
-    def test_context_overflow_abort_is_not_recorded_as_deadline(self):
+    def _run_context_overflow(self, *, include_abort):
         chat_id = None
+        clock = [0.0]
 
         class FakeWebSocket:
             def __init__(self, messages):
@@ -326,7 +327,25 @@ class TestChatDeadlineRegression(unittest.TestCase):
                 payload={"runId": chat_id, **payload},
             )
 
-        socket = FakeWebSocket([
+        def lifecycle_error_event():
+            if not include_abort:
+                # Simulate the chat channel never following the terminal
+                # lifecycle error with its normal `state=aborted` event.
+                clock[0] = 601.0
+            return current_run_event(
+                "agent",
+                {
+                    "stream": "lifecycle",
+                    "data": {
+                        "phase": "error",
+                        "error": (
+                            "Context overflow: prompt too large for the model."
+                        ),
+                    },
+                },
+            )
+
+        messages = [
             self._message(type="event", event="connect.challenge", payload={}),
             lambda: self._message(
                 type="res",
@@ -359,23 +378,16 @@ class TestChatDeadlineRegression(unittest.TestCase):
                     "data": {"delta": "Working through the requested tools."},
                 },
             ),
-            lambda: current_run_event(
-                "agent",
-                {
-                    "stream": "lifecycle",
-                    "data": {
-                        "phase": "error",
-                        "error": (
-                            "Context overflow: prompt too large for the model."
-                        ),
-                    },
-                },
-            ),
-            lambda: current_run_event(
-                "chat",
-                {"state": "aborted", "stopReason": "stop"},
-            ),
-        ])
+            lifecycle_error_event,
+        ]
+        if include_abort:
+            messages.append(
+                lambda: current_run_event(
+                    "chat",
+                    {"state": "aborted", "stopReason": "stop"},
+                )
+            )
+        socket = FakeWebSocket(messages)
         fake_websocket_module = mock.Mock()
         fake_websocket_module.create_connection.return_value = socket
         fake_websocket_module.WebSocketTimeoutException = TimeoutError
@@ -402,6 +414,10 @@ class TestChatDeadlineRegression(unittest.TestCase):
             mock.patch(
                 "harness_adapter.record_failure",
             ) as record_failure,
+            mock.patch(
+                "harness_adapter.time.time",
+                side_effect=lambda: clock[0],
+            ),
         ):
             result = adapter.process(
                 "Run a complex multi-tool request",
@@ -409,10 +425,14 @@ class TestChatDeadlineRegression(unittest.TestCase):
                 deadline_s=600,
             )
 
+        return result, record_failure.call_args.kwargs
+
+    def test_context_overflow_abort_is_not_recorded_as_deadline(self):
+        result, failure = self._run_context_overflow(include_abort=True)
+
         self.assertTrue(result.failed)
         self.assertEqual(result.error_class, "ContextOverflow")
         self.assertIn("Working through", result.text)
-        failure = record_failure.call_args.kwargs
         self.assertEqual(failure["error_class"], "ContextOverflow")
         self.assertNotEqual(
             failure["error_class"],
@@ -421,6 +441,16 @@ class TestChatDeadlineRegression(unittest.TestCase):
         self.assertEqual(failure["context"]["phase"], "chat_aborted")
         self.assertEqual(failure["context"]["deadline_s"], 600)
         self.assertLess(failure["context"]["elapsed_s"], 600)
+
+    def test_lifecycle_overflow_without_abort_is_not_recorded_as_deadline(self):
+        result, failure = self._run_context_overflow(include_abort=False)
+
+        self.assertTrue(result.failed)
+        self.assertEqual(result.error_class, "ContextOverflow")
+        self.assertNotIn("deadline expired", failure["error_message"].lower())
+        self.assertEqual(failure["context"]["phase"], "lifecycle_error")
+        self.assertEqual(failure["context"]["deadline_s"], 600)
+        self.assertGreaterEqual(failure["context"]["elapsed_s"], 600)
 
 
 class TestRecordItemToolEvent(unittest.TestCase):

--- a/infra/agent-image/test_harness_adapter.py
+++ b/infra/agent-image/test_harness_adapter.py
@@ -285,6 +285,144 @@ class TestResolveDeadline(unittest.TestCase):
             self.assertEqual(self.resolve(None), 840)
 
 
+class TestChatDeadlineRegression(unittest.TestCase):
+    """Aborted OpenClaw runs must retain their real lifecycle cause (#1461)."""
+
+    @staticmethod
+    def _message(**fields):
+        return json.dumps(fields)
+
+    def test_context_overflow_abort_is_not_recorded_as_deadline(self):
+        chat_id = None
+
+        class FakeWebSocket:
+            def __init__(self, messages):
+                self.messages = list(messages)
+                self.sent = []
+
+            def send(self, payload):
+                nonlocal chat_id
+                parsed = json.loads(payload)
+                self.sent.append(parsed)
+                if parsed.get("method") == "chat.send":
+                    chat_id = parsed["id"]
+
+            def recv(self):
+                message = self.messages.pop(0)
+                if callable(message):
+                    return message()
+                return message
+
+            def settimeout(self, _timeout):
+                return None
+
+            def close(self):
+                return None
+
+        def current_run_event(event, payload):
+            return self._message(
+                type="event",
+                event=event,
+                payload={"runId": chat_id, **payload},
+            )
+
+        socket = FakeWebSocket([
+            self._message(type="event", event="connect.challenge", payload={}),
+            lambda: self._message(
+                type="res",
+                id=socket.sent[-1]["id"],
+                ok=True,
+                payload={},
+            ),
+            lambda: self._message(
+                type="res",
+                id=socket.sent[-1]["id"],
+                ok=True,
+                payload={"tools": []},
+            ),
+            lambda: self._message(
+                type="res",
+                id=socket.sent[-1]["id"],
+                ok=True,
+                payload={},
+            ),
+            lambda: self._message(
+                type="res",
+                id=chat_id,
+                ok=True,
+                payload={"runId": chat_id, "status": "started"},
+            ),
+            lambda: current_run_event(
+                "agent",
+                {
+                    "stream": "assistant",
+                    "data": {"delta": "Working through the requested tools."},
+                },
+            ),
+            lambda: current_run_event(
+                "agent",
+                {
+                    "stream": "lifecycle",
+                    "data": {
+                        "phase": "error",
+                        "error": (
+                            "Context overflow: prompt too large for the model."
+                        ),
+                    },
+                },
+            ),
+            lambda: current_run_event(
+                "chat",
+                {"state": "aborted", "stopReason": "stop"},
+            ),
+        ])
+        fake_websocket_module = mock.Mock()
+        fake_websocket_module.create_connection.return_value = socket
+        fake_websocket_module.WebSocketTimeoutException = TimeoutError
+
+        adapter = OpenClawAdapter()
+        adapter._ready = True
+        empty_usage = {
+            "input": 0,
+            "output": 0,
+            "cache_read": 0,
+            "cache_write": 0,
+            "model_calls": 0,
+        }
+        with (
+            mock.patch.dict(
+                sys.modules,
+                {"websocket": fake_websocket_module},
+            ),
+            mock.patch.object(
+                adapter,
+                "_read_turn_usage",
+                return_value=empty_usage,
+            ),
+            mock.patch(
+                "harness_adapter.record_failure",
+            ) as record_failure,
+        ):
+            result = adapter.process(
+                "Run a complex multi-tool request",
+                "session-1461",
+                deadline_s=600,
+            )
+
+        self.assertTrue(result.failed)
+        self.assertEqual(result.error_class, "ContextOverflow")
+        self.assertIn("Working through", result.text)
+        failure = record_failure.call_args.kwargs
+        self.assertEqual(failure["error_class"], "ContextOverflow")
+        self.assertNotEqual(
+            failure["error_class"],
+            "ChatDeadlineExpiredPartial",
+        )
+        self.assertEqual(failure["context"]["phase"], "chat_aborted")
+        self.assertEqual(failure["context"]["deadline_s"], 600)
+        self.assertLess(failure["context"]["elapsed_s"], 600)
+
+
 class TestRecordItemToolEvent(unittest.TestCase):
     """Native-mode tool items must land in tool_calls telemetry (#1138 r12)."""
 

--- a/infra/lambdas/agent-router/index.ts
+++ b/infra/lambdas/agent-router/index.ts
@@ -74,7 +74,8 @@ import {
 import {
   buildJobPayload,
   jobChatDeliveryContext,
-  shouldPromoteToJob,
+  promotionReason,
+  type PromotionReason,
 } from './job-promotion';
 import type { ScheduledRunWrite } from './scheduled-run-telemetry';
 import {
@@ -2090,6 +2091,7 @@ async function fetchChatUploads(
  * worse than the status quo.
  */
 interface JobPromotionInput {
+  reason: PromotionReason;
   sessionId: string;
   userEmail: string;
   googleIdentity: string;
@@ -2198,6 +2200,7 @@ async function promoteToJob(
 
   try {
     const payload = buildJobPayload({
+      reason: input.reason,
       sessionId: input.sessionId,
       lockToken: jobLockToken,
       runtimeId,
@@ -2229,6 +2232,7 @@ async function promoteToJob(
       // is a "platform compensating for model behavior" counter — its trend is
       // an input to Loop-2 instruction tuning, so it's a metric without an alarm.
       marker: 'BACKGROUND_PROMOTION',
+      reason: input.reason,
       sessionId: input.sessionId,
       taskArn: taskArn ?? 'unknown',
     });
@@ -4242,9 +4246,11 @@ interface OwnerTurnContext {
 function buildOwnerJobPromotionInput(
   human: HumanMessage,
   user: AgentUser,
-  turn: OwnerAgentTurn
+  turn: OwnerAgentTurn,
+  reason: PromotionReason
 ): JobPromotionInput {
   return {
+    reason,
     sessionId: turn.sessionId,
     userEmail: human.senderEmail,
     googleIdentity: human.senderName,
@@ -4266,12 +4272,14 @@ async function promoteOwnerTurn(
   log: ReturnType<typeof createLogger>
 ): Promise<boolean> {
   const { human, prepared, turn, startTime } = context;
-  if (!shouldPromoteToJob(turn.result.errorClass)) return false;
+  const reason = promotionReason(turn.result.errorClass);
+  if (!reason) return false;
   const promoted = await promoteToJob(
     buildOwnerJobPromotionInput(
       human,
       prepared.user,
-      turn
+      turn,
+      reason
     ),
     log
   );

--- a/infra/lambdas/agent-router/job-promotion.test.ts
+++ b/infra/lambdas/agent-router/job-promotion.test.ts
@@ -14,13 +14,16 @@ import {
   jobChatDeliveryContext,
   JOB_DEADLINE_S,
   parseJobPayload,
+  promotionReason,
+  resolveJobInvocation,
   shouldPromoteToJob,
 } from './job-promotion';
 
 describe('shouldPromoteToJob', () => {
-  test('deadline classes promote', () => {
+  test('recoverable deadline and overflow classes promote', () => {
     expect(shouldPromoteToJob('ChatDeadlineExpired')).toBe(true);
     expect(shouldPromoteToJob('ChatDeadlineExpiredPartial')).toBe(true);
+    expect(shouldPromoteToJob('ContextOverflow')).toBe(true);
   });
 
   test('real errors and clean turns do NOT promote', () => {
@@ -29,6 +32,14 @@ describe('shouldPromoteToJob', () => {
     expect(shouldPromoteToJob('AgentCoreHttpError_500')).toBe(false);
     expect(shouldPromoteToJob(undefined)).toBe(false);
     expect(shouldPromoteToJob('')).toBe(false);
+  });
+
+  test('distinguishes resume deadlines from fresh-session overflow', () => {
+    expect(promotionReason('ChatDeadlineExpired')).toBe('deadline');
+    expect(promotionReason('ChatDeadlineExpiredPartial')).toBe('deadline');
+    expect(promotionReason('ContextOverflow')).toBe('context-overflow');
+    expect(promotionReason('OpenClawChatError')).toBeNull();
+    expect(promotionReason(undefined)).toBeNull();
   });
 });
 
@@ -70,6 +81,31 @@ describe('buildJobPayload / parseJobPayload round-trip', () => {
       buildJobPayload({ ...BASE, responsePrefix: '[aside] ' })
     );
     expect(parsed.responsePrefix).toBe('[aside] ');
+  });
+
+  test('round-trips context-overflow as a fresh-session restart', () => {
+    const parsed = parseJobPayload(
+      buildJobPayload({ ...BASE, reason: 'context-overflow' })
+    );
+    expect(parsed.reason).toBe('context-overflow');
+
+    const invocation = resolveJobInvocation(parsed);
+    expect(invocation.restart).toBe(true);
+    expect(invocation.invokeSessionId).not.toBe(BASE.sessionId);
+    expect(invocation.prompt).toContain('[job-restart]');
+    expect(invocation.prompt).toContain(BASE.originalPrompt);
+  });
+
+  test('never truncates the original request for a fresh-session restart', () => {
+    const originalPrompt = 'x'.repeat(5_000);
+    const parsed = parseJobPayload(
+      buildJobPayload({
+        ...BASE,
+        reason: 'context-overflow',
+        originalPrompt,
+      })
+    );
+    expect(parsed.promptExcerpt).toBe(originalPrompt);
   });
 
   test('round-trips optional scheduled-run context', () => {

--- a/infra/lambdas/agent-router/job-promotion.ts
+++ b/infra/lambdas/agent-router/job-promotion.ts
@@ -2,10 +2,11 @@
  * Async-job promotion — pure logic (issue #1138, "the 14-minute wall").
  *
  * A multi-step agent turn that cannot finish inside the router Lambda's
- * ~14-minute window is promoted EXACTLY ONCE into a long-lived ECS Fargate
- * job-runner task, which re-invokes the SAME AgentCore session with a
- * continuation prompt and a 2-hour deadline (AgentCore invocations may run
- * up to 8h; the Lambda caller was the only 15-minute wall).
+ * ~14-minute window, or whose transcript overflows the model context, is
+ * promoted EXACTLY ONCE into a long-lived ECS Fargate job-runner task.
+ * Deadlines resume the same AgentCore session; overflow recovery starts a
+ * fresh session from the original request. Job invocations get a 2-hour
+ * ceiling (AgentCore itself may run up to 8h).
  *
  * This module holds the dependency-free pieces (promotion predicate, job
  * payload build/parse, continuation prompt) so they can be unit tested
@@ -19,24 +20,18 @@ const DEADLINE_ERROR_CLASSES = new Set([
 ]);
 
 /**
+ * Context overflow is also recoverable, but only in a fresh session. The
+ * harness assigns this class from OpenClaw's lifecycle error; generic chat
+ * failures remain intentionally unpromotable.
+ */
+const CONTEXT_OVERFLOW_ERROR_CLASS = 'ContextOverflow';
+
+/**
  * Job leg ceiling: 2 hours (approved 2026-07-07). Mirrors the harness clamp
  * in agent-image/harness_adapter.py (_resolve_deadline_s, max 7200).
  */
 export const JOB_DEADLINE_S = 7200;
 
-/** True when a failed turn should be promoted to a background job. */
-export function shouldPromoteToJob(errorClass: string | undefined): boolean {
-  return !!errorClass && DEADLINE_ERROR_CLASSES.has(errorClass);
-}
-
-/**
- * Everything the job-runner needs to resume and deliver the turn. Carried
- * as a single JSON env var on the RunTask container override — AWS caps the
- * total override payload at 8 KiB, hence the prompt excerpt truncation in
- * buildJobPayload (the session already holds the full original prompt in
- * its OpenClaw history; the excerpt is context garnish for the continuation
- * message, not the source of truth).
- */
 /**
  * Why a turn was promoted. Drives OPPOSITE handling in the runner:
  *
@@ -51,6 +46,33 @@ export function shouldPromoteToJob(errorClass: string | undefined): boolean {
  */
 export type PromotionReason = 'deadline' | 'context-overflow';
 
+/**
+ * Why this failed turn should be promoted, or null for a genuine fault.
+ *
+ * The reason must be resolved before building the job payload because the
+ * runner takes opposite recovery paths: deadlines resume; overflow restarts.
+ */
+export function promotionReason(
+  errorClass: string | undefined
+): PromotionReason | null {
+  if (!errorClass) return null;
+  if (DEADLINE_ERROR_CLASSES.has(errorClass)) return 'deadline';
+  if (errorClass === CONTEXT_OVERFLOW_ERROR_CLASS) return 'context-overflow';
+  return null;
+}
+
+/** True when a failed turn should be promoted to a background job. */
+export function shouldPromoteToJob(errorClass: string | undefined): boolean {
+  return promotionReason(errorClass) !== null;
+}
+
+/**
+ * Everything the job-runner needs to resume and deliver the turn. Carried as
+ * one JSON env var on the RunTask container override, which AWS caps at 8 KiB.
+ * Deadline continuations can truncate the prompt excerpt because the original
+ * request is already in session history. Overflow restarts must carry the
+ * complete request or fail promotion rather than silently execute half of it.
+ */
 export interface JobPayload {
   /** AgentCore session to resume (sticky-routes to the same microVM). */
   sessionId: string;

--- a/tests/unit/agent-cron-job-promotion.test.ts
+++ b/tests/unit/agent-cron-job-promotion.test.ts
@@ -91,12 +91,13 @@ const baseInput = {
       expect(buildFromCron(baseInput)).toBe(buildFromRouter(baseInput))
     })
 
-    it("agrees with the router on the deadline classes", () => {
+    it("agrees with the router on every recoverable class", () => {
       // Two copies of the same error-class set. If the router gains a class
       // and cron does not, scheduled tasks silently stop being promoted.
       for (const cls of [
         "ChatDeadlineExpired",
         "ChatDeadlineExpiredPartial",
+        "ContextOverflow",
         "OpenClawChatError",
         "SomeFutureError",
         "",
@@ -104,25 +105,6 @@ const baseInput = {
       ]) {
         expect(shouldPromoteFromCron(cls)).toBe(shouldPromoteFromRouter(cls))
       }
-    })
-
-    it("INTENTIONALLY diverges from the router on context overflow", () => {
-      // Pinned rather than omitted, because the test above exists to catch
-      // exactly this kind of drift and would otherwise be routed around.
-      //
-      // Scheduled tasks restart on overflow: nobody is watching, the request
-      // is fully described by the stored schedule prompt, and the alternative
-      // is a silent failure every morning.
-      //
-      // Interactive turns do NOT, deliberately. A restart discards the user's
-      // conversation, and they are right there — they can /reset or rephrase,
-      // and they can see that something went wrong. Silently throwing away a
-      // chat history to retry is worse than telling them it failed.
-      //
-      // If interactive restart is ever wanted, change the router AND this
-      // test together.
-      expect(shouldPromoteFromCron("ContextOverflow")).toBe(true)
-      expect(shouldPromoteFromRouter("ContextOverflow")).toBe(false)
     })
 
     it("truncates a CONTINUATION prompt and stays inside the 8 KiB cap", () => {


### PR DESCRIPTION
## Description

Production trace activity for failures #251 and #255 showed that neither turn reached the 840-second chat deadline:

- #251 ran for 292 seconds with 49 model calls and 48 tool calls.
- #255 ran for 152 seconds with 20 model calls and 19 tool calls.
- Both exceeded the model context budget, emitted an OpenClaw lifecycle error, and then ended with the generic chat event `{ state: "aborted", stopReason: "stop" }`.

The adapter previously discarded that lifecycle error, broke on `aborted`, and fell through the same path used by a real deadline. The router then promoted the already-overflowed session as a deadline continuation.

This change:

- preserves the lifecycle error and records a terminal turn with its real class (`ContextOverflow`) plus elapsed/deadline telemetry, whether or not the chat channel follows with `state=aborted`;
- keeps genuine deadline handling unchanged;
- promotes an interactive context-overflow turn once into the existing background-job path with a fresh derived session and the complete original request;
- keeps deadline promotions resuming the original session;
- aligns the interactive router and scheduled-task recovery contracts.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature which changes existing behavior unexpectedly)
- [ ] Documentation update
- [x] Infrastructure/runtime change

## Testing

- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run test:ci` — 530 suites passed, 1 skipped; 4,927 tests passed, 15 skipped
- [x] Full agent-image Python CI suite — 544 passed, 1 environment-specific UID test skipped on macOS
- [x] `infra/agent-image/test_harness_adapter.py` — 54 passed
- [x] `infra/lambdas/agent-router/job-promotion.test.ts` — 18 passed
- [x] `tests/unit/agent-cron-job-promotion.test.ts` — 33 passed
- [x] All agent-image skill/smoke suites from CI
- [x] `bun run build`
- [x] Production auth Edge artifact smoke
- [x] `cd infra && bun run build`
- [x] `cd infra && bunx cdk synth --all --no-lookups --context baseDomain=example.com`
- [x] Unified-content and embedding Lambda artifact smokes in Docker
- [x] OpenAPI, capability-manifest, and agent eval-coverage generated checks

Browser E2E is N/A: this is an internal OpenClaw WebSocket lifecycle and Lambda job-promotion path with no browser/UI entry point. The regression tests mock the complete gateway handshake, send, assistant stream, lifecycle error, and terminal sequences and assert that overflow is not recorded as `ChatDeadlineExpiredPartial`.

## Checklist

- [x] No new `console.*` calls or `any` types
- [x] Types/interfaces follow project conventions and strict mode passes
- [x] No database schema or migration changes
- [x] No environment-variable changes
- [x] No `/api/v1/` changes
- [x] No generated OpenWiki edits
- [x] Applicable documentation/comments updated
- [x] App and infrastructure builds complete without module errors

## Risk and rollback

The change is limited to classifying terminal adapter events and selecting the existing job runner's already-tested fresh-session mode for `ContextOverflow`. Unrecognized abort causes remain generic failures and are not promoted. Reverting these commits restores the previous deadline-only promotion behavior.

## Related Issues

Closes #1461
