### PR TITLE
fix(agent-eval): preserve GPT OSS Mantle routes in L1

### DIFF
--- a/docs/learnings/testing/2026-07-30-eval-stubs-must-preserve-model-transport.md
+++ b/docs/learnings/testing/2026-07-30-eval-stubs-must-preserve-model-transport.md
@@ -21,14 +21,18 @@ A test double that replaces a process boundary must inventory every
 responsibility of that process, not only the dependency under test. Preserve
 the production model transport with an exact method/path allowlist, exact AWS
 origin validation, configured-model validation, root-held authorization, and
-active invocation authority. Keep model bodies out of fixture captures.
+active invocation authority. Preserve compatibility rewrites on model request
+history, and keep read-only model discovery available before a trial opens so
+client startup matches production. Keep model bodies out of fixture captures.
 
 Verify this boundary at two levels:
 
 1. A hermetic relay test sends an OpenAI-compatible request containing an
    assistant `tool_calls` entry and its matching `tool` result, then asserts
-   the JSON shape is forwarded unchanged and model-supplied authorization is
-   replaced.
+   ordinary JSON shape is forwarded unchanged, production compatibility
+   rewrites repair known provider-specific history, and model-supplied
+   authorization is replaced. A separate pre-trial test proves read-only model
+   discovery does not require paid-call invocation authority.
 2. A small live L1 suite exercises multiple broker routes before spending on a
    full comparison run.
 

--- a/docs/learnings/testing/2026-07-30-eval-stubs-must-preserve-model-transport.md
+++ b/docs/learnings/testing/2026-07-30-eval-stubs-must-preserve-model-transport.md
@@ -1,0 +1,39 @@
+# Eval stubs must preserve model transport
+
+## Symptom
+
+The GPT OSS 120B candidate reported `OpenClawChatError` in 95 of 150 trials,
+concentrated in L1 tasks that use fixture-backed tools. The surfaced message
+looked like a provider model-ID failure.
+
+## Root cause
+
+The L1 runner bind-mounted `eval/broker_stub.py` over
+`/app/mantle_proxy.py`. Direct-Mantle candidates use that same root-owned
+loopback process for model inference. The fixture stub preserved broker and
+summarization routes but not `/candidate-mantle/*`, so every L1 model request
+ended locally with `404 EvalUnsupportedPath`. OpenClaw translated that response
+into its generic model-not-found error; no request reached Bedrock.
+
+## Durable rule
+
+A test double that replaces a process boundary must inventory every
+responsibility of that process, not only the dependency under test. Preserve
+the production model transport with an exact method/path allowlist, exact AWS
+origin validation, configured-model validation, root-held authorization, and
+active invocation authority. Keep model bodies out of fixture captures.
+
+Verify this boundary at two levels:
+
+1. A hermetic relay test sends an OpenAI-compatible request containing an
+   assistant `tool_calls` entry and its matching `tool` result, then asserts
+   the JSON shape is forwarded unchanged and model-supplied authorization is
+   replaced.
+2. A small live L1 suite exercises multiple broker routes before spending on a
+   full comparison run.
+
+The expected upstream remains the Bedrock Mantle Chat Completions endpoint,
+whose documented GPT OSS model ID is `openai.gpt-oss-120b`:
+
+- <https://docs.aws.amazon.com/bedrock/latest/userguide/inference-chat-completions-mantle.html>
+- <https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-openai-gpt-oss-120b.html>

--- a/docs/learnings/testing/2026-07-30-eval-stubs-must-preserve-model-transport.md
+++ b/docs/learnings/testing/2026-07-30-eval-stubs-must-preserve-model-transport.md
@@ -36,6 +36,11 @@ Verify this boundary at two levels:
 2. A small live L1 suite exercises multiple broker routes before spending on a
    full comparison run.
 
+When an output grader checks a human-rendered identifier, accept Unicode
+hyphen and whitespace variants while keeping the broker-request grader exact.
+The broker assertion proves the machine-facing query and operation; typography
+must not turn an otherwise correct tool round trip into a false negative.
+
 The expected upstream remains the Bedrock Mantle Chat Completions endpoint,
 whose documented GPT OSS model ID is `openai.gpt-oss-120b`:
 

--- a/infra/agent-image/eval/README.md
+++ b/infra/agent-image/eval/README.md
@@ -23,7 +23,7 @@ python3 infra/agent-image/eval/runner.py \
 
 Use `eval/suites/capability.yaml` for the harder daily-driver comparison set.
 Use `eval/suites/tool-heavy-smoke.yaml` for a fast L1 check across credentials,
-AI Studio, and GitHub broker routes before spending on a full candidate run.
+AI Studio, and workflow broker routes before spending on a full candidate run.
 Passing `--agent-runtime-id` mirrors only the allowlisted, non-secret deployment
 fields required by L2 skills (currently HyperFrames and the optional summarize
 model override); it never copies the runtime's complete environment.

--- a/infra/agent-image/eval/README.md
+++ b/infra/agent-image/eval/README.md
@@ -299,16 +299,19 @@ also use this loopback process for model inference. The stub preserves only the
 production relay's exact provider operations, validated AWS origin, and
 configured model ID; it replaces the model-facing authorization header with
 the root-held bearer token and requires active invocation authority for paid
-calls. Model request and response bodies are never written to the fixture
-capture. It also preserves the fixed `/anthropic/v1/messages` loopback endpoint
-used by `psd-summarize`, relaying only that model path to the trusted web tier
-with root-held invocation authority. Finalization drains already-active broker,
-candidate-model, and summarization requests and rejects new work before
-acknowledging the boundary. The wrapper's end transition leaves the stub closed
-through runner capture collection; installing the next trial uses a separate
-root-only token to reopen it, so delayed work cannot spill across trials. L0
-and L2 tasks retain the image's real proxy; pure live and stubbed tasks use
-separate containers.
+calls. Read-only model discovery remains available while the eval trial gate is
+closed so clients can finish startup before the runner opens the first trial.
+The OpenAI-compatible relay also applies the production Kimi tool-call ID
+repair before forwarding tool history. Model request and response bodies are
+never written to the fixture capture. It also preserves the fixed
+`/anthropic/v1/messages` loopback endpoint used by `psd-summarize`, relaying
+only that model path to the trusted web tier with root-held invocation
+authority. Finalization drains already-active broker, candidate-model, and
+summarization requests and rejects new work before acknowledging the boundary.
+The wrapper's end transition leaves the stub closed through runner capture
+collection; installing the next trial uses a separate root-only token to reopen
+it, so delayed work cannot spill across trials. L0 and L2 tasks retain the
+image's real proxy; pure live and stubbed tasks use separate containers.
 
 ## Task and suite files
 

--- a/infra/agent-image/eval/README.md
+++ b/infra/agent-image/eval/README.md
@@ -22,6 +22,8 @@ python3 infra/agent-image/eval/runner.py \
 ```
 
 Use `eval/suites/capability.yaml` for the harder daily-driver comparison set.
+Use `eval/suites/tool-heavy-smoke.yaml` for a fast L1 check across credentials,
+AI Studio, and GitHub broker routes before spending on a full candidate run.
 Passing `--agent-runtime-id` mirrors only the allowlisted, non-secret deployment
 fields required by L2 skills (currently HyperFrames and the optional summarize
 model override); it never copies the runtime's complete environment.
@@ -290,17 +292,23 @@ modified. A root-owned `0700` in-container tmpfs carries only the active trial's
 fixtures and `0600` request capture; the runner installs and collects that state
 through root-only Docker execs, so the image's `node` user cannot read fixtures
 or forge grader inputs even when its numeric UID matches the host runner. The
-stub implements the same 16 fixed `/api/agent/*` routes as `agent-broker.js` and
-`mantle_proxy.py`, plus the health, usage, and finalization endpoints the wrapper
-needs. It also preserves the fixed `/anthropic/v1/messages` loopback endpoint
+stub implements the same 16 fixed `/api/agent/*` routes as `agent-broker.js`
+and `mantle_proxy.py`, plus the health, usage, and finalization endpoints the
+wrapper needs. Candidate images configured for a direct Bedrock Mantle model
+also use this loopback process for model inference. The stub preserves only the
+production relay's exact provider operations, validated AWS origin, and
+configured model ID; it replaces the model-facing authorization header with
+the root-held bearer token and requires active invocation authority for paid
+calls. Model request and response bodies are never written to the fixture
+capture. It also preserves the fixed `/anthropic/v1/messages` loopback endpoint
 used by `psd-summarize`, relaying only that model path to the trusted web tier
-with root-held invocation authority. Finalization drains already-active broker
-and summarization requests and rejects new work before acknowledging the
-boundary. The wrapper's end transition leaves the stub closed through runner
-capture collection; installing the next trial uses a separate root-only token
-to reopen it, so delayed work cannot spill across trials. L0 and L2 tasks
-retain the image's real proxy; pure live and stubbed tasks use separate
-containers.
+with root-held invocation authority. Finalization drains already-active broker,
+candidate-model, and summarization requests and rejects new work before
+acknowledging the boundary. The wrapper's end transition leaves the stub closed
+through runner capture collection; installing the next trial uses a separate
+root-only token to reopen it, so delayed work cannot spill across trials. L0
+and L2 tasks retain the image's real proxy; pure live and stubbed tasks use
+separate containers.
 
 ## Task and suite files
 

--- a/infra/agent-image/eval/broker_stub.py
+++ b/infra/agent-image/eval/broker_stub.py
@@ -60,6 +60,9 @@ CANDIDATE_MANTLE_OPERATIONS = {
 CANDIDATE_MANTLE_HOST_RE = re.compile(
     r"bedrock-mantle\.[a-z0-9-]+\.api\.aws"
 )
+# Keep this request repair identical to the production proxy. OpenClaw strips
+# the separators from Kimi's native tool-call IDs when it replays history.
+_STRIPPED_TC_ID = re.compile(r"^functions([a-z][a-z0-9_]*?)(\d+)$")
 CONTROL_DIRECTORY_ENV = "AGENT_EVAL_BROKER_CONTROL_DIR"
 DEFAULT_CONTROL_DIRECTORY = "/run/psd-agent-eval-broker"
 DEFAULT_WORKSPACE_FLUSH_TOKEN_PATH = (
@@ -198,6 +201,48 @@ def _resolve_candidate_mantle_request(
             "candidate Mantle request model does not match"
         )
     return f"{base_url}/{relative_path}"
+
+
+def _restore_tool_call_id(raw: str) -> str:
+    """Rewrite `functionsexec0` → `functions.exec:0`. Untouched if already
+    contains `.` or `:` (already in native format), or if it doesn't match
+    the OpenClaw-stripped shape."""
+    if not isinstance(raw, str):
+        return raw
+    if "." in raw or ":" in raw:
+        return raw
+    m = _STRIPPED_TC_ID.match(raw)
+    if not m:
+        return raw
+    return f"functions.{m.group(1)}:{m.group(2)}"
+
+
+def repair_tool_call_ids(payload: dict) -> int:
+    """Walk the messages array, restore tool_call ids and tool_call_id
+    references to Kimi's native format. Returns count of fields rewritten."""
+    rewrites = 0
+    messages = payload.get("messages")
+    if not isinstance(messages, list):
+        return 0
+    for msg in messages:
+        if not isinstance(msg, dict):
+            continue
+        tcs = msg.get("tool_calls")
+        if isinstance(tcs, list):
+            for tc in tcs:
+                if not isinstance(tc, dict):
+                    continue
+                old_id = tc.get("id")
+                new_id = _restore_tool_call_id(old_id)
+                if new_id != old_id:
+                    tc["id"] = new_id
+                    rewrites += 1
+        ref = msg.get("tool_call_id")
+        new_ref = _restore_tool_call_id(ref)
+        if new_ref != ref:
+            msg["tool_call_id"] = new_ref
+            rewrites += 1
+    return rewrites
 
 
 def _trusted_app_base_url(value: str) -> bool:
@@ -717,7 +762,17 @@ class BrokerStubState:
                     "invocation authority is unavailable"
                 ) from error
 
-        _, _, bearer_token, model_id = self.candidate_mantle_configuration
+        provider_api, _, bearer_token, model_id = (
+            self.candidate_mantle_configuration
+        )
+        forwarded_body = body
+        if provider_api == "openai-completions" and body is not None:
+            payload = json.loads(body)
+            if isinstance(payload, dict) and repair_tool_call_ids(payload):
+                forwarded_body = json.dumps(
+                    payload,
+                    ensure_ascii=False,
+                ).encode("utf-8")
         excluded_headers = {
             "accept-encoding",
             "authorization",
@@ -741,7 +796,7 @@ class BrokerStubState:
         headers["Authorization"] = f"Bearer {bearer_token}"
         request = urllib_request.Request(
             upstream,
-            data=body if method != "GET" else None,
+            data=forwarded_body if method != "GET" else None,
             method=method,
             headers=headers,
         )
@@ -779,10 +834,11 @@ class BrokerStubState:
         self,
         *,
         final_flush: bool = False,
+        allow_closed: bool = False,
     ) -> tuple[bool, str]:
         with self._finalization_condition:
             state = self._finalization_state
-            if state in {"draining", "closed"}:
+            if state == "draining" or (state == "closed" and not allow_closed):
                 return False, state
             if state == "flushing" and not final_flush:
                 return False, state
@@ -1193,7 +1249,13 @@ class BrokerStubRequestHandler(BaseHTTPRequestHandler):
         if self._handle_control(path):
             return
         if path.startswith(f"/{CANDIDATE_MANTLE_PREFIX}/"):
-            entered, _ = self.server.state.enter_request()
+            candidate_discovery = (
+                self.command == "GET"
+                and path == f"/{CANDIDATE_MANTLE_PREFIX}/models"
+            )
+            entered, _ = self.server.state.enter_request(
+                allow_closed=candidate_discovery
+            )
             if not entered:
                 self._send_json(
                     HTTPStatus.SERVICE_UNAVAILABLE,

--- a/infra/agent-image/eval/broker_stub.py
+++ b/infra/agent-image/eval/broker_stub.py
@@ -4,7 +4,10 @@
 The eval runner bind-mounts this file over ``/app/mantle_proxy.py`` in L1
 candidate containers. The existing wrapper therefore starts it on
 127.0.0.1:18791 without modifying the image. Trial fixtures and captures move
-through a root-owned in-container tmpfs.
+through a root-owned in-container tmpfs. Mantle candidates also use that same
+root-owned process for model inference, so the stub preserves the production
+relay's exact, allowlisted model routes instead of intercepting them as fixture
+traffic.
 """
 
 from __future__ import annotations
@@ -16,6 +19,7 @@ import hmac
 import json
 import logging
 import os
+import re
 import secrets
 import sys
 import threading
@@ -32,6 +36,30 @@ from urllib.parse import urlsplit
 
 
 LOGGER = logging.getLogger("agent_eval_broker_stub")
+CANDIDATE_MANTLE_API = os.environ.pop("CANDIDATE_MANTLE_API", "").strip()
+CANDIDATE_MANTLE_BASE_URL = os.environ.pop(
+    "CANDIDATE_MANTLE_BASE_URL", ""
+).strip()
+CANDIDATE_MANTLE_BEARER_TOKEN = os.environ.pop(
+    "CANDIDATE_MANTLE_BEARER_TOKEN", ""
+).strip()
+CANDIDATE_MANTLE_MODEL_ID = os.environ.pop(
+    "CANDIDATE_MANTLE_MODEL_ID", ""
+).strip()
+CANDIDATE_MANTLE_PREFIX = "candidate-mantle"
+CANDIDATE_MANTLE_OPERATIONS = {
+    "openai-completions": (
+        frozenset({("GET", "models"), ("POST", "chat/completions")}),
+        "/v1",
+    ),
+    "anthropic-messages": (
+        frozenset({("POST", "v1/messages")}),
+        "/anthropic",
+    ),
+}
+CANDIDATE_MANTLE_HOST_RE = re.compile(
+    r"bedrock-mantle\.[a-z0-9-]+\.api\.aws"
+)
 CONTROL_DIRECTORY_ENV = "AGENT_EVAL_BROKER_CONTROL_DIR"
 DEFAULT_CONTROL_DIRECTORY = "/run/psd-agent-eval-broker"
 DEFAULT_WORKSPACE_FLUSH_TOKEN_PATH = (
@@ -84,6 +112,92 @@ ALLOWED_AGENT_BROKER_ROUTES = frozenset(
 
 class BrokerStubConfigurationError(RuntimeError):
     """The runner supplied an invalid or unreadable trial fixture."""
+
+
+class CandidateMantleAuthorityUnavailable(BrokerStubConfigurationError):
+    """A paid candidate inference arrived outside an authorized trial."""
+
+
+def _candidate_mantle_configuration() -> tuple[str, str, str, str] | None:
+    """Validate the root-only direct-Mantle relay environment."""
+
+    values = (
+        CANDIDATE_MANTLE_API,
+        CANDIDATE_MANTLE_BASE_URL,
+        CANDIDATE_MANTLE_BEARER_TOKEN,
+        CANDIDATE_MANTLE_MODEL_ID,
+    )
+    if not any(values):
+        return None
+    if (
+        not all(values)
+        or CANDIDATE_MANTLE_API not in CANDIDATE_MANTLE_OPERATIONS
+    ):
+        raise BrokerStubConfigurationError(
+            "candidate Mantle relay configuration is incomplete"
+        )
+    _, expected_base_path = CANDIDATE_MANTLE_OPERATIONS[
+        CANDIDATE_MANTLE_API
+    ]
+    parsed = urlsplit(CANDIDATE_MANTLE_BASE_URL)
+    try:
+        port = parsed.port
+    except ValueError as error:
+        raise BrokerStubConfigurationError(
+            "candidate Mantle base URL has an invalid port"
+        ) from error
+    if (
+        parsed.scheme != "https"
+        or parsed.hostname is None
+        or not CANDIDATE_MANTLE_HOST_RE.fullmatch(parsed.hostname)
+        or parsed.username is not None
+        or parsed.password is not None
+        or port is not None
+        or parsed.path != expected_base_path
+        or parsed.query
+        or parsed.fragment
+    ):
+        raise BrokerStubConfigurationError(
+            "candidate Mantle base URL is not an exact AWS endpoint"
+        )
+    return values
+
+
+def _resolve_candidate_mantle_request(
+    method: str,
+    path: str,
+    body: bytes | None,
+    configuration: tuple[str, str, str, str] | None,
+) -> str | None:
+    """Map one fixed model operation to the configured AWS endpoint."""
+
+    prefix = f"/{CANDIDATE_MANTLE_PREFIX}/"
+    if not path.startswith(prefix):
+        return None
+    if configuration is None:
+        raise BrokerStubConfigurationError(
+            "candidate Mantle relay is disabled"
+        )
+    provider_api, base_url, _, model_id = configuration
+    allowed_operations, _ = CANDIDATE_MANTLE_OPERATIONS[provider_api]
+    relative_path = path[len(prefix) :]
+    if (method, relative_path) not in allowed_operations:
+        raise BrokerStubConfigurationError(
+            "unsupported candidate Mantle operation"
+        )
+    if method == "GET":
+        return f"{base_url}/{relative_path}"
+    try:
+        payload = json.loads(body) if body else None
+    except (TypeError, ValueError) as error:
+        raise BrokerStubConfigurationError(
+            "candidate Mantle request must be JSON"
+        ) from error
+    if not isinstance(payload, Mapping) or payload.get("model") != model_id:
+        raise BrokerStubConfigurationError(
+            "candidate Mantle request model does not match"
+        )
+    return f"{base_url}/{relative_path}"
 
 
 def _trusted_app_base_url(value: str) -> bool:
@@ -418,6 +532,9 @@ class BrokerStubState:
                 "APP_BASE_URL is not a trusted model broker URL"
             )
         self.model_upstream_base_url = configured_upstream
+        self.candidate_mantle_configuration = (
+            _candidate_mantle_configuration()
+        )
         self._runner_control_token = _ensure_runner_control_token(
             control_directory
         )
@@ -554,6 +671,99 @@ class BrokerStubState:
                 raise BrokerStubConfigurationError(
                     "model broker response exceeds eval stub limit"
                 )
+            return (
+                response.status,
+                response.headers.get(
+                    "Content-Type",
+                    "application/octet-stream",
+                ),
+                response_body,
+            )
+        finally:
+            response.close()
+
+    def forward_candidate_mantle_request(
+        self,
+        method: str,
+        path: str,
+        body: bytes | None,
+        request_headers: Mapping[str, str],
+    ) -> tuple[int, str, bytes]:
+        """Preserve the production candidate relay while L1 fixtures are active.
+
+        Candidate model traffic is deliberately never written to the fixture
+        capture. It can contain prompts and tool arguments, while eval records
+        retain only the resulting pass/fail and operational metadata.
+        """
+
+        upstream = _resolve_candidate_mantle_request(
+            method,
+            path,
+            body,
+            self.candidate_mantle_configuration,
+        )
+        if upstream is None or self.candidate_mantle_configuration is None:
+            raise BrokerStubConfigurationError(
+                "candidate Mantle relay is unavailable"
+            )
+        if method != "GET":
+            try:
+                _read_invocation_authority(
+                    self.invocation_context_path,
+                    self.request_proof_key_path,
+                )
+            except (OSError, ValueError) as error:
+                raise CandidateMantleAuthorityUnavailable(
+                    "invocation authority is unavailable"
+                ) from error
+
+        _, _, bearer_token, model_id = self.candidate_mantle_configuration
+        excluded_headers = {
+            "accept-encoding",
+            "authorization",
+            "connection",
+            "content-length",
+            "host",
+            "transfer-encoding",
+            "x-api-key",
+            "x-agent-invocation-context",
+            "x-agent-request-proof-version",
+            "x-agent-request-proof-timestamp",
+            "x-agent-request-proof-nonce",
+            "x-agent-request-proof-body-sha256",
+            "x-agent-request-proof-signature",
+        }
+        headers = {
+            key: value
+            for key, value in request_headers.items()
+            if key.lower() not in excluded_headers
+        }
+        headers["Authorization"] = f"Bearer {bearer_token}"
+        request = urllib_request.Request(
+            upstream,
+            data=body if method != "GET" else None,
+            method=method,
+            headers=headers,
+        )
+        opener = urllib_request.build_opener(_NoRedirectHandler())
+        try:
+            response = opener.open(request, timeout=300)
+        except urllib_error.HTTPError as error:
+            response = error
+        try:
+            response_body = response.read(MAX_MODEL_RESPONSE_BYTES + 1)
+            if len(response_body) > MAX_MODEL_RESPONSE_BYTES:
+                raise BrokerStubConfigurationError(
+                    "candidate Mantle response exceeds eval stub limit"
+                )
+            LOGGER.info(
+                "candidate Mantle relay method=%s path=%s model=%s status=%d bytes=%d",
+                method,
+                path,
+                model_id,
+                response.status,
+                len(response_body),
+            )
             return (
                 response.status,
                 response.headers.get(
@@ -917,6 +1127,45 @@ class BrokerStubRequestHandler(BaseHTTPRequestHandler):
                 },
             )
 
+    def _handle_candidate_mantle(self, path: str) -> None:
+        try:
+            body: bytes | None = None
+            if self.command != "GET":
+                body, _ = self._read_body()
+            status, content_type, response_body = (
+                self.server.state.forward_candidate_mantle_request(
+                    self.command,
+                    path,
+                    body,
+                    {
+                        key: value
+                        for key, value in self.headers.items()
+                    },
+                )
+            )
+            self._send_body(status, response_body, content_type)
+        except CandidateMantleAuthorityUnavailable:
+            self._send_json(
+                HTTPStatus.SERVICE_UNAVAILABLE,
+                {"error": "Invocation authority is unavailable"},
+            )
+        except BrokerStubConfigurationError as error:
+            self._send_json(
+                HTTPStatus.NOT_FOUND,
+                {
+                    "error": "EvalUnsupportedCandidateModelOperation",
+                    "message": str(error),
+                },
+            )
+        except (OSError, urllib_error.URLError) as error:
+            self._send_json(
+                HTTPStatus.BAD_GATEWAY,
+                {
+                    "error": "EvalCandidateModelRelayUnavailable",
+                    "message": str(error),
+                },
+            )
+
     def _capture_finalization_rejection(self, route: str) -> None:
         try:
             trial = self.server.state.load_trial()
@@ -942,6 +1191,19 @@ class BrokerStubRequestHandler(BaseHTTPRequestHandler):
     def _handle(self) -> None:
         path = urlsplit(self.path).path
         if self._handle_control(path):
+            return
+        if path.startswith(f"/{CANDIDATE_MANTLE_PREFIX}/"):
+            entered, _ = self.server.state.enter_request()
+            if not entered:
+                self._send_json(
+                    HTTPStatus.SERVICE_UNAVAILABLE,
+                    {"error": FINALIZING_ERROR},
+                )
+                return
+            try:
+                self._handle_candidate_mantle(path)
+            finally:
+                self.server.state.leave_request()
             return
         if path.startswith("/agent-broker/"):
             route = path[len("/agent-broker") :]

--- a/infra/agent-image/eval/suites/tool-heavy-smoke.yaml
+++ b/infra/agent-image/eval/suites/tool-heavy-smoke.yaml
@@ -2,4 +2,4 @@
 tasks:
   - ../../skills/psd-credentials/evals/check-capability.yaml
   - ../../skills/psd-aistudio/evals/repository-list.yaml
-  - ../../skills/psd-github/evals/view-issue-read-only.yaml
+  - ../../skills/psd-workflows/evals/list-roster.yaml

--- a/infra/agent-image/eval/suites/tool-heavy-smoke.yaml
+++ b/infra/agent-image/eval/suites/tool-heavy-smoke.yaml
@@ -1,0 +1,5 @@
+# Fast L1 smoke across three independent broker-backed tool paths.
+tasks:
+  - ../../skills/psd-credentials/evals/check-capability.yaml
+  - ../../skills/psd-aistudio/evals/repository-list.yaml
+  - ../../skills/psd-github/evals/view-issue-read-only.yaml

--- a/infra/agent-image/skills/psd-aistudio/evals/repository-list.yaml
+++ b/infra/agent-image/skills/psd-aistudio/evals/repository-list.yaml
@@ -9,4 +9,4 @@ fixtures:
   - fixtures/repository-list.json
 graders:
   - {"type":"broker_request","route":"/api/agent/aistudio","method":"POST","body":{"method":{"exact":"tools/call"},"params.name":{"exact":"repositories_list"},"params.arguments.query":{"exact":"EVAL-1426"}}}
-  - {"type":"output_match","pattern":"EVAL-1426 Canary Repository"}
+  - {"type":"output_match","pattern":"EVAL[-\u2010-\u2015]1426\\s+Canary\\s+Repository"}

--- a/infra/agent-image/test_broker_stub.py
+++ b/infra/agent-image/test_broker_stub.py
@@ -88,6 +88,27 @@ def _python_literal(path: Path, variable: str) -> object:
     raise AssertionError(f"{variable} was not found in {path}")
 
 
+def _python_assignment_ast(path: Path, variable: str) -> str:
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    for node in tree.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        if any(
+            isinstance(target, ast.Name) and target.id == variable
+            for target in node.targets
+        ):
+            return ast.dump(node.value, include_attributes=False)
+    raise AssertionError(f"{variable} was not found in {path}")
+
+
+def _python_function_ast(path: Path, function: str) -> str:
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    for node in tree.body:
+        if isinstance(node, ast.FunctionDef) and node.name == function:
+            return ast.dump(node, include_attributes=False)
+    raise AssertionError(f"{function} was not found in {path}")
+
+
 def _javascript_allowlist(path: Path) -> set[str]:
     source = path.read_text(encoding="utf-8")
     match = re.search(
@@ -242,6 +263,7 @@ class BrokerRouteParityTests(unittest.TestCase):
 
     def test_stub_matches_the_production_candidate_mantle_contract(self):
         proxy_path = AGENT_IMAGE_DIR / "mantle_proxy.py"
+        stub_path = AGENT_IMAGE_DIR / "eval" / "broker_stub.py"
 
         self.assertEqual(
             broker_stub.CANDIDATE_MANTLE_PREFIX,
@@ -251,6 +273,15 @@ class BrokerRouteParityTests(unittest.TestCase):
             broker_stub.CANDIDATE_MANTLE_OPERATIONS,
             _python_literal(proxy_path, "CANDIDATE_MANTLE_OPERATIONS"),
         )
+        self.assertEqual(
+            _python_assignment_ast(stub_path, "_STRIPPED_TC_ID"),
+            _python_assignment_ast(proxy_path, "_STRIPPED_TC_ID"),
+        )
+        for function in ("_restore_tool_call_id", "repair_tool_call_ids"):
+            self.assertEqual(
+                _python_function_ast(stub_path, function),
+                _python_function_ast(proxy_path, function),
+            )
 
 
 class BrokerControlStorageTests(unittest.TestCase):
@@ -329,14 +360,18 @@ class BrokerControlStorageTests(unittest.TestCase):
 
 
 class CandidateMantleRelayTests(unittest.TestCase):
-    def _environment(self) -> dict[str, str]:
+    def _environment(
+        self,
+        *,
+        model_id: str = "openai.gpt-oss-120b",
+    ) -> dict[str, str]:
         return {
             "CANDIDATE_MANTLE_API": "openai-completions",
             "CANDIDATE_MANTLE_BASE_URL": (
                 "https://bedrock-mantle.us-east-1.api.aws/v1"
             ),
             "CANDIDATE_MANTLE_BEARER_TOKEN": "root-only-token",
-            "CANDIDATE_MANTLE_MODEL_ID": "openai.gpt-oss-120b",
+            "CANDIDATE_MANTLE_MODEL_ID": model_id,
         }
 
     def test_configuration_rejects_a_lookalike_mantle_origin(self):
@@ -471,6 +506,150 @@ class CandidateMantleRelayTests(unittest.TestCase):
             "Bearer root-only-token",
         )
         self.assertEqual(received["timeout"], 300)
+        self.assertEqual(stub.captures(), [])
+
+    def test_candidate_relay_repairs_kimi_tool_call_history_like_production(
+        self,
+    ):
+        model_id = "moonshotai.kimi-k2.5"
+        stub = RunningStub(
+            candidate_mantle_environment=self._environment(
+                model_id=model_id
+            )
+        )
+        received: dict[str, object] = {}
+
+        class Response:
+            status = 200
+            headers = {"Content-Type": "application/json"}
+
+            def read(self, limit: int) -> bytes:
+                self.limit = limit
+                return b'{"choices":[]}'
+
+            def close(self) -> None:
+                return
+
+        class Opener:
+            def open(
+                self,
+                request: urllib.request.Request,
+                timeout: int,
+            ) -> Response:
+                received["body"] = request.data
+                return Response()
+
+        try:
+            stub.configure([])
+            with mock.patch.object(
+                broker_stub.urllib_request,
+                "build_opener",
+                return_value=Opener(),
+            ):
+                status, _ = stub.request(
+                    "/candidate-mantle/chat/completions",
+                    method="POST",
+                    body={
+                        "model": model_id,
+                        "messages": [
+                            {
+                                "role": "assistant",
+                                "tool_calls": [
+                                    {
+                                        "id": "functionsexec0",
+                                        "type": "function",
+                                        "function": {
+                                            "name": "exec",
+                                            "arguments": "{}",
+                                        },
+                                    }
+                                ],
+                            },
+                            {
+                                "role": "tool",
+                                "tool_call_id": "functionsexec0",
+                                "content": "{}",
+                            },
+                        ],
+                    },
+                )
+        finally:
+            stub.close()
+
+        self.assertEqual(status, 200)
+        forwarded = json.loads(received["body"])
+        self.assertEqual(
+            forwarded["messages"][0]["tool_calls"][0]["id"],
+            "functions.exec:0",
+        )
+        self.assertEqual(
+            forwarded["messages"][1]["tool_call_id"],
+            "functions.exec:0",
+        )
+        self.assertEqual(stub.captures(), [])
+
+    def test_model_discovery_is_available_before_the_first_trial_opens(self):
+        stub = RunningStub(
+            candidate_mantle_environment=self._environment()
+        )
+        received: dict[str, object] = {}
+        response_body = {
+            "object": "list",
+            "data": [{"id": "openai.gpt-oss-120b"}],
+        }
+
+        class Response:
+            status = 200
+            headers = {"Content-Type": "application/json"}
+
+            def read(self, limit: int) -> bytes:
+                self.limit = limit
+                return json.dumps(response_body).encode("utf-8")
+
+            def close(self) -> None:
+                return
+
+        class Opener:
+            def open(
+                self,
+                request: urllib.request.Request,
+                timeout: int,
+            ) -> Response:
+                received["url"] = request.full_url
+                received["headers"] = {
+                    key.lower(): value
+                    for key, value in request.header_items()
+                }
+                return Response()
+
+        try:
+            stub.invocation_context_path.unlink()
+            stub.request_proof_key_path.unlink()
+            with mock.patch.object(
+                broker_stub.urllib_request,
+                "build_opener",
+                return_value=Opener(),
+            ):
+                status, response = stub.request(
+                    "/candidate-mantle/models",
+                )
+        finally:
+            stub.close()
+
+        self.assertEqual(status, 200)
+        self.assertEqual(response, response_body)
+        self.assertEqual(
+            received["url"],
+            "https://bedrock-mantle.us-east-1.api.aws/v1/models",
+        )
+        self.assertEqual(
+            received["headers"]["authorization"],
+            "Bearer root-only-token",
+        )
+        self.assertEqual(
+            stub.server.state.finalization_state,
+            "closed",
+        )
         self.assertEqual(stub.captures(), [])
 
     def test_candidate_relay_rejects_the_wrong_model_without_upstream_call(self):

--- a/infra/agent-image/test_broker_stub.py
+++ b/infra/agent-image/test_broker_stub.py
@@ -23,6 +23,7 @@ import urllib.error
 import urllib.request
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
+from unittest import mock
 
 
 AGENT_IMAGE_DIR = Path(__file__).resolve().parent
@@ -52,6 +53,41 @@ def _python_allowlist(path: Path, variable: str) -> set[str]:
     raise AssertionError(f"{variable} was not found in {path}")
 
 
+def _python_literal(path: Path, variable: str) -> object:
+    """Read a literal assignment, including nested ``frozenset`` calls."""
+
+    def resolve(node: ast.AST) -> object:
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "frozenset"
+            and len(node.args) == 1
+            and not node.keywords
+        ):
+            return frozenset(resolve(node.args[0]))
+        if isinstance(node, ast.Dict):
+            return {
+                resolve(key): resolve(value)
+                for key, value in zip(node.keys, node.values, strict=True)
+            }
+        if isinstance(node, ast.Tuple):
+            return tuple(resolve(element) for element in node.elts)
+        if isinstance(node, ast.Set):
+            return {resolve(element) for element in node.elts}
+        return ast.literal_eval(node)
+
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    for node in tree.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        if any(
+            isinstance(target, ast.Name) and target.id == variable
+            for target in node.targets
+        ):
+            return resolve(node.value)
+    raise AssertionError(f"{variable} was not found in {path}")
+
+
 def _javascript_allowlist(path: Path) -> set[str]:
     source = path.read_text(encoding="utf-8")
     match = re.search(
@@ -69,6 +105,7 @@ class RunningStub:
         self,
         *,
         model_upstream_base_url: str = "http://127.0.0.1:9",
+        candidate_mantle_environment: dict[str, str] | None = None,
     ) -> None:
         self.temporary_directory = tempfile.TemporaryDirectory(
             prefix="issue-1424-broker-test-"
@@ -94,14 +131,27 @@ class RunningStub:
             self.control_directory / "request-proof-key"
         )
         self.request_proof_key_path.write_bytes(encoded_proof_key)
-        self.server = broker_stub.create_server(
-            self.control_directory,
-            port=0,
-            workspace_flush_token_path=self.flush_token_path,
-            invocation_context_path=self.invocation_context_path,
-            request_proof_key_path=self.request_proof_key_path,
-            model_upstream_base_url=model_upstream_base_url,
-        )
+        create_arguments = {
+            "port": 0,
+            "workspace_flush_token_path": self.flush_token_path,
+            "invocation_context_path": self.invocation_context_path,
+            "request_proof_key_path": self.request_proof_key_path,
+            "model_upstream_base_url": model_upstream_base_url,
+        }
+        if candidate_mantle_environment is None:
+            self.server = broker_stub.create_server(
+                self.control_directory,
+                **create_arguments,
+            )
+        else:
+            with mock.patch.multiple(
+                broker_stub,
+                **candidate_mantle_environment,
+            ):
+                self.server = broker_stub.create_server(
+                    self.control_directory,
+                    **create_arguments,
+                )
         self.thread = threading.Thread(
             target=self.server.serve_forever,
             daemon=True,
@@ -158,6 +208,8 @@ class RunningStub:
 
     def captures(self) -> list[dict[str, object]]:
         capture = self.control_directory / broker_stub.CAPTURE_FILENAME
+        if not capture.exists():
+            return []
         return [
             json.loads(line)
             for line in capture.read_text(encoding="utf-8").splitlines()
@@ -186,6 +238,18 @@ class BrokerRouteParityTests(unittest.TestCase):
         self.assertEqual(
             broker_stub.ALLOWED_AGENT_BROKER_ROUTES,
             javascript_routes,
+        )
+
+    def test_stub_matches_the_production_candidate_mantle_contract(self):
+        proxy_path = AGENT_IMAGE_DIR / "mantle_proxy.py"
+
+        self.assertEqual(
+            broker_stub.CANDIDATE_MANTLE_PREFIX,
+            _python_literal(proxy_path, "CANDIDATE_MANTLE_PREFIX"),
+        )
+        self.assertEqual(
+            broker_stub.CANDIDATE_MANTLE_OPERATIONS,
+            _python_literal(proxy_path, "CANDIDATE_MANTLE_OPERATIONS"),
         )
 
 
@@ -262,6 +326,201 @@ class BrokerControlStorageTests(unittest.TestCase):
                     Path(directory),
                     b"[]",
                 )
+
+
+class CandidateMantleRelayTests(unittest.TestCase):
+    def _environment(self) -> dict[str, str]:
+        return {
+            "CANDIDATE_MANTLE_API": "openai-completions",
+            "CANDIDATE_MANTLE_BASE_URL": (
+                "https://bedrock-mantle.us-east-1.api.aws/v1"
+            ),
+            "CANDIDATE_MANTLE_BEARER_TOKEN": "root-only-token",
+            "CANDIDATE_MANTLE_MODEL_ID": "openai.gpt-oss-120b",
+        }
+
+    def test_configuration_rejects_a_lookalike_mantle_origin(self):
+        environment = {
+            **self._environment(),
+            "CANDIDATE_MANTLE_BASE_URL": (
+                "https://bedrock-mantle.us-east-1.api.aws.attacker.test/v1"
+            ),
+        }
+        with mock.patch.multiple(
+            broker_stub,
+            **environment,
+        ), self.assertRaisesRegex(
+            broker_stub.BrokerStubConfigurationError,
+            "exact AWS endpoint",
+        ):
+            broker_stub._candidate_mantle_configuration()
+
+    def test_openai_tool_shapes_relay_byte_for_byte_with_root_bearer(self):
+        stub = RunningStub(
+            candidate_mantle_environment=self._environment()
+        )
+        received: dict[str, object] = {}
+        response_body = {
+            "id": "chatcmpl-eval",
+            "model": "openai.gpt-oss-120b",
+            "choices": [
+                {
+                    "index": 0,
+                    "message": {
+                        "role": "assistant",
+                        "content": "Capability is granted.",
+                    },
+                    "finish_reason": "stop",
+                }
+            ],
+        }
+
+        class Response:
+            status = 200
+            headers = {"Content-Type": "application/json"}
+
+            def read(self, limit: int) -> bytes:
+                self.limit = limit
+                return json.dumps(response_body).encode("utf-8")
+
+            def close(self) -> None:
+                return
+
+        class Opener:
+            def open(
+                self,
+                request: urllib.request.Request,
+                timeout: int,
+            ) -> Response:
+                received["url"] = request.full_url
+                received["body"] = request.data
+                received["headers"] = {
+                    key.lower(): value
+                    for key, value in request.header_items()
+                }
+                received["timeout"] = timeout
+                return Response()
+
+        tool_request = {
+            "model": "openai.gpt-oss-120b",
+            "messages": [
+                {"role": "user", "content": "Check capability"},
+                {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": "call_123",
+                            "type": "function",
+                            "function": {
+                                "name": "exec",
+                                "arguments": "{\"command\":\"check\"}",
+                            },
+                        }
+                    ],
+                },
+                {
+                    "role": "tool",
+                    "tool_call_id": "call_123",
+                    "content": "{\"granted\":true}",
+                },
+            ],
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "exec",
+                        "parameters": {"type": "object"},
+                    },
+                }
+            ],
+            "stream": True,
+        }
+        serialized_request = json.dumps(tool_request).encode("utf-8")
+        try:
+            stub.configure([])
+            with mock.patch.object(
+                broker_stub.urllib_request,
+                "build_opener",
+                return_value=Opener(),
+            ):
+                status, response = stub.request(
+                    "/candidate-mantle/chat/completions",
+                    method="POST",
+                    body=tool_request,
+                    headers={"Authorization": "Bearer model-supplied"},
+                )
+        finally:
+            stub.close()
+
+        self.assertEqual(status, 200)
+        self.assertEqual(response, response_body)
+        self.assertEqual(
+            received["url"],
+            (
+                "https://bedrock-mantle.us-east-1.api.aws/v1"
+                "/chat/completions"
+            ),
+        )
+        self.assertEqual(
+            json.loads(received["body"]),
+            json.loads(serialized_request),
+        )
+        self.assertEqual(
+            received["headers"]["authorization"],
+            "Bearer root-only-token",
+        )
+        self.assertEqual(received["timeout"], 300)
+        self.assertEqual(stub.captures(), [])
+
+    def test_candidate_relay_rejects_the_wrong_model_without_upstream_call(self):
+        stub = RunningStub(
+            candidate_mantle_environment=self._environment()
+        )
+        try:
+            stub.configure([])
+            with mock.patch.object(
+                broker_stub.urllib_request,
+                "build_opener",
+            ) as build_opener:
+                status, response = stub.request(
+                    "/candidate-mantle/chat/completions",
+                    method="POST",
+                    body={"model": "attacker-model", "messages": []},
+                )
+        finally:
+            stub.close()
+
+        self.assertEqual(status, 404)
+        self.assertEqual(
+            response["error"],
+            "EvalUnsupportedCandidateModelOperation",
+        )
+        build_opener.assert_not_called()
+
+    def test_paid_candidate_inference_requires_turn_authority(self):
+        stub = RunningStub(
+            candidate_mantle_environment=self._environment()
+        )
+        try:
+            stub.configure([])
+            stub.invocation_context_path.unlink()
+            status, response = stub.request(
+                "/candidate-mantle/chat/completions",
+                method="POST",
+                body={
+                    "model": "openai.gpt-oss-120b",
+                    "messages": [],
+                },
+            )
+        finally:
+            stub.close()
+
+        self.assertEqual(status, 503)
+        self.assertEqual(
+            response,
+            {"error": "Invocation authority is unavailable"},
+        )
 
 
 class BrokerStubHttpTests(unittest.TestCase):

--- a/infra/agent-image/test_eval_runner.py
+++ b/infra/agent-image/test_eval_runner.py
@@ -124,6 +124,24 @@ class SuiteLoadingTests(unittest.TestCase):
         self.assertEqual({task.workspace for task in tasks}, {"pure"})
         self.assertEqual({task.trials for task in tasks}, {3})
 
+    def test_repository_name_grader_accepts_typographic_separators(self):
+        [task] = runner.load_suite(
+            AGENT_IMAGE_DIR
+            / "skills"
+            / "psd-aistudio"
+            / "evals"
+            / "repository-list.yaml"
+        )
+        output_grader = next(
+            grader
+            for grader in task.graders
+            if grader["type"] == "output_match"
+        )
+        pattern = str(output_grader["pattern"])
+
+        self.assertRegex("EVAL-1426 Canary Repository", pattern)
+        self.assertRegex("EVAL‑1426 Canary Repository", pattern)
+
     def test_committed_skill_suites_meet_issue_1426_contract(self):
         suite_paths = {
             "regression": AGENT_IMAGE_DIR / "eval" / "suites" / "regression.yaml",


### PR DESCRIPTION
## Description

Fix the GPT OSS 120B L1 evaluation failure that was reported as 95
`OpenClawChatError` results in the first comparison run.

The failure was in the eval harness, before Bedrock: L1 tasks bind-mount
`eval/broker_stub.py` over `/app/mantle_proxy.py`, but direct-Mantle candidates
also use that root-owned loopback process for model inference. The stub did not
preserve `/candidate-mantle/*`, so it returned `404 EvalUnsupportedPath`;
OpenClaw translated that local 404 into its generic model-not-found message.

This PR:

- preserves the production candidate Mantle operation/model/origin contract
  while L1 fixtures are active;
- replaces model-supplied authorization with the root-held bearer and requires
  active invocation authority for paid calls;
- strips authority/proof headers, disables redirects, bounds request/response
  sizes, and never writes prompt or model bodies to fixture captures;
- preserves model discovery while the trial gate is initially closed, repairs
  Kimi tool-call IDs with production-parity coverage, and adds OpenAI
  tool-call/tool-result shape tests;
- adds a reusable three-route `tool-heavy-smoke.yaml` suite; and
- records the failure mode, durable test-double rule, and Unicode-tolerant
  grading for human-rendered repository names.

The expected upstream contract matches the AWS
[Mantle Chat Completions documentation](https://docs.aws.amazon.com/bedrock/latest/userguide/inference-chat-completions-mantle.html)
and [GPT OSS 120B model card](https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-openai-gpt-oss-120b.html).

## Validation

- `bun run lint`
- `bun run typecheck`
- Full documented agent-image hermetic suite: 559 passed, 1 skipped
- Focused broker-stub suite: 25 passed
- Focused eval-runner suite: 67 passed
- Final-SHA candidate build gate:
  - source commit `8f0ae3b675864dad5d1980e3764b49845b4e3e70`
  - includes current `dev` at `96dd89a09` (through PR #1493)
  - `BOOT_OK` in 36 seconds
  - canary answered exactly `CANDIDATE_OK` in 3 seconds
  - immutable digest
    `sha256:4ce2e8e9260dc541bd0bf1aa9e69b1836800ba92511786951f0714a1f70d57ae`
- Final committed tool-heavy smoke, 3 trials per task:
  - `credentials-check-capability`: 3/3 (`pass^3=True`)
  - `aistudio-repository-list`: 3/3 (`pass^3=True`)
  - `workflows-list-live-roster`: 3/3 (`pass^3=True`)
  - total: 9/9, with zero runtime, broker-stub, or grader failures

The current `dev` OpenClaw CLI-gateway path reports zero token counts and
`usage_capture_complete=false` under the L1 stub. This smoke intentionally
grades tool routing and tool-result handling, not cost telemetry; the limitation
does not affect these 9/9 behavioral results.

Authenticated browser E2E is not applicable to this Python-only eval-harness
change. The local pre-push suite requires a real `.env.local`; a synthetic-key
attempt failed unrelated admin-auth tests, so the documented one-push bypass
was used after the relevant suites, lint, and typecheck passed.

## Checklist

- [x] No `console.*` calls in production/shared code; all server-side logging uses Winston logger (`@/lib/logger`)
- [x] **No imports or usage of `@/lib/logger` in client components or client hooks**
- [x] Client code uses `console.error` only for actionable errors in development (never for routine info)
- [x] Lint passes (`bun run lint`)
- [x] All relevant tests pass
- [x] Types/interfaces follow project conventions
- [x] No type assertions (`as any`) without justification
- [x] Database field names use snake_case (automatic camelCase transformation handled by data API adapter)
- [x] TypeScript strict mode errors resolved
- [x] Environment variables handled securely; no `.env.example` change needed
- [x] Documentation updated
- [x] Code reviewed and approved
- [x] Candidate image builds, boots, and answers its canary

## Related Issues

Closes #1484

Part of #1429.
