### PR TITLE
fix(repositories): allow deletion of pending items

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -308,6 +308,11 @@ jobs:
       env:
         CI: true
 
+    - name: Run repository pending-deletion constraint smoke
+      run: bun run test:smoke:repository-pending-deletion
+      env:
+        CI: true
+
     - name: Run Google content connector lifecycle smoke
       run: bun run test:smoke:google-content
       env:

--- a/infra/database/migrations.json
+++ b/infra/database/migrations.json
@@ -157,6 +157,7 @@
     "164-nexus-memory-extraction-model.sql",
     "165-agent-scheduled-run-fire-idempotency.sql",
     "166-atrium-collection-management.sql",
-    "167-deep-research-interaction-binding.sql"
+    "167-deep-research-interaction-binding.sql",
+    "168-repository-item-cancelled-status.sql"
   ]
 }

--- a/infra/database/schema/168-repository-item-cancelled-status.sql
+++ b/infra/database/schema/168-repository-item-cancelled-status.sql
@@ -8,10 +8,10 @@
 -- only the missing cancellation state.
 -- ============================================================================
 
+-- Keep the replacement in one statement: the production migration runner
+-- executes semicolon-delimited statements independently.
 ALTER TABLE repository_items
-  DROP CONSTRAINT IF EXISTS repository_items_processing_status_check;
-
-ALTER TABLE repository_items
+  DROP CONSTRAINT IF EXISTS repository_items_processing_status_check,
   ADD CONSTRAINT repository_items_processing_status_check
   CHECK (
     processing_status IN (
@@ -29,8 +29,7 @@ ALTER TABLE repository_items
 
 -- Manual rollback (only after removing or reclassifying all 'cancelled' rows):
 -- ALTER TABLE repository_items
---   DROP CONSTRAINT IF EXISTS repository_items_processing_status_check;
--- ALTER TABLE repository_items
+--   DROP CONSTRAINT IF EXISTS repository_items_processing_status_check,
 --   ADD CONSTRAINT repository_items_processing_status_check
 --   CHECK (
 --     processing_status IN (

--- a/infra/database/schema/168-repository-item-cancelled-status.sql
+++ b/infra/database/schema/168-repository-item-cancelled-status.sql
@@ -1,0 +1,46 @@
+-- ============================================================================
+-- 168 — Allow deletion to cancel in-flight legacy repository items (#1474)
+--
+-- Repository and item deletion fence pending work by changing
+-- repository_items.processing_status to 'cancelled'. Migration 010's CHECK
+-- predates that lifecycle state, so pending/processing items currently make the
+-- entire deletion transaction roll back. Preserve every existing status and add
+-- only the missing cancellation state.
+-- ============================================================================
+
+ALTER TABLE repository_items
+  DROP CONSTRAINT IF EXISTS repository_items_processing_status_check;
+
+ALTER TABLE repository_items
+  ADD CONSTRAINT repository_items_processing_status_check
+  CHECK (
+    processing_status IN (
+      'pending',
+      'processing',
+      'processing_ocr',
+      'processing_embeddings',
+      'completed',
+      'embedded',
+      'failed',
+      'embedding_failed',
+      'cancelled'
+    )
+  );
+
+-- Manual rollback (only after removing or reclassifying all 'cancelled' rows):
+-- ALTER TABLE repository_items
+--   DROP CONSTRAINT IF EXISTS repository_items_processing_status_check;
+-- ALTER TABLE repository_items
+--   ADD CONSTRAINT repository_items_processing_status_check
+--   CHECK (
+--     processing_status IN (
+--       'pending',
+--       'processing',
+--       'processing_ocr',
+--       'processing_embeddings',
+--       'completed',
+--       'embedded',
+--       'failed',
+--       'embedding_failed'
+--     )
+--   );

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "test:smoke:unified-content": "DATABASE_URL='postgresql://postgres:postgres@localhost:5432/aistudio' DB_SSL=false bun run tests/smoke/unified-content-foundation.smoke.ts",
     "test:smoke:nexus-ephemeral": "DATABASE_URL='postgresql://postgres:postgres@localhost:5432/aistudio' DB_SSL=false bun run tests/smoke/nexus-ephemeral-repositories.smoke.ts",
     "test:smoke:repository-upload-quota": "DATABASE_URL='postgresql://postgres:postgres@localhost:5432/aistudio' DB_SSL=false bun run tests/smoke/repository-upload-quota.smoke.ts",
-    "test:smoke:repository-pending-deletion": "bun run tests/smoke/repository-pending-deletion.smoke.ts",
+    "test:smoke:repository-pending-deletion": "DATABASE_URL='postgresql://postgres:postgres@localhost:5432/aistudio' DB_SSL=false bun run tests/smoke/repository-pending-deletion.smoke.ts",
     "test:smoke:google-content": "DATABASE_URL='postgresql://postgres:postgres@localhost:5432/aistudio' DB_SSL=false bun run tests/smoke/google-content-connectors.smoke.ts",
     "test:smoke:roster-email-match": "DATABASE_URL='postgresql://postgres:postgres@localhost:5432/aistudio' DB_SSL=false bun run tests/smoke/roster-email-match-report.smoke.ts",
     "test:smoke:agents-projects": "DATABASE_URL='postgresql://postgres:postgres@localhost:5432/aistudio' DB_SSL=false bun --preload ./tests/smoke/server-only-preload.js tests/smoke/unified-content-agents-projects.smoke.ts",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "test:smoke:unified-content": "DATABASE_URL='postgresql://postgres:postgres@localhost:5432/aistudio' DB_SSL=false bun run tests/smoke/unified-content-foundation.smoke.ts",
     "test:smoke:nexus-ephemeral": "DATABASE_URL='postgresql://postgres:postgres@localhost:5432/aistudio' DB_SSL=false bun run tests/smoke/nexus-ephemeral-repositories.smoke.ts",
     "test:smoke:repository-upload-quota": "DATABASE_URL='postgresql://postgres:postgres@localhost:5432/aistudio' DB_SSL=false bun run tests/smoke/repository-upload-quota.smoke.ts",
+    "test:smoke:repository-pending-deletion": "bun run tests/smoke/repository-pending-deletion.smoke.ts",
     "test:smoke:google-content": "DATABASE_URL='postgresql://postgres:postgres@localhost:5432/aistudio' DB_SSL=false bun run tests/smoke/google-content-connectors.smoke.ts",
     "test:smoke:roster-email-match": "DATABASE_URL='postgresql://postgres:postgres@localhost:5432/aistudio' DB_SSL=false bun run tests/smoke/roster-email-match-report.smoke.ts",
     "test:smoke:agents-projects": "DATABASE_URL='postgresql://postgres:postgres@localhost:5432/aistudio' DB_SSL=false bun --preload ./tests/smoke/server-only-preload.js tests/smoke/unified-content-agents-projects.smoke.ts",

--- a/tests/smoke/repository-pending-deletion.smoke.ts
+++ b/tests/smoke/repository-pending-deletion.smoke.ts
@@ -1,0 +1,156 @@
+/**
+ * Real-PostgreSQL regression smoke for Issue #1474.
+ *
+ * It recreates migration 010's legacy repository_items CHECK in a temporary
+ * table, applies migration 168, and exercises the exact repository-level and
+ * item-level cancellation updates used by deletion-service.ts. The transaction
+ * owns only a temporary table and leaves the target database unchanged.
+ *
+ * Run:
+ *   DATABASE_URL='postgresql://postgres:postgres@localhost:5432/aistudio' \
+ *     DB_SSL=false bun run test:smoke:repository-pending-deletion
+ */
+
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import postgres from "postgres";
+import { scriptLogger as log } from "../../scripts/db/script-logger";
+
+const databaseUrl =
+  process.env.DATABASE_URL ??
+  "postgresql://postgres:postgres@localhost:5432/aistudio";
+const migration = fs.readFileSync(
+  path.join(
+    process.cwd(),
+    "infra/database/schema/168-repository-item-cancelled-status.sql"
+  ),
+  "utf8"
+);
+const migrationStatements = migration
+  .split("\n")
+  .filter((line) => !line.trim().startsWith("--"))
+  .join("\n")
+  .split(/;\s*(?:\r?\n|$)/)
+  .map((statement) => statement.trim())
+  .filter(Boolean);
+
+const database = postgres(databaseUrl, {
+  ssl: process.env.DB_SSL === "false" ? false : "require",
+  max: 1,
+});
+
+log.section("Repository pending-deletion PostgreSQL smoke");
+
+try {
+  await database.begin(async (transaction) => {
+    // postgres.js transaction objects keep the Sql tagged-template API at
+    // runtime, although TransactionSql omits that call signature in its types.
+    const transactionSql = transaction as unknown as postgres.Sql;
+
+    await transactionSql`
+      CREATE TEMP TABLE repository_items (
+        id integer GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+        lifecycle_status text NOT NULL DEFAULT 'active',
+        processing_status text DEFAULT 'pending'
+          CHECK (
+            processing_status IN (
+              'pending',
+              'processing',
+              'processing_ocr',
+              'processing_embeddings',
+              'completed',
+              'embedded',
+              'failed',
+              'embedding_failed'
+            )
+          )
+      ) ON COMMIT DROP
+    `;
+
+    await transactionSql`
+      INSERT INTO repository_items (processing_status)
+      VALUES ('pending'), ('processing'), ('completed')
+    `;
+
+    for (const statement of migrationStatements) {
+      await transactionSql.unsafe(statement);
+    }
+
+    await transactionSql`
+      UPDATE repository_items item
+      SET lifecycle_status = 'deleting',
+          processing_status = CASE
+            WHEN item.processing_status IN ('pending', 'processing')
+              THEN 'cancelled'
+            ELSE item.processing_status
+          END
+    `;
+
+    const repositoryRows = await transactionSql<
+      { id: number; processing_status: string }[]
+    >`
+      SELECT id, processing_status
+      FROM repository_items
+      ORDER BY id
+    `;
+    assert.deepEqual(repositoryRows, [
+      { id: 1, processing_status: "cancelled" },
+      { id: 2, processing_status: "cancelled" },
+      { id: 3, processing_status: "completed" },
+    ]);
+
+    const [pendingItem] = await transactionSql<{ id: number }[]>`
+      INSERT INTO repository_items (processing_status)
+      VALUES ('pending')
+      RETURNING id
+    `;
+    assert.ok(pendingItem);
+
+    await transactionSql`
+      UPDATE repository_items item
+      SET lifecycle_status = 'deleting',
+          processing_status = CASE
+            WHEN item.processing_status IN ('pending', 'processing')
+              THEN 'cancelled'
+            ELSE item.processing_status
+          END
+      WHERE item.id = ${pendingItem.id}
+    `;
+
+    const [cancelledItem] = await transactionSql<
+      { processing_status: string }[]
+    >`
+      SELECT processing_status
+      FROM repository_items
+      WHERE id = ${pendingItem.id}
+    `;
+    assert.equal(cancelledItem?.processing_status, "cancelled");
+
+    // Reapplying the migration must remain safe even after cancellation rows
+    // exist, matching local fresh-install and failed-deploy retry behavior.
+    for (const statement of migrationStatements) {
+      await transactionSql.unsafe(statement);
+    }
+
+    const [constraint] = await transactionSql<
+      { name: string; definition: string }[]
+    >`
+      SELECT conname AS name, pg_get_constraintdef(oid) AS definition
+      FROM pg_constraint
+      WHERE conrelid = 'repository_items'::regclass
+        AND conname = 'repository_items_processing_status_check'
+    `;
+    assert.equal(
+      constraint?.name,
+      "repository_items_processing_status_check"
+    );
+    assert.match(constraint?.definition ?? "", /cancelled/);
+  });
+
+  log.success(
+    "Pending repository/item deletion and completed-item preservation passed"
+  );
+} finally {
+  await database.end();
+}

--- a/tests/unit/lib/repositories/content-platform-deletion.test.ts
+++ b/tests/unit/lib/repositories/content-platform-deletion.test.ts
@@ -77,7 +77,7 @@ beforeEach(() => {
   jest.clearAllMocks();
 });
 
-it("locks repository and items before cancelling work and entering deleting", async () => {
+it("locks a repository and cancels pending items before entering deleting", async () => {
   const execute = installTransaction([
     [activeRepository],
     [activeItem],
@@ -115,6 +115,14 @@ it("locks repository and items before cancelling work and entering deleting", as
     "job.metrics ->> 'bdaInvocationState'"
   );
   expect(sqlText(execute.mock.calls[3]![0])).toContain("<> 'terminal'");
+  const itemCancellation = sqlText(execute.mock.calls[6]![0]);
+  expect(itemCancellation).toContain(
+    "WHEN item.processing_status IN ('pending', 'processing')"
+  );
+  expect(itemCancellation).toContain("THEN 'cancelled'");
+  expect(itemCancellation).toContain(
+    "ELSE item.processing_status"
+  );
   expect(sqlText(execute.mock.calls.at(-1)![0])).toContain(
     "lifecycle_status = 'deleting'"
   );
@@ -169,7 +177,7 @@ it("keeps a deleting repository reachable as an idempotent cleanup retry", async
   await expect(beginRepositoryDeletion(7, NOW)).resolves.toHaveLength(1);
 });
 
-it("fences one item while its parent remains active", async () => {
+it("fences and cancels one pending item while its parent remains active", async () => {
   const execute = installTransaction([
     [activeRepository],
     [activeItem],
@@ -187,6 +195,14 @@ it("fences one item while its parent remains active", async () => {
     "FOR UPDATE OF repository"
   );
   expect(sqlText(execute.mock.calls[1]![0])).toContain("FOR UPDATE OF item");
+  const itemCancellation = sqlText(execute.mock.calls[6]![0]);
+  expect(itemCancellation).toContain(
+    "WHEN item.processing_status IN ('pending', 'processing')"
+  );
+  expect(itemCancellation).toContain("THEN 'cancelled'");
+  expect(itemCancellation).toContain(
+    "ELSE item.processing_status"
+  );
 });
 
 it("makes both upload completion and worker claim reject after deletion wins the lock", () => {

--- a/tests/unit/repository-item-cancelled-status-migration.test.ts
+++ b/tests/unit/repository-item-cancelled-status-migration.test.ts
@@ -13,6 +13,16 @@ const manifest = JSON.parse(
   )
 ) as { migrationFiles: string[] };
 
+function executableStatements(): string[] {
+  return migration
+    .split("\n")
+    .filter((line) => !line.trim().startsWith("--"))
+    .join("\n")
+    .split(/;\s*(?:\r?\n|$)/)
+    .map((statement) => statement.trim())
+    .filter(Boolean);
+}
+
 function processingStatuses(): string[] {
   const constraint = migration.match(
     /ADD CONSTRAINT repository_items_processing_status_check\s+CHECK\s*\(\s*processing_status IN\s*\(([\s\S]*?)\)\s*\);/
@@ -35,6 +45,7 @@ describe("migration 168 repository item cancellation", () => {
   });
 
   it("replaces the live legacy constraint and preserves every existing status", () => {
+    expect(executableStatements()).toHaveLength(1);
     expect(migration).toContain(
       "DROP CONSTRAINT IF EXISTS repository_items_processing_status_check"
     );

--- a/tests/unit/repository-item-cancelled-status-migration.test.ts
+++ b/tests/unit/repository-item-cancelled-status-migration.test.ts
@@ -1,0 +1,53 @@
+import fs from "node:fs";
+import path from "node:path";
+
+const migrationName = "168-repository-item-cancelled-status.sql";
+const migration = fs.readFileSync(
+  path.join(process.cwd(), "infra/database/schema", migrationName),
+  "utf8"
+);
+const manifest = JSON.parse(
+  fs.readFileSync(
+    path.join(process.cwd(), "infra/database/migrations.json"),
+    "utf8"
+  )
+) as { migrationFiles: string[] };
+
+function processingStatuses(): string[] {
+  const constraint = migration.match(
+    /ADD CONSTRAINT repository_items_processing_status_check\s+CHECK\s*\(\s*processing_status IN\s*\(([\s\S]*?)\)\s*\);/
+  );
+  if (!constraint?.[1]) {
+    throw new Error("repository_items processing-status CHECK was not found");
+  }
+
+  return Array.from(constraint[1].matchAll(/'([^']+)'/g), (match) => match[1]);
+}
+
+describe("migration 168 repository item cancellation", () => {
+  it("runs immediately after the current migration head", () => {
+    const previousIndex = manifest.migrationFiles.indexOf(
+      "167-deep-research-interaction-binding.sql"
+    );
+
+    expect(previousIndex).toBeGreaterThanOrEqual(0);
+    expect(manifest.migrationFiles[previousIndex + 1]).toBe(migrationName);
+  });
+
+  it("replaces the live legacy constraint and preserves every existing status", () => {
+    expect(migration).toContain(
+      "DROP CONSTRAINT IF EXISTS repository_items_processing_status_check"
+    );
+    expect(processingStatuses()).toEqual([
+      "pending",
+      "processing",
+      "processing_ocr",
+      "processing_embeddings",
+      "completed",
+      "embedded",
+      "failed",
+      "embedding_failed",
+      "cancelled",
+    ]);
+  });
+});


### PR DESCRIPTION
## Description

Fixes repository and repository-item deletion when a legacy `repository_items` row is still `pending` or `processing`.

Migration 168 replaces the migration-010 processing-status CHECK with the same eight existing values plus `cancelled`, which is the state both deletion paths already write while fencing in-flight work. Completed items continue through the unchanged ELSE branch.

The change also adds:
- a migration registration and exact-status regression guard;
- deletion-service assertions for repository-level and item-level cancellation SQL;
- a disposable real-PostgreSQL smoke covering pending repository deletion, pending item deletion, completed-item preservation, and idempotent migration reapplication;
- the PostgreSQL smoke as a required step in the existing unified-content CI job.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change
- [ ] Documentation update
- [x] Infrastructure/database migration

## Migration and risk

- Adds `infra/database/schema/168-repository-item-cancelled-status.sql` and registers it in `infra/database/migrations.json`.
- The migration performs no data rewrite. It briefly locks `repository_items` while replacing one CHECK constraint.
- The drop and add are subcommands of one atomic `ALTER TABLE`, preventing the semicolon-based production migration runner from committing an unconstrained intermediate state.
- Fresh-schema PostgreSQL initialization applied migration 168 successfully. The migration log recorded `completed`, and the resulting constraint includes `cancelled`.
- Existing stuck rows become deletable when this migration is deployed.
- Manual rollback SQL is documented in the migration and requires cancelled rows to be removed or reclassified first.

## Testing
- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `CI=true bun run test:ci -- --runInBand` on the latest merged base — 536 suites passed; 4,967 tests passed; 15 policy skips
- [x] targeted deletion and migration tests — 10 tests passed
- [x] `bun run migration:list` — migration 168 registered; next number 169
- [x] real PostgreSQL pending-deletion smoke — repository, item, completed-item, and reapplication cases passed
- [x] fresh full-schema PostgreSQL initialization through migration 168
- [x] `bun run openapi:check`
- [x] `bun run capabilities:check`
- [x] `bun run build`
- [x] `cd infra && bun run build`
- [x] `cd infra && bunx cdk synth --all --no-lookups --context baseDomain=example.com`
- [x] all GitHub checks green on final SHA `22bf1cde9a61971e9c275de5f64fc506d30e57cf`
- [x] final-SHA Claude and Codex reviews clean; sole Codex P2 fixed and thread resolved

The authenticated local Playwright pre-push suite was not run because this dedicated worktree has no `.env.local` or `AUTH_SECRET`; the repository-documented one-push bypass was used. No UI code changed, and the database regression is enforced in the PostgreSQL CI job.

## Screenshots

Not applicable; this is a schema constraint fix with no UI changes.

## Checklist
- [x] No production logging or type-safety regressions
- [x] Database migration is additive in accepted state, atomic, and registered in the manifest
- [x] Regression coverage added and CI-wired
- [x] Documentation updated where needed (migration rationale and rollback are inline)
- [x] App and infrastructure builds pass

## Related Issues

Closes #1474