### PR TITLE
fix(content): retry existing canonical migrations

### DIFF
--- a/lib/repositories/content-platform/migration-runner.ts
+++ b/lib/repositories/content-platform/migration-runner.ts
@@ -290,7 +290,8 @@ async function loadNextRepositoryCandidate(
                 AND connector_source.status = 'unsupported'
             )
             AND (
-              item.current_version_id IS NULL
+              ${discoverUntrackedSources} = FALSE
+              OR item.current_version_id IS NULL
               OR EXISTS (
                 SELECT 1
                 FROM repository_item_chunks legacy_chunk

--- a/tests/unit/content-migration-retry-targeting.test.ts
+++ b/tests/unit/content-migration-retry-targeting.test.ts
@@ -72,6 +72,30 @@ describe("repository migration retry targeting", () => {
     expect(retryOnlyIds).toHaveLength(selectedRetryIds.size);
   });
 
+  it("allows targeted retries to re-register an existing canonical version", () => {
+    const repositoryCandidateStart = migrationRunner.indexOf(
+      "async function loadNextRepositoryCandidate",
+    );
+    const repositoryCandidateEnd = migrationRunner.indexOf(
+      "async function loadNextCandidate",
+      repositoryCandidateStart,
+    );
+    const repositoryCandidate = migrationRunner.slice(
+      repositoryCandidateStart,
+      repositoryCandidateEnd,
+    );
+
+    expect(repositoryCandidate).toMatch(
+      /\$\{discoverUntrackedSources\} = FALSE[\s\S]*?item\.current_version_id IS NULL/,
+    );
+    expect(repositoryCandidate).toContain(
+      "migration.run_id = ${run.id}::uuid",
+    );
+    expect(migrationRunner).toContain(
+      "await registerExistingCanonicalVersion(candidate, reserved, targetKey)",
+    );
+  });
+
   it("applies an exception-status filter before the bounded query limit", () => {
     const functionStart = migrationControlService.indexOf(
       "export async function listRepositoryMigrationExceptions",


### PR DESCRIPTION
## Summary
- allow retry-only repository migration runs to select already-canonical items
- re-register the item's existing canonical version instead of leaving the migration pending
- add regression coverage for targeted retry selection

## Production evidence
Repository item #37 was correctly surfaced as missing canonical migration evidence. Retry reset it to pending, but the normal discovery filter skipped it because the item already has a canonical version and no legacy chunks.

## Validation
- bunx jest tests/unit/content-migration-retry-targeting.test.ts --runInBand
- bunx eslint lib/repositories/content-platform/migration-runner.ts tests/unit/content-migration-retry-targeting.test.ts
- bun run typecheck
- bunx eslint . --max-warnings 0 --ignore-pattern lib/utils/text-sanitizer.js

Full lint without the ignore is blocked only by the pre-existing untracked lib/utils/text-sanitizer.js file.