### PR TITLE
docs(agent-skill): add psd-observances guide and refresh runbook

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -153,6 +153,10 @@ ECS streaming infrastructure operations and monitoring.
 Digest-bound harness, prompt, and model comparison decisions from the first
 full PSD Agent eval run.
 
+#### [operations/psd-observances-annual-refresh.md](./operations/psd-observances-annual-refresh.md)
+Annual NSPRA publication replacement, protected-source handling, repository
+configuration, retrieval validation, and prior-edition retirement.
+
 #### [operations/production-migration-checklist.md](./operations/production-migration-checklist.md)
 Comprehensive checklist for deploying to production.
 
@@ -182,6 +186,8 @@ AI integration patterns using Vercel AI SDK v6, provider factory implementation,
 **[Unified repository product integration](./features/unified-repository-product-integration.md)** — Authoritative Repository Manager source/ACL/version UI, Assistant Architect repository-only knowledge, Nexus private ephemeral attachments, promotion, retention, and rollback boundaries.
 
 **[Unified content agents and Projects](./features/unified-content-agents-and-projects.md)** — Repository catalog MCP/REST scopes, per-user OpenClaw PKCE OAuth, live skill repository bindings, and durable Nexus Project membership/repository/chat boundaries.
+
+**[PSD Observances agent skill](./features/psd-observances.md)** — Cited, bounded NSPRA calendar lookups, coverage limits, repository resolution, authorization behavior, and operational ownership.
 
 **[Google Workspace content synchronization](./features/google-workspace-content-sync.md)** — PKCE OAuth and Picker selection across My Drive and user-accessible Shared Drives, durable cursor/version reconciliation, deployment-owned configuration, deletion grace, and operations.
 

--- a/docs/features/psd-observances.md
+++ b/docs/features/psd-observances.md
@@ -1,0 +1,101 @@
+# PSD Observances Agent Skill
+
+`psd-observances` answers date-oriented questions from NSPRA's
+*Resources for Planning the School Calendar, 2026-2027* without putting the
+124-page publication into model context. The skill queries a staff-authorized
+AI Studio knowledge repository through the existing repository MCP tools and
+returns small, cited result sets.
+
+The publication is a copyrighted, members-only source. Neither the PDF nor its
+extracted prose belongs in this public repository. AI Studio stores the source
+outside Git in the normal knowledge-repository data path.
+
+## Coverage and accuracy
+
+- Ordinary observance, awareness-month, state-holiday, and conference lookups
+  cover **January 2026 through June 2027**.
+- The six-year major-holiday summary is the only surface that continues
+  through **2031**.
+- The source data was verified as of **November 2025**.
+- Part II is not an official or legal listing of each state's holidays. Treat
+  state results as planning information and verify legal questions against an
+  authoritative state source.
+- Questions outside the applicable range must be refused rather than guessed.
+
+Every result includes the printed page from `sourceLocator.page`. Preserve that
+citation when answering so staff can verify the result against their authorized
+copy.
+
+## Command surface
+
+The runnable skill lives at
+[`infra/agent-image/skills/psd-observances/`](../../infra/agent-image/skills/psd-observances/).
+
+| Command | Purpose |
+|---|---|
+| `lookup <name>` | Find a named observance and its date information |
+| `search <terms> [--any]` | Search the whole publication with ranked hybrid retrieval; `--any` uses OR semantics |
+| `month <YYYY-MM>` | Find observances in a covered month |
+| `on --date <YYYY-MM-DD>` | Find entries associated with a covered date |
+| `state <name> [--section legal\|school]` | Find a state's legal-holiday and/or school-holiday sections |
+| `conferences [--year N] [--org <text>]` | Find education-organization meetings |
+| `holiday-years <name>` | Find a major holiday in the 2026–2031 summary |
+
+Examples and agent-facing invocation guidance are maintained in the
+skill's [`SKILL.md`](../../infra/agent-image/skills/psd-observances/SKILL.md).
+
+## Output bounds
+
+The skill intentionally limits what enters agent context:
+
+- Default output contains no more than five results.
+- Default excerpts are limited to about 300 characters per result.
+- `--limit N` accepts 1–50 results. An unfiltered `state` request needs at
+  least two result slots so both legal and school sections can be represented.
+- `--full` expands excerpts but still enforces a total-output bound.
+- `--json` emits one machine-readable object and omits the text truncation
+  banner.
+
+Use the default form first. Expand a result only when the bounded excerpt does
+not answer the question; do not use the skill to reconstruct the publication.
+
+## Repository resolution
+
+Each invocation calls `repositories_list` and selects an accessible repository
+whose name contains **"NSPRA"**, case-insensitively. The skill never stores an
+environment-specific repository ID.
+
+If several repositories match, it prefers a name that also contains
+**"2026"**, then the lowest numeric repository ID, and reports which repository
+it selected. If none match, it explains that the NSPRA repository is not
+available to the caller's account.
+
+The repository must be a normal user-managed repository. Retrieval excludes
+repositories whose metadata marks them `systemManaged`. It must also remain
+staff-restricted and not public because the source is copyrighted.
+
+## Authorization behavior
+
+The agent broker resolves credentials in this order:
+
+1. the caller's AI Studio OAuth token;
+2. the caller's personal `sk-` key, when configured;
+3. the shared platform key.
+
+The shared key has only `platform:read`; it cannot search knowledge
+repositories. Normal use therefore relies on the caller's OAuth grant, or on a
+personal key with the required repository access. Repository ACLs still apply
+to every request.
+
+An unauthorized or insufficient-scope response exits with code `11` and tells
+the caller to connect AI Studio access. If AI Studio is already connected,
+reconnect it so the current repository scopes are authorized. Upstream MCP
+failures use code `12`, and rate limits use code `14`.
+
+## Operations
+
+Repository contents and edition changes are operational data, not source-code
+changes. Follow the
+[annual NSPRA refresh runbook](../operations/psd-observances-annual-refresh.md)
+when replacing the publication, changing its coverage window, validating
+retrieval, or retiring the prior edition.

--- a/docs/features/psd-observances.md
+++ b/docs/features/psd-observances.md
@@ -12,8 +12,8 @@ outside Git in the normal knowledge-repository data path.
 
 ## Coverage and accuracy
 
-- Ordinary observance, awareness-month, state-holiday, and conference lookups
-  cover **January 2026 through June 2027**.
+- Ordinary observance, state-holiday, and conference lookups cover **January
+  2026 through June 2027**.
 - The six-year major-holiday summary is the only surface that continues
   through **2031**.
 - The source data was verified as of **November 2025**.

--- a/docs/operations/psd-observances-annual-refresh.md
+++ b/docs/operations/psd-observances-annual-refresh.md
@@ -1,0 +1,198 @@
+# PSD Observances Annual NSPRA Refresh
+
+This runbook replaces the publication behind the `psd-observances` agent skill
+without copying copyrighted NSPRA content into Git. Run it separately for dev
+and production, retain evidence for each environment, and do not retire the
+previous edition until the replacement passes retrieval evaluation.
+
+See the [feature guide](../features/psd-observances.md) for the skill's command,
+authorization, citation, and output contracts.
+
+## Safety contract
+
+- The NSPRA publication is a copyrighted, members-only product. Never commit
+  the PDF, generated markdown, extracted text, screenshots, or prose fixtures.
+- Test and evaluation fixtures may contain observance names and dates as facts,
+  but not the publication's comments or other prose.
+- Do not make the repository public or student-accessible.
+- Do not reuse identifiers across environments; the skill resolves the
+  repository by name.
+- Do not reset a shared database to recover an upload or cleanup failure.
+
+For each target environment, record the edition, repository ID and name,
+operator, upload time, item status, rollout-setting values, evaluation result,
+and retirement decision in the normal operational change record.
+
+## 1. Obtain the new edition
+
+Purchase or obtain the new annual publication through the district's authorized
+NSPRA membership. Confirm the edition and its ordinary coverage window, plus
+the final year represented by its multi-year holiday summary.
+
+Keep the source in approved operator storage only. Do not place it in this
+checkout, a temporary directory under the repository, a pull-request
+attachment, or an issue comment.
+
+## 2. Protect the source from Git
+
+Before extraction, testing, or upload, confirm that the working method keeps
+both source and derivative content outside the repository. If offline tooling
+is needed, use an operator-controlled directory that is not beneath any Git
+worktree.
+
+Before completing the refresh, run:
+
+```bash
+git status --short -- '*.pdf'
+git diff --name-only --diff-filter=A origin/dev...HEAD -- '*.pdf'
+```
+
+Neither command may show a newly added NSPRA/source PDF. The repository contains
+unrelated, intentionally tracked PDF assets, so do not use a blanket
+"no PDFs anywhere" assertion. Review the refresh PR separately for copied NSPRA
+prose; a clean PDF check alone does not detect extracted text.
+
+## 3. Confirm content-platform settings
+
+In the target environment's settings administration path, confirm all three
+settings are `true`:
+
+- `CONTENT_PLATFORM_ENABLED`
+- `CONTENT_READ_V2_ENABLED`
+- `CONTENT_REPOSITORY_CUTOVER_ENABLED`
+
+These settings default to `false` and are independent per environment. The
+canonical upload path is active only when all three are enabled. Record their
+values before uploading.
+
+If they are not all enabled, stop and complete the normal reviewed rollout
+procedure. Do not upload and hope processing catches up later. A known symptom
+of a disabled canonical path is an item remaining `pending` with no
+`registerCanonicalUpload` activity.
+
+## 4. Create or verify the repository
+
+Use Repository Manager to create a new repository or inspect the repository
+that will receive the edition. It must satisfy every condition below:
+
+- it is a normal user-managed repository, never `systemManaged`;
+- its name contains **"NSPRA"**, case-insensitively;
+- staff-role access is granted;
+- public access is disabled; and
+- intended staff can see it with their own AI Studio identity.
+
+Retrieval deliberately excludes `systemManaged` repositories. The name
+substring is also part of the runtime contract: repository IDs differ between
+dev and production and must never be copied into the skill.
+
+If more than one accessible repository contains "NSPRA", remember that the
+skill prefers a name containing "2026", then the lowest numeric ID. Rename or
+retire ambiguous repositories deliberately rather than relying on an
+accidental selection.
+
+For the cleanest rollback boundary, create a replacement repository and leave
+the prior repository intact until the new items are active. Immediately before
+testing the replacement, rename the prior repository so its name no longer
+contains "NSPRA"; record both names so the change can be reversed. This matters
+for later editions because an older name containing "2026" otherwise wins the
+skill's current selection rule. If the existing repository is reused instead,
+remove its prior-edition items from retrieval before evaluation so old and new
+dates cannot be mixed.
+
+## 5. Upload and verify processing
+
+Upload the new publication through Repository Manager. Do not add repository
+write access to the agent and do not add a new broker route or MCP tool for this
+operation.
+
+Wait until every new item is `active` before testing or promotion. Record the
+item count and final status, and inspect failures through the normal canonical
+content processing telemetry. Stop on any pending, failed, or partially
+processed item; do not treat partial retrieval as a successful refresh.
+
+Apply the repository-name cutover from step 4, then run a skill lookup. Each
+invocation calls `repositories_list` and reports the selected repository;
+record that selection before scoring any lookup. If the replacement is not
+selected, stop and correct the names rather than accepting results from the
+prior edition.
+
+Run representative staff-authenticated lookups and confirm:
+
+- the expected repository was selected;
+- results include printed-page citations;
+- default output remains bounded; and
+- an account without repository access receives the connect/reconnect hint
+  instead of source data.
+
+## 6. Update the documented coverage window
+
+Update the coverage and accuracy section in
+[`SKILL.md`](../../infra/agent-image/skills/psd-observances/SKILL.md) and the
+[feature guide](../features/psd-observances.md) to match the new edition.
+Update both the ordinary date window and the multi-year-summary end year.
+
+Review every example date and evaluation fixture for the new range. Facts such
+as names and dates are permitted; remove or replace any fixture that contains
+source prose. Keep the `summary` frontmatter and calendar-oriented trigger
+phrasing intact so skill discovery continues to work.
+
+## 7. Re-run the retrieval evaluation
+
+Run the committed `psd-observances` retrieval evaluation against the real
+repository in the target environment, not mocks. The evaluation gate is
+tracked in [#1477](https://github.com/psd401/aistudio/issues/1477); if its
+runnable harness is not yet available, the refresh cannot pass this step.
+
+Verify expected answers against the authorized printed source, then record:
+
+- named-lookup accuracy;
+- enumeration recall;
+- citation correctness; and
+- any `needsOcrPages` entries or spurious OCR results.
+
+The current decision gate requires at least 90% Class A named-lookup accuracy
+and at least 80% Class B enumeration recall. A Class A result below 90% requires
+investigation before promotion. Class B recall below 80% requires the
+structured-markdown decision described in
+[#1478](https://github.com/psd401/aistudio/issues/1478); generated content must
+still remain outside Git.
+
+Repeat the evaluation in dev and production. Do not infer production success
+from a dev result because flags, repository IDs, ACLs, and ingested items are
+environment-specific.
+
+## 8. Retire the prior edition
+
+Keep the old edition available until the replacement is active, the skill and
+feature guide describe the new range, and the target environment passes the
+retrieval gate. A prior repository renamed in step 4 remains the rollback copy
+until this point. Then remove the prior items or repository through Repository
+Manager and confirm the replacement still resolves by the "NSPRA" name rule.
+
+Cleanup caveat: [#1474](https://github.com/psd401/aistudio/issues/1474)
+documented a failure when deleting `pending` items because migration 010 did
+not allow the `cancelled` processing status. The fix landed in migration
+`168-repository-item-cancelled-status.sql` through
+[PR #1481](https://github.com/psd401/aistudio/pull/1481). Before cleanup, verify
+that migration 168 is deployed in the target environment. Older deployments
+can still hit the original constraint failure.
+
+Even with the fix deployed, verify new and old uploads reach a terminal state
+before depending on cleanup. If retirement fails, preserve the old repository,
+capture identifiers and status without source text, and repair the target
+environment through the normal migration/deployment path.
+
+## Completion evidence
+
+The annual refresh is complete only when:
+
+- no source or derivative NSPRA content was committed;
+- all three content-platform settings were confirmed in both environments;
+- each selected repository is user-managed, staff-restricted, non-public, and
+  named with the required substring;
+- every replacement item is active;
+- skill and feature documentation match the new date range;
+- real-repository evaluation passed in dev and production with citations
+  recorded; and
+- retirement completed safely, or the retained prior edition and cleanup
+  blocker were explicitly recorded.

--- a/docs/operations/psd-observances-annual-refresh.md
+++ b/docs/operations/psd-observances-annual-refresh.md
@@ -121,12 +121,38 @@ Run representative staff-authenticated lookups and confirm:
 - the expected repository was selected;
 - results include printed-page citations;
 - default output remains bounded; and
-- an account without repository access receives the connect/reconnect hint
-  instead of source data.
+- an authenticated, correctly scoped account without this repository's ACL
+  receives the "NSPRA repository is not available" response instead of source
+  data; and
+- a caller with missing, expired, or insufficient repository scope receives
+  the connect/reconnect hint.
 
-## 6. Update the documented coverage window
+## 6. Update runtime and documented coverage
 
-Update the coverage and accuracy section in
+Update the executable coverage contract in
+[`run.js`](../../infra/agent-image/skills/psd-observances/run.js) before
+changing the documentation:
+
+- set `COVERAGE_START`, `COVERAGE_END`, `ACCURACY_NOTICE`, and
+  `COVERAGE_NOTICE` for the new edition;
+- update ordinary free-form year/month/period validation, including any
+  hardcoded boundary year or partial-year rules;
+- update the accepted conference years and their error message; and
+- update the multi-year holiday bounds and the years placed into its search
+  query.
+
+Search the runtime for every old boundary year and verification date so an
+obsolete validator, notice, or query term cannot survive the refresh. Then
+update
+[`run.test.js`](../../infra/agent-image/skills/psd-observances/run.test.js) to
+prove the new first/last ordinary dates, refused out-of-range dates, accepted
+conference years, holiday-summary bounds/query, and coverage notices. Run:
+
+```bash
+bun run test:skill:psd-observances
+```
+
+Only after that contract passes, update the coverage and accuracy section in
 [`SKILL.md`](../../infra/agent-image/skills/psd-observances/SKILL.md) and the
 [feature guide](../features/psd-observances.md) to match the new edition.
 Update both the ordinary date window and the multi-year-summary end year.
@@ -191,7 +217,8 @@ The annual refresh is complete only when:
 - each selected repository is user-managed, staff-restricted, non-public, and
   named with the required substring;
 - every replacement item is active;
-- skill and feature documentation match the new date range;
+- runtime validation/query bounds, unit tests, `SKILL.md`, and feature
+  documentation all match the new date range;
 - real-repository evaluation passed in dev and production with citations
   recorded; and
 - retirement completed safely, or the retained prior edition and cleanup


### PR DESCRIPTION
## Summary

- document the psd-observances command surface, coverage, citations, bounded output, repository resolution, and authorization behavior
- add the eight-step annual NSPRA refresh runbook with copyright controls, per-environment flags, staff-only repository configuration, reversible edition cutover, evaluation thresholds, and retirement evidence
- index both documents in the main documentation catalog

## Source and privacy boundary

No NSPRA PDF, extracted source text, screenshots, or source-derived prose fixtures are included. OpenWiki was not edited.

## Risks and migrations

This is documentation-only and changes no runtime code, API, infrastructure, environment variables, or database schema. The runbook accurately notes that migration 168, already merged through PR #1481, must be deployed before relying on the #1474 pending-item deletion fix.

## Validation

- `bun run test:skill:psd-observances` — 40 passed, 0 failed
- `bun run lint` — passed
- `bun run typecheck` — passed
- CI-equivalent `bun run build` with the auth artifact environment — passed
- documentation acceptance, relative-link, trailing-whitespace, source-PDF, and OpenWiki guards — passed
- E2E not run because repository policy exempts docs-only changes

## Related issues

Closes #1479
Part of #1475