### PR TITLE
fix(agent): make workspace restore contract fleet-safe

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,3 +100,5 @@ infra/agent-image/.candidate-staging.*/
 
 # Staged into the agent-image build context by build-and-push.sh; canonical copy is infra/validated-fs.cjs
 infra/agent-image/skills/validated-fs.cjs
+# Staged from lib/agent-workspace/workspace-policy.json for the image build.
+infra/agent-image/workspace_policy.json

--- a/docs/operations/agent-image-build-gate.md
+++ b/docs/operations/agent-image-build-gate.md
@@ -1,27 +1,44 @@
 # Agent Image Build-Time Eval Gate (#1161)
 
 `infra/agent-image/build-and-push.sh` refuses to push an agent image that has
-not been proven to boot and answer. This page documents the gate's five checks,
+not been proven to boot and answer. This page documents the gate's seven checks,
 how to satisfy the runtime half, and how to override it when you must.
 
 The gate exists because the image is an artifact optimised against an
-evaluator, and three separate regressions reached production before it did:
-a dead-boot image (r10), a missing provider (r11), and a silently truncated
-`SOUL.md`. Every one of them is caught on a laptop by the checks below.
+evaluator, and four separate regressions reached production before it did:
+a dead-boot image (r10), a missing provider (r11), a silently truncated
+`SOUL.md`, and a broker/image path-policy mismatch that made populated
+workspaces unrestorable. Every one of them is caught before push by the checks
+below.
 
-## The five checks
+## The seven checks
 
 | # | Check | Kind | Fails on |
 |---|-------|------|----------|
 | 1 | Instruction-budget (`check_bootstrap_budget.py`) | static | a bootstrap file that would be truncated at boot |
 | 2 | Config self-consistency (`check_config_consistency.py`) | static | bad `contextWindow`, `apiKey` hydration, plugin compatibility, web-search readiness, a stale host schema, or a host missing settled-tool finalization in `openclaw.json` / `Dockerfile` |
-| 3 | Plugin-aware config validation | build | the complete config is invalid after the pinned custom plugins are installed |
-| 4 | Boot probe | runtime | no `BOOT_OK` within `PROBE_BOOT_TIMEOUT` (default 120s) |
-| 5 | Canary turn | runtime | `/invocations` does not answer `OK` |
+| 3 | Cross-language workspace persistence contract | static | the Python sync/runtime tests or TypeScript broker integration tests fail |
+| 4 | Existing dev + prod workspace inventory | AWS read-only | any registered workspace contains durable state the candidate cannot round-trip, or the real TypeScript/Python classifications or generation hashes disagree |
+| 5 | Plugin-aware config validation | build | the complete config is invalid after the pinned custom plugins are installed |
+| 6 | Boot probe | runtime | no `BOOT_OK` within `PROBE_BOOT_TIMEOUT` (default 120s) |
+| 7 | Canary turn | runtime | `/invocations` does not answer `OK` |
 
 Static checks run before the build. Plugin-aware validation runs inside the
 image after the official Bedrock and Parallel plugins are installed. The
 runtime checks run against the freshly built image, before `docker push`.
+The inventory gate reads the authoritative workspace-prefix registries and
+every current S3 key in both dev and prod. It rejects incompatible durable
+state, then sends the same in-memory inventory through the actual Python image
+classifier and generation implementation and compares those results with the
+actual TypeScript broker. Excluded dependency/runtime trees are counted but do
+not block a build merely because they contain a path neither runtime restores.
+The gate emits aggregate counts and stable hashes only, performs no writes, and
+cannot be bypassed by `SKIP_STATIC_GATE=1`. This closes the gap where an empty
+canary passed while a normal filename already present in saved user history
+could not be restored.
+It also fails on any legacy v1 or unknown checkpoint-control object. The
+paused cutover runs the same audit again after all old writers drain, closing
+the time gap between image build and frontend deployment.
 
 Issue #1469 added a fail-closed host contract to check 2. The pinned OpenClaw
 runtime must contain its one-shot, tools-disabled finalization for a settled
@@ -84,12 +101,13 @@ That is usually all you need. When `AGENT_PROBE_APP_BASE_URL` and
 2. mints a fresh 15-minute canary context by running
    `scripts/agent-workspace/mint-agent-probe-context.ts`.
 
-Both steps need AWS credentials for the target environment. If either fails,
-the build **stops** — it does not push an unverified image.
+Both steps need AWS credentials for the target environment. The inventory gate
+also needs read access to the dev and prod user registries and workspace
+buckets. If any lookup or audit fails, the build **stops**.
 
 ### Building a one-axis candidate
 
-Candidate manifests use the same command and all four gates:
+Candidate manifests use the same command and all seven gates:
 
 ```bash
 cd infra/agent-image
@@ -229,8 +247,8 @@ than it must:
 | Flag | Disables | When |
 |------|----------|------|
 | `ALLOW_UNVERIFIED_IMAGE=1` | turns a *skipped* runtime probe from a hard failure into a warning | you cannot reach the broker (no credentials, environment not deployed) and accept an unverified image |
-| `SKIP_PROBE_GATE=1` | checks 3–4 entirely, even when they could run | the probe itself is broken and blocking a release |
-| `SKIP_STATIC_GATE=1` | checks 1–2 | true emergency only — these are pure file checks with no external dependency |
+| `SKIP_PROBE_GATE=1` | checks 6–7 entirely, even when they could run | the probe itself is broken and blocking a release |
+| `SKIP_STATIC_GATE=1` | checks 1–3 | true emergency only — these are pure file checks with no external dependency; the dev+prod inventory audit still runs |
 | `REQUIRE_PROBE_GATE=1` | nothing; **outranks** `ALLOW_UNVERIFIED_IMAGE` | CI, so an opt-in inherited from the environment cannot weaken the pipeline |
 
 `ALLOW_UNVERIFIED_IMAGE=1` does not print "PASSED". It prints:

--- a/docs/operations/agent-platform-setup.md
+++ b/docs/operations/agent-platform-setup.md
@@ -601,6 +601,29 @@ If the final assertion finds another enabled schedule, repeat the second
 16-minute drain window before continuing. At this point there are no new
 Router, scheduled, reconciliation, or promoted-job writers.
 
+Re-run the exact workspace compatibility gate after the last writer drains.
+This is a hard precondition for the v2 checkpoint namespace: any v1 control
+object means an older checkpoint may still be the last committed boundary, so
+the cutover must stop rather than blessing a possibly partial current state.
+
+```bash
+WORKSPACE_BUCKET="$(aws ssm get-parameter \
+  --name "/aistudio/${CUTOVER_ENV}/agent-workspace-bucket-name" \
+  --query 'Parameter.Value' \
+  --output text \
+  --region "$AWS_REGION")"
+test -n "$WORKSPACE_BUCKET"
+test "$WORKSPACE_BUCKET" != "None"
+bun run scripts/agent-workspace/audit-live-workspace-paths.ts \
+  --bucket "$WORKSPACE_BUCKET" \
+  --environment "$CUTOVER_ENV" \
+  --region "$AWS_REGION"
+```
+
+The audit is read-only. It must report empty
+`legacyV1CheckpointObjectHashes`, `unknownCheckpointObjectHashes`, path,
+conflict, and TypeScript/Python parity failure arrays before continuing.
+
 ##### 3. Remove the old runtime before changing the broker
 
 There is no list-all-runtime-sessions API that can prove every sticky microVM

--- a/infra/agent-image/Dockerfile
+++ b/infra/agent-image/Dockerfile
@@ -529,7 +529,7 @@ ENV OPENCLAW_SKIP_CRON=1
 # Firecracker snapshotter consistently fails overlay mount at 54+
 # layers (2026-05-18 incident). Folding six COPYs into one keeps us
 # safely under that ceiling.
-COPY *.py *.mjs /app/
+COPY *.py *.mjs workspace_policy.json /app/
 
 # Container OS clock is UTC. The wrapper reads the user's local time via
 # zoneinfo (requires the tzdata package installed above). TZ env var is set

--- a/infra/agent-image/build-and-push.sh
+++ b/infra/agent-image/build-and-push.sh
@@ -52,6 +52,8 @@ fi
 BUILD_CONFIG="${SCRIPT_DIR}/openclaw.json"
 BUILD_DOCKERFILE="${SCRIPT_DIR}/Dockerfile"
 BOOTSTRAP_SOURCE_DIR="${SCRIPT_DIR}"
+CANONICAL_WORKSPACE_POLICY="${REPO_ROOT}/lib/agent-workspace/workspace-policy.json"
+STAGED_WORKSPACE_POLICY="${SCRIPT_DIR}/workspace_policy.json"
 CANDIDATE_STAGING=""
 CANDIDATE_METADATA=""
 CANDIDATE_ID=""
@@ -74,6 +76,7 @@ cleanup_build() {
     docker rm -f "${CID}" >/dev/null 2>&1 || true
   fi
   rm -f "${SCRIPT_DIR}/skills/validated-fs.cjs"
+  rm -f "${STAGED_WORKSPACE_POLICY}"
   case "${CANDIDATE_STAGING}" in
     "${SCRIPT_DIR}"/.candidate-staging.*)
       rm -rf -- "${CANDIDATE_STAGING}"
@@ -88,12 +91,23 @@ if ! [[ "${SOURCE_COMMIT}" =~ ^[0-9a-f]{40}$ ]]; then
   exit 1
 fi
 if [ -n "$(git -C "${REPO_ROOT}" status --porcelain --untracked-files=all -- \
-    infra/agent-image infra/validated-fs.cjs)" ]; then
+    infra/agent-image infra/validated-fs.cjs \
+    app/api/agent/workspace-storage/route.ts \
+    lib/agent-workspace/storage-broker.ts \
+    lib/agent-workspace/path-policy.ts \
+    lib/agent-workspace/workspace-policy.json \
+    scripts/agent-workspace/audit-live-workspace-paths.ts \
+    scripts/agent-workspace/workspace-policy-probe.py \
+    tests/unit/agent-image-openclaw-runtime-patch.test.ts \
+    tests/unit/lib/agent-workspace/path-policy.test.ts \
+    tests/unit/lib/agent-workspace/storage-broker-checkpoint.test.ts \
+    tests/unit/lib/agent-workspace/storage-broker-list.test.ts \
+    tests/unit/lib/agent-workspace/storage-broker-upload.test.ts \
+    tests/unit/lib/agent-workspace/storage-broker.test.ts)" ]; then
   echo "ERROR: agent-image sources are dirty; commit them before building." >&2
   echo "       Image provenance must identify the exact source content." >&2
   exit 1
 fi
-
 PYTHON="${PYTHON:-python3}"
 if [ -n "${CANDIDATE_MANIFEST}" ]; then
   CANDIDATE_STAGING="$(mktemp -d "${SCRIPT_DIR}/.candidate-staging.XXXXXX")"
@@ -162,19 +176,21 @@ echo ""
 # ---------------------------------------------------------------------------
 # Build-time eval gate (issue #1161). The image is an artifact optimized
 # against an evaluator: it must pass an automated gate BEFORE it is pushed, so
-# the build loop stops being "deploy and chat." Five checks —
+# the build loop stops being "deploy and chat." Seven checks —
 #   1. instruction-budget gate   (static, no Docker)   — over-budget bootstrap
 #   2. config self-consistency   (static, no Docker)   — bad config/provider pins
-#   3. plugin-aware validation   (Docker build)        — invalid complete config
-#   4. boot probe                (runtime, needs image) — dead-boot (no BOOT_OK)
-#   5. canary turn               (runtime, needs image) — non-answering agent
+#   3. path-contract parity      (static, no Docker)   — broker/image drift
+#   4. dev+prod inventory audit (AWS read-only)       — unrestorable history
+#   5. plugin-aware validation  (Docker build)        — invalid complete config
+#   6. boot probe               (runtime, needs image) — dead-boot (no BOOT_OK)
+#   7. canary turn              (runtime, needs image) — non-answering agent
 # Would have stopped r10 (dead-boot), r11 (missing provider), and the weeks-long
 # SOUL.md truncation on a laptop instead of in prod.
 #
 # Two separate bypasses, so an emergency doesn't disable more than it must:
 #   SKIP_PROBE_GATE=1   skips only the RUNTIME boot-probe + canary turn (checks
-#                       4-5) — reserved for a broken probe blocking releases.
-#   SKIP_STATIC_GATE=1  skips the cheap STATIC checks (1-2). These are pure file
+#                       6-7) — reserved for a broken probe blocking releases.
+#   SKIP_STATIC_GATE=1  skips the cheap STATIC checks (1-3). These are pure file
 #                       checks with no external dependency and essentially never
 #                       need bypassing — this exists only for a true emergency,
 #                       and is deliberately a DIFFERENT flag so SKIP_PROBE_GATE
@@ -214,6 +230,25 @@ else
     exit 1
   fi
   echo ""
+
+  echo "3. Cross-language workspace path contract..."
+  if ! "${PYTHON}" -m unittest \
+        "${SCRIPT_DIR}/test_workspace_sync.py" \
+        "${SCRIPT_DIR}/test_workspace_path_contract.py"; then
+    echo "ERROR: Python workspace path contract FAILED." >&2
+    exit 1
+  fi
+  if ! bun run --cwd "${REPO_ROOT}" test -- --runInBand --silent \
+        "${REPO_ROOT}/tests/unit/lib/agent-workspace/path-policy.test.ts" \
+        "${REPO_ROOT}/tests/unit/lib/agent-workspace/storage-broker.test.ts" \
+        "${REPO_ROOT}/tests/unit/lib/agent-workspace/storage-broker-list.test.ts" \
+        "${REPO_ROOT}/tests/unit/lib/agent-workspace/storage-broker-upload.test.ts" \
+        "${REPO_ROOT}/tests/unit/lib/agent-workspace/storage-broker-checkpoint.test.ts" \
+        "${REPO_ROOT}/tests/unit/agent-image-openclaw-runtime-patch.test.ts"; then
+    echo "ERROR: TypeScript workspace path contract FAILED." >&2
+    exit 1
+  fi
+  echo ""
 fi
 
 # Get ECR repository URI from CloudFormation outputs
@@ -237,6 +272,35 @@ echo "ECR URI: ${ECR_URI}"
 echo "Registry: ${ECR_REGISTRY}"
 echo ""
 
+# A clean canary workspace cannot prove that a new persistence contract can
+# restore years of existing filenames. Audit every registered workspace in
+# BOTH environments with the exact TypeScript policy before building. This is
+# read-only and emits only aggregate counts plus stable hashes on failures.
+AUDIT_SCRIPT="${REPO_ROOT}/scripts/agent-workspace/audit-live-workspace-paths.ts"
+if ! command -v bun >/dev/null 2>&1 || [ ! -r "${AUDIT_SCRIPT}" ]; then
+  echo "ERROR: bun and ${AUDIT_SCRIPT} are required for the workspace compatibility gate." >&2
+  exit 1
+fi
+echo "=== Existing workspace compatibility gate (dev + prod) ==="
+for AUDIT_ENVIRONMENT in dev prod; do
+  AUDIT_BUCKET=$(aws ssm get-parameter \
+    --name "/aistudio/${AUDIT_ENVIRONMENT}/agent-workspace-bucket-name" \
+    --query 'Parameter.Value' --output text --region "${REGION}")
+  if [ -z "${AUDIT_BUCKET}" ] || [ "${AUDIT_BUCKET}" = "None" ]; then
+    echo "ERROR: workspace bucket is unavailable for ${AUDIT_ENVIRONMENT}." >&2
+    exit 1
+  fi
+  echo "Auditing ${AUDIT_ENVIRONMENT} workspaces..."
+  ENVIRONMENT="${AUDIT_ENVIRONMENT}" AWS_REGION="${REGION}" \
+    PYTHON="${PYTHON}" \
+    bun run --cwd "${REPO_ROOT}" "${AUDIT_SCRIPT}" \
+      --bucket "${AUDIT_BUCKET}" \
+      --environment "${AUDIT_ENVIRONMENT}" \
+      --region "${REGION}"
+done
+echo "=== Existing workspace compatibility gate PASSED ==="
+echo ""
+
 # Authenticate Docker with ECR
 echo "Authenticating with ECR..."
 aws ecr get-login-password --region "${REGION}" | \
@@ -251,6 +315,10 @@ echo "Building image (ARM64)..."
 # Staged (gitignored) rather than checked in twice, so it can never drift from
 # infra/validated-fs.cjs.
 cp "${SCRIPT_DIR}/../validated-fs.cjs" "${SCRIPT_DIR}/skills/validated-fs.cjs"
+# The canonical persistence contract must live under lib/ so the frontend
+# Docker/CDK asset includes it. Stage that exact committed file into the
+# separate agent-image build context; workspace_sync.py loads it from /app.
+cp "${CANONICAL_WORKSPACE_POLICY}" "${STAGED_WORKSPACE_POLICY}"
 DOCKER_BUILD_ARGS=(
   --platform linux/arm64
   --build-arg "AISTUDIO_SOURCE_COMMIT=${SOURCE_COMMIT}"
@@ -273,6 +341,7 @@ if [ -n "${CANDIDATE_ID}" ]; then
 fi
 docker build "${DOCKER_BUILD_ARGS[@]}" "${SCRIPT_DIR}"
 rm -f "${SCRIPT_DIR}/skills/validated-fs.cjs"
+rm -f "${STAGED_WORKSPACE_POLICY}"
 
 # ---------------------------------------------------------------------------
 # Build-time eval gate (issue #1161): runtime boot probe + signed canary turn.
@@ -615,11 +684,19 @@ echo ""
 echo "Image:  ${ECR_URI}:${TAG}"
 echo "Digest: ${DIGEST}"
 echo ""
-echo "Next step — deploy AgentCore Runtime pinned to the immutable digest:"
-echo ""
-echo "  cd infra && bunx cdk deploy ${STACK_NAME} \\"
-echo "    --context agentImageTag=${TAG} \\"
-echo "    --context agentImageDigest=${DIGEST}"
+if [ "${ENVIRONMENT}" = "dev" ]; then
+  echo "NEXT STEP REQUIRES A PAUSED, SAME-COMMIT WORKSPACE CUTOVER."
+  echo "DO NOT deploy AgentPlatform directly or mix this image with the old broker."
+  echo "Follow all steps under 'Dev workspace-generation cutover' in:"
+  echo "  docs/operations/agent-platform-setup.md"
+  echo "The sequence pauses ingress, drains writers, deploys Frontend first,"
+  echo "then deploys AgentPlatform pinned to the digest above, and resumes ingress."
+else
+  echo "NEXT STEP REQUIRES AN ENVIRONMENT-SPECIFIC PAUSED, SAME-COMMIT CUTOVER."
+  echo "DO NOT substitute Dev resource names or deploy AgentPlatform directly."
+  echo "Stop until the ${ENVIRONMENT} pause/drain, post-drain inventory audit,"
+  echo "Frontend-first deploy, AgentPlatform deploy, and resume steps are validated."
+fi
 echo ""
 echo "After deploy, confirm the running build via CloudWatch:"
 echo "  aws logs tail /aws/bedrock-agentcore/runtimes/<runtime-id>-DEFAULT \\"

--- a/infra/agent-image/test_workspace_path_contract.py
+++ b/infra/agent-image/test_workspace_path_contract.py
@@ -1,0 +1,153 @@
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+import workspace_sync
+
+
+class WorkspacePathContractTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cases_path = Path(__file__).with_name(
+            "workspace_path_contract_cases.json"
+        )
+        cls.cases = json.loads(cases_path.read_text(encoding="utf-8"))
+
+    def test_shared_valid_cases(self):
+        for relative in self.cases["valid"]:
+            with self.subTest(relative=relative):
+                self.assertIsNone(
+                    workspace_sync._workspace_relative_rejection_reason(
+                        relative
+                    )
+                )
+                self.assertEqual(
+                    workspace_sync._validate_workspace_relative(relative),
+                    tuple(relative.split("/")),
+                )
+
+    def test_shared_invalid_cases(self):
+        for case in self.cases["invalid"]:
+            with self.subTest(reason=case["reason"]):
+                self.assertEqual(
+                    workspace_sync._workspace_relative_rejection_reason(
+                        case["path"]
+                    ),
+                    case["reason"],
+                )
+                with self.assertRaises(OSError):
+                    workspace_sync._validate_workspace_relative(case["path"])
+
+    def test_utf8_segment_and_depth_bounds(self):
+        self.assertEqual(
+            workspace_sync._workspace_relative_rejection_reason("a" * 769),
+            "too-long",
+        )
+        self.assertEqual(
+            workspace_sync._workspace_relative_rejection_reason(
+                f"{'a' * 256}/file"
+            ),
+            "segment-too-long",
+        )
+        self.assertEqual(
+            workspace_sync._workspace_relative_rejection_reason(
+                "/".join("a" for _ in range(65))
+            ),
+            "too-deep",
+        )
+        self.assertEqual(
+            workspace_sync._workspace_relative_rejection_reason("\u00e9" * 385),
+            "too-long",
+        )
+        self.assertEqual(
+            workspace_sync._workspace_relative_rejection_reason(
+                "surrogate-\ud800"
+            ),
+            "unsupported-character",
+        )
+
+    def test_checkpoint_exclusions_are_loaded_from_shared_policy(self):
+        self.assertFalse(
+            workspace_sync._is_checkpoint_managed_relative(
+                "skills/example/.tts-venv/lib/site-packages/pkg/file.py"
+            )
+        )
+        self.assertFalse(
+            workspace_sync._is_checkpoint_managed_relative(
+                "node_modules/pkg/index.js"
+            )
+        )
+        self.assertTrue(
+            workspace_sync._is_checkpoint_managed_relative(
+                "memory/notes (v2).md"
+            )
+        )
+
+    def test_shallow_image_layout_uses_adjacent_staged_policy(self):
+        with tempfile.TemporaryDirectory() as directory:
+            image_dir = Path(directory) / "app"
+            image_dir.mkdir()
+            module_path = image_dir / "workspace_sync.py"
+            module_path.touch()
+            policy_path = image_dir / "workspace_policy.json"
+            policy_path.write_text("{}", encoding="utf-8")
+
+            self.assertEqual(
+                workspace_sync._workspace_policy_path(module_path),
+                policy_path.resolve(),
+            )
+
+    def test_generation_excludes_the_same_regenerable_tree(self):
+        durable_only = workspace_sync._generation_for_entries({
+            "memory/notes (v2).md": (4, '"durable"'),
+        })
+        with_regenerable_tree = workspace_sync._generation_for_entries({
+            "memory/notes (v2).md": (4, '"durable"'),
+            "skills/example/.tts-venv/lib/site-packages/pkg/"
+            "script (dev).tmpl": (1, '"generated"'),
+        })
+        self.assertEqual(with_regenerable_tree, durable_only)
+
+    def test_invalid_authoritative_path_fails_before_local_mutation(self):
+        invalid = "/".join("a" for _ in range(65))
+        snapshot = workspace_sync._RemoteWorkspaceSnapshot(
+            paths=(invalid,),
+            sizes={invalid: 1},
+            e_tags={invalid: '"etag"'},
+            generation=None,
+        )
+        with tempfile.TemporaryDirectory() as directory:
+            workspace = Path(directory) / "workspace"
+            with mock.patch.object(
+                workspace_sync,
+                "WORKSPACE_DIR",
+                workspace,
+            ):
+                with self.assertRaises(
+                    workspace_sync.WorkspaceRestoreIncomplete
+                ):
+                    workspace_sync.pull_workspace("owner", snapshot)
+            self.assertFalse(workspace.exists())
+
+    def test_invalid_local_path_fails_push_traversal(self):
+        with tempfile.TemporaryDirectory() as directory:
+            workspace = Path(directory)
+            (workspace / "bad\\name").write_text("unsafe", encoding="utf-8")
+            with mock.patch.object(
+                workspace_sync,
+                "WORKSPACE_DIR",
+                workspace,
+            ):
+                with self.assertRaises(
+                    workspace_sync.WorkspacePushIncomplete
+                ):
+                    list(workspace_sync._iter_workspace_files())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/infra/agent-image/test_workspace_sync.py
+++ b/infra/agent-image/test_workspace_sync.py
@@ -109,18 +109,15 @@ class PullTraversalTests(unittest.TestCase):
                    if not Path(d).resolve().is_relative_to(self.root)]
         return count, downloaded, escaped
 
-    def test_traversal_key_is_skipped_not_written(self):
+    def test_traversal_key_fails_the_entire_restore_before_writing(self):
         keys = [
             "../../home/node/.ssh/authorized_keys",  # classic zip-slip
             "../evil.txt",                            # single-level escape
             "notes/ok.md",                            # benign control
         ]
-        count, downloaded, escaped = self._run_pull(keys)
-        # Only the benign file downloads; both traversal keys are skipped.
-        self.assertEqual(count, 1)
-        self.assertEqual([k for (k, _) in downloaded], ["notes/ok.md"])
-        self.assertEqual(escaped, [])
-        self.assertTrue((self.root / "notes" / "ok.md").exists())
+        with self.assertRaises(workspace_sync.WorkspaceRestoreIncomplete):
+            self._run_pull(keys)
+        self.assertFalse((self.root / "notes" / "ok.md").exists())
 
     def test_forced_restore_prunes_uncommitted_local_extras_and_restores_seed(self):
         # Dirty turn changed a required parent from a directory to a file.
@@ -229,10 +226,9 @@ class PullTraversalTests(unittest.TestCase):
     def test_no_write_outside_workspace_dir(self):
         # Even if download_file were reached, assert nothing lands outside root.
         keys = ["../../tmp/pwned"]
-        count, downloaded, escaped = self._run_pull(keys)
-        self.assertEqual(count, 0)
-        self.assertEqual(downloaded, [])
-        self.assertEqual(escaped, [])
+        with self.assertRaises(workspace_sync.WorkspaceRestoreIncomplete):
+            self._run_pull(keys)
+        self.assertFalse((self.root.parent / "tmp" / "pwned").exists())
 
     def test_forced_restore_removes_attachment_root_symlink_only(self):
         outside = self.root.parent / "outside-attachments"

--- a/infra/agent-image/workspace_path_contract_cases.json
+++ b/infra/agent-image/workspace_path_contract_cases.json
@@ -1,0 +1,20 @@
+{
+  "valid": [
+    "memory/notes.md",
+    "skills/hagelk-morning-brief/.tts-venv/lib/python3.11/site-packages/setuptools/script (dev).tmpl",
+    "memory/Draft, final! [v2] #1 & notes's.txt",
+    "memory/Café/日本語/emoji-🧠.md"
+  ],
+  "invalid": [
+    { "path": "", "reason": "empty" },
+    { "path": "/absolute", "reason": "absolute" },
+    { "path": "trailing/", "reason": "trailing-slash" },
+    { "path": "repeated//slash", "reason": "empty-segment" },
+    { "path": "safe/../escape", "reason": "traversal-segment" },
+    { "path": "safe/./alias", "reason": "traversal-segment" },
+    { "path": "windows\\separator", "reason": "unsupported-character" },
+    { "path": "line\nbreak", "reason": "unsupported-character" },
+    { "path": "bidi-‮override", "reason": "unsupported-character" },
+    { "path": "line- separator", "reason": "unsupported-character" }
+  ]
+}

--- a/infra/agent-image/workspace_sync.py
+++ b/infra/agent-image/workspace_sync.py
@@ -102,6 +102,31 @@ class _PendingWorkspaceCompletion:
 
 
 WORKSPACE_DIR = Path("/home/node/.openclaw")
+
+
+def _workspace_policy_path(module_path: Path) -> Path:
+    module_directory = module_path.resolve().parent
+    repository_candidate = (
+        module_directory.parent.parent
+        / "lib"
+        / "agent-workspace"
+        / "workspace-policy.json"
+    )
+    image_candidate = module_directory / "workspace_policy.json"
+    return (
+        repository_candidate
+        if repository_candidate.is_file()
+        else image_candidate
+    )
+
+
+_WORKSPACE_POLICY_PATH = _workspace_policy_path(Path(__file__))
+with _WORKSPACE_POLICY_PATH.open(encoding="utf-8") as _policy_file:
+    _WORKSPACE_POLICY = json.load(_policy_file)
+if _WORKSPACE_POLICY.get("version") != 1:
+    raise RuntimeError("unsupported workspace persistence policy")
+_PRIVATE_PATH_POLICY = _WORKSPACE_POLICY["privatePath"]
+_CHECKPOINT_EXCLUSIONS = _WORKSPACE_POLICY["checkpointExclusions"]
 _IMAGE_SEED_RELATIVES = ("IDENTITY.md", "USER.md", "MEMORY.md")
 # Captured before the first owner hydration. If a dirty warm workspace must be
 # discarded, these per-image scaffolding files can be restored without
@@ -139,7 +164,7 @@ MAX_SYNC_FILES = 250_000
 # Was 4,000 — below live workspaces (two prefixes hold ~5,000 objects), so the
 # PUSH silently truncated and never uploaded the tail of a user's workspace.
 MAX_SYNC_ENTRIES = 250_000
-MAX_SYNC_DEPTH = 64
+MAX_SYNC_DEPTH = int(_PRIVATE_PATH_POLICY["maxDepth"])
 SYNC_WORKERS = 4
 TRANSFER_CHUNK_BYTES = 64 * 1024
 WORKSPACE_UPLOAD_CONTENT_TYPE = "application/octet-stream"
@@ -150,7 +175,7 @@ _TRANSIENT_HTTP_STATUSES = frozenset({408, 429, 500, 502, 503, 504})
 # generic 20-second broker read cap. Checkpoint calls are idempotent and are
 # deliberately not auto-retried: a client timeout does not prove the web tier
 # stopped working, and overlapping retries would queue behind the same lock.
-WORKSPACE_CHECKPOINT_BROKER_TIMEOUT_SECONDS = 55
+WORKSPACE_CHECKPOINT_BROKER_TIMEOUT_SECONDS = 240
 WORKSPACE_FLUSH_TOKEN_PATH = (
     "/run/psd-agent-authority/workspace-flush-token"
 )
@@ -187,10 +212,17 @@ _SQLITE_TRANSIENT_SIDECAR_SUFFIXES = (
     "-shm",
     "-journal",
 )
-_SQLITE_MEMORY_REINDEX_RE = re.compile(
-    r"^.+\.sqlite\.memory-reindex-[0-9A-Fa-f-]+"
-    r"(?:-(?:wal|shm|journal))?$"
+_SKIP_BASENAME_PATTERNS = tuple(
+    re.compile(pattern)
+    for pattern in _CHECKPOINT_EXCLUSIONS["basenamePatterns"]
 )
+
+
+def _matches_skip_basename_pattern(basename: str) -> bool:
+    return any(
+        pattern.fullmatch(basename)
+        for pattern in _SKIP_BASENAME_PATTERNS
+    )
 
 
 def _is_transient_read_error(error: BaseException) -> bool:
@@ -209,22 +241,48 @@ def _is_transient_read_error(error: BaseException) -> bool:
     )
 
 
+def _workspace_relative_rejection_reason(relative: object) -> str | None:
+    """Return the canonical cross-language rejection reason, if any."""
+    if not isinstance(relative, str) or not relative:
+        return "empty"
+    if relative.startswith("/"):
+        return "absolute"
+    if relative.endswith("/"):
+        return "trailing-slash"
+    try:
+        relative_bytes = relative.encode("utf-8")
+    except UnicodeEncodeError:
+        return "unsupported-character"
+    if len(relative_bytes) > int(_PRIVATE_PATH_POLICY["maxUtf8Bytes"]):
+        return "too-long"
+    rejected_ranges = _PRIVATE_PATH_POLICY["rejectedCodePointRanges"]
+    if any(
+        start <= ord(character) <= end
+        for character in relative
+        for start, end in rejected_ranges
+    ):
+        return "unsupported-character"
+
+    parts = tuple(relative.split("/"))
+    if len(parts) > MAX_SYNC_DEPTH:
+        return "too-deep"
+    for part in parts:
+        if not part:
+            return "empty-segment"
+        if part in (".", ".."):
+            return "traversal-segment"
+        if len(part.encode("utf-8")) > int(
+            _PRIVATE_PATH_POLICY["maxSegmentUtf8Bytes"]
+        ):
+            return "segment-too-long"
+    return None
+
+
 def _validate_workspace_relative(relative: str) -> tuple[str, ...]:
     """Return safe lexical path parts without consulting mutable symlinks."""
-    if (
-        not isinstance(relative, str)
-        or not relative
-        or relative.startswith("/")
-        or "\x00" in relative
-    ):
+    if _workspace_relative_rejection_reason(relative) is not None:
         raise OSError("invalid workspace file path")
-    parts = tuple(relative.split("/"))
-    if (
-        len(parts) > MAX_SYNC_DEPTH
-        or any(part in ("", ".", "..") for part in parts)
-    ):
-        raise OSError("invalid workspace file path")
-    return parts
+    return tuple(relative.split("/"))
 
 
 def _install_workspace_file(source: Path, relative: str) -> None:
@@ -566,57 +624,10 @@ def _materialize_empty_workspace_file(
 # and must round-trip.
 #
 # Match is: "skip if the relative path equals or starts with any entry".
-_SKIP_RELATIVE_PREFIXES = (
-    "openclaw.json",                  # gateway config
-    "openclaw.json.bak",               # gateway config backup
-    "agents/main/agent/models.json",   # per-agent provider/model config
-    "logs/",                           # gateway telemetry, not memory
-    "update-check.json",               # gateway version probe state
-    ".openclaw/",                      # nested OpenClaw internal state
-    "SOUL.md",                         # system prompt — image-owned
-    # Image-bundled skills — every file under these prefixes is shipped by
-    # the container deploy and must never be overlaid by S3 state. Same
-    # class of bug as SOUL.md (2026-04-26): stale skill files in each
-    # user's S3 prefix (debug-*.js, old SKILL.md, old common.js) were
-    # pulled on cold-start and overwriting the new image's psd-workspace
-    # skill, so Phase 1 user_account scope handling never took effect
-    # after the image was rebuilt and redeployed.
-    #
-    # IMPORTANT: skills/user/ is the agent's own authoring scratchpad —
-    # NOT image-owned, must round-trip. Don't blanket-skip skills/.
-    # Image-bundled skills now live at /opt/psd-skills/, OUTSIDE this
-    # workspace dir, so they CANNOT be overlaid by S3 state — the path
-    # separation makes the "agent overwrites a district skill" bug class
-    # physically impossible. The skip entries below remain as a defense
-    # against S3 pollution: stale files exist in some users' workspace
-    # prefixes from the pre-separation era, and an agent that hand-creates
-    # `~/.openclaw/skills/psd-foo/` would sync that scratch to S3 forever.
-    # Skipping these prefixes prevents both. Keep the list aligned with
-    # the directories that exist at /opt/psd-skills/.
-    "skills/gws-",
-    "skills/psd-brand-guidelines/",
-    "skills/psd-credentials/",
-    "skills/psd-data/",
-    "skills/psd-failure-report/",
-    "skills/psd-freshservice/",
-    "skills/psd-github/",
-    "skills/psd-html-artifact/",
-    # psd-html-output was REMOVED from the image (superseded by psd-html-artifact),
-    # but its skip entry is intentionally retained: stale objects may linger in
-    # some users' pre-separation S3 prefixes, and skipping the pull keeps the
-    # deleted skill from being resurrected under ~/.openclaw/skills/ on sync.
-    "skills/psd-html-output/",
-    "skills/psd-image-gen/",
-    # psd-redrover was REMOVED from the image (#1396 — Red Rover data is now
-    # served through the warehouse via psd-data, which authenticates as the
-    # calling user), but its skip entry is intentionally retained for the same
-    # reason as psd-html-output above: stale synced copies in users' S3
-    # prefixes must not be resurrected under ~/.openclaw/skills/ on sync.
-    "skills/psd-redrover/",
-    "skills/psd-rules/",
-    "skills/psd-schedules/",
-    "skills/psd-skills-meta/",
-    "skills/psd-workspace/",
+# The values live in workspace_policy.json so the web checkpoint and image
+# runtime cannot silently drift into different definitions of durable state.
+_SKIP_RELATIVE_PREFIXES = tuple(
+    _CHECKPOINT_EXCLUSIONS["relativePrefixes"]
 )
 
 # Filename suffixes that are always runtime cruft. SQLite WAL/SHM files are
@@ -624,17 +635,8 @@ _SKIP_RELATIVE_PREFIXES = (
 # while the gateway is live produced mismatched database generations in S3.
 # The wrapper now stops the gateway and checkpoints the main database before
 # every push.
-_SKIP_SUFFIXES = (
-    ".sock",
-    ".pid",
-    ".sqlite-wal",
-    ".sqlite-shm",
-    ".sqlite-journal",
-    ".reindex-lock.sqlite",
-)
-_SKIP_BASENAMES = frozenset({
-    "plugins.sync.lock",
-})
+_SKIP_SUFFIXES = tuple(_CHECKPOINT_EXCLUSIONS["suffixes"])
+_SKIP_BASENAMES = frozenset(_CHECKPOINT_EXCLUSIONS["basenames"])
 
 # Directory names that hold REGENERABLE build artifacts, matched at ANY depth.
 #
@@ -647,16 +649,15 @@ _SKIP_BASENAMES = frozenset({
 # Matched per path SEGMENT rather than as a prefix, because they appear
 # mid-path — e.g. skills/<name>/.tts-venv/lib/python3.11/site-packages/pip/...
 # — which the prefix list above cannot express.
-_SKIP_SEGMENT_NAMES = frozenset({
-    "node_modules",
-    "site-packages",
-    "__pycache__",
-    ".mypy_cache",
-    ".pytest_cache",
-    ".ruff_cache",
-    ".turbo",
-    ".next",
-})
+_SKIP_SEGMENT_NAMES = frozenset(
+    _CHECKPOINT_EXCLUSIONS["segmentNames"]
+)
+_EXACT_VENV_SEGMENTS = frozenset(
+    _CHECKPOINT_EXCLUSIONS["exactVenvSegments"]
+)
+_HIDDEN_VENV_SUFFIX = str(
+    _CHECKPOINT_EXCLUSIONS["hiddenVenvSuffix"]
+)
 
 
 def _is_regenerable_segment(segment: str) -> bool:
@@ -671,9 +672,9 @@ def _is_regenerable_segment(segment: str) -> bool:
     # restored nor uploaded. The two failure modes are not symmetric — an
     # unmatched venv only costs sync time, an over-matched skill loses work —
     # so keep the match narrow and let a stray visible venv ride along.
-    if segment in ("venv", ".venv"):
+    if segment in _EXACT_VENV_SEGMENTS:
         return True
-    return segment.startswith(".") and segment.endswith("-venv")
+    return segment.startswith(".") and segment.endswith(_HIDDEN_VENV_SUFFIX)
 
 
 # Legacy session transcripts.
@@ -721,14 +722,23 @@ def _should_skip_relative(relative: str) -> bool:
     for prefix in _SKIP_RELATIVE_PREFIXES:
         if rel == prefix or rel.startswith(prefix):
             return True
-    basename = Path(rel).name
+    basename = rel.split("/")[-1]
     if basename in _SKIP_BASENAMES:
         return True
-    if _SQLITE_MEMORY_REINDEX_RE.fullmatch(basename):
+    if _matches_skip_basename_pattern(basename):
         return True
     if any(_is_regenerable_segment(seg) for seg in rel.split("/")):
         return True
     return any(rel.endswith(suf) for suf in _SKIP_SUFFIXES)
+
+
+def _is_checkpoint_managed_relative(relative: str) -> bool:
+    """True only for mutable state represented by the atomic checkpoint."""
+    return (
+        relative != "attachments"
+        and not relative.startswith("attachments/")
+        and not _should_skip_relative(relative)
+    )
 
 
 def _preserve_image_owned_relative(relative: str) -> bool:
@@ -739,7 +749,7 @@ def _preserve_image_owned_relative(relative: str) -> bool:
             rel == prefix or rel.startswith(prefix)
             for prefix in _SKIP_RELATIVE_PREFIXES
         )
-        or Path(rel).name in _SKIP_BASENAMES
+        or rel.split("/")[-1] in _SKIP_BASENAMES
         or any(_is_regenerable_segment(part) for part in rel.split("/"))
     )
 
@@ -1133,7 +1143,7 @@ def _iter_workspace_sqlite_sidecars(
                             ))
                             or name.endswith(".reindex-lock.sqlite")
                             or bool(
-                                _SQLITE_MEMORY_REINDEX_RE.fullmatch(name)
+                                _matches_skip_basename_pattern(name)
                             )
                         )
                         if is_sqlite_transient:
@@ -1159,7 +1169,7 @@ def _discard_uncommitted_local_state(
         name = Path(relative).name
         remove_transient = (
             name.endswith(".reindex-lock.sqlite")
-            or bool(_SQLITE_MEMORY_REINDEX_RE.fullmatch(name))
+            or _matches_skip_basename_pattern(name)
         )
         if not remove_transient:
             for suffix in ("-wal", "-shm", "-journal"):
@@ -1576,12 +1586,13 @@ def _generation_for_entries(
     """Hash one complete S3 listing with an unambiguous cross-language format."""
     digest = hashlib.sha256()
     for relative in sorted(entries):
-        if relative == "attachments" or relative.startswith("attachments/"):
-            # Chat ingress writes immutable attachments while holding the
-            # workspace lock, and the wrapper explicitly pulls referenced
-            # attachment paths per turn. Keep them outside mutable-history CAS
-            # so an upload does not force a multi-thousand-object restore.
+        if not _is_checkpoint_managed_relative(relative):
+            # Router inputs, deployed config, telemetry, transient databases,
+            # and regenerable dependency trees are not mutable user history.
+            # Keep the exact exclusion set aligned with the web checkpoint via
+            # workspace_policy.json so neither side hashes a different state.
             continue
+        _validate_workspace_relative(relative)
         size, e_tag = entries[relative]
         path_bytes = relative.encode("utf-8")
         e_tag_bytes = e_tag.encode("utf-8")
@@ -1627,6 +1638,18 @@ def _list_remote_workspace_snapshot(
         for relative in paths:
             if not isinstance(relative, str) or not relative:
                 raise RuntimeError("workspace broker returned invalid path")
+            if _is_checkpoint_managed_relative(relative):
+                rejection_reason = _workspace_relative_rejection_reason(
+                    relative
+                )
+                if rejection_reason is not None:
+                    path_hash = hashlib.sha256(
+                        relative.encode("utf-8", errors="surrogatepass")
+                    ).hexdigest()[:16]
+                    raise WorkspaceRestoreIncomplete(
+                        "restore incompatible workspace path "
+                        f"reason={rejection_reason} path_hash={path_hash}"
+                    )
             if relative in seen_paths:
                 raise RuntimeError("workspace broker returned duplicate path")
             if len(listed_paths) >= MAX_SYNC_FILES:
@@ -1742,13 +1765,27 @@ def pull_workspace(
     if not prefix:
         return 0
 
-    WORKSPACE_DIR.mkdir(parents=True, exist_ok=True)
-
     # Collect the complete listing before choosing downloads. The durable
     # migration marker sorts after agents/* in S3, so deciding page-by-page can
     # mistakenly trim the very JSONL history a first-time migration needs.
     snapshot = _snapshot or _list_remote_workspace_snapshot(prefix)
     listed_paths = list(snapshot.paths)
+    for relative in listed_paths:
+        if not _is_checkpoint_managed_relative(relative):
+            continue
+        rejection_reason = _workspace_relative_rejection_reason(relative)
+        if rejection_reason is not None:
+            path_hash = hashlib.sha256(
+                relative.encode("utf-8", errors="surrogatepass")
+            ).hexdigest()[:16]
+            raise WorkspaceRestoreIncomplete(
+                "restore incompatible workspace path "
+                f"reason={rejection_reason} path_hash={path_hash}"
+            )
+
+    # No local tree mutation is permitted until the entire authoritative path
+    # set has passed the same contract as the web checkpoint.
+    WORKSPACE_DIR.mkdir(parents=True, exist_ok=True)
     listed_sizes = snapshot.sizes
     skipped = 0
     exact_restore_paths = set(listed_paths)
@@ -1853,14 +1890,9 @@ def pull_workspace(
             # with a WAL/SHM file from another point in time.
             skipped += 1
             continue
-        # Validate the lexical key only. The installer walks literal dirfds
-        # with O_NOFOLLOW, so a local symlink cannot redirect committed bytes.
-        try:
-            _validate_workspace_relative(relative)
-        except OSError:
-            logger.warning("workspace pull skip (path escape) %s", relative)
-            skipped += 1
-            continue
+        # The complete authoritative set was validated before any local
+        # mutation. Keep this assertion beside the install boundary too.
+        _validate_workspace_relative(relative)
         to_download.append((relative, listed_sizes.get(relative)))
 
     restored_signatures: dict[str, tuple[int, int, int]] = {}
@@ -2192,6 +2224,21 @@ def _iter_workspace_files(
                     )
                     if _should_skip_relative(relative):
                         continue
+                    rejection_reason = _workspace_relative_rejection_reason(
+                        relative
+                    )
+                    if rejection_reason is not None:
+                        path_hash = hashlib.sha256(
+                            relative.encode(
+                                "utf-8",
+                                errors="surrogatepass",
+                            )
+                        ).hexdigest()[:16]
+                        raise WorkspacePushIncomplete(
+                            "workspace traversal found an incompatible path "
+                            f"reason={rejection_reason} "
+                            f"path_hash={path_hash}"
+                        )
                     try:
                         if entry.is_dir(follow_symlinks=False):
                             if len(Path(relative).parts) <= MAX_SYNC_DEPTH:

--- a/lib/agent-workspace/path-policy.ts
+++ b/lib/agent-workspace/path-policy.ts
@@ -1,0 +1,133 @@
+import { Buffer } from "node:buffer"
+import workspacePolicy from "@/lib/agent-workspace/workspace-policy.json"
+
+export type WorkspacePathRejectionReason =
+  | "empty"
+  | "absolute"
+  | "trailing-slash"
+  | "too-long"
+  | "too-deep"
+  | "empty-segment"
+  | "traversal-segment"
+  | "segment-too-long"
+  | "unsupported-character"
+
+const PRIVATE_PATH_POLICY = workspacePolicy.privatePath
+const CHECKPOINT_EXCLUSIONS = workspacePolicy.checkpointExclusions
+const EXCLUDED_BASENAMES = new Set(CHECKPOINT_EXCLUSIONS.basenames)
+const EXCLUDED_SEGMENT_NAMES = new Set(CHECKPOINT_EXCLUSIONS.segmentNames)
+const EXACT_VENV_SEGMENTS = new Set(
+  CHECKPOINT_EXCLUSIONS.exactVenvSegments,
+)
+const EXCLUDED_BASENAME_PATTERNS =
+  CHECKPOINT_EXCLUSIONS.basenamePatterns.map(
+    // Patterns come only from the versioned, source-controlled policy file.
+    // eslint-disable-next-line security/detect-non-literal-regexp
+    (pattern) => new RegExp(pattern),
+  )
+
+function containsRejectedCodePoint(value: string): boolean {
+  for (const character of value) {
+    const codePoint = character.codePointAt(0)
+    if (
+      codePoint === undefined ||
+      PRIVATE_PATH_POLICY.rejectedCodePointRanges.some(
+        ([start, end]) => codePoint >= start && codePoint <= end,
+      )
+    ) {
+      return true
+    }
+  }
+  return false
+}
+
+/**
+ * Canonical private-workspace path contract shared with workspace_sync.py.
+ * It accepts ordinary POSIX punctuation and Unicode literally; safety comes
+ * from structural traversal bounds and no-follow filesystem operations, not
+ * a shell-oriented filename allowlist.
+ */
+export function workspaceRelativePathRejectionReason(
+  relativePath: string,
+): WorkspacePathRejectionReason | null {
+  if (!relativePath) return "empty"
+  if (relativePath.startsWith("/")) return "absolute"
+  if (relativePath.endsWith("/")) return "trailing-slash"
+  if (
+    Buffer.byteLength(relativePath, "utf8") >
+    PRIVATE_PATH_POLICY.maxUtf8Bytes
+  ) {
+    return "too-long"
+  }
+  if (containsRejectedCodePoint(relativePath)) {
+    return "unsupported-character"
+  }
+
+  const segments = relativePath.split("/")
+  if (segments.length > PRIVATE_PATH_POLICY.maxDepth) return "too-deep"
+  for (const segment of segments) {
+    if (!segment) return "empty-segment"
+    if (segment === "." || segment === "..") {
+      return "traversal-segment"
+    }
+    if (
+      Buffer.byteLength(segment, "utf8") >
+      PRIVATE_PATH_POLICY.maxSegmentUtf8Bytes
+    ) {
+      return "segment-too-long"
+    }
+  }
+  return null
+}
+
+export function validateWorkspaceRelativePath(relativePath: string): string {
+  if (workspaceRelativePathRejectionReason(relativePath)) {
+    throw new Error("Invalid workspace-relative path")
+  }
+  return relativePath
+}
+
+function isRegenerableSegment(segment: string): boolean {
+  if (
+    EXCLUDED_SEGMENT_NAMES.has(segment) ||
+    EXACT_VENV_SEGMENTS.has(segment)
+  ) {
+    return true
+  }
+  return (
+    segment.startsWith(".") &&
+    segment.endsWith(CHECKPOINT_EXCLUSIONS.hiddenVenvSuffix)
+  )
+}
+
+/** Paths intentionally excluded by the runtime in both pull and push. */
+export function isWorkspaceCheckpointExcluded(relativePath: string): boolean {
+  const relative = relativePath.replace(/^\/+/, "")
+  if (
+    CHECKPOINT_EXCLUSIONS.relativePrefixes.some(
+      (prefix) => relative === prefix || relative.startsWith(prefix),
+    )
+  ) {
+    return true
+  }
+  const segments = relative.split("/")
+  const basename = segments.at(-1) ?? ""
+  return (
+    EXCLUDED_BASENAMES.has(basename) ||
+    EXCLUDED_BASENAME_PATTERNS.some((pattern) => pattern.test(basename)) ||
+    segments.some(isRegenerableSegment) ||
+    CHECKPOINT_EXCLUSIONS.suffixes.some((suffix) =>
+      relative.endsWith(suffix),
+    )
+  )
+}
+
+export function isCheckpointManagedWorkspacePath(
+  relativePath: string,
+): boolean {
+  return (
+    relativePath !== "attachments" &&
+    !relativePath.startsWith("attachments/") &&
+    !isWorkspaceCheckpointExcluded(relativePath)
+  )
+}

--- a/lib/agent-workspace/storage-broker.ts
+++ b/lib/agent-workspace/storage-broker.ts
@@ -36,10 +36,16 @@ import {
   releaseResourceAdmission,
 } from "@/lib/resource-admission"
 import { createLogger } from "@/lib/logger"
+import {
+  isCheckpointManagedWorkspacePath,
+  validateWorkspaceRelativePath,
+  workspaceRelativePathRejectionReason,
+} from "@/lib/agent-workspace/path-policy"
+
+export { validateWorkspaceRelativePath } from "@/lib/agent-workspace/path-policy"
 
 const log = createLogger({ module: "workspace-storage-broker" })
 
-const MAX_RELATIVE_PATH_LENGTH = 768
 const MAX_LIST_KEYS = 1_000
 export const MAX_PRIVATE_UPLOAD_BYTES = 256 * 1024 * 1024
 export const MAX_PUBLIC_ARTIFACT_BYTES = 100 * 1024 * 1024
@@ -51,8 +57,9 @@ const UPLOAD_RESERVATION_MS = 5 * 60 * 1000
 const SHA256_BASE64_RE = /^[A-Za-z0-9+/]{43}=$/
 const WORKSPACE_GENERATION_RE = /^[0-9a-f]{64}$/
 const MAX_WORKSPACE_GENERATION_OBJECTS = 250_000
-const WORKSPACE_CHECKPOINT_VERSION = 1 as const
-const WORKSPACE_CHECKPOINT_CONTROL_PREFIX = ".workspace-checkpoints/v1"
+const WORKSPACE_CHECKPOINT_VERSION = 2 as const
+const WORKSPACE_CHECKPOINT_CONTROL_PREFIX = ".workspace-checkpoints/v2"
+const LEGACY_WORKSPACE_CHECKPOINT_CONTROL_PREFIX = ".workspace-checkpoints/v1"
 const MAX_WORKSPACE_CHECKPOINT_BYTES = 64 * 1024 * 1024
 const WORKSPACE_CHECKPOINT_CONCURRENCY = 32
 const CONTENT_TYPE_RE =
@@ -97,7 +104,7 @@ export function workspaceReservationCountsAsRetained(
     status as (typeof RETAINED_UPLOAD_STATUSES)[number],
   )
 }
-const SAFE_PATH_SEGMENT = /^[A-Za-z0-9._@+= -]+$/
+const SAFE_PUBLIC_ARTIFACT_NAME = /^[A-Za-z0-9._@+= -]+$/
 const PUBLIC_EXTENSIONS = new Set([
   ".csv",
   ".html",
@@ -620,30 +627,6 @@ function bucketName(): string {
   return bucket
 }
 
-export function validateWorkspaceRelativePath(relativePath: string): string {
-  if (
-    !relativePath ||
-    relativePath.length > MAX_RELATIVE_PATH_LENGTH ||
-    relativePath.startsWith("/") ||
-    relativePath.endsWith("/")
-  ) {
-    throw new Error("Invalid workspace-relative path")
-  }
-  const segments = relativePath.split("/")
-  if (
-    segments.some(
-      (segment) =>
-        !segment ||
-        segment === "." ||
-        segment === ".." ||
-        !SAFE_PATH_SEGMENT.test(segment)
-    )
-  ) {
-    throw new Error("Invalid workspace-relative path")
-  }
-  return segments.join("/")
-}
-
 function validateTrustedPrefix(prefix: string): string {
   const normalized = prefix.replace(/^\/+|\/+$/g, "")
   if (!normalized || normalized.includes("..") || normalized.includes("\\")) {
@@ -656,17 +639,17 @@ export function ownerWorkspaceKey(
   signedWorkspacePrefix: string,
   relativePath: string
 ): string {
-  return `${validateTrustedPrefix(signedWorkspacePrefix)}/${validateWorkspaceRelativePath(relativePath)}`
+  const key = `${validateTrustedPrefix(signedWorkspacePrefix)}/${validateWorkspaceRelativePath(relativePath)}`
+  if (Buffer.byteLength(key, "utf8") > 1_024) {
+    throw new Error("Invalid workspace object key length")
+  }
+  return key
 }
 
 export type WorkspaceGenerationEntry = {
   path: string
   size: number
   eTag: string
-}
-
-function isRouterOwnedWorkspacePath(path: string): boolean {
-  return path === "attachments" || path.startsWith("attachments/")
 }
 
 /**
@@ -680,7 +663,11 @@ export function workspaceGenerationFromEntries(
 ): string {
   const digest = createHash("sha256")
   const sorted = [...entries]
-    .filter((entry) => !isRouterOwnedWorkspacePath(entry.path))
+    .filter((entry) => isCheckpointManagedWorkspacePath(entry.path))
+    .map((entry) => ({
+      ...entry,
+      path: validateWorkspaceRelativePath(entry.path),
+    }))
     .sort((left, right) =>
       Buffer.compare(
         Buffer.from(left.path, "utf8"),
@@ -717,7 +704,9 @@ export function workspaceGenerationFromEntries(
 
 export function publicArtifactKey(ownerEmail: string, fileName: string): string {
   const safeName = validateWorkspaceRelativePath(fileName)
-  if (safeName.includes("/")) throw new Error("Public artifact name must be a file name")
+  if (safeName.includes("/") || !SAFE_PUBLIC_ARTIFACT_NAME.test(safeName)) {
+    throw new Error("Invalid public artifact name")
+  }
   const extensionIndex = safeName.lastIndexOf(".")
   const extension = extensionIndex === -1 ? "" : safeName.slice(extensionIndex).toLowerCase()
   if (!PUBLIC_EXTENSIONS.has(extension)) {
@@ -772,24 +761,46 @@ export async function listWorkspaceObjects(
 
   const entries = (response.Contents ?? [])
     .filter((entry): entry is typeof entry & { Key: string } =>
-      Boolean(entry.Key?.startsWith(prefix))
+      Boolean(
+        entry.Key?.startsWith(prefix) && entry.Key.length > prefix.length,
+      )
     )
-    .map((entry) => ({
-      path: entry.Key.slice(prefix.length),
-      size: entry.Size ?? 0,
-      // Epoch SECONDS. The restore only ever compares these to each other to
-      // rank recency, so second resolution is ample and avoids shipping a
-      // date-string the client would have to parse.
-      lastModified: entry.LastModified
-        ? Math.floor(entry.LastModified.getTime() / 1000)
-        : 0,
-      // ETag is the collision-resistant object generation token the agent
-      // image uses to prove a warm workspace has not gone stale between lock
-      // acquisition and its final checkpoint. Keep the raw opaque value:
-      // multipart/copy ETags are not necessarily content MD5s.
-      eTag: entry.ETag ?? "",
-    }))
-    .filter((entry) => entry.path.length > 0)
+    .map((entry) => {
+      const path = entry.Key.slice(prefix.length)
+      const rejectionReason = isCheckpointManagedWorkspacePath(path)
+        ? workspaceRelativePathRejectionReason(path)
+        : null
+      if (rejectionReason) {
+        log.warn(
+          "Persisted workspace path is incompatible with the storage contract",
+          {
+            pathHash: createHash("sha256")
+              .update(path)
+              .digest("hex")
+              .slice(0, 16),
+            rejectionReason,
+          },
+        )
+        throw new WorkspaceStorageCompletionError(
+          "Persisted workspace path is incompatible with the storage contract",
+        )
+      }
+      return {
+        path,
+        size: entry.Size ?? 0,
+        // Epoch SECONDS. The restore only ever compares these to each other to
+        // rank recency, so second resolution is ample and avoids shipping a
+        // date-string the client would have to parse.
+        lastModified: entry.LastModified
+          ? Math.floor(entry.LastModified.getTime() / 1000)
+          : 0,
+        // ETag is the collision-resistant object generation token the agent
+        // image uses to prove a warm workspace has not gone stale between lock
+        // acquisition and its final checkpoint. Keep the raw opaque value:
+        // multipart/copy ETags are not necessarily content MD5s.
+        eTag: entry.ETag ?? "",
+      }
+    })
 
   return {
     // `paths` is RETAINED for compatibility. Containers deploy independently of
@@ -882,14 +893,33 @@ async function readWorkspaceGenerationSnapshot(
   }
 }
 
-function checkpointNamespace(signedWorkspacePrefix: string): string {
+function checkpointNamespaceForControlPrefix(
+  signedWorkspacePrefix: string,
+  controlPrefix: string,
+): string {
   const prefix = validateTrustedPrefix(signedWorkspacePrefix)
   const prefixHash = createHash("sha256").update(prefix).digest("hex")
-  return `${WORKSPACE_CHECKPOINT_CONTROL_PREFIX}/${prefixHash}`
+  return `${controlPrefix}/${prefixHash}`
+}
+
+function checkpointNamespace(signedWorkspacePrefix: string): string {
+  return checkpointNamespaceForControlPrefix(
+    signedWorkspacePrefix,
+    WORKSPACE_CHECKPOINT_CONTROL_PREFIX,
+  )
 }
 
 function checkpointManifestKey(signedWorkspacePrefix: string): string {
   return `${checkpointNamespace(signedWorkspacePrefix)}/manifest.json`
+}
+
+function legacyCheckpointManifestKey(
+  signedWorkspacePrefix: string,
+): string {
+  return `${checkpointNamespaceForControlPrefix(
+    signedWorkspacePrefix,
+    LEGACY_WORKSPACE_CHECKPOINT_CONTROL_PREFIX,
+  )}/manifest.json`
 }
 
 function checkpointAnchorKey(
@@ -906,7 +936,7 @@ function mutableWorkspaceEntries(
   snapshot: WorkspaceGenerationSnapshot,
 ): WorkspaceGenerationEntry[] {
   return [...snapshot.entries.values()]
-    .filter((entry) => !isRouterOwnedWorkspacePath(entry.path))
+    .filter((entry) => isCheckpointManagedWorkspacePath(entry.path))
     .sort((left, right) =>
       Buffer.compare(
         Buffer.from(left.path, "utf8"),
@@ -938,6 +968,8 @@ async function mapWithWorkspaceCheckpointConcurrency<T, U>(
   if (values.length === 0) return []
   const results = Array.from({ length: values.length }) as U[]
   let nextIndex = 0
+  let failed = false
+  let firstError: unknown
   const workers = Array.from(
     {
       length: Math.min(
@@ -946,15 +978,24 @@ async function mapWithWorkspaceCheckpointConcurrency<T, U>(
       ),
     },
     async () => {
-      while (true) {
+      while (!failed) {
         const index = nextIndex
         nextIndex += 1
         if (index >= values.length) return
-        results[index] = await operation(values[index]!, index)
+        try {
+          results[index] = await operation(values[index]!, index)
+        } catch (error) {
+          if (!failed) {
+            failed = true
+            firstError = error
+          }
+          return
+        }
       }
     },
   )
   await Promise.all(workers)
+  if (failed) throw firstError
   return results
 }
 
@@ -998,8 +1039,8 @@ function parseWorkspaceCheckpointManifest(
     const entry = rawEntry as Record<string, unknown>
     if (
       typeof entry.path !== "string" ||
-      validateWorkspaceRelativePath(entry.path) !== entry.path ||
-      isRouterOwnedWorkspacePath(entry.path) ||
+      workspaceRelativePathRejectionReason(entry.path) !== null ||
+      !isCheckpointManagedWorkspacePath(entry.path) ||
       seenPaths.has(entry.path) ||
       !Number.isSafeInteger(entry.size) ||
       (entry.size as number) < 0 ||
@@ -1097,6 +1138,25 @@ async function readWorkspaceCheckpointManifest(
     )
   }
   return parseWorkspaceCheckpointManifest(parsed, signedWorkspacePrefix)
+}
+
+async function assertNoLegacyWorkspaceCheckpoint(
+  signedWorkspacePrefix: string,
+): Promise<void> {
+  try {
+    await s3Client().send(
+      new HeadObjectCommand({
+        Bucket: bucketName(),
+        Key: legacyCheckpointManifestKey(signedWorkspacePrefix),
+      }),
+    )
+  } catch (error) {
+    if (isS3ObjectNotFound(error)) return
+    throw error
+  }
+  throw new WorkspaceStorageCompletionError(
+    "Legacy workspace checkpoint must be recovered before v2 bootstrap",
+  )
 }
 
 async function writeWorkspaceCheckpointManifest(
@@ -1396,6 +1456,7 @@ export async function ensureWorkspaceCheckpoint(
         signedWorkspacePrefix,
       )
       if (!manifest) {
+        await assertNoLegacyWorkspaceCheckpoint(signedWorkspacePrefix)
         manifest = await captureWorkspaceCheckpointManifest(
           signedWorkspacePrefix,
           snapshot,
@@ -1599,7 +1660,7 @@ export async function deleteWorkspacePath(
 }> {
   const path = validateWorkspaceRelativePath(relativePath)
   if (
-    isRouterOwnedWorkspacePath(path) ||
+    !isCheckpointManagedWorkspacePath(path) ||
     !WORKSPACE_GENERATION_RE.test(expectedGeneration)
   ) {
     throw new Error("Invalid workspace delete request")
@@ -1953,6 +2014,9 @@ export async function createWorkspaceUploadUrl(
   )
   const checksum = expectedChecksum(checksumSha256)
   const normalizedContentType = expectedContentType(contentType)
+  if (!isCheckpointManagedWorkspacePath(relativePath)) {
+    throw new Error("Invalid workspace upload path")
+  }
   const targetKey = ownerWorkspaceKey(signedWorkspacePrefix, relativePath)
   const params: PrivateUploadParameters = {
     ownerEmail,
@@ -2251,6 +2315,12 @@ async function reconstructCommittedPrivateUpload(
       "Workspace upload target does not match its signed prefix",
     )
   }
+  const relativePath = reservation.targetKey.slice(prefix.length)
+  if (!isCheckpointManagedWorkspacePath(relativePath)) {
+    throw new WorkspaceStorageCompletionError(
+      "Workspace upload target is not mutable user state",
+    )
+  }
   const eTag = await committedUploadMatches(
     reservation.targetKey,
     reservation.objectVersionId,
@@ -2266,7 +2336,6 @@ async function reconstructCommittedPrivateUpload(
   const snapshot = await readWorkspaceGenerationSnapshot(
     signedWorkspacePrefix,
   )
-  const relativePath = reservation.targetKey.slice(prefix.length)
   const listed = snapshot.entries.get(relativePath)
   if (
     !listed ||
@@ -2301,9 +2370,9 @@ async function recoverVerifyingPrivateUpload(
     )
   }
   const relativePath = reservation.targetKey.slice(prefix.length)
-  if (isRouterOwnedWorkspacePath(relativePath)) {
+  if (!isCheckpointManagedWorkspacePath(relativePath)) {
     throw new WorkspaceStorageCompletionError(
-      "Router-owned attachments cannot be recovered by workspace sync",
+      "Workspace upload target is not mutable user state",
     )
   }
   let metadata
@@ -2738,9 +2807,9 @@ async function finishClaimedUpload(
         )
       }
       targetRelativePath = claimed.targetKey.slice(prefix.length)
-      if (isRouterOwnedWorkspacePath(targetRelativePath)) {
+      if (!isCheckpointManagedWorkspacePath(targetRelativePath)) {
         throw new WorkspaceStorageCompletionError(
-          "Router-owned attachments cannot be promoted by workspace sync",
+          "Workspace upload target is not mutable user state",
         )
       }
       generationSnapshot = await readWorkspaceGenerationSnapshot(

--- a/lib/agent-workspace/workspace-policy.json
+++ b/lib/agent-workspace/workspace-policy.json
@@ -1,0 +1,73 @@
+{
+  "version": 1,
+  "privatePath": {
+    "maxUtf8Bytes": 768,
+    "maxSegmentUtf8Bytes": 255,
+    "maxDepth": 64,
+    "rejectedCodePointRanges": [
+      [0, 31],
+      [92, 92],
+      [127, 159],
+      [1564, 1564],
+      [8206, 8207],
+      [8232, 8238],
+      [8294, 8297],
+      [55296, 57343]
+    ]
+  },
+  "checkpointExclusions": {
+    "relativePrefixes": [
+      "openclaw.json",
+      "openclaw.json.bak",
+      "agents/main/agent/models.json",
+      "logs/",
+      "update-check.json",
+      ".openclaw/",
+      "SOUL.md",
+      "skills/gws-",
+      "skills/psd-brand-guidelines/",
+      "skills/psd-credentials/",
+      "skills/psd-data/",
+      "skills/psd-failure-report/",
+      "skills/psd-freshservice/",
+      "skills/psd-github/",
+      "skills/psd-html-artifact/",
+      "skills/psd-html-output/",
+      "skills/psd-image-gen/",
+      "skills/psd-redrover/",
+      "skills/psd-rules/",
+      "skills/psd-schedules/",
+      "skills/psd-skills-meta/",
+      "skills/psd-workspace/"
+    ],
+    "suffixes": [
+      ".sock",
+      ".pid",
+      ".sqlite-wal",
+      ".sqlite-shm",
+      ".sqlite-journal",
+      ".reindex-lock.sqlite"
+    ],
+    "basenames": [
+      "plugins.sync.lock"
+    ],
+    "basenamePatterns": [
+      "^.+\\.sqlite\\.memory-reindex-[0-9A-Fa-f-]+(?:-(?:wal|shm|journal))?$"
+    ],
+    "segmentNames": [
+      "node_modules",
+      "site-packages",
+      "__pycache__",
+      ".mypy_cache",
+      ".pytest_cache",
+      ".ruff_cache",
+      ".turbo",
+      ".next"
+    ],
+    "exactVenvSegments": [
+      "venv",
+      ".venv"
+    ],
+    "hiddenVenvSuffix": "-venv"
+  }
+}

--- a/scripts/agent-workspace/audit-live-workspace-paths.ts
+++ b/scripts/agent-workspace/audit-live-workspace-paths.ts
@@ -1,0 +1,376 @@
+import { createHash } from "node:crypto"
+import { spawnSync } from "node:child_process"
+import { fileURLToPath } from "node:url"
+import {
+  DynamoDBClient,
+  ScanCommand,
+  type AttributeValue,
+} from "@aws-sdk/client-dynamodb"
+import {
+  paginateListObjectsV2,
+  S3Client,
+} from "@aws-sdk/client-s3"
+import {
+  isCheckpointManagedWorkspacePath,
+  workspaceRelativePathRejectionReason,
+  type WorkspacePathRejectionReason,
+} from "@/lib/agent-workspace/path-policy"
+import {
+  workspaceGenerationFromEntries,
+  type WorkspaceGenerationEntry,
+} from "@/lib/agent-workspace/storage-broker"
+
+type AuditOptions = {
+  bucket: string
+  environment: string
+  region: string
+}
+
+type PathFailure = {
+  ownerHash: string
+  pathHash: string
+  reason: WorkspacePathRejectionReason
+}
+
+type WorkspaceAudit = {
+  ownerHash: string
+  objects: number
+  checkpointManagedObjects: number
+  excludedObjects: number
+  maxPathBytes: number
+  maxDepth: number
+  failures: PathFailure[]
+  conflicts: Array<{ ownerHash: string; pathHash: string }>
+  entries: Array<
+    WorkspaceGenerationEntry & {
+      expectedReason: WorkspacePathRejectionReason | null
+      expectedManaged: boolean
+    }
+  >
+}
+
+type PythonParityResult = {
+  classificationMismatches: string[]
+  generationMismatches: string[]
+}
+
+type CheckpointControlAudit = {
+  objects: number
+  currentVersionObjects: number
+  legacyV1ObjectHashes: string[]
+  unknownObjectHashes: string[]
+}
+
+function parseArgs(argv: readonly string[]): AuditOptions {
+  const values = new Map<string, string>()
+  for (let index = 0; index < argv.length; index += 2) {
+    const flag = argv[index]
+    const value = argv[index + 1]
+    if (!flag?.startsWith("--") || !value || value.startsWith("--")) {
+      throw new Error(
+        "Usage: audit-live-workspace-paths.ts --bucket <name> --environment <name> [--region <region>]",
+      )
+    }
+    values.set(flag, value)
+  }
+  const bucket = values.get("--bucket")
+  const environment = values.get("--environment")
+  const region = values.get("--region") ?? process.env.AWS_REGION ?? "us-east-1"
+  if (!bucket || !environment) {
+    throw new Error("Both --bucket and --environment are required")
+  }
+  return { bucket, environment, region }
+}
+
+function shortHash(value: string): string {
+  return createHash("sha256").update(value).digest("hex").slice(0, 16)
+}
+
+function workspacePrefixFromItem(
+  item: Record<string, AttributeValue>,
+): string | null {
+  const value = item.workspacePrefix
+  return value && "S" in value && typeof value.S === "string" && value.S
+    ? value.S
+    : null
+}
+
+async function registeredWorkspacePrefixes(
+  environment: string,
+  region: string,
+): Promise<string[]> {
+  const client = new DynamoDBClient({ region })
+  const tableName = `psd-agent-users-${environment}`
+  const prefixes = new Set<string>()
+  let exclusiveStartKey: Record<string, AttributeValue> | undefined
+  do {
+    const page = await client.send(
+      new ScanCommand({
+        TableName: tableName,
+        ProjectionExpression: "workspacePrefix",
+        ExclusiveStartKey: exclusiveStartKey,
+      }),
+    )
+    for (const item of page.Items ?? []) {
+      const prefix = workspacePrefixFromItem(item)
+      if (prefix) prefixes.add(prefix)
+    }
+    exclusiveStartKey = page.LastEvaluatedKey
+  } while (exclusiveStartKey)
+  if (prefixes.size === 0) {
+    throw new Error(`No registered workspace prefixes found in ${tableName}`)
+  }
+  return [...prefixes].sort()
+}
+
+function findPrefixConflict(paths: ReadonlySet<string>): string | null {
+  for (const path of paths) {
+    const segments = path.split("/")
+    for (let index = 1; index < segments.length; index += 1) {
+      if (paths.has(segments.slice(0, index).join("/"))) return path
+    }
+  }
+  return null
+}
+
+async function auditCheckpointControlNamespace(
+  client: S3Client,
+  bucket: string,
+): Promise<CheckpointControlAudit> {
+  const prefix = ".workspace-checkpoints/"
+  let objects = 0
+  let currentVersionObjects = 0
+  const legacyV1ObjectHashes: string[] = []
+  const unknownObjectHashes: string[] = []
+  for await (const page of paginateListObjectsV2(
+    { client, pageSize: 1_000 },
+    { Bucket: bucket, Prefix: prefix },
+  )) {
+    for (const object of page.Contents ?? []) {
+      const key = object.Key
+      if (!key?.startsWith(prefix)) continue
+      objects += 1
+      if (key.startsWith(`${prefix}v2/`)) {
+        currentVersionObjects += 1
+      } else if (key.startsWith(`${prefix}v1/`)) {
+        legacyV1ObjectHashes.push(shortHash(key))
+      } else {
+        unknownObjectHashes.push(shortHash(key))
+      }
+    }
+  }
+  return {
+    objects,
+    currentVersionObjects,
+    legacyV1ObjectHashes,
+    unknownObjectHashes,
+  }
+}
+
+async function auditWorkspace(
+  client: S3Client,
+  bucket: string,
+  workspacePrefix: string,
+): Promise<WorkspaceAudit> {
+  const paths = new Set<string>()
+  const entries = new Map<string, WorkspaceAudit["entries"][number]>()
+  const failures: PathFailure[] = []
+  const ownerHash = shortHash(workspacePrefix)
+  let checkpointManagedObjects = 0
+  let excludedObjects = 0
+  let maxPathBytes = 0
+  let maxDepth = 0
+  for await (const page of paginateListObjectsV2(
+    { client, pageSize: 1_000 },
+    { Bucket: bucket, Prefix: `${workspacePrefix}/` },
+  )) {
+    for (const object of page.Contents ?? []) {
+      if (!object.Key?.startsWith(`${workspacePrefix}/`)) continue
+      const relativePath = object.Key.slice(workspacePrefix.length + 1)
+      if (!relativePath) continue
+      paths.add(relativePath)
+      maxPathBytes = Math.max(
+        maxPathBytes,
+        Buffer.byteLength(relativePath, "utf8"),
+      )
+      maxDepth = Math.max(maxDepth, relativePath.split("/").length)
+      const expectedReason = workspaceRelativePathRejectionReason(relativePath)
+      const expectedManaged = isCheckpointManagedWorkspacePath(relativePath)
+      entries.set(relativePath, {
+        path: relativePath,
+        size: object.Size ?? 0,
+        eTag: object.ETag ?? "",
+        expectedReason,
+        expectedManaged,
+      })
+      if (expectedManaged) {
+        checkpointManagedObjects += 1
+        if (expectedReason) {
+          failures.push({
+            ownerHash,
+            pathHash: shortHash(relativePath),
+            reason: expectedReason,
+          })
+        }
+      } else {
+        excludedObjects += 1
+      }
+    }
+  }
+  const conflict = findPrefixConflict(paths)
+  return {
+    ownerHash,
+    objects: paths.size,
+    checkpointManagedObjects,
+    excludedObjects,
+    maxPathBytes,
+    maxDepth,
+    failures,
+    conflicts: conflict
+      ? [{ ownerHash, pathHash: shortHash(conflict) }]
+      : [],
+    entries: [...entries.values()],
+  }
+}
+
+function parsePythonParityResult(output: string): PythonParityResult {
+  const parsed: unknown = JSON.parse(output)
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error("Python workspace policy probe returned invalid output")
+  }
+  const candidate = parsed as Record<string, unknown>
+  const classificationMismatches = candidate.classificationMismatches
+  const generationMismatches = candidate.generationMismatches
+  if (
+    !Array.isArray(classificationMismatches) ||
+    !classificationMismatches.every((value) => typeof value === "string") ||
+    !Array.isArray(generationMismatches) ||
+    !generationMismatches.every((value) => typeof value === "string")
+  ) {
+    throw new Error("Python workspace policy probe returned invalid output")
+  }
+  return { classificationMismatches, generationMismatches }
+}
+
+function verifyPythonRuntimeParity(
+  audits: readonly WorkspaceAudit[],
+): PythonParityResult {
+  const probePath = fileURLToPath(
+    new URL("./workspace-policy-probe.py", import.meta.url),
+  )
+  const workspaces = audits.map((audit) => ({
+    ownerHash: audit.ownerHash,
+    expectedGeneration: workspaceGenerationFromEntries(audit.entries),
+    entries: audit.entries,
+  }))
+  const result = spawnSync(
+    process.env.PYTHON ?? "python3",
+    [probePath],
+    {
+      input: JSON.stringify({ workspaces }),
+      encoding: "utf8",
+      maxBuffer: 16 * 1024 * 1024,
+    },
+  )
+  if (result.error || result.status !== 0) {
+    throw new Error("Python workspace policy probe failed")
+  }
+  return parsePythonParityResult(result.stdout)
+}
+
+async function mapWithConcurrency<T, U>(
+  values: readonly T[],
+  concurrency: number,
+  operation: (value: T) => Promise<U>,
+): Promise<U[]> {
+  const results = Array.from({ length: values.length }) as U[]
+  let nextIndex = 0
+  const workers = Array.from(
+    { length: Math.min(concurrency, values.length) },
+    async () => {
+      while (true) {
+        const index = nextIndex
+        nextIndex += 1
+        if (index >= values.length) return
+        results[index] = await operation(values[index]!)
+      }
+    },
+  )
+  await Promise.all(workers)
+  return results
+}
+
+async function main(): Promise<void> {
+  const options = parseArgs(process.argv.slice(2))
+  const prefixes = await registeredWorkspacePrefixes(
+    options.environment,
+    options.region,
+  )
+  const client = new S3Client({ region: options.region })
+  const [controlAudit, audits] = await Promise.all([
+    auditCheckpointControlNamespace(client, options.bucket),
+    mapWithConcurrency(prefixes, 8, (prefix) =>
+      auditWorkspace(client, options.bucket, prefix),
+    ),
+  ])
+  const populated = audits.filter((audit) => audit.objects > 0)
+  const failures = audits.flatMap((audit) => audit.failures)
+  const conflicts = audits.flatMap((audit) => audit.conflicts)
+  const parity =
+    failures.length === 0 && conflicts.length === 0
+      ? verifyPythonRuntimeParity(audits)
+      : {
+          classificationMismatches: [],
+          generationMismatches: [],
+        }
+  const summary = {
+    environment: options.environment,
+    registeredWorkspaces: prefixes.length,
+    populatedWorkspaces: populated.length,
+    objects: audits.reduce((sum, audit) => sum + audit.objects, 0),
+    checkpointManagedObjects: audits.reduce(
+      (sum, audit) => sum + audit.checkpointManagedObjects,
+      0,
+    ),
+    excludedObjects: audits.reduce(
+      (sum, audit) => sum + audit.excludedObjects,
+      0,
+    ),
+    largestWorkspaceObjects: Math.max(
+      0,
+      ...audits.map((audit) => audit.objects),
+    ),
+    largestWorkspaceCheckpointObjects: Math.max(
+      0,
+      ...audits.map((audit) => audit.checkpointManagedObjects),
+    ),
+    maxPathBytes: Math.max(0, ...audits.map((audit) => audit.maxPathBytes)),
+    maxDepth: Math.max(0, ...audits.map((audit) => audit.maxDepth)),
+    checkpointControlObjects: controlAudit.objects,
+    currentV2CheckpointControlObjects: controlAudit.currentVersionObjects,
+    legacyV1CheckpointObjectHashes: controlAudit.legacyV1ObjectHashes,
+    unknownCheckpointObjectHashes: controlAudit.unknownObjectHashes,
+    incompatiblePaths: failures,
+    fileDescendantConflicts: conflicts,
+    pythonClassificationMismatches: parity.classificationMismatches,
+    pythonGenerationMismatches: parity.generationMismatches,
+  }
+  process.stdout.write(`${JSON.stringify(summary, null, 2)}\n`)
+  if (
+    failures.length > 0 ||
+    conflicts.length > 0 ||
+    parity.classificationMismatches.length > 0 ||
+    parity.generationMismatches.length > 0 ||
+    controlAudit.legacyV1ObjectHashes.length > 0 ||
+    controlAudit.unknownObjectHashes.length > 0
+  ) {
+    process.exitCode = 1
+  }
+}
+
+main().catch((error: unknown) => {
+  process.stderr.write(
+    `Workspace compatibility audit failed: ${error instanceof Error ? error.message : String(error)}\n`,
+  )
+  process.exitCode = 1
+})

--- a/scripts/agent-workspace/workspace-policy-probe.py
+++ b/scripts/agent-workspace/workspace-policy-probe.py
@@ -1,0 +1,78 @@
+"""Compare live workspace metadata with the actual Python image contract."""
+
+import hashlib
+import json
+import sys
+from pathlib import Path
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPOSITORY_ROOT / "infra" / "agent-image"))
+
+import workspace_sync  # noqa: E402
+
+
+def _short_hash(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()[:16]
+
+
+def main() -> None:
+    payload = json.load(sys.stdin)
+    workspaces = payload.get("workspaces")
+    if not isinstance(workspaces, list):
+        raise ValueError("invalid parity-probe payload")
+
+    classification_mismatches = []
+    generation_mismatches = []
+    for workspace in workspaces:
+        if not isinstance(workspace, dict):
+            raise ValueError("invalid parity-probe workspace")
+        owner_hash = workspace.get("ownerHash")
+        entries = workspace.get("entries")
+        if not isinstance(owner_hash, str) or not isinstance(entries, list):
+            raise ValueError("invalid parity-probe workspace")
+        generation_entries = {}
+        for entry in entries:
+            if not isinstance(entry, dict):
+                raise ValueError("invalid parity-probe entry")
+            path = entry.get("path")
+            size = entry.get("size")
+            e_tag = entry.get("eTag")
+            if (
+                not isinstance(path, str)
+                or not isinstance(size, int)
+                or not isinstance(e_tag, str)
+            ):
+                raise ValueError("invalid parity-probe entry")
+            python_reason = (
+                workspace_sync._workspace_relative_rejection_reason(path)
+            )
+            python_managed = (
+                workspace_sync._is_checkpoint_managed_relative(path)
+            )
+            if (
+                python_reason != entry.get("expectedReason")
+                or python_managed != entry.get("expectedManaged")
+            ):
+                classification_mismatches.append(
+                    f"{owner_hash}:{_short_hash(path)}"
+                )
+            generation_entries[path] = (size, e_tag)
+        generation = workspace_sync._generation_for_entries(
+            generation_entries
+        )
+        if generation != workspace.get("expectedGeneration"):
+            generation_mismatches.append(owner_hash)
+
+    json.dump(
+        {
+            "classificationMismatches": classification_mismatches,
+            "generationMismatches": generation_mismatches,
+        },
+        sys.stdout,
+        ensure_ascii=False,
+    )
+    sys.stdout.write("\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/agent-image-openclaw-runtime-patch.test.ts
+++ b/tests/unit/agent-image-openclaw-runtime-patch.test.ts
@@ -8,6 +8,10 @@ const { readFileSync } = validatedFs
 const repoRoot = join(__dirname, "..", "..")
 const imageDir = join(repoRoot, "infra", "agent-image")
 const dockerfile = readFileSync(join(imageDir, "Dockerfile"), "utf8")
+const buildScript = readFileSync(
+  join(imageDir, "build-and-push.sh"),
+  "utf8",
+)
 const runtimePatch = readFileSync(
   join(imageDir, "openclaw_runtime_patch.mjs"),
   "utf8"
@@ -15,7 +19,12 @@ const runtimePatch = readFileSync(
 
 describe("pinned OpenClaw runtime backports", () => {
   it("ships and executes the patch before making /app immutable", () => {
-    expect(dockerfile).toContain("COPY *.py *.mjs /app/")
+    expect(dockerfile).toContain(
+      "COPY *.py *.mjs workspace_policy.json /app/",
+    )
+    expect(buildScript).toContain(
+      'cp "${CANONICAL_WORKSPACE_POLICY}" "${STAGED_WORKSPACE_POLICY}"',
+    )
     expect(dockerfile).toContain(
       "RUN node /app/openclaw_runtime_patch.mjs /app/dist"
     )

--- a/tests/unit/lib/agent-workspace/path-policy.test.ts
+++ b/tests/unit/lib/agent-workspace/path-policy.test.ts
@@ -1,0 +1,57 @@
+import contractCases from "@/infra/agent-image/workspace_path_contract_cases.json"
+import {
+  isCheckpointManagedWorkspacePath,
+  validateWorkspaceRelativePath,
+  workspaceRelativePathRejectionReason,
+} from "@/lib/agent-workspace/path-policy"
+
+describe("canonical private workspace path policy", () => {
+  it.each(contractCases.valid)("accepts %s", (path) => {
+    expect(validateWorkspaceRelativePath(path)).toBe(path)
+    expect(workspaceRelativePathRejectionReason(path)).toBeNull()
+  })
+
+  it.each(contractCases.invalid)(
+    "rejects $reason for $path",
+    ({ path, reason }) => {
+      expect(workspaceRelativePathRejectionReason(path)).toBe(reason)
+      expect(() => validateWorkspaceRelativePath(path)).toThrow(
+        "Invalid workspace-relative path",
+      )
+    },
+  )
+
+  it("applies UTF-8 byte, segment, and depth bounds", () => {
+    expect(workspaceRelativePathRejectionReason("a".repeat(769))).toBe(
+      "too-long",
+    )
+    expect(
+      workspaceRelativePathRejectionReason(`${"a".repeat(256)}/file`),
+    ).toBe("segment-too-long")
+    expect(
+      workspaceRelativePathRejectionReason(
+        Array.from({ length: 65 }, () => "a").join("/"),
+      ),
+    ).toBe("too-deep")
+    expect(workspaceRelativePathRejectionReason("é".repeat(385))).toBe(
+      "too-long",
+    )
+    expect(
+      workspaceRelativePathRejectionReason(
+        `surrogate-${String.fromCharCode(0xD800)}`,
+      ),
+    ).toBe("unsupported-character")
+  })
+
+  it("shares checkpoint exclusions with the image runtime", () => {
+    expect(
+      isCheckpointManagedWorkspacePath(
+        "skills/example/.tts-venv/lib/site-packages/pkg/file.py",
+      ),
+    ).toBe(false)
+    expect(isCheckpointManagedWorkspacePath("node_modules/pkg/index.js")).toBe(
+      false,
+    )
+    expect(isCheckpointManagedWorkspacePath("memory/notes (v2).md")).toBe(true)
+  })
+})

--- a/tests/unit/lib/agent-workspace/storage-broker-checkpoint.test.ts
+++ b/tests/unit/lib/agent-workspace/storage-broker-checkpoint.test.ts
@@ -75,6 +75,10 @@ class VersionedS3 {
   }> = []
   sequence = 0
   failNextManifestPutAfterWrite = false
+  beforeCommand?: (
+    name: string,
+    input: Record<string, unknown>,
+  ) => Promise<void>
 
   add(
     key: string,
@@ -149,6 +153,7 @@ class VersionedS3 {
     const name = typed.constructor.name
     const input = typed.input
     this.commands.push({ name, input })
+    await this.beforeCommand?.(name, input)
     const key = String(input.Key ?? "")
 
     if (name === "ListObjectsV2Command") {
@@ -289,6 +294,11 @@ function workspaceGeneration(
 }
 
 function manifestKey(): string {
+  const prefixHash = createHash("sha256").update(PREFIX).digest("hex")
+  return `.workspace-checkpoints/v2/${prefixHash}/manifest.json`
+}
+
+function legacyManifestKey(): string {
   const prefixHash = createHash("sha256").update(PREFIX).digest("hex")
   return `.workspace-checkpoints/v1/${prefixHash}/manifest.json`
 }
@@ -434,6 +444,137 @@ describe("durable workspace checkpoints", () => {
       ),
     ).toHaveLength(0)
     expect(store.current(manifestKey())?.scope).toBe("Scope=checkpoint")
+  })
+
+  it("accepts legacy punctuation and excludes regenerable trees from the checkpoint", async () => {
+    const durable = store.add(`${PREFIX}/memory/Review (draft), [v2].md`, {
+      size: 4,
+      eTag: '"durable"',
+      body: "keep",
+      scope: "Scope=private",
+    })
+    for (let index = 0; index < 5_500; index += 1) {
+      store.add(
+        `${PREFIX}/skills/example/.tts-venv/lib/python3.11/site-packages/pkg-${index}/script (dev).tmpl`,
+        {
+          size: 1,
+          eTag: `"generated-${index}"`,
+          body: "x",
+        },
+      )
+    }
+
+    const result = await ensureWorkspaceCheckpoint(PREFIX)
+
+    expect(result.workspaceGeneration).toBe(
+      workspaceGeneration([
+        {
+          path: "memory/Review (draft), [v2].md",
+          size: 4,
+          eTag: '"durable"',
+        },
+      ]),
+    )
+    expect(manifest().entries).toEqual([
+      expect.objectContaining({
+        path: "memory/Review (draft), [v2].md",
+        versionId: durable.versionId,
+      }),
+    ])
+    expect(
+      store.commands.filter(
+        (command) =>
+          command.name === "HeadObjectCommand" &&
+          String(command.input.Key).startsWith(`${PREFIX}/`),
+      ),
+    ).toHaveLength(1)
+  })
+
+  it("refuses to bless current state while a legacy v1 boundary exists", async () => {
+    const legacyBody = JSON.stringify({
+      version: 1,
+      entries: [{ path: "node_modules/legacy/index.js" }],
+    })
+    store.add(legacyManifestKey(), {
+      size: Buffer.byteLength(legacyBody),
+      eTag: '"legacy-manifest"',
+      body: legacyBody,
+      scope: "Scope=checkpoint",
+    })
+    store.add(`${PREFIX}/memory/durable.md`, {
+      size: 4,
+      eTag: '"durable"',
+      body: "keep",
+      scope: "Scope=private",
+    })
+
+    await expect(ensureWorkspaceCheckpoint(PREFIX)).rejects.toThrow(
+      "Legacy workspace checkpoint must be recovered before v2 bootstrap",
+    )
+
+    expect(store.current(manifestKey())).toBeUndefined()
+    expect(store.current(legacyManifestKey())?.body).toBe(legacyBody)
+  })
+
+  it("waits for every in-flight checkpoint worker before releasing the owner lock", async () => {
+    store.add(`${PREFIX}/memory/a.md`, {
+      size: 1,
+      eTag: '"a"',
+      body: "a",
+    })
+    store.add(`${PREFIX}/memory/b.md`, {
+      size: 1,
+      eTag: '"b"',
+      body: "b",
+    })
+    let finishSlow: (() => void) | undefined
+    const slow = new Promise<void>((resolve) => {
+      finishSlow = resolve
+    })
+    let slowSettled = false
+    let lockReleased = false
+    store.beforeCommand = async (name, input) => {
+      if (name !== "HeadObjectCommand") return
+      const key = String(input.Key)
+      if (key.endsWith("/memory/a.md")) {
+        throw new Error("checkpoint metadata failed")
+      }
+      if (key.endsWith("/memory/b.md")) {
+        await slow
+        slowSettled = true
+      }
+    }
+    withSessionMock.mockImplementation(
+      async (...args: unknown[]) => {
+        const callback = args[0] as (session: {
+          executeQuery: AsyncUnknownMock
+          executeTransaction: AsyncUnknownMock
+        }) => Promise<unknown>
+        return callback({
+          executeQuery: async (...queryArgs: unknown[]) => {
+            if (queryArgs[1] === "tryFenceWorkspaceUploadCompletion") {
+              return [{ acquired: true }]
+            }
+            if (queryArgs[1] === "releaseWorkspaceUploadCompletionFence") {
+              lockReleased = true
+              expect(slowSettled).toBe(true)
+              return [{ released: true }]
+            }
+            return executeQueryMock(...queryArgs)
+          },
+          executeTransaction: (...transactionArgs: unknown[]) =>
+            executeTransactionMock(...transactionArgs),
+        })
+      },
+    )
+
+    const checkpoint = ensureWorkspaceCheckpoint(PREFIX)
+    await new Promise((resolve) => setImmediate(resolve))
+    expect(lockReleased).toBe(false)
+    finishSlow?.()
+
+    await expect(checkpoint).rejects.toThrow("checkpoint metadata failed")
+    expect(lockReleased).toBe(true)
   })
 
   it("recovers a crash-partial batch, preserves history, and idempotently commits the retry", async () => {

--- a/tests/unit/lib/agent-workspace/storage-broker-list.test.ts
+++ b/tests/unit/lib/agent-workspace/storage-broker-list.test.ts
@@ -144,4 +144,38 @@ describe("listWorkspaceObjects", () => {
     expect(result.continuationToken).toBe("next-page")
     expect(send.mock.calls[0][0].input.ContinuationToken).toBe("prev-page")
   })
+
+  it("returns ordinary punctuation from persisted user history", async () => {
+    send.mockResolvedValue({
+      Contents: [
+        {
+          Key: `${PREFIX}/memory/Review (draft), [v2].md`,
+          Size: 4,
+          LastModified: new Date(),
+          ETag: '"punctuation"',
+        },
+      ],
+    })
+
+    const result = await listWorkspaceObjects(PREFIX)
+
+    expect(result.paths).toEqual(["memory/Review (draft), [v2].md"])
+  })
+
+  it("fails closed before returning an incompatible durable path", async () => {
+    send.mockResolvedValue({
+      Contents: [
+        {
+          Key: `${PREFIX}/memory/bad\\name.md`,
+          Size: 4,
+          LastModified: new Date(),
+          ETag: '"invalid"',
+        },
+      ],
+    })
+
+    await expect(listWorkspaceObjects(PREFIX)).rejects.toThrow(
+      "Persisted workspace path is incompatible with the storage contract",
+    )
+  })
 })

--- a/tests/unit/lib/agent-workspace/storage-broker-upload.test.ts
+++ b/tests/unit/lib/agent-workspace/storage-broker-upload.test.ts
@@ -80,7 +80,7 @@ function installCheckpointAwareS3(
 ): void {
   let responseIndex = 0
   let manifest = {
-    version: 1,
+    version: 2,
     signedWorkspacePrefix: "users/owner",
     workspaceGeneration: workspaceGenerationFromEntries(entries),
     entries: entries.map((entry, index) => ({
@@ -1334,7 +1334,7 @@ function defineVerifiedWorkspaceUploadReservationsSuite1Part6() {
       eTag: '"remote-old"',
     }])
     let checkpointManifest = {
-      version: 1,
+      version: 2,
       signedWorkspacePrefix: "users/owner",
       workspaceGeneration: expectedGeneration,
       entries: [{


### PR DESCRIPTION
Fixes the live AgentCore restore failure caused by divergent TypeScript and Python workspace path policies. Adds one canonical policy, checkpoint v2 fail-closed migration guards, exact dev/prod fleet audits with live cross-runtime classification and generation parity, large-workspace/concurrency regressions, and safe frontend-first cutover enforcement. Verification: Python workspace suites 68/68; focused broker/image Jest suites 73/73; full lint; shell/diff checks; dev 11,980 objects and prod 12,265 objects audited with zero incompatibilities, conflicts, control objects, or cross-runtime mismatches. E2E intentionally skipped per release direction because it does not exercise this fix.