### PR TITLE
fix(agent-schedules): migrate legacy records and targets

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -160,6 +160,10 @@ configuration, retrieval validation, and prior-edition retirement.
 #### [operations/production-migration-checklist.md](./operations/production-migration-checklist.md)
 Comprehensive checklist for deploying to production.
 
+#### [operations/agent-schedule-legacy-backfill.md](./operations/agent-schedule-legacy-backfill.md)
+Deployment, stale-DLQ cleanup, explicit invocation, and verification steps for
+the owner-bound agent schedule record and Scheduler-target migration.
+
 #### [operations/unified-content-migration-retirement.md](./operations/unified-content-migration-retirement.md)
 Inventory, backfill, reconciliation, cutover, rollback, and legacy-content retirement runbook.
 

--- a/docs/operations/agent-schedule-legacy-backfill.md
+++ b/docs/operations/agent-schedule-legacy-backfill.md
@@ -17,6 +17,9 @@ The migration is additive and idempotent:
 Do not manually run schedules or change their cadence while performing this
 repair. In particular, keep the dev forklift schedules disabled and preserve
 Morning Dispatch schedule `5123b45b` at `0 6 * * MON-FRI`.
+The runtime accepts this preserved eight-character hexadecimal ID for
+invocation, update, and deletion; newly created schedules continue to use
+UUIDs.
 
 ## Deployment order
 

--- a/docs/operations/agent-schedule-legacy-backfill.md
+++ b/docs/operations/agent-schedule-legacy-backfill.md
@@ -1,0 +1,103 @@
+# Agent schedule legacy backfill
+
+This runbook repairs schedule records and EventBridge Scheduler targets created
+before the owner-bound schedule-reference contract. It applies to
+`psd-agent-schedules-{dev,prod}` and the `psd-agent-{dev,prod}` Scheduler
+groups.
+
+The migration is additive and idempotent:
+
+- schedule rows gain `version`, `ownerEmail`, `schedulerExpression`,
+  `workspacePrefix`, and a missing `dmSpaceName`;
+- Scheduler target input becomes only `ownerEmail`, `scheduleId`, `version`,
+  and the `<aws.scheduler.scheduled-time>` context token;
+- existing Scheduler expressions, time zones, state, flexible time windows,
+  and delivery settings are preserved.
+
+Do not manually run schedules or change their cadence while performing this
+repair. In particular, keep the dev forklift schedules disabled and preserve
+Morning Dispatch schedule `5123b45b` at `0 6 * * MON-FRI`.
+
+## Deployment order
+
+1. Run the full infrastructure build and synth before deploying:
+
+   ```bash
+   cd infra
+   bun run build
+   bunx cdk synth --all --no-lookups --context baseDomain=example.com
+   ```
+
+2. Deploy the Agent Platform stack before the Frontend stack. The Agent
+   Platform stack publishes the corrected worker and IAM policy. The Frontend
+   stack's versioned custom resource invokes it after the lock-aware ECS
+   service is steady.
+
+3. Migrate and verify dev before prod.
+
+The worker starts with DynamoDB records, follows paginated continuations, and
+then migrates Scheduler targets. It retries IAM `AccessDeniedException` with
+exponential backoff for eight attempts; Lambda asynchronous retries and the
+alarm-backed DLQ remain the outer safety net.
+
+## Remove stale pre-fix DLQ invocations
+
+The old dev and prod backfill payloads failed before the IAM fix and must not be
+redriven. For each environment, inspect the messages in
+`psd-agent-async-dlq-{env}`, confirm the message is the stale
+`psd-agent-schedule-target-backfill` invocation, and delete that exact message
+by receipt handle. Do not redrive it and do not purge unrelated agent failures
+from the shared queue.
+
+After deletion, verify the queue contains no stale backfill invocation. Preserve
+and triage any unrelated message according to the normal agent DLQ procedure.
+
+## Explicit fresh invocation
+
+The versioned Frontend custom resource invokes the worker on both create and
+update. If an operator must repeat the idempotent migration, invoke the
+corrected function with a fresh records-phase payload:
+
+```bash
+aws lambda invoke \
+  --function-name psd-agent-schedule-target-backfill-dev \
+  --invocation-type Event \
+  --cli-binary-format raw-in-base64-out \
+  --payload '{"RequestType":"Update","phase":"records","migrationVersion":"legacy-schedule-records-and-targets-v4"}' \
+  /tmp/agent-schedule-backfill-dev.json
+```
+
+Repeat for prod only after dev verification, changing both `dev` occurrences
+to `prod`. A `202` status confirms acceptance, not completion.
+
+## Verification
+
+For each environment:
+
+1. Inspect `/aws/lambda/psd-agent-schedule-target-backfill-{env}` until the
+   final targets-phase page reports `continuationQueued=false`.
+2. Confirm every user schedule row has:
+   - `version >= 1`;
+   - `ownerEmail` equal to the `userId` partition key;
+   - `schedulerExpression` derived from the unchanged `cronExpression`;
+   - a trusted `workspacePrefix` and valid `dmSpaceName`.
+3. Confirm every Scheduler target input contains only the owner-bound reference
+   and scheduled-time token. Confirm the schedule's expression, time zone, and
+   state are unchanged.
+4. Confirm no new message entered `psd-agent-async-dlq-{env}` and no
+   `schedule_record_backfill_invalid_record` or
+   `schedule_target_backfill_invalid_target` marker remains unexplained.
+5. From the agent, run `psd-schedules list`. It must return the owner's
+   schedules without HTTP 409 and without a degraded flag after migration.
+
+For prod, additionally wait for the next weekday 6:00 AM PT Morning Dispatch
+fire. Confirm `Scheduled task completed` in
+`/aws/lambda/psd-agent-cron-prod` and confirm Chat delivery.
+
+## Rollback
+
+The row changes add missing authoritative fields, and the target changes use a
+minimal input understood by the hardened cron Lambda. Do not remove migrated
+fields as an operational rollback. Revert and redeploy the application/Lambda
+code if required; retain the migrated data and investigate any per-record
+failure before another fresh invocation.

--- a/infra/lambdas/agent-cron/run-telemetry.ts
+++ b/infra/lambdas/agent-cron/run-telemetry.ts
@@ -227,8 +227,8 @@ export async function writePreflightRun(
             UNION ALL
             SELECT existing.status
             FROM agent_scheduled_runs AS existing
-            WHERE :fire_key IS NOT NULL
-              AND existing.fire_key = :fire_key
+            WHERE CAST(:fire_key AS text) IS NOT NULL
+              AND existing.fire_key = CAST(:fire_key AS text)
               AND NOT EXISTS (SELECT 1 FROM inserted)
             LIMIT 1`,
       parameters: scheduledRunParameters(params),

--- a/infra/lambdas/agent-cron/schedule-preflight.ts
+++ b/infra/lambdas/agent-cron/schedule-preflight.ts
@@ -24,6 +24,13 @@ export interface SchedulePreflightResult {
   referencedScheduleId: string;
 }
 
+const ALARMED_REJECTION_REASONS = new Set([
+  'invalid-reference',
+  'owner-mismatch',
+  'version-mismatch',
+  'invalid-record',
+]);
+
 function boundedReferenceValue(
   value: unknown,
   maximumLength: number,
@@ -76,6 +83,9 @@ export async function runSchedulePreflight(
     const errorMessage = `Schedule reference rejected: ${loaded.reason}`;
     options.log.warn('Schedule reference rejected before invocation', {
       reason: loaded.reason,
+      ...(ALARMED_REJECTION_REASONS.has(loaded.reason)
+        ? { marker: 'SCHEDULE_REFERENCE_REJECTION' }
+        : {}),
     });
     await options.telemetry.recordPreflightRun(
       {

--- a/infra/lambdas/agent-cron/schedule-record.test.ts
+++ b/infra/lambdas/agent-cron/schedule-record.test.ts
@@ -6,6 +6,7 @@ import {
 
 const OWNER = 'owner@psd401.net';
 const SCHEDULE_ID = '36bb0456-1c51-4fb8-97d1-4e87d02765ce';
+const LEGACY_SCHEDULE_ID = '5123b45b';
 
 function record(overrides: Record<string, unknown> = {}) {
   return {
@@ -59,6 +60,42 @@ describe('authoritative cron schedule loading', () => {
       scheduleId: SCHEDULE_ID,
     });
     expect(input.ConsistentRead).toBe(true);
+  });
+
+  it('authorizes a preserved legacy hexadecimal schedule ID', async () => {
+    const legacyRecord = record({ scheduleId: LEGACY_SCHEDULE_ID });
+    const { result, get } = await load(
+      {
+        ownerEmail: OWNER,
+        scheduleId: LEGACY_SCHEDULE_ID,
+        version: 3,
+      },
+      legacyRecord,
+    );
+    expect(result).toEqual({
+      authorized: true,
+      schedule: legacyRecord,
+    });
+    expect(get.mock.calls[0][0].Key).toEqual({
+      userId: OWNER,
+      scheduleId: LEGACY_SCHEDULE_ID,
+    });
+  });
+
+  it('rejects arbitrary non-UUID schedule IDs', async () => {
+    const { result, get } = await load(
+      {
+        ownerEmail: OWNER,
+        scheduleId: 'schedule-id',
+        version: 3,
+      },
+      record({ scheduleId: 'schedule-id' }),
+    );
+    expect(result).toEqual({
+      authorized: false,
+      reason: 'invalid-reference',
+    });
+    expect(get).not.toHaveBeenCalled();
   });
 
   it.each([

--- a/infra/lambdas/agent-cron/schedule-record.ts
+++ b/infra/lambdas/agent-cron/schedule-record.ts
@@ -3,6 +3,7 @@ import type { GetCommandInput } from '@aws-sdk/lib-dynamodb';
 const SAFE_EMAIL_RE = /^[\w%+.-]+@[\d.A-Za-z-]+\.[A-Za-z]{2,}$/;
 const SCHEDULE_ID_RE =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const LEGACY_SCHEDULE_ID_RE = /^[0-9a-f]{8}$/i;
 const DM_SPACE_RE = /^spaces\/[\w-]{1,256}$/;
 
 export interface ScheduleReferenceEvent {
@@ -64,7 +65,10 @@ function isValidScheduleReference(
     && SAFE_EMAIL_RE.test(ownerEmail);
   const validScheduleId =
     typeof event.scheduleId === 'string'
-    && SCHEDULE_ID_RE.test(event.scheduleId);
+    && (
+      SCHEDULE_ID_RE.test(event.scheduleId)
+      || LEGACY_SCHEDULE_ID_RE.test(event.scheduleId)
+    );
   const validVersion =
     Number.isInteger(event.version) && Number(event.version) >= 1;
   return validOwner && validScheduleId && validVersion && !!schedulesTable;

--- a/infra/lambdas/agent-schedule-target-backfill/backfill.ts
+++ b/infra/lambdas/agent-schedule-target-backfill/backfill.ts
@@ -141,6 +141,34 @@ function normalizedEmail(value: unknown): string {
   return typeof value === 'string' ? value.trim().toLowerCase() : '';
 }
 
+export function selectTrustedOwnerProfile(
+  ownerEmail: string,
+  values: Record<string, unknown>[],
+): TrustedOwnerProfile | null {
+  const candidates = values.filter(
+    (value) =>
+      normalizedEmail(value.email) === ownerEmail
+      && typeof value.dmSpaceName === 'string'
+      && DM_SPACE_RE.test(value.dmSpaceName),
+  );
+  const selected = candidates.find(
+    (value) =>
+      typeof value.googleIdentity === 'string'
+      && /^users\/\d+$/.test(value.googleIdentity),
+  ) ?? candidates[0];
+  if (!selected || typeof selected.dmSpaceName !== 'string') return null;
+  const workspacePrefix =
+    typeof selected.workspacePrefix === 'string'
+    && selected.workspacePrefix.length > 0
+    && selected.workspacePrefix.length <= 128
+      ? selected.workspacePrefix
+      : ownerEmail.split('@')[0];
+  return {
+    workspacePrefix,
+    dmSpaceName: selected.dmSpaceName,
+  };
+}
+
 /**
  * Mirror the broker's five/six-field cron normalization for legacy records.
  * The migration deliberately preserves the stored cronExpression verbatim and
@@ -227,7 +255,7 @@ function legacyOwner(
       'Legacy schedule record owner conflicts with its partition',
     );
   }
-  return existingOwner ? undefined : partitionOwner;
+  return value === partitionOwner ? undefined : partitionOwner;
 }
 
 function legacyExpression(

--- a/infra/lambdas/agent-schedule-target-backfill/backfill.ts
+++ b/infra/lambdas/agent-schedule-target-backfill/backfill.ts
@@ -10,25 +10,71 @@ const SCHEDULED_TIME_PLACEHOLDER = '<aws.scheduler.scheduled-time>';
 const UPDATE_CONCURRENCY = 5;
 const MAXIMUM_EVENT_AGE_SECONDS = 60 * 60;
 const MAXIMUM_RETRY_ATTEMPTS = 5;
+const IAM_PROPAGATION_ATTEMPTS = 8;
 const SAFE_EMAIL_RE = /^[\w%+.-]+@[\d.A-Za-z-]+\.[A-Za-z]{2,}$/;
+const DM_SPACE_RE = /^spaces\/[\w-]{1,256}$/;
+const UPDATEABLE_RECORD_FIELDS = [
+  'version',
+  'ownerEmail',
+  'schedulerExpression',
+  'workspacePrefix',
+  'dmSpaceName',
+] as const;
+
+export type ScheduleBackfillPhase = 'records' | 'targets';
+
+export interface ScheduleBackfillContinuation {
+  phase: ScheduleBackfillPhase;
+  nextToken?: string;
+}
+
+export interface TrustedOwnerProfile {
+  dmSpaceName?: string;
+  workspacePrefix: string;
+}
+
+export interface LegacyScheduleRecordUpgrade {
+  version?: number;
+  ownerEmail?: string;
+  schedulerExpression?: string;
+  workspacePrefix?: string;
+  dmSpaceName?: string;
+}
 
 export interface ScheduleTargetBackfillDependencies {
   scheduleDlqArn: string;
+  listRecords(nextToken?: string): Promise<{
+    records: Record<string, unknown>[];
+    nextToken?: string;
+  }>;
+  getRecord(
+    identity: ScheduleMutationIdentity,
+  ): Promise<Record<string, unknown> | undefined>;
+  loadOwnerProfile(ownerEmail: string): Promise<TrustedOwnerProfile | null>;
+  updateRecord(
+    identity: ScheduleMutationIdentity,
+    upgrade: LegacyScheduleRecordUpgrade,
+  ): Promise<void>;
   list(nextToken?: string): Promise<{
     names: string[];
     nextToken?: string;
   }>;
   get(name: string): Promise<GetScheduleCommandOutput>;
   update(input: UpdateScheduleCommandInput): Promise<void>;
-  queueContinuation(nextToken: string): Promise<void>;
+  queueContinuation(continuation: ScheduleBackfillContinuation): Promise<void>;
   withMutationLock<T>(
     identity: ScheduleMutationIdentity,
     execute: () => Promise<T>,
   ): Promise<T>;
+  recordInvalidRecord(
+    identity: ScheduleMutationIdentity | null,
+    errorMessage: string,
+  ): void;
   recordInvalidTarget(name: string, errorMessage: string): void;
 }
 
 export interface ScheduleTargetBackfillResult {
+  phase: ScheduleBackfillPhase;
   scanned: number;
   updated: number;
   invalid: number;
@@ -42,6 +88,37 @@ export class InvalidScheduleTargetError extends Error {
   }
 }
 
+function isAccessDenied(error: unknown): boolean {
+  return (
+    error instanceof Error
+    && (
+      error.name === 'AccessDeniedException'
+      || error.name === 'AccessDenied'
+    )
+  );
+}
+
+export async function withIamPropagationRetry<T>(
+  operation: () => Promise<T>,
+  wait: (milliseconds: number) => Promise<void> =
+    (milliseconds) =>
+      new Promise((resolve) => setTimeout(resolve, milliseconds)),
+  attempts = IAM_PROPAGATION_ATTEMPTS,
+): Promise<T> {
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    try {
+      return await operation();
+    } catch (error) {
+      lastError = error;
+      if (!isAccessDenied(error) || attempt === attempts) throw error;
+      const delayMs = Math.min(2 ** (attempt - 1) * 1_000, 30_000);
+      await wait(delayMs);
+    }
+  }
+  throw lastError;
+}
+
 function objectValue(value: unknown): Record<string, unknown> | null {
   return (
     typeof value === 'object'
@@ -52,13 +129,191 @@ function objectValue(value: unknown): Record<string, unknown> | null {
     : null;
 }
 
-export interface ScheduleTargetReference extends ScheduleMutationIdentity {
-  version: number;
+function boundedString(value: unknown, maximumLength: number): value is string {
+  return (
+    typeof value === 'string'
+    && value.length > 0
+    && value.length <= maximumLength
+  );
 }
 
-export function scheduleTargetReference(
+function normalizedEmail(value: unknown): string {
+  return typeof value === 'string' ? value.trim().toLowerCase() : '';
+}
+
+/**
+ * Mirror the broker's five/six-field cron normalization for legacy records.
+ * The migration deliberately preserves the stored cronExpression verbatim and
+ * derives only the EventBridge representation.
+ */
+export function legacySchedulerExpression(value: unknown): string {
+  if (typeof value !== 'string' || value.trim().length === 0) {
+    throw new InvalidScheduleTargetError(
+      'Legacy schedule record has no cron expression',
+    );
+  }
+  const expression = value.trim();
+  if (
+    /^cron\(.+\)$/.test(expression)
+    || /^rate\(.+\)$/.test(expression)
+    || /^at\(.+\)$/.test(expression)
+  ) {
+    return expression;
+  }
+  const fields = expression.split(/\s+/);
+  if (fields.length !== 5 && fields.length !== 6) {
+    throw new InvalidScheduleTargetError(
+      'Legacy schedule record has an invalid cron expression',
+    );
+  }
+  const expanded = fields.length === 5 ? [...fields, '*'] : [...fields];
+  const dayOfMonthSpecified = expanded[2] !== '*' && expanded[2] !== '?';
+  const dayOfWeekSpecified = expanded[4] !== '*' && expanded[4] !== '?';
+  if (dayOfMonthSpecified && dayOfWeekSpecified) {
+    throw new InvalidScheduleTargetError(
+      'Legacy schedule record has an ambiguous cron expression',
+    );
+  }
+  if (dayOfWeekSpecified) expanded[2] = '?';
+  else expanded[4] = '?';
+  return `cron(${expanded.join(' ')})`;
+}
+
+export function scheduleRecordIdentity(
+  value: unknown,
+): ScheduleMutationIdentity | null {
+  const record = objectValue(value);
+  if (!record || typeof record.scheduleId !== 'string') {
+    throw new InvalidScheduleTargetError(
+      'Legacy schedule record has no schedule identity',
+    );
+  }
+  if (record.scheduleId.startsWith('__')) return null;
+  const ownerEmail = normalizedEmail(record.userId);
+  const scheduleId = record.scheduleId.trim().toLowerCase();
+  if (
+    !SAFE_EMAIL_RE.test(ownerEmail)
+    || scheduleId.length === 0
+    || scheduleId.length > 128
+  ) {
+    throw new InvalidScheduleTargetError(
+      'Legacy schedule record has no owner-bound identity',
+    );
+  }
+  return { ownerEmail, scheduleId };
+}
+
+function requiresTrustedOwnerProfile(
+  record: Record<string, unknown>,
+): boolean {
+  return (
+    typeof record.dmSpaceName !== 'string'
+    || !DM_SPACE_RE.test(record.dmSpaceName)
+    || !boundedString(record.workspacePrefix, 128)
+  );
+}
+
+function legacyVersion(value: unknown): number | undefined {
+  return Number.isInteger(value) && Number(value) >= 1 ? undefined : 1;
+}
+
+function legacyOwner(
+  value: unknown,
+  partitionOwner: string,
+): string | undefined {
+  const existingOwner = normalizedEmail(value);
+  if (existingOwner && existingOwner !== partitionOwner) {
+    throw new InvalidScheduleTargetError(
+      'Legacy schedule record owner conflicts with its partition',
+    );
+  }
+  return existingOwner ? undefined : partitionOwner;
+}
+
+function legacyExpression(
+  record: Record<string, unknown>,
+): string | undefined {
+  return boundedString(record.schedulerExpression, 256)
+    ? undefined
+    : legacySchedulerExpression(record.cronExpression);
+}
+
+function legacyWorkspace(
+  record: Record<string, unknown>,
+  profile: TrustedOwnerProfile | null,
+): string | undefined {
+  if (boundedString(record.workspacePrefix, 128)) return undefined;
+  if (!profile || !boundedString(profile.workspacePrefix, 128)) {
+    throw new InvalidScheduleTargetError(
+      'Legacy schedule owner has no trusted workspace profile',
+    );
+  }
+  return profile.workspacePrefix;
+}
+
+function legacyDmSpace(
+  record: Record<string, unknown>,
+  profile: TrustedOwnerProfile | null,
+): string | undefined {
+  if (
+    typeof record.dmSpaceName === 'string'
+    && DM_SPACE_RE.test(record.dmSpaceName)
+  ) {
+    return undefined;
+  }
+  if (
+    !profile
+    || typeof profile.dmSpaceName !== 'string'
+    || !DM_SPACE_RE.test(profile.dmSpaceName)
+  ) {
+    throw new InvalidScheduleTargetError(
+      'Legacy schedule owner has no trusted direct-message destination',
+    );
+  }
+  return profile.dmSpaceName;
+}
+
+function assignUpgrade<K extends keyof LegacyScheduleRecordUpgrade>(
+  upgrade: LegacyScheduleRecordUpgrade,
+  field: K,
+  value: LegacyScheduleRecordUpgrade[K],
+): void {
+  if (value !== undefined) upgrade[field] = value;
+}
+
+export function legacyScheduleRecordUpgrade(
+  value: unknown,
+  profile: TrustedOwnerProfile | null,
+): LegacyScheduleRecordUpgrade | null {
+  const record = objectValue(value);
+  const identity = scheduleRecordIdentity(record);
+  if (!record || !identity) return null;
+
+  const upgrade: LegacyScheduleRecordUpgrade = {};
+  assignUpgrade(upgrade, 'version', legacyVersion(record.version));
+  assignUpgrade(
+    upgrade,
+    'ownerEmail',
+    legacyOwner(record.ownerEmail, identity.ownerEmail),
+  );
+  assignUpgrade(upgrade, 'schedulerExpression', legacyExpression(record));
+  assignUpgrade(upgrade, 'workspacePrefix', legacyWorkspace(record, profile));
+  assignUpgrade(upgrade, 'dmSpaceName', legacyDmSpace(record, profile));
+
+  return UPDATEABLE_RECORD_FIELDS.some(
+    (field) => upgrade[field] !== undefined,
+  )
+    ? upgrade
+    : null;
+}
+
+export interface ScheduleTargetReference extends ScheduleMutationIdentity {
+  version?: number;
+}
+
+function parsedTargetInput(
   rawInput: string | undefined,
-): ScheduleTargetReference {
+): Record<string, unknown> {
   if (!rawInput) {
     throw new InvalidScheduleTargetError(
       'Schedule target is missing Input',
@@ -73,21 +328,52 @@ export function scheduleTargetReference(
     );
   }
   const input = objectValue(parsed);
-  const ownerEmail =
-    typeof input?.ownerEmail === 'string'
-      ? input.ownerEmail.trim().toLowerCase()
-      : '';
-  const scheduleId =
-    typeof input?.scheduleId === 'string'
-      ? input.scheduleId.trim().toLowerCase()
-      : '';
+  if (!input) {
+    throw new InvalidScheduleTargetError(
+      'Schedule target Input is not an object',
+    );
+  }
+  return input;
+}
+
+function targetOwner(input: Record<string, unknown>): string {
+  const currentOwner = normalizedEmail(input.ownerEmail);
+  const legacyOwnerEmail = normalizedEmail(input.userEmail);
   if (
-    !input
-    || !SAFE_EMAIL_RE.test(ownerEmail)
+    currentOwner
+    && legacyOwnerEmail
+    && currentOwner !== legacyOwnerEmail
+  ) {
+    throw new InvalidScheduleTargetError(
+      'Schedule target Input has conflicting owners',
+    );
+  }
+  return currentOwner || legacyOwnerEmail;
+}
+
+function targetScheduleId(input: Record<string, unknown>): string {
+  return typeof input.scheduleId === 'string'
+    ? input.scheduleId.trim().toLowerCase()
+    : '';
+}
+
+function targetVersion(input: Record<string, unknown>): number | undefined {
+  return Number.isInteger(input.version) && Number(input.version) >= 1
+    ? Number(input.version)
+    : undefined;
+}
+
+export function scheduleTargetReference(
+  rawInput: string | undefined,
+): ScheduleTargetReference {
+  const input = parsedTargetInput(rawInput);
+  const ownerEmail = targetOwner(input);
+  const scheduleId = targetScheduleId(input);
+  const version = targetVersion(input);
+  if (
+    !SAFE_EMAIL_RE.test(ownerEmail)
     || scheduleId.length === 0
     || scheduleId.length > 128
-    || !Number.isInteger(input.version)
-    || Number(input.version) < 1
   ) {
     throw new InvalidScheduleTargetError(
       'Schedule target Input has no owner-bound reference',
@@ -96,7 +382,7 @@ export function scheduleTargetReference(
   return {
     ownerEmail,
     scheduleId,
-    version: Number(input.version),
+    ...(version ? { version } : {}),
   };
 }
 
@@ -106,32 +392,31 @@ export function scheduleTargetReference(
  */
 export function backfilledTargetInput(
   rawInput: string | undefined,
+  authoritativeVersion?: number,
 ): string | null {
-  if (!rawInput) {
+  const input = parsedTargetInput(rawInput);
+  const reference = scheduleTargetReference(rawInput);
+  const version = authoritativeVersion ?? reference.version;
+  if (!Number.isInteger(version) || Number(version) < 1) {
     throw new InvalidScheduleTargetError(
-      'Schedule target is missing Input',
+      'Schedule target has no authoritative record version',
     );
   }
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(rawInput);
-  } catch {
-    throw new InvalidScheduleTargetError(
-      'Schedule target Input is not valid JSON',
-    );
-  }
-  const input = objectValue(parsed);
-  scheduleTargetReference(rawInput);
-  if (!input) {
-    throw new InvalidScheduleTargetError(
-      'Schedule target Input is not an object',
-    );
-  }
-  if (input.scheduledTime === SCHEDULED_TIME_PLACEHOLDER) return null;
-  return JSON.stringify({
-    ...input,
+  const canonical = {
+    ownerEmail: reference.ownerEmail,
+    scheduleId: reference.scheduleId,
+    version: Number(version),
     scheduledTime: SCHEDULED_TIME_PLACEHOLDER,
-  });
+  };
+  return (
+    input.ownerEmail === canonical.ownerEmail
+    && input.scheduleId === canonical.scheduleId
+    && input.version === canonical.version
+    && input.scheduledTime === canonical.scheduledTime
+    && Object.keys(input).length === Object.keys(canonical).length
+  )
+    ? null
+    : JSON.stringify(canonical);
 }
 
 function requiredScheduleFields(
@@ -208,6 +493,96 @@ function isResourceNotFound(error: unknown): boolean {
   );
 }
 
+function authoritativeRecordVersion(
+  value: unknown,
+  identity: ScheduleMutationIdentity,
+): number {
+  const record = objectValue(value);
+  if (
+    !record
+    || normalizedEmail(record.userId) !== identity.ownerEmail
+    || normalizedEmail(record.ownerEmail) !== identity.ownerEmail
+    || record.scheduleId !== identity.scheduleId
+    || !Number.isInteger(record.version)
+    || Number(record.version) < 1
+  ) {
+    throw new InvalidScheduleTargetError(
+      'Schedule target has no matching authoritative record',
+    );
+  }
+  return Number(record.version);
+}
+
+async function updateOneRecord(
+  rawRecord: Record<string, unknown>,
+  dependencies: ScheduleTargetBackfillDependencies,
+): Promise<boolean> {
+  const identity = scheduleRecordIdentity(rawRecord);
+  if (!identity) return false;
+  return dependencies.withMutationLock(identity, async () => {
+    const current = await dependencies.getRecord(identity);
+    if (!current) {
+      throw new InvalidScheduleTargetError(
+        'Legacy schedule record disappeared during migration',
+      );
+    }
+    const profile = requiresTrustedOwnerProfile(current)
+      ? await dependencies.loadOwnerProfile(identity.ownerEmail)
+      : null;
+    const upgrade = legacyScheduleRecordUpgrade(current, profile);
+    if (!upgrade) return false;
+    await dependencies.updateRecord(identity, upgrade);
+    return true;
+  });
+}
+
+export async function backfillScheduleRecordPage(
+  nextToken: string | undefined,
+  dependencies: ScheduleTargetBackfillDependencies,
+): Promise<ScheduleTargetBackfillResult> {
+  const page = await dependencies.listRecords(nextToken);
+  let updated = 0;
+  let invalid = 0;
+  for (
+    let offset = 0;
+    offset < page.records.length;
+    offset += UPDATE_CONCURRENCY
+  ) {
+    const outcomes = await Promise.all(
+      page.records
+        .slice(offset, offset + UPDATE_CONCURRENCY)
+        .map(async (record) => {
+          let identity: ScheduleMutationIdentity | null = null;
+          try {
+            identity = scheduleRecordIdentity(record);
+            return {
+              updated: await updateOneRecord(record, dependencies),
+              invalid: false,
+            };
+          } catch (error) {
+            if (!(error instanceof InvalidScheduleTargetError)) throw error;
+            dependencies.recordInvalidRecord(identity, error.message);
+            return { updated: false, invalid: true };
+          }
+        }),
+    );
+    updated += outcomes.filter((outcome) => outcome.updated).length;
+    invalid += outcomes.filter((outcome) => outcome.invalid).length;
+  }
+  await dependencies.queueContinuation(
+    page.nextToken
+      ? { phase: 'records', nextToken: page.nextToken }
+      : { phase: 'targets' },
+  );
+  return {
+    phase: 'records',
+    scanned: page.records.length,
+    updated,
+    invalid,
+    continuationQueued: true,
+  };
+}
+
 async function updateOne(
   name: string,
   dependencies: ScheduleTargetBackfillDependencies,
@@ -236,7 +611,9 @@ async function updateOne(
     ) {
       throw new Error('Schedule target ownership changed during backfill');
     }
-    const input = backfilledTargetInput(schedule.Target?.Input);
+    const record = await dependencies.getRecord(currentReference);
+    const version = authoritativeRecordVersion(record, currentReference);
+    const input = backfilledTargetInput(schedule.Target?.Input, version);
     if (
       input === null
       && hasCurrentDeliveryPolicy(schedule, dependencies.scheduleDlqArn)
@@ -290,9 +667,13 @@ export async function backfillScheduleTargetPage(
     invalid += outcomes.filter((outcome) => outcome.invalid).length;
   }
   if (page.nextToken) {
-    await dependencies.queueContinuation(page.nextToken);
+    await dependencies.queueContinuation({
+      phase: 'targets',
+      nextToken: page.nextToken,
+    });
   }
   return {
+    phase: 'targets',
     scanned: page.names.length,
     updated,
     invalid,

--- a/infra/lambdas/agent-schedule-target-backfill/backfill.ts
+++ b/infra/lambdas/agent-schedule-target-backfill/backfill.ts
@@ -12,6 +12,9 @@ const MAXIMUM_EVENT_AGE_SECONDS = 60 * 60;
 const MAXIMUM_RETRY_ATTEMPTS = 5;
 const IAM_PROPAGATION_ATTEMPTS = 8;
 const SAFE_EMAIL_RE = /^[\w%+.-]+@[\d.A-Za-z-]+\.[A-Za-z]{2,}$/;
+const SCHEDULE_ID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const LEGACY_SCHEDULE_ID_RE = /^[0-9a-f]{8}$/i;
 const DM_SPACE_RE = /^spaces\/[\w-]{1,256}$/;
 const UPDATEABLE_RECORD_FIELDS = [
   'version',
@@ -141,6 +144,10 @@ function normalizedEmail(value: unknown): string {
   return typeof value === 'string' ? value.trim().toLowerCase() : '';
 }
 
+function isSupportedScheduleId(value: string): boolean {
+  return SCHEDULE_ID_RE.test(value) || LEGACY_SCHEDULE_ID_RE.test(value);
+}
+
 export function selectTrustedOwnerProfile(
   ownerEmail: string,
   values: Record<string, unknown>[],
@@ -221,8 +228,7 @@ export function scheduleRecordIdentity(
   const scheduleId = record.scheduleId.trim().toLowerCase();
   if (
     !SAFE_EMAIL_RE.test(ownerEmail)
-    || scheduleId.length === 0
-    || scheduleId.length > 128
+    || !isSupportedScheduleId(scheduleId)
   ) {
     throw new InvalidScheduleTargetError(
       'Legacy schedule record has no owner-bound identity',
@@ -400,8 +406,7 @@ export function scheduleTargetReference(
   const version = targetVersion(input);
   if (
     !SAFE_EMAIL_RE.test(ownerEmail)
-    || scheduleId.length === 0
-    || scheduleId.length > 128
+    || !isSupportedScheduleId(scheduleId)
   ) {
     throw new InvalidScheduleTargetError(
       'Schedule target Input has no owner-bound reference',

--- a/infra/lambdas/agent-schedule-target-backfill/index.ts
+++ b/infra/lambdas/agent-schedule-target-backfill/index.ts
@@ -4,7 +4,10 @@ import {
 import {
   DeleteCommand,
   DynamoDBDocumentClient,
+  GetCommand,
   PutCommand,
+  QueryCommand,
+  ScanCommand,
   UpdateCommand,
 } from '@aws-sdk/lib-dynamodb';
 import {
@@ -19,23 +22,32 @@ import {
 } from '@aws-sdk/client-lambda';
 import * as crypto from 'node:crypto';
 import {
+  backfillScheduleRecordPage,
   backfillScheduleTargetPage,
+  type LegacyScheduleRecordUpgrade,
+  type ScheduleBackfillContinuation,
+  type ScheduleBackfillPhase,
   type ScheduleTargetBackfillDependencies,
   type ScheduleTargetBackfillResult,
+  type TrustedOwnerProfile,
+  withIamPropagationRetry,
 } from './backfill';
 import {
   SCHEDULE_MUTATION_LOCK_LEASE_SECONDS,
+  type ScheduleMutationIdentity,
   scheduleMutationLockKey,
 } from './mutation-lock';
 
 const SCHEDULE_GROUP = process.env.SCHEDULE_GROUP ?? '';
 const SCHEDULES_TABLE = process.env.SCHEDULES_TABLE ?? '';
+const USERS_TABLE = process.env.USERS_TABLE ?? '';
 const SCHEDULE_DLQ_ARN = process.env.SCHEDULE_DLQ_ARN ?? '';
 const FUNCTION_NAME = process.env.AWS_LAMBDA_FUNCTION_NAME ?? '';
 const PAGE_SIZE = 100;
 
 interface ScheduleTargetBackfillEvent {
   RequestType?: 'Create' | 'Update' | 'Delete';
+  phase?: ScheduleBackfillPhase;
   nextToken?: string;
 }
 
@@ -43,8 +55,121 @@ const scheduler = new SchedulerClient({});
 const lambda = new LambdaClient({});
 const dynamo = DynamoDBDocumentClient.from(new DynamoDBClient({}));
 
+function objectValue(value: unknown): Record<string, unknown> | null {
+  return (
+    typeof value === 'object'
+    && value !== null
+    && !Array.isArray(value)
+  )
+    ? value as Record<string, unknown>
+    : null;
+}
+
+function encodeCursor(key: Record<string, unknown>): string {
+  return Buffer.from(JSON.stringify(key), 'utf8').toString('base64url');
+}
+
+function decodeCursor(token?: string): Record<string, unknown> | undefined {
+  if (!token) return undefined;
+  try {
+    const decoded: unknown = JSON.parse(
+      Buffer.from(token, 'base64url').toString('utf8'),
+    );
+    const key = objectValue(decoded);
+    if (!key) throw new Error('Cursor is not an object');
+    return key;
+  } catch {
+    throw new Error('Schedule record backfill cursor is invalid');
+  }
+}
+
+function normalizedEmail(value: unknown): string {
+  return typeof value === 'string' ? value.trim().toLowerCase() : '';
+}
+
+function ownerProfile(
+  ownerEmail: string,
+  values: Record<string, unknown>[],
+): TrustedOwnerProfile | null {
+  const candidates = values.filter(
+    (value) => normalizedEmail(value.email) === ownerEmail,
+  );
+  const selected = candidates.find(
+    (value) =>
+      typeof value.googleIdentity === 'string'
+      && /^users\/\d+$/.test(value.googleIdentity),
+  ) ?? candidates[0];
+  if (!selected) return null;
+  const workspacePrefix =
+    typeof selected.workspacePrefix === 'string'
+    && selected.workspacePrefix.length > 0
+    && selected.workspacePrefix.length <= 128
+      ? selected.workspacePrefix
+      : ownerEmail.split('@')[0];
+  return {
+    workspacePrefix,
+    ...(typeof selected.dmSpaceName === 'string'
+      && /^spaces\/[\w-]{1,256}$/.test(selected.dmSpaceName)
+      ? { dmSpaceName: selected.dmSpaceName }
+      : {}),
+  };
+}
+
+function updateRecordRequest(
+  identity: ScheduleMutationIdentity,
+  upgrade: LegacyScheduleRecordUpgrade,
+) {
+  const names: Record<string, string> = {};
+  const values: Record<string, unknown> = {
+    ':owner': identity.ownerEmail,
+    ':scheduleId': identity.scheduleId,
+  };
+  const setters: string[] = [];
+  const append = (
+    field: keyof LegacyScheduleRecordUpgrade,
+    value: string | number | undefined,
+  ) => {
+    if (value === undefined) return;
+    const name = `#${field}`;
+    const parameter = `:${field}`;
+    names[name] = field;
+    values[parameter] = value;
+    setters.push(`${name} = ${parameter}`);
+  };
+  append('version', upgrade.version);
+  append('ownerEmail', upgrade.ownerEmail);
+  append('schedulerExpression', upgrade.schedulerExpression);
+  append('workspacePrefix', upgrade.workspacePrefix);
+  append('dmSpaceName', upgrade.dmSpaceName);
+  if (setters.length === 0) {
+    throw new Error('Schedule record backfill has no fields to update');
+  }
+  return {
+    TableName: SCHEDULES_TABLE,
+    Key: {
+      userId: identity.ownerEmail,
+      scheduleId: identity.scheduleId,
+    },
+    UpdateExpression: `SET ${setters.join(', ')}`,
+    ConditionExpression:
+      'userId = :owner AND scheduleId = :scheduleId',
+    ExpressionAttributeNames: names,
+    ExpressionAttributeValues: values,
+  };
+}
+
 const runtimeDependencies: ScheduleTargetBackfillDependencies = {
   scheduleDlqArn: SCHEDULE_DLQ_ARN,
+  recordInvalidRecord: (identity, errorMessage) => {
+    process.stderr.write(`${JSON.stringify({
+      level: 'ERROR',
+      marker: 'AGENT_FAILURE_RECORD',
+      event: 'schedule_record_backfill_invalid_record',
+      ownerBound: Boolean(identity?.ownerEmail),
+      scheduleId: identity?.scheduleId ?? 'unknown',
+      errorMessage,
+    })}\n`);
+  },
   recordInvalidTarget: (name, errorMessage) => {
     process.stderr.write(`${JSON.stringify({
       level: 'ERROR',
@@ -53,6 +178,54 @@ const runtimeDependencies: ScheduleTargetBackfillDependencies = {
       scheduleName: name,
       errorMessage,
     })}\n`);
+  },
+  listRecords: async (nextToken) => {
+    const page = await dynamo.send(new ScanCommand({
+      TableName: SCHEDULES_TABLE,
+      Limit: PAGE_SIZE,
+      ConsistentRead: true,
+      ...(nextToken
+        ? { ExclusiveStartKey: decodeCursor(nextToken) }
+        : {}),
+    }));
+    return {
+      records: (page.Items ?? []).filter(
+        (item): item is Record<string, unknown> => Boolean(objectValue(item)),
+      ),
+      ...(page.LastEvaluatedKey
+        ? { nextToken: encodeCursor(page.LastEvaluatedKey) }
+        : {}),
+    };
+  },
+  getRecord: async (identity) => {
+    const response = await dynamo.send(new GetCommand({
+      TableName: SCHEDULES_TABLE,
+      Key: {
+        userId: identity.ownerEmail,
+        scheduleId: identity.scheduleId,
+      },
+      ConsistentRead: true,
+    }));
+    return objectValue(response.Item) ?? undefined;
+  },
+  loadOwnerProfile: async (ownerEmail) => {
+    const response = await dynamo.send(new QueryCommand({
+      TableName: USERS_TABLE,
+      IndexName: 'email-index',
+      KeyConditionExpression: 'email = :email',
+      ExpressionAttributeValues: { ':email': ownerEmail },
+    }));
+    return ownerProfile(
+      ownerEmail,
+      (response.Items ?? []).filter(
+        (item): item is Record<string, unknown> => Boolean(objectValue(item)),
+      ),
+    );
+  },
+  updateRecord: async (identity, upgrade) => {
+    await dynamo.send(new UpdateCommand(
+      updateRecordRequest(identity, upgrade),
+    ));
   },
   list: async (nextToken) => {
     const page = await scheduler.send(
@@ -75,7 +248,7 @@ const runtimeDependencies: ScheduleTargetBackfillDependencies = {
   update: async (input) => {
     await scheduler.send(new UpdateScheduleCommand(input));
   },
-  queueContinuation: async (nextToken) => {
+  queueContinuation: async (continuation: ScheduleBackfillContinuation) => {
     if (!FUNCTION_NAME) {
       throw new Error('AWS_LAMBDA_FUNCTION_NAME is not configured');
     }
@@ -83,7 +256,7 @@ const runtimeDependencies: ScheduleTargetBackfillDependencies = {
       new InvokeCommand({
         FunctionName: FUNCTION_NAME,
         InvocationType: 'Event',
-        Payload: Buffer.from(JSON.stringify({ nextToken })),
+        Payload: Buffer.from(JSON.stringify(continuation)),
       }),
     );
     if (response.StatusCode !== 202) {
@@ -142,20 +315,25 @@ export async function handler(
 ): Promise<ScheduleTargetBackfillResult> {
   if (!SCHEDULE_GROUP) throw new Error('SCHEDULE_GROUP is not configured');
   if (!SCHEDULES_TABLE) throw new Error('SCHEDULES_TABLE is not configured');
+  if (!USERS_TABLE) throw new Error('USERS_TABLE is not configured');
   if (!SCHEDULE_DLQ_ARN) {
     throw new Error('SCHEDULE_DLQ_ARN is not configured');
   }
   if (event.RequestType === 'Delete') {
     return {
+      phase: event.phase ?? 'records',
       scanned: 0,
       updated: 0,
       invalid: 0,
       continuationQueued: false,
     };
   }
-  const result = await backfillScheduleTargetPage(
-    event.nextToken,
-    runtimeDependencies,
+  const phase = event.phase ?? 'records';
+  const result = await withIamPropagationRetry(
+    () =>
+      phase === 'records'
+        ? backfillScheduleRecordPage(event.nextToken, runtimeDependencies)
+        : backfillScheduleTargetPage(event.nextToken, runtimeDependencies),
   );
   process.stdout.write(`${JSON.stringify({
     level: 'INFO',

--- a/infra/lambdas/agent-schedule-target-backfill/index.ts
+++ b/infra/lambdas/agent-schedule-target-backfill/index.ts
@@ -29,7 +29,7 @@ import {
   type ScheduleBackfillPhase,
   type ScheduleTargetBackfillDependencies,
   type ScheduleTargetBackfillResult,
-  type TrustedOwnerProfile,
+  selectTrustedOwnerProfile,
   withIamPropagationRetry,
 } from './backfill';
 import {
@@ -81,38 +81,6 @@ function decodeCursor(token?: string): Record<string, unknown> | undefined {
   } catch {
     throw new Error('Schedule record backfill cursor is invalid');
   }
-}
-
-function normalizedEmail(value: unknown): string {
-  return typeof value === 'string' ? value.trim().toLowerCase() : '';
-}
-
-function ownerProfile(
-  ownerEmail: string,
-  values: Record<string, unknown>[],
-): TrustedOwnerProfile | null {
-  const candidates = values.filter(
-    (value) => normalizedEmail(value.email) === ownerEmail,
-  );
-  const selected = candidates.find(
-    (value) =>
-      typeof value.googleIdentity === 'string'
-      && /^users\/\d+$/.test(value.googleIdentity),
-  ) ?? candidates[0];
-  if (!selected) return null;
-  const workspacePrefix =
-    typeof selected.workspacePrefix === 'string'
-    && selected.workspacePrefix.length > 0
-    && selected.workspacePrefix.length <= 128
-      ? selected.workspacePrefix
-      : ownerEmail.split('@')[0];
-  return {
-    workspacePrefix,
-    ...(typeof selected.dmSpaceName === 'string'
-      && /^spaces\/[\w-]{1,256}$/.test(selected.dmSpaceName)
-      ? { dmSpaceName: selected.dmSpaceName }
-      : {}),
-  };
 }
 
 function updateRecordRequest(
@@ -215,7 +183,7 @@ const runtimeDependencies: ScheduleTargetBackfillDependencies = {
       KeyConditionExpression: 'email = :email',
       ExpressionAttributeValues: { ':email': ownerEmail },
     }));
-    return ownerProfile(
+    return selectTrustedOwnerProfile(
       ownerEmail,
       (response.Items ?? []).filter(
         (item): item is Record<string, unknown> => Boolean(objectValue(item)),

--- a/infra/lambdas/agent-schedule-target-backfill/package.json
+++ b/infra/lambdas/agent-schedule-target-backfill/package.json
@@ -1,7 +1,7 @@
 {
   "name": "agent-schedule-target-backfill",
   "version": "1.0.0",
-  "description": "One-time deployment backfill for EventBridge Scheduler fire identity",
+  "description": "Deployment backfill for legacy agent schedule records and targets",
   "main": "dist/index.js",
   "scripts": {
     "build": "tsc",

--- a/infra/lib/agent-platform-stack.ts
+++ b/infra/lib/agent-platform-stack.ts
@@ -2314,14 +2314,31 @@ export class AgentPlatformStack extends cdk.Stack {
                 },
               }),
               new iam.PolicyStatement({
-                sid: 'ScheduleTargetBackfillMutationLock',
+                sid: 'ScheduleTargetBackfillRecords',
                 effect: iam.Effect.ALLOW,
                 actions: [
+                  'dynamodb:GetItem',
                   'dynamodb:PutItem',
                   'dynamodb:DeleteItem',
                   'dynamodb:UpdateItem',
+                  'dynamodb:Scan',
                 ],
                 resources: [resources.schedulesTable.tableArn],
+                conditions: {
+                  StringEquals: {
+                    'aws:ResourceTag/Environment': environment,
+                    'aws:ResourceTag/ManagedBy': 'cdk',
+                  },
+                },
+              }),
+              new iam.PolicyStatement({
+                sid: 'ScheduleTargetBackfillReadOwners',
+                effect: iam.Effect.ALLOW,
+                actions: ['dynamodb:Query'],
+                resources: [
+                  resources.usersTable.tableArn,
+                  `${resources.usersTable.tableArn}/index/email-index`,
+                ],
                 conditions: {
                   StringEquals: {
                     'aws:ResourceTag/Environment': environment,
@@ -2398,6 +2415,7 @@ export class AgentPlatformStack extends cdk.Stack {
         environment: {
           SCHEDULE_GROUP: groupName,
           SCHEDULES_TABLE: resources.schedulesTable.tableName,
+          USERS_TABLE: resources.usersTable.tableName,
           SCHEDULE_DLQ_ARN: resources.agentAsyncDlq.queueArn,
         },
       },
@@ -3862,17 +3880,53 @@ export class AgentPlatformStack extends cdk.Stack {
       treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
     });
 
+    resources.failureMetricNamespace = `PSD/AgentPlatform/${environment}`;
+    const scheduleReferenceRejectionMetricName =
+      'ScheduleReferenceRejections';
+    new logs.MetricFilter(this, 'CronScheduleReferenceRejectionMetric', {
+      logGroup: resources.cronLogGroup,
+      metricNamespace: resources.failureMetricNamespace,
+      metricName: scheduleReferenceRejectionMetricName,
+      filterPattern: logs.FilterPattern.stringValue(
+        '$.marker',
+        '=',
+        'SCHEDULE_REFERENCE_REJECTION',
+      ),
+      metricValue: '1',
+      defaultValue: 0,
+    });
+    const scheduleReferenceRejectionAlarm = new cloudwatch.Alarm(
+      this,
+      'CronScheduleReferenceRejectionAlarm',
+      {
+        alarmName: `psd-agent-schedule-reference-rejections-${environment}`,
+        alarmDescription:
+          'Agent schedule references were rejected before invocation — scheduled work is silently unavailable',
+        metric: new cloudwatch.Metric({
+          namespace: resources.failureMetricNamespace,
+          metricName: scheduleReferenceRejectionMetricName,
+          period: cdk.Duration.minutes(5),
+          statistic: 'Sum',
+        }),
+        threshold: 1,
+        evaluationPeriods: 1,
+        comparisonOperator:
+          cloudwatch.ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+        treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
+      },
+    );
+
     if (resources.agentAlarmTopic) {
       const alarmAction = new cloudwatchActions.SnsAction(resources.agentAlarmTopic);
       cronErrorAlarm.addAlarmAction(alarmAction);
       cronThrottleAlarm.addAlarmAction(alarmAction);
+      scheduleReferenceRejectionAlarm.addAlarmAction(alarmAction);
     }
 
     // CloudWatch metric filter — emit a metric every time an
     // AGENT_FAILURE_RECORD line lands in the router Lambda log. Combined with
     // the harness-image structured log line of the same shape, this gives us
     // a single "agent failures per period" metric across all chokepoints.
-    resources.failureMetricNamespace = `PSD/AgentPlatform/${environment}`;
     const failureMetricName = 'AgentFailures';
 
     // Both router and cron filters intentionally write to the same metric name.

--- a/infra/lib/frontend-stack-ecs.ts
+++ b/infra/lib/frontend-stack-ecs.ts
@@ -439,28 +439,36 @@ export class FrontendStackEcs extends cdk.Stack {
   private createScheduleTargetBackfillTrigger(
     backfill: lambda.IFunction,
   ): void {
+    const migrationVersion = 'legacy-schedule-records-and-targets-v4';
+    const invocation = {
+      service: 'Lambda',
+      action: 'invoke',
+      parameters: {
+        FunctionName: backfill.functionName,
+        // A full group can take longer than the custom-resource provider's
+        // synchronous SDK timeout. Let Lambda's configured async retries,
+        // DLQ, and internal IAM-propagation backoff supervise the migration
+        // after acceptance.
+        InvocationType: 'Event',
+        Payload: JSON.stringify({
+          RequestType: 'Create',
+          phase: 'records',
+          migrationVersion,
+        }),
+      },
+      physicalResourceId: customResources.PhysicalResourceId.of(
+        `agent-schedule-target-backfill-${migrationVersion}`,
+      ),
+    };
     const trigger = new customResources.AwsCustomResource(
       this,
       'ScheduleTargetBackfillAfterFrontend',
       {
-        onCreate: {
-          service: 'Lambda',
-          action: 'invoke',
-          parameters: {
-            FunctionName: backfill.functionName,
-            // A full group can take longer than the custom-resource provider's
-            // synchronous SDK timeout. Let Lambda's configured async retries,
-            // DLQ, and alarm supervise the migration after acceptance.
-            InvocationType: 'Event',
-            Payload: JSON.stringify({
-              RequestType: 'Create',
-              migrationVersion: 'scheduled-time-delivery-policy-v3',
-            }),
-          },
-          physicalResourceId: customResources.PhysicalResourceId.of(
-            'agent-schedule-target-backfill-scheduled-time-delivery-policy-v3',
-          ),
-        },
+        onCreate: invocation,
+        // The v3 trigger already exists in deployed stacks. An explicit update
+        // hook guarantees this version is freshly invoked instead of relying
+        // on create-only custom-resource behavior.
+        onUpdate: invocation,
         policy: customResources.AwsCustomResourcePolicy.fromStatements([
           new iam.PolicyStatement({
             actions: ['lambda:InvokeFunction'],

--- a/infra/test/agent-invocation-context.test.ts
+++ b/infra/test/agent-invocation-context.test.ts
@@ -337,6 +337,25 @@ describe('Agent schedule reliability infrastructure', () => {
     }
   });
 
+  it('alarms schedule-reference rejections before invocation', () => {
+    template.hasResourceProperties('AWS::Logs::MetricFilter', {
+      MetricTransformations: Match.arrayWith([
+        Match.objectLike({
+          MetricName: 'ScheduleReferenceRejections',
+          MetricNamespace: `PSD/AgentPlatform/${ENV}`,
+          MetricValue: '1',
+        }),
+      ]),
+    });
+    template.hasResourceProperties('AWS::CloudWatch::Alarm', {
+      AlarmName: `psd-agent-schedule-reference-rejections-${ENV}`,
+      Namespace: `PSD/AgentPlatform/${ENV}`,
+      MetricName: 'ScheduleReferenceRejections',
+      Threshold: 1,
+      AlarmActions: Match.anyValue(),
+    });
+  });
+
   it('alarms Scheduler and Lambda DLQ depth through the agent alarm topic', () => {
     template.hasResourceProperties('AWS::CloudWatch::Alarm', {
       AlarmName: `psd-agent-async-dlq-${ENV}`,

--- a/infra/test/agent-invocation-context.test.ts
+++ b/infra/test/agent-invocation-context.test.ts
@@ -67,6 +67,7 @@ interface Statement {
   Effect?: string;
   Action?: unknown;
   Resource?: unknown;
+  Condition?: unknown;
 }
 
 function allStatements(template: Template): Statement[] {
@@ -354,6 +355,56 @@ describe('Agent schedule reliability infrastructure', () => {
       Threshold: 1,
       AlarmActions: Match.anyValue(),
     });
+  });
+
+  it('scopes legacy schedule backfill access to the required tables', () => {
+    const statements = allStatements(template);
+    const recordAccess = statements.find(
+      (statement) => statement.Sid === 'ScheduleTargetBackfillRecords'
+    );
+    expect(recordAccess).toMatchObject({
+      Effect: 'Allow',
+      Action: expect.arrayContaining([
+        'dynamodb:GetItem',
+        'dynamodb:PutItem',
+        'dynamodb:DeleteItem',
+        'dynamodb:UpdateItem',
+        'dynamodb:Scan',
+      ]),
+      Condition: {
+        StringEquals: {
+          'aws:ResourceTag/Environment': ENV,
+          'aws:ResourceTag/ManagedBy': 'cdk',
+        },
+      },
+    });
+    expect(JSON.stringify(recordAccess?.Resource)).toContain(
+      'AgentSchedulesTable'
+    );
+    expect(JSON.stringify(recordAccess?.Resource)).not.toContain(
+      'UsersTable'
+    );
+
+    const ownerAccess = statements.find(
+      (statement) => statement.Sid === 'ScheduleTargetBackfillReadOwners'
+    );
+    expect(ownerAccess).toMatchObject({
+      Effect: 'Allow',
+      Action: 'dynamodb:Query',
+      Condition: {
+        StringEquals: {
+          'aws:ResourceTag/Environment': ENV,
+          'aws:ResourceTag/ManagedBy': 'cdk',
+        },
+      },
+    });
+    expect(JSON.stringify(ownerAccess?.Resource)).toContain('UsersTable');
+    expect(JSON.stringify(ownerAccess?.Resource)).toContain(
+      '/index/email-index'
+    );
+    expect(JSON.stringify(ownerAccess?.Resource)).not.toContain(
+      'AgentSchedulesTable'
+    );
   });
 
   it('alarms Scheduler and Lambda DLQ depth through the agent alarm topic', () => {

--- a/lib/agent-schedules/service.ts
+++ b/lib/agent-schedules/service.ts
@@ -86,6 +86,8 @@ export type PublicAgentSchedule = Pick<
   lastRunAt: string | null;
   lastRunStatus: string | null;
   lastRunError: string | null;
+  degraded: boolean;
+  degradedReason: string | null;
 };
 
 export interface CreateAgentScheduleInput {
@@ -271,8 +273,54 @@ function publicSchedule(
     lastRunError: lastRun?.errorMessage
       ? lastRun.errorMessage.slice(0, LAST_RUN_ERROR_MAX_LENGTH)
       : null,
+    degraded: false,
+    degradedReason: null,
   };
 }
+
+function degradedString(
+  value: unknown,
+  maximumLength: number,
+  fallback: string,
+): string {
+  return typeof value === "string" && value.length > 0
+    ? value.slice(0, maximumLength)
+    : fallback;
+}
+
+function publicDegradedSchedule(
+  value: Record<string, unknown>,
+  lastRun?: AgentScheduleLastRun,
+  runEnrichmentAvailable = true,
+): PublicAgentSchedule {
+  return {
+    scheduleId: degradedString(value.scheduleId, 128, "unknown"),
+    version:
+      Number.isInteger(value.version) && Number(value.version) >= 1
+        ? Number(value.version)
+        : 0,
+    name: degradedString(value.name, 120, "Invalid schedule"),
+    prompt: degradedString(value.prompt, 20_000, ""),
+    cronExpression: degradedString(value.cronExpression, 256, ""),
+    timezone: degradedString(value.timezone, 100, DEFAULT_TIMEZONE),
+    enabled: typeof value.enabled === "boolean" ? value.enabled : false,
+    createdAt: degradedString(value.createdAt, 64, ""),
+    updatedAt: degradedString(value.updatedAt, 64, ""),
+    lastRunAt: lastRun?.createdAt.toISOString() ?? null,
+    lastRunStatus: runEnrichmentAvailable
+      ? lastRun?.status ?? null
+      : "unknown",
+    lastRunError: lastRun?.errorMessage
+      ? lastRun.errorMessage.slice(0, LAST_RUN_ERROR_MAX_LENGTH)
+      : null,
+    degraded: true,
+    degradedReason: "Schedule record requires migration",
+  };
+}
+
+type ListableAgentSchedule =
+  | { kind: "valid"; record: AgentScheduleRecord }
+  | { kind: "degraded"; value: Record<string, unknown> };
 
 function parseRecord(
   value: unknown,
@@ -738,34 +786,73 @@ export class AgentScheduleService {
 
   async list(owner: string): Promise<PublicAgentSchedule[]> {
     const ownerEmail = normalizeOwnerEmail(owner);
-    const records = (await this.ownerItems(ownerEmail))
+    const candidates: ListableAgentSchedule[] = (await this.ownerItems(
+      ownerEmail,
+    ))
       .filter(
         (item) =>
           typeof item.scheduleId === "string" &&
           !item.scheduleId.startsWith("__"),
       )
-      .map((item) => parseRecord(item, ownerEmail))
-      .sort((left, right) => left.createdAt.localeCompare(right.createdAt));
+      .flatMap((item): ListableAgentSchedule[] => {
+        try {
+          return [{ kind: "valid", record: parseRecord(item, ownerEmail) }];
+        } catch (error) {
+          if (!hasValidScheduleOwner(item, ownerEmail)) {
+            log.warn("Skipping schedule with invalid owner binding", {
+              scheduleId: degradedString(item.scheduleId, 128, "unknown"),
+            });
+            return [];
+          }
+          log.warn("Returning degraded schedule record", {
+            scheduleId: degradedString(item.scheduleId, 128, "unknown"),
+            error: error instanceof Error ? error.message : String(error),
+          });
+          return [{ kind: "degraded", value: item }];
+        }
+      })
+      .sort((left, right) => {
+        const leftCreatedAt =
+          left.kind === "valid"
+            ? left.record.createdAt
+            : degradedString(left.value.createdAt, 64, "");
+        const rightCreatedAt =
+          right.kind === "valid"
+            ? right.record.createdAt
+            : degradedString(right.value.createdAt, 64, "");
+        return leftCreatedAt.localeCompare(rightCreatedAt);
+      });
+    const scheduleIds = candidates.map((candidate) =>
+      candidate.kind === "valid"
+        ? candidate.record.scheduleId
+        : degradedString(candidate.value.scheduleId, 128, "unknown"),
+    );
     let lastRuns = new Map<string, AgentScheduleLastRun>();
     let runEnrichmentAvailable = true;
     try {
       lastRuns = await this.runReader.latestBySchedule(
         ownerEmail,
-        records.map((record) => record.scheduleId),
+        scheduleIds,
       );
     } catch (error) {
       runEnrichmentAvailable = false;
       log.warn("Latest schedule run enrichment unavailable", {
-        scheduleCount: records.length,
+        scheduleCount: candidates.length,
         error: error instanceof Error ? error.message : String(error),
       });
     }
-    return records.map((record) =>
-      publicSchedule(
-        record,
-        lastRuns.get(record.scheduleId),
-        runEnrichmentAvailable,
-      ),
+    return candidates.map((candidate, index) =>
+      candidate.kind === "valid"
+        ? publicSchedule(
+            candidate.record,
+            lastRuns.get(scheduleIds[index]),
+            runEnrichmentAvailable,
+          )
+        : publicDegradedSchedule(
+            candidate.value,
+            lastRuns.get(scheduleIds[index]),
+            runEnrichmentAvailable,
+          ),
     );
   }
 

--- a/lib/agent-schedules/validation.ts
+++ b/lib/agent-schedules/validation.ts
@@ -4,6 +4,7 @@ const MAX_EXPRESSION_LENGTH = 256;
 const MAX_TIMEZONE_LENGTH = 100;
 const SCHEDULE_ID_RE =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const LEGACY_SCHEDULE_ID_RE = /^[0-9a-f]{8}$/i;
 
 export class AgentScheduleInputError extends Error {
   constructor(message: string) {
@@ -34,8 +35,13 @@ function requireBoundedString(
 
 export function validateScheduleId(value: unknown): string {
   const scheduleId = requireBoundedString(value, "scheduleId", 64);
-  if (!SCHEDULE_ID_RE.test(scheduleId)) {
-    throw new AgentScheduleInputError("scheduleId must be a UUID");
+  if (
+    !SCHEDULE_ID_RE.test(scheduleId) &&
+    !LEGACY_SCHEDULE_ID_RE.test(scheduleId)
+  ) {
+    throw new AgentScheduleInputError(
+      "scheduleId must be a UUID or legacy 8-character hexadecimal ID",
+    );
   }
   return scheduleId.toLowerCase();
 }

--- a/tests/unit/agent-cron-reference-paths.test.ts
+++ b/tests/unit/agent-cron-reference-paths.test.ts
@@ -32,10 +32,12 @@ function harness() {
 
 describe("agent-cron pre-invocation telemetry", () => {
   it.each([
+    "invalid-reference",
     "not-found",
     "owner-mismatch",
     "version-mismatch",
     "disabled",
+    "invalid-record",
   ] as const)("records %s schedule references as skipped", async (reason) => {
     const { telemetry, recordPreflightRun, log } = harness()
 
@@ -61,6 +63,20 @@ describe("agent-cron pre-invocation telemetry", () => {
         errorMessage: `Schedule reference rejected: ${reason}`,
       }),
       log,
+    )
+    expect(log.warn).toHaveBeenCalledWith(
+      "Schedule reference rejected before invocation",
+      {
+        reason,
+        ...([
+          "invalid-reference",
+          "owner-mismatch",
+          "version-mismatch",
+          "invalid-record",
+        ].includes(reason)
+          ? { marker: "SCHEDULE_REFERENCE_REJECTION" }
+          : {}),
+      },
     )
   })
 

--- a/tests/unit/agent-cron-run-telemetry.test.ts
+++ b/tests/unit/agent-cron-run-telemetry.test.ts
@@ -4,6 +4,7 @@ import {
   isPromotedRunPending,
   reservePromotedRunId,
   updatePromotedRunTerminal,
+  writePreflightRun,
   type CronTelemetryLogger,
 } from "../../infra/lambdas/agent-cron/run-telemetry"
 
@@ -216,6 +217,39 @@ describe("agent-cron promoted run terminal repair", () => {
 })
 
 describe("agent-cron preflight run telemetry", () => {
+  it("types a nullable fire key through the preflight SQL path", async () => {
+    const execute = jest.fn().mockResolvedValue({
+      records: [[{ stringValue: "skipped" }]],
+    })
+
+    await expect(
+      writePreflightRun(
+        config,
+        { execute },
+        {
+          userEmail: "owner@psd401.net",
+          scheduleId: "legacy-schedule",
+          sessionId: "reference-session",
+          inputTokens: 0,
+          outputTokens: 0,
+          latencyMs: 12,
+          status: "skipped",
+          errorMessage: "Schedule reference rejected: invalid-reference",
+        },
+      ),
+    ).resolves.toBe("skipped")
+
+    const input = execute.mock.calls[0][0]
+    expect(input.sql).toContain("CAST(:fire_key AS text) IS NOT NULL")
+    expect(input.sql).toContain(
+      "existing.fire_key = CAST(:fire_key AS text)",
+    )
+    expect(input.parameters).toContainEqual({
+      name: "fire_key",
+      value: { isNull: true },
+    })
+  })
+
   it("never overwrites an existing fire with stale preflight telemetry", async () => {
     const execute = jest.fn().mockResolvedValue({
       records: [[{ stringValue: "promoted" }]],
@@ -245,7 +279,9 @@ describe("agent-cron preflight run telemetry", () => {
     const input = execute.mock.calls[0][0]
     expect(input.sql).toContain("DO NOTHING")
     expect(input.sql).not.toContain("DO UPDATE")
-    expect(input.sql).toContain("existing.fire_key = :fire_key")
+    expect(input.sql).toContain(
+      "existing.fire_key = CAST(:fire_key AS text)",
+    )
   })
 })
 

--- a/tests/unit/agent-schedule-target-backfill.test.ts
+++ b/tests/unit/agent-schedule-target-backfill.test.ts
@@ -7,6 +7,7 @@ import {
   backfillUpdateRequest,
   legacyScheduleRecordUpgrade,
   legacySchedulerExpression,
+  selectTrustedOwnerProfile,
   type ScheduleTargetBackfillDependencies,
   withIamPropagationRetry,
 } from "../../infra/lambdas/agent-schedule-target-backfill/backfill"
@@ -428,6 +429,39 @@ describe("agent schedule legacy record backfill", () => {
       dmSpaceName: "spaces/trusted-owner-dm",
     })
     expect(legacyRecord.cronExpression).toBe("0 6 * * MON-FRI")
+  })
+
+  it("canonicalizes an owner that only differs by case or whitespace", () => {
+    expect(
+      legacyScheduleRecordUpgrade({
+        ...legacyRecord,
+        version: 1,
+        ownerEmail: " Owner@PSD401.net ",
+        schedulerExpression: "cron(0 6 ? * MON-FRI *)",
+        workspacePrefix: "owner-workspace",
+        dmSpaceName: "spaces/trusted-owner-dm",
+      }, null),
+    ).toEqual({
+      ownerEmail: "owner@psd401.net",
+    })
+  })
+
+  it("prefers a duplicate owner profile with a usable DM destination", () => {
+    expect(selectTrustedOwnerProfile("owner@psd401.net", [
+      {
+        email: "owner@psd401.net",
+        googleIdentity: "users/12345",
+        workspacePrefix: "stale-workspace",
+      },
+      {
+        email: "Owner@PSD401.net ",
+        workspacePrefix: "usable-workspace",
+        dmSpaceName: "spaces/usable-dm",
+      },
+    ])).toEqual({
+      workspacePrefix: "usable-workspace",
+      dmSpaceName: "spaces/usable-dm",
+    })
   })
 
   it("migrates an exact legacy row before queuing target migration", async () => {

--- a/tests/unit/agent-schedule-target-backfill.test.ts
+++ b/tests/unit/agent-schedule-target-backfill.test.ts
@@ -2,9 +2,13 @@ import fs from "node:fs"
 import path from "node:path"
 import {
   backfilledTargetInput,
+  backfillScheduleRecordPage,
   backfillScheduleTargetPage,
   backfillUpdateRequest,
+  legacyScheduleRecordUpgrade,
+  legacySchedulerExpression,
   type ScheduleTargetBackfillDependencies,
+  withIamPropagationRetry,
 } from "../../infra/lambdas/agent-schedule-target-backfill/backfill"
 import {
   scheduleMutationLockKey as backfillMutationLockKey,
@@ -19,19 +23,27 @@ const LEGACY_INPUT = JSON.stringify({
   scheduleId: "schedule-id",
   version: 4,
 })
+const INLINE_LEGACY_INPUT = JSON.stringify({
+  scheduleId: "schedule-id",
+  scheduleName: "Morning dispatch",
+  userEmail: "owner@psd401.net",
+  googleIdentity: "users/12345",
+  dmSpaceName: "spaces/legacy-inline",
+  prompt: "Generate the dispatch",
+})
 const SCHEDULE_DLQ_ARN =
   "arn:aws:sqs:us-west-2:123:psd-agent-async-dlq-prod"
 
 function schedule(
   input = LEGACY_INPUT,
   overrides: {
-    version?: number
+    version?: number | null
     expression?: string
     state?: "ENABLED" | "DISABLED"
     currentPolicy?: boolean
   } = {},
 ) {
-  const version = overrides.version ?? 4
+  const version = overrides.version === undefined ? 4 : overrides.version
   const parsedInput = JSON.parse(input)
   return {
     $metadata: {},
@@ -47,7 +59,10 @@ function schedule(
     Target: {
       Arn: "arn:aws:lambda:us-west-2:123:function:psd-agent-cron-prod",
       RoleArn: "arn:aws:iam::123:role/psd-agent-scheduler-invoke-prod",
-      Input: JSON.stringify({ ...parsedInput, version }),
+      Input: JSON.stringify({
+        ...parsedInput,
+        ...(version === null ? {} : { version }),
+      }),
       ...(overrides.currentPolicy
         ? {
             DeadLetterConfig: { Arn: SCHEDULE_DLQ_ARN },
@@ -66,11 +81,24 @@ function dependencies(
 ): ScheduleTargetBackfillDependencies {
   return {
     scheduleDlqArn: SCHEDULE_DLQ_ARN,
+    listRecords: jest.fn().mockResolvedValue({ records: [] }),
+    getRecord: jest.fn().mockResolvedValue({
+      userId: "owner@psd401.net",
+      ownerEmail: "owner@psd401.net",
+      scheduleId: "schedule-id",
+      version: 4,
+    }),
+    loadOwnerProfile: jest.fn().mockResolvedValue({
+      dmSpaceName: "spaces/trusted-owner-dm",
+      workspacePrefix: "owner-workspace",
+    }),
+    updateRecord: jest.fn().mockResolvedValue(undefined),
     list: jest.fn().mockResolvedValue({ names: [] }),
     get: jest.fn().mockResolvedValue(schedule()),
     update: jest.fn().mockResolvedValue(undefined),
     queueContinuation: jest.fn().mockResolvedValue(undefined),
     withMutationLock: async (_identity, execute) => execute(),
+    recordInvalidRecord: jest.fn(),
     recordInvalidTarget: jest.fn(),
     ...overrides,
   }
@@ -100,6 +128,23 @@ describe("agent schedule target deployment backfill", () => {
         scheduledTime: "<aws.scheduler.scheduled-time>",
       })),
     ).toBeNull()
+  })
+
+  it("upgrades the exact inline legacy target to a minimal record-bound input", () => {
+    expect(
+      JSON.parse(backfilledTargetInput(INLINE_LEGACY_INPUT, 1) ?? ""),
+    ).toEqual({
+      ownerEmail: "owner@psd401.net",
+      scheduleId: "schedule-id",
+      version: 1,
+      scheduledTime: "<aws.scheduler.scheduled-time>",
+    })
+    expect(backfilledTargetInput(INLINE_LEGACY_INPUT, 1)).not.toContain(
+      "prompt",
+    )
+    expect(backfilledTargetInput(INLINE_LEGACY_INPUT, 1)).not.toContain(
+      "googleIdentity",
+    )
   })
 
   it("rejects malformed or unbound target inputs", () => {
@@ -136,7 +181,9 @@ describe("agent schedule target deployment backfill", () => {
       },
     })
   })
+})
 
+describe("agent schedule target deployment migration", () => {
   it("updates legacy targets and durably continues pagination", async () => {
     const first = schedule()
     const alreadyCurrent = schedule(JSON.stringify({
@@ -156,13 +203,17 @@ describe("agent schedule target deployment backfill", () => {
     await expect(
       backfillScheduleTargetPage(undefined, deps),
     ).resolves.toEqual({
+      phase: "targets",
       scanned: 2,
       updated: 1,
       invalid: 0,
       continuationQueued: true,
     })
     expect(deps.update).toHaveBeenCalledTimes(1)
-    expect(deps.queueContinuation).toHaveBeenCalledWith("next-page")
+    expect(deps.queueContinuation).toHaveBeenCalledWith({
+      phase: "targets",
+      nextToken: "next-page",
+    })
   })
 
   it("isolates a malformed target and continues the fleet migration", async () => {
@@ -190,6 +241,7 @@ describe("agent schedule target deployment backfill", () => {
     await expect(
       backfillScheduleTargetPage(undefined, deps),
     ).resolves.toEqual({
+      phase: "targets",
       scanned: 3,
       updated: 1,
       invalid: 2,
@@ -204,7 +256,10 @@ describe("agent schedule target deployment backfill", () => {
       expect.stringMatching(/owner-bound/),
     )
     expect(deps.update).toHaveBeenCalledTimes(1)
-    expect(deps.queueContinuation).toHaveBeenCalledWith("next-page")
+    expect(deps.queueContinuation).toHaveBeenCalledWith({
+      phase: "targets",
+      nextToken: "next-page",
+    })
   })
 
   it("still retries operational failures instead of skipping them", async () => {
@@ -227,6 +282,31 @@ describe("agent schedule target deployment backfill", () => {
 })
 
 describe("agent schedule target backfill safety", () => {
+  it("migrates inline legacy input using the authoritative migrated version", async () => {
+    const legacy = schedule(INLINE_LEGACY_INPUT, { version: null })
+    const deps = dependencies({
+      list: jest.fn().mockResolvedValue({ names: [legacy.Name] }),
+      get: jest.fn().mockResolvedValue(legacy),
+      getRecord: jest.fn().mockResolvedValue({
+        userId: "owner@psd401.net",
+        ownerEmail: "owner@psd401.net",
+        scheduleId: "schedule-id",
+        version: 1,
+      }),
+    })
+
+    await expect(
+      backfillScheduleTargetPage(undefined, deps),
+    ).resolves.toMatchObject({ phase: "targets", updated: 1, invalid: 0 })
+    const input = (deps.update as jest.Mock).mock.calls[0][0].Target.Input
+    expect(JSON.parse(input)).toEqual({
+      ownerEmail: "owner@psd401.net",
+      scheduleId: "schedule-id",
+      version: 1,
+      scheduledTime: "<aws.scheduler.scheduled-time>",
+    })
+  })
+
   it("adds the DLQ and bounded retry policy even when Input is current", async () => {
     const currentInput = JSON.stringify({
       ...JSON.parse(LEGACY_INPUT),
@@ -290,6 +370,12 @@ describe("agent schedule target backfill safety", () => {
     const deps = dependencies({
       list: jest.fn().mockResolvedValue({ names: [initial.Name] }),
       get,
+      getRecord: jest.fn().mockResolvedValue({
+        userId: "owner@psd401.net",
+        ownerEmail: "owner@psd401.net",
+        scheduleId: "schedule-id",
+        version: 5,
+      }),
       withMutationLock,
     })
 
@@ -309,6 +395,140 @@ describe("agent schedule target backfill safety", () => {
         }),
       }),
     )
+  })
+})
+
+describe("agent schedule legacy record backfill", () => {
+  const legacyRecord = {
+    userId: "owner@psd401.net",
+    scheduleId: "36bb0456-1c51-4fb8-97d1-4e87d02765ce",
+    name: "Morning Dispatch",
+    prompt: "Generate my dispatch",
+    cronExpression: "0 6 * * MON-FRI",
+    timezone: "America/Los_Angeles",
+    enabled: true,
+    createdAt: "2026-07-01T00:00:00.000Z",
+    updatedAt: "2026-07-01T00:00:00.000Z",
+  }
+
+  it("derives Scheduler cadence without changing the stored cron expression", () => {
+    expect(legacySchedulerExpression("0 6 * * MON-FRI")).toBe(
+      "cron(0 6 ? * MON-FRI *)",
+    )
+    expect(
+      legacyScheduleRecordUpgrade(legacyRecord, {
+        dmSpaceName: "spaces/trusted-owner-dm",
+        workspacePrefix: "owner-workspace",
+      }),
+    ).toEqual({
+      version: 1,
+      ownerEmail: "owner@psd401.net",
+      schedulerExpression: "cron(0 6 ? * MON-FRI *)",
+      workspacePrefix: "owner-workspace",
+      dmSpaceName: "spaces/trusted-owner-dm",
+    })
+    expect(legacyRecord.cronExpression).toBe("0 6 * * MON-FRI")
+  })
+
+  it("migrates an exact legacy row before queuing target migration", async () => {
+    const deps = dependencies({
+      listRecords: jest.fn().mockResolvedValue({
+        records: [legacyRecord],
+      }),
+      getRecord: jest.fn().mockResolvedValue(legacyRecord),
+    })
+
+    await expect(
+      backfillScheduleRecordPage(undefined, deps),
+    ).resolves.toEqual({
+      phase: "records",
+      scanned: 1,
+      updated: 1,
+      invalid: 0,
+      continuationQueued: true,
+    })
+    expect(deps.updateRecord).toHaveBeenCalledWith(
+      {
+        ownerEmail: "owner@psd401.net",
+        scheduleId: legacyRecord.scheduleId,
+      },
+      {
+        version: 1,
+        ownerEmail: "owner@psd401.net",
+        schedulerExpression: "cron(0 6 ? * MON-FRI *)",
+        workspacePrefix: "owner-workspace",
+        dmSpaceName: "spaces/trusted-owner-dm",
+      },
+    )
+    expect(deps.queueContinuation).toHaveBeenCalledWith({
+      phase: "targets",
+    })
+  })
+
+  it("continues record pagination and isolates an owner without a trusted DM", async () => {
+    const deps = dependencies({
+      listRecords: jest.fn().mockResolvedValue({
+        records: [legacyRecord],
+        nextToken: "record-page-2",
+      }),
+      getRecord: jest.fn().mockResolvedValue(legacyRecord),
+      loadOwnerProfile: jest.fn().mockResolvedValue({
+        workspacePrefix: "owner-workspace",
+      }),
+    })
+
+    await expect(
+      backfillScheduleRecordPage(undefined, deps),
+    ).resolves.toMatchObject({
+      phase: "records",
+      updated: 0,
+      invalid: 1,
+      continuationQueued: true,
+    })
+    expect(deps.recordInvalidRecord).toHaveBeenCalledWith(
+      {
+        ownerEmail: "owner@psd401.net",
+        scheduleId: legacyRecord.scheduleId,
+      },
+      expect.stringMatching(/direct-message destination/),
+    )
+    expect(deps.queueContinuation).toHaveBeenCalledWith({
+      phase: "records",
+      nextToken: "record-page-2",
+    })
+  })
+})
+
+describe("agent schedule backfill IAM propagation retry", () => {
+  it("backs off beyond Lambda's three async delivery attempts", async () => {
+    const operation = jest.fn()
+      .mockRejectedValueOnce(
+        Object.assign(new Error("not propagated"), {
+          name: "AccessDeniedException",
+        }),
+      )
+      .mockRejectedValueOnce(
+        Object.assign(new Error("still propagating"), {
+          name: "AccessDeniedException",
+        }),
+      )
+      .mockRejectedValueOnce(
+        Object.assign(new Error("still propagating"), {
+          name: "AccessDeniedException",
+        }),
+      )
+      .mockResolvedValue("migrated")
+    const wait = jest.fn().mockResolvedValue(undefined)
+
+    await expect(
+      withIamPropagationRetry(operation, wait),
+    ).resolves.toBe("migrated")
+    expect(operation).toHaveBeenCalledTimes(4)
+    expect(wait.mock.calls.map(([milliseconds]) => milliseconds)).toEqual([
+      1_000,
+      2_000,
+      4_000,
+    ])
   })
 })
 
@@ -347,8 +567,9 @@ describe("agent schedule target backfill infrastructure", () => {
       "ScheduleTargetBackfillAfterFrontend",
     )
     expect(frontendSource).toContain(
-      "migrationVersion: 'scheduled-time-delivery-policy-v3'",
+      "const migrationVersion = 'legacy-schedule-records-and-targets-v4'",
     )
+    expect(frontendSource).toContain("onUpdate: invocation")
     expect(frontendSource).toContain("InvocationType: 'Event'")
     expect(frontendSource).toContain(
       "trigger.node.addDependency(this.ecsService.service)",
@@ -375,8 +596,15 @@ describe("agent schedule target backfill infrastructure", () => {
     expect(backfill).toContain("'scheduler:UpdateSchedule'")
     expect(backfill).toContain("'iam:PassRole'")
     expect(backfill).toContain("'dynamodb:PutItem'")
+    expect(backfill).toContain("'dynamodb:GetItem'")
+    expect(backfill).toContain("'dynamodb:Scan'")
+    expect(backfill).toContain("'dynamodb:Query'")
     expect(backfill).toContain("'dynamodb:DeleteItem'")
     expect(backfill).toContain("'dynamodb:UpdateItem'")
+    expect(backfill).toContain("resources.usersTable.tableArn")
+    expect(backfill).toContain(
+      "USERS_TABLE: resources.usersTable.tableName",
+    )
     expect(backfill).toContain("resources.schedulerInvokeRole.roleArn")
     expect(backfill).toContain("deadLetterQueue: resources.agentAsyncDlq")
     expect(backfill).toContain("'lambda:InvokeFunction'")

--- a/tests/unit/agent-schedule-target-backfill.test.ts
+++ b/tests/unit/agent-schedule-target-backfill.test.ts
@@ -19,13 +19,14 @@ import {
 } from "../../lib/agent-schedules/mutation-lock"
 import { stripComments } from "../helpers/strip-ts-comments"
 
+const LEGACY_SCHEDULE_ID = "5123b45b"
 const LEGACY_INPUT = JSON.stringify({
   ownerEmail: "owner@psd401.net",
-  scheduleId: "schedule-id",
+  scheduleId: LEGACY_SCHEDULE_ID,
   version: 4,
 })
 const INLINE_LEGACY_INPUT = JSON.stringify({
-  scheduleId: "schedule-id",
+  scheduleId: LEGACY_SCHEDULE_ID,
   scheduleName: "Morning dispatch",
   userEmail: "owner@psd401.net",
   googleIdentity: "users/12345",
@@ -48,7 +49,7 @@ function schedule(
   const parsedInput = JSON.parse(input)
   return {
     $metadata: {},
-    Name: "psd-agent-prod-schedule-id",
+    Name: `psd-agent-prod-${parsedInput.scheduleId}`,
     GroupName: "psd-agent-prod",
     ScheduleExpression:
       overrides.expression ?? "cron(0 6 * * ? *)",
@@ -56,7 +57,7 @@ function schedule(
     FlexibleTimeWindow: { Mode: "OFF" as const },
     State: overrides.state ?? ("ENABLED" as const),
     ActionAfterCompletion: "NONE" as const,
-    Description: "PSD agent schedule schedule-id",
+    Description: `PSD agent schedule ${parsedInput.scheduleId}`,
     Target: {
       Arn: "arn:aws:lambda:us-west-2:123:function:psd-agent-cron-prod",
       RoleArn: "arn:aws:iam::123:role/psd-agent-scheduler-invoke-prod",
@@ -86,7 +87,7 @@ function dependencies(
     getRecord: jest.fn().mockResolvedValue({
       userId: "owner@psd401.net",
       ownerEmail: "owner@psd401.net",
-      scheduleId: "schedule-id",
+      scheduleId: LEGACY_SCHEDULE_ID,
       version: 4,
     }),
     loadOwnerProfile: jest.fn().mockResolvedValue({
@@ -109,7 +110,7 @@ describe("agent schedule target deployment backfill", () => {
   it("uses the exact same mutation-lock key as the schedule service", () => {
     const identity = {
       ownerEmail: "Owner@PSD401.net ",
-      scheduleId: "schedule-id",
+      scheduleId: LEGACY_SCHEDULE_ID,
     }
     expect(backfillMutationLockKey(identity)).toEqual(
       serviceMutationLockKey(identity),
@@ -119,7 +120,7 @@ describe("agent schedule target deployment backfill", () => {
   it("adds immutable Scheduler context without changing the reference", () => {
     expect(JSON.parse(backfilledTargetInput(LEGACY_INPUT) ?? "")).toEqual({
       ownerEmail: "owner@psd401.net",
-      scheduleId: "schedule-id",
+      scheduleId: LEGACY_SCHEDULE_ID,
       version: 4,
       scheduledTime: "<aws.scheduler.scheduled-time>",
     })
@@ -136,7 +137,7 @@ describe("agent schedule target deployment backfill", () => {
       JSON.parse(backfilledTargetInput(INLINE_LEGACY_INPUT, 1) ?? ""),
     ).toEqual({
       ownerEmail: "owner@psd401.net",
-      scheduleId: "schedule-id",
+      scheduleId: LEGACY_SCHEDULE_ID,
       version: 1,
       scheduledTime: "<aws.scheduler.scheduled-time>",
     })
@@ -155,6 +156,10 @@ describe("agent schedule target deployment backfill", () => {
     expect(() => backfilledTargetInput(JSON.stringify({
       ...JSON.parse(LEGACY_INPUT),
       ownerEmail: " ",
+    }))).toThrow(/owner-bound/)
+    expect(() => backfilledTargetInput(JSON.stringify({
+      ...JSON.parse(LEGACY_INPUT),
+      scheduleId: "schedule-id",
     }))).toThrow(/owner-bound/)
   })
 
@@ -291,7 +296,7 @@ describe("agent schedule target backfill safety", () => {
       getRecord: jest.fn().mockResolvedValue({
         userId: "owner@psd401.net",
         ownerEmail: "owner@psd401.net",
-        scheduleId: "schedule-id",
+        scheduleId: LEGACY_SCHEDULE_ID,
         version: 1,
       }),
     })
@@ -302,7 +307,7 @@ describe("agent schedule target backfill safety", () => {
     const input = (deps.update as jest.Mock).mock.calls[0][0].Target.Input
     expect(JSON.parse(input)).toEqual({
       ownerEmail: "owner@psd401.net",
-      scheduleId: "schedule-id",
+      scheduleId: LEGACY_SCHEDULE_ID,
       version: 1,
       scheduledTime: "<aws.scheduler.scheduled-time>",
     })
@@ -374,7 +379,7 @@ describe("agent schedule target backfill safety", () => {
       getRecord: jest.fn().mockResolvedValue({
         userId: "owner@psd401.net",
         ownerEmail: "owner@psd401.net",
-        scheduleId: "schedule-id",
+        scheduleId: LEGACY_SCHEDULE_ID,
         version: 5,
       }),
       withMutationLock,
@@ -384,7 +389,7 @@ describe("agent schedule target backfill safety", () => {
 
     expect(observedLocks).toEqual([{
       ownerEmail: "owner@psd401.net",
-      scheduleId: "schedule-id",
+      scheduleId: LEGACY_SCHEDULE_ID,
       version: 4,
     }])
     expect(deps.update).toHaveBeenCalledWith(
@@ -402,7 +407,7 @@ describe("agent schedule target backfill safety", () => {
 describe("agent schedule legacy record backfill", () => {
   const legacyRecord = {
     userId: "owner@psd401.net",
-    scheduleId: "36bb0456-1c51-4fb8-97d1-4e87d02765ce",
+    scheduleId: LEGACY_SCHEDULE_ID,
     name: "Morning Dispatch",
     prompt: "Generate my dispatch",
     cronExpression: "0 6 * * MON-FRI",

--- a/tests/unit/agent-schedules-service.test.ts
+++ b/tests/unit/agent-schedules-service.test.ts
@@ -289,6 +289,46 @@ function defineAgentScheduleServiceAuthorityBoundarySuite1Part2() {it("rolls bac
     ).toEqual({ userId: OWNER, scheduleId: SCHEDULE_ID })
   })
 
+  it("returns a degraded legacy row alongside valid schedules", async () => {
+    const legacyId = "a273413f-7a93-4e43-9b49-1bc8880be024"
+    const { service, dynamoSend, latestBySchedule } = harness()
+    dynamoSend.mockResolvedValueOnce({
+      Items: [
+        {
+          userId: OWNER,
+          scheduleId: legacyId,
+          name: "Legacy dispatch",
+          prompt: "Generate it",
+          cronExpression: "0 6 * * MON-FRI",
+          timezone: "America/Los_Angeles",
+          enabled: true,
+          createdAt: "2026-07-24T00:00:00.000Z",
+          updatedAt: "2026-07-24T00:00:00.000Z",
+        },
+        scheduleRecord(),
+      ],
+    })
+
+    await expect(service.list(OWNER)).resolves.toEqual([
+      expect.objectContaining({
+        scheduleId: legacyId,
+        version: 0,
+        name: "Legacy dispatch",
+        degraded: true,
+        degradedReason: "Schedule record requires migration",
+      }),
+      expect.objectContaining({
+        scheduleId: SCHEDULE_ID,
+        degraded: false,
+        degradedReason: null,
+      }),
+    ])
+    expect(latestBySchedule).toHaveBeenCalledWith(OWNER, [
+      legacyId,
+      SCHEDULE_ID,
+    ])
+  })
+
   it("joins each schedule to its latest run and truncates the error", async () => {
     const latestRunAt = new Date("2026-07-28T15:30:00.000Z")
     const longError = "failure ".repeat(100)
@@ -347,7 +387,9 @@ function defineAgentScheduleServiceAuthorityBoundarySuite1Part2() {it("rolls bac
       }),
     ])
   })
+}
 
+function defineAgentScheduleServiceAuthorityBoundarySuite1Part2b() {
   it("seeds legacy quota from all existing rows before admitting a create", async () => {
     const { service, dynamoSend, schedulerSend } = harness()
     const legacy = Array.from({ length: config.maxSchedulesPerOwner }, (_, i) =>
@@ -381,7 +423,7 @@ function defineAgentScheduleServiceAuthorityBoundarySuite1Part2() {it("rolls bac
     ).toMatchObject({ activeCount: 50, reconciled: true })
   })
 
-  }
+}
 
 function defineAgentScheduleServiceAuthorityBoundarySuite1Part3() {it("repairs a reconciled but drifted quota on a subsequent mutation", async () => {
     const { service, dynamoSend, schedulerSend } = harness()
@@ -518,6 +560,7 @@ function defineAgentScheduleServiceAuthorityBoundarySuite1Part3() {it("repairs a
 const defineAgentScheduleServiceAuthorityBoundarySuite1 = () => {
   defineAgentScheduleServiceAuthorityBoundarySuite1Part1()
   defineAgentScheduleServiceAuthorityBoundarySuite1Part2()
+  defineAgentScheduleServiceAuthorityBoundarySuite1Part2b()
   defineAgentScheduleServiceAuthorityBoundarySuite1Part3()
 };
 

--- a/tests/unit/agent-schedules-service.test.ts
+++ b/tests/unit/agent-schedules-service.test.ts
@@ -56,6 +56,7 @@ import {
 
 const OWNER = "owner@psd401.net"
 const SCHEDULE_ID = "36bb0456-1c51-4fb8-97d1-4e87d02765ce"
+const LEGACY_SCHEDULE_ID = "5123b45b"
 
 const config = {
   region: "us-east-1",
@@ -166,6 +167,9 @@ function defineAgentScheduleServiceAuthorityBoundarySuite1Part1() {
     })
     expect(created).not.toHaveProperty("ownerEmail")
     expect(created).not.toHaveProperty("dmSpaceName")
+    expect(created.scheduleId).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,
+    )
   })
 
   it("refreshes destination from the trusted owner row and versions updates", async () => {
@@ -226,6 +230,41 @@ function defineAgentScheduleServiceAuthorityBoundarySuite1Part1() {
       kind: "schedule-mutation-lock",
     })
     expect(dynamoSend.mock.calls[6][0]).toBeInstanceOf(DeleteCommand)
+  })
+
+  it("updates a preserved legacy hexadecimal schedule ID", async () => {
+    const legacyRecord = scheduleRecord({ scheduleId: LEGACY_SCHEDULE_ID })
+    const { service, dynamoSend, schedulerSend } = harness()
+    dynamoSend
+      .mockResolvedValueOnce({ Items: [legacyRecord] })
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({ Item: legacyRecord })
+      .mockResolvedValueOnce({
+        Items: [{
+          email: OWNER,
+          dmSpaceName: "spaces/trusted-owner-dm",
+          workspacePrefix: "owner-workspace",
+        }],
+      })
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({})
+    schedulerSend.mockResolvedValueOnce({})
+
+    await expect(service.update(OWNER, {
+      scheduleId: LEGACY_SCHEDULE_ID,
+      prompt: "Updated legacy prompt",
+    })).resolves.toMatchObject({
+      scheduleId: LEGACY_SCHEDULE_ID,
+      version: 2,
+    })
+
+    const update = schedulerSend.mock.calls[0][0] as UpdateScheduleCommand
+    expect(update.input.Name).toBe(`psd-agent-dev-${LEGACY_SCHEDULE_ID}`)
+    expect(JSON.parse(update.input.Target?.Input ?? "{}")).toMatchObject({
+      scheduleId: LEGACY_SCHEDULE_ID,
+      version: 2,
+    })
   })
 
   }
@@ -491,6 +530,26 @@ function defineAgentScheduleServiceAuthorityBoundarySuite1Part3() {it("repairs a
       "dynamo",
       "dynamo",
     ])
+  })
+
+  it("deletes a preserved legacy hexadecimal schedule ID", async () => {
+    const legacyRecord = scheduleRecord({ scheduleId: LEGACY_SCHEDULE_ID })
+    const { service, dynamoSend, schedulerSend } = harness()
+    dynamoSend
+      .mockResolvedValueOnce({ Items: [legacyRecord] })
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({ Item: legacyRecord })
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({})
+    schedulerSend.mockResolvedValueOnce({})
+
+    await expect(
+      service.delete(OWNER, LEGACY_SCHEDULE_ID),
+    ).resolves.toBe(LEGACY_SCHEDULE_ID)
+    const deletion = schedulerSend.mock.calls[0][0] as DeleteScheduleCommand
+    expect(deletion.input.Name).toBe(`psd-agent-dev-${LEGACY_SCHEDULE_ID}`)
   })
 
   it("keeps metadata retryable when scheduler deletion fails", async () => {


### PR DESCRIPTION
Closes #1490

## Summary

Repairs the legacy production agent-schedule state that is rejected by the hardened schedule preflight:

- migrates legacy DynamoDB schedule rows to the canonical owner-bound versioned record
- migrates legacy inline EventBridge target payloads to the minimal schedule reference
- makes the migration resumable across record and target pages and tolerant of malformed individual entries
- retries IAM propagation failures inside the custom-resource invocation window
- fixes the nullable `fire_key` PostgreSQL query that produced `42P18`
- keeps schedule listing available when valid and legacy records are mixed, while explicitly flagging degraded entries
- adds a metric filter and alarm for schedule-reference rejections
- documents the controlled dev-first rollout, verification, rollback, and stale-DLQ purge procedure

The migration preserves each stored cron expression verbatim. In particular, the production schedule `5123b45b` remains `0 6 * * MON-FRI`; this PR does not add an interim manual run or change cadence.

## Legacy-to-canonical migration

Legacy DynamoDB records are upgraded to:

```json
{
  "userId": "owner@example.com",
  "scheduleId": "5123b45b",
  "version": 1,
  "ownerEmail": "owner@example.com",
  "cronExpression": "0 6 * * MON-FRI",
  "schedulerExpression": "cron(0 6 ? * MON-FRI *)",
  "workspacePrefix": "owner",
  "dmSpaceName": "dm-owner"
}
```

Existing fields not involved in the migration remain intact. Legacy EventBridge target input such as:

```json
{
  "userEmail": "owner@example.com",
  "scheduleId": "5123b45b",
  "prompt": "sensitive inline prompt",
  "workspacePrefix": "owner",
  "dmSpaceName": "dm-owner"
}
```

is replaced with exactly:

```json
{
  "ownerEmail": "owner@example.com",
  "scheduleId": "5123b45b",
  "version": 1,
  "scheduledTime": "<aws.scheduler.scheduled-time>"
}
```

The target migration reads the canonical version from the migrated record and rejects conflicting ownership rather than guessing.

## Deployment and operational safety

- The custom resource first scans and upgrades schedule records, then lists and rewrites Scheduler targets.
- Pagination state is self-invoked so both DynamoDB records and Scheduler targets are processed completely.
- `AccessDenied` failures use bounded exponential retry to survive eventual IAM propagation before Lambda asynchronous retry is needed.
- The execution role now has only the required schedule-table and user-email-index permissions, with the existing environment tag conditions.
- A new migration version and `onUpdate` invocation ensure already-deployed environments receive a fresh run.
- Preflight rejection logs carry a stable `SCHEDULE_REFERENCE_REJECTION` marker; the stack emits an environment-scoped CloudWatch metric and alarm.
- Stale dev/prod backfill DLQ messages must be deleted rather than redriven. The runbook scopes deletion to this backfill's messages so unrelated shared-DLQ messages are not removed.

See `docs/operations/agent-schedule-legacy-backfill.md` for deploy order, validation queries, fresh-invoke payload, rollback, and the post-deploy production checks.

## Validation

- `bun run test:ci -- tests/unit/agent-schedule-target-backfill.test.ts tests/unit/agent-schedules-service.test.ts tests/unit/agent-cron-run-telemetry.test.ts tests/unit/agent-cron-reference-paths.test.ts --runInBand` — 4 suites / 67 tests passed
- `cd infra/lambdas/agent-cron && bun test schedule-record.test.ts` — 9 tests passed
- `bun run test:ci -- --runInBand` — 538 suites / 4,993 tests passed; 1 suite / 15 tests skipped
- `bun run test:skill:schedules` — 24 tests passed
- `bun run typecheck` — passed
- `bun run lint` — passed with zero warnings
- `bun run build` — passed (94 static pages)
- `cd infra && bun run build` — passed, including unified-content typecheck and 17 agent-skill-builder tests
- `cd infra && bunx cdk synth --all --no-lookups --context baseDomain=example.com` — all dev/prod stacks synthesized successfully
- synthesized Dev and Prod AgentPlatform templates — checked for dependency cycles; none found
- synthesized backfill Lambda environment/IAM and rejection alarm — inspected and matched the intended resources
- standalone `infra/lambdas/agent-cron` and `infra/lambdas/agent-schedule-target-backfill` builds — passed
- `bun run openapi:check` — passed
- `bun run capabilities:check` — passed
- `git diff --check` — passed

Browser E2E is not applicable: this change is confined to Lambda/EventBridge/DynamoDB migration behavior, schedule-service unit behavior, telemetry SQL, and CDK resources. The documented pre-push `SKIP_E2E=1` path was therefore used after the relevant full unit/build/synth gates passed.

The infra Jest runner cannot currently execute under the repository's TypeScript 7 / ts-jest 29 combination (`fileExists` is undefined). Equivalent coverage was exercised through the successful infra TypeScript build, all-stack synth, synthesized-template assertions, dependency-cycle check, and root Jest source assertions. This is an existing harness incompatibility, not introduced by this PR.

The application build still emits the repository's existing Edge-runtime/logger/AWS SDK, Browserslist age, and OIDC runtime warnings; it completes successfully.

## Post-merge rollout gates

No AWS deployment is performed from this PR. After merge, the runbook requires:

1. deploy and verify dev while schedules remain disabled
2. delete stale backfill messages from the shared DLQ without redriving them
3. deploy production and verify the migrated row and target reference
4. run a manual `psd schedule list` as the production owner
5. observe the next normal 6:00 AM weekday dispatch for schedule `5123b45b`

## Risk and rollback

Primary risk is partial migration across paginated records/targets. The migration is idempotent, records phase progress explicitly, isolates malformed entries, and can be freshly reinvoked using the documented payload. Rollback restores the previous Lambda/custom-resource configuration; migrated canonical records and minimal target references remain compatible with the current runtime and should not be reverted to sensitive inline payloads.
