### PR TITLE
fix(agent-skills): harden GLM skill contracts

### DIFF
--- a/.eval-runs/sha256-6a343e3f1dce515d621f69e9b47f76af4fce01e0ed4cbed183a536b74a6debf5.json
+++ b/.eval-runs/sha256-6a343e3f1dce515d621f69e9b47f76af4fce01e0ed4cbed183a536b74a6debf5.json
@@ -1,0 +1,456 @@
+{
+  "eval_harness_commit": "9d00a63e414c89df88e4ab7a0704353cf33f6f76",
+  "image": "390844780692.dkr.ecr.us-east-1.amazonaws.com/psd-agent-base-dev@sha256:6a343e3f1dce515d621f69e9b47f76af4fce01e0ed4cbed183a536b74a6debf5",
+  "image_digest": "sha256:6a343e3f1dce515d621f69e9b47f76af4fce01e0ed4cbed183a536b74a6debf5",
+  "model": {
+    "model_id": "zai.glm-5",
+    "pricing_usd_per_million_tokens": {
+      "cacheRead": 0.0,
+      "cacheWrite": 0.0,
+      "input": 1.0,
+      "output": 3.2
+    },
+    "primary": "amazon-bedrock/zai.glm-5",
+    "provider": "amazon-bedrock"
+  },
+  "overall": {
+    "pass^3": {
+      "passed_tasks": 5,
+      "rate": 1.0,
+      "total_tasks": 5
+    },
+    "task_count": 5,
+    "telemetry": {
+      "caching_status": "unknown",
+      "cost": {
+        "per_task_usd": null,
+        "per_trial_usd": null,
+        "total_usd": null
+      },
+      "duration_ms": {
+        "mean": 19615.0,
+        "p50": 17874,
+        "p95": 45728,
+        "total": 294225
+      },
+      "failures": {
+        "by_error_class": {},
+        "by_failed_grader": {},
+        "graded_rate": 0.0,
+        "graded_trials": 0,
+        "rate": 0.0,
+        "trials": 0
+      },
+      "latency_ms": {
+        "mean": 19507.467,
+        "p50": 17833,
+        "p95": 45333,
+        "total": 292612
+      },
+      "model_call_count": {
+        "mean": 3.733,
+        "p50": 4,
+        "p95": 7,
+        "total": 56
+      },
+      "nudged": {
+        "rate": 0.0,
+        "trials": 0
+      },
+      "tokens": {
+        "cache_read_input_tokens": 0,
+        "cache_write_input_tokens": 0,
+        "input_tokens": 0,
+        "output_tokens": 0
+      }
+    },
+    "trial_count": 15
+  },
+  "run": {
+    "completed_at": "2026-07-30T15:16:02.227565+00:00",
+    "first_trial_recorded_at": "2026-07-30T15:10:21.451392+00:00",
+    "start_time_status": "captured",
+    "started_at": "2026-07-30T15:09:36.777139+00:00",
+    "task_count": 5,
+    "trial_count": 15,
+    "trials_per_task": 3
+  },
+  "schema_version": 2,
+  "skills": {
+    "psd-data": {
+      "pass^3": {
+        "passed_tasks": 1,
+        "rate": 1.0,
+        "total_tasks": 1
+      },
+      "task_count": 1,
+      "task_ids": [
+        "data-list-tables"
+      ],
+      "telemetry": {
+        "caching_status": "unknown",
+        "cost": {
+          "per_task_usd": null,
+          "per_trial_usd": null,
+          "total_usd": null
+        },
+        "duration_ms": {
+          "mean": 17255.667,
+          "p50": 17196,
+          "p95": 21042,
+          "total": 51767
+        },
+        "failures": {
+          "by_error_class": {},
+          "by_failed_grader": {},
+          "graded_rate": 0.0,
+          "graded_trials": 0,
+          "rate": 0.0,
+          "trials": 0
+        },
+        "latency_ms": {
+          "mean": 17191.333,
+          "p50": 17072,
+          "p95": 20996,
+          "total": 51574
+        },
+        "model_call_count": {
+          "mean": 5.0,
+          "p50": 4,
+          "p95": 7,
+          "total": 15
+        },
+        "nudged": {
+          "rate": 0.0,
+          "trials": 0
+        },
+        "tokens": {
+          "cache_read_input_tokens": 0,
+          "cache_write_input_tokens": 0,
+          "input_tokens": 0,
+          "output_tokens": 0
+        }
+      },
+      "trial_count": 3
+    },
+    "psd-directory": {
+      "pass^3": {
+        "passed_tasks": 1,
+        "rate": 1.0,
+        "total_tasks": 1
+      },
+      "task_count": 1,
+      "task_ids": [
+        "directory-literal-address-no-lookup"
+      ],
+      "telemetry": {
+        "caching_status": "unknown",
+        "cost": {
+          "per_task_usd": null,
+          "per_trial_usd": null,
+          "total_usd": null
+        },
+        "duration_ms": {
+          "mean": 5562.333,
+          "p50": 4870,
+          "p95": 8846,
+          "total": 16687
+        },
+        "failures": {
+          "by_error_class": {},
+          "by_failed_grader": {},
+          "graded_rate": 0.0,
+          "graded_trials": 0,
+          "rate": 0.0,
+          "trials": 0
+        },
+        "latency_ms": {
+          "mean": 5525.667,
+          "p50": 4814,
+          "p95": 8818,
+          "total": 16577
+        },
+        "model_call_count": {
+          "mean": 1.0,
+          "p50": 1,
+          "p95": 1,
+          "total": 3
+        },
+        "nudged": {
+          "rate": 0.0,
+          "trials": 0
+        },
+        "tokens": {
+          "cache_read_input_tokens": 0,
+          "cache_write_input_tokens": 0,
+          "input_tokens": 0,
+          "output_tokens": 0
+        }
+      },
+      "trial_count": 3
+    },
+    "psd-failure-report": {
+      "pass^3": {
+        "passed_tasks": 1,
+        "rate": 1.0,
+        "total_tasks": 1
+      },
+      "task_count": 1,
+      "task_ids": [
+        "failure-report-synthetic-missing-data"
+      ],
+      "telemetry": {
+        "caching_status": "unknown",
+        "cost": {
+          "per_task_usd": null,
+          "per_trial_usd": null,
+          "total_usd": null
+        },
+        "duration_ms": {
+          "mean": 22427.333,
+          "p50": 17874,
+          "p95": 37326,
+          "total": 67282
+        },
+        "failures": {
+          "by_error_class": {},
+          "by_failed_grader": {},
+          "graded_rate": 0.0,
+          "graded_trials": 0,
+          "rate": 0.0,
+          "trials": 0
+        },
+        "latency_ms": {
+          "mean": 22340.667,
+          "p50": 17833,
+          "p95": 37299,
+          "total": 67022
+        },
+        "model_call_count": {
+          "mean": 4.0,
+          "p50": 4,
+          "p95": 4,
+          "total": 12
+        },
+        "nudged": {
+          "rate": 0.0,
+          "trials": 0
+        },
+        "tokens": {
+          "cache_read_input_tokens": 0,
+          "cache_write_input_tokens": 0,
+          "input_tokens": 0,
+          "output_tokens": 0
+        }
+      },
+      "trial_count": 3
+    },
+    "psd-freshservice": {
+      "pass^3": {
+        "passed_tasks": 1,
+        "rate": 1.0,
+        "total_tasks": 1
+      },
+      "task_count": 1,
+      "task_ids": [
+        "freshservice-update-ticket-priority"
+      ],
+      "telemetry": {
+        "caching_status": "unknown",
+        "cost": {
+          "per_task_usd": null,
+          "per_trial_usd": null,
+          "total_usd": null
+        },
+        "duration_ms": {
+          "mean": 25293.667,
+          "p50": 20016,
+          "p95": 45728,
+          "total": 75881
+        },
+        "failures": {
+          "by_error_class": {},
+          "by_failed_grader": {},
+          "graded_rate": 0.0,
+          "graded_trials": 0,
+          "rate": 0.0,
+          "trials": 0
+        },
+        "latency_ms": {
+          "mean": 25073.333,
+          "p50": 19900,
+          "p95": 45333,
+          "total": 75220
+        },
+        "model_call_count": {
+          "mean": 4.667,
+          "p50": 4,
+          "p95": 6,
+          "total": 14
+        },
+        "nudged": {
+          "rate": 0.0,
+          "trials": 0
+        },
+        "tokens": {
+          "cache_read_input_tokens": 0,
+          "cache_write_input_tokens": 0,
+          "input_tokens": 0,
+          "output_tokens": 0
+        }
+      },
+      "trial_count": 3
+    },
+    "psd-workspace": {
+      "pass^3": {
+        "passed_tasks": 1,
+        "rate": 1.0,
+        "total_tasks": 1
+      },
+      "task_count": 1,
+      "task_ids": [
+        "workspace-list-unread-mail"
+      ],
+      "telemetry": {
+        "caching_status": "unknown",
+        "cost": {
+          "per_task_usd": null,
+          "per_trial_usd": null,
+          "total_usd": null
+        },
+        "duration_ms": {
+          "mean": 27536.0,
+          "p50": 21231,
+          "p95": 40310,
+          "total": 82608
+        },
+        "failures": {
+          "by_error_class": {},
+          "by_failed_grader": {},
+          "graded_rate": 0.0,
+          "graded_trials": 0,
+          "rate": 0.0,
+          "trials": 0
+        },
+        "latency_ms": {
+          "mean": 27406.333,
+          "p50": 21124,
+          "p95": 40255,
+          "total": 82219
+        },
+        "model_call_count": {
+          "mean": 4.0,
+          "p50": 4,
+          "p95": 4,
+          "total": 12
+        },
+        "nudged": {
+          "rate": 0.0,
+          "trials": 0
+        },
+        "tokens": {
+          "cache_read_input_tokens": 0,
+          "cache_write_input_tokens": 0,
+          "input_tokens": 0,
+          "output_tokens": 0
+        }
+      },
+      "trial_count": 3
+    }
+  },
+  "source_commit": "9d00a63e414c89df88e4ab7a0704353cf33f6f76",
+  "source_commit_provenance": "image-label",
+  "suites": {
+    "regression": {
+      "pass^3": {
+        "passed_tasks": 5,
+        "rate": 1.0,
+        "total_tasks": 5
+      },
+      "task_count": 5,
+      "telemetry": {
+        "caching_status": "unknown",
+        "cost": {
+          "per_task_usd": null,
+          "per_trial_usd": null,
+          "total_usd": null
+        },
+        "duration_ms": {
+          "mean": 19615.0,
+          "p50": 17874,
+          "p95": 45728,
+          "total": 294225
+        },
+        "failures": {
+          "by_error_class": {},
+          "by_failed_grader": {},
+          "graded_rate": 0.0,
+          "graded_trials": 0,
+          "rate": 0.0,
+          "trials": 0
+        },
+        "latency_ms": {
+          "mean": 19507.467,
+          "p50": 17833,
+          "p95": 45333,
+          "total": 292612
+        },
+        "model_call_count": {
+          "mean": 3.733,
+          "p50": 4,
+          "p95": 7,
+          "total": 56
+        },
+        "nudged": {
+          "rate": 0.0,
+          "trials": 0
+        },
+        "tokens": {
+          "cache_read_input_tokens": 0,
+          "cache_write_input_tokens": 0,
+          "input_tokens": 0,
+          "output_tokens": 0
+        }
+      },
+      "trial_count": 15
+    }
+  },
+  "summary_kind": "agent-eval-run",
+  "tasks": {
+    "data-list-tables": {
+      "pass^3": true,
+      "passed_trials": 3,
+      "skill": "psd-data",
+      "suite": "regression",
+      "trials": 3
+    },
+    "directory-literal-address-no-lookup": {
+      "pass^3": true,
+      "passed_trials": 3,
+      "skill": "psd-directory",
+      "suite": "regression",
+      "trials": 3
+    },
+    "failure-report-synthetic-missing-data": {
+      "pass^3": true,
+      "passed_trials": 3,
+      "skill": "psd-failure-report",
+      "suite": "regression",
+      "trials": 3
+    },
+    "freshservice-update-ticket-priority": {
+      "pass^3": true,
+      "passed_trials": 3,
+      "skill": "psd-freshservice",
+      "suite": "regression",
+      "trials": 3
+    },
+    "workspace-list-unread-mail": {
+      "pass^3": true,
+      "passed_trials": 3,
+      "skill": "psd-workspace",
+      "suite": "regression",
+      "trials": 3
+    }
+  }
+}

--- a/.eval-runs/sha256-94d362aa12c604ea30aa3c80d70f274f6fb39c8b2063d976997d0788b2e23623.json
+++ b/.eval-runs/sha256-94d362aa12c604ea30aa3c80d70f274f6fb39c8b2063d976997d0788b2e23623.json
@@ -1,0 +1,456 @@
+{
+  "eval_harness_commit": "5e2294bd124f0956c25ef95772da41c89bb8ebfd",
+  "image": "390844780692.dkr.ecr.us-east-1.amazonaws.com/psd-agent-base-dev@sha256:94d362aa12c604ea30aa3c80d70f274f6fb39c8b2063d976997d0788b2e23623",
+  "image_digest": "sha256:94d362aa12c604ea30aa3c80d70f274f6fb39c8b2063d976997d0788b2e23623",
+  "model": {
+    "model_id": "zai.glm-5",
+    "pricing_usd_per_million_tokens": {
+      "cacheRead": 0.0,
+      "cacheWrite": 0.0,
+      "input": 1.0,
+      "output": 3.2
+    },
+    "primary": "amazon-bedrock/zai.glm-5",
+    "provider": "amazon-bedrock"
+  },
+  "overall": {
+    "pass^3": {
+      "passed_tasks": 5,
+      "rate": 1.0,
+      "total_tasks": 5
+    },
+    "task_count": 5,
+    "telemetry": {
+      "caching_status": "unknown",
+      "cost": {
+        "per_task_usd": null,
+        "per_trial_usd": null,
+        "total_usd": null
+      },
+      "duration_ms": {
+        "mean": 13937.133,
+        "p50": 13949,
+        "p95": 26433,
+        "total": 209057
+      },
+      "failures": {
+        "by_error_class": {},
+        "by_failed_grader": {},
+        "graded_rate": 0.0,
+        "graded_trials": 0,
+        "rate": 0.0,
+        "trials": 0
+      },
+      "latency_ms": {
+        "mean": 13893.267,
+        "p50": 13907,
+        "p95": 26409,
+        "total": 208399
+      },
+      "model_call_count": {
+        "mean": 3.533,
+        "p50": 4,
+        "p95": 5,
+        "total": 53
+      },
+      "nudged": {
+        "rate": 0.0,
+        "trials": 0
+      },
+      "tokens": {
+        "cache_read_input_tokens": 0,
+        "cache_write_input_tokens": 0,
+        "input_tokens": 0,
+        "output_tokens": 0
+      }
+    },
+    "trial_count": 15
+  },
+  "run": {
+    "completed_at": "2026-07-30T15:59:51.178574+00:00",
+    "first_trial_recorded_at": "2026-07-30T15:55:41.029104+00:00",
+    "start_time_status": "captured",
+    "started_at": "2026-07-30T15:54:57.766938+00:00",
+    "task_count": 5,
+    "trial_count": 15,
+    "trials_per_task": 3
+  },
+  "schema_version": 2,
+  "skills": {
+    "psd-data": {
+      "pass^3": {
+        "passed_tasks": 1,
+        "rate": 1.0,
+        "total_tasks": 1
+      },
+      "task_count": 1,
+      "task_ids": [
+        "data-list-tables"
+      ],
+      "telemetry": {
+        "caching_status": "unknown",
+        "cost": {
+          "per_task_usd": null,
+          "per_trial_usd": null,
+          "total_usd": null
+        },
+        "duration_ms": {
+          "mean": 16423.667,
+          "p50": 17479,
+          "p95": 17843,
+          "total": 49271
+        },
+        "failures": {
+          "by_error_class": {},
+          "by_failed_grader": {},
+          "graded_rate": 0.0,
+          "graded_trials": 0,
+          "rate": 0.0,
+          "trials": 0
+        },
+        "latency_ms": {
+          "mean": 16345.667,
+          "p50": 17309,
+          "p95": 17821,
+          "total": 49037
+        },
+        "model_call_count": {
+          "mean": 4.0,
+          "p50": 4,
+          "p95": 4,
+          "total": 12
+        },
+        "nudged": {
+          "rate": 0.0,
+          "trials": 0
+        },
+        "tokens": {
+          "cache_read_input_tokens": 0,
+          "cache_write_input_tokens": 0,
+          "input_tokens": 0,
+          "output_tokens": 0
+        }
+      },
+      "trial_count": 3
+    },
+    "psd-directory": {
+      "pass^3": {
+        "passed_tasks": 1,
+        "rate": 1.0,
+        "total_tasks": 1
+      },
+      "task_count": 1,
+      "task_ids": [
+        "directory-literal-address-no-lookup"
+      ],
+      "telemetry": {
+        "caching_status": "unknown",
+        "cost": {
+          "per_task_usd": null,
+          "per_trial_usd": null,
+          "total_usd": null
+        },
+        "duration_ms": {
+          "mean": 4181.667,
+          "p50": 3412,
+          "p95": 5939,
+          "total": 12545
+        },
+        "failures": {
+          "by_error_class": {},
+          "by_failed_grader": {},
+          "graded_rate": 0.0,
+          "graded_trials": 0,
+          "rate": 0.0,
+          "trials": 0
+        },
+        "latency_ms": {
+          "mean": 4146.667,
+          "p50": 3384,
+          "p95": 5920,
+          "total": 12440
+        },
+        "model_call_count": {
+          "mean": 1.0,
+          "p50": 1,
+          "p95": 1,
+          "total": 3
+        },
+        "nudged": {
+          "rate": 0.0,
+          "trials": 0
+        },
+        "tokens": {
+          "cache_read_input_tokens": 0,
+          "cache_write_input_tokens": 0,
+          "input_tokens": 0,
+          "output_tokens": 0
+        }
+      },
+      "trial_count": 3
+    },
+    "psd-failure-report": {
+      "pass^3": {
+        "passed_tasks": 1,
+        "rate": 1.0,
+        "total_tasks": 1
+      },
+      "task_count": 1,
+      "task_ids": [
+        "failure-report-synthetic-missing-data"
+      ],
+      "telemetry": {
+        "caching_status": "unknown",
+        "cost": {
+          "per_task_usd": null,
+          "per_trial_usd": null,
+          "total_usd": null
+        },
+        "duration_ms": {
+          "mean": 11360.0,
+          "p50": 10947,
+          "p95": 14967,
+          "total": 34080
+        },
+        "failures": {
+          "by_error_class": {},
+          "by_failed_grader": {},
+          "graded_rate": 0.0,
+          "graded_trials": 0,
+          "rate": 0.0,
+          "trials": 0
+        },
+        "latency_ms": {
+          "mean": 11306.333,
+          "p50": 10859,
+          "p95": 14948,
+          "total": 33919
+        },
+        "model_call_count": {
+          "mean": 4.0,
+          "p50": 4,
+          "p95": 4,
+          "total": 12
+        },
+        "nudged": {
+          "rate": 0.0,
+          "trials": 0
+        },
+        "tokens": {
+          "cache_read_input_tokens": 0,
+          "cache_write_input_tokens": 0,
+          "input_tokens": 0,
+          "output_tokens": 0
+        }
+      },
+      "trial_count": 3
+    },
+    "psd-freshservice": {
+      "pass^3": {
+        "passed_tasks": 1,
+        "rate": 1.0,
+        "total_tasks": 1
+      },
+      "task_count": 1,
+      "task_ids": [
+        "freshservice-update-ticket-priority"
+      ],
+      "telemetry": {
+        "caching_status": "unknown",
+        "cost": {
+          "per_task_usd": null,
+          "per_trial_usd": null,
+          "total_usd": null
+        },
+        "duration_ms": {
+          "mean": 11964.333,
+          "p50": 9006,
+          "p95": 18012,
+          "total": 35893
+        },
+        "failures": {
+          "by_error_class": {},
+          "by_failed_grader": {},
+          "graded_rate": 0.0,
+          "graded_trials": 0,
+          "rate": 0.0,
+          "trials": 0
+        },
+        "latency_ms": {
+          "mean": 11935.667,
+          "p50": 8981,
+          "p95": 17988,
+          "total": 35807
+        },
+        "model_call_count": {
+          "mean": 4.333,
+          "p50": 4,
+          "p95": 5,
+          "total": 13
+        },
+        "nudged": {
+          "rate": 0.0,
+          "trials": 0
+        },
+        "tokens": {
+          "cache_read_input_tokens": 0,
+          "cache_write_input_tokens": 0,
+          "input_tokens": 0,
+          "output_tokens": 0
+        }
+      },
+      "trial_count": 3
+    },
+    "psd-workspace": {
+      "pass^3": {
+        "passed_tasks": 1,
+        "rate": 1.0,
+        "total_tasks": 1
+      },
+      "task_count": 1,
+      "task_ids": [
+        "workspace-list-unread-mail"
+      ],
+      "telemetry": {
+        "caching_status": "unknown",
+        "cost": {
+          "per_task_usd": null,
+          "per_trial_usd": null,
+          "total_usd": null
+        },
+        "duration_ms": {
+          "mean": 25756.0,
+          "p50": 25660,
+          "p95": 26433,
+          "total": 77268
+        },
+        "failures": {
+          "by_error_class": {},
+          "by_failed_grader": {},
+          "graded_rate": 0.0,
+          "graded_trials": 0,
+          "rate": 0.0,
+          "trials": 0
+        },
+        "latency_ms": {
+          "mean": 25732.0,
+          "p50": 25634,
+          "p95": 26409,
+          "total": 77196
+        },
+        "model_call_count": {
+          "mean": 4.333,
+          "p50": 4,
+          "p95": 5,
+          "total": 13
+        },
+        "nudged": {
+          "rate": 0.0,
+          "trials": 0
+        },
+        "tokens": {
+          "cache_read_input_tokens": 0,
+          "cache_write_input_tokens": 0,
+          "input_tokens": 0,
+          "output_tokens": 0
+        }
+      },
+      "trial_count": 3
+    }
+  },
+  "source_commit": "5e2294bd124f0956c25ef95772da41c89bb8ebfd",
+  "source_commit_provenance": "image-label",
+  "suites": {
+    "regression": {
+      "pass^3": {
+        "passed_tasks": 5,
+        "rate": 1.0,
+        "total_tasks": 5
+      },
+      "task_count": 5,
+      "telemetry": {
+        "caching_status": "unknown",
+        "cost": {
+          "per_task_usd": null,
+          "per_trial_usd": null,
+          "total_usd": null
+        },
+        "duration_ms": {
+          "mean": 13937.133,
+          "p50": 13949,
+          "p95": 26433,
+          "total": 209057
+        },
+        "failures": {
+          "by_error_class": {},
+          "by_failed_grader": {},
+          "graded_rate": 0.0,
+          "graded_trials": 0,
+          "rate": 0.0,
+          "trials": 0
+        },
+        "latency_ms": {
+          "mean": 13893.267,
+          "p50": 13907,
+          "p95": 26409,
+          "total": 208399
+        },
+        "model_call_count": {
+          "mean": 3.533,
+          "p50": 4,
+          "p95": 5,
+          "total": 53
+        },
+        "nudged": {
+          "rate": 0.0,
+          "trials": 0
+        },
+        "tokens": {
+          "cache_read_input_tokens": 0,
+          "cache_write_input_tokens": 0,
+          "input_tokens": 0,
+          "output_tokens": 0
+        }
+      },
+      "trial_count": 15
+    }
+  },
+  "summary_kind": "agent-eval-run",
+  "tasks": {
+    "data-list-tables": {
+      "pass^3": true,
+      "passed_trials": 3,
+      "skill": "psd-data",
+      "suite": "regression",
+      "trials": 3
+    },
+    "directory-literal-address-no-lookup": {
+      "pass^3": true,
+      "passed_trials": 3,
+      "skill": "psd-directory",
+      "suite": "regression",
+      "trials": 3
+    },
+    "failure-report-synthetic-missing-data": {
+      "pass^3": true,
+      "passed_trials": 3,
+      "skill": "psd-failure-report",
+      "suite": "regression",
+      "trials": 3
+    },
+    "freshservice-update-ticket-priority": {
+      "pass^3": true,
+      "passed_trials": 3,
+      "skill": "psd-freshservice",
+      "suite": "regression",
+      "trials": 3
+    },
+    "workspace-list-unread-mail": {
+      "pass^3": true,
+      "passed_trials": 3,
+      "skill": "psd-workspace",
+      "suite": "regression",
+      "trials": 3
+    }
+  }
+}

--- a/.eval-runs/sha256-f5d4a93499b76084b203152a1c5a5a78c2f1758ad8a00f64f5c116dff9cd434b.json
+++ b/.eval-runs/sha256-f5d4a93499b76084b203152a1c5a5a78c2f1758ad8a00f64f5c116dff9cd434b.json
@@ -1,0 +1,456 @@
+{
+  "eval_harness_commit": "7e806d28e44b2a073741308e591bdd508816cb84",
+  "image": "390844780692.dkr.ecr.us-east-1.amazonaws.com/psd-agent-base-dev@sha256:f5d4a93499b76084b203152a1c5a5a78c2f1758ad8a00f64f5c116dff9cd434b",
+  "image_digest": "sha256:f5d4a93499b76084b203152a1c5a5a78c2f1758ad8a00f64f5c116dff9cd434b",
+  "model": {
+    "model_id": "zai.glm-5",
+    "pricing_usd_per_million_tokens": {
+      "cacheRead": 0.0,
+      "cacheWrite": 0.0,
+      "input": 1.0,
+      "output": 3.2
+    },
+    "primary": "amazon-bedrock/zai.glm-5",
+    "provider": "amazon-bedrock"
+  },
+  "overall": {
+    "pass^3": {
+      "passed_tasks": 5,
+      "rate": 1.0,
+      "total_tasks": 5
+    },
+    "task_count": 5,
+    "telemetry": {
+      "caching_status": "unknown",
+      "cost": {
+        "per_task_usd": null,
+        "per_trial_usd": null,
+        "total_usd": null
+      },
+      "duration_ms": {
+        "mean": 22973.8,
+        "p50": 20573,
+        "p95": 58933,
+        "total": 344607
+      },
+      "failures": {
+        "by_error_class": {},
+        "by_failed_grader": {},
+        "graded_rate": 0.0,
+        "graded_trials": 0,
+        "rate": 0.0,
+        "trials": 0
+      },
+      "latency_ms": {
+        "mean": 22904.867,
+        "p50": 20537,
+        "p95": 58882,
+        "total": 343573
+      },
+      "model_call_count": {
+        "mean": 4.133,
+        "p50": 4,
+        "p95": 8,
+        "total": 62
+      },
+      "nudged": {
+        "rate": 0.0,
+        "trials": 0
+      },
+      "tokens": {
+        "cache_read_input_tokens": 0,
+        "cache_write_input_tokens": 0,
+        "input_tokens": 0,
+        "output_tokens": 0
+      }
+    },
+    "trial_count": 15
+  },
+  "run": {
+    "completed_at": "2026-07-30T14:20:49.360278+00:00",
+    "first_trial_recorded_at": "2026-07-30T14:14:44.293945+00:00",
+    "start_time_status": "captured",
+    "started_at": "2026-07-30T14:13:30.155200+00:00",
+    "task_count": 5,
+    "trial_count": 15,
+    "trials_per_task": 3
+  },
+  "schema_version": 2,
+  "skills": {
+    "psd-data": {
+      "pass^3": {
+        "passed_tasks": 1,
+        "rate": 1.0,
+        "total_tasks": 1
+      },
+      "task_count": 1,
+      "task_ids": [
+        "data-list-tables"
+      ],
+      "telemetry": {
+        "caching_status": "unknown",
+        "cost": {
+          "per_task_usd": null,
+          "per_trial_usd": null,
+          "total_usd": null
+        },
+        "duration_ms": {
+          "mean": 25482.667,
+          "p50": 20410,
+          "p95": 45963,
+          "total": 76448
+        },
+        "failures": {
+          "by_error_class": {},
+          "by_failed_grader": {},
+          "graded_rate": 0.0,
+          "graded_trials": 0,
+          "rate": 0.0,
+          "trials": 0
+        },
+        "latency_ms": {
+          "mean": 25387.667,
+          "p50": 20365,
+          "p95": 45763,
+          "total": 76163
+        },
+        "model_call_count": {
+          "mean": 5.667,
+          "p50": 5,
+          "p95": 8,
+          "total": 17
+        },
+        "nudged": {
+          "rate": 0.0,
+          "trials": 0
+        },
+        "tokens": {
+          "cache_read_input_tokens": 0,
+          "cache_write_input_tokens": 0,
+          "input_tokens": 0,
+          "output_tokens": 0
+        }
+      },
+      "trial_count": 3
+    },
+    "psd-directory": {
+      "pass^3": {
+        "passed_tasks": 1,
+        "rate": 1.0,
+        "total_tasks": 1
+      },
+      "task_count": 1,
+      "task_ids": [
+        "directory-literal-address-no-lookup"
+      ],
+      "telemetry": {
+        "caching_status": "unknown",
+        "cost": {
+          "per_task_usd": null,
+          "per_trial_usd": null,
+          "total_usd": null
+        },
+        "duration_ms": {
+          "mean": 6072.333,
+          "p50": 3685,
+          "p95": 11301,
+          "total": 18217
+        },
+        "failures": {
+          "by_error_class": {},
+          "by_failed_grader": {},
+          "graded_rate": 0.0,
+          "graded_trials": 0,
+          "rate": 0.0,
+          "trials": 0
+        },
+        "latency_ms": {
+          "mean": 6023.0,
+          "p50": 3609,
+          "p95": 11272,
+          "total": 18069
+        },
+        "model_call_count": {
+          "mean": 1.0,
+          "p50": 1,
+          "p95": 1,
+          "total": 3
+        },
+        "nudged": {
+          "rate": 0.0,
+          "trials": 0
+        },
+        "tokens": {
+          "cache_read_input_tokens": 0,
+          "cache_write_input_tokens": 0,
+          "input_tokens": 0,
+          "output_tokens": 0
+        }
+      },
+      "trial_count": 3
+    },
+    "psd-failure-report": {
+      "pass^3": {
+        "passed_tasks": 1,
+        "rate": 1.0,
+        "total_tasks": 1
+      },
+      "task_count": 1,
+      "task_ids": [
+        "failure-report-synthetic-missing-data"
+      ],
+      "telemetry": {
+        "caching_status": "unknown",
+        "cost": {
+          "per_task_usd": null,
+          "per_trial_usd": null,
+          "total_usd": null
+        },
+        "duration_ms": {
+          "mean": 17166.0,
+          "p50": 12986,
+          "p95": 27248,
+          "total": 51498
+        },
+        "failures": {
+          "by_error_class": {},
+          "by_failed_grader": {},
+          "graded_rate": 0.0,
+          "graded_trials": 0,
+          "rate": 0.0,
+          "trials": 0
+        },
+        "latency_ms": {
+          "mean": 17080.333,
+          "p50": 12955,
+          "p95": 27213,
+          "total": 51241
+        },
+        "model_call_count": {
+          "mean": 4.0,
+          "p50": 4,
+          "p95": 4,
+          "total": 12
+        },
+        "nudged": {
+          "rate": 0.0,
+          "trials": 0
+        },
+        "tokens": {
+          "cache_read_input_tokens": 0,
+          "cache_write_input_tokens": 0,
+          "input_tokens": 0,
+          "output_tokens": 0
+        }
+      },
+      "trial_count": 3
+    },
+    "psd-freshservice": {
+      "pass^3": {
+        "passed_tasks": 1,
+        "rate": 1.0,
+        "total_tasks": 1
+      },
+      "task_count": 1,
+      "task_ids": [
+        "freshservice-update-ticket-priority"
+      ],
+      "telemetry": {
+        "caching_status": "unknown",
+        "cost": {
+          "per_task_usd": null,
+          "per_trial_usd": null,
+          "total_usd": null
+        },
+        "duration_ms": {
+          "mean": 24139.667,
+          "p50": 21736,
+          "p95": 30110,
+          "total": 72419
+        },
+        "failures": {
+          "by_error_class": {},
+          "by_failed_grader": {},
+          "graded_rate": 0.0,
+          "graded_trials": 0,
+          "rate": 0.0,
+          "trials": 0
+        },
+        "latency_ms": {
+          "mean": 24081.0,
+          "p50": 21647,
+          "p95": 30059,
+          "total": 72243
+        },
+        "model_call_count": {
+          "mean": 4.667,
+          "p50": 5,
+          "p95": 5,
+          "total": 14
+        },
+        "nudged": {
+          "rate": 0.0,
+          "trials": 0
+        },
+        "tokens": {
+          "cache_read_input_tokens": 0,
+          "cache_write_input_tokens": 0,
+          "input_tokens": 0,
+          "output_tokens": 0
+        }
+      },
+      "trial_count": 3
+    },
+    "psd-workspace": {
+      "pass^3": {
+        "passed_tasks": 1,
+        "rate": 1.0,
+        "total_tasks": 1
+      },
+      "task_count": 1,
+      "task_ids": [
+        "workspace-list-unread-mail"
+      ],
+      "telemetry": {
+        "caching_status": "unknown",
+        "cost": {
+          "per_task_usd": null,
+          "per_trial_usd": null,
+          "total_usd": null
+        },
+        "duration_ms": {
+          "mean": 42008.333,
+          "p50": 41801,
+          "p95": 58933,
+          "total": 126025
+        },
+        "failures": {
+          "by_error_class": {},
+          "by_failed_grader": {},
+          "graded_rate": 0.0,
+          "graded_trials": 0,
+          "rate": 0.0,
+          "trials": 0
+        },
+        "latency_ms": {
+          "mean": 41952.333,
+          "p50": 41729,
+          "p95": 58882,
+          "total": 125857
+        },
+        "model_call_count": {
+          "mean": 5.333,
+          "p50": 5,
+          "p95": 6,
+          "total": 16
+        },
+        "nudged": {
+          "rate": 0.0,
+          "trials": 0
+        },
+        "tokens": {
+          "cache_read_input_tokens": 0,
+          "cache_write_input_tokens": 0,
+          "input_tokens": 0,
+          "output_tokens": 0
+        }
+      },
+      "trial_count": 3
+    }
+  },
+  "source_commit": "7e806d28e44b2a073741308e591bdd508816cb84",
+  "source_commit_provenance": "image-label",
+  "suites": {
+    "regression": {
+      "pass^3": {
+        "passed_tasks": 5,
+        "rate": 1.0,
+        "total_tasks": 5
+      },
+      "task_count": 5,
+      "telemetry": {
+        "caching_status": "unknown",
+        "cost": {
+          "per_task_usd": null,
+          "per_trial_usd": null,
+          "total_usd": null
+        },
+        "duration_ms": {
+          "mean": 22973.8,
+          "p50": 20573,
+          "p95": 58933,
+          "total": 344607
+        },
+        "failures": {
+          "by_error_class": {},
+          "by_failed_grader": {},
+          "graded_rate": 0.0,
+          "graded_trials": 0,
+          "rate": 0.0,
+          "trials": 0
+        },
+        "latency_ms": {
+          "mean": 22904.867,
+          "p50": 20537,
+          "p95": 58882,
+          "total": 343573
+        },
+        "model_call_count": {
+          "mean": 4.133,
+          "p50": 4,
+          "p95": 8,
+          "total": 62
+        },
+        "nudged": {
+          "rate": 0.0,
+          "trials": 0
+        },
+        "tokens": {
+          "cache_read_input_tokens": 0,
+          "cache_write_input_tokens": 0,
+          "input_tokens": 0,
+          "output_tokens": 0
+        }
+      },
+      "trial_count": 15
+    }
+  },
+  "summary_kind": "agent-eval-run",
+  "tasks": {
+    "data-list-tables": {
+      "pass^3": true,
+      "passed_trials": 3,
+      "skill": "psd-data",
+      "suite": "regression",
+      "trials": 3
+    },
+    "directory-literal-address-no-lookup": {
+      "pass^3": true,
+      "passed_trials": 3,
+      "skill": "psd-directory",
+      "suite": "regression",
+      "trials": 3
+    },
+    "failure-report-synthetic-missing-data": {
+      "pass^3": true,
+      "passed_trials": 3,
+      "skill": "psd-failure-report",
+      "suite": "regression",
+      "trials": 3
+    },
+    "freshservice-update-ticket-priority": {
+      "pass^3": true,
+      "passed_trials": 3,
+      "skill": "psd-freshservice",
+      "suite": "regression",
+      "trials": 3
+    },
+    "workspace-list-unread-mail": {
+      "pass^3": true,
+      "passed_trials": 3,
+      "skill": "psd-workspace",
+      "suite": "regression",
+      "trials": 3
+    }
+  }
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -153,6 +153,10 @@ ECS streaming infrastructure operations and monitoring.
 Digest-bound harness, prompt, and model comparison decisions from the first
 full PSD Agent eval run.
 
+#### [operations/agent-eval-glm-5-contract-follow-up-2026-07-30.md](./operations/agent-eval-glm-5-contract-follow-up-2026-07-30.md)
+Reproduction evidence, prompt hardening, repeated trials, and the non-promotion
+decision for the GLM-5 stable-skill contract follow-up.
+
 #### [operations/production-migration-checklist.md](./operations/production-migration-checklist.md)
 Comprehensive checklist for deploying to production.
 

--- a/docs/operations/agent-eval-glm-5-contract-follow-up-2026-07-30.md
+++ b/docs/operations/agent-eval-glm-5-contract-follow-up-2026-07-30.md
@@ -47,9 +47,15 @@ The skill contracts now make the stable behaviors explicit:
 - Freshservice uses the documented numeric priority, one update, and one
   success response;
 - workspace URL/path parameters use `--params`, while request bodies use
-  `--json`; and
+  `--json`, with the canonical unread-mail call available before the first
+  tool invocation;
+- successful failure-report responses use the exact `Failure ID:
+  <failure_id>` label; and
 - the global rules require reading the current skill instructions before the
-  first invocation each turn and preserving exact user-provided text.
+  first invocation each turn and preserving exact user-provided text. A sole
+  current-message literal is returned without extra prose; compound requests
+  preserve the literal while answering the remaining parts, and literals from
+  earlier messages, attachments, or tool output must still be used.
 
 Tests pin these instructions and prove the focused suite resolves to the same
 task objects as the regression suite. No grader was relaxed to obtain a pass.
@@ -60,7 +66,9 @@ task objects as the regression suite. No grader was relaxed to obtain a pass.
 | --- | --- | --- | --- |
 | `sha256:0246a2246483d5d53f029043f426f4221a4eb447071679c31794c9d1a04017d2` | `ecc637068809f03511177f4f65d9d137d79a1145` | 3/3, 3/3, 3/3, 3/3, 1/3 | Reject: workspace trials skipped the current skill contract. |
 | `sha256:b93cba50795243b8b03ce1aa1147e8ff2910ffc4dd92977a6d0a6c764e5e6e4d` | `299e115459896bb6ea19c326d70c9e628b4a3d7f` | 3/3, 2/3, 3/3, 2/3, 2/3 | Reject: one literal was substituted and two correct tool calls ended in post-success runtime errors. |
-| `sha256:f5d4a93499b76084b203152a1c5a5a78c2f1758ad8a00f64f5c116dff9cd434b` | `7e806d28e44b2a073741308e591bdd508816cb84` | 3/3, 3/3, 3/3, 3/3, 3/3 | Accept the five-contract prompt mitigation. |
+| `sha256:f5d4a93499b76084b203152a1c5a5a78c2f1758ad8a00f64f5c116dff9cd434b` | `7e806d28e44b2a073741308e591bdd508816cb84` | 3/3, 3/3, 3/3, 3/3, 3/3 | Provisional pass; review found the global literal-only response rule was too broad for compound requests and literals from earlier sources. |
+| `sha256:e4f4a25cea83b631dba6aae368235a16abec29bac1646de88d2672c62f92f76d` | `3821cf2eb8b6a794f42d73599fd37d8930810b3c` | 3/3, 3/3, 2/3, 3/3, 1/3 | Reject: one response renamed `Failure ID`, and two workspace trials made a speculative `--json` call before reading the skill. |
+| `sha256:6a343e3f1dce515d621f69e9b47f76af4fce01e0ed4cbed183a536b74a6debf5` | `9d00a63e414c89df88e4ab7a0704353cf33f6f76` | 3/3, 3/3, 3/3, 3/3, 3/3 | Accept the narrowed, review-corrected five-contract prompt mitigation. |
 
 The final image also includes the settled post-tool-turn recovery from
 [#1469](https://github.com/psd401/aistudio/issues/1469). It passed the build
@@ -74,7 +82,7 @@ boot probe, the exact `CANDIDATE_OK` canary, and all 15 focused trials:
 | `freshservice-update-ticket-priority` | 3/3 |
 | `workspace-list-unread-mail` | 3/3 |
 
-[Transcript-free final summary](../../.eval-runs/sha256-f5d4a93499b76084b203152a1c5a5a78c2f1758ad8a00f64f5c116dff9cd434b.json)
+[Transcript-free final summary](../../.eval-runs/sha256-6a343e3f1dce515d621f69e9b47f76af4fce01e0ed4cbed183a536b74a6debf5.json)
 
 ## Decision
 

--- a/docs/operations/agent-eval-glm-5-contract-follow-up-2026-07-30.md
+++ b/docs/operations/agent-eval-glm-5-contract-follow-up-2026-07-30.md
@@ -47,15 +47,21 @@ The skill contracts now make the stable behaviors explicit:
 - Freshservice uses the documented numeric priority, one update, and one
   success response;
 - workspace URL/path parameters use `--params`, while request bodies use
-  `--json`, with the canonical unread-mail call available before the first
-  tool invocation;
+  `--json`; the canonical unread-mail defaults are available before the first
+  tool invocation, while caller-provided filters and page sizes are preserved;
 - successful failure-report responses use the exact `Failure ID:
   <failure_id>` label; and
-- the global rules require reading the current skill instructions before the
-  first invocation each turn and preserving exact user-provided text. A sole
-  current-message literal is returned without extra prose; compound requests
-  preserve the literal while answering the remaining parts, and literals from
-  earlier messages, attachments, or tool output must still be used.
+- the global rules require a successful read of the current skill instructions
+  before the first invocation in the current user turn and preserve exact
+  user-provided text. A sole current-message literal is returned without extra
+  prose; compound requests preserve the literal while answering the remaining
+  parts, and literals from earlier messages, attachments, or tool output must
+  still be used;
+- the literal-only response contract is scoped without disabling the global
+  no-tool-narration rule; and
+- transient read-only lookup results are not durable memory. After a successful
+  workspace lookup, the assistant returns the requested summary before any
+  memory or unrelated tool call.
 
 Tests pin these instructions and prove the focused suite resolves to the same
 task objects as the regression suite. No grader was relaxed to obtain a pass.
@@ -68,7 +74,9 @@ task objects as the regression suite. No grader was relaxed to obtain a pass.
 | `sha256:b93cba50795243b8b03ce1aa1147e8ff2910ffc4dd92977a6d0a6c764e5e6e4d` | `299e115459896bb6ea19c326d70c9e628b4a3d7f` | 3/3, 2/3, 3/3, 2/3, 2/3 | Reject: one literal was substituted and two correct tool calls ended in post-success runtime errors. |
 | `sha256:f5d4a93499b76084b203152a1c5a5a78c2f1758ad8a00f64f5c116dff9cd434b` | `7e806d28e44b2a073741308e591bdd508816cb84` | 3/3, 3/3, 3/3, 3/3, 3/3 | Provisional pass; review found the global literal-only response rule was too broad for compound requests and literals from earlier sources. |
 | `sha256:e4f4a25cea83b631dba6aae368235a16abec29bac1646de88d2672c62f92f76d` | `3821cf2eb8b6a794f42d73599fd37d8930810b3c` | 3/3, 3/3, 2/3, 3/3, 1/3 | Reject: one response renamed `Failure ID`, and two workspace trials made a speculative `--json` call before reading the skill. |
-| `sha256:6a343e3f1dce515d621f69e9b47f76af4fce01e0ed4cbed183a536b74a6debf5` | `9d00a63e414c89df88e4ab7a0704353cf33f6f76` | 3/3, 3/3, 3/3, 3/3, 3/3 | Accept the narrowed, review-corrected five-contract prompt mitigation. |
+| `sha256:6a343e3f1dce515d621f69e9b47f76af4fce01e0ed4cbed183a536b74a6debf5` | `9d00a63e414c89df88e4ab7a0704353cf33f6f76` | 3/3, 3/3, 3/3, 3/3, 3/3 | Provisional pass; later review found current-turn skill-read wording, caller-filter preservation, and no-narration scoping ambiguities. |
+| `sha256:ec99b3366fec36097f56a675b14686a70489bdb70b9026c99bdb34ab1648842b` | `1a705fee43239d02a3ae34722d775bc96a939d2e` | 3/3, 3/3, 3/3, 3/3, 2/3 | Reject: one workspace trial made the correct broker call, then attempted memory work and ended with an incomplete tool turn instead of the requested summary. |
+| `sha256:94d362aa12c604ea30aa3c80d70f274f6fb39c8b2063d976997d0788b2e23623` | `5e2294bd124f0956c25ef95772da41c89bb8ebfd` | 3/3, 3/3, 3/3, 3/3, 3/3 | Accept the review-corrected contracts plus explicit read-only result ordering. |
 
 The final image also includes the settled post-tool-turn recovery from
 [#1469](https://github.com/psd401/aistudio/issues/1469). It passed the build
@@ -82,7 +90,7 @@ boot probe, the exact `CANDIDATE_OK` canary, and all 15 focused trials:
 | `freshservice-update-ticket-priority` | 3/3 |
 | `workspace-list-unread-mail` | 3/3 |
 
-[Transcript-free final summary](../../.eval-runs/sha256-6a343e3f1dce515d621f69e9b47f76af4fce01e0ed4cbed183a536b74a6debf5.json)
+[Transcript-free final summary](../../.eval-runs/sha256-94d362aa12c604ea30aa3c80d70f274f6fb39c8b2063d976997d0788b2e23623.json)
 
 ## Decision
 

--- a/docs/operations/agent-eval-glm-5-contract-follow-up-2026-07-30.md
+++ b/docs/operations/agent-eval-glm-5-contract-follow-up-2026-07-30.md
@@ -1,0 +1,91 @@
+# GLM-5 skill-contract follow-up — 2026-07-30
+
+Issue [#1483](https://github.com/psd401/aistudio/issues/1483) followed up on
+the stable-skill regressions observed in the first GLM-5 comparison. This
+record captures the reproductions, prompt changes, repeated trials, and
+candidate decision. Building and evaluating these images did not deploy or
+promote GLM-5.
+
+## Scope and method
+
+- Candidate: Z.AI GLM-5 through native Bedrock Converse and SigV4
+- Original comparison digest:
+  `sha256:48bdedab676e00d95d107e2f2dc86f159a1ab3123234f3ccb3d8ff224928711c`
+- Five original regression tasks, three isolated trials per task
+- The focused suite references the existing regression task YAML files.
+  Their task definitions and deterministic graders are unchanged.
+- Raw JSONL transcripts remain outside the repository. The final committed
+  summary contains only aggregate grades and telemetry.
+
+The original immutable image predates the required
+`usage_capture_complete` metadata field. A local runner compatibility shim
+ignored only that missing legacy field so the original image could be
+replayed; it did not change task definitions or graders. The fresh replay
+reproduced two still-active contract failures:
+
+| Task | Original comparison | Fresh replay |
+| --- | ---: | ---: |
+| `data-list-tables` | 1/3 | 2/3 |
+| `directory-literal-address-no-lookup` | 2/3 | 3/3 |
+| `failure-report-synthetic-missing-data` | 2/3 | 3/3 |
+| `freshservice-update-ticket-priority` | 1/3 | 3/3 |
+| `workspace-list-unread-mail` | 1/3 | 2/3 |
+
+The replay observed `detailed=false` for the data call and `--json` instead
+of `--params` for the workspace query. The first comparison remains the
+evidence for the intermittent directory, failure-report, and Freshservice
+failures.
+
+## Prompt hardening
+
+The skill contracts now make the stable behaviors explicit:
+
+- table discovery uses exactly `tables --detailed`;
+- literal user-provided addresses are copied exactly once without lookup;
+- failure reports invoke the reporting tool and only claim logging from its
+  returned status;
+- Freshservice uses the documented numeric priority, one update, and one
+  success response;
+- workspace URL/path parameters use `--params`, while request bodies use
+  `--json`; and
+- the global rules require reading the current skill instructions before the
+  first invocation each turn and preserving exact user-provided text.
+
+Tests pin these instructions and prove the focused suite resolves to the same
+task objects as the regression suite. No grader was relaxed to obtain a pass.
+
+## Iterations
+
+| Candidate | Source revision | Results by task | Decision |
+| --- | --- | --- | --- |
+| `sha256:0246a2246483d5d53f029043f426f4221a4eb447071679c31794c9d1a04017d2` | `ecc637068809f03511177f4f65d9d137d79a1145` | 3/3, 3/3, 3/3, 3/3, 1/3 | Reject: workspace trials skipped the current skill contract. |
+| `sha256:b93cba50795243b8b03ce1aa1147e8ff2910ffc4dd92977a6d0a6c764e5e6e4d` | `299e115459896bb6ea19c326d70c9e628b4a3d7f` | 3/3, 2/3, 3/3, 2/3, 2/3 | Reject: one literal was substituted and two correct tool calls ended in post-success runtime errors. |
+| `sha256:f5d4a93499b76084b203152a1c5a5a78c2f1758ad8a00f64f5c116dff9cd434b` | `7e806d28e44b2a073741308e591bdd508816cb84` | 3/3, 3/3, 3/3, 3/3, 3/3 | Accept the five-contract prompt mitigation. |
+
+The final image also includes the settled post-tool-turn recovery from
+[#1469](https://github.com/psd401/aistudio/issues/1469). It passed the build
+boot probe, the exact `CANDIDATE_OK` canary, and all 15 focused trials:
+
+| Task | Final result |
+| --- | ---: |
+| `data-list-tables` | 3/3 |
+| `directory-literal-address-no-lookup` | 3/3 |
+| `failure-report-synthetic-missing-data` | 3/3 |
+| `freshservice-update-ticket-priority` | 3/3 |
+| `workspace-list-unread-mail` | 3/3 |
+
+[Transcript-free final summary](../../.eval-runs/sha256-f5d4a93499b76084b203152a1c5a5a78c2f1758ad8a00f64f5c116dff9cd434b.json)
+
+## Decision
+
+Explicit skill and global prompt contracts can enforce these five stable
+behaviors for GLM-5 without weakening their deterministic graders. The
+hardening is model-independent and protects the same contracts for every
+candidate.
+
+GLM-5 remains **rejected and unpromoted**. This focused follow-up does not
+rerun the complete regression and capability comparison, does not establish
+a strict capability improvement, and cannot evaluate the cost clause because
+the native transcript reported incomplete token-usage capture. A future
+promotion attempt must use a fresh immutable image and satisfy all three
+full-suite promotion clauses.

--- a/infra/agent-image/SOUL.md
+++ b/infra/agent-image/SOUL.md
@@ -24,6 +24,10 @@ Your memory is plain Markdown files in `~/.openclaw/`. **The model has no hidden
 - **`memory/YYYY-MM-DD.md`** — daily log (Pacific date). Append a 1–3 sentence summary at the end of every meaningful exchange.
 
 Before writing, read the file. Update or replace; don't keep duplicating the same fact.
+Transient read-only results are not durable memory. For a one-off inbox,
+calendar, directory, or file listing that establishes no preference or
+decision, return the requested result immediately and do not write the
+retrieved content to memory.
 
 ## What you actually have access to
 
@@ -66,6 +70,8 @@ caller supplies no different filter or page size:
 If the caller specifies a filter or page size, preserve those requested values
 inside `--params` instead of replacing them with the defaults.
 Do not make a speculative Workspace call before loading the current contract.
+After a successful read-only Workspace result, return the requested summary
+before any memory or unrelated tool call.
 
 **"My" vs "your" inbox:**
 - "my email", "my inbox", "my calendar" = the human user's account (you read it via delegation they configured to your agent account).

--- a/infra/agent-image/SOUL.md
+++ b/infra/agent-image/SOUL.md
@@ -40,7 +40,10 @@ You do **not** have built-in access to email, calendar, files outside the worksp
 
 1. **Tier 0 — fused into this prompt:** `psd-rules` body is concatenated into this file at container build time. The full rules are below; you always have them.
 2. **Tier 2 — catalog stub:** Name + one-line summary for every other skill (including `psd-schedules`, `psd-credentials`, `psd-skills-meta`, `psd-workspace`, `psd-image-gen`, `psd-freshservice`, plus user-approved skills). Use `psd-skills-meta` → `skills.search("keyword")` to find them.
-3. **Tier 3 — on-demand:** Use `skills.load("name")` to pull a Tier 2 skill's full SKILL.md into the current session before invoking it. Per Rule 9, do this whenever you're about to call a skill whose interface you don't already remember.
+3. **Tier 3 — on-demand:** Per Rule 9, read a skill's current SKILL.md before
+   its first invocation in every user turn, even when you believe you remember
+   the interface. Use `skills.load("name")` when the contract is not already
+   available in the session.
 
 ## Credentials
 

--- a/infra/agent-image/SOUL.md
+++ b/infra/agent-image/SOUL.md
@@ -42,8 +42,9 @@ You do **not** have built-in access to email, calendar, files outside the worksp
 2. **Tier 2 — catalog stub:** Name + one-line summary for every other skill (including `psd-schedules`, `psd-credentials`, `psd-skills-meta`, `psd-workspace`, `psd-image-gen`, `psd-freshservice`, plus user-approved skills). Use `psd-skills-meta` → `skills.search("keyword")` to find them.
 3. **Tier 3 — on-demand:** Per Rule 9, read a skill's current SKILL.md before
    its first invocation in every user turn, even when you believe you remember
-   the interface. Use `skills.load("name")` when the contract is not already
-   available in the session.
+   the interface. Use `skills.load("name")` unless you have already read that
+   skill's contract in the current turn — a read in an earlier turn does not
+   carry over.
 
 ## Credentials
 
@@ -60,8 +61,11 @@ For anything in Gmail, Calendar, Drive, Docs, Sheets, Slides, Forms, Tasks, Meet
 
 **Unread-mail command contract:** URL and query values belong in `--params`,
 never `--json`. After reading `psd-workspace/SKILL.md`, use the documented
-inner command exactly:
+inner command with its flags unchanged:
 `gmail users messages list --params '{"userId":"me","q":"is:unread","maxResults":20}'`.
+The `q` and `maxResults` values there are defaults for a bare "any unread
+mail?" request — when the caller asks for a narrower query or a different
+count, put their filter and count in `--params` instead of the defaults.
 Do not make a speculative Workspace call before loading the current contract.
 
 **"My" vs "your" inbox:**

--- a/infra/agent-image/SOUL.md
+++ b/infra/agent-image/SOUL.md
@@ -43,7 +43,7 @@ You do **not** have built-in access to email, calendar, files outside the worksp
 3. **Tier 3 — on-demand:** Per Rule 9, read a skill's current SKILL.md before
    its first invocation in every user turn, even when you believe you remember
    the interface. Use `skills.load("name")` when the contract is not already
-   available in the session.
+   available from a successful read in the current user turn.
 
 ## Credentials
 
@@ -60,8 +60,11 @@ For anything in Gmail, Calendar, Drive, Docs, Sheets, Slides, Forms, Tasks, Meet
 
 **Unread-mail command contract:** URL and query values belong in `--params`,
 never `--json`. After reading `psd-workspace/SKILL.md`, use the documented
-inner command exactly:
+default inner command exactly for a generic unread-mail listing when the
+caller supplies no different filter or page size:
 `gmail users messages list --params '{"userId":"me","q":"is:unread","maxResults":20}'`.
+If the caller specifies a filter or page size, preserve those requested values
+inside `--params` instead of replacing them with the defaults.
 Do not make a speculative Workspace call before loading the current contract.
 
 **"My" vs "your" inbox:**

--- a/infra/agent-image/SOUL.md
+++ b/infra/agent-image/SOUL.md
@@ -58,6 +58,12 @@ When a skill requires an API key, secret, or credential:
 
 For anything in Gmail, Calendar, Drive, Docs, Sheets, Slides, Forms, Tasks, Meet, Chat — use `psd-workspace`. See its SKILL.md for the full output contract and the gws CLI surface.
 
+**Unread-mail command contract:** URL and query values belong in `--params`,
+never `--json`. After reading `psd-workspace/SKILL.md`, use the documented
+inner command exactly:
+`gmail users messages list --params '{"userId":"me","q":"is:unread","maxResults":20}'`.
+Do not make a speculative Workspace call before loading the current contract.
+
 **"My" vs "your" inbox:**
 - "my email", "my inbox", "my calendar" = the human user's account (you read it via delegation they configured to your agent account).
 - "your inbox", "your calendar" = your own agent account.

--- a/infra/agent-image/eval/suites/glm-5-contracts.yaml
+++ b/infra/agent-image/eval/suites/glm-5-contracts.yaml
@@ -1,0 +1,7 @@
+# Focused regression suite for issue #1483's GLM-5 skill-contract failures.
+tasks:
+  - ../../skills/psd-data/evals/list-tables.yaml
+  - ../../skills/psd-directory/evals/literal-address-no-lookup.yaml
+  - ../../skills/psd-failure-report/evals/synthetic-missing-data.yaml
+  - ../../skills/psd-freshservice/evals/update-ticket-priority.yaml
+  - ../../skills/psd-workspace/evals/list-unread-mail.yaml

--- a/infra/agent-image/skills/psd-data/SKILL.md
+++ b/infra/agent-image/skills/psd-data/SKILL.md
@@ -117,6 +117,17 @@ node /opt/psd-skills/psd-data/run.js tables [--detailed]
 `--detailed` adds the table descriptions to the listing. Use this first
 when the user asks "do we have data on X?".
 
+**Table-availability contract:** when the user asks to list available tables
+or determine whether a named table exists, `--detailed` is required. Invoke
+this exact shape:
+
+```bash
+node /opt/psd-skills/psd-data/run.js tables --detailed
+```
+
+Do not omit `--detailed`, set `detailed` to false, or substitute a generic
+`call` invocation for this request.
+
 ### `schema` — inspect one or more tables' columns
 
 ```bash

--- a/infra/agent-image/skills/psd-directory/SKILL.md
+++ b/infra/agent-image/skills/psd-directory/SKILL.md
@@ -23,6 +23,14 @@ There is no `--user` flag. Whose directory access is used is decided by the
 signed invocation context on the server, not by anything you pass — you cannot
 look someone up "as" a different person.
 
+## Literal addresses are not lookup requests
+
+If the user supplies an address and asks you to return, repeat, quote, or
+format that literal address without identifying its owner, do not call this
+skill or any other tool. Follow the requested output shape directly. When the
+user asks for the address exactly as written, emit it exactly once with no
+label, explanation, duplication, or surrounding prose.
+
 ## What comes back
 
 One JSON line on stdout.

--- a/infra/agent-image/skills/psd-directory/SKILL.md
+++ b/infra/agent-image/skills/psd-directory/SKILL.md
@@ -28,8 +28,9 @@ look someone up "as" a different person.
 If the user supplies an address and asks you to return, repeat, quote, or
 format that literal address without identifying its owner, do not call this
 skill or any other tool. Follow the requested output shape directly. When the
-user asks for the address exactly as written, emit it exactly once with no
-label, explanation, duplication, or surrounding prose.
+literal address is the sole requested output, emit it exactly once with no
+label, explanation, duplication, or surrounding prose. For a compound request,
+preserve the literal address exactly while answering its other parts.
 
 ## What comes back
 

--- a/infra/agent-image/skills/psd-failure-report/SKILL.md
+++ b/infra/agent-image/skills/psd-failure-report/SKILL.md
@@ -42,6 +42,8 @@ Returns `{"logged": true, "failure_id": <int>}` on success. Returns `{"logged": 
 invoke `report.js` before replying. Planning the call, describing it, or
 claiming that it happened is not a report. Say the failure was logged only
 after stdout returns `"logged": true`, and include the returned `failure_id`.
+Use the exact user-facing label `Failure ID: <failure_id>`; never rename it
+`Record ID`, `Report ID`, or `Ticket ID`.
 If stdout returns `"logged": false`, say that the database log failed and do
 not invent an ID or claim success.
 

--- a/infra/agent-image/skills/psd-failure-report/SKILL.md
+++ b/infra/agent-image/skills/psd-failure-report/SKILL.md
@@ -38,6 +38,13 @@ Returns `{"logged": true, "failure_id": <int>}` on success. Returns `{"logged": 
 
 `--user-facing` (default `true`): when `true`, your reply to the user should also acknowledge what went wrong. When `false`, this is a silent telemetry-only report (use sparingly).
 
+**Execution and evidence contract:** "call `report`" means you must actually
+invoke `report.js` before replying. Planning the call, describing it, or
+claiming that it happened is not a report. Say the failure was logged only
+after stdout returns `"logged": true`, and include the returned `failure_id`.
+If stdout returns `"logged": false`, say that the database log failed and do
+not invent an ID or claim success.
+
 ## Examples
 
 ```bash

--- a/infra/agent-image/skills/psd-freshservice/SKILL.md
+++ b/infra/agent-image/skills/psd-freshservice/SKILL.md
@@ -64,6 +64,21 @@ node update_ticket.js --user <email> --id <id> --data '{"status":4}'
 node add_note.js --user <email> --id <id> --data '{"body":"...","notify_emails":["a@b.com"]}'
 ```
 
+### Exact update contract
+
+Translate priority names exactly: Low `1`, Medium `2`, High `3`, Urgent `4`.
+For a request to change only priority, invoke `update_ticket.js` once with a
+body containing only that field. For example:
+
+```bash
+node update_ticket.js --user <email> --id <id> --data '{"priority":4}'
+```
+
+Do not issue a preflight or follow-up `get_ticket.js` call unless the user asks
+for ticket details or the update returns an ambiguous error. After a successful
+update, report the ticket ID and new priority once; do not duplicate the
+success message.
+
 ## Agents and Workspaces
 
 ```bash

--- a/infra/agent-image/skills/psd-rules/SKILL.md
+++ b/infra/agent-image/skills/psd-rules/SKILL.md
@@ -159,13 +159,19 @@ If a skill exists for a task, its interface is the **only** path. Do not write B
 
 **How to apply:**
 
-1. Map the request to a skill (image → `psd-image-gen`, ticket → `psd-freshservice`, schedule → `psd-schedules`, secret → `psd-credentials`, Workspace API → `psd-workspace`) and call its CLI verbatim.
-2. Surface returned values *as-is*; don't generate a "fresh" one.
-3. **If a skill's JSON output contains a `url` field, your reply MUST include that exact URL on a line by itself** — no `**`, no `[label](url)`, no parentheses, no trailing period, no other text on that line. Narration (one short sentence at most) goes on a *separate* line, or is omitted.
-4. Describing the artifact in prose is **never** a substitute for pasting the URL. If you describe the image instead of pasting the URL, you have failed the rule.
-5. On an `error` field, surface the error text and stop — don't pivot to a custom pipeline.
-6. If you don't know what a skill does, call `psd-skills-meta load --name <skill>` first. Don't guess.
-7. Building the skill's behavior yourself in Bash is *always* wrong — even when the skill seems broken. Report the failure and stop.
+1. **Fresh-interface gate:** before the first invocation of any skill in every
+   user turn, read that skill's current `/opt/psd-skills/<skill>/SKILL.md`.
+   This is mandatory even if you used the skill in a previous turn, believe
+   you remember its interface, or the user included a likely command. Never
+   construct a skill command from memory. Copy its documented subcommand,
+   flags, and parameter/body roles exactly.
+2. Map the request to a skill (image → `psd-image-gen`, ticket → `psd-freshservice`, schedule → `psd-schedules`, secret → `psd-credentials`, Workspace API → `psd-workspace`) and call its CLI verbatim.
+3. Surface returned values *as-is*; don't generate a "fresh" one.
+4. **If a skill's JSON output contains a `url` field, your reply MUST include that exact URL on a line by itself** — no `**`, no `[label](url)`, no parentheses, no trailing period, no other text on that line. Narration (one short sentence at most) goes on a *separate* line, or is omitted.
+5. Describing the artifact in prose is **never** a substitute for pasting the URL. If you describe the image instead of pasting the URL, you have failed the rule.
+6. On an `error` field, surface the error text and stop — don't pivot to a custom pipeline.
+7. If you cannot read a skill contract, call `psd-skills-meta load --name <skill>` and use the returned contract before invoking it. Don't guess.
+8. Building the skill's behavior yourself in Bash is *always* wrong — even when the skill seems broken. Report the failure and stop.
 
 **Self-checks:**
 

--- a/infra/agent-image/skills/psd-rules/SKILL.md
+++ b/infra/agent-image/skills/psd-rules/SKILL.md
@@ -23,15 +23,16 @@ These rules are **non-negotiable**. They override stylistic guidance in `SOUL.md
 
 **How to apply:** before sending, re-read the draft and strike every sentence describing what *you* are about to do, are doing, or just did — including any that recount a tool call's existence ("checked the secret", "ran the query"). What remains is the answer; send only that. If nothing remains, you have no answer yet — do the work, then reply.
 
-**Standalone exact-output requests:** apply this no-prose rule only when the
-user asks for the entire reply to be one literal span that appears in the
-current user message. Copy that span character-for-character; do not replace
-it with an example, synonym, generic placeholder, or remembered value. Emit it
-exactly once with no label, explanation, or surrounding prose. If the request
-also asks for an explanation or another result, preserve the literal span but
-answer every requested part. If the source is an earlier message, attachment,
-or tool result, use that source instead of guessing or treating a remembered
-value as the requested text.
+**Standalone exact-output requests:** apply this literal-only,
+no-surrounding-prose behavior only when the user asks for the entire reply to
+be one literal span that appears in the current user message. Copy that span
+character-for-character; do not replace it with an example, synonym, generic
+placeholder, or remembered value. Emit it exactly once with no label,
+explanation, or surrounding prose. If the request also asks for an explanation
+or another result, preserve the literal span but answer every requested part.
+If the source is an earlier message, attachment, or tool result, use that
+source instead of guessing or treating a remembered value as the requested
+text.
 
 **Edge case:** state the *fact*, not the *process*. ✅ "The skill was using the wrong env var. Fixed in commit X." ❌ "Let me check common.js… line 200… found it…"
 

--- a/infra/agent-image/skills/psd-rules/SKILL.md
+++ b/infra/agent-image/skills/psd-rules/SKILL.md
@@ -23,11 +23,15 @@ These rules are **non-negotiable**. They override stylistic guidance in `SOUL.md
 
 **How to apply:** before sending, re-read the draft and strike every sentence describing what *you* are about to do, are doing, or just did — including any that recount a tool call's existence ("checked the secret", "ran the query"). What remains is the answer; send only that. If nothing remains, you have no answer yet — do the work, then reply.
 
-**Exact-output requests:** when the user asks you to return, repeat, or copy
-literal text exactly, copy the requested span from the current user message
-character-for-character. Do not replace it with an example, synonym, generic
-placeholder, or remembered value. Emit the literal exactly once with no label,
-explanation, or surrounding prose.
+**Standalone exact-output requests:** apply this no-prose rule only when the
+user asks for the entire reply to be one literal span that appears in the
+current user message. Copy that span character-for-character; do not replace
+it with an example, synonym, generic placeholder, or remembered value. Emit it
+exactly once with no label, explanation, or surrounding prose. If the request
+also asks for an explanation or another result, preserve the literal span but
+answer every requested part. If the source is an earlier message, attachment,
+or tool result, use that source instead of guessing or treating a remembered
+value as the requested text.
 
 **Edge case:** state the *fact*, not the *process*. ✅ "The skill was using the wrong env var. Fixed in commit X." ❌ "Let me check common.js… line 200… found it…"
 

--- a/infra/agent-image/skills/psd-rules/SKILL.md
+++ b/infra/agent-image/skills/psd-rules/SKILL.md
@@ -174,7 +174,9 @@ If a skill exists for a task, its interface is the **only** path. Do not write B
    This is mandatory even if you used the skill in a previous turn, believe
    you remember its interface, or the user included a likely command. Never
    construct a skill command from memory. Copy its documented subcommand,
-   flags, and parameter/body roles exactly.
+   flags, and parameter/body roles exactly. A skill invocation before you have
+   observed that read succeed in the current turn is a contract violation:
+   stop and read first, then construct the invocation.
 2. Map the request to a skill (image → `psd-image-gen`, ticket → `psd-freshservice`, schedule → `psd-schedules`, secret → `psd-credentials`, Workspace API → `psd-workspace`) and call its CLI verbatim.
 3. Surface returned values *as-is*; don't generate a "fresh" one.
 4. **If a skill's JSON output contains a `url` field, your reply MUST include that exact URL on a line by itself** — no `**`, no `[label](url)`, no parentheses, no trailing period, no other text on that line. Narration (one short sentence at most) goes on a *separate* line, or is omitted.
@@ -228,7 +230,10 @@ The `psd-` prefix is reserved for system skills bundled at `/opt/psd-skills/`. W
      --reason <category> \
      --details "<what you tried, what tool/data was missing, why you could not finish>"
    ```
-2. After `{"logged": true}`, write your normal reply and acknowledge what went wrong (don't pretend it succeeded).
+2. After `{"logged": true, "failure_id": <int>}`, write your normal reply,
+   acknowledge what went wrong, and include the exact label
+   `Failure ID: <failure_id>`. Never rename it `Record ID`, `Report ID`, or
+   `Ticket ID`.
 3. If in doubt, **call it** — over-report, never under-report.
 
 **Forbidden:** apologizing ("I wasn't able to…", "Sorry I couldn't…") without first calling `psd-failure-report`; fabricating success; skipping the report because "it might not be a real failure."

--- a/infra/agent-image/skills/psd-rules/SKILL.md
+++ b/infra/agent-image/skills/psd-rules/SKILL.md
@@ -23,6 +23,12 @@ These rules are **non-negotiable**. They override stylistic guidance in `SOUL.md
 
 **How to apply:** before sending, re-read the draft and strike every sentence describing what *you* are about to do, are doing, or just did — including any that recount a tool call's existence ("checked the secret", "ran the query"). What remains is the answer; send only that. If nothing remains, you have no answer yet — do the work, then reply.
 
+**Exact-output requests:** when the user asks you to return, repeat, or copy
+literal text exactly, copy the requested span from the current user message
+character-for-character. Do not replace it with an example, synonym, generic
+placeholder, or remembered value. Emit the literal exactly once with no label,
+explanation, or surrounding prose.
+
 **Edge case:** state the *fact*, not the *process*. ✅ "The skill was using the wrong env var. Fixed in commit X." ❌ "Let me check common.js… line 200… found it…"
 
 ---

--- a/infra/agent-image/skills/psd-rules/SKILL.md
+++ b/infra/agent-image/skills/psd-rules/SKILL.md
@@ -23,13 +23,18 @@ These rules are **non-negotiable**. They override stylistic guidance in `SOUL.md
 
 **How to apply:** before sending, re-read the draft and strike every sentence describing what *you* are about to do, are doing, or just did — including any that recount a tool call's existence ("checked the secret", "ran the query"). What remains is the answer; send only that. If nothing remains, you have no answer yet — do the work, then reply.
 
-**Standalone exact-output requests:** apply this no-prose rule only when the
-user asks for the entire reply to be one literal span that appears in the
+**Standalone exact-output requests:** this paragraph narrows one behavior
+only — emitting the literal span by itself, with nothing around it. It never
+relaxes the narration ban above, which applies to every reply without
+exception. Emit the bare literal only when the user asks for the
+entire reply to be one literal span that appears in the
 current user message. Copy that span character-for-character; do not replace
 it with an example, synonym, generic placeholder, or remembered value. Emit it
 exactly once with no label, explanation, or surrounding prose. If the request
-also asks for an explanation or another result, preserve the literal span but
-answer every requested part. If the source is an earlier message, attachment,
+also asks for an explanation or another result, preserve the literal span and
+answer every requested part — that surrounding answer is still subject to the
+narration ban, so it carries no plans, tool-call recounting, or debugging
+prose. If the source is an earlier message, attachment,
 or tool result, use that source instead of guessing or treating a remembered
 value as the requested text.
 

--- a/infra/agent-image/skills/psd-rules/SKILL.md
+++ b/infra/agent-image/skills/psd-rules/SKILL.md
@@ -134,6 +134,13 @@ Before ending the turn, update the relevant file:
 - **A decision was made** → one-line dated bullet in `MEMORY.md`.
 - **Always** append a 1–3 sentence summary to today's `memory/YYYY-MM-DD.md` (Pacific date, 24-hour timestamp).
 
+**Read-only exception:** a routine inbox, calendar, directory, file, or search
+lookup is not a meaningful exchange by itself, and its result is not durable
+memory. Unless the user explicitly asks you to remember it, do not write the
+retrieved content to memory. After the successful lookup, return the requested
+result immediately; do not insert a memory tool call between the result and
+the final answer.
+
 **Why:** without these writes the next turn boots blind and the user has to re-introduce themselves every time.
 
 ---

--- a/infra/agent-image/skills/psd-workspace/SKILL.md
+++ b/infra/agent-image/skills/psd-workspace/SKILL.md
@@ -89,6 +89,10 @@ and ask them to re-attach the file (or share it via Drive as a fallback).
 
 ### `--params` and `--json` are not interchangeable
 
+Reading this section is a precondition for the first Workspace invocation in
+each user turn. Do not make a speculative call from memory and correct it
+afterward: the first request must use the documented flags.
+
 Use `--params` for path and query parameters defined by the Google method
 (IDs, search queries, page sizes). Use `--json` only for a request body on a
 method that accepts one. Read/list methods such as

--- a/infra/agent-image/skills/psd-workspace/SKILL.md
+++ b/infra/agent-image/skills/psd-workspace/SKILL.md
@@ -108,6 +108,10 @@ When the caller supplies a query, sender, other filter, or page size, preserve
 those requested values inside `--params`; do not overwrite them with the
 defaults above.
 
+After a successful read/list call that the user asked only to summarize now,
+return the requested fields immediately. Do not read or write memory, and do
+not call an unrelated tool, before the final answer.
+
 ```bash
 node /opt/psd-skills/psd-workspace/run.js \
   --user <caller-email> \

--- a/infra/agent-image/skills/psd-workspace/SKILL.md
+++ b/infra/agent-image/skills/psd-workspace/SKILL.md
@@ -87,6 +87,18 @@ and ask them to re-attach the file (or share it via Drive as a fallback).
 
 ## Invocation
 
+### `--params` and `--json` are not interchangeable
+
+Use `--params` for path and query parameters defined by the Google method
+(IDs, search queries, page sizes). Use `--json` only for a request body on a
+method that accepts one. Read/list methods such as
+`gmail users messages list` take `--params`; never replace it with `--json`.
+For unread mail, preserve this exact command shape:
+
+```bash
+gmail users messages list --params '{"userId":"me","q":"is:unread","maxResults":20}'
+```
+
 ```bash
 node /opt/psd-skills/psd-workspace/run.js \
   --user <caller-email> \

--- a/infra/agent-image/skills/psd-workspace/SKILL.md
+++ b/infra/agent-image/skills/psd-workspace/SKILL.md
@@ -97,11 +97,16 @@ Use `--params` for path and query parameters defined by the Google method
 (IDs, search queries, page sizes). Use `--json` only for a request body on a
 method that accepts one. Read/list methods such as
 `gmail users messages list` take `--params`; never replace it with `--json`.
-For unread mail, preserve this exact command shape:
+For a generic unread-mail listing when the caller supplies no different filter
+or page size, preserve this exact default command shape:
 
 ```bash
 gmail users messages list --params '{"userId":"me","q":"is:unread","maxResults":20}'
 ```
+
+When the caller supplies a query, sender, other filter, or page size, preserve
+those requested values inside `--params`; do not overwrite them with the
+defaults above.
 
 ```bash
 node /opt/psd-skills/psd-workspace/run.js \

--- a/infra/agent-image/skills/psd-workspace/SKILL.md
+++ b/infra/agent-image/skills/psd-workspace/SKILL.md
@@ -97,11 +97,18 @@ Use `--params` for path and query parameters defined by the Google method
 (IDs, search queries, page sizes). Use `--json` only for a request body on a
 method that accepts one. Read/list methods such as
 `gmail users messages list` take `--params`; never replace it with `--json`.
-For unread mail, preserve this exact command shape:
+For unread mail, preserve this command and flag shape:
 
 ```bash
 gmail users messages list --params '{"userId":"me","q":"is:unread","maxResults":20}'
 ```
+
+`--params` is mandatory here and stays mandatory: never move `q`,
+`maxResults`, or any other query value into `--json`. The `q` and `maxResults`
+values above are the defaults for a bare "any unread mail?" request. When the
+caller asks for something narrower or a different count — five unread from one
+sender, mail from last week — carry their filter into `q` and their count into
+`maxResults` rather than sending the defaults back.
 
 ```bash
 node /opt/psd-skills/psd-workspace/run.js \

--- a/infra/agent-image/test_eval_runner.py
+++ b/infra/agent-image/test_eval_runner.py
@@ -705,6 +705,10 @@ class SuiteLoadingTests(unittest.TestCase):
                 "`--params` and `--json` are not interchangeable",
                 "gmail users messages list --params",
             ),
+            "psd-rules": (
+                "**Fresh-interface gate:**",
+                "Never\n   construct a skill command from memory.",
+            ),
         }
 
         for skill, required_fragments in skill_contracts.items():
@@ -714,6 +718,13 @@ class SuiteLoadingTests(unittest.TestCase):
                 ).read_text(encoding="utf-8")
                 for fragment in required_fragments:
                     self.assertIn(fragment, document)
+
+        soul = (AGENT_IMAGE_DIR / "SOUL.md").read_text(encoding="utf-8")
+        self.assertIn(
+            "read a skill's current SKILL.md before\n"
+            "   its first invocation in every user turn",
+            soul,
+        )
 
     def test_invalid_workspace_fails_closed(self):
         with self.subTest("validation happens after parsing"):

--- a/infra/agent-image/test_eval_runner.py
+++ b/infra/agent-image/test_eval_runner.py
@@ -714,6 +714,8 @@ class SuiteLoadingTests(unittest.TestCase):
                 "generic unread-mail listing when the caller supplies no "
                 "different filter",
                 "preserve\nthose requested values inside `--params`",
+                "Do not read or write memory",
+                "before the final answer",
             ),
             "psd-rules": (
                 "**Fresh-interface gate:**",
@@ -724,6 +726,9 @@ class SuiteLoadingTests(unittest.TestCase):
                 "entire reply to\nbe one literal span",
                 "also asks for an explanation\nor another result",
                 "earlier message, attachment, or tool result",
+                "**Read-only exception:**",
+                "do not insert a memory tool call between the result and\n"
+                "the final answer",
             ),
         }
 
@@ -752,6 +757,11 @@ class SuiteLoadingTests(unittest.TestCase):
         )
         self.assertIn(
             "caller supplies no different filter or page size",
+            soul,
+        )
+        self.assertIn(
+            "return the requested summary\nbefore any memory or unrelated "
+            "tool call",
             soul,
         )
 

--- a/infra/agent-image/test_eval_runner.py
+++ b/infra/agent-image/test_eval_runner.py
@@ -711,15 +711,19 @@ class SuiteLoadingTests(unittest.TestCase):
                 "`--params` and `--json` are not interchangeable",
                 "the first request must use the documented flags",
                 "gmail users messages list --params",
+                "generic unread-mail listing when the caller supplies no "
+                "different filter",
+                "preserve\nthose requested values inside `--params`",
             ),
             "psd-rules": (
                 "**Fresh-interface gate:**",
                 "Never\n   construct a skill command from memory.",
                 "observed that read succeed in the current turn",
                 "**Standalone exact-output requests:**",
-                "entire reply to be one literal span",
-                "If the request\nalso asks for an explanation or another result",
-                "earlier message, attachment,\nor tool result",
+                "literal-only,\nno-surrounding-prose behavior",
+                "entire reply to\nbe one literal span",
+                "also asks for an explanation\nor another result",
+                "earlier message, attachment, or tool result",
             ),
         }
 
@@ -738,8 +742,16 @@ class SuiteLoadingTests(unittest.TestCase):
             soul,
         )
         self.assertIn(
+            "available from a successful read in the current user turn",
+            soul,
+        )
+        self.assertIn(
             "**Unread-mail command contract:** URL and query values belong "
             "in `--params`,\nnever `--json`.",
+            soul,
+        )
+        self.assertIn(
+            "caller supplies no different filter or page size",
             soul,
         )
 

--- a/infra/agent-image/test_eval_runner.py
+++ b/infra/agent-image/test_eval_runner.py
@@ -708,6 +708,8 @@ class SuiteLoadingTests(unittest.TestCase):
             "psd-rules": (
                 "**Fresh-interface gate:**",
                 "Never\n   construct a skill command from memory.",
+                "**Exact-output requests:**",
+                "copy the requested span from the current user message",
             ),
         }
 

--- a/infra/agent-image/test_eval_runner.py
+++ b/infra/agent-image/test_eval_runner.py
@@ -684,6 +684,9 @@ class SuiteLoadingTests(unittest.TestCase):
             self.assertEqual(task, regression_tasks[task.id])
 
     def test_glm_regression_skill_prompts_pin_exact_contracts(self):
+        # These exact fragments deliberately pin behavior-bearing instructions.
+        # A copyedit failure should trigger contract review, not weaker matching;
+        # the separate repeated model eval is the behavioral proof.
         skill_contracts = {
             "psd-data": (
                 "node /opt/psd-skills/psd-data/run.js tables --detailed",
@@ -697,6 +700,8 @@ class SuiteLoadingTests(unittest.TestCase):
             "psd-failure-report": (
                 "actually\ninvoke `report.js`",
                 'stdout returns `"logged": true`',
+                "Failure ID: <failure_id>",
+                "never rename it\n`Record ID`",
             ),
             "psd-freshservice": (
                 "Urgent `4`",
@@ -704,11 +709,13 @@ class SuiteLoadingTests(unittest.TestCase):
             ),
             "psd-workspace": (
                 "`--params` and `--json` are not interchangeable",
+                "the first request must use the documented flags",
                 "gmail users messages list --params",
             ),
             "psd-rules": (
                 "**Fresh-interface gate:**",
                 "Never\n   construct a skill command from memory.",
+                "observed that read succeed in the current turn",
                 "**Standalone exact-output requests:**",
                 "entire reply to be one literal span",
                 "If the request\nalso asks for an explanation or another result",
@@ -728,6 +735,11 @@ class SuiteLoadingTests(unittest.TestCase):
         self.assertIn(
             "read a skill's current SKILL.md before\n"
             "   its first invocation in every user turn",
+            soul,
+        )
+        self.assertIn(
+            "**Unread-mail command contract:** URL and query values belong "
+            "in `--params`,\nnever `--json`.",
             soul,
         )
 

--- a/infra/agent-image/test_eval_runner.py
+++ b/infra/agent-image/test_eval_runner.py
@@ -659,6 +659,62 @@ class SuiteLoadingTests(unittest.TestCase):
             )
         )
 
+    def test_glm_contract_suite_reuses_unmodified_regression_tasks(self):
+        focused_tasks = runner.load_suite(
+            AGENT_IMAGE_DIR / "eval" / "suites" / "glm-5-contracts.yaml"
+        )
+        regression_tasks = {
+            task.id: task
+            for task in runner.load_suite(
+                AGENT_IMAGE_DIR / "eval" / "suites" / "regression.yaml"
+            )
+        }
+        expected_ids = [
+            "data-list-tables",
+            "directory-literal-address-no-lookup",
+            "failure-report-synthetic-missing-data",
+            "freshservice-update-ticket-priority",
+            "workspace-list-unread-mail",
+        ]
+
+        self.assertEqual([task.id for task in focused_tasks], expected_ids)
+        self.assertEqual({task.trials for task in focused_tasks}, {3})
+        self.assertEqual({task.suite for task in focused_tasks}, {"regression"})
+        for task in focused_tasks:
+            self.assertEqual(task, regression_tasks[task.id])
+
+    def test_glm_regression_skill_prompts_pin_exact_contracts(self):
+        skill_contracts = {
+            "psd-data": (
+                "node /opt/psd-skills/psd-data/run.js tables --detailed",
+                "set `detailed` to false",
+            ),
+            "psd-directory": (
+                "emit it exactly once",
+                "skill or any other tool",
+            ),
+            "psd-failure-report": (
+                "actually\ninvoke `report.js`",
+                'stdout returns `"logged": true`',
+            ),
+            "psd-freshservice": (
+                "Urgent `4`",
+                """--data '{"priority":4}'""",
+            ),
+            "psd-workspace": (
+                "`--params` and `--json` are not interchangeable",
+                "gmail users messages list --params",
+            ),
+        }
+
+        for skill, required_fragments in skill_contracts.items():
+            with self.subTest(skill=skill):
+                document = (
+                    AGENT_IMAGE_DIR / "skills" / skill / "SKILL.md"
+                ).read_text(encoding="utf-8")
+                for fragment in required_fragments:
+                    self.assertIn(fragment, document)
+
     def test_invalid_workspace_fails_closed(self):
         with self.subTest("validation happens after parsing"):
             with self.assertRaises(runner.EvalRunnerError):

--- a/infra/agent-image/test_eval_runner.py
+++ b/infra/agent-image/test_eval_runner.py
@@ -692,6 +692,7 @@ class SuiteLoadingTests(unittest.TestCase):
             "psd-directory": (
                 "emit it exactly once",
                 "skill or any other tool",
+                "For a compound request",
             ),
             "psd-failure-report": (
                 "actually\ninvoke `report.js`",
@@ -708,8 +709,10 @@ class SuiteLoadingTests(unittest.TestCase):
             "psd-rules": (
                 "**Fresh-interface gate:**",
                 "Never\n   construct a skill command from memory.",
-                "**Exact-output requests:**",
-                "copy the requested span from the current user message",
+                "**Standalone exact-output requests:**",
+                "entire reply to be one literal span",
+                "If the request\nalso asks for an explanation or another result",
+                "earlier message, attachment,\nor tool result",
             ),
         }
 


### PR DESCRIPTION
## Description

GLM-5 regressed five stable skill contracts in the first model comparison.
This change makes those contracts explicit in the affected skill instructions
and adds global safeguards for current-turn contract reads, exact
user-provided text, and returning transient read-only results before memory or
unrelated tool work.

The focused suite references the existing regression task YAML files, and its
test proves the resolved task objects are identical to the regression suite.
Deterministic graders were not weakened. Review also:

- narrowed the literal-only response rule without relaxing the global
  no-narration rule;
- made skill availability depend on a successful read in the current user
  turn; and
- preserved caller-specified Workspace filters and page sizes while retaining
  the canonical unread-mail defaults.

The review-corrected v6 candidate exposed one final trajectory failure: after a
correct Workspace broker call, one trial attempted memory work and ended with
an incomplete tool turn. The v7 contract fixes that ordering. The final
immutable candidate
`sha256:94d362aa12c604ea30aa3c80d70f274f6fb39c8b2063d976997d0788b2e23623`
passed all five tasks at 3/3:

- data table discovery: 3/3
- directory literal address: 3/3
- failure reporting: 3/3
- Freshservice priority update: 3/3
- workspace unread-mail query: 3/3

The transcript-free summary and full iteration record are committed. GLM-5
remains rejected and unpromoted because this focused follow-up does not satisfy
the complete regression, capability-improvement, and cost gates.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Infrastructure change (CDK/AWS)

## Testing

- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run test:ci`
- [x] 599 agent-image Python CI tests passed (one intentional skip)
- [x] All standalone agent-skill CI suites passed
- [x] `bun run openapi:check`
- [x] `bun run capabilities:check`
- [x] Eval coverage and committed-artifact validation passed
- [x] Bootstrap prompt budget passed at 33,213 / 80,000 characters
- [x] Candidate build boot probe and exact-answer canary passed
- [x] Focused GLM-5 evaluation passed 15/15 trials
- [x] `bun run build`
- [x] `cd infra && bun run build`

E2E was not run because this change has no UI or browser behavior. The local
pre-push hook used the repository-documented `SKIP_E2E=1` path because this
isolated worktree has no `AUTH_SECRET`.

The Unified Content PostgreSQL lifecycle job initially missed an unrelated
legacy-recovery claim assertion. A failed-job-only rerun on the same final SHA
passed all lifecycle smokes; no code change or test suppression was made.

## Checklist

- [x] No production `console.*`, client logger imports, unsafe type assertions, database, API, environment, or IAM changes
- [x] Tests pin the new prompt contracts and focused-suite integrity
- [x] Documentation and its index are updated
- [x] The branch targets `dev`
- [x] No runtime deployment or model promotion was performed

## Related Issues

Closes #1483

## Additional Notes

The current native transcript marks token-usage capture incomplete, so cache
and cost remain unknown. A future GLM-5 promotion attempt must use a fresh
immutable image and pass the full comparison gate.
