### PR TITLE
feat(agent-skill): add cited NSPRA observance lookups

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,6 +175,14 @@ jobs:
       env:
         CI: true
 
+    # psd-observances (#1476). This zero-dependency CJS skill sits outside
+    # Jest's roots. Its suite functionally exercises every documented command,
+    # repository-name resolution, citation/output bounds, and auth exit codes.
+    - name: Run psd-observances skill tests (Bun)
+      run: bun run test:skill:psd-observances
+      env:
+        CI: true
+
     # Direct-AWS credential boundary (#1442). OpenClaw strips inherited AWS
     # credentials from model-launched exec subprocesses; these tests prove TTS
     # and HyperFrames use only the root-owned fixed-operation relay and that the

--- a/infra/agent-image/eval/suites/regression.yaml
+++ b/infra/agent-image/eval/suites/regression.yaml
@@ -22,6 +22,7 @@ tasks:
   - ../../skills/psd-html-artifact/evals/audit-minimal-report.yaml
   - ../../skills/psd-instructional-vision/evals/four-essentials.yaml
   - ../../skills/psd-morning-brief/evals/offline-self-check.yaml
+  - ../../skills/psd-observances/evals/lookup-american-education-week.yaml
   - ../../skills/psd-open-adaptive-district/evals/weekly-check-in-fields.yaml
   - ../../skills/psd-pdf-to-markdown/evals/convert-bundled-brand-guide.yaml
   - ../../skills/psd-plaud/evals/list-recordings.yaml

--- a/infra/agent-image/skills/psd-observances/SKILL.md
+++ b/infra/agent-image/skills/psd-observances/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: psd-observances
+summary: Find cited dates for national observances, awareness months, state school holidays, education conferences, and NSPRA calendar questions such as when is an observance.
+description: Answer calendar and observance questions such as "when is <observance>", national observance dates, awareness months, state school holidays, education conference dates, and NSPRA calendar lookups by searching the authorized NSPRA knowledge repository.
+allowed-tools: Bash(node:*)
+---
+
+# psd-observances
+
+Answer questions from NSPRA's *Resources for Planning the School Calendar,
+2026-2027* through the caller's authorized AI Studio knowledge repository. The
+publication itself is never bundled in the skill.
+
+Use this skill when someone asks when an observance occurs, what observances
+fall in a month or on a date, which school holidays a state lists, when an
+education conference happens, or what the NSPRA calendar says.
+
+## Coverage and accuracy
+
+- Ordinary observance, state, and conference lookups cover **January 2026
+  through June 2027**. Refuse an out-of-range question rather than guessing.
+- `holiday-years` is the sole exception: the publication's six-year major
+  holiday summary continues through **2031**.
+- **Data was verified as of November 2025.**
+- For state results, always disclose: **Part II is not intended to serve as the
+  official or legal listing of holidays for each state.** Do not present Part II
+  as legal authority.
+
+Every returned result includes a printed-page citation. Preserve that citation
+in the answer so the user can check the publication.
+
+## Commands
+
+```bash
+# Named observance: dates and bounded comment context
+node /opt/psd-skills/psd-observances/run.js \
+  lookup "American Education Week"
+
+# Ranked hybrid search. --any uses OR semantics between terms.
+node /opt/psd-skills/psd-observances/run.js \
+  search school counseling --any
+
+# Observances in a covered month
+node /opt/psd-skills/psd-observances/run.js month 2026-11
+
+# Observances on a covered date
+node /opt/psd-skills/psd-observances/run.js on --date 2026-11-16
+
+# State legal and school-holiday sections, or one section only
+node /opt/psd-skills/psd-observances/run.js state Washington
+node /opt/psd-skills/psd-observances/run.js \
+  state Washington --section school
+
+# Education-organization meetings
+node /opt/psd-skills/psd-observances/run.js \
+  conferences --year 2026 --org "National PTA"
+
+# Major-holiday dates and weekdays across 2026-2031
+node /opt/psd-skills/psd-observances/run.js holiday-years Christmas
+```
+
+Global flags:
+
+| Flag | Behavior |
+|---|---|
+| `--limit N` | Return 1-50 results; default 5 |
+| `--full` | Expand each excerpt, while retaining a hard total-output bound |
+| `--json` | Emit one machine-readable JSON object without the text truncation banner |
+
+Default excerpts are at most about 300 characters each. Use `--full` only when
+the bounded default does not contain enough context; do not try to retrieve the
+whole 124-page source into model context.
+
+## Repository and authorization behavior
+
+The CLI calls `repositories_list` on every invocation and selects an accessible
+repository whose name contains **"NSPRA"** case-insensitively. It never
+hardcodes an environment-specific repository id. If several match, it prefers
+a name containing **"2026"**, then the lowest numeric id, and reports the
+selection.
+
+If no repository matches, say that the NSPRA repository is not available to
+the caller's account. On an unauthorized or insufficient-scope response, tell
+the user to **connect AI Studio access**. If already connected, they should
+reconnect so the current repository scopes are authorized.
+
+## Exit codes
+
+| Exit | Meaning |
+|---|---|
+| 0 | Success |
+| 1 | Bad arguments, out-of-range date, or unavailable NSPRA repository |
+| 2 | Unexpected internal error |
+| 11 | Unauthorized or insufficient scope; connect/reconnect AI Studio access |
+| 12 | Upstream MCP, broker, or malformed-response error |
+| 14 | Rate-limited; wait briefly and retry |

--- a/infra/agent-image/skills/psd-observances/SKILL.md
+++ b/infra/agent-image/skills/psd-observances/SKILL.md
@@ -63,7 +63,7 @@ Global flags:
 
 | Flag | Behavior |
 |---|---|
-| `--limit N` | Return 1-50 results; default 5 |
+| `--limit N` | Return 1-50 results; default 5. A state lookup without `--section` requires at least 2 so both sections are represented |
 | `--full` | Expand each excerpt, while retaining a hard total-output bound |
 | `--json` | Emit one machine-readable JSON object without the text truncation banner |
 

--- a/infra/agent-image/skills/psd-observances/common.js
+++ b/infra/agent-image/skills/psd-observances/common.js
@@ -1,0 +1,218 @@
+/**
+ * Owner-bound AI Studio repository client for psd-observances.
+ *
+ * The model runtime receives repository results only. OAuth grants and API keys
+ * stay behind the existing trusted agent broker.
+ */
+
+'use strict';
+
+const CONTAINER_BROKER_PATH = '/opt/psd-skills/_shared/agent-broker';
+
+function loadAgentBroker() {
+  try {
+    return require('/opt/psd-skills/_shared/agent-broker');
+  } catch (error) {
+    const missingContainerModule =
+      error &&
+      error.code === 'MODULE_NOT_FOUND' &&
+      String(error.message).includes(CONTAINER_BROKER_PATH);
+    if (!missingContainerModule) throw error;
+  }
+
+  // Repo-tree fallback for local development and unit tests.
+  return require('../_shared/agent-broker');
+}
+
+const { requestAgentBroker: defaultRequestAgentBroker } = loadAgentBroker();
+
+const TOOL_SCOPES = Object.freeze({
+  repositories_list: 'repositories:list',
+  repositories_search: 'repositories:search',
+});
+
+class SkillFailure extends Error {
+  constructor(message, code, exitCode, detail = undefined) {
+    super(message);
+    this.name = 'SkillFailure';
+    this.code = code;
+    this.exitCode = exitCode;
+    this.detail = detail;
+  }
+}
+
+function fail(message, code = 'bad_args', exitCode = 1, detail = undefined) {
+  throw new SkillFailure(message, code, exitCode, detail);
+}
+
+function reauthHint(toolName) {
+  const scope = TOOL_SCOPES[toolName] || 'repository access';
+  return (
+    `Connect AI Studio access and retry. If it is already connected, reconnect ` +
+    `it to authorize ${scope}.`
+  );
+}
+
+function authFailure(toolName, detail) {
+  fail(
+    `AI Studio did not authorize this repository request. ${reauthHint(toolName)}`,
+    'unauthorized',
+    11,
+    detail ? String(detail).slice(0, 512) : undefined,
+  );
+}
+
+function textFromToolResult(result) {
+  const content = result && Array.isArray(result.content) ? result.content : [];
+  const firstText = content.find(
+    (part) => part && part.type === 'text' && typeof part.text === 'string',
+  );
+  if (!firstText) return result ?? null;
+
+  try {
+    return JSON.parse(firstText.text);
+  } catch {
+    return firstText.text;
+  }
+}
+
+function looksUnauthorized(value) {
+  const text =
+    typeof value === 'string' ? value : JSON.stringify(value ?? '');
+  return /unauthori[sz]ed|forbidden|insufficient scope|permission denied|credential is not configured/i.test(
+    text,
+  );
+}
+
+function assertSuccessfulHttpStatus(brokerResult, toolName) {
+  const httpStatus = Number(brokerResult && brokerResult.httpStatus);
+  if (httpStatus === 401 || httpStatus === 403) {
+    authFailure(toolName, brokerResult && brokerResult.rawText);
+  }
+  if (httpStatus === 429) {
+    fail(
+      'AI Studio is rate-limiting repository requests. Wait briefly and retry.',
+      'rate_limited',
+      14,
+    );
+  }
+  if (!Number.isInteger(httpStatus)) {
+    fail(
+      'The AI Studio broker returned a malformed response.',
+      'upstream_error',
+      12,
+    );
+  }
+  if (httpStatus < 200 || httpStatus >= 300) {
+    fail(
+      `AI Studio repository request failed with HTTP ${httpStatus}.`,
+      'upstream_error',
+      12,
+    );
+  }
+  return httpStatus;
+}
+
+function parseMcpPayload(payload, toolName) {
+  if (!payload || typeof payload !== 'object') {
+    fail(
+      'AI Studio returned a non-JSON repository response.',
+      'upstream_error',
+      12,
+    );
+  }
+
+  if (payload.error) {
+    if (looksUnauthorized(payload.error)) authFailure(toolName, payload.error);
+    fail(
+      `AI Studio MCP error: ${
+        payload.error.message || JSON.stringify(payload.error)
+      }`,
+      'upstream_error',
+      12,
+    );
+  }
+  if (!Object.prototype.hasOwnProperty.call(payload, 'result')) {
+    fail(
+      'AI Studio MCP returned no result.',
+      'upstream_error',
+      12,
+    );
+  }
+
+  const result = payload.result;
+  const data = textFromToolResult(result);
+  if (result && result.isError) {
+    if (looksUnauthorized(data)) authFailure(toolName, data);
+    fail(
+      `AI Studio repository tool failed: ${
+        typeof data === 'string' ? data : JSON.stringify(data)
+      }`,
+      'upstream_error',
+      12,
+    );
+  }
+  return data;
+}
+
+function parseToolEnvelope(brokerResult, toolName) {
+  assertSuccessfulHttpStatus(brokerResult, toolName);
+  return parseMcpPayload(brokerResult && brokerResult.payload, toolName);
+}
+
+async function callRepositoryTool(
+  toolName,
+  toolArgs,
+  requestAgentBroker = defaultRequestAgentBroker,
+) {
+  let brokerResult;
+  try {
+    brokerResult = await requestAgentBroker(
+      '/api/agent/aistudio',
+      {
+        method: 'tools/call',
+        params: { name: toolName, arguments: toolArgs },
+      },
+      { timeoutMs: 180_000 },
+    );
+  } catch (error) {
+    const status = Number(error && error.status);
+    if (
+      status === 401 ||
+      status === 403 ||
+      looksUnauthorized(error instanceof Error ? error.message : error)
+    ) {
+      authFailure(
+        toolName,
+        error instanceof Error ? error.message : String(error),
+      );
+    }
+    if (status === 429) {
+      fail(
+        'AI Studio is rate-limiting repository requests. Wait briefly and retry.',
+        'rate_limited',
+        14,
+      );
+    }
+    fail(
+      `Could not reach the AI Studio repository service: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+      'upstream_error',
+      12,
+    );
+  }
+
+  return parseToolEnvelope(brokerResult, toolName);
+}
+
+module.exports = {
+  SkillFailure,
+  callRepositoryTool,
+  defaultRequestAgentBroker,
+  fail,
+  loadAgentBroker,
+  parseMcpPayload,
+  parseToolEnvelope,
+  reauthHint,
+};

--- a/infra/agent-image/skills/psd-observances/evals/fixtures/lookup-american-education-week.json
+++ b/infra/agent-image/skills/psd-observances/evals/fixtures/lookup-american-education-week.json
@@ -1,0 +1,72 @@
+[
+  {
+    "route": "/api/agent/aistudio",
+    "method": "POST",
+    "request_body": {
+      "method": "tools/call",
+      "params": {
+        "name": "repositories_list",
+        "arguments": {
+          "query": "NSPRA",
+          "limit": 50
+        }
+      }
+    },
+    "response": {
+      "status": 200,
+      "body": {
+        "httpStatus": 200,
+        "keySource": "oauth",
+        "payload": {
+          "jsonrpc": "2.0",
+          "id": "observances-list",
+          "result": {
+            "content": [
+              {
+                "type": "text",
+                "text": "{\"repositories\":[{\"id\":1476,\"name\":\"District NSPRA 2026-2027 Calendar\"}]}"
+              }
+            ]
+          }
+        }
+      }
+    }
+  },
+  {
+    "route": "/api/agent/aistudio",
+    "method": "POST",
+    "request_body": {
+      "method": "tools/call",
+      "params": {
+        "name": "repositories_search",
+        "arguments": {
+          "query": "American Education Week",
+          "repositoryIds": [
+            1476
+          ],
+          "mode": "hybrid",
+          "limit": 5
+        }
+      }
+    },
+    "response": {
+      "status": 200,
+      "body": {
+        "httpStatus": 200,
+        "keySource": "oauth",
+        "payload": {
+          "jsonrpc": "2.0",
+          "id": "observances-search",
+          "result": {
+            "content": [
+              {
+                "type": "text",
+                "text": "{\"results\":[{\"itemName\":\"NSPRA calendar\",\"content\":\"American Education Week — November 16-20, 2026\",\"sourceLocator\":{\"page\":17},\"citations\":[{\"sourceLocator\":{\"page\":17},\"label\":\"Page 17\"}],\"similarity\":0.91}],\"diagnostics\":{\"returnedResults\":1}}"
+              }
+            ]
+          }
+        }
+      }
+    }
+  }
+]

--- a/infra/agent-image/skills/psd-observances/evals/lookup-american-education-week.yaml
+++ b/infra/agent-image/skills/psd-observances/evals/lookup-american-education-week.yaml
@@ -1,0 +1,13 @@
+id: observances-american-education-week
+skill: psd-observances
+level: L1
+workspace: pure
+suite: regression
+prompt: "Use psd-observances to answer: when is American Education Week? Include the printed-page citation."
+trials: 3
+fixtures:
+  - fixtures/lookup-american-education-week.json
+graders:
+  - {"type":"broker_request","route":"/api/agent/aistudio","method":"POST","body":{"method":{"exact":"tools/call"},"params.name":{"exact":"repositories_list"},"params.arguments.query":{"exact":"NSPRA"}}}
+  - {"type":"broker_request","route":"/api/agent/aistudio","method":"POST","body":{"method":{"exact":"tools/call"},"params.name":{"exact":"repositories_search"},"params.arguments.query":{"exact":"American Education Week"},"params.arguments.repositoryIds":{"contains_any":[1476]}}}
+  - {"type":"output_match","pattern":"(?is)(American Education Week.*November 16-20, 2026.*Page 17|Page 17.*American Education Week.*November 16-20, 2026)"}

--- a/infra/agent-image/skills/psd-observances/package.json
+++ b/infra/agent-image/skills/psd-observances/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "psd-observances",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Bounded, cited NSPRA school-calendar lookups through an authorized AI Studio knowledge repository.",
+  "main": "run.js",
+  "scripts": {
+    "test": "bun test"
+  },
+  "dependencies": {}
+}

--- a/infra/agent-image/skills/psd-observances/run.js
+++ b/infra/agent-image/skills/psd-observances/run.js
@@ -193,6 +193,101 @@ function buildAnyQuery(value) {
   return terms.length > 1 ? terms.join(' OR ') : value;
 }
 
+function explicitYears(value) {
+  const years = [];
+  for (let index = 0; index <= value.length - 4; index += 1) {
+    const candidate = value.slice(index, index + 4);
+    const digitsOnly = [...candidate].every(
+      (character) => character >= '0' && character <= '9',
+    );
+    const previous = value[index - 1];
+    const next = value[index + 4];
+    const bounded =
+      (previous === undefined || previous < '0' || previous > '9') &&
+      (next === undefined || next < '0' || next > '9');
+    if (digitsOnly && bounded) {
+      years.push({ year: Number(candidate), index });
+      index += 3;
+    }
+  }
+  return years;
+}
+
+function explicitIsoDates(value) {
+  const dates = [];
+  for (let index = 0; index <= value.length - 10; index += 1) {
+    const candidate = value.slice(index, index + 10);
+    if (validIsoDate(candidate)) {
+      dates.push(candidate);
+      index += 9;
+    }
+  }
+  return dates;
+}
+
+function wordTokens(value) {
+  return value
+    .split(/\s+/u)
+    .map((token) => token.replace(/[^\p{L}\p{N}-]/gu, ''))
+    .filter(Boolean);
+}
+
+function rejectLate2027Month(value) {
+  const tokens = wordTokens(value).map((token) => token.toLocaleLowerCase());
+  const yearIndexes = tokens
+    .map((token, index) => (token === '2027' ? index : -1))
+    .filter((index) => index >= 0);
+  const lateMonths = new Set([
+    'july',
+    'august',
+    'september',
+    'october',
+    'november',
+    'december',
+  ]);
+  for (const [index, token] of tokens.entries()) {
+    if (!lateMonths.has(token) || yearIndexes.length === 0) continue;
+    const nearestYearDistance = Math.min(
+      ...yearIndexes.map((yearIndex) => Math.abs(yearIndex - index)),
+    );
+    if (nearestYearDistance <= 4) {
+      fail(
+        'The requested 2027 month is outside the January 2026 through June 2027 coverage window.',
+        'out_of_range',
+        1,
+      );
+    }
+  }
+}
+
+function validateOrdinaryFreeForm(value) {
+  for (const { year } of explicitYears(value)) {
+    if (year < 2026 || year > 2027) {
+      fail(
+        `Year ${year} is outside ordinary coverage. Use holiday-years only for major holidays from 2026 through 2031.`,
+        'out_of_range',
+        1,
+      );
+    }
+  }
+  for (const date of explicitIsoDates(value)) {
+    assertCoveredDate(date, 'date');
+  }
+  rejectLate2027Month(value);
+}
+
+function validateHolidayYearsName(value) {
+  for (const { year } of explicitYears(value)) {
+    if (year < 2026 || year > 2031) {
+      fail(
+        `Year ${year} is outside the six-year holiday summary for 2026 through 2031.`,
+        'out_of_range',
+        1,
+      );
+    }
+  }
+}
+
 function commandResult(context, query, includePartIINotice = false) {
   return {
     command: context.command,
@@ -204,14 +299,17 @@ function commandResult(context, query, includePartIINotice = false) {
 }
 
 function buildLookupCommand(context) {
+  const name = joinedPositionals(context.positionals, 'observance name');
+  validateOrdinaryFreeForm(name);
   return commandResult(
     context,
-    joinedPositionals(context.positionals, 'observance name'),
+    name,
   );
 }
 
 function buildSearchCommand(context) {
   const terms = joinedPositionals(context.positionals, 'search terms');
+  validateOrdinaryFreeForm(terms);
   return commandResult(
     context,
     context.flags.any === true ? buildAnyQuery(terms) : terms,
@@ -278,6 +376,7 @@ function buildConferencesCommand(context) {
 
 function buildHolidayYearsCommand(context) {
   const name = joinedPositionals(context.positionals, 'holiday name');
+  validateHolidayYearsName(name);
   return commandResult(
     context,
     `${name} 2026 2027 2028 2029 2030 2031 six-year summary`,
@@ -405,10 +504,12 @@ function resultContent(result) {
 }
 
 function searchTerms(query) {
-  return query
-    .split(/\s+OR\s+|\s+/i)
-    .map((term) => term.replace(/[^\p{L}\p{N}-]/gu, ''))
-    .filter((term) => term.length >= 3 && !/^\d{4}$/.test(term));
+  return wordTokens(query).filter(
+    (term) =>
+      term.toLocaleUpperCase() !== 'OR' &&
+      term.length >= 3 &&
+      !/^\d{4}$/.test(term),
+  );
 }
 
 function excerptAround(content, query, maximum) {

--- a/infra/agent-image/skills/psd-observances/run.js
+++ b/infra/agent-image/skills/psd-observances/run.js
@@ -226,10 +226,23 @@ function explicitIsoDates(value) {
 }
 
 function wordTokens(value) {
-  return value
-    .split(/\s+/u)
-    .map((token) => token.replace(/[^\p{L}\p{N}-]/gu, ''))
-    .filter(Boolean);
+  const tokens = [];
+  let token = '';
+  const flushToken = () => {
+    if (!token) return;
+    tokens.push(token);
+    token = '';
+  };
+
+  for (const character of value) {
+    if (/[\p{L}\p{N}]/u.test(character)) {
+      token += character;
+    } else {
+      flushToken();
+    }
+  }
+  flushToken();
+  return tokens;
 }
 
 function numericDateTokens(value) {
@@ -310,11 +323,26 @@ function numericMonthYears(value) {
   return tokens.flatMap((_, index) => numericMonthYearAt(tokens, index));
 }
 
+function nearestYearIs2027(tokens, index) {
+  const targetYears = new Set(['2027']);
+  let nearestDistance = Number.POSITIVE_INFINITY;
+  let nearestIncludes2027 = false;
+  for (const [yearIndex, token] of tokens.entries()) {
+    if (token.length !== 4 || !Number.isSafeInteger(Number(token))) continue;
+    const distance = Math.abs(yearIndex - index);
+    if (distance > nearestDistance) continue;
+    if (distance < nearestDistance) {
+      nearestDistance = distance;
+      nearestIncludes2027 = targetYears.has(token);
+    } else if (targetYears.has(token)) {
+      nearestIncludes2027 = true;
+    }
+  }
+  return nearestIncludes2027;
+}
+
 function rejectLate2027Month(value) {
   const tokens = wordTokens(value).map((token) => token.toLocaleLowerCase());
-  const yearIndexes = tokens
-    .map((token, index) => (token === '2027' ? index : -1))
-    .filter((index) => index >= 0);
   const lateMonths = new Set([
     'july',
     'jul',
@@ -331,11 +359,7 @@ function rejectLate2027Month(value) {
     'dec',
   ]);
   for (const [index, token] of tokens.entries()) {
-    if (!lateMonths.has(token) || yearIndexes.length === 0) continue;
-    const nearestYearDistance = Math.min(
-      ...yearIndexes.map((yearIndex) => Math.abs(yearIndex - index)),
-    );
-    if (nearestYearDistance <= 4) {
+    if (lateMonths.has(token) && nearestYearIs2027(tokens, index)) {
       fail(
         'The requested 2027 month is outside the January 2026 through June 2027 coverage window.',
         'out_of_range',
@@ -356,6 +380,55 @@ function rejectLate2027Month(value) {
   }
 }
 
+function rejectLate2027Period(value) {
+  const tokens = wordTokens(value).map((token) => token.toLocaleLowerCase());
+  const lateSeasons = new Set(['summer', 'fall', 'autumn']);
+  const latePeriodNames = new Set(['q3', 'q4', 'h2']);
+  const lateQuarterValues = new Set([
+    '3',
+    '3rd',
+    'three',
+    'third',
+    '4',
+    '4th',
+    'four',
+    'fourth',
+  ]);
+  const halfNames = new Set(['half']);
+  const quarterNames = new Set(['q', 'qtr', 'quarter']);
+  const describesLatePeriod = (token, index) => {
+    if (lateSeasons.has(token) || latePeriodNames.has(token)) return true;
+    if (halfNames.has(token)) {
+      return ['2', '2nd', 'second'].includes(tokens[index - 1]);
+    }
+    if (quarterNames.has(token)) {
+      return (
+        lateQuarterValues.has(tokens[index - 1]) ||
+        lateQuarterValues.has(tokens[index + 1])
+      );
+    }
+    return (
+      lateQuarterValues.has(token) &&
+      [tokens[index - 1], tokens[index + 1]].some((nearby) =>
+        quarterNames.has(nearby),
+      )
+    );
+  };
+
+  if (
+    tokens.some(
+      (token, index) =>
+        describesLatePeriod(token, index) && nearestYearIs2027(tokens, index),
+    )
+  ) {
+    fail(
+      'The requested 2027 period extends beyond the January 2026 through June 2027 coverage window.',
+      'out_of_range',
+      1,
+    );
+  }
+}
+
 function validateOrdinaryFreeForm(value) {
   for (const { year } of explicitYears(value)) {
     if (year < 2026 || year > 2027) {
@@ -370,6 +443,7 @@ function validateOrdinaryFreeForm(value) {
     assertCoveredDate(date, 'date');
   }
   rejectLate2027Month(value);
+  rejectLate2027Period(value);
 }
 
 function validateHolidayYearsName(value) {
@@ -384,13 +458,19 @@ function validateHolidayYearsName(value) {
   }
 }
 
-function commandResult(context, query, includePartIINotice = false) {
+function commandResult(
+  context,
+  query,
+  includePartIINotice = false,
+  searches = undefined,
+) {
   return {
     command: context.command,
     query,
     limit: context.limit,
     output: context.output,
     includePartIINotice,
+    ...(searches ? { searches } : {}),
   };
 }
 
@@ -435,13 +515,35 @@ function buildStateCommand(context) {
   ) {
     fail('--section must be legal or school');
   }
-  const sectionQuery =
-    section === 'legal'
-      ? 'legal holidays'
-      : section === 'school'
-        ? 'school holidays'
-        : 'legal holidays school holidays';
-  return commandResult(context, `${state} ${sectionQuery}`, true);
+  if (section === 'legal' || section === 'school') {
+    return commandResult(
+      context,
+      `${state} ${section} holidays`,
+      true,
+    );
+  }
+  if (context.limit < 2) {
+    fail(
+      'state without --section requires --limit 2 or greater so both legal and school holiday sections can be returned.',
+    );
+  }
+  return commandResult(
+    context,
+    `${state} legal and school holidays`,
+    true,
+    [
+      {
+        section: 'legal',
+        sectionLabel: 'Legal holidays',
+        query: `${state} legal holidays`,
+      },
+      {
+        section: 'school',
+        sectionLabel: 'School holidays',
+        query: `${state} school holidays`,
+      },
+    ],
+  );
 }
 
 function conferenceYear(value) {
@@ -665,6 +767,60 @@ function shapeSearchResponse(response, query, full, limit = MAX_LIMIT) {
   });
 }
 
+function interleaveResultGroups(groups, limit) {
+  const results = [];
+  for (let index = 0; results.length < limit; index += 1) {
+    let foundResult = false;
+    for (const group of groups) {
+      const result = group[index];
+      if (!result) continue;
+      results.push(result);
+      foundResult = true;
+      if (results.length === limit) break;
+    }
+    if (!foundResult) break;
+  }
+  return results;
+}
+
+async function searchRepository(command, repository, callTool) {
+  const searches = command.searches ?? [{ query: command.query }];
+  const groups = [];
+  for (const search of searches) {
+    const response = await callTool('repositories_search', {
+      query: search.query,
+      repositoryIds: [repository.id],
+      mode: 'hybrid',
+      limit: command.limit,
+    });
+    const results = shapeSearchResponse(
+      response,
+      search.query,
+      command.output.full,
+      command.limit,
+    ).map((result) => ({
+      ...result,
+      ...(search.section
+        ? {
+            section: search.section,
+            sectionLabel: search.sectionLabel,
+          }
+        : {}),
+    }));
+    if (command.searches && results.length === 0) {
+      fail(
+        `No cited ${search.sectionLabel.toLocaleLowerCase()} results were found for this state.`,
+        'no_results',
+        1,
+      );
+    }
+    groups.push(results);
+  }
+  return command.searches
+    ? interleaveResultGroups(groups, command.limit)
+    : groups[0];
+}
+
 async function executeCommand(
   command,
   requestAgentBroker = defaultRequestAgentBroker,
@@ -673,18 +829,7 @@ async function executeCommand(
     callRepositoryTool(toolName, toolArgs, requestAgentBroker);
   const resolveRepository = createRepositoryResolver(callTool);
   const repository = await resolveRepository();
-  const response = await callTool('repositories_search', {
-    query: command.query,
-    repositoryIds: [repository.id],
-    mode: 'hybrid',
-    limit: command.limit,
-  });
-  const results = shapeSearchResponse(
-    response,
-    command.query,
-    command.output.full,
-    command.limit,
-  );
+  const results = await searchRepository(command, repository, callTool);
   return {
     status: 'ok',
     command: command.command,
@@ -711,8 +856,9 @@ function renderText(result) {
   } else {
     for (const [index, item] of result.results.entries()) {
       const title = item.itemName ? `${item.itemName} — ` : '';
+      const section = item.sectionLabel ? `${item.sectionLabel}: ` : '';
       lines.push(
-        `${index + 1}. ${item.citation.label} — ${title}${item.excerpt}`,
+        `${index + 1}. ${section}${item.citation.label} — ${title}${item.excerpt}`,
       );
     }
   }

--- a/infra/agent-image/skills/psd-observances/run.js
+++ b/infra/agent-image/skills/psd-observances/run.js
@@ -232,6 +232,84 @@ function wordTokens(value) {
     .filter(Boolean);
 }
 
+function numericDateTokens(value) {
+  const tokens = [];
+  let digits = '';
+  const flushDigits = () => {
+    if (!digits) return;
+    tokens.push(digits);
+    digits = '';
+  };
+
+  for (const character of value) {
+    if (character >= '0' && character <= '9') {
+      digits += character;
+      continue;
+    }
+    flushDigits();
+    if (character === '/' || character === '-' || character === '.') {
+      tokens.push(character);
+    } else if (tokens.at(-1) !== '|') {
+      tokens.push('|');
+    }
+  }
+  flushDigits();
+  return tokens;
+}
+
+function isNumericToken(value) {
+  return (
+    typeof value === 'string' &&
+    value.length > 0 &&
+    [...value].every(
+      (character) => character >= '0' && character <= '9',
+    )
+  );
+}
+
+function numericMonthYearAt(tokens, index) {
+  const candidates = [];
+  const first = tokens[index];
+  const separator = tokens[index + 1];
+  const second = tokens[index + 2];
+  if (
+    !isNumericToken(first) ||
+    !['/', '-', '.'].includes(separator) ||
+    !isNumericToken(second)
+  ) {
+    return candidates;
+  }
+
+  const followsNumericDatePart =
+    tokens[index - 1] === separator &&
+    isNumericToken(tokens[index - 2]);
+  if (first.length === 4 && second.length <= 2) {
+    candidates.push({ year: Number(first), month: Number(second) });
+  } else if (
+    second.length === 4 &&
+    first.length <= 2 &&
+    !followsNumericDatePart
+  ) {
+    candidates.push({ year: Number(second), month: Number(first) });
+  }
+
+  const third = tokens[index + 4];
+  if (
+    tokens[index + 3] === separator &&
+    typeof third === 'string' &&
+    third.length === 4 &&
+    first.length <= 2
+  ) {
+    candidates.push({ year: Number(third), month: Number(first) });
+  }
+  return candidates;
+}
+
+function numericMonthYears(value) {
+  const tokens = numericDateTokens(value);
+  return tokens.flatMap((_, index) => numericMonthYearAt(tokens, index));
+}
+
 function rejectLate2027Month(value) {
   const tokens = wordTokens(value).map((token) => token.toLocaleLowerCase());
   const yearIndexes = tokens
@@ -239,11 +317,18 @@ function rejectLate2027Month(value) {
     .filter((index) => index >= 0);
   const lateMonths = new Set([
     'july',
+    'jul',
     'august',
+    'aug',
     'september',
+    'sep',
+    'sept',
     'october',
+    'oct',
     'november',
+    'nov',
     'december',
+    'dec',
   ]);
   for (const [index, token] of tokens.entries()) {
     if (!lateMonths.has(token) || yearIndexes.length === 0) continue;
@@ -257,6 +342,17 @@ function rejectLate2027Month(value) {
         1,
       );
     }
+  }
+  if (
+    numericMonthYears(value).some(
+      ({ year, month }) => year === 2027 && month > 6,
+    )
+  ) {
+    fail(
+      'The requested 2027 month is outside the January 2026 through June 2027 coverage window.',
+      'out_of_range',
+      1,
+    );
   }
 }
 

--- a/infra/agent-image/skills/psd-observances/run.js
+++ b/infra/agent-image/skills/psd-observances/run.js
@@ -1,0 +1,601 @@
+#!/usr/bin/env node
+/**
+ * psd-observances — bounded, cited NSPRA calendar lookups over the existing
+ * AI Studio repository MCP tools.
+ */
+
+'use strict';
+
+const {
+  SkillFailure,
+  callRepositoryTool,
+  defaultRequestAgentBroker,
+  fail,
+} = require('./common');
+
+const DEFAULT_LIMIT = 5;
+const MAX_LIMIT = 50;
+const DEFAULT_EXCERPT_CHARS = 300;
+const FULL_EXCERPT_CHARS = 2_000;
+const FULL_TOTAL_CHARS = 25_000;
+const COVERAGE_START = '2026-01-01';
+const COVERAGE_END = '2027-06-30';
+const ACCURACY_NOTICE = 'Data was verified as of November 2025.';
+const PART_II_NOTICE =
+  'Part II is not intended to serve as the official or legal listing of holidays for each state.';
+const COVERAGE_NOTICE =
+  'Coverage is January 2026 through June 2027, plus the six-year holiday summary through 2031.';
+const MONTH_NAMES = Object.freeze([
+  'January',
+  'February',
+  'March',
+  'April',
+  'May',
+  'June',
+  'July',
+  'August',
+  'September',
+  'October',
+  'November',
+  'December',
+]);
+
+const USAGE = `psd-observances — cited NSPRA school-calendar reference
+
+Usage:
+  node run.js lookup <name> [--limit N] [--full] [--json]
+  node run.js search <terms> [--any] [--limit N] [--full] [--json]
+  node run.js month <YYYY-MM> [--limit N] [--full] [--json]
+  node run.js on --date <YYYY-MM-DD> [--limit N] [--full] [--json]
+  node run.js state <name> [--section legal|school] [--limit N] [--full] [--json]
+  node run.js conferences [--year N] [--org <text>] [--limit N] [--full] [--json]
+  node run.js holiday-years <name> [--limit N] [--full] [--json]
+
+The skill resolves an accessible repository whose name contains "NSPRA".
+Default output returns at most five cited results with 300-character excerpts.`;
+
+const VALUE_FLAGS = new Set(['limit', 'date', 'section', 'year', 'org']);
+const BOOLEAN_FLAGS = new Set(['json', 'full', 'any', 'help']);
+const GLOBAL_FLAGS = new Set(['limit', 'json', 'full', 'help']);
+const COMMAND_FLAGS = Object.freeze({
+  lookup: new Set(),
+  search: new Set(['any']),
+  month: new Set(),
+  on: new Set(['date']),
+  state: new Set(['section']),
+  conferences: new Set(['year', 'org']),
+  'holiday-years': new Set(),
+});
+
+function parseCli(argv) {
+  if (!Array.isArray(argv) || argv.length === 0) {
+    return { help: true };
+  }
+  if (argv[0] === '--help' || argv[0] === '-h') {
+    return { help: true };
+  }
+
+  const command = argv[0];
+  const flags = Object.create(null);
+  const positionals = [];
+  for (let index = 1; index < argv.length; index += 1) {
+    const token = argv[index];
+    if (token === '--help' || token === '-h') {
+      flags.help = true;
+      continue;
+    }
+    if (!token.startsWith('--')) {
+      positionals.push(token);
+      continue;
+    }
+    if (token.includes('=')) {
+      fail(`Use "${token.split('=')[0]} <value>" instead of equals syntax.`);
+    }
+    const key = token.slice(2);
+    if (BOOLEAN_FLAGS.has(key)) {
+      flags[key] = true;
+      continue;
+    }
+    if (!VALUE_FLAGS.has(key)) {
+      fail(`Unknown flag: --${key}`);
+    }
+    const next = argv[index + 1];
+    if (next === undefined || next.startsWith('--')) {
+      fail(`--${key} requires a value`);
+    }
+    flags[key] = next;
+    index += 1;
+  }
+
+  return { command, flags, positionals, help: flags.help === true };
+}
+
+function assertAllowedFlags(command, flags) {
+  const commandFlags = COMMAND_FLAGS[command];
+  if (!commandFlags) {
+    fail(`Unknown subcommand: ${command}. Run with --help to see options.`);
+  }
+  for (const key of Object.keys(flags)) {
+    if (!GLOBAL_FLAGS.has(key) && !commandFlags.has(key)) {
+      fail(`--${key} is not valid with ${command}`);
+    }
+  }
+}
+
+function parseLimit(value) {
+  if (value === undefined) return DEFAULT_LIMIT;
+  const limit = Number(value);
+  if (!Number.isSafeInteger(limit) || limit < 1 || limit > MAX_LIMIT) {
+    fail(`--limit must be an integer from 1 to ${MAX_LIMIT}`);
+  }
+  return limit;
+}
+
+function joinedPositionals(positionals, label) {
+  const value = positionals.join(' ').trim();
+  if (!value) fail(`${label} is required`);
+  return value;
+}
+
+function assertNoPositionals(positionals, command) {
+  if (positionals.length > 0) {
+    fail(`${command} does not accept positional arguments`);
+  }
+}
+
+function validIsoDate(value) {
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
+  if (!match) return false;
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  const date = new Date(Date.UTC(year, month - 1, day));
+  return (
+    date.getUTCFullYear() === year &&
+    date.getUTCMonth() === month - 1 &&
+    date.getUTCDate() === day
+  );
+}
+
+function assertCoveredDate(value, label) {
+  if (!validIsoDate(value)) fail(`${label} must use YYYY-MM-DD`);
+  if (value < COVERAGE_START || value > COVERAGE_END) {
+    fail(
+      `${label} is outside the January 2026 through June 2027 coverage window. ` +
+        'Use holiday-years only for the six-year holiday summary through 2031.',
+      'out_of_range',
+      1,
+    );
+  }
+}
+
+function monthQuery(value) {
+  const match = /^(\d{4})-(\d{2})$/.exec(value);
+  if (!match) fail('month must use YYYY-MM');
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  if (month < 1 || month > 12) fail('month must use YYYY-MM');
+  assertCoveredDate(
+    `${match[1]}-${match[2]}-01`,
+    'month',
+  );
+  return `${MONTH_NAMES[month - 1]} ${year}`;
+}
+
+function naturalDate(value) {
+  assertCoveredDate(value, '--date');
+  const [year, month, day] = value.split('-').map(Number);
+  return `${MONTH_NAMES[month - 1]} ${day}, ${year}`;
+}
+
+function buildAnyQuery(value) {
+  const terms = value.split(/\s+/).filter(Boolean);
+  return terms.length > 1 ? terms.join(' OR ') : value;
+}
+
+function commandResult(context, query, includePartIINotice = false) {
+  return {
+    command: context.command,
+    query,
+    limit: context.limit,
+    output: context.output,
+    includePartIINotice,
+  };
+}
+
+function buildLookupCommand(context) {
+  return commandResult(
+    context,
+    joinedPositionals(context.positionals, 'observance name'),
+  );
+}
+
+function buildSearchCommand(context) {
+  const terms = joinedPositionals(context.positionals, 'search terms');
+  return commandResult(
+    context,
+    context.flags.any === true ? buildAnyQuery(terms) : terms,
+  );
+}
+
+function buildMonthCommand(context) {
+  if (context.positionals.length !== 1) {
+    fail('month requires exactly one YYYY-MM value');
+  }
+  return commandResult(context, monthQuery(context.positionals[0]));
+}
+
+function buildOnCommand(context) {
+  assertNoPositionals(context.positionals, context.command);
+  if (typeof context.flags.date !== 'string') fail('--date is required');
+  return commandResult(context, naturalDate(context.flags.date));
+}
+
+function buildStateCommand(context) {
+  const state = joinedPositionals(context.positionals, 'state name');
+  const section = context.flags.section;
+  if (
+    section !== undefined &&
+    section !== 'legal' &&
+    section !== 'school'
+  ) {
+    fail('--section must be legal or school');
+  }
+  const sectionQuery =
+    section === 'legal'
+      ? 'legal holidays'
+      : section === 'school'
+        ? 'school holidays'
+        : 'legal holidays school holidays';
+  return commandResult(context, `${state} ${sectionQuery}`, true);
+}
+
+function conferenceYear(value) {
+  if (value === undefined) return undefined;
+  const year = Number(value);
+  if (!Number.isSafeInteger(year) || year < 2026 || year > 2027) {
+    fail(
+      '--year must be 2026 or 2027; publication coverage ends in June 2027.',
+      'out_of_range',
+      1,
+    );
+  }
+  return year;
+}
+
+function buildConferencesCommand(context) {
+  assertNoPositionals(context.positionals, context.command);
+  const year = conferenceYear(context.flags.year);
+  const org =
+    typeof context.flags.org === 'string' && context.flags.org.trim()
+      ? context.flags.org.trim()
+      : undefined;
+  return commandResult(
+    context,
+    ['education conferences', org, year].filter(Boolean).join(' '),
+  );
+}
+
+function buildHolidayYearsCommand(context) {
+  const name = joinedPositionals(context.positionals, 'holiday name');
+  return commandResult(
+    context,
+    `${name} 2026 2027 2028 2029 2030 2031 six-year summary`,
+  );
+}
+
+const COMMAND_BUILDERS = Object.freeze({
+  lookup: buildLookupCommand,
+  search: buildSearchCommand,
+  month: buildMonthCommand,
+  on: buildOnCommand,
+  state: buildStateCommand,
+  conferences: buildConferencesCommand,
+  'holiday-years': buildHolidayYearsCommand,
+});
+
+function buildCommand(parsed) {
+  const { command, flags, positionals } = parsed;
+  assertAllowedFlags(command, flags);
+  return COMMAND_BUILDERS[command]({
+    command,
+    flags,
+    positionals,
+    limit: parseLimit(flags.limit),
+    output: {
+      json: flags.json === true,
+      full: flags.full === true,
+    },
+  });
+}
+
+function repositoryEntry(value) {
+  if (
+    !value ||
+    !Number.isSafeInteger(value.id) ||
+    value.id <= 0 ||
+    typeof value.name !== 'string'
+  ) {
+    return null;
+  }
+  return { id: value.id, name: value.name };
+}
+
+function createRepositoryResolver(callTool) {
+  let cachedPromise;
+  return async function resolveRepository() {
+    if (!cachedPromise) {
+      cachedPromise = (async () => {
+        const payload = await callTool('repositories_list', {
+          query: 'NSPRA',
+          limit: 50,
+        });
+        if (!payload || !Array.isArray(payload.repositories)) {
+          fail(
+            'AI Studio returned a malformed repository list.',
+            'upstream_error',
+            12,
+          );
+        }
+        const matches = payload.repositories
+          .map(repositoryEntry)
+          .filter(Boolean)
+          .filter((repository) => /nspra/i.test(repository.name));
+        if (matches.length === 0) {
+          fail(
+            'The NSPRA repository is not available to your account.',
+            'repository_unavailable',
+            1,
+          );
+        }
+        matches.sort((left, right) => {
+          const leftPreferred = /2026/i.test(left.name) ? 0 : 1;
+          const rightPreferred = /2026/i.test(right.name) ? 0 : 1;
+          return leftPreferred - rightPreferred || left.id - right.id;
+        });
+        const selected = matches[0];
+        return {
+          ...selected,
+          selectionNotice:
+            matches.length > 1
+              ? `Multiple NSPRA repositories matched; selected "${selected.name}" (id ${selected.id}).`
+              : undefined,
+        };
+      })();
+    }
+    return cachedPromise;
+  };
+}
+
+function pageCitation(result) {
+  const locators = [
+    result && result.sourceLocator,
+    ...((result && Array.isArray(result.citations)
+      ? result.citations
+      : []
+    ).map((citation) => citation && citation.sourceLocator)),
+  ];
+  for (const locator of locators) {
+    const page = Number(locator && locator.page);
+    const pageEnd = Number(locator && locator.pageEnd);
+    if (!Number.isSafeInteger(page) || page <= 0) continue;
+    if (Number.isSafeInteger(pageEnd) && pageEnd >= page && pageEnd !== page) {
+      return { page, pageEnd, label: `Pages ${page}-${pageEnd}` };
+    }
+    return { page, label: `Page ${page}` };
+  }
+  fail(
+    'AI Studio returned a result without the required page citation.',
+    'upstream_error',
+    12,
+  );
+}
+
+function resultContent(result) {
+  if (result && typeof result.content === 'string') return result.content;
+  if (result && Array.isArray(result.context)) {
+    return result.context
+      .map((segment) =>
+        segment && typeof segment.content === 'string' ? segment.content : '',
+      )
+      .filter(Boolean)
+      .join('\n');
+  }
+  return '';
+}
+
+function searchTerms(query) {
+  return query
+    .split(/\s+OR\s+|\s+/i)
+    .map((term) => term.replace(/[^\p{L}\p{N}-]/gu, ''))
+    .filter((term) => term.length >= 3 && !/^\d{4}$/.test(term));
+}
+
+function excerptAround(content, query, maximum) {
+  const normalized = String(content || '').replace(/\s+/g, ' ').trim();
+  if (normalized.length <= maximum) {
+    return { text: normalized, truncated: false };
+  }
+
+  const lower = normalized.toLocaleLowerCase();
+  const matchIndex = searchTerms(query)
+    .map((term) => lower.indexOf(term.toLocaleLowerCase()))
+    .find((index) => index >= 0);
+  const center = matchIndex === undefined ? 0 : matchIndex;
+  const prefix = center > 0 ? '…' : '';
+  const start = Math.max(0, center - Math.floor(maximum / 3));
+  const suffixBudget = start + maximum < normalized.length ? 1 : 0;
+  const bodyBudget = Math.max(1, maximum - prefix.length - suffixBudget);
+  const body = normalized.slice(start, start + bodyBudget);
+  const suffix = start + body.length < normalized.length ? '…' : '';
+  return { text: `${prefix}${body}${suffix}`, truncated: true };
+}
+
+function shapeSearchResponse(response, query, full, limit = MAX_LIMIT) {
+  if (!response || !Array.isArray(response.results)) {
+    fail(
+      'AI Studio returned a malformed repository search response.',
+      'upstream_error',
+      12,
+    );
+  }
+
+  const boundedResults = response.results.slice(0, limit);
+  let remaining = full
+    ? FULL_TOTAL_CHARS
+    : DEFAULT_EXCERPT_CHARS * boundedResults.length;
+  return boundedResults.map((result, index) => {
+    const remainingResults = boundedResults.length - index;
+    const maximum = full
+      ? Math.min(FULL_EXCERPT_CHARS, Math.floor(remaining / remainingResults))
+      : DEFAULT_EXCERPT_CHARS;
+    const excerpt = excerptAround(resultContent(result), query, maximum);
+    remaining -= excerpt.text.length;
+    const citation = pageCitation(result);
+    return {
+      itemName:
+        result && typeof result.itemName === 'string'
+          ? result.itemName
+          : undefined,
+      citation,
+      excerpt: excerpt.text,
+      truncated: excerpt.truncated,
+      similarity:
+        result && Number.isFinite(result.similarity)
+          ? result.similarity
+          : undefined,
+    };
+  });
+}
+
+async function executeCommand(
+  command,
+  requestAgentBroker = defaultRequestAgentBroker,
+) {
+  const callTool = (toolName, toolArgs) =>
+    callRepositoryTool(toolName, toolArgs, requestAgentBroker);
+  const resolveRepository = createRepositoryResolver(callTool);
+  const repository = await resolveRepository();
+  const response = await callTool('repositories_search', {
+    query: command.query,
+    repositoryIds: [repository.id],
+    mode: 'hybrid',
+    limit: command.limit,
+  });
+  const results = shapeSearchResponse(
+    response,
+    command.query,
+    command.output.full,
+    command.limit,
+  );
+  return {
+    status: 'ok',
+    command: command.command,
+    query: command.query,
+    repository: { id: repository.id, name: repository.name },
+    ...(repository.selectionNotice
+      ? { selectionNotice: repository.selectionNotice }
+      : {}),
+    resultCount: results.length,
+    results,
+    accuracyNotice: ACCURACY_NOTICE,
+    coverageNotice: COVERAGE_NOTICE,
+    ...(command.includePartIINotice ? { partIINotice: PART_II_NOTICE } : {}),
+  };
+}
+
+function renderText(result) {
+  const lines = [
+    `NSPRA repository: ${result.repository.name} (id ${result.repository.id})`,
+  ];
+  if (result.selectionNotice) lines.push(result.selectionNotice);
+  if (result.results.length === 0) {
+    lines.push('No matching cited results were found.');
+  } else {
+    for (const [index, item] of result.results.entries()) {
+      const title = item.itemName ? `${item.itemName} — ` : '';
+      lines.push(
+        `${index + 1}. ${item.citation.label} — ${title}${item.excerpt}`,
+      );
+    }
+  }
+  if (result.results.some((item) => item.truncated)) {
+    lines.push(
+      `Excerpts are bounded; use --full to expand them. Default excerpts are ${DEFAULT_EXCERPT_CHARS} characters.`,
+    );
+  }
+  lines.push(result.accuracyNotice, result.coverageNotice);
+  if (result.partIINotice) lines.push(result.partIINotice);
+  return `${lines.join('\n')}\n`;
+}
+
+function failurePayload(error) {
+  return {
+    status: 'error',
+    error: error.code,
+    message: error.message,
+    ...(error.detail ? { detail: error.detail } : {}),
+  };
+}
+
+async function main(
+  argv = process.argv.slice(2),
+  dependencies = {},
+  io = {
+    stdout: process.stdout.write.bind(process.stdout),
+    stderr: process.stderr.write.bind(process.stderr),
+  },
+) {
+  try {
+    const parsed = parseCli(argv);
+    if (parsed.help) {
+      io.stdout(`${USAGE}\n`);
+      return 0;
+    }
+    const command = buildCommand(parsed);
+    const result = await executeCommand(
+      command,
+      dependencies.requestAgentBroker || defaultRequestAgentBroker,
+    );
+    io.stdout(
+      command.output.json
+        ? `${JSON.stringify(result)}\n`
+        : renderText(result),
+    );
+    return 0;
+  } catch (error) {
+    const failure =
+      error instanceof SkillFailure
+        ? error
+        : new SkillFailure(
+            error instanceof Error ? error.message : String(error),
+            'internal',
+            2,
+          );
+    io.stderr(`psd-observances: ${failure.message}\n`);
+    io.stdout(`${JSON.stringify(failurePayload(failure))}\n`);
+    return failure.exitCode;
+  }
+}
+
+if (require.main === module) {
+  main().then((exitCode) => {
+    process.exitCode = exitCode;
+  });
+}
+
+module.exports = {
+  ACCURACY_NOTICE,
+  COVERAGE_NOTICE,
+  PART_II_NOTICE,
+  USAGE,
+  buildCommand,
+  createRepositoryResolver,
+  executeCommand,
+  excerptAround,
+  main,
+  pageCitation,
+  parseCli,
+  renderText,
+  shapeSearchResponse,
+};

--- a/infra/agent-image/skills/psd-observances/run.test.js
+++ b/infra/agent-image/skills/psd-observances/run.test.js
@@ -1,0 +1,534 @@
+/**
+ * psd-observances CLI, repository-resolution, output-bound, and broker tests.
+ *
+ * Every documented command runs through main() with a mocked owner-bound
+ * broker. Fixtures contain names and dates only, never NSPRA prose comments.
+ */
+
+'use strict';
+
+const { afterEach, describe, expect, test } = require('bun:test');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const {
+  createRepositoryResolver,
+  excerptAround,
+  main,
+  parseCli,
+} = require('./run');
+
+const DEFAULT_REPOSITORIES = [
+  { id: 1476, name: 'District NSPRA 2026-2027 Calendar' },
+];
+
+function toolEnvelope(data, options = {}) {
+  return {
+    httpStatus: options.httpStatus ?? 200,
+    keySource: options.keySource ?? 'oauth',
+    payload:
+      options.payload ??
+      {
+        jsonrpc: '2.0',
+        id: 'test',
+        result: {
+          content: [{ type: 'text', text: JSON.stringify(data) }],
+        },
+      },
+  };
+}
+
+function factForQuery(query) {
+  if (/washington/i.test(query)) {
+    return 'Washington — Legal holidays — School holidays';
+  }
+  if (/conference|National PTA/i.test(query)) {
+    return 'National PTA conference — June 18-21, 2026';
+  }
+  if (/christmas/i.test(query)) {
+    return 'Christmas — December 25 — 2026, 2027, 2028, 2029, 2030, 2031';
+  }
+  return 'American Education Week — November 16-20, 2026';
+}
+
+function searchResult(query, overrides = {}) {
+  return {
+    itemName: 'NSPRA calendar',
+    content: factForQuery(query),
+    sourceLocator: { page: 17 },
+    citations: [{ sourceLocator: { page: 17 }, label: 'Page 17' }],
+    similarity: 0.91,
+    ...overrides,
+  };
+}
+
+function createBroker(options = {}) {
+  const calls = [];
+  const broker = async (route, body, requestOptions) => {
+    calls.push({ route, body, requestOptions });
+    const toolName = body && body.params && body.params.name;
+    if (options.respond) {
+      const response = await options.respond(toolName, body.params.arguments);
+      if (response !== undefined) return response;
+    }
+    if (toolName === 'repositories_list') {
+      return toolEnvelope({
+        repositories: options.repositories ?? DEFAULT_REPOSITORIES,
+      });
+    }
+    if (toolName === 'repositories_search') {
+      const query = body.params.arguments.query;
+      return toolEnvelope({
+        results:
+          options.results ??
+          [searchResult(query)],
+        diagnostics: { returnedResults: 1 },
+      });
+    }
+    throw new Error(`Unexpected tool: ${toolName}`);
+  };
+  return { broker, calls };
+}
+
+async function invoke(argv, broker) {
+  let stdout = '';
+  let stderr = '';
+  const exitCode = await main(
+    argv,
+    { requestAgentBroker: broker },
+    {
+      stdout: (value) => {
+        stdout += value;
+      },
+      stderr: (value) => {
+        stderr += value;
+      },
+    },
+  );
+  return { exitCode, stdout, stderr };
+}
+
+describe('documented command forms', () => {
+  const cases = [
+    {
+      name: 'lookup',
+      argv: ['lookup', 'American Education Week'],
+      query: 'American Education Week',
+    },
+    {
+      name: 'search --any',
+      argv: ['search', 'school', 'counseling', '--any'],
+      query: 'school OR counseling',
+    },
+    {
+      name: 'month',
+      argv: ['month', '2026-11'],
+      query: 'November 2026',
+    },
+    {
+      name: 'on',
+      argv: ['on', '--date', '2026-11-16'],
+      query: 'November 16, 2026',
+    },
+    {
+      name: 'state',
+      argv: ['state', 'Washington'],
+      query: 'Washington legal holidays school holidays',
+    },
+    {
+      name: 'conferences',
+      argv: ['conferences', '--year', '2026', '--org', 'National PTA'],
+      query: 'education conferences National PTA 2026',
+    },
+    {
+      name: 'holiday-years',
+      argv: ['holiday-years', 'Christmas'],
+      query: 'Christmas 2026 2027 2028 2029 2030 2031 six-year summary',
+    },
+  ];
+
+  for (const commandCase of cases) {
+    test(`runs ${commandCase.name} with real arguments`, async () => {
+      const { broker, calls } = createBroker();
+      const result = await invoke(commandCase.argv, broker);
+      expect(result.exitCode).toBe(0);
+      expect(calls).toHaveLength(2);
+      expect(calls[0].route).toBe('/api/agent/aistudio');
+      expect(calls[0].body).toEqual({
+        method: 'tools/call',
+        params: {
+          name: 'repositories_list',
+          arguments: { query: 'NSPRA', limit: 50 },
+        },
+      });
+      expect(calls[1].body).toEqual({
+        method: 'tools/call',
+        params: {
+          name: 'repositories_search',
+          arguments: {
+            query: commandCase.query,
+            repositoryIds: [1476],
+            mode: 'hybrid',
+            limit: 5,
+          },
+        },
+      });
+      expect(result.stdout).toContain('Page 17');
+    });
+  }
+});
+
+test('lookup returns the acceptance date with a page citation', async () => {
+  const { broker } = createBroker();
+  const result = await invoke(
+    ['lookup', 'American Education Week'],
+    broker,
+  );
+  expect(result.exitCode).toBe(0);
+  expect(result.stdout).toContain('November 16-20, 2026');
+  expect(result.stdout).toContain('Page 17');
+});
+
+test('state Washington includes both sections and the Part II disclaimer', async () => {
+  const { broker } = createBroker();
+  const result = await invoke(['state', 'Washington'], broker);
+  expect(result.stdout).toContain('Legal holidays');
+  expect(result.stdout).toContain('School holidays');
+  expect(result.stdout).toContain(
+    'not intended to serve as the official or legal listing',
+  );
+});
+
+test('default lookup remains below an approximate 500-token bound', async () => {
+  const results = Array.from({ length: 8 }, (_, index) =>
+    searchResult('American Education Week', {
+      content:
+        `American Education Week — November 16-20, 2026 — ${index} ` +
+        'calendar '.repeat(200),
+      sourceLocator: { page: 17 + index },
+      citations: [{ sourceLocator: { page: 17 + index } }],
+    }),
+  );
+  const { broker } = createBroker({ results });
+  const result = await invoke(
+    ['lookup', 'American Education Week'],
+    broker,
+  );
+  expect(result.stdout.split(/\s+/).filter(Boolean).length).toBeLessThan(500);
+  expect((result.stdout.match(/^\d+\. Page/gm) || [])).toHaveLength(5);
+});
+
+test('--limit overrides the default and --json emits parseable output without a banner', async () => {
+  const results = Array.from({ length: 5 }, (_, index) =>
+    searchResult('American Education Week', {
+      sourceLocator: { page: index + 1 },
+      citations: [{ sourceLocator: { page: index + 1 } }],
+    }),
+  );
+  const { broker, calls } = createBroker({ results });
+  const result = await invoke(
+    ['lookup', 'American Education Week', '--limit', '2', '--json'],
+    broker,
+  );
+  const payload = JSON.parse(result.stdout);
+  expect(result.exitCode).toBe(0);
+  expect(payload.results).toHaveLength(2);
+  expect(result.stdout).not.toContain('Excerpts are bounded');
+  expect(calls[1].body.params.arguments.limit).toBe(2);
+});
+
+test('--full expands the default 300-character excerpt', async () => {
+  const content =
+    'American Education Week — November 16-20, 2026 — ' +
+    'calendar '.repeat(100);
+  const { broker } = createBroker({
+    results: [searchResult('American Education Week', { content })],
+  });
+  const defaultResult = await invoke(
+    ['lookup', 'American Education Week'],
+    broker,
+  );
+  const { broker: fullBroker } = createBroker({
+    results: [searchResult('American Education Week', { content })],
+  });
+  const fullResult = await invoke(
+    ['lookup', 'American Education Week', '--full'],
+    fullBroker,
+  );
+  expect(fullResult.stdout.length).toBeGreaterThan(defaultResult.stdout.length);
+});
+
+test('repository resolution prefers a 2026 name, then the lowest id, and reports it', async () => {
+  const { broker, calls } = createBroker({
+    repositories: [
+      { id: 2, name: 'NSPRA archive' },
+      { id: 9, name: 'NSPRA 2026 Calendar B' },
+      { id: 4, name: 'NSPRA 2026 Calendar A' },
+    ],
+  });
+  const result = await invoke(['lookup', 'American Education Week'], broker);
+  expect(result.exitCode).toBe(0);
+  expect(calls[1].body.params.arguments.repositoryIds).toEqual([4]);
+  expect(result.stdout).toContain('Multiple NSPRA repositories matched');
+  expect(result.stdout).toContain('NSPRA 2026 Calendar A');
+});
+
+test('repository resolution uses the lowest id when no name contains 2026', async () => {
+  const { broker, calls } = createBroker({
+    repositories: [
+      { id: 12, name: 'NSPRA calendar archive' },
+      { id: 3, name: 'NSPRA district reference' },
+    ],
+  });
+  const result = await invoke(['lookup', 'American Education Week'], broker);
+  expect(result.exitCode).toBe(0);
+  expect(calls[1].body.params.arguments.repositoryIds).toEqual([3]);
+});
+
+test('repository resolver caches the id for one invocation', async () => {
+  let calls = 0;
+  const resolve = createRepositoryResolver(async () => {
+    calls += 1;
+    return { repositories: DEFAULT_REPOSITORIES };
+  });
+  expect(await resolve()).toEqual({
+    id: 1476,
+    name: 'District NSPRA 2026-2027 Calendar',
+    selectionNotice: undefined,
+  });
+  expect(await resolve()).toEqual(await resolve());
+  expect(calls).toBe(1);
+});
+
+test('no accessible NSPRA repository gives a clear account-specific error', async () => {
+  const { broker } = createBroker({ repositories: [] });
+  const result = await invoke(['lookup', 'American Education Week'], broker);
+  expect(result.exitCode).toBe(1);
+  expect(result.stdout).toContain(
+    'The NSPRA repository is not available to your account',
+  );
+});
+
+test('HTTP unauthorized includes a connect/reconnect hint and exits 11', async () => {
+  const { broker } = createBroker({
+    respond: (toolName) =>
+      toolName === 'repositories_list'
+        ? toolEnvelope(null, {
+            httpStatus: 401,
+            payload: { error: 'expired' },
+          })
+        : undefined,
+  });
+  const result = await invoke(['lookup', 'American Education Week'], broker);
+  expect(result.exitCode).toBe(11);
+  expect(result.stdout).toMatch(/connect AI Studio access/i);
+  expect(result.stdout).toMatch(/reconnect/i);
+});
+
+test('an unconfigured AI Studio credential is a re-auth error with exit 11', async () => {
+  const { broker } = createBroker({
+    respond: () => {
+      const error = new Error(
+        'Agent broker rejected the request: AI Studio credential is not configured',
+      );
+      error.status = 404;
+      throw error;
+    },
+  });
+  const result = await invoke(['lookup', 'American Education Week'], broker);
+  expect(result.exitCode).toBe(11);
+  expect(result.stdout).toMatch(/connect AI Studio access/i);
+});
+
+test('insufficient-scope JSON-RPC errors include a re-auth hint and exit 11', async () => {
+  const { broker } = createBroker({
+    respond: (toolName) =>
+      toolName === 'repositories_list'
+        ? toolEnvelope(null, {
+            payload: {
+              jsonrpc: '2.0',
+              id: 'test',
+              error: {
+                code: -32602,
+                message: 'Insufficient scope for repositories_list',
+              },
+            },
+          })
+        : undefined,
+  });
+  const result = await invoke(['lookup', 'American Education Week'], broker);
+  expect(result.exitCode).toBe(11);
+  expect(result.stdout).toMatch(/connect AI Studio access/i);
+});
+
+test('rate limiting exits 14 and generic MCP errors exit 12', async () => {
+  const rateLimited = createBroker({
+    respond: () =>
+      toolEnvelope(null, { httpStatus: 429, payload: { error: 'slow down' } }),
+  });
+  expect(
+    (await invoke(['lookup', 'American Education Week'], rateLimited.broker))
+      .exitCode,
+  ).toBe(14);
+
+  const upstreamError = createBroker({
+    respond: () =>
+      toolEnvelope(null, {
+        payload: {
+          jsonrpc: '2.0',
+          id: 'test',
+          error: { code: -32603, message: 'retrieval unavailable' },
+        },
+      }),
+  });
+  expect(
+    (await invoke(['lookup', 'American Education Week'], upstreamError.broker))
+      .exitCode,
+  ).toBe(12);
+});
+
+test('malformed, tool-level, and transport failures exit 12', async () => {
+  const malformed = createBroker({
+    respond: () => ({ payload: null }),
+  });
+  expect(
+    (await invoke(['lookup', 'American Education Week'], malformed.broker))
+      .exitCode,
+  ).toBe(12);
+
+  const toolError = createBroker({
+    respond: () =>
+      toolEnvelope(null, {
+        payload: {
+          jsonrpc: '2.0',
+          id: 'test',
+          result: {
+            isError: true,
+            content: [{ type: 'text', text: 'repository unavailable' }],
+          },
+        },
+      }),
+  });
+  expect(
+    (await invoke(['lookup', 'American Education Week'], toolError.broker))
+      .exitCode,
+  ).toBe(12);
+
+  const transportError = createBroker({
+    respond: () => {
+      throw new Error('socket closed');
+    },
+  });
+  expect(
+    (await invoke(['lookup', 'American Education Week'], transportError.broker))
+      .exitCode,
+  ).toBe(12);
+});
+
+test('a result without a page citation is rejected', async () => {
+  const { broker } = createBroker({
+    results: [
+      searchResult('American Education Week', {
+        sourceLocator: {},
+        citations: [],
+      }),
+    ],
+  });
+  const result = await invoke(['lookup', 'American Education Week'], broker);
+  expect(result.exitCode).toBe(12);
+  expect(result.stdout).toContain('required page citation');
+});
+
+test('invalid command-specific flags and out-of-range dates fail before broker access', async () => {
+  const { broker, calls } = createBroker();
+  const invalidSection = await invoke(
+    ['state', 'Washington', '--section', 'statute'],
+    broker,
+  );
+  expect(invalidSection.exitCode).toBe(1);
+  const outOfRange = await invoke(['month', '2028-01'], broker);
+  expect(outOfRange.exitCode).toBe(1);
+  expect(outOfRange.stdout).toContain('outside');
+  expect(calls).toHaveLength(0);
+});
+
+test('parser accepts bare subcommand positionals and rejects unknown flags', () => {
+  expect(parseCli(['lookup', 'American', 'Education', 'Week']).positionals).toEqual([
+    'American',
+    'Education',
+    'Week',
+  ]);
+  expect(() => parseCli(['lookup', 'Name', '--bogus'])).toThrow(
+    'Unknown flag',
+  );
+});
+
+test('excerpting centers the named fact and keeps the hard character bound', () => {
+  const content =
+    'unrelated '.repeat(100) +
+    'American Education Week — November 16-20, 2026 — ' +
+    'unrelated '.repeat(100);
+  const excerpt = excerptAround(content, 'American Education Week', 300);
+  expect(excerpt.text.length).toBeLessThanOrEqual(300);
+  expect(excerpt.text).toContain('American Education Week');
+  expect(excerpt.truncated).toBe(true);
+});
+
+describe('skill registration and policy', () => {
+  const skillPath = path.join(__dirname, 'SKILL.md');
+  const packagePath = path.join(__dirname, 'package.json');
+  const skill = fs.readFileSync(skillPath, 'utf8');
+  const packageJson = JSON.parse(fs.readFileSync(packagePath, 'utf8'));
+
+  test('frontmatter has a single-line summary, trigger terms, and only Bash(node:*)', () => {
+    const frontmatter = skill.match(/^---\n([\s\S]*?)\n---/);
+    expect(frontmatter).not.toBeNull();
+    expect(frontmatter[1].match(/^summary:\s*.+$/gm)).toHaveLength(1);
+    expect(frontmatter[1]).toMatch(/when is/i);
+    expect(frontmatter[1]).toMatch(/state school holidays/i);
+    expect(frontmatter[1]).toMatch(/education conference/i);
+    expect(frontmatter[1]).toMatch(/NSPRA calendar/i);
+    expect(frontmatter[1]).toContain('allowed-tools: Bash(node:*)');
+  });
+
+  test('documents coverage, both accuracy disclaimers, re-auth, and all commands', () => {
+    const normalizedSkill = skill.replace(/\s+/g, ' ');
+    expect(skill).toContain('January 2026');
+    expect(skill).toContain('June 2027');
+    expect(skill).toContain('through **2031**');
+    expect(skill).toContain('verified as of November 2025');
+    expect(normalizedSkill).toContain(
+      'not intended to serve as the official or legal listing of holidays for each state',
+    );
+    expect(skill).toMatch(/connect AI Studio access/i);
+    for (const command of [
+      'lookup',
+      'search',
+      'month',
+      'on',
+      'state',
+      'conferences',
+      'holiday-years',
+    ]) {
+      expect(skill).toContain(command);
+    }
+  });
+
+  test('declares zero npm dependencies', () => {
+    expect(packageJson.dependencies).toEqual({});
+  });
+
+  test('inner implementation paths never call process.exit', () => {
+    const runSource = fs.readFileSync(path.join(__dirname, 'run.js'), 'utf8');
+    const commonSource = fs.readFileSync(
+      path.join(__dirname, 'common.js'),
+      'utf8',
+    );
+    expect(runSource).not.toContain('process.exit(');
+    expect(commonSource).not.toContain('process.exit(');
+  });
+});
+
+afterEach(() => {
+  process.exitCode = undefined;
+});

--- a/infra/agent-image/skills/psd-observances/run.test.js
+++ b/infra/agent-image/skills/psd-observances/run.test.js
@@ -40,7 +40,12 @@ function toolEnvelope(data, options = {}) {
 
 function factForQuery(query) {
   if (/washington/i.test(query)) {
-    return 'Washington — Legal holidays — School holidays';
+    if (/legal holidays/i.test(query)) {
+      return 'Washington — Legal holidays';
+    }
+    if (/school holidays/i.test(query)) {
+      return 'Washington — School holidays';
+    }
   }
   if (/conference|National PTA/i.test(query)) {
     return 'National PTA conference — June 18-21, 2026';
@@ -133,7 +138,10 @@ describe('documented command forms', () => {
     {
       name: 'state',
       argv: ['state', 'Washington'],
-      query: 'Washington legal holidays school holidays',
+      queries: [
+        'Washington legal holidays',
+        'Washington school holidays',
+      ],
     },
     {
       name: 'conferences',
@@ -152,7 +160,8 @@ describe('documented command forms', () => {
       const { broker, calls } = createBroker();
       const result = await invoke(commandCase.argv, broker);
       expect(result.exitCode).toBe(0);
-      expect(calls).toHaveLength(2);
+      const queries = commandCase.queries ?? [commandCase.query];
+      expect(calls).toHaveLength(1 + queries.length);
       expect(calls[0].route).toBe('/api/agent/aistudio');
       expect(calls[0].body).toEqual({
         method: 'tools/call',
@@ -161,18 +170,20 @@ describe('documented command forms', () => {
           arguments: { query: 'NSPRA', limit: 50 },
         },
       });
-      expect(calls[1].body).toEqual({
-        method: 'tools/call',
-        params: {
-          name: 'repositories_search',
-          arguments: {
-            query: commandCase.query,
-            repositoryIds: [1476],
-            mode: 'hybrid',
-            limit: 5,
+      for (const [index, query] of queries.entries()) {
+        expect(calls[index + 1].body).toEqual({
+          method: 'tools/call',
+          params: {
+            name: 'repositories_search',
+            arguments: {
+              query,
+              repositoryIds: [1476],
+              mode: 'hybrid',
+              limit: 5,
+            },
           },
-        },
-      });
+        });
+      }
       expect(result.stdout).toContain('Page 17');
     });
   }
@@ -190,13 +201,86 @@ test('lookup returns the acceptance date with a page citation', async () => {
 });
 
 test('state Washington includes both sections and the Part II disclaimer', async () => {
-  const { broker } = createBroker();
+  const { broker, calls } = createBroker();
   const result = await invoke(['state', 'Washington'], broker);
+  expect(result.exitCode).toBe(0);
+  expect(calls).toHaveLength(3);
+  expect(calls[1].body.params.arguments.query).toBe(
+    'Washington legal holidays',
+  );
+  expect(calls[2].body.params.arguments.query).toBe(
+    'Washington school holidays',
+  );
   expect(result.stdout).toContain('Legal holidays');
   expect(result.stdout).toContain('School holidays');
   expect(result.stdout).toContain(
     'not intended to serve as the official or legal listing',
   );
+});
+
+test('state section selection performs one targeted search', async () => {
+  const { broker, calls } = createBroker();
+  const result = await invoke(
+    ['state', 'Washington', '--section', 'legal'],
+    broker,
+  );
+  expect(result.exitCode).toBe(0);
+  expect(calls).toHaveLength(2);
+  expect(calls[1].body.params.arguments.query).toBe(
+    'Washington legal holidays',
+  );
+});
+
+test('state requires enough output space for both sections before broker access', async () => {
+  const { broker, calls } = createBroker();
+  const result = await invoke(
+    ['state', 'Washington', '--limit', '1'],
+    broker,
+  );
+  expect(result.exitCode).toBe(1);
+  expect(result.stdout).toContain('requires --limit 2 or greater');
+  expect(calls).toHaveLength(0);
+});
+
+test('state fails if either independently queried section has no cited result', async () => {
+  const { broker } = createBroker({
+    respond: (toolName, args) =>
+      toolName === 'repositories_search' &&
+      /school holidays/i.test(args.query)
+        ? toolEnvelope({ results: [], diagnostics: { returnedResults: 0 } })
+        : undefined,
+  });
+  const result = await invoke(['state', 'Washington'], broker);
+  expect(result.exitCode).toBe(1);
+  expect(result.stdout).toContain('no_results');
+  expect(result.stdout).toContain('school holidays');
+});
+
+test('state interleaves both sections within one global result limit', async () => {
+  const { broker } = createBroker({
+    respond: (toolName, args) => {
+      if (toolName !== 'repositories_search') return undefined;
+      return toolEnvelope({
+        results: Array.from({ length: 4 }, (_, index) =>
+          searchResult(args.query, {
+            sourceLocator: { page: 10 + index },
+            citations: [{ sourceLocator: { page: 10 + index } }],
+          }),
+        ),
+      });
+    },
+  });
+  const result = await invoke(
+    ['state', 'Washington', '--limit', '3', '--json'],
+    broker,
+  );
+  const payload = JSON.parse(result.stdout);
+  expect(payload.results).toHaveLength(3);
+  expect(payload.results.map((item) => item.section)).toEqual([
+    'legal',
+    'school',
+    'legal',
+  ]);
 });
 
 test('default lookup remains below an approximate 500-token bound', async () => {
@@ -463,6 +547,17 @@ test('free-form commands reject explicit out-of-range years and dates before bro
     ['search', 'observances on 07/01/2027'],
     ['lookup', 'observances on 2027/07/01'],
     ['search', 'observances in 2027/07'],
+    ['lookup', 'observances in Q3 2027'],
+    ['search', 'observances in Q4-2027'],
+    ['lookup', 'observances in Q 3 of 2027'],
+    ['search', 'observances in the 3rd qtr of 2027'],
+    ['lookup', 'observances in the third quarter of 2027'],
+    ['search', 'observances in quarter 4 of 2027'],
+    ['lookup', 'observances in summer 2027'],
+    ['search', 'observances in fall 2027'],
+    ['lookup', 'observances in autumn 2027'],
+    ['search', 'observances in H2 2027'],
+    ['lookup', 'observances in the second half of 2027'],
     ['holiday-years', 'Christmas 2032'],
   ]) {
     const result = await invoke(argv, broker);
@@ -484,6 +579,14 @@ for (const { label, argv } of [
   {
     label: 'a year-first June 2027 date',
     argv: ['lookup', 'observances on 2027/06/30'],
+  },
+  {
+    label: 'Q2 2027',
+    argv: ['search', 'observances in Q2 2027'],
+  },
+  {
+    label: 'spring 2027',
+    argv: ['lookup', 'observances in spring 2027'],
   },
 ]) {
   test(`free-form commands accept ${label}`, async () => {

--- a/infra/agent-image/skills/psd-observances/run.test.js
+++ b/infra/agent-image/skills/psd-observances/run.test.js
@@ -459,6 +459,10 @@ test('free-form commands reject explicit out-of-range years and dates before bro
     ['search', 'Constitution Day', '2030'],
     ['lookup', 'Observances on 2027-07-01'],
     ['search', 'observances in July 2027'],
+    ['lookup', 'observances in Jul 2027'],
+    ['search', 'observances on 07/01/2027'],
+    ['lookup', 'observances on 2027/07/01'],
+    ['search', 'observances in 2027/07'],
     ['holiday-years', 'Christmas 2032'],
   ]) {
     const result = await invoke(argv, broker);
@@ -467,6 +471,28 @@ test('free-form commands reject explicit out-of-range years and dates before bro
   }
   expect(calls).toHaveLength(0);
 });
+
+for (const { label, argv } of [
+  {
+    label: 'an abbreviated June 2027 month',
+    argv: ['lookup', 'observances in Jun 2027'],
+  },
+  {
+    label: 'a month-first June 2027 date',
+    argv: ['search', 'observances on 06/30/2027'],
+  },
+  {
+    label: 'a year-first June 2027 date',
+    argv: ['lookup', 'observances on 2027/06/30'],
+  },
+]) {
+  test(`free-form commands accept ${label}`, async () => {
+    const { broker, calls } = createBroker();
+    const result = await invoke(argv, broker);
+    expect(result.exitCode).toBe(0);
+    expect(calls).toHaveLength(2);
+  });
+}
 
 test('holiday-years accepts an in-range summary year', async () => {
   const { broker, calls } = createBroker();

--- a/infra/agent-image/skills/psd-observances/run.test.js
+++ b/infra/agent-image/skills/psd-observances/run.test.js
@@ -452,6 +452,29 @@ test('invalid command-specific flags and out-of-range dates fail before broker a
   expect(calls).toHaveLength(0);
 });
 
+test('free-form commands reject explicit out-of-range years and dates before broker access', async () => {
+  const { broker, calls } = createBroker();
+  for (const argv of [
+    ['lookup', 'Christmas 2030'],
+    ['search', 'Constitution Day', '2030'],
+    ['lookup', 'Observances on 2027-07-01'],
+    ['search', 'observances in July 2027'],
+    ['holiday-years', 'Christmas 2032'],
+  ]) {
+    const result = await invoke(argv, broker);
+    expect(result.exitCode).toBe(1);
+    expect(result.stdout).toContain('out_of_range');
+  }
+  expect(calls).toHaveLength(0);
+});
+
+test('holiday-years accepts an in-range summary year', async () => {
+  const { broker, calls } = createBroker();
+  const result = await invoke(['holiday-years', 'Christmas 2030'], broker);
+  expect(result.exitCode).toBe(0);
+  expect(calls[1].body.params.arguments.query).toContain('Christmas 2030');
+});
+
 test('parser accepts bare subcommand positionals and rejects unknown flags', () => {
   expect(parseCli(['lookup', 'American', 'Education', 'Week']).positionals).toEqual([
     'American',

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "test:skill:atrium": "cd infra/agent-image/skills/psd-atrium && bun test",
     "test:skill:sop-creator": "cd infra/agent-image/skills/psd-sop-creator && bun test",
     "test:skill:morning-brief": "cd infra/agent-image/skills/psd-morning-brief && bun test",
+    "test:skill:psd-observances": "cd infra/agent-image/skills/psd-observances && bun test",
     "test:smoke:atrium": "bun run test:smoke:atrium-render && bun run test:smoke:atrium-collab && bun run test:smoke:atrium-collab-token && bun run test:smoke:atrium-agent-bridge && bun run test:smoke:atrium-agent-read && bun run test:smoke:atrium-html-sanitize && bun run test:smoke:atrium-provenance-rail && bun run test:smoke:atrium-collab-schema && bun run test:smoke:atrium-suggestions-resolve && bun run test:smoke:atrium-suggestion-mode && bun run test:smoke:atrium-sandbox-config && bun run test:smoke:atrium-sandbox-host",
     "test:ci": "jest --config=jest.config.ci.js",
     "test:watch": "jest --watch",


### PR DESCRIPTION
## Summary

- add the zero-dependency `psd-observances` skill over the existing owner-bound AI Studio repository broker
- resolve accessible NSPRA repositories by name at runtime and implement all seven bounded, page-cited command forms
- add mocked broker coverage, a regression L1 eval fixture, a root test script, and a dedicated CI gate

## Tracking

Closes #1476
Parent epic: #1475

## Validation

- `bun run test:skill:psd-observances` — 29 passed
- `cd infra/agent-image/skills/psd-observances && bun test --coverage` — common.js 88.37% lines; run.js 91.00% lines
- `python3 -m unittest infra/agent-image/test_eval_coverage.py infra/agent-image/test_eval_runner.py infra/agent-image/test_graders.py` — 103 passed
- `bun run lint` — passed with zero warnings
- `bun run typecheck` — passed
- `bun run test:ci` — 530 suites / 4,927 tests passed; 1 suite / 15 tests skipped by existing policy
- `bun run build` — passed; only existing Edge-runtime and Browserslist warnings
- Playwright E2E — not applicable because this is a container CLI skill with no web route or UI change; every documented CLI form runs through the mocked broker suite

## Risk and migrations

- no database migration, API v1 change, new MCP tool, broker route, npm dependency, or Docker layer
- runtime availability depends on the caller having access to a repository whose name contains `NSPRA`; multiple matches prefer a `2026` name and then the lowest id
- no NSPRA PDF or extracted publication prose is included in this public repository; fixtures contain names and dates only