### PR TITLE
fix(agent): safely retire generated exec approval state

### DIFF
--- a/docs/operations/agent-image-build-gate.md
+++ b/docs/operations/agent-image-build-gate.md
@@ -1,44 +1,59 @@
 # Agent Image Build-Time Eval Gate (#1161)
 
 `infra/agent-image/build-and-push.sh` refuses to push an agent image that has
-not been proven to boot and answer. This page documents the gate's seven checks,
+not been proven to boot and answer. This page documents the gate's eight checks,
 how to satisfy the runtime half, and how to override it when you must.
 
 The gate exists because the image is an artifact optimised against an
-evaluator, and four separate regressions reached production before it did:
+evaluator, and five separate regressions reached production before it did:
 a dead-boot image (r10), a missing provider (r11), a silently truncated
-`SOUL.md`, and a broker/image path-policy mismatch that made populated
-workspaces unrestorable. Every one of them is caught before push by the checks
-below.
+`SOUL.md`, a broker/image path-policy mismatch that made populated workspaces
+unrestorable, and generated `exec-approvals.json` host state restored as user
+history. Every one of them is caught before push by the checks below.
 
-## The seven checks
+## The eight checks
 
 | # | Check | Kind | Fails on |
 |---|-------|------|----------|
 | 1 | Instruction-budget (`check_bootstrap_budget.py`) | static | a bootstrap file that would be truncated at boot |
 | 2 | Config self-consistency (`check_config_consistency.py`) | static | bad `contextWindow`, `apiKey` hydration, plugin compatibility, web-search readiness, a stale host schema, or a host missing settled-tool finalization in `openclaw.json` / `Dockerfile` |
 | 3 | Cross-language workspace persistence contract | static | the Python sync/runtime tests or TypeScript broker integration tests fail |
-| 4 | Existing dev + prod workspace inventory | AWS read-only | any registered workspace contains durable state the candidate cannot round-trip, or the real TypeScript/Python classifications or generation hashes disagree |
+| 4 | Existing dev + prod workspace inventory | AWS read-only | any registered workspace contains durable state the candidate cannot round-trip, the real TypeScript/Python classifications or generation hashes disagree, or any bucket object would retire a non-generated exec-approval policy / interrupted claim |
 | 5 | Plugin-aware config validation | build | the complete config is invalid after the pinned custom plugins are installed |
-| 6 | Boot probe | runtime | no `BOOT_OK` within `PROBE_BOOT_TIMEOUT` (default 120s) |
-| 7 | Canary turn | runtime | `/invocations` does not answer `OK` |
+| 6 | Restored host-state contract | runtime | the image would restore retired exec-approval JSON, bakes that state into the image, or lacks canonical SQLite state |
+| 7 | Boot probe | runtime | no `BOOT_OK` within `PROBE_BOOT_TIMEOUT` (default 120s) |
+| 8 | Canary turn | runtime | `/invocations` does not answer `OK` |
 
 Static checks run before the build. Plugin-aware validation runs inside the
 image after the official Bedrock and Parallel plugins are installed. The
 runtime checks run against the freshly built image, before `docker push`.
+Check 6 is hermetic: it reads the exact policy staged into the image, verifies
+both the retired source and interrupted-Doctor claim are excluded, verifies
+neither is baked into the image, contaminates the image workspace with both a
+file and directory form, proves the warm-runtime cleanup removes them, and
+requires the canonical OpenClaw SQLite state. The static checkpoint regression
+also loads a real pre-policy v2
+manifest and proves normalization retains every durable entry and both owner
+objects without copying or deleting workspace data.
 The inventory gate reads the authoritative workspace-prefix registries and
-every current S3 key in both dev and prod. It rejects incompatible durable
-state, then sends the same in-memory inventory through the actual Python image
-classifier and generation implementation and compares those results with the
-actual TypeScript broker. Excluded dependency/runtime trees are counted but do
-not block a build merely because they contain a path neither runtime restores.
-The gate emits aggregate counts and stable hashes only, performs no writes, and
-cannot be bypassed by `SKIP_STATIC_GATE=1`. This closes the gap where an empty
-canary passed while a normal filename already present in saved user history
-could not be restored.
+every current S3 key in both dev and prod, including orphaned workspace
+prefixes. It rejects incompatible durable state, then sends the same in-memory
+inventory through the actual Python image classifier and generation
+implementation and compares those results with the actual TypeScript broker.
+For the two retired exec-approval paths it bounded-reads the exact listed ETag,
+never logs the body or token, and permits only the pinned runtime's generated
+socket-only shape (empty defaults and empty agents). Any malformed body,
+policy, allowlist, unknown field, changed object, or interrupted Doctor claim
+fails closed. Excluded dependency/runtime trees are counted but do not block a
+build merely because they contain a path neither runtime restores. The gate
+emits aggregate counts and stable hashes only, performs no writes, and cannot
+be bypassed by `SKIP_STATIC_GATE=1`. This closes the gap where an empty canary
+passed while a normal filename already present in saved user history could not
+be restored.
 It also fails on any legacy v1 or unknown checkpoint-control object. The
-paused cutover runs the same audit again after all old writers drain, closing
-the time gap between image build and frontend deployment.
+paused cutover runs the same audit after all old writers drain and once more
+after deleting the old Runtime, closing both the build-to-deploy gap and the
+old wrapper's final shutdown-write window.
 
 Issue #1469 added a fail-closed host contract to check 2. The pinned OpenClaw
 runtime must contain its one-shot, tools-disabled finalization for a settled
@@ -107,7 +122,7 @@ buckets. If any lookup or audit fails, the build **stops**.
 
 ### Building a one-axis candidate
 
-Candidate manifests use the same command and all seven gates:
+Candidate manifests use the same command and all eight gates:
 
 ```bash
 cd infra/agent-image
@@ -247,7 +262,7 @@ than it must:
 | Flag | Disables | When |
 |------|----------|------|
 | `ALLOW_UNVERIFIED_IMAGE=1` | turns a *skipped* runtime probe from a hard failure into a warning | you cannot reach the broker (no credentials, environment not deployed) and accept an unverified image |
-| `SKIP_PROBE_GATE=1` | checks 6–7 entirely, even when they could run | the probe itself is broken and blocking a release |
+| `SKIP_PROBE_GATE=1` | checks 6–8 entirely, even when they could run | the probe itself is broken and blocking a release |
 | `SKIP_STATIC_GATE=1` | checks 1–3 | true emergency only — these are pure file checks with no external dependency; the dev+prod inventory audit still runs |
 | `REQUIRE_PROBE_GATE=1` | nothing; **outranks** `ALLOW_UNVERIFIED_IMAGE` | CI, so an opt-in inherited from the environment cannot weaken the pipeline |
 

--- a/docs/operations/agent-platform-setup.md
+++ b/docs/operations/agent-platform-setup.md
@@ -362,6 +362,14 @@ AgentCore keeps existing sessions on the image version with which their
 microVM was created, so rotating `AGENT_BUILD_TAG` prevents new calls from
 reusing an old microVM but does not terminate that old writer.
 
+This pause is also required when retiring a checkpoint path. The current
+broker excludes the exact generated `exec-approvals.json` source (and an
+interrupted Doctor claim) from listings and normalizes the one older v2
+manifest that recorded it. The owner object itself is deliberately retained.
+An old frontend task must never run checkpoint recovery after that
+normalization, because its older policy would treat the retained object as an
+uncommitted extra. Wait for ECS steady state before recreating AgentCore.
+
 The hard cutover below deliberately removes and recreates only the
 CloudFormation-managed AgentCore Runtime. The workspace bucket and every
 object version remain in place. It also preserves the enabled/disabled state
@@ -620,9 +628,14 @@ bun run scripts/agent-workspace/audit-live-workspace-paths.ts \
   --region "$AWS_REGION"
 ```
 
-The audit is read-only. It must report empty
+The audit is read-only. It scans the whole bucket, including orphaned prefixes,
+and bounded-reads only the retired exec-approval source objects. It must report
+zero interrupted claims and empty `retiredExecApprovalFailures`,
 `legacyV1CheckpointObjectHashes`, `unknownCheckpointObjectHashes`, path,
-conflict, and TypeScript/Python parity failure arrays before continuing.
+conflict, and TypeScript/Python parity failure arrays before continuing. A
+retired source is safe only when it is the exact generated socket-only shape;
+any defaults, agent policy, allowlist, malformed body, or changed ETag stops the
+cutover without exposing the socket token.
 
 ##### 3. Remove the old runtime before changing the broker
 
@@ -660,6 +673,22 @@ test "$(aws cloudformation describe-stacks \
 
 Do not proceed if either assertion fails. A failed deletion means an old image
 may still write during its shutdown path.
+
+Runtime deletion invokes the old wrapper's shutdown finalizer, so close that
+last-write window by running the same read-only bucket audit one final time
+after the old Runtime is confirmed absent and before deploying the broker:
+
+```bash
+bun run scripts/agent-workspace/audit-live-workspace-paths.ts \
+  --bucket "$WORKSPACE_BUCKET" \
+  --environment "$CUTOVER_ENV" \
+  --region "$AWS_REGION"
+```
+
+Do not continue unless the final audit again reports zero interrupted claims
+and no retired exec-approval, checkpoint-control, path, conflict, or parity
+failures. Keep ingress and schedules paused through this check and the broker
+and Runtime deployments below.
 
 ##### 4. Apply migration 171, then deploy the storage broker
 

--- a/infra/agent-image/build-and-push.sh
+++ b/infra/agent-image/build-and-push.sh
@@ -95,11 +95,13 @@ if [ -n "$(git -C "${REPO_ROOT}" status --porcelain --untracked-files=all -- \
     app/api/agent/workspace-storage/route.ts \
     lib/agent-workspace/storage-broker.ts \
     lib/agent-workspace/path-policy.ts \
+    lib/agent-workspace/retired-exec-approvals.ts \
     lib/agent-workspace/workspace-policy.json \
     scripts/agent-workspace/audit-live-workspace-paths.ts \
     scripts/agent-workspace/workspace-policy-probe.py \
     tests/unit/agent-image-openclaw-runtime-patch.test.ts \
     tests/unit/lib/agent-workspace/path-policy.test.ts \
+    tests/unit/lib/agent-workspace/retired-exec-approvals.test.ts \
     tests/unit/lib/agent-workspace/storage-broker-checkpoint.test.ts \
     tests/unit/lib/agent-workspace/storage-broker-list.test.ts \
     tests/unit/lib/agent-workspace/storage-broker-upload.test.ts \
@@ -180,16 +182,19 @@ echo ""
 #   1. instruction-budget gate   (static, no Docker)   — over-budget bootstrap
 #   2. config self-consistency   (static, no Docker)   — bad config/provider pins
 #   3. path-contract parity      (static, no Docker)   — broker/image drift
-#   4. dev+prod inventory audit (AWS read-only)       — unrestorable history
+#   4. dev+prod inventory audit (AWS read-only)       — unrestorable history /
+#                                                       unsafe retired policy
 #   5. plugin-aware validation  (Docker build)        — invalid complete config
-#   6. boot probe               (runtime, needs image) — dead-boot (no BOOT_OK)
-#   7. canary turn              (runtime, needs image) — non-answering agent
+#   6. host-state probe         (runtime, local image) — restored legacy gate
+#   7. boot probe               (runtime, needs image) — dead-boot (no BOOT_OK)
+#   8. canary turn              (runtime, needs image) — non-answering agent
 # Would have stopped r10 (dead-boot), r11 (missing provider), and the weeks-long
 # SOUL.md truncation on a laptop instead of in prod.
 #
 # Two separate bypasses, so an emergency doesn't disable more than it must:
-#   SKIP_PROBE_GATE=1   skips only the RUNTIME boot-probe + canary turn (checks
-#                       6-7) — reserved for a broken probe blocking releases.
+#   SKIP_PROBE_GATE=1   skips only the RUNTIME host-state, boot, and canary
+#                       checks (6-8) — reserved for a broken probe blocking
+#                       releases.
 #   SKIP_STATIC_GATE=1  skips the cheap STATIC checks (1-3). These are pure file
 #                       checks with no external dependency and essentially never
 #                       need bypassing — this exists only for a true emergency,
@@ -240,6 +245,7 @@ else
   fi
   if ! bun run --cwd "${REPO_ROOT}" test -- --runInBand --silent \
         "${REPO_ROOT}/tests/unit/lib/agent-workspace/path-policy.test.ts" \
+        "${REPO_ROOT}/tests/unit/lib/agent-workspace/retired-exec-approvals.test.ts" \
         "${REPO_ROOT}/tests/unit/lib/agent-workspace/storage-broker.test.ts" \
         "${REPO_ROOT}/tests/unit/lib/agent-workspace/storage-broker-list.test.ts" \
         "${REPO_ROOT}/tests/unit/lib/agent-workspace/storage-broker-upload.test.ts" \
@@ -363,11 +369,17 @@ rm -f "${STAGED_WORKSPACE_POLICY}"
 # unverified image reaching ECR is exactly the outcome #1161 exists to prevent.
 if [ "${SKIP_PROBE_GATE:-0}" = "1" ]; then
   echo ""
-  echo "WARNING: SKIP_PROBE_GATE=1 — runtime boot/canary probe BYPASSED."
+  echo "WARNING: SKIP_PROBE_GATE=1 — runtime host-state/boot/canary probes BYPASSED."
   echo "         This image is NOT boot-verified. See docs/operations/agent-image-build-gate.md"
 else
   echo ""
-  echo "=== Build-time eval gate (1161): runtime boot probe + canary turn ==="
+  echo "=== Build-time eval gate (1161): host-state + boot + canary probes ==="
+  echo "Image-local restored host-state contract probe..."
+  docker run --rm --platform linux/arm64 --user node \
+    --entrypoint python3 "${ECR_URI}:${TAG}" \
+    /app/probe_workspace_state_contract.py
+  echo "  Restored host-state contract probe PASSED."
+  echo ""
   PROBE_APP_BASE_URL="${AGENT_PROBE_APP_BASE_URL:-}"
   PROBE_INVOCATION_CONTEXT="${AGENT_PROBE_INVOCATION_CONTEXT:-}"
   PROBE_REQUEST_PROOF_KEY="${AGENT_PROBE_REQUEST_PROOF_KEY:-}"

--- a/infra/agent-image/probe_workspace_state_contract.py
+++ b/infra/agent-image/probe_workspace_state_contract.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""Verify the built image cannot restore retired exec-approval host state."""
+
+import workspace_sync
+
+
+RETIRED_PATHS = (
+    "exec-approvals.json",
+    "exec-approvals.json.doctor-importing",
+)
+
+
+def main() -> None:
+    for relative in RETIRED_PATHS:
+        if not workspace_sync._should_skip_relative(relative):
+            raise RuntimeError(f"retired host state is sync-eligible: {relative}")
+        if workspace_sync._is_checkpoint_managed_relative(relative):
+            raise RuntimeError(f"retired host state is checkpoint-managed: {relative}")
+        if (workspace_sync.WORKSPACE_DIR / relative).exists():
+            raise RuntimeError(f"retired host state is baked into image: {relative}")
+
+    # Exercise the actual warm-microVM cleanup path in the built image. The
+    # source is a regular file and the interrupted claim is a directory so the
+    # no-follow removal contract covers both shapes OpenClaw would otherwise
+    # treat as a blocking legacy presence.
+    source = workspace_sync.WORKSPACE_DIR / RETIRED_PATHS[0]
+    claim = workspace_sync.WORKSPACE_DIR / RETIRED_PATHS[1]
+    source.write_bytes(b"stale host token")
+    claim.mkdir()
+    (claim / "partial").write_bytes(b"interrupted")
+    workspace_sync._discard_retired_local_control_state()
+    for path in (source, claim):
+        if path.exists():
+            raise RuntimeError(f"retired host state survived cleanup: {path.name}")
+
+    canonical_state = workspace_sync.WORKSPACE_DIR / "state/openclaw.sqlite"
+    if not canonical_state.is_file():
+        raise RuntimeError("canonical OpenClaw SQLite state is missing")
+
+    print("Workspace host-state contract probe PASSED")
+
+
+if __name__ == "__main__":
+    main()

--- a/infra/agent-image/test_workspace_path_contract.py
+++ b/infra/agent-image/test_workspace_path_contract.py
@@ -88,6 +88,22 @@ class WorkspacePathContractTests(unittest.TestCase):
             )
         )
 
+    def test_exec_approvals_compatibility_state_is_checkpoint_excluded(self):
+        for relative in (
+            "exec-approvals.json",
+            "exec-approvals.json.doctor-importing",
+        ):
+            with self.subTest(relative=relative):
+                self.assertTrue(workspace_sync._should_skip_relative(relative))
+                self.assertFalse(
+                    workspace_sync._is_checkpoint_managed_relative(relative)
+                )
+        self.assertTrue(
+            workspace_sync._is_checkpoint_managed_relative(
+                "exec-approvals.json.backup"
+            )
+        )
+
     def test_shallow_image_layout_uses_adjacent_staged_policy(self):
         with tempfile.TemporaryDirectory() as directory:
             image_dir = Path(directory) / "app"

--- a/infra/agent-image/test_workspace_sync.py
+++ b/infra/agent-image/test_workspace_sync.py
@@ -762,7 +762,15 @@ class WorkspaceGenerationFenceTests(unittest.TestCase):
                 (self.root / "memory" / "MEMORY.md").read_bytes(),
                 remote["body"],
             )
+            retired_source = self.root / "exec-approvals.json"
+            retired_source.write_bytes(b"stale host token")
+            retired_claim = (
+                self.root / "exec-approvals.json.doctor-importing"
+            )
+            retired_claim.mkdir()
             self.assertEqual(workspace_sync.refresh_workspace("owner"), 0)
+            self.assertFalse(retired_source.exists())
+            self.assertFalse(retired_claim.exists())
 
         self.assertEqual(
             downloads,
@@ -885,6 +893,10 @@ class WorkspaceGenerationFenceTests(unittest.TestCase):
         attachment.write_bytes(b"router-owned")
         (self.root / "IDENTITY.md").write_bytes(b"stale model bytes")
         (self.root / "SOUL.md").write_bytes(b"image-owned soul")
+        retired_source = self.root / "exec-approvals.json"
+        retired_source.write_bytes(b"stale runtime control")
+        retired_claim = self.root / "exec-approvals.json.doctor-importing"
+        retired_claim.write_bytes(b"interrupted migration")
         empty_generation = workspace_sync._generation_for_entries({})
 
         def broker(payload, **_kwargs):
@@ -923,6 +935,8 @@ class WorkspaceGenerationFenceTests(unittest.TestCase):
             (self.root / "SOUL.md").read_bytes(),
             b"image-owned soul",
         )
+        self.assertFalse(retired_source.exists())
+        self.assertFalse(retired_claim.exists())
         self.assertNotIn(
             "owner",
             workspace_sync._force_exact_workspace_restores,

--- a/infra/agent-image/workspace_sync.py
+++ b/infra/agent-image/workspace_sync.py
@@ -623,9 +623,13 @@ def _materialize_empty_workspace_file(
 # intentionally NOT on this list — those are agent-written, user-owned,
 # and must round-trip.
 #
-# Match is: "skip if the relative path equals or starts with any entry".
-# The values live in workspace_policy.json so the web checkpoint and image
-# runtime cannot silently drift into different definitions of durable state.
+# Exact paths and prefix paths are separate so retiring one generated control
+# file can never hide similarly named user content. The values live in
+# workspace_policy.json so the web checkpoint and image runtime cannot
+# silently drift into different definitions of durable state.
+_SKIP_EXACT_PATHS = frozenset(
+    _CHECKPOINT_EXCLUSIONS["exactPaths"]
+)
 _SKIP_RELATIVE_PREFIXES = tuple(
     _CHECKPOINT_EXCLUSIONS["relativePrefixes"]
 )
@@ -719,6 +723,8 @@ def _is_imported_legacy_state(relative: str) -> bool:
 def _should_skip_relative(relative: str) -> bool:
     """True if this workspace-relative path is gateway-owned, not user memory."""
     rel = relative.lstrip("/")
+    if rel in _SKIP_EXACT_PATHS:
+        return True
     for prefix in _SKIP_RELATIVE_PREFIXES:
         if rel == prefix or rel.startswith(prefix):
             return True
@@ -922,6 +928,39 @@ def _remove_workspace_entry_no_follow(
     finally:
         os.close(directory_fd)
     os.rmdir(name, dir_fd=parent_fd)
+
+
+def _discard_retired_local_control_state(
+    deadline_monotonic: float | None = None,
+) -> None:
+    """Remove retired exact host-state paths before OpenClaw can probe them.
+
+    These paths are neither image-owned nor user history. Pinned OpenClaw
+    refuses to start while either one exists, so a contaminated warm microVM
+    must not preserve them merely because checkpoint sync excludes them.
+    """
+    workspace_fd = os.open(
+        WORKSPACE_DIR,
+        os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW,
+    )
+    try:
+        for relative in sorted(_SKIP_EXACT_PATHS):
+            _remaining_timeout(deadline_monotonic, 60)
+            parts = Path(relative).parts
+            if len(parts) != 1 or parts[0] in ("", ".", ".."):
+                raise WorkspaceRestoreIncomplete(
+                    "retired control-state path is not root-relative"
+                )
+            try:
+                _remove_workspace_entry_no_follow(
+                    workspace_fd,
+                    parts[0],
+                    deadline_monotonic=deadline_monotonic,
+                )
+            except FileNotFoundError:
+                continue
+    finally:
+        os.close(workspace_fd)
 
 
 def _prepare_committed_remote_parents(
@@ -1966,6 +2005,10 @@ def refresh_workspace(prefix: str) -> int:
     """Refresh a warm workspace after the owner-wide lock changes hands."""
     if not prefix:
         return 0
+    # The gateway is stopped before refresh. Remove retired OpenClaw host
+    # control files even when the durable generation is unchanged; otherwise
+    # its migration gate can keep a reused microVM permanently bricked.
+    _discard_retired_local_control_state()
     checkpoint_generation = _ensure_workspace_checkpoint(prefix)
     snapshot = _list_remote_workspace_snapshot(prefix)
     if snapshot.generation is None:

--- a/lib/agent-workspace/path-policy.ts
+++ b/lib/agent-workspace/path-policy.ts
@@ -14,6 +14,7 @@ export type WorkspacePathRejectionReason =
 
 const PRIVATE_PATH_POLICY = workspacePolicy.privatePath
 const CHECKPOINT_EXCLUSIONS = workspacePolicy.checkpointExclusions
+const EXCLUDED_EXACT_PATHS = new Set(CHECKPOINT_EXCLUSIONS.exactPaths)
 const EXCLUDED_BASENAMES = new Set(CHECKPOINT_EXCLUSIONS.basenames)
 const EXCLUDED_SEGMENT_NAMES = new Set(CHECKPOINT_EXCLUSIONS.segmentNames)
 const EXACT_VENV_SEGMENTS = new Set(
@@ -104,6 +105,7 @@ function isRegenerableSegment(segment: string): boolean {
 export function isWorkspaceCheckpointExcluded(relativePath: string): boolean {
   const relative = relativePath.replace(/^\/+/, "")
   if (
+    EXCLUDED_EXACT_PATHS.has(relative) ||
     CHECKPOINT_EXCLUSIONS.relativePrefixes.some(
       (prefix) => relative === prefix || relative.startsWith(prefix),
     )

--- a/lib/agent-workspace/retired-exec-approvals.ts
+++ b/lib/agent-workspace/retired-exec-approvals.ts
@@ -1,0 +1,193 @@
+export const RETIRED_EXEC_APPROVALS_SOURCE_PATH = "exec-approvals.json"
+export const RETIRED_EXEC_APPROVALS_CLAIM_PATH =
+  "exec-approvals.json.doctor-importing"
+export const MAX_RETIRED_EXEC_APPROVALS_BYTES = 4 * 1024
+
+const EXPECTED_SOCKET_PATH = "/home/node/.openclaw/exec-approvals.sock"
+const TOKEN_PATTERN = /^[A-Za-z0-9_-]{32}$/
+const TOP_LEVEL_FIELDS = new Set([
+  "version",
+  "socket",
+  "defaults",
+  "agents",
+])
+const SOCKET_FIELDS = new Set(["path", "token"])
+
+export type RetiredExecApprovalsValidationReason =
+  | "claim-present"
+  | "unexpected-path"
+  | "body-too-large"
+  | "invalid-size"
+  | "missing-etag"
+  | "etag-mismatch"
+  | "size-mismatch"
+  | "body-size-mismatch"
+  | "invalid-utf8"
+  | "malformed-json"
+  | "invalid-top-level"
+  | "unknown-top-level-field"
+  | "missing-top-level-field"
+  | "unsupported-version"
+  | "invalid-socket"
+  | "unknown-socket-field"
+  | "missing-socket-field"
+  | "invalid-socket-path"
+  | "invalid-socket-token"
+  | "invalid-defaults"
+  | "nonempty-defaults"
+  | "invalid-agents"
+  | "nonempty-agents"
+
+type RetiredExecApprovalsReadMetadata = {
+  size: number
+  eTag: string
+}
+
+type RetiredExecApprovalsRead = RetiredExecApprovalsReadMetadata & {
+  body: Uint8Array
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+function fieldSetReason(
+  value: Record<string, unknown>,
+  allowed: ReadonlySet<string>,
+  required: readonly string[],
+  unknownReason:
+    | "unknown-top-level-field"
+    | "unknown-socket-field",
+  missingReason:
+    | "missing-top-level-field"
+    | "missing-socket-field",
+): RetiredExecApprovalsValidationReason | null {
+  if (Object.keys(value).some((field) => !allowed.has(field))) {
+    return unknownReason
+  }
+  if (required.some((field) => !Object.hasOwn(value, field))) {
+    return missingReason
+  }
+  return null
+}
+
+function validateSocket(
+  socket: unknown,
+): RetiredExecApprovalsValidationReason | null {
+  if (!isRecord(socket)) return "invalid-socket"
+  const socketFields = fieldSetReason(
+    socket,
+    SOCKET_FIELDS,
+    ["path", "token"],
+    "unknown-socket-field",
+    "missing-socket-field",
+  )
+  if (socketFields) return socketFields
+  if (socket.path !== EXPECTED_SOCKET_PATH) return "invalid-socket-path"
+  if (typeof socket.token !== "string" || !TOKEN_PATTERN.test(socket.token)) {
+    return "invalid-socket-token"
+  }
+  return null
+}
+
+function validateEmptyPolicyMap(
+  value: unknown,
+  invalidReason: "invalid-defaults" | "invalid-agents",
+  nonemptyReason: "nonempty-defaults" | "nonempty-agents",
+): RetiredExecApprovalsValidationReason | null {
+  if (!isRecord(value)) return invalidReason
+  return Object.keys(value).length === 0 ? null : nonemptyReason
+}
+
+/**
+ * Only the generated source is safe to retire. An interrupted migration claim
+ * is evidence of unknown state and must always stop the release audit.
+ */
+export function validateRetiredExecApprovalsPath(
+  relativePath: string,
+): RetiredExecApprovalsValidationReason | null {
+  if (relativePath === RETIRED_EXEC_APPROVALS_SOURCE_PATH) return null
+  if (relativePath === RETIRED_EXEC_APPROVALS_CLAIM_PATH) {
+    return "claim-present"
+  }
+  return "unexpected-path"
+}
+
+/**
+ * Validate the exact OpenClaw-generated, socket-only approvals control file.
+ * The result deliberately contains no parsed fields so callers cannot log the
+ * socket token or source body by accident.
+ */
+export function validateRetiredExecApprovalsBody(
+  body: Uint8Array,
+): RetiredExecApprovalsValidationReason | null {
+  if (body.byteLength > MAX_RETIRED_EXEC_APPROVALS_BYTES) {
+    return "body-too-large"
+  }
+
+  let text: string
+  try {
+    text = new TextDecoder("utf-8", { fatal: true }).decode(body)
+  } catch {
+    return "invalid-utf8"
+  }
+
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(text) as unknown
+  } catch {
+    return "malformed-json"
+  }
+  if (!isRecord(parsed)) return "invalid-top-level"
+
+  const topLevelFields = fieldSetReason(
+    parsed,
+    TOP_LEVEL_FIELDS,
+    ["version", "socket", "defaults", "agents"],
+    "unknown-top-level-field",
+    "missing-top-level-field",
+  )
+  if (topLevelFields) return topLevelFields
+  if (parsed.version !== 1) return "unsupported-version"
+
+  const socketReason = validateSocket(parsed.socket)
+  if (socketReason) return socketReason
+  const defaultsReason = validateEmptyPolicyMap(
+    parsed.defaults,
+    "invalid-defaults",
+    "nonempty-defaults",
+  )
+  if (defaultsReason) return defaultsReason
+  return validateEmptyPolicyMap(
+    parsed.agents,
+    "invalid-agents",
+    "nonempty-agents",
+  )
+}
+
+/** Validate that a bounded conditional read still represents the listed S3 object. */
+export function validateRetiredExecApprovalsRead(
+  expected: RetiredExecApprovalsReadMetadata,
+  actual: RetiredExecApprovalsRead,
+): RetiredExecApprovalsValidationReason | null {
+  if (
+    !Number.isSafeInteger(expected.size) ||
+    expected.size < 0 ||
+    !Number.isSafeInteger(actual.size) ||
+    actual.size < 0
+  ) {
+    return "invalid-size"
+  }
+  if (
+    expected.size > MAX_RETIRED_EXEC_APPROVALS_BYTES ||
+    actual.size > MAX_RETIRED_EXEC_APPROVALS_BYTES ||
+    actual.body.byteLength > MAX_RETIRED_EXEC_APPROVALS_BYTES
+  ) {
+    return "body-too-large"
+  }
+  if (!expected.eTag || !actual.eTag) return "missing-etag"
+  if (expected.eTag !== actual.eTag) return "etag-mismatch"
+  if (expected.size !== actual.size) return "size-mismatch"
+  if (actual.size !== actual.body.byteLength) return "body-size-mismatch"
+  return validateRetiredExecApprovalsBody(actual.body)
+}

--- a/lib/agent-workspace/storage-broker.ts
+++ b/lib/agent-workspace/storage-broker.ts
@@ -41,6 +41,13 @@ import {
   validateWorkspaceRelativePath,
   workspaceRelativePathRejectionReason,
 } from "@/lib/agent-workspace/path-policy"
+import {
+  MAX_RETIRED_EXEC_APPROVALS_BYTES,
+  RETIRED_EXEC_APPROVALS_CLAIM_PATH,
+  RETIRED_EXEC_APPROVALS_SOURCE_PATH,
+  validateRetiredExecApprovalsPath,
+  validateRetiredExecApprovalsRead,
+} from "@/lib/agent-workspace/retired-exec-approvals"
 
 export { validateWorkspaceRelativePath } from "@/lib/agent-workspace/path-policy"
 
@@ -62,6 +69,15 @@ const WORKSPACE_CHECKPOINT_CONTROL_PREFIX = ".workspace-checkpoints/v2"
 const LEGACY_WORKSPACE_CHECKPOINT_CONTROL_PREFIX = ".workspace-checkpoints/v1"
 const MAX_WORKSPACE_CHECKPOINT_BYTES = 64 * 1024 * 1024
 const WORKSPACE_CHECKPOINT_CONCURRENCY = 32
+// These paths were checkpoint-managed before they were identified as
+// generated OpenClaw host state. Every current or manifest-bound source is
+// content-validated below before exclusion; a policy or interrupted claim
+// fails closed. Existing v2 manifests remain readable only long enough to
+// retire verified socket-only entries without touching the owner object.
+const RETIRED_WORKSPACE_CHECKPOINT_PATHS = new Set([
+  RETIRED_EXEC_APPROVALS_SOURCE_PATH,
+  RETIRED_EXEC_APPROVALS_CLAIM_PATH,
+])
 const CONTENT_TYPE_RE =
   /^[a-z0-9][a-z0-9!#$&^_.+-]{0,126}\/[a-z0-9][a-z0-9!#$&^_.+-]{0,126}$/i
 // S3 expires a public current version after 30 days, then its resulting
@@ -627,6 +643,61 @@ function bucketName(): string {
   return bucket
 }
 
+async function assertRetiredExecApprovalsObjectSafe(params: {
+  signedWorkspacePrefix: string
+  relativePath: string
+  key: string
+  size: number
+  eTag: string
+  versionId?: string
+}): Promise<void> {
+  const pathReason = validateRetiredExecApprovalsPath(params.relativePath)
+  let reason: string | null = pathReason
+  if (!reason) {
+    try {
+      const response = await s3Client().send(
+        new GetObjectCommand({
+          Bucket: bucketName(),
+          Key: params.key,
+          ...(params.versionId ? { VersionId: params.versionId } : {}),
+          IfMatch: params.eTag,
+          Range: `bytes=0-${MAX_RETIRED_EXEC_APPROVALS_BYTES - 1}`,
+        }),
+      )
+      if (!response.Body) {
+        reason = "missing-body"
+      } else {
+        const body = await response.Body.transformToByteArray()
+        reason = validateRetiredExecApprovalsRead(
+          { size: params.size, eTag: params.eTag },
+          {
+            size: response.ContentLength ?? -1,
+            eTag: response.ETag ?? "",
+            body,
+          },
+        )
+      }
+    } catch {
+      reason = "bounded-read-failed"
+    }
+  }
+  if (!reason) return
+  log.warn("Retired workspace host state is not safe to exclude", {
+    ownerHash: createHash("sha256")
+      .update(params.signedWorkspacePrefix)
+      .digest("hex")
+      .slice(0, 16),
+    pathHash: createHash("sha256")
+      .update(params.relativePath)
+      .digest("hex")
+      .slice(0, 16),
+    reason,
+  })
+  throw new WorkspaceStorageCompletionError(
+    "Retired workspace host state requires controlled migration",
+  )
+}
+
 function validateTrustedPrefix(prefix: string): string {
   const normalized = prefix.replace(/^\/+|\/+$/g, "")
   if (!normalized || normalized.includes("..") || normalized.includes("\\")) {
@@ -658,12 +729,13 @@ export type WorkspaceGenerationEntry = {
  * the owner lock, and explicitly pulled by path for each turn, so excluding
  * them avoids a full workspace restore for every new upload.
  */
-export function workspaceGenerationFromEntries(
+function workspaceGenerationFromMatchingEntries(
   entries: readonly WorkspaceGenerationEntry[],
+  include: (entry: WorkspaceGenerationEntry) => boolean,
 ): string {
   const digest = createHash("sha256")
   const sorted = [...entries]
-    .filter((entry) => isCheckpointManagedWorkspacePath(entry.path))
+    .filter(include)
     .map((entry) => ({
       ...entry,
       path: validateWorkspaceRelativePath(entry.path),
@@ -700,6 +772,26 @@ export function workspaceGenerationFromEntries(
     digest.update(eTag)
   }
   return digest.digest("hex")
+}
+
+export function workspaceGenerationFromEntries(
+  entries: readonly WorkspaceGenerationEntry[],
+): string {
+  return workspaceGenerationFromMatchingEntries(
+    entries,
+    (entry) => isCheckpointManagedWorkspacePath(entry.path),
+  )
+}
+
+function legacyWorkspaceCheckpointGeneration(
+  entries: readonly WorkspaceGenerationEntry[],
+): string {
+  return workspaceGenerationFromMatchingEntries(
+    entries,
+    (entry) =>
+      isCheckpointManagedWorkspacePath(entry.path) ||
+      RETIRED_WORKSPACE_CHECKPOINT_PATHS.has(entry.path),
+  )
 }
 
 export function publicArtifactKey(ownerEmail: string, fileName: string): string {
@@ -759,12 +851,56 @@ export async function listWorkspaceObjects(
     )
   }
 
-  const entries = (response.Contents ?? [])
-    .filter((entry): entry is typeof entry & { Key: string } =>
-      Boolean(
-        entry.Key?.startsWith(prefix) && entry.Key.length > prefix.length,
+  const listed = response.Contents ?? []
+  const retired = listed.flatMap((entry) => {
+    const key = entry.Key
+    if (
+      typeof key !== "string" ||
+      !key.startsWith(prefix) ||
+      key.length <= prefix.length
+    ) return []
+    const relativePath = key.slice(prefix.length)
+    return RETIRED_WORKSPACE_CHECKPOINT_PATHS.has(relativePath)
+      ? [{ entry, key, relativePath }]
+      : []
+  })
+  // A claim means Doctor may have moved the source but not committed its
+  // canonical SQLite row. Reject it without reading either object.
+  for (const candidate of retired) {
+    if (candidate.relativePath === RETIRED_EXEC_APPROVALS_CLAIM_PATH) {
+      await assertRetiredExecApprovalsObjectSafe({
+        signedWorkspacePrefix,
+        relativePath: candidate.relativePath,
+        key: candidate.key,
+        size: candidate.entry.Size ?? -1,
+        eTag: candidate.entry.ETag ?? "",
+      })
+    }
+  }
+  await Promise.all(
+    retired.map((candidate) =>
+      assertRetiredExecApprovalsObjectSafe({
+        signedWorkspacePrefix,
+        relativePath: candidate.relativePath,
+        key: candidate.key,
+        size: candidate.entry.Size ?? -1,
+        eTag: candidate.entry.ETag ?? "",
+      }),
+    ),
+  )
+
+  const entries = listed
+    .filter((entry): entry is typeof entry & { Key: string } => {
+      const key = entry.Key
+      if (
+        typeof key !== "string" ||
+        !key.startsWith(prefix) ||
+        key.length <= prefix.length
+      ) return false
+      return !RETIRED_WORKSPACE_CHECKPOINT_PATHS.has(
+        key.slice(prefix.length),
       )
-    )
+    })
     .map((entry) => {
       const path = entry.Key.slice(prefix.length)
       const rejectionReason = isCheckpointManagedWorkspacePath(path)
@@ -842,6 +978,12 @@ type WorkspaceCheckpointManifest = {
   signedWorkspacePrefix: string
   workspaceGeneration: string
   entries: WorkspaceCheckpointEntry[]
+}
+
+type ParsedWorkspaceCheckpointManifest = {
+  manifest: WorkspaceCheckpointManifest
+  normalizedRetiredPaths: boolean
+  retiredEntries: WorkspaceCheckpointEntry[]
 }
 
 async function readWorkspaceGenerationSnapshot(
@@ -1004,7 +1146,7 @@ async function mapWithWorkspaceCheckpointConcurrency<T, U>(
 function parseWorkspaceCheckpointManifest(
   value: unknown,
   signedWorkspacePrefix: string,
-): WorkspaceCheckpointManifest {
+): ParsedWorkspaceCheckpointManifest {
   const expectedPrefix = validateTrustedPrefix(signedWorkspacePrefix)
   if (!value || typeof value !== "object" || Array.isArray(value)) {
     throw new WorkspaceStorageCompletionError(
@@ -1037,10 +1179,13 @@ function parseWorkspaceCheckpointManifest(
       )
     }
     const entry = rawEntry as Record<string, unknown>
+    const pathIsRetired =
+      typeof entry.path === "string" &&
+      RETIRED_WORKSPACE_CHECKPOINT_PATHS.has(entry.path)
     if (
       typeof entry.path !== "string" ||
       workspaceRelativePathRejectionReason(entry.path) !== null ||
-      !isCheckpointManagedWorkspacePath(entry.path) ||
+      (!isCheckpointManagedWorkspacePath(entry.path) && !pathIsRetired) ||
       seenPaths.has(entry.path) ||
       !Number.isSafeInteger(entry.size) ||
       (entry.size as number) < 0 ||
@@ -1075,7 +1220,7 @@ function parseWorkspaceCheckpointManifest(
     })
   }
   if (
-    workspaceGenerationFromEntries(entries) !==
+    legacyWorkspaceCheckpointGeneration(entries) !==
     candidate.workspaceGeneration
   ) {
     throw new WorkspaceStorageCompletionError(
@@ -1083,17 +1228,29 @@ function parseWorkspaceCheckpointManifest(
     )
   }
   assertPrefixFreeWorkspaceEntries(entries)
-  entries.sort((left, right) =>
+  const normalizedEntries = entries
+    .filter(
+      (entry) => !RETIRED_WORKSPACE_CHECKPOINT_PATHS.has(entry.path),
+    )
+  normalizedEntries.sort((left, right) =>
     Buffer.compare(
       Buffer.from(left.path, "utf8"),
       Buffer.from(right.path, "utf8"),
     ),
   )
   return {
-    version: WORKSPACE_CHECKPOINT_VERSION,
-    signedWorkspacePrefix: expectedPrefix,
-    workspaceGeneration: candidate.workspaceGeneration,
-    entries,
+    manifest: {
+      version: WORKSPACE_CHECKPOINT_VERSION,
+      signedWorkspacePrefix: expectedPrefix,
+      workspaceGeneration:
+        workspaceGenerationFromEntries(normalizedEntries),
+      entries: normalizedEntries,
+    },
+    normalizedRetiredPaths:
+      normalizedEntries.length !== entries.length,
+    retiredEntries: entries.filter((entry) =>
+      RETIRED_WORKSPACE_CHECKPOINT_PATHS.has(entry.path),
+    ),
   }
 }
 
@@ -1137,7 +1294,27 @@ async function readWorkspaceCheckpointManifest(
       "Workspace checkpoint manifest is invalid",
     )
   }
-  return parseWorkspaceCheckpointManifest(parsed, signedWorkspacePrefix)
+  const result = parseWorkspaceCheckpointManifest(
+    parsed,
+    signedWorkspacePrefix,
+  )
+  if (result.normalizedRetiredPaths) {
+    for (const entry of result.retiredEntries) {
+      await assertRetiredExecApprovalsObjectSafe({
+        signedWorkspacePrefix,
+        relativePath: entry.path,
+        key: checkpointRecoverySourceKey(signedWorkspacePrefix, entry),
+        size: entry.size,
+        eTag: entry.sourceETag,
+        versionId: entry.versionId,
+      })
+    }
+    // Every caller holds the owner generation lock. This control-only rewrite
+    // changes the manifest's definition of durable state but deliberately
+    // leaves the retired, versioned owner object current and recoverable.
+    await writeWorkspaceCheckpointManifest(result.manifest)
+  }
+  return result.manifest
 }
 
 async function assertNoLegacyWorkspaceCheckpoint(

--- a/lib/agent-workspace/workspace-policy.json
+++ b/lib/agent-workspace/workspace-policy.json
@@ -16,6 +16,10 @@
     ]
   },
   "checkpointExclusions": {
+    "exactPaths": [
+      "exec-approvals.json",
+      "exec-approvals.json.doctor-importing"
+    ],
     "relativePrefixes": [
       "openclaw.json",
       "openclaw.json.bak",

--- a/scripts/agent-workspace/audit-live-workspace-paths.ts
+++ b/scripts/agent-workspace/audit-live-workspace-paths.ts
@@ -7,6 +7,7 @@ import {
   type AttributeValue,
 } from "@aws-sdk/client-dynamodb"
 import {
+  GetObjectCommand,
   paginateListObjectsV2,
   S3Client,
 } from "@aws-sdk/client-s3"
@@ -15,6 +16,13 @@ import {
   workspaceRelativePathRejectionReason,
   type WorkspacePathRejectionReason,
 } from "@/lib/agent-workspace/path-policy"
+import {
+  MAX_RETIRED_EXEC_APPROVALS_BYTES,
+  RETIRED_EXEC_APPROVALS_CLAIM_PATH,
+  RETIRED_EXEC_APPROVALS_SOURCE_PATH,
+  validateRetiredExecApprovalsRead,
+  type RetiredExecApprovalsValidationReason,
+} from "@/lib/agent-workspace/retired-exec-approvals"
 import {
   workspaceGenerationFromEntries,
   type WorkspaceGenerationEntry,
@@ -61,6 +69,35 @@ type CheckpointControlAudit = {
   unknownObjectHashes: string[]
 }
 
+type RetiredExecApprovalAuditReason =
+  | RetiredExecApprovalsValidationReason
+  | "read-failed"
+
+type RetiredExecApprovalFailure = {
+  ownerHash: string
+  objectHash: string
+  reason: RetiredExecApprovalAuditReason
+}
+
+type RetiredExecApprovalCandidate = {
+  key: string
+  ownerPrefix: string
+  ownerHash: string
+  objectHash: string
+  registered: boolean
+  size: number | undefined
+  eTag: string | undefined
+}
+
+type BucketInventoryAudit = {
+  retiredExecApprovalSources: number
+  retiredExecApprovalClaims: number
+  retiredExecApprovalSafeSources: number
+  retiredExecApprovalOrphanSources: number
+  retiredExecApprovalOrphanSourceOwnerHashes: string[]
+  retiredExecApprovalFailures: RetiredExecApprovalFailure[]
+}
+
 function parseArgs(argv: readonly string[]): AuditOptions {
   const values = new Map<string, string>()
   for (let index = 0; index < argv.length; index += 2) {
@@ -84,6 +121,215 @@ function parseArgs(argv: readonly string[]): AuditOptions {
 
 function shortHash(value: string): string {
   return createHash("sha256").update(value).digest("hex").slice(0, 16)
+}
+
+function retiredExecApprovalPathFromKey(
+  key: string,
+  registeredPrefixes: ReadonlySet<string>,
+): {
+  ownerPrefix: string
+  retiredPath: string
+  exactWorkspaceRoot: boolean
+} | null {
+  for (const ownerPrefix of registeredPrefixes) {
+    for (const relativePath of [
+      RETIRED_EXEC_APPROVALS_SOURCE_PATH,
+      RETIRED_EXEC_APPROVALS_CLAIM_PATH,
+    ]) {
+      if (key === `${ownerPrefix}/${relativePath}`) {
+        return {
+          ownerPrefix,
+          retiredPath: relativePath,
+          exactWorkspaceRoot: true,
+        }
+      }
+    }
+  }
+
+  const firstSeparator = key.indexOf("/")
+  if (firstSeparator > 0) {
+    const ownerPrefix = key.slice(0, firstSeparator)
+    const relativePath = key.slice(firstSeparator + 1)
+    if (
+      relativePath === RETIRED_EXEC_APPROVALS_SOURCE_PATH ||
+      relativePath === RETIRED_EXEC_APPROVALS_CLAIM_PATH
+    ) {
+      return {
+        ownerPrefix,
+        retiredPath: relativePath,
+        exactWorkspaceRoot: true,
+      }
+    }
+  }
+
+  for (const relativePath of [
+    RETIRED_EXEC_APPROVALS_SOURCE_PATH,
+    RETIRED_EXEC_APPROVALS_CLAIM_PATH,
+  ]) {
+    if (key === relativePath) {
+      return {
+        ownerPrefix: "",
+        retiredPath: relativePath,
+        exactWorkspaceRoot: false,
+      }
+    }
+    const suffix = `/${relativePath}`
+    if (key.endsWith(suffix)) {
+      return {
+        ownerPrefix: key.slice(0, -suffix.length),
+        retiredPath: relativePath,
+        exactWorkspaceRoot: false,
+      }
+    }
+  }
+  return null
+}
+
+function isPreconditionFailure(error: unknown): boolean {
+  if (typeof error !== "object" || error === null) return false
+  const candidate = error as {
+    name?: unknown
+    $metadata?: { httpStatusCode?: unknown }
+  }
+  return (
+    candidate.name === "PreconditionFailed" ||
+    candidate.$metadata?.httpStatusCode === 412
+  )
+}
+
+async function validateRetiredExecApprovalCandidate(
+  client: S3Client,
+  bucket: string,
+  candidate: RetiredExecApprovalCandidate,
+): Promise<RetiredExecApprovalAuditReason | null> {
+  if (
+    candidate.size === undefined ||
+    !Number.isSafeInteger(candidate.size) ||
+    candidate.size < 0
+  ) {
+    return "invalid-size"
+  }
+  if (candidate.size > MAX_RETIRED_EXEC_APPROVALS_BYTES) {
+    return "body-too-large"
+  }
+  if (!candidate.eTag) return "missing-etag"
+
+  try {
+    const response = await client.send(
+      new GetObjectCommand({
+        Bucket: bucket,
+        Key: candidate.key,
+        IfMatch: candidate.eTag,
+        Range: `bytes=0-${MAX_RETIRED_EXEC_APPROVALS_BYTES - 1}`,
+      }),
+    )
+    if (!response.Body) return "read-failed"
+    const body = await response.Body.transformToByteArray()
+    return validateRetiredExecApprovalsRead(
+      { size: candidate.size, eTag: candidate.eTag },
+      {
+        size: response.ContentLength ?? Number.NaN,
+        eTag: response.ETag ?? "",
+        body,
+      },
+    )
+  } catch (error: unknown) {
+    return isPreconditionFailure(error) ? "etag-mismatch" : "read-failed"
+  }
+}
+
+/**
+ * Inventory the whole bucket so retired host state in an unregistered/orphaned
+ * prefix cannot escape the release gate. Source bodies are fetched only with
+ * a bounded range and the ETag observed by ListObjectsV2 as an If-Match guard.
+ */
+async function auditBucketInventory(
+  client: S3Client,
+  bucket: string,
+  registeredPrefixes: ReadonlySet<string>,
+): Promise<BucketInventoryAudit> {
+  const sourceCandidates: RetiredExecApprovalCandidate[] = []
+  const failures: RetiredExecApprovalFailure[] = []
+  const orphanSourceOwnerHashes = new Set<string>()
+  let sources = 0
+  let orphanSources = 0
+  let claims = 0
+
+  for await (const page of paginateListObjectsV2(
+    { client, pageSize: 1_000 },
+    { Bucket: bucket },
+  )) {
+    for (const object of page.Contents ?? []) {
+      const key = object.Key
+      if (!key) continue
+
+      const retiredPath = retiredExecApprovalPathFromKey(
+        key,
+        registeredPrefixes,
+      )
+      if (!retiredPath) continue
+      const identity = {
+        ownerHash: shortHash(retiredPath.ownerPrefix),
+        objectHash: shortHash(key),
+      }
+      if (retiredPath.retiredPath === RETIRED_EXEC_APPROVALS_CLAIM_PATH) {
+        claims += 1
+        failures.push({ ...identity, reason: "claim-present" })
+        continue
+      }
+      sources += 1
+      if (!registeredPrefixes.has(retiredPath.ownerPrefix)) {
+        orphanSources += 1
+        orphanSourceOwnerHashes.add(identity.ownerHash)
+      }
+      if (!retiredPath.exactWorkspaceRoot) {
+        failures.push({ ...identity, reason: "unexpected-path" })
+        continue
+      }
+      sourceCandidates.push({
+        key,
+        ownerPrefix: retiredPath.ownerPrefix,
+        ...identity,
+        registered: registeredPrefixes.has(retiredPath.ownerPrefix),
+        size: object.Size,
+        eTag: object.ETag,
+      })
+    }
+  }
+
+  const validationReasons = await mapWithConcurrency(
+    sourceCandidates,
+    8,
+    (candidate) =>
+      validateRetiredExecApprovalCandidate(client, bucket, candidate),
+  )
+  let safeSources = 0
+  for (const [index, reason] of validationReasons.entries()) {
+    const candidate = sourceCandidates[index]!
+    if (reason) {
+      failures.push({
+        ownerHash: candidate.ownerHash,
+        objectHash: candidate.objectHash,
+        reason,
+      })
+    } else {
+      safeSources += 1
+    }
+  }
+
+  failures.sort((left, right) =>
+    left.objectHash.localeCompare(right.objectHash),
+  )
+  return {
+    retiredExecApprovalSources: sources,
+    retiredExecApprovalClaims: claims,
+    retiredExecApprovalSafeSources: safeSources,
+    retiredExecApprovalOrphanSources: orphanSources,
+    retiredExecApprovalOrphanSourceOwnerHashes: [
+      ...orphanSourceOwnerHashes,
+    ].sort(),
+    retiredExecApprovalFailures: failures,
+  }
 }
 
 function workspacePrefixFromItem(
@@ -302,17 +548,19 @@ async function mapWithConcurrency<T, U>(
 
 async function main(): Promise<void> {
   const options = parseArgs(process.argv.slice(2))
-  const prefixes = await registeredWorkspacePrefixes(
+  const registeredPrefixes = await registeredWorkspacePrefixes(
     options.environment,
     options.region,
   )
+  const registeredPrefixSet = new Set(registeredPrefixes)
   const client = new S3Client({ region: options.region })
-  const [controlAudit, audits] = await Promise.all([
+  const [controlAudit, bucketInventory] = await Promise.all([
     auditCheckpointControlNamespace(client, options.bucket),
-    mapWithConcurrency(prefixes, 8, (prefix) =>
-      auditWorkspace(client, options.bucket, prefix),
-    ),
+    auditBucketInventory(client, options.bucket, registeredPrefixSet),
   ])
+  const audits = await mapWithConcurrency(registeredPrefixes, 8, (prefix) =>
+    auditWorkspace(client, options.bucket, prefix),
+  )
   const populated = audits.filter((audit) => audit.objects > 0)
   const failures = audits.flatMap((audit) => audit.failures)
   const conflicts = audits.flatMap((audit) => audit.conflicts)
@@ -325,7 +573,7 @@ async function main(): Promise<void> {
         }
   const summary = {
     environment: options.environment,
-    registeredWorkspaces: prefixes.length,
+    registeredWorkspaces: registeredPrefixes.length,
     populatedWorkspaces: populated.length,
     objects: audits.reduce((sum, audit) => sum + audit.objects, 0),
     checkpointManagedObjects: audits.reduce(
@@ -350,6 +598,17 @@ async function main(): Promise<void> {
     currentV2CheckpointControlObjects: controlAudit.currentVersionObjects,
     legacyV1CheckpointObjectHashes: controlAudit.legacyV1ObjectHashes,
     unknownCheckpointObjectHashes: controlAudit.unknownObjectHashes,
+    retiredExecApprovalSources:
+      bucketInventory.retiredExecApprovalSources,
+    retiredExecApprovalClaims: bucketInventory.retiredExecApprovalClaims,
+    retiredExecApprovalSafeSources:
+      bucketInventory.retiredExecApprovalSafeSources,
+    retiredExecApprovalOrphanSources:
+      bucketInventory.retiredExecApprovalOrphanSources,
+    retiredExecApprovalOrphanSourceOwnerHashes:
+      bucketInventory.retiredExecApprovalOrphanSourceOwnerHashes,
+    retiredExecApprovalFailures:
+      bucketInventory.retiredExecApprovalFailures,
     incompatiblePaths: failures,
     fileDescendantConflicts: conflicts,
     pythonClassificationMismatches: parity.classificationMismatches,
@@ -361,6 +620,7 @@ async function main(): Promise<void> {
     conflicts.length > 0 ||
     parity.classificationMismatches.length > 0 ||
     parity.generationMismatches.length > 0 ||
+    bucketInventory.retiredExecApprovalFailures.length > 0 ||
     controlAudit.legacyV1ObjectHashes.length > 0 ||
     controlAudit.unknownObjectHashes.length > 0
   ) {

--- a/tests/unit/lib/agent-workspace/path-policy.test.ts
+++ b/tests/unit/lib/agent-workspace/path-policy.test.ts
@@ -1,6 +1,7 @@
 import contractCases from "@/infra/agent-image/workspace_path_contract_cases.json"
 import {
   isCheckpointManagedWorkspacePath,
+  isWorkspaceCheckpointExcluded,
   validateWorkspaceRelativePath,
   workspaceRelativePathRejectionReason,
 } from "@/lib/agent-workspace/path-policy"
@@ -53,5 +54,20 @@ describe("canonical private workspace path policy", () => {
       false,
     )
     expect(isCheckpointManagedWorkspacePath("memory/notes (v2).md")).toBe(true)
+  })
+
+  it.each([
+    "exec-approvals.json",
+    "exec-approvals.json.doctor-importing",
+  ])("excludes restored OpenClaw compatibility state at %s", (path) => {
+    expect(isWorkspaceCheckpointExcluded(path)).toBe(true)
+    expect(isCheckpointManagedWorkspacePath(path)).toBe(false)
+  })
+
+  it("keeps similarly named user paths checkpoint-managed", () => {
+    expect(isWorkspaceCheckpointExcluded("exec-approvals.json.backup"))
+      .toBe(false)
+    expect(isCheckpointManagedWorkspacePath("exec-approvals.json.backup"))
+      .toBe(true)
   })
 })

--- a/tests/unit/lib/agent-workspace/retired-exec-approvals.test.ts
+++ b/tests/unit/lib/agent-workspace/retired-exec-approvals.test.ts
@@ -1,0 +1,112 @@
+import {
+  MAX_RETIRED_EXEC_APPROVALS_BYTES,
+  RETIRED_EXEC_APPROVALS_CLAIM_PATH,
+  RETIRED_EXEC_APPROVALS_SOURCE_PATH,
+  validateRetiredExecApprovalsBody,
+  validateRetiredExecApprovalsPath,
+  validateRetiredExecApprovalsRead,
+} from "@/lib/agent-workspace/retired-exec-approvals"
+
+const encoder = new TextEncoder()
+const VALID_APPROVALS = {
+  version: 1,
+  socket: {
+    path: "/home/node/.openclaw/exec-approvals.sock",
+    token: "AbCdEfGhIjKlMnOpQrStUvWxYz_12345",
+  },
+  defaults: {},
+  agents: {},
+}
+
+function body(value: unknown): Uint8Array {
+  return encoder.encode(JSON.stringify(value))
+}
+
+describe("retired exec approvals validator", () => {
+  it("accepts only the exact generated socket-only source", () => {
+    expect(validateRetiredExecApprovalsBody(body(VALID_APPROVALS))).toBeNull()
+    expect(
+      validateRetiredExecApprovalsPath(RETIRED_EXEC_APPROVALS_SOURCE_PATH),
+    ).toBeNull()
+  })
+
+  it("rejects malformed JSON without returning source content", () => {
+    expect(validateRetiredExecApprovalsBody(encoder.encode("{token"))).toBe(
+      "malformed-json",
+    )
+  })
+
+  it("rejects nonempty defaults", () => {
+    expect(
+      validateRetiredExecApprovalsBody(
+        body({ ...VALID_APPROVALS, defaults: { security: "ask" } }),
+      ),
+    ).toBe("nonempty-defaults")
+  })
+
+  it("rejects every per-agent allowlist", () => {
+    expect(
+      validateRetiredExecApprovalsBody(
+        body({ ...VALID_APPROVALS, agents: { main: { allow: ["ls"] } } }),
+      ),
+    ).toBe("nonempty-agents")
+  })
+
+  it("rejects unknown top-level fields", () => {
+    expect(
+      validateRetiredExecApprovalsBody(
+        body({ ...VALID_APPROVALS, unexpected: true }),
+      ),
+    ).toBe("unknown-top-level-field")
+  })
+
+  it("rejects unknown socket fields", () => {
+    expect(
+      validateRetiredExecApprovalsBody(
+        body({
+          ...VALID_APPROVALS,
+          socket: { ...VALID_APPROVALS.socket, mode: "private" },
+        }),
+      ),
+    ).toBe("unknown-socket-field")
+  })
+
+  it("rejects an interrupted migration claim", () => {
+    expect(
+      validateRetiredExecApprovalsPath(RETIRED_EXEC_APPROVALS_CLAIM_PATH),
+    ).toBe("claim-present")
+  })
+
+  it("does not retire a nested durable file with the same basename", () => {
+    expect(
+      validateRetiredExecApprovalsPath(
+        `nested/${RETIRED_EXEC_APPROVALS_SOURCE_PATH}`,
+      ),
+    ).toBe("unexpected-path")
+  })
+
+  it("rejects metadata and ETag changes across the conditional read", () => {
+    const validBody = body(VALID_APPROVALS)
+    const expected = { size: validBody.byteLength, eTag: '"listed"' }
+
+    expect(
+      validateRetiredExecApprovalsRead(expected, {
+        size: validBody.byteLength,
+        eTag: '"changed"',
+        body: validBody,
+      }),
+    ).toBe("etag-mismatch")
+    expect(
+      validateRetiredExecApprovalsRead(expected, {
+        size: validBody.byteLength + 1,
+        eTag: '"listed"',
+        body: validBody,
+      }),
+    ).toBe("size-mismatch")
+  })
+
+  it("enforces the bounded-read ceiling", () => {
+    const oversized = new Uint8Array(MAX_RETIRED_EXEC_APPROVALS_BYTES + 1)
+    expect(validateRetiredExecApprovalsBody(oversized)).toBe("body-too-large")
+  })
+})

--- a/tests/unit/lib/agent-workspace/storage-broker-checkpoint.test.ts
+++ b/tests/unit/lib/agent-workspace/storage-broker-checkpoint.test.ts
@@ -187,13 +187,29 @@ class VersionedS3 {
       }
     }
     if (name === "GetObjectCommand") {
-      const version = this.version(key)
+      const version = this.version(
+        key,
+        typeof input.VersionId === "string"
+          ? input.VersionId
+          : undefined,
+      )
+      if (
+        typeof input.IfMatch === "string" &&
+        input.IfMatch !== version.eTag
+      ) {
+        throw Object.assign(new Error("precondition failed"), {
+          name: "PreconditionFailed",
+          $metadata: { httpStatusCode: 412 },
+        })
+      }
       const body = version.body ?? ""
       return {
         ContentLength: Buffer.byteLength(body),
+        ETag: version.eTag,
         VersionId: version.versionId,
         Body: {
           transformToString: async () => body,
+          transformToByteArray: async () => Buffer.from(body),
         },
       }
     }
@@ -283,6 +299,15 @@ const CHECKSUM = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 const CONTENT_TYPE = "application/octet-stream"
 const RESERVATION_ONE = "11111111-2222-4333-8444-555555555555"
 const RESERVATION_TWO = "66666666-7777-4888-8999-000000000000"
+const RETIRED_EXEC_APPROVALS = `${JSON.stringify({
+  version: 1,
+  socket: {
+    path: "/home/node/.openclaw/exec-approvals.sock",
+    token: "AbCdEfGhIjKlMnOpQrStUvWxYz_12345",
+  },
+  defaults: {},
+  agents: {},
+})}\n`
 
 let store: VersionedS3
 let activeReservation: Record<string, unknown> | undefined
@@ -291,6 +316,33 @@ function workspaceGeneration(
   paths: Array<{ path: string; size: number; eTag: string }>,
 ): string {
   return workspaceGenerationFromEntries(paths)
+}
+
+function legacyWorkspaceGenerationIncludingExcluded(
+  entries: Array<{ path: string; size: number; eTag: string }>,
+): string {
+  const digest = createHash("sha256")
+  for (const entry of [...entries].sort((left, right) =>
+    Buffer.compare(
+      Buffer.from(left.path, "utf8"),
+      Buffer.from(right.path, "utf8"),
+    ),
+  )) {
+    const path = Buffer.from(entry.path, "utf8")
+    const eTag = Buffer.from(entry.eTag, "utf8")
+    const pathLength = Buffer.alloc(8)
+    pathLength.writeBigUInt64BE(BigInt(path.length))
+    const size = Buffer.alloc(8)
+    size.writeBigUInt64BE(BigInt(entry.size))
+    const eTagLength = Buffer.alloc(8)
+    eTagLength.writeBigUInt64BE(BigInt(eTag.length))
+    digest.update(pathLength)
+    digest.update(path)
+    digest.update(size)
+    digest.update(eTagLength)
+    digest.update(eTag)
+  }
+  return digest.digest("hex")
 }
 
 function manifestKey(): string {
@@ -488,6 +540,258 @@ describe("durable workspace checkpoints", () => {
           String(command.input.Key).startsWith(`${PREFIX}/`),
       ),
     ).toHaveLength(1)
+  })
+
+  it("normalizes legacy exec approvals out of an existing v2 checkpoint without deleting owner state", async () => {
+    const durableMemory = store.add(`${PREFIX}/memory/MEMORY.md`, {
+      size: 4,
+      eTag: '"memory"',
+      body: "keep",
+      scope: "Scope=private",
+    })
+    const durableDatabase = store.add(`${PREFIX}/state/openclaw.sqlite`, {
+      size: 4,
+      eTag: '"sqlite"',
+      body: "data",
+      scope: "Scope=private",
+    })
+    const legacyApprovals = store.add(`${PREFIX}/exec-approvals.json`, {
+      size: Buffer.byteLength(RETIRED_EXEC_APPROVALS),
+      eTag: '"legacy"',
+      body: RETIRED_EXEC_APPROVALS,
+      scope: "Scope=private",
+    })
+    const oldEntries = [
+      {
+        path: "memory/MEMORY.md",
+        size: 4,
+        eTag: '"memory"',
+        source: "target",
+        versionId: durableMemory.versionId,
+        sourceETag: '"memory"',
+      },
+      {
+        path: "state/openclaw.sqlite",
+        size: 4,
+        eTag: '"sqlite"',
+        source: "target",
+        versionId: durableDatabase.versionId,
+        sourceETag: '"sqlite"',
+      },
+      {
+        path: "exec-approvals.json",
+        size: Buffer.byteLength(RETIRED_EXEC_APPROVALS),
+        eTag: '"legacy"',
+        source: "target",
+        versionId: legacyApprovals.versionId,
+        sourceETag: '"legacy"',
+      },
+    ]
+    const oldManifest = JSON.stringify({
+      version: 2,
+      signedWorkspacePrefix: PREFIX,
+      workspaceGeneration:
+        legacyWorkspaceGenerationIncludingExcluded(oldEntries),
+      entries: oldEntries,
+    })
+    store.add(manifestKey(), {
+      size: Buffer.byteLength(oldManifest),
+      eTag: '"old-manifest"',
+      body: oldManifest,
+      scope: "Scope=checkpoint",
+    })
+    const commandCount = store.commands.length
+
+    const result = await ensureWorkspaceCheckpoint(PREFIX)
+
+    const normalizedGeneration = workspaceGeneration([
+      { path: "memory/MEMORY.md", size: 4, eTag: '"memory"' },
+      { path: "state/openclaw.sqlite", size: 4, eTag: '"sqlite"' },
+    ])
+    expect(result).toEqual({
+      checkpointReady: true,
+      workspaceGeneration: normalizedGeneration,
+    })
+    expect(manifest()).toMatchObject({
+      version: 2,
+      signedWorkspacePrefix: PREFIX,
+      workspaceGeneration: normalizedGeneration,
+      entries: [
+        expect.objectContaining({
+          path: "memory/MEMORY.md",
+          versionId: durableMemory.versionId,
+        }),
+        expect.objectContaining({
+          path: "state/openclaw.sqlite",
+          versionId: durableDatabase.versionId,
+        }),
+      ],
+    })
+    expect(store.current(`${PREFIX}/memory/MEMORY.md`)).toEqual(
+      durableMemory,
+    )
+    expect(store.current(`${PREFIX}/state/openclaw.sqlite`)).toEqual(
+      durableDatabase,
+    )
+    expect(store.current(`${PREFIX}/exec-approvals.json`)).toEqual(
+      legacyApprovals,
+    )
+    expect(
+      store.commands.slice(commandCount).filter(
+        (command) =>
+          command.name === "CopyObjectCommand" ||
+          command.name === "DeleteObjectCommand",
+      ),
+    ).toHaveLength(0)
+  })
+
+  it("rejects an interrupted Doctor claim before normalizing its manifest entry", async () => {
+    const claimKey = `${PREFIX}/exec-approvals.json.doctor-importing`
+    const importingClaim = store.add(claimKey, {
+      size: Buffer.byteLength(RETIRED_EXEC_APPROVALS),
+      eTag: '"claim"',
+      body: RETIRED_EXEC_APPROVALS,
+      scope: "Scope=private",
+    })
+    // Simulate a current delete marker while the committed checkpoint still
+    // references the recoverable claim version. This reaches manifest-level
+    // validation rather than the current-list guard.
+    store.add(claimKey, {
+      size: 0,
+      eTag: '"claim-deleted"',
+      deleteMarker: true,
+    })
+    const entries = [{
+      path: "exec-approvals.json.doctor-importing",
+      size: Buffer.byteLength(RETIRED_EXEC_APPROVALS),
+      eTag: '"claim"',
+      source: "target",
+      versionId: importingClaim.versionId,
+      sourceETag: '"claim"',
+    }]
+    const oldManifest = JSON.stringify({
+      version: 2,
+      signedWorkspacePrefix: PREFIX,
+      workspaceGeneration:
+        legacyWorkspaceGenerationIncludingExcluded(entries),
+      entries,
+    })
+    store.add(manifestKey(), {
+      size: Buffer.byteLength(oldManifest),
+      eTag: '"claim-manifest"',
+      body: oldManifest,
+      scope: "Scope=checkpoint",
+    })
+    const commandCount = store.commands.length
+
+    await expect(ensureWorkspaceCheckpoint(PREFIX)).rejects.toThrow(
+      "Retired workspace host state requires controlled migration",
+    )
+    expect(
+      store.commands.slice(commandCount).some(
+        (command) =>
+          command.name === "PutObjectCommand" ||
+          command.name === "CopyObjectCommand" ||
+          command.name === "DeleteObjectCommand",
+      ),
+    ).toBe(false)
+    expect(store.versions(claimKey)).toContainEqual(importingClaim)
+  })
+
+  it("rejects any other excluded path in a v2 checkpoint", async () => {
+    const excluded = store.add(
+      `${PREFIX}/node_modules/legacy/index.js`,
+      {
+        size: 4,
+        eTag: '"excluded"',
+        body: "code",
+        scope: "Scope=private",
+      },
+    )
+    const entries = [{
+      path: "node_modules/legacy/index.js",
+      size: 4,
+      eTag: '"excluded"',
+      source: "target",
+      versionId: excluded.versionId,
+      sourceETag: '"excluded"',
+    }]
+    const oldManifest = JSON.stringify({
+      version: 2,
+      signedWorkspacePrefix: PREFIX,
+      workspaceGeneration:
+        legacyWorkspaceGenerationIncludingExcluded(entries),
+      entries,
+    })
+    store.add(manifestKey(), {
+      size: Buffer.byteLength(oldManifest),
+      eTag: '"invalid-manifest"',
+      body: oldManifest,
+      scope: "Scope=checkpoint",
+    })
+    const commandCount = store.commands.length
+
+    await expect(ensureWorkspaceCheckpoint(PREFIX)).rejects.toThrow(
+      "manifest is invalid",
+    )
+    expect(
+      store.commands.slice(commandCount).some(
+        (command) =>
+          command.name === "PutObjectCommand" ||
+          command.name === "CopyObjectCommand" ||
+          command.name === "DeleteObjectCommand",
+      ),
+    ).toBe(false)
+    expect(
+      store.current(`${PREFIX}/node_modules/legacy/index.js`),
+    ).toEqual(excluded)
+  })
+
+  it("rejects a retired-path manifest whose legacy generation is invalid", async () => {
+    const legacyApprovals = store.add(
+      `${PREFIX}/exec-approvals.json`,
+      {
+        size: Buffer.byteLength(RETIRED_EXEC_APPROVALS),
+        eTag: '"legacy"',
+        body: RETIRED_EXEC_APPROVALS,
+        scope: "Scope=private",
+      },
+    )
+    const oldManifest = JSON.stringify({
+      version: 2,
+      signedWorkspacePrefix: PREFIX,
+      workspaceGeneration: "0".repeat(64),
+      entries: [{
+        path: "exec-approvals.json",
+        size: Buffer.byteLength(RETIRED_EXEC_APPROVALS),
+        eTag: '"legacy"',
+        source: "target",
+        versionId: legacyApprovals.versionId,
+        sourceETag: '"legacy"',
+      }],
+    })
+    store.add(manifestKey(), {
+      size: Buffer.byteLength(oldManifest),
+      eTag: '"invalid-generation"',
+      body: oldManifest,
+      scope: "Scope=checkpoint",
+    })
+    const commandCount = store.commands.length
+
+    await expect(ensureWorkspaceCheckpoint(PREFIX)).rejects.toThrow(
+      "generation is invalid",
+    )
+    expect(
+      store.commands.slice(commandCount).some(
+        (command) =>
+          command.name === "PutObjectCommand" ||
+          command.name === "CopyObjectCommand" ||
+          command.name === "DeleteObjectCommand",
+      ),
+    ).toBe(false)
+    expect(store.current(`${PREFIX}/exec-approvals.json`)).toEqual(
+      legacyApprovals,
+    )
   })
 
   it("refuses to bless current state while a legacy v1 boundary exists", async () => {

--- a/tests/unit/lib/agent-workspace/storage-broker-list.test.ts
+++ b/tests/unit/lib/agent-workspace/storage-broker-list.test.ts
@@ -17,7 +17,7 @@ const send = jest.fn()
 jest.mock("@aws-sdk/client-s3", () => ({
   S3Client: jest.fn().mockImplementation(() => ({ send })),
   ListObjectsV2Command: jest.fn().mockImplementation((input) => ({ input })),
-  GetObjectCommand: jest.fn(),
+  GetObjectCommand: jest.fn().mockImplementation((input) => ({ input })),
   PutObjectCommand: jest.fn(),
   HeadObjectCommand: jest.fn(),
   DeleteObjectCommand: jest.fn(),
@@ -34,6 +34,15 @@ jest.mock("@aws-sdk/s3-request-presigner", () => ({
 import { listWorkspaceObjects } from "@/lib/agent-workspace/storage-broker"
 
 const PREFIX = "hagelk-db0f32b5"
+const RETIRED_SOURCE = `${JSON.stringify({
+  version: 1,
+  socket: {
+    path: "/home/node/.openclaw/exec-approvals.sock",
+    token: "AbCdEfGhIjKlMnOpQrStUvWxYz_12345",
+  },
+  defaults: {},
+  agents: {},
+})}\n`
 
 beforeEach(() => {
   send.mockReset()
@@ -132,7 +141,104 @@ describe("listWorkspaceObjects", () => {
     expect(result.paths).toEqual(["ok.md"])
     expect(JSON.stringify(result)).not.toContain("secret.md")
   })
+})
 
+describe("retired exec approvals listing", () => {
+  it("hides a verified generated source but preserves similarly named durable state", async () => {
+    send.mockResolvedValueOnce({
+      Contents: [
+        {
+          Key: `${PREFIX}/exec-approvals.json`,
+          Size: Buffer.byteLength(RETIRED_SOURCE),
+          ETag: '"retired"',
+        },
+        {
+          Key: `${PREFIX}/exec-approvals.json.backup`,
+          Size: 4,
+          ETag: '"durable"',
+        },
+      ],
+    }).mockResolvedValueOnce({
+      ContentLength: Buffer.byteLength(RETIRED_SOURCE),
+      ETag: '"retired"',
+      Body: {
+        transformToByteArray: async () => Buffer.from(RETIRED_SOURCE),
+      },
+    })
+
+    const result = await listWorkspaceObjects(PREFIX)
+
+    expect(result.paths).toEqual(["exec-approvals.json.backup"])
+    expect(result.entries.map((entry) => entry.path)).toEqual(
+      result.paths,
+    )
+    expect(send).toHaveBeenCalledTimes(2)
+    expect(send.mock.calls[1][0].input).toMatchObject({
+      Key: `${PREFIX}/exec-approvals.json`,
+      IfMatch: '"retired"',
+      Range: "bytes=0-4095",
+    })
+  })
+
+  it("fails closed on an interrupted Doctor claim without reading its body", async () => {
+    send.mockResolvedValue({
+      Contents: [{
+        Key: `${PREFIX}/exec-approvals.json.doctor-importing`,
+        Size: Buffer.byteLength(RETIRED_SOURCE),
+        ETag: '"claim"',
+      }],
+    })
+
+    await expect(listWorkspaceObjects(PREFIX)).rejects.toThrow(
+      "Retired workspace host state requires controlled migration",
+    )
+    expect(send).toHaveBeenCalledTimes(1)
+  })
+
+  it("fails closed instead of hiding a legacy approvals policy", async () => {
+    const unsafe = RETIRED_SOURCE.replace(
+      '"defaults":{}',
+      '"defaults":{"security":"deny"}',
+    )
+    send.mockResolvedValueOnce({
+      Contents: [{
+        Key: `${PREFIX}/exec-approvals.json`,
+        Size: Buffer.byteLength(unsafe),
+        ETag: '"unsafe"',
+      }],
+    }).mockResolvedValueOnce({
+      ContentLength: Buffer.byteLength(unsafe),
+      ETag: '"unsafe"',
+      Body: {
+        transformToByteArray: async () => Buffer.from(unsafe),
+      },
+    })
+
+    await expect(listWorkspaceObjects(PREFIX)).rejects.toThrow(
+      "Retired workspace host state requires controlled migration",
+    )
+  })
+
+  it("fails closed when the source changes after the bounded list", async () => {
+    send.mockResolvedValueOnce({
+      Contents: [{
+        Key: `${PREFIX}/exec-approvals.json`,
+        Size: Buffer.byteLength(RETIRED_SOURCE),
+        ETag: '"listed"',
+      }],
+    }).mockRejectedValueOnce(Object.assign(new Error("changed"), {
+      name: "PreconditionFailed",
+      $metadata: { httpStatusCode: 412 },
+    }))
+
+    await expect(listWorkspaceObjects(PREFIX)).rejects.toThrow(
+      "Retired workspace host state requires controlled migration",
+    )
+    expect(send.mock.calls[1][0].input.IfMatch).toBe('"listed"')
+  })
+})
+
+describe("listWorkspaceObjects continuation and path checks", () => {
   it("passes the continuation token through", async () => {
     send.mockResolvedValue({
       Contents: [{ Key: `${PREFIX}/a.md`, Size: 1, LastModified: new Date() }],


### PR DESCRIPTION
## Incident root cause
Pinned OpenClaw 2026.7.2-beta.5 refuses to start when a legacy exec-approvals.json is restored, even when that file contains only generated socket credentials and no approval policy. Warm microVMs could also keep the retired file after the durable generation stopped changing.

## Fix
- Exclude only the two exact retired host-state paths after content-aware, bounded, ETag-guarded validation.
- Fail closed on nonempty approval policy, malformed files, interrupted Doctor claims, metadata drift, or manifest/source mismatches.
- Normalize old v2 checkpoint manifests without deleting or overwriting owner objects or versions.
- Remove retired local state before every warm refresh, including unchanged generations.
- Add whole-bucket dev/prod audit gates, image contamination cleanup probe, and a required paused/drained same-commit cutover sequence.

## Workspace safety
Read-only fleet audit validated 24/24 dev and 24/24 prod generated socket-only sources, with zero claims or failures. The one orphan source per environment is included. Existing owner objects and versions remain untouched and recoverable.

## Validation
- Independent adversarial review: approved, no release blocker
- Focused Jest: 91/91 passed
- Python workspace/wrapper tests: 130 passed, 1 expected skip
- Full lint: passed
- Shell syntax, Python compile, diff check: passed
- Built-image host-state cleanup probe against the current image: passed
- Live read-only audit: dev and prod passed
- Changed-file typecheck: zero errors
- Full typecheck remains blocked only by pre-existing unchanged infra/lambdas/agent-router dependency and Smithy version skew errors
- E2E intentionally skipped for this incident hotfix per deployment owner direction

## Deployment requirement
Do not use an ordinary rolling redeploy. Follow the documented Dev workspace-generation cutover: pause/drain, deploy frontend and agent image from the same commit, audit after drain and again after deleting the old AgentCore Runtime, then create the new Runtime.