### PR TITLE
fix(agent-image): warn about the workspace cutover only when it actually applies

### DIFF
--- a/infra/agent-image/build-and-push.sh
+++ b/infra/agent-image/build-and-push.sh
@@ -671,6 +671,15 @@ echo ""
 echo "Pushing ${ECR_URI}:${TAG}..."
 docker push "${ECR_URI}:${TAG}"
 
+# Second, machine-readable tag recording the exact commit this image was built
+# from. The next build reads it back off the *deployed* image to decide whether
+# a workspace cutover is genuinely required, instead of warning on every push.
+# Tag names cannot hold all of a 40-char sha plus a prefix comfortably, and 12
+# hex is unambiguous at this repository's size.
+COMMIT_TAG="commit-${SOURCE_COMMIT:0:12}"
+docker tag "${ECR_URI}:${TAG}" "${ECR_URI}:${COMMIT_TAG}"
+docker push "${ECR_URI}:${COMMIT_TAG}"
+
 # Resolve the immutable digest so the caller can pin AgentCore by digest.
 # Tag-based pinning has produced stale image serving in AgentCore — see PR #902.
 echo ""
@@ -698,18 +707,93 @@ echo ""
 echo "Image:  ${ECR_URI}:${TAG}"
 echo "Digest: ${DIGEST}"
 echo ""
-if [ "${ENVIRONMENT}" = "dev" ]; then
-  echo "NEXT STEP REQUIRES A PAUSED, SAME-COMMIT WORKSPACE CUTOVER."
-  echo "DO NOT deploy AgentPlatform directly or mix this image with the old broker."
-  echo "Follow all steps under 'Dev workspace-generation cutover' in:"
-  echo "  docs/operations/agent-platform-setup.md"
-  echo "The sequence pauses ingress, drains writers, deploys Frontend first,"
-  echo "then deploys AgentPlatform pinned to the digest above, and resumes ingress."
+# Only a release that changes how workspaces are read or written needs the
+# paused cutover. AgentCore pins a session to the image its microVM was created
+# with, so a mixed-version fleet can put two incompatible writers on the same
+# workspace bucket at once; the drain exists to guarantee zero old writers
+# before the new format goes live. Nothing else does.
+#
+# This used to print unconditionally on every push. That made the one build
+# where it mattered indistinguishable from the twenty where it did not, so it
+# stopped being read. Decide from the actual diff instead, and fail closed (warn)
+# whenever the comparison cannot be made.
+CUTOVER_PATHS=(
+  "lib/agent-workspace/storage-broker.ts"
+  "infra/agent-image/workspace_sync.py"
+  "infra/database/schema/171"*
+)
+
+deployed_commit() {
+  # Deployed image -> digest -> its commit- tag. Older images predate that tag
+  # but follow a <name>-<sha12> convention, so fall back to the trailing field.
+  local runtime_id digest tags t sha
+  runtime_id="$(aws cloudformation describe-stacks \
+    --region "${REGION}" --stack-name "${STACK_NAME}" \
+    --query 'Stacks[0].Outputs[?OutputKey==`AgentCoreRuntimeId`].OutputValue | [0]' \
+    --output text 2>/dev/null)" || return 1
+  [ -n "${runtime_id}" ] && [ "${runtime_id}" != "None" ] || return 1
+  digest="$(aws bedrock-agentcore-control get-agent-runtime \
+    --region "${REGION}" --agent-runtime-id "${runtime_id}" \
+    --query 'agentRuntimeArtifact.containerConfiguration.containerUri' \
+    --output text 2>/dev/null)" || return 1
+  digest="${digest##*@}"
+  [ -n "${digest}" ] && [ "${digest}" != "None" ] || return 1
+  tags="$(aws ecr describe-images --region "${REGION}" \
+    --repository-name "${ECR_URI##*/}" --image-ids "imageDigest=${digest}" \
+    --query 'imageDetails[0].imageTags' --output text 2>/dev/null)" || return 1
+  for t in ${tags}; do
+    case "${t}" in
+      commit-*) sha="${t#commit-}"; break ;;
+    esac
+  done
+  if [ -z "${sha:-}" ]; then
+    for t in ${tags}; do
+      case "${t##*-}" in
+        [0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f]*) sha="${t##*-}"; break ;;
+      esac
+    done
+  fi
+  [ -n "${sha:-}" ] || return 1
+  git -C "${REPO_ROOT}" cat-file -e "${sha}^{commit}" 2>/dev/null || return 1
+  printf '%s' "${sha}"
+}
+
+CUTOVER_REASON=""
+if DEPLOYED_COMMIT="$(deployed_commit)"; then
+  CHANGED="$(git -C "${REPO_ROOT}" diff --name-only \
+    "${DEPLOYED_COMMIT}..${SOURCE_COMMIT}" -- "${CUTOVER_PATHS[@]}" 2>/dev/null || true)"
+  if [ -n "${CHANGED}" ]; then
+    CUTOVER_REASON="changed since the deployed image (${DEPLOYED_COMMIT:0:12}):
+$(printf '  - %s\n' ${CHANGED})"
+  fi
 else
-  echo "NEXT STEP REQUIRES AN ENVIRONMENT-SPECIFIC PAUSED, SAME-COMMIT CUTOVER."
-  echo "DO NOT substitute Dev resource names or deploy AgentPlatform directly."
-  echo "Stop until the ${ENVIRONMENT} pause/drain, post-drain inventory audit,"
-  echo "Frontend-first deploy, AgentPlatform deploy, and resume steps are validated."
+  CUTOVER_REASON="could not determine the deployed image's commit, so this
+  cannot be ruled out. Failing closed."
+fi
+
+if [ -n "${CUTOVER_REASON}" ]; then
+  echo "WORKSPACE CUTOVER REQUIRED — ${CUTOVER_REASON}"
+  echo ""
+  if [ "${ENVIRONMENT}" = "dev" ]; then
+    echo "DO NOT deploy AgentPlatform directly or mix this image with the old broker."
+    echo "Follow all steps under 'Dev workspace-generation cutover' in:"
+    echo "  docs/operations/agent-platform-setup.md"
+    echo "The sequence pauses ingress, drains writers, deploys Frontend first,"
+    echo "then deploys AgentPlatform pinned to the digest above, and resumes ingress."
+  else
+    echo "DO NOT substitute Dev resource names or deploy AgentPlatform directly."
+    echo "Stop until the ${ENVIRONMENT} pause/drain, post-drain inventory audit,"
+    echo "Frontend-first deploy, AgentPlatform deploy, and resume steps are validated."
+  fi
+else
+  echo "Ordinary deploy — no workspace cutover needed."
+  echo "Nothing under the workspace read/write contract changed since the"
+  echo "deployed image (${DEPLOYED_COMMIT:0:12}), so there is no mixed-writer"
+  echo "hazard to drain for:"
+  printf '  - %s\n' "${CUTOVER_PATHS[@]}"
+  echo ""
+  echo "Deploy Frontend BEFORE AgentPlatform, from this same commit, and pin"
+  echo "AgentPlatform to the digest above."
 fi
 echo ""
 echo "After deploy, confirm the running build via CloudWatch:"

--- a/infra/agent-image/skills/psd-workspace/common.js
+++ b/infra/agent-image/skills/psd-workspace/common.js
@@ -339,20 +339,14 @@ const USER_SCOPE_FORBIDDEN = [
     reason: 'creating a Google Slides deck owned by the user (create as the agent and share explicitly instead)' },
 ];
 
-const PROVENANCE_REQUIRED = [
-  { pattern: /\bcalendar[\s.]+events[\s.]+(patch|update)\b/i,
-    reason: 'calendar updates require server-recorded agent-created provenance' },
-  { pattern: /\btasks[\s.]+tasks[\s.]+(patch|update)\b/i,
-    reason: 'task updates require server-recorded agent-created provenance' },
-  { pattern: /\bdocs[\s.]+documents[\s.]+batchupdate\b/i,
-    reason: 'document mutations require server-recorded agent-created provenance' },
-  { pattern: /\bsheets[\s.]+spreadsheets[\s.]+batchupdate\b/i,
-    reason: 'spreadsheet mutations require server-recorded agent-created provenance' },
-  { pattern: /\bslides[\s.]+presentations[\s.]+batchupdate\b/i,
-    reason: 'presentation mutations require server-recorded agent-created provenance' },
-  { pattern: /\bdrive[\s.]+permissions[\s.]+create\b/i,
-    reason: 'permission creation requires server-recorded agent-created provenance' },
-];
+// Structural mutations of existing content. These were previously refused here
+// and by the broker, on a provenance requirement that nothing could satisfy —
+// no store recorded which files the agent created, so the check threw
+// unconditionally and an agent could create a Doc it could never write to or
+// share (agent_failures 798). They are now ordinary agent-slot writes; the
+// broker still confines them to the agent account via AGENT_ONLY_WRITES, and
+// USER_SCOPE_FORBIDDEN below keeps the user slot's impersonation boundary.
+const PROVENANCE_REQUIRED = [];
 
 const PHASE1_FORBIDDEN = [
   // Send mail — any path that puts a message on the wire

--- a/lib/agent-workspace/command-executor.ts
+++ b/lib/agent-workspace/command-executor.ts
@@ -63,35 +63,41 @@ const MUTATING_ACTIONS = new Set([
 
 const ALLOWED_WRITES = new Set([
   "calendar events insert",
+  "calendar events patch",
+  "calendar events update",
   "chat +send",
   "chat spaces messages create",
+  "docs documents batchupdate",
   "docs documents create",
   "drive files copy",
   "drive files create",
+  "drive permissions create",
   "gmail users drafts create",
   "gmail users drafts update",
   "gmail users messages modify",
+  "sheets spreadsheets batchupdate",
   "sheets spreadsheets create",
   "sheets spreadsheets values append",
   "sheets spreadsheets values update",
+  "slides presentations batchupdate",
   "slides presentations create",
   "tasks tasks insert",
-])
-
-const REQUIRES_AGENT_CREATED_PROVENANCE = new Set([
-  "calendar events patch",
-  "calendar events update",
-  "docs documents batchupdate",
-  "drive permissions create",
-  "sheets spreadsheets batchupdate",
-  "slides presentations batchupdate",
   "tasks tasks patch",
   "tasks tasks update",
 ])
 
-// Sheet values append/update intentionally stay outside the provenance gate:
-// issue #1514 restores content sync for sheets the agent account created or
-// that a user deliberately shared with it. Batch structural edits remain gated.
+// These mutations were previously refused outright by a provenance gate that
+// nothing could satisfy: it threw unconditionally, with no store recording which
+// files the agent created and no branch that ever returned success. The name and
+// the error described a condition the codebase could not produce, so an agent
+// could create a Doc and then never write to or share it — the observed failure
+// was three empty, unshareable Docs (agent_failures 798).
+//
+// They are now ordinary allowlisted writes, confined to the agent slot by
+// AGENT_ONLY_WRITES below. That confinement is what remains of the original
+// intent: the agent may restructure documents, calendars and tasks owned by its
+// own account, and is still refused on the user slot, where the same call would
+// be impersonation against the user's own Workspace.
 
 // Derived rather than enumerated: every allowlisted Chat write leaves the
 // owner's own Workspace data and therefore has to reach the audit log, so a
@@ -102,13 +108,25 @@ const ALLOWED_CHAT_WRITES = new Set(
 
 const AGENT_ONLY_WRITES = new Set([
   ...ALLOWED_CHAT_WRITES,
+  // Structural mutations of existing content. On the agent slot these act on
+  // the agent's own files; on the user slot the same call would restructure the
+  // user's own Workspace as them, which is the impersonation boundary the
+  // create operations below are already held to.
+  "calendar events patch",
+  "calendar events update",
+  "docs documents batchupdate",
   "docs documents create",
   "drive files copy",
   "drive files create",
+  "drive permissions create",
+  "sheets spreadsheets batchupdate",
   "sheets spreadsheets create",
   "sheets spreadsheets values append",
   "sheets spreadsheets values update",
+  "slides presentations batchupdate",
   "slides presentations create",
+  "tasks tasks patch",
+  "tasks tasks update",
 ])
 
 const DRIVE_FOLDER_MIME = "application/vnd.google-apps.folder"
@@ -360,11 +378,6 @@ function validateWorkspaceMutation(
   if (scope === "user" && operation === "drive files update") {
     validateUserDriveMetadataUpdate(argv)
     return
-  }
-  if (REQUIRES_AGENT_CREATED_PROVENANCE.has(operation)) {
-    throw new Error(
-      "Workspace mutation requires server-recorded agent-created provenance"
-    )
   }
   if (!ALLOWED_WRITES.has(operation)) {
     const diagnosticOperation = workspaceOperation(argv)

--- a/tests/unit/lib/agent-workspace/command-executor.test.ts
+++ b/tests/unit/lib/agent-workspace/command-executor.test.ts
@@ -253,10 +253,13 @@ function defineTrustedWorkspaceCommandPolicySuite1Part3() {it("rejects Gmail mod
     ["slides", "presentations", "batchUpdate"],
     ["tasks", "tasks", "patch"],
     ["tasks", "tasks", "update"],
-  ])("denies %s %s %s without server-recorded provenance", (...argv) => {
+  ])("allows %s %s %s on the agent slot", (...argv) => {
+    // These were refused by a provenance gate that nothing could satisfy, so an
+    // agent could create a Doc and never write to or share it (agent_failures
+    // 798). They are ordinary agent-slot writes now.
     expect(() =>
       validateWorkspaceCommand({ scope: "agent", argv })
-    ).toThrow(/server-recorded agent-created provenance/)
+    ).not.toThrow()
   })
 
   it.each([
@@ -383,10 +386,30 @@ function defineTrustedWorkspaceCommandPolicySuite1Part3() {it("rejects Gmail mod
   })
 }
 
+function defineTrustedWorkspaceCommandPolicySuite1Part4() {
+  it.each([
+    ["calendar", "events", "patch"],
+    ["calendar", "events", "update"],
+    ["docs", "documents", "batchUpdate"],
+    ["drive", "permissions", "create"],
+    ["sheets", "spreadsheets", "batchUpdate"],
+    ["slides", "presentations", "batchUpdate"],
+    ["tasks", "tasks", "patch"],
+    ["tasks", "tasks", "update"],
+  ])("still refuses %s %s %s on the user slot", (...argv) => {
+    // The impersonation boundary is what survives removing the gate: the same
+    // call on the user slot would restructure the user's own Workspace as them.
+    expect(() =>
+      validateWorkspaceCommand({ scope: "user", argv })
+    ).toThrow(/must use the agent-owned Workspace account/)
+  })
+}
+
 const defineTrustedWorkspaceCommandPolicySuite1 = () => {
   defineTrustedWorkspaceCommandPolicySuite1Part1()
   defineTrustedWorkspaceCommandPolicySuite1Part2()
   defineTrustedWorkspaceCommandPolicySuite1Part3()
+  defineTrustedWorkspaceCommandPolicySuite1Part4()
 };
 
 describe("trusted Workspace command policy", defineTrustedWorkspaceCommandPolicySuite1)


### PR DESCRIPTION
## The problem

`build-and-push.sh` printed **"NEXT STEP REQUIRES A PAUSED, SAME-COMMIT WORKSPACE CUTOVER"** on every single push. The condition was `if [ "$ENVIRONMENT" = "dev" ]` and nothing else — it never looked at what the release actually changed.

The runbook it points at is far narrower. A paused cutover is required for releases that change one of three things:

- `lib/agent-workspace/storage-broker.ts`
- migration 171
- the agent image's `workspace_sync.py`

Because AgentCore pins a session to the image its microVM was created with: rotating `AGENT_BUILD_TAG` stops *new* calls reusing an old microVM but does **not** terminate that old writer. A mixed-version fleet can therefore put two incompatible writers on one workspace bucket, and the drain exists to guarantee zero old writers before the new format goes live. Nothing else needs it.

Warning unconditionally made the one build where it mattered indistinguishable from the twenty where it didn't. It misled a reader **today**: this release touches none of the three paths, and the script still said to schedule a prod maintenance window.

## The fix

The script now decides from the actual diff.

- Every push also gets a `commit-<sha12>` ECR tag recording the exact source commit, so a later build can identify what's deployed.
- Before printing guidance it resolves the deployed image — stack output `AgentCoreRuntimeId` → `get-agent-runtime` → `containerUri` digest → that image's tags — and reads the commit back off the `commit-` tag, falling back to the trailing `<sha12>` of the existing `workspace-batch-<ts>-<sha>` convention so pre-existing images still resolve.
- It diffs the three cutover paths between that commit and the one being built:
  - **changed** → the full warning, naming which paths changed and which commit it compared against
  - **unchanged** → `Ordinary deploy`, with the Frontend-first and digest-pinning reminders that *do* still apply

**Fails closed.** If the deployed commit can't be resolved for any reason — stack missing, runtime unreachable, no usable tag, commit absent from the clone — the warning prints with an explicit note that the comparison couldn't be made.

## Verified against live dev, not just in theory

- **Resolver:** reads the deployed image's tag `workspace-batch-20260803T050052Z-9f128a003543` and recovers commit `9f128a003543`.
- **Negative control:** that commit → current `dev` touches none of the three paths → ordinary-deploy branch.
- **Positive control:** a range that *does* touch `storage-broker.ts` returns it → warning branch.
- **Glob check:** confirmed `infra/database/schema/171*` resolves to the real migration file rather than silently matching nothing, which would have failed open.

`bash -n` passes.

## Note

The export-ordering hazard that actually broke a deploy tonight (`Cannot delete export dev-PIITokenTableArn as it is in use by AIStudio-FrontendStack-ECS-Dev`) is **not** covered by that runbook section and isn't addressed here. It will recur on prod. Worth its own follow-up.
