### PR TITLE
fix(content): surface orphaned migrated rows

### DIFF
--- a/lib/repositories/content-platform/migration-runner.ts
+++ b/lib/repositories/content-platform/migration-runner.ts
@@ -1385,7 +1385,9 @@ async function reconcileMigrationCandidate(
   tx: DbTransaction,
   candidate: RepositoryMigrationItemRow,
   runId: string,
-): Promise<"skipped" | "pending" | "verified" | "mismatch"> {
+): Promise<
+  "skipped" | "pending" | "verified" | "mismatch" | "unrecoverable"
+> {
   // Serialize reconciliation with administrator approval/reprocess actions.
   // A stale worker observation must never overwrite a freshly approved
   // mismatch or mark a version verified after reprocessing reset it.
@@ -1395,11 +1397,26 @@ async function reconcileMigrationCandidate(
     .where(eq(repositoryMigrationItems.id, candidate.id))
     .limit(1)
     .for("update");
-  if (
-    !migration?.canonicalVersionId ||
-    !["migrated", "mismatch"].includes(migration.status)
-  ) {
+  if (!migration || !["migrated", "mismatch"].includes(migration.status)) {
     return "skipped";
+  }
+  if (!migration.canonicalVersionId) {
+    await tx
+      .update(repositoryMigrationItems)
+      .set({
+        status: "unrecoverable",
+        lastErrorCode: "MIGRATION_CANONICAL_VERSION_MISSING",
+        lastErrorMessage:
+          "Migration is missing canonical version evidence; retry the source to recreate it",
+        verifiedAt: null,
+        metadata: {
+          ...migration.metadata,
+          lastReconciledRunId: runId,
+        },
+        updatedAt: new Date(),
+      })
+      .where(eq(repositoryMigrationItems.id, migration.id));
+    return "unrecoverable";
   }
   const evidence = toPgRows<{
     processing_status: string | null;
@@ -1498,7 +1515,6 @@ async function reconcileNextBatch(
         .where(
           and(
             inArray(repositoryMigrationItems.status, ["migrated", "mismatch"]),
-            sql`${repositoryMigrationItems.canonicalVersionId} IS NOT NULL`,
             sql`COALESCE(
               ${repositoryMigrationItems.metadata} ->> 'lastReconciledRunId',
               ''
@@ -1525,7 +1541,6 @@ async function reconcileNextBatch(
           SELECT COUNT(*)::integer AS count
           FROM repository_migration_items
           WHERE status IN ('migrated', 'mismatch')
-            AND canonical_version_id IS NOT NULL
             AND COALESCE(metadata ->> 'lastReconciledRunId', '') <> ${run.id}
         `),
         "contentMigration.remainingReconciliation",
@@ -1539,6 +1554,8 @@ async function reconcileNextBatch(
           .update(repositoryMigrationRuns)
           .set({
             status:
+              (metrics.failed ?? 0) > 0 ||
+              (metrics.unrecoverable ?? 0) > 0 ||
               (metrics.mismatched ?? 0) > 0
                 ? "completed_with_errors"
                 : "completed",

--- a/tests/unit/content-migration-retry-targeting.test.ts
+++ b/tests/unit/content-migration-retry-targeting.test.ts
@@ -136,4 +136,25 @@ describe("repository migration retry targeting", () => {
     expect(migrationReasonDialog).toContain("minLength={10}");
     expect(migrationReasonDialog).toContain("maxLength={1000}");
   });
+
+  it("turns migrated rows without canonical versions into retryable exceptions", () => {
+    const functionStart = migrationRunner.indexOf(
+      "async function reconcileMigrationCandidate",
+    );
+    const functionEnd = migrationRunner.indexOf(
+      "async function finishPreviouslyPreparedRollback",
+      functionStart,
+    );
+    const reconciliation = migrationRunner.slice(functionStart, functionEnd);
+
+    expect(reconciliation).toContain(
+      'lastErrorCode: "MIGRATION_CANONICAL_VERSION_MISSING"',
+    );
+    expect(reconciliation).toContain('status: "unrecoverable"');
+    expect(reconciliation).toContain('return "unrecoverable"');
+    expect(reconciliation).not.toContain("canonical_version_id IS NOT NULL");
+    expect(reconciliation).not.toContain(
+      "repositoryMigrationItems.canonicalVersionId} IS NOT NULL",
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- reconcile migrated rows even when canonical version evidence is missing
- classify the malformed state as a retryable unrecoverable exception instead of silently completing
- mark reconciliation runs completed-with-errors when failed or unrecoverable rows remain

## Production evidence
Prod has exactly one migrated row skipped by the old canonical-version filter; the run completed with 96 migrated / 95 verified and no reconciliation candidate execution.

## Verification
- focused migration Jest: 17 passed
- focused ESLint: passed
- full TypeScript check: passed

Follow-up for #1531.