### PR TITLE
fix(agent): persist dmSpaceName from DM events and warn on unmonitored deploys

### DIFF
--- a/infra/lambdas/agent-router/index.test.ts
+++ b/infra/lambdas/agent-router/index.test.ts
@@ -2025,3 +2025,37 @@ describe("background promotion bounded idempotent retry", () => {
     expect(released).toEqual([])
   })
 })
+
+describe("dmSpaceForUserRecord", () => {
+  const { dmSpaceForUserRecord } = agentRouterTestHelpers
+
+  test("records the space for a 1:1 DM", () => {
+    expect(
+      dmSpaceForUserRecord({ name: "spaces/AAA1", type: "DM" }, "spaces/AAA1"),
+    ).toBe("spaces/AAA1")
+  })
+
+  // Scheduled runs deliver to whatever is stored here. A ROOM is shared, so
+  // recording one would publish an owner's scheduled output to other people.
+  test("never records a shared ROOM", () => {
+    expect(
+      dmSpaceForUserRecord({ name: "spaces/BBB2", type: "ROOM" }, "spaces/BBB2"),
+    ).toBeUndefined()
+  })
+
+  test("fails closed on an unspecified space type", () => {
+    expect(
+      dmSpaceForUserRecord(
+        { name: "spaces/CCC3", type: "TYPE_UNSPECIFIED" },
+        "spaces/CCC3",
+      ),
+    ).toBeUndefined()
+  })
+
+  test("rejects a malformed space resource name", () => {
+    expect(
+      dmSpaceForUserRecord({ name: "DDD4", type: "DM" }, "DDD4"),
+    ).toBeUndefined()
+    expect(dmSpaceForUserRecord({ name: "", type: "DM" }, "")).toBeUndefined()
+  })
+})

--- a/infra/lambdas/agent-router/index.ts
+++ b/infra/lambdas/agent-router/index.ts
@@ -471,6 +471,11 @@ interface AgentUser {
   //   excluded  — a student (numeric-prefix) username; never provisioned
   agentAccountStatus?: 'none' | 'requested' | 'active' | 'excluded';
   agentAccountCheckedAt?: string;
+  // Resource name of this user's 1:1 DM space with the bot ("spaces/..."),
+  // captured from live DM events. Scheduled runs post their results here, and
+  // the schedules service refuses to create a schedule without it. Absent until
+  // the user has DM'd the agent at least once.
+  dmSpaceName?: string;
 }
 
 /**
@@ -1425,12 +1430,39 @@ async function persistAgentAccountStatus(
 // User management
 // ---------------------------------------------------------------------------
 
+/**
+ * The DM space to record on a user's record for this event, or undefined.
+ *
+ * Only a 1:1 DM identifies an owner's personal delivery space. Scheduled runs
+ * post their results to whatever is stored here, so recording a ROOM would
+ * publish that owner's scheduled output into a space other people can read.
+ * Fail closed on anything that is not explicitly a DM.
+ */
+function dmSpaceForUserRecord(
+  space: GoogleChatEvent['space'],
+  spaceName: string
+): string | undefined {
+  if (space?.type !== 'DM') return undefined;
+  if (typeof spaceName !== 'string' || !/^spaces\/[\w-]{1,256}$/.test(spaceName)) {
+    return undefined;
+  }
+  return spaceName;
+}
+
 async function getOrCreateUser(
   senderName: string,
   senderEmail: string,
   senderDisplayName: string,
+  dmSpaceName: string | undefined,
   log: ReturnType<typeof createLogger>
 ): Promise<AgentUser> {
+  // The DM space resource name is only knowable from a live DM event, and it is
+  // a hard precondition for scheduled delivery: agent-cron posts results to
+  // schedule.dmSpaceName and the schedules service refuses to create a schedule
+  // for an owner whose user record has none. Nothing else writes it here, so
+  // without this a user could DM the agent for months and still be unable to
+  // create a schedule. Persist it whenever a DM tells us what it is.
+  const now = new Date().toISOString();
   // Optimized: single conditional UpdateCommand for existing users instead of
   // Get + Update (saves ~10–30ms per message). Falls back to PutCommand for new users.
   try {
@@ -1438,9 +1470,13 @@ async function getOrCreateUser(
       new UpdateCommand({
         TableName: USERS_TABLE,
         Key: { googleIdentity: senderName },
-        UpdateExpression: 'SET lastActiveAt = :now',
+        UpdateExpression: dmSpaceName
+          ? 'SET lastActiveAt = :now, dmSpaceName = :dm'
+          : 'SET lastActiveAt = :now',
         ConditionExpression: 'attribute_exists(googleIdentity)',
-        ExpressionAttributeValues: { ':now': new Date().toISOString() },
+        ExpressionAttributeValues: dmSpaceName
+          ? { ':now': now, ':dm': dmSpaceName }
+          : { ':now': now },
         ReturnValues: 'ALL_NEW',
       })
     );
@@ -1467,10 +1503,11 @@ async function getOrCreateUser(
     displayName: senderDisplayName,
     department: 'unknown', // Updated by admin later or via directory sync
     workspacePrefix,
-    createdAt: new Date().toISOString(),
-    lastActiveAt: new Date().toISOString(),
+    createdAt: now,
+    lastActiveAt: now,
     sessionCount: 0,
     agentAccountStatus: 'none', // #1233 — provisioned automatically on first messages
+    ...(dmSpaceName ? { dmSpaceName } : {}),
   };
 
   // Conditional put prevents race condition: if two messages arrive simultaneously
@@ -1504,9 +1541,13 @@ async function getOrCreateUser(
       new UpdateCommand({
         TableName: USERS_TABLE,
         Key: { googleIdentity: senderName },
-        UpdateExpression: 'SET lastActiveAt = :now',
+        UpdateExpression: dmSpaceName
+          ? 'SET lastActiveAt = :now, dmSpaceName = :dm'
+          : 'SET lastActiveAt = :now',
         ConditionExpression: 'attribute_exists(googleIdentity)',
-        ExpressionAttributeValues: { ':now': new Date().toISOString() },
+        ExpressionAttributeValues: dmSpaceName
+          ? { ':now': now, ':dm': dmSpaceName }
+          : { ':now': now },
         ReturnValues: 'ALL_NEW',
       })
     );
@@ -4510,6 +4551,7 @@ async function prepareHumanTurn(
     human.senderName,
     human.senderEmail,
     human.senderDisplayName,
+    dmSpaceForUserRecord(human.chatEvent.space, human.spaceName),
     log
   );
   void maybeProvisionAgentAccount(user, human.senderEmail, log);
@@ -5350,6 +5392,7 @@ async function processRecord(
 }
 
 export const agentRouterTestHelpers = {
+  dmSpaceForUserRecord,
   normalizeChatEvent,
   cardClickMessageText,
   parseAgentCoreResult,

--- a/infra/lib/agent-platform-stack.ts
+++ b/infra/lib/agent-platform-stack.ts
@@ -925,6 +925,24 @@ export class AgentPlatformStack extends cdk.Stack {
     // create for Router DLQ alerts further down. But we need it early here,
     // so we create it right now if alertEmail is configured; the DLQ block
     // below will reuse it.
+    //
+    // Without alertEmail there is no topic, and every `if (agentAlarmTopic)`
+    // guard below silently skips its addAlarmAction — the stack deploys with
+    // alarms that evaluate correctly and notify nobody, with nothing in the
+    // output to say so. Make that state loud instead of silent.
+    //
+    // Note this warns about a *missing* address only. An SNS email
+    // subscription also has to be confirmed by the recipient: AWS deletes
+    // unconfirmed email subscriptions after 3 days, while CloudFormation keeps
+    // the resource CREATE_COMPLETE forever, so no later deploy restores it.
+    // That failure is invisible to synth — verify delivery out-of-band with
+    // `aws sns get-topic-attributes --topic-arn <arn>` and check that
+    // SubscriptionsConfirmed is non-zero.
+    if (!props.alertEmail) {
+      cdk.Annotations.of(this).addWarning(
+        `No alertEmail context set for ${environment}: the agent alarm topic will not be created and every agent-platform alarm (cron errors, throttles, DLQ, schedule-reference rejections) will fire to nobody. Deploy with --context alertEmail=<address>.`,
+      );
+    }
     if (props.alertEmail) {
       resources.agentAlarmTopic = new sns.Topic(this, 'AgentAlarmTopic', {
         topicName: `psd-agent-alarms-${environment}`,

--- a/infra/lib/constructs/ecs-service.ts
+++ b/infra/lib/constructs/ecs-service.ts
@@ -1066,6 +1066,11 @@ export class EcsServiceConstruct extends Construct {
       // ECS service's authoritative auth origin so deployed links are never
       // relative or dependent on a separately hand-managed value.
       ATRIUM_PUBLIC_BASE_URL: props.authUrl,
+      // Absolute origin the agent broker (/api/agent/aistudio) uses to build the
+      // internal /api/mcp URL. Required — the route throws when it is unset, so
+      // every aistudio-MCP skill call fails closed without it. Same authoritative
+      // origin as AUTH_URL; the broker also enforces HTTPS.
+      APP_BASE_URL: props.authUrl,
       AUTH_COGNITO_CLIENT_ID: props.cognitoClientId,
       AUTH_COGNITO_ISSUER: props.cognitoIssuer,
       // Legacy RDS Data API variables (kept for backward compatibility during migration)

--- a/infra/lib/constructs/processing/unified-content-processing.ts
+++ b/infra/lib/constructs/processing/unified-content-processing.ts
@@ -767,7 +767,11 @@ export class UnifiedContentProcessing extends Construct {
         evaluationPeriods: 2,
         comparisonOperator:
           cloudwatch.ComparisonOperator.LESS_THAN_THRESHOLD,
-        treatMissingData: cloudwatch.TreatMissingData.BREACHING,
+        // The operational snapshot publishes on a slow cadence, not every period.
+        // BREACHING here made the alarm fire on absent datapoints rather than on a
+        // real zero, so it sat in ALARM permanently and carried no signal. Missing
+        // data now holds the last real state; a genuine 0 still trips the alarm.
+        treatMissingData: cloudwatch.TreatMissingData.MISSING,
       }
     );
     const connectorRevocationAlarm = new cloudwatch.Alarm(

--- a/infra/test/unit/ecs-service-atrium-public-base-url.test.ts
+++ b/infra/test/unit/ecs-service-atrium-public-base-url.test.ts
@@ -3,52 +3,57 @@ import * as ec2 from "aws-cdk-lib/aws-ec2";
 import { Match, Template } from "aws-cdk-lib/assertions";
 import { EcsServiceConstruct } from "../../lib/constructs/ecs-service";
 
-describe("ECS Service — Atrium public base URL", () => {
-  it("injects the canonical app origin into the frontend task", () => {
-    const app = new cdk.App();
-    const stack = new cdk.Stack(app, "TestStack", {
-      env: { account: "123456789012", region: "us-east-1" },
-    });
-    const vpc = new ec2.Vpc(stack, "TestVpc", { maxAzs: 2 });
-    const secretArn = (name: string) =>
-      `arn:aws:secretsmanager:us-east-1:123456789012:secret:aistudio-dev-${name}-AbCdEf`;
-    const appOrigin = "https://dev.aistudio.psd401.ai";
+describe("ECS Service — canonical app origin env vars", () => {
+  // APP_BASE_URL is load-bearing for the agent broker (/api/agent/aistudio),
+  // which throws when it is unset — every aistudio-MCP skill call fails closed.
+  it.each(["ATRIUM_PUBLIC_BASE_URL", "APP_BASE_URL"])(
+    "injects the canonical app origin as %s into the frontend task",
+    (envVarName) => {
+      const app = new cdk.App();
+      const stack = new cdk.Stack(app, "TestStack", {
+        env: { account: "123456789012", region: "us-east-1" },
+      });
+      const vpc = new ec2.Vpc(stack, "TestVpc", { maxAzs: 2 });
+      const secretArn = (name: string) =>
+        `arn:aws:secretsmanager:us-east-1:123456789012:secret:aistudio-dev-${name}-AbCdEf`;
+      const appOrigin = "https://dev.aistudio.psd401.ai";
 
-    new EcsServiceConstruct(stack, "EcsService", {
-      vpc,
-      environment: "dev",
-      documentsBucketName: "aistudio-dev-documents",
-      agentWorkspaceBucketName: "aistudio-dev-agent-workspace",
-      atriumSandboxOrigin: "https://sandbox.example.com",
-      dockerImageSource: "fromEcrRepository",
-      authUrl: appOrigin,
-      cognitoClientId: "test-client-id",
-      cognitoIssuer:
-        "https://cognito-idp.us-east-1.amazonaws.com/us-east-1_testpool",
-      rdsResourceArn:
-        "arn:aws:rds:us-east-1:123456789012:cluster:aistudio-dev-cluster",
-      rdsSecretArn: secretArn("db"),
-      authSecretArn: secretArn("auth"),
-      collabJwtSecretArn: secretArn("collab-jwt"),
-      guardrailHashSecretArn: secretArn("guardrail-hash"),
-      oidcCookieSecretArn: secretArn("oidc-cookie"),
-      oidcSigningJwksSecretArn: secretArn("oidc-signing"),
-    });
+      new EcsServiceConstruct(stack, "EcsService", {
+        vpc,
+        environment: "dev",
+        documentsBucketName: "aistudio-dev-documents",
+        agentWorkspaceBucketName: "aistudio-dev-agent-workspace",
+        atriumSandboxOrigin: "https://sandbox.example.com",
+        dockerImageSource: "fromEcrRepository",
+        authUrl: appOrigin,
+        cognitoClientId: "test-client-id",
+        cognitoIssuer:
+          "https://cognito-idp.us-east-1.amazonaws.com/us-east-1_testpool",
+        rdsResourceArn:
+          "arn:aws:rds:us-east-1:123456789012:cluster:aistudio-dev-cluster",
+        rdsSecretArn: secretArn("db"),
+        authSecretArn: secretArn("auth"),
+        collabJwtSecretArn: secretArn("collab-jwt"),
+        guardrailHashSecretArn: secretArn("guardrail-hash"),
+        oidcCookieSecretArn: secretArn("oidc-cookie"),
+        oidcSigningJwksSecretArn: secretArn("oidc-signing"),
+      });
 
-    Template.fromStack(stack).hasResourceProperties(
-      "AWS::ECS::TaskDefinition",
-      {
-        ContainerDefinitions: Match.arrayWith([
-          Match.objectLike({
-            Environment: Match.arrayWith([
-              {
-                Name: "ATRIUM_PUBLIC_BASE_URL",
-                Value: appOrigin,
-              },
-            ]),
-          }),
-        ]),
-      }
-    );
-  });
+      Template.fromStack(stack).hasResourceProperties(
+        "AWS::ECS::TaskDefinition",
+        {
+          ContainerDefinitions: Match.arrayWith([
+            Match.objectLike({
+              Environment: Match.arrayWith([
+                {
+                  Name: envVarName,
+                  Value: appOrigin,
+                },
+              ]),
+            }),
+          ]),
+        }
+      );
+    }
+  );
 });

--- a/infra/test/unit/unified-content-processing.test.ts
+++ b/infra/test/unit/unified-content-processing.test.ts
@@ -150,7 +150,10 @@ test("alarms on stalled work, failures, migration blockers, and stale indexes", 
     AlarmName: "aistudio-dev-agentic-models-unavailable",
     Threshold: 1,
     EvaluationPeriods: 2,
-    TreatMissingData: "breaching",
+    // The snapshot publishes slower than the evaluation period, so "breaching"
+    // fired on absent datapoints and pinned the alarm to ALARM regardless of the
+    // real value. Missing data must hold the last state instead.
+    TreatMissingData: "missing",
   });
   template.hasResourceProperties("AWS::CloudWatch::Alarm", {
     AlarmName: "aistudio-dev-repository-connector-revocations",


### PR DESCRIPTION
## Why

Follow-up to tonight's agent-schedule outage. Scheduled runs had been silently skipped for **every user for 7+ days**. The data was repaired out-of-band; these are the two code-level causes behind it.

## 1. Nothing ever wrote `dmSpaceName` to the users table (P0 — breaks fresh installs)

`resolveOwnerMetadata()` throws `AgentScheduleUserNotReadyError` when the selected `psd-agent-users-{env}` record has no `dmSpaceName`, and agent-cron delivers every scheduled result to `schedule.dmSpaceName`.

**The only writer of that attribute anywhere in the codebase** is `agent-triage-poll/storage.ts` `backfillDmSpaceName()` — and it writes to the *triage* table (keyed by `userEmail`), not the users table (keyed by `googleIdentity`).

It was therefore never populated for anyone: **0 of 39 prod and 0 of 35 dev** user records had it. Creating a schedule failed for every user — including on a completely fresh install of this system.

The router already receives the DM space on every message and already writes to the users table in `getOrCreateUser()`. Persist it there, across all three paths (conditional update, new-user put, concurrent-creation retry).

The decision is extracted into `dmSpaceForUserRecord()` rather than inlined, because it's security-relevant: scheduled output goes to whatever is stored in this field, so recording a shared ROOM would publish one owner's results into a space other people can read. It fails closed — recorded only when `space.type === 'DM'` **and** the name matches `^spaces/[\w-]{1,256}$`.

## 2. A deploy without `alertEmail` silently produces an unmonitored stack (P1)

The SNS alarm topic is only created when `props.alertEmail` is set, and every `addAlarmAction` is guarded by `if (resources.agentAlarmTopic)`. With it unset, the stack deploys cleanly with cron-error, throttle, DLQ, and schedule-rejection alarms that evaluate correctly and **notify nobody** — with nothing in the synth output saying so. Added a synth-time warning naming the consequence.

### The subtler failure this does *not* catch

Worth reading, because it's what actually happened and it's invisible to synth:

- CloudFormation: `AgentAlarmTopictechalertspsd401net5CAAD122` → **`CREATE_COMPLETE`**
- SNS: `SubscriptionsConfirmed: 0, Pending: 0, Deleted: 0`

The email subscription was **never confirmed**. AWS deletes unconfirmed email subscriptions after 3 days, but CloudFormation still holds the resource as created — so **no later deploy will ever restore it**. The stack looks healthy; the alarm path is dead. Both environments.

That's why a total scheduling outage ran for over a week with zero notification. Recorded in a code comment with the out-of-band check (`aws sns get-topic-attributes`, `SubscriptionsConfirmed` must be non-zero). Subscriptions have been re-created and are pending confirmation.

## Deliberately not included

Relaxing the schedule-record validators to derive missing `version`/`schedulerExpression`/`workspacePrefix` on read. It would make legacy records self-heal, but it loosens a version check that exists to reject replay of a stale schedule reference — on a path that is now working. That deserves its own change, not a fold-in at the end of an incident.

## Verification

- `bun test infra/lambdas/agent-router/index.test.ts` → **64 pass, 0 fail** (4 new)
- Root `lint`: exit 0 · `infra tsc --noEmit`: exit 0
- `lambdas/tsconfig.test.json` reports 388 errors across many untouched files (missing per-lambda `node_modules`, absent `bun:test` types, es2022 lib mismatch) — **identical count before and after**, verified by stashing
