### PR TITLE
fix(triage): self-heal trusted label mappings

### DIFF
--- a/docs/operations/email-triage.md
+++ b/docs/operations/email-triage.md
@@ -89,27 +89,33 @@ For each opted-in user every 5 minutes:
 1. **Refresh access token** via `workspace-token.ts` (Lambda-local copy
    of the helper in `lib/agent/`; reads the user's `user_account` slot
    from Secrets Manager, exchanges refresh token for an access token).
-2. **Pull Gmail history** since `lastHistoryId` (only `messageAdded`,
+2. **Validate the label mapping** against the owner's live Gmail labels.
+   A legacy row missing the trusted provenance stamp self-heals by resolving
+   the four code-constant label names with that owner token, requiring one
+   unique safe user-label id per name, and persisting the trusted mapping.
+   Ambiguous, missing, system, or duplicate ids remain fail-closed and emit
+   `untrusted_label_mapping`.
+3. **Pull Gmail history** since `lastHistoryId` (only `messageAdded`,
    `labelAdded`, `labelRemoved` events).
-3. For each new message: **deterministic rules first** (VIP → important,
+4. For each new message: **deterministic rules first** (VIP → important,
    mute → later, thread-with-user-reply → important, keyword rules in
    order). If undecided, **call Bedrock Nova Micro** with a small system
    prompt summarising the user's rules + sender/subject/snippet. Default
    to `later` if model confidence < 0.6.
-4. **Apply Gmail label** via `messages.modify`. **All three labels also
+5. **Apply Gmail label** via `messages.modify`. **All three labels also
    remove `INBOX`** — the design treats labels as mutually-exclusive
    folders so the user reviews each in one place. Inbox empty = triage
    caught up. The Chat escalation is the "look at this now" signal
    for the rare cases that warrant interruption.
-5. **Maybe escalate to Chat** — if the label matches the user's
+6. **Maybe escalate to Chat** — if the label matches the user's
    `escalation.labelTriggers` AND (no sender/keyword filter OR the
    sender/keyword matches), post a card to the user's DM via the Chat
    API.
-6. **Detect user-driven label changes** — if a recent classification
+7. **Detect user-driven label changes** — if a recent classification
    contradicts what the user just did (e.g. they moved an `@psd/Later`
    message back into Inbox), record as a `recentCorrections` entry
    (Phase 1 only records; Phase 2 acts on them).
-7. **Advance the cursor** in DDB.
+8. **Advance the cursor** in DDB.
 
 ---
 
@@ -190,6 +196,22 @@ Agent skill (in the container, env injected by `agent-platform-stack.ts`):
 | Daily digest never arrives | EventBridge Scheduler entry missing or Scheduler can't invoke the Lambda | Check `aws scheduler get-schedule --group-name psd-agent-<env> --name triage-digest-<userslug>` |
 | Admin sub-page shows "No triage row" but user says triage is on | DDB row was deleted (admin re-onboard) but user hasn't re-enabled yet | User runs `enable` again from chat |
 | Escalation posts not appearing in Chat | DM space resource name missing on the triage row OR Chat bot lacks DM space access | Check `dmSpaceName` field in DDB row; the user must have DM'd the bot at least once |
+| Worker logs `label_mapping_healed` | A legacy or stale row was safely rebuilt from the owner's live canonical Gmail labels | Expected once per affected row after rollout; confirm `lastPollAt` advances in the same tick |
+| Worker logs `untrusted_label_mapping` | Canonical Gmail labels are missing/ambiguous, contain unsafe or duplicate ids, or a trusted row no longer matches live Gmail | The poll intentionally fails closed and the `psd-agent-triage-untrusted-label-mapping-<env>` alarm fires; repair the Gmail label state, then let the next poll revalidate |
+
+### Provenance self-heal deploy verification
+
+After deploying the worker and stack:
+
+1. Confirm `label_mapping_healed` appears once for each affected user and
+   `untrusted_label_mapping` stops.
+2. Confirm each user's `lastPollAt` advances, proving the healed poll continued
+   in the same tick.
+3. If `cursor_too_old_reset` appears, run a manual `sweep` for the outage
+   window because Gmail could no longer replay the frozen history cursor.
+4. Confirm the
+   `psd-agent-triage-untrusted-label-mapping-<env>` alarm is present and wired
+   to the agent-platform alarm topic.
 
 ---
 

--- a/infra/lambdas/agent-triage-poll/__tests__/label-mapping.test.ts
+++ b/infra/lambdas/agent-triage-poll/__tests__/label-mapping.test.ts
@@ -1,0 +1,83 @@
+import {
+  resolveCanonicalTriageLabelMapping,
+  TRIAGE_LABEL_MAPPING_PROVENANCE,
+  TRIAGE_LABEL_MAPPING_VERSION,
+  TRIAGE_LABEL_NAMES,
+} from "../label-mapping";
+import type { GmailLabel } from "../gmail";
+
+const OWNER = "owner@example.com";
+const IDS = {
+  important: "Label_important",
+  later: "Label_later",
+  news: "Label_news",
+  task: "Label_task",
+};
+
+function liveLabels(
+  ids: typeof IDS = IDS,
+): GmailLabel[] {
+  return Object.entries(TRIAGE_LABEL_NAMES).map(([key, name]) => ({
+    id: ids[key as keyof typeof IDS],
+    name,
+    type: "user",
+  }));
+}
+
+describe("triage label mapping self-heal resolution", () => {
+  it("rebuilds every trusted field from canonical live owner labels", async () => {
+    await expect(
+      resolveCanonicalTriageLabelMapping(
+        OWNER,
+        async () => liveLabels(),
+        "2026-07-30T12:00:00.000Z",
+      ),
+    ).resolves.toEqual({
+      valid: true,
+      mapping: {
+        labels: TRIAGE_LABEL_NAMES,
+        labelIdsByKey: IDS,
+        labelMappingVersion: TRIAGE_LABEL_MAPPING_VERSION,
+        labelMappingProvenance: TRIAGE_LABEL_MAPPING_PROVENANCE,
+        labelMappingOwnerEmail: OWNER,
+        labelMappingResolvedAt: "2026-07-30T12:00:00.000Z",
+      },
+    });
+  });
+
+  it.each([
+    [
+      "missing",
+      liveLabels().filter(
+        (label) => label.name !== TRIAGE_LABEL_NAMES.important,
+      ),
+      "missing-or-ambiguous-live-label",
+    ],
+    [
+      "ambiguous",
+      [
+        ...liveLabels(),
+        {
+          id: "Label_important_duplicate",
+          name: TRIAGE_LABEL_NAMES.important,
+          type: "user" as const,
+        },
+      ],
+      "missing-or-ambiguous-live-label",
+    ],
+    [
+      "system id",
+      liveLabels({ ...IDS, important: "INBOX" }),
+      "invalid-or-system-label",
+    ],
+    [
+      "duplicate id",
+      liveLabels({ ...IDS, later: IDS.important }),
+      "duplicate-label-id",
+    ],
+  ])("fails closed for %s live state", async (_name, labels, reason) => {
+    await expect(
+      resolveCanonicalTriageLabelMapping(OWNER, async () => labels),
+    ).resolves.toEqual({ valid: false, reason });
+  });
+});

--- a/infra/lambdas/agent-triage-poll/__tests__/trusted-label-mapping.test.ts
+++ b/infra/lambdas/agent-triage-poll/__tests__/trusted-label-mapping.test.ts
@@ -1,0 +1,127 @@
+import {
+  TRIAGE_LABEL_MAPPING_PROVENANCE,
+  TRIAGE_LABEL_MAPPING_VERSION,
+  TRIAGE_LABEL_NAMES,
+  type TrustedTriageLabelMapping,
+} from "../label-mapping";
+import { loadTrustedLabelMappingForRow } from "../trusted-label-mapping";
+import type { GmailLabel } from "../gmail";
+import type { TriageRow } from "../types";
+
+const OWNER = "owner@example.com";
+const IDS = {
+  important: "Label_important",
+  later: "Label_later",
+  news: "Label_news",
+  task: "Label_task",
+};
+
+function liveLabels(): GmailLabel[] {
+  return Object.entries(TRIAGE_LABEL_NAMES).map(([key, name]) => ({
+    id: IDS[key as keyof typeof IDS],
+    name,
+    type: "user",
+  }));
+}
+
+function row(overrides: Partial<TriageRow> = {}): TriageRow {
+  return {
+    userEmail: OWNER,
+    enabled: true,
+    labels: TRIAGE_LABEL_NAMES,
+    labelIdsByKey: IDS,
+    labelMappingVersion: TRIAGE_LABEL_MAPPING_VERSION,
+    labelMappingProvenance: TRIAGE_LABEL_MAPPING_PROVENANCE,
+    labelMappingOwnerEmail: OWNER,
+    labelMappingResolvedAt: "2026-07-26T00:00:00.000Z",
+    rules: { vipSenders: [], muteSenders: [], keywordRules: [] },
+    escalation: { senders: [], keywords: [], labelTriggers: [] },
+    digestEnabled: false,
+    recentDecisions: [],
+    recentCorrections: [],
+    ...overrides,
+  };
+}
+
+function dependencies(labels: GmailLabel[] = liveLabels()) {
+  return {
+    loadLiveLabels: jest.fn().mockResolvedValue(labels),
+    stampTrustedMapping: jest
+      .fn<Promise<void>, [TrustedTriageLabelMapping]>()
+      .mockResolvedValue(undefined),
+    log: jest.fn(),
+  };
+}
+
+describe("trusted triage label mapping orchestration", () => {
+  it("stamps a legacy row and returns the healed mapping for same-tick work", async () => {
+    const deps = dependencies();
+    const result = await loadTrustedLabelMappingForRow(
+      row({
+        labelMappingVersion: undefined,
+        labelMappingProvenance: undefined,
+        labelMappingOwnerEmail: undefined,
+        labelMappingResolvedAt: undefined,
+      }),
+      deps,
+    );
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        labels: TRIAGE_LABEL_NAMES,
+        labelIdsByKey: IDS,
+        labelMappingVersion: TRIAGE_LABEL_MAPPING_VERSION,
+        labelMappingProvenance: TRIAGE_LABEL_MAPPING_PROVENANCE,
+        labelMappingOwnerEmail: OWNER,
+      }),
+    );
+    expect(deps.stampTrustedMapping).toHaveBeenCalledWith(result);
+    expect(deps.log).toHaveBeenCalledWith(
+      "INFO",
+      "label_mapping_healed",
+      expect.objectContaining({ user: OWNER }),
+    );
+  });
+
+  it("fails closed without a stamp when canonical live labels are ambiguous", async () => {
+    const deps = dependencies([
+      ...liveLabels(),
+      {
+        id: "Label_important_duplicate",
+        name: TRIAGE_LABEL_NAMES.important,
+        type: "user",
+      },
+    ]);
+
+    await expect(
+      loadTrustedLabelMappingForRow(
+        row({ labelMappingVersion: undefined }),
+        deps,
+      ),
+    ).resolves.toBeNull();
+    expect(deps.stampTrustedMapping).not.toHaveBeenCalled();
+    expect(deps.log).toHaveBeenCalledWith(
+      "ERROR",
+      "untrusted_label_mapping",
+      {
+        user: OWNER,
+        reason: "missing-or-ambiguous-live-label",
+      },
+    );
+  });
+
+  it("passes a valid row through without a re-resolution write", async () => {
+    const deps = dependencies();
+
+    await expect(
+      loadTrustedLabelMappingForRow(row(), deps),
+    ).resolves.toEqual(
+      expect.objectContaining({
+        labelIdsByKey: IDS,
+        labelMappingOwnerEmail: OWNER,
+      }),
+    );
+    expect(deps.loadLiveLabels).toHaveBeenCalledTimes(1);
+    expect(deps.stampTrustedMapping).not.toHaveBeenCalled();
+  });
+});

--- a/infra/lambdas/agent-triage-poll/__tests__/trusted-label-mapping.test.ts
+++ b/infra/lambdas/agent-triage-poll/__tests__/trusted-label-mapping.test.ts
@@ -131,6 +131,27 @@ describe("trusted triage label mapping orchestration", () => {
     );
   });
 
+  it("fails closed without healing when stored owner provenance mismatches", async () => {
+    const deps = dependencies();
+
+    await expect(
+      loadTrustedLabelMappingForRow(
+        row({ labelMappingOwnerEmail: "attacker@example.com" }),
+        deps,
+      ),
+    ).resolves.toBeNull();
+    expect(deps.loadLiveLabels).not.toHaveBeenCalled();
+    expect(deps.stampTrustedMapping).not.toHaveBeenCalled();
+    expect(deps.log).toHaveBeenCalledWith(
+      "ERROR",
+      "untrusted_label_mapping",
+      {
+        user: OWNER,
+        reason: "owner-mismatch",
+      },
+    );
+  });
+
   it("passes a valid row through without a re-resolution write", async () => {
     const deps = dependencies();
 

--- a/infra/lambdas/agent-triage-poll/__tests__/trusted-label-mapping.test.ts
+++ b/infra/lambdas/agent-triage-poll/__tests__/trusted-label-mapping.test.ts
@@ -110,6 +110,27 @@ describe("trusted triage label mapping orchestration", () => {
     );
   });
 
+  it("fails closed and logs when trusted provenance has no label id map", async () => {
+    const deps = dependencies();
+
+    await expect(
+      loadTrustedLabelMappingForRow(
+        row({ labelIdsByKey: undefined }),
+        deps,
+      ),
+    ).resolves.toBeNull();
+    expect(deps.loadLiveLabels).not.toHaveBeenCalled();
+    expect(deps.stampTrustedMapping).not.toHaveBeenCalled();
+    expect(deps.log).toHaveBeenCalledWith(
+      "ERROR",
+      "untrusted_label_mapping",
+      {
+        user: OWNER,
+        reason: "invalid-or-system-label",
+      },
+    );
+  });
+
   it("passes a valid row through without a re-resolution write", async () => {
     const deps = dependencies();
 

--- a/infra/lambdas/agent-triage-poll/index.ts
+++ b/infra/lambdas/agent-triage-poll/index.ts
@@ -54,6 +54,7 @@ import {
   recordPollResult,
   recordTaskCreated,
   resetCursor,
+  stampTrustedTriageLabelMapping,
 } from "./storage";
 import { requestTaskCreation } from "./agentcore";
 import type {
@@ -63,15 +64,15 @@ import type {
   TriageRow,
 } from "./types";
 import {
-  resolveTrustedTriageLabelMapping,
-  validateStoredTriageLabelMapping,
+  type TrustedTriageLabelMapping,
 } from "./label-mapping";
+import { loadTrustedLabelMappingForRow } from "./trusted-label-mapping";
 
 const ENV = process.env.ENVIRONMENT ?? "dev";
 const REGION = process.env.AWS_REGION ?? "us-east-1";
 const validatedLabelMappings = new WeakMap<
   TriageRow,
-  Promise<Record<"important" | "later" | "news" | "task", string> | null>
+  Promise<TrustedTriageLabelMapping | null>
 >();
 
 export function log(
@@ -130,21 +131,14 @@ export async function acquireUserAccessToken(
 async function trustedLabelIdsForRow(
   row: TriageRow,
   accessToken: string,
-): Promise<Record<"important" | "later" | "news" | "task", string> | null> {
+): Promise<TrustedTriageLabelMapping | null> {
   let pending = validatedLabelMappings.get(row);
   if (!pending) {
-    const stored = validateStoredTriageLabelMapping(row);
-    if (!stored.valid) {
-      log("ERROR", "untrusted_label_mapping", {
-        user: row.userEmail,
-        reason: stored.reason,
-      });
-      return null;
-    }
-    pending = resolveTrustedTriageLabelMapping(
-      row,
-      () => listLabels(accessToken)
-    );
+    pending = loadTrustedLabelMappingForRow(row, {
+      loadLiveLabels: () => listLabels(accessToken),
+      stampTrustedMapping: stampTrustedTriageLabelMapping,
+      log,
+    });
     validatedLabelMappings.set(row, pending);
   }
   return pending;
@@ -269,9 +263,9 @@ export async function processUser(row: TriageRow): Promise<void> {
   // Acquire access token.
   const accessToken = await acquireUserAccessToken(row.userEmail);
   if (!accessToken) return;
-  const trustedLabelIds = await trustedLabelIdsForRow(row, accessToken);
-  if (!trustedLabelIds) return;
-  row = { ...row, labelIdsByKey: trustedLabelIds };
+  const trustedLabelMapping = await trustedLabelIdsForRow(row, accessToken);
+  if (!trustedLabelMapping) return;
+  row = { ...row, ...trustedLabelMapping };
 
   // Anchor cursor — when missing or on first run we capture "now" so we
   // only classify forward.
@@ -544,9 +538,9 @@ export async function classifyAndLabel(
   msgRef: { id: string; threadId: string; labelIds?: string[] },
   opts: { suppressEscalation?: boolean } = {},
 ): Promise<{ decision: DecisionRecord; escalated: boolean } | null> {
-  const trustedLabelIds = await trustedLabelIdsForRow(row, accessToken);
-  if (!trustedLabelIds) return null;
-  row = { ...row, labelIdsByKey: trustedLabelIds };
+  const trustedLabelMapping = await trustedLabelIdsForRow(row, accessToken);
+  if (!trustedLabelMapping) return null;
+  row = { ...row, ...trustedLabelMapping };
 
   // Fetch metadata — needed for sender + subject + snippet.
   const meta = await getMessageMetadata(accessToken, msgRef.id);

--- a/infra/lambdas/agent-triage-poll/label-mapping.ts
+++ b/infra/lambdas/agent-triage-poll/label-mapping.ts
@@ -11,7 +11,20 @@ export const TRIAGE_LABEL_NAMES = {
   task: "@psd/Task",
 } as const;
 
-type TriageLabelKey = keyof typeof TRIAGE_LABEL_NAMES;
+export type TriageLabelKey = keyof typeof TRIAGE_LABEL_NAMES;
+
+export interface TrustedTriageLabelMapping {
+  labels: typeof TRIAGE_LABEL_NAMES;
+  labelIdsByKey: Record<TriageLabelKey, string>;
+  labelMappingVersion: typeof TRIAGE_LABEL_MAPPING_VERSION;
+  labelMappingProvenance: typeof TRIAGE_LABEL_MAPPING_PROVENANCE;
+  labelMappingOwnerEmail: string;
+  labelMappingResolvedAt: string;
+}
+
+export type TriageLabelMappingResolution =
+  | { valid: true; mapping: TrustedTriageLabelMapping }
+  | { valid: false; reason: string };
 
 const SAFE_GMAIL_ID = /^[A-Za-z0-9_-]{1,256}$/;
 const GMAIL_SYSTEM_IDS = new Set([
@@ -34,53 +47,112 @@ function isSafeUserLabelId(value: unknown): value is string {
   );
 }
 
-export function validateStoredTriageLabelMapping(
-  row: TriageRow,
-):
-  | { valid: true; labelIdsByKey: Record<TriageLabelKey, string> }
-  | { valid: false; reason: string } {
-  if (
-    row.labelMappingVersion !== TRIAGE_LABEL_MAPPING_VERSION ||
-    row.labelMappingProvenance !== TRIAGE_LABEL_MAPPING_PROVENANCE ||
-    row.labelMappingOwnerEmail !== row.userEmail ||
-    typeof row.labelMappingResolvedAt !== "string" ||
-    !Number.isFinite(Date.parse(row.labelMappingResolvedAt))
-  ) {
-    return { valid: false, reason: "untrusted-or-stale-provenance" };
-  }
-
+function createTrustedTriageLabelMapping(input: {
+  ownerEmail: string;
+  labelIdsByKey: Partial<Record<TriageLabelKey, string>>;
+  resolvedAt: string;
+}): TriageLabelMappingResolution {
   const ids = Object.create(null) as Record<TriageLabelKey, string>;
   const seen = new Set<string>();
   for (const key of Object.keys(TRIAGE_LABEL_NAMES) as TriageLabelKey[]) {
-    const id = row.labelIdsByKey?.[key];
-    if (
-      row.labels?.[key] !== TRIAGE_LABEL_NAMES[key] ||
-      !isSafeUserLabelId(id) ||
-      seen.has(id)
-    ) {
+    const id = input.labelIdsByKey[key];
+    if (!isSafeUserLabelId(id)) {
       return { valid: false, reason: "invalid-or-system-label" };
+    }
+    if (seen.has(id)) {
+      return { valid: false, reason: "duplicate-label-id" };
     }
     seen.add(id);
     ids[key] = id;
   }
-  return { valid: true, labelIdsByKey: ids };
+  return {
+    valid: true,
+    mapping: {
+      labels: TRIAGE_LABEL_NAMES,
+      labelIdsByKey: ids,
+      labelMappingVersion: TRIAGE_LABEL_MAPPING_VERSION,
+      labelMappingProvenance: TRIAGE_LABEL_MAPPING_PROVENANCE,
+      labelMappingOwnerEmail: input.ownerEmail,
+      labelMappingResolvedAt: input.resolvedAt,
+    },
+  };
+}
+
+export function validateStoredTriageLabelMapping(
+  row: TriageRow,
+): TriageLabelMappingResolution {
+  const resolvedAt = row.labelMappingResolvedAt;
+  if (
+    row.labelMappingVersion !== TRIAGE_LABEL_MAPPING_VERSION ||
+    row.labelMappingProvenance !== TRIAGE_LABEL_MAPPING_PROVENANCE ||
+    row.labelMappingOwnerEmail !== row.userEmail ||
+    typeof resolvedAt !== "string" ||
+    !Number.isFinite(Date.parse(resolvedAt))
+  ) {
+    return { valid: false, reason: "untrusted-or-stale-provenance" };
+  }
+
+  for (const key of Object.keys(TRIAGE_LABEL_NAMES) as TriageLabelKey[]) {
+    if (row.labels?.[key] !== TRIAGE_LABEL_NAMES[key]) {
+      return { valid: false, reason: "invalid-or-system-label" };
+    }
+  }
+  return createTrustedTriageLabelMapping({
+    ownerEmail: row.userEmail,
+    labelIdsByKey: row.labelIdsByKey,
+    resolvedAt,
+  });
 }
 
 export async function resolveTrustedTriageLabelMapping(
   row: TriageRow,
   loadLiveLabels: () => Promise<readonly GmailLabel[]>,
-): Promise<Record<TriageLabelKey, string> | null> {
+): Promise<TriageLabelMappingResolution> {
   const stored = validateStoredTriageLabelMapping(row);
-  if (!stored.valid) return null;
+  if (!stored.valid) return stored;
   const liveLabels = await loadLiveLabels();
   for (const key of Object.keys(TRIAGE_LABEL_NAMES) as TriageLabelKey[]) {
     const matches = liveLabels.filter(
       (label) =>
-        label.id === stored.labelIdsByKey[key] &&
+        label.id === stored.mapping.labelIdsByKey[key] &&
         label.name === TRIAGE_LABEL_NAMES[key] &&
         label.type === "user",
     );
-    if (matches.length !== 1) return null;
+    if (matches.length !== 1) {
+      return { valid: false, reason: "missing-or-unrelated-live-label" };
+    }
   }
-  return stored.labelIdsByKey;
+  return stored;
+}
+
+/**
+ * Rebuild a trusted mapping exclusively from code-constant names and the
+ * owner's live Gmail labels. Row-provided names and ids are deliberately not
+ * accepted here: this is the recovery boundary for legacy or stale rows.
+ */
+export async function resolveCanonicalTriageLabelMapping(
+  ownerEmail: string,
+  loadLiveLabels: () => Promise<readonly GmailLabel[]>,
+  resolvedAt = new Date().toISOString(),
+): Promise<TriageLabelMappingResolution> {
+  const liveLabels = await loadLiveLabels();
+  const labelIdsByKey: Partial<Record<TriageLabelKey, string>> =
+    Object.create(null);
+
+  for (const key of Object.keys(TRIAGE_LABEL_NAMES) as TriageLabelKey[]) {
+    const matches = liveLabels.filter(
+      (label) =>
+        label.name === TRIAGE_LABEL_NAMES[key] && label.type === "user",
+    );
+    if (matches.length !== 1) {
+      return { valid: false, reason: "missing-or-ambiguous-live-label" };
+    }
+    labelIdsByKey[key] = matches[0].id;
+  }
+
+  return createTrustedTriageLabelMapping({
+    ownerEmail,
+    labelIdsByKey,
+    resolvedAt,
+  });
 }

--- a/infra/lambdas/agent-triage-poll/label-mapping.ts
+++ b/infra/lambdas/agent-triage-poll/label-mapping.ts
@@ -83,6 +83,12 @@ export function validateStoredTriageLabelMapping(
 ): TriageLabelMappingResolution {
   const resolvedAt = row.labelMappingResolvedAt;
   if (
+    row.labelMappingOwnerEmail !== undefined &&
+    row.labelMappingOwnerEmail !== row.userEmail
+  ) {
+    return { valid: false, reason: "owner-mismatch" };
+  }
+  if (
     row.labelMappingVersion !== TRIAGE_LABEL_MAPPING_VERSION ||
     row.labelMappingProvenance !== TRIAGE_LABEL_MAPPING_PROVENANCE ||
     row.labelMappingOwnerEmail !== row.userEmail ||

--- a/infra/lambdas/agent-triage-poll/label-mapping.ts
+++ b/infra/lambdas/agent-triage-poll/label-mapping.ts
@@ -49,13 +49,13 @@ function isSafeUserLabelId(value: unknown): value is string {
 
 function createTrustedTriageLabelMapping(input: {
   ownerEmail: string;
-  labelIdsByKey: Partial<Record<TriageLabelKey, string>>;
+  labelIdsByKey?: Partial<Record<TriageLabelKey, string>>;
   resolvedAt: string;
 }): TriageLabelMappingResolution {
   const ids = Object.create(null) as Record<TriageLabelKey, string>;
   const seen = new Set<string>();
   for (const key of Object.keys(TRIAGE_LABEL_NAMES) as TriageLabelKey[]) {
-    const id = input.labelIdsByKey[key];
+    const id = input.labelIdsByKey?.[key];
     if (!isSafeUserLabelId(id)) {
       return { valid: false, reason: "invalid-or-system-label" };
     }

--- a/infra/lambdas/agent-triage-poll/storage.ts
+++ b/infra/lambdas/agent-triage-poll/storage.ts
@@ -17,6 +17,7 @@ import {
   UpdateCommand,
 } from "@aws-sdk/lib-dynamodb";
 
+import type { TrustedTriageLabelMapping } from "./label-mapping";
 import type {
   CorrectionRecord,
   DecisionRecord,
@@ -260,6 +261,41 @@ export async function backfillDmSpaceName(
       Key: { userEmail },
       UpdateExpression: "SET dmSpaceName = :s",
       ExpressionAttributeValues: { ":s": dmSpaceName },
+    }),
+  );
+}
+
+/**
+ * Persist a label mapping rebuilt from the owner's live Gmail labels.
+ * The caller must derive this object through resolveCanonicalTriageLabelMapping;
+ * this helper only mirrors the trusted ensure-labels writer into the worker.
+ */
+export async function stampTrustedTriageLabelMapping(
+  mapping: TrustedTriageLabelMapping,
+): Promise<void> {
+  await ddb().send(
+    new UpdateCommand({
+      TableName: TABLE,
+      Key: { userEmail: mapping.labelMappingOwnerEmail },
+      UpdateExpression:
+        "SET #labels = :labels, #ids = :ids, #version = :version, " +
+        "#provenance = :provenance, #owner = :owner, #resolved = :resolved",
+      ExpressionAttributeNames: {
+        "#labels": "labels",
+        "#ids": "labelIdsByKey",
+        "#version": "labelMappingVersion",
+        "#provenance": "labelMappingProvenance",
+        "#owner": "labelMappingOwnerEmail",
+        "#resolved": "labelMappingResolvedAt",
+      },
+      ExpressionAttributeValues: {
+        ":labels": mapping.labels,
+        ":ids": mapping.labelIdsByKey,
+        ":version": mapping.labelMappingVersion,
+        ":provenance": mapping.labelMappingProvenance,
+        ":owner": mapping.labelMappingOwnerEmail,
+        ":resolved": mapping.labelMappingResolvedAt,
+      },
     }),
   );
 }

--- a/infra/lambdas/agent-triage-poll/trusted-label-mapping.ts
+++ b/infra/lambdas/agent-triage-poll/trusted-label-mapping.ts
@@ -1,0 +1,85 @@
+import type { GmailLabel } from "./gmail";
+import {
+  resolveCanonicalTriageLabelMapping,
+  resolveTrustedTriageLabelMapping,
+  validateStoredTriageLabelMapping,
+  type TrustedTriageLabelMapping,
+} from "./label-mapping";
+import type { TriageRow } from "./types";
+
+interface TrustedLabelMappingDependencies {
+  loadLiveLabels: () => Promise<readonly GmailLabel[]>;
+  stampTrustedMapping: (
+    mapping: TrustedTriageLabelMapping,
+  ) => Promise<void>;
+  log: (
+    level: "INFO" | "WARN" | "ERROR",
+    evt: string,
+    fields: Record<string, unknown>,
+  ) => void;
+}
+
+/**
+ * Resolve a row's trusted label mapping, self-healing only the legacy/stale
+ * provenance case. All other invalid stored state and every ambiguous or
+ * unsafe live mapping remain fail-closed.
+ */
+export async function loadTrustedLabelMappingForRow(
+  row: TriageRow,
+  dependencies: TrustedLabelMappingDependencies,
+): Promise<TrustedTriageLabelMapping | null> {
+  const stored = validateStoredTriageLabelMapping(row);
+  if (!stored.valid && stored.reason === "untrusted-or-stale-provenance") {
+    return healTrustedLabelMapping(row, dependencies, stored.reason);
+  }
+  if (!stored.valid) {
+    logUntrustedLabelMapping(row, dependencies, stored.reason);
+    return null;
+  }
+
+  const verified = await resolveTrustedTriageLabelMapping(
+    row,
+    dependencies.loadLiveLabels,
+  );
+  if (!verified.valid) {
+    logUntrustedLabelMapping(row, dependencies, verified.reason);
+    return null;
+  }
+  return verified.mapping;
+}
+
+async function healTrustedLabelMapping(
+  row: TriageRow,
+  dependencies: TrustedLabelMappingDependencies,
+  storedReason: string,
+): Promise<TrustedTriageLabelMapping | null> {
+  if (!row.enabled) {
+    logUntrustedLabelMapping(row, dependencies, storedReason);
+    return null;
+  }
+  const healed = await resolveCanonicalTriageLabelMapping(
+    row.userEmail,
+    dependencies.loadLiveLabels,
+  );
+  if (!healed.valid) {
+    logUntrustedLabelMapping(row, dependencies, healed.reason);
+    return null;
+  }
+  await dependencies.stampTrustedMapping(healed.mapping);
+  dependencies.log("INFO", "label_mapping_healed", {
+    user: row.userEmail,
+    resolvedAt: healed.mapping.labelMappingResolvedAt,
+  });
+  return healed.mapping;
+}
+
+function logUntrustedLabelMapping(
+  row: TriageRow,
+  dependencies: TrustedLabelMappingDependencies,
+  reason: string,
+): void {
+  dependencies.log("ERROR", "untrusted_label_mapping", {
+    user: row.userEmail,
+    reason,
+  });
+}

--- a/infra/lambdas/agent-triage-poll/types.ts
+++ b/infra/lambdas/agent-triage-poll/types.ts
@@ -34,7 +34,7 @@ export interface TriageRow {
   lastHistoryId?: string;
   lastPollAt?: string;
   labels: Partial<Record<LabelKey, string>>;
-  labelIdsByKey: Partial<Record<LabelKey, string>>;
+  labelIdsByKey?: Partial<Record<LabelKey, string>>;
   labelMappingVersion?: number;
   labelMappingProvenance?: string;
   labelMappingOwnerEmail?: string;

--- a/infra/lib/agent-platform-stack.ts
+++ b/infra/lib/agent-platform-stack.ts
@@ -2624,6 +2624,48 @@ export class AgentPlatformStack extends cdk.Stack {
     cdk.Tags.of(triageWorkerLogGroup).add('Environment', environment);
     cdk.Tags.of(triageWorkerLogGroup).add('ManagedBy', 'cdk');
 
+    const triageMetricNamespace = `PSD/AgentPlatform/${environment}`;
+    const untrustedLabelMetricName = 'TriageUntrustedLabelMappings';
+    new logs.MetricFilter(this, 'TriageUntrustedLabelMappingMetric', {
+      logGroup: triageWorkerLogGroup,
+      metricNamespace: triageMetricNamespace,
+      metricName: untrustedLabelMetricName,
+      filterPattern: logs.FilterPattern.stringValue(
+        '$.evt',
+        '=',
+        'untrusted_label_mapping',
+      ),
+      metricValue: '1',
+      defaultValue: 0,
+    });
+
+    const untrustedLabelMappingAlarm = new cloudwatch.Alarm(
+      this,
+      'TriageUntrustedLabelMappingAlarm',
+      {
+        alarmName:
+          `psd-agent-triage-untrusted-label-mapping-${environment}`,
+        alarmDescription:
+          'Email triage rejected an untrusted label mapping — a user poll is fail-closed',
+        metric: new cloudwatch.Metric({
+          namespace: triageMetricNamespace,
+          metricName: untrustedLabelMetricName,
+          period: cdk.Duration.minutes(5),
+          statistic: 'Sum',
+        }),
+        threshold: 1,
+        evaluationPeriods: 1,
+        comparisonOperator:
+          cloudwatch.ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+        treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
+      },
+    );
+    if (resources.agentAlarmTopic) {
+      untrustedLabelMappingAlarm.addAlarmAction(
+        new cloudwatchActions.SnsAction(resources.agentAlarmTopic),
+      );
+    }
+
     resources.triageWorkerRole.addToPolicy(new iam.PolicyStatement({
       sid: 'TriageWorkerLogsCorrectArn',
       effect: iam.Effect.ALLOW,

--- a/jest.config.ci.js
+++ b/jest.config.ci.js
@@ -63,7 +63,9 @@ const customJestConfig = {
     '/node_modules/',
     '/tests/e2e/',
     '/.next/',
-    '/infra/',  // Infra has its own Jest config and CDK dependencies
+    // Infra has its own Jest config, except the triage worker's focused
+    // runtime-boundary tests (pure TypeScript with no CDK dependency).
+    '/infra/(?!lambdas/agent-triage-poll/__tests__/)',
     '/tests/performance/',  // EXCLUDE performance tests in CI
     '<rootDir>/.claude/worktrees/',  // Nested worktrees only - see note above
     'mock-sse-factory.ts',  // Utility file, not a test file

--- a/jest.config.js
+++ b/jest.config.js
@@ -54,7 +54,10 @@ const customJestConfig = {
     '/node_modules/',
     '/tests/e2e/',
     '/.next/',
-    '/infra/', // Infra has its own Jest config
+    // Infra has its own Jest config, except the triage worker's focused
+    // runtime-boundary tests. Keep those in the Lambda directory while
+    // executing them through the root Jest gate used by CI.
+    '/infra/(?!lambdas/agent-triage-poll/__tests__/)',
     '/infra/cdk.out/',
     '<rootDir>/.claude/worktrees/', // Nested worktrees only - see note above
     'mock-sse-factory.ts' // Utility file, not a test file

--- a/tests/unit/agent-triage-worker-security.test.ts
+++ b/tests/unit/agent-triage-worker-security.test.ts
@@ -13,6 +13,7 @@ const mockGetUserProfile = jest.fn()
 const mockRecordPollResult = jest.fn()
 const mockRecordTaskCreated = jest.fn()
 const mockReleaseTaskGestureClaim = jest.fn()
+const mockStampTrustedTriageLabelMapping = jest.fn()
 const mockRequestTaskCreation = jest.fn()
 const mockPostTaskOutcome = jest.fn()
 
@@ -64,6 +65,8 @@ jest.mock("@/infra/lambdas/agent-triage-poll/storage", () => ({
   releaseTaskGestureClaim: (...args: unknown[]) =>
     mockReleaseTaskGestureClaim(...args),
   resetCursor: jest.fn(),
+  stampTrustedTriageLabelMapping: (...args: unknown[]) =>
+    mockStampTrustedTriageLabelMapping(...args),
 }))
 
 jest.mock("@/infra/lambdas/agent-triage-poll/agentcore", () => ({
@@ -182,24 +185,75 @@ describe("agent triage worker label sink", () => {
     mockRecordPollResult.mockResolvedValue(undefined)
     mockRecordTaskCreated.mockResolvedValue(undefined)
     mockReleaseTaskGestureClaim.mockResolvedValue(undefined)
+    mockStampTrustedTriageLabelMapping.mockResolvedValue(undefined)
     mockPostTaskOutcome.mockResolvedValue(undefined)
     mockModifyThread.mockResolvedValue(undefined)
+    mockListHistory.mockResolvedValue({
+      events: [],
+      latestHistoryId: "101",
+      tooOld: false,
+    })
   })
 
-  it.each([
-    ["legacy", row({ labelMappingVersion: undefined })],
-    ["foreign", row({ labelMappingOwnerEmail: "attacker@example.com" })],
-  ])("fails closed before any Gmail call for %s state", async (_name, state) => {
-    await expect(
-      classifyAndLabel(state, "token", {
-        id: "message-1",
-        threadId: "thread-1",
+  it("heals a legacy mapping and continues the poll in the same tick", async () => {
+    await processUser(
+      row({
+        labelMappingVersion: undefined,
+        labelMappingProvenance: undefined,
+        labelMappingOwnerEmail: undefined,
+        labelMappingResolvedAt: undefined,
+        lastHistoryId: "100",
       })
-    ).resolves.toBeNull()
-    expect(mockListLabels).not.toHaveBeenCalled()
-    expect(mockGetMessageMetadata).not.toHaveBeenCalled()
-    expect(mockApplyRules).not.toHaveBeenCalled()
-    expect(mockModifyMessage).not.toHaveBeenCalled()
+    )
+
+    expect(mockStampTrustedTriageLabelMapping).toHaveBeenCalledWith(
+      expect.objectContaining({
+        labels: TRIAGE_LABEL_NAMES,
+        labelIdsByKey: IDS,
+        labelMappingVersion: TRIAGE_LABEL_MAPPING_VERSION,
+        labelMappingProvenance: TRIAGE_LABEL_MAPPING_PROVENANCE,
+        labelMappingOwnerEmail: "owner@example.com",
+        labelMappingResolvedAt: expect.any(String),
+      })
+    )
+    expect(mockListHistory).toHaveBeenCalledWith("token", "100")
+    expect(mockRecordPollResult).toHaveBeenCalledWith(
+      "owner@example.com",
+      expect.objectContaining({ lastHistoryId: "101" }),
+      [],
+      []
+    )
+  })
+
+  it("fails closed without stamping when live labels are ambiguous", async () => {
+    mockListLabels.mockResolvedValue([
+      ...liveLabels(),
+      {
+        id: "Label_important_duplicate",
+        name: TRIAGE_LABEL_NAMES.important,
+        type: "user",
+      },
+    ])
+
+    await processUser(
+      row({
+        labelMappingVersion: undefined,
+        lastHistoryId: "100",
+      })
+    )
+
+    expect(mockStampTrustedTriageLabelMapping).not.toHaveBeenCalled()
+    expect(mockListHistory).not.toHaveBeenCalled()
+    expect(mockRecordPollResult).not.toHaveBeenCalled()
+  })
+
+  it("passes through a valid row without a provenance write", async () => {
+    await processUser(row({ lastHistoryId: "100" }))
+
+    expect(mockListLabels).toHaveBeenCalledTimes(1)
+    expect(mockStampTrustedTriageLabelMapping).not.toHaveBeenCalled()
+    expect(mockListHistory).toHaveBeenCalledWith("token", "100")
+    expect(mockRecordPollResult).toHaveBeenCalled()
   })
 
   it("fails closed when the live label was renamed", async () => {

--- a/tests/unit/agent-triage-worker-security.test.ts
+++ b/tests/unit/agent-triage-worker-security.test.ts
@@ -247,6 +247,20 @@ describe("agent triage worker label sink", () => {
     expect(mockRecordPollResult).not.toHaveBeenCalled()
   })
 
+  it("fails closed before Gmail work for mismatched owner provenance", async () => {
+    await processUser(
+      row({
+        labelMappingOwnerEmail: "attacker@example.com",
+        lastHistoryId: "100",
+      })
+    )
+
+    expect(mockListLabels).not.toHaveBeenCalled()
+    expect(mockStampTrustedTriageLabelMapping).not.toHaveBeenCalled()
+    expect(mockListHistory).not.toHaveBeenCalled()
+    expect(mockRecordPollResult).not.toHaveBeenCalled()
+  })
+
   it("passes through a valid row without a provenance write", async () => {
     await processUser(row({ lastHistoryId: "100" }))
 

--- a/tests/unit/lib/email-triage-label-map.test.ts
+++ b/tests/unit/lib/email-triage-label-map.test.ts
@@ -25,7 +25,15 @@ const {
     loadLiveLabels: () => Promise<
       Array<{ id: string; name: string; type: "user" }>
     >
-  ) => Promise<Record<keyof typeof IDS, string> | null>
+  ) => Promise<
+    | {
+        valid: true
+        mapping: {
+          labelIdsByKey: Record<keyof typeof IDS, string>
+        }
+      }
+    | { valid: false; reason: string }
+  >
   TRIAGE_LABEL_MAPPING_PROVENANCE: string
   TRIAGE_LABEL_MAPPING_VERSION: number
   TRIAGE_LABEL_NAMES: Record<keyof typeof IDS, string>
@@ -119,7 +127,10 @@ describe("trusted email triage label mapping", () => {
         },
         loadLiveLabels
       )
-    ).resolves.toBeNull()
+    ).resolves.toEqual({
+      valid: false,
+      reason: "untrusted-or-stale-provenance",
+    })
     expect(loadLiveLabels).not.toHaveBeenCalled()
   })
 
@@ -148,9 +159,9 @@ describe("trusted email triage label mapping", () => {
     expect(classifier.indexOf("trustedLabelIdsForRow(")).toBeLessThan(
       classifier.indexOf("getMessageMetadata(")
     )
-    expect(classifier.indexOf("if (!trustedLabelIds) return null")).toBeLessThan(
-      classifier.indexOf("modifyMessage(")
-    )
+    expect(
+      classifier.indexOf("if (!trustedLabelMapping) return null")
+    ).toBeLessThan(classifier.indexOf("modifyMessage("))
     expect(classifier).toContain(
       'modifyMessage(accessToken, msgRef.id, [labelId], ["INBOX"])'
     )


### PR DESCRIPTION
## Description

Restore production email triage for legacy rows that predate the trusted label-mapping provenance fields.

This PR:

- rebuilds an enabled legacy row only from the owner token's live Gmail labels and the four code-constant canonical names;
- requires exactly one `type: "user"` match per name plus safe, unique label ids;
- persists the complete trusted mapping and continues the poll in the same tick;
- preserves fail-closed logging for missing, ambiguous, unsafe, duplicate, or no-longer-related live labels;
- adds a JSON log metric filter and five-minute CloudWatch alarm in dev and prod, routed to the existing agent alarm topic when configured; and
- documents rollout verification, including the existing stale-history/manual-sweep path.

No database migration or environment-variable change is required. The alarm is additive. Existing trusted rows are live-verified and are not rewritten.

## Acceptance criteria

- [x] Legacy/stale provenance self-heals from canonical owner-token Gmail resolution.
- [x] All trusted provenance fields and `labelIdsByKey` are stamped.
- [x] Polling continues in the same tick after a successful heal.
- [x] Missing/ambiguous/system/duplicate label state remains fail-closed and logged.
- [x] Jest tests under `infra/lambdas/agent-triage-poll/` cover heal success, ambiguity, and valid passthrough.
- [x] Dev/prod metric filter and CloudWatch alarm synthesize cleanly.
- [x] Deployment runbook covers `label_mapping_healed`, `lastPollAt`, stale history, and alarm verification.
- [x] E2E is N/A because this is a Lambda/CDK-only change with no UI surface.

## Validation

- `bun run lint` — passed with zero warnings
- `bun run typecheck` — passed
- `bun run test:ci -- --runInBand` — 538 suites passed (1 skipped), 4,976 tests passed (15 skipped)
- focused triage suites — 4 suites, 24 tests passed
- `bun run build` with CI auth artifact environment — passed
- `bun run openapi:check` — passed
- `bun run capabilities:check` — passed
- `infra/lambdas/agent-triage-poll: bun run build` — passed
- `infra: bun run build` — passed; agent-skill-builder 17 tests passed
- `infra: bunx cdk synth --all --no-lookups --context baseDomain=example.com` — passed for all dev/prod stacks
- production agent-platform synth with `alertEmail` context — passed; generated `AlarmActions` references `AgentAlarmTopic`
- `git diff --check` — passed

The repository's authenticated pre-push E2E hook requires a real `.env.local`; the issue explicitly marks E2E N/A for this Lambda/CDK-only change, so the documented one-push `SKIP_E2E=1` path was used after the relevant full gates passed.

## Checklist

- [x] No new `console.*` calls in production/shared code
- [x] No client logger changes
- [x] Lint passes (`bun run lint`)
- [x] All relevant tests pass
- [x] Types/interfaces follow project conventions
- [x] No `any` types or unjustified assertions
- [x] TypeScript strict-mode checks pass
- [x] No environment-variable or `.env.example` change needed
- [x] Documentation updated
- [ ] Code reviewed and approved
- [x] Application and Lambda/infra builds pass

## Risks and rollback

Risk is low-medium: recovery writes a mapping only after strict owner-token live resolution. A failed or ambiguous recovery writes nothing and skips the user. Rollback is the previous AgentPlatform worker/stack; mappings already stamped by this version remain compatible with the existing application writer.

## Related Issues

Closes #1489
