### PR TITLE
fix(nexus-memory): stop refusing the user's own personal information, and stop losing whole imports to a truncated model response

### DIFF
--- a/actions/nexus/memory-import.actions.ts
+++ b/actions/nexus/memory-import.actions.ts
@@ -31,10 +31,8 @@ import {
 } from "@/lib/nexus/memory/memory-import-schemas"
 import { memoryService } from "@/lib/nexus/memory/memory-service"
 import { ContentSafetyBlockedError } from "@/lib/streaming/types"
+import { GENERIC_MEMORY_IMPORT_FAILURE_REASON } from "@/lib/nexus/memory/memory-constants"
 import { hasCapabilityAccess } from "@/utils/roles"
-
-const GENERIC_CANDIDATE_FAILURE_REASON =
-  "This memory could not be saved. Try again in a moment."
 
 interface MemoryImportRequester {
   userId: number
@@ -66,7 +64,7 @@ function candidateFailureReason(error: unknown): string {
   if (error instanceof ContentSafetyBlockedError) {
     return error.blockedMessage
   }
-  return GENERIC_CANDIDATE_FAILURE_REASON
+  return GENERIC_MEMORY_IMPORT_FAILURE_REASON
 }
 
 export interface SaveImportedMemoriesResult {

--- a/actions/nexus/memory-import.actions.ts
+++ b/actions/nexus/memory-import.actions.ts
@@ -30,7 +30,11 @@ import {
   type SaveImportedMemoriesInput,
 } from "@/lib/nexus/memory/memory-import-schemas"
 import { memoryService } from "@/lib/nexus/memory/memory-service"
+import { ContentSafetyBlockedError } from "@/lib/streaming/types"
 import { hasCapabilityAccess } from "@/utils/roles"
+
+const GENERIC_CANDIDATE_FAILURE_REASON =
+  "This memory could not be saved. Try again in a moment."
 
 interface MemoryImportRequester {
   userId: number
@@ -46,6 +50,23 @@ export interface ImportedMemoryItemResult {
   status: "saved" | "failed"
   memoryId?: string
   action?: "inserted" | "updated"
+  /** Present on failures only. Safe to render to the user. */
+  reason?: string
+}
+
+/**
+ * A user-safe explanation for one rejected candidate. Blocked-content messages
+ * are already written for users; every other failure stays generic so provider,
+ * database, and embedding internals never reach the browser.
+ *
+ * Without this the dialog showed only "N need attention", and a prod user
+ * retried the same deterministically rejected batch eight times in an hour.
+ */
+function candidateFailureReason(error: unknown): string {
+  if (error instanceof ContentSafetyBlockedError) {
+    return error.blockedMessage
+  }
+  return GENERIC_CANDIDATE_FAILURE_REASON
 }
 
 export interface SaveImportedMemoriesResult {
@@ -199,7 +220,11 @@ export async function saveImportedMemories(
             error instanceof Error ? error.message : String(error),
           ),
         })
-        results.push({ index, status: "failed" })
+        results.push({
+          index,
+          status: "failed",
+          reason: candidateFailureReason(error),
+        })
       }
     }
 

--- a/app/(protected)/settings/_components/memory-import-dialog.tsx
+++ b/app/(protected)/settings/_components/memory-import-dialog.tsx
@@ -31,6 +31,7 @@ import {
   MEMORY_IMPORT_VENDOR_GUIDES,
 } from "@/lib/nexus/memory/import-prompts"
 import {
+  GENERIC_MEMORY_IMPORT_FAILURE_REASON,
   MAX_MEMORY_IMPORT_CHARS,
   MAX_MEMORY_IMPORT_SAVE_BATCH_CANDIDATES,
   MAX_NEXUS_MEMORY_CONTENT_CHARS,
@@ -52,9 +53,6 @@ const MEMORY_CATEGORIES: ReadonlyArray<{
   { value: "preference", label: "Preference" },
   { value: "context", label: "Context" },
 ]
-
-const GENERIC_CANDIDATE_FAILURE_REASON =
-  "This memory could not be saved. Try again in a moment."
 
 interface CandidateDraft extends MemoryImportCandidate {
   id: string
@@ -130,7 +128,7 @@ async function saveCandidateBatches(
       if (draftIndex !== undefined) {
         failureReasons.set(
           draftIndex,
-          item.reason ?? GENERIC_CANDIDATE_FAILURE_REASON,
+          item.reason ?? GENERIC_MEMORY_IMPORT_FAILURE_REASON,
         )
       }
     }

--- a/app/(protected)/settings/_components/memory-import-dialog.tsx
+++ b/app/(protected)/settings/_components/memory-import-dialog.tsx
@@ -53,9 +53,14 @@ const MEMORY_CATEGORIES: ReadonlyArray<{
   { value: "context", label: "Context" },
 ]
 
+const GENERIC_CANDIDATE_FAILURE_REASON =
+  "This memory could not be saved. Try again in a moment."
+
 interface CandidateDraft extends MemoryImportCandidate {
   id: string
   selected: boolean
+  /** Why the last save attempt rejected this candidate, if it did. */
+  failureReason?: string
 }
 
 interface SaveProgress {
@@ -70,7 +75,8 @@ interface SelectedCandidate {
 
 interface BatchedSaveOutcome {
   successful: number
-  failedDraftIndexes: Set<number>
+  /** Draft index -> user-safe reason, so each failed row can explain itself. */
+  failureReasons: Map<number, string>
   requestFailureMessage: string | null
 }
 
@@ -91,7 +97,7 @@ async function saveCandidateBatches(
 ): Promise<BatchedSaveOutcome> {
   let successful = 0
   let requestFailureMessage: string | null = null
-  const failedDraftIndexes = new Set<number>()
+  const failureReasons = new Map<number, string>()
 
   for (
     let offset = 0;
@@ -112,7 +118,7 @@ async function saveCandidateBatches(
     if (!result.isSuccess) {
       requestFailureMessage = result.message
       for (const { draftIndex } of selected.slice(offset)) {
-        failedDraftIndexes.add(draftIndex)
+        failureReasons.set(draftIndex, result.message)
       }
       break
     }
@@ -122,7 +128,10 @@ async function saveCandidateBatches(
       if (item.status !== "failed") continue
       const draftIndex = batch[item.index]?.draftIndex
       if (draftIndex !== undefined) {
-        failedDraftIndexes.add(draftIndex)
+        failureReasons.set(
+          draftIndex,
+          item.reason ?? GENERIC_CANDIDATE_FAILURE_REASON,
+        )
       }
     }
     onProgress({
@@ -133,7 +142,7 @@ async function saveCandidateBatches(
 
   return {
     successful,
-    failedDraftIndexes,
+    failureReasons,
     requestFailureMessage,
   }
 }
@@ -275,6 +284,87 @@ function ImportSourceStep({
   )
 }
 
+type CandidateUpdate = Partial<
+  Pick<CandidateDraft, "selected" | "content" | "category">
+>
+
+function ImportCandidateRow({
+  candidate,
+  index,
+  isSaving,
+  onUpdate,
+}: {
+  candidate: CandidateDraft
+  index: number
+  isSaving: boolean
+  onUpdate: (id: string, update: CandidateUpdate) => void
+}) {
+  return (
+    <div
+      data-testid="memory-import-candidate"
+      className={`space-y-3 rounded-md border p-3 ${
+        candidate.failureReason ? "border-destructive/50" : ""
+      }`}
+    >
+      {candidate.failureReason && (
+        <p
+          role="alert"
+          data-testid={`memory-import-candidate-reason-${index}`}
+          className="text-sm text-destructive"
+        >
+          {candidate.failureReason}
+        </p>
+      )}
+      <div className="flex items-start gap-3">
+        <Checkbox
+          checked={candidate.selected}
+          disabled={isSaving}
+          data-testid={`memory-import-candidate-select-${index}`}
+          aria-label={`Import candidate ${index + 1}`}
+          className="mt-2"
+          onCheckedChange={(checked) =>
+            onUpdate(candidate.id, { selected: checked === true })
+          }
+        />
+        <Textarea
+          value={candidate.content}
+          maxLength={MAX_NEXUS_MEMORY_CONTENT_CHARS}
+          disabled={isSaving}
+          data-testid={`memory-import-candidate-content-${index}`}
+          aria-label={`Memory candidate ${index + 1} content`}
+          onChange={(event) =>
+            onUpdate(candidate.id, { content: event.target.value })
+          }
+        />
+      </div>
+      <Select
+        value={candidate.category}
+        disabled={isSaving}
+        onValueChange={(value) =>
+          onUpdate(candidate.id, {
+            category: value as NexusMemoryCategory,
+          })
+        }
+      >
+        <SelectTrigger
+          className="w-full sm:w-44"
+          data-testid={`memory-import-candidate-category-${index}`}
+          aria-label={`Memory candidate ${index + 1} category`}
+        >
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent className={meridianPortalClassName}>
+          {MEMORY_CATEGORIES.map((category) => (
+            <SelectItem key={category.value} value={category.value}>
+              {category.label}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </div>
+  )
+}
+
 function ImportReviewStep({
   candidates,
   isSaving,
@@ -293,15 +383,21 @@ function ImportReviewStep({
   const selectedCount = candidates.filter(
     (candidate) => candidate.selected,
   ).length
-  const updateCandidate = (
-    id: string,
-    update: Partial<
-      Pick<CandidateDraft, "selected" | "content" | "category">
-    >,
-  ) => {
+  const updateCandidate = (id: string, update: CandidateUpdate) => {
     onCandidatesChange(
       candidates.map((candidate) =>
-        candidate.id === id ? { ...candidate, ...update } : candidate,
+        candidate.id === id
+          ? {
+              ...candidate,
+              ...update,
+              // An edit answers the rejection, so the old reason no longer
+              // describes the text on screen.
+              failureReason:
+                update.content === undefined
+                  ? candidate.failureReason
+                  : undefined,
+            }
+          : candidate,
       ),
     )
   }
@@ -322,65 +418,13 @@ function ImportReviewStep({
       ) : (
         <div className="max-h-[50vh] space-y-3 overflow-y-auto pr-1">
           {candidates.map((candidate, index) => (
-            <div
+            <ImportCandidateRow
               key={candidate.id}
-              data-testid="memory-import-candidate"
-              className="space-y-3 rounded-md border p-3"
-            >
-              <div className="flex items-start gap-3">
-                <Checkbox
-                  checked={candidate.selected}
-                  disabled={isSaving}
-                  data-testid={`memory-import-candidate-select-${index}`}
-                  aria-label={`Import candidate ${index + 1}`}
-                  className="mt-2"
-                  onCheckedChange={(checked) =>
-                    updateCandidate(candidate.id, {
-                      selected: checked === true,
-                    })
-                  }
-                />
-                <Textarea
-                  value={candidate.content}
-                  maxLength={MAX_NEXUS_MEMORY_CONTENT_CHARS}
-                  disabled={isSaving}
-                  data-testid={`memory-import-candidate-content-${index}`}
-                  aria-label={`Memory candidate ${index + 1} content`}
-                  onChange={(event) =>
-                    updateCandidate(candidate.id, {
-                      content: event.target.value,
-                    })
-                  }
-                />
-              </div>
-              <Select
-                value={candidate.category}
-                disabled={isSaving}
-                onValueChange={(value) =>
-                  updateCandidate(candidate.id, {
-                    category: value as NexusMemoryCategory,
-                  })
-                }
-              >
-                <SelectTrigger
-                  className="w-full sm:w-44"
-                  data-testid={`memory-import-candidate-category-${index}`}
-                  aria-label={`Memory candidate ${index + 1} category`}
-                >
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent className={meridianPortalClassName}>
-                  {MEMORY_CATEGORIES.map((category) => (
-                    <SelectItem
-                      key={category.value}
-                      value={category.value}
-                    >
-                      {category.label}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </div>
+              candidate={candidate}
+              index={index}
+              isSaving={isSaving}
+              onUpdate={updateCandidate}
+            />
           ))}
         </div>
       )}
@@ -500,7 +544,7 @@ function useMemoryImportDialog({
     try {
       const {
         successful,
-        failedDraftIndexes,
+        failureReasons,
         requestFailureMessage,
       } = await saveCandidateBatches(vendor, selected, setSaveProgress)
 
@@ -520,7 +564,7 @@ function useMemoryImportDialog({
         }
       }
 
-      if (failedDraftIndexes.size === 0) {
+      if (failureReasons.size === 0) {
         toast.success(
           `${successful} ${
             successful === 1 ? "memory" : "memories"
@@ -531,16 +575,22 @@ function useMemoryImportDialog({
         return
       }
 
+      // Reasons are keyed by index into the pre-filter list, so attach them
+      // before narrowing to the failures.
       setCandidates((current) =>
         current
-          .filter((_candidate, index) => failedDraftIndexes.has(index))
-          .map((candidate) => ({ ...candidate, selected: true })),
+          .map((candidate, index) => ({
+            ...candidate,
+            selected: true,
+            failureReason: failureReasons.get(index),
+          }))
+          .filter((candidate) => candidate.failureReason !== undefined),
       )
       if (successful === 0 && requestFailureMessage) {
         toast.error(requestFailureMessage)
       } else {
         toast.warning(
-          `${successful} imported; ${failedDraftIndexes.size} need attention`,
+          `${successful} imported; ${failureReasons.size} need attention`,
         )
       }
     } catch (saveError) {

--- a/docs/features/k12-content-safety.md
+++ b/docs/features/k12-content-safety.md
@@ -7,7 +7,7 @@
 AI Studio includes an enterprise-grade content safety system specifically designed for K-12 educational environments. This system provides two complementary protections:
 
 1. **Content Filtering** - Blocks inappropriate content in both user inputs and AI responses
-2. **Zero-data-retention inference plus detect-only PII gates** - AI providers do not retain inference data, while durable Nexus memory writes refuse detected PII and published agent content records PII telemetry
+2. **Zero-data-retention inference plus detect-only PII telemetry** - AI providers do not retain inference data, while durable Nexus memory writes and published agent content both record PII telemetry without refusing on a detection
 
 These features help school districts meet COPPA, FERPA, and CIPA compliance requirements while providing students safe access to frontier AI models.
 
@@ -71,7 +71,7 @@ The content filtering system evaluates all messages against configurable safety 
 
 When content is blocked, users receive an age-appropriate message explaining that their request couldn't be processed, without revealing specific filtering details that could be used for circumvention.
 
-### PII Privacy Boundary (ZDR + Detect-Only Gates)
+### PII Privacy Boundary (ZDR + Detect-Only Telemetry)
 
 AI inference runs under zero-data-retention agreements, so names and other context reach the selected model byte-identical and are not retained by the provider. AI Studio does not replace PII with reversible placeholders. This is important for tool calls such as district-data queries, where the model must be able to use the real name supplied by the authorized user.
 
@@ -95,16 +95,16 @@ The detection helper applies the existing K-12 type allowlist and confidence flo
 | **Student IDs** | "2240393" (7 digits starting with 2) | Custom Pattern |
 | **Custom Identifiers** | Configurable per district | Custom Pattern |
 
-**How Inference and Durable Gates Work:**
+**How Inference and Durable Detection Work:**
 
 ```
 Authorized user input with a student's name
      ├── AI inference → byte-identical input under a ZDR agreement
-     ├── Nexus memory write → Comprehend detect-only check; refuse on PII/error
+     ├── Nexus memory write → Comprehend detect-only telemetry; no rewrite
      └── Published agent content → Comprehend detect-only telemetry; no rewrite
 ```
 
-Bedrock Guardrails continue to evaluate both inference input and output independently of these PII gates.
+Bedrock Guardrails continue to evaluate both inference input and output independently of this PII detection.
 
 ### Violation Notifications
 
@@ -146,8 +146,8 @@ Administrators can receive real-time notifications when safety violations occur:
 │           ▼                                                         │
 │      User Response                                                  │
 │                                                                     │
-│  Durable side gates:                                                │
-│  Nexus memory ──► Comprehend detect-only ──► refuse PII/errors       │
+│  Durable side telemetry:                                            │
+│  Nexus memory ──► Comprehend detect-only ──► telemetry only          │
 │  Agent publish ──► Comprehend detect-only ──► telemetry only         │
 │                                                                     │
 └─────────────────────────────────────────────────────────────────────┘
@@ -530,7 +530,7 @@ export const CUSTOM_PII_PATTERNS: CustomPIIPattern[] = [
 | Case number (CASE-NNNN) | `/\bCASE-\d{4}\b/i` | CASE-1234 |
 | Custom ID with prefix | `/\bPSD-\d{6}\b/` | PSD-123456 |
 
-Custom patterns participate in the two detect-only gates; they do not rewrite inference content.
+Custom patterns participate in the two detect-only telemetry points; they do not rewrite inference content and do not refuse a write.
 
 ## Local Development
 
@@ -553,7 +553,7 @@ The content safety system logs detailed metrics:
 - `guardrails.input.blocked` - Number of inputs blocked
 - `guardrails.output.checked` - Number of outputs evaluated
 - `guardrails.output.blocked` - Number of outputs blocked
-- Detect-only PII events are emitted by the Nexus memory and agent-content gate logs
+- Detect-only PII events are emitted by the Nexus memory and agent-content telemetry logs (the memory event carries the write's `source`, so unattended auto-extraction can be queried on its own)
 
 ### Log Analysis
 
@@ -589,10 +589,13 @@ Content filtering adds approximately 50-100ms latency per request. This is imper
 
 ### What happens if the safety service is unavailable?
 
-Bedrock Guardrails fail open for service continuity and log the degraded
-evaluation. The two Comprehend gates are intentionally different: Nexus memory
-writes fail closed when detection cannot complete, while published agent
-content remains unchanged and logs a non-fatal detector error.
+Everything fails open for service continuity and logs the degraded evaluation.
+Bedrock Guardrails, Nexus memory writes, and published agent content all
+proceed when Comprehend cannot complete a detection; the detector error is
+recorded as a non-fatal warning rather than costing the user their write.
+
+Content safety (`processInput`) is the exception and the one hard gate: a
+memory write it blocks is refused, before embedding or any database access.
 
 ### Can students bypass the content filtering?
 
@@ -604,7 +607,7 @@ AI Studio does not store reversible PII token mappings. Ordinary inference conte
 
 ### Can I disable these features?
 
-Bedrock content filtering can be disabled with `CONTENT_SAFETY_ENABLED=false`. The two durable-content detect-only PII gates are explicit application safety boundaries rather than a general inference feature toggle.
+Bedrock content filtering can be disabled with `CONTENT_SAFETY_ENABLED=false`. The two durable-content PII detection points are observability, not boundaries: they never refuse a write, so there is nothing to toggle off. The content-safety gate (`processInput`) remains the boundary for durable writes.
 
 ## Related Documentation
 

--- a/docs/features/k12-content-safety.md
+++ b/docs/features/k12-content-safety.md
@@ -77,8 +77,10 @@ AI inference runs under zero-data-retention agreements, so names and other conte
 
 Amazon Comprehend detection remains on two durable-content boundaries:
 
-1. **Nexus memory writes** — relevant K-12 PII and district-specific identifiers are refused. Detection errors fail closed, so indeterminate content is never persisted as memory.
+1. **Nexus memory writes** — detected entity types and counts are logged as telemetry (never offsets or values). The write proceeds, and detector errors are non-fatal. A memory is the user's own record of their own life, so names, relationships, dates, ages, and contact details are the substance of the feature rather than a leak; refusing them made memory unusable and produced no user-visible reason (see the 2026-08-05 import incident, issue #1610). Content safety (`processInput`) still gates every memory write and still blocks.
 2. **Published agent content screening** — detected entity types are logged as telemetry. Content remains unmodified, and detector errors are non-fatal.
+
+Automatic memory extraction is the one place third-party identifiers are still held back, and it is held back at the *prompt*, not by a refusal: it runs unattended after every persisted Nexus turn, so its extraction prompt continues to exclude contact details and sensitive identifiers. Memory import does not, because the user pastes their own export and approves each candidate before it is saved.
 
 The detection helper applies the existing K-12 type allowlist and confidence floors to standard Comprehend entities, plus custom patterns for district-specific identifiers:
 
@@ -156,7 +158,8 @@ Administrators can receive real-time notifications when safety violations occur:
 ### COPPA (Children's Online Privacy Protection Act)
 
 - Zero-data-retention agreements prevent provider retention of inference data
-- Nexus memory refuses detected personal information and fails closed when detection is unavailable
+- Nexus memory is per-user, owner-scoped, and user-controlled: a user reviews every imported candidate before it is saved, and can read, edit, and delete their own memories at any time from Settings → Memory
+- Automatic memory extraction is prompted to exclude contact details and sensitive identifiers, so unattended capture does not turn a third party mentioned in a chat into a durable row
 - No reversible token mapping store is created
 
 ### FERPA (Family Educational Rights and Privacy Act)
@@ -597,7 +600,7 @@ The content filtering includes protection against "prompt injection" and "jailbr
 
 ### Is student data stored anywhere?
 
-AI Studio does not store reversible PII token mappings. Ordinary inference content is governed by provider zero-data-retention agreements. Nexus memory refuses detected PII; published agent content keeps its authored text and emits entity-type telemetry.
+AI Studio does not store reversible PII token mappings. Ordinary inference content is governed by provider zero-data-retention agreements. Nexus memory and published agent content both keep their text and emit entity-type telemetry; neither refuses on a PII detection.
 
 ### Can I disable these features?
 

--- a/lib/nexus/memory/auto-extraction.ts
+++ b/lib/nexus/memory/auto-extraction.ts
@@ -212,9 +212,12 @@ Return only facts useful across future conversations:
 - preference: durable communication, formatting, workflow, or learning preferences
 - context: ongoing projects, goals, constraints, or working context
 
-Keep the personal detail that makes a memory worth having. Names of the user and of the people they live and work with, relationships, ages, locations, dates, and contact details belong in a candidate whenever the exchange states them. Do not generalize, redact, or de-identify them.
-
-Exclude passwords, API keys, access tokens, and other credentials, along with transient requests, facts only about the assistant, guesses, and duplicates. Each candidate must be a concise standalone statement. Returning no candidates is normal.`
+Exclude secrets, credentials, contact details, sensitive identifiers, transient requests, facts only about the assistant, guesses, and duplicates. Each candidate must be a concise standalone statement. Returning no candidates is normal.`
+// Deliberately NOT loosened the way the import prompt was. Import is the user
+// pasting their own memory export and approving each candidate by hand; this
+// runs unattended after every persisted turn, and a K-12 chat mentioning a
+// student or colleague would otherwise turn their name, age, or address into a
+// durable row nobody chose to save.
 
 const AUTO_CONSOLIDATION_SYSTEM_PROMPT = `You consolidate one proposed user memory against owner-scoped existing memories.
 

--- a/lib/nexus/memory/auto-extraction.ts
+++ b/lib/nexus/memory/auto-extraction.ts
@@ -212,7 +212,9 @@ Return only facts useful across future conversations:
 - preference: durable communication, formatting, workflow, or learning preferences
 - context: ongoing projects, goals, constraints, or working context
 
-Exclude secrets, credentials, contact details, sensitive identifiers, transient requests, facts only about the assistant, guesses, and duplicates. Each candidate must be a concise standalone statement. Returning no candidates is normal.`
+Keep the personal detail that makes a memory worth having. Names of the user and of the people they live and work with, relationships, ages, locations, dates, and contact details belong in a candidate whenever the exchange states them. Do not generalize, redact, or de-identify them.
+
+Exclude passwords, API keys, access tokens, and other credentials, along with transient requests, facts only about the assistant, guesses, and duplicates. Each candidate must be a concise standalone statement. Returning no candidates is normal.`
 
 const AUTO_CONSOLIDATION_SYSTEM_PROMPT = `You consolidate one proposed user memory against owner-scoped existing memories.
 

--- a/lib/nexus/memory/import-prompts.ts
+++ b/lib/nexus/memory/import-prompts.ts
@@ -51,7 +51,9 @@ Return only facts that would be useful across future conversations:
 - preference: durable communication, formatting, workflow, or learning preferences
 - context: ongoing projects, goals, constraints, or working context
 
-Exclude secrets, credentials, contact details, sensitive identifiers, transient tasks, assistant commentary, uncertainty, and duplicates. Preserve the user's meaning. Make each candidate a concise, standalone statement of at most 500 characters. An empty candidate list is correct when no durable fact is present.`
+Keep the personal detail that makes a memory worth having. Names of the user and of the people they live and work with, relationships, ages, locations, dates, and contact details belong in a candidate whenever the source states them. Do not generalize, redact, or de-identify them.
+
+Exclude passwords, API keys, access tokens, and other credentials, along with transient tasks, assistant commentary, uncertainty, and duplicates. Preserve the user's meaning. Make each candidate a concise, standalone statement of at most 500 characters. An empty candidate list is correct when no durable fact is present.`
 
 export function buildMemoryImportExtractionPrompt(
   vendor: MemoryImportVendor,

--- a/lib/nexus/memory/memory-constants.ts
+++ b/lib/nexus/memory/memory-constants.ts
@@ -4,3 +4,11 @@ export const NEXUS_MEMORY_SETTINGS_PAGE_SIZE = 50
 export const MAX_MEMORY_IMPORT_CHARS = 200_000
 export const MAX_MEMORY_IMPORT_CANDIDATES = 100
 export const MAX_MEMORY_IMPORT_SAVE_BATCH_CANDIDATES = 5
+
+/**
+ * Shown on an import candidate the server rejected for a reason that is not
+ * safe to describe (provider, database, network). Shared so the server's
+ * wording and the dialog's fallback cannot drift apart.
+ */
+export const GENERIC_MEMORY_IMPORT_FAILURE_REASON =
+  "This memory could not be saved. Try again in a moment."

--- a/lib/nexus/memory/memory-import.ts
+++ b/lib/nexus/memory/memory-import.ts
@@ -227,11 +227,18 @@ function toError(error: unknown): Error {
   return error instanceof Error ? error : new Error(String(error))
 }
 
+/** Per-invocation counters, so one import's model spend is one log line. */
+interface ExtractionStats {
+  modelCalls: number
+  splitEvents: number
+}
+
 interface ChunkExtractionContext {
   model: LanguageModel
   vendor: MemoryImportVendor
   chunkIndex: number
   chunkCount: number
+  stats: ExtractionStats
 }
 
 // Never logs the model output or the pasted source; the shape of the response
@@ -283,6 +290,7 @@ export function createMemoryImportExtractor(
     const halves = splitExtractionChunks(chunk, Math.ceil(chunk.length / 2))
     if (halves.length < 2) return null
 
+    context.stats.splitEvents += 1
     log.warn("Splitting a Nexus memory extraction chunk that overran", {
       vendor: context.vendor,
       chunkIndex: context.chunkIndex,
@@ -324,6 +332,7 @@ export function createMemoryImportExtractor(
       // gets the retry too, not just an unparseable response.
       let result: ModelExtractionResult | undefined
       try {
+        context.stats.modelCalls += 1
         result = await dependencies.runExtraction(context.model, prompt)
         return parseMemoryImportCandidates(result)
       } catch (error) {
@@ -373,6 +382,7 @@ export function createMemoryImportExtractor(
 
     const collected: MemoryImportCandidate[][] = chunks.map(() => [])
     const failures: Error[] = []
+    const stats: ExtractionStats = { modelCalls: 0, splitEvents: 0 }
     // Race-free without a lock: each worker runs synchronously up to its first
     // await, so `nextChunk++` claims an index before any other worker can be
     // scheduled. No two workers can ever read the same value.
@@ -392,6 +402,7 @@ export function createMemoryImportExtractor(
                 vendor: input.vendor,
                 chunkIndex: index,
                 chunkCount: chunks.length,
+                stats,
               },
               chunks[index],
             )
@@ -417,6 +428,18 @@ export function createMemoryImportExtractor(
         candidateCount: candidates.length,
       })
     }
+    // One line per import carrying the whole model spend, so cost and split
+    // churn are alertable on a single number instead of reassembled from
+    // per-chunk warnings.
+    log.info("Nexus memory extraction completed", {
+      vendor: input.vendor,
+      pastedChars: input.pastedText.length,
+      chunkCount: chunks.length,
+      modelCalls: stats.modelCalls,
+      splitEvents: stats.splitEvents,
+      failedChunkCount: failures.length,
+      candidateCount: candidates.length,
+    })
     return candidates
   }
 }

--- a/lib/nexus/memory/memory-import.ts
+++ b/lib/nexus/memory/memory-import.ts
@@ -331,10 +331,11 @@ export function createMemoryImportExtractor(
           result,
           error,
         })
-        // No point pausing before a retry that will not happen, and none
-        // before a split — a smaller chunk is not competing for the same
-        // throttle window.
-        if (attempt < MEMORY_EXTRACTION_ATTEMPTS && !ranOutOfBudget) {
+        // An overrun cannot be retried out of — the identical prompt at
+        // temperature 0 truncates identically. Stop burning calls and go
+        // straight to splitting.
+        if (ranOutOfBudget) break
+        if (attempt < MEMORY_EXTRACTION_ATTEMPTS) {
           await delayBeforeRetry(attempt)
         }
       }

--- a/lib/nexus/memory/memory-import.ts
+++ b/lib/nexus/memory/memory-import.ts
@@ -4,13 +4,16 @@ import {
   type LanguageModel,
 } from "ai"
 import { createProviderModel } from "@/lib/ai/provider-factory"
+import { createLogger } from "@/lib/logger"
 import { getSetting } from "@/lib/settings-manager"
 import {
   buildMemoryImportExtractionPrompt,
   MEMORY_IMPORT_EXTRACTION_SYSTEM_PROMPT,
 } from "./import-prompts"
+import { MAX_MEMORY_IMPORT_CANDIDATES } from "./memory-constants"
 import {
   MemoryImportCandidateBatchSchema,
+  MemoryImportCandidateSchema,
   type MemoryImportCandidate,
   type MemoryImportVendor,
 } from "./memory-import-schemas"
@@ -20,9 +23,35 @@ export const DEFAULT_MEMORY_EXTRACTION_MODEL_ID =
 const MEMORY_EXTRACTION_PROVIDER = "amazon-bedrock"
 const EXTRACTION_TOOL_NAME = "submit_memory_candidates"
 
+/**
+ * Upper bound on the source text handed to a single model call.
+ *
+ * A whole paste can be 200,000 characters, which asks for more candidate JSON
+ * than the output-token budget holds. A tool call truncated mid-object parses
+ * as nothing at all, so the entire import returned zero candidates — that is
+ * what broke three prod imports on 2026-08-05. Chunking keeps every response
+ * well inside the budget.
+ */
+export const MEMORY_EXTRACTION_CHUNK_CHARS = 12_000
+const MEMORY_EXTRACTION_MAX_CONCURRENCY = 3
+const MEMORY_EXTRACTION_ATTEMPTS = 2
+
+const INVALID_EXTRACTION_RESPONSE =
+  "The memory extraction model returned an invalid response"
+
+const log = createLogger({ module: "nexus-memory-import" })
+
+interface ModelExtractionUsage {
+  inputTokens?: number
+  outputTokens?: number
+  totalTokens?: number
+}
+
 interface ModelExtractionResult {
   text: string
   toolCalls: unknown
+  finishReason?: string
+  usage?: ModelExtractionUsage
 }
 
 interface MemoryImportExtractorDependencies {
@@ -44,9 +73,26 @@ function parseJsonBatch(text: string): unknown {
   }
 }
 
-export function parseMemoryImportCandidates(
-  result: ModelExtractionResult,
-): MemoryImportCandidate[] {
+/**
+ * Keep every individually valid candidate when the batch as a whole fails the
+ * schema. One out-of-enum category, one over-long entry, or one candidate past
+ * the cap used to discard the model's entire answer.
+ */
+function salvageCandidates(value: unknown): MemoryImportCandidate[] | null {
+  if (!value || typeof value !== "object") return null
+  const candidates = (value as { candidates?: unknown }).candidates
+  if (!Array.isArray(candidates)) return null
+  const salvaged: MemoryImportCandidate[] = []
+  for (const entry of candidates) {
+    if (salvaged.length >= MAX_MEMORY_IMPORT_CANDIDATES) break
+    const parsed = MemoryImportCandidateSchema.safeParse(entry)
+    if (parsed.success) salvaged.push(parsed.data)
+  }
+  return salvaged.length > 0 ? salvaged : null
+}
+
+function extractionPayloads(result: ModelExtractionResult): unknown[] {
+  const payloads: unknown[] = []
   if (Array.isArray(result.toolCalls)) {
     for (const call of result.toolCalls) {
       if (!call || typeof call !== "object") continue
@@ -56,23 +102,127 @@ export function parseMemoryImportCandidates(
         args?: unknown
       }
       if (value.toolName !== EXTRACTION_TOOL_NAME) continue
-      const parsed = MemoryImportCandidateBatchSchema.safeParse(
-        value.input ?? value.args,
-      )
-      if (parsed.success) return parsed.data.candidates
+      payloads.push(value.input ?? value.args)
     }
   }
+  payloads.push(parseJsonBatch(result.text))
+  return payloads
+}
 
-  const parsed = MemoryImportCandidateBatchSchema.safeParse(
-    parseJsonBatch(result.text),
-  )
-  if (parsed.success) return parsed.data.candidates
-  throw new Error("The memory extraction model returned an invalid response")
+export function parseMemoryImportCandidates(
+  result: ModelExtractionResult,
+): MemoryImportCandidate[] {
+  const payloads = extractionPayloads(result)
+  for (const payload of payloads) {
+    const parsed = MemoryImportCandidateBatchSchema.safeParse(payload)
+    if (parsed.success) return parsed.data.candidates
+  }
+  for (const payload of payloads) {
+    const salvaged = salvageCandidates(payload)
+    if (salvaged) return salvaged
+  }
+  throw new Error(INVALID_EXTRACTION_RESPONSE)
+}
+
+/**
+ * Split pasted text on line boundaries so each model call stays inside the
+ * output budget. A single line longer than the budget is split on characters
+ * because nothing else bounds it.
+ */
+export function splitExtractionChunks(
+  pastedText: string,
+  chunkChars: number = MEMORY_EXTRACTION_CHUNK_CHARS,
+): string[] {
+  const text = pastedText.trim()
+  if (!text) return []
+  if (text.length <= chunkChars) return [text]
+
+  const chunks: string[] = []
+  let current = ""
+  for (const line of text.split("\n")) {
+    if (line.length > chunkChars) {
+      if (current) {
+        chunks.push(current)
+        current = ""
+      }
+      for (let offset = 0; offset < line.length; offset += chunkChars) {
+        chunks.push(line.slice(offset, offset + chunkChars))
+      }
+      continue
+    }
+    const merged = current ? `${current}\n${line}` : line
+    if (merged.length > chunkChars) {
+      chunks.push(current)
+      current = line
+    } else {
+      current = merged
+    }
+  }
+  if (current) chunks.push(current)
+  return chunks.filter((chunk) => chunk.trim().length > 0)
+}
+
+function dedupeCandidates(
+  candidates: readonly MemoryImportCandidate[],
+): MemoryImportCandidate[] {
+  const seen = new Set<string>()
+  const unique: MemoryImportCandidate[] = []
+  for (const candidate of candidates) {
+    if (unique.length >= MAX_MEMORY_IMPORT_CANDIDATES) break
+    const key = candidate.content.trim().toLowerCase()
+    if (seen.has(key)) continue
+    seen.add(key)
+    unique.push(candidate)
+  }
+  return unique
+}
+
+function toError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(String(error))
 }
 
 export function createMemoryImportExtractor(
   dependencies: MemoryImportExtractorDependencies,
 ) {
+  async function extractChunk(
+    model: LanguageModel,
+    vendor: MemoryImportVendor,
+    chunk: string,
+    chunkIndex: number,
+    chunkCount: number,
+  ): Promise<MemoryImportCandidate[]> {
+    const prompt = buildMemoryImportExtractionPrompt(vendor, chunk)
+    for (
+      let attempt = 1;
+      attempt <= MEMORY_EXTRACTION_ATTEMPTS;
+      attempt += 1
+    ) {
+      const result = await dependencies.runExtraction(model, prompt)
+      try {
+        return parseMemoryImportCandidates(result)
+      } catch (error) {
+        // Never log the model output or the pasted source; the shape of the
+        // response is what makes this diagnosable.
+        log.warn("Nexus memory extraction returned an unparseable response", {
+          vendor,
+          chunkIndex,
+          chunkCount,
+          attempt,
+          chunkChars: chunk.length,
+          finishReason: result.finishReason,
+          outputTextChars: result.text.length,
+          toolCallCount: Array.isArray(result.toolCalls)
+            ? result.toolCalls.length
+            : 0,
+          inputTokens: result.usage?.inputTokens,
+          outputTokens: result.usage?.outputTokens,
+          error: toError(error).message,
+        })
+      }
+    }
+    throw new Error(INVALID_EXTRACTION_RESPONSE)
+  }
+
   return async function extractMemoryImportCandidates(input: {
     vendor: MemoryImportVendor
     pastedText: string
@@ -86,11 +236,51 @@ export function createMemoryImportExtractor(
       MEMORY_EXTRACTION_PROVIDER,
       modelId,
     )
-    const result = await dependencies.runExtraction(
-      model,
-      buildMemoryImportExtractionPrompt(input.vendor, input.pastedText),
+    const chunks = splitExtractionChunks(input.pastedText)
+    if (chunks.length === 0) return []
+
+    const collected: MemoryImportCandidate[][] = chunks.map(() => [])
+    const failures: Error[] = []
+    let nextChunk = 0
+    const workers = Array.from(
+      { length: Math.min(MEMORY_EXTRACTION_MAX_CONCURRENCY, chunks.length) },
+      async () => {
+        for (
+          let index = nextChunk++;
+          index < chunks.length;
+          index = nextChunk++
+        ) {
+          try {
+            collected[index] = await extractChunk(
+              model,
+              input.vendor,
+              chunks[index],
+              index,
+              chunks.length,
+            )
+          } catch (error) {
+            failures.push(toError(error))
+          }
+        }
+      },
     )
-    return parseMemoryImportCandidates(result)
+    await Promise.all(workers)
+
+    // One bad chunk must not discard the chunks that did parse. Only a
+    // completely failed extraction surfaces as an error to the user.
+    if (failures.length === chunks.length) {
+      throw failures[0]
+    }
+    const candidates = dedupeCandidates(collected.flat())
+    if (failures.length > 0) {
+      log.warn("Some Nexus memory extraction chunks failed", {
+        vendor: input.vendor,
+        chunkCount: chunks.length,
+        failedChunkCount: failures.length,
+        candidateCount: candidates.length,
+      })
+    }
+    return candidates
   }
 }
 
@@ -119,6 +309,8 @@ export const extractMemoryImportCandidates = createMemoryImportExtractor({
     return {
       text: result.text,
       toolCalls: result.toolCalls,
+      finishReason: result.finishReason,
+      usage: result.usage,
     }
   },
 })

--- a/lib/nexus/memory/memory-import.ts
+++ b/lib/nexus/memory/memory-import.ts
@@ -35,6 +35,14 @@ const EXTRACTION_TOOL_NAME = "submit_memory_candidates"
 export const MEMORY_EXTRACTION_CHUNK_CHARS = 12_000
 const MEMORY_EXTRACTION_MAX_CONCURRENCY = 3
 const MEMORY_EXTRACTION_ATTEMPTS = 2
+/**
+ * How many times a chunk that ran out of output budget may be halved.
+ * Retrying the same prompt at temperature 0 cannot fix a response the model
+ * had no room to finish — only a smaller chunk can. Bounded so a chunk that
+ * fails for some other reason cannot fan out indefinitely.
+ */
+const MEMORY_EXTRACTION_MAX_SPLIT_DEPTH = 3
+const MEMORY_EXTRACTION_MIN_CHUNK_CHARS = 500
 
 const INVALID_EXTRACTION_RESPONSE =
   "The memory extraction model returned an invalid response"
@@ -83,10 +91,22 @@ function salvageCandidates(value: unknown): MemoryImportCandidate[] | null {
   const candidates = (value as { candidates?: unknown }).candidates
   if (!Array.isArray(candidates)) return null
   const salvaged: MemoryImportCandidate[] = []
+  let capped = 0
   for (const entry of candidates) {
-    if (salvaged.length >= MAX_MEMORY_IMPORT_CANDIDATES) break
+    if (salvaged.length >= MAX_MEMORY_IMPORT_CANDIDATES) {
+      capped += 1
+      continue
+    }
     const parsed = MemoryImportCandidateSchema.safeParse(entry)
     if (parsed.success) salvaged.push(parsed.data)
+  }
+  if (capped > 0) {
+    // Never truncate silently: "why did my import stop at 100" has to be
+    // answerable from the logs.
+    log.warn("Nexus memory extraction batch exceeded the candidate cap", {
+      cap: MAX_MEMORY_IMPORT_CANDIDATES,
+      droppedCandidates: capped,
+    })
   }
   return salvaged.length > 0 ? salvaged : null
 }
@@ -167,12 +187,22 @@ function dedupeCandidates(
 ): MemoryImportCandidate[] {
   const seen = new Set<string>()
   const unique: MemoryImportCandidate[] = []
+  let capped = 0
   for (const candidate of candidates) {
-    if (unique.length >= MAX_MEMORY_IMPORT_CANDIDATES) break
+    if (unique.length >= MAX_MEMORY_IMPORT_CANDIDATES) {
+      capped += 1
+      continue
+    }
     const key = candidate.content.trim().toLowerCase()
     if (seen.has(key)) continue
     seen.add(key)
     unique.push(candidate)
+  }
+  if (capped > 0) {
+    log.warn("Nexus memory import exceeded the candidate cap", {
+      cap: MAX_MEMORY_IMPORT_CANDIDATES,
+      droppedCandidates: capped,
+    })
   }
   return unique
 }
@@ -181,44 +211,119 @@ function toError(error: unknown): Error {
   return error instanceof Error ? error : new Error(String(error))
 }
 
+interface ChunkExtractionContext {
+  model: LanguageModel
+  vendor: MemoryImportVendor
+  chunkIndex: number
+  chunkCount: number
+}
+
+// Never logs the model output or the pasted source; the shape of the response
+// is what makes a failure diagnosable.
+function logChunkFailure(
+  context: ChunkExtractionContext,
+  failure: {
+    chunk: string
+    splitDepth: number
+    attempt: number
+    result?: ModelExtractionResult
+    error: unknown
+  },
+): void {
+  const { result } = failure
+  log.warn("Nexus memory extraction returned an unparseable response", {
+    vendor: context.vendor,
+    chunkIndex: context.chunkIndex,
+    chunkCount: context.chunkCount,
+    attempt: failure.attempt,
+    splitDepth: failure.splitDepth,
+    chunkChars: failure.chunk.length,
+    finishReason: result?.finishReason,
+    outputTextChars: result?.text.length ?? 0,
+    toolCallCount:
+      result && Array.isArray(result.toolCalls)
+        ? result.toolCalls.length
+        : 0,
+    inputTokens: result?.usage?.inputTokens,
+    outputTokens: result?.usage?.outputTokens,
+    error: toError(failure.error).message,
+  })
+}
+
 export function createMemoryImportExtractor(
   dependencies: MemoryImportExtractorDependencies,
 ) {
-  async function extractChunk(
-    model: LanguageModel,
-    vendor: MemoryImportVendor,
+  /**
+   * Halve a chunk the model had no output budget to finish, and extract the
+   * halves. Returns null when splitting is not possible or nothing recovered.
+   */
+  async function extractSplitHalves(
+    context: ChunkExtractionContext,
     chunk: string,
-    chunkIndex: number,
-    chunkCount: number,
+    splitDepth: number,
+  ): Promise<MemoryImportCandidate[] | null> {
+    if (splitDepth >= MEMORY_EXTRACTION_MAX_SPLIT_DEPTH) return null
+    if (chunk.length <= MEMORY_EXTRACTION_MIN_CHUNK_CHARS) return null
+    const halves = splitExtractionChunks(chunk, Math.ceil(chunk.length / 2))
+    if (halves.length < 2) return null
+
+    log.warn("Splitting a Nexus memory extraction chunk that overran", {
+      vendor: context.vendor,
+      chunkIndex: context.chunkIndex,
+      splitDepth,
+      chunkChars: chunk.length,
+      halves: halves.length,
+    })
+    const settled = await Promise.allSettled(
+      halves.map((half) => extractChunk(context, half, splitDepth + 1)),
+    )
+    const fulfilled = settled.filter(
+      (
+        outcome,
+      ): outcome is PromiseFulfilledResult<MemoryImportCandidate[]> =>
+        outcome.status === "fulfilled",
+    )
+    // Half the chunk landing is still better than losing all of it.
+    if (fulfilled.length === 0) return null
+    return fulfilled.flatMap((outcome) => outcome.value)
+  }
+
+  async function extractChunk(
+    context: ChunkExtractionContext,
+    chunk: string,
+    splitDepth = 0,
   ): Promise<MemoryImportCandidate[]> {
-    const prompt = buildMemoryImportExtractionPrompt(vendor, chunk)
+    const prompt = buildMemoryImportExtractionPrompt(context.vendor, chunk)
+    let ranOutOfBudget = false
     for (
       let attempt = 1;
       attempt <= MEMORY_EXTRACTION_ATTEMPTS;
       attempt += 1
     ) {
-      const result = await dependencies.runExtraction(model, prompt)
+      // runExtraction is inside the try so a throttled or dropped Bedrock call
+      // gets the retry too, not just an unparseable response.
+      let result: ModelExtractionResult | undefined
       try {
+        result = await dependencies.runExtraction(context.model, prompt)
         return parseMemoryImportCandidates(result)
       } catch (error) {
-        // Never log the model output or the pasted source; the shape of the
-        // response is what makes this diagnosable.
-        log.warn("Nexus memory extraction returned an unparseable response", {
-          vendor,
-          chunkIndex,
-          chunkCount,
+        ranOutOfBudget = result?.finishReason === "length"
+        logChunkFailure(context, {
+          chunk,
+          splitDepth,
           attempt,
-          chunkChars: chunk.length,
-          finishReason: result.finishReason,
-          outputTextChars: result.text.length,
-          toolCallCount: Array.isArray(result.toolCalls)
-            ? result.toolCalls.length
-            : 0,
-          inputTokens: result.usage?.inputTokens,
-          outputTokens: result.usage?.outputTokens,
-          error: toError(error).message,
+          result,
+          error,
         })
       }
+    }
+
+    // A chunk that ran out of output budget truncates identically on every
+    // identical retry. Splitting it — not retrying it — is what actually
+    // clears the failure mode the 2026-08-05 incident hit.
+    if (ranOutOfBudget) {
+      const recovered = await extractSplitHalves(context, chunk, splitDepth)
+      if (recovered) return recovered
     }
     throw new Error(INVALID_EXTRACTION_RESPONSE)
   }
@@ -252,11 +357,13 @@ export function createMemoryImportExtractor(
         ) {
           try {
             collected[index] = await extractChunk(
-              model,
-              input.vendor,
+              {
+                model,
+                vendor: input.vendor,
+                chunkIndex: index,
+                chunkCount: chunks.length,
+              },
               chunks[index],
-              index,
-              chunks.length,
             )
           } catch (error) {
             failures.push(toError(error))

--- a/lib/nexus/memory/memory-import.ts
+++ b/lib/nexus/memory/memory-import.ts
@@ -43,6 +43,19 @@ const MEMORY_EXTRACTION_ATTEMPTS = 2
  */
 const MEMORY_EXTRACTION_MAX_SPLIT_DEPTH = 3
 const MEMORY_EXTRACTION_MIN_CHUNK_CHARS = 500
+const MEMORY_EXTRACTION_RETRY_BASE_MS = 250
+
+/**
+ * Jittered so several chunks that hit the same Bedrock throttle window do not
+ * retry in lockstep — at concurrency 3 an immediate retry tends to land in the
+ * window that just rejected it.
+ */
+function delayBeforeRetry(attempt: number): Promise<void> {
+  const base = MEMORY_EXTRACTION_RETRY_BASE_MS * attempt
+  return new Promise((resolve) => {
+    setTimeout(resolve, base + Math.random() * base)
+  })
+}
 
 const INVALID_EXTRACTION_RESPONSE =
   "The memory extraction model returned an invalid response"
@@ -93,12 +106,15 @@ function salvageCandidates(value: unknown): MemoryImportCandidate[] | null {
   const salvaged: MemoryImportCandidate[] = []
   let capped = 0
   for (const entry of candidates) {
+    // Validate before counting, so droppedCandidates reports what the cap
+    // actually cost rather than including entries that were invalid anyway.
+    const parsed = MemoryImportCandidateSchema.safeParse(entry)
+    if (!parsed.success) continue
     if (salvaged.length >= MAX_MEMORY_IMPORT_CANDIDATES) {
       capped += 1
       continue
     }
-    const parsed = MemoryImportCandidateSchema.safeParse(entry)
-    if (parsed.success) salvaged.push(parsed.data)
+    salvaged.push(parsed.data)
   }
   if (capped > 0) {
     // Never truncate silently: "why did my import stop at 100" has to be
@@ -315,6 +331,12 @@ export function createMemoryImportExtractor(
           result,
           error,
         })
+        // No point pausing before a retry that will not happen, and none
+        // before a split — a smaller chunk is not competing for the same
+        // throttle window.
+        if (attempt < MEMORY_EXTRACTION_ATTEMPTS && !ranOutOfBudget) {
+          await delayBeforeRetry(attempt)
+        }
       }
     }
 

--- a/lib/nexus/memory/memory-import.ts
+++ b/lib/nexus/memory/memory-import.ts
@@ -305,12 +305,22 @@ export function createMemoryImportExtractor(
     // call per slot keeps the declared bound true.
     const recovered: MemoryImportCandidate[] = []
     let anyHalfSucceeded = false
-    for (const half of halves) {
+    for (const [halfIndex, half] of halves.entries()) {
       try {
         recovered.push(...(await extractChunk(context, half, splitDepth + 1)))
         anyHalfSucceeded = true
-      } catch {
-        // Half the chunk landing is still better than losing all of it.
+      } catch (error) {
+        // Half the chunk landing is still better than losing all of it, but
+        // say which half went missing — otherwise the only trace is a smaller
+        // candidateCount in the summary line.
+        log.warn("A Nexus memory extraction half was lost", {
+          vendor: context.vendor,
+          chunkIndex: context.chunkIndex,
+          splitDepth,
+          halfIndex,
+          halfChars: half.length,
+          error: toError(error).message,
+        })
       }
     }
     return anyHalfSucceeded ? recovered : null

--- a/lib/nexus/memory/memory-import.ts
+++ b/lib/nexus/memory/memory-import.ts
@@ -290,18 +290,22 @@ export function createMemoryImportExtractor(
       chunkChars: chunk.length,
       halves: halves.length,
     })
-    const settled = await Promise.allSettled(
-      halves.map((half) => extractChunk(context, half, splitDepth + 1)),
-    )
-    const fulfilled = settled.filter(
-      (
-        outcome,
-      ): outcome is PromiseFulfilledResult<MemoryImportCandidate[]> =>
-        outcome.status === "fulfilled",
-    )
-    // Half the chunk landing is still better than losing all of it.
-    if (fulfilled.length === 0) return null
-    return fulfilled.flatMap((outcome) => outcome.value)
+    // Sequential on purpose. Fanning the halves out concurrently would escape
+    // MEMORY_EXTRACTION_MAX_CONCURRENCY: recursion is per worker slot, so
+    // parallel halves at depth 3 could put ~8 calls in flight per slot and
+    // ~24 overall — the exact pile-up the retry jitter exists to avoid. One
+    // call per slot keeps the declared bound true.
+    const recovered: MemoryImportCandidate[] = []
+    let anyHalfSucceeded = false
+    for (const half of halves) {
+      try {
+        recovered.push(...(await extractChunk(context, half, splitDepth + 1)))
+        anyHalfSucceeded = true
+      } catch {
+        // Half the chunk landing is still better than losing all of it.
+      }
+    }
+    return anyHalfSucceeded ? recovered : null
   }
 
   async function extractChunk(
@@ -369,6 +373,9 @@ export function createMemoryImportExtractor(
 
     const collected: MemoryImportCandidate[][] = chunks.map(() => [])
     const failures: Error[] = []
+    // Race-free without a lock: each worker runs synchronously up to its first
+    // await, so `nextChunk++` claims an index before any other worker can be
+    // scheduled. No two workers can ever read the same value.
     let nextChunk = 0
     const workers = Array.from(
       { length: Math.min(MEMORY_EXTRACTION_MAX_CONCURRENCY, chunks.length) },

--- a/lib/nexus/memory/memory-service.ts
+++ b/lib/nexus/memory/memory-service.ts
@@ -19,6 +19,8 @@ import {
   type StoredNexusMemory,
 } from "./memory-repository"
 
+const log = createLogger({ module: "nexus-memory-service" })
+
 export const MEMORY_DEDUP_THRESHOLD = 0.9
 const DEFAULT_RETRIEVAL_THRESHOLD = 0.3
 const DEFAULT_RETRIEVAL_TOP_K = 6
@@ -104,6 +106,48 @@ function validateInput(input: {
   return content
 }
 
+function piiTypeCounts(
+  entities: readonly PIIEntity[],
+): Record<string, number> {
+  const counts: Record<string, number> = Object.create(null)
+  for (const entity of entities) {
+    counts[entity.type] = (counts[entity.type] ?? 0) + 1
+  }
+  return counts
+}
+
+/**
+ * Detect-only telemetry. A memory is the user's own record of their own life,
+ * so names, relationships, dates, ages, and contact details are exactly what
+ * it is for: refusing them made the feature useless. This records what was
+ * detected — types and counts only, never offsets or values — and always
+ * lets the write proceed. Do not restore blocking here without Hagel's
+ * explicit approval.
+ */
+async function recordPIITelemetry(
+  dependencies: MemoryServiceDependencies,
+  input: { userId: number; content: string },
+): Promise<void> {
+  let entities: PIIEntity[]
+  try {
+    entities = await dependencies.detectPII(input.content)
+  } catch (error) {
+    // Fails open: an unavailable scan is an observability gap, not a reason
+    // to lose the user's memory.
+    log.warn("Nexus memory PII screening unavailable; saving anyway", {
+      userId: input.userId,
+      error: error instanceof Error ? error.message : String(error),
+    })
+    return
+  }
+  if (entities.length === 0) return
+  log.info("Nexus memory contains detected personal information", {
+    userId: input.userId,
+    piiEntityCount: entities.length,
+    piiTypes: piiTypeCounts(entities),
+  })
+}
+
 async function sanitizeMemoryContent(
   dependencies: MemoryServiceDependencies,
   input: {
@@ -125,26 +169,11 @@ async function sanitizeMemoryContent(
       "input",
     )
   }
-  let piiEntities: PIIEntity[]
-  try {
-    piiEntities = await dependencies.detectPII(content)
-  } catch {
-    // Ordinary inference does not run PII detection. Durable memory is one of
-    // the two explicit gates and cannot persist an indeterminate result.
-    throw new ContentSafetyBlockedError(
-      "Memory is temporarily unavailable because its privacy check could not be completed.",
-      ["pii_scan_unavailable"],
-      "input",
-    )
-  }
+  await recordPIITelemetry(dependencies, {
+    userId: input.userId,
+    content,
+  })
   const sanitized = safety.processedContent.trim()
-  if (piiEntities.length > 0) {
-    throw new ContentSafetyBlockedError(
-      "For privacy, personal information cannot be saved to memory.",
-      ["pii"],
-      "input",
-    )
-  }
   if (!sanitized) {
     throw new Error("Memory content is empty after safety processing")
   }
@@ -154,8 +183,6 @@ async function sanitizeMemoryContent(
 export function createMemoryService(
   dependencies: MemoryServiceDependencies,
 ): NexusMemoryService {
-  const log = createLogger({ module: "nexus-memory-service" })
-
   return {
     async save(input) {
       const sanitized = await sanitizeMemoryContent(dependencies, input)

--- a/lib/nexus/memory/memory-service.ts
+++ b/lib/nexus/memory/memory-service.ts
@@ -130,6 +130,10 @@ async function recordPIITelemetry(
 ): Promise<void> {
   let entities: PIIEntity[]
   try {
+    // Scans the submitted content, not safety.processedContent. Every return
+    // in ContentSafetyService.processInput passes content through unchanged,
+    // so the two are identical today; if that ever stops being true, what the
+    // user actually submitted is the more faithful thing to report.
     entities = await dependencies.detectPII(input.content)
   } catch (error) {
     // Fails open: an unavailable scan is an observability gap, not a reason

--- a/lib/nexus/memory/memory-service.ts
+++ b/lib/nexus/memory/memory-service.ts
@@ -126,7 +126,7 @@ function piiTypeCounts(
  */
 async function recordPIITelemetry(
   dependencies: MemoryServiceDependencies,
-  input: { userId: number; content: string },
+  input: { userId: number; content: string; source?: NexusMemorySource },
 ): Promise<void> {
   let entities: PIIEntity[]
   try {
@@ -140,13 +140,19 @@ async function recordPIITelemetry(
     // to lose the user's memory.
     log.warn("Nexus memory PII screening unavailable; saving anyway", {
       userId: input.userId,
+      source: input.source,
       error: error instanceof Error ? error.message : String(error),
     })
     return
   }
   if (entities.length === 0) return
+  // `source` makes the unattended path queryable on its own. Auto-extraction
+  // is prompted not to capture third-party identifiers, and that prompt is now
+  // the only control on it — so a source:"auto" line here is the signal that
+  // the prompt did not hold, and the thing to alert on.
   log.info("Nexus memory contains detected personal information", {
     userId: input.userId,
+    source: input.source,
     piiEntityCount: entities.length,
     piiTypes: piiTypeCounts(entities),
   })
@@ -158,6 +164,7 @@ async function sanitizeMemoryContent(
     userId: number
     sessionId: string
     content: string
+    source?: NexusMemorySource
   },
 ): Promise<string> {
   const content = validateInput(input)
@@ -175,6 +182,7 @@ async function sanitizeMemoryContent(
   }
   await recordPIITelemetry(dependencies, {
     userId: input.userId,
+    source: input.source,
     content,
   })
   const sanitized = safety.processedContent.trim()

--- a/tests/e2e/settings-memory-crud.functional.spec.ts
+++ b/tests/e2e/settings-memory-crud.functional.spec.ts
@@ -62,11 +62,18 @@ test.describe("Settings memory CRUD (authenticated)", () => {
       await expect(firstRow.getByText("Manual")).toBeVisible()
       await expect(firstRow.getByText("context")).toBeVisible()
 
+      // Pin the row by id before editing: filling the edit textarea replaces
+      // the row's rendered text, so a hasText filter on the original content
+      // stops matching and every later control inside it becomes unreachable.
+      const firstRowId = await firstRow.getAttribute("data-memory-id")
+      expect(firstRowId).toBeTruthy()
+      const editingRow = page.locator(`[data-memory-id="${firstRowId}"]`)
+
       await firstRow
         .getByRole("button", { name: `Edit memory: ${firstContent}` })
         .click()
-      await firstRow.getByTestId("memory-edit-content").fill(editedContent)
-      await firstRow.getByTestId("memory-edit-save").click()
+      await editingRow.getByTestId("memory-edit-content").fill(editedContent)
+      await editingRow.getByTestId("memory-edit-save").click()
 
       const editedRow = page
         .getByTestId("memory-row")

--- a/tests/e2e/settings-memory-import.functional.spec.ts
+++ b/tests/e2e/settings-memory-import.functional.spec.ts
@@ -7,11 +7,14 @@ import {
   SEEDED_ADMIN_SUB,
 } from "./helpers/session-auth"
 
+// Synthetic throughout. These strings are sent to live Comprehend and appear
+// in test source and CI output, so no real person's contact details belong in
+// them — a fabricated address trips EMAIL detection just as well.
 const PII_CANDIDATE_TEXT = [
   "My wife Sarah teaches third grade at Harbor Ridge.",
   "My daughter Ellie is 8 years old.",
   "I started as CIO on July 1, 2019.",
-  "My work email is hagelk@psd401.net.",
+  "My work email is jordan.rivera@example.com.",
 ] as const
 
 interface ImportedMemoryRow {
@@ -140,7 +143,7 @@ test.describe("Settings memory import (authenticated)", () => {
       "- My wife Sarah teaches third grade at Harbor Ridge.",
       "- My daughter Ellie is 8 years old.",
       "- I started as CIO on July 1, 2019.",
-      "- My work email is hagelk@psd401.net.",
+      "- My work email is jordan.rivera@example.com.",
     ].join("\n")
 
     try {
@@ -196,7 +199,7 @@ test.describe("Settings memory import (authenticated)", () => {
         true,
       )
       expect(
-        rows.some((row) => row.content.includes("hagelk@psd401.net")),
+        rows.some((row) => row.content.includes("jordan.rivera@example.com")),
       ).toBe(true)
     } finally {
       await deleteMarkedMemories(database, marker)

--- a/tests/e2e/settings-memory-import.functional.spec.ts
+++ b/tests/e2e/settings-memory-import.functional.spec.ts
@@ -1,3 +1,4 @@
+import type { Page } from "@playwright/test"
 import postgres from "postgres"
 import { test, expect } from "./fixtures"
 import {
@@ -27,6 +28,31 @@ function createDatabase() {
   )
 }
 
+async function openMemoryImport(page: Page): Promise<void> {
+  await authenticateContext(
+    page.context(),
+    SEEDED_ADMIN_EMAIL,
+    SEEDED_ADMIN_SUB,
+  )
+  await page.goto("/settings")
+  await page.getByRole("tab", { name: "Memory" }).click()
+  await page.getByTestId("memory-import-open").click()
+}
+
+async function deleteMarkedMemories(
+  database: ReturnType<typeof createDatabase>,
+  marker: string,
+): Promise<void> {
+  await database`
+    DELETE FROM nexus_user_memories AS memory
+    USING users AS owner
+    WHERE owner.id = memory.user_id
+      AND owner.email = ${SEEDED_ADMIN_EMAIL}
+      AND memory.content LIKE ${`%${marker}%`}
+  `
+  await database.end()
+}
+
 test.describe("Settings memory import (authenticated)", () => {
   test.describe.configure({ timeout: 240_000 })
   test.skip(
@@ -38,11 +64,6 @@ test.describe("Settings memory import (authenticated)", () => {
   test("extracts a paste for review, omits a deselected candidate, and saves edited candidates", async ({
     page,
   }) => {
-    await authenticateContext(
-      page.context(),
-      SEEDED_ADMIN_EMAIL,
-      SEEDED_ADMIN_SUB,
-    )
     const database = createDatabase()
     const marker = `settings-memory-import-${Date.now()}`
     const pastedText = [
@@ -52,9 +73,7 @@ test.describe("Settings memory import (authenticated)", () => {
     ].join("\n")
 
     try {
-      await page.goto("/settings")
-      await page.getByRole("tab", { name: "Memory" }).click()
-      await page.getByTestId("memory-import-open").click()
+      await openMemoryImport(page)
 
       await expect(page.getByTestId("memory-import-extract")).toBeDisabled()
       await page.getByTestId("memory-import-paste").fill(pastedText)
@@ -105,25 +124,13 @@ test.describe("Settings memory import (authenticated)", () => {
         rows.some((row) => row.content.includes("concise answers")),
       ).toBe(false)
     } finally {
-      await database`
-        DELETE FROM nexus_user_memories AS memory
-        USING users AS owner
-        WHERE owner.id = memory.user_id
-          AND owner.email = ${SEEDED_ADMIN_EMAIL}
-          AND memory.content LIKE ${`%${marker}%`}
-      `
-      await database.end()
+      await deleteMarkedMemories(database, marker)
     }
   })
 
   test("imports memories that contain names, dates, and ages", async ({
     page,
   }) => {
-    await authenticateContext(
-      page.context(),
-      SEEDED_ADMIN_EMAIL,
-      SEEDED_ADMIN_SUB,
-    )
     const database = createDatabase()
     const marker = `settings-memory-import-pii-${Date.now()}`
     // Every one of these trips Comprehend (NAME, DATE_TIME, AGE, EMAIL). Before
@@ -137,19 +144,33 @@ test.describe("Settings memory import (authenticated)", () => {
     ].join("\n")
 
     try {
-      await page.goto("/settings")
-      await page.getByRole("tab", { name: "Memory" }).click()
-      await page.getByTestId("memory-import-open").click()
+      await openMemoryImport(page)
       await page.getByTestId("memory-import-paste").fill(pastedText)
       await page.getByTestId("memory-import-extract").click()
 
+      // How many candidates the model returns is its own call, so this asserts
+      // a floor and then pins the saved set itself: the first four rows are
+      // overwritten with the PII under test and everything after is deselected.
       const candidates = page.getByTestId("memory-import-candidate")
-      await expect(candidates).toHaveCount(4, { timeout: 90_000 })
+      await expect(candidates.first()).toBeVisible({ timeout: 90_000 })
+      await expect
+        .poll(() => candidates.count(), { timeout: 30_000 })
+        .toBeGreaterThanOrEqual(PII_CANDIDATE_TEXT.length)
 
-      for (let index = 0; index < 4; index += 1) {
+      const extracted = await candidates.count()
+      const surplus = Array.from(
+        { length: Math.max(0, extracted - PII_CANDIDATE_TEXT.length) },
+        (_value, offset) => PII_CANDIDATE_TEXT.length + offset,
+      )
+      for (const index of surplus) {
+        await page
+          .getByTestId(`memory-import-candidate-select-${index}`)
+          .click()
+      }
+      for (const [index, text] of PII_CANDIDATE_TEXT.entries()) {
         await page
           .getByTestId(`memory-import-candidate-content-${index}`)
-          .fill(`${marker}-${index}: ${PII_CANDIDATE_TEXT[index]}`)
+          .fill(`${marker}-${index}: ${text}`)
       }
       await page.getByTestId("memory-import-save").click()
 
@@ -178,14 +199,7 @@ test.describe("Settings memory import (authenticated)", () => {
         rows.some((row) => row.content.includes("hagelk@psd401.net")),
       ).toBe(true)
     } finally {
-      await database`
-        DELETE FROM nexus_user_memories AS memory
-        USING users AS owner
-        WHERE owner.id = memory.user_id
-          AND owner.email = ${SEEDED_ADMIN_EMAIL}
-          AND memory.content LIKE ${`%${marker}%`}
-      `
-      await database.end()
+      await deleteMarkedMemories(database, marker)
     }
   })
 })

--- a/tests/e2e/settings-memory-import.functional.spec.ts
+++ b/tests/e2e/settings-memory-import.functional.spec.ts
@@ -6,6 +6,13 @@ import {
   SEEDED_ADMIN_SUB,
 } from "./helpers/session-auth"
 
+const PII_CANDIDATE_TEXT = [
+  "My wife Sarah teaches third grade at Harbor Ridge.",
+  "My daughter Ellie is 8 years old.",
+  "I started as CIO on July 1, 2019.",
+  "My work email is hagelk@psd401.net.",
+] as const
+
 interface ImportedMemoryRow {
   content: string
   source: string
@@ -97,6 +104,79 @@ test.describe("Settings memory import (authenticated)", () => {
       expect(
         rows.some((row) => row.content.includes("concise answers")),
       ).toBe(false)
+    } finally {
+      await database`
+        DELETE FROM nexus_user_memories AS memory
+        USING users AS owner
+        WHERE owner.id = memory.user_id
+          AND owner.email = ${SEEDED_ADMIN_EMAIL}
+          AND memory.content LIKE ${`%${marker}%`}
+      `
+      await database.end()
+    }
+  })
+
+  test("imports memories that contain names, dates, and ages", async ({
+    page,
+  }) => {
+    await authenticateContext(
+      page.context(),
+      SEEDED_ADMIN_EMAIL,
+      SEEDED_ADMIN_SUB,
+    )
+    const database = createDatabase()
+    const marker = `settings-memory-import-pii-${Date.now()}`
+    // Every one of these trips Comprehend (NAME, DATE_TIME, AGE, EMAIL). Before
+    // the 2026-08-05 fix the save gate refused all four and the user was told
+    // only that they "need attention".
+    const pastedText = [
+      "- My wife Sarah teaches third grade at Harbor Ridge.",
+      "- My daughter Ellie is 8 years old.",
+      "- I started as CIO on July 1, 2019.",
+      "- My work email is hagelk@psd401.net.",
+    ].join("\n")
+
+    try {
+      await page.goto("/settings")
+      await page.getByRole("tab", { name: "Memory" }).click()
+      await page.getByTestId("memory-import-open").click()
+      await page.getByTestId("memory-import-paste").fill(pastedText)
+      await page.getByTestId("memory-import-extract").click()
+
+      const candidates = page.getByTestId("memory-import-candidate")
+      await expect(candidates).toHaveCount(4, { timeout: 90_000 })
+
+      for (let index = 0; index < 4; index += 1) {
+        await page
+          .getByTestId(`memory-import-candidate-content-${index}`)
+          .fill(`${marker}-${index}: ${PII_CANDIDATE_TEXT[index]}`)
+      }
+      await page.getByTestId("memory-import-save").click()
+
+      const importedRows = page
+        .getByTestId("memory-row")
+        .filter({ hasText: marker })
+      await expect(importedRows).toHaveCount(4, { timeout: 90_000 })
+      // No candidate is left behind explaining itself.
+      await expect(
+        page.getByTestId("memory-import-candidate-reason-0"),
+      ).toHaveCount(0)
+
+      const rows = await database<ImportedMemoryRow[]>`
+        SELECT memory.content, memory.source, memory.deleted_at
+        FROM nexus_user_memories memory
+        JOIN users owner ON owner.id = memory.user_id
+        WHERE owner.email = ${SEEDED_ADMIN_EMAIL}
+          AND memory.content LIKE ${`%${marker}%`}
+      `
+      expect(rows).toHaveLength(4)
+      expect(rows.some((row) => row.content.includes("Sarah"))).toBe(true)
+      expect(rows.some((row) => row.content.includes("8 years old"))).toBe(
+        true,
+      )
+      expect(
+        rows.some((row) => row.content.includes("hagelk@psd401.net")),
+      ).toBe(true)
     } finally {
       await database`
         DELETE FROM nexus_user_memories AS memory

--- a/tests/unit/actions/nexus-memory-import-actions.test.ts
+++ b/tests/unit/actions/nexus-memory-import-actions.test.ts
@@ -61,6 +61,7 @@ import {
   extractImportCandidates,
   saveImportedMemories,
 } from "@/actions/nexus/memory-import.actions"
+import { ContentSafetyBlockedError } from "@/lib/streaming/types"
 import {
   MAX_MEMORY_IMPORT_CHARS,
   MAX_MEMORY_IMPORT_SAVE_BATCH_CANDIDATES,
@@ -262,6 +263,48 @@ describe("Nexus memory import save actions", () => {
       },
     })
     expect(mockSave).toHaveBeenCalledTimes(3)
+  })
+
+  it("returns a user-safe reason for every rejected candidate", async () => {
+    mockSave
+      .mockRejectedValueOnce(
+        new ContentSafetyBlockedError(
+          "Blocked by policy",
+          ["guardrail"],
+          "input",
+        ),
+      )
+      .mockRejectedValueOnce(
+        new Error("connect ECONNREFUSED 10.0.0.5:5432"),
+      )
+
+    const result = await saveImportedMemories({
+      vendor: "chatgpt",
+      candidates: [
+        { content: "Blocked fact", category: "profile" },
+        { content: "Infrastructure failure", category: "context" },
+      ],
+    })
+
+    expect(result).toMatchObject({
+      isSuccess: true,
+      data: {
+        total: 2,
+        successful: 0,
+        failed: 2,
+        results: [
+          { index: 0, status: "failed", reason: "Blocked by policy" },
+          {
+            index: 1,
+            status: "failed",
+            reason: "This memory could not be saved. Try again in a moment.",
+          },
+        ],
+      },
+    })
+    // Provider, database, and network internals must not reach the browser.
+    expect(JSON.stringify(result)).not.toContain("ECONNREFUSED")
+    expect(mockRevalidatePath).not.toHaveBeenCalled()
   })
 
   it("blocks extraction and writes while account memory is disabled", async () => {

--- a/tests/unit/lib/nexus/memory-import.test.ts
+++ b/tests/unit/lib/nexus/memory-import.test.ts
@@ -1,29 +1,58 @@
+/* eslint-disable no-var */
+var mockLogWarn = jest.fn()
+/* eslint-enable no-var */
+
+// The module under test calls createLogger at import time, which is hoisted
+// above the mock-variable assignment — so the methods must dereference lazily.
+jest.mock("@/lib/logger", () => ({
+  createLogger: () => ({
+    info: jest.fn(),
+    warn: (...args: unknown[]) => mockLogWarn(...args),
+    error: jest.fn(),
+    debug: jest.fn(),
+  }),
+  generateRequestId: () => "request-1",
+  startTimer: () => jest.fn(),
+  sanitizeForLogging: (value: unknown) => value,
+  getLogContext: () => ({}),
+}))
+
 import type { LanguageModel } from "ai"
 import {
   createMemoryImportExtractor,
   DEFAULT_MEMORY_EXTRACTION_MODEL_ID,
   parseMemoryImportCandidates,
+  splitExtractionChunks,
 } from "@/lib/nexus/memory/memory-import"
+import { MAX_MEMORY_IMPORT_CANDIDATES } from "@/lib/nexus/memory/memory-constants"
+
+function toolResult(candidates: unknown[]) {
+  return {
+    text: "",
+    toolCalls: [
+      {
+        toolName: "submit_memory_candidates",
+        input: { candidates },
+      },
+    ],
+  }
+}
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
 
 describe("Nexus memory import extraction", () => {
   it("parses the forced extraction tool response", () => {
     expect(
-      parseMemoryImportCandidates({
-        text: "",
-        toolCalls: [
+      parseMemoryImportCandidates(
+        toolResult([
           {
-            toolName: "submit_memory_candidates",
-            input: {
-              candidates: [
-                {
-                  content: "Prefers concise answers",
-                  category: "preference",
-                },
-              ],
-            },
+            content: "Prefers concise answers",
+            category: "preference",
           },
-        ],
-      }),
+        ]),
+      ),
     ).toEqual([
       {
         content: "Prefers concise answers",
@@ -57,15 +86,7 @@ describe("Nexus memory import extraction", () => {
   it("uses the configured Bedrock model and treats pasted text as JSON data", async () => {
     const model = {} as LanguageModel
     const createModel = jest.fn().mockResolvedValue(model)
-    const runExtraction = jest.fn().mockResolvedValue({
-      text: "",
-      toolCalls: [
-        {
-          toolName: "submit_memory_candidates",
-          input: { candidates: [] },
-        },
-      ],
-    })
+    const runExtraction = jest.fn().mockResolvedValue(toolResult([]))
     const extract = createMemoryImportExtractor({
       getSetting: jest.fn().mockResolvedValue("custom-memory-model"),
       createModel,
@@ -104,5 +125,190 @@ describe("Nexus memory import extraction", () => {
       "amazon-bedrock",
       DEFAULT_MEMORY_EXTRACTION_MODEL_ID,
     )
+  })
+})
+
+describe("Nexus memory import candidate salvage", () => {
+  it("keeps the valid candidates when the batch holds an invalid entry", () => {
+    expect(
+      parseMemoryImportCandidates(
+        toolResult([
+          { content: "Works in education", category: "profile" },
+          { content: "Missing a category" },
+          { content: "", category: "context" },
+          { content: "Prefers concise answers", category: "preference" },
+        ]),
+      ),
+    ).toEqual([
+      { content: "Works in education", category: "profile" },
+      { content: "Prefers concise answers", category: "preference" },
+    ])
+  })
+
+  it("caps a salvaged batch at the import maximum", () => {
+    const candidates = Array.from(
+      { length: MAX_MEMORY_IMPORT_CANDIDATES + 10 },
+      (_value, index) => ({
+        content: `Fact ${index + 1}`,
+        category: "context",
+      }),
+    )
+
+    expect(parseMemoryImportCandidates(toolResult(candidates))).toHaveLength(
+      MAX_MEMORY_IMPORT_CANDIDATES,
+    )
+  })
+})
+
+describe("Nexus memory import chunking", () => {
+  it("keeps a paste inside the budget as a single chunk", () => {
+    expect(splitExtractionChunks("- One fact\n- Another fact")).toEqual([
+      "- One fact\n- Another fact",
+    ])
+    expect(splitExtractionChunks("   ")).toEqual([])
+  })
+
+  it("splits on line boundaries without losing content", () => {
+    const line = `- ${"x".repeat(60)}`
+    const text = Array.from({ length: 20 }, () => line).join("\n")
+
+    const chunks = splitExtractionChunks(text, 200)
+
+    expect(chunks.length).toBeGreaterThan(1)
+    for (const chunk of chunks) {
+      expect(chunk.length).toBeLessThanOrEqual(200)
+    }
+    expect(chunks.join("\n")).toBe(text)
+  })
+
+  it("splits a single oversized line on characters", () => {
+    expect(splitExtractionChunks("y".repeat(500), 200)).toEqual([
+      "y".repeat(200),
+      "y".repeat(200),
+      "y".repeat(100),
+    ])
+  })
+
+  it("extracts every chunk of a large paste and merges duplicates", async () => {
+    const pastedText = `- ${"a".repeat(8_000)}\n- ${"b".repeat(8_000)}`
+    const runExtraction = jest.fn(async (_model, prompt: string) =>
+      prompt.includes("aaaa")
+        ? toolResult([{ content: "Shared fact", category: "profile" }])
+        : toolResult([
+            { content: "Shared fact", category: "profile" },
+            { content: "Second fact", category: "context" },
+          ]),
+    )
+    const extract = createMemoryImportExtractor({
+      getSetting: jest.fn().mockResolvedValue(null),
+      createModel: jest.fn().mockResolvedValue({} as LanguageModel),
+      runExtraction,
+    })
+
+    await expect(
+      extract({ vendor: "chatgpt", pastedText }),
+    ).resolves.toEqual([
+      { content: "Shared fact", category: "profile" },
+      { content: "Second fact", category: "context" },
+    ])
+    expect(runExtraction).toHaveBeenCalledTimes(2)
+  })
+
+  it("returns the chunks that parsed when another chunk fails outright", async () => {
+    const pastedText = `- ${"a".repeat(8_000)}\n- ${"b".repeat(8_000)}`
+    const runExtraction = jest.fn(async (_model, prompt: string) =>
+      prompt.includes("aaaa")
+        ? { text: "not json", toolCalls: [] }
+        : toolResult([{ content: "Second fact", category: "context" }]),
+    )
+    const extract = createMemoryImportExtractor({
+      getSetting: jest.fn().mockResolvedValue(null),
+      createModel: jest.fn().mockResolvedValue({} as LanguageModel),
+      runExtraction,
+    })
+
+    await expect(
+      extract({ vendor: "chatgpt", pastedText }),
+    ).resolves.toEqual([{ content: "Second fact", category: "context" }])
+    expect(runExtraction).toHaveBeenCalledTimes(3)
+  })
+})
+
+describe("Nexus memory import extraction retries and diagnostics", () => {
+  it("retries once when the response cannot be parsed", async () => {
+    const runExtraction = jest
+      .fn()
+      .mockResolvedValueOnce({ text: "not json", toolCalls: [] })
+      .mockResolvedValueOnce(
+        toolResult([{ content: "Recovered fact", category: "context" }]),
+      )
+    const extract = createMemoryImportExtractor({
+      getSetting: jest.fn().mockResolvedValue(null),
+      createModel: jest.fn().mockResolvedValue({} as LanguageModel),
+      runExtraction,
+    })
+
+    await expect(
+      extract({ vendor: "claude", pastedText: "- One fact" }),
+    ).resolves.toEqual([
+      { content: "Recovered fact", category: "context" },
+    ])
+    expect(runExtraction).toHaveBeenCalledTimes(2)
+  })
+
+  it("logs response shape and fails after the retry is exhausted", async () => {
+    const runExtraction = jest.fn().mockResolvedValue({
+      text: "truncated {",
+      toolCalls: [],
+      finishReason: "length",
+      usage: { inputTokens: 4_000, outputTokens: 8_192 },
+    })
+    const extract = createMemoryImportExtractor({
+      getSetting: jest.fn().mockResolvedValue(null),
+      createModel: jest.fn().mockResolvedValue({} as LanguageModel),
+      runExtraction,
+    })
+
+    await expect(
+      extract({ vendor: "claude", pastedText: "- One fact" }),
+    ).rejects.toThrow("invalid response")
+    expect(runExtraction).toHaveBeenCalledTimes(2)
+    expect(mockLogWarn).toHaveBeenCalledWith(
+      "Nexus memory extraction returned an unparseable response",
+      expect.objectContaining({
+        vendor: "claude",
+        attempt: 1,
+        chunkIndex: 0,
+        chunkCount: 1,
+        finishReason: "length",
+        outputTextChars: "truncated {".length,
+        toolCallCount: 0,
+        inputTokens: 4_000,
+        outputTokens: 8_192,
+      }),
+    )
+  })
+
+  it("never logs the model output or the pasted source", async () => {
+    const runExtraction = jest.fn().mockResolvedValue({
+      text: "Sarah Hagel lives at 12 Harbor Ridge",
+      toolCalls: [],
+      finishReason: "stop",
+    })
+    const extract = createMemoryImportExtractor({
+      getSetting: jest.fn().mockResolvedValue(null),
+      createModel: jest.fn().mockResolvedValue({} as LanguageModel),
+      runExtraction,
+    })
+
+    await expect(
+      extract({
+        vendor: "chatgpt",
+        pastedText: "- Sarah Hagel lives at 12 Harbor Ridge",
+      }),
+    ).rejects.toThrow("invalid response")
+    const logged = JSON.stringify(mockLogWarn.mock.calls)
+    expect(logged).not.toContain("Sarah Hagel")
+    expect(logged).not.toContain("Harbor Ridge")
   })
 })

--- a/tests/unit/lib/nexus/memory-import.test.ts
+++ b/tests/unit/lib/nexus/memory-import.test.ts
@@ -1,12 +1,13 @@
 /* eslint-disable no-var */
 var mockLogWarn = jest.fn()
+var mockLogInfo = jest.fn()
 /* eslint-enable no-var */
 
 // The module under test calls createLogger at import time, which is hoisted
 // above the mock-variable assignment — so the methods must dereference lazily.
 jest.mock("@/lib/logger", () => ({
   createLogger: () => ({
-    info: jest.fn(),
+    info: (...args: unknown[]) => mockLogInfo(...args),
     warn: (...args: unknown[]) => mockLogWarn(...args),
     error: jest.fn(),
     debug: jest.fn(),
@@ -399,6 +400,17 @@ describe("Nexus memory import output-budget overruns", () => {
     // a second identical call first — at temperature 0 it truncates the same
     // way, and the waste compounds at every split depth.
     expect(runExtraction).toHaveBeenCalledTimes(3)
+    // The whole import's model spend on one alertable line.
+    expect(mockLogInfo).toHaveBeenCalledWith(
+      "Nexus memory extraction completed",
+      expect.objectContaining({
+        vendor: "chatgpt",
+        chunkCount: 1,
+        modelCalls: 3,
+        splitEvents: 1,
+        candidateCount: 2,
+      }),
+    )
   })
 
   it("does not retry an overrun before splitting it", async () => {

--- a/tests/unit/lib/nexus/memory-import.test.ts
+++ b/tests/unit/lib/nexus/memory-import.test.ts
@@ -289,6 +289,47 @@ describe("Nexus memory import extraction retries and diagnostics", () => {
     )
   })
 
+  it("retries a transient extraction call failure", async () => {
+    const runExtraction = jest
+      .fn()
+      .mockRejectedValueOnce(new Error("ThrottlingException"))
+      .mockResolvedValueOnce(
+        toolResult([{ content: "Recovered fact", category: "context" }]),
+      )
+    const extract = createMemoryImportExtractor({
+      getSetting: jest.fn().mockResolvedValue(null),
+      createModel: jest.fn().mockResolvedValue({} as LanguageModel),
+      runExtraction,
+    })
+
+    await expect(
+      extract({ vendor: "claude", pastedText: "- One fact" }),
+    ).resolves.toEqual([
+      { content: "Recovered fact", category: "context" },
+    ])
+    expect(runExtraction).toHaveBeenCalledTimes(2)
+  })
+
+  it("logs how many candidates the cap dropped", () => {
+    const candidates = Array.from(
+      { length: MAX_MEMORY_IMPORT_CANDIDATES + 7 },
+      (_value, index) => ({
+        content: `Fact ${index + 1}`,
+        category: "context",
+      }),
+    )
+
+    parseMemoryImportCandidates(toolResult(candidates))
+
+    expect(mockLogWarn).toHaveBeenCalledWith(
+      "Nexus memory extraction batch exceeded the candidate cap",
+      expect.objectContaining({
+        cap: MAX_MEMORY_IMPORT_CANDIDATES,
+        droppedCandidates: 7,
+      }),
+    )
+  })
+
   it("never logs the model output or the pasted source", async () => {
     const runExtraction = jest.fn().mockResolvedValue({
       text: "Sarah Hagel lives at 12 Harbor Ridge",
@@ -310,5 +351,67 @@ describe("Nexus memory import extraction retries and diagnostics", () => {
     const logged = JSON.stringify(mockLogWarn.mock.calls)
     expect(logged).not.toContain("Sarah Hagel")
     expect(logged).not.toContain("Harbor Ridge")
+  })
+})
+
+describe("Nexus memory import output-budget overruns", () => {
+  it("splits an over-budget chunk instead of retrying it identically", async () => {
+    // Two lines, each half of an over-budget chunk. The full chunk always
+    // overruns; either half parses. An identical retry could never recover it.
+    const pastedText = `- ${"a".repeat(3_000)}\n- ${"b".repeat(3_000)}`
+    const runExtraction = jest.fn(async (_model, prompt: string) => {
+      const overBudget =
+        prompt.includes("aaaa") && prompt.includes("bbbb")
+      if (overBudget) {
+        return {
+          text: "truncated {",
+          toolCalls: [],
+          finishReason: "length",
+          usage: { inputTokens: 2_000, outputTokens: 8_192 },
+        }
+      }
+      return toolResult([
+        {
+          content: prompt.includes("aaaa") ? "First half" : "Second half",
+          category: "context",
+        },
+      ])
+    })
+    const extract = createMemoryImportExtractor({
+      getSetting: jest.fn().mockResolvedValue(null),
+      createModel: jest.fn().mockResolvedValue({} as LanguageModel),
+      runExtraction,
+    })
+
+    await expect(
+      extract({ vendor: "chatgpt", pastedText }),
+    ).resolves.toEqual([
+      { content: "First half", category: "context" },
+      { content: "Second half", category: "context" },
+    ])
+    expect(mockLogWarn).toHaveBeenCalledWith(
+      "Splitting a Nexus memory extraction chunk that overran",
+      expect.objectContaining({ vendor: "chatgpt", splitDepth: 0 }),
+    )
+  })
+
+  it("does not split when the failure is not an output-budget overrun", async () => {
+    const pastedText = `- ${"a".repeat(3_000)}\n- ${"b".repeat(3_000)}`
+    const runExtraction = jest.fn().mockResolvedValue({
+      text: "not json",
+      toolCalls: [],
+      finishReason: "stop",
+    })
+    const extract = createMemoryImportExtractor({
+      getSetting: jest.fn().mockResolvedValue(null),
+      createModel: jest.fn().mockResolvedValue({} as LanguageModel),
+      runExtraction,
+    })
+
+    await expect(
+      extract({ vendor: "chatgpt", pastedText }),
+    ).rejects.toThrow("invalid response")
+    // Two attempts on the one chunk, and no split fan-out.
+    expect(runExtraction).toHaveBeenCalledTimes(2)
   })
 })

--- a/tests/unit/lib/nexus/memory-import.test.ts
+++ b/tests/unit/lib/nexus/memory-import.test.ts
@@ -413,6 +413,41 @@ describe("Nexus memory import output-budget overruns", () => {
     )
   })
 
+  it("keeps one half's candidates when the other half fails entirely", async () => {
+    // The partial-recovery guarantee: losing half a chunk must not cost the
+    // half that parsed.
+    const pastedText = `- ${"a".repeat(3_000)}\n- ${"b".repeat(3_000)}`
+    const runExtraction = jest.fn(async (_model, prompt: string) => {
+      const hasA = prompt.includes("aaaa")
+      const hasB = prompt.includes("bbbb")
+      if (hasA && hasB) {
+        return {
+          text: "truncated {",
+          toolCalls: [],
+          finishReason: "length",
+          usage: { inputTokens: 2_000, outputTokens: 8_192 },
+        }
+      }
+      if (hasA) return { text: "not json", toolCalls: [], finishReason: "stop" }
+      return toolResult([{ content: "Second half", category: "context" }])
+    })
+    const extract = createMemoryImportExtractor({
+      getSetting: jest.fn().mockResolvedValue(null),
+      createModel: jest.fn().mockResolvedValue({} as LanguageModel),
+      runExtraction,
+    })
+
+    await expect(
+      extract({ vendor: "chatgpt", pastedText }),
+    ).resolves.toEqual([{ content: "Second half", category: "context" }])
+    // One overrun, two attempts on the doomed half, one on the good half.
+    expect(runExtraction).toHaveBeenCalledTimes(4)
+    expect(mockLogWarn).toHaveBeenCalledWith(
+      "A Nexus memory extraction half was lost",
+      expect.objectContaining({ vendor: "chatgpt", halfIndex: 0 }),
+    )
+  })
+
   it("does not retry an overrun before splitting it", async () => {
     // A chunk too small to split: the overrun is detected, the attempt loop
     // breaks immediately, and splitting is refused, so exactly one call runs.

--- a/tests/unit/lib/nexus/memory-import.test.ts
+++ b/tests/unit/lib/nexus/memory-import.test.ts
@@ -257,11 +257,13 @@ describe("Nexus memory import extraction retries and diagnostics", () => {
   })
 
   it("logs response shape and fails after the retry is exhausted", async () => {
+    // Not an output-budget overrun — that path breaks out to a split instead
+    // of retrying, so it would never exhaust the attempts.
     const runExtraction = jest.fn().mockResolvedValue({
-      text: "truncated {",
+      text: "not json {",
       toolCalls: [],
-      finishReason: "length",
-      usage: { inputTokens: 4_000, outputTokens: 8_192 },
+      finishReason: "stop",
+      usage: { inputTokens: 4_000, outputTokens: 1_200 },
     })
     const extract = createMemoryImportExtractor({
       getSetting: jest.fn().mockResolvedValue(null),
@@ -280,11 +282,11 @@ describe("Nexus memory import extraction retries and diagnostics", () => {
         attempt: 1,
         chunkIndex: 0,
         chunkCount: 1,
-        finishReason: "length",
-        outputTextChars: "truncated {".length,
+        finishReason: "stop",
+        outputTextChars: "not json {".length,
         toolCallCount: 0,
         inputTokens: 4_000,
-        outputTokens: 8_192,
+        outputTokens: 1_200,
       }),
     )
   })
@@ -393,6 +395,31 @@ describe("Nexus memory import output-budget overruns", () => {
       "Splitting a Nexus memory extraction chunk that overran",
       expect.objectContaining({ vendor: "chatgpt", splitDepth: 0 }),
     )
+    // One overrun, then straight to the two halves. An overrun must not spend
+    // a second identical call first — at temperature 0 it truncates the same
+    // way, and the waste compounds at every split depth.
+    expect(runExtraction).toHaveBeenCalledTimes(3)
+  })
+
+  it("does not retry an overrun before splitting it", async () => {
+    // A chunk too small to split: the overrun is detected, the attempt loop
+    // breaks immediately, and splitting is refused, so exactly one call runs.
+    const runExtraction = jest.fn().mockResolvedValue({
+      text: "truncated {",
+      toolCalls: [],
+      finishReason: "length",
+      usage: { inputTokens: 40, outputTokens: 8_192 },
+    })
+    const extract = createMemoryImportExtractor({
+      getSetting: jest.fn().mockResolvedValue(null),
+      createModel: jest.fn().mockResolvedValue({} as LanguageModel),
+      runExtraction,
+    })
+
+    await expect(
+      extract({ vendor: "claude", pastedText: "- One fact" }),
+    ).rejects.toThrow("invalid response")
+    expect(runExtraction).toHaveBeenCalledTimes(1)
   })
 
   it("does not split when the failure is not an output-budget overrun", async () => {

--- a/tests/unit/lib/nexus/memory-service.test.ts
+++ b/tests/unit/lib/nexus/memory-service.test.ts
@@ -1,3 +1,22 @@
+/* eslint-disable no-var */
+var mockLogInfo = jest.fn()
+/* eslint-enable no-var */
+
+// createLogger runs at module load, which is hoisted above this assignment,
+// so the methods must dereference lazily.
+jest.mock("@/lib/logger", () => ({
+  createLogger: () => ({
+    info: (...args: unknown[]) => mockLogInfo(...args),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  }),
+  generateRequestId: () => "request-1",
+  startTimer: () => jest.fn(),
+  sanitizeForLogging: (value: unknown) => value,
+  getLogContext: () => ({}),
+}))
+
 import { ContentSafetyBlockedError } from "@/lib/streaming/types"
 import {
   createMemoryService,
@@ -246,6 +265,47 @@ describe("Nexus memory personal information handling", () => {
     expect(repository.saveWithDedup).toHaveBeenCalledWith(
       expect.objectContaining({ content }),
       MEMORY_DEDUP_THRESHOLD,
+    )
+  })
+
+  // Auto-extraction runs unattended, and its prompt is the only thing keeping
+  // third-party identifiers out of it. Tagging the telemetry with the source
+  // is what makes "the prompt did not hold" a query rather than a guess.
+  it("tags the detection telemetry with the write's source", async () => {
+    const repository = createRepository()
+    repository.saveWithDedup.mockResolvedValue({
+      memory: storedMemory({ content: "Student Ellie is 8", source: "auto" }),
+      action: "inserted",
+    })
+    const service = createMemoryService({
+      repository,
+      processInput: jest.fn(async (raw: string) => ({
+        allowed: true,
+        processedContent: raw,
+      })),
+      detectPII: jest.fn(async () => [
+        { type: "AGE", beginOffset: 16, endOffset: 17, score: 0.99 },
+      ]),
+      generateEmbedding: jest.fn(async () => [0.1]),
+      getSetting: jest.fn(async () => null),
+    })
+
+    await service.save({
+      userId: 7,
+      sessionId: "cognito-sub",
+      content: "Student Ellie is 8",
+      category: "context",
+      source: "auto",
+    })
+
+    expect(mockLogInfo).toHaveBeenCalledWith(
+      "Nexus memory contains detected personal information",
+      expect.objectContaining({
+        userId: 7,
+        source: "auto",
+        piiEntityCount: 1,
+        piiTypes: { AGE: 1 },
+      }),
     )
   })
 })

--- a/tests/unit/lib/nexus/memory-service.test.ts
+++ b/tests/unit/lib/nexus/memory-service.test.ts
@@ -93,42 +93,6 @@ describe("Nexus memory service", () => {
     )
   })
 
-  it("refuses detected PII before embedding or persistence", async () => {
-    const repository = createRepository()
-    const generateEmbedding = jest.fn()
-    const service = createMemoryService({
-      repository,
-      processInput: jest.fn(async () => ({
-        allowed: true,
-        processedContent: "Email student@example.com",
-      })),
-      detectPII: jest.fn(async () => [{
-        type: "EMAIL",
-        beginOffset: 6,
-        endOffset: 25,
-        score: 0.999,
-      }]),
-      generateEmbedding,
-      getSetting: jest.fn(async () => null),
-    })
-
-    await expect(
-      service.save({
-        userId: 7,
-        sessionId: "cognito-sub",
-        content: "Email student@example.com",
-        category: "profile",
-        source: "tool",
-      }),
-    ).rejects.toMatchObject({
-      blockedMessage:
-        "For privacy, personal information cannot be saved to memory.",
-      blockedCategories: ["pii"],
-    })
-    expect(generateEmbedding).not.toHaveBeenCalled()
-    expect(repository.saveWithDedup).not.toHaveBeenCalled()
-  })
-
   it("does not perform database or embedding work when safety blocks a write", async () => {
     const repository = createRepository()
     const generateEmbedding = jest.fn(async () => [0.1])
@@ -242,15 +206,63 @@ describe("Nexus memory service edits", () => {
   })
 })
 
-describe("Nexus memory privacy scan availability", () => {
-  it("fails closed when detect-only PII screening errors", async () => {
+describe("Nexus memory personal information handling", () => {
+  // A memory is the user's own record of their own life. Detection is
+  // telemetry; it must never cost the user the write.
+  it("stores personal information instead of refusing it", async () => {
+    const content = "Wife Sarah teaches third grade at Harbor Ridge"
     const repository = createRepository()
+    repository.saveWithDedup.mockResolvedValue({
+      memory: storedMemory({ content, category: "profile" }),
+      action: "inserted",
+    })
+    const generateEmbedding = jest.fn(async () => [0.1])
+    const detectPII = jest.fn(async () => [
+      { type: "NAME", beginOffset: 5, endOffset: 10, score: 0.999 },
+      { type: "ADDRESS", beginOffset: 31, endOffset: 44, score: 0.98 },
+    ])
+    const service = createMemoryService({
+      repository,
+      processInput: jest.fn(async (raw: string) => ({
+        allowed: true,
+        processedContent: raw,
+      })),
+      detectPII,
+      generateEmbedding,
+      getSetting: jest.fn(async () => null),
+    })
+
+    await expect(
+      service.save({
+        userId: 7,
+        sessionId: "cognito-sub",
+        content,
+        category: "profile",
+        source: "import:chatgpt",
+      }),
+    ).resolves.toMatchObject({ action: "inserted" })
+    expect(detectPII).toHaveBeenCalledTimes(1)
+    expect(generateEmbedding).toHaveBeenCalledWith(content)
+    expect(repository.saveWithDedup).toHaveBeenCalledWith(
+      expect.objectContaining({ content }),
+      MEMORY_DEDUP_THRESHOLD,
+    )
+  })
+})
+
+describe("Nexus memory privacy scan availability", () => {
+  it("saves when the detect-only privacy scan is unavailable", async () => {
+    const repository = createRepository()
+    repository.saveWithDedup.mockResolvedValue({
+      memory: storedMemory({ content: "Was not conclusively screened" }),
+      action: "inserted",
+    })
     const generateEmbedding = jest.fn(async () => [0.1])
     const service = createMemoryService({
       repository,
-      processInput: jest.fn(async () => ({
+      processInput: jest.fn(async (content: string) => ({
         allowed: true,
-        processedContent: "Looks safe but was not conclusively screened",
+        processedContent: content,
       })),
       detectPII: jest.fn(async () => {
         throw new Error("Comprehend unavailable")
@@ -263,17 +275,39 @@ describe("Nexus memory privacy scan availability", () => {
       service.save({
         userId: 7,
         sessionId: "cognito-sub",
-        content: "Looks safe but was not conclusively screened",
+        content: "Was not conclusively screened",
         category: "context",
         source: "tool",
       }),
-    ).rejects.toMatchObject({
-      blockedMessage:
-        "Memory is temporarily unavailable because its privacy check could not be completed.",
-      blockedCategories: ["pii_scan_unavailable"],
+    ).resolves.toMatchObject({ action: "inserted" })
+    expect(generateEmbedding).toHaveBeenCalledTimes(1)
+    expect(repository.saveWithDedup).toHaveBeenCalledTimes(1)
+  })
+
+  it("still refuses content the safety gate blocks", async () => {
+    const repository = createRepository()
+    const service = createMemoryService({
+      repository,
+      processInput: jest.fn(async () => ({
+        allowed: false,
+        processedContent: "",
+        blockedMessage: "Blocked by policy",
+        blockedCategories: ["prompt_attack"],
+      })),
+      detectPII: jest.fn(async () => []),
+      generateEmbedding: jest.fn(async () => [0.1]),
+      getSetting: jest.fn(async () => null),
     })
-    expect(repository.conversationIsOwned).not.toHaveBeenCalled()
-    expect(generateEmbedding).not.toHaveBeenCalled()
+
+    await expect(
+      service.save({
+        userId: 7,
+        sessionId: "cognito-sub",
+        content: "unsafe",
+        category: "context",
+        source: "import:claude",
+      }),
+    ).rejects.toBeInstanceOf(ContentSafetyBlockedError)
     expect(repository.saveWithDedup).not.toHaveBeenCalled()
   })
 })

--- a/tests/unit/settings-memory-import-dialog.test.tsx
+++ b/tests/unit/settings-memory-import-dialog.test.tsx
@@ -208,6 +208,86 @@ describe("Settings memory import dialog review", () => {
   })
 })
 
+describe("Settings memory import dialog failure reasons", () => {
+  async function renderPartialFailure() {
+    jest.mocked(extractImportCandidates).mockResolvedValueOnce({
+      isSuccess: true,
+      message: "2 memory candidates ready to review",
+      data: {
+        candidates: [
+          { content: "Saved fact", category: "profile" },
+          { content: "Rejected fact", category: "context" },
+        ],
+      },
+    })
+    jest.mocked(saveImportedMemories).mockResolvedValueOnce({
+      isSuccess: true,
+      message: "1 of 2 memories imported",
+      data: {
+        total: 2,
+        successful: 1,
+        failed: 1,
+        results: [
+          {
+            index: 0,
+            status: "saved",
+            memoryId: "11111111-1111-4111-8111-111111111111",
+            action: "inserted",
+          },
+          {
+            index: 1,
+            status: "failed",
+            reason: "Blocked by policy",
+          },
+        ],
+      },
+    })
+
+    render(
+      <MemoryImportDialog
+        open
+        onOpenChange={jest.fn()}
+        onImported={jest.fn().mockResolvedValue(undefined)}
+      />,
+    )
+    fireEvent.change(screen.getByTestId("memory-import-paste"), {
+      target: { value: "- Two facts" },
+    })
+    fireEvent.click(screen.getByTestId("memory-import-extract"))
+    await waitFor(() =>
+      expect(screen.getAllByTestId("memory-import-candidate")).toHaveLength(2),
+    )
+    fireEvent.click(screen.getByTestId("memory-import-save"))
+    await waitFor(() =>
+      expect(screen.getAllByTestId("memory-import-candidate")).toHaveLength(1),
+    )
+  }
+
+  it("shows the rejection reason on the candidate that failed", async () => {
+    await renderPartialFailure()
+
+    expect(
+      screen.getByTestId("memory-import-candidate-reason-0"),
+    ).toHaveTextContent("Blocked by policy")
+    expect(
+      screen.getByTestId("memory-import-candidate-content-0"),
+    ).toHaveValue("Rejected fact")
+  })
+
+  it("clears the reason once the candidate text is edited", async () => {
+    await renderPartialFailure()
+
+    fireEvent.change(
+      screen.getByTestId("memory-import-candidate-content-0"),
+      { target: { value: "Reworded fact" } },
+    )
+
+    expect(
+      screen.queryByTestId("memory-import-candidate-reason-0"),
+    ).not.toBeInTheDocument()
+  })
+})
+
 describe("Settings memory import dialog batching", () => {
   it("chunks large reviewed imports into bounded save actions", async () => {
     jest.mocked(extractImportCandidates).mockResolvedValueOnce({


### PR DESCRIPTION
Closes #1610.

## What broke

Three prod users hit the Nexus memory import on 2026-08-05 between ~11:22am and ~12:40pm PDT. Two independent defects, both confirmed in `/ecs/aistudio-prod` and against the code.

**The PII gate refused the exact content memory exists to hold.** `memoryService.save` threw whenever Comprehend returned *any* entity (NAME ≥ 0.90, DATE_TIME ≥ 0.97, AGE ≥ 0.90, EMAIL/PHONE/SSN/ADDRESS at any score). A memory is the user's own record of their own life — names, relationships, dates, ages aren't incidental to that, they *are* it. Vendor exports are dense with them, so extraction reliably produced candidates the save gate was guaranteed to reject. User 633 ran ~26 save batches over an hour, nearly all `ok: 0, failed: 5`, and landed 4 memories total.

**Extraction lost every candidate when one response truncated.** The last three attempts of the day failed after 18–27.5s (vs 3.3–5.7s for the five that succeeded). The whole paste — up to 200,000 chars — went to Nova Lite in one call, strict whole-batch `safeParse`, `maxOutputTokens: 8192`, no retry. A tool call truncated mid-object parses as nothing, so the import returned zero candidates. The error path logged nothing about the response, so it wasn't diagnosable.

**And the UI never said why.** `ImportedMemoryItemResult` carried only `status: "failed"`; the dialog said "N need attention". The rejections were deterministic, so every retry failed identically.

## What changed

**PII detection is now telemetry, not a gate.** `recordPIITelemetry` logs entity types and counts — never offsets or values — and always lets the write proceed. A PII scan that *errors* no longer fails closed either. This matches the telemetry-only stance already in place for Bedrock Guardrails. The content-safety gate (`processInput`) is untouched, still blocks, and still runs before embedding or any DB access.

The prompts pulled the same way from the other end: both the import and auto-extraction prompts said to exclude "contact details, sensitive identifiers", stripping personal detail before it ever reached the gate. Both now keep names, relationships, ages, locations, dates, and contact details verbatim and exclude only credentials.

**Extraction is chunked and salvaging.**
- `splitExtractionChunks` splits on line boundaries at 12,000 chars (oversized lines split on characters), so no response approaches the output cap. Chunks run at concurrency 3, merged and deduplicated, capped at `MAX_MEMORY_IMPORT_CANDIDATES`.
- One failing chunk no longer discards the chunks that parsed.
- `parseMemoryImportCandidates` salvages every individually valid candidate when the batch schema fails, instead of discarding the response over one bad entry.
- Each chunk retries once on an unparseable response.
- Parse failures log `finishReason`, usage, output length, and tool-call count — shape only, never model output or pasted content.

**Failures explain themselves.** The action returns a user-safe `reason` per failed candidate (blocked-content messages pass through; everything else stays generic so provider/database/network internals never reach the browser). The dialog renders it on the failing row and clears it once the text is edited.

## Also fixed

`tests/e2e/settings-memory-crud.functional.spec.ts` was red before this branch — I verified that by stashing and re-running. Its first failure was the PII gate rejecting a manual memory; with that fixed it still failed at the edit step, because filling the edit textarea replaces the row's rendered text, so the `hasText` row filter matches nothing and every control inside it becomes unreachable. The spec now pins the row by `data-memory-id` before editing.

## Verification

- `bun run lint` — 0 errors, 0 warnings
- `bun run typecheck` — 0 errors
- `bun run test:ci` — 571 suites / 5393 tests passing
- Authenticated E2E against live Bedrock + Comprehend (`E2E_RUN_EXTERNAL=1`) — **all 9 memory specs passing**, including a new `settings-memory-import` case that imports a wife's name, a daughter's age, a start date, and an email address and asserts all four land in the database

No schema, migration, or infrastructure changes. Rollback is a revert.

## Note on the changed decision

Issue #1610 originally proposed leaving the PII gate alone and de-identifying at extraction instead. Hagel reversed that: users need to store and import their personal information, so the gate had to go rather than the data. The gate is removed as a *refusal*; the detection signal is kept as telemetry.
