### PR TITLE
feat(db): add Atrium artifact data records

### DIFF
--- a/infra/database/migrations.json
+++ b/infra/database/migrations.json
@@ -161,6 +161,7 @@
     "168-repository-item-cancelled-status.sql",
     "169-agentic-model-readiness.sql",
     "170-nexus-durable-repository-bindings.sql",
-    "171-workspace-upload-zero-byte-files.sql"
+    "171-workspace-upload-zero-byte-files.sql",
+    "172-content-data-records.sql"
   ]
 }

--- a/infra/database/schema/172-content-data-records.sql
+++ b/infra/database/schema/172-content-data-records.sql
@@ -1,0 +1,33 @@
+-- ============================================================================
+-- 172: Atrium artifact data records (#1516, Epic #1515)
+-- ============================================================================
+--
+-- This is an append-only store. It intentionally has no updated_at column or
+-- update trigger, and it has no retention/TTL column. Records are retained
+-- until their parent content object is deleted.
+--
+-- The action layer also validates namespace and payload size. The namespace
+-- CHECK remains the database-level backstop for writes outside that layer.
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS content_data_records (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  content_id UUID NOT NULL
+    REFERENCES content_objects(id) ON DELETE CASCADE,
+  namespace VARCHAR(64) NOT NULL,
+  user_id INTEGER NOT NULL
+    REFERENCES users(id),
+  payload JSONB NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  CONSTRAINT chk_content_data_records_namespace
+    CHECK (namespace ~ '^[a-z0-9_-]{1,64}$')
+);
+
+CREATE INDEX IF NOT EXISTS idx_content_data_records_lookup
+  ON content_data_records (content_id, namespace, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_content_data_records_user
+  ON content_data_records (content_id, namespace, user_id);
+
+-- ROLLBACK SQL (for manual rollback if needed)
+-- DROP TABLE IF EXISTS content_data_records;

--- a/infra/database/schema/172-content-data-records.sql
+++ b/infra/database/schema/172-content-data-records.sql
@@ -28,7 +28,7 @@ CREATE INDEX IF NOT EXISTS idx_content_data_records_lookup
   ON content_data_records (content_id, namespace, created_at DESC);
 
 CREATE INDEX IF NOT EXISTS idx_content_data_records_user
-  ON content_data_records (content_id, namespace, user_id);
+  ON content_data_records (user_id, content_id, namespace);
 
 -- ROLLBACK SQL (for manual rollback if needed)
 -- DROP TABLE IF EXISTS content_data_records;

--- a/infra/database/schema/172-content-data-records.sql
+++ b/infra/database/schema/172-content-data-records.sql
@@ -4,7 +4,8 @@
 --
 -- This is an append-only store. It intentionally has no updated_at column or
 -- update trigger, and it has no retention/TTL column. Records are retained
--- until their parent content object is deleted.
+-- until their parent content object is deleted. User attribution is cleared,
+-- rather than blocking deletion or removing the record, if a user is deleted.
 --
 -- The action layer also validates namespace and payload size. The namespace
 -- CHECK remains the database-level backstop for writes outside that layer.
@@ -15,8 +16,8 @@ CREATE TABLE IF NOT EXISTS content_data_records (
   content_id UUID NOT NULL
     REFERENCES content_objects(id) ON DELETE CASCADE,
   namespace VARCHAR(64) NOT NULL,
-  user_id INTEGER NOT NULL
-    REFERENCES users(id),
+  user_id INTEGER
+    REFERENCES users(id) ON DELETE SET NULL,
   payload JSONB NOT NULL,
   created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
   CONSTRAINT chk_content_data_records_namespace

--- a/lib/db/schema/index.ts
+++ b/lib/db/schema/index.ts
@@ -214,6 +214,7 @@ export * from "./tables/content-index-links";
 export * from "./tables/content-audit-logs";
 export * from "./tables/content-idempotency-records";
 export * from "./tables/content-assets";
+export * from "./tables/content-data-records";
 // Epic #1059 completion: §26.4 public-publish approval queue
 export * from "./tables/content-publish-requests";
 // Phase 1 (#1051): live collaborative document state (Yjs CRDT)

--- a/lib/db/schema/relations.ts
+++ b/lib/db/schema/relations.ts
@@ -97,6 +97,10 @@ import { apiKeyUsage } from "./tables/api-key-usage";
 // Agent Workspace Integration
 import { psdAgentWorkspaceTokens } from "./tables/agent-workspace-tokens";
 
+// Atrium Artifact Data
+import { contentObjects } from "./tables/content-objects";
+import { contentDataRecords } from "./tables/content-data-records";
+
 // ============================================
 // User Relations
 // ============================================
@@ -130,6 +134,7 @@ export const usersRelations = relations(users, ({ one, many }) => ({
   graphNodes: many(graphNodes),
   graphEdges: many(graphEdges),
   apiKeys: many(apiKeys),
+  contentDataRecords: many(contentDataRecords),
   // One-to-one with nexus_user_preferences (user_id is the primary key)
   preferences: one(nexusUserPreferences, {
     fields: [users.id],
@@ -141,6 +146,28 @@ export const usersRelations = relations(users, ({ one, many }) => ({
     references: [psdAgentWorkspaceTokens.ownerUserId],
   }),
 }));
+
+// ============================================
+// Atrium Artifact Data Relations (#1516)
+// ============================================
+
+export const contentObjectsRelations = relations(contentObjects, ({ many }) => ({
+  dataRecords: many(contentDataRecords),
+}));
+
+export const contentDataRecordsRelations = relations(
+  contentDataRecords,
+  ({ one }) => ({
+    content: one(contentObjects, {
+      fields: [contentDataRecords.contentId],
+      references: [contentObjects.id],
+    }),
+    user: one(users, {
+      fields: [contentDataRecords.userId],
+      references: [users.id],
+    }),
+  })
+);
 
 export const rolesRelations = relations(roles, ({ many }) => ({
   userRoles: many(userRoles),

--- a/lib/db/schema/tables/content-data-records.ts
+++ b/lib/db/schema/tables/content-data-records.ts
@@ -2,8 +2,9 @@
  * Append-only records submitted by authenticated Atrium artifacts (#1516).
  *
  * Records are scoped to a content object and attributed to the session user
- * that submitted them. They intentionally have no `updated_at` or retention
- * column: artifact data is immutable and retained until its content is deleted.
+ * that submitted them. If that user is later hard-deleted, attribution is set
+ * to null while the record remains. They intentionally have no `updated_at` or
+ * retention column: artifact data is immutable until its content is deleted.
  */
 
 import { sql } from "drizzle-orm";
@@ -29,9 +30,9 @@ export const contentDataRecords = pgTable(
       .references(() => contentObjects.id, { onDelete: "cascade" })
       .notNull(),
     namespace: varchar("namespace", { length: 64 }).notNull(),
-    userId: integer("user_id")
-      .references(() => users.id)
-      .notNull(),
+    userId: integer("user_id").references(() => users.id, {
+      onDelete: "set null",
+    }),
     payload: jsonb("payload").$type<ArtifactDataPayload>().notNull(),
     createdAt: timestamp("created_at", { withTimezone: true })
       .defaultNow()

--- a/lib/db/schema/tables/content-data-records.ts
+++ b/lib/db/schema/tables/content-data-records.ts
@@ -1,0 +1,59 @@
+/**
+ * Append-only records submitted by authenticated Atrium artifacts (#1516).
+ *
+ * Records are scoped to a content object and attributed to the session user
+ * that submitted them. They intentionally have no `updated_at` or retention
+ * column: artifact data is immutable and retained until its content is deleted.
+ */
+
+import { sql } from "drizzle-orm";
+import {
+  check,
+  index,
+  integer,
+  jsonb,
+  pgTable,
+  timestamp,
+  uuid,
+  varchar,
+} from "drizzle-orm/pg-core";
+import type { ArtifactDataPayload } from "@/lib/db/types/jsonb";
+import { contentObjects } from "./content-objects";
+import { users } from "./users";
+
+export const contentDataRecords = pgTable(
+  "content_data_records",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    contentId: uuid("content_id")
+      .references(() => contentObjects.id, { onDelete: "cascade" })
+      .notNull(),
+    namespace: varchar("namespace", { length: 64 }).notNull(),
+    userId: integer("user_id")
+      .references(() => users.id)
+      .notNull(),
+    payload: jsonb("payload").$type<ArtifactDataPayload>().notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+  },
+  (t) => [
+    index("idx_content_data_records_lookup").on(
+      t.contentId,
+      t.namespace,
+      t.createdAt.desc(),
+    ),
+    index("idx_content_data_records_user").on(
+      t.contentId,
+      t.namespace,
+      t.userId,
+    ),
+    check(
+      "chk_content_data_records_namespace",
+      sql`${t.namespace} ~ '^[a-z0-9_-]{1,64}$'`,
+    ),
+  ],
+);
+
+export type ContentDataRecordRow = typeof contentDataRecords.$inferSelect;
+export type NewContentDataRecordRow = typeof contentDataRecords.$inferInsert;

--- a/lib/db/schema/tables/content-data-records.ts
+++ b/lib/db/schema/tables/content-data-records.ts
@@ -45,9 +45,9 @@ export const contentDataRecords = pgTable(
       t.createdAt.desc(),
     ),
     index("idx_content_data_records_user").on(
+      t.userId,
       t.contentId,
       t.namespace,
-      t.userId,
     ),
     check(
       "chk_content_data_records_namespace",

--- a/lib/db/types/jsonb/index.ts
+++ b/lib/db/types/jsonb/index.ts
@@ -255,6 +255,16 @@ export interface UserProfile {
 }
 
 // ============================================
+// Atrium Artifact Data JSONB Types
+// ============================================
+
+/**
+ * Artifact-defined record data persisted by the Atrium Artifact Data Service.
+ * The action layer bounds serialized size and rejects reserved identity keys.
+ */
+export type ArtifactDataPayload = Record<string, unknown>;
+
+// ============================================
 // Prompt Library JSONB Types
 // ============================================
 

--- a/tests/unit/content-data-records-migration.test.ts
+++ b/tests/unit/content-data-records-migration.test.ts
@@ -58,7 +58,7 @@ describe("migration 172 content data records", () => {
       /CREATE INDEX IF NOT EXISTS idx_content_data_records_lookup ON content_data_records \(content_id, namespace, created_at DESC\)/i,
     );
     expect(normalizedSql).toMatch(
-      /CREATE INDEX IF NOT EXISTS idx_content_data_records_user ON content_data_records \(content_id, namespace, user_id\)/i,
+      /CREATE INDEX IF NOT EXISTS idx_content_data_records_user ON content_data_records \(user_id, content_id, namespace\)/i,
     );
   });
 

--- a/tests/unit/content-data-records-migration.test.ts
+++ b/tests/unit/content-data-records-migration.test.ts
@@ -1,0 +1,75 @@
+/** @jest-environment node */
+
+import fs from "node:fs";
+import path from "node:path";
+
+const migrationName = "172-content-data-records.sql";
+const migration = fs.readFileSync(
+  path.join(process.cwd(), "infra/database/schema", migrationName),
+  "utf8",
+);
+const executableSql = migration.replace(/--[^\n]*/g, "");
+const normalizedSql = executableSql.replace(/\s+/g, " ");
+const manifest = JSON.parse(
+  fs.readFileSync(
+    path.join(process.cwd(), "infra/database/migrations.json"),
+    "utf8",
+  ),
+) as { migrationFiles: string[] };
+
+describe("migration 172 content data records", () => {
+  it("runs immediately after the previous migration head", () => {
+    const previousIndex = manifest.migrationFiles.indexOf(
+      "171-workspace-upload-zero-byte-files.sql",
+    );
+
+    expect(previousIndex).toBeGreaterThanOrEqual(0);
+    expect(manifest.migrationFiles[previousIndex + 1]).toBe(migrationName);
+  });
+
+  it("creates the append-only artifact record shape", () => {
+    expect(normalizedSql).toMatch(
+      /CREATE TABLE IF NOT EXISTS content_data_records \( id UUID PRIMARY KEY DEFAULT gen_random_uuid\(\)/i,
+    );
+    expect(normalizedSql).toMatch(
+      /content_id UUID NOT NULL REFERENCES content_objects\(id\) ON DELETE CASCADE/i,
+    );
+    expect(normalizedSql).toMatch(
+      /user_id INTEGER NOT NULL REFERENCES users\(id\)/i,
+    );
+    expect(normalizedSql).toMatch(/payload JSONB NOT NULL/i);
+    expect(normalizedSql).toMatch(
+      /created_at TIMESTAMPTZ NOT NULL DEFAULT NOW\(\)/i,
+    );
+    expect(normalizedSql).not.toMatch(/\bupdated_at\b/i);
+    expect(normalizedSql).not.toMatch(/\b(retention|expires_at|ttl)\b/i);
+  });
+
+  it("enforces the namespace contract in the database", () => {
+    expect(normalizedSql).toMatch(/namespace VARCHAR\(64\) NOT NULL/i);
+    expect(normalizedSql).toMatch(
+      /CHECK \(namespace ~ '\^\[a-z0-9_-\]\{1,64\}\$'\)/i,
+    );
+  });
+
+  it("indexes latest namespace reads and per-user reads", () => {
+    expect(normalizedSql).toMatch(
+      /CREATE INDEX IF NOT EXISTS idx_content_data_records_lookup ON content_data_records \(content_id, namespace, created_at DESC\)/i,
+    );
+    expect(normalizedSql).toMatch(
+      /CREATE INDEX IF NOT EXISTS idx_content_data_records_user ON content_data_records \(content_id, namespace, user_id\)/i,
+    );
+  });
+
+  it("is compatible with the database initialization statement splitter", () => {
+    expect(executableSql).not.toMatch(/\bDO\s+\$\$/i);
+    expect(executableSql).not.toMatch(/\bCONCURRENTLY\b/i);
+    expect(executableSql).not.toMatch(/\b(BEGIN|COMMIT|ROLLBACK)\s*;/i);
+  });
+
+  it("documents a manual rollback", () => {
+    expect(migration).toContain(
+      "-- DROP TABLE IF EXISTS content_data_records;",
+    );
+  });
+});

--- a/tests/unit/content-data-records-migration.test.ts
+++ b/tests/unit/content-data-records-migration.test.ts
@@ -35,8 +35,9 @@ describe("migration 172 content data records", () => {
       /content_id UUID NOT NULL REFERENCES content_objects\(id\) ON DELETE CASCADE/i,
     );
     expect(normalizedSql).toMatch(
-      /user_id INTEGER NOT NULL REFERENCES users\(id\)/i,
+      /user_id INTEGER REFERENCES users\(id\) ON DELETE SET NULL/i,
     );
+    expect(normalizedSql).not.toMatch(/user_id INTEGER NOT NULL/i);
     expect(normalizedSql).toMatch(/payload JSONB NOT NULL/i);
     expect(normalizedSql).toMatch(
       /created_at TIMESTAMPTZ NOT NULL DEFAULT NOW\(\)/i,


### PR DESCRIPTION
## Description

Adds the storage foundation for the Atrium Artifact Data Service.

- Defines the append-only `content_data_records` Drizzle table with typed JSONB payloads.
- Wires content and user relations.
- Adds migration 172 with content-delete cascade, database namespace validation, latest-record ordering, and per-user lookup indexes.
- Registers the migration and adds contract coverage for schema shape, manifest order, splitter compatibility, and rollback documentation.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Infrastructure change (database migration)

## Acceptance and Risks

- Migration: `172-content-data-records.sql` is additive and requires normal database migration deployment.
- Backfill: none.
- Retention: none by design; records are append-only and remain until their parent content object is deleted.
- Delete behavior: deleting content cascades its artifact data records; hard-deleting a submitter sets `user_id` to null so retained records do not block account deletion.
- Follow-up submit/list actions and bridge behavior remain scoped to later epic issues.

## Validation

- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run test:ci -- --runInBand` — 554 suites and 5,147 tests passed; 1 suite and 15 tests skipped by policy
- [x] `bun run test -- tests/unit/content-data-records-migration.test.ts tests/unit/db-migration-manifest.test.ts --runInBand` — 9 tests passed
- [x] `bun run build` — production build succeeded
- [x] `bun run migration:list` — migration 172 registered as the manifest head
- [x] Fresh issue-specific PostgreSQL 16 + pgvector initialization ran all 154 migrations through 172 successfully
- [x] Live schema inspection confirmed six expected columns, both foreign keys, the namespace check, and all three indexes
- [x] Invalid namespace insert was rejected by `chk_content_data_records_namespace`
- [x] User deletion retained the record with null attribution; parent content deletion then cascaded it

E2E was not applicable to this schema-only slice; no user-facing or API behavior changed.

## Related Issues

Closes #1516
Part of #1515
