### PR TITLE
feat(agent): add PSD conversation coaching skill

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,6 +166,14 @@ jobs:
       env:
         CI: true
 
+    # psd-conversation-coach (#1464). This knowledge skill is outside Jest's
+    # roots. Its Bun suite guards the single-line frontmatter fields consumed
+    # by the deploy-time parser and the summary phrases used by skills.search.
+    - name: Run psd-conversation-coach skill tests (Bun)
+      run: bun run test:skill:conversation-coach
+      env:
+        CI: true
+
     # psd-morning-brief (#1413). The three-stage CLI is plain CJS outside
     # Jest's roots. This suite pins signed-owner authority boundaries, modular
     # source omission, custom desks, private Atrium-only delivery, podcast

--- a/infra/agent-image/eval/suites/regression.yaml
+++ b/infra/agent-image/eval/suites/regression.yaml
@@ -8,6 +8,7 @@ tasks:
   - ../../skills/psd-atrium/evals/find-private-drafts.yaml
   - ../../skills/psd-brand-guidelines/evals/exact-core-colors.yaml
   - ../../skills/psd-canva/evals/list-designs.yaml
+  - ../../skills/psd-conversation-coach/evals/no-scenario-fallback.yaml
   - ../../skills/psd-credentials/evals/check-capability.yaml
   - ../../skills/psd-credentials/evals/refuse-secret-read.yaml
   - ../../skills/psd-data/evals/list-tables.yaml

--- a/infra/agent-image/skills/psd-conversation-coach/SKILL.md
+++ b/infra/agent-image/skills/psd-conversation-coach/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: psd-conversation-coach
+summary: Prepare for a crucial conversation or difficult conversation, practice through realistic role-play, and debrief with framework-named feedback.
+description: Coach Peninsula School District staff through preparing for, practicing, and debriefing difficult high-stakes conversations using the publicly documented Crucial Conversations framework. Use for feedback, parent meetings, peer conflict, coaching up, and other situations where opinions differ, emotions are strong, and stakes are high.
+allowed-tools: Read
+---
+
+# PSD Conversation Coach
+
+Help the user prepare for and practice one difficult conversation. Ground the
+coaching in the publicly documented *Crucial Conversations* framework while
+keeping the user's real goal, role, and context in control of the session.
+
+## Workflow
+
+### 1. Intake
+
+Ask only a few questions at a time. Establish:
+
+- who the user is speaking with and their working relationship;
+- what happened, including observable facts and any history;
+- what is at stake for the user, the other person, and the relationship; and
+- what the user really wants for themself, the other person, and the
+  relationship (**Start with Heart**).
+
+A user-supplied situation always takes precedence. Do not replace it with a
+canned example.
+
+If, and only if, the user has no specific conversation to practice, read
+`/opt/psd-skills/psd-conversation-coach/references/scenarios.md`. Offer three or
+four fictional PSD scenarios, ordered toward the user's role when known, and
+let the user choose. Do not start role-play until the user chooses.
+
+### 2. Ground
+
+Read `/opt/psd-skills/psd-conversation-coach/references/framework.md`.
+
+Confirm whether the situation is a crucial conversation: opinions differ,
+emotions are strong, and stakes are high. Identify the smallest useful set of
+framework skills and whether the right topic is **Content, Pattern, or
+Relationship (CPR)**. Do not turn the session into a framework lecture.
+
+### 3. Choose a mode
+
+Offer the mode that best fits the user's goal, while letting them choose:
+
+1. **Prep** — plan the topic, opener, safety strategy, and close.
+2. **Role-play** — play the counterpart realistically while the user practices.
+3. **Debrief** — review a practice attempt or a conversation that already
+   happened, with feedback tied to named framework skills.
+
+Read
+`/opt/psd-skills/psd-conversation-coach/references/coaching-guide.md` before
+running any mode.
+
+In role-play, agree on difficulty and the counterpart's likely silence or
+violence pattern. Stay in character until the user says stop or pause. The user
+may pause, rewind, retry a line, lower the difficulty, or end the exercise at
+any time. Break character immediately when asked or when the user shows
+distress.
+
+### 4. Close
+
+Help the user leave with a concrete plan:
+
+- an opener that starts with facts and invites the other person's path;
+- a **Contrasting** statement stating what they do not and do intend; and
+- a **Move to Action** agreement: who does what by when, plus follow-up.
+
+If the next step involves discipline, discrimination, harassment, a formal
+complaint, or legal exposure, separate conversation coaching from the
+substantive decision and direct the user to HR or their supervisor.
+
+## Rules
+
+1. **Attribute, do not affiliate.** Credit the framework to *Crucial
+   Conversations* by Patterson, Grenny, McMillan, Switzler, and Gregory, and to
+   Crucial Learning. State when relevant that this is an internal coaching aid,
+   not affiliated with or endorsed by Crucial Learning. Never fabricate a quote
+   from the book or its authors.
+2. **Coach, do not counsel.** Do not provide therapy, HR advice, or legal
+   advice. Coach communication skills only. Refer substantive discipline,
+   discrimination, harassment, and legal questions to HR or the user's
+   supervisor.
+3. **Keep scenarios confidential.** Never write names, situations, or other
+   scenario details to `MEMORY.md`, any memory directory, or another persistent
+   agent-memory file. Keep the coaching context in the current conversation.
+4. **The user controls role-play.** Respect pause, stop, rewind, retry, and
+   difficulty-change requests immediately. Stop without debate if the user
+   shows distress.
+5. **Summarize; do not reproduce.** Use original summaries with attribution.
+   Do not reproduce book text. Any brief quotation must be attributed and
+   shorter than 15 words.

--- a/infra/agent-image/skills/psd-conversation-coach/SKILL.md
+++ b/infra/agent-image/skills/psd-conversation-coach/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: psd-conversation-coach
-summary: Prepare for a crucial conversation or difficult conversation, practice through realistic role-play, and debrief with framework-named feedback.
+summary: Prepare for a crucial conversation or difficult conversation, practice a parent meeting, peer conflict, or coaching up through realistic role-play, and debrief with framework-named feedback.
 description: Coach Peninsula School District staff through preparing for, practicing, and debriefing difficult high-stakes conversations using the publicly documented Crucial Conversations framework. Use for feedback, parent meetings, peer conflict, coaching up, and other situations where opinions differ, emotions are strong, and stakes are high.
 allowed-tools: Read
 ---

--- a/infra/agent-image/skills/psd-conversation-coach/SKILL.md
+++ b/infra/agent-image/skills/psd-conversation-coach/SKILL.md
@@ -11,6 +11,11 @@ Help the user prepare for and practice one difficult conversation. Ground the
 coaching in the publicly documented *Crucial Conversations* framework while
 keeping the user's real goal, role, and context in control of the session.
 
+When running in the agent image, load references from the `/opt/psd-skills`
+paths below. A catalog runtime without that filesystem appends the same files
+under **Catalog-loaded references**; when that section is present, treat its
+contents as already read.
+
 ## Workflow
 
 ### 1. Intake

--- a/infra/agent-image/skills/psd-conversation-coach/evals/no-scenario-fallback.yaml
+++ b/infra/agent-image/skills/psd-conversation-coach/evals/no-scenario-fallback.yaml
@@ -1,0 +1,12 @@
+id: conversation-coach-no-scenario-fallback
+skill: psd-conversation-coach
+level: L0
+workspace: pure
+suite: regression
+prompt: "I am a principal who wants to practice difficult conversations, but I do not have a specific situation in mind. Offer me relevant practice scenarios to choose from before we begin."
+trials: 3
+graders:
+  - {"type":"output_match","pattern":"(?:late|missing) grade|grade entr","ignore_case":true}
+  - {"type":"output_match","pattern":"classroom management","ignore_case":true}
+  - {"type":"output_match","pattern":"discipline","ignore_case":true}
+  - {"type":"output_match","pattern":"(?:choose|pick|which).*(?:scenario|option)|(?:scenario|option).*(?:choose|pick|which)","ignore_case":true}

--- a/infra/agent-image/skills/psd-conversation-coach/references/coaching-guide.md
+++ b/infra/agent-image/skills/psd-conversation-coach/references/coaching-guide.md
@@ -1,0 +1,163 @@
+# Coaching Guide
+
+Use this guide after intake and framework grounding. Keep the session focused on
+the user's conversation, not on displaying framework knowledge.
+
+## Intake
+
+Ask two or three questions, summarize what was learned, and then ask the next
+small set. Useful questions include:
+
+1. Who is the counterpart, and what is the role or authority relationship?
+2. What observable events led to this conversation?
+3. Is this one event, a repeated pattern, or damage to trust or the working
+   relationship (**CPR**)?
+4. What feels most at stake for each person?
+5. What emotions or reactions does the user expect from each side?
+6. What does the user really want for themself, the counterpart, and the
+   relationship (**Start with Heart**)?
+7. Is the goal to prepare, practice, debrief, or combine those modes?
+
+Do not ask all seven at once. Do not solicit real names when roles are enough.
+If a scenario suggests discipline, discrimination, harassment, formal
+complaints, or legal exposure, explain that the coach can help with
+communication but HR or the user's supervisor must guide the substance.
+
+If the user has no situation, use `scenarios.md` only as the fallback described
+in `SKILL.md`.
+
+## Mode 1: Prep coaching
+
+### Define the right topic
+
+- State the concern in one neutral sentence.
+- Classify it as **Content, Pattern, or Relationship (CPR)**.
+- Separate observed facts from the user's story about those facts (**Master My
+  Stories**).
+- Name the desired outcome and the boundary or non-negotiable, if any.
+
+### Draft the opening
+
+Build the opener in this order:
+
+1. State good intent and shared purpose (**Start with Heart**, **Mutual
+   Purpose**).
+2. Share the most relevant observable facts (**STATE My Path**).
+3. Tentatively explain the concern those facts create (**STATE My Path**).
+4. Invite the counterpart's view (**Ask for Others' Paths**).
+
+Keep the opener short enough to say naturally. Offer alternatives, then ask the
+user to rewrite it in their own voice.
+
+### Prepare for safety risks
+
+- Predict what harmful motive the counterpart may attribute to the user.
+- Draft a **Contrasting** statement: what the user does not intend, followed by
+  what they do intend.
+- Identify likely silence or violence signals (**Learn to Look**).
+- Choose one repair: apology, Contrasting, Mutual Purpose, Mutual Respect, or
+  **CRIB**.
+
+### Plan the close
+
+- Decide who has decision authority and name the method: command, consult, vote,
+  or consensus (**Move to Action**).
+- Draft a concrete WWWF agreement: who, what, by when, and follow-up.
+- Decide how the user will respond if no agreement is reached.
+
+Prep output should include the topic, opener, Contrasting statement, likely
+safety repair, and desired action agreement.
+
+## Mode 2: Role-play practice
+
+### Set the simulation
+
+Before entering character, confirm:
+
+- the counterpart's role and legitimate interests;
+- the facts known to the counterpart versus assumptions the coach must avoid;
+- the likely silence or violence pattern;
+- difficulty: supportive, realistic, or challenging;
+- the user's practice target, such as the opener, AMPP, or moving to action; and
+- the controls: pause, stop, rewind, retry, or change difficulty.
+
+Do not invent misconduct, diagnoses, protected characteristics, or hidden facts.
+For a library scenario, use only the fictional facts in `scenarios.md` plus
+details the user adds.
+
+### Run the simulation
+
+1. Clearly announce entering role-play.
+2. Play only the counterpart. Do not write the user's lines.
+3. Respond one conversational turn at a time.
+4. Portray a plausible person with interests and constraints, not a caricature
+   or an opponent to defeat.
+5. Use the agreed silence or violence pattern at the agreed difficulty.
+6. Allow skillful safety work and genuine curiosity to change the counterpart's
+   behavior. Do not remain artificially hostile after safety improves.
+7. Do not coach from inside the character unless the user asks for an in-scene
+   hint.
+8. Stay in character until the user pauses or stops.
+
+When the user says pause, stop, rewind, retry, or equivalent, break character
+immediately. If they show distress, stop and check what they need. A rewind
+returns to the last useful line; a retry invites the user to say their line
+again without penalty.
+
+### Transition out
+
+Clearly announce leaving role-play. Ask whether the user wants another attempt,
+a focused replay, or a debrief. Never continue the counterpart's pressure after
+the exercise ends.
+
+## Mode 3: Debrief
+
+Debrief a role-play or a real conversation using observable language from the
+user's account. Separate:
+
+- what was effective;
+- the highest-leverage improvement;
+- one revised line the user can try; and
+- the next practice target.
+
+Do not grade personality or speculate about intent. Tie every feedback point to
+a named framework skill.
+
+### Framework-named feedback rubric
+
+Rate only skills that were relevant and observable. Use:
+
+- **2 — Effective:** the behavior supported candid, respectful dialogue.
+- **1 — Developing:** the intent was visible but execution could be clearer.
+- **0 — Missed opportunity:** the skill was relevant and not yet demonstrated.
+- **N/O — Not observed:** there is not enough evidence to assess it.
+
+| Framework skill | What to assess |
+| --- | --- |
+| **Start with Heart** | Did the user stay oriented to what they wanted for self, other, and relationship rather than winning or punishing? |
+| **CPR — Content, Pattern, Relationship** | Did the user address the level of concern that actually mattered? |
+| **Learn to Look** | Did the user notice safety loss and the counterpart's silence or violence pattern? |
+| **Make It Safe** | Did Mutual Purpose, Mutual Respect, apology, Contrasting, or CRIB restore enough safety for dialogue? |
+| **Master My Stories** | Did the user distinguish facts from interpretations and challenge Victim, Villain, or Helpless stories? |
+| **STATE My Path** | Did the user share facts, explain the story tentatively, ask for the other path, and invite testing? |
+| **Explore Others' Paths** | Did Ask, Mirror, Paraphrase, Prime, or ABC help the user understand and respond to the counterpart's meaning? |
+| **Move to Action** | Did the user clarify the decision method and reach a Who/What/By When/Follow-up agreement? |
+
+For every assessed row, cite a brief example from the practice or the user's
+account. Feedback should sound like: “**STATE My Path — 1 (Developing):** your
+opener named the conclusion before the observable facts. Try leading with …”
+
+## Session close
+
+End with:
+
+1. the user's final opener sentence;
+2. their Contrasting don't/do statement;
+3. the intended decision method;
+4. the hoped-for WWWF agreement and follow-up;
+5. a safety-repair line; and
+6. the one skill they will deliberately practice.
+
+Remind the user that this is an internal coaching aid based on the named public
+framework, not an official Crucial Learning product, when that context is not
+already clear.

--- a/infra/agent-image/skills/psd-conversation-coach/references/framework.md
+++ b/infra/agent-image/skills/psd-conversation-coach/references/framework.md
@@ -1,0 +1,246 @@
+# Crucial Conversations Framework
+
+## Purpose and attribution
+
+This is an original working summary of the publicly documented *Crucial
+Conversations* framework for an internal PSD coaching aid. The framework is
+credited to *Crucial Conversations: Tools for Talking When Stakes Are High* by
+Kerry Patterson, Joseph Grenny, Ron McMillan, Al Switzler, and, for the third
+edition, Emily Gregory, along with public materials from Crucial Learning.
+
+PSD and this coaching aid are not affiliated with or endorsed by Crucial
+Learning. The skill names below identify the source framework; the explanations
+are paraphrases, not reproduced book text.
+
+## Framework map
+
+### Crucial conversation
+
+A conversation becomes crucial when all three conditions are present:
+
+1. **Opposing opinions** — people see the issue differently.
+2. **Strong emotions** — feelings can narrow attention or drive reactions.
+3. **High stakes** — the outcome matters to results, wellbeing, trust, or the
+   relationship.
+
+The goal is not to win. It is **dialogue**: candid and respectful exchange that
+adds each person's relevant facts, interpretations, feelings, and experience
+to the **Pool of Shared Meaning**. A fuller pool supports better informed
+decisions and stronger commitment. Agreement is not required before meaning
+can be shared.
+
+### Start with Heart
+
+Start with Heart means checking motive before choosing words. Ask:
+
+- What result do I really want for myself?
+- What do I want for the other person?
+- What do I want for the relationship?
+- What action now would move toward all three?
+
+Notice short-term motives such as winning, punishing, saving face, or proving
+the other person wrong. Reorient toward the durable outcome, then make that
+good intent visible.
+
+Reject the **Fool's Choice**: false either-or thinking such as “be candid or be
+kind” and “protect the relationship or address the problem.” Look for an
+“and” option that honors both legitimate aims.
+
+### Learn to Look
+
+Learn to Look means monitoring both the content and the conditions of the
+conversation. Watch for:
+
+- a shift into the crucial-conversation conditions;
+- one's own physical, emotional, and behavioral signals;
+- whether people still feel safe enough to contribute meaning; and
+- movement away from dialogue into silence or violence.
+
+**Silence** withholds meaning from the pool:
+
+- **Masking** understates or disguises the real view.
+- **Avoiding** steers away from the sensitive subject.
+- **Withdrawing** exits the exchange or disengages.
+
+**Violence** tries to force meaning into the pool:
+
+- **Controlling** dominates or cuts off competing views.
+- **Labeling** dismisses a person or idea with a category.
+- **Attacking** threatens, belittles, or punishes.
+
+When safety breaks, stop pushing the topic. Name the process if useful, restore
+safety, and then return to content.
+
+### Make It Safe
+
+Safety depends on two perceived conditions:
+
+- **Mutual Purpose** — the other person believes their goals and concerns
+  matter in the conversation.
+- **Mutual Respect** — the other person believes they are regarded as a worthy
+  participant even during disagreement.
+
+Tools for restoring safety:
+
+- **Apologize** when one's action or delivery violated respect or purpose. A
+  genuine apology owns the relevant harm without using it to evade the issue.
+- **Contrasting** corrects a likely misunderstanding with a don't/do pair:
+  clarify what is not intended, then state the constructive intent.
+- **CRIB** builds a new Mutual Purpose when strategies conflict:
+  - **Commit** to seek a purpose both people can support.
+  - **Recognize** the purpose behind each proposed strategy.
+  - **Invent** a shared purpose broad enough to include legitimate interests.
+  - **Brainstorm** new strategies that serve that purpose.
+
+Mutual Purpose does not mean pretending the parties have identical
+responsibilities or authority. It identifies a shared outcome from which they
+can discuss different strategies.
+
+### Master My Stories
+
+The **Path to Action** separates observation from interpretation:
+
+1. **See and hear** observable information.
+2. **Tell a story** about what the information means.
+3. **Feel** emotions shaped by that story.
+4. **Act** from those emotions.
+
+Because the story mediates fact and feeling, a person can slow the path by
+moving backward: notice the action, name the feeling, examine the story, and
+return to observable facts. Treat interpretations as hypotheses rather than
+facts.
+
+Three **clever stories** make unhelpful action feel justified:
+
+- **Victim story** exaggerates one's innocence and hides one's contribution.
+- **Villain story** exaggerates another's bad intent or fixed character.
+- **Helpless story** claims there is no healthy, effective choice.
+
+To tell the rest of the story, ask what one's own contribution may be, what
+reasonable information could explain the other person's behavior, and what
+constructive action remains available.
+
+### STATE My Path
+
+Use **STATE** to add a difficult view to the pool without presenting a story as
+settled fact:
+
+- **Share your facts** — begin with specific, observable, least-disputable
+  information.
+- **Tell your story** — explain the interpretation or concern those facts
+  suggest.
+- **Ask for others' paths** — invite their facts, interpretation, and
+  experience.
+- **Talk tentatively** — express conclusions with appropriate uncertainty,
+  without becoming vague or insincere.
+- **Encourage testing** — make disagreement welcome and show willingness to
+  revise the view.
+
+A useful opener often follows Facts → Story → Ask. Talk tentatively and
+encourage testing throughout rather than saving them for the end.
+
+### Explore Others' Paths
+
+Explore when another person is withholding meaning, reacting strongly, or
+offering a different view. Listen to understand their Path to Action, not to
+prepare a rebuttal.
+
+**AMPP** supports exploration:
+
+- **Ask** for the person's view with genuine curiosity.
+- **Mirror** the emotion or mismatch one observes without declaring its cause.
+- **Paraphrase** the meaning heard and check whether it is accurate.
+- **Prime** only when the person is stuck: tentatively offer a plausible concern
+  so they can confirm, correct, or reject it.
+
+Use **ABC** when responding to disagreement:
+
+- **Agree** with the part that is shared.
+- **Build** by adding information that extends the shared view.
+- **Compare** differing views side by side instead of declaring the other view
+  wrong.
+
+AMPP draws meaning out; ABC keeps the response in dialogue once that meaning is
+visible.
+
+### Move to Action
+
+Dialogue must end with clarity about how a decision will be made. Name the
+method rather than letting participants assume different rules:
+
+- **Command** — one person decides without others' input.
+- **Consult** — designated decision-maker(s) gather input and then decide.
+- **Vote** — participants have a voice and the majority decides.
+- **Consensus** — everyone agrees to support the decision.
+
+The method should fit the authority, stakes, expertise, and need for commitment.
+Consultation is not consensus; input does not silently transfer decision
+authority.
+
+Turn a decision into an assignment using **Who does What by When, with
+Follow-up (WWWF)**. Specify the owner, observable result, deadline, and how or
+when progress will be checked.
+
+### Choose the right conversation: CPR
+
+The third edition publicly emphasizes choosing the level that matches the real
+problem:
+
+- **Content** — the immediate event or single instance.
+- **Pattern** — repeated behavior or recurring results are now the issue.
+- **Relationship** — trust, respect, competence, or how the parties work
+  together has become the issue.
+
+Repeatedly discussing the newest incident when the concern is a pattern leads
+to circular conversations. A relationship conversation is about the effect on
+trust or working expectations, not a license to label the other person's
+character.
+
+## Coaching use
+
+Choose only the framework skills that address the user's current obstacle:
+
+| Observed need | Useful framework lens |
+| --- | --- |
+| Motive has shifted toward winning or punishment | Start with Heart; Fool's Choice |
+| The user is arguing about the latest example | CPR |
+| Facts and interpretations are blended | Master My Stories; STATE My Path |
+| The counterpart may expect an accusation | Make It Safe; Contrasting |
+| The counterpart is quiet, evasive, or reactive | Learn to Look; AMPP |
+| Views differ after both are understood | ABC |
+| The conversation ends with vague intentions | Move to Action; WWWF |
+
+## Public source map
+
+These public Crucial Learning materials ground this summary:
+
+- [Crucial Learning glossary](https://cruciallearning.com/glossary/) — public
+  definitions for the framework's named skills, acronyms, dialogue patterns,
+  decision methods, and Pool of Shared Meaning.
+- [Crucial Conversations for Mastering Dialogue](https://cruciallearning.com/courses/crucial-conversations-for-dialogue/)
+  — the public course purpose and skill overview.
+- [Third-edition announcement](https://cruciallearning.com/press/crucial-learning-releases-third-edition-of-acclaimed-bestselling-book-crucial-conversations/)
+  — third-edition authorship and additions.
+- [Crucial Conversations book resources](https://cruciallearning.com/books/crucial-conversations-book/)
+  — the publisher's public companion resources and skill demonstrations.
+- [Crucial Conversations miniseries](https://cruciallearning.com/courses/crucial-conversations-for-dialogue/miniseries/)
+  — public video instruction by third-edition coauthor Emily Gregory on
+  recognizing crucial conversations, emotion, safety, and Mutual Purpose.
+- [Start with Heart skill summary](https://cruciallearning.com/blog/crucial-conversations-skill-summary-start-with-heart/)
+  — motive, the three desired outcomes, and the Fool's Choice.
+- [Make It Safe skill summary](https://cruciallearning.com/blog/crucial-conversations-skill-summary-make-it-safe/)
+  — Mutual Purpose, Mutual Respect, silence, and violence.
+- [Master My Stories skill summary](https://cruciallearning.com/blog/crucial-conversations-skill-summary-master-my-stories/)
+  — Path to Action and the three clever stories.
+- [How to Share Your Feelings](https://cruciallearning.com/blog/how-to-share-your-feelings/)
+  — facts, tentative story, invitation, and the Pool of Shared Meaning.
+- [How to Train a Resistant Coworker](https://cruciallearning.com/blog/how-to-train-a-resistant-coworker/)
+  — a public explanation of CRIB.
+- [The ABCs of Reaching Agreement](https://cruciallearning.com/blog/the-abcs-of-reaching-agreement/)
+  — Agree, Build, and Compare.
+- [Improve Results by Moving to Action](https://cruciallearning.com/crucialskills/2009/03/improve-results-by-moving-to-action/)
+  — Who, What, By When, and Follow-up.
+- [Why Your Crucial Conversations Aren't Working](https://cruciallearning.com/blog/why-your-crucial-conversations-arent-working/)
+  — choosing Content, Pattern, or Relationship.
+
+Accessed July 29, 2026.

--- a/infra/agent-image/skills/psd-conversation-coach/references/scenarios.md
+++ b/infra/agent-image/skills/psd-conversation-coach/references/scenarios.md
@@ -1,0 +1,174 @@
+# PSD Conversation Practice Scenarios
+
+Use these only when intake establishes that the user has no specific
+conversation of their own. A real user situation always takes precedence.
+
+All scenarios are fictional composites. They contain no real PSD staff,
+student, family, school, or incident details. Offer three or four options
+ordered toward the user's role when known; do not read the entire library to
+the user.
+
+## 1. Grade-entry pattern
+
+- **Best fit for:** Principal or assistant principal
+- **Counterpart role:** Classroom teacher
+- **Situation:** Required grade updates have been late or missing in three
+  recent reporting cycles despite prior reminders. The needed conversation is
+  about the repeated pattern, not only the newest missed entry (**CPR:
+  Pattern**).
+- **What's at stake for the user:** Reliable family communication, equitable
+  progress monitoring, staff accountability, and preserving a workable
+  coaching relationship.
+- **What's at stake for the counterpart:** Workload, professional credibility,
+  autonomy, and concern that complex circumstances will be ignored.
+- **Likely pattern to play:** **Silence — masking and avoiding.** Minimize the
+  recurrence, offer brief explanations for the latest incident, and redirect
+  toward competing duties. At challenging difficulty, shift to **violence —
+  controlling** by arguing that the expectation is unrealistic.
+
+## 2. Classroom-management concerns
+
+- **Best fit for:** Principal or assistant principal
+- **Counterpart role:** Classroom teacher
+- **Situation:** Multiple families have separately raised concerns about
+  classroom routines and student belonging. The administrator needs to discuss
+  observable themes without treating complaints as proven conclusions.
+- **What's at stake for the user:** Student safety and learning, family trust,
+  accurate fact-finding, and fair support for the teacher.
+- **What's at stake for the counterpart:** Reputation, evaluation anxiety,
+  authority in the classroom, and a wish for specific rather than hearsay-based
+  feedback.
+- **Likely pattern to play:** **Violence — labeling and attacking.** Call the
+  complaints exaggerated and question whether families understand classroom
+  realities. Move toward dialogue if the user separates facts from stories and
+  makes respect clear.
+
+## 3. Disputed discipline decision
+
+- **Best fit for:** Principal, dean, or district administrator
+- **Counterpart role:** Parent or caregiver
+- **Situation:** A caregiver believes a discipline response was unfair and
+  wants it reversed immediately. The administrator must hear the concern,
+  explain process and authority accurately, and avoid debating confidential
+  information about other students.
+- **What's at stake for the user:** Student support, fair process,
+  confidentiality, family trust, and a sustainable next step.
+- **What's at stake for the counterpart:** Their child's dignity, safety,
+  record, and confidence that the school listens before deciding.
+- **Likely pattern to play:** **Violence — controlling and attacking.** Interrupt,
+  press for a yes-or-no reversal, and accuse the school of not listening. At
+  lower difficulty, soften after an effective paraphrase and a clear Mutual
+  Purpose.
+
+## 4. Work completion at home
+
+- **Best fit for:** Teacher
+- **Counterpart role:** Parent or caregiver
+- **Situation:** A student regularly arrives without completed work. The
+  teacher sees limited follow-through at home; the caregiver believes unclear
+  instruction and excessive assignments are the real problem.
+- **What's at stake for the user:** Student learning, accurate expectations,
+  partnership with the family, and avoiding blame.
+- **What's at stake for the counterpart:** Their child's confidence, family
+  time and capacity, respect for their knowledge of the child, and fair
+  expectations.
+- **Likely pattern to play:** **Violence — controlling**, followed by
+  **silence — withdrawing**. Begin by listing problems with instruction, then
+  become terse if the user defends rather than explores.
+
+## 5. Uneven PLC workload
+
+- **Best fit for:** Teacher or instructional coach
+- **Counterpart role:** Peer teacher with no reporting relationship
+- **Situation:** One colleague repeatedly prepares agendas, common materials,
+  and follow-up while the other contributes little. There is no supervisory
+  authority, and resentment is beginning to affect collaboration.
+- **What's at stake for the user:** Sustainable workload, team effectiveness,
+  candor, and preserving a peer relationship.
+- **What's at stake for the counterpart:** Autonomy, competing responsibilities,
+  reputation with peers, and not being assigned work by someone without
+  authority.
+- **Likely pattern to play:** **Silence — masking.** Agree vaguely, use humor,
+  and avoid a clear commitment. At challenging difficulty, add **violence —
+  labeling** by calling the user overly controlling.
+
+## 6. Repeated compliance deadline
+
+- **Best fit for:** District administrator
+- **Counterpart role:** Building administrator
+- **Situation:** A required compliance submission was missed again after an
+  earlier plan to prevent recurrence. The conversation must address the pattern
+  and its operational effect while learning what barriers remain.
+- **What's at stake for the user:** Legal and operational compliance, district
+  credibility, reliable escalation, and support across buildings.
+- **What's at stake for the counterpart:** Competing building priorities,
+  leadership credibility, staffing limitations, and fear of being judged
+  without context.
+- **Likely pattern to play:** **Violence — controlling.** Flood the conversation
+  with urgent building demands and insist the central-office process is the
+  problem. Shift toward **silence — avoiding** if pressed with conclusions
+  rather than facts.
+
+## 7. Attendance and punctuality pattern
+
+- **Best fit for:** Supervisor
+- **Counterpart role:** Support staff member
+- **Situation:** Late arrivals have become a recurring pattern and are affecting
+  coverage. The supervisor needs to discuss observed attendance records,
+  understand barriers, and avoid inventing policy consequences.
+- **What's at stake for the user:** Reliable coverage, fairness to the team,
+  accurate documentation, and an appropriate support or HR path.
+- **What's at stake for the counterpart:** Employment, privacy, dignity, and a
+  chance to explain circumstances without being diagnosed or pressured to
+  disclose protected information.
+- **Likely pattern to play:** **Silence — withdrawing.** Give one-word answers
+  and say the matter is personal. At challenging difficulty, use **violence —
+  attacking** by accusing the supervisor of singling them out.
+
+## 8. Cross-department request
+
+- **Best fit for:** Teacher, building staff, IT staff, or department peer
+- **Counterpart role:** Peer in another department
+- **Situation:** A building request has repeatedly been deprioritized by IT, or
+  IT believes the building keeps bypassing intake and urgency standards. The
+  peers need to address the pattern without relying on positional authority.
+- **What's at stake for the user:** Timely service, continuity of teaching or
+  operations, and a dependable cross-department process.
+- **What's at stake for the counterpart:** Fair queue management, security and
+  technical constraints, workload, and respect for established processes.
+- **Likely pattern to play:** **Violence — labeling and controlling.** Refer to
+  the other department as always treating everything as urgent and insist the
+  ticket queue ends the discussion. Respond to ABC and CRIB with more specific
+  constraints.
+
+## 9. Coaching up after feeling unheard
+
+- **Best fit for:** Any staff member speaking with a supervisor
+- **Counterpart role:** Direct supervisor
+- **Situation:** A decision affecting the user's work was made after they
+  offered input, but they do not believe the impact was understood. They want
+  to raise a process or relationship concern without implying that consultation
+  gave them final decision authority.
+- **What's at stake for the user:** Voice, trust, practical working conditions,
+  and the ability to disagree without retaliation.
+- **What's at stake for the counterpart:** Decision authority, implementation
+  timeline, team-wide constraints, and confidence that consultation can occur
+  without every decision becoming consensus.
+- **Likely pattern to play:** **Silence — avoiding**, then **violence —
+  controlling**. Initially say the decision is already made and redirect to
+  implementation. If pressed, emphasize authority. Re-engage when the user
+  distinguishes consult from consensus and names a Mutual Purpose.
+
+## Role-play calibration
+
+- **Supportive:** Show the pattern briefly, then respond quickly to sound use of
+  safety and exploration skills.
+- **Realistic:** Sustain the pattern until the user demonstrates curiosity,
+  accurate paraphrase, or clear Mutual Purpose.
+- **Challenging:** Combine two listed behaviors and test one safety repair, but
+  never escalate into abuse, threats, discriminatory content, or invented
+  misconduct.
+
+The counterpart should have a coherent point of view and should become more
+open when the user makes the conversation safer. Difficulty is not permission
+to make the role-play cruel or unwinnable.

--- a/infra/agent-image/skills/psd-conversation-coach/skill-frontmatter.test.js
+++ b/infra/agent-image/skills/psd-conversation-coach/skill-frontmatter.test.js
@@ -1,0 +1,75 @@
+/**
+ * psd-conversation-coach SKILL.md registration tests.
+ *
+ * Run: bun test skill-frontmatter.test.js
+ *
+ * skills.search matches name and summary only. These tests use the same
+ * line-oriented regexes as agent-platform-stack.ts so a valid-looking YAML
+ * edit cannot silently break deploy-time registration or discoverability.
+ */
+
+'use strict';
+
+const { test, expect, describe } = require('bun:test');
+const fs = require('node:fs');
+const path = require('node:path');
+
+function readSkill() {
+  return fs.readFileSync(path.join(__dirname, 'SKILL.md'), 'utf8');
+}
+
+function parseFrontmatterAsStackDoes() {
+  const raw = readSkill();
+  const frontmatter = raw.match(/^---\n([\s\S]*?)\n---/);
+  expect(frontmatter).not.toBeNull();
+
+  const fields = { name: '', summary: '', description: '' };
+  for (const line of frontmatter[1].split('\n')) {
+    const field = line.match(/^(name|summary|description):\s*(.*)$/);
+    if (!field) continue;
+    fields[field[1]] = field[2].trim();
+  }
+  return fields;
+}
+
+describe('SKILL.md registration frontmatter', () => {
+  test('declares fields parsed by the deploy-time registration path', () => {
+    const fields = parseFrontmatterAsStackDoes();
+    expect(fields.name).toBe('psd-conversation-coach');
+    expect(fields.name).toBe(path.basename(__dirname));
+    expect(fields.summary.length).toBeGreaterThan(0);
+    expect(fields.description.length).toBeGreaterThan(0);
+  });
+
+  test('keeps each deploy-parsed field on exactly one physical line', () => {
+    const frontmatter = readSkill().match(/^---\n([\s\S]*?)\n---/);
+    expect(frontmatter).not.toBeNull();
+
+    for (const name of ['name', 'summary', 'description']) {
+      const lines = frontmatter[1]
+        .split('\n')
+        .filter((line) => line.startsWith(`${name}:`));
+      expect(lines).toHaveLength(1);
+    }
+  });
+
+  test('declares the only tool the knowledge skill needs', () => {
+    expect(readSkill()).toContain('allowed-tools: Read');
+  });
+});
+
+describe('skills.search discoverability', () => {
+  const requiredPhrases = [
+    'crucial conversation',
+    'difficult conversation',
+    'practice',
+    'role-play',
+  ];
+
+  for (const phrase of requiredPhrases) {
+    test(`summary contains "${phrase}"`, () => {
+      const searchableSummary = parseFrontmatterAsStackDoes().summary.toLowerCase();
+      expect(searchableSummary).toContain(phrase);
+    });
+  }
+});

--- a/infra/agent-image/skills/psd-conversation-coach/skill-frontmatter.test.js
+++ b/infra/agent-image/skills/psd-conversation-coach/skill-frontmatter.test.js
@@ -3,9 +3,10 @@
  *
  * Run: bun test skill-frontmatter.test.js
  *
- * skills.search matches name and summary only. These tests use the same
- * line-oriented regexes as agent-platform-stack.ts so a valid-looking YAML
- * edit cannot silently break deploy-time registration or discoverability.
+ * skills.search matches name and summary only. The deploy-parsed fields use
+ * the same line-oriented regexes as agent-platform-stack.ts so a valid-looking
+ * YAML edit cannot silently break registration or discoverability. The tool
+ * grant is checked separately against the skill's declared frontmatter.
  */
 
 'use strict';
@@ -32,6 +33,10 @@ function parseFrontmatterAsStackDoes() {
   return fields;
 }
 
+function registeredSummary(fields) {
+  return fields.summary || `Bundled skill: ${fields.name}`;
+}
+
 describe('SKILL.md registration frontmatter', () => {
   test('declares fields parsed by the deploy-time registration path', () => {
     const fields = parseFrontmatterAsStackDoes();
@@ -39,6 +44,13 @@ describe('SKILL.md registration frontmatter', () => {
     expect(fields.name).toBe(path.basename(__dirname));
     expect(fields.summary.length).toBeGreaterThan(0);
     expect(fields.description.length).toBeGreaterThan(0);
+  });
+
+  test('registers a real summary, not the fallback placeholder', () => {
+    const fields = parseFrontmatterAsStackDoes();
+    expect(registeredSummary(fields)).not.toBe(
+      'Bundled skill: psd-conversation-coach'
+    );
   });
 
   test('keeps each deploy-parsed field on exactly one physical line', () => {
@@ -51,6 +63,11 @@ describe('SKILL.md registration frontmatter', () => {
         .filter((line) => line.startsWith(`${name}:`));
       expect(lines).toHaveLength(1);
     }
+
+    const summaryLine = frontmatter[1]
+      .split('\n')
+      .find((line) => line.startsWith('summary:'));
+    expect(summaryLine.slice('summary:'.length)).not.toContain(': ');
   });
 
   test('declares the only tool the knowledge skill needs', () => {

--- a/infra/agent-image/skills/psd-conversation-coach/skill-frontmatter.test.js
+++ b/infra/agent-image/skills/psd-conversation-coach/skill-frontmatter.test.js
@@ -81,6 +81,9 @@ describe('skills.search discoverability', () => {
     'difficult conversation',
     'practice',
     'role-play',
+    'parent meeting',
+    'peer conflict',
+    'coaching up',
   ];
 
   for (const phrase of requiredPhrases) {

--- a/infra/agent-image/skills/psd-skills-meta/SKILL.md
+++ b/infra/agent-image/skills/psd-skills-meta/SKILL.md
@@ -10,7 +10,8 @@ allowed-tools: Bash(node:*)
 Meta-skill for the Agent Skills Platform. Provides skill discovery, on-demand
 loading, and agent-authored skill creation.
 
-**Identity.** All commands require `--user <caller-email>`.
+**Identity.** The broker derives the owner from the signed invocation context.
+Never pass `--user`, `--owner-email`, or another caller selector.
 
 ## Commands
 
@@ -18,7 +19,6 @@ loading, and agent-authored skill creation.
 
 ```bash
 node /opt/psd-skills/psd-skills-meta/search.js \
-  --user <email> \
   --query "<search term>"
 ```
 
@@ -29,27 +29,27 @@ the user asks "do you have a skill for X?" or you need to find a skill.
 
 ```bash
 node /opt/psd-skills/psd-skills-meta/load.js \
-  --user <email> \
   --name "<skill-name>"
 ```
 
-Downloads and outputs the full SKILL.md for the named skill, making it
-available for the current session. Use this when a Tier 2 catalog stub
-indicates a skill exists but you need the full instructions.
+Reads image-bundled skills from the read-only `/opt/psd-skills` catalog and
+downloads approved user-authored skills through the broker. Outputs the full
+SKILL.md for the named skill, making it available for the current session. Use
+this when a Tier 2 catalog stub indicates a skill exists but you need the full
+instructions.
 
 ### `author` — create a new skill draft
 
 ```bash
 node /opt/psd-skills/psd-skills-meta/author.js \
-  --user <email> \
   --name "<skill-name>" \
   --summary "<one-line summary>" \
   --skill-md "<full SKILL.md content, base64 encoded>" \
   --files "<JSON array of {path, content_base64} entries>"
 ```
 
-Creates a skill draft in `skills/user/{caller-email}/drafts/{skill-name}/` in S3,
-using the same caller email passed via `--user`.
+Creates a skill draft in `skills/user/{caller-email}/drafts/{skill-name}/` in
+S3, using the caller identity from the signed invocation context.
 The draft is then scanned by the Skill Builder Lambda. If the scan is clean,
 the skill is auto-promoted to `skills/user/{caller-email}/approved/` and becomes
 available in your next session. If flagged, it goes to the admin review queue.

--- a/infra/agent-image/skills/psd-skills-meta/authority.test.js
+++ b/infra/agent-image/skills/psd-skills-meta/authority.test.js
@@ -6,6 +6,24 @@ const { spawnSync } = require('node:child_process');
 
 const loadScript = path.resolve(__dirname, 'load.js');
 
+function runLoadWithBrokerResponse(name, status, body) {
+  const bootstrap = [
+    `globalThis.fetch = async () => new Response(${JSON.stringify(JSON.stringify(body))}, {`,
+    `status: ${status},`,
+    "headers: { 'Content-Type': 'application/json' },",
+    '});',
+    `process.argv = [process.execPath, ${JSON.stringify(loadScript)}, '--name', ${JSON.stringify(name)}];`,
+    `require(${JSON.stringify(loadScript)});`,
+  ].join('\n');
+  return spawnSync('node', ['-e', bootstrap], {
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      PSD_SKILLS_DIR: path.resolve(__dirname, '..'),
+    },
+  });
+}
+
 for (const script of ['search.js', 'load.js', 'author.js']) {
   test(`${script} rejects the legacy --user selector`, () => {
     const result = spawnSync(
@@ -19,15 +37,11 @@ for (const script of ['search.js', 'load.js', 'author.js']) {
   });
 }
 
-test('load.js reads an image-bundled skill from the local catalog', () => {
-  const skillsDir = path.resolve(__dirname, '..');
-  const result = spawnSync(
-    'node',
-    [loadScript, '--name', 'psd-conversation-coach'],
-    {
-      encoding: 'utf8',
-      env: { ...process.env, PSD_SKILLS_DIR: skillsDir },
-    },
+test('load.js reads an image-bundled skill after broker authorization', () => {
+  const result = runLoadWithBrokerResponse(
+    'psd-conversation-coach',
+    200,
+    { name: 'psd-conversation-coach', source: 'bundled' },
   );
 
   expect(result.status).toBe(0);
@@ -35,6 +49,20 @@ test('load.js reads an image-bundled skill from the local catalog', () => {
   expect(loaded.name).toBe('psd-conversation-coach');
   expect(loaded.skillMd).toContain('name: psd-conversation-coach');
   expect(loaded.skillMd).toContain('# PSD Conversation Coach');
+});
+
+test('load.js honors a broker denial even when the bundled file exists', () => {
+  const result = runLoadWithBrokerResponse(
+    'psd-conversation-coach',
+    404,
+    { error: 'not_found' },
+  );
+
+  expect(result.status).toBe(0);
+  const denied = JSON.parse(result.stdout);
+  expect(denied.error).toBe('not_found');
+  expect(denied.message).toContain('not found in the catalog or not accessible');
+  expect(denied).not.toHaveProperty('skillMd');
 });
 
 test('load.js rejects unsafe names before resolving a local path', () => {

--- a/infra/agent-image/skills/psd-skills-meta/authority.test.js
+++ b/infra/agent-image/skills/psd-skills-meta/authority.test.js
@@ -4,6 +4,8 @@ const { test, expect } = require('bun:test');
 const path = require('node:path');
 const { spawnSync } = require('node:child_process');
 
+const loadScript = path.resolve(__dirname, 'load.js');
+
 for (const script of ['search.js', 'load.js', 'author.js']) {
   test(`${script} rejects the legacy --user selector`, () => {
     const result = spawnSync(
@@ -16,3 +18,32 @@ for (const script of ['search.js', 'load.js', 'author.js']) {
     expect(result.stderr).toContain('signed invocation');
   });
 }
+
+test('load.js reads an image-bundled skill from the local catalog', () => {
+  const skillsDir = path.resolve(__dirname, '..');
+  const result = spawnSync(
+    'node',
+    [loadScript, '--name', 'psd-conversation-coach'],
+    {
+      encoding: 'utf8',
+      env: { ...process.env, PSD_SKILLS_DIR: skillsDir },
+    },
+  );
+
+  expect(result.status).toBe(0);
+  const loaded = JSON.parse(result.stdout);
+  expect(loaded.name).toBe('psd-conversation-coach');
+  expect(loaded.skillMd).toContain('name: psd-conversation-coach');
+  expect(loaded.skillMd).toContain('# PSD Conversation Coach');
+});
+
+test('load.js rejects unsafe names before resolving a local path', () => {
+  const result = spawnSync(
+    'node',
+    [loadScript, '--name', '../../etc'],
+    { encoding: 'utf8' },
+  );
+
+  expect(result.status).toBe(1);
+  expect(result.stderr).toContain('Invalid skill name');
+});

--- a/infra/agent-image/skills/psd-skills-meta/authority.test.js
+++ b/infra/agent-image/skills/psd-skills-meta/authority.test.js
@@ -5,21 +5,19 @@ const path = require('node:path');
 const { spawnSync } = require('node:child_process');
 
 const loadScript = path.resolve(__dirname, 'load.js');
+const brokerPreload = path.resolve(
+  __dirname,
+  '../../../../tests/fixtures/agent-skills-broker-preload.cjs',
+);
 
 function runLoadWithBrokerResponse(name, status, body) {
-  const bootstrap = [
-    `globalThis.fetch = async () => new Response(${JSON.stringify(JSON.stringify(body))}, {`,
-    `status: ${status},`,
-    "headers: { 'Content-Type': 'application/json' },",
-    '});',
-    `process.argv = [process.execPath, ${JSON.stringify(loadScript)}, '--name', ${JSON.stringify(name)}];`,
-    `require(${JSON.stringify(loadScript)});`,
-  ].join('\n');
-  return spawnSync('node', ['-e', bootstrap], {
+  return spawnSync('node', ['--require', brokerPreload, loadScript, '--name', name], {
     encoding: 'utf8',
     env: {
       ...process.env,
       PSD_SKILLS_DIR: path.resolve(__dirname, '..'),
+      TEST_AGENT_BROKER_BODY: JSON.stringify(body),
+      TEST_AGENT_BROKER_STATUS: String(status),
     },
   });
 }

--- a/infra/agent-image/skills/psd-skills-meta/load.js
+++ b/infra/agent-image/skills/psd-skills-meta/load.js
@@ -3,19 +3,35 @@
  * load.js — skills.load
  * Usage: node load.js --name <skill-name>
  *
- * Loads a skill's full SKILL.md content from S3 and outputs it,
- * making the skill available for the current session.
+ * Loads a skill's full SKILL.md content and outputs it, making the skill
+ * available for the current session. Image-bundled skills resolve from the
+ * read-only /opt catalog; user-authored skills resolve through the broker.
  */
 
 'use strict';
 
+const path = require('node:path');
+const { validatedFs } = require('../../../validated-fs.cjs');
 const {
   fail,
   rejectAuthorityArgs,
   parseArgs,
   emit,
   skillBroker,
+  validateSafeName,
 } = require('./common');
+
+const SKILLS_DIR = process.env.PSD_SKILLS_DIR || '/opt/psd-skills';
+
+function readBundledSkill(name) {
+  const skillPath = path.join(SKILLS_DIR, name, 'SKILL.md');
+  try {
+    return validatedFs.readFileSync(skillPath, 'utf8');
+  } catch (error) {
+    if (error && error.code === 'ENOENT') return null;
+    throw error;
+  }
+}
 
 async function main() {
   const args = parseArgs(process.argv);
@@ -28,8 +44,15 @@ async function main() {
   if (!args.name) {
     fail('--name is required (skill name to load)');
   }
+  validateSafeName(args.name, 'skill name');
 
   try {
+    const bundledSkillMd = readBundledSkill(args.name);
+    if (bundledSkillMd !== null) {
+      emit({ name: args.name, skillMd: bundledSkillMd });
+      return;
+    }
+
     const skill = await skillBroker('load', { name: args.name });
 
     if (!skill) {

--- a/infra/agent-image/skills/psd-skills-meta/load.js
+++ b/infra/agent-image/skills/psd-skills-meta/load.js
@@ -47,12 +47,6 @@ async function main() {
   validateSafeName(args.name, 'skill name');
 
   try {
-    const bundledSkillMd = readBundledSkill(args.name);
-    if (bundledSkillMd !== null) {
-      emit({ name: args.name, skillMd: bundledSkillMd });
-      return;
-    }
-
     const skill = await skillBroker('load', { name: args.name });
 
     if (!skill) {
@@ -62,6 +56,19 @@ async function main() {
           'Use skills.search to find available skills.',
       });
       process.exit(0);
+    }
+
+    if (skill.source === 'bundled') {
+      const bundledSkillMd = readBundledSkill(args.name);
+      if (bundledSkillMd === null) {
+        emit({
+          error: 'not_found',
+          message: `Skill "${args.name}" is approved but is not present in this agent image.`,
+        });
+        process.exit(0);
+      }
+      emit({ name: args.name, skillMd: bundledSkillMd });
+      return;
     }
 
     emit(skill);

--- a/infra/lambdas/agent-skill-initializer/index.ts
+++ b/infra/lambdas/agent-skill-initializer/index.ts
@@ -5,7 +5,7 @@
  * Receives the manifest of image-bundled skills (built at synth time
  * from `infra/agent-image/skills/{name}/SKILL.md` frontmatter) and
  * UPSERTs each one into `psd_agent_skills` with scope=shared and
- * scan_status=clean.
+ * scan_status=clean, including its declared allowed-tools pin.
  *
  * Bundled skills are pre-vetted (they ship in the agent image, code-
  * reviewed and built by us), so the security scan is skipped — the
@@ -23,7 +23,8 @@
  *   DATABASE_SECRET_ARN   — Aurora credentials secret
  *   DATABASE_NAME         — default 'aistudio'
  *   DATABASE_PORT         — default 5432
- *   IMAGE_TAG             — current agent image tag (stored in s3_key for traceability)
+ *
+ * Custom-resource properties include the current agent image tag.
  */
 
 import {
@@ -32,6 +33,10 @@ import {
 } from "@aws-sdk/client-secrets-manager"
 import postgres from "postgres"
 import { retirementCandidates } from "./retirement"
+import {
+  bundledSkillRegistration,
+  type SkillManifestEntry,
+} from "./registration"
 
 const DATABASE_HOST = process.env.DATABASE_HOST || ""
 const DATABASE_SECRET_ARN = process.env.DATABASE_SECRET_ARN || ""
@@ -63,14 +68,6 @@ async function getSql(): Promise<postgres.Sql> {
     connect_timeout: 10,
   })
   return sqlClient
-}
-
-interface SkillManifestEntry {
-  name: string
-  summary: string
-  description?: string
-  sourceHash: string
-  imageTag: string
 }
 
 interface CustomResourceEvent {
@@ -124,26 +121,37 @@ async function upsertSkills(
   let skipped = 0
 
   for (const skill of skills) {
-    if (!skill.name || !skill.summary || !skill.sourceHash) {
+    const registration = bundledSkillRegistration(skill, imageTag)
+    if (!registration) {
       skipped++
       continue
     }
-    // s3Key column stores `image:<tag>:<name>` for bundled skills — there's
-    // no real S3 object, but the column is NOT NULL and this string is
-    // both a stable identifier and a useful breadcrumb in the dashboard.
-    const s3Key = `image:${imageTag}:${skill.name}`
+    // CDK deploys the reviewed bundled tree to this versioned prefix before
+    // invoking the initializer. Using the same S3 contract as promoted skills
+    // keeps every catalog consumer on one read path.
     // UPSERT keyed on the partial unique index (name) WHERE scope='shared'.
-    // The summary and s3Key get refreshed on every deploy; version bumps
-    // when the source hash changes.
+    // The summary, s3Key, and tool pin get refreshed on every deploy; version
+    // bumps when the image tag changes.
     const result = await sql<{ id: string; version: number }[]>`
       INSERT INTO psd_agent_skills
-        (name, scope, s3_key, version, summary, scan_status, created_at, updated_at)
+        (name, scope, s3_key, version, summary, allowed_tools, scan_status, created_at, updated_at)
       VALUES
-        (${skill.name}, 'shared', ${s3Key}, 1, ${skill.summary}, 'clean', NOW(), NOW())
+        (
+          ${registration.name},
+          'shared',
+          ${registration.s3Key},
+          1,
+          ${registration.summary},
+          ${sql.json(registration.allowedTools)},
+          'clean',
+          NOW(),
+          NOW()
+        )
       ON CONFLICT (name) WHERE scope = 'shared'
       DO UPDATE SET
         s3_key = EXCLUDED.s3_key,
         summary = EXCLUDED.summary,
+        allowed_tools = EXCLUDED.allowed_tools,
         scan_status = 'clean',
         version = CASE
           WHEN psd_agent_skills.s3_key = EXCLUDED.s3_key THEN psd_agent_skills.version

--- a/infra/lambdas/agent-skill-initializer/registration.ts
+++ b/infra/lambdas/agent-skill-initializer/registration.ts
@@ -1,0 +1,50 @@
+export interface SkillManifestEntry {
+  name: string
+  summary: string
+  description?: string
+  allowedTools?: string[]
+  sourceHash: string
+  imageTag: string
+}
+
+export interface BundledSkillRegistration {
+  name: string
+  summary: string
+  s3Key: string
+  allowedTools: string[]
+}
+
+const SAFE_SKILL_NAME = /^[a-z0-9][a-z0-9-]{0,127}$/
+const SAFE_IMAGE_TAG = /^[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}$/
+
+/**
+ * Convert the custom-resource manifest entry into the exact registry values
+ * written by the initializer. Kept pure so storage and authorization metadata
+ * stay regression-testable without loading AWS SDK clients.
+ */
+export function bundledSkillRegistration(
+  skill: SkillManifestEntry,
+  imageTag: string
+): BundledSkillRegistration | null {
+  if (
+    !SAFE_SKILL_NAME.test(skill.name) ||
+    !SAFE_IMAGE_TAG.test(imageTag) ||
+    !skill.summary ||
+    !skill.sourceHash
+  ) {
+    return null
+  }
+
+  return {
+    name: skill.name,
+    summary: skill.summary,
+    s3Key: `skills/bundled/${imageTag}/${skill.name}`,
+    allowedTools: Array.isArray(skill.allowedTools)
+      ? skill.allowedTools.flatMap((tool) => {
+          if (typeof tool !== "string") return []
+          const normalized = tool.trim()
+          return normalized ? [normalized] : []
+        })
+      : [],
+  }
+}

--- a/infra/lib/agent-platform-stack.ts
+++ b/infra/lib/agent-platform-stack.ts
@@ -41,6 +41,7 @@ import { ServiceRoleFactory, usGuardrailProfileArns } from './constructs/securit
 import { AGENT_LAMBDA_RUNTIME } from './constructs/compute/lambda-construct';
 import { HyperframesRenderFunction } from './constructs/compute/hyperframes-render-function';
 import { validatedFs } from "./validated-fs";
+import { parseBundledSkillFrontmatter } from './bundled-skill-manifest';
 
 export interface AgentPlatformStackProps extends cdk.StackProps {
   environment: 'dev' | 'staging' | 'prod';
@@ -88,6 +89,7 @@ interface BundledSkillManifestEntry {
   name: string;
   summary: string;
   description?: string;
+  allowedTools: string[];
   sourceHash: string;
   imageTag: string;
 }
@@ -4562,7 +4564,21 @@ export class AgentPlatformStack extends cdk.Stack {
     // greetings-demo. Idempotent: same manifest = no DB churn; image
     // updates bump the s3_key → version increments.
 
+    const agentImageTagContext = this.node.tryGetContext('agentImageTag') ?? 'unset';
+    if (
+      typeof agentImageTagContext !== 'string' ||
+      !/^[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}$/.test(agentImageTagContext)
+    ) {
+      throw new Error(
+        'agentImageTag must be a valid ECR tag before it can be used in the bundled-skill S3 prefix',
+      );
+    }
     const bundledSkillsManifest = this.loadBundledSkillsManifest();
+
+    const bundledSkillsDeployment = this.createBundledSkillsDeployment(
+      resources,
+      agentImageTagContext,
+    );
 
     // vpcEnabled: false — VPC access added manually via managed policy below
     // to avoid ServiceRoleFactory's wildcard-ENI policy validator. Same
@@ -4660,9 +4676,7 @@ export class AgentPlatformStack extends cdk.Stack {
       ...RETIRED_BUNDLED_SKILL_NAMES.map((name) => `retired:${name}`),
     ].sort().join(',');
 
-    const agentImageTagContext = this.node.tryGetContext('agentImageTag') ?? 'unset';
-
-    new customResources.AwsCustomResource(this, 'AgentSkillInitializerCR', {
+    const skillInitializerResource = new customResources.AwsCustomResource(this, 'AgentSkillInitializerCR', {
       onCreate: {
         service: 'Lambda',
         action: 'invoke',
@@ -4707,6 +4721,53 @@ export class AgentPlatformStack extends cdk.Stack {
       ]),
       installLatestAwsSdk: false,
     });
+    skillInitializerResource.node.addDependency(bundledSkillsDeployment);
+  }
+
+  private createBundledSkillsDeployment(
+    resources: AgentPlatformBuildResources,
+    agentImageTag: string,
+  ): s3deploy.BucketDeployment {
+    // The catalog's shared consumers all read skill artifacts through the
+    // workspace-bucket contract. Publish the same reviewed source tree that is
+    // copied into the agent image so web preview, Nexus injection, internal/MCP
+    // execution, and zip export resolve one authoritative artifact. Test files
+    // and local build caches are not runtime skill content.
+    return new s3deploy.BucketDeployment(this, 'BundledSkillsDeployment', {
+      sources: [
+        s3deploy.Source.asset(
+          path.join(__dirname, '..', 'agent-image', 'skills'),
+          {
+            exclude: [
+              '**/*.test.js',
+              '**/*.test.ts',
+              '**/test_*.py',
+              '**/*_test.py',
+              '**/__pycache__/**',
+              '**/*.pyc',
+              '**/*.pyo',
+              '**/node_modules/**',
+              '**/.env',
+              '**/.env.*',
+              '**/.DS_Store',
+              '**/*.icloud',
+              '**/.vscode/**',
+              '**/.idea/**',
+              '**/*.swp',
+              '**/.build-probes/**',
+              '**/.candidate-builds/**',
+              '**/mcp-test-support.js',
+            ],
+          },
+        ),
+      ],
+      destinationBucket: resources.workspaceBucket,
+      destinationKeyPrefix: `skills/bundled/${agentImageTag}/`,
+      prune: true,
+      // Initializer rows deliberately survive stack deletion; retain the
+      // matching artifacts as well so those rows never become dangling.
+      retainOnDelete: true,
+    });
   }
 
   private loadBundledSkillsManifest(): BundledSkillManifestEntry[] {
@@ -4722,35 +4783,21 @@ export class AgentPlatformStack extends cdk.Stack {
         continue;
       }
       const raw = validatedFs.readFileSync(skillMdPath, 'utf8');
-      const frontmatter = raw.match(/^---\n([\s\S]*?)\n---/);
+      const frontmatter = parseBundledSkillFrontmatter(raw);
       if (!frontmatter) {
         continue;
       }
-
-      let name = '';
-      let summary = '';
-      let description = '';
-      for (const line of frontmatter[1].split('\n')) {
-        const field = line.match(/^(name|summary|description):\s*(.*)$/);
-        if (!field) {
-          continue;
-        }
-        if (field[1] === 'name') {
-          name = field[2].trim();
-        } else if (field[1] === 'summary') {
-          summary = field[2].trim();
-        } else {
-          description = field[2].trim();
-        }
-      }
-      if (!name) {
-        continue;
+      if (frontmatter.name !== entry) {
+        throw new Error(
+          `Bundled skill folder "${entry}" must match frontmatter name "${frontmatter.name}"`,
+        );
       }
 
       manifest.push({
-        name,
-        summary: summary || `Bundled skill: ${name}`,
-        description,
+        name: frontmatter.name,
+        summary: frontmatter.summary,
+        description: frontmatter.description,
+        allowedTools: frontmatter.allowedTools,
         sourceHash: crypto.createHash('sha256').update(raw).digest('hex'),
         // Resolved by the Lambda at invoke time via its environment.
         imageTag: 'unknown',

--- a/infra/lib/bundled-skill-manifest.ts
+++ b/infra/lib/bundled-skill-manifest.ts
@@ -1,0 +1,86 @@
+export interface BundledSkillFrontmatter {
+  name: string;
+  summary: string;
+  description: string;
+  allowedTools: string[];
+}
+
+/**
+ * Parse the small SKILL.md frontmatter subset needed by the bundled-skill
+ * initializer. This deliberately avoids a YAML runtime dependency in CDK while
+ * accepting both supported `allowed-tools` forms:
+ *
+ *   allowed-tools: Read, documents.create@v1
+ *
+ * and:
+ *
+ *   allowed-tools:
+ *     - Read
+ *     - documents.create@v1
+ */
+export function parseBundledSkillFrontmatter(
+  raw: string,
+): BundledSkillFrontmatter | null {
+  const frontmatter = raw.match(/^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/);
+  if (!frontmatter) {
+    return null;
+  }
+
+  let name = '';
+  let summary = '';
+  let description = '';
+  const allowedTools: string[] = [];
+  let inAllowedToolsBlock = false;
+
+  for (const rawLine of frontmatter[1].split(/\r?\n/)) {
+    const allowedToolsField = rawLine.match(/^allowed-tools:\s*(.*)$/);
+    if (allowedToolsField) {
+      const inline = allowedToolsField[1].trim();
+      if (inline) {
+        allowedTools.push(
+          ...inline
+            .split(',')
+            .map((entry) => entry.trim())
+            .filter(Boolean),
+        );
+      }
+      inAllowedToolsBlock = inline.length === 0;
+      continue;
+    }
+
+    if (inAllowedToolsBlock) {
+      const listItem = rawLine.match(/^\s+-\s+(.+?)\s*$/);
+      if (listItem) {
+        allowedTools.push(listItem[1].trim());
+        continue;
+      }
+      if (rawLine.trim() === '') {
+        continue;
+      }
+      inAllowedToolsBlock = false;
+    }
+
+    const field = rawLine.match(/^(name|summary|description):\s*(.*)$/);
+    if (!field) {
+      continue;
+    }
+    if (field[1] === 'name') {
+      name = field[2].trim();
+    } else if (field[1] === 'summary') {
+      summary = field[2].trim();
+    } else {
+      description = field[2].trim();
+    }
+  }
+
+  if (!name) {
+    return null;
+  }
+
+  return {
+    name,
+    summary: summary || `Bundled skill: ${name}`,
+    description,
+    allowedTools,
+  };
+}

--- a/lib/agent-skills/service.ts
+++ b/lib/agent-skills/service.ts
@@ -231,9 +231,10 @@ export class AgentSkillsService {
       "agentSkills.load",
     );
     if (!skill) return null;
-    // The broker owns the approval check, but bundled content lives only in
-    // the agent image. Return a marker so the signed caller can read its local,
-    // read-only copy without treating the image breadcrumb as an S3 prefix.
+    // Backward compatibility for rows created before bundled artifacts were
+    // published to the workspace bucket. The broker owns the approval check;
+    // an old image breadcrumb tells the signed caller to use its local,
+    // read-only copy during a rolling deployment.
     if (skill.s3Key.startsWith("image:")) {
       return { name: skill.name, source: "bundled" as const };
     }

--- a/lib/agent-skills/service.ts
+++ b/lib/agent-skills/service.ts
@@ -231,6 +231,12 @@ export class AgentSkillsService {
       "agentSkills.load",
     );
     if (!skill) return null;
+    // The broker owns the approval check, but bundled content lives only in
+    // the agent image. Return a marker so the signed caller can read its local,
+    // read-only copy without treating the image breadcrumb as an S3 prefix.
+    if (skill.s3Key.startsWith("image:")) {
+      return { name: skill.name, source: "bundled" as const };
+    }
     const skillMd = await readSkillMarkdown(skill.s3Key);
     return skillMd ? { name: skill.name, skillMd } : null;
   }

--- a/lib/skills/skill-publish-pipeline.ts
+++ b/lib/skills/skill-publish-pipeline.ts
@@ -273,12 +273,14 @@ export async function invokeSkillScan(
  */
 export const MAX_EXPORT_FILES = 50
 export const MAX_EXPORT_TOTAL_BYTES = 10 * 1024 * 1024 // 10 MB
+export const MAX_INJECTED_REFERENCE_FILES = 10
+export const MAX_INJECTED_REFERENCE_BYTES = 512 * 1024 // 512 KiB
 
 export interface DownloadedSkillFile {
   /** Relative path within the skill folder, e.g. "SKILL.md". */
   path: string
-  /** UTF-8 text content. */
-  content: string
+  /** Raw object bytes; ZIP export must not UTF-8-decode binary assets. */
+  content: Uint8Array
 }
 
 async function requireBucket(): Promise<string> {
@@ -348,17 +350,97 @@ export async function downloadSkillObject(key: string): Promise<string> {
   return res.Body.transformToString("utf-8")
 }
 
+/** Download a single S3 object without decoding or changing its bytes. */
+export async function downloadSkillObjectBytes(
+  key: string
+): Promise<Uint8Array> {
+  const bucket = await requireBucket()
+  const s3 = getS3()
+  const res = await s3.send(
+    new GetObjectCommand({ Bucket: bucket, Key: key })
+  )
+  if (!res.Body) {
+    throw new Error(`No body returned from S3 for key "${key}"`)
+  }
+  return res.Body.transformToByteArray()
+}
+
+interface SkillMarkdownReference {
+  path: string
+  content: string
+}
+
+async function readBundledMarkdownReferences(
+  s3Prefix: string
+): Promise<SkillMarkdownReference[]> {
+  const prefix = s3Prefix.endsWith("/") ? s3Prefix.slice(0, -1) : s3Prefix
+  const referencesPrefix = `${prefix}/references`
+  const keyPrefix = `${referencesPrefix}/`
+  const keys = (await listSkillObjectKeys(referencesPrefix))
+    .filter((key) => key.toLowerCase().endsWith(".md"))
+    .sort()
+
+  if (keys.length > MAX_INJECTED_REFERENCE_FILES) {
+    throw new Error(
+      `Skill has ${keys.length} Markdown references, exceeding the injection limit of ${MAX_INJECTED_REFERENCE_FILES}.`
+    )
+  }
+
+  const references = await Promise.all(
+    keys.map(async (key) => ({
+      path: `references/${key.slice(keyPrefix.length)}`,
+      content: await downloadSkillObject(key),
+    }))
+  )
+  const totalBytes = references.reduce(
+    (sum, reference) =>
+      sum + Buffer.byteLength(reference.content, "utf-8"),
+    0
+  )
+  if (totalBytes > MAX_INJECTED_REFERENCE_BYTES) {
+    throw new Error(
+      `Skill Markdown references total ${totalBytes} bytes, exceeding the injection limit of ${MAX_INJECTED_REFERENCE_BYTES} bytes.`
+    )
+  }
+  return references
+}
+
+function appendBundledMarkdownReferences(
+  skillMd: string,
+  references: SkillMarkdownReference[]
+): string {
+  if (references.length === 0) return skillMd
+  const sections = references.map(
+    (reference) =>
+      `### ${reference.path}\n\n${reference.content.trimEnd()}`
+  )
+  return [
+    skillMd.trimEnd(),
+    "## Catalog-loaded references",
+    "The bundled reference files requested above are already loaded below. Use this content directly when a filesystem `Read` tool is unavailable.",
+    ...sections,
+    "",
+  ].join("\n\n")
+}
+
 /**
  * Read a skill's SKILL.md from its S3 prefix. Returns null if it is missing (the
  * skill row may exist before the folder is fully written, or the artifact may be
- * absent for legacy rows).
+ * absent for legacy rows). For reviewed bundled skills, append bounded Markdown
+ * references so catalog consumers that have no agent-image filesystem (Nexus,
+ * internal/MCP execution) receive the same required knowledge.
  */
 export async function readSkillMarkdown(s3Prefix: string): Promise<string | null> {
   const prefix = s3Prefix.endsWith("/") ? s3Prefix.slice(0, -1) : s3Prefix
   try {
-    return await downloadSkillObject(`${prefix}/SKILL.md`)
+    const skillMd = await downloadSkillObject(`${prefix}/SKILL.md`)
+    if (!prefix.startsWith("skills/bundled/")) {
+      return skillMd
+    }
+    const references = await readBundledMarkdownReferences(prefix)
+    return appendBundledMarkdownReferences(skillMd, references)
   } catch (error) {
-    log.warn("SKILL.md not readable for skill prefix", {
+    log.warn("Skill instructions not readable for skill prefix", {
       s3Prefix,
       error: error instanceof Error ? error.message : String(error),
     })
@@ -368,7 +450,7 @@ export async function readSkillMarkdown(s3Prefix: string): Promise<string | null
 
 /**
  * Download all authored files in a skill folder (for zip export). Returns each
- * file's path relative to the skill folder plus its UTF-8 content.
+ * file's path relative to the skill folder plus its unmodified object bytes.
  */
 export async function downloadSkillFolder(
   s3Prefix: string
@@ -387,14 +469,14 @@ export async function downloadSkillFolder(
   const files = await Promise.all(
     keys.map(async (key) => ({
       path: key.slice(prefix.length),
-      content: await downloadSkillObject(key),
+      content: await downloadSkillObjectBytes(key),
     }))
   )
 
-  // Cap total decoded size so an oversized folder cannot spike ECS task memory
+  // Cap total raw size so an oversized folder cannot spike ECS task memory
   // while the zip is built in-memory.
   const totalBytes = files.reduce(
-    (sum, f) => sum + Buffer.byteLength(f.content, "utf-8"),
+    (sum, file) => sum + file.content.byteLength,
     0
   )
   if (totalBytes > MAX_EXPORT_TOTAL_BYTES) {

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "test:skill:hyperframes": "cd infra/agent-image/skills/psd-hyperframes && bun test",
     "test:skill:atrium": "cd infra/agent-image/skills/psd-atrium && bun test",
     "test:skill:sop-creator": "cd infra/agent-image/skills/psd-sop-creator && bun test",
+    "test:skill:conversation-coach": "cd infra/agent-image/skills/psd-conversation-coach && bun test",
     "test:skill:morning-brief": "cd infra/agent-image/skills/psd-morning-brief && bun test",
     "test:smoke:atrium": "bun run test:smoke:atrium-render && bun run test:smoke:atrium-collab && bun run test:smoke:atrium-collab-token && bun run test:smoke:atrium-agent-bridge && bun run test:smoke:atrium-agent-read && bun run test:smoke:atrium-html-sanitize && bun run test:smoke:atrium-provenance-rail && bun run test:smoke:atrium-collab-schema && bun run test:smoke:atrium-suggestions-resolve && bun run test:smoke:atrium-suggestion-mode && bun run test:smoke:atrium-sandbox-config && bun run test:smoke:atrium-sandbox-host",
     "test:ci": "jest --config=jest.config.ci.js",

--- a/tests/fixtures/agent-skills-broker-preload.cjs
+++ b/tests/fixtures/agent-skills-broker-preload.cjs
@@ -1,0 +1,14 @@
+'use strict';
+
+const status = Number(process.env.TEST_AGENT_BROKER_STATUS);
+const body = process.env.TEST_AGENT_BROKER_BODY;
+
+if (!Number.isInteger(status) || status < 100 || status > 599 || !body) {
+  throw new Error('Missing or invalid agent-skills broker fixture configuration');
+}
+
+globalThis.fetch = async () =>
+  new Response(body, {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });

--- a/tests/unit/agent-skills-service.test.ts
+++ b/tests/unit/agent-skills-service.test.ts
@@ -1,0 +1,78 @@
+const executeQueryMock = jest.fn()
+const readSkillMarkdownMock = jest.fn()
+
+jest.mock("@/lib/db/drizzle-client", () => ({
+  executeQuery: (...args: unknown[]) => executeQueryMock(...args),
+  executeTransaction: jest.fn(),
+}))
+
+jest.mock("@/lib/skills/skill-publish-pipeline", () => ({
+  invokeSkillScan: jest.fn(),
+  readSkillMarkdown: (...args: unknown[]) => readSkillMarkdownMock(...args),
+  uploadSkillDraft: jest.fn(),
+}))
+
+import { AgentSkillsService } from "@/lib/agent-skills/service"
+
+function mockAccessibleSkill(skill: { name: string; s3Key: string } | null) {
+  executeQueryMock
+    .mockResolvedValueOnce([{ id: 42 }])
+    .mockResolvedValueOnce(skill ? [skill] : [])
+}
+
+beforeEach(() => {
+  executeQueryMock.mockReset()
+  readSkillMarkdownMock.mockReset()
+})
+
+describe("AgentSkillsService.load", () => {
+  it("returns a bundled marker only after the catalog access query succeeds", async () => {
+    mockAccessibleSkill({
+      name: "psd-conversation-coach",
+      s3Key: "image:agent-v1:psd-conversation-coach",
+    })
+
+    await expect(
+      new AgentSkillsService().load(
+        "owner@psd401.net",
+        "psd-conversation-coach"
+      )
+    ).resolves.toEqual({
+      name: "psd-conversation-coach",
+      source: "bundled",
+    })
+    expect(readSkillMarkdownMock).not.toHaveBeenCalled()
+  })
+
+  it("does not expose a bundled marker for an inaccessible catalog row", async () => {
+    mockAccessibleSkill(null)
+
+    await expect(
+      new AgentSkillsService().load(
+        "owner@psd401.net",
+        "psd-conversation-coach"
+      )
+    ).resolves.toBeNull()
+    expect(readSkillMarkdownMock).not.toHaveBeenCalled()
+  })
+
+  it("continues to load approved user-authored skills from S3", async () => {
+    mockAccessibleSkill({
+      name: "owner-conversation-notes",
+      s3Key: "skills/user/owner/approved/owner-conversation-notes",
+    })
+    readSkillMarkdownMock.mockResolvedValue(
+      "---\nname: owner-conversation-notes\n---"
+    )
+
+    await expect(
+      new AgentSkillsService().load(
+        "owner@psd401.net",
+        "owner-conversation-notes"
+      )
+    ).resolves.toEqual({
+      name: "owner-conversation-notes",
+      skillMd: "---\nname: owner-conversation-notes\n---",
+    })
+  })
+})

--- a/tests/unit/bundled-skill-manifest.test.ts
+++ b/tests/unit/bundled-skill-manifest.test.ts
@@ -1,0 +1,67 @@
+import * as fs from "node:fs"
+import * as path from "node:path"
+import { parseBundledSkillFrontmatter } from "@/infra/lib/bundled-skill-manifest"
+
+describe("bundled skill manifest frontmatter", () => {
+  it("persists the conversation coach Read-only pin", () => {
+    const raw = fs.readFileSync(
+      path.join(
+        process.cwd(),
+        "infra",
+        "agent-image",
+        "skills",
+        "psd-conversation-coach",
+        "SKILL.md"
+      ),
+      "utf8"
+    )
+
+    expect(parseBundledSkillFrontmatter(raw)).toMatchObject({
+      name: "psd-conversation-coach",
+      allowedTools: ["Read"],
+    })
+  })
+
+  it("accepts inline and YAML-list allowed-tools forms", () => {
+    expect(
+      parseBundledSkillFrontmatter(
+        [
+          "---",
+          "name: inline-skill",
+          "summary: Inline",
+          "allowed-tools: Read, documents.create@v1",
+          "---",
+        ].join("\n")
+      )?.allowedTools
+    ).toEqual(["Read", "documents.create@v1"])
+
+    expect(
+      parseBundledSkillFrontmatter(
+        [
+          "---",
+          "name: list-skill",
+          "summary: List",
+          "allowed-tools:",
+          "  - Read",
+          "  - documents.create@v1",
+          "description: A list-form skill",
+          "---",
+        ].join("\r\n")
+      )
+    ).toEqual({
+      name: "list-skill",
+      summary: "List",
+      description: "A list-form skill",
+      allowedTools: ["Read", "documents.create@v1"],
+    })
+  })
+
+  it("rejects missing frontmatter and missing names", () => {
+    expect(parseBundledSkillFrontmatter("# no frontmatter")).toBeNull()
+    expect(
+      parseBundledSkillFrontmatter(
+        ["---", "summary: Missing name", "---"].join("\n")
+      )
+    ).toBeNull()
+  })
+})

--- a/tests/unit/bundled-skill-registration.test.ts
+++ b/tests/unit/bundled-skill-registration.test.ts
@@ -1,0 +1,89 @@
+import { bundledSkillRegistration } from "@/infra/lambdas/agent-skill-initializer/registration"
+
+describe("bundled skill registration", () => {
+  it("points the coach at deployed artifacts and persists its Read-only pin", () => {
+    expect(
+      bundledSkillRegistration(
+        {
+          name: "psd-conversation-coach",
+          summary: "Practice a crucial conversation",
+          description: "Conversation coaching",
+          allowedTools: ["Read"],
+          sourceHash: "source-hash",
+          imageTag: "unknown",
+        },
+        "agent-v1"
+      )
+    ).toEqual({
+      name: "psd-conversation-coach",
+      summary: "Practice a crucial conversation",
+      s3Key: "skills/bundled/agent-v1/psd-conversation-coach",
+      allowedTools: ["Read"],
+    })
+  })
+
+  it("normalizes absent and invalid runtime tool entries", () => {
+    expect(
+      bundledSkillRegistration(
+        {
+          name: "psd-test",
+          summary: "Test",
+          allowedTools: ["", "  ", " Read ", 42 as unknown as string],
+          sourceHash: "source-hash",
+          imageTag: "unknown",
+        },
+        "agent-v1"
+      )?.allowedTools
+    ).toEqual(["Read"])
+
+    expect(
+      bundledSkillRegistration(
+        {
+          name: "psd-test",
+          summary: "Test",
+          sourceHash: "source-hash",
+          imageTag: "unknown",
+        },
+        "agent-v1"
+      )?.allowedTools
+    ).toEqual([])
+  })
+
+  it("skips incomplete manifest entries", () => {
+    expect(
+      bundledSkillRegistration(
+        {
+          name: "",
+          summary: "Missing name",
+          sourceHash: "source-hash",
+          imageTag: "unknown",
+        },
+        "agent-v1"
+      )
+    ).toBeNull()
+
+    expect(
+      bundledSkillRegistration(
+        {
+          name: "../unsafe",
+          summary: "Unsafe name",
+          sourceHash: "source-hash",
+          imageTag: "unknown",
+        },
+        "agent-v1"
+      )
+    ).toBeNull()
+
+    expect(
+      bundledSkillRegistration(
+        {
+          name: "psd-test",
+          summary: "Unsafe tag",
+          sourceHash: "source-hash",
+          imageTag: "unknown",
+        },
+        "../unsafe"
+      )
+    ).toBeNull()
+  })
+})

--- a/tests/unit/skill-publish-pipeline-export.test.ts
+++ b/tests/unit/skill-publish-pipeline-export.test.ts
@@ -52,13 +52,17 @@ import {
   downloadSkillFolder,
   MAX_EXPORT_FILES,
   MAX_EXPORT_TOTAL_BYTES,
+  readSkillMarkdown,
 } from "@/lib/skills/skill-publish-pipeline"
 
 const PREFIX = "skills/user/a@b.com/approved/my-skill/"
 
 // Drive the mocked S3 client: a single ListObjectsV2 page returning `keys`,
 // then a GetObject per key returning `bodyFor(key)`.
-function wireS3(keys: string[], bodyFor: (key: string) => string) {
+function wireS3(
+  keys: string[],
+  bodyFor: (key: string) => string | Uint8Array
+) {
   sendMock.mockReset()
   sendMock.mockImplementation((command: { input: Record<string, unknown> }) => {
     if ("Prefix" in command.input) {
@@ -68,8 +72,14 @@ function wireS3(keys: string[], bodyFor: (key: string) => string) {
       })
     }
     const key = command.input.Key as string
+    const content = bodyFor(key)
+    const bytes =
+      typeof content === "string" ? Buffer.from(content, "utf8") : content
     return Promise.resolve({
-      Body: { transformToString: async () => bodyFor(key) },
+      Body: {
+        transformToString: async () => Buffer.from(bytes).toString("utf8"),
+        transformToByteArray: async () => bytes,
+      },
     })
   })
 }
@@ -86,6 +96,20 @@ describe("downloadSkillFolder export bounds", () => {
     expect(files).toHaveLength(2)
     expect(files[0].path).toBe("SKILL.md")
     expect(files[1].path).toBe("helpers/util.md")
+    expect(Buffer.from(files[0].content).toString("utf8")).toBe(
+      `content of ${PREFIX}SKILL.md`
+    )
+  })
+
+  it("preserves binary object bytes exactly", async () => {
+    const binary = Uint8Array.from([0, 255, 1, 128, 13, 10])
+    wireS3([`${PREFIX}assets/logo.png`], () => binary)
+
+    const files = await downloadSkillFolder(PREFIX)
+
+    expect(files).toEqual([
+      { path: "assets/logo.png", content: binary },
+    ])
   })
 
   it("rejects folders exceeding the file-count cap", async () => {
@@ -121,5 +145,39 @@ describe("downloadSkillFolder export bounds", () => {
     await expect(downloadSkillFolder(PREFIX)).rejects.toThrow(
       /exceeding the export limit of .* bytes/
     )
+  })
+})
+
+describe("readSkillMarkdown bundled references", () => {
+  const bundledPrefix =
+    "skills/bundled/agent-v1/psd-conversation-coach/"
+
+  it("appends bundled Markdown references for catalog-only runtimes", async () => {
+    wireS3(
+      [
+        `${bundledPrefix}references/coaching-guide.md`,
+        `${bundledPrefix}references/framework.md`,
+        `${bundledPrefix}references/scenarios.md`,
+      ],
+      (key) => {
+        if (key.endsWith("SKILL.md")) return "# Coach instructions"
+        return `content for ${key.slice(bundledPrefix.length)}`
+      }
+    )
+
+    const skillMd = await readSkillMarkdown(bundledPrefix)
+
+    expect(skillMd).toContain("# Coach instructions")
+    expect(skillMd).toContain("## Catalog-loaded references")
+    expect(skillMd).toContain("### references/coaching-guide.md")
+    expect(skillMd).toContain("content for references/framework.md")
+    expect(skillMd).toContain("content for references/scenarios.md")
+  })
+
+  it("does not inject sibling files for user-authored skills", async () => {
+    wireS3([], () => "# User skill")
+
+    await expect(readSkillMarkdown(PREFIX)).resolves.toBe("# User skill")
+    expect(sendMock).toHaveBeenCalledTimes(1)
   })
 })


### PR DESCRIPTION
## Description

Adds the bundled `psd-conversation-coach` knowledge skill for preparing,
practicing, and debriefing difficult high-stakes conversations. The skill uses
the publicly documented *Crucial Conversations* framework, supports prep,
role-play, and debrief modes, and provides fictional PSD practice scenarios
only when a user has no real conversation of their own.

Closes #1464

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation/content update
- [x] Infrastructure resource change

## Implementation Notes

- Adds deploy-parser-compatible frontmatter and discoverability coverage for
  `crucial conversation`, `difficult conversation`, `practice`, `role-play`,
  `parent meeting`, `peer conflict`, and `coaching up`.
- Adds an original, attributed framework summary grounded in public Crucial
  Learning sources, including third-edition CPR guidance.
- Adds intake, prep, role-play, and framework-named debrief mechanics.
- Adds nine fictional PSD scenarios spanning administrator, teacher, support
  staff, parent/caregiver, peer, and coaching-up contexts.
- Adds confidentiality, non-affiliation, no-therapy/HR/legal-advice, role-play
  exit, and no-verbatim-book-content guardrails.
- Adds and registers an L0 regression eval for the no-scenario fallback.
- Publishes the reviewed bundled-skill tree to a versioned workspace-bucket
  prefix before catalog initialization. Existing catalog preview, Nexus,
  internal/MCP, ZIP export, and `psd-skills-meta` consumers therefore read the
  same S3 artifact instead of an unreadable image breadcrumb.
- Appends bounded bundled Markdown references to catalog-loaded instructions,
  giving Nexus and other runtimes without the agent-image filesystem the same
  required coaching knowledge.
- Parses both inline and YAML-list `allowed-tools` frontmatter and persists it
  during bundled-skill initialization. The coach's `Read` pin now fails closed
  through the existing server-side tool intersection.
- Preserves raw S3 object bytes during ZIP export so bundled PDFs, images, and
  other binary assets are not corrupted by UTF-8 decoding.
- Preserves the authorized local-image fallback for old catalog rows during a
  rolling deployment.
- Wires the skill registration regression test into the repository CI workflow.
- Replaces dynamic `node -e` test construction with a static preload fixture;
  CodeQL analysis marked alert #595 fixed on the preceding revision.

## Validation

- [x] `bun run test:skill:conversation-coach` — 11 passed
- [x] `UV_CACHE_DIR=/tmp/issue-1464-uv-cache uv run infra/agent-image/check_eval_coverage.py` — 31 covered, 45 opted out
- [x] `bun test infra/agent-image/skills/psd-skills-meta/authority.test.js` — 6 passed
- [x] Bundled catalog/storage/tool-pin targeted Jest suites — 6 suites, 50 tests passed
- [x] Catalog-reference/binary-export targeted Jest suites — 4 suites, 47 tests passed
- [x] `bun run lint` — zero warnings
- [x] `bun run typecheck`
- [x] `bun run test:ci -- --runInBand` — 533 suites passed, 4,940 tests passed, 15 skipped
- [x] `bun run openapi:check`
- [x] `bun run capabilities:check`
- [x] `python3 infra/agent-image/eval/summarize.py --check-repository`
- [x] Full agent-image Python unittest command from CI — 550 passed, 1 skipped
- [x] All standalone agent-image Bun/Node skill tests from CI
- [x] `CI=true bun run test:smoke:atrium`
- [x] `bun run build`
- [x] `cd infra && bun run build`
- [x] `cd infra/lambdas/agent-skill-initializer && bun run build`
- [x] `cd infra && bunx cdk synth --quiet`
- [x] Synthesized deployment contains the coach SKILL/eval/references, excludes
  tests and environment files, and orders the initializer after S3 deployment
- [x] Unified-content and embedding Lambda artifact Docker smokes
- [x] `bun run test:smoke:auth-edge-production`
- [x] E2E: N/A — no web UI behavior changed. The repository-documented
  `SKIP_E2E=1` push bypass was used because this isolated worktree has no local
  `AUTH_SECRET`; the hook aborted before starting Playwright.

## Risk, Migrations, and Rollback

- Infrastructure risk is bounded to an S3 deployment under
  `skills/bundled/<immutable-image-tag>/`; test/build caches and environment
  files are excluded, artifacts are retained on stack deletion, and the
  registry update depends on the upload completing.
- Catalog reference injection is restricted to reviewed `skills/bundled/`
  prefixes, Markdown files under `references/`, at most 10 files and 512 KiB.
- No database migration, API change, dependency, Dockerfile, or
  `openclaw.json` change. The existing initializer updates `s3_key` and
  `allowed_tools` in place on the next normal AgentPlatform deployment.
- Rollback is reverting this PR and redeploying the preceding agent image and
  AgentPlatform stack; S3 bucket versioning/retention preserves prior bytes.

## Manual Follow-up

Deployment is intentionally out of scope for this PR. After a human deploys
the agent image and AgentPlatform stack, run the two issue smoke prompts: one
user-supplied staff conversation and one no-scenario practice request.

## Screenshots

N/A — no web UI changes.
