### PR TITLE
feat(atrium): add artifact data record actions

### DIFF
--- a/actions/db/atrium/artifact-data.ts
+++ b/actions/db/atrium/artifact-data.ts
@@ -31,7 +31,8 @@ import { getUserRequester } from "./requester";
 const NAMESPACE_RE = /^[a-z0-9_-]{1,64}$/;
 const MAX_CONTENT_ID_LENGTH = 200;
 const MAX_PAYLOAD_BYTES = 8 * 1024;
-const MAX_PAYLOAD_VALUES = MAX_PAYLOAD_BYTES;
+// Independent work cap for structural validation; it is not a byte-budget alias.
+const MAX_PAYLOAD_VALUES = 8_192;
 const DEFAULT_LIST_LIMIT = 50;
 const MAX_LIST_LIMIT = 200;
 const SUBMIT_RATE_LIMIT = 120;
@@ -86,7 +87,6 @@ interface ArtifactRecordRow {
   createdAt: Date;
   userFirstName: string | null;
   userLastName: string | null;
-  userEmail: string | null;
 }
 
 function validateContentId(contentId: unknown): string {
@@ -279,7 +279,7 @@ function displayNameFor(row: ArtifactRecordRow): string {
     .filter((part): part is string => Boolean(part))
     .join(" ")
     .trim();
-  return fullName || row.userEmail?.split("@")[0] || "Unknown user";
+  return fullName || "Unknown user";
 }
 
 function toArtifactRecordDTO(row: ArtifactRecordRow): ArtifactRecordDTO {
@@ -456,7 +456,6 @@ export async function listArtifactRecords(
             createdAt: contentDataRecords.createdAt,
             userFirstName: users.firstName,
             userLastName: users.lastName,
-            userEmail: users.email,
           })
           .from(contentDataRecords)
           .leftJoin(users, eq(contentDataRecords.userId, users.id))

--- a/actions/db/atrium/artifact-data.ts
+++ b/actions/db/atrium/artifact-data.ts
@@ -216,10 +216,6 @@ export async function submitArtifactRecord(
       payloadBytes: payload.bytes,
     });
 
-    // Resolves the canonical object id and preserves the shared 404 mask for a
-    // missing or non-viewable target before any record-specific work occurs.
-    const content = await contentService.get(requester, contentId);
-
     const rateLimit = consumeRateLimit({
       interval: SUBMIT_RATE_WINDOW_MS,
       uniqueTokenPerInterval: SUBMIT_RATE_LIMIT,
@@ -233,6 +229,11 @@ export async function submitArtifactRecord(
         new Date(rateLimit.resetTime).toISOString()
       );
     }
+
+    // Resolves the canonical object id and preserves the shared 404 mask for a
+    // missing or non-viewable target. The per-user guard runs first so a caller
+    // over budget cannot keep generating database-backed visibility lookups.
+    const content = await contentService.get(requester, contentId);
 
     const [created] = await executeQuery(
       (db) =>

--- a/actions/db/atrium/artifact-data.ts
+++ b/actions/db/atrium/artifact-data.ts
@@ -223,20 +223,16 @@ export async function submitArtifactRecord(
   try {
     const session = await getServerSession();
     if (!session?.sub) throw ErrorFactories.authNoSession();
-    const requester = await getUserRequester(requestId, session);
-    if (requester.kind !== "user" || requester.userId == null) {
-      throw ErrorFactories.authNoSession();
-    }
-    const userId = requester.userId;
 
-    // Consume the caller's budget before any payload serialization. Server
-    // Actions share a large global body limit, so an over-limit caller must not
-    // repeatedly force this action to stringify artifact-defined input.
+    // The authenticated Cognito subject is stable per user and available before
+    // requester resolution, which performs database-backed role/group lookups.
+    // Consume the budget first so an over-limit caller cannot force those
+    // lookups or any payload serialization.
     const rateLimit = consumeRateLimit({
       interval: SUBMIT_RATE_WINDOW_MS,
       uniqueTokenPerInterval: SUBMIT_RATE_LIMIT,
       namespace: SUBMIT_RATE_NAMESPACE,
-      identifier: `user:${userId}`,
+      identifier: `user-sub:${session.sub}`,
     });
     if (!rateLimit.allowed) {
       throw ErrorFactories.bizRateLimitExceeded(
@@ -245,6 +241,12 @@ export async function submitArtifactRecord(
         new Date(rateLimit.resetTime).toISOString()
       );
     }
+
+    const requester = await getUserRequester(requestId, session);
+    if (requester.kind !== "user" || requester.userId == null) {
+      throw ErrorFactories.authNoSession();
+    }
+    const userId = requester.userId;
 
     const contentId = validateContentId(input?.contentId);
     const namespace = validateNamespace(input?.namespace);

--- a/actions/db/atrium/artifact-data.ts
+++ b/actions/db/atrium/artifact-data.ts
@@ -214,8 +214,12 @@ function validatePayload(payload: unknown): ValidatedPayload {
 }
 
 function validateJsonValue(value: unknown): void {
-  const pending: unknown[] = [value];
-  const seen = new WeakSet<object>();
+  type ValidationFrame =
+    | { kind: "value"; value: unknown }
+    | { kind: "leave"; value: object };
+
+  const pending: ValidationFrame[] = [{ kind: "value", value }];
+  const activePath = new WeakSet<object>();
   let discoveredValues = 1;
   let discoveredStringCodeUnits = 0;
 
@@ -240,11 +244,29 @@ function validateJsonValue(value: unknown): void {
         "payload contains too many values"
       );
     }
-    pending.push(next);
+    pending.push({ kind: "value", value: next });
+  };
+
+  const enterContainer = (next: object): void => {
+    if (activePath.has(next)) {
+      throw ErrorFactories.invalidInput(
+        "payload",
+        null,
+        "payload must not contain cycles"
+      );
+    }
+    activePath.add(next);
+    pending.push({ kind: "leave", value: next });
   };
 
   while (pending.length > 0) {
-    const current = pending.pop();
+    const frame = pending.pop()!;
+    if (frame.kind === "leave") {
+      activePath.delete(frame.value);
+      continue;
+    }
+
+    const current = frame.value;
     if (current === null || typeof current === "boolean") {
       continue;
     }
@@ -262,10 +284,8 @@ function validateJsonValue(value: unknown): void {
         "payload must contain only JSON values"
       );
     }
-    if (seen.has(current)) continue;
-    seen.add(current);
-
     if (Array.isArray(current)) {
+      enterContainer(current);
       for (const item of current) enqueue(item);
       continue;
     }
@@ -278,6 +298,7 @@ function validateJsonValue(value: unknown): void {
         "payload must contain only plain JSON objects"
       );
     }
+    enterContainer(current);
     const record = current as Record<string, unknown>;
     for (const key in record) {
       if (Object.prototype.hasOwnProperty.call(record, key)) {

--- a/actions/db/atrium/artifact-data.ts
+++ b/actions/db/atrium/artifact-data.ts
@@ -102,6 +102,13 @@ function validateContentId(contentId: unknown): string {
       MAX_CONTENT_ID_LENGTH
     );
   }
+  if (hasPostgresIncompatibleUnicode(normalized)) {
+    throw ErrorFactories.invalidInput(
+      "contentId",
+      null,
+      "contentId must use PostgreSQL-compatible Unicode"
+    );
+  }
   return normalized;
 }
 
@@ -262,19 +269,24 @@ function validateJsonValue(value: unknown): void {
   }
 }
 
-function validateJsonString(value: string): void {
-  let hasInvalidSurrogate = false;
+function hasPostgresIncompatibleUnicode(value: string): boolean {
+  if (value.includes("\u0000")) return true;
+
   for (let index = 0; index < value.length; index += 1) {
     const code = value.charCodeAt(index);
     if (code >= 0xD800 && code <= 0xDBFF) {
       const next = value.charCodeAt(index + 1);
-      if (!(next >= 0xDC00 && next <= 0xDFFF)) hasInvalidSurrogate = true;
+      if (!(next >= 0xDC00 && next <= 0xDFFF)) return true;
       else index += 1;
     } else if (code >= 0xDC00 && code <= 0xDFFF) {
-      hasInvalidSurrogate = true;
+      return true;
     }
   }
-  if (value.includes("\u0000") || hasInvalidSurrogate) {
+  return false;
+}
+
+function validateJsonString(value: string): void {
+  if (hasPostgresIncompatibleUnicode(value)) {
     throw ErrorFactories.invalidInput(
       "payload",
       null,

--- a/actions/db/atrium/artifact-data.ts
+++ b/actions/db/atrium/artifact-data.ts
@@ -1,0 +1,354 @@
+"use server"
+
+/**
+ * Session-authenticated persistence for sandboxed Atrium artifacts (#1517).
+ *
+ * These actions are the sole human write/read boundary for
+ * `content_data_records`. The sandbox bridge supplies only artifact-defined
+ * data; content identity and user identity are resolved by this parent-side,
+ * authenticated boundary. Both operations call `contentService.get`, preserving
+ * the shared 404 mask for missing and non-viewable content.
+ */
+
+import { and, desc, eq, sql } from "drizzle-orm";
+import {
+  createLogger,
+  generateRequestId,
+  sanitizeForLogging,
+  startTimer,
+} from "@/lib/logger";
+import { createSuccess, ErrorFactories, handleError } from "@/lib/error-utils";
+import { getServerSession } from "@/lib/auth/server-session";
+import { contentService } from "@/lib/content";
+import { executeQuery } from "@/lib/db/drizzle-client";
+import { contentDataRecords, users } from "@/lib/db/schema";
+import { safeJsonbStringify } from "@/lib/db/json-utils";
+import type { ArtifactDataPayload } from "@/lib/db/types/jsonb";
+import { consumeRateLimit } from "@/lib/rate-limit";
+import type { ActionState } from "@/types";
+import { getUserRequester } from "./requester";
+
+const NAMESPACE_RE = /^[a-z0-9_-]{1,64}$/;
+const MAX_PAYLOAD_BYTES = 8 * 1024;
+const DEFAULT_LIST_LIMIT = 50;
+const MAX_LIST_LIMIT = 200;
+const SUBMIT_RATE_LIMIT = 120;
+const SUBMIT_RATE_WINDOW_MS = 60 * 1000;
+const SUBMIT_RATE_NAMESPACE = "atrium-artifact-record-submit";
+const RESERVED_IDENTITY_KEYS = new Set(["userId", "user_id"]);
+
+export interface SubmitArtifactRecordInput {
+  contentId: string;
+  namespace: string;
+  payload: ArtifactDataPayload;
+}
+
+export interface SubmitArtifactRecordResult {
+  id: string;
+  createdAt: string;
+}
+
+export type ArtifactRecordScope = "all" | "mine";
+
+export interface ListArtifactRecordsInput {
+  contentId: string;
+  namespace: string;
+  limit?: number;
+  scope?: ArtifactRecordScope;
+}
+
+export interface ArtifactRecordDTO {
+  id: string;
+  userId: number | null;
+  displayName: string;
+  payload: ArtifactDataPayload;
+  createdAt: string;
+}
+
+export interface ListArtifactRecordsResult {
+  records: ArtifactRecordDTO[];
+}
+
+interface ValidatedPayload {
+  serialized: string;
+  bytes: number;
+}
+
+interface ArtifactRecordRow {
+  id: string;
+  userId: number | null;
+  payload: ArtifactDataPayload;
+  createdAt: Date;
+  userFirstName: string | null;
+  userLastName: string | null;
+  userEmail: string | null;
+}
+
+function validateContentId(contentId: unknown): string {
+  if (typeof contentId !== "string" || !contentId.trim()) {
+    throw ErrorFactories.missingRequiredField("contentId");
+  }
+  return contentId.trim();
+}
+
+function validateNamespace(namespace: unknown): string {
+  if (typeof namespace !== "string" || !NAMESPACE_RE.test(namespace)) {
+    throw ErrorFactories.invalidFormat(
+      "namespace",
+      namespace,
+      "1-64 lowercase letters, numbers, underscores, or hyphens"
+    );
+  }
+  return namespace;
+}
+
+function validatePayload(payload: unknown): ValidatedPayload {
+  if (payload === null || typeof payload !== "object" || Array.isArray(payload)) {
+    throw ErrorFactories.invalidInput(
+      "payload",
+      null,
+      "payload must be a JSON object"
+    );
+  }
+
+  for (const key of RESERVED_IDENTITY_KEYS) {
+    if (Object.prototype.hasOwnProperty.call(payload, key)) {
+      throw ErrorFactories.invalidInput(
+        "payload",
+        key,
+        `payload must not contain reserved identity key '${key}'`
+      );
+    }
+  }
+
+  let serialized: string;
+  try {
+    serialized = safeJsonbStringify(payload);
+  } catch {
+    throw ErrorFactories.invalidInput(
+      "payload",
+      null,
+      "payload must be JSON serializable"
+    );
+  }
+
+  const bytes = Buffer.byteLength(serialized, "utf8");
+  if (bytes > MAX_PAYLOAD_BYTES) {
+    throw ErrorFactories.fileTooLarge(
+      "payload",
+      bytes,
+      MAX_PAYLOAD_BYTES
+    );
+  }
+
+  return {
+    serialized,
+    bytes,
+  };
+}
+
+function normalizeScope(scope: unknown): ArtifactRecordScope {
+  if (scope === undefined) return "all";
+  if (scope !== "all" && scope !== "mine") {
+    throw ErrorFactories.invalidInput(
+      "scope",
+      scope,
+      "scope must be 'all' or 'mine'"
+    );
+  }
+  return scope;
+}
+
+function normalizeLimit(limit: unknown): number {
+  if (limit === undefined) return DEFAULT_LIST_LIMIT;
+  if (typeof limit !== "number" || !Number.isFinite(limit) || limit < 1) {
+    throw ErrorFactories.valueOutOfRange(
+      "limit",
+      typeof limit === "number" ? limit : 0,
+      1,
+      MAX_LIST_LIMIT
+    );
+  }
+  return Math.min(Math.floor(limit), MAX_LIST_LIMIT);
+}
+
+function displayNameFor(row: ArtifactRecordRow): string {
+  const fullName = [row.userFirstName, row.userLastName]
+    .map((part) => part?.trim())
+    .filter((part): part is string => Boolean(part))
+    .join(" ")
+    .trim();
+  return fullName || row.userEmail?.split("@")[0] || "Unknown user";
+}
+
+function toArtifactRecordDTO(row: ArtifactRecordRow): ArtifactRecordDTO {
+  return {
+    id: row.id,
+    userId: row.userId,
+    displayName: displayNameFor(row),
+    payload: row.payload,
+    createdAt: row.createdAt.toISOString(),
+  };
+}
+
+export async function submitArtifactRecord(
+  input: SubmitArtifactRecordInput
+): Promise<ActionState<SubmitArtifactRecordResult>> {
+  const requestId = generateRequestId();
+  const timer = startTimer("submitArtifactRecord");
+  const log = createLogger({ requestId, action: "submitArtifactRecord" });
+
+  try {
+    const session = await getServerSession();
+    if (!session?.sub) throw ErrorFactories.authNoSession();
+    const requester = await getUserRequester(requestId, session);
+    if (requester.kind !== "user" || requester.userId == null) {
+      throw ErrorFactories.authNoSession();
+    }
+    const userId = requester.userId;
+
+    const contentId = validateContentId(input?.contentId);
+    const namespace = validateNamespace(input?.namespace);
+    const payload = validatePayload(input?.payload);
+    log.info("Action started: submit artifact record", {
+      contentId: sanitizeForLogging(contentId),
+      namespace,
+      payloadBytes: payload.bytes,
+    });
+
+    // Resolves the canonical object id and preserves the shared 404 mask for a
+    // missing or non-viewable target before any record-specific work occurs.
+    const content = await contentService.get(requester, contentId);
+
+    const rateLimit = consumeRateLimit({
+      interval: SUBMIT_RATE_WINDOW_MS,
+      uniqueTokenPerInterval: SUBMIT_RATE_LIMIT,
+      namespace: SUBMIT_RATE_NAMESPACE,
+      identifier: `user:${userId}`,
+    });
+    if (!rateLimit.allowed) {
+      throw ErrorFactories.bizRateLimitExceeded(
+        "submit artifact records",
+        rateLimit.retryAfterSeconds,
+        new Date(rateLimit.resetTime).toISOString()
+      );
+    }
+
+    const [created] = await executeQuery(
+      (db) =>
+        db
+          .insert(contentDataRecords)
+          .values({
+            contentId: content.id,
+            namespace,
+            userId,
+            payload: sql`${payload.serialized}::jsonb`,
+          })
+          .returning({
+            id: contentDataRecords.id,
+            createdAt: contentDataRecords.createdAt,
+          }),
+      "atrium.submitArtifactRecord"
+    );
+    if (!created) {
+      throw ErrorFactories.dbQueryFailed("insert content_data_records");
+    }
+
+    const result = {
+      id: created.id,
+      createdAt: created.createdAt.toISOString(),
+    };
+    timer({ status: "success" });
+    log.info("Artifact record submitted", {
+      contentId: content.id,
+      recordId: created.id,
+      userId,
+    });
+    return createSuccess(result, "Artifact record submitted");
+  } catch (error) {
+    timer({ status: "error" });
+    return handleError(error, "Failed to submit artifact record", {
+      context: "submitArtifactRecord",
+      requestId,
+      operation: "submitArtifactRecord",
+    });
+  }
+}
+
+export async function listArtifactRecords(
+  input: ListArtifactRecordsInput
+): Promise<ActionState<ListArtifactRecordsResult>> {
+  const requestId = generateRequestId();
+  const timer = startTimer("listArtifactRecords");
+  const log = createLogger({ requestId, action: "listArtifactRecords" });
+
+  try {
+    const session = await getServerSession();
+    if (!session?.sub) throw ErrorFactories.authNoSession();
+    const requester = await getUserRequester(requestId, session);
+    if (requester.kind !== "user" || requester.userId == null) {
+      throw ErrorFactories.authNoSession();
+    }
+    const userId = requester.userId;
+
+    const contentId = validateContentId(input?.contentId);
+    const namespace = validateNamespace(input?.namespace);
+    const scope = normalizeScope(input?.scope);
+    const limit = normalizeLimit(input?.limit);
+    log.info("Action started: list artifact records", {
+      contentId: sanitizeForLogging(contentId),
+      namespace,
+      scope,
+      limit,
+    });
+
+    const content = await contentService.get(requester, contentId);
+    const rows = await executeQuery(
+      (db) =>
+        db
+          .select({
+            id: contentDataRecords.id,
+            userId: contentDataRecords.userId,
+            payload: contentDataRecords.payload,
+            createdAt: contentDataRecords.createdAt,
+            userFirstName: users.firstName,
+            userLastName: users.lastName,
+            userEmail: users.email,
+          })
+          .from(contentDataRecords)
+          .leftJoin(users, eq(contentDataRecords.userId, users.id))
+          .where(
+            and(
+              eq(contentDataRecords.contentId, content.id),
+              eq(contentDataRecords.namespace, namespace),
+              scope === "mine"
+                ? eq(contentDataRecords.userId, userId)
+                : undefined
+            )
+          )
+          .orderBy(
+            desc(contentDataRecords.createdAt),
+            desc(contentDataRecords.id)
+          )
+          .limit(limit),
+      "atrium.listArtifactRecords"
+    );
+
+    const records = (rows as ArtifactRecordRow[]).map(toArtifactRecordDTO);
+    timer({ status: "success" });
+    log.info("Artifact records listed", {
+      contentId: content.id,
+      namespace,
+      scope,
+      count: records.length,
+    });
+    return createSuccess({ records }, "Artifact records loaded");
+  } catch (error) {
+    timer({ status: "error" });
+    return handleError(error, "Failed to list artifact records", {
+      context: "listArtifactRecords",
+      requestId,
+      operation: "listArtifactRecords",
+    });
+  }
+}

--- a/actions/db/atrium/artifact-data.ts
+++ b/actions/db/atrium/artifact-data.ts
@@ -132,6 +132,15 @@ function validatePayload(payload: unknown): ValidatedPayload {
     );
   }
 
+  const bytes = new TextEncoder().encode(serialized).byteLength;
+  if (bytes > MAX_PAYLOAD_BYTES) {
+    throw ErrorFactories.fileTooLarge(
+      "payload",
+      bytes,
+      MAX_PAYLOAD_BYTES
+    );
+  }
+
   let serializedShape: unknown;
   try {
     serializedShape = JSON.parse(serialized) as unknown;
@@ -151,15 +160,6 @@ function validatePayload(payload: unknown): ValidatedPayload {
       "payload",
       null,
       "payload must serialize to a JSON object"
-    );
-  }
-
-  const bytes = new TextEncoder().encode(serialized).byteLength;
-  if (bytes > MAX_PAYLOAD_BYTES) {
-    throw ErrorFactories.fileTooLarge(
-      "payload",
-      bytes,
-      MAX_PAYLOAD_BYTES
     );
   }
 

--- a/actions/db/atrium/artifact-data.ts
+++ b/actions/db/atrium/artifact-data.ts
@@ -148,6 +148,12 @@ function validatePayload(payload: unknown): ValidatedPayload {
     }
   }
 
+  // Walk the original value before JSON.stringify so fields that serialization
+  // would omit cannot force an unbounded pre-validation traversal. The walk
+  // caps both discovered values and cumulative string/key code units before
+  // performing per-string Unicode scans.
+  validateJsonValue(payload);
+
   let serialized: string;
   try {
     serialized = safeJsonbStringify(payload);
@@ -178,12 +184,6 @@ function validatePayload(payload: unknown): ValidatedPayload {
       MAX_PAYLOAD_BYTES
     );
   }
-
-  // Enforce the serialized byte budget before walking the graph so a very
-  // large array/object cannot expand the structural-validation work queue.
-  // Walk the original value deliberately: reject undefined and other values
-  // JSON.stringify would silently omit instead of accepting a lossy payload.
-  validateJsonValue(payload);
 
   let serializedShape: unknown;
   try {

--- a/actions/db/atrium/artifact-data.ts
+++ b/actions/db/atrium/artifact-data.ts
@@ -132,7 +132,29 @@ function validatePayload(payload: unknown): ValidatedPayload {
     );
   }
 
-  const bytes = Buffer.byteLength(serialized, "utf8");
+  let serializedShape: unknown;
+  try {
+    serializedShape = JSON.parse(serialized) as unknown;
+  } catch {
+    throw ErrorFactories.invalidInput(
+      "payload",
+      null,
+      "payload must serialize to a JSON object"
+    );
+  }
+  if (
+    serializedShape === null ||
+    typeof serializedShape !== "object" ||
+    Array.isArray(serializedShape)
+  ) {
+    throw ErrorFactories.invalidInput(
+      "payload",
+      null,
+      "payload must serialize to a JSON object"
+    );
+  }
+
+  const bytes = new TextEncoder().encode(serialized).byteLength;
   if (bytes > MAX_PAYLOAD_BYTES) {
     throw ErrorFactories.fileTooLarge(
       "payload",
@@ -234,6 +256,11 @@ export async function submitArtifactRecord(
     // missing or non-viewable target. The per-user guard runs first so a caller
     // over budget cannot keep generating database-backed visibility lookups.
     const content = await contentService.get(requester, contentId);
+    if (content.kind !== "artifact") {
+      throw ErrorFactories.validationFailed([
+        { field: "contentId", message: "Content is not an artifact" },
+      ]);
+    }
 
     const [created] = await executeQuery(
       (db) =>
@@ -304,6 +331,19 @@ export async function listArtifactRecords(
     });
 
     const content = await contentService.get(requester, contentId);
+    if (content.kind !== "artifact") {
+      throw ErrorFactories.validationFailed([
+        { field: "contentId", message: "Content is not an artifact" },
+      ]);
+    }
+    const conditions = [
+      eq(contentDataRecords.contentId, content.id),
+      eq(contentDataRecords.namespace, namespace),
+    ];
+    if (scope === "mine") {
+      conditions.push(eq(contentDataRecords.userId, userId));
+    }
+
     const rows = await executeQuery(
       (db) =>
         db
@@ -318,15 +358,7 @@ export async function listArtifactRecords(
           })
           .from(contentDataRecords)
           .leftJoin(users, eq(contentDataRecords.userId, users.id))
-          .where(
-            and(
-              eq(contentDataRecords.contentId, content.id),
-              eq(contentDataRecords.namespace, namespace),
-              scope === "mine"
-                ? eq(contentDataRecords.userId, userId)
-                : undefined
-            )
-          )
+          .where(and(...conditions))
           .orderBy(
             desc(contentDataRecords.createdAt),
             desc(contentDataRecords.id)

--- a/actions/db/atrium/artifact-data.ts
+++ b/actions/db/atrium/artifact-data.ts
@@ -1,4 +1,4 @@
-"use server"
+"use server";
 
 /**
  * Session-authenticated persistence for sandboxed Atrium artifacts (#1517).
@@ -124,8 +124,6 @@ function validatePayload(payload: unknown): ValidatedPayload {
     );
   }
 
-  validateJsonValue(payload);
-
   for (const key of RESERVED_IDENTITY_KEYS) {
     if (Object.prototype.hasOwnProperty.call(payload, key)) {
       throw ErrorFactories.invalidInput(
@@ -155,6 +153,10 @@ function validatePayload(payload: unknown): ValidatedPayload {
       MAX_PAYLOAD_BYTES
     );
   }
+
+  // Enforce the serialized byte budget before walking the graph so a very
+  // large array/object cannot expand the structural-validation work queue.
+  validateJsonValue(payload);
 
   let serializedShape: unknown;
   try {
@@ -211,7 +213,7 @@ function validateJsonValue(value: unknown): void {
     seen.add(current);
 
     if (Array.isArray(current)) {
-      pending.push(...current);
+      for (const item of current) pending.push(item);
       continue;
     }
 

--- a/actions/db/atrium/artifact-data.ts
+++ b/actions/db/atrium/artifact-data.ts
@@ -146,6 +146,17 @@ function validatePayload(payload: unknown): ValidatedPayload {
     );
   }
 
+  // UTF-8 always uses at least one byte per UTF-16 code unit. Reject by that
+  // allocation-free lower bound first so a huge ASCII payload cannot make
+  // TextEncoder materialize another huge buffer just to discover it is too big.
+  if (serialized.length > MAX_PAYLOAD_BYTES) {
+    throw ErrorFactories.fileTooLarge(
+      "payload",
+      serialized.length,
+      MAX_PAYLOAD_BYTES
+    );
+  }
+
   const bytes = new TextEncoder().encode(serialized).byteLength;
   if (bytes > MAX_PAYLOAD_BYTES) {
     throw ErrorFactories.fileTooLarge(

--- a/actions/db/atrium/artifact-data.ts
+++ b/actions/db/atrium/artifact-data.ts
@@ -229,15 +229,9 @@ export async function submitArtifactRecord(
     }
     const userId = requester.userId;
 
-    const contentId = validateContentId(input?.contentId);
-    const namespace = validateNamespace(input?.namespace);
-    const payload = validatePayload(input?.payload);
-    log.info("Action started: submit artifact record", {
-      contentId: sanitizeForLogging(contentId),
-      namespace,
-      payloadBytes: payload.bytes,
-    });
-
+    // Consume the caller's budget before any payload serialization. Server
+    // Actions share a large global body limit, so an over-limit caller must not
+    // repeatedly force this action to stringify artifact-defined input.
     const rateLimit = consumeRateLimit({
       interval: SUBMIT_RATE_WINDOW_MS,
       uniqueTokenPerInterval: SUBMIT_RATE_LIMIT,
@@ -251,6 +245,15 @@ export async function submitArtifactRecord(
         new Date(rateLimit.resetTime).toISOString()
       );
     }
+
+    const contentId = validateContentId(input?.contentId);
+    const namespace = validateNamespace(input?.namespace);
+    const payload = validatePayload(input?.payload);
+    log.info("Action started: submit artifact record", {
+      contentId: sanitizeForLogging(contentId),
+      namespace,
+      payloadBytes: payload.bytes,
+    });
 
     // Resolves the canonical object id and preserves the shared 404 mask for a
     // missing or non-viewable target. The per-user guard runs first so a caller

--- a/actions/db/atrium/artifact-data.ts
+++ b/actions/db/atrium/artifact-data.ts
@@ -33,6 +33,9 @@ const MAX_CONTENT_ID_LENGTH = 200;
 const MAX_PAYLOAD_BYTES = 8 * 1024;
 // Independent work cap for structural validation; it is not a byte-budget alias.
 const MAX_PAYLOAD_VALUES = 8_192;
+// Include original strings and keys that JSON.stringify would omit so lossy
+// inputs cannot bypass the serialized byte limit and force unbounded scanning.
+const MAX_PAYLOAD_STRING_CODE_UNITS = MAX_PAYLOAD_BYTES;
 const DEFAULT_LIST_LIMIT = 50;
 const MAX_LIST_LIMIT = 200;
 const SUBMIT_RATE_LIMIT = 120;
@@ -209,6 +212,19 @@ function validateJsonValue(value: unknown): void {
   const pending: unknown[] = [value];
   const seen = new WeakSet<object>();
   let discoveredValues = 1;
+  let discoveredStringCodeUnits = 0;
+
+  const validateBoundedString = (next: string): void => {
+    discoveredStringCodeUnits += next.length;
+    if (discoveredStringCodeUnits > MAX_PAYLOAD_STRING_CODE_UNITS) {
+      throw ErrorFactories.invalidInput(
+        "payload",
+        null,
+        "payload contains too much string data"
+      );
+    }
+    validateJsonString(next);
+  };
 
   const enqueue = (next: unknown): void => {
     discoveredValues += 1;
@@ -228,7 +244,7 @@ function validateJsonValue(value: unknown): void {
       continue;
     }
     if (typeof current === "string") {
-      validateJsonString(current);
+      validateBoundedString(current);
       continue;
     }
     if (typeof current === "number" && Number.isFinite(current)) {
@@ -260,7 +276,7 @@ function validateJsonValue(value: unknown): void {
     const record = current as Record<string, unknown>;
     for (const key in record) {
       if (Object.prototype.hasOwnProperty.call(record, key)) {
-        validateJsonString(key);
+        validateBoundedString(key);
         enqueue(record[key]);
       }
     }

--- a/actions/db/atrium/artifact-data.ts
+++ b/actions/db/atrium/artifact-data.ts
@@ -31,6 +31,7 @@ import { getUserRequester } from "./requester";
 const NAMESPACE_RE = /^[a-z0-9_-]{1,64}$/;
 const MAX_CONTENT_ID_LENGTH = 200;
 const MAX_PAYLOAD_BYTES = 8 * 1024;
+const MAX_PAYLOAD_VALUES = MAX_PAYLOAD_BYTES;
 const DEFAULT_LIST_LIMIT = 50;
 const MAX_LIST_LIMIT = 200;
 const SUBMIT_RATE_LIMIT = 120;
@@ -189,6 +190,19 @@ function validatePayload(payload: unknown): ValidatedPayload {
 function validateJsonValue(value: unknown): void {
   const pending: unknown[] = [value];
   const seen = new WeakSet<object>();
+  let discoveredValues = 1;
+
+  const enqueue = (next: unknown): void => {
+    discoveredValues += 1;
+    if (discoveredValues > MAX_PAYLOAD_VALUES) {
+      throw ErrorFactories.invalidInput(
+        "payload",
+        null,
+        "payload contains too many values"
+      );
+    }
+    pending.push(next);
+  };
 
   while (pending.length > 0) {
     const current = pending.pop();
@@ -213,7 +227,7 @@ function validateJsonValue(value: unknown): void {
     seen.add(current);
 
     if (Array.isArray(current)) {
-      for (const item of current) pending.push(item);
+      for (const item of current) enqueue(item);
       continue;
     }
 
@@ -225,7 +239,12 @@ function validateJsonValue(value: unknown): void {
         "payload must contain only plain JSON objects"
       );
     }
-    pending.push(...Object.values(current as Record<string, unknown>));
+    const record = current as Record<string, unknown>;
+    for (const key in record) {
+      if (Object.prototype.hasOwnProperty.call(record, key)) {
+        enqueue(record[key]);
+      }
+    }
   }
 }
 

--- a/actions/db/atrium/artifact-data.ts
+++ b/actions/db/atrium/artifact-data.ts
@@ -217,11 +217,11 @@ function validateJsonValue(value: unknown): void {
 
   while (pending.length > 0) {
     const current = pending.pop();
-    if (
-      current === null ||
-      typeof current === "string" ||
-      typeof current === "boolean"
-    ) {
+    if (current === null || typeof current === "boolean") {
+      continue;
+    }
+    if (typeof current === "string") {
+      validateJsonString(current);
       continue;
     }
     if (typeof current === "number" && Number.isFinite(current)) {
@@ -253,9 +253,31 @@ function validateJsonValue(value: unknown): void {
     const record = current as Record<string, unknown>;
     for (const key in record) {
       if (Object.prototype.hasOwnProperty.call(record, key)) {
+        validateJsonString(key);
         enqueue(record[key]);
       }
     }
+  }
+}
+
+function validateJsonString(value: string): void {
+  let hasInvalidSurrogate = false;
+  for (let index = 0; index < value.length; index += 1) {
+    const code = value.charCodeAt(index);
+    if (code >= 0xD800 && code <= 0xDBFF) {
+      const next = value.charCodeAt(index + 1);
+      if (!(next >= 0xDC00 && next <= 0xDFFF)) hasInvalidSurrogate = true;
+      else index += 1;
+    } else if (code >= 0xDC00 && code <= 0xDFFF) {
+      hasInvalidSurrogate = true;
+    }
+  }
+  if (value.includes("\u0000") || hasInvalidSurrogate) {
+    throw ErrorFactories.invalidInput(
+      "payload",
+      null,
+      "payload strings and object keys must use PostgreSQL-compatible Unicode"
+    );
   }
 }
 

--- a/actions/db/atrium/artifact-data.ts
+++ b/actions/db/atrium/artifact-data.ts
@@ -65,7 +65,6 @@ export interface ListArtifactRecordsInput {
 
 export interface ArtifactRecordDTO {
   id: string;
-  userId: number | null;
   displayName: string;
   payload: ArtifactDataPayload;
   createdAt: string;
@@ -82,7 +81,6 @@ interface ValidatedPayload {
 
 interface ArtifactRecordRow {
   id: string;
-  userId: number | null;
   payload: ArtifactDataPayload;
   createdAt: Date;
   userFirstName: string | null;
@@ -332,7 +330,6 @@ function displayNameFor(row: ArtifactRecordRow): string {
 function toArtifactRecordDTO(row: ArtifactRecordRow): ArtifactRecordDTO {
   return {
     id: row.id,
-    userId: row.userId,
     displayName: displayNameFor(row),
     payload: row.payload,
     createdAt: row.createdAt.toISOString(),
@@ -500,7 +497,6 @@ export async function listArtifactRecords(
         db
           .select({
             id: contentDataRecords.id,
-            userId: contentDataRecords.userId,
             payload: contentDataRecords.payload,
             createdAt: contentDataRecords.createdAt,
             userFirstName: users.firstName,

--- a/actions/db/atrium/artifact-data.ts
+++ b/actions/db/atrium/artifact-data.ts
@@ -91,17 +91,22 @@ interface ArtifactRecordRow {
 }
 
 function validateContentId(contentId: unknown): string {
-  if (typeof contentId !== "string" || !contentId.trim()) {
+  if (typeof contentId !== "string") {
     throw ErrorFactories.missingRequiredField("contentId");
   }
-  const normalized = contentId.trim();
-  if (normalized.length > MAX_CONTENT_ID_LENGTH) {
+  // Bound attacker-controlled work before trim scans or allocates a normalized
+  // copy. Padded IDs are invalid rather than a path around the raw input cap.
+  if (contentId.length > MAX_CONTENT_ID_LENGTH) {
     throw ErrorFactories.valueOutOfRange(
       "contentId",
-      normalized.length,
+      contentId.length,
       1,
       MAX_CONTENT_ID_LENGTH
     );
+  }
+  const normalized = contentId.trim();
+  if (!normalized) {
+    throw ErrorFactories.missingRequiredField("contentId");
   }
   if (hasPostgresIncompatibleUnicode(normalized)) {
     throw ErrorFactories.invalidInput(

--- a/actions/db/atrium/artifact-data.ts
+++ b/actions/db/atrium/artifact-data.ts
@@ -168,6 +168,8 @@ function validatePayload(payload: unknown): ValidatedPayload {
 
   // Enforce the serialized byte budget before walking the graph so a very
   // large array/object cannot expand the structural-validation work queue.
+  // Walk the original value deliberately: reject undefined and other values
+  // JSON.stringify would silently omit instead of accepting a lossy payload.
   validateJsonValue(payload);
 
   let serializedShape: unknown;
@@ -358,6 +360,7 @@ export async function submitArtifactRecord(
     const namespace = validateNamespace(input?.namespace);
     const payload = validatePayload(input?.payload);
     const requester = await getUserRequester(requestId, session);
+    // Keep the action boundary fail-closed if requester resolution broadens.
     if (requester.kind !== "user" || requester.userId == null) {
       throw ErrorFactories.authNoSession();
     }
@@ -453,6 +456,7 @@ export async function listArtifactRecords(
     const scope = normalizeScope(input?.scope);
     const limit = normalizeLimit(input?.limit);
     const requester = await getUserRequester(requestId, session);
+    // Keep the action boundary fail-closed if requester resolution broadens.
     if (requester.kind !== "user" || requester.userId == null) {
       throw ErrorFactories.authNoSession();
     }

--- a/actions/db/atrium/artifact-data.ts
+++ b/actions/db/atrium/artifact-data.ts
@@ -29,12 +29,16 @@ import type { ActionState } from "@/types";
 import { getUserRequester } from "./requester";
 
 const NAMESPACE_RE = /^[a-z0-9_-]{1,64}$/;
+const MAX_CONTENT_ID_LENGTH = 200;
 const MAX_PAYLOAD_BYTES = 8 * 1024;
 const DEFAULT_LIST_LIMIT = 50;
 const MAX_LIST_LIMIT = 200;
 const SUBMIT_RATE_LIMIT = 120;
+const LIST_RATE_LIMIT = 600;
 const SUBMIT_RATE_WINDOW_MS = 60 * 1000;
+const LIST_RATE_WINDOW_MS = 60 * 1000;
 const SUBMIT_RATE_NAMESPACE = "atrium-artifact-record-submit";
+const LIST_RATE_NAMESPACE = "atrium-artifact-record-list";
 const RESERVED_IDENTITY_KEYS = new Set(["userId", "user_id"]);
 
 export interface SubmitArtifactRecordInput {
@@ -88,7 +92,16 @@ function validateContentId(contentId: unknown): string {
   if (typeof contentId !== "string" || !contentId.trim()) {
     throw ErrorFactories.missingRequiredField("contentId");
   }
-  return contentId.trim();
+  const normalized = contentId.trim();
+  if (normalized.length > MAX_CONTENT_ID_LENGTH) {
+    throw ErrorFactories.valueOutOfRange(
+      "contentId",
+      normalized.length,
+      1,
+      MAX_CONTENT_ID_LENGTH
+    );
+  }
+  return normalized;
 }
 
 function validateNamespace(namespace: unknown): string {
@@ -110,6 +123,8 @@ function validatePayload(payload: unknown): ValidatedPayload {
       "payload must be a JSON object"
     );
   }
+
+  validateJsonValue(payload);
 
   for (const key of RESERVED_IDENTITY_KEYS) {
     if (Object.prototype.hasOwnProperty.call(payload, key)) {
@@ -167,6 +182,49 @@ function validatePayload(payload: unknown): ValidatedPayload {
     serialized,
     bytes,
   };
+}
+
+function validateJsonValue(value: unknown): void {
+  const pending: unknown[] = [value];
+  const seen = new WeakSet<object>();
+
+  while (pending.length > 0) {
+    const current = pending.pop();
+    if (
+      current === null ||
+      typeof current === "string" ||
+      typeof current === "boolean"
+    ) {
+      continue;
+    }
+    if (typeof current === "number" && Number.isFinite(current)) {
+      continue;
+    }
+    if (typeof current !== "object") {
+      throw ErrorFactories.invalidInput(
+        "payload",
+        null,
+        "payload must contain only JSON values"
+      );
+    }
+    if (seen.has(current)) continue;
+    seen.add(current);
+
+    if (Array.isArray(current)) {
+      pending.push(...current);
+      continue;
+    }
+
+    const prototype = Object.getPrototypeOf(current);
+    if (prototype !== Object.prototype && prototype !== null) {
+      throw ErrorFactories.invalidInput(
+        "payload",
+        null,
+        "payload must contain only plain JSON objects"
+      );
+    }
+    pending.push(...Object.values(current as Record<string, unknown>));
+  }
 }
 
 function normalizeScope(scope: unknown): ArtifactRecordScope {
@@ -242,15 +300,15 @@ export async function submitArtifactRecord(
       );
     }
 
+    const contentId = validateContentId(input?.contentId);
+    const namespace = validateNamespace(input?.namespace);
+    const payload = validatePayload(input?.payload);
     const requester = await getUserRequester(requestId, session);
     if (requester.kind !== "user" || requester.userId == null) {
       throw ErrorFactories.authNoSession();
     }
     const userId = requester.userId;
 
-    const contentId = validateContentId(input?.contentId);
-    const namespace = validateNamespace(input?.namespace);
-    const payload = validatePayload(input?.payload);
     log.info("Action started: submit artifact record", {
       contentId: sanitizeForLogging(contentId),
       namespace,
@@ -318,16 +376,34 @@ export async function listArtifactRecords(
   try {
     const session = await getServerSession();
     if (!session?.sub) throw ErrorFactories.authNoSession();
+
+    // List reads are cheap and bounded, but a sandbox can still poll them at a
+    // pathological rate. Consume a generous budget before requester resolution
+    // so repeated calls cannot amplify into role/group and visibility queries.
+    const rateLimit = consumeRateLimit({
+      interval: LIST_RATE_WINDOW_MS,
+      uniqueTokenPerInterval: LIST_RATE_LIMIT,
+      namespace: LIST_RATE_NAMESPACE,
+      identifier: `user-sub:${session.sub}`,
+    });
+    if (!rateLimit.allowed) {
+      throw ErrorFactories.bizRateLimitExceeded(
+        "list artifact records",
+        rateLimit.retryAfterSeconds,
+        new Date(rateLimit.resetTime).toISOString()
+      );
+    }
+
+    const contentId = validateContentId(input?.contentId);
+    const namespace = validateNamespace(input?.namespace);
+    const scope = normalizeScope(input?.scope);
+    const limit = normalizeLimit(input?.limit);
     const requester = await getUserRequester(requestId, session);
     if (requester.kind !== "user" || requester.userId == null) {
       throw ErrorFactories.authNoSession();
     }
     const userId = requester.userId;
 
-    const contentId = validateContentId(input?.contentId);
-    const namespace = validateNamespace(input?.namespace);
-    const scope = normalizeScope(input?.scope);
-    const limit = normalizeLimit(input?.limit);
     log.info("Action started: list artifact records", {
       contentId: sanitizeForLogging(contentId),
       namespace,

--- a/app/(protected)/test-user/artifact-data/artifact-data-test-client.tsx
+++ b/app/(protected)/test-user/artifact-data/artifact-data-test-client.tsx
@@ -1,0 +1,165 @@
+"use client";
+
+import { useState } from "react";
+import {
+  listArtifactRecords,
+  submitArtifactRecord,
+  type ArtifactRecordScope,
+} from "@/actions/db/atrium/artifact-data";
+import type { ArtifactDataPayload } from "@/lib/db/types/jsonb";
+
+type HarnessOperation = "submit" | "list";
+
+interface HarnessResult {
+  operation: HarnessOperation;
+  state: object;
+}
+
+function parsePayload(value: string): ArtifactDataPayload {
+  const parsed = JSON.parse(value) as unknown;
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error("Payload must be a JSON object");
+  }
+  return parsed as ArtifactDataPayload;
+}
+
+/**
+ * Development-only browser harness for the authenticated Artifact Data Service
+ * Server Actions. The page wrapper returns 404 in production; Playwright uses
+ * this client to exercise the real Next.js Server Action transport in local E2E.
+ */
+export function ArtifactDataTestClient(): React.JSX.Element {
+  const [contentId, setContentId] = useState("");
+  const [namespace, setNamespace] = useState("e2e_leaderboard");
+  const [payload, setPayload] = useState('{"score":42}');
+  const [scope, setScope] = useState<ArtifactRecordScope>("all");
+  const [result, setResult] = useState<HarnessResult | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  async function runSubmit(): Promise<void> {
+    setBusy(true);
+    try {
+      const state = await submitArtifactRecord({
+        contentId,
+        namespace,
+        payload: parsePayload(payload),
+      });
+      setResult({ operation: "submit", state });
+    } catch (error) {
+      setResult({
+        operation: "submit",
+        state: {
+          isSuccess: false,
+          message:
+            error instanceof Error ? error.message : "Unexpected request failure",
+        },
+      });
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function runList(): Promise<void> {
+    setBusy(true);
+    try {
+      const state = await listArtifactRecords({
+        contentId,
+        namespace,
+        scope,
+      });
+      setResult({ operation: "list", state });
+    } catch (error) {
+      setResult({
+        operation: "list",
+        state: {
+          isSuccess: false,
+          message:
+            error instanceof Error ? error.message : "Unexpected request failure",
+        },
+      });
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <main className="mx-auto max-w-3xl space-y-4 p-8">
+      <h1 className="text-2xl font-bold">Artifact data E2E harness</h1>
+      <p>
+        Development-only transport harness for authenticated Artifact Data
+        Service actions.
+      </p>
+
+      <label className="block">
+        Content ID
+        <input
+          data-testid="artifact-data-content-id"
+          className="block w-full border p-2"
+          value={contentId}
+          onChange={(event) => setContentId(event.target.value)}
+        />
+      </label>
+
+      <label className="block">
+        Namespace
+        <input
+          data-testid="artifact-data-namespace"
+          className="block w-full border p-2"
+          value={namespace}
+          onChange={(event) => setNamespace(event.target.value)}
+        />
+      </label>
+
+      <label className="block">
+        Payload JSON
+        <textarea
+          data-testid="artifact-data-payload"
+          className="block min-h-24 w-full border p-2 font-mono"
+          value={payload}
+          onChange={(event) => setPayload(event.target.value)}
+        />
+      </label>
+
+      <label className="block">
+        List scope
+        <select
+          data-testid="artifact-data-scope"
+          className="block border p-2"
+          value={scope}
+          onChange={(event) =>
+            setScope(event.target.value === "mine" ? "mine" : "all")
+          }
+        >
+          <option value="all">all</option>
+          <option value="mine">mine</option>
+        </select>
+      </label>
+
+      <div className="flex gap-2">
+        <button
+          type="button"
+          data-testid="artifact-data-submit"
+          disabled={busy}
+          onClick={runSubmit}
+        >
+          Submit record
+        </button>
+        <button
+          type="button"
+          data-testid="artifact-data-list"
+          disabled={busy}
+          onClick={runList}
+        >
+          List records
+        </button>
+      </div>
+
+      <pre
+        data-testid="artifact-data-result"
+        className="min-h-24 overflow-auto bg-muted p-4"
+      >
+        {result ? JSON.stringify(result, null, 2) : "No result"}
+      </pre>
+    </main>
+  );
+}

--- a/app/(protected)/test-user/artifact-data/page.tsx
+++ b/app/(protected)/test-user/artifact-data/page.tsx
@@ -1,0 +1,11 @@
+import { notFound } from "next/navigation";
+import { ArtifactDataTestClient } from "./artifact-data-test-client";
+
+/**
+ * Local-only Server Action transport harness used by the authenticated
+ * Playwright suite. It is deliberately unavailable in production builds.
+ */
+export default function ArtifactDataTestPage(): React.JSX.Element {
+  if (process.env.NODE_ENV === "production") notFound();
+  return <ArtifactDataTestClient />;
+}

--- a/lib/auth/artifact-data-e2e-probe.ts
+++ b/lib/auth/artifact-data-e2e-probe.ts
@@ -1,0 +1,41 @@
+export interface ArtifactDataE2EProbeContext {
+  nodeEnv: string | undefined;
+  probeFlag: string | undefined;
+  hostname: string;
+}
+
+export interface ArtifactDataE2EActionProbeRequest
+  extends ArtifactDataE2EProbeContext {
+  method: string;
+  pathname: string;
+  hasNextActionHeader: boolean;
+}
+
+function isLoopbackHostname(hostname: string): boolean {
+  return (
+    hostname === "localhost" ||
+    hostname === "127.0.0.1" ||
+    hostname === "[::1]"
+  );
+}
+
+export function isArtifactDataE2EProbeEnabled(
+  context: ArtifactDataE2EProbeContext,
+): boolean {
+  return (
+    context.nodeEnv !== "production" &&
+    context.probeFlag === "true" &&
+    isLoopbackHostname(context.hostname)
+  );
+}
+
+export function isLocalArtifactDataActionProbe(
+  request: ArtifactDataE2EActionProbeRequest,
+): boolean {
+  return (
+    isArtifactDataE2EProbeEnabled(request) &&
+    request.method === "POST" &&
+    request.pathname === "/test-user/artifact-data" &&
+    request.hasNextActionHeader
+  );
+}

--- a/lib/error-utils.ts
+++ b/lib/error-utils.ts
@@ -461,6 +461,10 @@ function handleTypedError(
   options: ResolvedHandleErrorOptions,
   log: ErrorLog
 ): ActionState<never> {
+  const rateLimit =
+    error.code === ErrorCode.BIZ_RATE_LIMIT_EXCEEDED
+      ? (error as BusinessLogicError).rateLimit
+      : undefined
   const details = sanitizeForLogging({
     code: error.code,
     details: error.details,
@@ -468,6 +472,7 @@ function handleTypedError(
     retryable: error.retryable,
     service: error.service,
     operation: error.operation,
+    rateLimit,
     ...options.metadata
   })
   logErrorAtLevel(
@@ -480,9 +485,20 @@ function handleTypedError(
   return {
     isSuccess: false,
     message: error.userMessage || fallbackMessage,
-    ...(options.includeErrorInResponse && {
-      error: { code: error.code, message: error.message, details }
-    })
+    ...(rateLimit
+      ? {
+          // Retry metadata is part of the safe action contract, not internal
+          // diagnostics, so production callers can distinguish and back off.
+          error: {
+            code: error.code,
+            statusCode: error.statusCode ?? 429,
+            retryAfterSeconds: rateLimit.retryAfterSeconds,
+            resetAt: rateLimit.resetAt,
+          },
+        }
+      : options.includeErrorInResponse
+        ? { error: { code: error.code, message: error.message, details } }
+        : {})
   }
 }
 

--- a/lib/error-utils.ts
+++ b/lib/error-utils.ts
@@ -464,7 +464,7 @@ function handleTypedError(
   const rateLimit =
     error.code === ErrorCode.BIZ_RATE_LIMIT_EXCEEDED
       ? (error as BusinessLogicError).rateLimit
-      : undefined
+      : undefined;
   const details = sanitizeForLogging({
     code: error.code,
     details: error.details,

--- a/lib/error-utils.ts
+++ b/lib/error-utils.ts
@@ -289,7 +289,7 @@ export const ErrorFactories = {
     createTypedError<BusinessLogicError>(
       ErrorCode.BIZ_RATE_LIMIT_EXCEEDED,
       `Rate limit exceeded for ${operation}. Retry after ${retryAfterSeconds}s`,
-      { operation, retryAfterSeconds, resetAt, ...details }
+      { operation, rateLimit: { retryAfterSeconds, resetAt }, ...details }
     ),
 
   // Streaming and Provider Errors

--- a/lib/error-utils.ts
+++ b/lib/error-utils.ts
@@ -285,6 +285,13 @@ export const ErrorFactories = {
       { operation, quota: { limit, current, resetAt }, ...details }
     ),
 
+  bizRateLimitExceeded: (operation: string, retryAfterSeconds: number, resetAt: string, details?: Partial<BusinessLogicError>) =>
+    createTypedError<BusinessLogicError>(
+      ErrorCode.BIZ_RATE_LIMIT_EXCEEDED,
+      `Rate limit exceeded for ${operation}. Retry after ${retryAfterSeconds}s`,
+      { operation, retryAfterSeconds, resetAt, ...details }
+    ),
+
   // Streaming and Provider Errors
   providerUnavailable: (provider: string, details?: Partial<ExternalServiceError>) =>
     createTypedError<ExternalServiceError>(
@@ -338,6 +345,7 @@ function isRetryableError(code: ErrorCode): boolean {
     ErrorCode.DB_POOL_EXHAUSTED,
     ErrorCode.EXTERNAL_SERVICE_TIMEOUT,
     ErrorCode.EXTERNAL_API_RATE_LIMIT,
+    ErrorCode.BIZ_RATE_LIMIT_EXCEEDED,
     ErrorCode.AWS_SERVICE_ERROR,
     ErrorCode.S3_UPLOAD_FAILED,
     ErrorCode.S3_DOWNLOAD_FAILED,

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -9,6 +9,20 @@ interface RateLimitConfig {
   namespace?: string;
 }
 
+export interface DirectRateLimitConfig {
+  interval: number;
+  uniqueTokenPerInterval: number;
+  namespace: string;
+  identifier: string;
+}
+
+export interface RateLimitDecision {
+  allowed: boolean;
+  retryAfterSeconds: number;
+  remaining: number;
+  resetTime: number;
+}
+
 // In-memory store for rate limiting (consider using Redis in production)
 const rateLimitStore = new Map<string, { count: number; resetTime: number }>();
 let rateLimiterInstance = 0;
@@ -52,6 +66,56 @@ async function getIdentifier(request: NextRequest, skipAuth: boolean): Promise<s
 }
 
 /**
+ * Consume one request from a named, in-memory rate-limit bucket.
+ *
+ * Server actions do not receive a `NextRequest`, so they cannot use the route
+ * middleware wrapper below. This direct form lets an already-authenticated
+ * caller supply its server-derived identifier while sharing the same store and
+ * fixed-window behavior as API routes.
+ */
+export function consumeRateLimit(
+  config: DirectRateLimitConfig
+): RateLimitDecision {
+  const storeKey = `${config.namespace}:${config.identifier}`;
+  const now = Date.now();
+  let entry = rateLimitStore.get(storeKey);
+
+  if (!entry || entry.resetTime < now) {
+    entry = {
+      count: 1,
+      resetTime: now + config.interval,
+    };
+    rateLimitStore.set(storeKey, entry);
+    return {
+      allowed: true,
+      retryAfterSeconds: 0,
+      remaining: Math.max(config.uniqueTokenPerInterval - 1, 0),
+      resetTime: entry.resetTime,
+    };
+  }
+
+  if (entry.count >= config.uniqueTokenPerInterval) {
+    return {
+      allowed: false,
+      retryAfterSeconds: Math.max(
+        Math.ceil((entry.resetTime - now) / 1000),
+        1
+      ),
+      remaining: 0,
+      resetTime: entry.resetTime,
+    };
+  }
+
+  entry.count += 1;
+  return {
+    allowed: true,
+    retryAfterSeconds: 0,
+    remaining: Math.max(config.uniqueTokenPerInterval - entry.count, 0),
+    resetTime: entry.resetTime,
+  };
+}
+
+/**
  * Rate limiting middleware
  */
 export function rateLimit(config: RateLimitConfig) {
@@ -61,50 +125,35 @@ export function rateLimit(config: RateLimitConfig) {
     request: NextRequest
   ): Promise<NextResponse | null> {
     const identifier = await getIdentifier(request, config.skipAuth || false);
-    const storeKey = `${namespace}:${identifier}`;
-    const now = Date.now();
-    
-    // Get or create rate limit entry
-    let entry = rateLimitStore.get(storeKey);
-    
-    if (!entry || entry.resetTime < now) {
-      // Create new entry
-      entry = {
-        count: 1,
-        resetTime: now + config.interval
-      };
-      rateLimitStore.set(storeKey, entry);
-      return null; // Allow request
-    }
-    
-    // Check if limit exceeded
-    if (entry.count >= config.uniqueTokenPerInterval) {
-      const retryAfter = Math.ceil((entry.resetTime - now) / 1000);
-      
+    const decision = consumeRateLimit({
+      interval: config.interval,
+      uniqueTokenPerInterval: config.uniqueTokenPerInterval,
+      namespace,
+      identifier,
+    });
+
+    if (!decision.allowed) {
       return NextResponse.json(
         {
           isSuccess: false,
           message: 'Too many requests. Please try again later.',
           error: {
             code: 'RATE_LIMIT_EXCEEDED',
-            retryAfter
+            retryAfter: decision.retryAfterSeconds
           }
         },
         {
           status: 429,
           headers: {
-            'Retry-After': String(retryAfter),
+            'Retry-After': String(decision.retryAfterSeconds),
             'X-RateLimit-Limit': String(config.uniqueTokenPerInterval),
             'X-RateLimit-Remaining': '0',
-            'X-RateLimit-Reset': String(entry.resetTime)
+            'X-RateLimit-Reset': String(decision.resetTime)
           }
         }
       );
     }
-    
-    // Increment count
-    entry.count++;
-    
+
     // Add rate limit headers to response
     return null; // Allow request, headers will be added by wrapper
   };

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -23,7 +23,8 @@ export interface RateLimitDecision {
   resetTime: number;
 }
 
-// In-memory store for rate limiting (consider using Redis in production)
+// TODO: Move enforcement that must span multiple application tasks to a shared
+// store. This in-memory map intentionally provides only a per-process guard.
 const rateLimitStore = new Map<string, { count: number; resetTime: number }>();
 let rateLimiterInstance = 0;
 

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -37,7 +37,7 @@ function nextRateLimiterNamespace(prefix: string): string {
 const rateLimitCleanupTimer = setInterval(() => {
   const now = Date.now();
   for (const [key, value] of rateLimitStore.entries()) {
-    if (value.resetTime < now) {
+    if (value.resetTime <= now) {
       rateLimitStore.delete(key);
     }
   }
@@ -81,7 +81,7 @@ export function consumeRateLimit(
   const now = Date.now();
   let entry = rateLimitStore.get(storeKey);
 
-  if (!entry || entry.resetTime < now) {
+  if (!entry || entry.resetTime <= now) {
     entry = {
       count: 1,
       resetTime: now + config.interval,

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,5 +1,5 @@
 import { authMiddleware } from "@/auth";
-import { NextResponse } from "next/server";
+import { NextResponse, type NextRequest } from "next/server";
 import { getArtifactSandboxOrigin } from "@/lib/content/artifact-sandbox-config";
 import { inAppSignInCallbackUrl } from "@/lib/auth/sign-in-callback";
 import { isOidcProviderResumePath } from "@/lib/oauth/resume-path";
@@ -94,25 +94,38 @@ const CONTENT_SECURITY_POLICY =
   `frame-src ${FRAME_SRC}; ` +
   "frame-ancestors 'none';";
 
+/**
+ * Local authenticated-E2E harness only: after Playwright loads the protected
+ * page with a valid session, it clears the session cookie and invokes the
+ * Artifact Data Server Actions. Let only those exact development-mode POSTs
+ * reach the actions so their own auth boundary is exercised through the real
+ * Next.js transport. The local E2E runner opts in explicitly and binds its
+ * server to loopback; ordinary development servers do not enable the probe.
+ * Deployed builds always use NODE_ENV=production, where this exception is
+ * disabled and the page itself also returns 404.
+ */
+function isLocalArtifactDataActionProbe(req: NextRequest): boolean {
+  const isLoopbackRequest =
+    req.nextUrl.hostname === "localhost" ||
+    req.nextUrl.hostname === "127.0.0.1" ||
+    req.nextUrl.hostname === "[::1]";
+  return (
+    process.env.NODE_ENV !== "production" &&
+    process.env.ATRIUM_ARTIFACT_DATA_E2E_ACTION_PROBE === "true" &&
+    isLoopbackRequest &&
+    req.method === "POST" &&
+    req.nextUrl.pathname === "/test-user/artifact-data" &&
+    req.headers.has("next-action")
+  );
+}
+
 export default authMiddleware((req) => {
   const { nextUrl, auth } = req;
   const isLoggedIn = !!auth;
 
-  // Local authenticated-E2E harness only: after Playwright loads the protected
-  // page with a valid session, it clears the session cookie and invokes the
-  // Artifact Data Server Actions. Let only those exact development-mode POSTs
-  // reach the actions so their own auth boundary is exercised through the real
-  // Next.js transport. Deployed builds always use NODE_ENV=production, where
-  // this exception is disabled and the page itself also returns 404.
-  const isLocalArtifactDataActionProbe =
-    process.env.NODE_ENV !== "production" &&
-    req.method === "POST" &&
-    nextUrl.pathname === "/test-user/artifact-data" &&
-    req.headers.has("next-action");
-
   // Check if path is public
   const isPublicPath =
-    isLocalArtifactDataActionProbe ||
+    isLocalArtifactDataActionProbe(req) ||
     EXACT_PUBLIC_PATHS.has(nextUrl.pathname) ||
     PUBLIC_PATHS.some(
       (path) =>

--- a/middleware.ts
+++ b/middleware.ts
@@ -98,8 +98,21 @@ export default authMiddleware((req) => {
   const { nextUrl, auth } = req;
   const isLoggedIn = !!auth;
 
+  // Local authenticated-E2E harness only: after Playwright loads the protected
+  // page with a valid session, it clears the session cookie and invokes the
+  // Artifact Data Server Actions. Let only those exact development-mode POSTs
+  // reach the actions so their own auth boundary is exercised through the real
+  // Next.js transport. Deployed builds always use NODE_ENV=production, where
+  // this exception is disabled and the page itself also returns 404.
+  const isLocalArtifactDataActionProbe =
+    process.env.NODE_ENV !== "production" &&
+    req.method === "POST" &&
+    nextUrl.pathname === "/test-user/artifact-data" &&
+    req.headers.has("next-action");
+
   // Check if path is public
   const isPublicPath =
+    isLocalArtifactDataActionProbe ||
     EXACT_PUBLIC_PATHS.has(nextUrl.pathname) ||
     PUBLIC_PATHS.some(
       (path) =>

--- a/middleware.ts
+++ b/middleware.ts
@@ -93,6 +93,24 @@ const CONTENT_SECURITY_POLICY =
   "connect-src 'self' https://*.amazonaws.com wss://*.amazonaws.com https://api.anthropic.com https://api.openai.com https://apis.google.com; " +
   `frame-src ${FRAME_SRC}; ` +
   "frame-ancestors 'none';";
+const ARTIFACT_DATA_E2E_PROBE_HEADER =
+  "X-AIStudio-Artifact-Data-E2E-Probe";
+
+function isLoopbackHostname(hostname: string): boolean {
+  return (
+    hostname === "localhost" ||
+    hostname === "127.0.0.1" ||
+    hostname === "[::1]"
+  );
+}
+
+function isArtifactDataE2EProbeEnabled(req: NextRequest): boolean {
+  return (
+    process.env.NODE_ENV !== "production" &&
+    process.env.ATRIUM_ARTIFACT_DATA_E2E_ACTION_PROBE === "true" &&
+    isLoopbackHostname(req.nextUrl.hostname)
+  );
+}
 
 /**
  * Local authenticated-E2E harness only: after Playwright loads the protected
@@ -105,17 +123,18 @@ const CONTENT_SECURITY_POLICY =
  * disabled and the page itself also returns 404.
  */
 function isLocalArtifactDataActionProbe(req: NextRequest): boolean {
-  const isLoopbackRequest =
-    req.nextUrl.hostname === "localhost" ||
-    req.nextUrl.hostname === "127.0.0.1" ||
-    req.nextUrl.hostname === "[::1]";
   return (
-    process.env.NODE_ENV !== "production" &&
-    process.env.ATRIUM_ARTIFACT_DATA_E2E_ACTION_PROBE === "true" &&
-    isLoopbackRequest &&
+    isArtifactDataE2EProbeEnabled(req) &&
     req.method === "POST" &&
     req.nextUrl.pathname === "/test-user/artifact-data" &&
     req.headers.has("next-action")
+  );
+}
+
+function isArtifactDataE2EProbeHealthCheck(req: NextRequest): boolean {
+  return (
+    isArtifactDataE2EProbeEnabled(req) &&
+    req.nextUrl.pathname === "/api/healthz"
   );
 }
 
@@ -180,6 +199,11 @@ export default authMiddleware((req) => {
   response.headers.set('X-Content-Type-Options', 'nosniff');
   response.headers.set('X-Frame-Options', 'DENY');
   response.headers.set('X-XSS-Protection', '1; mode=block');
+  if (isArtifactDataE2EProbeHealthCheck(req)) {
+    // The local runner uses this marker to avoid reusing an ordinary dev server
+    // whose process environment cannot exercise the cleared-session probe.
+    response.headers.set(ARTIFACT_DATA_E2E_PROBE_HEADER, "enabled");
+  }
   // CSP is set here (not next.config) so frame-src can include the runtime-known
   // Atrium sandbox origin. Single source → no intersection with a build-time
   // policy. See next.config.mjs note (#1052).

--- a/middleware.ts
+++ b/middleware.ts
@@ -2,6 +2,10 @@ import { authMiddleware } from "@/auth";
 import { NextResponse, type NextRequest } from "next/server";
 import { getArtifactSandboxOrigin } from "@/lib/content/artifact-sandbox-config";
 import { inAppSignInCallbackUrl } from "@/lib/auth/sign-in-callback";
+import {
+  isArtifactDataE2EProbeEnabled,
+  isLocalArtifactDataActionProbe,
+} from "@/lib/auth/artifact-data-e2e-probe";
 import { isOidcProviderResumePath } from "@/lib/oauth/resume-path";
 
 // Public paths that don't require authentication
@@ -96,20 +100,14 @@ const CONTENT_SECURITY_POLICY =
 const ARTIFACT_DATA_E2E_PROBE_HEADER =
   "X-AIStudio-Artifact-Data-E2E-Probe";
 
-function isLoopbackHostname(hostname: string): boolean {
-  return (
-    hostname === "localhost" ||
-    hostname === "127.0.0.1" ||
-    hostname === "[::1]"
-  );
-}
-
-function isArtifactDataE2EProbeEnabled(req: NextRequest): boolean {
-  return (
-    process.env.NODE_ENV !== "production" &&
-    process.env.ATRIUM_ARTIFACT_DATA_E2E_ACTION_PROBE === "true" &&
-    isLoopbackHostname(req.nextUrl.hostname)
-  );
+function artifactDataE2EProbeContext(req: NextRequest) {
+  // nextUrl.hostname may be derived from Host, so loopback is defense in depth;
+  // the production NODE_ENV check is the non-negotiable deployment boundary.
+  return {
+    nodeEnv: process.env.NODE_ENV,
+    probeFlag: process.env.ATRIUM_ARTIFACT_DATA_E2E_ACTION_PROBE,
+    hostname: req.nextUrl.hostname,
+  };
 }
 
 /**
@@ -122,18 +120,21 @@ function isArtifactDataE2EProbeEnabled(req: NextRequest): boolean {
  * Deployed builds always use NODE_ENV=production, where this exception is
  * disabled and the page itself also returns 404.
  */
-function isLocalArtifactDataActionProbe(req: NextRequest): boolean {
-  return (
-    isArtifactDataE2EProbeEnabled(req) &&
-    req.method === "POST" &&
-    req.nextUrl.pathname === "/test-user/artifact-data" &&
-    req.headers.has("next-action")
-  );
+function isLocalArtifactDataActionProbeRequest(req: NextRequest): boolean {
+  const context = artifactDataE2EProbeContext(req);
+  if (!isArtifactDataE2EProbeEnabled(context)) return false;
+
+  return isLocalArtifactDataActionProbe({
+    ...context,
+    method: req.method,
+    pathname: req.nextUrl.pathname,
+    hasNextActionHeader: req.headers.has("next-action"),
+  });
 }
 
 function isArtifactDataE2EProbeHealthCheck(req: NextRequest): boolean {
   return (
-    isArtifactDataE2EProbeEnabled(req) &&
+    isArtifactDataE2EProbeEnabled(artifactDataE2EProbeContext(req)) &&
     req.nextUrl.pathname === "/api/healthz"
   );
 }
@@ -144,7 +145,7 @@ export default authMiddleware((req) => {
 
   // Check if path is public
   const isPublicPath =
-    isLocalArtifactDataActionProbe(req) ||
+    isLocalArtifactDataActionProbeRequest(req) ||
     EXACT_PUBLIC_PATHS.has(nextUrl.pathname) ||
     PUBLIC_PATHS.some(
       (path) =>

--- a/scripts/test/e2e-local.sh
+++ b/scripts/test/e2e-local.sh
@@ -203,6 +203,15 @@ port_owner_cwd() {
   lsof -a -p "$pid" -d cwd -Fn 2>/dev/null | awk '/^n/ { print substr($0, 2); exit }'
 }
 
+# A same-worktree server is reusable only when it was started by this E2E
+# runner with the action-auth probe enabled. Process environments are immutable,
+# so an ordinary dev server cannot be retrofitted with the flag after startup.
+server_has_artifact_data_probe() {
+  curl -sf --max-time 3 -D - -o /dev/null \
+    "http://localhost:$1/api/healthz" 2>/dev/null |
+    grep -Fqi 'x-aistudio-artifact-data-e2e-probe: enabled'
+}
+
 # Two passes: prefer REUSING this worktree's own healthy server anywhere in the
 # range over starting a fresh one on a lower free port (a redundant boot wastes
 # a bun install + server start). Health probes carry --max-time: a server that
@@ -211,7 +220,7 @@ port_owner_cwd() {
 REUSE=0
 CHOSEN_PORT=""
 for port in $(seq "$E2E_PORT" $((E2E_PORT + 9))); do
-  if curl -sf --max-time 3 "http://localhost:${port}/api/healthz" >/dev/null 2>&1 &&
+  if server_has_artifact_data_probe "$port" &&
      [ "$(port_owner_cwd "$port")" = "$ROOT_CANON" ]; then
     REUSE=1; CHOSEN_PORT="$port"; break
   fi
@@ -220,7 +229,11 @@ if [ "$REUSE" != "1" ]; then
   for port in $(seq "$E2E_PORT" $((E2E_PORT + 9))); do
     if curl -sf --max-time 3 "http://localhost:${port}/api/healthz" >/dev/null 2>&1; then
       owner="$(port_owner_cwd "$port")"
-      echo "e2e-local: :$port serves ${owner:-an unknown directory}, not this worktree — can't gate this push on it."
+      if [ "$owner" = "$ROOT_CANON" ]; then
+        echo "e2e-local: :$port serves this worktree without the artifact-data E2E action probe — starting an isolated server elsewhere."
+      else
+        echo "e2e-local: :$port serves ${owner:-an unknown directory}, not this worktree — can't gate this push on it."
+      fi
     elif [ -n "$(lsof -nP -iTCP:"$port" -sTCP:LISTEN -t 2>/dev/null)" ]; then
       echo "e2e-local: :$port is occupied by a non-healthy listener — skipping."
     else
@@ -280,7 +293,7 @@ else
   echo -n "e2e-local: waiting for $BASE "
   ready=0
   for attempt in $(seq 1 90); do
-    curl -sf --max-time 3 "$BASE/api/healthz" >/dev/null 2>&1 && { ready=1; echo "— ready"; break; }
+    server_has_artifact_data_probe "$E2E_PORT" && { ready=1; echo "— ready"; break; }
     echo -n "."; sleep 2
   done
   if [ "$ready" != "1" ]; then

--- a/scripts/test/e2e-local.sh
+++ b/scripts/test/e2e-local.sh
@@ -272,6 +272,7 @@ else
   AUTH_URL="$BASE" NEXT_DIST_DIR=.next-e2e \
   DATABASE_URL="${E2E_DATABASE_URL:-postgresql://postgres:postgres@localhost:5432/aistudio}" \
   ATRIUM_LOCAL_STORAGE_DIR="${E2E_ATRIUM_STORAGE_DIR:-/tmp/aistudio-atrium-e2e-${E2E_PORT}}" \
+  ATRIUM_ARTIFACT_DATA_E2E_ACTION_PROBE=true \
   API_RATE_LIMIT_DEFAULT_RPM="${E2E_API_RATE_LIMIT_RPM:-600}" \
   DB_SSL="${E2E_DB_SSL:-false}" PORT="$E2E_PORT" HOSTNAME=127.0.0.1 \
     bun run server.ts > "$SERVER_LOG" 2>&1 &

--- a/tests/e2e/atrium-artifact-data.functional.spec.ts
+++ b/tests/e2e/atrium-artifact-data.functional.spec.ts
@@ -165,10 +165,10 @@ test.describe("Atrium Artifact Data Service — real Server Action transport", (
   test("an authenticated viewer submits and lists a persisted record", async ({
     browser,
   }) => {
+    const marker = `E2E artifact-data-${crypto.randomUUID()}`;
     const context = await browser.newContext();
     let page: import("@playwright/test").Page | undefined;
     let contentId: string | undefined;
-    const marker = `E2E artifact-data-${crypto.randomUUID()}`;
 
     try {
       await authenticateContext(context, SEEDED_ADMIN_EMAIL, SEEDED_ADMIN_SUB);
@@ -204,10 +204,10 @@ test.describe("Atrium Artifact Data Service — real Server Action transport", (
   test("cleared sessions cannot submit or list through the Server Action transport", async ({
     browser,
   }) => {
+    const marker = `E2E artifact-data-unauthenticated-${crypto.randomUUID()}`;
     const context = await browser.newContext();
     let page: import("@playwright/test").Page | undefined;
     let contentId: string | undefined;
-    const marker = `E2E artifact-data-unauthenticated-${crypto.randomUUID()}`;
 
     try {
       await authenticateContext(context, SEEDED_ADMIN_EMAIL, SEEDED_ADMIN_SUB);
@@ -272,10 +272,10 @@ test.describe("Atrium Artifact Data Service — real Server Action transport", (
   test("a non-viewer receives the same NotFound mask without record data", async ({
     browser,
   }) => {
+    const title = `E2E artifact-data-private-${crypto.randomUUID()}`;
     const ownerContext = await browser.newContext();
     let ownerPage: import("@playwright/test").Page | undefined;
     let contentId: string | undefined;
-    const title = `E2E artifact-data-private-${crypto.randomUUID()}`;
 
     try {
       await authenticateContext(

--- a/tests/e2e/atrium-artifact-data.functional.spec.ts
+++ b/tests/e2e/atrium-artifact-data.functional.spec.ts
@@ -59,10 +59,10 @@ function isListedContentItem(
   return typeof item.id === "string" && typeof item.title === "string";
 }
 
-async function findArtifactIdByTitle(
+async function findArtifactIdsByTitle(
   page: import("@playwright/test").Page,
   title: string
-): Promise<string | undefined> {
+): Promise<string[] | undefined> {
   const response = await page.request.get(
     "/api/v1/content?kind=artifact&query=" + encodeURIComponent(title)
   );
@@ -76,10 +76,12 @@ async function findArtifactIdByTitle(
 
   const body = (await response.json()) as ListedContentResponse;
   if (!Array.isArray(body.data)) return undefined;
-  return body.data.find(
-    (item): item is { id: string; title: string } =>
-      isListedContentItem(item) && item.title === title
-  )?.id;
+  return body.data
+    .filter(
+      (item): item is { id: string; title: string } =>
+        isListedContentItem(item) && item.title === title
+    )
+    .map((item) => item.id);
 }
 
 async function cleanupArtifact(
@@ -91,8 +93,20 @@ async function cleanupArtifact(
   try {
     // The exact-title lookup is authoritative: a malformed create response
     // must never make teardown delete an unrelated object by returned ID.
-    const cleanupId = await findArtifactIdByTitle(page, title);
-    if (!cleanupId) return;
+    const cleanupIds = await findArtifactIdsByTitle(page, title);
+    if (!cleanupIds) return;
+    expect
+      .soft(
+        cleanupIds.length,
+        "Artifact cleanup requires one unambiguous exact-title fixture"
+      )
+      .toBe(1);
+    if (cleanupIds.length !== 1) return;
+    const [cleanupId] = cleanupIds;
+    expect
+      .soft(isUuid(cleanupId), "Exact-title fixture did not have a UUID id")
+      .toBe(true);
+    if (!isUuid(cleanupId)) return;
     if (contentId && contentId !== cleanupId) {
       expect
         .soft(
@@ -100,6 +114,7 @@ async function cleanupArtifact(
           "Create response ID did not match the exact-title fixture"
         )
         .toBe(cleanupId);
+      return;
     }
     const response = await page.request.delete("/api/v1/content/" + cleanupId);
     expect

--- a/tests/e2e/atrium-artifact-data.functional.spec.ts
+++ b/tests/e2e/atrium-artifact-data.functional.spec.ts
@@ -99,6 +99,73 @@ test.describe("Atrium Artifact Data Service — real Server Action transport", (
     }
   });
 
+  test("cleared sessions cannot submit or list through the Server Action transport", async ({
+    browser,
+  }) => {
+    const context = await browser.newContext();
+    await authenticateContext(context, SEEDED_ADMIN_EMAIL, SEEDED_ADMIN_SUB);
+    const page = await context.newPage();
+    let contentId: string | undefined;
+
+    try {
+      const marker = `artifact-data-unauthenticated-${Date.now()}`;
+      contentId = await createPrivateArtifact(page, marker);
+      await page.goto(HARNESS_PATH);
+      // The protected layout initializes NextAuth after navigation. Let that
+      // response settle before clearing cookies; otherwise an already-in-flight
+      // session response can repopulate the jar after clearCookies() returns.
+      await page.waitForLoadState("networkidle");
+
+      await page.getByTestId("artifact-data-content-id").fill(contentId);
+      await page.getByTestId("artifact-data-namespace").fill("e2e_auth_probe");
+      await page
+        .getByTestId("artifact-data-payload")
+        .fill(JSON.stringify({ marker, score: 7 }));
+
+      // Keep the already-loaded action references, but remove the identity used
+      // by the subsequent Server Action POSTs. The local-only middleware probe
+      // permits these exact POSTs through so the actions' own auth checks run.
+      await context.clearCookies();
+
+      const authCookies = (await context.cookies()).filter((cookie) =>
+        cookie.name.includes("authjs.session-token")
+      );
+      expect(authCookies).toEqual([]);
+
+      const result = page.getByTestId("artifact-data-result");
+      const submitRequestPromise = page.waitForRequest(
+        (request) => request.headers()["next-action"] !== undefined
+      );
+      await page.getByTestId("artifact-data-submit").click();
+      const submitRequest = await submitRequestPromise;
+      expect((await submitRequest.allHeaders()).cookie ?? "").not.toContain(
+        "authjs.session-token"
+      );
+      await expect(result).toContainText('"operation": "submit"');
+      await expect(result).toContainText('"isSuccess": false');
+      await expect(result).toContainText("AUTH_NO_SESSION");
+
+      await page.getByTestId("artifact-data-list").click();
+      await expect(result).toContainText('"operation": "list"');
+      await expect(result).toContainText('"isSuccess": false');
+      await expect(result).toContainText("AUTH_NO_SESSION");
+
+      // Restore the owner session only to verify that the rejected submit did
+      // not persist anything. This also gives teardown an authenticated API.
+      await authenticateContext(context, SEEDED_ADMIN_EMAIL, SEEDED_ADMIN_SUB);
+      await page.getByTestId("artifact-data-list").click();
+      await expect(result).toContainText('"operation": "list"');
+      await expect(result).toContainText('"isSuccess": true');
+      await expect(result).not.toContainText(marker);
+    } finally {
+      if (contentId) {
+        await authenticateContext(context, SEEDED_ADMIN_EMAIL, SEEDED_ADMIN_SUB);
+      }
+      await cleanupArtifact(page, contentId);
+      await context.close();
+    }
+  });
+
   test("a non-viewer receives the same NotFound mask without record data", async ({
     browser,
   }) => {

--- a/tests/e2e/atrium-artifact-data.functional.spec.ts
+++ b/tests/e2e/atrium-artifact-data.functional.spec.ts
@@ -1,0 +1,150 @@
+import { expect, test } from "./fixtures";
+import {
+  authenticateContext,
+  SEEDED_ADMIN_EMAIL,
+  SEEDED_ADMIN_SUB,
+  SEEDED_NO_CAPABILITY_EMAIL,
+  SEEDED_NO_CAPABILITY_SUB,
+} from "./helpers/session-auth";
+
+const HARNESS_PATH = "/test-user/artifact-data";
+
+interface CreatedContentResponse {
+  data?: {
+    id?: unknown;
+  };
+}
+
+async function createPrivateArtifact(
+  page: import("@playwright/test").Page,
+  title: string
+): Promise<string> {
+  const response = await page.request.post("/api/v1/content", {
+    data: {
+      kind: "artifact",
+      title,
+      body: "<p>Artifact data E2E probe</p>",
+      bodyFormat: "html",
+    },
+  });
+  expect(response.status()).toBe(201);
+  const body = (await response.json()) as CreatedContentResponse;
+  expect(typeof body.data?.id).toBe("string");
+  if (typeof body.data?.id !== "string") {
+    throw new TypeError("Artifact create response did not include an id");
+  }
+  return body.data.id;
+}
+
+async function cleanupArtifact(
+  page: import("@playwright/test").Page,
+  contentId: string | undefined
+): Promise<void> {
+  if (!contentId) return;
+  try {
+    await page.request.delete(`/api/v1/content/${contentId}`);
+  } catch {
+    // Best-effort teardown must not hide the assertion that actually failed.
+  }
+}
+
+test.describe("Atrium Artifact Data Service — route guard (always-run)", () => {
+  test("the local action harness is auth-gated", async ({ request }) => {
+    const response = await request.get(HARNESS_PATH, { maxRedirects: 0 });
+    expect(response.status()).toBe(307);
+    expect(response.headers().location).toContain("/api/auth/signin");
+  });
+});
+
+test.describe("Atrium Artifact Data Service — real Server Action transport", () => {
+  test.skip(
+    process.env.PLAYWRIGHT_AUTH_ENABLED !== "true",
+    "Requires authenticated session, local PostgreSQL, and the host :3100 dev server — see docs/guides/e2e-authenticated-testing.md"
+  );
+  test.describe.configure({ timeout: 120_000 });
+
+  test("an authenticated viewer submits and lists a persisted record", async ({
+    browser,
+  }) => {
+    const context = await browser.newContext();
+    await authenticateContext(context, SEEDED_ADMIN_EMAIL, SEEDED_ADMIN_SUB);
+    const page = await context.newPage();
+    let contentId: string | undefined;
+
+    try {
+      const marker = `artifact-data-${Date.now()}`;
+      contentId = await createPrivateArtifact(page, marker);
+      await page.goto(HARNESS_PATH);
+
+      await page.getByTestId("artifact-data-content-id").fill(contentId);
+      await page.getByTestId("artifact-data-namespace").fill("e2e_leaderboard");
+      await page
+        .getByTestId("artifact-data-payload")
+        .fill(JSON.stringify({ marker, score: 42 }));
+      await page.getByTestId("artifact-data-submit").click();
+
+      const result = page.getByTestId("artifact-data-result");
+      await expect(result).toContainText('"operation": "submit"');
+      await expect(result).toContainText('"isSuccess": true');
+
+      await page.getByTestId("artifact-data-list").click();
+      await expect(result).toContainText('"operation": "list"');
+      await expect(result).toContainText('"isSuccess": true');
+      await expect(result).toContainText(marker);
+      await expect(result).toContainText("Test User");
+      await expect(result).not.toContainText(SEEDED_ADMIN_EMAIL);
+    } finally {
+      await cleanupArtifact(page, contentId);
+      await context.close();
+    }
+  });
+
+  test("a non-viewer receives the same NotFound mask without record data", async ({
+    browser,
+  }) => {
+    const ownerContext = await browser.newContext();
+    await authenticateContext(
+      ownerContext,
+      SEEDED_ADMIN_EMAIL,
+      SEEDED_ADMIN_SUB
+    );
+    const ownerPage = await ownerContext.newPage();
+    let contentId: string | undefined;
+
+    try {
+      contentId = await createPrivateArtifact(
+        ownerPage,
+        `artifact-data-private-${Date.now()}`
+      );
+
+      const viewerContext = await browser.newContext();
+      await authenticateContext(
+        viewerContext,
+        SEEDED_NO_CAPABILITY_EMAIL,
+        SEEDED_NO_CAPABILITY_SUB
+      );
+      try {
+        const viewerPage = await viewerContext.newPage();
+        await viewerPage.goto(HARNESS_PATH);
+        await viewerPage
+          .getByTestId("artifact-data-content-id")
+          .fill(contentId);
+        await viewerPage
+          .getByTestId("artifact-data-namespace")
+          .fill("e2e_leaderboard");
+        await viewerPage.getByTestId("artifact-data-list").click();
+
+        const result = viewerPage.getByTestId("artifact-data-result");
+        await expect(result).toContainText('"operation": "list"');
+        await expect(result).toContainText('"isSuccess": false');
+        await expect(result).toContainText("CONTENT_NOT_FOUND");
+        await expect(result).not.toContainText(/forbidden|permission/i);
+      } finally {
+        await viewerContext.close();
+      }
+    } finally {
+      await cleanupArtifact(ownerPage, contentId);
+      await ownerContext.close();
+    }
+  });
+});

--- a/tests/e2e/atrium-artifact-data.functional.spec.ts
+++ b/tests/e2e/atrium-artifact-data.functional.spec.ts
@@ -42,9 +42,19 @@ async function cleanupArtifact(
 ): Promise<void> {
   if (!contentId) return;
   try {
-    await page.request.delete(`/api/v1/content/${contentId}`);
-  } catch {
-    // Best-effort teardown must not hide the assertion that actually failed.
+    const response = await page.request.delete(`/api/v1/content/${contentId}`);
+    expect
+      .soft(
+        response.ok(),
+        `Artifact cleanup returned HTTP ${response.status()} for ${contentId}`
+      )
+      .toBe(true);
+  } catch (error) {
+    // A soft assertion reports teardown failures without replacing the primary
+    // failure that sent the test into finally.
+    expect
+      .soft(error, `Artifact cleanup request threw for ${contentId}`)
+      .toBeUndefined();
   }
 }
 

--- a/tests/e2e/atrium-artifact-data.functional.spec.ts
+++ b/tests/e2e/atrium-artifact-data.functional.spec.ts
@@ -8,6 +8,8 @@ import {
 } from "./helpers/session-auth";
 
 const HARNESS_PATH = "/test-user/artifact-data";
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 interface CreatedContentResponse {
   data?: {
@@ -17,6 +19,10 @@ interface CreatedContentResponse {
 
 interface ListedContentResponse {
   data?: unknown;
+}
+
+function isUuid(value: unknown): value is string {
+  return typeof value === "string" && UUID_PATTERN.test(value);
 }
 
 async function createPrivateArtifact(
@@ -33,14 +39,14 @@ async function createPrivateArtifact(
     },
   });
   const body = (await response.json()) as CreatedContentResponse;
-  if (typeof body.data?.id === "string") {
+  if (isUuid(body.data?.id)) {
     // Teardown owns the ID before either response assertion can throw.
     onCreated(body.data.id);
   }
   expect(response.status()).toBe(201);
-  expect(typeof body.data?.id).toBe("string");
-  if (typeof body.data?.id !== "string") {
-    throw new TypeError("Artifact create response did not include an id");
+  expect(isUuid(body.data?.id)).toBe(true);
+  if (!isUuid(body.data?.id)) {
+    throw new TypeError("Artifact create response did not include a UUID id");
   }
   return body.data.id;
 }
@@ -83,8 +89,18 @@ async function cleanupArtifact(
 ): Promise<void> {
   if (!page) return;
   try {
-    const cleanupId = contentId ?? (await findArtifactIdByTitle(page, title));
+    // The exact-title lookup is authoritative: a malformed create response
+    // must never make teardown delete an unrelated object by returned ID.
+    const cleanupId = await findArtifactIdByTitle(page, title);
     if (!cleanupId) return;
+    if (contentId && contentId !== cleanupId) {
+      expect
+        .soft(
+          contentId,
+          "Create response ID did not match the exact-title fixture"
+        )
+        .toBe(cleanupId);
+    }
     const response = await page.request.delete("/api/v1/content/" + cleanupId);
     expect
       .soft(

--- a/tests/e2e/atrium-artifact-data.functional.spec.ts
+++ b/tests/e2e/atrium-artifact-data.functional.spec.ts
@@ -58,6 +58,31 @@ async function cleanupArtifact(
   }
 }
 
+async function restoreOwnerSessionForCleanup(
+  context: import("@playwright/test").BrowserContext,
+  contentId: string | undefined
+): Promise<void> {
+  if (!contentId) return;
+  try {
+    await authenticateContext(context, SEEDED_ADMIN_EMAIL, SEEDED_ADMIN_SUB);
+  } catch (error) {
+    expect
+      .soft(error, `Could not restore owner session for cleanup of ${contentId}`)
+      .toBeUndefined();
+  }
+}
+
+async function closeContextSoftly(
+  context: import("@playwright/test").BrowserContext,
+  label: string
+): Promise<void> {
+  try {
+    await context.close();
+  } catch (error) {
+    expect.soft(error, `Could not close ${label} browser context`).toBeUndefined();
+  }
+}
+
 test.describe("Atrium Artifact Data Service — route guard (always-run)", () => {
   test("the local action harness is auth-gated", async ({ request }) => {
     const response = await request.get(HARNESS_PATH, { maxRedirects: 0 });
@@ -168,11 +193,9 @@ test.describe("Atrium Artifact Data Service — real Server Action transport", (
       await expect(result).toContainText('"isSuccess": true');
       await expect(result).not.toContainText(marker);
     } finally {
-      if (contentId) {
-        await authenticateContext(context, SEEDED_ADMIN_EMAIL, SEEDED_ADMIN_SUB);
-      }
+      await restoreOwnerSessionForCleanup(context, contentId);
       await cleanupArtifact(page, contentId);
-      await context.close();
+      await closeContextSoftly(context, "cleared-session artifact-data");
     }
   });
 

--- a/tests/e2e/atrium-artifact-data.functional.spec.ts
+++ b/tests/e2e/atrium-artifact-data.functional.spec.ts
@@ -117,7 +117,7 @@ async function cleanupArtifact(
     // A soft assertion reports teardown failures without replacing the primary
     // failure that sent the test into finally.
     expect
-      .soft(error, "Artifact cleanup request threw for " + (contentId ?? title))
+      .soft(error, "Artifact cleanup request threw for " + contentId)
       .toBeUndefined();
   }
 }

--- a/tests/e2e/atrium-artifact-data.functional.spec.ts
+++ b/tests/e2e/atrium-artifact-data.functional.spec.ts
@@ -15,9 +15,14 @@ interface CreatedContentResponse {
   };
 }
 
+interface ListedContentResponse {
+  data?: unknown;
+}
+
 async function createPrivateArtifact(
   page: import("@playwright/test").Page,
-  title: string
+  title: string,
+  onCreated: (contentId: string) => void
 ): Promise<string> {
   const response = await page.request.post("/api/v1/content", {
     data: {
@@ -27,8 +32,12 @@ async function createPrivateArtifact(
       bodyFormat: "html",
     },
   });
-  expect(response.status()).toBe(201);
   const body = (await response.json()) as CreatedContentResponse;
+  if (typeof body.data?.id === "string") {
+    // Teardown owns the ID before either response assertion can throw.
+    onCreated(body.data.id);
+  }
+  expect(response.status()).toBe(201);
   expect(typeof body.data?.id).toBe("string");
   if (typeof body.data?.id !== "string") {
     throw new TypeError("Artifact create response did not include an id");
@@ -36,24 +45,61 @@ async function createPrivateArtifact(
   return body.data.id;
 }
 
+function isListedContentItem(
+  value: unknown
+): value is { id: string; title: string } {
+  if (typeof value !== "object" || value === null) return false;
+  const item = value as Record<string, unknown>;
+  return typeof item.id === "string" && typeof item.title === "string";
+}
+
+async function findArtifactIdByTitle(
+  page: import("@playwright/test").Page,
+  title: string
+): Promise<string | undefined> {
+  const response = await page.request.get(
+    "/api/v1/content?kind=artifact&query=" + encodeURIComponent(title)
+  );
+  expect
+    .soft(
+      response.ok(),
+      "Artifact fallback lookup returned HTTP " + response.status()
+    )
+    .toBe(true);
+  if (!response.ok()) return undefined;
+
+  const body = (await response.json()) as ListedContentResponse;
+  if (!Array.isArray(body.data)) return undefined;
+  return body.data.find(
+    (item): item is { id: string; title: string } =>
+      isListedContentItem(item) && item.title === title
+  )?.id;
+}
+
 async function cleanupArtifact(
   page: import("@playwright/test").Page | undefined,
-  contentId: string | undefined
+  contentId: string | undefined,
+  title: string
 ): Promise<void> {
-  if (!page || !contentId) return;
+  if (!page) return;
   try {
-    const response = await page.request.delete(`/api/v1/content/${contentId}`);
+    const cleanupId = contentId ?? (await findArtifactIdByTitle(page, title));
+    if (!cleanupId) return;
+    const response = await page.request.delete("/api/v1/content/" + cleanupId);
     expect
       .soft(
         response.ok(),
-        `Artifact cleanup returned HTTP ${response.status()} for ${contentId}`
+        "Artifact cleanup returned HTTP " +
+          response.status() +
+          " for " +
+          cleanupId
       )
       .toBe(true);
   } catch (error) {
     // A soft assertion reports teardown failures without replacing the primary
     // failure that sent the test into finally.
     expect
-      .soft(error, `Artifact cleanup request threw for ${contentId}`)
+      .soft(error, "Artifact cleanup request threw for " + (contentId ?? title))
       .toBeUndefined();
   }
 }
@@ -104,12 +150,14 @@ test.describe("Atrium Artifact Data Service — real Server Action transport", (
     const context = await browser.newContext();
     let page: import("@playwright/test").Page | undefined;
     let contentId: string | undefined;
+    const marker = `E2E artifact-data-${Date.now()}`;
 
     try {
       await authenticateContext(context, SEEDED_ADMIN_EMAIL, SEEDED_ADMIN_SUB);
       page = await context.newPage();
-      const marker = `E2E artifact-data-${Date.now()}`;
-      contentId = await createPrivateArtifact(page, marker);
+      contentId = await createPrivateArtifact(page, marker, (createdId) => {
+        contentId = createdId;
+      });
       await page.goto(HARNESS_PATH);
 
       await page.getByTestId("artifact-data-content-id").fill(contentId);
@@ -130,7 +178,7 @@ test.describe("Atrium Artifact Data Service — real Server Action transport", (
       await expect(result).toContainText("Test User");
       await expect(result).not.toContainText(SEEDED_ADMIN_EMAIL);
     } finally {
-      await cleanupArtifact(page, contentId);
+      await cleanupArtifact(page, contentId, marker);
       await closeContextSoftly(context, "happy-path artifact-data");
     }
   });
@@ -141,12 +189,14 @@ test.describe("Atrium Artifact Data Service — real Server Action transport", (
     const context = await browser.newContext();
     let page: import("@playwright/test").Page | undefined;
     let contentId: string | undefined;
+    const marker = `E2E artifact-data-unauthenticated-${Date.now()}`;
 
     try {
       await authenticateContext(context, SEEDED_ADMIN_EMAIL, SEEDED_ADMIN_SUB);
       page = await context.newPage();
-      const marker = `E2E artifact-data-unauthenticated-${Date.now()}`;
-      contentId = await createPrivateArtifact(page, marker);
+      contentId = await createPrivateArtifact(page, marker, (createdId) => {
+        contentId = createdId;
+      });
       await page.goto(HARNESS_PATH);
       // The protected layout initializes NextAuth after navigation. Let that
       // response settle before clearing cookies; otherwise an already-in-flight
@@ -196,7 +246,7 @@ test.describe("Atrium Artifact Data Service — real Server Action transport", (
       await expect(result).not.toContainText(marker);
     } finally {
       await restoreOwnerSessionForCleanup(context, contentId);
-      await cleanupArtifact(page, contentId);
+      await cleanupArtifact(page, contentId, marker);
       await closeContextSoftly(context, "cleared-session artifact-data");
     }
   });
@@ -207,6 +257,7 @@ test.describe("Atrium Artifact Data Service — real Server Action transport", (
     const ownerContext = await browser.newContext();
     let ownerPage: import("@playwright/test").Page | undefined;
     let contentId: string | undefined;
+    const title = `E2E artifact-data-private-${Date.now()}`;
 
     try {
       await authenticateContext(
@@ -215,10 +266,9 @@ test.describe("Atrium Artifact Data Service — real Server Action transport", (
         SEEDED_ADMIN_SUB
       );
       ownerPage = await ownerContext.newPage();
-      contentId = await createPrivateArtifact(
-        ownerPage,
-        `E2E artifact-data-private-${Date.now()}`
-      );
+      contentId = await createPrivateArtifact(ownerPage, title, (createdId) => {
+        contentId = createdId;
+      });
 
       const viewerContext = await browser.newContext();
       try {
@@ -246,7 +296,7 @@ test.describe("Atrium Artifact Data Service — real Server Action transport", (
         await closeContextSoftly(viewerContext, "non-viewer artifact-data");
       }
     } finally {
-      await cleanupArtifact(ownerPage, contentId);
+      await cleanupArtifact(ownerPage, contentId, title);
       await closeContextSoftly(ownerContext, "owner artifact-data");
     }
   });

--- a/tests/e2e/atrium-artifact-data.functional.spec.ts
+++ b/tests/e2e/atrium-artifact-data.functional.spec.ts
@@ -108,7 +108,7 @@ test.describe("Atrium Artifact Data Service — real Server Action transport", (
     try {
       await authenticateContext(context, SEEDED_ADMIN_EMAIL, SEEDED_ADMIN_SUB);
       page = await context.newPage();
-      const marker = `artifact-data-${Date.now()}`;
+      const marker = `E2E artifact-data-${Date.now()}`;
       contentId = await createPrivateArtifact(page, marker);
       await page.goto(HARNESS_PATH);
 
@@ -145,7 +145,7 @@ test.describe("Atrium Artifact Data Service — real Server Action transport", (
     try {
       await authenticateContext(context, SEEDED_ADMIN_EMAIL, SEEDED_ADMIN_SUB);
       page = await context.newPage();
-      const marker = `artifact-data-unauthenticated-${Date.now()}`;
+      const marker = `E2E artifact-data-unauthenticated-${Date.now()}`;
       contentId = await createPrivateArtifact(page, marker);
       await page.goto(HARNESS_PATH);
       // The protected layout initializes NextAuth after navigation. Let that
@@ -217,7 +217,7 @@ test.describe("Atrium Artifact Data Service — real Server Action transport", (
       ownerPage = await ownerContext.newPage();
       contentId = await createPrivateArtifact(
         ownerPage,
-        `artifact-data-private-${Date.now()}`
+        `E2E artifact-data-private-${Date.now()}`
       );
 
       const viewerContext = await browser.newContext();

--- a/tests/e2e/atrium-artifact-data.functional.spec.ts
+++ b/tests/e2e/atrium-artifact-data.functional.spec.ts
@@ -37,10 +37,10 @@ async function createPrivateArtifact(
 }
 
 async function cleanupArtifact(
-  page: import("@playwright/test").Page,
+  page: import("@playwright/test").Page | undefined,
   contentId: string | undefined
 ): Promise<void> {
-  if (!contentId) return;
+  if (!page || !contentId) return;
   try {
     const response = await page.request.delete(`/api/v1/content/${contentId}`);
     expect
@@ -102,11 +102,12 @@ test.describe("Atrium Artifact Data Service — real Server Action transport", (
     browser,
   }) => {
     const context = await browser.newContext();
-    await authenticateContext(context, SEEDED_ADMIN_EMAIL, SEEDED_ADMIN_SUB);
-    const page = await context.newPage();
+    let page: import("@playwright/test").Page | undefined;
     let contentId: string | undefined;
 
     try {
+      await authenticateContext(context, SEEDED_ADMIN_EMAIL, SEEDED_ADMIN_SUB);
+      page = await context.newPage();
       const marker = `artifact-data-${Date.now()}`;
       contentId = await createPrivateArtifact(page, marker);
       await page.goto(HARNESS_PATH);
@@ -138,11 +139,12 @@ test.describe("Atrium Artifact Data Service — real Server Action transport", (
     browser,
   }) => {
     const context = await browser.newContext();
-    await authenticateContext(context, SEEDED_ADMIN_EMAIL, SEEDED_ADMIN_SUB);
-    const page = await context.newPage();
+    let page: import("@playwright/test").Page | undefined;
     let contentId: string | undefined;
 
     try {
+      await authenticateContext(context, SEEDED_ADMIN_EMAIL, SEEDED_ADMIN_SUB);
+      page = await context.newPage();
       const marker = `artifact-data-unauthenticated-${Date.now()}`;
       contentId = await createPrivateArtifact(page, marker);
       await page.goto(HARNESS_PATH);
@@ -203,27 +205,28 @@ test.describe("Atrium Artifact Data Service — real Server Action transport", (
     browser,
   }) => {
     const ownerContext = await browser.newContext();
-    await authenticateContext(
-      ownerContext,
-      SEEDED_ADMIN_EMAIL,
-      SEEDED_ADMIN_SUB
-    );
-    const ownerPage = await ownerContext.newPage();
+    let ownerPage: import("@playwright/test").Page | undefined;
     let contentId: string | undefined;
 
     try {
+      await authenticateContext(
+        ownerContext,
+        SEEDED_ADMIN_EMAIL,
+        SEEDED_ADMIN_SUB
+      );
+      ownerPage = await ownerContext.newPage();
       contentId = await createPrivateArtifact(
         ownerPage,
         `artifact-data-private-${Date.now()}`
       );
 
       const viewerContext = await browser.newContext();
-      await authenticateContext(
-        viewerContext,
-        SEEDED_NO_CAPABILITY_EMAIL,
-        SEEDED_NO_CAPABILITY_SUB
-      );
       try {
+        await authenticateContext(
+          viewerContext,
+          SEEDED_NO_CAPABILITY_EMAIL,
+          SEEDED_NO_CAPABILITY_SUB
+        );
         const viewerPage = await viewerContext.newPage();
         await viewerPage.goto(HARNESS_PATH);
         await viewerPage

--- a/tests/e2e/atrium-artifact-data.functional.spec.ts
+++ b/tests/e2e/atrium-artifact-data.functional.spec.ts
@@ -17,12 +17,23 @@ interface CreatedContentResponse {
   };
 }
 
-interface ListedContentResponse {
-  data?: unknown;
+interface ContentLookupResponse {
+  data?: {
+    id?: unknown;
+    kind?: unknown;
+    title?: unknown;
+    version?: {
+      bodyInline?: unknown;
+    } | null;
+  };
 }
 
 function isUuid(value: unknown): value is string {
   return typeof value === "string" && UUID_PATTERN.test(value);
+}
+
+function artifactFixtureBody(title: string): string {
+  return `<p>Artifact data E2E probe for ${title}</p>`;
 }
 
 async function createPrivateArtifact(
@@ -34,7 +45,7 @@ async function createPrivateArtifact(
     data: {
       kind: "artifact",
       title,
-      body: "<p>Artifact data E2E probe</p>",
+      body: artifactFixtureBody(title),
       bodyFormat: "html",
     },
   });
@@ -51,79 +62,55 @@ async function createPrivateArtifact(
   return body.data.id;
 }
 
-function isListedContentItem(
-  value: unknown
-): value is { id: string; title: string } {
-  if (typeof value !== "object" || value === null) return false;
-  const item = value as Record<string, unknown>;
-  return typeof item.id === "string" && typeof item.title === "string";
-}
-
-async function findArtifactIdsByTitle(
-  page: import("@playwright/test").Page,
-  title: string
-): Promise<string[] | undefined> {
-  const response = await page.request.get(
-    "/api/v1/content?kind=artifact&query=" + encodeURIComponent(title)
-  );
-  expect
-    .soft(
-      response.ok(),
-      "Artifact fallback lookup returned HTTP " + response.status()
-    )
-    .toBe(true);
-  if (!response.ok()) return undefined;
-
-  const body = (await response.json()) as ListedContentResponse;
-  if (!Array.isArray(body.data)) return undefined;
-  return body.data
-    .filter(
-      (item): item is { id: string; title: string } =>
-        isListedContentItem(item) && item.title === title
-    )
-    .map((item) => item.id);
-}
-
 async function cleanupArtifact(
   page: import("@playwright/test").Page | undefined,
   contentId: string | undefined,
   title: string
 ): Promise<void> {
-  if (!page) return;
+  if (!page || !contentId) return;
   try {
-    // The exact-title lookup is authoritative: a malformed create response
-    // must never make teardown delete an unrelated object by returned ID.
-    const cleanupIds = await findArtifactIdsByTitle(page, title);
-    if (!cleanupIds) return;
+    expect
+      .soft(isUuid(contentId), "Captured artifact fixture ID was not a UUID")
+      .toBe(true);
+    if (!isUuid(contentId)) return;
+
+    // Never delete solely because create returned an ID. First prove that the
+    // UUID-addressed, owner-visible object carries this test's unique title and
+    // body marker. If create did not return a trustworthy UUID, the recognized
+    // `E2E ` title prefix leaves the orphan recoverable by db:cleanup:e2e.
+    const lookupResponse = await page.request.get(
+      "/api/v1/content/" + contentId
+    );
     expect
       .soft(
-        cleanupIds.length,
-        "Artifact cleanup requires one unambiguous exact-title fixture"
+        lookupResponse.ok(),
+        "Artifact cleanup lookup returned HTTP " + lookupResponse.status()
       )
-      .toBe(1);
-    if (cleanupIds.length !== 1) return;
-    const [cleanupId] = cleanupIds;
-    expect
-      .soft(isUuid(cleanupId), "Exact-title fixture did not have a UUID id")
       .toBe(true);
-    if (!isUuid(cleanupId)) return;
-    if (contentId && contentId !== cleanupId) {
-      expect
-        .soft(
-          contentId,
-          "Create response ID did not match the exact-title fixture"
-        )
-        .toBe(cleanupId);
-      return;
-    }
-    const response = await page.request.delete("/api/v1/content/" + cleanupId);
+    if (!lookupResponse.ok()) return;
+
+    const lookupBody = (await lookupResponse.json()) as ContentLookupResponse;
+    const isExpectedFixture =
+      lookupBody.data?.id === contentId &&
+      lookupBody.data.kind === "artifact" &&
+      lookupBody.data.title === title &&
+      lookupBody.data.version?.bodyInline === artifactFixtureBody(title);
+    expect
+      .soft(
+        isExpectedFixture,
+        "UUID-addressed content did not match the artifact fixture markers"
+      )
+      .toBe(true);
+    if (!isExpectedFixture) return;
+
+    const response = await page.request.delete("/api/v1/content/" + contentId);
     expect
       .soft(
         response.ok(),
         "Artifact cleanup returned HTTP " +
           response.status() +
           " for " +
-          cleanupId
+          contentId
       )
       .toBe(true);
   } catch (error) {
@@ -181,7 +168,7 @@ test.describe("Atrium Artifact Data Service — real Server Action transport", (
     const context = await browser.newContext();
     let page: import("@playwright/test").Page | undefined;
     let contentId: string | undefined;
-    const marker = `E2E artifact-data-${Date.now()}`;
+    const marker = `E2E artifact-data-${crypto.randomUUID()}`;
 
     try {
       await authenticateContext(context, SEEDED_ADMIN_EMAIL, SEEDED_ADMIN_SUB);
@@ -220,7 +207,7 @@ test.describe("Atrium Artifact Data Service — real Server Action transport", (
     const context = await browser.newContext();
     let page: import("@playwright/test").Page | undefined;
     let contentId: string | undefined;
-    const marker = `E2E artifact-data-unauthenticated-${Date.now()}`;
+    const marker = `E2E artifact-data-unauthenticated-${crypto.randomUUID()}`;
 
     try {
       await authenticateContext(context, SEEDED_ADMIN_EMAIL, SEEDED_ADMIN_SUB);
@@ -288,7 +275,7 @@ test.describe("Atrium Artifact Data Service — real Server Action transport", (
     const ownerContext = await browser.newContext();
     let ownerPage: import("@playwright/test").Page | undefined;
     let contentId: string | undefined;
-    const title = `E2E artifact-data-private-${Date.now()}`;
+    const title = `E2E artifact-data-private-${crypto.randomUUID()}`;
 
     try {
       await authenticateContext(

--- a/tests/e2e/atrium-artifact-data.functional.spec.ts
+++ b/tests/e2e/atrium-artifact-data.functional.spec.ts
@@ -130,7 +130,7 @@ test.describe("Atrium Artifact Data Service — real Server Action transport", (
       await expect(result).not.toContainText(SEEDED_ADMIN_EMAIL);
     } finally {
       await cleanupArtifact(page, contentId);
-      await context.close();
+      await closeContextSoftly(context, "happy-path artifact-data");
     }
   });
 
@@ -240,11 +240,11 @@ test.describe("Atrium Artifact Data Service — real Server Action transport", (
         await expect(result).toContainText("CONTENT_NOT_FOUND");
         await expect(result).not.toContainText(/forbidden|permission/i);
       } finally {
-        await viewerContext.close();
+        await closeContextSoftly(viewerContext, "non-viewer artifact-data");
       }
     } finally {
       await cleanupArtifact(ownerPage, contentId);
-      await ownerContext.close();
+      await closeContextSoftly(ownerContext, "owner artifact-data");
     }
   });
 });

--- a/tests/unit/atrium-artifact-data-actions.test.ts
+++ b/tests/unit/atrium-artifact-data-actions.test.ts
@@ -221,6 +221,26 @@ describe("submitArtifactRecord validation", () => {
     expect(mockInsert).not.toHaveBeenCalled();
   });
 
+  it("bounds traversal when many undefined fields serialize away", async () => {
+    const payload: Record<string, unknown> = Object.create(null) as Record<
+      string,
+      unknown
+    >;
+    for (let index = 0; index < 9_000; index += 1) {
+      payload[`field-${index}`] = undefined;
+    }
+
+    const result = await submitArtifactRecord({
+      ...validSubmitInput,
+      payload,
+    });
+
+    expect(result.isSuccess).toBe(false);
+    expect(mockGetUserRequester).not.toHaveBeenCalled();
+    expect(mockContentGet).not.toHaveBeenCalled();
+    expect(mockInsert).not.toHaveBeenCalled();
+  });
+
   it("rejects an empty content id before visibility or persistence", async () => {
     const result = await submitArtifactRecord({
       ...validSubmitInput,

--- a/tests/unit/atrium-artifact-data-actions.test.ts
+++ b/tests/unit/atrium-artifact-data-actions.test.ts
@@ -374,6 +374,17 @@ describe("submitArtifactRecord PostgreSQL JSON compatibility", () => {
     expect(mockContentGet).not.toHaveBeenCalled();
     expect(mockInsert).not.toHaveBeenCalled();
   });
+
+  it("accepts valid surrogate pairs in values and keys", async () => {
+    const result = await submitArtifactRecord({
+      ...validSubmitInput,
+      payload: { ["emoji-\uD83D\uDE00"]: "\uD83D\uDE00" },
+    });
+
+    expect(result.isSuccess).toBe(true);
+    expect(mockContentGet).toHaveBeenCalled();
+    expect(mockInsert).toHaveBeenCalled();
+  });
 });
 
 describe("listArtifactRecords", () => {

--- a/tests/unit/atrium-artifact-data-actions.test.ts
+++ b/tests/unit/atrium-artifact-data-actions.test.ts
@@ -6,6 +6,8 @@
  */
 
 import { NotFoundError } from "@/lib/content/errors";
+import type { SQL } from "drizzle-orm";
+import { PgDialect } from "drizzle-orm/pg-core";
 import type {
   ListArtifactRecordsInput,
   SubmitArtifactRecordInput,
@@ -41,7 +43,7 @@ const mockInsert = jest.fn(() => ({ values: mockValues }));
 
 const mockLimit = jest.fn();
 const mockOrderBy = jest.fn(() => ({ limit: mockLimit }));
-const mockWhere = jest.fn(() => ({ orderBy: mockOrderBy }));
+const mockWhere = jest.fn((_condition: unknown) => ({ orderBy: mockOrderBy }));
 const mockLeftJoin = jest.fn(() => ({ where: mockWhere }));
 const mockFrom = jest.fn(() => ({ leftJoin: mockLeftJoin }));
 const mockSelect = jest.fn(() => ({ from: mockFrom }));
@@ -460,6 +462,15 @@ describe("listArtifactRecords", () => {
 
     expect(result.isSuccess).toBe(true);
     expect(mockWhere).toHaveBeenCalledTimes(1);
+    const whereClause = mockWhere.mock.calls[0]?.[0] as SQL | undefined;
+    if (!whereClause) throw new Error("Expected a list query WHERE clause");
+    const rendered = new PgDialect().sqlToQuery(whereClause);
+    expect(rendered.sql).toContain('"content_data_records"."user_id" = $3');
+    expect(rendered.params).toEqual([
+      CONTENT.id,
+      validListInput.namespace,
+      REQUESTER.userId,
+    ]);
   });
 
   it("rejects an invalid scope before visibility or database access", async () => {

--- a/tests/unit/atrium-artifact-data-actions.test.ts
+++ b/tests/unit/atrium-artifact-data-actions.test.ts
@@ -181,10 +181,27 @@ describe("submitArtifactRecord", () => {
 });
 
 describe("submitArtifactRecord validation", () => {
-  it("rejects a payload over 8 KiB before persistence", async () => {
+  it("rejects an oversized ASCII payload before UTF-8 allocation", async () => {
+    const encodeSpy = jest.spyOn(TextEncoder.prototype, "encode");
+    try {
+      const result = await submitArtifactRecord({
+        ...validSubmitInput,
+        payload: { value: "x".repeat(8 * 1024) },
+      });
+
+      expect(result.isSuccess).toBe(false);
+      expect(encodeSpy).not.toHaveBeenCalled();
+      expect(mockContentGet).not.toHaveBeenCalled();
+      expect(mockInsert).not.toHaveBeenCalled();
+    } finally {
+      encodeSpy.mockRestore();
+    }
+  });
+
+  it("still applies the exact UTF-8 limit to multibyte payloads", async () => {
     const result = await submitArtifactRecord({
       ...validSubmitInput,
-      payload: { value: "x".repeat(8 * 1024) },
+      payload: { value: "€".repeat(3_000) },
     });
 
     expect(result.isSuccess).toBe(false);

--- a/tests/unit/atrium-artifact-data-actions.test.ts
+++ b/tests/unit/atrium-artifact-data-actions.test.ts
@@ -241,6 +241,7 @@ describe("submitArtifactRecord validation", () => {
   });
 
   it("bounds traversal when many undefined fields serialize away", async () => {
+    const stringifySpy = jest.spyOn(JSON, "stringify");
     const payload: Record<string, unknown> = Object.create(null) as Record<
       string,
       unknown
@@ -249,15 +250,20 @@ describe("submitArtifactRecord validation", () => {
       payload[`field-${index}`] = undefined;
     }
 
-    const result = await submitArtifactRecord({
-      ...validSubmitInput,
-      payload,
-    });
+    try {
+      const result = await submitArtifactRecord({
+        ...validSubmitInput,
+        payload,
+      });
 
-    expect(result.isSuccess).toBe(false);
-    expect(mockGetUserRequester).not.toHaveBeenCalled();
-    expect(mockContentGet).not.toHaveBeenCalled();
-    expect(mockInsert).not.toHaveBeenCalled();
+      expect(stringifySpy).not.toHaveBeenCalled();
+      expect(result.isSuccess).toBe(false);
+      expect(mockGetUserRequester).not.toHaveBeenCalled();
+      expect(mockContentGet).not.toHaveBeenCalled();
+      expect(mockInsert).not.toHaveBeenCalled();
+    } finally {
+      stringifySpy.mockRestore();
+    }
   });
 
   it("rejects an empty content id before visibility or persistence", async () => {

--- a/tests/unit/atrium-artifact-data-actions.test.ts
+++ b/tests/unit/atrium-artifact-data-actions.test.ts
@@ -406,8 +406,34 @@ describe("submitArtifactRecord PostgreSQL JSON compatibility", () => {
   });
 });
 
+describe("listArtifactRecords scope filtering", () => {
+  it("binds the caller identity for mine scope", async () => {
+    const result = await listArtifactRecords({
+      ...validListInput,
+      scope: "mine",
+    });
+
+    expect(result.isSuccess).toBe(true);
+    expect(mockWhere).toHaveBeenCalledTimes(1);
+    const whereClause = mockWhere.mock.calls[0]?.[0] as SQL | undefined;
+    if (!whereClause) throw new Error("Expected a list query WHERE clause");
+    const rendered = new PgDialect().sqlToQuery(whereClause);
+    const userIdBinding = rendered.sql.match(
+      /"content_data_records"\."user_id" = \$(\d+)/
+    );
+    if (!userIdBinding?.[1]) {
+      throw new Error("Expected a bound user_id predicate for mine scope");
+    }
+    const parameterIndex = Number.parseInt(userIdBinding[1], 10) - 1;
+    expect(rendered.params[parameterIndex]).toBe(REQUESTER.userId);
+    expect(rendered.params).toEqual(
+      expect.arrayContaining([CONTENT.id, validListInput.namespace])
+    );
+  });
+});
+
 describe("listArtifactRecords", () => {
-  it("returns server-resolved names without exposing email identifiers", async () => {
+  it("returns server-resolved names without exposing user identifiers", async () => {
     mockLimit.mockResolvedValueOnce([
       {
         id: "record-2",
@@ -435,14 +461,12 @@ describe("listArtifactRecords", () => {
     expect(result.data.records).toEqual([
       {
         id: "record-2",
-        userId: 7,
         displayName: "Ada Lovelace",
         payload: { score: 84 },
         createdAt: "2026-08-01T20:05:00.000Z",
       },
       {
         id: "record-1",
-        userId: 8,
         displayName: "Unknown user",
         payload: { score: 42 },
         createdAt: CREATED_AT.toISOString(),
@@ -469,25 +493,6 @@ describe("listArtifactRecords", () => {
 
     expect(result.isSuccess).toBe(true);
     expect(mockLimit).toHaveBeenCalledWith(200);
-  });
-
-  it("supports the caller-only mine scope", async () => {
-    const result = await listArtifactRecords({
-      ...validListInput,
-      scope: "mine",
-    });
-
-    expect(result.isSuccess).toBe(true);
-    expect(mockWhere).toHaveBeenCalledTimes(1);
-    const whereClause = mockWhere.mock.calls[0]?.[0] as SQL | undefined;
-    if (!whereClause) throw new Error("Expected a list query WHERE clause");
-    const rendered = new PgDialect().sqlToQuery(whereClause);
-    expect(rendered.sql).toContain('"content_data_records"."user_id" = $3');
-    expect(rendered.params).toEqual([
-      CONTENT.id,
-      validListInput.namespace,
-      REQUESTER.userId,
-    ]);
   });
 
   it("rejects an invalid scope before visibility or database access", async () => {

--- a/tests/unit/atrium-artifact-data-actions.test.ts
+++ b/tests/unit/atrium-artifact-data-actions.test.ts
@@ -161,7 +161,7 @@ describe("submitArtifactRecord", () => {
     );
     expect(mockValues.mock.calls[0][0]).not.toHaveProperty("userId", 999);
     expect(mockConsumeRateLimit).toHaveBeenCalledWith(
-      expect.objectContaining({ identifier: "user:7" })
+      expect.objectContaining({ identifier: "user-sub:cognito-user-7" })
     );
   });
 
@@ -285,6 +285,7 @@ describe("submitArtifactRecord", () => {
       expect.objectContaining({ code: "BIZ_RATE_LIMIT_EXCEEDED" })
     );
     expect(result.message).toMatch(/too many requests/i);
+    expect(mockGetUserRequester).not.toHaveBeenCalled();
     expect(mockContentGet).not.toHaveBeenCalled();
     expect(mockInsert).not.toHaveBeenCalled();
   });

--- a/tests/unit/atrium-artifact-data-actions.test.ts
+++ b/tests/unit/atrium-artifact-data-actions.test.ts
@@ -359,6 +359,24 @@ describe("submitArtifactRecord validation", () => {
   });
 });
 
+describe("submitArtifactRecord original string bounds", () => {
+  it("bounds omitted object-key scanning by original string length", async () => {
+    const payload = {
+      ["x".repeat(8 * 1024 + 1)]: undefined,
+    };
+
+    const result = await submitArtifactRecord({
+      ...validSubmitInput,
+      payload,
+    });
+
+    expect(result.isSuccess).toBe(false);
+    expect(mockGetUserRequester).not.toHaveBeenCalled();
+    expect(mockContentGet).not.toHaveBeenCalled();
+    expect(mockInsert).not.toHaveBeenCalled();
+  });
+});
+
 describe("artifact content id PostgreSQL compatibility", () => {
   it.each([
     ["NUL", `artifact\u0000slug`],

--- a/tests/unit/atrium-artifact-data-actions.test.ts
+++ b/tests/unit/atrium-artifact-data-actions.test.ts
@@ -178,7 +178,9 @@ describe("submitArtifactRecord", () => {
       expect(mockInsert).not.toHaveBeenCalled();
     }
   );
+});
 
+describe("submitArtifactRecord validation", () => {
   it("rejects a payload over 8 KiB before persistence", async () => {
     const result = await submitArtifactRecord({
       ...validSubmitInput,
@@ -204,6 +206,21 @@ describe("submitArtifactRecord", () => {
     expect(mockInsert).not.toHaveBeenCalled();
   });
 
+  it.each([
+    ["Map", new Map([["score", 42]])],
+    ["nested Set", { scores: new Set([42]) }],
+  ])("rejects a non-JSON %s payload without lossy serialization", async (_label, payload) => {
+    const result = await submitArtifactRecord({
+      ...validSubmitInput,
+      payload: payload as unknown as Record<string, unknown>,
+    });
+
+    expect(result.isSuccess).toBe(false);
+    expect(mockGetUserRequester).not.toHaveBeenCalled();
+    expect(mockContentGet).not.toHaveBeenCalled();
+    expect(mockInsert).not.toHaveBeenCalled();
+  });
+
   it("rejects an empty content id before visibility or persistence", async () => {
     const result = await submitArtifactRecord({
       ...validSubmitInput,
@@ -211,6 +228,18 @@ describe("submitArtifactRecord", () => {
     });
 
     expect(result.isSuccess).toBe(false);
+    expect(mockContentGet).not.toHaveBeenCalled();
+    expect(mockInsert).not.toHaveBeenCalled();
+  });
+
+  it("rejects a content id over the supported 200-character bound", async () => {
+    const result = await submitArtifactRecord({
+      ...validSubmitInput,
+      contentId: "a".repeat(201),
+    });
+
+    expect(result.isSuccess).toBe(false);
+    expect(mockGetUserRequester).not.toHaveBeenCalled();
     expect(mockContentGet).not.toHaveBeenCalled();
     expect(mockInsert).not.toHaveBeenCalled();
   });
@@ -339,6 +368,12 @@ describe("listArtifactRecords", () => {
       "polyatomic-ion-mahjong"
     );
     expect(mockLimit).toHaveBeenCalledWith(50);
+    expect(mockConsumeRateLimit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        identifier: "user-sub:cognito-user-7",
+        namespace: "atrium-artifact-record-list",
+      })
+    );
   });
 
   it("clamps a requested limit above 200", async () => {
@@ -368,6 +403,38 @@ describe("listArtifactRecords", () => {
     });
 
     expect(result.isSuccess).toBe(false);
+    expect(mockContentGet).not.toHaveBeenCalled();
+    expect(mockSelect).not.toHaveBeenCalled();
+  });
+
+  it("rejects an oversized content id before requester or visibility lookups", async () => {
+    const result = await listArtifactRecords({
+      ...validListInput,
+      contentId: "a".repeat(201),
+    });
+
+    expect(result.isSuccess).toBe(false);
+    expect(mockGetUserRequester).not.toHaveBeenCalled();
+    expect(mockContentGet).not.toHaveBeenCalled();
+    expect(mockSelect).not.toHaveBeenCalled();
+  });
+
+  it("refuses an over-limit reader before requester or database lookups", async () => {
+    mockConsumeRateLimit.mockReturnValueOnce({
+      allowed: false,
+      retryAfterSeconds: 10,
+      remaining: 0,
+      resetTime: Date.now() + 10_000,
+    });
+
+    const result = await listArtifactRecords(validListInput);
+
+    expect(result.isSuccess).toBe(false);
+    if (result.isSuccess) return;
+    expect(result.error).toEqual(
+      expect.objectContaining({ code: "BIZ_RATE_LIMIT_EXCEEDED" })
+    );
+    expect(mockGetUserRequester).not.toHaveBeenCalled();
     expect(mockContentGet).not.toHaveBeenCalled();
     expect(mockSelect).not.toHaveBeenCalled();
   });

--- a/tests/unit/atrium-artifact-data-actions.test.ts
+++ b/tests/unit/atrium-artifact-data-actions.test.ts
@@ -271,8 +271,13 @@ describe("submitArtifactRecord", () => {
       remaining: 0,
       resetTime: Date.now() + 30_000,
     });
+    const circularPayload: Record<string, unknown> = {};
+    circularPayload.self = circularPayload;
 
-    const result = await submitArtifactRecord(validSubmitInput);
+    const result = await submitArtifactRecord({
+      ...validSubmitInput,
+      payload: circularPayload,
+    });
 
     expect(result.isSuccess).toBe(false);
     if (result.isSuccess) return;

--- a/tests/unit/atrium-artifact-data-actions.test.ts
+++ b/tests/unit/atrium-artifact-data-actions.test.ts
@@ -187,6 +187,17 @@ describe("submitArtifactRecord", () => {
     expect(mockInsert).not.toHaveBeenCalled();
   });
 
+  it("rejects an empty content id before visibility or persistence", async () => {
+    const result = await submitArtifactRecord({
+      ...validSubmitInput,
+      contentId: "   ",
+    });
+
+    expect(result.isSuccess).toBe(false);
+    expect(mockContentGet).not.toHaveBeenCalled();
+    expect(mockInsert).not.toHaveBeenCalled();
+  });
+
   it.each(["Leaderboard", "two words", "", "a".repeat(65)])(
     "rejects invalid namespace %p",
     async (namespace) => {
@@ -223,11 +234,11 @@ describe("submitArtifactRecord", () => {
 
     expect(result.isSuccess).toBe(false);
     expect(result.message).not.toMatch(/forbidden|permission/i);
-    expect(mockConsumeRateLimit).not.toHaveBeenCalled();
+    expect(mockConsumeRateLimit).toHaveBeenCalledTimes(1);
     expect(mockInsert).not.toHaveBeenCalled();
   });
 
-  it("exercises the per-user rate-limit refusal without writing", async () => {
+  it("refuses an over-limit caller before visibility or persistence", async () => {
     mockConsumeRateLimit.mockReturnValueOnce({
       allowed: false,
       retryAfterSeconds: 30,
@@ -243,7 +254,7 @@ describe("submitArtifactRecord", () => {
       expect.objectContaining({ code: "BIZ_RATE_LIMIT_EXCEEDED" })
     );
     expect(result.message).toMatch(/too many requests/i);
-    expect(mockContentGet).toHaveBeenCalledTimes(1);
+    expect(mockContentGet).not.toHaveBeenCalled();
     expect(mockInsert).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/atrium-artifact-data-actions.test.ts
+++ b/tests/unit/atrium-artifact-data-actions.test.ts
@@ -1,0 +1,356 @@
+/**
+ * Security and bounds coverage for the Atrium Artifact Data Service actions
+ * (#1517). Database, session, visibility, and rate-limit collaborators are
+ * mocked so these tests exercise the action boundary and query inputs without a
+ * shared database.
+ */
+
+import { NotFoundError } from "@/lib/content/errors";
+import type {
+  ListArtifactRecordsInput,
+  SubmitArtifactRecordInput,
+} from "@/actions/db/atrium/artifact-data";
+
+const mockGetServerSession = jest.fn();
+jest.mock("@/lib/auth/server-session", () => ({
+  getServerSession: () => mockGetServerSession(),
+}));
+
+const mockGetUserRequester = jest.fn();
+jest.mock("@/actions/db/atrium/requester", () => ({
+  getUserRequester: (...args: unknown[]) => mockGetUserRequester(...args),
+}));
+
+const mockContentGet = jest.fn();
+jest.mock("@/lib/content", () => ({
+  contentService: {
+    get: (...args: unknown[]) => mockContentGet(...args),
+  },
+}));
+
+const mockConsumeRateLimit = jest.fn();
+jest.mock("@/lib/rate-limit", () => ({
+  consumeRateLimit: (...args: unknown[]) => mockConsumeRateLimit(...args),
+}));
+
+const mockReturning = jest.fn();
+const mockValues = jest.fn((_values: Record<string, unknown>) => ({
+  returning: mockReturning,
+}));
+const mockInsert = jest.fn(() => ({ values: mockValues }));
+
+const mockLimit = jest.fn();
+const mockOrderBy = jest.fn(() => ({ limit: mockLimit }));
+const mockWhere = jest.fn(() => ({ orderBy: mockOrderBy }));
+const mockLeftJoin = jest.fn(() => ({ where: mockWhere }));
+const mockFrom = jest.fn(() => ({ leftJoin: mockLeftJoin }));
+const mockSelect = jest.fn(() => ({ from: mockFrom }));
+
+interface FakeDb {
+  insert: typeof mockInsert;
+  select: typeof mockSelect;
+}
+
+const fakeDb: FakeDb = {
+  insert: mockInsert,
+  select: mockSelect,
+};
+
+type QueryCallback = (db: FakeDb) => unknown;
+const mockExecuteQuery = jest.fn(
+  async (query: QueryCallback, _operation: string) => query(fakeDb)
+);
+jest.mock("@/lib/db/drizzle-client", () => ({
+  executeQuery: (query: QueryCallback, operation: string) =>
+    mockExecuteQuery(query, operation),
+}));
+
+jest.mock("@/lib/logger", () => ({
+  createLogger: () => ({
+    info: jest.fn(),
+    debug: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  }),
+  generateRequestId: () => "artifact-data-request-id",
+  getLogContext: () => ({
+    requestId: "artifact-data-request-id",
+    userId: undefined,
+  }),
+  sanitizeForLogging: (value: unknown) => value,
+  startTimer: () => jest.fn(),
+}));
+
+import {
+  listArtifactRecords,
+  submitArtifactRecord,
+} from "@/actions/db/atrium/artifact-data";
+
+const SESSION = { sub: "cognito-user-7" };
+const REQUESTER = {
+  kind: "user" as const,
+  userId: 7,
+  roles: ["student"],
+  building: null,
+  department: null,
+  gradeLevels: null,
+  groups: [],
+  isAdmin: false,
+};
+const CONTENT = { id: "11111111-1111-4111-8111-111111111111" };
+const CREATED_AT = new Date("2026-08-01T20:00:00.000Z");
+
+const validSubmitInput: SubmitArtifactRecordInput = {
+  contentId: "polyatomic-ion-mahjong",
+  namespace: "leaderboard",
+  payload: { difficulty: "hard", score: 42 },
+};
+
+const validListInput: ListArtifactRecordsInput = {
+  contentId: "polyatomic-ion-mahjong",
+  namespace: "leaderboard",
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockGetServerSession.mockResolvedValue(SESSION);
+  mockGetUserRequester.mockResolvedValue(REQUESTER);
+  mockContentGet.mockResolvedValue(CONTENT);
+  mockConsumeRateLimit.mockReturnValue({
+    allowed: true,
+    retryAfterSeconds: 0,
+    remaining: 119,
+    resetTime: Date.now() + 60_000,
+  });
+  mockReturning.mockResolvedValue([
+    { id: "record-1", createdAt: CREATED_AT },
+  ]);
+  mockLimit.mockResolvedValue([]);
+});
+
+describe("submitArtifactRecord", () => {
+  it("persists a viewable record with canonical content and session user ids", async () => {
+    const forgedInput = {
+      ...validSubmitInput,
+      userId: 999,
+    } as SubmitArtifactRecordInput;
+
+    const result = await submitArtifactRecord(forgedInput);
+
+    expect(result).toEqual({
+      isSuccess: true,
+      message: "Artifact record submitted",
+      data: {
+        id: "record-1",
+        createdAt: CREATED_AT.toISOString(),
+      },
+    });
+    expect(mockContentGet).toHaveBeenCalledWith(
+      REQUESTER,
+      "polyatomic-ion-mahjong"
+    );
+    expect(mockValues).toHaveBeenCalledWith(
+      expect.objectContaining({
+        contentId: CONTENT.id,
+        namespace: "leaderboard",
+        userId: REQUESTER.userId,
+      })
+    );
+    expect(mockValues.mock.calls[0][0]).not.toHaveProperty("userId", 999);
+    expect(mockConsumeRateLimit).toHaveBeenCalledWith(
+      expect.objectContaining({ identifier: "user:7" })
+    );
+  });
+
+  it.each(["userId", "user_id"])(
+    "rejects reserved payload identity key %s",
+    async (key) => {
+      const result = await submitArtifactRecord({
+        ...validSubmitInput,
+        payload: { score: 42, [key]: 999 },
+      });
+
+      expect(result.isSuccess).toBe(false);
+      expect(mockContentGet).not.toHaveBeenCalled();
+      expect(mockInsert).not.toHaveBeenCalled();
+    }
+  );
+
+  it("rejects a payload over 8 KiB before persistence", async () => {
+    const result = await submitArtifactRecord({
+      ...validSubmitInput,
+      payload: { value: "x".repeat(8 * 1024) },
+    });
+
+    expect(result.isSuccess).toBe(false);
+    expect(mockContentGet).not.toHaveBeenCalled();
+    expect(mockInsert).not.toHaveBeenCalled();
+  });
+
+  it.each(["Leaderboard", "two words", "", "a".repeat(65)])(
+    "rejects invalid namespace %p",
+    async (namespace) => {
+      const result = await submitArtifactRecord({
+        ...validSubmitInput,
+        namespace,
+      });
+
+      expect(result.isSuccess).toBe(false);
+      expect(mockInsert).not.toHaveBeenCalled();
+    }
+  );
+
+  it("rejects an unauthenticated call before visibility or database access", async () => {
+    mockGetServerSession.mockResolvedValueOnce(null);
+
+    const result = await submitArtifactRecord(validSubmitInput);
+
+    expect(result.isSuccess).toBe(false);
+    expect(result.message).toMatch(/sign in|authenticated|session/i);
+    expect(mockGetUserRequester).not.toHaveBeenCalled();
+    expect(mockContentGet).not.toHaveBeenCalled();
+    expect(mockInsert).not.toHaveBeenCalled();
+  });
+
+  it("returns a 404-style failure for content the user cannot view", async () => {
+    mockContentGet.mockRejectedValueOnce(
+      new NotFoundError("Content not found", {
+        idOrSlug: validSubmitInput.contentId,
+      })
+    );
+
+    const result = await submitArtifactRecord(validSubmitInput);
+
+    expect(result.isSuccess).toBe(false);
+    expect(result.message).not.toMatch(/forbidden|permission/i);
+    expect(mockConsumeRateLimit).not.toHaveBeenCalled();
+    expect(mockInsert).not.toHaveBeenCalled();
+  });
+
+  it("exercises the per-user rate-limit refusal without writing", async () => {
+    mockConsumeRateLimit.mockReturnValueOnce({
+      allowed: false,
+      retryAfterSeconds: 30,
+      remaining: 0,
+      resetTime: Date.now() + 30_000,
+    });
+
+    const result = await submitArtifactRecord(validSubmitInput);
+
+    expect(result.isSuccess).toBe(false);
+    if (result.isSuccess) return;
+    expect(result.error).toEqual(
+      expect.objectContaining({ code: "BIZ_RATE_LIMIT_EXCEEDED" })
+    );
+    expect(result.message).toMatch(/too many requests/i);
+    expect(mockContentGet).toHaveBeenCalledTimes(1);
+    expect(mockInsert).not.toHaveBeenCalled();
+  });
+});
+
+describe("listArtifactRecords", () => {
+  it("returns newest records with server-resolved display names", async () => {
+    mockLimit.mockResolvedValueOnce([
+      {
+        id: "record-2",
+        userId: 7,
+        payload: { score: 84 },
+        createdAt: new Date("2026-08-01T20:05:00.000Z"),
+        userFirstName: "Ada",
+        userLastName: "Lovelace",
+        userEmail: "ada@example.com",
+      },
+      {
+        id: "record-1",
+        userId: 8,
+        payload: { score: 42 },
+        createdAt: CREATED_AT,
+        userFirstName: null,
+        userLastName: null,
+        userEmail: "student@example.com",
+      },
+    ]);
+
+    const result = await listArtifactRecords(validListInput);
+
+    expect(result.isSuccess).toBe(true);
+    if (!result.isSuccess) return;
+    expect(result.data.records).toEqual([
+      {
+        id: "record-2",
+        userId: 7,
+        displayName: "Ada Lovelace",
+        payload: { score: 84 },
+        createdAt: "2026-08-01T20:05:00.000Z",
+      },
+      {
+        id: "record-1",
+        userId: 8,
+        displayName: "student",
+        payload: { score: 42 },
+        createdAt: CREATED_AT.toISOString(),
+      },
+    ]);
+    expect(mockContentGet).toHaveBeenCalledWith(
+      REQUESTER,
+      "polyatomic-ion-mahjong"
+    );
+    expect(mockLimit).toHaveBeenCalledWith(50);
+  });
+
+  it("clamps a requested limit above 200", async () => {
+    const result = await listArtifactRecords({
+      ...validListInput,
+      limit: 1000,
+    });
+
+    expect(result.isSuccess).toBe(true);
+    expect(mockLimit).toHaveBeenCalledWith(200);
+  });
+
+  it("supports the caller-only mine scope", async () => {
+    const result = await listArtifactRecords({
+      ...validListInput,
+      scope: "mine",
+    });
+
+    expect(result.isSuccess).toBe(true);
+    expect(mockWhere).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects an invalid scope before visibility or database access", async () => {
+    const result = await listArtifactRecords({
+      ...validListInput,
+      scope: "someone-else" as "mine",
+    });
+
+    expect(result.isSuccess).toBe(false);
+    expect(mockContentGet).not.toHaveBeenCalled();
+    expect(mockSelect).not.toHaveBeenCalled();
+  });
+
+  it("rejects an unauthenticated call", async () => {
+    mockGetServerSession.mockResolvedValueOnce(null);
+
+    const result = await listArtifactRecords(validListInput);
+
+    expect(result.isSuccess).toBe(false);
+    expect(result.message).toMatch(/sign in|authenticated|session/i);
+    expect(mockContentGet).not.toHaveBeenCalled();
+    expect(mockSelect).not.toHaveBeenCalled();
+  });
+
+  it("returns a 404-style failure for content the user cannot view", async () => {
+    mockContentGet.mockRejectedValueOnce(
+      new NotFoundError("Content not found", {
+        idOrSlug: validListInput.contentId,
+      })
+    );
+
+    const result = await listArtifactRecords(validListInput);
+
+    expect(result.isSuccess).toBe(false);
+    expect(result.message).not.toMatch(/forbidden|permission/i);
+    expect(mockSelect).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/atrium-artifact-data-actions.test.ts
+++ b/tests/unit/atrium-artifact-data-actions.test.ts
@@ -359,6 +359,23 @@ describe("submitArtifactRecord validation", () => {
   });
 });
 
+describe("artifact content id PostgreSQL compatibility", () => {
+  it.each([
+    ["NUL", `artifact\u0000slug`],
+    ["unpaired surrogate", `artifact\uD800slug`],
+  ])("rejects a content id containing %s", async (_label, contentId) => {
+    const result = await submitArtifactRecord({
+      ...validSubmitInput,
+      contentId,
+    });
+
+    expect(result.isSuccess).toBe(false);
+    expect(mockGetUserRequester).not.toHaveBeenCalled();
+    expect(mockContentGet).not.toHaveBeenCalled();
+    expect(mockInsert).not.toHaveBeenCalled();
+  });
+});
+
 describe("submitArtifactRecord PostgreSQL JSON compatibility", () => {
   it.each([
     ["NUL string value", { value: "before\u0000after" }],
@@ -488,6 +505,18 @@ describe("listArtifactRecords", () => {
     const result = await listArtifactRecords({
       ...validListInput,
       contentId: "a".repeat(201),
+    });
+
+    expect(result.isSuccess).toBe(false);
+    expect(mockGetUserRequester).not.toHaveBeenCalled();
+    expect(mockContentGet).not.toHaveBeenCalled();
+    expect(mockSelect).not.toHaveBeenCalled();
+  });
+
+  it("rejects a NUL-bearing content id before requester or database access", async () => {
+    const result = await listArtifactRecords({
+      ...validListInput,
+      contentId: `artifact\u0000slug`,
     });
 
     expect(result.isSuccess).toBe(false);

--- a/tests/unit/atrium-artifact-data-actions.test.ts
+++ b/tests/unit/atrium-artifact-data-actions.test.ts
@@ -357,6 +357,25 @@ describe("submitArtifactRecord validation", () => {
   });
 });
 
+describe("submitArtifactRecord PostgreSQL JSON compatibility", () => {
+  it.each([
+    ["NUL string value", { value: "before\u0000after" }],
+    ["NUL object key", { ["before\u0000after"]: 42 }],
+    ["unpaired high surrogate", { value: "\uD800" }],
+    ["unpaired low-surrogate key", { ["\uDC00"]: 42 }],
+  ])("rejects PostgreSQL-incompatible %s", async (_label, payload) => {
+    const result = await submitArtifactRecord({
+      ...validSubmitInput,
+      payload,
+    });
+
+    expect(result.isSuccess).toBe(false);
+    expect(mockGetUserRequester).not.toHaveBeenCalled();
+    expect(mockContentGet).not.toHaveBeenCalled();
+    expect(mockInsert).not.toHaveBeenCalled();
+  });
+});
+
 describe("listArtifactRecords", () => {
   it("returns server-resolved names without exposing email identifiers", async () => {
     mockLimit.mockResolvedValueOnce([

--- a/tests/unit/atrium-artifact-data-actions.test.ts
+++ b/tests/unit/atrium-artifact-data-actions.test.ts
@@ -369,6 +369,29 @@ describe("submitArtifactRecord original string bounds", () => {
     expect(mockContentGet).not.toHaveBeenCalled();
     expect(mockInsert).not.toHaveBeenCalled();
   });
+
+  it("bounds repeated-reference expansion before serialization", async () => {
+    const stringifySpy = jest.spyOn(JSON, "stringify");
+    let repeated: Record<string, unknown> = { leaf: true };
+    for (let depth = 0; depth < 14; depth += 1) {
+      repeated = { left: repeated, right: repeated };
+    }
+
+    try {
+      const result = await submitArtifactRecord({
+        ...validSubmitInput,
+        payload: { repeated },
+      });
+
+      expect(stringifySpy).not.toHaveBeenCalled();
+      expect(result.isSuccess).toBe(false);
+      expect(mockGetUserRequester).not.toHaveBeenCalled();
+      expect(mockContentGet).not.toHaveBeenCalled();
+      expect(mockInsert).not.toHaveBeenCalled();
+    } finally {
+      stringifySpy.mockRestore();
+    }
+  });
 });
 
 describe("artifact content id validation", () => {

--- a/tests/unit/atrium-artifact-data-actions.test.ts
+++ b/tests/unit/atrium-artifact-data-actions.test.ts
@@ -97,7 +97,10 @@ const REQUESTER = {
   groups: [],
   isAdmin: false,
 };
-const CONTENT = { id: "11111111-1111-4111-8111-111111111111" };
+const CONTENT = {
+  id: "11111111-1111-4111-8111-111111111111",
+  kind: "artifact",
+};
 const CREATED_AT = new Date("2026-08-01T20:00:00.000Z");
 
 const validSubmitInput: SubmitArtifactRecordInput = {
@@ -187,6 +190,20 @@ describe("submitArtifactRecord", () => {
     expect(mockInsert).not.toHaveBeenCalled();
   });
 
+  it("rejects an object that serializes to a JSON scalar", async () => {
+    const result = await submitArtifactRecord({
+      ...validSubmitInput,
+      payload: new Date("2026-08-01T20:00:00.000Z") as unknown as Record<
+        string,
+        unknown
+      >,
+    });
+
+    expect(result.isSuccess).toBe(false);
+    expect(mockContentGet).not.toHaveBeenCalled();
+    expect(mockInsert).not.toHaveBeenCalled();
+  });
+
   it("rejects an empty content id before visibility or persistence", async () => {
     const result = await submitArtifactRecord({
       ...validSubmitInput,
@@ -235,6 +252,15 @@ describe("submitArtifactRecord", () => {
     expect(result.isSuccess).toBe(false);
     expect(result.message).not.toMatch(/forbidden|permission/i);
     expect(mockConsumeRateLimit).toHaveBeenCalledTimes(1);
+    expect(mockInsert).not.toHaveBeenCalled();
+  });
+
+  it("rejects a viewable document before persistence", async () => {
+    mockContentGet.mockResolvedValueOnce({ ...CONTENT, kind: "document" });
+
+    const result = await submitArtifactRecord(validSubmitInput);
+
+    expect(result.isSuccess).toBe(false);
     expect(mockInsert).not.toHaveBeenCalled();
   });
 
@@ -362,6 +388,15 @@ describe("listArtifactRecords", () => {
 
     expect(result.isSuccess).toBe(false);
     expect(result.message).not.toMatch(/forbidden|permission/i);
+    expect(mockSelect).not.toHaveBeenCalled();
+  });
+
+  it("rejects listing records for a viewable document", async () => {
+    mockContentGet.mockResolvedValueOnce({ ...CONTENT, kind: "document" });
+
+    const result = await listArtifactRecords(validListInput);
+
+    expect(result.isSuccess).toBe(false);
     expect(mockSelect).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/atrium-artifact-data-actions.test.ts
+++ b/tests/unit/atrium-artifact-data-actions.test.ts
@@ -341,7 +341,7 @@ describe("submitArtifactRecord validation", () => {
 });
 
 describe("listArtifactRecords", () => {
-  it("returns newest records with server-resolved display names", async () => {
+  it("returns server-resolved names without exposing email identifiers", async () => {
     mockLimit.mockResolvedValueOnce([
       {
         id: "record-2",
@@ -350,7 +350,6 @@ describe("listArtifactRecords", () => {
         createdAt: new Date("2026-08-01T20:05:00.000Z"),
         userFirstName: "Ada",
         userLastName: "Lovelace",
-        userEmail: "ada@example.com",
       },
       {
         id: "record-1",
@@ -378,7 +377,7 @@ describe("listArtifactRecords", () => {
       {
         id: "record-1",
         userId: 8,
-        displayName: "student",
+        displayName: "Unknown user",
         payload: { score: 42 },
         createdAt: CREATED_AT.toISOString(),
       },

--- a/tests/unit/atrium-artifact-data-actions.test.ts
+++ b/tests/unit/atrium-artifact-data-actions.test.ts
@@ -271,18 +271,6 @@ describe("submitArtifactRecord validation", () => {
     expect(mockInsert).not.toHaveBeenCalled();
   });
 
-  it("rejects a content id over the supported 200-character bound", async () => {
-    const result = await submitArtifactRecord({
-      ...validSubmitInput,
-      contentId: "a".repeat(201),
-    });
-
-    expect(result.isSuccess).toBe(false);
-    expect(mockGetUserRequester).not.toHaveBeenCalled();
-    expect(mockContentGet).not.toHaveBeenCalled();
-    expect(mockInsert).not.toHaveBeenCalled();
-  });
-
   it.each(["Leaderboard", "two words", "", "a".repeat(65)])(
     "rejects invalid namespace %p",
     async (namespace) => {
@@ -377,7 +365,24 @@ describe("submitArtifactRecord original string bounds", () => {
   });
 });
 
-describe("artifact content id PostgreSQL compatibility", () => {
+describe("artifact content id validation", () => {
+  it("rejects an oversized raw content id before trimming it", async () => {
+    const trimSpy = jest.spyOn(String.prototype, "trim");
+    try {
+      const result = await submitArtifactRecord({
+        ...validSubmitInput,
+        contentId: `artifact${" ".repeat(201)}`,
+      });
+      expect(trimSpy).not.toHaveBeenCalled();
+      expect(result.isSuccess).toBe(false);
+      expect(mockGetUserRequester).not.toHaveBeenCalled();
+      expect(mockContentGet).not.toHaveBeenCalled();
+      expect(mockInsert).not.toHaveBeenCalled();
+    } finally {
+      trimSpy.mockRestore();
+    }
+  });
+
   it.each([
     ["NUL", `artifact\u0000slug`],
     ["unpaired surrogate", `artifact\uD800slug`],

--- a/tests/unit/lib/auth/artifact-data-e2e-probe.test.ts
+++ b/tests/unit/lib/auth/artifact-data-e2e-probe.test.ts
@@ -1,0 +1,56 @@
+import {
+  isArtifactDataE2EProbeEnabled,
+  isLocalArtifactDataActionProbe,
+} from "@/lib/auth/artifact-data-e2e-probe";
+
+const enabledContext = {
+  nodeEnv: "development",
+  probeFlag: "true",
+  hostname: "localhost",
+};
+
+const actionRequest = {
+  ...enabledContext,
+  method: "POST",
+  pathname: "/test-user/artifact-data",
+  hasNextActionHeader: true,
+};
+
+describe("artifact data E2E probe gate", () => {
+  it("requires development mode, explicit opt-in, and a loopback hostname", () => {
+    expect(isArtifactDataE2EProbeEnabled(enabledContext)).toBe(true);
+
+    expect(
+      isArtifactDataE2EProbeEnabled({
+        ...enabledContext,
+        nodeEnv: "production",
+      }),
+    ).toBe(false);
+    expect(
+      isArtifactDataE2EProbeEnabled({
+        ...enabledContext,
+        probeFlag: undefined,
+      }),
+    ).toBe(false);
+    expect(
+      isArtifactDataE2EProbeEnabled({
+        ...enabledContext,
+        hostname: "app.example.com",
+      }),
+    ).toBe(false);
+  });
+
+  it.each([
+    ["method", { method: "GET" }],
+    ["path", { pathname: "/test-user" }],
+    ["Next-Action header", { hasNextActionHeader: false }],
+  ])("requires the exact Server Action %s", (_label, override) => {
+    expect(
+      isLocalArtifactDataActionProbe({ ...actionRequest, ...override }),
+    ).toBe(false);
+  });
+
+  it("allows only the exact opted-in local Server Action request", () => {
+    expect(isLocalArtifactDataActionProbe(actionRequest)).toBe(true);
+  });
+});

--- a/tests/unit/lib/error-utils.test.ts
+++ b/tests/unit/lib/error-utils.test.ts
@@ -85,6 +85,28 @@ describe("handleError", () => {
     })
   })
 
+  it("keeps safe rate-limit retry metadata in production responses", () => {
+    const resetAt = "2026-08-01T20:30:00.000Z"
+    const error = ErrorFactories.bizRateLimitExceeded(
+      "submit artifact records",
+      30,
+      resetAt
+    )
+
+    expect(handleError(error, "Fallback", {
+      includeErrorInResponse: false,
+    })).toEqual({
+      isSuccess: false,
+      message: "Too many requests. Please wait a moment and try again",
+      error: {
+        code: "BIZ_RATE_LIMIT_EXCEEDED",
+        statusCode: 429,
+        retryAfterSeconds: 30,
+        resetAt,
+      },
+    })
+  })
+
   it("handles non-Error throws as unknown failures", () => {
     const result = handleError({ reason: "bad" }, "Safe message", {
       includeErrorInResponse: true,

--- a/tests/unit/rate-limit-direct.test.ts
+++ b/tests/unit/rate-limit-direct.test.ts
@@ -32,7 +32,7 @@ describe("consumeRateLimit", () => {
       remaining: 0,
     });
 
-    jest.advanceTimersByTime(60_001);
+    jest.advanceTimersByTime(60_000);
 
     expect(consumeRateLimit(config)).toMatchObject({
       allowed: true,

--- a/tests/unit/rate-limit-direct.test.ts
+++ b/tests/unit/rate-limit-direct.test.ts
@@ -1,0 +1,42 @@
+import { consumeRateLimit } from "@/lib/rate-limit";
+
+describe("consumeRateLimit", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date("2026-08-01T20:00:00.000Z"));
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("allows the configured budget, refuses overflow, and resets by window", () => {
+    const config = {
+      namespace: "direct-test-fixed-window",
+      identifier: "user:7",
+      interval: 60_000,
+      uniqueTokenPerInterval: 2,
+    };
+
+    expect(consumeRateLimit(config)).toMatchObject({
+      allowed: true,
+      remaining: 1,
+    });
+    expect(consumeRateLimit(config)).toMatchObject({
+      allowed: true,
+      remaining: 0,
+    });
+    expect(consumeRateLimit(config)).toMatchObject({
+      allowed: false,
+      retryAfterSeconds: 60,
+      remaining: 0,
+    });
+
+    jest.advanceTimersByTime(60_001);
+
+    expect(consumeRateLimit(config)).toMatchObject({
+      allowed: true,
+      remaining: 1,
+    });
+  });
+});

--- a/types/error-types.ts
+++ b/types/error-types.ts
@@ -197,8 +197,10 @@ export interface BusinessLogicError extends TypedError {
     current: number
     resetAt?: string
   }
-  retryAfterSeconds?: number
-  resetAt?: string
+  rateLimit?: {
+    retryAfterSeconds: number
+    resetAt: string
+  }
 }
 
 /**

--- a/types/error-types.ts
+++ b/types/error-types.ts
@@ -59,6 +59,7 @@ export enum ErrorCode {
   BIZ_INVALID_STATE = "BIZ_INVALID_STATE",
   BIZ_OPERATION_NOT_ALLOWED = "BIZ_OPERATION_NOT_ALLOWED",
   BIZ_QUOTA_EXCEEDED = "BIZ_QUOTA_EXCEEDED",
+  BIZ_RATE_LIMIT_EXCEEDED = "BIZ_RATE_LIMIT_EXCEEDED",
   BIZ_DUPLICATE_OPERATION = "BIZ_DUPLICATE_OPERATION",
   BIZ_DEPENDENCY_ERROR = "BIZ_DEPENDENCY_ERROR",
   
@@ -185,6 +186,7 @@ export interface BusinessLogicError extends TypedError {
   code: ErrorCode.BIZ_INVALID_STATE | 
         ErrorCode.BIZ_OPERATION_NOT_ALLOWED |
         ErrorCode.BIZ_QUOTA_EXCEEDED |
+        ErrorCode.BIZ_RATE_LIMIT_EXCEEDED |
         ErrorCode.BIZ_DUPLICATE_OPERATION |
         ErrorCode.BIZ_DEPENDENCY_ERROR
   operation: string
@@ -195,6 +197,8 @@ export interface BusinessLogicError extends TypedError {
     current: number
     resetAt?: string
   }
+  retryAfterSeconds?: number
+  resetAt?: string
 }
 
 /**
@@ -286,6 +290,7 @@ export const ERROR_STATUS_CODES: Record<ErrorCode, number> = {
   // 429 Too Many Requests
   [ErrorCode.EXTERNAL_API_RATE_LIMIT]: 429,
   [ErrorCode.BIZ_QUOTA_EXCEEDED]: 429,
+  [ErrorCode.BIZ_RATE_LIMIT_EXCEEDED]: 429,
   
   // 500 Internal Server Error
   [ErrorCode.DB_CONNECTION_FAILED]: 500,
@@ -367,6 +372,7 @@ export function getUserMessage(code: ErrorCode): string {
     [ErrorCode.BIZ_INVALID_STATE]: "This operation cannot be performed in the current state",
     [ErrorCode.BIZ_OPERATION_NOT_ALLOWED]: "This operation is not allowed",
     [ErrorCode.BIZ_QUOTA_EXCEEDED]: "You have exceeded your quota. Please upgrade or wait for reset",
+    [ErrorCode.BIZ_RATE_LIMIT_EXCEEDED]: "Too many requests. Please wait a moment and try again",
     [ErrorCode.BIZ_DUPLICATE_OPERATION]: "This operation has already been performed",
     [ErrorCode.BIZ_DEPENDENCY_ERROR]: "Cannot complete this operation due to dependency issues",
     


### PR DESCRIPTION
## Description

Adds the authenticated Atrium Artifact Data Service boundary required by epic #1515:

- `submitArtifactRecord` authenticates from the server session, applies its 120/minute per-user guard before database-backed requester resolution, preserves the shared `contentService.get` 404 visibility mask, requires artifact content, owns `user_id`, rejects reserved identity keys, and persists parameterized JSONB.
- Payload validation requires a non-lossy JSON object and walks the original graph before serialization, rejecting exotic/non-finite/undefined/cyclic values plus PostgreSQL-incompatible NUL or unpaired-surrogate strings/keys. That pre-serialization walk caps traversal at 8,192 reference occurrences, separately caps cumulative original string/key code units, and uses path-local cycle tracking so shared acyclic graphs are counted exactly as serialization expands them. Serialization-omitted fields and repeated-reference DAGs therefore cannot force unbounded traversal or scans. Successful graphs then use an allocation-free UTF-16 lower-bound before exact 8 KiB UTF-8 measurement and round-trip shape verification.
- `contentId` is rejected before requester/database work when its raw input exceeds 200 characters or contains a PostgreSQL-incompatible NUL/unpaired surrogate. The raw length cap runs before trimming, so oversized padded IDs cannot force unbounded normalization scans or allocation.
- `listArtifactRecords` applies the same authentication and visibility ladder plus a 600/minute pre-database per-user guard, supports `all` and `mine`, clamps reads to 200 rows (default 50), orders newest-first, and returns server-resolved display names without email or internal numeric `userId` exposure. The `mine` predicate binds the authenticated requester's ID server-side.
- Typed rate-limit failures expose only safe retry metadata in production, and fixed windows reset at the exact `resetTime` boundary. The limiter remains a best-effort per-process sanity guard, not a distributed quota or security boundary.
- A local-only Playwright harness exercises the real Server Action transport and PostgreSQL persistence. Its unauthenticated action probe requires an explicit E2E flag, non-production runtime, loopback hostname, exact path, POST, and a `Next-Action` header. The harness hard-404s in production; reuse and readiness require a loopback health marker proving the probe flag is active.
- Browser fixture setup and teardown preserve primary failures and close every created context even when setup fails. Cleanup deletes only a UUID-addressed, owner-visible artifact whose ID, kind, cryptographically unique title, and per-fixture inline body all match; unverifiable fixtures retain the repository's recognized `E2E ` prefix for recovery by the local cleanup script.

No schema or migration changes are included. This builds on the merged `content_data_records` migration from #1516 / PR #1524. No `/api/v1/` endpoint contract changed.

## Validation

On exact head `12b62e9a382f76c4a1ac6efa79ab1c870febec26`:

- `bash -n scripts/test/e2e-local.sh`
- `bun run lint`
- `bun run typecheck`
- `bun run test:ci` — 560 suites passed, 1 skipped; 5,251 tests passed, 15 skipped (5,266 total)
- `bun run build`
- Authenticated Playwright spec against the host dev server and local PostgreSQL — 4/4 passed: route guard, persisted submit/list round trip, cleared-session submit/list rejection with no persistence, and private visibility masking
- GitHub Actions — all required CI, CodeQL, auth-edge, infrastructure, PostgreSQL lifecycle, and mandatory Claude checks passed on the exact head
- Unit coverage proves every local E2E action-probe gate is independently load-bearing and verifies the generated `mine` SQL binds the authenticated requester ID
- Fresh exact-head Codex and full Claude reviews found no actionable issues; all review threads are resolved

The broad pre-push E2E hook was bypassed only after the exact authenticated spec and all repository gates above passed; the hook invocation itself lacked its required `AUTH_SECRET`. The local E2E runner injects the probe flag only into its isolated loopback server. No deployment environment configuration changed.

## Checklist

- [x] No `console.*` calls added to production/shared code; server-side logging uses `@/lib/logger`
- [x] No `any` types added; TypeScript strict checks pass
- [x] Authentication, visibility, privacy, bounds, rate-limit, and real-transport teardown/recovery behavior are covered
- [x] Lint, typecheck, full Jest suite, authenticated E2E, production build, CI, and exact-head reviews pass
- [x] Documentation assessed; no API v1 or user-facing documentation changes are required
- [x] No schema migration or deployment environment changes

## Related Issues

Closes #1517

Part of #1515
