### PR TITLE
fix(agent): bound large workspace finalization latency

### DIFF
--- a/infra/agent-image/test_workspace_sync.py
+++ b/infra/agent-image/test_workspace_sync.py
@@ -989,14 +989,6 @@ class WorkspaceGenerationFenceTests(unittest.TestCase):
 
     def test_generation_mismatch_aborts_before_any_upload(self):
         (self.root / "state.sqlite").write_bytes(b"local-history")
-        workspace_sync._remote_workspace_snapshots["owner"] = (
-            workspace_sync._RemoteWorkspaceSnapshot(
-                paths=(),
-                sizes={},
-                e_tags={},
-                generation="1" * 64,
-            )
-        )
         workspace_sync._committed_workspace_generations["owner"] = "1" * 64
         changed = workspace_sync._RemoteWorkspaceSnapshot(
             paths=(),
@@ -1034,7 +1026,9 @@ class WorkspaceGenerationFenceTests(unittest.TestCase):
         local.write_bytes(b"local-history")
         metadata = local.stat()
         old_generation = "1" * 64
-        advanced_generation = "2" * 64
+        advanced_generation = workspace_sync._generation_for_entries({
+            "state.sqlite": (metadata.st_size, '"new"'),
+        })
         workspace_sync._pending_workspace_generations["owner"] = (
             old_generation
         )
@@ -1101,9 +1095,13 @@ class WorkspaceGenerationFenceTests(unittest.TestCase):
         child = self.root / "a" / "b"
         child.parent.mkdir()
         child.write_bytes(b"child")
-        base_generation = "1" * 64
-        deleted_generation = "2" * 64
-        final_generation = "3" * 64
+        base_generation = workspace_sync._generation_for_entries({
+            "a": (4, '"old"'),
+        })
+        deleted_generation = workspace_sync._generation_for_entries({})
+        final_generation = workspace_sync._generation_for_entries({
+            "a/b": (5, '"child"'),
+        })
         workspace_sync._committed_workspace_generations["owner"] = (
             base_generation
         )
@@ -1112,12 +1110,6 @@ class WorkspaceGenerationFenceTests(unittest.TestCase):
             sizes={"a": 4},
             e_tags={"a": '"old"'},
             generation=base_generation,
-        )
-        committed = workspace_sync._RemoteWorkspaceSnapshot(
-            paths=("a/b",),
-            sizes={"a/b": 5},
-            e_tags={"a/b": '"child"'},
-            generation=final_generation,
         )
         events = []
         reservation = "36bb0456-1c51-4fb8-97d1-4e87d02765ce"
@@ -1143,7 +1135,7 @@ class WorkspaceGenerationFenceTests(unittest.TestCase):
         ), mock.patch.object(
             workspace_sync,
             "_list_remote_workspace_snapshot",
-            side_effect=[before, committed],
+            return_value=before,
         ), mock.patch.object(
             workspace_sync,
             "_upload_spec",
@@ -1182,6 +1174,85 @@ class WorkspaceGenerationFenceTests(unittest.TestCase):
         delete.assert_called_once_with("a", base_generation, None)
         self.assertLess(events.index("delete"), events.index("promote"))
         self.assertLess(events.index("promote"), events.index("commit"))
+
+    def test_verified_restore_cache_avoids_duplicate_pre_and_post_lists(self):
+        local = self.root / "state.sqlite"
+        local.write_bytes(b"local-history")
+        size = local.stat().st_size
+        base_generation = workspace_sync._generation_for_entries({
+            "state.sqlite": (3, '"old"'),
+        })
+        final_generation = workspace_sync._generation_for_entries({
+            "state.sqlite": (size, '"new"'),
+        })
+        cached = workspace_sync._RemoteWorkspaceSnapshot(
+            paths=("state.sqlite",),
+            sizes={"state.sqlite": 3},
+            e_tags={"state.sqlite": '"old"'},
+            generation=base_generation,
+        )
+        workspace_sync._remote_workspace_snapshots["owner"] = cached
+        workspace_sync._committed_workspace_generations["owner"] = (
+            base_generation
+        )
+        prepared = (
+            "https://upload.invalid/state",
+            "36bb0456-1c51-4fb8-97d1-4e87d02765ce",
+            {
+                "Content-Length": str(size),
+                "Content-Type": "application/octet-stream",
+                "x-amz-checksum-sha256":
+                    "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+            },
+        )
+
+        with mock.patch.object(
+            workspace_sync,
+            "WORKSPACE_DIR",
+            self.root,
+        ), mock.patch.object(
+            workspace_sync,
+            "_ensure_workspace_checkpoint",
+            return_value=base_generation,
+        ), mock.patch.object(
+            workspace_sync,
+            "_list_remote_workspace_snapshot",
+        ) as list_snapshot, mock.patch.object(
+            workspace_sync,
+            "_upload_spec",
+            return_value=prepared,
+        ), mock.patch.object(
+            workspace_sync,
+            "_stream_upload",
+        ), mock.patch.object(
+            workspace_sync,
+            "_complete_upload_reservation",
+            return_value=(final_generation, '"new"'),
+        ), mock.patch.object(
+            workspace_sync,
+            "_commit_workspace_checkpoint",
+            return_value=final_generation,
+        ) as commit:
+            self.assertEqual(
+                workspace_sync.push_workspace(
+                    "owner",
+                    expected_generation=base_generation,
+                    require_generation=True,
+                ),
+                1,
+            )
+
+        list_snapshot.assert_not_called()
+        commit.assert_called_once_with(
+            "owner",
+            base_generation,
+            final_generation,
+            None,
+        )
+        self.assertEqual(
+            workspace_sync._remote_workspace_snapshots["owner"].generation,
+            final_generation,
+        )
 
 
 class BoundedTransferTests(unittest.TestCase):
@@ -1435,6 +1506,83 @@ class BoundedTransferTests(unittest.TestCase):
             ):
                 workspace_sync._ensure_workspace_checkpoint("owner")
         self.assertEqual(timed_out.call_count, 1)
+        sleep.assert_not_called()
+
+    def test_generation_mutations_use_extended_deadline_bounded_timeout(self):
+        generation = "a" * 64
+        advanced = "b" * 64
+        completion = _FakeResponse(
+            json.dumps({
+                "key": "owner/state/openclaw.sqlite",
+                "eTag": '"new"',
+                "workspaceGeneration": advanced,
+            }).encode("utf-8")
+        )
+        with mock.patch.object(
+            workspace_sync.urllib.request,
+            "urlopen",
+            return_value=completion,
+        ) as request:
+            self.assertEqual(
+                workspace_sync._complete_upload_reservation(
+                    "36bb0456-1c51-4fb8-97d1-4e87d02765ce",
+                    generation,
+                    None,
+                ),
+                (advanced, '"new"'),
+            )
+        self.assertEqual(
+            request.call_args.kwargs["timeout"],
+            workspace_sync.WORKSPACE_MUTATION_BROKER_TIMEOUT_SECONDS,
+        )
+
+        deletion = _FakeResponse(
+            json.dumps({
+                "deleted": True,
+                "workspaceGeneration": advanced,
+            }).encode("utf-8")
+        )
+        with mock.patch.object(
+            workspace_sync.time,
+            "monotonic",
+            return_value=100.0,
+        ), mock.patch.object(
+            workspace_sync.urllib.request,
+            "urlopen",
+            return_value=deletion,
+        ) as request:
+            self.assertEqual(
+                workspace_sync._delete_workspace_path(
+                    "devices/pending.json",
+                    generation,
+                    107.0,
+                ),
+                advanced,
+            )
+        self.assertEqual(request.call_args.kwargs["timeout"], 7.0)
+
+    def test_spent_deadline_does_not_launch_or_retry_broker_request(self):
+        with mock.patch.object(
+            workspace_sync.time,
+            "monotonic",
+            return_value=100.0,
+        ), mock.patch.object(
+            workspace_sync.urllib.request,
+            "urlopen",
+        ) as request, mock.patch.object(
+            workspace_sync.time,
+            "sleep",
+        ) as sleep:
+            with self.assertRaisesRegex(
+                TimeoutError,
+                "workspace sync deadline exceeded",
+            ):
+                workspace_sync._delete_workspace_path(
+                    "devices/pending.json",
+                    "a" * 64,
+                    100.0,
+                )
+        request.assert_not_called()
         sleep.assert_not_called()
 
     def test_broker_exhaustion_still_fails_closed(self):

--- a/infra/agent-image/workspace_sync.py
+++ b/infra/agent-image/workspace_sync.py
@@ -176,6 +176,12 @@ _TRANSIENT_HTTP_STATUSES = frozenset({408, 429, 500, 502, 503, 504})
 # deliberately not auto-retried: a client timeout does not prove the web tier
 # stopped working, and overlapping retries would queue behind the same lock.
 WORKSPACE_CHECKPOINT_BROKER_TIMEOUT_SECONDS = 240
+# Generation-fenced mutations scan the authoritative workspace while holding
+# the broker lock. Large migrated workspaces can legitimately take more than
+# the generic 20-second read timeout. Keep one request alive long enough to
+# settle rather than launching an overlapping retry; the turn-wide deadline
+# remains the hard upper bound.
+WORKSPACE_MUTATION_BROKER_TIMEOUT_SECONDS = 60
 WORKSPACE_FLUSH_TOKEN_PATH = (
     "/run/psd-agent-authority/workspace-flush-token"
 )
@@ -1256,6 +1262,14 @@ def _broker_request(
         else ()
     )
     for attempt in range(len(retry_delays) + 1):
+        # A spent turn-wide budget is terminal. Calculate it outside the
+        # network exception handler so the local deadline is never mistaken
+        # for a transient socket timeout and retried after finalization has
+        # already expired.
+        request_timeout = _remaining_timeout(
+            deadline_monotonic,
+            maximum_timeout_seconds,
+        )
         request = urllib.request.Request(
             "http://127.0.0.1:18791/agent-broker/api/agent/workspace-storage",
             data=body,
@@ -1268,10 +1282,7 @@ def _broker_request(
         try:
             with urllib.request.urlopen(
                 request,
-                timeout=_remaining_timeout(
-                    deadline_monotonic,
-                    maximum_timeout_seconds,
-                ),
+                timeout=request_timeout,
             ) as response:
                 result = json.loads(response.read())
             if not isinstance(result, dict):
@@ -1438,6 +1449,9 @@ def _complete_upload_reservation(
         },
         deadline_monotonic,
         retry_transient=True,
+        maximum_timeout_seconds=(
+            WORKSPACE_MUTATION_BROKER_TIMEOUT_SECONDS
+        ),
     )
     next_generation = completed.get("workspaceGeneration")
     e_tag = completed.get("eTag")
@@ -1468,6 +1482,9 @@ def _delete_workspace_path(
         },
         deadline_monotonic,
         retry_transient=True,
+        maximum_timeout_seconds=(
+            WORKSPACE_MUTATION_BROKER_TIMEOUT_SECONDS
+        ),
     )
     next_generation = result.get("workspaceGeneration")
     if (
@@ -2511,13 +2528,24 @@ def push_workspace(
                 marker_upload = None
             _pending_workspace_generations[prefix] = current_generation
             _pending_workspace_completions.pop(prefix, None)
-        # Re-read immediately before opening an upload reservation. This is a
-        # client-side early abort; the broker repeats the exact comparison
-        # under its cross-instance commit mutex before each target promotion.
-        before_upload = _list_remote_workspace_snapshot(
-            prefix,
-            deadline_monotonic,
-        )
+        # The successful restore/refresh already retained the complete remote
+        # snapshot. `_ensure_workspace_checkpoint` just re-read the
+        # authoritative workspace under the broker lock and proved that its
+        # generation still equals this cache. Re-listing thousands of legacy
+        # objects here adds no information. A resumed partial push does not
+        # have that guarantee, so it deliberately falls back to a fresh list.
+        cached_before_upload = _remote_workspace_snapshots.get(prefix)
+        if (
+            not continuing_pending_push
+            and cached_before_upload is not None
+            and cached_before_upload.generation == current_generation
+        ):
+            before_upload = cached_before_upload
+        else:
+            before_upload = _list_remote_workspace_snapshot(
+                prefix,
+                deadline_monotonic,
+            )
         if before_upload.generation is None:
             raise WorkspaceGenerationUnavailable(
                 "workspace broker metadata is incomplete; refusing final push"
@@ -2598,7 +2626,7 @@ def push_workspace(
         pair: tuple[str, str, int, int, int, str],
         prepared: _PreparedWorkspaceUpload,
         generation: str,
-    ) -> str:
+    ) -> tuple[str, str | None]:
         (
             _path,
             relative,
@@ -2613,7 +2641,7 @@ def push_workspace(
                 modified_ns,
                 changed_ns,
             )
-            return generation
+            return generation, prepared.unchanged_e_tag
         if prepared.reservation_id is None:
             raise RuntimeError(
                 "workspace upload reservation id is unavailable"
@@ -2628,7 +2656,7 @@ def push_workspace(
                     changed_ns=changed_ns,
                 )
             )
-            next_generation, _e_tag = _complete_upload_reservation(
+            next_generation, e_tag = _complete_upload_reservation(
                 prepared.reservation_id,
                 generation,
                 deadline_monotonic,
@@ -2639,7 +2667,7 @@ def push_workspace(
                 modified_ns,
                 changed_ns,
             )
-            return next_generation
+            return next_generation, e_tag
         completed = _broker_request(
             {
                 "operation": "complete-upload",
@@ -2655,7 +2683,8 @@ def push_workspace(
                 modified_ns,
                 changed_ns,
             )
-            return generation
+            e_tag = completed.get("eTag")
+            return generation, e_tag if isinstance(e_tag, str) else None
         if (
             not isinstance(completed.get("key"), str)
             or not isinstance(completed.get("eTag"), str)
@@ -2671,7 +2700,7 @@ def push_workspace(
             modified_ns,
             changed_ns,
         )
-        return next_generation
+        return next_generation, completed["eTag"]
 
     count = 0
     started = time.monotonic()
@@ -2698,12 +2727,24 @@ def push_workspace(
 
     try:
         assert current_generation is not None
+        final_entries = (
+            {
+                relative: (
+                    before_upload.sizes[relative],
+                    before_upload.e_tags[relative],
+                )
+                for relative in before_upload.paths
+            }
+            if require_generation
+            else {}
+        )
         for relative in to_delete:
             current_generation = _delete_workspace_path(
                 relative,
                 current_generation,
                 deadline_monotonic,
             )
+            final_entries.pop(relative, None)
             _uploaded_state.pop((prefix, relative), None)
             if require_generation:
                 _pending_workspace_generations[prefix] = (
@@ -2711,11 +2752,17 @@ def push_workspace(
                 )
             count += 1
         for pair, prepared in staged:
-            current_generation = _complete_one(
+            current_generation, e_tag = _complete_one(
                 pair,
                 prepared,
                 current_generation,
             )
+            if require_generation and e_tag is None:
+                raise WorkspaceGenerationUnavailable(
+                    "workspace upload completion returned no generation metadata"
+                )
+            if e_tag is not None:
+                final_entries[pair[1]] = (pair[2], e_tag)
             if require_generation:
                 _pending_workspace_generations[prefix] = current_generation
             count += 1
@@ -2733,33 +2780,52 @@ def push_workspace(
                     "workspace push incomplete (migration marker stage failed) "
                     f"for prefix {prefix}: {marker_error or 'unknown error'}"
                 )
-            current_generation = _complete_one(
+            current_generation, marker_e_tag = _complete_one(
                 marker_pair,
                 marker_prepared,
                 current_generation,
             )
+            if require_generation and marker_e_tag is None:
+                raise WorkspaceGenerationUnavailable(
+                    "workspace marker completion returned no generation metadata"
+                )
+            if marker_e_tag is not None:
+                final_entries[marker_pair[1]] = (
+                    marker_pair[2],
+                    marker_e_tag,
+                )
             if require_generation:
                 _pending_workspace_generations[prefix] = current_generation
             count += 1
 
         if require_generation:
-            committed = _list_remote_workspace_snapshot(
-                prefix,
-                deadline_monotonic,
-            )
-            if committed.generation is None:
-                raise WorkspaceGenerationUnavailable(
-                    "workspace broker metadata became incomplete after push"
-                )
-            if committed.generation != current_generation:
+            synthesized_generation = _generation_for_entries(final_entries)
+            if synthesized_generation != current_generation:
                 raise WorkspaceGenerationConflict(
-                    "authoritative workspace changed during final push"
+                    "workspace mutation results did not form the broker generation"
                 )
+            # This call performs the authoritative full snapshot read under
+            # the broker lock and refuses the commit unless it exactly equals
+            # current_generation. A separate client-side full listing right
+            # before it was the same check twice and consumed another large
+            # fraction of the turn-final deadline.
             _commit_workspace_checkpoint(
                 prefix,
                 base_checkpoint_generation,
                 current_generation,
                 deadline_monotonic,
+            )
+            committed = _RemoteWorkspaceSnapshot(
+                paths=tuple(sorted(final_entries)),
+                sizes={
+                    relative: metadata[0]
+                    for relative, metadata in final_entries.items()
+                },
+                e_tags={
+                    relative: metadata[1]
+                    for relative, metadata in final_entries.items()
+                },
+                generation=current_generation,
             )
             _remote_workspace_snapshots[prefix] = committed
             _pending_workspace_generations.pop(prefix, None)

--- a/lib/agent-workspace/storage-broker.ts
+++ b/lib/agent-workspace/storage-broker.ts
@@ -1921,20 +1921,17 @@ export async function deleteWorkspacePath(
           (entry) => entry.path !== path,
         ),
       )
-      const nextSnapshot = await readWorkspaceGenerationSnapshot(
-        signedWorkspacePrefix,
-      )
-      if (
-        nextSnapshot.entries.has(path) ||
-        nextSnapshot.generation !== expectedNextGeneration
-      ) {
-        throw new WorkspaceStorageSettlementUncertainError(
-          "Workspace path deletion generation could not be confirmed",
-        )
-      }
+      // S3 is strongly consistent, the versionless delete returned both a
+      // delete marker and its VersionId, and this mutation still owns the
+      // per-workspace advisory lock. Re-listing the entire workspace here is
+      // therefore redundant. On large, migrated workspaces that second scan
+      // takes longer than the agent's request timeout and causes an
+      // overlapping idempotent retry. Derive the next generation from the
+      // already-validated pre-delete snapshot, exactly as upload promotion
+      // does below.
       return {
         deleted: true,
-        workspaceGeneration: nextSnapshot.generation,
+        workspaceGeneration: expectedNextGeneration,
       }
     },
   )

--- a/tests/unit/lib/agent-workspace/storage-broker-checkpoint.test.ts
+++ b/tests/unit/lib/agent-workspace/storage-broker-checkpoint.test.ts
@@ -1075,15 +1075,34 @@ describe("durable workspace checkpoints", () => {
     })
     const base = (await ensureWorkspaceCheckpoint(PREFIX))
       .workspaceGeneration
+    const commandsBeforeDelete = store.commands.length
 
     const deleted = await deleteWorkspacePath(
       PREFIX,
       "memory/remove.md",
       base,
     )
+    const firstDeleteCommands = store.commands.slice(commandsBeforeDelete)
+    expect(
+      firstDeleteCommands.filter(
+        (command) => command.name === "ListObjectsV2Command",
+      ),
+    ).toHaveLength(1)
+    expect(deleted.workspaceGeneration).toBe(
+      workspaceGeneration([
+        { path: "memory/keep.md", size: 4, eTag: '"keep"' },
+      ]),
+    )
     await expect(
       deleteWorkspacePath(PREFIX, "memory/remove.md", base),
     ).resolves.toEqual(deleted)
+    expect(
+      store.commands
+        .slice(commandsBeforeDelete)
+        .filter(
+          (command) => command.name === "ListObjectsV2Command",
+        ),
+    ).toHaveLength(2)
     expect(store.current(`${PREFIX}/memory/remove.md`)).toBeUndefined()
     expect(store.versions(`${PREFIX}/memory/remove.md`)).toEqual(
       expect.arrayContaining([retained]),


### PR DESCRIPTION
## Root cause

Large migrated workspaces require multiple paginated S3 listings to calculate a generation. Finalization repeated those listings around every mutation. A delete performed both a pre-delete and post-delete full scan, crossed the 20-second client timeout, and triggered an overlapping retry; duplicate pre/post client listings then exhausted the 120-second finalization budget after the model had already succeeded.

## Fix

- Derive a deletion generation from the lock-protected pre-delete snapshot after S3 confirms a version-preserving delete marker.
- Reuse the restored snapshot only after ensure-checkpoint independently verifies the same generation and no partial push is pending.
- Synthesize the post-mutation client cache from broker-returned ETags while retaining commit-checkpoint as the authoritative locked full scan and durable manifest boundary.
- Give generation-fenced mutations a 60-second timeout clamped by the turn-wide deadline.
- Stop retrying a locally expired finalization deadline as though it were a transient network failure.

For the observed 5,431-object workspace and four mutations, the live timing model drops from more than 120 seconds to approximately 72-77 seconds.

## Validation

- Python workspace sync/path contract: 72 passed
- Workspace broker/runtime Jest suites: 94 passed
- Full ESLint: passed
- Full TypeScript typecheck: passed
- Independent correctness and recovery review: approved by two reviewers
- E2E intentionally skipped for this infrastructure finalization hotfix per incident direction

## Deployment

This changes both the frontend broker and agent image. Deploy using the documented paused same-commit dev workspace-generation hard cutover; do not use an in-place runtime update.