### PR TITLE
test(atrium): align E2E specs with usability pass

### DIFF
--- a/tests/e2e/atrium-artifact-fixes.spec.ts
+++ b/tests/e2e/atrium-artifact-fixes.spec.ts
@@ -97,6 +97,14 @@ test.describe("Atrium artifact-UI fixes (authenticated)", () => {
     try {
       const page = await context.newPage();
       await page.goto("/atrium");
+      // The usability pass opens on a curated, bounded home. The seeded
+      // artifact is not guaranteed to land in one of its first six cards, so
+      // enter the complete grid before asserting the specific card.
+      const allContent = page
+        .getByRole("group", { name: "Filter content" })
+        .getByRole("button", { name: "All content" });
+      await allContent.click();
+      await expect(allContent).toHaveAttribute("aria-pressed", "true");
       // The seeded artifact card is present…
       const card = page.locator(".mer-lib-card", { hasText: ARTIFACT_TITLE }).first();
       await expect(card).toBeVisible({ timeout: 60000 });

--- a/tests/e2e/atrium-artifact-fixes.spec.ts
+++ b/tests/e2e/atrium-artifact-fixes.spec.ts
@@ -103,8 +103,12 @@ test.describe("Atrium artifact-UI fixes (authenticated)", () => {
       const allContent = page
         .getByRole("group", { name: "Filter content" })
         .getByRole("button", { name: "All content" });
-      await allContent.click();
-      await expect(allContent).toHaveAttribute("aria-pressed", "true");
+      await expect(async () => {
+        await allContent.click();
+        await expect(allContent).toHaveAttribute("aria-pressed", "true", {
+          timeout: 1500,
+        });
+      }).toPass({ timeout: 30_000 });
       // The seeded artifact card is present…
       const card = page.locator(".mer-lib-card", { hasText: ARTIFACT_TITLE }).first();
       await expect(card).toBeVisible({ timeout: 60000 });

--- a/tests/e2e/atrium-library.spec.ts
+++ b/tests/e2e/atrium-library.spec.ts
@@ -58,12 +58,12 @@ test.describe("Atrium content library (authenticated)", () => {
       // Create affordances for an authoring-capable user.
       await expect(page.getByRole("button", { name: "New doc" })).toBeVisible();
       await expect(
-        page.getByRole("button", { name: "New artifact" })
+        page.getByRole("button", { name: "New page" })
       ).toBeVisible();
 
-      // The filter controls render (title search + tag filter inputs).
+      // The filter controls render (combined title/tag search + tag filter).
       await expect(
-        page.getByRole("textbox", { name: "Search content by title" })
+        page.getByRole("textbox", { name: "Search content by title or tag" })
       ).toBeVisible();
       await expect(
         page.getByRole("textbox", { name: "Filter by tag" })

--- a/tests/e2e/atrium-meridian-creation.spec.ts
+++ b/tests/e2e/atrium-meridian-creation.spec.ts
@@ -10,10 +10,9 @@ import { authenticateContext } from "./helpers/session-auth";
  *  - "New doc" opens a BLANK sheet immediately — no create modal — and navigates
  *    straight to the editor, where the sheet title is inline-editable (the rename
  *    persists and lifts to the topbar breadcrumb).
- *  - "New artifact" opens a single agent-PROMPT field (not the old title form).
- *  - the primary "Publish ▾" split control houses destination + publish +
- *    unpublish + snapshot (replacing the old naked native select + separate
- *    Publish / Unpublish / Snapshot buttons).
+ *  - "New page" opens a single agent-PROMPT field (not the old title form).
+ *  - the unified Share control houses destination-specific publish and
+ *    unpublish actions (replacing the old Publish ▾ split control).
  *
  * Gated behind PLAYWRIGHT_AUTH_ENABLED — see docs/guides/e2e-authenticated-
  * testing.md for the :3100 host-server prereqs.
@@ -62,7 +61,7 @@ test.describe("Atrium Meridian creation flow (authenticated)", () => {
     }
   });
 
-  test("New artifact opens the single agent-prompt field", async ({ browser }) => {
+  test("New page opens the single agent-prompt field", async ({ browser }) => {
     const context = await browser.newContext({
       viewport: { width: 1440, height: 960 },
     });
@@ -74,13 +73,13 @@ test.describe("Atrium Meridian creation flow (authenticated)", () => {
         page.getByRole("heading", { name: "Content library" })
       ).toBeVisible({ timeout: 60000 });
 
-      await page.getByRole("button", { name: "New artifact" }).click();
+      await page.getByRole("button", { name: "New page" }).click();
       // A single free-text prompt surface, not a title form.
       const dialog = page.getByRole("dialog");
       await expect(dialog).toBeVisible();
       await expect(
         dialog.locator('[data-slot="dialog-title"]')
-      ).toHaveText("Create with the agent");
+      ).toHaveText("New interactive page");
       await expect(
         dialog.getByRole("textbox", {
           name: "Describe the artifact for the agent to build",
@@ -93,7 +92,7 @@ test.describe("Atrium Meridian creation flow (authenticated)", () => {
     }
   });
 
-  test("editor Publish ▾ consolidates destination + publish + unpublish", async ({
+  test("editor Share consolidates destination + publish + unpublish", async ({
     browser,
   }) => {
     const context = await browser.newContext({

--- a/tests/e2e/atrium-meridian-library.spec.ts
+++ b/tests/e2e/atrium-meridian-library.spec.ts
@@ -51,20 +51,24 @@ test.describe("Atrium Meridian library (authenticated)", () => {
 
       // Search field (⌘K hint) + create affordances.
       const search = page.getByRole("textbox", {
-        name: "Search content by title",
+        name: "Search content by title or tag",
       });
       await expect(search).toBeVisible();
       await expect(
         page.getByRole("button", { name: "New doc" })
       ).toBeVisible();
       await expect(
-        page.getByRole("button", { name: "New artifact" })
+        page.getByRole("button", { name: "New page" })
       ).toBeVisible();
 
-      // The card grid rendered content links + the dashed create card.
+      // The usability pass opens on the curated Home. The full card grid and
+      // its dashed create card live behind the one-click All content view.
+      const allContent = chips.getByRole("button", { name: "All content" });
+      await allContent.click();
+      await expect(allContent).toHaveAttribute("aria-pressed", "true");
       await expect(page.locator('a[href^="/atrium/"]').first()).toBeVisible();
       await expect(
-        page.getByRole("button", { name: /Create with the agent/i })
+        page.getByRole("button", { name: /New interactive page/i })
       ).toBeVisible();
 
       await page.screenshot({
@@ -83,7 +87,7 @@ test.describe("Atrium Meridian library (authenticated)", () => {
       // The grid re-queries; the create card is always present (proves no crash /
       // no error state after the owner-scoped reload).
       await expect(
-        page.getByRole("button", { name: /Create with the agent/i })
+        page.getByRole("button", { name: /New interactive page/i })
       ).toBeVisible();
     } finally {
       await context.close();

--- a/tests/e2e/atrium-meridian-library.spec.ts
+++ b/tests/e2e/atrium-meridian-library.spec.ts
@@ -64,8 +64,12 @@ test.describe("Atrium Meridian library (authenticated)", () => {
       // The usability pass opens on the curated Home. The full card grid and
       // its dashed create card live behind the one-click All content view.
       const allContent = chips.getByRole("button", { name: "All content" });
-      await allContent.click();
-      await expect(allContent).toHaveAttribute("aria-pressed", "true");
+      await expect(async () => {
+        await allContent.click();
+        await expect(allContent).toHaveAttribute("aria-pressed", "true", {
+          timeout: 1500,
+        });
+      }).toPass({ timeout: 30_000 });
       await expect(page.locator('a[href^="/atrium/"]').first()).toBeVisible();
       await expect(
         page.getByRole("button", { name: /New interactive page/i })

--- a/tests/e2e/atrium-meridian-reader.spec.ts
+++ b/tests/e2e/atrium-meridian-reader.spec.ts
@@ -152,8 +152,10 @@ test.describe("Atrium Meridian reader (authenticated)", () => {
       await expect(page.getByTestId("reader-edit-link")).toHaveCount(0);
       // The internal-facing view-only explainer is gone on the public surface.
       await expect(page.getByTestId("reader-view-only")).toHaveCount(0);
-      // The document body still renders — stripping chrome must not strip content.
-      await expect(page.locator(".atrium-content")).toBeVisible();
+      // The document body sink still renders — stripping chrome must not strip
+      // the reader surface. This committed fixture deliberately has no S3 blob,
+      // so its article is empty (and therefore has no visible box) in local E2E.
+      await expect(page.getByTestId("reader-body")).toBeAttached();
 
       await page.screenshot({
         path: `${SHOT_DIR}/07-reader-public.png`,

--- a/tests/e2e/atrium-publish-share.functional.spec.ts
+++ b/tests/e2e/atrium-publish-share.functional.spec.ts
@@ -176,10 +176,22 @@ function defineAtriumPublishShareAuthenticatedSuite1Part1() {
       // The success caption shows the copyable /c/{slug} reader URL.
       // The usability pass moved the canonical URL out of the editor status
       // caption and into the Share dialog's Link row, which stays open on the
-      // now-live destination after the widen completes.
+      // now-live destination after the widen completes. The Link row is also
+      // present before publishing with the private in-app viewer URL, so wait
+      // for the live destination before asserting that it has switched to /c.
+      await expect(page.getByTestId('share-dest-intranet')).toHaveAttribute(
+        'data-live',
+        'true',
+        { timeout: 60000 }
+      )
       const readerLink = page.getByTestId('share-link-url')
-      await expect(readerLink).toBeVisible({ timeout: 30000 })
-      expect((await readerLink.textContent())?.trim().endsWith(`/c/${slug}`)).toBe(true)
+      await expect
+        .poll(
+          async () =>
+            (await readerLink.textContent())?.trim().endsWith(`/c/${slug}`),
+          { timeout: 60000 }
+        )
+        .toBe(true)
 
       // The widen actually took effect: a SECOND seeded user (no grant, no
       // ownership) loads the intranet reader and gets 200 with the body.
@@ -206,9 +218,8 @@ function defineAtriumPublishShareAuthenticatedSuite1Part1() {
         await otherContext.close()
       }
 
-      // Back in the Share dialog, the destination is now badged LIVE and the
-      // Unpublish button is rendered for it (#1336 B8).
-      await page.getByTestId('share-control').click()
+      // The Share dialog stays open after publishing. The destination is now
+      // badged LIVE and the Unpublish button is rendered for it (#1336 B8).
       await expect(page.getByTestId('live-intranet')).toBeVisible({
         timeout: 15000,
       })
@@ -256,21 +267,29 @@ function defineAtriumPublishShareAuthenticatedSuite1Part2() {test('atrium-share-
       // caption carries the public URL.
       // The usability pass moved the canonical URL out of the editor status
       // caption and into the Share dialog's Link row, which stays open on the
-      // now-live destination after the widen completes.
+      // now-live destination after the widen completes. Wait for the live row
+      // because the same Link element initially contains the private viewer URL.
+      await expect(page.getByTestId('share-dest-public_web')).toHaveAttribute(
+        'data-live',
+        'true',
+        { timeout: 60000 }
+      )
       const readerLink = page.getByTestId('share-link-url')
-      await expect(readerLink).toBeVisible({ timeout: 30000 })
-      expect((await readerLink.textContent())?.trim().endsWith(`/p/${slug}`)).toBe(true)
+      await expect
+        .poll(
+          async () =>
+            (await readerLink.textContent())?.trim().endsWith(`/p/${slug}`),
+          { timeout: 60000 }
+        )
+        .toBe(true)
       await page.screenshot({
         path: `${SHOT_DIR}/atrium-share-url.png`,
         fullPage: false,
       })
 
-      // The Share dialog also surfaces the public link now that it is live.
-      await page.getByTestId('share-control').click()
-      await expect(page.getByTestId('visibility-public-url')).toBeVisible({
-        timeout: 60000,
-      })
-      await expect(page.getByTestId('public-not-published')).toHaveCount(0)
+      // The still-open Share dialog shows the destination as live alongside
+      // the public Link row asserted above.
+      await expect(page.getByTestId('live-public_web')).toBeVisible()
       await page.keyboard.press('Escape')
 
       // An ANONYMOUS context (no session at all) can read it.


### PR DESCRIPTION
## Summary
- update Atrium library, Meridian, artifact, and reader assertions for the curated usability-pass UI
- exercise the unified Share flow and wait for canonical live reader URLs
- update the remaining creation-flow labels required by the full E2E gate

## Implementation notes
Test-only change. No product behavior, API, migration, security, or documentation changes.

## Validation
- Exact issue specs: 12 passed (retries disabled)
- Remaining publish + Meridian library specs: 4 passed (retries disabled)
- Meridian creation spec: 3 passed (retries disabled)
- Isolated API diagnostic after transient full-run state: 26 passed, 2 policy-skipped
- bun run lint: passed
- bun run typecheck: passed
- bun run test:ci: 571 suites passed; 5,329 tests passed; 15 skipped
- bun run build: passed
- bun run openapi:check: passed
- bun run capabilities:check: passed
- git diff --check: passed

## Risk
Low: selector and expectation updates only. No migrations. Screenshots are not applicable.

Closes #1592