### PR TITLE
test(agent-skill): add NSPRA retrieval evaluation gate

### DIFF
--- a/docs/operations/psd-observances-annual-refresh.md
+++ b/docs/operations/psd-observances-annual-refresh.md
@@ -166,8 +166,27 @@ phrasing intact so skill discovery continues to work.
 
 Run the committed `psd-observances` retrieval evaluation against the real
 repository in the target environment, not mocks. The evaluation gate is
-tracked in [#1477](https://github.com/psd401/aistudio/issues/1477); if its
-runnable harness is not yet available, the refresh cannot pass this step.
+documented in the
+[live retrieval evaluation guide](../../infra/agent-image/skills/psd-observances/evals/retrieval-eval.md).
+Provide a short-lived key through `PSD_OBSERVANCES_EVAL_API_KEY`; never pass a
+key on the command line:
+
+```bash
+export PSD_OBSERVANCES_EVAL_API_KEY="<short-lived repository-read key>"
+
+bun run eval:skill:psd-observances-retrieval -- \
+  --environment dev \
+  --base-url https://dev.aistudio.psd401.ai \
+  --out /tmp/psd-observances-dev-retrieval-report.json
+
+unset PSD_OBSERVANCES_EVAL_API_KEY
+```
+
+Change both the environment label and base URL for production. The key needs
+only `repositories:list`, `repositories:read`, and `repositories:search`.
+Reports are transcript-free, but keep them in an environment-specific
+temporary path until their names/dates, citations, and aggregate figures have
+been reviewed.
 
 Verify expected answers against the authorized printed source, then record:
 

--- a/infra/agent-image/skills/psd-observances/evals/dev-2026-07-30-report.md
+++ b/infra/agent-image/skills/psd-observances/evals/dev-2026-07-30-report.md
@@ -1,0 +1,99 @@
+# Dev retrieval evaluation — 2026-07-30
+
+## Result
+
+The direct-PDF repository did not pass the retrieval gate:
+
+| Measure | Result | Gate |
+| --- | ---: | ---: |
+| Class A named-question accuracy | 10/12 (83.3%) | 90% |
+| Class B enumeration recall | 53/86 facts (61.6%) | 80% |
+| Citation correctness | 64/108 facts (59.3%) | Reported separately |
+
+**Recommendation: proceed with structured-markdown regeneration in #1478.**
+
+Class A's miss required investigation before applying the Class B decision.
+The investigation found the missing facts in the correct active indexed
+chunks, so this was not a wrong-repository, incomplete-ingest, or OCR failure.
+The live queries either ranked unrelated pages above the fact or returned the
+correct page without retaining the expected fact in the skill's bounded
+excerpt. Class B was independently below its 80% recall threshold.
+
+## Environment
+
+- Run: 2026-07-30T15:41:29Z through 2026-07-30T15:42:05Z
+- Environment: dev (`https://dev.aistudio.psd401.ai`)
+- Repository: `NSPRA Observances & School Calendar 2026-27` (id 166)
+- Repository item: id 496, status `embedded`, active version processing
+  `completed`
+- Active index generation: `995bc0e7-5063-4c33-8740-5b24be0965a4`
+- Canonical PDF artifact: 124 pages and 259 segments
+
+The live repository reports `visibility: public`. This conflicts with the
+staff-restricted, non-public operating requirement and needs an operational
+access-control correction independent of the retrieval recommendation.
+
+## Per-question measurements
+
+Class A counts a question as correct only when every expected fact was present.
+Citation counts are fact-level.
+
+| Class A question id | Facts returned | Correct citations |
+| --- | ---: | ---: |
+| `named-american-education-week-2026` | 1/1 | 1/1 |
+| `named-school-counseling-week-2027` | 0/1 | 0/1 |
+| `named-paraprofessionals-day-2026` | 1/1 | 1/1 |
+| `named-washington-school-holidays` | 11/11 | 7/11 |
+| `named-national-pta-conference-2026` | 1/1 | 1/1 |
+| `named-christmas-2029` | 0/1 | 0/1 |
+| `named-school-nurse-day-2026` | 1/1 | 1/1 |
+| `named-principals-month-2026` | 1/1 | 1/1 |
+| `named-purim-2026` | 1/1 | 1/1 |
+| `named-rosh-hashanah-2026` | 1/1 | 1/1 |
+| `named-teacher-appreciation-week-2027` | 1/1 | 0/1 |
+| `named-independence-day-2031` | 1/1 | 1/1 |
+
+| Class B question id | Facts returned | Recall | Correct citations |
+| --- | ---: | ---: | ---: |
+| `enumerate-november-2026` | 13/23 | 56.5% | 12/23 |
+| `enumerate-march-awareness-months-2027` | 3/8 | 37.5% | 3/8 |
+| `enumerate-june-conferences-2026` | 4/7 | 57.1% | 4/7 |
+| `enumerate-jewish-holidays-2026` | 3/11 | 27.3% | 3/11 |
+| `enumerate-april-first-2026` | 7/8 | 87.5% | 5/8 |
+| `enumerate-may-awareness-months-2026` | 5/5 | 100% | 5/5 |
+| `enumerate-major-holidays-2031` | 11/16 | 68.8% | 11/16 |
+| `enumerate-july-conferences-2026` | 7/8 | 87.5% | 6/8 |
+
+## Class A investigation
+
+- The counseling lookup returned pages 90, 93, and 96 instead of the
+  observance page. The active page-42 chunks contain both the full expected
+  name and date.
+- The Christmas lookup returned the correct six-year-summary page 59, but the
+  bounded skill output did not contain the 2029 fact. The active page-59
+  chunks contain the expected name, year, weekday, and date.
+
+Both checks queried the active index by repository, item, generation, and page
+and returned only presence booleans and counts; no source prose was retained.
+
+## OCR inspection
+
+The repository PDF extractor reported:
+
+```text
+needsOcrPages: [10, 58, 60, 86, 102, 124]
+```
+
+The active index has no chunks for pages 10, 102, or 124. Pages 58, 60, and 86
+each have one two-character chunk containing only the printed page number.
+None of the six pages introduced spurious OCR content.
+
+## Measurement hygiene
+
+- All 20 expected-answer sets were verified against the authorized source PDF.
+- The runner exercised the live MCP endpoint and the real
+  `psd-observances/run.js` command boundary.
+- The temporary API key had only repository list/read/search scopes.
+- Raw PDF text and retrieval excerpts remained outside Git; the committed
+  fixture and this report contain facts, page numbers, counts, and identifiers
+  only.

--- a/infra/agent-image/skills/psd-observances/evals/retrieval-cases.json
+++ b/infra/agent-image/skills/psd-observances/evals/retrieval-cases.json
@@ -1,0 +1,706 @@
+{
+  "version": 1,
+  "publication": "Resources for Planning the School Calendar, 2026-2027",
+  "questions": [
+    {
+      "id": "named-american-education-week-2026",
+      "class": "A",
+      "question": "When is American Education Week in 2026?",
+      "argv": ["lookup", "American Education Week 2026"],
+      "expected": [
+        {
+          "name": "American Education Week",
+          "date": "Nov. 16-20, 2026",
+          "pages": [38]
+        }
+      ]
+    },
+    {
+      "id": "named-school-counseling-week-2027",
+      "class": "A",
+      "question": "When is National School Counseling Week in 2027?",
+      "argv": ["lookup", "National School Counseling Week 2027"],
+      "expected": [
+        {
+          "name": "National School Counseling Week",
+          "date": "Feb. 1-5, 2027",
+          "pages": [42]
+        }
+      ]
+    },
+    {
+      "id": "named-paraprofessionals-day-2026",
+      "class": "A",
+      "question": "When is Paraprofessionals Appreciation Day in 2026?",
+      "argv": ["lookup", "Paraprofessionals Appreciation Day 2026"],
+      "expected": [
+        {
+          "name": "Paraprofessionals Appreciation Day",
+          "date": "April 1, 2026",
+          "pages": [20]
+        }
+      ]
+    },
+    {
+      "id": "named-washington-school-holidays",
+      "class": "A",
+      "question": "What are Washington's school holidays?",
+      "argv": ["state", "Washington", "--section", "school"],
+      "expected": [
+        {
+          "name": "New Year's Day",
+          "date": "January 1",
+          "pages": [83]
+        },
+        {
+          "name": "Martin Luther King Jr.",
+          "date": "third Monday of January",
+          "pages": [83]
+        },
+        {
+          "name": "Presidents' Day",
+          "date": "third Monday of February",
+          "pages": [83]
+        },
+        {
+          "name": "Memorial Day",
+          "date": "last Monday of May",
+          "pages": [83]
+        },
+        {
+          "name": "Juneteenth",
+          "date": "June 19",
+          "pages": [83]
+        },
+        {
+          "name": "Independence Day",
+          "date": "July 4",
+          "pages": [83]
+        },
+        {
+          "name": "Labor Day",
+          "date": "first Monday in September",
+          "pages": [83]
+        },
+        {
+          "name": "Veterans Day",
+          "date": "November 11",
+          "pages": [83]
+        },
+        {
+          "name": "Thanksgiving Day",
+          "date": "fourth Thursday in November",
+          "pages": [83]
+        },
+        {
+          "name": "Native American Heritage Day",
+          "date": "Friday after the fourth Thursday in November",
+          "pages": [83]
+        },
+        {
+          "name": "Christmas Day",
+          "date": "December 25",
+          "pages": [83]
+        }
+      ]
+    },
+    {
+      "id": "named-national-pta-conference-2026",
+      "class": "A",
+      "question": "When is the National PTA conference in 2026?",
+      "argv": ["conferences", "--year", "2026", "--org", "National PTA"],
+      "expected": [
+        {
+          "name": "National PTA",
+          "date": "June 18-21, 2026",
+          "pages": [90]
+        }
+      ]
+    },
+    {
+      "id": "named-christmas-2029",
+      "class": "A",
+      "question": "What day of the week is Christmas in 2029?",
+      "argv": ["holiday-years", "Christmas 2029"],
+      "expected": [
+        {
+          "name": "Christmas",
+          "date": "Tuesday, Dec. 25, 2029",
+          "pages": [59]
+        }
+      ]
+    },
+    {
+      "id": "named-school-nurse-day-2026",
+      "class": "A",
+      "question": "When is National School Nurse Day in 2026?",
+      "argv": ["lookup", "National School Nurse Day 2026"],
+      "expected": [
+        {
+          "name": "National School Nurse Day",
+          "date": "May 6, 2026",
+          "pages": [25]
+        }
+      ]
+    },
+    {
+      "id": "named-principals-month-2026",
+      "class": "A",
+      "question": "When is National Principals Month in 2026?",
+      "argv": ["lookup", "National Principals Month 2026"],
+      "expected": [
+        {
+          "name": "National Principals Month",
+          "date": "Oct. 1-31, 2026",
+          "pages": [34]
+        }
+      ]
+    },
+    {
+      "id": "named-purim-2026",
+      "class": "A",
+      "question": "When is Purim in 2026?",
+      "argv": ["lookup", "Purim 2026"],
+      "expected": [
+        {
+          "name": "Purim",
+          "date": "March 2-3, 2026",
+          "pages": [16]
+        }
+      ]
+    },
+    {
+      "id": "named-rosh-hashanah-2026",
+      "class": "A",
+      "question": "When is Rosh Hashanah in 2026?",
+      "argv": ["lookup", "Rosh Hashanah 2026"],
+      "expected": [
+        {
+          "name": "Rosh Hashanah",
+          "date": "Sept. 11-13, 2026",
+          "pages": [32]
+        }
+      ]
+    },
+    {
+      "id": "named-teacher-appreciation-week-2027",
+      "class": "A",
+      "question": "When is National Teacher Appreciation Week in 2027?",
+      "argv": ["lookup", "National Teacher Appreciation Week 2027"],
+      "expected": [
+        {
+          "name": "National Teacher Appreciation Week",
+          "date": "May 3-7, 2027",
+          "pages": [52]
+        }
+      ]
+    },
+    {
+      "id": "named-independence-day-2031",
+      "class": "A",
+      "question": "What day of the week is Independence Day in 2031?",
+      "argv": ["holiday-years", "Independence Day 2031"],
+      "expected": [
+        {
+          "name": "Independence Day",
+          "date": "Friday, July 4, 2031",
+          "pages": [59]
+        }
+      ]
+    },
+    {
+      "id": "enumerate-november-2026",
+      "class": "B",
+      "question": "What observances are in November 2026?",
+      "argv": ["month", "2026-11"],
+      "expected": [
+        {
+          "name": "National Native American Heritage Month",
+          "date": "Nov. 1-30, 2026",
+          "pages": [37]
+        },
+        {
+          "name": "All Saints Day",
+          "date": "Nov. 1, 2026",
+          "pages": [37]
+        },
+        {
+          "name": "Standard Time",
+          "date": "Nov. 1, 2026",
+          "pages": [37]
+        },
+        {
+          "name": "Election Day",
+          "date": "Nov. 3, 2026",
+          "pages": [37]
+        },
+        {
+          "name": "Marie Curie's Birthday",
+          "date": "Nov. 7, 2026",
+          "pages": [37]
+        },
+        {
+          "name": "Diwali",
+          "date": "Nov. 8, 2026",
+          "pages": [37]
+        },
+        {
+          "name": "Birth of the Bab",
+          "date": "Nov. 10, 2026",
+          "pages": [37]
+        },
+        {
+          "name": "Veterans Day",
+          "date": "Nov. 11, 2026",
+          "pages": [37]
+        },
+        {
+          "name": "Elizabeth Cady Stanton's Birthday",
+          "date": "Nov. 12, 2026",
+          "pages": [37]
+        },
+        {
+          "name": "World Kindness Day",
+          "date": "Nov. 13, 2026",
+          "pages": [38]
+        },
+        {
+          "name": "World Diabetes Day",
+          "date": "Nov. 14, 2026",
+          "pages": [38]
+        },
+        {
+          "name": "America Recycles Day",
+          "date": "Nov. 15, 2026",
+          "pages": [38]
+        },
+        {
+          "name": "American Education Week",
+          "date": "Nov. 16-20, 2026",
+          "pages": [38]
+        },
+        {
+          "name": "Geography Awareness Week",
+          "date": "Nov. 16-20, 2026",
+          "pages": [38]
+        },
+        {
+          "name": "Education Support Professionals Day",
+          "date": "Nov. 18, 2026",
+          "pages": [38]
+        },
+        {
+          "name": "Gettysburg Address Anniversary",
+          "date": "Nov. 19, 2026",
+          "pages": [38]
+        },
+        {
+          "name": "National Parental Involvement Day",
+          "date": "Nov. 19, 2026",
+          "pages": [38]
+        },
+        {
+          "name": "Anniversary of the Mexican Revolution",
+          "date": "Nov. 20, 2026",
+          "pages": [38]
+        },
+        {
+          "name": "Substitute Educators Day",
+          "date": "Nov. 20, 2026",
+          "pages": [39]
+        },
+        {
+          "name": "National Family Week",
+          "date": "Nov. 22-28, 2026",
+          "pages": [39]
+        },
+        {
+          "name": "Guru Nanak Dev Sahib's Birthday Festival",
+          "date": "Nov. 24, 2026",
+          "pages": [39]
+        },
+        {
+          "name": "Thanksgiving Day",
+          "date": "Nov. 26, 2026",
+          "pages": [39]
+        },
+        {
+          "name": "Mark Twain's Birthday",
+          "date": "Nov. 30, 2026",
+          "pages": [39]
+        }
+      ]
+    },
+    {
+      "id": "enumerate-march-awareness-months-2027",
+      "class": "B",
+      "question": "List every awareness month in March 2027.",
+      "argv": ["month", "2027-03"],
+      "expected": [
+        {
+          "name": "American Red Cross Month",
+          "date": "March 1-31, 2027",
+          "pages": [44]
+        },
+        {
+          "name": "Irish American Heritage Month",
+          "date": "March 1-31, 2027",
+          "pages": [44]
+        },
+        {
+          "name": "Middle Level Education Month",
+          "date": "March 1-31, 2027",
+          "pages": [44]
+        },
+        {
+          "name": "Music in Our Schools Month",
+          "date": "March 1-31, 2027",
+          "pages": [45]
+        },
+        {
+          "name": "National Nutrition Month",
+          "date": "March 1-31, 2027",
+          "pages": [45]
+        },
+        {
+          "name": "Social Work Month",
+          "date": "March 1-31, 2027",
+          "pages": [45]
+        },
+        {
+          "name": "Women's History Month",
+          "date": "March 1-31, 2027",
+          "pages": [45]
+        },
+        {
+          "name": "Youth Art Month",
+          "date": "March 1-31, 2027",
+          "pages": [45]
+        }
+      ]
+    },
+    {
+      "id": "enumerate-june-conferences-2026",
+      "class": "B",
+      "question": "Which education conferences happen in June 2026?",
+      "argv": ["search", "education conferences June 2026"],
+      "expected": [
+        {
+          "name": "American Association of Family and Consumer Sciences",
+          "date": "June 18-21, 2026",
+          "pages": [90]
+        },
+        {
+          "name": "National PTA",
+          "date": "June 18-21, 2026",
+          "pages": [90]
+        },
+        {
+          "name": "Council of Chief State School Officers",
+          "date": "June 22-24, 2026",
+          "pages": [90]
+        },
+        {
+          "name": "American Library Association",
+          "date": "June 25-29, 2026",
+          "pages": [90]
+        },
+        {
+          "name": "ASCD",
+          "date": "June 28-July 1, 2026",
+          "pages": [90]
+        },
+        {
+          "name": "International Society for Technology in Education",
+          "date": "June 28-July 1, 2026",
+          "pages": [90]
+        },
+        {
+          "name": "National Association of School Nurses",
+          "date": "June 29-July 2, 2026",
+          "pages": [90]
+        }
+      ]
+    },
+    {
+      "id": "enumerate-jewish-holidays-2026",
+      "class": "B",
+      "question": "What are all the Jewish holidays listed for 2026?",
+      "argv": ["search", "Jewish holidays 2026"],
+      "expected": [
+        {
+          "name": "Purim",
+          "date": "March 2-3, 2026",
+          "pages": [16]
+        },
+        {
+          "name": "Passover First Days",
+          "date": "April 1-2, 2026",
+          "pages": [19]
+        },
+        {
+          "name": "Passover Concluding Days",
+          "date": "April 8-9, 2026",
+          "pages": [20]
+        },
+        {
+          "name": "Holocaust Remembrance Day Yom Hashoah",
+          "date": "April 13-14, 2026",
+          "pages": [21]
+        },
+        {
+          "name": "Shavuot Festival of Weeks",
+          "date": "May 21-23, 2026",
+          "pages": [26]
+        },
+        {
+          "name": "Rosh Hashanah",
+          "date": "Sept. 11-13, 2026",
+          "pages": [32]
+        },
+        {
+          "name": "Yom Kippur Day of Atonement",
+          "date": "Sept. 20-21, 2026",
+          "pages": [32]
+        },
+        {
+          "name": "Sukkot Feast of Tabernacles",
+          "date": "Sept. 25-Oct. 2, 2026",
+          "pages": [33]
+        },
+        {
+          "name": "Shemini Atzeret",
+          "date": "Oct. 2-3, 2026",
+          "pages": [34]
+        },
+        {
+          "name": "Simchat Torah",
+          "date": "Oct. 3-4, 2026",
+          "pages": [34]
+        },
+        {
+          "name": "Hanukkah Festival of Lights",
+          "date": "Dec. 4-12, 2026",
+          "pages": [39]
+        }
+      ]
+    },
+    {
+      "id": "enumerate-april-first-2026",
+      "class": "B",
+      "question": "What observances fall on April 1, 2026?",
+      "argv": ["on", "--date", "2026-04-01"],
+      "expected": [
+        {
+          "name": "APR Month",
+          "date": "April 1-30, 2026",
+          "pages": [19]
+        },
+        {
+          "name": "National Occupational Therapy Month",
+          "date": "April 1-30, 2026",
+          "pages": [19]
+        },
+        {
+          "name": "National Poetry Month",
+          "date": "April 1-30, 2026",
+          "pages": [19]
+        },
+        {
+          "name": "School Library Month",
+          "date": "April 1-30, 2026",
+          "pages": [19]
+        },
+        {
+          "name": "World Autism Month",
+          "date": "April 1-30, 2026",
+          "pages": [19]
+        },
+        {
+          "name": "Passover First Days",
+          "date": "April 1-2, 2026",
+          "pages": [19]
+        },
+        {
+          "name": "April Fools' Day",
+          "date": "April 1, 2026",
+          "pages": [19]
+        },
+        {
+          "name": "Paraprofessionals Appreciation Day",
+          "date": "April 1, 2026",
+          "pages": [20]
+        }
+      ]
+    },
+    {
+      "id": "enumerate-may-awareness-months-2026",
+      "class": "B",
+      "question": "List every awareness month in May 2026.",
+      "argv": ["month", "2026-05"],
+      "expected": [
+        {
+          "name": "Asian Pacific American Heritage Month",
+          "date": "May 1-31, 2026",
+          "pages": [23]
+        },
+        {
+          "name": "Jewish American Heritage Month",
+          "date": "May 1-31, 2026",
+          "pages": [23]
+        },
+        {
+          "name": "National Physical Fitness and Sports Month",
+          "date": "May 1-31, 2026",
+          "pages": [23]
+        },
+        {
+          "name": "National Speech-Language-Hearing Month",
+          "date": "May 1-31, 2026",
+          "pages": [23]
+        },
+        {
+          "name": "Preservation Month",
+          "date": "May 1-31, 2026",
+          "pages": [23]
+        }
+      ]
+    },
+    {
+      "id": "enumerate-major-holidays-2031",
+      "class": "B",
+      "question": "List the major civil and religious holidays in 2031.",
+      "argv": ["holiday-years", "major civil religious holidays"],
+      "expected": [
+        {
+          "name": "New Year's Day",
+          "date": "Wednesday, Jan. 1, 2031",
+          "pages": [59]
+        },
+        {
+          "name": "Martin Luther King Jr.'s Birthday",
+          "date": "Monday, Jan. 20, 2031",
+          "pages": [59]
+        },
+        {
+          "name": "Presidents' Day",
+          "date": "Monday, Feb. 17, 2031",
+          "pages": [59]
+        },
+        {
+          "name": "Passover",
+          "date": "Monday, April 7, 2031",
+          "pages": [59]
+        },
+        {
+          "name": "Easter",
+          "date": "Sunday, April 13, 2031",
+          "pages": [59]
+        },
+        {
+          "name": "Memorial Day",
+          "date": "Monday, May 26, 2031",
+          "pages": [59]
+        },
+        {
+          "name": "Juneteenth National Independence Day",
+          "date": "Thursday, June 19, 2031",
+          "pages": [59]
+        },
+        {
+          "name": "Independence Day",
+          "date": "Friday, July 4, 2031",
+          "pages": [59]
+        },
+        {
+          "name": "Labor Day",
+          "date": "Monday, Sept. 1, 2031",
+          "pages": [59]
+        },
+        {
+          "name": "Rosh Hashanah",
+          "date": "Wednesday, Sept. 17, 2031",
+          "pages": [59]
+        },
+        {
+          "name": "Yom Kippur",
+          "date": "Friday, Sept. 26, 2031",
+          "pages": [59]
+        },
+        {
+          "name": "Columbus Discoverers Indigenous People's Day",
+          "date": "Monday, Oct. 13, 2031",
+          "pages": [59]
+        },
+        {
+          "name": "Election Day",
+          "date": "Tuesday, Nov. 4, 2031",
+          "pages": [59]
+        },
+        {
+          "name": "Veterans Day",
+          "date": "Tuesday, Nov. 11, 2031",
+          "pages": [59]
+        },
+        {
+          "name": "Thanksgiving",
+          "date": "Thursday, Nov. 27, 2031",
+          "pages": [59]
+        },
+        {
+          "name": "Christmas",
+          "date": "Thursday, Dec. 25, 2031",
+          "pages": [59]
+        }
+      ]
+    },
+    {
+      "id": "enumerate-july-conferences-2026",
+      "class": "B",
+      "question": "Which education conferences happen in July 2026?",
+      "argv": ["search", "education conferences July 2026"],
+      "expected": [
+        {
+          "name": "National Education Association",
+          "date": "July 3-7, 2026",
+          "pages": [90]
+        },
+        {
+          "name": "American School Counselor Association",
+          "date": "July 11-14, 2026",
+          "pages": [90]
+        },
+        {
+          "name": "National Association of Educational Office Professionals",
+          "date": "July 12-15, 2026",
+          "pages": [91]
+        },
+        {
+          "name": "School Nutrition Association",
+          "date": "July 12-14, 2026",
+          "pages": [91]
+        },
+        {
+          "name": "National Association of Elementary School Principals",
+          "date": "July 13-15, 2026",
+          "pages": [91]
+        },
+        {
+          "name": "American Federation of Teachers",
+          "date": "July 16-19, 2026",
+          "pages": [91]
+        },
+        {
+          "name": "National School Public Relations Association",
+          "date": "July 19-22, 2026",
+          "pages": [91]
+        },
+        {
+          "name": "Society for Nutrition Education and Behavior",
+          "date": "July 29-August 1, 2026",
+          "pages": [91]
+        }
+      ]
+    }
+  ]
+}

--- a/infra/agent-image/skills/psd-observances/evals/retrieval-eval.md
+++ b/infra/agent-image/skills/psd-observances/evals/retrieval-eval.md
@@ -59,7 +59,9 @@ bun run test:skill:psd-observances
   direct PDF is sufficient.
 
 Extra retrieved facts do not reduce a score: recall, not precision, is the
-enumeration decision metric.
+enumeration decision metric. Fact matching requires every normalized name and
+date token to appear in one returned excerpt; it is intentionally an unordered
+token match rather than a phrase match.
 
 The first dev measurement and its post-investigation recommendation are in
 [`dev-2026-07-30-report.md`](dev-2026-07-30-report.md).

--- a/infra/agent-image/skills/psd-observances/evals/retrieval-eval.md
+++ b/infra/agent-image/skills/psd-observances/evals/retrieval-eval.md
@@ -1,0 +1,77 @@
+# PSD Observances Live Retrieval Evaluation
+
+This gate measures the direct-PDF repository, not a mock. The committed
+[`retrieval-cases.json`](retrieval-cases.json) fixture contains 20
+source-verified questions:
+
+- 12 Class A named lookups across observances, Washington school holidays,
+  conferences, and the six-year summary;
+- 8 Class B enumeration questions; and
+- expected answers represented only as names, dates, and printed-PDF page
+  numbers.
+
+No NSPRA source prose belongs in the fixture, report, test output, or Git
+history.
+
+## Run against a named environment
+
+Use a short-lived API key with only `repositories:list`, `repositories:read`,
+and `repositories:search`. Supply it through an environment variable so it
+does not appear in the process list:
+
+```bash
+export PSD_OBSERVANCES_EVAL_API_KEY="<short-lived key>"
+
+bun run eval:skill:psd-observances-retrieval -- \
+  --environment dev \
+  --base-url https://dev.aistudio.psd401.ai \
+  --out /tmp/issue-1477-dev-retrieval-report.json
+
+unset PSD_OBSERVANCES_EVAL_API_KEY
+```
+
+The runner calls the live MCP endpoint but executes every question through
+`psd-observances/run.js`, including runtime NSPRA repository resolution,
+command-specific query shaping, result caps, excerpting, and citation shaping.
+Raw retrieval excerpts remain in memory and are discarded after scoring.
+Progress and saved reports contain only question ids, expected fact
+names/dates, page numbers, counts, timing, and aggregate scores.
+
+Run the skill unit and fixture-contract tests separately:
+
+```bash
+bun run test:skill:psd-observances
+```
+
+## Scoring and decision
+
+- Class A accuracy is the fraction of named questions for which every expected
+  fact was returned.
+- Class B recall is the number of expected enumeration facts returned divided
+  by the total expected facts.
+- Citation correctness is scored separately for every expected fact against
+  its printed-PDF page.
+- Class A accuracy below 90% requires ingest/retrieval investigation before a
+  chunking decision.
+- Otherwise, Class B recall below 80% recommends structured-markdown
+  regeneration.
+- Class A accuracy at least 90% and Class B recall at least 80% means the
+  direct PDF is sufficient.
+
+Extra retrieved facts do not reduce a score: recall, not precision, is the
+enumeration decision metric.
+
+The first dev measurement and its post-investigation recommendation are in
+[`dev-2026-07-30-report.md`](dev-2026-07-30-report.md).
+
+## OCR-page check
+
+The live retrieval run must be paired with a source-PDF extraction using
+`lib/repositories/content-platform/pdf-processing.ts`. Record
+`needsOcrPages`, then inspect the active repository chunks for those pages
+using counts or hashes rather than copying source text. Report whether OCR
+introduced any spurious content.
+
+Keep the source PDF and any extraction/transcript artifacts in an
+issue-specific temporary directory outside the repository, and remove them
+after the evaluation.

--- a/infra/agent-image/skills/psd-observances/retrieval-eval.js
+++ b/infra/agent-image/skills/psd-observances/retrieval-eval.js
@@ -1,0 +1,560 @@
+#!/usr/bin/env node
+/**
+ * Live retrieval-quality gate for the NSPRA observances repository.
+ *
+ * The runner exercises the real psd-observances command boundary while keeping
+ * raw repository excerpts in memory. Its persisted output contains only
+ * question ids, expected fact names/dates, page numbers, and aggregate scores.
+ */
+
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const crypto = require('node:crypto');
+const { main: runSkill } = require('./run');
+const { parseMcpPayload } = require('./common');
+
+const DEFAULT_FIXTURE = path.join(
+  __dirname,
+  'evals',
+  'retrieval-cases.json',
+);
+const DEFAULT_API_KEY_ENV = 'PSD_OBSERVANCES_EVAL_API_KEY';
+const CLASS_A_THRESHOLD = 0.9;
+const CLASS_B_THRESHOLD = 0.8;
+const MCP_PROTOCOL_VERSION = '2024-11-05';
+const OPTION_NAMES = new Set([
+  'environment',
+  'base-url',
+  'fixture',
+  'api-key-env',
+  'out',
+]);
+const STOP_WORDS = new Set([
+  'a',
+  'an',
+  'and',
+  'at',
+  'in',
+  'of',
+  'on',
+  'the',
+]);
+
+const USAGE = `psd-observances live retrieval evaluation
+
+Usage:
+  node retrieval-eval.js \\
+    --environment <name> \\
+    --base-url <https://environment.example> \\
+    [--fixture <path>] \\
+    [--api-key-env <environment-variable>] \\
+    [--out <sanitized-report.json>]
+
+The API key is read only from an environment variable and is never accepted on
+the command line or written to the report. The key needs repositories:list,
+repositories:read, and repositories:search.`;
+
+function fail(message) {
+  throw new Error(message);
+}
+
+function parseOptionTokens(argv) {
+  const options = Object.create(null);
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    if (token === '--help' || token === '-h') {
+      return { help: true, options };
+    }
+    if (!token.startsWith('--')) fail(`Unexpected argument: ${token}`);
+    if (token.includes('=')) {
+      fail(`Use "${token.split('=')[0]} <value>" instead of equals syntax.`);
+    }
+    const key = token.slice(2);
+    if (!OPTION_NAMES.has(key)) fail(`Unknown flag: --${key}`);
+    const value = argv[index + 1];
+    if (!value || value.startsWith('--')) fail(`--${key} requires a value`);
+    options[key] = value;
+    index += 1;
+  }
+  return { help: false, options };
+}
+
+function parseBaseUrl(value) {
+  if (!value) fail('--base-url is required');
+  let parsedBaseUrl;
+  try {
+    parsedBaseUrl = new URL(value);
+  } catch {
+    fail('--base-url must be a valid URL');
+  }
+  const localHost =
+    parsedBaseUrl.hostname === 'localhost' ||
+    parsedBaseUrl.hostname === '127.0.0.1';
+  if (parsedBaseUrl.protocol !== 'https:' && !localHost) {
+    fail('--base-url must use HTTPS unless it targets localhost');
+  }
+  return parsedBaseUrl.origin;
+}
+
+function parseArgs(argv) {
+  const parsed = parseOptionTokens(argv);
+  if (parsed.help) return { help: true };
+  const { options } = parsed;
+  const environment = options.environment?.trim();
+  if (!environment) fail('--environment is required');
+
+  return {
+    help: false,
+    environment,
+    baseUrl: parseBaseUrl(options['base-url']?.trim()),
+    fixture: path.resolve(options.fixture || DEFAULT_FIXTURE),
+    apiKeyEnv: options['api-key-env'] || DEFAULT_API_KEY_ENV,
+    out: options.out ? path.resolve(options.out) : undefined,
+  };
+}
+
+function isPositiveInteger(value) {
+  return Number.isSafeInteger(value) && value > 0;
+}
+
+function validateFact(questionId, fact) {
+  if (
+    !fact ||
+    typeof fact.name !== 'string' ||
+    typeof fact.date !== 'string' ||
+    !Array.isArray(fact.pages) ||
+    fact.pages.length === 0 ||
+    fact.pages.some((page) => !isPositiveInteger(page))
+  ) {
+    fail(`Question ${questionId} has an invalid expected fact`);
+  }
+}
+
+function validateQuestion(question) {
+  if (
+    !question ||
+    typeof question.id !== 'string' ||
+    !['A', 'B'].includes(question.class) ||
+    typeof question.question !== 'string' ||
+    !Array.isArray(question.argv) ||
+    question.argv.some((value) => typeof value !== 'string') ||
+    !Array.isArray(question.expected) ||
+    question.expected.length === 0
+  ) {
+    fail('Every retrieval question needs id, class, question, argv, and facts');
+  }
+  for (const fact of question.expected) {
+    validateFact(question.id, fact);
+  }
+}
+
+function loadFixture(fixturePath) {
+  // The operator-selected local fixture path is the purpose of --fixture.
+  // eslint-disable-next-line security/detect-non-literal-fs-filename
+  const fixture = JSON.parse(fs.readFileSync(fixturePath, 'utf8'));
+  if (
+    !fixture ||
+    fixture.version !== 1 ||
+    typeof fixture.publication !== 'string' ||
+    !Array.isArray(fixture.questions)
+  ) {
+    fail('Retrieval fixture has an unsupported shape');
+  }
+  const ids = new Set();
+  for (const question of fixture.questions) {
+    validateQuestion(question);
+    if (ids.has(question.id)) fail(`Duplicate question id: ${question.id}`);
+    ids.add(question.id);
+  }
+  if (
+    !fixture.questions.some((question) => question.class === 'A') ||
+    !fixture.questions.some((question) => question.class === 'B')
+  ) {
+    fail('Retrieval fixture needs at least one Class A and Class B question');
+  }
+  return fixture;
+}
+
+function normalizeText(value) {
+  return String(value)
+    .normalize('NFKD')
+    .replace(/\p{Diacritic}/gu, '')
+    .toLocaleLowerCase()
+    .replace(/\b(january|jan)\b/g, 'jan')
+    .replace(/\b(february|feb)\b/g, 'feb')
+    .replace(/\b(march|mar)\b/g, 'mar')
+    .replace(/\b(april|apr)\b/g, 'apr')
+    .replace(/\b(june|jun)\b/g, 'jun')
+    .replace(/\b(july|jul)\b/g, 'jul')
+    .replace(/\b(august|aug)\b/g, 'aug')
+    .replace(/\b(september|sept|sep)\b/g, 'sep')
+    .replace(/\b(october|oct)\b/g, 'oct')
+    .replace(/\b(november|nov)\b/g, 'nov')
+    .replace(/\b(december|dec)\b/g, 'dec')
+    .replace(/\bfollowing\b/g, 'after')
+    .replace(/\bimmediately\b/g, ' ')
+    .replace(/[^a-z0-9]+/g, ' ')
+    .trim();
+}
+
+function factTokens(fact) {
+  return normalizeText(`${fact.name} ${fact.date}`)
+    .split(/\s+/)
+    .filter(Boolean)
+    .filter((token) => !STOP_WORDS.has(token));
+}
+
+function resultTokens(result) {
+  return new Set(
+    normalizeText(result.excerpt)
+      .split(/\s+/)
+      .filter(Boolean),
+  );
+}
+
+function citationPages(result) {
+  const page = Number(result?.citation?.page);
+  const pageEnd = Number(result?.citation?.pageEnd);
+  if (!isPositiveInteger(page)) return [];
+  const end = isPositiveInteger(pageEnd) && pageEnd >= page ? pageEnd : page;
+  return Array.from({ length: end - page + 1 }, (_, index) => page + index);
+}
+
+function scoreFact(fact, preparedResults) {
+  const required = factTokens(fact);
+  const matches = preparedResults.filter(({ tokens }) =>
+    required.every((token) => tokens.has(token)),
+  );
+  const correctlyCited = matches.find(({ pages }) =>
+    pages.some((page) => fact.pages.includes(page)),
+  );
+  const selected = correctlyCited || matches[0];
+  return {
+    name: fact.name,
+    date: fact.date,
+    expectedPages: fact.pages,
+    matched: Boolean(selected),
+    citationCorrect: Boolean(correctlyCited),
+    returnedPages: selected?.pages ?? [],
+  };
+}
+
+function scoreQuestion(question, skillResult, durationMs) {
+  const preparedResults = skillResult.results.map((result) => ({
+    tokens: resultTokens(result),
+    pages: citationPages(result),
+  }));
+  const returnedPages = [
+    ...new Set(preparedResults.flatMap((result) => result.pages)),
+  ].sort((left, right) => left - right);
+  const facts = question.expected.map((fact) =>
+    scoreFact(fact, preparedResults),
+  );
+  const matchedFacts = facts.filter((fact) => fact.matched).length;
+  const correctlyCitedFacts = facts.filter(
+    (fact) => fact.citationCorrect,
+  ).length;
+  return {
+    id: question.id,
+    class: question.class,
+    question: question.question,
+    expectedFactCount: facts.length,
+    matchedFactCount: matchedFacts,
+    correctlyCitedFactCount: correctlyCitedFacts,
+    recall: matchedFacts / facts.length,
+    citationCorrectness: correctlyCitedFacts / facts.length,
+    correct: matchedFacts === facts.length,
+    returnedResultCount: skillResult.results.length,
+    returnedPages,
+    durationMs,
+    facts,
+  };
+}
+
+async function readJsonResponse(response) {
+  const text = await response.text();
+  if (!text) return { payload: null, rawText: '' };
+  try {
+    return { payload: JSON.parse(text), rawText: '' };
+  } catch {
+    return { payload: null, rawText: text.slice(0, 512) };
+  }
+}
+
+function createLiveMcpClient(baseUrl, apiKey) {
+  const endpoint = new URL('/api/mcp', baseUrl);
+  async function call(method, params) {
+    const response = await fetch(endpoint, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        'Content-Type': 'application/json',
+        'mcp-protocol-version': MCP_PROTOCOL_VERSION,
+      },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: crypto.randomUUID(),
+        method,
+        params,
+      }),
+      redirect: 'error',
+      signal: AbortSignal.timeout(180_000),
+    });
+    const parsed = await readJsonResponse(response);
+    return {
+      httpStatus: response.status,
+      payload: parsed.payload,
+      rawText: parsed.rawText,
+    };
+  }
+
+  return {
+    callTool: async (name, args) => {
+      const response = await call('tools/call', { name, arguments: args });
+      if (response.httpStatus < 200 || response.httpStatus >= 300) {
+        fail(`MCP ${name} failed with HTTP ${response.httpStatus}`);
+      }
+      return parseMcpPayload(response.payload, name);
+    },
+    requestAgentBroker: async (route, body) => {
+      if (route !== '/api/agent/aistudio') {
+        fail(`Unexpected broker route: ${route}`);
+      }
+      return call(body.method, body.params);
+    },
+  };
+}
+
+function selectRepository(payload) {
+  const matches = (payload?.repositories ?? [])
+    .filter(
+      (repository) =>
+        isPositiveInteger(repository?.id) &&
+        typeof repository.name === 'string' &&
+        /nspra/i.test(repository.name),
+    )
+    .sort((left, right) => {
+      const leftPreferred = /2026/i.test(left.name) ? 0 : 1;
+      const rightPreferred = /2026/i.test(right.name) ? 0 : 1;
+      return leftPreferred - rightPreferred || left.id - right.id;
+    });
+  if (matches.length === 0) fail('No accessible NSPRA repository was found');
+  const selected = matches[0];
+  return {
+    id: selected.id,
+    name: selected.name,
+    visibility: selected.visibility,
+    itemCount: selected.itemCount,
+    activeIndexGenerationId: selected.activeIndexGenerationId,
+    lastUpdated: selected.lastUpdated,
+  };
+}
+
+async function invokeQuestion(question, requestAgentBroker) {
+  let stdout = '';
+  let stderr = '';
+  const startedAt = Date.now();
+  const exitCode = await runSkill(
+    [...question.argv, '--limit', '50', '--full', '--json'],
+    { requestAgentBroker },
+    {
+      stdout: (value) => {
+        stdout += value;
+      },
+      stderr: (value) => {
+        stderr += value;
+      },
+    },
+  );
+  const durationMs = Date.now() - startedAt;
+  let result;
+  try {
+    result = JSON.parse(stdout);
+  } catch {
+    fail(`Question ${question.id} returned non-JSON output`);
+  }
+  if (exitCode !== 0 || result.status !== 'ok') {
+    fail(
+      `Question ${question.id} failed: ${
+        result.message || stderr.trim() || `exit ${exitCode}`
+      }`,
+    );
+  }
+  return { result, durationMs };
+}
+
+function sum(cases, field) {
+  return cases.reduce((total, result) => total + result[field], 0);
+}
+
+function aggregate(cases) {
+  const classA = cases.filter((result) => result.class === 'A');
+  const classB = cases.filter((result) => result.class === 'B');
+  const classACorrect = classA.filter((result) => result.correct).length;
+  const classBExpected = sum(classB, 'expectedFactCount');
+  const classBMatched = sum(classB, 'matchedFactCount');
+  const allExpected = sum(cases, 'expectedFactCount');
+  const allCited = sum(cases, 'correctlyCitedFactCount');
+  const classAAccuracy = classACorrect / classA.length;
+  const classBRecall = classBMatched / classBExpected;
+  const citationCorrectness = allCited / allExpected;
+  let decision;
+  if (classAAccuracy < CLASS_A_THRESHOLD) {
+    decision = {
+      outcome: 'investigate_named_retrieval',
+      markdownRegenerationNeeded: null,
+      reason:
+        'Class A is below 90%; investigate ingest or retrieval before deciding on chunk regeneration.',
+    };
+  } else if (classBRecall < CLASS_B_THRESHOLD) {
+    decision = {
+      outcome: 'structured_markdown_needed',
+      markdownRegenerationNeeded: true,
+      reason:
+        'Class A passed, but Class B recall is below 80%; proceed with structured-markdown regeneration.',
+    };
+  } else {
+    decision = {
+      outcome: 'direct_pdf_sufficient',
+      markdownRegenerationNeeded: false,
+      reason:
+        'Class A accuracy is at least 90% and Class B recall is at least 80%.',
+    };
+  }
+  return {
+    classA: {
+      questionCount: classA.length,
+      correctQuestionCount: classACorrect,
+      accuracy: classAAccuracy,
+      threshold: CLASS_A_THRESHOLD,
+      passed: classAAccuracy >= CLASS_A_THRESHOLD,
+    },
+    classB: {
+      questionCount: classB.length,
+      expectedFactCount: classBExpected,
+      matchedFactCount: classBMatched,
+      recall: classBRecall,
+      threshold: CLASS_B_THRESHOLD,
+      passed: classBRecall >= CLASS_B_THRESHOLD,
+    },
+    citations: {
+      expectedFactCount: allExpected,
+      correctlyCitedFactCount: allCited,
+      correctness: citationCorrectness,
+    },
+    decision,
+  };
+}
+
+async function runEvaluation(options, io = process.stderr) {
+  const fixture = loadFixture(options.fixture);
+  const apiKey = process.env[options.apiKeyEnv];
+  if (!apiKey) {
+    fail(`Environment variable ${options.apiKeyEnv} is required`);
+  }
+  if (!/^sk-[0-9a-f]{64}$/.test(apiKey)) {
+    fail(`Environment variable ${options.apiKeyEnv} is not an API key`);
+  }
+  const client = createLiveMcpClient(options.baseUrl, apiKey);
+  const startedAt = new Date();
+  const repository = selectRepository(
+    await client.callTool('repositories_list', { query: 'NSPRA', limit: 50 }),
+  );
+  const cases = [];
+  for (const question of fixture.questions) {
+    const invocation = await invokeQuestion(
+      question,
+      client.requestAgentBroker,
+    );
+    if (invocation.result.repository.id !== repository.id) {
+      fail(`Question ${question.id} selected a different repository`);
+    }
+    const scored = scoreQuestion(
+      question,
+      invocation.result,
+      invocation.durationMs,
+    );
+    cases.push(scored);
+    io.write(
+      `${question.id}: ${scored.matchedFactCount}/${scored.expectedFactCount} facts, ` +
+        `${scored.correctlyCitedFactCount}/${scored.expectedFactCount} cited\n`,
+    );
+  }
+  const completedAt = new Date();
+  return {
+    schemaVersion: 1,
+    publication: fixture.publication,
+    fixtureVersion: fixture.version,
+    environment: options.environment,
+    baseUrl: options.baseUrl,
+    startedAt: startedAt.toISOString(),
+    completedAt: completedAt.toISOString(),
+    repository,
+    ...aggregate(cases),
+    cases,
+  };
+}
+
+async function main(argv = process.argv.slice(2)) {
+  try {
+    const options = parseArgs(argv);
+    if (options.help) {
+      process.stdout.write(`${USAGE}\n`);
+      return 0;
+    }
+    const report = await runEvaluation(options);
+    const serialized = `${JSON.stringify(report, null, 2)}\n`;
+    if (options.out) {
+      // --out intentionally selects a local, sanitized report destination.
+      // eslint-disable-next-line security/detect-non-literal-fs-filename
+      fs.writeFileSync(options.out, serialized, {
+        encoding: 'utf8',
+        mode: 0o600,
+      });
+      process.stdout.write(
+        `${JSON.stringify({
+          status: 'completed',
+          out: options.out,
+          classAAccuracy: report.classA.accuracy,
+          classBRecall: report.classB.recall,
+          citationCorrectness: report.citations.correctness,
+          outcome: report.decision.outcome,
+        })}\n`,
+      );
+    } else {
+      process.stdout.write(serialized);
+    }
+    return 0;
+  } catch (error) {
+    process.stderr.write(
+      `psd-observances retrieval eval: ${
+        error instanceof Error ? error.message : String(error)
+      }\n`,
+    );
+    return 1;
+  }
+}
+
+if (require.main === module) {
+  main().then((exitCode) => {
+    process.exitCode = exitCode;
+  });
+}
+
+module.exports = {
+  CLASS_A_THRESHOLD,
+  CLASS_B_THRESHOLD,
+  USAGE,
+  aggregate,
+  citationPages,
+  factTokens,
+  loadFixture,
+  main,
+  normalizeText,
+  parseArgs,
+  scoreFact,
+  scoreQuestion,
+  selectRepository,
+};

--- a/infra/agent-image/skills/psd-observances/retrieval-eval.js
+++ b/infra/agent-image/skills/psd-observances/retrieval-eval.js
@@ -13,7 +13,7 @@ const fs = require('node:fs');
 const path = require('node:path');
 const crypto = require('node:crypto');
 const { main: runSkill } = require('./run');
-const { parseMcpPayload } = require('./common');
+const { parseToolEnvelope } = require('./common');
 
 const DEFAULT_FIXTURE = path.join(
   __dirname,
@@ -313,10 +313,7 @@ function createLiveMcpClient(baseUrl, apiKey) {
   return {
     callTool: async (name, args) => {
       const response = await call('tools/call', { name, arguments: args });
-      if (response.httpStatus < 200 || response.httpStatus >= 300) {
-        fail(`MCP ${name} failed with HTTP ${response.httpStatus}`);
-      }
-      return parseMcpPayload(response.payload, name);
+      return parseToolEnvelope(response, name);
     },
     requestAgentBroker: async (route, body) => {
       if (route !== '/api/agent/aistudio') {
@@ -327,6 +324,8 @@ function createLiveMcpClient(baseUrl, apiKey) {
   };
 }
 
+// Keep this rule aligned with run.js:createRepositoryResolver so the
+// preflight and every skill invocation select the same live repository.
 function selectRepository(payload) {
   const matches = (payload?.repositories ?? [])
     .filter(

--- a/infra/agent-image/skills/psd-observances/retrieval-eval.test.js
+++ b/infra/agent-image/skills/psd-observances/retrieval-eval.test.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const path = require('node:path');
+const { describe, expect, test } = require('bun:test');
 const {
   aggregate,
   citationPages,

--- a/infra/agent-image/skills/psd-observances/retrieval-eval.test.js
+++ b/infra/agent-image/skills/psd-observances/retrieval-eval.test.js
@@ -1,0 +1,299 @@
+'use strict';
+
+const path = require('node:path');
+const {
+  aggregate,
+  citationPages,
+  factTokens,
+  loadFixture,
+  normalizeText,
+  parseArgs,
+  scoreFact,
+  scoreQuestion,
+  selectRepository,
+} = require('./retrieval-eval');
+
+const fixturePath = path.join(
+  __dirname,
+  'evals',
+  'retrieval-cases.json',
+);
+
+function expectedPages(question) {
+  return question.expected.flatMap((fact) => fact.pages);
+}
+
+describe('retrieval evaluation fixture', () => {
+  const fixture = loadFixture(fixturePath);
+
+  test('contains exactly 12 Class A and 8 Class B questions', () => {
+    expect(fixture.questions).toHaveLength(20);
+    expect(
+      fixture.questions.filter((question) => question.class === 'A'),
+    ).toHaveLength(12);
+    expect(
+      fixture.questions.filter((question) => question.class === 'B'),
+    ).toHaveLength(8);
+  });
+
+  test('stores expected answers only as names, dates, and page numbers', () => {
+    for (const question of fixture.questions) {
+      for (const fact of question.expected) {
+        expect(Object.keys(fact).sort()).toEqual(['date', 'name', 'pages']);
+        expect(fact.name.length).toBeGreaterThan(0);
+        expect(fact.date.length).toBeGreaterThan(0);
+        expect(fact.pages.every(Number.isSafeInteger)).toBe(true);
+      }
+    }
+  });
+
+  test('covers all four publication parts', () => {
+    const pages = new Set(fixture.questions.flatMap(expectedPages));
+    expect([...pages].some((page) => page < 59)).toBe(true);
+    expect(pages.has(59)).toBe(true);
+    expect(pages.has(83)).toBe(true);
+    expect([...pages].some((page) => page >= 87 && page <= 102)).toBe(true);
+  });
+});
+
+describe('retrieval evaluation arguments', () => {
+  test('requires a named environment and URL', () => {
+    expect(() => parseArgs([])).toThrow('--environment is required');
+    expect(() => parseArgs(['--environment', 'dev'])).toThrow(
+      '--base-url is required',
+    );
+  });
+
+  test('accepts HTTPS and resolves paths', () => {
+    const parsed = parseArgs([
+      '--environment',
+      'dev',
+      '--base-url',
+      'https://dev.example.test/path',
+      '--fixture',
+      fixturePath,
+      '--out',
+      './report.json',
+    ]);
+    expect(parsed.environment).toBe('dev');
+    expect(parsed.baseUrl).toBe('https://dev.example.test');
+    expect(parsed.fixture).toBe(fixturePath);
+    expect(parsed.out).toBe(path.resolve('./report.json'));
+  });
+
+  test('never accepts an API key value on the command line', () => {
+    expect(() =>
+      parseArgs([
+        '--environment',
+        'dev',
+        '--base-url',
+        'https://dev.example.test',
+        '--api-key',
+        'sk-secret',
+      ]),
+    ).toThrow('Unknown flag: --api-key');
+  });
+});
+
+describe('fact matching and citation scoring', () => {
+  test('normalizes month names, accents, punctuation, and following/after', () => {
+    expect(normalizeText('Birth of the Báb — November 10')).toBe(
+      'birth of the bab nov 10',
+    );
+    expect(
+      normalizeText('Friday immediately following the fourth Thursday'),
+    ).toBe('friday after the fourth thursday');
+  });
+
+  test('ignores connector words while retaining fact-bearing tokens', () => {
+    expect(
+      factTokens({
+        name: 'Anniversary of the Mexican Revolution',
+        date: 'Nov. 20, 2026',
+      }),
+    ).toEqual([
+      'anniversary',
+      'mexican',
+      'revolution',
+      'nov',
+      '20',
+      '2026',
+    ]);
+  });
+
+  test('matches a fact only when its name and date tokens share one result', () => {
+    const fact = {
+      name: 'American Education Week',
+      date: 'Nov. 16-20, 2026',
+      pages: [38],
+    };
+    const prepared = [
+      {
+        tokens: new Set(
+          normalizeText(
+            '2026 Nov. 16-20 American Education Week',
+          ).split(' '),
+        ),
+        pages: [38],
+      },
+    ];
+    expect(scoreFact(fact, prepared)).toMatchObject({
+      matched: true,
+      citationCorrect: true,
+      returnedPages: [38],
+    });
+  });
+
+  test('reports a fact match separately from an incorrect citation', () => {
+    const fact = {
+      name: 'National PTA',
+      date: 'June 18-21, 2026',
+      pages: [90],
+    };
+    const prepared = [
+      {
+        tokens: new Set(
+          normalizeText('2026 June 18-21 National PTA').split(' '),
+        ),
+        pages: [89],
+      },
+    ];
+    expect(scoreFact(fact, prepared)).toMatchObject({
+      matched: true,
+      citationCorrect: false,
+      returnedPages: [89],
+    });
+  });
+
+  test('expands cited page ranges', () => {
+    expect(citationPages({ citation: { page: 37, pageEnd: 39 } })).toEqual([
+      37, 38, 39,
+    ]);
+  });
+
+  test('sanitized case output never retains excerpts', () => {
+    const question = {
+      id: 'test',
+      class: 'A',
+      question: 'When is the test observance?',
+      expected: [
+        { name: 'Test Observance', date: 'Jan. 1, 2026', pages: [11] },
+      ],
+    };
+    const scored = scoreQuestion(
+      question,
+      {
+        results: [
+          {
+            excerpt: '2026 Jan. 1 Test Observance source-only context',
+            citation: { page: 11 },
+          },
+        ],
+      },
+      12,
+    );
+    expect(scored.matchedFactCount).toBe(1);
+    expect(scored.returnedPages).toEqual([11]);
+    expect(JSON.stringify(scored)).not.toContain('source-only context');
+    expect(JSON.stringify(scored)).not.toContain('excerpt');
+  });
+
+  test('records only deduplicated, ordered citation pages for diagnostics', () => {
+    const scored = scoreQuestion(
+      {
+        id: 'pages',
+        class: 'A',
+        question: 'Which pages were returned?',
+        expected: [
+          { name: 'Missing fact', date: 'Jan. 1, 2026', pages: [11] },
+        ],
+      },
+      {
+        results: [
+          { excerpt: 'unrelated', citation: { page: 42 } },
+          { excerpt: 'unrelated', citation: { page: 7, pageEnd: 8 } },
+          { excerpt: 'unrelated', citation: { page: 42 } },
+        ],
+      },
+      12,
+    );
+    expect(scored.returnedPages).toEqual([7, 8, 42]);
+  });
+});
+
+describe('decision rule', () => {
+  function result(overrides) {
+    return {
+      class: 'A',
+      correct: true,
+      expectedFactCount: 1,
+      matchedFactCount: 1,
+      correctlyCitedFactCount: 1,
+      ...overrides,
+    };
+  }
+
+  test('requires investigation when Class A is below 90%', () => {
+    const cases = [
+      ...Array.from({ length: 8 }, () => result({})),
+      result({ correct: false, matchedFactCount: 0 }),
+      result({ correct: false, matchedFactCount: 0 }),
+      result({
+        class: 'B',
+        expectedFactCount: 10,
+        matchedFactCount: 10,
+      }),
+    ];
+    expect(aggregate(cases).decision.outcome).toBe(
+      'investigate_named_retrieval',
+    );
+  });
+
+  test('recommends markdown when Class B recall is below 80%', () => {
+    const cases = [
+      result({}),
+      result({
+        class: 'B',
+        expectedFactCount: 10,
+        matchedFactCount: 7,
+        correctlyCitedFactCount: 7,
+      }),
+    ];
+    expect(aggregate(cases).decision).toMatchObject({
+      outcome: 'structured_markdown_needed',
+      markdownRegenerationNeeded: true,
+    });
+  });
+
+  test('keeps direct PDF when both thresholds pass', () => {
+    const cases = [
+      result({}),
+      result({
+        class: 'B',
+        expectedFactCount: 10,
+        matchedFactCount: 8,
+        correctlyCitedFactCount: 8,
+      }),
+    ];
+    expect(aggregate(cases).decision).toMatchObject({
+      outcome: 'direct_pdf_sufficient',
+      markdownRegenerationNeeded: false,
+    });
+  });
+});
+
+test('repository selection follows the runtime NSPRA rule', () => {
+  expect(
+    selectRepository({
+      repositories: [
+        { id: 3, name: 'NSPRA archive' },
+        {
+          id: 9,
+          name: 'NSPRA 2026 Calendar',
+          visibility: 'private',
+          itemCount: 1,
+        },
+      ],
+    }),
+  ).toMatchObject({ id: 9, name: 'NSPRA 2026 Calendar' });
+});

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "test:skill:conversation-coach": "cd infra/agent-image/skills/psd-conversation-coach && bun test",
     "test:skill:morning-brief": "cd infra/agent-image/skills/psd-morning-brief && bun test",
     "test:skill:psd-observances": "cd infra/agent-image/skills/psd-observances && bun test",
+    "eval:skill:psd-observances-retrieval": "node infra/agent-image/skills/psd-observances/retrieval-eval.js",
     "test:smoke:atrium": "bun run test:smoke:atrium-render && bun run test:smoke:atrium-collab && bun run test:smoke:atrium-collab-token && bun run test:smoke:atrium-agent-bridge && bun run test:smoke:atrium-agent-read && bun run test:smoke:atrium-html-sanitize && bun run test:smoke:atrium-provenance-rail && bun run test:smoke:atrium-collab-schema && bun run test:smoke:atrium-suggestions-resolve && bun run test:smoke:atrium-suggestion-mode && bun run test:smoke:atrium-sandbox-config && bun run test:smoke:atrium-sandbox-host",
     "test:ci": "jest --config=jest.config.ci.js",
     "test:watch": "jest --watch",


### PR DESCRIPTION
Closes #1477

Related to #1475.

## Summary

- add a 20-question, source-verified retrieval fixture with 12 Class A named
  questions and 8 Class B enumeration questions across all four publication
  parts
- add a repeatable live MCP runner that executes every case through the real
  `psd-observances/run.js` command boundary while discarding raw excerpts
- score Class A accuracy, Class B fact recall, and citation correctness
  separately, with unit/contract coverage for scoring, sanitization, repository
  selection, and the decision rule
- document the annual operator workflow and commit the transcript-free dev
  measurement, OCR inspection, investigation, and recommendation

## Dev result and recommendation

| Measure | Result | Gate |
| --- | ---: | ---: |
| Class A accuracy | 10/12 (83.3%) | 90% |
| Class B recall | 53/86 facts (61.6%) | 80% |
| Citation correctness | 64/108 facts (59.3%) | reported separately |

Class A's two misses were investigated before deciding. Both expected facts
are present in the correct active indexed chunks, so the misses are retrieval
or bounded-output selection failures rather than a wrong repository,
incomplete ingest, or OCR gap. Because enumeration recall is independently
below 80%, the written recommendation is to proceed with structured-markdown
regeneration in #1478.

The extractor reported `needsOcrPages: [10, 58, 60, 86, 102, 124]`. Active
chunks were absent on three pages and contained only printed page numbers on
the other three; no spurious OCR content was found.

## Risk and operations

- No database or infrastructure migration.
- No API or UI behavior changes.
- Expected answers contain only names, dates, and printed-page metadata; no
  source PDF, extracted text, retrieval transcript, or NSPRA prose is in Git.
- The live dev repository reported `visibility: public`, which conflicts with
  the staff-restricted/non-public operating requirement. The report flags this
  as a separate operational access-control correction.
- The short-lived, repository-read-only evaluation key was revoked after the
  run, and all issue-specific source/key/transcript artifacts were removed.

## Validation

- live dev evaluation through `/api/mcp` and `psd-observances/run.js`:
  20/20 cases completed against repository id 166
- `bun run test:skill:psd-observances` — 57 passed, 0 failed
- `bun run lint` — passed with zero warnings
- `bun run typecheck` — passed
- `bun run build` — passed
- `bun run eval:skill:psd-observances-retrieval -- --help` — passed
- `node --check infra/agent-image/skills/psd-observances/retrieval-eval.js`
- `node --check infra/agent-image/skills/psd-observances/retrieval-eval.test.js`
- fixture-shape, source-prose, added-PDF, and `git diff --check` guards — passed

E2E was not applicable to this non-UI evaluation/documentation change; the
skills-only pre-push hook was skipped with `SKIP_E2E=1` per repository policy.
