### PR TITLE
fix(meridian): scope the remaining cream portals; fix two Atrium races found doing it

### DIFF
--- a/app/(protected)/admin/assistants/_components/assistants-table.tsx
+++ b/app/(protected)/admin/assistants/_components/assistants-table.tsx
@@ -181,7 +181,7 @@ function AssistantActions({
             <MoreHorizontal className="h-4 w-4" />
           </Button>
         </DropdownMenuTrigger>
-        <DropdownMenuContent align="end">
+        <DropdownMenuContent align="end" className={meridianPortalClassName}>
           <DropdownMenuLabel>Actions</DropdownMenuLabel>
           <DropdownMenuSeparator />
           <DropdownMenuItem onClick={() => onEdit(assistant.id)}>

--- a/app/(protected)/admin/repositories/_components/repositories-admin-client.tsx
+++ b/app/(protected)/admin/repositories/_components/repositories-admin-client.tsx
@@ -178,7 +178,7 @@ function RepositoryActions({
           <MoreHorizontal className="h-4 w-4" />
         </Button>
       </DropdownMenuTrigger>
-      <DropdownMenuContent align="end">
+      <DropdownMenuContent align="end" className={meridianPortalClassName}>
         <DropdownMenuLabel>Actions</DropdownMenuLabel>
         <DropdownMenuItem
           disabled={!isActive}

--- a/app/(protected)/admin/settings/_components/settings-table.tsx
+++ b/app/(protected)/admin/settings/_components/settings-table.tsx
@@ -155,7 +155,7 @@ function SettingRow({
               <MoreHorizontal className="h-4 w-4" />
             </Button>
           </DropdownMenuTrigger>
-          <DropdownMenuContent align="end">
+          <DropdownMenuContent align="end" className={meridianPortalClassName}>
             <DropdownMenuItem onClick={onEdit}>
               <Edit className="mr-2 h-4 w-4" />
               Edit

--- a/app/(protected)/admin/users/_components/user-detail-sheet.tsx
+++ b/app/(protected)/admin/users/_components/user-detail-sheet.tsx
@@ -487,7 +487,17 @@ export function UserDetailSheet({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className={cn("w-[90vw] h-[90vh] max-w-[90vw] flex flex-col p-0", className)}>
+      {/* meridianPortalClassName is applied HERE, not left to the caller: Radix
+          portals this to document.body, and the one call site passes no
+          className — so without it this dialog rendered the pre-Meridian cream
+          sheet in the system font. The prop still composes on top. */}
+      <DialogContent
+        className={cn(
+          "w-[90vw] h-[90vh] max-w-[90vw] flex flex-col p-0",
+          meridianPortalClassName,
+          className
+        )}
+      >
         <UserDetailHeader
           isEditing={isEditing}
           isSaving={isSaving}

--- a/app/(protected)/nexus/page.tsx
+++ b/app/(protected)/nexus/page.tsx
@@ -39,7 +39,6 @@ import { RepositoryPicker } from '@/components/features/repositories/repository-
 import { Button } from '@/components/ui/button'
 import { Database } from 'lucide-react'
 import { getNexusAccessibleRepositoriesAction } from '@/actions/repositories/repository.actions'
-import { meridianPortalClassName } from '@/lib/meridian/fonts'
 
 const log = createLogger({ moduleName: 'nexus-page' })
 const uuidSchema = z.string().uuid()
@@ -520,7 +519,6 @@ function NexusRepositorySelector({
         // Radix portals this dialog to document.body, outside the page's
         // `.meridian` scope — without this it renders in the global cream
         // palette and the system font.
-        contentClassName={meridianPortalClassName}
       />
     </>
   )

--- a/components/assistant-ui/attachment.tsx
+++ b/components/assistant-ui/attachment.tsx
@@ -33,6 +33,7 @@ import { TooltipIconButton } from "@/components/assistant-ui/tooltip-icon-button
 import { DialogContent as DialogPrimitiveContent } from "@radix-ui/react-dialog";
 import { temporaryAttachmentReferencesFromValue } from "@/lib/repositories/temporary-attachment-contract";
 import { RepositoryPromotionButton } from "@/components/assistant-ui/repository-attachment-message";
+import { meridianPortalClassName } from "@/lib/meridian/fonts";
 
 const log = createLogger({ module: 'attachment' });
 
@@ -307,7 +308,7 @@ export const ComposerAddAttachment: FC = () => {
 const AttachmentDialogContent: FC<PropsWithChildren> = ({ children }) => (
   <DialogPortal>
     <DialogOverlay />
-    <DialogPrimitiveContent className="data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] fixed left-[50%] top-[50%] z-50 grid translate-x-[-50%] translate-y-[-50%] shadow-lg duration-200">
+    <DialogPrimitiveContent className={`${meridianPortalClassName} data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] fixed left-[50%] top-[50%] z-50 grid translate-x-[-50%] translate-y-[-50%] shadow-lg duration-200`}>
       {children}
     </DialogPrimitiveContent>
   </DialogPortal>

--- a/components/atrium/CollectionManagementPanel.tsx
+++ b/components/atrium/CollectionManagementPanel.tsx
@@ -5,7 +5,7 @@
  * administrator's district hierarchy panel (#1438).
  */
 
-import { useEffect, useMemo, useState, useTransition } from "react";
+import { useEffect, useMemo, useRef, useState, useTransition } from "react";
 import { Archive, FolderPlus, RotateCcw, Save } from "lucide-react";
 import {
   createCollectionAction,
@@ -534,7 +534,29 @@ export function CollectionManagementPanel({
       row.scope === (mode === "private" ? "private" : "district")
   );
 
+  /**
+   * Bumped by every USER-initiated editor change ("New", picking a row).
+   * `refresh(selectId)` awaits a server action and then selects the saved row,
+   * so a click that lands during that await was silently overwritten when the
+   * transition resolved: pressing "New" straight after a save put the blank
+   * form up, then the late setEditor restored the collection just saved.
+   *
+   * That is what made nesting impossible — `parentOptions` filters out
+   * `editor.id`, so with the editor forced back onto the new collection it
+   * could never be chosen as a parent. Measured directly: after clicking "New"
+   * the Name field still held the saved collection's name at +50ms through
+   * +5000ms, and the collection never appeared as a Parent option.
+   */
+  const editorGenerationRef = useRef(0);
+
+  /** Use for every user-initiated editor change so a late refresh cannot win. */
+  function setEditorFromUser(next: EditorState): void {
+    editorGenerationRef.current += 1;
+    setEditor(next);
+  }
+
   function refresh(selectId?: string): void {
+    const generationAtStart = editorGenerationRef.current;
     startTransition(async () => {
       const result = await listManageableCollectionsAction(mode);
       if (!result.isSuccess) {
@@ -543,7 +565,8 @@ export function CollectionManagementPanel({
       }
       const next = result.data ?? [];
       setCollections(next);
-      if (selectId) {
+      // Only adopt the saved row if the user has not moved on in the meantime.
+      if (selectId && editorGenerationRef.current === generationAtStart) {
         const row = next.find((item) => item.id === selectId);
         if (row) setEditor(editorFor(row));
       }
@@ -628,14 +651,14 @@ export function CollectionManagementPanel({
         mode={mode}
         rows={rows}
         onNew={() =>
-          setEditor({
+          setEditorFromUser({
             ...EMPTY_EDITOR,
             defaultVisibilityLevel:
               mode === "private" ? "private" : "internal",
             inheritGrants: mode !== "private",
           })
         }
-        onSelect={(row) => setEditor(editorFor(row))}
+        onSelect={(row) => setEditorFromUser(editorFor(row))}
       />
       <CollectionEditor
         mode={mode}

--- a/components/atrium/CollectionManagementPanel.tsx
+++ b/components/atrium/CollectionManagementPanel.tsx
@@ -549,14 +549,26 @@ export function CollectionManagementPanel({
    */
   const editorGenerationRef = useRef(0);
 
-  /** Use for every user-initiated editor change so a late refresh cannot win. */
+  /**
+   * The ONLY way user intent should reach `editor`. Covers "New", selecting a
+   * row, and every in-place field edit — a partial guard leaves exactly the
+   * same race open for whichever path it misses.
+   */
   function setEditorFromUser(next: EditorState): void {
     editorGenerationRef.current += 1;
     setEditor(next);
   }
 
-  function refresh(selectId?: string): void {
-    const generationAtStart = editorGenerationRef.current;
+  /**
+   * @param expectedGeneration Editor generation this refresh is allowed to
+   *   overwrite. Callers that await BEFORE calling refresh must capture it
+   *   before their own await — otherwise an edit made during that await is
+   *   already folded into the counter by the time refresh snapshots it, and
+   *   the guard silently passes. Defaults to "whatever it is now" for the
+   *   plain reload case.
+   */
+  function refresh(selectId?: string, expectedGeneration?: number): void {
+    const generationAtStart = expectedGeneration ?? editorGenerationRef.current;
     startTransition(async () => {
       const result = await listManageableCollectionsAction(mode);
       if (!result.isSuccess) {
@@ -588,6 +600,10 @@ export function CollectionManagementPanel({
   function save(): void {
     setError(null);
     setNotice(null);
+    // Captured BEFORE the server round-trip: anything the user types into the
+    // still-open form while the save is in flight must survive the refresh that
+    // follows it.
+    const generationAtSave = editorGenerationRef.current;
     startTransition(async () => {
       const position = editor.position.trim()
         ? Number(editor.position)
@@ -624,7 +640,7 @@ export function CollectionManagementPanel({
       }
       setNotice(editor.id ? "Collection updated" : "Collection created");
       announceTreeChange();
-      refresh(result.data.id);
+      refresh(result.data.id, generationAtSave);
     });
   }
 
@@ -670,7 +686,11 @@ export function CollectionManagementPanel({
         error={error}
         notice={notice}
         isPending={isPending}
-        onChange={setEditor}
+        // Field edits count as user intent too: typing in the still-open form
+        // while a save's refresh is in flight must not be overwritten when that
+        // refresh resolves. Routing every mutation through the guarded setter is
+        // what makes the generation counter actually complete.
+        onChange={setEditorFromUser}
         onSave={save}
         onToggleArchived={toggleArchived}
       />

--- a/components/features/repositories/repository-picker.tsx
+++ b/components/features/repositories/repository-picker.tsx
@@ -28,6 +28,7 @@ import {
   Lock,
   Search,
 } from "lucide-react"
+import { meridianPortalClassName } from "@/lib/meridian/fonts"
 
 export interface RepositoryPickerProps {
   open: boolean
@@ -43,11 +44,21 @@ export interface RepositoryPickerProps {
   loadRepositories?: typeof getUserAccessibleRepositoriesAction
   maxSelections?: number
   /**
-   * Extra classes for the portaled DialogContent. Radix portals to
-   * document.body, so a design-system scope on the page does NOT reach this
-   * dialog — the caller passes its own scope class (e.g.
-   * `meridianPortalClassName`). Kept caller-supplied because this picker
-   * renders on both Meridian and non-Meridian surfaces.
+   * Extra classes for the portaled DialogContent.
+   *
+   * Radix portals to document.body, so the Meridian scope on the page does NOT
+   * reach this dialog — it needs the class on the content itself. That now
+   * DEFAULTS to `meridianPortalClassName` rather than being caller-supplied.
+   *
+   * It was originally opt-in because this picker also rendered on surfaces that
+   * had not adopted Meridian. That stopped being true once the scope moved to
+   * app/(protected)/layout.tsx: every surface reaching this component is
+   * Meridian, and the two call sites that were deliberately left opted-out
+   * (assistant-architect's repository browser and the repository source picker)
+   * silently kept rendering the old cream dialog.
+   *
+   * Pass a value only to ADD classes or to render somewhere genuinely outside
+   * the design system.
    */
   contentClassName?: string
 }
@@ -296,7 +307,7 @@ export function RepositoryPicker({
   description = "Select an accessible durable knowledge repository.",
   loadRepositories = getUserAccessibleRepositoriesAction,
   maxSelections,
-  contentClassName,
+  contentClassName = meridianPortalClassName,
 }: RepositoryPickerProps) {
   const { toast } = useToast()
   const [repositories, setRepositories] =

--- a/scripts/db/cleanup-e2e-content.ts
+++ b/scripts/db/cleanup-e2e-content.ts
@@ -148,6 +148,26 @@ async function pruneCollections(
         "this would delete. Widen the pattern or clean those first."
     );
   }
+
+  // content_objects.collection_id is ON DELETE NO ACTION, so ANY surviving
+  // content still filed under one of these collections rejects the delete and
+  // rolls back the whole transaction — including the content and graph prunes
+  // that already succeeded. The E2E content delete runs earlier in this same
+  // transaction, so this only bites when a NON-E2E object was filed into an
+  // E2E collection by hand; refuse with a usable message rather than surfacing
+  // a raw FK violation.
+  const contentRefs = await tx<{ n: number }[]>`
+    SELECT count(*)::int AS n
+      FROM content_objects o
+     WHERE o.collection_id IN ${tx(ids)}
+  `;
+  if ((contentRefs[0]?.n ?? 0) > 0) {
+    throw new Error(
+      `Refusing: ${contentRefs[0].n} content object(s) are still filed under ` +
+        "collections this would delete (content_objects.collection_id is NO " +
+        "ACTION). Move or delete that content first."
+    );
+  }
   const deleted = await tx<{ id: string }[]>`
     DELETE FROM content_collections
      WHERE id IN ${tx(ids)}

--- a/scripts/db/cleanup-e2e-content.ts
+++ b/scripts/db/cleanup-e2e-content.ts
@@ -68,6 +68,20 @@ const FIXTURE_ID_PREFIX = "a7100000-%";
  */
 const GRAPH_E2E_NAME_REGEX = "(E2E-[A-Z]+-|E2EGRAPH)[0-9]{12,}";
 
+/**
+ * Collections the Atrium collection-management specs create. They are NOT
+ * children of content_objects, so the content delete above never reached them
+ * and they accumulated every run — on 2026-08-01 the local DB held 47 of them
+ * and atrium-collection-management.functional timed out at its 180s budget
+ * until they were pruned by hand (twice).
+ *
+ * Anchored to the exact shapes those specs generate ("E2E Private <token>",
+ * "E2E Child <token>", "E2E Admin Private <token>", "E2E District <token>") so
+ * a real collection that merely starts with "E2E" is never matched.
+ */
+const COLLECTION_E2E_NAME_REGEX =
+  "^E2E (Private|Child|Admin Private|District) [A-Za-z0-9]+$";
+
 interface CandidateRow {
   id: string;
   title: string;
@@ -105,6 +119,41 @@ function parseArgs(argv: string[]): { yes: boolean; minAgeMinutes: number } {
     }
   }
   return { yes, minAgeMinutes };
+}
+
+/**
+ * Prune the Atrium collection fixtures. Split out of main() only to keep that
+ * function inside the max-lines budget.
+ */
+async function pruneCollections(
+  // Same cast rationale as the transaction body in main(): postgres.js types
+  // TransactionSql as non-callable, so callers hand us the re-cast handle.
+  tx: ReturnType<typeof postgres>,
+  collectionCandidates: { id: string }[]
+): Promise<void> {
+  if (collectionCandidates.length === 0) return;
+  const ids = collectionCandidates.map((c) => c.id);
+  // A flat delete is safe: parents and their children both match the anchored
+  // E2E name shapes, so the whole subtree goes in one statement. Guard first
+  // that nothing OUTSIDE the matched set is parented to a row being removed.
+  const orphanRisk = await tx<{ n: number }[]>`
+    SELECT count(*)::int AS n
+      FROM content_collections c
+     WHERE c.parent_id IN ${tx(ids)}
+       AND c.id NOT IN ${tx(ids)}
+  `;
+  if ((orphanRisk[0]?.n ?? 0) > 0) {
+    throw new Error(
+      `Refusing: ${orphanRisk[0].n} surviving collection(s) are children of rows ` +
+        "this would delete. Widen the pattern or clean those first."
+    );
+  }
+  const deleted = await tx<{ id: string }[]>`
+    DELETE FROM content_collections
+     WHERE id IN ${tx(ids)}
+     RETURNING id
+  `;
+  log.success(`Deleted ${deleted.length} content_collections rows.`);
 }
 
 async function main(): Promise<void> {
@@ -161,7 +210,18 @@ async function main(): Promise<void> {
          AND created_at < now() - make_interval(mins => ${minAgeMinutes})
     `;
 
-    if (candidates.length === 0 && graphCandidates.length === 0) {
+    const collectionCandidates = await sql<{ id: string }[]>`
+      SELECT id
+        FROM content_collections
+       WHERE name ~ ${COLLECTION_E2E_NAME_REGEX}
+         AND created_at < now() - make_interval(mins => ${minAgeMinutes})
+    `;
+
+    if (
+      candidates.length === 0 &&
+      graphCandidates.length === 0 &&
+      collectionCandidates.length === 0
+    ) {
       log.success("Nothing to clean up — no E2E-pattern rows older than the age guard.");
       return;
     }
@@ -184,6 +244,9 @@ async function main(): Promise<void> {
 
     log.info(
       `Matched ${graphCandidates.length} graph_nodes rows (E2E-tagged decision/graph fixtures)`
+    );
+    log.info(
+      `Matched ${collectionCandidates.length} content_collections rows (E2E-named private/district collections)`
     );
 
     if (!yes) {
@@ -264,6 +327,8 @@ async function main(): Promise<void> {
           `Deleted ${deletedGraph.length} graph_nodes rows (edges removed via ON DELETE CASCADE).`
         );
       }
+
+      await pruneCollections(tx, collectionCandidates);
     });
   } finally {
     await sql.end();

--- a/tests/e2e/atrium-library-polish.functional.spec.ts
+++ b/tests/e2e/atrium-library-polish.functional.spec.ts
@@ -72,6 +72,29 @@ function searchBox(page: import('@playwright/test').Page) {
   return page.getByRole('textbox', { name: 'Search content by title or tag' })
 }
 
+/**
+ * Wait until the grid has COMMITTED a fetch for `query`.
+ *
+ * The search is debounced and fetched server-side, so right after filling the
+ * box the grid still shows the previous result set. A read-only assertion does
+ * not care — the card it is waiting for is on screen either way. But anything
+ * that MUTATES per-row UI state does: checkbox selection is lost when the
+ * debounced response commits and re-renders the list, so a bulk selection made
+ * too early silently evaporates and `bulk-count` never appears.
+ *
+ * `data-results-query` exists for exactly this (see the settled-state note in
+ * useLibraryPage) — it is set in the same state batch as the items, so it can
+ * never describe a grid that is not on screen.
+ */
+async function awaitResultsFor(
+  page: import('@playwright/test').Page,
+  query: string
+) {
+  await expect(
+    page.locator(`section[data-results-query="${query}"]`)
+  ).toBeVisible({ timeout: 15000 })
+}
+
 function defineAtriumLibraryPolishSearchTagsBulkAuthenticatedSuite1Part1() {
   test.skip(
     process.env.PLAYWRIGHT_AUTH_ENABLED !== 'true',
@@ -210,6 +233,9 @@ function defineAtriumLibraryPolishSearchTagsBulkAuthenticatedSuite1Part2() {test
 
       await page.goto('/atrium')
       await searchBox(page).fill(tag)
+      // Selection is per-row React state: it must not be made against a grid
+      // that the debounced search is about to replace.
+      await awaitResultsFor(page, tag)
       await expect(page.getByTestId(`select-${ids[0]}`)).toBeVisible({
         timeout: 15000,
       })


### PR DESCRIPTION
## Summary

Follow-up to #1509. Fixes the surfaces still rendering the pre-Meridian cream design, plus two bugs found while chasing them.

## Portals still rendering the old design

The sweep in #1509 missed places, and correcting it found more. It had two blind spots, each hiding real bugs:

1. **It listed files rendering portal *primitives*.** A component rendering a shared wrapper instead — `repository-browser` renders `<RepositoryPicker>` — was never a candidate, because the portal is one component deeper. That is how the reported picker survived.
2. **It matched per *file*, not per *element*.** A file containing `meridianPortalClassName` anywhere counted as scoped, so a file with a correctly-scoped Dialog and an unscoped DropdownMenu passed clean.

The check now walks every portal primitive individually and treats a prop-fed `className` as guaranteed **only** when the component defaults that prop. 165 primitives scanned; zero unguaranteed.

Fixed:

- **`RepositoryPicker`** — reported: browsing/adding repositories from assistant-architect. It took the scope as an optional prop that `repository-browser` never passed. Now defaults it; callers can still add classes.
- **`/admin/users` user-detail dialog** — same failure mode, and its single call site passes no `className`. Reproduced before fixing: `lab(91.5…)` cream, `fontSans`, 8px radius → now `#ffffff`, fontMeridian, 16px.
- **Row action menus** on `/admin/repositories`, `/admin/assistants`, `/admin/settings` — `<DropdownMenuContent align="end">` with no className. Each of those files scopes its Dialog correctly, which is exactly why a file-level check waved them through.
- The Nexus attachment-preview lightbox, for completeness.

Both prop-dependent cases now apply the constant at the element rather than delegating to callers. A portal that requires an opt-in it does not control will eventually render unscoped.

## Atrium: could not nest under a just-created collection

Not a styling bug. Saving a collection and pressing "New" showed the blank form for a moment, then silently restored the collection just saved — and since `parentOptions` filters out `editor.id`, that collection could never be chosen as a parent. The only workaround was closing and reopening the dialog.

`refresh(selectId)` awaits a server action inside `startTransition`, then calls `setEditor` to select the saved row, overwriting anything the user did during the await. The save path sets the "Collection created" notice **before** calling refresh, so anyone reacting to that notice is inside the window every time.

Fixed with a generation counter bumped by user-initiated editor changes; `refresh` only adopts the saved row if it is unchanged, so a late refresh updates the list but leaves the editor alone.

Measured rather than inferred:

| | before | after |
|---|---|---|
| Name field after "New" | still the saved name at +50ms → +5000ms | empty at +50ms |
| New collection as a Parent option | never appeared (30s wait) | present at +50ms |

This is what had been failing `atrium-collection-management.functional` intermittently — it passed one full suite run and failed 3/3 in the next, always as a 180s timeout whose real cause was masked because the spec's `finally { context.close() }` reports the close failure instead of the assertion.

**The spec is deliberately unchanged.** Two earlier attempts to harden it (waiting on a render signal, then retrying the click) were built on a hydration diagnosis I could not substantiate and were reverted — neither removed the flake, because neither touched the cause. With the panel fixed, the untouched spec passes **4/4 at ~1.0m**, against 3.0m timeouts before.

## E2E cleanup script

`db:cleanup:e2e` covered `content_objects` and `graph_nodes` but not `content_collections`, which hang off neither — so Atrium collection fixtures accumulated every run and had to be pruned by hand (the local DB reached 47). Now included in the same dry-run/confirm flow, age guard and transaction, with an anchored pattern so a genuine "E2E…" collection is never matched, and an orphan guard that refuses rather than failing mid-transaction. Verified on a real backlog: 14 pruned, the 7 newest correctly spared by the age guard, all 7 genuine collections untouched.

## Atrium: bulk selection lost to the debounced search

A second, unrelated flake in `atrium-library-polish`. The library search is debounced and fetched server-side, so immediately after filling the box the grid still shows the previous result set. The bulk test selected rows against that stale grid; when the debounced response committed, the list re-rendered and the selection was discarded, so `bulk-count` never appeared.

The sibling tests in that file use the same pattern and pass — they only assert visibility, and a re-render does not disturb a card that is on screen either way. This test is different: checkbox selection is per-row React state that a re-render destroys.

`useLibraryPage` already publishes `data-results-query` for exactly this, set in the same state batch as the items, with a source comment noting that E2E search pinning should await it rather than race the debounce. The test now does. Only the mutating test changed; the read-only ones were left alone.

Unlike the collection-management flake, **this one was the spec's fault, not the app's** — worth separating, because the two presented identically.

## Note on diagnosing these

Both flakes were masked the same way: these specs wrap their body in `try { … } finally { await context.close() }`, so Playwright reports the context-close failure rather than the assertion that actually hung. Every failure surfaced as a bare 180s timeout pointing at the `finally`. Worth fixing across the suite — it cost a lot of time here.

## Testing

`tsc --noEmit` and `eslint --max-warnings 0` clean on every touched file. Portal fixes verified in-browser before and after. Authenticated Playwright suite via `bun run test:e2e:local`: **305 passed, 0 failed, 0 flaky, 40 skipped.**

Both fixed specs were also run in isolation to confirm the flakes are gone rather than merely re-rolled:
- `atrium-collection-management` — 4/4 at ~1.0m (was 3.0m timeouts), with the spec **unchanged**
- `atrium-library-polish` — 3/3 at ~1.4m (was 3.0m timeouts)
