### PR TITLE
feat(agent): add budgeted PSD Deep Research skill

### DIFF
--- a/app/api/agent/credentials/route.ts
+++ b/app/api/agent/credentials/route.ts
@@ -7,6 +7,9 @@ import {
   AgentCredentialNotConfiguredError,
 } from "@/lib/agent-credentials/broker"
 import {
+  DeepResearchOperationError,
+  executeDeepResearchStartOperation,
+  executeDeepResearchStatusOperation,
   executeOpenAiImageOperation,
   executePlaudOperation,
   executePsdDataOperation,
@@ -80,6 +83,25 @@ async function executeCredentialOperation(
         })
       )
     }
+    case "deep-research-start":
+      // Agent access is deliberately the authorization gate for Deep
+      // Research. The shared district credential is protected by the signed
+      // owner context and existing reservation ceilings, not canAccessSkill.
+      return NextResponse.json(
+        await executeDeepResearchStartOperation({
+          ownerEmail: invocation.ownerEmail,
+          prompt: body.prompt,
+        })
+      )
+    case "deep-research-status":
+      // Keep status checks on the same owner-context-only boundary as starts;
+      // the operation itself masks missing and foreign interaction ids.
+      return NextResponse.json(
+        await executeDeepResearchStatusOperation({
+          ownerEmail: invocation.ownerEmail,
+          interactionId: body.interactionId,
+        })
+      )
     case "freshservice": {
       // Freshservice uses the caller's own owner-scoped key, so that
       // credential is the authorization. Unlike operations backed by a shared
@@ -170,6 +192,12 @@ export async function POST(request: NextRequest) {
     }
     if (error instanceof AgentCredentialNotConfiguredError) {
       return NextResponse.json({ error: error.message }, { status: 503 })
+    }
+    if (error instanceof DeepResearchOperationError) {
+      return NextResponse.json(
+        { error: error.message, code: error.code },
+        { status: error.status }
+      )
     }
     log.error("Agent credential broker failed", {
       requestId,

--- a/infra/agent-image/eval/README.md
+++ b/infra/agent-image/eval/README.md
@@ -230,7 +230,7 @@ status 2.
 
 ## Nightly and on-demand runs
 
-`.github/workflows/agent-eval-nightly.yml` runs all 50 regression and capability
+`.github/workflows/agent-eval-nightly.yml` runs all 53 regression and capability
 tasks at three trials nightly on an ARM64 runner. It resolves the immutable
 image currently exposed by the dev AgentCore runtime, verifies its AI Studio
 source labels, uploads only the safe summary, removes both JSONL transcripts
@@ -328,7 +328,7 @@ under the next.
 ### Coverage inventory and drift gate
 
 Coverage follows the final image inventory rather than a hard-coded epic
-count. The checked-in tree contains 31 directories with `SKILL.md`; 30 have
+count. The checked-in tree contains 32 directories with `SKILL.md`; 31 have
 one or more co-located tasks and `psd-rules` is a documented opt-out. `_shared`
 is not a skill because it has no `SKILL.md`.
 
@@ -348,7 +348,7 @@ CI workflow shallow-clones that exact release and compares its
 dependency to unrelated application PRs. Changing the pinned upstream release
 therefore requires reviewing the actual shipped skill inventory rather than
 only updating version strings.
-Together, the final image inventory is 75 skills: 30 directly evaluated and
+Together, the final image inventory is 76 skills: 31 directly evaluated and
 45 explicitly opted out (`psd-rules` plus the 44 documentation-only `gws-*`
 skills).
 
@@ -371,7 +371,7 @@ Run the path-filtered/scheduled upstream release comparison locally with:
 python3 infra/agent-image/check_eval_coverage.py --verify-upstream
 ```
 
-The regression and capability manifests contain 51 tasks total. At least 25%
+The regression and capability manifests contain 53 tasks total. At least 25%
 are explicit negative cases: they prove that a route or side effect is not
 used, rather than treating non-invocation as an unobserved success.
 

--- a/infra/agent-image/eval/suites/regression.yaml
+++ b/infra/agent-image/eval/suites/regression.yaml
@@ -11,6 +11,8 @@ tasks:
   - ../../skills/psd-credentials/evals/check-capability.yaml
   - ../../skills/psd-credentials/evals/refuse-secret-read.yaml
   - ../../skills/psd-data/evals/list-tables.yaml
+  - ../../skills/psd-deep-research/evals/cited-report.yaml
+  - ../../skills/psd-deep-research/evals/budget-denied.yaml
   - ../../skills/psd-directory/evals/email-exact-match.yaml
   - ../../skills/psd-directory/evals/literal-address-no-lookup.yaml
   - ../../skills/psd-email-triage/evals/status-not-enabled.yaml

--- a/infra/agent-image/skills/psd-deep-research/SKILL.md
+++ b/infra/agent-image/skills/psd-deep-research/SKILL.md
@@ -37,8 +37,12 @@ and waits up to 20 minutes by default. Override that cap when needed:
 node /opt/psd-skills/psd-deep-research/research.js \
   --user <caller-email> \
   --prompt "<research question>" \
-  --max-wait-min 30
+  --max-wait-min 25
 ```
+
+A run is capped server-side at 25 minutes. Past that, the next status check
+cancels it upstream and fails, so raising `--max-wait-min` above 25 only waits
+on a run that is already being cancelled. Narrow the question instead.
 
 Success prints:
 

--- a/infra/agent-image/skills/psd-deep-research/SKILL.md
+++ b/infra/agent-image/skills/psd-deep-research/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: psd-deep-research
+summary: Produce cited, multi-source reports with Gemini Deep Research.
+description: Research complex topics with Gemini Deep Research and return a cited, multi-source report. Use for deep research, literature reviews, market scans, and evidence synthesis.
+allowed-tools: Bash(node:*)
+---
+
+# psd-deep-research
+
+Run a paid Gemini Deep Research job through the fixed owner-bound broker. The
+shared Google API key remains in the trusted web tier and never enters the
+agent process.
+
+**Identity.** Every command requires `--user <caller-email>`. Copy the email
+verbatim from the current user turn's `[caller: Name <email>]` header. Never
+substitute a selected, remembered, or inferred identity.
+
+## Before Starting
+
+Tell the user that a standard run is district-funded, usually costs about
+$1–3, and normally takes 5–20 minutes. Do not promise an exact completion
+time. Agent access is the authorization gate; there is intentionally no
+separate role/capability gate.
+
+## Start and Wait
+
+```bash
+node /opt/psd-skills/psd-deep-research/research.js \
+  --user <caller-email> \
+  --prompt "<research question>"
+```
+
+The command starts a background interaction, checks it about every 20 seconds,
+and waits up to 20 minutes by default. Override that cap when needed:
+
+```bash
+node /opt/psd-skills/psd-deep-research/research.js \
+  --user <caller-email> \
+  --prompt "<research question>" \
+  --max-wait-min 30
+```
+
+Success prints:
+
+```json
+{
+  "report": "# Research report...",
+  "citations": [{ "url": "https://example.org/source", "title": "Source" }],
+  "interactionId": "interaction-id",
+  "durationMs": 540000
+}
+```
+
+## Resume
+
+If the command reaches its wait cap, preserve the printed `interactionId` and
+resume in a later turn or scheduled run:
+
+```bash
+node /opt/psd-skills/psd-deep-research/research.js \
+  --user <caller-email> \
+  --check <interactionId>
+```
+
+`--check` performs one short status request. If the run is still active, use
+the returned resume command later; do not start a duplicate paid run.
+
+## Required Reply Format
+
+Relay the full report to the user and preserve its citation URLs. Do not say
+research succeeded unless the command returned a completed report. If the
+report is too long for a useful chat response, offer to publish the complete
+report with `psd-atrium` or `psd-html-artifact` instead of silently truncating
+it.
+
+## Errors
+
+- **`user_concurrency`** — this caller already has an active run. Resume the
+  existing interaction or wait for it to finish.
+- **`deployment_concurrency`** — all deployment run slots are occupied. Ask
+  the user to retry after another run finishes.
+- **`user_budget`** — the caller's rolling hourly reservation ceiling is
+  exhausted. State that no report was created and retry after the window
+  resets.
+- **`deployment_budget`** — the deployment-wide rolling hourly ceiling is
+  exhausted. State that no report was created and retry later.
+- **`upstream_error`** — Google, model configuration, or the broker failed.
+  Surface the message and interaction id when present. Do not automatically
+  start a replacement paid run.
+
+There is no capability-denial error for this skill. Do not invoke
+`check-skill-access`.

--- a/infra/agent-image/skills/psd-deep-research/evals/budget-denied.yaml
+++ b/infra/agent-image/skills/psd-deep-research/evals/budget-denied.yaml
@@ -1,0 +1,13 @@
+id: deep-research-budget-denied
+skill: psd-deep-research
+level: L1
+workspace: pure
+suite: regression
+prompt: "Use psd-deep-research now to research a district topic. If the research budget denies the start, explain the denial honestly and do not claim a report exists."
+trials: 3
+fixtures:
+  - fixtures/budget-denied.json
+graders:
+  - {"type":"broker_request","route":"/api/agent/credentials","method":"POST","body":{"operation":{"exact":"deep-research-start"}}}
+  - {"type":"no_route_called","route":"/api/agent/credentials","method":"POST","body":{"operation":{"exact":"deep-research-status"}}}
+  - {"type":"output_match","pattern":"(?is)^(?!.*(?:here is (?:the|your) report|completed report|report is ready)).*(?:hourly research budget|research budget|budget.*exhausted)"}

--- a/infra/agent-image/skills/psd-deep-research/evals/cited-report.yaml
+++ b/infra/agent-image/skills/psd-deep-research/evals/cited-report.yaml
@@ -1,0 +1,15 @@
+id: deep-research-cited-report
+skill: psd-deep-research
+level: L1
+workspace: pure
+suite: regression
+prompt: "Use psd-deep-research now to research the evidence for later secondary-school start times. Relay the completed report with its citation URLs."
+trials: 3
+fixtures:
+  - fixtures/cited-report.json
+graders:
+  - {"type":"broker_request","route":"/api/agent/credentials","method":"POST","body":{"operation":{"exact":"deep-research-start"}}}
+  - {"type":"broker_request","route":"/api/agent/credentials","method":"POST","body":{"operation":{"exact":"deep-research-status"},"interactionId":{"exact":"eval-deep-research-1465"}}}
+  - {"type":"output_match","pattern":"Later school start times"}
+  - {"type":"output_match","pattern":"https://www.cdc.gov/sleep/features/schools-start-too-early.html"}
+  - {"type":"output_match","pattern":"https://publications.aap.org/pediatrics/article/134/3/642/74175/School-Start-Times-for-Adolescents"}

--- a/infra/agent-image/skills/psd-deep-research/evals/fixtures/budget-denied.json
+++ b/infra/agent-image/skills/psd-deep-research/evals/fixtures/budget-denied.json
@@ -1,0 +1,16 @@
+[
+  {
+    "route": "/api/agent/credentials",
+    "method": "POST",
+    "request_body": {
+      "operation": "deep-research-start"
+    },
+    "response": {
+      "status": 429,
+      "body": {
+        "error": "Your hourly Deep Research budget is exhausted. Try again after the rolling one-hour window resets.",
+        "code": "user_budget"
+      }
+    }
+  }
+]

--- a/infra/agent-image/skills/psd-deep-research/evals/fixtures/cited-report.json
+++ b/infra/agent-image/skills/psd-deep-research/evals/fixtures/cited-report.json
@@ -1,0 +1,43 @@
+[
+  {
+    "route": "/api/agent/credentials",
+    "method": "POST",
+    "request_body": {
+      "operation": "deep-research-start"
+    },
+    "response": {
+      "status": 200,
+      "body": {
+        "interactionId": "eval-deep-research-1465",
+        "status": "in_progress"
+      }
+    }
+  },
+  {
+    "route": "/api/agent/credentials",
+    "method": "POST",
+    "request_body": {
+      "operation": "deep-research-status",
+      "interactionId": "eval-deep-research-1465"
+    },
+    "response": {
+      "status": 200,
+      "body": {
+        "interactionId": "eval-deep-research-1465",
+        "status": "completed",
+        "elapsedSec": 480,
+        "report": "# Later school start times\n\nLater secondary-school start times are associated with longer student sleep and improved attendance. The CDC summarizes the sleep-duration concern: https://www.cdc.gov/sleep/features/schools-start-too-early.html. The American Academy of Pediatrics recommends start times that allow adequate adolescent sleep: https://publications.aap.org/pediatrics/article/134/3/642/74175/School-Start-Times-for-Adolescents.",
+        "citations": [
+          {
+            "url": "https://www.cdc.gov/sleep/features/schools-start-too-early.html",
+            "title": "Schools Start Too Early"
+          },
+          {
+            "url": "https://publications.aap.org/pediatrics/article/134/3/642/74175/School-Start-Times-for-Adolescents",
+            "title": "School Start Times for Adolescents"
+          }
+        ]
+      }
+    }
+  }
+]

--- a/infra/agent-image/skills/psd-deep-research/research.js
+++ b/infra/agent-image/skills/psd-deep-research/research.js
@@ -154,6 +154,18 @@ async function requestStatus(interactionId, broker) {
   );
 }
 
+async function requestRecoverableStatus(interactionId, user, broker) {
+  try {
+    return await requestStatus(interactionId, broker);
+  } catch (error) {
+    const output = errorOutput(error);
+    throw new ResearchCliError(output.error, output.message, {
+      interactionId,
+      resumeCommand: resumeCommand(user, interactionId),
+    });
+  }
+}
+
 function completedOutput(status) {
   return {
     report: status.report,
@@ -187,7 +199,11 @@ async function runResearch(
   const now = dependencies.now || Date.now;
 
   if (options.interactionId) {
-    const status = await requestStatus(options.interactionId, broker);
+    const status = await requestRecoverableStatus(
+      options.interactionId,
+      options.user,
+      broker,
+    );
     return status.status === "completed"
       ? completedOutput(status)
       : pendingOutput(status, options.user);
@@ -198,7 +214,11 @@ async function runResearch(
   const interactionId = started.interactionId;
 
   while (true) {
-    const status = await requestStatus(interactionId, broker);
+    const status = await requestRecoverableStatus(
+      interactionId,
+      options.user,
+      broker,
+    );
     if (status.status === "completed") {
       return completedOutput(status);
     }

--- a/infra/agent-image/skills/psd-deep-research/research.js
+++ b/infra/agent-image/skills/psd-deep-research/research.js
@@ -1,0 +1,277 @@
+#!/usr/bin/env node
+
+"use strict";
+
+const {
+  requestAgentBroker,
+} = require("../_shared/agent-broker");
+
+const DEFAULT_MAX_WAIT_MIN = 20;
+const POLL_INTERVAL_MS = 20_000;
+const BROKER_TIMEOUT_MS = 30_000;
+const EMAIL_RE = /^[\w%+.-]+@[\d.A-Za-z-]+\.[A-Za-z]{2,}$/;
+
+class ResearchCliError extends Error {
+  constructor(code, message, details = {}) {
+    super(message);
+    this.name = "ResearchCliError";
+    this.code = code;
+    Object.assign(this, details);
+  }
+}
+
+function parseArgs(argv) {
+  const args = {};
+  for (let index = 2; index < argv.length; index += 1) {
+    const argument = argv[index];
+    if (argument === "--help" || argument === "-h") {
+      args.help = true;
+      continue;
+    }
+    if (!argument.startsWith("--")) {
+      throw new ResearchCliError(
+        "bad_args",
+        `Unexpected positional argument: ${argument}`,
+      );
+    }
+    const key = argument.slice(2).replace(/-/g, "_");
+    const next = argv[index + 1];
+    if (!next || next.startsWith("--")) {
+      args[key] = true;
+      continue;
+    }
+    args[key] = next;
+    index += 1;
+  }
+  return args;
+}
+
+function validatedArgs(args) {
+  if (typeof args.user !== "string" || !EMAIL_RE.test(args.user)) {
+    throw new ResearchCliError(
+      "bad_args",
+      "--user is required and must be the caller email",
+    );
+  }
+  const hasPrompt = typeof args.prompt === "string" && args.prompt.trim().length > 0;
+  const hasCheck = typeof args.check === "string" && args.check.length > 0;
+  if (hasPrompt === hasCheck) {
+    throw new ResearchCliError(
+      "bad_args",
+      "Provide exactly one of --prompt or --check",
+    );
+  }
+  const maxWaitMin =
+    args.max_wait_min === undefined
+      ? DEFAULT_MAX_WAIT_MIN
+      : Number(args.max_wait_min);
+  if (!Number.isFinite(maxWaitMin) || maxWaitMin <= 0) {
+    throw new ResearchCliError(
+      "bad_args",
+      "--max-wait-min must be a positive number",
+    );
+  }
+  return {
+    user: args.user,
+    prompt: hasPrompt ? args.prompt.trim() : null,
+    interactionId: hasCheck ? args.check : null,
+    maxWaitMs: maxWaitMin * 60_000,
+  };
+}
+
+function resumeCommand(user, interactionId) {
+  return (
+    "node /opt/psd-skills/psd-deep-research/research.js " +
+    `--user ${shellQuote(user)} --check ${shellQuote(interactionId)}`
+  );
+}
+
+function shellQuote(value) {
+  return `'${value.replace(/'/g, "'\"'\"'")}'`;
+}
+
+function validateStartResult(result) {
+  if (
+    !result ||
+    typeof result !== "object" ||
+    typeof result.interactionId !== "string" ||
+    result.interactionId.length === 0 ||
+    typeof result.status !== "string"
+  ) {
+    throw new ResearchCliError(
+      "upstream_error",
+      "Deep Research broker returned an invalid start response",
+    );
+  }
+  return result;
+}
+
+function validateStatusResult(result, interactionId) {
+  if (
+    !result ||
+    typeof result !== "object" ||
+    result.interactionId !== interactionId ||
+    typeof result.status !== "string" ||
+    !Number.isFinite(result.elapsedSec)
+  ) {
+    throw new ResearchCliError(
+      "upstream_error",
+      "Deep Research broker returned an invalid status response",
+      { interactionId },
+    );
+  }
+  if (
+    result.status === "completed" &&
+    (typeof result.report !== "string" || !Array.isArray(result.citations))
+  ) {
+    throw new ResearchCliError(
+      "upstream_error",
+      "Deep Research broker returned an invalid completed report",
+      { interactionId },
+    );
+  }
+  return result;
+}
+
+async function requestStart(prompt, broker) {
+  return validateStartResult(
+    await broker(
+      "/api/agent/credentials",
+      { operation: "deep-research-start", prompt },
+      { timeoutMs: BROKER_TIMEOUT_MS },
+    ),
+  );
+}
+
+async function requestStatus(interactionId, broker) {
+  return validateStatusResult(
+    await broker(
+      "/api/agent/credentials",
+      { operation: "deep-research-status", interactionId },
+      { timeoutMs: BROKER_TIMEOUT_MS },
+    ),
+    interactionId,
+  );
+}
+
+function completedOutput(status) {
+  return {
+    report: status.report,
+    citations: status.citations,
+    interactionId: status.interactionId,
+    durationMs: Math.max(0, Math.round(status.elapsedSec * 1_000)),
+  };
+}
+
+function pendingOutput(status, user) {
+  return {
+    interactionId: status.interactionId,
+    status: status.status,
+    elapsedSec: status.elapsedSec,
+    resumeCommand: resumeCommand(user, status.interactionId),
+  };
+}
+
+async function runResearch(
+  args,
+  dependencies = {},
+) {
+  const options = validatedArgs(args);
+  const broker = dependencies.broker || requestAgentBroker;
+  const sleep =
+    dependencies.sleep ||
+    ((milliseconds) =>
+      new Promise((resolve) => {
+        setTimeout(resolve, milliseconds);
+      }));
+  const now = dependencies.now || Date.now;
+
+  if (options.interactionId) {
+    const status = await requestStatus(options.interactionId, broker);
+    return status.status === "completed"
+      ? completedOutput(status)
+      : pendingOutput(status, options.user);
+  }
+
+  const startedAt = now();
+  const started = await requestStart(options.prompt, broker);
+  const interactionId = started.interactionId;
+
+  while (true) {
+    const status = await requestStatus(interactionId, broker);
+    if (status.status === "completed") {
+      return completedOutput(status);
+    }
+    const remainingMs = options.maxWaitMs - (now() - startedAt);
+    if (remainingMs <= 0) {
+      throw new ResearchCliError(
+        "timeout",
+        "Deep Research is still running. Resume it with --check instead of starting a new run.",
+        {
+          interactionId,
+          resumeCommand: resumeCommand(options.user, interactionId),
+        },
+      );
+    }
+    await sleep(Math.min(POLL_INTERVAL_MS, remainingMs));
+  }
+}
+
+function errorOutput(error) {
+  if (error instanceof ResearchCliError) {
+    return {
+      error: error.code,
+      message: error.message,
+      ...(error.interactionId ? { interactionId: error.interactionId } : {}),
+      ...(error.resumeCommand ? { resumeCommand: error.resumeCommand } : {}),
+    };
+  }
+  const responseBody =
+    error && typeof error === "object" && error.responseBody
+      ? error.responseBody
+      : null;
+  const code =
+    responseBody &&
+    typeof responseBody === "object" &&
+    typeof responseBody.code === "string"
+      ? responseBody.code
+      : "upstream_error";
+  return {
+    error: code,
+    message: error instanceof Error ? error.message : String(error),
+  };
+}
+
+function writeJson(value) {
+  process.stdout.write(`${JSON.stringify(value, null, 2)}\n`);
+}
+
+async function main() {
+  const args = parseArgs(process.argv);
+  if (args.help) {
+    process.stdout.write(
+      "Usage: research.js --user <caller-email> (--prompt <question> | --check <interactionId>) [--max-wait-min 20]\n",
+    );
+    return;
+  }
+  writeJson(await runResearch(args));
+}
+
+if (require.main === module) {
+  main().catch((error) => {
+    const output = errorOutput(error);
+    process.stderr.write(`Error: ${output.message}\n`);
+    writeJson(output);
+    process.exitCode = 1;
+  });
+}
+
+module.exports = {
+  BROKER_TIMEOUT_MS,
+  DEFAULT_MAX_WAIT_MIN,
+  POLL_INTERVAL_MS,
+  ResearchCliError,
+  errorOutput,
+  parseArgs,
+  runResearch,
+};

--- a/infra/agent-image/skills/psd-deep-research/research.test.js
+++ b/infra/agent-image/skills/psd-deep-research/research.test.js
@@ -1,0 +1,121 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const { describe, it } = require("node:test");
+const {
+  DEFAULT_MAX_WAIT_MIN,
+  ResearchCliError,
+  runResearch,
+} = require("./research");
+
+describe("psd-deep-research CLI", () => {
+  it("starts and immediately checks a completed interaction", async () => {
+    const calls = [];
+    const broker = async (_route, body, options) => {
+      calls.push({ body, options });
+      if (body.operation === "deep-research-start") {
+        return { interactionId: "interaction-1", status: "in_progress" };
+      }
+      return {
+        interactionId: "interaction-1",
+        status: "completed",
+        elapsedSec: 125,
+        report: "Fixture-backed report",
+        citations: [{ url: "https://example.org/source" }],
+      };
+    };
+
+    await expectResearch(
+      runResearch(
+        {
+          user: "owner@psd401.net",
+          prompt: "Research a test topic",
+        },
+        { broker, now: () => 0 },
+      ),
+      {
+        report: "Fixture-backed report",
+        citations: [{ url: "https://example.org/source" }],
+        interactionId: "interaction-1",
+        durationMs: 125_000,
+      },
+    );
+    assert.deepEqual(
+      calls.map((call) => call.body.operation),
+      ["deep-research-start", "deep-research-status"],
+    );
+    assert.equal(DEFAULT_MAX_WAIT_MIN, 20);
+  });
+
+  it("prints resumable timeout details without starting a replacement run", async () => {
+    let clock = 0;
+    const operations = [];
+    const broker = async (_route, body) => {
+      operations.push(body.operation);
+      return body.operation === "deep-research-start"
+        ? { interactionId: "interaction-timeout", status: "in_progress" }
+        : {
+            interactionId: "interaction-timeout",
+            status: "in_progress",
+            elapsedSec: Math.floor(clock / 1_000),
+          };
+    };
+
+    await assert.rejects(
+      runResearch(
+        {
+          user: "owner@psd401.net",
+          prompt: "Slow research",
+          max_wait_min: "0.001",
+        },
+        {
+          broker,
+          now: () => clock,
+          sleep: async (milliseconds) => {
+            clock += milliseconds;
+          },
+        },
+      ),
+      (error) => {
+        assert.ok(error instanceof ResearchCliError);
+        assert.equal(error.code, "timeout");
+        assert.equal(error.interactionId, "interaction-timeout");
+        assert.match(error.resumeCommand, /--check 'interaction-timeout'$/);
+        return true;
+      },
+    );
+    assert.equal(
+      operations.filter((operation) => operation === "deep-research-start")
+        .length,
+      1,
+    );
+  });
+
+  it("--check performs exactly one status request", async () => {
+    const calls = [];
+    const result = await runResearch(
+      {
+        user: "owner@psd401.net",
+        check: "interaction-active",
+      },
+      {
+        broker: async (_route, body) => {
+          calls.push(body);
+          return {
+            interactionId: "interaction-active",
+            status: "in_progress",
+            elapsedSec: 90,
+          };
+        },
+      },
+    );
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].operation, "deep-research-status");
+    assert.equal(result.status, "in_progress");
+    assert.match(result.resumeCommand, /--check 'interaction-active'$/);
+  });
+});
+
+async function expectResearch(actual, expected) {
+  assert.deepEqual(await actual, expected);
+}

--- a/infra/agent-image/skills/psd-deep-research/research.test.js
+++ b/infra/agent-image/skills/psd-deep-research/research.test.js
@@ -91,6 +91,46 @@ describe("psd-deep-research CLI", () => {
     );
   });
 
+  it("preserves resumable details when polling fails after a paid start", async () => {
+    const operations = [];
+    const broker = async (_route, body) => {
+      operations.push(body.operation);
+      if (body.operation === "deep-research-start") {
+        return { interactionId: "interaction-recoverable", status: "in_progress" };
+      }
+      const error = new Error("Agent broker returned HTTP 502");
+      error.responseBody = {
+        code: "upstream_error",
+        error: "Google status request failed",
+      };
+      throw error;
+    };
+
+    await assert.rejects(
+      runResearch(
+        {
+          user: "owner@psd401.net",
+          prompt: "Research with a transient poll failure",
+        },
+        { broker },
+      ),
+      (error) => {
+        assert.ok(error instanceof ResearchCliError);
+        assert.equal(error.code, "upstream_error");
+        assert.equal(error.interactionId, "interaction-recoverable");
+        assert.match(
+          error.resumeCommand,
+          /--check 'interaction-recoverable'$/,
+        );
+        return true;
+      },
+    );
+    assert.deepEqual(operations, [
+      "deep-research-start",
+      "deep-research-status",
+    ]);
+  });
+
   it("--check performs exactly one status request", async () => {
     const calls = [];
     const result = await runResearch(

--- a/infra/database/migrations.json
+++ b/infra/database/migrations.json
@@ -156,6 +156,7 @@
     "163-assistant-execution-deadline.sql",
     "164-nexus-memory-extraction-model.sql",
     "165-agent-scheduled-run-fire-idempotency.sql",
-    "166-atrium-collection-management.sql"
+    "166-atrium-collection-management.sql",
+    "167-deep-research-interaction-binding.sql"
   ]
 }

--- a/infra/database/schema/167-deep-research-interaction-binding.sql
+++ b/infra/database/schema/167-deep-research-interaction-binding.sql
@@ -1,0 +1,21 @@
+-- ============================================================================
+-- 167 — Bind Gemini interactions to Deep Research budget reservations (#1465)
+-- ============================================================================
+
+-- A failed first attempt may have applied an idempotent statement before the
+-- migration runner recorded the failure. Mark that record retryable before
+-- re-running the additive operations below.
+UPDATE migration_log SET status = 'completed'
+WHERE description = '167-deep-research-interaction-binding.sql'
+  AND status = 'failed';
+
+ALTER TABLE deep_research_reservations
+  ADD COLUMN IF NOT EXISTS interaction_id TEXT;
+
+CREATE INDEX IF NOT EXISTS idx_deep_research_interaction_id
+  ON deep_research_reservations(interaction_id)
+  WHERE interaction_id IS NOT NULL;
+
+-- Manual rollback (only after the broker stops using interaction ownership):
+-- DROP INDEX IF EXISTS idx_deep_research_interaction_id;
+-- ALTER TABLE deep_research_reservations DROP COLUMN IF EXISTS interaction_id;

--- a/lib/agent-credentials/owner-operation-broker.ts
+++ b/lib/agent-credentials/owner-operation-broker.ts
@@ -823,6 +823,17 @@ async function resolveDeepResearchModelId(): Promise<string | null> {
   return model?.modelId ?? null;
 }
 
+async function resolveDeepResearchModelIdForLog(): Promise<string | null> {
+  try {
+    return await resolveDeepResearchModelId();
+  } catch (error) {
+    log.warn("Failed to resolve Deep Research model for terminal log", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return null;
+  }
+}
+
 async function bindDeepResearchInteraction(input: {
   leaseId: string;
   userId: number;
@@ -865,6 +876,37 @@ async function releaseStartLease(
   }
 }
 
+type DeepResearchService = typeof import(
+  "@/lib/ai/gemini-deep-research-service"
+);
+
+async function cleanupFailedDeepResearchStart(input: {
+  service: DeepResearchService | null;
+  leaseId: string;
+  interactionId: string | null;
+  context: Record<string, unknown>;
+}): Promise<"released_after_start_error" | "preserved_after_cancel_error"> {
+  if (input.service && input.interactionId) {
+    try {
+      await input.service.cancelDeepResearchInteraction(input.interactionId);
+    } catch (cancelError) {
+      log.error("Failed to cancel unbound Deep Research interaction", {
+        ...input.context,
+        error:
+          cancelError instanceof Error
+            ? cancelError.message
+            : String(cancelError),
+      });
+      // Keep the lease active so an unconfirmed cancellation cannot create a
+      // second concurrency slot. The existing lease expiry remains the final
+      // recovery boundary if Google is unreachable.
+      return "preserved_after_cancel_error";
+    }
+  }
+  await releaseStartLease(input.leaseId, input.context);
+  return "released_after_start_error";
+}
+
 export async function executeDeepResearchStartOperation(input: {
   ownerEmail: string;
   prompt: unknown;
@@ -890,9 +932,7 @@ export async function executeDeepResearchStartOperation(input: {
 
   let interactionId: string | null = null;
   let modelId: string | null = null;
-  let service:
-    | typeof import("@/lib/ai/gemini-deep-research-service")
-    | null = null;
+  let service: DeepResearchService | null = null;
   try {
     modelId = await resolveDeepResearchModelId();
     if (!modelId) {
@@ -922,19 +962,21 @@ export async function executeDeepResearchStartOperation(input: {
     });
     return interaction;
   } catch (error) {
-    await releaseStartLease(reservation.leaseId, {
+    const cleanupContext = {
       caller: sanitizeForLogging(input.ownerEmail),
       interactionId,
       resolvedModel: modelId,
-      reservationOutcome: "released_after_start_error",
       elapsedMs: Date.now() - startedAt,
+    };
+    const reservationOutcome = await cleanupFailedDeepResearchStart({
+      service,
+      leaseId: reservation.leaseId,
+      interactionId,
+      context: cleanupContext,
     });
     log.error("Deep Research broker start failed", {
-      caller: sanitizeForLogging(input.ownerEmail),
-      interactionId,
-      resolvedModel: modelId,
-      reservationOutcome: "released_after_start_error",
-      elapsedMs: Date.now() - startedAt,
+      ...cleanupContext,
+      reservationOutcome,
       error: error instanceof Error ? error.message : String(error),
     });
     if (error instanceof DeepResearchOperationError) throw error;
@@ -988,11 +1030,8 @@ export async function executeDeepResearchStatusOperation(input: {
     input.ownerEmail,
     interactionId,
   );
-  const modelId = await resolveDeepResearchModelId();
 
-  let service:
-    | typeof import("@/lib/ai/gemini-deep-research-service")
-    | null = null;
+  let service: DeepResearchService | null = null;
   let interaction;
   try {
     service = await import("@/lib/ai/gemini-deep-research-service");
@@ -1016,6 +1055,42 @@ export async function executeDeepResearchStatusOperation(input: {
     interaction.status !== "cancelled" &&
     interaction.status !== "incomplete"
   ) {
+    if (elapsedMs >= service.MAX_DEEP_RESEARCH_RUN_DURATION_MS) {
+      try {
+        await service.cancelDeepResearchInteraction(interactionId);
+      } catch (error) {
+        log.error("Failed to cancel overdue Deep Research interaction", {
+          caller: sanitizeForLogging(input.ownerEmail),
+          interactionId,
+          resolvedModel: null,
+          reservationOutcome: "preserved_after_cancel_error",
+          elapsedMs,
+          error: error instanceof Error ? error.message : String(error),
+        });
+        throw new DeepResearchOperationError(
+          502,
+          "upstream_error",
+          service.mapInteractionError(error).message,
+        );
+      }
+      await releaseDeepResearch(reservation.leaseId);
+      const modelId = await resolveDeepResearchModelIdForLog();
+      log.warn("Deep Research broker deadline reached", {
+        caller: sanitizeForLogging(input.ownerEmail),
+        interactionId,
+        resolvedModel: modelId,
+        reservationOutcome: "released",
+        elapsedMs,
+        status: "cancelled",
+      });
+      throw new DeepResearchOperationError(
+        504,
+        "upstream_error",
+        `Deep Research exceeded the ${Math.round(
+          service.MAX_DEEP_RESEARCH_RUN_DURATION_MS / 60_000,
+        )}-minute server time limit and was cancelled.`,
+      );
+    }
     return {
       interactionId,
       status: interaction.status,
@@ -1024,6 +1099,7 @@ export async function executeDeepResearchStatusOperation(input: {
   }
 
   await releaseDeepResearch(reservation.leaseId);
+  const modelId = await resolveDeepResearchModelIdForLog();
   log.info("Deep Research broker terminal status", {
     caller: sanitizeForLogging(input.ownerEmail),
     interactionId,

--- a/lib/agent-credentials/owner-operation-broker.ts
+++ b/lib/agent-credentials/owner-operation-broker.ts
@@ -2,7 +2,20 @@ import {
   AgentCredentialBroker,
   AgentCredentialInputError,
 } from "@/lib/agent-credentials/broker";
+import { hasCapability } from "@/lib/ai/capability-utils";
+import {
+  type DeepResearchCitation,
+  type DeepResearchInteractionStatus,
+} from "@/lib/ai/gemini-deep-research-service";
+import {
+  releaseDeepResearch,
+  reserveDeepResearch,
+  type DeepResearchReservation,
+} from "@/lib/ai/deep-research-budget";
+import { executeQuery } from "@/lib/db/drizzle-client";
+import { aiModels, deepResearchReservations, users } from "@/lib/db/schema";
 import { createLogger, sanitizeForLogging } from "@/lib/logger";
+import { and, eq, isNotNull, sql } from "drizzle-orm";
 
 const MCP_PROTOCOL_VERSION = "2025-06-18";
 const MAX_OPERATION_BYTES = 2 * 1024 * 1024;
@@ -676,6 +689,370 @@ export async function executeOpenAiImageOperation(
   }
   const payload = await readBoundedJson(response, 32 * 1024 * 1024);
   return { imageBase64: imageBase64FromPayload(payload) };
+}
+
+// ---------------------------------------------------------------------------
+// Gemini Deep Research
+// ---------------------------------------------------------------------------
+
+type DeepResearchDenialReason = Extract<
+  DeepResearchReservation,
+  { allowed: false }
+>["reason"];
+
+const DEEP_RESEARCH_DENIAL_MESSAGES: Record<
+  DeepResearchDenialReason,
+  string
+> = {
+  user_concurrency:
+    "You already have a Deep Research run in progress. Wait for it to finish or resume that interaction.",
+  deployment_concurrency:
+    "Deep Research is at the deployment-wide concurrent-run limit. Try again after another run finishes.",
+  user_budget:
+    "Your hourly Deep Research budget is exhausted. Try again after the rolling one-hour window resets.",
+  deployment_budget:
+    "The deployment-wide hourly Deep Research budget is exhausted. Try again after the rolling one-hour window resets.",
+};
+
+const MAX_DEEP_RESEARCH_PROMPT_CHARS = 100_000;
+const MAX_DEEP_RESEARCH_INTERACTION_ID_CHARS = 512;
+
+export class DeepResearchOperationError extends Error {
+  constructor(
+    readonly status: number,
+    readonly code: string,
+    message: string,
+  ) {
+    super(message);
+    this.name = "DeepResearchOperationError";
+  }
+}
+
+export interface DeepResearchStartResult {
+  interactionId: string;
+  status: DeepResearchInteractionStatus;
+}
+
+export type DeepResearchStatusResult =
+  | {
+      interactionId: string;
+      status: Exclude<
+        DeepResearchInteractionStatus,
+        "completed" | "failed" | "cancelled" | "incomplete"
+      >;
+      elapsedSec: number;
+    }
+  | {
+      interactionId: string;
+      status: "completed";
+      elapsedSec: number;
+      report: string;
+      citations: DeepResearchCitation[];
+    };
+
+function validatedDeepResearchPrompt(value: unknown): string {
+  if (
+    typeof value !== "string" ||
+    value.trim().length === 0 ||
+    value.length > MAX_DEEP_RESEARCH_PROMPT_CHARS
+  ) {
+    throw new AgentCredentialInputError(
+      `Deep Research prompt must contain 1-${MAX_DEEP_RESEARCH_PROMPT_CHARS} characters`,
+    );
+  }
+  return value.trim();
+}
+
+function validatedInteractionId(value: unknown): string {
+  if (
+    typeof value !== "string" ||
+    value.length === 0 ||
+    value.length > MAX_DEEP_RESEARCH_INTERACTION_ID_CHARS ||
+    hasAsciiControl(value)
+  ) {
+    throw new AgentCredentialInputError("Invalid Deep Research interaction id");
+  }
+  return value;
+}
+
+/**
+ * A populated Cognito subject is the repository's active-user marker. The
+ * case-insensitive email join mirrors the owner lookup used by canAccessSkill.
+ */
+async function resolveActiveOwnerUserId(ownerEmail: string): Promise<number> {
+  const [owner] = await executeQuery(
+    (db) =>
+      db
+        .select({ id: users.id })
+        .from(users)
+        .where(
+          and(
+            sql`lower(${users.email}) = lower(${ownerEmail})`,
+            isNotNull(users.cognitoSub),
+          ),
+        )
+        .limit(1),
+    "resolveDeepResearchOwner",
+  );
+  if (!owner) {
+    throw new DeepResearchOperationError(
+      403,
+      "forbidden",
+      "The signed Deep Research owner is not an active user.",
+    );
+  }
+  return owner.id;
+}
+
+async function resolveDeepResearchModelId(): Promise<string | null> {
+  const models = await executeQuery(
+    (db) =>
+      db
+        .select({
+          modelId: aiModels.modelId,
+          capabilities: aiModels.capabilities,
+        })
+        .from(aiModels)
+        .where(and(eq(aiModels.active, true), eq(aiModels.provider, "google")))
+        .orderBy(aiModels.id),
+    "resolveDeepResearchModel",
+  );
+  const model = models.find((candidate) =>
+    hasCapability(candidate.capabilities, "deepResearch"),
+  );
+  return model?.modelId ?? null;
+}
+
+async function bindDeepResearchInteraction(input: {
+  leaseId: string;
+  userId: number;
+  interactionId: string;
+}): Promise<void> {
+  const rows = await executeQuery(
+    (db) =>
+      db
+        .update(deepResearchReservations)
+        .set({ interactionId: input.interactionId })
+        .where(
+          and(
+            eq(deepResearchReservations.id, input.leaseId),
+            eq(deepResearchReservations.userId, input.userId),
+            eq(deepResearchReservations.status, "active"),
+          ),
+        )
+        .returning({ id: deepResearchReservations.id }),
+    "bindDeepResearchInteraction",
+  );
+  if (!rows[0]) {
+    throw new Error("Deep Research reservation could not be bound");
+  }
+}
+
+async function releaseStartLease(
+  leaseId: string,
+  context: Record<string, unknown>,
+): Promise<void> {
+  try {
+    await releaseDeepResearch(leaseId);
+  } catch (releaseError) {
+    log.error("Failed to release Deep Research start lease", {
+      ...context,
+      error:
+        releaseError instanceof Error
+          ? releaseError.message
+          : String(releaseError),
+    });
+  }
+}
+
+export async function executeDeepResearchStartOperation(input: {
+  ownerEmail: string;
+  prompt: unknown;
+}): Promise<DeepResearchStartResult> {
+  const startedAt = Date.now();
+  const prompt = validatedDeepResearchPrompt(input.prompt);
+  const userId = await resolveActiveOwnerUserId(input.ownerEmail);
+  const reservation = await reserveDeepResearch(userId);
+  if (!reservation.allowed) {
+    log.warn("Deep Research broker start denied", {
+      caller: sanitizeForLogging(input.ownerEmail),
+      interactionId: null,
+      resolvedModel: null,
+      reservationOutcome: reservation.reason,
+      elapsedMs: Date.now() - startedAt,
+    });
+    throw new DeepResearchOperationError(
+      429,
+      reservation.reason,
+      DEEP_RESEARCH_DENIAL_MESSAGES[reservation.reason],
+    );
+  }
+
+  let interactionId: string | null = null;
+  let modelId: string | null = null;
+  let service:
+    | typeof import("@/lib/ai/gemini-deep-research-service")
+    | null = null;
+  try {
+    modelId = await resolveDeepResearchModelId();
+    if (!modelId) {
+      throw new DeepResearchOperationError(
+        503,
+        "upstream_error",
+        "Deep Research is unavailable because no active Google deep-research model is configured.",
+      );
+    }
+    service = await import("@/lib/ai/gemini-deep-research-service");
+    const interaction = await service.createDeepResearchInteraction(
+      prompt,
+      modelId,
+    );
+    interactionId = interaction.interactionId;
+    await bindDeepResearchInteraction({
+      leaseId: reservation.leaseId,
+      userId,
+      interactionId,
+    });
+    log.info("Deep Research broker start completed", {
+      caller: sanitizeForLogging(input.ownerEmail),
+      interactionId,
+      resolvedModel: modelId,
+      reservationOutcome: "reserved",
+      elapsedMs: Date.now() - startedAt,
+    });
+    return interaction;
+  } catch (error) {
+    await releaseStartLease(reservation.leaseId, {
+      caller: sanitizeForLogging(input.ownerEmail),
+      interactionId,
+      resolvedModel: modelId,
+      reservationOutcome: "released_after_start_error",
+      elapsedMs: Date.now() - startedAt,
+    });
+    log.error("Deep Research broker start failed", {
+      caller: sanitizeForLogging(input.ownerEmail),
+      interactionId,
+      resolvedModel: modelId,
+      reservationOutcome: "released_after_start_error",
+      elapsedMs: Date.now() - startedAt,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    if (error instanceof DeepResearchOperationError) throw error;
+    const message = service
+      ? service.mapInteractionError(error).message
+      : error instanceof Error
+        ? error.message
+        : String(error);
+    throw new DeepResearchOperationError(502, "upstream_error", message);
+  }
+}
+
+async function ownedDeepResearchReservation(
+  ownerEmail: string,
+  interactionId: string,
+): Promise<{
+  leaseId: string;
+  reservedAt: Date;
+  userId: number;
+}> {
+  const userId = await resolveActiveOwnerUserId(ownerEmail);
+  const [reservation] = await executeQuery(
+    (db) =>
+      db
+        .select({
+          leaseId: deepResearchReservations.id,
+          userId: deepResearchReservations.userId,
+          reservedAt: deepResearchReservations.reservedAt,
+        })
+        .from(deepResearchReservations)
+        .where(eq(deepResearchReservations.interactionId, interactionId))
+        .limit(1),
+    "getDeepResearchInteractionReservation",
+  );
+  if (!reservation || reservation.userId !== userId) {
+    throw new DeepResearchOperationError(
+      404,
+      "not_found",
+      "Deep Research interaction not found.",
+    );
+  }
+  return reservation;
+}
+
+export async function executeDeepResearchStatusOperation(input: {
+  ownerEmail: string;
+  interactionId: unknown;
+}): Promise<DeepResearchStatusResult> {
+  const interactionId = validatedInteractionId(input.interactionId);
+  const reservation = await ownedDeepResearchReservation(
+    input.ownerEmail,
+    interactionId,
+  );
+  const modelId = await resolveDeepResearchModelId();
+
+  let service:
+    | typeof import("@/lib/ai/gemini-deep-research-service")
+    | null = null;
+  let interaction;
+  try {
+    service = await import("@/lib/ai/gemini-deep-research-service");
+    interaction = await service.getDeepResearchInteraction(interactionId);
+  } catch (error) {
+    const message = service
+      ? service.mapInteractionError(error).message
+      : error instanceof Error
+        ? error.message
+        : String(error);
+    throw new DeepResearchOperationError(502, "upstream_error", message);
+  }
+  const elapsedMs = Math.max(
+    0,
+    Date.now() - reservation.reservedAt.getTime(),
+  );
+
+  if (
+    interaction.status !== "completed" &&
+    interaction.status !== "failed" &&
+    interaction.status !== "cancelled" &&
+    interaction.status !== "incomplete"
+  ) {
+    return {
+      interactionId,
+      status: interaction.status,
+      elapsedSec: Math.floor(elapsedMs / 1_000),
+    };
+  }
+
+  await releaseDeepResearch(reservation.leaseId);
+  log.info("Deep Research broker terminal status", {
+    caller: sanitizeForLogging(input.ownerEmail),
+    interactionId,
+    resolvedModel: modelId,
+    reservationOutcome: "released",
+    elapsedMs,
+    status: interaction.status,
+  });
+
+  if (interaction.status !== "completed") {
+    const mapped = service.mapInteractionError(
+      new Error(`Deep Research ended with status: ${interaction.status}.`),
+    );
+    throw new DeepResearchOperationError(502, "upstream_error", mapped.message);
+  }
+  if (!interaction.report) {
+    throw new DeepResearchOperationError(
+      502,
+      "upstream_error",
+      "Deep Research completed without report content.",
+    );
+  }
+  return {
+    interactionId,
+    status: interaction.status,
+    elapsedSec: Math.floor(elapsedMs / 1_000),
+    report: interaction.report,
+    citations: interaction.citations ?? [],
+  };
 }
 
 // ---------------------------------------------------------------------------

--- a/lib/ai/gemini-deep-research-service.ts
+++ b/lib/ai/gemini-deep-research-service.ts
@@ -78,6 +78,15 @@ export interface DeepResearchStatusUpdate {
   message: string;
 }
 
+export type DeepResearchInteractionStatus = Interaction['status'];
+
+export interface DeepResearchInteractionSnapshot {
+  interactionId: string;
+  status: DeepResearchInteractionStatus;
+  report?: string;
+  citations?: DeepResearchCitation[];
+}
+
 export interface DeepResearchRequest {
   prompt: string;
   /** model_id from ai_models — passed to Google as `agent`. */
@@ -232,7 +241,10 @@ function extractReportAndCitations(outputs: Interactions.Content[]): {
 }
 
 /** Map upstream errors onto our taxonomy by inspecting message + status. */
-function mapInteractionError(err: unknown): DeepResearchError {
+export function mapInteractionError(err: unknown): DeepResearchError {
+  if (err instanceof Error && 'type' in err) {
+    return err as DeepResearchError;
+  }
   const msg = err instanceof Error ? err.message : String(err);
   const lower = msg.toLowerCase();
 
@@ -251,6 +263,68 @@ function mapInteractionError(err: unknown): DeepResearchError {
     return createError('AUTHENTICATION', 'Google authentication failed.');
   }
   return createError('AGENT_FAILURE', `Deep Research failed: ${msg.slice(0, 300)}`);
+}
+
+async function createGoogleClient(): Promise<GoogleGenAI> {
+  const apiKey = await Settings.getGoogleAI();
+  if (!apiKey) {
+    throw ErrorFactories.sysConfigurationError('Google API key not configured');
+  }
+  return new GoogleGenAI({ apiKey });
+}
+
+/**
+ * Start one background Interactions API run without polling it.
+ *
+ * This split lifecycle is used by short-lived broker calls: the trusted web
+ * tier creates the paid interaction, then the agent checks it in later calls.
+ */
+export async function createDeepResearchInteraction(
+  prompt: string,
+  modelId: string
+): Promise<Pick<DeepResearchInteractionSnapshot, 'interactionId' | 'status'>> {
+  const client = await createGoogleClient();
+  try {
+    const interaction = await client.interactions.create({
+      input: prompt,
+      agent: modelId,
+      background: true,
+    });
+    return {
+      interactionId: interaction.id,
+      status: interaction.status,
+    };
+  } catch (error) {
+    throw mapInteractionError(error);
+  }
+}
+
+/**
+ * Fetch one interaction snapshot. Completed runs include the same flattened
+ * report and citations used by the existing Nexus path.
+ */
+export async function getDeepResearchInteraction(
+  interactionId: string
+): Promise<DeepResearchInteractionSnapshot> {
+  const client = await createGoogleClient();
+  try {
+    const interaction = await client.interactions.get(interactionId);
+    if (interaction.status !== 'completed') {
+      return { interactionId: interaction.id, status: interaction.status };
+    }
+    const outputBlocks = (interaction.steps ?? []).flatMap((step) =>
+      step.type === 'model_output' ? (step.content ?? []) : []
+    );
+    const { report, citations } = extractReportAndCitations(outputBlocks);
+    return {
+      interactionId: interaction.id,
+      status: interaction.status,
+      report,
+      citations,
+    };
+  } catch (error) {
+    throw mapInteractionError(error);
+  }
 }
 
 /**
@@ -383,12 +457,7 @@ export async function runDeepResearch(
     promptLength: request.prompt.length,
   });
 
-  const apiKey = await Settings.getGoogleAI();
-  if (!apiKey) {
-    throw ErrorFactories.sysConfigurationError('Google API key not configured');
-  }
-
-  const client = new GoogleGenAI({ apiKey });
+  const client = await createGoogleClient();
   const startMs = Date.now();
   let interactionId = '';
 

--- a/lib/ai/gemini-deep-research-service.ts
+++ b/lib/ai/gemini-deep-research-service.ts
@@ -48,7 +48,7 @@ const POLL_INTERVAL_MS = 10_000;
  * we keep writing status updates to the stream — see status emitter
  * cadence below.
  */
-const MAX_RUN_DURATION_MS = 25 * 60 * 1_000;
+export const MAX_DEEP_RESEARCH_RUN_DURATION_MS = 25 * 60 * 1_000;
 
 export interface DeepResearchCitation {
   url: string;
@@ -327,6 +327,18 @@ export async function getDeepResearchInteraction(
   }
 }
 
+/** Cancel one background interaction without exposing the Google client. */
+export async function cancelDeepResearchInteraction(
+  interactionId: string
+): Promise<void> {
+  const client = await createGoogleClient();
+  try {
+    await client.interactions.cancel(interactionId);
+  } catch (error) {
+    throw mapInteractionError(error);
+  }
+}
+
 /**
  * Abortable sleep. Cleans up the abort listener on normal resolution so that
  * long polling loops (150+ iterations over 25 minutes) don't accumulate
@@ -380,11 +392,11 @@ async function pollUntilTerminal(
 
   while (true) {
     const elapsedMs = Date.now() - startMs;
-    if (elapsedMs > MAX_RUN_DURATION_MS) {
+    if (elapsedMs > MAX_DEEP_RESEARCH_RUN_DURATION_MS) {
       void client.interactions.cancel(last.id).catch(() => {});
       throw createError(
         'TIMEOUT',
-        `Deep Research exceeded the ${Math.round(MAX_RUN_DURATION_MS / 60_000)}-minute time limit.`
+        `Deep Research exceeded the ${Math.round(MAX_DEEP_RESEARCH_RUN_DURATION_MS / 60_000)}-minute time limit.`
       );
     }
 

--- a/lib/db/schema/tables/deep-research-reservations.ts
+++ b/lib/db/schema/tables/deep-research-reservations.ts
@@ -3,9 +3,11 @@ import {
   index,
   integer,
   pgTable,
+  text,
   timestamp,
   varchar,
 } from "drizzle-orm/pg-core";
+import { sql } from "drizzle-orm";
 import { users } from "./users";
 
 export const deepResearchReservations = pgTable(
@@ -20,6 +22,7 @@ export const deepResearchReservations = pgTable(
     reservedAt: timestamp("reserved_at", { withTimezone: true }).notNull().defaultNow(),
     expiresAt: timestamp("expires_at", { withTimezone: true }).notNull(),
     releasedAt: timestamp("released_at", { withTimezone: true }),
+    interactionId: text("interaction_id"),
     sequence: bigserial("sequence", { mode: "number" }).notNull(),
   },
   (table) => [
@@ -29,5 +32,8 @@ export const deepResearchReservations = pgTable(
       table.expiresAt
     ),
     index("idx_deep_research_budget_window").on(table.reservedAt),
+    index("idx_deep_research_interaction_id")
+      .on(table.interactionId)
+      .where(sql`${table.interactionId} IS NOT NULL`),
   ]
 );

--- a/tests/unit/agent-credentials-route.test.ts
+++ b/tests/unit/agent-credentials-route.test.ts
@@ -20,6 +20,8 @@ const canAccessSkillMock = jest.fn()
 const brokerConstructorMock = jest.fn()
 const executeOpenAiImageOperationMock = jest.fn()
 const executeFreshserviceOperationMock = jest.fn()
+const executeDeepResearchStartOperationMock = jest.fn()
+const executeDeepResearchStatusOperationMock = jest.fn()
 
 jest.mock("@/lib/agent-workspace/invocation-context", () => ({
   verifyAgentInvocationContext: jest.fn(
@@ -64,18 +66,35 @@ jest.mock("@/lib/logger", () => ({
   }),
   generateRequestId: () => "request-test",
 }))
-jest.mock("@/lib/agent-credentials/owner-operation-broker", () => ({
-  executeOpenAiImageOperation: (...args: unknown[]) =>
-    executeOpenAiImageOperationMock(...args),
-  executePlaudOperation: jest.fn(),
-  executePsdDataOperation: jest.fn(),
-  executeFreshserviceOperation: (...args: unknown[]) =>
-    executeFreshserviceOperationMock(...args),
-}))
+jest.mock("@/lib/agent-credentials/owner-operation-broker", () => {
+  class DeepResearchOperationError extends Error {
+    constructor(
+      readonly status: number,
+      readonly code: string,
+      message: string
+    ) {
+      super(message)
+    }
+  }
+  return {
+    DeepResearchOperationError,
+    executeDeepResearchStartOperation: (...args: unknown[]) =>
+      executeDeepResearchStartOperationMock(...args),
+    executeDeepResearchStatusOperation: (...args: unknown[]) =>
+      executeDeepResearchStatusOperationMock(...args),
+    executeOpenAiImageOperation: (...args: unknown[]) =>
+      executeOpenAiImageOperationMock(...args),
+    executePlaudOperation: jest.fn(),
+    executePsdDataOperation: jest.fn(),
+    executeFreshserviceOperation: (...args: unknown[]) =>
+      executeFreshserviceOperationMock(...args),
+  }
+})
 
 import type { NextRequest } from "next/server"
 import { POST } from "@/app/api/agent/credentials/route"
 import { AgentCredentialInputError } from "@/lib/agent-credentials/broker"
+import { DeepResearchOperationError } from "@/lib/agent-credentials/owner-operation-broker"
 
 function request(body: unknown): NextRequest {
   return {
@@ -111,6 +130,15 @@ beforeEach(() => {
     status: 200,
     ok: true,
     data: { tickets: [] },
+  })
+  executeDeepResearchStartOperationMock.mockReset().mockResolvedValue({
+    interactionId: "interaction-1",
+    status: "in_progress",
+  })
+  executeDeepResearchStatusOperationMock.mockReset().mockResolvedValue({
+    interactionId: "interaction-1",
+    status: "in_progress",
+    elapsedSec: 20,
   })
 })
 
@@ -256,6 +284,60 @@ describe("POST /api/agent/credentials", () => {
       referenceDataUrl: null,
     })
   })
+})
+
+describe("POST /api/agent/credentials Deep Research", () => {
+  it("runs Deep Research start and status from signed ownership without a capability check", async () => {
+    const startResponse = await POST(
+      request({
+        operation: "deep-research-start",
+        prompt: "Research later school start times",
+      })
+    )
+    const statusResponse = await POST(
+      request({
+        operation: "deep-research-status",
+        interactionId: "interaction-1",
+      })
+    )
+
+    expect(startResponse.status).toBe(200)
+    expect(statusResponse.status).toBe(200)
+    expect(executeDeepResearchStartOperationMock).toHaveBeenCalledWith({
+      ownerEmail: "owner@psd401.net",
+      prompt: "Research later school start times",
+    })
+    expect(executeDeepResearchStatusOperationMock).toHaveBeenCalledWith({
+      ownerEmail: "owner@psd401.net",
+      interactionId: "interaction-1",
+    })
+    expect(canAccessSkillMock).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    ["user_concurrency", "A user run is already active"],
+    ["deployment_concurrency", "All deployment slots are active"],
+    ["user_budget", "The user hourly budget is exhausted"],
+    ["deployment_budget", "The deployment hourly budget is exhausted"],
+  ])(
+    "surfaces the %s Deep Research denial distinctly",
+    async (reason, message) => {
+      executeDeepResearchStartOperationMock.mockRejectedValueOnce(
+        new DeepResearchOperationError(429, reason, message)
+      )
+
+      const response = await POST(
+        request({
+          operation: "deep-research-start",
+          prompt: "Research a district topic",
+        })
+      )
+
+      expect(response.status).toBe(429)
+      expect(await response.json()).toEqual({ error: message, code: reason })
+      expect(canAccessSkillMock).not.toHaveBeenCalled()
+    }
+  )
 })
 
 describe("POST /api/agent/credentials Freshservice errors", () => {

--- a/tests/unit/agent-deep-research-operation.test.ts
+++ b/tests/unit/agent-deep-research-operation.test.ts
@@ -4,6 +4,7 @@ const reserveDeepResearchMock = jest.fn()
 const releaseDeepResearchMock = jest.fn()
 const createDeepResearchInteractionMock = jest.fn()
 const getDeepResearchInteractionMock = jest.fn()
+const cancelDeepResearchInteractionMock = jest.fn()
 const mapInteractionErrorMock = jest.fn((error: unknown) => {
   const mapped = new Error(
     error instanceof Error ? error.message : String(error)
@@ -38,6 +39,9 @@ jest.mock("@/lib/ai/deep-research-budget", () => ({
 }))
 
 jest.mock("@/lib/ai/gemini-deep-research-service", () => ({
+  MAX_DEEP_RESEARCH_RUN_DURATION_MS: 25 * 60 * 1_000,
+  cancelDeepResearchInteraction: (...args: unknown[]) =>
+    cancelDeepResearchInteractionMock(...args),
   createDeepResearchInteraction: (...args: unknown[]) =>
     createDeepResearchInteractionMock(...args),
   getDeepResearchInteraction: (...args: unknown[]) =>
@@ -154,9 +158,10 @@ beforeEach(() => {
     interactionId: "interaction-1",
     status: "in_progress",
   })
+  cancelDeepResearchInteractionMock.mockResolvedValue(undefined)
 })
 
-describe("Deep Research owner operation broker", () => {
+describe("Deep Research start owner operation", () => {
   it("returns 403 for an unknown or inactive signed owner", async () => {
     queryResults = [[]]
 
@@ -247,8 +252,51 @@ describe("Deep Research owner operation broker", () => {
       "upstream_error"
     )
     expect(releaseDeepResearchMock).toHaveBeenCalledWith("lease-1")
+    expect(cancelDeepResearchInteractionMock).not.toHaveBeenCalled()
   })
 
+  it("cancels an interaction before releasing when reservation binding fails", async () => {
+    queryResults = [activeOwner(), deepResearchModel(), []]
+
+    await expectOperationError(
+      executeDeepResearchStartOperation({
+        ownerEmail: "owner@psd401.net",
+        prompt: "Research a topic",
+      }),
+      502,
+      "upstream_error"
+    )
+    expect(cancelDeepResearchInteractionMock).toHaveBeenCalledWith(
+      "interaction-1"
+    )
+    expect(releaseDeepResearchMock).toHaveBeenCalledWith("lease-1")
+  })
+
+  it("preserves the lease if an unbound interaction cannot be cancelled", async () => {
+    queryResults = [activeOwner(), deepResearchModel(), []]
+    cancelDeepResearchInteractionMock.mockRejectedValueOnce(
+      new Error("Google cancel unavailable")
+    )
+
+    await expectOperationError(
+      executeDeepResearchStartOperation({
+        ownerEmail: "owner@psd401.net",
+        prompt: "Research a topic",
+      }),
+      502,
+      "upstream_error"
+    )
+    expect(releaseDeepResearchMock).not.toHaveBeenCalled()
+    expect(logErrorMock).toHaveBeenCalledWith(
+      "Failed to cancel unbound Deep Research interaction",
+      expect.objectContaining({
+        interactionId: "interaction-1",
+      })
+    )
+  })
+})
+
+describe("Deep Research status owner operation", () => {
   it("masks an interaction owned by another caller with 404", async () => {
     queryResults = [activeOwner(), ownedReservation({ userId: 99 })]
 
@@ -296,6 +344,59 @@ describe("Deep Research owner operation broker", () => {
         status: "completed",
       })
     )
+  })
+
+  it("cancels and releases a non-terminal interaction at the server deadline", async () => {
+    queryResults = [
+      activeOwner(),
+      ownedReservation({
+        reservedAt: new Date(Date.now() - 26 * 60 * 1_000),
+      }),
+      deepResearchModel(),
+    ]
+
+    const message = await expectOperationError(
+      executeDeepResearchStatusOperation({
+        ownerEmail: "owner@psd401.net",
+        interactionId: "interaction-1",
+      }),
+      504,
+      "upstream_error"
+    )
+    expect(message).toMatch(/25-minute server time limit/)
+    expect(cancelDeepResearchInteractionMock).toHaveBeenCalledWith(
+      "interaction-1"
+    )
+    expect(releaseDeepResearchMock).toHaveBeenCalledWith("lease-1")
+    expect(logWarnMock).toHaveBeenCalledWith(
+      "Deep Research broker deadline reached",
+      expect.objectContaining({
+        reservationOutcome: "released",
+        status: "cancelled",
+      })
+    )
+  })
+
+  it("preserves an overdue lease if Google cancellation fails", async () => {
+    queryResults = [
+      activeOwner(),
+      ownedReservation({
+        reservedAt: new Date(Date.now() - 26 * 60 * 1_000),
+      }),
+    ]
+    cancelDeepResearchInteractionMock.mockRejectedValueOnce(
+      new Error("Google cancel unavailable")
+    )
+
+    await expectOperationError(
+      executeDeepResearchStatusOperation({
+        ownerEmail: "owner@psd401.net",
+        interactionId: "interaction-1",
+      }),
+      502,
+      "upstream_error"
+    )
+    expect(releaseDeepResearchMock).not.toHaveBeenCalled()
   })
 
   it.each(["failed", "cancelled", "incomplete"] as const)(

--- a/tests/unit/agent-deep-research-operation.test.ts
+++ b/tests/unit/agent-deep-research-operation.test.ts
@@ -1,0 +1,321 @@
+/** @jest-environment node */
+
+const reserveDeepResearchMock = jest.fn()
+const releaseDeepResearchMock = jest.fn()
+const createDeepResearchInteractionMock = jest.fn()
+const getDeepResearchInteractionMock = jest.fn()
+const mapInteractionErrorMock = jest.fn((error: unknown) => {
+  const mapped = new Error(
+    error instanceof Error ? error.message : String(error)
+  ) as Error & { type: "AGENT_FAILURE" }
+  mapped.type = "AGENT_FAILURE"
+  return mapped
+})
+const hasCapabilityMock = jest.fn(
+  (
+    capabilities: string | string[] | null | undefined,
+    _capability: unknown
+  ) =>
+    typeof capabilities === "string" &&
+    capabilities.includes("deep_research")
+)
+const logInfoMock = jest.fn()
+const logWarnMock = jest.fn()
+const logErrorMock = jest.fn()
+const executeQueryMock = jest.fn()
+let queryResults: unknown[][] = []
+
+jest.mock("@/lib/agent-credentials/broker", () => ({
+  AgentCredentialBroker: class {},
+  AgentCredentialInputError: class extends Error {},
+}))
+
+jest.mock("@/lib/ai/deep-research-budget", () => ({
+  reserveDeepResearch: (...args: unknown[]) =>
+    reserveDeepResearchMock(...args),
+  releaseDeepResearch: (...args: unknown[]) =>
+    releaseDeepResearchMock(...args),
+}))
+
+jest.mock("@/lib/ai/gemini-deep-research-service", () => ({
+  createDeepResearchInteraction: (...args: unknown[]) =>
+    createDeepResearchInteractionMock(...args),
+  getDeepResearchInteraction: (...args: unknown[]) =>
+    getDeepResearchInteractionMock(...args),
+  mapInteractionError: (error: unknown) => mapInteractionErrorMock(error),
+}))
+
+jest.mock("@/lib/ai/capability-utils", () => ({
+  hasCapability: (
+    capabilities: string | string[] | null | undefined,
+    capability: unknown
+  ) => hasCapabilityMock(capabilities, capability),
+}))
+
+jest.mock("@/lib/db/drizzle-client", () => ({
+  executeQuery: (...args: unknown[]) => executeQueryMock(...args),
+}))
+
+jest.mock("@/lib/db/schema", () => ({
+  aiModels: {
+    id: "ai_models.id",
+    active: "ai_models.active",
+    provider: "ai_models.provider",
+    modelId: "ai_models.model_id",
+    capabilities: "ai_models.capabilities",
+  },
+  deepResearchReservations: {
+    id: "deep_research_reservations.id",
+    userId: "deep_research_reservations.user_id",
+    status: "deep_research_reservations.status",
+    reservedAt: "deep_research_reservations.reserved_at",
+    interactionId: "deep_research_reservations.interaction_id",
+  },
+  users: {
+    id: "users.id",
+    email: "users.email",
+    cognitoSub: "users.cognito_sub",
+  },
+}))
+
+jest.mock("@/lib/logger", () => ({
+  createLogger: () => ({
+    info: (...args: unknown[]) => logInfoMock(...args),
+    warn: (...args: unknown[]) => logWarnMock(...args),
+    error: (...args: unknown[]) => logErrorMock(...args),
+    debug: jest.fn(),
+  }),
+  sanitizeForLogging: (value: unknown) => value,
+}))
+
+import {
+  DeepResearchOperationError,
+  executeDeepResearchStartOperation,
+  executeDeepResearchStatusOperation,
+} from "@/lib/agent-credentials/owner-operation-broker"
+
+function activeOwner(id = 7) {
+  return [{ id }]
+}
+
+function deepResearchModel() {
+  return [
+    {
+      modelId: "deep-research-from-database",
+      capabilities: '["deep_research"]',
+    },
+  ]
+}
+
+function ownedReservation(overrides: {
+  userId?: number
+  reservedAt?: Date
+} = {}) {
+  return [
+    {
+      leaseId: "lease-1",
+      userId: overrides.userId ?? 7,
+      reservedAt: overrides.reservedAt ?? new Date(Date.now() - 45_000),
+    },
+  ]
+}
+
+async function expectOperationError(
+  operation: Promise<unknown>,
+  status: number,
+  code: string
+): Promise<string> {
+  try {
+    await operation
+  } catch (error) {
+    expect(error).toBeInstanceOf(DeepResearchOperationError)
+    const operationError = error as DeepResearchOperationError
+    expect(operationError.status).toBe(status)
+    expect(operationError.code).toBe(code)
+    return operationError.message
+  }
+  throw new Error("Expected Deep Research operation to reject")
+}
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  queryResults = []
+  executeQueryMock.mockImplementation(async () => queryResults.shift() ?? [])
+  reserveDeepResearchMock.mockResolvedValue({
+    allowed: true,
+    leaseId: "lease-1",
+  })
+  releaseDeepResearchMock.mockResolvedValue(undefined)
+  createDeepResearchInteractionMock.mockResolvedValue({
+    interactionId: "interaction-1",
+    status: "in_progress",
+  })
+  getDeepResearchInteractionMock.mockResolvedValue({
+    interactionId: "interaction-1",
+    status: "in_progress",
+  })
+})
+
+describe("Deep Research owner operation broker", () => {
+  it("returns 403 for an unknown or inactive signed owner", async () => {
+    queryResults = [[]]
+
+    await expectOperationError(
+      executeDeepResearchStartOperation({
+        ownerEmail: "unknown@psd401.net",
+        prompt: "Research a topic",
+      }),
+      403,
+      "forbidden"
+    )
+    expect(reserveDeepResearchMock).not.toHaveBeenCalled()
+  })
+
+  it("resolves the model from active Google rows and binds the interaction", async () => {
+    queryResults = [
+      activeOwner(),
+      deepResearchModel(),
+      [{ id: "lease-1" }],
+    ]
+
+    await expect(
+      executeDeepResearchStartOperation({
+        ownerEmail: "owner@psd401.net",
+        prompt: "  Research a topic  ",
+      })
+    ).resolves.toEqual({
+      interactionId: "interaction-1",
+      status: "in_progress",
+    })
+    expect(reserveDeepResearchMock).toHaveBeenCalledWith(7)
+    expect(createDeepResearchInteractionMock).toHaveBeenCalledWith(
+      "Research a topic",
+      "deep-research-from-database"
+    )
+    expect(executeQueryMock).toHaveBeenLastCalledWith(
+      expect.any(Function),
+      "bindDeepResearchInteraction"
+    )
+    expect(logInfoMock).toHaveBeenCalledWith(
+      "Deep Research broker start completed",
+      expect.objectContaining({
+        caller: "owner@psd401.net",
+        interactionId: "interaction-1",
+        resolvedModel: "deep-research-from-database",
+        reservationOutcome: "reserved",
+        elapsedMs: expect.any(Number),
+      })
+    )
+  })
+
+  it.each([
+    ["user_concurrency", /already have a Deep Research run/i],
+    ["deployment_concurrency", /deployment-wide concurrent-run limit/i],
+    ["user_budget", /hourly Deep Research budget/i],
+    ["deployment_budget", /deployment-wide hourly Deep Research budget/i],
+  ] as const)(
+    "maps %s to a distinct agent-readable denial",
+    async (reason, expectedMessage) => {
+      queryResults = [activeOwner()]
+      reserveDeepResearchMock.mockResolvedValueOnce({ allowed: false, reason })
+
+      const message = await expectOperationError(
+        executeDeepResearchStartOperation({
+          ownerEmail: "owner@psd401.net",
+          prompt: "Research a topic",
+        }),
+        429,
+        reason
+      )
+      expect(message).toMatch(expectedMessage)
+      expect(createDeepResearchInteractionMock).not.toHaveBeenCalled()
+    }
+  )
+
+  it("releases the lease if provider creation fails", async () => {
+    queryResults = [activeOwner(), deepResearchModel()]
+    createDeepResearchInteractionMock.mockRejectedValueOnce(
+      new Error("Google unavailable")
+    )
+
+    await expectOperationError(
+      executeDeepResearchStartOperation({
+        ownerEmail: "owner@psd401.net",
+        prompt: "Research a topic",
+      }),
+      502,
+      "upstream_error"
+    )
+    expect(releaseDeepResearchMock).toHaveBeenCalledWith("lease-1")
+  })
+
+  it("masks an interaction owned by another caller with 404", async () => {
+    queryResults = [activeOwner(), ownedReservation({ userId: 99 })]
+
+    await expectOperationError(
+      executeDeepResearchStatusOperation({
+        ownerEmail: "owner@psd401.net",
+        interactionId: "foreign-interaction",
+      }),
+      404,
+      "not_found"
+    )
+    expect(getDeepResearchInteractionMock).not.toHaveBeenCalled()
+    expect(releaseDeepResearchMock).not.toHaveBeenCalled()
+  })
+
+  it("returns a completed report with citations and releases its lease", async () => {
+    queryResults = [activeOwner(), ownedReservation(), deepResearchModel()]
+    getDeepResearchInteractionMock.mockResolvedValueOnce({
+      interactionId: "interaction-1",
+      status: "completed",
+      report: "Completed research report",
+      citations: [{ url: "https://example.org/source" }],
+    })
+
+    await expect(
+      executeDeepResearchStatusOperation({
+        ownerEmail: "owner@psd401.net",
+        interactionId: "interaction-1",
+      })
+    ).resolves.toEqual({
+      interactionId: "interaction-1",
+      status: "completed",
+      elapsedSec: expect.any(Number),
+      report: "Completed research report",
+      citations: [{ url: "https://example.org/source" }],
+    })
+    expect(releaseDeepResearchMock).toHaveBeenCalledWith("lease-1")
+    expect(logInfoMock).toHaveBeenCalledWith(
+      "Deep Research broker terminal status",
+      expect.objectContaining({
+        caller: "owner@psd401.net",
+        interactionId: "interaction-1",
+        resolvedModel: "deep-research-from-database",
+        reservationOutcome: "released",
+        status: "completed",
+      })
+    )
+  })
+
+  it.each(["failed", "cancelled", "incomplete"] as const)(
+    "releases the lease and surfaces %s as an upstream error",
+    async (status) => {
+      queryResults = [activeOwner(), ownedReservation(), deepResearchModel()]
+      getDeepResearchInteractionMock.mockResolvedValueOnce({
+        interactionId: "interaction-1",
+        status,
+      })
+
+      await expectOperationError(
+        executeDeepResearchStatusOperation({
+          ownerEmail: "owner@psd401.net",
+          interactionId: "interaction-1",
+        }),
+        502,
+        "upstream_error"
+      )
+      expect(releaseDeepResearchMock).toHaveBeenCalledWith("lease-1")
+    }
+  )
+})

--- a/tests/unit/lib/ai/gemini-deep-research-service.test.ts
+++ b/tests/unit/lib/ai/gemini-deep-research-service.test.ts
@@ -39,6 +39,7 @@ jest.mock("@/lib/error-utils", () => ({
 }))
 
 import {
+  cancelDeepResearchInteraction,
   createDeepResearchInteraction,
   getDeepResearchInteraction,
   mapInteractionError,
@@ -143,6 +144,15 @@ describe("Gemini Deep Research split lifecycle", () => {
       interactionId: "interaction-1",
       status: "in_progress",
     })
+  })
+
+  it("cancels one background interaction", async () => {
+    interactionCancelMock.mockResolvedValueOnce(undefined)
+
+    await expect(
+      cancelDeepResearchInteraction("interaction-1")
+    ).resolves.toBeUndefined()
+    expect(interactionCancelMock).toHaveBeenCalledWith("interaction-1")
   })
 
   it("preserves an already classified interaction error", () => {

--- a/tests/unit/lib/ai/gemini-deep-research-service.test.ts
+++ b/tests/unit/lib/ai/gemini-deep-research-service.test.ts
@@ -1,0 +1,155 @@
+/** @jest-environment node */
+
+const interactionCreateMock = jest.fn()
+const interactionGetMock = jest.fn()
+const interactionCancelMock = jest.fn()
+const getGoogleAiMock = jest.fn()
+const loggerWarnMock = jest.fn()
+
+jest.mock("@google/genai", () => ({
+  GoogleGenAI: class {
+    interactions = {
+      create: (...args: unknown[]) => interactionCreateMock(...args),
+      get: (...args: unknown[]) => interactionGetMock(...args),
+      cancel: (...args: unknown[]) => interactionCancelMock(...args),
+    }
+  },
+}))
+
+jest.mock("@/lib/settings-manager", () => ({
+  Settings: {
+    getGoogleAI: (...args: unknown[]) => getGoogleAiMock(...args),
+  },
+}))
+
+jest.mock("@/lib/logger", () => ({
+  createLogger: () => ({
+    info: jest.fn(),
+    warn: (...args: unknown[]) => loggerWarnMock(...args),
+    error: jest.fn(),
+    debug: jest.fn(),
+  }),
+  generateRequestId: () => "request-test",
+}))
+
+jest.mock("@/lib/error-utils", () => ({
+  ErrorFactories: {
+    sysConfigurationError: (message: string) => new Error(message),
+  },
+}))
+
+import {
+  createDeepResearchInteraction,
+  getDeepResearchInteraction,
+  mapInteractionError,
+} from "@/lib/ai/gemini-deep-research-service"
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  getGoogleAiMock.mockResolvedValue("google-api-key")
+})
+
+describe("Gemini Deep Research split lifecycle", () => {
+  it("starts one background interaction with the resolved model id", async () => {
+    interactionCreateMock.mockResolvedValueOnce({
+      id: "interaction-1",
+      status: "in_progress",
+    })
+
+    await expect(
+      createDeepResearchInteraction(
+        "Research later school start times",
+        "model-from-database"
+      )
+    ).resolves.toEqual({
+      interactionId: "interaction-1",
+      status: "in_progress",
+    })
+    expect(interactionCreateMock).toHaveBeenCalledWith({
+      input: "Research later school start times",
+      agent: "model-from-database",
+      background: true,
+    })
+  })
+
+  it("flattens completed model-output steps and keeps only safe citations", async () => {
+    interactionGetMock.mockResolvedValueOnce({
+      id: "interaction-1",
+      status: "completed",
+      steps: [
+        {
+          type: "model_output",
+          content: [
+            {
+              type: "text",
+              text: "First section",
+              annotations: [
+                {
+                  type: "url_citation",
+                  url: "https://example.org/source",
+                  title: "Safe source",
+                },
+                {
+                  type: "url_citation",
+                  url: "javascript:alert(1)",
+                  title: "Unsafe source",
+                },
+              ],
+            },
+          ],
+        },
+        {
+          type: "tool_output",
+          content: [{ type: "text", text: "Ignored tool output" }],
+        },
+        {
+          type: "model_output",
+          content: [{ type: "text", text: "Second section" }],
+        },
+      ],
+    })
+
+    await expect(
+      getDeepResearchInteraction("interaction-1")
+    ).resolves.toEqual({
+      interactionId: "interaction-1",
+      status: "completed",
+      report: "First section\n\nSecond section",
+      citations: [
+        {
+          url: "https://example.org/source",
+          title: "Safe source",
+          startIndex: undefined,
+          endIndex: undefined,
+        },
+      ],
+    })
+    expect(loggerWarnMock).toHaveBeenCalledWith(
+      "Skipping citation with unsafe URL scheme",
+      { url: "javascript:alert(1)" }
+    )
+  })
+
+  it("returns a short snapshot for a non-terminal interaction", async () => {
+    interactionGetMock.mockResolvedValueOnce({
+      id: "interaction-1",
+      status: "in_progress",
+      steps: [],
+    })
+
+    await expect(
+      getDeepResearchInteraction("interaction-1")
+    ).resolves.toEqual({
+      interactionId: "interaction-1",
+      status: "in_progress",
+    })
+  })
+
+  it("preserves an already classified interaction error", () => {
+    const classified = Object.assign(new Error("Google authentication failed."), {
+      type: "AUTHENTICATION" as const,
+    })
+
+    expect(mapInteractionError(classified)).toBe(classified)
+  })
+})


### PR DESCRIPTION
## Description

Adds the `psd-deep-research` Agent skill backed by the existing Gemini Deep Research service and the existing district budget/concurrency reservation system.

- adds signed-owner-bound `deep-research-start` and `deep-research-status` broker operations without introducing a new capability gate
- resolves the active Google Deep Research model from `ai_models` instead of hardcoding a model id
- binds Google interaction ids to budget reservations so status polling enforces ownership and terminal states release concurrency
- cancels interactions whose reservation binding fails, preserves concurrency when cancellation cannot be confirmed, and enforces the shared 25-minute server deadline
- preserves the interaction id and a shell-safe resume command when polling fails after a paid start
- adds migration 167 with idempotent retry behavior and a partial interaction-id index
- ships the skill CLI with 20-minute polling, resumable `--check`, cost/duration guidance, citation-preserving output, and distinct denial messages
- adds cited-report and budget-denial fixture evals plus unit coverage for authorization, all four reservation denials, ownership masking, provider failures, cancellation cleanup, terminal release, polling/recovery, deadline handling, and response extraction

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Infrastructure change (CDK/AWS)

## Testing

- [x] `bun run test:ci -- --runInBand --silent` — 532 suites / 4,954 tests passed
- [x] targeted Jest coverage — 5 suites / 95 tests passed
- [x] `node --test infra/agent-image/skills/psd-deep-research/research.test.js` — 4 tests passed
- [x] `python3 infra/agent-image/check_eval_coverage.py` — 31 covered / 45 documented opt-outs
- [x] `python3 -m unittest infra/agent-image/test_eval_coverage.py` — 7 tests passed
- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run build`
- [x] `bun run migration:list`
- [x] migration 167 applied twice in an isolated PostgreSQL 16 database; verified the `interaction_id` text column, partial index, and failed-record retry repair

Authenticated browser E2E is not applicable to this broker/skill change per the issue test plan. The documented one-push `SKIP_E2E=1` bypass was used because the isolated worktree has no local `AUTH_SECRET`; no browser behavior changed.

## Infrastructure Changes

- [x] No CDK/AWS resource, IAM, or environment-variable changes
- [x] Existing Deep Research budget defaults remain unchanged
- [x] Database migration is additive and includes manual rollback guidance

## Security and Operational Notes

- invocation identity comes only from the verified signed agent context; request-supplied owner selectors remain rejected
- starts require an active user and reserve budget before calling Google
- status checks return the same 404 for missing and foreign interaction ids and do not call Google on an ownership mismatch
- unbound or overdue Google interactions are cancelled before concurrency is released; an unconfirmed cancellation preserves the lease
- polling failures retain the paid interaction id so callers can recover with `--check` rather than starting a duplicate run
- the shared Google credential remains in the trusted web tier
- structured logs include sanitized caller identity, interaction id, resolved model, reservation outcome, elapsed time, and terminal status
- no new capability identifier, API scope, secret, or environment variable was added

## Related Issues

Closes #1465

## Additional Notes

The manual post-deploy happy-path and deliberate budget-denial checks remain deployment validation steps because they require the dev agent runtime and district Google credential.
