### PR TITLE
fix(agent): recover settled post-tool turns (#1469)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,7 @@ jobs:
           infra/agent-image/test_mantle_proxy_logging.py \
           infra/agent-image/test_check_bootstrap_budget.py \
           infra/agent-image/test_check_config_consistency.py \
+          infra/agent-image/test_candidate_matrix.py \
           infra/agent-image/test_workspace_sync.py \
           infra/agent-image/test_chat_format.py \
           infra/agent-image/test_artifact_publisher.py \

--- a/docs/operations/agent-image-build-gate.md
+++ b/docs/operations/agent-image-build-gate.md
@@ -34,6 +34,12 @@ The same static gate rejects the beta.5-retired
 canonical `memory.search` location, so host/config migrations fail before the
 Docker validator.
 
+The plugin-aware build gate also runs `openclaw plugins inspect --runtime` for
+the vendored Bedrock and Parallel plugins. Both must report `loaded` at the
+exact pins. This is deliberately stronger than `peerDependencies`: Bedrock
+plugin 2026.7.1 advertised a range that included the beta.5 host but imported a
+plugin-SDK export that host had removed.
+
 ## Why the runtime half needs a signed context
 
 Before PR #1353 the production probe handed the container a Bedrock API key

--- a/docs/operations/agent-image-build-gate.md
+++ b/docs/operations/agent-image-build-gate.md
@@ -14,7 +14,7 @@ a dead-boot image (r10), a missing provider (r11), and a silently truncated
 | # | Check | Kind | Fails on |
 |---|-------|------|----------|
 | 1 | Instruction-budget (`check_bootstrap_budget.py`) | static | a bootstrap file that would be truncated at boot |
-| 2 | Config self-consistency (`check_config_consistency.py`) | static | bad `contextWindow`, `apiKey` hydration, plugin compatibility, web-search readiness, or a host missing settled-tool finalization in `openclaw.json` / `Dockerfile` |
+| 2 | Config self-consistency (`check_config_consistency.py`) | static | bad `contextWindow`, `apiKey` hydration, plugin compatibility, web-search readiness, a stale host schema, or a host missing settled-tool finalization in `openclaw.json` / `Dockerfile` |
 | 3 | Plugin-aware config validation | build | the complete config is invalid after the pinned custom plugins are installed |
 | 4 | Boot probe | runtime | no `BOOT_OK` within `PROBE_BOOT_TIMEOUT` (default 120s) |
 | 5 | Canary turn | runtime | `/invocations` does not answer `OK` |
@@ -29,6 +29,10 @@ post-tool turn with no visible answer, plus the structured
 `settled post-tool turn lacked a final answer` diagnostic. The Docker build
 greps the compiled runtime for both the diagnostic and the no-repeat
 continuation prompt; version comments alone are not accepted as proof.
+The same static gate rejects the beta.5-retired
+`gateway.controlUi.allowInsecureAuth` key and requires semantic memory at its
+canonical `memory.search` location, so host/config migrations fail before the
+Docker validator.
 
 ## Why the runtime half needs a signed context
 

--- a/docs/operations/agent-image-build-gate.md
+++ b/docs/operations/agent-image-build-gate.md
@@ -14,7 +14,7 @@ a dead-boot image (r10), a missing provider (r11), and a silently truncated
 | # | Check | Kind | Fails on |
 |---|-------|------|----------|
 | 1 | Instruction-budget (`check_bootstrap_budget.py`) | static | a bootstrap file that would be truncated at boot |
-| 2 | Config self-consistency (`check_config_consistency.py`) | static | bad `contextWindow`, `apiKey` hydration, plugin compatibility, or web-search provider readiness in `openclaw.json` / `Dockerfile` |
+| 2 | Config self-consistency (`check_config_consistency.py`) | static | bad `contextWindow`, `apiKey` hydration, plugin compatibility, web-search readiness, or a host missing settled-tool finalization in `openclaw.json` / `Dockerfile` |
 | 3 | Plugin-aware config validation | build | the complete config is invalid after the pinned custom plugins are installed |
 | 4 | Boot probe | runtime | no `BOOT_OK` within `PROBE_BOOT_TIMEOUT` (default 120s) |
 | 5 | Canary turn | runtime | `/invocations` does not answer `OK` |
@@ -22,6 +22,13 @@ a dead-boot image (r10), a missing provider (r11), and a silently truncated
 Static checks run before the build. Plugin-aware validation runs inside the
 image after the official Bedrock and Parallel plugins are installed. The
 runtime checks run against the freshly built image, before `docker push`.
+
+Issue #1469 added a fail-closed host contract to check 2. The pinned OpenClaw
+runtime must contain its one-shot, tools-disabled finalization for a settled
+post-tool turn with no visible answer, plus the structured
+`settled post-tool turn lacked a final answer` diagnostic. The Docker build
+greps the compiled runtime for both the diagnostic and the no-repeat
+continuation prompt; version comments alone are not accepted as proof.
 
 ## Why the runtime half needs a signed context
 

--- a/docs/operations/agent-platform-setup.md
+++ b/docs/operations/agent-platform-setup.md
@@ -452,7 +452,7 @@ release (Morning Brief "chat deadline expired"; nested
 workspace double-nesting fix is present — no Docker required, just `curl`/`jq`/`gh`:
 
 ```bash
-REPO=openclaw/openclaw; TAG=2026.7.1         # target the latest stable release
+REPO=openclaw/openclaw; TAG=2026.7.2-beta.5  # exact reviewed release; prefer stable when it contains required fixes
 TOKEN=$(curl -s "https://ghcr.io/token?scope=repository:$REPO:pull&service=ghcr.io" | jq -r .token)
 
 # Multi-arch index digest (this is what goes in FROM):
@@ -469,6 +469,12 @@ curl -s -H "Authorization: Bearer $TOKEN" \
 # MANDATORY gate: confirm the workspace double-nesting fix (PR #93520, merge
 # commit 52280351bb53) is an ancestor of the target tag. ahead_by==0 ⇒ present.
 gh api "repos/$REPO/compare/v$TAG...52280351bb53" --jq '{ahead_by, fix_present: (.ahead_by==0)}'
+
+# MANDATORY since #1469: confirm the safe settled-post-tool finalization
+# (upstream PR #110565) is present. The Docker build also checks its compiled
+# diagnostic and tools-disabled continuation prompt.
+gh api "repos/$REPO/compare/v$TAG...8636bb6981844e4674ee2cdbc0d8d32aa2a8b816" \
+  --jq '{ahead_by, settled_tool_recovery_present: (.ahead_by==0)}'
 ```
 
 Then update the `FROM` digest and the header block in `infra/agent-image/Dockerfile`,

--- a/infra/agent-image/Dockerfile
+++ b/infra/agent-image/Dockerfile
@@ -56,10 +56,11 @@
 #     that diagnostic and its no-repeat continuation prompt in the compiled
 #     runtime, so a tag/digest mistake cannot silently remove the fix.
 #
-# The amazon-bedrock and Parallel plugins remain on stable 2026.7.1. Their
-# published peer contract is OpenClaw >=2026.7.1, which beta.5 satisfies, and
-# 2026.7.1 is still the first Bedrock plugin whose prompt-caching allowlist
-# recognizes `claude-sonnet-5`.
+# Both host-coupled plugins are pinned to the matching beta.5 release. The
+# stable Bedrock plugin's published >=2026.7.1 peer range is too broad: it
+# imports `registerApiProvider`, which this host no longer exports, so it passes
+# semver checks but fails to register at runtime. The plugin-loader assertions
+# in the install RUN below enforce real registration and exact versions.
 #
 # Rollback targets (previous pins):
 #   2026.7.1        index sha256:6a31d44b2944e7adcd2b582bf6fb463111264ebca97a0201795b799135bd102c
@@ -352,9 +353,8 @@ COPY skills /opt/psd-skills
 # "Unknown memory embedding provider: bedrock" (2026-07-10). It must live under
 # /opt (image-owned): ~/.openclaw is runtime-persistent storage that shadows
 # anything written there at build time. Loaded via openclaw.json
-# plugins.load.paths. Version-pinned to stable 2026.7.1, whose published host
-# contract is compatible with the newer beta.5 runtime; npm verifies the
-# registry integrity hash on pack. The tarball is self-contained
+# plugins.load.paths. Version-pinned to the same beta.5 release as the host;
+# npm verifies the registry integrity hash on pack. The tarball is self-contained
 # (bundleDependencies: @aws-sdk clients ship inside it, with an
 # npm-shrinkwrap.json), so no npm install runs after extraction.
 #
@@ -382,9 +382,9 @@ COPY skills /opt/psd-skills
 # config only after both custom plugin paths exist. Config validation is fatal:
 # an invalid provider would otherwise boot successfully and fail only when a
 # user invokes web_search.
-ARG BEDROCK_PLUGIN_VERSION=2026.7.1
+ARG BEDROCK_PLUGIN_VERSION=2026.7.2-beta.5
 ARG BEDROCK_PLUGIN_ASSERTION=claude-sonnet-5
-ARG PARALLEL_PLUGIN_VERSION=2026.7.1
+ARG PARALLEL_PLUGIN_VERSION=2026.7.2-beta.5
 ARG PARALLEL_PLUGIN_ENDPOINT=https://search.parallel.ai/mcp
 RUN cd /opt/psd-skills/psd-schedules && npm install --omit=dev --no-audit --no-fund && \
     cd /opt/psd-skills/psd-credentials && npm install --omit=dev --no-audit --no-fund && \
@@ -410,7 +410,16 @@ RUN cd /opt/psd-skills/psd-schedules && npm install --omit=dev --no-audit --no-f
     test -f /opt/openclaw-plugins/parallel/openclaw.plugin.json && \
     grep -RFq -- "${PARALLEL_PLUGIN_ENDPOINT}" \
       /opt/openclaw-plugins/parallel/dist && \
-    HOME=/home/node openclaw config validate
+    HOME=/home/node openclaw config validate && \
+    HOME=/home/node openclaw plugins inspect amazon-bedrock --runtime --json \
+      > /tmp/amazon-bedrock.inspect.json && \
+    node -e 'const fs=require("fs");const text=fs.readFileSync(process.argv[1],"utf8");const start=text.indexOf("{");const payload=JSON.parse(text.slice(start));const plugin=payload.plugin||{};const expected=process.argv[2];if(plugin.status!=="loaded"||plugin.version!==expected){console.error(`amazon-bedrock runtime registration failed: status=${plugin.status||"missing"} version=${plugin.version||"missing"} error=${plugin.error||"none"}`);process.exit(1)}' \
+      /tmp/amazon-bedrock.inspect.json "${BEDROCK_PLUGIN_VERSION}" && \
+    HOME=/home/node openclaw plugins inspect parallel --runtime --json \
+      > /tmp/parallel.inspect.json && \
+    node -e 'const fs=require("fs");const text=fs.readFileSync(process.argv[1],"utf8");const start=text.indexOf("{");const payload=JSON.parse(text.slice(start));const plugin=payload.plugin||{};const expected=process.argv[2];if(plugin.status!=="loaded"||plugin.version!==expected){console.error(`parallel runtime registration failed: status=${plugin.status||"missing"} version=${plugin.version||"missing"} error=${plugin.error||"none"}`);process.exit(1)}' \
+      /tmp/parallel.inspect.json "${PARALLEL_PLUGIN_VERSION}" && \
+    rm -f /tmp/amazon-bedrock.inspect.json /tmp/parallel.inspect.json
 # chat-card has zero npm deps. chat-chart's npm install is paired with the
 # matplotlib install above — both stay disabled until we figure out the
 # AgentCore overlay-mount failure. With both off the image boots cleanly

--- a/infra/agent-image/Dockerfile
+++ b/infra/agent-image/Dockerfile
@@ -78,11 +78,11 @@
 ARG OPENCLAW_BASE_IMAGE=ghcr.io/openclaw/openclaw@sha256:86e0a480a37d879311c9723ad2487cca9eb6c1925fa4732dec3f505b4728eee9
 FROM ${OPENCLAW_BASE_IMAGE}
 
-# OpenClaw 2026.7.2 classifies the TUI as a Control UI client and requires
-# device identity even for this non-browser loopback adapter. Harness
-# candidates can select the release's scope-preserving local CLI identity; the
-# production 2026.7.1 default keeps its proven TUI behavior.
-ARG OPENCLAW_GATEWAY_CLIENT_ID=openclaw-tui
+# OpenClaw 2026.7.2-beta.5 classifies TUI as a Control UI client and requires
+# device identity even for this non-browser loopback adapter. Production uses
+# the release's supported local-backend identity; harness candidates may select
+# another explicitly approved identity compatible with their pinned host.
+ARG OPENCLAW_GATEWAY_CLIENT_ID=gateway-client
 ARG OPENCLAW_GATEWAY_CLIENT_MODE=backend
 ENV PSD_OPENCLAW_GATEWAY_CLIENT_ID="${OPENCLAW_GATEWAY_CLIENT_ID}" \
     PSD_OPENCLAW_GATEWAY_CLIENT_MODE="${OPENCLAW_GATEWAY_CLIENT_MODE}"

--- a/infra/agent-image/Dockerfile
+++ b/infra/agent-image/Dockerfile
@@ -220,7 +220,7 @@ RUN mkdir -p /home/node/.openclaw/memory
 #   ours is ~30 tools, and Sonnet 5's prompt caching makes the schema prefix
 #   cheap. codeMode.timeoutMs is retained (inert unless code-mode returns).
 #
-#   agents.defaults.memorySearch — embedding provider for semantic search over
+#   memory.search — embedding provider for semantic search over
 #   the agent's local ~/.openclaw/memory/ files. OpenClaw's default provider is
 #   "openai", but this container provisions NO OpenAI key (it reaches models
 #   only through Bedrock Mantle), so memory indexing fails at runtime with
@@ -346,7 +346,7 @@ COPY skills /opt/psd-skills
 # The tail of this RUN also vendors the @openclaw/amazon-bedrock-provider and
 # @openclaw/parallel-plugin plugins. The first registers the "bedrock"
 # memory-embedding adapter that
-# openclaw.json's memorySearch.provider names. The published OpenClaw base
+# openclaw.json's memory.search.provider names. The published OpenClaw base
 # image ships with NO bundled extensions (they're an opt-in OPENCLAW_EXTENSIONS
 # build arg of the upstream Dockerfile), so memory sync failed every cycle with
 # "Unknown memory embedding provider: bedrock" (2026-07-10). It must live under

--- a/infra/agent-image/Dockerfile
+++ b/infra/agent-image/Dockerfile
@@ -11,8 +11,10 @@
 
 # Pin base image to a known-good immutable digest.
 #
-# Pinned to OpenClaw 2026.6.11 — the latest stable release (cut 2026-06-30),
-# bumped from 2026.4.20 for issue #1082. Digests verified 2026-06-30.
+# Pinned to OpenClaw 2026.7.2-beta.5 for issue #1469. The release is
+# prerelease, but it is the first immutable published artifact that contains
+# the upstream settled-post-tool recovery described below. Digest verified
+# 2026-07-30.
 #
 # Background — why the old 2026.4.20 pin existed: `:latest` floated through
 # 2026.4.21–2026.4.23 and broke the runtime twice:
@@ -35,36 +37,44 @@
 #     smoke test (docs/operations/agent-platform-setup.md) before trusting it.
 #
 # Multi-arch index digest (Docker picks arm64 at build time via --platform):
-#   ghcr.io/openclaw/openclaw:2026.7.1
-#   index: sha256:6a31d44b2944e7adcd2b582bf6fb463111264ebca97a0201795b799135bd102c
+#   ghcr.io/openclaw/openclaw:2026.7.2-beta.5
+#   index: sha256:86e0a480a37d879311c9723ad2487cca9eb6c1925fa4732dec3f505b4728eee9
 #
-# Moved from the 2026.7.1-beta.2 PRERELEASE pin to 2026.7.1 STABLE (2026-07-27),
-# which is what the prerelease note below asked for. Two reasons:
-#   1. It is the release of the same line — it carries openclaw PR #99678
-#      ("reconcile is not a function" after auto-compaction, the P1 that
-#      aborted the 7/6 Plaud production run) plus the empty-reply and
-#      compaction-precheck fixes that motivated the prerelease pin.
-#   2. It is REQUIRED by the amazon-bedrock provider bump below. Plugin
-#      2026.7.1 is the first release whose prompt-caching allowlist knows
-#      `claude-sonnet-5`, and it declares `peerDependencies.openclaw >=2026.7.1`
-#      / `compat.pluginApi >=2026.7.1`. A prerelease sorts BELOW its release in
-#      semver (2026.7.1-beta.2 < 2026.7.1), so pairing plugin 2026.7.1 with the
-#      beta.2 host would violate the plugin's own host contract. Host and
-#      plugin move together or not at all.
+# Why this prerelease is required:
+#   - Production failure #260 ended after five tool calls with OpenClaw's
+#     `incomplete turn detected ... stopReason=toolUse ... replaySafe=no`
+#     path. OpenClaw 2026.7.1 correctly refused to replay possible side
+#     effects, but had no safe final-answer continuation and returned the
+#     generic "Agent couldn't generate a response" error.
+#   - Upstream PR #110565 / commit 8636bb698184 adds one isolated,
+#     tools-disabled finalization from already-settled tool results. It never
+#     replays completed tools, and its regression suite covers both successful
+#     recovery and fail-closed exhaustion. The commit is an ancestor of
+#     v2026.7.2-beta.5 but not of the 2026.7.1 release line.
+#   - The recovery emits `settled post-tool turn lacked a final answer` with
+#     run/session/provider context. The build assertions below require both
+#     that diagnostic and its no-repeat continuation prompt in the compiled
+#     runtime, so a tag/digest mistake cannot silently remove the fix.
+#
+# The amazon-bedrock and Parallel plugins remain on stable 2026.7.1. Their
+# published peer contract is OpenClaw >=2026.7.1, which beta.5 satisfies, and
+# 2026.7.1 is still the first Bedrock plugin whose prompt-caching allowlist
+# recognizes `claude-sonnet-5`.
 #
 # Rollback targets (previous pins):
+#   2026.7.1        index sha256:6a31d44b2944e7adcd2b582bf6fb463111264ebca97a0201795b799135bd102c
 #   2026.7.1-beta.2  index sha256:0e5680d7d58d3b6c08afa0fc992f4ad319b5586f60923e1985b7c6f838c535d5
 #   2026.6.11        index sha256:3814fb1f62f9cfc5944de088c5817c68c88b5d721feebe36420b666a90a61ce7
 #   2026.4.20        index sha256:5db497263e85f266142ed6206644de4e401c5906cce835865981113c11486d64
-# Rolling back the host REQUIRES rolling the plugin back to 2026.6.11 in the
-# same commit (see the host-contract note above) — at the cost of prompt
-# caching, which that plugin cannot do for this model.
+# Rolling back the host to 2026.7.1 reintroduces #1469 and requires an explicit
+# incident tradeoff. Rolling back below 2026.7.1 ALSO requires rolling both
+# plugins back to a compatible release, at the cost of Sonnet 5 prompt caching.
 #
 # DO NOT revert to `:latest` or bump without (a) confirming the workspace
 # double-nesting fix by commit ancestry and (b) a clean end-to-end test that
 # includes the Morning Brief payload — a trivial "respond OK" prompt masks
 # session-completion regressions.
-ARG OPENCLAW_BASE_IMAGE=ghcr.io/openclaw/openclaw@sha256:6a31d44b2944e7adcd2b582bf6fb463111264ebca97a0201795b799135bd102c
+ARG OPENCLAW_BASE_IMAGE=ghcr.io/openclaw/openclaw@sha256:86e0a480a37d879311c9723ad2487cca9eb6c1925fa4732dec3f505b4728eee9
 FROM ${OPENCLAW_BASE_IMAGE}
 
 # OpenClaw 2026.7.2 classifies the TUI as a Control UI client and requires
@@ -86,12 +96,20 @@ LABEL org.opencontainers.image.source="https://github.com/psd401/aistudio" \
 # Switch to root for installations
 USER root
 
+# Assert the pinned host contains the exact safe-recovery contract required by
+# issue #1469. Keep these in the existing OS-package layer: AgentCore has a
+# strict overlay-layer ceiling, so this must not become a standalone RUN.
+ARG OPENCLAW_SETTLED_TOOL_RECOVERY_LOG="settled post-tool turn lacked a final answer"
+ARG OPENCLAW_SETTLED_TOOL_RECOVERY_PROMPT="The previous assistant turn completed its tool calls but did not produce a user-visible answer."
+
 # Base OS packages FIRST so the checksum-verified installs below have the
 # tooling they need: `unzip` for bun's .zip release artifact, `curl` +
 # `ca-certificates` for the downloads, and the python3 venv stack for the
 # AgentCore SDK. (The exact Python version tracks the base image's distro;
 # verify with: docker run --rm psd-agent-base:latest python3 --version)
-RUN apt-get update && \
+RUN grep -RFq -- "${OPENCLAW_SETTLED_TOOL_RECOVERY_LOG}" /app/dist && \
+    grep -RFq -- "${OPENCLAW_SETTLED_TOOL_RECOVERY_PROMPT}" /app/dist && \
+    apt-get update && \
     apt-get install -y --no-install-recommends \
       python3 python3-pip python3-venv tzdata ca-certificates curl unzip && \
     rm -rf /var/lib/apt/lists/*
@@ -334,10 +352,11 @@ COPY skills /opt/psd-skills
 # "Unknown memory embedding provider: bedrock" (2026-07-10). It must live under
 # /opt (image-owned): ~/.openclaw is runtime-persistent storage that shadows
 # anything written there at build time. Loaded via openclaw.json
-# plugins.load.paths. Version-pinned to the same OpenClaw release this image
-# pins (2026.7.1); npm verifies the registry integrity hash on pack. The
-# tarball is self-contained (bundleDependencies: @aws-sdk clients ship inside
-# it, with an npm-shrinkwrap.json), so no npm install runs after extraction.
+# plugins.load.paths. Version-pinned to stable 2026.7.1, whose published host
+# contract is compatible with the newer beta.5 runtime; npm verifies the
+# registry integrity hash on pack. The tarball is self-contained
+# (bundleDependencies: @aws-sdk clients ship inside it, with an
+# npm-shrinkwrap.json), so no npm install runs after extraction.
 #
 # 2026.6.11 -> 2026.7.1 (2026-07-27) RESTORES PROMPT CACHING, which had been
 # silently off for every turn since #1384 moved chat to this provider. The

--- a/infra/agent-image/build-and-push.sh
+++ b/infra/agent-image/build-and-push.sh
@@ -550,6 +550,9 @@ except Exception:
     else
       echo "ERROR: canary turn failed (exit=${CANARY_STATUS}) or missed the expected output." >&2
       printf '%s\n' "${CANARY_OUT}" | tail -5 | sed 's/^/    [canary-raw] /' >&2
+      echo "    [canary-container] bounded runtime log tail:" >&2
+      docker logs "${CID}" 2>&1 | tail -80 | \
+        sed 's/^/    [canary-container] /' >&2
       CANARY_OK="false"
     fi
 

--- a/infra/agent-image/check_config_consistency.py
+++ b/infra/agent-image/check_config_consistency.py
@@ -2,7 +2,7 @@
 """
 Config self-consistency gate for the agent image (issue #1161).
 
-Five static asserts over openclaw.json + the Dockerfile, run on the host before
+Six static asserts over openclaw.json + the Dockerfile, run on the host before
 build (no Docker):
 
   1. contextWindow sanity — every declared model's contextWindow must be a
@@ -36,6 +36,12 @@ build (no Docker):
      enabled, and the build must assert its fixed Search MCP endpoint. Without
      an explicit provider, OpenClaw still exposes the tool but every call fails
      at runtime with "disabled or no provider available".
+
+  6. settled-tool recovery — the OpenClaw host must contain the upstream
+     tools-disabled finalization for a settled post-tool turn that produced no
+     visible answer, plus its structured diagnostic. Without this contract a
+     replay-unsafe turn fails with generic OpenClawChatError after its tools
+     have already run (issue #1469).
 
 Exit 0 when consistent, 1 on any violation.
 """
@@ -135,6 +141,14 @@ _HOST_IMAGE_ARG_RE = re.compile(
 )
 _HOST_FROM_ARG_RE = re.compile(
     r"^FROM\s+\$\{OPENCLAW_BASE_IMAGE\}\s*$", re.MULTILINE,
+)
+_SETTLED_TOOL_RECOVERY_MIN = "2026.7.2-beta.5"
+_SETTLED_TOOL_RECOVERY_BUILD_CONTRACT = (
+    'ARG OPENCLAW_SETTLED_TOOL_RECOVERY_LOG="settled post-tool turn lacked a final answer"',
+    'ARG OPENCLAW_SETTLED_TOOL_RECOVERY_PROMPT="The previous assistant turn completed '
+    'its tool calls but did not produce a user-visible answer."',
+    'grep -RFq -- "${OPENCLAW_SETTLED_TOOL_RECOVERY_LOG}" /app/dist',
+    'grep -RFq -- "${OPENCLAW_SETTLED_TOOL_RECOVERY_PROMPT}" /app/dist',
 )
 
 
@@ -581,6 +595,49 @@ def check_host_plugin_compatibility(dockerfile_path: str) -> List[str]:
     return violations
 
 
+def check_settled_tool_recovery(dockerfile_path: str) -> List[str]:
+    """Keep the safe post-tool finalization and its diagnostic in the host.
+
+    OpenClaw 2026.7.1 detected replay-unsafe incomplete turns but could only
+    fail them. Upstream PR #110565 added one tools-disabled finalization from
+    settled results; v2026.7.2-beta.5 is the first immutable release artifact
+    containing it. The Docker build also greps the compiled runtime so a bad
+    tag/digest mapping fails closed rather than trusting this version string.
+    """
+    try:
+        with open(dockerfile_path, "r", encoding="utf-8") as fh:
+            source = fh.read()
+    except OSError as exc:
+        return [f"cannot read Dockerfile {dockerfile_path}: {exc}"]
+
+    tag_match = _HOST_TAG_RE.search(source)
+    if not tag_match:
+        # check_host_plugin_compatibility reports the missing tag/digest pair.
+        return []
+
+    violations: List[str] = []
+    host_tag = tag_match.group(1)
+    if _version_key(host_tag) < _version_key(_SETTLED_TOOL_RECOVERY_MIN):
+        violations.append(
+            f"OpenClaw base image {host_tag} predates settled-tool recovery "
+            f"{_SETTLED_TOOL_RECOVERY_MIN}; replay-unsafe tool turns would "
+            f"regress to generic OpenClawChatError (#1469)"
+        )
+
+    missing = [
+        contract
+        for contract in _SETTLED_TOOL_RECOVERY_BUILD_CONTRACT
+        if contract not in source
+    ]
+    if missing:
+        violations.append(
+            "Dockerfile does not assert the compiled settled-tool recovery "
+            "diagnostic and no-repeat continuation prompt: "
+            + "; ".join(missing)
+        )
+    return violations
+
+
 def check_prompt_caching_reachable(
     config: dict, dockerfile_path: str,
 ) -> List[str]:
@@ -739,6 +796,7 @@ def run_checks(
         + check_prompt_caching_reachable(config, dockerfile_path)
         + check_host_plugin_compatibility(dockerfile_path)
         + check_web_search_provider(config, dockerfile_path)
+        + check_settled_tool_recovery(dockerfile_path)
     )
     if verify_upstream:
         violations += check_upstream_pins(dockerfile_path)
@@ -783,7 +841,7 @@ def main(argv: Optional[List[str]] = None) -> int:
     print(
         "OK — openclaw.json context windows + apiKey hydration paths + "
         "prompt-caching reachability + host/plugin compatibility + web-search "
-        "provider readiness consistent."
+        "provider readiness + settled-tool recovery contract consistent."
     )
     return 0
 

--- a/infra/agent-image/check_config_consistency.py
+++ b/infra/agent-image/check_config_consistency.py
@@ -2,7 +2,7 @@
 """
 Config self-consistency gate for the agent image (issue #1161).
 
-Six static asserts over openclaw.json + the Dockerfile, run on the host before
+Seven static asserts over openclaw.json + the Dockerfile, run on the host before
 build (no Docker):
 
   1. contextWindow sanity — every declared model's contextWindow must be a
@@ -42,6 +42,11 @@ build (no Docker):
      visible answer, plus its structured diagnostic. Without this contract a
      replay-unsafe turn fails with generic OpenClawChatError after its tools
      have already run (issue #1469).
+
+  7. tier-eval config schema — the recovery-bearing host also moved semantic
+     memory from `agents.defaults.memorySearch` to `memory.search` and retired
+     `gateway.controlUi.allowInsecureAuth`. Catch those legacy keys before an
+     expensive Docker build reaches `openclaw config validate`.
 
 Exit 0 when consistent, 1 on any violation.
 """
@@ -735,6 +740,80 @@ def check_context_windows(config: dict) -> List[str]:
     return violations
 
 
+def check_tier_eval_config_schema(config: dict) -> List[str]:
+    """Enforce config migrations required by the recovery-bearing host.
+
+    OpenClaw v2026.7.2-beta.5 rejects the legacy memorySearch location and the
+    retired allowInsecureAuth compatibility toggle. Semantic memory is a
+    production contract for this image, so require its canonical Bedrock
+    provider/model rather than merely checking that the old key disappeared.
+    """
+    violations: List[str] = []
+    agents = config.get("agents")
+    if not isinstance(agents, dict):
+        agents = {}
+    defaults = agents.get("defaults")
+    if not isinstance(defaults, dict):
+        defaults = {}
+    if "memorySearch" in defaults:
+        violations.append(
+            "agents.defaults.memorySearch moved to memory.search in OpenClaw "
+            "v2026.7.2-beta.5"
+        )
+
+    entries = agents.get("entries")
+    if isinstance(entries, dict):
+        for agent_id, entry in entries.items():
+            if isinstance(entry, dict) and "memorySearch" in entry:
+                violations.append(
+                    f"agents.entries.{agent_id}.memorySearch moved to "
+                    f"agents.entries.{agent_id}.memory.search"
+                )
+    legacy_list = agents.get("list")
+    if isinstance(legacy_list, list):
+        for index, entry in enumerate(legacy_list):
+            if isinstance(entry, dict) and "memorySearch" in entry:
+                violations.append(
+                    f"agents.list[{index}].memorySearch moved to "
+                    f"agents.list[{index}].memory.search"
+                )
+    if "memorySearch" in config:
+        violations.append(
+            "top-level memorySearch moved to memory.search in OpenClaw "
+            "v2026.7.2-beta.5"
+        )
+
+    memory = config.get("memory")
+    search = memory.get("search") if isinstance(memory, dict) else None
+    if not isinstance(search, dict):
+        violations.append(
+            "memory.search is missing — semantic memory would lose its "
+            "explicit Bedrock embedding provider"
+        )
+    else:
+        if search.get("provider") != "bedrock":
+            violations.append(
+                "memory.search.provider must be 'bedrock' for key-free "
+                "semantic memory"
+            )
+        if search.get("model") != "amazon.titan-embed-text-v2:0":
+            violations.append(
+                "memory.search.model must be "
+                "'amazon.titan-embed-text-v2:0'"
+            )
+
+    gateway = config.get("gateway")
+    control_ui = (
+        gateway.get("controlUi") if isinstance(gateway, dict) else None
+    )
+    if isinstance(control_ui, dict) and "allowInsecureAuth" in control_ui:
+        violations.append(
+            "gateway.controlUi.allowInsecureAuth is retired in OpenClaw "
+            "v2026.7.2-beta.5; remove it (there is no replacement)"
+        )
+    return violations
+
+
 def check_apikey_hydration(config: dict, wrapper_path: str) -> List[str]:
     violations: List[str] = []
     try:
@@ -792,6 +871,7 @@ def run_checks(
     config = _load(config_path)
     violations = (
         check_context_windows(config)
+        + check_tier_eval_config_schema(config)
         + check_apikey_hydration(config, wrapper_path)
         + check_prompt_caching_reachable(config, dockerfile_path)
         + check_host_plugin_compatibility(dockerfile_path)
@@ -841,7 +921,8 @@ def main(argv: Optional[List[str]] = None) -> int:
     print(
         "OK — openclaw.json context windows + apiKey hydration paths + "
         "prompt-caching reachability + host/plugin compatibility + web-search "
-        "provider readiness + settled-tool recovery contract consistent."
+        "provider readiness + settled-tool recovery + tier-eval schema "
+        "contracts consistent."
     )
     return 0
 

--- a/infra/agent-image/check_config_consistency.py
+++ b/infra/agent-image/check_config_consistency.py
@@ -2,7 +2,7 @@
 """
 Config self-consistency gate for the agent image (issue #1161).
 
-Seven static asserts over openclaw.json + the Dockerfile, run on the host before
+Eight static asserts over openclaw.json + the Dockerfile, run on the host before
 build (no Docker):
 
   1. contextWindow sanity — every declared model's contextWindow must be a
@@ -47,6 +47,12 @@ build (no Docker):
      memory from `agents.defaults.memorySearch` to `memory.search` and retired
      `gateway.controlUi.allowInsecureAuth`. Catch those legacy keys before an
      expensive Docker build reaches `openclaw config validate`.
+
+  8. plugin runtime registration — the Docker build must load both host-coupled
+     plugins through OpenClaw and require status=loaded at their exact pins.
+     Published peer ranges are necessary but insufficient: Bedrock plugin
+     2026.7.1 claimed compatibility yet imported a plugin-SDK export removed by
+     the beta.5 host.
 
 Exit 0 when consistent, 1 on any violation.
 """
@@ -154,6 +160,11 @@ _SETTLED_TOOL_RECOVERY_BUILD_CONTRACT = (
     'its tool calls but did not produce a user-visible answer."',
     'grep -RFq -- "${OPENCLAW_SETTLED_TOOL_RECOVERY_LOG}" /app/dist',
     'grep -RFq -- "${OPENCLAW_SETTLED_TOOL_RECOVERY_PROMPT}" /app/dist',
+)
+_PLUGIN_RUNTIME_BUILD_CONTRACT = (
+    "openclaw plugins inspect amazon-bedrock --runtime --json",
+    "openclaw plugins inspect parallel --runtime --json",
+    'plugin.status!=="loaded"||plugin.version!==expected',
 )
 
 
@@ -643,6 +654,28 @@ def check_settled_tool_recovery(dockerfile_path: str) -> List[str]:
     return violations
 
 
+def check_plugin_runtime_assertions(dockerfile_path: str) -> List[str]:
+    """Require the build to prove host/plugin API compatibility by loading."""
+    try:
+        with open(dockerfile_path, "r", encoding="utf-8") as fh:
+            source = fh.read()
+    except OSError as exc:
+        return [f"cannot read Dockerfile {dockerfile_path}: {exc}"]
+
+    missing = [
+        contract
+        for contract in _PLUGIN_RUNTIME_BUILD_CONTRACT
+        if contract not in source
+    ]
+    if not missing:
+        return []
+    return [
+        "Dockerfile does not require exact-version runtime registration for "
+        "the host-coupled Bedrock and Parallel plugins: "
+        + "; ".join(missing)
+    ]
+
+
 def check_prompt_caching_reachable(
     config: dict, dockerfile_path: str,
 ) -> List[str]:
@@ -811,6 +844,20 @@ def check_tier_eval_config_schema(config: dict) -> List[str]:
             "gateway.controlUi.allowInsecureAuth is retired in OpenClaw "
             "v2026.7.2-beta.5; remove it (there is no replacement)"
         )
+    if isinstance(control_ui, dict) and "dangerouslyDisableDeviceAuth" in control_ui:
+        violations.append(
+            "gateway.controlUi.dangerouslyDisableDeviceAuth is retired in "
+            "OpenClaw v2026.7.2-beta.5"
+        )
+    if (
+        isinstance(control_ui, dict)
+        and control_ui.get("enabled") is False
+        and "dangerouslyAllowHostHeaderOriginFallback" in control_ui
+    ):
+        violations.append(
+            "gateway.controlUi.dangerouslyAllowHostHeaderOriginFallback must "
+            "not be enabled when the Control UI is disabled"
+        )
     return violations
 
 
@@ -877,6 +924,7 @@ def run_checks(
         + check_host_plugin_compatibility(dockerfile_path)
         + check_web_search_provider(config, dockerfile_path)
         + check_settled_tool_recovery(dockerfile_path)
+        + check_plugin_runtime_assertions(dockerfile_path)
     )
     if verify_upstream:
         violations += check_upstream_pins(dockerfile_path)
@@ -921,8 +969,8 @@ def main(argv: Optional[List[str]] = None) -> int:
     print(
         "OK — openclaw.json context windows + apiKey hydration paths + "
         "prompt-caching reachability + host/plugin compatibility + web-search "
-        "provider readiness + settled-tool recovery + tier-eval schema "
-        "contracts consistent."
+        "provider readiness + settled-tool recovery + tier-eval schema + "
+        "runtime plugin registration contracts consistent."
     )
     return 0
 

--- a/infra/agent-image/eval/README.md
+++ b/infra/agent-image/eval/README.md
@@ -266,7 +266,7 @@ tools while the container starts. Run evals only on a trusted workstation. The
 runner removes its containers on completion and logs a warning if Docker cannot
 remove one.
 
-OpenClaw 2026.7.1 deliberately removes inherited AWS access-key and container-
+OpenClaw 2026.7.1 and later deliberately remove inherited AWS access-key and container-
 credential variables from model-launched `exec` subprocesses. Direct-AWS skills
 therefore use the image's root-owned fixed-operation relay: the relay inherits
 the candidate container's credential chain, while the skill process receives

--- a/infra/agent-image/eval/candidates/README.md
+++ b/infra/agent-image/eval/candidates/README.md
@@ -36,18 +36,15 @@ Issue #1429 adds two non-model calibration arms:
 
 | Manifest | Axis | Candidate |
 |---|---|---|
-| `openclaw-2026-7-2-beta-5.json` | Harness | OpenClaw and Bedrock plugin `2026.7.2-beta.5`, pinned to OCI index `sha256:86e0a480…` |
+| `openclaw-cli-gateway.json` | Harness | Uses OpenClaw's reserved `cli`/`cli` loopback identity instead of production `gateway-client`/`backend` |
 | `conservative-tool-routing.json` | Prompt | Adds minimum-capability and explicit-side-effect routing guidance |
 
-The harness arm uses the first published OpenClaw release after the `2026.7.1`
-baseline. It is a prerelease and is evaluated as a candidate only; building it
-does not change the production pin. Its manifest records the upstream-required
-move from `agents.defaults.memorySearch` to `memory.search` and removes two
-retired Control UI compatibility keys. It also selects the beta's reserved
-`cli`/`cli` container-local identity because the beta reclassifies TUI as
-Control UI and requires device identity; the CLI path explicitly preserves
-operator scopes after loopback shared-token auth. The model and materialized
-prompt remain byte-identical to baseline.
+The harness arm exercises the beta's reserved `cli`/`cli` container-local
+identity against production's supported `gateway-client`/`backend` loopback
+identity. The beta reclassifies TUI as Control UI and requires device identity;
+both approved non-UI paths preserve operator scopes after loopback shared-token
+auth. Host, plugins, model, config, and materialized prompt remain byte-identical
+to baseline.
 
 ## Axis contract
 
@@ -65,9 +62,10 @@ rejects zero changes, an undeclared change, or changes to two or more axes.
   `check_config_consistency.py`; each `npm pack` and its tarball references
   share the same build argument. Harness candidates may also declare a
   narrowly allowlisted `configMigrations` list when the new host moves or
-  retires baseline keys, plus the exact `cli`/`cli` pair when the host requires
-  its scope-preserving container-local identity. These compatibility inputs
-  are part of the harness axis and cannot change model or prompt configuration.
+  retires baseline keys, plus an exact allowlisted loopback client pair when a
+  host requires a different scope-preserving identity. These compatibility
+  inputs are part of the harness axis and cannot change model or prompt
+  configuration.
 - `prompt` selects the SOUL preamble and rules skill. The candidate versions
   are passed as Docker build inputs and checked against the materialized
   config's bootstrap budgets.

--- a/infra/agent-image/eval/candidates/candidate.py
+++ b/infra/agent-image/eval/candidates/candidate.py
@@ -80,6 +80,7 @@ ALLOWED_HARNESS_CONFIG_MIGRATIONS = frozenset(
 )
 ALLOWED_HARNESS_GATEWAY_CLIENTS = frozenset(
     {
+        ("gateway-client", "backend"),
         ("openclaw-tui", "backend"),
         ("cli", "cli"),
     }
@@ -604,7 +605,7 @@ def _validate_harness(
     )
     gateway_client = harness.get("gatewayClient")
     if gateway_client is None:
-        gateway_client_id, gateway_client_mode = "openclaw-tui", "backend"
+        gateway_client_id, gateway_client_mode = "gateway-client", "backend"
     else:
         gateway_client_mapping = _mapping(
             gateway_client,

--- a/infra/agent-image/eval/candidates/manifests/baseline.json
+++ b/infra/agent-image/eval/candidates/manifests/baseline.json
@@ -10,9 +10,9 @@
     "harness": {
       "baseImage": "ghcr.io/openclaw/openclaw@sha256:86e0a480a37d879311c9723ad2487cca9eb6c1925fa4732dec3f505b4728eee9",
       "hostVersion": "2026.7.2-beta.5",
-      "bedrockPluginVersion": "2026.7.1",
+      "bedrockPluginVersion": "2026.7.2-beta.5",
       "expectedPluginToken": "claude-sonnet-5",
-      "parallelPluginVersion": "2026.7.1",
+      "parallelPluginVersion": "2026.7.2-beta.5",
       "parallelPluginEndpoint": "https://search.parallel.ai/mcp"
     },
     "prompt": {

--- a/infra/agent-image/eval/candidates/manifests/baseline.json
+++ b/infra/agent-image/eval/candidates/manifests/baseline.json
@@ -8,8 +8,8 @@
       "providerTemplate": "../providers/native-bedrock-sonnet-5.json"
     },
     "harness": {
-      "baseImage": "ghcr.io/openclaw/openclaw@sha256:6a31d44b2944e7adcd2b582bf6fb463111264ebca97a0201795b799135bd102c",
-      "hostVersion": "2026.7.1",
+      "baseImage": "ghcr.io/openclaw/openclaw@sha256:86e0a480a37d879311c9723ad2487cca9eb6c1925fa4732dec3f505b4728eee9",
+      "hostVersion": "2026.7.2-beta.5",
       "bedrockPluginVersion": "2026.7.1",
       "expectedPluginToken": "claude-sonnet-5",
       "parallelPluginVersion": "2026.7.1",

--- a/infra/agent-image/eval/candidates/manifests/conservative-tool-routing.json
+++ b/infra/agent-image/eval/candidates/manifests/conservative-tool-routing.json
@@ -8,11 +8,11 @@
       "providerTemplate": "../providers/native-bedrock-sonnet-5.json"
     },
     "harness": {
-      "baseImage": "ghcr.io/openclaw/openclaw@sha256:6a31d44b2944e7adcd2b582bf6fb463111264ebca97a0201795b799135bd102c",
-      "hostVersion": "2026.7.1",
-      "bedrockPluginVersion": "2026.7.1",
+      "baseImage": "ghcr.io/openclaw/openclaw@sha256:86e0a480a37d879311c9723ad2487cca9eb6c1925fa4732dec3f505b4728eee9",
+      "hostVersion": "2026.7.2-beta.5",
+      "bedrockPluginVersion": "2026.7.2-beta.5",
       "expectedPluginToken": "claude-sonnet-5",
-      "parallelPluginVersion": "2026.7.1",
+      "parallelPluginVersion": "2026.7.2-beta.5",
       "parallelPluginEndpoint": "https://search.parallel.ai/mcp"
     },
     "prompt": {

--- a/infra/agent-image/eval/candidates/manifests/glm-5-mantle-openai.json
+++ b/infra/agent-image/eval/candidates/manifests/glm-5-mantle-openai.json
@@ -8,8 +8,8 @@
       "providerTemplate": "../providers/mantle-openai-glm-5.json"
     },
     "harness": {
-      "baseImage": "ghcr.io/openclaw/openclaw@sha256:6a31d44b2944e7adcd2b582bf6fb463111264ebca97a0201795b799135bd102c",
-      "hostVersion": "2026.7.1",
+      "baseImage": "ghcr.io/openclaw/openclaw@sha256:86e0a480a37d879311c9723ad2487cca9eb6c1925fa4732dec3f505b4728eee9",
+      "hostVersion": "2026.7.2-beta.5",
       "bedrockPluginVersion": "2026.7.1",
       "expectedPluginToken": "claude-sonnet-5",
       "parallelPluginVersion": "2026.7.1",

--- a/infra/agent-image/eval/candidates/manifests/glm-5-mantle-openai.json
+++ b/infra/agent-image/eval/candidates/manifests/glm-5-mantle-openai.json
@@ -10,9 +10,9 @@
     "harness": {
       "baseImage": "ghcr.io/openclaw/openclaw@sha256:86e0a480a37d879311c9723ad2487cca9eb6c1925fa4732dec3f505b4728eee9",
       "hostVersion": "2026.7.2-beta.5",
-      "bedrockPluginVersion": "2026.7.1",
+      "bedrockPluginVersion": "2026.7.2-beta.5",
       "expectedPluginToken": "claude-sonnet-5",
-      "parallelPluginVersion": "2026.7.1",
+      "parallelPluginVersion": "2026.7.2-beta.5",
       "parallelPluginEndpoint": "https://search.parallel.ai/mcp"
     },
     "prompt": {

--- a/infra/agent-image/eval/candidates/manifests/glm-5-native.json
+++ b/infra/agent-image/eval/candidates/manifests/glm-5-native.json
@@ -8,8 +8,8 @@
       "providerTemplate": "../providers/native-bedrock-glm-5.json"
     },
     "harness": {
-      "baseImage": "ghcr.io/openclaw/openclaw@sha256:6a31d44b2944e7adcd2b582bf6fb463111264ebca97a0201795b799135bd102c",
-      "hostVersion": "2026.7.1",
+      "baseImage": "ghcr.io/openclaw/openclaw@sha256:86e0a480a37d879311c9723ad2487cca9eb6c1925fa4732dec3f505b4728eee9",
+      "hostVersion": "2026.7.2-beta.5",
       "bedrockPluginVersion": "2026.7.1",
       "expectedPluginToken": "claude-sonnet-5",
       "parallelPluginVersion": "2026.7.1",

--- a/infra/agent-image/eval/candidates/manifests/glm-5-native.json
+++ b/infra/agent-image/eval/candidates/manifests/glm-5-native.json
@@ -10,9 +10,9 @@
     "harness": {
       "baseImage": "ghcr.io/openclaw/openclaw@sha256:86e0a480a37d879311c9723ad2487cca9eb6c1925fa4732dec3f505b4728eee9",
       "hostVersion": "2026.7.2-beta.5",
-      "bedrockPluginVersion": "2026.7.1",
+      "bedrockPluginVersion": "2026.7.2-beta.5",
       "expectedPluginToken": "claude-sonnet-5",
-      "parallelPluginVersion": "2026.7.1",
+      "parallelPluginVersion": "2026.7.2-beta.5",
       "parallelPluginEndpoint": "https://search.parallel.ai/mcp"
     },
     "prompt": {

--- a/infra/agent-image/eval/candidates/manifests/kimi-k2-5.json
+++ b/infra/agent-image/eval/candidates/manifests/kimi-k2-5.json
@@ -8,8 +8,8 @@
       "providerTemplate": "../providers/mantle-openai-kimi-k2-5.json"
     },
     "harness": {
-      "baseImage": "ghcr.io/openclaw/openclaw@sha256:6a31d44b2944e7adcd2b582bf6fb463111264ebca97a0201795b799135bd102c",
-      "hostVersion": "2026.7.1",
+      "baseImage": "ghcr.io/openclaw/openclaw@sha256:86e0a480a37d879311c9723ad2487cca9eb6c1925fa4732dec3f505b4728eee9",
+      "hostVersion": "2026.7.2-beta.5",
       "bedrockPluginVersion": "2026.7.1",
       "expectedPluginToken": "claude-sonnet-5",
       "parallelPluginVersion": "2026.7.1",

--- a/infra/agent-image/eval/candidates/manifests/kimi-k2-5.json
+++ b/infra/agent-image/eval/candidates/manifests/kimi-k2-5.json
@@ -10,9 +10,9 @@
     "harness": {
       "baseImage": "ghcr.io/openclaw/openclaw@sha256:86e0a480a37d879311c9723ad2487cca9eb6c1925fa4732dec3f505b4728eee9",
       "hostVersion": "2026.7.2-beta.5",
-      "bedrockPluginVersion": "2026.7.1",
+      "bedrockPluginVersion": "2026.7.2-beta.5",
       "expectedPluginToken": "claude-sonnet-5",
-      "parallelPluginVersion": "2026.7.1",
+      "parallelPluginVersion": "2026.7.2-beta.5",
       "parallelPluginEndpoint": "https://search.parallel.ai/mcp"
     },
     "prompt": {

--- a/infra/agent-image/eval/candidates/manifests/openai-gpt-oss-120b.json
+++ b/infra/agent-image/eval/candidates/manifests/openai-gpt-oss-120b.json
@@ -8,8 +8,8 @@
       "providerTemplate": "../providers/mantle-openai-gpt-oss-120b.json"
     },
     "harness": {
-      "baseImage": "ghcr.io/openclaw/openclaw@sha256:6a31d44b2944e7adcd2b582bf6fb463111264ebca97a0201795b799135bd102c",
-      "hostVersion": "2026.7.1",
+      "baseImage": "ghcr.io/openclaw/openclaw@sha256:86e0a480a37d879311c9723ad2487cca9eb6c1925fa4732dec3f505b4728eee9",
+      "hostVersion": "2026.7.2-beta.5",
       "bedrockPluginVersion": "2026.7.1",
       "expectedPluginToken": "claude-sonnet-5",
       "parallelPluginVersion": "2026.7.1",

--- a/infra/agent-image/eval/candidates/manifests/openai-gpt-oss-120b.json
+++ b/infra/agent-image/eval/candidates/manifests/openai-gpt-oss-120b.json
@@ -10,9 +10,9 @@
     "harness": {
       "baseImage": "ghcr.io/openclaw/openclaw@sha256:86e0a480a37d879311c9723ad2487cca9eb6c1925fa4732dec3f505b4728eee9",
       "hostVersion": "2026.7.2-beta.5",
-      "bedrockPluginVersion": "2026.7.1",
+      "bedrockPluginVersion": "2026.7.2-beta.5",
       "expectedPluginToken": "claude-sonnet-5",
-      "parallelPluginVersion": "2026.7.1",
+      "parallelPluginVersion": "2026.7.2-beta.5",
       "parallelPluginEndpoint": "https://search.parallel.ai/mcp"
     },
     "prompt": {

--- a/infra/agent-image/eval/candidates/manifests/openclaw-cli-gateway.json
+++ b/infra/agent-image/eval/candidates/manifests/openclaw-cli-gateway.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "id": "openclaw-2026-7-2-beta-5",
+  "id": "openclaw-cli-gateway",
   "baseline": "baseline.json",
   "declaredAxis": "harness",
   "axes": {
@@ -12,27 +12,12 @@
       "hostVersion": "2026.7.2-beta.5",
       "bedrockPluginVersion": "2026.7.2-beta.5",
       "expectedPluginToken": "claude-sonnet-5",
-      "parallelPluginVersion": "2026.7.1",
+      "parallelPluginVersion": "2026.7.2-beta.5",
       "parallelPluginEndpoint": "https://search.parallel.ai/mcp",
       "gatewayClient": {
         "id": "cli",
         "mode": "cli"
-      },
-      "configMigrations": [
-        {
-          "op": "move",
-          "from": "agents.defaults.memorySearch",
-          "to": "memory.search"
-        },
-        {
-          "op": "remove",
-          "path": "gateway.controlUi.allowInsecureAuth"
-        },
-        {
-          "op": "remove",
-          "path": "gateway.controlUi.dangerouslyDisableDeviceAuth"
-        }
-      ]
+      }
     },
     "prompt": {
       "variant": "default",

--- a/infra/agent-image/eval/candidates/manifests/qwen3-coder-next.json
+++ b/infra/agent-image/eval/candidates/manifests/qwen3-coder-next.json
@@ -8,8 +8,8 @@
       "providerTemplate": "../providers/mantle-openai-qwen3-coder-next.json"
     },
     "harness": {
-      "baseImage": "ghcr.io/openclaw/openclaw@sha256:6a31d44b2944e7adcd2b582bf6fb463111264ebca97a0201795b799135bd102c",
-      "hostVersion": "2026.7.1",
+      "baseImage": "ghcr.io/openclaw/openclaw@sha256:86e0a480a37d879311c9723ad2487cca9eb6c1925fa4732dec3f505b4728eee9",
+      "hostVersion": "2026.7.2-beta.5",
       "bedrockPluginVersion": "2026.7.1",
       "expectedPluginToken": "claude-sonnet-5",
       "parallelPluginVersion": "2026.7.1",

--- a/infra/agent-image/eval/candidates/manifests/qwen3-coder-next.json
+++ b/infra/agent-image/eval/candidates/manifests/qwen3-coder-next.json
@@ -10,9 +10,9 @@
     "harness": {
       "baseImage": "ghcr.io/openclaw/openclaw@sha256:86e0a480a37d879311c9723ad2487cca9eb6c1925fa4732dec3f505b4728eee9",
       "hostVersion": "2026.7.2-beta.5",
-      "bedrockPluginVersion": "2026.7.1",
+      "bedrockPluginVersion": "2026.7.2-beta.5",
       "expectedPluginToken": "claude-sonnet-5",
-      "parallelPluginVersion": "2026.7.1",
+      "parallelPluginVersion": "2026.7.2-beta.5",
       "parallelPluginEndpoint": "https://search.parallel.ai/mcp"
     },
     "prompt": {

--- a/infra/agent-image/eval/candidates/manifests/sonnet-5-mantle-anthropic.json
+++ b/infra/agent-image/eval/candidates/manifests/sonnet-5-mantle-anthropic.json
@@ -10,9 +10,9 @@
     "harness": {
       "baseImage": "ghcr.io/openclaw/openclaw@sha256:86e0a480a37d879311c9723ad2487cca9eb6c1925fa4732dec3f505b4728eee9",
       "hostVersion": "2026.7.2-beta.5",
-      "bedrockPluginVersion": "2026.7.1",
+      "bedrockPluginVersion": "2026.7.2-beta.5",
       "expectedPluginToken": "claude-sonnet-5",
-      "parallelPluginVersion": "2026.7.1",
+      "parallelPluginVersion": "2026.7.2-beta.5",
       "parallelPluginEndpoint": "https://search.parallel.ai/mcp"
     },
     "prompt": {

--- a/infra/agent-image/eval/candidates/manifests/sonnet-5-mantle-anthropic.json
+++ b/infra/agent-image/eval/candidates/manifests/sonnet-5-mantle-anthropic.json
@@ -8,8 +8,8 @@
       "providerTemplate": "../providers/mantle-anthropic-sonnet-5.json"
     },
     "harness": {
-      "baseImage": "ghcr.io/openclaw/openclaw@sha256:6a31d44b2944e7adcd2b582bf6fb463111264ebca97a0201795b799135bd102c",
-      "hostVersion": "2026.7.1",
+      "baseImage": "ghcr.io/openclaw/openclaw@sha256:86e0a480a37d879311c9723ad2487cca9eb6c1925fa4732dec3f505b4728eee9",
+      "hostVersion": "2026.7.2-beta.5",
       "bedrockPluginVersion": "2026.7.1",
       "expectedPluginToken": "claude-sonnet-5",
       "parallelPluginVersion": "2026.7.1",

--- a/infra/agent-image/harness_adapter.py
+++ b/infra/agent-image/harness_adapter.py
@@ -390,8 +390,8 @@ class OpenClawAdapter(HarnessAdapter):
 
         websocket-client adds an Origin header unless told otherwise. Newer
         OpenClaw releases deliberately treat any Origin-bearing connection as
-        browser-originated and therefore refuse the privileged local-CLI auth
-        path. This adapter is a backend client on the same container loopback,
+        browser-originated and therefore refuse approved local-backend auth
+        paths. This adapter is a backend client on the same container loopback,
         not a browser, so suppress the synthetic header instead of weakening
         the gateway's browser-origin checks.
         """

--- a/infra/agent-image/harness_adapter.py
+++ b/infra/agent-image/harness_adapter.py
@@ -269,16 +269,16 @@ class OpenClawAdapter(HarnessAdapter):
     # startup and --token overrides that config value, so the on-disk config
     # token is never the operative secret.
     # The image contract chooses the identity supported by its pinned host.
-    # Production 2026.7.1 retains the proven TUI path; 2026.7.2 harness
-    # candidates select OpenClaw's local CLI identity, whose container-local
-    # shared-auth path preserves operator scopes without classifying this
-    # non-browser adapter as Control UI. candidate.py and the Docker build
-    # accept only these two exact pairs.
+    # Production 2026.7.2-beta.5 uses OpenClaw's supported local-backend
+    # identity; harness candidates may select another explicitly approved pair
+    # for their pinned host. These loopback identities preserve operator scopes
+    # without classifying this non-browser adapter as Control UI.
     _gateway_client_pair = (
-        os.environ.get("PSD_OPENCLAW_GATEWAY_CLIENT_ID", "openclaw-tui"),
+        os.environ.get("PSD_OPENCLAW_GATEWAY_CLIENT_ID", "gateway-client"),
         os.environ.get("PSD_OPENCLAW_GATEWAY_CLIENT_MODE", "backend"),
     )
     if _gateway_client_pair not in {
+        ("gateway-client", "backend"),
         ("openclaw-tui", "backend"),
         ("cli", "cli"),
     }:
@@ -688,10 +688,10 @@ class OpenClawAdapter(HarnessAdapter):
                         # gateway protocol docs so we negotiate v4 against this
                         # gateway yet stay compatible with a v3 gateway on
                         # rollback. The v4 connect envelope + fields below are
-                        # unchanged. The harness-selected loopback identity
-                        # authenticates with the per-container shared token and
-                        # avoids the host's device-auth Control UI path, so no
-                        # device block is required.
+                        # unchanged. The harness-selected supported loopback
+                        # identity authenticates with the per-process shared
+                        # token, so no interactive operator-UI device identity
+                        # is involved.
                         "minProtocol": 3,
                         "maxProtocol": 4,
                         "client": self.CLIENT_INFO,

--- a/infra/agent-image/harness_adapter.py
+++ b/infra/agent-image/harness_adapter.py
@@ -141,6 +141,7 @@ def _format_for_chat(text: str) -> str:
 
 
 CONTEXT_OVERFLOW_ERROR_CLASS = "ContextOverflow"
+INCOMPLETE_TOOL_TURN_ERROR_CLASS = "OpenClawIncompleteToolTurn"
 
 
 def _classify_chat_error(error_message: str) -> str:
@@ -153,6 +154,10 @@ def _classify_chat_error(error_message: str) -> str:
       • Context overflow — the transcript outgrew the model's window. The work
         itself is fine; the SESSION is the problem, and continuing it is
         guaranteed to fail again. Recoverable, but only by starting fresh.
+      • Incomplete post-tool turn — OpenClaw exhausted or declined its own
+        tools-disabled finalization after possible effects. Retrying the
+        original request is unsafe, but the distinct class and structured
+        context make the exact failed pipeline boundary observable.
       • Everything else — a genuine fault. Retrying is not obviously safe.
 
     Downstream (agent-cron promotion, agent_failures, alarms) has to tell these
@@ -168,6 +173,14 @@ def _classify_chat_error(error_message: str) -> str:
     lowered = (error_message or "").lower()
     if "context overflow" in lowered or "prompt too large" in lowered:
         return CONTEXT_OVERFLOW_ERROR_CLASS
+    if (
+        (
+            "couldn't generate a response" in lowered
+            or "could not generate a response" in lowered
+        )
+        and "some tool actions may have already been executed" in lowered
+    ):
+        return INCOMPLETE_TOOL_TURN_ERROR_CLASS
     return "OpenClawChatError"
 
 
@@ -1095,10 +1108,51 @@ class OpenClawAdapter(HarnessAdapter):
 
                         elif state == "error":
                             err_msg = payload.get("errorMessage", "unknown")
+                            err_class = _classify_chat_error(str(err_msg))
+                            elapsed_s = max(
+                                0, int(time.time() - chat_send_at)
+                            )
+                            run_id = payload.get("runId")
+                            event_sequence = payload.get("seq")
+                            visible_response = (
+                                response_text or agent_assistant_accum
+                            )
+                            failure_context = {
+                                "phase": "chat_event_error",
+                                "last_state": last_state,
+                                "elapsed_s": elapsed_s,
+                                "deadline_s": deadline_s,
+                                "response_chars": len(visible_response),
+                                "tool_call_count": len(tool_calls),
+                                "active_tool_count": len(tool_starts),
+                                "event_counts": event_counts,
+                                "first_events": first_event_types,
+                            }
+                            if isinstance(run_id, str) and run_id:
+                                failure_context["run_id"] = run_id
+                            if isinstance(event_sequence, int):
+                                failure_context["event_sequence"] = (
+                                    event_sequence
+                                )
                             logger.error(
-                                "chat event error: %s | full_payload=%s",
+                                "chat event error: class=%s run_id=%s seq=%s "
+                                "response_chars=%d tool_calls=%d "
+                                "active_tools=%d elapsed_s=%d deadline_s=%d "
+                                "event_counts=%s error=%s",
+                                err_class,
+                                run_id or "unknown",
+                                event_sequence
+                                if isinstance(event_sequence, int)
+                                else "unknown",
+                                len(visible_response),
+                                len(tool_calls),
+                                len(tool_starts),
+                                elapsed_s,
+                                deadline_s,
+                                json.dumps(
+                                    event_counts, separators=(",", ":")
+                                ),
                                 err_msg,
-                                json.dumps(payload)[:800],
                             )
                             # Previously returned silently — no failure signal.
                             # This is where OpenClaw's "reply session
@@ -1107,8 +1161,11 @@ class OpenClawAdapter(HarnessAdapter):
                             # failure visible in agent_failures / the alarm.
                             # Context overflow gets its own class so the caller
                             # can recover it (fresh session) instead of
-                            # treating it as a crash. See _classify_chat_error.
-                            err_class = _classify_chat_error(str(err_msg))
+                            # treating it as a crash. A replay-unsafe incomplete
+                            # tool turn is also distinct, but deliberately stays
+                            # fail-closed downstream: the upgraded OpenClaw host
+                            # already attempted the only safe, tools-disabled
+                            # finalization. See _classify_chat_error.
                             record_failure(
                                 source="harness",
                                 severity="error",
@@ -1116,17 +1173,14 @@ class OpenClawAdapter(HarnessAdapter):
                                 error_message=str(err_msg),
                                 session_id=session_id,
                                 model=observed_model or model_override,
-                                context={
-                                    "phase": "chat_event_error",
-                                    "last_state": last_state,
-                                },
+                                context=failure_context,
                             )
                             # Never post the accumulated scratchpad narration
                             # as if it were the answer — frame it as a failed
                             # partial (issue #1138 F4).
                             err_text = _frame_failed_partial(
-                                _format_for_chat(response_text)
-                                if response_text
+                                _format_for_chat(visible_response)
+                                if visible_response
                                 else ""
                             )
                             # An errored turn can still have burned tokens

--- a/infra/agent-image/openclaw.json
+++ b/infra/agent-image/openclaw.json
@@ -111,10 +111,7 @@
       "token": ""
     },
     "controlUi": {
-      "enabled": false,
-      "dangerouslyDisableDeviceAuth": true,
-      "dangerouslyAllowHostHeaderOriginFallback": true,
-      "allowedOrigins": ["*"]
+      "enabled": false
     }
   }
 }

--- a/infra/agent-image/openclaw.json
+++ b/infra/agent-image/openclaw.json
@@ -43,11 +43,13 @@
         "midTurnPrecheck": {
           "enabled": true
         }
-      },
-      "memorySearch": {
-        "provider": "bedrock",
-        "model": "amazon.titan-embed-text-v2:0"
       }
+    }
+  },
+  "memory": {
+    "search": {
+      "provider": "bedrock",
+      "model": "amazon.titan-embed-text-v2:0"
     }
   },
   "tools": {
@@ -110,7 +112,6 @@
     },
     "controlUi": {
       "enabled": false,
-      "allowInsecureAuth": true,
       "dangerouslyDisableDeviceAuth": true,
       "dangerouslyAllowHostHeaderOriginFallback": true,
       "allowedOrigins": ["*"]

--- a/infra/agent-image/test_candidate_matrix.py
+++ b/infra/agent-image/test_candidate_matrix.py
@@ -112,7 +112,7 @@ class CandidateMatrixTests(unittest.TestCase):
             self.assertEqual(metadata["contextTokens"], 180000)
             self.assertEqual(
                 metadata["harness"]["parallelPluginVersion"],
-                "2026.7.1",
+                "2026.7.2-beta.5",
             )
             self.assertEqual(
                 metadata["harness"]["parallelPluginEndpoint"],
@@ -576,11 +576,11 @@ class CandidateMatrixTests(unittest.TestCase):
             'grep -RFq -- "${OPENCLAW_SETTLED_TOOL_RECOVERY_PROMPT}"',
             dockerfile,
         )
-        self.assertIn("ARG BEDROCK_PLUGIN_VERSION=2026.7.1", dockerfile)
+        self.assertIn("ARG BEDROCK_PLUGIN_VERSION=2026.7.2-beta.5", dockerfile)
         self.assertIn(
             "ARG BEDROCK_PLUGIN_ASSERTION=claude-sonnet-5", dockerfile
         )
-        self.assertIn("ARG PARALLEL_PLUGIN_VERSION=2026.7.1", dockerfile)
+        self.assertIn("ARG PARALLEL_PLUGIN_VERSION=2026.7.2-beta.5", dockerfile)
         self.assertIn(
             "ARG PARALLEL_PLUGIN_ENDPOINT=https://search.parallel.ai/mcp",
             dockerfile,
@@ -593,6 +593,14 @@ class CandidateMatrixTests(unittest.TestCase):
         )
         self.assertIn(
             'grep -Fq -- "${BEDROCK_PLUGIN_ASSERTION}"', dockerfile
+        )
+        self.assertIn(
+            "openclaw plugins inspect amazon-bedrock --runtime --json",
+            dockerfile,
+        )
+        self.assertIn(
+            "openclaw plugins inspect parallel --runtime --json",
+            dockerfile,
         )
 
     def test_build_command_wires_manifest_inputs_and_digest_sidecar(self):

--- a/infra/agent-image/test_candidate_matrix.py
+++ b/infra/agent-image/test_candidate_matrix.py
@@ -565,7 +565,15 @@ class CandidateMatrixTests(unittest.TestCase):
         dockerfile = (HERE / "Dockerfile").read_text(encoding="utf-8")
         self.assertIn(
             "ARG OPENCLAW_BASE_IMAGE=ghcr.io/openclaw/openclaw@sha256:"
-            "6a31d44b2944e7adcd2b582bf6fb463111264ebca97a0201795b799135bd102c",
+            "86e0a480a37d879311c9723ad2487cca9eb6c1925fa4732dec3f505b4728eee9",
+            dockerfile,
+        )
+        self.assertIn(
+            'grep -RFq -- "${OPENCLAW_SETTLED_TOOL_RECOVERY_LOG}"',
+            dockerfile,
+        )
+        self.assertIn(
+            'grep -RFq -- "${OPENCLAW_SETTLED_TOOL_RECOVERY_PROMPT}"',
             dockerfile,
         )
         self.assertIn("ARG BEDROCK_PLUGIN_VERSION=2026.7.1", dockerfile)

--- a/infra/agent-image/test_candidate_matrix.py
+++ b/infra/agent-image/test_candidate_matrix.py
@@ -34,7 +34,7 @@ class CandidateMatrixTests(unittest.TestCase):
                 "glm-5-native",
                 "kimi-k2-5",
                 "openai-gpt-oss-120b",
-                "openclaw-2026-7-2-beta-5",
+                "openclaw-cli-gateway",
                 "qwen3-coder-next",
                 "conservative-tool-routing",
                 "sonnet-5-mantle-anthropic",
@@ -121,8 +121,8 @@ class CandidateMatrixTests(unittest.TestCase):
             self.assertIsNone(metadata["imageDigest"])
             self.assertEqual(set(metadata["cost"]), set(metadata["costSources"]))
 
-    def test_harness_candidate_applies_only_approved_config_migrations(self):
-        manifest = self.manifests_dir / "openclaw-2026-7-2-beta-5.json"
+    def test_harness_candidate_applies_only_approved_gateway_identity(self):
+        manifest = self.manifests_dir / "openclaw-cli-gateway.json"
         with tempfile.TemporaryDirectory(
             dir=HERE, prefix=".candidate-test."
         ) as directory:
@@ -130,33 +130,15 @@ class CandidateMatrixTests(unittest.TestCase):
             config = json.loads(
                 (Path(directory) / "openclaw.json").read_text(encoding="utf-8")
             )
-            self.assertNotIn("memorySearch", config["agents"]["defaults"])
             self.assertEqual(
-                config["memory"]["search"],
-                {
-                    "provider": "bedrock",
-                    "model": "amazon.titan-embed-text-v2:0",
-                },
-            )
-            self.assertNotIn(
-                "allowInsecureAuth",
-                config["gateway"]["controlUi"],
-            )
-            self.assertNotIn(
-                "dangerouslyDisableDeviceAuth",
-                config["gateway"]["controlUi"],
+                config,
+                json.loads((HERE / "openclaw.json").read_text(encoding="utf-8")),
             )
             metadata = json.loads(
                 Path(plan["metadata"]).read_text(encoding="utf-8")
             )
             self.assertEqual(metadata["variedAxis"], "harness")
-            expected_migrations = json.loads(
-                manifest.read_text(encoding="utf-8")
-            )["axes"]["harness"]["configMigrations"]
-            self.assertEqual(
-                metadata["harness"]["configMigrations"],
-                expected_migrations,
-            )
+            self.assertIsNone(metadata["harness"]["configMigrations"])
             self.assertEqual(
                 metadata["harness"]["gatewayClient"],
                 {
@@ -181,15 +163,15 @@ class CandidateMatrixTests(unittest.TestCase):
     def test_rejects_unapproved_harness_config_migration(self):
         source = json.loads(
             (
-                self.manifests_dir / "openclaw-2026-7-2-beta-5.json"
+                self.manifests_dir / "openclaw-cli-gateway.json"
             ).read_text(encoding="utf-8")
         )
-        source["axes"]["harness"]["configMigrations"].append(
+        source["axes"]["harness"]["configMigrations"] = [
             {
                 "op": "remove",
                 "path": "agents.defaults.model",
             }
-        )
+        ]
         with tempfile.TemporaryDirectory(
             dir=self.manifests_dir.parent, prefix=".candidate-contract-test."
         ) as directory:
@@ -209,7 +191,7 @@ class CandidateMatrixTests(unittest.TestCase):
     def test_rejects_unapproved_harness_gateway_client(self):
         source = json.loads(
             (
-                self.manifests_dir / "openclaw-2026-7-2-beta-5.json"
+                self.manifests_dir / "openclaw-cli-gateway.json"
             ).read_text(encoding="utf-8")
         )
         source["axes"]["harness"]["gatewayClient"] = {
@@ -586,7 +568,7 @@ class CandidateMatrixTests(unittest.TestCase):
             dockerfile,
         )
         self.assertIn(
-            "ARG OPENCLAW_GATEWAY_CLIENT_ID=openclaw-tui", dockerfile
+            "ARG OPENCLAW_GATEWAY_CLIENT_ID=gateway-client", dockerfile
         )
         self.assertIn(
             "ARG OPENCLAW_GATEWAY_CLIENT_MODE=backend", dockerfile

--- a/infra/agent-image/test_check_config_consistency.py
+++ b/infra/agent-image/test_check_config_consistency.py
@@ -98,6 +98,27 @@ class TierEvalConfigSchemaTests(unittest.TestCase):
             any("allowInsecureAuth is retired" in v for v in violations)
         )
 
+    def test_retired_and_unneeded_control_ui_danger_flags_are_rejected(self):
+        cfg = {
+            **self.CANONICAL,
+            "gateway": {
+                "controlUi": {
+                    "enabled": False,
+                    "dangerouslyDisableDeviceAuth": True,
+                    "dangerouslyAllowHostHeaderOriginFallback": True,
+                }
+            },
+        }
+        violations = ccc.check_tier_eval_config_schema(cfg)
+        self.assertTrue(
+            any("dangerouslyDisableDeviceAuth is retired" in v
+                for v in violations)
+        )
+        self.assertTrue(
+            any("dangerouslyAllowHostHeaderOriginFallback" in v
+                for v in violations)
+        )
+
     def test_semantic_memory_keeps_explicit_bedrock_model(self):
         cfg = {**self.CANONICAL, "memory": {"search": {}}}
         violations = ccc.check_tier_eval_config_schema(cfg)
@@ -533,7 +554,7 @@ class HostPluginCompatibilityTests(unittest.TestCase):
         version, violations = ccc.parse_pinned_plugin_version(
             os.path.join(here, "Dockerfile")
         )
-        self.assertEqual(version, "2026.7.1")
+        self.assertEqual(version, "2026.7.2-beta.5")
         self.assertEqual(violations, [])
 
 
@@ -605,6 +626,27 @@ class SettledToolRecoveryContractTests(unittest.TestCase):
         )
 
 
+class PluginRuntimeAssertionTests(unittest.TestCase):
+    def test_repo_dockerfile_loads_both_exact_plugin_pins(self):
+        here = os.path.dirname(os.path.abspath(__file__))
+        self.assertEqual(
+            ccc.check_plugin_runtime_assertions(
+                os.path.join(here, "Dockerfile")
+            ),
+            [],
+        )
+
+    def test_version_checks_without_runtime_loading_are_rejected(self):
+        with tempfile.TemporaryDirectory() as directory:
+            dockerfile = os.path.join(directory, "Dockerfile")
+            with open(dockerfile, "w", encoding="utf-8") as fh:
+                fh.write("RUN openclaw config validate\n")
+            violations = ccc.check_plugin_runtime_assertions(dockerfile)
+        self.assertTrue(
+            any("runtime registration" in v for v in violations)
+        )
+
+
 class RealFilesTests(unittest.TestCase):
     def test_repo_config_is_consistent(self):
         here = os.path.dirname(os.path.abspath(__file__))
@@ -629,7 +671,7 @@ class RealFilesTests(unittest.TestCase):
         here = os.path.dirname(os.path.abspath(__file__))
         version, violations = ccc.parse_pinned_parallel_plugin_version(
             os.path.join(here, "Dockerfile"))
-        self.assertEqual(version, "2026.7.1")
+        self.assertEqual(version, "2026.7.2-beta.5")
         self.assertEqual(violations, [])
 
 

--- a/infra/agent-image/test_check_config_consistency.py
+++ b/infra/agent-image/test_check_config_consistency.py
@@ -48,6 +48,65 @@ class ContextWindowTests(unittest.TestCase):
         self.assertTrue(ccc.check_context_windows(cfg))
 
 
+class TierEvalConfigSchemaTests(unittest.TestCase):
+    CANONICAL = {
+        "agents": {"defaults": {}},
+        "memory": {
+            "search": {
+                "provider": "bedrock",
+                "model": "amazon.titan-embed-text-v2:0",
+            }
+        },
+        "gateway": {"controlUi": {"enabled": False}},
+    }
+
+    def test_canonical_memory_schema_passes(self):
+        self.assertEqual(
+            ccc.check_tier_eval_config_schema(self.CANONICAL),
+            [],
+        )
+
+    def test_legacy_default_memory_search_is_rejected(self):
+        cfg = {
+            **self.CANONICAL,
+            "agents": {
+                "defaults": {
+                    "memorySearch": {
+                        "provider": "bedrock",
+                        "model": "amazon.titan-embed-text-v2:0",
+                    }
+                }
+            },
+        }
+        violations = ccc.check_tier_eval_config_schema(cfg)
+        self.assertTrue(
+            any("agents.defaults.memorySearch moved" in v for v in violations)
+        )
+
+    def test_retired_insecure_auth_toggle_is_rejected(self):
+        cfg = {
+            **self.CANONICAL,
+            "gateway": {
+                "controlUi": {
+                    "enabled": False,
+                    "allowInsecureAuth": True,
+                }
+            },
+        }
+        violations = ccc.check_tier_eval_config_schema(cfg)
+        self.assertTrue(
+            any("allowInsecureAuth is retired" in v for v in violations)
+        )
+
+    def test_semantic_memory_keeps_explicit_bedrock_model(self):
+        cfg = {**self.CANONICAL, "memory": {"search": {}}}
+        violations = ccc.check_tier_eval_config_schema(cfg)
+        self.assertTrue(
+            any("memory.search.provider" in v for v in violations)
+        )
+        self.assertTrue(any("memory.search.model" in v for v in violations))
+
+
 class ApiKeyHydrationTests(unittest.TestCase):
     def _wrapper(self, text: str) -> str:
         d = tempfile.mkdtemp()

--- a/infra/agent-image/test_check_config_consistency.py
+++ b/infra/agent-image/test_check_config_consistency.py
@@ -478,6 +478,74 @@ class HostPluginCompatibilityTests(unittest.TestCase):
         self.assertEqual(violations, [])
 
 
+class SettledToolRecoveryContractTests(unittest.TestCase):
+    """The host must recover settled tool turns without replaying effects."""
+
+    FIXED = (
+        "2026.7.2-beta.5",
+        "sha256:" + "86e0a480a37d879311c9723ad2487cca9eb6c1925fa4732dec3f505b4728eee9",
+    )
+    OLD = (
+        "2026.7.1",
+        "sha256:" + "6a31d44b2944e7adcd2b582bf6fb463111264ebca97a0201795b799135bd102c",
+    )
+
+    def _dockerfile(self, host, digest, *, assert_runtime=True):
+        d = tempfile.mkdtemp()
+        p = os.path.join(d, "Dockerfile")
+        contract = ""
+        if assert_runtime:
+            contract = (
+                'ARG OPENCLAW_SETTLED_TOOL_RECOVERY_LOG="settled post-tool turn '
+                'lacked a final answer"\n'
+                'ARG OPENCLAW_SETTLED_TOOL_RECOVERY_PROMPT="The previous assistant '
+                'turn completed its tool calls but did not produce a user-visible '
+                'answer."\n'
+                'RUN grep -RFq -- "${OPENCLAW_SETTLED_TOOL_RECOVERY_LOG}" /app/dist '
+                '&& \\\n'
+                '    grep -RFq -- "${OPENCLAW_SETTLED_TOOL_RECOVERY_PROMPT}" '
+                "/app/dist\n"
+            )
+        with open(p, "w", encoding="utf-8") as fh:
+            fh.write(
+                f"#   ghcr.io/openclaw/openclaw:{host}\n"
+                f"#   index: {digest}\n"
+                f"FROM ghcr.io/openclaw/openclaw@{digest}\n"
+                f"{contract}"
+            )
+        return p
+
+    def test_first_fixed_release_with_runtime_assertions_passes(self):
+        self.assertEqual(
+            ccc.check_settled_tool_recovery(self._dockerfile(*self.FIXED)),
+            [],
+        )
+
+    def test_previous_stable_release_is_rejected(self):
+        violations = ccc.check_settled_tool_recovery(
+            self._dockerfile(*self.OLD)
+        )
+        self.assertTrue(any("predates settled-tool recovery" in v for v in violations))
+
+    def test_missing_compiled_runtime_assertions_are_rejected(self):
+        violations = ccc.check_settled_tool_recovery(
+            self._dockerfile(*self.FIXED, assert_runtime=False)
+        )
+        self.assertTrue(
+            any("does not assert the compiled settled-tool recovery" in v
+                for v in violations)
+        )
+
+    def test_repo_dockerfile_keeps_recovery_contract(self):
+        here = os.path.dirname(os.path.abspath(__file__))
+        self.assertEqual(
+            ccc.check_settled_tool_recovery(
+                os.path.join(here, "Dockerfile")
+            ),
+            [],
+        )
+
+
 class RealFilesTests(unittest.TestCase):
     def test_repo_config_is_consistent(self):
         here = os.path.dirname(os.path.abspath(__file__))

--- a/infra/agent-image/test_eval_runner.py
+++ b/infra/agent-image/test_eval_runner.py
@@ -2531,6 +2531,10 @@ class BuildGateCompatibilityTests(unittest.TestCase):
         self.assertIn('eval/probe.py" last-result', build_script)
         self.assertIn('eval/probe.py" make-payload --', build_script)
         self.assertIn(
+            'docker logs "${CID}" 2>&1 | tail -80',
+            build_script,
+        )
+        self.assertIn(
             '\'{"tag":"%s","boot_ok":false,"boot_elapsed_s":%s,'
             '"canary_ok":false}\\n\'',
             build_script,

--- a/infra/agent-image/test_harness_adapter.py
+++ b/infra/agent-image/test_harness_adapter.py
@@ -97,11 +97,11 @@ class CatalogDiagnosticTests(unittest.TestCase):
 
 
 class GatewayTokenTests(unittest.TestCase):
-    def test_defaults_to_proven_baseline_gateway_identity(self):
+    def test_defaults_to_supported_baseline_gateway_identity(self):
         self.assertEqual(
             OpenClawAdapter.CLIENT_INFO,
             {
-                "id": "openclaw-tui",
+                "id": "gateway-client",
                 "mode": "backend",
                 "version": "dev",
                 "platform": "linux",
@@ -174,6 +174,25 @@ class GatewayTokenTests(unittest.TestCase):
             "ws://127.0.0.1:3100",
             timeout=120,
             suppress_origin=True,
+        )
+
+
+class GatewayClientIdentityTests(unittest.TestCase):
+    def test_loopback_adapter_uses_supported_backend_identity(self):
+        self.assertEqual(
+            OpenClawAdapter.CLIENT_INFO,
+            {
+                "id": "gateway-client",
+                "mode": "backend",
+                "version": "dev",
+                "platform": "linux",
+            },
+        )
+
+    def test_adapter_does_not_claim_an_interactive_operator_ui_identity(self):
+        self.assertNotIn(
+            OpenClawAdapter.CLIENT_INFO["id"],
+            {"openclaw-control-ui", "openclaw-browser-copilot", "openclaw-tui"},
         )
 
 

--- a/infra/agent-image/test_harness_adapter.py
+++ b/infra/agent-image/test_harness_adapter.py
@@ -195,6 +195,10 @@ class GatewayClientIdentityTests(unittest.TestCase):
             {"openclaw-control-ui", "openclaw-browser-copilot", "openclaw-tui"},
         )
 
+    def test_loopback_backend_socket_suppresses_browser_origin(self):
+        source = pathlib.Path(harness_adapter.__file__).read_text(encoding="utf-8")
+        self.assertIn("suppress_origin=True", source)
+
 
 # Bound staticmethod for readability.
 extract_text = OpenClawAdapter._extract_text

--- a/infra/agent-image/test_harness_adapter.py
+++ b/infra/agent-image/test_harness_adapter.py
@@ -482,6 +482,187 @@ class TestChatDeadlineRegression(unittest.TestCase):
         self.assertGreaterEqual(failure["context"]["elapsed_s"], 600)
 
 
+class TestIncompleteToolTurnTelemetry(unittest.TestCase):
+    """Failure #260 must name and locate the exhausted OpenClaw recovery."""
+
+    @staticmethod
+    def _message(**fields):
+        return json.dumps(fields)
+
+    def test_replay_unsafe_chat_error_records_pipeline_context(self):
+        chat_id = None
+
+        class FakeWebSocket:
+            def __init__(self, messages):
+                self.messages = list(messages)
+                self.sent = []
+
+            def send(self, payload):
+                nonlocal chat_id
+                parsed = json.loads(payload)
+                self.sent.append(parsed)
+                if parsed.get("method") == "chat.send":
+                    chat_id = parsed["id"]
+
+            def recv(self):
+                message = self.messages.pop(0)
+                return message() if callable(message) else message
+
+            def settimeout(self, _timeout):
+                return None
+
+            def close(self):
+                return None
+
+        def current_run_event(event, payload):
+            return self._message(
+                type="event",
+                event=event,
+                payload={"runId": chat_id, **payload},
+            )
+
+        error_message = (
+            "⚠️ Agent couldn't generate a response. Note: some tool actions "
+            "may have already been executed — please verify before retrying."
+        )
+        messages = [
+            self._message(type="event", event="connect.challenge", payload={}),
+            lambda: self._message(
+                type="res",
+                id=socket.sent[-1]["id"],
+                ok=True,
+                payload={},
+            ),
+            lambda: self._message(
+                type="res",
+                id=socket.sent[-1]["id"],
+                ok=True,
+                payload={"tools": []},
+            ),
+            lambda: self._message(
+                type="res",
+                id=socket.sent[-1]["id"],
+                ok=True,
+                payload={},
+            ),
+            lambda: self._message(
+                type="res",
+                id=chat_id,
+                ok=True,
+                payload={"runId": chat_id, "status": "started"},
+            ),
+            lambda: current_run_event(
+                "agent",
+                {
+                    "stream": "lifecycle",
+                    "sessionId": "openclaw-session-260",
+                    "agentId": "main",
+                    "data": {"phase": "start"},
+                },
+            ),
+            lambda: current_run_event(
+                "agent",
+                {
+                    "stream": "assistant",
+                    "data": {"delta": "The"},
+                },
+            ),
+            lambda: current_run_event(
+                "agent",
+                {
+                    "stream": "item",
+                    "data": {
+                        "itemId": "tool-260",
+                        "phase": "start",
+                        "kind": "tool",
+                        "name": "edit",
+                    },
+                },
+            ),
+            lambda: current_run_event(
+                "agent",
+                {
+                    "stream": "item",
+                    "data": {
+                        "itemId": "tool-260",
+                        "phase": "end",
+                        "kind": "tool",
+                        "name": "edit",
+                        "status": "completed",
+                        "output": "updated",
+                    },
+                },
+            ),
+            lambda: current_run_event(
+                "chat",
+                {
+                    "seq": 34,
+                    "state": "error",
+                    "errorMessage": error_message,
+                },
+            ),
+        ]
+        socket = FakeWebSocket(messages)
+        fake_websocket_module = mock.Mock()
+        fake_websocket_module.create_connection.return_value = socket
+        fake_websocket_module.WebSocketTimeoutException = TimeoutError
+        empty_usage = {
+            "input": 0,
+            "output": 0,
+            "cache_read": 0,
+            "cache_write": 0,
+            "model_calls": 0,
+        }
+        adapter = OpenClawAdapter()
+        adapter._ready = True
+
+        with (
+            mock.patch.dict(
+                sys.modules,
+                {"websocket": fake_websocket_module},
+            ),
+            mock.patch.object(
+                adapter,
+                "_read_turn_usage",
+                return_value=empty_usage,
+            ),
+            mock.patch(
+                "harness_adapter.record_failure",
+            ) as record_failure,
+            mock.patch(
+                "harness_adapter.time.time",
+                return_value=100.0,
+            ),
+        ):
+            result = adapter.process(
+                "Continue a multi-tool task",
+                "session-260",
+                deadline_s=600,
+            )
+
+        failure = record_failure.call_args.kwargs
+        context = failure["context"]
+        self.assertTrue(result.failed)
+        self.assertEqual(
+            result.error_class,
+            harness_adapter.INCOMPLETE_TOOL_TURN_ERROR_CLASS,
+        )
+        self.assertIn("The", result.text)
+        self.assertEqual(
+            failure["error_class"],
+            harness_adapter.INCOMPLETE_TOOL_TURN_ERROR_CLASS,
+        )
+        self.assertEqual(context["phase"], "chat_event_error")
+        self.assertEqual(context["run_id"], chat_id)
+        self.assertEqual(context["event_sequence"], 34)
+        self.assertEqual(context["response_chars"], 3)
+        self.assertEqual(context["tool_call_count"], 1)
+        self.assertEqual(context["active_tool_count"], 0)
+        self.assertEqual(context["deadline_s"], 600)
+        self.assertEqual(context["event_counts"]["event:chat"], 1)
+        self.assertIn("event:agent", context["first_events"])
+
+
 class TestRecordItemToolEvent(unittest.TestCase):
     """Native-mode tool items must land in tool_calls telemetry (#1138 r12)."""
 
@@ -777,7 +958,7 @@ class TurnResultCacheFieldTests(unittest.TestCase):
 
 
 class ChatErrorClassificationTests(unittest.TestCase):
-    """Context overflow must be distinguishable from a genuine crash.
+    """Recoverable and replay-unsafe failures must not look like crashes.
 
     Every chat-channel error used to arrive as the same OpenClawChatError, with
     the distinguishing detail buried in free text. That conflation is why the
@@ -815,6 +996,24 @@ class ChatErrorClassificationTests(unittest.TestCase):
                 f"should classify as overflow: {message!r}",
             )
 
+    def test_recognizes_the_replay_unsafe_message_from_failure_260(self):
+        message = (
+            "⚠️ Agent couldn't generate a response. Note: some tool actions "
+            "may have already been executed — please verify before retrying."
+        )
+        self.assertEqual(
+            harness_adapter._classify_chat_error(message),
+            harness_adapter.INCOMPLETE_TOOL_TURN_ERROR_CLASS,
+        )
+
+    def test_does_not_treat_a_side_effect_free_generic_error_as_tool_turn(self):
+        self.assertEqual(
+            harness_adapter._classify_chat_error(
+                "Agent couldn't generate a response. Please try again."
+            ),
+            "OpenClawChatError",
+        )
+
     def test_leaves_every_other_failure_generic(self):
         # These MUST NOT become promotable — each is a real fault where an
         # automatic two-hour retry is the wrong answer.
@@ -844,6 +1043,10 @@ class ChatErrorClassificationTests(unittest.TestCase):
         # A rename here silently stops every scheduled restart.
         self.assertEqual(
             harness_adapter.CONTEXT_OVERFLOW_ERROR_CLASS, "ContextOverflow"
+        )
+        self.assertEqual(
+            harness_adapter.INCOMPLETE_TOOL_TURN_ERROR_CLASS,
+            "OpenClawIncompleteToolTurn",
         )
 
 

--- a/infra/lambdas/agent-router/job-promotion.test.ts
+++ b/infra/lambdas/agent-router/job-promotion.test.ts
@@ -28,6 +28,7 @@ describe('shouldPromoteToJob', () => {
 
   test('real errors and clean turns do NOT promote', () => {
     expect(shouldPromoteToJob('OpenClawChatError')).toBe(false);
+    expect(shouldPromoteToJob('OpenClawIncompleteToolTurn')).toBe(false);
     expect(shouldPromoteToJob('EmptyAgentResponse')).toBe(false);
     expect(shouldPromoteToJob('AgentCoreHttpError_500')).toBe(false);
     expect(shouldPromoteToJob(undefined)).toBe(false);
@@ -39,6 +40,7 @@ describe('shouldPromoteToJob', () => {
     expect(promotionReason('ChatDeadlineExpiredPartial')).toBe('deadline');
     expect(promotionReason('ContextOverflow')).toBe('context-overflow');
     expect(promotionReason('OpenClawChatError')).toBeNull();
+    expect(promotionReason('OpenClawIncompleteToolTurn')).toBeNull();
     expect(promotionReason(undefined)).toBeNull();
   });
 });

--- a/infra/lib/agent-platform-stack.ts
+++ b/infra/lib/agent-platform-stack.ts
@@ -1848,8 +1848,8 @@ export class AgentPlatformStack extends cdk.Stack {
       // Python wrapper and every in-image skill compensate with a hardcoded
       // `|| us-east-1` fallback (see agentcore_wrapper.py, workspace_sync.py),
       // but the vendored OpenClaw binary has no such fallback: its native
-      // `bedrock` memorySearch provider (openclaw.json agents.defaults.
-      // memorySearch) calls bedrock-runtime.<region>.amazonaws.com directly and
+      // `bedrock` memory search provider (openclaw.json memory.search) calls
+      // bedrock-runtime.<region>.amazonaws.com directly and
       // would fail region resolution without this. Set to this.region so the
       // SDK region matches the region the Bedrock IAM grants are scoped to
       // (arn:aws:bedrock:<region>::foundation-model/*). No-op for existing

--- a/tests/unit/agent-cron-job-promotion.test.ts
+++ b/tests/unit/agent-cron-job-promotion.test.ts
@@ -99,6 +99,7 @@ const baseInput = {
         "ChatDeadlineExpiredPartial",
         "ContextOverflow",
         "OpenClawChatError",
+        "OpenClawIncompleteToolTurn",
         "SomeFutureError",
         "",
         undefined,
@@ -170,6 +171,9 @@ const baseInput = {
       // two-hour retry budget. The container classifies overflow separately
       // (harness_adapter._classify_chat_error) precisely so this can stay no.
       expect(shouldPromoteFromCron("OpenClawChatError")).toBe(false)
+      // OpenClaw already attempted the only safe tools-disabled finalization.
+      // Replaying the original request could duplicate side effects.
+      expect(shouldPromoteFromCron("OpenClawIncompleteToolTurn")).toBe(false)
 
       expect(shouldPromoteFromCron("InvocationContextInvalid")).toBe(false)
       expect(shouldPromoteFromCron(undefined)).toBe(false)
@@ -183,6 +187,7 @@ const baseInput = {
       expect(promotionReason("ChatDeadlineExpiredPartial")).toBe("deadline")
       expect(promotionReason("ContextOverflow")).toBe("context-overflow")
       expect(promotionReason("OpenClawChatError")).toBeNull()
+      expect(promotionReason("OpenClawIncompleteToolTurn")).toBeNull()
       expect(promotionReason(undefined)).toBeNull()
     })
 


### PR DESCRIPTION
## Summary

- upgrades the OpenClaw host to the first immutable beta.5 build containing upstream settled post-tool finalization
- pins host-coupled Bedrock and Parallel plugins to the same release and fails image builds unless both register at runtime
- preserves non-replay safety: settled tool results receive one tools-disabled finalization pass, while unsafe tool actions are never replayed
- classifies exhausted incomplete turns as `OpenClawIncompleteToolTurn` with bounded run, sequence, event, response, and tool telemetry
- prevents automatic retry or candidate promotion for this side-effect-ambiguous failure class
- migrates beta.5 config schema and uses the supported authenticated `gateway-client`/`backend` WebSocket contract
- preserves the latest `dev` candidate framework by retaining its alternate `cli`/`cli` identity arm and adding the candidate matrix to CI
- emits a bounded container log tail when a build canary fails

## Root cause

Production failure row 260 ended with `stopReason=toolUse` after settled tool actions and no user-visible final answer. OpenClaw 2026.7.1 detected that replay was unsafe and deliberately surfaced its generic failure instead of replaying side effects. The harness then collapsed that condition into `OpenClawChatError` with too little context. Upstream OpenClaw fixed this in issue 97324 by consuming already-settled tool results in one tools-disabled finalization pass.

## Validation

- `bun run lint`
- `bun run typecheck`
- `bun run test:ci`: 536 active suites and 4,967 tests passed
- expanded CI-equivalent agent-image Python suite: 597 tests passed, 1 intentional skip
- candidate matrix: production beta.5 baseline, prompt candidates, model candidates, and alternate gateway identity all compose and pass consistency gates
- root production Next build passed
- infra TypeScript build and 17 Lambda tests passed
- `bunx cdk synth --all` passed; only pre-existing LOW advisories and configuration warnings remain
- signed dev-broker image gate passed at final SHA: boot in 35s and final answer `OK` in 4s

Final verification image: `390844780692.dkr.ecr.us-east-1.amazonaws.com/psd-agent-base-dev:2026-07-30-issue-1469-658de03fe`

Immutable digest: `sha256:176ba95e8936174b6cbe4caad9d3dc39a8269a65e959d51beb41f3f6f8897d48`

No deployment or promotion was performed. E2E is not applicable because this change has no UI or browser behavior; the authenticated pre-push suite was skipped with the documented `SKIP_E2E=1` path after the validation above. The CI root-only model UID isolation check is authoritative because local sudo requires an interactive password.

## Risk and rollback

The host is a beta release because it is the first published immutable artifact containing the upstream recovery. Compatibility is guarded by exact digest/version pins, config validation, compiled recovery assertions, runtime plugin inspection, and a signed real-model canary. Rollback is the prior image digest; no database or API migration is involved.

Closes #1469
