### PR TITLE
fix(agent): allow agent-slot Workspace mutations previously blocked by an unsatisfiable gate

### DIFF
--- a/infra/agent-image/skills/psd-workspace/common.js
+++ b/infra/agent-image/skills/psd-workspace/common.js
@@ -339,20 +339,14 @@ const USER_SCOPE_FORBIDDEN = [
     reason: 'creating a Google Slides deck owned by the user (create as the agent and share explicitly instead)' },
 ];
 
-const PROVENANCE_REQUIRED = [
-  { pattern: /\bcalendar[\s.]+events[\s.]+(patch|update)\b/i,
-    reason: 'calendar updates require server-recorded agent-created provenance' },
-  { pattern: /\btasks[\s.]+tasks[\s.]+(patch|update)\b/i,
-    reason: 'task updates require server-recorded agent-created provenance' },
-  { pattern: /\bdocs[\s.]+documents[\s.]+batchupdate\b/i,
-    reason: 'document mutations require server-recorded agent-created provenance' },
-  { pattern: /\bsheets[\s.]+spreadsheets[\s.]+batchupdate\b/i,
-    reason: 'spreadsheet mutations require server-recorded agent-created provenance' },
-  { pattern: /\bslides[\s.]+presentations[\s.]+batchupdate\b/i,
-    reason: 'presentation mutations require server-recorded agent-created provenance' },
-  { pattern: /\bdrive[\s.]+permissions[\s.]+create\b/i,
-    reason: 'permission creation requires server-recorded agent-created provenance' },
-];
+// Structural mutations of existing content. These were previously refused here
+// and by the broker, on a provenance requirement that nothing could satisfy —
+// no store recorded which files the agent created, so the check threw
+// unconditionally and an agent could create a Doc it could never write to or
+// share (agent_failures 798). They are now ordinary agent-slot writes; the
+// broker still confines them to the agent account via AGENT_ONLY_WRITES, and
+// USER_SCOPE_FORBIDDEN below keeps the user slot's impersonation boundary.
+const PROVENANCE_REQUIRED = [];
 
 const PHASE1_FORBIDDEN = [
   // Send mail — any path that puts a message on the wire

--- a/lib/agent-workspace/command-executor.ts
+++ b/lib/agent-workspace/command-executor.ts
@@ -63,35 +63,41 @@ const MUTATING_ACTIONS = new Set([
 
 const ALLOWED_WRITES = new Set([
   "calendar events insert",
+  "calendar events patch",
+  "calendar events update",
   "chat +send",
   "chat spaces messages create",
+  "docs documents batchupdate",
   "docs documents create",
   "drive files copy",
   "drive files create",
+  "drive permissions create",
   "gmail users drafts create",
   "gmail users drafts update",
   "gmail users messages modify",
+  "sheets spreadsheets batchupdate",
   "sheets spreadsheets create",
   "sheets spreadsheets values append",
   "sheets spreadsheets values update",
+  "slides presentations batchupdate",
   "slides presentations create",
   "tasks tasks insert",
-])
-
-const REQUIRES_AGENT_CREATED_PROVENANCE = new Set([
-  "calendar events patch",
-  "calendar events update",
-  "docs documents batchupdate",
-  "drive permissions create",
-  "sheets spreadsheets batchupdate",
-  "slides presentations batchupdate",
   "tasks tasks patch",
   "tasks tasks update",
 ])
 
-// Sheet values append/update intentionally stay outside the provenance gate:
-// issue #1514 restores content sync for sheets the agent account created or
-// that a user deliberately shared with it. Batch structural edits remain gated.
+// These mutations were previously refused outright by a provenance gate that
+// nothing could satisfy: it threw unconditionally, with no store recording which
+// files the agent created and no branch that ever returned success. The name and
+// the error described a condition the codebase could not produce, so an agent
+// could create a Doc and then never write to or share it — the observed failure
+// was three empty, unshareable Docs (agent_failures 798).
+//
+// They are now ordinary allowlisted writes, confined to the agent slot by
+// AGENT_ONLY_WRITES below. That confinement is what remains of the original
+// intent: the agent may restructure documents, calendars and tasks owned by its
+// own account, and is still refused on the user slot, where the same call would
+// be impersonation against the user's own Workspace.
 
 // Derived rather than enumerated: every allowlisted Chat write leaves the
 // owner's own Workspace data and therefore has to reach the audit log, so a
@@ -102,13 +108,25 @@ const ALLOWED_CHAT_WRITES = new Set(
 
 const AGENT_ONLY_WRITES = new Set([
   ...ALLOWED_CHAT_WRITES,
+  // Structural mutations of existing content. On the agent slot these act on
+  // the agent's own files; on the user slot the same call would restructure the
+  // user's own Workspace as them, which is the impersonation boundary the
+  // create operations below are already held to.
+  "calendar events patch",
+  "calendar events update",
+  "docs documents batchupdate",
   "docs documents create",
   "drive files copy",
   "drive files create",
+  "drive permissions create",
+  "sheets spreadsheets batchupdate",
   "sheets spreadsheets create",
   "sheets spreadsheets values append",
   "sheets spreadsheets values update",
+  "slides presentations batchupdate",
   "slides presentations create",
+  "tasks tasks patch",
+  "tasks tasks update",
 ])
 
 const DRIVE_FOLDER_MIME = "application/vnd.google-apps.folder"
@@ -360,11 +378,6 @@ function validateWorkspaceMutation(
   if (scope === "user" && operation === "drive files update") {
     validateUserDriveMetadataUpdate(argv)
     return
-  }
-  if (REQUIRES_AGENT_CREATED_PROVENANCE.has(operation)) {
-    throw new Error(
-      "Workspace mutation requires server-recorded agent-created provenance"
-    )
   }
   if (!ALLOWED_WRITES.has(operation)) {
     const diagnosticOperation = workspaceOperation(argv)

--- a/tests/unit/lib/agent-workspace/command-executor.test.ts
+++ b/tests/unit/lib/agent-workspace/command-executor.test.ts
@@ -253,10 +253,13 @@ function defineTrustedWorkspaceCommandPolicySuite1Part3() {it("rejects Gmail mod
     ["slides", "presentations", "batchUpdate"],
     ["tasks", "tasks", "patch"],
     ["tasks", "tasks", "update"],
-  ])("denies %s %s %s without server-recorded provenance", (...argv) => {
+  ])("allows %s %s %s on the agent slot", (...argv) => {
+    // These were refused by a provenance gate that nothing could satisfy, so an
+    // agent could create a Doc and never write to or share it (agent_failures
+    // 798). They are ordinary agent-slot writes now.
     expect(() =>
       validateWorkspaceCommand({ scope: "agent", argv })
-    ).toThrow(/server-recorded agent-created provenance/)
+    ).not.toThrow()
   })
 
   it.each([
@@ -383,10 +386,30 @@ function defineTrustedWorkspaceCommandPolicySuite1Part3() {it("rejects Gmail mod
   })
 }
 
+function defineTrustedWorkspaceCommandPolicySuite1Part4() {
+  it.each([
+    ["calendar", "events", "patch"],
+    ["calendar", "events", "update"],
+    ["docs", "documents", "batchUpdate"],
+    ["drive", "permissions", "create"],
+    ["sheets", "spreadsheets", "batchUpdate"],
+    ["slides", "presentations", "batchUpdate"],
+    ["tasks", "tasks", "patch"],
+    ["tasks", "tasks", "update"],
+  ])("still refuses %s %s %s on the user slot", (...argv) => {
+    // The impersonation boundary is what survives removing the gate: the same
+    // call on the user slot would restructure the user's own Workspace as them.
+    expect(() =>
+      validateWorkspaceCommand({ scope: "user", argv })
+    ).toThrow(/must use the agent-owned Workspace account/)
+  })
+}
+
 const defineTrustedWorkspaceCommandPolicySuite1 = () => {
   defineTrustedWorkspaceCommandPolicySuite1Part1()
   defineTrustedWorkspaceCommandPolicySuite1Part2()
   defineTrustedWorkspaceCommandPolicySuite1Part3()
+  defineTrustedWorkspaceCommandPolicySuite1Part4()
 };
 
 describe("trusted Workspace command policy", defineTrustedWorkspaceCommandPolicySuite1)


### PR DESCRIPTION
Closes the last open item from the 2026-08-03 morning failure triage.

## The gate could not be satisfied

`validateWorkspaceCommand` refused eight operations with *"Workspace mutation requires server-recorded agent-created provenance"*. The entire implementation:

```ts
if (REQUIRES_AGENT_CREATED_PROVENANCE.has(operation)) {
  throw new Error("Workspace mutation requires server-recorded agent-created provenance")
}
```

No store recorded which files the agent created. No branch ever returned success. The name and the error described a condition the codebase **could not produce** — so it read like a check and behaved as a permanent denial list.

## Observed impact — `agent_failures` 798

`docs documents create` *is* allowed. So the agent created a Doc, then every attempt to write content into it was refused, and so was sharing it back. dizond ended up with **three separate empty Docs** after retries and delays, none shareable. The agent's own report named it: *"the skill has no confirmation-flow path exposed to the model to satisfy that requirement."*

## Removing the throw alone would have fixed nothing

None of the eight operations were in `ALLOWED_WRITES`, so they'd have fallen straight through to `"Workspace operation is not allowed"` — the same denial with a different message. Three changes were needed together:

1. Delete `REQUIRES_AGENT_CREATED_PROVENANCE` and its throw
2. Add the eight operations to `ALLOWED_WRITES` so they're reachable
3. Add them to `AGENT_ONLY_WRITES` so they're confined to the agent slot

## What survives

**(3) is the part of the original intent worth keeping.** The agent may restructure documents, calendars and tasks owned by *its own account*. The same call on the **user slot** is still refused with `must use the agent-owned Workspace account` — the impersonation boundary the create operations were already held to.

The client-side mirror in `psd-workspace/common.js` is emptied too; `USER_SCOPE_FORBIDDEN` there continues to enforce the user-slot boundary.

## Tradeoff, stated plainly

An unattended agent run can now batch-modify Docs, Sheets and Slides, patch calendar events and tasks, and create Drive permissions — as the agent account. Sheet values append/update were already outside the gate under #1514. This was raised with the repository owner, who directed the removal.

## Tests

The eight cases that asserted the provenance throw now assert the operations are **permitted on the agent slot**, and a new case asserts each is **still refused on the user slot** — the boundary that actually survives. Split into `Part4` to stay under `max-lines-per-function`, matching the file's existing structure.

- `command-executor` suite: **85/85**
- `psd-workspace` skill suite: **73/73**
- Root `lint`: exit 0 · Root `typecheck`: exit 0

## Deployment

Both tiers: the server-side allowlist ships with the web tier, the client-side mirror with the agent image.
