### PR TITLE
fix(infra): set APP_BASE_URL on ECS tasks and de-noise agentic-model alarm

### DIFF
--- a/infra/lib/constructs/ecs-service.ts
+++ b/infra/lib/constructs/ecs-service.ts
@@ -1066,6 +1066,11 @@ export class EcsServiceConstruct extends Construct {
       // ECS service's authoritative auth origin so deployed links are never
       // relative or dependent on a separately hand-managed value.
       ATRIUM_PUBLIC_BASE_URL: props.authUrl,
+      // Absolute origin the agent broker (/api/agent/aistudio) uses to build the
+      // internal /api/mcp URL. Required — the route throws when it is unset, so
+      // every aistudio-MCP skill call fails closed without it. Same authoritative
+      // origin as AUTH_URL; the broker also enforces HTTPS.
+      APP_BASE_URL: props.authUrl,
       AUTH_COGNITO_CLIENT_ID: props.cognitoClientId,
       AUTH_COGNITO_ISSUER: props.cognitoIssuer,
       // Legacy RDS Data API variables (kept for backward compatibility during migration)

--- a/infra/lib/constructs/processing/unified-content-processing.ts
+++ b/infra/lib/constructs/processing/unified-content-processing.ts
@@ -767,7 +767,11 @@ export class UnifiedContentProcessing extends Construct {
         evaluationPeriods: 2,
         comparisonOperator:
           cloudwatch.ComparisonOperator.LESS_THAN_THRESHOLD,
-        treatMissingData: cloudwatch.TreatMissingData.BREACHING,
+        // The operational snapshot publishes on a slow cadence, not every period.
+        // BREACHING here made the alarm fire on absent datapoints rather than on a
+        // real zero, so it sat in ALARM permanently and carried no signal. Missing
+        // data now holds the last real state; a genuine 0 still trips the alarm.
+        treatMissingData: cloudwatch.TreatMissingData.MISSING,
       }
     );
     const connectorRevocationAlarm = new cloudwatch.Alarm(

--- a/infra/test/unit/ecs-service-atrium-public-base-url.test.ts
+++ b/infra/test/unit/ecs-service-atrium-public-base-url.test.ts
@@ -3,52 +3,57 @@ import * as ec2 from "aws-cdk-lib/aws-ec2";
 import { Match, Template } from "aws-cdk-lib/assertions";
 import { EcsServiceConstruct } from "../../lib/constructs/ecs-service";
 
-describe("ECS Service — Atrium public base URL", () => {
-  it("injects the canonical app origin into the frontend task", () => {
-    const app = new cdk.App();
-    const stack = new cdk.Stack(app, "TestStack", {
-      env: { account: "123456789012", region: "us-east-1" },
-    });
-    const vpc = new ec2.Vpc(stack, "TestVpc", { maxAzs: 2 });
-    const secretArn = (name: string) =>
-      `arn:aws:secretsmanager:us-east-1:123456789012:secret:aistudio-dev-${name}-AbCdEf`;
-    const appOrigin = "https://dev.aistudio.psd401.ai";
+describe("ECS Service — canonical app origin env vars", () => {
+  // APP_BASE_URL is load-bearing for the agent broker (/api/agent/aistudio),
+  // which throws when it is unset — every aistudio-MCP skill call fails closed.
+  it.each(["ATRIUM_PUBLIC_BASE_URL", "APP_BASE_URL"])(
+    "injects the canonical app origin as %s into the frontend task",
+    (envVarName) => {
+      const app = new cdk.App();
+      const stack = new cdk.Stack(app, "TestStack", {
+        env: { account: "123456789012", region: "us-east-1" },
+      });
+      const vpc = new ec2.Vpc(stack, "TestVpc", { maxAzs: 2 });
+      const secretArn = (name: string) =>
+        `arn:aws:secretsmanager:us-east-1:123456789012:secret:aistudio-dev-${name}-AbCdEf`;
+      const appOrigin = "https://dev.aistudio.psd401.ai";
 
-    new EcsServiceConstruct(stack, "EcsService", {
-      vpc,
-      environment: "dev",
-      documentsBucketName: "aistudio-dev-documents",
-      agentWorkspaceBucketName: "aistudio-dev-agent-workspace",
-      atriumSandboxOrigin: "https://sandbox.example.com",
-      dockerImageSource: "fromEcrRepository",
-      authUrl: appOrigin,
-      cognitoClientId: "test-client-id",
-      cognitoIssuer:
-        "https://cognito-idp.us-east-1.amazonaws.com/us-east-1_testpool",
-      rdsResourceArn:
-        "arn:aws:rds:us-east-1:123456789012:cluster:aistudio-dev-cluster",
-      rdsSecretArn: secretArn("db"),
-      authSecretArn: secretArn("auth"),
-      collabJwtSecretArn: secretArn("collab-jwt"),
-      guardrailHashSecretArn: secretArn("guardrail-hash"),
-      oidcCookieSecretArn: secretArn("oidc-cookie"),
-      oidcSigningJwksSecretArn: secretArn("oidc-signing"),
-    });
+      new EcsServiceConstruct(stack, "EcsService", {
+        vpc,
+        environment: "dev",
+        documentsBucketName: "aistudio-dev-documents",
+        agentWorkspaceBucketName: "aistudio-dev-agent-workspace",
+        atriumSandboxOrigin: "https://sandbox.example.com",
+        dockerImageSource: "fromEcrRepository",
+        authUrl: appOrigin,
+        cognitoClientId: "test-client-id",
+        cognitoIssuer:
+          "https://cognito-idp.us-east-1.amazonaws.com/us-east-1_testpool",
+        rdsResourceArn:
+          "arn:aws:rds:us-east-1:123456789012:cluster:aistudio-dev-cluster",
+        rdsSecretArn: secretArn("db"),
+        authSecretArn: secretArn("auth"),
+        collabJwtSecretArn: secretArn("collab-jwt"),
+        guardrailHashSecretArn: secretArn("guardrail-hash"),
+        oidcCookieSecretArn: secretArn("oidc-cookie"),
+        oidcSigningJwksSecretArn: secretArn("oidc-signing"),
+      });
 
-    Template.fromStack(stack).hasResourceProperties(
-      "AWS::ECS::TaskDefinition",
-      {
-        ContainerDefinitions: Match.arrayWith([
-          Match.objectLike({
-            Environment: Match.arrayWith([
-              {
-                Name: "ATRIUM_PUBLIC_BASE_URL",
-                Value: appOrigin,
-              },
-            ]),
-          }),
-        ]),
-      }
-    );
-  });
+      Template.fromStack(stack).hasResourceProperties(
+        "AWS::ECS::TaskDefinition",
+        {
+          ContainerDefinitions: Match.arrayWith([
+            Match.objectLike({
+              Environment: Match.arrayWith([
+                {
+                  Name: envVarName,
+                  Value: appOrigin,
+                },
+              ]),
+            }),
+          ]),
+        }
+      );
+    }
+  );
 });

--- a/infra/test/unit/unified-content-processing.test.ts
+++ b/infra/test/unit/unified-content-processing.test.ts
@@ -150,7 +150,10 @@ test("alarms on stalled work, failures, migration blockers, and stale indexes", 
     AlarmName: "aistudio-dev-agentic-models-unavailable",
     Threshold: 1,
     EvaluationPeriods: 2,
-    TreatMissingData: "breaching",
+    // The snapshot publishes slower than the evaluation period, so "breaching"
+    // fired on absent datapoints and pinned the alarm to ALARM regardless of the
+    // real value. Missing data must hold the last state instead.
+    TreatMissingData: "missing",
   });
   template.hasResourceProperties("AWS::CloudWatch::Alarm", {
     AlarmName: "aistudio-dev-repository-connector-revocations",


### PR DESCRIPTION
## Why

Audited prod `agent_failures` directly (RDS Data API) for anything still failing since the Friday-night agent push. **Exactly one row since Saturday 00:00 PDT** — and it's a config gap that is still live.

Failure volume collapsed after the push, so this is a targeted fix, not a regression sweep:

| Day (PDT) | Failure rows | Sessions | Tool calls (non-success) |
|---|---|---|---|
| Jul 29 | 34 | 5 | 977 (62) |
| Jul 30 | 14 | 7 | 825 (65) |
| Jul 31 | 15 | 5 | 122 (14) |
| **Aug 1 (Sat)** | **1** | 6 | 25 (4) |
| **Aug 2** | **0** | 0 | 0 |

Caveat: today had zero activity and Saturday only 13 messages, so most paths simply haven't been exercised since the push.

## 1. `APP_BASE_URL` missing from the ECS task definition (P0)

`app/api/agent/aistudio/route.ts:32-36` throws when `APP_BASE_URL` is unset — it's how the broker builds the internal `/api/mcp` URL. **No ECS task definition has ever set it.** Confirmed absent from the live prod *and* dev task defs. Every aistudio-MCP skill call fails closed in both environments.

Evidence: `agent_failures` id 292 (2026-08-01 15:25:59Z) + 3 `agent_tool_invocations` rows at 15:26:09Z, all `Agent broker rejected the request: AI Studio operation failed`.

One line — `APP_BASE_URL: props.authUrl` — next to the existing `ATRIUM_PUBLIC_BASE_URL`.

## 2. `agentic-models-unavailable` alarm carried no signal (P1)

The alarm evaluated over 2×5min with `treatMissingData: BREACHING`, but the metric publisher runs far slower (~4 datapoints across two days). It went ALARM **17 seconds after its own creation** on absent datapoints and has been pinned there since — red regardless of the real value.

Switched to `MISSING`. A genuine 0 still trips it, which matters: prod currently has **zero** rows with `active AND architect_enabled AND agentic_ready`, so the first agentic Assistant Architect run will throw `AGENTIC_MODEL_CONFIGURATION_ERROR`. That model config is being fixed separately in `/admin/models`; this makes the alarm capable of reporting it.

## Verification

The worktree's infra ts-jest harness is broken **independently of this change** — untouched suites fail identically on a clean tree (`Cannot read properties of undefined (reading 'fileExists')`). So both fixes were asserted directly against rendered CloudFormation via `Template.fromStack` under bun:

```
PASS  ATRIUM_PUBLIC_BASE_URL === https://dev.aistudio.psd401.ai
PASS  APP_BASE_URL === https://dev.aistudio.psd401.ai
PASS  agentic-models-unavailable TreatMissingData = missing
```

- Root `lint`: exit 0
- `infra tsc --noEmit`: exit 0
- Root `typecheck`: exit 1 — **21 pre-existing errors** in `infra/lambdas/agent-router/index.ts` (`@aws-sdk`/`@smithy/types` duplicate-version conflict). Identical count before and after; verified by stashing.

## Follow-up (not in this PR)

Set on Sonnet 4.6 (id 109) and Haiku 4.5 (id 96) via `/admin/models` in **both** environments — the admission gate requires all of these non-null:

| Field | Sonnet 4.6 | Haiku 4.5 |
|---|---|---|
| `agentic_ready` | true | true |
| `context_window_tokens` | 1000000 | 200000 |
| `max_output_tokens` | 128000 | 64000 |
| `input_cost_per_1k_tokens` | 0.003 *(set)* | 0.001 |
| `output_cost_per_1k_tokens` | 0.015 *(set)* | 0.005 |

## Out of scope

Repository/migration work (other agents active), DLQ backlogs and IAM boundary denies (both pre-Saturday, not recurring), and OpenClaw plugin reinstall on cold boot (12 occurrences in 2 days — resilience, not a failure).
