### PR TITLE
fix(repositories): bound publication lock contention

### DIFF
--- a/infra/lambdas/unified-content-processor/__tests__/lifecycle.test.ts
+++ b/infra/lambdas/unified-content-processor/__tests__/lifecycle.test.ts
@@ -5,6 +5,26 @@ import {
   processingRetryDelaySeconds,
   RetryableManagedServiceJobError,
 } from "../lifecycle";
+import { RepositoryPublicationContentionError } from "../../../../lib/repositories/content-platform/publication-contention";
+
+describe("repository publication contention lifecycle", () => {
+  test("refunds a retry when repository publication loses the lock race", () => {
+    expect(
+      classifyContentProcessingError(
+        new RepositoryPublicationContentionError(
+          Object.assign(new Error("canceling statement due to lock timeout"), {
+            code: "55P03",
+          })
+        )
+      )
+    ).toEqual({
+      terminal: false,
+      code: "REPOSITORY_PUBLICATION_CONTENTION",
+      message: "canceling statement due to lock timeout",
+      refundAttempt: true,
+    });
+  });
+});
 
 describe("unified content lifecycle policy", () => {
   test("classifies deterministic source failures as terminal", () => {

--- a/infra/lambdas/unified-content-processor/lifecycle.ts
+++ b/infra/lambdas/unified-content-processor/lifecycle.ts
@@ -5,6 +5,8 @@
  * without importing the Lambda handler (whose clients are created at module load).
  */
 
+import { RepositoryPublicationContentionError } from "../../../lib/repositories/content-platform/publication-contention";
+
 export type DeferredProcessingReason =
   | "CONTENT_PLATFORM_DISABLED"
   | "AWAITING_SECURITY_SCAN"
@@ -20,6 +22,7 @@ export interface ProcessingFailureDecision {
   terminal: boolean;
   code: string;
   message: string;
+  refundAttempt?: boolean;
   resetManagedService?: "textract" | "bedrock-data-automation";
 }
 
@@ -107,6 +110,14 @@ export function classifyContentProcessingError(
   error: unknown
 ): ProcessingFailureDecision {
   const message = errorMessage(error);
+  if (error instanceof RepositoryPublicationContentionError) {
+    return {
+      terminal: false,
+      code: "REPOSITORY_PUBLICATION_CONTENTION",
+      message,
+      refundAttempt: true,
+    };
+  }
   if (error instanceof PermanentContentProcessingError) {
     return { terminal: true, code: error.code, message };
   }

--- a/lib/db/schema/tables/repository-processing-jobs.ts
+++ b/lib/db/schema/tables/repository-processing-jobs.ts
@@ -91,6 +91,8 @@ export interface RepositoryProcessingMetrics {
   chapterCount?: number;
   speakerCount?: number;
   estimatedCostUsd?: number;
+  /** Publication lock waits refunded without consuming the normal retry budget. */
+  contentionRefunds?: number;
 }
 
 export const repositoryProcessingJobs = pgTable(

--- a/lib/repositories/content-platform/publication-contention.ts
+++ b/lib/repositories/content-platform/publication-contention.ts
@@ -1,0 +1,50 @@
+const REPOSITORY_PUBLICATION_CONTENTION_MESSAGE =
+  /lock timeout|could not obtain lock|deadlock detected/i;
+
+interface ErrorLike {
+  cause?: unknown;
+  code?: unknown;
+  message?: unknown;
+}
+
+function isErrorLike(error: unknown): error is ErrorLike {
+  return typeof error === "object" && error !== null;
+}
+
+/** A bounded repository publication lock wait expired and may be retried. */
+export class RepositoryPublicationContentionError extends Error {
+  readonly name = "RepositoryPublicationContentionError";
+
+  constructor(cause: unknown) {
+    super(
+      cause instanceof Error
+        ? cause.message
+        : "Repository publication lock contention",
+      { cause }
+    );
+  }
+}
+
+/**
+ * Identify only PostgreSQL lock acquisition failures, including errors wrapped
+ * by Drizzle. Pool-capacity deadlines deliberately do not match this policy.
+ */
+export function isRepositoryPublicationContention(error: unknown): boolean {
+  const visited = new Set<unknown>();
+  let candidate: unknown = error;
+
+  while (isErrorLike(candidate) && !visited.has(candidate)) {
+    if (candidate instanceof RepositoryPublicationContentionError) return true;
+    if (candidate.code === "55P03") return true;
+    if (
+      typeof candidate.message === "string" &&
+      REPOSITORY_PUBLICATION_CONTENTION_MESSAGE.test(candidate.message)
+    ) {
+      return true;
+    }
+    visited.add(candidate);
+    candidate = candidate.cause;
+  }
+
+  return false;
+}

--- a/lib/repositories/content-platform/publication-contention.ts
+++ b/lib/repositories/content-platform/publication-contention.ts
@@ -1,6 +1,8 @@
 const REPOSITORY_PUBLICATION_CONTENTION_MESSAGE =
   /lock timeout|could not obtain lock|deadlock detected/i;
 
+export const REPOSITORY_PUBLICATION_LOCK_TIMEOUT_MS = 5_000;
+
 interface ErrorLike {
   cause?: unknown;
   code?: unknown;

--- a/lib/repositories/content-platform/publication-service.ts
+++ b/lib/repositories/content-platform/publication-service.ts
@@ -31,7 +31,10 @@ import { canReuseRepositoryEmbeddings } from "@/lib/repositories/embedding-confi
 import {
   isRepositoryPublicationContention,
   RepositoryPublicationContentionError,
+  REPOSITORY_PUBLICATION_LOCK_TIMEOUT_MS,
 } from "./publication-contention";
+
+export { REPOSITORY_PUBLICATION_LOCK_TIMEOUT_MS } from "./publication-contention";
 
 export interface PublishableSegment {
   content: string;
@@ -121,7 +124,6 @@ export function isPublicationTargetActive(
 export type PublishPdfVersionResult = PublishDocumentVersionResult;
 
 export const MAX_INLINE_ARTIFACT_CHARACTERS = 1_000_000;
-export const REPOSITORY_PUBLICATION_LOCK_TIMEOUT_MS = 5_000;
 export const REPOSITORY_PUBLICATION_STATEMENT_TIMEOUT_MS = 240_000;
 export const REPOSITORY_PUBLICATION_TRANSACTION_DEADLINE_MS = 270_000;
 

--- a/lib/repositories/content-platform/publication-service.ts
+++ b/lib/repositories/content-platform/publication-service.ts
@@ -28,6 +28,10 @@ import {
 } from "@/lib/db/schema";
 import type { PdfSegment } from "./pdf-processing";
 import { canReuseRepositoryEmbeddings } from "@/lib/repositories/embedding-configuration";
+import {
+  isRepositoryPublicationContention,
+  RepositoryPublicationContentionError,
+} from "./publication-contention";
 
 export interface PublishableSegment {
   content: string;
@@ -117,6 +121,7 @@ export function isPublicationTargetActive(
 export type PublishPdfVersionResult = PublishDocumentVersionResult;
 
 export const MAX_INLINE_ARTIFACT_CHARACTERS = 1_000_000;
+export const REPOSITORY_PUBLICATION_LOCK_TIMEOUT_MS = 5_000;
 export const REPOSITORY_PUBLICATION_STATEMENT_TIMEOUT_MS = 240_000;
 export const REPOSITORY_PUBLICATION_TRANSACTION_DEADLINE_MS = 270_000;
 
@@ -195,6 +200,13 @@ export async function configureRepositoryPublicationTransaction(
     SELECT set_config(
       'statement_timeout',
       ${REPOSITORY_PUBLICATION_STATEMENT_TIMEOUT_MS.toString()},
+      true
+    )
+  `);
+  await tx.execute(sql`
+    SELECT set_config(
+      'lock_timeout',
+      ${REPOSITORY_PUBLICATION_LOCK_TIMEOUT_MS.toString()},
       true
     )
   `);
@@ -823,22 +835,29 @@ export async function publishDocumentVersion(
   if (!canonicalTextSha256) {
     throw new Error("Canonical text SHA-256 is required");
   }
-  return executeTransaction(
-    async (tx) => {
-      await configureRepositoryPublicationTransaction(tx);
-      return publishDocumentVersionInTransaction(
-        tx,
-        input,
-        key,
-        canonicalTextSha256
-      );
-    },
-    "contentPlatform.publishDocumentVersion",
-    {
-      isolationLevel: "serializable",
-      deadlineMs: REPOSITORY_PUBLICATION_TRANSACTION_DEADLINE_MS,
+  try {
+    return await executeTransaction(
+      async (tx) => {
+        await configureRepositoryPublicationTransaction(tx);
+        return publishDocumentVersionInTransaction(
+          tx,
+          input,
+          key,
+          canonicalTextSha256
+        );
+      },
+      "contentPlatform.publishDocumentVersion",
+      {
+        isolationLevel: "serializable",
+        deadlineMs: REPOSITORY_PUBLICATION_TRANSACTION_DEADLINE_MS,
+      }
+    );
+  } catch (error) {
+    if (isRepositoryPublicationContention(error)) {
+      throw new RepositoryPublicationContentionError(error);
     }
-  );
+    throw error;
+  }
 }
 
 /** Backwards-compatible PDF entry point with a stricter page-citation guard. */

--- a/lib/repositories/content-platform/worker-job-service.ts
+++ b/lib/repositories/content-platform/worker-job-service.ts
@@ -14,7 +14,6 @@ import {
   type RepositoryProcessingJobRow,
   type RepositoryProcessingMetrics,
 } from "@/lib/db/schema";
-import { REPOSITORY_PUBLICATION_LOCK_TIMEOUT_MS } from "./publication-contention";
 
 export type RestartableManagedService =
   | "textract"
@@ -134,21 +133,6 @@ export function resolveRepositoryProcessingAttemptRefund(params: {
       ? { ...params.metrics, contentionRefunds: contentionRefunds + 1 }
       : params.metrics,
   };
-}
-
-/** Bound the second lock wait needed to durably record a refunded contention. */
-export async function configureRepositoryProcessingFailureTransaction(
-  tx: { execute(query: ReturnType<typeof sql>): PromiseLike<unknown> },
-  decision: RepositoryProcessingFailureDecision
-): Promise<void> {
-  if (decision.refundAttempt !== true) return;
-  await tx.execute(sql`
-    SELECT set_config(
-      'lock_timeout',
-      ${REPOSITORY_PUBLICATION_LOCK_TIMEOUT_MS.toString()},
-      true
-    )
-  `);
 }
 
 interface RepositoryProcessingMutationLockTransaction {
@@ -842,6 +826,55 @@ async function recordRetryFailure(params: {
   return { action: "retry", delaySeconds };
 }
 
+/**
+ * Persist a publication-contention refund while locking only the job row.
+ * This transaction never seeks an ancestor lifecycle lock, so it cannot wait
+ * behind the publication transaction's contested repository row or invert the
+ * repository -> item -> job -> version lock order.
+ */
+async function recordRefundedPublicationContentionInTransaction(params: {
+  tx: DbTransaction;
+  message: RepositoryProcessingJobMessage;
+  decision: RepositoryProcessingFailureDecision;
+  options: RecordRepositoryProcessingFailureOptions;
+  now: Date;
+}): Promise<RepositoryProcessingFailureResult | null> {
+  const [job] = await params.tx
+    .select()
+    .from(repositoryProcessingJobs)
+    .where(
+      and(
+        eq(repositoryProcessingJobs.id, params.message.jobId),
+        eq(
+          repositoryProcessingJobs.itemVersionId,
+          params.message.itemVersionId
+        )
+      )
+    )
+    .limit(1)
+    .for("update");
+  if (!job || job.status === "succeeded" || job.status === "cancelled") {
+    return { action: "ignore" };
+  }
+  const activeBdaInvocation = isBdaInvocationExternallyActive(job.metrics);
+  const attemptRefund = resolveRepositoryProcessingAttemptRefund({
+    activeBdaInvocation,
+    attempt: job.attempt,
+    decision: params.decision,
+    metrics: job.metrics,
+  });
+  if (!attemptRefund.refundAttempt) return null;
+  return recordRetryFailure({
+    tx: params.tx,
+    decision: params.decision,
+    job,
+    now: params.now,
+    retryDelaySeconds: params.options.retryDelaySeconds,
+    activeBdaInvocation,
+    attemptRefund,
+  });
+}
+
 async function recordRepositoryProcessingFailureInTransaction(params: {
   tx: DbTransaction;
   message: RepositoryProcessingJobMessage;
@@ -909,17 +942,29 @@ export async function recordRepositoryProcessingFailure(
   options: RecordRepositoryProcessingFailureOptions
 ): Promise<RepositoryProcessingFailureResult> {
   const now = options.now ?? new Date();
+  if (decision.refundAttempt === true) {
+    const refunded = await executeTransaction(
+      (tx) =>
+        recordRefundedPublicationContentionInTransaction({
+          tx,
+          message,
+          decision,
+          options,
+          now,
+        }),
+      "contentProcessor.recordContentionRefund"
+    );
+    if (refunded) return refunded;
+  }
   return executeTransaction(
-    async (tx) => {
-      await configureRepositoryProcessingFailureTransaction(tx, decision);
-      return recordRepositoryProcessingFailureInTransaction({
+    (tx) =>
+      recordRepositoryProcessingFailureInTransaction({
         tx,
         message,
         decision,
         options,
         now,
-      });
-    },
+      }),
     "contentProcessor.recordFailure"
   );
 }

--- a/lib/repositories/content-platform/worker-job-service.ts
+++ b/lib/repositories/content-platform/worker-job-service.ts
@@ -60,8 +60,11 @@ export interface RepositoryProcessingFailureDecision {
   terminal: boolean;
   code: string;
   message: string;
+  refundAttempt?: boolean;
   resetManagedService?: RestartableManagedService;
 }
+
+export const MAX_REPOSITORY_PUBLICATION_CONTENTION_REFUNDS = 20;
 
 export interface RepositoryProcessingDlqReconciliationResult {
   acknowledge: boolean;
@@ -94,6 +97,42 @@ export function isBdaInvocationExternallyActive(
     metrics.bdaInvocationArn &&
       metrics.bdaInvocationState !== "terminal"
   );
+}
+
+export interface RepositoryProcessingAttemptRefund {
+  refundAttempt: boolean;
+  attempt?: number;
+  metrics: RepositoryProcessingMetrics;
+}
+
+/**
+ * Refund transient publication contention without allowing a wedged repository
+ * to retry forever. Active BDA writers retain their existing uncapped refund.
+ */
+export function resolveRepositoryProcessingAttemptRefund(params: {
+  activeBdaInvocation: boolean;
+  attempt: number;
+  decision: RepositoryProcessingFailureDecision;
+  metrics: RepositoryProcessingMetrics;
+}): RepositoryProcessingAttemptRefund {
+  const contentionRefunds = Math.max(
+    0,
+    params.metrics.contentionRefunds ?? 0
+  );
+  const refundContention =
+    !params.decision.terminal &&
+    params.decision.refundAttempt === true &&
+    contentionRefunds < MAX_REPOSITORY_PUBLICATION_CONTENTION_REFUNDS;
+
+  return {
+    refundAttempt: params.activeBdaInvocation || refundContention,
+    ...(params.activeBdaInvocation || refundContention
+      ? { attempt: Math.max(0, params.attempt - 1) }
+      : {}),
+    metrics: refundContention
+      ? { ...params.metrics, contentionRefunds: contentionRefunds + 1 }
+      : params.metrics,
+  };
 }
 
 interface RepositoryProcessingMutationLockTransaction {
@@ -753,32 +792,33 @@ async function recordRetryFailure(params: {
   now: Date;
   retryDelaySeconds: (attempt: number) => number;
   activeBdaInvocation: boolean;
+  attemptRefund: RepositoryProcessingAttemptRefund;
 }): Promise<RepositoryProcessingFailureResult> {
   const delaySeconds = params.retryDelaySeconds(params.job.attempt);
   const restartManagedService = params.activeBdaInvocation
     ? undefined
     : params.decision.resetManagedService;
+  const retryMetrics = restartManagedService
+    ? resetManagedServiceMetrics(
+        params.attemptRefund.metrics,
+        restartManagedService
+      )
+    : params.attemptRefund.metrics;
+  const metricsChanged = retryMetrics !== params.job.metrics;
   await params.tx
     .update(repositoryProcessingJobs)
     .set({
       status: "pending",
-      ...(params.activeBdaInvocation
-        ? { attempt: Math.max(0, params.job.attempt - 1) }
-        : {}),
+      ...(params.attemptRefund.attempt === undefined
+        ? {}
+        : { attempt: params.attemptRefund.attempt }),
       availableAt: new Date(params.now.getTime() + delaySeconds * 1_000),
       leaseOwner: null,
       leaseExpiresAt: null,
       lastErrorCode: params.decision.code,
       lastErrorMessage: params.decision.message,
-      ...(restartManagedService
-        ? {
-            metrics: resetManagedServiceMetrics(
-              params.job.metrics,
-              restartManagedService
-            ),
-            startedAt: params.now,
-          }
-        : {}),
+      ...(metricsChanged ? { metrics: retryMetrics } : {}),
+      ...(restartManagedService ? { startedAt: params.now } : {}),
       finishedAt: null,
       updatedAt: params.now,
     })
@@ -812,8 +852,14 @@ async function recordRepositoryProcessingFailureInTransaction(params: {
     return { action: "ignore" };
   }
   const activeBdaInvocation = isBdaInvocationExternallyActive(job.metrics);
+  const attemptRefund = resolveRepositoryProcessingAttemptRefund({
+    activeBdaInvocation,
+    attempt: job.attempt,
+    decision: params.decision,
+    metrics: job.metrics,
+  });
   const terminal =
-    !activeBdaInvocation &&
+    !attemptRefund.refundAttempt &&
     (params.decision.terminal || job.attempt >= job.maxAttempts);
   if (terminal) {
     return recordTerminalFailure({
@@ -832,6 +878,7 @@ async function recordRepositoryProcessingFailureInTransaction(params: {
     now: params.now,
     retryDelaySeconds: params.options.retryDelaySeconds,
     activeBdaInvocation,
+    attemptRefund,
   });
 }
 

--- a/lib/repositories/content-platform/worker-job-service.ts
+++ b/lib/repositories/content-platform/worker-job-service.ts
@@ -14,6 +14,7 @@ import {
   type RepositoryProcessingJobRow,
   type RepositoryProcessingMetrics,
 } from "@/lib/db/schema";
+import { REPOSITORY_PUBLICATION_LOCK_TIMEOUT_MS } from "./publication-contention";
 
 export type RestartableManagedService =
   | "textract"
@@ -133,6 +134,21 @@ export function resolveRepositoryProcessingAttemptRefund(params: {
       ? { ...params.metrics, contentionRefunds: contentionRefunds + 1 }
       : params.metrics,
   };
+}
+
+/** Bound the second lock wait needed to durably record a refunded contention. */
+export async function configureRepositoryProcessingFailureTransaction(
+  tx: { execute(query: ReturnType<typeof sql>): PromiseLike<unknown> },
+  decision: RepositoryProcessingFailureDecision
+): Promise<void> {
+  if (decision.refundAttempt !== true) return;
+  await tx.execute(sql`
+    SELECT set_config(
+      'lock_timeout',
+      ${REPOSITORY_PUBLICATION_LOCK_TIMEOUT_MS.toString()},
+      true
+    )
+  `);
 }
 
 interface RepositoryProcessingMutationLockTransaction {
@@ -894,14 +910,16 @@ export async function recordRepositoryProcessingFailure(
 ): Promise<RepositoryProcessingFailureResult> {
   const now = options.now ?? new Date();
   return executeTransaction(
-    (tx) =>
-      recordRepositoryProcessingFailureInTransaction({
+    async (tx) => {
+      await configureRepositoryProcessingFailureTransaction(tx, decision);
+      return recordRepositoryProcessingFailureInTransaction({
         tx,
         message,
         decision,
         options,
         now,
-      }),
+      });
+    },
     "contentProcessor.recordFailure"
   );
 }

--- a/tests/unit/lib/repositories/content-platform-contention-recording.test.ts
+++ b/tests/unit/lib/repositories/content-platform-contention-recording.test.ts
@@ -1,0 +1,124 @@
+/** @jest-environment node */
+
+import { beforeAll, jest } from "@jest/globals";
+import { repositoryProcessingJobs } from "@/lib/db/schema";
+
+const mockExecuteTransaction = jest.fn();
+
+jest.mock("@/lib/db/drizzle-client", () => ({
+  executeQuery: jest.fn(),
+  executeTransaction: mockExecuteTransaction,
+  toPgRows: (result: unknown) => result,
+}));
+
+const JOB_ID = "11111111-2222-4333-8444-555555555555";
+const VERSION_ID = "66666666-7777-4888-8999-aaaaaaaaaaaa";
+const NOW = new Date("2026-08-01T12:00:00.000Z");
+const decision = {
+  terminal: false,
+  code: "REPOSITORY_PUBLICATION_CONTENTION",
+  message: "lock wait expired",
+  refundAttempt: true,
+} as const;
+
+let recordRepositoryProcessingFailure: typeof import("@/lib/repositories/content-platform/worker-job-service").recordRepositoryProcessingFailure;
+let maxContentionRefunds: number;
+
+function createJobOnlyTransaction(contentionRefunds: number) {
+  const forUpdate = jest.fn(async () => [
+    {
+      id: JOB_ID,
+      itemVersionId: VERSION_ID,
+      status: "running",
+      attempt: 5,
+      maxAttempts: 5,
+      metrics: { provider: "unified-content", contentionRefunds },
+    },
+  ]);
+  const limit = jest.fn(() => ({ for: forUpdate }));
+  const where = jest.fn(() => ({ limit }));
+  const from = jest.fn(() => ({ where }));
+  const select = jest.fn(() => ({ from }));
+  const updateWhere = jest.fn(async () => []);
+  const set = jest.fn((values: Record<string, unknown>) => ({
+    values,
+    where: updateWhere,
+  }));
+  const update = jest.fn(() => ({ set }));
+  return {
+    transaction: { select, update },
+    spies: { forUpdate, from, select, set, update, updateWhere },
+  };
+}
+
+beforeAll(async () => {
+  const workerJobService = await import(
+    "@/lib/repositories/content-platform/worker-job-service"
+  );
+  recordRepositoryProcessingFailure =
+    workerJobService.recordRepositoryProcessingFailure;
+  maxContentionRefunds =
+    workerJobService.MAX_REPOSITORY_PUBLICATION_CONTENTION_REFUNDS;
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockExecuteTransaction.mockReset();
+});
+
+describe("repository publication contention recording", () => {
+  it("persists a final-attempt refund without acquiring the repository lock", async () => {
+    const { transaction, spies } = createJobOnlyTransaction(3);
+    mockExecuteTransaction.mockImplementationOnce(
+      async (callback: unknown) =>
+        (callback as (tx: typeof transaction) => Promise<unknown>)(transaction)
+    );
+
+    await expect(
+      recordRepositoryProcessingFailure(
+        { jobId: JOB_ID, itemVersionId: VERSION_ID },
+        decision,
+        { now: NOW, retryDelaySeconds: () => 7 }
+      )
+    ).resolves.toEqual({ action: "retry", delaySeconds: 7 });
+
+    expect(mockExecuteTransaction).toHaveBeenCalledTimes(1);
+    expect(spies.from).toHaveBeenCalledWith(repositoryProcessingJobs);
+    expect(spies.forUpdate).toHaveBeenCalledWith("update");
+    expect(spies.update).toHaveBeenCalledWith(repositoryProcessingJobs);
+    expect(spies.set).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: "pending",
+        attempt: 4,
+        leaseOwner: null,
+        leaseExpiresAt: null,
+        metrics: { provider: "unified-content", contentionRefunds: 4 },
+      })
+    );
+  });
+
+  it("falls back to the normal failure budget once the refund cap is reached", async () => {
+    const { transaction } = createJobOnlyTransaction(maxContentionRefunds);
+    mockExecuteTransaction
+      .mockImplementationOnce(
+        async (callback: unknown) =>
+          (callback as (tx: typeof transaction) => Promise<unknown>)(transaction)
+      )
+      .mockImplementationOnce(async () => ({
+        action: "terminal",
+        code: "RETRY_BUDGET_EXHAUSTED",
+      }));
+
+    await expect(
+      recordRepositoryProcessingFailure(
+        { jobId: JOB_ID, itemVersionId: VERSION_ID },
+        decision,
+        { now: NOW, retryDelaySeconds: () => 7 }
+      )
+    ).resolves.toEqual({
+      action: "terminal",
+      code: "RETRY_BUDGET_EXHAUSTED",
+    });
+    expect(mockExecuteTransaction).toHaveBeenCalledTimes(2);
+  });
+});

--- a/tests/unit/lib/repositories/content-platform-publication-contention.test.ts
+++ b/tests/unit/lib/repositories/content-platform-publication-contention.test.ts
@@ -1,0 +1,44 @@
+/** @jest-environment node */
+
+import { DbPoolDeadlineError } from "@/lib/db/pool-guard";
+import {
+  isRepositoryPublicationContention,
+  RepositoryPublicationContentionError,
+} from "@/lib/repositories/content-platform/publication-contention";
+
+describe("repository publication contention", () => {
+  it("recognizes PostgreSQL lock codes through a wrapped Drizzle error", () => {
+    const postgresError = Object.assign(new Error("lock unavailable"), {
+      code: "55P03",
+    });
+    const drizzleError = new Error("Failed query: select ... for update", {
+      cause: postgresError,
+    });
+
+    expect(isRepositoryPublicationContention(drizzleError)).toBe(true);
+  });
+
+  it.each([
+    "canceling statement due to lock timeout",
+    "could not obtain lock on row in relation",
+    "deadlock detected",
+  ])("recognizes PostgreSQL contention message %s", (message) => {
+    expect(isRepositoryPublicationContention(new Error(message))).toBe(true);
+  });
+
+  it("recognizes the typed publication error", () => {
+    expect(
+      isRepositoryPublicationContention(
+        new RepositoryPublicationContentionError(new Error("locked"))
+      )
+    ).toBe(true);
+  });
+
+  it("does not misclassify a database pool deadline", () => {
+    expect(
+      isRepositoryPublicationContention(
+        new DbPoolDeadlineError("publishDocumentVersion", 270_000)
+      )
+    ).toBe(false);
+  });
+});

--- a/tests/unit/lib/repositories/content-platform-publication-timeout.test.ts
+++ b/tests/unit/lib/repositories/content-platform-publication-timeout.test.ts
@@ -5,6 +5,7 @@ import type { SQL } from "drizzle-orm";
 import { PgDialect } from "drizzle-orm/pg-core";
 import {
   configureRepositoryPublicationTransaction,
+  REPOSITORY_PUBLICATION_LOCK_TIMEOUT_MS,
   REPOSITORY_PUBLICATION_STATEMENT_TIMEOUT_MS,
   REPOSITORY_PUBLICATION_TRANSACTION_DEADLINE_MS,
 } from "@/lib/repositories/content-platform/publication-service";
@@ -17,14 +18,22 @@ describe("repository publication timeout boundary", () => {
 
     await configureRepositoryPublicationTransaction({ execute });
 
-    expect(execute).toHaveBeenCalledTimes(1);
-    const compiled = new PgDialect().sqlToQuery(
-      execute.mock.calls[0]![0],
+    expect(execute).toHaveBeenCalledTimes(2);
+    const compiled = execute.mock.calls.map(([query]) =>
+      new PgDialect().sqlToQuery(query)
     );
-    expect(compiled.sql).toContain("set_config");
-    expect(compiled.params).toEqual(["240000"]);
+    expect(compiled[0]?.sql).toContain("set_config");
+    expect(compiled[0]?.sql).toContain("'statement_timeout'");
+    expect(compiled[0]?.params).toEqual(["240000"]);
+    expect(compiled[1]?.sql).toContain("set_config");
+    expect(compiled[1]?.sql).toContain("'lock_timeout'");
+    expect(compiled[1]?.params).toEqual(["5000"]);
+    expect(REPOSITORY_PUBLICATION_LOCK_TIMEOUT_MS).toBe(5_000);
     expect(REPOSITORY_PUBLICATION_STATEMENT_TIMEOUT_MS).toBe(240_000);
     expect(REPOSITORY_PUBLICATION_TRANSACTION_DEADLINE_MS).toBe(270_000);
+    expect(REPOSITORY_PUBLICATION_STATEMENT_TIMEOUT_MS).toBeGreaterThan(
+      REPOSITORY_PUBLICATION_LOCK_TIMEOUT_MS,
+    );
     expect(REPOSITORY_PUBLICATION_TRANSACTION_DEADLINE_MS).toBeGreaterThan(
       REPOSITORY_PUBLICATION_STATEMENT_TIMEOUT_MS,
     );

--- a/tests/unit/lib/repositories/content-platform-worker-job-service.test.ts
+++ b/tests/unit/lib/repositories/content-platform-worker-job-service.test.ts
@@ -6,10 +6,70 @@ import { PgDialect } from "drizzle-orm/pg-core";
 import {
   isBdaInvocationExternallyActive,
   lockRepositoryProcessingMutationTarget,
+  MAX_REPOSITORY_PUBLICATION_CONTENTION_REFUNDS,
   resetManagedServiceMetrics,
+  resolveRepositoryProcessingAttemptRefund,
 } from "@/lib/repositories/content-platform/worker-job-service";
 
 const dialect = new PgDialect();
+
+describe("repository processing attempt refunds", () => {
+  it("refunds publication contention and increments its durable counter", () => {
+    expect(
+      resolveRepositoryProcessingAttemptRefund({
+        activeBdaInvocation: false,
+        attempt: 4,
+        decision: {
+          terminal: false,
+          code: "REPOSITORY_PUBLICATION_CONTENTION",
+          message: "lock wait expired",
+          refundAttempt: true,
+        },
+        metrics: { provider: "unified-content", contentionRefunds: 3 },
+      })
+    ).toEqual({
+      refundAttempt: true,
+      attempt: 3,
+      metrics: { provider: "unified-content", contentionRefunds: 4 },
+    });
+  });
+
+  it("stops refunding publication contention at the cap", () => {
+    const metrics = {
+      provider: "unified-content",
+      contentionRefunds: MAX_REPOSITORY_PUBLICATION_CONTENTION_REFUNDS,
+    };
+    expect(
+      resolveRepositoryProcessingAttemptRefund({
+        activeBdaInvocation: false,
+        attempt: 1,
+        decision: {
+          terminal: false,
+          code: "REPOSITORY_PUBLICATION_CONTENTION",
+          message: "lock wait expired",
+          refundAttempt: true,
+        },
+        metrics,
+      })
+    ).toEqual({ refundAttempt: false, metrics });
+  });
+
+  it("does not refund ordinary retryable failures", () => {
+    const metrics = { provider: "unified-content" };
+    expect(
+      resolveRepositoryProcessingAttemptRefund({
+        activeBdaInvocation: false,
+        attempt: 2,
+        decision: {
+          terminal: false,
+          code: "TRANSIENT_PROCESSING_ERROR",
+          message: "temporary outage",
+        },
+        metrics,
+      })
+    ).toEqual({ refundAttempt: false, metrics });
+  });
+});
 
 describe("unified-content worker managed-service recovery", () => {
   it("clears all Textract run identity and its wait clock", () => {

--- a/tests/unit/lib/repositories/content-platform-worker-job-service.test.ts
+++ b/tests/unit/lib/repositories/content-platform-worker-job-service.test.ts
@@ -4,6 +4,7 @@ import { jest } from "@jest/globals";
 import type { SQL } from "drizzle-orm";
 import { PgDialect } from "drizzle-orm/pg-core";
 import {
+  configureRepositoryProcessingFailureTransaction,
   isBdaInvocationExternallyActive,
   lockRepositoryProcessingMutationTarget,
   MAX_REPOSITORY_PUBLICATION_CONTENTION_REFUNDS,
@@ -12,6 +13,42 @@ import {
 } from "@/lib/repositories/content-platform/worker-job-service";
 
 const dialect = new PgDialect();
+
+describe("repository processing failure lock timeout", () => {
+  it("bounds the lock wait when recording a refundable contention", async () => {
+    const execute = jest.fn<(query: SQL) => Promise<unknown>>(async () => []);
+
+    await configureRepositoryProcessingFailureTransaction(
+      { execute },
+      {
+        terminal: false,
+        code: "REPOSITORY_PUBLICATION_CONTENTION",
+        message: "lock wait expired",
+        refundAttempt: true,
+      }
+    );
+
+    expect(execute).toHaveBeenCalledTimes(1);
+    const compiled = dialect.sqlToQuery(execute.mock.calls[0]![0]);
+    expect(compiled.sql).toContain("'lock_timeout'");
+    expect(compiled.params).toEqual(["5000"]);
+  });
+
+  it("preserves the existing failure transaction policy otherwise", async () => {
+    const execute = jest.fn<(query: SQL) => Promise<unknown>>(async () => []);
+
+    await configureRepositoryProcessingFailureTransaction(
+      { execute },
+      {
+        terminal: false,
+        code: "TRANSIENT_PROCESSING_ERROR",
+        message: "temporary outage",
+      }
+    );
+
+    expect(execute).not.toHaveBeenCalled();
+  });
+});
 
 describe("repository processing attempt refunds", () => {
   it("refunds publication contention and increments its durable counter", () => {

--- a/tests/unit/lib/repositories/content-platform-worker-job-service.test.ts
+++ b/tests/unit/lib/repositories/content-platform-worker-job-service.test.ts
@@ -4,7 +4,6 @@ import { jest } from "@jest/globals";
 import type { SQL } from "drizzle-orm";
 import { PgDialect } from "drizzle-orm/pg-core";
 import {
-  configureRepositoryProcessingFailureTransaction,
   isBdaInvocationExternallyActive,
   lockRepositoryProcessingMutationTarget,
   MAX_REPOSITORY_PUBLICATION_CONTENTION_REFUNDS,
@@ -13,42 +12,6 @@ import {
 } from "@/lib/repositories/content-platform/worker-job-service";
 
 const dialect = new PgDialect();
-
-describe("repository processing failure lock timeout", () => {
-  it("bounds the lock wait when recording a refundable contention", async () => {
-    const execute = jest.fn<(query: SQL) => Promise<unknown>>(async () => []);
-
-    await configureRepositoryProcessingFailureTransaction(
-      { execute },
-      {
-        terminal: false,
-        code: "REPOSITORY_PUBLICATION_CONTENTION",
-        message: "lock wait expired",
-        refundAttempt: true,
-      }
-    );
-
-    expect(execute).toHaveBeenCalledTimes(1);
-    const compiled = dialect.sqlToQuery(execute.mock.calls[0]![0]);
-    expect(compiled.sql).toContain("'lock_timeout'");
-    expect(compiled.params).toEqual(["5000"]);
-  });
-
-  it("preserves the existing failure transaction policy otherwise", async () => {
-    const execute = jest.fn<(query: SQL) => Promise<unknown>>(async () => []);
-
-    await configureRepositoryProcessingFailureTransaction(
-      { execute },
-      {
-        terminal: false,
-        code: "TRANSIENT_PROCESSING_ERROR",
-        message: "temporary outage",
-      }
-    );
-
-    expect(execute).not.toHaveBeenCalled();
-  });
-});
 
 describe("repository processing attempt refunds", () => {
   it("refunds publication contention and increments its durable counter", () => {


### PR DESCRIPTION
## Summary

- apply a transaction-local 5-second PostgreSQL `lock_timeout` before repository publication while preserving the 240-second statement timeout and 270-second transaction deadline
- wrap lock acquisition failures in a typed publication-contention error and classify them as retryable without consuming the normal five-attempt worker budget
- persist refundable contention through a job-only transaction that atomically returns the job to `pending`, restores the claimed attempt, and increments `metrics.contentionRefunds` without reacquiring the contested repository row
- stop refunding after 20 lock-contention retries and fall back to the normal retry budget so a wedged repository still fails visibly
- add focused coverage for timeout configuration, wrapped PostgreSQL errors, pool-deadline exclusion, lifecycle classification, final-attempt refund persistence, and refund-cap fallback

## Tracking

Closes #1526
Part of #1523

## Risk and operational notes

- No migration or API documentation change is required; the counter is stored in the existing JSONB metrics column.
- Lock hold time is still proportional to generation copy-forward and vector-index insertion work. This PR bounds waiting and preserves correctness; it does not replace the per-item generation model.
- Authenticated E2E was not run because this is an internal worker/database retry-policy change with no user-facing browser surface, and the isolated worktree has no `.env.local` `AUTH_SECRET`.
- Final CI synthesized the CDK stacks and passed the exact Lambda artifact smokes.

## Validation

- `bun run lint`
- `bun run typecheck`
- `CI=true bun run test:ci --runInBand` — 556 suites passed, 1 policy-skipped; 5,158 tests passed, 15 skipped
- focused repository contention tests — 4 suites and 17 tests passed
- `bun test infra/lambdas/unified-content-processor/__tests__/lifecycle.test.ts` — 9 tests passed
- `cd infra && bun run typecheck:unified-content`
- `bun run build` — passed with existing runtime and Browserslist warnings
- GitHub CI: lint/typecheck/tests, PostgreSQL lifecycle, CDK synthesis and exact artifact smokes, Auth Edge artifact, CodeQL, and mandatory Claude review all passed on `141f6c796`
