### PR TITLE
fix(agent): wire PSD data MCP URL to web tier

### DIFF
--- a/infra/lib/agent-endpoints.ts
+++ b/infra/lib/agent-endpoints.ts
@@ -1,0 +1,2 @@
+export const DEFAULT_PSD_DATA_MCP_URL =
+  'https://l3jpggwgsojgql275k6axcboue0syeuq.lambda-url.us-west-2.on.aws/mcp';

--- a/infra/lib/agent-platform-stack.ts
+++ b/infra/lib/agent-platform-stack.ts
@@ -1864,9 +1864,6 @@ export class AgentPlatformStack extends cdk.Stack {
       GUARDRAIL_ARN: props.guardrailArn,
       SKILL_BUILDER_LAMBDA_ARN: `arn:aws:lambda:${this.region}:${this.account}:function:${resources.skillBuilderFunctionName}`,
       APP_BASE_URL: props.appBaseUrl ?? '',
-      PSD_DATA_MCP_URL:
-        (this.node.tryGetContext('psdDataMcpUrl') as string | undefined)
-        ?? 'https://l3jpggwgsojgql275k6axcboue0syeuq.lambda-url.us-west-2.on.aws/mcp',
       // Service credentials and their endpoint selectors intentionally stay out
       // of the model-facing runtime environment. Skills reach the fixed,
       // allowlisted web-tier brokers via APP_BASE_URL.

--- a/infra/lib/constructs/ecs-service.ts
+++ b/infra/lib/constructs/ecs-service.ts
@@ -14,6 +14,7 @@ import * as secretsmanager from 'aws-cdk-lib/aws-secretsmanager';
 import * as autoscaling from 'aws-cdk-lib/aws-applicationautoscaling';
 import { RedisCache } from './cache/redis-cache';
 import { usGuardrailProfileArns } from './security';
+import { DEFAULT_PSD_DATA_MCP_URL } from '../agent-endpoints';
 
 export interface EcsServiceConstructProps {
   vpc: ec2.IVpc;
@@ -1016,6 +1017,11 @@ export class EcsServiceConstruct extends Construct {
         `arn:aws:iam::${cdk.Stack.of(this).account}:role/psd-agent-scheduler-invoke-${environment}`,
       AGENT_SCHEDULE_DLQ_ARN:
         `arn:aws:sqs:${cdk.Stack.of(this).region}:${cdk.Stack.of(this).account}:psd-agent-async-dlq-${environment}`,
+      // The web-tier owner-operation broker calls psd-data-mcp on behalf of
+      // AgentCore skills, so the endpoint belongs on this trusted container.
+      PSD_DATA_MCP_URL:
+        (this.node.tryGetContext('psdDataMcpUrl') as string | undefined)
+        ?? DEFAULT_PSD_DATA_MCP_URL,
       // DWD token broker (#1232) + agnt_ auto-provisioning (#1233) config —
       // the GCP project number, WIF pool/provider ids, DWD service-account
       // email, and the OneSync provisioning sheet id all live in ONE JSON

--- a/infra/test/unit/ecs-service-psd-data-mcp-url.test.ts
+++ b/infra/test/unit/ecs-service-psd-data-mcp-url.test.ts
@@ -1,0 +1,79 @@
+import * as cdk from "aws-cdk-lib";
+import * as ec2 from "aws-cdk-lib/aws-ec2";
+import { Match, Template } from "aws-cdk-lib/assertions";
+import { DEFAULT_PSD_DATA_MCP_URL } from "../../lib/agent-endpoints";
+import { EcsServiceConstruct } from "../../lib/constructs/ecs-service";
+
+type Environment = "dev" | "prod";
+
+function createTemplate(
+  environment: Environment,
+  context: Record<string, string> = {},
+): Template {
+  const app = new cdk.App({ context });
+  const stack = new cdk.Stack(app, `TestStack-${environment}`, {
+    env: { account: "123456789012", region: "us-east-1" },
+  });
+  const vpc = new ec2.Vpc(stack, "TestVpc", { maxAzs: 2 });
+  const secretArn = (name: string) =>
+    `arn:aws:secretsmanager:us-east-1:123456789012:secret:aistudio-${environment}-${name}-AbCdEf`;
+
+  new EcsServiceConstruct(stack, "EcsService", {
+    vpc,
+    environment,
+    documentsBucketName: `aistudio-${environment}-documents`,
+    agentWorkspaceBucketName: `aistudio-${environment}-agent-workspace`,
+    atriumSandboxOrigin: "https://sandbox.example.com",
+    dockerImageSource: "fromEcrRepository",
+    authUrl: `https://${environment}.aistudio.psd401.ai`,
+    cognitoClientId: "test-client-id",
+    cognitoIssuer:
+      "https://cognito-idp.us-east-1.amazonaws.com/us-east-1_testpool",
+    rdsResourceArn:
+      `arn:aws:rds:us-east-1:123456789012:cluster:aistudio-${environment}-cluster`,
+    rdsSecretArn: secretArn("db"),
+    authSecretArn: secretArn("auth"),
+    collabJwtSecretArn: secretArn("collab-jwt"),
+    guardrailHashSecretArn: secretArn("guardrail-hash"),
+    oidcCookieSecretArn: secretArn("oidc-cookie"),
+    oidcSigningJwksSecretArn: secretArn("oidc-signing"),
+  });
+
+  return Template.fromStack(stack);
+}
+
+function expectPsdDataMcpUrl(template: Template, expectedUrl: string): void {
+  template.hasResourceProperties("AWS::ECS::TaskDefinition", {
+    ContainerDefinitions: Match.arrayWith([
+      Match.objectLike({
+        Environment: Match.arrayWith([
+          {
+            Name: "PSD_DATA_MCP_URL",
+            Value: expectedUrl,
+          },
+        ]),
+      }),
+    ]),
+  });
+}
+
+describe("ECS Service — PSD data MCP URL", () => {
+  it.each<Environment>(["dev", "prod"])(
+    "injects the shared default into the %s frontend task",
+    (environment) => {
+      expectPsdDataMcpUrl(
+        createTemplate(environment),
+        DEFAULT_PSD_DATA_MCP_URL,
+      );
+    },
+  );
+
+  it("honors the psdDataMcpUrl context override", () => {
+    const overrideUrl = "https://data.example.test/mcp";
+
+    expectPsdDataMcpUrl(
+      createTemplate("dev", { psdDataMcpUrl: overrideUrl }),
+      overrideUrl,
+    );
+  });
+});


### PR DESCRIPTION
## Description

Fix the psd-data owner-operation broker failure by wiring `PSD_DATA_MCP_URL` into the trusted frontend ECS task, where `executePsdDataOperation` consumes it.

- Add the context-overridable endpoint to the frontend container environment for dev and prod.
- Centralize the production default in `infra/lib/agent-endpoints.ts`.
- Remove the obsolete endpoint from the model-facing AgentCore runtime environment.
- Add CDK regression assertions for both deployed environments and the context override.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Infrastructure change (CDK/AWS)

## Validation

- [x] `bun run lint` — passed with zero warnings
- [x] `bun run typecheck` — passed
- [x] `bun run test:ci -- --runInBand` — 536 suites passed; 4,967 tests passed; 15 policy skips
- [x] `bun run build` — passed (existing Edge-runtime and Browserslist warnings only)
- [x] `cd infra && bunx tsc --noEmit` — passed
- [x] `cd infra && bun test test/unit/ecs-service-psd-data-mcp-url.test.ts` — 3 passed
- [x] `cd infra && bun run build` — passed, including 17 Lambda tests
- [x] `cd infra && bunx cdk synth AIStudio-FrontendStack-ECS-Dev AIStudio-FrontendStack-ECS-Prod --no-lookups --context baseDomain=example.com` — passed
- [x] Synthesized dev and prod ECS task definitions both contain the shared default URL
- [x] Synthesized dev and prod AgentPlatform templates do not contain `PSD_DATA_MCP_URL`
- [x] `rg PSD_DATA_MCP_URL infra/agent-image` — no hits

Authenticated E2E is N/A for this task-definition-only change. The issue documents that the live path requires Cognito and the external data warehouse; the repository pre-push hook was intentionally bypassed with its documented `SKIP_E2E=1` option after all applicable local checks passed.

The generic `bun run test` command also launches non-PR live performance suites against `localhost:3000`; those reported connection failures with no app server. The actual PR-gated `test:ci` suite passed completely.

## Infrastructure Notes

- No new resource or IAM permissions.
- No migration, API contract, application behavior, documentation, or screenshot change.
- Risk is low: deploying the frontend task definition injects one existing public endpoint value.
- Removing the dead AgentCore runtime variable changes its configuration fingerprint once, so the next deploy intentionally rotates agent session IDs.
- Rollback is a commit revert.

## Post-deploy Manual Check

- Confirm psd-data `tools/list` succeeds from the agent.
- Confirm no new `Owner operation endpoint is not configured` errors appear in `/ecs/aistudio-prod`.

Closes #1491
