### PR TITLE
fix(infra): import repository generation fence schema

### DIFF
--- a/infra/lambdas/unified-content-processor/index.ts
+++ b/infra/lambdas/unified-content-processor/index.ts
@@ -36,6 +36,7 @@ import {
 import { and, asc, eq, gt, inArray, isNull, lt, lte, or, sql } from "drizzle-orm";
 import { executeQuery } from "../../../lib/db/drizzle-client";
 import {
+  repositoryIndexGenerations,
   repositoryItemChunks,
   repositoryArtifacts,
   repositoryItems,


### PR DESCRIPTION
## Problem
The dev branch CDK job and every cutover synth fail because the unified-content processor references repositoryIndexGenerations in two embedding dispatch fences without importing the schema table. This predates PR #1506 but blocks its required deployment sequence.

## Fix
Import the existing repositoryIndexGenerations export from the shared schema barrel. No runtime behavior or infrastructure resources change.

## Validation
- Full lint passed
- Full root typecheck passed
- Exact infra build passed
- Unified-content processor typecheck passed
- Agent skill-builder Lambda tests: 17/17 passed
- All-stack CDK synth with no lookups passed
- Diff check passed
- E2E intentionally skipped per deployment owner direction