### PR TITLE
fix(agent): reduce durable workspace turn latency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,10 @@ jobs:
     - name: Install dependencies
       run: bun install --frozen-lockfile
 
+    - name: Install agent-router dependencies
+      working-directory: infra/lambdas/agent-router
+      run: bun install --frozen-lockfile
+
     - name: Run linter
       run: bun run lint
 

--- a/app/(protected)/admin/settings/_components/settings-client.test.tsx
+++ b/app/(protected)/admin/settings/_components/settings-client.test.tsx
@@ -227,6 +227,29 @@ jest.mock('@/components/ui/checkbox', () => {
   }
 })
 
+// The generic Radix mapper aliases all primitive packages to one module. The
+// alert-dialog mock above would otherwise replace the Switch primitives too.
+jest.mock('@/components/ui/switch', () => ({
+  Switch: ({
+    checked,
+    onCheckedChange,
+    ...props
+  }: {
+    checked?: boolean
+    onCheckedChange?: (checked: boolean) => void
+    'aria-label'?: string
+    disabled?: boolean
+  }) => (
+    <button
+      {...props}
+      type="button"
+      role="switch"
+      aria-checked={checked}
+      onClick={() => onCheckedChange?.(!checked)}
+    />
+  ),
+}))
+
 // Create global form data store for test
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 let globalFormData: any = {
@@ -311,20 +334,35 @@ describe('SettingsClient', () => {
     };
   })
 
-  it('renders seeded Content Platform settings in their own category', () => {
-    render(<SettingsClient initialSettings={[{
-      id: 2,
-      key: 'CONTENT_PLATFORM_ENABLED',
-      value: 'false',
-      description: 'Enable the unified repository content platform.',
-      category: 'Content Platform',
-      isSecret: false,
-      hasValue: true,
-      createdAt: new Date(),
-      updatedAt: new Date()
-    }]} />)
+  it('renders seeded Content Platform settings in the guided rollout controls', () => {
+    render(
+      <SettingsClient
+        initialSettings={[{
+          id: 2,
+          key: 'CONTENT_PLATFORM_ENABLED',
+          value: 'false',
+          description: 'Enable the unified repository content platform.',
+          category: 'Content Platform',
+          isSecret: false,
+          hasValue: true,
+          createdAt: new Date(),
+          updatedAt: new Date()
+        }]}
+        contentRolloutEvidence={{
+          blockers: [],
+          dryRunCompleted: false,
+          rollbackDrillCompleted: false,
+          uncoveredSources: 0,
+          activeRunCount: 0,
+          staleRepositoryCount: 0,
+          shadowObservations: 0,
+        }}
+      />
+    )
 
     expect(screen.getAllByText('Content Platform')).toHaveLength(2)
+    expect(screen.getByText('Guided repository rollout')).toBeInTheDocument()
+    expect(screen.getByText('1. Platform foundation')).toBeInTheDocument()
     expect(screen.getByText('CONTENT_PLATFORM_ENABLED')).toBeInTheDocument()
     expect(screen.getByText(/Unified document ingestion/)).toBeInTheDocument()
   })

--- a/infra/agent-image/test_workspace_sync.py
+++ b/infra/agent-image/test_workspace_sync.py
@@ -728,12 +728,16 @@ class WorkspaceGenerationFenceTests(unittest.TestCase):
             )
 
         def ensure(_prefix, _deadline=None):
-            return workspace_sync._generation_for_entries({
+            generation = workspace_sync._generation_for_entries({
                 "memory/MEMORY.md": (
                     len(remote["body"]),
                     remote["eTag"],
                 ),
             })
+            return workspace_sync._EnsuredWorkspaceCheckpoint(
+                generation=generation,
+                snapshot=None,
+            )
 
         with mock.patch.object(
             workspace_sync, "WORKSPACE_DIR", self.root
@@ -813,10 +817,14 @@ class WorkspaceGenerationFenceTests(unittest.TestCase):
             )
 
         def ensure(_prefix, _deadline=None):
-            return workspace_sync._generation_for_entries({
+            generation = workspace_sync._generation_for_entries({
                 relative: (len(body), e_tag)
                 for relative, (body, e_tag) in remote.items()
             })
+            return workspace_sync._EnsuredWorkspaceCheckpoint(
+                generation=generation,
+                snapshot=None,
+            )
 
         def download(request, **_kwargs):
             relative = request.full_url.removeprefix(
@@ -912,7 +920,10 @@ class WorkspaceGenerationFenceTests(unittest.TestCase):
         ), mock.patch.object(
             workspace_sync,
             "_ensure_workspace_checkpoint",
-            return_value=empty_generation,
+            return_value=workspace_sync._EnsuredWorkspaceCheckpoint(
+                generation=empty_generation,
+                snapshot=None,
+            ),
         ), mock.patch.object(
             workspace_sync, "_broker_request", side_effect=broker
         ), mock.patch.object(
@@ -970,7 +981,10 @@ class WorkspaceGenerationFenceTests(unittest.TestCase):
         ), mock.patch.object(
             workspace_sync,
             "_ensure_workspace_checkpoint",
-            return_value="1" * 64,
+            return_value=workspace_sync._EnsuredWorkspaceCheckpoint(
+                generation="1" * 64,
+                snapshot=None,
+            ),
         ), mock.patch.object(
             workspace_sync, "_broker_request", side_effect=broker
         ), mock.patch.object(
@@ -987,6 +1001,165 @@ class WorkspaceGenerationFenceTests(unittest.TestCase):
 
         self.assertEqual(downloads, 0)
 
+    def test_refresh_consumes_inline_checkpoint_snapshot_without_list(self):
+        relative = "memory/empty.md"
+        e_tag = '"empty"'
+        generation = workspace_sync._generation_for_entries({
+            relative: (0, e_tag),
+        })
+        response = {
+            "checkpointReady": True,
+            "workspaceGeneration": generation,
+            "checkpointSnapshot": {
+                "workspaceGeneration": generation,
+                "entries": [{
+                    "path": relative,
+                    "size": 0,
+                    "eTag": e_tag,
+                }],
+            },
+        }
+
+        with mock.patch.object(
+            workspace_sync, "WORKSPACE_DIR", self.root
+        ), mock.patch.object(
+            workspace_sync,
+            "_broker_request",
+            return_value=response,
+        ) as broker, mock.patch.object(
+            workspace_sync,
+            "_list_remote_workspace_snapshot",
+        ) as list_snapshot:
+            self.assertEqual(workspace_sync.refresh_workspace("owner"), 1)
+
+        broker.assert_called_once()
+        self.assertEqual(
+            broker.call_args.args[0],
+            {"operation": "ensure-checkpoint"},
+        )
+        list_snapshot.assert_not_called()
+        self.assertEqual((self.root / relative).read_bytes(), b"")
+        self.assertEqual(
+            workspace_sync._remote_workspace_snapshots["owner"].generation,
+            generation,
+        )
+        self.assertEqual(
+            workspace_sync._committed_workspace_generations["owner"],
+            generation,
+        )
+
+    def test_refresh_falls_back_when_checkpoint_snapshot_is_absent(self):
+        generation = workspace_sync._generation_for_entries({})
+        response = {
+            "checkpointReady": True,
+            "workspaceGeneration": generation,
+        }
+        listed = workspace_sync._RemoteWorkspaceSnapshot(
+            paths=(),
+            sizes={},
+            e_tags={},
+            generation=generation,
+        )
+
+        with mock.patch.object(
+            workspace_sync, "WORKSPACE_DIR", self.root
+        ), mock.patch.object(
+            workspace_sync,
+            "_broker_request",
+            return_value=response,
+        ), mock.patch.object(
+            workspace_sync,
+            "_list_remote_workspace_snapshot",
+            return_value=listed,
+        ) as list_snapshot:
+            self.assertEqual(workspace_sync.refresh_workspace("owner"), 0)
+
+        list_snapshot.assert_called_once_with("owner")
+
+    def test_present_malformed_checkpoint_snapshot_fails_closed(self):
+        generation = workspace_sync._generation_for_entries({})
+        valid_entry = {
+            "path": "memory/MEMORY.md",
+            "size": 3,
+            "eTag": '"memory"',
+        }
+        malformed_snapshots = [
+            None,
+            {},
+            {
+                "workspaceGeneration": generation,
+                "entries": "not-an-array",
+            },
+            {
+                "workspaceGeneration": generation,
+                "entries": [{**valid_entry, "size": False}],
+            },
+            {
+                "workspaceGeneration": generation,
+                "entries": [valid_entry, valid_entry],
+            },
+            {
+                "workspaceGeneration": generation,
+                "entries": [{**valid_entry, "extra": True}],
+            },
+            {
+                "workspaceGeneration": generation,
+                "entries": [{
+                    "path": "attachments/input.pdf",
+                    "size": 3,
+                    "eTag": '"attachment"',
+                }],
+            },
+        ]
+
+        for snapshot in malformed_snapshots:
+            with self.subTest(snapshot=snapshot), mock.patch.object(
+                workspace_sync,
+                "_broker_request",
+                return_value={
+                    "checkpointReady": True,
+                    "workspaceGeneration": generation,
+                    "checkpointSnapshot": snapshot,
+                },
+            ):
+                with self.assertRaises(
+                    workspace_sync.WorkspaceGenerationUnavailable
+                ):
+                    workspace_sync._ensure_workspace_checkpoint("owner")
+
+    def test_checkpoint_snapshot_generation_mismatches_fail_closed(self):
+        entry = {
+            "path": "memory/MEMORY.md",
+            "size": 3,
+            "eTag": '"memory"',
+        }
+        top_generation = "a" * 64
+        snapshots = [
+            {
+                "workspaceGeneration": "b" * 64,
+                "entries": [],
+            },
+            {
+                "workspaceGeneration": top_generation,
+                "entries": [entry],
+            },
+        ]
+
+        for snapshot in snapshots:
+            with self.subTest(snapshot=snapshot), mock.patch.object(
+                workspace_sync,
+                "_broker_request",
+                return_value={
+                    "checkpointReady": True,
+                    "workspaceGeneration": top_generation,
+                    "checkpointSnapshot": snapshot,
+                },
+            ):
+                with self.assertRaises(
+                    workspace_sync.WorkspaceGenerationConflict
+                ):
+                    workspace_sync._ensure_workspace_checkpoint("owner")
+
     def test_generation_mismatch_aborts_before_any_upload(self):
         (self.root / "state.sqlite").write_bytes(b"local-history")
         workspace_sync._committed_workspace_generations["owner"] = "1" * 64
@@ -1002,8 +1175,7 @@ class WorkspaceGenerationFenceTests(unittest.TestCase):
         ), mock.patch.object(
             workspace_sync,
             "_ensure_workspace_checkpoint",
-            return_value="1" * 64,
-        ), mock.patch.object(
+        ) as ensure, mock.patch.object(
             workspace_sync,
             "_list_remote_workspace_snapshot",
             return_value=changed,
@@ -1019,6 +1191,7 @@ class WorkspaceGenerationFenceTests(unittest.TestCase):
                     require_generation=True,
                 )
 
+        ensure.assert_not_called()
         prepare.assert_not_called()
 
     def test_lost_completion_response_retries_the_same_reservation(self):
@@ -1055,13 +1228,16 @@ class WorkspaceGenerationFenceTests(unittest.TestCase):
             workspace_sync, "WORKSPACE_DIR", self.root
         ), mock.patch.object(
             workspace_sync,
-            "_complete_upload_reservation",
-            return_value=(advanced_generation, '"new"'),
-        ) as complete, mock.patch.object(
+            "_ensure_workspace_checkpoint",
+        ) as ensure, mock.patch.object(
             workspace_sync,
             "_list_remote_workspace_snapshot",
             return_value=committed,
-        ), mock.patch.object(
+        ) as list_snapshot, mock.patch.object(
+            workspace_sync,
+            "_complete_upload_reservation",
+            return_value=(advanced_generation, '"new"'),
+        ) as complete, mock.patch.object(
             workspace_sync,
             "_commit_workspace_checkpoint",
             return_value=advanced_generation,
@@ -1077,6 +1253,8 @@ class WorkspaceGenerationFenceTests(unittest.TestCase):
                 0,
             )
 
+        ensure.assert_not_called()
+        list_snapshot.assert_called_once_with("owner", None)
         complete.assert_called_once_with(
             "36bb0456-1c51-4fb8-97d1-4e87d02765ce",
             old_generation,
@@ -1131,8 +1309,7 @@ class WorkspaceGenerationFenceTests(unittest.TestCase):
         ), mock.patch.object(
             workspace_sync,
             "_ensure_workspace_checkpoint",
-            return_value=base_generation,
-        ), mock.patch.object(
+        ) as ensure, mock.patch.object(
             workspace_sync,
             "_list_remote_workspace_snapshot",
             return_value=before,
@@ -1171,11 +1348,50 @@ class WorkspaceGenerationFenceTests(unittest.TestCase):
                 2,
             )
 
+        ensure.assert_not_called()
         delete.assert_called_once_with("a", base_generation, None)
         self.assertLess(events.index("delete"), events.index("promote"))
         self.assertLess(events.index("promote"), events.index("commit"))
 
-    def test_verified_restore_cache_avoids_duplicate_pre_and_post_lists(self):
+    def test_fresh_push_requires_checkpoint_and_expected_generation_match(self):
+        (self.root / "state.sqlite").write_bytes(b"local-history")
+        expected_generation = workspace_sync._generation_for_entries({})
+        workspace_sync._committed_workspace_generations["owner"] = "1" * 64
+        workspace_sync._remote_workspace_snapshots["owner"] = (
+            workspace_sync._RemoteWorkspaceSnapshot(
+                paths=(),
+                sizes={},
+                e_tags={},
+                generation=expected_generation,
+            )
+        )
+
+        with mock.patch.object(
+            workspace_sync, "WORKSPACE_DIR", self.root
+        ), mock.patch.object(
+            workspace_sync,
+            "_ensure_workspace_checkpoint",
+        ) as ensure, mock.patch.object(
+            workspace_sync,
+            "_list_remote_workspace_snapshot",
+        ) as list_snapshot, mock.patch.object(
+            workspace_sync,
+            "_upload_spec",
+        ) as prepare:
+            with self.assertRaises(
+                workspace_sync.WorkspaceGenerationConflict
+            ):
+                workspace_sync.push_workspace(
+                    "owner",
+                    expected_generation=expected_generation,
+                    require_generation=True,
+                )
+
+        ensure.assert_not_called()
+        list_snapshot.assert_not_called()
+        prepare.assert_not_called()
+
+    def test_fresh_push_uses_verified_cache_without_preflight_scan(self):
         local = self.root / "state.sqlite"
         local.write_bytes(b"local-history")
         size = local.stat().st_size
@@ -1213,8 +1429,7 @@ class WorkspaceGenerationFenceTests(unittest.TestCase):
         ), mock.patch.object(
             workspace_sync,
             "_ensure_workspace_checkpoint",
-            return_value=base_generation,
-        ), mock.patch.object(
+        ) as ensure, mock.patch.object(
             workspace_sync,
             "_list_remote_workspace_snapshot",
         ) as list_snapshot, mock.patch.object(
@@ -1242,6 +1457,7 @@ class WorkspaceGenerationFenceTests(unittest.TestCase):
                 1,
             )
 
+        ensure.assert_not_called()
         list_snapshot.assert_not_called()
         commit.assert_called_once_with(
             "owner",
@@ -1483,10 +1699,9 @@ class BoundedTransferTests(unittest.TestCase):
             "urlopen",
             return_value=response,
         ) as request:
-            self.assertEqual(
-                workspace_sync._ensure_workspace_checkpoint("owner"),
-                generation,
-            )
+            checkpoint = workspace_sync._ensure_workspace_checkpoint("owner")
+            self.assertEqual(checkpoint.generation, generation)
+            self.assertIsNone(checkpoint.snapshot)
         self.assertEqual(
             request.call_args.kwargs["timeout"],
             workspace_sync.WORKSPACE_CHECKPOINT_BROKER_TIMEOUT_SECONDS,

--- a/infra/agent-image/workspace_sync.py
+++ b/infra/agent-image/workspace_sync.py
@@ -85,6 +85,12 @@ class _RemoteWorkspaceSnapshot:
 
 
 @dataclass(frozen=True)
+class _EnsuredWorkspaceCheckpoint:
+    generation: str
+    snapshot: Optional[_RemoteWorkspaceSnapshot]
+
+
+@dataclass(frozen=True)
 class _PreparedWorkspaceUpload:
     upload_url: Optional[str]
     reservation_id: Optional[str]
@@ -1498,10 +1504,103 @@ def _delete_workspace_path(
     return next_generation
 
 
+def _parse_checkpoint_snapshot(
+    value: object,
+    checkpoint_generation: str,
+) -> _RemoteWorkspaceSnapshot:
+    """Validate the broker's inline authoritative checkpoint snapshot."""
+    if (
+        not isinstance(value, dict)
+        or set(value) != {"workspaceGeneration", "entries"}
+    ):
+        raise WorkspaceGenerationUnavailable(
+            "workspace broker returned a malformed checkpoint snapshot"
+        )
+    snapshot_generation = value.get("workspaceGeneration")
+    entries = value.get("entries")
+    if (
+        not isinstance(snapshot_generation, str)
+        or not re.fullmatch(r"[0-9a-f]{64}", snapshot_generation)
+        or not isinstance(entries, list)
+    ):
+        raise WorkspaceGenerationUnavailable(
+            "workspace broker returned a malformed checkpoint snapshot"
+        )
+    if snapshot_generation != checkpoint_generation:
+        raise WorkspaceGenerationConflict(
+            "workspace checkpoint snapshot generation disagreed with checkpoint"
+        )
+    if len(entries) > MAX_SYNC_FILES:
+        raise WorkspaceRestoreIncomplete(
+            "restore incomplete (file-count backstop reached)"
+        )
+
+    paths: list[str] = []
+    sizes: dict[str, int] = {}
+    e_tags: dict[str, str] = {}
+    for entry in entries:
+        if (
+            not isinstance(entry, dict)
+            or set(entry) != {"path", "size", "eTag"}
+        ):
+            raise WorkspaceGenerationUnavailable(
+                "workspace broker returned a malformed checkpoint snapshot entry"
+            )
+        relative = entry.get("path")
+        size = entry.get("size")
+        e_tag = entry.get("eTag")
+        if (
+            not isinstance(relative, str)
+            or not relative
+            or relative in sizes
+            or not isinstance(size, int)
+            or isinstance(size, bool)
+            or size < 0
+            or size > MAX_SYNC_FILE_BYTES
+            or not isinstance(e_tag, str)
+            or not e_tag
+            or len(e_tag) > 1_024
+        ):
+            raise WorkspaceGenerationUnavailable(
+                "workspace broker returned a malformed checkpoint snapshot entry"
+            )
+        if not _is_checkpoint_managed_relative(relative):
+            raise WorkspaceGenerationUnavailable(
+                "workspace checkpoint snapshot included an unmanaged path"
+            )
+        rejection_reason = _workspace_relative_rejection_reason(relative)
+        if rejection_reason is not None:
+            path_hash = hashlib.sha256(
+                relative.encode("utf-8", errors="surrogatepass")
+            ).hexdigest()[:16]
+            raise WorkspaceRestoreIncomplete(
+                "restore incompatible workspace path "
+                f"reason={rejection_reason} path_hash={path_hash}"
+            )
+        paths.append(relative)
+        sizes[relative] = size
+        e_tags[relative] = e_tag
+
+    computed_generation = _generation_for_entries({
+        relative: (sizes[relative], e_tags[relative])
+        for relative in paths
+    })
+    if computed_generation != snapshot_generation:
+        raise WorkspaceGenerationConflict(
+            "workspace checkpoint snapshot did not form its claimed generation"
+        )
+    return _RemoteWorkspaceSnapshot(
+        paths=tuple(paths),
+        sizes=sizes,
+        e_tags=e_tags,
+        generation=snapshot_generation,
+    )
+
+
 def _ensure_workspace_checkpoint(
     prefix: str,
     deadline_monotonic: float | None = None,
-) -> str:
+) -> _EnsuredWorkspaceCheckpoint:
     """Recover or establish the broker's last complete workspace checkpoint."""
     result = _broker_request(
         {"operation": "ensure-checkpoint"},
@@ -1519,7 +1618,18 @@ def _ensure_workspace_checkpoint(
         raise WorkspaceGenerationUnavailable(
             "workspace broker did not establish a durable checkpoint"
         )
-    return generation
+    snapshot = (
+        _parse_checkpoint_snapshot(
+            result["checkpointSnapshot"],
+            generation,
+        )
+        if "checkpointSnapshot" in result
+        else None
+    )
+    return _EnsuredWorkspaceCheckpoint(
+        generation=generation,
+        snapshot=snapshot,
+    )
 
 
 def _commit_workspace_checkpoint(
@@ -2026,13 +2136,17 @@ def refresh_workspace(prefix: str) -> int:
     # control files even when the durable generation is unchanged; otherwise
     # its migration gate can keep a reused microVM permanently bricked.
     _discard_retired_local_control_state()
-    checkpoint_generation = _ensure_workspace_checkpoint(prefix)
-    snapshot = _list_remote_workspace_snapshot(prefix)
+    checkpoint = _ensure_workspace_checkpoint(prefix)
+    snapshot = checkpoint.snapshot
+    if snapshot is None:
+        # Rolling compatibility: an older broker does not include the
+        # authoritative snapshot captured while establishing the checkpoint.
+        snapshot = _list_remote_workspace_snapshot(prefix)
     if snapshot.generation is None:
         raise WorkspaceGenerationUnavailable(
             "workspace broker metadata is incomplete after checkpoint recovery"
         )
-    if snapshot.generation != checkpoint_generation:
+    if snapshot.generation != checkpoint.generation:
         raise WorkspaceGenerationConflict(
             "workspace broker did not restore the committed checkpoint"
         )
@@ -2041,7 +2155,7 @@ def refresh_workspace(prefix: str) -> int:
         cached is not None
         and cached.generation == snapshot.generation
     ):
-        _committed_workspace_generations[prefix] = checkpoint_generation
+        _committed_workspace_generations[prefix] = checkpoint.generation
         logger.info(
             "workspace refresh: prefix=%s generation=%s unchanged",
             prefix,
@@ -2062,7 +2176,7 @@ def refresh_workspace(prefix: str) -> int:
         snapshot.generation[:12] if snapshot.generation else "untrusted",
     )
     pulled = pull_workspace(prefix, snapshot)
-    _committed_workspace_generations[prefix] = checkpoint_generation
+    _committed_workspace_generations[prefix] = checkpoint.generation
     return pulled
 
 
@@ -2482,18 +2596,13 @@ def push_workspace(
             raise WorkspaceGenerationUnavailable(
                 "committed workspace checkpoint is unavailable"
             )
-        if not continuing_pending_push:
-            ensured_generation = _ensure_workspace_checkpoint(
-                prefix,
-                deadline_monotonic,
+        if (
+            not continuing_pending_push
+            and base_checkpoint_generation != current_generation
+        ):
+            raise WorkspaceGenerationConflict(
+                "hydrated workspace generation disagreed with checkpoint"
             )
-            if (
-                ensured_generation != base_checkpoint_generation
-                or ensured_generation != current_generation
-            ):
-                raise WorkspaceGenerationConflict(
-                    "committed workspace changed before final push"
-                )
         pending_completion = _pending_workspace_completions.get(prefix)
         if pending_completion is not None:
             current_generation, _e_tag = _complete_upload_reservation(
@@ -2528,12 +2637,10 @@ def push_workspace(
                 marker_upload = None
             _pending_workspace_generations[prefix] = current_generation
             _pending_workspace_completions.pop(prefix, None)
-        # The successful restore/refresh already retained the complete remote
-        # snapshot. `_ensure_workspace_checkpoint` just re-read the
-        # authoritative workspace under the broker lock and proved that its
-        # generation still equals this cache. Re-listing thousands of legacy
-        # objects here adds no information. A resumed partial push does not
-        # have that guarantee, so it deliberately falls back to a fresh list.
+        # The successful restore/refresh retained the complete checkpoint
+        # snapshot while the owner-wide lease was held. A resumed partial push
+        # no longer has that exact base, so it deliberately re-lists before
+        # replaying its pending completion.
         cached_before_upload = _remote_workspace_snapshots.get(prefix)
         if (
             not continuing_pending_push

--- a/infra/lambdas/agent-router/index.test.ts
+++ b/infra/lambdas/agent-router/index.test.ts
@@ -32,6 +32,7 @@ const {
   buildAgentInvocationContext,
   sendGoogleChatResponseWithDependencies,
   deferWorkspaceTurn,
+  workspaceRetryDelaySeconds,
   workspaceDeferredRecordNeedsRetry,
   WorkspaceTurnDeferredError,
   isDuplicateMessage,
@@ -631,7 +632,7 @@ describe("workspace turn durable deferral", () => {
     expect(values[":now"]).toBeNumber()
   })
 
-  test("releases the dedup claim and requeues a bounded copy in one minute", async () => {
+  test("releases the dedup claim and requeues the first copy within five seconds", async () => {
     const previousQueueUrl = process.env.ROUTER_QUEUE_URL
     process.env.ROUTER_QUEUE_URL =
       "https://sqs.us-east-1.amazonaws.com/123456789012/router"
@@ -676,12 +677,18 @@ describe("workspace turn durable deferral", () => {
     }
 
     expect(releasedClaims).toEqual(["spaces/room/messages/two"])
+    const retryAfterSeconds = workspaceRetryDelaySeconds(
+      { firstDeferredAt: 1_700_000_000, attempt: 1 },
+      "spaces/room/messages/two"
+    )
+    expect(retryAfterSeconds).toBeGreaterThanOrEqual(1)
+    expect(retryAfterSeconds).toBeLessThanOrEqual(5)
     expect(enqueued).toEqual([
       {
         QueueUrl:
           "https://sqs.us-east-1.amazonaws.com/123456789012/router",
         MessageBody: "{\"message\":{\"data\":\"original\"}}",
-        DelaySeconds: 60,
+        DelaySeconds: retryAfterSeconds,
         MessageAttributes: {
           TraceId: {
             DataType: "String",
@@ -731,6 +738,107 @@ describe("workspace turn durable deferral", () => {
 
     expect(requeued).toBe(false)
     expect(enqueued).toHaveLength(0)
+  })
+})
+
+describe("workspace turn retry backoff", () => {
+  test("uses deterministic exponential bands from persisted attempt state", () => {
+    const firstDeferredAt = 1_700_000_000
+    const messageIdentity = "spaces/room/messages/backoff"
+    const delays = Array.from({ length: 7 }, (_, index) =>
+      workspaceRetryDelaySeconds(
+        { firstDeferredAt, attempt: index + 1 },
+        messageIdentity
+      )
+    )
+
+    expect(delays[0]).toBeGreaterThanOrEqual(1)
+    expect(delays[0]).toBeLessThanOrEqual(5)
+    expect(delays[1]).toBeGreaterThan(delays[0])
+    expect(delays[1]).toBeLessThanOrEqual(10)
+    expect(delays[2]).toBeGreaterThan(delays[1])
+    expect(delays[2]).toBeLessThanOrEqual(20)
+    expect(delays[3]).toBeGreaterThan(delays[2])
+    expect(delays[3]).toBeLessThanOrEqual(40)
+    expect(delays[4]).toBeGreaterThan(delays[3])
+    expect(delays[4]).toBeLessThanOrEqual(60)
+    expect(delays[5]).toBe(60)
+    expect(delays[6]).toBe(60)
+    expect(
+      workspaceRetryDelaySeconds(
+        { firstDeferredAt, attempt: 4 },
+        messageIdentity
+      )
+    ).toBe(delays[3])
+
+    const identityDelays = new Set(
+      Array.from({ length: 12 }, (_, index) =>
+        workspaceRetryDelaySeconds(
+          { firstDeferredAt, attempt: 4 },
+          `spaces/room/messages/backoff-${index}`
+        )
+      )
+    )
+    expect(identityDelays.size).toBeGreaterThan(1)
+  })
+
+  test("advances the persisted attempt when requeueing a copied record", async () => {
+    const previousQueueUrl = process.env.ROUTER_QUEUE_URL
+    process.env.ROUTER_QUEUE_URL =
+      "https://sqs.us-east-1.amazonaws.com/123456789012/router"
+    const messageIdentity = "spaces/room/messages/persisted-backoff"
+    const firstDeferredAt = 1_700_000_000
+    const enqueued: Array<Record<string, unknown>> = []
+    try {
+      const requeued = await deferWorkspaceTurn(
+        {
+          body: "original",
+          messageAttributes: {
+            PsdWorkspaceDeferV1: {
+              dataType: "String",
+              stringValue: JSON.stringify({ firstDeferredAt, attempt: 1 }),
+            },
+          },
+        } as Parameters<typeof deferWorkspaceTurn>[0],
+        new WorkspaceTurnDeferredError(
+          messageIdentity,
+          "workspace-contended"
+        ),
+        TEST_LOG,
+        {
+          releaseClaim: async () => true,
+          enqueue: async input => {
+            enqueued.push(input)
+          },
+          nowSeconds: () => firstDeferredAt + 4,
+        }
+      )
+      expect(requeued).toBe(true)
+    } finally {
+      if (previousQueueUrl === undefined) {
+        delete process.env.ROUTER_QUEUE_URL
+      } else {
+        process.env.ROUTER_QUEUE_URL = previousQueueUrl
+      }
+    }
+
+    const retryAfterSeconds = workspaceRetryDelaySeconds(
+      { firstDeferredAt, attempt: 2 },
+      messageIdentity
+    )
+    expect(retryAfterSeconds).toBeGreaterThanOrEqual(6)
+    expect(retryAfterSeconds).toBeLessThanOrEqual(10)
+    expect(enqueued).toEqual([
+      expect.objectContaining({
+        DelaySeconds: retryAfterSeconds,
+        MessageAttributes: {
+          PsdWorkspaceDeferV1: {
+            DataType: "String",
+            StringValue: JSON.stringify({ firstDeferredAt, attempt: 2 }),
+          },
+        },
+      }),
+    ])
   })
 })
 

--- a/infra/lambdas/agent-router/index.ts
+++ b/infra/lambdas/agent-router/index.ts
@@ -533,7 +533,9 @@ const SLASH_COMMAND_NAMES: Record<string, string> = {
 };
 
 const ASIDE_RESPONSE_PREFIX = '[aside] ';
-const WORKSPACE_RETRY_VISIBILITY_SECONDS = 60;
+const WORKSPACE_RETRY_FIRST_DELAY_MAX_SECONDS = 5;
+const WORKSPACE_RETRY_MAX_DELAY_SECONDS = 60;
+const CHAT_DELIVERY_RETRY_VISIBILITY_SECONDS = 60;
 const WORKSPACE_DEFER_ATTRIBUTE = 'PsdWorkspaceDeferV1';
 const WORKSPACE_DEFER_MAX_ATTEMPTS = 180;
 const WORKSPACE_DEFER_MAX_AGE_SECONDS = 3 * 60 * 60;
@@ -931,6 +933,11 @@ async function deferWorkspaceTurn(
     });
     return false;
   }
+  const retryAfterSeconds = workspaceRetryDelaySeconds(
+    deferState,
+    error.messageName ??
+      crypto.createHash('sha256').update(record.body).digest('hex')
+  );
   const claimReleased = await dependencies.releaseClaim(
     error.messageName,
     log
@@ -945,7 +952,7 @@ async function deferWorkspaceTurn(
   await dependencies.enqueue({
     QueueUrl: queueUrl,
     MessageBody: record.body,
-    DelaySeconds: WORKSPACE_RETRY_VISIBILITY_SECONDS,
+    DelaySeconds: retryAfterSeconds,
     MessageAttributes: workspaceRetryMessageAttributes(
       record,
       deferState
@@ -954,7 +961,7 @@ async function deferWorkspaceTurn(
   log.info('Requeued Chat turn for durable workspace retry', {
     messageName: error.messageName,
     reason: error.reason,
-    retryAfterSeconds: WORKSPACE_RETRY_VISIBILITY_SECONDS,
+    retryAfterSeconds,
     deferAttempt: deferState.attempt,
     firstDeferredAt: deferState.firstDeferredAt,
     receiveCount: record.attributes?.ApproximateReceiveCount ?? '1',
@@ -966,6 +973,39 @@ type WorkspaceDeferState = {
   firstDeferredAt: number;
   attempt: number;
 };
+
+/**
+ * Assign each logical Chat message a stable delay inside non-overlapping,
+ * exponentially growing bands: 1-5s, 6-10s, 11-20s, 21-40s, 41-60s,
+ * then 60s. Persisted attempt state makes the schedule survive SQS copies;
+ * hashing the logical message identity spreads contending turns without
+ * introducing nondeterministic retry behavior.
+ */
+function workspaceRetryDelaySeconds(
+  state: WorkspaceDeferState,
+  messageIdentity: string
+): number {
+  const ceilingForAttempt = (attempt: number): number =>
+    Math.min(
+      WORKSPACE_RETRY_MAX_DELAY_SECONDS,
+      WORKSPACE_RETRY_FIRST_DELAY_MAX_SECONDS *
+        2 ** Math.min(Math.max(attempt - 1, 0), 4)
+    );
+  const upperBound = ceilingForAttempt(state.attempt);
+  const previousUpperBound =
+    state.attempt === 1 ? 0 : ceilingForAttempt(state.attempt - 1);
+  const lowerBound =
+    previousUpperBound === WORKSPACE_RETRY_MAX_DELAY_SECONDS
+      ? WORKSPACE_RETRY_MAX_DELAY_SECONDS
+      : previousUpperBound + 1;
+  const bandSize = upperBound - lowerBound + 1;
+  const sample = crypto
+    .createHash('sha256')
+    .update(`${messageIdentity}\0${state.firstDeferredAt}\0${state.attempt}`)
+    .digest()
+    .readUInt32BE(0);
+  return lowerBound + (sample % bandSize);
+}
 
 function nextWorkspaceDeferState(
   record: SQSRecord,
@@ -1030,7 +1070,7 @@ function workspaceDeferStateIsEligible(
 ): boolean {
   return (
     state.firstDeferredAt <=
-      nowSeconds + WORKSPACE_RETRY_VISIBILITY_SECONDS &&
+      nowSeconds + WORKSPACE_RETRY_MAX_DELAY_SECONDS &&
     state.attempt < WORKSPACE_DEFER_MAX_ATTEMPTS &&
     nowSeconds - state.firstDeferredAt < WORKSPACE_DEFER_MAX_AGE_SECONDS
   );
@@ -1086,11 +1126,11 @@ async function deferChatDeliveryRetry(
     new ChangeMessageVisibilityCommand({
       QueueUrl: queueUrl,
       ReceiptHandle: record.receiptHandle,
-      VisibilityTimeout: WORKSPACE_RETRY_VISIBILITY_SECONDS,
+      VisibilityTimeout: CHAT_DELIVERY_RETRY_VISIBILITY_SECONDS,
     })
   );
   log.warn('Deferred completed Chat response delivery for retry', {
-    retryAfterSeconds: WORKSPACE_RETRY_VISIBILITY_SECONDS,
+    retryAfterSeconds: CHAT_DELIVERY_RETRY_VISIBILITY_SECONDS,
     receiveCount: record.attributes?.ApproximateReceiveCount ?? '1',
   });
 }
@@ -5335,6 +5375,7 @@ export const agentRouterTestHelpers = {
   buildAgentInvocationContext,
   sendGoogleChatResponseWithDependencies,
   deferWorkspaceTurn,
+  workspaceRetryDelaySeconds,
   workspaceDeferredRecordNeedsRetry,
   WorkspaceTurnDeferredError,
   isDuplicateMessage,

--- a/lib/agent-workspace/storage-broker.ts
+++ b/lib/agent-workspace/storage-broker.ts
@@ -69,6 +69,10 @@ const WORKSPACE_CHECKPOINT_CONTROL_PREFIX = ".workspace-checkpoints/v2"
 const LEGACY_WORKSPACE_CHECKPOINT_CONTROL_PREFIX = ".workspace-checkpoints/v1"
 const MAX_WORKSPACE_CHECKPOINT_BYTES = 64 * 1024 * 1024
 const WORKSPACE_CHECKPOINT_CONCURRENCY = 32
+// Keep the inline checkpoint snapshot comfortably below API Gateway/Lambda
+// response limits. Large workspaces retain the legacy generation-only
+// response and the agent image falls back to the paginated list operation.
+const MAX_INLINE_WORKSPACE_CHECKPOINT_SNAPSHOT_BYTES = 512 * 1024
 // These paths were checkpoint-managed before they were identified as
 // generated OpenClaw host state. Every current or manifest-bound source is
 // content-validated below before exclusion; a policy or interrupted claim
@@ -723,6 +727,17 @@ export type WorkspaceGenerationEntry = {
   eTag: string
 }
 
+export type WorkspaceCheckpointSnapshot = {
+  workspaceGeneration: string
+  entries: WorkspaceGenerationEntry[]
+}
+
+export type EnsureWorkspaceCheckpointResult = {
+  checkpointReady: true
+  workspaceGeneration: string
+  checkpointSnapshot?: WorkspaceCheckpointSnapshot
+}
+
 /**
  * Hash mutable workspace state with the same unambiguous binary framing used
  * by the agent image. Router-owned attachments are immutable, written under
@@ -1085,6 +1100,53 @@ function mutableWorkspaceEntries(
         Buffer.from(right.path, "utf8"),
       ),
     )
+}
+
+function inlineWorkspaceCheckpointSnapshot(
+  snapshot: WorkspaceGenerationSnapshot,
+): WorkspaceCheckpointSnapshot | undefined {
+  const entries: WorkspaceGenerationEntry[] = []
+  const serializedPrefix =
+    `{"workspaceGeneration":${JSON.stringify(
+      snapshot.generation,
+    )},"entries":[`
+  let serializedBytes =
+    Buffer.byteLength(serializedPrefix, "utf8") +
+    Buffer.byteLength("]}", "utf8")
+  for (const entry of snapshot.entries.values()) {
+    if (!isCheckpointManagedWorkspacePath(entry.path)) continue
+    const responseEntry: WorkspaceGenerationEntry = {
+      path: entry.path,
+      size: entry.size,
+      eTag: entry.eTag,
+    }
+    serializedBytes +=
+      (entries.length === 0 ? 0 : 1) +
+      Buffer.byteLength(JSON.stringify(responseEntry), "utf8")
+    if (
+      serializedBytes > MAX_INLINE_WORKSPACE_CHECKPOINT_SNAPSHOT_BYTES
+    ) {
+      return undefined
+    }
+    entries.push(responseEntry)
+  }
+  entries.sort((left, right) =>
+    Buffer.compare(
+      Buffer.from(left.path, "utf8"),
+      Buffer.from(right.path, "utf8"),
+    ),
+  )
+  const workspaceGeneration = workspaceGenerationFromEntries(entries)
+  if (workspaceGeneration !== snapshot.generation) {
+    throw new WorkspaceStorageCompletionError(
+      "Workspace checkpoint snapshot generation is incomplete",
+    )
+  }
+  const candidate: WorkspaceCheckpointSnapshot = {
+    workspaceGeneration,
+    entries,
+  }
+  return candidate
 }
 
 function assertPrefixFreeWorkspaceEntries(
@@ -1511,7 +1573,10 @@ async function recoverWorkspaceCheckpoint(
   signedWorkspacePrefix: string,
   manifest: WorkspaceCheckpointManifest,
   snapshot: WorkspaceGenerationSnapshot,
-): Promise<WorkspaceCheckpointManifest> {
+): Promise<{
+  manifest: WorkspaceCheckpointManifest
+  snapshot: WorkspaceGenerationSnapshot
+}> {
   const expected = new Map(
     manifest.entries.map((entry) => [entry.path, entry]),
   )
@@ -1614,19 +1679,19 @@ async function recoverWorkspaceCheckpoint(
     // the equivalent recovered generation only after every target is restored.
     await writeWorkspaceCheckpointManifest(recoveredManifest)
   }
-  return recoveredManifest
+  return {
+    manifest: recoveredManifest,
+    snapshot: recoveredSnapshot,
+  }
 }
 
 export async function ensureWorkspaceCheckpoint(
   signedWorkspacePrefix: string,
-): Promise<{
-  checkpointReady: true
-  workspaceGeneration: string
-}> {
+): Promise<EnsureWorkspaceCheckpointResult> {
   return withWorkspaceGenerationLock(
     signedWorkspacePrefix,
     async () => {
-      const snapshot = await readWorkspaceGenerationSnapshot(
+      let snapshot = await readWorkspaceGenerationSnapshot(
         signedWorkspacePrefix,
       )
       let manifest = await readWorkspaceCheckpointManifest(
@@ -1642,15 +1707,24 @@ export async function ensureWorkspaceCheckpoint(
       } else if (
         snapshot.generation !== manifest.workspaceGeneration
       ) {
-        manifest = await recoverWorkspaceCheckpoint(
+        const recovered = await recoverWorkspaceCheckpoint(
           signedWorkspacePrefix,
           manifest,
           snapshot,
         )
+        manifest = recovered.manifest
+        snapshot = recovered.snapshot
       }
+      if (snapshot.generation !== manifest.workspaceGeneration) {
+        throw new WorkspaceStorageCompletionError(
+          "Workspace checkpoint snapshot generation is incomplete",
+        )
+      }
+      const checkpointSnapshot = inlineWorkspaceCheckpointSnapshot(snapshot)
       return {
         checkpointReady: true,
         workspaceGeneration: manifest.workspaceGeneration,
+        ...(checkpointSnapshot ? { checkpointSnapshot } : {}),
       }
     },
   )
@@ -1686,11 +1760,12 @@ export async function commitWorkspaceCheckpoint(
       )
       if (manifest.workspaceGeneration === workspaceGeneration) {
         if (snapshot.generation !== workspaceGeneration) {
-          manifest = await recoverWorkspaceCheckpoint(
+          const recovered = await recoverWorkspaceCheckpoint(
             signedWorkspacePrefix,
             manifest,
             snapshot,
           )
+          manifest = recovered.manifest
         }
         if (manifest.workspaceGeneration !== workspaceGeneration) {
           throw new WorkspaceStorageCompletionError(

--- a/tests/smoke/unified-content-foundation.smoke.ts
+++ b/tests/smoke/unified-content-foundation.smoke.ts
@@ -1220,6 +1220,7 @@ try {
         .where(eq(repositoryItems.id, legacyTextItem.id)),
     "smoke.unifiedContent.attachLegacyInlineVersion"
   );
+  const legacyRecoveryNow = new Date();
   const [legacyTextJob] = await executeQuery(
     (db) =>
       db
@@ -1231,6 +1232,7 @@ try {
           idempotencyKey: `${legacyTextVersion.id}:inspect:unified-content-v1`,
           attempt: CONTENT_PROCESSING_MAX_ATTEMPTS,
           maxAttempts: CONTENT_PROCESSING_MAX_ATTEMPTS,
+          availableAt: legacyRecoveryNow,
           lastErrorCode: "RETRY_BUDGET_EXHAUSTED",
           lastErrorMessage: "Processing job exhausted its retry budget",
         })
@@ -1238,7 +1240,6 @@ try {
     "smoke.unifiedContent.createLegacyInlineJob"
   );
   assert.ok(legacyTextJob);
-  const legacyRecoveryNow = new Date();
   const legacyClaims = await claimLegacyInlineTextRecoveries({
     leaseOwner: "legacy-inline-smoke:first",
     repositoryId: repository.id,

--- a/tests/unit/agent-workspace-storage-route.test.ts
+++ b/tests/unit/agent-workspace-storage-route.test.ts
@@ -88,6 +88,7 @@ beforeEach(() => {
   })
 })
 
+// eslint-disable-next-line max-lines-per-function
 describe("POST /api/agent/workspace-storage", () => {
   it("requires a signed owner or scheduled context", async () => {
     verifyContextMock.mockResolvedValue(null)
@@ -197,8 +198,30 @@ describe("POST /api/agent/workspace-storage", () => {
   })
 
   it("binds checkpoint operations to the signed workspace prefix", async () => {
+    const workspaceGeneration = "1".repeat(64)
+    const checkpointSnapshot = {
+      workspaceGeneration,
+      entries: [
+        {
+          path: "memory/MEMORY.md",
+          size: 4,
+          eTag: '"memory"',
+        },
+      ],
+    }
+    ensureWorkspaceCheckpointMock.mockResolvedValueOnce({
+      checkpointReady: true,
+      workspaceGeneration,
+      checkpointSnapshot,
+    })
+
     const ensured = await POST(request({ operation: "ensure-checkpoint" }))
     expect(ensured.status).toBe(200)
+    expect(await ensured.json()).toEqual({
+      checkpointReady: true,
+      workspaceGeneration,
+      checkpointSnapshot,
+    })
     expect(ensureWorkspaceCheckpointMock).toHaveBeenCalledWith(
       "workspaces/owner/",
     )

--- a/tests/unit/build-reproducibility.test.ts
+++ b/tests/unit/build-reproducibility.test.ts
@@ -8,7 +8,7 @@ describe("production build reproducibility", () => {
   it("uses checked-in font assets instead of build-time Google downloads", () => {
     for (const modulePath of [
       ["lib", "fonts.ts"],
-      ["lib", "atrium", "meridian-fonts.ts"],
+      ["lib", "meridian", "fonts.ts"],
     ]) {
       const source = validatedFs.readFileSync(projectFile(...modulePath), "utf8");
       expect(source).toContain("next/font/local");

--- a/tests/unit/file-upload-modal.test.tsx
+++ b/tests/unit/file-upload-modal.test.tsx
@@ -26,6 +26,34 @@ jest.mock("@/lib/repositories/content-platform/browser-upload", () => ({
 jest.mock("@/components/ui/use-toast", () => ({
   useToast: () => ({ toast: mockToast }),
 }))
+jest.mock("@radix-ui/react-alert-dialog", () => {
+  const React = require("react")
+  const primitive = (displayName: string, tag = "div") => {
+    function MockAlertDialogPrimitive({
+      children,
+    }: {
+      children?: React.ReactNode
+    }) {
+      return React.createElement(tag, null, children)
+    }
+    MockAlertDialogPrimitive.displayName = displayName
+    return MockAlertDialogPrimitive
+  }
+
+  const mockExports = {
+    Root: primitive("AlertDialogRoot"),
+    Trigger: primitive("AlertDialogTrigger", "button"),
+    Portal: primitive("AlertDialogPortal"),
+    Overlay: primitive("AlertDialogOverlay"),
+    Content: primitive("AlertDialogContent"),
+    Title: primitive("AlertDialogTitle", "h2"),
+    Description: primitive("AlertDialogDescription", "p"),
+    Action: primitive("AlertDialogAction", "button"),
+    Cancel: primitive("AlertDialogCancel", "button"),
+  }
+
+  return { __esModule: true, ...mockExports }
+})
 jest.mock("@/components/ui/form", () => {
   const React = require("react")
   const {

--- a/tests/unit/lib/agent-workspace/storage-broker-checkpoint.test.ts
+++ b/tests/unit/lib/agent-workspace/storage-broker-checkpoint.test.ts
@@ -471,6 +471,24 @@ describe("durable workspace checkpoints", () => {
         { path: "state/a.sqlite", size: 4, eTag: '"a-old"' },
         { path: "memory/MEMORY.md", size: 4, eTag: '"b-old"' },
       ]),
+      checkpointSnapshot: {
+        workspaceGeneration: workspaceGeneration([
+          { path: "state/a.sqlite", size: 4, eTag: '"a-old"' },
+          { path: "memory/MEMORY.md", size: 4, eTag: '"b-old"' },
+        ]),
+        entries: [
+          {
+            path: "memory/MEMORY.md",
+            size: 4,
+            eTag: '"b-old"',
+          },
+          {
+            path: "state/a.sqlite",
+            size: 4,
+            eTag: '"a-old"',
+          },
+        ],
+      },
     })
     const committed = manifest()
     expect(committed.signedWorkspacePrefix).toBe(PREFIX)
@@ -542,6 +560,29 @@ describe("durable workspace checkpoints", () => {
     ).toHaveLength(1)
   })
 
+  it("omits an inline checkpoint snapshot above the response-size cap", async () => {
+    for (let index = 0; index < 750; index += 1) {
+      const path = [
+        "memory",
+        `${String(index).padStart(4, "0")}-${"a".repeat(230)}`,
+        "b".repeat(240),
+        `${"c".repeat(217)}.md`,
+      ].join("/")
+      store.add(`${PREFIX}/${path}`, {
+        size: 1,
+        eTag: `"large-${index}"`,
+        body: "x",
+        scope: "Scope=private",
+      })
+    }
+
+    const result = await ensureWorkspaceCheckpoint(PREFIX)
+
+    expect(result.checkpointReady).toBe(true)
+    expect(result.workspaceGeneration).toMatch(/^[0-9a-f]{64}$/)
+    expect(result).not.toHaveProperty("checkpointSnapshot")
+  })
+
   it("normalizes legacy exec approvals out of an existing v2 checkpoint without deleting owner state", async () => {
     const durableMemory = store.add(`${PREFIX}/memory/MEMORY.md`, {
       size: 4,
@@ -611,6 +652,21 @@ describe("durable workspace checkpoints", () => {
     expect(result).toEqual({
       checkpointReady: true,
       workspaceGeneration: normalizedGeneration,
+      checkpointSnapshot: {
+        workspaceGeneration: normalizedGeneration,
+        entries: [
+          {
+            path: "memory/MEMORY.md",
+            size: 4,
+            eTag: '"memory"',
+          },
+          {
+            path: "state/openclaw.sqlite",
+            size: 4,
+            eTag: '"sqlite"',
+          },
+        ],
+      },
     })
     expect(manifest()).toMatchObject({
       version: 2,
@@ -881,6 +937,7 @@ describe("durable workspace checkpoints", () => {
     expect(lockReleased).toBe(true)
   })
 
+  // eslint-disable-next-line max-lines-per-function
   it("recovers a crash-partial batch, preserves history, and idempotently commits the retry", async () => {
     const originalA = store.add(`${PREFIX}/state/a.sqlite`, {
       size: 4,
@@ -951,6 +1008,21 @@ describe("durable workspace checkpoints", () => {
     })
 
     const recovered = await ensureWorkspaceCheckpoint(PREFIX)
+    expect(recovered.checkpointSnapshot).toEqual({
+      workspaceGeneration: recovered.workspaceGeneration,
+      entries: [
+        {
+          path: "memory/MEMORY.md",
+          size: 4,
+          eTag: '"b-old"',
+        },
+        {
+          path: "state/a.sqlite",
+          size: 4,
+          eTag: '"anchor-a-old"',
+        },
+      ],
+    })
     expect(store.current(`${PREFIX}/state/a.sqlite`)?.body).toBe("aaaa")
     expect(store.current(`${PREFIX}/memory/MEMORY.md`)?.body).toBe("bbbb")
     expect(store.current(`${PREFIX}/memory/new.md`)).toBeUndefined()


### PR DESCRIPTION
## Summary

- reuse the authoritative workspace checkpoint snapshot instead of repeatedly listing thousands of S3 objects during restore
- preserve strict generation fencing and fail closed on malformed or mismatched snapshots
- remove only the redundant fresh-push checkpoint call while retaining final locked verification and crash recovery
- replace the fixed 60-second workspace-contention delay with deterministic staged backoff

## Live diagnosis

The tagged shared-space trace took about 94 seconds. There was no queue or lock deferral: workspace restore consumed about 26 seconds and final workspace persistence about 45 seconds because a roughly 5,430-object workspace was repeatedly listed.

## Compatibility and safety

- snapshot response is optional and size capped; older image clients keep the legacy paginated path
- new clients fall back only when the field is absent and reject malformed snapshots
- delete, promotion, replay, and final commit paths remain generation fenced
- final checkpoint remains an authoritative locked full scan

## Validation

- 68 workspace sync tests passed
- 61 AgentCore wrapper tests passed, 1 intentional skip
- 60 router tests passed
- 25 storage broker and route tests passed
- full TypeScript typecheck passed
- full lint passed
- Python compile and git diff checks passed
- Dev Agent Platform and Frontend ECS CDK synth passed

The requester explicitly waived E2E for this operational fix; the repository documented SKIP_E2E pre-push path was used.