### PR TITLE
fix(agent): atomically finalize workspace checkpoints

### DIFF
--- a/app/api/agent/workspace-storage/route.ts
+++ b/app/api/agent/workspace-storage/route.ts
@@ -15,6 +15,7 @@ import {
   WorkspaceStorageAdmissionError,
   WorkspaceStorageCompletionError,
 } from "@/lib/agent-workspace/storage-broker"
+import { workspaceRelativePathRejectionReason } from "@/lib/agent-workspace/path-policy"
 import { createLogger, generateRequestId, sanitizeForLogging } from "@/lib/logger"
 
 const log = createLogger({ module: "agent-workspace-storage" })
@@ -169,7 +170,9 @@ function hasValidFinalizeCheckpointFields(
     ) ||
     !isOrderedUniqueStringArray(
       body.deletedPaths,
-      (item) => item.trim().length > 0,
+      (item) =>
+        item.trim().length > 0 &&
+        workspaceRelativePathRejectionReason(item) === null,
     )
   ) {
     return false

--- a/app/api/agent/workspace-storage/route.ts
+++ b/app/api/agent/workspace-storage/route.ts
@@ -1,3 +1,4 @@
+import { Buffer } from "node:buffer"
 import { NextRequest, NextResponse } from "next/server"
 import { verifyAgentInvocationContext } from "@/lib/agent-workspace/invocation-context"
 import {
@@ -9,6 +10,7 @@ import {
   createWorkspaceDownloadUrl,
   createWorkspaceUploadUrl,
   ensureWorkspaceCheckpoint,
+  finalizeWorkspaceCheckpoint,
   listWorkspaceObjects,
   WorkspaceStorageAdmissionError,
   WorkspaceStorageCompletionError,
@@ -25,8 +27,11 @@ const ALLOWED_FIELDS = new Set([
   "idempotencyKey",
   "checksumSha256",
   "reservationId",
+  "reservationIds",
   "baseWorkspaceGeneration",
   "workspaceGeneration",
+  "deletedPaths",
+  "checkpointFinalizationProof",
 ])
 const STORAGE_OPERATIONS = new Set([
   "list",
@@ -37,8 +42,21 @@ const STORAGE_OPERATIONS = new Set([
   "complete-upload",
   "ensure-checkpoint",
   "commit-checkpoint",
+  "finalize-checkpoint",
   "delete",
 ])
+const FINALIZE_CHECKPOINT_FIELDS = new Set([
+  "operation",
+  "baseWorkspaceGeneration",
+  "reservationIds",
+  "deletedPaths",
+  "checkpointFinalizationProof",
+])
+const MAX_FINALIZE_CHECKPOINT_ITEMS = 250_000
+const MAX_CHECKPOINT_FINALIZATION_PROOF_LENGTH = 4_096
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+const WORKSPACE_GENERATION_RE = /^[0-9a-f]{64}$/
 
 type StorageRequest = {
   operation:
@@ -50,6 +68,7 @@ type StorageRequest = {
     | "complete-upload"
     | "ensure-checkpoint"
     | "commit-checkpoint"
+    | "finalize-checkpoint"
     | "delete"
   path?: string
   continuationToken?: string
@@ -58,8 +77,11 @@ type StorageRequest = {
   idempotencyKey?: string
   checksumSha256?: string
   reservationId?: string
+  reservationIds?: string[]
   baseWorkspaceGeneration?: string
   workspaceGeneration?: string
+  deletedPaths?: string[]
+  checkpointFinalizationProof?: string
 }
 
 type AgentInvocation = NonNullable<
@@ -91,11 +113,11 @@ function hasValidStorageFields(body: Record<string, unknown>): boolean {
   const workspaceGenerationValid =
     body.workspaceGeneration === undefined ||
     (typeof body.workspaceGeneration === "string" &&
-      /^[0-9a-f]{64}$/.test(body.workspaceGeneration))
+      WORKSPACE_GENERATION_RE.test(body.workspaceGeneration))
   const baseWorkspaceGenerationValid =
     body.baseWorkspaceGeneration === undefined ||
     (typeof body.baseWorkspaceGeneration === "string" &&
-      /^[0-9a-f]{64}$/.test(body.baseWorkspaceGeneration))
+      WORKSPACE_GENERATION_RE.test(body.baseWorkspaceGeneration))
   return [
     isOptionalString(body.path),
     isOptionalString(body.continuationToken),
@@ -109,6 +131,55 @@ function hasValidStorageFields(body: Record<string, unknown>): boolean {
   ].every(Boolean)
 }
 
+function isOrderedUniqueStringArray(
+  value: unknown,
+  isValid: (item: string) => boolean,
+  normalize: (item: string) => string = (item) => item,
+): value is string[] {
+  if (!Array.isArray(value) || value.length > MAX_FINALIZE_CHECKPOINT_ITEMS) {
+    return false
+  }
+  const seen = new Set<string>()
+  for (const item of value) {
+    if (typeof item !== "string" || !isValid(item)) return false
+    const identity = normalize(item)
+    if (seen.has(identity)) return false
+    seen.add(identity)
+  }
+  return true
+}
+
+function hasValidFinalizeCheckpointFields(
+  body: Record<string, unknown>,
+): boolean {
+  if (
+    Object.keys(body).some(
+      (field) => !FINALIZE_CHECKPOINT_FIELDS.has(field),
+    ) ||
+    typeof body.baseWorkspaceGeneration !== "string" ||
+    !WORKSPACE_GENERATION_RE.test(body.baseWorkspaceGeneration) ||
+    typeof body.checkpointFinalizationProof !== "string" ||
+    body.checkpointFinalizationProof.length === 0 ||
+    Buffer.byteLength(body.checkpointFinalizationProof, "utf8") >
+      MAX_CHECKPOINT_FINALIZATION_PROOF_LENGTH ||
+    !isOrderedUniqueStringArray(
+      body.reservationIds,
+      (item) => UUID_RE.test(item),
+      (item) => item.toLowerCase(),
+    ) ||
+    !isOrderedUniqueStringArray(
+      body.deletedPaths,
+      (item) => item.trim().length > 0,
+    )
+  ) {
+    return false
+  }
+  return (
+    body.reservationIds.length + body.deletedPaths.length <=
+    MAX_FINALIZE_CHECKPOINT_ITEMS
+  )
+}
+
 function parseRequest(value: unknown): StorageRequest | null {
   if (!value || typeof value !== "object" || Array.isArray(value)) return null
   const body = value as Record<string, unknown>
@@ -118,6 +189,15 @@ function parseRequest(value: unknown): StorageRequest | null {
     !STORAGE_OPERATIONS.has(body.operation) ||
     !hasValidStorageFields(body)
   ) return null
+  if (body.operation === "finalize-checkpoint") {
+    if (!hasValidFinalizeCheckpointFields(body)) return null
+  } else if (
+    body.reservationIds !== undefined ||
+    body.deletedPaths !== undefined ||
+    body.checkpointFinalizationProof !== undefined
+  ) {
+    return null
+  }
   return body as StorageRequest
 }
 
@@ -156,13 +236,32 @@ async function executeStorageOperation(
           )
         : null
     case "ensure-checkpoint":
-      return ensureWorkspaceCheckpoint(context.workspacePrefix)
+      return ensureWorkspaceCheckpoint(context.workspacePrefix, {
+        invocationNonce: context.nonce,
+        expiresAt: context.expiresAt,
+      })
     case "commit-checkpoint":
       return input.baseWorkspaceGeneration && input.workspaceGeneration
         ? commitWorkspaceCheckpoint(
             context.workspacePrefix,
             input.baseWorkspaceGeneration,
             input.workspaceGeneration,
+          )
+        : null
+    case "finalize-checkpoint":
+      return input.baseWorkspaceGeneration &&
+        input.reservationIds &&
+        input.deletedPaths &&
+        input.checkpointFinalizationProof
+        ? finalizeWorkspaceCheckpoint(
+            context.ownerEmail,
+            context.workspacePrefix,
+            input.baseWorkspaceGeneration,
+            input.reservationIds,
+            input.deletedPaths,
+            input.checkpointFinalizationProof,
+            context.nonce,
+            context.expiresAt,
           )
         : null
     case "delete":

--- a/infra/agent-image/build-and-push.sh
+++ b/infra/agent-image/build-and-push.sh
@@ -236,11 +236,12 @@ else
   fi
   echo ""
 
-  echo "3. Cross-language workspace path contract..."
+  echo "3. Cross-language workspace persistence contracts..."
   if ! "${PYTHON}" -m unittest \
         "${SCRIPT_DIR}/test_workspace_sync.py" \
+        "${SCRIPT_DIR}/test_mantle_proxy.py" \
         "${SCRIPT_DIR}/test_workspace_path_contract.py"; then
-    echo "ERROR: Python workspace path contract FAILED." >&2
+    echo "ERROR: Python workspace persistence contract FAILED." >&2
     exit 1
   fi
   if ! bun run --cwd "${REPO_ROOT}" test -- --runInBand --silent \
@@ -250,8 +251,9 @@ else
         "${REPO_ROOT}/tests/unit/lib/agent-workspace/storage-broker-list.test.ts" \
         "${REPO_ROOT}/tests/unit/lib/agent-workspace/storage-broker-upload.test.ts" \
         "${REPO_ROOT}/tests/unit/lib/agent-workspace/storage-broker-checkpoint.test.ts" \
+        "${REPO_ROOT}/tests/unit/agent-workspace-storage-route.test.ts" \
         "${REPO_ROOT}/tests/unit/agent-image-openclaw-runtime-patch.test.ts"; then
-    echo "ERROR: TypeScript workspace path contract FAILED." >&2
+    echo "ERROR: TypeScript workspace persistence contract FAILED." >&2
     exit 1
   fi
   echo ""

--- a/infra/agent-image/mantle_proxy.py
+++ b/infra/agent-image/mantle_proxy.py
@@ -639,6 +639,7 @@ def _workspace_flush_request_allowed(
             "delete",
             "ensure-checkpoint",
             "commit-checkpoint",
+            "finalize-checkpoint",
         }
         or (
             operation == "complete-upload"

--- a/infra/agent-image/test_mantle_proxy.py
+++ b/infra/agent-image/test_mantle_proxy.py
@@ -591,6 +591,7 @@ class TestAgentBrokerRoute(unittest.TestCase):
             "complete-upload",
             "ensure-checkpoint",
             "commit-checkpoint",
+            "finalize-checkpoint",
         ):
             payload = {"operation": operation}
             if operation == "complete-upload":
@@ -644,6 +645,7 @@ class TestAgentBrokerRoute(unittest.TestCase):
             "upload",
             "delete",
             "ensure-checkpoint",
+            "finalize-checkpoint",
         ):
             self.assertFalse(
                 _workspace_flush_request_allowed(

--- a/infra/agent-image/test_workspace_sync.py
+++ b/infra/agent-image/test_workspace_sync.py
@@ -689,16 +689,24 @@ class WorkspaceGenerationFenceTests(unittest.TestCase):
         workspace_sync._uploaded_state.clear()
         workspace_sync._remote_workspace_snapshots.clear()
         workspace_sync._committed_workspace_generations.clear()
+        workspace_sync._atomic_checkpoint_finalization_capabilities.clear()
         workspace_sync._pending_workspace_generations.clear()
         workspace_sync._pending_workspace_completions.clear()
+        workspace_sync._pending_atomic_workspace_finalizations.clear()
         workspace_sync._force_exact_workspace_restores.clear()
         self.addCleanup(workspace_sync._uploaded_state.clear)
         self.addCleanup(workspace_sync._remote_workspace_snapshots.clear)
         self.addCleanup(
             workspace_sync._committed_workspace_generations.clear
         )
+        self.addCleanup(
+            workspace_sync._atomic_checkpoint_finalization_capabilities.clear
+        )
         self.addCleanup(workspace_sync._pending_workspace_generations.clear)
         self.addCleanup(workspace_sync._pending_workspace_completions.clear)
+        self.addCleanup(
+            workspace_sync._pending_atomic_workspace_finalizations.clear
+        )
         self.addCleanup(
             workspace_sync._force_exact_workspace_restores.clear
         )
@@ -1075,6 +1083,80 @@ class WorkspaceGenerationFenceTests(unittest.TestCase):
             self.assertEqual(workspace_sync.refresh_workspace("owner"), 0)
 
         list_snapshot.assert_called_once_with("owner")
+
+    def test_refresh_records_atomic_finalization_capability_and_proof(self):
+        generation = workspace_sync._generation_for_entries({})
+        response = {
+            "checkpointReady": True,
+            "workspaceGeneration": generation,
+            "atomicCheckpointCommitVersion": 1,
+            "checkpointFinalizationProof": "opaque-proof",
+            "checkpointSnapshot": {
+                "workspaceGeneration": generation,
+                "entries": [],
+            },
+        }
+
+        with mock.patch.object(
+            workspace_sync, "WORKSPACE_DIR", self.root
+        ), mock.patch.object(
+            workspace_sync,
+            "_broker_request",
+            return_value=response,
+        ):
+            self.assertEqual(workspace_sync.refresh_workspace("owner"), 0)
+
+        self.assertEqual(
+            workspace_sync._atomic_checkpoint_finalization_capabilities[
+                "owner"
+            ],
+            workspace_sync._AtomicCheckpointFinalizationCapability(
+                version=1,
+                proof="opaque-proof",
+            ),
+        )
+
+    def test_malformed_atomic_finalization_capability_fails_closed(self):
+        generation = workspace_sync._generation_for_entries({})
+        malformed = [
+            {"atomicCheckpointCommitVersion": 1},
+            {"checkpointFinalizationProof": "proof"},
+            {
+                "atomicCheckpointCommitVersion": True,
+                "checkpointFinalizationProof": "proof",
+            },
+            {
+                "atomicCheckpointCommitVersion": 2,
+                "checkpointFinalizationProof": "proof",
+            },
+            {
+                "atomicCheckpointCommitVersion": 1,
+                "checkpointFinalizationProof": "",
+            },
+            {
+                "atomicCheckpointCommitVersion": 1,
+                "checkpointFinalizationProof": "x" * 4_097,
+            },
+            {
+                "atomicCheckpointCommitVersion": 1,
+                "checkpointFinalizationProof": "\ud800",
+            },
+        ]
+
+        for capability in malformed:
+            with self.subTest(capability=capability), mock.patch.object(
+                workspace_sync,
+                "_broker_request",
+                return_value={
+                    "checkpointReady": True,
+                    "workspaceGeneration": generation,
+                    **capability,
+                },
+            ):
+                with self.assertRaises(
+                    workspace_sync.WorkspaceGenerationUnavailable
+                ):
+                    workspace_sync._ensure_workspace_checkpoint("owner")
 
     def test_present_malformed_checkpoint_snapshot_fails_closed(self):
         generation = workspace_sync._generation_for_entries({})
@@ -1468,6 +1550,770 @@ class WorkspaceGenerationFenceTests(unittest.TestCase):
         self.assertEqual(
             workspace_sync._remote_workspace_snapshots["owner"].generation,
             final_generation,
+        )
+
+    def test_atomic_push_finalizes_uploads_and_deletions_in_one_request(self):
+        local = self.root / "state.sqlite"
+        local.write_bytes(b"new-history")
+        metadata = local.stat()
+        reservation = "36bb0456-1c51-4fb8-97d1-4e87d02765ce"
+        base_entries = {
+            "deleted.md": (4, '"deleted"'),
+            "state.sqlite": (3, '"old"'),
+        }
+        base_generation = workspace_sync._generation_for_entries(
+            base_entries
+        )
+        final_generation = workspace_sync._generation_for_entries({
+            "state.sqlite": (metadata.st_size, '"new"'),
+        })
+        workspace_sync._remote_workspace_snapshots["owner"] = (
+            workspace_sync._RemoteWorkspaceSnapshot(
+                paths=tuple(sorted(base_entries)),
+                sizes={
+                    relative: value[0]
+                    for relative, value in base_entries.items()
+                },
+                e_tags={
+                    relative: value[1]
+                    for relative, value in base_entries.items()
+                },
+                generation=base_generation,
+            )
+        )
+        workspace_sync._committed_workspace_generations["owner"] = (
+            base_generation
+        )
+        workspace_sync._atomic_checkpoint_finalization_capabilities[
+            "owner"
+        ] = workspace_sync._AtomicCheckpointFinalizationCapability(
+            version=1,
+            proof="opaque-proof",
+        )
+        prepared = workspace_sync._PreparedWorkspaceUpload(
+            upload_url="https://upload.invalid/state",
+            reservation_id=reservation,
+            required_headers={
+                "Content-Length": str(metadata.st_size),
+                "Content-Type": "application/octet-stream",
+                "x-amz-checksum-sha256":
+                    "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+            },
+        )
+        response = {
+            "checkpointCommitted": True,
+            "workspaceGeneration": final_generation,
+            "uploads": [{
+                "reservationId": reservation,
+                "key": "owner/state.sqlite",
+                "eTag": '"new"',
+            }],
+            "deletions": [{"path": "deleted.md", "deleted": True}],
+        }
+
+        with mock.patch.object(
+            workspace_sync, "WORKSPACE_DIR", self.root
+        ), mock.patch.object(
+            workspace_sync,
+            "_upload_spec",
+            return_value=prepared,
+        ), mock.patch.object(
+            workspace_sync, "_stream_upload"
+        ), mock.patch.object(
+            workspace_sync,
+            "_broker_request",
+            return_value=response,
+        ) as broker, mock.patch.object(
+            workspace_sync, "_delete_workspace_path"
+        ) as legacy_delete, mock.patch.object(
+            workspace_sync, "_complete_upload_reservation"
+        ) as legacy_complete, mock.patch.object(
+            workspace_sync, "_commit_workspace_checkpoint"
+        ) as legacy_commit:
+            self.assertEqual(
+                workspace_sync.push_workspace(
+                    "owner",
+                    expected_generation=base_generation,
+                    require_generation=True,
+                ),
+                2,
+            )
+
+        self.assertEqual(
+            broker.call_args.args[0],
+            {
+                "operation": "finalize-checkpoint",
+                "baseWorkspaceGeneration": base_generation,
+                "checkpointFinalizationProof": "opaque-proof",
+                "reservationIds": [reservation],
+                "deletedPaths": ["deleted.md"],
+            },
+        )
+        legacy_delete.assert_not_called()
+        legacy_complete.assert_not_called()
+        legacy_commit.assert_not_called()
+        self.assertEqual(
+            workspace_sync.workspace_generation("owner"),
+            final_generation,
+        )
+        self.assertEqual(
+            workspace_sync._uploaded_state[("owner", "state.sqlite")],
+            (
+                metadata.st_size,
+                metadata.st_mtime_ns,
+                metadata.st_ctime_ns,
+            ),
+        )
+        self.assertNotIn(
+            "owner", workspace_sync._pending_atomic_workspace_finalizations
+        )
+        self.assertNotIn(
+            "owner",
+            workspace_sync._atomic_checkpoint_finalization_capabilities,
+        )
+
+    def test_atomic_push_commits_an_empty_batch_without_legacy_calls(self):
+        generation = workspace_sync._generation_for_entries({})
+        workspace_sync._remote_workspace_snapshots["owner"] = (
+            workspace_sync._RemoteWorkspaceSnapshot(
+                paths=(), sizes={}, e_tags={}, generation=generation
+            )
+        )
+        workspace_sync._committed_workspace_generations["owner"] = generation
+        workspace_sync._atomic_checkpoint_finalization_capabilities[
+            "owner"
+        ] = workspace_sync._AtomicCheckpointFinalizationCapability(
+            version=1,
+            proof="opaque-proof",
+        )
+        response = {
+            "checkpointCommitted": True,
+            "workspaceGeneration": generation,
+            "uploads": [],
+            "deletions": [],
+        }
+
+        with mock.patch.object(
+            workspace_sync, "WORKSPACE_DIR", self.root
+        ), mock.patch.object(
+            workspace_sync, "_broker_request", return_value=response
+        ) as broker, mock.patch.object(
+            workspace_sync, "_upload_spec"
+        ) as upload, mock.patch.object(
+            workspace_sync, "_commit_workspace_checkpoint"
+        ) as legacy_commit:
+            self.assertEqual(
+                workspace_sync.push_workspace(
+                    "owner",
+                    expected_generation=generation,
+                    require_generation=True,
+                ),
+                0,
+            )
+
+        self.assertEqual(
+            broker.call_args.args[0],
+            {
+                "operation": "finalize-checkpoint",
+                "baseWorkspaceGeneration": generation,
+                "checkpointFinalizationProof": "opaque-proof",
+                "reservationIds": [],
+                "deletedPaths": [],
+            },
+        )
+        upload.assert_not_called()
+        legacy_commit.assert_not_called()
+
+    def test_atomic_push_retries_exact_pending_batch_after_bad_generation(self):
+        local = self.root / "state.sqlite"
+        local.write_bytes(b"new-history")
+        metadata = local.stat()
+        reservation = "36bb0456-1c51-4fb8-97d1-4e87d02765ce"
+        base_generation = workspace_sync._generation_for_entries({})
+        final_generation = workspace_sync._generation_for_entries({
+            "state.sqlite": (metadata.st_size, '"new"'),
+        })
+        workspace_sync._remote_workspace_snapshots["owner"] = (
+            workspace_sync._RemoteWorkspaceSnapshot(
+                paths=(),
+                sizes={},
+                e_tags={},
+                generation=base_generation,
+            )
+        )
+        workspace_sync._committed_workspace_generations["owner"] = (
+            base_generation
+        )
+        workspace_sync._atomic_checkpoint_finalization_capabilities[
+            "owner"
+        ] = workspace_sync._AtomicCheckpointFinalizationCapability(
+            version=1,
+            proof="opaque-proof",
+        )
+        prepared = workspace_sync._PreparedWorkspaceUpload(
+            upload_url="https://upload.invalid/state",
+            reservation_id=reservation,
+            required_headers={},
+        )
+
+        def response(generation):
+            return {
+                "checkpointCommitted": True,
+                "workspaceGeneration": generation,
+                "uploads": [{
+                    "reservationId": reservation,
+                    "key": "owner/state.sqlite",
+                    "eTag": '"new"',
+                }],
+                "deletions": [],
+            }
+
+        with mock.patch.object(
+            workspace_sync, "WORKSPACE_DIR", self.root
+        ), mock.patch.object(
+            workspace_sync,
+            "_upload_spec",
+            return_value=prepared,
+        ) as prepare, mock.patch.object(
+            workspace_sync, "_stream_upload"
+        ) as stream, mock.patch.object(
+            workspace_sync,
+            "_broker_request",
+            side_effect=[response("f" * 64), response(final_generation)],
+        ) as broker:
+            with self.assertRaises(
+                workspace_sync.WorkspaceGenerationConflict
+            ):
+                workspace_sync.push_workspace(
+                    "owner",
+                    expected_generation=base_generation,
+                    require_generation=True,
+                )
+            self.assertIn(
+                "owner",
+                workspace_sync._pending_atomic_workspace_finalizations,
+            )
+            # A retry runs under a newly authenticated invocation. Its fresh
+            # capability must not rewrite the exact old batch journal key.
+            workspace_sync._atomic_checkpoint_finalization_capabilities[
+                "owner"
+            ] = workspace_sync._AtomicCheckpointFinalizationCapability(
+                version=1,
+                proof="new-invocation-proof",
+            )
+            self.assertEqual(
+                workspace_sync.push_workspace(
+                    "owner",
+                    expected_generation=base_generation,
+                    require_generation=True,
+                ),
+                0,
+            )
+
+        self.assertEqual(prepare.call_count, 1)
+        self.assertEqual(stream.call_count, 1)
+        self.assertEqual(broker.call_count, 2)
+        self.assertEqual(
+            broker.call_args_list[1].args[0][
+                "checkpointFinalizationProof"
+            ],
+            "opaque-proof",
+        )
+        self.assertEqual(
+            workspace_sync.workspace_generation("owner"),
+            final_generation,
+        )
+
+    def test_atomic_apply_rejects_upload_key_for_another_workspace(self):
+        reservation = "36bb0456-1c51-4fb8-97d1-4e87d02765ce"
+        pending = workspace_sync._PendingAtomicWorkspaceFinalization(
+            base_generation=workspace_sync._generation_for_entries({}),
+            proof="opaque-proof",
+            uploads=(workspace_sync._PendingWorkspaceCompletion(
+                reservation_id=reservation,
+                relative="state.sqlite",
+                content_length=3,
+                modified_ns=1,
+                changed_ns=2,
+            ),),
+            unchanged_uploads=(),
+            deleted_paths=(),
+            base_entries=(),
+        )
+        finalized = workspace_sync._FinalizedWorkspaceCheckpoint(
+            generation=workspace_sync._generation_for_entries({
+                "state.sqlite": (3, '"new"'),
+            }),
+            uploads=((reservation, "other-owner/state.sqlite", '"new"'),),
+            deletions=(),
+        )
+
+        with self.assertRaises(workspace_sync.WorkspacePushIncomplete):
+            workspace_sync._apply_atomic_workspace_finalization(
+                "owner",
+                pending,
+                finalized,
+            )
+
+        self.assertNotIn(("owner", "state.sqlite"), workspace_sync._uploaded_state)
+        self.assertNotIn("owner", workspace_sync._remote_workspace_snapshots)
+
+    def test_atomic_finalize_response_is_exactly_validated(self):
+        reservation = "36bb0456-1c51-4fb8-97d1-4e87d02765ce"
+        valid = {
+            "checkpointCommitted": True,
+            "workspaceGeneration": "a" * 64,
+            "uploads": [{
+                "reservationId": reservation,
+                "key": "owner/state.sqlite",
+                "eTag": '"new"',
+            }],
+            "deletions": [{"path": "deleted.md", "deleted": True}],
+        }
+        malformed = [
+            {**valid, "extra": True},
+            {**valid, "checkpointCommitted": False},
+            {**valid, "workspaceGeneration": "A" * 64},
+            {**valid, "uploads": []},
+            {
+                **valid,
+                "uploads": [{**valid["uploads"][0], "extra": True}],
+            },
+            {
+                **valid,
+                "uploads": [{
+                    **valid["uploads"][0],
+                    "reservationId":
+                        "46bb0456-1c51-4fb8-97d1-4e87d02765ce",
+                }],
+            },
+            {**valid, "deletions": []},
+            {
+                **valid,
+                "deletions": [{"path": "other.md", "deleted": True}],
+            },
+            {
+                **valid,
+                "deletions": [{"path": "deleted.md", "deleted": 1}],
+            },
+        ]
+
+        for result in malformed:
+            with self.subTest(result=result), mock.patch.object(
+                workspace_sync,
+                "_broker_request",
+                return_value=result,
+            ):
+                with self.assertRaises(
+                    workspace_sync.WorkspacePushIncomplete
+                ):
+                    workspace_sync._finalize_workspace_checkpoint(
+                        "0" * 64,
+                        "opaque-proof",
+                        (reservation,),
+                        ("deleted.md",),
+                    )
+
+    def test_atomic_finalize_rejects_untransportable_proof_before_request(self):
+        reservation = "36bb0456-1c51-4fb8-97d1-4e87d02765ce"
+        for proof in ("x" * 4_097, "\ud800"):
+            with self.subTest(proof_length=len(proof)), mock.patch.object(
+                workspace_sync,
+                "_broker_request",
+            ) as broker:
+                with self.assertRaises(
+                    workspace_sync.WorkspacePushIncomplete
+                ):
+                    workspace_sync._finalize_workspace_checkpoint(
+                        "0" * 64,
+                        proof,
+                        (reservation,),
+                        (),
+                    )
+            broker.assert_not_called()
+
+    def test_atomic_finalize_request_matches_route_uuid_and_item_limits(self):
+        invalid_reservations = (
+            # UUID version nibble must be RFC 1-8.
+            "36bb0456-1c51-0fb8-97d1-4e87d02765ce",
+            # UUID variant nibble must be RFC 8, 9, a, or b.
+            "36bb0456-1c51-4fb8-77d1-4e87d02765ce",
+        )
+        for reservation in invalid_reservations:
+            with self.subTest(reservation=reservation), mock.patch.object(
+                workspace_sync,
+                "_broker_request",
+            ) as broker:
+                with self.assertRaises(
+                    workspace_sync.WorkspacePushIncomplete
+                ):
+                    workspace_sync._finalize_workspace_checkpoint(
+                        "0" * 64,
+                        "opaque-proof",
+                        (reservation,),
+                        (),
+                    )
+            broker.assert_not_called()
+
+        valid_reservation = "36bb0456-1c51-4fb8-97d1-4e87d02765ce"
+        with mock.patch.object(
+            workspace_sync,
+            "MAX_WORKSPACE_FINALIZATION_ITEMS",
+            1,
+        ), mock.patch.object(
+            workspace_sync,
+            "_broker_request",
+        ) as broker:
+            with self.assertRaises(workspace_sync.WorkspacePushIncomplete):
+                workspace_sync._finalize_workspace_checkpoint(
+                    "0" * 64,
+                    "opaque-proof",
+                    (valid_reservation,),
+                    ("deleted.md",),
+                )
+        broker.assert_not_called()
+
+    def test_atomic_finalize_falls_back_only_for_parse_time_old_route_400(self):
+        local = self.root / "state.sqlite"
+        local.write_bytes(b"new-history")
+        metadata = local.stat()
+        reservation = "36bb0456-1c51-4fb8-97d1-4e87d02765ce"
+        base_generation = workspace_sync._generation_for_entries({})
+        final_generation = workspace_sync._generation_for_entries({
+            "state.sqlite": (metadata.st_size, '"new"'),
+        })
+        workspace_sync._remote_workspace_snapshots["owner"] = (
+            workspace_sync._RemoteWorkspaceSnapshot(
+                paths=(), sizes={}, e_tags={}, generation=base_generation
+            )
+        )
+        workspace_sync._committed_workspace_generations["owner"] = (
+            base_generation
+        )
+        workspace_sync._atomic_checkpoint_finalization_capabilities[
+            "owner"
+        ] = workspace_sync._AtomicCheckpointFinalizationCapability(
+            version=1,
+            proof="opaque-proof",
+        )
+        prepared = workspace_sync._PreparedWorkspaceUpload(
+            upload_url="https://upload.invalid/state",
+            reservation_id=reservation,
+            required_headers={},
+        )
+        old_route_rejection = workspace_sync._WorkspaceBrokerHttpError(
+            400,
+            '{"error":"Invalid storage request"}',
+            {"error": "Invalid storage request"},
+        )
+
+        def commit(prefix, base, final, _deadline):
+            self.assertEqual((prefix, base, final), (
+                "owner", base_generation, final_generation
+            ))
+            workspace_sync._committed_workspace_generations[prefix] = final
+            return final
+
+        with mock.patch.object(
+            workspace_sync, "WORKSPACE_DIR", self.root
+        ), mock.patch.object(
+            workspace_sync, "_upload_spec", return_value=prepared
+        ), mock.patch.object(
+            workspace_sync, "_stream_upload"
+        ), mock.patch.object(
+            workspace_sync,
+            "_broker_request",
+            side_effect=old_route_rejection,
+        ), mock.patch.object(
+            workspace_sync,
+            "_complete_upload_reservation",
+            return_value=(final_generation, '"new"'),
+        ) as complete, mock.patch.object(
+            workspace_sync,
+            "_commit_workspace_checkpoint",
+            side_effect=commit,
+        ) as checkpoint:
+            self.assertEqual(
+                workspace_sync.push_workspace(
+                    "owner",
+                    expected_generation=base_generation,
+                    require_generation=True,
+                ),
+                1,
+            )
+
+        complete.assert_called_once_with(reservation, base_generation, None)
+        checkpoint.assert_called_once()
+        self.assertNotIn(
+            "owner",
+            workspace_sync._atomic_checkpoint_finalization_capabilities,
+        )
+        self.assertEqual(
+            workspace_sync.workspace_generation("owner"),
+            final_generation,
+        )
+
+    def test_old_route_fallback_completes_migration_marker_last(self):
+        database = self.root / "state" / "openclaw.sqlite"
+        database.parent.mkdir(parents=True)
+        database.write_bytes(b"database")
+        with mock.patch.object(workspace_sync, "WORKSPACE_DIR", self.root):
+            workspace_sync.mark_openclaw_migration_complete()
+        marker = self.root / workspace_sync.OPENCLAW_MIGRATION_MARKER
+        base_generation = workspace_sync._generation_for_entries({})
+        database_generation = workspace_sync._generation_for_entries({
+            "state/openclaw.sqlite": (database.stat().st_size, '"database"'),
+        })
+        final_generation = workspace_sync._generation_for_entries({
+            "state/openclaw.sqlite": (database.stat().st_size, '"database"'),
+            workspace_sync.OPENCLAW_MIGRATION_MARKER: (
+                marker.stat().st_size,
+                '"marker"',
+            ),
+        })
+        workspace_sync._remote_workspace_snapshots["owner"] = (
+            workspace_sync._RemoteWorkspaceSnapshot(
+                paths=(),
+                sizes={},
+                e_tags={},
+                generation=base_generation,
+            )
+        )
+        workspace_sync._committed_workspace_generations["owner"] = (
+            base_generation
+        )
+        workspace_sync._atomic_checkpoint_finalization_capabilities[
+            "owner"
+        ] = workspace_sync._AtomicCheckpointFinalizationCapability(
+            version=1,
+            proof="opaque-proof",
+        )
+        reservations = {
+            "state/openclaw.sqlite":
+                "36bb0456-1c51-4fb8-97d1-4e87d02765ce",
+            workspace_sync.OPENCLAW_MIGRATION_MARKER:
+                "46bb0456-1c51-4fb8-97d1-4e87d02765ce",
+        }
+        staged_paths = []
+        completion_order = []
+
+        def prepare(relative, *_args):
+            staged_paths.append(relative)
+            return workspace_sync._PreparedWorkspaceUpload(
+                upload_url=f"https://upload.invalid/{relative}",
+                reservation_id=reservations[relative],
+                required_headers={},
+            )
+
+        def complete(reservation, generation, _deadline):
+            completion_order.append(reservation)
+            if reservation == reservations["state/openclaw.sqlite"]:
+                self.assertEqual(generation, base_generation)
+                return database_generation, '"database"'
+            self.assertEqual(generation, database_generation)
+            return final_generation, '"marker"'
+
+        def commit(prefix, base, final, _deadline):
+            self.assertEqual(
+                (prefix, base, final),
+                ("owner", base_generation, final_generation),
+            )
+            workspace_sync._committed_workspace_generations[prefix] = final
+            return final
+
+        old_route_rejection = workspace_sync._WorkspaceBrokerHttpError(
+            400,
+            '{"error":"Invalid storage request"}',
+            {"error": "Invalid storage request"},
+        )
+        with mock.patch.object(
+            workspace_sync, "WORKSPACE_DIR", self.root
+        ), mock.patch.object(
+            workspace_sync, "_upload_spec", side_effect=prepare
+        ), mock.patch.object(
+            workspace_sync, "_stream_upload"
+        ), mock.patch.object(
+            workspace_sync,
+            "_broker_request",
+            side_effect=old_route_rejection,
+        ), mock.patch.object(
+            workspace_sync,
+            "_complete_upload_reservation",
+            side_effect=complete,
+        ), mock.patch.object(
+            workspace_sync,
+            "_commit_workspace_checkpoint",
+            side_effect=commit,
+        ):
+            self.assertEqual(
+                workspace_sync.push_workspace(
+                    "owner",
+                    expected_generation=base_generation,
+                    require_generation=True,
+                ),
+                2,
+            )
+
+        self.assertEqual(
+            staged_paths,
+            [
+                "state/openclaw.sqlite",
+                workspace_sync.OPENCLAW_MIGRATION_MARKER,
+            ],
+        )
+        self.assertEqual(
+            completion_order,
+            [
+                reservations["state/openclaw.sqlite"],
+                reservations[workspace_sync.OPENCLAW_MIGRATION_MARKER],
+            ],
+        )
+
+    def test_atomic_finalize_does_not_fallback_for_ambiguous_400(self):
+        pending = workspace_sync._PendingAtomicWorkspaceFinalization(
+            base_generation="0" * 64,
+            proof="opaque-proof",
+            uploads=(),
+            unchanged_uploads=(),
+            deleted_paths=(),
+            base_entries=(),
+        )
+        workspace_sync._pending_workspace_generations["owner"] = "0" * 64
+        workspace_sync._pending_atomic_workspace_finalizations[
+            "owner"
+        ] = pending
+        workspace_sync._committed_workspace_generations["owner"] = "0" * 64
+        ambiguous = workspace_sync._WorkspaceBrokerHttpError(
+            400,
+            '{"error":"Workspace storage operation failed"}',
+            {"error": "Workspace storage operation failed"},
+        )
+
+        with mock.patch.object(
+            workspace_sync, "WORKSPACE_DIR", self.root
+        ), mock.patch.object(
+            workspace_sync,
+            "_broker_request",
+            side_effect=ambiguous,
+        ), mock.patch.object(
+            workspace_sync, "_commit_workspace_checkpoint"
+        ) as legacy_commit:
+            with self.assertRaises(workspace_sync._WorkspaceBrokerHttpError):
+                workspace_sync.push_workspace(
+                    "owner",
+                    expected_generation="0" * 64,
+                    require_generation=True,
+                )
+
+        legacy_commit.assert_not_called()
+        self.assertIs(
+            workspace_sync._pending_atomic_workspace_finalizations["owner"],
+            pending,
+        )
+
+    def test_pending_atomic_retry_never_falls_back_after_prior_ambiguity(self):
+        generation = workspace_sync._generation_for_entries({})
+        workspace_sync._remote_workspace_snapshots["owner"] = (
+            workspace_sync._RemoteWorkspaceSnapshot(
+                paths=(), sizes={}, e_tags={}, generation=generation
+            )
+        )
+        workspace_sync._committed_workspace_generations["owner"] = generation
+        workspace_sync._atomic_checkpoint_finalization_capabilities[
+            "owner"
+        ] = workspace_sync._AtomicCheckpointFinalizationCapability(
+            version=1,
+            proof="opaque-proof",
+        )
+        broker_url = (
+            "http://127.0.0.1:18791"
+            "/agent-broker/api/agent/workspace-storage"
+        )
+        transient = workspace_sync.urllib.error.HTTPError(
+            broker_url,
+            502,
+            "Bad Gateway",
+            {},
+            io.BytesIO(b"temporary"),
+        )
+        old_route_rejection = workspace_sync.urllib.error.HTTPError(
+            broker_url,
+            400,
+            "Bad Request",
+            {},
+            io.BytesIO(b'{"error":"Invalid storage request"}'),
+        )
+        next_invocation_old_route_rejection = (
+            workspace_sync.urllib.error.HTTPError(
+                broker_url,
+                400,
+                "Bad Request",
+                {},
+                io.BytesIO(b'{"error":"Invalid storage request"}'),
+            )
+        )
+
+        with mock.patch.object(
+            workspace_sync, "WORKSPACE_DIR", self.root
+        ), mock.patch.object(
+            workspace_sync.urllib.request,
+            "urlopen",
+            side_effect=[
+                transient,
+                old_route_rejection,
+                next_invocation_old_route_rejection,
+            ],
+        ) as request, mock.patch.object(
+            workspace_sync.time, "sleep"
+        ) as sleep, mock.patch.object(
+            workspace_sync,
+            "_legacy_finalize_pending_atomic_workspace",
+        ) as legacy_fallback:
+            with self.assertRaises(
+                workspace_sync._WorkspaceBrokerHttpError
+            ) as raised:
+                workspace_sync.push_workspace(
+                    "owner",
+                    expected_generation=generation,
+                    require_generation=True,
+                )
+            pending = (
+                workspace_sync._pending_atomic_workspace_finalizations[
+                    "owner"
+                ]
+            )
+            # The next invocation reaches an old task on its first attempt.
+            # That 400 is locally parse-time-safe but cannot erase ambiguity
+            # from the retained batch's earlier new-task attempt.
+            with self.assertRaises(
+                workspace_sync._WorkspaceBrokerHttpError
+            ) as retried:
+                workspace_sync.push_workspace(
+                    "owner",
+                    expected_generation=generation,
+                    require_generation=True,
+                )
+
+        self.assertEqual(request.call_count, 3)
+        sleep.assert_called_once_with(0.25)
+        self.assertEqual(raised.exception.status, 400)
+        self.assertEqual(raised.exception.prior_transient_attempts, 1)
+        self.assertFalse(
+            workspace_sync._is_side_effect_free_finalize_rejection(
+                raised.exception
+            )
+        )
+        self.assertEqual(retried.exception.status, 400)
+        self.assertEqual(retried.exception.prior_transient_attempts, 0)
+        self.assertTrue(
+            workspace_sync._is_side_effect_free_finalize_rejection(
+                retried.exception
+            )
+        )
+        legacy_fallback.assert_not_called()
+        self.assertIs(
+            workspace_sync._pending_atomic_workspace_finalizations["owner"],
+            pending,
         )
 
 

--- a/infra/agent-image/workspace_sync.py
+++ b/infra/agent-image/workspace_sync.py
@@ -88,6 +88,8 @@ class _RemoteWorkspaceSnapshot:
 class _EnsuredWorkspaceCheckpoint:
     generation: str
     snapshot: Optional[_RemoteWorkspaceSnapshot]
+    atomic_checkpoint_commit_version: Optional[int] = None
+    checkpoint_finalization_proof: Optional[str] = None
 
 
 @dataclass(frozen=True)
@@ -105,6 +107,45 @@ class _PendingWorkspaceCompletion:
     content_length: int
     modified_ns: int
     changed_ns: int
+
+
+@dataclass(frozen=True)
+class _AtomicCheckpointFinalizationCapability:
+    version: int
+    proof: str
+
+
+@dataclass(frozen=True)
+class _PendingAtomicWorkspaceFinalization:
+    base_generation: str
+    proof: str
+    uploads: tuple[_PendingWorkspaceCompletion, ...]
+    unchanged_uploads: tuple[tuple[str, int, int, int, str], ...]
+    deleted_paths: tuple[str, ...]
+    base_entries: tuple[tuple[str, int, str], ...]
+
+
+@dataclass(frozen=True)
+class _FinalizedWorkspaceCheckpoint:
+    generation: str
+    uploads: tuple[tuple[str, str, str], ...]
+    deletions: tuple[tuple[str, bool], ...]
+
+
+class _WorkspaceBrokerHttpError(RuntimeError):
+    """An HTTP rejection whose exact response remains available to callers."""
+
+    def __init__(
+        self,
+        status: int,
+        detail: str,
+        error_body: object,
+        prior_transient_attempts: int = 0,
+    ):
+        super().__init__(f"workspace broker HTTP {status}: {detail}")
+        self.status = status
+        self.error_body = error_body
+        self.prior_transient_attempts = prior_transient_attempts
 
 
 WORKSPACE_DIR = Path("/home/node/.openclaw")
@@ -182,12 +223,14 @@ _TRANSIENT_HTTP_STATUSES = frozenset({408, 429, 500, 502, 503, 504})
 # deliberately not auto-retried: a client timeout does not prove the web tier
 # stopped working, and overlapping retries would queue behind the same lock.
 WORKSPACE_CHECKPOINT_BROKER_TIMEOUT_SECONDS = 240
-# Generation-fenced mutations scan the authoritative workspace while holding
-# the broker lock. Large migrated workspaces can legitimately take more than
-# the generic 20-second read timeout. Keep one request alive long enough to
-# settle rather than launching an overlapping retry; the turn-wide deadline
-# remains the hard upper bound.
+# Atomic finalization uses the checkpoint manifest and proof instead of
+# rescanning once per mutation. Mixed-version and legacy fallback operations
+# can still perform generation-fenced scans while holding the broker lock, so
+# keep one request alive beyond the generic 20-second read timeout; the
+# turn-wide deadline remains the hard upper bound.
 WORKSPACE_MUTATION_BROKER_TIMEOUT_SECONDS = 60
+MAX_WORKSPACE_FINALIZATION_PROOF_BYTES = 4 * 1024
+MAX_WORKSPACE_FINALIZATION_ITEMS = 250_000
 WORKSPACE_FLUSH_TOKEN_PATH = (
     "/run/psd-agent-authority/workspace-flush-token"
 )
@@ -200,6 +243,9 @@ _remote_workspace_snapshots: dict[str, _RemoteWorkspaceSnapshot] = {}
 # complete turn. Individual S3 target versions are promoted one at a time, so
 # their raw generation is not committed until the manifest advances last.
 _committed_workspace_generations: dict[str, str] = {}
+_atomic_checkpoint_finalization_capabilities: dict[
+    str, _AtomicCheckpointFinalizationCapability
+] = {}
 # When target promotions succeeded but final verification/listing did not, the
 # wrapper remains dirty and retries from this broker-returned generation. Do
 # not discard it on transient post-commit errors: that would strand a fully
@@ -207,6 +253,9 @@ _committed_workspace_generations: dict[str, str] = {}
 _pending_workspace_generations: dict[str, str] = {}
 _pending_workspace_completions: dict[
     str, _PendingWorkspaceCompletion
+] = {}
+_pending_atomic_workspace_finalizations: dict[
+    str, _PendingAtomicWorkspaceFinalization
 ] = {}
 _force_exact_workspace_restores: set[str] = set()
 
@@ -827,8 +876,10 @@ def invalidate_local_workspace(prefix: str) -> None:
         return
     _remote_workspace_snapshots.pop(prefix, None)
     _committed_workspace_generations.pop(prefix, None)
+    _atomic_checkpoint_finalization_capabilities.pop(prefix, None)
     _pending_workspace_generations.pop(prefix, None)
     _pending_workspace_completions.pop(prefix, None)
+    _pending_atomic_workspace_finalizations.pop(prefix, None)
     for state_key in [
         key for key in _uploaded_state if key[0] == prefix
     ]:
@@ -1299,8 +1350,15 @@ def _broker_request(
                 detail = exc.read(500).decode("utf-8", errors="replace")
             finally:
                 exc.close()
-            error = RuntimeError(
-                f"workspace broker HTTP {exc.code}: {detail}"
+            try:
+                error_body: object = json.loads(detail)
+            except (TypeError, ValueError):
+                error_body = None
+            error = _WorkspaceBrokerHttpError(
+                exc.code,
+                detail,
+                error_body,
+                prior_transient_attempts=attempt,
             )
             if exc.code not in _TRANSIENT_HTTP_STATUSES:
                 raise error from exc
@@ -1597,6 +1655,17 @@ def _parse_checkpoint_snapshot(
     )
 
 
+def _is_valid_checkpoint_finalization_proof(value: object) -> bool:
+    """Return whether an opaque proof can be transported losslessly as UTF-8."""
+    if not isinstance(value, str) or not value:
+        return False
+    try:
+        encoded = value.encode("utf-8", errors="strict")
+    except UnicodeEncodeError:
+        return False
+    return len(encoded) <= MAX_WORKSPACE_FINALIZATION_PROOF_BYTES
+
+
 def _ensure_workspace_checkpoint(
     prefix: str,
     deadline_monotonic: float | None = None,
@@ -1618,6 +1687,24 @@ def _ensure_workspace_checkpoint(
         raise WorkspaceGenerationUnavailable(
             "workspace broker did not establish a durable checkpoint"
         )
+    has_atomic_version = "atomicCheckpointCommitVersion" in result
+    has_finalization_proof = "checkpointFinalizationProof" in result
+    atomic_version = result.get("atomicCheckpointCommitVersion")
+    finalization_proof = result.get("checkpointFinalizationProof")
+    if has_atomic_version != has_finalization_proof:
+        raise WorkspaceGenerationUnavailable(
+            "workspace broker returned an incomplete finalization capability"
+        )
+    if has_atomic_version and (
+        atomic_version != 1
+        or isinstance(atomic_version, bool)
+        or not _is_valid_checkpoint_finalization_proof(
+            finalization_proof
+        )
+    ):
+        raise WorkspaceGenerationUnavailable(
+            "workspace broker returned a malformed finalization capability"
+        )
     snapshot = (
         _parse_checkpoint_snapshot(
             result["checkpointSnapshot"],
@@ -1629,6 +1716,12 @@ def _ensure_workspace_checkpoint(
     return _EnsuredWorkspaceCheckpoint(
         generation=generation,
         snapshot=snapshot,
+        atomic_checkpoint_commit_version=(
+            atomic_version if has_atomic_version else None
+        ),
+        checkpoint_finalization_proof=(
+            finalization_proof if has_finalization_proof else None
+        ),
     )
 
 
@@ -1660,6 +1753,133 @@ def _commit_workspace_checkpoint(
         )
     _committed_workspace_generations[prefix] = committed_generation
     return committed_generation
+
+
+def _finalize_workspace_checkpoint(
+    base_generation: str,
+    proof: str,
+    reservation_ids: tuple[str, ...],
+    deleted_paths: tuple[str, ...],
+    deadline_monotonic: float | None = None,
+) -> _FinalizedWorkspaceCheckpoint:
+    """Atomically promote every staged mutation and publish its checkpoint."""
+    if (
+        not re.fullmatch(r"[0-9a-f]{64}", base_generation)
+        or not _is_valid_checkpoint_finalization_proof(proof)
+        or len({value.lower() for value in reservation_ids}) != len(
+            reservation_ids
+        )
+        or len(set(deleted_paths)) != len(deleted_paths)
+        or (
+            len(reservation_ids) + len(deleted_paths)
+            > MAX_WORKSPACE_FINALIZATION_ITEMS
+        )
+        or any(
+            re.fullmatch(
+                r"[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-"
+                r"[89ab][0-9a-f]{3}-[0-9a-f]{12}",
+                reservation_id,
+                flags=re.IGNORECASE,
+            ) is None
+            for reservation_id in reservation_ids
+        )
+    ):
+        raise WorkspacePushIncomplete(
+            "workspace atomic finalization request is malformed"
+        )
+    result = _broker_request(
+        {
+            "operation": "finalize-checkpoint",
+            "baseWorkspaceGeneration": base_generation,
+            "checkpointFinalizationProof": proof,
+            "reservationIds": list(reservation_ids),
+            "deletedPaths": list(deleted_paths),
+        },
+        deadline_monotonic,
+        retry_transient=True,
+        maximum_timeout_seconds=(
+            WORKSPACE_MUTATION_BROKER_TIMEOUT_SECONDS
+        ),
+    )
+    if set(result) != {
+        "checkpointCommitted",
+        "workspaceGeneration",
+        "uploads",
+        "deletions",
+    }:
+        raise WorkspacePushIncomplete(
+            "workspace broker returned a malformed atomic finalization"
+        )
+    generation = result.get("workspaceGeneration")
+    raw_uploads = result.get("uploads")
+    raw_deletions = result.get("deletions")
+    if (
+        result.get("checkpointCommitted") is not True
+        or not isinstance(generation, str)
+        or re.fullmatch(r"[0-9a-f]{64}", generation) is None
+        or not isinstance(raw_uploads, list)
+        or not isinstance(raw_deletions, list)
+        or len(raw_uploads) != len(reservation_ids)
+        or len(raw_deletions) != len(deleted_paths)
+    ):
+        raise WorkspacePushIncomplete(
+            "workspace broker returned a malformed atomic finalization"
+        )
+
+    uploads: list[tuple[str, str, str]] = []
+    for expected_reservation_id, entry in zip(
+        reservation_ids,
+        raw_uploads,
+    ):
+        if (
+            not isinstance(entry, dict)
+            or set(entry) != {"reservationId", "key", "eTag"}
+            or entry.get("reservationId") != expected_reservation_id
+            or not isinstance(entry.get("key"), str)
+            or not entry["key"]
+            or not isinstance(entry.get("eTag"), str)
+            or not entry["eTag"]
+            or len(entry["eTag"]) > 1_024
+        ):
+            raise WorkspacePushIncomplete(
+                "workspace broker returned a malformed atomic upload result"
+            )
+        uploads.append(
+            (entry["reservationId"], entry["key"], entry["eTag"])
+        )
+
+    deletions: list[tuple[str, bool]] = []
+    for expected_path, entry in zip(deleted_paths, raw_deletions):
+        if (
+            not isinstance(entry, dict)
+            or set(entry) != {"path", "deleted"}
+            or entry.get("path") != expected_path
+            or not isinstance(entry.get("deleted"), bool)
+        ):
+            raise WorkspacePushIncomplete(
+                "workspace broker returned a malformed atomic deletion result"
+            )
+        deletions.append((entry["path"], entry["deleted"]))
+
+    return _FinalizedWorkspaceCheckpoint(
+        generation=generation,
+        uploads=tuple(uploads),
+        deletions=tuple(deletions),
+    )
+
+
+def _is_side_effect_free_finalize_rejection(error: BaseException) -> bool:
+    """Return whether the first wire attempt was rejected before dispatch.
+
+    A later old-task 400 cannot erase ambiguity from an earlier timeout or
+    transient response that may have followed a successful new-task commit.
+    """
+    return (
+        isinstance(error, _WorkspaceBrokerHttpError)
+        and error.status == 400
+        and error.prior_transient_attempts == 0
+        and error.error_body == {"error": "Invalid storage request"}
+    )
 
 
 def _download_bounded(
@@ -2113,6 +2333,7 @@ def pull_workspace(
         _remote_workspace_snapshots[prefix] = snapshot
     _pending_workspace_generations.pop(prefix, None)
     _pending_workspace_completions.pop(prefix, None)
+    _pending_atomic_workspace_finalizations.pop(prefix, None)
     _force_exact_workspace_restores.discard(prefix)
 
     logger.info(
@@ -2137,6 +2358,18 @@ def refresh_workspace(prefix: str) -> int:
     # its migration gate can keep a reused microVM permanently bricked.
     _discard_retired_local_control_state()
     checkpoint = _ensure_workspace_checkpoint(prefix)
+    if (
+        checkpoint.atomic_checkpoint_commit_version == 1
+        and checkpoint.checkpoint_finalization_proof is not None
+    ):
+        _atomic_checkpoint_finalization_capabilities[prefix] = (
+            _AtomicCheckpointFinalizationCapability(
+                version=1,
+                proof=checkpoint.checkpoint_finalization_proof,
+            )
+        )
+    else:
+        _atomic_checkpoint_finalization_capabilities.pop(prefix, None)
     snapshot = checkpoint.snapshot
     if snapshot is None:
         # Rolling compatibility: an older broker does not include the
@@ -2460,6 +2693,178 @@ def _remote_mutable_paths_to_delete(
     )
 
 
+def _apply_atomic_workspace_finalization(
+    prefix: str,
+    pending: _PendingAtomicWorkspaceFinalization,
+    finalized: _FinalizedWorkspaceCheckpoint,
+) -> str:
+    """Validate the batch generation before publishing any local cache state."""
+    final_entries = {
+        relative: (size, e_tag)
+        for relative, size, e_tag in pending.base_entries
+    }
+    for relative in pending.deleted_paths:
+        final_entries.pop(relative, None)
+    for (
+        relative,
+        content_length,
+        _modified_ns,
+        _changed_ns,
+        e_tag,
+    ) in pending.unchanged_uploads:
+        final_entries[relative] = (content_length, e_tag)
+    if len(finalized.uploads) != len(pending.uploads):
+        raise WorkspacePushIncomplete(
+            "workspace atomic finalization omitted an upload"
+        )
+    for completion, upload in zip(pending.uploads, finalized.uploads):
+        reservation_id, key, e_tag = upload
+        if (
+            reservation_id != completion.reservation_id
+            or key != f"{prefix}/{completion.relative}"
+        ):
+            raise WorkspacePushIncomplete(
+                "workspace atomic finalization returned mismatched upload metadata"
+            )
+        final_entries[completion.relative] = (
+            completion.content_length,
+            e_tag,
+        )
+
+    synthesized_generation = _generation_for_entries(final_entries)
+    if synthesized_generation != finalized.generation:
+        raise WorkspaceGenerationConflict(
+            "workspace atomic mutation results did not form the broker generation"
+        )
+
+    # Publish caches only after the complete response and local generation have
+    # been verified. A malformed/lost response leaves the exact batch pending.
+    for relative in pending.deleted_paths:
+        _uploaded_state.pop((prefix, relative), None)
+    for completion in pending.uploads:
+        _uploaded_state[(prefix, completion.relative)] = (
+            completion.content_length,
+            completion.modified_ns,
+            completion.changed_ns,
+        )
+    for (
+        relative,
+        content_length,
+        modified_ns,
+        changed_ns,
+        _e_tag,
+    ) in pending.unchanged_uploads:
+        _uploaded_state[(prefix, relative)] = (
+            content_length,
+            modified_ns,
+            changed_ns,
+        )
+
+    committed = _RemoteWorkspaceSnapshot(
+        paths=tuple(sorted(final_entries)),
+        sizes={
+            relative: metadata[0]
+            for relative, metadata in final_entries.items()
+        },
+        e_tags={
+            relative: metadata[1]
+            for relative, metadata in final_entries.items()
+        },
+        generation=finalized.generation,
+    )
+    _remote_workspace_snapshots[prefix] = committed
+    _committed_workspace_generations[prefix] = finalized.generation
+    _atomic_checkpoint_finalization_capabilities.pop(prefix, None)
+    _pending_workspace_generations.pop(prefix, None)
+    _pending_workspace_completions.pop(prefix, None)
+    _pending_atomic_workspace_finalizations.pop(prefix, None)
+    return finalized.generation
+
+
+def _legacy_finalize_pending_atomic_workspace(
+    prefix: str,
+    pending: _PendingAtomicWorkspaceFinalization,
+    deadline_monotonic: float | None,
+) -> str:
+    """Finish a parse-time-rejected batch through the old fenced protocol."""
+    _atomic_checkpoint_finalization_capabilities.pop(prefix, None)
+    _pending_atomic_workspace_finalizations.pop(prefix, None)
+    current_generation = pending.base_generation
+    final_entries = {
+        relative: (size, e_tag)
+        for relative, size, e_tag in pending.base_entries
+    }
+    for relative in pending.deleted_paths:
+        current_generation = _delete_workspace_path(
+            relative,
+            current_generation,
+            deadline_monotonic,
+        )
+        final_entries.pop(relative, None)
+        _uploaded_state.pop((prefix, relative), None)
+        _pending_workspace_generations[prefix] = current_generation
+
+    for completion in pending.uploads:
+        _pending_workspace_completions[prefix] = completion
+        current_generation, e_tag = _complete_upload_reservation(
+            completion.reservation_id,
+            current_generation,
+            deadline_monotonic,
+        )
+        _pending_workspace_completions.pop(prefix, None)
+        _uploaded_state[(prefix, completion.relative)] = (
+            completion.content_length,
+            completion.modified_ns,
+            completion.changed_ns,
+        )
+        final_entries[completion.relative] = (
+            completion.content_length,
+            e_tag,
+        )
+        _pending_workspace_generations[prefix] = current_generation
+
+    for (
+        relative,
+        content_length,
+        modified_ns,
+        changed_ns,
+        e_tag,
+    ) in pending.unchanged_uploads:
+        _uploaded_state[(prefix, relative)] = (
+            content_length,
+            modified_ns,
+            changed_ns,
+        )
+        final_entries[relative] = (content_length, e_tag)
+
+    synthesized_generation = _generation_for_entries(final_entries)
+    if synthesized_generation != current_generation:
+        raise WorkspaceGenerationConflict(
+            "workspace mutation results did not form the broker generation"
+        )
+    _commit_workspace_checkpoint(
+        prefix,
+        pending.base_generation,
+        current_generation,
+        deadline_monotonic,
+    )
+    _remote_workspace_snapshots[prefix] = _RemoteWorkspaceSnapshot(
+        paths=tuple(sorted(final_entries)),
+        sizes={
+            relative: metadata[0]
+            for relative, metadata in final_entries.items()
+        },
+        e_tags={
+            relative: metadata[1]
+            for relative, metadata in final_entries.items()
+        },
+        generation=current_generation,
+    )
+    _pending_workspace_generations.pop(prefix, None)
+    _pending_workspace_completions.pop(prefix, None)
+    return current_generation
+
+
 def push_workspace(
     prefix: str,
     deadline_monotonic: float | None = None,
@@ -2582,6 +2987,7 @@ def push_workspace(
         continuing_pending_push = (
             prefix in _pending_workspace_generations
             or prefix in _pending_workspace_completions
+            or prefix in _pending_atomic_workspace_finalizations
         )
         base_checkpoint_generation = _committed_workspace_generations.get(
             prefix
@@ -2596,6 +3002,76 @@ def push_workspace(
             raise WorkspaceGenerationUnavailable(
                 "committed workspace checkpoint is unavailable"
             )
+        pending_atomic = _pending_atomic_workspace_finalizations.get(prefix)
+        if pending_atomic is not None:
+            if (
+                current_generation != pending_atomic.base_generation
+                or base_checkpoint_generation
+                != pending_atomic.base_generation
+            ):
+                raise WorkspaceGenerationConflict(
+                    "pending atomic finalization lost its base generation"
+                )
+            current_pairs = list(to_upload)
+            if marker_upload is not None:
+                current_pairs.append(marker_upload)
+            current_signatures = {
+                pair[1]: (pair[2], pair[3], pair[4])
+                for pair in current_pairs
+            }
+            pending_signatures = {
+                completion.relative: (
+                    completion.content_length,
+                    completion.modified_ns,
+                    completion.changed_ns,
+                )
+                for completion in pending_atomic.uploads
+            }
+            pending_signatures.update({
+                relative: (content_length, modified_ns, changed_ns)
+                for (
+                    relative,
+                    content_length,
+                    modified_ns,
+                    changed_ns,
+                    _e_tag,
+                ) in pending_atomic.unchanged_uploads
+            })
+            if (
+                current_signatures != pending_signatures
+                or any(
+                    relative in local_mutable_paths
+                    for relative in pending_atomic.deleted_paths
+                )
+            ):
+                raise WorkspaceGenerationConflict(
+                    "local workspace changed while atomic finalization was pending"
+                )
+            # A retained batch has already crossed an ambiguous attempt
+            # boundary. Even an exact old-route 400 on this later invocation
+            # cannot prove the original attempt was side-effect-free, so only
+            # an idempotent atomic replay may resolve it.
+            finalized = _finalize_workspace_checkpoint(
+                pending_atomic.base_generation,
+                pending_atomic.proof,
+                tuple(
+                    completion.reservation_id
+                    for completion in pending_atomic.uploads
+                ),
+                pending_atomic.deleted_paths,
+                deadline_monotonic,
+            )
+            current_generation = _apply_atomic_workspace_finalization(
+                prefix,
+                pending_atomic,
+                finalized,
+            )
+            logger.info(
+                "workspace push resumed: prefix=%s generation=%s",
+                prefix,
+                current_generation[:12],
+            )
+            return 0
         if (
             not continuing_pending_push
             and base_checkpoint_generation != current_generation
@@ -2831,6 +3307,19 @@ def push_workspace(
             f"workspace push incomplete ({len(stage_errors)} file error(s)) "
             f"for prefix {prefix}"
         )
+    # Stage the migration marker last. Atomic-capable brokers promote this
+    # reservation in the same checkpoint as every database/state object; the
+    # legacy path below still completes it after the earlier staged entries.
+    if marker_upload is not None:
+        marker_pair, marker_prepared, marker_error = _stage_one(
+            marker_upload
+        )
+        if marker_error is not None or marker_prepared is None:
+            raise WorkspacePushIncomplete(
+                "workspace push incomplete (migration marker stage failed) "
+                f"for prefix {prefix}: {marker_error or 'unknown error'}"
+            )
+        staged.append((marker_pair, marker_prepared))
 
     try:
         assert current_generation is not None
@@ -2845,6 +3334,89 @@ def push_workspace(
             if require_generation
             else {}
         )
+        capability = _atomic_checkpoint_finalization_capabilities.get(prefix)
+        if require_generation and capability is not None:
+            pending_uploads: list[_PendingWorkspaceCompletion] = []
+            unchanged_uploads: list[
+                tuple[str, int, int, int, str]
+            ] = []
+            for pair, prepared in staged:
+                if prepared.unchanged_e_tag is not None:
+                    unchanged_uploads.append((
+                        pair[1],
+                        pair[2],
+                        pair[3],
+                        pair[4],
+                        prepared.unchanged_e_tag,
+                    ))
+                    continue
+                if prepared.reservation_id is None:
+                    raise WorkspacePushIncomplete(
+                        "workspace atomic upload reservation is unavailable"
+                    )
+                pending_uploads.append(_PendingWorkspaceCompletion(
+                    reservation_id=prepared.reservation_id,
+                    relative=pair[1],
+                    content_length=pair[2],
+                    modified_ns=pair[3],
+                    changed_ns=pair[4],
+                ))
+            pending_atomic = _PendingAtomicWorkspaceFinalization(
+                base_generation=base_checkpoint_generation,
+                proof=capability.proof,
+                uploads=tuple(pending_uploads),
+                unchanged_uploads=tuple(unchanged_uploads),
+                deleted_paths=tuple(to_delete),
+                base_entries=tuple(
+                    (
+                        relative,
+                        before_upload.sizes[relative],
+                        before_upload.e_tags[relative],
+                    )
+                    for relative in before_upload.paths
+                ),
+            )
+            _pending_atomic_workspace_finalizations[prefix] = pending_atomic
+            atomic_committed = True
+            try:
+                finalized = _finalize_workspace_checkpoint(
+                    pending_atomic.base_generation,
+                    pending_atomic.proof,
+                    tuple(
+                        completion.reservation_id
+                        for completion in pending_atomic.uploads
+                    ),
+                    pending_atomic.deleted_paths,
+                    deadline_monotonic,
+                )
+                current_generation = _apply_atomic_workspace_finalization(
+                    prefix,
+                    pending_atomic,
+                    finalized,
+                )
+            except Exception as exc:
+                if not _is_side_effect_free_finalize_rejection(exc):
+                    raise
+                atomic_committed = False
+                current_generation = (
+                    _legacy_finalize_pending_atomic_workspace(
+                        prefix,
+                        pending_atomic,
+                        deadline_monotonic,
+                    )
+                )
+            count = len(to_delete) + len(staged)
+            elapsed = time.monotonic() - started
+            logger.info(
+                "workspace push: prefix=%s files=%d generation=%s "
+                "elapsed_s=%.1f atomic=%s",
+                prefix,
+                count,
+                current_generation[:12],
+                elapsed,
+                atomic_committed,
+            )
+            return count
         for relative in to_delete:
             current_generation = _delete_workspace_path(
                 relative,
@@ -2870,37 +3442,6 @@ def push_workspace(
                 )
             if e_tag is not None:
                 final_entries[pair[1]] = (pair[2], e_tag)
-            if require_generation:
-                _pending_workspace_generations[prefix] = current_generation
-            count += 1
-
-        # Commit the migration boundary last. If this upload is interrupted,
-        # the next microVM safely replays the preserved legacy archive. Once
-        # the marker exists remotely, every database/state object from this
-        # snapshot has already completed and been verified by the broker.
-        if marker_upload is not None:
-            marker_pair, marker_prepared, marker_error = _stage_one(
-                marker_upload
-            )
-            if marker_error is not None or marker_prepared is None:
-                raise WorkspacePushIncomplete(
-                    "workspace push incomplete (migration marker stage failed) "
-                    f"for prefix {prefix}: {marker_error or 'unknown error'}"
-                )
-            current_generation, marker_e_tag = _complete_one(
-                marker_pair,
-                marker_prepared,
-                current_generation,
-            )
-            if require_generation and marker_e_tag is None:
-                raise WorkspaceGenerationUnavailable(
-                    "workspace marker completion returned no generation metadata"
-                )
-            if marker_e_tag is not None:
-                final_entries[marker_pair[1]] = (
-                    marker_pair[2],
-                    marker_e_tag,
-                )
             if require_generation:
                 _pending_workspace_generations[prefix] = current_generation
             count += 1

--- a/infra/lib/agent-platform-stack.ts
+++ b/infra/lib/agent-platform-stack.ts
@@ -392,6 +392,16 @@ export class AgentPlatformStack extends cdk.Stack {
           // this as an InvalidRequest that fails the whole stack update.
         },
         {
+          id: 'cleanup-checkpoint-control-versions',
+          tagFilters: { Scope: 'checkpoint' },
+          noncurrentVersionExpiration: cdk.Duration.days(30),
+          // Checkpoint manifests, anchors, and finalization records remain
+          // durable at their current version. Only superseded control-plane
+          // versions age out after the recovery window. As with the private
+          // tag-filtered rule above, this rule intentionally carries no
+          // multipart-abort action because S3 rejects that combination.
+        },
+        {
           // Bucket-wide abort of abandoned multipart uploads, with no prefix
           // or tag filter so it is a legal home for the action the rule above
           // cannot carry. Keeps the cleanup intent that the tag-filtered rule

--- a/infra/test/agent-workspace-lifecycle.test.ts
+++ b/infra/test/agent-workspace-lifecycle.test.ts
@@ -83,6 +83,11 @@ describe('Agent workspace lifecycle admission invariants', () => {
             TagFilters: [{ Key: 'Scope', Value: 'private' }],
             NoncurrentVersionExpiration: { NoncurrentDays: 30 },
           }),
+          Match.objectLike({
+            Id: 'cleanup-checkpoint-control-versions',
+            TagFilters: [{ Key: 'Scope', Value: 'checkpoint' }],
+            NoncurrentVersionExpiration: { NoncurrentDays: 30 },
+          }),
         ]),
       },
     });

--- a/lib/agent-workspace/storage-broker.ts
+++ b/lib/agent-workspace/storage-broker.ts
@@ -82,6 +82,8 @@ const WORKSPACE_CHECKPOINT_CONCURRENCY = 32
 // response and the agent image falls back to the paginated list operation.
 const MAX_INLINE_WORKSPACE_CHECKPOINT_SNAPSHOT_BYTES = 512 * 1024
 const WORKSPACE_FINALIZATION_PROOF_VERSION = "v1"
+const WORKSPACE_FINALIZATION_PROOF_DOMAIN =
+  "aistudio.workspace-checkpoint-finalization"
 const MAX_WORKSPACE_FINALIZATION_PROOF_BYTES = 4 * 1024
 // The prepared replay record contains the next checkpoint manifest plus the
 // bounded mutation result. Keep a hard cap even though both source payloads
@@ -808,7 +810,10 @@ async function createWorkspaceFinalizationProof(
     "sha256",
     await workspaceFinalizationProofSecret(),
   )
-    .update(`${WORKSPACE_FINALIZATION_PROOF_VERSION}.${encoded}`)
+    .update(
+      `${WORKSPACE_FINALIZATION_PROOF_DOMAIN}:` +
+        `${WORKSPACE_FINALIZATION_PROOF_VERSION}.${encoded}`,
+    )
     .digest("base64url")
   return `${WORKSPACE_FINALIZATION_PROOF_VERSION}.${encoded}.${signature}`
 }
@@ -843,7 +848,9 @@ async function verifyWorkspaceFinalizationProof(
     "sha256",
     await workspaceFinalizationProofSecret(),
   )
-    .update(`${parts[0]}.${parts[1]}`)
+    .update(
+      `${WORKSPACE_FINALIZATION_PROOF_DOMAIN}:${parts[0]}.${parts[1]}`,
+    )
     .digest()
   let providedSignature: Buffer
   let claims: unknown
@@ -3958,6 +3965,164 @@ async function verifyPreparedWorkspaceFinalizationTargets(
   }
 }
 
+type WorkspaceFinalizationClaim = {
+  reservation: WorkspaceUploadReservation
+  relativePath: string
+  promotedETag?: string
+}
+
+async function removeRecoveredUploadStaging(
+  reservation: WorkspaceUploadReservation,
+): Promise<void> {
+  let versionId: string | undefined
+  try {
+    const staged = await s3Client().send(
+      new HeadObjectCommand({
+        Bucket: bucketName(),
+        Key: reservation.stagingKey,
+      }),
+    )
+    versionId =
+      typeof staged.VersionId === "string" && staged.VersionId.length > 0
+        ? staged.VersionId
+        : undefined
+  } catch (error) {
+    if (isS3ObjectNotFound(error)) return
+    throw error
+  }
+  if (!versionId) {
+    throw new WorkspaceStorageSettlementUncertainError(
+      "Recovered workspace upload staging version is unavailable",
+    )
+  }
+  await s3Client().send(
+    new DeleteObjectCommand({
+      Bucket: bucketName(),
+      Key: reservation.stagingKey,
+      VersionId: versionId,
+    }),
+  )
+}
+
+/**
+ * Classify a reservation from an exact pending batch after an invocation may
+ * have died anywhere between claim and journal preparation. A target that is
+ * still the committed base is safe to promote; an exact reserved payload is a
+ * previously completed promotion and is settled in place. Anything else is
+ * fail-closed rather than overwriting an unknown current version.
+ */
+// The explicit state classifier keeps crash recovery in one auditable boundary.
+// eslint-disable-next-line complexity
+async function recoverWorkspaceFinalizationClaim(
+  claim: Awaited<ReturnType<typeof claimUploadCompletion>>,
+  signedWorkspacePrefix: string,
+  baseEntry: WorkspaceCheckpointEntry | undefined,
+  database: UnretriedDatabaseSession,
+): Promise<WorkspaceFinalizationClaim> {
+  const reservation = claim.reservation
+  const ownerPrefix = `${validateTrustedPrefix(signedWorkspacePrefix)}/`
+  if (
+    reservation.publicArtifact ||
+    !reservation.targetKey.startsWith(ownerPrefix)
+  ) {
+    throw new WorkspaceStorageCompletionError(
+      "Workspace upload target does not match its signed prefix",
+    )
+  }
+  const relativePath = reservation.targetKey.slice(ownerPrefix.length)
+  if (!isCheckpointManagedWorkspacePath(relativePath)) {
+    throw new WorkspaceStorageCompletionError(
+      "Workspace upload target is not mutable user state",
+    )
+  }
+
+  if (claim.kind === "committed") {
+    if (!reservation.objectVersionId) {
+      throw new WorkspaceStorageCompletionError(
+        "Committed workspace upload has no verified object version",
+      )
+    }
+    const eTag = await committedUploadMatches(
+      reservation.targetKey,
+      reservation.objectVersionId,
+      reservation.expectedBytes,
+      reservation.checksumSha256,
+      reservation.contentType,
+    )
+    if (!eTag) {
+      throw new WorkspaceStorageCompletionError(
+        "Committed workspace upload no longer matches its reservation",
+      )
+    }
+    return { reservation, relativePath, promotedETag: eTag }
+  }
+
+  let current:
+    | {
+        ContentLength?: number
+        ETag?: string
+        VersionId?: string
+        ChecksumSHA256?: string
+        ContentType?: string
+      }
+    | undefined
+  try {
+    current = await s3Client().send(
+      new HeadObjectCommand({
+        Bucket: bucketName(),
+        Key: reservation.targetKey,
+        ChecksumMode: "ENABLED",
+      }),
+    )
+  } catch (error) {
+    if (!isS3ObjectNotFound(error)) throw error
+  }
+
+  const targetIsCommittedBase =
+    current !== undefined &&
+    baseEntry !== undefined &&
+    current.ContentLength === baseEntry.size &&
+    current.ETag === baseEntry.eTag &&
+    (baseEntry.source === "anchor" ||
+      current.VersionId === baseEntry.versionId)
+  if (targetIsCommittedBase || (!current && !baseEntry)) {
+    return { reservation, relativePath }
+  }
+  if (!current) {
+    throw new WorkspaceStorageSettlementUncertainError(
+      "Pending workspace upload target no longer matches its base",
+    )
+  }
+  const promotedETag =
+    current.ContentLength === reservation.expectedBytes &&
+    current.ChecksumSHA256 === reservation.checksumSha256 &&
+    current.ContentType === reservation.contentType &&
+    typeof current.ETag === "string" &&
+    current.ETag.length > 0 &&
+    typeof current.VersionId === "string" &&
+    current.VersionId.length > 0
+      ? current.ETag
+      : undefined
+  if (!promotedETag || !current.VersionId) {
+    throw new WorkspaceStorageSettlementUncertainError(
+      "Pending workspace upload target has an unknown version",
+    )
+  }
+  await removeRecoveredUploadStaging(reservation)
+  const priorVersions = await supersededUploadVersions(
+    reservation.ownerKey,
+    reservation.targetKey,
+    database,
+  )
+  await settleUploadReservation(
+    reservation.id,
+    current.VersionId,
+    priorVersions.map((prior) => prior.id),
+    database,
+  )
+  return { reservation, relativePath, promotedETag }
+}
+
 /**
  * Publish every turn-final workspace mutation behind one generation fence.
  *
@@ -4116,8 +4281,14 @@ export async function finalizeWorkspaceCheckpoint(
           ),
         }
 
-        const claimed: WorkspaceUploadReservation[] = []
+        const batchUploads: WorkspaceFinalizationClaim[] = []
+        const claimedReservations: WorkspaceUploadReservation[] = []
+        const deletedPathSet = new Set(normalizedDeletedPaths)
         try {
+          const baseEntries = new Map(
+            manifest.entries.map((entry) => [entry.path, entry]),
+          )
+          const uploadPaths = new Set<string>()
           for (const reservationId of normalizedReservationIds) {
             const claim = await claimUploadCompletion(
               ownerKey,
@@ -4126,67 +4297,64 @@ export async function finalizeWorkspaceCheckpoint(
               false,
               true,
             )
-            if (claim.kind !== "claimed") {
-              throw new WorkspaceStorageCompletionError(
-                "Workspace checkpoint batch is not retryable",
-              )
-            }
-            claimed.push(claim.reservation)
-          }
-
-          const uploadPaths = new Set<string>()
-          for (const reservation of claimed) {
-            const ownerPrefix = `${prefix}/`
-            if (
-              reservation.publicArtifact ||
-              !reservation.targetKey.startsWith(ownerPrefix)
-            ) {
-              throw new WorkspaceStorageCompletionError(
-                "Workspace upload target does not match its signed prefix",
-              )
-            }
-            const relativePath = reservation.targetKey.slice(
-              ownerPrefix.length,
+            claimedReservations.push(claim.reservation)
+            const recovered = await recoverWorkspaceFinalizationClaim(
+              claim,
+              prefix,
+              baseEntries.get(
+                claim.reservation.targetKey.slice(prefix.length + 1),
+              ),
+              database,
             )
             if (
-              !isCheckpointManagedWorkspacePath(relativePath) ||
-              uploadPaths.has(relativePath) ||
-              normalizedDeletedPaths.includes(relativePath)
+              uploadPaths.has(recovered.relativePath) ||
+              deletedPathSet.has(recovered.relativePath)
             ) {
               throw new WorkspaceStorageCompletionError(
                 "Workspace checkpoint batch contains conflicting paths",
               )
             }
-            uploadPaths.add(relativePath)
-            const staged = await inspectStagedUpload(
-              reservation,
-              bucketName(),
-            )
-            if (!staged.matches || !staged.versionId) {
-              throw new WorkspaceStorageCompletionError(
-                "Uploaded object did not match its reservation",
+            uploadPaths.add(recovered.relativePath)
+            batchUploads.push(recovered)
+            if (recovered.promotedETag) {
+              snapshot.entries.set(recovered.relativePath, {
+                path: recovered.relativePath,
+                size: recovered.reservation.expectedBytes,
+                eTag: recovered.promotedETag,
+              })
+            } else {
+              const staged = await inspectStagedUpload(
+                recovered.reservation,
+                bucketName(),
               )
+              if (!staged.matches || !staged.versionId) {
+                throw new WorkspaceStorageCompletionError(
+                  "Uploaded object did not match its reservation",
+                )
+              }
             }
           }
+          snapshot.generation = workspaceGenerationFromEntries(
+            [...snapshot.entries.values()],
+          )
 
           const plannedEntries = new Map(snapshot.entries)
           for (const path of normalizedDeletedPaths) {
             plannedEntries.delete(path)
           }
-          for (const reservation of claimed) {
-            const relativePath = reservation.targetKey.slice(
-              prefix.length + 1,
-            )
-            plannedEntries.set(relativePath, {
-              path: relativePath,
-              size: reservation.expectedBytes,
-              eTag: `pending-${reservation.id}`,
+          for (const upload of batchUploads) {
+            plannedEntries.set(upload.relativePath, {
+              path: upload.relativePath,
+              size: upload.reservation.expectedBytes,
+              eTag:
+                upload.promotedETag ??
+                `pending-${upload.reservation.id}`,
             })
           }
           assertPrefixFreeWorkspaceEntries([...plannedEntries.values()])
         } catch (error) {
           await Promise.allSettled(
-            claimed.map((reservation) =>
+            claimedReservations.map((reservation) =>
               resetWorkspaceUploadClaim(reservation.id, database),
             ),
           )
@@ -4194,10 +4362,8 @@ export async function finalizeWorkspaceCheckpoint(
         }
 
         const mutationPaths = new Set(normalizedDeletedPaths)
-        for (const reservation of claimed) {
-          mutationPaths.add(
-            reservation.targetKey.slice(prefix.length + 1),
-          )
+        for (const upload of batchUploads) {
+          mutationPaths.add(upload.relativePath)
         }
         try {
           for (const path of mutationPaths) {
@@ -4261,31 +4427,36 @@ export async function finalizeWorkspaceCheckpoint(
           }
 
           const uploads: FinalizeWorkspaceCheckpointResult["uploads"] = []
-          for (const [index, reservation] of claimed.entries()) {
-            const completed = await finishClaimedUpload(
-              reservation,
-              ownerKey,
-              reservation.id,
-              database,
-              () => {
-                leasesToDrop.push(reservation)
-              },
-              {
-                signedWorkspacePrefix: prefix,
-                expectedGeneration: snapshot.generation,
-                snapshot,
-                checkpointAlreadyAnchored: true,
-              },
-            )
-            if (!completed.eTag || !completed.workspaceGeneration) {
-              throw new WorkspaceStorageCompletionError(
-                "Workspace batch promotion returned incomplete metadata",
+          for (const [index, upload] of batchUploads.entries()) {
+            const reservation = upload.reservation
+            let eTag = upload.promotedETag
+            if (!eTag) {
+              const completed = await finishClaimedUpload(
+                reservation,
+                ownerKey,
+                reservation.id,
+                database,
+                () => {
+                  leasesToDrop.push(reservation)
+                },
+                {
+                  signedWorkspacePrefix: prefix,
+                  expectedGeneration: snapshot.generation,
+                  snapshot,
+                  checkpointAlreadyAnchored: true,
+                },
               )
+              if (!completed.eTag || !completed.workspaceGeneration) {
+                throw new WorkspaceStorageCompletionError(
+                  "Workspace batch promotion returned incomplete metadata",
+                )
+              }
+              eTag = completed.eTag
             }
             uploads.push({
               reservationId: normalizedReservationIds[index]!,
-              key: completed.key,
-              eTag: completed.eTag,
+              key: reservation.targetKey,
+              eTag,
             })
             await Promise.allSettled([
               settleLease(
@@ -4329,7 +4500,7 @@ export async function finalizeWorkspaceCheckpoint(
           return result
         } catch (error) {
           await Promise.allSettled(
-            claimed.map((reservation) =>
+            claimedReservations.map((reservation) =>
               resetWorkspaceUploadClaim(reservation.id, database),
             ),
           )

--- a/lib/agent-workspace/storage-broker.ts
+++ b/lib/agent-workspace/storage-broker.ts
@@ -1,4 +1,9 @@
-import { createHash, randomUUID } from "node:crypto"
+import {
+  createHash,
+  createHmac,
+  randomUUID,
+  timingSafeEqual,
+} from "node:crypto"
 import {
   CopyObjectCommand,
   DeleteObjectCommand,
@@ -36,6 +41,7 @@ import {
   releaseResourceAdmission,
 } from "@/lib/resource-admission"
 import { createLogger } from "@/lib/logger"
+import { getSecretString } from "@/lib/agent-workspace/secrets-manager"
 import {
   isCheckpointManagedWorkspacePath,
   validateWorkspaceRelativePath,
@@ -63,6 +69,8 @@ const MAX_PUBLIC_RETAINED_OBJECTS = 1_000
 const UPLOAD_RESERVATION_MS = 5 * 60 * 1000
 const SHA256_BASE64_RE = /^[A-Za-z0-9+/]{43}=$/
 const WORKSPACE_GENERATION_RE = /^[0-9a-f]{64}$/
+const WORKSPACE_RESERVATION_ID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
 const MAX_WORKSPACE_GENERATION_OBJECTS = 250_000
 const WORKSPACE_CHECKPOINT_VERSION = 2 as const
 const WORKSPACE_CHECKPOINT_CONTROL_PREFIX = ".workspace-checkpoints/v2"
@@ -73,6 +81,14 @@ const WORKSPACE_CHECKPOINT_CONCURRENCY = 32
 // response limits. Large workspaces retain the legacy generation-only
 // response and the agent image falls back to the paginated list operation.
 const MAX_INLINE_WORKSPACE_CHECKPOINT_SNAPSHOT_BYTES = 512 * 1024
+const WORKSPACE_FINALIZATION_PROOF_VERSION = "v1"
+const MAX_WORKSPACE_FINALIZATION_PROOF_BYTES = 4 * 1024
+// The prepared replay record contains the next checkpoint manifest plus the
+// bounded mutation result. Keep a hard cap even though both source payloads
+// are independently bounded, so a corrupt control object can never force an
+// unbounded read into the web tier.
+const MAX_WORKSPACE_FINALIZATION_JOURNAL_BYTES =
+  MAX_WORKSPACE_CHECKPOINT_BYTES * 2
 // These paths were checkpoint-managed before they were identified as
 // generated OpenClaw host state. Every current or manifest-bound source is
 // content-validated below before exclusion; a policy or interrupted claim
@@ -735,7 +751,142 @@ export type WorkspaceCheckpointSnapshot = {
 export type EnsureWorkspaceCheckpointResult = {
   checkpointReady: true
   workspaceGeneration: string
+  atomicCheckpointCommitVersion?: 1
+  checkpointFinalizationProof?: string
   checkpointSnapshot?: WorkspaceCheckpointSnapshot
+}
+
+type WorkspaceFinalizationBinding = {
+  invocationNonce: string
+  expiresAt: number
+}
+
+type WorkspaceFinalizationProofClaims = {
+  version: 1
+  signedWorkspacePrefix: string
+  workspaceGeneration: string
+  invocationNonce: string
+  expiresAt: number
+}
+
+async function workspaceFinalizationProofSecret(): Promise<string> {
+  const inline = process.env.AGENT_INVOCATION_SIGNING_SECRET
+  if (inline) return inline
+  const secretId = process.env.AGENT_INVOCATION_SIGNING_SECRET_ID
+  if (!secretId) {
+    throw new WorkspaceStorageCompletionError(
+      "Workspace finalization proof secret is unavailable",
+    )
+  }
+  const secret = await getSecretString(secretId)
+  if (!secret) {
+    throw new WorkspaceStorageCompletionError(
+      "Workspace finalization proof secret is unavailable",
+    )
+  }
+  return secret
+}
+
+async function createWorkspaceFinalizationProof(
+  signedWorkspacePrefix: string,
+  workspaceGeneration: string,
+  binding: WorkspaceFinalizationBinding,
+): Promise<string> {
+  const claims: WorkspaceFinalizationProofClaims = {
+    version: 1,
+    signedWorkspacePrefix: validateTrustedPrefix(
+      signedWorkspacePrefix,
+    ),
+    workspaceGeneration,
+    invocationNonce: binding.invocationNonce,
+    expiresAt: binding.expiresAt,
+  }
+  const encoded = Buffer.from(JSON.stringify(claims), "utf8").toString(
+    "base64url",
+  )
+  const signature = createHmac(
+    "sha256",
+    await workspaceFinalizationProofSecret(),
+  )
+    .update(`${WORKSPACE_FINALIZATION_PROOF_VERSION}.${encoded}`)
+    .digest("base64url")
+  return `${WORKSPACE_FINALIZATION_PROOF_VERSION}.${encoded}.${signature}`
+}
+
+// Proof verification deliberately checks every authenticated claim before use.
+// eslint-disable-next-line complexity
+async function verifyWorkspaceFinalizationProof(
+  proof: string,
+  expected: WorkspaceFinalizationProofClaims,
+): Promise<void> {
+  if (
+    !proof ||
+    Buffer.byteLength(proof, "utf8") >
+      MAX_WORKSPACE_FINALIZATION_PROOF_BYTES
+  ) {
+    throw new WorkspaceStorageCompletionError(
+      "Workspace finalization proof is invalid",
+    )
+  }
+  const parts = proof.split(".")
+  if (
+    parts.length !== 3 ||
+    parts[0] !== WORKSPACE_FINALIZATION_PROOF_VERSION ||
+    !parts[1] ||
+    !parts[2]
+  ) {
+    throw new WorkspaceStorageCompletionError(
+      "Workspace finalization proof is invalid",
+    )
+  }
+  const expectedSignature = createHmac(
+    "sha256",
+    await workspaceFinalizationProofSecret(),
+  )
+    .update(`${parts[0]}.${parts[1]}`)
+    .digest()
+  let providedSignature: Buffer
+  let claims: unknown
+  try {
+    providedSignature = Buffer.from(parts[2], "base64url")
+    claims = JSON.parse(
+      Buffer.from(parts[1], "base64url").toString("utf8"),
+    )
+  } catch {
+    throw new WorkspaceStorageCompletionError(
+      "Workspace finalization proof is invalid",
+    )
+  }
+  if (providedSignature.length !== expectedSignature.length) {
+    timingSafeEqual(expectedSignature, expectedSignature)
+    throw new WorkspaceStorageCompletionError(
+      "Workspace finalization proof is invalid",
+    )
+  }
+  if (!timingSafeEqual(providedSignature, expectedSignature)) {
+    throw new WorkspaceStorageCompletionError(
+      "Workspace finalization proof is invalid",
+    )
+  }
+  const candidate = claims as Partial<WorkspaceFinalizationProofClaims>
+  if (
+    !claims ||
+    typeof claims !== "object" ||
+    Array.isArray(claims) ||
+    Object.keys(claims).length !== 5 ||
+    candidate.version !== expected.version ||
+    candidate.signedWorkspacePrefix !==
+      expected.signedWorkspacePrefix ||
+    candidate.workspaceGeneration !== expected.workspaceGeneration ||
+    candidate.invocationNonce !== expected.invocationNonce ||
+    candidate.expiresAt !== expected.expiresAt ||
+    !Number.isInteger(candidate.expiresAt) ||
+    candidate.expiresAt! < Math.floor(Date.now() / 1000)
+  ) {
+    throw new WorkspaceStorageCompletionError(
+      "Workspace finalization proof is invalid",
+    )
+  }
 }
 
 /**
@@ -1687,8 +1838,10 @@ async function recoverWorkspaceCheckpoint(
 
 export async function ensureWorkspaceCheckpoint(
   signedWorkspacePrefix: string,
+  finalizationBinding?: WorkspaceFinalizationBinding,
 ): Promise<EnsureWorkspaceCheckpointResult> {
-  return withWorkspaceGenerationLock(
+  const checkpoint =
+    await withWorkspaceGenerationLock<EnsureWorkspaceCheckpointResult>(
     signedWorkspacePrefix,
     async () => {
       let snapshot = await readWorkspaceGenerationSnapshot(
@@ -1722,12 +1875,32 @@ export async function ensureWorkspaceCheckpoint(
       }
       const checkpointSnapshot = inlineWorkspaceCheckpointSnapshot(snapshot)
       return {
-        checkpointReady: true,
+        checkpointReady: true as const,
         workspaceGeneration: manifest.workspaceGeneration,
         ...(checkpointSnapshot ? { checkpointSnapshot } : {}),
       }
     },
   )
+  if (!finalizationBinding) return checkpoint
+  if (
+    !finalizationBinding.invocationNonce ||
+    !Number.isInteger(finalizationBinding.expiresAt) ||
+    finalizationBinding.expiresAt < Math.floor(Date.now() / 1000)
+  ) {
+    throw new WorkspaceStorageCompletionError(
+      "Workspace finalization binding is invalid",
+    )
+  }
+  return {
+    ...checkpoint,
+    atomicCheckpointCommitVersion: 1,
+    checkpointFinalizationProof:
+      await createWorkspaceFinalizationProof(
+        signedWorkspacePrefix,
+        checkpoint.workspaceGeneration,
+        finalizationBinding,
+      ),
+  }
 }
 
 export async function commitWorkspaceCheckpoint(
@@ -3023,6 +3196,8 @@ async function finishClaimedUpload(
   generationFence?: {
     signedWorkspacePrefix: string
     expectedGeneration: string
+    snapshot?: WorkspaceGenerationSnapshot
+    checkpointAlreadyAnchored?: boolean
   },
 ): Promise<CompletedWorkspaceUpload> {
   const bucket = bucketName()
@@ -3061,9 +3236,11 @@ async function finishClaimedUpload(
           "Workspace upload target is not mutable user state",
         )
       }
-      generationSnapshot = await readWorkspaceGenerationSnapshot(
-        generationFence.signedWorkspacePrefix,
-      )
+      generationSnapshot =
+        generationFence.snapshot ??
+        await readWorkspaceGenerationSnapshot(
+          generationFence.signedWorkspacePrefix,
+        )
       if (
         generationSnapshot.generation !==
         generationFence.expectedGeneration
@@ -3073,10 +3250,12 @@ async function finishClaimedUpload(
         )
       }
       generationChecked = true
-      await anchorCommittedCheckpointPathBeforePromotion(
-        generationFence.signedWorkspacePrefix,
-        targetRelativePath,
-      )
+      if (!generationFence.checkpointAlreadyAnchored) {
+        await anchorCommittedCheckpointPathBeforePromotion(
+          generationFence.signedWorkspacePrefix,
+          targetRelativePath,
+        )
+      }
     }
     const priorVersions = await supersededUploadVersions(
       ownerKey,
@@ -3130,6 +3309,7 @@ async function finishClaimedUpload(
       workspaceGeneration = workspaceGenerationFromEntries(
         [...generationSnapshot.entries.values()],
       )
+      generationSnapshot.generation = workspaceGeneration
     }
     return {
       key: claimed.targetKey,
@@ -3172,6 +3352,999 @@ async function finishClaimedUpload(
       database,
       onCapacityRelease,
     })
+  }
+}
+
+export type FinalizeWorkspaceCheckpointResult = {
+  checkpointCommitted: true
+  workspaceGeneration: string
+  uploads: Array<{
+    reservationId: string
+    key: string
+    eTag: string
+  }>
+  deletions: Array<{
+    path: string
+    deleted: boolean
+  }>
+}
+
+type WorkspaceFinalizationJournalRequest = {
+  ownerHash: string
+  signedWorkspacePrefix: string
+  baseWorkspaceGeneration: string
+  proofHash: string
+  reservationIds: string[]
+  deletedPaths: string[]
+  requestDigest: string
+}
+
+type PendingWorkspaceFinalizationJournal =
+  WorkspaceFinalizationJournalRequest & {
+    version: 1
+    state: "pending"
+  }
+
+type PreparedWorkspaceFinalizationJournal =
+  WorkspaceFinalizationJournalRequest & {
+    version: 1
+    state: "prepared" | "committed"
+    baseManifestDigest: string
+    result: FinalizeWorkspaceCheckpointResult
+    nextManifest: WorkspaceCheckpointManifest
+  }
+
+type WorkspaceFinalizationJournal =
+  | PendingWorkspaceFinalizationJournal
+  | PreparedWorkspaceFinalizationJournal
+
+function workspaceFinalizationJournalKey(
+  signedWorkspacePrefix: string,
+): string {
+  return `${checkpointNamespace(signedWorkspacePrefix)}/last-finalization.json`
+}
+
+function workspaceFinalizationOwnerHash(ownerKey: string): string {
+  return createHash("sha256").update(ownerKey).digest("hex")
+}
+
+function workspaceFinalizationProofHash(proof: string): string {
+  return createHash("sha256").update(proof).digest("hex")
+}
+
+function workspaceFinalizationRequestDigest(
+  request: Omit<WorkspaceFinalizationJournalRequest, "requestDigest">,
+): string {
+  return createHash("sha256")
+    .update(
+      JSON.stringify({
+        version: 1,
+        ownerHash: request.ownerHash,
+        signedWorkspacePrefix: request.signedWorkspacePrefix,
+        baseWorkspaceGeneration: request.baseWorkspaceGeneration,
+        proofHash: request.proofHash,
+        reservationIds: request.reservationIds,
+        deletedPaths: request.deletedPaths,
+      }),
+    )
+    .digest("hex")
+}
+
+function workspaceCheckpointManifestDigest(
+  manifest: WorkspaceCheckpointManifest,
+): string {
+  return createHash("sha256")
+    .update(JSON.stringify(manifest))
+    .digest("hex")
+}
+
+function createWorkspaceFinalizationJournalRequest(options: {
+  ownerKey: string
+  signedWorkspacePrefix: string
+  baseWorkspaceGeneration: string
+  proof: string
+  reservationIds: readonly string[]
+  deletedPaths: readonly string[]
+}): WorkspaceFinalizationJournalRequest {
+  const requestWithoutDigest = {
+    ownerHash: workspaceFinalizationOwnerHash(options.ownerKey),
+    signedWorkspacePrefix: options.signedWorkspacePrefix,
+    baseWorkspaceGeneration: options.baseWorkspaceGeneration,
+    proofHash: workspaceFinalizationProofHash(options.proof),
+    reservationIds: [...options.reservationIds],
+    deletedPaths: [...options.deletedPaths],
+  }
+  return {
+    ...requestWithoutDigest,
+    requestDigest: workspaceFinalizationRequestDigest(
+      requestWithoutDigest,
+    ),
+  }
+}
+
+function isExactRecord(
+  value: Record<string, unknown>,
+  fields: readonly string[],
+): boolean {
+  const actual = Object.keys(value).sort()
+  const expected = [...fields].sort()
+  return (
+    actual.length === expected.length &&
+    actual.every((field, index) => field === expected[index])
+  )
+}
+
+function stringArraysEqual(
+  left: readonly string[],
+  right: readonly string[],
+): boolean {
+  return (
+    left.length === right.length &&
+    left.every((item, index) => item === right[index])
+  )
+}
+
+function workspaceFinalizationRequestsEqual(
+  left: WorkspaceFinalizationJournalRequest,
+  right: WorkspaceFinalizationJournalRequest,
+): boolean {
+  return (
+    left.ownerHash === right.ownerHash &&
+    left.signedWorkspacePrefix === right.signedWorkspacePrefix &&
+    left.baseWorkspaceGeneration === right.baseWorkspaceGeneration &&
+    left.proofHash === right.proofHash &&
+    left.requestDigest === right.requestDigest &&
+    stringArraysEqual(left.reservationIds, right.reservationIds) &&
+    stringArraysEqual(left.deletedPaths, right.deletedPaths)
+  )
+}
+
+function parseWorkspaceFinalizationStringArray(
+  value: unknown,
+  validate: (item: string) => boolean,
+): string[] | null {
+  if (
+    !Array.isArray(value) ||
+    value.length > MAX_WORKSPACE_GENERATION_OBJECTS
+  ) {
+    return null
+  }
+  const items: string[] = []
+  const seen = new Set<string>()
+  for (const candidate of value) {
+    if (typeof candidate !== "string" || !validate(candidate)) return null
+    if (seen.has(candidate)) return null
+    seen.add(candidate)
+    items.push(candidate)
+  }
+  return items
+}
+
+// A persisted result is hostile input; every nested field is validated.
+// eslint-disable-next-line complexity
+function parseWorkspaceFinalizationResult(
+  value: unknown,
+  signedWorkspacePrefix: string,
+  reservationIds: readonly string[],
+  deletedPaths: readonly string[],
+): FinalizeWorkspaceCheckpointResult | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return null
+  }
+  const candidate = value as Record<string, unknown>
+  if (
+    !isExactRecord(candidate, [
+      "checkpointCommitted",
+      "workspaceGeneration",
+      "uploads",
+      "deletions",
+    ]) ||
+    candidate.checkpointCommitted !== true ||
+    typeof candidate.workspaceGeneration !== "string" ||
+    !WORKSPACE_GENERATION_RE.test(candidate.workspaceGeneration) ||
+    !Array.isArray(candidate.uploads) ||
+    candidate.uploads.length !== reservationIds.length ||
+    !Array.isArray(candidate.deletions) ||
+    candidate.deletions.length !== deletedPaths.length
+  ) {
+    return null
+  }
+
+  const uploads: FinalizeWorkspaceCheckpointResult["uploads"] = []
+  for (let index = 0; index < candidate.uploads.length; index += 1) {
+    const raw = candidate.uploads[index]
+    if (!raw || typeof raw !== "object" || Array.isArray(raw)) return null
+    const upload = raw as Record<string, unknown>
+    if (
+      !isExactRecord(upload, ["reservationId", "key", "eTag"]) ||
+      upload.reservationId !== reservationIds[index] ||
+      typeof upload.key !== "string" ||
+      !upload.key.startsWith(`${signedWorkspacePrefix}/`) ||
+      typeof upload.eTag !== "string" ||
+      upload.eTag.length === 0 ||
+      upload.eTag.length > 1_024
+    ) {
+      return null
+    }
+    const relativePath = upload.key.slice(signedWorkspacePrefix.length + 1)
+    if (
+      !isCheckpointManagedWorkspacePath(relativePath) ||
+      ownerWorkspaceKey(signedWorkspacePrefix, relativePath) !== upload.key
+    ) {
+      return null
+    }
+    uploads.push({
+      reservationId: upload.reservationId,
+      key: upload.key,
+      eTag: upload.eTag,
+    })
+  }
+
+  const deletions: FinalizeWorkspaceCheckpointResult["deletions"] = []
+  for (let index = 0; index < candidate.deletions.length; index += 1) {
+    const raw = candidate.deletions[index]
+    if (!raw || typeof raw !== "object" || Array.isArray(raw)) return null
+    const deletion = raw as Record<string, unknown>
+    if (
+      !isExactRecord(deletion, ["path", "deleted"]) ||
+      deletion.path !== deletedPaths[index] ||
+      typeof deletion.deleted !== "boolean"
+    ) {
+      return null
+    }
+    deletions.push({
+      path: deletion.path,
+      deleted: deletion.deleted,
+    })
+  }
+  return {
+    checkpointCommitted: true,
+    workspaceGeneration: candidate.workspaceGeneration,
+    uploads,
+    deletions,
+  }
+}
+
+// Persisted control state is treated as hostile until every field is checked.
+// eslint-disable-next-line complexity
+function parseWorkspaceFinalizationJournal(
+  value: unknown,
+  signedWorkspacePrefix: string,
+): WorkspaceFinalizationJournal {
+  const invalid = (): never => {
+    throw new WorkspaceStorageCompletionError(
+      "Workspace finalization journal is invalid",
+    )
+  }
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return invalid()
+  }
+  const candidate = value as Record<string, unknown>
+  const commonFields = [
+    "version",
+    "state",
+    "ownerHash",
+    "signedWorkspacePrefix",
+    "baseWorkspaceGeneration",
+    "proofHash",
+    "reservationIds",
+    "deletedPaths",
+    "requestDigest",
+  ] as const
+  const prepared =
+    candidate.state === "prepared" || candidate.state === "committed"
+  if (
+    !isExactRecord(
+      candidate,
+      prepared
+        ? [
+            ...commonFields,
+            "baseManifestDigest",
+            "result",
+            "nextManifest",
+          ]
+        : commonFields,
+    ) ||
+    candidate.version !== 1 ||
+    (candidate.state !== "pending" && !prepared) ||
+    typeof candidate.ownerHash !== "string" ||
+    !WORKSPACE_GENERATION_RE.test(candidate.ownerHash) ||
+    candidate.signedWorkspacePrefix !== signedWorkspacePrefix ||
+    typeof candidate.baseWorkspaceGeneration !== "string" ||
+    !WORKSPACE_GENERATION_RE.test(candidate.baseWorkspaceGeneration) ||
+    typeof candidate.proofHash !== "string" ||
+    !WORKSPACE_GENERATION_RE.test(candidate.proofHash) ||
+    typeof candidate.requestDigest !== "string" ||
+    !WORKSPACE_GENERATION_RE.test(candidate.requestDigest)
+  ) {
+    return invalid()
+  }
+  const reservationIds = parseWorkspaceFinalizationStringArray(
+    candidate.reservationIds,
+    (item) => WORKSPACE_RESERVATION_ID_RE.test(item),
+  )
+  const deletedPaths = parseWorkspaceFinalizationStringArray(
+    candidate.deletedPaths,
+    (item) => {
+      try {
+        return (
+          validateWorkspaceRelativePath(item) === item &&
+          isCheckpointManagedWorkspacePath(item)
+        )
+      } catch {
+        return false
+      }
+    },
+  )
+  if (
+    !reservationIds ||
+    !deletedPaths ||
+    reservationIds.length + deletedPaths.length >
+      MAX_WORKSPACE_GENERATION_OBJECTS
+  ) {
+    return invalid()
+  }
+  const request = {
+    ownerHash: candidate.ownerHash,
+    signedWorkspacePrefix,
+    baseWorkspaceGeneration: candidate.baseWorkspaceGeneration,
+    proofHash: candidate.proofHash,
+    reservationIds,
+    deletedPaths,
+  }
+  if (
+    workspaceFinalizationRequestDigest(request) !== candidate.requestDigest
+  ) {
+    return invalid()
+  }
+  const base: WorkspaceFinalizationJournalRequest = {
+    ...request,
+    requestDigest: candidate.requestDigest,
+  }
+  if (!prepared) {
+    return { version: 1, state: "pending", ...base }
+  }
+  const result = parseWorkspaceFinalizationResult(
+    candidate.result,
+    signedWorkspacePrefix,
+    reservationIds,
+    deletedPaths,
+  )
+  if (!result) return invalid()
+  if (
+    typeof candidate.baseManifestDigest !== "string" ||
+    !WORKSPACE_GENERATION_RE.test(candidate.baseManifestDigest)
+  ) {
+    return invalid()
+  }
+  const nextManifest = parseWorkspaceCheckpointManifest(
+    candidate.nextManifest,
+    signedWorkspacePrefix,
+  ).manifest
+  if (nextManifest.workspaceGeneration !== result.workspaceGeneration) {
+    return invalid()
+  }
+  return {
+    version: 1,
+    state: candidate.state as "prepared" | "committed",
+    ...base,
+    baseManifestDigest: candidate.baseManifestDigest,
+    result,
+    nextManifest,
+  }
+}
+
+async function readWorkspaceFinalizationJournal(
+  signedWorkspacePrefix: string,
+): Promise<WorkspaceFinalizationJournal | null> {
+  let response
+  try {
+    response = await s3Client().send(
+      new GetObjectCommand({
+        Bucket: bucketName(),
+        Key: workspaceFinalizationJournalKey(signedWorkspacePrefix),
+      }),
+    )
+  } catch (error) {
+    if (isS3ObjectNotFound(error)) return null
+    throw error
+  }
+  if (
+    !Number.isSafeInteger(response.ContentLength) ||
+    !response.ContentLength ||
+    response.ContentLength > MAX_WORKSPACE_FINALIZATION_JOURNAL_BYTES ||
+    !response.Body
+  ) {
+    throw new WorkspaceStorageCompletionError(
+      "Workspace finalization journal is invalid",
+    )
+  }
+  const serialized = await response.Body.transformToString("utf-8")
+  if (Buffer.byteLength(serialized, "utf8") !== response.ContentLength) {
+    throw new WorkspaceStorageCompletionError(
+      "Workspace finalization journal is invalid",
+    )
+  }
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(serialized)
+  } catch {
+    throw new WorkspaceStorageCompletionError(
+      "Workspace finalization journal is invalid",
+    )
+  }
+  return parseWorkspaceFinalizationJournal(parsed, signedWorkspacePrefix)
+}
+
+async function writeWorkspaceFinalizationJournal(
+  journal: WorkspaceFinalizationJournal,
+): Promise<void> {
+  const serialized = JSON.stringify(journal)
+  const contentLength = Buffer.byteLength(serialized, "utf8")
+  if (
+    contentLength === 0 ||
+    contentLength > MAX_WORKSPACE_FINALIZATION_JOURNAL_BYTES
+  ) {
+    throw new WorkspaceStorageCompletionError(
+      "Workspace finalization journal exceeds its size backstop",
+    )
+  }
+  try {
+    const written = await s3Client().send(
+      new PutObjectCommand({
+        Bucket: bucketName(),
+        Key: workspaceFinalizationJournalKey(
+          journal.signedWorkspacePrefix,
+        ),
+        Body: serialized,
+        ContentLength: contentLength,
+        ContentType: "application/json",
+        Tagging: "Scope=checkpoint",
+      }),
+    )
+    if (!written.VersionId) {
+      throw new WorkspaceStorageCompletionError(
+        "Workspace finalization journal returned no object version",
+      )
+    }
+  } catch (error) {
+    // S3 PutObject can commit durably while its HTTP response is lost. The
+    // stable versioned journal key is strongly consistent, so an exact
+    // read-after-error makes each phase transition safely idempotent.
+    let persisted: WorkspaceFinalizationJournal | null
+    try {
+      persisted = await readWorkspaceFinalizationJournal(
+        journal.signedWorkspacePrefix,
+      )
+    } catch {
+      throw error
+    }
+    if (
+      persisted &&
+      workspaceFinalizationJournalsEqual(persisted, journal)
+    ) {
+      return
+    }
+    throw error
+  }
+}
+
+function workspaceFinalizationResultsEqual(
+  left: FinalizeWorkspaceCheckpointResult,
+  right: FinalizeWorkspaceCheckpointResult,
+): boolean {
+  return (
+    left.checkpointCommitted === right.checkpointCommitted &&
+    left.workspaceGeneration === right.workspaceGeneration &&
+    left.uploads.length === right.uploads.length &&
+    left.uploads.every((upload, index) => {
+      const candidate = right.uploads[index]
+      return (
+        candidate !== undefined &&
+        upload.reservationId === candidate.reservationId &&
+        upload.key === candidate.key &&
+        upload.eTag === candidate.eTag
+      )
+    }) &&
+    left.deletions.length === right.deletions.length &&
+    left.deletions.every((deletion, index) => {
+      const candidate = right.deletions[index]
+      return (
+        candidate !== undefined &&
+        deletion.path === candidate.path &&
+        deletion.deleted === candidate.deleted
+      )
+    })
+  )
+}
+
+function workspaceCheckpointManifestsEqual(
+  left: WorkspaceCheckpointManifest,
+  right: WorkspaceCheckpointManifest,
+): boolean {
+  if (
+    left.version !== right.version ||
+    left.signedWorkspacePrefix !== right.signedWorkspacePrefix ||
+    left.workspaceGeneration !== right.workspaceGeneration ||
+    left.entries.length !== right.entries.length
+  ) return false
+  return left.entries.every((entry, index) => {
+    const candidate = right.entries[index]
+    return (
+      candidate !== undefined &&
+      entry.path === candidate.path &&
+      entry.size === candidate.size &&
+      entry.eTag === candidate.eTag &&
+      entry.source === candidate.source &&
+      entry.versionId === candidate.versionId &&
+      entry.sourceETag === candidate.sourceETag
+    )
+  })
+}
+
+function workspaceFinalizationJournalsEqual(
+  left: WorkspaceFinalizationJournal,
+  right: WorkspaceFinalizationJournal,
+): boolean {
+  if (
+    left.version !== right.version ||
+    left.state !== right.state ||
+    !workspaceFinalizationRequestsEqual(left, right)
+  ) {
+    return false
+  }
+  if (left.state === "pending" || right.state === "pending") {
+    return left.state === right.state
+  }
+  return (
+    left.baseManifestDigest === right.baseManifestDigest &&
+    workspaceFinalizationResultsEqual(left.result, right.result) &&
+    workspaceCheckpointManifestsEqual(
+      left.nextManifest,
+      right.nextManifest,
+    )
+  )
+}
+
+async function verifyPreparedWorkspaceFinalizationTargets(
+  journal: PreparedWorkspaceFinalizationJournal,
+): Promise<void> {
+  const finalEntries = new Map(
+    journal.nextManifest.entries.map((entry) => [entry.path, entry]),
+  )
+  for (const upload of journal.result.uploads) {
+    const path = upload.key.slice(journal.signedWorkspacePrefix.length + 1)
+    const entry = finalEntries.get(path)
+    if (!entry || entry.eTag !== upload.eTag) {
+      throw new WorkspaceStorageCompletionError(
+        "Prepared workspace finalization upload is invalid",
+      )
+    }
+    const current = await s3Client().send(
+      new HeadObjectCommand({
+        Bucket: bucketName(),
+        Key: upload.key,
+      }),
+    )
+    if (
+      current.ContentLength !== entry.size ||
+      current.ETag !== entry.eTag ||
+      current.VersionId !== entry.versionId
+    ) {
+      throw new WorkspaceStorageCompletionError(
+        "Prepared workspace finalization target changed",
+      )
+    }
+  }
+  for (const deletion of journal.result.deletions) {
+    if (!deletion.deleted) continue
+    try {
+      await s3Client().send(
+        new HeadObjectCommand({
+          Bucket: bucketName(),
+          Key: ownerWorkspaceKey(
+            journal.signedWorkspacePrefix,
+            deletion.path,
+          ),
+        }),
+      )
+    } catch (error) {
+      if (isS3ObjectNotFound(error)) continue
+      throw error
+    }
+    throw new WorkspaceStorageCompletionError(
+      "Prepared workspace finalization deletion changed",
+    )
+  }
+}
+
+/**
+ * Publish every turn-final workspace mutation behind one generation fence.
+ *
+ * `ensureWorkspaceCheckpoint` already performed the authoritative full S3
+ * scan after the Router acquired the owner-wide lease. Its signed proof lets
+ * this operation seed the batch from the exact committed manifest instead of
+ * repeating that same scan once per changed SQLite file. The manifest Put
+ * below remains the single commit point; exact-version anchors are durable
+ * before the first target mutation, so the ordinary ensure path can recover a
+ * crash-partial batch without losing the prior checkpoint.
+ */
+// The explicit phases keep the fail-closed boundary auditable in one place.
+// eslint-disable-next-line max-lines-per-function, max-params
+export async function finalizeWorkspaceCheckpoint(
+  ownerEmail: string,
+  signedWorkspacePrefix: string,
+  baseWorkspaceGeneration: string,
+  reservationIds: readonly string[],
+  deletedPaths: readonly string[],
+  checkpointFinalizationProof: string,
+  invocationNonce: string,
+  invocationExpiresAt: number,
+): Promise<FinalizeWorkspaceCheckpointResult> {
+  const prefix = validateTrustedPrefix(signedWorkspacePrefix)
+  const ownerKey = ownerEmail.trim().toLowerCase()
+  if (
+    !WORKSPACE_GENERATION_RE.test(baseWorkspaceGeneration) ||
+    !invocationNonce ||
+    !Number.isInteger(invocationExpiresAt) ||
+    reservationIds.length + deletedPaths.length >
+      MAX_WORKSPACE_GENERATION_OBJECTS
+  ) {
+    throw new Error("Invalid workspace checkpoint batch")
+  }
+  const normalizedReservationIds = reservationIds.map((id) => {
+    if (!WORKSPACE_RESERVATION_ID_RE.test(id)) {
+      throw new Error("Invalid workspace checkpoint batch")
+    }
+    return id.toLowerCase()
+  })
+  if (
+    new Set(normalizedReservationIds.map((id) => id.toLowerCase()))
+      .size !== normalizedReservationIds.length
+  ) {
+    throw new Error("Invalid workspace checkpoint batch")
+  }
+  const normalizedDeletedPaths = deletedPaths.map((path) => {
+    const normalized = validateWorkspaceRelativePath(path)
+    if (!isCheckpointManagedWorkspacePath(normalized)) {
+      throw new Error("Invalid workspace checkpoint batch")
+    }
+    return normalized
+  })
+  if (new Set(normalizedDeletedPaths).size !== normalizedDeletedPaths.length) {
+    throw new Error("Invalid workspace checkpoint batch")
+  }
+  const journalRequest = createWorkspaceFinalizationJournalRequest({
+    ownerKey,
+    signedWorkspacePrefix: prefix,
+    baseWorkspaceGeneration,
+    proof: checkpointFinalizationProof,
+    reservationIds: normalizedReservationIds,
+    deletedPaths: normalizedDeletedPaths,
+  })
+  const leasesToDrop: WorkspaceUploadReservation[] = []
+  try {
+    return await withWorkspaceGenerationLock(
+      prefix,
+      // All mutation phases stay inside one owner-wide generation fence.
+      // eslint-disable-next-line max-lines-per-function, complexity
+      async (database) => {
+        let manifest = await readWorkspaceCheckpointManifest(prefix)
+        const existingJournal = await readWorkspaceFinalizationJournal(
+          prefix,
+        )
+        if (
+          existingJournal &&
+          workspaceFinalizationRequestsEqual(
+            existingJournal,
+            journalRequest,
+          )
+        ) {
+          if (existingJournal.state !== "pending") {
+            if (
+              manifest &&
+              workspaceCheckpointManifestsEqual(
+                manifest,
+                existingJournal.nextManifest,
+              )
+            ) {
+              if (existingJournal.state === "prepared") {
+                await writeWorkspaceFinalizationJournal({
+                  ...existingJournal,
+                  state: "committed",
+                })
+              }
+              return existingJournal.result
+            }
+            if (
+              existingJournal.state === "prepared" &&
+              manifest &&
+              workspaceCheckpointManifestDigest(manifest) ===
+                existingJournal.baseManifestDigest
+            ) {
+              await verifyPreparedWorkspaceFinalizationTargets(
+                existingJournal,
+              )
+              await writeWorkspaceCheckpointManifest(
+                existingJournal.nextManifest,
+              )
+              await writeWorkspaceFinalizationJournal({
+                ...existingJournal,
+                state: "committed",
+              })
+              return existingJournal.result
+            }
+            throw new WorkspaceStorageCompletionError(
+              "Workspace generation changed after checkpoint finalization",
+            )
+          }
+        }
+        await verifyWorkspaceFinalizationProof(
+          checkpointFinalizationProof,
+          {
+            version: 1,
+            signedWorkspacePrefix: prefix,
+            workspaceGeneration: baseWorkspaceGeneration,
+            invocationNonce,
+            expiresAt: invocationExpiresAt,
+          },
+        )
+        if (
+          !manifest ||
+          manifest.workspaceGeneration !== baseWorkspaceGeneration
+        ) {
+          throw new WorkspaceStorageCompletionError(
+            "Workspace generation changed before checkpoint finalization",
+          )
+        }
+        await writeWorkspaceFinalizationJournal({
+          version: 1,
+          state: "pending",
+          ...journalRequest,
+        })
+        const snapshot: WorkspaceGenerationSnapshot = {
+          generation: manifest.workspaceGeneration,
+          entries: new Map(
+            manifest.entries.map((entry) => [
+              entry.path,
+              {
+                path: entry.path,
+                size: entry.size,
+                eTag: entry.eTag,
+              },
+            ]),
+          ),
+        }
+
+        const claimed: WorkspaceUploadReservation[] = []
+        try {
+          for (const reservationId of normalizedReservationIds) {
+            const claim = await claimUploadCompletion(
+              ownerKey,
+              reservationId,
+              database,
+              false,
+              true,
+            )
+            if (claim.kind !== "claimed") {
+              throw new WorkspaceStorageCompletionError(
+                "Workspace checkpoint batch is not retryable",
+              )
+            }
+            claimed.push(claim.reservation)
+          }
+
+          const uploadPaths = new Set<string>()
+          for (const reservation of claimed) {
+            const ownerPrefix = `${prefix}/`
+            if (
+              reservation.publicArtifact ||
+              !reservation.targetKey.startsWith(ownerPrefix)
+            ) {
+              throw new WorkspaceStorageCompletionError(
+                "Workspace upload target does not match its signed prefix",
+              )
+            }
+            const relativePath = reservation.targetKey.slice(
+              ownerPrefix.length,
+            )
+            if (
+              !isCheckpointManagedWorkspacePath(relativePath) ||
+              uploadPaths.has(relativePath) ||
+              normalizedDeletedPaths.includes(relativePath)
+            ) {
+              throw new WorkspaceStorageCompletionError(
+                "Workspace checkpoint batch contains conflicting paths",
+              )
+            }
+            uploadPaths.add(relativePath)
+            const staged = await inspectStagedUpload(
+              reservation,
+              bucketName(),
+            )
+            if (!staged.matches || !staged.versionId) {
+              throw new WorkspaceStorageCompletionError(
+                "Uploaded object did not match its reservation",
+              )
+            }
+          }
+
+          const plannedEntries = new Map(snapshot.entries)
+          for (const path of normalizedDeletedPaths) {
+            plannedEntries.delete(path)
+          }
+          for (const reservation of claimed) {
+            const relativePath = reservation.targetKey.slice(
+              prefix.length + 1,
+            )
+            plannedEntries.set(relativePath, {
+              path: relativePath,
+              size: reservation.expectedBytes,
+              eTag: `pending-${reservation.id}`,
+            })
+          }
+          assertPrefixFreeWorkspaceEntries([...plannedEntries.values()])
+        } catch (error) {
+          await Promise.allSettled(
+            claimed.map((reservation) =>
+              resetWorkspaceUploadClaim(reservation.id, database),
+            ),
+          )
+          throw error
+        }
+
+        const mutationPaths = new Set(normalizedDeletedPaths)
+        for (const reservation of claimed) {
+          mutationPaths.add(
+            reservation.targetKey.slice(prefix.length + 1),
+          )
+        }
+        try {
+          for (const path of mutationPaths) {
+            await anchorCommittedCheckpointPathBeforePromotion(
+              prefix,
+              path,
+            )
+          }
+          const anchoredManifest = await readWorkspaceCheckpointManifest(
+            prefix,
+          )
+          if (
+            !anchoredManifest ||
+            anchoredManifest.workspaceGeneration !==
+              baseWorkspaceGeneration
+          ) {
+            throw new WorkspaceStorageCompletionError(
+              "Workspace checkpoint anchor generation changed",
+            )
+          }
+          manifest = anchoredManifest
+          const baseManifestDigest = workspaceCheckpointManifestDigest(
+            anchoredManifest,
+          )
+
+          const deletions: FinalizeWorkspaceCheckpointResult["deletions"] = []
+          for (const path of normalizedDeletedPaths) {
+            const currentEntry = snapshot.entries.get(path)
+            if (!currentEntry) {
+              deletions.push({ path, deleted: false })
+              continue
+            }
+            const committedEntry = manifest.entries.find(
+              (entry) => entry.path === path,
+            )
+            if (
+              !committedEntry ||
+              committedEntry.size !== currentEntry.size ||
+              committedEntry.eTag !== currentEntry.eTag
+            ) {
+              throw new WorkspaceStorageCompletionError(
+                "Workspace delete target is not in the committed checkpoint",
+              )
+            }
+            const deleted = await s3Client().send(
+              new DeleteObjectCommand({
+                Bucket: bucketName(),
+                Key: ownerWorkspaceKey(prefix, path),
+              }),
+            )
+            if (deleted.DeleteMarker !== true || !deleted.VersionId) {
+              throw new WorkspaceStorageCompletionError(
+                "Workspace path deletion was not version preserving",
+              )
+            }
+            snapshot.entries.delete(path)
+            snapshot.generation = workspaceGenerationFromEntries(
+              [...snapshot.entries.values()],
+            )
+            deletions.push({ path, deleted: true })
+          }
+
+          const uploads: FinalizeWorkspaceCheckpointResult["uploads"] = []
+          for (const [index, reservation] of claimed.entries()) {
+            const completed = await finishClaimedUpload(
+              reservation,
+              ownerKey,
+              reservation.id,
+              database,
+              () => {
+                leasesToDrop.push(reservation)
+              },
+              {
+                signedWorkspacePrefix: prefix,
+                expectedGeneration: snapshot.generation,
+                snapshot,
+                checkpointAlreadyAnchored: true,
+              },
+            )
+            if (!completed.eTag || !completed.workspaceGeneration) {
+              throw new WorkspaceStorageCompletionError(
+                "Workspace batch promotion returned incomplete metadata",
+              )
+            }
+            uploads.push({
+              reservationId: normalizedReservationIds[index]!,
+              key: completed.key,
+              eTag: completed.eTag,
+            })
+            await Promise.allSettled([
+              settleLease(
+                reservation.byteLeaseId,
+                reservation.expectedBytes,
+              ),
+              settleLease(reservation.objectLeaseId, 1),
+            ])
+          }
+
+          const nextManifest = await captureWorkspaceCheckpointManifest(
+            prefix,
+            snapshot,
+            manifest,
+          )
+          if (nextManifest.workspaceGeneration !== snapshot.generation) {
+            throw new WorkspaceStorageCompletionError(
+              "Workspace checkpoint batch generation is incomplete",
+            )
+          }
+          const result: FinalizeWorkspaceCheckpointResult = {
+            checkpointCommitted: true,
+            workspaceGeneration: nextManifest.workspaceGeneration,
+            uploads,
+            deletions,
+          }
+          const preparedJournal: PreparedWorkspaceFinalizationJournal = {
+            version: 1,
+            state: "prepared",
+            ...journalRequest,
+            baseManifestDigest,
+            result,
+            nextManifest,
+          }
+          await writeWorkspaceFinalizationJournal(preparedJournal)
+          await writeWorkspaceCheckpointManifest(nextManifest)
+          await writeWorkspaceFinalizationJournal({
+            ...preparedJournal,
+            state: "committed",
+          })
+          return result
+        } catch (error) {
+          await Promise.allSettled(
+            claimed.map((reservation) =>
+              resetWorkspaceUploadClaim(reservation.id, database),
+            ),
+          )
+          throw error
+        }
+      },
+    )
+  } catch (error) {
+    await Promise.allSettled(
+      leasesToDrop.flatMap((reservation) => [
+        dropLease(reservation.byteLeaseId),
+        dropLease(reservation.objectLeaseId),
+      ]),
+    )
+    throw error
   }
 }
 

--- a/lib/agent-workspace/storage-broker.ts
+++ b/lib/agent-workspace/storage-broker.ts
@@ -4078,14 +4078,16 @@ async function recoverWorkspaceFinalizationClaim(
     if (!isS3ObjectNotFound(error)) throw error
   }
 
-  const targetIsCommittedBase =
+  const targetMatchesBaseContent =
     current !== undefined &&
     baseEntry !== undefined &&
     current.ContentLength === baseEntry.size &&
-    current.ETag === baseEntry.eTag &&
-    (baseEntry.source === "anchor" ||
-      current.VersionId === baseEntry.versionId)
-  if (targetIsCommittedBase || (!current && !baseEntry)) {
+    current.ETag === baseEntry.eTag
+  const targetIsExactCommittedVersion =
+    targetMatchesBaseContent &&
+    baseEntry?.source === "target" &&
+    current?.VersionId === baseEntry.versionId
+  if (targetIsExactCommittedVersion || (!current && !baseEntry)) {
     return { reservation, relativePath }
   }
   if (!current) {
@@ -4104,6 +4106,13 @@ async function recoverWorkspaceFinalizationClaim(
       ? current.ETag
       : undefined
   if (!promotedETag || !current.VersionId) {
+    // Once a base entry is anchored its target VersionId is deliberately no
+    // longer retained in the manifest. Matching base content is therefore the
+    // only safe unpromoted state when the current target is not the exact
+    // reserved payload.
+    if (targetMatchesBaseContent && baseEntry?.source === "anchor") {
+      return { reservation, relativePath }
+    }
     throw new WorkspaceStorageSettlementUncertainError(
       "Pending workspace upload target has an unknown version",
     )

--- a/tests/unit/agent-workspace-storage-route.test.ts
+++ b/tests/unit/agent-workspace-storage-route.test.ts
@@ -310,6 +310,29 @@ describe("POST /api/agent/workspace-storage", () => {
     )
   })
 
+  it("accepts a deletion path at the canonical UTF-8 byte limit", async () => {
+    const boundaryPath = [
+      "a".repeat(255),
+      "b".repeat(255),
+      "c".repeat(254),
+      "d",
+    ].join("/")
+
+    const response = await POST(
+      request({
+        operation: "finalize-checkpoint",
+        baseWorkspaceGeneration: "1".repeat(64),
+        reservationIds: [],
+        deletedPaths: [boundaryPath],
+        checkpointFinalizationProof: CHECKPOINT_FINALIZATION_PROOF,
+      }),
+    )
+
+    expect(Buffer.byteLength(boundaryPath, "utf8")).toBe(768)
+    expect(response.status).toBe(200)
+    expect(finalizeWorkspaceCheckpointMock).toHaveBeenCalled()
+  })
+
   it.each([
     [
       "a missing array",
@@ -390,6 +413,35 @@ describe("POST /api/agent/workspace-storage", () => {
         baseWorkspaceGeneration: "1".repeat(64),
         reservationIds: [],
         deletedPaths: [42],
+        checkpointFinalizationProof: CHECKPOINT_FINALIZATION_PROOF,
+      },
+    ],
+    [
+      "a deletion path over the canonical UTF-8 byte limit",
+      {
+        operation: "finalize-checkpoint",
+        baseWorkspaceGeneration: "1".repeat(64),
+        reservationIds: [],
+        deletedPaths: [
+          [
+            "a".repeat(255),
+            "b".repeat(255),
+            "c".repeat(255),
+            "dd",
+          ].join("/"),
+        ],
+        checkpointFinalizationProof: CHECKPOINT_FINALIZATION_PROOF,
+      },
+    ],
+    [
+      "a multibyte deletion path over the canonical UTF-8 byte limit",
+      {
+        operation: "finalize-checkpoint",
+        baseWorkspaceGeneration: "1".repeat(64),
+        reservationIds: [],
+        deletedPaths: [
+          Array.from({ length: 4 }, () => "é".repeat(96)).join("/"),
+        ],
         checkpointFinalizationProof: CHECKPOINT_FINALIZATION_PROOF,
       },
     ],

--- a/tests/unit/agent-workspace-storage-route.test.ts
+++ b/tests/unit/agent-workspace-storage-route.test.ts
@@ -1,3 +1,5 @@
+/** @jest-environment node */
+
 import type { NextRequest } from "next/server"
 
 const verifyContextMock = jest.fn()
@@ -9,6 +11,7 @@ const createPublicArtifactDownloadUrlMock = jest.fn()
 const completeWorkspaceUploadMock = jest.fn()
 const ensureWorkspaceCheckpointMock = jest.fn()
 const commitWorkspaceCheckpointMock = jest.fn()
+const finalizeWorkspaceCheckpointMock = jest.fn()
 const deleteWorkspacePathMock = jest.fn()
 
 jest.mock("@/lib/agent-workspace/invocation-context", () => ({
@@ -34,6 +37,8 @@ jest.mock("@/lib/agent-workspace/storage-broker", () => ({
     ensureWorkspaceCheckpointMock(...args),
   commitWorkspaceCheckpoint: (...args: unknown[]) =>
     commitWorkspaceCheckpointMock(...args),
+  finalizeWorkspaceCheckpoint: (...args: unknown[]) =>
+    finalizeWorkspaceCheckpointMock(...args),
   deleteWorkspacePath: (...args: unknown[]) =>
     deleteWorkspacePathMock(...args),
 }))
@@ -49,6 +54,8 @@ jest.mock("@/lib/logger", () => ({
 import { POST } from "@/app/api/agent/workspace-storage/route"
 import { WorkspaceStorageCompletionError } from "@/lib/agent-workspace/storage-broker"
 
+const CHECKPOINT_FINALIZATION_PROOF = "signed-checkpoint-finalization-proof"
+
 function request(body: unknown): NextRequest {
   return {
     json: async () => body,
@@ -63,6 +70,7 @@ beforeEach(() => {
     mode: "owner",
     sessionId: "session-1",
     nonce: "nonce-1",
+    expiresAt: 2_000_000_000,
     workspacePrefix: "workspaces/owner/",
   })
   listWorkspaceObjectsMock.mockResolvedValue({ keys: [] })
@@ -79,6 +87,10 @@ beforeEach(() => {
     workspaceGeneration: "1".repeat(64),
   })
   commitWorkspaceCheckpointMock.mockResolvedValue({
+    checkpointCommitted: true,
+    workspaceGeneration: "2".repeat(64),
+  })
+  finalizeWorkspaceCheckpointMock.mockResolvedValue({
     checkpointCommitted: true,
     workspaceGeneration: "2".repeat(64),
   })
@@ -212,6 +224,8 @@ describe("POST /api/agent/workspace-storage", () => {
     ensureWorkspaceCheckpointMock.mockResolvedValueOnce({
       checkpointReady: true,
       workspaceGeneration,
+      atomicCheckpointCommitVersion: 1,
+      checkpointFinalizationProof: CHECKPOINT_FINALIZATION_PROOF,
       checkpointSnapshot,
     })
 
@@ -220,10 +234,16 @@ describe("POST /api/agent/workspace-storage", () => {
     expect(await ensured.json()).toEqual({
       checkpointReady: true,
       workspaceGeneration,
+      atomicCheckpointCommitVersion: 1,
+      checkpointFinalizationProof: CHECKPOINT_FINALIZATION_PROOF,
       checkpointSnapshot,
     })
     expect(ensureWorkspaceCheckpointMock).toHaveBeenCalledWith(
       "workspaces/owner/",
+      {
+        invocationNonce: "nonce-1",
+        expiresAt: 2_000_000_000,
+      },
     )
 
     const committed = await POST(
@@ -258,6 +278,204 @@ describe("POST /api/agent/workspace-storage", () => {
     expect(missingBase.status).toBe(400)
     expect(malformedBase.status).toBe(400)
     expect(commitWorkspaceCheckpointMock).not.toHaveBeenCalled()
+  })
+
+  it("finalizes an ordered upload and deletion batch for the signed owner", async () => {
+    const reservationIds = [
+      "11111111-2222-4333-8444-555555555555",
+      "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee",
+    ]
+    const deletedPaths = ["memory/old.md", "state/removed.sqlite"]
+
+    const response = await POST(
+      request({
+        operation: "finalize-checkpoint",
+        baseWorkspaceGeneration: "1".repeat(64),
+        reservationIds,
+        deletedPaths,
+        checkpointFinalizationProof: CHECKPOINT_FINALIZATION_PROOF,
+      }),
+    )
+
+    expect(response.status).toBe(200)
+    expect(finalizeWorkspaceCheckpointMock).toHaveBeenCalledWith(
+      "owner@example.com",
+      "workspaces/owner/",
+      "1".repeat(64),
+      reservationIds,
+      deletedPaths,
+      CHECKPOINT_FINALIZATION_PROOF,
+      "nonce-1",
+      2_000_000_000,
+    )
+  })
+
+  it.each([
+    [
+      "a missing array",
+      {
+        operation: "finalize-checkpoint",
+        baseWorkspaceGeneration: "1".repeat(64),
+        reservationIds: [],
+        checkpointFinalizationProof: CHECKPOINT_FINALIZATION_PROOF,
+      },
+    ],
+    [
+      "a malformed base generation",
+      {
+        operation: "finalize-checkpoint",
+        baseWorkspaceGeneration: "not-a-generation",
+        reservationIds: [],
+        deletedPaths: [],
+        checkpointFinalizationProof: CHECKPOINT_FINALIZATION_PROOF,
+      },
+    ],
+    [
+      "a malformed reservation UUID",
+      {
+        operation: "finalize-checkpoint",
+        baseWorkspaceGeneration: "1".repeat(64),
+        reservationIds: ["not-a-uuid"],
+        deletedPaths: [],
+        checkpointFinalizationProof: CHECKPOINT_FINALIZATION_PROOF,
+      },
+    ],
+    [
+      "a non-array reservation list",
+      {
+        operation: "finalize-checkpoint",
+        baseWorkspaceGeneration: "1".repeat(64),
+        reservationIds: "11111111-2222-4333-8444-555555555555",
+        deletedPaths: [],
+        checkpointFinalizationProof: CHECKPOINT_FINALIZATION_PROOF,
+      },
+    ],
+    [
+      "duplicate reservation UUIDs",
+      {
+        operation: "finalize-checkpoint",
+        baseWorkspaceGeneration: "1".repeat(64),
+        reservationIds: [
+          "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee",
+          "AAAAAAAA-BBBB-4CCC-8DDD-EEEEEEEEEEEE",
+        ],
+        deletedPaths: [],
+        checkpointFinalizationProof: CHECKPOINT_FINALIZATION_PROOF,
+      },
+    ],
+    [
+      "an empty deletion path",
+      {
+        operation: "finalize-checkpoint",
+        baseWorkspaceGeneration: "1".repeat(64),
+        reservationIds: [],
+        deletedPaths: ["   "],
+        checkpointFinalizationProof: CHECKPOINT_FINALIZATION_PROOF,
+      },
+    ],
+    [
+      "duplicate deletion paths",
+      {
+        operation: "finalize-checkpoint",
+        baseWorkspaceGeneration: "1".repeat(64),
+        reservationIds: [],
+        deletedPaths: ["memory/old.md", "memory/old.md"],
+        checkpointFinalizationProof: CHECKPOINT_FINALIZATION_PROOF,
+      },
+    ],
+    [
+      "a non-string deletion path",
+      {
+        operation: "finalize-checkpoint",
+        baseWorkspaceGeneration: "1".repeat(64),
+        reservationIds: [],
+        deletedPaths: [42],
+        checkpointFinalizationProof: CHECKPOINT_FINALIZATION_PROOF,
+      },
+    ],
+    [
+      "a missing finalization proof",
+      {
+        operation: "finalize-checkpoint",
+        baseWorkspaceGeneration: "1".repeat(64),
+        reservationIds: [],
+        deletedPaths: [],
+      },
+    ],
+    [
+      "an empty finalization proof",
+      {
+        operation: "finalize-checkpoint",
+        baseWorkspaceGeneration: "1".repeat(64),
+        reservationIds: [],
+        deletedPaths: [],
+        checkpointFinalizationProof: "",
+      },
+    ],
+    [
+      "a non-string finalization proof",
+      {
+        operation: "finalize-checkpoint",
+        baseWorkspaceGeneration: "1".repeat(64),
+        reservationIds: [],
+        deletedPaths: [],
+        checkpointFinalizationProof: 42,
+      },
+    ],
+    [
+      "an oversized finalization proof",
+      {
+        operation: "finalize-checkpoint",
+        baseWorkspaceGeneration: "1".repeat(64),
+        reservationIds: [],
+        deletedPaths: [],
+        checkpointFinalizationProof: "x".repeat(4_097),
+      },
+    ],
+    [
+      "a multibyte finalization proof over the byte limit",
+      {
+        operation: "finalize-checkpoint",
+        baseWorkspaceGeneration: "1".repeat(64),
+        reservationIds: [],
+        deletedPaths: [],
+        checkpointFinalizationProof: "💥".repeat(1_025),
+      },
+    ],
+    [
+      "an undeclared field",
+      {
+        operation: "finalize-checkpoint",
+        baseWorkspaceGeneration: "1".repeat(64),
+        reservationIds: [],
+        deletedPaths: [],
+        checkpointFinalizationProof: CHECKPOINT_FINALIZATION_PROOF,
+        workspaceGeneration: "2".repeat(64),
+      },
+    ],
+  ])("rejects finalize-checkpoint with %s", async (_label, body) => {
+    const response = await POST(request(body))
+
+    expect(response.status).toBe(400)
+    expect(finalizeWorkspaceCheckpointMock).not.toHaveBeenCalled()
+  })
+
+  it("caps the total finalize-checkpoint batch cardinality", async () => {
+    const response = await POST(
+      request({
+        operation: "finalize-checkpoint",
+        baseWorkspaceGeneration: "1".repeat(64),
+        reservationIds: [],
+        checkpointFinalizationProof: CHECKPOINT_FINALIZATION_PROOF,
+        deletedPaths: Array.from(
+          { length: 250_001 },
+          (_value, index) => `memory/deleted-${index}.md`,
+        ),
+      }),
+    )
+
+    expect(response.status).toBe(400)
+    expect(finalizeWorkspaceCheckpointMock).not.toHaveBeenCalled()
   })
 
   it("generation-fences deletes inside the signed prefix", async () => {

--- a/tests/unit/lib/agent-workspace/storage-broker-checkpoint.test.ts
+++ b/tests/unit/lib/agent-workspace/storage-broker-checkpoint.test.ts
@@ -438,6 +438,51 @@ function stageWorkspaceUpload(
   })
 }
 
+function seedPendingFinalizationJournal(
+  workspaceGeneration: string,
+  proof: string,
+  reservationIds: string[],
+  deletedPaths: string[] = [],
+): void {
+  const request = {
+    version: 1,
+    ownerHash: createHash("sha256")
+      .update("owner@example.com")
+      .digest("hex"),
+    signedWorkspacePrefix: PREFIX,
+    baseWorkspaceGeneration: workspaceGeneration,
+    proofHash: createHash("sha256").update(proof).digest("hex"),
+    reservationIds,
+    deletedPaths,
+  }
+  const body = JSON.stringify({
+    ...request,
+    state: "pending",
+    requestDigest: createHash("sha256")
+      .update(JSON.stringify(request))
+      .digest("hex"),
+  })
+  store.add(finalizationJournalKey(), {
+    size: Buffer.byteLength(body),
+    eTag: '"pending-journal"',
+    body,
+    scope: "Scope=checkpoint",
+  })
+}
+
+function returnActiveReservationAsVerifying(): void {
+  executeQueryMock.mockImplementation(async (...args: unknown[]) => {
+    const label = args[1]
+    if (label === "claimWorkspaceUploadCompletion") return []
+    if (label === "getWorkspaceUploadCompletion") {
+      return activeReservation ? [activeReservation] : []
+    }
+    if (label === "getSupersededWorkspaceUploadVersions") return []
+    if (label === "confirmWorkspaceUploadSettlement") return []
+    return []
+  })
+}
+
 beforeAll(async () => {
   const broker = await import("@/lib/agent-workspace/storage-broker")
   ensureWorkspaceCheckpoint = broker.ensureWorkspaceCheckpoint
@@ -1240,6 +1285,160 @@ describe("durable workspace checkpoints", () => {
         (command) => command.name === "ListObjectsV2Command",
       ),
     ).toHaveLength(0)
+  })
+
+  it("reclaims an exact pending batch after a crash midway through reservation claims", async () => {
+    const expiresAt = Math.floor(Date.now() / 1000) + 60
+    const checkpoint = await ensureFinalizationCheckpoint(
+      "invocation-mid-claim",
+      expiresAt,
+    )
+    stageWorkspaceUpload(
+      RESERVATION_ONE,
+      "state/a.sqlite",
+      '"a-new"',
+      "nnnn",
+    )
+    seedPendingFinalizationJournal(
+      checkpoint.workspaceGeneration,
+      checkpoint.proof,
+      [RESERVATION_ONE],
+    )
+    returnActiveReservationAsVerifying()
+    const beforeRetry = store.commands.length
+
+    const result = await finalizeWorkspaceCheckpoint(
+      "owner@example.com",
+      PREFIX,
+      checkpoint.workspaceGeneration,
+      [RESERVATION_ONE],
+      [],
+      checkpoint.proof,
+      "invocation-mid-claim",
+      expiresAt,
+    )
+
+    expect(result.uploads).toEqual([
+      {
+        reservationId: RESERVATION_ONE,
+        key: `${PREFIX}/state/a.sqlite`,
+        eTag: '"a-new"',
+      },
+    ])
+    expect(store.current(`${PREFIX}/state/a.sqlite`)?.body).toBe("nnnn")
+    expect(manifest().workspaceGeneration).toBe(
+      result.workspaceGeneration,
+    )
+    expect(
+      store.commands.slice(beforeRetry).filter(
+        (command) => command.name === "ListObjectsV2Command",
+      ),
+    ).toHaveLength(0)
+  })
+
+  it("rolls forward an exact pending batch after promotion but before journal preparation", async () => {
+    const expiresAt = Math.floor(Date.now() / 1000) + 60
+    const checkpoint = await ensureFinalizationCheckpoint(
+      "invocation-post-promotion",
+      expiresAt,
+    )
+    stageWorkspaceUpload(
+      RESERVATION_ONE,
+      "state/a.sqlite",
+      '"a-new"',
+      "nnnn",
+    )
+    const promoted = store.add(`${PREFIX}/state/a.sqlite`, {
+      size: 4,
+      eTag: '"a-new"',
+      body: "nnnn",
+      checksum: CHECKSUM,
+      contentType: CONTENT_TYPE,
+      scope: "Scope=private",
+    })
+    seedPendingFinalizationJournal(
+      checkpoint.workspaceGeneration,
+      checkpoint.proof,
+      [RESERVATION_ONE],
+    )
+    returnActiveReservationAsVerifying()
+    const beforeRetry = store.commands.length
+
+    const result = await finalizeWorkspaceCheckpoint(
+      "owner@example.com",
+      PREFIX,
+      checkpoint.workspaceGeneration,
+      [RESERVATION_ONE],
+      [],
+      checkpoint.proof,
+      "invocation-post-promotion",
+      expiresAt,
+    )
+
+    expect(result.uploads[0]).toMatchObject({
+      reservationId: RESERVATION_ONE,
+      eTag: '"a-new"',
+    })
+    expect(store.current(`${PREFIX}/state/a.sqlite`)?.versionId).toBe(
+      promoted.versionId,
+    )
+    expect(
+      store.commands.slice(beforeRetry).filter(
+        (command) => command.name === "CopyObjectCommand",
+      ),
+    ).toHaveLength(0)
+    expect(
+      store.commands.slice(beforeRetry).filter(
+        (command) => command.name === "ListObjectsV2Command",
+      ),
+    ).toHaveLength(0)
+    expect(
+      JSON.parse(
+        store.current(finalizationJournalKey())?.body ?? "{}",
+      ),
+    ).toMatchObject({ state: "committed", result })
+  })
+
+  it("returns a newly claimed reservation when pending recovery fails", async () => {
+    const expiresAt = Math.floor(Date.now() / 1000) + 60
+    const checkpoint = await ensureFinalizationCheckpoint(
+      "invocation-recovery-reject",
+      expiresAt,
+    )
+    stageWorkspaceUpload(
+      RESERVATION_ONE,
+      "state/a.sqlite",
+      '"a-new"',
+      "nnnn",
+    )
+    store.add(`${PREFIX}/state/a.sqlite`, {
+      size: 7,
+      eTag: '"unknown"',
+      body: "unknown",
+      checksum: "not-the-reserved-checksum",
+      contentType: "text/plain",
+      scope: "Scope=private",
+    })
+
+    await expect(
+      finalizeWorkspaceCheckpoint(
+        "owner@example.com",
+        PREFIX,
+        checkpoint.workspaceGeneration,
+        [RESERVATION_ONE],
+        [],
+        checkpoint.proof,
+        "invocation-recovery-reject",
+        expiresAt,
+      ),
+    ).rejects.toThrow("unknown version")
+
+    expect(
+      executeQueryMock.mock.calls.some(
+        (call) =>
+          call[1] === "resetWorkspaceUploadCompletionClaim",
+      ),
+    ).toBe(true)
   })
 
   it("rejects a mismatched proof and never starts its pending journal or mutations", async () => {

--- a/tests/unit/lib/agent-workspace/storage-broker-checkpoint.test.ts
+++ b/tests/unit/lib/agent-workspace/storage-broker-checkpoint.test.ts
@@ -368,6 +368,14 @@ function manifestKey(): string {
   return `.workspace-checkpoints/v2/${prefixHash}/manifest.json`
 }
 
+function anchorKey(relativePath: string): string {
+  const prefixHash = createHash("sha256").update(PREFIX).digest("hex")
+  const pathHash = createHash("sha256")
+    .update(Buffer.from(relativePath, "utf8"))
+    .digest("hex")
+  return `.workspace-checkpoints/v2/${prefixHash}/anchors/${pathHash}`
+}
+
 function legacyManifestKey(): string {
   const prefixHash = createHash("sha256").update(PREFIX).digest("hex")
   return `.workspace-checkpoints/v1/${prefixHash}/manifest.json`
@@ -1397,6 +1405,89 @@ describe("durable workspace checkpoints", () => {
         store.current(finalizationJournalKey())?.body ?? "{}",
       ),
     ).toMatchObject({ state: "committed", result })
+  })
+
+  it("recovers an identical promoted payload after its anchored staging object was removed", async () => {
+    const relativePath = "state/a.sqlite"
+    store.add(`${PREFIX}/${relativePath}`, {
+      size: 4,
+      eTag: '"same"',
+      body: "same",
+      checksum: CHECKSUM,
+      contentType: CONTENT_TYPE,
+      scope: "Scope=private",
+    })
+    const expiresAt = Math.floor(Date.now() / 1000) + 60
+    const checkpoint = await ensureFinalizationCheckpoint(
+      "invocation-identical-promotion",
+      expiresAt,
+    )
+    const anchored = store.add(anchorKey(relativePath), {
+      size: 4,
+      eTag: '"anchor-same"',
+      body: "same",
+      checksum: CHECKSUM,
+      contentType: CONTENT_TYPE,
+      scope: "Scope=checkpoint",
+    })
+    const anchoredManifest = manifest()
+    const anchoredEntry = (
+      anchoredManifest.entries as Array<Record<string, unknown>>
+    )[0]!
+    anchoredEntry.source = "anchor"
+    anchoredEntry.versionId = anchored.versionId
+    anchoredEntry.sourceETag = anchored.eTag
+    const anchoredBody = JSON.stringify(anchoredManifest)
+    store.add(manifestKey(), {
+      size: Buffer.byteLength(anchoredBody),
+      eTag: '"anchored-manifest"',
+      body: anchoredBody,
+      scope: "Scope=checkpoint",
+    })
+    stageWorkspaceUpload(
+      RESERVATION_ONE,
+      relativePath,
+      '"same"',
+      "same",
+    )
+    const stagingKey = String(activeReservation?.stagingKey)
+    const promoted = store.add(`${PREFIX}/${relativePath}`, {
+      size: 4,
+      eTag: '"same"',
+      body: "same",
+      checksum: CHECKSUM,
+      contentType: CONTENT_TYPE,
+      scope: "Scope=private",
+    })
+    store.objects.delete(stagingKey)
+    seedPendingFinalizationJournal(
+      checkpoint.workspaceGeneration,
+      checkpoint.proof,
+      [RESERVATION_ONE],
+    )
+    returnActiveReservationAsVerifying()
+    const beforeRetry = store.commands.length
+
+    const result = await finalizeWorkspaceCheckpoint(
+      "owner@example.com",
+      PREFIX,
+      checkpoint.workspaceGeneration,
+      [RESERVATION_ONE],
+      [],
+      checkpoint.proof,
+      "invocation-identical-promotion",
+      expiresAt,
+    )
+
+    expect(result.uploads[0]?.eTag).toBe('"same"')
+    expect(store.current(`${PREFIX}/${relativePath}`)?.versionId).toBe(
+      promoted.versionId,
+    )
+    expect(
+      store.commands.slice(beforeRetry).filter(
+        (command) => command.name === "CopyObjectCommand",
+      ),
+    ).toHaveLength(0)
   })
 
   it("returns a newly claimed reservation when pending recovery fails", async () => {

--- a/tests/unit/lib/agent-workspace/storage-broker-checkpoint.test.ts
+++ b/tests/unit/lib/agent-workspace/storage-broker-checkpoint.test.ts
@@ -75,6 +75,8 @@ class VersionedS3 {
   }> = []
   sequence = 0
   failNextManifestPutAfterWrite = false
+  failNextManifestPutBeforeWrite = false
+  failNextJournalPutAfterWrite = false
   beforeCommand?: (
     name: string,
     input: Record<string, unknown>,
@@ -215,12 +217,26 @@ class VersionedS3 {
     }
     if (name === "PutObjectCommand") {
       const body = String(input.Body ?? "")
+      if (
+        key.endsWith("/manifest.json") &&
+        this.failNextManifestPutBeforeWrite
+      ) {
+        this.failNextManifestPutBeforeWrite = false
+        throw new Error("manifest put failed before write")
+      }
       const stored = this.add(key, {
         size: Buffer.byteLength(body),
         eTag: `"manifest-${this.sequence + 1}"`,
         body,
         scope: String(input.Tagging ?? ""),
       })
+      if (
+        key.endsWith("/last-finalization.json") &&
+        this.failNextJournalPutAfterWrite
+      ) {
+        this.failNextJournalPutAfterWrite = false
+        throw new Error("journal response lost after durable put")
+      }
       if (
         key.endsWith("/manifest.json") &&
         this.failNextManifestPutAfterWrite
@@ -286,6 +302,8 @@ let commitWorkspaceCheckpoint:
   typeof import("@/lib/agent-workspace/storage-broker").commitWorkspaceCheckpoint
 let completeWorkspaceUpload:
   typeof import("@/lib/agent-workspace/storage-broker").completeWorkspaceUpload
+let finalizeWorkspaceCheckpoint:
+  typeof import("@/lib/agent-workspace/storage-broker").finalizeWorkspaceCheckpoint
 let deleteWorkspacePath:
   typeof import("@/lib/agent-workspace/storage-broker").deleteWorkspacePath
 let workspaceGenerationFromEntries:
@@ -355,6 +373,11 @@ function legacyManifestKey(): string {
   return `.workspace-checkpoints/v1/${prefixHash}/manifest.json`
 }
 
+function finalizationJournalKey(): string {
+  const prefixHash = createHash("sha256").update(PREFIX).digest("hex")
+  return `.workspace-checkpoints/v2/${prefixHash}/last-finalization.json`
+}
+
 function manifest(): Record<string, unknown> {
   return JSON.parse(store.current(manifestKey())!.body ?? "{}") as Record<
     string,
@@ -382,11 +405,45 @@ function stagedReservation(
   }
 }
 
+async function ensureFinalizationCheckpoint(
+  invocationNonce: string,
+  expiresAt: number,
+): Promise<{ workspaceGeneration: string; proof: string }> {
+  const checkpoint = await ensureWorkspaceCheckpoint(PREFIX, {
+    invocationNonce,
+    expiresAt,
+  })
+  if (!checkpoint.checkpointFinalizationProof) {
+    throw new Error("checkpoint finalization proof was not issued")
+  }
+  return {
+    workspaceGeneration: checkpoint.workspaceGeneration,
+    proof: checkpoint.checkpointFinalizationProof,
+  }
+}
+
+function stageWorkspaceUpload(
+  reservationId: string,
+  relativePath: string,
+  eTag: string,
+  body: string,
+): void {
+  activeReservation = stagedReservation(reservationId, relativePath)
+  store.add(String(activeReservation.stagingKey), {
+    size: Buffer.byteLength(body),
+    eTag,
+    body,
+    checksum: CHECKSUM,
+    contentType: CONTENT_TYPE,
+  })
+}
+
 beforeAll(async () => {
   const broker = await import("@/lib/agent-workspace/storage-broker")
   ensureWorkspaceCheckpoint = broker.ensureWorkspaceCheckpoint
   commitWorkspaceCheckpoint = broker.commitWorkspaceCheckpoint
   completeWorkspaceUpload = broker.completeWorkspaceUpload
+  finalizeWorkspaceCheckpoint = broker.finalizeWorkspaceCheckpoint
   deleteWorkspacePath = broker.deleteWorkspacePath
   workspaceGenerationFromEntries = broker.workspaceGenerationFromEntries
   resetWorkspaceStorageClientForTests =
@@ -396,6 +453,7 @@ beforeAll(async () => {
 beforeEach(() => {
   jest.clearAllMocks()
   process.env.AGENT_WORKSPACE_BUCKET = BUCKET
+  process.env.AGENT_INVOCATION_SIGNING_SECRET = "test-finalization-secret"
   resetWorkspaceStorageClientForTests()
   store = new VersionedS3()
   activeReservation = undefined
@@ -1096,6 +1154,401 @@ describe("durable workspace checkpoints", () => {
       source: "target",
       versionId: store.current(`${PREFIX}/state/a.sqlite`)?.versionId,
     })
+  })
+
+  it("atomically finalizes an exact batch with one full scan and survives a lost journal response", async () => {
+    store.add(`${PREFIX}/state/a.sqlite`, {
+      size: 4,
+      eTag: '"a-old"',
+      body: "aaaa",
+      scope: "Scope=private",
+    })
+    store.add(`${PREFIX}/memory/remove.md`, {
+      size: 4,
+      eTag: '"remove-old"',
+      body: "old!",
+      scope: "Scope=private",
+    })
+    const expiresAt = Math.floor(Date.now() / 1000) + 60
+    const checkpoint = await ensureFinalizationCheckpoint(
+      "invocation-normal",
+      expiresAt,
+    )
+    stageWorkspaceUpload(
+      RESERVATION_ONE,
+      "state/a.sqlite",
+      '"a-new"',
+      "nnnn",
+    )
+    const beforeFinalize = store.commands.length
+    store.failNextJournalPutAfterWrite = true
+
+    const result = await finalizeWorkspaceCheckpoint(
+      "owner@example.com",
+      PREFIX,
+      checkpoint.workspaceGeneration,
+      [RESERVATION_ONE],
+      ["memory/remove.md"],
+      checkpoint.proof,
+      "invocation-normal",
+      expiresAt,
+    )
+
+    expect(result).toEqual({
+      checkpointCommitted: true,
+      workspaceGeneration: workspaceGeneration([
+        { path: "state/a.sqlite", size: 4, eTag: '"a-new"' },
+      ]),
+      uploads: [
+        {
+          reservationId: RESERVATION_ONE,
+          key: `${PREFIX}/state/a.sqlite`,
+          eTag: '"a-new"',
+        },
+      ],
+      deletions: [{ path: "memory/remove.md", deleted: true }],
+    })
+    expect(store.current(`${PREFIX}/state/a.sqlite`)?.body).toBe("nnnn")
+    expect(store.current(`${PREFIX}/memory/remove.md`)).toBeUndefined()
+    expect(manifest().workspaceGeneration).toBe(
+      result.workspaceGeneration,
+    )
+    expect(
+      (manifest().entries as Array<Record<string, unknown>>)[0],
+    ).toMatchObject({
+      path: "state/a.sqlite",
+      source: "target",
+      versionId: store.current(`${PREFIX}/state/a.sqlite`)?.versionId,
+    })
+    expect(
+      JSON.parse(
+        store.current(finalizationJournalKey())?.body ?? "{}",
+      ),
+    ).toMatchObject({
+      state: "committed",
+      reservationIds: [RESERVATION_ONE],
+      deletedPaths: ["memory/remove.md"],
+      result,
+    })
+    expect(
+      store.commands.filter(
+        (command) => command.name === "ListObjectsV2Command",
+      ),
+    ).toHaveLength(1)
+    expect(
+      store.commands.slice(beforeFinalize).filter(
+        (command) => command.name === "ListObjectsV2Command",
+      ),
+    ).toHaveLength(0)
+  })
+
+  it("rejects a mismatched proof and never starts its pending journal or mutations", async () => {
+    const expiresAt = Math.floor(Date.now() / 1000) + 60
+    const checkpoint = await ensureFinalizationCheckpoint(
+      "invocation-proof",
+      expiresAt,
+    )
+    stageWorkspaceUpload(
+      RESERVATION_ONE,
+      "state/a.sqlite",
+      '"a-new"',
+      "nnnn",
+    )
+    const beforeFinalize = store.commands.length
+
+    await expect(
+      finalizeWorkspaceCheckpoint(
+        "owner@example.com",
+        PREFIX,
+        checkpoint.workspaceGeneration,
+        [RESERVATION_ONE],
+        [],
+        checkpoint.proof,
+        "different-invocation",
+        expiresAt,
+      ),
+    ).rejects.toThrow("finalization proof is invalid")
+
+    expect(store.current(finalizationJournalKey())).toBeUndefined()
+    expect(store.current(`${PREFIX}/state/a.sqlite`)).toBeUndefined()
+    expect(
+      store.commands.slice(beforeFinalize).some(
+        (command) =>
+          command.name === "CopyObjectCommand" ||
+          command.name === "DeleteObjectCommand" ||
+          command.name === "PutObjectCommand" ||
+          command.name === "ListObjectsV2Command",
+      ),
+    ).toBe(false)
+  })
+
+  it("replays a committed result under a new invocation and rejects it after a later checkpoint", async () => {
+    const expiresAt = Math.floor(Date.now() / 1000) + 5
+    const checkpoint = await ensureFinalizationCheckpoint(
+      "invocation-original",
+      expiresAt,
+    )
+    stageWorkspaceUpload(
+      RESERVATION_ONE,
+      "state/a.sqlite",
+      '"a-new"',
+      "nnnn",
+    )
+    const original = await finalizeWorkspaceCheckpoint(
+      "owner@example.com",
+      PREFIX,
+      checkpoint.workspaceGeneration,
+      [RESERVATION_ONE],
+      [],
+      checkpoint.proof,
+      "invocation-original",
+      expiresAt,
+    )
+    const beforeReplay = store.commands.length
+    const now = jest
+      .spyOn(Date, "now")
+      .mockReturnValue((expiresAt + 10) * 1_000)
+    try {
+      await expect(
+        finalizeWorkspaceCheckpoint(
+          "owner@example.com",
+          PREFIX,
+          checkpoint.workspaceGeneration,
+          [RESERVATION_ONE],
+          [],
+          checkpoint.proof,
+          "invocation-retry",
+          expiresAt + 300,
+        ),
+      ).resolves.toEqual(original)
+
+      expect(
+        store.commands.slice(beforeReplay).some(
+          (command) =>
+            command.name === "CopyObjectCommand" ||
+            command.name === "DeleteObjectCommand" ||
+            command.name === "PutObjectCommand" ||
+            command.name === "ListObjectsV2Command",
+        ),
+      ).toBe(false)
+
+      const currentEntries = manifest().entries as Array<
+        Record<string, unknown>
+      >
+      const later = store.add(`${PREFIX}/memory/later.md`, {
+        size: 5,
+        eTag: '"later"',
+        body: "later",
+        scope: "Scope=private",
+      })
+      const laterEntry = {
+        path: "memory/later.md",
+        size: 5,
+        eTag: '"later"',
+        source: "target",
+        versionId: later.versionId,
+        sourceETag: '"later"',
+      }
+      const laterEntries = [...currentEntries, laterEntry].sort(
+        (left, right) => String(left.path).localeCompare(String(right.path)),
+      )
+      const laterGeneration = workspaceGeneration(
+        laterEntries.map((entry) => ({
+          path: String(entry.path),
+          size: Number(entry.size),
+          eTag: String(entry.eTag),
+        })),
+      )
+      const laterManifest = JSON.stringify({
+        version: 2,
+        signedWorkspacePrefix: PREFIX,
+        workspaceGeneration: laterGeneration,
+        entries: laterEntries,
+      })
+      store.add(manifestKey(), {
+        size: Buffer.byteLength(laterManifest),
+        eTag: '"later-manifest"',
+        body: laterManifest,
+        scope: "Scope=checkpoint",
+      })
+      const beforeStaleReplay = store.commands.length
+
+      await expect(
+        finalizeWorkspaceCheckpoint(
+          "owner@example.com",
+          PREFIX,
+          checkpoint.workspaceGeneration,
+          [RESERVATION_ONE],
+          [],
+          checkpoint.proof,
+          "invocation-retry",
+          expiresAt + 300,
+        ),
+      ).rejects.toThrow(
+        "generation changed after checkpoint finalization",
+      )
+      expect(manifest().workspaceGeneration).toBe(laterGeneration)
+      expect(
+        store.commands.slice(beforeStaleReplay).some(
+          (command) =>
+            command.name === "CopyObjectCommand" ||
+            command.name === "DeleteObjectCommand" ||
+            command.name === "PutObjectCommand" ||
+            command.name === "ListObjectsV2Command",
+        ),
+      ).toBe(false)
+    } finally {
+      now.mockRestore()
+    }
+  })
+
+  it("publishes a prepared exact manifest on a later invocation without repeating mutations", async () => {
+    const expiresAt = Math.floor(Date.now() / 1000) + 5
+    const checkpoint = await ensureFinalizationCheckpoint(
+      "invocation-prepared",
+      expiresAt,
+    )
+    stageWorkspaceUpload(
+      RESERVATION_ONE,
+      "state/a.sqlite",
+      '"a-new"',
+      "nnnn",
+    )
+    store.failNextManifestPutBeforeWrite = true
+
+    await expect(
+      finalizeWorkspaceCheckpoint(
+        "owner@example.com",
+        PREFIX,
+        checkpoint.workspaceGeneration,
+        [RESERVATION_ONE],
+        [],
+        checkpoint.proof,
+        "invocation-prepared",
+        expiresAt,
+      ),
+    ).rejects.toThrow("manifest put failed before write")
+
+    expect(manifest().workspaceGeneration).toBe(
+      checkpoint.workspaceGeneration,
+    )
+    expect(
+      JSON.parse(
+        store.current(finalizationJournalKey())?.body ?? "{}",
+      ),
+    ).toMatchObject({ state: "prepared" })
+    const promotedVersion = store.current(
+      `${PREFIX}/state/a.sqlite`,
+    )?.versionId
+    const beforeReplay = store.commands.length
+    const now = jest
+      .spyOn(Date, "now")
+      .mockReturnValue((expiresAt + 10) * 1_000)
+    try {
+      const replayed = await finalizeWorkspaceCheckpoint(
+        "owner@example.com",
+        PREFIX,
+        checkpoint.workspaceGeneration,
+        [RESERVATION_ONE],
+        [],
+        checkpoint.proof,
+        "invocation-later",
+        expiresAt + 300,
+      )
+
+      expect(replayed).toMatchObject({
+        checkpointCommitted: true,
+        uploads: [{ reservationId: RESERVATION_ONE }],
+      })
+      expect(manifest().workspaceGeneration).toBe(
+        replayed.workspaceGeneration,
+      )
+      expect(
+        store.current(`${PREFIX}/state/a.sqlite`)?.versionId,
+      ).toBe(promotedVersion)
+      expect(
+        JSON.parse(
+          store.current(finalizationJournalKey())?.body ?? "{}",
+        ),
+      ).toMatchObject({ state: "committed", result: replayed })
+      expect(
+        store.commands.slice(beforeReplay).some(
+          (command) =>
+            command.name === "CopyObjectCommand" ||
+            command.name === "DeleteObjectCommand" ||
+            command.name === "ListObjectsV2Command",
+        ),
+      ).toBe(false)
+    } finally {
+      now.mockRestore()
+    }
+  })
+
+  it("fails closed when an exact pending journal is retried by a different invocation", async () => {
+    const expiresAt = Math.floor(Date.now() / 1000) + 5
+    const checkpoint = await ensureFinalizationCheckpoint(
+      "invocation-pending",
+      expiresAt,
+    )
+    const proofHash = createHash("sha256")
+      .update(checkpoint.proof)
+      .digest("hex")
+    const ownerHash = createHash("sha256")
+      .update("owner@example.com")
+      .digest("hex")
+    const request = {
+      version: 1,
+      ownerHash,
+      signedWorkspacePrefix: PREFIX,
+      baseWorkspaceGeneration: checkpoint.workspaceGeneration,
+      proofHash,
+      reservationIds: [] as string[],
+      deletedPaths: [] as string[],
+    }
+    const requestDigest = createHash("sha256")
+      .update(JSON.stringify(request))
+      .digest("hex")
+    const journal = JSON.stringify({
+      version: 1,
+      state: "pending",
+      ownerHash,
+      signedWorkspacePrefix: PREFIX,
+      baseWorkspaceGeneration: checkpoint.workspaceGeneration,
+      proofHash,
+      reservationIds: [],
+      deletedPaths: [],
+      requestDigest,
+    })
+    store.add(finalizationJournalKey(), {
+      size: Buffer.byteLength(journal),
+      eTag: '"pending-journal"',
+      body: journal,
+      scope: "Scope=checkpoint",
+    })
+    const now = jest
+      .spyOn(Date, "now")
+      .mockReturnValue((expiresAt + 10) * 1_000)
+    try {
+      await expect(
+        finalizeWorkspaceCheckpoint(
+          "owner@example.com",
+          PREFIX,
+          checkpoint.workspaceGeneration,
+          [],
+          [],
+          checkpoint.proof,
+          "invocation-later",
+          expiresAt + 300,
+        ),
+      ).rejects.toThrow("finalization proof is invalid")
+      expect(
+        JSON.parse(
+          store.current(finalizationJournalKey())?.body ?? "{}",
+        ),
+      ).toMatchObject({ state: "pending", requestDigest })
+    } finally {
+      now.mockRestore()
+    }
   })
 
   it("fails closed on a corrupt committed manifest before mutating workspace targets", async () => {


### PR DESCRIPTION
## Summary
- replace per-file workspace generation scans with one proof-bound atomic finalize batch after the authoritative ensure scan
- persist one replayable finalization journal per workspace for lost-response and new-invocation recovery
- retain safe rolling fallback to legacy broker operations and close mixed-version retry races
- authorize the private finalize operation through the root sync proxy
- expire noncurrent checkpoint control versions after 30 days

## Validation
- full lint passed
- full TypeScript typecheck passed
- 167 Python persistence tests passed
- 85 targeted Jest tests passed, including 20 direct checkpoint crash/replay tests and 26 route contract tests
- Python compile, shell syntax, and git diff checks passed

E2E intentionally skipped for this backend persistence fix, per deployment request.